### PR TITLE
Add path-based conditional CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,33 @@ on:
     branches: [ main ]
 
 jobs:
+  # Detect which paths changed to conditionally run jobs
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'backend/**'
+              - 'tests/**'
+              - 'go.mod'
+            frontend:
+              - 'frontend/**'
+
   backend-tests:
     name: Backend Tests
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.backend == 'true' }}
 
     services:
       postgres:
@@ -75,6 +99,8 @@ jobs:
   frontend-tests:
     name: Frontend Tests
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.frontend == 'true' }}
 
     steps:
       - name: Checkout code
@@ -91,7 +117,7 @@ jobs:
 
       - name: Run linter (non-blocking)
         working-directory: frontend
-        run: bun run lint || echo "⚠️  Linting issues found - will be fixed in follow-up PR"
+        run: bun run lint || echo "Linting issues found - will be fixed in follow-up PR"
 
       - name: Run frontend tests
         working-directory: frontend
@@ -106,6 +132,8 @@ jobs:
   e2e-tests:
     name: E2E Tests
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true' }}
 
     services:
       postgres:


### PR DESCRIPTION
## Summary

- Uses `dorny/paths-filter` to detect which files changed
- Conditionally runs CI jobs based on changed paths
- Skipped jobs report "Success" instead of staying "Pending"

### Path Triggers

| Files Changed | Jobs Run |
|---------------|----------|
| `backend/**`, `tests/**`, `go.mod` | Backend Tests, E2E Tests |
| `frontend/**` | Frontend Tests, E2E Tests |
| Other files (docs, scripts, etc.) | None (all skip as Success) |

### Why This Approach

GitHub has no native "all checks that run must pass" option. When using workflow-level `paths:` filters, skipped workflows stay "Pending" forever, blocking merges if those checks are required.

By using job-level `if:` conditionals, skipped jobs report "Success", allowing you to require these checks without blocking merges on unrelated changes.

## Test plan

- [ ] Push a backend-only change → verify only Backend + E2E run
- [ ] Push a frontend-only change → verify only Frontend + E2E run
- [ ] Push a docs-only change → verify all jobs skip (show as Success)
- [ ] Verify required status checks can be configured after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)