### PR TITLE
fix: process stop commands and prod migrations path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,8 @@ dev:
 # Development helpers
 dev-stop:
 	@echo "Stopping development servers (backend and frontend dev)..."
-	@pkill -f crm-api || true
+	@# Kill backend by port (go run creates binary named 'main', not 'crm-api')
+	@lsof -ti:8080 | xargs kill -9 2>/dev/null || true
 	@pkill -f "next dev" || true
 	@pkill -f "node.*next" || true
 	@if [ -f logs/frontend-dev.pid ]; then kill $$(cat logs/frontend-dev.pid) 2>/dev/null || true; fi
@@ -356,8 +357,11 @@ start-local:
 
 stop:
 	@echo "🛑 Stopping Personal CRM..."
+	@# Kill backend by port and name (prod uses compiled crm-api binary)
+	@lsof -ti:8080 | xargs kill -9 2>/dev/null || true
 	@pkill -f crm-api || true
-	@pkill -f "next start" || true
+	@# Kill frontend by port (process is 'next-server', not 'next start')
+	@lsof -ti:3001 | xargs kill -9 2>/dev/null || true
 	@make docker-down
 	@echo "✅ Personal CRM stopped"
 

--- a/scripts/start-backend-prod.sh
+++ b/scripts/start-backend-prod.sh
@@ -18,6 +18,7 @@ source ./.env
 set +a
 
 export DATABASE_URL="postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT:-5432}/${POSTGRES_DB}?sslmode=disable"
+export MIGRATIONS_PATH="backend/migrations"
 
 # Kill any existing process on the port
 echo "Checking for existing backend process..."


### PR DESCRIPTION
## Summary

- **dev-stop**: Kill backend by port 8080 instead of `pkill crm-api` (`go run` creates binary named `main`, not `crm-api`)
- **stop**: Kill frontend by port 3001 instead of `pkill "next start"` (process is `next-server`, not `next start`)
- **start-backend-prod.sh**: Add `MIGRATIONS_PATH=backend/migrations` (script runs from project root, not `backend/`)

## Test plan

- [x] `make dev-stop` successfully stops backend on port 8080
- [x] `make stop` successfully stops frontend on port 3001
- [x] `make start` successfully starts prod with correct migrations path

🤖 Generated with [Claude Code](https://claude.com/claude-code)