### PR TITLE
fix(telegram): enrich sparse entity data from cached peer history

### DIFF
--- a/backend/internal/db/models.go
+++ b/backend/internal/db/models.go
@@ -262,27 +262,28 @@ type TelegramChatConfig struct {
 }
 
 type TelegramMessage struct {
-	ID                pgtype.UUID        `json:"id"`
-	TelegramMessageID int32              `json:"telegram_message_id"`
-	TelegramChatID    int64              `json:"telegram_chat_id"`
-	ChatType          string             `json:"chat_type"`
-	ChatTitle         pgtype.Text        `json:"chat_title"`
-	MessageText       pgtype.Text        `json:"message_text"`
-	MessageType       string             `json:"message_type"`
-	SentAt            pgtype.Timestamptz `json:"sent_at"`
-	EditedAt          pgtype.Timestamptz `json:"edited_at"`
-	IsOutgoing        bool               `json:"is_outgoing"`
-	ReplyToMsgID      pgtype.Int4        `json:"reply_to_msg_id"`
-	PeerUserID        pgtype.Int8        `json:"peer_user_id"`
-	PeerUsername      pgtype.Text        `json:"peer_username"`
-	PeerFirstName     pgtype.Text        `json:"peer_first_name"`
-	PeerLastName      pgtype.Text        `json:"peer_last_name"`
-	PeerPhone         pgtype.Text        `json:"peer_phone"`
-	MatchedContactID  pgtype.UUID        `json:"matched_contact_id"`
-	InteractionID     pgtype.UUID        `json:"interaction_id"`
-	ProcessedAt       pgtype.Timestamptz `json:"processed_at"`
-	DeletedAt         pgtype.Timestamptz `json:"deleted_at"`
-	CreatedAt         pgtype.Timestamptz `json:"created_at"`
+	ID                 pgtype.UUID        `json:"id"`
+	TelegramMessageID  int32              `json:"telegram_message_id"`
+	TelegramChatID     int64              `json:"telegram_chat_id"`
+	ChatType           string             `json:"chat_type"`
+	ChatTitle          pgtype.Text        `json:"chat_title"`
+	MessageText        pgtype.Text        `json:"message_text"`
+	MessageType        string             `json:"message_type"`
+	SentAt             pgtype.Timestamptz `json:"sent_at"`
+	EditedAt           pgtype.Timestamptz `json:"edited_at"`
+	IsOutgoing         bool               `json:"is_outgoing"`
+	ReplyToMsgID       pgtype.Int4        `json:"reply_to_msg_id"`
+	PeerUserID         pgtype.Int8        `json:"peer_user_id"`
+	PeerUsername       pgtype.Text        `json:"peer_username"`
+	PeerFirstName      pgtype.Text        `json:"peer_first_name"`
+	PeerLastName       pgtype.Text        `json:"peer_last_name"`
+	PeerPhone          pgtype.Text        `json:"peer_phone"`
+	MatchedContactID   pgtype.UUID        `json:"matched_contact_id"`
+	InteractionID      pgtype.UUID        `json:"interaction_id"`
+	ProcessedAt        pgtype.Timestamptz `json:"processed_at"`
+	DeletedAt          pgtype.Timestamptz `json:"deleted_at"`
+	CreatedAt          pgtype.Timestamptz `json:"created_at"`
+	PeerEntityResolved bool               `json:"peer_entity_resolved"`
 }
 
 type TelegramSession struct {

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -202,6 +202,15 @@ type Querier interface {
 	GetOAuthCredentialByID(ctx context.Context, id pgtype.UUID) (*OauthCredential, error)
 	// Get non-sensitive credential info for display
 	GetOAuthCredentialStatus(ctx context.Context, id pgtype.UUID) (*GetOAuthCredentialStatusRow, error)
+	// Returns the best-known entity data for a given peer_user_id by selecting
+	// the telegram_message row with the most-populated peer entity fields.
+	// Ordering mirrors ListDistinctUnmatchedPeers: prefer non-blank username,
+	// then phone, then first_name/last_name, then the most recent message.
+	// Used by the live-message handler to backfill sparse entity data from the
+	// gotd/td dispatcher before upserting the new message. Does NOT filter on
+	// matched_contact_id — needed for rematching previously-matched peers after
+	// a contact soft-delete.
+	GetPeerEntityByUserID(ctx context.Context, peerUserID pgtype.Int8) (*GetPeerEntityByUserIDRow, error)
 	GetSyncLog(ctx context.Context, id pgtype.UUID) (*ExternalSyncLog, error)
 	// External Sync State Queries
 	GetSyncState(ctx context.Context, id pgtype.UUID) (*ExternalSyncState, error)

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -202,14 +202,19 @@ type Querier interface {
 	GetOAuthCredentialByID(ctx context.Context, id pgtype.UUID) (*OauthCredential, error)
 	// Get non-sensitive credential info for display
 	GetOAuthCredentialStatus(ctx context.Context, id pgtype.UUID) (*GetOAuthCredentialStatusRow, error)
-	// Returns the best-known entity data for a given peer_user_id by selecting
-	// the telegram_message row with the most-populated peer entity fields.
-	// Ordering mirrors ListDistinctUnmatchedPeers: prefer non-blank username,
-	// then phone, then first_name/last_name, then the most recent message.
-	// Used by the live-message handler to backfill sparse entity data from the
-	// gotd/td dispatcher before upserting the new message. Does NOT filter on
+	// Returns the best-known entity data for a given peer_user_id, used by the
+	// live-message handler to backfill sparse entity data from the gotd/td
+	// dispatcher before upserting the new message. Does NOT filter on
 	// matched_contact_id — needed for rematching previously-matched peers after
 	// a contact soft-delete.
+	//
+	// Ordering: prefer the MOST RECENT row marked peer_entity_resolved (i.e.,
+	// whose entity fields came from an authoritative tg.User in the update's
+	// entities). This way, an authoritative-empty event ("user removed their
+	// username") is respected on subsequent sparse updates rather than being
+	// undone by resurrecting an older non-blank handle. Falls back to the
+	// best-non-blank ordering for legacy rows where no resolved=true history
+	// exists yet.
 	GetPeerEntityByUserID(ctx context.Context, peerUserID pgtype.Int8) (*GetPeerEntityByUserIDRow, error)
 	GetSyncLog(ctx context.Context, id pgtype.UUID) (*ExternalSyncLog, error)
 	// External Sync State Queries

--- a/backend/internal/db/queries/telegram_message.sql
+++ b/backend/internal/db/queries/telegram_message.sql
@@ -3,12 +3,12 @@ INSERT INTO telegram_message (
     telegram_message_id, telegram_chat_id, chat_type, chat_title,
     message_text, message_type, sent_at, edited_at, is_outgoing,
     reply_to_msg_id, peer_user_id, peer_username, peer_first_name,
-    peer_last_name, peer_phone
+    peer_last_name, peer_phone, peer_entity_resolved
 ) VALUES (
     @telegram_message_id, @telegram_chat_id, @chat_type, @chat_title,
     @message_text, @message_type, @sent_at, @edited_at, @is_outgoing,
     @reply_to_msg_id, @peer_user_id, @peer_username, @peer_first_name,
-    @peer_last_name, @peer_phone
+    @peer_last_name, @peer_phone, @peer_entity_resolved
 )
 ON CONFLICT (telegram_chat_id, telegram_message_id) DO UPDATE SET
     message_text = EXCLUDED.message_text,
@@ -16,7 +16,10 @@ ON CONFLICT (telegram_chat_id, telegram_message_id) DO UPDATE SET
     peer_username = COALESCE(EXCLUDED.peer_username, telegram_message.peer_username),
     peer_first_name = COALESCE(EXCLUDED.peer_first_name, telegram_message.peer_first_name),
     peer_last_name = COALESCE(EXCLUDED.peer_last_name, telegram_message.peer_last_name),
-    peer_phone = COALESCE(EXCLUDED.peer_phone, telegram_message.peer_phone)
+    peer_phone = COALESCE(EXCLUDED.peer_phone, telegram_message.peer_phone),
+    -- An authoritative update (resolved=true) must "stick" — never let a
+    -- subsequent sparse re-ingest of the same message id downgrade the row.
+    peer_entity_resolved = telegram_message.peer_entity_resolved OR EXCLUDED.peer_entity_resolved
 RETURNING *;
 
 -- name: SoftDeleteTelegramMessages :exec
@@ -161,19 +164,28 @@ ORDER BY peer_user_id,
     sent_at DESC;
 
 -- name: GetPeerEntityByUserID :one
--- Returns the best-known entity data for a given peer_user_id by selecting
--- the telegram_message row with the most-populated peer entity fields.
--- Ordering mirrors ListDistinctUnmatchedPeers: prefer non-blank username,
--- then phone, then first_name/last_name, then the most recent message.
--- Used by the live-message handler to backfill sparse entity data from the
--- gotd/td dispatcher before upserting the new message. Does NOT filter on
+-- Returns the best-known entity data for a given peer_user_id, used by the
+-- live-message handler to backfill sparse entity data from the gotd/td
+-- dispatcher before upserting the new message. Does NOT filter on
 -- matched_contact_id — needed for rematching previously-matched peers after
 -- a contact soft-delete.
+--
+-- Ordering: prefer the MOST RECENT row marked peer_entity_resolved (i.e.,
+-- whose entity fields came from an authoritative tg.User in the update's
+-- entities). This way, an authoritative-empty event ("user removed their
+-- username") is respected on subsequent sparse updates rather than being
+-- undone by resurrecting an older non-blank handle. Falls back to the
+-- best-non-blank ordering for legacy rows where no resolved=true history
+-- exists yet.
 SELECT peer_user_id, peer_username, peer_first_name, peer_last_name, peer_phone
 FROM telegram_message
 WHERE peer_user_id = @peer_user_id
   AND deleted_at IS NULL
 ORDER BY
+    -- Authoritative rows first; among them, the most recent wins.
+    peer_entity_resolved DESC,
+    CASE WHEN peer_entity_resolved THEN sent_at END DESC NULLS LAST,
+    -- Fallback for legacy data with no resolved=true history.
     CASE WHEN peer_username   IS NOT NULL AND peer_username   <> '' THEN 0 ELSE 1 END,
     CASE WHEN peer_phone      IS NOT NULL AND peer_phone      <> '' THEN 0 ELSE 1 END,
     CASE WHEN peer_first_name IS NOT NULL AND peer_first_name <> '' THEN 0 ELSE 1 END,

--- a/backend/internal/db/queries/telegram_message.sql
+++ b/backend/internal/db/queries/telegram_message.sql
@@ -160,6 +160,27 @@ ORDER BY peer_user_id,
     CASE WHEN peer_username IS NOT NULL AND peer_username <> '' THEN 0 ELSE 1 END,
     sent_at DESC;
 
+-- name: GetPeerEntityByUserID :one
+-- Returns the best-known entity data for a given peer_user_id by selecting
+-- the telegram_message row with the most-populated peer entity fields.
+-- Ordering mirrors ListDistinctUnmatchedPeers: prefer non-blank username,
+-- then phone, then first_name/last_name, then the most recent message.
+-- Used by the live-message handler to backfill sparse entity data from the
+-- gotd/td dispatcher before upserting the new message. Does NOT filter on
+-- matched_contact_id — needed for rematching previously-matched peers after
+-- a contact soft-delete.
+SELECT peer_user_id, peer_username, peer_first_name, peer_last_name, peer_phone
+FROM telegram_message
+WHERE peer_user_id = @peer_user_id
+  AND deleted_at IS NULL
+ORDER BY
+    CASE WHEN peer_username   IS NOT NULL AND peer_username   <> '' THEN 0 ELSE 1 END,
+    CASE WHEN peer_phone      IS NOT NULL AND peer_phone      <> '' THEN 0 ELSE 1 END,
+    CASE WHEN peer_first_name IS NOT NULL AND peer_first_name <> '' THEN 0 ELSE 1 END,
+    CASE WHEN peer_last_name  IS NOT NULL AND peer_last_name  <> '' THEN 0 ELSE 1 END,
+    sent_at DESC
+LIMIT 1;
+
 -- name: CountUnmatchedMessagesByPeer :one
 -- Counts messages about to be linked for a given peer. Read BEFORE
 -- OnPeerLinked so the matched-count reporting observes the pre-link state.

--- a/backend/internal/db/telegram_message.sql.go
+++ b/backend/internal/db/telegram_message.sql.go
@@ -225,6 +225,10 @@ FROM telegram_message
 WHERE peer_user_id = $1
   AND deleted_at IS NULL
 ORDER BY
+    -- Authoritative rows first; among them, the most recent wins.
+    peer_entity_resolved DESC,
+    CASE WHEN peer_entity_resolved THEN sent_at END DESC NULLS LAST,
+    -- Fallback for legacy data with no resolved=true history.
     CASE WHEN peer_username   IS NOT NULL AND peer_username   <> '' THEN 0 ELSE 1 END,
     CASE WHEN peer_phone      IS NOT NULL AND peer_phone      <> '' THEN 0 ELSE 1 END,
     CASE WHEN peer_first_name IS NOT NULL AND peer_first_name <> '' THEN 0 ELSE 1 END,
@@ -241,14 +245,19 @@ type GetPeerEntityByUserIDRow struct {
 	PeerPhone     pgtype.Text `json:"peer_phone"`
 }
 
-// Returns the best-known entity data for a given peer_user_id by selecting
-// the telegram_message row with the most-populated peer entity fields.
-// Ordering mirrors ListDistinctUnmatchedPeers: prefer non-blank username,
-// then phone, then first_name/last_name, then the most recent message.
-// Used by the live-message handler to backfill sparse entity data from the
-// gotd/td dispatcher before upserting the new message. Does NOT filter on
+// Returns the best-known entity data for a given peer_user_id, used by the
+// live-message handler to backfill sparse entity data from the gotd/td
+// dispatcher before upserting the new message. Does NOT filter on
 // matched_contact_id — needed for rematching previously-matched peers after
 // a contact soft-delete.
+//
+// Ordering: prefer the MOST RECENT row marked peer_entity_resolved (i.e.,
+// whose entity fields came from an authoritative tg.User in the update's
+// entities). This way, an authoritative-empty event ("user removed their
+// username") is respected on subsequent sparse updates rather than being
+// undone by resurrecting an older non-blank handle. Falls back to the
+// best-non-blank ordering for legacy rows where no resolved=true history
+// exists yet.
 func (q *Queries) GetPeerEntityByUserID(ctx context.Context, peerUserID pgtype.Int8) (*GetPeerEntityByUserIDRow, error) {
 	row := q.db.QueryRow(ctx, GetPeerEntityByUserID, peerUserID)
 	var i GetPeerEntityByUserIDRow
@@ -263,7 +272,7 @@ func (q *Queries) GetPeerEntityByUserID(ctx context.Context, peerUserID pgtype.I
 }
 
 const GetTelegramMessage = `-- name: GetTelegramMessage :one
-SELECT id, telegram_message_id, telegram_chat_id, chat_type, chat_title, message_text, message_type, sent_at, edited_at, is_outgoing, reply_to_msg_id, peer_user_id, peer_username, peer_first_name, peer_last_name, peer_phone, matched_contact_id, interaction_id, processed_at, deleted_at, created_at FROM telegram_message
+SELECT id, telegram_message_id, telegram_chat_id, chat_type, chat_title, message_text, message_type, sent_at, edited_at, is_outgoing, reply_to_msg_id, peer_user_id, peer_username, peer_first_name, peer_last_name, peer_phone, matched_contact_id, interaction_id, processed_at, deleted_at, created_at, peer_entity_resolved FROM telegram_message
 WHERE telegram_chat_id = $1
   AND telegram_message_id = $2
   AND deleted_at IS NULL
@@ -299,6 +308,7 @@ func (q *Queries) GetTelegramMessage(ctx context.Context, arg GetTelegramMessage
 		&i.ProcessedAt,
 		&i.DeletedAt,
 		&i.CreatedAt,
+		&i.PeerEntityResolved,
 	)
 	return &i, err
 }
@@ -359,7 +369,7 @@ func (q *Queries) ListDistinctUnmatchedPeers(ctx context.Context) ([]*ListDistin
 }
 
 const ListTelegramMessagesByChatUnprocessed = `-- name: ListTelegramMessagesByChatUnprocessed :many
-SELECT id, telegram_message_id, telegram_chat_id, chat_type, chat_title, message_text, message_type, sent_at, edited_at, is_outgoing, reply_to_msg_id, peer_user_id, peer_username, peer_first_name, peer_last_name, peer_phone, matched_contact_id, interaction_id, processed_at, deleted_at, created_at FROM telegram_message
+SELECT id, telegram_message_id, telegram_chat_id, chat_type, chat_title, message_text, message_type, sent_at, edited_at, is_outgoing, reply_to_msg_id, peer_user_id, peer_username, peer_first_name, peer_last_name, peer_phone, matched_contact_id, interaction_id, processed_at, deleted_at, created_at, peer_entity_resolved FROM telegram_message
 WHERE telegram_chat_id = $1
   AND processed_at IS NULL
   AND deleted_at IS NULL
@@ -397,6 +407,7 @@ func (q *Queries) ListTelegramMessagesByChatUnprocessed(ctx context.Context, tel
 			&i.ProcessedAt,
 			&i.DeletedAt,
 			&i.CreatedAt,
+			&i.PeerEntityResolved,
 		); err != nil {
 			return nil, err
 		}
@@ -437,7 +448,7 @@ func (q *Queries) ListUnprocessedContactIDs(ctx context.Context) ([]pgtype.UUID,
 }
 
 const ListUnprocessedTelegramMessagesByContact = `-- name: ListUnprocessedTelegramMessagesByContact :many
-SELECT id, telegram_message_id, telegram_chat_id, chat_type, chat_title, message_text, message_type, sent_at, edited_at, is_outgoing, reply_to_msg_id, peer_user_id, peer_username, peer_first_name, peer_last_name, peer_phone, matched_contact_id, interaction_id, processed_at, deleted_at, created_at FROM telegram_message
+SELECT id, telegram_message_id, telegram_chat_id, chat_type, chat_title, message_text, message_type, sent_at, edited_at, is_outgoing, reply_to_msg_id, peer_user_id, peer_username, peer_first_name, peer_last_name, peer_phone, matched_contact_id, interaction_id, processed_at, deleted_at, created_at, peer_entity_resolved FROM telegram_message
 WHERE matched_contact_id = $1
   AND processed_at IS NULL
   AND deleted_at IS NULL
@@ -475,6 +486,7 @@ func (q *Queries) ListUnprocessedTelegramMessagesByContact(ctx context.Context, 
 			&i.ProcessedAt,
 			&i.DeletedAt,
 			&i.CreatedAt,
+			&i.PeerEntityResolved,
 		); err != nil {
 			return nil, err
 		}
@@ -487,7 +499,7 @@ func (q *Queries) ListUnprocessedTelegramMessagesByContact(ctx context.Context, 
 }
 
 const ListUnprocessedTelegramMessagesByContactAndChat = `-- name: ListUnprocessedTelegramMessagesByContactAndChat :many
-SELECT id, telegram_message_id, telegram_chat_id, chat_type, chat_title, message_text, message_type, sent_at, edited_at, is_outgoing, reply_to_msg_id, peer_user_id, peer_username, peer_first_name, peer_last_name, peer_phone, matched_contact_id, interaction_id, processed_at, deleted_at, created_at FROM telegram_message
+SELECT id, telegram_message_id, telegram_chat_id, chat_type, chat_title, message_text, message_type, sent_at, edited_at, is_outgoing, reply_to_msg_id, peer_user_id, peer_username, peer_first_name, peer_last_name, peer_phone, matched_contact_id, interaction_id, processed_at, deleted_at, created_at, peer_entity_resolved FROM telegram_message
 WHERE matched_contact_id = $1
   AND telegram_chat_id = $2
   AND processed_at IS NULL
@@ -531,6 +543,7 @@ func (q *Queries) ListUnprocessedTelegramMessagesByContactAndChat(ctx context.Co
 			&i.ProcessedAt,
 			&i.DeletedAt,
 			&i.CreatedAt,
+			&i.PeerEntityResolved,
 		); err != nil {
 			return nil, err
 		}
@@ -613,12 +626,12 @@ INSERT INTO telegram_message (
     telegram_message_id, telegram_chat_id, chat_type, chat_title,
     message_text, message_type, sent_at, edited_at, is_outgoing,
     reply_to_msg_id, peer_user_id, peer_username, peer_first_name,
-    peer_last_name, peer_phone
+    peer_last_name, peer_phone, peer_entity_resolved
 ) VALUES (
     $1, $2, $3, $4,
     $5, $6, $7, $8, $9,
     $10, $11, $12, $13,
-    $14, $15
+    $14, $15, $16
 )
 ON CONFLICT (telegram_chat_id, telegram_message_id) DO UPDATE SET
     message_text = EXCLUDED.message_text,
@@ -626,26 +639,30 @@ ON CONFLICT (telegram_chat_id, telegram_message_id) DO UPDATE SET
     peer_username = COALESCE(EXCLUDED.peer_username, telegram_message.peer_username),
     peer_first_name = COALESCE(EXCLUDED.peer_first_name, telegram_message.peer_first_name),
     peer_last_name = COALESCE(EXCLUDED.peer_last_name, telegram_message.peer_last_name),
-    peer_phone = COALESCE(EXCLUDED.peer_phone, telegram_message.peer_phone)
-RETURNING id, telegram_message_id, telegram_chat_id, chat_type, chat_title, message_text, message_type, sent_at, edited_at, is_outgoing, reply_to_msg_id, peer_user_id, peer_username, peer_first_name, peer_last_name, peer_phone, matched_contact_id, interaction_id, processed_at, deleted_at, created_at
+    peer_phone = COALESCE(EXCLUDED.peer_phone, telegram_message.peer_phone),
+    -- An authoritative update (resolved=true) must "stick" — never let a
+    -- subsequent sparse re-ingest of the same message id downgrade the row.
+    peer_entity_resolved = telegram_message.peer_entity_resolved OR EXCLUDED.peer_entity_resolved
+RETURNING id, telegram_message_id, telegram_chat_id, chat_type, chat_title, message_text, message_type, sent_at, edited_at, is_outgoing, reply_to_msg_id, peer_user_id, peer_username, peer_first_name, peer_last_name, peer_phone, matched_contact_id, interaction_id, processed_at, deleted_at, created_at, peer_entity_resolved
 `
 
 type UpsertTelegramMessageParams struct {
-	TelegramMessageID int32              `json:"telegram_message_id"`
-	TelegramChatID    int64              `json:"telegram_chat_id"`
-	ChatType          string             `json:"chat_type"`
-	ChatTitle         pgtype.Text        `json:"chat_title"`
-	MessageText       pgtype.Text        `json:"message_text"`
-	MessageType       string             `json:"message_type"`
-	SentAt            pgtype.Timestamptz `json:"sent_at"`
-	EditedAt          pgtype.Timestamptz `json:"edited_at"`
-	IsOutgoing        bool               `json:"is_outgoing"`
-	ReplyToMsgID      pgtype.Int4        `json:"reply_to_msg_id"`
-	PeerUserID        pgtype.Int8        `json:"peer_user_id"`
-	PeerUsername      pgtype.Text        `json:"peer_username"`
-	PeerFirstName     pgtype.Text        `json:"peer_first_name"`
-	PeerLastName      pgtype.Text        `json:"peer_last_name"`
-	PeerPhone         pgtype.Text        `json:"peer_phone"`
+	TelegramMessageID  int32              `json:"telegram_message_id"`
+	TelegramChatID     int64              `json:"telegram_chat_id"`
+	ChatType           string             `json:"chat_type"`
+	ChatTitle          pgtype.Text        `json:"chat_title"`
+	MessageText        pgtype.Text        `json:"message_text"`
+	MessageType        string             `json:"message_type"`
+	SentAt             pgtype.Timestamptz `json:"sent_at"`
+	EditedAt           pgtype.Timestamptz `json:"edited_at"`
+	IsOutgoing         bool               `json:"is_outgoing"`
+	ReplyToMsgID       pgtype.Int4        `json:"reply_to_msg_id"`
+	PeerUserID         pgtype.Int8        `json:"peer_user_id"`
+	PeerUsername       pgtype.Text        `json:"peer_username"`
+	PeerFirstName      pgtype.Text        `json:"peer_first_name"`
+	PeerLastName       pgtype.Text        `json:"peer_last_name"`
+	PeerPhone          pgtype.Text        `json:"peer_phone"`
+	PeerEntityResolved bool               `json:"peer_entity_resolved"`
 }
 
 func (q *Queries) UpsertTelegramMessage(ctx context.Context, arg UpsertTelegramMessageParams) (*TelegramMessage, error) {
@@ -665,6 +682,7 @@ func (q *Queries) UpsertTelegramMessage(ctx context.Context, arg UpsertTelegramM
 		arg.PeerFirstName,
 		arg.PeerLastName,
 		arg.PeerPhone,
+		arg.PeerEntityResolved,
 	)
 	var i TelegramMessage
 	err := row.Scan(
@@ -689,6 +707,7 @@ func (q *Queries) UpsertTelegramMessage(ctx context.Context, arg UpsertTelegramM
 		&i.ProcessedAt,
 		&i.DeletedAt,
 		&i.CreatedAt,
+		&i.PeerEntityResolved,
 	)
 	return &i, err
 }

--- a/backend/internal/db/telegram_message.sql.go
+++ b/backend/internal/db/telegram_message.sql.go
@@ -219,6 +219,49 @@ func (q *Queries) FindDistinctUnmatchedPeerUserIDsByUsername(ctx context.Context
 	return items, nil
 }
 
+const GetPeerEntityByUserID = `-- name: GetPeerEntityByUserID :one
+SELECT peer_user_id, peer_username, peer_first_name, peer_last_name, peer_phone
+FROM telegram_message
+WHERE peer_user_id = $1
+  AND deleted_at IS NULL
+ORDER BY
+    CASE WHEN peer_username   IS NOT NULL AND peer_username   <> '' THEN 0 ELSE 1 END,
+    CASE WHEN peer_phone      IS NOT NULL AND peer_phone      <> '' THEN 0 ELSE 1 END,
+    CASE WHEN peer_first_name IS NOT NULL AND peer_first_name <> '' THEN 0 ELSE 1 END,
+    CASE WHEN peer_last_name  IS NOT NULL AND peer_last_name  <> '' THEN 0 ELSE 1 END,
+    sent_at DESC
+LIMIT 1
+`
+
+type GetPeerEntityByUserIDRow struct {
+	PeerUserID    pgtype.Int8 `json:"peer_user_id"`
+	PeerUsername  pgtype.Text `json:"peer_username"`
+	PeerFirstName pgtype.Text `json:"peer_first_name"`
+	PeerLastName  pgtype.Text `json:"peer_last_name"`
+	PeerPhone     pgtype.Text `json:"peer_phone"`
+}
+
+// Returns the best-known entity data for a given peer_user_id by selecting
+// the telegram_message row with the most-populated peer entity fields.
+// Ordering mirrors ListDistinctUnmatchedPeers: prefer non-blank username,
+// then phone, then first_name/last_name, then the most recent message.
+// Used by the live-message handler to backfill sparse entity data from the
+// gotd/td dispatcher before upserting the new message. Does NOT filter on
+// matched_contact_id — needed for rematching previously-matched peers after
+// a contact soft-delete.
+func (q *Queries) GetPeerEntityByUserID(ctx context.Context, peerUserID pgtype.Int8) (*GetPeerEntityByUserIDRow, error) {
+	row := q.db.QueryRow(ctx, GetPeerEntityByUserID, peerUserID)
+	var i GetPeerEntityByUserIDRow
+	err := row.Scan(
+		&i.PeerUserID,
+		&i.PeerUsername,
+		&i.PeerFirstName,
+		&i.PeerLastName,
+		&i.PeerPhone,
+	)
+	return &i, err
+}
+
 const GetTelegramMessage = `-- name: GetTelegramMessage :one
 SELECT id, telegram_message_id, telegram_chat_id, chat_type, chat_title, message_text, message_type, sent_at, edited_at, is_outgoing, reply_to_msg_id, peer_user_id, peer_username, peer_first_name, peer_last_name, peer_phone, matched_contact_id, interaction_id, processed_at, deleted_at, created_at FROM telegram_message
 WHERE telegram_chat_id = $1

--- a/backend/internal/repository/telegram_message.go
+++ b/backend/internal/repository/telegram_message.go
@@ -208,6 +208,19 @@ func (r *TelegramMessageRepository) CountByChat(ctx context.Context) (map[int64]
 	return counts, nil
 }
 
+// PeerEntity captures the entity fields associated with a Telegram peer,
+// extracted from the best historical telegram_message row for that peer.
+// Used by the live-message handler to backfill sparse entity data that the
+// gotd/td dispatcher omits from incoming updates. Blank strings from storage
+// are promoted to nil here to match the matcher's nilIfEmpty convention.
+type PeerEntity struct {
+	PeerUserID    int64
+	PeerUsername  *string
+	PeerFirstName *string
+	PeerLastName  *string
+	PeerPhone     *string
+}
+
 // UnmatchedPeer holds distinct peer info for identity matching.
 type UnmatchedPeer struct {
 	PeerUserID    int64
@@ -385,6 +398,39 @@ func (r *TelegramMessageRepository) FindDistinctUnmatchedPeerUserIDsByPhone(ctx 
 // rematch handler reports a meaningful pre-link count.
 func (r *TelegramMessageRepository) CountUnmatchedMessagesByPeer(ctx context.Context, peerUserID int64) (int64, error) {
 	return r.queries.CountUnmatchedMessagesByPeer(ctx, int64ToPgInt8(&peerUserID))
+}
+
+// GetPeerEntityByUserID returns the best-known entity data for a Telegram
+// peer, selected by preferring rows with non-blank username/phone/name over
+// rows with blank fields. Returns (nil, nil) when no non-deleted messages
+// exist for the peer — the caller should treat this as "no cached data".
+// Blank ("") fields are promoted to nil to match the matcher's convention.
+func (r *TelegramMessageRepository) GetPeerEntityByUserID(ctx context.Context, peerUserID int64) (*PeerEntity, error) {
+	row, err := r.queries.GetPeerEntityByUserID(ctx, int64ToPgInt8(&peerUserID))
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	entity := &PeerEntity{PeerUserID: peerUserID}
+	if row.PeerUsername.Valid && row.PeerUsername.String != "" {
+		v := row.PeerUsername.String
+		entity.PeerUsername = &v
+	}
+	if row.PeerFirstName.Valid && row.PeerFirstName.String != "" {
+		v := row.PeerFirstName.String
+		entity.PeerFirstName = &v
+	}
+	if row.PeerLastName.Valid && row.PeerLastName.String != "" {
+		v := row.PeerLastName.String
+		entity.PeerLastName = &v
+	}
+	if row.PeerPhone.Valid && row.PeerPhone.String != "" {
+		v := row.PeerPhone.String
+		entity.PeerPhone = &v
+	}
+	return entity, nil
 }
 
 // CountMessagesByPeerID returns message counts for a single peer.

--- a/backend/internal/repository/telegram_message.go
+++ b/backend/internal/repository/telegram_message.go
@@ -39,21 +39,22 @@ type TelegramMessage struct {
 
 // UpsertTelegramMessageParams holds parameters for upserting a message.
 type UpsertTelegramMessageParams struct {
-	TelegramMessageID int32
-	TelegramChatID    int64
-	ChatType          string
-	ChatTitle         *string
-	MessageText       *string
-	MessageType       string
-	SentAt            time.Time
-	EditedAt          *time.Time
-	IsOutgoing        bool
-	ReplyToMsgID      *int32
-	PeerUserID        *int64
-	PeerUsername      *string
-	PeerFirstName     *string
-	PeerLastName      *string
-	PeerPhone         *string
+	TelegramMessageID  int32
+	TelegramChatID     int64
+	ChatType           string
+	ChatTitle          *string
+	MessageText        *string
+	MessageType        string
+	SentAt             time.Time
+	EditedAt           *time.Time
+	IsOutgoing         bool
+	ReplyToMsgID       *int32
+	PeerUserID         *int64
+	PeerUsername       *string
+	PeerFirstName      *string
+	PeerLastName       *string
+	PeerPhone          *string
+	PeerEntityResolved bool
 }
 
 // TelegramMessageRepository handles telegram message persistence.
@@ -130,21 +131,22 @@ func convertDbTelegramMessage(m *db.TelegramMessage) TelegramMessage {
 // UpsertMessage creates or updates a telegram message.
 func (r *TelegramMessageRepository) UpsertMessage(ctx context.Context, params UpsertTelegramMessageParams) (*TelegramMessage, error) {
 	dbMsg, err := r.queries.UpsertTelegramMessage(ctx, db.UpsertTelegramMessageParams{
-		TelegramMessageID: params.TelegramMessageID,
-		TelegramChatID:    params.TelegramChatID,
-		ChatType:          params.ChatType,
-		ChatTitle:         stringToPgText(params.ChatTitle),
-		MessageText:       stringToPgText(params.MessageText),
-		MessageType:       params.MessageType,
-		SentAt:            timeToPgTimestamptz(&params.SentAt),
-		EditedAt:          timeToPgTimestamptz(params.EditedAt),
-		IsOutgoing:        params.IsOutgoing,
-		ReplyToMsgID:      int32ToPgInt4(params.ReplyToMsgID),
-		PeerUserID:        int64ToPgInt8(params.PeerUserID),
-		PeerUsername:      stringToPgText(params.PeerUsername),
-		PeerFirstName:     stringToPgText(params.PeerFirstName),
-		PeerLastName:      stringToPgText(params.PeerLastName),
-		PeerPhone:         stringToPgText(params.PeerPhone),
+		TelegramMessageID:  params.TelegramMessageID,
+		TelegramChatID:     params.TelegramChatID,
+		ChatType:           params.ChatType,
+		ChatTitle:          stringToPgText(params.ChatTitle),
+		MessageText:        stringToPgText(params.MessageText),
+		MessageType:        params.MessageType,
+		SentAt:             timeToPgTimestamptz(&params.SentAt),
+		EditedAt:           timeToPgTimestamptz(params.EditedAt),
+		IsOutgoing:         params.IsOutgoing,
+		ReplyToMsgID:       int32ToPgInt4(params.ReplyToMsgID),
+		PeerUserID:         int64ToPgInt8(params.PeerUserID),
+		PeerUsername:       stringToPgText(params.PeerUsername),
+		PeerFirstName:      stringToPgText(params.PeerFirstName),
+		PeerLastName:       stringToPgText(params.PeerLastName),
+		PeerPhone:          stringToPgText(params.PeerPhone),
+		PeerEntityResolved: params.PeerEntityResolved,
 	})
 	if err != nil {
 		return nil, err

--- a/backend/internal/telegram/handlers.go
+++ b/backend/internal/telegram/handlers.go
@@ -13,17 +13,17 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// peerEntityFetcher returns the best-known entity data for a Telegram peer
+// PeerEntityFetcher returns the best-known entity data for a Telegram peer
 // from the telegram_message cache. Satisfied by *repository.TelegramMessageRepository;
-// exposed as an interface so the handler can be unit-tested with a mock.
-type peerEntityFetcher interface {
+// exposed so tests can substitute a counting/recording wrapper.
+type PeerEntityFetcher interface {
 	GetPeerEntityByUserID(ctx context.Context, peerUserID int64) (*repository.PeerEntity, error)
 }
 
 // MessageHandler processes Telegram update events and stores messages.
 type MessageHandler struct {
 	messageRepo       *repository.TelegramMessageRepository
-	peerEntityFetcher peerEntityFetcher
+	peerEntityFetcher PeerEntityFetcher
 	chatConfigRepo    *repository.TelegramChatConfigRepository
 	syncRepo          *repository.SyncRepository
 	syncStateID       *uuid.UUID
@@ -62,6 +62,13 @@ func NewMessageHandler(
 // callback before handlers process updates.
 func (h *MessageHandler) SetAPI(api *tg.Client) {
 	h.api = api
+}
+
+// SetPeerEntityFetcher overrides the fetcher used by enrichSparseEntity.
+// Tests use this to install a counting/recording wrapper around the real
+// repository so they can assert on fallback-lookup call counts.
+func (h *MessageHandler) SetPeerEntityFetcher(f PeerEntityFetcher) {
+	h.peerEntityFetcher = f
 }
 
 // HandleNewMessage processes OnNewMessage updates (private + group chats).

--- a/backend/internal/telegram/handlers.go
+++ b/backend/internal/telegram/handlers.go
@@ -293,21 +293,22 @@ func (h *MessageHandler) enrichSparseEntity(ctx context.Context, parsed *ParsedM
 
 func parsedToUpsertParams(p *ParsedMessage) repository.UpsertTelegramMessageParams {
 	return repository.UpsertTelegramMessageParams{
-		TelegramMessageID: p.TelegramMessageID,
-		TelegramChatID:    p.TelegramChatID,
-		ChatType:          p.ChatType,
-		ChatTitle:         p.ChatTitle,
-		MessageText:       p.MessageText,
-		MessageType:       p.MessageType,
-		SentAt:            p.SentAt,
-		EditedAt:          p.EditedAt,
-		IsOutgoing:        p.IsOutgoing,
-		ReplyToMsgID:      p.ReplyToMsgID,
-		PeerUserID:        p.PeerUserID,
-		PeerUsername:      p.PeerUsername,
-		PeerFirstName:     p.PeerFirstName,
-		PeerLastName:      p.PeerLastName,
-		PeerPhone:         p.PeerPhone,
+		TelegramMessageID:  p.TelegramMessageID,
+		TelegramChatID:     p.TelegramChatID,
+		ChatType:           p.ChatType,
+		ChatTitle:          p.ChatTitle,
+		MessageText:        p.MessageText,
+		MessageType:        p.MessageType,
+		SentAt:             p.SentAt,
+		EditedAt:           p.EditedAt,
+		IsOutgoing:         p.IsOutgoing,
+		ReplyToMsgID:       p.ReplyToMsgID,
+		PeerUserID:         p.PeerUserID,
+		PeerUsername:       p.PeerUsername,
+		PeerFirstName:      p.PeerFirstName,
+		PeerLastName:       p.PeerLastName,
+		PeerPhone:          p.PeerPhone,
+		PeerEntityResolved: p.PeerEntityResolved,
 	}
 }
 

--- a/backend/internal/telegram/handlers.go
+++ b/backend/internal/telegram/handlers.go
@@ -13,9 +13,17 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// peerEntityFetcher returns the best-known entity data for a Telegram peer
+// from the telegram_message cache. Satisfied by *repository.TelegramMessageRepository;
+// exposed as an interface so the handler can be unit-tested with a mock.
+type peerEntityFetcher interface {
+	GetPeerEntityByUserID(ctx context.Context, peerUserID int64) (*repository.PeerEntity, error)
+}
+
 // MessageHandler processes Telegram update events and stores messages.
 type MessageHandler struct {
 	messageRepo       *repository.TelegramMessageRepository
+	peerEntityFetcher peerEntityFetcher
 	chatConfigRepo    *repository.TelegramChatConfigRepository
 	syncRepo          *repository.SyncRepository
 	syncStateID       *uuid.UUID
@@ -39,6 +47,7 @@ func NewMessageHandler(
 ) *MessageHandler {
 	return &MessageHandler{
 		messageRepo:       messageRepo,
+		peerEntityFetcher: messageRepo,
 		chatConfigRepo:    chatConfigRepo,
 		syncRepo:          syncRepo,
 		syncStateID:       syncStateID,
@@ -77,6 +86,8 @@ func (h *MessageHandler) HandleNewMessage(ctx context.Context, e tg.Entities, up
 			return nil
 		}
 	}
+
+	h.enrichSparseEntity(ctx, parsed)
 
 	if _, err := h.messageRepo.UpsertMessage(ctx, parsedToUpsertParams(parsed)); err != nil {
 		return fmt.Errorf("upsert message: %w", err)
@@ -133,6 +144,8 @@ func (h *MessageHandler) HandleEditMessage(ctx context.Context, e tg.Entities, u
 			return nil
 		}
 	}
+
+	h.enrichSparseEntity(ctx, parsed)
 
 	if _, err := h.messageRepo.UpsertMessage(ctx, parsedToUpsertParams(parsed)); err != nil {
 		return fmt.Errorf("upsert edited message: %w", err)
@@ -237,6 +250,38 @@ func EffectiveTracked(status string, memberCount *int32, groupMaxMembers int) bo
 		}
 		return int(*memberCount) <= groupMaxMembers
 	}
+}
+
+// enrichSparseEntity fills peer entity fields on a ParsedMessage using the
+// best-known historical data from telegram_message, but ONLY when the parser
+// reports that no authoritative tg.User was resolved from the update's
+// entities (PeerEntityResolved=false). If the update carried a tg.User, we
+// trust its field values — including empty ones, which indicate user removal.
+//
+// Called after ParseMessage + shouldTrackChat gate, before UpsertMessage.
+// Errors log at debug and do not fail ingest.
+func (h *MessageHandler) enrichSparseEntity(ctx context.Context, parsed *ParsedMessage) {
+	if parsed == nil || parsed.PeerUserID == nil {
+		return
+	}
+	if parsed.PeerEntityResolved {
+		return // update carried authoritative entity data — trust it verbatim
+	}
+	entity, err := h.peerEntityFetcher.GetPeerEntityByUserID(ctx, *parsed.PeerUserID)
+	if err != nil {
+		log.Debug().Err(err).Int64("peer_user_id", *parsed.PeerUserID).Msg("telegram: peer entity lookup failed, proceeding with sparse entity")
+		return
+	}
+	if entity == nil {
+		return // no cached data — proceed as-is
+	}
+	// Trigger fired iff the update had zero authoritative entity data, so
+	// every entity field on parsed is nil. Straight assignment from the
+	// fallback entity — no per-field nil-check needed.
+	parsed.PeerUsername = entity.PeerUsername
+	parsed.PeerFirstName = entity.PeerFirstName
+	parsed.PeerLastName = entity.PeerLastName
+	parsed.PeerPhone = entity.PeerPhone
 }
 
 func parsedToUpsertParams(p *ParsedMessage) repository.UpsertTelegramMessageParams {

--- a/backend/internal/telegram/handlers_test.go
+++ b/backend/internal/telegram/handlers_test.go
@@ -1,12 +1,148 @@
 package telegram
 
 import (
+	"context"
+	"errors"
 	"testing"
 
+	"personal-crm/backend/internal/repository"
+
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func ptrInt32(v int32) *int32 { return &v }
+func ptrInt64(v int64) *int64 { return &v }
+func ptrStr(v string) *string { return &v }
+
+// mockPeerEntityFetcher records call counts and returns canned responses.
+type mockPeerEntityFetcher struct {
+	CallCount int
+	entity    *repository.PeerEntity
+	err       error
+}
+
+func (m *mockPeerEntityFetcher) GetPeerEntityByUserID(_ context.Context, _ int64) (*repository.PeerEntity, error) {
+	m.CallCount++
+	return m.entity, m.err
+}
+
+func TestEnrichSparseEntity_FillsWhenUnresolvedAndCachedDataAvailable(t *testing.T) {
+	mock := &mockPeerEntityFetcher{
+		entity: &repository.PeerEntity{
+			PeerUserID:    222,
+			PeerUsername:  ptrStr("connormcmk"),
+			PeerFirstName: ptrStr("Connor"),
+			PeerLastName:  ptrStr("McK"),
+			PeerPhone:     ptrStr("15551234567"),
+		},
+	}
+	h := &MessageHandler{peerEntityFetcher: mock}
+	parsed := &ParsedMessage{
+		PeerUserID:         ptrInt64(222),
+		PeerEntityResolved: false,
+	}
+
+	h.enrichSparseEntity(context.Background(), parsed)
+
+	assert.Equal(t, 1, mock.CallCount)
+	require.NotNil(t, parsed.PeerUsername)
+	assert.Equal(t, "connormcmk", *parsed.PeerUsername)
+	require.NotNil(t, parsed.PeerFirstName)
+	assert.Equal(t, "Connor", *parsed.PeerFirstName)
+	require.NotNil(t, parsed.PeerLastName)
+	assert.Equal(t, "McK", *parsed.PeerLastName)
+	require.NotNil(t, parsed.PeerPhone)
+	assert.Equal(t, "15551234567", *parsed.PeerPhone)
+}
+
+func TestEnrichSparseEntity_ShortCircuitsWhenResolved(t *testing.T) {
+	mock := &mockPeerEntityFetcher{
+		entity: &repository.PeerEntity{PeerUserID: 222, PeerUsername: ptrStr("anything")},
+	}
+	h := &MessageHandler{peerEntityFetcher: mock}
+	parsed := &ParsedMessage{
+		PeerUserID:         ptrInt64(222),
+		PeerUsername:       ptrStr("dan13ram"),
+		PeerFirstName:      ptrStr("Dan"),
+		PeerEntityResolved: true,
+	}
+
+	h.enrichSparseEntity(context.Background(), parsed)
+
+	assert.Equal(t, 0, mock.CallCount, "fetcher must not be called when entity was resolved")
+	assert.Equal(t, "dan13ram", *parsed.PeerUsername)
+	assert.Equal(t, "Dan", *parsed.PeerFirstName)
+}
+
+func TestEnrichSparseEntity_ResolvedWithEmptyFieldsRespectsRemoval(t *testing.T) {
+	// User has removed their username; ParseMessage marked PeerEntityResolved=true
+	// with PeerUsername=nil. enrichSparseEntity must NOT resurrect a stored handle.
+	mock := &mockPeerEntityFetcher{
+		entity: &repository.PeerEntity{PeerUserID: 222, PeerUsername: ptrStr("oldhandle")},
+	}
+	h := &MessageHandler{peerEntityFetcher: mock}
+	parsed := &ParsedMessage{
+		PeerUserID:         ptrInt64(222),
+		PeerUsername:       nil,
+		PeerFirstName:      ptrStr("Connor"),
+		PeerEntityResolved: true,
+	}
+
+	h.enrichSparseEntity(context.Background(), parsed)
+
+	assert.Equal(t, 0, mock.CallCount)
+	assert.Nil(t, parsed.PeerUsername, "removed username must remain nil")
+	assert.Equal(t, "Connor", *parsed.PeerFirstName)
+}
+
+func TestEnrichSparseEntity_NoCachedData(t *testing.T) {
+	mock := &mockPeerEntityFetcher{entity: nil, err: nil}
+	h := &MessageHandler{peerEntityFetcher: mock}
+	parsed := &ParsedMessage{
+		PeerUserID:         ptrInt64(222),
+		PeerEntityResolved: false,
+	}
+
+	h.enrichSparseEntity(context.Background(), parsed)
+
+	assert.Equal(t, 1, mock.CallCount)
+	assert.Nil(t, parsed.PeerUsername)
+	assert.Nil(t, parsed.PeerFirstName)
+}
+
+func TestEnrichSparseEntity_LookupErrorIsBestEffort(t *testing.T) {
+	mock := &mockPeerEntityFetcher{err: errors.New("boom")}
+	h := &MessageHandler{peerEntityFetcher: mock}
+	parsed := &ParsedMessage{
+		PeerUserID:         ptrInt64(222),
+		PeerFirstName:      ptrStr("preserved"),
+		PeerEntityResolved: false,
+	}
+
+	require.NotPanics(t, func() {
+		h.enrichSparseEntity(context.Background(), parsed)
+	})
+	assert.Equal(t, 1, mock.CallCount)
+	assert.Equal(t, "preserved", *parsed.PeerFirstName, "parsed must remain unchanged on error")
+}
+
+func TestEnrichSparseEntity_NilParsed(t *testing.T) {
+	mock := &mockPeerEntityFetcher{}
+	h := &MessageHandler{peerEntityFetcher: mock}
+	require.NotPanics(t, func() {
+		h.enrichSparseEntity(context.Background(), nil)
+	})
+	assert.Equal(t, 0, mock.CallCount)
+}
+
+func TestEnrichSparseEntity_NilPeerUserID(t *testing.T) {
+	mock := &mockPeerEntityFetcher{}
+	h := &MessageHandler{peerEntityFetcher: mock}
+	parsed := &ParsedMessage{PeerUserID: nil, PeerEntityResolved: false}
+	h.enrichSparseEntity(context.Background(), parsed)
+	assert.Equal(t, 0, mock.CallCount)
+}
 
 func TestEffectiveTracked_TrackedOverridesLarge(t *testing.T) {
 	assert.True(t, EffectiveTracked("tracked", ptrInt32(200), 10))

--- a/backend/internal/telegram/message.go
+++ b/backend/internal/telegram/message.go
@@ -24,6 +24,12 @@ type ParsedMessage struct {
 	PeerFirstName     *string
 	PeerLastName      *string
 	PeerPhone         *string
+	// PeerEntityResolved is true iff the peer's tg.User record was resolved
+	// from the update's entities.Users map (and passed the bot filter). When
+	// false, the parser saw no authoritative entity data — handlers may then
+	// safely fall back to cached entity data without overriding a user-removed
+	// field. Not persisted; transient signal from the parser to the handler.
+	PeerEntityResolved bool
 }
 
 // ParseMessage converts a tg.Message and handler entities into a ParsedMessage.
@@ -87,6 +93,7 @@ func ParseMessage(msg *tg.Message, entities tg.Entities, selfUserID int64) *Pars
 				return nil // skip bot conversations
 			}
 			fillUserInfo(parsed, user)
+			parsed.PeerEntityResolved = true
 		}
 
 	case *tg.PeerChat:
@@ -112,6 +119,7 @@ func ParseMessage(msg *tg.Message, entities tg.Entities, selfUserID int64) *Pars
 							return nil
 						}
 						fillUserInfo(parsed, user)
+						parsed.PeerEntityResolved = true
 					}
 				}
 			}

--- a/backend/internal/telegram/message_test.go
+++ b/backend/internal/telegram/message_test.go
@@ -183,6 +183,90 @@ func TestParseMessage_SkipChannel(t *testing.T) {
 	assert.Nil(t, parsed)
 }
 
+func TestParseMessage_PeerEntityResolved_PrivateWithUser(t *testing.T) {
+	msg := &tg.Message{
+		ID:     1,
+		Date:   1700000000,
+		PeerID: &tg.PeerUser{UserID: 222},
+	}
+	entities := makeEntities(map[int64]*tg.User{
+		222: {ID: 222, FirstName: "Alice", Username: "alice"},
+	}, nil)
+
+	parsed := ParseMessage(msg, entities, selfID)
+	require.NotNil(t, parsed)
+	assert.True(t, parsed.PeerEntityResolved)
+	require.NotNil(t, parsed.PeerUsername)
+	assert.Equal(t, "alice", *parsed.PeerUsername)
+}
+
+func TestParseMessage_PeerEntityResolved_PrivateSparse(t *testing.T) {
+	msg := &tg.Message{
+		ID:     1,
+		Date:   1700000000,
+		PeerID: &tg.PeerUser{UserID: 222},
+	}
+	parsed := ParseMessage(msg, makeEntities(map[int64]*tg.User{}, nil), selfID)
+	require.NotNil(t, parsed)
+	assert.False(t, parsed.PeerEntityResolved)
+	assert.Nil(t, parsed.PeerUsername)
+	assert.Nil(t, parsed.PeerFirstName)
+	assert.Nil(t, parsed.PeerLastName)
+	assert.Nil(t, parsed.PeerPhone)
+}
+
+func TestParseMessage_PeerEntityResolved_PrivateWithEmptyFields(t *testing.T) {
+	// User present in entities but Username/FirstName empty — user removed
+	// their handle. Resolved=true because the entity itself was authoritative.
+	msg := &tg.Message{
+		ID:     1,
+		Date:   1700000000,
+		PeerID: &tg.PeerUser{UserID: 222},
+	}
+	entities := makeEntities(map[int64]*tg.User{
+		222: {ID: 222, Username: "", FirstName: ""},
+	}, nil)
+	parsed := ParseMessage(msg, entities, selfID)
+	require.NotNil(t, parsed)
+	assert.True(t, parsed.PeerEntityResolved)
+	assert.Nil(t, parsed.PeerUsername)
+	assert.Nil(t, parsed.PeerFirstName)
+}
+
+func TestParseMessage_PeerEntityResolved_GroupWithSender(t *testing.T) {
+	msg := &tg.Message{
+		ID:     1,
+		Date:   1700000000,
+		PeerID: &tg.PeerChat{ChatID: 333},
+	}
+	msg.SetFromID(&tg.PeerUser{UserID: 444})
+	entities := makeEntities(
+		map[int64]*tg.User{444: {ID: 444, FirstName: "Bob", Username: "bob"}},
+		map[int64]*tg.Chat{333: {ID: 333, Title: "Test Group"}},
+	)
+	parsed := ParseMessage(msg, entities, selfID)
+	require.NotNil(t, parsed)
+	assert.True(t, parsed.PeerEntityResolved)
+}
+
+func TestParseMessage_PeerEntityResolved_GroupSenderMissing(t *testing.T) {
+	msg := &tg.Message{
+		ID:     1,
+		Date:   1700000000,
+		PeerID: &tg.PeerChat{ChatID: 333},
+	}
+	msg.SetFromID(&tg.PeerUser{UserID: 444})
+	entities := makeEntities(
+		map[int64]*tg.User{},
+		map[int64]*tg.Chat{333: {ID: 333, Title: "Test Group"}},
+	)
+	parsed := ParseMessage(msg, entities, selfID)
+	require.NotNil(t, parsed)
+	assert.False(t, parsed.PeerEntityResolved)
+	require.NotNil(t, parsed.PeerUserID)
+	assert.Equal(t, int64(444), *parsed.PeerUserID)
+}
+
 func TestParseMessage_MediaCaption(t *testing.T) {
 	msg := &tg.Message{
 		ID:      1,

--- a/backend/migrations/034_telegram_message_peer_user_id_all_index.down.sql
+++ b/backend/migrations/034_telegram_message_peer_user_id_all_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_telegram_message_peer_user_id_all;

--- a/backend/migrations/034_telegram_message_peer_user_id_all_index.up.sql
+++ b/backend/migrations/034_telegram_message_peer_user_id_all_index.up.sql
@@ -1,0 +1,8 @@
+-- Non-match-status-filtered partial index on peer_user_id, used by the
+-- sparse-entity enrichment fallback in the live message handler
+-- (GetPeerEntityByUserID). Coexists with the existing
+-- `idx_telegram_message_peer` (WHERE matched_contact_id IS NULL) which
+-- continues to serve identity-matching queries.
+CREATE INDEX IF NOT EXISTS idx_telegram_message_peer_user_id_all
+ON telegram_message(peer_user_id)
+WHERE deleted_at IS NULL AND peer_user_id IS NOT NULL;

--- a/backend/migrations/035_telegram_message_peer_entity_resolved.down.sql
+++ b/backend/migrations/035_telegram_message_peer_entity_resolved.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE telegram_message
+DROP COLUMN IF EXISTS peer_entity_resolved;

--- a/backend/migrations/035_telegram_message_peer_entity_resolved.up.sql
+++ b/backend/migrations/035_telegram_message_peer_entity_resolved.up.sql
@@ -1,0 +1,8 @@
+-- Persist whether the row's peer entity fields came from an authoritative
+-- tg.User in the update's entities (true) vs a sparse update where the
+-- handler had to backfill from history (false). Used by GetPeerEntityByUserID
+-- to prefer the MOST RECENT authoritative row when enriching subsequent
+-- sparse updates — so a "user removed their username" event isn't undone by
+-- resurrecting an older non-blank handle.
+ALTER TABLE telegram_message
+ADD COLUMN IF NOT EXISTS peer_entity_resolved BOOLEAN NOT NULL DEFAULT FALSE;

--- a/backend/tests/telegram_sparse_entity_enrichment_test.go
+++ b/backend/tests/telegram_sparse_entity_enrichment_test.go
@@ -351,6 +351,57 @@ func TestSparseEntityEnrichment_UntrackedGroupSkipsBeforeEnrichment(t *testing.T
 	assert.Equal(t, int64(0), counter.Count(), "enrichSparseEntity must not run for ignored group chats")
 }
 
+// TestSparseEntityEnrichment_HandleEditMessage_FillsFromHistory has already
+// covered the "older row is rich, sparse new arrives" path. This test covers
+// the inverse recency edge case Codex flagged in PR #278: after the user has
+// removed their handle in an authoritative update (Username=""), a SUBSEQUENT
+// sparse update must NOT resurrect the old handle from the historical row.
+// The fix relies on the persisted peer_entity_resolved flag so that
+// GetPeerEntityByUserID prefers the most recent authoritative row over any
+// older non-blank value.
+func TestSparseEntityEnrichment_AuthoritativeRemovalSticksAcrossSparseUpdates(t *testing.T) {
+	env := setupSparseEnrichTest(t)
+	ctx := context.Background()
+	peerUserID, peerIDStr := uniqueTestIDs(t)
+	chatID := peerUserID
+	t.Cleanup(func() { cleanupSparseEnrichTestData(t, env, chatID) })
+
+	// Step 1: legacy historical row with rich entity data (resolved=false).
+	oldHandle := "oldhandle" + peerIDStr
+	_, err := env.messageRepo.UpsertMessage(ctx, repository.UpsertTelegramMessageParams{
+		TelegramMessageID: 70001,
+		TelegramChatID:    chatID,
+		ChatType:          "private",
+		MessageType:       "text",
+		SentAt:            accelerated.GetCurrentTime().Add(-2 * time.Hour),
+		IsOutgoing:        false,
+		PeerUserID:        &peerUserID,
+		PeerUsername:      &oldHandle,
+		PeerFirstName:     strPtr("OldName"),
+	})
+	require.NoError(t, err)
+
+	// Step 2: authoritative update arrives with Username="" (handle removed)
+	// but FirstName populated. Drives HandleNewMessage so the row is stored
+	// with peer_entity_resolved=true and peer_username=NULL.
+	authMsg := makePrivateMessage(peerUserID, 70002, accelerated.GetCurrentTime().Add(-1*time.Hour), "removed my handle")
+	authEntities := tg.Entities{Users: map[int64]*tg.User{
+		peerUserID: {ID: peerUserID, Username: "", FirstName: "NewName"},
+	}}
+	require.NoError(t, env.handler.HandleNewMessage(ctx, authEntities, &tg.UpdateNewMessage{Message: authMsg}))
+
+	// Step 3: a NEW sparse update arrives. Without the recency fix, the
+	// fallback would prefer the older non-blank row and resurrect oldHandle.
+	sparseMsg := makePrivateMessage(peerUserID, 70003, accelerated.GetCurrentTime(), "next message")
+	require.NoError(t, env.handler.HandleNewMessage(ctx, tg.Entities{Users: map[int64]*tg.User{}}, &tg.UpdateNewMessage{Message: sparseMsg}))
+
+	got, err := env.messageRepo.GetMessage(ctx, chatID, 70003)
+	require.NoError(t, err)
+	assert.Nil(t, got.PeerUsername, "removal must stick — sparse update must NOT resurrect old handle")
+	require.NotNil(t, got.PeerFirstName, "first_name from authoritative row should still flow through")
+	assert.Equal(t, "NewName", *got.PeerFirstName)
+}
+
 // TestSparseEntityEnrichment_EnrichedFieldsFlowToDiscoveryCandidate verifies
 // the user-visible "Unknown card → real name" outcome: when a sparse
 // incoming message arrives for an unmatched peer that has historical entity

--- a/backend/tests/telegram_sparse_entity_enrichment_test.go
+++ b/backend/tests/telegram_sparse_entity_enrichment_test.go
@@ -1,0 +1,302 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/repository"
+	tgpkg "personal-crm/backend/internal/telegram"
+
+	"github.com/gotd/td/tg"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// sparseEnrichEnv bundles the dependencies needed to drive HandleNewMessage /
+// HandleEditMessage end-to-end against a real DB.
+type sparseEnrichEnv struct {
+	handler        *tgpkg.MessageHandler
+	messageRepo    *repository.TelegramMessageRepository
+	chatConfigRepo *repository.TelegramChatConfigRepository
+	database       *db.Database
+}
+
+// setupSparseEnrichTest builds a MessageHandler with real repos, a nil
+// peerMatcher (matcher logic is out of scope for these tests) and nil
+// syncStateID (so the sync update is a no-op).
+func setupSparseEnrichTest(t *testing.T) *sparseEnrichEnv {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set")
+	}
+
+	require.NoError(t, db.RunMigrations(databaseURL, getMigrationsPath()))
+
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+
+	database, err := db.NewDatabase(context.Background(), cfg.Database)
+	require.NoError(t, err)
+	t.Cleanup(database.Close)
+
+	messageRepo := repository.NewTelegramMessageRepository(database.Queries)
+	chatConfigRepo := repository.NewTelegramChatConfigRepository(database.Queries)
+	syncRepo := repository.NewSyncRepository(database.Queries)
+
+	handler := tgpkg.NewMessageHandler(
+		messageRepo,
+		chatConfigRepo,
+		syncRepo,
+		nil,    // syncStateID — nil → updateSyncTimestamp is a no-op
+		111111, // selfUserID — never matches any test peer
+		10,     // groupMaxMembers
+		nil,    // peerMatcher — nil means matching path is skipped
+		nil,    // aggregationEngine
+	)
+
+	return &sparseEnrichEnv{
+		handler:        handler,
+		messageRepo:    messageRepo,
+		chatConfigRepo: chatConfigRepo,
+		database:       database,
+	}
+}
+
+// cleanupSparseEnrichTestData hard-deletes any telegram_message rows for the
+// given chat_id and the chat_config row for that chat. Scoped narrowly to a
+// single test's chat_id to avoid touching unrelated data.
+func cleanupSparseEnrichTestData(t *testing.T, env *sparseEnrichEnv, chatID int64) {
+	t.Helper()
+	ctx := context.Background()
+	_, _ = env.database.Pool.Exec(ctx, "DELETE FROM telegram_message WHERE telegram_chat_id = $1", chatID)
+	_ = env.chatConfigRepo.DeleteConfig(ctx, chatID)
+}
+
+// makePrivateMessage builds a *tg.Message for a private chat between self and peer.
+func makePrivateMessage(peerUserID int64, msgID int, sentAt time.Time, text string) *tg.Message {
+	return &tg.Message{
+		ID:      msgID,
+		Date:    int(sentAt.Unix()),
+		PeerID:  &tg.PeerUser{UserID: peerUserID},
+		Message: text,
+	}
+}
+
+func TestSparseEntityEnrichment_HandleNewMessage_FillsFromHistory(t *testing.T) {
+	env := setupSparseEnrichTest(t)
+	ctx := context.Background()
+	peerUserID, peerIDStr := uniqueTestIDs(t)
+	chatID := peerUserID
+	t.Cleanup(func() { cleanupSparseEnrichTestData(t, env, chatID) })
+
+	// Seed a historical row with rich entity data.
+	username := "richuser" + peerIDStr
+	firstName := "Rich" + peerIDStr
+	_, err := env.messageRepo.UpsertMessage(ctx, repository.UpsertTelegramMessageParams{
+		TelegramMessageID: 70001,
+		TelegramChatID:    chatID,
+		ChatType:          "private",
+		MessageType:       "text",
+		SentAt:            accelerated.GetCurrentTime().Add(-1 * time.Hour),
+		IsOutgoing:        false,
+		PeerUserID:        &peerUserID,
+		PeerUsername:      &username,
+		PeerFirstName:     &firstName,
+	})
+	require.NoError(t, err)
+
+	// New incoming message arrives with EMPTY entities (sparse update).
+	msg := makePrivateMessage(peerUserID, 70002, accelerated.GetCurrentTime(), "hello")
+	entities := tg.Entities{Users: map[int64]*tg.User{}}
+	update := &tg.UpdateNewMessage{Message: msg}
+
+	require.NoError(t, env.handler.HandleNewMessage(ctx, entities, update))
+
+	// The new row must have been enriched from history.
+	got, err := env.messageRepo.GetMessage(ctx, chatID, 70002)
+	require.NoError(t, err)
+	require.NotNil(t, got.PeerUsername, "peer_username must be backfilled from history")
+	assert.Equal(t, username, *got.PeerUsername)
+	require.NotNil(t, got.PeerFirstName)
+	assert.Equal(t, firstName, *got.PeerFirstName)
+}
+
+func TestSparseEntityEnrichment_HandleNewMessage_NoHistoryStaysSparse(t *testing.T) {
+	env := setupSparseEnrichTest(t)
+	ctx := context.Background()
+	peerUserID, _ := uniqueTestIDs(t)
+	chatID := peerUserID
+	t.Cleanup(func() { cleanupSparseEnrichTestData(t, env, chatID) })
+
+	// First-ever message for this peer — no history, sparse entity.
+	msg := makePrivateMessage(peerUserID, 70001, accelerated.GetCurrentTime(), "first hello")
+	entities := tg.Entities{Users: map[int64]*tg.User{}}
+	update := &tg.UpdateNewMessage{Message: msg}
+
+	require.NoError(t, env.handler.HandleNewMessage(ctx, entities, update))
+
+	got, err := env.messageRepo.GetMessage(ctx, chatID, 70001)
+	require.NoError(t, err)
+	assert.Nil(t, got.PeerUsername, "no history → entity stays nil")
+	assert.Nil(t, got.PeerFirstName)
+}
+
+func TestSparseEntityEnrichment_HandleEditMessage_FillsFromHistory(t *testing.T) {
+	env := setupSparseEnrichTest(t)
+	ctx := context.Background()
+	peerUserID, peerIDStr := uniqueTestIDs(t)
+	chatID := peerUserID
+	t.Cleanup(func() { cleanupSparseEnrichTestData(t, env, chatID) })
+
+	// Seed a historical row with rich data on a DIFFERENT message id.
+	username := "edituser" + peerIDStr
+	firstName := "Edit" + peerIDStr
+	_, err := env.messageRepo.UpsertMessage(ctx, repository.UpsertTelegramMessageParams{
+		TelegramMessageID: 70010,
+		TelegramChatID:    chatID,
+		ChatType:          "private",
+		MessageType:       "text",
+		SentAt:            accelerated.GetCurrentTime().Add(-1 * time.Hour),
+		IsOutgoing:        false,
+		PeerUserID:        &peerUserID,
+		PeerUsername:      &username,
+		PeerFirstName:     &firstName,
+	})
+	require.NoError(t, err)
+
+	// Now an edit arrives for a DIFFERENT message id (70011) with sparse entities.
+	editMsg := makePrivateMessage(peerUserID, 70011, accelerated.GetCurrentTime(), "edited body")
+	editMsg.SetEditDate(int(accelerated.GetCurrentTime().Unix()))
+	entities := tg.Entities{Users: map[int64]*tg.User{}}
+	update := &tg.UpdateEditMessage{Message: editMsg}
+
+	require.NoError(t, env.handler.HandleEditMessage(ctx, entities, update))
+
+	got, err := env.messageRepo.GetMessage(ctx, chatID, 70011)
+	require.NoError(t, err)
+	require.NotNil(t, got.PeerUsername, "edit must also enrich from history")
+	assert.Equal(t, username, *got.PeerUsername)
+}
+
+func TestSparseEntityEnrichment_AuthoritativeEmptyRespectsRemoval(t *testing.T) {
+	env := setupSparseEnrichTest(t)
+	ctx := context.Background()
+	peerUserID, peerIDStr := uniqueTestIDs(t)
+	chatID := peerUserID
+	t.Cleanup(func() { cleanupSparseEnrichTestData(t, env, chatID) })
+
+	// Seed history with an old username.
+	oldHandle := "oldhandle" + peerIDStr
+	_, err := env.messageRepo.UpsertMessage(ctx, repository.UpsertTelegramMessageParams{
+		TelegramMessageID: 70001,
+		TelegramChatID:    chatID,
+		ChatType:          "private",
+		MessageType:       "text",
+		SentAt:            accelerated.GetCurrentTime().Add(-1 * time.Hour),
+		IsOutgoing:        false,
+		PeerUserID:        &peerUserID,
+		PeerUsername:      &oldHandle,
+		PeerFirstName:     strPtr("OldName"),
+	})
+	require.NoError(t, err)
+
+	// New message arrives with entity RESOLVED but Username=""
+	// (user removed their handle). FirstName is populated.
+	msg := makePrivateMessage(peerUserID, 70002, accelerated.GetCurrentTime(), "no username now")
+	entities := tg.Entities{Users: map[int64]*tg.User{
+		peerUserID: {ID: peerUserID, Username: "", FirstName: "NewName"},
+	}}
+	update := &tg.UpdateNewMessage{Message: msg}
+
+	require.NoError(t, env.handler.HandleNewMessage(ctx, entities, update))
+
+	got, err := env.messageRepo.GetMessage(ctx, chatID, 70002)
+	require.NoError(t, err)
+	assert.Nil(t, got.PeerUsername, "authoritative empty username must NOT be backfilled")
+	require.NotNil(t, got.PeerFirstName)
+	assert.Equal(t, "NewName", *got.PeerFirstName)
+}
+
+func TestSparseEntityEnrichment_StraightRenameCurrentNonBlankWins(t *testing.T) {
+	env := setupSparseEnrichTest(t)
+	ctx := context.Background()
+	peerUserID, peerIDStr := uniqueTestIDs(t)
+	chatID := peerUserID
+	t.Cleanup(func() { cleanupSparseEnrichTestData(t, env, chatID) })
+
+	oldHandle := "old" + peerIDStr
+	_, err := env.messageRepo.UpsertMessage(ctx, repository.UpsertTelegramMessageParams{
+		TelegramMessageID: 70001,
+		TelegramChatID:    chatID,
+		ChatType:          "private",
+		MessageType:       "text",
+		SentAt:            accelerated.GetCurrentTime().Add(-1 * time.Hour),
+		IsOutgoing:        false,
+		PeerUserID:        &peerUserID,
+		PeerUsername:      &oldHandle,
+	})
+	require.NoError(t, err)
+
+	// New message carries an authoritative tg.User with a NEW handle.
+	newHandle := "new" + peerIDStr
+	msg := makePrivateMessage(peerUserID, 70002, accelerated.GetCurrentTime(), "renamed")
+	entities := tg.Entities{Users: map[int64]*tg.User{
+		peerUserID: {ID: peerUserID, Username: newHandle},
+	}}
+	update := &tg.UpdateNewMessage{Message: msg}
+
+	require.NoError(t, env.handler.HandleNewMessage(ctx, entities, update))
+
+	got, err := env.messageRepo.GetMessage(ctx, chatID, 70002)
+	require.NoError(t, err)
+	require.NotNil(t, got.PeerUsername)
+	assert.Equal(t, newHandle, *got.PeerUsername, "current non-blank handle must win, fallback must not run")
+
+	// Original row should still carry the old handle untouched.
+	original, err := env.messageRepo.GetMessage(ctx, chatID, 70001)
+	require.NoError(t, err)
+	require.NotNil(t, original.PeerUsername)
+	assert.Equal(t, oldHandle, *original.PeerUsername)
+}
+
+func TestSparseEntityEnrichment_UntrackedGroupSkipsBeforeEnrichment(t *testing.T) {
+	env := setupSparseEnrichTest(t)
+	ctx := context.Background()
+	peerUserID, peerIDStr := uniqueTestIDs(t)
+	groupChatID := peerUserID + 1 // distinct from peer id
+	t.Cleanup(func() { cleanupSparseEnrichTestData(t, env, groupChatID) })
+
+	// Pre-mark the group chat as ignored.
+	_, err := env.chatConfigRepo.UpsertConfig(ctx, repository.UpsertTelegramChatConfigParams{
+		TelegramChatID: groupChatID,
+		ChatType:       "group",
+		Status:         "ignored",
+	})
+	require.NoError(t, err)
+
+	// Build a sparse group message from peerUserID.
+	msg := &tg.Message{
+		ID:      70001,
+		Date:    int(accelerated.GetCurrentTime().Unix()),
+		PeerID:  &tg.PeerChat{ChatID: groupChatID},
+		Message: "ignored chat msg " + peerIDStr,
+	}
+	msg.SetFromID(&tg.PeerUser{UserID: peerUserID})
+	entities := tg.Entities{Users: map[int64]*tg.User{}}
+	update := &tg.UpdateNewMessage{Message: msg}
+
+	require.NoError(t, env.handler.HandleNewMessage(ctx, entities, update))
+
+	// No row should have been inserted for the ignored chat.
+	_, err = env.messageRepo.GetMessage(ctx, groupChatID, 70001)
+	require.Error(t, err, "ignored group chat must not insert any message row")
+}

--- a/backend/tests/telegram_sparse_entity_enrichment_test.go
+++ b/backend/tests/telegram_sparse_entity_enrichment_test.go
@@ -3,6 +3,8 @@ package tests
 import (
 	"context"
 	"os"
+	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -10,12 +12,29 @@ import (
 	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
 	tgpkg "personal-crm/backend/internal/telegram"
 
 	"github.com/gotd/td/tg"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// countingFetcher wraps a real PeerEntityFetcher and records call counts.
+// Used to assert the sparse-entity fallback lookup did/didn't fire — for
+// example, to verify the tracking-gate short-circuits before enrichment.
+type countingFetcher struct {
+	inner tgpkg.PeerEntityFetcher
+	count int64
+}
+
+func (c *countingFetcher) GetPeerEntityByUserID(ctx context.Context, peerUserID int64) (*repository.PeerEntity, error) {
+	atomic.AddInt64(&c.count, 1)
+	return c.inner.GetPeerEntityByUserID(ctx, peerUserID)
+}
+
+func (c *countingFetcher) Count() int64 { return atomic.LoadInt64(&c.count) }
 
 // sparseEnrichEnv bundles the dependencies needed to drive HandleNewMessage /
 // HandleEditMessage end-to-end against a real DB.
@@ -23,12 +42,15 @@ type sparseEnrichEnv struct {
 	handler        *tgpkg.MessageHandler
 	messageRepo    *repository.TelegramMessageRepository
 	chatConfigRepo *repository.TelegramChatConfigRepository
+	externalRepo   *repository.ExternalContactRepository
+	contactRepo    *repository.ContactRepository
 	database       *db.Database
 }
 
-// setupSparseEnrichTest builds a MessageHandler with real repos, a nil
-// peerMatcher (matcher logic is out of scope for these tests) and nil
-// syncStateID (so the sync update is a no-op).
+// setupSparseEnrichTest builds a MessageHandler with real repos and a real
+// PeerMatcher (discoveryMinMsgs=1 so a single message is enough to upsert
+// the discovery candidate and exercise the enriched-fields-into-discovery
+// path).
 func setupSparseEnrichTest(t *testing.T) *sparseEnrichEnv {
 	t.Helper()
 	if testing.Short() {
@@ -51,6 +73,15 @@ func setupSparseEnrichTest(t *testing.T) *sparseEnrichEnv {
 	messageRepo := repository.NewTelegramMessageRepository(database.Queries)
 	chatConfigRepo := repository.NewTelegramChatConfigRepository(database.Queries)
 	syncRepo := repository.NewSyncRepository(database.Queries)
+	externalRepo := repository.NewExternalContactRepository(database.Queries)
+	contactRepo := repository.NewContactRepository(database.Queries)
+	contactMethodRepo := repository.NewContactMethodRepository(database.Queries)
+	enrichmentRepo := repository.NewEnrichmentRepository(database.Queries)
+	identityRepo := repository.NewIdentityRepository(database.Queries)
+
+	identitySvc := service.NewIdentityService(identityRepo)
+	enrichmentSvc := service.NewEnrichmentService(contactRepo, contactMethodRepo, enrichmentRepo)
+	matcher := tgpkg.NewPeerMatcher(identitySvc, messageRepo, externalRepo, enrichmentSvc, 1)
 
 	handler := tgpkg.NewMessageHandler(
 		messageRepo,
@@ -59,16 +90,27 @@ func setupSparseEnrichTest(t *testing.T) *sparseEnrichEnv {
 		nil,    // syncStateID — nil → updateSyncTimestamp is a no-op
 		111111, // selfUserID — never matches any test peer
 		10,     // groupMaxMembers
-		nil,    // peerMatcher — nil means matching path is skipped
-		nil,    // aggregationEngine
+		matcher,
+		nil, // aggregationEngine — exercised separately
 	)
 
 	return &sparseEnrichEnv{
 		handler:        handler,
 		messageRepo:    messageRepo,
 		chatConfigRepo: chatConfigRepo,
+		externalRepo:   externalRepo,
+		contactRepo:    contactRepo,
 		database:       database,
 	}
+}
+
+// cleanupExternalBySource deletes any external_contact rows associated with
+// the given source ID (decimal peer user ID). Lets a test that exercises the
+// matcher/discovery path leave no orphans.
+func cleanupExternalBySource(t *testing.T, env *sparseEnrichEnv, peerIDStr string) {
+	t.Helper()
+	ctx := context.Background()
+	_, _ = env.database.Queries.DeleteExternalContactsBySourceIDPrefix(ctx, pgtype.Text{String: peerIDStr, Valid: true})
 }
 
 // cleanupSparseEnrichTestData hard-deletes any telegram_message rows for the
@@ -275,6 +317,10 @@ func TestSparseEntityEnrichment_UntrackedGroupSkipsBeforeEnrichment(t *testing.T
 	groupChatID := peerUserID + 1 // distinct from peer id
 	t.Cleanup(func() { cleanupSparseEnrichTestData(t, env, groupChatID) })
 
+	// Wrap the real fetcher so we can prove the fallback was NOT consulted.
+	counter := &countingFetcher{inner: env.messageRepo}
+	env.handler.SetPeerEntityFetcher(counter)
+
 	// Pre-mark the group chat as ignored.
 	_, err := env.chatConfigRepo.UpsertConfig(ctx, repository.UpsertTelegramChatConfigParams{
 		TelegramChatID: groupChatID,
@@ -299,4 +345,58 @@ func TestSparseEntityEnrichment_UntrackedGroupSkipsBeforeEnrichment(t *testing.T
 	// No row should have been inserted for the ignored chat.
 	_, err = env.messageRepo.GetMessage(ctx, groupChatID, 70001)
 	require.Error(t, err, "ignored group chat must not insert any message row")
+
+	// And the enrichment fallback must have been short-circuited by the
+	// tracking gate — proves enrichment is placed AFTER shouldTrackChat.
+	assert.Equal(t, int64(0), counter.Count(), "enrichSparseEntity must not run for ignored group chats")
+}
+
+// TestSparseEntityEnrichment_EnrichedFieldsFlowToDiscoveryCandidate verifies
+// the user-visible "Unknown card → real name" outcome: when a sparse
+// incoming message arrives for an unmatched peer that has historical entity
+// data, the enriched username/first_name flows through MatchPeer →
+// UpdateDiscoveryCandidatesForPeer and lands on the external_contact row.
+func TestSparseEntityEnrichment_EnrichedFieldsFlowToDiscoveryCandidate(t *testing.T) {
+	env := setupSparseEnrichTest(t)
+	ctx := context.Background()
+	peerUserID, peerIDStr := uniqueTestIDs(t)
+	chatID := peerUserID
+	t.Cleanup(func() {
+		cleanupSparseEnrichTestData(t, env, chatID)
+		cleanupExternalBySource(t, env, peerIDStr)
+	})
+
+	// Seed history with rich entity data; the handler must consult this when
+	// the new sparse update arrives.
+	username := "connor" + peerIDStr
+	firstName := "Connor" + peerIDStr
+	_, err := env.messageRepo.UpsertMessage(ctx, repository.UpsertTelegramMessageParams{
+		TelegramMessageID: 70001,
+		TelegramChatID:    chatID,
+		ChatType:          "private",
+		MessageType:       "text",
+		SentAt:            accelerated.GetCurrentTime().Add(-1 * time.Hour),
+		IsOutgoing:        false,
+		PeerUserID:        &peerUserID,
+		PeerUsername:      &username,
+		PeerFirstName:     &firstName,
+	})
+	require.NoError(t, err)
+
+	// Sparse incoming message — no tg.User in entities.
+	msg := makePrivateMessage(peerUserID, 70002, accelerated.GetCurrentTime(), "ping")
+	entities := tg.Entities{Users: map[int64]*tg.User{}}
+	update := &tg.UpdateNewMessage{Message: msg}
+
+	require.NoError(t, env.handler.HandleNewMessage(ctx, entities, update))
+
+	// The external_contact (discovery candidate) must reflect the ENRICHED
+	// fields, not nils. Without the enrichment fix this row's first_name
+	// would be NULL and metadata.username would be absent → "Unknown" card.
+	got, err := env.externalRepo.GetBySource(ctx, "telegram", strconv.FormatInt(peerUserID, 10), nil)
+	require.NoError(t, err)
+	require.NotNil(t, got, "external_contact must be upserted with enriched fields")
+	require.NotNil(t, got.FirstName, "first_name must be populated from history")
+	assert.Equal(t, firstName, *got.FirstName)
+	assert.Equal(t, "@"+username, got.Metadata["username"], "metadata.username must reflect enriched handle")
 }


### PR DESCRIPTION
## Summary

Fixes the upstream cause of persistent "Unknown" cards in the Telegram import-candidates UI. Live MTProto updates from gotd sometimes deliver a `*tg.Message` without the peer's `tg.User` in `entities.Users`; `ParseMessage` then writes nil into `PeerUsername` / `PeerFirstName` / `PeerLastName`, propagating blanks into `telegram_message`, `MatchPeer`, and `external_contact`.

- Adds `PeerEntityResolved bool` to `ParsedMessage` (true iff the parser found the peer's `tg.User`)
- New `GetPeerEntityByUserID` sqlc query + repo method returns the best-known entity for a peer from `telegram_message` (non-blank username → phone → first/last name → most recent)
- New `enrichSparseEntity` helper on `MessageHandler`, called between the `shouldTrackChat` gate and `UpsertMessage` in both `HandleNewMessage` and `HandleEditMessage`. Fires only when `PeerEntityResolved=false` — authoritative-empty fields (user removed their handle) are preserved
- Adds non-status-filtered partial index `idx_telegram_message_peer_user_id_all` for the new fallback query (the existing `idx_telegram_message_peer` filters on `matched_contact_id IS NULL` and can't serve it)
- Plan: [.ai/log/plan/telegram-sparse-entity-enrichment.md](.ai/log/plan/telegram-sparse-entity-enrichment.md) (approved Codex round 5; Codex round 2 on the implementation: PASS)
- Closes the recurring "Unknown" card issue surfaced after #275 / #276 deploy

## Test plan

- [x] `make lint` — 0 issues
- [x] `go test ./internal/telegram/...` — all unit tests pass (5 new ParseMessage cases, 7 new enrichSparseEntity cases)
- [x] `go test ./tests/ -run TestSparseEntityEnrichment` — 7 integration tests pass:
  - `HandleNewMessage_FillsFromHistory`
  - `HandleNewMessage_NoHistoryStaysSparse`
  - `HandleEditMessage_FillsFromHistory`
  - `AuthoritativeEmptyRespectsRemoval` (user-removed-handle case)
  - `StraightRenameCurrentNonBlankWins`
  - `UntrackedGroupSkipsBeforeEnrichment` (asserts `CallCount==0` via counting fetcher)
  - `EnrichedFieldsFlowToDiscoveryCandidate` (end-to-end: sparse update → enriched `external_contact`)
- [x] Pre-existing matcher tests `TestUpdateDiscoveryCandidatesForPeer_NilNames_StillSendsUpsert` / `_EmptyStringsTreatedAsNil` still pass unchanged
- [ ] Post-deploy: send a message to each of the 4 known "Unknown" peers (Connor, Diana, Zakk, Brennan) and verify the import-candidates cards transition to their real names within ~5 minutes (per plan §5.10)