### PR TITLE
fix(telegram): preserve peer data on discovery upsert + show @username on cards

### DIFF
--- a/.ai/log/learnings/b011cdd8-ce92-4530-87c2-2d2532b91f9a.yaml
+++ b/.ai/log/learnings/b011cdd8-ce92-4530-87c2-2d2532b91f9a.yaml
@@ -1,0 +1,120 @@
+---
+timestamp: "2026-04-12T16:59:02.966769"
+type: gotcha
+summary: Telegram API returns blank strings for missing peer fields, not NULL
+detail: |
+  When a Telegram message has no peer metadata (e.g., from deleted accounts), the Telegram API returns empty strings ("") for peer_username, peer_first_name, peer_last_name, not NULL. This breaks NULL-based upsert logic (COALESCE skips ""). **Fix:** Normalize empty strings to nil in Go before upserting (`if s == "" { return nil }`), and add `!= ''` filters to SQL aggregation ORDER BY clauses. The prod bug (peer 1504114951 showing "Unknown") was caused by a blank-string row winning the DISTINCT ON sort and then overwriting populated data via unconditional upsert.
+actionable: true
+
+---
+timestamp: "2026-04-12T16:59:02.966769"
+type: architecture
+summary: DISTINCT ON with ORDER BY can select 'best' row per group in one pass
+detail: |
+  For Telegram peer aggregation across messages, using `SELECT DISTINCT ON (peer_user_id) ... ORDER BY peer_user_id, (peer_username IS NOT NULL AND peer_username != '') DESC, ... peer_first_name ...` picks the most-populated row per peer in a single query. This avoids multi-pass COALESCE accumulation in Go. The tiebreaker order matters: (1) username/phone for identity matching, (2) non-empty name fields, (3) message_id DESC for recency. Without the `!= ''` guards, blank strings sort equal to populated strings and the result is non-deterministic.
+actionable: true
+
+---
+timestamp: "2026-04-12T16:59:02.966769"
+type: rule
+summary: Integration tests must call db.RunMigrations before db.NewDatabase
+detail: |
+  CI runs tests against a bare PostgreSQL container with no pre-existing schema. Tests in `backend/tests/` MUST call `db.RunMigrations(databaseURL, getMigrationsPath())` before `db.NewDatabase()`, otherwise queries fail with "relation does not exist". Local dev often has migrations already applied, masking this. Add the RunMigrations call in test setup (e.g., `func setupExternalContactRepo(t *testing.T)`) to ensure tests work in CI.
+actionable: true
+
+---
+timestamp: "2026-04-12T16:59:02.966769"
+type: rule
+summary: Test cleanup must use sqlc-generated queries, not raw SQL
+detail: |
+  Core rule: "Never write raw SQL in Go." This applies to test cleanup too. Use `database.Queries.DeleteExternalContactsBySourceIDPrefix(ctx, pgtype.Text{String: prefix, Valid: true})` instead of `database.Pool.Exec(ctx, "DELETE FROM external_contact WHERE source_id LIKE ...")`. The test.sql file already has prefix-based cleanup queries. Codex caught three instances of raw SQL in test cleanup that violated this rule.
+actionable: true
+
+---
+timestamp: "2026-04-12T16:59:02.966769"
+type: distinction
+summary: Codex review catches subtle bugs that slip past local testing
+detail: |
+  The implement-and-review skill runs Codex before push. In this session, Codex identified three real issues: (1) blank-string normalization missing from both SQL and Go, (2) missing batch-path test coverage, (3) raw SQL in test cleanup. All three would have passed local tests but broken production or violated codebase rules. The empty-string bug was particularly subtle — it only manifests when Telegram returns "" for a peer that previously had populated names, then the next sync overwrites the good data. Codex saw this because it cross-referenced the prod symptom in the plan against the code.
+actionable: false
+
+---
+timestamp: "2026-04-12T16:59:02.966769"
+type: gotcha
+summary: sqlc test cleanup queries require pgtype wrappers, not raw strings
+detail: |
+  When calling generated test cleanup queries like `DeleteExternalContactsBySourceIDPrefix`, the parameter type is `pgtype.Text`, not `string`. Must pass `pgtype.Text{String: "test-prefix-", Valid: true}`. Passing a raw string causes a compilation error. This is different from production queries which often take plain strings due to sqlc's `emit_pointers_for_null_types: false`. Test queries use pgtype because they're in a separate file (test.sql) with different emit settings.
+actionable: true
+
+---
+timestamp: "2026-04-12T17:14:04.195725"
+type: architecture
+summary: Use DISTINCT ON with multi-field ORDER BY for PostgreSQL aggregation in one pass
+detail: |
+  For Telegram peer aggregation across messages, `SELECT DISTINCT ON (peer_user_id) ... ORDER BY peer_user_id, (peer_username IS NOT NULL AND peer_username != '') DESC, (peer_first_name IS NOT NULL AND peer_first_name != '') DESC, message_id DESC` picks the most-populated row per peer in a single query. This avoids multi-pass queries or Go-side COALESCE accumulation. The tiebreaker order matters: prioritize fields needed for identity matching (username/phone), then name fields for display, then recency. Without `!= ''` guards, blank strings sort equal to populated strings making results non-deterministic.
+actionable: true
+
+---
+timestamp: "2026-04-12T17:14:04.195725"
+type: gotcha
+summary: Test cleanup queries require pgtype wrappers, not raw strings
+detail: |
+  When calling generated test cleanup queries like DeleteExternalContactsBySourceIDPrefix, the parameter type is pgtype.Text, not string. Must pass pgtype.Text{String: "prefix", Valid: true}. Passing raw strings causes compilation errors. This differs from production queries which often accept plain strings due to emit_pointers_for_null_types: false. Test queries in test.sql use different emit settings, hence require pgtype wrappers.
+actionable: true
+
+---
+timestamp: "2026-04-12T17:14:04.195725"
+type: architecture
+summary: Display name fallbacks from metadata must be sent explicitly on import
+detail: |
+  When adding display name fallbacks that pull from metadata (e.g., Telegram @username when first_name/last_name/display_name are missing), the import logic must explicitly send this fallback value to the backend. Frontend pattern: check if candidate lacks source name fields (display_name, first_name, last_name all null/empty), and if so, always include the derived displayName in the import payload even if user didn't edit it. Otherwise the backend receives empty name fields and import fails. See ImportLinkModal.handleImport for reference implementation.
+actionable: true
+
+---
+timestamp: "2026-04-12T17:14:04.195725"
+type: rule
+summary: "\"Never write raw SQL in Go\" applies to test code too"
+detail: |
+  The core rule "Never write raw SQL in Go" extends to test cleanup code. Use sqlc-generated queries from test.sql (e.g., DeleteTelegramMessagesByPeerUserID, DeleteExternalContactsBySourceIDPrefix) instead of database.Pool.Exec("DELETE FROM ..."). Create new test.sql queries if needed. Codex will catch violations of this rule in review, but it's better to follow the pattern from the start.
+actionable: true
+
+---
+timestamp: "2026-04-12T17:14:04.195725"
+type: documentation_gap
+summary: Integration test setup requirement not prominent enough for test cleanup
+detail: |
+  The Common Gotchas table documents that integration tests must call db.RunMigrations before db.NewDatabase for CI compatibility. However, it doesn't emphasize that the "Never write raw SQL" rule applies equally to test cleanup code. Agents may think test code is exempt from sqlc requirements. The gap: test-specific patterns (cleanup, setup) should be explicitly called out as following the same rules as production code. Strengthen by adding example in Anti-Patterns section showing wrong (raw SQL cleanup) vs right (sqlc cleanup).
+actionable: false
+
+---
+timestamp: "2026-04-12T17:24:28.292762"
+type: gotcha
+summary: Import modal display and backend method creation are separate concerns
+detail: |
+  Backend `buildMethodsAuto` may correctly create a contact method from metadata (e.g., Telegram username) on import, but the import/link modal won't display it in the Contact Methods section unless you also update: (1) `extractExternalMethods` in method-conflict-detection.ts to extract from metadata for Link mode conflict detection, (2) modal's `methodSelections` initialization to include the metadata field, (3) the "no contact methods available" guard condition. The backend creating it ≠ the modal showing it.
+actionable: true
+
+---
+timestamp: "2026-04-12T17:24:28.292762"
+type: architecture
+summary: Adding contact method types from metadata requires 6-location update pattern
+detail: |
+  When adding a new contact method type that comes from metadata (not emails/phones arrays on ImportCandidate), you must update: **Backend:** (1) `buildMethodsAuto` to create the method, (2) `buildMethodsFromSelection` to add the value to `availableValues` map for validation. **Frontend:** (3) `extractExternalMethods` to extract and return the handle from metadata, (4) modal's `methodSelections` useEffect to add the handle to selections, (5) "no contact methods available" guard to check metadata fields, (6) MethodSelector to support the method's icon and readonly/editable pattern. Missing any location causes display gaps or validation failures.
+actionable: true
+
+---
+timestamp: "2026-04-12T17:24:28.292762"
+type: architecture
+summary: MethodSelector supports two UI patterns based on HANDLE_METHOD_TYPES
+detail: |
+  MethodSelector renders differently based on method type: **Email methods** (email, gchat) get a type dropdown (personal/work/other/etc.) because users commonly have multiple emails with distinct purposes. **Handle methods** (telegram, discord, twitter) get a readonly type label and Send icon because handles are typically singular and non-categorizable. The distinction is determined by `HANDLE_METHOD_TYPES` set in contact-methods.ts. When adding a new handle-based method type, add it to `HANDLE_METHOD_TYPES` and update MethodSelector's icon rendering logic.
+actionable: true
+
+---
+timestamp: "2026-04-12T17:24:28.292762"
+type: documentation_gap
+summary: "\"When You Change X, Check Y\" entry for contact methods incomplete"
+detail: |
+  The "When You Change X, Check Y" table has an entry for "Contact method types" that mentions updating the `contact_method` CHECK constraint and `identity.IdentifierType` enum. This is correct but incomplete — it doesn't mention the 6-location pattern required when adding method types from metadata (not standard emails/phones arrays). **Why missed:** The table focuses on database/type system changes, not UI display patterns. **How to strengthen:** Add a second row distinguishing "Contact method types (standard)" vs "Contact method types (from metadata)" with the latter listing all 6 update locations: buildMethodsAuto, buildMethodsFromSelection availableValues, extractExternalMethods, methodSelections init, no-methods guard, MethodSelector.
+actionable: true
+

--- a/backend/internal/api/handlers/import.go
+++ b/backend/internal/api/handlers/import.go
@@ -199,8 +199,8 @@ func (h *ImportHandler) ListImportCandidates(c *gin.Context) {
 		}
 
 		// Neither has match: sort alphabetically by display name, empty names last
-		iName := getCandidateDisplayName(candidates[i].DisplayName, candidates[i].FirstName, candidates[i].LastName)
-		jName := getCandidateDisplayName(candidates[j].DisplayName, candidates[j].FirstName, candidates[j].LastName)
+		iName := getCandidateDisplayName(candidates[i].DisplayName, candidates[i].FirstName, candidates[i].LastName, candidates[i].Metadata, candidates[i].Source)
+		jName := getCandidateDisplayName(candidates[j].DisplayName, candidates[j].FirstName, candidates[j].LastName, candidates[j].Metadata, candidates[j].Source)
 
 		// Empty names sort to end
 		if iName == "" && jName != "" {
@@ -650,8 +650,11 @@ func (h *ImportHandler) toImportCandidateResponse(contact *repository.ExternalCo
 	return response
 }
 
-// getCandidateDisplayName extracts the display name from response fields for sorting
-func getCandidateDisplayName(displayName, firstName, lastName *string) string {
+// getCandidateDisplayName extracts the display name from response fields for
+// sorting. For Telegram candidates, falls back to metadata["username"] (with
+// the stored leading "@" stripped) so handle-only peers sort alphabetically
+// instead of being bunched at the end with an empty key.
+func getCandidateDisplayName(displayName, firstName, lastName *string, metadata map[string]any, source string) string {
 	if displayName != nil {
 		return *displayName
 	}
@@ -663,6 +666,11 @@ func getCandidateDisplayName(displayName, firstName, lastName *string) string {
 	}
 	if lastName != nil {
 		return *lastName
+	}
+	if source == "telegram" {
+		if u, ok := metadata["username"].(string); ok && u != "" {
+			return strings.TrimPrefix(u, "@")
+		}
 	}
 	return ""
 }

--- a/backend/internal/api/handlers/import.go
+++ b/backend/internal/api/handlers/import.go
@@ -383,13 +383,27 @@ func (h *ImportHandler) ImportContact(c *gin.Context) {
 
 // buildMethodsFromSelection builds contact methods from user selection
 func (h *ImportHandler) buildMethodsFromSelection(external *repository.ExternalContact, selected []SelectedMethodInput) []service.ContactMethodInput {
-	// Build map of available values from external contact
-	availableValues := make(map[string]bool)
+	// Build map of available values from external contact. Tracks the value
+	// that should be persisted so telegram handles are stored without the
+	// leading '@' even when the frontend sends '@daledobeck' as the
+	// display-friendly original_value (matches buildMethodsAuto semantics).
+	availableValues := make(map[string]string)
 	for _, email := range external.Emails {
-		availableValues[email.Value] = true
+		availableValues[email.Value] = email.Value
 	}
 	for _, phone := range external.Phones {
-		availableValues[phone.Value] = true
+		availableValues[phone.Value] = phone.Value
+	}
+	// Telegram handle from metadata — accept both the stored ('@daledobeck')
+	// and bare ('daledobeck') forms as the original_value, but persist without
+	// the '@' so it matches buildMethodsAuto and downstream contact-method
+	// uniqueness checks.
+	if external.Source == "telegram" {
+		if handle, ok := external.Metadata["username"].(string); ok && handle != "" {
+			bare := strings.TrimPrefix(handle, "@")
+			availableValues[handle] = bare
+			availableValues[bare] = bare
+		}
 	}
 
 	methods := make([]service.ContactMethodInput, 0, len(selected))
@@ -397,13 +411,15 @@ func (h *ImportHandler) buildMethodsFromSelection(external *repository.ExternalC
 	hasPrimary := false // Track if we've already assigned a primary
 
 	for _, sel := range selected {
-		// Validate the value exists in external contact
-		if !availableValues[sel.OriginalValue] {
+		// Validate the value exists in external contact, and look up the
+		// canonical stored value (strips '@' for telegram handles).
+		storedValue, ok := availableValues[sel.OriginalValue]
+		if !ok {
 			logger.Warn().Str("value", sel.OriginalValue).Msg("selected value not found in external contact")
 			continue
 		}
 
-		normalized := repository.NormalizeContactMethodValue(sel.Type, sel.OriginalValue)
+		normalized := repository.NormalizeContactMethodValue(sel.Type, storedValue)
 		if normalized == "" {
 			continue
 		}
@@ -421,7 +437,7 @@ func (h *ImportHandler) buildMethodsFromSelection(external *repository.ExternalC
 
 		methods = append(methods, service.ContactMethodInput{
 			Type:      sel.Type,
-			Value:     sel.OriginalValue,
+			Value:     storedValue,
 			IsPrimary: isPrimary,
 		})
 		usedValues[key] = true

--- a/backend/internal/api/handlers/import_matching_test.go
+++ b/backend/internal/api/handlers/import_matching_test.go
@@ -439,8 +439,8 @@ func TestCandidateSorting_ByConfidence(t *testing.T) {
 				}
 
 				// Neither has match: sort alphabetically by display name, empty names last
-				iName := getCandidateDisplayName(tt.candidates[i].DisplayName, tt.candidates[i].FirstName, tt.candidates[i].LastName)
-				jName := getCandidateDisplayName(tt.candidates[j].DisplayName, tt.candidates[j].FirstName, tt.candidates[j].LastName)
+				iName := getCandidateDisplayName(tt.candidates[i].DisplayName, tt.candidates[i].FirstName, tt.candidates[i].LastName, tt.candidates[i].Metadata, tt.candidates[i].Source)
+				jName := getCandidateDisplayName(tt.candidates[j].DisplayName, tt.candidates[j].FirstName, tt.candidates[j].LastName, tt.candidates[j].Metadata, tt.candidates[j].Source)
 
 				// Empty names sort to end
 				if iName == "" && jName != "" {
@@ -473,6 +473,54 @@ func TestCandidateSorting_ByConfidence(t *testing.T) {
 	}
 }
 
+// TestSortCandidates_TelegramUsername verifies that Telegram candidates with
+// only a metadata.username sort alphabetically by the handle (instead of being
+// bunched at the end with an empty key). Regression for anthropics/personal-crm#270.
+func TestSortCandidates_TelegramUsername(t *testing.T) {
+	candidates := []ImportCandidateResponse{
+		{
+			Source:   "telegram",
+			Metadata: map[string]any{"username": "@zara"},
+		},
+		{
+			Source:      "telegram",
+			DisplayName: stringPtr("Alice"),
+		},
+		{
+			Source:   "telegram",
+			Metadata: map[string]any{"username": "@bob"},
+		},
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		iName := getCandidateDisplayName(candidates[i].DisplayName, candidates[i].FirstName, candidates[i].LastName, candidates[i].Metadata, candidates[i].Source)
+		jName := getCandidateDisplayName(candidates[j].DisplayName, candidates[j].FirstName, candidates[j].LastName, candidates[j].Metadata, candidates[j].Source)
+		if iName == "" && jName != "" {
+			return false
+		}
+		if iName != "" && jName == "" {
+			return true
+		}
+		return iName < jName
+	})
+
+	// Expected order: Alice, bob, zara — handle-only peers sort in line with
+	// named ones rather than landing in the nameless tail.
+	got := make([]string, 0, len(candidates))
+	for _, c := range candidates {
+		if c.DisplayName != nil {
+			got = append(got, *c.DisplayName)
+			continue
+		}
+		if u, ok := c.Metadata["username"].(string); ok {
+			got = append(got, u)
+			continue
+		}
+		got = append(got, "")
+	}
+	assert.Equal(t, []string{"Alice", "@bob", "@zara"}, got)
+}
+
 // TestGetCandidateDisplayName tests the helper function for extracting display names
 func TestGetCandidateDisplayName(t *testing.T) {
 	tests := []struct {
@@ -480,6 +528,8 @@ func TestGetCandidateDisplayName(t *testing.T) {
 		displayName *string
 		firstName   *string
 		lastName    *string
+		metadata    map[string]any
+		source      string
 		expected    string
 	}{
 		{
@@ -514,11 +564,43 @@ func TestGetCandidateDisplayName(t *testing.T) {
 			name:     "all nil - returns empty",
 			expected: "",
 		},
+		{
+			name:     "telegram with username, no names — strips @ for sort",
+			metadata: map[string]any{"username": "@alice"},
+			source:   "telegram",
+			expected: "alice",
+		},
+		{
+			name:     "telegram with username but no leading @",
+			metadata: map[string]any{"username": "alice"},
+			source:   "telegram",
+			expected: "alice",
+		},
+		{
+			name:     "non-telegram source with username ignored",
+			metadata: map[string]any{"username": "@alice"},
+			source:   "gcontacts",
+			expected: "",
+		},
+		{
+			name:     "telegram with empty username string",
+			metadata: map[string]any{"username": ""},
+			source:   "telegram",
+			expected: "",
+		},
+		{
+			name:      "telegram with names present — name wins over username",
+			firstName: stringPtr("Dale"),
+			lastName:  stringPtr("Dobeck"),
+			metadata:  map[string]any{"username": "@daledobeck"},
+			source:    "telegram",
+			expected:  "Dale Dobeck",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := getCandidateDisplayName(tt.displayName, tt.firstName, tt.lastName)
+			result := getCandidateDisplayName(tt.displayName, tt.firstName, tt.lastName, tt.metadata, tt.source)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/backend/internal/api/handlers/test.go
+++ b/backend/internal/api/handlers/test.go
@@ -45,13 +45,20 @@ func NewTestHandler(
 	}
 }
 
-// SeedExternalContactInput represents input for creating an external contact
+// SeedExternalContactInput represents input for creating an external contact.
+// Source defaults to "test"; pass "telegram"/"gcontacts"/"gcal_attendee" to
+// seed source-specific rows. display_name is optional for Telegram seeds
+// where the candidate may only have a metadata.username.
 type SeedExternalContactInput struct {
-	DisplayName  string   `json:"display_name" validate:"required,min=1,max=255"`
-	Emails       []string `json:"emails,omitempty"`
-	Phones       []string `json:"phones,omitempty"`
-	Organization string   `json:"organization,omitempty"`
-	JobTitle     string   `json:"job_title,omitempty"`
+	DisplayName  string         `json:"display_name,omitempty" validate:"omitempty,max=255"`
+	FirstName    string         `json:"first_name,omitempty" validate:"omitempty,max=255"`
+	LastName     string         `json:"last_name,omitempty" validate:"omitempty,max=255"`
+	Source       string         `json:"source,omitempty" validate:"omitempty,oneof=test telegram gcontacts gcal_attendee"`
+	Emails       []string       `json:"emails,omitempty"`
+	Phones       []string       `json:"phones,omitempty"`
+	Organization string         `json:"organization,omitempty"`
+	JobTitle     string         `json:"job_title,omitempty"`
+	Metadata     map[string]any `json:"metadata,omitempty"`
 }
 
 // SeedExternalContactsRequest represents the request to seed external contacts
@@ -115,17 +122,41 @@ func (h *TestHandler) SeedExternalContacts(c *gin.Context) {
 			})
 		}
 
-		// Create upsert request with prefix in source_id for cleanup
-		displayName := req.Prefix + "-" + input.DisplayName
-		upsertReq := repository.UpsertExternalContactRequest{
-			Source:      "test",
-			SourceID:    fmt.Sprintf("%s-contact-%d", req.Prefix, i),
-			DisplayName: &displayName,
-			Emails:      emails,
-			Phones:      phones,
-			SyncedAt:    &now,
+		source := input.Source
+		if source == "" {
+			source = "test"
 		}
 
+		// Pick a source-aware source_id format so Cleanup's prefix-based
+		// DeleteExternalContactsBySourceIDPrefix picks up the rows later.
+		sourceIDSuffix := "contact"
+		if source == "telegram" {
+			sourceIDSuffix = "tg"
+		}
+
+		// Create upsert request with prefix in source_id for cleanup.
+		// display_name keeps the prefix when provided so cleanup-by-display_name works too.
+		upsertReq := repository.UpsertExternalContactRequest{
+			Source:   source,
+			SourceID: fmt.Sprintf("%s-%s-%d", req.Prefix, sourceIDSuffix, i),
+			Emails:   emails,
+			Phones:   phones,
+			Metadata: input.Metadata,
+			SyncedAt: &now,
+		}
+
+		if input.DisplayName != "" {
+			displayName := req.Prefix + "-" + input.DisplayName
+			upsertReq.DisplayName = &displayName
+		}
+		if input.FirstName != "" {
+			firstName := input.FirstName
+			upsertReq.FirstName = &firstName
+		}
+		if input.LastName != "" {
+			lastName := input.LastName
+			upsertReq.LastName = &lastName
+		}
 		if input.Organization != "" {
 			upsertReq.Organization = &input.Organization
 		}

--- a/backend/internal/api/handlers/test_handler_test.go
+++ b/backend/internal/api/handlers/test_handler_test.go
@@ -1,8 +1,10 @@
 package handlers
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/go-playground/validator/v10"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -83,13 +85,14 @@ func TestEscapeSQLLikeWildcards(t *testing.T) {
 }
 
 func TestSeedExternalContactInput_Validation(t *testing.T) {
+	v := validator.New()
 	tests := []struct {
 		name    string
 		input   SeedExternalContactInput
 		isValid bool
 	}{
 		{
-			name: "valid minimal input",
+			name: "valid minimal input (display_name only)",
 			input: SeedExternalContactInput{
 				DisplayName: "Test User",
 			},
@@ -107,9 +110,33 @@ func TestSeedExternalContactInput_Validation(t *testing.T) {
 			isValid: true,
 		},
 		{
-			name: "empty display name",
+			name: "valid telegram seed with metadata.username and no display_name",
 			input: SeedExternalContactInput{
-				DisplayName: "",
+				Source:   "telegram",
+				Metadata: map[string]any{"username": "@daledobeck"},
+			},
+			isValid: true,
+		},
+		{
+			name: "valid with first/last name, no display_name",
+			input: SeedExternalContactInput{
+				FirstName: "Dale",
+				LastName:  "Dobeck",
+			},
+			isValid: true,
+		},
+		{
+			name: "invalid source rejected",
+			input: SeedExternalContactInput{
+				DisplayName: "Test User",
+				Source:      "bogus",
+			},
+			isValid: false,
+		},
+		{
+			name: "display_name exceeds max length",
+			input: SeedExternalContactInput{
+				DisplayName: strings.Repeat("a", 256),
 			},
 			isValid: false,
 		},
@@ -117,11 +144,11 @@ func TestSeedExternalContactInput_Validation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Test that display_name is required
+			err := v.Struct(tt.input)
 			if tt.isValid {
-				assert.NotEmpty(t, tt.input.DisplayName)
+				assert.NoError(t, err)
 			} else {
-				assert.Empty(t, tt.input.DisplayName)
+				assert.Error(t, err)
 			}
 		})
 	}

--- a/backend/internal/db/external_contact.sql.go
+++ b/backend/internal/db/external_contact.sql.go
@@ -822,3 +822,67 @@ func (q *Queries) UpsertExternalContact(ctx context.Context, arg UpsertExternalC
 	)
 	return &i, err
 }
+
+const UpsertTelegramDiscoveryCandidate = `-- name: UpsertTelegramDiscoveryCandidate :one
+INSERT INTO external_contact (
+    source, source_id, display_name, first_name, last_name, metadata, synced_at
+) VALUES ('telegram', $1, $2, $3, $4, $5, $6)
+ON CONFLICT (source, source_id, COALESCE(account_id, '')) DO UPDATE SET
+    display_name = COALESCE(EXCLUDED.display_name, external_contact.display_name),
+    first_name   = COALESCE(EXCLUDED.first_name,   external_contact.first_name),
+    last_name    = COALESCE(EXCLUDED.last_name,    external_contact.last_name),
+    metadata     = external_contact.metadata || EXCLUDED.metadata,
+    synced_at    = EXCLUDED.synced_at,
+    updated_at   = NOW()
+RETURNING id, source, source_id, account_id, display_name, first_name, last_name, emails, phones, addresses, organization, job_title, birthday, photo_url, crm_contact_id, match_status, duplicate_of_id, etag, metadata, synced_at, created_at, updated_at
+`
+
+type UpsertTelegramDiscoveryCandidateParams struct {
+	SourceID    string             `json:"source_id"`
+	DisplayName pgtype.Text        `json:"display_name"`
+	FirstName   pgtype.Text        `json:"first_name"`
+	LastName    pgtype.Text        `json:"last_name"`
+	Metadata    []byte             `json:"metadata"`
+	SyncedAt    pgtype.Timestamptz `json:"synced_at"`
+}
+
+// Telegram-specific upsert that preserves populated peer fields when a later
+// message arrives with null entity data. Never clears a name/handle that was
+// previously captured. Metadata is merged (|| operator) so keys from earlier
+// writes (e.g. username) are retained when the new map omits them.
+func (q *Queries) UpsertTelegramDiscoveryCandidate(ctx context.Context, arg UpsertTelegramDiscoveryCandidateParams) (*ExternalContact, error) {
+	row := q.db.QueryRow(ctx, UpsertTelegramDiscoveryCandidate,
+		arg.SourceID,
+		arg.DisplayName,
+		arg.FirstName,
+		arg.LastName,
+		arg.Metadata,
+		arg.SyncedAt,
+	)
+	var i ExternalContact
+	err := row.Scan(
+		&i.ID,
+		&i.Source,
+		&i.SourceID,
+		&i.AccountID,
+		&i.DisplayName,
+		&i.FirstName,
+		&i.LastName,
+		&i.Emails,
+		&i.Phones,
+		&i.Addresses,
+		&i.Organization,
+		&i.JobTitle,
+		&i.Birthday,
+		&i.PhotoUrl,
+		&i.CrmContactID,
+		&i.MatchStatus,
+		&i.DuplicateOfID,
+		&i.Etag,
+		&i.Metadata,
+		&i.SyncedAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return &i, err
+}

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -363,6 +363,11 @@ type Querier interface {
 	UpsertTelegramChannelAccessHash(ctx context.Context, arg UpsertTelegramChannelAccessHashParams) (*TelegramChannelState, error)
 	UpsertTelegramChannelState(ctx context.Context, arg UpsertTelegramChannelStateParams) (*TelegramChannelState, error)
 	UpsertTelegramChatConfig(ctx context.Context, arg UpsertTelegramChatConfigParams) (*TelegramChatConfig, error)
+	// Telegram-specific upsert that preserves populated peer fields when a later
+	// message arrives with null entity data. Never clears a name/handle that was
+	// previously captured. Metadata is merged (|| operator) so keys from earlier
+	// writes (e.g. username) are retained when the new map omits them.
+	UpsertTelegramDiscoveryCandidate(ctx context.Context, arg UpsertTelegramDiscoveryCandidateParams) (*ExternalContact, error)
 	UpsertTelegramMessage(ctx context.Context, arg UpsertTelegramMessageParams) (*TelegramMessage, error)
 	UpsertTelegramSession(ctx context.Context, arg UpsertTelegramSessionParams) (*TelegramSession, error)
 	// Used by gotd/td session.Storage — only updates encrypted session data,

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -91,6 +91,7 @@ type Querier interface {
 	DeleteExternalContactsByDisplayNamePrefix(ctx context.Context, dollar_1 pgtype.Text) (int64, error)
 	DeleteExternalContactsBySourceAccount(ctx context.Context, arg DeleteExternalContactsBySourceAccountParams) error
 	DeleteExternalContactsBySourceIDPrefix(ctx context.Context, dollar_1 pgtype.Text) (int64, error)
+	DeleteExternalIdentitiesBySourceID(ctx context.Context, sourceID pgtype.Text) (int64, error)
 	DeleteIdentitiesForContact(ctx context.Context, contactID pgtype.UUID) error
 	DeleteIdentity(ctx context.Context, id pgtype.UUID) error
 	DeleteNote(ctx context.Context, id pgtype.UUID) error
@@ -104,6 +105,7 @@ type Querier interface {
 	DeleteTag(ctx context.Context, id pgtype.UUID) error
 	DeleteTelegramChannelState(ctx context.Context, channelID int64) error
 	DeleteTelegramChatConfig(ctx context.Context, telegramChatID int64) error
+	DeleteTelegramMessagesByPeerUserID(ctx context.Context, peerUserID pgtype.Int8) (int64, error)
 	DeleteTelegramSession(ctx context.Context) error
 	DeleteTelegramUpdateState(ctx context.Context, userID int64) error
 	// Demote source's primary contact methods when target already has a primary for that type
@@ -216,6 +218,9 @@ type Querier interface {
 	// Prefer rows with username/phone for identity matching, then rows with
 	// populated names so a single aggregation pass picks the most-populated row
 	// per peer (avoids depending on multi-pass COALESCE accumulation in Go).
+	// Treats blank strings as absent — Telegram sometimes persists '' instead of
+	// NULL for entity fields on outbound private chats, and those rows must not
+	// outrank a row with a real name.
 	ListDistinctUnmatchedPeers(ctx context.Context) ([]*ListDistinctUnmatchedPeersRow, error)
 	ListDueSyncStates(ctx context.Context, nextSyncAt pgtype.Timestamptz) ([]*ExternalSyncState, error)
 	ListEnabledSyncStates(ctx context.Context) ([]*ExternalSyncState, error)

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -213,7 +213,9 @@ type Querier interface {
 	// Lists contacts that have a contact_by date set (used for testing mode filtering).
 	// Returns contacts ordered by contact_by (soonest first).
 	ListContactsWithContactBy(ctx context.Context, limit int32) ([]*Contact, error)
-	// Prefer rows with username/phone for identity matching
+	// Prefer rows with username/phone for identity matching, then rows with
+	// populated names so a single aggregation pass picks the most-populated row
+	// per peer (avoids depending on multi-pass COALESCE accumulation in Go).
 	ListDistinctUnmatchedPeers(ctx context.Context) ([]*ListDistinctUnmatchedPeersRow, error)
 	ListDueSyncStates(ctx context.Context, nextSyncAt pgtype.Timestamptz) ([]*ExternalSyncState, error)
 	ListEnabledSyncStates(ctx context.Context) ([]*ExternalSyncState, error)

--- a/backend/internal/db/queries/external_contact.sql
+++ b/backend/internal/db/queries/external_contact.sql
@@ -109,6 +109,23 @@ WHERE source = $1 AND COALESCE(account_id, '') = COALESCE($2, '');
 -- name: DeleteExternalContact :exec
 DELETE FROM external_contact WHERE id = $1;
 
+-- name: UpsertTelegramDiscoveryCandidate :one
+-- Telegram-specific upsert that preserves populated peer fields when a later
+-- message arrives with null entity data. Never clears a name/handle that was
+-- previously captured. Metadata is merged (|| operator) so keys from earlier
+-- writes (e.g. username) are retained when the new map omits them.
+INSERT INTO external_contact (
+    source, source_id, display_name, first_name, last_name, metadata, synced_at
+) VALUES ('telegram', $1, $2, $3, $4, $5, $6)
+ON CONFLICT (source, source_id, COALESCE(account_id, '')) DO UPDATE SET
+    display_name = COALESCE(EXCLUDED.display_name, external_contact.display_name),
+    first_name   = COALESCE(EXCLUDED.first_name,   external_contact.first_name),
+    last_name    = COALESCE(EXCLUDED.last_name,    external_contact.last_name),
+    metadata     = external_contact.metadata || EXCLUDED.metadata,
+    synced_at    = EXCLUDED.synced_at,
+    updated_at   = NOW()
+RETURNING *;
+
 -- Contact Enrichment queries
 
 -- name: GetEnrichmentsForContact :many

--- a/backend/internal/db/queries/telegram_message.sql
+++ b/backend/internal/db/queries/telegram_message.sql
@@ -67,7 +67,9 @@ WHERE matched_contact_id = @matched_contact_id
 ORDER BY telegram_chat_id, sent_at;
 
 -- name: ListDistinctUnmatchedPeers :many
--- Prefer rows with username/phone for identity matching
+-- Prefer rows with username/phone for identity matching, then rows with
+-- populated names so a single aggregation pass picks the most-populated row
+-- per peer (avoids depending on multi-pass COALESCE accumulation in Go).
 SELECT DISTINCT ON (peer_user_id)
     peer_user_id, peer_username, peer_first_name, peer_last_name, peer_phone
 FROM telegram_message
@@ -75,8 +77,10 @@ WHERE matched_contact_id IS NULL
   AND peer_user_id IS NOT NULL
   AND deleted_at IS NULL
 ORDER BY peer_user_id,
-    CASE WHEN peer_username IS NOT NULL THEN 0 ELSE 1 END,
-    CASE WHEN peer_phone IS NOT NULL THEN 0 ELSE 1 END,
+    CASE WHEN peer_username   IS NOT NULL THEN 0 ELSE 1 END,
+    CASE WHEN peer_phone      IS NOT NULL THEN 0 ELSE 1 END,
+    CASE WHEN peer_first_name IS NOT NULL THEN 0 ELSE 1 END,
+    CASE WHEN peer_last_name  IS NOT NULL THEN 0 ELSE 1 END,
     sent_at DESC;
 
 -- name: UpdateTelegramMessageContact :exec

--- a/backend/internal/db/queries/telegram_message.sql
+++ b/backend/internal/db/queries/telegram_message.sql
@@ -70,6 +70,9 @@ ORDER BY telegram_chat_id, sent_at;
 -- Prefer rows with username/phone for identity matching, then rows with
 -- populated names so a single aggregation pass picks the most-populated row
 -- per peer (avoids depending on multi-pass COALESCE accumulation in Go).
+-- Treats blank strings as absent — Telegram sometimes persists '' instead of
+-- NULL for entity fields on outbound private chats, and those rows must not
+-- outrank a row with a real name.
 SELECT DISTINCT ON (peer_user_id)
     peer_user_id, peer_username, peer_first_name, peer_last_name, peer_phone
 FROM telegram_message
@@ -77,10 +80,10 @@ WHERE matched_contact_id IS NULL
   AND peer_user_id IS NOT NULL
   AND deleted_at IS NULL
 ORDER BY peer_user_id,
-    CASE WHEN peer_username   IS NOT NULL THEN 0 ELSE 1 END,
-    CASE WHEN peer_phone      IS NOT NULL THEN 0 ELSE 1 END,
-    CASE WHEN peer_first_name IS NOT NULL THEN 0 ELSE 1 END,
-    CASE WHEN peer_last_name  IS NOT NULL THEN 0 ELSE 1 END,
+    CASE WHEN peer_username   IS NOT NULL AND peer_username   <> '' THEN 0 ELSE 1 END,
+    CASE WHEN peer_phone      IS NOT NULL AND peer_phone      <> '' THEN 0 ELSE 1 END,
+    CASE WHEN peer_first_name IS NOT NULL AND peer_first_name <> '' THEN 0 ELSE 1 END,
+    CASE WHEN peer_last_name  IS NOT NULL AND peer_last_name  <> '' THEN 0 ELSE 1 END,
     sent_at DESC;
 
 -- name: UpdateTelegramMessageContact :exec

--- a/backend/internal/db/queries/test.sql
+++ b/backend/internal/db/queries/test.sql
@@ -21,3 +21,9 @@ DELETE FROM calendar_event WHERE title LIKE $1 || '%';
 
 -- name: DeleteCalendarEventsByGcalEventIdPrefix :execrows
 DELETE FROM calendar_event WHERE gcal_event_id LIKE $1 || '%';
+
+-- name: DeleteTelegramMessagesByPeerUserID :execrows
+DELETE FROM telegram_message WHERE peer_user_id = $1;
+
+-- name: DeleteExternalIdentitiesBySourceID :execrows
+DELETE FROM external_identity WHERE source_id = $1;

--- a/backend/internal/db/telegram_message.sql.go
+++ b/backend/internal/db/telegram_message.sql.go
@@ -168,10 +168,10 @@ WHERE matched_contact_id IS NULL
   AND peer_user_id IS NOT NULL
   AND deleted_at IS NULL
 ORDER BY peer_user_id,
-    CASE WHEN peer_username   IS NOT NULL THEN 0 ELSE 1 END,
-    CASE WHEN peer_phone      IS NOT NULL THEN 0 ELSE 1 END,
-    CASE WHEN peer_first_name IS NOT NULL THEN 0 ELSE 1 END,
-    CASE WHEN peer_last_name  IS NOT NULL THEN 0 ELSE 1 END,
+    CASE WHEN peer_username   IS NOT NULL AND peer_username   <> '' THEN 0 ELSE 1 END,
+    CASE WHEN peer_phone      IS NOT NULL AND peer_phone      <> '' THEN 0 ELSE 1 END,
+    CASE WHEN peer_first_name IS NOT NULL AND peer_first_name <> '' THEN 0 ELSE 1 END,
+    CASE WHEN peer_last_name  IS NOT NULL AND peer_last_name  <> '' THEN 0 ELSE 1 END,
     sent_at DESC
 `
 
@@ -186,6 +186,9 @@ type ListDistinctUnmatchedPeersRow struct {
 // Prefer rows with username/phone for identity matching, then rows with
 // populated names so a single aggregation pass picks the most-populated row
 // per peer (avoids depending on multi-pass COALESCE accumulation in Go).
+// Treats blank strings as absent — Telegram sometimes persists ” instead of
+// NULL for entity fields on outbound private chats, and those rows must not
+// outrank a row with a real name.
 func (q *Queries) ListDistinctUnmatchedPeers(ctx context.Context) ([]*ListDistinctUnmatchedPeersRow, error) {
 	rows, err := q.db.Query(ctx, ListDistinctUnmatchedPeers)
 	if err != nil {

--- a/backend/internal/db/telegram_message.sql.go
+++ b/backend/internal/db/telegram_message.sql.go
@@ -168,8 +168,10 @@ WHERE matched_contact_id IS NULL
   AND peer_user_id IS NOT NULL
   AND deleted_at IS NULL
 ORDER BY peer_user_id,
-    CASE WHEN peer_username IS NOT NULL THEN 0 ELSE 1 END,
-    CASE WHEN peer_phone IS NOT NULL THEN 0 ELSE 1 END,
+    CASE WHEN peer_username   IS NOT NULL THEN 0 ELSE 1 END,
+    CASE WHEN peer_phone      IS NOT NULL THEN 0 ELSE 1 END,
+    CASE WHEN peer_first_name IS NOT NULL THEN 0 ELSE 1 END,
+    CASE WHEN peer_last_name  IS NOT NULL THEN 0 ELSE 1 END,
     sent_at DESC
 `
 
@@ -181,7 +183,9 @@ type ListDistinctUnmatchedPeersRow struct {
 	PeerPhone     pgtype.Text `json:"peer_phone"`
 }
 
-// Prefer rows with username/phone for identity matching
+// Prefer rows with username/phone for identity matching, then rows with
+// populated names so a single aggregation pass picks the most-populated row
+// per peer (avoids depending on multi-pass COALESCE accumulation in Go).
 func (q *Queries) ListDistinctUnmatchedPeers(ctx context.Context) ([]*ListDistinctUnmatchedPeersRow, error) {
 	rows, err := q.db.Query(ctx, ListDistinctUnmatchedPeers)
 	if err != nil {

--- a/backend/internal/db/test.sql.go
+++ b/backend/internal/db/test.sql.go
@@ -95,3 +95,27 @@ func (q *Queries) DeleteExternalContactsBySourceIDPrefix(ctx context.Context, do
 	}
 	return result.RowsAffected(), nil
 }
+
+const DeleteExternalIdentitiesBySourceID = `-- name: DeleteExternalIdentitiesBySourceID :execrows
+DELETE FROM external_identity WHERE source_id = $1
+`
+
+func (q *Queries) DeleteExternalIdentitiesBySourceID(ctx context.Context, sourceID pgtype.Text) (int64, error) {
+	result, err := q.db.Exec(ctx, DeleteExternalIdentitiesBySourceID, sourceID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const DeleteTelegramMessagesByPeerUserID = `-- name: DeleteTelegramMessagesByPeerUserID :execrows
+DELETE FROM telegram_message WHERE peer_user_id = $1
+`
+
+func (q *Queries) DeleteTelegramMessagesByPeerUserID(ctx context.Context, peerUserID pgtype.Int8) (int64, error) {
+	result, err := q.db.Exec(ctx, DeleteTelegramMessagesByPeerUserID, peerUserID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}

--- a/backend/internal/repository/external_contact.go
+++ b/backend/internal/repository/external_contact.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"personal-crm/backend/internal/db"
@@ -66,6 +67,18 @@ type ExternalContact struct {
 	SyncedAt      *time.Time     `json:"synced_at,omitempty"`
 	CreatedAt     time.Time      `json:"created_at"`
 	UpdatedAt     time.Time      `json:"updated_at"`
+}
+
+// UpsertTelegramDiscoveryCandidateRequest carries the Telegram-specific fields
+// used by the peer matcher. Nil name fields are preserved (never overwrite a
+// previously-captured name). Metadata is merged with existing stored metadata.
+type UpsertTelegramDiscoveryCandidateRequest struct {
+	SourceID    string         `json:"source_id"`
+	DisplayName *string        `json:"display_name,omitempty"`
+	FirstName   *string        `json:"first_name,omitempty"`
+	LastName    *string        `json:"last_name,omitempty"`
+	Metadata    map[string]any `json:"metadata,omitempty"`
+	SyncedAt    *time.Time     `json:"synced_at,omitempty"`
 }
 
 // UpsertExternalContactRequest holds parameters for creating/updating an external contact
@@ -299,6 +312,40 @@ func (r *ExternalContactRepository) Upsert(ctx context.Context, req UpsertExtern
 	dbContact, err := r.queries.UpsertExternalContact(ctx, params)
 	if err != nil {
 		return nil, err
+	}
+	return convertDbExternalContact(dbContact)
+}
+
+// UpsertTelegramDiscoveryCandidate inserts or updates a Telegram discovery
+// candidate via the dedicated SQL query. Unlike the shared Upsert, nil name
+// fields are preserved (never overwrite a stored value) and metadata is merged
+// with the existing stored map instead of replacing it. Unrelated columns
+// (emails, phones, addresses, organization, job_title, birthday, photo_url,
+// etag, account_id) are not touched on update.
+func (r *ExternalContactRepository) UpsertTelegramDiscoveryCandidate(
+	ctx context.Context,
+	req UpsertTelegramDiscoveryCandidateRequest,
+) (*ExternalContact, error) {
+	metadata := req.Metadata
+	if metadata == nil {
+		metadata = map[string]any{}
+	}
+	metadataBytes, err := json.Marshal(metadata)
+	if err != nil {
+		return nil, fmt.Errorf("marshal metadata: %w", err)
+	}
+
+	params := db.UpsertTelegramDiscoveryCandidateParams{
+		SourceID:    req.SourceID,
+		DisplayName: stringToPgText(req.DisplayName),
+		FirstName:   stringToPgText(req.FirstName),
+		LastName:    stringToPgText(req.LastName),
+		Metadata:    metadataBytes,
+		SyncedAt:    timeToPgTimestamptz(req.SyncedAt),
+	}
+	dbContact, err := r.queries.UpsertTelegramDiscoveryCandidate(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("upsert telegram discovery candidate: %w", err)
 	}
 	return convertDbExternalContact(dbContact)
 }

--- a/backend/internal/telegram/matcher.go
+++ b/backend/internal/telegram/matcher.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"personal-crm/backend/internal/accelerated"
 	"personal-crm/backend/internal/identity"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/service"
@@ -22,7 +23,7 @@ type identityMatcher interface {
 
 // externalContactUpserter defines the interface for upserting/updating external contacts.
 type externalContactUpserter interface {
-	Upsert(ctx context.Context, req repository.UpsertExternalContactRequest) (*repository.ExternalContact, error)
+	UpsertTelegramDiscoveryCandidate(ctx context.Context, req repository.UpsertTelegramDiscoveryCandidateRequest) (*repository.ExternalContact, error)
 	GetBySource(ctx context.Context, source, sourceID string, accountID *string) (*repository.ExternalContact, error)
 	UpdateMatch(ctx context.Context, id uuid.UUID, crmContactID *uuid.UUID, status repository.MatchStatus) (*repository.ExternalContact, error)
 }
@@ -181,6 +182,7 @@ func (m *PeerMatcher) UpdateDiscoveryCandidates(ctx context.Context) error {
 		peerMap[p.PeerUserID] = p
 	}
 
+	now := accelerated.GetCurrentTime()
 	created := 0
 	for _, count := range counts {
 		if count.TotalCount < int64(m.discoveryMinMsgs) {
@@ -208,13 +210,13 @@ func (m *PeerMatcher) UpdateDiscoveryCandidates(ctx context.Context) error {
 			metadata["username"] = "@" + *peer.PeerUsername
 		}
 
-		_, err := m.externalContactRepo.Upsert(ctx, repository.UpsertExternalContactRequest{
-			Source:      "telegram",
+		_, err := m.externalContactRepo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
 			SourceID:    sourceID,
 			DisplayName: displayName,
 			FirstName:   peer.PeerFirstName,
 			LastName:    peer.PeerLastName,
 			Metadata:    metadata,
+			SyncedAt:    &now,
 		})
 		if err != nil {
 			log.Warn().Err(err).Int64("peer_user_id", count.PeerUserID).Msg("telegram: failed to upsert discovery candidate")
@@ -256,13 +258,14 @@ func (m *PeerMatcher) UpdateDiscoveryCandidatesForPeer(ctx context.Context, peer
 		metadata["username"] = "@" + *peerUsername
 	}
 
-	if _, err := m.externalContactRepo.Upsert(ctx, repository.UpsertExternalContactRequest{
-		Source:      "telegram",
+	now := accelerated.GetCurrentTime()
+	if _, err := m.externalContactRepo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
 		SourceID:    sourceID,
 		DisplayName: displayName,
 		FirstName:   peerFirstName,
 		LastName:    peerLastName,
 		Metadata:    metadata,
+		SyncedAt:    &now,
 	}); err != nil {
 		log.Warn().Err(err).Int64("peer_user_id", peerUserID).Msg("telegram: failed to upsert discovery candidate for live peer")
 	}

--- a/backend/internal/telegram/matcher.go
+++ b/backend/internal/telegram/matcher.go
@@ -195,7 +195,14 @@ func (m *PeerMatcher) UpdateDiscoveryCandidates(ctx context.Context) error {
 			continue // peer was matched, skip
 		}
 
-		displayName := buildDisplayName(peer.PeerFirstName, peer.PeerLastName)
+		// Normalize empty-string peer fields to nil so the dedicated upsert's
+		// COALESCE preserves stored values (the prod symptom included rows with
+		// blank strings that would otherwise read as "populated" and clobber).
+		firstName := nilIfEmpty(peer.PeerFirstName)
+		lastName := nilIfEmpty(peer.PeerLastName)
+		username := nilIfEmpty(peer.PeerUsername)
+
+		displayName := buildDisplayName(firstName, lastName)
 		sourceID := strconv.FormatInt(count.PeerUserID, 10)
 
 		metadata := map[string]any{
@@ -206,15 +213,15 @@ func (m *PeerMatcher) UpdateDiscoveryCandidates(ctx context.Context) error {
 		if !count.LastMessageAt.IsZero() {
 			metadata["last_message_at"] = count.LastMessageAt.Format("2006-01-02T15:04:05Z")
 		}
-		if peer.PeerUsername != nil {
-			metadata["username"] = "@" + *peer.PeerUsername
+		if username != nil {
+			metadata["username"] = "@" + *username
 		}
 
 		_, err := m.externalContactRepo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
 			SourceID:    sourceID,
 			DisplayName: displayName,
-			FirstName:   peer.PeerFirstName,
-			LastName:    peer.PeerLastName,
+			FirstName:   firstName,
+			LastName:    lastName,
 			Metadata:    metadata,
 			SyncedAt:    &now,
 		})
@@ -243,7 +250,14 @@ func (m *PeerMatcher) UpdateDiscoveryCandidatesForPeer(ctx context.Context, peer
 		return // below threshold
 	}
 
-	displayName := buildDisplayName(peerFirstName, peerLastName)
+	// Normalize empty strings to nil so the dedicated upsert's COALESCE
+	// preserves stored values (outbound private-chat messages often carry
+	// blank entity fields instead of nil).
+	firstName := nilIfEmpty(peerFirstName)
+	lastName := nilIfEmpty(peerLastName)
+	username := nilIfEmpty(peerUsername)
+
+	displayName := buildDisplayName(firstName, lastName)
 	sourceID := strconv.FormatInt(peerUserID, 10)
 
 	metadata := map[string]any{
@@ -254,21 +268,32 @@ func (m *PeerMatcher) UpdateDiscoveryCandidatesForPeer(ctx context.Context, peer
 	if !count.LastMessageAt.IsZero() {
 		metadata["last_message_at"] = count.LastMessageAt.Format("2006-01-02T15:04:05Z")
 	}
-	if peerUsername != nil {
-		metadata["username"] = "@" + *peerUsername
+	if username != nil {
+		metadata["username"] = "@" + *username
 	}
 
 	now := accelerated.GetCurrentTime()
 	if _, err := m.externalContactRepo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
 		SourceID:    sourceID,
 		DisplayName: displayName,
-		FirstName:   peerFirstName,
-		LastName:    peerLastName,
+		FirstName:   firstName,
+		LastName:    lastName,
 		Metadata:    metadata,
 		SyncedAt:    &now,
 	}); err != nil {
 		log.Warn().Err(err).Int64("peer_user_id", peerUserID).Msg("telegram: failed to upsert discovery candidate for live peer")
 	}
+}
+
+// nilIfEmpty returns nil if the pointer is nil or dereferences to "".
+// Telegram often carries blank entity strings for outbound private chats;
+// treating them as absent keeps the COALESCE-preserve upsert semantics
+// from being subverted by an empty-string "write" that looks populated.
+func nilIfEmpty(s *string) *string {
+	if s == nil || *s == "" {
+		return nil
+	}
+	return s
 }
 
 // OnPeerLinked is called after a Telegram import/link to back-fill message matching.

--- a/backend/internal/telegram/matcher_test.go
+++ b/backend/internal/telegram/matcher_test.go
@@ -34,14 +34,14 @@ type updateMatchCall struct {
 }
 
 type mockExternalContactUpserter struct {
-	upsertCalls      []repository.UpsertExternalContactRequest
+	upsertCalls      []repository.UpsertTelegramDiscoveryCandidateRequest
 	getResult        *repository.ExternalContact
 	updateMatchCalls []updateMatchCall
 }
 
-func (m *mockExternalContactUpserter) Upsert(_ context.Context, req repository.UpsertExternalContactRequest) (*repository.ExternalContact, error) {
+func (m *mockExternalContactUpserter) UpsertTelegramDiscoveryCandidate(_ context.Context, req repository.UpsertTelegramDiscoveryCandidateRequest) (*repository.ExternalContact, error) {
 	m.upsertCalls = append(m.upsertCalls, req)
-	return &repository.ExternalContact{ID: uuid.New(), Source: req.Source, SourceID: req.SourceID}, nil
+	return &repository.ExternalContact{ID: uuid.New(), Source: "telegram", SourceID: req.SourceID}, nil
 }
 
 func (m *mockExternalContactUpserter) GetBySource(_ context.Context, _, _ string, _ *string) (*repository.ExternalContact, error) {
@@ -322,10 +322,10 @@ func TestUpdateDiscoveryCandidatesForPeer_AtThreshold(t *testing.T) {
 
 	// At threshold — should upsert
 	require.Len(t, ecMock.upsertCalls, 1)
-	assert.Equal(t, "telegram", ecMock.upsertCalls[0].Source)
 	assert.Equal(t, "12345", ecMock.upsertCalls[0].SourceID)
 	assert.Equal(t, int64(3), ecMock.upsertCalls[0].Metadata["message_count"])
 	assert.Equal(t, "@alice", ecMock.upsertCalls[0].Metadata["username"])
+	require.NotNil(t, ecMock.upsertCalls[0].SyncedAt, "synced_at should be set on live-path upsert")
 }
 
 func ptr(s string) *string { return &s }

--- a/backend/internal/telegram/matcher_test.go
+++ b/backend/internal/telegram/matcher_test.go
@@ -358,4 +358,31 @@ func TestUpdateDiscoveryCandidatesForPeer_NilNames_StillSendsUpsert(t *testing.T
 	require.NotNil(t, call.SyncedAt)
 }
 
+// TestUpdateDiscoveryCandidatesForPeer_EmptyStringsTreatedAsNil covers the
+// normalization applied before the upsert: Telegram sometimes carries blank
+// entity strings (not NULL) on outbound private chats. If we wrote "" through
+// the COALESCE upsert, the stored value would be overwritten with a
+// meaningless empty string, or the metadata would gain a "@" username.
+func TestUpdateDiscoveryCandidatesForPeer_EmptyStringsTreatedAsNil(t *testing.T) {
+	ecMock := &mockExternalContactUpserter{}
+	matcher := &PeerMatcher{
+		messageCounter: &mockMessageCounter{counts: map[int64]*repository.PeerMessageCount{
+			12345: {TotalCount: 3, OutboundCount: 1, InboundCount: 2},
+		}},
+		externalContactRepo: ecMock,
+		discoveryMinMsgs:    3,
+	}
+
+	empty := ""
+	matcher.UpdateDiscoveryCandidatesForPeer(context.Background(), 12345, &empty, &empty, &empty)
+
+	require.Len(t, ecMock.upsertCalls, 1)
+	call := ecMock.upsertCalls[0]
+	assert.Nil(t, call.FirstName, "empty first_name pointer should normalize to nil")
+	assert.Nil(t, call.LastName, "empty last_name pointer should normalize to nil")
+	assert.Nil(t, call.DisplayName)
+	_, hasUsername := call.Metadata["username"]
+	assert.False(t, hasUsername, "empty username pointer should not write a metadata key")
+}
+
 func ptr(s string) *string { return &s }

--- a/backend/internal/telegram/matcher_test.go
+++ b/backend/internal/telegram/matcher_test.go
@@ -328,4 +328,34 @@ func TestUpdateDiscoveryCandidatesForPeer_AtThreshold(t *testing.T) {
 	require.NotNil(t, ecMock.upsertCalls[0].SyncedAt, "synced_at should be set on live-path upsert")
 }
 
+// TestUpdateDiscoveryCandidatesForPeer_NilNames_StillSendsUpsert documents the
+// Go-layer contract after the null-overwrite fix: the live path keeps passing
+// whatever names it has (including all-nil). The SQL COALESCE in the dedicated
+// UpsertTelegramDiscoveryCandidate query is what actually preserves stored
+// values. The metadata map must not carry a "username" key when peerUsername
+// is nil — otherwise the JSONB merge would overwrite an earlier non-null handle
+// with a bogus null-ish entry.
+func TestUpdateDiscoveryCandidatesForPeer_NilNames_StillSendsUpsert(t *testing.T) {
+	ecMock := &mockExternalContactUpserter{}
+	matcher := &PeerMatcher{
+		messageCounter: &mockMessageCounter{counts: map[int64]*repository.PeerMessageCount{
+			12345: {TotalCount: 3, OutboundCount: 1, InboundCount: 2},
+		}},
+		externalContactRepo: ecMock,
+		discoveryMinMsgs:    3,
+	}
+
+	matcher.UpdateDiscoveryCandidatesForPeer(context.Background(), 12345, nil, nil, nil)
+
+	require.Len(t, ecMock.upsertCalls, 1)
+	call := ecMock.upsertCalls[0]
+	assert.Equal(t, "12345", call.SourceID)
+	assert.Nil(t, call.FirstName)
+	assert.Nil(t, call.LastName)
+	assert.Nil(t, call.DisplayName)
+	_, hasUsername := call.Metadata["username"]
+	assert.False(t, hasUsername, "no username key when peerUsername is nil")
+	require.NotNil(t, call.SyncedAt)
+}
+
 func ptr(s string) *string { return &s }

--- a/backend/tests/telegram_aggregation_test.go
+++ b/backend/tests/telegram_aggregation_test.go
@@ -333,3 +333,73 @@ func TestAggregation_IncrementalExplicitReplyBridge(t *testing.T) {
 	_, _ = database.Pool.Exec(ctx, "DELETE FROM telegram_message WHERE telegram_message_id IN (80061, 80062)")
 	_, _ = database.Pool.Exec(ctx, "DELETE FROM interaction WHERE source_ref LIKE 'tg:303:%'")
 }
+
+// TestListDistinctUnmatchedPeers_PrefersPopulatedNameRow locks in the
+// ORDER BY extension: with two unmatched rows for the same peer, the one with
+// non-null first/last names wins the DISTINCT ON, even if it's older. Ensures
+// a single aggregation pass picks the most-populated row.
+func TestListDistinctUnmatchedPeers_PrefersPopulatedNameRow(t *testing.T) {
+	messageRepo, _, _, _, _, database := setupAggregationTest(t)
+	ctx := context.Background()
+
+	const testPeerID int64 = 90001
+	const testChatID int64 = 900
+	username := "dale"
+	firstName := "Dale"
+	lastName := "Dobeck"
+
+	// Narrow cleanup scoped to this test's peer/chat.
+	t.Cleanup(func() {
+		_, _ = database.Pool.Exec(ctx, "DELETE FROM telegram_message WHERE peer_user_id = $1", testPeerID)
+	})
+
+	base := accelerated.GetCurrentTime().Truncate(time.Microsecond)
+	text := "hi"
+
+	// Newer row: has username but no names.
+	_, err := messageRepo.UpsertMessage(ctx, repository.UpsertTelegramMessageParams{
+		TelegramMessageID: 90001,
+		TelegramChatID:    testChatID,
+		ChatType:          "private",
+		MessageText:       &text,
+		MessageType:       "text",
+		SentAt:            base,
+		IsOutgoing:        false,
+		PeerUserID:        ptrInt64(testPeerID),
+		PeerUsername:      &username,
+	})
+	require.NoError(t, err)
+
+	// Older row: has username AND names. Older means it'd lose the sent_at DESC
+	// tiebreak; the name-prefering ORDER BY clauses should still pick it.
+	_, err = messageRepo.UpsertMessage(ctx, repository.UpsertTelegramMessageParams{
+		TelegramMessageID: 90002,
+		TelegramChatID:    testChatID,
+		ChatType:          "private",
+		MessageText:       &text,
+		MessageType:       "text",
+		SentAt:            base.Add(-1 * time.Hour),
+		IsOutgoing:        false,
+		PeerUserID:        ptrInt64(testPeerID),
+		PeerUsername:      &username,
+		PeerFirstName:     &firstName,
+		PeerLastName:      &lastName,
+	})
+	require.NoError(t, err)
+
+	peers, err := messageRepo.ListDistinctUnmatchedPeers(ctx)
+	require.NoError(t, err)
+
+	var got *repository.UnmatchedPeer
+	for i := range peers {
+		if peers[i].PeerUserID == testPeerID {
+			got = &peers[i]
+			break
+		}
+	}
+	require.NotNil(t, got, "expected test peer to be returned by ListDistinctUnmatchedPeers")
+	require.NotNil(t, got.PeerFirstName, "populated-name row should win even though it is older")
+	assert.Equal(t, "Dale", *got.PeerFirstName)
+	require.NotNil(t, got.PeerLastName)
+	assert.Equal(t, "Dobeck", *got.PeerLastName)
+}

--- a/backend/tests/telegram_aggregation_test.go
+++ b/backend/tests/telegram_aggregation_test.go
@@ -403,3 +403,72 @@ func TestListDistinctUnmatchedPeers_PrefersPopulatedNameRow(t *testing.T) {
 	require.NotNil(t, got.PeerLastName)
 	assert.Equal(t, "Dobeck", *got.PeerLastName)
 }
+
+// TestListDistinctUnmatchedPeers_TreatsBlankStringsAsAbsent guards the ORDER BY
+// clauses: a row with blank peer_first_name / peer_last_name must not outrank
+// a row with a real name. Without the `<> ”` guards the outbound-private-chat
+// shape (blank strings instead of NULL) would keep winning the tiebreak and
+// the batch path would re-seed external_contact with blanks.
+func TestListDistinctUnmatchedPeers_TreatsBlankStringsAsAbsent(t *testing.T) {
+	messageRepo, _, _, _, _, database := setupAggregationTest(t)
+	ctx := context.Background()
+
+	const testPeerID int64 = 90002
+	const testChatID int64 = 901
+	empty := ""
+	firstName := "Dale"
+	lastName := "Dobeck"
+
+	t.Cleanup(func() {
+		_, _ = database.Pool.Exec(ctx, "DELETE FROM telegram_message WHERE peer_user_id = $1", testPeerID)
+	})
+
+	base := accelerated.GetCurrentTime().Truncate(time.Microsecond)
+	text := "hi"
+
+	// Newer row: blank entity strings.
+	_, err := messageRepo.UpsertMessage(ctx, repository.UpsertTelegramMessageParams{
+		TelegramMessageID: 90003,
+		TelegramChatID:    testChatID,
+		ChatType:          "private",
+		MessageText:       &text,
+		MessageType:       "text",
+		SentAt:            base,
+		IsOutgoing:        true,
+		PeerUserID:        ptrInt64(testPeerID),
+		PeerFirstName:     &empty,
+		PeerLastName:      &empty,
+	})
+	require.NoError(t, err)
+
+	// Older row: populated entity data.
+	_, err = messageRepo.UpsertMessage(ctx, repository.UpsertTelegramMessageParams{
+		TelegramMessageID: 90004,
+		TelegramChatID:    testChatID,
+		ChatType:          "private",
+		MessageText:       &text,
+		MessageType:       "text",
+		SentAt:            base.Add(-1 * time.Hour),
+		IsOutgoing:        false,
+		PeerUserID:        ptrInt64(testPeerID),
+		PeerFirstName:     &firstName,
+		PeerLastName:      &lastName,
+	})
+	require.NoError(t, err)
+
+	peers, err := messageRepo.ListDistinctUnmatchedPeers(ctx)
+	require.NoError(t, err)
+
+	var got *repository.UnmatchedPeer
+	for i := range peers {
+		if peers[i].PeerUserID == testPeerID {
+			got = &peers[i]
+			break
+		}
+	}
+	require.NotNil(t, got)
+	require.NotNil(t, got.PeerFirstName)
+	assert.Equal(t, "Dale", *got.PeerFirstName, "blank-string row must not outrank a real-name row")
+	require.NotNil(t, got.PeerLastName)
+	assert.Equal(t, "Dobeck", *got.PeerLastName)
+}

--- a/backend/tests/telegram_aggregation_test.go
+++ b/backend/tests/telegram_aggregation_test.go
@@ -14,6 +14,7 @@ import (
 	tgpkg "personal-crm/backend/internal/telegram"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -348,9 +349,13 @@ func TestListDistinctUnmatchedPeers_PrefersPopulatedNameRow(t *testing.T) {
 	firstName := "Dale"
 	lastName := "Dobeck"
 
-	// Narrow cleanup scoped to this test's peer/chat.
+	// Narrow cleanup scoped to this test's peer/chat — use the sqlc helper
+	// (the "Never write raw SQL in Go" rule applies in tests too).
 	t.Cleanup(func() {
-		_, _ = database.Pool.Exec(ctx, "DELETE FROM telegram_message WHERE peer_user_id = $1", testPeerID)
+		_, _ = database.Queries.DeleteTelegramMessagesByPeerUserID(
+			ctx,
+			pgtype.Int8{Int64: testPeerID, Valid: true},
+		)
 	})
 
 	base := accelerated.GetCurrentTime().Truncate(time.Microsecond)
@@ -420,7 +425,10 @@ func TestListDistinctUnmatchedPeers_TreatsBlankStringsAsAbsent(t *testing.T) {
 	lastName := "Dobeck"
 
 	t.Cleanup(func() {
-		_, _ = database.Pool.Exec(ctx, "DELETE FROM telegram_message WHERE peer_user_id = $1", testPeerID)
+		_, _ = database.Queries.DeleteTelegramMessagesByPeerUserID(
+			ctx,
+			pgtype.Int8{Int64: testPeerID, Valid: true},
+		)
 	})
 
 	base := accelerated.GetCurrentTime().Truncate(time.Microsecond)

--- a/backend/tests/telegram_discovery_upsert_test.go
+++ b/backend/tests/telegram_discovery_upsert_test.go
@@ -10,7 +10,10 @@ import (
 	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+	tgpkg "personal-crm/backend/internal/telegram"
 
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -43,10 +46,11 @@ func setupDiscoveryUpsertTest(t *testing.T) (
 
 	cleanup := func() {
 		// Narrow cleanup: only touch rows this test file creates. All test
-		// source_ids are prefixed with "tg-discovery-upsert-".
-		_, _ = database.Pool.Exec(
+		// source_ids are prefixed with "tg-discovery-upsert-". Use the sqlc
+		// query (also used by the /test/cleanup handler) rather than raw SQL.
+		_, _ = database.Queries.DeleteExternalContactsBySourceIDPrefix(
 			context.Background(),
-			"DELETE FROM external_contact WHERE source_id LIKE 'tg-discovery-upsert-%'",
+			pgtype.Text{String: "tg-discovery-upsert-", Valid: true},
 		)
 		database.Close()
 	}
@@ -261,7 +265,10 @@ func TestUpsertTelegramDiscoveryCandidate_DoesNotTouchMatchStatus(t *testing.T) 
 	})
 	require.NoError(t, err)
 	defer func() {
-		_, _ = database.Pool.Exec(ctx, "DELETE FROM contact WHERE id = $1", crmContact.ID)
+		_, _ = database.Queries.DeleteContactsByNamePrefix(
+			ctx,
+			pgtype.Text{String: "tg-discovery-upsert-match-contact", Valid: true},
+		)
 	}()
 
 	row, err := repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
@@ -314,4 +321,119 @@ func TestUpsertExternalContact_SharedUpsertStillOverwrites(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Nil(t, got.FirstName, "shared UpsertExternalContact must still overwrite scalar fields with NULL for Google flows")
+}
+
+// TestUpdateDiscoveryCandidates_BatchPath_BlankStringsDoNotClobberStoredData
+// exercises the end-to-end prod-healing path that caused the original bug:
+// two unmatched messages for the same peer — one with blank entity strings
+// (outbound private chat), one with real first/last name — are aggregated,
+// and the batch UpdateDiscoveryCandidates call is expected to leave the
+// external_contact row with populated names and a metadata.username, not
+// wipe them.
+func TestUpdateDiscoveryCandidates_BatchPath_BlankStringsDoNotClobberStoredData(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set")
+	}
+	require.NoError(t, db.RunMigrations(databaseURL, getMigrationsPath()))
+
+	ctx := context.Background()
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	defer database.Close()
+
+	const testPeerID int64 = 99001
+	const testChatID int64 = 9900
+	username := "daledobeck"
+	empty := ""
+	firstName := "Dale"
+	lastName := "Dobeck"
+	text := "hi"
+
+	messageRepo := repository.NewTelegramMessageRepository(database.Queries)
+	externalRepo := repository.NewExternalContactRepository(database.Queries)
+	identityRepo := repository.NewIdentityRepository(database.Queries)
+	identitySvc := service.NewIdentityService(identityRepo)
+	matcher := tgpkg.NewPeerMatcher(identitySvc, messageRepo, externalRepo, 2) // threshold = 2
+
+	t.Cleanup(func() {
+		_, _ = database.Queries.DeleteTelegramMessagesByPeerUserID(
+			ctx,
+			pgtype.Int8{Int64: testPeerID, Valid: true},
+		)
+		_, _ = database.Queries.DeleteExternalContactsBySourceIDPrefix(
+			ctx,
+			pgtype.Text{String: "99001", Valid: true},
+		)
+		// External_identity row created by MatchOrCreate — also keyed by source_id.
+		_, _ = database.Queries.DeleteExternalIdentitiesBySourceID(
+			ctx,
+			pgtype.Text{String: "99001", Valid: true},
+		)
+	})
+
+	base := accelerated.GetCurrentTime().Truncate(time.Microsecond)
+
+	// Newer row: blank entity strings (the outbound private-chat shape).
+	_, err = messageRepo.UpsertMessage(ctx, repository.UpsertTelegramMessageParams{
+		TelegramMessageID: 99001,
+		TelegramChatID:    testChatID,
+		ChatType:          "private",
+		MessageText:       &text,
+		MessageType:       "text",
+		SentAt:            base,
+		IsOutgoing:        true,
+		PeerUserID:        ptrInt64(testPeerID),
+		PeerUsername:      &empty,
+		PeerFirstName:     &empty,
+		PeerLastName:      &empty,
+	})
+	require.NoError(t, err)
+
+	// Older row: good entity data.
+	_, err = messageRepo.UpsertMessage(ctx, repository.UpsertTelegramMessageParams{
+		TelegramMessageID: 99002,
+		TelegramChatID:    testChatID,
+		ChatType:          "private",
+		MessageText:       &text,
+		MessageType:       "text",
+		SentAt:            base.Add(-1 * time.Hour),
+		IsOutgoing:        false,
+		PeerUserID:        ptrInt64(testPeerID),
+		PeerUsername:      &username,
+		PeerFirstName:     &firstName,
+		PeerLastName:      &lastName,
+	})
+	require.NoError(t, err)
+
+	// Required: MatchAllUnmatched creates the external_identity row so the
+	// peer shows up as unmatched in ListDistinctUnmatchedPeers. Discovery then
+	// populates external_contact.
+	require.NoError(t, matcher.MatchAllUnmatched(ctx))
+	require.NoError(t, matcher.UpdateDiscoveryCandidates(ctx))
+
+	got, err := externalRepo.GetBySource(ctx, "telegram", "99001", nil)
+	require.NoError(t, err)
+	require.NotNil(t, got, "discovery should have inserted an external_contact row")
+	require.NotNil(t, got.FirstName)
+	assert.Equal(t, "Dale", *got.FirstName, "batch path must surface the populated-name row, not the blank-string row")
+	require.NotNil(t, got.LastName)
+	assert.Equal(t, "Dobeck", *got.LastName)
+	assert.Equal(t, "@daledobeck", got.Metadata["username"])
+
+	// Running the batch again must be idempotent — existing names survive
+	// even when future aggregation picks the blank-string row.
+	require.NoError(t, matcher.UpdateDiscoveryCandidates(ctx))
+
+	got, err = externalRepo.GetBySource(ctx, "telegram", "99001", nil)
+	require.NoError(t, err)
+	require.NotNil(t, got.FirstName)
+	assert.Equal(t, "Dale", *got.FirstName, "re-running discovery must not clobber stored names")
+	assert.Equal(t, "@daledobeck", got.Metadata["username"])
 }

--- a/backend/tests/telegram_discovery_upsert_test.go
+++ b/backend/tests/telegram_discovery_upsert_test.go
@@ -1,0 +1,317 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupDiscoveryUpsertTest spins up a real DB-backed ExternalContactRepository
+// and returns a cleanup function that hard-deletes the rows seeded by the test.
+func setupDiscoveryUpsertTest(t *testing.T) (
+	*repository.ExternalContactRepository,
+	*db.Database,
+	func(),
+) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set")
+	}
+
+	require.NoError(t, db.RunMigrations(databaseURL, getMigrationsPath()))
+
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+
+	database, err := db.NewDatabase(context.Background(), cfg.Database)
+	require.NoError(t, err)
+
+	repo := repository.NewExternalContactRepository(database.Queries)
+
+	cleanup := func() {
+		// Narrow cleanup: only touch rows this test file creates. All test
+		// source_ids are prefixed with "tg-discovery-upsert-".
+		_, _ = database.Pool.Exec(
+			context.Background(),
+			"DELETE FROM external_contact WHERE source_id LIKE 'tg-discovery-upsert-%'",
+		)
+		database.Close()
+	}
+	return repo, database, cleanup
+}
+
+func TestUpsertTelegramDiscoveryCandidate_InsertsNewRow(t *testing.T) {
+	repo, _, cleanup := setupDiscoveryUpsertTest(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	now := accelerated.GetCurrentTime()
+
+	got, err := repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
+		SourceID:    "tg-discovery-upsert-insert",
+		DisplayName: strPtr("Dale Dobeck"),
+		FirstName:   strPtr("Dale"),
+		LastName:    strPtr("Dobeck"),
+		Metadata:    map[string]any{"username": "@daledobeck", "message_count": 5},
+		SyncedAt:    &now,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	assert.Equal(t, "telegram", got.Source)
+	assert.Equal(t, "tg-discovery-upsert-insert", got.SourceID)
+	require.NotNil(t, got.DisplayName)
+	assert.Equal(t, "Dale Dobeck", *got.DisplayName)
+	require.NotNil(t, got.FirstName)
+	assert.Equal(t, "Dale", *got.FirstName)
+	require.NotNil(t, got.LastName)
+	assert.Equal(t, "Dobeck", *got.LastName)
+	assert.Equal(t, "@daledobeck", got.Metadata["username"])
+	// JSON numbers deserialize as float64
+	assert.EqualValues(t, 5, got.Metadata["message_count"])
+	assert.Equal(t, repository.MatchStatusUnmatched, got.MatchStatus)
+}
+
+func TestUpsertTelegramDiscoveryCandidate_PreservesFirstNameWhenNil(t *testing.T) {
+	repo, _, cleanup := setupDiscoveryUpsertTest(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	now := accelerated.GetCurrentTime()
+
+	// Seed with names populated.
+	_, err := repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
+		SourceID:  "tg-discovery-upsert-preserve",
+		FirstName: strPtr("Dale"),
+		LastName:  strPtr("Dobeck"),
+		SyncedAt:  &now,
+	})
+	require.NoError(t, err)
+
+	// Re-upsert with nil names — should preserve existing.
+	got, err := repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
+		SourceID: "tg-discovery-upsert-preserve",
+		SyncedAt: &now,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, got.FirstName)
+	assert.Equal(t, "Dale", *got.FirstName)
+	require.NotNil(t, got.LastName)
+	assert.Equal(t, "Dobeck", *got.LastName)
+}
+
+func TestUpsertTelegramDiscoveryCandidate_OverwritesFirstNameWhenNewValueProvided(t *testing.T) {
+	repo, _, cleanup := setupDiscoveryUpsertTest(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	now := accelerated.GetCurrentTime()
+
+	_, err := repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
+		SourceID:  "tg-discovery-upsert-overwrite",
+		FirstName: strPtr("Dale"),
+		SyncedAt:  &now,
+	})
+	require.NoError(t, err)
+
+	got, err := repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
+		SourceID:  "tg-discovery-upsert-overwrite",
+		FirstName: strPtr("Daniel"),
+		SyncedAt:  &now,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, got.FirstName)
+	assert.Equal(t, "Daniel", *got.FirstName)
+}
+
+func TestUpsertTelegramDiscoveryCandidate_MergesMetadata_PreservesExistingKey(t *testing.T) {
+	repo, _, cleanup := setupDiscoveryUpsertTest(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	now := accelerated.GetCurrentTime()
+
+	// Seed with a username key.
+	_, err := repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
+		SourceID: "tg-discovery-upsert-merge-keep",
+		Metadata: map[string]any{"username": "@dale", "message_count": 5},
+		SyncedAt: &now,
+	})
+	require.NoError(t, err)
+
+	// Re-upsert with only message_count — username must be retained.
+	got, err := repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
+		SourceID: "tg-discovery-upsert-merge-keep",
+		Metadata: map[string]any{"message_count": 10},
+		SyncedAt: &now,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "@dale", got.Metadata["username"], "username key should be preserved by JSONB merge")
+	assert.EqualValues(t, 10, got.Metadata["message_count"], "incoming message_count should win for the duplicate key")
+}
+
+func TestUpsertTelegramDiscoveryCandidate_MergesMetadata_IncomingWinsForDuplicate(t *testing.T) {
+	repo, _, cleanup := setupDiscoveryUpsertTest(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	now := accelerated.GetCurrentTime()
+
+	_, err := repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
+		SourceID: "tg-discovery-upsert-merge-new",
+		Metadata: map[string]any{"username": "@old"},
+		SyncedAt: &now,
+	})
+	require.NoError(t, err)
+
+	got, err := repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
+		SourceID: "tg-discovery-upsert-merge-new",
+		Metadata: map[string]any{"username": "@new"},
+		SyncedAt: &now,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "@new", got.Metadata["username"])
+}
+
+func TestUpsertTelegramDiscoveryCandidate_SyncedAtAlwaysUpdates(t *testing.T) {
+	repo, _, cleanup := setupDiscoveryUpsertTest(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	start := accelerated.GetCurrentTime()
+	_, err := repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
+		SourceID: "tg-discovery-upsert-syncedat",
+		SyncedAt: &start,
+	})
+	require.NoError(t, err)
+
+	later := start.Add(1 * time.Hour)
+	got, err := repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
+		SourceID: "tg-discovery-upsert-syncedat",
+		SyncedAt: &later,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, got.SyncedAt)
+	assert.WithinDuration(t, later, *got.SyncedAt, time.Second)
+}
+
+// TestUpsertTelegramDiscoveryCandidate_DoesNotClearEmailsSetBySharedUpsert
+// proves the dedicated DO UPDATE SET only touches the 6 columns it manages —
+// anything seeded via the shared Upsert (emails, phones, etc.) is untouched.
+func TestUpsertTelegramDiscoveryCandidate_DoesNotClearEmailsSetBySharedUpsert(t *testing.T) {
+	repo, _, cleanup := setupDiscoveryUpsertTest(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	now := accelerated.GetCurrentTime()
+
+	// Seed via the shared Upsert so emails are populated.
+	_, err := repo.Upsert(ctx, repository.UpsertExternalContactRequest{
+		Source:   "telegram",
+		SourceID: "tg-discovery-upsert-emails",
+		Emails:   []repository.EmailEntry{{Value: "a@x", Type: "personal", Primary: true}},
+		SyncedAt: &now,
+	})
+	require.NoError(t, err)
+
+	// Call the dedicated upsert with only names.
+	_, err = repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
+		SourceID:  "tg-discovery-upsert-emails",
+		FirstName: strPtr("Dale"),
+		Metadata:  map[string]any{"username": "@dale"},
+		SyncedAt:  &now,
+	})
+	require.NoError(t, err)
+
+	got, err := repo.GetBySource(ctx, "telegram", "tg-discovery-upsert-emails", nil)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Len(t, got.Emails, 1)
+	assert.Equal(t, "a@x", got.Emails[0].Value, "existing email should survive the Telegram-specific upsert")
+}
+
+func TestUpsertTelegramDiscoveryCandidate_DoesNotTouchMatchStatus(t *testing.T) {
+	repo, database, cleanup := setupDiscoveryUpsertTest(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	now := accelerated.GetCurrentTime()
+
+	// Create a real CRM contact so the FK (external_contact.crm_contact_id ->
+	// contact.id) is satisfiable. Use a unique name so it doesn't collide with
+	// other tests and cleans up cleanly.
+	contactRepo := repository.NewContactRepository(database.Queries)
+	crmContact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
+		FullName:      "tg-discovery-upsert-match-contact",
+		LastContacted: &now,
+	})
+	require.NoError(t, err)
+	defer func() {
+		_, _ = database.Pool.Exec(ctx, "DELETE FROM contact WHERE id = $1", crmContact.ID)
+	}()
+
+	row, err := repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
+		SourceID: "tg-discovery-upsert-match",
+		SyncedAt: &now,
+	})
+	require.NoError(t, err)
+
+	_, err = repo.UpdateMatch(ctx, row.ID, &crmContact.ID, repository.MatchStatusMatched)
+	require.NoError(t, err)
+
+	_, err = repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
+		SourceID:  "tg-discovery-upsert-match",
+		FirstName: strPtr("Dale"),
+		SyncedAt:  &now,
+	})
+	require.NoError(t, err)
+
+	got, err := repo.GetBySource(ctx, "telegram", "tg-discovery-upsert-match", nil)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, repository.MatchStatusMatched, got.MatchStatus, "dedicated upsert must not reset match_status")
+	require.NotNil(t, got.CRMContactID)
+	assert.Equal(t, crmContact.ID, *got.CRMContactID)
+}
+
+// TestUpsertExternalContact_SharedUpsertStillOverwrites confirms the shared
+// upsert retains its "authoritative overwrite" semantics for Google flows —
+// this plan only adds a parallel path, it does not change the shared one.
+func TestUpsertExternalContact_SharedUpsertStillOverwrites(t *testing.T) {
+	repo, _, cleanup := setupDiscoveryUpsertTest(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	now := accelerated.GetCurrentTime()
+
+	_, err := repo.Upsert(ctx, repository.UpsertExternalContactRequest{
+		Source:    "gcontacts",
+		SourceID:  "tg-discovery-upsert-shared-overwrite",
+		FirstName: strPtr("Alice"),
+		SyncedAt:  &now,
+	})
+	require.NoError(t, err)
+
+	got, err := repo.Upsert(ctx, repository.UpsertExternalContactRequest{
+		Source:   "gcontacts",
+		SourceID: "tg-discovery-upsert-shared-overwrite",
+		// FirstName intentionally nil — shared upsert should clear it.
+		SyncedAt: &now,
+	})
+	require.NoError(t, err)
+	assert.Nil(t, got.FirstName, "shared UpsertExternalContact must still overwrite scalar fields with NULL for Google flows")
+}

--- a/frontend/src/app/imports/__tests__/page.test.tsx
+++ b/frontend/src/app/imports/__tests__/page.test.tsx
@@ -536,3 +536,95 @@ describe('ImportsPage - Source Filter', () => {
     expect(useImportCandidates).toHaveBeenCalledWith(expect.objectContaining({ page: 1 }))
   })
 })
+
+describe('ImportsPage - Telegram @username', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    vi.mocked(useImportAsContact).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    } as any)
+    vi.mocked(useLinkCandidate).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    } as any)
+    vi.mocked(useIgnoreCandidate).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    } as any)
+    vi.mocked(useTriggerSync).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false,
+    } as any)
+    vi.mocked(useGoogleAccounts).mockReturnValue({ data: [] } as any)
+    vi.mocked(useContacts).mockReturnValue({
+      data: { contacts: [], total: 0, page: 1, limit: 500 },
+    } as any)
+    vi.mocked(useContact).mockReturnValue({ data: null } as any)
+  })
+
+  it('renders @username chip for Telegram candidate with a handle', () => {
+    vi.mocked(useImportCandidates).mockReturnValue({
+      data: {
+        candidates: [
+          {
+            id: 'tg-candidate-1',
+            source: 'telegram',
+            display_name: 'Dale Dobeck',
+            emails: [],
+            phones: [],
+            metadata: { username: '@daledobeck' },
+          },
+        ],
+        total: 1,
+        page: 1,
+        limit: 20,
+        pages: 1,
+      },
+      isLoading: false,
+      error: null,
+    } as any)
+
+    render(<ImportsPage />, { wrapper: createWrapper() })
+
+    // Heading shows the display name
+    expect(screen.getByRole('heading', { name: 'Dale Dobeck' })).toBeInTheDocument()
+    // Chip is a link to t.me/<handle> (no '@' in the URL path)
+    const chip = screen.getByRole('link', { name: '@daledobeck' })
+    expect(chip).toHaveAttribute('href', 'https://t.me/daledobeck')
+    expect(chip).toHaveAttribute('target', '_blank')
+    expect(chip).toHaveAttribute('rel', expect.stringContaining('noopener'))
+  })
+
+  it('falls back to @username heading and hides the chip when no names are set', () => {
+    vi.mocked(useImportCandidates).mockReturnValue({
+      data: {
+        candidates: [
+          {
+            id: 'tg-candidate-2',
+            source: 'telegram',
+            emails: [],
+            phones: [],
+            metadata: { username: '@daledobeck' },
+          },
+        ],
+        total: 1,
+        page: 1,
+        limit: 20,
+        pages: 1,
+      },
+      isLoading: false,
+      error: null,
+    } as any)
+
+    render(<ImportsPage />, { wrapper: createWrapper() })
+
+    // @username becomes the primary heading
+    expect(screen.getByRole('heading', { name: '@daledobeck' })).toBeInTheDocument()
+    // No "Unknown" rendered
+    expect(screen.queryByText('Unknown')).not.toBeInTheDocument()
+    // Chip is suppressed — no duplicate link rendered for the same handle
+    expect(screen.queryByRole('link', { name: '@daledobeck' })).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/app/imports/page.tsx
+++ b/frontend/src/app/imports/page.tsx
@@ -21,6 +21,7 @@ import { Pagination } from '@/components/ui/pagination'
 import { ImportLinkModal } from '@/components/imports/import-link-modal'
 import { useImportCandidates, useIgnoreCandidate, useTriggerSync } from '@/hooks/use-imports'
 import { useGoogleAccounts } from '@/hooks/use-google-accounts'
+import { getCandidateDisplayName } from '@/lib/candidate-display'
 import type { ImportCandidate, ImportCandidatesListParams } from '@/types/import'
 
 // Constants
@@ -98,10 +99,7 @@ function CandidateCard({
   importLoading: boolean
   ignoreLoading: boolean
 }) {
-  const displayName =
-    candidate.display_name ||
-    [candidate.first_name, candidate.last_name].filter(Boolean).join(' ') ||
-    'Unknown'
+  const displayName = getCandidateDisplayName(candidate)
 
   // Get meeting context for calendar attendees
   const meetingContext =
@@ -275,10 +273,7 @@ export default function ImportsPage() {
   }
 
   const handleIgnore = async (candidate: ImportCandidate) => {
-    const displayName =
-      candidate.display_name ||
-      [candidate.first_name, candidate.last_name].filter(Boolean).join(' ') ||
-      'contact'
+    const displayName = getCandidateDisplayName(candidate)
 
     setActionInProgress(candidate.id)
     try {

--- a/frontend/src/app/imports/page.tsx
+++ b/frontend/src/app/imports/page.tsx
@@ -14,6 +14,7 @@ import {
   AlertCircle,
   CloudDownload,
   Calendar,
+  Send,
 } from 'lucide-react'
 import { Navigation } from '@/components/layout/navigation'
 import { Button } from '@/components/ui/button'
@@ -200,6 +201,19 @@ function CandidateCard({
                   {phone}
                 </a>
               ))}
+              {candidate.source === 'telegram' &&
+                candidate.metadata?.username &&
+                displayName !== candidate.metadata.username && (
+                  <a
+                    href={`https://t.me/${encodeURIComponent(candidate.metadata.username.replace(/^@/, ''))}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center px-2 py-0.5 rounded bg-gray-100 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-600 transition-colors"
+                  >
+                    <Send className="w-3.5 h-3.5 mr-1.5 text-gray-400" />
+                    {candidate.metadata.username}
+                  </a>
+                )}
             </div>
           </div>
         </div>

--- a/frontend/src/components/imports/import-link-modal.tsx
+++ b/frontend/src/components/imports/import-link-modal.tsx
@@ -367,8 +367,18 @@ export function ImportLinkModal({
     }
     const selectedMethods = buildSelectedMethods()
     const cadence = selectedCadence || undefined
-    // Only include name if it differs from external source
-    const nameToSend = editedName.trim() !== displayName ? editedName.trim() : undefined
+    // Only include name if it differs from external source.
+    // For candidates with no source name fields (e.g. Telegram peers where the
+    // displayed heading is a metadata.username fallback), always send the name
+    // — the backend cannot derive one from display_name/first_name/last_name.
+    const candidateHasSourceName = Boolean(
+      candidate.display_name || candidate.first_name || candidate.last_name
+    )
+    const nameToSend = candidateHasSourceName
+      ? editedName.trim() !== displayName
+        ? editedName.trim()
+        : undefined
+      : editedName.trim()
 
     try {
       await importMutation.mutateAsync({

--- a/frontend/src/components/imports/import-link-modal.tsx
+++ b/frontend/src/components/imports/import-link-modal.tsx
@@ -175,6 +175,21 @@ export function ImportLinkModal({
       })
     })
 
+    // Add Telegram @username from metadata as a telegram method.
+    // Mirrors the backend's buildMethodsAuto behavior in handlers/import.go so
+    // the UI reflects the method that will actually be created on import.
+    // Display the handle with a leading '@' for consistency with the card chip.
+    if (candidate.source === 'telegram' && candidate.metadata?.username) {
+      const rawHandle = candidate.metadata.username
+      const displayValue = rawHandle.startsWith('@') ? rawHandle : `@${rawHandle}`
+      selections.set(displayValue, {
+        value: displayValue,
+        selected: true,
+        type: 'telegram',
+        isEmail: false,
+      })
+    }
+
     setMethodSelections(selections)
     setConflictResolutions(new Map())
     setSelectedCadence('')
@@ -718,7 +733,7 @@ export function ImportLinkModal({
         >
           <h4 className="text-sm font-medium text-gray-700 mb-3">Contact Methods</h4>
 
-          {candidate.emails.length === 0 && candidate.phones.length === 0 ? (
+          {methodSelections.size === 0 ? (
             <p className="text-sm text-gray-500">No contact methods available</p>
           ) : mode === 'import' ? (
             // Import mode: Simple method selection

--- a/frontend/src/components/imports/import-link-modal.tsx
+++ b/frontend/src/components/imports/import-link-modal.tsx
@@ -15,11 +15,8 @@ import {
   useIgnoreCandidate,
   useImportCandidates,
 } from '@/hooks/use-imports'
-import {
-  detectMethodConflicts,
-  getCandidateDisplayName,
-  areNamesSimilar,
-} from '@/lib/method-conflict-detection'
+import { detectMethodConflicts, areNamesSimilar } from '@/lib/method-conflict-detection'
+import { getCandidateDisplayName } from '@/lib/candidate-display'
 import { getSourceDisplay } from '@/lib/source-display'
 import type { ImportCandidate, SelectedMethod, MethodComparison } from '@/types/import'
 import type { ContactMethodType } from '@/types/contact'

--- a/frontend/src/components/imports/method-selector.tsx
+++ b/frontend/src/components/imports/method-selector.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Check, Mail, Phone } from 'lucide-react'
+import { Check, Mail, Phone, Send } from 'lucide-react'
 import { clsx } from 'clsx'
 import { Select } from '@/components/ui/select'
 import { CONTACT_METHOD_OPTIONS } from '@/lib/contact-methods'
@@ -13,21 +13,21 @@ import type { MethodState } from '@/types/import'
 import type { ContactMethodType } from '@/types/contact'
 
 interface MethodSelectorProps {
-  /** The method value to display (email or phone) */
+  /** The method value to display (email, phone, or handle) */
   value: string
   /** Whether this method is selected for import/link */
   selected: boolean
-  /** The assigned CRM type (email, phone, etc.) */
+  /** The assigned CRM type (email, phone, telegram, etc.) */
   selectedType: ContactMethodType
   /** Visual state for styling */
   state: MethodState
   /** Callback when checkbox is toggled */
   onToggle: () => void
-  /** Callback when type is changed */
+  /** Callback when type is changed (only used for emails, which support subtypes) */
   onTypeChange: (type: ContactMethodType) => void
   /** Whether the selector is disabled */
   disabled?: boolean
-  /** Whether this is an email (vs phone) */
+  /** Whether this is an email (vs phone/handle). When false, no type dropdown is shown. */
   isEmail: boolean
   /** Whether this method is marked as primary */
   isPrimary?: boolean
@@ -47,12 +47,11 @@ export function MethodSelector({
   isPrimary = false,
   onPrimaryToggle,
 }: MethodSelectorProps) {
-  // Filter options to only show relevant types
+  // Filter options to only show relevant types. Email has multiple subtypes;
+  // phone and handle-based types (telegram, signal, etc.) just render a label.
   const relevantOptions = CONTACT_METHOD_OPTIONS.filter(opt => {
-    if (isEmail) {
-      return opt.value === 'email'
-    }
-    return opt.value === 'phone'
+    if (isEmail) return opt.value === 'email'
+    return opt.value === selectedType
   })
 
   const stateClasses = getMethodStateClasses(state)
@@ -86,7 +85,13 @@ export function MethodSelector({
 
       {/* Icon */}
       <div className="flex-shrink-0 text-gray-400">
-        {isEmail ? <Mail className="w-4 h-4" /> : <Phone className="w-4 h-4" />}
+        {isEmail ? (
+          <Mail className="w-4 h-4" />
+        ) : selectedType === 'telegram' ? (
+          <Send className="w-4 h-4" />
+        ) : (
+          <Phone className="w-4 h-4" />
+        )}
       </div>
 
       {/* Value */}

--- a/frontend/src/lib/__tests__/candidate-display.test.ts
+++ b/frontend/src/lib/__tests__/candidate-display.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { getCandidateDisplayName } from '../candidate-display'
+import type { ImportCandidate } from '@/types/import'
+
+function candidate(overrides: Partial<ImportCandidate> = {}): ImportCandidate {
+  return {
+    id: '1',
+    source: 'test',
+    emails: [],
+    phones: [],
+    ...overrides,
+  }
+}
+
+describe('getCandidateDisplayName', () => {
+  it('uses display_name when present', () => {
+    expect(
+      getCandidateDisplayName(
+        candidate({ display_name: 'John Doe', first_name: 'Johnny', last_name: 'Doer' })
+      )
+    ).toBe('John Doe')
+  })
+
+  it('joins first + last when no display_name', () => {
+    expect(getCandidateDisplayName(candidate({ first_name: 'John', last_name: 'Doe' }))).toBe(
+      'John Doe'
+    )
+  })
+
+  it('returns first name alone', () => {
+    expect(getCandidateDisplayName(candidate({ first_name: 'John' }))).toBe('John')
+  })
+
+  it('returns last name alone', () => {
+    expect(getCandidateDisplayName(candidate({ last_name: 'Doe' }))).toBe('Doe')
+  })
+
+  it('returns Unknown when nothing is set', () => {
+    expect(getCandidateDisplayName(candidate())).toBe('Unknown')
+  })
+
+  it('falls back to telegram @username when no names are set', () => {
+    expect(
+      getCandidateDisplayName(
+        candidate({ source: 'telegram', metadata: { username: '@daledobeck' } })
+      )
+    ).toBe('@daledobeck')
+  })
+
+  it('ignores metadata.username for non-telegram sources', () => {
+    expect(
+      getCandidateDisplayName(
+        candidate({ source: 'gcontacts', metadata: { username: '@daledobeck' } })
+      )
+    ).toBe('Unknown')
+  })
+
+  it('returns Unknown when telegram metadata.username is empty', () => {
+    expect(
+      getCandidateDisplayName(candidate({ source: 'telegram', metadata: { username: '' } }))
+    ).toBe('Unknown')
+  })
+
+  it('prefers stored name fields over telegram fallback', () => {
+    expect(
+      getCandidateDisplayName(
+        candidate({
+          source: 'telegram',
+          first_name: 'Dale',
+          last_name: 'Dobeck',
+          metadata: { username: '@daledobeck' },
+        })
+      )
+    ).toBe('Dale Dobeck')
+  })
+})

--- a/frontend/src/lib/__tests__/method-conflict-detection.test.ts
+++ b/frontend/src/lib/__tests__/method-conflict-detection.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import {
   detectMethodConflicts,
-  getCandidateDisplayName,
   calculateNameSimilarity,
   areNamesSimilar,
   getMethodStateClasses,
@@ -12,58 +11,6 @@ import type { ImportCandidate } from '@/types/import'
 import type { ContactMethod } from '@/types/contact'
 
 describe('method-conflict-detection', () => {
-  describe('getCandidateDisplayName', () => {
-    it('uses display_name if available', () => {
-      const candidate = {
-        id: '1',
-        display_name: 'John Doe',
-        first_name: 'Johnny',
-        last_name: 'Doer',
-        emails: [],
-        phones: [],
-        source: 'test',
-      } as ImportCandidate
-
-      expect(getCandidateDisplayName(candidate)).toBe('John Doe')
-    })
-
-    it('combines first and last name if no display_name', () => {
-      const candidate = {
-        id: '1',
-        first_name: 'John',
-        last_name: 'Doe',
-        emails: [],
-        phones: [],
-        source: 'test',
-      } as ImportCandidate
-
-      expect(getCandidateDisplayName(candidate)).toBe('John Doe')
-    })
-
-    it('uses only first name if no last name', () => {
-      const candidate = {
-        id: '1',
-        first_name: 'John',
-        emails: [],
-        phones: [],
-        source: 'test',
-      } as ImportCandidate
-
-      expect(getCandidateDisplayName(candidate)).toBe('John')
-    })
-
-    it('returns Unknown if no name parts', () => {
-      const candidate = {
-        id: '1',
-        emails: [],
-        phones: [],
-        source: 'test',
-      } as ImportCandidate
-
-      expect(getCandidateDisplayName(candidate)).toBe('Unknown')
-    })
-  })
-
   describe('calculateNameSimilarity', () => {
     it('returns 1 for identical names', () => {
       expect(calculateNameSimilarity('John Doe', 'John Doe')).toBe(1)

--- a/frontend/src/lib/candidate-display.ts
+++ b/frontend/src/lib/candidate-display.ts
@@ -1,0 +1,17 @@
+import type { ImportCandidate } from '@/types/import'
+
+/**
+ * Compute the display name for a candidate, with Telegram @username as the
+ * last-resort fallback before "Unknown". Returns the stored '@handle' when
+ * all name fields are empty for a Telegram candidate so cards never render
+ * a meaningless "Unknown" heading for peers we actually have a handle for.
+ */
+export function getCandidateDisplayName(candidate: ImportCandidate): string {
+  if (candidate.display_name) return candidate.display_name
+  const name = [candidate.first_name, candidate.last_name].filter(Boolean).join(' ')
+  if (name) return name
+  if (candidate.source === 'telegram' && candidate.metadata?.username) {
+    return candidate.metadata.username
+  }
+  return 'Unknown'
+}

--- a/frontend/src/lib/method-conflict-detection.ts
+++ b/frontend/src/lib/method-conflict-detection.ts
@@ -116,6 +116,43 @@ export function detectMethodConflicts(
     })
   }
 
+  // Process Telegram @username from metadata (source-gated). Mirrors the
+  // backend's buildMethodsAuto — a Telegram peer's handle is itself a
+  // contact method that should appear in the Link modal's comparison UI.
+  // The external_value is kept in display form ('@handle') so the modal's
+  // methodSelections lookup (keyed by @handle) matches.
+  if (candidate.source === 'telegram' && candidate.metadata?.username) {
+    const rawHandle = candidate.metadata.username
+    const displayValue = rawHandle.startsWith('@') ? rawHandle : `@${rawHandle}`
+    const suggestedType: ContactMethodType = 'telegram'
+    const normalized = normalizeContactMethodValueForComparison(suggestedType, displayValue)
+
+    const existingByValue = crmByNormalizedValue.get(normalized)
+
+    let conflictType: ConflictType = 'none'
+    let state: MethodState = 'adding'
+    let crmMethod: MethodComparison['crm_method'] | undefined
+
+    if (existingByValue) {
+      crmMethod = {
+        id: existingByValue.id || '',
+        type: existingByValue.type,
+        value: existingByValue.value,
+      }
+      conflictType = 'identical'
+      state = 'unchanged'
+    }
+
+    comparisons.push({
+      external_value: displayValue,
+      external_type: 'telegram',
+      suggested_crm_type: suggestedType,
+      crm_method: crmMethod,
+      conflict_type: conflictType,
+      state,
+    })
+  }
+
   return comparisons
 }
 

--- a/frontend/src/lib/method-conflict-detection.ts
+++ b/frontend/src/lib/method-conflict-detection.ts
@@ -3,15 +3,6 @@ import type { ImportCandidate, MethodComparison, ConflictType, MethodState } fro
 import { normalizeContactMethodValueForComparison } from './contact-methods'
 
 /**
- * Get the display name from an import candidate.
- */
-export function getCandidateDisplayName(candidate: ImportCandidate): string {
-  if (candidate.display_name) return candidate.display_name
-  const parts = [candidate.first_name, candidate.last_name].filter(Boolean)
-  return parts.join(' ') || 'Unknown'
-}
-
-/**
  * Extract external contact methods from an import candidate.
  * Preserves original type information for conflict resolution.
  */

--- a/frontend/src/types/import.ts
+++ b/frontend/src/types/import.ts
@@ -9,10 +9,13 @@ export interface SuggestedMatch {
 }
 
 export interface ImportCandidateMetadata {
+  // Calendar attendee metadata (source: 'gcal_attendee')
   meeting_title?: string
   meeting_date?: string
   meeting_link?: string
   discovered_at?: string
+  // Telegram peer metadata (source: 'telegram'). Stored with leading '@'.
+  username?: string
 }
 
 export interface ImportCandidate {

--- a/frontend/tests/e2e/helpers/test-api.ts
+++ b/frontend/tests/e2e/helpers/test-api.ts
@@ -48,11 +48,15 @@ export interface SeedContactsResponse {
 }
 
 export interface SeedExternalContactInput {
-  display_name: string
+  display_name?: string
+  first_name?: string
+  last_name?: string
+  source?: 'test' | 'telegram' | 'gcontacts' | 'gcal_attendee'
   emails?: string[]
   phones?: string[]
   organization?: string
   job_title?: string
+  metadata?: Record<string, unknown>
 }
 
 export interface SeedExternalContactsRequest {

--- a/frontend/tests/e2e/imports-features.spec.ts
+++ b/frontend/tests/e2e/imports-features.spec.ts
@@ -351,6 +351,12 @@ test.describe('Imports Features @area:imports', () => {
       // Modal opens in import mode (mode toggle is visible).
       await expect(page.getByRole('button', { name: 'Import as New', exact: true })).toBeVisible()
 
+      // Contact Methods section shows the @handle as a selectable method row —
+      // NOT "No contact methods available". The row carries the handle as its
+      // visible value and defaults to selected.
+      await expect(page.getByText('No contact methods available')).not.toBeVisible()
+      await expect(page.locator('.space-y-2').getByText(handle)).toBeVisible()
+
       // Import without editing the name — click "Import as New Contact" submit button.
       await page.getByRole('button', { name: 'Import as New Contact', exact: true }).click()
 
@@ -358,6 +364,44 @@ test.describe('Imports Features @area:imports', () => {
       await expect(page.getByText(`${handle} imported successfully!`)).toBeVisible({
         timeout: 10000,
       })
+    })
+
+    test('shows @username method in Link to Existing modal', async ({ page }) => {
+      const handle = `@dale_${testApi.prefix.replace(/-/g, '_')}`
+
+      // Seed a CRM contact to link to
+      await testApi.seedContacts([
+        {
+          full_name: 'Link Target For Telegram',
+        },
+      ])
+
+      // Seed a Telegram candidate with no name fields
+      await testApi.seedExternalContacts([
+        {
+          source: 'telegram',
+          metadata: { username: handle },
+        },
+      ])
+
+      await page.goto('/imports')
+      await page.waitForLoadState('domcontentloaded')
+      await page.getByRole('button', { name: 'Telegram', exact: true }).click()
+
+      const candidateCard = page.locator('[class*="border-gray-200"]').filter({ hasText: handle })
+      await candidateCard.getByRole('button', { name: /Link/i }).click()
+
+      // Switch to Link mode
+      await page.getByRole('button', { name: 'Link to Existing', exact: true }).click()
+
+      // Select the CRM contact
+      await page.getByText('Search for a contact...').click()
+      await page.getByText(`${testApi.prefix}-Link Target For Telegram`).click()
+
+      // The handle is rendered in the methods list as "Will be added" / "Same as CRM"
+      // rather than "No contact methods available".
+      await expect(page.getByText('No contact methods available')).not.toBeVisible()
+      await expect(page.locator('.space-y-2').getByText(handle).first()).toBeVisible()
     })
   })
 })

--- a/frontend/tests/e2e/imports-features.spec.ts
+++ b/frontend/tests/e2e/imports-features.spec.ts
@@ -320,5 +320,44 @@ test.describe('Imports Features @area:imports', () => {
       const handleLinks = page.getByRole('link', { name: handle })
       await expect(handleLinks).toHaveCount(0)
     })
+
+    // Regression for Codex review feedback on PR #273: a candidate with no
+    // source name fields must still be importable without editing the name —
+    // the frontend needs to send the @handle as `name` explicitly, because
+    // the backend can't derive it from display_name/first_name/last_name.
+    test('imports a handle-only Telegram candidate without requiring a name edit', async ({
+      page,
+    }) => {
+      const handle = `@dale_${testApi.prefix.replace(/-/g, '_')}`
+
+      await testApi.seedExternalContacts([
+        {
+          source: 'telegram',
+          metadata: { username: handle },
+        },
+      ])
+
+      await page.goto('/imports')
+      await page.waitForLoadState('domcontentloaded')
+      await page.getByRole('button', { name: 'Telegram', exact: true }).click()
+
+      // The candidate card heading shows the handle (display-name fallback).
+      await expect(page.getByRole('heading', { name: handle })).toBeVisible()
+
+      // Open the Import action for this candidate.
+      const candidateCard = page.locator('[class*="border-gray-200"]').filter({ hasText: handle })
+      await candidateCard.getByRole('button', { name: /Import/i }).click()
+
+      // Modal opens in import mode (mode toggle is visible).
+      await expect(page.getByRole('button', { name: 'Import as New', exact: true })).toBeVisible()
+
+      // Import without editing the name — click "Import as New Contact" submit button.
+      await page.getByRole('button', { name: 'Import as New Contact', exact: true }).click()
+
+      // Success notification confirms the contact was created with the handle as name.
+      await expect(page.getByText(`${handle} imported successfully!`)).toBeVisible({
+        timeout: 10000,
+      })
+    })
   })
 })

--- a/frontend/tests/e2e/imports-features.spec.ts
+++ b/frontend/tests/e2e/imports-features.spec.ts
@@ -254,4 +254,71 @@ test.describe('Imports Features @area:imports', () => {
       expect(mediumConfidenceIdx).toBeLessThan(noMatchIdx)
     })
   })
+
+  test.describe('Telegram @username display', () => {
+    let testApi: TestAPI
+
+    test.beforeEach(async ({ request }, testInfo) => {
+      testApi = createTestAPI(request, testInfo)
+    })
+
+    test.afterEach(async () => {
+      await testApi.cleanup()
+    })
+
+    test('shows @username chip on Telegram candidate card', async ({ page }) => {
+      // Use a prefix-scoped handle so parallel test runs don't collide on the
+      // link selector and so we can scope assertions to our card.
+      const handle = `@dale_${testApi.prefix.replace(/-/g, '_')}`
+      const telegramPath = handle.replace(/^@/, '')
+
+      await testApi.seedExternalContacts([
+        {
+          source: 'telegram',
+          display_name: 'Dale Dobeck',
+          metadata: { username: handle },
+        },
+      ])
+
+      await page.goto('/imports')
+      await page.waitForLoadState('domcontentloaded')
+
+      // Filter to Telegram so only our seeded card is visible even on a busy DB.
+      await page.getByRole('button', { name: 'Telegram', exact: true }).click()
+
+      const displayName = `${testApi.prefix}-Dale Dobeck`
+      await findCandidateByName(page, displayName)
+
+      // Heading shows the display_name; chip shows the handle and links to t.me
+      await expect(page.getByRole('heading', { name: displayName })).toBeVisible()
+      const handleLink = page.getByRole('link', { name: handle })
+      await expect(handleLink).toBeVisible()
+      await expect(handleLink).toHaveAttribute('href', `https://t.me/${telegramPath}`)
+    })
+
+    test('falls back to @username when no name is set on Telegram candidate', async ({ page }) => {
+      const handle = `@dale_${testApi.prefix.replace(/-/g, '_')}`
+
+      await testApi.seedExternalContacts([
+        {
+          source: 'telegram',
+          // No display_name, no first/last
+          metadata: { username: handle },
+        },
+      ])
+
+      await page.goto('/imports')
+      await page.waitForLoadState('domcontentloaded')
+
+      await page.getByRole('button', { name: 'Telegram', exact: true }).click()
+
+      // @username becomes the primary heading
+      await expect(page.getByRole('heading', { name: handle })).toBeVisible()
+      // Chip is suppressed when the handle is already the heading. Scoping
+      // by the unique prefix-based handle avoids clashing with other seeded
+      // rows on a shared DB.
+      const handleLinks = page.getByRole('link', { name: handle })
+      await expect(handleLinks).toHaveCount(0)
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- **Fixes the null-overwrite bug** (anthropics/personal-crm#271): the shared `UpsertExternalContact` query unconditionally replaced `display_name`, `first_name`, `last_name`, and `metadata` with `EXCLUDED.*`. When the Telegram matcher re-upserted a peer after a message with null/empty entity data, this wiped the populated name and dropped the `metadata.username` key. Observed in prod: peer `1504114951` showing "Unknown" even though `telegram_message` had `peer_first_name='Dale'`, `peer_last_name='Dobeck'`, `peer_username='daledobeck'`.
- **Adds the `@username` chip on import cards** (anthropics/personal-crm#270): for Telegram candidates, `metadata.username` renders as a clickable `@<handle>` chip linking to `t.me/<handle>`. If no display/first/last name is set, the handle becomes the primary heading (instead of "Unknown"), with the chip suppressed to avoid duplication.

## Key changes

- **New dedicated SQL**: `UpsertTelegramDiscoveryCandidate` in `external_contact.sql`. `COALESCE(EXCLUDED.*, existing)` preserves scalar names; `metadata || EXCLUDED.metadata` merges JSONB. Touches only the 6 columns the matcher manages — `emails`, `match_status`, etc. are untouched on update. Shared `UpsertExternalContact` is left intact for Google flows (authoritative overwrite semantics).
- **Blank-string normalization**: Telegram returns `""` (not NULL) for missing entity fields on outbound private chats. Both the Go matcher (via new `nilIfEmpty` helper) and `ListDistinctUnmatchedPeers` ORDER BY (via `<> ''` guards) now treat blanks as absent.
- **Aggregation improvement**: `ListDistinctUnmatchedPeers` prefers rows with populated names so a single discovery pass picks the most-populated row per peer.
- **Shared `getCandidateDisplayName`**: extracted from `method-conflict-detection.ts` into `frontend/src/lib/candidate-display.ts` with the Telegram fallback; used by card heading, link modal, and ignore notification.
- **Backend sort fallback**: nameless Telegram peers now sort alphabetically by handle (stripped `@`) instead of bunched at the end.

## Test plan

- [x] `make lint` clean
- [x] `make test` — 258 frontend + 487 backend unit/integration pass
- [x] `make test-e2e-diff` — all 125 E2E tests pass (one flaky test passed on retry)
- [x] New integration coverage: `TestUpsertTelegramDiscoveryCandidate_*` (8 tests), `TestListDistinctUnmatchedPeers_*` (2 tests), `TestUpdateDiscoveryCandidates_BatchPath_BlankStringsDoNotClobberStoredData` (end-to-end prod-symptom regression)
- [x] New unit coverage: `TestGetCandidateDisplayName` (Telegram username cases), `TestUpdateDiscoveryCandidatesForPeer_{NilNames,EmptyStrings}`, vitest for `getCandidateDisplayName` helper
- [x] New E2E: `imports-features.spec.ts` — Telegram @username chip renders + heading fallback
- [x] Manual prod verification (after deploy): peer `1504114951` should self-heal on next `UpdateDiscoveryCandidates` run — card should show "Dale Dobeck" with `@daledobeck` chip

Plan doc: `.ai/log/plan/telegram-discovery-upsert-username.md`
Closes #271, closes #270