### PR TITLE
fix: use PR head SHA for Claude review check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,7 +294,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           PR_NUMBER="${{ github.event.pull_request.number }}"
-          COMMIT_SHA="${{ github.sha }}"
+          COMMIT_SHA="${{ github.event.pull_request.head.sha }}"
 
           # Get Claude's review for this specific commit
           REVIEW=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER/reviews" \


### PR DESCRIPTION
## Summary
- Fix commit SHA mismatch in Claude review CI check that caused it to always pass

## Problem
The "Check Claude review result" step used `github.sha` to look up Claude's reviews, but for `pull_request` events this is the **merge commit SHA**. Claude submits reviews against the PR's **head commit SHA**, so they never matched.

This caused the check to fall into fail-open mode:
```
No Claude review found for commit 4a0de86... - passing (fail-open)
```

## Fix
Use `github.event.pull_request.head.sha` instead of `github.sha`.

## Test plan
- [x] Verify the fix matches what GitHub Actions provides for PR events
- [ ] CI should now correctly fail when Claude requests changes

Fixes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)