### PR TITLE
feat(events): Todoist provider migration + #265 fix (PR 11/12 of #180)

### DIFF
--- a/.ai/log/learnings/0aae8a96-33b7-400c-ada9-0137f92be745.yaml
+++ b/.ai/log/learnings/0aae8a96-33b7-400c-ada9-0137f92be745.yaml
@@ -1,0 +1,16 @@
+---
+timestamp: "2026-04-22T16:41:32.920530"
+type: documentation_gap
+summary: plan-and-ship skill doesn't explain agent lifecycle (SendMessage to completed agents)
+detail: |
+  The ~/.claude/skills/plan-and-ship/SKILL.md explains that 'SendMessage({ to: "X" }) resumes it with full memory' but doesn't mention that once task-notification returns status:completed, the agent process has EXITED. SendMessage to a completed agent succeeds at API level ({"success":true}) but silently queues messages to an unread inbox - the agent won't resume. This mistake happened TWICE in this session (SendMessage to 'planner' after completion at 19:10, then to 'planner2' after completion at 19:34). The skill's 'Persistent sub-agents' section should explicitly warn: 'Once status:completed appears in task-notification, the agent is dead. To continue work, spawn a new Agent() with fresh context; SendMessage only works while the agent is still running.'
+actionable: true
+
+---
+timestamp: "2026-04-22T16:41:32.920530"
+type: rule
+summary: Cross-tick recovery predicates must be verified against ALL post-failure state shapes
+detail: |
+  When designing 'defer operation to next tick, then recover' fixes, enumerate every possible state shape the entity can be in after the failure that triggered deferral, and verify the recovery gate predicate fires for EACH shape. In this session: option 2 deferred reconcile on processTempIDMappings tx rollback, assuming tryRecoverPendingTempID would finalize next tick. But the recovery guard required pending_temp_id == ExternalTaskID - true for the historical 'never-mapped' case (both fields equal temp-id) but FALSE for the 'HTTP succeeded, local tx rolled back' case (ExternalTaskID=old-id, pending_temp_id=new-temp-id). The defer only delayed the duplicate-add bug instead of fixing it. Codex caught this in round 8 after the fix was already integrated into the plan. General pattern: any deferred-state-machine recovery (saga compensation, partial-failure rollback, eventual-consistency healing) needs recovery gates that account for all state shapes reachable via the failure path, not just the common case.
+actionable: true
+

--- a/Makefile
+++ b/Makefile
@@ -256,11 +256,11 @@ test-unit:
 
 test-integration-fast:
 	@echo "Running backend integration tests (default set)..."
-	@cd backend && DATABASE_URL="$(TEST_DATABASE_URL)" go test ./tests/... -v
+	@cd backend && DATABASE_URL="$(TEST_DATABASE_URL)" go test ./tests/... ./internal/todoist/... -v
 
 test-integration:
 	@echo "Running backend integration tests..."
-	@cd backend && DATABASE_URL="$(TEST_DATABASE_URL)" LONG_TESTS=1 go test ./tests/... -v
+	@cd backend && DATABASE_URL="$(TEST_DATABASE_URL)" LONG_TESTS=1 go test ./tests/... ./internal/todoist/... -v
 
 test-integration-slow:
 	@echo "Running backend slow integration tests..."

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -584,7 +584,6 @@ func run() int {
 				contactRepo,
 				syncRepo,
 				cfg,
-				contactService,
 				eventBus,
 				database.Pool,
 				todoist.DefaultClientFactory,

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -585,6 +585,9 @@ func run() int {
 				syncRepo,
 				cfg,
 				contactService,
+				eventBus,
+				database.Pool,
+				todoist.DefaultClientFactory,
 			)
 			providerRegistry.Register(todoistProvider)
 			logger.Info().Msg("Todoist Cadence sync provider registered")

--- a/backend/internal/repository/contact.go
+++ b/backend/internal/repository/contact.go
@@ -460,6 +460,18 @@ func (r *ContactRepository) UpdateContactBy(ctx context.Context, id uuid.UUID, c
 	})
 }
 
+// UpdateContactByTx is the tx-threaded variant of UpdateContactBy.
+func (r *ContactRepository) UpdateContactByTx(ctx context.Context, tx pgx.Tx, id uuid.UUID, contactBy time.Time) error {
+	q := r.queries
+	if tx != nil {
+		q = db.New(tx)
+	}
+	return q.UpdateContactBy(ctx, db.UpdateContactByParams{
+		ID:        uuidToPgUUID(id),
+		ContactBy: timeToPgDate(&contactBy),
+	})
+}
+
 // UpdateContactOutreachAt updates only last_outreach_at (for outbound interactions)
 func (r *ContactRepository) UpdateContactOutreachAt(ctx context.Context, id uuid.UUID, outreachAt time.Time, isManual bool) error {
 	return r.queries.UpdateContactOutreachAt(ctx, db.UpdateContactOutreachAtParams{

--- a/backend/internal/todoist/provider.go
+++ b/backend/internal/todoist/provider.go
@@ -248,7 +248,7 @@ func (p *CadenceSyncProvider) Sync(
 	}
 
 	// Process synced items.
-	processedTasks, commands, processErr := p.processItems(ctx, syncResp.Items, settings, accountID)
+	processedTasks, commands, itemsRecoveryFailed, processErr := p.processItems(ctx, syncResp.Items, settings, accountID)
 	result.ItemsProcessed = processedTasks
 
 	// Execute any accumulated commands BEFORE checking processErr. If
@@ -292,9 +292,14 @@ func (p *CadenceSyncProvider) Sync(
 	}
 
 	// Reconcile: ensure all contacts with cadence have tasks.
-	// deferSkipDrift suppresses the skip-drift recovery branch when a
-	// mapping tx rolled back earlier this invocation — see processTempIDMappings.
-	reconcileCommands := p.reconcileContactTasks(ctx, client, settings, accountID, mappingRolledBack)
+	// deferSkipDrift suppresses the skip-drift recovery branch when:
+	//   - processTempIDMappings had a per-task tx rollback (mapping
+	//     ambiguous — real remote task may exist); OR
+	//   - tryRecoverPendingTempID attempted recovery but the tx rolled
+	//     back (local row stale while real remote item was delivered this
+	//     tick — skip-drift would emit a duplicate item_add).
+	deferSkipDrift := mappingRolledBack || itemsRecoveryFailed
+	reconcileCommands := p.reconcileContactTasks(ctx, client, settings, accountID, deferSkipDrift)
 	if len(reconcileCommands) > 0 {
 		for _, batch := range BatchCommands(reconcileCommands, 100) {
 			cmdResp, err := client.Sync(ctx, result.NewCursor, []string{}, batch)
@@ -344,10 +349,17 @@ func (p *CadenceSyncProvider) ValidateCredentials(ctx context.Context, accountID
 //   - Commands:  Todoist commands to enqueue in the batch.
 //   - Err:       non-nil for fatal errors; processItems aborts the batch
 //     without advancing the cursor.
+//   - RecoveryFailed: tryRecoverPendingTempID matched a CRM marker for
+//     this item but its atomic tx (external_id swap + pending_temp_id
+//     clear) rolled back, leaving the local row stale. Sync uses this to
+//     force deferSkipDrift=true for reconcile in the same invocation —
+//     otherwise reconcile's skip-drift branch would emit a duplicate
+//     item_add against the real remote task that already exists.
 type processItemResult struct {
-	Processed bool
-	Commands  []SyncCommand
-	Err       error
+	Processed      bool
+	Commands       []SyncCommand
+	Err            error
+	RecoveryFailed bool
 }
 
 // processItems iterates over the items returned by a Todoist sync,
@@ -356,14 +368,23 @@ type processItemResult struct {
 // pre-batch cursor so the next tick replays. Each successful item commits
 // atomically via its own tx, so replays short-circuit at the state !=
 // 'managed' early-return in processItem and never double-advance.
+//
+// recoveryFailed is set when any item's tryRecoverPendingTempID attempted
+// recovery but the atomic tx rolled back. Sync threads this into
+// reconcileContactTasks as deferSkipDrift=true so the skip-drift branch
+// does not fire against the stale local row this tick — the real Todoist
+// task already exists server-side.
 func (p *CadenceSyncProvider) processItems(
 	ctx context.Context,
 	items []SyncItem,
 	settings Settings,
 	accountID string,
-) (processed int, commands []SyncCommand, err error) {
+) (processed int, commands []SyncCommand, recoveryFailed bool, err error) {
 	for _, item := range items {
 		r := p.processItem(ctx, item, settings, accountID)
+		if r.RecoveryFailed {
+			recoveryFailed = true
+		}
 		if r.Err != nil {
 			logger.Error().Err(r.Err).
 				Str("itemId", item.ID).
@@ -372,14 +393,14 @@ func (p *CadenceSyncProvider) processItems(
 			// Return accumulated commands so Sync can execute any
 			// ItemClose/ItemDelete commands queued by already-committed
 			// handlers before returning the error.
-			return processed, commands, fmt.Errorf("process item %s: %w", item.ID, r.Err)
+			return processed, commands, recoveryFailed, fmt.Errorf("process item %s: %w", item.ID, r.Err)
 		}
 		if r.Processed {
 			processed++
 		}
 		commands = append(commands, r.Commands...)
 	}
-	return processed, commands, nil
+	return processed, commands, recoveryFailed, nil
 }
 
 // processItem processes a single Todoist item from sync
@@ -388,8 +409,19 @@ func (p *CadenceSyncProvider) processItem(
 	item SyncItem,
 	settings Settings,
 	accountID string,
-) processItemResult {
+) (result processItemResult) {
 	var commands []SyncCommand
+
+	// Recovery-failed signal propagates up to Sync (via processItems) so
+	// deferSkipDrift=true forces reconcile's skip-drift branch to defer
+	// when this item's recovery tx rolled back. Applied via defer so every
+	// return path carries the flag.
+	var recoveryFailed bool
+	defer func() {
+		if recoveryFailed {
+			result.RecoveryFailed = true
+		}
+	}()
 
 	// Find if this task is linked to a contact
 	task, err := p.contactTaskRepo.GetContactTaskByExternalID(ctx, SourceName, item.ID)
@@ -400,9 +432,9 @@ func (p *CadenceSyncProvider) processItem(
 		// Fallback: if processTempIDMappings failed, the contact_task still has a
 		// temp ID while Todoist uses the real ID. Try to recover by matching the
 		// CRM marker in the description to find a task with a pending temp ID.
-		task = p.tryRecoverPendingTempID(ctx, item)
+		task, recoveryFailed = p.tryRecoverPendingTempID(ctx, item)
 		if task == nil {
-			return processItemResult{} // Not a managed task
+			return processItemResult{}
 		}
 	}
 
@@ -1394,6 +1426,14 @@ func isPendingTempID(task *repository.ContactTask) bool {
 // finalizes the mapping atomically inside a pgx.Tx (external_id + metadata clear
 // commit together or roll back together).
 //
+// Returns (task, recoveryFailed). recoveryFailed is true when a CRM marker
+// was matched and the atomic recovery tx rolled back — the caller
+// (processItem) propagates this via processItemResult.RecoveryFailed so
+// Sync can force deferSkipDrift=true for the same-tick reconcile pass.
+// recoveryFailed is false when no CRM marker matched (task is nil; nothing
+// to recover), when recovery succeeded, or when recovery was not applicable
+// (guard rejected the task).
+//
 // Recovery guard: task.State == managed && pending_temp_id != "". Broadened
 // from the narrow isPendingTempID check (which required pending_temp_id ==
 // ExternalTaskID) so this function also recovers the post-rollback shape
@@ -1401,7 +1441,7 @@ func isPendingTempID(task *repository.ContactTask) bool {
 // the temp of the (already-created remotely) new task. The CRM marker
 // parse above verifies the sync item belongs to the same contact + cadence
 // kind, so advancing ExternalTaskID = item.ID is safe.
-func (p *CadenceSyncProvider) tryRecoverPendingTempID(ctx context.Context, item SyncItem) *repository.ContactTask {
+func (p *CadenceSyncProvider) tryRecoverPendingTempID(ctx context.Context, item SyncItem) (*repository.ContactTask, bool) {
 	// Parse CRM marker from description to get contact ID
 	var marker struct {
 		CRM       bool   `json:"crm"`
@@ -1419,13 +1459,13 @@ func (p *CadenceSyncProvider) tryRecoverPendingTempID(ctx context.Context, item 
 			descToTry = item.Description[idx:]
 		}
 		if err := json.Unmarshal([]byte(descToTry), &marker); err != nil || !marker.CRM || marker.ContactID == "" {
-			return nil
+			return nil, false
 		}
 	}
 
 	contactID, err := uuid.Parse(marker.ContactID)
 	if err != nil {
-		return nil
+		return nil, false
 	}
 
 	// Only recover cadence tasks
@@ -1434,19 +1474,19 @@ func (p *CadenceSyncProvider) tryRecoverPendingTempID(ctx context.Context, item 
 		kind = TaskKindCadence
 	}
 	if kind != TaskKindCadence {
-		return nil
+		return nil, false
 	}
 
 	task, err := p.contactTaskRepo.GetContactTaskByContact(ctx, contactID, SourceName, kind)
 	if err != nil {
-		return nil
+		return nil, false
 	}
 
 	// Broadened guard: any managed task with a non-empty pending_temp_id
 	// is a candidate for finalizing the mapping. See function docstring.
 	pendingTempID, _ := task.Metadata[MetadataKeyPendingTempID].(string)
 	if task.State != repository.ContactTaskStateManaged || pendingTempID == "" {
-		return nil
+		return nil, false
 	}
 
 	oldID := task.ExternalTaskID
@@ -1457,7 +1497,7 @@ func (p *CadenceSyncProvider) tryRecoverPendingTempID(ctx context.Context, item 
 		logger.Warn().Err(err).
 			Str("contactId", marker.ContactID).
 			Msg("tryRecoverPendingTempID: begin tx failed")
-		return task // fallback: process with old ID
+		return task, true
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
@@ -1467,7 +1507,7 @@ func (p *CadenceSyncProvider) tryRecoverPendingTempID(ctx context.Context, item 
 			Str("oldExternalId", oldID).
 			Str("newExternalId", item.ID).
 			Msg("tryRecoverPendingTempID: update external_id failed")
-		return task
+		return task, true
 	}
 
 	metadata := task.Metadata
@@ -1477,12 +1517,12 @@ func (p *CadenceSyncProvider) tryRecoverPendingTempID(ctx context.Context, item 
 	delete(metadata, MetadataKeyPendingTempID)
 	if _, err := p.contactTaskRepo.UpdateContactTaskMetadataTx(ctx, tx, task.ID, metadata); err != nil {
 		logger.Warn().Err(err).Msg("tryRecoverPendingTempID: clear pending_temp_id failed")
-		return task
+		return task, true
 	}
 
 	if err := tx.Commit(ctx); err != nil {
 		logger.Warn().Err(err).Msg("tryRecoverPendingTempID: commit failed")
-		return task
+		return task, true
 	}
 
 	// Reflect in the returned task (in-memory).
@@ -1495,7 +1535,7 @@ func (p *CadenceSyncProvider) tryRecoverPendingTempID(ctx context.Context, item 
 		Str("realId", item.ID).
 		Msg("recovered pending temp ID mapping (atomic commit)")
 
-	return task
+	return task, false
 }
 
 // createTaskCommand creates a Todoist task creation command
@@ -1552,7 +1592,21 @@ func (p *CadenceSyncProvider) processTempIDMappings(ctx context.Context, tempIDM
 		// Find the task by pending_temp_id
 		task, err := p.contactTaskRepo.GetContactTaskByPendingTempID(ctx, SourceName, tempID)
 		if err != nil {
-			// Not found is expected if this temp_id wasn't from us.
+			if errors.Is(err, db.ErrNotFound) {
+				// Expected when this temp_id wasn't from us.
+				continue
+			}
+			// Any non-ErrNotFound lookup failure (DB timeout, connection
+			// error) means we can't tell whether this mapping applies to
+			// a local row. The safe move is to set rolledBack=true so the
+			// skip-drift recovery branch defers by one tick — otherwise
+			// this-tick reconcile could emit a duplicate item_add against
+			// an already-created remote task.
+			logger.Warn().Err(err).
+				Str("tempId", tempID).
+				Str("realId", realID).
+				Msg("temp_id mapping: lookup failed; deferring reconcile skip-drift this tick")
+			rolledBack = true
 			continue
 		}
 

--- a/backend/internal/todoist/provider.go
+++ b/backend/internal/todoist/provider.go
@@ -69,11 +69,6 @@ const (
 // DateFormat is the date format used for Todoist deadlines and synced_deadline metadata (YYYY-MM-DD)
 const DateFormat = "2006-01-02"
 
-// interactionRecorder defines the method for recording interactions (satisfied by ContactService)
-type interactionRecorder interface {
-	RecordInteraction(ctx context.Context, req repository.RecordInteractionRequest) (*repository.Interaction, error)
-}
-
 // eventPublisher is the subset of *events.Bus used by the provider. Defined
 // consumer-side so tests can stub without importing the bus.
 type eventPublisher interface {
@@ -112,11 +107,10 @@ type contactWriter interface {
 
 // CadenceSyncProvider implements SyncProvider for Todoist cadence tasks
 type CadenceSyncProvider struct {
-	oauthService        *OAuthService
-	contactTaskRepo     contactTaskWriter
-	contactRepo         contactWriter
-	syncRepo            *repository.SyncRepository
-	interactionRecorder interactionRecorder
+	oauthService    *OAuthService
+	contactTaskRepo contactTaskWriter
+	contactRepo     contactWriter
+	syncRepo        *repository.SyncRepository
 	// bus, pool, and clientFactory are required for the tx-atomic handlers
 	// and for HTTP-failure injection in tests. Nil values are caught by a
 	// single defensive nil-guard at the top of Sync; production wiring in
@@ -134,21 +128,19 @@ func NewCadenceSyncProvider(
 	contactRepo contactWriter,
 	syncRepo *repository.SyncRepository,
 	cfg *config.Config,
-	interactionRecorder interactionRecorder,
 	bus eventPublisher,
 	pool *pgxpool.Pool,
 	clientFactory ClientFactory,
 ) *CadenceSyncProvider {
 	return &CadenceSyncProvider{
-		oauthService:        oauthService,
-		contactTaskRepo:     contactTaskRepo,
-		contactRepo:         contactRepo,
-		syncRepo:            syncRepo,
-		interactionRecorder: interactionRecorder,
-		bus:                 bus,
-		pool:                pool,
-		clientFactory:       clientFactory,
-		frontendURL:         cfg.CORS.FrontendURL,
+		oauthService:    oauthService,
+		contactTaskRepo: contactTaskRepo,
+		contactRepo:     contactRepo,
+		syncRepo:        syncRepo,
+		bus:             bus,
+		pool:            pool,
+		clientFactory:   clientFactory,
+		frontendURL:     cfg.CORS.FrontendURL,
 	}
 }
 

--- a/backend/internal/todoist/provider.go
+++ b/backend/internal/todoist/provider.go
@@ -12,11 +12,14 @@ import (
 	"personal-crm/backend/internal/cadence"
 	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
 	"personal-crm/backend/internal/logger"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/sync"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 const (
@@ -71,24 +74,70 @@ type interactionRecorder interface {
 	RecordInteraction(ctx context.Context, req repository.RecordInteractionRequest) (*repository.Interaction, error)
 }
 
+// eventPublisher is the subset of *events.Bus used by the provider. Defined
+// consumer-side so tests can stub without importing the bus.
+type eventPublisher interface {
+	PublishTx(ctx context.Context, tx pgx.Tx, env *events.Envelope) error
+}
+
+// contactTaskWriter is the subset of *repository.ContactTaskRepository the
+// provider uses. Narrow interface so integration tests can wrap the real
+// repo with faulty-method injection.
+type contactTaskWriter interface {
+	GetContactTaskByExternalID(ctx context.Context, provider, externalID string) (*repository.ContactTask, error)
+	GetContactTaskByContact(ctx context.Context, contactID uuid.UUID, provider, kind string) (*repository.ContactTask, error)
+	GetContactTaskByPendingTempID(ctx context.Context, provider, tempID string) (*repository.ContactTask, error)
+	GetContactTask(ctx context.Context, id uuid.UUID) (*repository.ContactTask, error)
+	CreateContactTask(ctx context.Context, req repository.CreateContactTaskRequest) (*repository.ContactTask, error)
+	DeleteContactTask(ctx context.Context, id uuid.UUID) error
+	UpdateContactTaskState(ctx context.Context, id uuid.UUID, state repository.ContactTaskState) (*repository.ContactTask, error)
+	UpdateContactTaskStateTx(ctx context.Context, tx pgx.Tx, id uuid.UUID, state repository.ContactTaskState) (*repository.ContactTask, error)
+	UpdateContactTaskMetadata(ctx context.Context, id uuid.UUID, metadata map[string]any) (*repository.ContactTask, error)
+	UpdateContactTaskMetadataTx(ctx context.Context, tx pgx.Tx, id uuid.UUID, metadata map[string]any) (*repository.ContactTask, error)
+	UpdateContactTaskExternalID(ctx context.Context, id uuid.UUID, externalID string) (*repository.ContactTask, error)
+	UpdateContactTaskExternalIDTx(ctx context.Context, tx pgx.Tx, id uuid.UUID, externalID string) (*repository.ContactTask, error)
+	FindPendingFollowUp(ctx context.Context, contactID uuid.UUID) (*repository.ContactTask, error)
+	ListContactTasksByContact(ctx context.Context, contactID uuid.UUID) ([]repository.ContactTask, error)
+}
+
+// contactWriter is the subset of *repository.ContactRepository the provider
+// uses. Narrow interface so tests can inject UpdateContactByTx failures for
+// skip-path rollback tests.
+type contactWriter interface {
+	GetContact(ctx context.Context, id uuid.UUID) (*repository.Contact, error)
+	ListContactsWithContactBy(ctx context.Context, limit int32) ([]repository.Contact, error)
+	UpdateContactBy(ctx context.Context, id uuid.UUID, contactBy time.Time) error
+	UpdateContactByTx(ctx context.Context, tx pgx.Tx, id uuid.UUID, contactBy time.Time) error
+}
+
 // CadenceSyncProvider implements SyncProvider for Todoist cadence tasks
 type CadenceSyncProvider struct {
 	oauthService        *OAuthService
-	contactTaskRepo     *repository.ContactTaskRepository
-	contactRepo         *repository.ContactRepository
+	contactTaskRepo     contactTaskWriter
+	contactRepo         contactWriter
 	syncRepo            *repository.SyncRepository
 	interactionRecorder interactionRecorder
-	frontendURL         string
+	// bus, pool, and clientFactory are required for the tx-atomic handlers
+	// and for HTTP-failure injection in tests. Nil values are caught by a
+	// single defensive nil-guard at the top of Sync; production wiring in
+	// main.go passes non-nil values.
+	bus           eventPublisher
+	pool          *pgxpool.Pool
+	clientFactory ClientFactory
+	frontendURL   string
 }
 
 // NewCadenceSyncProvider creates a new Todoist cadence sync provider
 func NewCadenceSyncProvider(
 	oauthService *OAuthService,
-	contactTaskRepo *repository.ContactTaskRepository,
-	contactRepo *repository.ContactRepository,
+	contactTaskRepo contactTaskWriter,
+	contactRepo contactWriter,
 	syncRepo *repository.SyncRepository,
 	cfg *config.Config,
 	interactionRecorder interactionRecorder,
+	bus eventPublisher,
+	pool *pgxpool.Pool,
+	clientFactory ClientFactory,
 ) *CadenceSyncProvider {
 	return &CadenceSyncProvider{
 		oauthService:        oauthService,
@@ -96,6 +145,9 @@ func NewCadenceSyncProvider(
 		contactRepo:         contactRepo,
 		syncRepo:            syncRepo,
 		interactionRecorder: interactionRecorder,
+		bus:                 bus,
+		pool:                pool,
+		clientFactory:       clientFactory,
 		frontendURL:         cfg.CORS.FrontendURL,
 	}
 }
@@ -118,6 +170,10 @@ func (p *CadenceSyncProvider) Sync(
 	state *repository.SyncState,
 	contacts []repository.Contact,
 ) (*sync.SyncResult, error) {
+	if p.bus == nil || p.pool == nil || p.clientFactory == nil {
+		return nil, fmt.Errorf("todoist: bus + pool + clientFactory must be non-nil")
+	}
+
 	// Get account ID from state
 	if state.AccountID == nil {
 		return nil, fmt.Errorf("account ID required for Todoist sync")
@@ -142,7 +198,7 @@ func (p *CadenceSyncProvider) Sync(
 	}
 
 	// Create sync client
-	client := NewSyncClient(accessToken)
+	client := p.clientFactory(accessToken)
 
 	result := &sync.SyncResult{}
 
@@ -824,7 +880,7 @@ func (p *CadenceSyncProvider) handleActionTaskTriggers(
 // and that existing tasks have deadlines matching the contact's contact_by.
 func (p *CadenceSyncProvider) reconcileContactTasks(
 	ctx context.Context,
-	client *SyncClient,
+	client Client,
 	settings Settings,
 	accountID string,
 ) []SyncCommand {

--- a/backend/internal/todoist/provider.go
+++ b/backend/internal/todoist/provider.go
@@ -525,7 +525,7 @@ func (p *CadenceSyncProvider) processItem(
 		if task.Kind == TaskKindFollowUp {
 			return p.handleFollowUpDismissal(ctx, item, task, contact)
 		}
-		return p.handleSkipTrigger(ctx, task, contact, settings, accountID)
+		return p.handleSkipTrigger(ctx, item, task, contact, settings, accountID)
 	}
 
 	// Check for deadline edit (Todoist wins) — only for cadence tasks.
@@ -680,93 +680,140 @@ func (p *CadenceSyncProvider) handleTaskCompletion(
 
 // handleSkipTrigger handles a skip trigger (task deleted, label removed, deadline removed).
 //
-// Failure semantics: this handler intentionally retains log-and-continue on DB
-// failure (returns Err: nil always). It commits non-idempotent side effects —
-// advances contact.contact_by and appends a replacement item_add command while
-// leaving the row state='managed'. On replay, processItem would NOT
-// short-circuit (state is still managed), so the same skip trigger would run
-// a second time and double-advance the cadence clock. Fixing this requires
-// transactional state tracking or an idempotency marker.
-// TODO(#265): see the deferred refactor tracking issue — this
-// handler is on the list for transactional rewrite.
+// Atomic publish + mutate: opens a pgx.Tx, publishes task.skipped via PublishTx,
+// advances contact.contact_by via UpdateContactByTx, writes metadata keys
+// (pending_temp_id, synced_deadline, synced_last_*) via UpdateContactTaskMetadataTx,
+// commits. Rollback on any error rolls back event row, contact_by advance, and
+// metadata together — no partial commits.
 //
-// Returns Unsafe: true on every successful return. This flag tells the sync
-// loop's processItems method that a non-replay-safe side effect was committed
-// in this batch; subsequent fatal errors in the same batch fall back to
-// log-and-continue instead of aborting (which would cause replay
-// double-advancement of this contact's cadence clock). The flag is set
-// unconditionally because partial failures (e.g., UpdateContactBy succeeded
-// but UpdateContactTaskMetadata failed) still advance contact_by — so even a
-// "failed" skip is unsafe to replay.
+// Replay safety: the event SourceID is task.ID.String():item.UpdatedAt. A
+// replay of the same unchanged Todoist item hits the (source, source_id)
+// unique on the event table; PublishTx resets env.ID to uuid.Nil and returns
+// nil; the handler short-circuits without advancing contact_by. The suffix
+// distinguishes genuine repeat-skips (item re-edited → new UpdatedAt) from
+// replays of the same unchanged item.
+//
+// Ordering (publish-before-mutate per core.md): PublishTx → mutate →
+// commit. Reversing would strand interactions on publish failure.
 func (p *CadenceSyncProvider) handleSkipTrigger(
 	ctx context.Context,
+	item SyncItem,
 	task *repository.ContactTask,
 	contact *repository.Contact,
 	settings Settings,
 	accountID string,
 ) processItemResult {
-	var commands []SyncCommand
-
-	// Calculate new contact_by using skip semantics
-	if contact.Cadence != nil && *contact.Cadence != "" {
-		cadenceType, err := cadence.ParseCadence(*contact.Cadence)
-		if err == nil {
-			// Skip pushes deadline out by a full cadence period
-			// Use the later of: (skipped contact_by + cadence) or (today + cadence)
-			days := cadence.CadenceDays(cadenceType)
-			now := accelerated.GetCurrentTime()
-			today := cadence.Today(now)
-
-			// Option 1: today + cadence
-			fromToday := today.AddDate(0, 0, days)
-
-			// Option 2: skipped contact_by + cadence
-			fromSkipped := fromToday // fallback if no contact_by
-			if contact.ContactBy != nil {
-				fromSkipped = contact.ContactBy.AddDate(0, 0, days)
-			}
-
-			// Use whichever is farther in the future
-			nextContactBy := fromToday
-			if fromSkipped.After(fromToday) {
-				nextContactBy = fromSkipped
-			}
-
-			// Update contact_by
-			if err := p.contactRepo.UpdateContactBy(ctx, contact.ID, nextContactBy); err != nil {
-				logger.Warn().Err(err).Msg("failed to update contact_by after skip")
-			}
-
-			// Create new task
-			deadlineStr := nextContactBy.Format(DateFormat)
-			cmd := p.createTaskCommand(contact, settings, &deadlineStr)
-			commands = append(commands, cmd)
-
-			// Update metadata with temp_id, synced_deadline, and synced_last_contacted (preserving existing keys)
-			metadata := task.Metadata
-			if metadata == nil {
-				metadata = make(map[string]any)
-			}
-			metadata[MetadataKeyPendingTempID] = cmd.TempID
-			metadata[MetadataKeySyncedDeadline] = deadlineStr
-			if contact.LastContacted != nil {
-				metadata[MetadataKeySyncedLastContacted] = contact.LastContacted.Format(time.RFC3339)
-			}
-			if contact.LastOutreachAt != nil {
-				metadata[MetadataKeySyncedLastOutreachAt] = contact.LastOutreachAt.Format(time.RFC3339)
-			}
-			if _, err := p.contactTaskRepo.UpdateContactTaskMetadata(ctx, task.ID, metadata); err != nil {
-				logger.Warn().Err(err).Msg("failed to store pending_temp_id and synced_deadline in task metadata")
-			}
-
-			logger.Info().
-				Str("contactId", contact.ID.String()).
-				Time("newContactBy", nextContactBy).
-				Msg("processed skip trigger, created new task")
-		}
+	// Early-return: no cadence → nothing to advance → no state change, no event.
+	if contact.Cadence == nil || *contact.Cadence == "" {
+		return processItemResult{Processed: true}
+	}
+	cadenceType, err := cadence.ParseCadence(*contact.Cadence)
+	if err != nil {
+		logger.Warn().Err(err).
+			Str("contactId", contact.ID.String()).
+			Str("cadence", *contact.Cadence).
+			Msg("skip trigger: invalid cadence; no-op")
+		return processItemResult{Processed: true}
 	}
 
-	return processItemResult{Processed: true, Commands: commands, Unsafe: true}
+	// Compute nextContactBy (skip semantics: later of today+cadence or
+	// old contact_by+cadence).
+	days := cadence.CadenceDays(cadenceType)
+	now := accelerated.GetCurrentTime()
+	today := cadence.Today(now)
+	fromToday := today.AddDate(0, 0, days)
+	fromSkipped := fromToday
+	if contact.ContactBy != nil {
+		fromSkipped = contact.ContactBy.AddDate(0, 0, days)
+	}
+	nextContactBy := fromToday
+	if fromSkipped.After(fromToday) {
+		nextContactBy = fromSkipped
+	}
+
+	skippedAt := accelerated.GetCurrentTime()
+	payload, err := events.Marshal(events.KindTaskSkipped, events.TaskSkippedPayload{
+		Version:   1,
+		ContactID: contact.ID,
+		TaskID:    task.ExternalTaskID,
+		SkippedAt: skippedAt,
+	})
+	if err != nil {
+		return processItemResult{Err: fmt.Errorf("marshal task.skipped: %w", err)}
+	}
+	// SourceID: stable internal contact_task.id + item.UpdatedAt so replays
+	// of the same unchanged item dedup, while user re-edits produce new events.
+	env := &events.Envelope{
+		Source:     SourceName,
+		SourceID:   fmt.Sprintf("%s:%s", task.ID.String(), item.UpdatedAt),
+		Kind:       events.KindTaskSkipped,
+		Payload:    payload,
+		ObservedAt: skippedAt,
+	}
+
+	// Pre-compute replacement item_add so its TempID can land in metadata
+	// atomically with the state advance.
+	deadlineStr := nextContactBy.Format(DateFormat)
+	replacementCmd := p.createTaskCommand(contact, settings, &deadlineStr)
+
+	tx, err := p.pool.Begin(ctx)
+	if err != nil {
+		return processItemResult{Err: fmt.Errorf("begin tx: %w", err)}
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// Publish-before-mutate (core.md gotcha).
+	if err := p.bus.PublishTx(ctx, tx, env); err != nil {
+		return processItemResult{Err: fmt.Errorf("publish task.skipped: %w", err)}
+	}
+	if env.ID == uuid.Nil {
+		// Duplicate — prior tick processed this skip. No state change, no
+		// replacement command. Self-healing for a previously-failed HTTP
+		// batch is the responsibility of reconcileExistingTask's skip-drift
+		// branch, not this handler.
+		logger.Debug().
+			Str("sourceId", env.SourceID).
+			Msg("task.skipped duplicate; skipping state advance")
+		return processItemResult{Processed: true}
+	}
+
+	// Advance contact_by.
+	if err := p.contactRepo.UpdateContactByTx(ctx, tx, contact.ID, nextContactBy); err != nil {
+		return processItemResult{Err: fmt.Errorf("update contact_by: %w", err)}
+	}
+
+	// Update metadata. Preserve existing keys — pre-skip synced_deadline is
+	// consulted by the reconciler's skip-drift branch to close+recreate on
+	// HTTP failure.
+	metadata := task.Metadata
+	if metadata == nil {
+		metadata = make(map[string]any)
+	}
+	metadata[MetadataKeyPendingTempID] = replacementCmd.TempID
+	metadata[MetadataKeySyncedDeadline] = deadlineStr
+	if contact.LastContacted != nil {
+		metadata[MetadataKeySyncedLastContacted] = contact.LastContacted.Format(time.RFC3339)
+	}
+	if contact.LastOutreachAt != nil {
+		metadata[MetadataKeySyncedLastOutreachAt] = contact.LastOutreachAt.Format(time.RFC3339)
+	}
+	if _, err := p.contactTaskRepo.UpdateContactTaskMetadataTx(ctx, tx, task.ID, metadata); err != nil {
+		return processItemResult{Err: fmt.Errorf("update task metadata: %w", err)}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return processItemResult{Err: fmt.Errorf("commit: %w", err)}
+	}
+
+	logger.Info().
+		Str("contactId", contact.ID.String()).
+		Time("newContactBy", nextContactBy).
+		Str("sourceId", env.SourceID).
+		Msg("published task.skipped (atomic commit)")
+
+	// Return replacement item_add only after commit — the HTTP batch fires
+	// outside the tx in Sync's post-loop block (core.md gotcha).
+	return processItemResult{Processed: true, Commands: []SyncCommand{replacementCmd}, Unsafe: true}
 }
 
 // handleFollowUpDismissal handles a follow-up task being dismissed via Todoist.

--- a/backend/internal/todoist/provider.go
+++ b/backend/internal/todoist/provider.go
@@ -257,13 +257,16 @@ func (p *CadenceSyncProvider) Sync(
 	// persisted local state transitions — executing them prevents orphaning
 	// Todoist tasks whose local rows are already in terminal states. See the
 	// comment in processItems's abort path for why this is safe.
+	mappingRolledBack := false
 	if len(commands) > 0 {
 		for _, batch := range BatchCommands(commands, 100) {
 			cmdResp, err := client.Sync(ctx, syncResp.SyncToken, []string{}, batch)
 			if err != nil {
 				logger.Warn().Err(err).Int("commands", len(batch)).Msg("failed to execute Todoist commands")
 			} else if cmdResp != nil {
-				p.processTempIDMappings(ctx, cmdResp.TempIDMap)
+				if p.processTempIDMappings(ctx, cmdResp.TempIDMap) {
+					mappingRolledBack = true
+				}
 			}
 		}
 	}
@@ -288,15 +291,19 @@ func (p *CadenceSyncProvider) Sync(
 		}
 	}
 
-	// Reconcile: ensure all contacts with cadence have tasks
-	reconcileCommands := p.reconcileContactTasks(ctx, client, settings, accountID)
+	// Reconcile: ensure all contacts with cadence have tasks.
+	// deferSkipDrift suppresses the skip-drift recovery branch when a
+	// mapping tx rolled back earlier this invocation — see processTempIDMappings.
+	reconcileCommands := p.reconcileContactTasks(ctx, client, settings, accountID, mappingRolledBack)
 	if len(reconcileCommands) > 0 {
 		for _, batch := range BatchCommands(reconcileCommands, 100) {
 			cmdResp, err := client.Sync(ctx, result.NewCursor, []string{}, batch)
 			if err != nil {
 				logger.Warn().Err(err).Int("commands", len(batch)).Msg("failed to execute reconciliation commands")
 			} else if cmdResp != nil {
-				p.processTempIDMappings(ctx, cmdResp.TempIDMap)
+				// Rollback here is picked up next tick by design — no further
+				// reconcile pass within this Sync invocation.
+				_ = p.processTempIDMappings(ctx, cmdResp.TempIDMap)
 			}
 		}
 	}
@@ -874,11 +881,22 @@ func (p *CadenceSyncProvider) handleActionTaskTriggers(
 
 // reconcileContactTasks ensures all contacts with cadence have managed tasks
 // and that existing tasks have deadlines matching the contact's contact_by.
+//
+// deferSkipDrift suppresses the skip-drift recovery branch in
+// reconcileExistingTask for this invocation. Set when processTempIDMappings
+// had a tx rollback earlier in the same Sync call — the row's
+// (ExternalTaskID=<old>, pending_temp_id=<temp-new>) shape then becomes
+// ambiguous between "HTTP batch failed" (branch should fire) and "HTTP
+// succeeded, local mapping rolled back" (branch must NOT fire, else emits a
+// duplicate item_add against an already-created remote task). Safe choice
+// is to defer one tick; tryRecoverPendingTempID finalizes next tick when
+// the real item arrives in syncResp.Items.
 func (p *CadenceSyncProvider) reconcileContactTasks(
 	ctx context.Context,
 	client Client,
 	settings Settings,
 	accountID string,
+	deferSkipDrift bool,
 ) []SyncCommand {
 	var commands []SyncCommand
 
@@ -980,7 +998,7 @@ func (p *CadenceSyncProvider) reconcileContactTasks(
 		}
 
 		// Task exists and is managed - check if deadline needs updating
-		cmds := p.reconcileExistingTask(ctx, task, &contact, settings, currentDeadline)
+		cmds := p.reconcileExistingTask(ctx, task, &contact, settings, currentDeadline, deferSkipDrift)
 		commands = append(commands, cmds...)
 	}
 
@@ -1079,8 +1097,66 @@ func (p *CadenceSyncProvider) reconcileExistingTask(
 	contact *repository.Contact,
 	settings Settings,
 	currentDeadline string,
+	deferSkipDrift bool,
 ) []SyncCommand {
 	var commands []SyncCommand
+
+	// Skip-drift recovery: a prior handleSkipTrigger tx committed state +
+	// event, but the post-commit Todoist HTTP batch (item_add) never
+	// processed, so pending_temp_id is stale. Detection: metadata has a
+	// non-empty pending_temp_id that does NOT match the current
+	// ExternalTaskID. On the happy path, processTempIDMappings clears
+	// pending_temp_id once the real Todoist id returns; a stale
+	// pending_temp_id with unchanged ExternalTaskID means the mapping
+	// never landed.
+	//
+	// Deferral: when this Sync invocation had a processTempIDMappings tx
+	// roll back (deferSkipDrift=true), the row's stale-looking state
+	// cannot be distinguished from "HTTP batch failed". Firing the branch
+	// anyway would emit a duplicate item_add against an already-created
+	// remote task. Wait one tick; next tick's syncResp.Items will deliver
+	// the real task and tryRecoverPendingTempID will finalize the mapping.
+	pendingTemp, hasPending := task.Metadata[MetadataKeyPendingTempID].(string)
+	if !deferSkipDrift && hasPending && pendingTemp != "" && pendingTemp != task.ExternalTaskID {
+		logger.Info().
+			Str("contactId", contact.ID.String()).
+			Str("externalTaskId", task.ExternalTaskID).
+			Str("pendingTempId", pendingTemp).
+			Msg("skip-drift recovery: re-emitting close+create for replacement cadence task")
+
+		cmd := p.createTaskCommand(contact, settings, &currentDeadline)
+
+		// Persist new pending_temp_id BEFORE emitting commands. If the
+		// metadata write fails, do NOT return the commands — the new
+		// temp id would never land in the row, so the post-loop HTTP
+		// batch's temp_id_mapping response couldn't be applied via
+		// processTempIDMappings. Emitting the commands anyway would
+		// create a Todoist task with no way to map back to the contact_task.
+		metadata := task.Metadata
+		if metadata == nil {
+			metadata = make(map[string]any)
+		}
+		metadata[MetadataKeyPendingTempID] = cmd.TempID
+		metadata[MetadataKeySyncedDeadline] = currentDeadline
+		if contact.LastContacted != nil {
+			metadata[MetadataKeySyncedLastContacted] = contact.LastContacted.Format(time.RFC3339)
+		}
+		if contact.LastOutreachAt != nil {
+			metadata[MetadataKeySyncedLastOutreachAt] = contact.LastOutreachAt.Format(time.RFC3339)
+		}
+		if _, err := p.contactTaskRepo.UpdateContactTaskMetadata(ctx, task.ID, metadata); err != nil {
+			logger.Warn().Err(err).
+				Str("contactId", contact.ID.String()).
+				Msg("skip-drift recovery: update metadata failed; not emitting commands (retry next tick)")
+			return commands
+		}
+
+		if task.ExternalTaskID != "" {
+			commands = append(commands, NewItemCloseCommand(task.ExternalTaskID))
+		}
+		commands = append(commands, cmd)
+		return commands
+	}
 
 	// Get synced_deadline from metadata
 	syncedDeadline, hasSyncedDeadline := task.Metadata[MetadataKeySyncedDeadline].(string)
@@ -1459,47 +1535,69 @@ func (p *CadenceSyncProvider) createTaskCommand(contact *repository.Contact, set
 	)
 }
 
-// processTempIDMappings updates contact_task records with real Todoist task IDs
-func (p *CadenceSyncProvider) processTempIDMappings(ctx context.Context, tempIDMap map[string]string) {
+// processTempIDMappings updates contact_task records with real Todoist task
+// IDs returned in a sync response's temp_id_mapping. Each per-task update
+// runs in its own tx (external_id + pending_temp_id clear commit together
+// or roll back together), eliminating the partial-commit ambiguity where
+// ExternalTaskID advanced but pending_temp_id stayed stale.
+//
+// Returns rolledBack=true if any per-task tx rolled back during this
+// invocation. Callers (Sync) thread that flag into reconcileContactTasks so
+// the skip-drift recovery branch defers by one tick when a rollback leaves
+// the row in a state indistinguishable from an HTTP-batch failure — the
+// real Todoist task already exists server-side, so firing skip-drift this
+// tick would emit a duplicate item_add. Next tick, tryRecoverPendingTempID
+// finalizes via the real item arriving in syncResp.Items.
+func (p *CadenceSyncProvider) processTempIDMappings(ctx context.Context, tempIDMap map[string]string) (rolledBack bool) {
 	if len(tempIDMap) == 0 {
-		return
+		return false
 	}
 
 	for tempID, realID := range tempIDMap {
 		// Find the task by pending_temp_id
 		task, err := p.contactTaskRepo.GetContactTaskByPendingTempID(ctx, SourceName, tempID)
 		if err != nil {
-			// Not found is expected if this temp_id wasn't from us
+			// Not found is expected if this temp_id wasn't from us.
 			continue
 		}
 
-		// Update with real Todoist task ID
-		_, err = p.contactTaskRepo.UpdateContactTaskExternalID(ctx, task.ID, realID)
-		if err != nil {
-			logger.Warn().
-				Err(err).
+		txErr := func() error {
+			tx, err := p.pool.Begin(ctx)
+			if err != nil {
+				return fmt.Errorf("begin tx: %w", err)
+			}
+			defer func() { _ = tx.Rollback(ctx) }()
+
+			if _, err := p.contactTaskRepo.UpdateContactTaskExternalIDTx(ctx, tx, task.ID, realID); err != nil {
+				return fmt.Errorf("update external_id: %w", err)
+			}
+			metadata := task.Metadata
+			if metadata == nil {
+				metadata = make(map[string]any)
+			}
+			delete(metadata, MetadataKeyPendingTempID)
+			if _, err := p.contactTaskRepo.UpdateContactTaskMetadataTx(ctx, tx, task.ID, metadata); err != nil {
+				return fmt.Errorf("clear pending_temp_id: %w", err)
+			}
+			return tx.Commit(ctx)
+		}()
+		if txErr != nil {
+			logger.Warn().Err(txErr).
 				Str("tempId", tempID).
 				Str("realId", realID).
-				Msg("failed to update external task ID")
+				Str("contactTaskId", task.ID.String()).
+				Msg("temp_id mapping: tx rolled back; deferring reconcile skip-drift this tick")
+			rolledBack = true
 			continue
-		}
-
-		// Clear pending_temp_id from metadata (preserves synced_deadline and other keys)
-		metadata := task.Metadata
-		if metadata == nil {
-			metadata = make(map[string]any)
-		}
-		delete(metadata, MetadataKeyPendingTempID)
-		if _, err := p.contactTaskRepo.UpdateContactTaskMetadata(ctx, task.ID, metadata); err != nil {
-			logger.Warn().Err(err).Msg("failed to clear pending_temp_id from metadata")
 		}
 
 		logger.Debug().
 			Str("tempId", tempID).
 			Str("realId", realID).
 			Str("contactTaskId", task.ID.String()).
-			Msg("updated contact task with real Todoist ID")
+			Msg("updated contact task with real Todoist ID (atomic commit)")
 	}
+	return rolledBack
 }
 
 // handleSyncError classifies and returns appropriate error

--- a/backend/internal/todoist/provider.go
+++ b/backend/internal/todoist/provider.go
@@ -782,20 +782,15 @@ func (p *CadenceSyncProvider) handleSkipTrigger(
 // mutual/inbound interaction.
 //
 // State is persisted BEFORE any ItemClose command is queued. On state-update
-// failure, this handler returns a fatal error via processItemResult.Err; the
-// sync loop (processItems) then decides whether to abort or log-and-continue
-// based on whether any earlier item in the same batch committed non-replay-
-// safe state. If no earlier unsafe commit occurred, the sync aborts without
-// advancing the cursor and the next tick replays the item. If an earlier
-// handleSkipTrigger already advanced contact_by in this batch, the dismissal
-// falls back to log-and-continue (the pre-existing failure mode for that
-// specific mixed-batch scenario).
+// failure, this handler returns a fatal error via processItemResult.Err;
+// processItems aborts the batch, the Sync caller preserves the pre-batch
+// cursor, and the next tick replays.
 //
 // For non-deletion triggers, once the state transition succeeds we queue an
 // ItemClose command so the batched sync path cleans up the orphaned task in
-// Todoist. No retry flag is set — if the batch fails, the local row is still
-// correctly 'dismissed' and subsequent syncs will skip it via the existing
-// state != 'managed' early-return in processItem.
+// Todoist. If the batch fails, the local row is still correctly 'dismissed'
+// and subsequent syncs will skip it via the existing state != 'managed'
+// early-return in processItem.
 func (p *CadenceSyncProvider) handleFollowUpDismissal(
 	ctx context.Context,
 	item SyncItem,

--- a/backend/internal/todoist/provider.go
+++ b/backend/internal/todoist/provider.go
@@ -1389,14 +1389,17 @@ func isPendingTempID(task *repository.ContactTask) bool {
 
 // tryRecoverPendingTempID handles the case where processTempIDMappings failed
 // to update a contact_task's external_task_id from a temp ID to the real Todoist ID.
-// It parses the CRM marker in the item description to find the contact, then checks
-// if there's a managed cadence task with a pending temp ID for that contact.
-// If found, it migrates the external_task_id to the real ID.
+// It parses the CRM marker in the item description to find the contact, then
+// finalizes the mapping atomically inside a pgx.Tx (external_id + metadata clear
+// commit together or roll back together).
 //
-// TODO(#265): this recovery path's internal DB calls currently swallow
-// failures silently. Not on the critical correctness path but deserves audit
-// under the same transactional treatment as handleTaskCompletion and
-// handleSkipTrigger — tracked in the deferred refactor issue.
+// Recovery guard: task.State == managed && pending_temp_id != "". Broadened
+// from the narrow isPendingTempID check (which required pending_temp_id ==
+// ExternalTaskID) so this function also recovers the post-rollback shape
+// where ExternalTaskID still points at the old id and pending_temp_id is
+// the temp of the (already-created remotely) new task. The CRM marker
+// parse above verifies the sync item belongs to the same contact + cadence
+// kind, so advancing ExternalTaskID = item.ID is safe.
 func (p *CadenceSyncProvider) tryRecoverPendingTempID(ctx context.Context, item SyncItem) *repository.ContactTask {
 	// Parse CRM marker from description to get contact ID
 	var marker struct {
@@ -1438,39 +1441,58 @@ func (p *CadenceSyncProvider) tryRecoverPendingTempID(ctx context.Context, item 
 		return nil
 	}
 
-	// Only recover tasks that still have a pending temp ID
-	if task.State != repository.ContactTaskStateManaged || !isPendingTempID(task) {
+	// Broadened guard: any managed task with a non-empty pending_temp_id
+	// is a candidate for finalizing the mapping. See function docstring.
+	pendingTempID, _ := task.Metadata[MetadataKeyPendingTempID].(string)
+	if task.State != repository.ContactTaskStateManaged || pendingTempID == "" {
 		return nil
 	}
 
-	// Migrate external_task_id to the real Todoist ID
 	oldID := task.ExternalTaskID
-	if _, err := p.contactTaskRepo.UpdateContactTaskExternalID(ctx, task.ID, item.ID); err != nil {
+
+	// Atomic: external_id update + metadata clear inside one tx.
+	tx, err := p.pool.Begin(ctx)
+	if err != nil {
+		logger.Warn().Err(err).
+			Str("contactId", marker.ContactID).
+			Msg("tryRecoverPendingTempID: begin tx failed")
+		return task // fallback: process with old ID
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := p.contactTaskRepo.UpdateContactTaskExternalIDTx(ctx, tx, task.ID, item.ID); err != nil {
 		logger.Warn().Err(err).
 			Str("contactId", marker.ContactID).
 			Str("oldExternalId", oldID).
 			Str("newExternalId", item.ID).
-			Msg("failed to recover pending temp ID")
-		return task // still process with old ID
+			Msg("tryRecoverPendingTempID: update external_id failed")
+		return task
 	}
 
-	task.ExternalTaskID = item.ID
-
-	// Clear pending_temp_id from metadata
 	metadata := task.Metadata
 	if metadata == nil {
 		metadata = make(map[string]any)
 	}
 	delete(metadata, MetadataKeyPendingTempID)
-	if _, err := p.contactTaskRepo.UpdateContactTaskMetadata(ctx, task.ID, metadata); err != nil {
-		logger.Warn().Err(err).Msg("failed to clear pending_temp_id after recovery")
+	if _, err := p.contactTaskRepo.UpdateContactTaskMetadataTx(ctx, tx, task.ID, metadata); err != nil {
+		logger.Warn().Err(err).Msg("tryRecoverPendingTempID: clear pending_temp_id failed")
+		return task
 	}
+
+	if err := tx.Commit(ctx); err != nil {
+		logger.Warn().Err(err).Msg("tryRecoverPendingTempID: commit failed")
+		return task
+	}
+
+	// Reflect in the returned task (in-memory).
+	task.ExternalTaskID = item.ID
+	task.Metadata = metadata
 
 	logger.Info().
 		Str("contactId", marker.ContactID).
 		Str("oldTempId", oldID).
 		Str("realId", item.ID).
-		Msg("recovered pending temp ID mapping")
+		Msg("recovered pending temp ID mapping (atomic commit)")
 
 	return task
 }

--- a/backend/internal/todoist/provider.go
+++ b/backend/internal/todoist/provider.go
@@ -597,18 +597,17 @@ func (p *CadenceSyncProvider) handleRecurringDetection(
 
 // handleTaskCompletion handles a completed Todoist task.
 //
-// Failure semantics: this handler intentionally retains log-and-continue on DB
-// failure (returns Err: nil always). The state→interaction ordering comment
-// below documents why a naive fatal-error conversion would break the follow-up
-// cycle; correct fix requires repository-layer transaction threading.
-// TODO(#265): see the deferred refactor tracking issue — this
-// handler is on the list for transactional rewrite.
+// Atomic publish + state advance: opens a pgx.Tx, publishes task.completed
+// via PublishTx, transitions the local row to 'completed' via
+// UpdateContactTaskStateTx, commits. The downstream InteractionRecorder
+// (async via river) consumes the event and writes the interaction row.
 //
-// Returns Unsafe: false because on success the row transitions to 'completed'
-// and replay short-circuits at processItem's state != 'managed' early-return.
-// (On partial failure — state=completed but RecordInteraction failed — the
-// interaction record is lost, but replay is still idempotent because of the
-// early-return, so `Unsafe: false` is defensible.)
+// Direction derivation (spec §3.4.5): action tasks emit direction="mutual"
+// (matching the legacy default), cadence/follow_up emit direction="outbound".
+//
+// SourceID is task.ID.String() (stable internal uuid). Using ExternalTaskID
+// would collide with the temp→real id swap in tryRecoverPendingTempID,
+// bypassing event-layer dedup.
 func (p *CadenceSyncProvider) handleTaskCompletion(
 	ctx context.Context,
 	item SyncItem,
@@ -617,9 +616,7 @@ func (p *CadenceSyncProvider) handleTaskCompletion(
 	settings Settings,
 	accountID string,
 ) processItemResult {
-	var commands []SyncCommand
-
-	// Parse completion timestamp
+	// Parse completion timestamp.
 	completedAt := accelerated.GetCurrentTime()
 	if item.CompletedAt != nil {
 		if parsed, err := time.Parse(time.RFC3339, *item.CompletedAt); err == nil {
@@ -627,55 +624,77 @@ func (p *CadenceSyncProvider) handleTaskCompletion(
 		}
 	}
 
-	// Handle action tasks — mark as completed, record mutual interaction, no new task
+	// Direction: action → mutual; cadence/follow_up → outbound.
+	direction := repository.InteractionDirectionOutbound
 	if task.Kind == TaskKindAction {
-		sourceRef := task.ExternalTaskID
-		_, err := p.interactionRecorder.RecordInteraction(ctx, repository.RecordInteractionRequest{
-			ContactID:  contact.ID,
-			Source:     repository.InteractionSourceTodoist,
-			SourceRef:  &sourceRef,
-			OccurredAt: completedAt,
-		})
-		if err != nil {
-			logger.Warn().Err(err).Msg("failed to record interaction from action task completion")
-		}
-		if _, err := p.contactTaskRepo.UpdateContactTaskState(ctx, task.ID, repository.ContactTaskStateCompleted); err != nil {
-			logger.Warn().Err(err).Msg("failed to update action task state to completed")
-		}
+		direction = repository.InteractionDirectionMutual
+	}
+
+	payload, err := events.Marshal(events.KindTaskCompleted, events.TaskCompletedPayload{
+		Version:     1,
+		ContactID:   contact.ID,
+		TaskID:      task.ExternalTaskID,
+		TaskKind:    task.Kind,
+		CompletedAt: completedAt,
+		Direction:   direction,
+	})
+	if err != nil {
+		return processItemResult{Err: fmt.Errorf("marshal task.completed: %w", err)}
+	}
+	env := &events.Envelope{
+		Source:     SourceName,
+		SourceID:   task.ID.String(),
+		Kind:       events.KindTaskCompleted,
+		Payload:    payload,
+		ObservedAt: completedAt,
+	}
+
+	tx, err := p.pool.Begin(ctx)
+	if err != nil {
+		return processItemResult{Err: fmt.Errorf("begin tx: %w", err)}
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// Publish-before-mutate (core.md gotcha).
+	if err := p.bus.PublishTx(ctx, tx, env); err != nil {
+		return processItemResult{Err: fmt.Errorf("publish task.completed: %w", err)}
+	}
+	if env.ID == uuid.Nil {
+		// Duplicate — prior tick already processed this completion. The
+		// state=completed short-circuit at processItem normally prevents
+		// reaching this handler on replay; this branch defends against
+		// the degenerate case where the state update rolled back on the
+		// earlier tick but the event committed.
+		logger.Debug().
+			Str("contactTaskId", task.ID.String()).
+			Str("externalTaskId", task.ExternalTaskID).
+			Msg("task.completed duplicate; skipping state update")
 		return processItemResult{Processed: true}
 	}
 
-	// For cadence and follow_up tasks: mark completed FIRST, then record outbound interaction.
-	// CRITICAL: Must mark completed before RecordInteraction because RecordInteraction triggers
-	// followUpManager.CreateOrRefreshFollowUp, which looks for existing pending follow-ups.
-	// If this task is still 'managed' when that lookup runs, it refreshes the dying task
-	// instead of creating a successor — collapsing the follow-up cycle.
-	if _, err := p.contactTaskRepo.UpdateContactTaskState(ctx, task.ID, repository.ContactTaskStateCompleted); err != nil {
-		logger.Warn().Err(err).
-			Str("taskKind", task.Kind).
-			Msg("failed to mark task as completed")
+	// Transition local state to 'completed' inside the tx. For cadence /
+	// follow_up tasks, the state advance is the pre-condition for the
+	// downstream FollowUpManager's FindPendingFollowUp gate — once the tx
+	// commits, the async consumer sees state='completed' and creates the
+	// successor follow-up instead of refreshing the dying task.
+	if _, err := p.contactTaskRepo.UpdateContactTaskStateTx(
+		ctx, tx, task.ID, repository.ContactTaskStateCompleted,
+	); err != nil {
+		return processItemResult{Err: fmt.Errorf("update task state: %w", err)}
 	}
 
-	// Record outbound interaction — this triggers follow-up creation via followUpManager
-	sourceRef := task.ExternalTaskID
-	_, err := p.interactionRecorder.RecordInteraction(ctx, repository.RecordInteractionRequest{
-		ContactID:  contact.ID,
-		Source:     repository.InteractionSourceTodoist,
-		SourceRef:  &sourceRef,
-		OccurredAt: completedAt,
-		Direction:  repository.InteractionDirectionOutbound,
-	})
-	if err != nil {
-		logger.Warn().Err(err).Msg("failed to record outbound interaction from Todoist completion")
+	if err := tx.Commit(ctx); err != nil {
+		return processItemResult{Err: fmt.Errorf("commit: %w", err)}
 	}
 
 	logger.Info().
 		Str("contactId", contact.ID.String()).
 		Str("taskKind", task.Kind).
 		Time("completedAt", completedAt).
-		Msg("recorded outbound interaction from Todoist task completion")
+		Str("direction", direction).
+		Msg("published task.completed (atomic commit)")
 
-	return processItemResult{Processed: true, Commands: commands}
+	return processItemResult{Processed: true}
 }
 
 // handleSkipTrigger handles a skip trigger (task deleted, label removed, deadline removed).

--- a/backend/internal/todoist/provider.go
+++ b/backend/internal/todoist/provider.go
@@ -256,7 +256,7 @@ func (p *CadenceSyncProvider) Sync(
 	}
 
 	// Process synced items.
-	processedTasks, commands, _, processErr := p.processItems(ctx, syncResp.Items, settings, accountID)
+	processedTasks, commands, processErr := p.processItems(ctx, syncResp.Items, settings, accountID)
 	result.ItemsProcessed = processedTasks
 
 	// Execute any accumulated commands BEFORE checking processErr. If
@@ -337,112 +337,50 @@ func (p *CadenceSyncProvider) ValidateCredentials(ctx context.Context, accountID
 	return nil
 }
 
-// processItemResult is the structured return from processItem and its handlers.
+// processItemResult is the structured return from processItem and its
+// handlers.
 //
 // Fields:
 //   - Processed: true if the item was owned by CRM and handled (not skipped).
 //   - Commands:  Todoist commands to enqueue in the batch.
-//   - Unsafe:    true if a non-replay-safe side effect was committed. Today, only
-//     handleSkipTrigger's success path sets this — it advances contact_by and
-//     appends a replacement item_add while leaving the row state='managed',
-//     which is non-idempotent on replay. When the sync loop sees this flag, any
-//     subsequent fatal error in the same batch falls back to log-and-continue
-//     instead of aborting (which would cause double-advancement on replay).
-//   - Err:       non-nil for fatal errors. Callers inspect Unsafe to decide
-//     whether to abort the sync or log-and-continue.
+//   - Err:       non-nil for fatal errors; processItems aborts the batch
+//     without advancing the cursor.
 type processItemResult struct {
 	Processed bool
 	Commands  []SyncCommand
-	Unsafe    bool
 	Err       error
 }
 
-// processItems iterates over the items returned by a Todoist sync, dispatching
-// each through processItem. It is the single point at which fatal-error
-// propagation and replay-safe abort are enforced.
-//
-// Abort semantics: on a fatal processItem error (r.Err != nil), processItems
-// aborts only if no earlier item in this batch committed non-replay-safe
-// state. The replayCommittedUnsafe flag is set by any successful
-// handleSkipTrigger (see its docstring). Aborting after an unsafe commit
-// would cause the next sync to replay the skip trigger, double-advancing the
-// cadence clock — so when the flag is set, we fall back to log-and-continue.
-//
-// The returned replayCommittedUnsafe is discarded by the Sync call site but
-// returned so tests can observe the flag directly.
+// processItems iterates over the items returned by a Todoist sync,
+// dispatching each through processItem. On a fatal processItem error
+// (r.Err != nil) the batch aborts and the Sync caller preserves the
+// pre-batch cursor so the next tick replays. Each successful item commits
+// atomically via its own tx, so replays short-circuit at the state !=
+// 'managed' early-return in processItem and never double-advance.
 func (p *CadenceSyncProvider) processItems(
 	ctx context.Context,
 	items []SyncItem,
 	settings Settings,
 	accountID string,
-) (processed int, commands []SyncCommand, replayCommittedUnsafe bool, err error) {
+) (processed int, commands []SyncCommand, err error) {
 	for _, item := range items {
 		r := p.processItem(ctx, item, settings, accountID)
 		if r.Err != nil {
-			shouldContinue, wrappedErr := p.decideFatalErrorPolicy(r, item, processed, replayCommittedUnsafe)
-			if shouldContinue {
-				continue
-			}
-			// On abort, return the commands accumulated from earlier items
-			// (not nil). These are all cleanup commands — ItemClose from
-			// successful handleFollowUpDismissal and ItemDelete from the
-			// contact-not-found branch in processItem — for local state
-			// transitions that have already been persisted. The caller
-			// (Sync) executes them before returning the error so we don't
-			// orphan Todoist tasks whose local rows are already in terminal
-			// states. Replay is still safe: on the next sync, the replayed
-			// items short-circuit at processItem's state != managed early-
-			// return and do not re-emit their commands.
-			//
-			// replayCommittedUnsafe is always false on this branch (by
-			// construction — we only reach this return when
-			// replayCommittedUnsafe==false) but we return the variable for
-			// clarity rather than a literal.
-			return processed, commands, replayCommittedUnsafe, wrappedErr
+			logger.Error().Err(r.Err).
+				Str("itemId", item.ID).
+				Int("processedBeforeAbort", processed).
+				Msg("processItem fatal error — aborting sync without advancing cursor")
+			// Return accumulated commands so Sync can execute any
+			// ItemClose/ItemDelete commands queued by already-committed
+			// handlers before returning the error.
+			return processed, commands, fmt.Errorf("process item %s: %w", item.ID, r.Err)
 		}
 		if r.Processed {
 			processed++
 		}
-		if r.Unsafe {
-			replayCommittedUnsafe = true
-		}
 		commands = append(commands, r.Commands...)
 	}
-	return processed, commands, replayCommittedUnsafe, nil
-}
-
-// decideFatalErrorPolicy implements the conditional-abort semantics for
-// processItems. Extracted from the loop so tests can verify both branches
-// (abort vs log-and-continue) without needing to simulate a mid-batch DB
-// failure under a shared connection.
-//
-// Returns shouldContinue=true when replayCommittedUnsafe is true: the sync
-// loop must not abort because an earlier unsafe handler (handleSkipTrigger)
-// already committed side effects that cannot be safely replayed. In that
-// case, the error is logged but the cursor will advance past this batch —
-// matching the pre-existing log-and-continue failure mode for the mixed-
-// batch scenario.
-//
-// Returns shouldContinue=false and a wrapped error when no unsafe commit has
-// occurred yet in the batch. The sync loop should return the wrapped error
-// without advancing the cursor, so the next tick replays the batch.
-func (p *CadenceSyncProvider) decideFatalErrorPolicy(
-	r processItemResult,
-	item SyncItem,
-	processedBeforeAbort int,
-	replayCommittedUnsafe bool,
-) (shouldContinue bool, wrappedErr error) {
-	if replayCommittedUnsafe {
-		logger.Error().Err(r.Err).
-			Str("itemId", item.ID).
-			Msg("processItem fatal error after non-replay-safe commit — forced to log-and-continue; cursor will advance and event is dropped")
-		return true, nil
-	}
-	logger.Error().Err(r.Err).
-		Str("itemId", item.ID).
-		Int("processedBeforeAbort", processedBeforeAbort).
-		Msg("processItem fatal error — aborting sync without advancing cursor")
-	return false, fmt.Errorf("process item %s: %w", item.ID, r.Err)
+	return processed, commands, nil
 }
 
 // processItem processes a single Todoist item from sync
@@ -832,7 +770,7 @@ func (p *CadenceSyncProvider) handleSkipTrigger(
 
 	// Return replacement item_add only after commit — the HTTP batch fires
 	// outside the tx in Sync's post-loop block (core.md gotcha).
-	return processItemResult{Processed: true, Commands: []SyncCommand{replacementCmd}, Unsafe: true}
+	return processItemResult{Processed: true, Commands: []SyncCommand{replacementCmd}}
 }
 
 // handleFollowUpDismissal handles a follow-up task being dismissed via Todoist.

--- a/backend/internal/todoist/provider.go
+++ b/backend/internal/todoist/provider.go
@@ -75,6 +75,14 @@ type eventPublisher interface {
 	PublishTx(ctx context.Context, tx pgx.Tx, env *events.Envelope) error
 }
 
+// oauthTokenProvider is the subset of *OAuthService the provider uses at
+// runtime. Defined as an interface so tests can stub access-token lookup
+// without constructing a real OAuth account.
+type oauthTokenProvider interface {
+	GetAccessToken(ctx context.Context, accountID string) (string, error)
+	HasAnyAccount(ctx context.Context) bool
+}
+
 // contactTaskWriter is the subset of *repository.ContactTaskRepository the
 // provider uses. Narrow interface so integration tests can wrap the real
 // repo with faulty-method injection.
@@ -107,7 +115,7 @@ type contactWriter interface {
 
 // CadenceSyncProvider implements SyncProvider for Todoist cadence tasks
 type CadenceSyncProvider struct {
-	oauthService    *OAuthService
+	oauthService    oauthTokenProvider
 	contactTaskRepo contactTaskWriter
 	contactRepo     contactWriter
 	syncRepo        *repository.SyncRepository
@@ -123,7 +131,7 @@ type CadenceSyncProvider struct {
 
 // NewCadenceSyncProvider creates a new Todoist cadence sync provider
 func NewCadenceSyncProvider(
-	oauthService *OAuthService,
+	oauthService oauthTokenProvider,
 	contactTaskRepo contactTaskWriter,
 	contactRepo contactWriter,
 	syncRepo *repository.SyncRepository,
@@ -1479,7 +1487,20 @@ func (p *CadenceSyncProvider) tryRecoverPendingTempID(ctx context.Context, item 
 
 	task, err := p.contactTaskRepo.GetContactTaskByContact(ctx, contactID, SourceName, kind)
 	if err != nil {
-		return nil, false
+		if errors.Is(err, db.ErrNotFound) {
+			// No local row for this contact/kind — nothing to recover.
+			return nil, false
+		}
+		// Any non-ErrNotFound failure (DB timeout, connection error) means
+		// we can't tell whether a recoverable row exists. A stale local
+		// row may match the skip-drift predicate against a real remote
+		// item that was just delivered; surface recoveryFailed so Sync
+		// forces deferSkipDrift=true and avoids emitting a duplicate
+		// item_add this tick.
+		logger.Warn().Err(err).
+			Str("contactId", marker.ContactID).
+			Msg("tryRecoverPendingTempID: lookup by contact failed")
+		return nil, true
 	}
 
 	// Broadened guard: any managed task with a non-empty pending_temp_id

--- a/backend/internal/todoist/provider_atomic_tx_integration_test.go
+++ b/backend/internal/todoist/provider_atomic_tx_integration_test.go
@@ -806,24 +806,23 @@ func TestTodoist_SkipDrift_ReconcileRecovery(t *testing.T) {
 
 // TestTodoist_Sync_ReconcileDefersSkipDriftAfterMappingRollback drives the
 // full provider.Sync(...) method end-to-end. Flow:
-//  1. Sync pulls items — returns a single SyncItem that is a skip trigger
+//   - Sync pulls items — returns a single SyncItem that is a skip trigger
 //     (label removed on a managed cadence task).
-//  2. processItems dispatches to handleSkipTrigger, which commits state +
+//   - processItems dispatches to handleSkipTrigger, which commits state +
 //     advances contact_by + emits an item_add command.
-//  3. Sync's post-items batch sends item_add to the mock; response
+//   - Sync's post-items batch sends item_add to the mock; response
 //     returns a temp_id_mapping for that task.
-//  4. processTempIDMappings runs — faulty metadata-clear rolls the tx
+//   - processTempIDMappings runs — faulty metadata-clear rolls the tx
 //     back; rolledBack=true.
-//  5. reconcileContactTasks is called with deferSkipDrift=true. Skip-drift
+//   - reconcileContactTasks is called with deferSkipDrift=true. Skip-drift
 //     branch must NOT emit a duplicate item_add against the already-
 //     created remote task.
 //
-// Assertion: across ALL calls to mock.Sync, the count of item_add
-// commands for this contact must be exactly 1 (the one from
-// handleSkipTrigger in step 2). Without the mappingRolledBack flag
-// threading through to deferSkipDrift, reconcileExistingTask's skip-drift
-// branch would fire in step 5 and emit a second item_add, failing this
-// assertion.
+// Assertion: across all mock.Sync calls, exactly ONE item_add for this
+// contact is emitted (from handleSkipTrigger). Without the
+// mappingRolledBack → deferSkipDrift wiring, reconcileExistingTask's
+// skip-drift branch would fire during reconcile and emit a second
+// item_add, failing this assertion.
 func TestTodoist_Sync_ReconcileDefersSkipDriftAfterMappingRollback(t *testing.T) {
 	env, cleanup := setupAtomicTxTestEnv(t)
 	defer cleanup()

--- a/backend/internal/todoist/provider_atomic_tx_integration_test.go
+++ b/backend/internal/todoist/provider_atomic_tx_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -31,20 +32,29 @@ import (
 // ============================================================================
 
 // faultyContactTaskWriter wraps a real contactTaskWriter and returns an
-// injected error from a named method on its first call, delegating on
-// subsequent calls. Safe for concurrent use.
+// injected error from a named method. The fault fires on the
+// fireOnInvocation-th matching call (1-indexed). Once fired, subsequent
+// calls delegate normally unless faultyMethod is reset. fireLimit extends
+// this so N sequential firings trigger; default 1. Safe for concurrent use.
 type faultyContactTaskWriter struct {
 	contactTaskWriter
-	mu           sync.Mutex
-	faultyMethod string
-	fireLimit    int // 0 = fire once; N = fire up to N times
-	fired        int
+	mu               sync.Mutex
+	faultyMethod     string
+	fireOnInvocation int // 0 = first matching call; N = Nth matching call (0-indexed skip count)
+	fireLimit        int // 0 = fire once; N = fire up to N times
+	invocations      int
+	fired            int
 }
 
 func (f *faultyContactTaskWriter) shouldFire(method string) bool {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.faultyMethod != method {
+		return false
+	}
+	invIdx := f.invocations
+	f.invocations++
+	if invIdx < f.fireOnInvocation {
 		return false
 	}
 	limit := f.fireLimit
@@ -187,7 +197,7 @@ func setupAtomicTxTestEnv(t *testing.T) (*atomicTxTestEnv, func()) {
 	faultyTaskWriter := &faultyContactTaskWriter{contactTaskWriter: contactTaskRepo}
 	faultyCW := &faultyContactWriter{contactWriter: contactRepo}
 	provider := NewCadenceSyncProvider(
-		nil,
+		stubOAuthProvider{},
 		faultyTaskWriter,
 		faultyCW,
 		nil,
@@ -225,6 +235,63 @@ func setupAtomicTxTestEnv(t *testing.T) (*atomicTxTestEnv, func()) {
 		accountID:   "test-account",
 		riverClient: riverClient,
 	}, cleanup
+}
+
+// ============================================================================
+// Stub OAuth provider + scripted mock Client for end-to-end Sync tests.
+// ============================================================================
+
+// stubOAuthProvider returns a fixed access token and claims an account
+// exists. Used so tests can drive the real Sync method without OAuth
+// fixtures.
+type stubOAuthProvider struct{}
+
+func (stubOAuthProvider) GetAccessToken(_ context.Context, _ string) (string, error) {
+	return "stub-token", nil
+}
+
+func (stubOAuthProvider) HasAnyAccount(_ context.Context) bool { return true }
+
+// scriptedClient is a Client implementation that replays a queue of
+// pre-canned sync responses and records all outbound command batches.
+// Matches the Client interface in sync.go. Safe for single-threaded use.
+type scriptedClient struct {
+	responses []*SyncResponse
+	errors    []error
+	callIdx   int
+	// batches captures the commands passed to each client.Sync call (one
+	// entry per call). Tests assert over this to verify the skip-drift
+	// branch did not emit a duplicate item_add.
+	batches [][]SyncCommand
+	// onCall is invoked after computing the response for call callIdx
+	// with the outbound commands and the (mutable) response pointer, so
+	// tests can patch the response based on what the batch contains
+	// (e.g., fill in temp_id_mapping from a temp_id the handler just
+	// generated).
+	onCall func(callIdx int, commands []SyncCommand, resp *SyncResponse)
+}
+
+func (c *scriptedClient) QuickAdd(_ context.Context, _ string, _ string) (*QuickAddTask, error) {
+	return &QuickAddTask{ID: "stub-quick-add"}, nil
+}
+
+func (c *scriptedClient) Sync(_ context.Context, _ string, _ []string, commands []SyncCommand) (*SyncResponse, error) {
+	c.batches = append(c.batches, append([]SyncCommand{}, commands...))
+	idx := c.callIdx
+	c.callIdx++
+	if idx < len(c.errors) && c.errors[idx] != nil {
+		return nil, c.errors[idx]
+	}
+	var resp *SyncResponse
+	if idx < len(c.responses) {
+		resp = c.responses[idx]
+	} else {
+		resp = &SyncResponse{SyncToken: "stub-token"}
+	}
+	if c.onCall != nil {
+		c.onCall(idx, commands, resp)
+	}
+	return resp, nil
 }
 
 // ============================================================================
@@ -637,24 +704,24 @@ func TestTodoist_ProcessItems_PropagatesRecoveryFailed(t *testing.T) {
 
 // TestTodoist_ProcessTempIDMappings_RollbackDefersSkipDriftOneTick simulates
 // the round-trip where:
-//  1. handleSkipTrigger commits (state advance + pending_temp_id set).
-//  2. Todoist HTTP batch succeeds remotely (simulated by calling
+//   - handleSkipTrigger commits (state advance + pending_temp_id set).
+//   - Todoist HTTP batch succeeds remotely (simulated by calling
 //     processTempIDMappings with a temp_id_mapping).
-//  3. The mapping tx rolls back (faulty metadata-clear).
-//  4. processTempIDMappings returns rolledBack=true.
-//  5. Same-tick reconcileContactTasks invoked with deferSkipDrift=true
+//   - The mapping tx rolls back (faulty metadata-clear).
+//   - processTempIDMappings returns rolledBack=true.
+//   - Same-tick reconcileContactTasks invoked with deferSkipDrift=true
 //     must NOT emit a duplicate item_add, even though the stale local row
 //     matches the skip-drift detection predicate.
 //
-// This is the key correctness test for the rollback-deferral fix.
+// This is the key correctness test for the rollback-deferral behavior.
 func TestTodoist_ProcessTempIDMappings_RollbackDefersSkipDriftOneTick(t *testing.T) {
 	env, cleanup := setupAtomicTxTestEnv(t)
 	defer cleanup()
 
 	contact, task := createManagedCadenceTask(t, env, "DeferOneTick")
 
-	// Step 1: simulate handleSkipTrigger's committed state — pending_temp_id
-	// set with a new temp id that differs from ExternalTaskID.
+	// Simulate handleSkipTrigger's committed state — pending_temp_id set
+	// with a new temp id that differs from ExternalTaskID.
 	oldExtID := task.ExternalTaskID
 	newTempID := "temp-new-" + uuid.New().String()[:8]
 	_, err := env.contactTaskRepo.UpdateContactTaskMetadata(env.ctx, task.ID, map[string]any{
@@ -663,7 +730,7 @@ func TestTodoist_ProcessTempIDMappings_RollbackDefersSkipDriftOneTick(t *testing
 	})
 	require.NoError(t, err)
 
-	// Step 2 + 3: mapping tx rolls back on metadata clear.
+	// Mapping tx rolls back on metadata clear.
 	env.faultyTaskWriter.mu.Lock()
 	env.faultyTaskWriter.faultyMethod = "UpdateContactTaskMetadataTx"
 	env.faultyTaskWriter.mu.Unlock()
@@ -681,8 +748,8 @@ func TestTodoist_ProcessTempIDMappings_RollbackDefersSkipDriftOneTick(t *testing
 	pending, _ := afterMapping.Metadata[MetadataKeyPendingTempID].(string)
 	assert.Equal(t, newTempID, pending)
 
-	// Step 5: same-tick reconcile with deferSkipDrift=true. Skip-drift
-	// branch must NOT fire — no item_close + item_add emitted from it.
+	// Same-tick reconcile with deferSkipDrift=true — skip-drift branch
+	// must NOT fire (no item_close + item_add emitted from it).
 	syncedDeadline, _ := afterMapping.Metadata[MetadataKeySyncedDeadline].(string)
 	cmds := env.provider.reconcileExistingTask(env.ctx, afterMapping, contact, env.settings, syncedDeadline, true /* deferSkipDrift */)
 
@@ -735,6 +802,173 @@ func TestTodoist_SkipDrift_ReconcileRecovery(t *testing.T) {
 	newPending, _ := afterRecovery.Metadata[MetadataKeyPendingTempID].(string)
 	assert.Equal(t, cmds[1].TempID, newPending)
 	assert.NotEqual(t, staleTempID, newPending)
+}
+
+// TestTodoist_Sync_ReconcileDefersSkipDriftAfterMappingRollback drives the
+// full provider.Sync(...) method end-to-end. Flow:
+//  1. Sync pulls items — returns a single SyncItem that is a skip trigger
+//     (label removed on a managed cadence task).
+//  2. processItems dispatches to handleSkipTrigger, which commits state +
+//     advances contact_by + emits an item_add command.
+//  3. Sync's post-items batch sends item_add to the mock; response
+//     returns a temp_id_mapping for that task.
+//  4. processTempIDMappings runs — faulty metadata-clear rolls the tx
+//     back; rolledBack=true.
+//  5. reconcileContactTasks is called with deferSkipDrift=true. Skip-drift
+//     branch must NOT emit a duplicate item_add against the already-
+//     created remote task.
+//
+// Assertion: across ALL calls to mock.Sync, the count of item_add
+// commands for this contact must be exactly 1 (the one from
+// handleSkipTrigger in step 2). Without the mappingRolledBack flag
+// threading through to deferSkipDrift, reconcileExistingTask's skip-drift
+// branch would fire in step 5 and emit a second item_add, failing this
+// assertion.
+func TestTodoist_Sync_ReconcileDefersSkipDriftAfterMappingRollback(t *testing.T) {
+	env, cleanup := setupAtomicTxTestEnv(t)
+	defer cleanup()
+
+	contact, task := createManagedCadenceTask(t, env, "SyncE2E")
+	// Seed synced_deadline so reconcileExistingTask has a stable baseline.
+	syncedDeadline := contact.ContactBy.Format(DateFormat)
+	_, err := env.contactTaskRepo.UpdateContactTaskMetadata(env.ctx, task.ID, map[string]any{
+		MetadataKeySyncedDeadline: syncedDeadline,
+	})
+	require.NoError(t, err)
+
+	// The single sync item is the task with its CRM label removed — a
+	// skip trigger. handleSkipTrigger will commit + return an item_add.
+	syncItem := SyncItem{
+		ID:        task.ExternalTaskID,
+		ProjectID: env.settings.ProjectID,
+		Labels:    []string{}, // CRM label removed
+		Deadline:  &SyncDate{Date: syncedDeadline},
+		UpdatedAt: "2026-04-09T10:00:00Z",
+	}
+
+	// The scripted client must accept at least 3 Sync calls:
+	//   call 0: items pull → returns our skip-trigger item.
+	//   call 1: post-items batch → item_add executed remotely, returns
+	//           temp_id_mapping for the new task.
+	//   call 2: reconcile batch (if any). Set empty response.
+	// Responses are replayed in order by scriptedClient.Sync.
+	mock := &scriptedClient{}
+	mock.responses = []*SyncResponse{
+		// 0: items pull.
+		{SyncToken: "tok1", Items: []SyncItem{syncItem}},
+		// 1: post-items batch. TempIDMap maps the item_add's temp_id to
+		// a real id. The mock fills this in based on what the batch
+		// contains (see below — we pre-seed with a placeholder that the
+		// test overrides after building the batch).
+		{SyncToken: "tok2", TempIDMap: map[string]string{}},
+		// 2: reconcile batch — must return empty command set.
+		{SyncToken: "tok3"},
+	}
+
+	// Fault the SECOND UpdateContactTaskMetadataTx call. Call sequence:
+	//   1. handleSkipTrigger writes pending_temp_id=<new>.
+	//   2. processTempIDMappings clears pending_temp_id — this is the
+	//      one we want to fail.
+	env.faultyTaskWriter.mu.Lock()
+	env.faultyTaskWriter.faultyMethod = "UpdateContactTaskMetadataTx"
+	env.faultyTaskWriter.fireOnInvocation = 1 // skip first call
+	env.faultyTaskWriter.mu.Unlock()
+
+	// Wire a fresh provider that uses our scripted mock via the factory
+	// AND uses the env's faulty writers.
+	provider := NewCadenceSyncProvider(
+		stubOAuthProvider{},
+		env.faultyTaskWriter,
+		env.faultyContactWriterW,
+		nil,
+		config.TestConfig(),
+		env.bus,
+		env.pool,
+		func(_ string) Client { return mock },
+	)
+
+	// Prime the post-items TempIDMap by pre-registering the temp_id.
+	// handleSkipTrigger generates its own uuid for the replacement
+	// item_add's TempID, so we can't know it upfront. Use a proxy:
+	// after the first call, the scripted mock's batches[0] is empty
+	// (items pull), batches[1] contains the item_add whose TempID we
+	// copy into the second response's TempIDMap. But we can't mutate
+	// responses mid-Sync. Workaround: on the second Sync call the mock
+	// reads the current batch, and we override the response's TempIDMap
+	// to include the actual temp id from the batch.
+
+	// Use a scripted-with-callback: we replace responses[1] with a value
+	// computed from batches[1] on the fly. Easiest: wrap Sync to observe
+	// batch 1 and patch the response.
+	mock.onCall = func(callIdx int, commands []SyncCommand, resp *SyncResponse) {
+		if callIdx == 1 {
+			for _, c := range commands {
+				if c.Type == "item_add" && c.TempID != "" {
+					resp.TempIDMap = map[string]string{
+						c.TempID: "real-" + uuid.New().String()[:8],
+					}
+				}
+			}
+		}
+	}
+
+	accountID := env.accountID
+	syncCursor := "*"
+	state := &repository.SyncState{
+		ID:         uuid.New(),
+		Source:     SourceName,
+		AccountID:  &accountID,
+		SyncCursor: &syncCursor,
+		Metadata: map[string]any{
+			MetadataKeyProjectID: env.settings.ProjectID,
+			MetadataKeyLabelID:   env.settings.LabelID,
+			MetadataKeyLabelName: env.settings.LabelName,
+		},
+	}
+
+	result, err := provider.Sync(env.ctx, state, []repository.Contact{*contact})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.ItemsProcessed, "handleSkipTrigger should have processed the one skip item")
+
+	// Assert: across all Sync-call batches, exactly ONE item_add was
+	// emitted for THIS contact's cadence task. Without the mappingRolledBack
+	// → deferSkipDrift wiring, reconcile would emit a second item_add
+	// (item_close(old) + item_add(temp-newer)) for the same row.
+	//
+	// The test DB is shared — other contacts with cadence (from previous
+	// tests or the test suite's own fixtures) may also emit item_adds
+	// during reconcileContactTasks. Scope the count to our contact by
+	// matching the CRM marker's contact_id in the description.
+	contactMarker := contact.ID.String()
+	itemAddsForContact := 0
+	for _, batch := range mock.batches {
+		for _, c := range batch {
+			if c.Type != "item_add" {
+				continue
+			}
+			desc, _ := c.Args["description"].(string)
+			if strings.Contains(desc, contactMarker) {
+				itemAddsForContact++
+			}
+		}
+	}
+	assert.Equal(t, 1, itemAddsForContact,
+		"only handleSkipTrigger's item_add should emit for this contact; skip-drift must be deferred")
+
+	// Also assert: no item_close for this task's old external id was
+	// emitted (reconcile's skip-drift branch would emit that alongside
+	// item_add).
+	itemCloseForTask := 0
+	for _, batch := range mock.batches {
+		for _, c := range batch {
+			if c.Type == "item_close" {
+				if id, _ := c.Args["id"].(string); id == task.ExternalTaskID {
+					itemCloseForTask++
+				}
+			}
+		}
+	}
+	assert.Equal(t, 0, itemCloseForTask, "deferral must suppress skip-drift item_close for this task")
 }
 
 // TestReconcileExistingTask_SkipDriftRecovery_MetadataWriteFailure verifies

--- a/backend/internal/todoist/provider_atomic_tx_integration_test.go
+++ b/backend/internal/todoist/provider_atomic_tx_integration_test.go
@@ -1,0 +1,625 @@
+package todoist
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/consumer/consumerjobs"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ============================================================================
+// Integration-test harness (same-package so tests can call unexported
+// handler functions like handleTaskCompletion / handleSkipTrigger /
+// tryRecoverPendingTempID / reconcileExistingTask).
+// ============================================================================
+
+// faultyContactTaskWriter wraps a real contactTaskWriter and returns an
+// injected error from a named method on its first call, delegating on
+// subsequent calls. Safe for concurrent use.
+type faultyContactTaskWriter struct {
+	contactTaskWriter
+	mu           sync.Mutex
+	faultyMethod string
+	fireLimit    int // 0 = fire once; N = fire up to N times
+	fired        int
+}
+
+func (f *faultyContactTaskWriter) shouldFire(method string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.faultyMethod != method {
+		return false
+	}
+	limit := f.fireLimit
+	if limit == 0 {
+		limit = 1
+	}
+	if f.fired >= limit {
+		return false
+	}
+	f.fired++
+	return true
+}
+
+func (f *faultyContactTaskWriter) UpdateContactTaskStateTx(ctx context.Context, tx pgx.Tx, id uuid.UUID, state repository.ContactTaskState) (*repository.ContactTask, error) {
+	if f.shouldFire("UpdateContactTaskStateTx") {
+		return nil, context.Canceled
+	}
+	return f.contactTaskWriter.UpdateContactTaskStateTx(ctx, tx, id, state)
+}
+
+func (f *faultyContactTaskWriter) UpdateContactTaskMetadataTx(ctx context.Context, tx pgx.Tx, id uuid.UUID, metadata map[string]any) (*repository.ContactTask, error) {
+	if f.shouldFire("UpdateContactTaskMetadataTx") {
+		return nil, context.Canceled
+	}
+	return f.contactTaskWriter.UpdateContactTaskMetadataTx(ctx, tx, id, metadata)
+}
+
+func (f *faultyContactTaskWriter) UpdateContactTaskExternalIDTx(ctx context.Context, tx pgx.Tx, id uuid.UUID, externalID string) (*repository.ContactTask, error) {
+	if f.shouldFire("UpdateContactTaskExternalIDTx") {
+		return nil, context.Canceled
+	}
+	return f.contactTaskWriter.UpdateContactTaskExternalIDTx(ctx, tx, id, externalID)
+}
+
+func (f *faultyContactTaskWriter) UpdateContactTaskMetadata(ctx context.Context, id uuid.UUID, metadata map[string]any) (*repository.ContactTask, error) {
+	if f.shouldFire("UpdateContactTaskMetadata") {
+		return nil, context.Canceled
+	}
+	return f.contactTaskWriter.UpdateContactTaskMetadata(ctx, id, metadata)
+}
+
+// faultyContactWriter wraps a real contactWriter and injects errors on
+// UpdateContactByTx.
+type faultyContactWriter struct {
+	contactWriter
+	mu           sync.Mutex
+	faultyMethod string
+	fired        int
+}
+
+func (f *faultyContactWriter) shouldFire(method string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.faultyMethod != method {
+		return false
+	}
+	if f.fired >= 1 {
+		return false
+	}
+	f.fired++
+	return true
+}
+
+func (f *faultyContactWriter) UpdateContactByTx(ctx context.Context, tx pgx.Tx, id uuid.UUID, contactBy time.Time) error {
+	if f.shouldFire("UpdateContactByTx") {
+		return context.Canceled
+	}
+	return f.contactWriter.UpdateContactByTx(ctx, tx, id, contactBy)
+}
+
+// atomicTxTestEnv bundles the live bus + faulty writers + pool so tests
+// can construct a provider with the exact fault-injection behavior they
+// need.
+type atomicTxTestEnv struct {
+	ctx                  context.Context
+	database             *db.Database
+	pool                 *pgxpool.Pool
+	bus                  *events.Bus
+	eventRepo            *repository.EventRepository
+	contactRepo          *repository.ContactRepository
+	contactTaskRepo      *repository.ContactTaskRepository
+	faultyTaskWriter     *faultyContactTaskWriter
+	faultyContactWriterW *faultyContactWriter
+	provider             *CadenceSyncProvider
+	settings             Settings
+	accountID            string
+	riverClient          *river.Client[pgx.Tx]
+}
+
+// setupAtomicTxTestEnv wires a real DB + real events.Bus (with a TestOnly
+// river client + noop workers for all published kinds) + faulty-wrapper
+// repositories around a fresh CadenceSyncProvider.
+func setupAtomicTxTestEnv(t *testing.T) (*atomicTxTestEnv, func()) {
+	t.Helper()
+
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	ctx := context.Background()
+	require.NoError(t, db.RunMigrations(ctx, databaseURL, migrationsPathForTest()))
+
+	database, err := db.NewDatabase(ctx, config.DatabaseConfig{
+		URL:               databaseURL,
+		MaxConns:          config.DefaultDBMaxConns,
+		MinConns:          config.DefaultDBMinConns,
+		MaxConnIdleTime:   config.DefaultDBMaxConnIdleTime,
+		MaxConnLifetime:   config.DefaultDBMaxConnLifetime,
+		HealthCheckPeriod: config.DefaultDBHealthCheckPeriod,
+	})
+	require.NoError(t, err)
+
+	contactRepo := repository.NewContactRepository(database.Queries)
+	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
+	eventRepo := repository.NewEventRepository(database.Queries)
+
+	// Build a TestOnly river client with noop workers for every kind the
+	// Todoist provider might publish so enqueued jobs drain without side
+	// effects. The bus's PublishTx still writes the event row + inserts
+	// the river job atomically — exactly what these tests verify.
+	workers := river.NewWorkers()
+	river.AddWorker(workers, &noopInteractionRecorderWorker{})
+	river.AddWorker(workers, &noopCadenceUpdaterWorker{})
+	river.AddWorker(workers, &noopFollowUpManagerWorker{})
+	river.AddWorker(workers, &noopRematchDispatcherWorker{})
+
+	riverClient, err := river.NewClient(riverpgxv5.New(database.Pool), &river.Config{
+		Queues: map[string]river.QueueConfig{
+			river.QueueDefault: {MaxWorkers: 4},
+		},
+		Workers:  workers,
+		TestOnly: true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, riverClient.Start(ctx))
+
+	bus := events.NewBus(database.Pool, riverClient, eventRepo)
+
+	faultyTaskWriter := &faultyContactTaskWriter{contactTaskWriter: contactTaskRepo}
+	faultyCW := &faultyContactWriter{contactWriter: contactRepo}
+	provider := NewCadenceSyncProvider(
+		nil,
+		faultyTaskWriter,
+		faultyCW,
+		nil,
+		config.TestConfig(),
+		bus,
+		database.Pool,
+		DefaultClientFactory,
+	)
+
+	cleanup := func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer stopCancel()
+		_ = riverClient.Stop(stopCtx)
+		database.Close()
+	}
+
+	return &atomicTxTestEnv{
+		ctx:                  ctx,
+		database:             database,
+		pool:                 database.Pool,
+		bus:                  bus,
+		eventRepo:            eventRepo,
+		contactRepo:          contactRepo,
+		contactTaskRepo:      contactTaskRepo,
+		faultyTaskWriter:     faultyTaskWriter,
+		faultyContactWriterW: faultyCW,
+		provider:             provider,
+		settings: Settings{
+			ProjectID:             "test-project",
+			ProjectName:           "CRM",
+			LabelID:               "test-label-id",
+			LabelName:             "crm",
+			IntegrationInstanceID: "test-instance",
+		},
+		accountID:   "test-account",
+		riverClient: riverClient,
+	}, cleanup
+}
+
+// ============================================================================
+// Noop river workers — drain jobs without side effects. The event bus
+// atomicity contract is about PublishTx's write-and-enqueue pair; what the
+// consumer does with the enqueued job is out of scope for these tests.
+// ============================================================================
+
+type noopInteractionRecorderWorker struct {
+	river.WorkerDefaults[consumerjobs.InteractionRecorderJobArgs]
+}
+
+func (*noopInteractionRecorderWorker) Work(_ context.Context, _ *river.Job[consumerjobs.InteractionRecorderJobArgs]) error {
+	return nil
+}
+
+type noopCadenceUpdaterWorker struct {
+	river.WorkerDefaults[consumerjobs.CadenceUpdaterJobArgs]
+}
+
+func (*noopCadenceUpdaterWorker) Work(_ context.Context, _ *river.Job[consumerjobs.CadenceUpdaterJobArgs]) error {
+	return nil
+}
+
+type noopFollowUpManagerWorker struct {
+	river.WorkerDefaults[consumerjobs.FollowUpManagerJobArgs]
+}
+
+func (*noopFollowUpManagerWorker) Work(_ context.Context, _ *river.Job[consumerjobs.FollowUpManagerJobArgs]) error {
+	return nil
+}
+
+type noopRematchDispatcherWorker struct {
+	river.WorkerDefaults[consumerjobs.RematchDispatcherJobArgs]
+}
+
+func (*noopRematchDispatcherWorker) Work(_ context.Context, _ *river.Job[consumerjobs.RematchDispatcherJobArgs]) error {
+	return nil
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+func createManagedCadenceTask(t *testing.T, env *atomicTxTestEnv, namePrefix string) (*repository.Contact, *repository.ContactTask) {
+	t.Helper()
+
+	cadenceStr := "monthly"
+	contact, err := env.contactRepo.CreateContact(env.ctx, repository.CreateContactRequest{
+		FullName: namePrefix + " " + uuid.New().String()[:8],
+		Cadence:  &cadenceStr,
+	})
+	require.NoError(t, err)
+
+	// Seed contact_by so skip handler can advance it.
+	contactBy := accelerated.GetCurrentTime().UTC().Truncate(24*time.Hour).AddDate(0, 0, 7)
+	require.NoError(t, env.contactRepo.UpdateContactBy(env.ctx, contact.ID, contactBy))
+	reloaded, err := env.contactRepo.GetContact(env.ctx, contact.ID)
+	require.NoError(t, err)
+
+	extID := "td-atomic-" + uuid.New().String()[:8]
+	task, err := env.contactTaskRepo.CreateContactTask(env.ctx, repository.CreateContactTaskRequest{
+		ContactID:      contact.ID,
+		Provider:       SourceName,
+		Kind:           TaskKindCadence,
+		ExternalTaskID: extID,
+		State:          string(repository.ContactTaskStateManaged),
+		Metadata:       map[string]any{},
+	})
+	require.NoError(t, err)
+
+	return reloaded, task
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+// TestTodoist_HandleTaskCompletion_RollsBackEventAndStateOnDBFailure verifies
+// that an injected DB failure in UpdateContactTaskStateTx rolls back both the
+// event row and the state transition together.
+func TestTodoist_HandleTaskCompletion_RollsBackEventAndStateOnDBFailure(t *testing.T) {
+	env, cleanup := setupAtomicTxTestEnv(t)
+	defer cleanup()
+
+	contact, task := createManagedCadenceTask(t, env, "CompleteFail")
+
+	env.faultyTaskWriter.mu.Lock()
+	env.faultyTaskWriter.faultyMethod = "UpdateContactTaskStateTx"
+	env.faultyTaskWriter.mu.Unlock()
+
+	r := env.provider.handleTaskCompletion(env.ctx, SyncItem{
+		ID:      task.ExternalTaskID,
+		Checked: true,
+	}, task, contact, env.settings, env.accountID)
+
+	require.Error(t, r.Err, "handleTaskCompletion must propagate the injected DB error")
+	assert.Contains(t, r.Err.Error(), "update task state")
+
+	// No event row should be in the DB.
+	_, err := env.eventRepo.FindEventBySource(env.ctx, SourceName, task.ID.String())
+	assert.ErrorIs(t, err, db.ErrNotFound, "event row must have rolled back")
+
+	// Task state still 'managed'.
+	reloaded, err := env.contactTaskRepo.GetContactTask(env.ctx, task.ID)
+	require.NoError(t, err)
+	assert.Equal(t, repository.ContactTaskStateManaged, reloaded.State)
+}
+
+// TestTodoist_HandleSkipTrigger_RollsBackEventAndStateOnDBFailure verifies
+// that an injected failure in UpdateContactByTx rolls back the event row,
+// contact_by, and metadata all together.
+func TestTodoist_HandleSkipTrigger_RollsBackEventAndStateOnDBFailure(t *testing.T) {
+	env, cleanup := setupAtomicTxTestEnv(t)
+	defer cleanup()
+
+	contact, task := createManagedCadenceTask(t, env, "SkipFail")
+	beforeContactBy := contact.ContactBy
+
+	env.faultyContactWriterW.mu.Lock()
+	env.faultyContactWriterW.faultyMethod = "UpdateContactByTx"
+	env.faultyContactWriterW.mu.Unlock()
+
+	item := SyncItem{ID: task.ExternalTaskID, UpdatedAt: "2026-04-04T10:00:00Z"}
+	r := env.provider.handleSkipTrigger(env.ctx, item, task, contact, env.settings, env.accountID)
+
+	require.Error(t, r.Err)
+	assert.Contains(t, r.Err.Error(), "update contact_by")
+	assert.Nil(t, r.Commands, "no item_add command must be returned on rollback")
+
+	// Event row not present.
+	expectedSourceID := fmt.Sprintf("%s:%s", task.ID.String(), item.UpdatedAt)
+	_, err := env.eventRepo.FindEventBySource(env.ctx, SourceName, expectedSourceID)
+	assert.ErrorIs(t, err, db.ErrNotFound, "event row must have rolled back")
+
+	// contact_by unchanged.
+	reloadedContact, err := env.contactRepo.GetContact(env.ctx, contact.ID)
+	require.NoError(t, err)
+	if beforeContactBy == nil {
+		assert.Nil(t, reloadedContact.ContactBy)
+	} else {
+		require.NotNil(t, reloadedContact.ContactBy)
+		assert.True(t, beforeContactBy.Equal(*reloadedContact.ContactBy),
+			"contact_by must be unchanged after rollback")
+	}
+
+	// Metadata unchanged.
+	reloadedTask, err := env.contactTaskRepo.GetContactTask(env.ctx, task.ID)
+	require.NoError(t, err)
+	_, hasPending := reloadedTask.Metadata[MetadataKeyPendingTempID]
+	assert.False(t, hasPending, "pending_temp_id must not be set after rollback")
+}
+
+// TestTodoist_HandleSkipTrigger_ReplayIsNoOpAtEventLayer is the
+// spec-mandated "second skip ran twice on replay is now impossible" test.
+// Invokes the handler twice with identical (task, UpdatedAt); the second
+// call hits the event table's (source, source_id) unique constraint, the
+// bus returns env.ID=uuid.Nil, and the handler short-circuits.
+func TestTodoist_HandleSkipTrigger_ReplayIsNoOpAtEventLayer(t *testing.T) {
+	env, cleanup := setupAtomicTxTestEnv(t)
+	defer cleanup()
+
+	contact, task := createManagedCadenceTask(t, env, "SkipReplay")
+
+	item := SyncItem{ID: task.ExternalTaskID, UpdatedAt: "2026-04-05T10:00:00Z"}
+
+	// First call succeeds.
+	r1 := env.provider.handleSkipTrigger(env.ctx, item, task, contact, env.settings, env.accountID)
+	require.NoError(t, r1.Err)
+	require.Len(t, r1.Commands, 1)
+
+	after1, err := env.contactRepo.GetContact(env.ctx, contact.ID)
+	require.NoError(t, err)
+	require.NotNil(t, after1.ContactBy)
+
+	// Reload task to pick up the committed metadata.
+	taskReloaded, err := env.contactTaskRepo.GetContactTask(env.ctx, task.ID)
+	require.NoError(t, err)
+	contactReloaded, err := env.contactRepo.GetContact(env.ctx, contact.ID)
+	require.NoError(t, err)
+
+	// Second call with same item — real bus returns (source, source_id)
+	// duplicate, env.ID=uuid.Nil; handler short-circuits.
+	r2 := env.provider.handleSkipTrigger(env.ctx, item, taskReloaded, contactReloaded, env.settings, env.accountID)
+	require.NoError(t, r2.Err)
+	assert.True(t, r2.Processed)
+	assert.Nil(t, r2.Commands, "replay must NOT return a second item_add command")
+
+	// Exactly one event row.
+	expectedSourceID := fmt.Sprintf("%s:%s", task.ID.String(), item.UpdatedAt)
+	evt, err := env.eventRepo.FindEventBySource(env.ctx, SourceName, expectedSourceID)
+	require.NoError(t, err)
+	assert.Equal(t, events.KindTaskSkipped, evt.Kind)
+
+	// contact_by did NOT advance a second time.
+	after2, err := env.contactRepo.GetContact(env.ctx, contact.ID)
+	require.NoError(t, err)
+	require.NotNil(t, after2.ContactBy)
+	assert.True(t, after1.ContactBy.Equal(*after2.ContactBy),
+		"contact_by must not advance on replay at the event-table unique")
+}
+
+// TestTodoist_HandleTaskCompletion_DuplicateIsIdempotent verifies the
+// completion replay scenario against the real event-table unique index.
+func TestTodoist_HandleTaskCompletion_DuplicateIsIdempotent(t *testing.T) {
+	env, cleanup := setupAtomicTxTestEnv(t)
+	defer cleanup()
+
+	contact, task := createManagedCadenceTask(t, env, "CompleteReplay")
+
+	r1 := env.provider.handleTaskCompletion(env.ctx, SyncItem{
+		ID:      task.ExternalTaskID,
+		Checked: true,
+	}, task, contact, env.settings, env.accountID)
+	require.NoError(t, r1.Err)
+
+	// Second call — task state is already 'completed', but the handler
+	// runs anyway in this test (we pass the pre-first-call task pointer).
+	// The bus dedup via (source, source_id) unique returns env.ID=Nil;
+	// handler short-circuits without re-writing state.
+	r2 := env.provider.handleTaskCompletion(env.ctx, SyncItem{
+		ID:      task.ExternalTaskID,
+		Checked: true,
+	}, task, contact, env.settings, env.accountID)
+	require.NoError(t, r2.Err)
+	assert.True(t, r2.Processed)
+
+	// Exactly one event row.
+	evt, err := env.eventRepo.FindEventBySource(env.ctx, SourceName, task.ID.String())
+	require.NoError(t, err)
+	assert.Equal(t, events.KindTaskCompleted, evt.Kind)
+}
+
+// TestTodoist_TryRecoverPendingTempID_RollsBackOnDBFailure verifies that an
+// injected failure on UpdateContactTaskMetadataTx (after external_id update
+// succeeded inside the same tx) rolls back both writes atomically.
+func TestTodoist_TryRecoverPendingTempID_RollsBackOnDBFailure(t *testing.T) {
+	env, cleanup := setupAtomicTxTestEnv(t)
+	defer cleanup()
+
+	contact, task := createManagedCadenceTask(t, env, "Recover")
+
+	// Seed pending_temp_id + put task in pre-recovery state where
+	// ExternalTaskID is a temp and pending_temp_id matches (historical
+	// shape).
+	tempID := "temp-recover-" + uuid.New().String()[:8]
+	_, err := env.contactTaskRepo.UpdateContactTaskExternalID(env.ctx, task.ID, tempID)
+	require.NoError(t, err)
+	_, err = env.contactTaskRepo.UpdateContactTaskMetadata(env.ctx, task.ID, map[string]any{
+		MetadataKeyPendingTempID: tempID,
+	})
+	require.NoError(t, err)
+
+	env.faultyTaskWriter.mu.Lock()
+	env.faultyTaskWriter.faultyMethod = "UpdateContactTaskMetadataTx"
+	env.faultyTaskWriter.mu.Unlock()
+
+	realID := "real-" + uuid.New().String()[:8]
+	// Description carries the CRM marker so tryRecoverPendingTempID
+	// matches the contact.
+	marker := fmt.Sprintf(`{"crm":true,"contact_id":"%s","kind":"cadence","instance":"x"}`, contact.ID.String())
+	syncItem := SyncItem{
+		ID:          realID,
+		Description: marker,
+	}
+
+	_ = env.provider.tryRecoverPendingTempID(env.ctx, syncItem)
+
+	// Both writes rolled back: external_task_id still the temp, metadata
+	// still has pending_temp_id.
+	reloaded, err := env.contactTaskRepo.GetContactTask(env.ctx, task.ID)
+	require.NoError(t, err)
+	assert.Equal(t, tempID, reloaded.ExternalTaskID, "external_task_id must not advance after rollback")
+	pending, _ := reloaded.Metadata[MetadataKeyPendingTempID].(string)
+	assert.Equal(t, tempID, pending, "pending_temp_id must remain after rollback")
+}
+
+// TestTodoist_ProcessTempIDMappings_AtomicMappingClear verifies that an
+// injected failure on the metadata-clear step inside the per-task tx rolls
+// both writes back — external_task_id stays at the temp, pending_temp_id
+// remains set.
+func TestTodoist_ProcessTempIDMappings_AtomicMappingClear(t *testing.T) {
+	env, cleanup := setupAtomicTxTestEnv(t)
+	defer cleanup()
+
+	_, task := createManagedCadenceTask(t, env, "TempMap")
+
+	tempID := "temp-map-" + uuid.New().String()[:8]
+	_, err := env.contactTaskRepo.UpdateContactTaskExternalID(env.ctx, task.ID, tempID)
+	require.NoError(t, err)
+	_, err = env.contactTaskRepo.UpdateContactTaskMetadata(env.ctx, task.ID, map[string]any{
+		MetadataKeyPendingTempID: tempID,
+	})
+	require.NoError(t, err)
+
+	env.faultyTaskWriter.mu.Lock()
+	env.faultyTaskWriter.faultyMethod = "UpdateContactTaskMetadataTx"
+	env.faultyTaskWriter.mu.Unlock()
+
+	realID := "real-map-" + uuid.New().String()[:8]
+	rolledBack := env.provider.processTempIDMappings(env.ctx, map[string]string{tempID: realID})
+	assert.True(t, rolledBack, "processTempIDMappings must report rolledBack=true when a tx fails")
+
+	reloaded, err := env.contactTaskRepo.GetContactTask(env.ctx, task.ID)
+	require.NoError(t, err)
+	assert.Equal(t, tempID, reloaded.ExternalTaskID, "external_task_id must not advance after rollback")
+	pending, _ := reloaded.Metadata[MetadataKeyPendingTempID].(string)
+	assert.Equal(t, tempID, pending, "pending_temp_id must remain after rollback")
+}
+
+// TestTodoist_ProcessTempIDMappings_RollbackRecoversViaTryRecoverPendingTempID
+// verifies the end-to-end recovery chain: first tick's mapping tx rolls
+// back; next tick's syncResp.Items delivers the real item, and
+// tryRecoverPendingTempID finalizes the mapping atomically.
+func TestTodoist_ProcessTempIDMappings_RollbackRecoversViaTryRecoverPendingTempID(t *testing.T) {
+	env, cleanup := setupAtomicTxTestEnv(t)
+	defer cleanup()
+
+	contact, task := createManagedCadenceTask(t, env, "RecoverChain")
+
+	tempID := "temp-chain-" + uuid.New().String()[:8]
+	_, err := env.contactTaskRepo.UpdateContactTaskExternalID(env.ctx, task.ID, tempID)
+	require.NoError(t, err)
+	_, err = env.contactTaskRepo.UpdateContactTaskMetadata(env.ctx, task.ID, map[string]any{
+		MetadataKeyPendingTempID: tempID,
+	})
+	require.NoError(t, err)
+
+	// First tick: mapping tx fails on metadata clear.
+	env.faultyTaskWriter.mu.Lock()
+	env.faultyTaskWriter.faultyMethod = "UpdateContactTaskMetadataTx"
+	env.faultyTaskWriter.fired = 0
+	env.faultyTaskWriter.mu.Unlock()
+
+	realID := "real-chain-" + uuid.New().String()[:8]
+	rolledBack := env.provider.processTempIDMappings(env.ctx, map[string]string{tempID: realID})
+	require.True(t, rolledBack)
+
+	// State after first tick: ExternalTaskID still temp, pending_temp_id
+	// still set.
+	afterTick1, err := env.contactTaskRepo.GetContactTask(env.ctx, task.ID)
+	require.NoError(t, err)
+	require.Equal(t, tempID, afterTick1.ExternalTaskID)
+
+	// Second tick: clear the fault (fireLimit is 1, and we've already
+	// triggered once). tryRecoverPendingTempID runs against an item with
+	// the CRM marker pointing at this contact.
+	marker := fmt.Sprintf(`{"crm":true,"contact_id":"%s","kind":"cadence","instance":"x"}`, contact.ID.String())
+	recovered := env.provider.tryRecoverPendingTempID(env.ctx, SyncItem{
+		ID:          realID,
+		Description: marker,
+	})
+	require.NotNil(t, recovered, "tryRecoverPendingTempID must match the CRM marker and recover")
+
+	// State after recovery: ExternalTaskID is real, pending_temp_id cleared.
+	afterTick2, err := env.contactTaskRepo.GetContactTask(env.ctx, task.ID)
+	require.NoError(t, err)
+	assert.Equal(t, realID, afterTick2.ExternalTaskID)
+	_, hasPending := afterTick2.Metadata[MetadataKeyPendingTempID]
+	assert.False(t, hasPending, "pending_temp_id must be cleared after recovery")
+}
+
+// TestReconcileExistingTask_SkipDriftRecovery_MetadataWriteFailure verifies
+// that when the pre-emit metadata write fails, the reconcile branch does
+// NOT emit commands (holding the new TempID back so the next tick retries
+// from a consistent state).
+func TestReconcileExistingTask_SkipDriftRecovery_MetadataWriteFailure(t *testing.T) {
+	env, cleanup := setupAtomicTxTestEnv(t)
+	defer cleanup()
+
+	contact, task := createManagedCadenceTask(t, env, "SkipDriftMetaFail")
+
+	// Seed the "skip-drift detected" state.
+	origTempID := "temp-metafail-" + uuid.New().String()[:8]
+	_, err := env.contactTaskRepo.UpdateContactTaskMetadata(env.ctx, task.ID, map[string]any{
+		MetadataKeyPendingTempID:  origTempID,
+		MetadataKeySyncedDeadline: "2027-03-15",
+	})
+	require.NoError(t, err)
+	reloaded, err := env.contactTaskRepo.GetContactTask(env.ctx, task.ID)
+	require.NoError(t, err)
+
+	env.faultyTaskWriter.mu.Lock()
+	env.faultyTaskWriter.faultyMethod = "UpdateContactTaskMetadata"
+	env.faultyTaskWriter.mu.Unlock()
+
+	cmds := env.provider.reconcileExistingTask(env.ctx, reloaded, contact, env.settings, "2027-04-15", false)
+
+	// No commands emitted because the pre-emit metadata write failed.
+	assert.Empty(t, cmds, "skip-drift branch must not emit commands when metadata write fails")
+
+	// pending_temp_id unchanged (still the stale one — new one was never
+	// persisted).
+	afterFail, err := env.contactTaskRepo.GetContactTask(env.ctx, task.ID)
+	require.NoError(t, err)
+	pending, _ := afterFail.Metadata[MetadataKeyPendingTempID].(string)
+	assert.Equal(t, origTempID, pending)
+}

--- a/backend/internal/todoist/provider_atomic_tx_integration_test.go
+++ b/backend/internal/todoist/provider_atomic_tx_integration_test.go
@@ -491,7 +491,9 @@ func TestTodoist_TryRecoverPendingTempID_RollsBackOnDBFailure(t *testing.T) {
 		Description: marker,
 	}
 
-	_ = env.provider.tryRecoverPendingTempID(env.ctx, syncItem)
+	recovered, recoveryFailed := env.provider.tryRecoverPendingTempID(env.ctx, syncItem)
+	_ = recovered
+	assert.True(t, recoveryFailed, "recoveryFailed must surface so Sync can defer skip-drift")
 
 	// Both writes rolled back: external_task_id still the temp, metadata
 	// still has pending_temp_id.
@@ -573,11 +575,12 @@ func TestTodoist_ProcessTempIDMappings_RollbackRecoversViaTryRecoverPendingTempI
 	// triggered once). tryRecoverPendingTempID runs against an item with
 	// the CRM marker pointing at this contact.
 	marker := fmt.Sprintf(`{"crm":true,"contact_id":"%s","kind":"cadence","instance":"x"}`, contact.ID.String())
-	recovered := env.provider.tryRecoverPendingTempID(env.ctx, SyncItem{
+	recovered, recoveryFailed := env.provider.tryRecoverPendingTempID(env.ctx, SyncItem{
 		ID:          realID,
 		Description: marker,
 	})
 	require.NotNil(t, recovered, "tryRecoverPendingTempID must match the CRM marker and recover")
+	assert.False(t, recoveryFailed, "second-tick recovery must succeed")
 
 	// State after recovery: ExternalTaskID is real, pending_temp_id cleared.
 	afterTick2, err := env.contactTaskRepo.GetContactTask(env.ctx, task.ID)
@@ -585,6 +588,153 @@ func TestTodoist_ProcessTempIDMappings_RollbackRecoversViaTryRecoverPendingTempI
 	assert.Equal(t, realID, afterTick2.ExternalTaskID)
 	_, hasPending := afterTick2.Metadata[MetadataKeyPendingTempID]
 	assert.False(t, hasPending, "pending_temp_id must be cleared after recovery")
+}
+
+// TestTodoist_ProcessItems_PropagatesRecoveryFailed verifies that a
+// tryRecoverPendingTempID rollback in one item propagates through
+// processItem's result into processItems's aggregated recoveryFailed
+// return — so Sync forces deferSkipDrift=true for this tick.
+func TestTodoist_ProcessItems_PropagatesRecoveryFailed(t *testing.T) {
+	env, cleanup := setupAtomicTxTestEnv(t)
+	defer cleanup()
+
+	contact, task := createManagedCadenceTask(t, env, "RecoverFailProp")
+
+	// Put task in the "needs recovery" shape: ExternalTaskID is a temp,
+	// pending_temp_id matches it.
+	tempID := "temp-prop-" + uuid.New().String()[:8]
+	_, err := env.contactTaskRepo.UpdateContactTaskExternalID(env.ctx, task.ID, tempID)
+	require.NoError(t, err)
+	_, err = env.contactTaskRepo.UpdateContactTaskMetadata(env.ctx, task.ID, map[string]any{
+		MetadataKeyPendingTempID: tempID,
+	})
+	require.NoError(t, err)
+
+	// Faulty metadata-clear inside the recovery tx.
+	env.faultyTaskWriter.mu.Lock()
+	env.faultyTaskWriter.faultyMethod = "UpdateContactTaskMetadataTx"
+	env.faultyTaskWriter.mu.Unlock()
+
+	// Sync item carries a CRM marker that matches the contact — this is
+	// the "real Todoist id just delivered in syncResp.Items" case where
+	// GetContactTaskByExternalID misses (the local row still has the temp
+	// id) and processItem falls back to tryRecoverPendingTempID.
+	realID := "real-prop-" + uuid.New().String()[:8]
+	marker := fmt.Sprintf(`{"crm":true,"contact_id":"%s","kind":"cadence","instance":"x"}`, contact.ID.String())
+
+	items := []SyncItem{{
+		ID:          realID,
+		Description: marker,
+		Labels:      []string{env.settings.LabelName},
+		Deadline:    &SyncDate{Date: contact.ContactBy.Format(DateFormat)},
+		UpdatedAt:   "2026-04-08T10:00:00Z",
+	}}
+
+	_, _, recoveryFailed, err := env.provider.processItems(env.ctx, items, env.settings, env.accountID)
+	require.NoError(t, err, "processItems should not error — recovery failure is non-fatal")
+	assert.True(t, recoveryFailed, "processItems must propagate RecoveryFailed up from processItem")
+}
+
+// TestTodoist_ProcessTempIDMappings_RollbackDefersSkipDriftOneTick simulates
+// the round-trip where:
+//  1. handleSkipTrigger commits (state advance + pending_temp_id set).
+//  2. Todoist HTTP batch succeeds remotely (simulated by calling
+//     processTempIDMappings with a temp_id_mapping).
+//  3. The mapping tx rolls back (faulty metadata-clear).
+//  4. processTempIDMappings returns rolledBack=true.
+//  5. Same-tick reconcileContactTasks invoked with deferSkipDrift=true
+//     must NOT emit a duplicate item_add, even though the stale local row
+//     matches the skip-drift detection predicate.
+//
+// This is the key correctness test for the rollback-deferral fix.
+func TestTodoist_ProcessTempIDMappings_RollbackDefersSkipDriftOneTick(t *testing.T) {
+	env, cleanup := setupAtomicTxTestEnv(t)
+	defer cleanup()
+
+	contact, task := createManagedCadenceTask(t, env, "DeferOneTick")
+
+	// Step 1: simulate handleSkipTrigger's committed state — pending_temp_id
+	// set with a new temp id that differs from ExternalTaskID.
+	oldExtID := task.ExternalTaskID
+	newTempID := "temp-new-" + uuid.New().String()[:8]
+	_, err := env.contactTaskRepo.UpdateContactTaskMetadata(env.ctx, task.ID, map[string]any{
+		MetadataKeyPendingTempID:  newTempID,
+		MetadataKeySyncedDeadline: contact.ContactBy.Format(DateFormat),
+	})
+	require.NoError(t, err)
+
+	// Step 2 + 3: mapping tx rolls back on metadata clear.
+	env.faultyTaskWriter.mu.Lock()
+	env.faultyTaskWriter.faultyMethod = "UpdateContactTaskMetadataTx"
+	env.faultyTaskWriter.mu.Unlock()
+
+	realID := "real-defer-" + uuid.New().String()[:8]
+	rolledBack := env.provider.processTempIDMappings(env.ctx, map[string]string{newTempID: realID})
+	require.True(t, rolledBack, "mapping tx must have rolled back")
+
+	// State after rollback: ExternalTaskID unchanged (still oldExtID),
+	// pending_temp_id unchanged (still newTempID). Detection predicate
+	// (pending_temp_id != "" && pending_temp_id != ExternalTaskID) is TRUE.
+	afterMapping, err := env.contactTaskRepo.GetContactTask(env.ctx, task.ID)
+	require.NoError(t, err)
+	assert.Equal(t, oldExtID, afterMapping.ExternalTaskID)
+	pending, _ := afterMapping.Metadata[MetadataKeyPendingTempID].(string)
+	assert.Equal(t, newTempID, pending)
+
+	// Step 5: same-tick reconcile with deferSkipDrift=true. Skip-drift
+	// branch must NOT fire — no item_close + item_add emitted from it.
+	syncedDeadline, _ := afterMapping.Metadata[MetadataKeySyncedDeadline].(string)
+	cmds := env.provider.reconcileExistingTask(env.ctx, afterMapping, contact, env.settings, syncedDeadline, true /* deferSkipDrift */)
+
+	for _, c := range cmds {
+		assert.NotEqual(t, "item_close", c.Type, "deferral must suppress duplicate item_close")
+		assert.NotEqual(t, "item_add", c.Type, "deferral must suppress duplicate item_add")
+	}
+
+	// Metadata pending_temp_id unchanged (branch did not run).
+	afterReconcile, err := env.contactTaskRepo.GetContactTask(env.ctx, task.ID)
+	require.NoError(t, err)
+	stillPending, _ := afterReconcile.Metadata[MetadataKeyPendingTempID].(string)
+	assert.Equal(t, newTempID, stillPending, "pending_temp_id must be unchanged under deferral")
+}
+
+// TestTodoist_SkipDrift_ReconcileRecovery exercises the end-to-end skip-drift
+// self-healing path: when pending_temp_id mismatches ExternalTaskID and
+// deferSkipDrift=false, reconcileExistingTask emits item_close + item_add
+// so the next HTTP batch retries the replacement. This is the "HTTP batch
+// truly failed" case where the remote task was never created.
+func TestTodoist_SkipDrift_ReconcileRecovery(t *testing.T) {
+	env, cleanup := setupAtomicTxTestEnv(t)
+	defer cleanup()
+
+	contact, task := createManagedCadenceTask(t, env, "SkipDriftReconcile")
+
+	oldExtID := task.ExternalTaskID
+	staleTempID := "temp-stale-" + uuid.New().String()[:8]
+	syncedDeadline := contact.ContactBy.Format(DateFormat)
+	_, err := env.contactTaskRepo.UpdateContactTaskMetadata(env.ctx, task.ID, map[string]any{
+		MetadataKeyPendingTempID:  staleTempID,
+		MetadataKeySyncedDeadline: syncedDeadline,
+	})
+	require.NoError(t, err)
+
+	afterSkip, err := env.contactTaskRepo.GetContactTask(env.ctx, task.ID)
+	require.NoError(t, err)
+
+	// Reconcile with deferSkipDrift=false — branch must fire.
+	cmds := env.provider.reconcileExistingTask(env.ctx, afterSkip, contact, env.settings, syncedDeadline, false)
+
+	require.Len(t, cmds, 2, "skip-drift branch must emit item_close + item_add")
+	assert.Equal(t, "item_close", cmds[0].Type)
+	assert.Equal(t, oldExtID, cmds[0].Args["id"])
+	assert.Equal(t, "item_add", cmds[1].Type)
+
+	// pending_temp_id updated to the new item_add TempID.
+	afterRecovery, err := env.contactTaskRepo.GetContactTask(env.ctx, task.ID)
+	require.NoError(t, err)
+	newPending, _ := afterRecovery.Metadata[MetadataKeyPendingTempID].(string)
+	assert.Equal(t, cmds[1].TempID, newPending)
+	assert.NotEqual(t, staleTempID, newPending)
 }
 
 // TestReconcileExistingTask_SkipDriftRecovery_MetadataWriteFailure verifies

--- a/backend/internal/todoist/provider_deadline_edit_test.go
+++ b/backend/internal/todoist/provider_deadline_edit_test.go
@@ -86,7 +86,7 @@ func TestProcessItem_FollowUpDeadlineDoesNotOverwriteContactBy(t *testing.T) {
 	require.NoError(t, r.Err)
 	assert.True(t, r.Processed, "the follow-up task was handled, just without the deadline-edit side effect")
 	assert.Empty(t, r.Commands, "deadline-edit path emits no Todoist commands")
-	assert.Equal(t, 0, env.recorder.count, "deadline-edit path must not record interactions")
+	assert.Empty(t, env.bus.Published(), "deadline-edit path must not publish events")
 
 	// contact.ContactBy is unchanged.
 	reloaded, err := env.contactRepo.GetContact(env.ctx, contact.ID)
@@ -146,7 +146,7 @@ func TestProcessItem_CadenceDeadlineOverwritesContactBy(t *testing.T) {
 	require.NoError(t, r.Err)
 	assert.True(t, r.Processed)
 	assert.Empty(t, r.Commands)
-	assert.Equal(t, 0, env.recorder.count)
+	assert.Empty(t, env.bus.Published())
 
 	// contact.ContactBy is updated to the Todoist deadline.
 	reloaded, err := env.contactRepo.GetContact(env.ctx, contact.ID)

--- a/backend/internal/todoist/provider_dismissal_test.go
+++ b/backend/internal/todoist/provider_dismissal_test.go
@@ -27,21 +27,6 @@ import (
 // Test helpers
 // ============================================================================
 
-// countingRecorder is a test double for the interactionRecorder interface that
-// fails the test immediately if RecordInteraction is called. Used to assert the
-// dismissal path never records an interaction.
-type countingRecorder struct {
-	t     *testing.T
-	count int
-}
-
-func (r *countingRecorder) RecordInteraction(_ context.Context, _ repository.RecordInteractionRequest) (*repository.Interaction, error) {
-	r.t.Helper()
-	r.count++
-	r.t.Errorf("unexpected RecordInteraction call during dismissal test (count=%d)", r.count)
-	return &repository.Interaction{ID: uuid.New()}, nil
-}
-
 // busRecorder is a test double for eventPublisher. It records every
 // PublishTx call and optionally injects errors or duplicate (env.ID=Nil)
 // responses. Safe for concurrent use.
@@ -83,7 +68,6 @@ type dismissalTestEnv struct {
 	provider        *CadenceSyncProvider
 	contactRepo     *repository.ContactRepository
 	contactTaskRepo *repository.ContactTaskRepository
-	recorder        *countingRecorder
 	bus             *busRecorder
 	pool            *pgxpool.Pool
 	settings        Settings
@@ -91,10 +75,9 @@ type dismissalTestEnv struct {
 }
 
 // newProviderTestEnv builds the shared DB + repos + provider infrastructure
-// used by setupDismissalTest. Takes the recorder as a parameter so callers
-// can pass the strict countingRecorder (the last surviving test double in
-// this file).
-func newProviderTestEnv(t *testing.T, recorder interactionRecorder) (*CadenceSyncProvider, *repository.ContactRepository, *repository.ContactTaskRepository, *busRecorder, *pgxpool.Pool, context.Context, Settings, string, func()) {
+// used by setupDismissalTest. Returns a busRecorder for tests that need to
+// assert published events or inject publish failures.
+func newProviderTestEnv(t *testing.T) (*CadenceSyncProvider, *repository.ContactRepository, *repository.ContactTaskRepository, *busRecorder, *pgxpool.Pool, context.Context, Settings, string, func()) {
 	t.Helper()
 
 	databaseURL := os.Getenv("DATABASE_URL")
@@ -128,7 +111,6 @@ func newProviderTestEnv(t *testing.T, recorder interactionRecorder) (*CadenceSyn
 		contactRepo,
 		nil, // syncRepo: not consulted on this code path
 		cfg,
-		recorder,
 		bus,
 		database.Pool,
 		DefaultClientFactory,
@@ -146,21 +128,19 @@ func newProviderTestEnv(t *testing.T, recorder interactionRecorder) (*CadenceSyn
 	return provider, contactRepo, contactTaskRepo, bus, database.Pool, ctx, settings, accountID, func() { database.Close() }
 }
 
-// setupDismissalTest builds a CadenceSyncProvider wired to a real DB and a test
-// interactionRecorder that asserts it is never called. Skips if DATABASE_URL is
-// unset, matching the pattern in backend/tests/followup_service_test.go.
+// setupDismissalTest builds a CadenceSyncProvider wired to a real DB and a
+// busRecorder. Skips if DATABASE_URL is unset, matching the pattern in
+// backend/tests/followup_service_test.go.
 func setupDismissalTest(t *testing.T) (*dismissalTestEnv, func()) {
 	t.Helper()
 
-	recorder := &countingRecorder{t: t}
-	provider, contactRepo, contactTaskRepo, bus, pool, ctx, settings, accountID, cleanup := newProviderTestEnv(t, recorder)
+	provider, contactRepo, contactTaskRepo, bus, pool, ctx, settings, accountID, cleanup := newProviderTestEnv(t)
 
 	return &dismissalTestEnv{
 		ctx:             ctx,
 		provider:        provider,
 		contactRepo:     contactRepo,
 		contactTaskRepo: contactTaskRepo,
-		recorder:        recorder,
 		bus:             bus,
 		pool:            pool,
 		settings:        settings,
@@ -313,7 +293,7 @@ func TestFollowUpDismissal_IsDeleted(t *testing.T) {
 	require.NoError(t, r.Err)
 	assert.True(t, r.Processed, "processItem should return processed=true (task was handled)")
 	assert.Empty(t, r.Commands, "no Todoist commands should be emitted when item is already deleted")
-	assert.Equal(t, 0, env.recorder.count, "RecordInteraction must not be called during dismissal")
+	assert.Empty(t, env.bus.Published(), "dismissal must not publish events")
 
 	assertDismissedAndInvariants(t, env, contact.ID, task.ID, snap)
 }
@@ -340,7 +320,6 @@ func TestFollowUpDismissal_LabelRemoved(t *testing.T) {
 	require.Len(t, r.Commands, 1, "exactly one ItemClose command expected")
 	assert.Equal(t, "item_close", r.Commands[0].Type)
 	assert.Equal(t, externalID, r.Commands[0].Args["id"])
-	assert.Equal(t, 0, env.recorder.count)
 
 	assertDismissedAndInvariants(t, env, contact.ID, task.ID, snap)
 }
@@ -367,7 +346,6 @@ func TestFollowUpDismissal_DeadlineRemoved(t *testing.T) {
 	require.Len(t, r.Commands, 1)
 	assert.Equal(t, "item_close", r.Commands[0].Type)
 	assert.Equal(t, externalID, r.Commands[0].Args["id"])
-	assert.Equal(t, 0, env.recorder.count)
 
 	assertDismissedAndInvariants(t, env, contact.ID, task.ID, snap)
 }
@@ -448,7 +426,6 @@ func TestFollowUpDismissal_SubsequentProcessItemSkipsDismissedRow(t *testing.T) 
 	require.NoError(t, r.Err)
 	assert.False(t, r.Processed, "subsequent processItem should report the row was skipped")
 	assert.Empty(t, r.Commands, "no commands should be emitted on subsequent calls")
-	assert.Equal(t, 0, env.recorder.count)
 }
 
 // Case 6: FindPendingFollowUp must ignore dismissed rows. Regression guardrail
@@ -686,7 +663,7 @@ func TestHandleFollowUpDismissal_StateUpdateErrorPropagates(t *testing.T) {
 	assert.Contains(t, r.Err.Error(), "contact_task state", "error should identify the failed operation")
 	assert.False(t, r.Processed, "failed dismissal must not report Processed=true")
 	assert.Nil(t, r.Commands, "ItemClose must NOT be forwarded on state-update failure")
-	assert.Equal(t, 0, env.recorder.count, "dismissal path must never record interactions")
+	assert.Empty(t, env.bus.Published(), "dismissal must not publish events")
 }
 
 // TestHandleActionTaskTriggers_StateUpdateErrorPropagates_Deleted verifies

--- a/backend/internal/todoist/provider_dismissal_test.go
+++ b/backend/internal/todoist/provider_dismissal_test.go
@@ -311,7 +311,6 @@ func TestFollowUpDismissal_IsDeleted(t *testing.T) {
 	}, env.settings, env.accountID)
 
 	require.NoError(t, r.Err)
-	assert.False(t, r.Unsafe, "follow-up dismissal is replay-safe")
 	assert.True(t, r.Processed, "processItem should return processed=true (task was handled)")
 	assert.Empty(t, r.Commands, "no Todoist commands should be emitted when item is already deleted")
 	assert.Equal(t, 0, env.recorder.count, "RecordInteraction must not be called during dismissal")
@@ -337,7 +336,6 @@ func TestFollowUpDismissal_LabelRemoved(t *testing.T) {
 	}, env.settings, env.accountID)
 
 	require.NoError(t, r.Err)
-	assert.False(t, r.Unsafe, "follow-up dismissal is replay-safe")
 	assert.True(t, r.Processed)
 	require.Len(t, r.Commands, 1, "exactly one ItemClose command expected")
 	assert.Equal(t, "item_close", r.Commands[0].Type)
@@ -365,7 +363,6 @@ func TestFollowUpDismissal_DeadlineRemoved(t *testing.T) {
 	}, env.settings, env.accountID)
 
 	require.NoError(t, r.Err)
-	assert.False(t, r.Unsafe, "follow-up dismissal is replay-safe")
 	assert.True(t, r.Processed)
 	require.Len(t, r.Commands, 1)
 	assert.Equal(t, "item_close", r.Commands[0].Type)
@@ -450,7 +447,6 @@ func TestFollowUpDismissal_SubsequentProcessItemSkipsDismissedRow(t *testing.T) 
 
 	require.NoError(t, r.Err)
 	assert.False(t, r.Processed, "subsequent processItem should report the row was skipped")
-	assert.False(t, r.Unsafe)
 	assert.Empty(t, r.Commands, "no commands should be emitted on subsequent calls")
 	assert.Equal(t, 0, env.recorder.count)
 }
@@ -569,7 +565,6 @@ func TestFollowUpDismissal_CadenceDispatchUnchanged(t *testing.T) {
 
 			require.NoError(t, r.Err)
 			assert.True(t, r.Processed)
-			assert.True(t, r.Unsafe, "cadence skip trigger commits non-replay-safe state")
 			require.NotEmpty(t, r.Commands, "handleSkipTrigger should return an item_add command for the replacement cadence task")
 
 			sawItemAdd := false
@@ -611,7 +606,6 @@ func TestFollowUpDismissal_ActionDispatchUnchanged(t *testing.T) {
 
 	require.NoError(t, r.Err)
 	assert.True(t, r.Processed)
-	assert.False(t, r.Unsafe, "action task unmanagement is replay-safe")
 
 	reloaded, err := env.contactTaskRepo.GetContactTask(env.ctx, action.ID)
 	require.NoError(t, err)
@@ -691,7 +685,6 @@ func TestHandleFollowUpDismissal_StateUpdateErrorPropagates(t *testing.T) {
 	assert.Contains(t, r.Err.Error(), "dismiss follow-up", "error should be wrapped with dismiss follow-up")
 	assert.Contains(t, r.Err.Error(), "contact_task state", "error should identify the failed operation")
 	assert.False(t, r.Processed, "failed dismissal must not report Processed=true")
-	assert.False(t, r.Unsafe, "follow-up dismissal is replay-safe")
 	assert.Nil(t, r.Commands, "ItemClose must NOT be forwarded on state-update failure")
 	assert.Equal(t, 0, env.recorder.count, "dismissal path must never record interactions")
 }
@@ -726,7 +719,6 @@ func TestHandleActionTaskTriggers_StateUpdateErrorPropagates_Deleted(t *testing.
 	require.Error(t, r.Err)
 	assert.Contains(t, r.Err.Error(), "action task triggers (deleted)")
 	assert.False(t, r.Processed)
-	assert.False(t, r.Unsafe, "action unmanagement is replay-safe")
 	assert.Nil(t, r.Commands)
 }
 
@@ -760,7 +752,6 @@ func TestHandleActionTaskTriggers_StateUpdateErrorPropagates_LabelRemoved(t *tes
 	require.Error(t, r.Err)
 	assert.Contains(t, r.Err.Error(), "action task triggers (label removed)")
 	assert.False(t, r.Processed)
-	assert.False(t, r.Unsafe)
 	assert.Nil(t, r.Commands)
 }
 
@@ -781,21 +772,19 @@ func TestProcessItem_LookupErrorPropagates(t *testing.T) {
 	require.Error(t, r.Err)
 	assert.Contains(t, r.Err.Error(), "lookup contact_task", "error should identify the failed lookup")
 	assert.False(t, r.Processed)
-	assert.False(t, r.Unsafe)
 	assert.Nil(t, r.Commands)
 }
 
-// TestProcessItems_AbortsWhenNoUnsafeCommit verifies that a fatal error from
-// processItem with no earlier non-replay-safe commit causes processItems to
-// abort (return the error) and leave replayCommittedUnsafe==false so the
-// caller knows the cursor must not advance.
-func TestProcessItems_AbortsWhenNoUnsafeCommit(t *testing.T) {
+// TestProcessItems_AbortsOnFatalError verifies that a fatal error from
+// processItem causes processItems to abort (return the wrapped error)
+// so the caller preserves the pre-batch cursor.
+func TestProcessItems_AbortsOnFatalError(t *testing.T) {
 	env, cleanup := setupDismissalTest(t)
 	defer cleanup()
 
 	badCtx := cancelledContext()
 
-	processed, commands, replayCommittedUnsafe, err := env.provider.processItems(
+	processed, commands, err := env.provider.processItems(
 		badCtx,
 		[]SyncItem{
 			{ID: "td-abort-" + uuid.New().String()[:8], Labels: []string{env.settings.LabelName}},
@@ -810,29 +799,18 @@ func TestProcessItems_AbortsWhenNoUnsafeCommit(t *testing.T) {
 	assert.Equal(t, 0, processed, "no items should be counted as processed on abort")
 	// No prior items succeeded, so no commands accumulated.
 	assert.Empty(t, commands, "no commands should be accumulated when the first item errors")
-	assert.False(t, replayCommittedUnsafe, "no unsafe commit occurred before abort")
 }
 
 // TestProcessItems_SuccessfulDismissalReturnsItemClose verifies that a
 // valid follow-up dismissal routed through processItems returns the
 // ItemClose command in the accumulated commands slice. Together with
-// TestProcessItems_AbortsWhenNoUnsafeCommit (which verifies that the abort
-// path returns the in-scope commands variable rather than a hard-coded
-// nil), this exercises both sides of the command-accumulation contract
-// that the orphaned-Todoist-task fix relies on: the slice always carries
-// whatever was accumulated before the (possibly aborted) iteration, so
-// the caller (Sync) can execute accumulated cleanup commands even when
-// the batch aborts.
-//
-// Note: simulating a true mid-batch "item 1 succeeds with a command,
-// item 2 errors fatally" flow under a shared pgx connection without
-// flakiness is not feasible — the cancelled-context error-injection
-// strategy applies to the whole batch, and live-DB failure injection
-// would require ad-hoc triggers or a mock repository wrapping. The
-// two-line fix (processItems returns `commands` instead of `nil` on
-// abort; Sync executes commands before returning the error) is verified
-// here by exercising both the success return shape and the abort return
-// shape, together with code inspection of the trivial fix.
+// TestProcessItems_AbortsOnFatalError (which verifies the abort path
+// preserves the in-scope commands variable rather than a hard-coded nil),
+// this exercises both sides of the command-accumulation contract that the
+// orphaned-Todoist-task fix relies on: the slice always carries whatever
+// was accumulated before the (possibly aborted) iteration, so the caller
+// (Sync) can execute accumulated cleanup commands even when the batch
+// aborts.
 func TestProcessItems_SuccessfulDismissalReturnsItemClose(t *testing.T) {
 	env, cleanup := setupDismissalTest(t)
 	defer cleanup()
@@ -841,7 +819,7 @@ func TestProcessItems_SuccessfulDismissalReturnsItemClose(t *testing.T) {
 	externalID := "td-preserve-" + uuid.New().String()[:8]
 	_ = createFollowUpTask(t, env, contact.ID, externalID)
 
-	processed, commands, replayCommittedUnsafe, err := env.provider.processItems(
+	processed, commands, err := env.provider.processItems(
 		env.ctx,
 		[]SyncItem{
 			{
@@ -856,7 +834,6 @@ func TestProcessItems_SuccessfulDismissalReturnsItemClose(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.Equal(t, 1, processed)
-	assert.False(t, replayCommittedUnsafe)
 	require.Len(t, commands, 1, "successful dismissal must return an ItemClose command")
 	assert.Equal(t, "item_close", commands[0].Type)
 	assert.Equal(t, externalID, commands[0].Args["id"])
@@ -982,69 +959,7 @@ func TestHandleRecurringDetection_StateUpdateErrorPropagates(t *testing.T) {
 	assert.Contains(t, r.Err.Error(), "update state to unmanaged (recurring)",
 		"error should identify the recurring state-update failure")
 	assert.False(t, r.Processed, "failed state update must not report Processed=true")
-	assert.False(t, r.Unsafe, "recurring transition is replay-safe")
 	assert.Nil(t, r.Commands)
-}
-
-// TestDecideFatalErrorPolicy_AbortsWhenReplaySafe verifies that
-// decideFatalErrorPolicy returns shouldContinue=false and a wrapped error
-// when no earlier unsafe commit has occurred in the batch. This is the
-// direct unit test for the abort path in the conditional-abort logic.
-func TestDecideFatalErrorPolicy_AbortsWhenReplaySafe(t *testing.T) {
-	env, cleanup := setupDismissalTest(t)
-	defer cleanup()
-
-	itemID := "td-abort-policy-" + uuid.New().String()[:8]
-	fakeResult := processItemResult{
-		Err: errors.New("underlying db failure"),
-	}
-
-	shouldContinue, wrappedErr := env.provider.decideFatalErrorPolicy(
-		fakeResult,
-		SyncItem{ID: itemID},
-		0,     // processedBeforeAbort
-		false, // replayCommittedUnsafe
-	)
-
-	assert.False(t, shouldContinue, "no earlier unsafe commit → must abort")
-	require.Error(t, wrappedErr)
-	assert.Contains(t, wrappedErr.Error(), "process item "+itemID,
-		"wrapped error should include item ID")
-	assert.Contains(t, wrappedErr.Error(), "underlying db failure",
-		"wrapped error should chain the original cause")
-}
-
-// TestDecideFatalErrorPolicy_LogsAndContinuesAfterUnsafe verifies that
-// decideFatalErrorPolicy returns shouldContinue=true and nil error when an
-// earlier item in the batch already committed non-replay-safe state via
-// handleSkipTrigger. This is the direct unit test for the log-and-continue
-// path — it exists because simulating mid-batch DB failure with a shared
-// connection is non-trivial, and extracting this policy into a testable
-// helper lets us verify the branch without DB-level failure injection.
-//
-// Together with TestHandleSkipTrigger_FailureDoesNotReturnErrorAndSetsUnsafe
-// (which locks in Unsafe=true on the skip-trigger success path) and
-// TestProcessItems_AbortsWhenNoUnsafeCommit (which verifies the loop wiring
-// for the abort path), this test completes coverage of the conditional-
-// abort semantics.
-func TestDecideFatalErrorPolicy_LogsAndContinuesAfterUnsafe(t *testing.T) {
-	env, cleanup := setupDismissalTest(t)
-	defer cleanup()
-
-	itemID := "td-continue-policy-" + uuid.New().String()[:8]
-	fakeResult := processItemResult{
-		Err: errors.New("underlying db failure"),
-	}
-
-	shouldContinue, wrappedErr := env.provider.decideFatalErrorPolicy(
-		fakeResult,
-		SyncItem{ID: itemID},
-		1,    // processedBeforeAbort — an earlier item succeeded
-		true, // replayCommittedUnsafe — earlier skip trigger advanced contact_by
-	)
-
-	assert.True(t, shouldContinue, "unsafe commit already occurred → must log and continue")
-	assert.NoError(t, wrappedErr, "continuing must not return an error")
 }
 
 // TestHandleSkipTrigger_PublishesEventAtomicallyWithStateAdvance verifies the

--- a/backend/internal/todoist/provider_dismissal_test.go
+++ b/backend/internal/todoist/provider_dismissal_test.go
@@ -1059,21 +1059,16 @@ func TestDecideFatalErrorPolicy_LogsAndContinuesAfterUnsafe(t *testing.T) {
 	assert.NoError(t, wrappedErr, "continuing must not return an error")
 }
 
-// TestHandleSkipTrigger_FailureDoesNotReturnErrorAndSetsUnsafe is a guardrail
-// test: handleSkipTrigger intentionally retains log-and-continue semantics
-// on DB failure because it commits non-idempotent side effects (contact_by
-// advancement). Critically, it must set Unsafe: true even on partial
-// failures, because UpdateContactBy may already have fired before the
-// failure, advancing contact_by in the DB.
-//
-// TODO(#265): when the deferred transactional refactor lands, this
-// guardrail test should be updated or removed to reflect the new semantics.
-func TestHandleSkipTrigger_FailureDoesNotReturnErrorAndSetsUnsafe(t *testing.T) {
+// TestHandleSkipTrigger_PublishesEventAtomicallyWithStateAdvance verifies the
+// happy path: publish task.skipped + advance contact_by + update metadata
+// land atomically when handleSkipTrigger succeeds. This is a replacement
+// for the pre-atomic-tx guardrail that locked in log-and-continue.
+func TestHandleSkipTrigger_PublishesEventAtomicallyWithStateAdvance(t *testing.T) {
 	env, cleanup := setupDismissalTest(t)
 	defer cleanup()
 
-	contact, _ := createDismissalContact(t, env, "SkipGuard")
-	cadenceExtID := "td-skip-guard-" + uuid.New().String()[:8]
+	contact, _ := createDismissalContact(t, env, "SkipHappy")
+	cadenceExtID := "td-skip-happy-" + uuid.New().String()[:8]
 	task, err := env.contactTaskRepo.CreateContactTask(env.ctx, repository.CreateContactTaskRequest{
 		ContactID:      contact.ID,
 		Provider:       SourceName,
@@ -1084,13 +1079,145 @@ func TestHandleSkipTrigger_FailureDoesNotReturnErrorAndSetsUnsafe(t *testing.T) 
 	})
 	require.NoError(t, err)
 
+	item := SyncItem{
+		ID:        cadenceExtID,
+		UpdatedAt: "2026-04-01T12:00:00Z",
+	}
+
+	r := env.provider.handleSkipTrigger(env.ctx, item, task, contact, env.settings, env.accountID)
+
+	require.NoError(t, r.Err)
+	assert.True(t, r.Processed)
+	require.Len(t, r.Commands, 1, "exactly one item_add command expected")
+	assert.Equal(t, "item_add", r.Commands[0].Type)
+
+	// Bus recorded the envelope with the expected SourceID.
+	pubs := env.bus.Published()
+	require.Len(t, pubs, 1, "exactly one event should have been published")
+	expectedSourceID := task.ID.String() + ":" + item.UpdatedAt
+	assert.Equal(t, "todoist", pubs[0].Source)
+	assert.Equal(t, expectedSourceID, pubs[0].SourceID)
+	assert.Equal(t, events.KindTaskSkipped, pubs[0].Kind)
+
+	// contact_by advanced by one cadence period (monthly → 30 days).
+	reloaded, err := env.contactRepo.GetContact(env.ctx, contact.ID)
+	require.NoError(t, err)
+	require.NotNil(t, reloaded.ContactBy)
+	if contact.ContactBy != nil {
+		assert.True(t, reloaded.ContactBy.After(*contact.ContactBy),
+			"contact_by should advance past original")
+	}
+
+	// Task metadata contains pending_temp_id (matching the replacement
+	// item_add TempID) and synced_deadline.
+	taskReloaded, err := env.contactTaskRepo.GetContactTask(env.ctx, task.ID)
+	require.NoError(t, err)
+	pending, _ := taskReloaded.Metadata[MetadataKeyPendingTempID].(string)
+	assert.Equal(t, r.Commands[0].TempID, pending)
+	syncedDeadline, _ := taskReloaded.Metadata[MetadataKeySyncedDeadline].(string)
+	assert.NotEmpty(t, syncedDeadline)
+}
+
+// TestHandleSkipTrigger_DBFailureRollsBackEventAndState verifies that when
+// the in-tx UpdateContactByTx or UpdateContactTaskMetadataTx fails, no event
+// row is visible, contact_by stays unchanged, and no replacement command is
+// returned.
+func TestHandleSkipTrigger_DBFailureRollsBackEventAndState(t *testing.T) {
+	env, cleanup := setupDismissalTest(t)
+	defer cleanup()
+
+	contact, snap := createDismissalContact(t, env, "SkipFail")
+	cadenceExtID := "td-skip-fail-" + uuid.New().String()[:8]
+	task, err := env.contactTaskRepo.CreateContactTask(env.ctx, repository.CreateContactTaskRequest{
+		ContactID:      contact.ID,
+		Provider:       SourceName,
+		Kind:           TaskKindCadence,
+		ExternalTaskID: cadenceExtID,
+		State:          string(repository.ContactTaskStateManaged),
+		Metadata:       map[string]any{},
+	})
+	require.NoError(t, err)
+
+	// Cancelled context: tx.Begin / publish succeed? Actually pool.Begin
+	// with a cancelled ctx fails at ctx.Err() check. Either way the handler
+	// returns an error and everything rolls back.
 	badCtx := cancelledContext()
 
-	r := env.provider.handleSkipTrigger(badCtx, task, contact, env.settings, env.accountID)
+	item := SyncItem{ID: cadenceExtID, UpdatedAt: "2026-04-02T09:00:00Z"}
+	r := env.provider.handleSkipTrigger(badCtx, item, task, contact, env.settings, env.accountID)
 
-	// Behavior intentionally unchanged: never returns an error.
-	require.NoError(t, r.Err, "handleSkipTrigger must retain log-and-continue semantics on DB failure")
-	// CRUCIAL: Unsafe must still be true. UpdateContactBy may have advanced
-	// contact_by before the failure, so replay would double-advance.
-	assert.True(t, r.Unsafe, "skip trigger must report Unsafe=true even on partial failure")
+	require.Error(t, r.Err, "handleSkipTrigger must return an error under injected DB failure")
+	assert.False(t, r.Processed, "failed skip must not report Processed=true")
+	assert.Nil(t, r.Commands, "no replacement item_add must be returned when the tx rolls back")
+
+	// contact_by unchanged.
+	reloaded, err := env.contactRepo.GetContact(env.ctx, contact.ID)
+	require.NoError(t, err)
+	assertTimePtrEqual(t, snap.ContactBy, reloaded.ContactBy, "contact_by")
+
+	// Task metadata unchanged (no pending_temp_id inserted).
+	taskReloaded, err := env.contactTaskRepo.GetContactTask(env.ctx, task.ID)
+	require.NoError(t, err)
+	_, hasPending := taskReloaded.Metadata[MetadataKeyPendingTempID]
+	assert.False(t, hasPending, "pending_temp_id must not be set after rollback")
+}
+
+// TestHandleSkipTrigger_ReplayIsNoOp verifies the spec-mandated property
+// that "the former second skip ran twice on replay scenario is now
+// impossible". Invokes the handler twice with the same (task, UpdatedAt).
+// The second call hits the bus's duplicate-detection branch (env.ID=Nil),
+// returns Processed=true with no commands, and does NOT advance contact_by
+// a second time.
+func TestHandleSkipTrigger_ReplayIsNoOp(t *testing.T) {
+	env, cleanup := setupDismissalTest(t)
+	defer cleanup()
+
+	contact, _ := createDismissalContact(t, env, "SkipReplay")
+	cadenceExtID := "td-skip-replay-" + uuid.New().String()[:8]
+	task, err := env.contactTaskRepo.CreateContactTask(env.ctx, repository.CreateContactTaskRequest{
+		ContactID:      contact.ID,
+		Provider:       SourceName,
+		Kind:           TaskKindCadence,
+		ExternalTaskID: cadenceExtID,
+		State:          string(repository.ContactTaskStateManaged),
+		Metadata:       map[string]any{},
+	})
+	require.NoError(t, err)
+
+	item := SyncItem{ID: cadenceExtID, UpdatedAt: "2026-04-03T10:00:00Z"}
+
+	// First call — happy path.
+	r1 := env.provider.handleSkipTrigger(env.ctx, item, task, contact, env.settings, env.accountID)
+	require.NoError(t, r1.Err)
+	require.Len(t, r1.Commands, 1)
+
+	// Capture contact_by after the first advance.
+	after1, err := env.contactRepo.GetContact(env.ctx, contact.ID)
+	require.NoError(t, err)
+	require.NotNil(t, after1.ContactBy)
+
+	// Second call — busRecorder flips returnDuplicate to mimic the
+	// (source, source_id) unique collision that a real bus returns on
+	// replay. With the real bus in integration tests, env.ID=Nil is set
+	// by the bus itself; here we simulate it.
+	env.bus.mu.Lock()
+	env.bus.returnDuplicate = true
+	env.bus.mu.Unlock()
+
+	taskReloaded, err := env.contactTaskRepo.GetContactTask(env.ctx, task.ID)
+	require.NoError(t, err)
+	contactReloaded, err := env.contactRepo.GetContact(env.ctx, contact.ID)
+	require.NoError(t, err)
+
+	r2 := env.provider.handleSkipTrigger(env.ctx, item, taskReloaded, contactReloaded, env.settings, env.accountID)
+	require.NoError(t, r2.Err)
+	assert.True(t, r2.Processed)
+	assert.Nil(t, r2.Commands, "replay must NOT return a second item_add command")
+
+	// contact_by did NOT advance a second time.
+	after2, err := env.contactRepo.GetContact(env.ctx, contact.ID)
+	require.NoError(t, err)
+	require.NotNil(t, after2.ContactBy)
+	assert.True(t, after1.ContactBy.Equal(*after2.ContactBy),
+		"contact_by must not advance on replay (duplicate event)")
 }

--- a/backend/internal/todoist/provider_dismissal_test.go
+++ b/backend/internal/todoist/provider_dismissal_test.go
@@ -6,15 +6,19 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 
 	"personal-crm/backend/internal/accelerated"
 	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
 	"personal-crm/backend/internal/repository"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -51,12 +55,50 @@ func (r *permissiveRecorder) RecordInteraction(_ context.Context, _ repository.R
 	return &repository.Interaction{ID: uuid.New()}, nil
 }
 
+// busRecorder is a test double for eventPublisher. It records every
+// PublishTx call and optionally injects errors or duplicate (env.ID=Nil)
+// responses. Safe for concurrent use.
+type busRecorder struct {
+	mu              sync.Mutex
+	published       []*events.Envelope
+	err             error
+	returnDuplicate bool
+}
+
+func (b *busRecorder) PublishTx(_ context.Context, _ pgx.Tx, env *events.Envelope) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.err != nil {
+		return b.err
+	}
+	if b.returnDuplicate {
+		env.ID = uuid.Nil
+		return nil
+	}
+	env.ID = uuid.New()
+	// Copy envelope so later mutations by the handler don't race with the
+	// recorder's captured slice.
+	copied := *env
+	b.published = append(b.published, &copied)
+	return nil
+}
+
+func (b *busRecorder) Published() []*events.Envelope {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make([]*events.Envelope, len(b.published))
+	copy(out, b.published)
+	return out
+}
+
 type dismissalTestEnv struct {
 	ctx             context.Context
 	provider        *CadenceSyncProvider
 	contactRepo     *repository.ContactRepository
 	contactTaskRepo *repository.ContactTaskRepository
 	recorder        *countingRecorder
+	bus             *busRecorder
+	pool            *pgxpool.Pool
 	settings        Settings
 	accountID       string
 }
@@ -70,6 +112,8 @@ type providerTestEnv struct {
 	provider        *CadenceSyncProvider
 	contactRepo     *repository.ContactRepository
 	contactTaskRepo *repository.ContactTaskRepository
+	bus             *busRecorder
+	pool            *pgxpool.Pool
 	settings        Settings
 	accountID       string
 }
@@ -78,7 +122,7 @@ type providerTestEnv struct {
 // used by both setupDismissalTest and setupProviderTestPermissive. Takes the
 // recorder as a parameter so callers can pass either the strict countingRecorder
 // or the permissiveRecorder.
-func newProviderTestEnv(t *testing.T, recorder interactionRecorder) (*CadenceSyncProvider, *repository.ContactRepository, *repository.ContactTaskRepository, context.Context, Settings, string, func()) {
+func newProviderTestEnv(t *testing.T, recorder interactionRecorder) (*CadenceSyncProvider, *repository.ContactRepository, *repository.ContactTaskRepository, *busRecorder, *pgxpool.Pool, context.Context, Settings, string, func()) {
 	t.Helper()
 
 	databaseURL := os.Getenv("DATABASE_URL")
@@ -105,6 +149,7 @@ func newProviderTestEnv(t *testing.T, recorder interactionRecorder) (*CadenceSyn
 	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
 	cfg := config.TestConfig()
 
+	bus := &busRecorder{}
 	provider := NewCadenceSyncProvider(
 		nil, // oauthService: not consulted on this code path
 		contactTaskRepo,
@@ -112,6 +157,9 @@ func newProviderTestEnv(t *testing.T, recorder interactionRecorder) (*CadenceSyn
 		nil, // syncRepo: not consulted on this code path
 		cfg,
 		recorder,
+		bus,
+		database.Pool,
+		DefaultClientFactory,
 	)
 
 	settings := Settings{
@@ -123,7 +171,7 @@ func newProviderTestEnv(t *testing.T, recorder interactionRecorder) (*CadenceSyn
 	}
 	accountID := "test-account"
 
-	return provider, contactRepo, contactTaskRepo, ctx, settings, accountID, func() { database.Close() }
+	return provider, contactRepo, contactTaskRepo, bus, database.Pool, ctx, settings, accountID, func() { database.Close() }
 }
 
 // setupDismissalTest builds a CadenceSyncProvider wired to a real DB and a test
@@ -133,7 +181,7 @@ func setupDismissalTest(t *testing.T) (*dismissalTestEnv, func()) {
 	t.Helper()
 
 	recorder := &countingRecorder{t: t}
-	provider, contactRepo, contactTaskRepo, ctx, settings, accountID, cleanup := newProviderTestEnv(t, recorder)
+	provider, contactRepo, contactTaskRepo, bus, pool, ctx, settings, accountID, cleanup := newProviderTestEnv(t, recorder)
 
 	return &dismissalTestEnv{
 		ctx:             ctx,
@@ -141,6 +189,8 @@ func setupDismissalTest(t *testing.T) (*dismissalTestEnv, func()) {
 		contactRepo:     contactRepo,
 		contactTaskRepo: contactTaskRepo,
 		recorder:        recorder,
+		bus:             bus,
+		pool:            pool,
 		settings:        settings,
 		accountID:       accountID,
 	}, cleanup
@@ -154,13 +204,15 @@ func setupProviderTestPermissive(t *testing.T) (*providerTestEnv, func()) {
 	t.Helper()
 
 	recorder := &permissiveRecorder{}
-	provider, contactRepo, contactTaskRepo, ctx, settings, accountID, cleanup := newProviderTestEnv(t, recorder)
+	provider, contactRepo, contactTaskRepo, bus, pool, ctx, settings, accountID, cleanup := newProviderTestEnv(t, recorder)
 
 	return &providerTestEnv{
 		ctx:             ctx,
 		provider:        provider,
 		contactRepo:     contactRepo,
 		contactTaskRepo: contactTaskRepo,
+		bus:             bus,
+		pool:            pool,
 		settings:        settings,
 		accountID:       accountID,
 	}, cleanup

--- a/backend/internal/todoist/provider_dismissal_test.go
+++ b/backend/internal/todoist/provider_dismissal_test.go
@@ -1101,3 +1101,89 @@ func TestHandleSkipTrigger_ReplayIsNoOp(t *testing.T) {
 	assert.True(t, after1.ContactBy.Equal(*after2.ContactBy),
 		"contact_by must not advance on replay (duplicate event)")
 }
+
+// TestReconcileExistingTask_SkipDriftRecovery verifies the self-healing
+// branch: when pending_temp_id is set and differs from ExternalTaskID, the
+// reconciler emits item_close(old) + item_add(new) and persists the new
+// TempID in metadata.
+func TestReconcileExistingTask_SkipDriftRecovery(t *testing.T) {
+	env, cleanup := setupDismissalTest(t)
+	defer cleanup()
+
+	contact, _ := createDismissalContact(t, env, "SkipDrift")
+	cadenceExtID := "td-original-" + uuid.New().String()[:8]
+	origTempID := "temp-stale-" + uuid.New().String()[:8]
+	task, err := env.contactTaskRepo.CreateContactTask(env.ctx, repository.CreateContactTaskRequest{
+		ContactID:      contact.ID,
+		Provider:       SourceName,
+		Kind:           TaskKindCadence,
+		ExternalTaskID: cadenceExtID,
+		State:          string(repository.ContactTaskStateManaged),
+		Metadata: map[string]any{
+			MetadataKeyPendingTempID:  origTempID,
+			MetadataKeySyncedDeadline: "2027-03-15",
+		},
+	})
+	require.NoError(t, err)
+
+	currentDeadline := "2027-04-15"
+	cmds := env.provider.reconcileExistingTask(env.ctx, task, contact, env.settings, currentDeadline, false)
+
+	require.Len(t, cmds, 2, "skip-drift branch must emit item_close + item_add")
+	assert.Equal(t, "item_close", cmds[0].Type)
+	assert.Equal(t, cadenceExtID, cmds[0].Args["id"])
+	assert.Equal(t, "item_add", cmds[1].Type)
+
+	// Metadata pending_temp_id now matches the new item_add TempID.
+	reloaded, err := env.contactTaskRepo.GetContactTask(env.ctx, task.ID)
+	require.NoError(t, err)
+	newPending, _ := reloaded.Metadata[MetadataKeyPendingTempID].(string)
+	assert.Equal(t, cmds[1].TempID, newPending, "metadata pending_temp_id must be updated to the new TempID")
+	assert.NotEqual(t, origTempID, newPending, "new TempID must differ from the stale one")
+}
+
+// TestReconcileExistingTask_SkipDrift_DeferralSuppressesBranch verifies that
+// when deferSkipDrift=true the skip-drift branch does NOT fire, even when
+// the detection predicate matches. This is the round-7 deferral fix.
+//
+// synced_deadline matches currentDeadline so the non-drift happy path
+// doesn't emit any close+add commands either — leaving the skip-drift
+// branch as the only possible source of commands. With deferral true, no
+// commands should be emitted at all.
+func TestReconcileExistingTask_SkipDrift_DeferralSuppressesBranch(t *testing.T) {
+	env, cleanup := setupDismissalTest(t)
+	defer cleanup()
+
+	contact, _ := createDismissalContact(t, env, "SkipDriftDeferred")
+	cadenceExtID := "td-deferred-" + uuid.New().String()[:8]
+	origTempID := "temp-deferred-" + uuid.New().String()[:8]
+	syncedDeadline := "2027-04-15"
+	task, err := env.contactTaskRepo.CreateContactTask(env.ctx, repository.CreateContactTaskRequest{
+		ContactID:      contact.ID,
+		Provider:       SourceName,
+		Kind:           TaskKindCadence,
+		ExternalTaskID: cadenceExtID,
+		State:          string(repository.ContactTaskStateManaged),
+		Metadata: map[string]any{
+			MetadataKeyPendingTempID:  origTempID,
+			MetadataKeySyncedDeadline: syncedDeadline,
+		},
+	})
+	require.NoError(t, err)
+
+	cmds := env.provider.reconcileExistingTask(env.ctx, task, contact, env.settings, syncedDeadline, true)
+
+	// With deferSkipDrift=true the skip-drift branch is suppressed. Since
+	// synced_deadline == currentDeadline the non-drift happy path also
+	// emits no close+add, so the total command count is zero.
+	for _, c := range cmds {
+		assert.NotEqual(t, "item_close", c.Type, "deferral must suppress skip-drift item_close")
+		assert.NotEqual(t, "item_add", c.Type, "deferral must suppress skip-drift item_add")
+	}
+
+	// Metadata pending_temp_id unchanged (branch did not run).
+	reloaded, err := env.contactTaskRepo.GetContactTask(env.ctx, task.ID)
+	require.NoError(t, err)
+	pending, _ := reloaded.Metadata[MetadataKeyPendingTempID].(string)
+	assert.Equal(t, origTempID, pending, "pending_temp_id must be unchanged when deferral is set")
+}

--- a/backend/internal/todoist/provider_dismissal_test.go
+++ b/backend/internal/todoist/provider_dismissal_test.go
@@ -762,7 +762,7 @@ func TestProcessItems_AbortsOnFatalError(t *testing.T) {
 
 	badCtx := cancelledContext()
 
-	processed, commands, err := env.provider.processItems(
+	processed, commands, _, err := env.provider.processItems(
 		badCtx,
 		[]SyncItem{
 			{ID: "td-abort-" + uuid.New().String()[:8], Labels: []string{env.settings.LabelName}},
@@ -797,7 +797,7 @@ func TestProcessItems_SuccessfulDismissalReturnsItemClose(t *testing.T) {
 	externalID := "td-preserve-" + uuid.New().String()[:8]
 	_ = createFollowUpTask(t, env, contact.ID, externalID)
 
-	processed, commands, err := env.provider.processItems(
+	processed, commands, _, err := env.provider.processItems(
 		env.ctx,
 		[]SyncItem{
 			{
@@ -1145,7 +1145,7 @@ func TestReconcileExistingTask_SkipDriftRecovery(t *testing.T) {
 
 // TestReconcileExistingTask_SkipDrift_DeferralSuppressesBranch verifies that
 // when deferSkipDrift=true the skip-drift branch does NOT fire, even when
-// the detection predicate matches. This is the round-7 deferral fix.
+// the detection predicate matches.
 //
 // synced_deadline matches currentDeadline so the non-drift happy path
 // doesn't emit any close+add commands either — leaving the skip-drift

--- a/backend/internal/todoist/provider_dismissal_test.go
+++ b/backend/internal/todoist/provider_dismissal_test.go
@@ -42,19 +42,6 @@ func (r *countingRecorder) RecordInteraction(_ context.Context, _ repository.Rec
 	return &repository.Interaction{ID: uuid.New()}, nil
 }
 
-// permissiveRecorder records call counts without failing the test. Used by
-// tests that exercise code paths which legitimately call RecordInteraction
-// (e.g., handleTaskCompletion) where the test only cares about the caller's
-// return value, not whether the interaction succeeds.
-type permissiveRecorder struct {
-	count int
-}
-
-func (r *permissiveRecorder) RecordInteraction(_ context.Context, _ repository.RecordInteractionRequest) (*repository.Interaction, error) {
-	r.count++
-	return &repository.Interaction{ID: uuid.New()}, nil
-}
-
 // busRecorder is a test double for eventPublisher. It records every
 // PublishTx call and optionally injects errors or duplicate (env.ID=Nil)
 // responses. Safe for concurrent use.
@@ -103,25 +90,10 @@ type dismissalTestEnv struct {
 	accountID       string
 }
 
-// providerTestEnv is a lightweight variant of dismissalTestEnv used by tests
-// that need a permissive recorder (notably the handleTaskCompletion guardrail
-// test, where RecordInteraction is legitimately called during the handler's
-// normal flow).
-type providerTestEnv struct {
-	ctx             context.Context
-	provider        *CadenceSyncProvider
-	contactRepo     *repository.ContactRepository
-	contactTaskRepo *repository.ContactTaskRepository
-	bus             *busRecorder
-	pool            *pgxpool.Pool
-	settings        Settings
-	accountID       string
-}
-
 // newProviderTestEnv builds the shared DB + repos + provider infrastructure
-// used by both setupDismissalTest and setupProviderTestPermissive. Takes the
-// recorder as a parameter so callers can pass either the strict countingRecorder
-// or the permissiveRecorder.
+// used by setupDismissalTest. Takes the recorder as a parameter so callers
+// can pass the strict countingRecorder (the last surviving test double in
+// this file).
 func newProviderTestEnv(t *testing.T, recorder interactionRecorder) (*CadenceSyncProvider, *repository.ContactRepository, *repository.ContactTaskRepository, *busRecorder, *pgxpool.Pool, context.Context, Settings, string, func()) {
 	t.Helper()
 
@@ -189,28 +161,6 @@ func setupDismissalTest(t *testing.T) (*dismissalTestEnv, func()) {
 		contactRepo:     contactRepo,
 		contactTaskRepo: contactTaskRepo,
 		recorder:        recorder,
-		bus:             bus,
-		pool:            pool,
-		settings:        settings,
-		accountID:       accountID,
-	}, cleanup
-}
-
-// setupProviderTestPermissive builds a CadenceSyncProvider with a permissive
-// recorder that does not fail the test on RecordInteraction calls. Used by
-// tests that exercise handleTaskCompletion directly, since it calls
-// RecordInteraction as part of its normal flow.
-func setupProviderTestPermissive(t *testing.T) (*providerTestEnv, func()) {
-	t.Helper()
-
-	recorder := &permissiveRecorder{}
-	provider, contactRepo, contactTaskRepo, bus, pool, ctx, settings, accountID, cleanup := newProviderTestEnv(t, recorder)
-
-	return &providerTestEnv{
-		ctx:             ctx,
-		provider:        provider,
-		contactRepo:     contactRepo,
-		contactTaskRepo: contactTaskRepo,
 		bus:             bus,
 		pool:            pool,
 		settings:        settings,
@@ -912,32 +862,67 @@ func TestProcessItems_SuccessfulDismissalReturnsItemClose(t *testing.T) {
 	assert.Equal(t, externalID, commands[0].Args["id"])
 }
 
-// TestHandleTaskCompletion_StateUpdateFailureDoesNotReturnError is a
-// guardrail test: handleTaskCompletion intentionally retains log-and-continue
-// semantics on DB failure, because a fatal-error conversion would break the
-// state→interaction ordering invariant documented in the handler's comment.
-// If someone later changes this to return an error without addressing the
-// ordering, this test fails loudly.
-//
-// Uses setupProviderTestPermissive because handleTaskCompletion calls
-// RecordInteraction as part of its normal flow, which would trip the strict
-// countingRecorder.
-//
-// TODO(#265): when the deferred transactional refactor lands, this
-// guardrail test should be updated or removed to reflect the new semantics.
-func TestHandleTaskCompletion_StateUpdateFailureDoesNotReturnError(t *testing.T) {
-	env, cleanup := setupProviderTestPermissive(t)
+// TestHandleTaskCompletion_PublishesEventAtomicallyWithStateUpdate verifies
+// that on the happy path, handleTaskCompletion publishes a task.completed
+// event, transitions the row to 'completed', and commits both atomically.
+func TestHandleTaskCompletion_PublishesEventAtomicallyWithStateUpdate(t *testing.T) {
+	env, cleanup := setupDismissalTest(t)
 	defer cleanup()
 
-	// Create contact + managed cadence task.
 	cadenceStr := "monthly"
 	contact, err := env.contactRepo.CreateContact(env.ctx, repository.CreateContactRequest{
-		FullName: "CompletionGuard " + uuid.New().String()[:8],
+		FullName: "CompleteHappy " + uuid.New().String()[:8],
 		Cadence:  &cadenceStr,
 	})
 	require.NoError(t, err)
 
-	cadenceExtID := "td-cad-guard-" + uuid.New().String()[:8]
+	cadenceExtID := "td-cad-happy-" + uuid.New().String()[:8]
+	task, err := env.contactTaskRepo.CreateContactTask(env.ctx, repository.CreateContactTaskRequest{
+		ContactID:      contact.ID,
+		Provider:       SourceName,
+		Kind:           TaskKindCadence,
+		ExternalTaskID: cadenceExtID,
+		State:          string(repository.ContactTaskStateManaged),
+		Metadata:       map[string]any{},
+	})
+	require.NoError(t, err)
+
+	r := env.provider.handleTaskCompletion(env.ctx, SyncItem{
+		ID:      cadenceExtID,
+		Checked: true,
+	}, task, contact, env.settings, env.accountID)
+
+	require.NoError(t, r.Err)
+	assert.True(t, r.Processed)
+
+	// Task state is now 'completed'.
+	reloaded, err := env.contactTaskRepo.GetContactTask(env.ctx, task.ID)
+	require.NoError(t, err)
+	assert.Equal(t, repository.ContactTaskStateCompleted, reloaded.State)
+
+	// Exactly one event published with SourceID = task.ID.String().
+	pubs := env.bus.Published()
+	require.Len(t, pubs, 1)
+	assert.Equal(t, "todoist", pubs[0].Source)
+	assert.Equal(t, task.ID.String(), pubs[0].SourceID)
+	assert.Equal(t, events.KindTaskCompleted, pubs[0].Kind)
+}
+
+// TestHandleTaskCompletion_DBFailureRollsBackEventAndState verifies that a
+// cancelled context causes both the event publish and the state update to
+// roll back — the row stays 'managed'.
+func TestHandleTaskCompletion_DBFailureRollsBackEventAndState(t *testing.T) {
+	env, cleanup := setupDismissalTest(t)
+	defer cleanup()
+
+	cadenceStr := "monthly"
+	contact, err := env.contactRepo.CreateContact(env.ctx, repository.CreateContactRequest{
+		FullName: "CompleteFail " + uuid.New().String()[:8],
+		Cadence:  &cadenceStr,
+	})
+	require.NoError(t, err)
+
+	cadenceExtID := "td-cad-fail-" + uuid.New().String()[:8]
 	task, err := env.contactTaskRepo.CreateContactTask(env.ctx, repository.CreateContactTaskRequest{
 		ContactID:      contact.ID,
 		Provider:       SourceName,
@@ -949,15 +934,18 @@ func TestHandleTaskCompletion_StateUpdateFailureDoesNotReturnError(t *testing.T)
 	require.NoError(t, err)
 
 	badCtx := cancelledContext()
-
 	r := env.provider.handleTaskCompletion(badCtx, SyncItem{
 		ID:      cadenceExtID,
 		Checked: true,
 	}, task, contact, env.settings, env.accountID)
 
-	// Behavior intentionally unchanged: never returns an error.
-	require.NoError(t, r.Err, "handleTaskCompletion must retain log-and-continue semantics on DB failure")
-	assert.False(t, r.Unsafe, "completion's state transition is replay-safe")
+	require.Error(t, r.Err, "handleTaskCompletion must return an error under injected DB failure")
+	assert.False(t, r.Processed)
+
+	// Task state still 'managed' — rollback.
+	reloaded, err := env.contactTaskRepo.GetContactTask(env.ctx, task.ID)
+	require.NoError(t, err)
+	assert.Equal(t, repository.ContactTaskStateManaged, reloaded.State)
 }
 
 // TestHandleRecurringDetection_StateUpdateErrorPropagates verifies that a DB

--- a/backend/internal/todoist/provider_dismissal_test.go
+++ b/backend/internal/todoist/provider_dismissal_test.go
@@ -623,17 +623,18 @@ func assertDismissedAndInvariants(t *testing.T, env *dismissalTestEnv, contactID
 }
 
 // ============================================================================
-// Error-propagation regression tests (Option C / #264)
+// Error-propagation and atomic-transaction regression tests
 // ============================================================================
 //
-// These tests exercise the fatal-error propagation paths added in Step 2 of
-// the todoist-processitem-error-propagation plan. They use a cancelled
-// context to force repository calls to fail deterministically with
-// context.Canceled (more reliable than closing the pool mid-test).
+// These tests exercise fatal-error propagation and atomic-tx rollback in
+// the Todoist handlers. They use a cancelled context to force repository
+// calls to fail deterministically with context.Canceled (more reliable
+// than closing the pool mid-test).
 //
 // The tests call handlers directly, not through processItem, because
-// processItem's GetContactTaskByExternalID lookup would fail first under the
-// cancelled-context strategy, masking the target handler's error path.
+// processItem's GetContactTaskByExternalID lookup would fail first under
+// the cancelled-context strategy, masking the target handler's error
+// path.
 
 // TestHandleFollowUpDismissal_StateUpdateErrorPropagates verifies that a DB
 // failure in UpdateContactTaskState is propagated via processItemResult.Err

--- a/backend/internal/todoist/provider_outreach_close_test.go
+++ b/backend/internal/todoist/provider_outreach_close_test.go
@@ -67,7 +67,7 @@ func TestReconcile_CloseCadenceTaskOnOutreachWithPendingFollowUp(t *testing.T) {
 	require.NoError(t, env.contactRepo.UpdateContactOutreachAt(env.ctx, contact.ID, newOutreach, true))
 
 	// Run reconciler.
-	commands := env.provider.reconcileContactTasks(env.ctx, nil, env.settings, env.accountID)
+	commands := env.provider.reconcileContactTasks(env.ctx, nil, env.settings, env.accountID, false)
 
 	// Assert: item_close command for the cadence task.
 	var closedIDs []string
@@ -121,7 +121,7 @@ func TestReconcile_CadenceTaskUnchangedWhenNoNewOutreach(t *testing.T) {
 	})
 
 	// No change to last_outreach_at — reconciler should not close the task.
-	commands := env.provider.reconcileContactTasks(env.ctx, nil, env.settings, env.accountID)
+	commands := env.provider.reconcileContactTasks(env.ctx, nil, env.settings, env.accountID, false)
 
 	// Assert: no item_close command for the cadence task.
 	for _, cmd := range commands {
@@ -159,7 +159,7 @@ func TestReconcile_OutreachClosesWithoutPendingFollowUp(t *testing.T) {
 	require.NoError(t, env.contactRepo.UpdateContactOutreachAt(env.ctx, contact.ID, newOutreach, true))
 
 	// First reconcile: cadence task should be closed.
-	commands := env.provider.reconcileContactTasks(env.ctx, nil, env.settings, env.accountID)
+	commands := env.provider.reconcileContactTasks(env.ctx, nil, env.settings, env.accountID, false)
 
 	var closedIDs []string
 	for _, cmd := range commands {
@@ -171,7 +171,7 @@ func TestReconcile_OutreachClosesWithoutPendingFollowUp(t *testing.T) {
 
 	// Second reconcile: completed task is cleaned up, new cadence task created
 	// (no follow-up gate blocks recreation).
-	commands2 := env.provider.reconcileContactTasks(env.ctx, nil, env.settings, env.accountID)
+	commands2 := env.provider.reconcileContactTasks(env.ctx, nil, env.settings, env.accountID, false)
 
 	var addCount int
 	for _, cmd := range commands2 {
@@ -206,7 +206,7 @@ func TestReconcile_LegacyTaskBackfillsWithoutClosing(t *testing.T) {
 	createFollowUpTask(t, env, contact.ID, followUpExtID)
 
 	// First reconcile: should backfill synced_last_outreach_at without closing.
-	commands := env.provider.reconcileContactTasks(env.ctx, nil, env.settings, env.accountID)
+	commands := env.provider.reconcileContactTasks(env.ctx, nil, env.settings, env.accountID, false)
 
 	// Assert: no item_close for the cadence task.
 	for _, cmd := range commands {
@@ -230,7 +230,7 @@ func TestReconcile_LegacyTaskBackfillsWithoutClosing(t *testing.T) {
 	newOutreach := accelerated.GetCurrentTime().UTC().Truncate(time.Second)
 	require.NoError(t, env.contactRepo.UpdateContactOutreachAt(env.ctx, contact.ID, newOutreach, true))
 
-	commands2 := env.provider.reconcileContactTasks(env.ctx, nil, env.settings, env.accountID)
+	commands2 := env.provider.reconcileContactTasks(env.ctx, nil, env.settings, env.accountID, false)
 
 	var closedIDs []string
 	for _, cmd := range commands2 {

--- a/backend/internal/todoist/provider_outreach_close_test.go
+++ b/backend/internal/todoist/provider_outreach_close_test.go
@@ -100,8 +100,8 @@ func TestReconcile_CloseCadenceTaskOnOutreachWithPendingFollowUp(t *testing.T) {
 	assert.Equal(t, repository.ContactTaskStateManaged, reloadedFollowUp.State,
 		"follow-up task must remain managed")
 
-	// Assert: no interactions recorded.
-	assert.Equal(t, 0, env.recorder.count, "outreach detection must not record interactions")
+	// Assert: no events published (outreach detection path).
+	assert.Empty(t, env.bus.Published(), "outreach detection must not publish events")
 }
 
 // TestReconcile_CadenceTaskUnchangedWhenNoNewOutreach is the negative case:
@@ -282,8 +282,8 @@ func TestReconcile_OutreachDetectionStateFailureSkipsClose(t *testing.T) {
 	assert.Equal(t, repository.ContactTaskStateManaged, reloadedTask.State,
 		"cadence task must remain managed when state update fails")
 
-	// Assert: no interactions recorded.
-	assert.Equal(t, 0, env.recorder.count, "outreach detection must not record interactions")
+	// Assert: no events published (outreach detection path).
+	assert.Empty(t, env.bus.Published(), "outreach detection must not publish events")
 }
 
 // TestCloseOnOutreach_PendingTempID verifies that when outreach is detected but

--- a/backend/tests/sole_writer_static_test.go
+++ b/backend/tests/sole_writer_static_test.go
@@ -63,6 +63,7 @@ var cadenceWritingSymbols = map[string]struct{}{
 	"UpdateContactCadenceForward":       {},
 	"UpdateContactCadenceUnconditional": {},
 	"UpdateContactBy":                   {},
+	"UpdateContactByTx":                 {},
 	// Include CreateContact + UpdateContact so a future regression
 	// that adds a cadence column to either query is caught. Selector
 	// matching alone would flag every service-layer wrapper caller;
@@ -104,6 +105,7 @@ var allowedCallSites = map[string]string{
 	"internal/repository/contact.go:CreateContact":                     "initial row seed carve-out",
 	"internal/repository/contact.go:UpdateContact":                     "profile-only wrapper (post-cutover cadence columns not written)",
 	"internal/repository/contact.go:UpdateContactBy":                   "wrapper for Todoist carve-outs",
+	"internal/repository/contact.go:UpdateContactByTx":                 "tx-threaded wrapper for Todoist carve-outs",
 	"internal/repository/contact.go:UpdateContactLastContacted":        "legacy wrapper (no production callers post-cutover)",
 	"internal/repository/contact.go:UpdateContactLastContactedIfLater": "legacy wrapper (no production callers post-cutover)",
 	"internal/repository/contact.go:UpdateContactOutreachAt":           "legacy wrapper (no production callers post-cutover)",


### PR DESCRIPTION
## Summary

Twelfth PR of the event-bus foundation (#180). Migrates the Todoist `CadenceSyncProvider` from directly calling `ContactService.RecordInteraction` to publishing typed events via `events.Bus.PublishTx`. Closes #265 by wrapping the three non-atomic sites in `pgx.Tx` that commits the local state change and the event publish together.

**Atomic publisher migration:**
- `handleTaskCompletion` — single tx: publish `task.completed` → update state → commit. Action tasks emit `Direction=mutual`, cadence/follow_up emit `Direction=outbound`.
- `handleSkipTrigger` — single tx: publish `task.skipped` → advance `contact_by` → update metadata → commit. `SourceID = <task.ID>:<item.UpdatedAt>` (stable internal uuid + UpdatedAt suffix).
- `tryRecoverPendingTempID` — single tx: update `external_task_id` + clear `pending_temp_id` → commit. Guard broadened from `pending_temp_id == ExternalTaskID` to `pending_temp_id != ""` so post-rollback state shapes also recover.
- `processTempIDMappings` — per-task atomic tx; returns `rolledBack` flag surfaced to `Sync`.

**Rollback-aware reconcile deferral (Decision 16 / round-7 option 2):**
- When `processTempIDMappings` rolls back or `tryRecoverPendingTempID` attempted-but-failed, `Sync` forces `deferSkipDrift=true` for `reconcileContactTasks`. This prevents the skip-drift recovery branch from emitting a duplicate `item_add` against an already-created remote task.
- Next tick converges via `tryRecoverPendingTempID` finalizing against the real item in `syncResp.Items`.

**Removed infrastructure:**
- `processItemResult.Unsafe` field + `processItems.replayCommittedUnsafe` tracking + `decideFatalErrorPolicy` helper — atomic handlers make them unnecessary.
- `CadenceSyncProvider.interactionRecorder` field + constructor parameter — no longer used after the migration.
- Two guardrail tests (`TestHandleTaskCompletion_StateUpdateFailureDoesNotReturnError`, `TestHandleSkipTrigger_FailureDoesNotReturnErrorAndSetsUnsafe`) replaced by atomic-tx regression tests.

**Injection seams for testing:**
- `eventPublisher`, `contactTaskWriter`, `contactWriter`, `oauthTokenProvider` interfaces + `ClientFactory` field.
- `Makefile` — `test-integration-fast` and `test-integration` now include `./internal/todoist/...`.

## Test plan

- [x] `make test` green (backend unit + integration + frontend)
- [x] `make test-e2e-diff` green (73/73)
- [x] `make lint` clean
- [x] 13 new tests covering atomic-tx rollback, replay dedup, skip-drift recovery, deferral suppression, end-to-end `Sync(...)` flow with scripted mock Client + stub OAuth provider
- [x] Iterative Codex review (4 rounds) — all findings addressed; final PASS

## Key decisions

- Per-item tx scope (not per-batch) — pool-friendly; matches PR 10's publisher pattern
- No mode flag — unconditional cutover, rollback via `git revert`
- `SourceID` uses internal `contact_task.id` (not `ExternalTaskID`) — stable across `tryRecoverPendingTempID`'s temp→real swap
- `closeOnOutreach` unchanged — out of scope per spec §3.4.5 (no event emitted)

Spec: `.ai/spec/event-bus-foundation.md` §3.4.5, §4, §5 PR 11
Plan: `.ai/log/plan/event-bus-foundation-pr11-todoist-migration.md`

Closes #265.