### PR TITLE
chore: unwire pre-push learnings extraction

### DIFF
--- a/.ai/pre-push.json
+++ b/.ai/pre-push.json
@@ -14,8 +14,5 @@
       { "name": "Frontend tests", "command": "make test-frontend" },
       { "name": "E2E tests", "command": "make test-e2e-diff" }
     ]
-  },
-  "learnings": {
-    "enabled": true
   }
 }

--- a/.ai/rules/core.md
+++ b/.ai/rules/core.md
@@ -33,13 +33,6 @@ These rules apply to all AI agents working on this project.
 Git pre-push hooks run automatically and may block push:
 
 - **Tests**: Runs lint and all test suites. Push blocked if tests fail.
-- **Learnings**: Extracts session learnings. If new learnings found, push blocked with instructions to review and apply them.
-
-When push is blocked by learnings extraction:
-1. Read the new learnings in `.ai/log/learnings/`
-2. For each actionable learning, decide if/where to apply it
-3. Commit any applied changes plus the learnings files
-4. Push again
 
 ## Code Review Approval Criteria
 

--- a/.ai/skills/learnings/SKILL.md
+++ b/.ai/skills/learnings/SKILL.md
@@ -1,10 +1,12 @@
 ---
 name: learnings
-description: Extract learnings from current session before push or session end
+description: "[DORMANT] Manual learnings extraction. No longer auto-invoked by push hooks or session end. The corpus in .ai/log/learnings/ is preserved as a historical archive. Files and extract script remain available if invoked explicitly."
 allowed-tools: Bash Read Edit Glob Skill
 ---
 
-# Extract Session Learnings
+# Extract Session Learnings (Dormant)
+
+**Status:** This skill is no longer auto-invoked. The pre-push hook does not run extraction, and agents should not invoke it as part of normal workflow. The `.ai/log/learnings/*.yaml` corpus is preserved for historical reference. Files in this directory and `extract-learnings.sh` remain in place for manual use only.
 
 Capture insights so problems become patterns, mistakes become rules, techniques become skills.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,6 @@ Find all instances of a layer:
 
 ## Privacy
 
-- **Never include PII in code, comments, commit messages, PR descriptions, GitHub issues, plan docs, learnings, or any other repo artifact.** PII = real contact full names, email addresses, phone numbers, contact UUIDs, account IDs, prod hostnames, anything that could identify a real person or system. Use placeholders ("contact A", "the affected contact", "two contacts on date X", `<prod-host>`), redact UUIDs, and keep specifics in private notes outside the repo. The repo is the user's own CRM and the data inside it is real — leaking PII into git history is irreversible.
+- **Never include PII in code, comments, commit messages, PR descriptions, GitHub issues, plan docs, or any other repo artifact.** PII = real contact full names, email addresses, phone numbers, contact UUIDs, account IDs, prod hostnames, anything that could identify a real person or system. Use placeholders ("contact A", "the affected contact", "two contacts on date X", `<prod-host>`), redact UUIDs, and keep specifics in private notes outside the repo. The repo is the user's own CRM and the data inside it is real — leaking PII into git history is irreversible.
 - `.ai/log/plan/` is gitignored (safe scratch space for raw prod observations).
-- `.ai/log/learnings/*.yaml` IS tracked in git (the `.ai/log/*` ignore is overridden by `!.ai/log/learnings/*`) — the PII rule applies there. Don't write prod hostnames, real names, or contact identifiers into learnings yaml.
+- `.ai/log/learnings/*.yaml` IS tracked in git (the `.ai/log/*` ignore is overridden by `!.ai/log/learnings/*`). This is a historical archive; new learnings extraction is no longer wired into the push flow. The PII rule applies to any manual edits.

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -1,9 +1,8 @@
 #!/bin/bash
-# Unified pre-push hook: lint, test, learnings (parallel execution)
+# Unified pre-push hook: lint, test (parallel execution)
 #
 # Reads configuration from .ai/pre-push.json
-# Runs enabled checks in parallel for speed
-# Blocks push if any required check fails
+# Runs enabled checks; blocks push if any required check fails
 #
 # To bypass (not recommended): git push --no-verify
 
@@ -23,8 +22,7 @@ fi
 # Temp files for parallel execution results
 LINT_RESULT=$(mktemp)
 TEST_RESULT=$(mktemp)
-LEARN_RESULT=$(mktemp)
-trap "rm -f $LINT_RESULT $TEST_RESULT $LEARN_RESULT" EXIT
+trap "rm -f $LINT_RESULT $TEST_RESULT" EXIT
 
 echo "==============================================================" >&2
 echo "Pre-push: Running checks..." >&2
@@ -166,7 +164,7 @@ run_tests() {
 
   # Check if we can skip tests
   if should_skip_tests; then
-    echo "  [test] OK Skipped (only learnings changed since last pass)" >&2
+    echo "  [test] OK Skipped (no trigger files changed since last pass)" >&2
     echo "PASS" > "$TEST_RESULT"
     return
   fi
@@ -204,90 +202,6 @@ run_tests() {
   fi
 }
 
-# Check if only learnings-related docs changed since last extraction
-# This checks commits SINCE last extraction, not all unpushed commits
-should_skip_learnings() {
-  local state_file=".ai/log/.last-extraction-commit"
-
-  # If no state file, can't skip (first run)
-  [[ ! -f "$state_file" ]] && return 1
-
-  local last_commit
-  last_commit=$(cat "$state_file" 2>/dev/null)
-
-  # Verify the commit exists
-  if ! git rev-parse --verify "$last_commit" >/dev/null 2>&1; then
-    return 1  # Invalid commit, must run extraction
-  fi
-
-  # Get files changed since last extraction
-  local changed_files
-  changed_files=$(git diff --name-only "$last_commit" HEAD 2>/dev/null)
-
-  [[ -z "$changed_files" ]] && return 0  # No changes since extraction
-
-  # Check if ALL changed files are learnings application locations
-  while IFS= read -r file; do
-    case "$file" in
-      .ai/log/*|.ai/guides/*|.ai/patterns/*|.ai/rules/*) ;;  # Skip these
-      .claude/CLAUDE.md|CLAUDE.md|AGENTS.md) ;;              # Skip these
-      *) return 1 ;;  # Found a file that might generate learnings
-    esac
-  done <<< "$changed_files"
-
-  return 0  # Only learnings docs changed since last extraction
-}
-
-# Save current commit as last extraction point
-save_extraction_commit() {
-  local state_file=".ai/log/.last-extraction-commit"
-  git rev-parse HEAD > "$state_file"
-}
-
-# Run learnings extraction (runs synchronously for reliable temp file writing)
-run_learnings() {
-  cd "$PROJECT_ROOT"
-  local enabled=$(jq -r '.learnings.enabled // false' "$CONFIG_FILE")
-  if [[ "$enabled" != "true" ]]; then
-    echo "SKIP" > "$LEARN_RESULT"
-    return
-  fi
-
-  # Skip if only learnings files are being pushed
-  if should_skip_learnings; then
-    echo "  [learn] OK Skipped (only learnings files)" >&2
-    echo "PASS" > "$LEARN_RESULT"
-    return
-  fi
-
-  echo "  [learn] -> Extracting learnings..." >&2
-
-  # Run synchronously, show stderr (agent sees instructions), hide stdout
-  # Exit codes: 0 = no new learnings, 2 = new learnings extracted, other = error
-  # Disable errexit temporarily to capture non-zero exit codes
-  set +e
-  ./.ai/skills/learnings/extract-learnings.sh --trigger pre-push >/dev/null
-  local exit_code=$?
-  set -e
-
-  if [[ "$exit_code" -eq 0 ]] || [[ "$exit_code" -eq 2 ]]; then
-    # Save extraction point so we can skip next time if only learnings docs change
-    save_extraction_commit
-
-    # Check if new learnings were added (uncommitted changes to directory)
-    if git diff --quiet .ai/log/learnings/ 2>/dev/null && [[ -z "$(git ls-files --others --exclude-standard .ai/log/learnings/)" ]]; then
-      echo "  [learn] OK No new learnings" >&2
-      echo "PASS" > "$LEARN_RESULT"
-    else
-      echo "  [learn] WARN New learnings extracted" >&2
-      echo "NEW" > "$LEARN_RESULT"
-    fi
-  else
-    echo "  [learn] WARN Extraction failed (non-blocking)" >&2
-    echo "PASS" > "$LEARN_RESULT"
-  fi
-}
-
 # Run lint first (fast, fail early)
 run_lint
 LINT_STATUS=$(cat "$LINT_RESULT")
@@ -300,34 +214,21 @@ if [[ "$LINT_STATUS" == "FAIL" ]]; then
   exit 1
 fi
 
-# Run tests in background, learnings synchronously (for reliable temp file writing)
-run_tests &
-run_learnings
-wait
-
-# Collect results
+# Run tests
+run_tests
 TEST_STATUS=$(cat "$TEST_RESULT")
-LEARN_STATUS=$(cat "$LEARN_RESULT")
 
 echo "" >&2
 echo "==============================================================" >&2
 echo "Results:" >&2
-echo "  Lint:      $LINT_STATUS" >&2
-echo "  Tests:     $TEST_STATUS" >&2
-echo "  Learnings: $LEARN_STATUS" >&2
+echo "  Lint:   $LINT_STATUS" >&2
+echo "  Tests:  $TEST_STATUS" >&2
 echo "==============================================================" >&2
 
 # Determine exit (lint already checked above)
 if [[ "$TEST_STATUS" == "FAIL" ]]; then
   echo "" >&2
   echo "FAILED: Tests failed. Fix issues before pushing." >&2
-  echo "" >&2
-  exit 1
-fi
-
-if [[ "$LEARN_STATUS" == "NEW" ]]; then
-  echo "" >&2
-  echo "BLOCKED: New learnings extracted. See instructions above." >&2
   echo "" >&2
   exit 1
 fi

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -13,4 +13,4 @@ git config core.hooksPath scripts/hooks
 echo "Git hooks configured."
 echo "  hooks path: scripts/hooks/"
 echo "  pre-commit: auto-formats Go and frontend files"
-echo "  pre-push: lint, tests, learnings extraction"
+echo "  pre-push: lint, tests"


### PR DESCRIPTION
## Summary

- Removes the `learnings` extraction step from the pre-push hook to reduce per-push overhead. The flow hasn't materially improved development quality and was adding notable cost to every push.
- **Kept:** the `.ai/log/learnings/*.yaml` corpus (44 historical entries) as a tracked archive, and the `.ai/skills/learnings/` directory on disk. The skill's frontmatter description is changed to `[DORMANT]` so it's no longer auto-invoked.
- **Removed/unwired:** the `learnings` section in `.ai/pre-push.json`, the `run_learnings` / `should_skip_learnings` / `save_extraction_commit` functions in `scripts/hooks/pre-push` (script went from ~338 → ~231 lines), the announce line in `scripts/install-git-hooks.sh`, and learnings references in `.ai/rules/core.md` and `AGENTS.md`.

After this merges, pre-push is just `lint → tests`.

## Test plan

- [x] `bash -n scripts/hooks/pre-push` — syntax check passes
- [x] Push of this branch ran the new hook: lint passed, tests correctly skipped (no trigger files changed since last pass), no learnings step executed
- [x] Reviewer: confirm no other code paths reference `learnings.enabled`, `should_skip_learnings`, or `extract-learnings.sh`