### PR TITLE
feat(followup): allow dismissing follow-up tasks without creating a new one

### DIFF
--- a/.ai/log/learnings/5d10e404-2c73-4e8d-8704-8ab449318894.yaml
+++ b/.ai/log/learnings/5d10e404-2c73-4e8d-8704-8ab449318894.yaml
@@ -654,3 +654,43 @@ detail: |
   **How to apply:** Any webhook or real-time event handler that triggers aggregation should use the chat-scoped incremental method. Reserve batch aggregation for backfill operations (e.g., post-sync historical data processing, OnPeerLinked for discovering old messages across chats).
 actionable: true
 
+---
+timestamp: "2026-04-11T16:31:54.276345"
+type: gotcha
+summary: Ghostty terminal type not in remote Pi terminfo causes nano/editor failures
+detail: |
+  When SSH'ing to production Pi from Ghostty terminal, `nano` fails with "Error opening terminal: xterm-ghostty" because the terminfo entry doesn't exist on the remote system. Fix permanently: `infocmp -x xterm-ghostty | ssh raspberet 'sudo tic -x -'`. Applies to any remote system that hasn't seen Ghostty before. Alternative: use `TERM=xterm-256color` prefix for one-off commands.
+actionable: true
+
+---
+timestamp: "2026-04-11T16:31:54.276345"
+type: distinction
+summary: Dismissed follow-ups don't trigger Todoist close (unlike completed follow-ups)
+detail: |
+  Follow-up task completion (`handleTaskCompletion`) issues `ItemClose` command with retry on failure. Follow-up dismissal (`handleFollowUpDismissal`) does NOT issue `ItemClose` — the Todoist task becomes orphaned. This matches the existing skip-trigger pattern for cadence tasks (which also leave orphaned tasks). Rationale: dismissal is triggered by user action in Todoist itself (delete/label-remove/deadline-remove), so the task state in Todoist is already what the user wanted. Closing it would be redundant or wrong.
+actionable: true
+
+---
+timestamp: "2026-04-11T16:31:54.276345"
+type: architecture
+summary: Todoist sync provider doesn't reconcile per-command success/failure
+detail: |
+  The `CadenceSyncProvider.processItem` batches multiple `SyncCommand`s but has no mechanism to observe which specific commands succeeded vs failed in the response. Commands are fire-and-forget within a sync cycle. This means setting retry flags (like `todoist_close_pending`) must only happen in contexts where failure is observed synchronously (e.g., `FollowUpService.CompleteFollowUp` calls Sync API directly and sees error), NOT in the provider where commands are queued. This architectural constraint shapes retry design for any new Todoist operations.
+actionable: true
+
+---
+timestamp: "2026-04-11T16:31:54.276345"
+type: rule
+summary: "Contact task state changes require updating 3 layers: DB constraint, API validator, and frontend types"
+detail: |
+  Adding a new `contact_task.state` value (e.g., 'dismissed') requires changes in: (1) Migration to widen CHECK constraint, (2) `backend/internal/api/handlers/contact_task.go` ListContactTasksQuery.State oneof validator, (3) `frontend/src/types/contact-task.ts` ContactTask.state union AND ContactTaskListParams.state union. Missing any layer causes validation failures or type errors. This is a cross-cutting change that Codex review caught in round 1.
+actionable: true
+
+---
+timestamp: "2026-04-11T16:31:54.276345"
+type: documentation_gap
+summary: Todoist provider test location guidance wasn't followed initially
+detail: |
+  Initial plan proposed same-package unit tests in `backend/internal/todoist/provider_dismissal_test.go`. Codex review flagged this: provider tests should be DB-backed integration tests in `backend/tests/` (mirroring existing `followup_service_test.go` pattern). The `.ai/rules/testing.md` states "integration tests for DB operations" but doesn't explicitly call out where sync provider tests belong. Strengthen: add example to testing.md or architecture.md showing sync provider tests live in `backend/tests/` with full DB setup, not in `internal/todoist/`.
+actionable: true
+

--- a/.ai/log/learnings/5d10e404-2c73-4e8d-8704-8ab449318894.yaml
+++ b/.ai/log/learnings/5d10e404-2c73-4e8d-8704-8ab449318894.yaml
@@ -694,3 +694,51 @@ detail: |
   Initial plan proposed same-package unit tests in `backend/internal/todoist/provider_dismissal_test.go`. Codex review flagged this: provider tests should be DB-backed integration tests in `backend/tests/` (mirroring existing `followup_service_test.go` pattern). The `.ai/rules/testing.md` states "integration tests for DB operations" but doesn't explicitly call out where sync provider tests belong. Strengthen: add example to testing.md or architecture.md showing sync provider tests live in `backend/tests/` with full DB setup, not in `internal/todoist/`.
 actionable: true
 
+---
+timestamp: "2026-04-11T16:49:18.516258"
+type: architecture
+summary: Todoist sync cursor is opaque — abort-on-error and replay the batch is the only coherent error-recovery pattern
+detail: |
+  The Todoist Sync API returns an opaque sync_token cursor with incremental diffs. There is no way to partially commit a response batch. On any fatal error during batch processing, the sync MUST abort without advancing the cursor so the entire batch is redelivered on the next tick. This is analogous to Kafka consumer semantics. Attempting to 'skip bad items and continue' silently drops events permanently because incremental sync won't redeliver unchanged items. Why: This constraint shapes the entire error-handling strategy in CadenceSyncProvider.Sync and all processItem handlers. How to apply: When adding new Todoist sync handlers or modifying error paths, always propagate fatal errors to abort the sync. Never log-and-continue for state-changing operations unless explicitly justified (see conditional abort pattern).
+actionable: true
+
+---
+timestamp: "2026-04-11T16:49:18.516258"
+type: gotcha
+summary: Some Todoist handlers are NOT replay-safe — requires conditional abort-on-error logic
+detail: |
+  handleSkipTrigger commits non-state-changing side effects (advances contact_by, appends item_add command) while leaving the task state='managed'. If the sync aborts and replays, these side effects double. This means processItem cannot unconditionally abort on all errors — it must track whether a non-replay-safe operation succeeded earlier in the batch via a replayCommittedUnsafe flag. If set, subsequent fatal errors MUST log-and-continue (not abort) to prevent double-execution. Why: Replay idempotency is critical for correctness. A blanket abort-on-error strategy breaks for handlers that commit side effects without state transitions. How to apply: When adding new Todoist handlers, analyze whether they are replay-safe. If a handler commits any non-transactional side effect (updating contact fields, appending commands) without changing task state, it must set Unsafe=true in processItemResult.
+actionable: true
+
+---
+timestamp: "2026-04-11T16:49:18.516258"
+type: gotcha
+summary: Incremental sync semantics mean DB failures can permanently strand rows — not auto-retried
+detail: |
+  Todoist incremental sync only delivers items that changed since the last cursor. If a DB error occurs mid-processing (e.g., UpdateContactTaskState fails during dismissal) and the code log-and-continues, the cursor advances and the failed item is never redelivered unless it changes again externally. For deleted items (IsDeleted=true), the item is gone forever — no second chance. This violates the 'will retry on next sync' assumption that might be intuitive from polling systems. Why: This was a subtle bug in handleFollowUpDismissal's original implementation that Codex caught. The comment claimed retry-on-next-sync but incremental semantics made that false. How to apply: For state-changing operations in Todoist handlers, DB failures should propagate as fatal errors to abort the sync (unless replayCommittedUnsafe=true). Never assume incremental sync will redeliver on the next tick.
+actionable: true
+
+---
+timestamp: "2026-04-11T16:49:18.516258"
+type: distinction
+summary: Classify Todoist handler DB errors as fatal vs best-effort based on reconcile-loop recoverability
+detail: |
+  Not all DB failures in Todoist sync handlers should abort the sync. Operations that are reconciled on every tick (UpdateContactBy for deadline changes, UpdateContactTaskMetadata for synced_deadline) can be best-effort: log-and-continue on error because the next sync will fix them. Only state transitions and operations that won't self-heal via reconciliation should be fatal. Example fatal: UpdateContactTaskState (state won't change until item changes), GetContact non-NotFound (can't process without contact). Example best-effort: UpdateContactBy (reconcile loop compares item.Deadline to contact.ContactBy every tick). Why: This distinction prevents wedging the sync on transient errors for non-critical fields while still failing fast for correctness-critical state changes. How to apply: When adding DB operations in Todoist handlers, ask: 'Will the reconcile loop fix this if it fails?' If yes, log-and-continue. If no, propagate as fatal error.
+actionable: true
+
+---
+timestamp: "2026-04-11T16:49:18.516258"
+type: architecture
+summary: Plan-and-review loop can be used mid-implementation when Codex identifies architectural issues
+detail: |
+  During local Codex review of the #264 dismissal feature, Codex flagged a correctness gap: handleFollowUpDismissal returns (false, nil) on DB failure but the sync advances the cursor unconditionally, permanently dropping failed dismissals. This required expanding scope into error-propagation plumbing across processItem and all handlers — well beyond the original 'add follow-up dismissal' plan. Instead of either (A) cargo-culting the existing flawed pattern or (C) expanding scope without permission, the correct move was to escalate to the user, get approval to expand scope, then re-enter plan-and-review to design the refactor. The plan-and-review skill successfully caught three non-obvious issues (handleSkipTrigger replay non-idempotency, handleTaskCompletion guardrail test fixture mismatch, stale tuple language) across 4 Codex rounds before approving. Why: Plan-and-review isn't just for greenfield features — it's valuable for mid-implementation scope expansions when Codex surfaces architectural issues. How to apply: If Codex review identifies a correctness gap that requires touching pre-existing code paths, escalate to the user and use plan-and-review to design the fix before implementing.
+actionable: true
+
+---
+timestamp: "2026-04-11T16:49:18.516258"
+type: rule
+summary: Use pgxpool.Close() for integration test error injection, not mocks
+detail: |
+  To test fatal error propagation in Todoist handlers (e.g., 'does handleFollowUpDismissal return an error when UpdateContactTaskState fails?'), close the underlying pgxpool connection with env.database.Close() after setting up the test fixture. Subsequent DB operations return connection-closed errors. This is superior to mocking because: (1) tests actual error paths with real pgx error types, (2) no need to build elaborate fakes, (3) works for same-package tests where mocking internal dependencies is awkward. The test file added a closeDB(t, env) helper that calls env.database.Close() and tracks closure state to prevent double-close. Why: This technique wasn't obvious from existing test patterns and required experimentation. It's now the established pattern for error-injection tests in provider_dismissal_test.go. How to apply: When adding integration tests for DB error handling in Todoist handlers, use closeDB(t, env) to force failures after fixture setup.
+actionable: true
+

--- a/backend/internal/api/handlers/contact_task.go
+++ b/backend/internal/api/handlers/contact_task.go
@@ -136,8 +136,8 @@ func (h *ContactTaskHandler) CreateActionTask(c *gin.Context) {
 // @Tags contact-tasks
 // @Produce json
 // @Param id path string true "Contact ID"
-// @Param state query string false "Filter by state (managed, completed, unmanaged)"
-// @Param kind query string false "Filter by kind (action, cadence)"
+// @Param state query string false "Filter by state (managed, completed, unmanaged, dismissed)"
+// @Param kind query string false "Filter by kind (action, cadence, follow_up)"
 // @Success 200 {object} api.APIResponse{data=[]ContactTaskResponse}
 // @Failure 400 {object} api.APIResponse{error=api.APIError}
 // @Failure 404 {object} api.APIResponse{error=api.APIError}

--- a/backend/internal/api/handlers/contact_task.go
+++ b/backend/internal/api/handlers/contact_task.go
@@ -50,7 +50,7 @@ type ContactTaskResponse struct {
 
 // ListContactTasksQuery represents query parameters for listing tasks
 type ListContactTasksQuery struct {
-	State string `form:"state" validate:"omitempty,oneof=managed completed unmanaged"`
+	State string `form:"state" validate:"omitempty,oneof=managed completed unmanaged dismissed"`
 	Kind  string `form:"kind" validate:"omitempty,oneof=action cadence follow_up"`
 }
 

--- a/backend/internal/repository/contact_task.go
+++ b/backend/internal/repository/contact_task.go
@@ -19,6 +19,7 @@ const (
 	ContactTaskStateManaged   ContactTaskState = "managed"
 	ContactTaskStateUnmanaged ContactTaskState = "unmanaged"
 	ContactTaskStateCompleted ContactTaskState = "completed"
+	ContactTaskStateDismissed ContactTaskState = "dismissed"
 )
 
 // ContactTask represents a link between a contact and an external task provider

--- a/backend/internal/todoist/provider.go
+++ b/backend/internal/todoist/provider.go
@@ -480,7 +480,7 @@ func (p *CadenceSyncProvider) processItem(
 // failure (returns Err: nil always). The state→interaction ordering comment
 // below documents why a naive fatal-error conversion would break the follow-up
 // cycle; correct fix requires repository-layer transaction threading.
-// TODO(followup-issue): see the deferred refactor tracking issue — this
+// TODO(#265): see the deferred refactor tracking issue — this
 // handler is on the list for transactional rewrite.
 //
 // Returns Unsafe: false because on success the row transitions to 'completed'
@@ -566,7 +566,7 @@ func (p *CadenceSyncProvider) handleTaskCompletion(
 // short-circuit (state is still managed), so the same skip trigger would run
 // a second time and double-advance the cadence clock. Fixing this requires
 // transactional state tracking or an idempotency marker.
-// TODO(followup-issue): see the deferred refactor tracking issue — this
+// TODO(#265): see the deferred refactor tracking issue — this
 // handler is on the list for transactional rewrite.
 //
 // Returns Unsafe: true on every successful return. This flag tells the sync
@@ -1069,6 +1069,11 @@ func isPendingTempID(task *repository.ContactTask) bool {
 // It parses the CRM marker in the item description to find the contact, then checks
 // if there's a managed cadence task with a pending temp ID for that contact.
 // If found, it migrates the external_task_id to the real ID.
+//
+// TODO(#265): this recovery path's internal DB calls currently swallow
+// failures silently. Not on the critical correctness path but deserves audit
+// under the same transactional treatment as handleTaskCompletion and
+// handleSkipTrigger — tracked in the deferred refactor issue.
 func (p *CadenceSyncProvider) tryRecoverPendingTempID(ctx context.Context, item SyncItem) *repository.ContactTask {
 	// Parse CRM marker from description to get contact ID
 	var marker struct {

--- a/backend/internal/todoist/provider.go
+++ b/backend/internal/todoist/provider.go
@@ -306,10 +306,15 @@ type processItemResult struct {
 // each through processItem. It is the single point at which fatal-error
 // propagation and replay-safe abort are enforced.
 //
-// The returned replayCommittedUnsafe reflects whether any item in this batch
-// committed non-replay-safe state via handleSkipTrigger — the sync loop does
-// not need it (it's discarded at the call site) but we return it so tests can
-// observe the flag directly.
+// Abort semantics: on a fatal processItem error (r.Err != nil), processItems
+// aborts only if no earlier item in this batch committed non-replay-safe
+// state. The replayCommittedUnsafe flag is set by any successful
+// handleSkipTrigger (see its docstring). Aborting after an unsafe commit
+// would cause the next sync to replay the skip trigger, double-advancing the
+// cadence clock — so when the flag is set, we fall back to log-and-continue.
+//
+// The returned replayCommittedUnsafe is discarded by the Sync call site but
+// returned so tests can observe the flag directly.
 func (p *CadenceSyncProvider) processItems(
 	ctx context.Context,
 	items []SyncItem,
@@ -318,8 +323,19 @@ func (p *CadenceSyncProvider) processItems(
 ) (processed int, commands []SyncCommand, replayCommittedUnsafe bool, err error) {
 	for _, item := range items {
 		r := p.processItem(ctx, item, settings, accountID)
-		// NOTE: commit 1 intentionally ignores r.Err — no handler produces a
-		// non-nil Err yet. Commit 2 turns on the abort logic.
+		if r.Err != nil {
+			if replayCommittedUnsafe {
+				logger.Error().Err(r.Err).
+					Str("itemId", item.ID).
+					Msg("processItem fatal error after non-replay-safe commit — forced to log-and-continue; cursor will advance and event is dropped")
+				continue
+			}
+			logger.Error().Err(r.Err).
+				Str("itemId", item.ID).
+				Int("processedBeforeAbort", processed).
+				Msg("processItem fatal error — aborting sync without advancing cursor")
+			return processed, nil, false, fmt.Errorf("process item %s: %w", item.ID, r.Err)
+		}
 		if r.Processed {
 			processed++
 		}
@@ -344,8 +360,7 @@ func (p *CadenceSyncProvider) processItem(
 	task, err := p.contactTaskRepo.GetContactTaskByExternalID(ctx, SourceName, item.ID)
 	if err != nil {
 		if !errors.Is(err, db.ErrNotFound) {
-			logger.Warn().Err(err).Str("taskId", item.ID).Msg("failed to find contact task")
-			return processItemResult{}
+			return processItemResult{Err: fmt.Errorf("process item: lookup contact_task: %w", err)}
 		}
 		// Fallback: if processTempIDMappings failed, the contact_task still has a
 		// temp ID while Todoist uses the real ID. Try to recover by matching the
@@ -370,8 +385,9 @@ func (p *CadenceSyncProvider) processItem(
 			if err := p.contactTaskRepo.DeleteContactTask(ctx, task.ID); err != nil {
 				logger.Warn().Err(err).Str("taskId", task.ID.String()).Msg("failed to delete contact task")
 			}
+			return processItemResult{Commands: commands}
 		}
-		return processItemResult{Commands: commands}
+		return processItemResult{Err: fmt.Errorf("process item: load contact: %w", err)}
 	}
 
 	// Check for recurring detection (transition to unmanaged)
@@ -381,7 +397,7 @@ func (p *CadenceSyncProvider) processItem(
 			Str("contactId", task.ContactID.String()).
 			Msg("task became recurring, transitioning to unmanaged")
 		if _, err := p.contactTaskRepo.UpdateContactTaskState(ctx, task.ID, repository.ContactTaskStateUnmanaged); err != nil {
-			logger.Warn().Err(err).Msg("failed to update task state to unmanaged")
+			return processItemResult{Err: fmt.Errorf("process item: update state to unmanaged (recurring): %w", err)}
 		}
 		return processItemResult{Processed: true}
 	}
@@ -638,20 +654,15 @@ func (p *CadenceSyncProvider) handleSkipTrigger(
 // cadence clock is driven by real engagement and continues from its last real
 // mutual/inbound interaction.
 //
-// State is persisted BEFORE any ItemClose command is queued. If the state
-// update fails, we return (false, nil) — crucially, we do NOT forward the
-// ItemClose — so the Todoist task is never closed while the local row is
-// stranded in 'managed'. That combination would permanently suppress cadence
-// reconciliation via FindPendingFollowUp with no obvious recovery path.
-//
-// Failure recovery caveat: on a DB error mid-dismissal, the local row stays
-// 'managed' but the incremental Todoist sync advances its cursor, so the
-// dismissal event will not be redelivered unless the user touches the task
-// again in Todoist or a full sync (`*` cursor) is performed. We log this at
-// error level so the stuck row is visible; the operator can manually mark the
-// row dismissed, or a full sync will re-present the item (for label/deadline
-// removed; IsDeleted=true is unrecoverable because the Todoist item is gone).
-// This matches the best-effort failure semantics of handleTaskCompletion.
+// State is persisted BEFORE any ItemClose command is queued. On state-update
+// failure, this handler returns a fatal error via processItemResult.Err; the
+// sync loop (processItems) then decides whether to abort or log-and-continue
+// based on whether any earlier item in the same batch committed non-replay-
+// safe state. If no earlier unsafe commit occurred, the sync aborts without
+// advancing the cursor and the next tick replays the item. If an earlier
+// handleSkipTrigger already advanced contact_by in this batch, the dismissal
+// falls back to log-and-continue (the pre-existing failure mode for that
+// specific mixed-batch scenario).
 //
 // For non-deletion triggers, once the state transition succeeds we queue an
 // ItemClose command so the batched sync path cleans up the orphaned task in
@@ -665,15 +676,9 @@ func (p *CadenceSyncProvider) handleFollowUpDismissal(
 	contact *repository.Contact,
 ) processItemResult {
 	if _, err := p.contactTaskRepo.UpdateContactTaskState(ctx, task.ID, repository.ContactTaskStateDismissed); err != nil {
-		logger.Error().Err(err).
-			Str("taskId", task.ID.String()).
-			Str("contactId", contact.ID.String()).
-			Str("todoistTaskId", task.ExternalTaskID).
-			Bool("itemDeleted", item.IsDeleted).
-			Msg("failed to mark follow-up task as dismissed — local row stranded in 'managed'; ItemClose suppressed. Recover via full sync or manual state update.")
 		// Do NOT forward the ItemClose command — stranding local 'managed' +
 		// closed Todoist would break FindPendingFollowUp permanently.
-		return processItemResult{}
+		return processItemResult{Err: fmt.Errorf("dismiss follow-up: update contact_task state: %w", err)}
 	}
 
 	var commands []SyncCommand
@@ -708,7 +713,7 @@ func (p *CadenceSyncProvider) handleActionTaskTriggers(
 			Str("contactTaskId", task.ID.String()).
 			Msg("action task deleted in Todoist, marking as unmanaged")
 		if _, err := p.contactTaskRepo.UpdateContactTaskState(ctx, task.ID, repository.ContactTaskStateUnmanaged); err != nil {
-			logger.Warn().Err(err).Msg("failed to update action task state to unmanaged")
+			return processItemResult{Err: fmt.Errorf("action task triggers (deleted): update state to unmanaged: %w", err)}
 		}
 		return processItemResult{Processed: true}
 	}
@@ -720,7 +725,7 @@ func (p *CadenceSyncProvider) handleActionTaskTriggers(
 			Str("contactTaskId", task.ID.String()).
 			Msg("CRM label removed from action task, marking as unmanaged")
 		if _, err := p.contactTaskRepo.UpdateContactTaskState(ctx, task.ID, repository.ContactTaskStateUnmanaged); err != nil {
-			logger.Warn().Err(err).Msg("failed to update action task state to unmanaged")
+			return processItemResult{Err: fmt.Errorf("action task triggers (label removed): update state to unmanaged: %w", err)}
 		}
 		return processItemResult{Processed: true}
 	}

--- a/backend/internal/todoist/provider.go
+++ b/backend/internal/todoist/provider.go
@@ -206,15 +206,12 @@ func (p *CadenceSyncProvider) Sync(
 	}
 
 	// Process synced items
-	var commands []SyncCommand
-	processedTasks := 0
-
-	for _, item := range syncResp.Items {
-		processed, cmds := p.processItem(ctx, item, settings, accountID)
-		if processed {
-			processedTasks++
-		}
-		commands = append(commands, cmds...)
+	processedTasks, commands, _, err := p.processItems(ctx, syncResp.Items, settings, accountID)
+	if err != nil {
+		// commit 1: processItems never returns a non-nil err. commit 2 turns on
+		// real fatal-error handling with the conditional-abort logic.
+		result.ItemsProcessed = processedTasks
+		return result, err
 	}
 
 	result.ItemsProcessed = processedTasks
@@ -285,13 +282,62 @@ func (p *CadenceSyncProvider) ValidateCredentials(ctx context.Context, accountID
 	return nil
 }
 
+// processItemResult is the structured return from processItem and its handlers.
+//
+// Fields:
+//   - Processed: true if the item was owned by CRM and handled (not skipped).
+//   - Commands:  Todoist commands to enqueue in the batch.
+//   - Unsafe:    true if a non-replay-safe side effect was committed. Today, only
+//     handleSkipTrigger's success path sets this — it advances contact_by and
+//     appends a replacement item_add while leaving the row state='managed',
+//     which is non-idempotent on replay. When the sync loop sees this flag, any
+//     subsequent fatal error in the same batch falls back to log-and-continue
+//     instead of aborting (which would cause double-advancement on replay).
+//   - Err:       non-nil for fatal errors. Callers inspect Unsafe to decide
+//     whether to abort the sync or log-and-continue.
+type processItemResult struct {
+	Processed bool
+	Commands  []SyncCommand
+	Unsafe    bool
+	Err       error
+}
+
+// processItems iterates over the items returned by a Todoist sync, dispatching
+// each through processItem. It is the single point at which fatal-error
+// propagation and replay-safe abort are enforced.
+//
+// The returned replayCommittedUnsafe reflects whether any item in this batch
+// committed non-replay-safe state via handleSkipTrigger — the sync loop does
+// not need it (it's discarded at the call site) but we return it so tests can
+// observe the flag directly.
+func (p *CadenceSyncProvider) processItems(
+	ctx context.Context,
+	items []SyncItem,
+	settings Settings,
+	accountID string,
+) (processed int, commands []SyncCommand, replayCommittedUnsafe bool, err error) {
+	for _, item := range items {
+		r := p.processItem(ctx, item, settings, accountID)
+		// NOTE: commit 1 intentionally ignores r.Err — no handler produces a
+		// non-nil Err yet. Commit 2 turns on the abort logic.
+		if r.Processed {
+			processed++
+		}
+		if r.Unsafe {
+			replayCommittedUnsafe = true
+		}
+		commands = append(commands, r.Commands...)
+	}
+	return processed, commands, replayCommittedUnsafe, nil
+}
+
 // processItem processes a single Todoist item from sync
 func (p *CadenceSyncProvider) processItem(
 	ctx context.Context,
 	item SyncItem,
 	settings Settings,
 	accountID string,
-) (bool, []SyncCommand) {
+) processItemResult {
 	var commands []SyncCommand
 
 	// Find if this task is linked to a contact
@@ -299,20 +345,20 @@ func (p *CadenceSyncProvider) processItem(
 	if err != nil {
 		if !errors.Is(err, db.ErrNotFound) {
 			logger.Warn().Err(err).Str("taskId", item.ID).Msg("failed to find contact task")
-			return false, nil
+			return processItemResult{}
 		}
 		// Fallback: if processTempIDMappings failed, the contact_task still has a
 		// temp ID while Todoist uses the real ID. Try to recover by matching the
 		// CRM marker in the description to find a task with a pending temp ID.
 		task = p.tryRecoverPendingTempID(ctx, item)
 		if task == nil {
-			return false, nil // Not a managed task
+			return processItemResult{} // Not a managed task
 		}
 	}
 
 	// Skip unmanaged tasks
 	if task.State != repository.ContactTaskStateManaged {
-		return false, nil
+		return processItemResult{}
 	}
 
 	// Get the contact
@@ -325,7 +371,7 @@ func (p *CadenceSyncProvider) processItem(
 				logger.Warn().Err(err).Str("taskId", task.ID.String()).Msg("failed to delete contact task")
 			}
 		}
-		return false, commands
+		return processItemResult{Commands: commands}
 	}
 
 	// Check for recurring detection (transition to unmanaged)
@@ -337,7 +383,7 @@ func (p *CadenceSyncProvider) processItem(
 		if _, err := p.contactTaskRepo.UpdateContactTaskState(ctx, task.ID, repository.ContactTaskStateUnmanaged); err != nil {
 			logger.Warn().Err(err).Msg("failed to update task state to unmanaged")
 		}
-		return true, nil
+		return processItemResult{Processed: true}
 	}
 
 	// Check for completion
@@ -409,10 +455,23 @@ func (p *CadenceSyncProvider) processItem(
 		}
 	}
 
-	return true, commands
+	return processItemResult{Processed: true, Commands: commands}
 }
 
-// handleTaskCompletion handles a completed Todoist task
+// handleTaskCompletion handles a completed Todoist task.
+//
+// Failure semantics: this handler intentionally retains log-and-continue on DB
+// failure (returns Err: nil always). The state→interaction ordering comment
+// below documents why a naive fatal-error conversion would break the follow-up
+// cycle; correct fix requires repository-layer transaction threading.
+// TODO(followup-issue): see the deferred refactor tracking issue — this
+// handler is on the list for transactional rewrite.
+//
+// Returns Unsafe: false because on success the row transitions to 'completed'
+// and replay short-circuits at processItem's state != 'managed' early-return.
+// (On partial failure — state=completed but RecordInteraction failed — the
+// interaction record is lost, but replay is still idempotent because of the
+// early-return, so `Unsafe: false` is defensible.)
 func (p *CadenceSyncProvider) handleTaskCompletion(
 	ctx context.Context,
 	item SyncItem,
@@ -420,7 +479,7 @@ func (p *CadenceSyncProvider) handleTaskCompletion(
 	contact *repository.Contact,
 	settings Settings,
 	accountID string,
-) (bool, []SyncCommand) {
+) processItemResult {
 	var commands []SyncCommand
 
 	// Parse completion timestamp
@@ -446,7 +505,7 @@ func (p *CadenceSyncProvider) handleTaskCompletion(
 		if _, err := p.contactTaskRepo.UpdateContactTaskState(ctx, task.ID, repository.ContactTaskStateCompleted); err != nil {
 			logger.Warn().Err(err).Msg("failed to update action task state to completed")
 		}
-		return true, nil
+		return processItemResult{Processed: true}
 	}
 
 	// For cadence and follow_up tasks: mark completed FIRST, then record outbound interaction.
@@ -479,17 +538,36 @@ func (p *CadenceSyncProvider) handleTaskCompletion(
 		Time("completedAt", completedAt).
 		Msg("recorded outbound interaction from Todoist task completion")
 
-	return true, commands
+	return processItemResult{Processed: true, Commands: commands}
 }
 
-// handleSkipTrigger handles a skip trigger (task deleted, label removed, deadline removed)
+// handleSkipTrigger handles a skip trigger (task deleted, label removed, deadline removed).
+//
+// Failure semantics: this handler intentionally retains log-and-continue on DB
+// failure (returns Err: nil always). It commits non-idempotent side effects —
+// advances contact.contact_by and appends a replacement item_add command while
+// leaving the row state='managed'. On replay, processItem would NOT
+// short-circuit (state is still managed), so the same skip trigger would run
+// a second time and double-advance the cadence clock. Fixing this requires
+// transactional state tracking or an idempotency marker.
+// TODO(followup-issue): see the deferred refactor tracking issue — this
+// handler is on the list for transactional rewrite.
+//
+// Returns Unsafe: true on every successful return. This flag tells the sync
+// loop's processItems method that a non-replay-safe side effect was committed
+// in this batch; subsequent fatal errors in the same batch fall back to
+// log-and-continue instead of aborting (which would cause replay
+// double-advancement of this contact's cadence clock). The flag is set
+// unconditionally because partial failures (e.g., UpdateContactBy succeeded
+// but UpdateContactTaskMetadata failed) still advance contact_by — so even a
+// "failed" skip is unsafe to replay.
 func (p *CadenceSyncProvider) handleSkipTrigger(
 	ctx context.Context,
 	task *repository.ContactTask,
 	contact *repository.Contact,
 	settings Settings,
 	accountID string,
-) (bool, []SyncCommand) {
+) processItemResult {
 	var commands []SyncCommand
 
 	// Calculate new contact_by using skip semantics
@@ -548,7 +626,7 @@ func (p *CadenceSyncProvider) handleSkipTrigger(
 		}
 	}
 
-	return true, commands
+	return processItemResult{Processed: true, Commands: commands, Unsafe: true}
 }
 
 // handleFollowUpDismissal handles a follow-up task being dismissed via Todoist.
@@ -585,7 +663,7 @@ func (p *CadenceSyncProvider) handleFollowUpDismissal(
 	item SyncItem,
 	task *repository.ContactTask,
 	contact *repository.Contact,
-) (bool, []SyncCommand) {
+) processItemResult {
 	if _, err := p.contactTaskRepo.UpdateContactTaskState(ctx, task.ID, repository.ContactTaskStateDismissed); err != nil {
 		logger.Error().Err(err).
 			Str("taskId", task.ID.String()).
@@ -595,7 +673,7 @@ func (p *CadenceSyncProvider) handleFollowUpDismissal(
 			Msg("failed to mark follow-up task as dismissed — local row stranded in 'managed'; ItemClose suppressed. Recover via full sync or manual state update.")
 		// Do NOT forward the ItemClose command — stranding local 'managed' +
 		// closed Todoist would break FindPendingFollowUp permanently.
-		return false, nil
+		return processItemResult{}
 	}
 
 	var commands []SyncCommand
@@ -611,7 +689,7 @@ func (p *CadenceSyncProvider) handleFollowUpDismissal(
 		Int("commandsQueued", len(commands)).
 		Msg("follow-up dismissed via Todoist")
 
-	return true, commands
+	return processItemResult{Processed: true, Commands: commands}
 }
 
 // handleActionTaskTriggers handles unmanagement triggers for action tasks
@@ -622,7 +700,7 @@ func (p *CadenceSyncProvider) handleActionTaskTriggers(
 	item SyncItem,
 	task *repository.ContactTask,
 	settings Settings,
-) (bool, []SyncCommand) {
+) processItemResult {
 	// Task deleted - mark as unmanaged
 	if item.IsDeleted {
 		logger.Info().
@@ -632,7 +710,7 @@ func (p *CadenceSyncProvider) handleActionTaskTriggers(
 		if _, err := p.contactTaskRepo.UpdateContactTaskState(ctx, task.ID, repository.ContactTaskStateUnmanaged); err != nil {
 			logger.Warn().Err(err).Msg("failed to update action task state to unmanaged")
 		}
-		return true, nil
+		return processItemResult{Processed: true}
 	}
 
 	// Label removed - mark as unmanaged
@@ -644,7 +722,7 @@ func (p *CadenceSyncProvider) handleActionTaskTriggers(
 		if _, err := p.contactTaskRepo.UpdateContactTaskState(ctx, task.ID, repository.ContactTaskStateUnmanaged); err != nil {
 			logger.Warn().Err(err).Msg("failed to update action task state to unmanaged")
 		}
-		return true, nil
+		return processItemResult{Processed: true}
 	}
 
 	// Update metadata with current task state (content, due_date, project)
@@ -666,7 +744,7 @@ func (p *CadenceSyncProvider) handleActionTaskTriggers(
 		logger.Warn().Err(err).Msg("failed to update action task metadata")
 	}
 
-	return true, nil
+	return processItemResult{Processed: true}
 }
 
 // reconcileContactTasks ensures all contacts with cadence have managed tasks

--- a/backend/internal/todoist/provider.go
+++ b/backend/internal/todoist/provider.go
@@ -205,18 +205,16 @@ func (p *CadenceSyncProvider) Sync(
 		}
 	}
 
-	// Process synced items. On a fatal error from processItems, we return
-	// early WITHOUT setting result.NewCursor so the next sync replays the
-	// batch from the pre-batch cursor.
-	processedTasks, commands, _, err := p.processItems(ctx, syncResp.Items, settings, accountID)
-	if err != nil {
-		result.ItemsProcessed = processedTasks
-		return result, err
-	}
-
+	// Process synced items.
+	processedTasks, commands, _, processErr := p.processItems(ctx, syncResp.Items, settings, accountID)
 	result.ItemsProcessed = processedTasks
 
-	// If we have commands to execute, send them
+	// Execute any accumulated commands BEFORE checking processErr. If
+	// processItems aborted mid-batch, the commands accumulated up to that
+	// point are all cleanup commands (ItemClose / ItemDelete) for already-
+	// persisted local state transitions — executing them prevents orphaning
+	// Todoist tasks whose local rows are already in terminal states. See the
+	// comment in processItems's abort path for why this is safe.
 	if len(commands) > 0 {
 		for _, batch := range BatchCommands(commands, 100) {
 			cmdResp, err := client.Sync(ctx, syncResp.SyncToken, []string{}, batch)
@@ -226,6 +224,13 @@ func (p *CadenceSyncProvider) Sync(
 				p.processTempIDMappings(ctx, cmdResp.TempIDMap)
 			}
 		}
+	}
+
+	// On a fatal error from processItems, return WITHOUT setting
+	// result.NewCursor so the next sync replays the batch from the pre-batch
+	// cursor.
+	if processErr != nil {
+		return result, processErr
 	}
 
 	// Store new sync token
@@ -328,7 +333,22 @@ func (p *CadenceSyncProvider) processItems(
 			if shouldContinue {
 				continue
 			}
-			return processed, nil, false, wrappedErr
+			// On abort, return the commands accumulated from earlier items
+			// (not nil). These are all cleanup commands — ItemClose from
+			// successful handleFollowUpDismissal and ItemDelete from the
+			// contact-not-found branch in processItem — for local state
+			// transitions that have already been persisted. The caller
+			// (Sync) executes them before returning the error so we don't
+			// orphan Todoist tasks whose local rows are already in terminal
+			// states. Replay is still safe: on the next sync, the replayed
+			// items short-circuit at processItem's state != managed early-
+			// return and do not re-emit their commands.
+			//
+			// replayCommittedUnsafe is always false on this branch (by
+			// construction — we only reach this return when
+			// replayCommittedUnsafe==false) but we return the variable for
+			// clarity rather than a literal.
+			return processed, commands, replayCommittedUnsafe, wrappedErr
 		}
 		if r.Processed {
 			processed++

--- a/backend/internal/todoist/provider.go
+++ b/backend/internal/todoist/provider.go
@@ -561,11 +561,19 @@ func (p *CadenceSyncProvider) handleSkipTrigger(
 // mutual/inbound interaction.
 //
 // State is persisted BEFORE any ItemClose command is queued. If the state
-// update fails, we return (false, nil) so the sync loop does not forward an
-// ItemClose that would close the Todoist task while leaving the local row
-// `managed` — that combination would permanently suppress cadence
-// reconciliation via FindPendingFollowUp. Returning false also means the next
-// sync tick will see the still-managed task and retry dismissal.
+// update fails, we return (false, nil) — crucially, we do NOT forward the
+// ItemClose — so the Todoist task is never closed while the local row is
+// stranded in 'managed'. That combination would permanently suppress cadence
+// reconciliation via FindPendingFollowUp with no obvious recovery path.
+//
+// Failure recovery caveat: on a DB error mid-dismissal, the local row stays
+// 'managed' but the incremental Todoist sync advances its cursor, so the
+// dismissal event will not be redelivered unless the user touches the task
+// again in Todoist or a full sync (`*` cursor) is performed. We log this at
+// error level so the stuck row is visible; the operator can manually mark the
+// row dismissed, or a full sync will re-present the item (for label/deadline
+// removed; IsDeleted=true is unrecoverable because the Todoist item is gone).
+// This matches the best-effort failure semantics of handleTaskCompletion.
 //
 // For non-deletion triggers, once the state transition succeeds we queue an
 // ItemClose command so the batched sync path cleans up the orphaned task in
@@ -579,12 +587,14 @@ func (p *CadenceSyncProvider) handleFollowUpDismissal(
 	contact *repository.Contact,
 ) (bool, []SyncCommand) {
 	if _, err := p.contactTaskRepo.UpdateContactTaskState(ctx, task.ID, repository.ContactTaskStateDismissed); err != nil {
-		logger.Warn().Err(err).
+		logger.Error().Err(err).
 			Str("taskId", task.ID.String()).
 			Str("contactId", contact.ID.String()).
-			Msg("failed to mark follow-up task as dismissed — will retry on next sync")
-		// Return false + nil commands so the sync loop does not forward an
-		// ItemClose that would strand the local row in 'managed'.
+			Str("todoistTaskId", task.ExternalTaskID).
+			Bool("itemDeleted", item.IsDeleted).
+			Msg("failed to mark follow-up task as dismissed — local row stranded in 'managed'; ItemClose suppressed. Recover via full sync or manual state update.")
+		// Do NOT forward the ItemClose command — stranding local 'managed' +
+		// closed Todoist would break FindPendingFollowUp permanently.
 		return false, nil
 	}
 

--- a/backend/internal/todoist/provider.go
+++ b/backend/internal/todoist/provider.go
@@ -205,11 +205,11 @@ func (p *CadenceSyncProvider) Sync(
 		}
 	}
 
-	// Process synced items
+	// Process synced items. On a fatal error from processItems, we return
+	// early WITHOUT setting result.NewCursor so the next sync replays the
+	// batch from the pre-batch cursor.
 	processedTasks, commands, _, err := p.processItems(ctx, syncResp.Items, settings, accountID)
 	if err != nil {
-		// commit 1: processItems never returns a non-nil err. commit 2 turns on
-		// real fatal-error handling with the conditional-abort logic.
 		result.ItemsProcessed = processedTasks
 		return result, err
 	}
@@ -324,17 +324,11 @@ func (p *CadenceSyncProvider) processItems(
 	for _, item := range items {
 		r := p.processItem(ctx, item, settings, accountID)
 		if r.Err != nil {
-			if replayCommittedUnsafe {
-				logger.Error().Err(r.Err).
-					Str("itemId", item.ID).
-					Msg("processItem fatal error after non-replay-safe commit — forced to log-and-continue; cursor will advance and event is dropped")
+			shouldContinue, wrappedErr := p.decideFatalErrorPolicy(r, item, processed, replayCommittedUnsafe)
+			if shouldContinue {
 				continue
 			}
-			logger.Error().Err(r.Err).
-				Str("itemId", item.ID).
-				Int("processedBeforeAbort", processed).
-				Msg("processItem fatal error — aborting sync without advancing cursor")
-			return processed, nil, false, fmt.Errorf("process item %s: %w", item.ID, r.Err)
+			return processed, nil, false, wrappedErr
 		}
 		if r.Processed {
 			processed++
@@ -345,6 +339,40 @@ func (p *CadenceSyncProvider) processItems(
 		commands = append(commands, r.Commands...)
 	}
 	return processed, commands, replayCommittedUnsafe, nil
+}
+
+// decideFatalErrorPolicy implements the conditional-abort semantics for
+// processItems. Extracted from the loop so tests can verify both branches
+// (abort vs log-and-continue) without needing to simulate a mid-batch DB
+// failure under a shared connection.
+//
+// Returns shouldContinue=true when replayCommittedUnsafe is true: the sync
+// loop must not abort because an earlier unsafe handler (handleSkipTrigger)
+// already committed side effects that cannot be safely replayed. In that
+// case, the error is logged but the cursor will advance past this batch —
+// matching the pre-existing log-and-continue failure mode for the mixed-
+// batch scenario.
+//
+// Returns shouldContinue=false and a wrapped error when no unsafe commit has
+// occurred yet in the batch. The sync loop should return the wrapped error
+// without advancing the cursor, so the next tick replays the batch.
+func (p *CadenceSyncProvider) decideFatalErrorPolicy(
+	r processItemResult,
+	item SyncItem,
+	processedBeforeAbort int,
+	replayCommittedUnsafe bool,
+) (shouldContinue bool, wrappedErr error) {
+	if replayCommittedUnsafe {
+		logger.Error().Err(r.Err).
+			Str("itemId", item.ID).
+			Msg("processItem fatal error after non-replay-safe commit — forced to log-and-continue; cursor will advance and event is dropped")
+		return true, nil
+	}
+	logger.Error().Err(r.Err).
+		Str("itemId", item.ID).
+		Int("processedBeforeAbort", processedBeforeAbort).
+		Msg("processItem fatal error — aborting sync without advancing cursor")
+	return false, fmt.Errorf("process item %s: %w", item.ID, r.Err)
 }
 
 // processItem processes a single Todoist item from sync
@@ -392,14 +420,7 @@ func (p *CadenceSyncProvider) processItem(
 
 	// Check for recurring detection (transition to unmanaged)
 	if item.Due != nil && item.Due.IsRecurring {
-		logger.Info().
-			Str("taskId", item.ID).
-			Str("contactId", task.ContactID.String()).
-			Msg("task became recurring, transitioning to unmanaged")
-		if _, err := p.contactTaskRepo.UpdateContactTaskState(ctx, task.ID, repository.ContactTaskStateUnmanaged); err != nil {
-			return processItemResult{Err: fmt.Errorf("process item: update state to unmanaged (recurring): %w", err)}
-		}
-		return processItemResult{Processed: true}
+		return p.handleRecurringDetection(ctx, item, task)
 	}
 
 	// Check for completion
@@ -472,6 +493,28 @@ func (p *CadenceSyncProvider) processItem(
 	}
 
 	return processItemResult{Processed: true, Commands: commands}
+}
+
+// handleRecurringDetection transitions a task to 'unmanaged' when it has been
+// edited in Todoist to become recurring. Recurring tasks are not cadence-
+// tracked because they manage their own lifecycle in Todoist.
+//
+// Returns a fatal error via processItemResult.Err on state-update failure.
+// This state transition is the entire point of the branch, so a silent failure
+// would leave the row permanently mis-managed.
+func (p *CadenceSyncProvider) handleRecurringDetection(
+	ctx context.Context,
+	item SyncItem,
+	task *repository.ContactTask,
+) processItemResult {
+	logger.Info().
+		Str("taskId", item.ID).
+		Str("contactId", task.ContactID.String()).
+		Msg("task became recurring, transitioning to unmanaged")
+	if _, err := p.contactTaskRepo.UpdateContactTaskState(ctx, task.ID, repository.ContactTaskStateUnmanaged); err != nil {
+		return processItemResult{Err: fmt.Errorf("process item: update state to unmanaged (recurring): %w", err)}
+	}
+	return processItemResult{Processed: true}
 }
 
 // handleTaskCompletion handles a completed Todoist task.

--- a/backend/internal/todoist/provider.go
+++ b/backend/internal/todoist/provider.go
@@ -560,28 +560,37 @@ func (p *CadenceSyncProvider) handleSkipTrigger(
 // cadence clock is driven by real engagement and continues from its last real
 // mutual/inbound interaction.
 //
-// For non-deletion triggers we return an ItemClose command so the batched sync
-// path cleans up the orphaned task in Todoist. No retry flag is set — if the
-// batch fails, the local row is still correctly 'dismissed' and subsequent
-// syncs will skip it via the existing state != 'managed' early-return in
-// processItem.
+// State is persisted BEFORE any ItemClose command is queued. If the state
+// update fails, we return (false, nil) so the sync loop does not forward an
+// ItemClose that would close the Todoist task while leaving the local row
+// `managed` — that combination would permanently suppress cadence
+// reconciliation via FindPendingFollowUp. Returning false also means the next
+// sync tick will see the still-managed task and retry dismissal.
+//
+// For non-deletion triggers, once the state transition succeeds we queue an
+// ItemClose command so the batched sync path cleans up the orphaned task in
+// Todoist. No retry flag is set — if the batch fails, the local row is still
+// correctly 'dismissed' and subsequent syncs will skip it via the existing
+// state != 'managed' early-return in processItem.
 func (p *CadenceSyncProvider) handleFollowUpDismissal(
 	ctx context.Context,
 	item SyncItem,
 	task *repository.ContactTask,
 	contact *repository.Contact,
 ) (bool, []SyncCommand) {
-	var commands []SyncCommand
-	if !item.IsDeleted {
-		commands = append(commands, NewItemCloseCommand(item.ID))
-	}
-
 	if _, err := p.contactTaskRepo.UpdateContactTaskState(ctx, task.ID, repository.ContactTaskStateDismissed); err != nil {
 		logger.Warn().Err(err).
 			Str("taskId", task.ID.String()).
 			Str("contactId", contact.ID.String()).
-			Msg("failed to mark follow-up task as dismissed")
-		return true, commands
+			Msg("failed to mark follow-up task as dismissed — will retry on next sync")
+		// Return false + nil commands so the sync loop does not forward an
+		// ItemClose that would strand the local row in 'managed'.
+		return false, nil
+	}
+
+	var commands []SyncCommand
+	if !item.IsDeleted {
+		commands = append(commands, NewItemCloseCommand(item.ID))
 	}
 
 	logger.Info().

--- a/backend/internal/todoist/provider.go
+++ b/backend/internal/todoist/provider.go
@@ -345,33 +345,33 @@ func (p *CadenceSyncProvider) processItem(
 		return p.handleTaskCompletion(ctx, item, task, contact, settings, accountID)
 	}
 
-	// Handle action tasks vs cadence tasks differently for skip triggers
+	// Handle action tasks vs cadence/follow-up tasks differently for skip triggers.
 	if task.Kind == TaskKindAction {
 		return p.handleActionTaskTriggers(ctx, item, task, settings)
 	}
 
-	// Skip triggers for cadence tasks only
+	// Detect skip triggers (shared between cadence and follow_up kinds).
 	skipTriggered := false
-
-	// 1. Task deleted
-	if item.IsDeleted {
-		skipTriggered = true
-		logger.Info().Str("taskId", item.ID).Str("reason", "deleted").Msg("skip trigger detected")
-	}
-
-	// 2. Label removed (check if our label is still present)
-	if !skipTriggered && !containsLabel(item.Labels, settings.LabelName) {
-		skipTriggered = true
-		logger.Info().Str("taskId", item.ID).Str("reason", "label_removed").Msg("skip trigger detected")
-	}
-
-	// 3. Deadline removed
-	if !skipTriggered && item.Deadline == nil {
-		skipTriggered = true
-		logger.Info().Str("taskId", item.ID).Str("reason", "deadline_removed").Msg("skip trigger detected")
+	reason := ""
+	switch {
+	case item.IsDeleted:
+		skipTriggered, reason = true, "deleted"
+	case !containsLabel(item.Labels, settings.LabelName):
+		skipTriggered, reason = true, "label_removed"
+	case item.Deadline == nil:
+		skipTriggered, reason = true, "deadline_removed"
 	}
 
 	if skipTriggered {
+		logger.Info().
+			Str("taskId", item.ID).
+			Str("reason", reason).
+			Str("kind", task.Kind).
+			Msg("skip trigger detected")
+
+		if task.Kind == TaskKindFollowUp {
+			return p.handleFollowUpDismissal(ctx, item, task, contact)
+		}
 		return p.handleSkipTrigger(ctx, task, contact, settings, accountID)
 	}
 
@@ -547,6 +547,50 @@ func (p *CadenceSyncProvider) handleSkipTrigger(
 				Msg("processed skip trigger, created new task")
 		}
 	}
+
+	return true, commands
+}
+
+// handleFollowUpDismissal handles a follow-up task being dismissed via Todoist.
+// Triggered when the user deletes the task, removes the CRM label, or removes
+// the deadline on a follow_up kind task. Marks the local contact_task as
+// 'dismissed' and does NOT record an interaction, does NOT create a successor
+// follow-up, and does NOT touch any contact date field (last_contacted,
+// last_interaction_at, last_response_at, contact_by, last_outreach_at). The
+// cadence clock is driven by real engagement and continues from its last real
+// mutual/inbound interaction.
+//
+// For non-deletion triggers we return an ItemClose command so the batched sync
+// path cleans up the orphaned task in Todoist. No retry flag is set — if the
+// batch fails, the local row is still correctly 'dismissed' and subsequent
+// syncs will skip it via the existing state != 'managed' early-return in
+// processItem.
+func (p *CadenceSyncProvider) handleFollowUpDismissal(
+	ctx context.Context,
+	item SyncItem,
+	task *repository.ContactTask,
+	contact *repository.Contact,
+) (bool, []SyncCommand) {
+	var commands []SyncCommand
+	if !item.IsDeleted {
+		commands = append(commands, NewItemCloseCommand(item.ID))
+	}
+
+	if _, err := p.contactTaskRepo.UpdateContactTaskState(ctx, task.ID, repository.ContactTaskStateDismissed); err != nil {
+		logger.Warn().Err(err).
+			Str("taskId", task.ID.String()).
+			Str("contactId", contact.ID.String()).
+			Msg("failed to mark follow-up task as dismissed")
+		return true, commands
+	}
+
+	logger.Info().
+		Str("contactId", contact.ID.String()).
+		Str("contactName", contact.FullName).
+		Str("todoistTaskId", task.ExternalTaskID).
+		Bool("itemDeleted", item.IsDeleted).
+		Int("commandsQueued", len(commands)).
+		Msg("follow-up dismissed via Todoist")
 
 	return true, commands
 }

--- a/backend/internal/todoist/provider_dismissal_test.go
+++ b/backend/internal/todoist/provider_dismissal_test.go
@@ -806,8 +806,58 @@ func TestProcessItems_AbortsWhenNoUnsafeCommit(t *testing.T) {
 	assert.Contains(t, err.Error(), "process item", "outer wrapper should identify the item")
 	assert.Contains(t, err.Error(), "lookup contact_task", "inner error should identify the failed op")
 	assert.Equal(t, 0, processed, "no items should be counted as processed on abort")
-	assert.Nil(t, commands, "no commands should be returned on abort")
+	// No prior items succeeded, so no commands accumulated.
+	assert.Empty(t, commands, "no commands should be accumulated when the first item errors")
 	assert.False(t, replayCommittedUnsafe, "no unsafe commit occurred before abort")
+}
+
+// TestProcessItems_SuccessfulDismissalReturnsItemClose verifies that a
+// valid follow-up dismissal routed through processItems returns the
+// ItemClose command in the accumulated commands slice. Together with
+// TestProcessItems_AbortsWhenNoUnsafeCommit (which verifies that the abort
+// path returns the in-scope commands variable rather than a hard-coded
+// nil), this exercises both sides of the command-accumulation contract
+// that the orphaned-Todoist-task fix relies on: the slice always carries
+// whatever was accumulated before the (possibly aborted) iteration, so
+// the caller (Sync) can execute accumulated cleanup commands even when
+// the batch aborts.
+//
+// Note: simulating a true mid-batch "item 1 succeeds with a command,
+// item 2 errors fatally" flow under a shared pgx connection without
+// flakiness is not feasible — the cancelled-context error-injection
+// strategy applies to the whole batch, and live-DB failure injection
+// would require ad-hoc triggers or a mock repository wrapping. The
+// two-line fix (processItems returns `commands` instead of `nil` on
+// abort; Sync executes commands before returning the error) is verified
+// here by exercising both the success return shape and the abort return
+// shape, together with code inspection of the trivial fix.
+func TestProcessItems_SuccessfulDismissalReturnsItemClose(t *testing.T) {
+	env, cleanup := setupDismissalTest(t)
+	defer cleanup()
+
+	contact, _ := createDismissalContact(t, env, "PreserveCmds")
+	externalID := "td-preserve-" + uuid.New().String()[:8]
+	_ = createFollowUpTask(t, env, contact.ID, externalID)
+
+	processed, commands, replayCommittedUnsafe, err := env.provider.processItems(
+		env.ctx,
+		[]SyncItem{
+			{
+				ID:        externalID,
+				IsDeleted: false,
+				Labels:    []string{}, // label removed trigger
+				Deadline:  &SyncDate{Date: "2099-01-01"},
+			},
+		},
+		env.settings,
+		env.accountID,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 1, processed)
+	assert.False(t, replayCommittedUnsafe)
+	require.Len(t, commands, 1, "successful dismissal must return an ItemClose command")
+	assert.Equal(t, "item_close", commands[0].Type)
+	assert.Equal(t, externalID, commands[0].Args["id"])
 }
 
 // TestHandleTaskCompletion_StateUpdateFailureDoesNotReturnError is a

--- a/backend/internal/todoist/provider_dismissal_test.go
+++ b/backend/internal/todoist/provider_dismissal_test.go
@@ -858,6 +858,105 @@ func TestHandleTaskCompletion_StateUpdateFailureDoesNotReturnError(t *testing.T)
 	assert.False(t, r.Unsafe, "completion's state transition is replay-safe")
 }
 
+// TestHandleRecurringDetection_StateUpdateErrorPropagates verifies that a DB
+// failure in the recurring-detection branch is propagated via
+// processItemResult.Err. Without this, a silent failure would leave the row
+// permanently mis-managed.
+func TestHandleRecurringDetection_StateUpdateErrorPropagates(t *testing.T) {
+	env, cleanup := setupDismissalTest(t)
+	defer cleanup()
+
+	contact, _ := createDismissalContact(t, env, "Recurring")
+	cadenceExtID := "td-recur-" + uuid.New().String()[:8]
+	task, err := env.contactTaskRepo.CreateContactTask(env.ctx, repository.CreateContactTaskRequest{
+		ContactID:      contact.ID,
+		Provider:       SourceName,
+		Kind:           TaskKindCadence,
+		ExternalTaskID: cadenceExtID,
+		State:          string(repository.ContactTaskStateManaged),
+		Metadata:       map[string]any{},
+	})
+	require.NoError(t, err)
+
+	badCtx := cancelledContext()
+
+	r := env.provider.handleRecurringDetection(badCtx, SyncItem{
+		ID: cadenceExtID,
+		Due: &SyncDue{
+			Date:        "2099-01-01",
+			IsRecurring: true,
+		},
+	}, task)
+
+	require.Error(t, r.Err)
+	assert.Contains(t, r.Err.Error(), "update state to unmanaged (recurring)",
+		"error should identify the recurring state-update failure")
+	assert.False(t, r.Processed, "failed state update must not report Processed=true")
+	assert.False(t, r.Unsafe, "recurring transition is replay-safe")
+	assert.Nil(t, r.Commands)
+}
+
+// TestDecideFatalErrorPolicy_AbortsWhenReplaySafe verifies that
+// decideFatalErrorPolicy returns shouldContinue=false and a wrapped error
+// when no earlier unsafe commit has occurred in the batch. This is the
+// direct unit test for the abort path in the conditional-abort logic.
+func TestDecideFatalErrorPolicy_AbortsWhenReplaySafe(t *testing.T) {
+	env, cleanup := setupDismissalTest(t)
+	defer cleanup()
+
+	itemID := "td-abort-policy-" + uuid.New().String()[:8]
+	fakeResult := processItemResult{
+		Err: errors.New("underlying db failure"),
+	}
+
+	shouldContinue, wrappedErr := env.provider.decideFatalErrorPolicy(
+		fakeResult,
+		SyncItem{ID: itemID},
+		0,     // processedBeforeAbort
+		false, // replayCommittedUnsafe
+	)
+
+	assert.False(t, shouldContinue, "no earlier unsafe commit → must abort")
+	require.Error(t, wrappedErr)
+	assert.Contains(t, wrappedErr.Error(), "process item "+itemID,
+		"wrapped error should include item ID")
+	assert.Contains(t, wrappedErr.Error(), "underlying db failure",
+		"wrapped error should chain the original cause")
+}
+
+// TestDecideFatalErrorPolicy_LogsAndContinuesAfterUnsafe verifies that
+// decideFatalErrorPolicy returns shouldContinue=true and nil error when an
+// earlier item in the batch already committed non-replay-safe state via
+// handleSkipTrigger. This is the direct unit test for the log-and-continue
+// path — it exists because simulating mid-batch DB failure with a shared
+// connection is non-trivial, and extracting this policy into a testable
+// helper lets us verify the branch without DB-level failure injection.
+//
+// Together with TestHandleSkipTrigger_FailureDoesNotReturnErrorAndSetsUnsafe
+// (which locks in Unsafe=true on the skip-trigger success path) and
+// TestProcessItems_AbortsWhenNoUnsafeCommit (which verifies the loop wiring
+// for the abort path), this test completes coverage of the conditional-
+// abort semantics.
+func TestDecideFatalErrorPolicy_LogsAndContinuesAfterUnsafe(t *testing.T) {
+	env, cleanup := setupDismissalTest(t)
+	defer cleanup()
+
+	itemID := "td-continue-policy-" + uuid.New().String()[:8]
+	fakeResult := processItemResult{
+		Err: errors.New("underlying db failure"),
+	}
+
+	shouldContinue, wrappedErr := env.provider.decideFatalErrorPolicy(
+		fakeResult,
+		SyncItem{ID: itemID},
+		1,    // processedBeforeAbort — an earlier item succeeded
+		true, // replayCommittedUnsafe — earlier skip trigger advanced contact_by
+	)
+
+	assert.True(t, shouldContinue, "unsafe commit already occurred → must log and continue")
+	assert.NoError(t, wrappedErr, "continuing must not return an error")
+}
+
 // TestHandleSkipTrigger_FailureDoesNotReturnErrorAndSetsUnsafe is a guardrail
 // test: handleSkipTrigger intentionally retains log-and-continue semantics
 // on DB failure because it commits non-idempotent side effects (contact_by

--- a/backend/internal/todoist/provider_dismissal_test.go
+++ b/backend/internal/todoist/provider_dismissal_test.go
@@ -299,7 +299,8 @@ func TestFollowUpDismissal_DeadlineRemoved(t *testing.T) {
 }
 
 // Case 4: dismissing a follow-up must not touch a coexisting managed cadence
-// task for the same contact.
+// task for the same contact — state, external ID, metadata, and updated_at
+// stay exactly as they were.
 func TestFollowUpDismissal_CadenceTaskUnaffected(t *testing.T) {
 	env, cleanup := setupDismissalTest(t)
 	defer cleanup()
@@ -307,15 +308,21 @@ func TestFollowUpDismissal_CadenceTaskUnaffected(t *testing.T) {
 	contact, _ := createDismissalContact(t, env, "CadenceUnaffected")
 
 	cadenceExtID := "td-cadence-" + uuid.New().String()[:8]
+	cadenceMetadata := map[string]any{
+		"synced_deadline":       "2099-01-01",
+		"synced_last_contacted": "2026-01-01T00:00:00Z",
+		"pending_temp_id":       "temp-123",
+	}
 	cadenceTask, err := env.contactTaskRepo.CreateContactTask(env.ctx, repository.CreateContactTaskRequest{
 		ContactID:      contact.ID,
 		Provider:       SourceName,
 		Kind:           TaskKindCadence,
 		ExternalTaskID: cadenceExtID,
 		State:          string(repository.ContactTaskStateManaged),
-		Metadata:       map[string]any{"synced_deadline": "2099-01-01"},
+		Metadata:       cadenceMetadata,
 	})
 	require.NoError(t, err)
+	originalUpdatedAt := cadenceTask.UpdatedAt
 
 	followupExtID := "td-followup-" + uuid.New().String()[:8]
 	_ = createFollowUpTask(t, env, contact.ID, followupExtID)
@@ -331,6 +338,10 @@ func TestFollowUpDismissal_CadenceTaskUnaffected(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, repository.ContactTaskStateManaged, reloaded.State, "cadence task must remain managed")
 	assert.Equal(t, cadenceExtID, reloaded.ExternalTaskID, "cadence external ID must be unchanged")
+	assert.Equal(t, cadenceMetadata["synced_deadline"], reloaded.Metadata["synced_deadline"], "cadence synced_deadline must be unchanged")
+	assert.Equal(t, cadenceMetadata["synced_last_contacted"], reloaded.Metadata["synced_last_contacted"], "cadence synced_last_contacted must be unchanged")
+	assert.Equal(t, cadenceMetadata["pending_temp_id"], reloaded.Metadata["pending_temp_id"], "cadence pending_temp_id must be unchanged")
+	assert.True(t, reloaded.UpdatedAt.Equal(originalUpdatedAt), "cadence updated_at must not have been bumped")
 }
 
 // Case 5: after dismissal, a subsequent processItem call on the same external
@@ -411,43 +422,84 @@ func TestFollowUpDismissal_ContactFollowUpFiltersIgnoreDismissed(t *testing.T) {
 	assert.True(t, contactInFilter("no_followup"), "contact with only a dismissed follow-up should appear in no_followup")
 }
 
-// Case 8a: dispatch for cadence is unchanged — a cadence task hit with a skip
-// trigger still routes through handleSkipTrigger (observable via a new
-// item_add command being returned).
+// Case 8a: dispatch for cadence is unchanged — a cadence task hit with any
+// skip trigger (deleted / label removed / deadline removed) still routes
+// through handleSkipTrigger (observable via a new item_add command being
+// returned for the replacement cadence task). This is the regression guardrail
+// for the processItem skip-trigger switch: a broken precedence would fail to
+// dispatch one of the three trigger variants.
 func TestFollowUpDismissal_CadenceDispatchUnchanged(t *testing.T) {
-	env, cleanup := setupDismissalTest(t)
-	defer cleanup()
-
-	contact, _ := createDismissalContact(t, env, "CadenceDispatch")
-
-	cadenceExtID := "td-cadence-" + uuid.New().String()[:8]
-	_, err := env.contactTaskRepo.CreateContactTask(env.ctx, repository.CreateContactTaskRequest{
-		ContactID:      contact.ID,
-		Provider:       SourceName,
-		Kind:           TaskKindCadence,
-		ExternalTaskID: cadenceExtID,
-		State:          string(repository.ContactTaskStateManaged),
-		Metadata:       map[string]any{"synced_deadline": "2099-01-01"},
-	})
-	require.NoError(t, err)
-
-	ok, commands := env.provider.processItem(env.ctx, SyncItem{
-		ID:        cadenceExtID,
-		IsDeleted: true,
-		Labels:    []string{env.settings.LabelName},
-		Deadline:  &SyncDate{Date: "2099-01-01"},
-	}, env.settings, env.accountID)
-
-	assert.True(t, ok)
-	require.NotEmpty(t, commands, "handleSkipTrigger should return an item_add command for the replacement cadence task")
-
-	sawItemAdd := false
-	for _, cmd := range commands {
-		if cmd.Type == "item_add" {
-			sawItemAdd = true
-		}
+	cases := []struct {
+		name string
+		item func(externalID, label string) SyncItem
+	}{
+		{
+			name: "deleted",
+			item: func(externalID, label string) SyncItem {
+				return SyncItem{
+					ID:        externalID,
+					IsDeleted: true,
+					Labels:    []string{label},
+					Deadline:  &SyncDate{Date: "2099-01-01"},
+				}
+			},
+		},
+		{
+			name: "label_removed",
+			item: func(externalID, _ string) SyncItem {
+				return SyncItem{
+					ID:        externalID,
+					IsDeleted: false,
+					Labels:    []string{}, // CRM label absent
+					Deadline:  &SyncDate{Date: "2099-01-01"},
+				}
+			},
+		},
+		{
+			name: "deadline_removed",
+			item: func(externalID, label string) SyncItem {
+				return SyncItem{
+					ID:        externalID,
+					IsDeleted: false,
+					Labels:    []string{label},
+					Deadline:  nil,
+				}
+			},
+		},
 	}
-	assert.True(t, sawItemAdd, "expected at least one item_add command from cadence skip-trigger")
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env, cleanup := setupDismissalTest(t)
+			defer cleanup()
+
+			contact, _ := createDismissalContact(t, env, "CadenceDispatch_"+tc.name)
+
+			cadenceExtID := "td-cadence-" + uuid.New().String()[:8]
+			_, err := env.contactTaskRepo.CreateContactTask(env.ctx, repository.CreateContactTaskRequest{
+				ContactID:      contact.ID,
+				Provider:       SourceName,
+				Kind:           TaskKindCadence,
+				ExternalTaskID: cadenceExtID,
+				State:          string(repository.ContactTaskStateManaged),
+				Metadata:       map[string]any{"synced_deadline": "2099-01-01"},
+			})
+			require.NoError(t, err)
+
+			ok, commands := env.provider.processItem(env.ctx, tc.item(cadenceExtID, env.settings.LabelName), env.settings, env.accountID)
+
+			assert.True(t, ok)
+			require.NotEmpty(t, commands, "handleSkipTrigger should return an item_add command for the replacement cadence task")
+
+			sawItemAdd := false
+			for _, cmd := range commands {
+				if cmd.Type == "item_add" {
+					sawItemAdd = true
+				}
+			}
+			assert.True(t, sawItemAdd, "expected at least one item_add command from cadence skip-trigger (%s)", tc.name)
+		})
+	}
 }
 
 // Case 8b: dispatch for action is unchanged — an action task being deleted

--- a/backend/internal/todoist/provider_dismissal_test.go
+++ b/backend/internal/todoist/provider_dismissal_test.go
@@ -38,6 +38,19 @@ func (r *countingRecorder) RecordInteraction(_ context.Context, _ repository.Rec
 	return &repository.Interaction{ID: uuid.New()}, nil
 }
 
+// permissiveRecorder records call counts without failing the test. Used by
+// tests that exercise code paths which legitimately call RecordInteraction
+// (e.g., handleTaskCompletion) where the test only cares about the caller's
+// return value, not whether the interaction succeeds.
+type permissiveRecorder struct {
+	count int
+}
+
+func (r *permissiveRecorder) RecordInteraction(_ context.Context, _ repository.RecordInteractionRequest) (*repository.Interaction, error) {
+	r.count++
+	return &repository.Interaction{ID: uuid.New()}, nil
+}
+
 type dismissalTestEnv struct {
 	ctx             context.Context
 	provider        *CadenceSyncProvider
@@ -48,10 +61,24 @@ type dismissalTestEnv struct {
 	accountID       string
 }
 
-// setupDismissalTest builds a CadenceSyncProvider wired to a real DB and a test
-// interactionRecorder that asserts it is never called. Skips if DATABASE_URL is
-// unset, matching the pattern in backend/tests/followup_service_test.go.
-func setupDismissalTest(t *testing.T) (*dismissalTestEnv, func()) {
+// providerTestEnv is a lightweight variant of dismissalTestEnv used by tests
+// that need a permissive recorder (notably the handleTaskCompletion guardrail
+// test, where RecordInteraction is legitimately called during the handler's
+// normal flow).
+type providerTestEnv struct {
+	ctx             context.Context
+	provider        *CadenceSyncProvider
+	contactRepo     *repository.ContactRepository
+	contactTaskRepo *repository.ContactTaskRepository
+	settings        Settings
+	accountID       string
+}
+
+// newProviderTestEnv builds the shared DB + repos + provider infrastructure
+// used by both setupDismissalTest and setupProviderTestPermissive. Takes the
+// recorder as a parameter so callers can pass either the strict countingRecorder
+// or the permissiveRecorder.
+func newProviderTestEnv(t *testing.T, recorder interactionRecorder) (*CadenceSyncProvider, *repository.ContactRepository, *repository.ContactTaskRepository, context.Context, Settings, string, func()) {
 	t.Helper()
 
 	databaseURL := os.Getenv("DATABASE_URL")
@@ -77,34 +104,76 @@ func setupDismissalTest(t *testing.T) (*dismissalTestEnv, func()) {
 	contactRepo := repository.NewContactRepository(database.Queries)
 	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
 	cfg := config.TestConfig()
-	recorder := &countingRecorder{t: t}
 
 	provider := NewCadenceSyncProvider(
-		nil, // oauthService: not consulted on the dismissal path
+		nil, // oauthService: not consulted on this code path
 		contactTaskRepo,
 		contactRepo,
-		nil, // syncRepo: not consulted on the dismissal path
+		nil, // syncRepo: not consulted on this code path
 		cfg,
 		recorder,
 	)
 
-	env := &dismissalTestEnv{
+	settings := Settings{
+		ProjectID:             "test-project",
+		ProjectName:           "CRM",
+		LabelID:               "test-label-id",
+		LabelName:             "crm",
+		IntegrationInstanceID: "test-instance",
+	}
+	accountID := "test-account"
+
+	return provider, contactRepo, contactTaskRepo, ctx, settings, accountID, func() { database.Close() }
+}
+
+// setupDismissalTest builds a CadenceSyncProvider wired to a real DB and a test
+// interactionRecorder that asserts it is never called. Skips if DATABASE_URL is
+// unset, matching the pattern in backend/tests/followup_service_test.go.
+func setupDismissalTest(t *testing.T) (*dismissalTestEnv, func()) {
+	t.Helper()
+
+	recorder := &countingRecorder{t: t}
+	provider, contactRepo, contactTaskRepo, ctx, settings, accountID, cleanup := newProviderTestEnv(t, recorder)
+
+	return &dismissalTestEnv{
 		ctx:             ctx,
 		provider:        provider,
 		contactRepo:     contactRepo,
 		contactTaskRepo: contactTaskRepo,
 		recorder:        recorder,
-		settings: Settings{
-			ProjectID:             "test-project",
-			ProjectName:           "CRM",
-			LabelID:               "test-label-id",
-			LabelName:             "crm",
-			IntegrationInstanceID: "test-instance",
-		},
-		accountID: "test-account",
-	}
+		settings:        settings,
+		accountID:       accountID,
+	}, cleanup
+}
 
-	return env, func() { database.Close() }
+// setupProviderTestPermissive builds a CadenceSyncProvider with a permissive
+// recorder that does not fail the test on RecordInteraction calls. Used by
+// tests that exercise handleTaskCompletion directly, since it calls
+// RecordInteraction as part of its normal flow.
+func setupProviderTestPermissive(t *testing.T) (*providerTestEnv, func()) {
+	t.Helper()
+
+	recorder := &permissiveRecorder{}
+	provider, contactRepo, contactTaskRepo, ctx, settings, accountID, cleanup := newProviderTestEnv(t, recorder)
+
+	return &providerTestEnv{
+		ctx:             ctx,
+		provider:        provider,
+		contactRepo:     contactRepo,
+		contactTaskRepo: contactTaskRepo,
+		settings:        settings,
+		accountID:       accountID,
+	}, cleanup
+}
+
+// cancelledContext returns a context that is already cancelled. Used by
+// error-injection tests to force pgx repository calls to fail deterministically
+// with context.Canceled. More reliable than closing the DB pool, which may
+// allow in-flight queries to succeed non-deterministically.
+func cancelledContext() context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	return ctx
 }
 
 // migrationsPathForTest returns the absolute path to backend/migrations from the
@@ -578,4 +647,249 @@ func assertDismissedAndInvariants(t *testing.T, env *dismissalTestEnv, contactID
 
 	// All contact date fields unchanged.
 	assertDatesUnchanged(t, env, contactID, snap)
+}
+
+// ============================================================================
+// Error-propagation regression tests (Option C / #264)
+// ============================================================================
+//
+// These tests exercise the fatal-error propagation paths added in Step 2 of
+// the todoist-processitem-error-propagation plan. They use a cancelled
+// context to force repository calls to fail deterministically with
+// context.Canceled (more reliable than closing the pool mid-test).
+//
+// The tests call handlers directly, not through processItem, because
+// processItem's GetContactTaskByExternalID lookup would fail first under the
+// cancelled-context strategy, masking the target handler's error path.
+
+// TestHandleFollowUpDismissal_StateUpdateErrorPropagates verifies that a DB
+// failure in UpdateContactTaskState is propagated via processItemResult.Err
+// rather than swallowed. The handler must NOT forward an ItemClose command
+// on failure (stranding the local row in 'managed' while closing Todoist
+// would break FindPendingFollowUp permanently).
+func TestHandleFollowUpDismissal_StateUpdateErrorPropagates(t *testing.T) {
+	env, cleanup := setupDismissalTest(t)
+	defer cleanup()
+
+	contact, _ := createDismissalContact(t, env, "DismissalError")
+	externalID := "td-err-" + uuid.New().String()[:8]
+	task := createFollowUpTask(t, env, contact.ID, externalID)
+
+	// Use a cancelled context to force the next repository call to fail.
+	badCtx := cancelledContext()
+
+	r := env.provider.handleFollowUpDismissal(badCtx, SyncItem{
+		ID:        externalID,
+		IsDeleted: false,
+		Labels:    []string{}, // label removed trigger (but any trigger is fine)
+		Deadline:  &SyncDate{Date: "2099-01-01"},
+	}, task, contact)
+
+	require.Error(t, r.Err)
+	assert.Contains(t, r.Err.Error(), "dismiss follow-up", "error should be wrapped with dismiss follow-up")
+	assert.Contains(t, r.Err.Error(), "contact_task state", "error should identify the failed operation")
+	assert.False(t, r.Processed, "failed dismissal must not report Processed=true")
+	assert.False(t, r.Unsafe, "follow-up dismissal is replay-safe")
+	assert.Nil(t, r.Commands, "ItemClose must NOT be forwarded on state-update failure")
+	assert.Equal(t, 0, env.recorder.count, "dismissal path must never record interactions")
+}
+
+// TestHandleActionTaskTriggers_StateUpdateErrorPropagates_Deleted verifies
+// that the deleted-branch state-update failure propagates via Err.
+func TestHandleActionTaskTriggers_StateUpdateErrorPropagates_Deleted(t *testing.T) {
+	env, cleanup := setupDismissalTest(t)
+	defer cleanup()
+
+	contact, _ := createDismissalContact(t, env, "ActionErrDeleted")
+	actionExtID := "td-action-err-" + uuid.New().String()[:8]
+	action, err := env.contactTaskRepo.CreateContactTask(env.ctx, repository.CreateContactTaskRequest{
+		ContactID:      contact.ID,
+		Provider:       SourceName,
+		Kind:           TaskKindAction,
+		ExternalTaskID: actionExtID,
+		State:          string(repository.ContactTaskStateManaged),
+		Metadata:       map[string]any{},
+	})
+	require.NoError(t, err)
+
+	badCtx := cancelledContext()
+
+	r := env.provider.handleActionTaskTriggers(badCtx, SyncItem{
+		ID:        actionExtID,
+		IsDeleted: true,
+		Labels:    []string{env.settings.LabelName},
+		Deadline:  &SyncDate{Date: "2099-01-01"},
+	}, action, env.settings)
+
+	require.Error(t, r.Err)
+	assert.Contains(t, r.Err.Error(), "action task triggers (deleted)")
+	assert.False(t, r.Processed)
+	assert.False(t, r.Unsafe, "action unmanagement is replay-safe")
+	assert.Nil(t, r.Commands)
+}
+
+// TestHandleActionTaskTriggers_StateUpdateErrorPropagates_LabelRemoved verifies
+// that the label-removed branch state-update failure propagates via Err.
+func TestHandleActionTaskTriggers_StateUpdateErrorPropagates_LabelRemoved(t *testing.T) {
+	env, cleanup := setupDismissalTest(t)
+	defer cleanup()
+
+	contact, _ := createDismissalContact(t, env, "ActionErrLabel")
+	actionExtID := "td-action-err2-" + uuid.New().String()[:8]
+	action, err := env.contactTaskRepo.CreateContactTask(env.ctx, repository.CreateContactTaskRequest{
+		ContactID:      contact.ID,
+		Provider:       SourceName,
+		Kind:           TaskKindAction,
+		ExternalTaskID: actionExtID,
+		State:          string(repository.ContactTaskStateManaged),
+		Metadata:       map[string]any{},
+	})
+	require.NoError(t, err)
+
+	badCtx := cancelledContext()
+
+	r := env.provider.handleActionTaskTriggers(badCtx, SyncItem{
+		ID:        actionExtID,
+		IsDeleted: false,
+		Labels:    []string{}, // CRM label removed
+		Deadline:  &SyncDate{Date: "2099-01-01"},
+	}, action, env.settings)
+
+	require.Error(t, r.Err)
+	assert.Contains(t, r.Err.Error(), "action task triggers (label removed)")
+	assert.False(t, r.Processed)
+	assert.False(t, r.Unsafe)
+	assert.Nil(t, r.Commands)
+}
+
+// TestProcessItem_LookupErrorPropagates verifies that a failed
+// GetContactTaskByExternalID lookup is propagated as a fatal error rather
+// than silently skipped.
+func TestProcessItem_LookupErrorPropagates(t *testing.T) {
+	env, cleanup := setupDismissalTest(t)
+	defer cleanup()
+
+	badCtx := cancelledContext()
+
+	r := env.provider.processItem(badCtx, SyncItem{
+		ID:     "td-lookup-err-" + uuid.New().String()[:8],
+		Labels: []string{env.settings.LabelName},
+	}, env.settings, env.accountID)
+
+	require.Error(t, r.Err)
+	assert.Contains(t, r.Err.Error(), "lookup contact_task", "error should identify the failed lookup")
+	assert.False(t, r.Processed)
+	assert.False(t, r.Unsafe)
+	assert.Nil(t, r.Commands)
+}
+
+// TestProcessItems_AbortsWhenNoUnsafeCommit verifies that a fatal error from
+// processItem with no earlier non-replay-safe commit causes processItems to
+// abort (return the error) and leave replayCommittedUnsafe==false so the
+// caller knows the cursor must not advance.
+func TestProcessItems_AbortsWhenNoUnsafeCommit(t *testing.T) {
+	env, cleanup := setupDismissalTest(t)
+	defer cleanup()
+
+	badCtx := cancelledContext()
+
+	processed, commands, replayCommittedUnsafe, err := env.provider.processItems(
+		badCtx,
+		[]SyncItem{
+			{ID: "td-abort-" + uuid.New().String()[:8], Labels: []string{env.settings.LabelName}},
+		},
+		env.settings,
+		env.accountID,
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "process item", "outer wrapper should identify the item")
+	assert.Contains(t, err.Error(), "lookup contact_task", "inner error should identify the failed op")
+	assert.Equal(t, 0, processed, "no items should be counted as processed on abort")
+	assert.Nil(t, commands, "no commands should be returned on abort")
+	assert.False(t, replayCommittedUnsafe, "no unsafe commit occurred before abort")
+}
+
+// TestHandleTaskCompletion_StateUpdateFailureDoesNotReturnError is a
+// guardrail test: handleTaskCompletion intentionally retains log-and-continue
+// semantics on DB failure, because a fatal-error conversion would break the
+// state→interaction ordering invariant documented in the handler's comment.
+// If someone later changes this to return an error without addressing the
+// ordering, this test fails loudly.
+//
+// Uses setupProviderTestPermissive because handleTaskCompletion calls
+// RecordInteraction as part of its normal flow, which would trip the strict
+// countingRecorder.
+//
+// TODO(followup-issue): when the deferred transactional refactor lands, this
+// guardrail test should be updated or removed to reflect the new semantics.
+func TestHandleTaskCompletion_StateUpdateFailureDoesNotReturnError(t *testing.T) {
+	env, cleanup := setupProviderTestPermissive(t)
+	defer cleanup()
+
+	// Create contact + managed cadence task.
+	cadenceStr := "monthly"
+	contact, err := env.contactRepo.CreateContact(env.ctx, repository.CreateContactRequest{
+		FullName: "CompletionGuard " + uuid.New().String()[:8],
+		Cadence:  &cadenceStr,
+	})
+	require.NoError(t, err)
+
+	cadenceExtID := "td-cad-guard-" + uuid.New().String()[:8]
+	task, err := env.contactTaskRepo.CreateContactTask(env.ctx, repository.CreateContactTaskRequest{
+		ContactID:      contact.ID,
+		Provider:       SourceName,
+		Kind:           TaskKindCadence,
+		ExternalTaskID: cadenceExtID,
+		State:          string(repository.ContactTaskStateManaged),
+		Metadata:       map[string]any{},
+	})
+	require.NoError(t, err)
+
+	badCtx := cancelledContext()
+
+	r := env.provider.handleTaskCompletion(badCtx, SyncItem{
+		ID:      cadenceExtID,
+		Checked: true,
+	}, task, contact, env.settings, env.accountID)
+
+	// Behavior intentionally unchanged: never returns an error.
+	require.NoError(t, r.Err, "handleTaskCompletion must retain log-and-continue semantics on DB failure")
+	assert.False(t, r.Unsafe, "completion's state transition is replay-safe")
+}
+
+// TestHandleSkipTrigger_FailureDoesNotReturnErrorAndSetsUnsafe is a guardrail
+// test: handleSkipTrigger intentionally retains log-and-continue semantics
+// on DB failure because it commits non-idempotent side effects (contact_by
+// advancement). Critically, it must set Unsafe: true even on partial
+// failures, because UpdateContactBy may already have fired before the
+// failure, advancing contact_by in the DB.
+//
+// TODO(followup-issue): when the deferred transactional refactor lands, this
+// guardrail test should be updated or removed to reflect the new semantics.
+func TestHandleSkipTrigger_FailureDoesNotReturnErrorAndSetsUnsafe(t *testing.T) {
+	env, cleanup := setupDismissalTest(t)
+	defer cleanup()
+
+	contact, _ := createDismissalContact(t, env, "SkipGuard")
+	cadenceExtID := "td-skip-guard-" + uuid.New().String()[:8]
+	task, err := env.contactTaskRepo.CreateContactTask(env.ctx, repository.CreateContactTaskRequest{
+		ContactID:      contact.ID,
+		Provider:       SourceName,
+		Kind:           TaskKindCadence,
+		ExternalTaskID: cadenceExtID,
+		State:          string(repository.ContactTaskStateManaged),
+		Metadata:       map[string]any{},
+	})
+	require.NoError(t, err)
+
+	badCtx := cancelledContext()
+
+	r := env.provider.handleSkipTrigger(badCtx, task, contact, env.settings, env.accountID)
+
+	// Behavior intentionally unchanged: never returns an error.
+	require.NoError(t, r.Err, "handleSkipTrigger must retain log-and-continue semantics on DB failure")
+	// CRUCIAL: Unsafe must still be true. UpdateContactBy may have advanced
+	// contact_by before the failure, so replay would double-advance.
+	assert.True(t, r.Unsafe, "skip trigger must report Unsafe=true even on partial failure")
 }

--- a/backend/internal/todoist/provider_dismissal_test.go
+++ b/backend/internal/todoist/provider_dismissal_test.go
@@ -232,15 +232,17 @@ func TestFollowUpDismissal_IsDeleted(t *testing.T) {
 	externalID := "td-task-" + uuid.New().String()[:8]
 	task := createFollowUpTask(t, env, contact.ID, externalID)
 
-	ok, commands := env.provider.processItem(env.ctx, SyncItem{
+	r := env.provider.processItem(env.ctx, SyncItem{
 		ID:        externalID,
 		IsDeleted: true,
 		Labels:    []string{env.settings.LabelName},
 		Deadline:  &SyncDate{Date: "2099-01-01"},
 	}, env.settings, env.accountID)
 
-	assert.True(t, ok, "processItem should return true (task was handled)")
-	assert.Empty(t, commands, "no Todoist commands should be emitted when item is already deleted")
+	require.NoError(t, r.Err)
+	assert.False(t, r.Unsafe, "follow-up dismissal is replay-safe")
+	assert.True(t, r.Processed, "processItem should return processed=true (task was handled)")
+	assert.Empty(t, r.Commands, "no Todoist commands should be emitted when item is already deleted")
 	assert.Equal(t, 0, env.recorder.count, "RecordInteraction must not be called during dismissal")
 
 	assertDismissedAndInvariants(t, env, contact.ID, task.ID, snap)
@@ -256,17 +258,19 @@ func TestFollowUpDismissal_LabelRemoved(t *testing.T) {
 	externalID := "td-task-" + uuid.New().String()[:8]
 	task := createFollowUpTask(t, env, contact.ID, externalID)
 
-	ok, commands := env.provider.processItem(env.ctx, SyncItem{
+	r := env.provider.processItem(env.ctx, SyncItem{
 		ID:        externalID,
 		IsDeleted: false,
 		Labels:    []string{}, // CRM label removed
 		Deadline:  &SyncDate{Date: "2099-01-01"},
 	}, env.settings, env.accountID)
 
-	assert.True(t, ok)
-	require.Len(t, commands, 1, "exactly one ItemClose command expected")
-	assert.Equal(t, "item_close", commands[0].Type)
-	assert.Equal(t, externalID, commands[0].Args["id"])
+	require.NoError(t, r.Err)
+	assert.False(t, r.Unsafe, "follow-up dismissal is replay-safe")
+	assert.True(t, r.Processed)
+	require.Len(t, r.Commands, 1, "exactly one ItemClose command expected")
+	assert.Equal(t, "item_close", r.Commands[0].Type)
+	assert.Equal(t, externalID, r.Commands[0].Args["id"])
 	assert.Equal(t, 0, env.recorder.count)
 
 	assertDismissedAndInvariants(t, env, contact.ID, task.ID, snap)
@@ -282,17 +286,19 @@ func TestFollowUpDismissal_DeadlineRemoved(t *testing.T) {
 	externalID := "td-task-" + uuid.New().String()[:8]
 	task := createFollowUpTask(t, env, contact.ID, externalID)
 
-	ok, commands := env.provider.processItem(env.ctx, SyncItem{
+	r := env.provider.processItem(env.ctx, SyncItem{
 		ID:        externalID,
 		IsDeleted: false,
 		Labels:    []string{env.settings.LabelName},
 		Deadline:  nil,
 	}, env.settings, env.accountID)
 
-	assert.True(t, ok)
-	require.Len(t, commands, 1)
-	assert.Equal(t, "item_close", commands[0].Type)
-	assert.Equal(t, externalID, commands[0].Args["id"])
+	require.NoError(t, r.Err)
+	assert.False(t, r.Unsafe, "follow-up dismissal is replay-safe")
+	assert.True(t, r.Processed)
+	require.Len(t, r.Commands, 1)
+	assert.Equal(t, "item_close", r.Commands[0].Type)
+	assert.Equal(t, externalID, r.Commands[0].Args["id"])
 	assert.Equal(t, 0, env.recorder.count)
 
 	assertDismissedAndInvariants(t, env, contact.ID, task.ID, snap)
@@ -327,7 +333,7 @@ func TestFollowUpDismissal_CadenceTaskUnaffected(t *testing.T) {
 	followupExtID := "td-followup-" + uuid.New().String()[:8]
 	_ = createFollowUpTask(t, env, contact.ID, followupExtID)
 
-	_, _ = env.provider.processItem(env.ctx, SyncItem{
+	_ = env.provider.processItem(env.ctx, SyncItem{
 		ID:        followupExtID,
 		IsDeleted: true,
 		Labels:    []string{env.settings.LabelName},
@@ -356,7 +362,7 @@ func TestFollowUpDismissal_SubsequentProcessItemSkipsDismissedRow(t *testing.T) 
 	_ = createFollowUpTask(t, env, contact.ID, externalID)
 
 	// First dismissal.
-	_, _ = env.provider.processItem(env.ctx, SyncItem{
+	_ = env.provider.processItem(env.ctx, SyncItem{
 		ID:        externalID,
 		IsDeleted: false,
 		Labels:    []string{env.settings.LabelName},
@@ -364,15 +370,17 @@ func TestFollowUpDismissal_SubsequentProcessItemSkipsDismissedRow(t *testing.T) 
 	}, env.settings, env.accountID)
 
 	// Second call — simulates the next sync tick seeing the same task.
-	ok, commands := env.provider.processItem(env.ctx, SyncItem{
+	r := env.provider.processItem(env.ctx, SyncItem{
 		ID:        externalID,
 		IsDeleted: false,
 		Labels:    []string{env.settings.LabelName},
 		Deadline:  nil,
 	}, env.settings, env.accountID)
 
-	assert.False(t, ok, "subsequent processItem should report the row was skipped")
-	assert.Empty(t, commands, "no commands should be emitted on subsequent calls")
+	require.NoError(t, r.Err)
+	assert.False(t, r.Processed, "subsequent processItem should report the row was skipped")
+	assert.False(t, r.Unsafe)
+	assert.Empty(t, r.Commands, "no commands should be emitted on subsequent calls")
 	assert.Equal(t, 0, env.recorder.count)
 }
 
@@ -486,13 +494,15 @@ func TestFollowUpDismissal_CadenceDispatchUnchanged(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			ok, commands := env.provider.processItem(env.ctx, tc.item(cadenceExtID, env.settings.LabelName), env.settings, env.accountID)
+			r := env.provider.processItem(env.ctx, tc.item(cadenceExtID, env.settings.LabelName), env.settings, env.accountID)
 
-			assert.True(t, ok)
-			require.NotEmpty(t, commands, "handleSkipTrigger should return an item_add command for the replacement cadence task")
+			require.NoError(t, r.Err)
+			assert.True(t, r.Processed)
+			assert.True(t, r.Unsafe, "cadence skip trigger commits non-replay-safe state")
+			require.NotEmpty(t, r.Commands, "handleSkipTrigger should return an item_add command for the replacement cadence task")
 
 			sawItemAdd := false
-			for _, cmd := range commands {
+			for _, cmd := range r.Commands {
 				if cmd.Type == "item_add" {
 					sawItemAdd = true
 				}
@@ -521,14 +531,16 @@ func TestFollowUpDismissal_ActionDispatchUnchanged(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	ok, _ := env.provider.processItem(env.ctx, SyncItem{
+	r := env.provider.processItem(env.ctx, SyncItem{
 		ID:        actionExtID,
 		IsDeleted: true,
 		Labels:    []string{env.settings.LabelName},
 		Deadline:  &SyncDate{Date: "2099-01-01"},
 	}, env.settings, env.accountID)
 
-	assert.True(t, ok)
+	require.NoError(t, r.Err)
+	assert.True(t, r.Processed)
+	assert.False(t, r.Unsafe, "action task unmanagement is replay-safe")
 
 	reloaded, err := env.contactTaskRepo.GetContactTask(env.ctx, action.ID)
 	require.NoError(t, err)

--- a/backend/internal/todoist/provider_dismissal_test.go
+++ b/backend/internal/todoist/provider_dismissal_test.go
@@ -821,7 +821,7 @@ func TestProcessItems_AbortsWhenNoUnsafeCommit(t *testing.T) {
 // RecordInteraction as part of its normal flow, which would trip the strict
 // countingRecorder.
 //
-// TODO(followup-issue): when the deferred transactional refactor lands, this
+// TODO(#265): when the deferred transactional refactor lands, this
 // guardrail test should be updated or removed to reflect the new semantics.
 func TestHandleTaskCompletion_StateUpdateFailureDoesNotReturnError(t *testing.T) {
 	env, cleanup := setupProviderTestPermissive(t)
@@ -865,7 +865,7 @@ func TestHandleTaskCompletion_StateUpdateFailureDoesNotReturnError(t *testing.T)
 // failures, because UpdateContactBy may already have fired before the
 // failure, advancing contact_by in the DB.
 //
-// TODO(followup-issue): when the deferred transactional refactor lands, this
+// TODO(#265): when the deferred transactional refactor lands, this
 // guardrail test should be updated or removed to reflect the new semantics.
 func TestHandleSkipTrigger_FailureDoesNotReturnErrorAndSetsUnsafe(t *testing.T) {
 	env, cleanup := setupDismissalTest(t)

--- a/backend/internal/todoist/provider_dismissal_test.go
+++ b/backend/internal/todoist/provider_dismissal_test.go
@@ -1,0 +1,517 @@
+package todoist
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+// countingRecorder is a test double for the interactionRecorder interface that
+// fails the test immediately if RecordInteraction is called. Used to assert the
+// dismissal path never records an interaction.
+type countingRecorder struct {
+	t     *testing.T
+	count int
+}
+
+func (r *countingRecorder) RecordInteraction(_ context.Context, _ repository.RecordInteractionRequest) (*repository.Interaction, error) {
+	r.t.Helper()
+	r.count++
+	r.t.Errorf("unexpected RecordInteraction call during dismissal test (count=%d)", r.count)
+	return &repository.Interaction{ID: uuid.New()}, nil
+}
+
+type dismissalTestEnv struct {
+	ctx             context.Context
+	provider        *CadenceSyncProvider
+	contactRepo     *repository.ContactRepository
+	contactTaskRepo *repository.ContactTaskRepository
+	recorder        *countingRecorder
+	settings        Settings
+	accountID       string
+}
+
+// setupDismissalTest builds a CadenceSyncProvider wired to a real DB and a test
+// interactionRecorder that asserts it is never called. Skips if DATABASE_URL is
+// unset, matching the pattern in backend/tests/followup_service_test.go.
+func setupDismissalTest(t *testing.T) (*dismissalTestEnv, func()) {
+	t.Helper()
+
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	if err := db.RunMigrations(databaseURL, migrationsPathForTest()); err != nil {
+		t.Fatalf("run migrations: %v", err)
+	}
+
+	ctx := context.Background()
+	database, err := db.NewDatabase(ctx, config.DatabaseConfig{
+		URL:               databaseURL,
+		MaxConns:          config.DefaultDBMaxConns,
+		MinConns:          config.DefaultDBMinConns,
+		MaxConnIdleTime:   config.DefaultDBMaxConnIdleTime,
+		MaxConnLifetime:   config.DefaultDBMaxConnLifetime,
+		HealthCheckPeriod: config.DefaultDBHealthCheckPeriod,
+	})
+	require.NoError(t, err)
+
+	contactRepo := repository.NewContactRepository(database.Queries)
+	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
+	cfg := config.TestConfig()
+	recorder := &countingRecorder{t: t}
+
+	provider := NewCadenceSyncProvider(
+		nil, // oauthService: not consulted on the dismissal path
+		contactTaskRepo,
+		contactRepo,
+		nil, // syncRepo: not consulted on the dismissal path
+		cfg,
+		recorder,
+	)
+
+	env := &dismissalTestEnv{
+		ctx:             ctx,
+		provider:        provider,
+		contactRepo:     contactRepo,
+		contactTaskRepo: contactTaskRepo,
+		recorder:        recorder,
+		settings: Settings{
+			ProjectID:             "test-project",
+			ProjectName:           "CRM",
+			LabelID:               "test-label-id",
+			LabelName:             "crm",
+			IntegrationInstanceID: "test-instance",
+		},
+		accountID: "test-account",
+	}
+
+	return env, func() { database.Close() }
+}
+
+// migrationsPathForTest returns the absolute path to backend/migrations from the
+// location of this test file. Same-package test, so we can't reuse
+// tests/integration_test.go's getMigrationsPath helper.
+func migrationsPathForTest() string {
+	if path := os.Getenv("MIGRATIONS_PATH"); path != "" && filepath.IsAbs(path) {
+		return path
+	}
+	_, filename, _, _ := runtime.Caller(0)
+	testDir := filepath.Dir(filename) // backend/internal/todoist
+	return filepath.Join(testDir, "..", "..", "migrations")
+}
+
+// createDismissalContact creates a contact with cadence set, a full set of
+// populated date fields, and returns both the contact and a snapshot of the
+// date fields so tests can assert they remain unchanged after dismissal.
+type dateSnapshot struct {
+	LastContacted     *time.Time
+	LastInteractionAt *time.Time
+	LastResponseAt    *time.Time
+	LastOutreachAt    *time.Time
+	ContactBy         *time.Time
+}
+
+func createDismissalContact(t *testing.T, env *dismissalTestEnv, nameSuffix string) (*repository.Contact, dateSnapshot) {
+	t.Helper()
+
+	cadence := "monthly"
+	contact, err := env.contactRepo.CreateContact(env.ctx, repository.CreateContactRequest{
+		FullName: "Dismissal " + nameSuffix + " " + uuid.New().String()[:8],
+		Cadence:  &cadence,
+	})
+	require.NoError(t, err)
+
+	// Seed all contact date fields so tests can assert they remain unchanged.
+	// Use a mutual update to populate last_contacted, last_interaction_at,
+	// last_response_at, contact_by in one call.
+	now := accelerated.GetCurrentTime().UTC().Truncate(time.Second)
+	mutualAt := now.AddDate(0, 0, -5)
+	contactBy := mutualAt.AddDate(0, 1, 0)
+	require.NoError(t, env.contactRepo.UpdateContactMutualFields(env.ctx, contact.ID, mutualAt, &contactBy, true))
+
+	// Seed last_outreach_at separately — outbound updates only that field.
+	outreachAt := now.AddDate(0, 0, -1)
+	require.NoError(t, env.contactRepo.UpdateContactOutreachAt(env.ctx, contact.ID, outreachAt, true))
+
+	// Reload to capture persisted values.
+	reloaded, err := env.contactRepo.GetContact(env.ctx, contact.ID)
+	require.NoError(t, err)
+
+	snapshot := dateSnapshot{
+		LastContacted:     copyTimePtr(reloaded.LastContacted),
+		LastInteractionAt: copyTimePtr(reloaded.LastInteractionAt),
+		LastResponseAt:    copyTimePtr(reloaded.LastResponseAt),
+		LastOutreachAt:    copyTimePtr(reloaded.LastOutreachAt),
+		ContactBy:         copyTimePtr(reloaded.ContactBy),
+	}
+
+	return reloaded, snapshot
+}
+
+func copyTimePtr(t *time.Time) *time.Time {
+	if t == nil {
+		return nil
+	}
+	v := *t
+	return &v
+}
+
+// createFollowUpTask inserts a managed follow_up row for the given contact with
+// the given external task ID. Returns the created task.
+func createFollowUpTask(t *testing.T, env *dismissalTestEnv, contactID uuid.UUID, externalID string) *repository.ContactTask {
+	t.Helper()
+	task, err := env.contactTaskRepo.CreateContactTask(env.ctx, repository.CreateContactTaskRequest{
+		ContactID:      contactID,
+		Provider:       SourceName,
+		Kind:           TaskKindFollowUp,
+		ExternalTaskID: externalID,
+		State:          string(repository.ContactTaskStateManaged),
+		Metadata:       map[string]any{"due_date": "2099-01-01"},
+	})
+	require.NoError(t, err)
+	return task
+}
+
+// assertDatesUnchanged reloads the contact and asserts every date field still
+// matches the snapshot. Uses time.Equal to compare pointer values correctly.
+func assertDatesUnchanged(t *testing.T, env *dismissalTestEnv, contactID uuid.UUID, snap dateSnapshot) {
+	t.Helper()
+	c, err := env.contactRepo.GetContact(env.ctx, contactID)
+	require.NoError(t, err)
+	assertTimePtrEqual(t, snap.LastContacted, c.LastContacted, "last_contacted")
+	assertTimePtrEqual(t, snap.LastInteractionAt, c.LastInteractionAt, "last_interaction_at")
+	assertTimePtrEqual(t, snap.LastResponseAt, c.LastResponseAt, "last_response_at")
+	assertTimePtrEqual(t, snap.LastOutreachAt, c.LastOutreachAt, "last_outreach_at")
+	assertTimePtrEqual(t, snap.ContactBy, c.ContactBy, "contact_by")
+}
+
+func assertTimePtrEqual(t *testing.T, want, got *time.Time, field string) {
+	t.Helper()
+	if want == nil && got == nil {
+		return
+	}
+	if want == nil || got == nil {
+		t.Errorf("%s: want=%v got=%v", field, want, got)
+		return
+	}
+	if !want.Equal(*got) {
+		t.Errorf("%s: want=%v got=%v", field, *want, *got)
+	}
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+// Case 1: dismissal via IsDeleted — no command emitted, state transitions, no
+// interactions recorded, and every contact date field stays unchanged.
+func TestFollowUpDismissal_IsDeleted(t *testing.T) {
+	env, cleanup := setupDismissalTest(t)
+	defer cleanup()
+
+	contact, snap := createDismissalContact(t, env, "IsDeleted")
+	externalID := "td-task-" + uuid.New().String()[:8]
+	task := createFollowUpTask(t, env, contact.ID, externalID)
+
+	ok, commands := env.provider.processItem(env.ctx, SyncItem{
+		ID:        externalID,
+		IsDeleted: true,
+		Labels:    []string{env.settings.LabelName},
+		Deadline:  &SyncDate{Date: "2099-01-01"},
+	}, env.settings, env.accountID)
+
+	assert.True(t, ok, "processItem should return true (task was handled)")
+	assert.Empty(t, commands, "no Todoist commands should be emitted when item is already deleted")
+	assert.Equal(t, 0, env.recorder.count, "RecordInteraction must not be called during dismissal")
+
+	assertDismissedAndInvariants(t, env, contact.ID, task.ID, snap)
+}
+
+// Case 2: dismissal via label removed — exactly one ItemClose command is
+// emitted, targeting the follow-up's external task ID.
+func TestFollowUpDismissal_LabelRemoved(t *testing.T) {
+	env, cleanup := setupDismissalTest(t)
+	defer cleanup()
+
+	contact, snap := createDismissalContact(t, env, "LabelRemoved")
+	externalID := "td-task-" + uuid.New().String()[:8]
+	task := createFollowUpTask(t, env, contact.ID, externalID)
+
+	ok, commands := env.provider.processItem(env.ctx, SyncItem{
+		ID:        externalID,
+		IsDeleted: false,
+		Labels:    []string{}, // CRM label removed
+		Deadline:  &SyncDate{Date: "2099-01-01"},
+	}, env.settings, env.accountID)
+
+	assert.True(t, ok)
+	require.Len(t, commands, 1, "exactly one ItemClose command expected")
+	assert.Equal(t, "item_close", commands[0].Type)
+	assert.Equal(t, externalID, commands[0].Args["id"])
+	assert.Equal(t, 0, env.recorder.count)
+
+	assertDismissedAndInvariants(t, env, contact.ID, task.ID, snap)
+}
+
+// Case 3: dismissal via deadline removed — same as case 2 but triggered by a
+// nil Deadline (CRM label still present).
+func TestFollowUpDismissal_DeadlineRemoved(t *testing.T) {
+	env, cleanup := setupDismissalTest(t)
+	defer cleanup()
+
+	contact, snap := createDismissalContact(t, env, "DeadlineRemoved")
+	externalID := "td-task-" + uuid.New().String()[:8]
+	task := createFollowUpTask(t, env, contact.ID, externalID)
+
+	ok, commands := env.provider.processItem(env.ctx, SyncItem{
+		ID:        externalID,
+		IsDeleted: false,
+		Labels:    []string{env.settings.LabelName},
+		Deadline:  nil,
+	}, env.settings, env.accountID)
+
+	assert.True(t, ok)
+	require.Len(t, commands, 1)
+	assert.Equal(t, "item_close", commands[0].Type)
+	assert.Equal(t, externalID, commands[0].Args["id"])
+	assert.Equal(t, 0, env.recorder.count)
+
+	assertDismissedAndInvariants(t, env, contact.ID, task.ID, snap)
+}
+
+// Case 4: dismissing a follow-up must not touch a coexisting managed cadence
+// task for the same contact.
+func TestFollowUpDismissal_CadenceTaskUnaffected(t *testing.T) {
+	env, cleanup := setupDismissalTest(t)
+	defer cleanup()
+
+	contact, _ := createDismissalContact(t, env, "CadenceUnaffected")
+
+	cadenceExtID := "td-cadence-" + uuid.New().String()[:8]
+	cadenceTask, err := env.contactTaskRepo.CreateContactTask(env.ctx, repository.CreateContactTaskRequest{
+		ContactID:      contact.ID,
+		Provider:       SourceName,
+		Kind:           TaskKindCadence,
+		ExternalTaskID: cadenceExtID,
+		State:          string(repository.ContactTaskStateManaged),
+		Metadata:       map[string]any{"synced_deadline": "2099-01-01"},
+	})
+	require.NoError(t, err)
+
+	followupExtID := "td-followup-" + uuid.New().String()[:8]
+	_ = createFollowUpTask(t, env, contact.ID, followupExtID)
+
+	_, _ = env.provider.processItem(env.ctx, SyncItem{
+		ID:        followupExtID,
+		IsDeleted: true,
+		Labels:    []string{env.settings.LabelName},
+		Deadline:  &SyncDate{Date: "2099-01-01"},
+	}, env.settings, env.accountID)
+
+	reloaded, err := env.contactTaskRepo.GetContactTask(env.ctx, cadenceTask.ID)
+	require.NoError(t, err)
+	assert.Equal(t, repository.ContactTaskStateManaged, reloaded.State, "cadence task must remain managed")
+	assert.Equal(t, cadenceExtID, reloaded.ExternalTaskID, "cadence external ID must be unchanged")
+}
+
+// Case 5: after dismissal, a subsequent processItem call on the same external
+// task ID must skip the row via the state != managed early-return, not
+// re-emitting any commands.
+func TestFollowUpDismissal_SubsequentProcessItemSkipsDismissedRow(t *testing.T) {
+	env, cleanup := setupDismissalTest(t)
+	defer cleanup()
+
+	contact, _ := createDismissalContact(t, env, "Subsequent")
+	externalID := "td-task-" + uuid.New().String()[:8]
+	_ = createFollowUpTask(t, env, contact.ID, externalID)
+
+	// First dismissal.
+	_, _ = env.provider.processItem(env.ctx, SyncItem{
+		ID:        externalID,
+		IsDeleted: false,
+		Labels:    []string{env.settings.LabelName},
+		Deadline:  nil,
+	}, env.settings, env.accountID)
+
+	// Second call — simulates the next sync tick seeing the same task.
+	ok, commands := env.provider.processItem(env.ctx, SyncItem{
+		ID:        externalID,
+		IsDeleted: false,
+		Labels:    []string{env.settings.LabelName},
+		Deadline:  nil,
+	}, env.settings, env.accountID)
+
+	assert.False(t, ok, "subsequent processItem should report the row was skipped")
+	assert.Empty(t, commands, "no commands should be emitted on subsequent calls")
+	assert.Equal(t, 0, env.recorder.count)
+}
+
+// Case 6: FindPendingFollowUp must ignore dismissed rows. Regression guardrail
+// for the existing SQL (state='managed' filter) against the new state constant.
+func TestFollowUpDismissal_FindPendingFollowUpIgnoresDismissed(t *testing.T) {
+	env, cleanup := setupDismissalTest(t)
+	defer cleanup()
+
+	contact, _ := createDismissalContact(t, env, "FindPending")
+	task := createFollowUpTask(t, env, contact.ID, "td-"+uuid.New().String()[:8])
+
+	// Transition directly to dismissed via the repository.
+	_, err := env.contactTaskRepo.UpdateContactTaskState(env.ctx, task.ID, repository.ContactTaskStateDismissed)
+	require.NoError(t, err)
+
+	_, err = env.contactTaskRepo.FindPendingFollowUp(env.ctx, contact.ID)
+	assert.True(t, errors.Is(err, db.ErrNotFound), "FindPendingFollowUp must treat dismissed as absent")
+}
+
+// Case 7: has_followup / no_followup contact filters must ignore dismissed rows.
+func TestFollowUpDismissal_ContactFollowUpFiltersIgnoreDismissed(t *testing.T) {
+	env, cleanup := setupDismissalTest(t)
+	defer cleanup()
+
+	contact, _ := createDismissalContact(t, env, "Filters")
+	task := createFollowUpTask(t, env, contact.ID, "td-"+uuid.New().String()[:8])
+	_, err := env.contactTaskRepo.UpdateContactTaskState(env.ctx, task.ID, repository.ContactTaskStateDismissed)
+	require.NoError(t, err)
+
+	// Helper to check whether this contact is in a filter result.
+	contactInFilter := func(filter string) bool {
+		contacts, err := env.contactRepo.ListContacts(env.ctx, repository.ListContactsParams{
+			Limit:          1000,
+			FollowupFilter: filter,
+		})
+		require.NoError(t, err)
+		for _, c := range contacts {
+			if c.ID == contact.ID {
+				return true
+			}
+		}
+		return false
+	}
+
+	assert.False(t, contactInFilter("has_followup"), "dismissed row must not count as pending follow-up")
+	assert.True(t, contactInFilter("no_followup"), "contact with only a dismissed follow-up should appear in no_followup")
+}
+
+// Case 8a: dispatch for cadence is unchanged — a cadence task hit with a skip
+// trigger still routes through handleSkipTrigger (observable via a new
+// item_add command being returned).
+func TestFollowUpDismissal_CadenceDispatchUnchanged(t *testing.T) {
+	env, cleanup := setupDismissalTest(t)
+	defer cleanup()
+
+	contact, _ := createDismissalContact(t, env, "CadenceDispatch")
+
+	cadenceExtID := "td-cadence-" + uuid.New().String()[:8]
+	_, err := env.contactTaskRepo.CreateContactTask(env.ctx, repository.CreateContactTaskRequest{
+		ContactID:      contact.ID,
+		Provider:       SourceName,
+		Kind:           TaskKindCadence,
+		ExternalTaskID: cadenceExtID,
+		State:          string(repository.ContactTaskStateManaged),
+		Metadata:       map[string]any{"synced_deadline": "2099-01-01"},
+	})
+	require.NoError(t, err)
+
+	ok, commands := env.provider.processItem(env.ctx, SyncItem{
+		ID:        cadenceExtID,
+		IsDeleted: true,
+		Labels:    []string{env.settings.LabelName},
+		Deadline:  &SyncDate{Date: "2099-01-01"},
+	}, env.settings, env.accountID)
+
+	assert.True(t, ok)
+	require.NotEmpty(t, commands, "handleSkipTrigger should return an item_add command for the replacement cadence task")
+
+	sawItemAdd := false
+	for _, cmd := range commands {
+		if cmd.Type == "item_add" {
+			sawItemAdd = true
+		}
+	}
+	assert.True(t, sawItemAdd, "expected at least one item_add command from cadence skip-trigger")
+}
+
+// Case 8b: dispatch for action is unchanged — an action task being deleted
+// transitions the local row to unmanaged (via handleActionTaskTriggers).
+func TestFollowUpDismissal_ActionDispatchUnchanged(t *testing.T) {
+	env, cleanup := setupDismissalTest(t)
+	defer cleanup()
+
+	contact, _ := createDismissalContact(t, env, "ActionDispatch")
+
+	actionExtID := "td-action-" + uuid.New().String()[:8]
+	action, err := env.contactTaskRepo.CreateContactTask(env.ctx, repository.CreateContactTaskRequest{
+		ContactID:      contact.ID,
+		Provider:       SourceName,
+		Kind:           TaskKindAction,
+		ExternalTaskID: actionExtID,
+		State:          string(repository.ContactTaskStateManaged),
+		Metadata:       map[string]any{},
+	})
+	require.NoError(t, err)
+
+	ok, _ := env.provider.processItem(env.ctx, SyncItem{
+		ID:        actionExtID,
+		IsDeleted: true,
+		Labels:    []string{env.settings.LabelName},
+		Deadline:  &SyncDate{Date: "2099-01-01"},
+	}, env.settings, env.accountID)
+
+	assert.True(t, ok)
+
+	reloaded, err := env.contactTaskRepo.GetContactTask(env.ctx, action.ID)
+	require.NoError(t, err)
+	assert.Equal(t, repository.ContactTaskStateUnmanaged, reloaded.State, "action task must transition to unmanaged on delete")
+}
+
+// ============================================================================
+// Shared assertion helpers
+// ============================================================================
+
+// assertDismissedAndInvariants rolls up the post-dismissal checks that all
+// three trigger-variant cases share: state transitions, no new interaction, no
+// new follow-up, HasPendingFollowUp false, and every date field unchanged.
+func assertDismissedAndInvariants(t *testing.T, env *dismissalTestEnv, contactID uuid.UUID, taskID uuid.UUID, snap dateSnapshot) {
+	t.Helper()
+
+	reloaded, err := env.contactTaskRepo.GetContactTask(env.ctx, taskID)
+	require.NoError(t, err)
+	assert.Equal(t, repository.ContactTaskStateDismissed, reloaded.State, "follow-up must be dismissed")
+
+	// No pending follow-up remains.
+	_, err = env.contactTaskRepo.FindPendingFollowUp(env.ctx, contactID)
+	assert.True(t, errors.Is(err, db.ErrNotFound), "no pending follow-up should exist after dismissal")
+
+	// No new follow-up rows were created (count stays at 1 — the dismissed one).
+	tasks, err := env.contactTaskRepo.ListContactTasksByContact(env.ctx, contactID)
+	require.NoError(t, err)
+	followupCount := 0
+	for _, tk := range tasks {
+		if tk.Kind == TaskKindFollowUp {
+			followupCount++
+		}
+	}
+	assert.Equal(t, 1, followupCount, "no new follow-up rows should have been created")
+
+	// All contact date fields unchanged.
+	assertDatesUnchanged(t, env, contactID, snap)
+}

--- a/backend/migrations/033_contact_task_dismissed.down.sql
+++ b/backend/migrations/033_contact_task_dismissed.down.sql
@@ -1,0 +1,8 @@
+-- Revert: drop the constraint and restore the pre-033 version.
+-- Any existing 'dismissed' rows are coerced to 'completed' so the constraint
+-- accepts them. This is a best-effort down migration for dev; production
+-- should not roll this back once it has taken effect.
+UPDATE contact_task SET state = 'completed' WHERE state = 'dismissed';
+ALTER TABLE contact_task DROP CONSTRAINT contact_task_state_check;
+ALTER TABLE contact_task ADD CONSTRAINT contact_task_state_check
+    CHECK (state IN ('managed', 'unmanaged', 'completed'));

--- a/backend/migrations/033_contact_task_dismissed.up.sql
+++ b/backend/migrations/033_contact_task_dismissed.up.sql
@@ -1,0 +1,7 @@
+-- Allow 'dismissed' as a terminal state for contact_task.
+-- Used for follow-up tasks that the user has dismissed via Todoist (deletion,
+-- label removal, or deadline removal on a follow_up kind) without wanting to
+-- record a new outbound interaction or create a successor follow-up.
+ALTER TABLE contact_task DROP CONSTRAINT contact_task_state_check;
+ALTER TABLE contact_task ADD CONSTRAINT contact_task_state_check
+    CHECK (state IN ('managed', 'unmanaged', 'completed', 'dismissed'));

--- a/frontend/src/types/contact-task.ts
+++ b/frontend/src/types/contact-task.ts
@@ -8,7 +8,7 @@ export interface ContactTask {
   content?: string
   due_date?: string
   project_id?: string
-  state: 'managed' | 'completed' | 'unmanaged'
+  state: 'managed' | 'completed' | 'unmanaged' | 'dismissed'
   created_at: string
 }
 
@@ -18,6 +18,6 @@ export interface CreateActionTaskRequest {
 }
 
 export interface ContactTaskListParams {
-  state?: 'managed' | 'completed' | 'unmanaged'
+  state?: 'managed' | 'completed' | 'unmanaged' | 'dismissed'
   kind?: 'action' | 'cadence' | 'follow_up'
 }


### PR DESCRIPTION
## Summary

Closes #264. Adds a `dismissed` terminal state for contact_task + fixes a latent error-propagation bug in the Todoist sync loop (Option C from the plan).

### Dismissal feature (commits 1–4)
- New `dismissed` state in `contact_task.state` CHECK constraint (migration 033)
- `handleFollowUpDismissal` in `CadenceSyncProvider` transitions follow-up tasks to `dismissed` when deleted / label-removed / deadline-removed in Todoist — without recording an interaction, creating a successor, or touching any contact date field
- API + frontend updated to surface `dismissed` in list filters and type unions
- 9 DB-backed same-package tests cover all three trigger variants, cadence/action dispatch invariants, and date-field immutability

### Error propagation refactor (commits 5–9)
- New `processItemResult` struct replaces the `(bool, []SyncCommand)` return of `processItem` and its 4 handlers
- New `processItems` method extracts the per-item loop from `Sync` with conditional-abort semantics
- Fatal errors from `handleFollowUpDismissal`, `handleActionTaskTriggers`, and three `processItem` sites (lookup, contact load, recurring) now abort the sync without advancing the cursor — except when an earlier `handleSkipTrigger` in the same batch already committed non-replay-safe state, in which case the loop falls back to log-and-continue (prior behavior)
- `handleTaskCompletion` and `handleSkipTrigger` intentionally retain their existing log-and-continue semantics (see #265 for the deferred transactional refactor) — signaled via the `Unsafe` flag on `processItemResult`
- Extracted `decideFatalErrorPolicy` and `handleRecurringDetection` for testability

### Test coverage
- 7 dismissal tests (existing) updated to unpack `processItemResult`
- 10 new tests covering: handler error injection (follow-up dismissal, action task × 2, processItem lookup), recurring-branch error, `processItems` abort-on-error, guardrails for `handleTaskCompletion` and `handleSkipTrigger`, and direct unit tests of the `decideFatalErrorPolicy` helper for both branches

### Local review
- 4 rounds of plan-and-review (Codex approved)
- 2 rounds of implement-and-review (Codex PASS)

## Test plan

- [x] \`make lint\` clean
- [x] \`make test\` (backend + frontend unit + integration) green
- [x] Targeted todoist package tests green with local DATABASE_URL
- [ ] CI backend tests + E2E tests green
- [ ] CI code reviewers (Claude, Codex) happy
- [ ] Manual smoke on Pi: dismiss a follow-up in Todoist → row transitions to \`dismissed\` without creating a successor

## Links

- Issue: #264
- Deferred refactor tracking: #265
- Plan docs:
  - \`.ai/log/plan/followup-dismissal.md\` (dismissal feature)
  - \`.ai/log/plan/todoist-processitem-error-propagation.md\` (Option C refactor)