### PR TITLE
feat(contacts): rename Last Contact column to Last response (PR-A)

### DIFF
--- a/backend/internal/api/handlers/contact.go
+++ b/backend/internal/api/handlers/contact.go
@@ -150,7 +150,7 @@ type ListContactsQuery struct {
 	Page           int    `form:"page" validate:"omitempty,min=1" example:"1"`
 	Limit          int    `form:"limit" validate:"omitempty,min=1,max=1000" example:"20"`
 	Search         string `form:"search" validate:"omitempty,max=255" example:"john"`
-	Sort           string `form:"sort" validate:"omitempty,oneof=name location birthday last_contacted contact_by cadence" example:"name"`
+	Sort           string `form:"sort" validate:"omitempty,oneof=name location birthday last_contacted last_response_at contact_by cadence" example:"name"`
 	Order          string `form:"order" validate:"omitempty,oneof=asc desc" example:"asc"`
 	IDsOnly        bool   `form:"ids_only" example:"false"`
 	CadenceFilter  string `form:"cadence_filter" validate:"omitempty,oneof=has_cadence no_cadence" example:"has_cadence"`
@@ -372,7 +372,7 @@ func (h *ContactHandler) GetContact(c *gin.Context) {
 // @Param page query int false "Page number" default(1) minimum(1)
 // @Param limit query int false "Items per page" default(20) minimum(1) maximum(100)
 // @Param search query string false "Search term (name or contact methods)" maxlength(255)
-// @Param sort query string false "Sort by field" Enums(name, location, birthday, last_contacted) default("")
+// @Param sort query string false "Sort by field" Enums(name, location, birthday, last_contacted, last_response_at, contact_by, cadence) default("")
 // @Param order query string false "Sort order" Enums(asc, desc) default("asc")
 // @Param ids_only query bool false "Return only contact IDs (for navigation)" default(false)
 // @Success 200 {object} api.APIResponse{data=[]ContactResponse,meta=api.Meta} "Contacts retrieved successfully"

--- a/backend/internal/db/contact.sql.go
+++ b/backend/internal/db/contact.sql.go
@@ -358,6 +358,8 @@ ORDER BY
   CASE WHEN $3 = 'birthday' AND $4 = 'desc' THEN birthday END DESC NULLS LAST,
   CASE WHEN $3 = 'last_contacted' AND $4 = 'asc' THEN last_contacted END ASC NULLS LAST,
   CASE WHEN $3 = 'last_contacted' AND $4 = 'desc' THEN last_contacted END DESC NULLS LAST,
+  CASE WHEN $3 = 'last_response_at' AND $4 = 'asc' THEN last_response_at END ASC NULLS LAST,
+  CASE WHEN $3 = 'last_response_at' AND $4 = 'desc' THEN last_response_at END DESC NULLS LAST,
   CASE WHEN $3 = 'contact_by' AND $4 = 'asc' THEN contact_by END ASC NULLS LAST,
   CASE WHEN $3 = 'contact_by' AND $4 = 'desc' THEN contact_by END DESC NULLS LAST,
   -- Cadence sort by frequency: weekly=1 (most frequent) to annual=6 (least frequent), null=7
@@ -485,6 +487,8 @@ ORDER BY
   CASE WHEN $3 = 'birthday' AND $4 = 'desc' THEN birthday END DESC NULLS LAST,
   CASE WHEN $3 = 'last_contacted' AND $4 = 'asc' THEN last_contacted END ASC NULLS LAST,
   CASE WHEN $3 = 'last_contacted' AND $4 = 'desc' THEN last_contacted END DESC NULLS LAST,
+  CASE WHEN $3 = 'last_response_at' AND $4 = 'asc' THEN last_response_at END ASC NULLS LAST,
+  CASE WHEN $3 = 'last_response_at' AND $4 = 'desc' THEN last_response_at END DESC NULLS LAST,
   CASE WHEN $3 = 'contact_by' AND $4 = 'asc' THEN contact_by END ASC NULLS LAST,
   CASE WHEN $3 = 'contact_by' AND $4 = 'desc' THEN contact_by END DESC NULLS LAST,
   -- Cadence sort by frequency: weekly=1 (most frequent) to annual=6 (least frequent), null=7
@@ -768,6 +772,8 @@ ORDER BY
   CASE WHEN $4 = 'birthday' AND $5 = 'desc' THEN c.birthday END DESC NULLS LAST,
   CASE WHEN $4 = 'last_contacted' AND $5 = 'asc' THEN c.last_contacted END ASC NULLS LAST,
   CASE WHEN $4 = 'last_contacted' AND $5 = 'desc' THEN c.last_contacted END DESC NULLS LAST,
+  CASE WHEN $4 = 'last_response_at' AND $5 = 'asc' THEN c.last_response_at END ASC NULLS LAST,
+  CASE WHEN $4 = 'last_response_at' AND $5 = 'desc' THEN c.last_response_at END DESC NULLS LAST,
   CASE WHEN $4 = 'contact_by' AND $5 = 'asc' THEN c.contact_by END ASC NULLS LAST,
   CASE WHEN $4 = 'contact_by' AND $5 = 'desc' THEN c.contact_by END DESC NULLS LAST,
   -- Cadence sort by frequency: weekly=1 (most frequent) to annual=6 (least frequent), null=7
@@ -912,6 +918,8 @@ ORDER BY
   CASE WHEN $4 = 'birthday' AND $5 = 'desc' THEN c.birthday END DESC NULLS LAST,
   CASE WHEN $4 = 'last_contacted' AND $5 = 'asc' THEN c.last_contacted END ASC NULLS LAST,
   CASE WHEN $4 = 'last_contacted' AND $5 = 'desc' THEN c.last_contacted END DESC NULLS LAST,
+  CASE WHEN $4 = 'last_response_at' AND $5 = 'asc' THEN c.last_response_at END ASC NULLS LAST,
+  CASE WHEN $4 = 'last_response_at' AND $5 = 'desc' THEN c.last_response_at END DESC NULLS LAST,
   CASE WHEN $4 = 'contact_by' AND $5 = 'asc' THEN c.contact_by END ASC NULLS LAST,
   CASE WHEN $4 = 'contact_by' AND $5 = 'desc' THEN c.contact_by END DESC NULLS LAST,
   -- Cadence sort by frequency: weekly=1 (most frequent) to annual=6 (least frequent), null=7

--- a/backend/internal/db/queries/contact.sql
+++ b/backend/internal/db/queries/contact.sql
@@ -36,6 +36,8 @@ ORDER BY
   CASE WHEN sqlc.arg(sort_field) = 'birthday' AND sqlc.arg(sort_order) = 'desc' THEN birthday END DESC NULLS LAST,
   CASE WHEN sqlc.arg(sort_field) = 'last_contacted' AND sqlc.arg(sort_order) = 'asc' THEN last_contacted END ASC NULLS LAST,
   CASE WHEN sqlc.arg(sort_field) = 'last_contacted' AND sqlc.arg(sort_order) = 'desc' THEN last_contacted END DESC NULLS LAST,
+  CASE WHEN sqlc.arg(sort_field) = 'last_response_at' AND sqlc.arg(sort_order) = 'asc' THEN last_response_at END ASC NULLS LAST,
+  CASE WHEN sqlc.arg(sort_field) = 'last_response_at' AND sqlc.arg(sort_order) = 'desc' THEN last_response_at END DESC NULLS LAST,
   CASE WHEN sqlc.arg(sort_field) = 'contact_by' AND sqlc.arg(sort_order) = 'asc' THEN contact_by END ASC NULLS LAST,
   CASE WHEN sqlc.arg(sort_field) = 'contact_by' AND sqlc.arg(sort_order) = 'desc' THEN contact_by END DESC NULLS LAST,
   -- Cadence sort by frequency: weekly=1 (most frequent) to annual=6 (least frequent), null=7
@@ -95,6 +97,8 @@ ORDER BY
   CASE WHEN sqlc.arg(sort_field) = 'birthday' AND sqlc.arg(sort_order) = 'desc' THEN c.birthday END DESC NULLS LAST,
   CASE WHEN sqlc.arg(sort_field) = 'last_contacted' AND sqlc.arg(sort_order) = 'asc' THEN c.last_contacted END ASC NULLS LAST,
   CASE WHEN sqlc.arg(sort_field) = 'last_contacted' AND sqlc.arg(sort_order) = 'desc' THEN c.last_contacted END DESC NULLS LAST,
+  CASE WHEN sqlc.arg(sort_field) = 'last_response_at' AND sqlc.arg(sort_order) = 'asc' THEN c.last_response_at END ASC NULLS LAST,
+  CASE WHEN sqlc.arg(sort_field) = 'last_response_at' AND sqlc.arg(sort_order) = 'desc' THEN c.last_response_at END DESC NULLS LAST,
   CASE WHEN sqlc.arg(sort_field) = 'contact_by' AND sqlc.arg(sort_order) = 'asc' THEN c.contact_by END ASC NULLS LAST,
   CASE WHEN sqlc.arg(sort_field) = 'contact_by' AND sqlc.arg(sort_order) = 'desc' THEN c.contact_by END DESC NULLS LAST,
   -- Cadence sort by frequency: weekly=1 (most frequent) to annual=6 (least frequent), null=7
@@ -384,6 +388,8 @@ ORDER BY
   CASE WHEN sqlc.arg(sort_field) = 'birthday' AND sqlc.arg(sort_order) = 'desc' THEN birthday END DESC NULLS LAST,
   CASE WHEN sqlc.arg(sort_field) = 'last_contacted' AND sqlc.arg(sort_order) = 'asc' THEN last_contacted END ASC NULLS LAST,
   CASE WHEN sqlc.arg(sort_field) = 'last_contacted' AND sqlc.arg(sort_order) = 'desc' THEN last_contacted END DESC NULLS LAST,
+  CASE WHEN sqlc.arg(sort_field) = 'last_response_at' AND sqlc.arg(sort_order) = 'asc' THEN last_response_at END ASC NULLS LAST,
+  CASE WHEN sqlc.arg(sort_field) = 'last_response_at' AND sqlc.arg(sort_order) = 'desc' THEN last_response_at END DESC NULLS LAST,
   CASE WHEN sqlc.arg(sort_field) = 'contact_by' AND sqlc.arg(sort_order) = 'asc' THEN contact_by END ASC NULLS LAST,
   CASE WHEN sqlc.arg(sort_field) = 'contact_by' AND sqlc.arg(sort_order) = 'desc' THEN contact_by END DESC NULLS LAST,
   -- Cadence sort by frequency: weekly=1 (most frequent) to annual=6 (least frequent), null=7
@@ -442,6 +448,8 @@ ORDER BY
   CASE WHEN sqlc.arg(sort_field) = 'birthday' AND sqlc.arg(sort_order) = 'desc' THEN c.birthday END DESC NULLS LAST,
   CASE WHEN sqlc.arg(sort_field) = 'last_contacted' AND sqlc.arg(sort_order) = 'asc' THEN c.last_contacted END ASC NULLS LAST,
   CASE WHEN sqlc.arg(sort_field) = 'last_contacted' AND sqlc.arg(sort_order) = 'desc' THEN c.last_contacted END DESC NULLS LAST,
+  CASE WHEN sqlc.arg(sort_field) = 'last_response_at' AND sqlc.arg(sort_order) = 'asc' THEN c.last_response_at END ASC NULLS LAST,
+  CASE WHEN sqlc.arg(sort_field) = 'last_response_at' AND sqlc.arg(sort_order) = 'desc' THEN c.last_response_at END DESC NULLS LAST,
   CASE WHEN sqlc.arg(sort_field) = 'contact_by' AND sqlc.arg(sort_order) = 'asc' THEN c.contact_by END ASC NULLS LAST,
   CASE WHEN sqlc.arg(sort_field) = 'contact_by' AND sqlc.arg(sort_order) = 'desc' THEN c.contact_by END DESC NULLS LAST,
   -- Cadence sort by frequency: weekly=1 (most frequent) to annual=6 (least frequent), null=7

--- a/backend/tests/api/contact_sort_test.go
+++ b/backend/tests/api/contact_sort_test.go
@@ -14,7 +14,7 @@ import (
 	"personal-crm/backend/internal/api/handlers"
 	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/db"
-	_ "personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/repository"
 	_ "personal-crm/backend/internal/service"
 
 	"github.com/gin-gonic/gin"
@@ -46,6 +46,8 @@ func setupContactSortTestRouter(t *testing.T) (*gin.Engine, func()) {
 	cfg := &config.Config{River: config.RiverConfig{WorkerConcurrency: 1}}
 	manualHandler, contactService := mustBuildManualHandlerForTest(t, ctx, database, cfg)
 	contactHandler := handlers.NewContactHandler(contactService, manualHandler)
+	interactionRepo := repository.NewInteractionRepository(database.Queries)
+	interactionHandler := handlers.NewInteractionHandler(interactionRepo, manualHandler)
 
 	router := gin.New()
 	router.Use(api.RequestIDMiddleware())
@@ -60,6 +62,7 @@ func setupContactSortTestRouter(t *testing.T) (*gin.Engine, func()) {
 		contacts.PUT("/:id", contactHandler.UpdateContact)
 		contacts.DELETE("/:id", contactHandler.DeleteContact)
 		contacts.PATCH("/:id/last-contacted", contactHandler.UpdateContactLastContacted)
+		contacts.POST("/:id/interactions", interactionHandler.CreateInteraction)
 	}
 
 	cleanup := func() {
@@ -112,6 +115,18 @@ func (h *sortTestHelper) markContacted(id, date string) {
 	w := httptest.NewRecorder()
 	h.router.ServeHTTP(w, req)
 	require.Equal(h.t, http.StatusOK, w.Code)
+}
+
+// recordInteraction posts a directional interaction so that direction-aware
+// timestamp columns (last_response_at, last_outreach_at) can be seeded.
+// direction must be one of: "outbound", "inbound", "mutual".
+func (h *sortTestHelper) recordInteraction(id, direction, date string) {
+	body := fmt.Sprintf(`{"direction": "%s", "occurred_at": "%s"}`, direction, date)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/contacts/"+id+"/interactions", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.router.ServeHTTP(w, req)
+	require.Equal(h.t, http.StatusCreated, w.Code)
 }
 
 func (h *sortTestHelper) deleteContact(id string) {
@@ -307,5 +322,100 @@ func TestContactSort_ContactBy(t *testing.T) {
 		router.ServeHTTP(w, req)
 
 		assert.Equal(t, http.StatusOK, w.Code)
+	})
+}
+
+func TestContactSort_LastResponseAtNullsLast(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	router, cleanup := setupContactSortTestRouter(t)
+	defer cleanup()
+
+	h := &sortTestHelper{router: router, t: t}
+
+	t.Run("last_response_at descending sorts most recent first", func(t *testing.T) {
+		// Per-subtest unique prefix so trigram matching from prior runs / sibling
+		// subtests doesn't leak across t.Run blocks (shared DB).
+		prefix := "SortLRAD"
+		idOld := h.createContact(prefix + " Old Test")
+		idRecent := h.createContact(prefix + " Recent Test")
+		idNull := h.createContact(prefix + " Null Test")
+		defer h.deleteContact(idOld)
+		defer h.deleteContact(idRecent)
+		defer h.deleteContact(idNull)
+
+		// Inbound interaction bumps last_response_at (and last_contacted, but we
+		// only assert ordering on last_response_at).
+		h.recordInteraction(idOld, "inbound", "2024-01-01")
+		h.recordInteraction(idRecent, "inbound", "2025-06-01")
+		// idNull intentionally has no interaction → last_response_at IS NULL.
+
+		resp := h.getIDsResponse("/api/v1/contacts?ids_only=true&search=" + prefix + "&sort=last_response_at&order=desc")
+
+		posRecent := h.findPosition(resp.IDs, idRecent)
+		posOld := h.findPosition(resp.IDs, idOld)
+		posNull := h.findPosition(resp.IDs, idNull)
+
+		assert.NotEqual(t, -1, posRecent, "Recent should be in results")
+		assert.NotEqual(t, -1, posOld, "Old should be in results")
+		assert.NotEqual(t, -1, posNull, "Null should be in results")
+		assert.Less(t, posRecent, posOld, "Recent should come before old in desc order")
+		assert.Less(t, posOld, posNull, "Non-null should come before null (NULLS LAST) in desc order")
+	})
+
+	t.Run("last_response_at ascending sorts oldest first NULLS LAST", func(t *testing.T) {
+		prefix := "SortLRAA"
+		idOld := h.createContact(prefix + " Old Test")
+		idRecent := h.createContact(prefix + " Recent Test")
+		idNull := h.createContact(prefix + " Null Test")
+		defer h.deleteContact(idOld)
+		defer h.deleteContact(idRecent)
+		defer h.deleteContact(idNull)
+
+		h.recordInteraction(idOld, "inbound", "2024-01-01")
+		h.recordInteraction(idRecent, "inbound", "2025-06-01")
+
+		resp := h.getIDsResponse("/api/v1/contacts?ids_only=true&search=" + prefix + "&sort=last_response_at&order=asc")
+
+		posOld := h.findPosition(resp.IDs, idOld)
+		posRecent := h.findPosition(resp.IDs, idRecent)
+		posNull := h.findPosition(resp.IDs, idNull)
+
+		assert.NotEqual(t, -1, posOld, "Old should be in results")
+		assert.NotEqual(t, -1, posRecent, "Recent should be in results")
+		assert.NotEqual(t, -1, posNull, "Null should be in results")
+		assert.Less(t, posOld, posRecent, "Old should come before recent in asc order")
+		assert.Less(t, posRecent, posNull, "Non-null should come before null (NULLS LAST) in asc order")
+	})
+
+	t.Run("last_response_at sort is accepted by API validation", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/contacts?sort=last_response_at&order=desc", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("legacy last_contacted sort still accepted", func(t *testing.T) {
+		// Decision 2 of the plan: keep last_contacted as a valid sort value on the
+		// API even though no UI surface emits it. Regression-guard for any
+		// external API caller that still passes the legacy field.
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/contacts?sort=last_contacted&order=desc", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("unknown sort field rejected with 400", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/contacts?sort=bogus&order=desc", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
 	})
 }

--- a/backend/tests/api/contact_sort_test.go
+++ b/backend/tests/api/contact_sort_test.go
@@ -157,6 +157,32 @@ func (h *sortTestHelper) getIDsResponse(url string) ContactIDsResponse {
 	return resp
 }
 
+// getListResponseIDs requests the full contact list (no ids_only) so the
+// (Search)ContactsSorted SQL paths are exercised, and returns the resulting
+// contact IDs in response order.
+func (h *sortTestHelper) getListResponseIDs(url string) []string {
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	w := httptest.NewRecorder()
+	h.router.ServeHTTP(w, req)
+	require.Equal(h.t, http.StatusOK, w.Code)
+
+	var apiResp api.APIResponse
+	err := json.Unmarshal(w.Body.Bytes(), &apiResp)
+	require.NoError(h.t, err)
+	require.True(h.t, apiResp.Success)
+
+	dataIface, ok := apiResp.Data.([]interface{})
+	require.True(h.t, ok, "expected list response data to be an array")
+
+	ids := make([]string, 0, len(dataIface))
+	for _, item := range dataIface {
+		row, ok := item.(map[string]interface{})
+		require.True(h.t, ok)
+		ids = append(ids, row["id"].(string))
+	}
+	return ids
+}
+
 func (h *sortTestHelper) findPosition(ids []string, target string) int {
 	for i, id := range ids {
 		if id == target {
@@ -395,6 +421,46 @@ func TestContactSort_LastResponseAtNullsLast(t *testing.T) {
 		assert.Less(t, posRecent, posNull, "Non-null should come before null (NULLS LAST) in asc order")
 	})
 
+	t.Run("full list path desc returns ordered rows", func(t *testing.T) {
+		// Exercises SearchContactsSorted (search query + sort, no ids_only).
+		prefix := "SortLRAList"
+		idOld := h.createContact(prefix + " Old Test")
+		idRecent := h.createContact(prefix + " Recent Test")
+		defer h.deleteContact(idOld)
+		defer h.deleteContact(idRecent)
+
+		h.recordInteraction(idOld, "inbound", "2024-01-01")
+		h.recordInteraction(idRecent, "inbound", "2025-06-01")
+
+		ids := h.getListResponseIDs("/api/v1/contacts?search=" + prefix + "&sort=last_response_at&order=desc")
+
+		posRecent := h.findPosition(ids, idRecent)
+		posOld := h.findPosition(ids, idOld)
+		assert.NotEqual(t, -1, posRecent, "Recent should appear in full list")
+		assert.NotEqual(t, -1, posOld, "Old should appear in full list")
+		assert.Less(t, posRecent, posOld, "Recent should come before old in desc order")
+	})
+
+	t.Run("full list path asc puts oldest first", func(t *testing.T) {
+		// Same as above but ASC; both directions hit the same SQL CASE pair.
+		prefix := "SortLRAListAsc"
+		idOld := h.createContact(prefix + " Old Test")
+		idRecent := h.createContact(prefix + " Recent Test")
+		defer h.deleteContact(idOld)
+		defer h.deleteContact(idRecent)
+
+		h.recordInteraction(idOld, "inbound", "2024-01-01")
+		h.recordInteraction(idRecent, "inbound", "2025-06-01")
+
+		ids := h.getListResponseIDs("/api/v1/contacts?search=" + prefix + "&sort=last_response_at&order=asc")
+
+		posOld := h.findPosition(ids, idOld)
+		posRecent := h.findPosition(ids, idRecent)
+		assert.NotEqual(t, -1, posOld, "Old should appear in full list")
+		assert.NotEqual(t, -1, posRecent, "Recent should appear in full list")
+		assert.Less(t, posOld, posRecent, "Old should come before recent in asc order")
+	})
+
 	t.Run("last_response_at sort is accepted by API validation", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/contacts?sort=last_response_at&order=desc", nil)
 		w := httptest.NewRecorder()
@@ -403,9 +469,9 @@ func TestContactSort_LastResponseAtNullsLast(t *testing.T) {
 	})
 
 	t.Run("legacy last_contacted sort still accepted", func(t *testing.T) {
-		// Decision 2 of the plan: keep last_contacted as a valid sort value on the
-		// API even though no UI surface emits it. Regression-guard for any
-		// external API caller that still passes the legacy field.
+		// last_contacted remains a valid sort value on the API even though no UI
+		// surface emits it; regression-guard for any external caller still using
+		// the legacy field.
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/contacts?sort=last_contacted&order=desc", nil)
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, req)

--- a/backend/tests/api/contact_sort_test.go
+++ b/backend/tests/api/contact_sort_test.go
@@ -421,7 +421,7 @@ func TestContactSort_LastResponseAtNullsLast(t *testing.T) {
 		assert.Less(t, posRecent, posNull, "Non-null should come before null (NULLS LAST) in asc order")
 	})
 
-	t.Run("full list path desc returns ordered rows", func(t *testing.T) {
+	t.Run("full list path with search desc returns ordered rows", func(t *testing.T) {
 		// Exercises SearchContactsSorted (search query + sort, no ids_only).
 		prefix := "SortLRAList"
 		idOld := h.createContact(prefix + " Old Test")
@@ -441,7 +441,7 @@ func TestContactSort_LastResponseAtNullsLast(t *testing.T) {
 		assert.Less(t, posRecent, posOld, "Recent should come before old in desc order")
 	})
 
-	t.Run("full list path asc puts oldest first", func(t *testing.T) {
+	t.Run("full list path with search asc puts oldest first", func(t *testing.T) {
 		// Same as above but ASC; both directions hit the same SQL CASE pair.
 		prefix := "SortLRAListAsc"
 		idOld := h.createContact(prefix + " Old Test")
@@ -459,6 +459,38 @@ func TestContactSort_LastResponseAtNullsLast(t *testing.T) {
 		assert.NotEqual(t, -1, posOld, "Old should appear in full list")
 		assert.NotEqual(t, -1, posRecent, "Recent should appear in full list")
 		assert.Less(t, posOld, posRecent, "Old should come before recent in asc order")
+	})
+
+	t.Run("no-search list path returns rows in sorted order", func(t *testing.T) {
+		// No search query → routes to ListContactsSorted (full) and
+		// ListContactIDsSorted (ids_only). Two contacts with distinct
+		// last_response_at values; we assert relative ordering via
+		// findPosition rather than absolute row index because the shared
+		// test DB carries other contacts with arbitrary dates.
+		idOld := h.createContact("SortLRANoSearch Old Test")
+		idRecent := h.createContact("SortLRANoSearch Recent Test")
+		defer h.deleteContact(idOld)
+		defer h.deleteContact(idRecent)
+
+		h.recordInteraction(idOld, "inbound", "2024-01-01")
+		h.recordInteraction(idRecent, "inbound", "2025-06-01")
+
+		// Full list path (no search): exercises ListContactsSorted. Use a
+		// large limit so both seeded contacts land in the response window.
+		listIDs := h.getListResponseIDs("/api/v1/contacts?sort=last_response_at&order=desc&limit=1000")
+		posRecent := h.findPosition(listIDs, idRecent)
+		posOld := h.findPosition(listIDs, idOld)
+		require.NotEqual(t, -1, posRecent, "Recent should be in full list response")
+		require.NotEqual(t, -1, posOld, "Old should be in full list response")
+		assert.Less(t, posRecent, posOld, "Recent should precede old (desc order, no search)")
+
+		// IDs-only path (no search): exercises ListContactIDsSorted.
+		idsResp := h.getIDsResponse("/api/v1/contacts?ids_only=true&sort=last_response_at&order=desc&limit=1000")
+		posRecentIDs := h.findPosition(idsResp.IDs, idRecent)
+		posOldIDs := h.findPosition(idsResp.IDs, idOld)
+		require.NotEqual(t, -1, posRecentIDs, "Recent should be in ids response")
+		require.NotEqual(t, -1, posOldIDs, "Old should be in ids response")
+		assert.Less(t, posRecentIDs, posOldIDs, "Recent should precede old in ids-only desc order")
 	})
 
 	t.Run("last_response_at sort is accepted by API validation", func(t *testing.T) {

--- a/backend/tests/unit/validation_test.go
+++ b/backend/tests/unit/validation_test.go
@@ -367,7 +367,7 @@ func TestQueryValidation_Search(t *testing.T) {
 // TestQueryValidation_Sort tests Sort field validation
 func TestQueryValidation_Sort(t *testing.T) {
 	type Query struct {
-		Sort string `validate:"omitempty,oneof=name location birthday last_contacted contact_by cadence"`
+		Sort string `validate:"omitempty,oneof=name location birthday last_contacted last_response_at contact_by cadence"`
 	}
 
 	tests := []struct {
@@ -379,6 +379,7 @@ func TestQueryValidation_Sort(t *testing.T) {
 		{"Valid sort - location", "location", false},
 		{"Valid sort - birthday", "birthday", false},
 		{"Valid sort - last_contacted", "last_contacted", false},
+		{"Valid sort - last_response_at", "last_response_at", false},
 		{"Valid sort - contact_by", "contact_by", false},
 		{"Valid sort - cadence", "cadence", false},
 		{"Empty sort valid", "", false},

--- a/frontend/src/app/contacts/page.tsx
+++ b/frontend/src/app/contacts/page.tsx
@@ -25,7 +25,14 @@ import { FORM_CONTROL_WITH_ICON, FORM_SELECT_BASE } from '@/lib/form-classes'
 import { formatDateOnly, formatCadence } from '@/lib/utils'
 import type { Contact, ContactListParams } from '@/types/contact'
 
-type SortField = 'name' | 'location' | 'birthday' | 'last_contacted' | 'contact_by' | 'cadence'
+type SortField =
+  | 'name'
+  | 'location'
+  | 'birthday'
+  | 'last_contacted'
+  | 'last_response_at'
+  | 'contact_by'
+  | 'cadence'
 
 // Default sort configuration
 const DEFAULT_SORT_FIELD: SortField = 'cadence'
@@ -195,11 +202,11 @@ function ContactsTable({
             </th>
             <th
               className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100"
-              onClick={() => onSort('last_contacted')}
+              onClick={() => onSort('last_response_at')}
             >
               <div className="flex items-center">
-                Last Contact
-                {getSortIcon('last_contacted')}
+                Last response
+                {getSortIcon('last_response_at')}
               </div>
             </th>
             <th
@@ -267,8 +274,8 @@ function ContactsTable({
                   : '-'}
               </td>
               <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-500">
-                {contact.last_contacted
-                  ? formatDateOnly(contact.last_contacted, {
+                {contact.last_response_at
+                  ? formatDateOnly(contact.last_response_at, {
                       year: '2-digit',
                       month: 'numeric',
                       day: 'numeric',
@@ -437,12 +444,12 @@ export default function ContactsPage() {
           page: 1, // Reset to first page when sorting
         }
       }
-      // Default sort: cadence/last_contacted → desc (most frequent/recent first)
+      // Default sort: cadence/last_response_at → desc (most frequent/recent first)
       // contact_by/birthday/name/location → asc (soonest due/alphabetical first)
       return {
         ...prev,
         sort: field,
-        order: field === 'cadence' || field === 'last_contacted' ? 'desc' : 'asc',
+        order: field === 'cadence' || field === 'last_response_at' ? 'desc' : 'asc',
         page: 1,
       }
     })

--- a/frontend/src/app/contacts/page.tsx
+++ b/frontend/src/app/contacts/page.tsx
@@ -280,7 +280,7 @@ function ContactsTable({
                       month: 'numeric',
                       day: 'numeric',
                     })
-                  : 'Never'}
+                  : '-'}
               </td>
               <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-500">
                 {contact.cadence && contact.contact_by

--- a/frontend/src/types/contact.ts
+++ b/frontend/src/types/contact.ts
@@ -66,7 +66,14 @@ export interface ContactListParams {
   page?: number
   limit?: number
   search?: string
-  sort?: 'name' | 'location' | 'birthday' | 'last_contacted' | 'contact_by' | 'cadence'
+  sort?:
+    | 'name'
+    | 'location'
+    | 'birthday'
+    | 'last_contacted'
+    | 'last_response_at'
+    | 'contact_by'
+    | 'cadence'
   order?: 'asc' | 'desc'
   cadence_filter?: 'has_cadence' | 'no_cadence'
   followup_filter?: 'has_followup' | 'no_followup'

--- a/frontend/tests/e2e/contacts.spec.ts
+++ b/frontend/tests/e2e/contacts.spec.ts
@@ -624,7 +624,7 @@ test.describe('Contacts - UI Create (preserved for coverage) @area:contacts', ()
     await expect(weeklyRow).toBeVisible()
     // The Next Contact cell should contain a date (digits with slashes)
     const weeklyCells = weeklyRow.locator('td')
-    // Next Contact is the 6th column (Name, Cadence, Location, Birthday, Last Contact, Next Contact, Actions)
+    // Next Contact is the 6th column (Name, Cadence, Location, Birthday, Last response, Next Contact, Actions)
     const weeklyNextContact = weeklyCells.nth(5)
     await expect(weeklyNextContact).not.toHaveText('-')
 
@@ -676,6 +676,48 @@ test.describe('Contacts - UI Create (preserved for coverage) @area:contacts', ()
 
     // Contact should still be visible after sort toggling
     await expect(page.getByText(`${testApi.prefix}-SortNext Contact`)).toBeVisible()
+  })
+
+  test('should display Last response column header and sort by last_response_at', async ({
+    page,
+  }) => {
+    await testApi.seedContacts([{ full_name: 'SortResp Contact' }])
+
+    await page.goto('/contacts')
+    await page.waitForLoadState('domcontentloaded')
+
+    // Header text matches the new directionally-correct label.
+    const lastResponseHeader = page.getByRole('columnheader').filter({ hasText: 'Last response' })
+    await expect(lastResponseHeader).toBeVisible()
+    // The legacy "Last Contact" header is gone.
+    await expect(page.getByRole('columnheader').filter({ hasText: /^Last Contact$/i })).toHaveCount(
+      0
+    )
+
+    // Isolate our test contact via search so the sort click reliably
+    // produces a fetch we can listen for.
+    const searchInput = page.getByPlaceholder('Search contacts...')
+    await searchInput.fill(`${testApi.prefix}-SortResp`)
+    await searchInput.press('Enter')
+    await expect(page.getByText(`${testApi.prefix}-SortResp Contact`)).toBeVisible()
+
+    // First click → desc (default direction for last_response_at, matching the
+    // existing cadence-column convention of "most recent first").
+    const descResponse = page.waitForResponse(
+      resp => resp.url().includes('sort=last_response_at') && resp.url().includes('order=desc')
+    )
+    await lastResponseHeader.click()
+    await descResponse
+    await expect(lastResponseHeader.locator('svg')).toBeVisible()
+
+    // Second click → asc.
+    const ascResponse = page.waitForResponse(
+      resp => resp.url().includes('sort=last_response_at') && resp.url().includes('order=asc')
+    )
+    await lastResponseHeader.click()
+    await ascResponse
+
+    await expect(page.getByText(`${testApi.prefix}-SortResp Contact`)).toBeVisible()
   })
 
   test('should show page number buttons and top/bottom pagination when multiple pages exist', async ({

--- a/frontend/tests/e2e/overdue-contact-updates.spec.ts
+++ b/frontend/tests/e2e/overdue-contact-updates.spec.ts
@@ -181,7 +181,10 @@ test.describe('Overdue Contact Updates - With Seeded Data @area:overdue', () => 
     const today = getTodayUTC()
     await expect(page.getByText(today).first()).toBeVisible()
 
-    // 2. Contacts List: should show today's date in the row (use first() as date may appear in both Last Contact and Next Contact columns)
+    // 2. Contacts List: should show today's date in the Next Contact column
+    // (weekly cadence + just-marked = contact_by is today). The Last response
+    // column may render "Never" because PATCH /last-contacted does not bump
+    // last_response_at. Use first() to match any matching cell in the row.
     await page.goto('/contacts')
     await expect(page.getByRole('heading', { name: 'Contacts', level: 2 })).toBeVisible()
     const contactRow = page.locator('tr').filter({ hasText: contactName })

--- a/frontend/tests/e2e/overdue-contact-updates.spec.ts
+++ b/frontend/tests/e2e/overdue-contact-updates.spec.ts
@@ -181,10 +181,12 @@ test.describe('Overdue Contact Updates - With Seeded Data @area:overdue', () => 
     const today = getTodayUTC()
     await expect(page.getByText(today).first()).toBeVisible()
 
-    // 2. Contacts List: should show today's date in the Next Contact column
-    // (weekly cadence + just-marked = contact_by is today). The Last response
-    // column may render "Never" because PATCH /last-contacted does not bump
-    // last_response_at. Use first() to match any matching cell in the row.
+    // 2. Contacts List: should show today's date in the row. PATCH
+    // /last-contacted records a mutual interaction, which bumps both
+    // last_contacted and last_response_at, so today appears in both the
+    // Last response column and the Next Contact column (weekly cadence +
+    // just-marked = contact_by is today). Use first() to match any matching
+    // cell in the row.
     await page.goto('/contacts')
     await expect(page.getByRole('heading', { name: 'Contacts', level: 2 })).toBeVisible()
     const contactRow = page.locator('tr').filter({ hasText: contactName })


### PR DESCRIPTION
## Summary

PR-A of the task-direction-taxonomy split (spec at `.ai/spec/task-direction-taxonomy.md` §5). Switches the `/contacts` list view's sortable column from `last_contacted` (label-data mismatch since the direction model landed) to the directionally-correct `last_response_at`. The underlying `last_contacted` field stays live in the API (still bumped by inbound + mutual interactions and read by cadence math); only the UI surface changes.

After this PR:
- Header: "Last response" (was "Last Contact")
- Cell value: `contact.last_response_at` (was `contact.last_contacted`)
- Sort field: `last_response_at` (was `last_contacted`); legacy `last_contacted` still accepted by the API validator for any external caller
- Default sort direction on click: `desc` — preserves the existing "most recent first" convention

## Cross-cutting changes (per CLAUDE.md "When You Change" — sortable contact field)

- `backend/internal/db/queries/contact.sql` — `last_response_at` ASC/DESC `CASE` pairs added to all four sortable list queries (`ListContactsSorted`, `SearchContactsSorted`, `ListContactIDsSorted`, `SearchContactIDsSorted`).
- `backend/internal/api/handlers/contact.go` — `Sort` validator's `oneof` widened; Swagger `Enums` list updated.
- `frontend/src/types/contact.ts` — `ContactListParams.sort` union extended.
- `frontend/src/app/contacts/page.tsx` — local `SortField` union, header text, `onSort`/`getSortIcon` target, cell value, and default-direction map all switched. Null cells render `-` (matching sibling cells like birthday/contact_by).

## Plan & decisions

- Plan: `.ai/log/plan/task-direction-taxonomy-pr-a-list-column-rename.md`
- `last_contacted` deliberately kept as a valid sort value on the API (zero deprecation cost, still semantically meaningful for cadence/inbound/mutual reporting).
- No URL-param hydration on the contacts page → no bookmark-drift surface.
- Generated `backend/docs/docs.go` is left as-is: handler comment is the source of truth and is updated. `make api-docs` (swag) fails on a pre-existing parse error in `sync.SourceConfig` unrelated to this PR.

## Test plan

- [x] Backend integration: `TestContactSort_LastResponseAtNullsLast` — 8 subtests covering ASC/DESC NULLS LAST, both with-search (Search(IDs)Sorted) and no-search (List(IDs)Sorted) paths, validator-200 for `last_response_at` and legacy `last_contacted`, validator-400 for unknown.
- [x] Backend unit: `TestQueryValidation_Sort` extended with `last_response_at` case.
- [x] Frontend E2E: new `contacts.spec.ts` test asserting header text "Last response" (legacy "Last Contact" gone), first click → `sort=last_response_at&order=desc`, second click → `order=asc`, via `waitForResponse` (no row-position assertion).
- [x] `make lint` / `make test` / `make test-e2e-diff` all green locally.

## Out of scope

PR-B (kind/lifecycle taxonomy refactor, schema migration, event payload V2/V3, manual Log Interaction modal, three frontend mutation consolidations) is a separate PR per the spec's "Sequencing note." This PR touches no code paths PR-B touches except `frontend/src/app/contacts/page.tsx`, where PR-B's row-action button work lives in a different section of the file (low merge-conflict risk).