### PR TITLE
feat: add time tracking feature flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,3 +65,7 @@ FRONTEND_URL=http://localhost:3000
 ENABLE_VECTOR_SEARCH=false
 ENABLE_TELEGRAM_BOT=false
 ENABLE_CALENDAR_SYNC=false
+ENABLE_TIME_TRACKING=false
+
+# Frontend feature flags (must match backend settings)
+NEXT_PUBLIC_ENABLE_TIME_TRACKING=false

--- a/.env.example.production
+++ b/.env.example.production
@@ -80,6 +80,10 @@ SCHEDULER_CRON="0 8 * * *"  # Run daily at 8 AM
 ENABLE_VECTOR_SEARCH=false
 ENABLE_TELEGRAM_BOT=false
 ENABLE_CALENDAR_SYNC=false
+ENABLE_TIME_TRACKING=false
+
+# Frontend feature flags (must match backend settings)
+NEXT_PUBLIC_ENABLE_TIME_TRACKING=false
 
 # ===========================================
 # REMINDER CADENCES

--- a/.env.example.staging
+++ b/.env.example.staging
@@ -78,6 +78,10 @@ SCHEDULER_CRON="*/5m"  # Run every 5 minutes for staging
 ENABLE_VECTOR_SEARCH=false
 ENABLE_TELEGRAM_BOT=false
 ENABLE_CALENDAR_SYNC=false
+ENABLE_TIME_TRACKING=false
+
+# Frontend feature flags (must match backend settings)
+NEXT_PUBLIC_ENABLE_TIME_TRACKING=false
 
 # ===========================================
 # REMINDER CADENCES

--- a/.env.example.testing
+++ b/.env.example.testing
@@ -78,6 +78,10 @@ SCHEDULER_CRON="*/30s"  # Run every 30 seconds for testing
 ENABLE_VECTOR_SEARCH=false
 ENABLE_TELEGRAM_BOT=false
 ENABLE_CALENDAR_SYNC=false
+ENABLE_TIME_TRACKING=false
+
+# Frontend feature flags (must match backend settings)
+NEXT_PUBLIC_ENABLE_TIME_TRACKING=false
 
 # ===========================================
 # REMINDER CADENCES

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -154,16 +154,18 @@ func main() {
 			system.POST("/time/acceleration", systemHandler.SetTimeAcceleration)
 		}
 
-		// Time entry routes
-		timeEntries := v1.Group("/time-entries")
-		{
-			timeEntries.POST("", timeEntryHandler.CreateTimeEntry)
-			timeEntries.GET("", timeEntryHandler.ListTimeEntries)
-			timeEntries.GET("/running", timeEntryHandler.GetRunningTimeEntry)
-			timeEntries.GET("/stats", timeEntryHandler.GetTimeEntryStats)
-			timeEntries.GET("/:id", timeEntryHandler.GetTimeEntry)
-			timeEntries.PUT("/:id", timeEntryHandler.UpdateTimeEntry)
-			timeEntries.DELETE("/:id", timeEntryHandler.DeleteTimeEntry)
+		// Time entry routes (feature-flagged)
+		if cfg.Features.EnableTimeTracking {
+			timeEntries := v1.Group("/time-entries")
+			{
+				timeEntries.POST("", timeEntryHandler.CreateTimeEntry)
+				timeEntries.GET("", timeEntryHandler.ListTimeEntries)
+				timeEntries.GET("/running", timeEntryHandler.GetRunningTimeEntry)
+				timeEntries.GET("/stats", timeEntryHandler.GetTimeEntryStats)
+				timeEntries.GET("/:id", timeEntryHandler.GetTimeEntry)
+				timeEntries.PUT("/:id", timeEntryHandler.UpdateTimeEntry)
+				timeEntries.DELETE("/:id", timeEntryHandler.DeleteTimeEntry)
+			}
 		}
 
 		// Export/Import routes

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -50,6 +50,7 @@ type FeatureFlags struct {
 	EnableVectorSearch bool // Default: false
 	EnableTelegramBot  bool // Default: false
 	EnableCalendarSync bool // Default: false
+	EnableTimeTracking bool // Default: false
 }
 
 // RuntimeConfig holds runtime-only settings (not validated at startup)
@@ -132,6 +133,7 @@ func Load() (*Config, error) {
 			EnableVectorSearch: getEnvAsBool("ENABLE_VECTOR_SEARCH", false),
 			EnableTelegramBot:  getEnvAsBool("ENABLE_TELEGRAM_BOT", false),
 			EnableCalendarSync: getEnvAsBool("ENABLE_CALENDAR_SYNC", false),
+			EnableTimeTracking: getEnvAsBool("ENABLE_TIME_TRACKING", false),
 		},
 		Runtime: RuntimeConfig{
 			CRMEnvironment:   getEnv("CRM_ENV", DefaultCRMEnvironment),
@@ -325,6 +327,7 @@ func TestConfig() *Config {
 			EnableVectorSearch: false,
 			EnableTelegramBot:  false,
 			EnableCalendarSync: false,
+			EnableTimeTracking: false,
 		},
 		Runtime: RuntimeConfig{
 			CRMEnvironment:   "test",

--- a/frontend/src/components/layout/navigation.tsx
+++ b/frontend/src/components/layout/navigation.tsx
@@ -6,12 +6,16 @@ import { Users, Calendar, Bell, Settings, Cake, Clock } from 'lucide-react'
 import { clsx } from 'clsx'
 import { TimeAccelerationWidget } from '@/components/ui/time-acceleration-widget'
 
+const isTimeTrackingEnabled = process.env.NEXT_PUBLIC_ENABLE_TIME_TRACKING === 'true'
+
 const navigation = [
   { name: 'Dashboard', href: '/dashboard', icon: Calendar },
   { name: 'Contacts', href: '/contacts', icon: Users },
   { name: 'Birthdays', href: '/birthdays', icon: Cake },
   { name: 'Reminders', href: '/reminders', icon: Bell },
-  { name: 'Time Tracking', href: '/time-tracking', icon: Clock },
+  ...(isTimeTrackingEnabled
+    ? [{ name: 'Time Tracking', href: '/time-tracking', icon: Clock }]
+    : []),
   { name: 'Settings', href: '/settings', icon: Settings },
 ]
 


### PR DESCRIPTION
## Summary

- Add `ENABLE_TIME_TRACKING` feature flag (default: `false`) to disable time tracking while preserving code for future re-enablement
- Backend: Conditionally register `/time-entries` routes based on flag
- Frontend: Hide Time Tracking nav item when `NEXT_PUBLIC_ENABLE_TIME_TRACKING !== 'true'`

## Changes

| File | Description |
|------|-------------|
| `backend/internal/config/config.go` | Add `EnableTimeTracking` to `FeatureFlags` struct |
| `backend/cmd/crm-api/main.go` | Wrap time-entry routes in feature flag conditional |
| `frontend/src/components/layout/navigation.tsx` | Conditionally show Time Tracking nav item |
| `.env.example*` | Document new `ENABLE_TIME_TRACKING` and `NEXT_PUBLIC_ENABLE_TIME_TRACKING` flags |

## Test plan

- [ ] Verify backend compiles (`go build ./cmd/crm-api`)
- [ ] Verify frontend lints (`bun run lint`)
- [ ] With flags disabled: confirm `/time-entries` returns 404 and nav item is hidden
- [ ] With flags enabled: confirm time tracking works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)