### PR TITLE
feat: add WhatsApp as contact method

### DIFF
--- a/backend/internal/api/handlers/contact.go
+++ b/backend/internal/api/handlers/contact.go
@@ -141,7 +141,7 @@ type ListContactsQuery struct {
 
 // ContactMethodRequest represents a single contact method in requests
 type ContactMethodRequest struct {
-	Type      string `json:"type" validate:"required,oneof=email_personal email_work phone telegram discord twitter signal gchat" example:"email_personal"`
+	Type      string `json:"type" validate:"required,oneof=email_personal email_work phone telegram discord twitter signal gchat whatsapp" example:"email_personal"`
 	Value     string `json:"value" validate:"required,max=255" example:"john.doe@example.com"`
 	IsPrimary bool   `json:"is_primary" example:"true"`
 }
@@ -675,7 +675,8 @@ func validateContactMethods(validate *validator.Validate, methods []ContactMetho
 				return fmt.Errorf("invalid email for contact method %s", method.Type)
 			}
 		case string(repository.ContactMethodPhone),
-			string(repository.ContactMethodSignal):
+			string(repository.ContactMethodSignal),
+			string(repository.ContactMethodWhatsApp):
 			if len(method.Value) > 50 {
 				return fmt.Errorf("contact method %s must be less than 50 characters", method.Type)
 			}

--- a/backend/internal/api/handlers/contact_methods_test.go
+++ b/backend/internal/api/handlers/contact_methods_test.go
@@ -55,3 +55,19 @@ func TestValidateContactMethods_PhoneLength(t *testing.T) {
 	})
 	assert.Error(t, err)
 }
+
+func TestValidateContactMethods_WhatsAppValid(t *testing.T) {
+	validate := validator.New()
+	err := validateContactMethods(validate, []ContactMethodRequest{
+		{Type: "whatsapp", Value: "+1-555-123-4567"},
+	})
+	assert.NoError(t, err)
+}
+
+func TestValidateContactMethods_WhatsAppLength(t *testing.T) {
+	validate := validator.New()
+	err := validateContactMethods(validate, []ContactMethodRequest{
+		{Type: "whatsapp", Value: strings.Repeat("1", 51)},
+	})
+	assert.Error(t, err)
+}

--- a/backend/internal/repository/contact_method.go
+++ b/backend/internal/repository/contact_method.go
@@ -23,6 +23,7 @@ const (
 	ContactMethodTwitter       ContactMethodType = "twitter"
 	ContactMethodSignal        ContactMethodType = "signal"
 	ContactMethodGChat         ContactMethodType = "gchat"
+	ContactMethodWhatsApp      ContactMethodType = "whatsapp"
 )
 
 var ContactMethodTypes = []ContactMethodType{
@@ -34,6 +35,7 @@ var ContactMethodTypes = []ContactMethodType{
 	ContactMethodDiscord,
 	ContactMethodTwitter,
 	ContactMethodGChat,
+	ContactMethodWhatsApp,
 }
 
 type ContactMethod struct {

--- a/backend/migrations/008_add_whatsapp_contact_method.down.sql
+++ b/backend/migrations/008_add_whatsapp_contact_method.down.sql
@@ -1,0 +1,20 @@
+-- Remove whatsapp from contact_method type constraint
+
+-- First delete any whatsapp entries (they won't be valid after this migration reverts)
+DELETE FROM contact_method WHERE type = 'whatsapp';
+
+ALTER TABLE contact_method
+DROP CONSTRAINT contact_method_type_check;
+
+ALTER TABLE contact_method
+ADD CONSTRAINT contact_method_type_check
+CHECK (type IN (
+    'email_personal',
+    'email_work',
+    'phone',
+    'telegram',
+    'discord',
+    'twitter',
+    'signal',
+    'gchat'
+));

--- a/backend/migrations/008_add_whatsapp_contact_method.up.sql
+++ b/backend/migrations/008_add_whatsapp_contact_method.up.sql
@@ -1,0 +1,18 @@
+-- Add whatsapp to contact_method type constraint
+
+ALTER TABLE contact_method
+DROP CONSTRAINT contact_method_type_check;
+
+ALTER TABLE contact_method
+ADD CONSTRAINT contact_method_type_check
+CHECK (type IN (
+    'email_personal',
+    'email_work',
+    'phone',
+    'telegram',
+    'discord',
+    'twitter',
+    'signal',
+    'gchat',
+    'whatsapp'
+));

--- a/frontend/src/components/contacts/contact-method-icon.tsx
+++ b/frontend/src/components/contacts/contact-method-icon.tsx
@@ -13,6 +13,7 @@ const iconMap: Record<ContactMethodType, ComponentType<{ className?: string }>> 
   discord: MessageCircle,
   twitter: AtSign,
   gchat: MessageCircle,
+  whatsapp: MessageCircle,
 }
 
 export function ContactMethodIcon({

--- a/frontend/src/lib/contact-methods.ts
+++ b/frontend/src/lib/contact-methods.ts
@@ -9,6 +9,7 @@ export const CONTACT_METHOD_TYPE_VALUES: ContactMethodType[] = [
   'discord',
   'twitter',
   'gchat',
+  'whatsapp',
 ]
 
 export const CONTACT_METHOD_OPTIONS = [
@@ -60,6 +61,12 @@ export const CONTACT_METHOD_OPTIONS = [
     placeholder: 'name@gmail.com',
     inputType: 'email',
   },
+  {
+    value: 'whatsapp',
+    label: 'WhatsApp',
+    placeholder: '+1 (555) 555-1234',
+    inputType: 'tel',
+  },
 ]
 
 const HANDLE_METHOD_TYPES = new Set<ContactMethodType>(['telegram', 'discord', 'twitter'])
@@ -69,11 +76,12 @@ const CONTACT_METHOD_PRIORITY: Record<ContactMethodType, number> = {
   email_personal: 1,
   email_work: 2,
   phone: 3,
-  telegram: 4,
-  signal: 5,
-  discord: 6,
-  twitter: 7,
-  gchat: 8,
+  whatsapp: 4,
+  telegram: 5,
+  signal: 6,
+  discord: 7,
+  twitter: 8,
+  gchat: 9,
 }
 
 export function normalizeContactMethodValue(type: ContactMethodType, value: string) {
@@ -125,6 +133,11 @@ export function getContactMethodHref(type: ContactMethodType, value: string) {
 
   if (type === 'twitter') {
     return `https://twitter.com/${value}`
+  }
+
+  if (type === 'whatsapp') {
+    const numbersOnly = value.replace(/\D/g, '')
+    return `https://wa.me/${numbersOnly}`
   }
 
   return undefined

--- a/frontend/src/lib/validations/__tests__/contact.test.ts
+++ b/frontend/src/lib/validations/__tests__/contact.test.ts
@@ -128,6 +128,26 @@ describe('contactSchema', () => {
       expect(result.success).toBe(false)
     })
 
+    it('accepts valid whatsapp method', () => {
+      const data = {
+        full_name: 'Test User',
+        methods: [{ type: 'whatsapp', value: '+1-555-123-4567', is_primary: true }],
+      }
+
+      const result = contactSchema.safeParse(data)
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects whatsapp longer than 50 characters', () => {
+      const data = {
+        full_name: 'Test User',
+        methods: [{ type: 'whatsapp', value: '1'.repeat(51), is_primary: false }],
+      }
+
+      const result = contactSchema.safeParse(data)
+      expect(result.success).toBe(false)
+    })
+
     it('allows empty method rows', () => {
       const data = {
         full_name: 'Test User',

--- a/frontend/src/lib/validations/contact.ts
+++ b/frontend/src/lib/validations/contact.ts
@@ -113,7 +113,7 @@ export const contactSchema = z
         }
       }
 
-      if (rawType === 'phone' || rawType === 'signal') {
+      if (rawType === 'phone' || rawType === 'signal' || rawType === 'whatsapp') {
         if (normalizedValue.length > 50) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,

--- a/frontend/src/types/contact.ts
+++ b/frontend/src/types/contact.ts
@@ -7,6 +7,7 @@ export type ContactMethodType =
   | 'discord'
   | 'twitter'
   | 'gchat'
+  | 'whatsapp'
 
 export interface ContactMethod {
   id?: string


### PR DESCRIPTION
## Summary
- Add WhatsApp as a new contact method type across the full stack
- Database migration adds 'whatsapp' to the contact_method type constraint
- Backend validates WhatsApp like phone numbers (max 50 characters)
- Frontend supports WhatsApp with tel input, wa.me link generation, and MessageCircle icon

## Test plan
- [x] Backend unit tests pass (including new WhatsApp validation tests)
- [ ] Manual test: Create a contact with WhatsApp number
- [ ] Manual test: Verify WhatsApp link opens wa.me correctly
- [ ] Manual test: Verify validation rejects numbers > 50 characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)