### PR TITLE
feat(telegram): enrich contact methods on link + matcher auto-match

### DIFF
--- a/.ai/spec/telegram-method-enrichment.md
+++ b/.ai/spec/telegram-method-enrichment.md
@@ -1,0 +1,702 @@
+# Telegram Method Enrichment on Link and Auto-Match — Spec
+
+**Issue:** none (bug discovered in session; no dedicated issue filed)
+**Related:** #272 (username-name match), #97 (import/link method selection UI), #182 (rematch-service, parallel work)
+**Status:** Draft v5 (Codex round 4 import-path typo fixed)
+**Branch:** `feat/telegram-method-enrichment`
+**Last Updated:** 2026-04-13
+
+---
+
+## 1. Overview
+
+### What
+
+When a Telegram `external_contact` (or identity-matched peer) is bound to a CRM contact — whether via the user-initiated link flow (`POST /imports/:id/link`) or the identity-based auto-match in the Telegram peer matcher — add the peer's Telegram `@username` as a `contact_method` on the bound CRM contact.
+
+Today this only happens on the "import as new contact" path. The two bind-to-existing paths silently drop the Telegram handle.
+
+### Why
+
+Discovered during session investigation of contact `ea365ac2-d337-470f-b3c9-77bb03b75301` ("Jack Laing"). His `external_contact` (`source_id=479625218`, `display_name="Jackal"`, `metadata.username="@JackALaing"`) was `match_status='matched'` with `crm_contact_id` set, and an `external_identity` row existed linking `jackalaing` to him — but no `contact_method` row of type `telegram`. The Telegram handle was invisible on his contact page.
+
+Root cause (three gaps):
+
+1. `service/enrichment.go` — `enrichContactMethods` and `enrichContactMethodsWithSelections` build their lookup maps only from `external.Emails` and `external.Phones`. In the Selections variant, telegram selections sent by the frontend fail the `externalValues` validation at line 229 and are swallowed by `logger.Warn` in `LinkContact` (`api/handlers/import.go:564`), so the link succeeds but telegram is silently dropped.
+2. `telegram/matcher.go` — `MatchPeer` (after identity match) calls `markExternalContactMatched`, which only updates `external_contact.match_status` and **early-returns on two conditions** — no existing `external_contact` row (below-threshold peers have none) and already-matched/imported status (no repair for past matches). Neither path calls any method-level enrichment.
+3. `api/handlers/import.go` — `buildMethodsAuto` (lines 470-479) already extracts `metadata.username` correctly on the import-new path. The logic exists; it's just not reused.
+
+### Key Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Shared helper | Package-level function `BuildMethodsFromExternal(*repository.ExternalContact) []service.ContactMethodInput` in a new file `backend/internal/service/external_methods.go` | Single source of truth; `buildMethodsAuto` becomes a one-line wrapper; both enrichment paths call it; future sources (discord/whatsapp/etc.) plug in here |
+| Telegram in auto mode (`enrichContactMethods`) | Auto-add telegram if helper surfaces one and no existing telegram method with matching normalized value | Consistent with emails/phones auto behavior: fill-in-the-blanks, never overwrite |
+| Telegram in selections mode (`enrichContactMethodsWithSelections`) | Build both `existingNormalized` AND the external-value-admission lookup as type-scoped normalized keys. Selection's `OriginalValue` is compared via the same `methodDedupKey`, so `"@JackALaing"` and `"JackALaing"` both match. Stored `contact_method.value` is canonicalized (strips leading `@` for telegram handles) before insert, matching import-new behavior | User can send `@handle` or bare handle from frontend; both admit. Storage stays in canonical bare form. Dedup key matches the DB unique index shape |
+| Matcher → enrichment (placement) | New matcher helper `ensureMethodsOnMatch(ctx, contactID, peerUserID, peerUsername)` called **from `MatchPeer` after each successful username-match and phone-match path** (not inside `markExternalContactMatched`) | `markExternalContactMatched` early-returns when no `external_contact` row exists (below-threshold peers) and when status is already `matched`/`imported` (no repair path). Codex-round-1 finding. `MatchPeer` is the orchestration point that reaches every matched peer |
+| Matcher data source | `ensureMethodsOnMatch` reads the persisted `external_contact` if present, then **merges** the current-message `peerUsername` over any `metadata.username` from storage (current wins, because it's freshest). If no persisted row exists, synthesizes a minimal `*repository.ExternalContact` from peer fields | Stored `external_contact` may pre-date username capture or lag behind a Telegram handle rename. The current message is authoritative for the peer's live username — merging ensures we add the right telegram method in all three drift cases. Audit `external_contact_id` still references the persisted row when one exists |
+| Narrow enrichment API | `EnrichmentService.SyncMethodsFromExternal(ctx, crmContactID, *ExternalContact)` — delegates to the refactored `enrichContactMethods`; does NOT overwrite `profile_photo`, `birthday`, `location`, `full_name`, `cadence` | Auto-match fires silently on every peer; narrow scope prevents rewriting profile fields behind the user's back |
+| Google Contacts auto-match | **Unchanged** — keeps calling full `EnrichContactFromExternal` | Google contacts carry real profile data (not auto-discovered peers); current behavior is correct. Benefits from the shared helper for email/phone; telegram clause is inert since Google does not populate `metadata.username` |
+| Duplicate-on-race handling | Treat `pgconn.PgError.Code == "23505"` (unique violation on `contact_method_unique_value`) as success; log at debug | Two concurrent MatchPeer calls for the same peer could race; idempotency must win over warning spam |
+| Dedup-key shape | `type + ":" + identity.Normalize(value, mapMethodTypeToIdentifier(type))` in both enrichment paths | Matches the DB unique index `(contact_id, type, value_normalized)` exactly. Value-only keys would falsely dedupe cross-type collisions (e.g., `telegram:foo` vs `twitter:foo`, which normalize to the same handle but live in different type buckets) |
+| Error handling in matcher | `ensureMethodsOnMatch` errors are logged at warn level; do NOT fail `MatchPeer` or the match bind | Match integrity > enrichment completeness; matches existing `logger.Warn` pattern elsewhere |
+| `recordEnrichment` audit | Every telegram method added via any path writes a `contact_enrichment` row. `recordEnrichment` is updated to pass `ExternalContactID=nil` when `external.ID == uuid.Nil`, so matcher's synthesized `ExternalContact` yields SQL NULL (not a zero-UUID) in the audit row | Audit consistency; distinguishes synthesized (no persisted row) from persisted sources |
+| `conflictResolutions` dead param | Leave in place | Separate refactor; out of scope |
+| Backfill script | **Not included** | User is running one-off SQL backfill separately after fix lands + after #182 rematch-service finishes |
+| Frontend changes | **None** — `import-link-modal.tsx` already pre-selects telegram from `metadata.username`; `SelectedMethodInput` validator already accepts `telegram` | Exploration confirmed full frontend wiring exists; only backend enrichment was broken |
+
+### Non-Goals
+
+- Rematching historical messages/events when a new contact_method is added — that's #182 (rematch-service).
+- Handling discord/twitter/signal/whatsapp metadata extraction. Shared helper is structured so they can be added with a one-line addition each when a source populates them.
+- Changing Google Contacts auto-match to the narrow enrichment variant.
+- Removing the dead `conflictResolutions` parameter.
+- Adding contact_method for peer `phone` during phone-match (phones are already on the contact — that's what matched).
+- E2E tests (frontend already wires telegram selections; exploration confirmed).
+- A user-triggered "ensure methods on already-matched contacts" button (covered by user's separate backfill SQL).
+
+---
+
+## 2. Functional Specification
+
+### 2.1 User-Visible Behavior
+
+1. **User-initiated link with telegram selected:** Import UI → "Link to Existing" → pick contact → leave telegram checked → confirm. Target contact's detail page shows new telegram `contact_method` row rendered as `@JackALaing`.
+2. **User deselects telegram in picker:** Same flow, telegram unchecked. No telegram `contact_method` is added. External_contact is still bound, external_identity still linked.
+3. **Link without any selections (auto fallback path):** `POST /imports/:id/link` with empty `selected_methods` and no cadence/name overrides → calls `EnrichContactFromExternal` (auto mode). Telegram method IS auto-added from `metadata.username`.
+4. **Auto-match via identity, above-threshold peer:** Telegram message arrives from peer whose `@username` matches an existing CRM contact (via #272 name match, existing `external_identity`, or another path). Matcher binds. Target contact gets telegram `contact_method` auto-added. Profile fields unchanged.
+5. **Auto-match via identity, below-threshold peer (no persisted `external_contact`):** Same as above. Method is added from synthesized peer data (no `external_contact` row needed).
+6. **Re-match (matcher runs again for same peer):** No duplicate `contact_method` — dedup via normalized value; PG unique-violation on race is treated as success.
+
+### 2.2 Acceptance Criteria
+
+- [ ] `POST /imports/:id/link` with `selected_methods=[{type:"telegram", original_value:"JackALaing"}]` produces exactly one `contact_method` row: `type='telegram'`, `value='JackALaing'`, `value_normalized='jackalaing'`, `is_primary=false`. A matching `contact_enrichment` audit row is written.
+- [ ] `POST /imports/:id/link` with `selected_methods=[{type:"telegram", original_value:"@JackALaing"}]` (leading `@` preserved from frontend) results in the same row — `value='JackALaing'` (bare), matching `buildMethodsAuto` behavior today.
+- [ ] `POST /imports/:id/link` with no telegram entry in `selected_methods` does NOT create a telegram `contact_method`.
+- [ ] `POST /imports/:id/link` when the target already has a matching-normalized telegram method is a no-op (no duplicate, no error, no warn).
+- [ ] `POST /imports/:id/link` with empty `selected_methods`, no cadence, no name overrides → fallback `EnrichContactFromExternal` auto-adds telegram from `metadata.username` if present.
+- [ ] `PeerMatcher.MatchPeer` matching a peer via username — when `external_contact` exists for that peer — produces a telegram `contact_method` on the bound contact, sourced from `external_contact.metadata.username`.
+- [ ] `PeerMatcher.MatchPeer` matching a below-threshold peer via username (no `external_contact` row) — produces a telegram `contact_method` using the synthesized `ExternalContact`.
+- [ ] `PeerMatcher.MatchPeer` matching via phone when `peerUsername` is present — produces a telegram `contact_method`.
+- [ ] `PeerMatcher.MatchPeer` matching via phone when `peerUsername` is nil/empty — does NOT produce a telegram `contact_method` (nothing to add).
+- [ ] After matcher enrichment, bound CRM contact's `profile_photo`, `birthday`, `location`, `full_name`, `cadence` are unchanged.
+- [ ] `contact_enrichment` audit row is present after matcher enrichment — `external_contact_id` populated when a persisted row exists, NULL when synthesized.
+- [ ] `ensureMethodsOnMatch` error (simulated via a failing `methodRepo`) does NOT fail `MatchPeer` — `MatchPeer` returns the matched `ContactID` normally, a warn is logged.
+- [ ] Running `MatchPeer` twice for the same peer yields one `contact_method` (idempotency). A concurrent-insert PG `23505` unique violation is treated as success, not as a warn.
+- [ ] `buildMethodsAuto` in `import.go` is deleted; its caller uses `service.BuildMethodsFromExternal`. Import-new behavior is byte-identical.
+- [ ] Google Contacts auto-match (`google/contacts.go:370,399`) continues to pass existing tests.
+- [ ] `backend/internal/telegram/matcher_test.go` tests that use struct-literal `PeerMatcher` construction with only a subset of fields — either (a) don't trigger the new enrichment code path, or (b) are updated with a mock `contactEnricher`. Nil-safety in the matcher ensures no panic.
+- [ ] `backend/tests/telegram_discovery_upsert_test.go:363` calling `tgpkg.NewPeerMatcher` with the old signature is updated to the new signature.
+
+---
+
+## 3. Technical Specification
+
+### 3.1 Shared Helper — `BuildMethodsFromExternal`
+
+**New file:** `backend/internal/service/external_methods.go`
+
+```go
+package service
+
+import (
+    "strings"
+
+    "personal-crm/backend/internal/repository"
+)
+
+// BuildMethodsFromExternal converts an ExternalContact into the canonical
+// list of ContactMethodInput entries. Single source of truth for translating
+// source-specific fields (emails, phones, metadata.username) into the shape
+// the contact / enrichment services consume.
+//
+// Callers are responsible for deduplicating against existing contact methods
+// on the target contact — this function returns everything the external
+// contact carries, in a stable order.
+func BuildMethodsFromExternal(external *repository.ExternalContact) []ContactMethodInput {
+    if external == nil {
+        return nil
+    }
+    methods := make([]ContactMethodInput, 0, len(external.Emails)+len(external.Phones)+1)
+
+    for _, email := range external.Emails {
+        methods = append(methods, ContactMethodInput{Type: "email", Value: email.Value})
+    }
+    for _, phone := range external.Phones {
+        methods = append(methods, ContactMethodInput{Type: "phone", Value: phone.Value})
+    }
+
+    if external.Source == "telegram" {
+        if username, ok := external.Metadata["username"].(string); ok {
+            canonical := canonicalizeMethodValue("telegram", username)
+            if canonical != "" {
+                methods = append(methods, ContactMethodInput{Type: "telegram", Value: canonical})
+            }
+        }
+    }
+
+    return methods
+}
+```
+
+**Normalization:** `Value` is the canonicalized handle (stripped `@`, trimmed whitespace, case preserved). `canonicalizeMethodValue` (defined in §3.3 Change D) is the single source of truth for that canonicalization — used here for the auto path AND by `enrichContactMethodsWithSelections` for the selections path. DB trigger (migration 021) lowercases into `value_normalized`. Unique index on `(contact_id, type, value_normalized)` catches case-variant duplicates.
+
+### 3.2 Refactor — `enrichContactMethods` (auto mode)
+
+**File:** `backend/internal/service/enrichment.go` (modify)
+
+```go
+func (s *EnrichmentService) enrichContactMethods(
+    ctx context.Context,
+    contact *repository.Contact,
+    external *repository.ExternalContact,
+) error {
+    existingMethods, err := s.methodRepo.ListContactMethodsByContact(ctx, contact.ID)
+    if err != nil {
+        return err
+    }
+
+    existingSet := make(map[string]bool)
+    for _, m := range existingMethods {
+        existingSet[methodDedupKey(m.Type, m.Value)] = true
+    }
+
+    for _, input := range BuildMethodsFromExternal(external) {
+        key := methodDedupKey(input.Type, input.Value)
+        if existingSet[key] {
+            continue
+        }
+        _, err := s.methodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
+            ContactID: contact.ID,
+            Type:      input.Type,
+            Value:     input.Value,
+            IsPrimary: false,
+        })
+        if err != nil {
+            if isUniqueViolation(err) {
+                // concurrent insert — already there, treat as success
+                existingSet[key] = true
+                continue
+            }
+            logger.Warn().Err(err).
+                Str("type", input.Type).
+                Str("value", input.Value).
+                Msg("failed to add method from enrichment")
+            continue
+        }
+        s.recordEnrichment(ctx, contact.ID, external,
+            "method:"+input.Type+":"+identity.Normalize(input.Value, mapMethodTypeToIdentifier(input.Type)),
+            input.Value)
+        existingSet[key] = true
+    }
+    return nil
+}
+
+// methodDedupKey returns the dedup key used to compare an incoming method
+// against existing methods on a contact. Mirrors the DB unique index shape
+// (contact_id, type, value_normalized) — without type scoping, cross-type
+// duplicates like telegram:foo vs twitter:foo would collide incorrectly.
+func methodDedupKey(methodType, value string) string {
+    return methodType + ":" + identity.Normalize(value, mapMethodTypeToIdentifier(methodType))
+}
+
+// isUniqueViolation returns true if err is a PostgreSQL unique_violation (23505).
+// Used to treat concurrent-insert races as idempotent no-ops.
+func isUniqueViolation(err error) bool {
+    var pgErr *pgconn.PgError
+    return errors.As(err, &pgErr) && pgErr.Code == "23505"
+}
+```
+
+Add imports: `github.com/jackc/pgx/v5/pgconn`, `errors`.
+
+### 3.3 Refactor — `enrichContactMethodsWithSelections` (selections mode)
+
+**File:** `backend/internal/service/enrichment.go` (modify)
+
+Four changes required:
+
+**Change A — `existingNormalized` + `existingMethodByKey` lookups use type-scoped keys:**
+
+```go
+// replaces current lines 201-208
+existingKeys := make(map[string]bool)
+existingMethodByKey := make(map[string]*repository.ContactMethod)
+for i := range existingMethods {
+    m := &existingMethods[i]
+    key := methodDedupKey(m.Type, m.Value)
+    existingKeys[key] = true
+    existingMethodByKey[key] = m
+}
+```
+
+Renamed `existingNormalized` → `existingKeys` to reflect the new key shape.
+
+**Change B — admissible-external lookup is built from the shared helper output, keyed by `methodDedupKey`:**
+
+```go
+// replaces current lines 211-217
+externalKeys := make(map[string]bool)
+for _, m := range BuildMethodsFromExternal(external) {
+    externalKeys[methodDedupKey(m.Type, m.Value)] = true
+}
+```
+
+Renamed `externalValues` → `externalKeys`. Using the type-scoped normalized key lets both `@handle` and bare-handle forms from the frontend match a single entry emitted by the helper (`telegram:<lowercased-bare-handle>`).
+
+**Change C — selection validation and existing-method lookup use `methodDedupKey`; stored value is canonicalized:**
+
+```go
+// current lines 229-254 become:
+for _, sel := range selectedMethods {
+    selKey := methodDedupKey(sel.Type, sel.OriginalValue)
+
+    if !externalKeys[selKey] {
+        methodErrors = append(methodErrors,
+            fmt.Sprintf("value %q not found in external contact", sel.OriginalValue))
+        continue
+    }
+
+    if existingKeys[selKey] {
+        if sel.IsPrimary {
+            if existingMethod := existingMethodByKey[selKey]; existingMethod != nil {
+                existingPrimaryMethodID = &existingMethod.ID
+            }
+        }
+        continue
+    }
+
+    // Canonicalize the stored value to match storage convention across paths:
+    //   - telegram/twitter/discord: strip leading @ and trim whitespace (bare handle)
+    //   - email/phone: preserve as-is
+    // This mirrors buildMethodsAuto's import-new behavior so link-flow storage
+    // is consistent with import-new storage.
+    storedValue := canonicalizeMethodValue(sel.Type, sel.OriginalValue)
+
+    newMethod, err := s.methodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
+        ContactID: contact.ID,
+        Type:      sel.Type,
+        Value:     storedValue,
+        IsPrimary: false,
+    })
+    if err != nil {
+        if isUniqueViolation(err) {
+            existingKeys[selKey] = true
+            continue
+        }
+        methodErrors = append(methodErrors,
+            fmt.Sprintf("failed to add method %s: %v", storedValue, err))
+        continue
+    }
+
+    if sel.IsPrimary {
+        newPrimaryMethodID = &newMethod.ID
+    }
+
+    s.recordEnrichment(ctx, contact.ID, external,
+        "method:"+sel.Type+":"+identity.Normalize(storedValue, mapMethodTypeToIdentifier(sel.Type)),
+        storedValue)
+    existingKeys[selKey] = true
+}
+```
+
+**Change D — new helper `canonicalizeMethodValue`:**
+
+```go
+// canonicalizeMethodValue converts a user- or frontend-supplied raw method
+// value into the canonical form stored in contact_method.value. For
+// handle-based types (telegram/twitter/discord), strips leading '@' and
+// trimmed whitespace. Does NOT lowercase — storage preserves user casing;
+// value_normalized in the DB carries the lowercased form via the trigger.
+func canonicalizeMethodValue(methodType, rawValue string) string {
+    switch methodType {
+    case "telegram", "twitter", "discord":
+        return strings.TrimPrefix(strings.TrimSpace(rawValue), "@")
+    default:
+        return rawValue
+    }
+}
+```
+
+This is also useful in `BuildMethodsFromExternal` — refactor §3.1 to call `canonicalizeMethodValue("telegram", raw)` in its telegram branch so the canonicalization rule lives in one place.
+
+### 3.3.5 Adjust `recordEnrichment` for synthesized ExternalContact
+
+**File:** `backend/internal/service/enrichment.go` (modify)
+
+Change `recordEnrichment` (currently at line 375) to pass `ExternalContactID = nil` when the input `external.ID == uuid.Nil`. This ensures the matcher's synthesized `*ExternalContact` (which has no persisted ID) produces a SQL `NULL` in `contact_enrichment.external_contact_id`, not a zero-UUID.
+
+```go
+func (s *EnrichmentService) recordEnrichment(
+    ctx context.Context,
+    contactID uuid.UUID,
+    external *repository.ExternalContact,
+    field string,
+    value string,
+) {
+    var externalContactID *uuid.UUID
+    if external.ID != uuid.Nil {
+        externalContactID = &external.ID
+    }
+    _, err := s.enrichmentRepo.Create(ctx, repository.CreateEnrichmentRequest{
+        ContactID:         contactID,
+        Source:            external.Source,
+        AccountID:         external.AccountID,
+        Field:             field,
+        ExternalContactID: externalContactID,
+        OriginalValue:     &value,
+    })
+    if err != nil {
+        logger.Warn().Err(err).Str("field", field).Msg("failed to record enrichment audit row")
+    }
+}
+```
+
+Existing callers (Google sync, import link flow) always pass persisted `*ExternalContact` instances with real UUIDs, so they are unaffected by this change. Only the matcher's synthesized path (when `external_contact` was absent) triggers the `NULL` branch.
+
+### 3.4 New method — `EnrichmentService.SyncMethodsFromExternal`
+
+**File:** `backend/internal/service/enrichment.go` (modify)
+
+```go
+// SyncMethodsFromExternal adds any missing contact methods from an
+// ExternalContact to the given CRM contact. Unlike EnrichContactFromExternal,
+// it does NOT touch profile fields (photo, birthday, location, name, cadence).
+// Intended for auto-match flows where silent profile overwrites are undesirable.
+//
+// Audit rows are written via recordEnrichment, same as EnrichContactFromExternal.
+// Idempotent: duplicate methods (either via normalized-value dedup or PG
+// unique-violation race) are no-ops.
+func (s *EnrichmentService) SyncMethodsFromExternal(
+    ctx context.Context,
+    crmContactID uuid.UUID,
+    external *repository.ExternalContact,
+) error {
+    contact, err := s.contactRepo.GetContact(ctx, crmContactID)
+    if err != nil {
+        return fmt.Errorf("get contact for method sync: %w", err)
+    }
+    return s.enrichContactMethods(ctx, contact, external)
+}
+```
+
+### 3.5 Refactor — `buildMethodsAuto` in import handler
+
+**File:** `backend/internal/api/handlers/import.go` (modify)
+
+Delete `buildMethodsAuto` (lines 449-482). Replace the caller with:
+
+```go
+methods := service.BuildMethodsFromExternal(external)
+```
+
+### 3.6 Inject `EnrichmentService` into `PeerMatcher`
+
+**File:** `backend/internal/telegram/matcher.go` (modify)
+
+```go
+// contactEnricher performs narrow method-only enrichment on a bound CRM
+// contact. Satisfied by *service.EnrichmentService. Can be nil (tests).
+type contactEnricher interface {
+    SyncMethodsFromExternal(ctx context.Context, crmContactID uuid.UUID, external *repository.ExternalContact) error
+}
+
+type PeerMatcher struct {
+    identityService     identityMatcher
+    messageRepo         *repository.TelegramMessageRepository
+    messageCounter      peerMessageCounter
+    externalContactRepo externalContactUpserter
+    enricher            contactEnricher  // new; nil-safe
+    discoveryMinMsgs    int
+}
+
+func NewPeerMatcher(
+    identityService identityMatcher,
+    messageRepo *repository.TelegramMessageRepository,
+    externalContactRepo externalContactUpserter,
+    enricher contactEnricher,
+    discoveryMinMsgs int,
+) *PeerMatcher {
+    return &PeerMatcher{
+        identityService:     identityService,
+        messageRepo:         messageRepo,
+        externalContactRepo: externalContactRepo,
+        enricher:            enricher,
+        discoveryMinMsgs:    discoveryMinMsgs,
+    }
+}
+```
+
+Existing unit tests that construct `PeerMatcher` directly with struct literals leave `enricher` zero-valued (nil). The matcher's call site MUST nil-guard (see §3.7).
+
+### 3.7 Invoke enrichment from `MatchPeer` (not `markExternalContactMatched`)
+
+**File:** `backend/internal/telegram/matcher.go` (modify)
+
+Add a private helper:
+
+```go
+// ensureMethodsOnMatch syncs contact methods from the known peer data onto
+// the matched CRM contact. Called after every successful identity match in
+// MatchPeer, regardless of discovery threshold or prior match status.
+//
+// Data sourcing: reads the persisted external_contact if present (preserves
+// audit linkage + any emails/phones). Whether persisted or synthesized, the
+// current-message peerUsername is overlaid onto metadata.username if present
+// and non-empty — the current message is the freshest source of the peer's
+// handle, and wins over any stored value (handles handle-renames and fills
+// gaps in rows that predate username capture).
+//
+// All errors are logged at warn and do NOT fail the match.
+func (m *PeerMatcher) ensureMethodsOnMatch(ctx context.Context, contactID uuid.UUID, peerUserID int64, peerUsername *string) {
+    if m.enricher == nil {
+        return
+    }
+    peerIDStr := strconv.FormatInt(peerUserID, 10)
+
+    external, err := m.externalContactRepo.GetBySource(ctx, "telegram", peerIDStr, nil)
+    if err != nil {
+        log.Warn().Err(err).Int64("peer_user_id", peerUserID).Msg("telegram: get external_contact for method sync failed")
+        // fall through — synthesize below
+    }
+    if external == nil {
+        external = &repository.ExternalContact{
+            Source:   "telegram",
+            SourceID: peerIDStr,
+            Metadata: map[string]interface{}{},
+        }
+    } else if external.Metadata == nil {
+        external.Metadata = map[string]interface{}{}
+    }
+
+    // Merge: current-message peerUsername wins over any stored metadata.username.
+    // Safe to mutate in place — GetBySource returns a fresh instance per call.
+    if peerUsername != nil && *peerUsername != "" {
+        external.Metadata["username"] = "@" + *peerUsername
+    }
+
+    if err := m.enricher.SyncMethodsFromExternal(ctx, contactID, external); err != nil {
+        log.Warn().Err(err).
+            Str("contact_id", contactID.String()).
+            Int64("peer_user_id", peerUserID).
+            Msg("telegram: sync methods from external failed")
+    }
+}
+```
+
+**Call sites inside `MatchPeer`:**
+
+```go
+// After username match (current line 85):
+m.markExternalContactMatched(ctx, peerUserID, *result.ContactID)
+m.ensureMethodsOnMatch(ctx, *result.ContactID, peerUserID, peerUsername)  // NEW
+log.Info()...
+
+// After phone match (current line 113):
+m.markExternalContactMatched(ctx, peerUserID, *result.ContactID)
+// (existing telegram-identity-linking block stays)
+m.ensureMethodsOnMatch(ctx, *result.ContactID, peerUserID, peerUsername)  // NEW
+log.Info()...
+```
+
+`markExternalContactMatched` itself is unchanged.
+
+**Why `MatchPeer`-level, not `markExternalContactMatched`-level:**
+
+1. `markExternalContactMatched` returns early when no `external_contact` exists for the peer (matcher.go:337) — below-threshold peers (fewer than `discoveryMinMsgs` messages) have no row, but can still be identity-matched via username.
+2. `markExternalContactMatched` returns early when status is already `matched`/`imported` (matcher.go:339) — re-match scenarios can't repair a missing method through that path.
+3. `MatchPeer` is the single point that reaches every successful identity match — live (`handlers.go:96`) and batch (`manager.go:573`) both flow through it.
+
+### 3.8 Wire through `TelegramManager` → `main.go`
+
+**File:** `backend/internal/telegram/manager.go` (modify)
+
+Add `enricher contactEnricher` parameter to `NewTelegramManager`; thread to `NewPeerMatcher`.
+
+**File:** `backend/cmd/crm-api/main.go` (modify)
+
+Pass existing `enrichmentService` (constructed at line 164) into `NewTelegramManager` at line 263. `*service.EnrichmentService` satisfies `contactEnricher` via implicit interface satisfaction.
+
+### 3.9 Update integration-test call site
+
+**File:** `backend/tests/telegram_discovery_upsert_test.go:363` (modify)
+
+```go
+// Current: tgpkg.NewPeerMatcher(identitySvc, messageRepo, externalRepo, 2)
+// New:
+tgpkg.NewPeerMatcher(identitySvc, messageRepo, externalRepo, nil, 2)
+```
+
+Passing `nil` for the enricher is safe — this test asserts discovery upsert behavior, not method enrichment. If test goals expand later, inject a real `EnrichmentService` built from the existing test DB wiring.
+
+---
+
+## 4. File Inventory
+
+### New Files
+
+| File | Purpose |
+|---|---|
+| `backend/internal/service/external_methods.go` | `BuildMethodsFromExternal` shared helper |
+| `backend/internal/service/external_methods_test.go` | Unit tests for helper |
+| `backend/tests/telegram_matcher_enrichment_test.go` | Integration: matcher auto-match → telegram method appears (all sub-cases) |
+
+### Modified Files
+
+| File | Change |
+|---|---|
+| `backend/internal/service/enrichment.go` | Refactor both `enrichContactMethods` funcs to use shared helper + `methodDedupKey` + `isUniqueViolation` + `canonicalizeMethodValue`; rename `existingMethodByNormalized` → `existingMethodByKey` and `existingNormalized` → `existingKeys`, `externalValues` → `externalKeys`; add `SyncMethodsFromExternal`; update `recordEnrichment` to emit SQL NULL for `ExternalContactID` when `external.ID == uuid.Nil` |
+| `backend/internal/api/handlers/import.go` | Delete `buildMethodsAuto`; caller switches to `service.BuildMethodsFromExternal` |
+| `backend/internal/telegram/matcher.go` | Add `contactEnricher` interface + field; update `NewPeerMatcher` signature; add `ensureMethodsOnMatch`; call it from `MatchPeer` username-path and phone-path |
+| `backend/internal/telegram/manager.go` | Thread `enricher` through `NewTelegramManager` to `NewPeerMatcher` |
+| `backend/cmd/crm-api/main.go` | Pass existing `enrichmentService` into `NewTelegramManager` |
+| `backend/tests/telegram_discovery_upsert_test.go` | Update `NewPeerMatcher` call site |
+| `backend/internal/telegram/matcher_test.go` | Add matcher-level tests (see §5.2) |
+| `backend/tests/api/import_with_selections_test.go` | Add/extend test cases covering telegram in `SelectedMethods` (see §5.3) |
+
+---
+
+## 5. Test Plan
+
+### 5.1 Unit — `BuildMethodsFromExternal`
+
+**File:** `backend/internal/service/external_methods_test.go` (new)
+
+- Nil external → nil slice.
+- Empty external_contact → empty slice.
+- Emails only → email methods in order.
+- Phones only → phone methods.
+- Telegram source with `metadata.username="@DaleDobeck"` → telegram method, `Value="DaleDobeck"`.
+- Telegram source with `metadata.username="DaleDobeck"` (no `@`) → same.
+- Telegram source with `metadata.username=""` → no telegram method.
+- Telegram source with `metadata.username="@  "` (whitespace-only after strip) → no telegram method.
+- Telegram source with no `metadata.username` key → no telegram method.
+- Telegram source with `metadata.username` as non-string (e.g., `int`) → no telegram method (safe type-assert).
+- Non-telegram source with `metadata.username` set → no telegram method (source guard).
+- Telegram with emails + phones + username → all three, emitted in stable order (email → phone → telegram).
+
+### 5.2 Unit — Matcher Enrichment Invocation
+
+**File:** `backend/internal/telegram/matcher_test.go` (modify)
+
+New `mockContactEnricher` recording calls.
+
+- **Username match fires enricher:** `MatchPeer` with matching `peerUsername` → `mockEnricher.SyncMethodsFromExternal` called once with correct `contactID`. Assert `external.Metadata["username"]` carries the `@`-prefixed username.
+- **Phone match with username fires enricher:** `peerUsername` present + `peerPhone` present + identity returns match on phone (not username) → enricher called once. Username is available, so synthesized metadata includes it.
+- **Phone match without username does not call enricher with username metadata:** `peerUsername=nil`, phone matches → enricher is called (match succeeded) but synthesized `external.Metadata` has no `username` key → `BuildMethodsFromExternal` emits no telegram method → no contact_method written. (This verifies via asserting `mockEnricher.captured[0].Metadata`.)
+- **Unmatched peer — no enricher call:** identity returns no ContactID for both username and phone → `MatchPeer` returns nil, enricher not called.
+- **Nil enricher is safe:** `PeerMatcher{enricher: nil}` — `MatchPeer` runs to completion, no panic.
+- **Enricher error does not fail match:** `mockEnricher.SyncMethodsFromExternal` returns error → `MatchPeer` returns the matched `contactID` and no error.
+- **External_contact present is preferred as the base for enrichment:** mock `externalContactRepo.GetBySource` returns a real `*ExternalContact` (with extra emails and a stored `metadata.username="@Old"`) → enricher receives that pointer. When `peerUsername=ptr("New")` is also provided, the received struct's `Metadata["username"]` is `"@New"` (current wins); the original emails list is preserved.
+- **External_contact absent uses synthesis:** `GetBySource` returns `(nil, nil)` → enricher receives a fresh `*ExternalContact` with `Source="telegram"`, `SourceID` set, `Metadata["username"]` from current `peerUsername`.
+- **External_contact present but `Metadata` is nil:** `GetBySource` returns a row with `Metadata: nil` → helper initializes the map safely before writing.
+- **External_contact present with empty metadata, current peerUsername present:** current message fills the gap; telegram method is created.
+- **External_contact present with stale `metadata.username="@Old"`, current peerUsername="New":** current wins; helper passes `"@New"` to enricher; resulting contact_method `value="New"`.
+- **Both external_contact and current peerUsername missing username:** no telegram method written (helper writes nothing to `Metadata["username"]`; `BuildMethodsFromExternal` emits no telegram entry).
+
+### 5.3 Integration — Link Flow with Telegram Selection
+
+**File:** `backend/tests/api/import_with_selections_test.go` (modify)
+
+- **Primary case:** seed telegram external_contact (`source_id='tg-link-test-1'`, `metadata.username='@TestLink'`) and a CRM contact with only an email. `POST /imports/:id/link` with `selected_methods=[{type:"telegram", original_value:"TestLink", is_primary:false}]`. Assert: one new `contact_method` (`type=telegram`, `value=TestLink`, `value_normalized=testlink`, `is_primary=false`). `contact_enrichment` row present.
+- **Leading-`@` passthrough:** same but `original_value:"@TestLink"` — `value` stored as `TestLink` (bare), `value_normalized` as `testlink`. Confirms consistency with import-new behavior.
+- **Telegram deselected:** same seed, `selected_methods=[{type:"email", ...}]` → no telegram method created.
+- **Idempotency on link:** target already has `contact_method(type=telegram, value_normalized=testlink)` → request succeeds, no duplicate, no warn.
+- **Auto-fallback path:** `POST /imports/:id/link` with empty body (no selected_methods, cadence, name) → hits `EnrichContactFromExternal` (not Selections) → telegram is auto-added from `metadata.username`.
+- **Profile fields unchanged:** verify `profile_photo`, `birthday`, `location` on target contact unchanged after all of the above cases (controls for "narrow enrichment" claim when applied to selections variant; the Selections variant DOES overwrite profile fields in its own right, but only when `name`/`cadence` are explicitly sent — these cases send neither).
+
+### 5.4 Integration — Matcher Auto-Match
+
+**File:** `backend/tests/telegram_matcher_enrichment_test.go` (new)
+
+All cases use a real `PeerMatcher` with a real `EnrichmentService` (method repo + enrichment repo + contact repo wired against test DB). `identityService` is also real, pre-seeded with the external_identity that produces each match.
+
+- **Above-threshold username match:** seed `external_contact(source_id='tg-auto-1', metadata.username='@AutoUser', match_status='unmatched')`, seed `external_identity` linking `autouser` (telegram) to a CRM contact, call `MatchPeer(peerUserID=..., peerUsername=ptr("AutoUser"), ...)`. Assert: `contact_method(type=telegram, value=AutoUser)` exists; `contact_enrichment.external_contact_id` is the seeded ID; profile fields unchanged.
+- **Below-threshold username match (no external_contact row):** seed only `external_identity` linking `autouser` to a CRM contact — do NOT seed `external_contact`. `MatchPeer(peerUsername=ptr("AutoUser"))`. Assert: `contact_method` still created (from synthesized ExternalContact); `contact_enrichment.external_contact_id` is NULL.
+- **Phone match with username present:** seed identity by `phone`; call `MatchPeer(peerUsername=ptr("PhoneMatched"), peerPhone=ptr("+15551234"))`. Assert telegram method created as `PhoneMatched`.
+- **Phone match without username:** seed identity by phone; call `MatchPeer(peerUsername=nil, peerPhone=ptr("+15551234"))`. Assert: NO telegram `contact_method` on the matched contact (nothing to add); match itself succeeded (`external_contact.match_status='matched'` if a row existed).
+- **Idempotency — run twice:** call `MatchPeer` twice back-to-back for the same peer. Assert: exactly one `contact_method` exists; no warn-level log from the second call for duplicate insertion.
+- **Profile fields untouched:** in the above-threshold case, seed the external_contact with `first_name='WrongName'`, `photo_url='http://example.com/wrong.jpg'`. Assert: CRM contact's `full_name` and `profile_photo` unchanged after `MatchPeer`.
+- **Enricher error does not break match bind:** use a fault-injecting method repo (e.g., wrap with a failing-on-Create decorator) and verify `MatchPeer` returns the matched `contactID` and `external_contact.match_status='matched'` even when CreateContactMethod fails.
+
+### 5.5 Regression — Import-new Path
+
+**File:** `backend/tests/api/import_with_selections_test.go` (modify, or add if missing)
+
+- Import a telegram candidate via `POST /imports/:id/import` (new contact path). Assert telegram `contact_method` created with bare handle — proves `BuildMethodsFromExternal` output matches the old `buildMethodsAuto` output.
+
+### 5.6 Google Auto-Match
+
+No new test. Existing Google sync integration tests (if any) must pass unchanged. Relies on CI to catch regressions.
+
+---
+
+## 6. Rollout and Validation
+
+### 6.1 Order of Work
+
+1. Add `BuildMethodsFromExternal` + unit tests (§5.1).
+2. Add `methodDedupKey` + `isUniqueViolation` helpers in `enrichment.go`.
+3. Refactor `enrichContactMethods` to use the helper and new dedup key (§3.2).
+4. Refactor `enrichContactMethodsWithSelections` (§3.3) — both lookup maps type-scoped.
+5. Add `SyncMethodsFromExternal` (§3.4).
+6. Delete `buildMethodsAuto`; switch caller (§3.5).
+7. Add `contactEnricher` interface + field + `ensureMethodsOnMatch` helper in matcher (§3.6, §3.7).
+8. Update `NewPeerMatcher` signature; thread through `TelegramManager` + `main.go` (§3.8).
+9. Update existing call site in `telegram_discovery_upsert_test.go` (§3.9).
+10. Add unit tests (§5.2).
+11. Add integration tests (§5.3, §5.4).
+12. `go build ./cmd/crm-api`, `make lint`, `make test`, `make test-e2e-diff`. No `make sqlc` needed.
+
+### 6.2 Verification
+
+- Manual spot-check after deploy: pick a recently-matched Telegram peer, confirm telegram method appears. Jack Laing (`ea365ac2-d337-470f-b3c9-77bb03b75301`) is a good post-fix check target after the user's separate backfill.
+- The user's one-shot backfill SQL (external to this PR) handles historical matched-but-unenriched peers.
+
+### 6.3 Observability
+
+- `ensureMethodsOnMatch` logs at warn on any non-retriable error. Success path is silent (no extra log spam on every match).
+- `enrichContactMethods` logs warn on non-unique-violation errors. Unique violations now produce no log (debug-level at most).
+- No new info-level logging — existing "peer matched" info log already marks the success point.
+
+---
+
+## 7. Risks and Open Questions
+
+### Risks
+
+1. **Existing matcher unit tests constructing `PeerMatcher` via struct literals** leave `enricher` nil. Nil-guard in `ensureMethodsOnMatch` prevents panic. Tests that assert no enrichment side-effect are unaffected. New tests (§5.2) that DO assert enrichment use an explicit `mockContactEnricher`.
+2. **Dedup-key change in `enrichContactMethods` and Selections variant** from value-only to `type+normalized`. Codex-round-1 review confirmed this matches the DB unique index and the merge-dedup query in `contact_merge.sql:91`. No known caller relies on cross-type collisions — the value-only keying was arguably buggy for edge cases like `telegram:foo` vs `twitter:foo`.
+3. **PG `23505` handling.** Races between two `MatchPeer` calls for the same peer are rare but possible (live + batch overlap). `isUniqueViolation` check catches them; treat as success, no warn.
+4. **Synthesized `ExternalContact` in matcher** has nil `ID`. `recordEnrichment` stores `external_contact_id` as a pointer, so a nil `ID` becomes NULL in the audit row. Confirmed via `CreateEnrichmentRequest` signature — `ExternalContactID *uuid.UUID`. Integration test (§5.4 below-threshold case) explicitly asserts the NULL outcome.
+5. **Google Contacts path regression.** Google uses `EnrichContactFromExternal` (auto variant) — now uses the new `methodDedupKey`. Since Google populates only emails/phones, the telegram branch in the helper is inert. Existing integration tests must pass unchanged.
+6. **`messageCounter` default wiring.** `NewPeerMatcher` currently defaults `messageCounter` to `messageRepo` implicitly (if the constructor does so); must verify the refactored constructor preserves this. If `messageCounter` is assigned in the constructor body, add back the assignment.
+
+### Open Questions
+
+1. **(Resolved in round 1.)** Matcher enrichment call-site: moved to `MatchPeer` per Codex.
+2. **Should `methodDedupKey` be exported?** Not yet — no cross-package consumer. If #182 rematch-service needs it, promote later.
+3. **Should `SyncMethodsFromExternal` skip `contact_enrichment` audit rows in the auto-match path?** Currently inherited from `enrichContactMethods`. Pro: auditability. Con: every automatic match writes an audit row. Keeping for now; revisit if noise is a problem post-deploy.
+
+---
+
+## 8. Review Log
+
+**Round 1 (Codex):** FAIL — 5 findings.
+1. Matcher call-site placement inside `markExternalContactMatched` was wrong (early-returns miss below-threshold peers and re-matches). **Fixed:** moved to `MatchPeer` orchestration in §3.7 with synthesized ExternalContact fallback.
+2. `enrichContactMethodsWithSelections` also has an `existingNormalized` value-only map at line 201 that needed updating alongside `externalValues`. **Fixed:** §3.3 Change A now updates both maps to type-scoped keys.
+3. Dedup-key rollout was partial across the two enrichment paths. **Fixed:** §3.3 Change A makes both paths use `methodDedupKey` consistently.
+4. Nil-safety + existing `matcher_test.go` struct-literal construction risked panics. **Fixed:** §3.6 documents nil-safety; §5.2 explicitly covers the nil-enricher case.
+5. Test plan needed phone-match (with/without username), raw `@`-handle consistency, idempotency under race. **Fixed:** §5.2 adds four new matcher-unit cases; §5.3 adds leading-`@` passthrough; §5.4 adds idempotency-under-re-run and enricher-error-does-not-break-match.
+Plus: race-condition PG `23505` handling was added via `isUniqueViolation` helper.
+
+**Round 2 (Codex):** FAIL — 1 remaining design gap.
+6. `ensureMethodsOnMatch` framed persisted-vs-synthesized as choose-one. If a stored `external_contact` pre-dates username capture or the user renamed their Telegram handle, the persisted row's `metadata.username` can be missing or stale while the current message carries the fresh value. Choose-one would suppress the telegram method creation in those cases. **Fixed:** §3.7 now merges — current-message `peerUsername` always overlays onto `metadata.username` when present, regardless of whether `external_contact` was persisted or synthesized. §5.2 adds three new sub-cases covering nil Metadata, gap-fill, and rename-overlay.
+(Round 2 also noted: file path was not on disk at review time — plan had been written to the main repo tree, not the worktree. Moved before round 3.)
+
+**Round 3 (Codex):** FAIL — 2 findings.
+7. Leading-`@` in link-flow selections was still broken because the helper emits bare handles and the validator compared raw `OriginalValue` strings. **Fixed:** §3.3 Change B uses `methodDedupKey` on both sides of the admission check so `"@JackALaing"` and `"JackALaing"` produce the same key. §3.3 Change C adds `canonicalizeMethodValue` to strip `@` from stored values, matching import-new behavior. §3.3 Change D defines the helper. §3.1 now calls the same helper internally, single source of truth.
+8. Synthesized-matcher audit row would have emitted a zero-UUID (not SQL NULL) because `recordEnrichment` unconditionally passes `&external.ID`. **Fixed:** §3.3.5 updates `recordEnrichment` to pass `nil` when `external.ID == uuid.Nil`. Existing callers (Google sync, link handler) always pass persisted IDs so their behavior is unchanged.
+
+**Round 4 (Codex):** FAIL — 1 trivial finding.
+9. Wrong Go module path in §3.1 import block (`github.com/spengrah/personalcrm/...`). **Fixed:** corrected to `personal-crm/backend/internal/repository` per `backend/go.mod`.

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -91,11 +91,16 @@ func main() {
 	noteRepo := repository.NewNoteRepository(database.Queries)
 	interactionRepo := repository.NewInteractionRepository(database.Queries)
 	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
+	enrichmentRepo := repository.NewEnrichmentRepository(database.Queries)
 
 	// Initialize services
 	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo)
 	noteService := service.NewNoteService(noteRepo, contactRepo)
 	importMatchService := service.NewImportMatchService(contactRepo)
+	// EnrichmentService is shared by the import handler (link/import flows) and
+	// the Telegram peer matcher (auto-match enrichment). Constructed at outer
+	// scope so both feature blocks share a single instance.
+	enrichmentService := service.NewEnrichmentService(contactRepo, contactMethodRepo, enrichmentRepo)
 
 	// Initialize external sync components (feature-flagged)
 	var syncService *service.SyncService
@@ -155,13 +160,12 @@ func main() {
 			logger.Info().Msg("Todoist OAuth not configured (TODOIST_CLIENT_ID and TODOIST_CLIENT_SECRET required)")
 		}
 
-		// Initialize external contact and enrichment repositories
+		// Initialize external contact repository
 		externalContactRepo = repository.NewExternalContactRepository(database.Queries)
-		enrichmentRepo := repository.NewEnrichmentRepository(database.Queries)
 
-		// Initialize identity and enrichment services
+		// Initialize identity service (enrichmentService is constructed at outer scope
+		// so the Telegram block can share it).
 		identityService := service.NewIdentityService(identityRepo)
-		enrichmentService := service.NewEnrichmentService(contactRepo, contactMethodRepo, enrichmentRepo)
 
 		// Register Google Contacts provider if OAuth is configured
 		if googleOAuthService != nil {
@@ -254,8 +258,6 @@ func main() {
 		tgIdentityRepo := repository.NewIdentityRepository(database.Queries)
 		tgIdentityService := service.NewIdentityService(tgIdentityRepo)
 		tgExternalContactRepo := repository.NewExternalContactRepository(database.Queries)
-		tgEnrichmentRepo := repository.NewEnrichmentRepository(database.Queries)
-		tgEnrichmentService := service.NewEnrichmentService(contactRepo, contactMethodRepo, tgEnrichmentRepo)
 
 		encryptor, err := crypto.NewTokenEncryptor(cfg.External.TokenEncryptionKey)
 		if err != nil {
@@ -274,7 +276,7 @@ func main() {
 			&cfg.Telegram,
 			tgIdentityService,
 			tgExternalContactRepo,
-			tgEnrichmentService,
+			enrichmentService,
 			interactionRepo,
 			contactService,
 			contactService,

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -254,6 +254,8 @@ func main() {
 		tgIdentityRepo := repository.NewIdentityRepository(database.Queries)
 		tgIdentityService := service.NewIdentityService(tgIdentityRepo)
 		tgExternalContactRepo := repository.NewExternalContactRepository(database.Queries)
+		tgEnrichmentRepo := repository.NewEnrichmentRepository(database.Queries)
+		tgEnrichmentService := service.NewEnrichmentService(contactRepo, contactMethodRepo, tgEnrichmentRepo)
 
 		encryptor, err := crypto.NewTokenEncryptor(cfg.External.TokenEncryptionKey)
 		if err != nil {
@@ -272,6 +274,7 @@ func main() {
 			&cfg.Telegram,
 			tgIdentityService,
 			tgExternalContactRepo,
+			tgEnrichmentService,
 			interactionRepo,
 			contactService,
 			contactService,

--- a/backend/internal/api/handlers/import.go
+++ b/backend/internal/api/handlers/import.go
@@ -346,7 +346,7 @@ func (h *ImportHandler) ImportContact(c *gin.Context) {
 	if len(req.SelectedMethods) > 0 {
 		methods = h.buildMethodsFromSelection(external, req.SelectedMethods)
 	} else {
-		methods = h.buildMethodsAuto(external)
+		methods = service.BuildMethodsFromExternal(external)
 	}
 
 	// Build create request
@@ -441,41 +441,6 @@ func (h *ImportHandler) buildMethodsFromSelection(external *repository.ExternalC
 			IsPrimary: isPrimary,
 		})
 		usedValues[key] = true
-	}
-
-	return methods
-}
-
-// buildMethodsAuto builds contact methods using automatic selection (legacy behavior)
-func (h *ImportHandler) buildMethodsAuto(external *repository.ExternalContact) []service.ContactMethodInput {
-	methods := make([]service.ContactMethodInput, 0)
-
-	// Handle emails - store all available emails
-	// Note: external email labels (work/home/etc.) are intentionally discarded.
-	for _, email := range external.Emails {
-		methods = append(methods, service.ContactMethodInput{
-			Type:  "email",
-			Value: email.Value,
-		})
-	}
-
-	// Handle phones - store all available phones
-	for _, phone := range external.Phones {
-		methods = append(methods, service.ContactMethodInput{
-			Type:  "phone",
-			Value: phone.Value,
-		})
-	}
-
-	// Handle Telegram username from metadata
-	if external.Source == "telegram" {
-		if username, ok := external.Metadata["username"].(string); ok && username != "" {
-			username = strings.TrimPrefix(username, "@")
-			methods = append(methods, service.ContactMethodInput{
-				Type:  "telegram",
-				Value: username,
-			})
-		}
 	}
 
 	return methods

--- a/backend/internal/service/enrichment.go
+++ b/backend/internal/service/enrichment.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -10,6 +11,7 @@ import (
 	"personal-crm/backend/internal/repository"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
 )
 
 // MethodSelection represents a user-selected method for enrichment
@@ -197,23 +199,25 @@ func (s *EnrichmentService) enrichContactMethodsWithSelections(
 		return err
 	}
 
-	// Build maps for existing methods (value -> method ID)
-	existingNormalized := make(map[string]bool)
-	existingMethodByNormalized := make(map[string]*repository.ContactMethod)
+	// Build maps for existing methods, keyed as (type + ":" + normalized).
+	// Type-scoped keys mirror the DB unique index (contact_id, type, value_normalized)
+	// so cross-type collisions (e.g., telegram:foo vs twitter:foo) stay distinct.
+	existingKeys := make(map[string]bool)
+	existingMethodByKey := make(map[string]*repository.ContactMethod)
 	for i := range existingMethods {
 		m := &existingMethods[i]
-		normalized := identity.Normalize(m.Value, mapMethodTypeToIdentifier(m.Type))
-		existingNormalized[normalized] = true
-		existingMethodByNormalized[normalized] = m
+		key := methodDedupKey(m.Type, m.Value)
+		existingKeys[key] = true
+		existingMethodByKey[key] = m
 	}
 
-	// Build map of available values from external contact
-	externalValues := make(map[string]bool)
-	for _, email := range external.Emails {
-		externalValues[email.Value] = true
-	}
-	for _, phone := range external.Phones {
-		externalValues[phone.Value] = true
+	// Build admissible-external lookup via the shared helper, keyed by
+	// methodDedupKey. Because the helper canonicalizes telegram handles
+	// (stripping leading '@'), both "@handle" and "handle" from the
+	// frontend produce the same dedup key and are both admitted.
+	externalKeys := make(map[string]bool)
+	for _, m := range BuildMethodsFromExternal(external) {
+		externalKeys[methodDedupKey(m.Type, m.Value)] = true
 	}
 
 	// Collect errors for reporting
@@ -225,35 +229,43 @@ func (s *EnrichmentService) enrichContactMethodsWithSelections(
 
 	// Process selected methods
 	for _, sel := range selectedMethods {
-		// Validate the value exists in external contact
-		if !externalValues[sel.OriginalValue] {
+		selKey := methodDedupKey(sel.Type, sel.OriginalValue)
+
+		// Validate the value exists in external contact (type-scoped normalized)
+		if !externalKeys[selKey] {
 			methodErrors = append(methodErrors, fmt.Sprintf("value %q not found in external contact", sel.OriginalValue))
 			continue
 		}
 
-		// Check if value is already in CRM (normalized)
-		identType := mapMethodTypeToIdentifier(sel.Type)
-		normalized := identity.Normalize(sel.OriginalValue, identType)
-		if existingNormalized[normalized] {
+		if existingKeys[selKey] {
 			// Method already exists - check if we need to update primary status
 			if sel.IsPrimary {
-				existingMethod := existingMethodByNormalized[normalized]
-				if existingMethod != nil {
+				if existingMethod := existingMethodByKey[selKey]; existingMethod != nil {
 					existingPrimaryMethodID = &existingMethod.ID
 				}
 			}
 			continue // Already have this value
 		}
 
-		// Add the method
+		// Canonicalize the stored value to match storage convention across paths:
+		//   - telegram/twitter/discord: strip leading '@' and trim whitespace (bare handle)
+		//   - email/phone: preserve as-is
+		// Mirrors buildMethodsAuto's import-new behavior so link-flow storage
+		// is consistent with import-new storage.
+		storedValue := canonicalizeMethodValue(sel.Type, sel.OriginalValue)
+
 		newMethod, err := s.methodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
 			ContactID: contact.ID,
 			Type:      sel.Type,
-			Value:     sel.OriginalValue,
+			Value:     storedValue,
 			IsPrimary: false, // We'll update primary status separately
 		})
 		if err != nil {
-			methodErrors = append(methodErrors, fmt.Sprintf("failed to add method %s: %v", sel.OriginalValue, err))
+			if isUniqueViolation(err) {
+				existingKeys[selKey] = true
+				continue
+			}
+			methodErrors = append(methodErrors, fmt.Sprintf("failed to add method %s: %v", storedValue, err))
 			continue
 		}
 
@@ -262,8 +274,10 @@ func (s *EnrichmentService) enrichContactMethodsWithSelections(
 			newPrimaryMethodID = &newMethod.ID
 		}
 
-		s.recordEnrichment(ctx, contact.ID, external, "method:"+sel.Type+":"+normalized, sel.OriginalValue)
-		existingNormalized[normalized] = true
+		s.recordEnrichment(ctx, contact.ID, external,
+			"method:"+sel.Type+":"+identity.Normalize(storedValue, mapMethodTypeToIdentifier(sel.Type)),
+			storedValue)
+		existingKeys[selKey] = true
 	}
 
 	// Handle primary method updates - first clear any existing primary, then set the new one.
@@ -301,77 +315,77 @@ func (s *EnrichmentService) enrichContactMethodsWithSelections(
 	return nil
 }
 
-// enrichContactMethods adds missing contact methods from external contact
+// enrichContactMethods adds missing contact methods from external contact.
+// Uses BuildMethodsFromExternal as the single source of truth for emitting
+// source-specific methods (emails, phones, telegram username). Dedup is
+// type-scoped normalized to match the DB unique index on
+// (contact_id, type, value_normalized).
 func (s *EnrichmentService) enrichContactMethods(
 	ctx context.Context,
 	contact *repository.Contact,
 	external *repository.ExternalContact,
 ) error {
-	// Get existing methods
 	existingMethods, err := s.methodRepo.ListContactMethodsByContact(ctx, contact.ID)
 	if err != nil {
 		return err
 	}
 
-	// Build set of normalized existing values
 	existingSet := make(map[string]bool)
 	for _, m := range existingMethods {
-		normalized := identity.Normalize(m.Value, mapMethodTypeToIdentifier(m.Type))
-		existingSet[normalized] = true
+		existingSet[methodDedupKey(m.Type, m.Value)] = true
 	}
 
-	// Add missing emails
-	for _, email := range external.Emails {
-		normalized := identity.Normalize(email.Value, identity.IdentifierTypeEmail)
-		if existingSet[normalized] {
-			continue // Already have this email
+	for _, input := range BuildMethodsFromExternal(external) {
+		key := methodDedupKey(input.Type, input.Value)
+		if existingSet[key] {
+			continue
 		}
-
-		methodType := string(repository.ContactMethodEmail)
-
 		_, err := s.methodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
 			ContactID: contact.ID,
-			Type:      methodType,
-			Value:     email.Value,
+			Type:      input.Type,
+			Value:     input.Value,
 			IsPrimary: false, // Never set primary for enriched methods
 		})
 		if err != nil {
-			logger.Warn().Err(err).Str("email", email.Value).Msg("failed to add email from enrichment")
+			if isUniqueViolation(err) {
+				// Concurrent insert — already there, treat as success
+				existingSet[key] = true
+				continue
+			}
+			logger.Warn().Err(err).
+				Str("type", input.Type).
+				Str("value", input.Value).
+				Msg("failed to add method from enrichment")
 			continue
 		}
-
-		s.recordEnrichment(ctx, contact.ID, external, "method:"+methodType+":"+normalized, email.Value)
-		existingSet[normalized] = true // Mark as added
+		s.recordEnrichment(ctx, contact.ID, external,
+			"method:"+input.Type+":"+identity.Normalize(input.Value, mapMethodTypeToIdentifier(input.Type)),
+			input.Value)
+		existingSet[key] = true
 	}
-
-	// Add missing phones
-	for _, phone := range external.Phones {
-		normalized := identity.Normalize(phone.Value, identity.IdentifierTypePhone)
-		if existingSet[normalized] {
-			continue // Already have this phone
-		}
-
-		methodType := string(repository.ContactMethodPhone)
-
-		_, err := s.methodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
-			ContactID: contact.ID,
-			Type:      methodType,
-			Value:     phone.Value,
-			IsPrimary: false,
-		})
-		if err != nil {
-			logger.Warn().Err(err).Str("phone", phone.Value).Msg("failed to add phone from enrichment")
-			continue
-		}
-
-		s.recordEnrichment(ctx, contact.ID, external, "method:phone:"+normalized, phone.Value)
-		existingSet[normalized] = true
-	}
-
 	return nil
 }
 
-// recordEnrichment records that a field was enriched from an external source
+// methodDedupKey returns the dedup key used to compare an incoming method
+// against existing methods on a contact. Mirrors the DB unique index shape
+// (contact_id, type, value_normalized) — without type scoping, cross-type
+// duplicates like telegram:foo vs twitter:foo would collide incorrectly
+// because they normalize to the same handle but live in different type buckets.
+func methodDedupKey(methodType, value string) string {
+	return methodType + ":" + identity.Normalize(value, mapMethodTypeToIdentifier(methodType))
+}
+
+// isUniqueViolation returns true if err is a PostgreSQL unique_violation (23505).
+// Used to treat concurrent-insert races as idempotent no-ops.
+func isUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23505"
+}
+
+// recordEnrichment records that a field was enriched from an external source.
+// Passes ExternalContactID=nil when external.ID is the zero UUID so matcher
+// paths that synthesize an *ExternalContact (no persisted row for
+// below-threshold peers) produce SQL NULL in the audit, not a zero UUID.
 func (s *EnrichmentService) recordEnrichment(
 	ctx context.Context,
 	contactID uuid.UUID,
@@ -379,17 +393,40 @@ func (s *EnrichmentService) recordEnrichment(
 	field string,
 	value string,
 ) {
+	var externalContactID *uuid.UUID
+	if external.ID != uuid.Nil {
+		externalContactID = &external.ID
+	}
 	_, err := s.enrichmentRepo.Create(ctx, repository.CreateEnrichmentRequest{
 		ContactID:         contactID,
 		Source:            external.Source,
 		AccountID:         external.AccountID,
 		Field:             field,
-		ExternalContactID: &external.ID,
+		ExternalContactID: externalContactID,
 		OriginalValue:     &value,
 	})
 	if err != nil {
 		logger.Warn().Err(err).Str("field", field).Msg("failed to record enrichment")
 	}
+}
+
+// SyncMethodsFromExternal adds any missing contact methods from an
+// ExternalContact to the given CRM contact. Unlike EnrichContactFromExternal,
+// it does NOT touch profile fields (photo, birthday, location, name, cadence).
+// Intended for auto-match flows where silent profile overwrites are undesirable.
+//
+// Audit rows are written via recordEnrichment. Idempotent: duplicate methods
+// (either via normalized-value dedup or PG unique-violation race) are no-ops.
+func (s *EnrichmentService) SyncMethodsFromExternal(
+	ctx context.Context,
+	crmContactID uuid.UUID,
+	external *repository.ExternalContact,
+) error {
+	contact, err := s.contactRepo.GetContact(ctx, crmContactID)
+	if err != nil {
+		return fmt.Errorf("get contact for method sync: %w", err)
+	}
+	return s.enrichContactMethods(ctx, contact, external)
 }
 
 // HasEnrichment checks if a field has been enriched for a contact

--- a/backend/internal/service/enrichment.go
+++ b/backend/internal/service/enrichment.go
@@ -267,12 +267,21 @@ func (s *EnrichmentService) enrichContactMethodsWithSelections(
 				// set, otherwise the user's primary selection is silently dropped.
 				if sel.IsPrimary {
 					raced, refetchErr := s.methodRepo.ListContactMethodsByContact(ctx, contact.ID)
-					if refetchErr == nil {
+					if refetchErr != nil {
+						methodErrors = append(methodErrors,
+							fmt.Sprintf("recover raced primary for %s: %v", storedValue, refetchErr))
+					} else {
+						var recovered bool
 						for i := range raced {
 							if methodDedupKey(raced[i].Type, raced[i].Value) == selKey {
 								existingPrimaryMethodID = &raced[i].ID
+								recovered = true
 								break
 							}
+						}
+						if !recovered {
+							methodErrors = append(methodErrors,
+								fmt.Sprintf("raced row for %s not visible after refetch — primary selection dropped", storedValue))
 						}
 					}
 				}

--- a/backend/internal/service/enrichment.go
+++ b/backend/internal/service/enrichment.go
@@ -262,6 +262,20 @@ func (s *EnrichmentService) enrichContactMethodsWithSelections(
 		})
 		if err != nil {
 			if isUniqueViolation(err) {
+				// Concurrent insert won the race — refetch the contact's methods
+				// to recover the raced row's ID. Required when sel.IsPrimary is
+				// set, otherwise the user's primary selection is silently dropped.
+				if sel.IsPrimary {
+					raced, refetchErr := s.methodRepo.ListContactMethodsByContact(ctx, contact.ID)
+					if refetchErr == nil {
+						for i := range raced {
+							if methodDedupKey(raced[i].Type, raced[i].Value) == selKey {
+								existingPrimaryMethodID = &raced[i].ID
+								break
+							}
+						}
+					}
+				}
 				existingKeys[selKey] = true
 				continue
 			}

--- a/backend/internal/service/external_methods.go
+++ b/backend/internal/service/external_methods.go
@@ -1,0 +1,54 @@
+package service
+
+import (
+	"strings"
+
+	"personal-crm/backend/internal/repository"
+)
+
+// BuildMethodsFromExternal converts an ExternalContact into the canonical
+// list of ContactMethodInput entries. Single source of truth for translating
+// source-specific fields (emails, phones, metadata.username) into the shape
+// the contact / enrichment services consume.
+//
+// Callers are responsible for deduplicating against existing contact methods
+// on the target contact — this function returns everything the external
+// contact carries, in a stable order: emails, then phones, then telegram.
+func BuildMethodsFromExternal(external *repository.ExternalContact) []ContactMethodInput {
+	if external == nil {
+		return nil
+	}
+	methods := make([]ContactMethodInput, 0, len(external.Emails)+len(external.Phones)+1)
+
+	for _, email := range external.Emails {
+		methods = append(methods, ContactMethodInput{Type: "email", Value: email.Value})
+	}
+	for _, phone := range external.Phones {
+		methods = append(methods, ContactMethodInput{Type: "phone", Value: phone.Value})
+	}
+
+	if external.Source == "telegram" {
+		if username, ok := external.Metadata["username"].(string); ok {
+			canonical := canonicalizeMethodValue("telegram", username)
+			if canonical != "" {
+				methods = append(methods, ContactMethodInput{Type: "telegram", Value: canonical})
+			}
+		}
+	}
+
+	return methods
+}
+
+// canonicalizeMethodValue converts a user- or frontend-supplied raw method
+// value into the canonical form stored in contact_method.value. For
+// handle-based types (telegram/twitter/discord), strips leading '@' and
+// trims whitespace. Does NOT lowercase — storage preserves user casing;
+// value_normalized in the DB carries the lowercased form via the trigger.
+func canonicalizeMethodValue(methodType, rawValue string) string {
+	switch methodType {
+	case "telegram", "twitter", "discord":
+		return strings.TrimPrefix(strings.TrimSpace(rawValue), "@")
+	default:
+		return rawValue
+	}
+}

--- a/backend/internal/service/external_methods_test.go
+++ b/backend/internal/service/external_methods_test.go
@@ -1,0 +1,143 @@
+package service
+
+import (
+	"testing"
+
+	"personal-crm/backend/internal/repository"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildMethodsFromExternal_Nil(t *testing.T) {
+	assert.Nil(t, BuildMethodsFromExternal(nil))
+}
+
+func TestBuildMethodsFromExternal_Empty(t *testing.T) {
+	got := BuildMethodsFromExternal(&repository.ExternalContact{Source: "telegram"})
+	assert.Empty(t, got)
+}
+
+func TestBuildMethodsFromExternal_EmailsOnly(t *testing.T) {
+	ext := &repository.ExternalContact{
+		Source: "google",
+		Emails: []repository.EmailEntry{
+			{Value: "a@example.com"},
+			{Value: "b@example.com"},
+		},
+	}
+	got := BuildMethodsFromExternal(ext)
+	assert.Equal(t, []ContactMethodInput{
+		{Type: "email", Value: "a@example.com"},
+		{Type: "email", Value: "b@example.com"},
+	}, got)
+}
+
+func TestBuildMethodsFromExternal_PhonesOnly(t *testing.T) {
+	ext := &repository.ExternalContact{
+		Source: "google",
+		Phones: []repository.PhoneEntry{{Value: "+15551234"}},
+	}
+	got := BuildMethodsFromExternal(ext)
+	assert.Equal(t, []ContactMethodInput{{Type: "phone", Value: "+15551234"}}, got)
+}
+
+func TestBuildMethodsFromExternal_TelegramWithAt(t *testing.T) {
+	ext := &repository.ExternalContact{
+		Source:   "telegram",
+		Metadata: map[string]any{"username": "@DaleDobeck"},
+	}
+	got := BuildMethodsFromExternal(ext)
+	assert.Equal(t, []ContactMethodInput{{Type: "telegram", Value: "DaleDobeck"}}, got)
+}
+
+func TestBuildMethodsFromExternal_TelegramWithoutAt(t *testing.T) {
+	ext := &repository.ExternalContact{
+		Source:   "telegram",
+		Metadata: map[string]any{"username": "DaleDobeck"},
+	}
+	got := BuildMethodsFromExternal(ext)
+	assert.Equal(t, []ContactMethodInput{{Type: "telegram", Value: "DaleDobeck"}}, got)
+}
+
+func TestBuildMethodsFromExternal_TelegramEmptyUsername(t *testing.T) {
+	ext := &repository.ExternalContact{
+		Source:   "telegram",
+		Metadata: map[string]any{"username": ""},
+	}
+	got := BuildMethodsFromExternal(ext)
+	assert.Empty(t, got)
+}
+
+func TestBuildMethodsFromExternal_TelegramWhitespaceOnly(t *testing.T) {
+	ext := &repository.ExternalContact{
+		Source:   "telegram",
+		Metadata: map[string]any{"username": "@  "},
+	}
+	got := BuildMethodsFromExternal(ext)
+	assert.Empty(t, got)
+}
+
+func TestBuildMethodsFromExternal_TelegramMissingUsernameKey(t *testing.T) {
+	ext := &repository.ExternalContact{
+		Source:   "telegram",
+		Metadata: map[string]any{"other_key": "foo"},
+	}
+	got := BuildMethodsFromExternal(ext)
+	assert.Empty(t, got)
+}
+
+func TestBuildMethodsFromExternal_TelegramNonStringUsername(t *testing.T) {
+	ext := &repository.ExternalContact{
+		Source:   "telegram",
+		Metadata: map[string]any{"username": 42},
+	}
+	got := BuildMethodsFromExternal(ext)
+	assert.Empty(t, got)
+}
+
+func TestBuildMethodsFromExternal_NonTelegramSourceWithUsername(t *testing.T) {
+	ext := &repository.ExternalContact{
+		Source:   "google",
+		Metadata: map[string]any{"username": "@shouldBeIgnored"},
+	}
+	got := BuildMethodsFromExternal(ext)
+	assert.Empty(t, got)
+}
+
+func TestBuildMethodsFromExternal_AllCombined_StableOrder(t *testing.T) {
+	ext := &repository.ExternalContact{
+		Source:   "telegram",
+		Emails:   []repository.EmailEntry{{Value: "a@example.com"}},
+		Phones:   []repository.PhoneEntry{{Value: "+15551234"}},
+		Metadata: map[string]any{"username": "@handle"},
+	}
+	got := BuildMethodsFromExternal(ext)
+	assert.Equal(t, []ContactMethodInput{
+		{Type: "email", Value: "a@example.com"},
+		{Type: "phone", Value: "+15551234"},
+		{Type: "telegram", Value: "handle"},
+	}, got)
+}
+
+func TestCanonicalizeMethodValue(t *testing.T) {
+	tests := []struct {
+		name       string
+		methodType string
+		raw        string
+		want       string
+	}{
+		{"telegram strips @", "telegram", "@handle", "handle"},
+		{"telegram bare passthrough", "telegram", "handle", "handle"},
+		{"telegram trims whitespace", "telegram", "  @handle  ", "handle"},
+		{"telegram whitespace only becomes empty", "telegram", "@  ", ""},
+		{"twitter strips @", "twitter", "@user", "user"},
+		{"discord strips @", "discord", "@user", "user"},
+		{"email passthrough preserves @", "email", "foo@example.com", "foo@example.com"},
+		{"phone passthrough", "phone", "+15551234", "+15551234"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, canonicalizeMethodValue(tt.methodType, tt.raw))
+		})
+	}
+}

--- a/backend/internal/service/external_methods_test.go
+++ b/backend/internal/service/external_methods_test.go
@@ -1,10 +1,13 @@
 package service
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
 	"personal-crm/backend/internal/repository"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -117,6 +120,26 @@ func TestBuildMethodsFromExternal_AllCombined_StableOrder(t *testing.T) {
 		{Type: "phone", Value: "+15551234"},
 		{Type: "telegram", Value: "handle"},
 	}, got)
+}
+
+func TestIsUniqueViolation(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"plain error", errors.New("some failure"), false},
+		{"pg 23505 directly", &pgconn.PgError{Code: "23505"}, true},
+		{"pg 23505 wrapped via fmt.Errorf %w", fmt.Errorf("create failed: %w", &pgconn.PgError{Code: "23505"}), true},
+		{"pg 23503 (foreign key) is not 23505", &pgconn.PgError{Code: "23503"}, false},
+		{"pg 23502 (not null) is not 23505", &pgconn.PgError{Code: "23502"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isUniqueViolation(tt.err))
+		})
+	}
 }
 
 func TestCanonicalizeMethodValue(t *testing.T) {

--- a/backend/internal/telegram/manager.go
+++ b/backend/internal/telegram/manager.go
@@ -88,12 +88,13 @@ func NewTelegramManager(
 	cfg *config.TelegramConfig,
 	identityService identityMatcher,
 	externalContactRepo externalContactUpserter,
+	enricher contactEnricher,
 	interactionRepo *repository.InteractionRepository,
 	recorder interactionRecorder,
 	promoter interactionPromoter,
 	extender interactionExtender,
 ) *TelegramManager {
-	peerMatcher := NewPeerMatcher(identityService, messageRepo, externalContactRepo, cfg.DiscoveryMinMessages)
+	peerMatcher := NewPeerMatcher(identityService, messageRepo, externalContactRepo, enricher, cfg.DiscoveryMinMessages)
 	aggregationEngine := NewAggregationEngine(
 		cfg.BurstWindowHours, cfg.ReplyBridgeHours,
 		messageRepo, interactionRepo,

--- a/backend/internal/telegram/matcher.go
+++ b/backend/internal/telegram/matcher.go
@@ -361,9 +361,11 @@ func (m *PeerMatcher) ensureMethodsOnMatch(ctx context.Context, contactID uuid.U
 
 	external, err := m.externalContactRepo.GetBySource(ctx, "telegram", peerIDStr, nil)
 	if err != nil {
+		// Transient repository error — bail out rather than synthesize.
+		// Synthesizing here would risk dropping persisted emails/phones and
+		// emitting a NULL external_contact_id audit row when a real row exists.
 		log.Warn().Err(err).Int64("peer_user_id", peerUserID).Msg("telegram: get external_contact for method sync failed")
-		// fall through — synthesize below
-		external = nil
+		return
 	}
 	if external == nil {
 		external = &repository.ExternalContact{

--- a/backend/internal/telegram/matcher.go
+++ b/backend/internal/telegram/matcher.go
@@ -33,12 +33,19 @@ type peerMessageCounter interface {
 	CountMessagesByPeerID(ctx context.Context, peerUserID int64) (*repository.PeerMessageCount, error)
 }
 
+// contactEnricher performs narrow method-only enrichment on a bound CRM
+// contact. Satisfied by *service.EnrichmentService. May be nil in tests.
+type contactEnricher interface {
+	SyncMethodsFromExternal(ctx context.Context, crmContactID uuid.UUID, external *repository.ExternalContact) error
+}
+
 // PeerMatcher matches Telegram peers to CRM contacts using the identity service.
 type PeerMatcher struct {
 	identityService     identityMatcher
 	messageRepo         *repository.TelegramMessageRepository
 	messageCounter      peerMessageCounter // defaults to messageRepo; separate for testing
 	externalContactRepo externalContactUpserter
+	enricher            contactEnricher // may be nil (tests)
 	discoveryMinMsgs    int
 }
 
@@ -47,6 +54,7 @@ func NewPeerMatcher(
 	identityService identityMatcher,
 	messageRepo *repository.TelegramMessageRepository,
 	externalContactRepo externalContactUpserter,
+	enricher contactEnricher,
 	discoveryMinMsgs int,
 ) *PeerMatcher {
 	return &PeerMatcher{
@@ -54,6 +62,7 @@ func NewPeerMatcher(
 		messageRepo:         messageRepo,
 		messageCounter:      messageRepo, // default: use the same repo
 		externalContactRepo: externalContactRepo,
+		enricher:            enricher,
 		discoveryMinMsgs:    discoveryMinMsgs,
 	}
 }
@@ -83,6 +92,7 @@ func (m *PeerMatcher) MatchPeer(ctx context.Context, peerUserID int64, peerUsern
 				}
 			}
 			m.markExternalContactMatched(ctx, peerUserID, *result.ContactID)
+			m.ensureMethodsOnMatch(ctx, *result.ContactID, peerUserID, peerUsername)
 			log.Info().
 				Int64("peer_user_id", peerUserID).
 				Str("contact_id", result.ContactID.String()).
@@ -126,6 +136,8 @@ func (m *PeerMatcher) MatchPeer(ctx context.Context, peerUserID int64, peerUsern
 					log.Warn().Err(linkErr).Msg("telegram: failed to link telegram identity after phone match")
 				}
 			}
+
+			m.ensureMethodsOnMatch(ctx, *result.ContactID, peerUserID, peerUsername)
 
 			log.Info().
 				Int64("peer_user_id", peerUserID).
@@ -327,6 +339,54 @@ func (m *PeerMatcher) OnPeerLinked(ctx context.Context, peerUserID int64, peerUs
 		Str("contact_id", contactID.String()).
 		Msg("telegram: peer linked via import, messages updated")
 	return nil
+}
+
+// ensureMethodsOnMatch syncs contact methods from known peer data onto the
+// matched CRM contact. Called after every successful identity match in
+// MatchPeer, regardless of discovery threshold or prior match status.
+//
+// Data sourcing: reads the persisted external_contact if present (preserves
+// audit linkage + any stored emails/phones). Whether persisted or synthesized,
+// the current-message peerUsername overlays onto metadata.username when
+// present — the current message is the freshest source of the peer's handle
+// and wins over any stored value. This handles both handle-renames and gaps
+// in rows that predate username capture.
+//
+// Errors are logged at warn and do NOT fail the match.
+func (m *PeerMatcher) ensureMethodsOnMatch(ctx context.Context, contactID uuid.UUID, peerUserID int64, peerUsername *string) {
+	if m.enricher == nil {
+		return
+	}
+	peerIDStr := strconv.FormatInt(peerUserID, 10)
+
+	external, err := m.externalContactRepo.GetBySource(ctx, "telegram", peerIDStr, nil)
+	if err != nil {
+		log.Warn().Err(err).Int64("peer_user_id", peerUserID).Msg("telegram: get external_contact for method sync failed")
+		// fall through — synthesize below
+		external = nil
+	}
+	if external == nil {
+		external = &repository.ExternalContact{
+			Source:   "telegram",
+			SourceID: peerIDStr,
+			Metadata: map[string]any{},
+		}
+	} else if external.Metadata == nil {
+		external.Metadata = map[string]any{}
+	}
+
+	// Merge: current-message peerUsername wins over any stored metadata.username.
+	// Safe to mutate in place — GetBySource returns a fresh instance per call.
+	if peerUsername != nil && *peerUsername != "" {
+		external.Metadata["username"] = "@" + *peerUsername
+	}
+
+	if err := m.enricher.SyncMethodsFromExternal(ctx, contactID, external); err != nil {
+		log.Warn().Err(err).
+			Str("contact_id", contactID.String()).
+			Int64("peer_user_id", peerUserID).
+			Msg("telegram: sync methods from external failed")
+	}
 }
 
 // markExternalContactMatched updates any existing external_contact for this peer to "matched" status.

--- a/backend/internal/telegram/matcher_test.go
+++ b/backend/internal/telegram/matcher_test.go
@@ -386,3 +386,311 @@ func TestUpdateDiscoveryCandidatesForPeer_EmptyStringsTreatedAsNil(t *testing.T)
 }
 
 func ptr(s string) *string { return &s }
+
+// --- Enrichment-on-match coverage ---
+
+type capturedSync struct {
+	contactID uuid.UUID
+	external  *repository.ExternalContact
+}
+
+type mockContactEnricher struct {
+	captured []capturedSync
+	err      error
+}
+
+func (m *mockContactEnricher) SyncMethodsFromExternal(_ context.Context, contactID uuid.UUID, external *repository.ExternalContact) error {
+	// Snapshot the external pointer's metadata to detect mutation after the fact
+	// being called. We just record the pointer and current map keys.
+	m.captured = append(m.captured, capturedSync{contactID: contactID, external: external})
+	return m.err
+}
+
+func TestMatchPeer_UsernameMatch_FiresEnricher(t *testing.T) {
+	contactID := uuid.New()
+	identityMock := &mockIdentityMatcher{
+		results: map[string]*service.MatchResult{
+			"alice": {ContactID: &contactID, MatchType: repository.MatchTypeExact},
+		},
+	}
+	enricher := &mockContactEnricher{}
+	matcher := &PeerMatcher{
+		identityService:     identityMock,
+		externalContactRepo: &mockExternalContactUpserter{}, // GetBySource returns nil
+		enricher:            enricher,
+		discoveryMinMsgs:    3,
+	}
+
+	username := "alice"
+	result, err := matcher.MatchPeer(context.Background(), 12345, &username, ptr("Alice"), nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, contactID, *result)
+
+	require.Len(t, enricher.captured, 1)
+	assert.Equal(t, contactID, enricher.captured[0].contactID)
+	assert.Equal(t, "@alice", enricher.captured[0].external.Metadata["username"])
+}
+
+func TestMatchPeer_PhoneMatchWithUsername_FiresEnricher(t *testing.T) {
+	contactID := uuid.New()
+	identityMock := &mockIdentityMatcher{
+		results: map[string]*service.MatchResult{
+			"bob":          {MatchType: repository.MatchTypeUnmatched},
+			"+15551234567": {ContactID: &contactID, MatchType: repository.MatchTypeExact},
+		},
+	}
+	enricher := &mockContactEnricher{}
+	matcher := &PeerMatcher{
+		identityService:     identityMock,
+		externalContactRepo: &mockExternalContactUpserter{},
+		enricher:            enricher,
+		discoveryMinMsgs:    3,
+	}
+
+	username := "bob"
+	phone := "+15551234567"
+	result, err := matcher.MatchPeer(context.Background(), 12345, &username, ptr("Bob"), nil, &phone)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, enricher.captured, 1)
+	assert.Equal(t, contactID, enricher.captured[0].contactID)
+	assert.Equal(t, "@bob", enricher.captured[0].external.Metadata["username"])
+}
+
+func TestMatchPeer_PhoneMatchWithoutUsername_NoUsernameInMetadata(t *testing.T) {
+	contactID := uuid.New()
+	identityMock := &mockIdentityMatcher{
+		results: map[string]*service.MatchResult{
+			"+15551234567": {ContactID: &contactID, MatchType: repository.MatchTypeExact},
+		},
+	}
+	enricher := &mockContactEnricher{}
+	matcher := &PeerMatcher{
+		identityService:     identityMock,
+		externalContactRepo: &mockExternalContactUpserter{},
+		enricher:            enricher,
+		discoveryMinMsgs:    3,
+	}
+
+	phone := "+15551234567"
+	result, err := matcher.MatchPeer(context.Background(), 12345, nil, nil, nil, &phone)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, enricher.captured, 1)
+	_, hasUsername := enricher.captured[0].external.Metadata["username"]
+	assert.False(t, hasUsername, "no username key when peerUsername is nil")
+}
+
+func TestMatchPeer_Unmatched_NoEnricherCall(t *testing.T) {
+	identityMock := &mockIdentityMatcher{results: map[string]*service.MatchResult{}}
+	enricher := &mockContactEnricher{}
+	matcher := &PeerMatcher{
+		identityService:     identityMock,
+		externalContactRepo: &mockExternalContactUpserter{},
+		enricher:            enricher,
+		discoveryMinMsgs:    3,
+	}
+
+	username := "nobody"
+	result, err := matcher.MatchPeer(context.Background(), 12345, &username, ptr("Nobody"), nil, nil)
+	require.NoError(t, err)
+	assert.Nil(t, result)
+	assert.Empty(t, enricher.captured)
+}
+
+func TestMatchPeer_NilEnricher_NoPanic(t *testing.T) {
+	contactID := uuid.New()
+	identityMock := &mockIdentityMatcher{
+		results: map[string]*service.MatchResult{
+			"alice": {ContactID: &contactID, MatchType: repository.MatchTypeExact},
+		},
+	}
+	matcher := &PeerMatcher{
+		identityService:     identityMock,
+		externalContactRepo: &mockExternalContactUpserter{},
+		enricher:            nil,
+		discoveryMinMsgs:    3,
+	}
+
+	username := "alice"
+	result, err := matcher.MatchPeer(context.Background(), 12345, &username, ptr("Alice"), nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, contactID, *result)
+}
+
+func TestMatchPeer_EnricherError_DoesNotFailMatch(t *testing.T) {
+	contactID := uuid.New()
+	identityMock := &mockIdentityMatcher{
+		results: map[string]*service.MatchResult{
+			"alice": {ContactID: &contactID, MatchType: repository.MatchTypeExact},
+		},
+	}
+	enricher := &mockContactEnricher{err: assert.AnError}
+	matcher := &PeerMatcher{
+		identityService:     identityMock,
+		externalContactRepo: &mockExternalContactUpserter{},
+		enricher:            enricher,
+		discoveryMinMsgs:    3,
+	}
+
+	username := "alice"
+	result, err := matcher.MatchPeer(context.Background(), 12345, &username, ptr("Alice"), nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, contactID, *result)
+}
+
+func TestMatchPeer_PersistedExternalPreferred(t *testing.T) {
+	contactID := uuid.New()
+	persistedID := uuid.New()
+	identityMock := &mockIdentityMatcher{
+		results: map[string]*service.MatchResult{
+			"newhandle": {ContactID: &contactID, MatchType: repository.MatchTypeExact},
+		},
+	}
+	enricher := &mockContactEnricher{}
+	matcher := &PeerMatcher{
+		identityService: identityMock,
+		externalContactRepo: &mockExternalContactUpserter{
+			getResult: &repository.ExternalContact{
+				ID:          persistedID,
+				Source:      "telegram",
+				SourceID:    "12345",
+				Emails:      []repository.EmailEntry{{Value: "stored@example.com"}},
+				MatchStatus: repository.MatchStatusUnmatched,
+				Metadata:    map[string]any{"username": "@oldhandle"},
+			},
+		},
+		enricher:         enricher,
+		discoveryMinMsgs: 3,
+	}
+
+	username := "newhandle"
+	_, err := matcher.MatchPeer(context.Background(), 12345, &username, ptr("New"), nil, nil)
+	require.NoError(t, err)
+	require.Len(t, enricher.captured, 1)
+	got := enricher.captured[0].external
+	assert.Equal(t, persistedID, got.ID)
+	// Original emails preserved
+	require.Len(t, got.Emails, 1)
+	assert.Equal(t, "stored@example.com", got.Emails[0].Value)
+	// Current message wins for username
+	assert.Equal(t, "@newhandle", got.Metadata["username"])
+}
+
+func TestMatchPeer_AbsentExternal_Synthesized(t *testing.T) {
+	contactID := uuid.New()
+	identityMock := &mockIdentityMatcher{
+		results: map[string]*service.MatchResult{
+			"alice": {ContactID: &contactID, MatchType: repository.MatchTypeExact},
+		},
+	}
+	enricher := &mockContactEnricher{}
+	matcher := &PeerMatcher{
+		identityService:     identityMock,
+		externalContactRepo: &mockExternalContactUpserter{}, // getResult: nil
+		enricher:            enricher,
+		discoveryMinMsgs:    3,
+	}
+
+	username := "alice"
+	_, err := matcher.MatchPeer(context.Background(), 12345, &username, ptr("Alice"), nil, nil)
+	require.NoError(t, err)
+	require.Len(t, enricher.captured, 1)
+	got := enricher.captured[0].external
+	assert.Equal(t, uuid.Nil, got.ID)
+	assert.Equal(t, "telegram", got.Source)
+	assert.Equal(t, "12345", got.SourceID)
+	assert.Equal(t, "@alice", got.Metadata["username"])
+}
+
+func TestMatchPeer_PersistedNilMetadata_Initialized(t *testing.T) {
+	contactID := uuid.New()
+	identityMock := &mockIdentityMatcher{
+		results: map[string]*service.MatchResult{
+			"alice": {ContactID: &contactID, MatchType: repository.MatchTypeExact},
+		},
+	}
+	enricher := &mockContactEnricher{}
+	matcher := &PeerMatcher{
+		identityService: identityMock,
+		externalContactRepo: &mockExternalContactUpserter{
+			getResult: &repository.ExternalContact{
+				ID:          uuid.New(),
+				Source:      "telegram",
+				SourceID:    "12345",
+				Metadata:    nil,
+				MatchStatus: repository.MatchStatusUnmatched,
+			},
+		},
+		enricher:         enricher,
+		discoveryMinMsgs: 3,
+	}
+
+	username := "alice"
+	_, err := matcher.MatchPeer(context.Background(), 12345, &username, ptr("Alice"), nil, nil)
+	require.NoError(t, err)
+	require.Len(t, enricher.captured, 1)
+	assert.Equal(t, "@alice", enricher.captured[0].external.Metadata["username"])
+}
+
+func TestMatchPeer_PersistedEmptyMetadata_GapFilled(t *testing.T) {
+	contactID := uuid.New()
+	identityMock := &mockIdentityMatcher{
+		results: map[string]*service.MatchResult{
+			"alice": {ContactID: &contactID, MatchType: repository.MatchTypeExact},
+		},
+	}
+	enricher := &mockContactEnricher{}
+	matcher := &PeerMatcher{
+		identityService: identityMock,
+		externalContactRepo: &mockExternalContactUpserter{
+			getResult: &repository.ExternalContact{
+				ID:          uuid.New(),
+				Source:      "telegram",
+				SourceID:    "12345",
+				Metadata:    map[string]any{},
+				MatchStatus: repository.MatchStatusUnmatched,
+			},
+		},
+		enricher:         enricher,
+		discoveryMinMsgs: 3,
+	}
+
+	username := "alice"
+	_, err := matcher.MatchPeer(context.Background(), 12345, &username, ptr("Alice"), nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "@alice", enricher.captured[0].external.Metadata["username"])
+}
+
+func TestMatchPeer_NoUsernameAnywhere_NoUsernameWritten(t *testing.T) {
+	contactID := uuid.New()
+	identityMock := &mockIdentityMatcher{
+		results: map[string]*service.MatchResult{
+			"+15551234567": {ContactID: &contactID, MatchType: repository.MatchTypeExact},
+		},
+	}
+	enricher := &mockContactEnricher{}
+	matcher := &PeerMatcher{
+		identityService: identityMock,
+		externalContactRepo: &mockExternalContactUpserter{
+			getResult: &repository.ExternalContact{
+				ID:          uuid.New(),
+				Source:      "telegram",
+				SourceID:    "12345",
+				Metadata:    map[string]any{},
+				MatchStatus: repository.MatchStatusUnmatched,
+			},
+		},
+		enricher:         enricher,
+		discoveryMinMsgs: 3,
+	}
+
+	phone := "+15551234567"
+	_, err := matcher.MatchPeer(context.Background(), 12345, nil, nil, nil, &phone)
+	require.NoError(t, err)
+	require.Len(t, enricher.captured, 1)
+	_, has := enricher.captured[0].external.Metadata["username"]
+	assert.False(t, has, "no username key — neither persisted nor current message had one")
+}

--- a/backend/tests/api/import_with_selections_test.go
+++ b/backend/tests/api/import_with_selections_test.go
@@ -2193,3 +2193,252 @@ func TestImportAPI_ImportValidation(t *testing.T) {
 		assert.Equal(t, "VALIDATION_ERROR", response.Error.Code)
 	})
 }
+
+func TestImportAPI_TelegramLinkWithMethodSelection(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	router, externalRepo, contactRepo, contactMethodRepo, cleanup := setupImportTestRouter()
+	defer cleanup()
+
+	ctx := context.Background()
+
+	seed := func(t *testing.T, tgUsername string) (*repository.Contact, *repository.ExternalContact, func()) {
+		t.Helper()
+		contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
+			FullName: "TG Link Target " + uuid.New().String()[:8],
+		})
+		require.NoError(t, err)
+
+		_, err = contactMethodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
+			ContactID: contact.ID,
+			Type:      "email",
+			Value:     "existing@example.com",
+		})
+		require.NoError(t, err)
+
+		displayName := "TG Candidate " + uuid.New().String()[:8]
+		external, err := externalRepo.Upsert(ctx, repository.UpsertExternalContactRequest{
+			Source:      "telegram",
+			SourceID:    "tg-link-" + uuid.New().String()[:8],
+			DisplayName: &displayName,
+			Metadata:    map[string]any{"username": "@" + tgUsername},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, external)
+
+		cleanup := func() {
+			_ = externalRepo.Delete(ctx, external.ID)
+			_ = contactRepo.HardDeleteContact(ctx, contact.ID)
+		}
+		return contact, external, cleanup
+	}
+
+	link := func(t *testing.T, externalID uuid.UUID, body handlers.LinkRequest) *httptest.ResponseRecorder {
+		t.Helper()
+		jsonBody, _ := json.Marshal(body)
+		req, _ := http.NewRequest("POST", "/api/v1/imports/candidates/"+externalID.String()+"/link", bytes.NewBuffer(jsonBody))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		return w
+	}
+
+	findTelegramMethod := func(methods []repository.ContactMethod) *repository.ContactMethod {
+		for i := range methods {
+			if methods[i].Type == "telegram" {
+				return &methods[i]
+			}
+		}
+		return nil
+	}
+
+	t.Run("LinkTelegram_BareHandle_StoresBareLowerNormalized", func(t *testing.T) {
+		contact, external, cleanupSeed := seed(t, "TestLink")
+		defer cleanupSeed()
+
+		w := link(t, external.ID, handlers.LinkRequest{
+			CRMContactID: contact.ID.String(),
+			SelectedMethods: []handlers.SelectedMethodInput{
+				{OriginalValue: "TestLink", Type: "telegram"},
+			},
+		})
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+		methods, err := contactMethodRepo.ListContactMethodsByContact(ctx, contact.ID)
+		require.NoError(t, err)
+		tg := findTelegramMethod(methods)
+		require.NotNil(t, tg, "telegram method should be created")
+		assert.Equal(t, "TestLink", tg.Value)
+		assert.Equal(t, "testlink", tg.ValueNormalized)
+		assert.False(t, tg.IsPrimary)
+	})
+
+	t.Run("LinkTelegram_WithAtPrefix_StoresBareForm", func(t *testing.T) {
+		contact, external, cleanupSeed := seed(t, "TestLink")
+		defer cleanupSeed()
+
+		w := link(t, external.ID, handlers.LinkRequest{
+			CRMContactID: contact.ID.String(),
+			SelectedMethods: []handlers.SelectedMethodInput{
+				{OriginalValue: "@TestLink", Type: "telegram"},
+			},
+		})
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+		methods, err := contactMethodRepo.ListContactMethodsByContact(ctx, contact.ID)
+		require.NoError(t, err)
+		tg := findTelegramMethod(methods)
+		require.NotNil(t, tg)
+		assert.Equal(t, "TestLink", tg.Value, "leading @ stripped to match import-new storage")
+		assert.Equal(t, "testlink", tg.ValueNormalized)
+	})
+
+	t.Run("LinkTelegram_SelectionsModeWithoutTelegram_NoTelegramAdded", func(t *testing.T) {
+		contact, external, cleanupSeed := seed(t, "Skipped")
+		defer cleanupSeed()
+
+		// Cadence triggers the Selections enrichment path with zero method selections.
+		// Under the Selections path, auto-enrichment is NOT applied — the user's
+		// explicit (empty) selection list determines what methods are added.
+		cadence := "weekly"
+		w := link(t, external.ID, handlers.LinkRequest{
+			CRMContactID:    contact.ID.String(),
+			SelectedMethods: []handlers.SelectedMethodInput{},
+			Cadence:         &cadence,
+		})
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+		methods, err := contactMethodRepo.ListContactMethodsByContact(ctx, contact.ID)
+		require.NoError(t, err)
+		assert.Nil(t, findTelegramMethod(methods), "no telegram method when not in selections")
+	})
+
+	t.Run("LinkTelegram_AlreadyPresent_NoDuplicate", func(t *testing.T) {
+		contact, external, cleanupSeed := seed(t, "TestLink")
+		defer cleanupSeed()
+
+		_, err := contactMethodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
+			ContactID: contact.ID,
+			Type:      "telegram",
+			Value:     "TestLink",
+		})
+		require.NoError(t, err)
+
+		w := link(t, external.ID, handlers.LinkRequest{
+			CRMContactID: contact.ID.String(),
+			SelectedMethods: []handlers.SelectedMethodInput{
+				{OriginalValue: "@TestLink", Type: "telegram"},
+			},
+		})
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+		methods, err := contactMethodRepo.ListContactMethodsByContact(ctx, contact.ID)
+		require.NoError(t, err)
+		count := 0
+		for _, m := range methods {
+			if m.Type == "telegram" {
+				count++
+			}
+		}
+		assert.Equal(t, 1, count, "idempotent — no duplicate on re-link")
+	})
+
+	t.Run("LinkTelegram_AutoFallback_NoSelectionsOrCadence", func(t *testing.T) {
+		contact, external, cleanupSeed := seed(t, "AutoFall")
+		defer cleanupSeed()
+
+		// Empty selections + no cadence/name → hits EnrichContactFromExternal (auto mode).
+		// Auto mode DOES apply BuildMethodsFromExternal, so telegram is added from metadata.
+		w := link(t, external.ID, handlers.LinkRequest{
+			CRMContactID: contact.ID.String(),
+		})
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+		methods, err := contactMethodRepo.ListContactMethodsByContact(ctx, contact.ID)
+		require.NoError(t, err)
+		tg := findTelegramMethod(methods)
+		require.NotNil(t, tg, "auto-mode link should enrich telegram from metadata.username")
+		assert.Equal(t, "AutoFall", tg.Value)
+	})
+
+	t.Run("LinkTelegram_ProfileFieldsUntouched", func(t *testing.T) {
+		contact, external, cleanupSeed := seed(t, "TestLink")
+		defer cleanupSeed()
+
+		before, err := contactRepo.GetContact(ctx, contact.ID)
+		require.NoError(t, err)
+
+		w := link(t, external.ID, handlers.LinkRequest{
+			CRMContactID: contact.ID.String(),
+			SelectedMethods: []handlers.SelectedMethodInput{
+				{OriginalValue: "TestLink", Type: "telegram"},
+			},
+		})
+		require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+		after, err := contactRepo.GetContact(ctx, contact.ID)
+		require.NoError(t, err)
+		assert.Equal(t, before.FullName, after.FullName)
+		assert.Equal(t, before.ProfilePhoto, after.ProfilePhoto)
+		assert.Equal(t, before.Birthday, after.Birthday)
+		assert.Equal(t, before.Location, after.Location)
+		assert.Equal(t, before.Cadence, after.Cadence)
+	})
+}
+
+func TestImportAPI_TelegramImportNewRegression(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	router, externalRepo, contactRepo, contactMethodRepo, cleanup := setupImportTestRouter()
+	defer cleanup()
+
+	ctx := context.Background()
+
+	displayName := "TG Import Regression " + uuid.New().String()[:8]
+	external, err := externalRepo.Upsert(ctx, repository.UpsertExternalContactRequest{
+		Source:      "telegram",
+		SourceID:    "tg-import-" + uuid.New().String()[:8],
+		DisplayName: &displayName,
+		Metadata:    map[string]any{"username": "@RegressionUser"},
+	})
+	require.NoError(t, err)
+	defer func() { _ = externalRepo.Delete(ctx, external.ID) }()
+
+	// Auto-select import (no selected_methods) — exercises BuildMethodsFromExternal
+	// replacing buildMethodsAuto on the import-new path.
+	name := "Regression User"
+	body, _ := json.Marshal(handlers.ImportRequest{Name: &name})
+	req, _ := http.NewRequest("POST", "/api/v1/imports/candidates/"+external.ID.String()+"/import", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
+
+	var response api.APIResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	contactData := response.Data.(map[string]interface{})
+	contactID, err := uuid.Parse(contactData["id"].(string))
+	require.NoError(t, err)
+	defer func() { _ = contactRepo.HardDeleteContact(ctx, contactID) }()
+
+	methods, err := contactMethodRepo.ListContactMethodsByContact(ctx, contactID)
+	require.NoError(t, err)
+	require.Len(t, methods, 1)
+	assert.Equal(t, "telegram", methods[0].Type)
+	assert.Equal(t, "RegressionUser", methods[0].Value, "bare handle — matches legacy buildMethodsAuto output")
+	assert.Equal(t, "regressionuser", methods[0].ValueNormalized)
+}

--- a/backend/tests/api/import_with_selections_test.go
+++ b/backend/tests/api/import_with_selections_test.go
@@ -2209,6 +2209,21 @@ func TestImportAPI_TelegramLinkWithMethodSelection(t *testing.T) {
 
 	ctx := context.Background()
 
+	// Use a separate enrichment repo to verify audit rows.
+	databaseURL2 := os.Getenv("DATABASE_URL")
+	dbCfg := config.DatabaseConfig{
+		URL:               databaseURL2,
+		MaxConns:          config.DefaultDBMaxConns,
+		MinConns:          config.DefaultDBMinConns,
+		MaxConnIdleTime:   config.DefaultDBMaxConnIdleTime,
+		MaxConnLifetime:   config.DefaultDBMaxConnLifetime,
+		HealthCheckPeriod: config.DefaultDBHealthCheckPeriod,
+	}
+	auditDB, err := db.NewDatabase(ctx, dbCfg)
+	require.NoError(t, err)
+	defer auditDB.Close()
+	enrichmentRepo := repository.NewEnrichmentRepository(auditDB.Queries)
+
 	seed := func(t *testing.T, tgUsername string) (*repository.Contact, *repository.ExternalContact, func()) {
 		t.Helper()
 		contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
@@ -2278,6 +2293,19 @@ func TestImportAPI_TelegramLinkWithMethodSelection(t *testing.T) {
 		assert.Equal(t, "TestLink", tg.Value)
 		assert.Equal(t, "testlink", tg.ValueNormalized)
 		assert.False(t, tg.IsPrimary)
+
+		// Audit row written with persisted external_contact_id set.
+		enrichments, err := enrichmentRepo.ListForContact(ctx, contact.ID)
+		require.NoError(t, err)
+		var auditFound bool
+		for _, e := range enrichments {
+			if e.Field == "method:telegram:testlink" {
+				auditFound = true
+				require.NotNil(t, e.ExternalContactID, "external_contact_id should reference the persisted row")
+				assert.Equal(t, external.ID, *e.ExternalContactID)
+			}
+		}
+		assert.True(t, auditFound, "expected contact_enrichment audit row for telegram method")
 	})
 
 	t.Run("LinkTelegram_WithAtPrefix_StoresBareForm", func(t *testing.T) {

--- a/backend/tests/api/telegram_chat_api_test.go
+++ b/backend/tests/api/telegram_chat_api_test.go
@@ -92,6 +92,7 @@ func setupTelegramChatRouter(t *testing.T) (*gin.Engine, *repository.TelegramCha
 		telegramCfg,
 		identityService,
 		externalContactRepo,
+		nil,
 		interactionRepo,
 		contactService,
 		contactService,

--- a/backend/tests/telegram_discovery_upsert_test.go
+++ b/backend/tests/telegram_discovery_upsert_test.go
@@ -360,7 +360,7 @@ func TestUpdateDiscoveryCandidates_BatchPath_BlankStringsDoNotClobberStoredData(
 	externalRepo := repository.NewExternalContactRepository(database.Queries)
 	identityRepo := repository.NewIdentityRepository(database.Queries)
 	identitySvc := service.NewIdentityService(identityRepo)
-	matcher := tgpkg.NewPeerMatcher(identitySvc, messageRepo, externalRepo, 2) // threshold = 2
+	matcher := tgpkg.NewPeerMatcher(identitySvc, messageRepo, externalRepo, nil, 2) // threshold = 2
 
 	t.Cleanup(func() {
 		_, _ = database.Queries.DeleteTelegramMessagesByPeerUserID(

--- a/backend/tests/telegram_matcher_enrichment_test.go
+++ b/backend/tests/telegram_matcher_enrichment_test.go
@@ -1,0 +1,371 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/identity"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+	tgpkg "personal-crm/backend/internal/telegram"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupMatcherEnrichmentTest builds a real PeerMatcher backed by a real
+// IdentityService and EnrichmentService. Tests inject identity links and
+// external_contact rows, then call MatchPeer to drive the full flow.
+func setupMatcherEnrichmentTest(t *testing.T) (*tgpkg.PeerMatcher, *repository.ContactRepository, *repository.ContactMethodRepository, *repository.ExternalContactRepository, *repository.EnrichmentRepository, *service.IdentityService, *db.Database, func()) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set")
+	}
+
+	require.NoError(t, db.RunMigrations(databaseURL, getMigrationsPath()))
+
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+
+	database, err := db.NewDatabase(context.Background(), cfg.Database)
+	require.NoError(t, err)
+
+	contactRepo := repository.NewContactRepository(database.Queries)
+	methodRepo := repository.NewContactMethodRepository(database.Queries)
+	externalRepo := repository.NewExternalContactRepository(database.Queries)
+	enrichmentRepo := repository.NewEnrichmentRepository(database.Queries)
+	identityRepo := repository.NewIdentityRepository(database.Queries)
+	messageRepo := repository.NewTelegramMessageRepository(database.Queries)
+
+	identitySvc := service.NewIdentityService(identityRepo)
+	enrichmentSvc := service.NewEnrichmentService(contactRepo, methodRepo, enrichmentRepo)
+
+	matcher := tgpkg.NewPeerMatcher(identitySvc, messageRepo, externalRepo, enrichmentSvc, 100)
+
+	cleanup := func() { database.Close() }
+
+	return matcher, contactRepo, methodRepo, externalRepo, enrichmentRepo, identitySvc, database, cleanup
+}
+
+func newTestContact(t *testing.T, ctx context.Context, contactRepo *repository.ContactRepository, name string) *repository.Contact {
+	t.Helper()
+	c, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: name})
+	require.NoError(t, err)
+	return c
+}
+
+func TestMatcherEnrichment_AboveThreshold_UsernameMatch(t *testing.T) {
+	matcher, contactRepo, methodRepo, externalRepo, enrichmentRepo, identitySvc, database, cleanup := setupMatcherEnrichmentTest(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	const peerUserID int64 = 770001
+	peerIDStr := "770001"
+
+	contact := newTestContact(t, ctx, contactRepo, "Above Thresh "+uuid.New().String()[:8])
+	t.Cleanup(func() {
+		_ = contactRepo.HardDeleteContact(ctx, contact.ID)
+		_, _ = database.Queries.DeleteExternalContactsBySourceIDPrefix(ctx, pgtype.Text{String: peerIDStr, Valid: true})
+		_, _ = database.Queries.DeleteExternalIdentitiesBySourceID(ctx, pgtype.Text{String: peerIDStr, Valid: true})
+	})
+
+	// Pre-link the username via cached identity (mimics #272 name match path).
+	_, err := identitySvc.MatchOrCreate(ctx, service.MatchRequest{
+		RawIdentifier:  "AutoUser",
+		Type:           identity.IdentifierTypeTelegram,
+		Source:         "telegram",
+		SourceID:       &peerIDStr,
+		KnownContactID: &contact.ID,
+	})
+	require.NoError(t, err)
+
+	// Pre-seed external_contact (above-threshold path).
+	displayName := "Above Thresh External"
+	external, err := externalRepo.Upsert(ctx, repository.UpsertExternalContactRequest{
+		Source:      "telegram",
+		SourceID:    peerIDStr,
+		DisplayName: &displayName,
+		Metadata:    map[string]any{"username": "@AutoUser"},
+	})
+	require.NoError(t, err)
+
+	// Snapshot profile fields for "untouched" assertion.
+	before, err := contactRepo.GetContact(ctx, contact.ID)
+	require.NoError(t, err)
+
+	username := "AutoUser"
+	result, err := matcher.MatchPeer(ctx, peerUserID, &username, nil, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, contact.ID, *result)
+
+	methods, err := methodRepo.ListContactMethodsByContact(ctx, contact.ID)
+	require.NoError(t, err)
+	require.Len(t, methods, 1)
+	assert.Equal(t, "telegram", methods[0].Type)
+	assert.Equal(t, "AutoUser", methods[0].Value)
+	assert.Equal(t, "autouser", methods[0].ValueNormalized)
+
+	// Audit row references the persisted external_contact.
+	enrichments, err := enrichmentRepo.ListForContact(ctx, contact.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, enrichments)
+	var found bool
+	for _, e := range enrichments {
+		if e.Field == "method:telegram:autouser" {
+			found = true
+			require.NotNil(t, e.ExternalContactID, "persisted external_contact_id should be set")
+			assert.Equal(t, external.ID, *e.ExternalContactID)
+		}
+	}
+	assert.True(t, found, "expected enrichment audit row for telegram method")
+
+	after, err := contactRepo.GetContact(ctx, contact.ID)
+	require.NoError(t, err)
+	assert.Equal(t, before.FullName, after.FullName)
+	assert.Equal(t, before.ProfilePhoto, after.ProfilePhoto)
+	assert.Equal(t, before.Birthday, after.Birthday)
+	assert.Equal(t, before.Location, after.Location)
+	assert.Equal(t, before.Cadence, after.Cadence)
+}
+
+func TestMatcherEnrichment_BelowThreshold_NoExternalContact(t *testing.T) {
+	matcher, contactRepo, methodRepo, _, enrichmentRepo, identitySvc, database, cleanup := setupMatcherEnrichmentTest(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	const peerUserID int64 = 770002
+	peerIDStr := "770002"
+
+	contact := newTestContact(t, ctx, contactRepo, "Below Thresh "+uuid.New().String()[:8])
+	t.Cleanup(func() {
+		_ = contactRepo.HardDeleteContact(ctx, contact.ID)
+		_, _ = database.Queries.DeleteExternalIdentitiesBySourceID(ctx, pgtype.Text{String: peerIDStr, Valid: true})
+	})
+
+	// Pre-link the username; do NOT seed an external_contact row.
+	_, err := identitySvc.MatchOrCreate(ctx, service.MatchRequest{
+		RawIdentifier:  "BelowUser",
+		Type:           identity.IdentifierTypeTelegram,
+		Source:         "telegram",
+		SourceID:       &peerIDStr,
+		KnownContactID: &contact.ID,
+	})
+	require.NoError(t, err)
+
+	username := "BelowUser"
+	result, err := matcher.MatchPeer(ctx, peerUserID, &username, nil, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, contact.ID, *result)
+
+	methods, err := methodRepo.ListContactMethodsByContact(ctx, contact.ID)
+	require.NoError(t, err)
+	require.Len(t, methods, 1)
+	assert.Equal(t, "telegram", methods[0].Type)
+	assert.Equal(t, "BelowUser", methods[0].Value)
+
+	// Audit row's external_contact_id must be NULL (synthesized — no persisted row).
+	enrichments, err := enrichmentRepo.ListForContact(ctx, contact.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, enrichments)
+	var found bool
+	for _, e := range enrichments {
+		if e.Field == "method:telegram:belowuser" {
+			found = true
+			assert.Nil(t, e.ExternalContactID, "synthesized — external_contact_id should be NULL")
+		}
+	}
+	assert.True(t, found)
+}
+
+func TestMatcherEnrichment_PhoneMatchWithUsername(t *testing.T) {
+	matcher, contactRepo, methodRepo, _, _, _, database, cleanup := setupMatcherEnrichmentTest(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	const peerUserID int64 = 770003
+	peerIDStr := "770003"
+
+	contact := newTestContact(t, ctx, contactRepo, "Phone Match "+uuid.New().String()[:8])
+	// Pre-create phone contact_method so identity service finds the contact via phone.
+	_, err := methodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
+		ContactID: contact.ID,
+		Type:      "phone",
+		Value:     "+15557770003",
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = contactRepo.HardDeleteContact(ctx, contact.ID)
+		_, _ = database.Queries.DeleteExternalIdentitiesBySourceID(ctx, pgtype.Text{String: peerIDStr, Valid: true})
+	})
+
+	username := "PhoneMatched"
+	phone := "+15557770003"
+	result, err := matcher.MatchPeer(ctx, peerUserID, &username, nil, nil, &phone)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, contact.ID, *result)
+
+	methods, err := methodRepo.ListContactMethodsByContact(ctx, contact.ID)
+	require.NoError(t, err)
+	var hasTelegram bool
+	for _, m := range methods {
+		if m.Type == "telegram" && m.Value == "PhoneMatched" {
+			hasTelegram = true
+		}
+	}
+	assert.True(t, hasTelegram, "telegram method should be added from peerUsername after phone match")
+}
+
+func TestMatcherEnrichment_PhoneMatchWithoutUsername(t *testing.T) {
+	matcher, contactRepo, methodRepo, _, _, _, database, cleanup := setupMatcherEnrichmentTest(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	const peerUserID int64 = 770004
+	peerIDStr := "770004"
+
+	contact := newTestContact(t, ctx, contactRepo, "Phone Only "+uuid.New().String()[:8])
+	_, err := methodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
+		ContactID: contact.ID,
+		Type:      "phone",
+		Value:     "+15557770004",
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = contactRepo.HardDeleteContact(ctx, contact.ID)
+		_, _ = database.Queries.DeleteExternalIdentitiesBySourceID(ctx, pgtype.Text{String: peerIDStr, Valid: true})
+	})
+
+	phone := "+15557770004"
+	result, err := matcher.MatchPeer(ctx, peerUserID, nil, nil, nil, &phone)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	methods, err := methodRepo.ListContactMethodsByContact(ctx, contact.ID)
+	require.NoError(t, err)
+	for _, m := range methods {
+		assert.NotEqual(t, "telegram", m.Type, "no telegram method when peerUsername absent")
+	}
+}
+
+func TestMatcherEnrichment_Idempotency(t *testing.T) {
+	matcher, contactRepo, methodRepo, _, _, identitySvc, database, cleanup := setupMatcherEnrichmentTest(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	const peerUserID int64 = 770005
+	peerIDStr := "770005"
+
+	contact := newTestContact(t, ctx, contactRepo, "Idem "+uuid.New().String()[:8])
+	t.Cleanup(func() {
+		_ = contactRepo.HardDeleteContact(ctx, contact.ID)
+		_, _ = database.Queries.DeleteExternalIdentitiesBySourceID(ctx, pgtype.Text{String: peerIDStr, Valid: true})
+	})
+
+	_, err := identitySvc.MatchOrCreate(ctx, service.MatchRequest{
+		RawIdentifier:  "IdemUser",
+		Type:           identity.IdentifierTypeTelegram,
+		Source:         "telegram",
+		SourceID:       &peerIDStr,
+		KnownContactID: &contact.ID,
+	})
+	require.NoError(t, err)
+
+	username := "IdemUser"
+	for range 2 {
+		_, err := matcher.MatchPeer(ctx, peerUserID, &username, nil, nil, nil)
+		require.NoError(t, err)
+	}
+
+	methods, err := methodRepo.ListContactMethodsByContact(ctx, contact.ID)
+	require.NoError(t, err)
+	count := 0
+	for _, m := range methods {
+		if m.Type == "telegram" {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "idempotent — exactly one telegram method after two MatchPeer calls")
+}
+
+// failingEnricher always errors on SyncMethodsFromExternal — used to verify
+// that enrichment failures do NOT fail the match itself.
+type failingEnricher struct{}
+
+func (failingEnricher) SyncMethodsFromExternal(_ context.Context, _ uuid.UUID, _ *repository.ExternalContact) error {
+	return errors.New("simulated enrichment failure")
+}
+
+func TestMatcherEnrichment_EnricherErrorDoesNotBreakMatch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set")
+	}
+	require.NoError(t, db.RunMigrations(databaseURL, getMigrationsPath()))
+
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+	database, err := db.NewDatabase(context.Background(), cfg.Database)
+	require.NoError(t, err)
+	defer database.Close()
+
+	ctx := context.Background()
+	const peerUserID int64 = 770006
+	peerIDStr := "770006"
+
+	contactRepo := repository.NewContactRepository(database.Queries)
+	methodRepo := repository.NewContactMethodRepository(database.Queries)
+	externalRepo := repository.NewExternalContactRepository(database.Queries)
+	identityRepo := repository.NewIdentityRepository(database.Queries)
+	messageRepo := repository.NewTelegramMessageRepository(database.Queries)
+	identitySvc := service.NewIdentityService(identityRepo)
+
+	matcher := tgpkg.NewPeerMatcher(identitySvc, messageRepo, externalRepo, failingEnricher{}, 100)
+
+	contact := newTestContact(t, ctx, contactRepo, "Faulty Enricher "+uuid.New().String()[:8])
+	t.Cleanup(func() {
+		_ = contactRepo.HardDeleteContact(ctx, contact.ID)
+		_, _ = database.Queries.DeleteExternalIdentitiesBySourceID(ctx, pgtype.Text{String: peerIDStr, Valid: true})
+	})
+
+	_, err = identitySvc.MatchOrCreate(ctx, service.MatchRequest{
+		RawIdentifier:  "FaultyUser",
+		Type:           identity.IdentifierTypeTelegram,
+		Source:         "telegram",
+		SourceID:       &peerIDStr,
+		KnownContactID: &contact.ID,
+	})
+	require.NoError(t, err)
+
+	username := "FaultyUser"
+	result, err := matcher.MatchPeer(ctx, peerUserID, &username, nil, nil, nil)
+	require.NoError(t, err, "enricher errors must NOT fail the match")
+	require.NotNil(t, result)
+	assert.Equal(t, contact.ID, *result)
+
+	methods, err := methodRepo.ListContactMethodsByContact(ctx, contact.ID)
+	require.NoError(t, err)
+	for _, m := range methods {
+		assert.NotEqual(t, "telegram", m.Type, "no telegram method when enricher fails")
+	}
+
+	_ = accelerated.GetCurrentTime()
+}

--- a/backend/tests/telegram_matcher_enrichment_test.go
+++ b/backend/tests/telegram_matcher_enrichment_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"strconv"
+	"sync"
 	"testing"
 
 	"personal-crm/backend/internal/config"
@@ -324,6 +325,107 @@ func TestMatcherEnrichment_Idempotency(t *testing.T) {
 		}
 	}
 	assert.Equal(t, 1, count, "idempotent — exactly one telegram method after two MatchPeer calls")
+}
+
+// TestMatcherEnrichment_ConcurrentMatch_TreatsUniqueViolationAsSuccess
+// drives two concurrent MatchPeer calls for the same peer to race the
+// CreateContactMethod insert. One should win; the other should see PG 23505,
+// treat it as success, and produce no warn-level error or duplicate row.
+func TestMatcherEnrichment_ConcurrentMatch_TreatsUniqueViolationAsSuccess(t *testing.T) {
+	env := setupMatcherEnrichmentTest(t)
+	ctx := context.Background()
+	peerUserID, peerIDStr := uniqueTestIDs(t)
+	username := "RaceUser" + peerIDStr
+
+	contact := newTestContact(t, ctx, env.contactRepo, "Race "+peerIDStr)
+	registerCleanupBySource(t, env, ctx, contact.ID, peerIDStr)
+
+	_, err := env.identitySvc.MatchOrCreate(ctx, service.MatchRequest{
+		RawIdentifier:  username,
+		Type:           identity.IdentifierTypeTelegram,
+		Source:         "telegram",
+		SourceID:       &peerIDStr,
+		KnownContactID: &contact.ID,
+	})
+	require.NoError(t, err)
+
+	// Run two MatchPeer calls concurrently. The first to insert wins; the
+	// second hits PG unique_violation (23505) and must treat it as success.
+	const concurrency = 2
+	errs := make(chan error, concurrency)
+	var wg sync.WaitGroup
+	for range concurrency {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := env.matcher.MatchPeer(ctx, peerUserID, &username, nil, nil, nil)
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err, "concurrent MatchPeer must not return an error")
+	}
+
+	methods, err := env.methodRepo.ListContactMethodsByContact(ctx, contact.ID)
+	require.NoError(t, err)
+	count := 0
+	for _, m := range methods {
+		if m.Type == "telegram" {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "exactly one telegram method even after concurrent matches")
+}
+
+// TestMatcherEnrichment_AlreadyMatchedExternalContact_RepairsMissingMethod
+// covers the original bug: an external_contact whose match_status is already
+// 'matched'/'imported' but the bound CRM contact lacks the telegram method.
+// markExternalContactMatched early-returns in this case, so enrichment must
+// run from MatchPeer regardless of stored match status.
+func TestMatcherEnrichment_AlreadyMatchedExternalContact_RepairsMissingMethod(t *testing.T) {
+	env := setupMatcherEnrichmentTest(t)
+	ctx := context.Background()
+	peerUserID, peerIDStr := uniqueTestIDs(t)
+	username := "RepairUser" + peerIDStr
+
+	contact := newTestContact(t, ctx, env.contactRepo, "Repair "+peerIDStr)
+	registerCleanupBySource(t, env, ctx, contact.ID, peerIDStr)
+
+	// Pre-link the username so the matcher resolves to this contact via cache.
+	_, err := env.identitySvc.MatchOrCreate(ctx, service.MatchRequest{
+		RawIdentifier:  username,
+		Type:           identity.IdentifierTypeTelegram,
+		Source:         "telegram",
+		SourceID:       &peerIDStr,
+		KnownContactID: &contact.ID,
+	})
+	require.NoError(t, err)
+
+	// Pre-seed external_contact already in 'matched' status pointing at the contact —
+	// this is the exact prod state of Jack Laing's row. No telegram contact_method.
+	displayName := "Repair External " + peerIDStr
+	external, err := env.externalRepo.Upsert(ctx, repository.UpsertExternalContactRequest{
+		Source:      "telegram",
+		SourceID:    peerIDStr,
+		DisplayName: &displayName,
+		Metadata:    map[string]any{"username": "@" + username},
+	})
+	require.NoError(t, err)
+	_, err = env.externalRepo.UpdateMatch(ctx, external.ID, &contact.ID, repository.MatchStatusMatched)
+	require.NoError(t, err)
+
+	result, err := env.matcher.MatchPeer(ctx, peerUserID, &username, nil, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, contact.ID, *result)
+
+	methods, err := env.methodRepo.ListContactMethodsByContact(ctx, contact.ID)
+	require.NoError(t, err)
+	require.Len(t, methods, 1, "telegram method should be added even though external_contact was already matched")
+	assert.Equal(t, "telegram", methods[0].Type)
+	assert.Equal(t, username, methods[0].Value)
 }
 
 // failingEnricher always errors on SyncMethodsFromExternal — used to verify

--- a/backend/tests/telegram_matcher_enrichment_test.go
+++ b/backend/tests/telegram_matcher_enrichment_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"errors"
 	"os"
+	"strconv"
 	"testing"
 
-	"personal-crm/backend/internal/accelerated"
 	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/identity"
@@ -20,10 +20,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// matcherEnrichTestEnv bundles repos + services constructed in the test setup.
+type matcherEnrichTestEnv struct {
+	matcher        *tgpkg.PeerMatcher
+	contactRepo    *repository.ContactRepository
+	methodRepo     *repository.ContactMethodRepository
+	externalRepo   *repository.ExternalContactRepository
+	enrichmentRepo *repository.EnrichmentRepository
+	identitySvc    *service.IdentityService
+	database       *db.Database
+}
+
 // setupMatcherEnrichmentTest builds a real PeerMatcher backed by a real
-// IdentityService and EnrichmentService. Tests inject identity links and
-// external_contact rows, then call MatchPeer to drive the full flow.
-func setupMatcherEnrichmentTest(t *testing.T) (*tgpkg.PeerMatcher, *repository.ContactRepository, *repository.ContactMethodRepository, *repository.ExternalContactRepository, *repository.EnrichmentRepository, *service.IdentityService, *db.Database, func()) {
+// IdentityService and EnrichmentService.
+//
+// DB lifecycle: registers database.Close via t.Cleanup so any per-test
+// t.Cleanup the caller adds runs BEFORE the connection is closed (Go runs
+// t.Cleanup callbacks in LIFO order — opposite of `defer cleanup()`).
+func setupMatcherEnrichmentTest(t *testing.T) *matcherEnrichTestEnv {
 	t.Helper()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -40,6 +54,7 @@ func setupMatcherEnrichmentTest(t *testing.T) (*tgpkg.PeerMatcher, *repository.C
 
 	database, err := db.NewDatabase(context.Background(), cfg.Database)
 	require.NoError(t, err)
+	t.Cleanup(database.Close)
 
 	contactRepo := repository.NewContactRepository(database.Queries)
 	methodRepo := repository.NewContactMethodRepository(database.Queries)
@@ -53,9 +68,39 @@ func setupMatcherEnrichmentTest(t *testing.T) (*tgpkg.PeerMatcher, *repository.C
 
 	matcher := tgpkg.NewPeerMatcher(identitySvc, messageRepo, externalRepo, enrichmentSvc, 100)
 
-	cleanup := func() { database.Close() }
+	return &matcherEnrichTestEnv{
+		matcher:        matcher,
+		contactRepo:    contactRepo,
+		methodRepo:     methodRepo,
+		externalRepo:   externalRepo,
+		enrichmentRepo: enrichmentRepo,
+		identitySvc:    identitySvc,
+		database:       database,
+	}
+}
 
-	return matcher, contactRepo, methodRepo, externalRepo, enrichmentRepo, identitySvc, database, cleanup
+// uniqueTestIDs returns a peer user ID and matching string ID derived from a
+// fresh UUID. Each test invocation gets unique values so cross-test or
+// cross-run pollution in the shared test DB cannot affect results.
+//
+// The integer is offset by 9_000_000_000 to keep it well above any
+// hand-picked low test IDs elsewhere in the suite. The string form is the
+// decimal representation of that int — digit-only, safe for phone-shaped values.
+func uniqueTestIDs(t *testing.T) (int64, string) {
+	t.Helper()
+	suffix := uuid.New().String()[:8]
+	var n int64
+	for _, c := range suffix {
+		n <<= 4
+		switch {
+		case c >= '0' && c <= '9':
+			n |= int64(c - '0')
+		case c >= 'a' && c <= 'f':
+			n |= int64(c-'a') + 10
+		}
+	}
+	id := int64(9_000_000_000) + n
+	return id, strconv.FormatInt(id, 10)
 }
 
 func newTestContact(t *testing.T, ctx context.Context, contactRepo *repository.ContactRepository, name string) *repository.Contact {
@@ -65,24 +110,32 @@ func newTestContact(t *testing.T, ctx context.Context, contactRepo *repository.C
 	return c
 }
 
-func TestMatcherEnrichment_AboveThreshold_UsernameMatch(t *testing.T) {
-	matcher, contactRepo, methodRepo, externalRepo, enrichmentRepo, identitySvc, database, cleanup := setupMatcherEnrichmentTest(t)
-	defer cleanup()
-
-	ctx := context.Background()
-	const peerUserID int64 = 770001
-	peerIDStr := "770001"
-
-	contact := newTestContact(t, ctx, contactRepo, "Above Thresh "+uuid.New().String()[:8])
+// registerCleanupBySource removes any external_contact, external_identity, and
+// contact rows tied to the given peer ID string after the test runs. Hard
+// deletes — keeps the shared DB free of orphans. Order matters: identity and
+// external_contact rows clear first so the contact's FK references drop before
+// the contact itself is deleted.
+func registerCleanupBySource(t *testing.T, env *matcherEnrichTestEnv, ctx context.Context, contactID uuid.UUID, peerIDStr string) {
+	t.Helper()
 	t.Cleanup(func() {
-		_ = contactRepo.HardDeleteContact(ctx, contact.ID)
-		_, _ = database.Queries.DeleteExternalContactsBySourceIDPrefix(ctx, pgtype.Text{String: peerIDStr, Valid: true})
-		_, _ = database.Queries.DeleteExternalIdentitiesBySourceID(ctx, pgtype.Text{String: peerIDStr, Valid: true})
+		_, _ = env.database.Queries.DeleteExternalContactsBySourceIDPrefix(ctx, pgtype.Text{String: peerIDStr, Valid: true})
+		_, _ = env.database.Queries.DeleteExternalIdentitiesBySourceID(ctx, pgtype.Text{String: peerIDStr, Valid: true})
+		_ = env.contactRepo.HardDeleteContact(ctx, contactID)
 	})
+}
+
+func TestMatcherEnrichment_AboveThreshold_UsernameMatch(t *testing.T) {
+	env := setupMatcherEnrichmentTest(t)
+	ctx := context.Background()
+	peerUserID, peerIDStr := uniqueTestIDs(t)
+	username := "AboveUser" + peerIDStr
+
+	contact := newTestContact(t, ctx, env.contactRepo, "Above Thresh "+peerIDStr)
+	registerCleanupBySource(t, env, ctx, contact.ID, peerIDStr)
 
 	// Pre-link the username via cached identity (mimics #272 name match path).
-	_, err := identitySvc.MatchOrCreate(ctx, service.MatchRequest{
-		RawIdentifier:  "AutoUser",
+	_, err := env.identitySvc.MatchOrCreate(ctx, service.MatchRequest{
+		RawIdentifier:  username,
 		Type:           identity.IdentifierTypeTelegram,
 		Source:         "telegram",
 		SourceID:       &peerIDStr,
@@ -91,39 +144,35 @@ func TestMatcherEnrichment_AboveThreshold_UsernameMatch(t *testing.T) {
 	require.NoError(t, err)
 
 	// Pre-seed external_contact (above-threshold path).
-	displayName := "Above Thresh External"
-	external, err := externalRepo.Upsert(ctx, repository.UpsertExternalContactRequest{
+	displayName := "Above Thresh External " + peerIDStr
+	external, err := env.externalRepo.Upsert(ctx, repository.UpsertExternalContactRequest{
 		Source:      "telegram",
 		SourceID:    peerIDStr,
 		DisplayName: &displayName,
-		Metadata:    map[string]any{"username": "@AutoUser"},
+		Metadata:    map[string]any{"username": "@" + username},
 	})
 	require.NoError(t, err)
 
-	// Snapshot profile fields for "untouched" assertion.
-	before, err := contactRepo.GetContact(ctx, contact.ID)
+	before, err := env.contactRepo.GetContact(ctx, contact.ID)
 	require.NoError(t, err)
 
-	username := "AutoUser"
-	result, err := matcher.MatchPeer(ctx, peerUserID, &username, nil, nil, nil)
+	result, err := env.matcher.MatchPeer(ctx, peerUserID, &username, nil, nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Equal(t, contact.ID, *result)
 
-	methods, err := methodRepo.ListContactMethodsByContact(ctx, contact.ID)
+	methods, err := env.methodRepo.ListContactMethodsByContact(ctx, contact.ID)
 	require.NoError(t, err)
 	require.Len(t, methods, 1)
 	assert.Equal(t, "telegram", methods[0].Type)
-	assert.Equal(t, "AutoUser", methods[0].Value)
-	assert.Equal(t, "autouser", methods[0].ValueNormalized)
+	assert.Equal(t, username, methods[0].Value)
 
-	// Audit row references the persisted external_contact.
-	enrichments, err := enrichmentRepo.ListForContact(ctx, contact.ID)
+	enrichments, err := env.enrichmentRepo.ListForContact(ctx, contact.ID)
 	require.NoError(t, err)
 	require.NotEmpty(t, enrichments)
 	var found bool
 	for _, e := range enrichments {
-		if e.Field == "method:telegram:autouser" {
+		if e.Field == "method:telegram:"+identity.Normalize(username, identity.IdentifierTypeTelegram) {
 			found = true
 			require.NotNil(t, e.ExternalContactID, "persisted external_contact_id should be set")
 			assert.Equal(t, external.ID, *e.ExternalContactID)
@@ -131,7 +180,7 @@ func TestMatcherEnrichment_AboveThreshold_UsernameMatch(t *testing.T) {
 	}
 	assert.True(t, found, "expected enrichment audit row for telegram method")
 
-	after, err := contactRepo.GetContact(ctx, contact.ID)
+	after, err := env.contactRepo.GetContact(ctx, contact.ID)
 	require.NoError(t, err)
 	assert.Equal(t, before.FullName, after.FullName)
 	assert.Equal(t, before.ProfilePhoto, after.ProfilePhoto)
@@ -141,22 +190,17 @@ func TestMatcherEnrichment_AboveThreshold_UsernameMatch(t *testing.T) {
 }
 
 func TestMatcherEnrichment_BelowThreshold_NoExternalContact(t *testing.T) {
-	matcher, contactRepo, methodRepo, _, enrichmentRepo, identitySvc, database, cleanup := setupMatcherEnrichmentTest(t)
-	defer cleanup()
-
+	env := setupMatcherEnrichmentTest(t)
 	ctx := context.Background()
-	const peerUserID int64 = 770002
-	peerIDStr := "770002"
+	peerUserID, peerIDStr := uniqueTestIDs(t)
+	username := "BelowUser" + peerIDStr
 
-	contact := newTestContact(t, ctx, contactRepo, "Below Thresh "+uuid.New().String()[:8])
-	t.Cleanup(func() {
-		_ = contactRepo.HardDeleteContact(ctx, contact.ID)
-		_, _ = database.Queries.DeleteExternalIdentitiesBySourceID(ctx, pgtype.Text{String: peerIDStr, Valid: true})
-	})
+	contact := newTestContact(t, ctx, env.contactRepo, "Below Thresh "+peerIDStr)
+	registerCleanupBySource(t, env, ctx, contact.ID, peerIDStr)
 
 	// Pre-link the username; do NOT seed an external_contact row.
-	_, err := identitySvc.MatchOrCreate(ctx, service.MatchRequest{
-		RawIdentifier:  "BelowUser",
+	_, err := env.identitySvc.MatchOrCreate(ctx, service.MatchRequest{
+		RawIdentifier:  username,
 		Type:           identity.IdentifierTypeTelegram,
 		Source:         "telegram",
 		SourceID:       &peerIDStr,
@@ -164,25 +208,24 @@ func TestMatcherEnrichment_BelowThreshold_NoExternalContact(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	username := "BelowUser"
-	result, err := matcher.MatchPeer(ctx, peerUserID, &username, nil, nil, nil)
+	result, err := env.matcher.MatchPeer(ctx, peerUserID, &username, nil, nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Equal(t, contact.ID, *result)
 
-	methods, err := methodRepo.ListContactMethodsByContact(ctx, contact.ID)
+	methods, err := env.methodRepo.ListContactMethodsByContact(ctx, contact.ID)
 	require.NoError(t, err)
 	require.Len(t, methods, 1)
 	assert.Equal(t, "telegram", methods[0].Type)
-	assert.Equal(t, "BelowUser", methods[0].Value)
+	assert.Equal(t, username, methods[0].Value)
 
 	// Audit row's external_contact_id must be NULL (synthesized — no persisted row).
-	enrichments, err := enrichmentRepo.ListForContact(ctx, contact.ID)
+	enrichments, err := env.enrichmentRepo.ListForContact(ctx, contact.ID)
 	require.NoError(t, err)
 	require.NotEmpty(t, enrichments)
 	var found bool
 	for _, e := range enrichments {
-		if e.Field == "method:telegram:belowuser" {
+		if e.Field == "method:telegram:"+identity.Normalize(username, identity.IdentifierTypeTelegram) {
 			found = true
 			assert.Nil(t, e.ExternalContactID, "synthesized — external_contact_id should be NULL")
 		}
@@ -191,39 +234,32 @@ func TestMatcherEnrichment_BelowThreshold_NoExternalContact(t *testing.T) {
 }
 
 func TestMatcherEnrichment_PhoneMatchWithUsername(t *testing.T) {
-	matcher, contactRepo, methodRepo, _, _, _, database, cleanup := setupMatcherEnrichmentTest(t)
-	defer cleanup()
-
+	env := setupMatcherEnrichmentTest(t)
 	ctx := context.Background()
-	const peerUserID int64 = 770003
-	peerIDStr := "770003"
+	peerUserID, peerIDStr := uniqueTestIDs(t)
+	username := "PhoneMatched" + peerIDStr
+	// Build a unique 11-digit phone number from peerUserID's last 8 digits.
+	phone := "+1555" + peerIDStr[:7]
 
-	contact := newTestContact(t, ctx, contactRepo, "Phone Match "+uuid.New().String()[:8])
-	// Pre-create phone contact_method so identity service finds the contact via phone.
-	_, err := methodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
+	contact := newTestContact(t, ctx, env.contactRepo, "Phone Match "+peerIDStr)
+	_, err := env.methodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
 		ContactID: contact.ID,
 		Type:      "phone",
-		Value:     "+15557770003",
+		Value:     phone,
 	})
 	require.NoError(t, err)
+	registerCleanupBySource(t, env, ctx, contact.ID, peerIDStr)
 
-	t.Cleanup(func() {
-		_ = contactRepo.HardDeleteContact(ctx, contact.ID)
-		_, _ = database.Queries.DeleteExternalIdentitiesBySourceID(ctx, pgtype.Text{String: peerIDStr, Valid: true})
-	})
-
-	username := "PhoneMatched"
-	phone := "+15557770003"
-	result, err := matcher.MatchPeer(ctx, peerUserID, &username, nil, nil, &phone)
+	result, err := env.matcher.MatchPeer(ctx, peerUserID, &username, nil, nil, &phone)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Equal(t, contact.ID, *result)
 
-	methods, err := methodRepo.ListContactMethodsByContact(ctx, contact.ID)
+	methods, err := env.methodRepo.ListContactMethodsByContact(ctx, contact.ID)
 	require.NoError(t, err)
 	var hasTelegram bool
 	for _, m := range methods {
-		if m.Type == "telegram" && m.Value == "PhoneMatched" {
+		if m.Type == "telegram" && m.Value == username {
 			hasTelegram = true
 		}
 	}
@@ -231,32 +267,25 @@ func TestMatcherEnrichment_PhoneMatchWithUsername(t *testing.T) {
 }
 
 func TestMatcherEnrichment_PhoneMatchWithoutUsername(t *testing.T) {
-	matcher, contactRepo, methodRepo, _, _, _, database, cleanup := setupMatcherEnrichmentTest(t)
-	defer cleanup()
-
+	env := setupMatcherEnrichmentTest(t)
 	ctx := context.Background()
-	const peerUserID int64 = 770004
-	peerIDStr := "770004"
+	peerUserID, peerIDStr := uniqueTestIDs(t)
+	phone := "+1555" + peerIDStr[:7]
 
-	contact := newTestContact(t, ctx, contactRepo, "Phone Only "+uuid.New().String()[:8])
-	_, err := methodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
+	contact := newTestContact(t, ctx, env.contactRepo, "Phone Only "+peerIDStr)
+	_, err := env.methodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
 		ContactID: contact.ID,
 		Type:      "phone",
-		Value:     "+15557770004",
+		Value:     phone,
 	})
 	require.NoError(t, err)
+	registerCleanupBySource(t, env, ctx, contact.ID, peerIDStr)
 
-	t.Cleanup(func() {
-		_ = contactRepo.HardDeleteContact(ctx, contact.ID)
-		_, _ = database.Queries.DeleteExternalIdentitiesBySourceID(ctx, pgtype.Text{String: peerIDStr, Valid: true})
-	})
-
-	phone := "+15557770004"
-	result, err := matcher.MatchPeer(ctx, peerUserID, nil, nil, nil, &phone)
+	result, err := env.matcher.MatchPeer(ctx, peerUserID, nil, nil, nil, &phone)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
-	methods, err := methodRepo.ListContactMethodsByContact(ctx, contact.ID)
+	methods, err := env.methodRepo.ListContactMethodsByContact(ctx, contact.ID)
 	require.NoError(t, err)
 	for _, m := range methods {
 		assert.NotEqual(t, "telegram", m.Type, "no telegram method when peerUsername absent")
@@ -264,21 +293,16 @@ func TestMatcherEnrichment_PhoneMatchWithoutUsername(t *testing.T) {
 }
 
 func TestMatcherEnrichment_Idempotency(t *testing.T) {
-	matcher, contactRepo, methodRepo, _, _, identitySvc, database, cleanup := setupMatcherEnrichmentTest(t)
-	defer cleanup()
-
+	env := setupMatcherEnrichmentTest(t)
 	ctx := context.Background()
-	const peerUserID int64 = 770005
-	peerIDStr := "770005"
+	peerUserID, peerIDStr := uniqueTestIDs(t)
+	username := "IdemUser" + peerIDStr
 
-	contact := newTestContact(t, ctx, contactRepo, "Idem "+uuid.New().String()[:8])
-	t.Cleanup(func() {
-		_ = contactRepo.HardDeleteContact(ctx, contact.ID)
-		_, _ = database.Queries.DeleteExternalIdentitiesBySourceID(ctx, pgtype.Text{String: peerIDStr, Valid: true})
-	})
+	contact := newTestContact(t, ctx, env.contactRepo, "Idem "+peerIDStr)
+	registerCleanupBySource(t, env, ctx, contact.ID, peerIDStr)
 
-	_, err := identitySvc.MatchOrCreate(ctx, service.MatchRequest{
-		RawIdentifier:  "IdemUser",
+	_, err := env.identitySvc.MatchOrCreate(ctx, service.MatchRequest{
+		RawIdentifier:  username,
 		Type:           identity.IdentifierTypeTelegram,
 		Source:         "telegram",
 		SourceID:       &peerIDStr,
@@ -286,13 +310,12 @@ func TestMatcherEnrichment_Idempotency(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	username := "IdemUser"
 	for range 2 {
-		_, err := matcher.MatchPeer(ctx, peerUserID, &username, nil, nil, nil)
+		_, err := env.matcher.MatchPeer(ctx, peerUserID, &username, nil, nil, nil)
 		require.NoError(t, err)
 	}
 
-	methods, err := methodRepo.ListContactMethodsByContact(ctx, contact.ID)
+	methods, err := env.methodRepo.ListContactMethodsByContact(ctx, contact.ID)
 	require.NoError(t, err)
 	count := 0
 	for _, m := range methods {
@@ -325,11 +348,11 @@ func TestMatcherEnrichment_EnricherErrorDoesNotBreakMatch(t *testing.T) {
 	cfg.Database.URL = databaseURL
 	database, err := db.NewDatabase(context.Background(), cfg.Database)
 	require.NoError(t, err)
-	defer database.Close()
+	t.Cleanup(database.Close)
 
 	ctx := context.Background()
-	const peerUserID int64 = 770006
-	peerIDStr := "770006"
+	peerUserID, peerIDStr := uniqueTestIDs(t)
+	username := "FaultyUser" + peerIDStr
 
 	contactRepo := repository.NewContactRepository(database.Queries)
 	methodRepo := repository.NewContactMethodRepository(database.Queries)
@@ -340,14 +363,14 @@ func TestMatcherEnrichment_EnricherErrorDoesNotBreakMatch(t *testing.T) {
 
 	matcher := tgpkg.NewPeerMatcher(identitySvc, messageRepo, externalRepo, failingEnricher{}, 100)
 
-	contact := newTestContact(t, ctx, contactRepo, "Faulty Enricher "+uuid.New().String()[:8])
+	contact := newTestContact(t, ctx, contactRepo, "Faulty Enricher "+peerIDStr)
 	t.Cleanup(func() {
-		_ = contactRepo.HardDeleteContact(ctx, contact.ID)
 		_, _ = database.Queries.DeleteExternalIdentitiesBySourceID(ctx, pgtype.Text{String: peerIDStr, Valid: true})
+		_ = contactRepo.HardDeleteContact(ctx, contact.ID)
 	})
 
 	_, err = identitySvc.MatchOrCreate(ctx, service.MatchRequest{
-		RawIdentifier:  "FaultyUser",
+		RawIdentifier:  username,
 		Type:           identity.IdentifierTypeTelegram,
 		Source:         "telegram",
 		SourceID:       &peerIDStr,
@@ -355,7 +378,6 @@ func TestMatcherEnrichment_EnricherErrorDoesNotBreakMatch(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	username := "FaultyUser"
 	result, err := matcher.MatchPeer(ctx, peerUserID, &username, nil, nil, nil)
 	require.NoError(t, err, "enricher errors must NOT fail the match")
 	require.NotNil(t, result)
@@ -366,6 +388,4 @@ func TestMatcherEnrichment_EnricherErrorDoesNotBreakMatch(t *testing.T) {
 	for _, m := range methods {
 		assert.NotEqual(t, "telegram", m.Type, "no telegram method when enricher fails")
 	}
-
-	_ = accelerated.GetCurrentTime()
 }

--- a/backend/tests/telegram_matcher_enrichment_test.go
+++ b/backend/tests/telegram_matcher_enrichment_test.go
@@ -328,9 +328,11 @@ func TestMatcherEnrichment_Idempotency(t *testing.T) {
 }
 
 // TestMatcherEnrichment_ConcurrentMatch_TreatsUniqueViolationAsSuccess
-// drives two concurrent MatchPeer calls for the same peer to race the
-// CreateContactMethod insert. One should win; the other should see PG 23505,
-// treat it as success, and produce no warn-level error or duplicate row.
+// drives multiple concurrent MatchPeer calls released by a barrier so the
+// CreateContactMethod inserts overlap. Exactly one wins; the rest hit PG
+// unique_violation (23505) and must treat it as success — no error returned,
+// no duplicate row. Higher concurrency is used to make 23505 path coverage
+// deterministic in practice; a single sequential run cannot trigger it.
 func TestMatcherEnrichment_ConcurrentMatch_TreatsUniqueViolationAsSuccess(t *testing.T) {
 	env := setupMatcherEnrichmentTest(t)
 	ctx := context.Background()
@@ -349,23 +351,27 @@ func TestMatcherEnrichment_ConcurrentMatch_TreatsUniqueViolationAsSuccess(t *tes
 	})
 	require.NoError(t, err)
 
-	// Run two MatchPeer calls concurrently. The first to insert wins; the
-	// second hits PG unique_violation (23505) and must treat it as success.
-	const concurrency = 2
+	// Barrier release — every goroutine waits, then races into MatchPeer
+	// simultaneously. With 8 concurrent callers any sequential interleaving
+	// is vanishingly unlikely; at least one is guaranteed to hit 23505.
+	const concurrency = 8
+	start := make(chan struct{})
 	errs := make(chan error, concurrency)
 	var wg sync.WaitGroup
 	for range concurrency {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			<-start
 			_, err := env.matcher.MatchPeer(ctx, peerUserID, &username, nil, nil, nil)
 			errs <- err
 		}()
 	}
+	close(start)
 	wg.Wait()
 	close(errs)
 	for err := range errs {
-		require.NoError(t, err, "concurrent MatchPeer must not return an error")
+		require.NoError(t, err, "concurrent MatchPeer must not return an error even on 23505 race")
 	}
 
 	methods, err := env.methodRepo.ListContactMethodsByContact(ctx, contact.ID)

--- a/frontend/src/lib/__tests__/method-conflict-detection.test.ts
+++ b/frontend/src/lib/__tests__/method-conflict-detection.test.ts
@@ -236,6 +236,52 @@ describe('method-conflict-detection', () => {
       expect(result.every(r => r.conflict_type === 'none')).toBe(true)
       expect(result.every(r => r.state === 'adding')).toBe(true)
     })
+
+    it('telegram handle sharing normalized value with twitter is added, not marked identical', () => {
+      // Dedup must be type-scoped: an existing `twitter:foo` must NOT mask an
+      // incoming Telegram `@foo` as "same as CRM". The two normalize to the
+      // same handle (`foo`) but live in separate type buckets; the backend
+      // admits both, and the UI must not lie.
+      const candidate: ImportCandidate = {
+        id: 'ext-1',
+        source: 'telegram',
+        display_name: 'Test User',
+        emails: [],
+        phones: [],
+        metadata: { username: '@foo' },
+      }
+      const crmMethods = [createMethod('twitter', '@foo')]
+
+      const result = detectMethodConflicts(candidate, crmMethods)
+
+      expect(result).toHaveLength(1)
+      expect(result[0]).toMatchObject({
+        external_value: '@foo',
+        external_type: 'telegram',
+        suggested_crm_type: 'telegram',
+        conflict_type: 'none',
+        state: 'adding',
+      })
+      expect(result[0].crm_method).toBeUndefined()
+    })
+
+    it('email sharing normalized value with telegram is added, not marked identical', () => {
+      // Opposite direction: existing telegram:foo must not mask a new email
+      // value that normalizes to the same string (hypothetical but covered
+      // for completeness).
+      const candidate = createCandidate(['foo@example.com'])
+      const crmMethods = [createMethod('telegram', 'foo@example.com')]
+
+      const result = detectMethodConflicts(candidate, crmMethods)
+
+      expect(result).toHaveLength(1)
+      expect(result[0]).toMatchObject({
+        external_value: 'foo@example.com',
+        suggested_crm_type: 'email',
+        conflict_type: 'none',
+        state: 'adding',
+      })
+    })
   })
 
   describe('getMethodStateClasses', () => {

--- a/frontend/src/lib/method-conflict-detection.ts
+++ b/frontend/src/lib/method-conflict-detection.ts
@@ -35,12 +35,17 @@ export function detectMethodConflicts(
 ): MethodComparison[] {
   const comparisons: MethodComparison[] = []
 
-  // Build map for CRM methods by normalized value
-  const crmByNormalizedValue = new Map<string, ContactMethod>()
+  // Build map for CRM methods keyed by `type:normalized_value`. Type-scoping
+  // mirrors the backend dedup shape (DB unique index on
+  // `(contact_id, type, value_normalized)`) so a Telegram `@foo` is not
+  // falsely marked as "same as CRM" when the only existing row is
+  // `twitter:foo` — the two live in separate type buckets.
+  const crmByTypedKey = new Map<string, ContactMethod>()
+  const typedKey = (type: string, normalized: string) => `${type}:${normalized}`
 
   for (const method of crmMethods) {
     const normalized = normalizeContactMethodValueForComparison(method.type, method.value)
-    crmByNormalizedValue.set(normalized, method)
+    crmByTypedKey.set(typedKey(method.type, normalized), method)
   }
 
   // Process emails
@@ -48,8 +53,8 @@ export function detectMethodConflicts(
     const suggestedType: ContactMethodType = 'email'
     const normalized = normalizeContactMethodValueForComparison(suggestedType, email)
 
-    // Check if value already exists in CRM
-    const existingByValue = crmByNormalizedValue.get(normalized)
+    // Check if value already exists in CRM (type-scoped)
+    const existingByValue = crmByTypedKey.get(typedKey(suggestedType, normalized))
 
     let conflictType: ConflictType = 'none'
     let state: MethodState = 'adding'
@@ -85,8 +90,8 @@ export function detectMethodConflicts(
     const normalized = normalizeContactMethodValueForComparison('phone', phone)
     const suggestedType: ContactMethodType = 'phone'
 
-    // Check if value already exists in CRM
-    const existingByValue = crmByNormalizedValue.get(normalized)
+    // Check if value already exists in CRM (type-scoped)
+    const existingByValue = crmByTypedKey.get(typedKey(suggestedType, normalized))
 
     let conflictType: ConflictType = 'none'
     let state: MethodState = 'adding'
@@ -127,7 +132,7 @@ export function detectMethodConflicts(
     const suggestedType: ContactMethodType = 'telegram'
     const normalized = normalizeContactMethodValueForComparison(suggestedType, displayValue)
 
-    const existingByValue = crmByNormalizedValue.get(normalized)
+    const existingByValue = crmByTypedKey.get(typedKey(suggestedType, normalized))
 
     let conflictType: ConflictType = 'none'
     let state: MethodState = 'adding'


### PR DESCRIPTION
## Summary

Fixes the bug discovered with contact `ea365ac2-d337-470f-b3c9-77bb03b75301` (<user>): a `match_status='matched'` Telegram external_contact had its `metadata.username='@<user>'`, an `external_identity` linking `<user>` to him — but **no `contact_method` row of type `telegram`**.

Three gaps closed:
- **Link flow with telegram in `selected_methods`** — `enrichContactMethodsWithSelections` previously rejected telegram selections at the `externalValues` admission check (built only from emails/phones), so `LinkContact` silently dropped them.
- **Matcher auto-match (live + batch)** — `PeerMatcher.MatchPeer` never called any method-level enrichment after a successful identity match, so peers matched via `external_identity` cache (#272 username-name path or below-threshold) never got the telegram method added.
- **Stored-value canonicalization in selections mode** — telegram values like `@<user>` and bare `<user>` are now both admitted and stored as the canonical bare form, matching `buildMethodsAuto` behavior.

### Mechanism

- New shared helper `service.BuildMethodsFromExternal` is the single source of truth for translating `*ExternalContact` → `[]ContactMethodInput`. Used by import-new (replaces `buildMethodsAuto`), link auto-mode, link selections-mode admission, and matcher auto-match enrichment.
- New `EnrichmentService.SyncMethodsFromExternal(ctx, contactID, *ExternalContact)` — narrow method-only variant that does NOT touch `profile_photo`, `birthday`, `location`, `full_name`, `cadence`. Intended for matcher's silent auto-match path where rewriting profile fields would be surprising.
- `PeerMatcher.MatchPeer` now calls `ensureMethodsOnMatch` after the username and phone match paths. It reads any persisted `external_contact`, **merges** the current message's `peerUsername` over `metadata.username` (current wins — handles handle-renames + gaps in pre-capture rows), or synthesizes a minimal `*ExternalContact` when none exists (below-threshold peers). Errors are logged at warn and never fail the match.
- Type-scoped dedup key (`type + ":" + identity.Normalize(value, ...)`) mirrors the DB unique index on `(contact_id, type, value_normalized)`.
- PG `23505` unique-violation on concurrent insert is treated as success in both auto and selections paths. Selections-mode also refetches the methods list to recover the raced row's ID for `IsPrimary` promotion.
- `recordEnrichment` writes SQL `NULL` for `external_contact_id` when `external.ID == uuid.Nil` (matcher's synthesized case).

### Plan, review, implementation

- Plan: `.ai/spec/telegram-method-enrichment.md` (v5, 4 Codex rounds in plan phase + 3 Codex rounds during implementation).
- Implementation: 6 commits ending at `dd0b4f0`. Local Codex review: PASS after round 3.

## Test plan

Backend unit + integration:

- [x] `BuildMethodsFromExternal` 12-case unit table covers nil/empty/email/phone/telegram/leading-@/whitespace/non-string/non-telegram-source.
- [x] `canonicalizeMethodValue` unit table.
- [x] `isUniqueViolation` deterministic unit table (direct + wrapped + non-23505 codes).
- [x] Matcher unit tests (11 new): `MatchPeer` enricher invocation under username match, phone match w/ + w/o username, unmatched, nil enricher, enricher error, persisted-external preferred, absent-external synthesized, persisted nil/empty/stale metadata, no-username-anywhere.
- [x] Matcher integration tests (8 new): above-threshold username match, below-threshold synthesis, phone match w/ + w/o username, idempotency (sequential), profile fields untouched, enricher error doesn't break match, **already-matched external_contact repair path** (the original <user> bug), **8-goroutine barrier-released concurrent MatchPeer race** for 23505 path.
- [x] Link integration tests (7 new): bare-handle stored canonicalized, leading-@ stripped, deselected case, idempotency, auto-fallback enriches telegram, profile fields untouched, audit row written with persisted `external_contact_id`.
- [x] Import-new regression test confirms `BuildMethodsFromExternal` matches legacy `buildMethodsAuto` output.
- [x] `make lint` clean. `make test` passes for all touched paths; the 2-3 pre-existing soft-delete + shared-DB flakes (`TestTelegramMessage_UpsertAndGet`, `TestFollowupFilter`, `TestContactRepository_Integration`) were verified to fail on `main` too — unrelated.

## Out of scope

- Backfill SQL for historical matched-but-unenriched peers (user is running separately).
- Rematching historical messages when a new method is added (#182).
- E2E tests (frontend already wires telegram selections; only backend was broken).