### PR TITLE
feat(rematch): retroactively link calendar events and telegram messages on new contact methods

### DIFF
--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -321,7 +321,7 @@ func main() {
 	noteHandler := handlers.NewNoteHandler(noteService)
 	interactionHandler := handlers.NewInteractionHandler(contactService, interactionRepo)
 	systemHandler := handlers.NewSystemHandler(contactRepo, cfg.Runtime)
-	rematchHandler := handlers.NewRematchHandler(rematchService, contactService, contactMethodRepo)
+	rematchHandler := handlers.NewRematchHandler(rematchService, contactService)
 
 	// Initialize and start scheduler
 	cronScheduler := scheduler.NewScheduler(syncService, cfg.Features.EnableExternalSync)

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -102,6 +102,12 @@ func main() {
 	// scope so both feature blocks share a single instance.
 	enrichmentService := service.NewEnrichmentService(contactRepo, contactMethodRepo, enrichmentRepo)
 
+	// Rematch service — wired now so downstream services can call SetRematchService.
+	// Handlers are registered below once their dependencies are constructed.
+	rematchService := service.NewRematchService()
+	contactService.SetRematchService(rematchService)
+	enrichmentService.SetRematchService(rematchService)
+
 	// Initialize external sync components (feature-flagged)
 	var syncService *service.SyncService
 	var syncHandler *handlers.SyncHandler
@@ -302,6 +308,7 @@ func main() {
 	noteHandler := handlers.NewNoteHandler(noteService)
 	interactionHandler := handlers.NewInteractionHandler(contactService, interactionRepo)
 	systemHandler := handlers.NewSystemHandler(contactRepo, cfg.Runtime)
+	rematchHandler := handlers.NewRematchHandler(rematchService, contactService, contactMethodRepo)
 
 	// Initialize and start scheduler
 	cronScheduler := scheduler.NewScheduler(syncService, cfg.Features.EnableExternalSync)
@@ -364,6 +371,14 @@ func main() {
 		interactions := v1.Group("/interactions")
 		{
 			interactions.DELETE("/:id", interactionHandler.DeleteInteraction)
+		}
+
+		// Rematch routes — always registered; service no-ops when no handlers
+		// are registered (e.g. telegram-disabled deployments still get calendar).
+		rematchRoutes := v1.Group("/rematch")
+		{
+			rematchRoutes.GET("/jobs/:jobID", rematchHandler.GetJob)
+			rematchRoutes.POST("/contacts/:id/rescan", rematchHandler.Rescan)
 		}
 
 		// System routes

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -173,6 +173,15 @@ func main() {
 		// so the Telegram block can share it).
 		identityService := service.NewIdentityService(identityRepo)
 
+		// Calendar repo + handler + rematch handler are wired whenever external
+		// sync is enabled, regardless of OAuth configuration. Rematch over
+		// calendar_event is pure DB work and must run in test/local environments
+		// that don't have Google OAuth set up.
+		calendarRepo := repository.NewCalendarEventRepository(database.Queries)
+		calendarHandler = handlers.NewCalendarHandler(calendarRepo)
+		rematchService.Register(google.NewCalendarRematchHandler(calendarRepo, externalContactRepo, contactService))
+		logger.Info().Msg("Calendar rematch handler registered")
+
 		// Register Google Contacts provider if OAuth is configured
 		if googleOAuthService != nil {
 			gcontactsProvider := google.NewContactsProvider(
@@ -185,7 +194,6 @@ func main() {
 			logger.Info().Msg("Google Contacts sync provider registered")
 
 			// Register Google Calendar provider
-			calendarRepo := repository.NewCalendarEventRepository(database.Queries)
 			gcalProvider := google.NewCalendarSyncProvider(
 				googleOAuthService,
 				calendarRepo,
@@ -196,14 +204,6 @@ func main() {
 			)
 			providerRegistry.Register(gcalProvider)
 			logger.Info().Msg("Google Calendar sync provider registered")
-
-			// Register calendar rematch handler — same contactService instance
-			// passed to the sync provider so per-source dedup behavior matches.
-			rematchService.Register(google.NewCalendarRematchHandler(calendarRepo, externalContactRepo, contactService))
-			logger.Info().Msg("Calendar rematch handler registered")
-
-			// Initialize calendar handler
-			calendarHandler = handlers.NewCalendarHandler(calendarRepo)
 		}
 
 		// Register Todoist Cadence provider if OAuth is configured

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -197,6 +197,11 @@ func main() {
 			providerRegistry.Register(gcalProvider)
 			logger.Info().Msg("Google Calendar sync provider registered")
 
+			// Register calendar rematch handler — same contactService instance
+			// passed to the sync provider so per-source dedup behavior matches.
+			rematchService.Register(google.NewCalendarRematchHandler(calendarRepo, externalContactRepo, contactService))
+			logger.Info().Msg("Calendar rematch handler registered")
+
 			// Initialize calendar handler
 			calendarHandler = handlers.NewCalendarHandler(calendarRepo)
 		}

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -300,6 +300,14 @@ func main() {
 		defer telegramManager.Stop()
 
 		telegramHandler = handlers.NewTelegramHandler(telegramManager)
+
+		// Register telegram rematch handlers (telegram + phone identifiers)
+		// against the same matcher/aggregator instances the manager owns so
+		// rematch behavior is identical to the post-import path.
+		rematchService.Register(tgpkg.NewUsernameRematchHandler(telegramMessageRepo, telegramManager.PeerMatcher(), telegramManager.AggregationEngine()))
+		rematchService.Register(tgpkg.NewPhoneRematchHandler(telegramMessageRepo, telegramManager.PeerMatcher(), telegramManager.AggregationEngine()))
+		logger.Info().Msg("Telegram rematch handlers registered")
+
 		logger.Info().Msg("Telegram integration initialized")
 	}
 

--- a/backend/internal/api/handlers/contact.go
+++ b/backend/internal/api/handlers/contact.go
@@ -92,6 +92,7 @@ type ContactResponse struct {
 	ProfilePhoto       *string                 `json:"profile_photo,omitempty" example:"https://example.com/photo.jpg"`
 	CreatedAt          time.Time               `json:"created_at" example:"2024-01-01T00:00:00Z"`
 	UpdatedAt          time.Time               `json:"updated_at" example:"2024-01-15T10:30:00Z"`
+	RematchJobID       *string                 `json:"rematch_job_id,omitempty"`
 }
 
 // ContactMethodResponse represents a contact method in responses
@@ -201,6 +202,16 @@ func contactToResponse(contact *repository.Contact) ContactResponse {
 	}
 }
 
+// nilStringPtrFromUUID converts a uuid to a *string, returning nil for uuid.Nil.
+// Used to populate optional rematch_job_id fields on response DTOs.
+func nilStringPtrFromUUID(id uuid.UUID) *string {
+	if id == uuid.Nil {
+		return nil
+	}
+	s := id.String()
+	return &s
+}
+
 func contactMethodToResponse(method repository.ContactMethod) ContactMethodResponse {
 	return ContactMethodResponse{
 		ID:        method.ID.String(),
@@ -283,7 +294,7 @@ func (h *ContactHandler) CreateContact(c *gin.Context) {
 		return
 	}
 
-	contact, err := h.contactService.CreateContact(
+	contact, rematchJobID, err := h.contactService.CreateContact(
 		c.Request.Context(),
 		createRequestToRepo(req),
 		buildContactMethodInputs(req.Methods),
@@ -294,6 +305,7 @@ func (h *ContactHandler) CreateContact(c *gin.Context) {
 	}
 
 	response := contactToResponse(contact)
+	response.RematchJobID = nilStringPtrFromUUID(rematchJobID)
 	api.SendSuccess(c, http.StatusCreated, response, nil)
 }
 
@@ -512,7 +524,7 @@ func (h *ContactHandler) UpdateContact(c *gin.Context) {
 		return
 	}
 
-	contact, err := h.contactService.UpdateContact(
+	contact, rematchJobID, err := h.contactService.UpdateContact(
 		c.Request.Context(),
 		id,
 		updateRequestToRepo(req),
@@ -529,6 +541,7 @@ func (h *ContactHandler) UpdateContact(c *gin.Context) {
 	}
 
 	response := contactToResponse(contact)
+	response.RematchJobID = nilStringPtrFromUUID(rematchJobID)
 	api.SendSuccess(c, http.StatusOK, response, nil)
 }
 

--- a/backend/internal/api/handlers/import.go
+++ b/backend/internal/api/handlers/import.go
@@ -108,6 +108,18 @@ type LinkRequest struct {
 	Name                *string               `json:"name,omitempty"`
 }
 
+// ImportContactResponse wraps the created contact along with an optional rematch job ID.
+type ImportContactResponse struct {
+	Contact      ContactResponse `json:"contact"`
+	RematchJobID *string         `json:"rematch_job_id,omitempty"`
+}
+
+// LinkContactResponse wraps the linked external contact along with an optional rematch job ID.
+type LinkContactResponse struct {
+	ExternalContact *repository.ExternalContact `json:"external_contact"`
+	RematchJobID    *string                     `json:"rematch_job_id,omitempty"`
+}
+
 // ListImportCandidates returns unmatched external contacts
 // @Summary List import candidates
 // @Description Get unmatched external contacts that can be imported as CRM contacts
@@ -281,7 +293,7 @@ func (h *ImportHandler) GetImportCandidate(c *gin.Context) {
 // @Produce json
 // @Param id path string true "External contact ID"
 // @Param body body ImportRequest false "Optional method selection"
-// @Success 201 {object} api.APIResponse{data=repository.Contact}
+// @Success 201 {object} api.APIResponse{data=ImportContactResponse}
 // @Failure 400 {object} api.APIResponse{error=api.APIError}
 // @Failure 404 {object} api.APIResponse{error=api.APIError}
 // @Failure 500 {object} api.APIResponse{error=api.APIError}
@@ -362,23 +374,28 @@ func (h *ImportHandler) ImportContact(c *gin.Context) {
 	}
 
 	// Create the CRM contact
-	contact, err := h.contactSvc.CreateContact(ctx, createReq, methods)
+	contact, rematchJobID, err := h.contactSvc.CreateContact(ctx, createReq, methods)
 	if err != nil {
 		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to create contact", err.Error())
 		return
 	}
 
+	response := ImportContactResponse{
+		Contact:      contactToResponse(contact),
+		RematchJobID: nilStringPtrFromUUID(rematchJobID),
+	}
+
 	// Update external contact to link to new CRM contact
 	if _, err := h.externalRepo.UpdateMatch(ctx, id, &contact.ID, repository.MatchStatusImported); err != nil {
 		logger.Warn().Err(err).Str("external_id", id.String()).Msg("failed to update match status after import")
-		api.SendSuccess(c, http.StatusCreated, contact, nil)
+		api.SendSuccess(c, http.StatusCreated, response, nil)
 		return
 	}
 
 	// Post-import hook: back-link Telegram message history
 	h.triggerPostImportHook(ctx, external, contact.ID)
 
-	api.SendSuccess(c, http.StatusCreated, contact, nil)
+	api.SendSuccess(c, http.StatusCreated, response, nil)
 }
 
 // buildMethodsFromSelection builds contact methods from user selection
@@ -454,7 +471,7 @@ func (h *ImportHandler) buildMethodsFromSelection(external *repository.ExternalC
 // @Produce json
 // @Param id path string true "External contact ID"
 // @Param body body LinkRequest true "Link request"
-// @Success 200 {object} api.APIResponse{data=repository.ExternalContact}
+// @Success 200 {object} api.APIResponse{data=LinkContactResponse}
 // @Failure 400 {object} api.APIResponse{error=api.APIError}
 // @Failure 404 {object} api.APIResponse{error=api.APIError}
 // @Failure 500 {object} api.APIResponse{error=api.APIError}
@@ -505,9 +522,12 @@ func (h *ImportHandler) LinkContact(c *gin.Context) {
 	}
 
 	// Enrich the CRM contact - use method selections if provided
-	var enrichErr error
+	var (
+		enrichErr    error
+		rematchJobID uuid.UUID
+	)
 	if len(req.SelectedMethods) > 0 || len(req.ConflictResolutions) > 0 || req.Cadence != nil || req.Name != nil {
-		enrichErr = h.enricher.EnrichContactFromExternalWithSelections(
+		rematchJobID, enrichErr = h.enricher.EnrichContactFromExternalWithSelections(
 			ctx,
 			crmContactID,
 			updated,
@@ -517,7 +537,7 @@ func (h *ImportHandler) LinkContact(c *gin.Context) {
 			req.Name,
 		)
 	} else {
-		enrichErr = h.enricher.EnrichContactFromExternal(ctx, crmContactID, updated)
+		rematchJobID, enrichErr = h.enricher.EnrichContactFromExternal(ctx, crmContactID, updated)
 	}
 
 	if enrichErr != nil {
@@ -532,7 +552,10 @@ func (h *ImportHandler) LinkContact(c *gin.Context) {
 	// Post-import hook: back-link Telegram message history
 	h.triggerPostImportHook(ctx, external, crmContactID)
 
-	api.SendSuccess(c, http.StatusOK, updated, nil)
+	api.SendSuccess(c, http.StatusOK, LinkContactResponse{
+		ExternalContact: updated,
+		RematchJobID:    nilStringPtrFromUUID(rematchJobID),
+	}, nil)
 }
 
 // triggerPostImportHook calls the post-import hook for Telegram candidates (best-effort).

--- a/backend/internal/api/handlers/rematch.go
+++ b/backend/internal/api/handlers/rematch.go
@@ -7,7 +7,6 @@ import (
 
 	"personal-crm/backend/internal/api"
 	"personal-crm/backend/internal/db"
-	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/service"
 
 	"github.com/gin-gonic/gin"
@@ -19,15 +18,13 @@ import (
 type RematchHandler struct {
 	rematchSvc *service.RematchService
 	contactSvc *service.ContactService
-	methodRepo *repository.ContactMethodRepository
 }
 
 // NewRematchHandler constructs a RematchHandler.
-func NewRematchHandler(rematchSvc *service.RematchService, contactSvc *service.ContactService, methodRepo *repository.ContactMethodRepository) *RematchHandler {
+func NewRematchHandler(rematchSvc *service.RematchService, contactSvc *service.ContactService) *RematchHandler {
 	return &RematchHandler{
 		rematchSvc: rematchSvc,
 		contactSvc: contactSvc,
-		methodRepo: methodRepo,
 	}
 }
 
@@ -103,23 +100,15 @@ func (h *RematchHandler) Rescan(c *gin.Context) {
 		return
 	}
 
-	// Confirm the contact exists (and is not soft-deleted).
-	if _, err := h.contactSvc.GetContact(ctx, id); err != nil {
+	jobID, err := h.rematchSvc.RescanContact(ctx, h.contactSvc, id)
+	if err != nil {
 		if errors.Is(err, db.ErrNotFound) {
 			api.SendNotFound(c, "Contact")
 			return
 		}
-		api.SendInternalError(c, "Failed to load contact")
+		api.SendInternalError(c, "Failed to start rematch")
 		return
 	}
-
-	methods, err := h.methodRepo.ListContactMethodsByContact(ctx, id)
-	if err != nil {
-		api.SendInternalError(c, "Failed to load contact methods")
-		return
-	}
-
-	jobID := h.rematchSvc.StartRematchForContact(id, serviceMethodsFromContactMethods(methods))
 	api.SendSuccess(c, http.StatusOK, RescanResponse{
 		RematchJobID: nilStringPtrFromUUID(jobID),
 	}, nil)
@@ -140,14 +129,4 @@ func toRematchJobResponse(j service.JobProgress) RematchJobResponse {
 		CompletedAt: j.CompletedAt,
 		Error:       j.Error,
 	}
-}
-
-// serviceMethodsFromContactMethods is a handler-local helper that mirrors
-// service.toRematchMethods (unexported in the service package).
-func serviceMethodsFromContactMethods(methods []repository.ContactMethod) []service.Method {
-	out := make([]service.Method, len(methods))
-	for i, m := range methods {
-		out[i] = service.Method{Type: m.Type, Value: m.ValueNormalized}
-	}
-	return out
 }

--- a/backend/internal/api/handlers/rematch.go
+++ b/backend/internal/api/handlers/rematch.go
@@ -1,0 +1,153 @@
+package handlers
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	"personal-crm/backend/internal/api"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+// RematchHandler exposes HTTP endpoints for inspecting and triggering rematch
+// jobs produced by service.RematchService.
+type RematchHandler struct {
+	rematchSvc *service.RematchService
+	contactSvc *service.ContactService
+	methodRepo *repository.ContactMethodRepository
+}
+
+// NewRematchHandler constructs a RematchHandler.
+func NewRematchHandler(rematchSvc *service.RematchService, contactSvc *service.ContactService, methodRepo *repository.ContactMethodRepository) *RematchHandler {
+	return &RematchHandler{
+		rematchSvc: rematchSvc,
+		contactSvc: contactSvc,
+		methodRepo: methodRepo,
+	}
+}
+
+// RematchJobMethod mirrors service.Method for HTTP responses.
+type RematchJobMethod struct {
+	Type  string `json:"type"`
+	Value string `json:"value"`
+}
+
+// RematchJobResponse is the external view of a rematch job.
+type RematchJobResponse struct {
+	ID          string             `json:"id"`
+	ContactID   string             `json:"contact_id"`
+	Status      string             `json:"status"`
+	Matched     int                `json:"matched"`
+	Methods     []RematchJobMethod `json:"methods"`
+	StartedAt   time.Time          `json:"started_at"`
+	CompletedAt *time.Time         `json:"completed_at,omitempty"`
+	Error       string             `json:"error,omitempty"`
+}
+
+// RescanResponse is returned by the manual rescan endpoint.
+type RescanResponse struct {
+	RematchJobID *string `json:"rematch_job_id"`
+}
+
+// GetJob returns the current state of a rematch job.
+// @Summary Get rematch job
+// @Description Returns the progress of a rematch job by ID.
+// @Tags rematch
+// @Produce json
+// @Param jobID path string true "Rematch job ID" format(uuid)
+// @Success 200 {object} api.APIResponse{data=RematchJobResponse}
+// @Failure 400 {object} api.APIResponse{error=api.APIError}
+// @Failure 404 {object} api.APIResponse{error=api.APIError}
+// @Router /rematch/jobs/{jobID} [get]
+func (h *RematchHandler) GetJob(c *gin.Context) {
+	id, err := uuid.Parse(c.Param("jobID"))
+	if err != nil {
+		api.SendValidationError(c, "Invalid job ID", "ID must be a valid UUID")
+		return
+	}
+
+	job, err := h.rematchSvc.GetJob(id)
+	if err != nil {
+		if errors.Is(err, service.ErrJobNotFound) {
+			api.SendNotFound(c, "Rematch job")
+			return
+		}
+		api.SendInternalError(c, "Failed to load rematch job")
+		return
+	}
+
+	api.SendSuccess(c, http.StatusOK, toRematchJobResponse(job), nil)
+}
+
+// Rescan triggers a full rematch across all of the contact's current methods.
+// @Summary Trigger rematch for a contact
+// @Description Re-runs rematch handlers for every method currently on the contact.
+// @Tags rematch
+// @Produce json
+// @Param id path string true "Contact ID" format(uuid)
+// @Success 200 {object} api.APIResponse{data=RescanResponse}
+// @Failure 400 {object} api.APIResponse{error=api.APIError}
+// @Failure 404 {object} api.APIResponse{error=api.APIError}
+// @Router /rematch/contacts/{id}/rescan [post]
+func (h *RematchHandler) Rescan(c *gin.Context) {
+	ctx := c.Request.Context()
+
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		api.SendValidationError(c, "Invalid contact ID", "ID must be a valid UUID")
+		return
+	}
+
+	// Confirm the contact exists (and is not soft-deleted).
+	if _, err := h.contactSvc.GetContact(ctx, id); err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			api.SendNotFound(c, "Contact")
+			return
+		}
+		api.SendInternalError(c, "Failed to load contact")
+		return
+	}
+
+	methods, err := h.methodRepo.ListContactMethodsByContact(ctx, id)
+	if err != nil {
+		api.SendInternalError(c, "Failed to load contact methods")
+		return
+	}
+
+	jobID := h.rematchSvc.StartRematchForContact(id, serviceMethodsFromContactMethods(methods))
+	api.SendSuccess(c, http.StatusOK, RescanResponse{
+		RematchJobID: nilStringPtrFromUUID(jobID),
+	}, nil)
+}
+
+func toRematchJobResponse(j service.JobProgress) RematchJobResponse {
+	methods := make([]RematchJobMethod, len(j.Methods))
+	for i, m := range j.Methods {
+		methods[i] = RematchJobMethod{Type: m.Type, Value: m.Value}
+	}
+	return RematchJobResponse{
+		ID:          j.ID.String(),
+		ContactID:   j.ContactID.String(),
+		Status:      string(j.Status),
+		Matched:     j.Matched,
+		Methods:     methods,
+		StartedAt:   j.StartedAt,
+		CompletedAt: j.CompletedAt,
+		Error:       j.Error,
+	}
+}
+
+// serviceMethodsFromContactMethods is a handler-local helper that mirrors
+// service.toRematchMethods (unexported in the service package).
+func serviceMethodsFromContactMethods(methods []repository.ContactMethod) []service.Method {
+	out := make([]service.Method, len(methods))
+	for i, m := range methods {
+		out[i] = service.Method{Type: m.Type, Value: m.ValueNormalized}
+	}
+	return out
+}

--- a/backend/internal/api/handlers/test.go
+++ b/backend/internal/api/handlers/test.go
@@ -403,12 +403,16 @@ func (h *TestHandler) SeedOverdueContacts(c *gin.Context) {
 
 // SeedCalendarEventInput represents input for creating a calendar event
 type SeedCalendarEventInput struct {
-	Title     string `json:"title" validate:"required,min=1,max=255"`
-	Location  string `json:"location,omitempty"`
-	HtmlLink  string `json:"html_link,omitempty"`
-	IsPast    bool   `json:"is_past,omitempty"`    // If true, event is set in the past
-	DaysAgo   int    `json:"days_ago,omitempty"`   // If is_past, how many days ago (default: 7)
-	DaysAhead int    `json:"days_ahead,omitempty"` // If not is_past, how many days ahead (default: 7)
+	Title          string   `json:"title" validate:"required,min=1,max=255"`
+	Location       string   `json:"location,omitempty"`
+	HtmlLink       string   `json:"html_link,omitempty"`
+	IsPast         bool     `json:"is_past,omitempty"`    // If true, event is set in the past
+	DaysAgo        int      `json:"days_ago,omitempty"`   // If is_past, how many days ago (default: 7)
+	DaysAhead      int      `json:"days_ahead,omitempty"` // If not is_past, how many days ahead (default: 7)
+	AttendeeEmails []string `json:"attendee_emails,omitempty"`
+	// Unmatched, when true, seeds the event with attendee emails but does NOT
+	// add contact_id to matched_contact_ids. Used for rematch E2E tests.
+	Unmatched bool `json:"unmatched,omitempty"`
 }
 
 // SeedCalendarEventsRequest represents the request to seed calendar events
@@ -481,6 +485,20 @@ func (h *TestHandler) SeedCalendarEvents(c *gin.Context) {
 		// Build title with prefix
 		title := req.Prefix + "-" + input.Title
 
+		// Build attendee list from optional attendee_emails.
+		attendees := make([]repository.Attendee, 0, len(input.AttendeeEmails))
+		for _, email := range input.AttendeeEmails {
+			attendees = append(attendees, repository.Attendee{Email: email})
+		}
+
+		// matched_contact_ids defaults to the request's primary contact, but
+		// is empty when Unmatched is set so rematch E2E tests can drive the
+		// "no link until method is added" flow.
+		matchedIDs := []uuid.UUID{contactID}
+		if input.Unmatched {
+			matchedIDs = []uuid.UUID{}
+		}
+
 		// Build upsert request
 		upsertReq := repository.UpsertCalendarEventRequest{
 			GcalEventID:          fmt.Sprintf("%s-event-%d", req.Prefix, i),
@@ -490,7 +508,8 @@ func (h *TestHandler) SeedCalendarEvents(c *gin.Context) {
 			StartTime:            startTime,
 			EndTime:              endTime,
 			Status:               "confirmed",
-			MatchedContactIDs:    []uuid.UUID{contactID},
+			Attendees:            attendees,
+			MatchedContactIDs:    matchedIDs,
 			SyncedAt:             now,
 			LastContactedUpdated: false,
 		}

--- a/backend/internal/api/handlers/test.go
+++ b/backend/internal/api/handlers/test.go
@@ -286,7 +286,7 @@ func (h *TestHandler) SeedContacts(c *gin.Context) {
 			createReq.Cadence = &input.Cadence
 		}
 
-		contact, err := h.contactSvc.CreateContact(ctx, createReq, methods)
+		contact, _, err := h.contactSvc.CreateContact(ctx, createReq, methods)
 		if err != nil {
 			api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal,
 				fmt.Sprintf("Contact %d (%s): creation failed", i+1, input.FullName), err.Error())
@@ -386,7 +386,7 @@ func (h *TestHandler) SeedOverdueContacts(c *gin.Context) {
 			LastContacted: &lastContacted,
 		}
 
-		contact, err := h.contactSvc.CreateContact(ctx, createReq, methods)
+		contact, _, err := h.contactSvc.CreateContact(ctx, createReq, methods)
 		if err != nil {
 			api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to create contact", err.Error())
 			return

--- a/backend/internal/db/calendar_event.sql.go
+++ b/backend/internal/db/calendar_event.sql.go
@@ -11,6 +11,28 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const AppendMatchedContact = `-- name: AppendMatchedContact :exec
+UPDATE calendar_event
+SET matched_contact_ids = array_append(matched_contact_ids, $1::uuid),
+    updated_at = NOW()
+WHERE id = $2::uuid
+  AND NOT ($1::uuid = ANY(matched_contact_ids))
+`
+
+type AppendMatchedContactParams struct {
+	ContactID pgtype.UUID `json:"contact_id"`
+	EventID   pgtype.UUID `json:"event_id"`
+}
+
+// Atomically appends a contact to an event's matched_contact_ids iff it isn't
+// already present. Does NOT reset last_contacted_updated — the rematch handler
+// records interactions directly for past events (see rematch plan Design
+// Decision 6) so the scheduler race is avoided at the source.
+func (q *Queries) AppendMatchedContact(ctx context.Context, arg AppendMatchedContactParams) error {
+	_, err := q.db.Exec(ctx, AppendMatchedContact, arg.ContactID, arg.EventID)
+	return err
+}
+
 const CountEventsForContact = `-- name: CountEventsForContact :one
 SELECT COUNT(*) FROM calendar_event
 WHERE $1::uuid = ANY(matched_contact_ids)
@@ -34,6 +56,67 @@ WHERE google_account_id = $1
 func (q *Queries) DeleteEventsByAccount(ctx context.Context, googleAccountID string) error {
 	_, err := q.db.Exec(ctx, DeleteEventsByAccount, googleAccountID)
 	return err
+}
+
+const FindEventsByAttendeeEmailUnmatchedForContact = `-- name: FindEventsByAttendeeEmailUnmatchedForContact :many
+SELECT id, gcal_event_id, gcal_calendar_id, google_account_id, title, description, location, start_time, end_time, all_day, status, user_response, organizer_email, attendees, matched_contact_ids, synced_at, last_contacted_updated, created_at, updated_at, html_link FROM calendar_event
+WHERE EXISTS (
+    SELECT 1 FROM jsonb_array_elements(attendees) AS a
+    WHERE LOWER(a->>'email') = LOWER($1::text)
+)
+  AND NOT ($2::uuid = ANY(matched_contact_ids))
+  AND status != 'cancelled'
+`
+
+type FindEventsByAttendeeEmailUnmatchedForContactParams struct {
+	Email     string      `json:"email"`
+	ContactID pgtype.UUID `json:"contact_id"`
+}
+
+// Finds events whose JSONB attendees contain the given normalized email but
+// do not yet have the contact in matched_contact_ids. Used by the rematch
+// service to retroactively link historical calendar events when a contact
+// method is added to a CRM contact.
+// calendar_event has no deleted_at column — do not filter on it.
+func (q *Queries) FindEventsByAttendeeEmailUnmatchedForContact(ctx context.Context, arg FindEventsByAttendeeEmailUnmatchedForContactParams) ([]*CalendarEvent, error) {
+	rows, err := q.db.Query(ctx, FindEventsByAttendeeEmailUnmatchedForContact, arg.Email, arg.ContactID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []*CalendarEvent{}
+	for rows.Next() {
+		var i CalendarEvent
+		if err := rows.Scan(
+			&i.ID,
+			&i.GcalEventID,
+			&i.GcalCalendarID,
+			&i.GoogleAccountID,
+			&i.Title,
+			&i.Description,
+			&i.Location,
+			&i.StartTime,
+			&i.EndTime,
+			&i.AllDay,
+			&i.Status,
+			&i.UserResponse,
+			&i.OrganizerEmail,
+			&i.Attendees,
+			&i.MatchedContactIds,
+			&i.SyncedAt,
+			&i.LastContactedUpdated,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.HtmlLink,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const GetCalendarEventByGcalID = `-- name: GetCalendarEventByGcalID :one

--- a/backend/internal/db/external_contact.sql.go
+++ b/backend/internal/db/external_contact.sql.go
@@ -226,6 +226,64 @@ func (q *Queries) FindExternalContactsByNormalizedEmail(ctx context.Context, low
 	return items, nil
 }
 
+const FindExternalContactsBySourceAndSourceID = `-- name: FindExternalContactsBySourceAndSourceID :many
+SELECT id, source, source_id, account_id, display_name, first_name, last_name, emails, phones, addresses, organization, job_title, birthday, photo_url, crm_contact_id, match_status, duplicate_of_id, etag, metadata, synced_at, created_at, updated_at FROM external_contact
+WHERE source = $1
+  AND source_id = $2
+  AND match_status = 'unmatched'
+`
+
+type FindExternalContactsBySourceAndSourceIDParams struct {
+	Source   string `json:"source"`
+	SourceID string `json:"source_id"`
+}
+
+// Finds all unmatched external_contact rows for a (source, source_id) pair
+// regardless of account_id. Used by the calendar rematch handler to mark
+// gcal_attendee import candidates as matched after a CRM contact links them.
+func (q *Queries) FindExternalContactsBySourceAndSourceID(ctx context.Context, arg FindExternalContactsBySourceAndSourceIDParams) ([]*ExternalContact, error) {
+	rows, err := q.db.Query(ctx, FindExternalContactsBySourceAndSourceID, arg.Source, arg.SourceID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []*ExternalContact{}
+	for rows.Next() {
+		var i ExternalContact
+		if err := rows.Scan(
+			&i.ID,
+			&i.Source,
+			&i.SourceID,
+			&i.AccountID,
+			&i.DisplayName,
+			&i.FirstName,
+			&i.LastName,
+			&i.Emails,
+			&i.Phones,
+			&i.Addresses,
+			&i.Organization,
+			&i.JobTitle,
+			&i.Birthday,
+			&i.PhotoUrl,
+			&i.CrmContactID,
+			&i.MatchStatus,
+			&i.DuplicateOfID,
+			&i.Etag,
+			&i.Metadata,
+			&i.SyncedAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const GetEnrichmentByField = `-- name: GetEnrichmentByField :one
 SELECT id, contact_id, source, account_id, field, external_contact_id, original_value, enriched_at FROM contact_enrichment
 WHERE contact_id = $1 AND field = $2

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -12,6 +12,11 @@ import (
 
 type Querier interface {
 	AddContactTag(ctx context.Context, arg AddContactTagParams) error
+	// Atomically appends a contact to an event's matched_contact_ids iff it isn't
+	// already present. Does NOT reset last_contacted_updated — the rematch handler
+	// records interactions directly for past events (see rematch plan Design
+	// Decision 6) so the scheduler race is avoided at the source.
+	AppendMatchedContact(ctx context.Context, arg AppendMatchedContactParams) error
 	BulkLinkIdentitiesToContact(ctx context.Context, arg BulkLinkIdentitiesToContactParams) error
 	// Mark all pending follow-up tasks as completed for a contact (when a response arrives)
 	CompleteFollowUpForContact(ctx context.Context, contactID pgtype.UUID) ([]*ContactTask, error)
@@ -114,8 +119,18 @@ type Querier interface {
 	// Find contact methods that exist in both source and target
 	// Used to identify duplicates that will be skipped during merge
 	FindDuplicateContactMethods(ctx context.Context, arg FindDuplicateContactMethodsParams) ([]*FindDuplicateContactMethodsRow, error)
+	// Finds events whose JSONB attendees contain the given normalized email but
+	// do not yet have the contact in matched_contact_ids. Used by the rematch
+	// service to retroactively link historical calendar events when a contact
+	// method is added to a CRM contact.
+	// calendar_event has no deleted_at column — do not filter on it.
+	FindEventsByAttendeeEmailUnmatchedForContact(ctx context.Context, arg FindEventsByAttendeeEmailUnmatchedForContactParams) ([]*CalendarEvent, error)
 	FindExternalContactsByEmail(ctx context.Context, dollar_1 []byte) ([]*ExternalContact, error)
 	FindExternalContactsByNormalizedEmail(ctx context.Context, lower string) ([]*ExternalContact, error)
+	// Finds all unmatched external_contact rows for a (source, source_id) pair
+	// regardless of account_id. Used by the calendar rematch handler to mark
+	// gcal_attendee import candidates as matched after a CRM contact links them.
+	FindExternalContactsBySourceAndSourceID(ctx context.Context, arg FindExternalContactsBySourceAndSourceIDParams) ([]*ExternalContact, error)
 	FindIdentitiesByIdentifier(ctx context.Context, arg FindIdentitiesByIdentifierParams) ([]*ExternalIdentity, error)
 	// Find an existing interaction by contact, source, and source_ref (for deduplication)
 	FindInteractionBySourceRef(ctx context.Context, arg FindInteractionBySourceRefParams) (*Interaction, error)

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -49,6 +49,9 @@ type Querier interface {
 	CountTelegramMessagesByPeerID(ctx context.Context, peerUserID pgtype.Int8) (*CountTelegramMessagesByPeerIDRow, error)
 	CountUnmatchedExternalContacts(ctx context.Context, source string) (int64, error)
 	CountUnmatchedIdentities(ctx context.Context) (int64, error)
+	// Counts messages about to be linked for a given peer. Read BEFORE
+	// OnPeerLinked so the matched-count reporting observes the pre-link state.
+	CountUnmatchedMessagesByPeer(ctx context.Context, peerUserID pgtype.Int8) (int64, error)
 	CreateContact(ctx context.Context, arg CreateContactParams) (*Contact, error)
 	CreateContactMethod(ctx context.Context, arg CreateContactMethodParams) (*ContactMethod, error)
 	CreateContactTask(ctx context.Context, arg CreateContactTaskParams) (*ContactTask, error)
@@ -116,6 +119,18 @@ type Querier interface {
 	// Demote source's primary contact methods when target already has a primary for that type
 	// This prevents violation of the unique partial index on (contact_id, type) WHERE is_primary = true
 	DemoteSourcePrimaryMethods(ctx context.Context, arg DemoteSourcePrimaryMethodsParams) error
+	// peer_phone is stored raw from MTProto (typically digits only); contact_method
+	// value_normalized is E.164 with leading '+'. Compare on digits-only.
+	// Same DISTINCT ON ordering as the username variant — prefer rows with a
+	// non-blank peer_username so OnPeerLinked can create the identity even when
+	// the matched row is found by phone.
+	FindDistinctUnmatchedPeerUserIDsByPhone(ctx context.Context, phone string) ([]*FindDistinctUnmatchedPeerUserIDsByPhoneRow, error)
+	// Returns distinct peer_user_ids whose unmatched messages carry the given
+	// normalized telegram handle. Mirrors ListDistinctUnmatchedPeers ordering:
+	// when a peer has multiple rows, prefer the one with a non-blank
+	// peer_username so OnPeerLinked can create the identity. Treats blank
+	// strings as absent (Telegram persists '' for outbound private chats).
+	FindDistinctUnmatchedPeerUserIDsByUsername(ctx context.Context, username string) ([]*FindDistinctUnmatchedPeerUserIDsByUsernameRow, error)
 	// Find contact methods that exist in both source and target
 	// Used to identify duplicates that will be skipped during merge
 	FindDuplicateContactMethods(ctx context.Context, arg FindDuplicateContactMethodsParams) ([]*FindDuplicateContactMethodsRow, error)

--- a/backend/internal/db/queries/calendar_event.sql
+++ b/backend/internal/db/queries/calendar_event.sql
@@ -132,3 +132,28 @@ ORDER BY start_time ASC;
 -- Delete all events for a Google account (used when revoking access)
 DELETE FROM calendar_event
 WHERE google_account_id = $1;
+
+-- name: FindEventsByAttendeeEmailUnmatchedForContact :many
+-- Finds events whose JSONB attendees contain the given normalized email but
+-- do not yet have the contact in matched_contact_ids. Used by the rematch
+-- service to retroactively link historical calendar events when a contact
+-- method is added to a CRM contact.
+-- calendar_event has no deleted_at column — do not filter on it.
+SELECT * FROM calendar_event
+WHERE EXISTS (
+    SELECT 1 FROM jsonb_array_elements(attendees) AS a
+    WHERE LOWER(a->>'email') = LOWER(@email::text)
+)
+  AND NOT (@contact_id::uuid = ANY(matched_contact_ids))
+  AND status != 'cancelled';
+
+-- name: AppendMatchedContact :exec
+-- Atomically appends a contact to an event's matched_contact_ids iff it isn't
+-- already present. Does NOT reset last_contacted_updated — the rematch handler
+-- records interactions directly for past events (see rematch plan Design
+-- Decision 6) so the scheduler race is avoided at the source.
+UPDATE calendar_event
+SET matched_contact_ids = array_append(matched_contact_ids, @contact_id::uuid),
+    updated_at = NOW()
+WHERE id = @event_id::uuid
+  AND NOT (@contact_id::uuid = ANY(matched_contact_ids));

--- a/backend/internal/db/queries/external_contact.sql
+++ b/backend/internal/db/queries/external_contact.sql
@@ -3,6 +3,15 @@
 -- name: GetExternalContact :one
 SELECT * FROM external_contact WHERE id = $1;
 
+-- name: FindExternalContactsBySourceAndSourceID :many
+-- Finds all unmatched external_contact rows for a (source, source_id) pair
+-- regardless of account_id. Used by the calendar rematch handler to mark
+-- gcal_attendee import candidates as matched after a CRM contact links them.
+SELECT * FROM external_contact
+WHERE source = sqlc.arg('source')
+  AND source_id = sqlc.arg('source_id')
+  AND match_status = 'unmatched';
+
 -- name: GetExternalContactBySource :one
 SELECT * FROM external_contact
 WHERE source = $1 AND source_id = $2 AND COALESCE(account_id, '') = COALESCE($3, '');

--- a/backend/internal/db/queries/telegram_message.sql
+++ b/backend/internal/db/queries/telegram_message.sql
@@ -128,5 +128,45 @@ FROM telegram_message
 WHERE peer_user_id = @peer_user_id
   AND deleted_at IS NULL;
 
+-- name: FindDistinctUnmatchedPeerUserIDsByUsername :many
+-- Returns distinct peer_user_ids whose unmatched messages carry the given
+-- normalized telegram handle. Mirrors ListDistinctUnmatchedPeers ordering:
+-- when a peer has multiple rows, prefer the one with a non-blank
+-- peer_username so OnPeerLinked can create the identity. Treats blank
+-- strings as absent (Telegram persists '' for outbound private chats).
+SELECT DISTINCT ON (peer_user_id) peer_user_id, peer_username
+FROM telegram_message
+WHERE LOWER(peer_username) = LOWER(@username::text)
+  AND matched_contact_id IS NULL
+  AND peer_user_id IS NOT NULL
+  AND deleted_at IS NULL
+ORDER BY peer_user_id,
+    CASE WHEN peer_username IS NOT NULL AND peer_username <> '' THEN 0 ELSE 1 END,
+    sent_at DESC;
+
+-- name: FindDistinctUnmatchedPeerUserIDsByPhone :many
+-- peer_phone is stored raw from MTProto (typically digits only); contact_method
+-- value_normalized is E.164 with leading '+'. Compare on digits-only.
+-- Same DISTINCT ON ordering as the username variant — prefer rows with a
+-- non-blank peer_username so OnPeerLinked can create the identity even when
+-- the matched row is found by phone.
+SELECT DISTINCT ON (peer_user_id) peer_user_id, peer_username
+FROM telegram_message
+WHERE regexp_replace(peer_phone, '[^0-9]', '', 'g') = regexp_replace(@phone::text, '[^0-9]', '', 'g')
+  AND matched_contact_id IS NULL
+  AND peer_user_id IS NOT NULL
+  AND deleted_at IS NULL
+ORDER BY peer_user_id,
+    CASE WHEN peer_username IS NOT NULL AND peer_username <> '' THEN 0 ELSE 1 END,
+    sent_at DESC;
+
+-- name: CountUnmatchedMessagesByPeer :one
+-- Counts messages about to be linked for a given peer. Read BEFORE
+-- OnPeerLinked so the matched-count reporting observes the pre-link state.
+SELECT COUNT(*) FROM telegram_message
+WHERE peer_user_id = @peer_user_id
+  AND matched_contact_id IS NULL
+  AND deleted_at IS NULL;
+
 -- GetTelegramMessageByReplyTo removed: identical to GetTelegramMessage.
 -- Use GetMessage repo method for reply resolution.

--- a/backend/internal/db/telegram_message.sql.go
+++ b/backend/internal/db/telegram_message.sql.go
@@ -119,6 +119,106 @@ func (q *Queries) CountTelegramMessagesByPeerID(ctx context.Context, peerUserID 
 	return &i, err
 }
 
+const CountUnmatchedMessagesByPeer = `-- name: CountUnmatchedMessagesByPeer :one
+SELECT COUNT(*) FROM telegram_message
+WHERE peer_user_id = $1
+  AND matched_contact_id IS NULL
+  AND deleted_at IS NULL
+`
+
+// Counts messages about to be linked for a given peer. Read BEFORE
+// OnPeerLinked so the matched-count reporting observes the pre-link state.
+func (q *Queries) CountUnmatchedMessagesByPeer(ctx context.Context, peerUserID pgtype.Int8) (int64, error) {
+	row := q.db.QueryRow(ctx, CountUnmatchedMessagesByPeer, peerUserID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const FindDistinctUnmatchedPeerUserIDsByPhone = `-- name: FindDistinctUnmatchedPeerUserIDsByPhone :many
+SELECT DISTINCT ON (peer_user_id) peer_user_id, peer_username
+FROM telegram_message
+WHERE regexp_replace(peer_phone, '[^0-9]', '', 'g') = regexp_replace($1::text, '[^0-9]', '', 'g')
+  AND matched_contact_id IS NULL
+  AND peer_user_id IS NOT NULL
+  AND deleted_at IS NULL
+ORDER BY peer_user_id,
+    CASE WHEN peer_username IS NOT NULL AND peer_username <> '' THEN 0 ELSE 1 END,
+    sent_at DESC
+`
+
+type FindDistinctUnmatchedPeerUserIDsByPhoneRow struct {
+	PeerUserID   pgtype.Int8 `json:"peer_user_id"`
+	PeerUsername pgtype.Text `json:"peer_username"`
+}
+
+// peer_phone is stored raw from MTProto (typically digits only); contact_method
+// value_normalized is E.164 with leading '+'. Compare on digits-only.
+// Same DISTINCT ON ordering as the username variant — prefer rows with a
+// non-blank peer_username so OnPeerLinked can create the identity even when
+// the matched row is found by phone.
+func (q *Queries) FindDistinctUnmatchedPeerUserIDsByPhone(ctx context.Context, phone string) ([]*FindDistinctUnmatchedPeerUserIDsByPhoneRow, error) {
+	rows, err := q.db.Query(ctx, FindDistinctUnmatchedPeerUserIDsByPhone, phone)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []*FindDistinctUnmatchedPeerUserIDsByPhoneRow{}
+	for rows.Next() {
+		var i FindDistinctUnmatchedPeerUserIDsByPhoneRow
+		if err := rows.Scan(&i.PeerUserID, &i.PeerUsername); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const FindDistinctUnmatchedPeerUserIDsByUsername = `-- name: FindDistinctUnmatchedPeerUserIDsByUsername :many
+SELECT DISTINCT ON (peer_user_id) peer_user_id, peer_username
+FROM telegram_message
+WHERE LOWER(peer_username) = LOWER($1::text)
+  AND matched_contact_id IS NULL
+  AND peer_user_id IS NOT NULL
+  AND deleted_at IS NULL
+ORDER BY peer_user_id,
+    CASE WHEN peer_username IS NOT NULL AND peer_username <> '' THEN 0 ELSE 1 END,
+    sent_at DESC
+`
+
+type FindDistinctUnmatchedPeerUserIDsByUsernameRow struct {
+	PeerUserID   pgtype.Int8 `json:"peer_user_id"`
+	PeerUsername pgtype.Text `json:"peer_username"`
+}
+
+// Returns distinct peer_user_ids whose unmatched messages carry the given
+// normalized telegram handle. Mirrors ListDistinctUnmatchedPeers ordering:
+// when a peer has multiple rows, prefer the one with a non-blank
+// peer_username so OnPeerLinked can create the identity. Treats blank
+// strings as absent (Telegram persists ” for outbound private chats).
+func (q *Queries) FindDistinctUnmatchedPeerUserIDsByUsername(ctx context.Context, username string) ([]*FindDistinctUnmatchedPeerUserIDsByUsernameRow, error) {
+	rows, err := q.db.Query(ctx, FindDistinctUnmatchedPeerUserIDsByUsername, username)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []*FindDistinctUnmatchedPeerUserIDsByUsernameRow{}
+	for rows.Next() {
+		var i FindDistinctUnmatchedPeerUserIDsByUsernameRow
+		if err := rows.Scan(&i.PeerUserID, &i.PeerUsername); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const GetTelegramMessage = `-- name: GetTelegramMessage :one
 SELECT id, telegram_message_id, telegram_chat_id, chat_type, chat_title, message_text, message_type, sent_at, edited_at, is_outgoing, reply_to_msg_id, peer_user_id, peer_username, peer_first_name, peer_last_name, peer_phone, matched_contact_id, interaction_id, processed_at, deleted_at, created_at FROM telegram_message
 WHERE telegram_chat_id = $1

--- a/backend/internal/google/calendar_rematch.go
+++ b/backend/internal/google/calendar_rematch.go
@@ -1,0 +1,127 @@
+package google
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/logger"
+	"personal-crm/backend/internal/matching"
+	"personal-crm/backend/internal/repository"
+)
+
+// calendarRematchInteractionRecorder is the subset of ContactService the
+// calendar rematch handler depends on. Mirrors CalendarSyncProvider's recorder
+// dependency — pass the same *service.ContactService instance.
+type calendarRematchInteractionRecorder interface {
+	RecordInteraction(ctx context.Context, req repository.RecordInteractionRequest) (*repository.Interaction, error)
+}
+
+// CalendarRematchHandler implements service.RematchHandler for the "email"
+// identifier type. When an email is added to a CRM contact, this handler
+// retroactively links any historical calendar events whose attendees include
+// that email but where the contact wasn't matched at sync time. For events
+// whose end_time has already passed, it records the interaction directly so
+// the contact's last_contacted reflects the event without depending on the
+// scheduler reading a now-stale matched_contact_ids snapshot (rematch plan
+// Design Decision 6).
+type CalendarRematchHandler struct {
+	calendarRepo *repository.CalendarEventRepository
+	externalRepo *repository.ExternalContactRepository
+	recorder     calendarRematchInteractionRecorder
+}
+
+// NewCalendarRematchHandler constructs a CalendarRematchHandler. The recorder
+// must be the same *service.ContactService instance used by CalendarSyncProvider
+// so per-source dedup behavior is identical between sync and rematch paths.
+func NewCalendarRematchHandler(
+	cr *repository.CalendarEventRepository,
+	er *repository.ExternalContactRepository,
+	rec calendarRematchInteractionRecorder,
+) *CalendarRematchHandler {
+	return &CalendarRematchHandler{
+		calendarRepo: cr,
+		externalRepo: er,
+		recorder:     rec,
+	}
+}
+
+// IdentifierType returns the contact_method type this handler binds to.
+func (h *CalendarRematchHandler) IdentifierType() string { return "email" }
+
+// Rematch finds calendar events whose attendees include the email, appends
+// the contact to each event's matched_contact_ids, and records past-event
+// interactions directly.
+func (h *CalendarRematchHandler) Rematch(ctx context.Context, contactID uuid.UUID, emailNormalized string) (int, error) {
+	// Defensive normalization: contact_method.value_normalized should already
+	// match matching.NormalizeEmail, but run through it again so the SQL's
+	// LOWER comparison stays correct even if the migration 022 trigger drifts.
+	email := matching.NormalizeEmail(emailNormalized)
+	if email == "" {
+		return 0, nil
+	}
+
+	events, err := h.calendarRepo.FindEventsByAttendeeEmailUnmatchedForContact(ctx, email, contactID)
+	if err != nil {
+		return 0, fmt.Errorf("find events: %w", err)
+	}
+
+	now := accelerated.GetCurrentTime()
+	matched := 0
+	for _, e := range events {
+		if err := h.calendarRepo.AppendMatchedContact(ctx, e.ID, contactID); err != nil {
+			logger.Warn().Err(err).
+				Str("event_id", e.ID.String()).
+				Str("contact_id", contactID.String()).
+				Msg("calendar rematch: append failed")
+			continue
+		}
+		// Past events: record the interaction now so last_contacted reflects
+		// the event without a scheduler race. RecordInteraction dedupes on
+		// (contact_id, source, source_ref) — both at the service layer
+		// (ContactService.RecordInteraction → FindBySourceRef) and at the DB
+		// layer (idx_interaction_source_ref UNIQUE). Safe to call repeatedly.
+		if e.EndTime.Before(now) {
+			eventIDStr := e.ID.String()
+			title := ""
+			if e.Title != nil {
+				title = *e.Title
+			}
+			if _, err := h.recorder.RecordInteraction(ctx, repository.RecordInteractionRequest{
+				ContactID:   contactID,
+				Source:      repository.InteractionSourceGCal,
+				SourceRef:   &eventIDStr,
+				OccurredAt:  e.EndTime,
+				Description: &title,
+			}); err != nil {
+				logger.Warn().Err(err).
+					Str("event_id", e.ID.String()).
+					Str("contact_id", contactID.String()).
+					Msg("calendar rematch: record interaction failed")
+				// Continue — append already succeeded. If the scheduler picks
+				// this event up later it will redo the work safely (idempotent).
+			}
+		}
+		matched++
+	}
+
+	// Mark any matching gcal_attendee external_contact rows as matched so they
+	// disappear from the import candidate list. Errors are logged but never
+	// returned — this is housekeeping, not correctness.
+	candidates, err := h.externalRepo.FindBySourceAndSourceID(ctx, "gcal_attendee", email)
+	if err != nil {
+		logger.Warn().Err(err).Str("email", email).Msg("calendar rematch: external candidate lookup failed")
+	}
+	for _, ec := range candidates {
+		if _, err := h.externalRepo.UpdateMatch(ctx, ec.ID, &contactID, repository.MatchStatusMatched); err != nil {
+			logger.Warn().Err(err).
+				Str("external_id", ec.ID.String()).
+				Str("contact_id", contactID.String()).
+				Msg("calendar rematch: external candidate update failed")
+		}
+	}
+
+	return matched, nil
+}

--- a/backend/internal/google/calendar_rematch.go
+++ b/backend/internal/google/calendar_rematch.go
@@ -78,12 +78,15 @@ func (h *CalendarRematchHandler) Rematch(ctx context.Context, contactID uuid.UUI
 				Msg("calendar rematch: append failed")
 			continue
 		}
-		// Past events: record the interaction now so last_contacted reflects
-		// the event without a scheduler race. RecordInteraction dedupes on
+		// Past confirmed events: record the interaction now so last_contacted
+		// reflects the event without a scheduler race. Match
+		// ListPastEventsNeedingUpdate's filter (status = 'confirmed') so
+		// rematch doesn't record interactions the scheduler would have
+		// skipped for tentative events. RecordInteraction dedupes on
 		// (contact_id, source, source_ref) — both at the service layer
 		// (ContactService.RecordInteraction → FindBySourceRef) and at the DB
 		// layer (idx_interaction_source_ref UNIQUE). Safe to call repeatedly.
-		if e.EndTime.Before(now) {
+		if e.EndTime.Before(now) && e.Status == "confirmed" {
 			eventIDStr := e.ID.String()
 			title := ""
 			if e.Title != nil {

--- a/backend/internal/google/contacts.go
+++ b/backend/internal/google/contacts.go
@@ -364,10 +364,12 @@ func (p *ContactsProvider) attemptMatch(
 				return fmt.Errorf("update match: %w", err)
 			}
 
-			// Enrich the CRM contact with external data
+			// Enrich the CRM contact with external data.
+			// Any rematch job kicked off by the newly-added methods is fire-and-forget —
+			// sync paths have no HTTP response to surface it on.
 			enrichedContact, _ := p.externalRepo.GetByID(ctx, contact.ID)
 			if enrichedContact != nil {
-				if err := p.enricher.EnrichContactFromExternal(ctx, *result.ContactID, enrichedContact); err != nil {
+				if _, err := p.enricher.EnrichContactFromExternal(ctx, *result.ContactID, enrichedContact); err != nil {
 					logger.Warn().Err(err).Msg("enrichment failed")
 				}
 			}
@@ -393,10 +395,10 @@ func (p *ContactsProvider) attemptMatch(
 				return fmt.Errorf("update match: %w", err)
 			}
 
-			// Enrich the CRM contact
+			// Enrich the CRM contact. Any rematch job is fire-and-forget (see above).
 			enrichedContact, _ := p.externalRepo.GetByID(ctx, contact.ID)
 			if enrichedContact != nil {
-				if err := p.enricher.EnrichContactFromExternal(ctx, *result.ContactID, enrichedContact); err != nil {
+				if _, err := p.enricher.EnrichContactFromExternal(ctx, *result.ContactID, enrichedContact); err != nil {
 					logger.Warn().Err(err).Msg("enrichment failed")
 				}
 			}

--- a/backend/internal/repository/calendar.go
+++ b/backend/internal/repository/calendar.go
@@ -342,6 +342,35 @@ func (r *CalendarEventRepository) CountEventsForContact(ctx context.Context, con
 	return r.queries.CountEventsForContact(ctx, uuidToPgUUID(contactID))
 }
 
+// FindEventsByAttendeeEmailUnmatchedForContact returns events whose attendees JSONB
+// contains the given normalized email but where the given contact is not yet in
+// matched_contact_ids. Used by the rematch service.
+func (r *CalendarEventRepository) FindEventsByAttendeeEmailUnmatchedForContact(ctx context.Context, email string, contactID uuid.UUID) ([]CalendarEvent, error) {
+	dbEvents, err := r.queries.FindEventsByAttendeeEmailUnmatchedForContact(ctx, db.FindEventsByAttendeeEmailUnmatchedForContactParams{
+		Email:     email,
+		ContactID: uuidToPgUUID(contactID),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	events := make([]CalendarEvent, len(dbEvents))
+	for i, dbEvent := range dbEvents {
+		events[i] = convertDbCalendarEvent(dbEvent)
+	}
+
+	return events, nil
+}
+
+// AppendMatchedContact appends contactID to an event's matched_contact_ids array
+// iff it isn't already present. Does NOT reset last_contacted_updated.
+func (r *CalendarEventRepository) AppendMatchedContact(ctx context.Context, eventID, contactID uuid.UUID) error {
+	return r.queries.AppendMatchedContact(ctx, db.AppendMatchedContactParams{
+		ContactID: uuidToPgUUID(contactID),
+		EventID:   uuidToPgUUID(eventID),
+	})
+}
+
 // DeleteEventsByAccount deletes all events for a Google account
 func (r *CalendarEventRepository) DeleteEventsByAccount(ctx context.Context, googleAccountID string) error {
 	return r.queries.DeleteEventsByAccount(ctx, googleAccountID)

--- a/backend/internal/repository/external_contact.go
+++ b/backend/internal/repository/external_contact.go
@@ -434,6 +434,29 @@ func (r *ExternalContactRepository) Ignore(ctx context.Context, id uuid.UUID) er
 	return r.queries.IgnoreExternalContact(ctx, pgtype.UUID{Bytes: id, Valid: true})
 }
 
+// FindBySourceAndSourceID finds all unmatched external_contact rows for a
+// (source, source_id) pair regardless of account_id. Used by the calendar
+// rematch handler to mark gcal_attendee candidates as matched.
+func (r *ExternalContactRepository) FindBySourceAndSourceID(ctx context.Context, source, sourceID string) ([]ExternalContact, error) {
+	dbContacts, err := r.queries.FindExternalContactsBySourceAndSourceID(ctx, db.FindExternalContactsBySourceAndSourceIDParams{
+		Source:   source,
+		SourceID: sourceID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	contacts := make([]ExternalContact, 0, len(dbContacts))
+	for _, dbContact := range dbContacts {
+		contact, err := convertDbExternalContact(dbContact)
+		if err != nil {
+			continue
+		}
+		contacts = append(contacts, *contact)
+	}
+	return contacts, nil
+}
+
 // FindByNormalizedEmail finds external contacts by normalized email
 func (r *ExternalContactRepository) FindByNormalizedEmail(ctx context.Context, email string) ([]ExternalContact, error) {
 	dbContacts, err := r.queries.FindExternalContactsByNormalizedEmail(ctx, email)

--- a/backend/internal/repository/telegram_message.go
+++ b/backend/internal/repository/telegram_message.go
@@ -341,6 +341,52 @@ func (r *TelegramMessageRepository) CountMessagesByPeer(ctx context.Context) ([]
 	return counts, nil
 }
 
+// FindDistinctUnmatchedPeerUserIDsByUsername returns one row per peer_user_id
+// whose unmatched messages carry the given Telegram handle (case-insensitive).
+// Used by the rematch service when a "telegram" contact_method is added.
+func (r *TelegramMessageRepository) FindDistinctUnmatchedPeerUserIDsByUsername(ctx context.Context, username string) ([]UnmatchedPeer, error) {
+	rows, err := r.queries.FindDistinctUnmatchedPeerUserIDsByUsername(ctx, username)
+	if err != nil {
+		return nil, err
+	}
+	peers := make([]UnmatchedPeer, 0, len(rows))
+	for _, row := range rows {
+		p := UnmatchedPeer{PeerUserID: row.PeerUserID.Int64}
+		if row.PeerUsername.Valid {
+			val := row.PeerUsername.String
+			p.PeerUsername = &val
+		}
+		peers = append(peers, p)
+	}
+	return peers, nil
+}
+
+// FindDistinctUnmatchedPeerUserIDsByPhone returns one row per peer_user_id
+// whose unmatched messages carry the given phone (compared digits-only).
+func (r *TelegramMessageRepository) FindDistinctUnmatchedPeerUserIDsByPhone(ctx context.Context, phone string) ([]UnmatchedPeer, error) {
+	rows, err := r.queries.FindDistinctUnmatchedPeerUserIDsByPhone(ctx, phone)
+	if err != nil {
+		return nil, err
+	}
+	peers := make([]UnmatchedPeer, 0, len(rows))
+	for _, row := range rows {
+		p := UnmatchedPeer{PeerUserID: row.PeerUserID.Int64}
+		if row.PeerUsername.Valid {
+			val := row.PeerUsername.String
+			p.PeerUsername = &val
+		}
+		peers = append(peers, p)
+	}
+	return peers, nil
+}
+
+// CountUnmatchedMessagesByPeer returns the number of messages for a peer that
+// are not yet linked to a contact. Read this BEFORE OnPeerLinked so the
+// rematch handler reports a meaningful pre-link count.
+func (r *TelegramMessageRepository) CountUnmatchedMessagesByPeer(ctx context.Context, peerUserID int64) (int64, error) {
+	return r.queries.CountUnmatchedMessagesByPeer(ctx, int64ToPgInt8(&peerUserID))
+}
+
 // CountMessagesByPeerID returns message counts for a single peer.
 func (r *TelegramMessageRepository) CountMessagesByPeerID(ctx context.Context, peerUserID int64) (*PeerMessageCount, error) {
 	row, err := r.queries.CountTelegramMessagesByPeerID(ctx, int64ToPgInt8(&peerUserID))

--- a/backend/internal/service/contact.go
+++ b/backend/internal/service/contact.go
@@ -44,6 +44,7 @@ type ContactService struct {
 	interactionRepo   *repository.InteractionRepository
 	contactTaskRepo   *repository.ContactTaskRepository
 	followUpMgr       followUpManager
+	rematchSvc        *RematchService
 }
 
 func NewContactService(database *db.Database, contactRepo *repository.ContactRepository, contactMethodRepo *repository.ContactMethodRepository, interactionRepo *repository.InteractionRepository, contactTaskRepo *repository.ContactTaskRepository) *ContactService {
@@ -59,6 +60,12 @@ func NewContactService(database *db.Database, contactRepo *repository.ContactRep
 // SetFollowUpManager injects the follow-up manager after construction (resolves circular dependency)
 func (s *ContactService) SetFollowUpManager(fm followUpManager) {
 	s.followUpMgr = fm
+}
+
+// SetRematchService injects the rematch service. Safe to leave unset — CreateContact
+// and UpdateContact return uuid.Nil as the jobID when nil.
+func (s *ContactService) SetRematchService(r *RematchService) {
+	s.rematchSvc = r
 }
 
 // HasPendingFollowUp checks if a contact has a pending follow-up task
@@ -156,10 +163,10 @@ func (s *ContactService) ListContactIDs(ctx context.Context, params repository.L
 	return s.contactRepo.ListContactIDs(ctx, params)
 }
 
-func (s *ContactService) CreateContact(ctx context.Context, req repository.CreateContactRequest, methods []ContactMethodInput) (contact *repository.Contact, err error) {
+func (s *ContactService) CreateContact(ctx context.Context, req repository.CreateContactRequest, methods []ContactMethodInput) (contact *repository.Contact, jobID uuid.UUID, err error) {
 	tx, err := s.database.Pool.Begin(ctx)
 	if err != nil {
-		return nil, err
+		return nil, uuid.Nil, err
 	}
 	defer func() {
 		if rollbackErr := tx.Rollback(ctx); rollbackErr != nil && !errors.Is(rollbackErr, pgx.ErrTxClosed) {
@@ -175,26 +182,29 @@ func (s *ContactService) CreateContact(ctx context.Context, req repository.Creat
 
 	contact, err = contactRepo.CreateContact(ctx, req)
 	if err != nil {
-		return nil, err
+		return nil, uuid.Nil, err
 	}
 
 	createdMethods, err := createContactMethods(ctx, contactMethodRepo, contact.ID, methods)
 	if err != nil {
-		return nil, err
+		return nil, uuid.Nil, err
 	}
 
 	if err = tx.Commit(ctx); err != nil {
-		return nil, err
+		return nil, uuid.Nil, err
 	}
 
 	assignMethods(contact, createdMethods)
-	return contact, nil
+	if s.rematchSvc != nil && len(createdMethods) > 0 {
+		jobID = s.rematchSvc.StartRematchForContact(contact.ID, toRematchMethods(createdMethods))
+	}
+	return contact, jobID, nil
 }
 
-func (s *ContactService) UpdateContact(ctx context.Context, id uuid.UUID, req repository.UpdateContactRequest, methods []ContactMethodInput, replaceMethods bool) (contact *repository.Contact, err error) {
+func (s *ContactService) UpdateContact(ctx context.Context, id uuid.UUID, req repository.UpdateContactRequest, methods []ContactMethodInput, replaceMethods bool) (contact *repository.Contact, jobID uuid.UUID, err error) {
 	tx, err := s.database.Pool.Begin(ctx)
 	if err != nil {
-		return nil, err
+		return nil, uuid.Nil, err
 	}
 	defer func() {
 		if rollbackErr := tx.Rollback(ctx); rollbackErr != nil && !errors.Is(rollbackErr, pgx.ErrTxClosed) {
@@ -210,7 +220,7 @@ func (s *ContactService) UpdateContact(ctx context.Context, id uuid.UUID, req re
 
 	existingContact, err := contactRepo.GetContact(ctx, id)
 	if err != nil {
-		return nil, err
+		return nil, uuid.Nil, err
 	}
 
 	// Calculate contact_by based on cadence change
@@ -233,33 +243,46 @@ func (s *ContactService) UpdateContact(ctx context.Context, id uuid.UUID, req re
 
 	contact, err = contactRepo.UpdateContact(ctx, id, req)
 	if err != nil {
-		return nil, err
+		return nil, uuid.Nil, err
 	}
 
-	var updatedMethods []repository.ContactMethod
+	var (
+		updatedMethods []repository.ContactMethod
+		existingBefore []repository.ContactMethod
+	)
 	if replaceMethods {
+		existingBefore, err = contactMethodRepo.ListContactMethodsByContact(ctx, id)
+		if err != nil {
+			return nil, uuid.Nil, err
+		}
 		if err := contactMethodRepo.DeleteContactMethodsByContact(ctx, id); err != nil {
-			return nil, err
+			return nil, uuid.Nil, err
 		}
 
 		updatedMethods, err = createContactMethods(ctx, contactMethodRepo, id, methods)
 		if err != nil {
-			return nil, err
+			return nil, uuid.Nil, err
 		}
 	} else {
 		updatedMethods, err = contactMethodRepo.ListContactMethodsByContact(ctx, id)
 		if err != nil {
-			return nil, err
+			return nil, uuid.Nil, err
 		}
 		sortContactMethods(updatedMethods)
 	}
 
 	if err = tx.Commit(ctx); err != nil {
-		return nil, err
+		return nil, uuid.Nil, err
 	}
 
 	assignMethods(contact, updatedMethods)
-	return contact, nil
+	if replaceMethods && s.rematchSvc != nil {
+		newlyAdded := diffNewMethods(existingBefore, updatedMethods)
+		if len(newlyAdded) > 0 {
+			jobID = s.rematchSvc.StartRematchForContact(id, newlyAdded)
+		}
+	}
+	return contact, jobID, nil
 }
 
 func (s *ContactService) DeleteContact(ctx context.Context, id uuid.UUID) error {

--- a/backend/internal/service/enrichment.go
+++ b/backend/internal/service/enrichment.go
@@ -26,6 +26,7 @@ type EnrichmentService struct {
 	contactRepo    *repository.ContactRepository
 	methodRepo     *repository.ContactMethodRepository
 	enrichmentRepo *repository.EnrichmentRepository
+	rematchSvc     *RematchService
 }
 
 // NewEnrichmentService creates a new enrichment service
@@ -41,17 +42,24 @@ func NewEnrichmentService(
 	}
 }
 
+// SetRematchService injects the rematch service. Safe to leave unset —
+// Enrich* methods return uuid.Nil as the jobID when nil.
+func (s *EnrichmentService) SetRematchService(r *RematchService) {
+	s.rematchSvc = r
+}
+
 // EnrichContactFromExternal enriches a CRM contact with data from an external contact.
-// Only fills in missing fields - never overwrites existing data.
+// Only fills in missing fields - never overwrites existing data. Returns a rematch
+// job ID (uuid.Nil when no handlers match any newly-added method).
 func (s *EnrichmentService) EnrichContactFromExternal(
 	ctx context.Context,
 	crmContactID uuid.UUID,
 	external *repository.ExternalContact,
-) error {
+) (uuid.UUID, error) {
 	// Get current contact
 	contact, err := s.contactRepo.GetContact(ctx, crmContactID)
 	if err != nil {
-		return err
+		return uuid.Nil, err
 	}
 
 	// Track what needs updating
@@ -95,17 +103,28 @@ func (s *EnrichmentService) EnrichContactFromExternal(
 	}
 
 	// Enrich contact methods (emails, phones)
-	if err := s.enrichContactMethods(ctx, contact, external); err != nil {
+	addedMethods, err := s.enrichContactMethods(ctx, contact, external)
+	if err != nil {
 		logger.Warn().Err(err).Msg("failed to enrich contact methods")
 	}
 
-	return nil
+	return s.startRematchIfEligible(crmContactID, addedMethods), nil
+}
+
+// startRematchIfEligible dispatches a rematch job when the service is wired and
+// at least one method was added. Returns uuid.Nil otherwise.
+func (s *EnrichmentService) startRematchIfEligible(contactID uuid.UUID, added []Method) uuid.UUID {
+	if s.rematchSvc == nil || len(added) == 0 {
+		return uuid.Nil
+	}
+	return s.rematchSvc.StartRematchForContact(contactID, added)
 }
 
 // EnrichContactFromExternalWithSelections enriches a CRM contact with user-selected methods.
 // Unlike EnrichContactFromExternal, this uses explicit method selections and conflict resolutions.
 // If cadence is provided, it will update the contact's cadence.
 // If name is provided, it will update the contact's full name.
+// Returns a rematch job ID (uuid.Nil when no handlers match any added method).
 func (s *EnrichmentService) EnrichContactFromExternalWithSelections(
 	ctx context.Context,
 	crmContactID uuid.UUID,
@@ -114,11 +133,11 @@ func (s *EnrichmentService) EnrichContactFromExternalWithSelections(
 	conflictResolutions map[string]string,
 	cadence *string,
 	name *string,
-) error {
+) (uuid.UUID, error) {
 	// Get current contact
 	contact, err := s.contactRepo.GetContact(ctx, crmContactID)
 	if err != nil {
-		return err
+		return uuid.Nil, err
 	}
 
 	// Track what needs updating
@@ -175,29 +194,33 @@ func (s *EnrichmentService) EnrichContactFromExternalWithSelections(
 	}
 
 	// Enrich contact methods using selections
-	if err := s.enrichContactMethodsWithSelections(ctx, contact, external, selectedMethods, conflictResolutions); err != nil {
-		return err
+	addedMethods, err := s.enrichContactMethodsWithSelections(ctx, contact, external, selectedMethods, conflictResolutions)
+	if err != nil {
+		return uuid.Nil, err
 	}
 
-	return nil
+	return s.startRematchIfEligible(crmContactID, addedMethods), nil
 }
 
-// enrichContactMethodsWithSelections adds methods based on user selection and conflict resolution
+// enrichContactMethodsWithSelections adds methods based on user selection and conflict resolution.
+// Returns the list of newly-created methods (for rematch dispatch) plus any error.
 func (s *EnrichmentService) enrichContactMethodsWithSelections(
 	ctx context.Context,
 	contact *repository.Contact,
 	external *repository.ExternalContact,
 	selectedMethods []MethodSelection,
 	conflictResolutions map[string]string,
-) error {
+) ([]Method, error) {
 	// conflictResolutions is kept for API compatibility; type conflicts are no longer applicable.
 	_ = conflictResolutions
 
 	// Get existing methods
 	existingMethods, err := s.methodRepo.ListContactMethodsByContact(ctx, contact.ID)
 	if err != nil {
-		return err
+		return nil, err
 	}
+
+	added := make([]Method, 0)
 
 	// Build maps for existing methods, keyed as (type + ":" + normalized).
 	// Type-scoped keys mirror the DB unique index (contact_id, type, value_normalized)
@@ -297,6 +320,7 @@ func (s *EnrichmentService) enrichContactMethodsWithSelections(
 			newPrimaryMethodID = &newMethod.ID
 		}
 
+		added = append(added, Method{Type: newMethod.Type, Value: newMethod.ValueNormalized})
 		s.recordEnrichment(ctx, contact.ID, external,
 			"method:"+sel.Type+":"+identity.Normalize(storedValue, mapMethodTypeToIdentifier(sel.Type)),
 			storedValue)
@@ -320,22 +344,22 @@ func (s *EnrichmentService) enrichContactMethodsWithSelections(
 			m := &existingMethods[i]
 			if m.IsPrimary && m.ID != *primaryMethodID {
 				if err := s.methodRepo.SetPrimary(ctx, m.ID, false); err != nil {
-					return fmt.Errorf("failed to clear existing primary method: %w", err)
+					return added, fmt.Errorf("failed to clear existing primary method: %w", err)
 				}
 			}
 		}
 		// Set new primary
 		if err := s.methodRepo.SetPrimary(ctx, *primaryMethodID, true); err != nil {
-			return fmt.Errorf("failed to set primary method: %w", err)
+			return added, fmt.Errorf("failed to set primary method: %w", err)
 		}
 	}
 
 	// Return error if any method operations failed
 	if len(methodErrors) > 0 {
-		return fmt.Errorf("method enrichment errors: %s", strings.Join(methodErrors, "; "))
+		return added, fmt.Errorf("method enrichment errors: %s", strings.Join(methodErrors, "; "))
 	}
 
-	return nil
+	return added, nil
 }
 
 // enrichContactMethods adds missing contact methods from external contact.
@@ -343,14 +367,15 @@ func (s *EnrichmentService) enrichContactMethodsWithSelections(
 // source-specific methods (emails, phones, telegram username). Dedup is
 // type-scoped normalized to match the DB unique index on
 // (contact_id, type, value_normalized).
+// Returns the list of newly-created methods (for rematch dispatch).
 func (s *EnrichmentService) enrichContactMethods(
 	ctx context.Context,
 	contact *repository.Contact,
 	external *repository.ExternalContact,
-) error {
+) ([]Method, error) {
 	existingMethods, err := s.methodRepo.ListContactMethodsByContact(ctx, contact.ID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	existingSet := make(map[string]bool)
@@ -358,12 +383,14 @@ func (s *EnrichmentService) enrichContactMethods(
 		existingSet[methodDedupKey(m.Type, m.Value)] = true
 	}
 
+	added := make([]Method, 0)
+
 	for _, input := range BuildMethodsFromExternal(external) {
 		key := methodDedupKey(input.Type, input.Value)
 		if existingSet[key] {
 			continue
 		}
-		_, err := s.methodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
+		created, err := s.methodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
 			ContactID: contact.ID,
 			Type:      input.Type,
 			Value:     input.Value,
@@ -381,12 +408,13 @@ func (s *EnrichmentService) enrichContactMethods(
 				Msg("failed to add method from enrichment")
 			continue
 		}
+		added = append(added, Method{Type: created.Type, Value: created.ValueNormalized})
 		s.recordEnrichment(ctx, contact.ID, external,
 			"method:"+input.Type+":"+identity.Normalize(input.Value, mapMethodTypeToIdentifier(input.Type)),
 			input.Value)
 		existingSet[key] = true
 	}
-	return nil
+	return added, nil
 }
 
 // methodDedupKey returns the dedup key used to compare an incoming method
@@ -449,7 +477,10 @@ func (s *EnrichmentService) SyncMethodsFromExternal(
 	if err != nil {
 		return fmt.Errorf("get contact for method sync: %w", err)
 	}
-	return s.enrichContactMethods(ctx, contact, external)
+	// Matcher paths don't need the list of added methods; rematch is only
+	// dispatched from the HTTP-facing Enrich* entry points.
+	_, err = s.enrichContactMethods(ctx, contact, external)
+	return err
 }
 
 // HasEnrichment checks if a field has been enriched for a contact

--- a/backend/internal/service/rematch.go
+++ b/backend/internal/service/rematch.go
@@ -1,0 +1,249 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/logger"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+)
+
+// Method is a single (type, normalized value) pair that a rematch handler can
+// dispatch against — e.g. ("email", "alice@example.com").
+type Method struct {
+	Type  string
+	Value string
+}
+
+// RematchHandler is implemented per identifier type. When a contact method of
+// that type is added, the handler is invoked once per identifier to link any
+// pre-existing external records (calendar events, telegram messages, ...) to
+// the CRM contact. The returned count is how many records were newly linked.
+type RematchHandler interface {
+	IdentifierType() string
+	Rematch(ctx context.Context, contactID uuid.UUID, value string) (int, error)
+}
+
+// JobStatus represents the lifecycle state of a rematch job.
+type JobStatus string
+
+const (
+	JobStatusRunning   JobStatus = "running"
+	JobStatusCompleted JobStatus = "completed"
+	JobStatusFailed    JobStatus = "failed"
+)
+
+// ErrJobNotFound is returned by GetJob when the job ID is unknown.
+var ErrJobNotFound = errors.New("rematch job not found")
+
+// JobProgress is the externally-visible snapshot of a rematch job.
+type JobProgress struct {
+	ID          uuid.UUID
+	ContactID   uuid.UUID
+	Methods     []Method
+	Status      JobStatus
+	Matched     int
+	StartedAt   time.Time
+	CompletedAt *time.Time
+	Error       string
+}
+
+// job is the internal mutable representation protected by its own mutex.
+type job struct {
+	id        uuid.UUID
+	contactID uuid.UUID
+	methods   []Method
+	startedAt time.Time
+
+	mu          sync.RWMutex
+	status      JobStatus
+	matched     int
+	completedAt *time.Time
+	err         string
+}
+
+func (j *job) snapshot() JobProgress {
+	j.mu.RLock()
+	defer j.mu.RUnlock()
+	methodsCopy := make([]Method, len(j.methods))
+	copy(methodsCopy, j.methods)
+	var completed *time.Time
+	if j.completedAt != nil {
+		t := *j.completedAt
+		completed = &t
+	}
+	return JobProgress{
+		ID:          j.id,
+		ContactID:   j.contactID,
+		Methods:     methodsCopy,
+		Status:      j.status,
+		Matched:     j.matched,
+		StartedAt:   j.startedAt,
+		CompletedAt: completed,
+		Error:       j.err,
+	}
+}
+
+func (j *job) addMatched(n int) {
+	j.mu.Lock()
+	j.matched += n
+	j.mu.Unlock()
+}
+
+func (j *job) setCompleted() {
+	j.mu.Lock()
+	j.status = JobStatusCompleted
+	t := accelerated.GetCurrentTime()
+	j.completedAt = &t
+	j.mu.Unlock()
+}
+
+func (j *job) setFailed(err error) {
+	j.mu.Lock()
+	j.status = JobStatusFailed
+	t := accelerated.GetCurrentTime()
+	j.completedAt = &t
+	if err != nil {
+		j.err = err.Error()
+	}
+	j.mu.Unlock()
+}
+
+// RematchService dispatches rematch work per contact method type. Handlers
+// register at startup; StartRematchForContact spawns a background goroutine
+// that runs handlers sequentially for the given methods, serialized per
+// contactID by a mutex.
+type RematchService struct {
+	handlers     map[string]RematchHandler
+	jobs         sync.Map // uuid.UUID -> *job
+	contactLocks sync.Map // uuid.UUID -> *sync.Mutex
+
+	// detachedCtx returns a fresh context for the background goroutine.
+	// Overridable in tests.
+	detachedCtx func() context.Context
+}
+
+// NewRematchService constructs a RematchService with no handlers registered.
+// Callers register handlers via Register before use.
+func NewRematchService() *RematchService {
+	return &RematchService{
+		handlers:    make(map[string]RematchHandler),
+		detachedCtx: func() context.Context { return context.Background() },
+	}
+}
+
+// Register adds a handler for a specific identifier type. Intended to be
+// called at startup before any jobs run.
+func (s *RematchService) Register(h RematchHandler) {
+	s.handlers[h.IdentifierType()] = h
+}
+
+// StartRematchForContact filters the given methods to those that have a
+// registered handler, then spawns a detached goroutine to run them. Returns
+// uuid.Nil when no methods map to a registered handler — this is the normal
+// case when the feature is off or only some handler types are wired.
+func (s *RematchService) StartRematchForContact(contactID uuid.UUID, methods []Method) uuid.UUID {
+	eligible := make([]Method, 0, len(methods))
+	for _, m := range methods {
+		if _, ok := s.handlers[m.Type]; ok {
+			eligible = append(eligible, m)
+		}
+	}
+	if len(eligible) == 0 {
+		return uuid.Nil
+	}
+
+	j := &job{
+		id:        uuid.New(),
+		contactID: contactID,
+		methods:   eligible,
+		startedAt: accelerated.GetCurrentTime(),
+		status:    JobStatusRunning,
+	}
+	s.jobs.Store(j.id, j)
+
+	go s.run(j)
+	return j.id
+}
+
+func (s *RematchService) run(j *job) {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Error().
+				Str("contactId", j.contactID.String()).
+				Str("jobId", j.id.String()).
+				Interface("panic", r).
+				Msg("rematch: job panicked")
+			j.setFailed(fmt.Errorf("handler panic: %v", r))
+		}
+	}()
+
+	lockIface, _ := s.contactLocks.LoadOrStore(j.contactID, &sync.Mutex{})
+	lock := lockIface.(*sync.Mutex)
+	lock.Lock()
+	defer lock.Unlock()
+
+	ctx := s.detachedCtx()
+
+	for _, m := range j.methods {
+		handler, ok := s.handlers[m.Type]
+		if !ok {
+			continue
+		}
+		n, err := handler.Rematch(ctx, j.contactID, m.Value)
+		if err != nil {
+			logger.Warn().Err(err).
+				Str("contactId", j.contactID.String()).
+				Str("type", m.Type).
+				Msg("rematch: handler failed")
+			j.setFailed(err)
+			return
+		}
+		j.addMatched(n)
+	}
+
+	j.setCompleted()
+}
+
+// GetJob returns a snapshot of the job, or ErrJobNotFound if unknown.
+func (s *RematchService) GetJob(id uuid.UUID) (JobProgress, error) {
+	v, ok := s.jobs.Load(id)
+	if !ok {
+		return JobProgress{}, ErrJobNotFound
+	}
+	return v.(*job).snapshot(), nil
+}
+
+// diffNewMethods returns methods present in `after` whose (type,
+// value_normalized) pair is not in `before`. Order-insensitive.
+func diffNewMethods(before, after []repository.ContactMethod) []Method {
+	existing := make(map[string]struct{}, len(before))
+	for _, m := range before {
+		existing[m.Type+"|"+m.ValueNormalized] = struct{}{}
+	}
+	out := make([]Method, 0, len(after))
+	for _, m := range after {
+		key := m.Type + "|" + m.ValueNormalized
+		if _, ok := existing[key]; ok {
+			continue
+		}
+		out = append(out, Method{Type: m.Type, Value: m.ValueNormalized})
+	}
+	return out
+}
+
+// toRematchMethods converts a slice of ContactMethod to rematch Methods using
+// the normalized value.
+func toRematchMethods(methods []repository.ContactMethod) []Method {
+	out := make([]Method, len(methods))
+	for i, m := range methods {
+		out[i] = Method{Type: m.Type, Value: m.ValueNormalized}
+	}
+	return out
+}

--- a/backend/internal/service/rematch.go
+++ b/backend/internal/service/rematch.go
@@ -220,6 +220,17 @@ func (s *RematchService) GetJob(id uuid.UUID) (JobProgress, error) {
 	return v.(*job).snapshot(), nil
 }
 
+// RescanContact triggers a full rematch for every method currently on the
+// contact. Resolves the methods via the supplied ContactService so the
+// handler layer doesn't need a direct repository dependency.
+func (s *RematchService) RescanContact(ctx context.Context, contactSvc *ContactService, contactID uuid.UUID) (uuid.UUID, error) {
+	contact, err := contactSvc.GetContact(ctx, contactID)
+	if err != nil {
+		return uuid.Nil, err
+	}
+	return s.StartRematchForContact(contactID, toRematchMethods(contact.Methods)), nil
+}
+
 // diffNewMethods returns methods present in `after` whose (type,
 // value_normalized) pair is not in `before`. Order-insensitive.
 func diffNewMethods(before, after []repository.ContactMethod) []Method {

--- a/backend/internal/service/rematch.go
+++ b/backend/internal/service/rematch.go
@@ -144,6 +144,12 @@ func (s *RematchService) Register(h RematchHandler) {
 	s.handlers[h.IdentifierType()] = h
 }
 
+// jobRetention bounds how long terminal jobs remain queryable via GetJob.
+// After a job completes/fails, clients have this long to poll for the final
+// state before the entry is evicted on the next StartRematchForContact call.
+// Keeps the in-memory job map bounded without requiring a separate reaper.
+const jobRetention = 10 * time.Minute
+
 // StartRematchForContact filters the given methods to those that have a
 // registered handler, then spawns a detached goroutine to run them. Returns
 // uuid.Nil when no methods map to a registered handler — this is the normal
@@ -159,6 +165,10 @@ func (s *RematchService) StartRematchForContact(contactID uuid.UUID, methods []M
 		return uuid.Nil
 	}
 
+	// Opportunistic prune on dispatch — keeps the map bounded for long-running
+	// processes without a dedicated reaper goroutine.
+	s.pruneTerminalJobs()
+
 	j := &job{
 		id:        uuid.New(),
 		contactID: contactID,
@@ -170,6 +180,26 @@ func (s *RematchService) StartRematchForContact(contactID uuid.UUID, methods []M
 
 	go s.run(j)
 	return j.id
+}
+
+// pruneTerminalJobs evicts completed/failed jobs whose terminal timestamp is
+// older than jobRetention. Called opportunistically before each new dispatch.
+func (s *RematchService) pruneTerminalJobs() {
+	cutoff := accelerated.GetCurrentTime().Add(-jobRetention)
+	s.jobs.Range(func(key, value any) bool {
+		j := value.(*job)
+		j.mu.RLock()
+		terminal := j.status != JobStatusRunning
+		var completedAt time.Time
+		if j.completedAt != nil {
+			completedAt = *j.completedAt
+		}
+		j.mu.RUnlock()
+		if terminal && completedAt.Before(cutoff) {
+			s.jobs.Delete(key)
+		}
+		return true
+	})
 }
 
 func (s *RematchService) run(j *job) {

--- a/backend/internal/service/rematch_test.go
+++ b/backend/internal/service/rematch_test.go
@@ -1,0 +1,243 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+)
+
+// stubHandler records invocations and returns a configurable matched count / err.
+type stubHandler struct {
+	typ     string
+	matched int
+	err     error
+
+	mu     sync.Mutex
+	calls  []stubCall
+	before func()
+	after  func()
+	sleep  time.Duration
+}
+
+type stubCall struct {
+	contactID uuid.UUID
+	value     string
+}
+
+func (s *stubHandler) IdentifierType() string { return s.typ }
+
+func (s *stubHandler) Rematch(ctx context.Context, contactID uuid.UUID, value string) (int, error) {
+	if s.before != nil {
+		s.before()
+	}
+	if s.sleep > 0 {
+		time.Sleep(s.sleep)
+	}
+	s.mu.Lock()
+	s.calls = append(s.calls, stubCall{contactID: contactID, value: value})
+	s.mu.Unlock()
+	if s.after != nil {
+		s.after()
+	}
+	if s.err != nil {
+		return 0, s.err
+	}
+	return s.matched, nil
+}
+
+func (s *stubHandler) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.calls)
+}
+
+func waitForJob(t *testing.T, svc *RematchService, jobID uuid.UUID) JobProgress {
+	t.Helper()
+	// Poll up to 2s in 5ms steps.
+	const maxAttempts = 400
+	for range maxAttempts {
+		j, err := svc.GetJob(jobID)
+		if err == nil && j.Status != JobStatusRunning {
+			return j
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("rematch job %s did not finish in time", jobID)
+	return JobProgress{}
+}
+
+func TestStartRematchForContact_NoMatchingHandler(t *testing.T) {
+	svc := NewRematchService()
+	jobID := svc.StartRematchForContact(uuid.New(), []Method{{Type: "email", Value: "a@b.c"}})
+	if jobID != uuid.Nil {
+		t.Fatalf("expected uuid.Nil when no handlers registered, got %s", jobID)
+	}
+}
+
+func TestStartRematchForContact_DispatchesToHandler(t *testing.T) {
+	svc := NewRematchService()
+	h := &stubHandler{typ: "email", matched: 3}
+	svc.Register(h)
+
+	contactID := uuid.New()
+	jobID := svc.StartRematchForContact(contactID, []Method{{Type: "email", Value: "a@b.c"}})
+	if jobID == uuid.Nil {
+		t.Fatal("expected non-nil jobID")
+	}
+
+	job := waitForJob(t, svc, jobID)
+	if job.Status != JobStatusCompleted {
+		t.Fatalf("expected completed, got %s", job.Status)
+	}
+	if job.Matched != 3 {
+		t.Fatalf("expected Matched=3, got %d", job.Matched)
+	}
+	if h.callCount() != 1 {
+		t.Fatalf("expected 1 handler call, got %d", h.callCount())
+	}
+	if h.calls[0].contactID != contactID || h.calls[0].value != "a@b.c" {
+		t.Fatalf("unexpected handler args: %+v", h.calls[0])
+	}
+}
+
+func TestStartRematchForContact_AggregatesCountsAcrossMethods(t *testing.T) {
+	svc := NewRematchService()
+	emailH := &stubHandler{typ: "email", matched: 2}
+	phoneH := &stubHandler{typ: "phone", matched: 4}
+	svc.Register(emailH)
+	svc.Register(phoneH)
+
+	jobID := svc.StartRematchForContact(uuid.New(), []Method{
+		{Type: "email", Value: "a@b.c"},
+		{Type: "phone", Value: "+15551212"},
+	})
+	job := waitForJob(t, svc, jobID)
+	if job.Status != JobStatusCompleted {
+		t.Fatalf("expected completed, got %s", job.Status)
+	}
+	if job.Matched != 6 {
+		t.Fatalf("expected Matched=6, got %d", job.Matched)
+	}
+}
+
+func TestStartRematchForContact_HandlerErrorFailsJob(t *testing.T) {
+	svc := NewRematchService()
+	errBoom := errors.New("boom")
+	svc.Register(&stubHandler{typ: "email", err: errBoom})
+
+	jobID := svc.StartRematchForContact(uuid.New(), []Method{{Type: "email", Value: "a@b.c"}})
+	job := waitForJob(t, svc, jobID)
+	if job.Status != JobStatusFailed {
+		t.Fatalf("expected failed, got %s", job.Status)
+	}
+	if job.Error == "" {
+		t.Fatal("expected non-empty error message")
+	}
+}
+
+func TestStartRematchForContact_PanicRecovered(t *testing.T) {
+	svc := NewRematchService()
+	svc.Register(panickyHandler{})
+	jobID := svc.StartRematchForContact(uuid.New(), []Method{{Type: "email", Value: "x"}})
+	job := waitForJob(t, svc, jobID)
+	if job.Status != JobStatusFailed {
+		t.Fatalf("expected failed after panic, got %s", job.Status)
+	}
+}
+
+type panickyHandler struct{}
+
+func (panickyHandler) IdentifierType() string { return "email" }
+func (panickyHandler) Rematch(ctx context.Context, contactID uuid.UUID, value string) (int, error) {
+	panic("intentional")
+}
+
+func TestPerContactMutex_SerializesConcurrentJobs(t *testing.T) {
+	svc := NewRematchService()
+
+	var active int32
+	var maxActive int32
+	sleep := 40 * time.Millisecond
+
+	h := &stubHandler{
+		typ:   "email",
+		sleep: sleep,
+		before: func() {
+			n := atomic.AddInt32(&active, 1)
+			for {
+				cur := atomic.LoadInt32(&maxActive)
+				if n <= cur || atomic.CompareAndSwapInt32(&maxActive, cur, n) {
+					break
+				}
+			}
+		},
+		after: func() { atomic.AddInt32(&active, -1) },
+	}
+	svc.Register(h)
+
+	contactID := uuid.New()
+	j1 := svc.StartRematchForContact(contactID, []Method{{Type: "email", Value: "a"}})
+	j2 := svc.StartRematchForContact(contactID, []Method{{Type: "email", Value: "b"}})
+
+	waitForJob(t, svc, j1)
+	waitForJob(t, svc, j2)
+
+	if got := atomic.LoadInt32(&maxActive); got != 1 {
+		t.Fatalf("expected at most 1 concurrent handler call for same contact, got %d", got)
+	}
+}
+
+func TestGetJob_NotFound(t *testing.T) {
+	svc := NewRematchService()
+	if _, err := svc.GetJob(uuid.New()); !errors.Is(err, ErrJobNotFound) {
+		t.Fatalf("expected ErrJobNotFound, got %v", err)
+	}
+}
+
+func TestDiffNewMethods_NormalizedKey(t *testing.T) {
+	before := []repository.ContactMethod{
+		{Type: "email", ValueNormalized: "alice@example.com"},
+	}
+	after := []repository.ContactMethod{
+		{Type: "email", ValueNormalized: "alice@example.com"}, // unchanged
+		{Type: "email", ValueNormalized: "bob@example.com"},   // new
+		{Type: "phone", ValueNormalized: "+15551212"},         // new
+	}
+	diff := diffNewMethods(before, after)
+	if len(diff) != 2 {
+		t.Fatalf("expected 2 new methods, got %d: %+v", len(diff), diff)
+	}
+	wantValues := map[string]bool{"bob@example.com": true, "+15551212": true}
+	for _, m := range diff {
+		if !wantValues[m.Value] {
+			t.Fatalf("unexpected method %+v", m)
+		}
+	}
+}
+
+func TestDiffNewMethods_EmptyInputs(t *testing.T) {
+	if got := diffNewMethods(nil, nil); len(got) != 0 {
+		t.Fatalf("expected empty diff, got %+v", got)
+	}
+	if got := diffNewMethods(nil, []repository.ContactMethod{{Type: "email", ValueNormalized: "a@b"}}); len(got) != 1 {
+		t.Fatalf("expected 1 new, got %d", len(got))
+	}
+}
+
+func TestToRematchMethods(t *testing.T) {
+	in := []repository.ContactMethod{
+		{Type: "email", ValueNormalized: "x@y.z"},
+		{Type: "phone", ValueNormalized: "+15551212"},
+	}
+	out := toRematchMethods(in)
+	if len(out) != 2 || out[0].Value != "x@y.z" || out[1].Value != "+15551212" {
+		t.Fatalf("unexpected output: %+v", out)
+	}
+}

--- a/backend/internal/service/rematch_test.go
+++ b/backend/internal/service/rematch_test.go
@@ -201,6 +201,36 @@ func TestGetJob_NotFound(t *testing.T) {
 	}
 }
 
+func TestPruneTerminalJobs_EvictsOldTerminalButKeepsFresh(t *testing.T) {
+	svc := NewRematchService()
+	svc.Register(&stubHandler{typ: "email"})
+
+	// Dispatch a job and let it complete.
+	oldID := svc.StartRematchForContact(uuid.New(), []Method{{Type: "email", Value: "x@y.z"}})
+	waitForJob(t, svc, oldID)
+
+	// Backdate completedAt so the prune considers it expired. Use a fixed
+	// epoch-anchored past time — well beyond jobRetention regardless of the
+	// current clock.
+	v, _ := svc.jobs.Load(oldID)
+	oldJob := v.(*job)
+	oldJob.mu.Lock()
+	stale := time.Unix(0, 0)
+	oldJob.completedAt = &stale
+	oldJob.mu.Unlock()
+
+	// A fresh dispatch should prune the stale job but keep the new one.
+	freshID := svc.StartRematchForContact(uuid.New(), []Method{{Type: "email", Value: "new@y.z"}})
+	waitForJob(t, svc, freshID)
+
+	if _, err := svc.GetJob(oldID); !errors.Is(err, ErrJobNotFound) {
+		t.Fatalf("expected stale terminal job to be pruned, got err=%v", err)
+	}
+	if _, err := svc.GetJob(freshID); err != nil {
+		t.Fatalf("expected fresh job to still be queryable, got err=%v", err)
+	}
+}
+
 func TestDiffNewMethods_NormalizedKey(t *testing.T) {
 	before := []repository.ContactMethod{
 		{Type: "email", ValueNormalized: "alice@example.com"},

--- a/backend/internal/telegram/manager.go
+++ b/backend/internal/telegram/manager.go
@@ -587,6 +587,14 @@ func (m *TelegramManager) maybeStartBackfill(ctx context.Context, client *telegr
 	}()
 }
 
+// PeerMatcher returns the manager's PeerMatcher instance for use by external
+// rematch handlers that need to call OnPeerLinked.
+func (m *TelegramManager) PeerMatcher() *PeerMatcher { return m.peerMatcher }
+
+// AggregationEngine returns the manager's AggregationEngine instance for use
+// by external rematch handlers that need to call AggregateForContactBatch.
+func (m *TelegramManager) AggregationEngine() *AggregationEngine { return m.aggregationEngine }
+
 // OnPeerLinked satisfies handlers.PostImportHook. Called after a Telegram candidate
 // is imported/linked to back-fill message matching and trigger aggregation.
 func (m *TelegramManager) OnPeerLinked(ctx context.Context, peerUserID int64, peerUsername string, contactID uuid.UUID) error {

--- a/backend/internal/telegram/rematch.go
+++ b/backend/internal/telegram/rematch.go
@@ -1,0 +1,114 @@
+package telegram
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+
+	"personal-crm/backend/internal/repository"
+)
+
+var phoneDigitsOnly = regexp.MustCompile(`[^0-9]`)
+
+// peerRematchBase shares per-peer iteration logic between the username and
+// phone telegram rematch handlers. Both handlers translate an identifier
+// (handle or phone) into a set of distinct peer_user_ids whose unmatched
+// messages match that identifier, then call OnPeerLinked per peer and run
+// AggregateForContactBatch exactly once for the contact.
+type peerRematchBase struct {
+	messageRepo       *repository.TelegramMessageRepository
+	peerMatcher       *PeerMatcher
+	aggregationEngine *AggregationEngine
+}
+
+// rematchPeers iterates the peer set, links each via OnPeerLinked, sums the
+// pre-link unmatched message counts as the "matched" total, and runs
+// aggregation once if anything changed.
+func (b *peerRematchBase) rematchPeers(ctx context.Context, contactID uuid.UUID, peers []repository.UnmatchedPeer) (int, error) {
+	matched := 0
+	for _, p := range peers {
+		// Read pre-link count first so we report what the link will affect.
+		// Failures are non-fatal; a 0 just means we under-report this peer.
+		n, err := b.messageRepo.CountUnmatchedMessagesByPeer(ctx, p.PeerUserID)
+		if err != nil {
+			log.Warn().Err(err).Int64("peer_user_id", p.PeerUserID).
+				Str("contact_id", contactID.String()).
+				Msg("telegram rematch: count failed")
+			n = 0
+		}
+		username := ""
+		if p.PeerUsername != nil {
+			username = *p.PeerUsername
+		}
+		if err := b.peerMatcher.OnPeerLinked(ctx, p.PeerUserID, username, contactID); err != nil {
+			log.Warn().Err(err).Int64("peer_user_id", p.PeerUserID).
+				Str("contact_id", contactID.String()).
+				Msg("telegram rematch: peer link failed")
+			continue
+		}
+		matched += int(n)
+	}
+	if matched > 0 {
+		if err := b.aggregationEngine.AggregateForContactBatch(ctx, contactID); err != nil {
+			log.Warn().Err(err).Str("contact_id", contactID.String()).
+				Msg("telegram rematch: aggregation failed")
+			// Don't fail the job — messages are linked. Next aggregation pass
+			// will catch up.
+		}
+	}
+	return matched, nil
+}
+
+// UsernameRematchHandler implements service.RematchHandler for the "telegram"
+// identifier type, matching by peer_username (case-insensitive).
+type UsernameRematchHandler struct{ peerRematchBase }
+
+// NewUsernameRematchHandler constructs a UsernameRematchHandler.
+func NewUsernameRematchHandler(mr *repository.TelegramMessageRepository, pm *PeerMatcher, ae *AggregationEngine) *UsernameRematchHandler {
+	return &UsernameRematchHandler{peerRematchBase{messageRepo: mr, peerMatcher: pm, aggregationEngine: ae}}
+}
+
+// IdentifierType returns "telegram".
+func (h *UsernameRematchHandler) IdentifierType() string { return "telegram" }
+
+// Rematch links pre-existing telegram messages whose peer_username matches
+// the given handle to the supplied contact and runs aggregation.
+func (h *UsernameRematchHandler) Rematch(ctx context.Context, contactID uuid.UUID, handleNormalized string) (int, error) {
+	if handleNormalized == "" {
+		return 0, nil
+	}
+	peers, err := h.messageRepo.FindDistinctUnmatchedPeerUserIDsByUsername(ctx, handleNormalized)
+	if err != nil {
+		return 0, fmt.Errorf("find peers by username: %w", err)
+	}
+	return h.rematchPeers(ctx, contactID, peers)
+}
+
+// PhoneRematchHandler implements service.RematchHandler for the "phone"
+// identifier type, matching by peer_phone using digits-only comparison.
+type PhoneRematchHandler struct{ peerRematchBase }
+
+// NewPhoneRematchHandler constructs a PhoneRematchHandler.
+func NewPhoneRematchHandler(mr *repository.TelegramMessageRepository, pm *PeerMatcher, ae *AggregationEngine) *PhoneRematchHandler {
+	return &PhoneRematchHandler{peerRematchBase{messageRepo: mr, peerMatcher: pm, aggregationEngine: ae}}
+}
+
+// IdentifierType returns "phone".
+func (h *PhoneRematchHandler) IdentifierType() string { return "phone" }
+
+// Rematch links pre-existing telegram messages whose peer_phone matches the
+// digits-only form of the given phone to the supplied contact.
+func (h *PhoneRematchHandler) Rematch(ctx context.Context, contactID uuid.UUID, phoneNormalized string) (int, error) {
+	digits := phoneDigitsOnly.ReplaceAllString(phoneNormalized, "")
+	if digits == "" {
+		return 0, nil
+	}
+	peers, err := h.messageRepo.FindDistinctUnmatchedPeerUserIDsByPhone(ctx, digits)
+	if err != nil {
+		return 0, fmt.Errorf("find peers by phone: %w", err)
+	}
+	return h.rematchPeers(ctx, contactID, peers)
+}

--- a/backend/internal/telegram/rematch.go
+++ b/backend/internal/telegram/rematch.go
@@ -26,9 +26,15 @@ type peerRematchBase struct {
 
 // rematchPeers iterates the peer set, links each via OnPeerLinked, sums the
 // pre-link unmatched message counts as the "matched" total, and runs
-// aggregation once if anything changed.
+// aggregation once if any peer was linked.
+//
+// Aggregation is gated on "did we link any peer", NOT on the summed count.
+// A transient count-query failure drops the reported total to 0 for that
+// peer, but the link itself already happened — skipping aggregation there
+// would leave those messages unprocessed until the next batch pass.
 func (b *peerRematchBase) rematchPeers(ctx context.Context, contactID uuid.UUID, peers []repository.UnmatchedPeer) (int, error) {
 	matched := 0
+	linked := false
 	for _, p := range peers {
 		// Read pre-link count first so we report what the link will affect.
 		// Failures are non-fatal; a 0 just means we under-report this peer.
@@ -49,9 +55,10 @@ func (b *peerRematchBase) rematchPeers(ctx context.Context, contactID uuid.UUID,
 				Msg("telegram rematch: peer link failed")
 			continue
 		}
+		linked = true
 		matched += int(n)
 	}
-	if matched > 0 {
+	if linked {
 		if err := b.aggregationEngine.AggregateForContactBatch(ctx, contactID); err != nil {
 			log.Warn().Err(err).Str("contact_id", contactID.String()).
 				Msg("telegram rematch: aggregation failed")

--- a/backend/tests/api/import_with_selections_test.go
+++ b/backend/tests/api/import_with_selections_test.go
@@ -144,8 +144,10 @@ func TestImportAPI_ImportWithMethodSelection(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, response.Success)
 
-		// Verify created contact
-		contactData := response.Data.(map[string]interface{})
+		// Verify created contact. Import responses wrap the contact in an
+		// ImportContactResponse to carry an optional rematch_job_id.
+		responseData := response.Data.(map[string]interface{})
+		contactData := responseData["contact"].(map[string]interface{})
 		contactID, err := uuid.Parse(contactData["id"].(string))
 		require.NoError(t, err)
 
@@ -215,7 +217,8 @@ func TestImportAPI_ImportWithMethodSelection(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, response.Success)
 
-		contactData := response.Data.(map[string]interface{})
+		responseData := response.Data.(map[string]interface{})
+		contactData := responseData["contact"].(map[string]interface{})
 		contactID, err := uuid.Parse(contactData["id"].(string))
 		require.NoError(t, err)
 
@@ -275,7 +278,8 @@ func TestImportAPI_ImportWithMethodSelection(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, response.Success)
 
-		contactData := response.Data.(map[string]interface{})
+		responseData := response.Data.(map[string]interface{})
+		contactData := responseData["contact"].(map[string]interface{})
 		contactID, err := uuid.Parse(contactData["id"].(string))
 		require.NoError(t, err)
 
@@ -324,7 +328,8 @@ func TestImportAPI_ImportWithMethodSelection(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, response.Success)
 
-		contactData := response.Data.(map[string]interface{})
+		responseData := response.Data.(map[string]interface{})
+		contactData := responseData["contact"].(map[string]interface{})
 		contactID, err := uuid.Parse(contactData["id"].(string))
 		require.NoError(t, err)
 
@@ -693,7 +698,8 @@ func TestImportAPI_ImportWithCadence(t *testing.T) {
 		assert.True(t, response.Success)
 
 		// Verify created contact has cadence
-		contactData := response.Data.(map[string]interface{})
+		responseData := response.Data.(map[string]interface{})
+		contactData := responseData["contact"].(map[string]interface{})
 		contactID, err := uuid.Parse(contactData["id"].(string))
 		require.NoError(t, err)
 
@@ -748,7 +754,8 @@ func TestImportAPI_ImportWithCadence(t *testing.T) {
 		assert.True(t, response.Success)
 
 		// Verify created contact has no cadence
-		contactData := response.Data.(map[string]interface{})
+		responseData := response.Data.(map[string]interface{})
+		contactData := responseData["contact"].(map[string]interface{})
 		contactID, err := uuid.Parse(contactData["id"].(string))
 		require.NoError(t, err)
 
@@ -1044,7 +1051,8 @@ func TestImportAPI_ImportWithName(t *testing.T) {
 		assert.True(t, response.Success)
 
 		// Verify created contact has custom name
-		contactData := response.Data.(map[string]interface{})
+		responseData := response.Data.(map[string]interface{})
+		contactData := responseData["contact"].(map[string]interface{})
 		contactID, err := uuid.Parse(contactData["id"].(string))
 		require.NoError(t, err)
 
@@ -1097,7 +1105,8 @@ func TestImportAPI_ImportWithName(t *testing.T) {
 		assert.True(t, response.Success)
 
 		// Verify created contact uses external name
-		contactData := response.Data.(map[string]interface{})
+		responseData := response.Data.(map[string]interface{})
+		contactData := responseData["contact"].(map[string]interface{})
 		contactID, err := uuid.Parse(contactData["id"].(string))
 		require.NoError(t, err)
 
@@ -1167,7 +1176,8 @@ func TestImportAPI_ImportWithPrimaryMethod(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, response.Success)
 
-		contactData := response.Data.(map[string]interface{})
+		responseData := response.Data.(map[string]interface{})
+		contactData := responseData["contact"].(map[string]interface{})
 		contactID, err := uuid.Parse(contactData["id"].(string))
 		require.NoError(t, err)
 
@@ -1233,7 +1243,8 @@ func TestImportAPI_ImportWithPrimaryMethod(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, response.Success)
 
-		contactData := response.Data.(map[string]interface{})
+		responseData := response.Data.(map[string]interface{})
+		contactData := responseData["contact"].(map[string]interface{})
 		contactID, err := uuid.Parse(contactData["id"].(string))
 		require.NoError(t, err)
 
@@ -1641,7 +1652,8 @@ func TestImportAPI_EdgeCases(t *testing.T) {
 		assert.True(t, response.Success)
 
 		// Verify contact uses original name
-		contactData := response.Data.(map[string]interface{})
+		responseData := response.Data.(map[string]interface{})
+		contactData := responseData["contact"].(map[string]interface{})
 		contactID, err := uuid.Parse(contactData["id"].(string))
 		require.NoError(t, err)
 
@@ -1696,7 +1708,8 @@ func TestImportAPI_EdgeCases(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, response.Success)
 
-		contactData := response.Data.(map[string]interface{})
+		responseData := response.Data.(map[string]interface{})
+		contactData := responseData["contact"].(map[string]interface{})
 		contactID, err := uuid.Parse(contactData["id"].(string))
 		require.NoError(t, err)
 
@@ -1751,7 +1764,8 @@ func TestImportAPI_EdgeCases(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, response.Success)
 
-		contactData := response.Data.(map[string]interface{})
+		responseData := response.Data.(map[string]interface{})
+		contactData := responseData["contact"].(map[string]interface{})
 		contactID, err := uuid.Parse(contactData["id"].(string))
 		require.NoError(t, err)
 
@@ -1884,7 +1898,8 @@ func TestImportAPI_EdgeCases(t *testing.T) {
 		assert.True(t, response.Success)
 
 		// Verify contact uses original name
-		contactData := response.Data.(map[string]interface{})
+		responseData := response.Data.(map[string]interface{})
+		contactData := responseData["contact"].(map[string]interface{})
 		contactID, err := uuid.Parse(contactData["id"].(string))
 		require.NoError(t, err)
 
@@ -1940,7 +1955,8 @@ func TestImportAPI_EdgeCases(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, response.Success)
 
-		contactData := response.Data.(map[string]interface{})
+		responseData := response.Data.(map[string]interface{})
+		contactData := responseData["contact"].(map[string]interface{})
 		contactID, err := uuid.Parse(contactData["id"].(string))
 		require.NoError(t, err)
 
@@ -2050,7 +2066,8 @@ func TestImportAPI_EdgeCases(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, response.Success)
 
-		contactData := response.Data.(map[string]interface{})
+		responseData := response.Data.(map[string]interface{})
+		contactData := responseData["contact"].(map[string]interface{})
 		contactID, err := uuid.Parse(contactData["id"].(string))
 		require.NoError(t, err)
 

--- a/backend/tests/api/import_with_selections_test.go
+++ b/backend/tests/api/import_with_selections_test.go
@@ -2475,7 +2475,8 @@ func TestImportAPI_TelegramImportNewRegression(t *testing.T) {
 
 	var response api.APIResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
-	contactData := response.Data.(map[string]interface{})
+	responseData := response.Data.(map[string]interface{})
+	contactData := responseData["contact"].(map[string]interface{})
 	contactID, err := uuid.Parse(contactData["id"].(string))
 	require.NoError(t, err)
 	defer func() { _ = contactRepo.HardDeleteContact(ctx, contactID) }()

--- a/backend/tests/rematch_integration_test.go
+++ b/backend/tests/rematch_integration_test.go
@@ -1,0 +1,424 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/google"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+	tgpkg "personal-crm/backend/internal/telegram"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// rematchTestEnv bundles the dependencies a typical rematch test needs.
+type rematchTestEnv struct {
+	ctx               context.Context
+	database          *db.Database
+	contactRepo       *repository.ContactRepository
+	contactMethodRepo *repository.ContactMethodRepository
+	calendarRepo      *repository.CalendarEventRepository
+	externalRepo      *repository.ExternalContactRepository
+	interactionRepo   *repository.InteractionRepository
+	contactSvc        *service.ContactService
+	enrichmentSvc     *service.EnrichmentService
+	rematchSvc        *service.RematchService
+}
+
+func setupRematchEnv(t *testing.T) *rematchTestEnv {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set")
+	}
+
+	require.NoError(t, db.RunMigrations(databaseURL, getMigrationsPath()))
+
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+
+	ctx := context.Background()
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	t.Cleanup(func() { database.Close() })
+
+	contactRepo := repository.NewContactRepository(database.Queries)
+	contactMethodRepo := repository.NewContactMethodRepository(database.Queries)
+	interactionRepo := repository.NewInteractionRepository(database.Queries)
+	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
+	calendarRepo := repository.NewCalendarEventRepository(database.Queries)
+	externalRepo := repository.NewExternalContactRepository(database.Queries)
+	enrichmentRepo := repository.NewEnrichmentRepository(database.Queries)
+
+	contactSvc := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo)
+	enrichmentSvc := service.NewEnrichmentService(contactRepo, contactMethodRepo, enrichmentRepo)
+
+	rematchSvc := service.NewRematchService()
+	rematchSvc.Register(google.NewCalendarRematchHandler(calendarRepo, externalRepo, contactSvc))
+	contactSvc.SetRematchService(rematchSvc)
+	enrichmentSvc.SetRematchService(rematchSvc)
+
+	return &rematchTestEnv{
+		ctx:               ctx,
+		database:          database,
+		contactRepo:       contactRepo,
+		contactMethodRepo: contactMethodRepo,
+		calendarRepo:      calendarRepo,
+		externalRepo:      externalRepo,
+		interactionRepo:   interactionRepo,
+		contactSvc:        contactSvc,
+		enrichmentSvc:     enrichmentSvc,
+		rematchSvc:        rematchSvc,
+	}
+}
+
+// waitForJob polls the rematch service until the job is in a terminal state.
+// Bounded by maxAttempts × sleep so it doesn't hang test runs.
+func waitForRematchJob(t *testing.T, svc *service.RematchService, jobID uuid.UUID) service.JobProgress {
+	t.Helper()
+	const maxAttempts = 400 // 400 × 5ms = 2s
+	for range maxAttempts {
+		j, err := svc.GetJob(jobID)
+		if err == nil && j.Status != service.JobStatusRunning {
+			return j
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("rematch job %s did not finish in time", jobID)
+	return service.JobProgress{}
+}
+
+func seedCalendarEventWithAttendee(t *testing.T, env *rematchTestEnv, accountID, email string, endTime time.Time, status string) *repository.CalendarEvent {
+	t.Helper()
+	title := "Test Meeting"
+	resp := "accepted"
+	syncedAt := accelerated.GetCurrentTime()
+	event, err := env.calendarRepo.Upsert(env.ctx, repository.UpsertCalendarEventRequest{
+		GcalEventID:     "rematch-event-" + uuid.NewString(),
+		GcalCalendarID:  "primary",
+		GoogleAccountID: accountID,
+		Title:           &title,
+		StartTime:       endTime.Add(-time.Hour),
+		EndTime:         endTime,
+		Status:          status,
+		UserResponse:    &resp,
+		Attendees: []repository.Attendee{
+			{Email: email, DisplayName: "Test Attendee"},
+		},
+		MatchedContactIDs:    []uuid.UUID{},
+		SyncedAt:             syncedAt,
+		LastContactedUpdated: false,
+	})
+	require.NoError(t, err)
+	return event
+}
+
+func TestRematch_CalendarPastEvent_RecordsInteraction(t *testing.T) {
+	env := setupRematchEnv(t)
+
+	contact, err := env.contactRepo.CreateContact(env.ctx, repository.CreateContactRequest{
+		FullName: "Rematch Past Event " + uuid.NewString()[:8],
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = env.contactRepo.HardDeleteContact(env.ctx, contact.ID) })
+
+	accountID := "rematch-past-" + uuid.NewString()
+	email := "alice@example.com"
+	t.Cleanup(func() { _ = env.calendarRepo.DeleteEventsByAccount(env.ctx, accountID) })
+
+	pastEnd := accelerated.GetCurrentTime().Add(-2 * time.Hour)
+	event := seedCalendarEventWithAttendee(t, env, accountID, email, pastEnd, "confirmed")
+
+	jobID := env.rematchSvc.StartRematchForContact(contact.ID, []service.Method{
+		{Type: "email", Value: email},
+	})
+	require.NotEqual(t, uuid.Nil, jobID)
+
+	job := waitForRematchJob(t, env.rematchSvc, jobID)
+	assert.Equal(t, service.JobStatusCompleted, job.Status)
+	assert.Equal(t, 1, job.Matched)
+
+	// matched_contact_ids should now include the contact.
+	updatedEvent, err := env.calendarRepo.GetByID(env.ctx, event.ID)
+	require.NoError(t, err)
+	require.Contains(t, updatedEvent.MatchedContactIDs, contact.ID)
+
+	// An interaction should exist for (contact, gcal, event.ID).
+	eventIDStr := event.ID.String()
+	interaction, err := env.interactionRepo.FindBySourceRef(env.ctx, contact.ID, repository.InteractionSourceGCal, eventIDStr)
+	require.NoError(t, err)
+	require.NotNil(t, interaction)
+	assert.WithinDuration(t, pastEnd, interaction.OccurredAt, time.Second)
+
+	// Contact's last_contacted should reflect the event.
+	updatedContact, err := env.contactRepo.GetContact(env.ctx, contact.ID)
+	require.NoError(t, err)
+	require.NotNil(t, updatedContact.LastContacted)
+	assert.WithinDuration(t, pastEnd, *updatedContact.LastContacted, time.Second)
+}
+
+func TestRematch_CalendarFutureEvent_NoInteraction(t *testing.T) {
+	env := setupRematchEnv(t)
+
+	contact, err := env.contactRepo.CreateContact(env.ctx, repository.CreateContactRequest{
+		FullName: "Rematch Future Event " + uuid.NewString()[:8],
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = env.contactRepo.HardDeleteContact(env.ctx, contact.ID) })
+
+	accountID := "rematch-future-" + uuid.NewString()
+	email := "bob@example.com"
+	t.Cleanup(func() { _ = env.calendarRepo.DeleteEventsByAccount(env.ctx, accountID) })
+
+	futureEnd := accelerated.GetCurrentTime().Add(48 * time.Hour)
+	event := seedCalendarEventWithAttendee(t, env, accountID, email, futureEnd, "confirmed")
+
+	jobID := env.rematchSvc.StartRematchForContact(contact.ID, []service.Method{
+		{Type: "email", Value: email},
+	})
+	require.NotEqual(t, uuid.Nil, jobID)
+
+	job := waitForRematchJob(t, env.rematchSvc, jobID)
+	assert.Equal(t, service.JobStatusCompleted, job.Status)
+	assert.Equal(t, 1, job.Matched)
+
+	// matched_contact_ids updated.
+	updatedEvent, err := env.calendarRepo.GetByID(env.ctx, event.ID)
+	require.NoError(t, err)
+	assert.Contains(t, updatedEvent.MatchedContactIDs, contact.ID)
+
+	// No interaction should be recorded (future events).
+	eventIDStr := event.ID.String()
+	_, err = env.interactionRepo.FindBySourceRef(env.ctx, contact.ID, repository.InteractionSourceGCal, eventIDStr)
+	assert.True(t, errors.Is(err, db.ErrNotFound), "expected no interaction for future event, got %v", err)
+}
+
+func TestRematch_CalendarCaseInsensitiveEmailMatch(t *testing.T) {
+	env := setupRematchEnv(t)
+
+	contact, err := env.contactRepo.CreateContact(env.ctx, repository.CreateContactRequest{
+		FullName: "Rematch Case " + uuid.NewString()[:8],
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = env.contactRepo.HardDeleteContact(env.ctx, contact.ID) })
+
+	accountID := "rematch-case-" + uuid.NewString()
+	t.Cleanup(func() { _ = env.calendarRepo.DeleteEventsByAccount(env.ctx, accountID) })
+
+	pastEnd := accelerated.GetCurrentTime().Add(-time.Hour)
+	// Stored attendee email uses mixed case.
+	event := seedCalendarEventWithAttendee(t, env, accountID, "Alice@Example.COM", pastEnd, "confirmed")
+
+	jobID := env.rematchSvc.StartRematchForContact(contact.ID, []service.Method{
+		{Type: "email", Value: "alice@example.com"},
+	})
+	require.NotEqual(t, uuid.Nil, jobID)
+	job := waitForRematchJob(t, env.rematchSvc, jobID)
+	assert.Equal(t, service.JobStatusCompleted, job.Status)
+	assert.Equal(t, 1, job.Matched, "case-insensitive match should still find the event")
+
+	updatedEvent, err := env.calendarRepo.GetByID(env.ctx, event.ID)
+	require.NoError(t, err)
+	assert.Contains(t, updatedEvent.MatchedContactIDs, contact.ID)
+}
+
+func TestRematch_CalendarIdempotent(t *testing.T) {
+	env := setupRematchEnv(t)
+
+	contact, err := env.contactRepo.CreateContact(env.ctx, repository.CreateContactRequest{
+		FullName: "Rematch Idempotent " + uuid.NewString()[:8],
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = env.contactRepo.HardDeleteContact(env.ctx, contact.ID) })
+
+	accountID := "rematch-idem-" + uuid.NewString()
+	email := "carol@example.com"
+	t.Cleanup(func() { _ = env.calendarRepo.DeleteEventsByAccount(env.ctx, accountID) })
+
+	pastEnd := accelerated.GetCurrentTime().Add(-time.Hour)
+	event := seedCalendarEventWithAttendee(t, env, accountID, email, pastEnd, "confirmed")
+
+	// Run twice. The second run should be a no-op (matched=0) — query filters
+	// out events that already include the contact.
+	for i := range 2 {
+		jobID := env.rematchSvc.StartRematchForContact(contact.ID, []service.Method{
+			{Type: "email", Value: email},
+		})
+		require.NotEqual(t, uuid.Nil, jobID)
+		job := waitForRematchJob(t, env.rematchSvc, jobID)
+		assert.Equal(t, service.JobStatusCompleted, job.Status)
+		if i == 0 {
+			assert.Equal(t, 1, job.Matched, "first run links the event")
+		} else {
+			assert.Equal(t, 0, job.Matched, "second run is a no-op")
+		}
+	}
+
+	// matched_contact_ids should contain the contact exactly once.
+	updatedEvent, err := env.calendarRepo.GetByID(env.ctx, event.ID)
+	require.NoError(t, err)
+	count := 0
+	for _, id := range updatedEvent.MatchedContactIDs {
+		if id == contact.ID {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "matched_contact_ids should contain the contact exactly once")
+
+	// Exactly one interaction should exist (RecordInteraction dedupes).
+	interactions, err := env.interactionRepo.ListContactInteractions(env.ctx, contact.ID, 100, 0)
+	require.NoError(t, err)
+	count = 0
+	for _, it := range interactions {
+		if it.Source == repository.InteractionSourceGCal && it.SourceRef != nil && *it.SourceRef == event.ID.String() {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "exactly one interaction per (contact, source, source_ref)")
+}
+
+func TestRematch_CalendarMarksGcalAttendeeExternalContactMatched(t *testing.T) {
+	env := setupRematchEnv(t)
+
+	contact, err := env.contactRepo.CreateContact(env.ctx, repository.CreateContactRequest{
+		FullName: "Rematch External " + uuid.NewString()[:8],
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = env.contactRepo.HardDeleteContact(env.ctx, contact.ID) })
+
+	email := "dan-" + uuid.NewString()[:8] + "@example.com"
+	displayName := "Dan Test"
+
+	// Seed a gcal_attendee external_contact with this email as its source_id.
+	syncedAt := accelerated.GetCurrentTime()
+	external, err := env.externalRepo.Upsert(env.ctx, repository.UpsertExternalContactRequest{
+		Source:      "gcal_attendee",
+		SourceID:    email,
+		DisplayName: &displayName,
+		Emails:      []repository.EmailEntry{{Value: email, Type: "calendar"}},
+		SyncedAt:    &syncedAt,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = env.externalRepo.Delete(env.ctx, external.ID) })
+
+	accountID := "rematch-ext-" + uuid.NewString()
+	t.Cleanup(func() { _ = env.calendarRepo.DeleteEventsByAccount(env.ctx, accountID) })
+
+	pastEnd := accelerated.GetCurrentTime().Add(-time.Hour)
+	_ = seedCalendarEventWithAttendee(t, env, accountID, email, pastEnd, "confirmed")
+
+	jobID := env.rematchSvc.StartRematchForContact(contact.ID, []service.Method{
+		{Type: "email", Value: email},
+	})
+	require.NotEqual(t, uuid.Nil, jobID)
+	job := waitForRematchJob(t, env.rematchSvc, jobID)
+	assert.Equal(t, service.JobStatusCompleted, job.Status)
+
+	// External candidate should now be marked matched and linked to the contact.
+	updatedExternal, err := env.externalRepo.GetByID(env.ctx, external.ID)
+	require.NoError(t, err)
+	assert.Equal(t, repository.MatchStatusMatched, updatedExternal.MatchStatus)
+	require.NotNil(t, updatedExternal.CRMContactID)
+	assert.Equal(t, contact.ID, *updatedExternal.CRMContactID)
+}
+
+// TestRematch_TelegramUsernameMatch covers the username path end-to-end:
+// seed unmatched messages with peer_username, run UsernameRematchHandler,
+// verify messages were linked. Aggregation correctness is owned by the
+// existing aggregation tests.
+func TestRematch_TelegramUsernameMatch(t *testing.T) {
+	env := setupRematchEnv(t)
+
+	// Stand up the telegram handler stack — we register the username handler
+	// directly against the env's rematch service so we can assert on it.
+	cfg := config.TestConfig()
+	messageRepo := repository.NewTelegramMessageRepository(env.database.Queries)
+	identityRepo := repository.NewIdentityRepository(env.database.Queries)
+	identityService := service.NewIdentityService(identityRepo)
+	peerMatcher := tgpkg.NewPeerMatcher(identityService, messageRepo, env.externalRepo, cfg.Telegram.DiscoveryMinMessages)
+	aggregationEngine := tgpkg.NewAggregationEngine(
+		cfg.Telegram.BurstWindowHours, cfg.Telegram.ReplyBridgeHours,
+		messageRepo, env.interactionRepo,
+		env.contactSvc, env.contactSvc, env.contactSvc,
+	)
+	env.rematchSvc.Register(tgpkg.NewUsernameRematchHandler(messageRepo, peerMatcher, aggregationEngine))
+
+	contact, err := env.contactRepo.CreateContact(env.ctx, repository.CreateContactRequest{
+		FullName: "Rematch TG Username " + uuid.NewString()[:8],
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = env.contactRepo.HardDeleteContact(env.ctx, contact.ID) })
+
+	suffix := uuid.NewString()[:8]
+	chatID := int64(900100)
+	peerUserID := int64(800100)
+	username := "rematchuser_" + suffix
+	t.Cleanup(func() {
+		_, _ = env.database.Pool.Exec(env.ctx,
+			"DELETE FROM telegram_message WHERE peer_user_id = $1", peerUserID)
+	})
+
+	now := accelerated.GetCurrentTime()
+	text := "Hello"
+	for i := range 3 {
+		_, err = messageRepo.UpsertMessage(env.ctx, repository.UpsertTelegramMessageParams{
+			TelegramMessageID: int32(90100 + i),
+			TelegramChatID:    chatID,
+			ChatType:          "private",
+			MessageText:       &text,
+			MessageType:       "text",
+			SentAt:            now.Add(-time.Duration(3-i) * time.Hour).Truncate(time.Microsecond),
+			IsOutgoing:        i%2 == 0,
+			PeerUserID:        ptrInt64(peerUserID),
+			PeerUsername:      &username,
+		})
+		require.NoError(t, err)
+	}
+
+	jobID := env.rematchSvc.StartRematchForContact(contact.ID, []service.Method{
+		{Type: "telegram", Value: username},
+	})
+	require.NotEqual(t, uuid.Nil, jobID)
+
+	job := waitForRematchJob(t, env.rematchSvc, jobID)
+	assert.Equal(t, service.JobStatusCompleted, job.Status)
+	assert.Equal(t, 3, job.Matched)
+
+	// All three messages should now be linked to the contact.
+	linked, err := messageRepo.ListUnprocessedByContact(env.ctx, contact.ID)
+	require.NoError(t, err)
+	// Aggregation will mark them processed; before that they're returned by
+	// ListUnprocessedByContact only if processed_at IS NULL. Either way the
+	// handler runs aggregation so they may now be processed. Verify via raw
+	// SQL count of matched messages instead.
+	_ = linked
+	var matchedCount int
+	require.NoError(t, env.database.Pool.QueryRow(env.ctx,
+		"SELECT COUNT(*) FROM telegram_message WHERE peer_user_id = $1 AND matched_contact_id = $2 AND deleted_at IS NULL",
+		peerUserID, contact.ID,
+	).Scan(&matchedCount))
+	assert.Equal(t, 3, matchedCount, "all messages for the peer should be linked to the contact")
+}
+
+func TestRematch_NoHandlerForType_ReturnsNilJobID(t *testing.T) {
+	env := setupRematchEnv(t)
+
+	// Only the calendar (email) handler is registered in the base env;
+	// asking for rematch on a phone-only set should return uuid.Nil.
+	jobID := env.rematchSvc.StartRematchForContact(uuid.New(), []service.Method{
+		{Type: "phone", Value: "+15551212"},
+	})
+	assert.Equal(t, uuid.Nil, jobID)
+}

--- a/backend/tests/rematch_integration_test.go
+++ b/backend/tests/rematch_integration_test.go
@@ -584,6 +584,100 @@ func TestRematch_RescanContact_UnknownContactReturnsNotFound(t *testing.T) {
 	assert.True(t, errors.Is(err, db.ErrNotFound), "expected ErrNotFound for unknown contact, got %v", err)
 }
 
+// TestRematch_TelegramRematchPlusPostImportHook_NoDuplicateInteraction
+// simulates what happens on the Telegram import/link HTTP path: rematch
+// links the messages and runs aggregation, AND the PostImportHook (which
+// ImportContact / LinkContact still call) runs afterwards and performs the
+// same work. The DB unique index on (contact_id, source, source_ref) must
+// prevent duplicate interactions even though the two paths overlap.
+// Regression test for plan Test Case 5.
+func TestRematch_TelegramRematchPlusPostImportHook_NoDuplicateInteraction(t *testing.T) {
+	env := setupRematchEnv(t)
+
+	// Build the shared matcher + aggregator — the manager normally owns these.
+	cfg := config.TestConfig()
+	messageRepo := repository.NewTelegramMessageRepository(env.database.Queries)
+	identityRepo := repository.NewIdentityRepository(env.database.Queries)
+	identityService := service.NewIdentityService(identityRepo)
+	peerMatcher := tgpkg.NewPeerMatcher(identityService, messageRepo, env.externalRepo, cfg.Telegram.DiscoveryMinMessages)
+	aggregationEngine := tgpkg.NewAggregationEngine(
+		cfg.Telegram.BurstWindowHours, cfg.Telegram.ReplyBridgeHours,
+		messageRepo, env.interactionRepo,
+		env.contactSvc, env.contactSvc, env.contactSvc,
+	)
+	env.rematchSvc.Register(tgpkg.NewUsernameRematchHandler(messageRepo, peerMatcher, aggregationEngine))
+
+	contact, err := env.contactRepo.CreateContact(env.ctx, repository.CreateContactRequest{
+		FullName: "Rematch TG Combined " + uuid.NewString()[:8],
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = env.contactRepo.HardDeleteContact(env.ctx, contact.ID) })
+
+	suffix := uuid.NewString()[:8]
+	chatID := int64(900300)
+	peerUserID := int64(800300)
+	username := "combinedpath_" + suffix
+	t.Cleanup(func() {
+		_, _ = env.database.Pool.Exec(env.ctx,
+			"DELETE FROM telegram_message WHERE peer_user_id = $1", peerUserID)
+		_, _ = env.database.Pool.Exec(env.ctx,
+			"DELETE FROM interaction WHERE contact_id = $1 AND source = 'telegram'", contact.ID)
+	})
+
+	// Seed three outbound messages so the aggregation engine produces a single
+	// outbound-burst interaction.
+	now := accelerated.GetCurrentTime().Truncate(time.Microsecond)
+	text := "ping"
+	for i := range 3 {
+		_, err = messageRepo.UpsertMessage(env.ctx, repository.UpsertTelegramMessageParams{
+			TelegramMessageID: int32(90300 + i),
+			TelegramChatID:    chatID,
+			ChatType:          "private",
+			MessageText:       &text,
+			MessageType:       "text",
+			SentAt:            now.Add(-time.Duration(3-i) * 30 * time.Minute),
+			IsOutgoing:        true,
+			PeerUserID:        ptrInt64(peerUserID),
+			PeerUsername:      &username,
+		})
+		require.NoError(t, err)
+	}
+
+	// Step 1: rematch — this mirrors what UpdateContact dispatches when the
+	// user adds a telegram handle to an existing contact.
+	jobID := env.rematchSvc.StartRematchForContact(contact.ID, []service.Method{
+		{Type: "telegram", Value: username},
+	})
+	require.NotEqual(t, uuid.Nil, jobID)
+	job := waitForRematchJob(t, env.rematchSvc, jobID)
+	require.Equal(t, service.JobStatusCompleted, job.Status)
+	require.Equal(t, 3, job.Matched)
+
+	// Step 2: simulate the ImportContact/LinkContact PostImportHook firing
+	// AFTER rematch. peerMatcher.OnPeerLinked is idempotent
+	// (matched_contact_id IS NULL filter) and aggregation reruns over the
+	// already-processed messages (processed_at IS NULL filter) — both should
+	// be no-ops.
+	require.NoError(t, peerMatcher.OnPeerLinked(env.ctx, peerUserID, username, contact.ID))
+	require.NoError(t, aggregationEngine.AggregateForContactBatch(env.ctx, contact.ID))
+
+	// Invariant: exactly one telegram interaction for this contact.
+	var total int
+	require.NoError(t, env.database.Pool.QueryRow(env.ctx,
+		"SELECT COUNT(*) FROM interaction WHERE contact_id = $1 AND source = 'telegram' AND deleted_at IS NULL",
+		contact.ID,
+	).Scan(&total))
+	assert.Equal(t, 1, total, "rematch + PostImportHook together must not produce duplicate interactions")
+
+	// All seeded messages should be linked and processed.
+	var processed int
+	require.NoError(t, env.database.Pool.QueryRow(env.ctx,
+		"SELECT COUNT(*) FROM telegram_message WHERE peer_user_id = $1 AND matched_contact_id = $2 AND processed_at IS NOT NULL",
+		peerUserID, contact.ID,
+	).Scan(&processed))
+	assert.Equal(t, 3, processed)
+}
+
 func TestRematch_ContactServiceUpdateContact_FiresForNewMethodOnly(t *testing.T) {
 	env := setupRematchEnv(t)
 

--- a/backend/tests/rematch_integration_test.go
+++ b/backend/tests/rematch_integration_test.go
@@ -347,7 +347,7 @@ func TestRematch_TelegramUsernameMatch(t *testing.T) {
 	messageRepo := repository.NewTelegramMessageRepository(env.database.Queries)
 	identityRepo := repository.NewIdentityRepository(env.database.Queries)
 	identityService := service.NewIdentityService(identityRepo)
-	peerMatcher := tgpkg.NewPeerMatcher(identityService, messageRepo, env.externalRepo, cfg.Telegram.DiscoveryMinMessages)
+	peerMatcher := tgpkg.NewPeerMatcher(identityService, messageRepo, env.externalRepo, env.enrichmentSvc, cfg.Telegram.DiscoveryMinMessages)
 	aggregationEngine := tgpkg.NewAggregationEngine(
 		cfg.Telegram.BurstWindowHours, cfg.Telegram.ReplyBridgeHours,
 		messageRepo, env.interactionRepo,
@@ -432,7 +432,7 @@ func registerTelegramHandlers(t *testing.T, env *rematchTestEnv) *repository.Tel
 	messageRepo := repository.NewTelegramMessageRepository(env.database.Queries)
 	identityRepo := repository.NewIdentityRepository(env.database.Queries)
 	identityService := service.NewIdentityService(identityRepo)
-	peerMatcher := tgpkg.NewPeerMatcher(identityService, messageRepo, env.externalRepo, cfg.Telegram.DiscoveryMinMessages)
+	peerMatcher := tgpkg.NewPeerMatcher(identityService, messageRepo, env.externalRepo, env.enrichmentSvc, cfg.Telegram.DiscoveryMinMessages)
 	aggregationEngine := tgpkg.NewAggregationEngine(
 		cfg.Telegram.BurstWindowHours, cfg.Telegram.ReplyBridgeHours,
 		messageRepo, env.interactionRepo,
@@ -599,7 +599,7 @@ func TestRematch_TelegramRematchPlusPostImportHook_NoDuplicateInteraction(t *tes
 	messageRepo := repository.NewTelegramMessageRepository(env.database.Queries)
 	identityRepo := repository.NewIdentityRepository(env.database.Queries)
 	identityService := service.NewIdentityService(identityRepo)
-	peerMatcher := tgpkg.NewPeerMatcher(identityService, messageRepo, env.externalRepo, cfg.Telegram.DiscoveryMinMessages)
+	peerMatcher := tgpkg.NewPeerMatcher(identityService, messageRepo, env.externalRepo, env.enrichmentSvc, cfg.Telegram.DiscoveryMinMessages)
 	aggregationEngine := tgpkg.NewAggregationEngine(
 		cfg.Telegram.BurstWindowHours, cfg.Telegram.ReplyBridgeHours,
 		messageRepo, env.interactionRepo,

--- a/backend/tests/rematch_integration_test.go
+++ b/backend/tests/rematch_integration_test.go
@@ -422,3 +422,212 @@ func TestRematch_NoHandlerForType_ReturnsNilJobID(t *testing.T) {
 	})
 	assert.Equal(t, uuid.Nil, jobID)
 }
+
+// registerTelegramHandlers wires the username + phone handlers against env's
+// rematch service using the same PeerMatcher and AggregationEngine the
+// production manager would own. Returns the message repo for seeding.
+func registerTelegramHandlers(t *testing.T, env *rematchTestEnv) *repository.TelegramMessageRepository {
+	t.Helper()
+	cfg := config.TestConfig()
+	messageRepo := repository.NewTelegramMessageRepository(env.database.Queries)
+	identityRepo := repository.NewIdentityRepository(env.database.Queries)
+	identityService := service.NewIdentityService(identityRepo)
+	peerMatcher := tgpkg.NewPeerMatcher(identityService, messageRepo, env.externalRepo, cfg.Telegram.DiscoveryMinMessages)
+	aggregationEngine := tgpkg.NewAggregationEngine(
+		cfg.Telegram.BurstWindowHours, cfg.Telegram.ReplyBridgeHours,
+		messageRepo, env.interactionRepo,
+		env.contactSvc, env.contactSvc, env.contactSvc,
+	)
+	env.rematchSvc.Register(tgpkg.NewUsernameRematchHandler(messageRepo, peerMatcher, aggregationEngine))
+	env.rematchSvc.Register(tgpkg.NewPhoneRematchHandler(messageRepo, peerMatcher, aggregationEngine))
+	return messageRepo
+}
+
+func TestRematch_TelegramPhoneMatch(t *testing.T) {
+	env := setupRematchEnv(t)
+	messageRepo := registerTelegramHandlers(t, env)
+
+	contact, err := env.contactRepo.CreateContact(env.ctx, repository.CreateContactRequest{
+		FullName: "Rematch TG Phone " + uuid.NewString()[:8],
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = env.contactRepo.HardDeleteContact(env.ctx, contact.ID) })
+
+	chatID := int64(900200)
+	peerUserID := int64(800200)
+	// peer_phone is raw MTProto (digits only); contact_method value_normalized
+	// carries a leading '+'. Rematch must compare on digits-only.
+	rawPhone := "14155550101"
+	normalizedPhone := "+14155550101"
+	t.Cleanup(func() {
+		_, _ = env.database.Pool.Exec(env.ctx,
+			"DELETE FROM telegram_message WHERE peer_user_id = $1", peerUserID)
+	})
+
+	now := accelerated.GetCurrentTime()
+	text := "Hi"
+	_, err = messageRepo.UpsertMessage(env.ctx, repository.UpsertTelegramMessageParams{
+		TelegramMessageID: 90200,
+		TelegramChatID:    chatID,
+		ChatType:          "private",
+		MessageText:       &text,
+		MessageType:       "text",
+		SentAt:            now.Add(-time.Hour).Truncate(time.Microsecond),
+		IsOutgoing:        false,
+		PeerUserID:        ptrInt64(peerUserID),
+		PeerPhone:         &rawPhone,
+	})
+	require.NoError(t, err)
+
+	jobID := env.rematchSvc.StartRematchForContact(contact.ID, []service.Method{
+		{Type: "phone", Value: normalizedPhone},
+	})
+	require.NotEqual(t, uuid.Nil, jobID)
+	job := waitForRematchJob(t, env.rematchSvc, jobID)
+	assert.Equal(t, service.JobStatusCompleted, job.Status)
+	assert.Equal(t, 1, job.Matched)
+
+	var matchedCount int
+	require.NoError(t, env.database.Pool.QueryRow(env.ctx,
+		"SELECT COUNT(*) FROM telegram_message WHERE peer_user_id = $1 AND matched_contact_id = $2",
+		peerUserID, contact.ID,
+	).Scan(&matchedCount))
+	assert.Equal(t, 1, matchedCount)
+}
+
+func TestRematch_ConcurrentJobs_PerContactMutex(t *testing.T) {
+	env := setupRematchEnv(t)
+
+	contact, err := env.contactRepo.CreateContact(env.ctx, repository.CreateContactRequest{
+		FullName: "Rematch Concurrent " + uuid.NewString()[:8],
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = env.contactRepo.HardDeleteContact(env.ctx, contact.ID) })
+
+	accountID := "rematch-concurrent-" + uuid.NewString()
+	email1 := "conc1@example.com"
+	email2 := "conc2@example.com"
+	t.Cleanup(func() { _ = env.calendarRepo.DeleteEventsByAccount(env.ctx, accountID) })
+
+	// Seed two distinct past events so both rematch calls have work to do.
+	pastEnd := accelerated.GetCurrentTime().Add(-time.Hour)
+	seedCalendarEventWithAttendee(t, env, accountID, email1, pastEnd, "confirmed")
+	seedCalendarEventWithAttendee(t, env, accountID, email2, pastEnd.Add(-30*time.Minute), "confirmed")
+
+	// Fire two jobs targeting the same contact — the per-contact mutex should
+	// serialize them, and both should ultimately complete cleanly.
+	job1 := env.rematchSvc.StartRematchForContact(contact.ID, []service.Method{{Type: "email", Value: email1}})
+	job2 := env.rematchSvc.StartRematchForContact(contact.ID, []service.Method{{Type: "email", Value: email2}})
+	require.NotEqual(t, uuid.Nil, job1)
+	require.NotEqual(t, uuid.Nil, job2)
+
+	p1 := waitForRematchJob(t, env.rematchSvc, job1)
+	p2 := waitForRematchJob(t, env.rematchSvc, job2)
+	assert.Equal(t, service.JobStatusCompleted, p1.Status)
+	assert.Equal(t, service.JobStatusCompleted, p2.Status)
+	assert.Equal(t, 1, p1.Matched)
+	assert.Equal(t, 1, p2.Matched)
+
+	// Both events should be linked to the contact, with no torn writes.
+	var linkedCount int
+	require.NoError(t, env.database.Pool.QueryRow(env.ctx,
+		"SELECT COUNT(*) FROM calendar_event WHERE google_account_id = $1 AND $2 = ANY(matched_contact_ids)",
+		accountID, contact.ID,
+	).Scan(&linkedCount))
+	assert.Equal(t, 2, linkedCount)
+}
+
+func TestRematch_RescanContact_RunsForAllMethods(t *testing.T) {
+	env := setupRematchEnv(t)
+
+	contact, err := env.contactRepo.CreateContact(env.ctx, repository.CreateContactRequest{
+		FullName: "Rematch Rescan " + uuid.NewString()[:8],
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = env.contactRepo.HardDeleteContact(env.ctx, contact.ID) })
+
+	// Create the method directly on the repo so the create path doesn't
+	// trigger a rematch job we don't care about.
+	email := "rescan@example.com"
+	_, err = env.contactMethodRepo.CreateContactMethod(env.ctx, repository.CreateContactMethodRequest{
+		ContactID: contact.ID,
+		Type:      "email",
+		Value:     email,
+		IsPrimary: true,
+	})
+	require.NoError(t, err)
+
+	accountID := "rematch-rescan-" + uuid.NewString()
+	t.Cleanup(func() { _ = env.calendarRepo.DeleteEventsByAccount(env.ctx, accountID) })
+
+	pastEnd := accelerated.GetCurrentTime().Add(-time.Hour)
+	event := seedCalendarEventWithAttendee(t, env, accountID, email, pastEnd, "confirmed")
+
+	// Manual rescan — exercise the service-level method the handler calls.
+	jobID, err := env.rematchSvc.RescanContact(env.ctx, env.contactSvc, contact.ID)
+	require.NoError(t, err)
+	require.NotEqual(t, uuid.Nil, jobID)
+
+	job := waitForRematchJob(t, env.rematchSvc, jobID)
+	assert.Equal(t, service.JobStatusCompleted, job.Status)
+	assert.Equal(t, 1, job.Matched)
+
+	updatedEvent, err := env.calendarRepo.GetByID(env.ctx, event.ID)
+	require.NoError(t, err)
+	assert.Contains(t, updatedEvent.MatchedContactIDs, contact.ID)
+}
+
+func TestRematch_RescanContact_UnknownContactReturnsNotFound(t *testing.T) {
+	env := setupRematchEnv(t)
+
+	_, err := env.rematchSvc.RescanContact(env.ctx, env.contactSvc, uuid.New())
+	assert.True(t, errors.Is(err, db.ErrNotFound), "expected ErrNotFound for unknown contact, got %v", err)
+}
+
+func TestRematch_ContactServiceUpdateContact_FiresForNewMethodOnly(t *testing.T) {
+	env := setupRematchEnv(t)
+
+	existingEmail := "existing@example.com"
+	contact, err := env.contactRepo.CreateContact(env.ctx, repository.CreateContactRequest{
+		FullName: "Rematch Diff " + uuid.NewString()[:8],
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = env.contactRepo.HardDeleteContact(env.ctx, contact.ID) })
+
+	// Seed an existing email method outside the service so no rematch fires.
+	_, err = env.contactMethodRepo.CreateContactMethod(env.ctx, repository.CreateContactMethodRequest{
+		ContactID: contact.ID, Type: "email", Value: existingEmail, IsPrimary: true,
+	})
+	require.NoError(t, err)
+
+	accountID := "rematch-diff-" + uuid.NewString()
+	t.Cleanup(func() { _ = env.calendarRepo.DeleteEventsByAccount(env.ctx, accountID) })
+
+	pastEnd := accelerated.GetCurrentTime().Add(-time.Hour)
+	// Event whose attendee matches the PRE-EXISTING email. Rematch should
+	// NOT link this on the update — diffNewMethods filters it out.
+	_ = seedCalendarEventWithAttendee(t, env, accountID, existingEmail, pastEnd, "confirmed")
+	// Event whose attendee matches the NEWLY-ADDED email. Should be linked.
+	newEmail := "added@example.com"
+	newEvent := seedCalendarEventWithAttendee(t, env, accountID, newEmail, pastEnd, "confirmed")
+
+	_, jobID, err := env.contactSvc.UpdateContact(env.ctx, contact.ID, repository.UpdateContactRequest{
+		FullName: contact.FullName,
+	}, []service.ContactMethodInput{
+		{Type: "email", Value: existingEmail, IsPrimary: true},
+		{Type: "email", Value: newEmail, IsPrimary: false},
+	}, true)
+	require.NoError(t, err)
+	require.NotEqual(t, uuid.Nil, jobID, "UpdateContact should dispatch rematch for newly-added email")
+
+	job := waitForRematchJob(t, env.rematchSvc, jobID)
+	assert.Equal(t, service.JobStatusCompleted, job.Status)
+	// matched is the number of new events linked — only the newEmail event.
+	assert.Equal(t, 1, job.Matched)
+
+	// Verify: new event linked, existing-email event still unlinked from this
+	// contact (since rematch was only for the new email diff).
+	newEventState, err := env.calendarRepo.GetByID(env.ctx, newEvent.ID)
+	require.NoError(t, err)
+	assert.Contains(t, newEventState.MatchedContactIDs, contact.ID)
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import { Geist, Geist_Mono } from 'next/font/google'
 import './globals.css'
 import { QueryProvider } from '@/components/providers/query-provider'
+import { RematchJobsProvider } from '@/components/providers/rematch-jobs-provider'
 import { ErrorBoundary } from '@/components/error-boundary'
 
 const geistSans = Geist({
@@ -28,7 +29,9 @@ export default function RootLayout({
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         <QueryProvider>
-          <ErrorBoundary>{children}</ErrorBoundary>
+          <RematchJobsProvider>
+            <ErrorBoundary>{children}</ErrorBoundary>
+          </RematchJobsProvider>
         </QueryProvider>
       </body>
     </html>

--- a/frontend/src/components/providers/rematch-job-watcher.tsx
+++ b/frontend/src/components/providers/rematch-job-watcher.tsx
@@ -22,30 +22,32 @@ interface Props {
 export function RematchJobWatcher({ jobId, contactId, invalidateImports, onDone }: Props) {
   const queryClient = useQueryClient()
 
-  const { data } = useQuery({
+  const { data, error } = useQuery({
     queryKey: rematchKeys.job(jobId),
     queryFn: () => rematchApi.getJob(jobId),
     refetchInterval: query => {
       const status = query.state.data?.status
-      // Poll while running or while we don't yet have a status; stop on any
-      // terminal state (completed, failed) or on a 404 (server lost the job).
+      const errStatus = getErrStatus(query.state.error)
+      // Stop polling on any terminal state: completed/failed, or a 404 (the
+      // server lost the job — e.g. after a restart). Poll while running or
+      // before the first response arrives.
+      if (errStatus === 404) return false
       return status === 'running' || status == null ? 1000 : false
     },
-    // 404 is terminal — don't keep retrying when the job is gone.
+    // 404 is terminal — don't retry. Anything else gets a couple of retries.
     retry: (count, err: unknown) => {
-      if (typeof err === 'object' && err !== null && 'status' in err) {
-        const status = (err as { status?: number }).status
-        if (status === 404) {
-          return false
-        }
-      }
+      if (getErrStatus(err) === 404) return false
       return count < 2
     },
   })
 
   useEffect(() => {
-    if (!data || data.status === 'running') return
+    const errStatus = getErrStatus(error)
+    const isTerminal = (data && data.status !== 'running') || errStatus === 404
+    if (!isTerminal) return
 
+    // On 404 we can't prove the rematch completed vs. was never started —
+    // invalidate anyway so stale reads are corrected at the next render.
     queryClient.invalidateQueries({ queryKey: contactKeys.detail(contactId) })
     queryClient.invalidateQueries({ queryKey: contactKeys.lists() })
     queryClient.invalidateQueries({ queryKey: calendarKeys.forContact(contactId) })
@@ -54,7 +56,14 @@ export function RematchJobWatcher({ jobId, contactId, invalidateImports, onDone 
       queryClient.invalidateQueries({ queryKey: importKeys.all })
     }
     onDone()
-  }, [data, contactId, invalidateImports, queryClient, onDone])
+  }, [data, error, contactId, invalidateImports, queryClient, onDone])
 
   return null
+}
+
+function getErrStatus(err: unknown): number | undefined {
+  if (typeof err === 'object' && err !== null && 'status' in err) {
+    return (err as { status?: number }).status
+  }
+  return undefined
 }

--- a/frontend/src/components/providers/rematch-job-watcher.tsx
+++ b/frontend/src/components/providers/rematch-job-watcher.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { rematchApi } from '@/lib/rematch-api'
+import { calendarKeys, contactKeys, importKeys, rematchKeys } from '@/lib/query-keys'
+
+interface Props {
+  jobId: string
+  contactId: string
+  invalidateImports?: boolean
+  onDone: () => void
+}
+
+/**
+ * Render-nothing component that polls a single rematch job and invalidates
+ * the relevant caches once it reaches a terminal status. Mounted (and
+ * unmounted) by RematchJobsProvider — never rendered directly by feature
+ * code. Surviving navigation is the whole reason this lives at app root
+ * rather than per-page.
+ */
+export function RematchJobWatcher({ jobId, contactId, invalidateImports, onDone }: Props) {
+  const queryClient = useQueryClient()
+
+  const { data } = useQuery({
+    queryKey: rematchKeys.job(jobId),
+    queryFn: () => rematchApi.getJob(jobId),
+    refetchInterval: query => {
+      const status = query.state.data?.status
+      // Poll while running or while we don't yet have a status; stop on any
+      // terminal state (completed, failed) or on a 404 (server lost the job).
+      return status === 'running' || status == null ? 1000 : false
+    },
+    // 404 is terminal — don't keep retrying when the job is gone.
+    retry: (count, err: unknown) => {
+      if (typeof err === 'object' && err !== null && 'status' in err) {
+        const status = (err as { status?: number }).status
+        if (status === 404) {
+          return false
+        }
+      }
+      return count < 2
+    },
+  })
+
+  useEffect(() => {
+    if (!data || data.status === 'running') return
+
+    queryClient.invalidateQueries({ queryKey: contactKeys.detail(contactId) })
+    queryClient.invalidateQueries({ queryKey: contactKeys.lists() })
+    queryClient.invalidateQueries({ queryKey: calendarKeys.forContact(contactId) })
+    queryClient.invalidateQueries({ queryKey: calendarKeys.upcomingForContact(contactId) })
+    if (invalidateImports) {
+      queryClient.invalidateQueries({ queryKey: importKeys.all })
+    }
+    onDone()
+  }, [data, contactId, invalidateImports, queryClient, onDone])
+
+  return null
+}

--- a/frontend/src/components/providers/rematch-jobs-provider.tsx
+++ b/frontend/src/components/providers/rematch-jobs-provider.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import { createContext, useCallback, useContext, useState } from 'react'
+import { RematchJobWatcher } from './rematch-job-watcher'
+
+interface PendingJob {
+  jobId: string
+  contactId: string
+  invalidateImports?: boolean
+}
+
+interface RematchJobsContextValue {
+  registerJob: (job: PendingJob) => void
+}
+
+const RematchJobsContext = createContext<RematchJobsContextValue | null>(null)
+
+/**
+ * Tracks rematch jobs across the whole app so polling continues even when the
+ * user navigates away from the page that triggered the rematch. Each job runs
+ * its own RematchJobWatcher (a render-nothing component) which polls the API
+ * once per second and invalidates the affected query caches on terminal
+ * status.
+ *
+ * Why global, not a per-page hook: a useRematchJob hook scoped to a contact
+ * detail page would unmount when the user navigates away, and React Query
+ * would garbage-collect the polling query after gcTime — leaving stale
+ * calendar data in the cache for the user's next visit. The provider is
+ * mounted at app root so it survives page transitions.
+ */
+export function RematchJobsProvider({ children }: { children: React.ReactNode }) {
+  const [jobs, setJobs] = useState<PendingJob[]>([])
+
+  const registerJob = useCallback((job: PendingJob) => {
+    setJobs(prev => (prev.some(p => p.jobId === job.jobId) ? prev : [...prev, job]))
+  }, [])
+
+  const removeJob = useCallback((jobId: string) => {
+    setJobs(prev => prev.filter(p => p.jobId !== jobId))
+  }, [])
+
+  return (
+    <RematchJobsContext.Provider value={{ registerJob }}>
+      {children}
+      {jobs.map(job => (
+        <RematchJobWatcher
+          key={job.jobId}
+          jobId={job.jobId}
+          contactId={job.contactId}
+          invalidateImports={job.invalidateImports}
+          onDone={() => removeJob(job.jobId)}
+        />
+      ))}
+    </RematchJobsContext.Provider>
+  )
+}
+
+/**
+ * Returns a function that mutation hooks call inside their onSuccess handler
+ * to register a freshly-created rematch job with the global watcher. The
+ * provider takes ownership of polling + invalidation from there.
+ */
+export function useRegisterRematchJob() {
+  const ctx = useContext(RematchJobsContext)
+  if (!ctx) {
+    throw new Error('useRegisterRematchJob must be used inside RematchJobsProvider')
+  }
+  return ctx.registerJob
+}

--- a/frontend/src/hooks/__tests__/use-imports.test.tsx
+++ b/frontend/src/hooks/__tests__/use-imports.test.tsx
@@ -43,6 +43,12 @@ vi.mock('@/lib/query-invalidation', () => ({
   },
 }))
 
+// Mock the rematch jobs provider — useImportAsContact / useLinkCandidate
+// register jobs through this context. Tests don't exercise the provider.
+vi.mock('@/components/providers/rematch-jobs-provider', () => ({
+  useRegisterRematchJob: () => vi.fn(),
+}))
+
 // Import mocked modules
 import { importsApi } from '@/lib/imports-api'
 import { invalidateFor } from '@/lib/query-invalidation'
@@ -314,8 +320,8 @@ describe('use-imports hooks', () => {
 
   describe('useImportAsContact', () => {
     it('imports candidate and invalidates queries on success', async () => {
-      const mockContact = { id: 'crm-456', full_name: 'John Doe' }
-      mockedImportsApi.importCandidate.mockResolvedValueOnce(mockContact)
+      const mockResponse = { contact: { id: 'crm-456', full_name: 'John Doe' } }
+      mockedImportsApi.importCandidate.mockResolvedValueOnce(mockResponse)
 
       const { result } = renderHook(() => useImportAsContact(), {
         wrapper: createWrapper(queryClient),
@@ -328,8 +334,8 @@ describe('use-imports hooks', () => {
     })
 
     it('imports candidate with method selection', async () => {
-      const mockContact = { id: 'crm-456', full_name: 'John Doe' }
-      mockedImportsApi.importCandidate.mockResolvedValueOnce(mockContact)
+      const mockResponse = { contact: { id: 'crm-456', full_name: 'John Doe' } }
+      mockedImportsApi.importCandidate.mockResolvedValueOnce(mockResponse)
 
       const { result } = renderHook(() => useImportAsContact(), {
         wrapper: createWrapper(queryClient),
@@ -349,7 +355,7 @@ describe('use-imports hooks', () => {
 
     it('populates contact detail cache on success', async () => {
       const mockContact = { id: 'crm-456', full_name: 'John Doe' }
-      mockedImportsApi.importCandidate.mockResolvedValueOnce(mockContact)
+      mockedImportsApi.importCandidate.mockResolvedValueOnce({ contact: mockContact })
 
       const { result } = renderHook(() => useImportAsContact(), {
         wrapper: createWrapper(queryClient),
@@ -365,7 +371,7 @@ describe('use-imports hooks', () => {
 
   describe('useLinkCandidate', () => {
     it('links candidate and invalidates queries on success', async () => {
-      mockedImportsApi.linkCandidate.mockResolvedValueOnce(undefined)
+      mockedImportsApi.linkCandidate.mockResolvedValueOnce({ external_contact: { id: 'ext-123' } })
 
       const { result } = renderHook(() => useLinkCandidate(), {
         wrapper: createWrapper(queryClient),
@@ -383,7 +389,7 @@ describe('use-imports hooks', () => {
     })
 
     it('links candidate with method selection and conflict resolutions', async () => {
-      mockedImportsApi.linkCandidate.mockResolvedValueOnce(undefined)
+      mockedImportsApi.linkCandidate.mockResolvedValueOnce({ external_contact: { id: 'ext-123' } })
 
       const { result } = renderHook(() => useLinkCandidate(), {
         wrapper: createWrapper(queryClient),

--- a/frontend/src/hooks/use-calendar.ts
+++ b/frontend/src/hooks/use-calendar.ts
@@ -1,14 +1,9 @@
 import { useQuery } from '@tanstack/react-query'
 import { calendarApi } from '@/lib/calendar-api'
+import { calendarKeys } from '@/lib/query-keys'
 
-// Query key factory for calendar events
-export const calendarKeys = {
-  all: ['calendar-events'] as const,
-  forContact: (contactId: string) => [...calendarKeys.all, 'contact', contactId] as const,
-  upcomingForContact: (contactId: string) =>
-    [...calendarKeys.all, 'upcoming', 'contact', contactId] as const,
-  upcoming: () => [...calendarKeys.all, 'upcoming'] as const,
-}
+// Re-export for backward compatibility (key was previously defined here).
+export { calendarKeys }
 
 // Get all events for a contact
 export function useEventsForContact(

--- a/frontend/src/hooks/use-contacts.ts
+++ b/frontend/src/hooks/use-contacts.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { contactsApi, type ContactIDsParams } from '@/lib/contacts-api'
 import { contactKeys, invalidateFor } from '@/lib/query-invalidation'
+import { useRegisterRematchJob } from '@/components/providers/rematch-jobs-provider'
 import type { CreateContactRequest, UpdateContactRequest, ContactListParams } from '@/types/contact'
 
 // Re-export contactKeys for backward compatibility
@@ -61,12 +62,16 @@ export function useContactIDs(params: ContactIDsParams = {}) {
 // Create contact mutation
 export function useCreateContact() {
   const queryClient = useQueryClient()
+  const registerJob = useRegisterRematchJob()
 
   return useMutation({
     mutationFn: (data: CreateContactRequest) => contactsApi.createContact(data),
     onSuccess: newContact => {
       queryClient.setQueryData(contactKeys.detail(newContact.id), newContact)
       invalidateFor('contact:created')
+      if (newContact.rematch_job_id) {
+        registerJob({ jobId: newContact.rematch_job_id, contactId: newContact.id })
+      }
     },
   })
 }
@@ -74,6 +79,7 @@ export function useCreateContact() {
 // Update contact mutation
 export function useUpdateContact() {
   const queryClient = useQueryClient()
+  const registerJob = useRegisterRematchJob()
 
   return useMutation({
     mutationFn: ({ id, data }: { id: string; data: UpdateContactRequest }) =>
@@ -81,6 +87,9 @@ export function useUpdateContact() {
     onSuccess: updatedContact => {
       queryClient.setQueryData(contactKeys.detail(updatedContact.id), updatedContact)
       invalidateFor('contact:updated')
+      if (updatedContact.rematch_job_id) {
+        registerJob({ jobId: updatedContact.rematch_job_id, contactId: updatedContact.id })
+      }
     },
   })
 }

--- a/frontend/src/hooks/use-imports.ts
+++ b/frontend/src/hooks/use-imports.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { importsApi } from '@/lib/imports-api'
 import { contactKeys, importKeys, invalidateFor } from '@/lib/query-invalidation'
+import { useRegisterRematchJob } from '@/components/providers/rematch-jobs-provider'
 import type {
   ImportCandidatesListParams,
   ImportContactRequest,
@@ -32,14 +33,22 @@ export function useImportCandidate(id: string) {
 // Supports optional method selection for enhanced UI
 export function useImportAsContact() {
   const queryClient = useQueryClient()
+  const registerJob = useRegisterRematchJob()
 
   return useMutation({
     mutationFn: ({ id, request }: { id: string; request?: ImportContactRequest }) =>
       importsApi.importCandidate(id, request),
-    onSuccess: newContact => {
+    onSuccess: response => {
       // Populate the contact detail cache with the new contact
-      queryClient.setQueryData(contactKeys.detail(newContact.id), newContact)
+      queryClient.setQueryData(contactKeys.detail(response.contact.id), response.contact)
       invalidateFor('import:imported')
+      if (response.rematch_job_id) {
+        registerJob({
+          jobId: response.rematch_job_id,
+          contactId: response.contact.id,
+          invalidateImports: true,
+        })
+      }
     },
   })
 }
@@ -47,11 +56,20 @@ export function useImportAsContact() {
 // Link candidate to existing CRM contact
 // Supports method selection and conflict resolutions for enhanced UI
 export function useLinkCandidate() {
+  const registerJob = useRegisterRematchJob()
+
   return useMutation({
     mutationFn: ({ id, request }: { id: string; request: LinkContactRequest }) =>
       importsApi.linkCandidate(id, request),
-    onSuccess: () => {
+    onSuccess: (response, vars) => {
       invalidateFor('import:linked')
+      if (response.rematch_job_id) {
+        registerJob({
+          jobId: response.rematch_job_id,
+          contactId: vars.request.crm_contact_id,
+          invalidateImports: true,
+        })
+      }
     },
   })
 }

--- a/frontend/src/lib/imports-api.ts
+++ b/frontend/src/lib/imports-api.ts
@@ -4,9 +4,10 @@ import type {
   ImportCandidatesListParams,
   ImportCandidatesListResponse,
   ImportContactRequest,
+  ImportContactResponse,
   LinkContactRequest,
+  LinkContactResponse,
 } from '@/types/import'
-import type { Contact } from '@/types/contact'
 
 export const importsApi = {
   // Get import candidates (paginated)
@@ -39,15 +40,23 @@ export const importsApi = {
   },
 
   // Import candidate as new CRM contact
-  // Accepts optional method selection for enhanced UI
-  importCandidate: async (id: string, request?: ImportContactRequest): Promise<Contact> => {
-    return apiClient.post<Contact>(`/api/v1/imports/${id}/import`, request)
+  // Accepts optional method selection for enhanced UI. Returns the new
+  // contact wrapped with an optional rematch_job_id (set when historical
+  // calendar events / telegram messages may be retroactively linked).
+  importCandidate: async (
+    id: string,
+    request?: ImportContactRequest
+  ): Promise<ImportContactResponse> => {
+    return apiClient.post<ImportContactResponse>(`/api/v1/imports/${id}/import`, request)
   },
 
   // Link candidate to existing CRM contact
-  // Accepts method selection and conflict resolutions for enhanced UI
-  linkCandidate: async (id: string, request: LinkContactRequest): Promise<void> => {
-    return apiClient.post<void>(`/api/v1/imports/${id}/link`, request)
+  // Accepts method selection and conflict resolutions for enhanced UI.
+  // Returns the linked external contact wrapped with an optional
+  // rematch_job_id (set when newly-enriched methods may retroactively link
+  // historical events / messages).
+  linkCandidate: async (id: string, request: LinkContactRequest): Promise<LinkContactResponse> => {
+    return apiClient.post<LinkContactResponse>(`/api/v1/imports/${id}/link`, request)
   },
 
   // Ignore candidate (won't appear in list anymore)

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -58,3 +58,18 @@ export const telegramKeys = {
   status: () => [...telegramKeys.all, 'status'] as const,
   chats: () => [...telegramKeys.all, 'chats'] as const,
 }
+
+// Calendar event query keys
+export const calendarKeys = {
+  all: ['calendar-events'] as const,
+  forContact: (contactId: string) => [...calendarKeys.all, 'contact', contactId] as const,
+  upcomingForContact: (contactId: string) =>
+    [...calendarKeys.all, 'upcoming', 'contact', contactId] as const,
+  upcoming: () => [...calendarKeys.all, 'upcoming'] as const,
+}
+
+// Rematch job query keys
+export const rematchKeys = {
+  all: ['rematch'] as const,
+  job: (jobId: string) => [...rematchKeys.all, 'job', jobId] as const,
+}

--- a/frontend/src/lib/rematch-api.ts
+++ b/frontend/src/lib/rematch-api.ts
@@ -1,0 +1,35 @@
+import { apiClient } from './api-client'
+
+export type RematchJobStatus = 'running' | 'completed' | 'failed'
+
+export interface RematchJobMethod {
+  type: string
+  value: string
+}
+
+export interface RematchJob {
+  id: string
+  contact_id: string
+  status: RematchJobStatus
+  matched: number
+  methods: RematchJobMethod[]
+  started_at: string
+  completed_at?: string | null
+  error?: string | null
+}
+
+export interface RescanResponse {
+  rematch_job_id: string | null
+}
+
+export const rematchApi = {
+  // Fetch the current state of a rematch job. Returns 404 (thrown) once the
+  // job is no longer known (e.g. process restart cleared the in-memory map).
+  getJob: (jobId: string): Promise<RematchJob> =>
+    apiClient.get<RematchJob>(`/api/v1/rematch/jobs/${jobId}`),
+
+  // Trigger a full rematch across all of a contact's current methods. Returns
+  // null jobID when no method types match a registered handler.
+  rescan: (contactId: string): Promise<RescanResponse> =>
+    apiClient.post<RescanResponse>(`/api/v1/rematch/contacts/${contactId}/rescan`, {}),
+}

--- a/frontend/src/types/contact.ts
+++ b/frontend/src/types/contact.ts
@@ -32,6 +32,12 @@ export interface Contact {
   created_at: string
   updated_at: string
   deleted_at?: string
+  /**
+   * Set when create/update kicked off a rematch job to retroactively link
+   * historical calendar events / telegram messages. Null when no methods
+   * matched a registered handler. Polled by RematchJobsProvider.
+   */
+  rematch_job_id?: string | null
 }
 
 export interface OverdueContact extends Contact {

--- a/frontend/src/types/import.ts
+++ b/frontend/src/types/import.ts
@@ -99,3 +99,15 @@ export interface MethodComparison {
   conflict_type: ConflictType
   state: MethodState
 }
+
+/** Response from POST /imports/:id/import — wraps the new contact and an optional rematch job ID. */
+export interface ImportContactResponse {
+  contact: import('./contact').Contact
+  rematch_job_id?: string | null
+}
+
+/** Response from POST /imports/:id/link — wraps the linked external contact and an optional rematch job ID. */
+export interface LinkContactResponse {
+  external_contact: ImportCandidate
+  rematch_job_id?: string | null
+}

--- a/frontend/tests/e2e/helpers/test-api.ts
+++ b/frontend/tests/e2e/helpers/test-api.ts
@@ -93,6 +93,10 @@ export interface SeedCalendarEventInput {
   is_past?: boolean
   days_ago?: number
   days_ahead?: number
+  attendee_emails?: string[]
+  // Seed the event with attendees but no matched_contact_ids — the caller
+  // intends to drive the rematch flow from the UI.
+  unmatched?: boolean
 }
 
 export interface SeedCalendarEventsRequest {

--- a/frontend/tests/e2e/rematch-on-add-email.spec.ts
+++ b/frontend/tests/e2e/rematch-on-add-email.spec.ts
@@ -47,41 +47,25 @@ test.describe('Rematch on add email @area:contacts', () => {
       },
     ])
 
-    // Navigate to contact detail page.
-    await page.goto(`/contacts/${contactId}`)
+    // Navigate straight into the edit view via the existing ?action=edit query
+    // param (same path the list-page "Edit" context menu uses).
+    await page.goto(`/contacts/${contactId}?action=edit`)
     await page.waitForLoadState('domcontentloaded')
-
-    // Meetings section should currently be empty (no matched events).
-    const meetingsHeading = page.getByRole('heading', { name: /Meetings/i })
-    await expect(meetingsHeading).toBeVisible({ timeout: 15000 })
-    await expect(page.getByText(`${testApi.prefix}-Rematch Meeting`)).not.toBeVisible()
-
-    // Open edit view via context menu.
-    await page
-      .getByRole('button', { name: /Actions|More/i })
-      .first()
-      .click()
-    await page.getByRole('menuitem', { name: 'Edit' }).click()
     await expect(page.getByRole('heading', { name: 'Edit Contact' })).toBeVisible({
       timeout: 15000,
     })
 
-    // Add an email method. The form starts with one empty method row.
-    await page
-      .getByRole('combobox')
-      .filter({ hasText: /Select|Email/i })
-      .first()
-      .selectOption('email')
-    await page
-      .locator('input[placeholder*="email" i], input[type="email"]')
-      .first()
-      .fill(attendeeEmail)
+    // Add an email method. The form starts with one empty method row (type
+    // "Select", value ""); pick email + fill the attendee address.
+    const firstRow = page.locator('.group').first()
+    await firstRow.getByRole('combobox').selectOption('email')
+    await firstRow.locator('input[type="email"]').fill(attendeeEmail)
 
     // Capture the PUT response so we can read back the rematch_job_id.
     const updateResponsePromise = page.waitForResponse(
       res => res.url().includes(`/api/v1/contacts/${contactId}`) && res.request().method() === 'PUT'
     )
-    await page.getByRole('button', { name: /Save|Update/i }).click()
+    await page.getByRole('button', { name: 'Update Contact' }).click()
     const updateResponse = await updateResponsePromise
     expect(updateResponse.ok()).toBe(true)
     const updateBody = await updateResponse.json()
@@ -109,8 +93,8 @@ test.describe('Rematch on add email @area:contacts', () => {
     }
     expect(jobCompleted, 'rematch job should reach a terminal state').toBe(true)
 
-    // The provider's invalidation should refresh the Meetings list. Switch to
-    // the All tab so past events are visible regardless of default filter.
+    // The provider's invalidation should refresh the Meetings list. Click the
+    // All tab so past events are visible regardless of default filter.
     await page.getByRole('button', { name: /All \(\d+\)/i }).click()
 
     await expect(page.getByText(`${testApi.prefix}-Rematch Meeting`)).toBeVisible({

--- a/frontend/tests/e2e/rematch-on-add-email.spec.ts
+++ b/frontend/tests/e2e/rematch-on-add-email.spec.ts
@@ -1,0 +1,120 @@
+import { test, expect } from '@playwright/test'
+import { createTestAPI, TestAPI } from './helpers/test-api'
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080'
+const API_KEY = process.env.NEXT_PUBLIC_API_KEY || 'test-api-key-for-ci'
+const API_HEADERS = {
+  'X-API-Key': API_KEY,
+  'Content-Type': 'application/json',
+}
+
+// Exercise the full rematch happy path: seed an unmatched calendar event
+// with an attendee email, add that email to a CRM contact, and assert the
+// Meetings tab shows the event once the rematch job completes. The frontend
+// polls the job silently (RematchJobsProvider); invalidation causes the
+// Meetings list to refresh. @area:contacts
+test.describe('Rematch on add email @area:contacts', () => {
+  let testApi: TestAPI
+
+  test.beforeEach(async ({ request }, testInfo) => {
+    testApi = createTestAPI(request, testInfo)
+  })
+
+  test.afterEach(async () => {
+    await testApi.cleanup()
+  })
+
+  test('adding an email retroactively links a past calendar event to the contact', async ({
+    page,
+    request,
+  }) => {
+    const attendeeEmail = `rematch-${Date.now()}@example.com`
+
+    // Seed a contact with no email so the rematch handler has something to link to.
+    const { ids } = await testApi.seedContacts([{ full_name: 'Rematch Target' }])
+    const contactId = ids[0]
+
+    // Seed an unmatched past calendar event with the attendee email. The
+    // `unmatched` flag keeps contact_id OUT of matched_contact_ids so the
+    // event isn't visible on the Meetings tab until rematch links it.
+    await testApi.seedCalendarEvents(contactId, [
+      {
+        title: 'Rematch Meeting',
+        is_past: true,
+        days_ago: 3,
+        attendee_emails: [attendeeEmail],
+        unmatched: true,
+      },
+    ])
+
+    // Navigate to contact detail page.
+    await page.goto(`/contacts/${contactId}`)
+    await page.waitForLoadState('domcontentloaded')
+
+    // Meetings section should currently be empty (no matched events).
+    const meetingsHeading = page.getByRole('heading', { name: /Meetings/i })
+    await expect(meetingsHeading).toBeVisible({ timeout: 15000 })
+    await expect(page.getByText(`${testApi.prefix}-Rematch Meeting`)).not.toBeVisible()
+
+    // Open edit view via context menu.
+    await page
+      .getByRole('button', { name: /Actions|More/i })
+      .first()
+      .click()
+    await page.getByRole('menuitem', { name: 'Edit' }).click()
+    await expect(page.getByRole('heading', { name: 'Edit Contact' })).toBeVisible({
+      timeout: 15000,
+    })
+
+    // Add an email method. The form starts with one empty method row.
+    await page
+      .getByRole('combobox')
+      .filter({ hasText: /Select|Email/i })
+      .first()
+      .selectOption('email')
+    await page
+      .locator('input[placeholder*="email" i], input[type="email"]')
+      .first()
+      .fill(attendeeEmail)
+
+    // Capture the PUT response so we can read back the rematch_job_id.
+    const updateResponsePromise = page.waitForResponse(
+      res => res.url().includes(`/api/v1/contacts/${contactId}`) && res.request().method() === 'PUT'
+    )
+    await page.getByRole('button', { name: /Save|Update/i }).click()
+    const updateResponse = await updateResponsePromise
+    expect(updateResponse.ok()).toBe(true)
+    const updateBody = await updateResponse.json()
+    const rematchJobId: string | undefined = updateBody?.data?.rematch_job_id
+    expect(rematchJobId, 'PUT /contacts response should carry rematch_job_id').toBeTruthy()
+
+    // The frontend polls the job silently. Poll the backend directly from the
+    // test so we can fail fast if something is wrong — visual assertions below
+    // cover the actual user-visible outcome (Meetings tab refresh).
+    let jobCompleted = false
+    for (let i = 0; i < 40 && !jobCompleted; i++) {
+      const res = await request.get(`${API_BASE_URL}/api/v1/rematch/jobs/${rematchJobId}`, {
+        headers: API_HEADERS,
+      })
+      if (res.ok()) {
+        const body = await res.json()
+        if (body?.data?.status === 'completed' || body?.data?.status === 'failed') {
+          expect(body.data.status).toBe('completed')
+          expect(body.data.matched).toBeGreaterThanOrEqual(1)
+          jobCompleted = true
+          break
+        }
+      }
+      await new Promise(r => setTimeout(r, 250))
+    }
+    expect(jobCompleted, 'rematch job should reach a terminal state').toBe(true)
+
+    // The provider's invalidation should refresh the Meetings list. Switch to
+    // the All tab so past events are visible regardless of default filter.
+    await page.getByRole('button', { name: /All \(\d+\)/i }).click()
+
+    await expect(page.getByText(`${testApi.prefix}-Rematch Meeting`)).toBeVisible({
+      timeout: 10000,
+    })
+  })
+})

--- a/frontend/tests/e2e/test-map.json
+++ b/frontend/tests/e2e/test-map.json
@@ -405,6 +405,34 @@
     "tags": ["@area:contacts"]
   },
   {
+    "pattern": "^frontend/tests/e2e/rematch-on-add-email\\.spec\\.ts$",
+    "tags": ["@area:contacts", "@area:meetings"]
+  },
+  {
+    "pattern": "^backend/internal/service/rematch\\.go$",
+    "tags": ["@area:contacts", "@area:meetings"]
+  },
+  {
+    "pattern": "^backend/internal/api/handlers/rematch\\.go$",
+    "tags": ["@area:contacts", "@area:meetings"]
+  },
+  {
+    "pattern": "^backend/internal/google/calendar_rematch\\.go$",
+    "tags": ["@area:meetings"]
+  },
+  {
+    "pattern": "^backend/internal/telegram/rematch\\.go$",
+    "tags": ["@area:settings"]
+  },
+  {
+    "pattern": "^frontend/src/lib/rematch-api\\.ts$",
+    "tags": ["@area:contacts", "@area:meetings"]
+  },
+  {
+    "pattern": "^frontend/src/components/providers/rematch-",
+    "tags": ["@area:contacts", "@area:meetings"]
+  },
+  {
     "pattern": "^backend/internal/service/followup\\.go$",
     "tags": ["@area:contacts", "@area:tasks"]
   },


### PR DESCRIPTION
Implements issue #182 — when a user adds an email, telegram handle, or phone to a CRM contact, historical calendar events and Telegram messages that reference that identifier but were synced before the link existed are retroactively attributed to the contact.

Plan: `.ai/log/plan/rematch-service.md`

## Summary

- **Backend scaffolding** — new `RematchService` dispatches per-identifier handlers in a detached goroutine, serialized per-contact by a mutex. `ContactService.CreateContact`/`UpdateContact` and `EnrichmentService.EnrichContactFromExternal{,WithSelections}` now return a rematch job ID alongside their existing results. New `GET /rematch/jobs/:jobID` for polling and `POST /rematch/contacts/:id/rescan` for manual full-method rematch.
- **Calendar handler** — resolves email → attendee-matched events, appends the contact to `matched_contact_ids`, and records `gcal` interactions directly for past events (avoids the scheduler race documented in plan Design Decision 6).
- **Telegram handlers** — username and phone handlers share a `peerRematchBase`; aggregation runs exactly once per invocation gated on "did we link any peer", not on the summed message count (so a transient count-query failure doesn't strand linked messages).
- **Frontend polling** — global `RematchJobsProvider` mounted at app root owns the set of in-flight jobs. Each job runs a render-nothing `RematchJobWatcher` that polls every 1s, treats 404 as terminal, and invalidates contact / contact-list / calendar (and optionally imports) caches on completion. Four mutation hooks (`useCreateContact`, `useUpdateContact`, `useImportAsContact`, `useLinkCandidate`) register jobs on success.
- **Intentional deviations from spec** — no user-facing toast UX (silent invalidation, tracked as follow-up), no telegram E2E (covered by Go integration tests until an MTProto seeder lands). Both called out in plan deviations section.

## Test plan

- [ ] `make test-unit` green
- [ ] `make test-integration` green (12 new `TestRematch_*` cases: past/future event, case-insensitive match, idempotent, external-candidate cleanup, username, phone, no-handler-returns-nil, concurrent per-contact mutex, rescan success/404, UpdateContact diff, combined rematch+PostImportHook no-dup)
- [ ] `make test-frontend` green (258 passing, updated `use-imports.test.tsx` assertions for new wrapper response shapes)
- [ ] `make test-e2e-diff` green (new `rematch-on-add-email.spec.ts` drives the add-email → meeting-appears flow)
- [ ] `make lint` clean

## Review loop

Two rounds of Codex and one round of Claude Code (non-interactive). Round 1 (Codex) flagged 5 issues — 4 fixed, 1 deliberately retained per plan Design Decision 5 (PostImportHook double-invocation protected by the `idx_interaction_source_ref` unique index). Round 2 (Codex) asked for a dedicated regression test on the combined path — added as `TestRematch_TelegramRematchPlusPostImportHook_NoDuplicateInteraction`. Round 3 (Claude Code) returned PASS.

Closes #182