### PR TITLE
Fix duplicate Claude reviews (clean)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -91,7 +91,9 @@ jobs:
 
             ## How to Submit Review
 
-            After reviewing, you MUST submit an actual GitHub review (not just a comment):
+            After reviewing, you MUST submit exactly ONE GitHub review using `gh pr review`.
+
+            CRITICAL: Do NOT submit multiple reviews or use both `gh api` and `gh pr review`. Submit ONE review only.
 
             ### If Code is Excellent (rare):
             ```bash
@@ -128,7 +130,7 @@ jobs:
             Since these can be quickly fixed with Claude Code, please address before merging."
             ```
 
-            IMPORTANT: You can also add inline comments using gh api for specific line-by-line feedback, but you MUST also submit a final review with --approve or --request-changes.
+            Note: For specific line-by-line feedback, include file paths and line numbers in your review body using markdown formatting. Do not use gh api to create separate inline comments.
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options


### PR DESCRIPTION
## Problem

PR #90 accidentally included a stray commit (fe777f5 - OAuth tests) along with the duplicate review fix.

## Solution

This PR:
1. Reverts PR #90 entirely
2. Re-applies ONLY the duplicate review fix

## Changes

Net result vs current main:
- ✅ Keeps: Claude duplicate review fix (.github/workflows/claude-code-review.yml)
- ❌ Removes: Stray OAuth test file (backend/internal/google/oauth_test.go)

## Commits

1. Revert "Fix duplicate Claude reviews (#90)"
2. fix: prevent duplicate Claude reviews

The stray OAuth test commit can be submitted separately in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)