### PR TITLE
feat: include auto-memory in learnings extraction

### DIFF
--- a/.ai/skills/learnings/extract-learnings.py
+++ b/.ai/skills/learnings/extract-learnings.py
@@ -26,6 +26,8 @@ from typing import Iterator
 
 EXTRACTION_PROMPT = """\
 Analyze this session transcript to extract learnings that will help future agents work better on this project.
+The transcript may include a "Claude Code Auto-Memory" section at the end with notes Claude saved for itself.
+Treat these as an additional source of insights worth promoting to shared project documentation.
 
 Quality bar: Only extract insights that would meaningfully change how a future agent approaches work.
 
@@ -41,6 +43,7 @@ SKIP:
 - Implementation details specific to this session
 - Things obvious from reading the code or docs
 - Generic truisms ("consistency matters", "test before committing")
+- Insights already captured in the auto-memory section (avoid duplicating what Claude already knows)
 
 For documentation gaps, note:
 - What guidance existed but wasn't followed?
@@ -99,6 +102,35 @@ def get_project_sessions_path() -> Path:
     if not project_dir_name.startswith("-"):
         project_dir_name = "-" + project_dir_name
     return Path.home() / ".claude" / "projects" / project_dir_name
+
+
+def get_auto_memory_path() -> Path:
+    """Get the Claude Code auto-memory directory for this project."""
+    return get_project_sessions_path() / "memory"
+
+
+def read_auto_memory() -> str | None:
+    """Read all auto-memory markdown files and return as combined text.
+
+    Returns None if no memory files exist or directory is missing.
+    """
+    memory_dir = get_auto_memory_path()
+    if not memory_dir.exists():
+        return None
+
+    parts = []
+    for md_file in sorted(memory_dir.glob("*.md")):
+        try:
+            content = md_file.read_text().strip()
+            if content:
+                parts.append(f"### {md_file.name}\n\n{content}")
+        except (IOError, OSError):
+            continue
+
+    if not parts:
+        return None
+
+    return "\n\n---\n\n".join(parts)
 
 
 def get_extraction_state_path() -> Path:
@@ -538,6 +570,18 @@ def main():
     if not transcript.strip():
         print("No new content since last extraction.", file=sys.stderr)
         sys.exit(0)
+
+    # Append auto-memory content as additional context
+    auto_memory = read_auto_memory()
+    if auto_memory:
+        transcript += (
+            "\n\n---\n\n"
+            "# Claude Code Auto-Memory (for additional context)\n\n"
+            "The following are notes Claude saved for itself during this project. "
+            "Extract any insights worth promoting to shared project docs.\n\n"
+            + auto_memory
+        )
+        print(f"Included auto-memory from: {get_auto_memory_path()}", file=sys.stderr)
 
     if args.dry_run:
         print(transcript)

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,11 +1,118 @@
+# the name by which the project can be referenced within Serena
 project_name: PersonalCRM
+
+
+# list of languages for which language servers are started; choose from:
+#   al                  bash                clojure             cpp                 csharp
+#   csharp_omnisharp    dart                elixir              elm                 erlang
+#   fortran             fsharp              go                  groovy              haskell
+#   java                julia               kotlin              lua                 markdown
+#   matlab              nix                 pascal              perl                php
+#   powershell          python              python_jedi         r                   rego
+#   ruby                ruby_solargraph     rust                scala               swift
+#   terraform           toml                typescript          typescript_vts      vue
+#   yaml                zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple languages, the first language server that supports a given file will be used for that file.
+# The first language is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
 languages:
-  - go
-  - typescript
+- go
+- typescript
+
+# list of additional paths to ignore in all projects
+# same syntax as gitignore, so you can use * and **
 ignored_paths:
-  - node_modules
-  - .git
-  - .next
-  - frontend/.next
-  - backend/bin
+- node_modules
+- .git
+- .next
+- frontend/.next
+- backend/bin
+
+# whether to use project's .gitignore files to ignore files
 ignore_all_files_in_gitignore: true
+
+# list of mode names to that are always to be included in the set of active modes
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the base_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this setting overrides the global configuration.
+# Set this to [] to disable base modes for this project.
+# Set this to a list of mode names to always include the respective modes for this project.
+base_modes:
+
+# list of mode names that are to be activated by default.
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+default_modes:
+
+# list of tool names to exclude. We recommend not excluding any tools, see the readme for more details.
+# Below is the complete list of tools for convenience.
+# To make sure you have the latest list of tools, and to view their descriptions, 
+# execute `uv run scripts/print_tool_overview.py`.
+#
+#  * `activate_project`: Activates a project by name.
+#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
+#  * `create_text_file`: Creates/overwrites a file in the project directory.
+#  * `delete_lines`: Deletes a range of lines within a file.
+#  * `delete_memory`: Deletes a memory from Serena's project-specific memory store.
+#  * `execute_shell_command`: Executes a shell command.
+#  * `find_referencing_code_snippets`: Finds code snippets in which the symbol at the given location is referenced.
+#  * `find_referencing_symbols`: Finds symbols that reference the symbol at the given location (optionally filtered by type).
+#  * `find_symbol`: Performs a global (or local) search for symbols with/containing a given name/substring (optionally filtered by type).
+#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
+#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
+#  * `initial_instructions`: Gets the initial instructions for the current project.
+#     Should only be used in settings where the system prompt cannot be set,
+#     e.g. in clients you have no control over, like Claude Desktop.
+#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
+#  * `insert_at_line`: Inserts content at a given line in a file.
+#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
+#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
+#  * `list_memories`: Lists memories in Serena's project-specific memory store.
+#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
+#  * `prepare_for_new_conversation`: Provides instructions for preparing for a new conversation (in order to continue with the necessary context).
+#  * `read_file`: Reads a file within the project directory.
+#  * `read_memory`: Reads the memory with the given name from Serena's project-specific memory store.
+#  * `remove_project`: Removes a project from the Serena configuration.
+#  * `replace_lines`: Replaces a range of lines within a file with new content.
+#  * `replace_symbol_body`: Replaces the full definition of a symbol.
+#  * `restart_language_server`: Restarts the language server, may be necessary when edits not through Serena happen.
+#  * `search_for_pattern`: Performs a search for a pattern in the project.
+#  * `summarize_changes`: Provides instructions for summarizing the changes made to the codebase.
+#  * `switch_modes`: Activates modes by providing a list of their names
+#  * `think_about_collected_information`: Thinking tool for pondering the completeness of collected information.
+#  * `think_about_task_adherence`: Thinking tool for determining whether the agent is still on track with the current task.
+#  * `think_about_whether_you_are_done`: Thinking tool for determining whether the task is truly completed.
+#  * `write_memory`: Writes a named memory (for future reference) to Serena's project-specific memory store.
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default)
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+fixed_tools: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ''
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: utf-8


### PR DESCRIPTION
## Summary
- Feed Claude Code's auto-memory files into the learnings extraction prompt so insights saved during sessions can be promoted to shared project documentation
- Update `.serena/project.yml` with full config defaults

## Test plan
- [ ] Run `python .ai/skills/learnings/extract-learnings.py --dry-run` and verify auto-memory content is appended to transcript
- [ ] Verify learnings extraction still works normally when no auto-memory files exist