### PR TITLE
fix(todoist): guard deadline edit by task.Kind == cadence

### DIFF
--- a/.ai/log/learnings/4c9ef02a-1b97-4585-8476-a8c960c368b8.yaml
+++ b/.ai/log/learnings/4c9ef02a-1b97-4585-8476-a8c960c368b8.yaml
@@ -1,0 +1,32 @@
+---
+timestamp: "2026-04-11T18:37:09.520439"
+type: gotcha
+summary: Todoist processItem branches may have implicit cadence-only assumptions
+detail: |
+  When the follow-up task feature (#266) was added, it exposed a bug in the deadline-edit branch of processItem. The branch had an implicit assumption that only cadence tasks would reach it, but follow-up tasks (which use grace-period deadlines unrelated to contact_by) also fell through and regressed contact.contact_by via UpdateContactBy. The fix required adding an explicit `task.Kind == TaskKindCadence` guard. When adding new task kinds or modifying processItem routing, audit all downstream branches for similar implicit assumptions and add defensive guards.
+actionable: true
+
+---
+timestamp: "2026-04-11T18:37:09.520439"
+type: distinction
+summary: make test vs CI test scope differs for package-level tests
+detail: |
+  `make test` runs `go test ./tests/...` which only covers integration tests in `backend/tests/`. Package-level unit tests (e.g., `internal/todoist/*_test.go`) are NOT run by `make test` locally but ARE run by CI via `go test -short ./...`. When adding package-level tests, run them explicitly with `cd backend && go test ./internal/package/...` in addition to `make test`, or you may have false confidence that your changes are fully tested locally. CI will catch them, but that adds latency.
+actionable: true
+
+---
+timestamp: "2026-04-11T18:37:09.520439"
+type: rule
+summary: Guard-based bug fixes need both negative and positive regression tests
+detail: |
+  When fixing a bug by adding a guard condition (like `if task.Kind == TaskKindCadence`), write two regression tests: (1) negative case confirming the guard blocks the unwanted behavior (e.g., follow-up deadline does NOT update contact_by), and (2) positive case confirming the guard still allows the intended behavior (e.g., cadence deadline DOES update contact_by). This verifies the guard is both necessary (prevents regression) and sufficient (preserves correct behavior).
+actionable: true
+
+---
+timestamp: "2026-04-11T18:37:09.520439"
+type: architecture
+summary: Todoist sync provider uses multi-stage task kind dispatch with defensive guards
+detail: |
+  processItem has multiple dispatch points for task kinds: early return for actions, skip-trigger routing for deletions/label removals/deadline removals, and downstream branches like deadline-edit. While the routing logic theoretically ensures certain branches only see certain task kinds, defensive guards (like `task.Kind == TaskKindCadence`) are still valuable as self-documentation and regression prevention when new task kinds are added. The fix/followup-deadline-regression demonstrates this: even though actions dispatch early, the deadline-edit branch still benefits from an explicit cadence check.
+actionable: true
+

--- a/backend/internal/todoist/provider.go
+++ b/backend/internal/todoist/provider.go
@@ -478,8 +478,15 @@ func (p *CadenceSyncProvider) processItem(
 		return p.handleSkipTrigger(ctx, task, contact, settings, accountID)
 	}
 
-	// Check for deadline edit (Todoist wins)
-	if item.Deadline != nil && contact.ContactBy != nil {
+	// Check for deadline edit (Todoist wins) — only for cadence tasks.
+	// Follow-up tasks use a separate grace-period deadline (last_outreach_at +
+	// watchdog_days) that is unrelated to contact_by; allowing them through
+	// here previously regressed contact_by via UpdateContactBy on the next
+	// sync tick (see fix/followup-deadline-regression). Action tasks are
+	// already routed out at the TaskKindAction dispatch above and cannot
+	// reach here in normal flow, but the explicit TaskKindCadence check is
+	// self-documenting and load-bearing for follow-ups.
+	if task.Kind == TaskKindCadence && item.Deadline != nil && contact.ContactBy != nil {
 		todoistDeadline, err := time.Parse(DateFormat, item.Deadline.Date)
 		if err == nil {
 			// Compare dates using UTC year/month/day to avoid timezone issues
@@ -505,6 +512,7 @@ func (p *CadenceSyncProvider) processItem(
 
 					logger.Info().
 						Str("contactId", contact.ID.String()).
+						Str("taskKind", task.Kind).
 						Time("newContactBy", todoistDeadline).
 						Msg("updated contact_by and synced_deadline from Todoist deadline edit")
 				}

--- a/backend/internal/todoist/provider_deadline_edit_test.go
+++ b/backend/internal/todoist/provider_deadline_edit_test.go
@@ -1,0 +1,168 @@
+package todoist
+
+import (
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression tests for the processItem deadline-edit branch
+// (fix/followup-deadline-regression).
+//
+// The deadline-edit branch in processItem (Todoist wins) is responsible for
+// propagating a user's deadline edit on a managed Todoist task back into
+// contact.contact_by. Before this fix it ran for any task kind, including
+// follow-up tasks whose deadlines are computed on a completely different
+// basis (last_outreach_at + watchdog_days). When the Telegram Phase 4
+// backfill replayed historical outbound messages, it created back-dated
+// follow-up tasks whose grace-period deadlines were then written into
+// contact_by, regressing the cadence state for 12 contacts on prod.
+//
+// The fix is a single guard: the branch only fires when
+// task.Kind == TaskKindCadence. These two tests pin both halves of the
+// guard so a future "simplification" cannot revert it without an explicit
+// signal:
+//
+//   - TestProcessItem_FollowUpDeadlineDoesNotOverwriteContactBy
+//     Negative path: a follow-up task with a diverging deadline must NOT
+//     mutate contact_by and must NOT add a synced_deadline key to the
+//     follow-up's metadata.
+//
+//   - TestProcessItem_CadenceDeadlineOverwritesContactBy
+//     Positive path: a cadence task with a diverging deadline MUST update
+//     contact_by AND update its own metadata.synced_deadline (without
+//     wiping other metadata keys).
+//
+// Both tests use the shared dismissalTestEnv helpers from
+// provider_dismissal_test.go. The strict countingRecorder is fine for both
+// cases because the deadline-edit branch never calls RecordInteraction.
+
+// TestProcessItem_FollowUpDeadlineDoesNotOverwriteContactBy verifies that a
+// follow-up task arriving via processItem with a deadline that differs from
+// contact_by is left alone — the deadline-edit branch must short-circuit on
+// task.Kind != cadence.
+func TestProcessItem_FollowUpDeadlineDoesNotOverwriteContactBy(t *testing.T) {
+	env, cleanup := setupDismissalTest(t)
+	defer cleanup()
+
+	contact, _ := createDismissalContact(t, env, "FollowUpDeadline")
+
+	// Override contact_by to a specific known value so the assertion can be exact.
+	// 2027-02-03 is well in the future, far enough from any natural cadence
+	// computation that an accidental write would be obvious.
+	seededContactBy := time.Date(2027, 2, 3, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, env.contactRepo.UpdateContactBy(env.ctx, contact.ID, seededContactBy))
+
+	externalID := "td-fu-deadline-" + uuid.New().String()[:8]
+	followupMetadata := map[string]any{
+		"due_date": "2026-02-24",
+		"content":  "Follow up: test",
+	}
+	task, err := env.contactTaskRepo.CreateContactTask(env.ctx, repository.CreateContactTaskRequest{
+		ContactID:      contact.ID,
+		Provider:       SourceName,
+		Kind:           TaskKindFollowUp,
+		ExternalTaskID: externalID,
+		State:          string(repository.ContactTaskStateManaged),
+		Metadata:       followupMetadata,
+	})
+	require.NoError(t, err)
+
+	// item.Deadline (2026-02-24) differs from contact.ContactBy (2027-02-03).
+	// Without the guard, the branch would fire UpdateContactBy(2026-02-24)
+	// and clobber the cadence state.
+	r := env.provider.processItem(env.ctx, SyncItem{
+		ID:        externalID,
+		IsDeleted: false,
+		Labels:    []string{env.settings.LabelName},
+		Deadline:  &SyncDate{Date: "2026-02-24"},
+	}, env.settings, env.accountID)
+
+	require.NoError(t, r.Err)
+	assert.True(t, r.Processed, "the follow-up task was handled, just without the deadline-edit side effect")
+	assert.Empty(t, r.Commands, "deadline-edit path emits no Todoist commands")
+	assert.Equal(t, 0, env.recorder.count, "deadline-edit path must not record interactions")
+
+	// contact.ContactBy is unchanged.
+	reloaded, err := env.contactRepo.GetContact(env.ctx, contact.ID)
+	require.NoError(t, err)
+	require.NotNil(t, reloaded.ContactBy, "contact_by must remain set")
+	assert.True(t, reloaded.ContactBy.Equal(seededContactBy),
+		"contact_by must NOT be regressed by a follow-up deadline; want=%v got=%v",
+		seededContactBy, *reloaded.ContactBy)
+
+	// The follow-up task's metadata must be unchanged. Specifically it must NOT
+	// have gained a synced_deadline key — the buggy code path unconditionally
+	// mutates task.Metadata[MetadataKeySyncedDeadline] regardless of kind.
+	reloadedTask, err := env.contactTaskRepo.GetContactTask(env.ctx, task.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "2026-02-24", reloadedTask.Metadata["due_date"], "due_date must be preserved")
+	assert.Equal(t, "Follow up: test", reloadedTask.Metadata["content"], "content must be preserved")
+	_, hasSynced := reloadedTask.Metadata[MetadataKeySyncedDeadline]
+	assert.False(t, hasSynced, "follow-up metadata must NOT gain a synced_deadline key")
+}
+
+// TestProcessItem_CadenceDeadlineOverwritesContactBy is the regression guard
+// for the legitimate cadence-edit path. Without this test, an over-eager fix
+// could disable the entire deadline-edit branch and break the user-visible
+// flow where editing a cadence task's deadline in Todoist updates the CRM's
+// contact_by on the next sync tick.
+func TestProcessItem_CadenceDeadlineOverwritesContactBy(t *testing.T) {
+	env, cleanup := setupDismissalTest(t)
+	defer cleanup()
+
+	contact, _ := createDismissalContact(t, env, "CadenceDeadline")
+
+	seededContactBy := time.Date(2027, 2, 3, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, env.contactRepo.UpdateContactBy(env.ctx, contact.ID, seededContactBy))
+
+	externalID := "td-cad-deadline-" + uuid.New().String()[:8]
+	cadenceMetadata := map[string]any{
+		MetadataKeySyncedDeadline:      "2027-02-03",
+		MetadataKeySyncedLastContacted: "2026-02-03T00:00:00Z",
+	}
+	task, err := env.contactTaskRepo.CreateContactTask(env.ctx, repository.CreateContactTaskRequest{
+		ContactID:      contact.ID,
+		Provider:       SourceName,
+		Kind:           TaskKindCadence,
+		ExternalTaskID: externalID,
+		State:          string(repository.ContactTaskStateManaged),
+		Metadata:       cadenceMetadata,
+	})
+	require.NoError(t, err)
+
+	r := env.provider.processItem(env.ctx, SyncItem{
+		ID:        externalID,
+		IsDeleted: false,
+		Labels:    []string{env.settings.LabelName},
+		Deadline:  &SyncDate{Date: "2026-02-24"},
+	}, env.settings, env.accountID)
+
+	require.NoError(t, r.Err)
+	assert.True(t, r.Processed)
+	assert.Empty(t, r.Commands)
+	assert.Equal(t, 0, env.recorder.count)
+
+	// contact.ContactBy is updated to the Todoist deadline.
+	reloaded, err := env.contactRepo.GetContact(env.ctx, contact.ID)
+	require.NoError(t, err)
+	require.NotNil(t, reloaded.ContactBy)
+	expectedContactBy := time.Date(2026, 2, 24, 0, 0, 0, 0, time.UTC)
+	assert.True(t, reloaded.ContactBy.Equal(expectedContactBy),
+		"contact_by must be updated to the Todoist deadline; want=%v got=%v",
+		expectedContactBy, *reloaded.ContactBy)
+
+	// synced_deadline is updated to the new Todoist deadline; other metadata
+	// keys (synced_last_contacted) survive the partial update.
+	reloadedTask, err := env.contactTaskRepo.GetContactTask(env.ctx, task.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "2026-02-24", reloadedTask.Metadata[MetadataKeySyncedDeadline],
+		"cadence synced_deadline must be updated to the new Todoist deadline")
+	assert.Equal(t, "2026-02-03T00:00:00Z", reloadedTask.Metadata[MetadataKeySyncedLastContacted],
+		"synced_last_contacted must be preserved across the metadata update")
+}


### PR DESCRIPTION
## Summary

- Gate the \`processItem\` deadline-edit branch on \`task.Kind == TaskKindCadence\` so follow-up tasks can no longer drive \`UpdateContactBy\`. Follow-up deadlines are grace-period values (\`last_outreach_at + watchdog_days\`) unrelated to cadence clocks — previously they clobbered \`contact.contact_by\` on the next sync tick.
- Add \`taskKind\` to the existing "updated contact_by and synced_deadline from Todoist deadline edit" log line so future incidents of this class are trivially greppable.
- Add two regression tests pinning both halves of the guard (negative: follow-up must not mutate; positive: cadence must still mutate).

The Telegram Phase 4 backfill surfaced this at scale on 2026-04-11: replaying historical outbound messages created back-dated follow-up tasks whose grace-period deadlines were then written into \`contact_by\`, regressing cadence state for 12 contacts on prod.

Plan: \`.ai/log/plan/todoist-followup-deadline-regression.md\`
Secondary issue (stale follow-up creation from history-replaying sync sources): #267

## Test plan

- [x] \`make lint\` — clean
- [x] \`make test\` — all backend unit + integration tests pass
- [x] \`cd backend && DATABASE_URL=... go test ./internal/todoist/...\` — full todoist package green (39 tests, including both new regression tests)
- [x] \`make test-e2e-diff\` — diff-selected E2E specs green (20 tests)
- [x] Local Codex review pass — no blocking findings
- [x] Post-merge: deploy fix, verify via prod logs that \`taskKind=cadence\` appears in deadline-edit log lines and follow-ups no longer reach the branch
- [x] Post-deploy: run one-off SQL data repair against prod (scope: 12 contacts, script in plan doc Step 3) to recompute \`contact_by = last_contacted + cadence_days\` for affected rows
- [x] Post-repair: spot-check repaired contacts in the Tailscale UI