### PR TITLE
feat(telegram): Phase 4 — identity matching, aggregation, discovery

### DIFF
--- a/.ai/log/learnings/5d10e404-2c73-4e8d-8704-8ab449318894.yaml
+++ b/.ai/log/learnings/5d10e404-2c73-4e8d-8704-8ab449318894.yaml
@@ -642,3 +642,15 @@ detail: |
   The agent discovered the cleanup gap only after CI review feedback, causing wasted effort (failed CI, debugging, fix, re-run). The 'Common Gotchas' table documents many patterns but has no entry about integration test cleanup helpers. Adding guidance like 'When adding test data with shared cleanup helpers → Update ALL cleanup locations (inline + shared) to prevent CI flakiness' would prevent this class of error. The pattern of having shared cleanup helpers (cleanupAggregationMessages, etc.) is established in the codebase but not documented in CLAUDE.md or Session Hints.
 actionable: true
 
+---
+timestamp: "2026-04-09T15:20:26.160272"
+type: distinction
+summary: Live event aggregation must use chat-scoped incremental mode, not batch
+detail: |
+  When processing real-time events (webhooks, incoming messages), use `AggregateForContact(ctx, contactID, chatID)` (incremental, chat-scoped) not `AggregateForContactBatch(ctx, contactID)` (processes all chats). Incremental mode coalesces interactions within a 2h window, preventing separate interactions for burst messages in a conversation. Batch mode skips coalescing logic entirely and is for historical backfill only. Using batch mode for live events makes burst coalescing dead code, degrading UX (multiple separate interactions instead of one coalesced interaction per conversation).
+  
+  **Why:** Incremental mode checks for recent interactions in the same chat and coalesces within the window; batch processes all historical messages without time-based coalescing.
+  
+  **How to apply:** Any webhook or real-time event handler that triggers aggregation should use the chat-scoped incremental method. Reserve batch aggregation for backfill operations (e.g., post-sync historical data processing, OnPeerLinked for discovering old messages across chats).
+actionable: true
+

--- a/.ai/log/learnings/5d10e404-2c73-4e8d-8704-8ab449318894.yaml
+++ b/.ai/log/learnings/5d10e404-2c73-4e8d-8704-8ab449318894.yaml
@@ -302,3 +302,139 @@ detail: |
   Implement HandleChatParticipant update handler that calls h.api.MessagesGetFullChat() to query current participant count, then calls chatConfigRepo.UpdateMemberCount(). This keeps `member_count` in `telegram_chat_config` up-to-date as group membership changes. Important for auto-tracking logic: if a group grows past the threshold and status='auto', it should stop being tracked. Fresh member count ensures accurate threshold checks.
 actionable: true
 
+---
+timestamp: "2026-04-09T12:18:43.266412"
+type: gotcha
+summary: Telegram OffsetDate parameter semantics are reversed from expectations
+detail: |
+  Telegram's messages.getHistory `offset_date` parameter means "return messages BEFORE this date", not "since this date". Using `OffsetDate(2026-01-01)` returns messages from BEFORE January 2026, which is the opposite of what a backfill horizon suggests. For fresh backfills, start from newest messages (no OffsetDate) and iterate backwards until hitting the horizon in the loop. Only use OffsetDate for resuming from a cursor (message ID-based pagination).
+actionable: true
+
+---
+timestamp: "2026-04-09T12:18:43.266412"
+type: gotcha
+summary: Telegram dialog peers with access hashes must be used immediately, not reconstructed
+detail: |
+  InputPeerUser requires an access hash to fetch message history. A two-pass approach (discover all dialogs → reconstruct peers → backfill) loses the access hashes from the dialog iterator. The gotd library's dialog.Elem includes both the Peer (with access hash) and the Last message. Discovery and backfill must happen in one pass: iterate dialogs, process each dialog's history immediately using the Elem.Peer, not later with a reconstructed peer.
+actionable: true
+
+---
+timestamp: "2026-04-09T12:18:43.266412"
+type: rule
+summary: Filter Telegram dialogs by last message date before creating config records
+detail: |
+  Telegram's getDialogs returns every dialog in history (thousands), even those with no activity in years. Before creating a telegram_chat_config or attempting backfill, check `elem.Last.GetDate()` (Unix timestamp of dialog's most recent message). Skip dialogs where the last message is older than the backfill horizon. This prevents creating 1000+ chat configs for inactive conversations that would all be marked backfill_complete instantly.
+actionable: true
+
+---
+timestamp: "2026-04-09T12:18:43.266412"
+type: gotcha
+summary: Playwright route patterns with ** suffix match path + descendants
+detail: |
+  Playwright's `page.route('**/api/v1/telegram/chats', ...)` matches GET to `/chats` but NOT PATCH to `/chats/-100111` (path with ID suffix). The glob `**/chats` matches the exact path only. Use `**/chats**` (double-star suffix) to match both `/chats` and `/chats/:id`, or register separate route handlers for each pattern. This applies to any API with resource-level operations (GET /resource, PATCH /resource/:id).
+actionable: true
+
+---
+timestamp: "2026-04-09T12:18:43.266412"
+type: gotcha
+summary: E2E strict mode violations from real backend data during mocked tests
+detail: |
+  When E2E tests mock API responses but the test server is connected to a real backend (e.g., Telegram), `getByText('5 members')` may match multiple elements: the mocked chat AND real backend data rendered elsewhere on the page. Solution: scope assertions to the specific section using `page.locator('section', { has: page.getByRole(...) }).getByText(...)` instead of global selectors. Always consider data pollution from live integrations during E2E mocking.
+actionable: true
+
+---
+timestamp: "2026-04-09T12:18:43.266412"
+type: gotcha
+summary: Timezone-naive date parsing affects backfill horizons in UTC-stored systems
+detail: |
+  When using `time.Parse('2006-01-02', '2026-04-01')` for a backfill horizon, Go defaults to UTC midnight (2026-04-01 00:00:00 UTC). For users in CT (UTC-5), a message sent at 11pm CT on March 31st is stored as April 1st 04:00 UTC and gets included, even though it's conceptually "before" the horizon. Phase 4 aggregation logic must either: (1) parse the horizon in the user's local timezone, (2) document that horizon is UTC-based, or (3) add timezone awareness to occurred_at comparisons.
+actionable: true
+
+---
+timestamp: "2026-04-09T12:18:43.266412"
+type: gotcha
+summary: Crypto TokenEncryptor requires hex-encoded keys, not raw strings
+detail: |
+  When creating a crypto.NewTokenEncryptor(key), the key must be hex-encoded (64 hex chars = 32 bytes), not a raw string like `'test-encryption-key-32-bytes!!'`. The constructor validates with encoding/hex and fails with 'invalid byte: U+0074 't'' on non-hex input. Test keys should use a valid hex string like `'0123456789abcdef...'` (64 chars). Check existing crypto setup code for the pattern before creating test fixtures.
+actionable: true
+
+---
+timestamp: "2026-04-09T12:18:43.266412"
+type: distinction
+summary: SendValidationError returns 400, not 422 for invalid request bodies
+detail: |
+  The api.SendValidationError helper returns HTTP 400 (Bad Request), not 422 (Unprocessable Entity). When testing validation failures (invalid status values, malformed payloads), assert `StatusBadRequest` not `StatusUnprocessableEntity`. The codebase convention is: 400 for client errors in request syntax/values, 404 for not found, 500 for server errors. This is consistent across all handlers using the api package.
+actionable: true
+
+---
+timestamp: "2026-04-09T12:18:43.266412"
+type: architecture
+summary: Codex review catches progressively subtler issues over multiple rounds
+detail: |
+  Codex review is designed to run iteratively, not as one-shot approval. This session went through 5 rounds: (1) critical errors (error handling, backfill logic), (2) test coverage gaps, (3) edge cases (chat status change detection), (4) E2E test quality (post-mutation assertions), (5) API test robustness (encryption key format). Each round caught different issue types. Budget time for multiple review cycles and treat early passes as 'surface issues fixed', not 'production ready'.
+actionable: false
+
+---
+timestamp: "2026-04-09T12:18:43.266412"
+type: documentation_gap
+summary: Common Gotchas table doesn't include Playwright route pattern pitfalls
+detail: |
+  The `.ai/rules/core.md` Common Gotchas table has entries for SQL, git, E2E page loads, but nothing about Playwright route matching patterns. The `**/path` vs `**/path**` distinction caused E2E test failures where PATCH requests hit the real backend instead of mocks. This is a common pattern for any API with resource-level operations. Should add: 'Playwright route with `**/api/path` | Use `**/api/path**` to match both `/path` and `/path/:id` routes, or register separate handlers' to the gotchas table.
+actionable: true
+
+---
+timestamp: "2026-04-09T12:39:44.334516"
+type: gotcha
+summary: Pre-push E2E tests fail when dev server is already running
+detail: |
+  The pre-push hook runs the full E2E test suite which starts its own test server on port 8080. If `make dev` is already running the development server on that port, E2E tests fail with port conflicts. This manifests as mysterious E2E failures during git push that pass when run manually. Solution: run `make stop` before pushing, or configure E2E tests to use a different port during hook execution. The hook doesn't automatically stop the dev server because that would disrupt active development work.
+actionable: true
+
+---
+timestamp: "2026-04-09T12:39:44.334516"
+type: architecture
+summary: Flood wait should return partial results, not fail entirely
+detail: |
+  When Telegram API returns a flood wait error during dialog discovery (e.g., rate limit after processing 100 dialogs), the backfill should return the successfully processed dialogs rather than treating it as total failure. Pattern: catch `tgerr.FloodWait`, log the delay requirement, return what was collected so far with `nil` error. This provides graceful degradation - partial sync is better than no sync. Without this, a flood wait late in discovery discards all prior work and forces full restart.
+actionable: true
+
+---
+timestamp: "2026-04-09T12:39:44.334516"
+type: rule
+summary: Single-operation async tasks must call progress callbacks at start and completion
+detail: |
+  When implementing async operations with progress reporting (e.g., BackfillChat for retroactive single-chat backfill), must call `onProgress(1, 0)` before starting and `onProgress(1, 1)` after completion, even though it's a single operation. Without these calls, the UI shows no feedback during execution. Multi-operation batches naturally call progress on each iteration, but single operations need explicit bookend calls. The total=1, completed=0→1 pattern signals 'operation in progress' → 'operation done'.
+actionable: true
+
+---
+timestamp: "2026-04-09T12:39:44.334516"
+type: gotcha
+summary: Long-lived async goroutines need stored context, not context.Background()
+detail: |
+  When managers trigger background operations in goroutines (e.g., TelegramManager.TriggerChatBackfill), those goroutines need a context with proper cancellation tied to the manager's lifecycle. Using `context.Background()` means the goroutine ignores manager shutdown. Pattern: store the long-lived context in the manager (`clientCtx context.Context` field) during initialization, then use that stored context for triggered goroutines. This was caught by code review when `TriggerChatBackfill` used `context.Background()` instead of the client lifecycle context.
+actionable: true
+
+---
+timestamp: "2026-04-09T12:39:44.334516"
+type: gotcha
+summary: Ignored errors from existence checks can trigger false-positive flows
+detail: |
+  When checking for existence before optional operations (e.g., `allConfigs, _ := chatConfigRepo.ListConfigs(ctx)`), ignoring the error can trigger false-positive behavior. If the DB query fails, an empty slice is returned, which might trigger 'no configs exist' logic (like starting initial backfill) when configs actually DO exist but were unreachable. Pattern: always check errors from existence queries; only ignore errors where the absence/presence distinction doesn't change program behavior.
+actionable: true
+
+---
+timestamp: "2026-04-09T12:39:44.334516"
+type: distinction
+summary: Unknown resource (ErrNotFound) vs operational errors require different handler responses
+detail: |
+  In handlers checking group chat tracking status, distinguishing `db.ErrNotFound` (chat not in database yet) from other errors matters for user experience. Unknown chat should trigger auto-upsert with default 'auto' status and continue processing. DB connection failure or constraint violation should abort with 500. Initial implementation treated both as 'not tracked', which masked real errors. Pattern: `if errors.Is(err, db.ErrNotFound) { upsertDefault(); continue } else if err != nil { return 500 }`. This ensures first-time chats get auto-configured while actual errors surface properly.
+actionable: true
+
+---
+timestamp: "2026-04-09T12:39:44.334516"
+type: documentation_gap
+summary: Common Gotchas table missing pre-push hook environment conflicts
+detail: |
+  The `.ai/rules/core.md` Common Gotchas table documents test execution gotchas but doesn't cover pre-push hook environment conflicts. The E2E-with-running-dev-server port conflict caused push failures that weren't obvious to diagnose. This pattern applies to any hook-executed test that assumes clean environment. Suggestion: add row 'Pre-push E2E fails | Run `make stop` before push — hook's test server conflicts with dev server on port 8080'.
+actionable: true
+

--- a/.ai/log/learnings/5d10e404-2c73-4e8d-8704-8ab449318894.yaml
+++ b/.ai/log/learnings/5d10e404-2c73-4e8d-8704-8ab449318894.yaml
@@ -518,3 +518,59 @@ detail: |
   Message aggregation requires two distinct modes: **Batch mode** for backfill processes entire chat history, pre-resolves mutual interactions (looks ahead for both directions), creates all sessions upfront. **Incremental mode** for real-time messages processes one message at a time, extends existing bursts if within window, promotes outbound→mutual when reply arrives. Batch is complete-graph analysis; incremental is streaming with limited lookback. Both share the same burst/session logic but differ in when they resolve mutual status.
 actionable: true
 
+---
+timestamp: "2026-04-09T14:13:41.844496"
+type: gotcha
+summary: ExtendInteraction vs PromoteInteractionToMutual for direction changes
+detail: |
+  When a mutual session coalesces with an existing outbound interaction, must use PromoteInteractionToMutual instead of ExtendInteraction. ExtendInteraction passes the new direction but doesn't update the interaction.direction column. PromoteInteractionToMutual explicitly updates the direction field. This was caught in PR review when mutual sessions weren't actually marking interactions as mutual.
+actionable: true
+
+---
+timestamp: "2026-04-09T14:13:41.844496"
+type: gotcha
+summary: sqlc type assertions for nullable timestamps need pgtype.Timestamptz check
+detail: |
+  When sqlc queries return nullable timestamps (e.g., MAX(sent_at) as LastMessageAt), the type can be either pgtype.Timestamptz or time.Time depending on context. Must check both: `if ts, ok := row.LastMessageAt.(pgtype.Timestamptz); ok && ts.Valid { count.LastMessageAt = ts.Time } else if t, ok := row.LastMessageAt.(time.Time); ok { count.LastMessageAt = t }`. Single type assertion causes runtime panics when the type doesn't match.
+actionable: true
+
+---
+timestamp: "2026-04-09T14:13:41.844496"
+type: rule
+summary: Repository method calls in unit tests require nil checks for optional dependencies
+detail: |
+  When unit testing matcher/aggregation logic with mocks, repository method calls (e.g., messageRepo.UpdateMessageContact) need nil checks: `if m.messageRepo != nil { m.messageRepo.UpdateMessageContact(...) }`. This allows unit tests to pass nil for repos that aren't being tested, avoiding the need to mock every dependency. Only add nil checks for optional side-effect operations, not core data access.
+actionable: true
+
+---
+timestamp: "2026-04-09T14:13:41.844496"
+type: gotcha
+summary: Integration tests with shared database need unique identifiers per test
+detail: |
+  Integration tests that create telegram messages with hard-coded peer_user_id (e.g., 99999) fail when run in parallel or after cleanup skips. Soft-deleted messages from earlier runs remain in the DB. Other tests calling UpdateMessageContact(99999, contactID) update ALL messages for that peer, including soft-deleted ones from different tests. Solution: use unique peer IDs per test (80001, 80011, 80021, etc.) to avoid cross-test contamination.
+actionable: true
+
+---
+timestamp: "2026-04-09T14:13:41.844496"
+type: rule
+summary: DISTINCT ON requires deterministic ORDER BY to prevent flaky results
+detail: |
+  PostgreSQL DISTINCT ON returns arbitrary rows when the ORDER BY clause doesn't provide deterministic ordering. Query like `SELECT DISTINCT ON (peer_user_id) * FROM telegram_message ORDER BY peer_user_id` can return different messages across runs. Must add secondary sort: `ORDER BY peer_user_id, id DESC` or `ORDER BY peer_user_id, sent_at DESC` to ensure consistent results. Caught by code review when discovery candidate selection was nondeterministic.
+actionable: true
+
+---
+timestamp: "2026-04-09T14:13:41.844496"
+type: architecture
+summary: "Telegram interaction aggregation requires dual-mode design: batch vs incremental"
+detail: |
+  Message aggregation needs two modes with different mutual-resolution semantics: (1) Batch mode (backfill): processes entire chat history, pre-resolves outbound+inbound pairs into mutual before creating interactions, prevents cadence churn from historical data. (2) Incremental mode (live): processes new messages one at a time, extends existing bursts, promotes outbound→mutual when reply arrives. Both share burst/session logic but batch does complete-graph analysis while incremental is streaming. Can't use same code path for both.
+actionable: true
+
+---
+timestamp: "2026-04-09T14:13:41.844496"
+type: documentation_gap
+summary: Codex review rounds needed to catch subtle aggregation and matching bugs
+detail: |
+  Initial implementation passed all tests but Codex review found: (1) DISTINCT ON without ORDER BY causing nondeterministic peer selection, (2) live message handler not updating discovery candidates, (3) mutual session coalescing using wrong service method (ExtendInteraction instead of PromoteInteractionToMutual), (4) global peer count query on hot path. These issues weren't caught by unit/integration tests because tests used predictable data. Pattern: run Codex review iteratively (3-5 rounds) for complex multi-layered features like aggregation engines, don't rely solely on test coverage.
+actionable: true
+

--- a/.ai/log/learnings/5d10e404-2c73-4e8d-8704-8ab449318894.yaml
+++ b/.ai/log/learnings/5d10e404-2c73-4e8d-8704-8ab449318894.yaml
@@ -602,3 +602,27 @@ detail: |
   **How to apply**: When adding unit tests to methods with multiple dependencies, consider nil guards for dependencies used only for side effects rather than requiring full mock setup. Use real mocks for dependencies that affect return values or control flow.
 actionable: true
 
+---
+timestamp: "2026-04-09T14:56:02.838812"
+type: gotcha
+summary: "contacts.spec.ts:79 'expandable notes' test is flaky ~50%"
+detail: |
+  The E2E test 'should show expandable notes for long content' in contacts.spec.ts:79 fails intermittently. It waits for text content ('Met at the AI conference'), then checks for a 'Show more' button. The flakiness occurs because CSS line-clamp overflow detection hasn't necessarily completed when the test checks for button visibility. The test needs better wait conditions that ensure CSS layout has finished (e.g., waiting for the button itself with a longer timeout, or using a resize observer). This is a pre-existing issue unrelated to most feature work — retrying the push is often faster than fixing it unless you're specifically working on the notes UI.
+actionable: true
+
+---
+timestamp: "2026-04-09T14:56:02.838812"
+type: gotcha
+summary: Pre-push hook E2E failures don't show which test failed
+detail: |
+  When the pre-push hook reports '[test] FAIL E2E tests', it doesn't include details about which specific test failed. To diagnose, run `make test-e2e-diff` locally — it will show the exact test name and error (e.g., 'contacts.spec.ts:79'). The hook output file (shown in task notifications) also lacks this detail. This is a workflow gotcha that causes wasted time grepping hook output.
+actionable: true
+
+---
+timestamp: "2026-04-09T14:56:02.838812"
+type: rule
+summary: Don't fix pre-existing flaky tests as scope creep during feature work
+detail: |
+  When a pre-existing, unrelated flaky test blocks your push, prefer retrying over fixing it. Expanding scope to fix unrelated issues fragments your work and delays shipping. Example from this session: contacts.spec.ts expandable notes test was flaky during Telegram Phase 4 work. Agent correctly identified it as pre-existing, unrelated to changes, and retried until it passed rather than debugging CSS timing. Exception: if you're specifically working on that feature area, fix it properly. Otherwise, retry or note it for separate cleanup.
+actionable: true
+

--- a/.ai/log/learnings/5d10e404-2c73-4e8d-8704-8ab449318894.yaml
+++ b/.ai/log/learnings/5d10e404-2c73-4e8d-8704-8ab449318894.yaml
@@ -590,3 +590,15 @@ detail: |
   core.md documents: 'When push is blocked by learnings extraction: 1. Read the new learnings 2. For each actionable learning, decide if/where to apply it 3. Commit any applied changes plus the learnings files'. In practice, Claude committed learnings directly without reading them first. Why missed: instruction exists in core.md but isn't in the blocking message itself. How to strengthen: Either include the workflow steps in the pre-push hook's blocking message, or make the instruction more prominent in core.md's Pre-push Hooks section.
 actionable: true
 
+---
+timestamp: "2026-04-09T14:42:06.934469"
+type: rule
+summary: Nil guards in production code acceptable for test simplification
+detail: |
+  When a method calls dependencies purely for side effects (not return values), it's acceptable to add `if m.dependency != nil` guards specifically to enable unit testing without complete mock setup. Example from session: `OnPeerLinked` calls `m.messageRepo.UpdateMessageContact()` for side effects only — adding a nil guard allows testing the core matching logic without mocking the message repository. The code even documents this: "Nil guard for messageRepo in OnPeerLinked (enables unit testing)". This pattern trades stricter dependency verification for simpler test setup.
+  
+  **Why**: Always-present production dependencies can be nil in unit tests when you want to test core logic in isolation.
+  
+  **How to apply**: When adding unit tests to methods with multiple dependencies, consider nil guards for dependencies used only for side effects rather than requiring full mock setup. Use real mocks for dependencies that affect return values or control flow.
+actionable: true
+

--- a/.ai/log/learnings/5d10e404-2c73-4e8d-8704-8ab449318894.yaml
+++ b/.ai/log/learnings/5d10e404-2c73-4e8d-8704-8ab449318894.yaml
@@ -574,3 +574,19 @@ detail: |
   Initial implementation passed all tests but Codex review found: (1) DISTINCT ON without ORDER BY causing nondeterministic peer selection, (2) live message handler not updating discovery candidates, (3) mutual session coalescing using wrong service method (ExtendInteraction instead of PromoteInteractionToMutual), (4) global peer count query on hot path. These issues weren't caught by unit/integration tests because tests used predictable data. Pattern: run Codex review iteratively (3-5 rounds) for complex multi-layered features like aggregation engines, don't rely solely on test coverage.
 actionable: true
 
+---
+timestamp: "2026-04-09T14:29:56.088102"
+type: architecture
+summary: Aggregation logic must explicitly guard entity boundaries
+detail: |
+  When implementing record aggregation/session logic that groups multiple records, add explicit guards to prevent cross-entity merging. The resolveSessions cross-chat bug required adding `prev.chatID == b.chatID` to prevent bridging sessions across different chats for the same contact. Without this guard, the function would merge conversations from separate chats. Pattern: when coalescing/bridging records based on time windows or relationships, always verify they share the same entity scope (chat, user, workspace, etc.).
+actionable: true
+
+---
+timestamp: "2026-04-09T14:29:56.088102"
+type: documentation_gap
+summary: Pre-push learning workflow instruction not followed
+detail: |
+  core.md documents: 'When push is blocked by learnings extraction: 1. Read the new learnings 2. For each actionable learning, decide if/where to apply it 3. Commit any applied changes plus the learnings files'. In practice, Claude committed learnings directly without reading them first. Why missed: instruction exists in core.md but isn't in the blocking message itself. How to strengthen: Either include the workflow steps in the pre-push hook's blocking message, or make the instruction more prominent in core.md's Pre-push Hooks section.
+actionable: true
+

--- a/.ai/log/learnings/5d10e404-2c73-4e8d-8704-8ab449318894.yaml
+++ b/.ai/log/learnings/5d10e404-2c73-4e8d-8704-8ab449318894.yaml
@@ -438,3 +438,83 @@ detail: |
   The `.ai/rules/core.md` Common Gotchas table documents test execution gotchas but doesn't cover pre-push hook environment conflicts. The E2E-with-running-dev-server port conflict caused push failures that weren't obvious to diagnose. This pattern applies to any hook-executed test that assumes clean environment. Suggestion: add row 'Pre-push E2E fails | Run `make stop` before push — hook's test server conflicts with dev server on port 8080'.
 actionable: true
 
+---
+timestamp: "2026-04-09T13:49:02.792919"
+type: gotcha
+summary: Import handler buildMethodsAuto only checks emails/phones JSONB, not metadata fields
+detail: |
+  The import handler's `buildMethodsAuto` function only extracts contact methods from `external_contact.Emails` and `external_contact.Phones` JSONB arrays. For social platforms like Telegram where identifiers live in `metadata["username"]`, need explicit source check (e.g., `if external.Source == "telegram" && metadata["username"] exists`) to extract and create the telegram contact method. This pattern applies to any external source that stores identifiers in metadata rather than structured phone/email fields.
+actionable: true
+
+---
+timestamp: "2026-04-09T13:49:02.792919"
+type: architecture
+summary: Use narrow service interfaces to avoid circular dependencies between packages
+detail: |
+  When a specialized package (e.g., telegram) needs service methods but can't import the service package (would create circular dependency), define narrow interfaces in the specialized package (`interactionRecorder`, `interactionPromoter`, `interactionExtender`) that the service satisfies. This keeps packages decoupled while maintaining testability. All three interfaces can be satisfied by the same concrete service (`*ContactService`), passed as separate interface parameters.
+actionable: true
+
+---
+timestamp: "2026-04-09T13:49:02.792919"
+type: architecture
+summary: "Circular dependency resolution: move shared types to repository package"
+detail: |
+  When two packages need shared request types or constants and both would import each other (e.g., sync providers need service types, service needs provider types), move the shared types to the `repository` package. Providers already depend on repository for DB access, so this breaks the cycle without adding new dependencies. This is the established pattern for this codebase.
+actionable: true
+
+---
+timestamp: "2026-04-09T13:49:02.792919"
+type: rule
+summary: PostImportHook pattern for source-specific post-processing after import/link
+detail: |
+  For external sources that need to back-fill or update data after a candidate is imported/linked (e.g., updating message history with newly matched contact), use an optional `PostImportHook` interface on the import handler. The source manager implements `OnPeerLinked(ctx, sourceID, sourceUsername, contactID)` and the handler calls it after successful import/link. This allows source-specific logic without tight coupling between import handler and individual sources.
+actionable: true
+
+---
+timestamp: "2026-04-09T13:49:02.792919"
+type: gotcha
+summary: Type name collisions with package imports require renaming
+detail: |
+  When defining a new type, check for name collisions with imported packages. Example: defining `type session struct` failed to compile because another file imported `"github.com/gotd/td/session"`. Had to rename to `msgSession`. Use grep to check all imports in the package before naming new types.
+actionable: true
+
+---
+timestamp: "2026-04-09T13:49:02.792919"
+type: gotcha
+summary: Integration tests must call db.RunMigrations before db.NewDatabase
+detail: |
+  Integration tests that create their own DB connection (in `backend/tests/`) MUST call `db.RunMigrations(databaseURL, getMigrationsPath())` before `db.NewDatabase()`. CI PostgreSQL starts with a bare database without pre-existing schema. Local dev often has schema from prior runs, causing tests to pass locally but fail in CI.
+actionable: true
+
+---
+timestamp: "2026-04-09T13:49:02.792919"
+type: rule
+summary: Never use time.Now() anywhere—use accelerated.GetCurrentTime() in ALL code including tests
+detail: |
+  The codebase enforces time acceleration support via forbidigo linter rules. `time.Now()` is forbidden everywhere, including unit tests and test helpers. Always use `accelerated.GetCurrentTime()`. Forgetting this in test code will cause lint failures even though tests pass.
+actionable: true
+
+---
+timestamp: "2026-04-09T13:49:02.792919"
+type: gotcha
+summary: Integration tests with shared DB cannot assert cross-query equality
+detail: |
+  When writing integration tests that share a database with other parallel tests, don't assert equality across separate count queries (e.g., `countBefore == countAfter`). Other tests can create/delete rows between calls. Instead, assert per-query invariants like `count >= expectedMinimum` or verify specific IDs returned rather than counts.
+actionable: true
+
+---
+timestamp: "2026-04-09T13:49:02.792919"
+type: architecture
+summary: Codex iterative review pattern for complex implementations
+detail: |
+  For complex multi-step implementations, use Codex (AI code reviewer) in an iterative loop: implement according to plan, run codex review, fix all issues it identifies, re-run codex on fixes until it approves. This session went through 5 rounds fixing 12 issues (burst coalescing, mutual pre-resolution, chat scoping, identity linkage, LIKE wildcards, query bounds, callable interfaces, wiring). The pattern: implement → codex review → batch fix issues → repeat until PASS.
+actionable: true
+
+---
+timestamp: "2026-04-09T13:49:02.792919"
+type: distinction
+summary: "Two aggregation modes needed: batch (backfill) vs incremental (real-time)"
+detail: |
+  Message aggregation requires two distinct modes: **Batch mode** for backfill processes entire chat history, pre-resolves mutual interactions (looks ahead for both directions), creates all sessions upfront. **Incremental mode** for real-time messages processes one message at a time, extends existing bursts if within window, promotes outbound→mutual when reply arrives. Batch is complete-graph analysis; incremental is streaming with limited lookback. Both share the same burst/session logic but differ in when they resolve mutual status.
+actionable: true
+

--- a/.ai/log/learnings/5d10e404-2c73-4e8d-8704-8ab449318894.yaml
+++ b/.ai/log/learnings/5d10e404-2c73-4e8d-8704-8ab449318894.yaml
@@ -626,3 +626,19 @@ detail: |
   When a pre-existing, unrelated flaky test blocks your push, prefer retrying over fixing it. Expanding scope to fix unrelated issues fragments your work and delays shipping. Example from this session: contacts.spec.ts expandable notes test was flaky during Telegram Phase 4 work. Agent correctly identified it as pre-existing, unrelated to changes, and retried until it passed rather than debugging CSS timing. Exception: if you're specifically working on that feature area, fix it properly. Otherwise, retry or note it for separate cleanup.
 actionable: true
 
+---
+timestamp: "2026-04-09T15:08:43.511544"
+type: gotcha
+summary: Integration test cleanup requires updating both inline and shared helper functions
+detail: |
+  When adding test data to an integration test that uses a shared cleanup helper (e.g., cleanupAggregationMessages), the new data must be cleaned up in TWO places: (1) inline cleanup at the end of the specific test, and (2) the shared cleanup helper function. Missing the shared helper update causes CI flakiness when tests run in different orders. In this session, message IDs 80061/80062 and chat prefix tg:303:% were added to a test but forgotten in cleanupAggregationMessages(), causing intermittent CI failures. When adding test data, grep for all cleanup functions and update them.
+actionable: true
+
+---
+timestamp: "2026-04-09T15:08:43.511544"
+type: documentation_gap
+summary: No guidance exists about test cleanup completeness patterns
+detail: |
+  The agent discovered the cleanup gap only after CI review feedback, causing wasted effort (failed CI, debugging, fix, re-run). The 'Common Gotchas' table documents many patterns but has no entry about integration test cleanup helpers. Adding guidance like 'When adding test data with shared cleanup helpers → Update ALL cleanup locations (inline + shared) to prevent CI flakiness' would prevent this class of error. The pattern of having shared cleanup helpers (cleanupAggregationMessages, etc.) is established in the codebase but not documented in CLAUDE.md or Session Hints.
+actionable: true
+

--- a/.ai/spec/telegram-integration.md
+++ b/.ai/spec/telegram-integration.md
@@ -712,10 +712,11 @@ func (e *AggregationEngine) AggregateForContact(ctx context.Context, contactID u
 
 Telegram peers are matched to CRM contacts in priority order:
 
-1. **Primary: Telegram username** — Match `peer_username` against `external_identity(identifier_type='telegram')`. Also check `contact_method(type='telegram')`.
-2. **Secondary: Phone number** — Match `peer_phone` (if available; Telegram only shares phone for mutual contacts) against `external_identity(identifier_type='phone')`.
-3. **Tertiary: Fuzzy name** — Match `peer_first_name + peer_last_name` against contact names using existing fuzzy matching infrastructure.
-4. **Unmatched** — Upsert `external_contact(source='telegram', source_id=peer_user_id)` for discovery. Also create `external_identity(identifier_type='telegram', source='telegram', contact_id=NULL)` for future matching.
+1. **Primary: Telegram username** — Match `peer_username` against `external_identity(identifier_type='telegram')`. Also check `contact_method(type='telegram')`. Uses `IdentityService.MatchOrCreate` in discovery mode.
+2. **Secondary: Phone number** — Match `peer_phone` (if available; Telegram only shares phone for mutual contacts) against `external_identity(identifier_type='phone')`. Uses `IdentityService.MatchOrCreate`.
+3. **Unmatched** — Upsert `external_contact(source='telegram', source_id=peer_user_id)` for discovery. Also create `external_identity(identifier_type='telegram', source='telegram', contact_id=NULL)` for future matching.
+
+**No fuzzy name matching (v1):** Fuzzy auto-matching by peer name is deferred. The risk of false positives from common first names (e.g., "John", "Alex") outweighs the benefit. Unmatched peers flow to the import candidates page, where the existing fuzzy suggested-match UI helps users make informed manual matches. This follows the same approach used by Google Contacts and iCloud import channels.
 
 ### 5.7 Discovery via external_contact
 

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -250,6 +250,11 @@ func main() {
 		telegramMessageRepo := repository.NewTelegramMessageRepository(database.Queries)
 		telegramSyncRepo := repository.NewSyncRepository(database.Queries)
 
+		// Phase 4: identity + aggregation dependencies
+		tgIdentityRepo := repository.NewIdentityRepository(database.Queries)
+		tgIdentityService := service.NewIdentityService(tgIdentityRepo)
+		tgExternalContactRepo := repository.NewExternalContactRepository(database.Queries)
+
 		encryptor, err := crypto.NewTokenEncryptor(cfg.External.TokenEncryptionKey)
 		if err != nil {
 			logger.Fatal().Err(err).Msg("failed to initialize Telegram encryptor (TOKEN_ENCRYPTION_KEY required)")
@@ -265,6 +270,12 @@ func main() {
 			cfg.External.TelegramAPIID,
 			cfg.External.TelegramAPIHash,
 			&cfg.Telegram,
+			tgIdentityService,
+			tgExternalContactRepo,
+			interactionRepo,
+			contactService,
+			contactService,
+			contactService,
 		)
 
 		if err := telegramManager.Start(ctx); err != nil {
@@ -274,6 +285,11 @@ func main() {
 
 		telegramHandler = handlers.NewTelegramHandler(telegramManager)
 		logger.Info().Msg("Telegram integration initialized")
+	}
+
+	// Wire Telegram post-import hook (if both Telegram and imports are enabled)
+	if telegramManager != nil && importHandler != nil {
+		importHandler.SetPostImportHook(telegramManager)
 	}
 
 	// Initialize handlers

--- a/backend/internal/api/handlers/import.go
+++ b/backend/internal/api/handlers/import.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"net/http"
 	"sort"
 	"strconv"
@@ -24,12 +25,19 @@ import (
 const MaxCandidatesForSorting = 10000
 
 // ImportHandler handles import candidate HTTP requests
+// PostImportHook is called after a Telegram candidate is imported/linked
+// to back-fill message matching and trigger aggregation.
+type PostImportHook interface {
+	OnPeerLinked(ctx context.Context, peerUserID int64, peerUsername string, contactID uuid.UUID) error
+}
+
 type ImportHandler struct {
-	externalRepo *repository.ExternalContactRepository
-	contactSvc   *service.ContactService
-	matchSvc     *service.ImportMatchService
-	enricher     *service.EnrichmentService
-	validator    *validator.Validate
+	externalRepo   *repository.ExternalContactRepository
+	contactSvc     *service.ContactService
+	matchSvc       *service.ImportMatchService
+	enricher       *service.EnrichmentService
+	validator      *validator.Validate
+	postImportHook PostImportHook
 }
 
 // NewImportHandler creates a new import handler
@@ -46,6 +54,11 @@ func NewImportHandler(
 		enricher:     enricher,
 		validator:    validator.New(),
 	}
+}
+
+// SetPostImportHook sets an optional hook for post-import processing (e.g., Telegram back-linking).
+func (h *ImportHandler) SetPostImportHook(hook PostImportHook) {
+	h.postImportHook = hook
 }
 
 // ImportCandidateResponse represents an import candidate for the API
@@ -362,6 +375,9 @@ func (h *ImportHandler) ImportContact(c *gin.Context) {
 		return
 	}
 
+	// Post-import hook: back-link Telegram message history
+	h.triggerPostImportHook(ctx, external, contact.ID)
+
 	api.SendSuccess(c, http.StatusCreated, contact, nil)
 }
 
@@ -433,6 +449,17 @@ func (h *ImportHandler) buildMethodsAuto(external *repository.ExternalContact) [
 			Type:  "phone",
 			Value: phone.Value,
 		})
+	}
+
+	// Handle Telegram username from metadata
+	if external.Source == "telegram" {
+		if username, ok := external.Metadata["username"].(string); ok && username != "" {
+			username = strings.TrimPrefix(username, "@")
+			methods = append(methods, service.ContactMethodInput{
+				Type:  "telegram",
+				Value: username,
+			})
+		}
 	}
 
 	return methods
@@ -521,7 +548,29 @@ func (h *ImportHandler) LinkContact(c *gin.Context) {
 		logger.Warn().Err(enrichErr).Str("external_id", id.String()).Msg("enrichment failed during link")
 	}
 
+	// Post-import hook: back-link Telegram message history
+	h.triggerPostImportHook(ctx, external, crmContactID)
+
 	api.SendSuccess(c, http.StatusOK, updated, nil)
+}
+
+// triggerPostImportHook calls the post-import hook for Telegram candidates (best-effort).
+func (h *ImportHandler) triggerPostImportHook(ctx context.Context, external *repository.ExternalContact, contactID uuid.UUID) {
+	if h.postImportHook == nil || external.Source != "telegram" {
+		return
+	}
+	peerUserID, err := strconv.ParseInt(external.SourceID, 10, 64)
+	if err != nil {
+		logger.Warn().Err(err).Str("source_id", external.SourceID).Msg("failed to parse telegram peer user ID for post-import hook")
+		return
+	}
+	var peerUsername string
+	if username, ok := external.Metadata["username"].(string); ok {
+		peerUsername = strings.TrimPrefix(username, "@")
+	}
+	if err := h.postImportHook.OnPeerLinked(ctx, peerUserID, peerUsername, contactID); err != nil {
+		logger.Warn().Err(err).Int64("peer_user_id", peerUserID).Msg("telegram: post-import hook failed")
+	}
 }
 
 // toEnrichmentMethodSelections converts handler selections to service format

--- a/backend/internal/db/interaction.sql.go
+++ b/backend/internal/db/interaction.sql.go
@@ -132,6 +132,96 @@ func (q *Queries) FindInteractionInWindow(ctx context.Context, arg FindInteracti
 	return &i, err
 }
 
+const FindRecentOutboundTelegramInteraction = `-- name: FindRecentOutboundTelegramInteraction :one
+SELECT id, contact_id, source, source_ref, occurred_at, description, created_at, deleted_at, direction FROM interaction
+WHERE contact_id = $1
+  AND source = 'telegram'
+  AND direction = 'outbound'
+  AND source_ref LIKE $2
+  AND occurred_at >= $3
+  AND occurred_at <= $4
+  AND deleted_at IS NULL
+ORDER BY occurred_at DESC
+LIMIT 1
+`
+
+type FindRecentOutboundTelegramInteractionParams struct {
+	ContactID       pgtype.UUID        `json:"contact_id"`
+	SourceRefPrefix pgtype.Text        `json:"source_ref_prefix"`
+	WindowStart     pgtype.Timestamptz `json:"window_start"`
+	WindowEnd       pgtype.Timestamptz `json:"window_end"`
+}
+
+// Find the most recent outbound telegram interaction for a contact in a specific chat
+// within a time window. source_ref_prefix should include trailing % for LIKE match.
+func (q *Queries) FindRecentOutboundTelegramInteraction(ctx context.Context, arg FindRecentOutboundTelegramInteractionParams) (*Interaction, error) {
+	row := q.db.QueryRow(ctx, FindRecentOutboundTelegramInteraction,
+		arg.ContactID,
+		arg.SourceRefPrefix,
+		arg.WindowStart,
+		arg.WindowEnd,
+	)
+	var i Interaction
+	err := row.Scan(
+		&i.ID,
+		&i.ContactID,
+		&i.Source,
+		&i.SourceRef,
+		&i.OccurredAt,
+		&i.Description,
+		&i.CreatedAt,
+		&i.DeletedAt,
+		&i.Direction,
+	)
+	return &i, err
+}
+
+const FindRecentTelegramInteraction = `-- name: FindRecentTelegramInteraction :one
+SELECT id, contact_id, source, source_ref, occurred_at, description, created_at, deleted_at, direction FROM interaction
+WHERE contact_id = $1
+  AND source = 'telegram'
+  AND direction = $2
+  AND source_ref LIKE $3
+  AND occurred_at >= $4
+  AND occurred_at <= $5
+  AND deleted_at IS NULL
+ORDER BY occurred_at DESC
+LIMIT 1
+`
+
+type FindRecentTelegramInteractionParams struct {
+	ContactID       pgtype.UUID        `json:"contact_id"`
+	Direction       string             `json:"direction"`
+	SourceRefPrefix pgtype.Text        `json:"source_ref_prefix"`
+	WindowStart     pgtype.Timestamptz `json:"window_start"`
+	WindowEnd       pgtype.Timestamptz `json:"window_end"`
+}
+
+// Find the most recent telegram interaction for a contact in a specific chat
+// with a given direction. Used for incremental coalescing.
+func (q *Queries) FindRecentTelegramInteraction(ctx context.Context, arg FindRecentTelegramInteractionParams) (*Interaction, error) {
+	row := q.db.QueryRow(ctx, FindRecentTelegramInteraction,
+		arg.ContactID,
+		arg.Direction,
+		arg.SourceRefPrefix,
+		arg.WindowStart,
+		arg.WindowEnd,
+	)
+	var i Interaction
+	err := row.Scan(
+		&i.ID,
+		&i.ContactID,
+		&i.Source,
+		&i.SourceRef,
+		&i.OccurredAt,
+		&i.Description,
+		&i.CreatedAt,
+		&i.DeletedAt,
+		&i.Direction,
+	)
+	return &i, err
+}
+
 const GetInteraction = `-- name: GetInteraction :one
 
 SELECT id, contact_id, source, source_ref, occurred_at, description, created_at, deleted_at, direction FROM interaction WHERE id = $1 AND deleted_at IS NULL
@@ -226,6 +316,39 @@ type UpdateInteractionDirectionParams struct {
 // Promote an outbound interaction to mutual when a reply arrives (in-place update)
 func (q *Queries) UpdateInteractionDirection(ctx context.Context, arg UpdateInteractionDirectionParams) (*Interaction, error) {
 	row := q.db.QueryRow(ctx, UpdateInteractionDirection, arg.Direction, arg.OccurredAt, arg.ID)
+	var i Interaction
+	err := row.Scan(
+		&i.ID,
+		&i.ContactID,
+		&i.Source,
+		&i.SourceRef,
+		&i.OccurredAt,
+		&i.Description,
+		&i.CreatedAt,
+		&i.DeletedAt,
+		&i.Direction,
+	)
+	return &i, err
+}
+
+const UpdateInteractionTimestamp = `-- name: UpdateInteractionTimestamp :one
+UPDATE interaction
+SET occurred_at = $1,
+    description = $2
+WHERE id = $3
+  AND deleted_at IS NULL
+RETURNING id, contact_id, source, source_ref, occurred_at, description, created_at, deleted_at, direction
+`
+
+type UpdateInteractionTimestampParams struct {
+	OccurredAt  pgtype.Timestamptz `json:"occurred_at"`
+	Description pgtype.Text        `json:"description"`
+	ID          pgtype.UUID        `json:"id"`
+}
+
+// Extend an existing interaction's occurred_at and description (incremental coalescing)
+func (q *Queries) UpdateInteractionTimestamp(ctx context.Context, arg UpdateInteractionTimestampParams) (*Interaction, error) {
+	row := q.db.QueryRow(ctx, UpdateInteractionTimestamp, arg.OccurredAt, arg.Description, arg.ID)
 	var i Interaction
 	err := row.Scan(
 		&i.ID,

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -39,6 +39,7 @@ type Querier interface {
 	CountSearchContacts(ctx context.Context, arg CountSearchContactsParams) (int64, error)
 	CountSyncLogsByState(ctx context.Context, syncStateID pgtype.UUID) (int64, error)
 	CountTelegramMessagesByChat(ctx context.Context) ([]*CountTelegramMessagesByChatRow, error)
+	CountTelegramMessagesByPeer(ctx context.Context) ([]*CountTelegramMessagesByPeerRow, error)
 	CountUnmatchedExternalContacts(ctx context.Context, source string) (int64, error)
 	CountUnmatchedIdentities(ctx context.Context) (int64, error)
 	CreateContact(ctx context.Context, arg CreateContactParams) (*Contact, error)
@@ -119,6 +120,12 @@ type Querier interface {
 	FindMethodsByNormalizedValue(ctx context.Context, arg FindMethodsByNormalizedValueParams) ([]*FindMethodsByNormalizedValueRow, error)
 	// Find a pending follow-up task for a contact (kind='follow_up', state='managed')
 	FindPendingFollowUp(ctx context.Context, contactID pgtype.UUID) (*ContactTask, error)
+	// Find the most recent outbound telegram interaction for a contact in a specific chat
+	// within a time window. source_ref_prefix should include trailing % for LIKE match.
+	FindRecentOutboundTelegramInteraction(ctx context.Context, arg FindRecentOutboundTelegramInteractionParams) (*Interaction, error)
+	// Find the most recent telegram interaction for a contact in a specific chat
+	// with a given direction. Used for incremental coalescing.
+	FindRecentTelegramInteraction(ctx context.Context, arg FindRecentTelegramInteractionParams) (*Interaction, error)
 	FindSimilarContacts(ctx context.Context, arg FindSimilarContactsParams) ([]*FindSimilarContactsRow, error)
 	// Finds similar contacts for multiple candidate names in a single batch query.
 	// Uses UNNEST to expand input arrays and LATERAL join to find matches per candidate.
@@ -171,6 +178,7 @@ type Querier interface {
 	GetTelegramChannelState(ctx context.Context, channelID int64) (*TelegramChannelState, error)
 	GetTelegramChatConfig(ctx context.Context, telegramChatID int64) (*TelegramChatConfig, error)
 	GetTelegramMessage(ctx context.Context, arg GetTelegramMessageParams) (*TelegramMessage, error)
+	GetTelegramMessageByReplyTo(ctx context.Context, arg GetTelegramMessageByReplyToParams) (*TelegramMessage, error)
 	GetTelegramSession(ctx context.Context) (*TelegramSession, error)
 	GetTelegramUpdateState(ctx context.Context, userID int64) (*TelegramUpdateState, error)
 	HardDeleteContact(ctx context.Context, id pgtype.UUID) error
@@ -204,6 +212,7 @@ type Querier interface {
 	// Lists contacts that have a contact_by date set (used for testing mode filtering).
 	// Returns contacts ordered by contact_by (soonest first).
 	ListContactsWithContactBy(ctx context.Context, limit int32) ([]*Contact, error)
+	ListDistinctUnmatchedPeers(ctx context.Context) ([]*ListDistinctUnmatchedPeersRow, error)
 	ListDueSyncStates(ctx context.Context, nextSyncAt pgtype.Timestamptz) ([]*ExternalSyncState, error)
 	ListEnabledSyncStates(ctx context.Context) ([]*ExternalSyncState, error)
 	ListEnrichmentsBySource(ctx context.Context, arg ListEnrichmentsBySourceParams) ([]*ContactEnrichment, error)
@@ -238,12 +247,16 @@ type Querier interface {
 	ListTelegramMessagesByChatUnprocessed(ctx context.Context, telegramChatID int64) ([]*TelegramMessage, error)
 	ListUnmatchedExternalContacts(ctx context.Context, arg ListUnmatchedExternalContactsParams) ([]*ExternalContact, error)
 	ListUnmatchedIdentities(ctx context.Context, arg ListUnmatchedIdentitiesParams) ([]*ExternalIdentity, error)
+	ListUnprocessedContactIDs(ctx context.Context) ([]pgtype.UUID, error)
+	ListUnprocessedTelegramMessagesByContact(ctx context.Context, matchedContactID pgtype.UUID) ([]*TelegramMessage, error)
+	ListUnprocessedTelegramMessagesByContactAndChat(ctx context.Context, arg ListUnprocessedTelegramMessagesByContactAndChatParams) ([]*TelegramMessage, error)
 	// List upcoming calendar events for a specific contact
 	ListUpcomingEventsForContact(ctx context.Context, arg ListUpcomingEventsForContactParams) ([]*CalendarEvent, error)
 	// List upcoming events that have matched CRM contacts
 	ListUpcomingEventsWithContacts(ctx context.Context, arg ListUpcomingEventsWithContactsParams) ([]*CalendarEvent, error)
 	// Mark an event as having updated last_contacted for its contacts
 	MarkLastContactedUpdated(ctx context.Context, id pgtype.UUID) error
+	MarkTelegramMessagesProcessed(ctx context.Context, arg MarkTelegramMessagesProcessedParams) error
 	RemoveContactTag(ctx context.Context, arg RemoveContactTagParams) error
 	// Replace source contact ID with target contact ID in calendar event matched_contact_ids array
 	// Uses array_replace for efficient in-place replacement
@@ -309,6 +322,8 @@ type Querier interface {
 	UpdateIdentityMessageCount(ctx context.Context, arg UpdateIdentityMessageCountParams) (*ExternalIdentity, error)
 	// Promote an outbound interaction to mutual when a reply arrives (in-place update)
 	UpdateInteractionDirection(ctx context.Context, arg UpdateInteractionDirectionParams) (*Interaction, error)
+	// Extend an existing interaction's occurred_at and description (incremental coalescing)
+	UpdateInteractionTimestamp(ctx context.Context, arg UpdateInteractionTimestampParams) (*Interaction, error)
 	// Update the matched contact IDs for an event
 	UpdateMatchedContacts(ctx context.Context, arg UpdateMatchedContactsParams) (*CalendarEvent, error)
 	UpdateNote(ctx context.Context, arg UpdateNoteParams) (*Note, error)
@@ -325,6 +340,7 @@ type Querier interface {
 	UpdateTelegramChatConfigBackfillCursor(ctx context.Context, arg UpdateTelegramChatConfigBackfillCursorParams) error
 	UpdateTelegramChatConfigMemberCount(ctx context.Context, arg UpdateTelegramChatConfigMemberCountParams) error
 	UpdateTelegramChatConfigStatus(ctx context.Context, arg UpdateTelegramChatConfigStatusParams) (*TelegramChatConfig, error)
+	UpdateTelegramMessageContact(ctx context.Context, arg UpdateTelegramMessageContactParams) error
 	UpdateTelegramSessionAuthState(ctx context.Context, authState string) (*TelegramSession, error)
 	UpdateTelegramSessionUserInfo(ctx context.Context, arg UpdateTelegramSessionUserInfoParams) (*TelegramSession, error)
 	// Insert or update a calendar event from Google Calendar

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -180,7 +180,6 @@ type Querier interface {
 	GetTelegramChannelState(ctx context.Context, channelID int64) (*TelegramChannelState, error)
 	GetTelegramChatConfig(ctx context.Context, telegramChatID int64) (*TelegramChatConfig, error)
 	GetTelegramMessage(ctx context.Context, arg GetTelegramMessageParams) (*TelegramMessage, error)
-	GetTelegramMessageByReplyTo(ctx context.Context, arg GetTelegramMessageByReplyToParams) (*TelegramMessage, error)
 	GetTelegramSession(ctx context.Context) (*TelegramSession, error)
 	GetTelegramUpdateState(ctx context.Context, userID int64) (*TelegramUpdateState, error)
 	HardDeleteContact(ctx context.Context, id pgtype.UUID) error

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -40,6 +40,8 @@ type Querier interface {
 	CountSyncLogsByState(ctx context.Context, syncStateID pgtype.UUID) (int64, error)
 	CountTelegramMessagesByChat(ctx context.Context) ([]*CountTelegramMessagesByChatRow, error)
 	CountTelegramMessagesByPeer(ctx context.Context) ([]*CountTelegramMessagesByPeerRow, error)
+	// Count messages for a single peer (for incremental discovery threshold check)
+	CountTelegramMessagesByPeerID(ctx context.Context, peerUserID pgtype.Int8) (*CountTelegramMessagesByPeerIDRow, error)
 	CountUnmatchedExternalContacts(ctx context.Context, source string) (int64, error)
 	CountUnmatchedIdentities(ctx context.Context) (int64, error)
 	CreateContact(ctx context.Context, arg CreateContactParams) (*Contact, error)
@@ -212,6 +214,7 @@ type Querier interface {
 	// Lists contacts that have a contact_by date set (used for testing mode filtering).
 	// Returns contacts ordered by contact_by (soonest first).
 	ListContactsWithContactBy(ctx context.Context, limit int32) ([]*Contact, error)
+	// Prefer rows with username/phone for identity matching
 	ListDistinctUnmatchedPeers(ctx context.Context) ([]*ListDistinctUnmatchedPeersRow, error)
 	ListDueSyncStates(ctx context.Context, nextSyncAt pgtype.Timestamptz) ([]*ExternalSyncState, error)
 	ListEnabledSyncStates(ctx context.Context) ([]*ExternalSyncState, error)

--- a/backend/internal/db/queries/interaction.sql
+++ b/backend/internal/db/queries/interaction.sql
@@ -46,3 +46,40 @@ WHERE contact_id = $1
   AND occurred_at BETWEEN $2 AND $3
 ORDER BY occurred_at DESC
 LIMIT 1;
+
+-- name: FindRecentOutboundTelegramInteraction :one
+-- Find the most recent outbound telegram interaction for a contact in a specific chat
+-- within a time window. source_ref_prefix should include trailing % for LIKE match.
+SELECT * FROM interaction
+WHERE contact_id = sqlc.arg(contact_id)
+  AND source = 'telegram'
+  AND direction = 'outbound'
+  AND source_ref LIKE sqlc.arg(source_ref_prefix)
+  AND occurred_at >= sqlc.arg(window_start)
+  AND occurred_at <= sqlc.arg(window_end)
+  AND deleted_at IS NULL
+ORDER BY occurred_at DESC
+LIMIT 1;
+
+-- name: FindRecentTelegramInteraction :one
+-- Find the most recent telegram interaction for a contact in a specific chat
+-- with a given direction. Used for incremental coalescing.
+SELECT * FROM interaction
+WHERE contact_id = sqlc.arg(contact_id)
+  AND source = 'telegram'
+  AND direction = sqlc.arg(direction)
+  AND source_ref LIKE sqlc.arg(source_ref_prefix)
+  AND occurred_at >= sqlc.arg(window_start)
+  AND occurred_at <= sqlc.arg(window_end)
+  AND deleted_at IS NULL
+ORDER BY occurred_at DESC
+LIMIT 1;
+
+-- name: UpdateInteractionTimestamp :one
+-- Extend an existing interaction's occurred_at and description (incremental coalescing)
+UPDATE interaction
+SET occurred_at = sqlc.arg(occurred_at),
+    description = sqlc.arg(description)
+WHERE id = sqlc.arg(id)
+  AND deleted_at IS NULL
+RETURNING *;

--- a/backend/internal/db/queries/telegram_message.sql
+++ b/backend/internal/db/queries/telegram_message.sql
@@ -121,8 +121,5 @@ FROM telegram_message
 WHERE peer_user_id = @peer_user_id
   AND deleted_at IS NULL;
 
--- name: GetTelegramMessageByReplyTo :one
-SELECT * FROM telegram_message
-WHERE telegram_chat_id = @telegram_chat_id
-  AND telegram_message_id = @telegram_message_id
-  AND deleted_at IS NULL;
+-- GetTelegramMessageByReplyTo removed: identical to GetTelegramMessage.
+-- Use GetMessage repo method for reply resolution.

--- a/backend/internal/db/queries/telegram_message.sql
+++ b/backend/internal/db/queries/telegram_message.sql
@@ -111,6 +111,16 @@ WHERE peer_user_id IS NOT NULL
   AND deleted_at IS NULL
 GROUP BY peer_user_id;
 
+-- name: CountTelegramMessagesByPeerID :one
+-- Count messages for a single peer (for incremental discovery threshold check)
+SELECT COUNT(*) as total_count,
+       COUNT(*) FILTER (WHERE is_outgoing) as outbound_count,
+       COUNT(*) FILTER (WHERE NOT is_outgoing) as inbound_count,
+       MAX(sent_at) as last_message_at
+FROM telegram_message
+WHERE peer_user_id = @peer_user_id
+  AND deleted_at IS NULL;
+
 -- name: GetTelegramMessageByReplyTo :one
 SELECT * FROM telegram_message
 WHERE telegram_chat_id = @telegram_chat_id

--- a/backend/internal/db/queries/telegram_message.sql
+++ b/backend/internal/db/queries/telegram_message.sql
@@ -50,3 +50,64 @@ SELECT telegram_chat_id, COUNT(*) as message_count
 FROM telegram_message
 WHERE deleted_at IS NULL
 GROUP BY telegram_chat_id;
+
+-- name: ListUnprocessedTelegramMessagesByContactAndChat :many
+SELECT * FROM telegram_message
+WHERE matched_contact_id = @matched_contact_id
+  AND telegram_chat_id = @telegram_chat_id
+  AND processed_at IS NULL
+  AND deleted_at IS NULL
+ORDER BY sent_at;
+
+-- name: ListUnprocessedTelegramMessagesByContact :many
+SELECT * FROM telegram_message
+WHERE matched_contact_id = @matched_contact_id
+  AND processed_at IS NULL
+  AND deleted_at IS NULL
+ORDER BY telegram_chat_id, sent_at;
+
+-- name: ListDistinctUnmatchedPeers :many
+SELECT DISTINCT ON (peer_user_id)
+    peer_user_id, peer_username, peer_first_name, peer_last_name, peer_phone
+FROM telegram_message
+WHERE matched_contact_id IS NULL
+  AND peer_user_id IS NOT NULL
+  AND deleted_at IS NULL;
+
+-- name: UpdateTelegramMessageContact :exec
+UPDATE telegram_message
+SET matched_contact_id = @matched_contact_id
+WHERE peer_user_id = @peer_user_id
+  AND matched_contact_id IS NULL
+  AND deleted_at IS NULL;
+
+-- name: MarkTelegramMessagesProcessed :exec
+UPDATE telegram_message
+SET processed_at = NOW(),
+    interaction_id = @interaction_id
+WHERE id = ANY(@message_ids::uuid[])
+  AND deleted_at IS NULL;
+
+-- name: ListUnprocessedContactIDs :many
+SELECT DISTINCT matched_contact_id
+FROM telegram_message
+WHERE matched_contact_id IS NOT NULL
+  AND processed_at IS NULL
+  AND deleted_at IS NULL;
+
+-- name: CountTelegramMessagesByPeer :many
+SELECT peer_user_id,
+       COUNT(*) as total_count,
+       COUNT(*) FILTER (WHERE is_outgoing) as outbound_count,
+       COUNT(*) FILTER (WHERE NOT is_outgoing) as inbound_count,
+       MAX(sent_at) as last_message_at
+FROM telegram_message
+WHERE peer_user_id IS NOT NULL
+  AND deleted_at IS NULL
+GROUP BY peer_user_id;
+
+-- name: GetTelegramMessageByReplyTo :one
+SELECT * FROM telegram_message
+WHERE telegram_chat_id = @telegram_chat_id
+  AND telegram_message_id = @telegram_message_id
+  AND deleted_at IS NULL;

--- a/backend/internal/db/queries/telegram_message.sql
+++ b/backend/internal/db/queries/telegram_message.sql
@@ -67,12 +67,17 @@ WHERE matched_contact_id = @matched_contact_id
 ORDER BY telegram_chat_id, sent_at;
 
 -- name: ListDistinctUnmatchedPeers :many
+-- Prefer rows with username/phone for identity matching
 SELECT DISTINCT ON (peer_user_id)
     peer_user_id, peer_username, peer_first_name, peer_last_name, peer_phone
 FROM telegram_message
 WHERE matched_contact_id IS NULL
   AND peer_user_id IS NOT NULL
-  AND deleted_at IS NULL;
+  AND deleted_at IS NULL
+ORDER BY peer_user_id,
+    CASE WHEN peer_username IS NOT NULL THEN 0 ELSE 1 END,
+    CASE WHEN peer_phone IS NOT NULL THEN 0 ELSE 1 END,
+    sent_at DESC;
 
 -- name: UpdateTelegramMessageContact :exec
 UPDATE telegram_message

--- a/backend/internal/db/telegram_message.sql.go
+++ b/backend/internal/db/telegram_message.sql.go
@@ -43,6 +43,52 @@ func (q *Queries) CountTelegramMessagesByChat(ctx context.Context) ([]*CountTele
 	return items, nil
 }
 
+const CountTelegramMessagesByPeer = `-- name: CountTelegramMessagesByPeer :many
+SELECT peer_user_id,
+       COUNT(*) as total_count,
+       COUNT(*) FILTER (WHERE is_outgoing) as outbound_count,
+       COUNT(*) FILTER (WHERE NOT is_outgoing) as inbound_count,
+       MAX(sent_at) as last_message_at
+FROM telegram_message
+WHERE peer_user_id IS NOT NULL
+  AND deleted_at IS NULL
+GROUP BY peer_user_id
+`
+
+type CountTelegramMessagesByPeerRow struct {
+	PeerUserID    pgtype.Int8 `json:"peer_user_id"`
+	TotalCount    int64       `json:"total_count"`
+	OutboundCount int64       `json:"outbound_count"`
+	InboundCount  int64       `json:"inbound_count"`
+	LastMessageAt interface{} `json:"last_message_at"`
+}
+
+func (q *Queries) CountTelegramMessagesByPeer(ctx context.Context) ([]*CountTelegramMessagesByPeerRow, error) {
+	rows, err := q.db.Query(ctx, CountTelegramMessagesByPeer)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []*CountTelegramMessagesByPeerRow{}
+	for rows.Next() {
+		var i CountTelegramMessagesByPeerRow
+		if err := rows.Scan(
+			&i.PeerUserID,
+			&i.TotalCount,
+			&i.OutboundCount,
+			&i.InboundCount,
+			&i.LastMessageAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const GetTelegramMessage = `-- name: GetTelegramMessage :one
 SELECT id, telegram_message_id, telegram_chat_id, chat_type, chat_title, message_text, message_type, sent_at, edited_at, is_outgoing, reply_to_msg_id, peer_user_id, peer_username, peer_first_name, peer_last_name, peer_phone, matched_contact_id, interaction_id, processed_at, deleted_at, created_at FROM telegram_message
 WHERE telegram_chat_id = $1
@@ -82,6 +128,90 @@ func (q *Queries) GetTelegramMessage(ctx context.Context, arg GetTelegramMessage
 		&i.CreatedAt,
 	)
 	return &i, err
+}
+
+const GetTelegramMessageByReplyTo = `-- name: GetTelegramMessageByReplyTo :one
+SELECT id, telegram_message_id, telegram_chat_id, chat_type, chat_title, message_text, message_type, sent_at, edited_at, is_outgoing, reply_to_msg_id, peer_user_id, peer_username, peer_first_name, peer_last_name, peer_phone, matched_contact_id, interaction_id, processed_at, deleted_at, created_at FROM telegram_message
+WHERE telegram_chat_id = $1
+  AND telegram_message_id = $2
+  AND deleted_at IS NULL
+`
+
+type GetTelegramMessageByReplyToParams struct {
+	TelegramChatID    int64 `json:"telegram_chat_id"`
+	TelegramMessageID int32 `json:"telegram_message_id"`
+}
+
+func (q *Queries) GetTelegramMessageByReplyTo(ctx context.Context, arg GetTelegramMessageByReplyToParams) (*TelegramMessage, error) {
+	row := q.db.QueryRow(ctx, GetTelegramMessageByReplyTo, arg.TelegramChatID, arg.TelegramMessageID)
+	var i TelegramMessage
+	err := row.Scan(
+		&i.ID,
+		&i.TelegramMessageID,
+		&i.TelegramChatID,
+		&i.ChatType,
+		&i.ChatTitle,
+		&i.MessageText,
+		&i.MessageType,
+		&i.SentAt,
+		&i.EditedAt,
+		&i.IsOutgoing,
+		&i.ReplyToMsgID,
+		&i.PeerUserID,
+		&i.PeerUsername,
+		&i.PeerFirstName,
+		&i.PeerLastName,
+		&i.PeerPhone,
+		&i.MatchedContactID,
+		&i.InteractionID,
+		&i.ProcessedAt,
+		&i.DeletedAt,
+		&i.CreatedAt,
+	)
+	return &i, err
+}
+
+const ListDistinctUnmatchedPeers = `-- name: ListDistinctUnmatchedPeers :many
+SELECT DISTINCT ON (peer_user_id)
+    peer_user_id, peer_username, peer_first_name, peer_last_name, peer_phone
+FROM telegram_message
+WHERE matched_contact_id IS NULL
+  AND peer_user_id IS NOT NULL
+  AND deleted_at IS NULL
+`
+
+type ListDistinctUnmatchedPeersRow struct {
+	PeerUserID    pgtype.Int8 `json:"peer_user_id"`
+	PeerUsername  pgtype.Text `json:"peer_username"`
+	PeerFirstName pgtype.Text `json:"peer_first_name"`
+	PeerLastName  pgtype.Text `json:"peer_last_name"`
+	PeerPhone     pgtype.Text `json:"peer_phone"`
+}
+
+func (q *Queries) ListDistinctUnmatchedPeers(ctx context.Context) ([]*ListDistinctUnmatchedPeersRow, error) {
+	rows, err := q.db.Query(ctx, ListDistinctUnmatchedPeers)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []*ListDistinctUnmatchedPeersRow{}
+	for rows.Next() {
+		var i ListDistinctUnmatchedPeersRow
+		if err := rows.Scan(
+			&i.PeerUserID,
+			&i.PeerUsername,
+			&i.PeerFirstName,
+			&i.PeerLastName,
+			&i.PeerPhone,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const ListTelegramMessagesByChatUnprocessed = `-- name: ListTelegramMessagesByChatUnprocessed :many
@@ -134,6 +264,158 @@ func (q *Queries) ListTelegramMessagesByChatUnprocessed(ctx context.Context, tel
 	return items, nil
 }
 
+const ListUnprocessedContactIDs = `-- name: ListUnprocessedContactIDs :many
+SELECT DISTINCT matched_contact_id
+FROM telegram_message
+WHERE matched_contact_id IS NOT NULL
+  AND processed_at IS NULL
+  AND deleted_at IS NULL
+`
+
+func (q *Queries) ListUnprocessedContactIDs(ctx context.Context) ([]pgtype.UUID, error) {
+	rows, err := q.db.Query(ctx, ListUnprocessedContactIDs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []pgtype.UUID{}
+	for rows.Next() {
+		var matched_contact_id pgtype.UUID
+		if err := rows.Scan(&matched_contact_id); err != nil {
+			return nil, err
+		}
+		items = append(items, matched_contact_id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const ListUnprocessedTelegramMessagesByContact = `-- name: ListUnprocessedTelegramMessagesByContact :many
+SELECT id, telegram_message_id, telegram_chat_id, chat_type, chat_title, message_text, message_type, sent_at, edited_at, is_outgoing, reply_to_msg_id, peer_user_id, peer_username, peer_first_name, peer_last_name, peer_phone, matched_contact_id, interaction_id, processed_at, deleted_at, created_at FROM telegram_message
+WHERE matched_contact_id = $1
+  AND processed_at IS NULL
+  AND deleted_at IS NULL
+ORDER BY telegram_chat_id, sent_at
+`
+
+func (q *Queries) ListUnprocessedTelegramMessagesByContact(ctx context.Context, matchedContactID pgtype.UUID) ([]*TelegramMessage, error) {
+	rows, err := q.db.Query(ctx, ListUnprocessedTelegramMessagesByContact, matchedContactID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []*TelegramMessage{}
+	for rows.Next() {
+		var i TelegramMessage
+		if err := rows.Scan(
+			&i.ID,
+			&i.TelegramMessageID,
+			&i.TelegramChatID,
+			&i.ChatType,
+			&i.ChatTitle,
+			&i.MessageText,
+			&i.MessageType,
+			&i.SentAt,
+			&i.EditedAt,
+			&i.IsOutgoing,
+			&i.ReplyToMsgID,
+			&i.PeerUserID,
+			&i.PeerUsername,
+			&i.PeerFirstName,
+			&i.PeerLastName,
+			&i.PeerPhone,
+			&i.MatchedContactID,
+			&i.InteractionID,
+			&i.ProcessedAt,
+			&i.DeletedAt,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const ListUnprocessedTelegramMessagesByContactAndChat = `-- name: ListUnprocessedTelegramMessagesByContactAndChat :many
+SELECT id, telegram_message_id, telegram_chat_id, chat_type, chat_title, message_text, message_type, sent_at, edited_at, is_outgoing, reply_to_msg_id, peer_user_id, peer_username, peer_first_name, peer_last_name, peer_phone, matched_contact_id, interaction_id, processed_at, deleted_at, created_at FROM telegram_message
+WHERE matched_contact_id = $1
+  AND telegram_chat_id = $2
+  AND processed_at IS NULL
+  AND deleted_at IS NULL
+ORDER BY sent_at
+`
+
+type ListUnprocessedTelegramMessagesByContactAndChatParams struct {
+	MatchedContactID pgtype.UUID `json:"matched_contact_id"`
+	TelegramChatID   int64       `json:"telegram_chat_id"`
+}
+
+func (q *Queries) ListUnprocessedTelegramMessagesByContactAndChat(ctx context.Context, arg ListUnprocessedTelegramMessagesByContactAndChatParams) ([]*TelegramMessage, error) {
+	rows, err := q.db.Query(ctx, ListUnprocessedTelegramMessagesByContactAndChat, arg.MatchedContactID, arg.TelegramChatID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []*TelegramMessage{}
+	for rows.Next() {
+		var i TelegramMessage
+		if err := rows.Scan(
+			&i.ID,
+			&i.TelegramMessageID,
+			&i.TelegramChatID,
+			&i.ChatType,
+			&i.ChatTitle,
+			&i.MessageText,
+			&i.MessageType,
+			&i.SentAt,
+			&i.EditedAt,
+			&i.IsOutgoing,
+			&i.ReplyToMsgID,
+			&i.PeerUserID,
+			&i.PeerUsername,
+			&i.PeerFirstName,
+			&i.PeerLastName,
+			&i.PeerPhone,
+			&i.MatchedContactID,
+			&i.InteractionID,
+			&i.ProcessedAt,
+			&i.DeletedAt,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const MarkTelegramMessagesProcessed = `-- name: MarkTelegramMessagesProcessed :exec
+UPDATE telegram_message
+SET processed_at = NOW(),
+    interaction_id = $1
+WHERE id = ANY($2::uuid[])
+  AND deleted_at IS NULL
+`
+
+type MarkTelegramMessagesProcessedParams struct {
+	InteractionID pgtype.UUID   `json:"interaction_id"`
+	MessageIds    []pgtype.UUID `json:"message_ids"`
+}
+
+func (q *Queries) MarkTelegramMessagesProcessed(ctx context.Context, arg MarkTelegramMessagesProcessedParams) error {
+	_, err := q.db.Exec(ctx, MarkTelegramMessagesProcessed, arg.InteractionID, arg.MessageIds)
+	return err
+}
+
 const SoftDeleteTelegramChannelMessages = `-- name: SoftDeleteTelegramChannelMessages :exec
 UPDATE telegram_message
 SET deleted_at = NOW()
@@ -161,6 +443,24 @@ WHERE telegram_message_id = ANY($1::int[])
 
 func (q *Queries) SoftDeleteTelegramMessages(ctx context.Context, messageIds []int32) error {
 	_, err := q.db.Exec(ctx, SoftDeleteTelegramMessages, messageIds)
+	return err
+}
+
+const UpdateTelegramMessageContact = `-- name: UpdateTelegramMessageContact :exec
+UPDATE telegram_message
+SET matched_contact_id = $1
+WHERE peer_user_id = $2
+  AND matched_contact_id IS NULL
+  AND deleted_at IS NULL
+`
+
+type UpdateTelegramMessageContactParams struct {
+	MatchedContactID pgtype.UUID `json:"matched_contact_id"`
+	PeerUserID       pgtype.Int8 `json:"peer_user_id"`
+}
+
+func (q *Queries) UpdateTelegramMessageContact(ctx context.Context, arg UpdateTelegramMessageContactParams) error {
+	_, err := q.db.Exec(ctx, UpdateTelegramMessageContact, arg.MatchedContactID, arg.PeerUserID)
 	return err
 }
 

--- a/backend/internal/db/telegram_message.sql.go
+++ b/backend/internal/db/telegram_message.sql.go
@@ -160,47 +160,6 @@ func (q *Queries) GetTelegramMessage(ctx context.Context, arg GetTelegramMessage
 	return &i, err
 }
 
-const GetTelegramMessageByReplyTo = `-- name: GetTelegramMessageByReplyTo :one
-SELECT id, telegram_message_id, telegram_chat_id, chat_type, chat_title, message_text, message_type, sent_at, edited_at, is_outgoing, reply_to_msg_id, peer_user_id, peer_username, peer_first_name, peer_last_name, peer_phone, matched_contact_id, interaction_id, processed_at, deleted_at, created_at FROM telegram_message
-WHERE telegram_chat_id = $1
-  AND telegram_message_id = $2
-  AND deleted_at IS NULL
-`
-
-type GetTelegramMessageByReplyToParams struct {
-	TelegramChatID    int64 `json:"telegram_chat_id"`
-	TelegramMessageID int32 `json:"telegram_message_id"`
-}
-
-func (q *Queries) GetTelegramMessageByReplyTo(ctx context.Context, arg GetTelegramMessageByReplyToParams) (*TelegramMessage, error) {
-	row := q.db.QueryRow(ctx, GetTelegramMessageByReplyTo, arg.TelegramChatID, arg.TelegramMessageID)
-	var i TelegramMessage
-	err := row.Scan(
-		&i.ID,
-		&i.TelegramMessageID,
-		&i.TelegramChatID,
-		&i.ChatType,
-		&i.ChatTitle,
-		&i.MessageText,
-		&i.MessageType,
-		&i.SentAt,
-		&i.EditedAt,
-		&i.IsOutgoing,
-		&i.ReplyToMsgID,
-		&i.PeerUserID,
-		&i.PeerUsername,
-		&i.PeerFirstName,
-		&i.PeerLastName,
-		&i.PeerPhone,
-		&i.MatchedContactID,
-		&i.InteractionID,
-		&i.ProcessedAt,
-		&i.DeletedAt,
-		&i.CreatedAt,
-	)
-	return &i, err
-}
-
 const ListDistinctUnmatchedPeers = `-- name: ListDistinctUnmatchedPeers :many
 SELECT DISTINCT ON (peer_user_id)
     peer_user_id, peer_username, peer_first_name, peer_last_name, peer_phone

--- a/backend/internal/db/telegram_message.sql.go
+++ b/backend/internal/db/telegram_message.sql.go
@@ -178,6 +178,10 @@ FROM telegram_message
 WHERE matched_contact_id IS NULL
   AND peer_user_id IS NOT NULL
   AND deleted_at IS NULL
+ORDER BY peer_user_id,
+    CASE WHEN peer_username IS NOT NULL THEN 0 ELSE 1 END,
+    CASE WHEN peer_phone IS NOT NULL THEN 0 ELSE 1 END,
+    sent_at DESC
 `
 
 type ListDistinctUnmatchedPeersRow struct {
@@ -188,6 +192,7 @@ type ListDistinctUnmatchedPeersRow struct {
 	PeerPhone     pgtype.Text `json:"peer_phone"`
 }
 
+// Prefer rows with username/phone for identity matching
 func (q *Queries) ListDistinctUnmatchedPeers(ctx context.Context) ([]*ListDistinctUnmatchedPeersRow, error) {
 	rows, err := q.db.Query(ctx, ListDistinctUnmatchedPeers)
 	if err != nil {

--- a/backend/internal/db/telegram_message.sql.go
+++ b/backend/internal/db/telegram_message.sql.go
@@ -89,6 +89,36 @@ func (q *Queries) CountTelegramMessagesByPeer(ctx context.Context) ([]*CountTele
 	return items, nil
 }
 
+const CountTelegramMessagesByPeerID = `-- name: CountTelegramMessagesByPeerID :one
+SELECT COUNT(*) as total_count,
+       COUNT(*) FILTER (WHERE is_outgoing) as outbound_count,
+       COUNT(*) FILTER (WHERE NOT is_outgoing) as inbound_count,
+       MAX(sent_at) as last_message_at
+FROM telegram_message
+WHERE peer_user_id = $1
+  AND deleted_at IS NULL
+`
+
+type CountTelegramMessagesByPeerIDRow struct {
+	TotalCount    int64       `json:"total_count"`
+	OutboundCount int64       `json:"outbound_count"`
+	InboundCount  int64       `json:"inbound_count"`
+	LastMessageAt interface{} `json:"last_message_at"`
+}
+
+// Count messages for a single peer (for incremental discovery threshold check)
+func (q *Queries) CountTelegramMessagesByPeerID(ctx context.Context, peerUserID pgtype.Int8) (*CountTelegramMessagesByPeerIDRow, error) {
+	row := q.db.QueryRow(ctx, CountTelegramMessagesByPeerID, peerUserID)
+	var i CountTelegramMessagesByPeerIDRow
+	err := row.Scan(
+		&i.TotalCount,
+		&i.OutboundCount,
+		&i.InboundCount,
+		&i.LastMessageAt,
+	)
+	return &i, err
+}
+
 const GetTelegramMessage = `-- name: GetTelegramMessage :one
 SELECT id, telegram_message_id, telegram_chat_id, chat_type, chat_title, message_text, message_type, sent_at, edited_at, is_outgoing, reply_to_msg_id, peer_user_id, peer_username, peer_first_name, peer_last_name, peer_phone, matched_contact_id, interaction_id, processed_at, deleted_at, created_at FROM telegram_message
 WHERE telegram_chat_id = $1

--- a/backend/internal/repository/interaction.go
+++ b/backend/internal/repository/interaction.go
@@ -198,6 +198,62 @@ func (r *InteractionRepository) FindInWindow(ctx context.Context, contactID uuid
 	return &interaction, nil
 }
 
+// FindRecentOutboundTelegramInteraction finds the most recent outbound telegram interaction
+// for a contact in a specific chat within a time window.
+func (r *InteractionRepository) FindRecentOutboundTelegramInteraction(ctx context.Context, contactID uuid.UUID, sourceRefPrefix string, windowStart, windowEnd time.Time) (*Interaction, error) {
+	dbInteraction, err := r.queries.FindRecentOutboundTelegramInteraction(ctx, db.FindRecentOutboundTelegramInteractionParams{
+		ContactID:       uuidToPgUUID(contactID),
+		SourceRefPrefix: pgtype.Text{String: sourceRefPrefix, Valid: true},
+		WindowStart:     pgtype.Timestamptz{Time: windowStart, Valid: true},
+		WindowEnd:       pgtype.Timestamptz{Time: windowEnd, Valid: true},
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, db.ErrNotFound
+		}
+		return nil, err
+	}
+	interaction := convertDbInteraction(dbInteraction)
+	return &interaction, nil
+}
+
+// FindRecentTelegramInteraction finds the most recent telegram interaction for a contact
+// in a specific chat with a given direction. Used for incremental coalescing.
+func (r *InteractionRepository) FindRecentTelegramInteraction(ctx context.Context, contactID uuid.UUID, direction, sourceRefPrefix string, windowStart, windowEnd time.Time) (*Interaction, error) {
+	dbInteraction, err := r.queries.FindRecentTelegramInteraction(ctx, db.FindRecentTelegramInteractionParams{
+		ContactID:       uuidToPgUUID(contactID),
+		Direction:       direction,
+		SourceRefPrefix: pgtype.Text{String: sourceRefPrefix, Valid: true},
+		WindowStart:     pgtype.Timestamptz{Time: windowStart, Valid: true},
+		WindowEnd:       pgtype.Timestamptz{Time: windowEnd, Valid: true},
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, db.ErrNotFound
+		}
+		return nil, err
+	}
+	interaction := convertDbInteraction(dbInteraction)
+	return &interaction, nil
+}
+
+// UpdateInteractionTimestamp extends an existing interaction's occurred_at and description.
+func (r *InteractionRepository) UpdateInteractionTimestamp(ctx context.Context, id uuid.UUID, occurredAt time.Time, description *string) (*Interaction, error) {
+	dbInteraction, err := r.queries.UpdateInteractionTimestamp(ctx, db.UpdateInteractionTimestampParams{
+		ID:          uuidToPgUUID(id),
+		OccurredAt:  pgtype.Timestamptz{Time: occurredAt, Valid: true},
+		Description: stringToPgText(description),
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, db.ErrNotFound
+		}
+		return nil, err
+	}
+	interaction := convertDbInteraction(dbInteraction)
+	return &interaction, nil
+}
+
 // UpdateInteractionDirection updates the direction and occurred_at of an interaction (for reply bridging)
 func (r *InteractionRepository) UpdateInteractionDirection(ctx context.Context, id uuid.UUID, direction string, occurredAt time.Time) (*Interaction, error) {
 	dbInteraction, err := r.queries.UpdateInteractionDirection(ctx, db.UpdateInteractionDirectionParams{

--- a/backend/internal/repository/telegram_message.go
+++ b/backend/internal/repository/telegram_message.go
@@ -355,4 +355,22 @@ func (r *TelegramMessageRepository) GetMessageByReplyTo(ctx context.Context, cha
 	return &msg, nil
 }
 
+// CountMessagesByPeerID returns message counts for a single peer.
+func (r *TelegramMessageRepository) CountMessagesByPeerID(ctx context.Context, peerUserID int64) (*PeerMessageCount, error) {
+	row, err := r.queries.CountTelegramMessagesByPeerID(ctx, int64ToPgInt8(&peerUserID))
+	if err != nil {
+		return nil, err
+	}
+	count := &PeerMessageCount{
+		PeerUserID:    peerUserID,
+		TotalCount:    row.TotalCount,
+		OutboundCount: row.OutboundCount,
+		InboundCount:  row.InboundCount,
+	}
+	if t, ok := row.LastMessageAt.(time.Time); ok {
+		count.LastMessageAt = t
+	}
+	return count, nil
+}
+
 // int32ToPgInt4 already defined in telegram_chat_config.go

--- a/backend/internal/repository/telegram_message.go
+++ b/backend/internal/repository/telegram_message.go
@@ -341,22 +341,6 @@ func (r *TelegramMessageRepository) CountMessagesByPeer(ctx context.Context) ([]
 	return counts, nil
 }
 
-// GetMessageByReplyTo retrieves a message by chat ID and message ID (for reply resolution).
-func (r *TelegramMessageRepository) GetMessageByReplyTo(ctx context.Context, chatID int64, messageID int32) (*TelegramMessage, error) {
-	dbMsg, err := r.queries.GetTelegramMessageByReplyTo(ctx, db.GetTelegramMessageByReplyToParams{
-		TelegramChatID:    chatID,
-		TelegramMessageID: messageID,
-	})
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, db.ErrNotFound
-		}
-		return nil, err
-	}
-	msg := convertDbTelegramMessage(dbMsg)
-	return &msg, nil
-}
-
 // CountMessagesByPeerID returns message counts for a single peer.
 func (r *TelegramMessageRepository) CountMessagesByPeerID(ctx context.Context, peerUserID int64) (*PeerMessageCount, error) {
 	row, err := r.queries.CountTelegramMessagesByPeerID(ctx, int64ToPgInt8(&peerUserID))

--- a/backend/internal/repository/telegram_message.go
+++ b/backend/internal/repository/telegram_message.go
@@ -332,7 +332,9 @@ func (r *TelegramMessageRepository) CountMessagesByPeer(ctx context.Context) ([]
 			OutboundCount: row.OutboundCount,
 			InboundCount:  row.InboundCount,
 		}
-		if t, ok := row.LastMessageAt.(time.Time); ok {
+		if ts, ok := row.LastMessageAt.(pgtype.Timestamptz); ok && ts.Valid {
+			counts[i].LastMessageAt = ts.Time
+		} else if t, ok := row.LastMessageAt.(time.Time); ok {
 			counts[i].LastMessageAt = t
 		}
 	}
@@ -367,7 +369,9 @@ func (r *TelegramMessageRepository) CountMessagesByPeerID(ctx context.Context, p
 		OutboundCount: row.OutboundCount,
 		InboundCount:  row.InboundCount,
 	}
-	if t, ok := row.LastMessageAt.(time.Time); ok {
+	if ts, ok := row.LastMessageAt.(pgtype.Timestamptz); ok && ts.Valid {
+		count.LastMessageAt = ts.Time
+	} else if t, ok := row.LastMessageAt.(time.Time); ok {
 		count.LastMessageAt = t
 	}
 	return count, nil

--- a/backend/internal/repository/telegram_message.go
+++ b/backend/internal/repository/telegram_message.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 // TelegramMessage represents a stored Telegram message.
@@ -205,6 +206,153 @@ func (r *TelegramMessageRepository) CountByChat(ctx context.Context) (map[int64]
 		counts[row.TelegramChatID] = row.MessageCount
 	}
 	return counts, nil
+}
+
+// UnmatchedPeer holds distinct peer info for identity matching.
+type UnmatchedPeer struct {
+	PeerUserID    int64
+	PeerUsername  *string
+	PeerFirstName *string
+	PeerLastName  *string
+	PeerPhone     *string
+}
+
+// PeerMessageCount holds message counts for a peer.
+type PeerMessageCount struct {
+	PeerUserID    int64
+	TotalCount    int64
+	OutboundCount int64
+	InboundCount  int64
+	LastMessageAt time.Time
+}
+
+// ListUnprocessedByContactAndChat returns unprocessed messages for a contact+chat.
+func (r *TelegramMessageRepository) ListUnprocessedByContactAndChat(ctx context.Context, contactID uuid.UUID, chatID int64) ([]TelegramMessage, error) {
+	dbMsgs, err := r.queries.ListUnprocessedTelegramMessagesByContactAndChat(ctx, db.ListUnprocessedTelegramMessagesByContactAndChatParams{
+		MatchedContactID: uuidToPgUUID(contactID),
+		TelegramChatID:   chatID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	msgs := make([]TelegramMessage, len(dbMsgs))
+	for i, m := range dbMsgs {
+		msgs[i] = convertDbTelegramMessage(m)
+	}
+	return msgs, nil
+}
+
+// ListUnprocessedByContact returns all unprocessed messages for a contact.
+func (r *TelegramMessageRepository) ListUnprocessedByContact(ctx context.Context, contactID uuid.UUID) ([]TelegramMessage, error) {
+	dbMsgs, err := r.queries.ListUnprocessedTelegramMessagesByContact(ctx, uuidToPgUUID(contactID))
+	if err != nil {
+		return nil, err
+	}
+	msgs := make([]TelegramMessage, len(dbMsgs))
+	for i, m := range dbMsgs {
+		msgs[i] = convertDbTelegramMessage(m)
+	}
+	return msgs, nil
+}
+
+// ListDistinctUnmatchedPeers returns distinct peer info for unmatched messages.
+func (r *TelegramMessageRepository) ListDistinctUnmatchedPeers(ctx context.Context) ([]UnmatchedPeer, error) {
+	rows, err := r.queries.ListDistinctUnmatchedPeers(ctx)
+	if err != nil {
+		return nil, err
+	}
+	peers := make([]UnmatchedPeer, len(rows))
+	for i, row := range rows {
+		p := UnmatchedPeer{
+			PeerUserID: row.PeerUserID.Int64,
+		}
+		if row.PeerUsername.Valid {
+			p.PeerUsername = &row.PeerUsername.String
+		}
+		if row.PeerFirstName.Valid {
+			p.PeerFirstName = &row.PeerFirstName.String
+		}
+		if row.PeerLastName.Valid {
+			p.PeerLastName = &row.PeerLastName.String
+		}
+		if row.PeerPhone.Valid {
+			p.PeerPhone = &row.PeerPhone.String
+		}
+		peers[i] = p
+	}
+	return peers, nil
+}
+
+// UpdateMessageContact sets matched_contact_id on all messages for a peer.
+func (r *TelegramMessageRepository) UpdateMessageContact(ctx context.Context, peerUserID int64, contactID uuid.UUID) error {
+	return r.queries.UpdateTelegramMessageContact(ctx, db.UpdateTelegramMessageContactParams{
+		MatchedContactID: uuidToPgUUID(contactID),
+		PeerUserID:       int64ToPgInt8(&peerUserID),
+	})
+}
+
+// MarkMessagesProcessed sets processed_at and interaction_id on messages.
+func (r *TelegramMessageRepository) MarkMessagesProcessed(ctx context.Context, messageIDs []uuid.UUID, interactionID uuid.UUID) error {
+	pgIDs := make([]pgtype.UUID, len(messageIDs))
+	for i, id := range messageIDs {
+		pgIDs[i] = uuidToPgUUID(id)
+	}
+	return r.queries.MarkTelegramMessagesProcessed(ctx, db.MarkTelegramMessagesProcessedParams{
+		InteractionID: uuidToPgUUID(interactionID),
+		MessageIds:    pgIDs,
+	})
+}
+
+// ListUnprocessedContactIDs returns distinct contact IDs with unprocessed messages.
+func (r *TelegramMessageRepository) ListUnprocessedContactIDs(ctx context.Context) ([]uuid.UUID, error) {
+	pgIDs, err := r.queries.ListUnprocessedContactIDs(ctx)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]uuid.UUID, 0, len(pgIDs))
+	for _, pgID := range pgIDs {
+		if pgID.Valid {
+			ids = append(ids, uuid.UUID(pgID.Bytes))
+		}
+	}
+	return ids, nil
+}
+
+// CountMessagesByPeer returns message counts grouped by peer.
+func (r *TelegramMessageRepository) CountMessagesByPeer(ctx context.Context) ([]PeerMessageCount, error) {
+	rows, err := r.queries.CountTelegramMessagesByPeer(ctx)
+	if err != nil {
+		return nil, err
+	}
+	counts := make([]PeerMessageCount, len(rows))
+	for i, row := range rows {
+		counts[i] = PeerMessageCount{
+			PeerUserID:    row.PeerUserID.Int64,
+			TotalCount:    row.TotalCount,
+			OutboundCount: row.OutboundCount,
+			InboundCount:  row.InboundCount,
+		}
+		if t, ok := row.LastMessageAt.(time.Time); ok {
+			counts[i].LastMessageAt = t
+		}
+	}
+	return counts, nil
+}
+
+// GetMessageByReplyTo retrieves a message by chat ID and message ID (for reply resolution).
+func (r *TelegramMessageRepository) GetMessageByReplyTo(ctx context.Context, chatID int64, messageID int32) (*TelegramMessage, error) {
+	dbMsg, err := r.queries.GetTelegramMessageByReplyTo(ctx, db.GetTelegramMessageByReplyToParams{
+		TelegramChatID:    chatID,
+		TelegramMessageID: messageID,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, db.ErrNotFound
+		}
+		return nil, err
+	}
+	msg := convertDbTelegramMessage(dbMsg)
+	return &msg, nil
 }
 
 // int32ToPgInt4 already defined in telegram_chat_config.go

--- a/backend/internal/service/contact.go
+++ b/backend/internal/service/contact.go
@@ -364,77 +364,106 @@ func (s *ContactService) RecordInteraction(ctx context.Context, req repository.R
 		return nil, fmt.Errorf("create interaction: %w", err)
 	}
 
-	// 5. Direction-conditional contact field updates
-	isManual := req.Source == repository.InteractionSourceManual
+	// 5+6. Direction-conditional contact field updates + follow-up management
+	s.applyInteractionEffects(ctx, contact, req.Direction, req.OccurredAt, req.Source == repository.InteractionSourceManual)
 
-	switch req.Direction {
+	return interaction, nil
+}
+
+// PromoteInteractionToMutual updates an outbound interaction to mutual (reply bridging)
+// and applies the resulting contact field updates and follow-up completion.
+func (s *ContactService) PromoteInteractionToMutual(ctx context.Context, interactionID, contactID uuid.UUID, replyAt time.Time) error {
+	_, err := s.interactionRepo.UpdateInteractionDirection(ctx, interactionID, repository.InteractionDirectionMutual, replyAt)
+	if err != nil {
+		return fmt.Errorf("update interaction direction: %w", err)
+	}
+	contact, err := s.contactRepo.GetContact(ctx, contactID)
+	if err != nil {
+		return fmt.Errorf("get contact for promotion: %w", err)
+	}
+	s.applyInteractionEffects(ctx, contact, repository.InteractionDirectionMutual, replyAt, false)
+	return nil
+}
+
+// ExtendInteraction extends an existing interaction's timestamp/description (incremental
+// coalescing) and re-applies contact field effects for the updated timestamp.
+func (s *ContactService) ExtendInteraction(ctx context.Context, interactionID, contactID uuid.UUID, direction string, occurredAt time.Time, description *string) error {
+	_, err := s.interactionRepo.UpdateInteractionTimestamp(ctx, interactionID, occurredAt, description)
+	if err != nil {
+		return fmt.Errorf("update interaction timestamp: %w", err)
+	}
+	contact, err := s.contactRepo.GetContact(ctx, contactID)
+	if err != nil {
+		return fmt.Errorf("get contact for extension: %w", err)
+	}
+	s.applyInteractionEffects(ctx, contact, direction, occurredAt, false)
+	return nil
+}
+
+// applyInteractionEffects handles direction-conditional contact field updates
+// and follow-up task management. Shared by RecordInteraction, PromoteInteractionToMutual,
+// and ExtendInteraction.
+func (s *ContactService) applyInteractionEffects(ctx context.Context, contact *repository.Contact, direction string, occurredAt time.Time, isManual bool) {
+	contactID := contact.ID
+
+	switch direction {
 	case repository.InteractionDirectionOutbound:
-		// Outbound: only update last_outreach_at (does NOT reset cadence clock)
-		if err := s.contactRepo.UpdateContactOutreachAt(ctx, req.ContactID, req.OccurredAt, isManual); err != nil {
+		if err := s.contactRepo.UpdateContactOutreachAt(ctx, contactID, occurredAt, isManual); err != nil {
 			logger.Warn().Err(err).
-				Str("contactId", req.ContactID.String()).
+				Str("contactId", contactID.String()).
 				Msg("failed to update last_outreach_at from outbound interaction")
 		}
 
 	case repository.InteractionDirectionInbound:
-		// Inbound: update last_contacted, last_interaction_at, last_response_at, contact_by
-		// Only recalculate contact_by if this event would actually advance last_contacted
-		// (forward-only guard prevents late-arriving events from regressing the due date)
 		var contactBy *time.Time
-		shouldRecalcContactBy := isManual || contact.LastContacted == nil || req.OccurredAt.After(*contact.LastContacted)
+		shouldRecalcContactBy := isManual || contact.LastContacted == nil || occurredAt.After(*contact.LastContacted)
 		if shouldRecalcContactBy && contact.Cadence != nil && *contact.Cadence != "" {
 			if cadenceType, err := cadence.ParseCadence(*contact.Cadence); err == nil {
-				contactByTime := cadence.CalculateContactBy(req.OccurredAt, cadenceType)
+				contactByTime := cadence.CalculateContactBy(occurredAt, cadenceType)
 				contactBy = &contactByTime
 			}
 		}
-		if err := s.contactRepo.UpdateContactResponseFields(ctx, req.ContactID, req.OccurredAt, contactBy, isManual); err != nil {
+		if err := s.contactRepo.UpdateContactResponseFields(ctx, contactID, occurredAt, contactBy, isManual); err != nil {
 			logger.Warn().Err(err).
-				Str("contactId", req.ContactID.String()).
+				Str("contactId", contactID.String()).
 				Msg("failed to update contact fields from inbound interaction")
 		}
 
 	default: // mutual
-		// Mutual: update all fields + contact_by
-		// Same forward-only guard for contact_by
 		var contactBy *time.Time
-		shouldRecalcContactBy := isManual || contact.LastContacted == nil || req.OccurredAt.After(*contact.LastContacted)
+		shouldRecalcContactBy := isManual || contact.LastContacted == nil || occurredAt.After(*contact.LastContacted)
 		if shouldRecalcContactBy && contact.Cadence != nil && *contact.Cadence != "" {
 			if cadenceType, err := cadence.ParseCadence(*contact.Cadence); err == nil {
-				contactByTime := cadence.CalculateContactBy(req.OccurredAt, cadenceType)
+				contactByTime := cadence.CalculateContactBy(occurredAt, cadenceType)
 				contactBy = &contactByTime
 			}
 		}
-		if err := s.contactRepo.UpdateContactMutualFields(ctx, req.ContactID, req.OccurredAt, contactBy, isManual); err != nil {
+		if err := s.contactRepo.UpdateContactMutualFields(ctx, contactID, occurredAt, contactBy, isManual); err != nil {
 			logger.Warn().Err(err).
-				Str("contactId", req.ContactID.String()).
+				Str("contactId", contactID.String()).
 				Msg("failed to update contact fields from mutual interaction")
 		}
 	}
 
-	// 6. Follow-up management (best-effort, non-blocking)
+	// Follow-up management (best-effort, non-blocking)
 	if s.followUpMgr != nil {
-		switch req.Direction {
+		switch direction {
 		case repository.InteractionDirectionOutbound:
-			if err := s.followUpMgr.CreateOrRefreshFollowUp(ctx, *contact, req.OccurredAt); err != nil {
+			if err := s.followUpMgr.CreateOrRefreshFollowUp(ctx, *contact, occurredAt); err != nil {
 				logger.Warn().Err(err).
-					Str("contactId", req.ContactID.String()).
-					Str("direction", req.Direction).
-					Str("source", req.Source).
+					Str("contactId", contactID.String()).
+					Str("direction", direction).
 					Msg("failed to create/refresh follow-up task")
 			}
 		case repository.InteractionDirectionInbound, repository.InteractionDirectionMutual:
-			if err := s.followUpMgr.CompleteFollowUp(ctx, req.ContactID); err != nil {
+			if err := s.followUpMgr.CompleteFollowUp(ctx, contactID); err != nil {
 				logger.Warn().Err(err).
-					Str("contactId", req.ContactID.String()).
-					Str("direction", req.Direction).
-					Str("source", req.Source).
+					Str("contactId", contactID.String()).
+					Str("direction", direction).
 					Msg("failed to complete follow-up task")
 			}
 		}
 	}
-
-	return interaction, nil
 }
 
 // ListOverdueContacts retrieves contacts whose contact_by date is in the past.

--- a/backend/internal/telegram/aggregation.go
+++ b/backend/internal/telegram/aggregation.go
@@ -126,6 +126,13 @@ func (e *AggregationEngine) AggregateAll(ctx context.Context) error {
 	return nil
 }
 
+// AggregateForContactBatch processes all unprocessed messages for a single contact in batch mode.
+// Used after import/link to aggregate newly-matched messages without scanning all contacts.
+func (e *AggregationEngine) AggregateForContactBatch(ctx context.Context, contactID uuid.UUID) error {
+	_, err := e.aggregateBatch(ctx, contactID)
+	return err
+}
+
 // aggregateBatch processes all unprocessed messages for a contact in batch mode.
 func (e *AggregationEngine) aggregateBatch(ctx context.Context, contactID uuid.UUID) (int, error) {
 	msgs, err := e.messageRepo.ListUnprocessedByContact(ctx, contactID)
@@ -145,7 +152,7 @@ func (e *AggregationEngine) aggregateBatch(ctx context.Context, contactID uuid.U
 		bursts := e.groupIntoBursts(chatMessages, chatID)
 
 		// Resolve bursts into sessions (merge outbound+inbound into mutual where applicable)
-		sessions := e.resolveSessions(ctx, bursts)
+		sessions := e.resolveSessions(bursts)
 
 		// Create interactions for each session
 		for _, sess := range sessions {
@@ -174,7 +181,7 @@ func (e *AggregationEngine) AggregateForContact(ctx context.Context, contactID u
 	bursts := e.groupIntoBursts(msgs, chatID)
 
 	// Resolve into sessions (same logic as batch)
-	sessions := e.resolveSessions(ctx, bursts)
+	sessions := e.resolveSessions(bursts)
 
 	sourceRefPrefix := fmt.Sprintf("tg:%d:%%", chatID)
 	now := msgs[len(msgs)-1].SentAt // use latest message time as upper bound
@@ -328,7 +335,7 @@ func (e *AggregationEngine) groupIntoBursts(msgs []repository.TelegramMessage, c
 }
 
 // resolveSessions merges bursts into sessions, applying reply bridging for batch mode.
-func (e *AggregationEngine) resolveSessions(ctx context.Context, bursts []burst) []msgSession {
+func (e *AggregationEngine) resolveSessions(bursts []burst) []msgSession {
 	if len(bursts) == 0 {
 		return nil
 	}

--- a/backend/internal/telegram/aggregation.go
+++ b/backend/internal/telegram/aggregation.go
@@ -1,0 +1,404 @@
+package telegram
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+)
+
+// interactionRecorder creates new interactions. Satisfied by *service.ContactService.
+type interactionRecorder interface {
+	RecordInteraction(ctx context.Context, req repository.RecordInteractionRequest) (*repository.Interaction, error)
+}
+
+// interactionPromoter promotes outbound → mutual. Satisfied by *service.ContactService.
+type interactionPromoter interface {
+	PromoteInteractionToMutual(ctx context.Context, interactionID, contactID uuid.UUID, replyAt time.Time) error
+}
+
+// interactionExtender extends an existing interaction. Satisfied by *service.ContactService.
+type interactionExtender interface {
+	ExtendInteraction(ctx context.Context, interactionID, contactID uuid.UUID, direction string, occurredAt time.Time, description *string) error
+}
+
+// AggregationEngine processes raw telegram_message rows into interaction records.
+type AggregationEngine struct {
+	burstWindowHours int
+	replyBridgeHours int
+	messageRepo      *repository.TelegramMessageRepository
+	interactionRepo  *repository.InteractionRepository
+	recorder         interactionRecorder
+	promoter         interactionPromoter
+	extender         interactionExtender
+}
+
+// NewAggregationEngine creates a new aggregation engine.
+func NewAggregationEngine(
+	burstWindowHours, replyBridgeHours int,
+	messageRepo *repository.TelegramMessageRepository,
+	interactionRepo *repository.InteractionRepository,
+	recorder interactionRecorder,
+	promoter interactionPromoter,
+	extender interactionExtender,
+) *AggregationEngine {
+	return &AggregationEngine{
+		burstWindowHours: burstWindowHours,
+		replyBridgeHours: replyBridgeHours,
+		messageRepo:      messageRepo,
+		interactionRepo:  interactionRepo,
+		recorder:         recorder,
+		promoter:         promoter,
+		extender:         extender,
+	}
+}
+
+// burst groups consecutive same-direction messages within a time window.
+type burst struct {
+	direction string // "outbound" or "inbound"
+	messages  []repository.TelegramMessage
+	chatID    int64
+}
+
+func (b burst) firstMsgID() int32      { return b.messages[0].TelegramMessageID }
+func (b burst) firstSentAt() time.Time { return b.messages[0].SentAt }
+
+// msgSession is a resolved aggregation unit — may be a single burst or merged bursts.
+type msgSession struct {
+	direction string // "outbound", "inbound", or "mutual"
+	messages  []repository.TelegramMessage
+	chatID    int64
+	firstMsg  int32 // telegram_message_id of the first message (for source_ref)
+}
+
+func (s msgSession) sourceRef() string {
+	return fmt.Sprintf("tg:%d:%d", s.chatID, s.firstMsg)
+}
+
+func (s msgSession) lastSentAt() time.Time { return s.messages[len(s.messages)-1].SentAt }
+
+func (s msgSession) messageIDs() []uuid.UUID {
+	ids := make([]uuid.UUID, len(s.messages))
+	for i, m := range s.messages {
+		ids[i] = m.ID
+	}
+	return ids
+}
+
+func (s msgSession) description() string {
+	label := "exchange"
+	switch s.direction {
+	case repository.InteractionDirectionOutbound:
+		label = "outreach"
+	case repository.InteractionDirectionInbound:
+		label = "response"
+	}
+	return fmt.Sprintf("Telegram %s (%d messages)", label, len(s.messages))
+}
+
+// AggregateAll processes all contacts with unprocessed messages (batch mode).
+// Used after backfill. Pre-resolves outbound+inbound into mutual before calling RecordInteraction.
+func (e *AggregationEngine) AggregateAll(ctx context.Context) error {
+	contactIDs, err := e.messageRepo.ListUnprocessedContactIDs(ctx)
+	if err != nil {
+		return fmt.Errorf("list unprocessed contact IDs: %w", err)
+	}
+
+	if len(contactIDs) == 0 {
+		return nil
+	}
+
+	interactionsCreated := 0
+	for _, contactID := range contactIDs {
+		n, err := e.aggregateBatch(ctx, contactID)
+		if err != nil {
+			log.Warn().Err(err).Str("contact_id", contactID.String()).Msg("telegram: batch aggregation failed for contact")
+			continue
+		}
+		interactionsCreated += n
+	}
+
+	log.Info().Int("contacts", len(contactIDs)).Int("interactions", interactionsCreated).Msg("telegram: batch aggregation complete")
+	return nil
+}
+
+// aggregateBatch processes all unprocessed messages for a contact in batch mode.
+func (e *AggregationEngine) aggregateBatch(ctx context.Context, contactID uuid.UUID) (int, error) {
+	msgs, err := e.messageRepo.ListUnprocessedByContact(ctx, contactID)
+	if err != nil {
+		return 0, fmt.Errorf("list unprocessed messages: %w", err)
+	}
+	if len(msgs) == 0 {
+		return 0, nil
+	}
+
+	// Partition by chat
+	chatMsgs := partitionByChat(msgs)
+	interactionsCreated := 0
+
+	for chatID, chatMessages := range chatMsgs {
+		// Group into bursts
+		bursts := e.groupIntoBursts(chatMessages, chatID)
+
+		// Resolve bursts into sessions (merge outbound+inbound into mutual where applicable)
+		sessions := e.resolveSessions(ctx, bursts)
+
+		// Create interactions for each session
+		for _, sess := range sessions {
+			if err := e.createInteractionForSession(ctx, contactID, sess); err != nil {
+				log.Warn().Err(err).Int64("chat_id", chatID).Msg("telegram: failed to create interaction for session")
+				continue
+			}
+			interactionsCreated++
+		}
+	}
+
+	return interactionsCreated, nil
+}
+
+// AggregateForContact processes unprocessed messages for a specific contact+chat (incremental mode).
+func (e *AggregationEngine) AggregateForContact(ctx context.Context, contactID uuid.UUID, chatID int64) error {
+	msgs, err := e.messageRepo.ListUnprocessedByContactAndChat(ctx, contactID, chatID)
+	if err != nil {
+		return fmt.Errorf("list unprocessed messages: %w", err)
+	}
+	if len(msgs) == 0 {
+		return nil
+	}
+
+	// Group into bursts
+	bursts := e.groupIntoBursts(msgs, chatID)
+
+	// Resolve into sessions (same logic as batch)
+	sessions := e.resolveSessions(ctx, bursts)
+
+	sourceRefPrefix := fmt.Sprintf("tg:%d:%%", chatID)
+	now := msgs[len(msgs)-1].SentAt // use latest message time as upper bound
+
+	for _, sess := range sessions {
+		// Check explicit reply bridging first
+		if sess.direction == repository.InteractionDirectionInbound || sess.direction == repository.InteractionDirectionMutual {
+			if bridged := e.tryExplicitReplyBridge(ctx, contactID, sess); bridged {
+				continue
+			}
+		}
+
+		// Check time-based reply bridging for inbound sessions
+		if sess.direction == repository.InteractionDirectionInbound {
+			windowStart := sess.messages[0].SentAt.Add(-time.Duration(e.replyBridgeHours) * time.Hour)
+			existing, err := e.interactionRepo.FindRecentOutboundTelegramInteraction(
+				ctx, contactID, sourceRefPrefix, windowStart, sess.messages[0].SentAt,
+			)
+			if err == nil {
+				// Promote outbound → mutual
+				if err := e.promoter.PromoteInteractionToMutual(ctx, existing.ID, contactID, sess.lastSentAt()); err != nil {
+					log.Warn().Err(err).Msg("telegram: failed to promote interaction to mutual")
+				} else {
+					if err := e.messageRepo.MarkMessagesProcessed(ctx, sess.messageIDs(), existing.ID); err != nil {
+						log.Warn().Err(err).Msg("telegram: failed to mark messages processed after promotion")
+					}
+					continue
+				}
+			}
+		}
+
+		// Check same-direction coalescing (burst window)
+		coalesceDir := sess.direction
+		if coalesceDir == repository.InteractionDirectionMutual {
+			coalesceDir = repository.InteractionDirectionOutbound
+		}
+		windowStart := sess.messages[0].SentAt.Add(-time.Duration(e.burstWindowHours) * time.Hour)
+		existing, err := e.interactionRepo.FindRecentTelegramInteraction(
+			ctx, contactID, coalesceDir, sourceRefPrefix, windowStart, now,
+		)
+		if err == nil {
+			// Extend existing interaction
+			desc := sess.description()
+			if err := e.extender.ExtendInteraction(ctx, existing.ID, contactID, sess.direction, sess.lastSentAt(), &desc); err != nil {
+				log.Warn().Err(err).Msg("telegram: failed to extend interaction")
+			} else {
+				if err := e.messageRepo.MarkMessagesProcessed(ctx, sess.messageIDs(), existing.ID); err != nil {
+					log.Warn().Err(err).Msg("telegram: failed to mark messages processed after extension")
+				}
+				continue
+			}
+		}
+
+		// Create new interaction
+		if err := e.createInteractionForSession(ctx, contactID, sess); err != nil {
+			log.Warn().Err(err).Int64("chat_id", chatID).Msg("telegram: failed to create interaction for session")
+		}
+	}
+
+	return nil
+}
+
+// tryExplicitReplyBridge checks if any inbound message has reply_to_msg_id pointing
+// to an outgoing message with an interaction_id. Bridges regardless of time gap.
+func (e *AggregationEngine) tryExplicitReplyBridge(ctx context.Context, contactID uuid.UUID, sess msgSession) bool {
+	for _, msg := range sess.messages {
+		if msg.ReplyToMsgID == nil {
+			continue
+		}
+		// Resolve the referenced message
+		referenced, err := e.messageRepo.GetMessageByReplyTo(ctx, sess.chatID, *msg.ReplyToMsgID)
+		if err != nil {
+			continue // message not found or error
+		}
+		// Check if it's outgoing and has an interaction_id
+		if !referenced.IsOutgoing || referenced.InteractionID == nil {
+			continue
+		}
+		// Verify the interaction is outbound telegram
+		existing, err := e.interactionRepo.GetInteraction(ctx, *referenced.InteractionID)
+		if err != nil || existing.Source != repository.InteractionSourceTelegram || existing.Direction != repository.InteractionDirectionOutbound {
+			continue
+		}
+		// Promote to mutual
+		if err := e.promoter.PromoteInteractionToMutual(ctx, existing.ID, contactID, sess.lastSentAt()); err != nil {
+			log.Warn().Err(err).Msg("telegram: failed to promote interaction via explicit reply")
+			continue
+		}
+		if err := e.messageRepo.MarkMessagesProcessed(ctx, sess.messageIDs(), existing.ID); err != nil {
+			log.Warn().Err(err).Msg("telegram: failed to mark messages processed after explicit reply bridge")
+		}
+		return true
+	}
+	return false
+}
+
+// createInteractionForSession creates a new interaction for a session and marks messages processed.
+func (e *AggregationEngine) createInteractionForSession(ctx context.Context, contactID uuid.UUID, sess msgSession) error {
+	sourceRef := sess.sourceRef()
+	desc := sess.description()
+
+	interaction, err := e.recorder.RecordInteraction(ctx, repository.RecordInteractionRequest{
+		ContactID:   contactID,
+		Source:      repository.InteractionSourceTelegram,
+		SourceRef:   &sourceRef,
+		OccurredAt:  sess.lastSentAt(),
+		Description: &desc,
+		Direction:   sess.direction,
+	})
+	if err != nil {
+		return fmt.Errorf("record interaction: %w", err)
+	}
+
+	if err := e.messageRepo.MarkMessagesProcessed(ctx, sess.messageIDs(), interaction.ID); err != nil {
+		return fmt.Errorf("mark messages processed: %w", err)
+	}
+
+	return nil
+}
+
+// groupIntoBursts groups consecutive same-direction messages within the burst window.
+func (e *AggregationEngine) groupIntoBursts(msgs []repository.TelegramMessage, chatID int64) []burst {
+	if len(msgs) == 0 {
+		return nil
+	}
+
+	var bursts []burst
+	current := burst{
+		direction: msgDirection(msgs[0]),
+		messages:  []repository.TelegramMessage{msgs[0]},
+		chatID:    chatID,
+	}
+
+	for i := 1; i < len(msgs); i++ {
+		dir := msgDirection(msgs[i])
+		gap := msgs[i].SentAt.Sub(msgs[i-1].SentAt)
+
+		if dir != current.direction || gap > time.Duration(e.burstWindowHours)*time.Hour {
+			bursts = append(bursts, current)
+			current = burst{
+				direction: dir,
+				messages:  []repository.TelegramMessage{msgs[i]},
+				chatID:    chatID,
+			}
+		} else {
+			current.messages = append(current.messages, msgs[i])
+		}
+	}
+	bursts = append(bursts, current)
+	return bursts
+}
+
+// resolveSessions merges bursts into sessions, applying reply bridging for batch mode.
+func (e *AggregationEngine) resolveSessions(ctx context.Context, bursts []burst) []msgSession {
+	if len(bursts) == 0 {
+		return nil
+	}
+
+	var sessions []msgSession
+
+	for i := 0; i < len(bursts); i++ {
+		b := bursts[i]
+
+		// Check if this inbound burst should bridge with the previous outbound session
+		if b.direction == repository.InteractionDirectionInbound && len(sessions) > 0 {
+			prev := &sessions[len(sessions)-1]
+			if prev.direction == repository.InteractionDirectionOutbound {
+				shouldBridge := false
+
+				// Time-based bridging
+				gap := b.firstSentAt().Sub(prev.lastSentAt())
+				if gap <= time.Duration(e.replyBridgeHours)*time.Hour {
+					shouldBridge = true
+				}
+
+				// Explicit reply bridging
+				if !shouldBridge {
+					for _, msg := range b.messages {
+						if msg.ReplyToMsgID != nil {
+							for _, prevMsg := range prev.messages {
+								if prevMsg.TelegramMessageID == *msg.ReplyToMsgID {
+									shouldBridge = true
+									break
+								}
+							}
+							if shouldBridge {
+								break
+							}
+						}
+					}
+				}
+
+				if shouldBridge {
+					// Merge into mutual session
+					prev.direction = repository.InteractionDirectionMutual
+					prev.messages = append(prev.messages, b.messages...)
+					continue
+				}
+			}
+		}
+
+		sessions = append(sessions, msgSession{
+			direction: b.direction,
+			messages:  b.messages,
+			chatID:    b.chatID,
+			firstMsg:  b.firstMsgID(),
+		})
+	}
+
+	return sessions
+}
+
+// partitionByChat groups messages by telegram_chat_id.
+func partitionByChat(msgs []repository.TelegramMessage) map[int64][]repository.TelegramMessage {
+	result := make(map[int64][]repository.TelegramMessage)
+	for _, m := range msgs {
+		result[m.TelegramChatID] = append(result[m.TelegramChatID], m)
+	}
+	return result
+}
+
+func msgDirection(msg repository.TelegramMessage) string {
+	if msg.IsOutgoing {
+		return repository.InteractionDirectionOutbound
+	}
+	return repository.InteractionDirectionInbound
+}

--- a/backend/internal/telegram/aggregation.go
+++ b/backend/internal/telegram/aggregation.go
@@ -214,24 +214,41 @@ func (e *AggregationEngine) AggregateForContact(ctx context.Context, contactID u
 		}
 
 		// Check same-direction coalescing (burst window)
-		coalesceDir := sess.direction
-		if coalesceDir == repository.InteractionDirectionMutual {
-			coalesceDir = repository.InteractionDirectionOutbound
-		}
-		windowStart := sess.messages[0].SentAt.Add(-time.Duration(e.burstWindowHours) * time.Hour)
-		existing, err := e.interactionRepo.FindRecentTelegramInteraction(
-			ctx, contactID, coalesceDir, sourceRefPrefix, windowStart, now,
-		)
-		if err == nil {
-			// Extend existing interaction
-			desc := sess.description()
-			if err := e.extender.ExtendInteraction(ctx, existing.ID, contactID, sess.direction, sess.lastSentAt(), &desc); err != nil {
-				log.Warn().Err(err).Msg("telegram: failed to extend interaction")
-			} else {
-				if err := e.messageRepo.MarkMessagesProcessed(ctx, sess.messageIDs(), existing.ID); err != nil {
-					log.Warn().Err(err).Msg("telegram: failed to mark messages processed after extension")
+		// For mutual sessions: check if there's an outbound interaction to promote
+		// rather than extend, since ExtendInteraction doesn't update direction.
+		if sess.direction == repository.InteractionDirectionMutual {
+			windowStart := sess.messages[0].SentAt.Add(-time.Duration(e.burstWindowHours) * time.Hour)
+			existing, err := e.interactionRepo.FindRecentTelegramInteraction(
+				ctx, contactID, repository.InteractionDirectionOutbound, sourceRefPrefix, windowStart, now,
+			)
+			if err == nil {
+				// Promote outbound → mutual (updates direction + contact fields)
+				if err := e.promoter.PromoteInteractionToMutual(ctx, existing.ID, contactID, sess.lastSentAt()); err != nil {
+					log.Warn().Err(err).Msg("telegram: failed to promote interaction to mutual during coalescing")
+				} else {
+					if err := e.messageRepo.MarkMessagesProcessed(ctx, sess.messageIDs(), existing.ID); err != nil {
+						log.Warn().Err(err).Msg("telegram: failed to mark messages processed after promotion")
+					}
+					continue
 				}
-				continue
+			}
+			// No outbound to promote — fall through to create new mutual interaction
+		} else {
+			// Same-direction coalescing: extend the existing interaction
+			windowStart := sess.messages[0].SentAt.Add(-time.Duration(e.burstWindowHours) * time.Hour)
+			existing, err := e.interactionRepo.FindRecentTelegramInteraction(
+				ctx, contactID, sess.direction, sourceRefPrefix, windowStart, now,
+			)
+			if err == nil {
+				desc := sess.description()
+				if err := e.extender.ExtendInteraction(ctx, existing.ID, contactID, sess.direction, sess.lastSentAt(), &desc); err != nil {
+					log.Warn().Err(err).Msg("telegram: failed to extend interaction")
+				} else {
+					if err := e.messageRepo.MarkMessagesProcessed(ctx, sess.messageIDs(), existing.ID); err != nil {
+						log.Warn().Err(err).Msg("telegram: failed to mark messages processed after extension")
+					}
+					continue
+				}
 			}
 		}
 

--- a/backend/internal/telegram/aggregation.go
+++ b/backend/internal/telegram/aggregation.go
@@ -269,7 +269,7 @@ func (e *AggregationEngine) tryExplicitReplyBridge(ctx context.Context, contactI
 			continue
 		}
 		// Resolve the referenced message
-		referenced, err := e.messageRepo.GetMessageByReplyTo(ctx, sess.chatID, *msg.ReplyToMsgID)
+		referenced, err := e.messageRepo.GetMessage(ctx, sess.chatID, *msg.ReplyToMsgID)
 		if err != nil {
 			continue // message not found or error
 		}
@@ -365,7 +365,7 @@ func (e *AggregationEngine) resolveSessions(bursts []burst) []msgSession {
 		// Check if this inbound burst should bridge with the previous outbound session
 		if b.direction == repository.InteractionDirectionInbound && len(sessions) > 0 {
 			prev := &sessions[len(sessions)-1]
-			if prev.direction == repository.InteractionDirectionOutbound {
+			if prev.direction == repository.InteractionDirectionOutbound && prev.chatID == b.chatID {
 				shouldBridge := false
 
 				// Time-based bridging

--- a/backend/internal/telegram/aggregation_test.go
+++ b/backend/internal/telegram/aggregation_test.go
@@ -1,7 +1,6 @@
 package telegram
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -12,10 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// Silence unused import warnings
-var _ = require.New
-var _ = context.Background
 
 func makeMsg(id int32, chatID int64, outgoing bool, sentAt time.Time) repository.TelegramMessage {
 	return repository.TelegramMessage{
@@ -103,7 +98,7 @@ func TestResolveSessions_ReplyBridgeWithin48h(t *testing.T) {
 		},
 	}
 
-	sessions := e.resolveSessions(context.Background(), bursts)
+	sessions := e.resolveSessions(bursts)
 	require.Len(t, sessions, 1)
 	assert.Equal(t, repository.InteractionDirectionMutual, sessions[0].direction)
 	assert.Len(t, sessions[0].messages, 3)
@@ -130,7 +125,7 @@ func TestResolveSessions_ReplyBridgeExpired(t *testing.T) {
 		},
 	}
 
-	sessions := e.resolveSessions(context.Background(), bursts)
+	sessions := e.resolveSessions(bursts)
 	require.Len(t, sessions, 2) // not bridged
 }
 
@@ -163,7 +158,7 @@ func TestResolveSessions_ExplicitReplyBridges(t *testing.T) {
 		},
 	}
 
-	sessions := e.resolveSessions(context.Background(), bursts)
+	sessions := e.resolveSessions(bursts)
 	require.Len(t, sessions, 1) // bridged via explicit reply
 	assert.Equal(t, repository.InteractionDirectionMutual, sessions[0].direction)
 }
@@ -194,7 +189,7 @@ func TestResolveSessions_ChatScoped(t *testing.T) {
 		},
 	}
 
-	sessions := e.resolveSessions(context.Background(), bursts)
+	sessions := e.resolveSessions(bursts)
 	require.Len(t, sessions, 2) // separate chats = separate sessions
 }
 

--- a/backend/internal/telegram/aggregation_test.go
+++ b/backend/internal/telegram/aggregation_test.go
@@ -193,6 +193,30 @@ func TestResolveSessions_ChatScoped(t *testing.T) {
 	require.Len(t, sessions, 2) // separate chats = separate sessions
 }
 
+func TestResolveSessions_CrossChatNoBridge(t *testing.T) {
+	e := &AggregationEngine{burstWindowHours: 2, replyBridgeHours: 48}
+	base := accelerated.GetCurrentTime()
+
+	// Outbound in chat 100, inbound in chat 200 — should NOT bridge even within 48h
+	bursts := []burst{
+		{
+			direction: repository.InteractionDirectionOutbound,
+			messages:  []repository.TelegramMessage{makeMsg(1, 100, true, base)},
+			chatID:    100,
+		},
+		{
+			direction: repository.InteractionDirectionInbound,
+			messages:  []repository.TelegramMessage{makeMsg(2, 200, false, base.Add(1*time.Hour))},
+			chatID:    200,
+		},
+	}
+
+	sessions := e.resolveSessions(bursts)
+	require.Len(t, sessions, 2) // different chats — no bridging
+	assert.Equal(t, repository.InteractionDirectionOutbound, sessions[0].direction)
+	assert.Equal(t, repository.InteractionDirectionInbound, sessions[1].direction)
+}
+
 func TestPartitionByChat(t *testing.T) {
 	now := accelerated.GetCurrentTime()
 	msgs := []repository.TelegramMessage{

--- a/backend/internal/telegram/aggregation_test.go
+++ b/backend/internal/telegram/aggregation_test.go
@@ -1,0 +1,217 @@
+package telegram
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Silence unused import warnings
+var _ = require.New
+var _ = context.Background
+
+func makeMsg(id int32, chatID int64, outgoing bool, sentAt time.Time) repository.TelegramMessage {
+	return repository.TelegramMessage{
+		ID:                uuid.New(),
+		TelegramMessageID: id,
+		TelegramChatID:    chatID,
+		IsOutgoing:        outgoing,
+		SentAt:            sentAt,
+	}
+}
+
+func TestGroupIntoBursts_SingleOutbound(t *testing.T) {
+	e := &AggregationEngine{burstWindowHours: 2}
+	base := accelerated.GetCurrentTime()
+	msgs := []repository.TelegramMessage{
+		makeMsg(1, 100, true, base),
+		makeMsg(2, 100, true, base.Add(10*time.Minute)),
+		makeMsg(3, 100, true, base.Add(30*time.Minute)),
+	}
+
+	bursts := e.groupIntoBursts(msgs, 100)
+	require.Len(t, bursts, 1)
+	assert.Equal(t, repository.InteractionDirectionOutbound, bursts[0].direction)
+	assert.Len(t, bursts[0].messages, 3)
+}
+
+func TestGroupIntoBursts_SingleInbound(t *testing.T) {
+	e := &AggregationEngine{burstWindowHours: 2}
+	base := accelerated.GetCurrentTime()
+	msgs := []repository.TelegramMessage{
+		makeMsg(1, 100, false, base),
+		makeMsg(2, 100, false, base.Add(5*time.Minute)),
+	}
+
+	bursts := e.groupIntoBursts(msgs, 100)
+	require.Len(t, bursts, 1)
+	assert.Equal(t, repository.InteractionDirectionInbound, bursts[0].direction)
+}
+
+func TestGroupIntoBursts_SplitByGap(t *testing.T) {
+	e := &AggregationEngine{burstWindowHours: 2}
+	base := accelerated.GetCurrentTime()
+	msgs := []repository.TelegramMessage{
+		makeMsg(1, 100, true, base),
+		makeMsg(2, 100, true, base.Add(3*time.Hour)), // >2h gap
+	}
+
+	bursts := e.groupIntoBursts(msgs, 100)
+	require.Len(t, bursts, 2)
+}
+
+func TestGroupIntoBursts_DirectionChangeSplits(t *testing.T) {
+	e := &AggregationEngine{burstWindowHours: 2}
+	base := accelerated.GetCurrentTime()
+	msgs := []repository.TelegramMessage{
+		makeMsg(1, 100, true, base),
+		makeMsg(2, 100, false, base.Add(5*time.Minute)), // direction change
+	}
+
+	bursts := e.groupIntoBursts(msgs, 100)
+	require.Len(t, bursts, 2)
+	assert.Equal(t, repository.InteractionDirectionOutbound, bursts[0].direction)
+	assert.Equal(t, repository.InteractionDirectionInbound, bursts[1].direction)
+}
+
+func TestResolveSessions_ReplyBridgeWithin48h(t *testing.T) {
+	e := &AggregationEngine{burstWindowHours: 2, replyBridgeHours: 48}
+	base := accelerated.GetCurrentTime()
+
+	bursts := []burst{
+		{
+			direction: repository.InteractionDirectionOutbound,
+			messages: []repository.TelegramMessage{
+				makeMsg(1, 100, true, base),
+				makeMsg(2, 100, true, base.Add(5*time.Minute)),
+			},
+			chatID: 100,
+		},
+		{
+			direction: repository.InteractionDirectionInbound,
+			messages: []repository.TelegramMessage{
+				makeMsg(3, 100, false, base.Add(1*time.Hour)), // within 48h
+			},
+			chatID: 100,
+		},
+	}
+
+	sessions := e.resolveSessions(context.Background(), bursts)
+	require.Len(t, sessions, 1)
+	assert.Equal(t, repository.InteractionDirectionMutual, sessions[0].direction)
+	assert.Len(t, sessions[0].messages, 3)
+}
+
+func TestResolveSessions_ReplyBridgeExpired(t *testing.T) {
+	e := &AggregationEngine{burstWindowHours: 2, replyBridgeHours: 48}
+	base := accelerated.GetCurrentTime()
+
+	bursts := []burst{
+		{
+			direction: repository.InteractionDirectionOutbound,
+			messages: []repository.TelegramMessage{
+				makeMsg(1, 100, true, base),
+			},
+			chatID: 100,
+		},
+		{
+			direction: repository.InteractionDirectionInbound,
+			messages: []repository.TelegramMessage{
+				makeMsg(2, 100, false, base.Add(49*time.Hour)), // >48h gap
+			},
+			chatID: 100,
+		},
+	}
+
+	sessions := e.resolveSessions(context.Background(), bursts)
+	require.Len(t, sessions, 2) // not bridged
+}
+
+func TestResolveSessions_ExplicitReplyBridges(t *testing.T) {
+	e := &AggregationEngine{burstWindowHours: 2, replyBridgeHours: 48}
+	base := accelerated.GetCurrentTime()
+
+	replyTo := int32(1)
+	bursts := []burst{
+		{
+			direction: repository.InteractionDirectionOutbound,
+			messages: []repository.TelegramMessage{
+				makeMsg(1, 100, true, base),
+			},
+			chatID: 100,
+		},
+		{
+			direction: repository.InteractionDirectionInbound,
+			messages: []repository.TelegramMessage{
+				{
+					ID:                uuid.New(),
+					TelegramMessageID: 2,
+					TelegramChatID:    100,
+					IsOutgoing:        false,
+					SentAt:            base.Add(72 * time.Hour), // >48h gap
+					ReplyToMsgID:      &replyTo,                 // explicit reply to msg 1
+				},
+			},
+			chatID: 100,
+		},
+	}
+
+	sessions := e.resolveSessions(context.Background(), bursts)
+	require.Len(t, sessions, 1) // bridged via explicit reply
+	assert.Equal(t, repository.InteractionDirectionMutual, sessions[0].direction)
+}
+
+func TestSessionKey_Stability(t *testing.T) {
+	sess := msgSession{
+		chatID:   12345,
+		firstMsg: 50001,
+	}
+	assert.Equal(t, "tg:12345:50001", sess.sourceRef())
+}
+
+func TestResolveSessions_ChatScoped(t *testing.T) {
+	e := &AggregationEngine{burstWindowHours: 2, replyBridgeHours: 48}
+	base := accelerated.GetCurrentTime()
+
+	// Messages from same contact in different chats should NOT merge
+	bursts := []burst{
+		{
+			direction: repository.InteractionDirectionOutbound,
+			messages:  []repository.TelegramMessage{makeMsg(1, 100, true, base)},
+			chatID:    100,
+		},
+		{
+			direction: repository.InteractionDirectionOutbound,
+			messages:  []repository.TelegramMessage{makeMsg(2, 200, true, base.Add(5*time.Minute))},
+			chatID:    200,
+		},
+	}
+
+	sessions := e.resolveSessions(context.Background(), bursts)
+	require.Len(t, sessions, 2) // separate chats = separate sessions
+}
+
+func TestPartitionByChat(t *testing.T) {
+	now := accelerated.GetCurrentTime()
+	msgs := []repository.TelegramMessage{
+		makeMsg(1, 100, true, now),
+		makeMsg(2, 200, true, now),
+		makeMsg(3, 100, false, now),
+	}
+
+	result := partitionByChat(msgs)
+	assert.Len(t, result[100], 2)
+	assert.Len(t, result[200], 1)
+}
+
+func TestMsgDirection(t *testing.T) {
+	assert.Equal(t, repository.InteractionDirectionOutbound, msgDirection(repository.TelegramMessage{IsOutgoing: true}))
+	assert.Equal(t, repository.InteractionDirectionInbound, msgDirection(repository.TelegramMessage{IsOutgoing: false}))
+}

--- a/backend/internal/telegram/handlers.go
+++ b/backend/internal/telegram/handlers.go
@@ -97,7 +97,9 @@ func (h *MessageHandler) HandleNewMessage(ctx context.Context, e tg.Entities, up
 		if err != nil {
 			log.Warn().Err(err).Int64("peer_user_id", *parsed.PeerUserID).Msg("telegram: peer matching failed")
 		} else if contactID != nil && h.aggregationEngine != nil {
-			if err := h.aggregationEngine.AggregateForContact(ctx, *contactID, parsed.TelegramChatID); err != nil {
+			// Use batch aggregation to process all chats for this contact
+			// (MatchPeer links messages across all chats for the peer)
+			if err := h.aggregationEngine.AggregateForContactBatch(ctx, *contactID); err != nil {
 				log.Warn().Err(err).Str("contact_id", contactID.String()).Msg("telegram: aggregation failed")
 			}
 		} else if contactID == nil {

--- a/backend/internal/telegram/handlers.go
+++ b/backend/internal/telegram/handlers.go
@@ -15,13 +15,15 @@ import (
 
 // MessageHandler processes Telegram update events and stores messages.
 type MessageHandler struct {
-	messageRepo     *repository.TelegramMessageRepository
-	chatConfigRepo  *repository.TelegramChatConfigRepository
-	syncRepo        *repository.SyncRepository
-	syncStateID     *uuid.UUID
-	selfUserID      int64
-	groupMaxMembers int
-	api             *tg.Client
+	messageRepo       *repository.TelegramMessageRepository
+	chatConfigRepo    *repository.TelegramChatConfigRepository
+	syncRepo          *repository.SyncRepository
+	syncStateID       *uuid.UUID
+	selfUserID        int64
+	groupMaxMembers   int
+	api               *tg.Client
+	peerMatcher       *PeerMatcher
+	aggregationEngine *AggregationEngine
 }
 
 // NewMessageHandler creates a new message handler.
@@ -32,14 +34,18 @@ func NewMessageHandler(
 	syncStateID *uuid.UUID,
 	selfUserID int64,
 	groupMaxMembers int,
+	peerMatcher *PeerMatcher,
+	aggregationEngine *AggregationEngine,
 ) *MessageHandler {
 	return &MessageHandler{
-		messageRepo:     messageRepo,
-		chatConfigRepo:  chatConfigRepo,
-		syncRepo:        syncRepo,
-		syncStateID:     syncStateID,
-		selfUserID:      selfUserID,
-		groupMaxMembers: groupMaxMembers,
+		messageRepo:       messageRepo,
+		chatConfigRepo:    chatConfigRepo,
+		syncRepo:          syncRepo,
+		syncStateID:       syncStateID,
+		selfUserID:        selfUserID,
+		groupMaxMembers:   groupMaxMembers,
+		peerMatcher:       peerMatcher,
+		aggregationEngine: aggregationEngine,
 	}
 }
 
@@ -84,6 +90,18 @@ func (h *MessageHandler) HandleNewMessage(ctx context.Context, e tg.Entities, up
 		Str("chat_type", parsed.ChatType).
 		Bool("is_outgoing", parsed.IsOutgoing).
 		Msg("telegram: message stored")
+
+	// Phase 4: identity matching + aggregation (best-effort)
+	if h.peerMatcher != nil && parsed.PeerUserID != nil {
+		contactID, err := h.peerMatcher.MatchPeer(ctx, *parsed.PeerUserID, parsed.PeerUsername, parsed.PeerFirstName, parsed.PeerLastName, parsed.PeerPhone)
+		if err != nil {
+			log.Warn().Err(err).Int64("peer_user_id", *parsed.PeerUserID).Msg("telegram: peer matching failed")
+		} else if contactID != nil && h.aggregationEngine != nil {
+			if err := h.aggregationEngine.AggregateForContact(ctx, *contactID, parsed.TelegramChatID); err != nil {
+				log.Warn().Err(err).Str("contact_id", contactID.String()).Msg("telegram: aggregation failed")
+			}
+		}
+	}
 
 	return nil
 }

--- a/backend/internal/telegram/handlers.go
+++ b/backend/internal/telegram/handlers.go
@@ -100,6 +100,9 @@ func (h *MessageHandler) HandleNewMessage(ctx context.Context, e tg.Entities, up
 			if err := h.aggregationEngine.AggregateForContact(ctx, *contactID, parsed.TelegramChatID); err != nil {
 				log.Warn().Err(err).Str("contact_id", contactID.String()).Msg("telegram: aggregation failed")
 			}
+		} else if contactID == nil {
+			// Unmatched peer — update discovery candidates incrementally
+			h.peerMatcher.UpdateDiscoveryCandidatesForPeer(ctx, *parsed.PeerUserID, parsed.PeerUsername, parsed.PeerFirstName, parsed.PeerLastName)
 		}
 	}
 

--- a/backend/internal/telegram/handlers.go
+++ b/backend/internal/telegram/handlers.go
@@ -97,9 +97,9 @@ func (h *MessageHandler) HandleNewMessage(ctx context.Context, e tg.Entities, up
 		if err != nil {
 			log.Warn().Err(err).Int64("peer_user_id", *parsed.PeerUserID).Msg("telegram: peer matching failed")
 		} else if contactID != nil && h.aggregationEngine != nil {
-			// Use batch aggregation to process all chats for this contact
-			// (MatchPeer links messages across all chats for the peer)
-			if err := h.aggregationEngine.AggregateForContactBatch(ctx, *contactID); err != nil {
+			// Use incremental aggregation for the current chat — this coalesces
+			// with existing interactions in the burst window and handles reply bridging.
+			if err := h.aggregationEngine.AggregateForContact(ctx, *contactID, parsed.TelegramChatID); err != nil {
 				log.Warn().Err(err).Str("contact_id", contactID.String()).Msg("telegram: aggregation failed")
 			}
 		} else if contactID == nil {

--- a/backend/internal/telegram/manager.go
+++ b/backend/internal/telegram/manager.go
@@ -69,6 +69,10 @@ type TelegramManager struct {
 	backfillInProgress bool
 	backfillTotal      int
 	backfillCompleted  int
+
+	// Phase 4: identity matching + aggregation
+	peerMatcher       *PeerMatcher
+	aggregationEngine *AggregationEngine
 }
 
 // NewTelegramManager creates the manager and its embedded AuthSessionManager.
@@ -82,17 +86,32 @@ func NewTelegramManager(
 	apiID int,
 	apiHash string,
 	cfg *config.TelegramConfig,
+	identityService identityMatcher,
+	externalContactRepo externalContactUpserter,
+	interactionRepo *repository.InteractionRepository,
+	recorder interactionRecorder,
+	promoter interactionPromoter,
+	extender interactionExtender,
 ) *TelegramManager {
+	peerMatcher := NewPeerMatcher(identityService, messageRepo, externalContactRepo, cfg.DiscoveryMinMessages)
+	aggregationEngine := NewAggregationEngine(
+		cfg.BurstWindowHours, cfg.ReplyBridgeHours,
+		messageRepo, interactionRepo,
+		recorder, promoter, extender,
+	)
+
 	m := &TelegramManager{
-		sessionRepo:     sessionRepo,
-		updateStateRepo: updateStateRepo,
-		chatConfigRepo:  chatConfigRepo,
-		messageRepo:     messageRepo,
-		syncRepo:        syncRepo,
-		encryptor:       encryptor,
-		apiID:           apiID,
-		apiHash:         apiHash,
-		cfg:             cfg,
+		sessionRepo:       sessionRepo,
+		updateStateRepo:   updateStateRepo,
+		chatConfigRepo:    chatConfigRepo,
+		messageRepo:       messageRepo,
+		syncRepo:          syncRepo,
+		encryptor:         encryptor,
+		apiID:             apiID,
+		apiHash:           apiHash,
+		cfg:               cfg,
+		peerMatcher:       peerMatcher,
+		aggregationEngine: aggregationEngine,
 	}
 
 	m.authManager = NewAuthSessionManager(
@@ -181,6 +200,8 @@ func (m *TelegramManager) runWithReconnect(clientCtx context.Context, cancel con
 		m.syncStateID,
 		selfUserID,
 		m.cfg.GroupMaxMembers,
+		m.peerMatcher,
+		m.aggregationEngine,
 	)
 
 	// Create dispatcher with real handlers
@@ -547,10 +568,35 @@ func (m *TelegramManager) maybeStartBackfill(ctx context.Context, client *telegr
 		if err := backfiller.Run(ctx); err != nil {
 			log.Warn().Err(err).Msg("telegram: backfill failed")
 		}
+
+		// Phase 4: batch identity matching + aggregation after backfill
+		if err := m.peerMatcher.MatchAllUnmatched(ctx); err != nil {
+			log.Warn().Err(err).Msg("telegram: batch identity matching failed")
+		}
+		if err := m.aggregationEngine.AggregateAll(ctx); err != nil {
+			log.Warn().Err(err).Msg("telegram: batch aggregation failed")
+		}
+		if err := m.peerMatcher.UpdateDiscoveryCandidates(ctx); err != nil {
+			log.Warn().Err(err).Msg("telegram: discovery candidate update failed")
+		}
+
 		m.backfillMu.Lock()
 		m.backfillInProgress = false
 		m.backfillMu.Unlock()
 	}()
+}
+
+// OnPeerLinked satisfies handlers.PostImportHook. Called after a Telegram candidate
+// is imported/linked to back-fill message matching and trigger aggregation.
+func (m *TelegramManager) OnPeerLinked(ctx context.Context, peerUserID int64, peerUsername string, contactID uuid.UUID) error {
+	if err := m.peerMatcher.OnPeerLinked(ctx, peerUserID, peerUsername, contactID); err != nil {
+		return err
+	}
+	// Aggregate for the newly-matched contact
+	if err := m.aggregationEngine.AggregateAll(ctx); err != nil {
+		log.Warn().Err(err).Msg("telegram: post-import aggregation failed")
+	}
+	return nil
 }
 
 // updateSyncStatus updates the external_sync_state row for Telegram.

--- a/backend/internal/telegram/manager.go
+++ b/backend/internal/telegram/manager.go
@@ -592,8 +592,8 @@ func (m *TelegramManager) OnPeerLinked(ctx context.Context, peerUserID int64, pe
 	if err := m.peerMatcher.OnPeerLinked(ctx, peerUserID, peerUsername, contactID); err != nil {
 		return err
 	}
-	// Aggregate for the newly-matched contact
-	if err := m.aggregationEngine.AggregateAll(ctx); err != nil {
+	// Aggregate only the newly-matched contact (not all contacts)
+	if err := m.aggregationEngine.AggregateForContactBatch(ctx, contactID); err != nil {
 		log.Warn().Err(err).Msg("telegram: post-import aggregation failed")
 	}
 	return nil

--- a/backend/internal/telegram/matcher.go
+++ b/backend/internal/telegram/matcher.go
@@ -69,8 +69,10 @@ func (m *PeerMatcher) MatchPeer(ctx context.Context, peerUserID int64, peerUsern
 			log.Warn().Err(err).Str("username", *peerUsername).Msg("telegram: failed to match username")
 		} else if result.ContactID != nil {
 			// Matched via username
-			if err := m.messageRepo.UpdateMessageContact(ctx, peerUserID, *result.ContactID); err != nil {
-				log.Warn().Err(err).Int64("peer_user_id", peerUserID).Msg("telegram: failed to update message contacts")
+			if m.messageRepo != nil {
+				if err := m.messageRepo.UpdateMessageContact(ctx, peerUserID, *result.ContactID); err != nil {
+					log.Warn().Err(err).Int64("peer_user_id", peerUserID).Msg("telegram: failed to update message contacts")
+				}
 			}
 			m.markExternalContactMatched(ctx, peerUserID, *result.ContactID)
 			log.Info().
@@ -95,8 +97,10 @@ func (m *PeerMatcher) MatchPeer(ctx context.Context, peerUserID int64, peerUsern
 			log.Warn().Err(err).Str("phone", *peerPhone).Msg("telegram: failed to match phone")
 		} else if result.ContactID != nil {
 			// Matched via phone — also link the telegram identity
-			if err := m.messageRepo.UpdateMessageContact(ctx, peerUserID, *result.ContactID); err != nil {
-				log.Warn().Err(err).Int64("peer_user_id", peerUserID).Msg("telegram: failed to update message contacts")
+			if m.messageRepo != nil {
+				if err := m.messageRepo.UpdateMessageContact(ctx, peerUserID, *result.ContactID); err != nil {
+					log.Warn().Err(err).Int64("peer_user_id", peerUserID).Msg("telegram: failed to update message contacts")
+				}
 			}
 			m.markExternalContactMatched(ctx, peerUserID, *result.ContactID)
 

--- a/backend/internal/telegram/matcher.go
+++ b/backend/internal/telegram/matcher.go
@@ -212,6 +212,52 @@ func (m *PeerMatcher) UpdateDiscoveryCandidates(ctx context.Context) error {
 	return nil
 }
 
+// UpdateDiscoveryCandidatesForPeer checks if a specific unmatched peer has crossed the
+// discovery threshold and upserts their external_contact if so. Used for live messages.
+func (m *PeerMatcher) UpdateDiscoveryCandidatesForPeer(ctx context.Context, peerUserID int64, peerUsername, peerFirstName, peerLastName *string) {
+	counts, err := m.messageRepo.CountMessagesByPeer(ctx)
+	if err != nil {
+		log.Warn().Err(err).Msg("telegram: failed to count messages for discovery check")
+		return
+	}
+
+	for _, count := range counts {
+		if count.PeerUserID != peerUserID {
+			continue
+		}
+		if count.TotalCount < int64(m.discoveryMinMsgs) {
+			return // below threshold
+		}
+
+		displayName := buildDisplayName(peerFirstName, peerLastName)
+		sourceID := strconv.FormatInt(peerUserID, 10)
+
+		metadata := map[string]any{
+			"message_count":  count.TotalCount,
+			"outbound_count": count.OutboundCount,
+			"inbound_count":  count.InboundCount,
+		}
+		if !count.LastMessageAt.IsZero() {
+			metadata["last_message_at"] = count.LastMessageAt.Format("2006-01-02T15:04:05Z")
+		}
+		if peerUsername != nil {
+			metadata["username"] = "@" + *peerUsername
+		}
+
+		if _, err := m.externalContactRepo.Upsert(ctx, repository.UpsertExternalContactRequest{
+			Source:      "telegram",
+			SourceID:    sourceID,
+			DisplayName: displayName,
+			FirstName:   peerFirstName,
+			LastName:    peerLastName,
+			Metadata:    metadata,
+		}); err != nil {
+			log.Warn().Err(err).Int64("peer_user_id", peerUserID).Msg("telegram: failed to upsert discovery candidate for live peer")
+		}
+		return
+	}
+}
+
 // OnPeerLinked is called after a Telegram import/link to back-fill message matching.
 // It links the identity, updates matched_contact_id on messages, and returns true
 // to signal that aggregation should run.

--- a/backend/internal/telegram/matcher.go
+++ b/backend/internal/telegram/matcher.go
@@ -27,10 +27,16 @@ type externalContactUpserter interface {
 	UpdateMatch(ctx context.Context, id uuid.UUID, crmContactID *uuid.UUID, status repository.MatchStatus) (*repository.ExternalContact, error)
 }
 
+// peerMessageCounter counts messages for a peer (for discovery threshold checks).
+type peerMessageCounter interface {
+	CountMessagesByPeerID(ctx context.Context, peerUserID int64) (*repository.PeerMessageCount, error)
+}
+
 // PeerMatcher matches Telegram peers to CRM contacts using the identity service.
 type PeerMatcher struct {
 	identityService     identityMatcher
 	messageRepo         *repository.TelegramMessageRepository
+	messageCounter      peerMessageCounter // defaults to messageRepo; separate for testing
 	externalContactRepo externalContactUpserter
 	discoveryMinMsgs    int
 }
@@ -45,6 +51,7 @@ func NewPeerMatcher(
 	return &PeerMatcher{
 		identityService:     identityService,
 		messageRepo:         messageRepo,
+		messageCounter:      messageRepo, // default: use the same repo
 		externalContactRepo: externalContactRepo,
 		discoveryMinMsgs:    discoveryMinMsgs,
 	}
@@ -224,7 +231,7 @@ func (m *PeerMatcher) UpdateDiscoveryCandidates(ctx context.Context) error {
 // discovery threshold and upserts their external_contact if so. Used for live messages.
 // Uses a single-peer count query to avoid scanning all peers.
 func (m *PeerMatcher) UpdateDiscoveryCandidatesForPeer(ctx context.Context, peerUserID int64, peerUsername, peerFirstName, peerLastName *string) {
-	count, err := m.messageRepo.CountMessagesByPeerID(ctx, peerUserID)
+	count, err := m.messageCounter.CountMessagesByPeerID(ctx, peerUserID)
 	if err != nil {
 		log.Warn().Err(err).Int64("peer_user_id", peerUserID).Msg("telegram: failed to count messages for discovery check")
 		return

--- a/backend/internal/telegram/matcher.go
+++ b/backend/internal/telegram/matcher.go
@@ -20,9 +20,11 @@ type identityMatcher interface {
 	MatchOrCreate(ctx context.Context, req service.MatchRequest) (*service.MatchResult, error)
 }
 
-// externalContactUpserter defines the interface for upserting external contacts.
+// externalContactUpserter defines the interface for upserting/updating external contacts.
 type externalContactUpserter interface {
 	Upsert(ctx context.Context, req repository.UpsertExternalContactRequest) (*repository.ExternalContact, error)
+	GetBySource(ctx context.Context, source, sourceID string, accountID *string) (*repository.ExternalContact, error)
+	UpdateMatch(ctx context.Context, id uuid.UUID, crmContactID *uuid.UUID, status repository.MatchStatus) (*repository.ExternalContact, error)
 }
 
 // PeerMatcher matches Telegram peers to CRM contacts using the identity service.
@@ -70,6 +72,7 @@ func (m *PeerMatcher) MatchPeer(ctx context.Context, peerUserID int64, peerUsern
 			if err := m.messageRepo.UpdateMessageContact(ctx, peerUserID, *result.ContactID); err != nil {
 				log.Warn().Err(err).Int64("peer_user_id", peerUserID).Msg("telegram: failed to update message contacts")
 			}
+			m.markExternalContactMatched(ctx, peerUserID, *result.ContactID)
 			log.Info().
 				Int64("peer_user_id", peerUserID).
 				Str("contact_id", result.ContactID.String()).
@@ -95,6 +98,7 @@ func (m *PeerMatcher) MatchPeer(ctx context.Context, peerUserID int64, peerUsern
 			if err := m.messageRepo.UpdateMessageContact(ctx, peerUserID, *result.ContactID); err != nil {
 				log.Warn().Err(err).Int64("peer_user_id", peerUserID).Msg("telegram: failed to update message contacts")
 			}
+			m.markExternalContactMatched(ctx, peerUserID, *result.ContactID)
 
 			// Link telegram identity to this contact (so future matches use username cache)
 			if peerUsername != nil && *peerUsername != "" {
@@ -282,6 +286,21 @@ func (m *PeerMatcher) OnPeerLinked(ctx context.Context, peerUserID int64, peerUs
 		Str("contact_id", contactID.String()).
 		Msg("telegram: peer linked via import, messages updated")
 	return nil
+}
+
+// markExternalContactMatched updates any existing external_contact for this peer to "matched" status.
+func (m *PeerMatcher) markExternalContactMatched(ctx context.Context, peerUserID int64, contactID uuid.UUID) {
+	sourceID := strconv.FormatInt(peerUserID, 10)
+	existing, err := m.externalContactRepo.GetBySource(ctx, "telegram", sourceID, nil)
+	if err != nil || existing == nil {
+		return // no existing candidate, nothing to update
+	}
+	if existing.MatchStatus == repository.MatchStatusMatched || existing.MatchStatus == repository.MatchStatusImported {
+		return // already marked
+	}
+	if _, err := m.externalContactRepo.UpdateMatch(ctx, existing.ID, &contactID, repository.MatchStatusMatched); err != nil {
+		log.Warn().Err(err).Int64("peer_user_id", peerUserID).Msg("telegram: failed to mark external contact as matched")
+	}
 }
 
 func buildDisplayName(firstName, lastName *string) *string {

--- a/backend/internal/telegram/matcher.go
+++ b/backend/internal/telegram/matcher.go
@@ -1,0 +1,259 @@
+package telegram
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"personal-crm/backend/internal/identity"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+)
+
+// identityMatcher defines the interface for matching identifiers to contacts.
+// Satisfied by *service.IdentityService.
+type identityMatcher interface {
+	MatchOrCreate(ctx context.Context, req service.MatchRequest) (*service.MatchResult, error)
+}
+
+// externalContactUpserter defines the interface for upserting external contacts.
+type externalContactUpserter interface {
+	Upsert(ctx context.Context, req repository.UpsertExternalContactRequest) (*repository.ExternalContact, error)
+}
+
+// PeerMatcher matches Telegram peers to CRM contacts using the identity service.
+type PeerMatcher struct {
+	identityService     identityMatcher
+	messageRepo         *repository.TelegramMessageRepository
+	externalContactRepo externalContactUpserter
+	discoveryMinMsgs    int
+}
+
+// NewPeerMatcher creates a new peer matcher.
+func NewPeerMatcher(
+	identityService identityMatcher,
+	messageRepo *repository.TelegramMessageRepository,
+	externalContactRepo externalContactUpserter,
+	discoveryMinMsgs int,
+) *PeerMatcher {
+	return &PeerMatcher{
+		identityService:     identityService,
+		messageRepo:         messageRepo,
+		externalContactRepo: externalContactRepo,
+		discoveryMinMsgs:    discoveryMinMsgs,
+	}
+}
+
+// MatchPeer attempts to match a Telegram peer to a CRM contact.
+// Returns the matched contact ID or nil if unmatched.
+func (m *PeerMatcher) MatchPeer(ctx context.Context, peerUserID int64, peerUsername, peerFirstName, peerLastName, peerPhone *string) (*uuid.UUID, error) {
+	peerIDStr := strconv.FormatInt(peerUserID, 10)
+	displayName := buildDisplayName(peerFirstName, peerLastName)
+
+	// 1. Try username match
+	if peerUsername != nil && *peerUsername != "" {
+		result, err := m.identityService.MatchOrCreate(ctx, service.MatchRequest{
+			RawIdentifier: *peerUsername,
+			Type:          identity.IdentifierTypeTelegram,
+			Source:        "telegram",
+			SourceID:      &peerIDStr,
+			DisplayName:   displayName,
+		})
+		if err != nil {
+			log.Warn().Err(err).Str("username", *peerUsername).Msg("telegram: failed to match username")
+		} else if result.ContactID != nil {
+			// Matched via username
+			if err := m.messageRepo.UpdateMessageContact(ctx, peerUserID, *result.ContactID); err != nil {
+				log.Warn().Err(err).Int64("peer_user_id", peerUserID).Msg("telegram: failed to update message contacts")
+			}
+			log.Info().
+				Int64("peer_user_id", peerUserID).
+				Str("contact_id", result.ContactID.String()).
+				Str("match_type", string(result.MatchType)).
+				Msg("telegram: peer matched via username")
+			return result.ContactID, nil
+		}
+	}
+
+	// 2. Try phone match
+	if peerPhone != nil && *peerPhone != "" {
+		result, err := m.identityService.MatchOrCreate(ctx, service.MatchRequest{
+			RawIdentifier: *peerPhone,
+			Type:          identity.IdentifierTypePhone,
+			Source:        "telegram",
+			SourceID:      &peerIDStr,
+			DisplayName:   displayName,
+		})
+		if err != nil {
+			log.Warn().Err(err).Str("phone", *peerPhone).Msg("telegram: failed to match phone")
+		} else if result.ContactID != nil {
+			// Matched via phone — also link the telegram identity
+			if err := m.messageRepo.UpdateMessageContact(ctx, peerUserID, *result.ContactID); err != nil {
+				log.Warn().Err(err).Int64("peer_user_id", peerUserID).Msg("telegram: failed to update message contacts")
+			}
+
+			// Link telegram identity to this contact (so future matches use username cache)
+			if peerUsername != nil && *peerUsername != "" {
+				_, linkErr := m.identityService.MatchOrCreate(ctx, service.MatchRequest{
+					RawIdentifier:  *peerUsername,
+					Type:           identity.IdentifierTypeTelegram,
+					Source:         "telegram",
+					SourceID:       &peerIDStr,
+					DisplayName:    displayName,
+					KnownContactID: result.ContactID,
+				})
+				if linkErr != nil {
+					log.Warn().Err(linkErr).Msg("telegram: failed to link telegram identity after phone match")
+				}
+			}
+
+			log.Info().
+				Int64("peer_user_id", peerUserID).
+				Str("contact_id", result.ContactID.String()).
+				Msg("telegram: peer matched via phone")
+			return result.ContactID, nil
+		}
+	}
+
+	// 3. Unmatched — external_identity was already created by MatchOrCreate
+	log.Debug().Int64("peer_user_id", peerUserID).Msg("telegram: peer unmatched")
+	return nil, nil
+}
+
+// MatchAllUnmatched runs identity matching for all distinct unmatched peers.
+func (m *PeerMatcher) MatchAllUnmatched(ctx context.Context) error {
+	peers, err := m.messageRepo.ListDistinctUnmatchedPeers(ctx)
+	if err != nil {
+		return fmt.Errorf("list unmatched peers: %w", err)
+	}
+
+	matched, unmatched := 0, 0
+	for _, peer := range peers {
+		contactID, err := m.MatchPeer(ctx, peer.PeerUserID, peer.PeerUsername, peer.PeerFirstName, peer.PeerLastName, peer.PeerPhone)
+		if err != nil {
+			log.Warn().Err(err).Int64("peer_user_id", peer.PeerUserID).Msg("telegram: batch match failed for peer")
+			continue
+		}
+		if contactID != nil {
+			matched++
+		} else {
+			unmatched++
+		}
+	}
+
+	log.Info().Int("matched", matched).Int("unmatched", unmatched).Int("total", len(peers)).Msg("telegram: batch identity matching complete")
+	return nil
+}
+
+// UpdateDiscoveryCandidates upserts external_contact rows for qualifying unmatched peers.
+func (m *PeerMatcher) UpdateDiscoveryCandidates(ctx context.Context) error {
+	counts, err := m.messageRepo.CountMessagesByPeer(ctx)
+	if err != nil {
+		return fmt.Errorf("count messages by peer: %w", err)
+	}
+
+	// Build a map of peer info for display names
+	peers, err := m.messageRepo.ListDistinctUnmatchedPeers(ctx)
+	if err != nil {
+		return fmt.Errorf("list unmatched peers for discovery: %w", err)
+	}
+	peerMap := make(map[int64]repository.UnmatchedPeer, len(peers))
+	for _, p := range peers {
+		peerMap[p.PeerUserID] = p
+	}
+
+	created := 0
+	for _, count := range counts {
+		if count.TotalCount < int64(m.discoveryMinMsgs) {
+			continue
+		}
+
+		// Only upsert for unmatched peers
+		peer, ok := peerMap[count.PeerUserID]
+		if !ok {
+			continue // peer was matched, skip
+		}
+
+		displayName := buildDisplayName(peer.PeerFirstName, peer.PeerLastName)
+		sourceID := strconv.FormatInt(count.PeerUserID, 10)
+
+		metadata := map[string]any{
+			"message_count":  count.TotalCount,
+			"outbound_count": count.OutboundCount,
+			"inbound_count":  count.InboundCount,
+		}
+		if !count.LastMessageAt.IsZero() {
+			metadata["last_message_at"] = count.LastMessageAt.Format("2006-01-02T15:04:05Z")
+		}
+		if peer.PeerUsername != nil {
+			metadata["username"] = "@" + *peer.PeerUsername
+		}
+
+		_, err := m.externalContactRepo.Upsert(ctx, repository.UpsertExternalContactRequest{
+			Source:      "telegram",
+			SourceID:    sourceID,
+			DisplayName: displayName,
+			FirstName:   peer.PeerFirstName,
+			LastName:    peer.PeerLastName,
+			Metadata:    metadata,
+		})
+		if err != nil {
+			log.Warn().Err(err).Int64("peer_user_id", count.PeerUserID).Msg("telegram: failed to upsert discovery candidate")
+			continue
+		}
+		created++
+	}
+
+	log.Info().Int("candidates", created).Msg("telegram: discovery candidates updated")
+	return nil
+}
+
+// OnPeerLinked is called after a Telegram import/link to back-fill message matching.
+// It links the identity, updates matched_contact_id on messages, and returns true
+// to signal that aggregation should run.
+func (m *PeerMatcher) OnPeerLinked(ctx context.Context, peerUserID int64, peerUsername string, contactID uuid.UUID) error {
+	// 1. Link the telegram identity to this contact
+	if peerUsername != "" {
+		peerIDStr := strconv.FormatInt(peerUserID, 10)
+		_, err := m.identityService.MatchOrCreate(ctx, service.MatchRequest{
+			RawIdentifier:  peerUsername,
+			Type:           identity.IdentifierTypeTelegram,
+			Source:         "telegram",
+			SourceID:       &peerIDStr,
+			KnownContactID: &contactID,
+		})
+		if err != nil {
+			log.Warn().Err(err).Msg("telegram: failed to link identity on import")
+		}
+	}
+
+	// 2. Update matched_contact_id on all messages for this peer
+	if err := m.messageRepo.UpdateMessageContact(ctx, peerUserID, contactID); err != nil {
+		return fmt.Errorf("update message contacts on import: %w", err)
+	}
+
+	log.Info().
+		Int64("peer_user_id", peerUserID).
+		Str("contact_id", contactID.String()).
+		Msg("telegram: peer linked via import, messages updated")
+	return nil
+}
+
+func buildDisplayName(firstName, lastName *string) *string {
+	var parts []string
+	if firstName != nil && *firstName != "" {
+		parts = append(parts, *firstName)
+	}
+	if lastName != nil && *lastName != "" {
+		parts = append(parts, *lastName)
+	}
+	if len(parts) == 0 {
+		return nil
+	}
+	name := strings.Join(parts, " ")
+	return &name
+}

--- a/backend/internal/telegram/matcher.go
+++ b/backend/internal/telegram/matcher.go
@@ -281,8 +281,10 @@ func (m *PeerMatcher) OnPeerLinked(ctx context.Context, peerUserID int64, peerUs
 	}
 
 	// 2. Update matched_contact_id on all messages for this peer
-	if err := m.messageRepo.UpdateMessageContact(ctx, peerUserID, contactID); err != nil {
-		return fmt.Errorf("update message contacts on import: %w", err)
+	if m.messageRepo != nil {
+		if err := m.messageRepo.UpdateMessageContact(ctx, peerUserID, contactID); err != nil {
+			return fmt.Errorf("update message contacts on import: %w", err)
+		}
 	}
 
 	log.Info().

--- a/backend/internal/telegram/matcher.go
+++ b/backend/internal/telegram/matcher.go
@@ -214,47 +214,42 @@ func (m *PeerMatcher) UpdateDiscoveryCandidates(ctx context.Context) error {
 
 // UpdateDiscoveryCandidatesForPeer checks if a specific unmatched peer has crossed the
 // discovery threshold and upserts their external_contact if so. Used for live messages.
+// Uses a single-peer count query to avoid scanning all peers.
 func (m *PeerMatcher) UpdateDiscoveryCandidatesForPeer(ctx context.Context, peerUserID int64, peerUsername, peerFirstName, peerLastName *string) {
-	counts, err := m.messageRepo.CountMessagesByPeer(ctx)
+	count, err := m.messageRepo.CountMessagesByPeerID(ctx, peerUserID)
 	if err != nil {
-		log.Warn().Err(err).Msg("telegram: failed to count messages for discovery check")
+		log.Warn().Err(err).Int64("peer_user_id", peerUserID).Msg("telegram: failed to count messages for discovery check")
 		return
 	}
 
-	for _, count := range counts {
-		if count.PeerUserID != peerUserID {
-			continue
-		}
-		if count.TotalCount < int64(m.discoveryMinMsgs) {
-			return // below threshold
-		}
+	if count.TotalCount < int64(m.discoveryMinMsgs) {
+		return // below threshold
+	}
 
-		displayName := buildDisplayName(peerFirstName, peerLastName)
-		sourceID := strconv.FormatInt(peerUserID, 10)
+	displayName := buildDisplayName(peerFirstName, peerLastName)
+	sourceID := strconv.FormatInt(peerUserID, 10)
 
-		metadata := map[string]any{
-			"message_count":  count.TotalCount,
-			"outbound_count": count.OutboundCount,
-			"inbound_count":  count.InboundCount,
-		}
-		if !count.LastMessageAt.IsZero() {
-			metadata["last_message_at"] = count.LastMessageAt.Format("2006-01-02T15:04:05Z")
-		}
-		if peerUsername != nil {
-			metadata["username"] = "@" + *peerUsername
-		}
+	metadata := map[string]any{
+		"message_count":  count.TotalCount,
+		"outbound_count": count.OutboundCount,
+		"inbound_count":  count.InboundCount,
+	}
+	if !count.LastMessageAt.IsZero() {
+		metadata["last_message_at"] = count.LastMessageAt.Format("2006-01-02T15:04:05Z")
+	}
+	if peerUsername != nil {
+		metadata["username"] = "@" + *peerUsername
+	}
 
-		if _, err := m.externalContactRepo.Upsert(ctx, repository.UpsertExternalContactRequest{
-			Source:      "telegram",
-			SourceID:    sourceID,
-			DisplayName: displayName,
-			FirstName:   peerFirstName,
-			LastName:    peerLastName,
-			Metadata:    metadata,
-		}); err != nil {
-			log.Warn().Err(err).Int64("peer_user_id", peerUserID).Msg("telegram: failed to upsert discovery candidate for live peer")
-		}
-		return
+	if _, err := m.externalContactRepo.Upsert(ctx, repository.UpsertExternalContactRequest{
+		Source:      "telegram",
+		SourceID:    sourceID,
+		DisplayName: displayName,
+		FirstName:   peerFirstName,
+		LastName:    peerLastName,
+		Metadata:    metadata,
+	}); err != nil {
+		log.Warn().Err(err).Int64("peer_user_id", peerUserID).Msg("telegram: failed to upsert discovery candidate for live peer")
 	}
 }
 

--- a/backend/internal/telegram/matcher_test.go
+++ b/backend/internal/telegram/matcher_test.go
@@ -27,9 +27,16 @@ func (m *mockIdentityMatcher) MatchOrCreate(_ context.Context, req service.Match
 	return &service.MatchResult{MatchType: repository.MatchTypeUnmatched}, nil
 }
 
+type updateMatchCall struct {
+	id        uuid.UUID
+	contactID *uuid.UUID
+	status    repository.MatchStatus
+}
+
 type mockExternalContactUpserter struct {
-	upsertCalls []repository.UpsertExternalContactRequest
-	getResult   *repository.ExternalContact
+	upsertCalls      []repository.UpsertExternalContactRequest
+	getResult        *repository.ExternalContact
+	updateMatchCalls []updateMatchCall
 }
 
 func (m *mockExternalContactUpserter) Upsert(_ context.Context, req repository.UpsertExternalContactRequest) (*repository.ExternalContact, error) {
@@ -41,7 +48,8 @@ func (m *mockExternalContactUpserter) GetBySource(_ context.Context, _, _ string
 	return m.getResult, nil
 }
 
-func (m *mockExternalContactUpserter) UpdateMatch(_ context.Context, _ uuid.UUID, _ *uuid.UUID, _ repository.MatchStatus) (*repository.ExternalContact, error) {
+func (m *mockExternalContactUpserter) UpdateMatch(_ context.Context, id uuid.UUID, contactID *uuid.UUID, status repository.MatchStatus) (*repository.ExternalContact, error) {
+	m.updateMatchCalls = append(m.updateMatchCalls, updateMatchCall{id: id, contactID: contactID, status: status})
 	return nil, nil
 }
 
@@ -194,6 +202,82 @@ func TestMatchPeer_NilUsernameAndPhone(t *testing.T) {
 	assert.Nil(t, result)
 	// No calls — nothing to match on
 	assert.Empty(t, identityMock.calls)
+}
+
+func TestOnPeerLinked_WithUsername(t *testing.T) {
+	contactID := uuid.New()
+	identityMock := &mockIdentityMatcher{
+		results: map[string]*service.MatchResult{},
+	}
+	matcher := &PeerMatcher{
+		identityService:     identityMock,
+		externalContactRepo: &mockExternalContactUpserter{},
+		discoveryMinMsgs:    3,
+	}
+
+	err := matcher.OnPeerLinked(context.Background(), 12345, "alice", contactID)
+	require.NoError(t, err)
+
+	// Should call MatchOrCreate with KnownContactID to link identity
+	require.Len(t, identityMock.calls, 1)
+	assert.Equal(t, "alice", identityMock.calls[0].RawIdentifier)
+	assert.NotNil(t, identityMock.calls[0].KnownContactID)
+	assert.Equal(t, contactID, *identityMock.calls[0].KnownContactID)
+}
+
+func TestOnPeerLinked_WithoutUsername(t *testing.T) {
+	contactID := uuid.New()
+	identityMock := &mockIdentityMatcher{
+		results: map[string]*service.MatchResult{},
+	}
+	matcher := &PeerMatcher{
+		identityService:     identityMock,
+		externalContactRepo: &mockExternalContactUpserter{},
+		discoveryMinMsgs:    3,
+	}
+
+	err := matcher.OnPeerLinked(context.Background(), 12345, "", contactID)
+	require.NoError(t, err)
+
+	// No MatchOrCreate call when username is empty
+	assert.Empty(t, identityMock.calls)
+}
+
+func TestMarkExternalContactMatched_AlreadyMatched(t *testing.T) {
+	contactID := uuid.New()
+	ecMock := &mockExternalContactUpserter{
+		getResult: &repository.ExternalContact{
+			ID:          uuid.New(),
+			MatchStatus: repository.MatchStatusMatched,
+		},
+	}
+	matcher := &PeerMatcher{
+		externalContactRepo: ecMock,
+	}
+
+	// Should not upsert — already matched
+	matcher.markExternalContactMatched(context.Background(), 12345, contactID)
+	assert.Empty(t, ecMock.upsertCalls)
+}
+
+func TestMarkExternalContactMatched_Unmatched(t *testing.T) {
+	contactID := uuid.New()
+	ecID := uuid.New()
+	ecMock := &mockExternalContactUpserter{
+		getResult: &repository.ExternalContact{
+			ID:          ecID,
+			MatchStatus: repository.MatchStatusUnmatched,
+		},
+		updateMatchCalls: make([]updateMatchCall, 0),
+	}
+	matcher := &PeerMatcher{
+		externalContactRepo: ecMock,
+	}
+
+	matcher.markExternalContactMatched(context.Background(), 12345, contactID)
+	require.Len(t, ecMock.updateMatchCalls, 1)
+	assert.Equal(t, ecID, ecMock.updateMatchCalls[0].id)
+	assert.Equal(t, contactID, *ecMock.updateMatchCalls[0].contactID)
 }
 
 func ptr(s string) *string { return &s }

--- a/backend/internal/telegram/matcher_test.go
+++ b/backend/internal/telegram/matcher_test.go
@@ -280,4 +280,51 @@ func TestMarkExternalContactMatched_Unmatched(t *testing.T) {
 	assert.Equal(t, contactID, *ecMock.updateMatchCalls[0].contactID)
 }
 
+// --- Mock message counter ---
+
+type mockMessageCounter struct {
+	counts map[int64]*repository.PeerMessageCount
+}
+
+func (m *mockMessageCounter) CountMessagesByPeerID(_ context.Context, peerUserID int64) (*repository.PeerMessageCount, error) {
+	if count, ok := m.counts[peerUserID]; ok {
+		return count, nil
+	}
+	return &repository.PeerMessageCount{PeerUserID: peerUserID}, nil
+}
+
+func TestUpdateDiscoveryCandidatesForPeer_BelowThreshold(t *testing.T) {
+	ecMock := &mockExternalContactUpserter{}
+	matcher := &PeerMatcher{
+		messageCounter:      &mockMessageCounter{counts: map[int64]*repository.PeerMessageCount{12345: {TotalCount: 2}}},
+		externalContactRepo: ecMock,
+		discoveryMinMsgs:    3,
+	}
+
+	matcher.UpdateDiscoveryCandidatesForPeer(context.Background(), 12345, ptr("alice"), ptr("Alice"), nil)
+
+	// Below threshold — no upsert
+	assert.Empty(t, ecMock.upsertCalls)
+}
+
+func TestUpdateDiscoveryCandidatesForPeer_AtThreshold(t *testing.T) {
+	ecMock := &mockExternalContactUpserter{}
+	matcher := &PeerMatcher{
+		messageCounter: &mockMessageCounter{counts: map[int64]*repository.PeerMessageCount{
+			12345: {TotalCount: 3, OutboundCount: 1, InboundCount: 2},
+		}},
+		externalContactRepo: ecMock,
+		discoveryMinMsgs:    3,
+	}
+
+	matcher.UpdateDiscoveryCandidatesForPeer(context.Background(), 12345, ptr("alice"), ptr("Alice"), nil)
+
+	// At threshold — should upsert
+	require.Len(t, ecMock.upsertCalls, 1)
+	assert.Equal(t, "telegram", ecMock.upsertCalls[0].Source)
+	assert.Equal(t, "12345", ecMock.upsertCalls[0].SourceID)
+	assert.Equal(t, int64(3), ecMock.upsertCalls[0].Metadata["message_count"])
+	assert.Equal(t, "@alice", ecMock.upsertCalls[0].Metadata["username"])
+}
+
 func ptr(s string) *string { return &s }

--- a/backend/internal/telegram/matcher_test.go
+++ b/backend/internal/telegram/matcher_test.go
@@ -1,10 +1,51 @@
 package telegram
 
 import (
+	"context"
 	"testing"
 
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// --- Mocks ---
+
+type mockIdentityMatcher struct {
+	calls   []service.MatchRequest
+	results map[string]*service.MatchResult // keyed by RawIdentifier
+}
+
+func (m *mockIdentityMatcher) MatchOrCreate(_ context.Context, req service.MatchRequest) (*service.MatchResult, error) {
+	m.calls = append(m.calls, req)
+	if result, ok := m.results[req.RawIdentifier]; ok {
+		return result, nil
+	}
+	return &service.MatchResult{MatchType: repository.MatchTypeUnmatched}, nil
+}
+
+type mockExternalContactUpserter struct {
+	upsertCalls []repository.UpsertExternalContactRequest
+	getResult   *repository.ExternalContact
+}
+
+func (m *mockExternalContactUpserter) Upsert(_ context.Context, req repository.UpsertExternalContactRequest) (*repository.ExternalContact, error) {
+	m.upsertCalls = append(m.upsertCalls, req)
+	return &repository.ExternalContact{ID: uuid.New(), Source: req.Source, SourceID: req.SourceID}, nil
+}
+
+func (m *mockExternalContactUpserter) GetBySource(_ context.Context, _, _ string, _ *string) (*repository.ExternalContact, error) {
+	return m.getResult, nil
+}
+
+func (m *mockExternalContactUpserter) UpdateMatch(_ context.Context, _ uuid.UUID, _ *uuid.UUID, _ repository.MatchStatus) (*repository.ExternalContact, error) {
+	return nil, nil
+}
+
+// --- Tests ---
 
 func TestBuildDisplayName(t *testing.T) {
 	tests := []struct {
@@ -31,6 +72,128 @@ func TestBuildDisplayName(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMatchPeer_UsernameMatch(t *testing.T) {
+	contactID := uuid.New()
+	identityMock := &mockIdentityMatcher{
+		results: map[string]*service.MatchResult{
+			"alice": {ContactID: &contactID, MatchType: repository.MatchTypeExact},
+		},
+	}
+	// Use a nil messageRepo — MatchPeer will call UpdateMessageContact which needs it,
+	// but we're testing the matching logic flow, not the DB update.
+	// For a full test, use integration tests.
+	matcher := &PeerMatcher{
+		identityService:     identityMock,
+		externalContactRepo: &mockExternalContactUpserter{},
+		discoveryMinMsgs:    3,
+	}
+
+	username := "alice"
+	result, err := matcher.MatchPeer(context.Background(), 12345, &username, ptr("Alice"), nil, nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, contactID, *result)
+	// Should have called MatchOrCreate with telegram type
+	require.Len(t, identityMock.calls, 1)
+	assert.Equal(t, "alice", identityMock.calls[0].RawIdentifier)
+	assert.Equal(t, "telegram", string(identityMock.calls[0].Type))
+}
+
+func TestMatchPeer_PhoneFallback(t *testing.T) {
+	contactID := uuid.New()
+	identityMock := &mockIdentityMatcher{
+		results: map[string]*service.MatchResult{
+			// Username doesn't match
+			"bob": {MatchType: repository.MatchTypeUnmatched},
+			// Phone matches
+			"+15551234567": {ContactID: &contactID, MatchType: repository.MatchTypeExact},
+		},
+	}
+	matcher := &PeerMatcher{
+		identityService:     identityMock,
+		externalContactRepo: &mockExternalContactUpserter{},
+		discoveryMinMsgs:    3,
+	}
+
+	username := "bob"
+	phone := "+15551234567"
+	result, err := matcher.MatchPeer(context.Background(), 12345, &username, ptr("Bob"), nil, &phone)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, contactID, *result)
+	// Should have tried username first, then phone, then linked telegram identity
+	require.Len(t, identityMock.calls, 3)
+	assert.Equal(t, "telegram", string(identityMock.calls[0].Type)) // username attempt
+	assert.Equal(t, "phone", string(identityMock.calls[1].Type))    // phone match
+	assert.Equal(t, "telegram", string(identityMock.calls[2].Type)) // link telegram identity
+	assert.NotNil(t, identityMock.calls[2].KnownContactID)          // with KnownContactID
+}
+
+func TestMatchPeer_UsernamePriority(t *testing.T) {
+	contactA := uuid.New()
+	contactB := uuid.New()
+	identityMock := &mockIdentityMatcher{
+		results: map[string]*service.MatchResult{
+			"charlie":      {ContactID: &contactA, MatchType: repository.MatchTypeExact},
+			"+15559876543": {ContactID: &contactB, MatchType: repository.MatchTypeExact},
+		},
+	}
+	matcher := &PeerMatcher{
+		identityService:     identityMock,
+		externalContactRepo: &mockExternalContactUpserter{},
+		discoveryMinMsgs:    3,
+	}
+
+	username := "charlie"
+	phone := "+15559876543"
+	result, err := matcher.MatchPeer(context.Background(), 12345, &username, ptr("Charlie"), nil, &phone)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, contactA, *result) // username match wins
+	// Should only have tried username (short-circuits on match)
+	require.Len(t, identityMock.calls, 1)
+}
+
+func TestMatchPeer_Unmatched(t *testing.T) {
+	identityMock := &mockIdentityMatcher{
+		results: map[string]*service.MatchResult{},
+	}
+	matcher := &PeerMatcher{
+		identityService:     identityMock,
+		externalContactRepo: &mockExternalContactUpserter{},
+		discoveryMinMsgs:    3,
+	}
+
+	username := "nobody"
+	result, err := matcher.MatchPeer(context.Background(), 12345, &username, ptr("Nobody"), nil, nil)
+
+	require.NoError(t, err)
+	assert.Nil(t, result) // no match
+	// Should have tried username
+	require.Len(t, identityMock.calls, 1)
+}
+
+func TestMatchPeer_NilUsernameAndPhone(t *testing.T) {
+	identityMock := &mockIdentityMatcher{
+		results: map[string]*service.MatchResult{},
+	}
+	matcher := &PeerMatcher{
+		identityService:     identityMock,
+		externalContactRepo: &mockExternalContactUpserter{},
+		discoveryMinMsgs:    3,
+	}
+
+	result, err := matcher.MatchPeer(context.Background(), 12345, nil, nil, nil, nil)
+
+	require.NoError(t, err)
+	assert.Nil(t, result)
+	// No calls — nothing to match on
+	assert.Empty(t, identityMock.calls)
 }
 
 func ptr(s string) *string { return &s }

--- a/backend/internal/telegram/matcher_test.go
+++ b/backend/internal/telegram/matcher_test.go
@@ -250,14 +250,15 @@ func TestMarkExternalContactMatched_AlreadyMatched(t *testing.T) {
 			ID:          uuid.New(),
 			MatchStatus: repository.MatchStatusMatched,
 		},
+		updateMatchCalls: make([]updateMatchCall, 0),
 	}
 	matcher := &PeerMatcher{
 		externalContactRepo: ecMock,
 	}
 
-	// Should not upsert — already matched
+	// Should not call UpdateMatch — already matched
 	matcher.markExternalContactMatched(context.Background(), 12345, contactID)
-	assert.Empty(t, ecMock.upsertCalls)
+	assert.Empty(t, ecMock.updateMatchCalls)
 }
 
 func TestMarkExternalContactMatched_Unmatched(t *testing.T) {

--- a/backend/internal/telegram/matcher_test.go
+++ b/backend/internal/telegram/matcher_test.go
@@ -1,0 +1,36 @@
+package telegram
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildDisplayName(t *testing.T) {
+	tests := []struct {
+		name      string
+		firstName *string
+		lastName  *string
+		want      *string
+	}{
+		{"both names", ptr("John"), ptr("Doe"), ptr("John Doe")},
+		{"first only", ptr("John"), nil, ptr("John")},
+		{"last only", nil, ptr("Doe"), ptr("Doe")},
+		{"neither", nil, nil, nil},
+		{"empty first", ptr(""), nil, nil},
+		{"empty both", ptr(""), ptr(""), nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildDisplayName(tt.firstName, tt.lastName)
+			if tt.want == nil {
+				assert.Nil(t, got)
+			} else {
+				assert.Equal(t, *tt.want, *got)
+			}
+		})
+	}
+}
+
+func ptr(s string) *string { return &s }

--- a/backend/tests/api/telegram_chat_api_test.go
+++ b/backend/tests/api/telegram_chat_api_test.go
@@ -15,6 +15,7 @@ import (
 	"personal-crm/backend/internal/crypto"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
 	tgpkg "personal-crm/backend/internal/telegram"
 
 	"github.com/gin-gonic/gin"
@@ -62,9 +63,22 @@ func setupTelegramChatRouter(t *testing.T) (*gin.Engine, *repository.TelegramCha
 	require.NoError(t, err)
 
 	telegramCfg := &config.TelegramConfig{
-		GroupMaxMembers: 10,
-		BackfillSince:   "2026-01-01",
+		GroupMaxMembers:      10,
+		BackfillSince:        "2026-01-01",
+		BurstWindowHours:     2,
+		ReplyBridgeHours:     48,
+		DiscoveryMinMessages: 3,
 	}
+
+	// Phase 4 dependencies (nil for chat API tests — not exercised)
+	identityRepo := repository.NewIdentityRepository(database.Queries)
+	identityService := service.NewIdentityService(identityRepo)
+	externalContactRepo := repository.NewExternalContactRepository(database.Queries)
+	interactionRepo := repository.NewInteractionRepository(database.Queries)
+	contactRepo := repository.NewContactRepository(database.Queries)
+	contactMethodRepo := repository.NewContactMethodRepository(database.Queries)
+	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
+	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo)
 
 	manager := tgpkg.NewTelegramManager(
 		sessionRepo,
@@ -76,6 +90,12 @@ func setupTelegramChatRouter(t *testing.T) (*gin.Engine, *repository.TelegramCha
 		12345,
 		"testhash",
 		telegramCfg,
+		identityService,
+		externalContactRepo,
+		interactionRepo,
+		contactService,
+		contactService,
+		contactService,
 	)
 
 	handler := handlers.NewTelegramHandler(manager)

--- a/backend/tests/telegram_aggregation_test.go
+++ b/backend/tests/telegram_aggregation_test.go
@@ -23,9 +23,9 @@ func cleanupAggregationMessages(t *testing.T, database *db.Database) {
 	t.Helper()
 	ctx := context.Background()
 	// Hard delete test messages (unique message IDs for this test suite)
-	_, _ = database.Pool.Exec(ctx, "DELETE FROM telegram_message WHERE telegram_message_id IN (80001, 80002, 80003, 80011, 80012, 80013, 80021, 80022, 80031, 80032)")
+	_, _ = database.Pool.Exec(ctx, "DELETE FROM telegram_message WHERE telegram_message_id IN (80001, 80002, 80003, 80011, 80012, 80013, 80021, 80022, 80031, 80032, 80041, 80042, 80051, 80052)")
 	// Hard delete interactions with source_ref matching test chat IDs
-	_, _ = database.Pool.Exec(ctx, "DELETE FROM interaction WHERE source_ref LIKE 'tg:100:%' OR source_ref LIKE 'tg:101:%' OR source_ref LIKE 'tg:102:%' OR source_ref LIKE 'tg:201:%' OR source_ref LIKE 'tg:202:%'")
+	_, _ = database.Pool.Exec(ctx, "DELETE FROM interaction WHERE source_ref LIKE 'tg:100:%' OR source_ref LIKE 'tg:101:%' OR source_ref LIKE 'tg:102:%' OR source_ref LIKE 'tg:201:%' OR source_ref LIKE 'tg:202:%' OR source_ref LIKE 'tg:301:%' OR source_ref LIKE 'tg:302:%'")
 }
 
 func setupAggregationTest(t *testing.T) (
@@ -206,4 +206,67 @@ func TestAggregation_ChatScoped(t *testing.T) {
 	interactions, err := interactionRepo.ListContactInteractions(ctx, contact.ID, 100, 0)
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, len(interactions), 2) // at least 2 (one per chat)
+}
+
+func TestAggregation_IncrementalCoalescing(t *testing.T) {
+	messageRepo, interactionRepo, contactRepo, _, engine, _ := setupAggregationTest(t)
+	ctx := context.Background()
+
+	contact := createTestContact(t, contactRepo, "Aggregation Incremental Coalesce")
+	t.Cleanup(func() {
+		_ = contactRepo.SoftDeleteContact(ctx, contact.ID)
+	})
+
+	base := accelerated.GetCurrentTime().Add(-30 * time.Minute).Truncate(time.Microsecond)
+
+	// First outbound message → creates interaction
+	insertTestMessage(t, messageRepo, 80041, 301, true, base, &contact.ID, 70005)
+	err := engine.AggregateForContact(ctx, contact.ID, 301)
+	require.NoError(t, err)
+
+	interactions, err := interactionRepo.ListContactInteractions(ctx, contact.ID, 100, 0)
+	require.NoError(t, err)
+	require.Len(t, interactions, 1)
+	assert.Equal(t, "outbound", interactions[0].Direction)
+
+	// Second outbound message within burst window → should coalesce (extend), not create new
+	insertTestMessage(t, messageRepo, 80042, 301, true, base.Add(10*time.Minute), &contact.ID, 70005)
+	err = engine.AggregateForContact(ctx, contact.ID, 301)
+	require.NoError(t, err)
+
+	interactions, err = interactionRepo.ListContactInteractions(ctx, contact.ID, 100, 0)
+	require.NoError(t, err)
+	assert.Len(t, interactions, 1) // still just 1 interaction (coalesced)
+}
+
+func TestAggregation_IncrementalReplyBridge(t *testing.T) {
+	messageRepo, interactionRepo, contactRepo, _, engine, _ := setupAggregationTest(t)
+	ctx := context.Background()
+
+	contact := createTestContact(t, contactRepo, "Aggregation Incremental Bridge")
+	t.Cleanup(func() {
+		_ = contactRepo.SoftDeleteContact(ctx, contact.ID)
+	})
+
+	base := accelerated.GetCurrentTime().Add(-2 * time.Hour).Truncate(time.Microsecond)
+
+	// Create outbound interaction first
+	insertTestMessage(t, messageRepo, 80051, 302, true, base, &contact.ID, 70006)
+	err := engine.AggregateForContact(ctx, contact.ID, 302)
+	require.NoError(t, err)
+
+	interactions, err := interactionRepo.ListContactInteractions(ctx, contact.ID, 100, 0)
+	require.NoError(t, err)
+	require.Len(t, interactions, 1)
+	assert.Equal(t, "outbound", interactions[0].Direction)
+
+	// Inbound reply within 48h → should promote to mutual
+	insertTestMessage(t, messageRepo, 80052, 302, false, base.Add(30*time.Minute), &contact.ID, 70006)
+	err = engine.AggregateForContact(ctx, contact.ID, 302)
+	require.NoError(t, err)
+
+	interactions, err = interactionRepo.ListContactInteractions(ctx, contact.ID, 100, 0)
+	require.NoError(t, err)
+	require.Len(t, interactions, 1) // still 1, promoted
+	assert.Equal(t, "mutual", interactions[0].Direction)
 }

--- a/backend/tests/telegram_aggregation_test.go
+++ b/backend/tests/telegram_aggregation_test.go
@@ -1,0 +1,209 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+	tgpkg "personal-crm/backend/internal/telegram"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// cleanupAggregationMessages hard-deletes test messages and interactions.
+func cleanupAggregationMessages(t *testing.T, database *db.Database) {
+	t.Helper()
+	ctx := context.Background()
+	// Hard delete test messages (unique message IDs for this test suite)
+	_, _ = database.Pool.Exec(ctx, "DELETE FROM telegram_message WHERE telegram_message_id IN (80001, 80002, 80003, 80011, 80012, 80013, 80021, 80022, 80031, 80032)")
+	// Hard delete interactions with source_ref matching test chat IDs
+	_, _ = database.Pool.Exec(ctx, "DELETE FROM interaction WHERE source_ref LIKE 'tg:100:%' OR source_ref LIKE 'tg:101:%' OR source_ref LIKE 'tg:102:%' OR source_ref LIKE 'tg:201:%' OR source_ref LIKE 'tg:202:%'")
+}
+
+func setupAggregationTest(t *testing.T) (
+	*repository.TelegramMessageRepository,
+	*repository.InteractionRepository,
+	*repository.ContactRepository,
+	*service.ContactService,
+	*tgpkg.AggregationEngine,
+	*db.Database,
+) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set")
+	}
+
+	err := db.RunMigrations(databaseURL, getMigrationsPath())
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	t.Cleanup(func() { database.Close() })
+
+	messageRepo := repository.NewTelegramMessageRepository(database.Queries)
+	interactionRepo := repository.NewInteractionRepository(database.Queries)
+	contactRepo := repository.NewContactRepository(database.Queries)
+	contactMethodRepo := repository.NewContactMethodRepository(database.Queries)
+	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
+	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo)
+
+	engine := tgpkg.NewAggregationEngine(
+		2, 48, // burst window 2h, reply bridge 48h
+		messageRepo, interactionRepo,
+		contactService, contactService, contactService,
+	)
+
+	// Clean up test messages from previous runs
+	cleanupAggregationMessages(t, database)
+	t.Cleanup(func() { cleanupAggregationMessages(t, database) })
+
+	return messageRepo, interactionRepo, contactRepo, contactService, engine, database
+}
+
+func createTestContact(t *testing.T, contactRepo *repository.ContactRepository, name string) *repository.Contact {
+	t.Helper()
+	contact, err := contactRepo.CreateContact(context.Background(), repository.CreateContactRequest{
+		FullName: name,
+	})
+	require.NoError(t, err)
+	return contact
+}
+
+func insertTestMessage(t *testing.T, repo *repository.TelegramMessageRepository, msgID int32, chatID int64, outgoing bool, sentAt time.Time, contactID *uuid.UUID, peerUserID int64) *repository.TelegramMessage {
+	t.Helper()
+	text := "test message"
+	msg, err := repo.UpsertMessage(context.Background(), repository.UpsertTelegramMessageParams{
+		TelegramMessageID: msgID,
+		TelegramChatID:    chatID,
+		ChatType:          "private",
+		MessageText:       &text,
+		MessageType:       "text",
+		SentAt:            sentAt,
+		IsOutgoing:        outgoing,
+		PeerUserID:        ptrInt64(peerUserID),
+	})
+	require.NoError(t, err)
+
+	if contactID != nil {
+		err = repo.UpdateMessageContact(context.Background(), peerUserID, *contactID)
+		require.NoError(t, err)
+	}
+
+	return msg
+}
+
+func TestAggregation_BatchOutboundBurst(t *testing.T) {
+	messageRepo, interactionRepo, contactRepo, _, engine, _ := setupAggregationTest(t)
+	ctx := context.Background()
+
+	contact := createTestContact(t, contactRepo, "Aggregation Test 1")
+	t.Cleanup(func() {
+		_ = contactRepo.SoftDeleteContact(ctx, contact.ID)
+	})
+
+	base := accelerated.GetCurrentTime().Add(-1 * time.Hour).Truncate(time.Microsecond)
+
+	// 3 outbound messages within 2h
+	insertTestMessage(t, messageRepo, 80001, 100, true, base, &contact.ID, 70001)
+	insertTestMessage(t, messageRepo, 80002, 100, true, base.Add(10*time.Minute), &contact.ID, 70001)
+	insertTestMessage(t, messageRepo, 80003, 100, true, base.Add(30*time.Minute), &contact.ID, 70001)
+
+	err := engine.AggregateAll(ctx)
+	require.NoError(t, err)
+
+	interactions, err := interactionRepo.ListContactInteractions(ctx, contact.ID, 100, 0)
+	require.NoError(t, err)
+	require.Len(t, interactions, 1)
+	assert.Equal(t, "outbound", interactions[0].Direction)
+	assert.Equal(t, "telegram", interactions[0].Source)
+	assert.Contains(t, *interactions[0].SourceRef, "tg:100:")
+}
+
+func TestAggregation_BatchMutualBridge(t *testing.T) {
+	messageRepo, interactionRepo, contactRepo, _, engine, _ := setupAggregationTest(t)
+	ctx := context.Background()
+
+	contact := createTestContact(t, contactRepo, "Aggregation Test 2")
+	t.Cleanup(func() {
+		_ = contactRepo.SoftDeleteContact(ctx, contact.ID)
+	})
+
+	base := accelerated.GetCurrentTime().Add(-2 * time.Hour).Truncate(time.Microsecond)
+
+	// Outbound burst, then inbound within 48h → batch resolves to mutual
+	insertTestMessage(t, messageRepo, 80011, 101, true, base, &contact.ID, 70002)
+	insertTestMessage(t, messageRepo, 80012, 101, true, base.Add(5*time.Minute), &contact.ID, 70002)
+	insertTestMessage(t, messageRepo, 80013, 101, false, base.Add(1*time.Hour), &contact.ID, 70002)
+
+	err := engine.AggregateAll(ctx)
+	require.NoError(t, err)
+
+	interactions, err := interactionRepo.ListContactInteractions(ctx, contact.ID, 100, 0)
+	require.NoError(t, err)
+	require.Len(t, interactions, 1)
+	assert.Equal(t, "mutual", interactions[0].Direction)
+}
+
+func TestAggregation_BatchNoChurnFollowUp(t *testing.T) {
+	// Batch mode should NOT create an outbound interaction first and then promote —
+	// it should directly create mutual. This test verifies by checking that exactly
+	// one interaction is created (not an outbound followed by a mutual update).
+	messageRepo, interactionRepo, contactRepo, _, engine, _ := setupAggregationTest(t)
+	ctx := context.Background()
+
+	contact := createTestContact(t, contactRepo, "Aggregation Test No Churn")
+	t.Cleanup(func() {
+		_ = contactRepo.SoftDeleteContact(ctx, contact.ID)
+	})
+
+	base := accelerated.GetCurrentTime().Add(-3 * time.Hour).Truncate(time.Microsecond)
+	insertTestMessage(t, messageRepo, 80021, 102, true, base, &contact.ID, 70003)
+	insertTestMessage(t, messageRepo, 80022, 102, false, base.Add(30*time.Minute), &contact.ID, 70003)
+
+	err := engine.AggregateAll(ctx)
+	require.NoError(t, err)
+
+	interactions, err := interactionRepo.ListContactInteractions(ctx, contact.ID, 100, 0)
+	require.NoError(t, err)
+	require.Len(t, interactions, 1)
+	assert.Equal(t, "mutual", interactions[0].Direction)
+}
+
+func TestAggregation_ChatScoped(t *testing.T) {
+	messageRepo, interactionRepo, contactRepo, _, engine, _ := setupAggregationTest(t)
+	ctx := context.Background()
+
+	contact := createTestContact(t, contactRepo, "Aggregation Chat Scoped")
+	t.Cleanup(func() {
+		_ = contactRepo.SoftDeleteContact(ctx, contact.ID)
+	})
+
+	base := accelerated.GetCurrentTime().Add(-1 * time.Hour).Truncate(time.Microsecond)
+
+	// Same contact, different chats → separate interactions
+	insertTestMessage(t, messageRepo, 80031, 201, true, base, &contact.ID, 70004)
+	insertTestMessage(t, messageRepo, 80032, 202, true, base.Add(5*time.Minute), &contact.ID, 70004)
+
+	err := engine.AggregateAll(ctx)
+	require.NoError(t, err)
+
+	interactions, err := interactionRepo.ListContactInteractions(ctx, contact.ID, 100, 0)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(interactions), 2) // at least 2 (one per chat)
+}

--- a/backend/tests/telegram_aggregation_test.go
+++ b/backend/tests/telegram_aggregation_test.go
@@ -23,9 +23,9 @@ func cleanupAggregationMessages(t *testing.T, database *db.Database) {
 	t.Helper()
 	ctx := context.Background()
 	// Hard delete test messages (unique message IDs for this test suite)
-	_, _ = database.Pool.Exec(ctx, "DELETE FROM telegram_message WHERE telegram_message_id IN (80001, 80002, 80003, 80011, 80012, 80013, 80021, 80022, 80031, 80032, 80041, 80042, 80051, 80052)")
+	_, _ = database.Pool.Exec(ctx, "DELETE FROM telegram_message WHERE telegram_message_id IN (80001, 80002, 80003, 80011, 80012, 80013, 80021, 80022, 80031, 80032, 80041, 80042, 80051, 80052, 80061, 80062)")
 	// Hard delete interactions with source_ref matching test chat IDs
-	_, _ = database.Pool.Exec(ctx, "DELETE FROM interaction WHERE source_ref LIKE 'tg:100:%' OR source_ref LIKE 'tg:101:%' OR source_ref LIKE 'tg:102:%' OR source_ref LIKE 'tg:201:%' OR source_ref LIKE 'tg:202:%' OR source_ref LIKE 'tg:301:%' OR source_ref LIKE 'tg:302:%'")
+	_, _ = database.Pool.Exec(ctx, "DELETE FROM interaction WHERE source_ref LIKE 'tg:100:%' OR source_ref LIKE 'tg:101:%' OR source_ref LIKE 'tg:102:%' OR source_ref LIKE 'tg:201:%' OR source_ref LIKE 'tg:202:%' OR source_ref LIKE 'tg:301:%' OR source_ref LIKE 'tg:302:%' OR source_ref LIKE 'tg:303:%'")
 }
 
 func setupAggregationTest(t *testing.T) (

--- a/backend/tests/telegram_aggregation_test.go
+++ b/backend/tests/telegram_aggregation_test.go
@@ -270,3 +270,66 @@ func TestAggregation_IncrementalReplyBridge(t *testing.T) {
 	require.Len(t, interactions, 1) // still 1, promoted
 	assert.Equal(t, "mutual", interactions[0].Direction)
 }
+
+func TestAggregation_IncrementalExplicitReplyBridge(t *testing.T) {
+	messageRepo, interactionRepo, contactRepo, _, engine, database := setupAggregationTest(t)
+	ctx := context.Background()
+
+	contact := createTestContact(t, contactRepo, "Aggregation Explicit Reply Bridge")
+	t.Cleanup(func() {
+		_ = contactRepo.SoftDeleteContact(ctx, contact.ID)
+	})
+
+	// Use timestamps >48h apart to prove explicit reply bridges regardless of time
+	outboundTime := accelerated.GetCurrentTime().Add(-72 * time.Hour).Truncate(time.Microsecond)
+	inboundTime := accelerated.GetCurrentTime().Add(-1 * time.Hour).Truncate(time.Microsecond)
+
+	// Step 1: outbound message → aggregate → creates outbound interaction
+	insertTestMessage(t, messageRepo, 80061, 303, true, outboundTime, &contact.ID, 70007)
+	err := engine.AggregateForContact(ctx, contact.ID, 303)
+	require.NoError(t, err)
+
+	interactions, err := interactionRepo.ListContactInteractions(ctx, contact.ID, 100, 0)
+	require.NoError(t, err)
+	require.Len(t, interactions, 1)
+	assert.Equal(t, "outbound", interactions[0].Direction)
+
+	// Step 2: inbound message with reply_to_msg_id pointing to the outbound message
+	replyToID := int32(80061)
+	text := "reply message"
+	_, err = messageRepo.UpsertMessage(ctx, repository.UpsertTelegramMessageParams{
+		TelegramMessageID: 80062,
+		TelegramChatID:    303,
+		ChatType:          "private",
+		MessageText:       &text,
+		MessageType:       "text",
+		SentAt:            inboundTime,
+		IsOutgoing:        false,
+		PeerUserID:        ptrInt64(70007),
+		ReplyToMsgID:      &replyToID,
+	})
+	require.NoError(t, err)
+	err = messageRepo.UpdateMessageContact(ctx, 70007, contact.ID)
+	require.NoError(t, err)
+
+	// Need to mark the outbound message as processed with the interaction_id
+	// so tryExplicitReplyBridge can find it
+	outboundMsg, err := messageRepo.GetMessage(ctx, 303, 80061)
+	require.NoError(t, err)
+	err = messageRepo.MarkMessagesProcessed(ctx, []uuid.UUID{outboundMsg.ID}, interactions[0].ID)
+	require.NoError(t, err)
+
+	// Step 3: aggregate incrementally
+	err = engine.AggregateForContact(ctx, contact.ID, 303)
+	require.NoError(t, err)
+
+	// Assert: 1 mutual interaction (bridged via explicit reply despite >48h gap)
+	interactions, err = interactionRepo.ListContactInteractions(ctx, contact.ID, 100, 0)
+	require.NoError(t, err)
+	require.Len(t, interactions, 1)
+	assert.Equal(t, "mutual", interactions[0].Direction)
+
+	// Clean up test-specific data
+	_, _ = database.Pool.Exec(ctx, "DELETE FROM telegram_message WHERE telegram_message_id IN (80061, 80062)")
+	_, _ = database.Pool.Exec(ctx, "DELETE FROM interaction WHERE source_ref LIKE 'tg:303:%'")
+}

--- a/frontend/src/app/imports/__tests__/page.test.tsx
+++ b/frontend/src/app/imports/__tests__/page.test.tsx
@@ -453,6 +453,7 @@ describe('ImportsPage - Source Filter', () => {
     expect(screen.getByRole('button', { name: 'All Sources' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Google Contacts' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Calendar' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Telegram' })).toBeInTheDocument()
   })
 
   it('All Sources filter is selected by default', () => {
@@ -491,6 +492,19 @@ describe('ImportsPage - Source Filter', () => {
     // useImportCandidates should be called with source filter
     expect(useImportCandidates).toHaveBeenCalledWith(
       expect.objectContaining({ source: 'gcal_attendee' })
+    )
+  })
+
+  it('clicking Telegram filter updates selection', async () => {
+    const user = userEvent.setup()
+    render(<ImportsPage />, { wrapper: createWrapper() })
+
+    const telegramButton = screen.getByRole('button', { name: 'Telegram' })
+    await user.click(telegramButton)
+
+    // useImportCandidates should be called with source filter
+    expect(useImportCandidates).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'telegram' })
     )
   })
 

--- a/frontend/src/app/imports/page.tsx
+++ b/frontend/src/app/imports/page.tsx
@@ -29,6 +29,7 @@ const SOURCE_FILTERS = [
   { value: '', label: 'All Sources' },
   { value: 'gcontacts', label: 'Google Contacts' },
   { value: 'gcal_attendee', label: 'Calendar' },
+  { value: 'telegram', label: 'Telegram' },
 ] as const
 
 // Trusted domains for photo URLs (Google profile photos)

--- a/frontend/src/lib/__tests__/source-display.test.ts
+++ b/frontend/src/lib/__tests__/source-display.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { getSourceDisplay } from '../source-display'
-import { Users, Calendar, HelpCircle } from 'lucide-react'
+import { Users, Calendar, Send, HelpCircle } from 'lucide-react'
 
 describe('getSourceDisplay', () => {
   it('returns friendly name and icon for gcontacts', () => {
@@ -13,6 +13,12 @@ describe('getSourceDisplay', () => {
     const result = getSourceDisplay('gcal_attendee')
     expect(result.label).toBe('Google Calendar')
     expect(result.icon).toBe(Calendar)
+  })
+
+  it('returns friendly name and icon for telegram', () => {
+    const result = getSourceDisplay('telegram')
+    expect(result.label).toBe('Telegram')
+    expect(result.icon).toBe(Send)
   })
 
   it('returns raw source name for unknown sources', () => {

--- a/frontend/src/lib/source-display.ts
+++ b/frontend/src/lib/source-display.ts
@@ -1,4 +1,4 @@
-import { Users, Calendar, HelpCircle } from 'lucide-react'
+import { Users, Calendar, Send, HelpCircle } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 
 export interface SourceDisplayInfo {
@@ -9,6 +9,7 @@ export interface SourceDisplayInfo {
 const SOURCE_DISPLAY_MAP: Record<string, SourceDisplayInfo> = {
   gcontacts: { label: 'Google Contacts', icon: Users },
   gcal_attendee: { label: 'Google Calendar', icon: Calendar },
+  telegram: { label: 'Telegram', icon: Send },
 }
 
 /**


### PR DESCRIPTION
## Summary
- **Identity matching pipeline**: PeerMatcher matches Telegram peers to CRM contacts via username and phone number using the existing IdentityService
- **Aggregation engine**: Groups messages into directional interaction records with 2h burst window, 48h reply bridging, explicit reply_to bridging, and chat-scoped sessionization
- **Discovery**: Unmatched peers with ≥3 messages surface as import candidates via external_contact
- **Import back-linking**: PostImportHook wires Telegram message history to newly imported contacts

## Key design decisions
- **Two aggregation modes**: Batch (backfill) pre-resolves outbound+inbound into mutual to avoid follow-up task churn. Incremental (real-time) coalesces with existing interactions and promotes outbound→mutual on reply detection
- **Shared `applyInteractionEffects`**: Refactored ContactService to eliminate direction logic duplication across RecordInteraction, PromoteInteractionToMutual, and ExtendInteraction
- **No fuzzy name matching (v1)**: Username + phone auto-match only. Unmatched peers flow to import candidates with fuzzy suggested matches

## Test plan
- [x] Unit tests: burst grouping, reply bridging, session key stability, chat scoping, display name building
- [x] Integration tests: batch outbound burst, mutual bridge, no-churn follow-up, chat-scoped aggregation
- [x] Lint passes (0 issues)
- [x] All pre-push checks pass (lint, unit, integration, frontend, E2E)
- [ ] CI backend tests
- [ ] CI E2E tests
- [ ] CI Claude Code review

🤖 Generated with [Claude Code](https://claude.com/claude-code)