### PR TITLE
perf: remove unnecessary React Query polling intervals

### DIFF
--- a/frontend/src/hooks/use-accelerated-time.ts
+++ b/frontend/src/hooks/use-accelerated-time.ts
@@ -29,8 +29,8 @@ export function useAcceleratedTime() {
   } = useQuery({
     queryKey: systemKeys.time(),
     queryFn: systemApi.getSystemTime,
-    refetchInterval: 30000, // Refetch every 30 seconds
-    staleTime: 25000, // Consider stale after 25 seconds
+    staleTime: 1000 * 60 * 5, // 5 minutes
+    refetchOnWindowFocus: true,
   })
 
   // Track page visibility to pause intervals when tab is hidden

--- a/frontend/src/hooks/use-contacts.ts
+++ b/frontend/src/hooks/use-contacts.ts
@@ -34,21 +34,9 @@ export function useContact(id: string) {
 export function useOverdueContacts() {
   return useQuery({
     queryKey: contactKeys.overdue(),
-    queryFn: async () => {
-      console.log('🔄 Fetching overdue contacts...')
-      try {
-        const result = await contactsApi.getOverdueContacts()
-        console.log('✅ Overdue contacts fetched:', result?.length || 0, 'contacts')
-        return result
-      } catch (error) {
-        console.error('❌ Failed to fetch overdue contacts:', error)
-        throw error
-      }
-    },
-    staleTime: 1000 * 60 * 5, // 5 minutes - match query client default
-    refetchInterval: 1000 * 60 * 5, // Refetch every 5 minutes
-    retry: 3, // Explicit retry count
-    retryDelay: attemptIndex => Math.min(1000 * 2 ** attemptIndex, 30000), // Exponential backoff
+    queryFn: () => contactsApi.getOverdueContacts(),
+    staleTime: 1000 * 60 * 5, // 5 minutes
+    refetchOnWindowFocus: true,
   })
 }
 

--- a/frontend/src/hooks/use-reminders.ts
+++ b/frontend/src/hooks/use-reminders.ts
@@ -25,8 +25,8 @@ export function useTodayReminders() {
   return useQuery({
     queryKey: reminderKeys.list({ due_today: true }),
     queryFn: () => remindersApi.getReminders({ due_today: true }),
-    staleTime: 1000 * 30, // 30 seconds for today's reminders
-    refetchInterval: 1000 * 60, // Refetch every minute
+    staleTime: 1000 * 60 * 5, // 5 minutes
+    refetchOnWindowFocus: true,
   })
 }
 
@@ -44,8 +44,8 @@ export function useReminderStats() {
   return useQuery({
     queryKey: reminderKeys.stats(),
     queryFn: () => remindersApi.getStats(),
-    staleTime: 1000 * 60 * 2, // 2 minutes
-    refetchInterval: 1000 * 60 * 5, // Refetch every 5 minutes
+    staleTime: 1000 * 60 * 5, // 5 minutes
+    refetchOnWindowFocus: true,
   })
 }
 


### PR DESCRIPTION
## Summary
- Remove `refetchInterval` from all React Query hooks (useTodayReminders, useReminderStats, useOverdueContacts, useAcceleratedTime)
- Use `refetchOnWindowFocus: true` instead for efficient data refresh when user returns to the tab
- Increase `staleTime` to 5 minutes for consistency
- Remove debug console.log statements from useOverdueContacts (violates repo rules)

## Test plan
- [ ] Verify data refreshes when switching back to the tab
- [x] Confirm no continuous network polling in DevTools Network tab
- [x] Check that time acceleration still works correctly in testing mode
- [x] Test that reminders and overdue contacts still update appropriately

Fixes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)