### PR TITLE
ci: add Playwright E2E tests to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main, chore/add-e2e-ci ]  # TEMP: added chore branch for testing
+    branches: [ main ]
 
 jobs:
   backend-tests:


### PR DESCRIPTION
## Summary

- Add new `e2e-tests` job to CI workflow that runs Playwright E2E tests
- Set up PostgreSQL with pgvector service for database
- Configure Go and Bun for backend/frontend compilation
- Cache Playwright browsers to speed up subsequent runs
- Run chromium-only tests for faster CI execution
- Upload test artifacts (report always, traces on failure)

## Test plan

- [x] CI workflow runs successfully on this PR
- [x] E2E tests execute against chromium
- [ ] Artifacts are uploaded correctly

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)