### PR TITLE
feat(health): add enhanced health check endpoint with DB status

### DIFF
--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -109,7 +109,8 @@ func main() {
 	router.Use(api.ErrorHandlerMiddleware())
 
 	// Health check endpoint
-	router.GET("/health", health.HealthHandler)
+	healthChecker := health.NewHealthChecker(database)
+	router.GET("/health", healthChecker.Handler)
 
 	// API routes
 	v1 := router.Group("/api/v1")

--- a/backend/internal/health/health.go
+++ b/backend/internal/health/health.go
@@ -1,16 +1,218 @@
 package health
 
 import (
+	"context"
 	"net/http"
+	"runtime"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
 
 	"github.com/gin-gonic/gin"
 )
 
-type HealthResponse struct {
-	Status string `json:"status"`
+// Version info - set at build time or defaults
+var (
+	Version   = "dev"
+	BuildTime = "unknown"
+	GitCommit = "unknown"
+)
+
+// DatabaseChecker interface for checking database connectivity
+type DatabaseChecker interface {
+	HealthCheck(ctx context.Context) error
 }
 
+// HealthChecker handles health check requests
+type HealthChecker struct {
+	db        DatabaseChecker
+	startTime time.Time
+}
+
+// NewHealthChecker creates a new health checker with database reference
+func NewHealthChecker(db DatabaseChecker) *HealthChecker {
+	return &HealthChecker{
+		db:        db,
+		startTime: accelerated.GetCurrentTime(),
+	}
+}
+
+// ComponentStatus represents the status of a component
+type ComponentStatus struct {
+	Status       string  `json:"status"`
+	ResponseTime *string `json:"response_time,omitempty"`
+	Error        *string `json:"error,omitempty"`
+}
+
+// VersionInfo contains version information
+type VersionInfo struct {
+	Version   string `json:"version"`
+	BuildTime string `json:"build_time"`
+	GitCommit string `json:"git_commit"`
+}
+
+// SystemInfo contains system runtime information
+type SystemInfo struct {
+	Uptime       string `json:"uptime"`
+	GoVersion    string `json:"go_version"`
+	NumGoroutine int    `json:"num_goroutine"`
+	MemoryAlloc  string `json:"memory_alloc_mb"`
+}
+
+// HealthResponse is the response for the health endpoint
+type HealthResponse struct {
+	Status     string                     `json:"status"`
+	Timestamp  string                     `json:"timestamp"`
+	Version    VersionInfo                `json:"version"`
+	Components map[string]ComponentStatus `json:"components"`
+	System     *SystemInfo                `json:"system,omitempty"`
+}
+
+// Handler handles the health check request
+func (h *HealthChecker) Handler(c *gin.Context) {
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+	defer cancel()
+
+	now := accelerated.GetCurrentTime()
+	overallStatus := "healthy"
+	httpStatus := http.StatusOK
+
+	// Check database
+	dbStatus := h.checkDatabase(ctx)
+	if dbStatus.Status != "healthy" {
+		overallStatus = "degraded"
+		httpStatus = http.StatusServiceUnavailable
+	}
+
+	// Build response
+	response := HealthResponse{
+		Status:    overallStatus,
+		Timestamp: now.UTC().Format(time.RFC3339),
+		Version: VersionInfo{
+			Version:   Version,
+			BuildTime: BuildTime,
+			GitCommit: GitCommit,
+		},
+		Components: map[string]ComponentStatus{
+			"database": dbStatus,
+		},
+	}
+
+	// Include system info if requested or always (optional per requirements)
+	// Including by default for observability
+	response.System = h.getSystemInfo()
+
+	c.JSON(httpStatus, response)
+}
+
+// checkDatabase checks database connectivity and returns status
+func (h *HealthChecker) checkDatabase(ctx context.Context) ComponentStatus {
+	if h.db == nil {
+		errMsg := "database not configured"
+		return ComponentStatus{
+			Status: "unhealthy",
+			Error:  &errMsg,
+		}
+	}
+
+	start := accelerated.GetCurrentTime()
+	err := h.db.HealthCheck(ctx)
+	elapsed := accelerated.GetCurrentTime().Sub(start)
+	responseTime := elapsed.String()
+
+	if err != nil {
+		errMsg := err.Error()
+		return ComponentStatus{
+			Status:       "unhealthy",
+			ResponseTime: &responseTime,
+			Error:        &errMsg,
+		}
+	}
+
+	return ComponentStatus{
+		Status:       "healthy",
+		ResponseTime: &responseTime,
+	}
+}
+
+// getSystemInfo returns system runtime information
+func (h *HealthChecker) getSystemInfo() *SystemInfo {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+
+	uptime := accelerated.GetCurrentTime().Sub(h.startTime)
+
+	return &SystemInfo{
+		Uptime:       uptime.Round(time.Second).String(),
+		GoVersion:    runtime.Version(),
+		NumGoroutine: runtime.NumGoroutine(),
+		MemoryAlloc:  formatMemoryMB(m.Alloc),
+	}
+}
+
+// formatMemoryMB formats bytes to megabytes string
+func formatMemoryMB(bytes uint64) string {
+	mb := float64(bytes) / 1024 / 1024
+	return formatFloat(mb, 2)
+}
+
+// formatFloat formats a float with specified precision
+func formatFloat(f float64, precision int) string {
+	format := "%." + string(rune('0'+precision)) + "f"
+	return sprintf(format, f)
+}
+
+// sprintf is a simple fmt.Sprintf without importing fmt
+func sprintf(format string, a float64) string {
+	// Simple implementation for our specific use case
+	intPart := int(a)
+	fracPart := int((a - float64(intPart)) * 100)
+	if fracPart < 0 {
+		fracPart = -fracPart
+	}
+	return itoa(intPart) + "." + padLeft(itoa(fracPart), 2, '0')
+}
+
+// itoa converts int to string without fmt package
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	negative := i < 0
+	if negative {
+		i = -i
+	}
+	var digits []byte
+	for i > 0 {
+		digits = append([]byte{byte('0' + i%10)}, digits...)
+		i /= 10
+	}
+	if negative {
+		digits = append([]byte{'-'}, digits...)
+	}
+	return string(digits)
+}
+
+// padLeft pads string with char on left to reach length
+func padLeft(s string, length int, char byte) string {
+	for len(s) < length {
+		s = string(char) + s
+	}
+	return s
+}
+
+// HealthHandler is a legacy handler for backward compatibility (without DB check)
+// Deprecated: Use NewHealthChecker().Handler instead
 func HealthHandler(c *gin.Context) {
-	response := HealthResponse{Status: "ok"}
+	response := HealthResponse{
+		Status:    "ok",
+		Timestamp: accelerated.GetCurrentTime().UTC().Format(time.RFC3339),
+		Version: VersionInfo{
+			Version:   Version,
+			BuildTime: BuildTime,
+			GitCommit: GitCommit,
+		},
+		Components: map[string]ComponentStatus{},
+	}
 	c.JSON(http.StatusOK, response)
 }

--- a/backend/tests/unit_test.go
+++ b/backend/tests/unit_test.go
@@ -1,7 +1,9 @@
 package tests
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -10,39 +12,213 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-type HealthResponse struct {
-	Status string `json:"status"`
+// mockDatabaseChecker implements health.DatabaseChecker for testing
+type mockDatabaseChecker struct {
+	shouldError bool
+	err         error
 }
 
-func TestHealthEndpoint(t *testing.T) {
-	// Set Gin to test mode
+func (m *mockDatabaseChecker) HealthCheck(ctx context.Context) error {
+	if m.shouldError {
+		if m.err != nil {
+			return m.err
+		}
+		return errors.New("database connection failed")
+	}
+	return nil
+}
+
+func TestHealthEndpoint_Healthy(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	// Create a new Gin router
+	mockDB := &mockDatabaseChecker{shouldError: false}
+	healthChecker := health.NewHealthChecker(mockDB)
+
 	router := gin.New()
-	router.GET("/health", health.HealthHandler)
+	router.GET("/health", healthChecker.Handler)
 
-	// Create a request
 	req, err := http.NewRequest("GET", "/health", nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	// Create a response recorder
 	w := httptest.NewRecorder()
-
-	// Serve the request
 	router.ServeHTTP(w, req)
 
-	// Check status code
+	// Should return 200 when healthy
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	// Check response body
-	var response HealthResponse
+	var response health.HealthResponse
 	err = json.Unmarshal(w.Body.Bytes(), &response)
-	assert.NoError(t, err)
-	assert.Equal(t, "ok", response.Status)
+	require.NoError(t, err)
+
+	// Verify status
+	assert.Equal(t, "healthy", response.Status)
+
+	// Verify timestamp is present
+	assert.NotEmpty(t, response.Timestamp)
+
+	// Verify version info
+	assert.NotEmpty(t, response.Version.Version)
+
+	// Verify database component is healthy
+	dbStatus, ok := response.Components["database"]
+	assert.True(t, ok, "database component should be present")
+	assert.Equal(t, "healthy", dbStatus.Status)
+	assert.NotNil(t, dbStatus.ResponseTime)
+	assert.Nil(t, dbStatus.Error)
+
+	// Verify system info is present
+	assert.NotNil(t, response.System)
+	assert.NotEmpty(t, response.System.Uptime)
+	assert.NotEmpty(t, response.System.GoVersion)
+	assert.Greater(t, response.System.NumGoroutine, 0)
+	assert.NotEmpty(t, response.System.MemoryAlloc)
 
 	// Check content type
 	assert.Equal(t, "application/json; charset=utf-8", w.Header().Get("Content-Type"))
+}
+
+func TestHealthEndpoint_Degraded(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	mockDB := &mockDatabaseChecker{
+		shouldError: true,
+		err:         errors.New("connection refused"),
+	}
+	healthChecker := health.NewHealthChecker(mockDB)
+
+	router := gin.New()
+	router.GET("/health", healthChecker.Handler)
+
+	req, err := http.NewRequest("GET", "/health", nil)
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Should return 503 when degraded
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+
+	var response health.HealthResponse
+	err = json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	// Verify status is degraded
+	assert.Equal(t, "degraded", response.Status)
+
+	// Verify database component is unhealthy
+	dbStatus, ok := response.Components["database"]
+	assert.True(t, ok, "database component should be present")
+	assert.Equal(t, "unhealthy", dbStatus.Status)
+	assert.NotNil(t, dbStatus.Error)
+	assert.Contains(t, *dbStatus.Error, "connection refused")
+}
+
+func TestHealthEndpoint_NoDatabaseConfigured(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// Pass nil database
+	healthChecker := health.NewHealthChecker(nil)
+
+	router := gin.New()
+	router.GET("/health", healthChecker.Handler)
+
+	req, err := http.NewRequest("GET", "/health", nil)
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Should return 503 when no database
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+
+	var response health.HealthResponse
+	err = json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	// Verify status is degraded
+	assert.Equal(t, "degraded", response.Status)
+
+	// Verify database component shows not configured
+	dbStatus, ok := response.Components["database"]
+	assert.True(t, ok, "database component should be present")
+	assert.Equal(t, "unhealthy", dbStatus.Status)
+	assert.NotNil(t, dbStatus.Error)
+	assert.Contains(t, *dbStatus.Error, "not configured")
+}
+
+func TestHealthEndpoint_LegacyHandler(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	router.GET("/health", health.HealthHandler)
+
+	req, err := http.NewRequest("GET", "/health", nil)
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Legacy handler should always return 200
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response health.HealthResponse
+	err = json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	// Verify status is ok (legacy)
+	assert.Equal(t, "ok", response.Status)
+
+	// Verify timestamp is present
+	assert.NotEmpty(t, response.Timestamp)
+
+	// Verify version info is present
+	assert.NotEmpty(t, response.Version.Version)
+}
+
+func TestHealthResponse_JSONFormat(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	mockDB := &mockDatabaseChecker{shouldError: false}
+	healthChecker := health.NewHealthChecker(mockDB)
+
+	router := gin.New()
+	router.GET("/health", healthChecker.Handler)
+
+	req, err := http.NewRequest("GET", "/health", nil)
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Parse as generic map to verify JSON structure
+	var rawResponse map[string]interface{}
+	err = json.Unmarshal(w.Body.Bytes(), &rawResponse)
+	require.NoError(t, err)
+
+	// Verify top-level fields exist
+	assert.Contains(t, rawResponse, "status")
+	assert.Contains(t, rawResponse, "timestamp")
+	assert.Contains(t, rawResponse, "version")
+	assert.Contains(t, rawResponse, "components")
+	assert.Contains(t, rawResponse, "system")
+
+	// Verify version structure
+	version, ok := rawResponse["version"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Contains(t, version, "version")
+	assert.Contains(t, version, "build_time")
+	assert.Contains(t, version, "git_commit")
+
+	// Verify components structure
+	components, ok := rawResponse["components"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Contains(t, components, "database")
+
+	// Verify database component structure
+	dbComponent, ok := components["database"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Contains(t, dbComponent, "status")
 }


### PR DESCRIPTION
## Summary
Implements enhanced health check endpoint per issue #4.

## Changes
- Add database connectivity check with response time tracking
- Return 503 when degraded (database unavailable)
- Include timestamp in RFC3339 format
- Add version info (version, build_time, git_commit)
- Add system info (uptime, go_version, goroutines, memory)
- Add component status structure for extensibility
- Maintain backward compatible legacy HealthHandler
- Add comprehensive unit tests for all scenarios

## Sample Response
```json
{
  "status": "healthy",
  "timestamp": "2025-12-20T21:44:21Z",
  "version": { "version": "dev", "build_time": "unknown", "git_commit": "unknown" },
  "components": { "database": { "status": "healthy", "response_time": "1.798167ms" } },
  "system": { "uptime": "15s", "go_version": "go1.25.5", "num_goroutine": 8, "memory_alloc_mb": "9.78" }
}
```

## Testing
- [x] Unit tests pass (`make test-unit`)
- [x] Smoke test passes (`./smoke-test.sh`)
- [x] Manual verification of endpoint response

Fixes #4