### PR TITLE
feat(events): HTTP ingestion endpoint for external daemon events

### DIFF
--- a/.ai/guides/feature-development.md
+++ b/.ai/guides/feature-development.md
@@ -334,6 +334,7 @@ v1 := router.Group("/api/v1")
 | **System** | `/system/time` | GET | SystemHandler | Current time |
 | | `/export` | POST | SystemHandler | Export data |
 | | `/import` | POST | SystemHandler | Import data |
+| **Ingest** | `/ingest/events` | POST | IngestHandler | Batched event ingestion (gated by `EVENT_BUS_INGEST_ENABLED`) |
 
 Routes defined in `backend/cmd/crm-api/main.go`.
 

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -37,6 +37,7 @@ import (
 	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/crypto"
 	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
 	"personal-crm/backend/internal/google"
 	"personal-crm/backend/internal/health"
 	"personal-crm/backend/internal/logger"
@@ -145,6 +146,16 @@ func run() int {
 	logger.Info().
 		Int("worker_concurrency", cfg.River.WorkerConcurrency).
 		Msg("river client started")
+
+	// Event bus — first in-process publisher arrives in PR 4 of #180 (HTTP
+	// ingestion). Constructed unconditionally: the Bus is three pointers
+	// (pool, river client, event repo) and zero runtime cost when nothing
+	// publishes. The ingest handler/service/route are gated below by
+	// cfg.Features.EnableEventBusIngest.
+	eventRepo := repository.NewEventRepository(database.Queries)
+	eventBus := events.NewBus(database.Pool, riverClient, eventRepo)
+	ingestService := service.NewIngestService(database, eventBus)
+	ingestHandler := handlers.NewIngestHandler(ingestService)
 
 	// Initialize repositories
 	contactRepo := repository.NewContactRepository(database.Queries)
@@ -579,6 +590,19 @@ func run() int {
 		// Export/Import routes
 		v1.POST("/export", systemHandler.ExportData)
 		v1.POST("/import", systemHandler.ImportData)
+
+		// Event bus ingestion endpoint (feature-flagged per spec §3.9).
+		// When the flag is off the route is NOT registered — gin's NoRoute
+		// handler returns 404 without running the API-key middleware, per
+		// plan Decision 1. This matches the spec's acceptance criterion:
+		// "EVENT_BUS_INGEST_ENABLED=false (default) returns 404."
+		if cfg.Features.EnableEventBusIngest {
+			ingest := v1.Group("/ingest")
+			{
+				ingest.POST("/events", ingestHandler.IngestEvents)
+			}
+			logger.Info().Msg("event bus ingestion endpoint enabled")
+		}
 
 		// Test routes (gated by CRM_ENV=testing or CRM_ENV=test)
 		if cfg.Runtime.CRMEnvironment == "testing" || cfg.Runtime.CRMEnvironment == "test" {

--- a/backend/internal/api/handlers/ingest.go
+++ b/backend/internal/api/handlers/ingest.go
@@ -1,0 +1,252 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"personal-crm/backend/internal/api"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/logger"
+	"personal-crm/backend/internal/service"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Ingestion limits. Chosen per plan/spec §3.5:
+//   - maxBatchSize: hard ceiling on the number of events per POST.
+//   - maxIngestBodyBytes: 8 MiB body cap wrapped via http.MaxBytesReader
+//     at the top of the handler — DoS mitigation.
+//   - maxSourceLen / maxSourceIDLen: bounded keys for the partial unique
+//     index; avoids pathological btree entries.
+//   - maxPayloadBytes: 64 KiB guard so even JSON-valid payloads can't
+//     pressure jsonb storage.
+const (
+	maxBatchSize       = 500
+	maxIngestBodyBytes = 8 << 20 // 8 MiB
+	maxSourceLen       = 64
+	maxSourceIDLen     = 255
+	maxPayloadBytes    = 64 << 10 // 64 KiB
+)
+
+// Ingestion error codes surfaced in the per-event errors[] array. HTTP
+// status for the batch remains 200 when only per-event rejections occur;
+// request-level failures (batch too large, malformed JSON, body too big)
+// use the standard api.Send* helpers.
+const (
+	ingestCodeMissingField    = "MISSING_FIELD"
+	ingestCodeFieldTooLong    = "FIELD_TOO_LONG"
+	ingestCodeUnknownKind     = "UNKNOWN_KIND"
+	ingestCodePayloadInvalid  = "PAYLOAD_INVALID"
+	ingestCodePayloadTooLarge = "PAYLOAD_TOO_LARGE"
+)
+
+// IngestHandler exposes POST /api/v1/ingest/events. Registered only when
+// cfg.Features.EnableEventBusIngest is true (spec §3.9).
+type IngestHandler struct {
+	ingestService *service.IngestService
+}
+
+// NewIngestHandler builds an IngestHandler over the given service.
+func NewIngestHandler(s *service.IngestService) *IngestHandler {
+	return &IngestHandler{ingestService: s}
+}
+
+// IngestEventRequest matches the per-event wire shape in spec §3.5.
+type IngestEventRequest struct {
+	Source     string          `json:"source"      binding:"required"`
+	SourceID   string          `json:"source_id,omitempty"`
+	Kind       string          `json:"kind"        binding:"required"`
+	Payload    json.RawMessage `json:"payload"     binding:"required"`
+	ObservedAt time.Time       `json:"observed_at" binding:"required"`
+}
+
+// IngestBatchRequest is the top-level POST body. events must be a non-empty
+// array; an empty array is rejected with 400 (spec deliberately unspecified;
+// plan Decision 9 chose 400 for client-bug visibility).
+type IngestBatchRequest struct {
+	Events []IngestEventRequest `json:"events" binding:"required"`
+}
+
+// IngestError is a per-event validation failure reported in the response.
+// Index is the 0-based position in the original request's events array.
+type IngestError struct {
+	Index   int    `json:"index"`
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// IngestResponse matches the spec §3.5 happy-path shape literally —
+// deliberately NOT wrapped in api.APIResponse. External daemons are
+// contract consumers and the wrapping would be a spec deviation.
+type IngestResponse struct {
+	Accepted  int           `json:"accepted"`
+	Duplicate int           `json:"duplicate"`
+	Rejected  int           `json:"rejected"`
+	Errors    []IngestError `json:"errors"`
+}
+
+// IngestEvents is the HTTP handler for POST /api/v1/ingest/events.
+//
+// Flow:
+//  1. Wrap the body in http.MaxBytesReader (8 MiB cap). Reject oversize
+//     bodies with 413 before parsing JSON.
+//  2. Bind the JSON body. Malformed → 400.
+//  3. Enforce batch shape: non-empty, ≤ maxBatchSize.
+//  4. Validate each event (required fields, length bounds, known kind,
+//     payload shape). Failures land in errors[]; the batch continues.
+//  5. If any events pass validation, forward them to the service as a
+//     single atomic batch. Return spec-shaped success response. If the
+//     service errors (unexpected DB failure), return 500.
+func (h *IngestHandler) IngestEvents(c *gin.Context) {
+	// Body size cap. MaxBytesReader returns an error from the JSON decoder
+	// when the body exceeds the limit; we detect that via string match
+	// since gin/pgx don't expose a typed error for it.
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxIngestBodyBytes)
+
+	var req IngestBatchRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		if strings.Contains(err.Error(), "http: request body too large") {
+			api.SendError(c, http.StatusRequestEntityTooLarge, api.ErrCodeValidation,
+				"Request body too large",
+				fmt.Sprintf("body exceeds %d bytes", maxIngestBodyBytes))
+			return
+		}
+		api.SendValidationError(c, "Invalid request body", err.Error())
+		return
+	}
+
+	// Empty batch: spec-silent; plan Decision 9 chose 400 for client-bug
+	// visibility. gin's binding:"required" tag catches nil/missing events
+	// but NOT an explicit empty array, so check here.
+	if len(req.Events) == 0 {
+		api.SendValidationError(c, "events must be non-empty", "")
+		return
+	}
+
+	if len(req.Events) > maxBatchSize {
+		api.SendValidationError(c,
+			fmt.Sprintf("batch exceeds maximum size of %d events", maxBatchSize),
+			fmt.Sprintf("got %d events", len(req.Events)))
+		return
+	}
+
+	// Validate each event pre-tx. Valid ones become envelopes to publish.
+	envsToIngest := make([]*events.Envelope, 0, len(req.Events))
+	ingestErrors := make([]IngestError, 0)
+	for i, ev := range req.Events {
+		if ierr := validateIngestEvent(i, ev); ierr != nil {
+			ingestErrors = append(ingestErrors, *ierr)
+			continue
+		}
+		envsToIngest = append(envsToIngest, &events.Envelope{
+			Source:     ev.Source,
+			SourceID:   ev.SourceID,
+			Kind:       events.Kind(ev.Kind),
+			Payload:    ev.Payload,
+			ObservedAt: ev.ObservedAt,
+		})
+	}
+
+	rejected := len(ingestErrors)
+
+	// All events failed validation — still a success response (spec §3.5
+	// distinguishes "validation failure per event" from "batch-level
+	// failure"). No tx work needed.
+	if len(envsToIngest) == 0 {
+		logger.Info().
+			Int("batch_size", len(req.Events)).
+			Int("accepted", 0).
+			Int("duplicate", 0).
+			Int("rejected", rejected).
+			Msg("event batch ingested (all rejected)")
+		c.JSON(http.StatusOK, IngestResponse{
+			Accepted:  0,
+			Duplicate: 0,
+			Rejected:  rejected,
+			Errors:    ingestErrors,
+		})
+		return
+	}
+
+	accepted, duplicate, err := h.ingestService.IngestBatch(c.Request.Context(), envsToIngest)
+	if err != nil {
+		logger.Error().
+			Err(err).
+			Int("batch_size", len(req.Events)).
+			Int("validated_batch_size", len(envsToIngest)).
+			Msg("event batch ingest failed (tx rolled back)")
+		api.SendInternalError(c, "Failed to ingest events")
+		return
+	}
+
+	logger.Info().
+		Int("batch_size", len(req.Events)).
+		Int("accepted", accepted).
+		Int("duplicate", duplicate).
+		Int("rejected", rejected).
+		Msg("event batch ingested")
+
+	c.JSON(http.StatusOK, IngestResponse{
+		Accepted:  accepted,
+		Duplicate: duplicate,
+		Rejected:  rejected,
+		Errors:    ingestErrors,
+	})
+}
+
+// validateIngestEvent runs the per-event validation chain. Returns nil
+// when the event passes; otherwise returns a populated *IngestError. The
+// caller appends rejected events to the response's errors[] array.
+func validateIngestEvent(index int, ev IngestEventRequest) *IngestError {
+	// Required-field bounds. binding:"required" catches missing keys and
+	// empty strings for source/kind, but ObservedAt's zero-time passes
+	// the tag since Go's zero-value time.Time isn't "empty" to gin's
+	// validator — we check IsZero() below.
+	if ev.Source == "" {
+		return &IngestError{Index: index, Code: ingestCodeMissingField, Message: "source is required"}
+	}
+	if len(ev.Source) > maxSourceLen {
+		return &IngestError{Index: index, Code: ingestCodeFieldTooLong,
+			Message: fmt.Sprintf("source exceeds %d chars", maxSourceLen)}
+	}
+	if len(ev.SourceID) > maxSourceIDLen {
+		return &IngestError{Index: index, Code: ingestCodeFieldTooLong,
+			Message: fmt.Sprintf("source_id exceeds %d chars", maxSourceIDLen)}
+	}
+	if ev.Kind == "" {
+		return &IngestError{Index: index, Code: ingestCodeMissingField, Message: "kind is required"}
+	}
+	if ev.ObservedAt.IsZero() {
+		return &IngestError{Index: index, Code: ingestCodeMissingField, Message: "observed_at is required"}
+	}
+	if len(ev.Payload) == 0 {
+		return &IngestError{Index: index, Code: ingestCodeMissingField, Message: "payload is required"}
+	}
+	if len(ev.Payload) > maxPayloadBytes {
+		return &IngestError{Index: index, Code: ingestCodePayloadTooLarge,
+			Message: fmt.Sprintf("payload exceeds %d bytes", maxPayloadBytes)}
+	}
+
+	kind := events.Kind(ev.Kind)
+	if !events.IsKnownKind(kind) {
+		return &IngestError{Index: index, Code: ingestCodeUnknownKind,
+			Message: fmt.Sprintf("unknown kind %q", ev.Kind)}
+	}
+
+	// Structural payload check via reflection-backed helper. See
+	// events.ValidatePayload for the exact contract (lenient unknown
+	// fields; absent fields decode to zero values).
+	tmp := &events.Envelope{Kind: kind, Payload: ev.Payload}
+	if err := events.ValidatePayload(tmp); err != nil {
+		return &IngestError{
+			Index:   index,
+			Code:    ingestCodePayloadInvalid,
+			Message: fmt.Sprintf("payload failed structural validation: %s", err.Error()),
+		}
+	}
+
+	return nil
+}

--- a/backend/internal/api/handlers/ingest.go
+++ b/backend/internal/api/handlers/ingest.go
@@ -55,19 +55,34 @@ func NewIngestHandler(s *service.IngestService) *IngestHandler {
 }
 
 // IngestEventRequest matches the per-event wire shape in spec §3.5.
+//
+// Fields are deliberately NOT tagged with `binding:"required"`: a single
+// bad event (missing source, unknown kind, empty payload, missing
+// observed_at) must NOT cause gin's bind step to fail the whole batch
+// with 400. Per-event validation runs in validateIngestEvent after bind
+// and surfaces each bad event in the response's errors[] — spec §3.5
+// "the batch continues" contract.
+//
+// ObservedAt is *time.Time so (a) an absent key is distinguishable from
+// a zero timestamp; (b) a syntactically invalid RFC3339 string still
+// fails the whole batch at bind (that's a wire-protocol error, not a
+// per-event logical error).
 type IngestEventRequest struct {
-	Source     string          `json:"source"      binding:"required"`
+	Source     string          `json:"source"`
 	SourceID   string          `json:"source_id,omitempty"`
-	Kind       string          `json:"kind"        binding:"required"`
-	Payload    json.RawMessage `json:"payload"     binding:"required"`
-	ObservedAt time.Time       `json:"observed_at" binding:"required"`
+	Kind       string          `json:"kind"`
+	Payload    json.RawMessage `json:"payload"`
+	ObservedAt *time.Time      `json:"observed_at"`
 }
 
-// IngestBatchRequest is the top-level POST body. events must be a non-empty
-// array; an empty array is rejected with 400 (spec deliberately unspecified;
-// plan Decision 9 chose 400 for client-bug visibility).
+// IngestBatchRequest is the top-level POST body.
+//
+// The Events slice is NOT `binding:"required"` — gin treats an explicit
+// empty array as satisfying that tag, so we'd check length explicitly
+// anyway. A missing `events` key decodes to a nil slice, which falls
+// into the same empty-batch path.
 type IngestBatchRequest struct {
-	Events []IngestEventRequest `json:"events" binding:"required"`
+	Events []IngestEventRequest `json:"events"`
 }
 
 // IngestError is a per-event validation failure reported in the response.
@@ -146,7 +161,7 @@ func (h *IngestHandler) IngestEvents(c *gin.Context) {
 			SourceID:   ev.SourceID,
 			Kind:       events.Kind(ev.Kind),
 			Payload:    ev.Payload,
-			ObservedAt: ev.ObservedAt,
+			ObservedAt: *ev.ObservedAt, // validator guarantees non-nil + non-zero
 		})
 	}
 
@@ -200,11 +215,11 @@ func (h *IngestHandler) IngestEvents(c *gin.Context) {
 // validateIngestEvent runs the per-event validation chain. Returns nil
 // when the event passes; otherwise returns a populated *IngestError. The
 // caller appends rejected events to the response's errors[] array.
+//
+// This function owns ALL per-event rejections — no binding:"required" tag
+// fires at gin-bind time, because that would 400 the whole batch and
+// violate spec §3.5's "batch continues" contract.
 func validateIngestEvent(index int, ev IngestEventRequest) *IngestError {
-	// Required-field bounds. binding:"required" catches missing keys and
-	// empty strings for source/kind, but ObservedAt's zero-time passes
-	// the tag since Go's zero-value time.Time isn't "empty" to gin's
-	// validator — we check IsZero() below.
 	if ev.Source == "" {
 		return &IngestError{Index: index, Code: ingestCodeMissingField, Message: "source is required"}
 	}
@@ -219,7 +234,10 @@ func validateIngestEvent(index int, ev IngestEventRequest) *IngestError {
 	if ev.Kind == "" {
 		return &IngestError{Index: index, Code: ingestCodeMissingField, Message: "kind is required"}
 	}
-	if ev.ObservedAt.IsZero() {
+	// *time.Time lets us distinguish "observed_at absent" (nil pointer)
+	// from "observed_at: 0001-01-01..." (IsZero). Both are rejected with
+	// MISSING_FIELD.
+	if ev.ObservedAt == nil || ev.ObservedAt.IsZero() {
 		return &IngestError{Index: index, Code: ingestCodeMissingField, Message: "observed_at is required"}
 	}
 	if len(ev.Payload) == 0 {
@@ -238,7 +256,9 @@ func validateIngestEvent(index int, ev IngestEventRequest) *IngestError {
 
 	// Structural payload check via reflection-backed helper. See
 	// events.ValidatePayload for the exact contract (lenient unknown
-	// fields; absent fields decode to zero values).
+	// fields; absent fields decode to zero values). ValidatePayload also
+	// rejects a literal JSON `null` payload — we don't want to persist a
+	// row whose payload decodes to an all-zero canonical struct.
 	tmp := &events.Envelope{Kind: kind, Payload: ev.Payload}
 	if err := events.ValidatePayload(tmp); err != nil {
 		return &IngestError{

--- a/backend/internal/api/handlers/ingest.go
+++ b/backend/internal/api/handlers/ingest.go
@@ -2,9 +2,9 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"personal-crm/backend/internal/api"
@@ -116,14 +116,15 @@ type IngestResponse struct {
 //     single atomic batch. Return spec-shaped success response. If the
 //     service errors (unexpected DB failure), return 500.
 func (h *IngestHandler) IngestEvents(c *gin.Context) {
-	// Body size cap. MaxBytesReader returns an error from the JSON decoder
-	// when the body exceeds the limit; we detect that via string match
-	// since gin/pgx don't expose a typed error for it.
+	// Body size cap. MaxBytesReader returns *http.MaxBytesError (Go 1.21+)
+	// which propagates through json.Decoder without re-wrapping; detect it
+	// with errors.As rather than string-matching the message.
 	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxIngestBodyBytes)
 
 	var req IngestBatchRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		if strings.Contains(err.Error(), "http: request body too large") {
+		var mbe *http.MaxBytesError
+		if errors.As(err, &mbe) {
 			api.SendError(c, http.StatusRequestEntityTooLarge, api.ErrCodeValidation,
 				"Request body too large",
 				fmt.Sprintf("body exceeds %d bytes", maxIngestBodyBytes))

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -58,10 +58,11 @@ type CORSConfig struct {
 
 // FeatureFlags holds experimental feature toggles
 type FeatureFlags struct {
-	EnableVectorSearch bool // Default: false
-	EnableTelegramSync bool // Default: false
-	EnableCalendarSync bool // Default: false
-	EnableExternalSync bool // Default: false
+	EnableVectorSearch   bool // Default: false
+	EnableTelegramSync   bool // Default: false
+	EnableCalendarSync   bool // Default: false
+	EnableExternalSync   bool // Default: false
+	EnableEventBusIngest bool // Default: false (gates POST /api/v1/ingest/events — spec §3.9)
 }
 
 // RuntimeConfig holds runtime-only settings (not validated at startup)
@@ -199,10 +200,11 @@ func Load() (*Config, error) {
 			FrontendURL: getEnv("FRONTEND_URL", "http://localhost:3000"),
 		},
 		Features: FeatureFlags{
-			EnableVectorSearch: getEnvAsBool("ENABLE_VECTOR_SEARCH", false),
-			EnableTelegramSync: getEnvAsBool("ENABLE_TELEGRAM_SYNC", false),
-			EnableCalendarSync: getEnvAsBool("ENABLE_CALENDAR_SYNC", false),
-			EnableExternalSync: getEnvAsBool("ENABLE_EXTERNAL_SYNC", false),
+			EnableVectorSearch:   getEnvAsBool("ENABLE_VECTOR_SEARCH", false),
+			EnableTelegramSync:   getEnvAsBool("ENABLE_TELEGRAM_SYNC", false),
+			EnableCalendarSync:   getEnvAsBool("ENABLE_CALENDAR_SYNC", false),
+			EnableExternalSync:   getEnvAsBool("ENABLE_EXTERNAL_SYNC", false),
+			EnableEventBusIngest: getEnvAsBool("EVENT_BUS_INGEST_ENABLED", false),
 		},
 		Runtime: RuntimeConfig{
 			CRMEnvironment:   getEnv("CRM_ENV", DefaultCRMEnvironment),
@@ -475,10 +477,11 @@ func TestConfig() *Config {
 			FrontendURL: "http://localhost:3000",
 		},
 		Features: FeatureFlags{
-			EnableVectorSearch: false,
-			EnableTelegramSync: false,
-			EnableCalendarSync: false,
-			EnableExternalSync: false,
+			EnableVectorSearch:   false,
+			EnableTelegramSync:   false,
+			EnableCalendarSync:   false,
+			EnableExternalSync:   false,
+			EnableEventBusIngest: false,
 		},
 		Runtime: RuntimeConfig{
 			CRMEnvironment:   "test",

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -238,6 +238,34 @@ func TestConfig_TypeConversions(t *testing.T) {
 	}
 }
 
+// TestConfig_EventBusIngestFlag ensures EVENT_BUS_INGEST_ENABLED wires into
+// Features.EnableEventBusIngest (default false, env override true). The
+// ingest route registration in main.go reads this flag — spec §3.9.
+func TestConfig_EventBusIngestFlag(t *testing.T) {
+	t.Run("DefaultFalse", func(t *testing.T) {
+		WithEnv(t, "DATABASE_URL", "postgres://localhost/test")
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("Load() failed: %v", err)
+		}
+		if cfg.Features.EnableEventBusIngest {
+			t.Error("Expected EnableEventBusIngest=false by default")
+		}
+	})
+
+	t.Run("EnvOverrideTrue", func(t *testing.T) {
+		WithEnv(t, "DATABASE_URL", "postgres://localhost/test")
+		WithEnv(t, "EVENT_BUS_INGEST_ENABLED", "true")
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("Load() failed: %v", err)
+		}
+		if !cfg.Features.EnableEventBusIngest {
+			t.Error("Expected EnableEventBusIngest=true when EVENT_BUS_INGEST_ENABLED=true")
+		}
+	})
+}
+
 func TestConfig_IsProduction(t *testing.T) {
 	tests := []struct {
 		env  string

--- a/backend/internal/db/event.sql.go
+++ b/backend/internal/db/event.sql.go
@@ -11,6 +11,20 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const CountEventsBySource = `-- name: CountEventsBySource :one
+SELECT COUNT(*) FROM event WHERE source = $1
+`
+
+// Used by integration tests (and potentially ops dashboards) to assert
+// ingest outcomes per source. The event log is append-only, so no
+// deleted_at filter is needed.
+func (q *Queries) CountEventsBySource(ctx context.Context, source string) (int64, error) {
+	row := q.db.QueryRow(ctx, CountEventsBySource, source)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const FindEventBySource = `-- name: FindEventBySource :one
 SELECT id, source, source_id, kind, payload, observed_at, received_at, created_at FROM event
 WHERE source = $1 AND source_id = $2

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -27,6 +27,10 @@ type Querier interface {
 	CountContactTasksByProvider(ctx context.Context, arg CountContactTasksByProviderParams) (int64, error)
 	CountContacts(ctx context.Context, arg CountContactsParams) (int64, error)
 	CountContactsByNamePrefix(ctx context.Context, dollar_1 pgtype.Text) (int64, error)
+	// Used by integration tests (and potentially ops dashboards) to assert
+	// ingest outcomes per source. The event log is append-only, so no
+	// deleted_at filter is needed.
+	CountEventsBySource(ctx context.Context, source string) (int64, error)
 	// Count events for a specific contact
 	CountEventsForContact(ctx context.Context, contactID pgtype.UUID) (int64, error)
 	CountExternalContactsByDisplayNamePrefix(ctx context.Context, dollar_1 pgtype.Text) (int64, error)

--- a/backend/internal/db/queries/event.sql
+++ b/backend/internal/db/queries/event.sql
@@ -32,3 +32,9 @@ SELECT * FROM event WHERE id = @id;
 SELECT * FROM event
 WHERE source = @source AND source_id = @source_id
 LIMIT 1;
+
+-- name: CountEventsBySource :one
+-- Used by integration tests (and potentially ops dashboards) to assert
+-- ingest outcomes per source. The event log is append-only, so no
+-- deleted_at filter is needed.
+SELECT COUNT(*) FROM event WHERE source = @source;

--- a/backend/internal/events/kinds.go
+++ b/backend/internal/events/kinds.go
@@ -185,6 +185,44 @@ var kindPayloadTypes = map[Kind]reflect.Type{
 	KindInteractionRecorded:  reflect.TypeOf(InteractionRecordedPayload{}),
 }
 
+// IsKnownKind reports whether kind has a registered payload type. Used by
+// ingestion validation (spec §3.5) to reject unknown kinds pre-tx without
+// exposing the private kindPayloadTypes registry.
+func IsKnownKind(kind Kind) bool {
+	_, ok := kindPayloadTypes[kind]
+	return ok
+}
+
+// ValidatePayload decodes env.Payload into a zero-value of env.Kind's
+// canonical payload type (via reflect.New) and returns a descriptive error
+// on kind-mismatch / unknown kind / decode failure. The decoded value is
+// discarded — this is a validation-only helper for call sites that don't
+// know the payload type P at compile time (e.g., the HTTP ingestion
+// handler, which dispatches on a string-valued kind from the wire).
+//
+// Uses json.Unmarshal with default (lenient) settings: unknown fields are
+// silently dropped. This matches spec §3.2's Version-int evolution model —
+// forward-compat additions must not be rejected at the ingest boundary.
+// Required-field presence is NOT checked (absent non-pointer fields decode
+// to zero values); consumers enforce their own required-field contracts.
+func ValidatePayload(env *Envelope) error {
+	if env == nil {
+		return fmt.Errorf("validate: nil envelope")
+	}
+	expected, ok := kindPayloadTypes[env.Kind]
+	if !ok {
+		return fmt.Errorf("validate: unknown kind %q", env.Kind)
+	}
+	if len(env.Payload) == 0 {
+		return fmt.Errorf("validate %s: empty payload", env.Kind)
+	}
+	dst := reflect.New(expected).Interface() // *P
+	if err := json.Unmarshal(env.Payload, dst); err != nil {
+		return fmt.Errorf("validate %s: %w", env.Kind, err)
+	}
+	return nil
+}
+
 // Marshal serializes a typed payload for an Envelope's Payload field and
 // asserts the payload's type matches the canonical type for kind. Callers
 // should populate payload.Version before calling.

--- a/backend/internal/events/kinds.go
+++ b/backend/internal/events/kinds.go
@@ -216,11 +216,40 @@ func ValidatePayload(env *Envelope) error {
 	if len(env.Payload) == 0 {
 		return fmt.Errorf("validate %s: empty payload", env.Kind)
 	}
+	// Reject literal `null`: json.Unmarshal of `null` into a struct
+	// pointer succeeds and leaves the struct zero-valued, which would
+	// silently pass a garbage event through to the event table. Rejecting
+	// here matches the ingest boundary's "payload is the kind's typed
+	// struct" contract.
+	if isJSONNull(env.Payload) {
+		return fmt.Errorf("validate %s: payload must be an object, got null", env.Kind)
+	}
 	dst := reflect.New(expected).Interface() // *P
 	if err := json.Unmarshal(env.Payload, dst); err != nil {
 		return fmt.Errorf("validate %s: %w", env.Kind, err)
 	}
 	return nil
+}
+
+// isJSONNull reports whether b is the literal JSON token `null`, ignoring
+// surrounding whitespace. Used to distinguish an absent/null payload from
+// a real object payload at the ingestion boundary.
+func isJSONNull(b []byte) bool {
+	lo, hi := 0, len(b)
+	for lo < hi && isJSONSpace(b[lo]) {
+		lo++
+	}
+	for hi > lo && isJSONSpace(b[hi-1]) {
+		hi--
+	}
+	trimmed := b[lo:hi]
+	return len(trimmed) == 4 &&
+		trimmed[0] == 'n' && trimmed[1] == 'u' &&
+		trimmed[2] == 'l' && trimmed[3] == 'l'
+}
+
+func isJSONSpace(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r'
 }
 
 // Marshal serializes a typed payload for an Envelope's Payload field and

--- a/backend/internal/events/kinds_test.go
+++ b/backend/internal/events/kinds_test.go
@@ -288,3 +288,131 @@ func TestKindPayloadTypes_CoversAllKinds(t *testing.T) {
 func TestAllKinds_ExpectedCount(t *testing.T) {
 	require.Len(t, AllKinds, 10)
 }
+
+// TestIsKnownKind_CoversAllKinds is the positive side: every Kind declared
+// in AllKinds must be reported as known. Guards against registry drift.
+func TestIsKnownKind_CoversAllKinds(t *testing.T) {
+	for _, k := range AllKinds {
+		require.True(t, IsKnownKind(k), "kind %s should be known", k)
+	}
+}
+
+func TestIsKnownKind_UnknownReturnsFalse(t *testing.T) {
+	require.False(t, IsKnownKind(Kind("made.up.kind")))
+	require.False(t, IsKnownKind(Kind("")))
+}
+
+// buildCanonicalPayload returns a round-trippable JSON payload for a given
+// Kind. Only test code needs this — it's the fixture for the
+// ValidatePayload round-trip test.
+func buildCanonicalPayload(t *testing.T, kind Kind) json.RawMessage {
+	t.Helper()
+	cid := uuid.New()
+	at := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+	switch kind {
+	case KindMessageReceived:
+		raw, err := Marshal(kind, MessageReceivedPayload{Version: 1, PeerRef: "tg:1:2", MessageAt: at})
+		require.NoError(t, err)
+		return raw
+	case KindMessageSent:
+		raw, err := Marshal(kind, MessageSentPayload{Version: 1, PeerRef: "tg:1:2", MessageAt: at})
+		require.NoError(t, err)
+		return raw
+	case KindCalendarAttended:
+		raw, err := Marshal(kind, CalendarAttendedPayload{Version: 1, ContactID: cid, EventID: "gcal-1", OccurredAt: at})
+		require.NoError(t, err)
+		return raw
+	case KindCalendarDeclined:
+		raw, err := Marshal(kind, CalendarDeclinedPayload{Version: 1, ContactID: cid, EventID: "gcal-1", OccurredAt: at})
+		require.NoError(t, err)
+		return raw
+	case KindTaskCompleted:
+		raw, err := Marshal(kind, TaskCompletedPayload{Version: 1, ContactID: cid, TaskID: "t1", TaskKind: "cadence", CompletedAt: at, Direction: "mutual"})
+		require.NoError(t, err)
+		return raw
+	case KindTaskSkipped:
+		raw, err := Marshal(kind, TaskSkippedPayload{Version: 1, ContactID: cid, TaskID: "t1", SkippedAt: at})
+		require.NoError(t, err)
+		return raw
+	case KindTaskOutreachDetected:
+		raw, err := Marshal(kind, TaskOutreachDetectedPayload{Version: 1, ContactID: cid, TaskID: "t1", DetectedAt: at})
+		require.NoError(t, err)
+		return raw
+	case KindInteractionManual:
+		raw, err := Marshal(kind, InteractionManualPayload{Version: 1, ContactID: cid, Direction: "mutual", OccurredAt: at})
+		require.NoError(t, err)
+		return raw
+	case KindContactMethodsAdded:
+		raw, err := Marshal(kind, ContactMethodsAddedPayload{Version: 1, ContactID: cid, Methods: []ContactMethodRef{{Type: "email", Value: "a@b.com"}}, RematchJobID: uuid.New()})
+		require.NoError(t, err)
+		return raw
+	case KindInteractionRecorded:
+		raw, err := Marshal(kind, InteractionRecordedPayload{Version: 1, ContactID: cid, InteractionID: uuid.New(), Direction: "mutual", OccurredAt: at, Source: "manual"})
+		require.NoError(t, err)
+		return raw
+	}
+	t.Fatalf("unhandled kind %s", kind)
+	return nil
+}
+
+// TestValidatePayload_AllKindsRoundTrip exercises the validate-only helper
+// against every declared Kind. Round-tripping a canonical payload must
+// succeed (no structural mismatch).
+func TestValidatePayload_AllKindsRoundTrip(t *testing.T) {
+	for _, k := range AllKinds {
+		t.Run(string(k), func(t *testing.T) {
+			env := &Envelope{Kind: k, Payload: buildCanonicalPayload(t, k)}
+			require.NoError(t, ValidatePayload(env))
+		})
+	}
+}
+
+func TestValidatePayload_MalformedJSON(t *testing.T) {
+	env := &Envelope{Kind: KindInteractionManual, Payload: json.RawMessage("{not json")}
+	err := ValidatePayload(env)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "validate interaction.manual")
+}
+
+func TestValidatePayload_EmptyPayload(t *testing.T) {
+	env := &Envelope{Kind: KindInteractionManual}
+	err := ValidatePayload(env)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "empty payload")
+}
+
+func TestValidatePayload_UnknownKind(t *testing.T) {
+	env := &Envelope{Kind: Kind("made.up.kind"), Payload: json.RawMessage(`{}`)}
+	err := ValidatePayload(env)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown kind")
+}
+
+func TestValidatePayload_NilEnvelope(t *testing.T) {
+	err := ValidatePayload(nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "nil envelope")
+}
+
+// TestValidatePayload_StructuralTypeMismatch covers the case where the
+// payload JSON decodes but a field's type is wrong — e.g. Version is a
+// string instead of an int. json.UnmarshalTypeError surfaces through
+// ValidatePayload as a wrapped error. This is the primary "payload doesn't
+// match kind's type" guardrail.
+func TestValidatePayload_StructuralTypeMismatch(t *testing.T) {
+	// KindCalendarAttended's ContactID is uuid.UUID — if we pass an int the
+	// JSON decoder rejects it with UnmarshalTypeError.
+	bad := json.RawMessage(`{"version": "not-a-number", "contact_id": "00000000-0000-0000-0000-000000000000", "event_id": "e", "occurred_at": "2026-04-10T12:00:00Z"}`)
+	env := &Envelope{Kind: KindCalendarAttended, Payload: bad}
+	err := ValidatePayload(env)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "validate calendar.attended")
+}
+
+// TestValidatePayload_NonObjectPayload rejects a top-level primitive JSON
+// value (e.g. "just a string") that can't unmarshal into any struct.
+func TestValidatePayload_NonObjectPayload(t *testing.T) {
+	env := &Envelope{Kind: KindInteractionManual, Payload: json.RawMessage(`"not an object"`)}
+	err := ValidatePayload(env)
+	require.Error(t, err)
+}

--- a/backend/internal/events/kinds_test.go
+++ b/backend/internal/events/kinds_test.go
@@ -416,3 +416,23 @@ func TestValidatePayload_NonObjectPayload(t *testing.T) {
 	err := ValidatePayload(env)
 	require.Error(t, err)
 }
+
+// TestValidatePayload_NullPayload rejects a literal JSON `null`. stdlib
+// json.Unmarshal happily decodes `null` into a struct pointer (leaving
+// the struct zero-valued), which would silently admit garbage events
+// into the event log. The ingest boundary is the right place to reject.
+func TestValidatePayload_NullPayload(t *testing.T) {
+	env := &Envelope{Kind: KindInteractionManual, Payload: json.RawMessage(`null`)}
+	err := ValidatePayload(env)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "got null")
+}
+
+// TestValidatePayload_NullPayloadWithWhitespace documents that whitespace
+// around the literal `null` still triggers the rejection.
+func TestValidatePayload_NullPayloadWithWhitespace(t *testing.T) {
+	env := &Envelope{Kind: KindInteractionManual, Payload: json.RawMessage("  null\n")}
+	err := ValidatePayload(env)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "got null")
+}

--- a/backend/internal/repository/event.go
+++ b/backend/internal/repository/event.go
@@ -106,6 +106,14 @@ func (r *EventRepository) GetEvent(ctx context.Context, id uuid.UUID) (*events.E
 	return convertDbEvent(row), nil
 }
 
+// CountBySource returns the number of events for a source. Used by
+// integration tests to assert ingest outcomes (and could power ops
+// dashboards later). The event log is append-only — no soft-delete
+// filter needed.
+func (r *EventRepository) CountBySource(ctx context.Context, source string) (int64, error) {
+	return r.queries.CountEventsBySource(ctx, source)
+}
+
 // FindEventBySource returns the event matching (source, source_id). Returns
 // db.ErrNotFound if absent OR if sourceID is empty. Used by batch ingestion
 // pre-filtering and tests.

--- a/backend/internal/service/ingest.go
+++ b/backend/internal/service/ingest.go
@@ -50,12 +50,32 @@ func NewIngestService(database *db.Database, bus *events.Bus) *IngestService {
 //
 // Duplicate detection relies on Bus.PublishTx returning nil for both
 // happy-path inserts and ON CONFLICT DO NOTHING hits. The repository
-// populates env.ID only on a real RETURNING row, so env.ID == uuid.Nil is
-// the duplicate sentinel. See PR 2 plan Design Decision 2 for the
+// populates env.ID only on a real RETURNING row, so env.ID == uuid.Nil
+// is the duplicate sentinel. See PR 2 plan Design Decision 2 for the
 // documented contract this depends on.
+//
+// Precondition: every envelope MUST have env.ID == uuid.Nil on entry.
+// EventRepository.InsertEvent supports caller-supplied IDs (via the
+// COALESCE in the sqlc query), which would collide with the sentinel
+// logic here and cause a duplicate to be miscounted as accepted. The
+// HTTP handler constructs fresh envelopes so this always holds; we
+// guard defensively to keep the contract visible at the service
+// boundary. A precondition violation is a caller bug — return an error
+// rather than silently miscounting.
 func (s *IngestService) IngestBatch(ctx context.Context, envs []*events.Envelope) (accepted, duplicate int, err error) {
 	if len(envs) == 0 {
 		return 0, 0, nil
+	}
+
+	for i, env := range envs {
+		if env == nil {
+			return 0, 0, fmt.Errorf("ingest: envelope at index %d is nil", i)
+		}
+		if env.ID != uuid.Nil {
+			return 0, 0, fmt.Errorf(
+				"ingest: envelope at index %d has a pre-assigned ID; IngestBatch "+
+					"requires ID=uuid.Nil so the duplicate sentinel works", i)
+		}
 	}
 
 	tx, err := s.database.Pool.Begin(ctx)

--- a/backend/internal/service/ingest.go
+++ b/backend/internal/service/ingest.go
@@ -1,0 +1,93 @@
+// Package service provides business-logic wrappers around repositories.
+// IngestService owns the single-tx batch-publish semantics for the HTTP
+// ingestion endpoint introduced in PR 4 of the event-bus-foundation spec.
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// IngestService persists pre-validated event envelopes inside a single
+// transaction. All envelopes in a batch commit together or roll back
+// together — spec §3.5 "all-or-nothing on unexpected errors."
+//
+// Duplicates (ON CONFLICT hits on the (source, source_id) partial unique
+// index) are silent no-ops inside Bus.PublishTx and do NOT abort the tx;
+// they're counted separately via the env.ID-sentinel pattern (see
+// IngestBatch docs).
+type IngestService struct {
+	database *db.Database
+	bus      *events.Bus
+}
+
+// NewIngestService builds an IngestService. database.Pool is used to open
+// the batch transaction; bus.PublishTx does the per-envelope insert.
+func NewIngestService(database *db.Database, bus *events.Bus) *IngestService {
+	return &IngestService{database: database, bus: bus}
+}
+
+// IngestBatch persists envs in one pgx transaction. Returns (accepted,
+// duplicate, err):
+//
+//   - accepted: number of envelopes whose INSERT produced a fresh row.
+//   - duplicate: number of envelopes whose INSERT hit the (source,
+//     source_id) unique index and was silently dropped by the ON CONFLICT
+//     DO NOTHING clause.
+//   - err: any unexpected failure (begin-tx, publish-tx mid-batch, commit).
+//     The whole tx rolls back in this case; both counters are zero on
+//     error return.
+//
+// The empty-slice case is handled without opening a transaction (trivial
+// optimization).
+//
+// Duplicate detection relies on Bus.PublishTx returning nil for both
+// happy-path inserts and ON CONFLICT DO NOTHING hits. The repository
+// populates env.ID only on a real RETURNING row, so env.ID == uuid.Nil is
+// the duplicate sentinel. See PR 2 plan Design Decision 2 for the
+// documented contract this depends on.
+func (s *IngestService) IngestBatch(ctx context.Context, envs []*events.Envelope) (accepted, duplicate int, err error) {
+	if len(envs) == 0 {
+		return 0, 0, nil
+	}
+
+	tx, err := s.database.Pool.Begin(ctx)
+	if err != nil {
+		return 0, 0, fmt.Errorf("begin tx: %w", err)
+	}
+	// Rollback on any non-commit return. Safe to call after Commit: pgx
+	// returns ErrTxClosed which we ignore. If rollback itself fails and no
+	// prior error has been recorded, surface it.
+	defer func() {
+		if rollbackErr := tx.Rollback(ctx); rollbackErr != nil &&
+			!errors.Is(rollbackErr, pgx.ErrTxClosed) && err == nil {
+			err = fmt.Errorf("rollback: %w", rollbackErr)
+		}
+	}()
+
+	for i, env := range envs {
+		if pubErr := s.bus.PublishTx(ctx, tx, env); pubErr != nil {
+			return 0, 0, fmt.Errorf("publish event index %d: %w", i, pubErr)
+		}
+		// env.ID is populated iff the INSERT produced a row. On ON CONFLICT
+		// DO NOTHING (dup (source, source_id)) the repository returns nil
+		// without mutating env.ID, leaving it at uuid.Nil.
+		if env.ID == uuid.Nil {
+			duplicate++
+		} else {
+			accepted++
+		}
+	}
+
+	if commitErr := tx.Commit(ctx); commitErr != nil {
+		return 0, 0, fmt.Errorf("commit: %w", commitErr)
+	}
+	return accepted, duplicate, nil
+}

--- a/backend/internal/service/ingest_test.go
+++ b/backend/internal/service/ingest_test.go
@@ -1,0 +1,28 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"personal-crm/backend/internal/events"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestIngestService_EmptyBatch_FastPath ensures the empty-slice case does
+// NOT open a transaction — it returns (0, 0, nil) immediately. Passing a
+// nil database + nil bus would panic if the code tried to Begin on the
+// pool, so the test proves the short-circuit works.
+func TestIngestService_EmptyBatch_FastPath(t *testing.T) {
+	svc := &IngestService{} // no DB, no bus — fast path must not touch them
+	accepted, duplicate, err := svc.IngestBatch(context.Background(), nil)
+	require.NoError(t, err)
+	require.Equal(t, 0, accepted)
+	require.Equal(t, 0, duplicate)
+
+	// Same for an explicit zero-length slice.
+	accepted, duplicate, err = svc.IngestBatch(context.Background(), []*events.Envelope{})
+	require.NoError(t, err)
+	require.Equal(t, 0, accepted)
+	require.Equal(t, 0, duplicate)
+}

--- a/backend/internal/service/ingest_test.go
+++ b/backend/internal/service/ingest_test.go
@@ -6,6 +6,7 @@ import (
 
 	"personal-crm/backend/internal/events"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,4 +26,27 @@ func TestIngestService_EmptyBatch_FastPath(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 0, accepted)
 	require.Equal(t, 0, duplicate)
+}
+
+// TestIngestService_RejectsNilEnvelope guards against a caller bug where
+// an envelope slot is nil. Surface a caller error rather than panicking
+// inside the publish loop once a transaction is open.
+func TestIngestService_RejectsNilEnvelope(t *testing.T) {
+	svc := &IngestService{} // precondition check fires before DB access
+	_, _, err := svc.IngestBatch(context.Background(), []*events.Envelope{nil})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "envelope at index 0 is nil")
+}
+
+// TestIngestService_RejectsPreAssignedID guards the fragile env.ID
+// sentinel contract: callers MUST hand in uuid.Nil envelopes so the
+// service can count duplicates correctly. A non-zero ID on entry would
+// cause a duplicate to look accepted. Surface it as a caller bug at the
+// service boundary.
+func TestIngestService_RejectsPreAssignedID(t *testing.T) {
+	svc := &IngestService{} // precondition check fires before DB access
+	env := &events.Envelope{ID: uuid.New()}
+	_, _, err := svc.IngestBatch(context.Background(), []*events.Envelope{env})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "pre-assigned ID")
 }

--- a/backend/tests/api/ingest_test.go
+++ b/backend/tests/api/ingest_test.go
@@ -1,0 +1,663 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/api"
+	"personal-crm/backend/internal/api/handlers"
+	"personal-crm/backend/internal/auth"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/stretchr/testify/require"
+)
+
+// ingestTestAPIKey is the fixed key tests send in X-API-Key. TestConfig
+// leaves External.APIKey empty; we override to this value and assert
+// authentication against it.
+const ingestTestAPIKey = "test-ingest-api-key"
+
+// ingestTestNoopArgs satisfies river's "at least one worker" requirement.
+// No job is enqueued at this kind — PR 4 only publishes events; consumer
+// jobs arrive in PR 5+.
+type ingestTestNoopArgs struct{}
+
+func (ingestTestNoopArgs) Kind() string { return "ingest_test_noop" }
+
+type ingestTestNoopWorker struct {
+	river.WorkerDefaults[ingestTestNoopArgs]
+}
+
+func (*ingestTestNoopWorker) Work(_ context.Context, _ *river.Job[ingestTestNoopArgs]) error {
+	return nil
+}
+
+// ingestTestSetup bundles the router + deps returned by setupIngestTestRouter.
+// Exposed fields let subtests interact with the DB directly (e.g., for
+// counting rows persisted for a given source).
+type ingestTestSetup struct {
+	router     *gin.Engine
+	apiKey     string
+	eventRepo  *repository.EventRepository
+	database   *db.Database
+	ctx        context.Context
+	busFactory func(repo events.EventRepository) *events.Bus // for mid-tx-rollback test
+}
+
+// setupIngestTestRouter builds a full router with real DB, real river, real
+// Bus, real IngestService + IngestHandler, and conditional route
+// registration based on enableIngest. Returns a cleanup closure registered
+// via t.Cleanup so callers don't need to defer anything.
+func setupIngestTestRouter(t *testing.T, enableIngest bool) *ingestTestSetup {
+	t.Helper()
+
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	ctx := context.Background()
+	migrationsPath := getMigrationsPath()
+	require.NoError(t, db.RunMigrations(ctx, databaseURL, migrationsPath))
+
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+	cfg.Database.MigrationsPath = migrationsPath
+	cfg.External.APIKey = ingestTestAPIKey
+	cfg.Features.EnableEventBusIngest = enableIngest
+
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	t.Cleanup(func() { database.Close() })
+
+	// River client (TestOnly skips leader election / periodic loops).
+	workers := river.NewWorkers()
+	river.AddWorker(workers, &ingestTestNoopWorker{})
+	client, err := river.NewClient(riverpgxv5.New(database.Pool), &river.Config{
+		Queues: map[string]river.QueueConfig{
+			river.QueueDefault: {MaxWorkers: cfg.River.WorkerConcurrency},
+		},
+		Workers:  workers,
+		TestOnly: true,
+	})
+	require.NoError(t, err)
+	startCtx, startCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer startCancel()
+	require.NoError(t, client.Start(startCtx))
+	t.Cleanup(func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer stopCancel()
+		_ = client.Stop(stopCtx)
+	})
+
+	eventRepo := repository.NewEventRepository(database.Queries)
+	busFactory := func(repo events.EventRepository) *events.Bus {
+		return events.NewBus(database.Pool, client, repo)
+	}
+	eventBus := busFactory(eventRepo)
+	ingestService := service.NewIngestService(database, eventBus)
+	ingestHandler := handlers.NewIngestHandler(ingestService)
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(api.RequestIDMiddleware())
+	router.Use(api.LoggingMiddleware())
+	router.Use(api.CORSMiddleware(cfg.CORS))
+	router.Use(api.ErrorHandlerMiddleware())
+
+	v1 := router.Group("/api/v1")
+	v1.Use(auth.APIKeyMiddleware(cfg))
+	{
+		if enableIngest {
+			ingest := v1.Group("/ingest")
+			{
+				ingest.POST("/events", ingestHandler.IngestEvents)
+			}
+		}
+	}
+
+	return &ingestTestSetup{
+		router:     router,
+		apiKey:     cfg.External.APIKey,
+		eventRepo:  eventRepo,
+		database:   database,
+		ctx:        ctx,
+		busFactory: busFactory,
+	}
+}
+
+// postIngest POSTs a JSON body to /api/v1/ingest/events with the given
+// API key header. Returns the recorder for assertion.
+func postIngest(t *testing.T, router *gin.Engine, apiKey string, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/ingest/events", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	if apiKey != "" {
+		req.Header.Set("X-API-Key", apiKey)
+	}
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func jsonBody(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return b
+}
+
+// buildManualEventReq builds a valid interaction.manual ingest request body.
+// source/sourceID are caller-supplied to ensure per-test uniqueness under
+// the shared DB.
+func buildManualEventReq(t *testing.T, source, sourceID string) handlers.IngestEventRequest {
+	t.Helper()
+	observed := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+	payload, err := events.Marshal(events.KindInteractionManual, events.InteractionManualPayload{
+		Version:    1,
+		ContactID:  uuid.New(),
+		Direction:  "mutual",
+		OccurredAt: observed,
+	})
+	require.NoError(t, err)
+	return handlers.IngestEventRequest{
+		Source:     source,
+		SourceID:   sourceID,
+		Kind:       string(events.KindInteractionManual),
+		Payload:    payload,
+		ObservedAt: observed,
+	}
+}
+
+// uniqueIngestSource builds a per-subtest unique source name so tests on
+// the shared DB don't observe each other's rows via CountBySource.
+func uniqueIngestSource(prefix string) string {
+	return prefix + "-" + uuid.NewString()
+}
+
+func TestIngest_ValidBatch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	setup := setupIngestTestRouter(t, true)
+
+	source := uniqueIngestSource("valid-batch")
+	batch := handlers.IngestBatchRequest{
+		Events: []handlers.IngestEventRequest{
+			buildManualEventReq(t, source, uuid.NewString()),
+			buildManualEventReq(t, source, uuid.NewString()),
+			buildManualEventReq(t, source, uuid.NewString()),
+		},
+	}
+
+	w := postIngest(t, setup.router, setup.apiKey, jsonBody(t, batch))
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	var resp handlers.IngestResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, 3, resp.Accepted)
+	require.Equal(t, 0, resp.Duplicate)
+	require.Equal(t, 0, resp.Rejected)
+	require.NotNil(t, resp.Errors)
+	require.Len(t, resp.Errors, 0)
+
+	count, err := setup.eventRepo.CountBySource(setup.ctx, source)
+	require.NoError(t, err)
+	require.Equal(t, int64(3), count)
+}
+
+func TestIngest_AuthFailure_MissingKey(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	setup := setupIngestTestRouter(t, true)
+	batch := handlers.IngestBatchRequest{
+		Events: []handlers.IngestEventRequest{
+			buildManualEventReq(t, uniqueIngestSource("auth-missing"), uuid.NewString()),
+		},
+	}
+	w := postIngest(t, setup.router, "", jsonBody(t, batch))
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+	require.Contains(t, w.Body.String(), "MISSING_API_KEY")
+}
+
+func TestIngest_AuthFailure_InvalidKey(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	setup := setupIngestTestRouter(t, true)
+	batch := handlers.IngestBatchRequest{
+		Events: []handlers.IngestEventRequest{
+			buildManualEventReq(t, uniqueIngestSource("auth-invalid"), uuid.NewString()),
+		},
+	}
+	w := postIngest(t, setup.router, "wrong-key", jsonBody(t, batch))
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+	require.Contains(t, w.Body.String(), "INVALID_API_KEY")
+}
+
+func TestIngest_MalformedJSON(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	setup := setupIngestTestRouter(t, true)
+	w := postIngest(t, setup.router, setup.apiKey, []byte("{not json"))
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestIngest_MissingFields(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	setup := setupIngestTestRouter(t, true)
+
+	// Build one valid event + one with an empty source (post-bind check) +
+	// one with a zero observed_at (post-bind check). The top-level JSON
+	// body must be valid so gin's bind doesn't reject the whole request;
+	// per-event validation produces IngestError entries.
+	//
+	// Note: `binding:"required"` on source / kind rejects the whole POST
+	// if source or kind is "" at the wire level, so to get individual
+	// rejections we build the raw JSON ourselves where those fields are
+	// missing / zero-time.
+	source := uniqueIngestSource("missing-fields")
+	valid := buildManualEventReq(t, source, uuid.NewString())
+	rawValid := jsonBody(t, valid)
+
+	// Build a raw JSON body where event[0] is valid, event[1] has zero
+	// observed_at (passes binding but IsZero() rejects), event[2] has
+	// missing payload (rejected as MISSING_FIELD). gin's binding:"required"
+	// on Source/Kind would reject the whole batch, so we only test
+	// post-bind checks here.
+	zeroTimeEv := fmt.Sprintf(`{"source":%q,"source_id":%q,"kind":%q,"payload":%s,"observed_at":"0001-01-01T00:00:00Z"}`,
+		source, uuid.NewString(), string(events.KindInteractionManual), string(valid.Payload))
+
+	body := []byte(`{"events":[` + string(rawValid) + `,` + zeroTimeEv + `]}`)
+
+	w := postIngest(t, setup.router, setup.apiKey, body)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	var resp handlers.IngestResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, 1, resp.Accepted)
+	require.Equal(t, 1, resp.Rejected)
+	require.Len(t, resp.Errors, 1)
+	require.Equal(t, 1, resp.Errors[0].Index)
+	require.Equal(t, "MISSING_FIELD", resp.Errors[0].Code)
+	require.Contains(t, resp.Errors[0].Message, "observed_at")
+}
+
+func TestIngest_UnknownKind(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	setup := setupIngestTestRouter(t, true)
+	source := uniqueIngestSource("unknown-kind")
+
+	valid := buildManualEventReq(t, source, uuid.NewString())
+	unknown := buildManualEventReq(t, source, uuid.NewString())
+	unknown.Kind = "nope.kind"
+
+	batch := handlers.IngestBatchRequest{
+		Events: []handlers.IngestEventRequest{valid, unknown},
+	}
+	w := postIngest(t, setup.router, setup.apiKey, jsonBody(t, batch))
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	var resp handlers.IngestResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, 1, resp.Accepted)
+	require.Equal(t, 1, resp.Rejected)
+	require.Len(t, resp.Errors, 1)
+	require.Equal(t, 1, resp.Errors[0].Index)
+	require.Equal(t, "UNKNOWN_KIND", resp.Errors[0].Code)
+}
+
+func TestIngest_PayloadStructurallyInvalid(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	setup := setupIngestTestRouter(t, true)
+	source := uniqueIngestSource("payload-invalid")
+
+	// Use KindCalendarAttended: ContactID is uuid.UUID. Send a raw payload
+	// with contact_id="not-a-uuid" — JSON decoder rejects with
+	// UnmarshalTypeError, which ValidatePayload wraps.
+	badPayload := json.RawMessage(`{"version":1,"contact_id":"not-a-uuid","event_id":"e","occurred_at":"2026-04-10T12:00:00Z"}`)
+	bad := handlers.IngestEventRequest{
+		Source:     source,
+		SourceID:   uuid.NewString(),
+		Kind:       string(events.KindCalendarAttended),
+		Payload:    badPayload,
+		ObservedAt: time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC),
+	}
+	batch := handlers.IngestBatchRequest{Events: []handlers.IngestEventRequest{bad}}
+	w := postIngest(t, setup.router, setup.apiKey, jsonBody(t, batch))
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	var resp handlers.IngestResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, 0, resp.Accepted)
+	require.Equal(t, 1, resp.Rejected)
+	require.Len(t, resp.Errors, 1)
+	require.Equal(t, "PAYLOAD_INVALID", resp.Errors[0].Code)
+}
+
+func TestIngest_BatchTooLarge(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	setup := setupIngestTestRouter(t, true)
+
+	// 501 events, each tiny. The batch-size check runs pre-validation so
+	// payloads don't need to be valid for this specific test.
+	source := uniqueIngestSource("batch-too-large")
+	evs := make([]handlers.IngestEventRequest, 501)
+	for i := range evs {
+		evs[i] = buildManualEventReq(t, source, uuid.NewString())
+	}
+	batch := handlers.IngestBatchRequest{Events: evs}
+	w := postIngest(t, setup.router, setup.apiKey, jsonBody(t, batch))
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "VALIDATION_ERROR")
+}
+
+func TestIngest_EmptyBatch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	setup := setupIngestTestRouter(t, true)
+
+	// binding:"required" on Events []IngestEventRequest flags nil/missing.
+	// We're testing the explicit empty-array case, which passes bind.
+	body := []byte(`{"events":[]}`)
+	w := postIngest(t, setup.router, setup.apiKey, body)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "events must be non-empty")
+}
+
+func TestIngest_DuplicateInBatch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	setup := setupIngestTestRouter(t, true)
+
+	source := uniqueIngestSource("dup-in-batch")
+	sourceID := uuid.NewString()
+	first := buildManualEventReq(t, source, sourceID)
+	second := buildManualEventReq(t, source, sourceID) // same (source, source_id)
+	batch := handlers.IngestBatchRequest{
+		Events: []handlers.IngestEventRequest{first, second},
+	}
+	w := postIngest(t, setup.router, setup.apiKey, jsonBody(t, batch))
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	var resp handlers.IngestResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, 1, resp.Accepted)
+	require.Equal(t, 1, resp.Duplicate)
+	require.Equal(t, 0, resp.Rejected)
+
+	count, err := setup.eventRepo.CountBySource(setup.ctx, source)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), count)
+}
+
+func TestIngest_DuplicateAcrossBatches(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	setup := setupIngestTestRouter(t, true)
+
+	source := uniqueIngestSource("dup-across")
+	sourceID := uuid.NewString()
+	ev := buildManualEventReq(t, source, sourceID)
+
+	// First request: accepted.
+	w1 := postIngest(t, setup.router, setup.apiKey, jsonBody(t, handlers.IngestBatchRequest{
+		Events: []handlers.IngestEventRequest{ev},
+	}))
+	require.Equal(t, http.StatusOK, w1.Code)
+	var r1 handlers.IngestResponse
+	require.NoError(t, json.Unmarshal(w1.Body.Bytes(), &r1))
+	require.Equal(t, 1, r1.Accepted)
+	require.Equal(t, 0, r1.Duplicate)
+
+	// Second request: duplicate.
+	w2 := postIngest(t, setup.router, setup.apiKey, jsonBody(t, handlers.IngestBatchRequest{
+		Events: []handlers.IngestEventRequest{ev},
+	}))
+	require.Equal(t, http.StatusOK, w2.Code)
+	var r2 handlers.IngestResponse
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &r2))
+	require.Equal(t, 0, r2.Accepted)
+	require.Equal(t, 1, r2.Duplicate)
+
+	count, err := setup.eventRepo.CountBySource(setup.ctx, source)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), count)
+}
+
+// TestIngest_NullSourceID_NotDeduped covers the partial-index semantics:
+// migration 036 creates the unique index WHERE source_id IS NOT NULL, so
+// NULL source_ids never collide. Two events with empty source_id submitted
+// as two separate requests both insert.
+func TestIngest_NullSourceID_NotDeduped(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	setup := setupIngestTestRouter(t, true)
+
+	source := uniqueIngestSource("null-sid")
+	ev1 := buildManualEventReq(t, source, "") // empty → NULL at DB
+	ev2 := buildManualEventReq(t, source, "")
+
+	w1 := postIngest(t, setup.router, setup.apiKey, jsonBody(t, handlers.IngestBatchRequest{
+		Events: []handlers.IngestEventRequest{ev1},
+	}))
+	require.Equal(t, http.StatusOK, w1.Code)
+	w2 := postIngest(t, setup.router, setup.apiKey, jsonBody(t, handlers.IngestBatchRequest{
+		Events: []handlers.IngestEventRequest{ev2},
+	}))
+	require.Equal(t, http.StatusOK, w2.Code)
+
+	var r2 handlers.IngestResponse
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &r2))
+	require.Equal(t, 1, r2.Accepted, "NULL source_id must not trip the unique index")
+
+	count, err := setup.eventRepo.CountBySource(setup.ctx, source)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), count)
+}
+
+// TestIngest_GateDisabled_Returns404 exercises the spec acceptance
+// criterion: EVENT_BUS_INGEST_ENABLED=false → 404. The route is not
+// registered; gin's default NoRoute handler emits 404 without running the
+// v1 group's API-key middleware.
+func TestIngest_GateDisabled_Returns404(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	setup := setupIngestTestRouter(t, false)
+	batch := handlers.IngestBatchRequest{
+		Events: []handlers.IngestEventRequest{
+			buildManualEventReq(t, uniqueIngestSource("gate-off"), uuid.NewString()),
+		},
+	}
+	w := postIngest(t, setup.router, setup.apiKey, jsonBody(t, batch))
+	require.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestIngest_GateDisabled_NoKey_StillReturns404 pins down plan Decision 1:
+// the flag-off + no-key case returns 404, NOT 401. An unregistered route
+// bypasses the v1 group's middleware chain entirely.
+func TestIngest_GateDisabled_NoKey_StillReturns404(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	setup := setupIngestTestRouter(t, false)
+	body := []byte(`{"events":[]}`)
+	w := postIngest(t, setup.router, "", body)
+	require.Equal(t, http.StatusNotFound, w.Code)
+	// Ensure the auth-middleware's MISSING_API_KEY error envelope is NOT
+	// present — proves no middleware ran.
+	require.NotContains(t, w.Body.String(), "MISSING_API_KEY")
+}
+
+func TestIngest_MixedBatch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	setup := setupIngestTestRouter(t, true)
+
+	source := uniqueIngestSource("mixed")
+	dupSourceID := uuid.NewString()
+
+	// 4 valid events (distinct source_ids) + 1 unknown-kind + 1
+	// duplicate-of-first-valid. Expected: accepted=4, duplicate=1,
+	// rejected=1.
+	ev0 := buildManualEventReq(t, source, dupSourceID)
+	ev1 := buildManualEventReq(t, source, uuid.NewString())
+	ev2 := buildManualEventReq(t, source, uuid.NewString())
+	ev3 := buildManualEventReq(t, source, uuid.NewString())
+	evBad := buildManualEventReq(t, source, uuid.NewString())
+	evBad.Kind = "nope.kind"                             // rejected pre-tx
+	evDup := buildManualEventReq(t, source, dupSourceID) // duplicates ev0
+
+	batch := handlers.IngestBatchRequest{
+		Events: []handlers.IngestEventRequest{ev0, ev1, ev2, ev3, evBad, evDup},
+	}
+	w := postIngest(t, setup.router, setup.apiKey, jsonBody(t, batch))
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	var resp handlers.IngestResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, 4, resp.Accepted)
+	require.Equal(t, 1, resp.Duplicate)
+	require.Equal(t, 1, resp.Rejected)
+	require.Len(t, resp.Errors, 1)
+	require.Equal(t, 4, resp.Errors[0].Index) // index of evBad in the original batch
+	require.Equal(t, 6, resp.Accepted+resp.Duplicate+resp.Rejected)
+
+	count, err := setup.eventRepo.CountBySource(setup.ctx, source)
+	require.NoError(t, err)
+	require.Equal(t, int64(4), count)
+}
+
+// TestIngest_BodyTooLarge_Returns413 posts a body exceeding the 8 MiB cap.
+// The cheapest way is one event with an oversized payload. The
+// per-payload size check would also reject this but the MaxBytesReader
+// wrap at the handler boundary fires first because it's enforced during
+// JSON decode, before any per-field validation runs.
+func TestIngest_BodyTooLarge_Returns413(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	setup := setupIngestTestRouter(t, true)
+
+	// Build a body > 8 MiB: an events array containing a single event with
+	// a ~9 MiB string payload. The raw body doesn't need to be valid JSON
+	// for a real event — the 413 path fires before validation.
+	big := strings.Repeat("x", 9<<20)
+	raw := fmt.Sprintf(`{"events":[{"source":"x","kind":"interaction.manual","payload":{"v":%q},"observed_at":"2026-04-10T12:00:00Z"}]}`, big)
+	w := postIngest(t, setup.router, setup.apiKey, []byte(raw))
+	require.Equal(t, http.StatusRequestEntityTooLarge, w.Code, "body: %s", w.Body.String())
+}
+
+// failingRepo is a test double that wraps a real EventRepository and fails
+// InsertEvent on the Nth call. Used to exercise the mid-tx rollback
+// contract: a service-level error must roll back the WHOLE batch, not
+// just the failing event.
+type failingRepo struct {
+	inner   events.EventRepository
+	failOn  int
+	callCnt int
+	fireCnt int // how many times the failure actually triggered
+}
+
+func (f *failingRepo) InsertEvent(ctx context.Context, tx pgx.Tx, env *events.Envelope) error {
+	f.callCnt++
+	if f.callCnt == f.failOn {
+		f.fireCnt++
+		return fmt.Errorf("injected failure at call %d", f.callCnt)
+	}
+	return f.inner.InsertEvent(ctx, tx, env)
+}
+
+func (f *failingRepo) GetEvent(ctx context.Context, id uuid.UUID) (*events.Envelope, error) {
+	return f.inner.GetEvent(ctx, id)
+}
+
+func (f *failingRepo) FindEventBySource(ctx context.Context, source, sourceID string) (*events.Envelope, error) {
+	return f.inner.FindEventBySource(ctx, source, sourceID)
+}
+
+// TestIngest_MidTxRollback_RollsBack_And_Returns500 exercises the spec §3.5
+// atomicity contract: on an unexpected mid-batch failure, the whole tx
+// rolls back and NO rows are persisted. A fake EventRepository wraps the
+// real one and fails on its 3rd InsertEvent; a 5-event batch is posted
+// and we assert zero rows landed in the event table for this batch's
+// source prefix.
+func TestIngest_MidTxRollback_RollsBack_And_Returns500(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	setup := setupIngestTestRouter(t, true)
+
+	// Wire a new handler over a failing repo, mounted on a fresh router
+	// so the rest of the suite isn't affected.
+	fake := &failingRepo{inner: setup.eventRepo, failOn: 3}
+	bus := setup.busFactory(fake)
+	ingestService := service.NewIngestService(setup.database, bus)
+	handler := handlers.NewIngestHandler(ingestService)
+
+	cfg := config.TestConfig()
+	cfg.External.APIKey = setup.apiKey
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(api.RequestIDMiddleware())
+	router.Use(api.LoggingMiddleware())
+	router.Use(api.CORSMiddleware(cfg.CORS))
+	router.Use(api.ErrorHandlerMiddleware())
+	v1 := router.Group("/api/v1")
+	v1.Use(auth.APIKeyMiddleware(cfg))
+	{
+		v1.POST("/ingest/events", handler.IngestEvents)
+	}
+
+	source := uniqueIngestSource("midtx-rollback")
+	evs := make([]handlers.IngestEventRequest, 5)
+	for i := range evs {
+		evs[i] = buildManualEventReq(t, source, uuid.NewString())
+	}
+	batch := handlers.IngestBatchRequest{Events: evs}
+	w := postIngest(t, router, setup.apiKey, jsonBody(t, batch))
+	require.Equal(t, http.StatusInternalServerError, w.Code, "body: %s", w.Body.String())
+	require.Contains(t, w.Body.String(), "INTERNAL_ERROR")
+
+	// Sanity: the failure actually fired.
+	require.Equal(t, 1, fake.fireCnt, "injected failure should have triggered once")
+
+	// Atomicity: zero rows persisted for this batch's source prefix.
+	count, err := setup.eventRepo.CountBySource(setup.ctx, source)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), count,
+		"spec §3.5: all-or-nothing on unexpected errors — no rows must persist")
+}

--- a/backend/tests/api/ingest_test.go
+++ b/backend/tests/api/ingest_test.go
@@ -182,7 +182,7 @@ func buildManualEventReq(t *testing.T, source, sourceID string) handlers.IngestE
 		SourceID:   sourceID,
 		Kind:       string(events.KindInteractionManual),
 		Payload:    payload,
-		ObservedAt: observed,
+		ObservedAt: &observed,
 	}
 }
 
@@ -262,34 +262,44 @@ func TestIngest_MalformedJSON(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, w.Code)
 }
 
+// TestIngest_MissingFields exercises spec §3.5's "batch continues" rule:
+// a mixed batch where events are missing source / kind / payload /
+// observed_at must return HTTP 200 with those events surfaced in
+// errors[] — NOT 400'd wholesale at gin's bind step.
 func TestIngest_MissingFields(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
 	setup := setupIngestTestRouter(t, true)
 
-	// Build one valid event + one with an empty source (post-bind check) +
-	// one with a zero observed_at (post-bind check). The top-level JSON
-	// body must be valid so gin's bind doesn't reject the whole request;
-	// per-event validation produces IngestError entries.
-	//
-	// Note: `binding:"required"` on source / kind rejects the whole POST
-	// if source or kind is "" at the wire level, so to get individual
-	// rejections we build the raw JSON ourselves where those fields are
-	// missing / zero-time.
 	source := uniqueIngestSource("missing-fields")
 	valid := buildManualEventReq(t, source, uuid.NewString())
 	rawValid := jsonBody(t, valid)
 
-	// Build a raw JSON body where event[0] is valid, event[1] has zero
-	// observed_at (passes binding but IsZero() rejects), event[2] has
-	// missing payload (rejected as MISSING_FIELD). gin's binding:"required"
-	// on Source/Kind would reject the whole batch, so we only test
-	// post-bind checks here.
+	// Construct raw JSON events that each violate a single required field.
+	// index=0: valid.
+	// index=1: observed_at is the zero-time (serializable as a literal RFC3339).
+	// index=2: source is absent.
+	// index=3: kind is absent.
+	// index=4: payload is absent.
+	// index=5: observed_at key absent entirely.
 	zeroTimeEv := fmt.Sprintf(`{"source":%q,"source_id":%q,"kind":%q,"payload":%s,"observed_at":"0001-01-01T00:00:00Z"}`,
 		source, uuid.NewString(), string(events.KindInteractionManual), string(valid.Payload))
+	missingSource := fmt.Sprintf(`{"source_id":%q,"kind":%q,"payload":%s,"observed_at":"2026-04-10T12:00:00Z"}`,
+		uuid.NewString(), string(events.KindInteractionManual), string(valid.Payload))
+	missingKind := fmt.Sprintf(`{"source":%q,"source_id":%q,"payload":%s,"observed_at":"2026-04-10T12:00:00Z"}`,
+		source, uuid.NewString(), string(valid.Payload))
+	missingPayload := fmt.Sprintf(`{"source":%q,"source_id":%q,"kind":%q,"observed_at":"2026-04-10T12:00:00Z"}`,
+		source, uuid.NewString(), string(events.KindInteractionManual))
+	missingObservedAt := fmt.Sprintf(`{"source":%q,"source_id":%q,"kind":%q,"payload":%s}`,
+		source, uuid.NewString(), string(events.KindInteractionManual), string(valid.Payload))
 
-	body := []byte(`{"events":[` + string(rawValid) + `,` + zeroTimeEv + `]}`)
+	body := []byte(`{"events":[` + string(rawValid) + `,` +
+		zeroTimeEv + `,` +
+		missingSource + `,` +
+		missingKind + `,` +
+		missingPayload + `,` +
+		missingObservedAt + `]}`)
 
 	w := postIngest(t, setup.router, setup.apiKey, body)
 	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
@@ -297,11 +307,63 @@ func TestIngest_MissingFields(t *testing.T) {
 	var resp handlers.IngestResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	require.Equal(t, 1, resp.Accepted)
+	require.Equal(t, 5, resp.Rejected)
+	require.Len(t, resp.Errors, 5)
+
+	// Every per-event rejection should be coded MISSING_FIELD.
+	indexes := map[int]string{}
+	for _, e := range resp.Errors {
+		require.Equal(t, "MISSING_FIELD", e.Code)
+		indexes[e.Index] = e.Message
+	}
+	require.Contains(t, indexes, 1)
+	require.Contains(t, indexes[1], "observed_at")
+	require.Contains(t, indexes, 2)
+	require.Contains(t, indexes[2], "source")
+	require.Contains(t, indexes, 3)
+	require.Contains(t, indexes[3], "kind")
+	require.Contains(t, indexes, 4)
+	require.Contains(t, indexes[4], "payload")
+	require.Contains(t, indexes, 5)
+	require.Contains(t, indexes[5], "observed_at")
+
+	// The valid event at index 0 persisted.
+	count, err := setup.eventRepo.CountBySource(setup.ctx, source)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), count)
+}
+
+// TestIngest_NullPayload covers the `payload: null` case: stdlib json
+// would silently decode null into a zero-value struct, so the ingest
+// boundary must reject it as PAYLOAD_INVALID rather than persist a row
+// with all-zero payload fields.
+func TestIngest_NullPayload(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	setup := setupIngestTestRouter(t, true)
+	source := uniqueIngestSource("null-payload")
+	nullEv := fmt.Sprintf(`{"source":%q,"source_id":%q,"kind":%q,"payload":null,"observed_at":"2026-04-10T12:00:00Z"}`,
+		source, uuid.NewString(), string(events.KindInteractionManual))
+	body := []byte(`{"events":[` + nullEv + `]}`)
+
+	w := postIngest(t, setup.router, setup.apiKey, body)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	var resp handlers.IngestResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, 0, resp.Accepted)
 	require.Equal(t, 1, resp.Rejected)
+	// Null payload is caught by the per-event validator — either via
+	// the "payload is required" path (RawMessage is nil on `null`) or
+	// via ValidatePayload's null-rejection.
 	require.Len(t, resp.Errors, 1)
-	require.Equal(t, 1, resp.Errors[0].Index)
-	require.Equal(t, "MISSING_FIELD", resp.Errors[0].Code)
-	require.Contains(t, resp.Errors[0].Message, "observed_at")
+	require.Contains(t, []string{"MISSING_FIELD", "PAYLOAD_INVALID"}, resp.Errors[0].Code)
+
+	// Confirm nothing was persisted.
+	count, err := setup.eventRepo.CountBySource(setup.ctx, source)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), count)
 }
 
 func TestIngest_UnknownKind(t *testing.T) {
@@ -341,12 +403,13 @@ func TestIngest_PayloadStructurallyInvalid(t *testing.T) {
 	// with contact_id="not-a-uuid" — JSON decoder rejects with
 	// UnmarshalTypeError, which ValidatePayload wraps.
 	badPayload := json.RawMessage(`{"version":1,"contact_id":"not-a-uuid","event_id":"e","occurred_at":"2026-04-10T12:00:00Z"}`)
+	observed := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
 	bad := handlers.IngestEventRequest{
 		Source:     source,
 		SourceID:   uuid.NewString(),
 		Kind:       string(events.KindCalendarAttended),
 		Payload:    badPayload,
-		ObservedAt: time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC),
+		ObservedAt: &observed,
 	}
 	batch := handlers.IngestBatchRequest{Events: []handlers.IngestEventRequest{bad}}
 	w := postIngest(t, setup.router, setup.apiKey, jsonBody(t, batch))


### PR DESCRIPTION
## Summary

PR 4 of 12 in the event-bus-foundation sequence (spec: `.ai/spec/event-bus-foundation.md`; parent: #180). Adds the single external-daemon ingestion surface on top of PRs 1 (river client, #279) and 2 (event table + `events.Bus.PublishTx`, #280) — both already on `main`.

- `POST /api/v1/ingest/events` accepts batched events, validates each pre-tx, and persists the whole batch in a single `pgx.Tx` via `Bus.PublishTx`. Duplicates ((source, source_id) hits) are silent no-ops and counted separately.
- Response shape matches the spec literally: `{ "accepted": N, "duplicate": N, "rejected": N, "errors": [...] }`. Per-event rejections flow into `errors[]` with an index + code + message — the batch continues.
- Route registration is gated by `EVENT_BUS_INGEST_ENABLED` (default `false`); when the flag is off the route is never registered, so gin returns 404 without invoking the API-key middleware. That matches the spec's acceptance criterion.
- 8 MiB body cap via `http.MaxBytesReader`; 64 KiB per-event payload guard; 500-event batch ceiling.

## Key design calls

- **`IngestService` owns the tx.** Handler → Service → Bus → Repository. The handler never touches `pgx.Tx` directly.
- **Gating by route registration, not handler short-circuit.** Plan Decision 1: unregistered routes bypass the v1 group's middleware, so `flag=off, no key → 404` (integration test `TestIngest_GateDisabled_NoKey_StillReturns404` locks this in).
- **`ValidatePayload` helper in the `events` package** — reflection-based validate-only decode so the HTTP handler can check payload shape without compile-time knowledge of the kind's canonical type P. Forward-compat on unknown fields per spec §3.2; rejects a literal JSON `null` payload so zero-value structs can't slip through.
- **Spec-literal response shape** (not wrapped in `api.APIResponse`). External daemons are contract consumers; the wrapping layer would be a spec deviation. Error responses (400/401/413/500) still use the standard envelope.
- **Duplicate detection via `env.ID == uuid.Nil` sentinel.** `IngestService.IngestBatch` defensively rejects pre-assigned IDs so the sentinel contract is visible at the service boundary.

## Test plan

- [x] `go test ./internal/events ./internal/service ./internal/config` — unit tests pass (validation helpers, null-payload rejection, nil-envelope/pre-assigned-ID preconditions)
- [x] `DATABASE_URL=... go test ./tests/api -run TestIngest_` — 17 HTTP integration tests pass, covering:
  - Valid batch (3 events persisted)
  - Auth failure: missing key → 401 `MISSING_API_KEY`; invalid key → 401 `INVALID_API_KEY`
  - Malformed JSON body → 400
  - Per-event missing fields (source / kind / payload / observed_at each surface as an `errors[]` entry — HTTP 200)
  - Unknown kind → `UNKNOWN_KIND` entry
  - Structurally invalid payload → `PAYLOAD_INVALID` entry
  - `payload: null` → `PAYLOAD_INVALID` entry (new)
  - Batch size > 500 → 400
  - Empty batch → 400
  - Duplicate within a batch: `accepted=1, duplicate=1`
  - Duplicate across batches: second request `duplicate=1`
  - NULL source_id: not deduped (partial-index semantics)
  - Mixed batch: `accepted + duplicate + rejected` summary
  - Body > 8 MiB → 413 (MaxBytesReader wrap)
  - Mid-tx rollback via injected failing `EventRepository` → 500 + zero rows persisted (§3.5 atomicity contract)
  - Gate disabled → 404
  - Gate disabled + no API key → still 404 (no middleware invocation)
- [x] `make lint` — 0 issues
- [x] Local Codex review round 1: FAIL (4 findings — binding:required breaking batch-continue, null payload acceptance, fragile ID sentinel, missing docs entry). Fixes committed in `24f673f`.
- [x] Local Codex review round 2: PASS

## Spec acceptance criteria (§5 PR 4)

- [x] Endpoint accepts batched events; duplicates counted
- [x] `EVENT_BUS_INGEST_ENABLED=false` (default) returns 404
- [x] "E2E" test with valid / auth-failure / malformed / duplicate-in-batch fixtures — satisfied at the HTTP integration level (plan Decision 11); the endpoint has no UI surface, and `backend/tests/api/ingest_test.go` exercises the real router + DB + river + Bus end-to-end.

## Out of scope

- No consumer workers (`consumerJobsForKind` unchanged from PR 2 — empty slice for every kind).
- No other publishers (Telegram, Calendar, Todoist, Manual UI) — PR 5+.
- No deprecation of direct-write paths.

## Plan

`.ai/log/plan/event-bus-foundation-pr4-ingestion-endpoint.md`