### PR TITLE
feat(reminders): add upcoming filter

### DIFF
--- a/frontend/src/app/reminders/page.tsx
+++ b/frontend/src/app/reminders/page.tsx
@@ -228,7 +228,7 @@ function RemindersTable({ reminders, loading }: { reminders: DueReminder[]; load
 
 export default function RemindersPage() {
   const [searchTerm, setSearchTerm] = useState('')
-  const [filter, setFilter] = useState<'all' | 'due' | 'completed'>('all')
+  const [filter, setFilter] = useState<'all' | 'due' | 'upcoming' | 'completed'>('all')
   const [showCreateForm, setShowCreateForm] = useState(false)
 
   const params: ReminderListParams = {
@@ -255,10 +255,15 @@ export default function RemindersPage() {
         (reminder.contact_name &&
           reminder.contact_name.toLowerCase().includes(searchTerm.toLowerCase()))
 
+      const dueDate = new Date(reminder.due_date)
+      const now = new Date()
+      const isUpcoming = dueDate > now
+
       const matchesFilter =
         filter === 'all' ||
         (filter === 'completed' && reminder.completed) ||
-        (filter === 'due' && !reminder.completed)
+        (filter === 'due' && !reminder.completed && !isUpcoming) ||
+        (filter === 'upcoming' && !reminder.completed && isUpcoming)
 
       return matchesSearch && matchesFilter
     }) || []
@@ -339,6 +344,17 @@ export default function RemindersPage() {
               )}
             >
               Due
+            </button>
+            <button
+              onClick={() => setFilter('upcoming')}
+              className={clsx(
+                'px-3 py-2 text-sm font-medium rounded-md',
+                filter === 'upcoming'
+                  ? 'bg-blue-100 text-blue-700'
+                  : 'text-gray-500 hover:text-gray-700'
+              )}
+            >
+              Upcoming
             </button>
             <button
               onClick={() => setFilter('completed')}

--- a/frontend/tests/e2e/reminders.spec.ts
+++ b/frontend/tests/e2e/reminders.spec.ts
@@ -18,6 +18,7 @@ test.describe('Reminders Page', () => {
     // Check filter tabs are visible
     await expect(page.getByRole('button', { name: 'All' })).toBeVisible()
     await expect(page.getByRole('button', { name: 'Due' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Upcoming' })).toBeVisible()
     await expect(page.getByRole('button', { name: 'Completed' })).toBeVisible()
   })
 


### PR DESCRIPTION
## Summary

- Add an "Upcoming" filter tab to the reminders page
- Shows reminders with due dates in the future that haven't been completed
- Separates "Due" (past/today) from "Upcoming" (future) for clearer organization

## Test plan

- [x] E2E test updated to verify Upcoming filter button is visible
- [ ] Manual verification: create reminders with future dates and verify they appear under "Upcoming"

🤖 Generated with [Claude Code](https://claude.com/claude-code)