### PR TITLE
feat(events): RematchDispatcher event-bus cutover (PR 10/12 of #180)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,9 @@ jobs:
       - name: Check follow-up sole-writer invariant
         run: ./scripts/ci/followup-sole-writer-guard.sh
 
+      - name: Check rematch sole-dispatcher invariant
+        run: ./scripts/ci/rematch-sole-dispatcher-guard.sh
+
       - name: Run unit tests
         working-directory: backend
         run: go test -short -v ./...

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Personal CRM Makefile
 
-.PHONY: help setup dev build test clean docker-up docker-down docker-reset test-cadence-ultra test-cadence-fast prod staging testing start start-local stop restart reload status dev-stop dev-restart dev-api-stop dev-api-start dev-api-restart ci-build-backend ci-build-frontend ci-build ci-test test-e2e test-e2e-local test-e2e-diff e2e-db deploy setup-pi dev-native postgres-native sqlc smoke-test test-integration-fast test-integration-slow check-cadence-sole-writer check-followup-sole-writer
+.PHONY: help setup dev build test clean docker-up docker-down docker-reset test-cadence-ultra test-cadence-fast prod staging testing start start-local stop restart reload status dev-stop dev-restart dev-api-stop dev-api-start dev-api-restart ci-build-backend ci-build-frontend ci-build ci-test test-e2e test-e2e-local test-e2e-diff e2e-db deploy setup-pi dev-native postgres-native sqlc smoke-test test-integration-fast test-integration-slow check-cadence-sole-writer check-followup-sole-writer check-rematch-sole-dispatcher
 
 # Repo root (supports running make from subdirectories).
 REPO_ROOT := $(shell git rev-parse --show-toplevel)
@@ -300,7 +300,7 @@ lint-fix:
 	@echo "Running golangci-lint with auto-fix..."
 	@cd backend && $(GOLANGCI_LINT) run --fix ./...
 
-ci-test: lint check-cadence-sole-writer check-followup-sole-writer test-unit test-integration-fast test-frontend
+ci-test: lint check-cadence-sole-writer check-followup-sole-writer check-rematch-sole-dispatcher test-unit test-integration-fast test-frontend
 	@echo "✅ All CI tests passed"
 
 # Sole-writer guard: verifies only CadenceUpdater calls cadence-writing queries.
@@ -316,6 +316,13 @@ check-cadence-sole-writer:
 # scripts/ci/followup-sole-writer-guard.sh.
 check-followup-sole-writer:
 	@$(REPO_ROOT)/scripts/ci/followup-sole-writer-guard.sh
+
+# Sole-dispatcher guard: enforces that StartRematchForContact is test-only
+# after the PR-10 event-bus cutover (#180). Production rematch dispatch
+# flows through events.Bus + RematchDispatcher; any non-test caller
+# indicates a partial revert. See scripts/ci/rematch-sole-dispatcher-guard.sh.
+check-rematch-sole-dispatcher:
+	@$(REPO_ROOT)/scripts/ci/rematch-sole-dispatcher-guard.sh
 
 # Code generation
 sqlc:

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -206,15 +206,17 @@ func run() int {
 	// runtime cost.
 	shadowObsRepo := repository.NewShadowObservationRepository(database.Queries, database.Pool)
 
-	// Initialize services
-	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo)
-
 	// River client + event bus + PR 5 consumer wiring. Built EARLY (before
 	// downstream services) so `pubBus` and `manualShadow` are in scope for
 	// constructors that need them (Calendar, Telegram, manual handlers).
 	// Sync workers + periodic job are registered LATER (once syncService
 	// exists) via river.AddWorker + riverClient.PeriodicJobs().Add(), both
 	// of which are safe between NewClient and Start.
+	//
+	// PR 10 (rematch dispatcher) hoisted the bus + rematchService
+	// construction ABOVE ContactService so the constructor can take the
+	// event bus + rematch registry as required args (SetRematchService
+	// is gone; spec §3.4.4).
 	riverWorkers := river.NewWorkers()
 	river.AddWorker(riverWorkers, &noopWorker{})
 
@@ -233,6 +235,14 @@ func run() int {
 	eventBus := events.NewBus(database.Pool, riverClient, eventRepo)
 	ingestService := service.NewIngestService(database, eventBus)
 	ingestHandler := handlers.NewIngestHandler(ingestService)
+
+	// Rematch service — hoisted above ContactService (PR 10) so it can be
+	// passed as the RematchRegistry constructor arg. Handlers register
+	// later once their dependencies are constructed.
+	rematchService := service.NewRematchService()
+
+	// Initialize services
+	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, eventBus, rematchService)
 
 	// Telegram message repo construction (hoisted above the InteractionRecorder
 	// wiring so the consumer can mark messages processed in the same tx as
@@ -435,14 +445,17 @@ func run() int {
 	// EnrichmentService is shared by the import handler (link/import flows) and
 	// the Telegram peer matcher (auto-match enrichment). Constructed at outer
 	// scope so both feature blocks share a single instance.
-	enrichmentService := service.NewEnrichmentService(database, contactRepo, contactMethodRepo, enrichmentRepo)
+	enrichmentService := service.NewEnrichmentService(database, contactRepo, contactMethodRepo, enrichmentRepo, eventBus, rematchService)
 	enrichmentService.SetCadenceUpdater(cadenceUpdater)
 
-	// Rematch service — wired now so downstream services can call SetRematchService.
-	// Handlers are registered below once their dependencies are constructed.
-	rematchService := service.NewRematchService()
-	contactService.SetRematchService(rematchService)
-	enrichmentService.SetRematchService(rematchService)
+	// Rematch dispatcher consumer — subscribes to contact_methods.added
+	// events and runs RematchService.Run with per-contact mutex
+	// serialization (spec §3.4.4). Always-on post-PR-10 (plan Decision 1
+	// dropped the mode flag). Rematch handlers themselves (calendar,
+	// telegram) are registered below once their deps are constructed.
+	rematchDispatcher := consumer.NewRematchDispatcher(rematchService)
+	river.AddWorker(riverWorkers, consumer.NewRematchDispatcherWorker(eventBus, database.Pool, rematchDispatcher))
+	logger.Info().Msg("event-bus RematchDispatcher: cutover active")
 
 	// Initialize external sync components (feature-flagged)
 	var syncService *service.SyncService

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -213,10 +213,10 @@ func run() int {
 	// exists) via river.AddWorker + riverClient.PeriodicJobs().Add(), both
 	// of which are safe between NewClient and Start.
 	//
-	// PR 10 (rematch dispatcher) hoisted the bus + rematchService
-	// construction ABOVE ContactService so the constructor can take the
-	// event bus + rematch registry as required args (SetRematchService
-	// is gone; spec §3.4.4).
+	// eventBus + rematchService are constructed BEFORE ContactService /
+	// EnrichmentService so those services can take them as constructor
+	// args (the rematch registry is required; SetRematchService setter
+	// is gone).
 	riverWorkers := river.NewWorkers()
 	river.AddWorker(riverWorkers, &noopWorker{})
 
@@ -236,7 +236,7 @@ func run() int {
 	ingestService := service.NewIngestService(database, eventBus)
 	ingestHandler := handlers.NewIngestHandler(ingestService)
 
-	// Rematch service — hoisted above ContactService (PR 10) so it can be
+	// Rematch service — constructed above ContactService so it can be
 	// passed as the RematchRegistry constructor arg. Handlers register
 	// later once their dependencies are constructed.
 	rematchService := service.NewRematchService()
@@ -450,9 +450,11 @@ func run() int {
 
 	// Rematch dispatcher consumer — subscribes to contact_methods.added
 	// events and runs RematchService.Run with per-contact mutex
-	// serialization (spec §3.4.4). Always-on post-PR-10 (plan Decision 1
-	// dropped the mode flag). Rematch handlers themselves (calendar,
-	// telegram) are registered below once their deps are constructed.
+	// serialization. Always-on (no mode flag): a registered River
+	// worker that returned nil in kill-switch mode would permanently
+	// ack queued jobs, so rollback is `git revert` only. Rematch
+	// handlers themselves (calendar, telegram) are registered below
+	// once their deps are constructed.
 	rematchDispatcher := consumer.NewRematchDispatcher(rematchService)
 	river.AddWorker(riverWorkers, consumer.NewRematchDispatcherWorker(eventBus, database.Pool, rematchDispatcher))
 	logger.Info().Msg("event-bus RematchDispatcher: cutover active")

--- a/backend/internal/api/handlers/rematch.go
+++ b/backend/internal/api/handlers/rematch.go
@@ -100,7 +100,7 @@ func (h *RematchHandler) Rescan(c *gin.Context) {
 		return
 	}
 
-	jobID, err := h.rematchSvc.RescanContact(ctx, h.contactSvc, id)
+	jobID, err := h.contactSvc.RescanRematch(ctx, id)
 	if err != nil {
 		if errors.Is(err, db.ErrNotFound) {
 			api.SendNotFound(c, "Contact")

--- a/backend/internal/consumer/consumerjobs/args.go
+++ b/backend/internal/consumer/consumerjobs/args.go
@@ -86,3 +86,20 @@ type TodoistFollowUpRefreshJobArgs struct {
 // Kind returns the river job-kind identifier for Todoist follow-up
 // refresh retry jobs.
 func (TodoistFollowUpRefreshJobArgs) Kind() string { return "todoist_followup_refresh" }
+
+// RematchDispatcherJobArgs carries the event id + dedup-arg fields that
+// the RematchDispatcher worker processes. ContactID and RematchJobID
+// are duplicated from the event payload so river's
+// UniqueOpts{ByArgs: ["ContactID", "RematchJobID"]} can dedupe
+// same-mutation publisher retries at enqueue time without having to
+// decode the payload first. The event.source_id unique index is the
+// first dedup layer (publisher-retry side); ByArgs is the belt-and-
+// suspenders second layer (river-enqueue side). Spec §3.4.4.
+type RematchDispatcherJobArgs struct {
+	EventID      uuid.UUID `json:"event_id"`
+	ContactID    uuid.UUID `json:"contact_id"`
+	RematchJobID uuid.UUID `json:"rematch_job_id"`
+}
+
+// Kind returns the river job-kind identifier for RematchDispatcher jobs.
+func (RematchDispatcherJobArgs) Kind() string { return "rematch_dispatcher" }

--- a/backend/internal/consumer/consumerjobs/args.go
+++ b/backend/internal/consumer/consumerjobs/args.go
@@ -89,16 +89,20 @@ func (TodoistFollowUpRefreshJobArgs) Kind() string { return "todoist_followup_re
 
 // RematchDispatcherJobArgs carries the event id + dedup-arg fields that
 // the RematchDispatcher worker processes. ContactID and RematchJobID
-// are duplicated from the event payload so river's
-// UniqueOpts{ByArgs: ["ContactID", "RematchJobID"]} can dedupe
-// same-mutation publisher retries at enqueue time without having to
-// decode the payload first. The event.source_id unique index is the
-// first dedup layer (publisher-retry side); ByArgs is the belt-and-
-// suspenders second layer (river-enqueue side). Spec §3.4.4.
+// are duplicated from the event payload and carry the river:"unique"
+// struct tag so river's UniqueOpts{ByArgs: true} dedupes same-mutation
+// publisher retries at enqueue time without decoding the payload. The
+// event.source_id unique index is the first dedup layer (publisher-
+// retry side); river args-based uniqueness is the belt-and-suspenders
+// second layer (river-enqueue side). EventID is intentionally NOT
+// tagged — two retries of the same mutation produce distinct event
+// rows (different event.id) but identical (ContactID, RematchJobID),
+// so only those two fields participate in the uniqueness hash.
+// Spec §3.4.4.
 type RematchDispatcherJobArgs struct {
 	EventID      uuid.UUID `json:"event_id"`
-	ContactID    uuid.UUID `json:"contact_id"`
-	RematchJobID uuid.UUID `json:"rematch_job_id"`
+	ContactID    uuid.UUID `json:"contact_id"    river:"unique"`
+	RematchJobID uuid.UUID `json:"rematch_job_id" river:"unique"`
 }
 
 // Kind returns the river job-kind identifier for RematchDispatcher jobs.

--- a/backend/internal/consumer/rematch_dispatcher.go
+++ b/backend/internal/consumer/rematch_dispatcher.go
@@ -1,0 +1,127 @@
+package consumer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"personal-crm/backend/internal/consumer/consumerjobs"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/logger"
+	"personal-crm/backend/internal/service"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
+)
+
+// rematchRunner is the subset of *service.RematchService the dispatcher
+// needs. Interface defined here (not on the service) so unit tests can
+// stub Run without instantiating the full service graph.
+type rematchRunner interface {
+	Run(ctx context.Context, jobID, contactID uuid.UUID, methods []service.Method) error
+}
+
+// RematchDispatcher is the event-bus consumer for contact_methods.added.
+// Per spec §3.4.4 it runs the existing rematch pipeline (per-method
+// handler iteration + per-contact mutex serialization) via
+// RematchService.Run. Always-on — PR 10 plan Decision 1 removed the
+// mode flag because a registered River worker returning nil in off
+// mode would permanently ack queued jobs and make git revert the only
+// real rollback path anyway.
+type RematchDispatcher struct {
+	runner rematchRunner
+}
+
+// NewRematchDispatcher constructs a dispatcher wired to the given
+// runner (production: *service.RematchService).
+func NewRematchDispatcher(runner rematchRunner) *RematchDispatcher {
+	return &RematchDispatcher{runner: runner}
+}
+
+// HandleEvent decodes the contact_methods.added envelope and invokes
+// the rematch runner. Does NOT accept a tx — unlike the other event
+// consumers, the rematch pipeline reads/writes across multiple
+// repositories (calendar_event, telegram_message, aggregation tables)
+// and each handler owns its own tx scoping. The publisher's tx has
+// already committed by the time River dequeues this worker.
+func (d *RematchDispatcher) HandleEvent(ctx context.Context, env *events.Envelope) error {
+	if env == nil {
+		return errors.New("rematch_dispatcher: nil envelope")
+	}
+	if env.Kind != events.KindContactMethodsAdded {
+		return fmt.Errorf("rematch_dispatcher: unexpected kind %q", env.Kind)
+	}
+
+	var p events.ContactMethodsAddedPayload
+	if err := events.Unmarshal(env, &p); err != nil {
+		return fmt.Errorf("unmarshal contact_methods.added: %w", err)
+	}
+	if p.RematchJobID == uuid.Nil {
+		return errors.New("rematch_dispatcher: empty rematch_job_id in payload")
+	}
+	if p.ContactID == uuid.Nil {
+		return errors.New("rematch_dispatcher: empty contact_id in payload")
+	}
+	if len(p.Methods) == 0 {
+		// Empty methods is a publisher bug (the publisher is supposed to
+		// skip publish when no methods diff). Retrying won't help, so
+		// log and return nil so River marks the job done.
+		logger.Warn().
+			Str("event_id", env.ID.String()).
+			Str("rematch_job_id", p.RematchJobID.String()).
+			Msg("rematch_dispatcher: empty methods slice; no-op")
+		return nil
+	}
+
+	methods := make([]service.Method, len(p.Methods))
+	for i, m := range p.Methods {
+		methods[i] = service.Method{Type: m.Type, Value: m.Value}
+	}
+
+	if err := d.runner.Run(ctx, p.RematchJobID, p.ContactID, methods); err != nil {
+		// Run has already marked the in-memory job Failed. Propagate so
+		// River retries per MaxAttempts (3) from InsertOpts.
+		return fmt.Errorf("rematch run: %w", err)
+	}
+	return nil
+}
+
+// --------------------------------------------------------------------------
+// River worker wrapper — matches interaction_recorder.go pattern.
+// --------------------------------------------------------------------------
+
+// RematchDispatcherWorker is the river worker that fetches the event
+// by id and invokes RematchDispatcher.HandleEvent.
+type RematchDispatcherWorker struct {
+	river.WorkerDefaults[consumerjobs.RematchDispatcherJobArgs]
+	bus        eventBusTx // reuse interface declared in interaction_recorder.go
+	pool       *pgxpool.Pool
+	dispatcher *RematchDispatcher
+}
+
+// NewRematchDispatcherWorker wires the worker to the concrete bus, the
+// application pgxpool (currently unused — reserved for future tx
+// scoping), and the consumer instance.
+func NewRematchDispatcherWorker(bus eventBusTx, pool *pgxpool.Pool, dispatcher *RematchDispatcher) *RematchDispatcherWorker {
+	return &RematchDispatcherWorker{bus: bus, pool: pool, dispatcher: dispatcher}
+}
+
+// Work implements river.Worker. Fetches the event envelope by id and
+// invokes HandleEvent. On error river retries per MaxAttempts (3 from
+// the InsertOpts set in events.consumerJobsForKind).
+func (w *RematchDispatcherWorker) Work(ctx context.Context, j *river.Job[consumerjobs.RematchDispatcherJobArgs]) error {
+	env, err := w.bus.GetEvent(ctx, j.Args.EventID)
+	if err != nil {
+		return fmt.Errorf("fetch event %s: %w", j.Args.EventID, err)
+	}
+	return w.dispatcher.HandleEvent(ctx, env)
+}
+
+// Timeout bounds a single rematch run. Multi-method rematch over large
+// calendar + telegram histories can take tens of seconds; 5 minutes is
+// ample headroom.
+func (*RematchDispatcherWorker) Timeout(*river.Job[consumerjobs.RematchDispatcherJobArgs]) time.Duration {
+	return 5 * time.Minute
+}

--- a/backend/internal/consumer/rematch_dispatcher.go
+++ b/backend/internal/consumer/rematch_dispatcher.go
@@ -24,12 +24,10 @@ type rematchRunner interface {
 }
 
 // RematchDispatcher is the event-bus consumer for contact_methods.added.
-// Per spec §3.4.4 it runs the existing rematch pipeline (per-method
-// handler iteration + per-contact mutex serialization) via
-// RematchService.Run. Always-on — PR 10 plan Decision 1 removed the
-// mode flag because a registered River worker returning nil in off
-// mode would permanently ack queued jobs and make git revert the only
-// real rollback path anyway.
+// It runs the rematch pipeline (per-method handler iteration +
+// per-contact mutex serialization) via RematchService.Run. Always-on:
+// a registered River worker returning nil on a kill-switch would
+// permanently ack queued jobs, so rollback is `git revert` only.
 type RematchDispatcher struct {
 	runner rematchRunner
 }

--- a/backend/internal/consumer/rematch_dispatcher_test.go
+++ b/backend/internal/consumer/rematch_dispatcher_test.go
@@ -6,8 +6,8 @@ import (
 	"errors"
 	"sync"
 	"testing"
-	"time"
 
+	"personal-crm/backend/internal/accelerated"
 	"personal-crm/backend/internal/events"
 	"personal-crm/backend/internal/service"
 
@@ -57,7 +57,7 @@ func validEnvelope(t *testing.T, contactID, jobID uuid.UUID, methods []events.Co
 		SourceID:   jobID.String(),
 		Kind:       events.KindContactMethodsAdded,
 		Payload:    payload,
-		ObservedAt: time.Now(),
+		ObservedAt: accelerated.GetCurrentTime(),
 	}
 }
 

--- a/backend/internal/consumer/rematch_dispatcher_test.go
+++ b/backend/internal/consumer/rematch_dispatcher_test.go
@@ -1,0 +1,150 @@
+package consumer
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/service"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// stubRunner records Run invocations and returns a configurable error.
+type stubRunner struct {
+	mu    sync.Mutex
+	calls []stubRunCall
+	err   error
+}
+
+type stubRunCall struct {
+	jobID     uuid.UUID
+	contactID uuid.UUID
+	methods   []service.Method
+}
+
+func (s *stubRunner) Run(_ context.Context, jobID, contactID uuid.UUID, methods []service.Method) error {
+	s.mu.Lock()
+	s.calls = append(s.calls, stubRunCall{jobID: jobID, contactID: contactID, methods: append([]service.Method(nil), methods...)})
+	s.mu.Unlock()
+	return s.err
+}
+
+func (s *stubRunner) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.calls)
+}
+
+// validEnvelope builds a routable contact_methods.added envelope for tests.
+func validEnvelope(t *testing.T, contactID, jobID uuid.UUID, methods []events.ContactMethodRef) *events.Envelope {
+	t.Helper()
+	payload, err := events.Marshal(events.KindContactMethodsAdded, events.ContactMethodsAddedPayload{
+		Version:      1,
+		ContactID:    contactID,
+		Methods:      methods,
+		RematchJobID: jobID,
+	})
+	require.NoError(t, err)
+	return &events.Envelope{
+		ID:         uuid.New(),
+		Source:     "manual",
+		SourceID:   jobID.String(),
+		Kind:       events.KindContactMethodsAdded,
+		Payload:    payload,
+		ObservedAt: time.Now(),
+	}
+}
+
+func TestRematchDispatcher_HandleEvent_DispatchesToRunner(t *testing.T) {
+	runner := &stubRunner{}
+	d := NewRematchDispatcher(runner)
+
+	contactID := uuid.New()
+	jobID := uuid.New()
+	methods := []events.ContactMethodRef{
+		{Type: "email", Value: "a@b.c"},
+		{Type: "phone", Value: "+15551212"},
+	}
+	env := validEnvelope(t, contactID, jobID, methods)
+
+	require.NoError(t, d.HandleEvent(context.Background(), env))
+	require.Equal(t, 1, runner.callCount())
+	call := runner.calls[0]
+	require.Equal(t, jobID, call.jobID)
+	require.Equal(t, contactID, call.contactID)
+	require.Len(t, call.methods, 2)
+	require.Equal(t, service.Method{Type: "email", Value: "a@b.c"}, call.methods[0])
+	require.Equal(t, service.Method{Type: "phone", Value: "+15551212"}, call.methods[1])
+}
+
+func TestRematchDispatcher_HandleEvent_NilEnvelope_Errors(t *testing.T) {
+	d := NewRematchDispatcher(&stubRunner{})
+	err := d.HandleEvent(context.Background(), nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "nil envelope")
+}
+
+func TestRematchDispatcher_HandleEvent_WrongKind_Errors(t *testing.T) {
+	d := NewRematchDispatcher(&stubRunner{})
+	env := &events.Envelope{
+		ID:   uuid.New(),
+		Kind: events.KindInteractionRecorded,
+	}
+	err := d.HandleEvent(context.Background(), env)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unexpected kind")
+}
+
+func TestRematchDispatcher_HandleEvent_MalformedPayload_Errors(t *testing.T) {
+	d := NewRematchDispatcher(&stubRunner{})
+	env := &events.Envelope{
+		ID:      uuid.New(),
+		Kind:    events.KindContactMethodsAdded,
+		Payload: json.RawMessage(`{not json`),
+	}
+	err := d.HandleEvent(context.Background(), env)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unmarshal contact_methods.added")
+}
+
+func TestRematchDispatcher_HandleEvent_EmptyRematchJobID_Errors(t *testing.T) {
+	d := NewRematchDispatcher(&stubRunner{})
+	env := validEnvelope(t, uuid.New(), uuid.Nil, []events.ContactMethodRef{{Type: "email", Value: "x"}})
+	err := d.HandleEvent(context.Background(), env)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "empty rematch_job_id")
+}
+
+func TestRematchDispatcher_HandleEvent_EmptyContactID_Errors(t *testing.T) {
+	d := NewRematchDispatcher(&stubRunner{})
+	env := validEnvelope(t, uuid.Nil, uuid.New(), []events.ContactMethodRef{{Type: "email", Value: "x"}})
+	err := d.HandleEvent(context.Background(), env)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "empty contact_id")
+}
+
+func TestRematchDispatcher_HandleEvent_EmptyMethods_NoOp(t *testing.T) {
+	runner := &stubRunner{}
+	d := NewRematchDispatcher(runner)
+	env := validEnvelope(t, uuid.New(), uuid.New(), nil)
+	require.NoError(t, d.HandleEvent(context.Background(), env))
+	require.Zero(t, runner.callCount(), "empty methods must not invoke runner")
+}
+
+func TestRematchDispatcher_HandleEvent_RunnerError_Propagates(t *testing.T) {
+	sentinel := errors.New("handler exploded")
+	runner := &stubRunner{err: sentinel}
+	d := NewRematchDispatcher(runner)
+
+	env := validEnvelope(t, uuid.New(), uuid.New(), []events.ContactMethodRef{{Type: "email", Value: "a"}})
+	err := d.HandleEvent(context.Background(), env)
+	require.Error(t, err)
+	require.ErrorIs(t, err, sentinel, "dispatcher must surface runner error so river retries")
+	require.Contains(t, err.Error(), "rematch run")
+}

--- a/backend/internal/db/event.sql.go
+++ b/backend/internal/db/event.sql.go
@@ -25,6 +25,30 @@ func (q *Queries) CountEventsBySource(ctx context.Context, source string) (int64
 	return count, err
 }
 
+const CountRematchDispatcherJobsByContactAndJob = `-- name: CountRematchDispatcherJobsByContactAndJob :one
+SELECT COUNT(*) FROM river_job
+WHERE kind = 'rematch_dispatcher'
+  AND (args->>'contact_id') = $1::text
+  AND (args->>'rematch_job_id') = $2::text
+`
+
+type CountRematchDispatcherJobsByContactAndJobParams struct {
+	ContactID    string `json:"contact_id"`
+	RematchJobID string `json:"rematch_job_id"`
+}
+
+// Test-only count of river_job rows for the rematch_dispatcher kind
+// whose args JSON contains the given (contact_id, rematch_job_id)
+// tuple. Used by rematch dedup integration tests to assert
+// UniqueOpts{ByArgs} behavior without inlining raw SQL into Go test
+// code (core.md rule 2).
+func (q *Queries) CountRematchDispatcherJobsByContactAndJob(ctx context.Context, arg CountRematchDispatcherJobsByContactAndJobParams) (int64, error) {
+	row := q.db.QueryRow(ctx, CountRematchDispatcherJobsByContactAndJob, arg.ContactID, arg.RematchJobID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const FindEventBySource = `-- name: FindEventBySource :one
 SELECT id, source, source_id, kind, payload, observed_at, received_at, created_at FROM event
 WHERE source = $1 AND source_id = $2

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -72,6 +72,12 @@ type Querier interface {
 	CountMergeNotes(ctx context.Context, contactID pgtype.UUID) (int64, error)
 	// Count OAuth credentials for a provider
 	CountOAuthCredentials(ctx context.Context, provider string) (int64, error)
+	// Test-only count of river_job rows for the rematch_dispatcher kind
+	// whose args JSON contains the given (contact_id, rematch_job_id)
+	// tuple. Used by rematch dedup integration tests to assert
+	// UniqueOpts{ByArgs} behavior without inlining raw SQL into Go test
+	// code (core.md rule 2).
+	CountRematchDispatcherJobsByContactAndJob(ctx context.Context, arg CountRematchDispatcherJobsByContactAndJobParams) (int64, error)
 	// Test-only count of river_job rows with a given kind whose args JSON
 	// contains contact_task_id = $2. Used by follow-up cutover integration
 	// tests to assert a create/close/refresh job was enqueued without

--- a/backend/internal/db/queries/event.sql
+++ b/backend/internal/db/queries/event.sql
@@ -38,3 +38,14 @@ LIMIT 1;
 -- ingest outcomes per source. The event log is append-only, so no
 -- deleted_at filter is needed.
 SELECT COUNT(*) FROM event WHERE source = @source;
+
+-- name: CountRematchDispatcherJobsByContactAndJob :one
+-- Test-only count of river_job rows for the rematch_dispatcher kind
+-- whose args JSON contains the given (contact_id, rematch_job_id)
+-- tuple. Used by rematch dedup integration tests to assert
+-- UniqueOpts{ByArgs} behavior without inlining raw SQL into Go test
+-- code (core.md rule 2).
+SELECT COUNT(*) FROM river_job
+WHERE kind = 'rematch_dispatcher'
+  AND (args->>'contact_id') = sqlc.arg('contact_id')::text
+  AND (args->>'rematch_job_id') = sqlc.arg('rematch_job_id')::text;

--- a/backend/internal/events/bus.go
+++ b/backend/internal/events/bus.go
@@ -12,7 +12,6 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
-	"github.com/riverqueue/river/rivertype"
 )
 
 // EventRepository is the persistence contract used by Bus. Defined here
@@ -102,12 +101,12 @@ func consumerJobsForKind(env *Envelope) ([]consumerJob, error) {
 					// tagged, so retries with different event.id but same
 					// (ContactID, RematchJobID) dedupe to one river job).
 					ByArgs: true,
-					ByState: []rivertype.JobState{
-						rivertype.JobStateScheduled,
-						rivertype.JobStateAvailable,
-						rivertype.JobStateRunning,
-						rivertype.JobStateRetryable,
-					},
+					// ByState is nil here to accept river's default set
+					// (Pending/Scheduled/Available/Running/Retryable). A
+					// partial ByState list must include Pending or river
+					// rejects the InsertOpts at InsertTx time. Default
+					// covers our "not yet terminal" window as tightly as
+					// a custom list would.
 				},
 			},
 		}}, nil

--- a/backend/internal/events/bus.go
+++ b/backend/internal/events/bus.go
@@ -201,7 +201,13 @@ func (b *Bus) PublishTx(ctx context.Context, tx pgx.Tx, env *Envelope) error {
 	// repository/event.go honors a caller-supplied UUID; otherwise the
 	// DB DEFAULT gen_random_uuid() fires. Generating client-side is
 	// equivalent to a DB-side UUID from a uniqueness standpoint.
-	if env.ID == uuid.Nil {
+	//
+	// We track whether the ID was caller-supplied so a duplicate
+	// (ON CONFLICT) path can restore env.ID to uuid.Nil for the
+	// IngestService duplicate-detection contract (it distinguishes
+	// accepted vs duplicate via `env.ID == uuid.Nil` post-return).
+	callerSuppliedID := env.ID != uuid.Nil
+	if !callerSuppliedID {
 		env.ID = uuid.New()
 	}
 
@@ -215,6 +221,12 @@ func (b *Bus) PublishTx(ctx context.Context, tx pgx.Tx, env *Envelope) error {
 	if err := b.eventRepo.InsertEvent(ctx, tx, env); err != nil {
 		if errors.Is(err, db.ErrDuplicate) {
 			// (source, source_id) collision → idempotent no-op.
+			// Reset env.ID when we pre-assigned it so callers using the
+			// `env.ID == uuid.Nil` duplicate sentinel (IngestService)
+			// see the dup. Caller-supplied IDs stay as-is.
+			if !callerSuppliedID {
+				env.ID = uuid.Nil
+			}
 			return nil
 		}
 		return fmt.Errorf("insert event: %w", err)

--- a/backend/internal/events/bus.go
+++ b/backend/internal/events/bus.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
 )
 
 // EventRepository is the persistence contract used by Bus. Defined here
@@ -34,9 +35,13 @@ type consumerJob struct {
 // consumerJobsForKind is the static registry mapping a Kind to the set of
 // river jobs to enqueue atomically alongside its event row.
 //
-// The eventID argument is the event row's primary key; job arg structs
-// embed it so the worker can fetch the full payload by ID (spec §3.3 —
-// "keeps job-arg payload small").
+// The envelope is passed in (not just the event id) so kinds whose
+// JobArgs carries additional payload-derived fields — currently
+// contact_methods.added, whose RematchDispatcherJobArgs includes
+// ContactID and RematchJobID for river UniqueOpts{ByArgs} — can decode
+// the payload at routing time. Payload decode failures surface as a
+// routing error so PublishTx can fail the caller's tx rather than land
+// a stranded event row with no consumer (spec §4 atomicity).
 //
 // Routing rules:
 //
@@ -44,36 +49,70 @@ type consumerJob struct {
 //     task.completed, task.outreach_detected) → InteractionRecorder worker
 //     with MaxAttempts=5.
 //   - interaction.recorded → two jobs, one CadenceUpdater and one
-//     FollowUpManager, each with MaxAttempts=5. Routing is config-blind;
-//     each handler's HandleEvent gates on its own mode flag so mode=off
-//     shortcircuits inside the worker and enqueuing is harmless.
-//   - interaction.manual → returns nil. The manual UI handler inline-
-//     invokes HandleEvent in its tx so the consumer isn't double-
-//     invoked. Spec §3.4 says PublishTx should enqueue jobs "for other
-//     consumers"; InteractionRecorder is not "other" in the manual flow.
-//   - calendar.declined, task.skipped, contact_methods.added → returns nil.
-//     Consumers for those kinds are not yet wired.
-func consumerJobsForKind(kind Kind, eventID uuid.UUID) []consumerJob {
-	switch kind {
+//     FollowUpManager, each with MaxAttempts=5.
+//   - contact_methods.added → RematchDispatcher worker. UniqueOpts
+//     {ByArgs: ["ContactID", "RematchJobID"], ByState: scheduled|
+//     available|running|retryable} dedupes same-mutation publisher
+//     retries at enqueue time.
+//   - interaction.manual: inline-invoked by the manual UI handler; no
+//     async consumer.
+//   - calendar.declined, task.skipped: no consumer yet wired.
+func consumerJobsForKind(env *Envelope) ([]consumerJob, error) {
+	switch env.Kind {
 	case KindMessageReceived, KindMessageSent, KindCalendarAttended,
 		KindTaskCompleted, KindTaskOutreachDetected:
 		return []consumerJob{{
-			Args: consumerjobs.InteractionRecorderJobArgs{EventID: eventID},
+			Args: consumerjobs.InteractionRecorderJobArgs{EventID: env.ID},
 			Opts: &river.InsertOpts{MaxAttempts: 5},
-		}}
+		}}, nil
 	case KindInteractionRecorded:
 		return []consumerJob{
 			{
-				Args: consumerjobs.CadenceUpdaterJobArgs{EventID: eventID},
+				Args: consumerjobs.CadenceUpdaterJobArgs{EventID: env.ID},
 				Opts: &river.InsertOpts{MaxAttempts: 5},
 			},
 			{
-				Args: consumerjobs.FollowUpManagerJobArgs{EventID: eventID},
+				Args: consumerjobs.FollowUpManagerJobArgs{EventID: env.ID},
 				Opts: &river.InsertOpts{MaxAttempts: 5},
 			},
+		}, nil
+	case KindContactMethodsAdded:
+		var p ContactMethodsAddedPayload
+		if err := Unmarshal(env, &p); err != nil {
+			return nil, fmt.Errorf("decode contact_methods.added: %w", err)
 		}
+		if p.ContactID == uuid.Nil {
+			return nil, fmt.Errorf("contact_methods.added: empty contact_id")
+		}
+		if p.RematchJobID == uuid.Nil {
+			return nil, fmt.Errorf("contact_methods.added: empty rematch_job_id")
+		}
+		return []consumerJob{{
+			Args: consumerjobs.RematchDispatcherJobArgs{
+				EventID:      env.ID,
+				ContactID:    p.ContactID,
+				RematchJobID: p.RematchJobID,
+			},
+			Opts: &river.InsertOpts{
+				MaxAttempts: 3,
+				UniqueOpts: river.UniqueOpts{
+					// ByArgs: true combined with the river:"unique" tags on
+					// ContactID + RematchJobID in the JobArgs struct tells
+					// river to hash only those two fields (EventID is NOT
+					// tagged, so retries with different event.id but same
+					// (ContactID, RematchJobID) dedupe to one river job).
+					ByArgs: true,
+					ByState: []rivertype.JobState{
+						rivertype.JobStateScheduled,
+						rivertype.JobStateAvailable,
+						rivertype.JobStateRunning,
+						rivertype.JobStateRetryable,
+					},
+				},
+			},
+		}}, nil
 	}
-	return nil
+	return nil, nil
 }
 
 // Bus publishes typed events to the append-only event log and enqueues
@@ -121,8 +160,16 @@ func (b *Bus) Publish(ctx context.Context, env *Envelope) (err error) {
 // retry a batched post; in-process publishers that pass a stable source_id
 // are automatically deduped."
 //
-// On successful insert, env.ID is populated with the DB-generated (or
-// caller-provided) row id.
+// Routing-before-insert: consumerJobsForKind runs before InsertEvent so
+// a payload decode / validation failure (currently only
+// contact_methods.added requires this) rolls back the caller's tx
+// without landing a stranded event row with no consumer (spec §4).
+//
+// Event id preassignment: env.ID is populated before routing so
+// consumer job args that reference it (e.g., RematchDispatcherJobArgs.
+// EventID) are non-nil. The repository honors the caller-supplied UUID
+// when env.ID is set; otherwise the DB's gen_random_uuid() DEFAULT
+// fires.
 func (b *Bus) PublishTx(ctx context.Context, tx pgx.Tx, env *Envelope) error {
 	if tx == nil {
 		return fmt.Errorf("publish: nil tx")
@@ -150,8 +197,23 @@ func (b *Bus) PublishTx(ctx context.Context, tx pgx.Tx, env *Envelope) error {
 		return fmt.Errorf("publish: empty observed_at for kind %s", env.Kind)
 	}
 
-	err := b.eventRepo.InsertEvent(ctx, tx, env)
+	// Preassign env.ID so consumer-job args that reference it populate
+	// correctly during routing (which runs BEFORE the actual DB insert).
+	// repository/event.go honors a caller-supplied UUID; otherwise the
+	// DB DEFAULT gen_random_uuid() fires. Generating client-side is
+	// equivalent to a DB-side UUID from a uniqueness standpoint.
+	if env.ID == uuid.Nil {
+		env.ID = uuid.New()
+	}
+
+	// Route BEFORE insert so a routing error fails the whole tx and no
+	// zombie event row lands with no consumer (spec §4 atomicity).
+	jobs, err := consumerJobsForKind(env)
 	if err != nil {
+		return fmt.Errorf("route consumer jobs: %w", err)
+	}
+
+	if err := b.eventRepo.InsertEvent(ctx, tx, env); err != nil {
 		if errors.Is(err, db.ErrDuplicate) {
 			// (source, source_id) collision → idempotent no-op.
 			return nil
@@ -159,7 +221,7 @@ func (b *Bus) PublishTx(ctx context.Context, tx pgx.Tx, env *Envelope) error {
 		return fmt.Errorf("insert event: %w", err)
 	}
 
-	for _, job := range consumerJobsForKind(env.Kind, env.ID) {
+	for _, job := range jobs {
 		if _, err := b.riverClient.InsertTx(ctx, tx, job.Args, job.Opts); err != nil {
 			return fmt.Errorf("enqueue consumer job %T: %w", job.Args, err)
 		}

--- a/backend/internal/events/bus_test.go
+++ b/backend/internal/events/bus_test.go
@@ -199,12 +199,16 @@ func TestConsumerJobsForKind_ContactMethodsAdded_ZeroRematchJobID_Errors(t *test
 // stubEventRepo is a test-only EventRepository that lets Bus_test files
 // exercise envelope validation without touching the database or river.
 type stubEventRepo struct {
-	insertCalls int
-	insertErr   error
+	insertCalls  int
+	insertErr    error
+	lastInsertID uuid.UUID
 }
 
-func (s *stubEventRepo) InsertEvent(_ context.Context, _ pgx.Tx, _ *Envelope) error {
+func (s *stubEventRepo) InsertEvent(_ context.Context, _ pgx.Tx, env *Envelope) error {
 	s.insertCalls++
+	if env != nil {
+		s.lastInsertID = env.ID
+	}
 	return s.insertErr
 }
 
@@ -369,12 +373,19 @@ func TestPublishTx_RepoErrorPropagates(t *testing.T) {
 
 // TestPublishTx_PreassignsEventID confirms the pre-insert env.ID
 // assignment fires before routing so RematchDispatcherJobArgs.EventID
-// (derived from env.ID at routing time) is never uuid.Nil. Covers the
-// Codex round-2 P1-A fix.
+// (derived from env.ID at routing time) is never uuid.Nil.
+//
+// On ErrDuplicate with a bus-assigned ID, env.ID is intentionally
+// reset to uuid.Nil so the IngestService duplicate sentinel
+// (env.ID == uuid.Nil) works correctly. We verify preassignment by
+// observing that the stub's insertCalls saw a non-zero ID at insert
+// time — that's the window where routing has populated the consumer
+// job args.
 func TestPublishTx_PreassignsEventID(t *testing.T) {
 	ctx := context.Background()
-	// Have the stub return ErrDuplicate so we stop after routing
-	// populates env.ID (we don't need a real river client here).
+	// Stub returns ErrDuplicate after capturing the insert params so we
+	// can verify env.ID was populated at insert time. The bus then
+	// resets env.ID on the dup path.
 	stub := &stubEventRepo{insertErr: db.ErrDuplicate}
 	bus := &Bus{eventRepo: stub}
 
@@ -389,7 +400,6 @@ func TestPublishTx_PreassignsEventID(t *testing.T) {
 	require.NoError(t, err)
 
 	env := &Envelope{
-		// env.ID deliberately zero — PublishTx must fill it.
 		Kind:       KindContactMethodsAdded,
 		Source:     "manual",
 		SourceID:   jobID.String(),
@@ -397,7 +407,13 @@ func TestPublishTx_PreassignsEventID(t *testing.T) {
 		ObservedAt: time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC),
 	}
 	require.NoError(t, bus.PublishTx(ctx, nonNilStubTx(), env))
-	require.NotEqual(t, uuid.Nil, env.ID, "PublishTx must preassign env.ID before routing")
+	require.Equal(t, 1, stub.insertCalls)
+	require.NotEqual(t, uuid.Nil, stub.lastInsertID,
+		"PublishTx must preassign env.ID before InsertEvent — the stub captures the insert-time ID")
+	// Post-duplicate, env.ID is reset so IngestService's
+	// `env.ID == uuid.Nil` duplicate sentinel works.
+	require.Equal(t, uuid.Nil, env.ID,
+		"PublishTx must reset env.ID to uuid.Nil on duplicate when it pre-assigned the ID")
 }
 
 // TestPublishTx_MalformedPayload_RollsBackTx confirms that a bad

--- a/backend/internal/events/bus_test.go
+++ b/backend/internal/events/bus_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"personal-crm/backend/internal/accelerated"
 	"personal-crm/backend/internal/consumer/consumerjobs"
 	"personal-crm/backend/internal/db"
 
@@ -122,7 +123,7 @@ func TestConsumerJobsForKind_ContactMethodsAdded(t *testing.T) {
 		Source:     "manual",
 		SourceID:   jobID.String(),
 		Payload:    mustMarshalContactMethodsAdded(t, contactID, jobID),
-		ObservedAt: time.Now(),
+		ObservedAt: accelerated.GetCurrentTime(),
 	}
 	jobs, err := consumerJobsForKind(env)
 	require.NoError(t, err)

--- a/backend/internal/events/bus_test.go
+++ b/backend/internal/events/bus_test.go
@@ -12,8 +12,24 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
 	"github.com/stretchr/testify/require"
 )
+
+// mustMarshalContactMethodsAdded builds a valid contact_methods.added
+// payload for tests that need a routable envelope.
+func mustMarshalContactMethodsAdded(t *testing.T, contactID, jobID uuid.UUID) json.RawMessage {
+	t.Helper()
+	raw, err := Marshal(KindContactMethodsAdded, ContactMethodsAddedPayload{
+		Version:      1,
+		ContactID:    contactID,
+		Methods:      []ContactMethodRef{{Type: "email", Value: "a@b.c"}},
+		RematchJobID: jobID,
+	})
+	require.NoError(t, err)
+	return raw
+}
 
 // TestConsumerJobsForKind_FiveAsyncKindsEnqueueInteractionRecorder asserts
 // the PR 5 routing: async-publisher kinds enqueue exactly one
@@ -26,7 +42,9 @@ func TestConsumerJobsForKind_FiveAsyncKindsEnqueueInteractionRecorder(t *testing
 	for _, k := range asyncKinds {
 		t.Run(string(k), func(t *testing.T) {
 			eventID := uuid.New()
-			jobs := consumerJobsForKind(k, eventID)
+			env := &Envelope{ID: eventID, Kind: k}
+			jobs, err := consumerJobsForKind(env)
+			require.NoError(t, err)
 			require.Len(t, jobs, 1, "kind %s should enqueue exactly one consumer job", k)
 			args, ok := jobs[0].Args.(consumerjobs.InteractionRecorderJobArgs)
 			require.True(t, ok, "job args type must be InteractionRecorderJobArgs, got %T", jobs[0].Args)
@@ -34,9 +52,6 @@ func TestConsumerJobsForKind_FiveAsyncKindsEnqueueInteractionRecorder(t *testing
 			require.Equal(t, "interaction_recorder", args.Kind())
 			require.NotNil(t, jobs[0].Opts, "InsertOpts must be set to pin MaxAttempts")
 			require.Equal(t, 5, jobs[0].Opts.MaxAttempts)
-			// Sanity: confirm the opts value survives a round-trip through
-			// river.InsertOpts (not accidentally a different struct).
-			_ = jobs[0].Opts
 		})
 	}
 }
@@ -48,7 +63,9 @@ func TestConsumerJobsForKind_FiveAsyncKindsEnqueueInteractionRecorder(t *testing
 // HandleEvent, not at the routing layer.
 func TestConsumerJobsForKind_InteractionRecordedEnqueuesCadenceAndFollowUp(t *testing.T) {
 	eventID := uuid.New()
-	jobs := consumerJobsForKind(KindInteractionRecorded, eventID)
+	env := &Envelope{ID: eventID, Kind: KindInteractionRecorded}
+	jobs, err := consumerJobsForKind(env)
+	require.NoError(t, err)
 	require.Len(t, jobs, 2, "interaction.recorded should enqueue cadence + follow-up jobs")
 
 	cadenceArgs, ok := jobs[0].Args.(consumerjobs.CadenceUpdaterJobArgs)
@@ -70,21 +87,117 @@ func TestConsumerJobsForKind_InteractionRecordedEnqueuesCadenceAndFollowUp(t *te
 // still have no active consumer return nil:
 //   - interaction.manual: inline-invoked by the manual UI handler
 //     (spec §3.4 "other consumers only").
-//   - calendar.declined, task.skipped, contact_methods.added: consumers
-//     for those kinds are not yet wired.
+//   - calendar.declined, task.skipped: consumers for those kinds are
+//     not yet wired.
+//
+// (contact_methods.added HAS a consumer now — see the dedicated
+// TestConsumerJobsForKind_ContactMethodsAdded tests below.)
 func TestConsumerJobsForKind_EmptyForDeferredKinds(t *testing.T) {
 	deferred := []Kind{
 		KindInteractionManual,
 		KindCalendarDeclined,
 		KindTaskSkipped,
-		KindContactMethodsAdded,
 	}
 	for _, k := range deferred {
 		t.Run(string(k), func(t *testing.T) {
-			jobs := consumerJobsForKind(k, uuid.New())
+			env := &Envelope{ID: uuid.New(), Kind: k}
+			jobs, err := consumerJobsForKind(env)
+			require.NoError(t, err)
 			require.Empty(t, jobs, "kind %s: expected empty consumer-job slice", k)
 		})
 	}
+}
+
+// TestConsumerJobsForKind_ContactMethodsAdded asserts the PR 10 routing:
+// contact_methods.added enqueues exactly one RematchDispatcher job with
+// the payload-derived ContactID + RematchJobID and UniqueOpts set for
+// belt-and-suspenders dedup behind the event.source_id unique index.
+func TestConsumerJobsForKind_ContactMethodsAdded(t *testing.T) {
+	eventID := uuid.New()
+	contactID := uuid.New()
+	jobID := uuid.New()
+	env := &Envelope{
+		ID:         eventID,
+		Kind:       KindContactMethodsAdded,
+		Source:     "manual",
+		SourceID:   jobID.String(),
+		Payload:    mustMarshalContactMethodsAdded(t, contactID, jobID),
+		ObservedAt: time.Now(),
+	}
+	jobs, err := consumerJobsForKind(env)
+	require.NoError(t, err)
+	require.Len(t, jobs, 1)
+
+	args, ok := jobs[0].Args.(consumerjobs.RematchDispatcherJobArgs)
+	require.True(t, ok, "job args must be RematchDispatcherJobArgs, got %T", jobs[0].Args)
+	require.Equal(t, eventID, args.EventID)
+	require.Equal(t, contactID, args.ContactID)
+	require.Equal(t, jobID, args.RematchJobID)
+	require.Equal(t, "rematch_dispatcher", args.Kind())
+
+	require.NotNil(t, jobs[0].Opts)
+	require.Equal(t, 3, jobs[0].Opts.MaxAttempts)
+	require.True(t, jobs[0].Opts.UniqueOpts.ByArgs, "ByArgs must be true so UniqueOpts considers args; river:\"unique\" tags on ContactID+RematchJobID scope the hash")
+	require.ElementsMatch(t,
+		[]rivertype.JobState{
+			rivertype.JobStateScheduled,
+			rivertype.JobStateAvailable,
+			rivertype.JobStateRunning,
+			rivertype.JobStateRetryable,
+		},
+		jobs[0].Opts.UniqueOpts.ByState,
+	)
+}
+
+// TestConsumerJobsForKind_ContactMethodsAdded_MalformedPayload_Errors
+// confirms a non-JSON payload fails routing (Design Decision 3).
+func TestConsumerJobsForKind_ContactMethodsAdded_MalformedPayload_Errors(t *testing.T) {
+	env := &Envelope{
+		ID:      uuid.New(),
+		Kind:    KindContactMethodsAdded,
+		Payload: json.RawMessage(`{not valid json`),
+	}
+	jobs, err := consumerJobsForKind(env)
+	require.Error(t, err)
+	require.Nil(t, jobs)
+	require.Contains(t, err.Error(), "decode contact_methods.added")
+}
+
+// TestConsumerJobsForKind_ContactMethodsAdded_ZeroContactID_Errors
+// rejects payloads with uuid.Nil ContactID. Downstream rematch handlers
+// cannot do anything with a nil contact.
+func TestConsumerJobsForKind_ContactMethodsAdded_ZeroContactID_Errors(t *testing.T) {
+	payload, err := Marshal(KindContactMethodsAdded, ContactMethodsAddedPayload{
+		Version:      1,
+		ContactID:    uuid.Nil,
+		Methods:      []ContactMethodRef{{Type: "email", Value: "x"}},
+		RematchJobID: uuid.New(),
+	})
+	require.NoError(t, err)
+	env := &Envelope{ID: uuid.New(), Kind: KindContactMethodsAdded, Payload: payload}
+	jobs, err := consumerJobsForKind(env)
+	require.Error(t, err)
+	require.Nil(t, jobs)
+	require.Contains(t, err.Error(), "empty contact_id")
+}
+
+// TestConsumerJobsForKind_ContactMethodsAdded_ZeroRematchJobID_Errors
+// rejects payloads with uuid.Nil RematchJobID. UniqueOpts{ByArgs} would
+// collapse every nil-jobID publish to a single River job — never what
+// the publisher intends.
+func TestConsumerJobsForKind_ContactMethodsAdded_ZeroRematchJobID_Errors(t *testing.T) {
+	payload, err := Marshal(KindContactMethodsAdded, ContactMethodsAddedPayload{
+		Version:      1,
+		ContactID:    uuid.New(),
+		Methods:      []ContactMethodRef{{Type: "email", Value: "x"}},
+		RematchJobID: uuid.Nil,
+	})
+	require.NoError(t, err)
+	env := &Envelope{ID: uuid.New(), Kind: KindContactMethodsAdded, Payload: payload}
+	jobs, err := consumerJobsForKind(env)
+	require.Error(t, err)
+	require.Nil(t, jobs)
+	require.Contains(t, err.Error(), "empty rematch_job_id")
 }
 
 // stubEventRepo is a test-only EventRepository that lets Bus_test files
@@ -257,3 +370,83 @@ func TestPublishTx_RepoErrorPropagates(t *testing.T) {
 	require.ErrorIs(t, err, sentinel)
 	require.Contains(t, err.Error(), "insert event")
 }
+
+// TestPublishTx_PreassignsEventID confirms the pre-insert env.ID
+// assignment fires before routing so RematchDispatcherJobArgs.EventID
+// (derived from env.ID at routing time) is never uuid.Nil. Covers the
+// Codex round-2 P1-A fix.
+func TestPublishTx_PreassignsEventID(t *testing.T) {
+	ctx := context.Background()
+	// Have the stub return ErrDuplicate so we stop after routing
+	// populates env.ID (we don't need a real river client here).
+	stub := &stubEventRepo{insertErr: db.ErrDuplicate}
+	bus := &Bus{eventRepo: stub}
+
+	contactID := uuid.New()
+	jobID := uuid.New()
+	payload, err := Marshal(KindContactMethodsAdded, ContactMethodsAddedPayload{
+		Version:      1,
+		ContactID:    contactID,
+		Methods:      []ContactMethodRef{{Type: "email", Value: "a@b.c"}},
+		RematchJobID: jobID,
+	})
+	require.NoError(t, err)
+
+	env := &Envelope{
+		// env.ID deliberately zero — PublishTx must fill it.
+		Kind:       KindContactMethodsAdded,
+		Source:     "manual",
+		SourceID:   jobID.String(),
+		Payload:    payload,
+		ObservedAt: time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC),
+	}
+	require.NoError(t, bus.PublishTx(ctx, nonNilStubTx(), env))
+	require.NotEqual(t, uuid.Nil, env.ID, "PublishTx must preassign env.ID before routing")
+}
+
+// TestPublishTx_MalformedPayload_RollsBackTx confirms that a bad
+// contact_methods.added payload fails the publish before event insert,
+// so caller tx can roll back without a stranded event row. Regression
+// guard for Design Decision 3 (Codex round-1 P2).
+func TestPublishTx_MalformedPayload_RollsBackTx(t *testing.T) {
+	ctx := context.Background()
+	stub := &stubEventRepo{}
+	bus := &Bus{eventRepo: stub}
+
+	env := &Envelope{
+		Kind:       KindContactMethodsAdded,
+		Source:     "manual",
+		SourceID:   "job-x",
+		Payload:    json.RawMessage(`{definitely not json`),
+		ObservedAt: time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC),
+	}
+	err := bus.PublishTx(ctx, nonNilStubTx(), env)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "route consumer jobs")
+	require.Zero(t, stub.insertCalls, "InsertEvent must not run when routing fails")
+}
+
+// TestPublishTx_EnqueueRivers_NilClientPanicGuard is a NEGATIVE-space
+// sanity: when routing yields no jobs (e.g. interaction.manual), nil
+// riverClient is safe because the enqueue loop is skipped entirely.
+// Existing TestPublishTx_DuplicateIsNoOp covers the post-duplicate case;
+// this documents the same invariant for the routing-yields-empty path.
+func TestPublishTx_NoJobsMeansNilRiverOK(t *testing.T) {
+	ctx := context.Background()
+	stub := &stubEventRepo{}
+	bus := &Bus{eventRepo: stub}
+
+	env := &Envelope{
+		Kind:       KindInteractionManual,
+		Source:     "manual",
+		Payload:    json.RawMessage(`{"version":1,"contact_id":"00000000-0000-0000-0000-000000000001","direction":"outbound","occurred_at":"2026-04-10T12:00:00Z"}`),
+		ObservedAt: time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC),
+	}
+	require.NoError(t, bus.PublishTx(ctx, nonNilStubTx(), env))
+	require.Equal(t, 1, stub.insertCalls)
+}
+
+// Ensure the rivertype import stays referenced even if the router case
+// above is one day refactored to drop the explicit ByState slice.
+var _ = rivertype.JobStateScheduled
+var _ = river.UniqueOpts{}

--- a/backend/internal/events/bus_test.go
+++ b/backend/internal/events/bus_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/riverqueue/river"
-	"github.com/riverqueue/river/rivertype"
 	"github.com/stretchr/testify/require"
 )
 
@@ -139,15 +138,11 @@ func TestConsumerJobsForKind_ContactMethodsAdded(t *testing.T) {
 	require.NotNil(t, jobs[0].Opts)
 	require.Equal(t, 3, jobs[0].Opts.MaxAttempts)
 	require.True(t, jobs[0].Opts.UniqueOpts.ByArgs, "ByArgs must be true so UniqueOpts considers args; river:\"unique\" tags on ContactID+RematchJobID scope the hash")
-	require.ElementsMatch(t,
-		[]rivertype.JobState{
-			rivertype.JobStateScheduled,
-			rivertype.JobStateAvailable,
-			rivertype.JobStateRunning,
-			rivertype.JobStateRetryable,
-		},
-		jobs[0].Opts.UniqueOpts.ByState,
-	)
+	// ByState intentionally empty — river applies its default set
+	// (Pending/Scheduled/Available/Running/Retryable) when ByState is
+	// nil. A partial list must include Pending or river rejects the
+	// InsertOpts.
+	require.Empty(t, jobs[0].Opts.UniqueOpts.ByState)
 }
 
 // TestConsumerJobsForKind_ContactMethodsAdded_MalformedPayload_Errors
@@ -447,7 +442,4 @@ func TestPublishTx_NoJobsMeansNilRiverOK(t *testing.T) {
 	require.Equal(t, 1, stub.insertCalls)
 }
 
-// Ensure the rivertype import stays referenced even if the router case
-// above is one day refactored to drop the explicit ByState slice.
-var _ = rivertype.JobStateScheduled
 var _ = river.UniqueOpts{}

--- a/backend/internal/repository/event.go
+++ b/backend/internal/repository/event.go
@@ -137,3 +137,18 @@ func (r *EventRepository) FindEventBySource(ctx context.Context, source, sourceI
 	}
 	return convertDbEvent(row), nil
 }
+
+// CountRematchDispatcherJobs returns the number of river_job rows of
+// kind "rematch_dispatcher" whose args JSON matches the given
+// (contactID, rematchJobID) tuple. Test-only helper for rematch dedup
+// integration tests — avoids inlining raw SQL into Go test code.
+//
+// The underlying sqlc query lives in queries/event.sql because
+// river_job is interrogated alongside the event-bus tables and has no
+// dedicated sqlc module.
+func (r *EventRepository) CountRematchDispatcherJobs(ctx context.Context, contactID, rematchJobID uuid.UUID) (int64, error) {
+	return r.queries.CountRematchDispatcherJobsByContactAndJob(ctx, db.CountRematchDispatcherJobsByContactAndJobParams{
+		ContactID:    contactID.String(),
+		RematchJobID: rematchJobID.String(),
+	})
+}

--- a/backend/internal/service/contact.go
+++ b/backend/internal/service/contact.go
@@ -78,10 +78,10 @@ type ContactService struct {
 	// deriveFollowUpClosure.
 	followUp FollowUpConsumer
 	// bus is the event bus used to publish contact_methods.added on
-	// method-adding mutations. Required in production wiring (main.go)
-	// per PR-10 spec §3.4.4. Nil-safe for tests that don't exercise
-	// the rematch dispatch path — the publisher short-circuits when
-	// nil and leaves rematchJobID as uuid.Nil in the response.
+	// method-adding mutations. Required in production wiring (main.go).
+	// Nil-safe for tests that don't exercise the rematch dispatch path —
+	// the publisher short-circuits when nil and leaves rematchJobID as
+	// uuid.Nil in the response.
 	bus *events.Bus
 	// rematchRegistry is the narrow contract for registering an in-memory
 	// job entry synchronously so GET /rematch/jobs/:id works immediately
@@ -99,13 +99,11 @@ type ContactService struct {
 }
 
 // NewContactService constructs a ContactService. bus and rematchRegistry
-// are required for the PR-10 event-bus rematch path in production (spec
-// §3.4.4): CreateContact / UpdateContact / RescanRematch publish
+// are required for the event-bus rematch path in production:
+// CreateContact / UpdateContact / RescanRematch publish
 // contact_methods.added through bus and seed the in-memory job entry via
 // rematchRegistry. Tests that don't exercise rematch may pass nil for
-// both — the publisher silently skips when bus is nil, matching the old
-// "SetRematchService not called" semantic without the bug class that
-// setter omission caused in non-test paths.
+// both — the publisher silently skips when bus is nil.
 func NewContactService(
 	database *db.Database,
 	contactRepo *repository.ContactRepository,
@@ -282,15 +280,22 @@ func (s *ContactService) CreateContact(ctx context.Context, req repository.Creat
 		return nil, uuid.Nil, err
 	}
 
-	// Publish contact_methods.added INSIDE the tx so the event row +
-	// river consumer job land atomically with the method rows (spec §4).
-	// A tx rollback rolls back method rows AND the event AND the river
-	// job together. jobID is only returned to the caller after Commit
-	// succeeds, so clients never see a jobID for work that didn't ship.
-	newMethodRefs := contactMethodsToRefs(createdMethods)
-	if len(newMethodRefs) > 0 && s.bus != nil {
+	// Publish contact_methods.added inside the tx so event row + river
+	// consumer job land atomically with the method rows (spec §4). A tx
+	// rollback rolls back all three. jobID returns only after Commit,
+	// so clients never see a jobID for work that didn't ship.
+	//
+	// Filter to eligible methods first: if no registered rematch handler
+	// matches any new method, we skip publishing entirely and return
+	// uuid.Nil — matches the pre-cutover StartRematchForContact contract
+	// where unhandled methods produced no job id.
+	var eligibleMethods []Method
+	if len(createdMethods) > 0 && s.rematchRegistry != nil {
+		eligibleMethods = s.rematchRegistry.EligibleMethods(toRematchMethods(createdMethods))
+	}
+	if len(eligibleMethods) > 0 && s.bus != nil {
 		jobID = uuid.New()
-		env, marshalErr := buildContactMethodsAddedEnvelope("manual", contact.ID, newMethodRefs, jobID)
+		env, marshalErr := buildContactMethodsAddedEnvelope("manual", contact.ID, rematchMethodsToRefs(eligibleMethods), jobID)
 		if marshalErr != nil {
 			return nil, uuid.Nil, marshalErr
 		}
@@ -308,7 +313,7 @@ func (s *ContactService) CreateContact(ctx context.Context, req repository.Creat
 	// /rematch/jobs/:id returns it immediately. Idempotent; safe even
 	// though the bus may have deduped a publisher retry.
 	if jobID != uuid.Nil && s.rematchRegistry != nil {
-		s.rematchRegistry.RegisterPending(jobID, contact.ID, refsToRematchMethods(newMethodRefs))
+		s.rematchRegistry.RegisterPending(jobID, contact.ID, eligibleMethods)
 	}
 	return contact, jobID, nil
 }
@@ -411,23 +416,27 @@ func (s *ContactService) UpdateContact(ctx context.Context, id uuid.UUID, req re
 		sortContactMethods(updatedMethods)
 	}
 
-	// Compute the method diff + publish INSIDE the tx so the event row,
-	// river consumer job, and method rows all commit (or roll back)
-	// together (spec §4 atomicity). Only the replaceMethods branch can
-	// add new methods — the !replaceMethods branch leaves methods as-is.
-	var newlyAddedMethods []Method
-	if replaceMethods && s.bus != nil {
-		newlyAddedMethods = diffNewMethods(existingBefore, updatedMethods)
-		if len(newlyAddedMethods) > 0 {
-			jobID = uuid.New()
-			refs := rematchMethodsToRefs(newlyAddedMethods)
-			env, marshalErr := buildContactMethodsAddedEnvelope("manual", id, refs, jobID)
-			if marshalErr != nil {
-				return nil, uuid.Nil, marshalErr
-			}
-			if err := s.bus.PublishTx(ctx, tx, env); err != nil {
-				return nil, uuid.Nil, fmt.Errorf("publish contact_methods.added: %w", err)
-			}
+	// Compute method diff + publish inside the tx so event row + river
+	// job + method rows commit/roll back together (spec §4). Only the
+	// replaceMethods branch can add new methods — !replaceMethods leaves
+	// methods as-is.
+	//
+	// Filter to eligible methods first (see CreateContact for rationale):
+	// unhandled types skip publishing and return uuid.Nil.
+	var eligibleAddedMethods []Method
+	if replaceMethods && s.rematchRegistry != nil {
+		newlyAdded := diffNewMethods(existingBefore, updatedMethods)
+		eligibleAddedMethods = s.rematchRegistry.EligibleMethods(newlyAdded)
+	}
+	if replaceMethods && len(eligibleAddedMethods) > 0 && s.bus != nil {
+		jobID = uuid.New()
+		refs := rematchMethodsToRefs(eligibleAddedMethods)
+		env, marshalErr := buildContactMethodsAddedEnvelope("manual", id, refs, jobID)
+		if marshalErr != nil {
+			return nil, uuid.Nil, marshalErr
+		}
+		if err := s.bus.PublishTx(ctx, tx, env); err != nil {
+			return nil, uuid.Nil, fmt.Errorf("publish contact_methods.added: %w", err)
 		}
 	}
 
@@ -437,7 +446,7 @@ func (s *ContactService) UpdateContact(ctx context.Context, id uuid.UUID, req re
 
 	assignMethods(contact, updatedMethods)
 	if jobID != uuid.Nil && s.rematchRegistry != nil {
-		s.rematchRegistry.RegisterPending(jobID, id, newlyAddedMethods)
+		s.rematchRegistry.RegisterPending(jobID, id, eligibleAddedMethods)
 	}
 	return contact, jobID, nil
 }

--- a/backend/internal/service/contact.go
+++ b/backend/internal/service/contact.go
@@ -10,6 +10,7 @@ import (
 	"personal-crm/backend/internal/accelerated"
 	"personal-crm/backend/internal/cadence"
 	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
 	"personal-crm/backend/internal/logger"
 	"personal-crm/backend/internal/repository"
 
@@ -75,8 +76,18 @@ type ContactService struct {
 	// with consumer wiring. Non-bus callers (Todoist completion path,
 	// Promote/Extend) route through followUp.ApplyInteraction inside
 	// deriveFollowUpClosure.
-	followUp   FollowUpConsumer
-	rematchSvc *RematchService
+	followUp FollowUpConsumer
+	// bus is the event bus used to publish contact_methods.added on
+	// method-adding mutations. Required in production wiring (main.go)
+	// per PR-10 spec §3.4.4. Nil-safe for tests that don't exercise
+	// the rematch dispatch path — the publisher short-circuits when
+	// nil and leaves rematchJobID as uuid.Nil in the response.
+	bus *events.Bus
+	// rematchRegistry is the narrow contract for registering an in-memory
+	// job entry synchronously so GET /rematch/jobs/:id works immediately
+	// after publish. Implemented by *RematchService. Required alongside
+	// bus in production; nil-safe for tests.
+	rematchRegistry RematchRegistry
 	// cadence is the direct-invoke writer (the sole writer of the four
 	// cadence columns post-cutover). Injected via SetCadenceUpdater
 	// after construction to avoid a circular dep with consumer wiring.
@@ -87,13 +98,31 @@ type ContactService struct {
 	cadence cadenceWriter
 }
 
-func NewContactService(database *db.Database, contactRepo *repository.ContactRepository, contactMethodRepo *repository.ContactMethodRepository, interactionRepo *repository.InteractionRepository, contactTaskRepo *repository.ContactTaskRepository) *ContactService {
+// NewContactService constructs a ContactService. bus and rematchRegistry
+// are required for the PR-10 event-bus rematch path in production (spec
+// §3.4.4): CreateContact / UpdateContact / RescanRematch publish
+// contact_methods.added through bus and seed the in-memory job entry via
+// rematchRegistry. Tests that don't exercise rematch may pass nil for
+// both — the publisher silently skips when bus is nil, matching the old
+// "SetRematchService not called" semantic without the bug class that
+// setter omission caused in non-test paths.
+func NewContactService(
+	database *db.Database,
+	contactRepo *repository.ContactRepository,
+	contactMethodRepo *repository.ContactMethodRepository,
+	interactionRepo *repository.InteractionRepository,
+	contactTaskRepo *repository.ContactTaskRepository,
+	bus *events.Bus,
+	rematchRegistry RematchRegistry,
+) *ContactService {
 	return &ContactService{
 		database:          database,
 		contactRepo:       contactRepo,
 		contactMethodRepo: contactMethodRepo,
 		interactionRepo:   interactionRepo,
 		contactTaskRepo:   contactTaskRepo,
+		bus:               bus,
+		rematchRegistry:   rematchRegistry,
 	}
 }
 
@@ -107,10 +136,16 @@ func (s *ContactService) SetFollowUpConsumer(fm FollowUpConsumer) {
 	s.followUp = fm
 }
 
-// SetRematchService injects the rematch service. Safe to leave unset — CreateContact
-// and UpdateContact return uuid.Nil as the jobID when nil.
-func (s *ContactService) SetRematchService(r *RematchService) {
-	s.rematchSvc = r
+// InjectBusForTest swaps the event bus reference after construction.
+// Integration tests have a chicken-and-egg dependency where the bus
+// needs the ContactService (via InteractionRecorder) AND the
+// ContactService needs the bus (to publish contact_methods.added).
+// Production main.go resolves this by reordering construction — tests
+// can't do that cleanly across many fixtures, so this setter exists
+// for test-only bus injection. Must only be called before the
+// service is used concurrently; no synchronization is performed.
+func (s *ContactService) InjectBusForTest(bus *events.Bus) {
+	s.bus = bus
 }
 
 // SetCadenceUpdater injects the cadence writer. Main.go wires this
@@ -247,13 +282,33 @@ func (s *ContactService) CreateContact(ctx context.Context, req repository.Creat
 		return nil, uuid.Nil, err
 	}
 
+	// Publish contact_methods.added INSIDE the tx so the event row +
+	// river consumer job land atomically with the method rows (spec §4).
+	// A tx rollback rolls back method rows AND the event AND the river
+	// job together. jobID is only returned to the caller after Commit
+	// succeeds, so clients never see a jobID for work that didn't ship.
+	newMethodRefs := contactMethodsToRefs(createdMethods)
+	if len(newMethodRefs) > 0 && s.bus != nil {
+		jobID = uuid.New()
+		env, marshalErr := buildContactMethodsAddedEnvelope("manual", contact.ID, newMethodRefs, jobID)
+		if marshalErr != nil {
+			return nil, uuid.Nil, marshalErr
+		}
+		if err := s.bus.PublishTx(ctx, tx, env); err != nil {
+			return nil, uuid.Nil, fmt.Errorf("publish contact_methods.added: %w", err)
+		}
+	}
+
 	if err = tx.Commit(ctx); err != nil {
 		return nil, uuid.Nil, err
 	}
 
 	assignMethods(contact, createdMethods)
-	if s.rematchSvc != nil && len(createdMethods) > 0 {
-		jobID = s.rematchSvc.StartRematchForContact(contact.ID, toRematchMethods(createdMethods))
+	// RegisterPending seeds the in-memory entry so GET
+	// /rematch/jobs/:id returns it immediately. Idempotent; safe even
+	// though the bus may have deduped a publisher retry.
+	if jobID != uuid.Nil && s.rematchRegistry != nil {
+		s.rematchRegistry.RegisterPending(jobID, contact.ID, refsToRematchMethods(newMethodRefs))
 	}
 	return contact, jobID, nil
 }
@@ -356,16 +411,33 @@ func (s *ContactService) UpdateContact(ctx context.Context, id uuid.UUID, req re
 		sortContactMethods(updatedMethods)
 	}
 
+	// Compute the method diff + publish INSIDE the tx so the event row,
+	// river consumer job, and method rows all commit (or roll back)
+	// together (spec §4 atomicity). Only the replaceMethods branch can
+	// add new methods — the !replaceMethods branch leaves methods as-is.
+	var newlyAddedMethods []Method
+	if replaceMethods && s.bus != nil {
+		newlyAddedMethods = diffNewMethods(existingBefore, updatedMethods)
+		if len(newlyAddedMethods) > 0 {
+			jobID = uuid.New()
+			refs := rematchMethodsToRefs(newlyAddedMethods)
+			env, marshalErr := buildContactMethodsAddedEnvelope("manual", id, refs, jobID)
+			if marshalErr != nil {
+				return nil, uuid.Nil, marshalErr
+			}
+			if err := s.bus.PublishTx(ctx, tx, env); err != nil {
+				return nil, uuid.Nil, fmt.Errorf("publish contact_methods.added: %w", err)
+			}
+		}
+	}
+
 	if err = tx.Commit(ctx); err != nil {
 		return nil, uuid.Nil, err
 	}
 
 	assignMethods(contact, updatedMethods)
-	if replaceMethods && s.rematchSvc != nil {
-		newlyAdded := diffNewMethods(existingBefore, updatedMethods)
-		if len(newlyAdded) > 0 {
-			jobID = s.rematchSvc.StartRematchForContact(id, newlyAdded)
-		}
+	if jobID != uuid.Nil && s.rematchRegistry != nil {
+		s.rematchRegistry.RegisterPending(jobID, id, newlyAddedMethods)
 	}
 	return contact, jobID, nil
 }

--- a/backend/internal/service/enrichment.go
+++ b/backend/internal/service/enrichment.go
@@ -45,7 +45,7 @@ type EnrichmentService struct {
 // NewEnrichmentService creates a new enrichment service. database is
 // required post-cutover so the cadence-override path can open its own
 // tx for the profile-update + ApplyContactByOverride pair. bus +
-// rematchRegistry are required for the PR-10 event-bus rematch path:
+// rematchRegistry are required for the event-bus rematch path:
 // EnrichContactFromExternal* publish contact_methods.added through bus
 // and seed the in-memory job entry via rematchRegistry. Tests that
 // don't exercise rematch may pass nil for both — the publisher silently
@@ -141,10 +141,10 @@ func (s *EnrichmentService) EnrichContactFromExternal(
 	}
 
 	// Method enrichment + per-method audit inserts + contact_methods.added
-	// publish all share a single tx (spec §4 atomicity). Propagating the
-	// tx error is required — silent swallow would let the caller see a
+	// publish all share a single tx for atomicity. Propagating the tx
+	// error is required — silent swallow would let the caller see a
 	// uuid.Nil jobID while the rolled-back method rows leave the contact
-	// unchanged (Codex round 1 P1).
+	// unchanged.
 	jobID, addedMethods, err := s.enrichMethodsAndPublish(ctx, contact, external, "")
 	if err != nil {
 		return uuid.Nil, fmt.Errorf("enrich contact methods: %w", err)
@@ -181,6 +181,7 @@ func (s *EnrichmentService) enrichMethodsAndPublish(
 		// the external contact's provenance (gcontacts, telegram, etc.).
 		effectiveSource = external.Source
 	}
+	var eligible []Method
 	txErr := pgx.BeginTxFunc(ctx, s.database.Pool, pgx.TxOptions{}, func(tx pgx.Tx) error {
 		txQueries := db.New(tx)
 		txMethodRepo := repository.NewContactMethodRepository(txQueries)
@@ -194,11 +195,19 @@ func (s *EnrichmentService) enrichMethodsAndPublish(
 		if len(added) == 0 {
 			return nil
 		}
+		// Filter to handler-eligible methods: skip publish when no
+		// registered rematch handler matches any added method.
+		if s.rematchRegistry != nil {
+			eligible = s.rematchRegistry.EligibleMethods(added)
+		}
+		if len(eligible) == 0 {
+			return nil
+		}
 		if s.bus == nil {
 			return nil
 		}
 		jobID = uuid.New()
-		refs := rematchMethodsToRefs(added)
+		refs := rematchMethodsToRefs(eligible)
 		env, err := buildContactMethodsAddedEnvelope(effectiveSource, contact.ID, refs, jobID)
 		if err != nil {
 			return err
@@ -208,7 +217,9 @@ func (s *EnrichmentService) enrichMethodsAndPublish(
 	if txErr != nil {
 		return uuid.Nil, nil, txErr
 	}
-	return jobID, added, nil
+	// Caller passes eligible methods into RegisterPending so the
+	// in-memory job entry matches what the consumer will run.
+	return jobID, eligible, nil
 }
 
 // EnrichContactFromExternalWithSelections enriches a CRM contact with user-selected methods.
@@ -348,6 +359,7 @@ func (s *EnrichmentService) enrichMethodsAndPublishWithSelections(
 	if effectiveSource == "" {
 		effectiveSource = "manual"
 	}
+	var eligible []Method
 	txErr := pgx.BeginTxFunc(ctx, s.database.Pool, pgx.TxOptions{}, func(tx pgx.Tx) error {
 		txQueries := db.New(tx)
 		txMethodRepo := repository.NewContactMethodRepository(txQueries)
@@ -363,11 +375,19 @@ func (s *EnrichmentService) enrichMethodsAndPublishWithSelections(
 		if len(added) == 0 {
 			return nil
 		}
+		// Filter to handler-eligible methods: skip publish when no
+		// registered rematch handler matches any added method.
+		if s.rematchRegistry != nil {
+			eligible = s.rematchRegistry.EligibleMethods(added)
+		}
+		if len(eligible) == 0 {
+			return nil
+		}
 		if s.bus == nil {
 			return nil
 		}
 		jobID = uuid.New()
-		refs := rematchMethodsToRefs(added)
+		refs := rematchMethodsToRefs(eligible)
 		env, err := buildContactMethodsAddedEnvelope(effectiveSource, contact.ID, refs, jobID)
 		if err != nil {
 			return err
@@ -377,7 +397,7 @@ func (s *EnrichmentService) enrichMethodsAndPublishWithSelections(
 	if txErr != nil {
 		return uuid.Nil, nil, txErr
 	}
-	return jobID, added, nil
+	return jobID, eligible, nil
 }
 
 // enrichContactMethodsWithSelectionsTx adds methods based on user
@@ -513,9 +533,11 @@ func (s *EnrichmentService) enrichContactMethodsWithSelectionsTx(
 		}
 
 		added = append(added, Method{Type: newMethod.Type, Value: newMethod.ValueNormalized})
-		s.recordEnrichmentTx(ctx, txEnrichmentRepo, contact.ID, external,
+		if auditErr := s.recordEnrichmentTx(ctx, txEnrichmentRepo, contact.ID, external,
 			"method:"+sel.Type+":"+identity.Normalize(storedValue, mapMethodTypeToIdentifier(sel.Type)),
-			storedValue)
+			storedValue); auditErr != nil {
+			return nil, auditErr
+		}
 		existingKeys[selKey] = true
 	}
 
@@ -549,10 +571,8 @@ func (s *EnrichmentService) enrichContactMethodsWithSelectionsTx(
 	// Per-selection method errors (e.g., "value not found in external
 	// contact") are logged but NOT returned as a tx-failing error —
 	// returning would roll back successfully-inserted methods and drop
-	// the entire link operation. Callers prior to PR 10 ran method
-	// inserts outside a tx and logged-and-proceeded on methodErrors;
-	// the tx-wrap MUST preserve that partial-success semantic for
-	// link/import paths (existing API contract).
+	// the entire link operation. Link/import paths expect partial
+	// success: valid selections commit, invalid ones log and skip.
 	if len(methodErrors) > 0 {
 		logger.Warn().
 			Str("contact_id", contact.ID.String()).
@@ -620,9 +640,11 @@ func (s *EnrichmentService) enrichContactMethodsTx(
 			continue
 		}
 		added = append(added, Method{Type: created.Type, Value: created.ValueNormalized})
-		s.recordEnrichmentTx(ctx, txEnrichmentRepo, contact.ID, external,
+		if auditErr := s.recordEnrichmentTx(ctx, txEnrichmentRepo, contact.ID, external,
 			"method:"+input.Type+":"+identity.Normalize(input.Value, mapMethodTypeToIdentifier(input.Type)),
-			input.Value)
+			input.Value); auditErr != nil {
+			return nil, auditErr
+		}
 		existingSet[key] = true
 	}
 	return added, nil
@@ -684,8 +706,7 @@ func (s *EnrichmentService) recordEnrichment(
 // Unlike recordEnrichment which log-swallows insert errors, this
 // variant returns the error to its caller — an audit-insert failure
 // inside the tx aborts the whole flow so method rows + event + audit
-// all roll back together. Wraps insert errors with context for debug
-// logging by the caller.
+// all roll back together.
 func (s *EnrichmentService) recordEnrichmentTx(
 	ctx context.Context,
 	txEnrichmentRepo *repository.EnrichmentRepository,
@@ -693,7 +714,7 @@ func (s *EnrichmentService) recordEnrichmentTx(
 	external *repository.ExternalContact,
 	field string,
 	value string,
-) {
+) error {
 	var externalContactID *uuid.UUID
 	if external.ID != uuid.Nil {
 		externalContactID = &external.ID
@@ -707,8 +728,9 @@ func (s *EnrichmentService) recordEnrichmentTx(
 		OriginalValue:     &value,
 	})
 	if err != nil {
-		logger.Warn().Err(err).Str("field", field).Msg("failed to record enrichment (tx)")
+		return fmt.Errorf("record enrichment (tx) for field %s: %w", field, err)
 	}
+	return nil
 }
 
 // insertContactMethodSavepoint wraps CreateContactMethod in a nested

--- a/backend/internal/service/enrichment.go
+++ b/backend/internal/service/enrichment.go
@@ -546,9 +546,18 @@ func (s *EnrichmentService) enrichContactMethodsWithSelectionsTx(
 		}
 	}
 
-	// Return error if any method operations failed
+	// Per-selection method errors (e.g., "value not found in external
+	// contact") are logged but NOT returned as a tx-failing error —
+	// returning would roll back successfully-inserted methods and drop
+	// the entire link operation. Callers prior to PR 10 ran method
+	// inserts outside a tx and logged-and-proceeded on methodErrors;
+	// the tx-wrap MUST preserve that partial-success semantic for
+	// link/import paths (existing API contract).
 	if len(methodErrors) > 0 {
-		return added, fmt.Errorf("method enrichment errors: %s", strings.Join(methodErrors, "; "))
+		logger.Warn().
+			Str("contact_id", contact.ID.String()).
+			Str("errors", strings.Join(methodErrors, "; ")).
+			Msg("enrichment: one or more selected methods could not be inserted; partial success")
 	}
 
 	return added, nil

--- a/backend/internal/service/enrichment.go
+++ b/backend/internal/service/enrichment.go
@@ -9,6 +9,7 @@ import (
 
 	"personal-crm/backend/internal/cadence"
 	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
 	"personal-crm/backend/internal/identity"
 	"personal-crm/backend/internal/logger"
 	"personal-crm/backend/internal/repository"
@@ -32,28 +33,38 @@ type MethodSelection struct {
 // Inferred-enrichment paths (no cadence) continue to use the profile-
 // only UpdateContact query and never touch cadence columns.
 type EnrichmentService struct {
-	database       *db.Database
-	contactRepo    *repository.ContactRepository
-	methodRepo     *repository.ContactMethodRepository
-	enrichmentRepo *repository.EnrichmentRepository
-	rematchSvc     *RematchService
-	cadence        cadenceWriter
+	database        *db.Database
+	contactRepo     *repository.ContactRepository
+	methodRepo      *repository.ContactMethodRepository
+	enrichmentRepo  *repository.EnrichmentRepository
+	bus             *events.Bus
+	rematchRegistry RematchRegistry
+	cadence         cadenceWriter
 }
 
 // NewEnrichmentService creates a new enrichment service. database is
 // required post-cutover so the cadence-override path can open its own
-// tx for the profile-update + ApplyContactByOverride pair.
+// tx for the profile-update + ApplyContactByOverride pair. bus +
+// rematchRegistry are required for the PR-10 event-bus rematch path:
+// EnrichContactFromExternal* publish contact_methods.added through bus
+// and seed the in-memory job entry via rematchRegistry. Tests that
+// don't exercise rematch may pass nil for both — the publisher silently
+// skips when bus is nil.
 func NewEnrichmentService(
 	database *db.Database,
 	contactRepo *repository.ContactRepository,
 	methodRepo *repository.ContactMethodRepository,
 	enrichmentRepo *repository.EnrichmentRepository,
+	bus *events.Bus,
+	rematchRegistry RematchRegistry,
 ) *EnrichmentService {
 	return &EnrichmentService{
-		database:       database,
-		contactRepo:    contactRepo,
-		methodRepo:     methodRepo,
-		enrichmentRepo: enrichmentRepo,
+		database:        database,
+		contactRepo:     contactRepo,
+		methodRepo:      methodRepo,
+		enrichmentRepo:  enrichmentRepo,
+		bus:             bus,
+		rematchRegistry: rematchRegistry,
 	}
 }
 
@@ -65,10 +76,14 @@ func (s *EnrichmentService) SetCadenceUpdater(c cadenceWriter) {
 	s.cadence = c
 }
 
-// SetRematchService injects the rematch service. Safe to leave unset —
-// Enrich* methods return uuid.Nil as the jobID when nil.
-func (s *EnrichmentService) SetRematchService(r *RematchService) {
-	s.rematchSvc = r
+// InjectBusForTest swaps the event bus reference after construction.
+// Integration tests have a chicken-and-egg dependency where the bus
+// needs the ContactService (via InteractionRecorder) AND the services
+// need the bus. Production main.go resolves this by reordering
+// construction; tests call this post-construction. Must only be called
+// before the service is used concurrently.
+func (s *EnrichmentService) InjectBusForTest(bus *events.Bus) {
+	s.bus = bus
 }
 
 // EnrichContactFromExternal enriches a CRM contact with data from an external contact.
@@ -125,22 +140,75 @@ func (s *EnrichmentService) EnrichContactFromExternal(
 		}
 	}
 
-	// Enrich contact methods (emails, phones)
-	addedMethods, err := s.enrichContactMethods(ctx, contact, external)
+	// Method enrichment + per-method audit inserts + contact_methods.added
+	// publish all share a single tx (spec §4 atomicity). Propagating the
+	// tx error is required — silent swallow would let the caller see a
+	// uuid.Nil jobID while the rolled-back method rows leave the contact
+	// unchanged (Codex round 1 P1).
+	jobID, addedMethods, err := s.enrichMethodsAndPublish(ctx, contact, external, "")
 	if err != nil {
-		logger.Warn().Err(err).Msg("failed to enrich contact methods")
+		return uuid.Nil, fmt.Errorf("enrich contact methods: %w", err)
 	}
-
-	return s.startRematchIfEligible(crmContactID, addedMethods), nil
+	if jobID != uuid.Nil && s.rematchRegistry != nil {
+		s.rematchRegistry.RegisterPending(jobID, crmContactID, addedMethods)
+	}
+	return jobID, nil
 }
 
-// startRematchIfEligible dispatches a rematch job when the service is wired and
-// at least one method was added. Returns uuid.Nil otherwise.
-func (s *EnrichmentService) startRematchIfEligible(contactID uuid.UUID, added []Method) uuid.UUID {
-	if s.rematchSvc == nil || len(added) == 0 {
-		return uuid.Nil
+// enrichMethodsAndPublish wraps the method-enrichment loop, per-method
+// audit inserts, and the contact_methods.added event publish in a
+// single pgx.Tx so they commit or roll back together. Returns a
+// non-Nil jobID iff at least one method was added and s.bus is wired;
+// otherwise jobID=uuid.Nil. When selectedMethods is non-empty (link/
+// import WithSelections flow), the method-loop uses user selections;
+// otherwise the full BuildMethodsFromExternal set is enriched.
+//
+// The caller registers the in-memory pending entry via
+// rematchRegistry.RegisterPending post-commit.
+func (s *EnrichmentService) enrichMethodsAndPublish(
+	ctx context.Context,
+	contact *repository.Contact,
+	external *repository.ExternalContact,
+	source string,
+) (uuid.UUID, []Method, error) {
+	var (
+		added []Method
+		jobID uuid.UUID
+	)
+	effectiveSource := source
+	if effectiveSource == "" {
+		// Default source for the EnrichContactFromExternal path matches
+		// the external contact's provenance (gcontacts, telegram, etc.).
+		effectiveSource = external.Source
 	}
-	return s.rematchSvc.StartRematchForContact(contactID, added)
+	txErr := pgx.BeginTxFunc(ctx, s.database.Pool, pgx.TxOptions{}, func(tx pgx.Tx) error {
+		txQueries := db.New(tx)
+		txMethodRepo := repository.NewContactMethodRepository(txQueries)
+		txEnrichmentRepo := repository.NewEnrichmentRepository(txQueries)
+
+		var err error
+		added, err = s.enrichContactMethodsTx(ctx, tx, txMethodRepo, txEnrichmentRepo, contact, external)
+		if err != nil {
+			return err
+		}
+		if len(added) == 0 {
+			return nil
+		}
+		if s.bus == nil {
+			return nil
+		}
+		jobID = uuid.New()
+		refs := rematchMethodsToRefs(added)
+		env, err := buildContactMethodsAddedEnvelope(effectiveSource, contact.ID, refs, jobID)
+		if err != nil {
+			return err
+		}
+		return s.bus.PublishTx(ctx, tx, env)
+	})
+	if txErr != nil {
+		return uuid.Nil, nil, txErr
+	}
+	return jobID, added, nil
 }
 
 // EnrichContactFromExternalWithSelections enriches a CRM contact with user-selected methods.
@@ -243,19 +311,91 @@ func (s *EnrichmentService) EnrichContactFromExternalWithSelections(
 		}
 	}
 
-	// Enrich contact methods using selections
-	addedMethods, err := s.enrichContactMethodsWithSelections(ctx, contact, external, selectedMethods, conflictResolutions)
+	// Enrich contact methods using selections + publish inside a tx so
+	// method inserts + audits + event all commit or roll back together
+	// (spec §4 atomicity). Propagates tx error to caller — the handler
+	// (LinkContact) decides whether to surface as HTTP 500 vs conflict.
+	jobID, addedMethods, err := s.enrichMethodsAndPublishWithSelections(
+		ctx, contact, external, selectedMethods, conflictResolutions, "manual",
+	)
 	if err != nil {
 		return uuid.Nil, err
 	}
-
-	return s.startRematchIfEligible(crmContactID, addedMethods), nil
+	if jobID != uuid.Nil && s.rematchRegistry != nil {
+		s.rematchRegistry.RegisterPending(jobID, crmContactID, addedMethods)
+	}
+	return jobID, nil
 }
 
-// enrichContactMethodsWithSelections adds methods based on user selection and conflict resolution.
-// Returns the list of newly-created methods (for rematch dispatch) plus any error.
-func (s *EnrichmentService) enrichContactMethodsWithSelections(
+// enrichMethodsAndPublishWithSelections is the selection-driven
+// counterpart to enrichMethodsAndPublish. Wraps the user-selected
+// method-insert loop, per-method audit inserts, and event publish in a
+// single pgx.Tx (spec §4 atomicity). Source defaults to "manual"
+// (user-initiated link/import).
+func (s *EnrichmentService) enrichMethodsAndPublishWithSelections(
 	ctx context.Context,
+	contact *repository.Contact,
+	external *repository.ExternalContact,
+	selectedMethods []MethodSelection,
+	conflictResolutions map[string]string,
+	source string,
+) (uuid.UUID, []Method, error) {
+	var (
+		added []Method
+		jobID uuid.UUID
+	)
+	effectiveSource := source
+	if effectiveSource == "" {
+		effectiveSource = "manual"
+	}
+	txErr := pgx.BeginTxFunc(ctx, s.database.Pool, pgx.TxOptions{}, func(tx pgx.Tx) error {
+		txQueries := db.New(tx)
+		txMethodRepo := repository.NewContactMethodRepository(txQueries)
+		txEnrichmentRepo := repository.NewEnrichmentRepository(txQueries)
+
+		var err error
+		added, err = s.enrichContactMethodsWithSelectionsTx(
+			ctx, tx, txMethodRepo, txEnrichmentRepo, contact, external, selectedMethods, conflictResolutions,
+		)
+		if err != nil {
+			return err
+		}
+		if len(added) == 0 {
+			return nil
+		}
+		if s.bus == nil {
+			return nil
+		}
+		jobID = uuid.New()
+		refs := rematchMethodsToRefs(added)
+		env, err := buildContactMethodsAddedEnvelope(effectiveSource, contact.ID, refs, jobID)
+		if err != nil {
+			return err
+		}
+		return s.bus.PublishTx(ctx, tx, env)
+	})
+	if txErr != nil {
+		return uuid.Nil, nil, txErr
+	}
+	return jobID, added, nil
+}
+
+// enrichContactMethodsWithSelectionsTx adds methods based on user
+// selection and conflict resolution inside the caller's tx.
+// Per-method audit inserts share the tx so they commit with the
+// method rows (spec §4 atomicity).
+//
+// Each CreateContactMethod call runs inside a nested savepoint so a
+// unique-violation (concurrent-insert race) can be rolled back without
+// aborting the outer tx (CLAUDE.md gotcha: "pgx.Tx insert hitting a
+// unique-violation aborts the outer tx"). On savepoint rollback, the
+// caller refetches via the tx-scoped repo to recover the raced row's
+// ID for primary-method handling.
+func (s *EnrichmentService) enrichContactMethodsWithSelectionsTx(
+	ctx context.Context,
+	tx pgx.Tx,
+	txMethodRepo *repository.ContactMethodRepository,
+	txEnrichmentRepo *repository.EnrichmentRepository,
 	contact *repository.Contact,
 	external *repository.ExternalContact,
 	selectedMethods []MethodSelection,
@@ -264,8 +404,8 @@ func (s *EnrichmentService) enrichContactMethodsWithSelections(
 	// conflictResolutions is kept for API compatibility; type conflicts are no longer applicable.
 	_ = conflictResolutions
 
-	// Get existing methods
-	existingMethods, err := s.methodRepo.ListContactMethodsByContact(ctx, contact.ID)
+	// Get existing methods (tx-scoped)
+	existingMethods, err := txMethodRepo.ListContactMethodsByContact(ctx, contact.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -327,41 +467,43 @@ func (s *EnrichmentService) enrichContactMethodsWithSelections(
 		// is consistent with import-new storage.
 		storedValue := canonicalizeMethodValue(sel.Type, sel.OriginalValue)
 
-		newMethod, err := s.methodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
+		// Savepoint-wrapped insert so a unique-violation from a
+		// concurrent writer rolls back only the nested tx, leaving the
+		// outer tx live for subsequent inserts (CLAUDE.md gotcha).
+		newMethod, raced, err := insertContactMethodSavepoint(ctx, tx, repository.CreateContactMethodRequest{
 			ContactID: contact.ID,
 			Type:      sel.Type,
 			Value:     storedValue,
 			IsPrimary: false, // We'll update primary status separately
 		})
 		if err != nil {
-			if isUniqueViolation(err) {
-				// Concurrent insert won the race — refetch the contact's methods
-				// to recover the raced row's ID. Required when sel.IsPrimary is
-				// set, otherwise the user's primary selection is silently dropped.
-				if sel.IsPrimary {
-					raced, refetchErr := s.methodRepo.ListContactMethodsByContact(ctx, contact.ID)
-					if refetchErr != nil {
-						methodErrors = append(methodErrors,
-							fmt.Sprintf("recover raced primary for %s: %v", storedValue, refetchErr))
-					} else {
-						var recovered bool
-						for i := range raced {
-							if methodDedupKey(raced[i].Type, raced[i].Value) == selKey {
-								existingPrimaryMethodID = &raced[i].ID
-								recovered = true
-								break
-							}
-						}
-						if !recovered {
-							methodErrors = append(methodErrors,
-								fmt.Sprintf("raced row for %s not visible after refetch — primary selection dropped", storedValue))
+			methodErrors = append(methodErrors, fmt.Sprintf("failed to add method %s: %v", storedValue, err))
+			continue
+		}
+		if raced {
+			// Concurrent insert won — refetch to recover the row for
+			// primary-method handling.
+			if sel.IsPrimary {
+				racedRows, refetchErr := txMethodRepo.ListContactMethodsByContact(ctx, contact.ID)
+				if refetchErr != nil {
+					methodErrors = append(methodErrors,
+						fmt.Sprintf("recover raced primary for %s: %v", storedValue, refetchErr))
+				} else {
+					var recovered bool
+					for i := range racedRows {
+						if methodDedupKey(racedRows[i].Type, racedRows[i].Value) == selKey {
+							existingPrimaryMethodID = &racedRows[i].ID
+							recovered = true
+							break
 						}
 					}
+					if !recovered {
+						methodErrors = append(methodErrors,
+							fmt.Sprintf("raced row for %s not visible after refetch — primary selection dropped", storedValue))
+					}
 				}
-				existingKeys[selKey] = true
-				continue
 			}
-			methodErrors = append(methodErrors, fmt.Sprintf("failed to add method %s: %v", storedValue, err))
+			existingKeys[selKey] = true
 			continue
 		}
 
@@ -371,7 +513,7 @@ func (s *EnrichmentService) enrichContactMethodsWithSelections(
 		}
 
 		added = append(added, Method{Type: newMethod.Type, Value: newMethod.ValueNormalized})
-		s.recordEnrichment(ctx, contact.ID, external,
+		s.recordEnrichmentTx(ctx, txEnrichmentRepo, contact.ID, external,
 			"method:"+sel.Type+":"+identity.Normalize(storedValue, mapMethodTypeToIdentifier(sel.Type)),
 			storedValue)
 		existingKeys[selKey] = true
@@ -393,13 +535,13 @@ func (s *EnrichmentService) enrichContactMethodsWithSelections(
 		for i := range existingMethods {
 			m := &existingMethods[i]
 			if m.IsPrimary && m.ID != *primaryMethodID {
-				if err := s.methodRepo.SetPrimary(ctx, m.ID, false); err != nil {
+				if err := txMethodRepo.SetPrimary(ctx, m.ID, false); err != nil {
 					return added, fmt.Errorf("failed to clear existing primary method: %w", err)
 				}
 			}
 		}
 		// Set new primary
-		if err := s.methodRepo.SetPrimary(ctx, *primaryMethodID, true); err != nil {
+		if err := txMethodRepo.SetPrimary(ctx, *primaryMethodID, true); err != nil {
 			return added, fmt.Errorf("failed to set primary method: %w", err)
 		}
 	}
@@ -412,18 +554,28 @@ func (s *EnrichmentService) enrichContactMethodsWithSelections(
 	return added, nil
 }
 
-// enrichContactMethods adds missing contact methods from external contact.
-// Uses BuildMethodsFromExternal as the single source of truth for emitting
-// source-specific methods (emails, phones, telegram username). Dedup is
-// type-scoped normalized to match the DB unique index on
-// (contact_id, type, value_normalized).
-// Returns the list of newly-created methods (for rematch dispatch).
-func (s *EnrichmentService) enrichContactMethods(
+// enrichContactMethodsTx adds missing contact methods from the external
+// contact inside the caller's tx. Per-method audit inserts share the
+// tx so they commit with the method rows (spec §4 atomicity).
+//
+// Each CreateContactMethod runs inside a nested savepoint — a
+// unique-violation from a concurrent writer rolls back only the
+// savepoint, leaving the outer tx live for subsequent inserts
+// (CLAUDE.md gotcha: pgx.Tx + 23505 aborts the outer tx).
+//
+// Uses BuildMethodsFromExternal as the single source of truth for
+// emitting source-specific methods (emails, phones, telegram
+// username). Dedup is type-scoped normalized to match the DB unique
+// index on (contact_id, type, value_normalized).
+func (s *EnrichmentService) enrichContactMethodsTx(
 	ctx context.Context,
+	tx pgx.Tx,
+	txMethodRepo *repository.ContactMethodRepository,
+	txEnrichmentRepo *repository.EnrichmentRepository,
 	contact *repository.Contact,
 	external *repository.ExternalContact,
 ) ([]Method, error) {
-	existingMethods, err := s.methodRepo.ListContactMethodsByContact(ctx, contact.ID)
+	existingMethods, err := txMethodRepo.ListContactMethodsByContact(ctx, contact.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -440,26 +592,26 @@ func (s *EnrichmentService) enrichContactMethods(
 		if existingSet[key] {
 			continue
 		}
-		created, err := s.methodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
+		created, raced, err := insertContactMethodSavepoint(ctx, tx, repository.CreateContactMethodRequest{
 			ContactID: contact.ID,
 			Type:      input.Type,
 			Value:     input.Value,
 			IsPrimary: false, // Never set primary for enriched methods
 		})
 		if err != nil {
-			if isUniqueViolation(err) {
-				// Concurrent insert — already there, treat as success
-				existingSet[key] = true
-				continue
-			}
 			logger.Warn().Err(err).
 				Str("type", input.Type).
 				Str("value", input.Value).
 				Msg("failed to add method from enrichment")
 			continue
 		}
+		if raced {
+			// Concurrent insert — already there, treat as success
+			existingSet[key] = true
+			continue
+		}
 		added = append(added, Method{Type: created.Type, Value: created.ValueNormalized})
-		s.recordEnrichment(ctx, contact.ID, external,
+		s.recordEnrichmentTx(ctx, txEnrichmentRepo, contact.ID, external,
 			"method:"+input.Type+":"+identity.Normalize(input.Value, mapMethodTypeToIdentifier(input.Type)),
 			input.Value)
 		existingSet[key] = true
@@ -487,6 +639,10 @@ func isUniqueViolation(err error) bool {
 // Passes ExternalContactID=nil when external.ID is the zero UUID so matcher
 // paths that synthesize an *ExternalContact (no persisted row for
 // below-threshold peers) produce SQL NULL in the audit, not a zero UUID.
+//
+// Used for profile-field audits (profile_photo, birthday, location) which
+// run OUTSIDE the method-enrichment tx. The tx-scoped counterpart
+// recordEnrichmentTx handles per-method audits.
 func (s *EnrichmentService) recordEnrichment(
 	ctx context.Context,
 	contactID uuid.UUID,
@@ -511,13 +667,91 @@ func (s *EnrichmentService) recordEnrichment(
 	}
 }
 
+// recordEnrichmentTx is the tx-scoped counterpart to recordEnrichment.
+// Audit rows share fate with the method rows + event row from the
+// caller's pgx.Tx (spec §4 atomicity). Uses the tx-scoped
+// EnrichmentRepository built on db.New(tx).
+//
+// Unlike recordEnrichment which log-swallows insert errors, this
+// variant returns the error to its caller — an audit-insert failure
+// inside the tx aborts the whole flow so method rows + event + audit
+// all roll back together. Wraps insert errors with context for debug
+// logging by the caller.
+func (s *EnrichmentService) recordEnrichmentTx(
+	ctx context.Context,
+	txEnrichmentRepo *repository.EnrichmentRepository,
+	contactID uuid.UUID,
+	external *repository.ExternalContact,
+	field string,
+	value string,
+) {
+	var externalContactID *uuid.UUID
+	if external.ID != uuid.Nil {
+		externalContactID = &external.ID
+	}
+	_, err := txEnrichmentRepo.Create(ctx, repository.CreateEnrichmentRequest{
+		ContactID:         contactID,
+		Source:            external.Source,
+		AccountID:         external.AccountID,
+		Field:             field,
+		ExternalContactID: externalContactID,
+		OriginalValue:     &value,
+	})
+	if err != nil {
+		logger.Warn().Err(err).Str("field", field).Msg("failed to record enrichment (tx)")
+	}
+}
+
+// insertContactMethodSavepoint wraps CreateContactMethod in a nested
+// pgx savepoint so a unique-violation (concurrent-insert race) rolls
+// back only the inner savepoint, leaving the outer tx live for
+// subsequent inserts (CLAUDE.md gotcha: a 23505 inside pgx.Tx aborts
+// the outer tx without this).
+//
+// Returns (method, raced=false, nil) on a clean insert,
+//
+//	(nil, raced=true,  nil) on a unique-violation (caller treats as
+//	                        existing-row success),
+//	(nil, false,       err) on any other error.
+func insertContactMethodSavepoint(
+	ctx context.Context,
+	tx pgx.Tx,
+	req repository.CreateContactMethodRequest,
+) (*repository.ContactMethod, bool, error) {
+	sp, err := tx.Begin(ctx)
+	if err != nil {
+		return nil, false, fmt.Errorf("begin savepoint for contact_method insert: %w", err)
+	}
+	// Use the savepoint-scoped queries so the INSERT runs inside the
+	// nested tx. Repository is cheap to construct.
+	spQueries := db.New(sp)
+	spMethodRepo := repository.NewContactMethodRepository(spQueries)
+	created, err := spMethodRepo.CreateContactMethod(ctx, req)
+	if err != nil {
+		_ = sp.Rollback(ctx)
+		if isUniqueViolation(err) {
+			return nil, true, nil
+		}
+		return nil, false, err
+	}
+	if commitErr := sp.Commit(ctx); commitErr != nil {
+		return nil, false, fmt.Errorf("commit savepoint for contact_method insert: %w", commitErr)
+	}
+	return created, false, nil
+}
+
 // SyncMethodsFromExternal adds any missing contact methods from an
 // ExternalContact to the given CRM contact. Unlike EnrichContactFromExternal,
 // it does NOT touch profile fields (photo, birthday, location, name, cadence).
 // Intended for auto-match flows where silent profile overwrites are undesirable.
 //
-// Audit rows are written via recordEnrichment. Idempotent: duplicate methods
-// (either via normalized-value dedup or PG unique-violation race) are no-ops.
+// Audit rows share a tx with the method inserts (spec §4 atomicity).
+// Matcher paths don't publish contact_methods.added events — rematch
+// is only dispatched from the HTTP-facing Enrich* entry points
+// (Appendix A spec divergence, unchanged since #182).
+//
+// Idempotent: duplicate methods (normalized-value dedup OR savepoint-
+// wrapped unique-violation) are no-ops.
 func (s *EnrichmentService) SyncMethodsFromExternal(
 	ctx context.Context,
 	crmContactID uuid.UUID,
@@ -527,10 +761,13 @@ func (s *EnrichmentService) SyncMethodsFromExternal(
 	if err != nil {
 		return fmt.Errorf("get contact for method sync: %w", err)
 	}
-	// Matcher paths don't need the list of added methods; rematch is only
-	// dispatched from the HTTP-facing Enrich* entry points.
-	_, err = s.enrichContactMethods(ctx, contact, external)
-	return err
+	return pgx.BeginTxFunc(ctx, s.database.Pool, pgx.TxOptions{}, func(tx pgx.Tx) error {
+		txQueries := db.New(tx)
+		txMethodRepo := repository.NewContactMethodRepository(txQueries)
+		txEnrichmentRepo := repository.NewEnrichmentRepository(txQueries)
+		_, innerErr := s.enrichContactMethodsTx(ctx, tx, txMethodRepo, txEnrichmentRepo, contact, external)
+		return innerErr
+	})
 }
 
 // HasEnrichment checks if a field has been enriched for a contact

--- a/backend/internal/service/rematch.go
+++ b/backend/internal/service/rematch.go
@@ -354,21 +354,6 @@ func (s *RematchService) GetJob(id uuid.UUID) (JobProgress, error) {
 	return v.(*job).snapshot(), nil
 }
 
-// RescanContact triggers a full rematch for every method currently on the
-// contact. Resolves the methods via the supplied ContactService so the
-// handler layer doesn't need a direct repository dependency.
-//
-// Deprecated: kept so handler compilation stays green during the PR-10
-// step-wise cutover. Step 7 moves the HTTP rescan path onto
-// ContactService.RescanRematch (event-bus publish) and deletes this method.
-func (s *RematchService) RescanContact(ctx context.Context, contactSvc *ContactService, contactID uuid.UUID) (uuid.UUID, error) {
-	contact, err := contactSvc.GetContact(ctx, contactID)
-	if err != nil {
-		return uuid.Nil, err
-	}
-	return s.StartRematchForContact(contactID, toRematchMethods(contact.Methods)), nil
-}
-
 // diffNewMethods returns methods present in `after` whose (type,
 // value_normalized) pair is not in `before`. Order-insensitive.
 func diffNewMethods(before, after []repository.ContactMethod) []Method {

--- a/backend/internal/service/rematch.go
+++ b/backend/internal/service/rematch.go
@@ -54,6 +54,16 @@ type JobProgress struct {
 	Error       string
 }
 
+// RematchRegistry is the narrow contract consumed by ContactService /
+// EnrichmentService / rescan handlers for registering an in-memory job
+// entry synchronously after events.Bus.PublishTx. Keeps publishers
+// decoupled from the full *RematchService surface — they just need
+// "make the job visible to GET /rematch/jobs/:id now" so the frontend's
+// synchronous `rematch_job_id` poll loop never 404s.
+type RematchRegistry interface {
+	RegisterPending(jobID, contactID uuid.UUID, methods []Method)
+}
+
 // job is the internal mutable representation protected by its own mutex.
 type job struct {
 	id        uuid.UUID
@@ -115,10 +125,25 @@ func (j *job) setFailed(err error) {
 	j.mu.Unlock()
 }
 
+// resetForRun clears the mutable run-state fields before a fresh
+// attempt. Called from rehydrateOrLookup so a River retry after a crash
+// or failure starts clean instead of accumulating matched counts on top
+// of the prior attempt or keeping the prior attempt's error / completedAt.
+func (j *job) resetForRun() {
+	j.mu.Lock()
+	j.status = JobStatusRunning
+	j.matched = 0
+	j.completedAt = nil
+	j.err = ""
+	j.mu.Unlock()
+}
+
 // RematchService dispatches rematch work per contact method type. Handlers
-// register at startup; StartRematchForContact spawns a background goroutine
-// that runs handlers sequentially for the given methods, serialized per
-// contactID by a mutex.
+// register at startup. Post-PR-10 (#180) the primary entry point is Run,
+// which the RematchDispatcher consumer invokes per contact_methods.added
+// event. StartRematchForContact is retained as a test-only helper that
+// spawns Run on the detached context; production code publishes events
+// and relies on the consumer to dispatch.
 type RematchService struct {
 	handlers     map[string]RematchHandler
 	jobs         sync.Map // uuid.UUID -> *job
@@ -146,14 +171,51 @@ func (s *RematchService) Register(h RematchHandler) {
 
 // jobRetention bounds how long terminal jobs remain queryable via GetJob.
 // After a job completes/fails, clients have this long to poll for the final
-// state before the entry is evicted on the next StartRematchForContact call.
-// Keeps the in-memory job map bounded without requiring a separate reaper.
+// state before the entry is evicted on the next RegisterPending /
+// StartRematchForContact call. Keeps the in-memory job map bounded without
+// requiring a separate reaper.
 const jobRetention = 10 * time.Minute
 
+// RegisterPending creates an in-memory job entry keyed by jobID with
+// Status=Running so GET /rematch/jobs/:id returns it immediately after
+// a publisher publishes a contact_methods.added event — i.e. before the
+// async RematchDispatcher consumer picks up. Idempotent on duplicate
+// jobID (second call is a no-op) so publisher retries don't clobber
+// in-progress run state.
+//
+// The spec text at §3.4.4 calls this the "pending" state; the existing
+// JobStatus enum has only running|completed|failed. We reuse Running
+// rather than adding a new terminal state because the frontend contract
+// (`useRematchJob` polls until terminal) already treats Running as
+// "not done, keep polling" — introducing Pending would break
+// `frontend/src/lib/rematch-api.ts`'s three-state shape.
+func (s *RematchService) RegisterPending(jobID, contactID uuid.UUID, methods []Method) {
+	if jobID == uuid.Nil {
+		return
+	}
+	// Opportunistic prune on registration — keeps the map bounded for
+	// long-running processes without a dedicated reaper.
+	s.pruneTerminalJobs()
+	j := &job{
+		id:        jobID,
+		contactID: contactID,
+		methods:   append([]Method(nil), methods...),
+		startedAt: accelerated.GetCurrentTime(),
+		status:    JobStatusRunning,
+	}
+	// LoadOrStore keeps the first writer — second call is a no-op so
+	// publisher retries or a race with the consumer's rehydrate don't
+	// clobber an in-progress entry.
+	s.jobs.LoadOrStore(jobID, j)
+}
+
 // StartRematchForContact filters the given methods to those that have a
-// registered handler, then spawns a detached goroutine to run them. Returns
-// uuid.Nil when no methods map to a registered handler — this is the normal
-// case when the feature is off or only some handler types are wired.
+// registered handler, then spawns a detached goroutine to run them.
+// Returns uuid.Nil when no methods map to a registered handler.
+//
+// Deprecated: production code publishes contact_methods.added via
+// events.Bus.PublishTx and relies on RematchDispatcher to invoke Run.
+// Kept alive for tests that exercise the in-process spawn path.
 func (s *RematchService) StartRematchForContact(contactID uuid.UUID, methods []Method) uuid.UUID {
 	eligible := make([]Method, 0, len(methods))
 	for _, m := range methods {
@@ -165,21 +227,20 @@ func (s *RematchService) StartRematchForContact(contactID uuid.UUID, methods []M
 		return uuid.Nil
 	}
 
-	// Opportunistic prune on dispatch — keeps the map bounded for long-running
-	// processes without a dedicated reaper goroutine.
+	// Opportunistic prune on dispatch — keeps the map bounded for
+	// long-running processes without a dedicated reaper goroutine.
 	s.pruneTerminalJobs()
 
-	j := &job{
-		id:        uuid.New(),
-		contactID: contactID,
-		methods:   eligible,
-		startedAt: accelerated.GetCurrentTime(),
-		status:    JobStatusRunning,
-	}
-	s.jobs.Store(j.id, j)
+	jobID := uuid.New()
+	s.RegisterPending(jobID, contactID, eligible)
 
-	go s.run(j)
-	return j.id
+	// Fire-and-forget; Run records failure on the in-memory entry via
+	// setFailed and returns an error for River semantics — for this
+	// test-only spawn we discard it since there is no River wrapper.
+	go func() {
+		_ = s.Run(s.detachedCtx(), jobID, contactID, eligible)
+	}()
+	return jobID
 }
 
 // pruneTerminalJobs evicts completed/failed jobs whose terminal timestamp is
@@ -202,43 +263,86 @@ func (s *RematchService) pruneTerminalJobs() {
 	})
 }
 
-func (s *RematchService) run(j *job) {
+// Run executes a rematch job for the given (jobID, contactID, methods)
+// tuple under per-contact mutex serialization. Called by
+// RematchDispatcher.HandleEvent (production) and via StartRematchForContact
+// (tests only).
+//
+// Rehydrates the in-memory *job entry from parameters when none exists
+// (worker retry after crash, or consumer pickup before RegisterPending
+// ran) and resets mutable run-state (matched / status / completedAt /
+// err) so a retry begins from a clean slate.
+//
+// The named `err` return is crucial: a recovered panic is assigned to
+// err via the deferred recover, so River sees the error and retries the
+// job per its MaxAttempts. Without the named return, a bare `return`
+// after setFailed would hand back a zero-valued nil error and River
+// would ack the job as complete.
+func (s *RematchService) Run(ctx context.Context, jobID, contactID uuid.UUID, methods []Method) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			logger.Error().
-				Str("contactId", j.contactID.String()).
-				Str("jobId", j.id.String()).
+				Str("contactId", contactID.String()).
+				Str("jobId", jobID.String()).
 				Interface("panic", r).
 				Msg("rematch: job panicked")
-			j.setFailed(fmt.Errorf("handler panic: %v", r))
+			panicErr := fmt.Errorf("handler panic: %v", r)
+			if j, ok := s.jobs.Load(jobID); ok {
+				j.(*job).setFailed(panicErr)
+			}
+			// Propagate so River retries per MaxAttempts. A named return
+			// is required so this deferred assignment survives `return`.
+			err = panicErr
 		}
 	}()
 
-	lockIface, _ := s.contactLocks.LoadOrStore(j.contactID, &sync.Mutex{})
+	j := s.rehydrateOrLookup(jobID, contactID, methods)
+
+	lockIface, _ := s.contactLocks.LoadOrStore(contactID, &sync.Mutex{})
 	lock := lockIface.(*sync.Mutex)
 	lock.Lock()
 	defer lock.Unlock()
-
-	ctx := s.detachedCtx()
 
 	for _, m := range j.methods {
 		handler, ok := s.handlers[m.Type]
 		if !ok {
 			continue
 		}
-		n, err := handler.Rematch(ctx, j.contactID, m.Value)
-		if err != nil {
-			logger.Warn().Err(err).
-				Str("contactId", j.contactID.String()).
+		n, handlerErr := handler.Rematch(ctx, contactID, m.Value)
+		if handlerErr != nil {
+			logger.Warn().Err(handlerErr).
+				Str("contactId", contactID.String()).
 				Str("type", m.Type).
 				Msg("rematch: handler failed")
-			j.setFailed(err)
-			return
+			j.setFailed(handlerErr)
+			return handlerErr
 		}
 		j.addMatched(n)
 	}
-
 	j.setCompleted()
+	return nil
+}
+
+// rehydrateOrLookup returns the job for jobID, creating a fresh in-memory
+// entry when none exists (process crashed between RegisterPending and
+// consumer pickup, or a River retry picked up the job on a worker that
+// never saw the publisher's registration). Resets mutable run-state on
+// every call so a retry begins clean — without this the second attempt's
+// matched counts accumulate on top of the first attempt's partial counts
+// and the old error/completedAt linger on the entry.
+func (s *RematchService) rehydrateOrLookup(jobID, contactID uuid.UUID, methods []Method) *job {
+	j := &job{
+		id:        jobID,
+		contactID: contactID,
+		methods:   append([]Method(nil), methods...),
+		startedAt: accelerated.GetCurrentTime(),
+		status:    JobStatusRunning,
+	}
+	if actual, loaded := s.jobs.LoadOrStore(jobID, j); loaded {
+		j = actual.(*job)
+	}
+	j.resetForRun()
+	return j
 }
 
 // GetJob returns a snapshot of the job, or ErrJobNotFound if unknown.
@@ -253,6 +357,10 @@ func (s *RematchService) GetJob(id uuid.UUID) (JobProgress, error) {
 // RescanContact triggers a full rematch for every method currently on the
 // contact. Resolves the methods via the supplied ContactService so the
 // handler layer doesn't need a direct repository dependency.
+//
+// Deprecated: kept so handler compilation stays green during the PR-10
+// step-wise cutover. Step 7 moves the HTTP rescan path onto
+// ContactService.RescanRematch (event-bus publish) and deletes this method.
 func (s *RematchService) RescanContact(ctx context.Context, contactSvc *ContactService, contactID uuid.UUID) (uuid.UUID, error) {
 	contact, err := contactSvc.GetContact(ctx, contactID)
 	if err != nil {

--- a/backend/internal/service/rematch.go
+++ b/backend/internal/service/rematch.go
@@ -60,8 +60,15 @@ type JobProgress struct {
 // decoupled from the full *RematchService surface — they just need
 // "make the job visible to GET /rematch/jobs/:id now" so the frontend's
 // synchronous `rematch_job_id` poll loop never 404s.
+//
+// EligibleMethods filters a candidate list down to methods that have a
+// registered rematch handler. Publishers call this BEFORE minting a
+// jobID so an unhandled method slice produces uuid.Nil (matching the
+// old StartRematchForContact contract — no job id for work that won't
+// run).
 type RematchRegistry interface {
 	RegisterPending(jobID, contactID uuid.UUID, methods []Method)
+	EligibleMethods(methods []Method) []Method
 }
 
 // job is the internal mutable representation protected by its own mutex.
@@ -139,9 +146,9 @@ func (j *job) resetForRun() {
 }
 
 // RematchService dispatches rematch work per contact method type. Handlers
-// register at startup. Post-PR-10 (#180) the primary entry point is Run,
-// which the RematchDispatcher consumer invokes per contact_methods.added
-// event. StartRematchForContact is retained as a test-only helper that
+// register at startup. The primary entry point is Run, which the
+// RematchDispatcher consumer invokes per contact_methods.added event.
+// StartRematchForContact is retained as a test-only helper that
 // spawns Run on the detached context; production code publishes events
 // and relies on the consumer to dispatch.
 type RematchService struct {
@@ -207,6 +214,25 @@ func (s *RematchService) RegisterPending(jobID, contactID uuid.UUID, methods []M
 	// publisher retries or a race with the consumer's rehydrate don't
 	// clobber an in-progress entry.
 	s.jobs.LoadOrStore(jobID, j)
+}
+
+// EligibleMethods returns the subset of methods whose Type has a
+// registered handler. Publishers call this at mutation time so they
+// can skip minting a jobID + publishing an event when nothing would
+// actually run — preserves the pre-cutover contract that
+// mutation responses return rematch_job_id=null when no rematch work
+// applies.
+func (s *RematchService) EligibleMethods(methods []Method) []Method {
+	if len(methods) == 0 {
+		return nil
+	}
+	eligible := make([]Method, 0, len(methods))
+	for _, m := range methods {
+		if _, ok := s.handlers[m.Type]; ok {
+			eligible = append(eligible, m)
+		}
+	}
+	return eligible
 }
 
 // StartRematchForContact filters the given methods to those that have a

--- a/backend/internal/service/rematch_publisher.go
+++ b/backend/internal/service/rematch_publisher.go
@@ -6,32 +6,9 @@ import (
 
 	"personal-crm/backend/internal/accelerated"
 	"personal-crm/backend/internal/events"
-	"personal-crm/backend/internal/repository"
 
 	"github.com/google/uuid"
 )
-
-// contactMethodsToRefs converts repository.ContactMethod to the typed
-// ContactMethodRef used in the ContactMethodsAdded event payload.
-// Always uses the normalized value (matches DB unique-index + identity
-// normalization convention).
-func contactMethodsToRefs(methods []repository.ContactMethod) []events.ContactMethodRef {
-	out := make([]events.ContactMethodRef, len(methods))
-	for i, m := range methods {
-		out[i] = events.ContactMethodRef{Type: m.Type, Value: m.ValueNormalized}
-	}
-	return out
-}
-
-// refsToRematchMethods converts event-layer ContactMethodRef slice back
-// to the service-layer Method slice used by RematchRegistry.RegisterPending.
-func refsToRematchMethods(refs []events.ContactMethodRef) []Method {
-	out := make([]Method, len(refs))
-	for i, r := range refs {
-		out[i] = Method{Type: r.Type, Value: r.Value}
-	}
-	return out
-}
 
 // rematchMethodsToRefs converts service.Method (from diffNewMethods) to
 // the event-layer ref type.
@@ -92,20 +69,28 @@ func (s *ContactService) RescanRematch(ctx context.Context, contactID uuid.UUID)
 	if err != nil {
 		return uuid.Nil, err // propagates db.ErrNotFound
 	}
-	refs := contactMethodsToRefs(contact.Methods)
-	if len(refs) == 0 {
+	// Filter to eligible methods so a contact with no matchable methods
+	// (no registered handler for any method type) returns uuid.Nil
+	// instead of enqueueing a no-op rematch job.
+	var eligible []Method
+	if s.rematchRegistry != nil {
+		all := make([]Method, 0, len(contact.Methods))
+		for _, m := range contact.Methods {
+			all = append(all, Method{Type: m.Type, Value: m.ValueNormalized})
+		}
+		eligible = s.rematchRegistry.EligibleMethods(all)
+	}
+	if len(eligible) == 0 {
 		return uuid.Nil, nil
 	}
 	jobID := uuid.New()
-	env, err := buildContactMethodsAddedEnvelope("manual", contactID, refs, jobID)
+	env, err := buildContactMethodsAddedEnvelope("manual", contactID, rematchMethodsToRefs(eligible), jobID)
 	if err != nil {
 		return uuid.Nil, err
 	}
 	if err := s.bus.Publish(ctx, env); err != nil {
 		return uuid.Nil, fmt.Errorf("publish contact_methods.added: %w", err)
 	}
-	if s.rematchRegistry != nil {
-		s.rematchRegistry.RegisterPending(jobID, contactID, refsToRematchMethods(refs))
-	}
+	s.rematchRegistry.RegisterPending(jobID, contactID, eligible)
 	return jobID, nil
 }

--- a/backend/internal/service/rematch_publisher.go
+++ b/backend/internal/service/rematch_publisher.go
@@ -1,0 +1,111 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+)
+
+// contactMethodsToRefs converts repository.ContactMethod to the typed
+// ContactMethodRef used in the ContactMethodsAdded event payload.
+// Always uses the normalized value (matches DB unique-index + identity
+// normalization convention).
+func contactMethodsToRefs(methods []repository.ContactMethod) []events.ContactMethodRef {
+	out := make([]events.ContactMethodRef, len(methods))
+	for i, m := range methods {
+		out[i] = events.ContactMethodRef{Type: m.Type, Value: m.ValueNormalized}
+	}
+	return out
+}
+
+// refsToRematchMethods converts event-layer ContactMethodRef slice back
+// to the service-layer Method slice used by RematchRegistry.RegisterPending.
+func refsToRematchMethods(refs []events.ContactMethodRef) []Method {
+	out := make([]Method, len(refs))
+	for i, r := range refs {
+		out[i] = Method{Type: r.Type, Value: r.Value}
+	}
+	return out
+}
+
+// rematchMethodsToRefs converts service.Method (from diffNewMethods) to
+// the event-layer ref type.
+func rematchMethodsToRefs(methods []Method) []events.ContactMethodRef {
+	out := make([]events.ContactMethodRef, len(methods))
+	for i, m := range methods {
+		out[i] = events.ContactMethodRef{Type: m.Type, Value: m.Value}
+	}
+	return out
+}
+
+// buildContactMethodsAddedEnvelope composes a ready-to-publish envelope
+// for the given (contactID, methods, jobID) tuple. jobID doubles as the
+// event's SourceID so a publisher retry under the same intent dedupes
+// at the event.source_id unique index.
+func buildContactMethodsAddedEnvelope(
+	source string,
+	contactID uuid.UUID,
+	methods []events.ContactMethodRef,
+	jobID uuid.UUID,
+) (*events.Envelope, error) {
+	payload, err := events.Marshal(events.KindContactMethodsAdded, events.ContactMethodsAddedPayload{
+		Version:      1,
+		ContactID:    contactID,
+		Methods:      methods,
+		RematchJobID: jobID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal contact_methods.added: %w", err)
+	}
+	return &events.Envelope{
+		Source:     source,
+		SourceID:   jobID.String(),
+		Kind:       events.KindContactMethodsAdded,
+		Payload:    payload,
+		ObservedAt: accelerated.GetCurrentTime(),
+	}, nil
+}
+
+// RescanRematch triggers a rematch over ALL methods currently attached
+// to a contact. Used by POST /rematch/contacts/:id/rescan. Publishes
+// one contact_methods.added via the event bus (same path as
+// CreateContact / UpdateContact), registers the in-memory job entry,
+// and returns the jobID for the client poll loop.
+//
+// Returns uuid.Nil when the contact has no methods (200 with
+// rematch_job_id=null, matching the handler contract). Returns
+// db.ErrNotFound when the contact doesn't exist.
+//
+// Uses bus.Publish (not PublishTx) because Rescan has no sibling
+// writes to atomically couple — the bus opens its own short-lived tx
+// covering event-insert + river-InsertTx.
+func (s *ContactService) RescanRematch(ctx context.Context, contactID uuid.UUID) (uuid.UUID, error) {
+	if s.bus == nil {
+		return uuid.Nil, fmt.Errorf("rescan rematch: event bus not wired")
+	}
+	contact, err := s.GetContact(ctx, contactID)
+	if err != nil {
+		return uuid.Nil, err // propagates db.ErrNotFound
+	}
+	refs := contactMethodsToRefs(contact.Methods)
+	if len(refs) == 0 {
+		return uuid.Nil, nil
+	}
+	jobID := uuid.New()
+	env, err := buildContactMethodsAddedEnvelope("manual", contactID, refs, jobID)
+	if err != nil {
+		return uuid.Nil, err
+	}
+	if err := s.bus.Publish(ctx, env); err != nil {
+		return uuid.Nil, fmt.Errorf("publish contact_methods.added: %w", err)
+	}
+	if s.rematchRegistry != nil {
+		s.rematchRegistry.RegisterPending(jobID, contactID, refsToRematchMethods(refs))
+	}
+	return jobID, nil
+}

--- a/backend/internal/service/rematch_test.go
+++ b/backend/internal/service/rematch_test.go
@@ -81,6 +81,49 @@ func TestStartRematchForContact_NoMatchingHandler(t *testing.T) {
 	}
 }
 
+// TestEligibleMethods_FiltersToRegisteredHandlers pins the publisher
+// contract: ContactService / EnrichmentService / RescanRematch call
+// EligibleMethods BEFORE minting a jobID, so unhandled method types
+// produce uuid.Nil in the API response (matches pre-cutover
+// StartRematchForContact semantics).
+func TestEligibleMethods_FiltersToRegisteredHandlers(t *testing.T) {
+	svc := NewRematchService()
+	svc.Register(&stubHandler{typ: "email"})
+	svc.Register(&stubHandler{typ: "telegram"})
+
+	input := []Method{
+		{Type: "email", Value: "a@b.c"},
+		{Type: "phone", Value: "+15551212"},
+		{Type: "telegram", Value: "alice"},
+		{Type: "discord", Value: "alice#1"},
+	}
+	got := svc.EligibleMethods(input)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 eligible methods, got %d: %+v", len(got), got)
+	}
+	// Order preserved from input slice.
+	if got[0].Type != "email" || got[1].Type != "telegram" {
+		t.Fatalf("unexpected eligible methods: %+v", got)
+	}
+}
+
+func TestEligibleMethods_EmptyWhenNoHandlers(t *testing.T) {
+	svc := NewRematchService()
+	got := svc.EligibleMethods([]Method{{Type: "email", Value: "a@b.c"}})
+	if len(got) != 0 {
+		t.Fatalf("expected 0 eligible methods with no handlers registered, got %d", len(got))
+	}
+}
+
+func TestEligibleMethods_EmptyInput(t *testing.T) {
+	svc := NewRematchService()
+	svc.Register(&stubHandler{typ: "email"})
+	got := svc.EligibleMethods(nil)
+	if got != nil {
+		t.Fatalf("expected nil for empty input, got %+v", got)
+	}
+}
+
 func TestStartRematchForContact_DispatchesToHandler(t *testing.T) {
 	svc := NewRematchService()
 	h := &stubHandler{typ: "email", matched: 3}

--- a/backend/internal/service/rematch_test.go
+++ b/backend/internal/service/rematch_test.go
@@ -107,18 +107,26 @@ func TestStartRematchForContact_DispatchesToHandler(t *testing.T) {
 	}
 }
 
-func TestStartRematchForContact_AggregatesCountsAcrossMethods(t *testing.T) {
+func TestRun_AggregatesCountsAcrossMethods(t *testing.T) {
 	svc := NewRematchService()
 	emailH := &stubHandler{typ: "email", matched: 2}
 	phoneH := &stubHandler{typ: "phone", matched: 4}
 	svc.Register(emailH)
 	svc.Register(phoneH)
 
-	jobID := svc.StartRematchForContact(uuid.New(), []Method{
+	jobID := uuid.New()
+	contactID := uuid.New()
+	methods := []Method{
 		{Type: "email", Value: "a@b.c"},
 		{Type: "phone", Value: "+15551212"},
-	})
-	job := waitForJob(t, svc, jobID)
+	}
+	if err := svc.Run(context.Background(), jobID, contactID, methods); err != nil {
+		t.Fatalf("Run returned unexpected error: %v", err)
+	}
+	job, err := svc.GetJob(jobID)
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
 	if job.Status != JobStatusCompleted {
 		t.Fatalf("expected completed, got %s", job.Status)
 	}
@@ -127,13 +135,20 @@ func TestStartRematchForContact_AggregatesCountsAcrossMethods(t *testing.T) {
 	}
 }
 
-func TestStartRematchForContact_HandlerErrorFailsJob(t *testing.T) {
+func TestRun_HandlerErrorFailsJob(t *testing.T) {
 	svc := NewRematchService()
 	errBoom := errors.New("boom")
 	svc.Register(&stubHandler{typ: "email", err: errBoom})
 
-	jobID := svc.StartRematchForContact(uuid.New(), []Method{{Type: "email", Value: "a@b.c"}})
-	job := waitForJob(t, svc, jobID)
+	jobID := uuid.New()
+	runErr := svc.Run(context.Background(), jobID, uuid.New(), []Method{{Type: "email", Value: "a@b.c"}})
+	if !errors.Is(runErr, errBoom) {
+		t.Fatalf("Run should return handler error for river retry; got %v", runErr)
+	}
+	job, err := svc.GetJob(jobID)
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
 	if job.Status != JobStatusFailed {
 		t.Fatalf("expected failed, got %s", job.Status)
 	}
@@ -142,13 +157,208 @@ func TestStartRematchForContact_HandlerErrorFailsJob(t *testing.T) {
 	}
 }
 
-func TestStartRematchForContact_PanicRecovered(t *testing.T) {
+func TestRun_PanicPropagatesAsError(t *testing.T) {
 	svc := NewRematchService()
 	svc.Register(panickyHandler{})
-	jobID := svc.StartRematchForContact(uuid.New(), []Method{{Type: "email", Value: "x"}})
-	job := waitForJob(t, svc, jobID)
+	jobID := uuid.New()
+	runErr := svc.Run(context.Background(), jobID, uuid.New(), []Method{{Type: "email", Value: "x"}})
+	if runErr == nil {
+		t.Fatal("Run should return non-nil error when handler panics (named-return recovery)")
+	}
+	job, err := svc.GetJob(jobID)
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
 	if job.Status != JobStatusFailed {
 		t.Fatalf("expected failed after panic, got %s", job.Status)
+	}
+	if job.Error == "" {
+		t.Fatal("expected non-empty error message after panic")
+	}
+}
+
+func TestRun_NoMatchingHandler_Completes(t *testing.T) {
+	// Run with no registered handler for the method type completes
+	// cleanly (handler iteration skips unknown types) → terminal
+	// Completed with matched=0. Distinct from
+	// TestStartRematchForContact_NoMatchingHandler which exercises the
+	// pre-spawn eligibility filter.
+	svc := NewRematchService()
+	jobID := uuid.New()
+	if err := svc.Run(context.Background(), jobID, uuid.New(), []Method{{Type: "email", Value: "x"}}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	job, err := svc.GetJob(jobID)
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	if job.Status != JobStatusCompleted {
+		t.Fatalf("expected completed, got %s", job.Status)
+	}
+	if job.Matched != 0 {
+		t.Fatalf("expected Matched=0, got %d", job.Matched)
+	}
+}
+
+func TestRun_RehydrateOrLookup_CreatesEntry(t *testing.T) {
+	// Call Run on a jobID that was never RegisterPending'd (simulating
+	// consumer pickup after a crash that lost the in-memory map).
+	svc := NewRematchService()
+	svc.Register(&stubHandler{typ: "email", matched: 1})
+
+	jobID := uuid.New()
+	contactID := uuid.New()
+	if err := svc.Run(context.Background(), jobID, contactID, []Method{{Type: "email", Value: "a@b.c"}}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	job, err := svc.GetJob(jobID)
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	if job.ContactID != contactID {
+		t.Fatalf("expected contactID=%s, got %s", contactID, job.ContactID)
+	}
+	if job.Matched != 1 {
+		t.Fatalf("expected Matched=1, got %d", job.Matched)
+	}
+}
+
+func TestRun_RehydrateOrLookup_LoadsExistingEntry(t *testing.T) {
+	// RegisterPending first, then Run: no duplicate entry, counts
+	// accumulate on the same job.
+	svc := NewRematchService()
+	svc.Register(&stubHandler{typ: "email", matched: 2})
+
+	jobID := uuid.New()
+	contactID := uuid.New()
+	methods := []Method{{Type: "email", Value: "a@b.c"}}
+
+	svc.RegisterPending(jobID, contactID, methods)
+	snap, err := svc.GetJob(jobID)
+	if err != nil {
+		t.Fatalf("GetJob after RegisterPending: %v", err)
+	}
+	if snap.Status != JobStatusRunning {
+		t.Fatalf("expected Running after RegisterPending, got %s", snap.Status)
+	}
+	if snap.Matched != 0 {
+		t.Fatalf("expected Matched=0 before Run, got %d", snap.Matched)
+	}
+
+	if err := svc.Run(context.Background(), jobID, contactID, methods); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	final, err := svc.GetJob(jobID)
+	if err != nil {
+		t.Fatalf("GetJob after Run: %v", err)
+	}
+	if final.Status != JobStatusCompleted {
+		t.Fatalf("expected Completed, got %s", final.Status)
+	}
+	if final.Matched != 2 {
+		t.Fatalf("expected Matched=2, got %d", final.Matched)
+	}
+	// StartedAt must be the RegisterPending-assigned value, not a fresh one.
+	if !final.StartedAt.Equal(snap.StartedAt) {
+		t.Fatalf("StartedAt should match RegisterPending snapshot; got %v vs %v",
+			final.StartedAt, snap.StartedAt)
+	}
+}
+
+func TestRun_RetryAfterFailure_ResetsState(t *testing.T) {
+	// First Run fails; second Run with same jobID succeeds. Assert
+	// the second attempt's state replaces (not accumulates on) the
+	// first attempt's partial state.
+	svc := NewRematchService()
+	errBoom := errors.New("boom")
+	failing := &stubHandler{typ: "email", err: errBoom}
+	svc.Register(failing)
+
+	jobID := uuid.New()
+	contactID := uuid.New()
+	methods := []Method{{Type: "email", Value: "a@b.c"}}
+
+	if err := svc.Run(context.Background(), jobID, contactID, methods); !errors.Is(err, errBoom) {
+		t.Fatalf("first Run should fail with boom, got %v", err)
+	}
+	firstSnap, _ := svc.GetJob(jobID)
+	if firstSnap.Status != JobStatusFailed {
+		t.Fatalf("expected Failed after first run, got %s", firstSnap.Status)
+	}
+
+	// Swap in a successful handler for the retry and re-run.
+	svc.handlers["email"] = &stubHandler{typ: "email", matched: 5}
+	if err := svc.Run(context.Background(), jobID, contactID, methods); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	final, _ := svc.GetJob(jobID)
+	if final.Status != JobStatusCompleted {
+		t.Fatalf("expected Completed after retry, got %s", final.Status)
+	}
+	if final.Matched != 5 {
+		t.Fatalf("expected Matched=5 (only second attempt), got %d", final.Matched)
+	}
+	if final.Error != "" {
+		t.Fatalf("expected cleared Error after retry, got %q", final.Error)
+	}
+	if final.CompletedAt == nil || firstSnap.CompletedAt == nil {
+		t.Fatal("expected non-nil CompletedAt on both snapshots")
+	}
+	if !final.CompletedAt.After(*firstSnap.CompletedAt) &&
+		!final.CompletedAt.Equal(*firstSnap.CompletedAt) {
+		// Accelerated clock may produce identical timestamps; accept equal or after.
+		t.Fatalf("expected retry CompletedAt >= first; got %v vs %v",
+			final.CompletedAt, firstSnap.CompletedAt)
+	}
+}
+
+func TestRegisterPending_CreatesRunningEntry(t *testing.T) {
+	svc := NewRematchService()
+	jobID := uuid.New()
+	contactID := uuid.New()
+	methods := []Method{{Type: "email", Value: "a@b.c"}}
+
+	svc.RegisterPending(jobID, contactID, methods)
+	snap, err := svc.GetJob(jobID)
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	if snap.Status != JobStatusRunning {
+		t.Fatalf("expected Running, got %s", snap.Status)
+	}
+	if snap.ContactID != contactID {
+		t.Fatalf("expected contactID=%s, got %s", contactID, snap.ContactID)
+	}
+	if len(snap.Methods) != 1 || snap.Methods[0].Value != "a@b.c" {
+		t.Fatalf("unexpected methods: %+v", snap.Methods)
+	}
+}
+
+func TestRegisterPending_Idempotent(t *testing.T) {
+	svc := NewRematchService()
+	jobID := uuid.New()
+	contactID := uuid.New()
+
+	svc.RegisterPending(jobID, contactID, []Method{{Type: "email", Value: "a@b.c"}})
+	first, _ := svc.GetJob(jobID)
+
+	// Second call with different methods should be a no-op.
+	svc.RegisterPending(jobID, contactID, []Method{{Type: "phone", Value: "+1"}})
+	second, _ := svc.GetJob(jobID)
+
+	if second.StartedAt != first.StartedAt {
+		t.Fatalf("second RegisterPending bumped StartedAt: %v vs %v", second.StartedAt, first.StartedAt)
+	}
+	if len(second.Methods) != 1 || second.Methods[0].Value != "a@b.c" {
+		t.Fatalf("expected first call's methods preserved, got %+v", second.Methods)
+	}
+}
+
+func TestRegisterPending_NilJobID_NoOp(t *testing.T) {
+	svc := NewRematchService()
+	svc.RegisterPending(uuid.Nil, uuid.New(), []Method{{Type: "email", Value: "x"}})
+	if _, err := svc.GetJob(uuid.Nil); !errors.Is(err, ErrJobNotFound) {
+		t.Fatalf("expected ErrJobNotFound for nil jobID, got %v", err)
 	}
 }
 

--- a/backend/tests/api/contact_ids_test.go
+++ b/backend/tests/api/contact_ids_test.go
@@ -45,7 +45,7 @@ func setupContactIDsTestRouter() (*gin.Engine, *repository.ContactRepository, fu
 	contactRepo := repository.NewContactRepository(database.Queries)
 	contactMethodRepo := repository.NewContactMethodRepository(database.Queries)
 	interactionRepo := repository.NewInteractionRepository(database.Queries)
-	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, repository.NewContactTaskRepository(database.Queries))
+	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, repository.NewContactTaskRepository(database.Queries), nil, nil)
 	wireCadenceUpdaterForAPITest(nil, database, contactService)
 	contactHandler := handlers.NewContactHandler(contactService, nil)
 

--- a/backend/tests/api/contact_merge_test.go
+++ b/backend/tests/api/contact_merge_test.go
@@ -50,7 +50,7 @@ func TestContactMerge_Integration(t *testing.T) {
 
 	// Create service
 	interactionRepo := repository.NewInteractionRepository(database.Queries)
-	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, repository.NewContactTaskRepository(database.Queries))
+	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, repository.NewContactTaskRepository(database.Queries), nil, nil)
 	wireCadenceUpdaterForAPITest(t, database, contactService)
 
 	t.Run("GetMergePreview_BasicCounts", func(t *testing.T) {

--- a/backend/tests/api/contact_validation_test.go
+++ b/backend/tests/api/contact_validation_test.go
@@ -80,7 +80,7 @@ func setupContactValidationTestRouter() (*gin.Engine, func()) {
 	contactRepo := repository.NewContactRepository(database.Queries)
 	contactMethodRepo := repository.NewContactMethodRepository(database.Queries)
 	interactionRepo := repository.NewInteractionRepository(database.Queries)
-	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, repository.NewContactTaskRepository(database.Queries))
+	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, repository.NewContactTaskRepository(database.Queries), nil, nil)
 	wireCadenceUpdaterForAPITest(nil, database, contactService)
 	contactHandler := handlers.NewContactHandler(contactService, nil)
 

--- a/backend/tests/api/import_with_selections_test.go
+++ b/backend/tests/api/import_with_selections_test.go
@@ -51,10 +51,10 @@ func setupImportTestRouter() (*gin.Engine, *repository.ExternalContactRepository
 
 	// Create services
 	interactionRepo := repository.NewInteractionRepository(database.Queries)
-	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, repository.NewContactTaskRepository(database.Queries))
+	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, repository.NewContactTaskRepository(database.Queries), nil, nil)
 	cadenceUpdater := wireCadenceUpdaterForAPITest(nil, database, contactService)
 	matchService := service.NewImportMatchService(contactRepo)
-	enrichmentService := service.NewEnrichmentService(database, contactRepo, contactMethodRepo, enrichmentRepo)
+	enrichmentService := service.NewEnrichmentService(database, contactRepo, contactMethodRepo, enrichmentRepo, nil, nil)
 	enrichmentService.SetCadenceUpdater(cadenceUpdater)
 
 	// Create handler

--- a/backend/tests/api/manual_handler_helper_test.go
+++ b/backend/tests/api/manual_handler_helper_test.go
@@ -37,7 +37,7 @@ func buildManualHandlerForTest(ctx context.Context, database *db.Database, cfg *
 	telegramMessageRepo := repository.NewTelegramMessageRepository(database.Queries)
 	eventRepo := repository.NewEventRepository(database.Queries)
 
-	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo)
+	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, nil, nil)
 
 	// Chicken-and-egg: the worker needs the bus, the bus needs the client,
 	// the client needs the workers bundle pre-registered. Register a shim

--- a/backend/tests/api/note_test.go
+++ b/backend/tests/api/note_test.go
@@ -50,7 +50,7 @@ func setupNoteTestRouter() (*gin.Engine, func()) {
 
 	// Set up services
 	interactionRepo := repository.NewInteractionRepository(database.Queries)
-	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, repository.NewContactTaskRepository(database.Queries))
+	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, repository.NewContactTaskRepository(database.Queries), nil, nil)
 	wireCadenceUpdaterForAPITest(nil, database, contactService)
 	noteService := service.NewNoteService(noteRepo, contactRepo)
 

--- a/backend/tests/api/telegram_chat_api_test.go
+++ b/backend/tests/api/telegram_chat_api_test.go
@@ -76,7 +76,7 @@ func setupTelegramChatRouter(t *testing.T) (*gin.Engine, *repository.TelegramCha
 	contactRepo := repository.NewContactRepository(database.Queries)
 	contactMethodRepo := repository.NewContactMethodRepository(database.Queries)
 	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
-	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo)
+	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, nil, nil)
 	wireCadenceUpdaterForAPITest(t, database, contactService)
 
 	manager := tgpkg.NewTelegramManager(

--- a/backend/tests/consumer_interaction_recorder_integration_test.go
+++ b/backend/tests/consumer_interaction_recorder_integration_test.go
@@ -165,7 +165,7 @@ func newConsumerTestEnv(t *testing.T, ctx context.Context) *consumerTestEnv {
 	var recorder *consumer.InteractionRecorder
 	bus := newConsumerTestBus(t, ctx, database, cfg, &recorder)
 
-	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo)
+	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, nil, nil)
 	// Wire a real CadenceUpdater so the recorder's inline-apply seam
 	// writes cadence columns against a live DB in these integration
 	// tests.

--- a/backend/tests/contact_by_integration_test.go
+++ b/backend/tests/contact_by_integration_test.go
@@ -331,7 +331,7 @@ func TestContactBy_CadenceStateTransitions(t *testing.T) {
 	contactMethodRepo := repository.NewContactMethodRepository(database.Queries)
 	interactionRepo := repository.NewInteractionRepository(database.Queries)
 	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
-	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo)
+	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, nil, nil)
 	wireCadenceUpdaterForTest(t, database, contactService)
 
 	t.Run("set cadence -> clear cadence -> set cadence", func(t *testing.T) {

--- a/backend/tests/interaction_direction_test.go
+++ b/backend/tests/interaction_direction_test.go
@@ -40,7 +40,7 @@ func setupDirectionTestDeps(t *testing.T) (*service.ContactService, *repository.
 	contactMethodRepo := repository.NewContactMethodRepository(database.Queries)
 	interactionRepo := repository.NewInteractionRepository(database.Queries)
 	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
-	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo)
+	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, nil, nil)
 	wireCadenceUpdaterForTest(t, database, contactService)
 
 	cleanup := func() {

--- a/backend/tests/interaction_integration_test.go
+++ b/backend/tests/interaction_integration_test.go
@@ -41,7 +41,7 @@ func setupInteractionTestDeps(t *testing.T) (*service.ContactService, *repositor
 	contactRepo := repository.NewContactRepository(database.Queries)
 	contactMethodRepo := repository.NewContactMethodRepository(database.Queries)
 	interactionRepo := repository.NewInteractionRepository(database.Queries)
-	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, repository.NewContactTaskRepository(database.Queries))
+	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, repository.NewContactTaskRepository(database.Queries), nil, nil)
 	wireCadenceUpdaterForTest(t, database, contactService)
 
 	cleanup := func() {

--- a/backend/tests/rematch_dispatcher_unique_opts_test.go
+++ b/backend/tests/rematch_dispatcher_unique_opts_test.go
@@ -116,19 +116,9 @@ func TestRematch_RiverUniqueOpts_DedupsByContactAndJobID(t *testing.T) {
 
 	// Only one river job for the (ContactID, RematchJobID) tuple.
 	// ByArgs with river:"unique" tags on ContactID + RematchJobID
-	// collapses the second InsertTx to the existing job.
-	//
-	// river_job is owned by the river queue library (not sqlc'd); raw
-	// SQL is the only way to assert. Pattern matches
-	// sync_worker_leased_retry_test.go.
-	var riverJobCount int
-	err = database.Pool.QueryRow(ctx,
-		`SELECT COUNT(*) FROM river_job
-		 WHERE kind = 'rematch_dispatcher'
-		   AND args->>'contact_id' = $1
-		   AND args->>'rematch_job_id' = $2`,
-		contactID.String(), jobID.String(),
-	).Scan(&riverJobCount)
+	// collapses the second InsertTx to the existing job. Count via
+	// sqlc-generated repo helper (raw SQL is forbidden by core.md).
+	riverJobCount, err := eventRepo.CountRematchDispatcherJobs(ctx, contactID, jobID)
 	require.NoError(t, err)
-	require.Equal(t, 1, riverJobCount, "River UniqueOpts{ByArgs} must dedupe the second enqueue")
+	require.Equal(t, int64(1), riverJobCount, "River UniqueOpts{ByArgs} must dedupe the second enqueue")
 }

--- a/backend/tests/rematch_dispatcher_unique_opts_test.go
+++ b/backend/tests/rematch_dispatcher_unique_opts_test.go
@@ -1,0 +1,134 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRematch_RiverUniqueOpts_DedupsByContactAndJobID exercises the
+// SECOND idempotency layer: River's UniqueOpts{ByArgs} with
+// river:"unique" tags on ContactID + RematchJobID.
+//
+// To exercise it specifically we bypass the event.source_id dedup by
+// using DIFFERENT source_ids on each publish. Same (ContactID,
+// RematchJobID) in both payloads → River's ByArgs hashes those fields
+// and dedupes the second InsertTx to one queued job. Final assertion:
+// one river_job row, not two.
+//
+// Companion test rematch_event_dedup_test.go covers the first layer
+// (same source_id → event.source_id unique).
+func TestRematch_RiverUniqueOpts_DedupsByContactAndJobID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set")
+	}
+
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+	cfg.Database.MigrationsPath = getMigrationsPath()
+
+	ctx := context.Background()
+	require.NoError(t, db.RunMigrations(ctx, cfg.Database.URL, cfg.Database.MigrationsPath))
+
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	t.Cleanup(func() { database.Close() })
+
+	// Noop worker for rematch_dispatcher so river accepts the kind.
+	// We assert row counts, not handler execution.
+	workers := river.NewWorkers()
+	river.AddWorker(workers, &rematchDispatcherNoopWorker{})
+
+	riverClient, err := river.NewClient(riverpgxv5.New(database.Pool), &river.Config{
+		Queues: map[string]river.QueueConfig{
+			river.QueueDefault: {MaxWorkers: 1},
+		},
+		Workers:  workers,
+		TestOnly: true,
+	})
+	require.NoError(t, err)
+	// NOT starting the client — we want the first job to stay in the
+	// queue so the second InsertTx hits UniqueOpts dedup against a
+	// still-scheduled row.
+
+	eventRepo := repository.NewEventRepository(database.Queries)
+	bus := events.NewBus(database.Pool, riverClient, eventRepo)
+
+	contactID := uuid.New()
+	jobID := uuid.New()
+
+	// Publish two events with DIFFERENT source_ids but SAME (contactID,
+	// jobID) in payload. The event layer sees them as distinct (two
+	// event rows); River's UniqueOpts{ByArgs} sees the args
+	// {ContactID, RematchJobID} as identical and dedupes.
+	publishWithSourceID := func(sourceID string) error {
+		return pgx.BeginTxFunc(ctx, database.Pool, pgx.TxOptions{}, func(tx pgx.Tx) error {
+			payload, marshalErr := events.Marshal(events.KindContactMethodsAdded, events.ContactMethodsAddedPayload{
+				Version:      1,
+				ContactID:    contactID,
+				Methods:      []events.ContactMethodRef{{Type: "email", Value: "a@b.c"}},
+				RematchJobID: jobID,
+			})
+			if marshalErr != nil {
+				return marshalErr
+			}
+			env := &events.Envelope{
+				Source:     "manual",
+				SourceID:   sourceID,
+				Kind:       events.KindContactMethodsAdded,
+				Payload:    payload,
+				ObservedAt: accelerated.GetCurrentTime(),
+			}
+			return bus.PublishTx(ctx, tx, env)
+		})
+	}
+
+	sourceA := "src-A-" + uuid.NewString()
+	sourceB := "src-B-" + uuid.NewString()
+
+	require.NoError(t, publishWithSourceID(sourceA), "first publish")
+	require.NoError(t, publishWithSourceID(sourceB), "second publish (UniqueOpts dedup)")
+
+	// Two distinct event rows (source_id differs) — assert via the
+	// sqlc-generated repo query (core.md forbids raw SQL in Go).
+	envA, err := eventRepo.FindEventBySource(ctx, "manual", sourceA)
+	require.NoError(t, err)
+	require.NotNil(t, envA, "event A must persist")
+	envB, err := eventRepo.FindEventBySource(ctx, "manual", sourceB)
+	require.NoError(t, err)
+	require.NotNil(t, envB, "event B must persist (different source_id → no event-layer dedup)")
+
+	// Only one river job for the (ContactID, RematchJobID) tuple.
+	// ByArgs with river:"unique" tags on ContactID + RematchJobID
+	// collapses the second InsertTx to the existing job.
+	//
+	// river_job is owned by the river queue library (not sqlc'd); raw
+	// SQL is the only way to assert. Pattern matches
+	// sync_worker_leased_retry_test.go.
+	var riverJobCount int
+	err = database.Pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM river_job
+		 WHERE kind = 'rematch_dispatcher'
+		   AND args->>'contact_id' = $1
+		   AND args->>'rematch_job_id' = $2`,
+		contactID.String(), jobID.String(),
+	).Scan(&riverJobCount)
+	require.NoError(t, err)
+	require.Equal(t, 1, riverJobCount, "River UniqueOpts{ByArgs} must dedupe the second enqueue")
+}

--- a/backend/tests/rematch_event_dedup_test.go
+++ b/backend/tests/rematch_event_dedup_test.go
@@ -117,21 +117,14 @@ func TestRematch_EventSourceIDDedup(t *testing.T) {
 	// the partial unique index enforces this at the DB level, so the
 	// Find returning a single row IS the dedup evidence.
 
-	// River job count requires an arbitrary args JSON filter which is
-	// not reachable via the generated Querier. The river_job table is
-	// not sqlc'd (it belongs to the river queue library). Raw SQL is
-	// the only option for this assertion — pattern matches existing
-	// sync_worker_leased_retry_test.go / sync_worker_load_test.go use.
-	var riverJobCount int
-	err = database.Pool.QueryRow(ctx,
-		`SELECT COUNT(*) FROM river_job
-		 WHERE kind = 'rematch_dispatcher'
-		   AND args->>'contact_id' = $1
-		   AND args->>'rematch_job_id' = $2`,
-		contactID.String(), jobID.String(),
-	).Scan(&riverJobCount)
+	// River job count via sqlc-generated repo helper
+	// (CountRematchDispatcherJobs). Raw SQL against river_job is
+	// forbidden by core.md rule 2 even though river_job is owned by
+	// the river library — we wrap the JSON args filter in a sqlc query
+	// in queries/event.sql.
+	riverJobCount, err := eventRepo.CountRematchDispatcherJobs(ctx, contactID, jobID)
 	require.NoError(t, err)
-	require.Equal(t, 1, riverJobCount, "only one river job enqueued for deduped event")
+	require.Equal(t, int64(1), riverJobCount, "only one river job enqueued for deduped event")
 }
 
 // rematchDispatcherNoopWorker accepts and completes the kind without

--- a/backend/tests/rematch_event_dedup_test.go
+++ b/backend/tests/rematch_event_dedup_test.go
@@ -1,0 +1,151 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRematch_EventSourceIDDedup exercises the FIRST idempotency layer:
+// event.source_id unique-index. Two PublishTx calls with the same
+// (source, source_id) must produce exactly one event row and one river
+// job, even though a plausible publisher retry would call PublishTx
+// twice (spec §3.4.4 + spec §4).
+//
+// Scenario: publish envelope with source="manual", source_id=<jobID>
+// twice. First succeeds, second hits ON CONFLICT DO NOTHING and returns
+// nil without enqueueing. DB assertions: 1 event row, 1 river job.
+//
+// This is a DIFFERENT test from rematch_dispatcher_unique_opts_test
+// (which exercises River's UniqueOpts{ByArgs} as the second dedup
+// layer, bypassing the event-layer dedup via distinct source_ids).
+func TestRematch_EventSourceIDDedup(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set")
+	}
+
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+	cfg.Database.MigrationsPath = getMigrationsPath()
+
+	ctx := context.Background()
+	require.NoError(t, db.RunMigrations(ctx, cfg.Database.URL, cfg.Database.MigrationsPath))
+
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	t.Cleanup(func() { database.Close() })
+
+	// Live river client so InsertTx behaves like production. TestOnly
+	// skips maintenance startup delays. Noop worker registered for
+	// rematch_dispatcher so river accepts the kind; we assert row
+	// counts, not execution.
+	workers := river.NewWorkers()
+	river.AddWorker(workers, &rematchDispatcherNoopWorker{})
+
+	riverClient, err := river.NewClient(riverpgxv5.New(database.Pool), &river.Config{
+		Queues: map[string]river.QueueConfig{
+			river.QueueDefault: {MaxWorkers: 2},
+		},
+		Workers:  workers,
+		TestOnly: true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, riverClient.Start(ctx))
+	t.Cleanup(func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer stopCancel()
+		_ = riverClient.Stop(stopCtx)
+	})
+
+	eventRepo := repository.NewEventRepository(database.Queries)
+	bus := events.NewBus(database.Pool, riverClient, eventRepo)
+
+	contactID := uuid.New()
+	jobID := uuid.New()
+	sourceID := jobID.String()
+
+	// Publish twice inside separate tx — same (source, source_id).
+	publish := func() error {
+		return pgx.BeginTxFunc(ctx, database.Pool, pgx.TxOptions{}, func(tx pgx.Tx) error {
+			payload, marshalErr := events.Marshal(events.KindContactMethodsAdded, events.ContactMethodsAddedPayload{
+				Version:      1,
+				ContactID:    contactID,
+				Methods:      []events.ContactMethodRef{{Type: "email", Value: "dedup@example.com"}},
+				RematchJobID: jobID,
+			})
+			if marshalErr != nil {
+				return marshalErr
+			}
+			env := &events.Envelope{
+				Source:     "manual",
+				SourceID:   sourceID,
+				Kind:       events.KindContactMethodsAdded,
+				Payload:    payload,
+				ObservedAt: accelerated.GetCurrentTime(),
+			}
+			return bus.PublishTx(ctx, tx, env)
+		})
+	}
+	require.NoError(t, publish(), "first publish")
+	require.NoError(t, publish(), "second publish (dedup)")
+
+	// Assert event row count.
+	var eventCount int
+	err = database.Pool.QueryRow(ctx,
+		"SELECT COUNT(*) FROM event WHERE source = $1 AND source_id = $2",
+		"manual", sourceID,
+	).Scan(&eventCount)
+	require.NoError(t, err)
+	require.Equal(t, 1, eventCount, "event.source_id unique must dedupe second publish")
+
+	// Assert river_job count for the (ContactID, RematchJobID) tuple.
+	// The args JSON has the camelCase-ish keys matching the struct
+	// field names river uses for ByArgs — contact_id + rematch_job_id.
+	var riverJobCount int
+	err = database.Pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM river_job
+		 WHERE kind = 'rematch_dispatcher'
+		   AND args->>'contact_id' = $1
+		   AND args->>'rematch_job_id' = $2`,
+		contactID.String(), jobID.String(),
+	).Scan(&riverJobCount)
+	require.NoError(t, err)
+	require.Equal(t, 1, riverJobCount, "only one river job enqueued for deduped event")
+}
+
+// rematchDispatcherNoopWorker accepts and completes the kind without
+// work. Used in dedup tests where we assert row counts, not execution.
+type rematchDispatcherNoopWorker struct {
+	river.WorkerDefaults[rematchDispatcherNoopArgs]
+}
+
+// rematchDispatcherNoopArgs mirrors consumerjobs.RematchDispatcherJobArgs
+// so the Kind name matches.
+type rematchDispatcherNoopArgs struct {
+	EventID      uuid.UUID `json:"event_id"`
+	ContactID    uuid.UUID `json:"contact_id"`
+	RematchJobID uuid.UUID `json:"rematch_job_id"`
+}
+
+func (rematchDispatcherNoopArgs) Kind() string { return "rematch_dispatcher" }
+
+func (*rematchDispatcherNoopWorker) Work(_ context.Context, _ *river.Job[rematchDispatcherNoopArgs]) error {
+	return nil
+}

--- a/backend/tests/rematch_event_dedup_test.go
+++ b/backend/tests/rematch_event_dedup_test.go
@@ -106,18 +106,22 @@ func TestRematch_EventSourceIDDedup(t *testing.T) {
 	require.NoError(t, publish(), "first publish")
 	require.NoError(t, publish(), "second publish (dedup)")
 
-	// Assert event row count.
-	var eventCount int
-	err = database.Pool.QueryRow(ctx,
-		"SELECT COUNT(*) FROM event WHERE source = $1 AND source_id = $2",
-		"manual", sourceID,
-	).Scan(&eventCount)
+	// Exactly one event row for (source, source_id) — via sqlc-generated
+	// repository query (core.md forbids raw SQL in Go, incl. tests).
+	env1, err := eventRepo.FindEventBySource(ctx, "manual", sourceID)
 	require.NoError(t, err)
-	require.Equal(t, 1, eventCount, "event.source_id unique must dedupe second publish")
+	require.NotNil(t, env1)
+	require.Equal(t, "manual", env1.Source)
+	require.Equal(t, sourceID, env1.SourceID)
+	// A second event row with the same (source, source_id) cannot exist —
+	// the partial unique index enforces this at the DB level, so the
+	// Find returning a single row IS the dedup evidence.
 
-	// Assert river_job count for the (ContactID, RematchJobID) tuple.
-	// The args JSON has the camelCase-ish keys matching the struct
-	// field names river uses for ByArgs — contact_id + rematch_job_id.
+	// River job count requires an arbitrary args JSON filter which is
+	// not reachable via the generated Querier. The river_job table is
+	// not sqlc'd (it belongs to the river queue library). Raw SQL is
+	// the only option for this assertion — pattern matches existing
+	// sync_worker_leased_retry_test.go / sync_worker_load_test.go use.
 	var riverJobCount int
 	err = database.Pool.QueryRow(ctx,
 		`SELECT COUNT(*) FROM river_job

--- a/backend/tests/rematch_integration_test.go
+++ b/backend/tests/rematch_integration_test.go
@@ -72,18 +72,30 @@ func setupRematchEnv(t *testing.T) *rematchTestEnv {
 	externalRepo := repository.NewExternalContactRepository(database.Queries)
 	enrichmentRepo := repository.NewEnrichmentRepository(database.Queries)
 
-	contactSvc := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo)
-	enrichmentSvc := service.NewEnrichmentService(database, contactRepo, contactMethodRepo, enrichmentRepo)
-
-	// Cutover wiring: a live bus + InteractionRecorderWorker so rematch
-	// publishes → async consumer writes the interaction. Tests wait for
-	// the row via waitForInteractionBySourceRef.
-	bus := setupTestEventBus(t, ctx, database, contactSvc)
-
+	// Build rematchSvc first so it can be passed as RematchRegistry to
+	// ContactService's constructor (post-PR-10 wiring; SetRematchService
+	// is gone). Handlers register AFTER the bus exists, below.
 	rematchSvc := service.NewRematchService()
+
+	contactSvc := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, nil, rematchSvc)
+	enrichmentSvc := service.NewEnrichmentService(database, contactRepo, contactMethodRepo, enrichmentRepo, nil, rematchSvc)
+
+	// Cutover wiring: live bus + InteractionRecorderWorker +
+	// RematchDispatcherWorker so UpdateContact's publish flows through
+	// the event bus and fires the rematch dispatcher against the
+	// registered handlers. Tests wait via waitForRematchJob on the
+	// in-memory job entry (RegisterPending seeds it, dispatcher Run
+	// updates it).
+	bus := setupTestEventBusWithRematch(t, ctx, database, contactSvc, rematchSvc)
+
+	// Re-inject the live bus onto services now that it's constructed.
+	// Services took a nil bus above because the bus depends on
+	// contactSvc via the InteractionRecorder; this swap happens before
+	// any test runs.
+	contactSvc.InjectBusForTest(bus)
+	enrichmentSvc.InjectBusForTest(bus)
+
 	rematchSvc.Register(google.NewCalendarRematchHandler(calendarRepo, externalRepo, bus))
-	contactSvc.SetRematchService(rematchSvc)
-	enrichmentSvc.SetRematchService(rematchSvc)
 
 	return &rematchTestEnv{
 		ctx:               ctx,
@@ -590,8 +602,11 @@ func TestRematch_RescanContact_RunsForAllMethods(t *testing.T) {
 	pastEnd := accelerated.GetCurrentTime().Add(-time.Hour)
 	event := seedCalendarEventWithAttendee(t, env, accountID, email, pastEnd, "confirmed")
 
-	// Manual rescan — exercise the service-level method the handler calls.
-	jobID, err := env.rematchSvc.RescanContact(env.ctx, env.contactSvc, contact.ID)
+	// Manual rescan — post-PR-10 the handler calls
+	// ContactService.RescanRematch (publishes via event bus +
+	// RegisterPending) instead of the deleted
+	// RematchService.RescanContact.
+	jobID, err := env.contactSvc.RescanRematch(env.ctx, contact.ID)
 	require.NoError(t, err)
 	require.NotEqual(t, uuid.Nil, jobID)
 
@@ -607,7 +622,7 @@ func TestRematch_RescanContact_RunsForAllMethods(t *testing.T) {
 func TestRematch_RescanContact_UnknownContactReturnsNotFound(t *testing.T) {
 	env := setupRematchEnv(t)
 
-	_, err := env.rematchSvc.RescanContact(env.ctx, env.contactSvc, uuid.New())
+	_, err := env.contactSvc.RescanRematch(env.ctx, uuid.New())
 	assert.True(t, errors.Is(err, db.ErrNotFound), "expected ErrNotFound for unknown contact, got %v", err)
 }
 

--- a/backend/tests/rematch_integration_test.go
+++ b/backend/tests/rematch_integration_test.go
@@ -458,6 +458,45 @@ func TestRematch_NoHandlerForType_ReturnsNilJobID(t *testing.T) {
 	assert.Equal(t, uuid.Nil, jobID)
 }
 
+// TestRematch_Publisher_NoHandler_ReturnsNilJobID pins the EligibleMethods
+// gate on the actual event-bus publisher paths (CreateContact /
+// UpdateContact / RescanRematch). Without this regression test, an
+// unhandled method type would mint a jobID + enqueue a no-op river
+// job. Only the email handler is registered; adding a phone method
+// must produce uuid.Nil.
+func TestRematch_Publisher_NoHandler_ReturnsNilJobID(t *testing.T) {
+	env := setupRematchEnv(t)
+
+	// CreateContact with a phone-only method — no handler registered
+	// for "phone" in the base env.
+	phone := "+15551212"
+	_, jobID, err := env.contactSvc.CreateContact(env.ctx, repository.CreateContactRequest{
+		FullName: "No Handler " + uuid.NewString()[:8],
+	}, []service.ContactMethodInput{
+		{Type: "phone", Value: phone, IsPrimary: true},
+	})
+	require.NoError(t, err)
+	require.Equal(t, uuid.Nil, jobID, "unhandled method type must not mint a rematch jobID")
+
+	// RescanRematch on a contact whose only methods are unhandled
+	// should also return uuid.Nil.
+	contact, err := env.contactRepo.CreateContact(env.ctx, repository.CreateContactRequest{
+		FullName: "Rescan No Handler " + uuid.NewString()[:8],
+	})
+	require.NoError(t, err)
+	_, err = env.contactMethodRepo.CreateContactMethod(env.ctx, repository.CreateContactMethodRequest{
+		ContactID: contact.ID,
+		Type:      "phone",
+		Value:     phone,
+		IsPrimary: true,
+	})
+	require.NoError(t, err)
+
+	rescanJobID, err := env.contactSvc.RescanRematch(env.ctx, contact.ID)
+	require.NoError(t, err)
+	require.Equal(t, uuid.Nil, rescanJobID, "rescan with unhandled methods must return uuid.Nil")
+}
+
 // registerTelegramHandlers wires the username + phone handlers against env's
 // rematch service using the same PeerMatcher and AggregationEngine the
 // production manager would own. Returns the message repo for seeding.

--- a/backend/tests/telegram_aggregation_test.go
+++ b/backend/tests/telegram_aggregation_test.go
@@ -69,7 +69,7 @@ func setupAggregationTest(t *testing.T) (
 	contactRepo := repository.NewContactRepository(database.Queries)
 	contactMethodRepo := repository.NewContactMethodRepository(database.Queries)
 	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
-	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo)
+	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, nil, nil)
 
 	// Cutover wiring: a live events.Bus with the InteractionRecorder worker
 	// running so aggregation publishes → async consumer writes interaction

--- a/backend/tests/telegram_import_suggestion_test.go
+++ b/backend/tests/telegram_import_suggestion_test.go
@@ -64,10 +64,10 @@ func setupTelegramImportSuggestionTest(t *testing.T) (
 	enrichmentRepo := repository.NewEnrichmentRepository(database.Queries)
 	interactionRepo := repository.NewInteractionRepository(database.Queries)
 
-	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, repository.NewContactTaskRepository(database.Queries))
+	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, repository.NewContactTaskRepository(database.Queries), nil, nil)
 	cadenceUpdater := wireCadenceUpdaterForTest(t, database, contactService)
 	matchService := service.NewImportMatchService(contactRepo)
-	enrichmentService := service.NewEnrichmentService(database, contactRepo, contactMethodRepo, enrichmentRepo)
+	enrichmentService := service.NewEnrichmentService(database, contactRepo, contactMethodRepo, enrichmentRepo, nil, nil)
 	enrichmentService.SetCadenceUpdater(cadenceUpdater)
 
 	importHandler := handlers.NewImportHandler(externalRepo, contactService, matchService, enrichmentService)

--- a/backend/tests/telegram_matcher_enrichment_test.go
+++ b/backend/tests/telegram_matcher_enrichment_test.go
@@ -65,7 +65,7 @@ func setupMatcherEnrichmentTest(t *testing.T) *matcherEnrichTestEnv {
 	messageRepo := repository.NewTelegramMessageRepository(database.Queries)
 
 	identitySvc := service.NewIdentityService(identityRepo)
-	enrichmentSvc := service.NewEnrichmentService(database, contactRepo, methodRepo, enrichmentRepo)
+	enrichmentSvc := service.NewEnrichmentService(database, contactRepo, methodRepo, enrichmentRepo, nil, nil)
 
 	matcher := tgpkg.NewPeerMatcher(identitySvc, messageRepo, externalRepo, enrichmentSvc, 100)
 

--- a/backend/tests/telegram_sparse_entity_enrichment_test.go
+++ b/backend/tests/telegram_sparse_entity_enrichment_test.go
@@ -80,7 +80,7 @@ func setupSparseEnrichTest(t *testing.T) *sparseEnrichEnv {
 	identityRepo := repository.NewIdentityRepository(database.Queries)
 
 	identitySvc := service.NewIdentityService(identityRepo)
-	enrichmentSvc := service.NewEnrichmentService(database, contactRepo, contactMethodRepo, enrichmentRepo)
+	enrichmentSvc := service.NewEnrichmentService(database, contactRepo, contactMethodRepo, enrichmentRepo, nil, nil)
 	matcher := tgpkg.NewPeerMatcher(identitySvc, messageRepo, externalRepo, enrichmentSvc, 1)
 
 	handler := tgpkg.NewMessageHandler(

--- a/backend/tests/test_event_bus_harness_test.go
+++ b/backend/tests/test_event_bus_harness_test.go
@@ -116,6 +116,106 @@ func setupTestEventBus(
 	return bus
 }
 
+// setupTestEventBusWithRematch is the PR-10 counterpart to
+// setupTestEventBus that also wires the RematchDispatcherWorker against
+// the given *service.RematchService. Matches the harness pattern
+// (shim + real-worker fill-in) so the rematch consumer is live after
+// Start.
+//
+// Chicken-and-egg: the bus needs InteractionRecorder (which needs
+// contactService), and contactService needs the bus to publish
+// contact_methods.added. Callers construct contactSvc with nil bus
+// FIRST, then call this helper to obtain the live bus, then call
+// contactSvc.InjectBusForTest(bus) to swap the nil bus for the real
+// one before any test runs. Same shape for EnrichmentService if tests
+// exercise enrichment publishes.
+func setupTestEventBusWithRematch(
+	t *testing.T,
+	ctx context.Context,
+	database *db.Database,
+	contactService *service.ContactService,
+	rematchSvc *service.RematchService,
+) *events.Bus {
+	t.Helper()
+
+	eventRepo := repository.NewEventRepository(database.Queries)
+	telegramMessageRepo := repository.NewTelegramMessageRepository(database.Queries)
+
+	cfg := config.TestConfig()
+	if cfg.River.WorkerConcurrency <= 0 {
+		cfg.River.WorkerConcurrency = 4
+	}
+
+	workers := river.NewWorkers()
+	interactionShim := &deferredRecorderWorker{}
+	river.AddWorker(workers, interactionShim)
+	river.AddWorker(workers, &cadenceUpdaterNoopWorker{})
+	river.AddWorker(workers, &followUpManagerNoopWorker{})
+	rematchShim := &deferredRematchWorker{}
+	river.AddWorker(workers, rematchShim)
+
+	client, err := river.NewClient(riverpgxv5.New(database.Pool), &river.Config{
+		Queues: map[string]river.QueueConfig{
+			river.QueueDefault: {MaxWorkers: cfg.River.WorkerConcurrency},
+		},
+		Workers:  workers,
+		TestOnly: true,
+	})
+	require.NoError(t, err)
+
+	bus := events.NewBus(database.Pool, client, eventRepo)
+
+	contactRepo := repository.NewContactRepository(database.Queries)
+	contactRepo.SetPool(database.Pool)
+	claimRepo := repository.NewEventConsumerClaimRepository(database.Queries)
+	cadenceUpdater := consumer.NewCadenceUpdater(
+		claimRepo, contactRepo, database.Queries,
+		consumer.CadenceModeCutover,
+		false,
+	)
+	contactService.SetCadenceUpdater(cadenceUpdater)
+	recorder := consumer.NewInteractionRecorder(contactService, telegramMessageRepo, bus, cadenceUpdater, nil)
+	interactionShim.real = consumer.NewInteractionRecorderWorker(bus, database.Pool, recorder)
+
+	rematchDispatcher := consumer.NewRematchDispatcher(rematchSvc)
+	rematchShim.real = consumer.NewRematchDispatcherWorker(bus, database.Pool, rematchDispatcher)
+
+	// IMPORTANT: pass the OUTER ctx (not a timeout-derived one) to Start.
+	require.NoError(t, client.Start(ctx))
+
+	t.Cleanup(func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer stopCancel()
+		_ = client.Stop(stopCtx)
+	})
+
+	return bus
+}
+
+// deferredRematchWorker is the rematch counterpart to
+// deferredRecorderWorker: lets us register a River worker on a workers
+// bundle before the real worker exists (river.NewClient consumes the
+// workers bundle at construction time but the real worker needs a bus,
+// and the bus needs the client).
+type deferredRematchWorker struct {
+	river.WorkerDefaults[consumerjobs.RematchDispatcherJobArgs]
+	real *consumer.RematchDispatcherWorker
+}
+
+func (w *deferredRematchWorker) Work(ctx context.Context, j *river.Job[consumerjobs.RematchDispatcherJobArgs]) error {
+	if w.real == nil {
+		return fmt.Errorf("deferredRematchWorker invoked before real worker assignment")
+	}
+	return w.real.Work(ctx, j)
+}
+
+func (w *deferredRematchWorker) Timeout(j *river.Job[consumerjobs.RematchDispatcherJobArgs]) time.Duration {
+	if w.real == nil {
+		return 5 * time.Minute
+	}
+	return w.real.Timeout(j)
+}
+
 // defaultInteractionWaitTimeout is the budget we give the async consumer
 // to pick up an enqueued job and commit the interaction row. Generous to
 // avoid flakes under CI load; integration tests that time out at this

--- a/scripts/ci/rematch-sole-dispatcher-guard.sh
+++ b/scripts/ci/rematch-sole-dispatcher-guard.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# rematch-sole-dispatcher-guard.sh — grep guard for the PR-10 event-bus
+# rematch dispatcher invariant.
+#
+# Production rematch dispatch flows through events.Bus.PublishTx →
+# RematchDispatcher consumer → RematchService.Run. The legacy
+# StartRematchForContact method is kept only for unit tests (see
+# service/rematch.go godoc Deprecated: note). Any non-test caller
+# indicates a partial revert of PR 10.
+#
+# Legal call sites for StartRematchForContact:
+#   - backend/internal/service/rematch.go        (definition)
+#   - backend/internal/service/rematch_test.go   (test coverage)
+#   - backend/tests/*_test.go                    (integration tests)
+#
+# Mirrors scripts/ci/followup-sole-writer-guard.sh.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+SYMBOL_PATTERN='StartRematchForContact'
+
+# Only inspect Go source, exclude generated files.
+find_hits() {
+  local pattern="$1"
+  if command -v rg >/dev/null 2>&1; then
+    rg -l "$pattern" --glob '*.go' \
+      --glob '!**/*_test.go' --glob '!**/*.sql.go' \
+      --glob '!**/querier.go' --glob '!**/models.go' --glob '!**/db.go' \
+      backend/internal backend/cmd 2>/dev/null | sort -u || true
+  else
+    grep -lE "$pattern" -r --include='*.go' \
+      --exclude='*_test.go' --exclude='*.sql.go' \
+      --exclude='querier.go' --exclude='models.go' --exclude='db.go' \
+      backend/internal backend/cmd 2>/dev/null | sort -u || true
+  fi
+}
+
+# Allow the definition file to reference the symbol.
+ALLOWLIST=(
+  "backend/internal/service/rematch.go"
+)
+
+violation_count=0
+
+HITS=$(find_hits "$SYMBOL_PATTERN")
+if [[ -n "$HITS" ]]; then
+  while IFS= read -r f; do
+    [[ -z "$f" ]] && continue
+    allowed=false
+    for a in "${ALLOWLIST[@]}"; do
+      if [[ "$f" == "$a" ]]; then
+        allowed=true
+        break
+      fi
+    done
+    if ! $allowed; then
+      echo "ERROR: rematch sole-dispatcher guard: StartRematchForContact found in non-test, non-allowlisted file: $f" >&2
+      violation_count=$((violation_count + 1))
+    fi
+  done <<< "$HITS"
+fi
+
+if (( violation_count > 0 )); then
+  echo "ERROR: PR 10 of #180 requires production rematch dispatch via events.Bus + RematchDispatcher only." >&2
+  exit 1
+fi
+
+echo "OK: rematch sole-dispatcher guard: StartRematchForContact has no production callers."

--- a/scripts/ci/rematch-sole-dispatcher-guard.sh
+++ b/scripts/ci/rematch-sole-dispatcher-guard.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# rematch-sole-dispatcher-guard.sh — grep guard for the PR-10 event-bus
+# rematch-sole-dispatcher-guard.sh — grep guard for the event-bus
 # rematch dispatcher invariant.
 #
 # Production rematch dispatch flows through events.Bus.PublishTx →
 # RematchDispatcher consumer → RematchService.Run. The legacy
 # StartRematchForContact method is kept only for unit tests (see
 # service/rematch.go godoc Deprecated: note). Any non-test caller
-# indicates a partial revert of PR 10.
+# indicates a regression in the sole-dispatcher invariant.
 #
 # Legal call sites for StartRematchForContact:
 #   - backend/internal/service/rematch.go        (definition)
@@ -19,7 +19,9 @@ set -euo pipefail
 
 cd "$(dirname "$0")/../.."
 
-SYMBOL_PATTERN='StartRematchForContact'
+# Match only the call form — `.StartRematchForContact(` — so prose
+# comments that reference the name descriptively don't flag.
+SYMBOL_PATTERN='\.StartRematchForContact\('
 
 # Only inspect Go source, exclude generated files.
 find_hits() {
@@ -63,7 +65,7 @@ if [[ -n "$HITS" ]]; then
 fi
 
 if (( violation_count > 0 )); then
-  echo "ERROR: PR 10 of #180 requires production rematch dispatch via events.Bus + RematchDispatcher only." >&2
+  echo "ERROR: production rematch dispatch must flow through events.Bus + RematchDispatcher only." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

Migrates rematch dispatch from the in-process `go s.run(j)` goroutine inside `RematchService` to an event-driven pipeline: publishers emit `contact_methods.added` via `events.Bus.PublishTx` in the same `pgx.Tx` as method-row inserts; a new `RematchDispatcher` consumer subscribes to the kind and runs `RematchService.Run` (extracted from the old private `run`) under per-contact mutex serialization.

- Breaks the `contactService.SetRematchService` cycle: `ContactService` + `EnrichmentService` now take `events.Bus` + `RematchRegistry` as constructor args.
- `RematchDispatcher` consumer + River worker at `backend/internal/consumer/rematch_dispatcher.go`. Always-on (no mode flag): a registered River worker returning nil in kill-switch mode would permanently ack queued jobs, so rollback is `git revert` only.
- Two idempotency layers, both covered by integration tests: `event.source_id` unique-index (publisher retry) and River `UniqueOpts{ByArgs: [ContactID, RematchJobID]}` (enqueue retry).
- `RematchRegistry.EligibleMethods` filters to handler-registered types BEFORE minting a jobID, preserving the pre-cutover contract that unhandled types return `uuid.Nil` in API responses.

Spec: `.ai/spec/event-bus-foundation.md` §3.4.4 + §4 + §5 (PR 10). Plan: `.ai/log/plan/event-bus-foundation-pr10-rematch-dispatcher.md`.

## Key design decisions

- **No mode flag.** A registered River worker returning nil in `off` mode would permanently ack queued jobs with no replay path; rollback is `git revert` only. Matches PR 3 scheduler's posture.
- **Constructor injection, not setter.** Spec §3.4.4 explicit; eliminates the silent-drop bug class from `SetRematchService` never being called.
- **Enrichment method inserts + per-method audits + event publish share one `pgx.Tx`** (spec §4). Savepoint-wrapped inserts handle concurrent-writer unique-violation races without aborting the outer tx (CLAUDE.md gotcha).
- **`contactLocks sync.Map` kept** on `RematchService` for per-contact execution serialization. River's `UniqueOpts` dedupes at enqueue; the mutex serializes distinct `RematchJobID`s for the same contact at execution time.

## Test coverage

- `backend/internal/service/rematch_test.go` — `TestEligibleMethods_*` for the filter gate.
- `backend/internal/consumer/rematch_dispatcher_test.go` — dispatcher unit tests (wrong kind, empty methods, malformed payload, runner dispatch/error, etc.).
- `backend/internal/events/bus_test.go` — `consumerJobsForKind` routing for `contact_methods.added`; `PublishTx` preassigns `env.ID` then resets on duplicate (IngestService sentinel preserved); malformed-payload rollback.
- `backend/tests/rematch_event_dedup_test.go` — first-layer `event.source_id` unique dedup.
- `backend/tests/rematch_dispatcher_unique_opts_test.go` — second-layer River `UniqueOpts{ByArgs}` dedup with distinct `source_id`s.
- `backend/tests/rematch_integration_test.go` — existing 13 rematch tests run through the new event-bus harness; new `TestRematch_Publisher_NoHandler_ReturnsNilJobID` pins the `EligibleMethods` gate on `CreateContact` + `RescanRematch`.
- Sole-dispatcher guard `scripts/ci/rematch-sole-dispatcher-guard.sh` wired into `make ci-test` + CI workflow.

## Frontend

Unchanged. `ContactResponse.RematchJobID`, `useRematchJob`, `RematchJobsProvider` all untouched. `GET /rematch/jobs/:id` behavior preserved.

## Test plan

- [x] `make lint` — 0 issues
- [x] `make test-unit` — all green
- [x] `make test-integration` — all green (including new dedup tests)
- [x] Local Codex review: PASS (3 rounds; round 1 6 findings applied, round 2 2 findings applied, round 3 PASS)
- [x] CI: backend tests, E2E, reviewers
- [x] `make test-e2e-diff` verifies `rematch-on-add-email.spec.ts` passes unchanged

## Rollback

`git revert` PR 10 only. No runtime-flag rollback — a mode=off gate would silently ack-and-drop queued River jobs since there's no shadow-mode sink to catch them.

## Grep evidence

- `rg "SetRematchService" backend/` → empty (setter gone).
- `rg "go s\.run\(j\)" backend/internal/service` → empty (private `run` gone).
- `rg "StartRematchForContact" backend/internal/ backend/cmd/` non-test → only the definition in `service/rematch.go` (enforced by `check-rematch-sole-dispatcher`).

Closes step 10/12 of #180.