### PR TITLE
feat(todoist): close cadence task on non-Todoist outreach (#268 follow-up)

### DIFF
--- a/.ai/log/learnings/6bf30213-5221-4c04-826b-4a3f9196eff1.yaml
+++ b/.ai/log/learnings/6bf30213-5221-4c04-826b-4a3f9196eff1.yaml
@@ -38,3 +38,35 @@ detail: |
   When a cadence task has `MetadataKeyPendingTempID` matching `external_task_id` (Todoist hasn't confirmed the creation yet), you can't send an `item_close` command to Todoist (no real ID exists). But you must still transition the local `contact_task` state to completed. The `closeOnOutreach` function had to return `(nil, true)` for this case: no Sync commands to send, but outreach WAS handled. This is why the bool return was critical—otherwise the caller would interpret `nil` as "no outreach, continue processing" instead of "outreach handled, stop processing this contact".
 actionable: true
 
+---
+timestamp: "2026-04-12T12:47:49.617463"
+type: gotcha
+summary: Contact task metadata updates without in-memory state sync cause stale data bugs
+detail: |
+  After UpdateContactTaskMetadata succeeds, you MUST set task.Metadata = metadata to sync the in-memory state. Without this, subsequent code in the same sync cycle sees stale metadata and may make incorrect control flow decisions or perform redundant DB writes. This pattern appears in reconcileExistingTask and was missed in closeOnOutreach's backfill path until CI review caught it. Tests passed because they don't verify in-memory state between operations in the same cycle.
+actionable: true
+
+---
+timestamp: "2026-04-12T12:47:49.617463"
+type: architecture
+summary: Todoist sync loop guarantees processItems runs before reconcileContactTasks
+detail: |
+  In CadenceSyncProvider.Sync(), processItems (which calls tryRecoverPendingTempID) always executes before reconcileContactTasks. This ordering ensures that temp-ID-to-real-ID recovery happens before any close/complete/reconcile logic runs. When adding new reconciliation logic that depends on external_task_id state or makes state transitions, this execution order guarantee means recovery will have run first. A P2 reviewer raised a concern about pending temp IDs being orphaned by state transitions, but this turned out to be invalid due to this architectural guarantee - worth documenting to prevent future confusion.
+actionable: true
+
+---
+timestamp: "2026-04-12T12:47:49.617463"
+type: rule
+summary: Functions returning nil for semantically different outcomes create untestable control flow bugs
+detail: |
+  When closeOnOutreach returned nil for both "no outreach detected" and "outreach handled but can't close yet (pending temp ID)", the caller couldn't distinguish these cases. This caused it to skip follow-up gate checks when it should have continued processing. Five comprehensive integration tests all passed because they didn't cover the cross-case control flow. Fix: return ([]SyncCommand, bool) where bool indicates whether the function handled the condition, letting callers distinguish "not applicable" from "handled with no commands". Codex caught this in review even though tests passed - shows value of architectural review beyond test coverage.
+actionable: true
+
+---
+timestamp: "2026-04-12T12:47:49.617463"
+type: documentation_gap
+summary: Learnings extraction identified in-memory state sync pattern but didn't validate consistency
+detail: |
+  The pre-push learnings extraction correctly identified the in-memory state sync pattern (learning #4 in the yaml) by analyzing the implementation, but didn't verify the pattern was followed everywhere in the code being pushed. The same bug was then caught by CI review. This reveals that extracted learnings should either: (a) trigger immediate consistency checks across the changeset, or (b) be clearly marked as "pattern observed, not validated" so the commit+push doesn't create false confidence. The learning was correct, but its presence in the learnings file didn't prevent the bug from being shipped to CI.
+actionable: true
+

--- a/.ai/log/learnings/6bf30213-5221-4c04-826b-4a3f9196eff1.yaml
+++ b/.ai/log/learnings/6bf30213-5221-4c04-826b-4a3f9196eff1.yaml
@@ -1,0 +1,40 @@
+---
+timestamp: "2026-04-12T11:20:52.444554"
+type: gotcha
+summary: Functions returning nil for semantically different cases create ambiguity bugs
+detail: |
+  In this session, `closeOnOutreach` initially returned `nil` for both "no outreach detected" AND "outreach detected but pending temp ID (can't close yet)". The caller couldn't distinguish these cases, causing it to skip the follow-up gate check when it should have continued processing. Codex caught this in review even though all 5 comprehensive integration tests passed. **Fix:** Return `([]SyncCommand, bool)` where the bool indicates whether the condition was handled, allowing the caller to distinguish "not applicable" from "handled but no commands".
+actionable: true
+
+---
+timestamp: "2026-04-12T11:20:52.444554"
+type: rule
+summary: When adding parallel metadata keys, update ALL write locations atomically
+detail: |
+  The plan explicitly identified 6 locations where `synced_last_contacted` is written and required adding `synced_last_outreach_at` to all 6 in the same commit: handleSkipTrigger, reconcileContactTasks (new task), reconcileExistingTask (3 backfill/drift locations). Missing even one location creates subtle desync bugs. This is already partially documented in the gotchas table ("Adding new Todoist task metadata key to only one path") but this session demonstrates why: the reconciler has multiple code paths that can create or update tasks, and each path must maintain the same metadata invariants.
+actionable: true
+
+---
+timestamp: "2026-04-12T11:20:52.444554"
+type: architecture
+summary: Detection logic must run before conditional gates that might skip it
+detail: |
+  The outreach detection needed to run BEFORE the existing `FindPendingFollowUp` gate at line 854 because that gate skips the entire contact when a follow-up exists. Initially, the cadence task lookup happened at line 870 (after the gate), making it unreachable when a follow-up existed—but outreach detection specifically needed to fire in that case. The fix moved the lookup and outreach check before the gate. **General pattern:** When adding new detection/cleanup logic to a reconciler with early-exit gates, consider whether the logic should run unconditionally (before gates) or only when certain conditions don't hold (after gates).
+actionable: true
+
+---
+timestamp: "2026-04-12T11:20:52.444554"
+type: distinction
+summary: Codex review catches control flow bugs that comprehensive tests miss
+detail: |
+  All 5 integration tests passed after the initial implementation, including tests for the exact scenario (outreach with pending follow-up). But Codex review identified that the nil-return ambiguity would cause the reconciler to skip the follow-up gate check when outreach was detected with a pending temp ID. The tests verified "output matches expected state" but didn't catch the control flow bug because the bug's impact (skipping the gate check) only matters in edge cases the tests didn't exercise. **Takeaway:** Tests verify "does this produce the right output"; code review verifies "does the control flow make sense". Both are necessary.
+actionable: false
+
+---
+timestamp: "2026-04-12T11:20:52.444554"
+type: gotcha
+summary: Pending temp ID tasks require special handling in close/delete paths
+detail: |
+  When a cadence task has `MetadataKeyPendingTempID` matching `external_task_id` (Todoist hasn't confirmed the creation yet), you can't send an `item_close` command to Todoist (no real ID exists). But you must still transition the local `contact_task` state to completed. The `closeOnOutreach` function had to return `(nil, true)` for this case: no Sync commands to send, but outreach WAS handled. This is why the bool return was critical—otherwise the caller would interpret `nil` as "no outreach, continue processing" instead of "outreach handled, stop processing this contact".
+actionable: true
+

--- a/.ai/rules/core.md
+++ b/.ai/rules/core.md
@@ -121,7 +121,7 @@ See [Request Flow Diagram](../guides/architecture.md#why-layered) for the full s
 | Todoist QuickAdd `note` parameter for descriptions | `note` creates comments, not descriptions - use two-step: QuickAdd then Sync API `item_update` |
 | Todoist v9 numeric IDs with v1 API | v1 returns alphanumeric IDs (e.g., `6fw9cQQ5JppCp7qX`) - migration complete as of Feb 2026; `tryRecoverPendingTempID` handles only failed temp ID resolution |
 | Parsing Todoist CRM markers as full description | CRM markers are embedded after markdown prefix or as standalone JSON - `tryRecoverPendingTempID` uses `strings.LastIndex` to extract |
-| Adding new Todoist task metadata key to only one path | Must update ALL 5 task creation/update paths: reconcileContactTasks, handleTaskCompletion, handleSkipTrigger, reconcileExistingTask (drift + backfill) |
+| Adding new Todoist task metadata key to only one path | Must update ALL 6 task creation/update paths: handleSkipTrigger, reconcileContactTasks (new task), reconcileExistingTask (3 backfill paths + drift), plus closeOnOutreach (outreach detection + pre-gate backfill) |
 | Using UUID for external source references | Use TEXT - only GCal uses UUIDs; Todoist uses alphanumeric strings (e.g., `6fw9cQQ5JppCp7qX`) |
 | Forward-only update semantics for all sources | Manual source must always update (user correction); forward-only is only for automated sources (gcal, todoist) |
 | Creating FK-referencing record without existence check | Check parent exists first and return ErrNotFound - otherwise FK constraint violation returns 500 instead of 404 |

--- a/backend/internal/todoist/provider.go
+++ b/backend/internal/todoist/provider.go
@@ -1013,6 +1013,8 @@ func (p *CadenceSyncProvider) closeOnOutreach(
 			metadata[MetadataKeySyncedLastOutreachAt] = contact.LastOutreachAt.Format(time.RFC3339)
 			if _, err := p.contactTaskRepo.UpdateContactTaskMetadata(ctx, task.ID, metadata); err != nil {
 				logger.Warn().Err(err).Str("contactId", contact.ID.String()).Msg("failed to backfill synced_last_outreach_at (pre-gate)")
+			} else {
+				task.Metadata = metadata
 			}
 		}
 	}

--- a/backend/internal/todoist/provider.go
+++ b/backend/internal/todoist/provider.go
@@ -878,8 +878,8 @@ func (p *CadenceSyncProvider) reconcileContactTasks(
 		// If a managed cadence task exists, check if the contact was reached out to
 		// from a non-Todoist source (e.g., Telegram). If so, close the cadence task.
 		if err == nil && task.State == repository.ContactTaskStateManaged {
-			closeCmds := p.closeOnOutreach(ctx, task, &contact)
-			if closeCmds != nil {
+			closeCmds, handled := p.closeOnOutreach(ctx, task, &contact)
+			if handled {
 				commands = append(commands, closeCmds...)
 				continue
 			}
@@ -952,14 +952,16 @@ func (p *CadenceSyncProvider) reconcileContactTasks(
 }
 
 // closeOnOutreach closes a managed cadence task when the contact has been reached out to
-// from a non-Todoist source (e.g., Telegram). Returns commands to send to Todoist
-// (item_close), or nil if no outreach was detected. State transition must succeed before
-// the close command is enqueued (same pattern as handleFollowUpDismissal).
+// from a non-Todoist source (e.g., Telegram). Returns (commands, true) when outreach was
+// detected and handled, (nil, false) otherwise. The bool distinguishes "no outreach" from
+// "outreach handled but no Todoist command needed" (e.g., pending temp ID). State
+// transition must succeed before the close command is enqueued (same pattern as
+// handleFollowUpDismissal).
 func (p *CadenceSyncProvider) closeOnOutreach(
 	ctx context.Context,
 	task *repository.ContactTask,
 	contact *repository.Contact,
-) []SyncCommand {
+) ([]SyncCommand, bool) {
 	if p.wasReachedOutSinceSync(contact, task) {
 		logger.Info().
 			Str("contactId", contact.ID.String()).
@@ -972,7 +974,7 @@ func (p *CadenceSyncProvider) closeOnOutreach(
 		// handleFollowUpDismissal).
 		if _, err := p.contactTaskRepo.UpdateContactTaskState(ctx, task.ID, repository.ContactTaskStateCompleted); err != nil {
 			logger.Warn().Err(err).Str("contactId", contact.ID.String()).Msg("failed to mark cadence task completed after outreach detection — skipping close")
-			return nil
+			return nil, false
 		}
 
 		var commands []SyncCommand
@@ -994,7 +996,7 @@ func (p *CadenceSyncProvider) closeOnOutreach(
 			logger.Warn().Err(err).Str("contactId", contact.ID.String()).Msg("failed to update synced_last_outreach_at after outreach detection")
 		}
 
-		return commands
+		return commands, true
 	}
 
 	// No outreach detected. Backfill synced_last_outreach_at if missing (legacy tasks
@@ -1015,7 +1017,7 @@ func (p *CadenceSyncProvider) closeOnOutreach(
 		}
 	}
 
-	return nil
+	return nil, false
 }
 
 // reconcileExistingTask checks if an existing managed task's deadline matches contact_by.

--- a/backend/internal/todoist/provider.go
+++ b/backend/internal/todoist/provider.go
@@ -56,6 +56,11 @@ const (
 	// as contacted from a non-Todoist source (e.g., calendar sync), even when contact_by
 	// doesn't change (same cadence period).
 	MetadataKeySyncedLastContacted = "synced_last_contacted"
+	// MetadataKeySyncedLastOutreachAt stores the last_outreach_at timestamp (RFC3339) at
+	// the time the task was created or last synced. Used to detect when a contact is
+	// reached out to from a non-Todoist source (e.g., Telegram), so the cadence task
+	// (outreach reminder) can be closed.
+	MetadataKeySyncedLastOutreachAt = "synced_last_outreach_at"
 )
 
 // DateFormat is the date format used for Todoist deadlines and synced_deadline metadata (YYYY-MM-DD)
@@ -702,6 +707,9 @@ func (p *CadenceSyncProvider) handleSkipTrigger(
 			if contact.LastContacted != nil {
 				metadata[MetadataKeySyncedLastContacted] = contact.LastContacted.Format(time.RFC3339)
 			}
+			if contact.LastOutreachAt != nil {
+				metadata[MetadataKeySyncedLastOutreachAt] = contact.LastOutreachAt.Format(time.RFC3339)
+			}
 			if _, err := p.contactTaskRepo.UpdateContactTaskMetadata(ctx, task.ID, metadata); err != nil {
 				logger.Warn().Err(err).Msg("failed to store pending_temp_id and synced_deadline in task metadata")
 			}
@@ -851,22 +859,8 @@ func (p *CadenceSyncProvider) reconcileContactTasks(
 			continue
 		}
 
-		// Skip contacts with pending follow-up (grace period — waiting for response)
-		_, err := p.contactTaskRepo.FindPendingFollowUp(ctx, contact.ID)
-		if err == nil {
-			logger.Debug().
-				Str("contactId", contact.ID.String()).
-				Str("contactName", contact.FullName).
-				Msg("skipping reconciliation: pending follow-up task exists")
-			continue
-		}
-		if !errors.Is(err, db.ErrNotFound) {
-			continue // unexpected error, skip
-		}
-
-		currentDeadline := contact.ContactBy.Format(DateFormat)
-
-		// Check if contact has a managed task
+		// Look up existing cadence task (before follow-up gate so outreach detection
+		// can fire even when a pending follow-up exists).
 		task, err := p.contactTaskRepo.GetContactTaskByContact(ctx, contact.ID, SourceName, TaskKindCadence)
 		if err == nil && task.State == repository.ContactTaskStateCompleted {
 			// Clean up completed cadence task so a new one can be created.
@@ -880,6 +874,32 @@ func (p *CadenceSyncProvider) reconcileContactTasks(
 			}
 			err = db.ErrNotFound
 		}
+
+		// If a managed cadence task exists, check if the contact was reached out to
+		// from a non-Todoist source (e.g., Telegram). If so, close the cadence task.
+		if err == nil && task.State == repository.ContactTaskStateManaged {
+			closeCmds := p.closeOnOutreach(ctx, task, &contact)
+			if closeCmds != nil {
+				commands = append(commands, closeCmds...)
+				continue
+			}
+		}
+
+		// Skip contacts with pending follow-up (grace period — waiting for response)
+		_, followUpErr := p.contactTaskRepo.FindPendingFollowUp(ctx, contact.ID)
+		if followUpErr == nil {
+			logger.Debug().
+				Str("contactId", contact.ID.String()).
+				Str("contactName", contact.FullName).
+				Msg("skipping reconciliation: pending follow-up task exists")
+			continue
+		}
+		if !errors.Is(followUpErr, db.ErrNotFound) {
+			continue // unexpected error, skip
+		}
+
+		currentDeadline := contact.ContactBy.Format(DateFormat)
+
 		if err != nil {
 			if !errors.Is(err, db.ErrNotFound) {
 				continue
@@ -896,7 +916,10 @@ func (p *CadenceSyncProvider) reconcileContactTasks(
 			if contact.LastContacted != nil {
 				taskMetadata[MetadataKeySyncedLastContacted] = contact.LastContacted.Format(time.RFC3339)
 			}
-			_, err := p.contactTaskRepo.CreateContactTask(ctx, repository.CreateContactTaskRequest{
+			if contact.LastOutreachAt != nil {
+				taskMetadata[MetadataKeySyncedLastOutreachAt] = contact.LastOutreachAt.Format(time.RFC3339)
+			}
+			_, createErr := p.contactTaskRepo.CreateContactTask(ctx, repository.CreateContactTaskRequest{
 				ContactID:      contact.ID,
 				Provider:       SourceName,
 				Kind:           TaskKindCadence,
@@ -904,8 +927,8 @@ func (p *CadenceSyncProvider) reconcileContactTasks(
 				State:          string(repository.ContactTaskStateManaged),
 				Metadata:       taskMetadata,
 			})
-			if err != nil {
-				logger.Warn().Err(err).Str("contactId", contact.ID.String()).Msg("failed to create contact task")
+			if createErr != nil {
+				logger.Warn().Err(createErr).Str("contactId", contact.ID.String()).Msg("failed to create contact task")
 			}
 			continue
 		}
@@ -926,6 +949,73 @@ func (p *CadenceSyncProvider) reconcileContactTasks(
 	}
 
 	return commands
+}
+
+// closeOnOutreach closes a managed cadence task when the contact has been reached out to
+// from a non-Todoist source (e.g., Telegram). Returns commands to send to Todoist
+// (item_close), or nil if no outreach was detected. State transition must succeed before
+// the close command is enqueued (same pattern as handleFollowUpDismissal).
+func (p *CadenceSyncProvider) closeOnOutreach(
+	ctx context.Context,
+	task *repository.ContactTask,
+	contact *repository.Contact,
+) []SyncCommand {
+	if p.wasReachedOutSinceSync(contact, task) {
+		logger.Info().
+			Str("contactId", contact.ID.String()).
+			Str("contactName", contact.FullName).
+			Msg("contact was reached out to since last sync (non-Todoist source), closing cadence task")
+
+		// Mark completed locally FIRST — only enqueue the Todoist close if this succeeds.
+		// If state update fails, skip the remote close entirely to avoid leaving a
+		// local 'managed' row while the Todoist task is closed (same pattern as
+		// handleFollowUpDismissal).
+		if _, err := p.contactTaskRepo.UpdateContactTaskState(ctx, task.ID, repository.ContactTaskStateCompleted); err != nil {
+			logger.Warn().Err(err).Str("contactId", contact.ID.String()).Msg("failed to mark cadence task completed after outreach detection — skipping close")
+			return nil
+		}
+
+		var commands []SyncCommand
+
+		// State transition succeeded — now safe to close in Todoist
+		if task.ExternalTaskID != "" && !isPendingTempID(task) {
+			commands = append(commands, NewItemCloseCommand(task.ExternalTaskID))
+		}
+
+		// Update synced_last_outreach_at so we don't re-fire on the next tick
+		metadata := task.Metadata
+		if metadata == nil {
+			metadata = make(map[string]any)
+		}
+		if contact.LastOutreachAt != nil {
+			metadata[MetadataKeySyncedLastOutreachAt] = contact.LastOutreachAt.Format(time.RFC3339)
+		}
+		if _, err := p.contactTaskRepo.UpdateContactTaskMetadata(ctx, task.ID, metadata); err != nil {
+			logger.Warn().Err(err).Str("contactId", contact.ID.String()).Msg("failed to update synced_last_outreach_at after outreach detection")
+		}
+
+		return commands
+	}
+
+	// No outreach detected. Backfill synced_last_outreach_at if missing (legacy tasks
+	// created before this feature). This backfill is critical here because
+	// reconcileExistingTask (the other backfill location) is only reached AFTER the
+	// follow-up gate — tasks with a pending follow-up would never get backfilled
+	// without this pre-gate path.
+	if _, hasSyncedLO := task.Metadata[MetadataKeySyncedLastOutreachAt].(string); !hasSyncedLO {
+		if contact.LastOutreachAt != nil {
+			metadata := task.Metadata
+			if metadata == nil {
+				metadata = make(map[string]any)
+			}
+			metadata[MetadataKeySyncedLastOutreachAt] = contact.LastOutreachAt.Format(time.RFC3339)
+			if _, err := p.contactTaskRepo.UpdateContactTaskMetadata(ctx, task.ID, metadata); err != nil {
+				logger.Warn().Err(err).Str("contactId", contact.ID.String()).Msg("failed to backfill synced_last_outreach_at (pre-gate)")
+			}
+		}
+	}
+
+	return nil
 }
 
 // reconcileExistingTask checks if an existing managed task's deadline matches contact_by.
@@ -970,6 +1060,9 @@ func (p *CadenceSyncProvider) reconcileExistingTask(
 		if contact.LastContacted != nil {
 			metadata[MetadataKeySyncedLastContacted] = contact.LastContacted.Format(time.RFC3339)
 		}
+		if contact.LastOutreachAt != nil {
+			metadata[MetadataKeySyncedLastOutreachAt] = contact.LastOutreachAt.Format(time.RFC3339)
+		}
 		if _, err := p.contactTaskRepo.UpdateContactTaskMetadata(ctx, task.ID, metadata); err != nil {
 			logger.Warn().Err(err).Str("contactId", contact.ID.String()).Msg("failed to backfill synced_deadline")
 		}
@@ -986,10 +1079,30 @@ func (p *CadenceSyncProvider) reconcileExistingTask(
 				metadata = make(map[string]any)
 			}
 			metadata[MetadataKeySyncedLastContacted] = contact.LastContacted.Format(time.RFC3339)
+			if contact.LastOutreachAt != nil {
+				metadata[MetadataKeySyncedLastOutreachAt] = contact.LastOutreachAt.Format(time.RFC3339)
+			}
 			if _, err := p.contactTaskRepo.UpdateContactTaskMetadata(ctx, task.ID, metadata); err != nil {
 				logger.Warn().Err(err).Str("contactId", contact.ID.String()).Msg("failed to backfill synced_last_contacted")
 			} else {
 				// Update task in memory so wasContactedSinceSync can use it this cycle
+				task.Metadata = metadata
+			}
+		}
+	}
+
+	// Backfill synced_last_outreach_at if missing (tasks created before this feature).
+	// Without this, wasReachedOutSinceSync would always return false for legacy tasks.
+	if _, hasSyncedLO := task.Metadata[MetadataKeySyncedLastOutreachAt].(string); !hasSyncedLO {
+		if contact.LastOutreachAt != nil {
+			metadata := task.Metadata
+			if metadata == nil {
+				metadata = make(map[string]any)
+			}
+			metadata[MetadataKeySyncedLastOutreachAt] = contact.LastOutreachAt.Format(time.RFC3339)
+			if _, err := p.contactTaskRepo.UpdateContactTaskMetadata(ctx, task.ID, metadata); err != nil {
+				logger.Warn().Err(err).Str("contactId", contact.ID.String()).Msg("failed to backfill synced_last_outreach_at")
+			} else {
 				task.Metadata = metadata
 			}
 		}
@@ -1039,6 +1152,9 @@ func (p *CadenceSyncProvider) reconcileExistingTask(
 					if contact.LastContacted != nil {
 						metadata[MetadataKeySyncedLastContacted] = contact.LastContacted.Format(time.RFC3339)
 					}
+					if contact.LastOutreachAt != nil {
+						metadata[MetadataKeySyncedLastOutreachAt] = contact.LastOutreachAt.Format(time.RFC3339)
+					}
 					if _, err := p.contactTaskRepo.UpdateContactTaskMetadata(ctx, task.ID, metadata); err != nil {
 						logger.Warn().Err(err).Msg("failed to update metadata after non-Todoist contact")
 					}
@@ -1081,6 +1197,9 @@ func (p *CadenceSyncProvider) reconcileExistingTask(
 	if contact.LastContacted != nil {
 		metadata[MetadataKeySyncedLastContacted] = contact.LastContacted.Format(time.RFC3339)
 	}
+	if contact.LastOutreachAt != nil {
+		metadata[MetadataKeySyncedLastOutreachAt] = contact.LastOutreachAt.Format(time.RFC3339)
+	}
 	if _, err := p.contactTaskRepo.UpdateContactTaskMetadata(ctx, task.ID, metadata); err != nil {
 		logger.Error().
 			Err(err).
@@ -1116,6 +1235,29 @@ func (p *CadenceSyncProvider) wasContactedSinceSync(contact *repository.Contact,
 	}
 
 	return contact.LastContacted.Truncate(time.Second).After(syncedLastContacted)
+}
+
+// wasReachedOutSinceSync checks if the contact's last_outreach_at has advanced since the
+// task was last synced. This detects non-Todoist outbound events (e.g., Telegram messages)
+// that should trigger cadence task completion — the cadence task is an outreach reminder,
+// and the outreach has happened.
+func (p *CadenceSyncProvider) wasReachedOutSinceSync(contact *repository.Contact, task *repository.ContactTask) bool {
+	if contact.LastOutreachAt == nil {
+		return false
+	}
+
+	syncedLastOutreachStr, ok := task.Metadata[MetadataKeySyncedLastOutreachAt].(string)
+	if !ok || syncedLastOutreachStr == "" {
+		return false
+	}
+
+	syncedLastOutreach, err := time.Parse(time.RFC3339, syncedLastOutreachStr)
+	if err != nil {
+		logger.Warn().Err(err).Str("value", syncedLastOutreachStr).Msg("failed to parse synced_last_outreach_at")
+		return false
+	}
+
+	return contact.LastOutreachAt.Truncate(time.Second).After(syncedLastOutreach)
 }
 
 // isPendingTempID checks if the task's external ID is still a pending temp ID

--- a/backend/internal/todoist/provider_outreach_close_test.go
+++ b/backend/internal/todoist/provider_outreach_close_test.go
@@ -270,9 +270,10 @@ func TestReconcile_OutreachDetectionStateFailureSkipsClose(t *testing.T) {
 
 	// Call closeOnOutreach with a cancelled context to force state update failure.
 	badCtx := cancelledContext()
-	commands := env.provider.closeOnOutreach(badCtx, cadenceTask, reloadedContact)
+	commands, handled := env.provider.closeOnOutreach(badCtx, cadenceTask, reloadedContact)
 
-	// Assert: no commands returned (safe failure — don't close remote).
+	// Assert: not handled and no commands returned (safe failure — don't close remote).
+	assert.False(t, handled, "outreach must not be handled when state update fails")
 	assert.Nil(t, commands, "no commands must be returned when state update fails")
 
 	// Assert: cadence task remains managed (state update failed).
@@ -305,7 +306,8 @@ func TestCloseOnOutreach_NilLastOutreachAt(t *testing.T) {
 	})
 
 	// contact.LastOutreachAt is nil — wasReachedOutSinceSync should return false.
-	commands := env.provider.closeOnOutreach(env.ctx, task, contact)
+	commands, handled := env.provider.closeOnOutreach(env.ctx, task, contact)
+	assert.False(t, handled, "closeOnOutreach must not handle when LastOutreachAt is nil")
 	assert.Nil(t, commands, "closeOnOutreach must return nil when LastOutreachAt is nil")
 
 	// Verify task is still managed.

--- a/backend/internal/todoist/provider_outreach_close_test.go
+++ b/backend/internal/todoist/provider_outreach_close_test.go
@@ -286,6 +286,51 @@ func TestReconcile_OutreachDetectionStateFailureSkipsClose(t *testing.T) {
 	assert.Equal(t, 0, env.recorder.count, "outreach detection must not record interactions")
 }
 
+// TestCloseOnOutreach_PendingTempID verifies that when outreach is detected but
+// the cadence task has a pending temp ID (no real Todoist ID yet), closeOnOutreach
+// still returns handled=true (so the caller skips further processing) but emits
+// no item_close command (can't close what Todoist hasn't confirmed yet). The DB
+// row must still transition to completed.
+func TestCloseOnOutreach_PendingTempID(t *testing.T) {
+	env, cleanup := setupDismissalTest(t)
+	defer cleanup()
+
+	contact, snap := createDismissalContact(t, env, "PendingTemp")
+
+	// Seed cadence task with a pending temp ID (simulating a task whose Todoist
+	// ID hasn't been resolved yet) and old synced_last_outreach_at.
+	oldOutreach := snap.LastOutreachAt.Add(-24 * time.Hour)
+	tempID := "tmp-" + uuid.New().String()[:8]
+	cadenceTask := createCadenceTask(t, env, contact.ID, tempID, map[string]any{
+		MetadataKeySyncedDeadline:       contact.ContactBy.Format(DateFormat),
+		MetadataKeySyncedLastContacted:  snap.LastContacted.Format(time.RFC3339),
+		MetadataKeySyncedLastOutreachAt: oldOutreach.Format(time.RFC3339),
+		MetadataKeyPendingTempID:        tempID, // marks this as a pending temp ID
+	})
+
+	// Advance last_outreach_at so outreach is detected.
+	newOutreach := accelerated.GetCurrentTime().UTC().Truncate(time.Second)
+	require.NoError(t, env.contactRepo.UpdateContactOutreachAt(env.ctx, contact.ID, newOutreach, true))
+
+	// Reload contact.
+	reloadedContact, err := env.contactRepo.GetContact(env.ctx, contact.ID)
+	require.NoError(t, err)
+
+	commands, handled := env.provider.closeOnOutreach(env.ctx, cadenceTask, reloadedContact)
+
+	// Assert: handled=true (outreach was detected and processed).
+	assert.True(t, handled, "outreach must be handled even with pending temp ID")
+
+	// Assert: no item_close command (can't close a pending temp task in Todoist).
+	assert.Empty(t, commands, "no item_close command should be emitted for pending temp ID tasks")
+
+	// Assert: DB row transitioned to completed.
+	reloadedTask, err := env.contactTaskRepo.GetContactTask(env.ctx, cadenceTask.ID)
+	require.NoError(t, err)
+	assert.Equal(t, repository.ContactTaskStateCompleted, reloadedTask.State,
+		"cadence task must be marked completed even with pending temp ID")
+}
+
 // TestCloseOnOutreach_NilLastOutreachAt verifies that closeOnOutreach returns
 // nil when the contact has no last_outreach_at (wasReachedOutSinceSync returns
 // false).

--- a/backend/internal/todoist/provider_outreach_close_test.go
+++ b/backend/internal/todoist/provider_outreach_close_test.go
@@ -1,0 +1,318 @@
+package todoist
+
+import (
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression tests for outreach-triggered cadence task closure.
+//
+// When the user sends a message via a non-Todoist source (e.g., Telegram),
+// the CRM records an outbound interaction and updates last_outreach_at. The
+// reconciler should detect this and close the existing cadence task (outreach
+// reminder) in Todoist.
+//
+// These tests use the shared dismissalTestEnv harness from
+// provider_dismissal_test.go. The strict countingRecorder is fine because
+// outreach detection never calls RecordInteraction.
+
+// createCadenceTask creates a managed cadence task for the given contact with
+// the specified metadata. Returns the created task.
+func createCadenceTask(t *testing.T, env *dismissalTestEnv, contactID uuid.UUID, externalID string, metadata map[string]any) *repository.ContactTask {
+	t.Helper()
+	task, err := env.contactTaskRepo.CreateContactTask(env.ctx, repository.CreateContactTaskRequest{
+		ContactID:      contactID,
+		Provider:       SourceName,
+		Kind:           TaskKindCadence,
+		ExternalTaskID: externalID,
+		State:          string(repository.ContactTaskStateManaged),
+		Metadata:       metadata,
+	})
+	require.NoError(t, err)
+	return task
+}
+
+// TestReconcile_CloseCadenceTaskOnOutreachWithPendingFollowUp is the primary
+// regression test for the root cause. When a Telegram outbound message updates
+// last_outreach_at AND creates a follow-up task, the reconciler must still
+// close the cadence task despite the follow-up gate.
+func TestReconcile_CloseCadenceTaskOnOutreachWithPendingFollowUp(t *testing.T) {
+	env, cleanup := setupDismissalTest(t)
+	defer cleanup()
+
+	contact, snap := createDismissalContact(t, env, "OutreachClose")
+
+	// Seed a managed cadence task with synced_last_outreach_at in the past.
+	oldOutreach := snap.LastOutreachAt.Add(-24 * time.Hour)
+	cadenceExtID := "td-cadence-" + uuid.New().String()[:8]
+	cadenceTask := createCadenceTask(t, env, contact.ID, cadenceExtID, map[string]any{
+		MetadataKeySyncedDeadline:       contact.ContactBy.Format(DateFormat),
+		MetadataKeySyncedLastContacted:  snap.LastContacted.Format(time.RFC3339),
+		MetadataKeySyncedLastOutreachAt: oldOutreach.Format(time.RFC3339),
+	})
+
+	// Create a pending follow-up (simulating the Telegram outbound flow).
+	followUpExtID := "td-followup-" + uuid.New().String()[:8]
+	followUp := createFollowUpTask(t, env, contact.ID, followUpExtID)
+
+	// Advance last_outreach_at (simulating a new Telegram outbound).
+	newOutreach := accelerated.GetCurrentTime().UTC().Truncate(time.Second)
+	require.NoError(t, env.contactRepo.UpdateContactOutreachAt(env.ctx, contact.ID, newOutreach, true))
+
+	// Run reconciler.
+	commands := env.provider.reconcileContactTasks(env.ctx, nil, env.settings, env.accountID)
+
+	// Assert: item_close command for the cadence task.
+	var closedIDs []string
+	for _, cmd := range commands {
+		if cmd.Type == "item_close" {
+			closedIDs = append(closedIDs, cmd.Args["id"].(string))
+		}
+	}
+	assert.Contains(t, closedIDs, cadenceExtID, "cadence task must be closed in Todoist")
+
+	// Assert: no new cadence task row created for this contact (the completed one
+	// still exists but no replacement was created).
+	_, lookupErr := env.contactTaskRepo.GetContactTaskByContact(env.ctx, contact.ID, SourceName, TaskKindCadence)
+	require.NoError(t, lookupErr, "completed cadence task row should still exist")
+
+	// Assert: cadence task state is completed.
+	reloadedCadence, err := env.contactTaskRepo.GetContactTask(env.ctx, cadenceTask.ID)
+	require.NoError(t, err)
+	assert.Equal(t, repository.ContactTaskStateCompleted, reloadedCadence.State)
+
+	// Assert: contact_by is unchanged.
+	reloadedContact, err := env.contactRepo.GetContact(env.ctx, contact.ID)
+	require.NoError(t, err)
+	assert.True(t, reloadedContact.ContactBy.Equal(*snap.ContactBy),
+		"contact_by must not change; want=%v got=%v", *snap.ContactBy, *reloadedContact.ContactBy)
+
+	// Assert: follow-up task is unchanged.
+	reloadedFollowUp, err := env.contactTaskRepo.GetContactTask(env.ctx, followUp.ID)
+	require.NoError(t, err)
+	assert.Equal(t, repository.ContactTaskStateManaged, reloadedFollowUp.State,
+		"follow-up task must remain managed")
+
+	// Assert: no interactions recorded.
+	assert.Equal(t, 0, env.recorder.count, "outreach detection must not record interactions")
+}
+
+// TestReconcile_CadenceTaskUnchangedWhenNoNewOutreach is the negative case:
+// last_outreach_at equals synced_last_outreach_at, so no outreach is detected.
+func TestReconcile_CadenceTaskUnchangedWhenNoNewOutreach(t *testing.T) {
+	env, cleanup := setupDismissalTest(t)
+	defer cleanup()
+
+	contact, snap := createDismissalContact(t, env, "NoOutreach")
+
+	// Seed cadence task with synced_last_outreach_at matching the contact's current value.
+	cadenceExtID := "td-cadence-noout-" + uuid.New().String()[:8]
+	createCadenceTask(t, env, contact.ID, cadenceExtID, map[string]any{
+		MetadataKeySyncedDeadline:       contact.ContactBy.Format(DateFormat),
+		MetadataKeySyncedLastContacted:  snap.LastContacted.Format(time.RFC3339),
+		MetadataKeySyncedLastOutreachAt: snap.LastOutreachAt.Format(time.RFC3339),
+	})
+
+	// No change to last_outreach_at — reconciler should not close the task.
+	commands := env.provider.reconcileContactTasks(env.ctx, nil, env.settings, env.accountID)
+
+	// Assert: no item_close command for the cadence task.
+	for _, cmd := range commands {
+		if cmd.Type == "item_close" {
+			if id, ok := cmd.Args["id"].(string); ok {
+				assert.NotEqual(t, cadenceExtID, id,
+					"cadence task must NOT be closed when no new outreach detected")
+			}
+		}
+	}
+}
+
+// TestReconcile_OutreachClosesWithoutPendingFollowUp verifies the cadence task
+// closes even when no follow-up task exists. On the next tick, the cadence task
+// should be recreated (since there's no follow-up to gate recreation).
+func TestReconcile_OutreachClosesWithoutPendingFollowUp(t *testing.T) {
+	env, cleanup := setupDismissalTest(t)
+	defer cleanup()
+
+	contact, snap := createDismissalContact(t, env, "OutreachNoFollowUp")
+
+	// Seed cadence task with old synced_last_outreach_at.
+	oldOutreach := snap.LastOutreachAt.Add(-24 * time.Hour)
+	cadenceExtID := "td-cadence-nofu-" + uuid.New().String()[:8]
+	createCadenceTask(t, env, contact.ID, cadenceExtID, map[string]any{
+		MetadataKeySyncedDeadline:       contact.ContactBy.Format(DateFormat),
+		MetadataKeySyncedLastContacted:  snap.LastContacted.Format(time.RFC3339),
+		MetadataKeySyncedLastOutreachAt: oldOutreach.Format(time.RFC3339),
+	})
+
+	// No follow-up task exists.
+
+	// Advance last_outreach_at.
+	newOutreach := accelerated.GetCurrentTime().UTC().Truncate(time.Second)
+	require.NoError(t, env.contactRepo.UpdateContactOutreachAt(env.ctx, contact.ID, newOutreach, true))
+
+	// First reconcile: cadence task should be closed.
+	commands := env.provider.reconcileContactTasks(env.ctx, nil, env.settings, env.accountID)
+
+	var closedIDs []string
+	for _, cmd := range commands {
+		if cmd.Type == "item_close" {
+			closedIDs = append(closedIDs, cmd.Args["id"].(string))
+		}
+	}
+	assert.Contains(t, closedIDs, cadenceExtID, "cadence task must be closed on outreach")
+
+	// Second reconcile: completed task is cleaned up, new cadence task created
+	// (no follow-up gate blocks recreation).
+	commands2 := env.provider.reconcileContactTasks(env.ctx, nil, env.settings, env.accountID)
+
+	var addCount int
+	for _, cmd := range commands2 {
+		if cmd.Type == "item_add" {
+			addCount++
+		}
+	}
+	assert.GreaterOrEqual(t, addCount, 1, "new cadence task should be recreated on the next tick")
+}
+
+// TestReconcile_LegacyTaskBackfillsWithoutClosing is a migration test for the
+// pre-gate backfill path. Legacy tasks without synced_last_outreach_at should
+// get the key backfilled on the first cycle without closing, then detect
+// outreach on the second cycle.
+func TestReconcile_LegacyTaskBackfillsWithoutClosing(t *testing.T) {
+	env, cleanup := setupDismissalTest(t)
+	defer cleanup()
+
+	contact, snap := createDismissalContact(t, env, "LegacyBackfill")
+
+	// Seed cadence task WITHOUT synced_last_outreach_at (legacy task).
+	cadenceExtID := "td-cadence-legacy-" + uuid.New().String()[:8]
+	cadenceTask := createCadenceTask(t, env, contact.ID, cadenceExtID, map[string]any{
+		MetadataKeySyncedDeadline:      contact.ContactBy.Format(DateFormat),
+		MetadataKeySyncedLastContacted: snap.LastContacted.Format(time.RFC3339),
+		// deliberately omitted: MetadataKeySyncedLastOutreachAt
+	})
+
+	// Create a pending follow-up so the follow-up gate would block
+	// reconcileExistingTask (verifying the pre-gate backfill runs).
+	followUpExtID := "td-followup-legacy-" + uuid.New().String()[:8]
+	createFollowUpTask(t, env, contact.ID, followUpExtID)
+
+	// First reconcile: should backfill synced_last_outreach_at without closing.
+	commands := env.provider.reconcileContactTasks(env.ctx, nil, env.settings, env.accountID)
+
+	// Assert: no item_close for the cadence task.
+	for _, cmd := range commands {
+		if cmd.Type == "item_close" {
+			if id, ok := cmd.Args["id"].(string); ok {
+				assert.NotEqual(t, cadenceExtID, id,
+					"cadence task must NOT be closed during backfill cycle")
+			}
+		}
+	}
+
+	// Assert: metadata now has synced_last_outreach_at.
+	reloaded, err := env.contactTaskRepo.GetContactTask(env.ctx, cadenceTask.ID)
+	require.NoError(t, err)
+	syncedLO, ok := reloaded.Metadata[MetadataKeySyncedLastOutreachAt].(string)
+	require.True(t, ok, "synced_last_outreach_at must be backfilled")
+	assert.Equal(t, snap.LastOutreachAt.Format(time.RFC3339), syncedLO,
+		"backfilled value must match contact's current last_outreach_at")
+
+	// Second cycle: advance last_outreach_at past the backfilled value.
+	newOutreach := accelerated.GetCurrentTime().UTC().Truncate(time.Second)
+	require.NoError(t, env.contactRepo.UpdateContactOutreachAt(env.ctx, contact.ID, newOutreach, true))
+
+	commands2 := env.provider.reconcileContactTasks(env.ctx, nil, env.settings, env.accountID)
+
+	var closedIDs []string
+	for _, cmd := range commands2 {
+		if cmd.Type == "item_close" {
+			closedIDs = append(closedIDs, cmd.Args["id"].(string))
+		}
+	}
+	assert.Contains(t, closedIDs, cadenceExtID, "cadence task must be closed on second cycle after backfill")
+}
+
+// TestReconcile_OutreachDetectionStateFailureSkipsClose verifies that if the
+// state transition to 'completed' fails, no item_close command is emitted.
+// Uses a cancelled context to deterministically fail the DB call (same pattern
+// as TestHandleFollowUpDismissal_StateUpdateErrorPropagates).
+func TestReconcile_OutreachDetectionStateFailureSkipsClose(t *testing.T) {
+	env, cleanup := setupDismissalTest(t)
+	defer cleanup()
+
+	contact, snap := createDismissalContact(t, env, "StateFailure")
+
+	// Seed cadence task with old synced_last_outreach_at so outreach IS detected.
+	oldOutreach := snap.LastOutreachAt.Add(-24 * time.Hour)
+	cadenceExtID := "td-cadence-fail-" + uuid.New().String()[:8]
+	cadenceTask := createCadenceTask(t, env, contact.ID, cadenceExtID, map[string]any{
+		MetadataKeySyncedDeadline:       contact.ContactBy.Format(DateFormat),
+		MetadataKeySyncedLastContacted:  snap.LastContacted.Format(time.RFC3339),
+		MetadataKeySyncedLastOutreachAt: oldOutreach.Format(time.RFC3339),
+	})
+
+	// Advance last_outreach_at so wasReachedOutSinceSync returns true.
+	newOutreach := accelerated.GetCurrentTime().UTC().Truncate(time.Second)
+	require.NoError(t, env.contactRepo.UpdateContactOutreachAt(env.ctx, contact.ID, newOutreach, true))
+
+	// Reload contact for closeOnOutreach.
+	reloadedContact, err := env.contactRepo.GetContact(env.ctx, contact.ID)
+	require.NoError(t, err)
+
+	// Call closeOnOutreach with a cancelled context to force state update failure.
+	badCtx := cancelledContext()
+	commands := env.provider.closeOnOutreach(badCtx, cadenceTask, reloadedContact)
+
+	// Assert: no commands returned (safe failure — don't close remote).
+	assert.Nil(t, commands, "no commands must be returned when state update fails")
+
+	// Assert: cadence task remains managed (state update failed).
+	reloadedTask, err := env.contactTaskRepo.GetContactTask(env.ctx, cadenceTask.ID)
+	require.NoError(t, err)
+	assert.Equal(t, repository.ContactTaskStateManaged, reloadedTask.State,
+		"cadence task must remain managed when state update fails")
+
+	// Assert: no interactions recorded.
+	assert.Equal(t, 0, env.recorder.count, "outreach detection must not record interactions")
+}
+
+// TestCloseOnOutreach_NilLastOutreachAt verifies that closeOnOutreach returns
+// nil when the contact has no last_outreach_at (wasReachedOutSinceSync returns
+// false).
+func TestCloseOnOutreach_NilLastOutreachAt(t *testing.T) {
+	env, cleanup := setupDismissalTest(t)
+	defer cleanup()
+
+	cadence := "monthly"
+	contact, err := env.contactRepo.CreateContact(env.ctx, repository.CreateContactRequest{
+		FullName: "NoOutreach " + uuid.New().String()[:8],
+		Cadence:  &cadence,
+	})
+	require.NoError(t, err)
+
+	cadenceExtID := "td-cadence-nil-" + uuid.New().String()[:8]
+	task := createCadenceTask(t, env, contact.ID, cadenceExtID, map[string]any{
+		MetadataKeySyncedDeadline: "2099-01-01",
+	})
+
+	// contact.LastOutreachAt is nil — wasReachedOutSinceSync should return false.
+	commands := env.provider.closeOnOutreach(env.ctx, task, contact)
+	assert.Nil(t, commands, "closeOnOutreach must return nil when LastOutreachAt is nil")
+
+	// Verify task is still managed.
+	_, findErr := env.contactTaskRepo.GetContactTaskByContact(env.ctx, contact.ID, SourceName, TaskKindCadence)
+	require.NoError(t, findErr, "cadence task must still exist as managed")
+
+	// Clean up — soft-delete the contact so it doesn't pollute other tests.
+	require.NoError(t, env.contactRepo.SoftDeleteContact(env.ctx, contact.ID))
+	_ = env.contactTaskRepo.DeleteContactTask(env.ctx, task.ID)
+}


### PR DESCRIPTION
## Summary

- Add outreach detection to the Todoist reconciler so cadence tasks (outreach reminders) are automatically closed when the user reaches out via a non-Todoist source (e.g., Telegram)
- Introduce `wasReachedOutSinceSync` function and `synced_last_outreach_at` metadata key, mirroring the existing `wasContactedSinceSync` / `synced_last_contacted` pattern
- Restructure `reconcileContactTasks` to check outreach **before** the follow-up gate, so cadence tasks are closed even when a pending follow-up exists
- Extract `closeOnOutreach` helper with `([]SyncCommand, bool)` return to safely distinguish "no outreach" from "outreach handled but no Todoist command needed" (pending temp ID case)

**Plan:** `.ai/log/plan/cadence-task-close-on-outreach.md`

## Test plan

- [x] 7 new integration tests in `provider_outreach_close_test.go`:
  - Close cadence task with pending follow-up (primary regression)
  - No close when no new outreach (negative case)
  - Close without follow-up + recreation on next tick
  - Legacy task backfill without closing (migration test)
  - State failure skips close (safety test)
  - Pending temp ID: handled=true, no item_close, DB transition
  - Nil last_outreach_at edge case
- [x] All 40 todoist package tests pass (33 existing + 7 new)
- [x] `make lint` clean
- [x] `make test` all pass
- [x] `make test-e2e-diff` all pass (20 E2E tests)
- [x] Codex review: PASS after 3 rounds (fixed nil-return ambiguity bug)
- [x] Manual verification after deploy: send Telegram message to contact with cadence task, verify task closes on next sync tick