### PR TITLE
feat(mac-daemon): PR2 — extract burst aggregator into messaging/aggregation

### DIFF
--- a/.ai/patterns/sync.md
+++ b/.ai/patterns/sync.md
@@ -50,9 +50,9 @@ Each source provides a thin adapter in its package that:
    bus is configured — typed-nil concrete pointers (`(*events.Bus)(nil)`)
    bypass the engine's `publisher == nil` guard.
 
-Telegram's `*telegram.AggregationEngine` is the only caller as of PR2; it is
-now a thin shim around the shared engine, preserving its exported signature
-so manager/handlers/rematch wiring and integration tests compile unchanged.
+Telegram's `*telegram.AggregationEngine` is currently the only caller; it is
+a thin shim around the shared engine, preserving its exported signature so
+manager/handlers/rematch wiring and integration tests compile unchanged.
 
 The `MessageStore` ordering contract requires adapters to emit rows ordered
 by `SentAt ASC`; the engine sorts defensively, but adapters should keep the

--- a/.ai/patterns/sync.md
+++ b/.ai/patterns/sync.md
@@ -26,6 +26,40 @@ transactional CAS lives in `SyncRepository.CommitMacHostCursor`.
 
 ---
 
+## Shared Message Aggregation (`messaging/aggregation`)
+
+Per-source message staging tables (`telegram_message` today; `messages_message`,
+`whatsapp_message` in later PRs) feed a single source-parametric burst/session
+aggregator at `backend/internal/messaging/aggregation`. The shared engine
+implements the burst → session → interaction pipeline (groupIntoBursts,
+resolveSessions, time-based + explicit reply bridging, same-direction
+coalescing) and depends only on interfaces — `SourceAdapter`, `MessageStore`,
+`InteractionFinder`, `InteractionPromoter`, `InteractionExtender`,
+`EventPublisher`.
+
+Each source provides a thin adapter in its package that:
+
+1. Implements `SourceAdapter` (returns the `interaction.source` constant,
+   formats `source_ref`/`peer_ref` strings, builds description labels).
+2. Implements `MessageStore` by wrapping its per-source staging repository
+   and mapping rows into the source-neutral `aggregation.Message` struct.
+   The staging-row → Message mapping MUST carry `InteractionID` through so
+   cross-batch explicit reply bridging works.
+3. Constructs `aggregation.Engine` via `aggregation.NewEngine(...)`. The
+   `EventPublisher` argument MUST be the untyped-nil interface when no
+   bus is configured — typed-nil concrete pointers (`(*events.Bus)(nil)`)
+   bypass the engine's `publisher == nil` guard.
+
+Telegram's `*telegram.AggregationEngine` is the only caller as of PR2; it is
+now a thin shim around the shared engine, preserving its exported signature
+so manager/handlers/rematch wiring and integration tests compile unchanged.
+
+The `MessageStore` ordering contract requires adapters to emit rows ordered
+by `SentAt ASC`; the engine sorts defensively, but adapters should keep the
+`ORDER BY sent_at` idiom that the Telegram sqlc queries already use.
+
+---
+
 ## Normalize External Schemas at the Boundary
 
 Fix external API quirks where data enters the system, not in business logic.

--- a/.ai/spec/mac-daemon.md
+++ b/.ai/spec/mac-daemon.md
@@ -1,0 +1,688 @@
+# Mac Daemon (`crm-mac`) — Design Spec
+
+**Date:** 2026-05-11
+**Status:** Design — under adversarial review
+**Issues this design supersedes/incorporates:** #73 (iMessage), #74 (iCloud Contacts)
+**Author:** Brainstormed with Claude; final scope and decisions per user.
+
+---
+
+## Summary
+
+Defines a new Mac-side daemon, `crm-mac` (Swift, launchd-managed), that runs on the user's MacBook and ingests local data sources unreachable from the Pi backend. The daemon publishes events to the existing `/api/v1/ingest/events` endpoint and heartbeats host status to a new `mac_host` model. It establishes five logical data sources (Messages.app, WhatsApp, iCloud Contacts, Anarlog humans, Anarlog sessions) and a phased build order with v1 shipping the daemon framework plus Messages and iCloud Contacts.
+
+Local LLM inference on the Mac is **explicitly out of scope** for this spec.
+
+---
+
+## Goals
+
+- Provide a single, observable Mac-side process that ingests local data sources the Pi cannot reach.
+- Reuse the existing CRM event-bus + sync infrastructure unchanged where possible; additive extensions where not (new event kinds, `mac_host` model, `external_contact` source value, `interaction.source` enum extension, identifier type additions, `external_sync_state.strategy=push` exclusion in the scheduler).
+- Keep the Pi as the source of truth for sync state and CRM data; Mac is a stateless ingest pipe with minimal local cache.
+- Respect Mac as a daily-driver laptop: predictable low resource footprint, energy-friendly periodic work, no background CPU during idle.
+- Future-proof for multiple Mac hosts; v1 ships single-host UI.
+
+## Non-goals
+
+- Local inference (separate future spec).
+- Pi → Mac inbound calls (daemon is push-only).
+- Native Mac UI (menu bar app, settings GUI). Observability is via CLI on Mac and the existing Pi web frontend.
+- Native Mac notifications.
+- Attachment content/files (only metadata: type tag, optionally filename/MIME/size when cheap).
+- Mac-side data sources we don't need: Mail.app, Notes.app, Reminders.app, Calendar.app, Signal, Photos.app, Voice Memos.
+- Browser extension companion.
+
+---
+
+## Vision
+
+The Mac daemon ingests five logical data sources, publishing events to the Pi:
+
+| Source | Strategy | Identifier type emitted | Content fidelity | Backfill floor | Discovery? |
+|---|---|---|---|---|---|
+| `messages` (iMessage + SMS via Messages.app) | event stream | `phone`, `email` (generic — see Identifier Types below) | full text + type tag | 2026-01-01 | no |
+| `whatsapp` | event stream | `whatsapp` | full text + type tag | 2026-01-01 | no |
+| `icloud_contacts` | entity sync | n/a (matches via contact methods) | full entity, into existing `external_contact` table | all current | yes |
+| `anarlog_humans` | entity sync | `anarlog_human_id` (new) | full entity | all current | yes |
+| `anarlog_sessions` | event stream | participants by `anarlog_human_id` | `_meta.json` + `_summary.md` + optional `_memo.md` | 2026-01-01 | no |
+
+**Data flow:** the daemon publishes events to `/api/v1/ingest/events` (existing event-bus ingest endpoint). The Pi's event-bus consumers derive interactions, enrichments, and downstream effects from those events.
+
+**Polling cadence (per source):**
+- `messages`: scheduled ~60-90s
+- `whatsapp`: scheduled ~60-90s
+- `icloud_contacts`: scheduled ~15min (full delta via `CNChangeHistoryFetchRequest`)
+- `anarlog_humans`: scheduled ~5min (mtime-based)
+- `anarlog_sessions`: **event-driven via FSEvents**, hourly safety poll for catchup and tombstone detection
+
+**Backfill:** all event streams backfill to `2026-01-01`. Pattern follows Telegram's `backfill_cursor` + `backfill_complete` model. iCloud Contacts and Anarlog humans sync all current entities; entity tombstones are first-class (see deletion handling below).
+
+---
+
+## Architecture
+
+### 1. The `crm-mac` daemon (Swift)
+
+**Language & stack:** all-Swift, SPM-built. Single binary `crm-mac` that runs as both the launchd agent (`crm-mac daemon`) and the user-facing CLI. Rationale for Swift documented in conversation; key driver is `CNContactStore` access and modern macOS lifecycle APIs (`SMAppService`, FSEvents via `DispatchSource`, Keychain, `os.Log`).
+
+**Repo layout:** `mac-daemon/` at repo root.
+
+**Process model:** Swift binary, launchd user-domain agent. Registered via `SMAppService.agent` (macOS 13+) with a fallback plist for older systems. Runs as the user (not root) — Full Disk Access and Contacts permission are user-scoped.
+
+**Internal components:**
+- **Source readers** — one Swift module per source. Isolated; a crashing reader does not affect others.
+- **Per-source scheduler** — each source has either an `NSBackgroundActivityScheduler` activity (messages, whatsapp, icloud_contacts, anarlog_humans) or an FSEvents source + safety poll (anarlog_sessions). See "Scheduling determinism" note in Failure Modes.
+- **Pi client** — `URLSession` with API key auth from Keychain. Retries with bounded exponential backoff. Chunked batch uploads (~500 events per push). No local queue.
+- **Heartbeat reporter** — every ~60s, POSTs rich status to `/api/v1/host/<id>/heartbeat`. Heartbeat payload defined below under "Observability."
+- **CLI dispatcher** — `swift-argument-parser` subcommands.
+
+**State on Mac:** minimal. Pi is source of truth for cursors. State cached locally in `~/Library/Application Support/crm-mac/state.json` for fast warm restart; Pi is authoritative on conflict (see Cursor Protocol).
+
+**Configuration:**
+- `~/Library/Application Support/crm-mac/config.json` — non-secret: Pi URL, Anarlog folder path, iCloud container allowlist, per-source enabled flags.
+- macOS Keychain — secrets: Pi API key, `mac_host` UUID, cursor epoch token.
+
+**CLI surface:**
+```
+crm-mac daemon                # launchd entry point — runs forever
+crm-mac install [--upgrade]   # install or upgrade; interactive setup; consumes pairing token
+crm-mac configure             # re-run container allowlist, path config, source enable/disable
+crm-mac uninstall             # remove service registration, binary, keychain, config (NOT Pi-side state)
+crm-mac status                # current sync state + heartbeat health + cursor lag per source
+crm-mac logs [--source X] [--follow]
+crm-mac doctor                # check permissions, Pi reachability, source readability
+crm-mac version               # daemon version + protocol version
+```
+
+**Lifecycle — install + pairing flow:**
+1. User clicks "Pair new Mac" in Pi web UI. Pi mints a short-TTL (10 min), single-use pairing token. Token shown in UI.
+2. User runs `crm-mac install` on Mac, pastes pairing token.
+3. Daemon POSTs `/api/v1/host` with `{pairing_token, hostname, daemon_version, protocol_version}`. Pi validates token, mints `mac_host` row, returns `{host_id, api_key, cursor_epoch}`. Both stored in Keychain.
+4. Daemon runs the iCloud container allowlist picker (`CNContainer` enumeration with `--containers iCloud,Local` as a non-interactive override).
+5. Daemon prompts for Anarlog folder path (default: `~/Documents/notes/meetings`).
+6. Daemon runs `doctor` to surface permission gaps with deep links.
+7. Daemon registers via `SMAppService` and starts.
+
+The pairing token model means there's no admin/bootstrap key in widespread use — every host has its own scoped API key. The pairing endpoint is the only un-authenticated path; the rest live behind the host's API key middleware.
+
+**Lifecycle — update:** drop new binary; `crm-mac install --upgrade` re-registers and bounces. Daemon includes its `protocol_version` in heartbeat; Pi can refuse stale daemons (see Version Skew).
+
+**Lifecycle — uninstall:** removes service, binary, keychain, config. Does NOT delete Pi-side `mac_host` row or staging data — that's a separate `DELETE /api/v1/host/<id>` from the Pi UI.
+
+**Permissions:** Full Disk Access (chat.db; WhatsApp likely not required since sandbox container is user-readable), Contacts permission (native `requestAccess`), Files & Folders for Anarlog path. `doctor` enumerates and provides `x-apple.systempreferences:` deep links.
+
+### 2. Data sources
+
+#### `messages` (iMessage + SMS via Messages.app)
+
+- **Source:** `~/Library/Messages/chat.db`, read-only via GRDB.swift.
+- **Cursor:** `MAX(ROWID)` from `message` table.
+- **Identifier types emitted:** generic `phone` and `email`. Channel/provenance carried in `source='messages'`. Rationale: Messages.app delivers both iMessage and SMS uniformly; `imessage_*` identifier types in the existing codebase are semantically misleading (SMS is not iMessage) and will be retired in a cleanup migration. Identifier type describes identifier shape; source describes the integration. See "Identifier Types" appendix.
+- **Content:** message text, `is_from_me`, `date`, `guid` (per-message stable ID — used as primary dedup key), `chat.guid`, group flag, reply-to, `message_type` tag (text/photo/audio/video/document/other) inferred from `attachment.uti` or `mime_type`. Optional attachment metadata: filename, size, mime_type (no content).
+- **Group chat attribution:** ONE interaction is created — for the sender only. Other participants in a group chat are NOT marked as having "contacted" the user when a third party sends. Matches Telegram's current behavior (see `backend/internal/telegram/aggregation.go`). Group chat participant *membership* is recorded in the staging table for context but does not produce per-participant interactions.
+- **Aggregation:** v1 prerequisite. Telegram's existing aggregator (`backend/internal/telegram/aggregation.go`) is extracted into a shared `backend/internal/messaging/aggregation` package with a source-neutral interface. Burst-windowing, reply bridging, direction inference (inbound/outbound/mutual) all carry over unchanged. Mac-specific staging tables (`messages_message`, `whatsapp_message`) satisfy the shared aggregator's interface. The aggregator's input filter is the **claim-aware** filter: `processed_at IS NULL AND (claimed_at IS NULL OR claimed_at < NOW() - INTERVAL '5 minutes')` — extends Telegram's existing `ListUnprocessedByContact` query. Concurrency is handled by **per-`(contact_id, source)` River job serialization** (the aggregator runs as a single River job keyed on `(contact_id, source)`); no PostgreSQL advisory lock needed. The key includes source so `messages` and `whatsapp` jobs for the same contact can run in parallel without contention. **Two-path output**, matching Telegram exactly:
+  - **Extend path:** if a session resolves to a recent existing interaction in window (same contact + chat + same-or-mutual direction), the aggregator extends that interaction via direct `ContactService.ExtendInteraction` call AND marks the staging rows `processed_at = NOW()` + `interaction_id = <existing>` in the same call. **No event is published for extensions** — `cadence_updater` / `followup_manager` do not re-fire on conversation continuations (already the right product behavior per Telegram).
+  - **Create path:** if no recent existing interaction matches, the aggregator publishes a `message.received` or `message.sent` event. The `InteractionRecorder` consumer creates the interaction row AND marks the staging rows processed atomically in the same tx (per the comment in `aggregation.go:323` — "gives us atomicity between the interaction row and the telegram_message.interaction_id FK").
+
+  This **eliminates the cross-batch burst fragmentation problem in steady state**: when message B arrives in a later poll than message A and A's interaction already exists, the extend path picks B up into A's interaction. Concurrency between the aggregator and the InteractionRecorder introduces a narrower race (B arrives between aggregator-publish and InteractionRecorder-commit) which is resolved by the explicit `claimed_at` claim mechanism on the create path — see "Race mechanics" under Event flow.
+- **Edits / deletes / reactions:** acknowledged out of scope for v1. chat.db represents reactions (tapbacks) as `associated_message_*` columns on a new message row; edits update existing rows (post-iOS 16). A `MAX(ROWID)` cursor sees new rows but not mutations to old rows. v1 stored content reflects message state at first ingestion. v2 adds a "mutation scan" reader that scans recent rows (last N days) for `date_edited`/`is_deleted` changes.
+- **Permission:** Full Disk Access.
+- **Discovery:** none. All participants expected to exist via `icloud_contacts` / `gcontacts`. Unmatched messages stay in staging with `matched_contact_id = NULL`; `messages_rematch` worker picks them up retroactively when contact methods later appear.
+
+#### `whatsapp`
+
+- **Source:** `~/Library/Group Containers/group.net.whatsapp.WhatsApp.shared/` — primary DB `ChatStorage.sqlite`. Secondary: `ContactsV2.sqlite`, `ExtChatDB/ExtChatDatabase.sqlite`. Read-only via GRDB.swift with `?mode=ro&immutable=1` and backoff on `SQLITE_CANTOPEN`/`SQLITE_BUSY` (WhatsApp.app holds locks while running).
+- **Cursor:** `ZWAMESSAGE.ZSORT` (monotonic integer, indexed).
+- **Identifier type emitted:** `whatsapp`. Rationale: `whatsapp` is both a `contact_method.type` (added in migration 008) and an identifier_type with dual-mapping behavior (matches `contact_method.whatsapp` AND `contact_method.phone`). Functional matching difference vs generic `phone` — preserves matches against contacts that have explicitly tagged WhatsApp methods.
+- **Content:** message body (`ZWAMESSAGE.ZTEXT`), `ZSTANZAID` (server-side message ID — primary dedup key across hosts), chat JID, sender JID, `ZISFROMME`, group membership via `ZWAGROUPMEMBER`, media type tag from `ZWAMEDIAITEM.ZMEDIATYPE`. Optional media metadata: filename, size, no content.
+- **Group chat attribution:** same as `messages` — sender-only interactions.
+- **Aggregation:** same shared aggregation service (see `messages`).
+- **Edits / deletes / reactions:** WhatsApp's protocol supports edits and revoked messages. v1 scope same as messages — accept stored state at first ingestion; v2 mutation-scan reader covers updates. Reactions tracked as separate `ZWAMESSAGE` rows referencing the original; v1 stores them as plain messages (low value, low effort to filter later).
+- **Permission:** Full Disk Access likely NOT required (sandboxed user-readable). `doctor` probes; falls back to recommending FDA if access fails.
+- **Discovery:** none.
+- **Schema fragility:** Core Data schema is ORM-generated (Z-prefixed). Validate `Z_METADATA.version` on startup; use `PRAGMA table_info` to detect missing columns. Reader marks itself unhealthy with structured error on drift; other sources unaffected.
+
+#### `icloud_contacts`
+
+- **Source:** `CNContactStore` via Contacts framework. **Not** AddressBook SQLite.
+- **Cursor:** `CNChangeHistoryFetchRequest` delta token (macOS 13+). First run fetches all contacts in allowlisted containers; afterward fetches changes since last token.
+- **Pi-side storage:** existing **`external_contact` table** with `source='icloud_contacts'`, `source_id = CNContact identifier`. NOT a separate `icloud_contact` table. Reuses existing match_status enum, duplicate_of_id deduplication, and Import UI. Adds a new `container_identifier` field to `external_contact.metadata` JSONB to track which `CNContainer` produced each row.
+- **Identifier type:** n/a — match flows through existing `MatchOrCreate` on each contact method (email/phone) from the contact's data, same as `gcontacts`.
+- **Content:** display_name, first/last name, organization, job_title, emails JSONB, phones JSONB, postal addresses, birthday, photo_url (we do not yet store photos; capture URL/path for future).
+- **Deletion handling:** `CNChangeHistoryFetchRequest` reports `delete` and `update` events alongside `add`. Daemon emits explicit `external_contact.deleted` events; **the ingest service inline (Stage 1)** sets `external_contact.deleted_at = NOW()` (new column added in same migration). `crm_contact_id` and `match_status` are **preserved unchanged** — `deleted_at` is the tombstone mechanism; the existing FK link enables transparent revive (if the same source_id reappears, the upsert path NULLs `deleted_at` and the row is functionally restored with its original link intact). Removed contact methods within an updated contact are diffed and synced.
+- **Token expiration / full resync:** if the change-history token expires (Apple may invalidate it; spec assumes possible), `CNContactStore` returns an error. Daemon detects, drops cursor, performs full re-sync against the current contact set, and reconciles tombstones (any previously-synced contact not present in the full set is treated as deleted via `external_contact.deleted` event).
+- **Container moves:** a contact moving between containers (e.g., promoted from On-My-Mac to iCloud) is observed as a delete+add. Same contact identifier may not be preserved; the daemon emits both events and relies on existing fuzzy de-dup to keep the CRM contact intact via email/phone match.
+- **Container allowlist:** `crm-mac install` enumerates `CNContainer`s and prompts user. Defaults: include iCloud and On-My-Mac; exclude all CardDAV/Exchange (covered by `gcontacts`). New containers fail-closed; `doctor` warns on overlap with active `gcontacts` integration.
+- **Permission:** Contacts via `requestAccess`.
+- **Discovery:** yes — every contact either matches or surfaces as import candidate, identical to `gcontacts` flow.
+
+#### `anarlog_humans`
+
+- **Source:** `~/Documents/notes/meetings/humans/<uuid>.md` (user-configurable path). YAML frontmatter + optional markdown body (`memo`). Direct file reads (Anarlog CLI rejected: no structured-output guarantees).
+- **Cursor + tombstones + change detection:** state tracked as `{uuid → {mtime, content_hash}}`. mtime advance triggers a content-hash check (SHA-256 of file bytes); only push on hash change. **Mtime alone is insufficient** — Mac filesystem timestamps can be preserved across copies, rounded by filesystems, or move backward under sync tools like iCloud/Dropbox/git restore. **Tombstone detection** via full inventory scan (every safety-poll interval): a UUID present in last scan but absent in current scan is emitted as `external_contact.deleted` for source=anarlog_humans.
+- **Identifier type emitted:** new `anarlog_human_id` (UUID, no contact_method mapping — pure identity-storage hook for future session matching). Match for the human itself happens via the human record's name/emails fields.
+- **Content:** frontmatter (`name`, `emails[]`, `job_title`, `linkedin_username`, `org_id`, `user_id`, `pin_order`, `pinned`, `created_at`) + optional body (`memo`). Defensive parsing: whitelist known fields, accept both `[]` and CSV array formats (Anarlog v1.0.1 changed serialization), tolerate timestamp format drift.
+- **Self-human exclusion:** the file `00000000-0000-0000-0000-000000000000.md` is skipped at reader level.
+- **Pi-side storage:** existing **`external_contact` table** with `source='anarlog_humans'`, `source_id = anarlog UUID`. Same model as `icloud_contacts`. The `anarlog_human_id` is also written to `external_identity` for session-participant lookup.
+- **Permission:** Files & Folders for the configured path.
+- **Discovery:** yes — Anarlog humans are import candidates in the existing Import UI.
+
+#### `anarlog_sessions`
+
+- **Source:** `~/Documents/notes/meetings/sessions/<uuid>/`. Daemon reads `_meta.json`, `_summary.md`, optional `_memo.md`. **`transcript.json` is out of scope for v1** (no speaker labels, word-level only).
+- **Cursor + tombstones + change detection:** state tracked as `{uuid → {meta_mtime, meta_hash, summary_hash, memo_hash}}`. Re-push on any hash change of `_meta.json`, `_summary.md`, or `_memo.md`. Full inventory scan on hourly safety poll detects deleted sessions; emit `meeting_note.deleted` events. Same mtime-unreliability reasoning as `anarlog_humans`.
+- **Identifier type:** participants referenced by `anarlog_human_id` via `_meta.json.participants[].human_id`. Resolution flows through `anarlog_humans` entity sync.
+- **Content:** session id, title, created_at, participants (UUIDs), tags, `_summary.md` body, `_memo.md` body (if present).
+- **Permission:** Files & Folders.
+- **Discovery:** none.
+- **Skip list:** daemon explicitly ignores `chats/`, `daily_notes.json`, `chat_shortcuts.json`, `memories.json`, `tasks.json`, `settings.json`, `store.json`, `search_index/`, `plugins/`, `events.json`, `calendars.json` (calendar already covered by `gcal`).
+
+### 3. Pi-side model
+
+#### Event flow
+
+The daemon publishes events to the existing `/api/v1/ingest/events` endpoint **without changing its wire contract.** The endpoint accepts `{events: [{source, source_id, kind, payload, observed_at}]}` and returns `{accepted, duplicate, rejected, errors}` — unchanged. Cursor management lives on separate endpoints (see Cursor Protocol).
+
+**Three-stage flow, matching the existing Telegram precedent:**
+
+**Stage 1 — Pi ingest service (synchronous, single transaction per batch):**
+For each raw event from the daemon: validate, match identity via `IdentityService.MatchOrCreate`, upsert into the appropriate staging table (dedup by canonical source_id, with `processed_at = NULL` on insert). On batch commit, enqueue an aggregator River job per affected `(contact_id, source)` pair (deduplicated by `(contact_id, source)` — River's built-in uniqueness key). For non-message events (`external_contact.*`, `meeting_note.*`), Stage 1 ALSO performs the full domain work inline in the same tx: upsert `external_contact` row (or `meeting_note` staging row), run identity match, etc. — there is no Stage 2/3 for non-message events; the consumer entries in the table below are descriptive of the inline work, not separate River jobs. The daemon's batch returns `{accepted, duplicate, rejected, errors}` based on staging-row dedup. **Stage 2/3 (aggregation + interaction creation) only applies to `raw_message.*` events.**
+
+**Stage 2 — Aggregator (River job, per-contact serialized):**
+For each contact with new unprocessed staging rows, the shared aggregator job runs: lists rows from the source-specific staging table where `processed_at IS NULL AND (claimed_at IS NULL OR claimed_at < NOW() - INTERVAL '5 minutes')` (a stale-claim recovery window — see Race Mechanics below), groups into bursts, resolves into sessions. For each session, either:
+
+- **Extend path:** find a recent existing interaction matching the session — call `ContactService.ExtendInteraction` and mark the staging rows `processed_at = NOW()` + `interaction_id = <existing>` in the same call. **No event published.**
+- **Create path:** atomically (a) set `claimed_at = NOW()` and `claimed_session_ref = <deterministic_sourceRef>` on the included rows, AND (b) publish the create-event (`message.received` / `message.sent`) with `source_id = <deterministic_sourceRef>`. The claim and the publish are in one DB tx so they succeed or fail together.
+
+River's per-key job-uniqueness ensures at most one aggregator instance runs per `(contact_id, source)` at a time.
+
+**Stage 3 — `InteractionRecorder` (River consumer, async):**
+Consumes create-events from Stage 2. In a single tx: insert the interaction row (idempotent by `(source, source_ref)`); call `StagingRepo.MarkProcessed(ctx, source, ids, interaction_id)` to set `processed_at = NOW()`, **clear `claimed_at = NULL` and `claimed_session_ref = NULL`**, and set `interaction_id = <new>` on those rows; emit `interaction.recorded`. **Post-commit hook: re-enqueue the aggregator job for the same `(contact_id, source)`** — this catches any rows that arrived between Stage 2 and Stage 3 and were excluded by the claim, and any rows whose claim expired during a long-running Stage 3.
+
+Downstream consumers (`cadence_updater`, `followup_manager`) react to `interaction.recorded`.
+
+**Race mechanics — the dedup-then-stuck case Codex flagged:**
+
+Without a claim mechanism, the following race can lose work:
+
+1. Message A arrives → staged with `processed_at=NULL`. Aggregator enqueued.
+2. Aggregator pass 1 lists `[A]`, emits create-event sourceRef X.
+3. Before InteractionRecorder commits, message B arrives → staged with `processed_at=NULL`. Aggregator enqueued.
+4. River starts aggregator pass 2 (allowed because pass 1 has completed publishing). Pass 2 lists `[A, B]` (A still unprocessed), groups into a single session, emits same deterministic sourceRef X.
+5. Event-log `(source, source_id)` dedup catches it. Pass 2's event is dropped.
+6. InteractionRecorder eventually processes the original event with `message_ids=[A]` only. Marks A processed. B stays `processed_at=NULL`, never reconsidered until another trigger arrives.
+
+**The claim + recovery design resolves this:**
+- Step 4's pass 2 lists rows where `processed_at IS NULL AND claimed_at IS NULL`. A was claimed in pass 1 → excluded. Pass 2 sees only `[B]`. Either it finds A's just-created interaction within window (extends, picks up B), or it creates a new session for B.
+- **If pass 2 runs before InteractionRecorder commits A's interaction:** pass 2 sees only B and creates a new session. Result: A and B in two adjacent interactions instead of one. Acceptable; matches v1's "occasional fragmentation" tradeoff.
+- **If pass 2 runs after InteractionRecorder commits A's interaction:** pass 2 finds A's interaction within window via the extend path and includes B in it. Single interaction.
+- **Post-commit re-enqueue from Stage 3** ensures pass 2 is triggered immediately after every Stage 3 commit, maximizing the second case (extend wins) over the first (fragmentation).
+- **Stale-claim recovery (`claimed_at < NOW() - INTERVAL '5 minutes'`):** the recovery path is NOT to re-publish the create-event (event-log `(source, source_id)` dedup would suppress the retry). Instead, the aggregator detects that an event already exists for `claimed_session_ref` and **re-enqueues a River InteractionRecorder job for that existing event** (by event ID, not by re-publishing). The consumer processes the existing event row idempotently: if the interaction was already created, just complete the `MarkProcessed` step (clear `claimed_at`, set `processed_at`, set `interaction_id`); if not, create the interaction + mark in one tx. This makes Stage 3 retryable indefinitely without depending on event re-publication. **Bounds the worst-case stuck duration to the claim TTL.** If `claimed_session_ref` exists in claim but NOT in event log (impossible in practice given the same-tx claim+publish, but defensive): the aggregator clears the claim and treats rows as unclaimed (next pass re-emits cleanly).
+
+**Cursor commit safety:** the daemon commits the source cursor only after the ingest response (Stage 1 commit). At that point, staging rows are durable AND an aggregator job is queued. If Stage 2 or Stage 3 fails transiently, River retries. Daemon re-pushes after cursor-commit failure are absorbed by `(source, source_id)` event-log dedup AND by per-source staging-table unique constraints (`guid`, `stanza_id`, etc.).
+
+| Event kind | Status | Producer (Stage 1) | Consumer (Stage 2) | Stage-1 side effects | Stage-2 side effects |
+|---|---|---|---|---|---|
+| `raw_message.received`, `raw_message.sent` (messages, whatsapp) | **new daemon-emitted kinds** | daemon | (no event-bus consumer; processed by ingest service + aggregator job) | Stage 1: match identity, upsert staging row (dedup by Guid), enqueue aggregator job for affected `(contact_id, source)` | n/a — these events stay in the event-log as raw input record; not delivered to bus consumers |
+| `message.received`, `message.sent` (create path, post-aggregation) | existing | Aggregator (Stage 2 River job) | `InteractionRecorder` (generalized) | published only when aggregator's create path applies — i.e., session has no recent existing interaction to extend. source_id = deterministic burst sourceRef | InteractionRecorder creates interaction row, atomically marks referenced staging rows processed via source-neutral StagingRepo.MarkProcessed, emits `interaction.recorded` |
+| (extend path) | n/a — no event | n/a | n/a | When aggregator finds a recent matching interaction, it extends via direct `ContactService.ExtendInteraction` and marks staging rows processed in the same call. No event is published — extensions intentionally do NOT re-fire cadence/followup consumers (matches Telegram's product behavior). | n/a |
+| `external_contact.upserted` (icloud_contacts, anarlog_humans) | new | Pi ingest service inline (Stage 1 only) | n/a — fully inline | upsert `external_contact` row, run identity match against contact methods, store event row for audit | n/a |
+| `external_contact.deleted` | new | same | n/a — fully inline | set `external_contact.deleted_at = NOW()`. **Does NOT detach `crm_contact_id`** — the `deleted_at` filter already hides the row from match/import queries; preserving the FK enables transparent revive (the upsert path NULLs out `deleted_at` and the prior link remains intact). | n/a |
+| `meeting_note.recorded` (anarlog_sessions) | new | Pi ingest service inline (Stage 1 only) | n/a — fully inline | upsert `meeting_note` staging row (dedup by session UUID), resolve participants via `external_identity` for `anarlog_human_id`, create one interaction per matched participant, emit `interaction.recorded` via existing bus | n/a |
+| `meeting_note.deleted` | new | same | n/a — fully inline | mark staging row `deleted_at = NOW()`; mark the linked interactions soft-deleted via existing interaction soft-delete | n/a |
+
+**`mac_host.heartbeat` is NOT an event** — it's a dedicated endpoint (`POST /api/v1/host/:id/heartbeat`) writing directly to the `mac_host` table. Heartbeats don't traverse the event bus; they're operational state, not domain events.
+
+**`MessageReceivedPayload` V2 extension** (additive, backward-compatible):
+```go
+type MessageReceivedPayload struct {
+    // V1 fields (existing, used by Telegram):
+    Version           int        `json:"version"`           // bumped to 2 by Mac daemon
+    ContactID         *uuid.UUID `json:"contact_id,omitempty"` // nil if unmatched at producer
+    PeerRef           string     `json:"peer_ref"`          // e.g. "messages:+15551234567"
+    MessageAt         time.Time  `json:"message_at"`
+    Description       *string    `json:"description,omitempty"`
+    ExternalMessageID string     `json:"external_message_id,omitempty"`  // chat.db ROWID or WhatsApp Z_PK
+    Direction         string     `json:"direction,omitempty"`
+    MessageIDs        []uuid.UUID `json:"message_ids,omitempty"` // Source-neutral list of staging-row UUIDs (telegram_message, messages_message, or whatsapp_message)
+
+    // V2 fields (optional; populated by Mac daemon emitting raw_message.*, AND by Mac
+    // aggregator emitting aggregated message.received/.sent for source-neutral session events):
+    HostID           *uuid.UUID  `json:"host_id,omitempty"`             // mac_host.id provenance
+    Guid             *string     `json:"guid,omitempty"`                // iMessage guid OR WhatsApp stanza_id (raw_message events only)
+    ChatID           *string     `json:"chat_id,omitempty"`             // chat.db chat.guid, or WhatsApp JID
+    PeerName         *string     `json:"peer_name,omitempty"`           // display name from chat partner (if available)
+    RawText          *string     `json:"raw_text,omitempty"`            // full message body (raw_message events; condensed digest for aggregated)
+    MessageType      *string     `json:"message_type,omitempty"`        // text/photo/audio/video/document/other
+    IsGroup          *bool       `json:"is_group,omitempty"`
+    Attachments      []AttachmentMeta `json:"attachments,omitempty"`
+}
+
+// MessageIDs (existing field) carries source-neutral staging-row UUIDs for ALL
+// sources post-aggregation. Telegram populates with telegram_message UUIDs; Mac
+// aggregator populates with messages_message or whatsapp_message UUIDs.
+// The generalized InteractionRecorder dispatches on event envelope source to mark
+// rows processed_at = NOW() via StagingRepo.MarkProcessed(ctx, source, ids).
+
+type AttachmentMeta struct {
+    Type     string  `json:"type"`               // photo/audio/video/document/other
+    Filename *string `json:"filename,omitempty"`
+    MimeType *string `json:"mime_type,omitempty"`
+    Size     *int64  `json:"size,omitempty"`
+}
+```
+
+V2 fields are populated by the Mac daemon. Telegram's existing producer continues emitting V1; existing consumer logic unchanged. The aggregator (extracted from telegram, now in `backend/internal/messaging/aggregation`) emits V1 or V2 events depending on source. `InteractionRecorder` consumes both; new V2 fields are passed through to the interaction row's metadata where useful.
+
+`interaction.source` CHECK constraint extended via migration to add `messages`, `whatsapp`, `anarlog_sessions`. `external_sync_state.strategy` CHECK constraint extended to add `push`.
+
+**Non-message event payloads (new):**
+
+```go
+// External contact entity sync (icloud_contacts, anarlog_humans)
+type ExternalContactUpsertedPayload struct {
+    Version          int                    `json:"version"` // start at 1
+    HostID           uuid.UUID              `json:"host_id"`
+    Source           string                 `json:"source"`    // "icloud_contacts" | "anarlog_humans"
+    SourceID         string                 `json:"source_id"` // CNContact identifier or Anarlog UUID
+    DisplayName      *string                `json:"display_name,omitempty"`
+    FirstName        *string                `json:"first_name,omitempty"`
+    LastName         *string                `json:"last_name,omitempty"`
+    Emails           []ContactMethodValue   `json:"emails"`    // [{value, type, primary}]
+    Phones           []ContactMethodValue   `json:"phones"`
+    Addresses        []AddressValue         `json:"addresses,omitempty"`
+    Organization     *string                `json:"organization,omitempty"`
+    JobTitle         *string                `json:"job_title,omitempty"`
+    Birthday         *string                `json:"birthday,omitempty"` // ISO date
+    PhotoURL         *string                `json:"photo_url,omitempty"`
+    Metadata         map[string]any         `json:"metadata,omitempty"` // source-specific (container_identifier, anarlog app_version, etc.)
+}
+
+type ExternalContactDeletedPayload struct {
+    Version  int       `json:"version"` // start at 1
+    HostID   uuid.UUID `json:"host_id"`
+    Source   string    `json:"source"`
+    SourceID string    `json:"source_id"`
+}
+
+// Meeting note entity (anarlog_sessions)
+type MeetingNoteRecordedPayload struct {
+    Version       int        `json:"version"` // start at 1
+    HostID        uuid.UUID  `json:"host_id"`
+    Source        string     `json:"source"`           // "anarlog_sessions"
+    SourceID      string     `json:"source_id"`        // anarlog session UUID
+    Title         *string    `json:"title,omitempty"`
+    MeetingAt     time.Time  `json:"meeting_at"`
+    Summary       *string    `json:"summary,omitempty"`        // _summary.md body
+    Memo          *string    `json:"memo,omitempty"`           // _memo.md body, if present
+    ParticipantIDs []string  `json:"participant_ids,omitempty"` // anarlog_human UUIDs
+    Tags          []string   `json:"tags,omitempty"`
+}
+
+type MeetingNoteDeletedPayload struct {
+    Version  int       `json:"version"` // start at 1
+    HostID   uuid.UUID `json:"host_id"`
+    Source   string    `json:"source"`
+    SourceID string    `json:"source_id"`
+}
+```
+
+**Canonical `source_id` values per event kind.** The existing event table has `UNIQUE INDEX idx_event_source_source_id ON event (source, source_id) WHERE source_id IS NOT NULL` (migration 036). Same `(source, source_id)` is dedup-rejected. For **mutable** entity events, the daemon must include a content discriminator in `source_id` so updates aren't lost as duplicates of the initial upsert.
+
+| Event kind | `source_id` value | Notes |
+|---|---|---|
+| `raw_message.received`, `raw_message.sent` (daemon → ingest) | iMessage `guid` (messages) or WhatsApp `stanza_id` (whatsapp) | Globally unique per message; second-host push returns `duplicate` |
+| `message.received`, `message.sent` (aggregator → bus, **create path only**) | Telegram's existing deterministic burst `sourceRef` pattern: e.g., `messages:<chat_id>:<earliest_msg_guid>` (mirrors `backend/internal/telegram/aggregation.go:89` `sourceRef()` method) | Deterministic from the session's first message. If aggregator re-runs on the same message set (e.g., after River retry), source_id is stable → dedup absorbs duplicate emit. Note: the cross-batch fragmentation case is handled by the aggregator's **extend path** (no event), not by source_id semantics — see Aggregation section. |
+| `external_contact.upserted` (icloud_contacts, anarlog_humans) | `<entity_uuid>@<content_hash>` where content_hash = SHA-256 hex of the canonicalized event payload (excluding the source_id itself and the host_id) | Same content → same source_id → dedup as no-op. Content change → new source_id → new event. |
+| `external_contact.deleted` | `<entity_uuid>@deleted@<previous_content_hash>` where previous_content_hash is the SHA-256 of the last content state the daemon observed before this entity disappeared | Deterministic — re-push after cursor-commit failure produces the same source_id because the previous content hash is fixed. Supports delete → revive → delete: each revive cycle's last-observed content yields a different prior hash, so each subsequent delete is its own unique event. If the daemon doesn't know the previous content (e.g., daemon restart with no local cache), it falls back to fetching the entity's current content from `GET /known-ids` extended response (which can include last-content-hash per known ID) or uses sentinel `<entity_uuid>@deleted@unknown` — accepting one-time dedup against any prior `@unknown` delete for the same entity. |
+| `meeting_note.recorded` (anarlog_sessions) | `<session_uuid>@<content_hash>` | Same model as `external_contact.upserted` |
+| `meeting_note.deleted` | `<session_uuid>@deleted@<previous_content_hash>` | Same model as `external_contact.deleted` |
+
+**Distinct event-kind families:** daemon-emitted `raw_message.*` (raw input) and aggregator-emitted `message.*` (aggregated session output) are **different kinds**. Daemon never publishes `message.received`/`message.sent` directly — only `raw_message.*`. The Pi ingest service is the boundary that transforms raw events into aggregated session events. `InteractionRecorder` only consumes `message.received`/`message.sent` — it never sees raw events. This avoids the producer-vs-aggregator naming collision and preserves the existing Telegram consumer flow unchanged (Telegram's producer already emits aggregated `message.*` directly).
+
+New event kinds to add to `events/kinds.go`: `raw_message.received`, `raw_message.sent`, `external_contact.upserted`, `external_contact.deleted`, `meeting_note.recorded`, `meeting_note.deleted`.
+
+**Raw message payload schemas** (concrete Go types, distinct from `MessageReceivedPayload`):
+
+```go
+// RawMessageReceivedPayload — emitted by Mac daemon for messages/whatsapp.
+// Carries the full raw data needed by the Pi ingest service to match identity,
+// upsert staging, and run aggregation. NOT consumed by any bus consumer —
+// processed inline within the ingest transaction.
+type RawMessageReceivedPayload struct {
+    Version      int       `json:"version"` // start at 1
+    HostID       uuid.UUID `json:"host_id"`
+    Source       string    `json:"source"`         // "messages" | "whatsapp"
+    Guid         string    `json:"guid"`           // iMessage guid OR WhatsApp stanza_id
+    ChatID       string    `json:"chat_id"`        // chat.db chat.guid OR WhatsApp JID
+    PeerHandle   string    `json:"peer_handle"`    // raw handle as observed (phone/email)
+    PeerName     *string   `json:"peer_name,omitempty"`
+    Text         *string   `json:"text,omitempty"` // full message body
+    MessageType  string    `json:"message_type"`   // text/photo/audio/video/document/other
+    IsGroup      bool      `json:"is_group"`
+    SentAt       time.Time `json:"sent_at"`        // from source data, NOT daemon clock
+    ReplyToGuid  *string   `json:"reply_to_guid,omitempty"`
+    Attachments  []AttachmentMeta `json:"attachments,omitempty"`
+}
+
+// RawMessageSentPayload — identical shape; separate type for outbound messages
+// emitted by the user. Used by aggregator to determine direction.
+type RawMessageSentPayload RawMessageReceivedPayload
+```
+
+The existing `MessageReceivedPayload` and `MessageSentPayload` (used post-aggregation) keep their V1 fields for Telegram compatibility; the V2 fields described earlier remain optional and may carry post-aggregation digest info (e.g., session-level message_type if all underlying messages share a type) when emitted by the Mac aggregator. **The `MessageIDs` field is generalized**: it is the source-neutral list of staging-row UUIDs that compose the aggregated session, regardless of source. The generalized `InteractionRecorder` looks up the source from the event envelope and marks the corresponding staging table's rows `processed_at = NOW()` via a source-neutral repository method (`StagingRepo.MarkProcessed(ctx, source, ids)`).
+
+#### New tables
+
+- **`mac_host`** — `id` (UUID, stable across reinstalls via Keychain), `hostname`, `daemon_version`, `protocol_version`, `last_heartbeat_at`, `permissions` JSONB, `source_health` JSONB (per-source last_cursor, last_pushed_at, last_error, schema_version), `cursor_epoch` BIGINT (incremented when Pi restored from backup; daemon must match for pushes), `api_key_hash TEXT`, `api_key_revoked_at TIMESTAMPTZ`, `created_at`, `updated_at`. Table designed for multi-host future-proofing, **but v1 enforces single non-revoked host** via a partial unique index: `CREATE UNIQUE INDEX idx_mac_host_singleton ON mac_host ((true)) WHERE api_key_revoked_at IS NULL`. Multi-host operation requires resolving content-hash source_id collisions across hosts — explicitly deferred to a follow-up spec.
+- **`messages_message`** — staging table mirroring `telegram_message`. **Globally unique on `guid`** (iMessage's per-message stable ID — cross-host dedup). Columns include: `guid`, `chat_guid`, `peer_handle`, `peer_normalized`, `text`, `message_type`, `sent_at`, `is_outgoing`, `is_group_chat`, `matched_contact_id`, `interaction_id`, `mac_host_id` (provenance only), `processed_at` (NULL until Stage 3 commits), **`claimed_at` TIMESTAMPTZ** (NULL until aggregator's create path claims; cleared by InteractionRecorder when Stage 3 commits), **`claimed_session_ref` TEXT** (deterministic sourceRef of the pending create-event; cleared by Stage 3). Partial index on `(matched_contact_id) WHERE processed_at IS NULL AND claimed_at IS NULL` to support the aggregator's input filter efficiently.
+- **`whatsapp_message`** — staging table. **Globally unique on `stanza_id`** (WhatsApp server-side message ID). Same column shape as `messages_message` (including `claimed_at` and `claimed_session_ref`) with WhatsApp-specific JIDs. Schema details in implementation plan.
+- **`anarlog_session_message`** (or `meeting_note`) — staging table for anarlog session content. Unique on `anarlog_session_id` (UUID). Columns: session UUID, title, summary, memo, participants JSONB, created_at, `mac_host_id`. **No `claimed_at`/`claimed_session_ref` needed** — anarlog sessions are 1:1 with events (no burst aggregation), so the create-path race doesn't apply.
+
+**Telegram migration:** the existing `telegram_message` table also gains `claimed_at` and `claimed_session_ref` columns via the same migration. The shared aggregator requires them on its source-neutral repository interface. Existing rows backfill with NULL (safe — equivalent to "unclaimed"); the Telegram aggregator's call sites update to use the claim-aware filter.
+
+#### Existing tables — used unchanged or with additive extensions
+
+- **`external_contact`** — used for `source IN ('gcontacts', 'icloud_contacts', 'anarlog_humans')` (see source naming matrix below). **Schema additions:** new `deleted_at TIMESTAMPTZ` column for tombstones, and container_identifier (for iCloud) / app_version (for Anarlog) tracked in `metadata` JSONB.
+  - **Query rules for `deleted_at`:** every query against `external_contact` must filter `WHERE deleted_at IS NULL` unless explicitly working with tombstones. This includes: identity matching candidate lookups, import-candidate UI listings, duplicate-of-id resolution, rematch-worker scans, and per-source statistics. Mirrors the existing soft-delete pattern across the codebase (per `.ai/rules/core.md`). The upsert path (driven by `external_contact.upserted` events) NULLs out `deleted_at` if the row was previously tombstoned, restoring it transparently.
+- **`external_identity`** — used for `(identifier, identifier_type, source)` tracking. New identifier type `anarlog_human_id`. Existing `imessage_phone` / `imessage_email` types become unused; cleanup migration in a follow-up.
+- **`external_sync_state`** — one row per `(source, account_id)` where `account_id = mac_host.id`. Strategy CHECK constraint extended to include `'push'`. The existing `cursor TEXT` column is sufficient for opaque cursor storage.
+- **`interaction.source`** CHECK constraint extended to include `'messages'`, `'whatsapp'`, `'anarlog_sessions'`.
+- **`sync_log`** — one entry per batch.
+- **`event` table + River workers** — unchanged.
+
+#### Source naming matrix
+
+Canonical names per surface. v1 migrations align Mac-introduced sources with the existing convention (using the registered provider name as the source string everywhere data ingress occurs).
+
+| Logical source (this spec) | Provider registry name | `external_sync_state.source` | `external_contact.source` | `interaction.source` | Event envelope `source` field | Frontend label |
+|---|---|---|---|---|---|---|
+| Google Contacts (existing) | `gcontacts` | `gcontacts` | `gcontacts` | n/a (entity sync, no interactions) | `gcontacts` | Google Contacts |
+| Google Calendar (existing) | `gcal` | `gcal` | n/a | `gcal` | `gcal` | Google Calendar |
+| Telegram (existing) | `telegram` | `telegram` | n/a | `telegram` | `telegram` | Telegram |
+| Todoist (existing) | `todoist` | `todoist` | n/a | `todoist` | `todoist` | Todoist |
+| Messages.app (new) | `messages` | `messages` | n/a (no contact entity sync) | `messages` | `messages` | Messages |
+| WhatsApp (new) | `whatsapp` | `whatsapp` | n/a | `whatsapp` | `whatsapp` | WhatsApp |
+| iCloud Contacts (new) | `icloud_contacts` | `icloud_contacts` | `icloud_contacts` | n/a (entity sync) | `icloud_contacts` | iCloud Contacts |
+| Anarlog Humans (new) | `anarlog_humans` | `anarlog_humans` | `anarlog_humans` | n/a (entity sync) | `anarlog_humans` | Anarlog Humans |
+| Anarlog Sessions (new) | `anarlog_sessions` | `anarlog_sessions` | n/a | `anarlog_sessions` | `anarlog_sessions` | Anarlog Sessions |
+
+**Note on the existing `external_contact.source='google'` value (currently in production data):** there is a naming gap between `external_contact.source='google'` and provider registry `gcontacts`. v1 does NOT propose renaming the existing column value; new sources align to the registry name, and the existing `'google'` value continues to function (with a documented inconsistency). A future cleanup migration could rename `'google'` → `'gcontacts'` for full alignment, scheduled when the team is ready for the data migration.
+
+#### Sync provider registration
+
+The 5 sources register in `ProviderRegistry` with new `Strategy=push` (added to existing `contact_driven`, `fetch_all`, `fetch_filtered`). For `push` providers:
+- `Sync()` is a no-op.
+- The scheduler's `ListDueAccounts` **explicitly excludes push-strategy providers**. Push providers never get enqueued by the periodic tick. Tested explicitly to prevent silent regression.
+- The integrations UI treats push providers as first-class: shows last heartbeat-reported cursor, last-pushed-at, errors. Status is reported via heartbeat, not via internal sync logs.
+
+#### Per-source rematch workers
+
+Mirror Telegram's pattern. Run on `contact_method.created` (for phone/email-derived sources) and on `external_contact.upserted` (with `match_status=matched`) (for `anarlog_humans` → `anarlog_sessions` chain):
+- `messages_rematch` — on `contact_method.created` with type phone/email
+- `whatsapp_rematch` — on `contact_method.created` with type phone or whatsapp
+- `anarlog_sessions_rematch` — on `external_contact.upserted` (with `match_status=matched`) for source=anarlog_humans
+
+#### Endpoints
+
+```
+POST   /api/v1/host                                # pairing token → host_id + api_key (unauthenticated; pairing-token-only)
+POST   /api/v1/host/:id/heartbeat                  # rich status update; updates mac_host.last_heartbeat_at and per-source health
+GET    /api/v1/host/:id/sync/:source/cursor        # daemon fetches {cursor, epoch, backfill_complete} for a source
+POST   /api/v1/host/:id/sync/:source/cursor        # daemon commits new cursor after successful event push
+GET    /api/v1/host/:id/sync/:source/known-ids     # returns [{source_id, last_content_hash}] for entities the Pi has for this (host, source). Used for tombstone reconciliation (entity in Pi-set but absent from daemon scan → daemon emits external_contact.deleted with previous content hash) and for delete source_id determinism (daemon uses the returned last_content_hash to build the deterministic delete source_id).
+POST   /api/v1/ingest/events                       # existing endpoint, used by daemon for all data events; contract unchanged
+GET    /api/v1/host/:id                            # for Pi UI
+DELETE /api/v1/host/:id                            # user uninstall path; cascades source state
+```
+
+**Two-tier authentication.** Mac-related routes split into **daemon self-service routes** (authenticated as the host itself) and **admin/UI routes** (authenticated as the human user via the existing global API key).
+
+1. `mac_host` schema stores `api_key_hash TEXT` (bcrypt hash) and `api_key_revoked_at TIMESTAMPTZ` columns. Plaintext host key returned once at pairing.
+2. **Daemon self-service routes** — authenticated by new `MacHostAuthMiddleware`:
+   - `POST /api/v1/host/:id/heartbeat`
+   - `GET  /api/v1/host/:id/sync/:source/cursor`
+   - `POST /api/v1/host/:id/sync/:source/cursor`
+   - `GET  /api/v1/host/:id/sync/:source/known-ids`
+   - `POST /api/v1/ingest/events` (when `X-Mac-Host-ID` header is present)
+   - Middleware reads `X-Mac-Host-ID` header and Bearer token; looks up `mac_host` by ID; verifies `api_key_revoked_at IS NULL`; validates token against `api_key_hash` (constant-time bcrypt compare); for `:id` parameter routes, asserts URL `:id` matches `X-Mac-Host-ID`.
+3. **Admin/UI routes** — authenticated by the existing global `APIKeyMiddleware` (the Pi UI's existing auth surface):
+   - `GET    /api/v1/host`         (list all registered Macs)
+   - `GET    /api/v1/host/:id`     (Mac status detail for UI)
+   - `DELETE /api/v1/host/:id`     (uninstall flow — also revokes host key by setting `api_key_revoked_at`)
+   - `POST   /api/v1/host/pairing-token` (Pi UI requests a new pairing token to display)
+   - `POST   /api/v1/ingest/events` (when `X-Mac-Host-ID` header is absent — other publishers continue using the global key)
+4. **Pairing endpoint** (`POST /api/v1/host`) bypasses both — validates against the short-TTL pairing_token (separate table `mac_host_pairing_token` with `token_hash`, `expires_at`, `consumed_at`, `created_by_user`).
+5. **Revocation:** UI's "uninstall Mac" flow calls `DELETE /api/v1/host/:id` which sets `api_key_revoked_at`. Daemon's next request returns 401; daemon detects, halts, and surfaces the error in `crm-mac status` and `os.Log`.
+
+**Routing implementation:** the ingest endpoint's auth path is selected by presence of `X-Mac-Host-ID`. All other route paths are statically partitioned into the two tiers above by URL pattern.
+
+#### Cursor protocol
+
+Cursors are managed on a **dedicated endpoint** rather than baked into the ingest contract — this preserves the existing `/api/v1/ingest/events` wire contract that other publishers depend on.
+
+**Cursor representation:** opaque `TEXT` per source. Pi never interprets the cursor value; it only stores and returns it. Per-source semantics:
+- `messages`, `whatsapp`: cursor is a JSON object `{"backfill_cursor": "<value>", "live_cursor": "<value>", "backfill_complete": bool}` — backfill and live progress coexist. `backfill_cursor` walks **backward** from the install-time `MAX(ROWID)` (or `MAX(ZSORT)`) toward 2026-01-01; `live_cursor` advances **forward** from the install-time max. When `backfill_complete=true`, only `live_cursor` is consulted on subsequent polls. Late-arriving historical rows (e.g., Messages sync from another device backfills past data) are picked up because the daemon polls from `live_cursor` forward only; rows older than `live_cursor` are not revisited, but the daemon emits them during the initial backward backfill pass. Acceptable tradeoff documented; v2 mutation-scan reader covers the long tail.
+- `icloud_contacts`: cursor is the opaque `CNChangeHistory` token (Apple-managed, persisted as base64 string). Backfill is a single bulk fetch on first run; no separate backfill_cursor. Token expiration → daemon performs full resync: fetches all contacts via `CNContactStore`, fetches `GET /known-ids` from Pi (returning source_ids the Pi has for this source/host), computes set diff. Contacts in Pi-set but not in current scan → emit `external_contact.deleted` events. Contacts in current scan but not in Pi-set → emit `external_contact.upserted`. Contacts in both → emit `upserted` (content-hash dedup absorbs no-ops).
+- `anarlog_humans`, `anarlog_sessions`: cursor is a JSON map `{uuid: {content_hash, mtime}}` snapshot of the last successful full scan. mtime is a cheap optimization (skip files with unchanged mtime), but **content_hash is the truth** — a file with same mtime but different hash IS re-pushed. Tombstones: UUIDs in previous cursor but absent from current scan are emitted as `*.deleted` events. On cursor-state loss (daemon reinstall, Pi restore, epoch mismatch), daemon fetches `GET /known-ids` from Pi and reconciles same as iCloud token-expiration flow.
+
+**Daemon flow per source poll:**
+1. `GET /api/v1/host/:id/sync/:source/cursor` → returns `{cursor: "X", epoch: 42, backfill_complete: true}`. Daemon caches both values locally.
+2. Read source data from cursor `X` → produce events.
+3. `POST /api/v1/ingest/events` with batch. Existing 4xx/5xx error handling applies. Returns `{accepted, duplicate, rejected, errors}`.
+4. If batch outcome is "all rows accepted or duplicate; no rejections," daemon advances cursor: `POST /api/v1/host/:id/sync/:source/cursor` with `{cursor: "Y", epoch: 42, base_cursor: "X"}`.
+5. Pi validates `epoch` matches current `mac_host.cursor_epoch` AND `base_cursor` matches stored cursor for that source. On match: stores new cursor `Y`. On mismatch: returns `409 Conflict` with `{current_cursor, current_epoch}`. Daemon refetches and retries from step 2.
+6. If any events were rejected: daemon does NOT advance cursor. Next poll re-reads and re-pushes; staging-table unique constraints on `guid`/`stanza_id`/session UUID dedupe naturally.
+
+**`cursor_epoch` semantics:** column on `mac_host`. Bumped manually (or via admin endpoint) whenever Pi is restored from backup or its sync state is reset. Forces daemons to refetch all cursors and reconcile. Protects against the "Pi restored to older state while daemon held newer cursor" failure mode.
+
+**Cursor commit vs event materialization:**
+- Stage 1 ingest is transactional per batch (existing behavior). In a single tx: insert raw event row(s); upsert staging row(s) with `processed_at = NULL`; enqueue aggregator River job(s) for affected contacts. All durable on commit.
+- Aggregation (Stage 2) and interaction creation (Stage 3) happen asynchronously. Cursor safety does **not** depend on either succeeding; it depends only on Stage 1's tx committing.
+- Cursor commit happens *after* successful ingest response. At that point, raw events + staging rows + queued aggregator jobs are all durable.
+- If cursor commit fails after a successful ingest: next poll re-reads source from the old cursor and re-pushes the same events. Raw events dedup at `(source, source_id)` on the event table; staging rows dedup at the per-source unique constraint. Result: idempotent end-to-end.
+- If Stage 2 (aggregator) fails before publishing: River retries the aggregator job. Rows remain `claimed_at = NULL AND processed_at = NULL`; clean retry.
+- If Stage 3 (InteractionRecorder) fails: River retries that consumer against the same event row. Rows persist with `claimed_at IS NOT NULL AND processed_at = NULL`. If River exhausts retries, stale-claim recovery (aggregator's next pass after 5 min) re-enqueues a consumer job against the existing event by ID lookup (NOT by re-publishing — see Race mechanics).
+- No "phantom cursor advance past unmaterialized data" risk because Stage 1 (the durability boundary) is atomic. No "lost messages" risk because `processed_at IS NULL` rows are the persistent claim that work remains.
+
+#### Multi-host content-level dedup
+
+Same message landing on two Macs is deduplicated at the staging-table unique constraint:
+- `messages_message`: unique on `guid` (iMessage's stable per-message ID). First push wins; second push is a no-op insert (returns existing row).
+- `whatsapp_message`: unique on `stanza_id`. Same model.
+- `anarlog_session_message`: unique on `anarlog_session_id`.
+
+`mac_host_id` on staging rows is provenance only. Interactions are created once per matched message; subsequent hosts pushing the same content noop on staging insert.
+
+#### Frontend additions
+
+- **New "Mac" settings page:** lists `mac_host` rows (single host in v1, multi-host display when 2nd registers); per-host shows connection status from heartbeat age, version + protocol version, permissions state (FDA/Contacts/Files), source-level health, "uninstall" button (calls `DELETE /api/v1/host/:id`).
+- **Five new sources auto-appear in the existing Integrations list.**
+- **Contact detail timeline:** messages, WhatsApp, Anarlog session interactions appear via existing `interaction.source` rendering; new source values get icons/labels.
+- **Discovery UI:** existing Import page gets icloud + anarlog contacts via `external_contact.source` filter, no new tables needed.
+- **No UI uses `identifier_type` directly** (verified via grep) — identifier_type is internal matching plumbing.
+
+### 4. Identifier types — explicit per-source mapping
+
+| Source | Identifier type | Rationale |
+|---|---|---|
+| `messages` (phone handles) | `phone` (generic) | Messages.app delivers both iMessage and SMS; `imessage_phone` is semantically inaccurate. `source='messages'` carries channel provenance. |
+| `messages` (email handles) | `email` (generic) | Same reasoning. |
+| `whatsapp` | `whatsapp` | Both a contact_method type and an identifier_type with functional dual-mapping (matches `contact_method.whatsapp` AND `contact_method.phone`). Loses match coverage if reduced to generic. |
+| `icloud_contacts` | n/a — matches via individual phone/email contact methods, same as `gcontacts` |
+| `anarlog_humans` | `anarlog_human_id` (new) | UUID identity space, no contact_method mapping; pure storage hook for future session→human→contact resolution. |
+| `anarlog_sessions` | (consumes) `anarlog_human_id` | Participant resolution flows through `external_identity` keyed on `anarlog_human_id`. |
+
+**Existing types becoming unused:** `imessage_phone`, `imessage_email`. Cleanup migration removes them in a follow-up PR (no v1 dependency).
+
+### 5. Failure modes & resilience
+
+**Daemon crash:** launchd restarts. On startup: re-fetch cursors from Pi (including `cursor_epoch`), re-validate permissions, resume polling. No data loss; source data is durable.
+
+**Pi unreachable:** poller tick fails fast (short timeout), logs to `os.Log`, retries next tick with bounded exponential backoff. No local queue.
+
+**Mac asleep / closed lid / offline:** launchd suspends. On wake, `NSBackgroundActivityScheduler` triggers the next scheduled run. Catch-up via cursor-based incremental sync.
+
+**Permission revoked:** reader emits structured permission error, marks itself unhealthy in heartbeat. `doctor` shows remediation. Other sources unaffected.
+
+**Source schema drift (chat.db, WhatsApp, Anarlog):** reader detects via `PRAGMA table_info` (SQLite) or whitelist-parsing failure (markdown). Marks unhealthy, includes specific column-name diff in heartbeat error. Ships a daemon update to fix.
+
+**Pi cursor / Mac cursor disagree:** governed by Cursor Protocol — `cursor_epoch` + `base_cursor` precondition. Daemon refetches on `409 Conflict`; safe even if Pi was restored mid-flight.
+
+**Duplicate ingestion:** staging-table unique constraints on content-level IDs (`guid`, `stanza_id`, anarlog UUID). Replays are safe noops. The event table's `UNIQUE (source, source_id) WHERE source_id IS NOT NULL` partial index (migration 036) provides a second idempotency layer at the event-log level.
+
+**Backfill in progress + new live events:** Telegram's `backfill_cursor` + `live_cursor` pattern. Backfill completes at 2026-01-01 floor.
+
+**Multiple Mac hosts pushing simultaneously:** first-to-push wins at staging unique constraint; subsequent hosts noop. Cursors are per-`(source, host_id)` so each host advances independently, but interactions are content-deduped.
+
+**Scheduling determinism (NSBackgroundActivityScheduler):** macOS may coalesce or defer background activity for energy reasons, especially on battery. v1 accepts this tradeoff — we're already comfortable with Todoist-tier latency (~1-2 min). If determinism becomes a problem (e.g., users consistently see >5min lag on AC power), fall back to `Timer` + `DispatchSource` + explicit `ProcessInfo.beginActivity` markers. Heartbeat tracks actual schedule vs target so this is observable.
+
+**Version skew:** daemon's `protocol_version` reported in heartbeat. Pi defines `MIN_PROTOCOL_VERSION`; older daemons get a `412 Precondition Failed` with upgrade instructions. Skew is observable in the Pi UI ("Mac daemon version 1.2 is incompatible with this Pi version; upgrade with `crm-mac install --upgrade`").
+
+**Daemon-Pi clock skew:** all event timestamps come from source data (chat.db, WhatsApp, file mtimes, Anarlog frontmatter). Daemon clock is only used for `last_heartbeat_at` display purposes; minor skew is acceptable. Pi never trusts daemon-supplied "now."
+
+### 6. Observability
+
+**Heartbeat payload (POSTed every ~60s):**
+```json
+{
+  "host_id": "uuid",
+  "hostname": "spencer-mbp",
+  "daemon_version": "0.3.1",
+  "protocol_version": 1,
+  "cursor_epoch": 42,
+  "permissions": {"fda": true, "contacts": true, "files_anarlog": true},
+  "sources": {
+    "messages": {
+      "enabled": true,
+      "last_scheduled_at": "2026-05-11T15:30:00Z",
+      "last_pushed_at":   "2026-05-11T15:30:02Z",
+      "observed_cursor":  104289,
+      "pushed_cursor":    104289,
+      "schema_version":   "chat_db_v1",
+      "backfill_complete": true,
+      "last_error":       null,
+      "last_error_at":    null
+    },
+    ...
+  }
+}
+```
+
+**Mac-side:** `crm-mac status` (instant local view), `crm-mac logs --source X --follow`, `crm-mac doctor`. All logs to `os.Log` with subsystem `com.spengrah.crm-mac`.
+
+**Pi-side:** new Mac settings page surfacing heartbeat fields. Existing integrations UI shows per-source last-pushed and errors. New cursor-lag visualization: `observed_cursor - pushed_cursor` per source highlights stuck pushes.
+
+**Alerting:** none in v1. UI cues are sufficient (single user). Future hook: Pi emits toast via #196 infrastructure when any source's last-pushed lag exceeds threshold.
+
+---
+
+## Phasing
+
+### v1 — Daemon framework + `messages` + `icloud_contacts`
+
+Validates the trickiest cross-cutting concerns (FDA permission, container allowlist, pairing flow, event-bus generalization).
+
+**Daemon shell (Swift):**
+- SPM scaffold, `crm-mac` binary with `daemon` and CLI subcommands
+- `SMAppService` registration, install/uninstall/configure flow
+- Keychain integration, config file, `state.json` cache
+- `URLSession` Pi client with auth, retries, chunked uploads
+- `NSBackgroundActivityScheduler` per-source registration
+- `os.Log` integration
+- `crm-mac doctor` Pi-reachability + FDA + Contacts probes
+- Pairing token flow (Pi UI generates → daemon consumes)
+
+**Pi side:**
+- `mac_host` table + endpoints (`POST /host` with pairing token; heartbeat; DELETE; GET)
+- Cursor protocol implementation (`cursor_epoch`, `base_cursor` validation)
+- `sync_strategy=push` added to enum; scheduler `ListDueAccounts` exclusion + regression test
+- **Shared aggregation extraction:** Telegram's `backend/internal/telegram/aggregation.go` (and its `interactionExtender` interface) extracted into `backend/internal/messaging/aggregation` with a source-neutral interface. The `messageRepo` dependency becomes a source-neutral interface implemented by per-source staging repositories (`messages_message`, `whatsapp_message`, existing `telegram_message`). Telegram's existing call site swapped to use the shared package — semantic behavior preserved verbatim. The aggregator continues to handle burst-windowing, reply bridging, direction inference, and the two-path output (extend vs create) identically across sources.
+- **Ingest service generalization:** receives Mac-emitted events at `/api/v1/ingest/events`. For `raw_message.*` events, per batch in single tx: (1) match identifier → contact_id via existing `IdentityService.MatchOrCreate`; (2) upsert staging rows with `processed_at = NULL` (dedup by Guid); (3) record event rows; (4) enqueue aggregator River jobs deduplicated by `(contact_id, source)`. Stage 2 aggregator + Stage 3 InteractionRecorder run async; both already exist for Telegram (with minor source-neutralizing refactor). For `external_contact.*` and `meeting_note.*` events, ingest service does all domain work inline in the same tx — no async stages.
+- **Aggregator River job scheduling:** new River job kind `MessagingAggregateForContact(contact_id, source)`. Uniqueness key = (contact_id, source). When ingest stages new rows, it enqueues this job; if a job with the same key is already pending/running, the enqueue is a no-op (River's built-in dedup). Each job processes all **eligible** rows for that (contact, source) pair — the claim-aware filter `processed_at IS NULL AND (claimed_at IS NULL OR claimed_at < NOW() - INTERVAL '5 minutes')`. The job exits when no eligible rows remain; rows currently claimed by a pending create-event are intentionally skipped and will be drained by Stage 3's post-commit re-enqueue (or by stale-claim recovery if Stage 3 fails). This ensures per-contact serialization across batches.
+- **InteractionRecorder generalization:** the existing consumer is extended to use `StagingRepo.MarkProcessed(ctx, source, ids, interaction_id)` — a new source-neutral repository method that dispatches to the right per-source staging table. Today the consumer directly calls `telegram_message.MarkMessagesProcessed`; the refactor replaces this with the dispatching method without changing the consumer's flow semantics.
+- `interaction.source` CHECK constraint migration: add `messages`
+- `external_sync_state.strategy` CHECK constraint migration: add `push`
+- New Mac settings page in Next.js frontend
+
+**`messages` source:**
+- chat.db reader (GRDB.swift, read-only)
+- `messages_message` staging table (unique on `guid`) + migration + sqlc queries + repository
+- Event publisher: `raw_message.received` / `raw_message.sent` events to `/api/v1/ingest/events` (Pi-side aggregator transforms into aggregated `message.received`/`message.sent`)
+- `messages_rematch` worker on `contact_method.created`
+- Backfill to 2026-01-01 with `backfill_cursor` pattern
+- Identity matching via existing matcher with generic `phone`/`email` types
+- Group-chat attribution: sender-only interactions (no per-participant)
+- Edits/deletes/reactions: accepted as v1 limitation; documented in plan
+
+**`icloud_contacts` source:**
+- `CNContactStore` reader with `CNChangeHistoryFetchRequest`
+- Container allowlist picker (`crm-mac install` and `crm-mac configure`)
+- Event publisher: `external_contact.upserted`, `external_contact.deleted`
+- Ingest service extended to handle `external_contact.upserted` / `external_contact.deleted` events inline for `source='icloud_contacts'` (no separate consumer)
+- Token expiration → full resync + tombstone reconciliation
+- Reuses existing Import UI via `external_contact.source='icloud_contacts'`
+
+**Value at end of v1:** `last_contacted` auto-updates from iMessage/SMS via Messages.app; iCloud contacts surface as import candidates and enrich existing CRM contacts.
+
+### v2 — Anarlog (humans + sessions)
+
+- File-format inspection sub-task (research already done; see `.ai/log/plan/mac-daemon-research-findings.md`).
+- Swift readers (`AnarlogHumans` mtime-based, `AnarlogSessions` FSEvents + safety poll).
+- New identifier type `anarlog_human_id` in `external_identity` enum.
+- `external_contact.source='anarlog_humans'` (no new contact table).
+- New `meeting_note` staging table + `meeting_note.recorded` / `meeting_note.deleted` event kinds.
+- Ingest service extended to handle `meeting_note.*` events inline (participant resolution + per-matched-participant interaction creation + `interaction.recorded` emit, all in the ingest tx). No separate consumer.
+- Tombstone events (`external_contact.deleted`, `meeting_note.deleted`).
+- `anarlog_sessions_rematch` worker on `external_contact.upserted` (with `match_status=matched`) for source=anarlog_humans.
+
+### v3 — WhatsApp
+
+- WhatsApp Mac client store discovery already done; see research findings.
+- Swift reader with Core Data schema validation via `Z_METADATA` and `PRAGMA table_info`.
+- `whatsapp_message` staging table (unique on `stanza_id`).
+- `whatsapp` identifier type wiring (existing in normalize.go).
+- `interaction.source` migration: add `whatsapp`.
+- `whatsapp_rematch` worker.
+- Lock contention handling (backoff on `SQLITE_BUSY`).
+
+---
+
+## Open questions
+
+Items deferred to implementation phase (genuine design decisions, not unresolved questions):
+
+- **Exact `messages_message` and `whatsapp_message` column lists** — implementation plan derives from chat.db / `ZWAMESSAGE` schemas captured in research findings.
+- **Anarlog folder path UX edge cases** — `doctor` validation rules when path is configured but doesn't exist, or contains no `humans/`/`sessions/` subdirectories.
+- **Backfill progress UI** — Telegram pattern covers the data; whether to surface a progress bar in v1 is a small polish item.
+- **Pairing token UI** — exact UX of token generation and display in the Pi web UI. Functional design: button → token displayed in modal with copy-to-clipboard + countdown timer.
+
+Items intentionally **out of v1 scope, queued for follow-up specs:**
+
+- **Edit/delete/reaction sync for messages and WhatsApp** — needs a separate "mutation scan" reader pattern over a recent-N-day window.
+- **Anarlog transcript ingestion** — speaker diarization required before transcripts become CRM-useful.
+- **Cross-source unified discovery UI** — consolidate import candidates from multiple sources into a single ranked view.
+- **Cleanup migration to remove dead `imessage_phone`/`imessage_email` identifier types** — non-blocking; data has no producers.
+
+---
+
+## References
+
+**Issues this incorporates:**
+- #73 — feat: iMessage integration
+- #74 — feat: iCloud Contacts integration
+
+**Existing patterns referenced:**
+- `backend/internal/sync/provider.go` — `SyncProvider` interface, `ProviderRegistry`
+- `backend/internal/api/handlers/ingest.go` + `backend/internal/service/ingest.go` — existing `/api/v1/ingest/events` ingest path
+- `backend/internal/telegram/aggregation.go` — message-burst aggregation, reply bridging, direction-aware cadence; v1 extracts to shared package
+- `backend/internal/identity/normalize.go` — identifier type mapping and matching
+- `backend/migrations/014_external_contact.up.sql` — unified external_contact table
+- `backend/migrations/032_telegram.up.sql` — telegram_message staging precedent
+- `backend/internal/consumer/interaction_recorder.go` — currently telegram-only; v1 generalizes
+- `.ai/patterns/sync.md` — sync pipeline architecture
+- `.ai/spec/event-bus-foundation.md` — event-bus design context
+- `.ai/spec/telegram-integration.md` — similar-shape integration spec
+- `.ai/log/plan/mac-daemon-research-findings.md` — preliminary research findings (gitignored)
+- PR #298 — versioned event payloads

--- a/.ai/spec/mac-daemon.md
+++ b/.ai/spec/mac-daemon.md
@@ -548,7 +548,7 @@ Same message landing on two Macs is deduplicated at the staging-table unique con
 ```json
 {
   "host_id": "uuid",
-  "hostname": "spencer-mbp",
+  "hostname": "<mac-hostname>",
   "daemon_version": "0.3.1",
   "protocol_version": 1,
   "cursor_epoch": 42,

--- a/backend/internal/db/event.sql.go
+++ b/backend/internal/db/event.sql.go
@@ -104,6 +104,27 @@ func (q *Queries) GetEvent(ctx context.Context, id pgtype.UUID) (*Event, error) 
 	return &i, err
 }
 
+const HardDeleteEventsBySourceAndSourceIDPrefix = `-- name: HardDeleteEventsBySourceAndSourceIDPrefix :exec
+DELETE FROM event
+WHERE source = $1
+  AND source_id LIKE $2
+`
+
+type HardDeleteEventsBySourceAndSourceIDPrefixParams struct {
+	Source         string      `json:"source"`
+	SourceIDPrefix pgtype.Text `json:"source_id_prefix"`
+}
+
+// Test-only: hard-deletes event rows whose (source, source_id) match the
+// given source and a LIKE-prefix on source_id. Used by integration tests
+// to purge per-run event envelopes so a re-run does not collide on the
+// (source, source_id) partial unique. The event log is otherwise
+// append-only; production code MUST NOT call this.
+func (q *Queries) HardDeleteEventsBySourceAndSourceIDPrefix(ctx context.Context, arg HardDeleteEventsBySourceAndSourceIDPrefixParams) error {
+	_, err := q.db.Exec(ctx, HardDeleteEventsBySourceAndSourceIDPrefix, arg.Source, arg.SourceIDPrefix)
+	return err
+}
+
 const InsertEvent = `-- name: InsertEvent :one
 
 INSERT INTO event (id, source, source_id, kind, payload, observed_at)

--- a/backend/internal/db/interaction.sql.go
+++ b/backend/internal/db/interaction.sql.go
@@ -138,6 +138,103 @@ func (q *Queries) FindInteractionInWindow(ctx context.Context, arg FindInteracti
 	return &i, err
 }
 
+const FindRecentInteractionBySourceAndDirection = `-- name: FindRecentInteractionBySourceAndDirection :one
+SELECT id, contact_id, source, source_ref, occurred_at, description, created_at, deleted_at, direction FROM interaction
+WHERE contact_id = $1
+  AND source = $2
+  AND direction = $3
+  AND source_ref LIKE $4
+  AND occurred_at >= $5
+  AND occurred_at <= $6
+  AND deleted_at IS NULL
+ORDER BY occurred_at DESC
+LIMIT 1
+`
+
+type FindRecentInteractionBySourceAndDirectionParams struct {
+	ContactID       pgtype.UUID        `json:"contact_id"`
+	Source          string             `json:"source"`
+	Direction       string             `json:"direction"`
+	SourceRefPrefix pgtype.Text        `json:"source_ref_prefix"`
+	WindowStart     pgtype.Timestamptz `json:"window_start"`
+	WindowEnd       pgtype.Timestamptz `json:"window_end"`
+}
+
+// Source-neutral generalization of FindRecentTelegramInteraction.
+// Used by the shared aggregator (backend/internal/messaging/aggregation)
+// for same-direction coalescing. source_ref_prefix should include
+// trailing % for LIKE match.
+func (q *Queries) FindRecentInteractionBySourceAndDirection(ctx context.Context, arg FindRecentInteractionBySourceAndDirectionParams) (*Interaction, error) {
+	row := q.db.QueryRow(ctx, FindRecentInteractionBySourceAndDirection,
+		arg.ContactID,
+		arg.Source,
+		arg.Direction,
+		arg.SourceRefPrefix,
+		arg.WindowStart,
+		arg.WindowEnd,
+	)
+	var i Interaction
+	err := row.Scan(
+		&i.ID,
+		&i.ContactID,
+		&i.Source,
+		&i.SourceRef,
+		&i.OccurredAt,
+		&i.Description,
+		&i.CreatedAt,
+		&i.DeletedAt,
+		&i.Direction,
+	)
+	return &i, err
+}
+
+const FindRecentOutboundInteractionBySource = `-- name: FindRecentOutboundInteractionBySource :one
+SELECT id, contact_id, source, source_ref, occurred_at, description, created_at, deleted_at, direction FROM interaction
+WHERE contact_id = $1
+  AND source = $2
+  AND direction = 'outbound'
+  AND source_ref LIKE $3
+  AND occurred_at >= $4
+  AND occurred_at <= $5
+  AND deleted_at IS NULL
+ORDER BY occurred_at DESC
+LIMIT 1
+`
+
+type FindRecentOutboundInteractionBySourceParams struct {
+	ContactID       pgtype.UUID        `json:"contact_id"`
+	Source          string             `json:"source"`
+	SourceRefPrefix pgtype.Text        `json:"source_ref_prefix"`
+	WindowStart     pgtype.Timestamptz `json:"window_start"`
+	WindowEnd       pgtype.Timestamptz `json:"window_end"`
+}
+
+// Source-neutral generalization of FindRecentOutboundTelegramInteraction.
+// Used by the shared aggregator for time-based reply bridging on inbound
+// sessions.
+func (q *Queries) FindRecentOutboundInteractionBySource(ctx context.Context, arg FindRecentOutboundInteractionBySourceParams) (*Interaction, error) {
+	row := q.db.QueryRow(ctx, FindRecentOutboundInteractionBySource,
+		arg.ContactID,
+		arg.Source,
+		arg.SourceRefPrefix,
+		arg.WindowStart,
+		arg.WindowEnd,
+	)
+	var i Interaction
+	err := row.Scan(
+		&i.ID,
+		&i.ContactID,
+		&i.Source,
+		&i.SourceRef,
+		&i.OccurredAt,
+		&i.Description,
+		&i.CreatedAt,
+		&i.DeletedAt,
+		&i.Direction,
+	)
+	return &i, err
+}
+
 const FindRecentOutboundTelegramInteraction = `-- name: FindRecentOutboundTelegramInteraction :one
 SELECT id, contact_id, source, source_ref, occurred_at, description, created_at, deleted_at, direction FROM interaction
 WHERE contact_id = $1
@@ -249,6 +346,27 @@ func (q *Queries) GetInteraction(ctx context.Context, id pgtype.UUID) (*Interact
 		&i.Direction,
 	)
 	return &i, err
+}
+
+const HardDeleteInteractionsBySourceRefPrefix = `-- name: HardDeleteInteractionsBySourceRefPrefix :exec
+DELETE FROM interaction
+WHERE source = $1
+  AND source_ref LIKE $2
+`
+
+type HardDeleteInteractionsBySourceRefPrefixParams struct {
+	Source          string      `json:"source"`
+	SourceRefPrefix pgtype.Text `json:"source_ref_prefix"`
+}
+
+// Test-only: hard-deletes interactions whose source matches and source_ref
+// begins with prefix. Used by integration tests to purge per-run rows
+// cleanly; soft-delete is unsafe because the (source, source_ref) partial
+// unique constraint would block a same-source_ref re-insert on the next
+// test run even with deleted_at set.
+func (q *Queries) HardDeleteInteractionsBySourceRefPrefix(ctx context.Context, arg HardDeleteInteractionsBySourceRefPrefixParams) error {
+	_, err := q.db.Exec(ctx, HardDeleteInteractionsBySourceRefPrefix, arg.Source, arg.SourceRefPrefix)
+	return err
 }
 
 const HasResponseAfter = `-- name: HasResponseAfter :one

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -243,6 +243,15 @@ type Querier interface {
 	// two-step creation is visible to this guard. Used by the
 	// FollowUpManager consumer when running inside a worker transaction.
 	FindPendingFollowUpTx(ctx context.Context, contactID pgtype.UUID) (*ContactTask, error)
+	// Source-neutral generalization of FindRecentTelegramInteraction.
+	// Used by the shared aggregator (backend/internal/messaging/aggregation)
+	// for same-direction coalescing. source_ref_prefix should include
+	// trailing % for LIKE match.
+	FindRecentInteractionBySourceAndDirection(ctx context.Context, arg FindRecentInteractionBySourceAndDirectionParams) (*Interaction, error)
+	// Source-neutral generalization of FindRecentOutboundTelegramInteraction.
+	// Used by the shared aggregator for time-based reply bridging on inbound
+	// sessions.
+	FindRecentOutboundInteractionBySource(ctx context.Context, arg FindRecentOutboundInteractionBySourceParams) (*Interaction, error)
 	// Find the most recent outbound telegram interaction for a contact in a specific chat
 	// within a time window. source_ref_prefix should include trailing % for LIKE match.
 	FindRecentOutboundTelegramInteraction(ctx context.Context, arg FindRecentOutboundTelegramInteractionParams) (*Interaction, error)
@@ -354,6 +363,20 @@ type Querier interface {
 	GetTelegramSession(ctx context.Context) (*TelegramSession, error)
 	GetTelegramUpdateState(ctx context.Context, userID int64) (*TelegramUpdateState, error)
 	HardDeleteContact(ctx context.Context, id pgtype.UUID) error
+	// Test-only: hard-deletes interactions whose source matches and source_ref
+	// begins with prefix. Used by integration tests to purge per-run rows
+	// cleanly; soft-delete is unsafe because the (source, source_ref) partial
+	// unique constraint would block a same-source_ref re-insert on the next
+	// test run even with deleted_at set.
+	HardDeleteInteractionsBySourceRefPrefix(ctx context.Context, arg HardDeleteInteractionsBySourceRefPrefixParams) error
+	// GetTelegramMessageByReplyTo removed: identical to GetTelegramMessage.
+	// Use GetMessage repo method for reply resolution.
+	// Test-only: hard-deletes telegram_message rows whose telegram_chat_id
+	// falls in [lo, hi]. Used by integration tests to cleanly purge per-run
+	// chat ID ranges so soft-deleted rows from prior runs do not resurrect
+	// on the next UpsertTelegramMessage call (UpsertTelegramMessage does
+	// not clear deleted_at on conflict).
+	HardDeleteTelegramMessagesByChatIDRange(ctx context.Context, arg HardDeleteTelegramMessagesByChatIDRangeParams) error
 	HasEnrichmentForField(ctx context.Context, arg HasEnrichmentForFieldParams) (bool, error)
 	// Returns TRUE if any later inbound/mutual interaction exists for the
 	// contact after the given outreach time. Used by the FollowUpManager's

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -363,6 +363,12 @@ type Querier interface {
 	GetTelegramSession(ctx context.Context) (*TelegramSession, error)
 	GetTelegramUpdateState(ctx context.Context, userID int64) (*TelegramUpdateState, error)
 	HardDeleteContact(ctx context.Context, id pgtype.UUID) error
+	// Test-only: hard-deletes event rows whose (source, source_id) match the
+	// given source and a LIKE-prefix on source_id. Used by integration tests
+	// to purge per-run event envelopes so a re-run does not collide on the
+	// (source, source_id) partial unique. The event log is otherwise
+	// append-only; production code MUST NOT call this.
+	HardDeleteEventsBySourceAndSourceIDPrefix(ctx context.Context, arg HardDeleteEventsBySourceAndSourceIDPrefixParams) error
 	// Test-only: hard-deletes interactions whose source matches and source_ref
 	// begins with prefix. Used by integration tests to purge per-run rows
 	// cleanly; soft-delete is unsafe because the (source, source_ref) partial

--- a/backend/internal/db/queries/event.sql
+++ b/backend/internal/db/queries/event.sql
@@ -39,6 +39,16 @@ LIMIT 1;
 -- deleted_at filter is needed.
 SELECT COUNT(*) FROM event WHERE source = @source;
 
+-- name: HardDeleteEventsBySourceAndSourceIDPrefix :exec
+-- Test-only: hard-deletes event rows whose (source, source_id) match the
+-- given source and a LIKE-prefix on source_id. Used by integration tests
+-- to purge per-run event envelopes so a re-run does not collide on the
+-- (source, source_id) partial unique. The event log is otherwise
+-- append-only; production code MUST NOT call this.
+DELETE FROM event
+WHERE source = @source
+  AND source_id LIKE @source_id_prefix;
+
 -- name: CountRematchDispatcherJobsByContactAndJob :one
 -- Test-only count of river_job rows for the rematch_dispatcher kind
 -- whose args JSON contains the given (contact_id, rematch_job_id)

--- a/backend/internal/db/queries/interaction.sql
+++ b/backend/internal/db/queries/interaction.sql
@@ -79,6 +79,47 @@ WHERE contact_id = sqlc.arg(contact_id)
 ORDER BY occurred_at DESC
 LIMIT 1;
 
+-- name: FindRecentInteractionBySourceAndDirection :one
+-- Source-neutral generalization of FindRecentTelegramInteraction.
+-- Used by the shared aggregator (backend/internal/messaging/aggregation)
+-- for same-direction coalescing. source_ref_prefix should include
+-- trailing % for LIKE match.
+SELECT * FROM interaction
+WHERE contact_id = sqlc.arg(contact_id)
+  AND source = sqlc.arg(source)
+  AND direction = sqlc.arg(direction)
+  AND source_ref LIKE sqlc.arg(source_ref_prefix)
+  AND occurred_at >= sqlc.arg(window_start)
+  AND occurred_at <= sqlc.arg(window_end)
+  AND deleted_at IS NULL
+ORDER BY occurred_at DESC
+LIMIT 1;
+
+-- name: FindRecentOutboundInteractionBySource :one
+-- Source-neutral generalization of FindRecentOutboundTelegramInteraction.
+-- Used by the shared aggregator for time-based reply bridging on inbound
+-- sessions.
+SELECT * FROM interaction
+WHERE contact_id = sqlc.arg(contact_id)
+  AND source = sqlc.arg(source)
+  AND direction = 'outbound'
+  AND source_ref LIKE sqlc.arg(source_ref_prefix)
+  AND occurred_at >= sqlc.arg(window_start)
+  AND occurred_at <= sqlc.arg(window_end)
+  AND deleted_at IS NULL
+ORDER BY occurred_at DESC
+LIMIT 1;
+
+-- name: HardDeleteInteractionsBySourceRefPrefix :exec
+-- Test-only: hard-deletes interactions whose source matches and source_ref
+-- begins with prefix. Used by integration tests to purge per-run rows
+-- cleanly; soft-delete is unsafe because the (source, source_ref) partial
+-- unique constraint would block a same-source_ref re-insert on the next
+-- test run even with deleted_at set.
+DELETE FROM interaction
+WHERE source = sqlc.arg(source)
+  AND source_ref LIKE sqlc.arg(source_ref_prefix);
+
 -- name: UpdateInteractionTimestamp :one
 -- Extend an existing interaction's occurred_at and description (incremental coalescing)
 UPDATE interaction

--- a/backend/internal/db/queries/telegram_message.sql
+++ b/backend/internal/db/queries/telegram_message.sql
@@ -203,3 +203,13 @@ WHERE peer_user_id = @peer_user_id
 
 -- GetTelegramMessageByReplyTo removed: identical to GetTelegramMessage.
 -- Use GetMessage repo method for reply resolution.
+
+-- name: HardDeleteTelegramMessagesByChatIDRange :exec
+-- Test-only: hard-deletes telegram_message rows whose telegram_chat_id
+-- falls in [lo, hi]. Used by integration tests to cleanly purge per-run
+-- chat ID ranges so soft-deleted rows from prior runs do not resurrect
+-- on the next UpsertTelegramMessage call (UpsertTelegramMessage does
+-- not clear deleted_at on conflict).
+DELETE FROM telegram_message
+WHERE telegram_chat_id >= sqlc.arg(lo)
+  AND telegram_chat_id <= sqlc.arg(hi);

--- a/backend/internal/db/telegram_message.sql.go
+++ b/backend/internal/db/telegram_message.sql.go
@@ -313,6 +313,30 @@ func (q *Queries) GetTelegramMessage(ctx context.Context, arg GetTelegramMessage
 	return &i, err
 }
 
+const HardDeleteTelegramMessagesByChatIDRange = `-- name: HardDeleteTelegramMessagesByChatIDRange :exec
+
+DELETE FROM telegram_message
+WHERE telegram_chat_id >= $1
+  AND telegram_chat_id <= $2
+`
+
+type HardDeleteTelegramMessagesByChatIDRangeParams struct {
+	Lo int64 `json:"lo"`
+	Hi int64 `json:"hi"`
+}
+
+// GetTelegramMessageByReplyTo removed: identical to GetTelegramMessage.
+// Use GetMessage repo method for reply resolution.
+// Test-only: hard-deletes telegram_message rows whose telegram_chat_id
+// falls in [lo, hi]. Used by integration tests to cleanly purge per-run
+// chat ID ranges so soft-deleted rows from prior runs do not resurrect
+// on the next UpsertTelegramMessage call (UpsertTelegramMessage does
+// not clear deleted_at on conflict).
+func (q *Queries) HardDeleteTelegramMessagesByChatIDRange(ctx context.Context, arg HardDeleteTelegramMessagesByChatIDRangeParams) error {
+	_, err := q.db.Exec(ctx, HardDeleteTelegramMessagesByChatIDRange, arg.Lo, arg.Hi)
+	return err
+}
+
 const ListDistinctUnmatchedPeers = `-- name: ListDistinctUnmatchedPeers :many
 SELECT DISTINCT ON (peer_user_id)
     peer_user_id, peer_username, peer_first_name, peer_last_name, peer_phone

--- a/backend/internal/messaging/aggregation/doc.go
+++ b/backend/internal/messaging/aggregation/doc.go
@@ -1,0 +1,27 @@
+// Package aggregation provides source-neutral burst/session aggregation
+// for message streams (Telegram today; iMessage, WhatsApp, etc. in
+// upcoming Mac-daemon PRs).
+//
+// Existing semantics preserved verbatim from the Telegram precedent:
+//
+//   - Bursts: consecutive same-direction messages within a burst window.
+//   - Sessions: bursts merged when adjacent outbound→inbound bridge
+//     within the reply-bridge window OR via explicit reply (per-source-
+//     defined "reply target" hook).
+//   - Two-path output: extend an existing recent interaction OR publish
+//     a create-event (message.received / message.sent).
+//   - Cross-batch reply bridging via the source's GetMessageByReplyTarget
+//     hook (uses the referenced row's InteractionID to find the existing
+//     interaction).
+//
+// Adding a new source: implement SourceAdapter and MessageStore (and
+// reuse InteractionFinder, InteractionPromoter, InteractionExtender as
+// satisfied by the existing repository / service types). The Engine is
+// instantiated per source — concurrent engines for telegram + messages
+// + whatsapp share no mutable state.
+//
+// The engine does NOT read "now"; window math uses message timestamps
+// only. Do NOT introduce a time.Now() / accelerated.GetCurrentTime()
+// call inside this package; preserving timestamp-driven math is part of
+// the semantics contract.
+package aggregation

--- a/backend/internal/messaging/aggregation/engine.go
+++ b/backend/internal/messaging/aggregation/engine.go
@@ -3,6 +3,7 @@ package aggregation
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 
 	"personal-crm/backend/internal/events"
@@ -11,6 +12,16 @@ import (
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 )
+
+// sortBySentAt sorts msgs by SentAt ascending in place. The MessageStore
+// contract requires adapters to emit sorted rows; this defensive sort
+// absorbs minor adapter drift so the burst/session derivation can
+// safely assume chronological adjacency.
+func sortBySentAt(msgs []Message) {
+	sort.SliceStable(msgs, func(i, j int) bool {
+		return msgs[i].SentAt.Before(msgs[j].SentAt)
+	})
+}
 
 // Engine processes per-source staging-message rows into interaction
 // records. Created per source — concurrent engines for telegram +
@@ -113,6 +124,11 @@ func (e *Engine) aggregateBatch(ctx context.Context, contactID uuid.UUID) (int, 
 	interactionsCreated := 0
 
 	for chatID, chatMessages := range chatMsgs {
+		// Defensive sort: the MessageStore contract requires sorted
+		// rows, but partitionByChat preserves input order so a
+		// noisy adapter that emits unsorted batches would corrupt
+		// bursts here. The sort is in-place and stable.
+		sortBySentAt(chatMessages)
 		bursts := e.groupIntoBursts(chatMessages, chatID)
 		sessions := e.resolveSessions(bursts)
 
@@ -144,6 +160,11 @@ func (e *Engine) AggregateForContact(ctx context.Context, contactID uuid.UUID, c
 	if len(msgs) == 0 {
 		return nil
 	}
+
+	// Defensive sort: MessageStore contract requires sorted rows; we
+	// re-sort to absorb adapter drift before deriving bursts/sessions
+	// that depend on chronological adjacency.
+	sortBySentAt(msgs)
 
 	bursts := e.groupIntoBursts(msgs, chatID)
 	sessions := e.resolveSessions(bursts)

--- a/backend/internal/messaging/aggregation/engine.go
+++ b/backend/internal/messaging/aggregation/engine.go
@@ -1,0 +1,366 @@
+package aggregation
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+)
+
+// Engine processes per-source staging-message rows into interaction
+// records. Created per source — concurrent engines for telegram +
+// messages + whatsapp share no mutable state.
+type Engine struct {
+	adapter   SourceAdapter
+	store     MessageStore
+	finder    InteractionFinder
+	promoter  InteractionPromoter
+	extender  InteractionExtender
+	publisher EventPublisher
+
+	burstWindowHours int
+	replyBridgeHours int
+}
+
+// NewEngine builds a source-parametric aggregation engine.
+//
+// publisher MUST be the untyped-nil interface when no event bus is
+// configured (see EventPublisher doc). The Engine guards on
+// publisher == nil inside the session create path; a typed-nil concrete
+// pointer would silently bypass that guard.
+func NewEngine(
+	adapter SourceAdapter,
+	store MessageStore,
+	finder InteractionFinder,
+	promoter InteractionPromoter,
+	extender InteractionExtender,
+	publisher EventPublisher,
+	burstWindowHours, replyBridgeHours int,
+) *Engine {
+	return &Engine{
+		adapter:          adapter,
+		store:            store,
+		finder:           finder,
+		promoter:         promoter,
+		extender:         extender,
+		publisher:        publisher,
+		burstWindowHours: burstWindowHours,
+		replyBridgeHours: replyBridgeHours,
+	}
+}
+
+// AggregateAll processes all contacts with unprocessed messages
+// (batch mode). Used after backfill. Per-contact errors are swallowed
+// with a Warn log so a single failing contact does not abort the batch.
+func (e *Engine) AggregateAll(ctx context.Context) error {
+	contactIDs, err := e.store.ListUnprocessedContactIDs(ctx)
+	if err != nil {
+		return fmt.Errorf("list unprocessed contact IDs: %w", err)
+	}
+
+	if len(contactIDs) == 0 {
+		return nil
+	}
+
+	source := e.adapter.SourceName()
+	interactionsCreated := 0
+	for _, contactID := range contactIDs {
+		n, err := e.aggregateBatch(ctx, contactID)
+		if err != nil {
+			log.Warn().
+				Err(err).
+				Str("source", source).
+				Str("contact_id", contactID.String()).
+				Msg("aggregation: batch aggregation failed for contact")
+			continue
+		}
+		interactionsCreated += n
+	}
+
+	log.Info().
+		Str("source", source).
+		Int("contacts", len(contactIDs)).
+		Int("interactions", interactionsCreated).
+		Msg("aggregation: batch aggregation complete")
+	return nil
+}
+
+// AggregateForContactBatch processes all unprocessed messages for a
+// single contact in batch mode. Used after import/link to aggregate
+// newly-matched messages without scanning every contact.
+func (e *Engine) AggregateForContactBatch(ctx context.Context, contactID uuid.UUID) error {
+	_, err := e.aggregateBatch(ctx, contactID)
+	return err
+}
+
+// aggregateBatch processes all unprocessed messages for a contact in
+// batch mode (no extend/bridge — just create-path).
+func (e *Engine) aggregateBatch(ctx context.Context, contactID uuid.UUID) (int, error) {
+	msgs, err := e.store.ListUnprocessedByContact(ctx, contactID)
+	if err != nil {
+		return 0, fmt.Errorf("list unprocessed messages: %w", err)
+	}
+	if len(msgs) == 0 {
+		return 0, nil
+	}
+
+	chatMsgs := partitionByChat(msgs)
+	interactionsCreated := 0
+
+	for chatID, chatMessages := range chatMsgs {
+		bursts := e.groupIntoBursts(chatMessages, chatID)
+		sessions := e.resolveSessions(bursts)
+
+		for _, sess := range sessions {
+			if err := e.createInteractionForSession(ctx, contactID, sess); err != nil {
+				log.Warn().
+					Err(err).
+					Str("source", e.adapter.SourceName()).
+					Str("chat_id", chatID).
+					Msg("aggregation: failed to create interaction for session")
+				continue
+			}
+			interactionsCreated++
+		}
+	}
+
+	return interactionsCreated, nil
+}
+
+// AggregateForContact processes unprocessed messages for a specific
+// contact+chat (incremental mode). Tries explicit reply bridge →
+// time-based reply bridge (inbound only) → same-direction coalescing
+// → create.
+func (e *Engine) AggregateForContact(ctx context.Context, contactID uuid.UUID, chatID string) error {
+	msgs, err := e.store.ListUnprocessedByContactAndChat(ctx, contactID, chatID)
+	if err != nil {
+		return fmt.Errorf("list unprocessed messages: %w", err)
+	}
+	if len(msgs) == 0 {
+		return nil
+	}
+
+	bursts := e.groupIntoBursts(msgs, chatID)
+	sessions := e.resolveSessions(bursts)
+
+	source := e.adapter.SourceName()
+	sourceRefPrefix := e.adapter.SourceRefPrefix(chatID)
+	// Use latest message time as upper bound — matches the pre-refactor
+	// telegram behaviour at aggregation.go:198.
+	now := msgs[len(msgs)-1].SentAt
+
+	for _, sess := range sessions {
+		// Explicit reply bridging first (inbound/mutual sessions).
+		if sess.direction == repository.InteractionDirectionInbound || sess.direction == repository.InteractionDirectionMutual {
+			if bridged := e.tryExplicitReplyBridge(ctx, contactID, sess); bridged {
+				continue
+			}
+		}
+
+		// Time-based reply bridging for inbound sessions.
+		if sess.direction == repository.InteractionDirectionInbound {
+			windowStart := sess.messages[0].SentAt.Add(-time.Duration(e.replyBridgeHours) * time.Hour)
+			existing, err := e.finder.FindRecentOutboundBySource(
+				ctx, contactID, source, sourceRefPrefix, windowStart, sess.messages[0].SentAt,
+			)
+			if err == nil {
+				// Promote outbound → mutual.
+				if err := e.promoter.PromoteInteractionToMutual(ctx, existing.ID, contactID, sess.lastSentAt()); err != nil {
+					log.Warn().Err(err).Str("source", source).Msg("aggregation: failed to promote interaction to mutual")
+				} else {
+					if err := e.store.MarkProcessed(ctx, sess.messageIDs(), existing.ID); err != nil {
+						log.Warn().Err(err).Str("source", source).Msg("aggregation: failed to mark messages processed after promotion")
+					}
+					continue
+				}
+			}
+		}
+
+		// Same-direction coalescing within the burst window.
+		// For mutual sessions: check whether an outbound interaction
+		// exists to promote rather than extend, because
+		// ExtendInteraction does not update direction.
+		if sess.direction == repository.InteractionDirectionMutual {
+			windowStart := sess.messages[0].SentAt.Add(-time.Duration(e.burstWindowHours) * time.Hour)
+			existing, err := e.finder.FindRecentBySourceAndDirection(
+				ctx, contactID, source, repository.InteractionDirectionOutbound, sourceRefPrefix, windowStart, now,
+			)
+			if err == nil {
+				if err := e.promoter.PromoteInteractionToMutual(ctx, existing.ID, contactID, sess.lastSentAt()); err != nil {
+					log.Warn().Err(err).Str("source", source).Msg("aggregation: failed to promote interaction to mutual during coalescing")
+				} else {
+					if err := e.store.MarkProcessed(ctx, sess.messageIDs(), existing.ID); err != nil {
+						log.Warn().Err(err).Str("source", source).Msg("aggregation: failed to mark messages processed after promotion")
+					}
+					continue
+				}
+			}
+			// No outbound to promote — fall through to create-path.
+		} else {
+			windowStart := sess.messages[0].SentAt.Add(-time.Duration(e.burstWindowHours) * time.Hour)
+			existing, err := e.finder.FindRecentBySourceAndDirection(
+				ctx, contactID, source, sess.direction, sourceRefPrefix, windowStart, now,
+			)
+			if err == nil {
+				desc := sess.description(e.adapter)
+				if err := e.extender.ExtendInteraction(ctx, existing.ID, contactID, sess.direction, sess.lastSentAt(), &desc); err != nil {
+					log.Warn().Err(err).Str("source", source).Msg("aggregation: failed to extend interaction")
+				} else {
+					if err := e.store.MarkProcessed(ctx, sess.messageIDs(), existing.ID); err != nil {
+						log.Warn().Err(err).Str("source", source).Msg("aggregation: failed to mark messages processed after extension")
+					}
+					continue
+				}
+			}
+		}
+
+		// Create new interaction (via publish).
+		if err := e.createInteractionForSession(ctx, contactID, sess); err != nil {
+			log.Warn().
+				Err(err).
+				Str("source", source).
+				Str("chat_id", chatID).
+				Msg("aggregation: failed to create interaction for session")
+		}
+	}
+
+	return nil
+}
+
+// tryExplicitReplyBridge checks if any inbound message in the session
+// has ReplyTargetID pointing to an outgoing message with an existing
+// interaction. Bridges regardless of time gap.
+func (e *Engine) tryExplicitReplyBridge(ctx context.Context, contactID uuid.UUID, sess msgSession) bool {
+	source := e.adapter.SourceName()
+	for _, msg := range sess.messages {
+		if msg.ReplyTargetID == nil {
+			continue
+		}
+		referenced, ok, err := e.store.GetMessageByReplyTarget(ctx, sess.chatID, *msg.ReplyTargetID)
+		if err != nil || !ok {
+			continue
+		}
+		if !referenced.IsOutgoing || referenced.InteractionID == nil {
+			continue
+		}
+		existing, err := e.finder.GetInteraction(ctx, *referenced.InteractionID)
+		if err != nil || existing.Source != source || existing.Direction != repository.InteractionDirectionOutbound {
+			continue
+		}
+		if err := e.promoter.PromoteInteractionToMutual(ctx, existing.ID, contactID, sess.lastSentAt()); err != nil {
+			log.Warn().Err(err).Str("source", source).Msg("aggregation: failed to promote interaction via explicit reply")
+			continue
+		}
+		if err := e.store.MarkProcessed(ctx, sess.messageIDs(), existing.ID); err != nil {
+			log.Warn().Err(err).Str("source", source).Msg("aggregation: failed to mark messages processed after explicit reply bridge")
+		}
+		return true
+	}
+	return false
+}
+
+// createInteractionForSession publishes a message.received /
+// message.sent event for a session. In cutover the async consumer
+// handles the interaction-row write inside a single tx that also marks
+// the source's staging rows processed.
+//
+// Returns an error when publisher is the nil interface — mode=off/
+// shadow is effectively broken post-cutover and the publisher refuses
+// to silently drop the interaction.
+func (e *Engine) createInteractionForSession(ctx context.Context, contactID uuid.UUID, sess msgSession) error {
+	if e.publisher == nil {
+		return fmt.Errorf("aggregation: cutover wiring requires publisher; refusing to drop interaction (mode=off/shadow is post-cutover broken per spec §3.9)")
+	}
+	sourceRef := sess.sourceRef(e.adapter)
+	desc := sess.description(e.adapter)
+	if pubErr := e.publishForSession(ctx, contactID, sess, sourceRef, &desc); pubErr != nil {
+		return fmt.Errorf("publish %s interaction event: %w", e.adapter.SourceName(), pubErr)
+	}
+	return nil
+}
+
+// publishForSession emits the message.received / message.sent event
+// for a freshly-created interaction. Mutual sessions carry
+// Direction="mutual" in the payload so the consumer can write a
+// matching mutual row.
+//
+// Kind selection:
+//   - inbound session  → KindMessageReceived (Direction="")
+//   - outbound session → KindMessageSent (Direction="")
+//   - mutual session   → KindMessageReceived (Direction="mutual")
+//
+// SourceID = sourceRef so publisher-idempotency dedupes retries.
+func (e *Engine) publishForSession(
+	ctx context.Context,
+	contactID uuid.UUID,
+	sess msgSession,
+	sourceRef string,
+	description *string,
+) error {
+	cid := contactID
+	messageAt := sess.lastSentAt()
+
+	var kind events.Kind
+	var payloadDirection string
+	switch sess.direction {
+	case repository.InteractionDirectionOutbound:
+		kind = events.KindMessageSent
+		payloadDirection = ""
+	case repository.InteractionDirectionInbound:
+		kind = events.KindMessageReceived
+		payloadDirection = ""
+	case repository.InteractionDirectionMutual:
+		kind = events.KindMessageReceived
+		payloadDirection = repository.InteractionDirectionMutual
+	default:
+		return fmt.Errorf("unexpected session direction %q", sess.direction)
+	}
+
+	peerRef := e.adapter.PeerRef(sess.chatID)
+	msgIDs := sess.messageIDs()
+	var raw []byte
+	var marshalErr error
+	switch kind {
+	case events.KindMessageReceived:
+		msg, err := events.Marshal(kind, events.MessageReceivedPayload{
+			Version:           1,
+			ContactID:         &cid,
+			PeerRef:           peerRef,
+			MessageAt:         messageAt,
+			Description:       description,
+			ExternalMessageID: sourceRef,
+			Direction:         payloadDirection,
+			MessageIDs:        msgIDs,
+		})
+		raw, marshalErr = msg, err
+	case events.KindMessageSent:
+		msg, err := events.Marshal(kind, events.MessageSentPayload{
+			Version:           1,
+			ContactID:         &cid,
+			PeerRef:           peerRef,
+			MessageAt:         messageAt,
+			Description:       description,
+			ExternalMessageID: sourceRef,
+			Direction:         payloadDirection,
+			MessageIDs:        msgIDs,
+		})
+		raw, marshalErr = msg, err
+	}
+	if marshalErr != nil {
+		return fmt.Errorf("marshal %s: %w", kind, marshalErr)
+	}
+
+	env := &events.Envelope{
+		Source:     e.adapter.SourceName(),
+		SourceID:   sourceRef,
+		Kind:       kind,
+		Payload:    raw,
+		ObservedAt: messageAt,
+	}
+	return e.publisher.Publish(ctx, env)
+}

--- a/backend/internal/messaging/aggregation/engine_test.go
+++ b/backend/internal/messaging/aggregation/engine_test.go
@@ -1,0 +1,784 @@
+package aggregation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- shared test types -------------------------------------------------
+
+// telegramShapedAdapter mirrors the production telegramAdapter exactly so
+// shared-package tests can lock in the wire format "tg:<chatID>:<extID>"
+// without importing the telegram package (which would create a cycle).
+type telegramShapedAdapter struct{}
+
+func (telegramShapedAdapter) SourceName() string {
+	return repository.InteractionSourceTelegram
+}
+func (telegramShapedAdapter) SourceRef(chatID, firstExternalID string) string {
+	return "tg:" + chatID + ":" + firstExternalID
+}
+func (telegramShapedAdapter) SourceRefPrefix(chatID string) string {
+	return "tg:" + chatID + ":%"
+}
+func (telegramShapedAdapter) PeerRef(chatID string) string {
+	return "tg:" + chatID
+}
+func (telegramShapedAdapter) Description(direction string, msgCount int) string {
+	label := "exchange"
+	switch direction {
+	case repository.InteractionDirectionOutbound:
+		label = "outreach"
+	case repository.InteractionDirectionInbound:
+		label = "response"
+	}
+	return fmt.Sprintf("Telegram %s (%d messages)", label, msgCount)
+}
+
+// fakeAdapter is a minimal SourceAdapter used to prove the engine is
+// source-neutral (non-telegram naming).
+type fakeAdapter struct {
+	name string
+}
+
+func (a fakeAdapter) SourceName() string { return a.name }
+func (a fakeAdapter) SourceRef(chatID, firstExternalID string) string {
+	return a.name + ":" + chatID + ":" + firstExternalID
+}
+func (a fakeAdapter) SourceRefPrefix(chatID string) string { return a.name + ":" + chatID + ":%" }
+func (a fakeAdapter) PeerRef(chatID string) string         { return a.name + ":" + chatID }
+func (a fakeAdapter) Description(direction string, msgCount int) string {
+	return fmt.Sprintf("%s %s (%d messages)", a.name, direction, msgCount)
+}
+
+// fakeStore captures the MessageStore protocol in-memory.
+type fakeStore struct {
+	unprocessedContactIDs []uuid.UUID
+	byContact             map[uuid.UUID][]Message
+	byContactAndChat      map[string][]Message // key: contactID.String()+"|"+chatID
+	byReplyTarget         map[string]Message   // key: chatID+"|"+replyTargetID
+	markProcessedCalls    []markProcessedCall
+
+	// listUnprocessedByContactErr controls injection points for negative tests.
+	listUnprocessedByContactErr error
+}
+
+type markProcessedCall struct {
+	messageIDs    []uuid.UUID
+	interactionID uuid.UUID
+}
+
+func newFakeStore() *fakeStore {
+	return &fakeStore{
+		byContact:        map[uuid.UUID][]Message{},
+		byContactAndChat: map[string][]Message{},
+		byReplyTarget:    map[string]Message{},
+	}
+}
+
+func (s *fakeStore) ListUnprocessedContactIDs(_ context.Context) ([]uuid.UUID, error) {
+	return s.unprocessedContactIDs, nil
+}
+
+func (s *fakeStore) ListUnprocessedByContact(_ context.Context, contactID uuid.UUID) ([]Message, error) {
+	if s.listUnprocessedByContactErr != nil {
+		return nil, s.listUnprocessedByContactErr
+	}
+	return s.byContact[contactID], nil
+}
+
+func (s *fakeStore) ListUnprocessedByContactAndChat(_ context.Context, contactID uuid.UUID, chatID string) ([]Message, error) {
+	return s.byContactAndChat[contactID.String()+"|"+chatID], nil
+}
+
+func (s *fakeStore) GetMessageByReplyTarget(_ context.Context, chatID, replyTargetID string) (Message, bool, error) {
+	msg, ok := s.byReplyTarget[chatID+"|"+replyTargetID]
+	return msg, ok, nil
+}
+
+func (s *fakeStore) MarkProcessed(_ context.Context, messageIDs []uuid.UUID, interactionID uuid.UUID) error {
+	s.markProcessedCalls = append(s.markProcessedCalls, markProcessedCall{
+		messageIDs:    append([]uuid.UUID(nil), messageIDs...),
+		interactionID: interactionID,
+	})
+	return nil
+}
+
+// fakeFinder dispenses pre-seeded interactions and tracks calls.
+type fakeFinder struct {
+	mu                          sync.Mutex
+	findRecentBySourceAndDirRet *repository.Interaction
+	findRecentBySourceAndDirErr error
+	findRecentBySourceAndDirArg findRecentBySourceAndDirCall
+
+	findRecentOutboundRet *repository.Interaction
+	findRecentOutboundErr error
+
+	getInteractionRet *repository.Interaction
+	getInteractionErr error
+}
+
+type findRecentBySourceAndDirCall struct {
+	contactID       uuid.UUID
+	source          string
+	direction       string
+	sourceRefPrefix string
+}
+
+func (f *fakeFinder) FindRecentBySourceAndDirection(
+	_ context.Context,
+	contactID uuid.UUID,
+	source, direction, sourceRefPrefix string,
+	_, _ time.Time,
+) (*repository.Interaction, error) {
+	f.mu.Lock()
+	f.findRecentBySourceAndDirArg = findRecentBySourceAndDirCall{
+		contactID:       contactID,
+		source:          source,
+		direction:       direction,
+		sourceRefPrefix: sourceRefPrefix,
+	}
+	f.mu.Unlock()
+	if f.findRecentBySourceAndDirErr != nil {
+		return nil, f.findRecentBySourceAndDirErr
+	}
+	return f.findRecentBySourceAndDirRet, nil
+}
+
+func (f *fakeFinder) FindRecentOutboundBySource(
+	_ context.Context,
+	_ uuid.UUID,
+	_, _ string,
+	_, _ time.Time,
+) (*repository.Interaction, error) {
+	if f.findRecentOutboundErr != nil {
+		return nil, f.findRecentOutboundErr
+	}
+	return f.findRecentOutboundRet, nil
+}
+
+func (f *fakeFinder) GetInteraction(_ context.Context, _ uuid.UUID) (*repository.Interaction, error) {
+	if f.getInteractionErr != nil {
+		return nil, f.getInteractionErr
+	}
+	return f.getInteractionRet, nil
+}
+
+type fakePromoter struct {
+	mu    sync.Mutex
+	calls []promoteCall
+}
+
+type promoteCall struct {
+	interactionID uuid.UUID
+	contactID     uuid.UUID
+	replyAt       time.Time
+}
+
+func (p *fakePromoter) PromoteInteractionToMutual(_ context.Context, interactionID, contactID uuid.UUID, replyAt time.Time) error {
+	p.mu.Lock()
+	p.calls = append(p.calls, promoteCall{interactionID, contactID, replyAt})
+	p.mu.Unlock()
+	return nil
+}
+
+type fakeExtender struct {
+	mu    sync.Mutex
+	calls []extendCall
+}
+
+type extendCall struct {
+	interactionID uuid.UUID
+	contactID     uuid.UUID
+	direction     string
+	occurredAt    time.Time
+	description   string
+}
+
+func (e *fakeExtender) ExtendInteraction(_ context.Context, interactionID, contactID uuid.UUID, direction string, occurredAt time.Time, description *string) error {
+	e.mu.Lock()
+	desc := ""
+	if description != nil {
+		desc = *description
+	}
+	e.calls = append(e.calls, extendCall{interactionID, contactID, direction, occurredAt, desc})
+	e.mu.Unlock()
+	return nil
+}
+
+type fakePublisher struct {
+	mu        sync.Mutex
+	envelopes []events.Envelope
+}
+
+func (p *fakePublisher) Publish(_ context.Context, env *events.Envelope) error {
+	p.mu.Lock()
+	p.envelopes = append(p.envelopes, *env)
+	p.mu.Unlock()
+	return nil
+}
+
+// helper: make a Message with the telegram-shaped fields used by the
+// migrated tests (chatID as decimal string, externalID as decimal
+// string, no reply target unless overridden).
+func makeMsg(extID int32, chatID int64, outgoing bool, sentAt time.Time) Message {
+	return Message{
+		ID:         uuid.New(),
+		ChatID:     strconv.FormatInt(chatID, 10),
+		ExternalID: strconv.Itoa(int(extID)),
+		IsOutgoing: outgoing,
+		SentAt:     sentAt,
+	}
+}
+
+// --- migrated burst/session tests --------------------------------------
+
+func TestGroupIntoBursts_SingleOutbound(t *testing.T) {
+	e := &Engine{burstWindowHours: 2}
+	base := accelerated.GetCurrentTime()
+	msgs := []Message{
+		makeMsg(1, 100, true, base),
+		makeMsg(2, 100, true, base.Add(10*time.Minute)),
+		makeMsg(3, 100, true, base.Add(30*time.Minute)),
+	}
+
+	bursts := e.groupIntoBursts(msgs, "100")
+	require.Len(t, bursts, 1)
+	assert.Equal(t, repository.InteractionDirectionOutbound, bursts[0].direction)
+	assert.Len(t, bursts[0].messages, 3)
+}
+
+func TestGroupIntoBursts_SingleInbound(t *testing.T) {
+	e := &Engine{burstWindowHours: 2}
+	base := accelerated.GetCurrentTime()
+	msgs := []Message{
+		makeMsg(1, 100, false, base),
+		makeMsg(2, 100, false, base.Add(5*time.Minute)),
+	}
+
+	bursts := e.groupIntoBursts(msgs, "100")
+	require.Len(t, bursts, 1)
+	assert.Equal(t, repository.InteractionDirectionInbound, bursts[0].direction)
+}
+
+func TestGroupIntoBursts_SplitByGap(t *testing.T) {
+	e := &Engine{burstWindowHours: 2}
+	base := accelerated.GetCurrentTime()
+	msgs := []Message{
+		makeMsg(1, 100, true, base),
+		makeMsg(2, 100, true, base.Add(3*time.Hour)),
+	}
+
+	bursts := e.groupIntoBursts(msgs, "100")
+	require.Len(t, bursts, 2)
+}
+
+func TestGroupIntoBursts_DirectionChangeSplits(t *testing.T) {
+	e := &Engine{burstWindowHours: 2}
+	base := accelerated.GetCurrentTime()
+	msgs := []Message{
+		makeMsg(1, 100, true, base),
+		makeMsg(2, 100, false, base.Add(5*time.Minute)),
+	}
+
+	bursts := e.groupIntoBursts(msgs, "100")
+	require.Len(t, bursts, 2)
+	assert.Equal(t, repository.InteractionDirectionOutbound, bursts[0].direction)
+	assert.Equal(t, repository.InteractionDirectionInbound, bursts[1].direction)
+}
+
+func TestResolveSessions_ReplyBridgeWithin48h(t *testing.T) {
+	e := &Engine{burstWindowHours: 2, replyBridgeHours: 48}
+	base := accelerated.GetCurrentTime()
+
+	bursts := []burst{
+		{
+			direction: repository.InteractionDirectionOutbound,
+			messages: []Message{
+				makeMsg(1, 100, true, base),
+				makeMsg(2, 100, true, base.Add(5*time.Minute)),
+			},
+			chatID: "100",
+		},
+		{
+			direction: repository.InteractionDirectionInbound,
+			messages: []Message{
+				makeMsg(3, 100, false, base.Add(1*time.Hour)),
+			},
+			chatID: "100",
+		},
+	}
+
+	sessions := e.resolveSessions(bursts)
+	require.Len(t, sessions, 1)
+	assert.Equal(t, repository.InteractionDirectionMutual, sessions[0].direction)
+	assert.Len(t, sessions[0].messages, 3)
+}
+
+func TestResolveSessions_ReplyBridgeExpired(t *testing.T) {
+	e := &Engine{burstWindowHours: 2, replyBridgeHours: 48}
+	base := accelerated.GetCurrentTime()
+
+	bursts := []burst{
+		{
+			direction: repository.InteractionDirectionOutbound,
+			messages:  []Message{makeMsg(1, 100, true, base)},
+			chatID:    "100",
+		},
+		{
+			direction: repository.InteractionDirectionInbound,
+			messages:  []Message{makeMsg(2, 100, false, base.Add(49*time.Hour))},
+			chatID:    "100",
+		},
+	}
+
+	sessions := e.resolveSessions(bursts)
+	require.Len(t, sessions, 2)
+}
+
+func TestResolveSessions_ExplicitReplyBridges(t *testing.T) {
+	e := &Engine{burstWindowHours: 2, replyBridgeHours: 48}
+	base := accelerated.GetCurrentTime()
+
+	replyTo := "1" // ExternalID of msg 1 (outbound burst's first message)
+	inbound := makeMsg(2, 100, false, base.Add(72*time.Hour))
+	inbound.ReplyTargetID = &replyTo
+
+	bursts := []burst{
+		{
+			direction: repository.InteractionDirectionOutbound,
+			messages:  []Message{makeMsg(1, 100, true, base)},
+			chatID:    "100",
+		},
+		{
+			direction: repository.InteractionDirectionInbound,
+			messages:  []Message{inbound},
+			chatID:    "100",
+		},
+	}
+
+	sessions := e.resolveSessions(bursts)
+	require.Len(t, sessions, 1)
+	assert.Equal(t, repository.InteractionDirectionMutual, sessions[0].direction)
+}
+
+func TestSessionKey_Stability_TelegramShape(t *testing.T) {
+	adapter := telegramShapedAdapter{}
+	sess := msgSession{chatID: "12345", firstExternalID: "50001"}
+	assert.Equal(t, "tg:12345:50001", sess.sourceRef(adapter))
+}
+
+func TestResolveSessions_ChatScoped(t *testing.T) {
+	e := &Engine{burstWindowHours: 2, replyBridgeHours: 48}
+	base := accelerated.GetCurrentTime()
+
+	bursts := []burst{
+		{
+			direction: repository.InteractionDirectionOutbound,
+			messages:  []Message{makeMsg(1, 100, true, base)},
+			chatID:    "100",
+		},
+		{
+			direction: repository.InteractionDirectionOutbound,
+			messages:  []Message{makeMsg(2, 200, true, base.Add(5*time.Minute))},
+			chatID:    "200",
+		},
+	}
+
+	sessions := e.resolveSessions(bursts)
+	require.Len(t, sessions, 2)
+}
+
+func TestResolveSessions_CrossChatNoBridge(t *testing.T) {
+	e := &Engine{burstWindowHours: 2, replyBridgeHours: 48}
+	base := accelerated.GetCurrentTime()
+
+	bursts := []burst{
+		{
+			direction: repository.InteractionDirectionOutbound,
+			messages:  []Message{makeMsg(1, 100, true, base)},
+			chatID:    "100",
+		},
+		{
+			direction: repository.InteractionDirectionInbound,
+			messages:  []Message{makeMsg(2, 200, false, base.Add(1*time.Hour))},
+			chatID:    "200",
+		},
+	}
+
+	sessions := e.resolveSessions(bursts)
+	require.Len(t, sessions, 2)
+	assert.Equal(t, repository.InteractionDirectionOutbound, sessions[0].direction)
+	assert.Equal(t, repository.InteractionDirectionInbound, sessions[1].direction)
+}
+
+func TestPartitionByChat(t *testing.T) {
+	now := accelerated.GetCurrentTime()
+	msgs := []Message{
+		makeMsg(1, 100, true, now),
+		makeMsg(2, 200, true, now),
+		makeMsg(3, 100, false, now),
+	}
+
+	result := partitionByChat(msgs)
+	assert.Len(t, result["100"], 2)
+	assert.Len(t, result["200"], 1)
+}
+
+func TestMsgDirection(t *testing.T) {
+	assert.Equal(t, repository.InteractionDirectionOutbound, msgDirection(Message{IsOutgoing: true}))
+	assert.Equal(t, repository.InteractionDirectionInbound, msgDirection(Message{IsOutgoing: false}))
+}
+
+// --- engine wiring tests with fake adapters ----------------------------
+
+// TestEngine_FakeSource_AggregateForContactBatch_CreatesEvents asserts
+// the engine emits a message.received envelope with adapter-formatted
+// fields when the inbound batch has no existing interaction to bridge
+// against.
+func TestEngine_FakeSource_AggregateForContactBatch_CreatesEvents(t *testing.T) {
+	ctx := context.Background()
+	base := accelerated.GetCurrentTime()
+	contactID := uuid.New()
+
+	adapter := fakeAdapter{name: "fakesrc"}
+	store := newFakeStore()
+	msgs := []Message{
+		{ID: uuid.New(), ChatID: "chatA", ExternalID: "m1", IsOutgoing: false, SentAt: base},
+		{ID: uuid.New(), ChatID: "chatA", ExternalID: "m2", IsOutgoing: false, SentAt: base.Add(5 * time.Minute)},
+		{ID: uuid.New(), ChatID: "chatA", ExternalID: "m3", IsOutgoing: false, SentAt: base.Add(10 * time.Minute)},
+	}
+	store.byContact[contactID] = msgs
+
+	publisher := &fakePublisher{}
+	engine := NewEngine(adapter, store, &fakeFinder{}, &fakePromoter{}, &fakeExtender{}, publisher, 2, 48)
+
+	require.NoError(t, engine.AggregateForContactBatch(ctx, contactID))
+
+	require.Len(t, publisher.envelopes, 1)
+	env := publisher.envelopes[0]
+	assert.Equal(t, "fakesrc", env.Source)
+	assert.Equal(t, "fakesrc:chatA:m1", env.SourceID)
+	assert.Equal(t, events.KindMessageReceived, env.Kind)
+}
+
+// TestEngine_FakeSource_AggregateForContact_TimeBridgePromotesToMutual
+// asserts the time-based reply bridge fires when an inbound session
+// arrives within the reply-bridge window after an outbound interaction.
+func TestEngine_FakeSource_AggregateForContact_TimeBridgePromotesToMutual(t *testing.T) {
+	ctx := context.Background()
+	base := accelerated.GetCurrentTime()
+	contactID := uuid.New()
+	priorOutboundID := uuid.New()
+
+	adapter := fakeAdapter{name: "fakesrc"}
+	store := newFakeStore()
+	inbound := Message{ID: uuid.New(), ChatID: "chatA", ExternalID: "i1", IsOutgoing: false, SentAt: base}
+	store.byContactAndChat[contactID.String()+"|chatA"] = []Message{inbound}
+
+	finder := &fakeFinder{
+		findRecentOutboundRet: &repository.Interaction{
+			ID:        priorOutboundID,
+			Source:    "fakesrc",
+			Direction: repository.InteractionDirectionOutbound,
+		},
+		// same-direction inbound coalescing finds nothing, so the
+		// extend path doesn't run and the create-path is dead code here.
+		findRecentBySourceAndDirErr: db.ErrNotFound,
+	}
+	promoter := &fakePromoter{}
+	extender := &fakeExtender{}
+	publisher := &fakePublisher{}
+
+	engine := NewEngine(adapter, store, finder, promoter, extender, publisher, 2, 48)
+	require.NoError(t, engine.AggregateForContact(ctx, contactID, "chatA"))
+
+	require.Len(t, promoter.calls, 1)
+	assert.Equal(t, priorOutboundID, promoter.calls[0].interactionID)
+	assert.Empty(t, extender.calls)
+	require.Len(t, store.markProcessedCalls, 1)
+	assert.Equal(t, priorOutboundID, store.markProcessedCalls[0].interactionID)
+}
+
+// TestEngine_FakeSource_AggregateForContact_ExtendPathExtendsSameDirection
+// asserts an inbound session with a matching prior inbound interaction
+// extends rather than creates.
+func TestEngine_FakeSource_AggregateForContact_ExtendPathExtendsSameDirection(t *testing.T) {
+	ctx := context.Background()
+	base := accelerated.GetCurrentTime()
+	contactID := uuid.New()
+	priorInboundID := uuid.New()
+
+	adapter := fakeAdapter{name: "fakesrc"}
+	store := newFakeStore()
+	inbound := Message{ID: uuid.New(), ChatID: "chatA", ExternalID: "i1", IsOutgoing: false, SentAt: base}
+	store.byContactAndChat[contactID.String()+"|chatA"] = []Message{inbound}
+
+	finder := &fakeFinder{
+		findRecentOutboundErr: db.ErrNotFound, // no outbound to bridge to
+		findRecentBySourceAndDirRet: &repository.Interaction{
+			ID:        priorInboundID,
+			Source:    "fakesrc",
+			Direction: repository.InteractionDirectionInbound,
+		},
+	}
+	promoter := &fakePromoter{}
+	extender := &fakeExtender{}
+	publisher := &fakePublisher{}
+
+	engine := NewEngine(adapter, store, finder, promoter, extender, publisher, 2, 48)
+	require.NoError(t, engine.AggregateForContact(ctx, contactID, "chatA"))
+
+	require.Len(t, extender.calls, 1)
+	assert.Equal(t, priorInboundID, extender.calls[0].interactionID)
+	assert.Equal(t, "fakesrc inbound (1 messages)", extender.calls[0].description)
+	assert.Empty(t, promoter.calls)
+	require.Len(t, store.markProcessedCalls, 1)
+	assert.Equal(t, priorInboundID, store.markProcessedCalls[0].interactionID)
+	// No event published: extend path consumes the message.
+	assert.Empty(t, publisher.envelopes)
+}
+
+// TestEngine_FakeSource_ExplicitReplyBridge covers the cross-batch
+// explicit reply path: an inbound message has ReplyTargetID pointing to
+// a prior outbound message (resolved via GetMessageByReplyTarget),
+// whose InteractionID is the existing outbound interaction. The
+// engine must call GetInteraction, verify the source/direction, and
+// promote.
+func TestEngine_FakeSource_ExplicitReplyBridge(t *testing.T) {
+	ctx := context.Background()
+	base := accelerated.GetCurrentTime()
+	contactID := uuid.New()
+	priorOutboundID := uuid.New()
+
+	adapter := fakeAdapter{name: "fakesrc"}
+	store := newFakeStore()
+
+	replyTarget := "outboundExt"
+	inbound := Message{
+		ID:            uuid.New(),
+		ChatID:        "chatA",
+		ExternalID:    "i1",
+		IsOutgoing:    false,
+		SentAt:        base.Add(100 * time.Hour), // outside reply-bridge window
+		ReplyTargetID: &replyTarget,
+	}
+	store.byContactAndChat[contactID.String()+"|chatA"] = []Message{inbound}
+
+	// Referenced outbound message: outgoing + has an InteractionID
+	referenced := Message{
+		ID:            uuid.New(),
+		ChatID:        "chatA",
+		ExternalID:    replyTarget,
+		IsOutgoing:    true,
+		SentAt:        base,
+		InteractionID: &priorOutboundID,
+	}
+	store.byReplyTarget["chatA|"+replyTarget] = referenced
+
+	finder := &fakeFinder{
+		// Time-based bridge fails (no outbound in window).
+		findRecentOutboundErr: db.ErrNotFound,
+		// GetInteraction returns the existing outbound row.
+		getInteractionRet: &repository.Interaction{
+			ID:        priorOutboundID,
+			Source:    "fakesrc",
+			Direction: repository.InteractionDirectionOutbound,
+		},
+	}
+	promoter := &fakePromoter{}
+	publisher := &fakePublisher{}
+
+	engine := NewEngine(adapter, store, finder, promoter, &fakeExtender{}, publisher, 2, 48)
+	require.NoError(t, engine.AggregateForContact(ctx, contactID, "chatA"))
+
+	require.Len(t, promoter.calls, 1)
+	assert.Equal(t, priorOutboundID, promoter.calls[0].interactionID)
+	require.Len(t, store.markProcessedCalls, 1)
+	assert.Equal(t, priorOutboundID, store.markProcessedCalls[0].interactionID)
+	assert.Empty(t, publisher.envelopes)
+}
+
+// TestEngine_FakeSource_NoMatch_PublishesCreateEvent asserts the
+// create-path runs when finder + reply target both miss.
+func TestEngine_FakeSource_NoMatch_PublishesCreateEvent(t *testing.T) {
+	ctx := context.Background()
+	base := accelerated.GetCurrentTime()
+	contactID := uuid.New()
+
+	adapter := fakeAdapter{name: "fakesrc"}
+	store := newFakeStore()
+	inbound := Message{ID: uuid.New(), ChatID: "chatA", ExternalID: "i1", IsOutgoing: false, SentAt: base}
+	store.byContactAndChat[contactID.String()+"|chatA"] = []Message{inbound}
+
+	finder := &fakeFinder{
+		findRecentOutboundErr:       db.ErrNotFound,
+		findRecentBySourceAndDirErr: db.ErrNotFound,
+	}
+	publisher := &fakePublisher{}
+
+	engine := NewEngine(adapter, store, finder, &fakePromoter{}, &fakeExtender{}, publisher, 2, 48)
+	require.NoError(t, engine.AggregateForContact(ctx, contactID, "chatA"))
+
+	require.Len(t, publisher.envelopes, 1)
+	assert.Equal(t, events.KindMessageReceived, publisher.envelopes[0].Kind)
+	assert.Equal(t, "fakesrc", publisher.envelopes[0].Source)
+	assert.Equal(t, "fakesrc:chatA:i1", publisher.envelopes[0].SourceID)
+	// No staging-row mark — the consumer's tx does that in the create path.
+	assert.Empty(t, store.markProcessedCalls)
+}
+
+// TestEngine_FakeSource_NilPublisher_Errors covers the publisher==nil
+// guard inside createInteractionForSession. Calling the private method
+// directly (same-package access) keeps the assertion focused — the
+// public AggregateForContact swallows this error and returns nil to
+// match the pre-refactor behaviour.
+func TestEngine_FakeSource_NilPublisher_Errors(t *testing.T) {
+	ctx := context.Background()
+	contactID := uuid.New()
+	sess := msgSession{
+		direction:       repository.InteractionDirectionInbound,
+		chatID:          "chatA",
+		firstExternalID: "i1",
+		messages: []Message{
+			{ID: uuid.New(), ChatID: "chatA", ExternalID: "i1", IsOutgoing: false, SentAt: accelerated.GetCurrentTime()},
+		},
+	}
+
+	engine := NewEngine(fakeAdapter{name: "fakesrc"}, newFakeStore(), &fakeFinder{}, &fakePromoter{}, &fakeExtender{}, nil, 2, 48)
+	err := engine.createInteractionForSession(ctx, contactID, sess)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "publisher")
+}
+
+// TestEngine_TelegramShape_SourceRefMatchesLegacyFormat locks the wire
+// format "tg:<chatID>:<firstExternalID>" via a telegram-shaped adapter
+// in the shared package — proves the adapter contract reproduces the
+// pre-refactor source_ref byte-for-byte.
+func TestEngine_TelegramShape_SourceRefMatchesLegacyFormat(t *testing.T) {
+	ctx := context.Background()
+	base := accelerated.GetCurrentTime()
+	contactID := uuid.New()
+
+	adapter := telegramShapedAdapter{}
+	store := newFakeStore()
+	// chatID and ExternalID mirror what telegram's row-mapping helper
+	// produces: strconv.FormatInt(int64) and strconv.Itoa(int32).
+	msgs := []Message{
+		{ID: uuid.New(), ChatID: "12345", ExternalID: "50001", IsOutgoing: false, SentAt: base},
+	}
+	store.byContact[contactID] = msgs
+
+	publisher := &fakePublisher{}
+	engine := NewEngine(adapter, store, &fakeFinder{}, &fakePromoter{}, &fakeExtender{}, publisher, 2, 48)
+
+	require.NoError(t, engine.AggregateForContactBatch(ctx, contactID))
+	require.Len(t, publisher.envelopes, 1)
+	assert.Equal(t, "tg:12345:50001", publisher.envelopes[0].SourceID)
+	assert.Equal(t, repository.InteractionSourceTelegram, publisher.envelopes[0].Source)
+}
+
+// TestEngine_FakeSource_FinderReceivesAdapterPrefix asserts the
+// SourceRefPrefix passed to the finder is exactly what
+// adapter.SourceRefPrefix(chatID) produces. Regression guard for the
+// "engine bakes its own format" failure mode.
+func TestEngine_FakeSource_FinderReceivesAdapterPrefix(t *testing.T) {
+	ctx := context.Background()
+	base := accelerated.GetCurrentTime()
+	contactID := uuid.New()
+
+	adapter := fakeAdapter{name: "fakesrc"}
+	store := newFakeStore()
+	inbound := Message{ID: uuid.New(), ChatID: "chatA", ExternalID: "i1", IsOutgoing: false, SentAt: base}
+	// Use the inbound→same-direction-extend branch so the engine calls
+	// FindRecentBySourceAndDirection (which records the prefix).
+	store.byContactAndChat[contactID.String()+"|chatA"] = []Message{inbound}
+
+	finder := &fakeFinder{
+		findRecentOutboundErr:       db.ErrNotFound,
+		findRecentBySourceAndDirErr: db.ErrNotFound,
+	}
+
+	engine := NewEngine(adapter, store, finder, &fakePromoter{}, &fakeExtender{}, &fakePublisher{}, 2, 48)
+	require.NoError(t, engine.AggregateForContact(ctx, contactID, "chatA"))
+
+	finder.mu.Lock()
+	got := finder.findRecentBySourceAndDirArg
+	finder.mu.Unlock()
+	assert.Equal(t, "fakesrc", got.source)
+	assert.Equal(t, "fakesrc:chatA:%", got.sourceRefPrefix)
+	assert.Equal(t, repository.InteractionDirectionInbound, got.direction)
+}
+
+// TestEngine_FakeSource_AggregateAll_SwallowsPerContactErrors covers
+// the AggregateAll batch-mode error-swallowing semantic: a contact
+// whose ListUnprocessedByContact fails does NOT abort the loop.
+func TestEngine_FakeSource_AggregateAll_SwallowsPerContactErrors(t *testing.T) {
+	ctx := context.Background()
+	base := accelerated.GetCurrentTime()
+	failingContactID := uuid.New()
+	goodContactID := uuid.New()
+
+	adapter := fakeAdapter{name: "fakesrc"}
+	store := newFakeStore()
+	store.unprocessedContactIDs = []uuid.UUID{failingContactID, goodContactID}
+	// failingContactID has no entry in byContact, but we want a real
+	// error (not just empty result). Use a separate flag.
+	store.listUnprocessedByContactErr = nil // start fresh
+	store.byContact[goodContactID] = []Message{
+		{ID: uuid.New(), ChatID: "chatA", ExternalID: "m1", IsOutgoing: false, SentAt: base},
+	}
+
+	// Swap in a store that errors for failingContactID only.
+	erroringStore := &perContactErroringStore{
+		inner: store,
+		errs: map[uuid.UUID]error{
+			failingContactID: errors.New("simulated per-contact failure"),
+		},
+	}
+
+	publisher := &fakePublisher{}
+	engine := NewEngine(adapter, erroringStore, &fakeFinder{}, &fakePromoter{}, &fakeExtender{}, publisher, 2, 48)
+	require.NoError(t, engine.AggregateAll(ctx))
+	// goodContactID's batch produced one published event despite the
+	// failingContactID error.
+	require.Len(t, publisher.envelopes, 1)
+}
+
+type perContactErroringStore struct {
+	inner *fakeStore
+	errs  map[uuid.UUID]error
+}
+
+func (s *perContactErroringStore) ListUnprocessedContactIDs(ctx context.Context) ([]uuid.UUID, error) {
+	return s.inner.ListUnprocessedContactIDs(ctx)
+}
+func (s *perContactErroringStore) ListUnprocessedByContact(ctx context.Context, contactID uuid.UUID) ([]Message, error) {
+	if err, ok := s.errs[contactID]; ok {
+		return nil, err
+	}
+	return s.inner.ListUnprocessedByContact(ctx, contactID)
+}
+func (s *perContactErroringStore) ListUnprocessedByContactAndChat(ctx context.Context, contactID uuid.UUID, chatID string) ([]Message, error) {
+	return s.inner.ListUnprocessedByContactAndChat(ctx, contactID, chatID)
+}
+func (s *perContactErroringStore) GetMessageByReplyTarget(ctx context.Context, chatID, replyTargetID string) (Message, bool, error) {
+	return s.inner.GetMessageByReplyTarget(ctx, chatID, replyTargetID)
+}
+func (s *perContactErroringStore) MarkProcessed(ctx context.Context, messageIDs []uuid.UUID, interactionID uuid.UUID) error {
+	return s.inner.MarkProcessed(ctx, messageIDs, interactionID)
+}

--- a/backend/internal/messaging/aggregation/interfaces.go
+++ b/backend/internal/messaging/aggregation/interfaces.go
@@ -1,0 +1,164 @@
+package aggregation
+
+import (
+	"context"
+	"time"
+
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+)
+
+// Message is the source-neutral row the aggregator consumes. The
+// per-source adapter (via MessageStore) projects its staging-table row
+// into this shape.
+//
+// InteractionID is the foreign key set once aggregation has processed
+// this row — mirrors every per-source staging table's interaction_id
+// column. Read by tryExplicitReplyBridge to resolve "the interaction
+// the referenced outgoing message produced." It is required at the
+// shared layer; without it cross-batch explicit reply bridging silently
+// fails.
+type Message struct {
+	ID            uuid.UUID
+	ChatID        string     // source-neutral chat scope key (numeric stringified for sources with numeric chat IDs, opaque guid for sources like Apple Messages)
+	IsOutgoing    bool       // direction at the row level
+	SentAt        time.Time  // wall clock of the message
+	ReplyTargetID *string    // opaque source-defined "external message id" of the referenced message; nil if not a reply
+	ExternalID    string     // opaque per-source "first message id" used in source_ref; comparison-by-equality only
+	InteractionID *uuid.UUID // FK to interaction once processed; nil for unprocessed rows
+}
+
+// SourceAdapter binds a source-name to the aggregator. Concrete adapters
+// live in their respective per-source packages; the shared engine
+// depends only on this interface.
+type SourceAdapter interface {
+	// SourceName: the interaction.source constant ("telegram",
+	// "messages", "whatsapp"). Used for event envelope Source AND for
+	// the interaction.source filter in InteractionFinder.
+	SourceName() string
+
+	// SourceRef formats the deterministic burst sourceRef.
+	// Telegram returns "tg:<chatID>:<firstExternalID>"; future sources
+	// return their own namespace prefix. Aggregator passes (chatID,
+	// firstExternalID) lifted from the session's first Message; the
+	// adapter formats the string.
+	SourceRef(chatID, firstExternalID string) string
+
+	// SourceRefPrefix returns the LIKE-pattern used by InteractionFinder
+	// to scope "recent interaction in this chat" queries.
+	//
+	// CONTRACT: the returned string is consumed as a PostgreSQL `LIKE`
+	// pattern. The `%` and `_` characters in chatID are treated as
+	// wildcards. Adapters whose chat IDs may legitimately contain `_`
+	// or `%` MUST escape the pattern's special characters before
+	// returning — recommended escape:
+	//   strings.NewReplacer("\\", "\\\\", "%", "\\%", "_", "\\_").Replace(chatID)
+	// and switch the underlying SQL to `source_ref LIKE prefix ESCAPE '\'`.
+	// Numeric-only chat IDs (e.g. Telegram) do not require escaping.
+	SourceRefPrefix(chatID string) string
+
+	// PeerRef formats the event-payload PeerRef field.
+	// Telegram returns "tg:<chatID>"; future sources mirror their
+	// own namespace.
+	PeerRef(chatID string) string
+
+	// Description formats the human-readable interaction description.
+	// Telegram returns "Telegram <label> (<n> messages)" where label is
+	// "outreach"/"response"/"exchange". Per-source so labels stay
+	// accurate ("iMessage", "WhatsApp", etc.) and the existing Telegram
+	// phrasing is preserved verbatim.
+	Description(direction string, msgCount int) string
+}
+
+// MessageStore is the source-neutral staging-IO surface. Concrete
+// repositories satisfy this via per-source adapter wrappers (not
+// directly) because the shared interface uses Message rows and string
+// chat IDs while the underlying per-source repositories use their own
+// row types and typed chat IDs. The wrapper does the row-by-row
+// conversion and any ID type translation.
+type MessageStore interface {
+	ListUnprocessedContactIDs(ctx context.Context) ([]uuid.UUID, error)
+	ListUnprocessedByContact(ctx context.Context, contactID uuid.UUID) ([]Message, error)
+	ListUnprocessedByContactAndChat(ctx context.Context, contactID uuid.UUID, chatID string) ([]Message, error)
+
+	// GetMessageByReplyTarget resolves the message referenced by a
+	// reply (Message.ReplyTargetID). The returned Message includes its
+	// InteractionID and IsOutgoing so tryExplicitReplyBridge can verify
+	// the bridged interaction exists and the message direction is
+	// correct.
+	//
+	// Returns (msg, true, nil) on hit; (Message{}, false, nil) if not
+	// found OR if the source-specific ID cannot be parsed; non-nil
+	// error only on infrastructure failure.
+	GetMessageByReplyTarget(ctx context.Context, chatID, replyTargetID string) (Message, bool, error)
+
+	// MarkProcessed sets processed_at and interaction_id on the rows.
+	// The adapter wraps the per-source equivalent query. Non-tx by
+	// design; the consumer's tx-bound MarkProcessed dispatch remains
+	// source-specific and is not part of this interface in PR2.
+	MarkProcessed(ctx context.Context, messageIDs []uuid.UUID, interactionID uuid.UUID) error
+}
+
+// InteractionFinder locates a "recent matching interaction" for the
+// extend/bridge paths. Source-neutral signature; the engine passes
+// adapter.SourceName() as source.
+type InteractionFinder interface {
+	// FindRecentBySourceAndDirection looks up the most recent
+	// interaction for (contactID, source, direction) whose source_ref
+	// matches the LIKE pattern and whose occurred_at falls in the
+	// window. Used by same-direction coalescing.
+	FindRecentBySourceAndDirection(
+		ctx context.Context,
+		contactID uuid.UUID,
+		source, direction, sourceRefPrefix string,
+		windowStart, windowEnd time.Time,
+	) (*repository.Interaction, error)
+
+	// FindRecentOutboundBySource looks up the most recent outbound
+	// interaction for (contactID, source) within window. Used by
+	// time-based reply bridging on inbound sessions.
+	FindRecentOutboundBySource(
+		ctx context.Context,
+		contactID uuid.UUID,
+		source, sourceRefPrefix string,
+		windowStart, windowEnd time.Time,
+	) (*repository.Interaction, error)
+
+	// GetInteraction passthrough (used by explicit reply bridge to
+	// verify direction/source of the bridged interaction).
+	GetInteraction(ctx context.Context, id uuid.UUID) (*repository.Interaction, error)
+}
+
+// InteractionPromoter promotes an outbound interaction to mutual.
+// Satisfied by *service.ContactService via Go's structural typing.
+type InteractionPromoter interface {
+	PromoteInteractionToMutual(ctx context.Context, interactionID, contactID uuid.UUID, replyAt time.Time) error
+}
+
+// InteractionExtender extends an existing interaction's occurred_at and
+// description. Satisfied by *service.ContactService via Go's structural
+// typing.
+type InteractionExtender interface {
+	ExtendInteraction(ctx context.Context, interactionID, contactID uuid.UUID, direction string, occurredAt time.Time, description *string) error
+}
+
+// EventPublisher emits domain events.
+//
+// NOTE on nil: callers MUST pass nil literally (not a typed-nil pointer
+// like `(*events.Bus)(nil)`) when the publisher is unavailable. The
+// engine's "publisher==nil" guard checks the interface value, which a
+// typed-nil concrete pointer would satisfy as non-nil. Constructors
+// that accept a concrete pointer must convert as
+//
+//	var pub aggregation.EventPublisher
+//	if bus != nil { pub = bus }
+//
+// so untyped nil propagates. The Engine asserts publisher == nil only
+// inside the session create path; modes that intentionally omit the
+// bus are refused-with-error there (matching the pre-refactor
+// telegram contract).
+type EventPublisher interface {
+	Publish(ctx context.Context, env *events.Envelope) error
+}

--- a/backend/internal/messaging/aggregation/interfaces.go
+++ b/backend/internal/messaging/aggregation/interfaces.go
@@ -78,6 +78,15 @@ type SourceAdapter interface {
 // chat IDs while the underlying per-source repositories use their own
 // row types and typed chat IDs. The wrapper does the row-by-row
 // conversion and any ID type translation.
+//
+// ORDERING CONTRACT: ListUnprocessedByContact and
+// ListUnprocessedByContactAndChat SHOULD return rows ordered by
+// SentAt ascending. Burst/session derivation depends on chronological
+// adjacency; the engine sorts defensively to absorb minor adapter
+// drift, but adapters that emit grossly out-of-order rows will pay an
+// O(N log N) sort tax on every aggregation. Telegram's existing sqlc
+// queries already ORDER BY sent_at — preserve that idiom in future
+// adapters.
 type MessageStore interface {
 	ListUnprocessedContactIDs(ctx context.Context) ([]uuid.UUID, error)
 	ListUnprocessedByContact(ctx context.Context, contactID uuid.UUID) ([]Message, error)

--- a/backend/internal/messaging/aggregation/interfaces.go
+++ b/backend/internal/messaging/aggregation/interfaces.go
@@ -105,8 +105,8 @@ type MessageStore interface {
 
 	// MarkProcessed sets processed_at and interaction_id on the rows.
 	// The adapter wraps the per-source equivalent query. Non-tx by
-	// design; the consumer's tx-bound MarkProcessed dispatch remains
-	// source-specific and is not part of this interface in PR2.
+	// design; the consumer's tx-bound MarkProcessed dispatch is not
+	// part of this interface (it remains source-specific).
 	MarkProcessed(ctx context.Context, messageIDs []uuid.UUID, interactionID uuid.UUID) error
 }
 

--- a/backend/internal/messaging/aggregation/session.go
+++ b/backend/internal/messaging/aggregation/session.go
@@ -1,0 +1,165 @@
+package aggregation
+
+import (
+	"time"
+
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+)
+
+// burst groups consecutive same-direction messages within a time window.
+type burst struct {
+	direction string // "outbound" or "inbound"
+	messages  []Message
+	chatID    string
+}
+
+func (b burst) firstExternalID() string { return b.messages[0].ExternalID }
+func (b burst) firstSentAt() time.Time  { return b.messages[0].SentAt }
+
+// msgSession is a resolved aggregation unit — may be a single burst or
+// merged bursts.
+type msgSession struct {
+	direction       string // "outbound", "inbound", or "mutual"
+	messages        []Message
+	chatID          string
+	firstExternalID string // ExternalID of the first message (for sourceRef)
+}
+
+func (s msgSession) lastSentAt() time.Time { return s.messages[len(s.messages)-1].SentAt }
+
+func (s msgSession) messageIDs() []uuid.UUID {
+	ids := make([]uuid.UUID, len(s.messages))
+	for i, m := range s.messages {
+		ids[i] = m.ID
+	}
+	return ids
+}
+
+// sourceRef returns the source-specific deterministic source_ref string
+// for this session, computed via the adapter so the engine never bakes
+// in source-specific formatting.
+func (s msgSession) sourceRef(adapter SourceAdapter) string {
+	return adapter.SourceRef(s.chatID, s.firstExternalID)
+}
+
+// description returns the human-readable session description, also
+// per-adapter so each source can label sessions naturally
+// ("Telegram outreach (3 messages)", "iMessage exchange (2 messages)").
+func (s msgSession) description(adapter SourceAdapter) string {
+	return adapter.Description(s.direction, len(s.messages))
+}
+
+// groupIntoBursts groups consecutive same-direction messages within the
+// burst window.
+func (e *Engine) groupIntoBursts(msgs []Message, chatID string) []burst {
+	if len(msgs) == 0 {
+		return nil
+	}
+
+	var bursts []burst
+	current := burst{
+		direction: msgDirection(msgs[0]),
+		messages:  []Message{msgs[0]},
+		chatID:    chatID,
+	}
+
+	for i := 1; i < len(msgs); i++ {
+		dir := msgDirection(msgs[i])
+		gap := msgs[i].SentAt.Sub(msgs[i-1].SentAt)
+
+		if dir != current.direction || gap > time.Duration(e.burstWindowHours)*time.Hour {
+			bursts = append(bursts, current)
+			current = burst{
+				direction: dir,
+				messages:  []Message{msgs[i]},
+				chatID:    chatID,
+			}
+		} else {
+			current.messages = append(current.messages, msgs[i])
+		}
+	}
+	bursts = append(bursts, current)
+	return bursts
+}
+
+// resolveSessions merges bursts into sessions, applying reply bridging
+// for batch mode. Time-based bridging fires when the gap is within the
+// configured reply-bridge window; explicit reply bridging compares the
+// inbound burst's reply targets against the previous outbound burst's
+// external IDs (string equality — opaque per-source IDs).
+func (e *Engine) resolveSessions(bursts []burst) []msgSession {
+	if len(bursts) == 0 {
+		return nil
+	}
+
+	var sessions []msgSession
+
+	for i := 0; i < len(bursts); i++ {
+		b := bursts[i]
+
+		// Check if this inbound burst should bridge with the previous
+		// outbound session.
+		if b.direction == repository.InteractionDirectionInbound && len(sessions) > 0 {
+			prev := &sessions[len(sessions)-1]
+			if prev.direction == repository.InteractionDirectionOutbound && prev.chatID == b.chatID {
+				shouldBridge := false
+
+				// Time-based bridging.
+				gap := b.firstSentAt().Sub(prev.lastSentAt())
+				if gap <= time.Duration(e.replyBridgeHours)*time.Hour {
+					shouldBridge = true
+				}
+
+				// Explicit reply bridging via opaque external IDs.
+				if !shouldBridge {
+					for _, msg := range b.messages {
+						if msg.ReplyTargetID != nil {
+							for _, prevMsg := range prev.messages {
+								if prevMsg.ExternalID == *msg.ReplyTargetID {
+									shouldBridge = true
+									break
+								}
+							}
+							if shouldBridge {
+								break
+							}
+						}
+					}
+				}
+
+				if shouldBridge {
+					prev.direction = repository.InteractionDirectionMutual
+					prev.messages = append(prev.messages, b.messages...)
+					continue
+				}
+			}
+		}
+
+		sessions = append(sessions, msgSession{
+			direction:       b.direction,
+			messages:        b.messages,
+			chatID:          b.chatID,
+			firstExternalID: b.firstExternalID(),
+		})
+	}
+
+	return sessions
+}
+
+// partitionByChat groups messages by their (source-neutral) chat ID.
+func partitionByChat(msgs []Message) map[string][]Message {
+	result := make(map[string][]Message)
+	for _, m := range msgs {
+		result[m.ChatID] = append(result[m.ChatID], m)
+	}
+	return result
+}
+
+func msgDirection(msg Message) string {
+	if msg.IsOutgoing {
+		return repository.InteractionDirectionOutbound
+	}
+	return repository.InteractionDirectionInbound
+}

--- a/backend/internal/repository/event.go
+++ b/backend/internal/repository/event.go
@@ -138,6 +138,19 @@ func (r *EventRepository) FindEventBySource(ctx context.Context, source, sourceI
 	return convertDbEvent(row), nil
 }
 
+// HardDeleteEventsBySourceAndSourceIDPrefix removes event rows whose
+// (source, source_id) match the given source and a LIKE-prefix on
+// source_id. Test-only helper for integration tests that publish
+// per-run event envelopes — a soft-delete is not possible because the
+// event log is append-only and the (source, source_id) partial unique
+// must be cleared between test runs. Production code MUST NOT call this.
+func (r *EventRepository) HardDeleteEventsBySourceAndSourceIDPrefix(ctx context.Context, source, sourceIDPrefix string) error {
+	return r.queries.HardDeleteEventsBySourceAndSourceIDPrefix(ctx, db.HardDeleteEventsBySourceAndSourceIDPrefixParams{
+		Source:         source,
+		SourceIDPrefix: pgtype.Text{String: sourceIDPrefix, Valid: true},
+	})
+}
+
 // CountRematchDispatcherJobs returns the number of river_job rows of
 // kind "rematch_dispatcher" whose args JSON matches the given
 // (contactID, rematchJobID) tuple. Test-only helper for rematch dedup

--- a/backend/internal/repository/interaction.go
+++ b/backend/internal/repository/interaction.go
@@ -288,6 +288,72 @@ func (r *InteractionRepository) FindRecentTelegramInteraction(ctx context.Contex
 	return &interaction, nil
 }
 
+// FindRecentInteractionBySourceAndDirection is the source-neutral version of
+// FindRecentTelegramInteraction. The shared aggregator
+// (backend/internal/messaging/aggregation) uses this for same-direction
+// coalescing across sources (telegram, messages, whatsapp).
+func (r *InteractionRepository) FindRecentInteractionBySourceAndDirection(
+	ctx context.Context,
+	contactID uuid.UUID,
+	source, direction, sourceRefPrefix string,
+	windowStart, windowEnd time.Time,
+) (*Interaction, error) {
+	dbInteraction, err := r.queries.FindRecentInteractionBySourceAndDirection(ctx, db.FindRecentInteractionBySourceAndDirectionParams{
+		ContactID:       uuidToPgUUID(contactID),
+		Source:          source,
+		Direction:       direction,
+		SourceRefPrefix: pgtype.Text{String: sourceRefPrefix, Valid: true},
+		WindowStart:     pgtype.Timestamptz{Time: windowStart, Valid: true},
+		WindowEnd:       pgtype.Timestamptz{Time: windowEnd, Valid: true},
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, db.ErrNotFound
+		}
+		return nil, err
+	}
+	interaction := convertDbInteraction(dbInteraction)
+	return &interaction, nil
+}
+
+// FindRecentOutboundInteractionBySource is the source-neutral version of
+// FindRecentOutboundTelegramInteraction. Used by the shared aggregator for
+// time-based reply bridging on inbound sessions.
+func (r *InteractionRepository) FindRecentOutboundInteractionBySource(
+	ctx context.Context,
+	contactID uuid.UUID,
+	source, sourceRefPrefix string,
+	windowStart, windowEnd time.Time,
+) (*Interaction, error) {
+	dbInteraction, err := r.queries.FindRecentOutboundInteractionBySource(ctx, db.FindRecentOutboundInteractionBySourceParams{
+		ContactID:       uuidToPgUUID(contactID),
+		Source:          source,
+		SourceRefPrefix: pgtype.Text{String: sourceRefPrefix, Valid: true},
+		WindowStart:     pgtype.Timestamptz{Time: windowStart, Valid: true},
+		WindowEnd:       pgtype.Timestamptz{Time: windowEnd, Valid: true},
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, db.ErrNotFound
+		}
+		return nil, err
+	}
+	interaction := convertDbInteraction(dbInteraction)
+	return &interaction, nil
+}
+
+// HardDeleteInteractionsBySourceRefPrefix is a test-only helper that
+// hard-deletes interactions whose source matches and source_ref begins
+// with prefix. Used by integration tests for per-run cleanup; soft-delete
+// is unsafe because the (source, source_ref) partial unique index would
+// otherwise block re-inserts on subsequent runs.
+func (r *InteractionRepository) HardDeleteInteractionsBySourceRefPrefix(ctx context.Context, source, sourceRefPrefix string) error {
+	return r.queries.HardDeleteInteractionsBySourceRefPrefix(ctx, db.HardDeleteInteractionsBySourceRefPrefixParams{
+		Source:          source,
+		SourceRefPrefix: pgtype.Text{String: sourceRefPrefix, Valid: true},
+	})
+}
+
 // UpdateInteractionTimestamp extends an existing interaction's occurred_at and description.
 func (r *InteractionRepository) UpdateInteractionTimestamp(ctx context.Context, id uuid.UUID, occurredAt time.Time, description *string) (*Interaction, error) {
 	dbInteraction, err := r.queries.UpdateInteractionTimestamp(ctx, db.UpdateInteractionTimestampParams{

--- a/backend/internal/repository/telegram_message.go
+++ b/backend/internal/repository/telegram_message.go
@@ -473,4 +473,16 @@ func (r *TelegramMessageRepository) CountMessagesByPeerID(ctx context.Context, p
 	return count, nil
 }
 
+// HardDeleteByChatIDRange is a test-only helper that hard-deletes
+// telegram_message rows whose telegram_chat_id falls in [lo, hi].
+// Integration tests use this for per-run cleanup; soft-delete is unsafe
+// because UpsertTelegramMessage does not clear deleted_at on conflict,
+// so soft-deleted rows would resurrect as phantoms on subsequent runs.
+func (r *TelegramMessageRepository) HardDeleteByChatIDRange(ctx context.Context, lo, hi int64) error {
+	return r.queries.HardDeleteTelegramMessagesByChatIDRange(ctx, db.HardDeleteTelegramMessagesByChatIDRangeParams{
+		Lo: lo,
+		Hi: hi,
+	})
+}
+
 // int32ToPgInt4 already defined in telegram_chat_config.go

--- a/backend/internal/telegram/aggregation.go
+++ b/backend/internal/telegram/aggregation.go
@@ -2,53 +2,54 @@ package telegram
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strconv"
 	"time"
 
+	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/messaging/aggregation"
 	"personal-crm/backend/internal/repository"
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 )
 
-// interactionPromoter promotes outbound → mutual. Satisfied by *service.ContactService.
-// Used by the coalescing and reply-bridge paths — not migrated in PR 6
-// cutover because these operations MODIFY an existing interaction row
-// (no create) and have no event-kind peer in the spec's 10 kinds
-// (plan Decision 3).
+// interactionPromoter promotes outbound → mutual. Satisfied by
+// *service.ContactService via Go's structural typing. Re-declared here
+// for the shim's NewAggregationEngine signature; the shared package
+// declares its own equivalent interface (aggregation.InteractionPromoter).
 type interactionPromoter interface {
 	PromoteInteractionToMutual(ctx context.Context, interactionID, contactID uuid.UUID, replyAt time.Time) error
 }
 
-// interactionExtender extends an existing interaction. Satisfied by *service.ContactService.
-// Same rationale as interactionPromoter — out of PR 6 scope (plan Decision 3).
+// interactionExtender extends an existing interaction. Satisfied by
+// *service.ContactService via Go's structural typing.
 type interactionExtender interface {
 	ExtendInteraction(ctx context.Context, interactionID, contactID uuid.UUID, direction string, occurredAt time.Time, description *string) error
 }
 
-// AggregationEngine processes raw telegram_message rows into interaction records.
-// Post-PR-6 (cutover): new interaction creation runs through the event
-// bus — createInteractionForSession only publishes message.received /
-// message.sent events; the async InteractionRecorder consumer writes the
-// interaction row and marks telegram_messages processed inside its tx.
+// AggregationEngine is the telegram-side facade for the shared
+// aggregation engine (backend/internal/messaging/aggregation). The
+// exported method signatures match the pre-refactor type byte-for-byte
+// so manager.go, handlers.go, rematch.go, integration tests, and
+// cmd/crm-api wiring compile unchanged.
 type AggregationEngine struct {
-	burstWindowHours int
-	replyBridgeHours int
-	messageRepo      *repository.TelegramMessageRepository
-	interactionRepo  *repository.InteractionRepository
-	promoter         interactionPromoter
-	extender         interactionExtender
-	// eventBus is required in cutover mode. When nil, createInteractionForSession
-	// returns an error — off/shadow modes are effective no-ops post-cutover
-	// (spec §3.9; plan Decision 6).
-	eventBus *events.Bus
+	engine *aggregation.Engine
 }
 
-// NewAggregationEngine creates a new aggregation engine. eventBus is
-// required in cutover (default post-PR-6). Passing nil makes
-// createInteractionForSession a no-op error path (equivalent to the
-// off/shadow modes documented in EventBusConfig).
+// NewAggregationEngine constructs the telegram facade over the shared
+// aggregator. eventBus is required in cutover (default post-PR-6).
+// Passing a nil *events.Bus makes the engine's session-create path
+// return an error — equivalent to the off/shadow modes documented in
+// EventBusConfig (spec §3.9).
+//
+// CRITICAL: a nil *events.Bus is converted to the untyped-nil
+// aggregation.EventPublisher interface value explicitly. Assigning a
+// typed-nil pointer to an interface variable produces a non-nil
+// interface, which would silently bypass the engine's publisher==nil
+// guard.
 func NewAggregationEngine(
 	burstWindowHours, replyBridgeHours int,
 	messageRepo *repository.TelegramMessageRepository,
@@ -57,468 +58,196 @@ func NewAggregationEngine(
 	extender interactionExtender,
 	eventBus *events.Bus,
 ) *AggregationEngine {
-	return &AggregationEngine{
-		burstWindowHours: burstWindowHours,
-		replyBridgeHours: replyBridgeHours,
-		messageRepo:      messageRepo,
-		interactionRepo:  interactionRepo,
-		promoter:         promoter,
-		extender:         extender,
-		eventBus:         eventBus,
+	adapter := telegramAdapter{}
+	store := &telegramMessageStoreAdapter{repo: messageRepo}
+	finder := &interactionFinderAdapter{repo: interactionRepo}
+
+	var pub aggregation.EventPublisher
+	if eventBus != nil {
+		pub = eventBus
 	}
+
+	eng := aggregation.NewEngine(
+		adapter,
+		store,
+		finder,
+		promoter,
+		extender,
+		pub,
+		burstWindowHours,
+		replyBridgeHours,
+	)
+	return &AggregationEngine{engine: eng}
 }
 
-// burst groups consecutive same-direction messages within a time window.
-type burst struct {
-	direction string // "outbound" or "inbound"
-	messages  []repository.TelegramMessage
-	chatID    int64
+// AggregateAll processes all contacts with unprocessed telegram messages.
+func (e *AggregationEngine) AggregateAll(ctx context.Context) error {
+	return e.engine.AggregateAll(ctx)
 }
 
-func (b burst) firstMsgID() int32      { return b.messages[0].TelegramMessageID }
-func (b burst) firstSentAt() time.Time { return b.messages[0].SentAt }
-
-// msgSession is a resolved aggregation unit — may be a single burst or merged bursts.
-type msgSession struct {
-	direction string // "outbound", "inbound", or "mutual"
-	messages  []repository.TelegramMessage
-	chatID    int64
-	firstMsg  int32 // telegram_message_id of the first message (for source_ref)
+// AggregateForContactBatch processes all unprocessed telegram messages
+// for a single contact (no extend/bridge — create-path only).
+func (e *AggregationEngine) AggregateForContactBatch(ctx context.Context, contactID uuid.UUID) error {
+	return e.engine.AggregateForContactBatch(ctx, contactID)
 }
 
-func (s msgSession) sourceRef() string {
-	return fmt.Sprintf("tg:%d:%d", s.chatID, s.firstMsg)
+// AggregateForContact processes unprocessed messages for a specific
+// contact+chat in incremental mode. chatID stays int64 at the telegram
+// boundary; the shim stringifies before delegating to the shared
+// engine.
+func (e *AggregationEngine) AggregateForContact(ctx context.Context, contactID uuid.UUID, chatID int64) error {
+	return e.engine.AggregateForContact(ctx, contactID, strconv.FormatInt(chatID, 10))
 }
 
-func (s msgSession) lastSentAt() time.Time { return s.messages[len(s.messages)-1].SentAt }
+// --- adapters --------------------------------------------------------
 
-func (s msgSession) messageIDs() []uuid.UUID {
-	ids := make([]uuid.UUID, len(s.messages))
-	for i, m := range s.messages {
-		ids[i] = m.ID
-	}
-	return ids
+// telegramAdapter binds the source-name and formatting hooks for
+// Telegram. Wire format ("tg:<chatID>:<firstMsgID>") preserved
+// byte-for-byte from the pre-refactor msgSession.sourceRef.
+type telegramAdapter struct{}
+
+func (telegramAdapter) SourceName() string {
+	return repository.InteractionSourceTelegram
 }
 
-func (s msgSession) description() string {
+func (telegramAdapter) SourceRef(chatID, firstExternalID string) string {
+	return "tg:" + chatID + ":" + firstExternalID
+}
+
+func (telegramAdapter) SourceRefPrefix(chatID string) string {
+	return "tg:" + chatID + ":%"
+}
+
+func (telegramAdapter) PeerRef(chatID string) string {
+	return "tg:" + chatID
+}
+
+func (telegramAdapter) Description(direction string, msgCount int) string {
 	label := "exchange"
-	switch s.direction {
+	switch direction {
 	case repository.InteractionDirectionOutbound:
 		label = "outreach"
 	case repository.InteractionDirectionInbound:
 		label = "response"
 	}
-	return fmt.Sprintf("Telegram %s (%d messages)", label, len(s.messages))
+	return fmt.Sprintf("Telegram %s (%d messages)", label, msgCount)
 }
 
-// AggregateAll processes all contacts with unprocessed messages (batch mode).
-// Used after backfill. Pre-resolves outbound+inbound into mutual before calling RecordInteraction.
-func (e *AggregationEngine) AggregateAll(ctx context.Context) error {
-	contactIDs, err := e.messageRepo.ListUnprocessedContactIDs(ctx)
+// telegramMessageStoreAdapter wraps *repository.TelegramMessageRepository
+// and exposes the source-neutral aggregation.MessageStore surface.
+// Maps repository.TelegramMessage rows into aggregation.Message rows
+// row-by-row.
+type telegramMessageStoreAdapter struct {
+	repo *repository.TelegramMessageRepository
+}
+
+func (a *telegramMessageStoreAdapter) ListUnprocessedContactIDs(ctx context.Context) ([]uuid.UUID, error) {
+	return a.repo.ListUnprocessedContactIDs(ctx)
+}
+
+func (a *telegramMessageStoreAdapter) ListUnprocessedByContact(ctx context.Context, contactID uuid.UUID) ([]aggregation.Message, error) {
+	rows, err := a.repo.ListUnprocessedByContact(ctx, contactID)
 	if err != nil {
-		return fmt.Errorf("list unprocessed contact IDs: %w", err)
+		return nil, err
 	}
-
-	if len(contactIDs) == 0 {
-		return nil
+	out := make([]aggregation.Message, len(rows))
+	for i := range rows {
+		out[i] = mapTelegramMessage(rows[i])
 	}
-
-	interactionsCreated := 0
-	for _, contactID := range contactIDs {
-		n, err := e.aggregateBatch(ctx, contactID)
-		if err != nil {
-			log.Warn().Err(err).Str("contact_id", contactID.String()).Msg("telegram: batch aggregation failed for contact")
-			continue
-		}
-		interactionsCreated += n
-	}
-
-	log.Info().Int("contacts", len(contactIDs)).Int("interactions", interactionsCreated).Msg("telegram: batch aggregation complete")
-	return nil
+	return out, nil
 }
 
-// AggregateForContactBatch processes all unprocessed messages for a single contact in batch mode.
-// Used after import/link to aggregate newly-matched messages without scanning all contacts.
-func (e *AggregationEngine) AggregateForContactBatch(ctx context.Context, contactID uuid.UUID) error {
-	_, err := e.aggregateBatch(ctx, contactID)
-	return err
-}
-
-// aggregateBatch processes all unprocessed messages for a contact in batch mode.
-func (e *AggregationEngine) aggregateBatch(ctx context.Context, contactID uuid.UUID) (int, error) {
-	msgs, err := e.messageRepo.ListUnprocessedByContact(ctx, contactID)
+func (a *telegramMessageStoreAdapter) ListUnprocessedByContactAndChat(ctx context.Context, contactID uuid.UUID, chatID string) ([]aggregation.Message, error) {
+	parsedChat, err := strconv.ParseInt(chatID, 10, 64)
 	if err != nil {
-		return 0, fmt.Errorf("list unprocessed messages: %w", err)
+		// Telegram chat IDs are int64 in storage; a non-parseable string
+		// here would mean a caller passed a non-numeric chat ID. Log and
+		// return empty (no unprocessed messages) — equivalent to "no
+		// rows" rather than crashing.
+		log.Warn().Err(err).Str("chat_id", chatID).Msg("telegram: aggregation chat_id is not int64-parseable; returning no rows")
+		return nil, nil
 	}
-	if len(msgs) == 0 {
-		return 0, nil
-	}
-
-	// Partition by chat
-	chatMsgs := partitionByChat(msgs)
-	interactionsCreated := 0
-
-	for chatID, chatMessages := range chatMsgs {
-		// Group into bursts
-		bursts := e.groupIntoBursts(chatMessages, chatID)
-
-		// Resolve bursts into sessions (merge outbound+inbound into mutual where applicable)
-		sessions := e.resolveSessions(bursts)
-
-		// Create interactions for each session
-		for _, sess := range sessions {
-			if err := e.createInteractionForSession(ctx, contactID, sess); err != nil {
-				log.Warn().Err(err).Int64("chat_id", chatID).Msg("telegram: failed to create interaction for session")
-				continue
-			}
-			interactionsCreated++
-		}
-	}
-
-	return interactionsCreated, nil
-}
-
-// AggregateForContact processes unprocessed messages for a specific contact+chat (incremental mode).
-func (e *AggregationEngine) AggregateForContact(ctx context.Context, contactID uuid.UUID, chatID int64) error {
-	msgs, err := e.messageRepo.ListUnprocessedByContactAndChat(ctx, contactID, chatID)
+	rows, err := a.repo.ListUnprocessedByContactAndChat(ctx, contactID, parsedChat)
 	if err != nil {
-		return fmt.Errorf("list unprocessed messages: %w", err)
+		return nil, err
 	}
-	if len(msgs) == 0 {
-		return nil
+	out := make([]aggregation.Message, len(rows))
+	for i := range rows {
+		out[i] = mapTelegramMessage(rows[i])
 	}
-
-	// Group into bursts
-	bursts := e.groupIntoBursts(msgs, chatID)
-
-	// Resolve into sessions (same logic as batch)
-	sessions := e.resolveSessions(bursts)
-
-	sourceRefPrefix := fmt.Sprintf("tg:%d:%%", chatID)
-	now := msgs[len(msgs)-1].SentAt // use latest message time as upper bound
-
-	for _, sess := range sessions {
-		// Check explicit reply bridging first
-		if sess.direction == repository.InteractionDirectionInbound || sess.direction == repository.InteractionDirectionMutual {
-			if bridged := e.tryExplicitReplyBridge(ctx, contactID, sess); bridged {
-				continue
-			}
-		}
-
-		// Check time-based reply bridging for inbound sessions
-		if sess.direction == repository.InteractionDirectionInbound {
-			windowStart := sess.messages[0].SentAt.Add(-time.Duration(e.replyBridgeHours) * time.Hour)
-			existing, err := e.interactionRepo.FindRecentOutboundTelegramInteraction(
-				ctx, contactID, sourceRefPrefix, windowStart, sess.messages[0].SentAt,
-			)
-			if err == nil {
-				// Promote outbound → mutual
-				if err := e.promoter.PromoteInteractionToMutual(ctx, existing.ID, contactID, sess.lastSentAt()); err != nil {
-					log.Warn().Err(err).Msg("telegram: failed to promote interaction to mutual")
-				} else {
-					if err := e.messageRepo.MarkMessagesProcessed(ctx, sess.messageIDs(), existing.ID); err != nil {
-						log.Warn().Err(err).Msg("telegram: failed to mark messages processed after promotion")
-					}
-					continue
-				}
-			}
-		}
-
-		// Check same-direction coalescing (burst window)
-		// For mutual sessions: check if there's an outbound interaction to promote
-		// rather than extend, since ExtendInteraction doesn't update direction.
-		if sess.direction == repository.InteractionDirectionMutual {
-			windowStart := sess.messages[0].SentAt.Add(-time.Duration(e.burstWindowHours) * time.Hour)
-			existing, err := e.interactionRepo.FindRecentTelegramInteraction(
-				ctx, contactID, repository.InteractionDirectionOutbound, sourceRefPrefix, windowStart, now,
-			)
-			if err == nil {
-				// Promote outbound → mutual (updates direction + contact fields)
-				if err := e.promoter.PromoteInteractionToMutual(ctx, existing.ID, contactID, sess.lastSentAt()); err != nil {
-					log.Warn().Err(err).Msg("telegram: failed to promote interaction to mutual during coalescing")
-				} else {
-					if err := e.messageRepo.MarkMessagesProcessed(ctx, sess.messageIDs(), existing.ID); err != nil {
-						log.Warn().Err(err).Msg("telegram: failed to mark messages processed after promotion")
-					}
-					continue
-				}
-			}
-			// No outbound to promote — fall through to create new mutual interaction
-		} else {
-			// Same-direction coalescing: extend the existing interaction
-			windowStart := sess.messages[0].SentAt.Add(-time.Duration(e.burstWindowHours) * time.Hour)
-			existing, err := e.interactionRepo.FindRecentTelegramInteraction(
-				ctx, contactID, sess.direction, sourceRefPrefix, windowStart, now,
-			)
-			if err == nil {
-				desc := sess.description()
-				if err := e.extender.ExtendInteraction(ctx, existing.ID, contactID, sess.direction, sess.lastSentAt(), &desc); err != nil {
-					log.Warn().Err(err).Msg("telegram: failed to extend interaction")
-				} else {
-					if err := e.messageRepo.MarkMessagesProcessed(ctx, sess.messageIDs(), existing.ID); err != nil {
-						log.Warn().Err(err).Msg("telegram: failed to mark messages processed after extension")
-					}
-					continue
-				}
-			}
-		}
-
-		// Create new interaction
-		if err := e.createInteractionForSession(ctx, contactID, sess); err != nil {
-			log.Warn().Err(err).Int64("chat_id", chatID).Msg("telegram: failed to create interaction for session")
-		}
-	}
-
-	return nil
+	return out, nil
 }
 
-// tryExplicitReplyBridge checks if any inbound message has reply_to_msg_id pointing
-// to an outgoing message with an interaction_id. Bridges regardless of time gap.
-func (e *AggregationEngine) tryExplicitReplyBridge(ctx context.Context, contactID uuid.UUID, sess msgSession) bool {
-	for _, msg := range sess.messages {
-		if msg.ReplyToMsgID == nil {
-			continue
-		}
-		// Resolve the referenced message
-		referenced, err := e.messageRepo.GetMessage(ctx, sess.chatID, *msg.ReplyToMsgID)
-		if err != nil {
-			continue // message not found or error
-		}
-		// Check if it's outgoing and has an interaction_id
-		if !referenced.IsOutgoing || referenced.InteractionID == nil {
-			continue
-		}
-		// Verify the interaction is outbound telegram
-		existing, err := e.interactionRepo.GetInteraction(ctx, *referenced.InteractionID)
-		if err != nil || existing.Source != repository.InteractionSourceTelegram || existing.Direction != repository.InteractionDirectionOutbound {
-			continue
-		}
-		// Promote to mutual
-		if err := e.promoter.PromoteInteractionToMutual(ctx, existing.ID, contactID, sess.lastSentAt()); err != nil {
-			log.Warn().Err(err).Msg("telegram: failed to promote interaction via explicit reply")
-			continue
-		}
-		if err := e.messageRepo.MarkMessagesProcessed(ctx, sess.messageIDs(), existing.ID); err != nil {
-			log.Warn().Err(err).Msg("telegram: failed to mark messages processed after explicit reply bridge")
-		}
-		return true
+func (a *telegramMessageStoreAdapter) GetMessageByReplyTarget(ctx context.Context, chatID, replyTargetID string) (aggregation.Message, bool, error) {
+	parsedChat, err := strconv.ParseInt(chatID, 10, 64)
+	if err != nil {
+		log.Warn().Err(err).Str("chat_id", chatID).Msg("telegram: reply-target chat_id is not int64-parseable; treating as not-found")
+		return aggregation.Message{}, false, nil
 	}
-	return false
+	parsedMsg, err := strconv.Atoi(replyTargetID)
+	if err != nil {
+		log.Warn().Err(err).Str("reply_target_id", replyTargetID).Msg("telegram: reply-target msg_id is not int32-parseable; treating as not-found")
+		return aggregation.Message{}, false, nil
+	}
+	row, err := a.repo.GetMessage(ctx, parsedChat, int32(parsedMsg))
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return aggregation.Message{}, false, nil
+		}
+		return aggregation.Message{}, false, err
+	}
+	return mapTelegramMessage(*row), true, nil
 }
 
-// createInteractionForSession publishes a message.received / message.sent
-// event for a session. In cutover (post-PR-6) the async
-// InteractionRecorder consumer handles the write inside a single tx that
-// also marks the telegram_message rows processed (plan Decisions 7 + 10).
-//
-// Returns an error when eventBus is nil — mode=off/shadow is effectively
-// broken post-cutover (spec §3.9; the direct path has been removed).
-func (e *AggregationEngine) createInteractionForSession(ctx context.Context, contactID uuid.UUID, sess msgSession) error {
-	if e.eventBus == nil {
-		return fmt.Errorf("telegram: cutover wiring requires eventBus; publisher refusing to drop interaction (mode=off/shadow is post-cutover broken per spec §3.9)")
-	}
-	sourceRef := sess.sourceRef()
-	desc := sess.description()
-	if pubErr := e.publishForSession(ctx, contactID, sess, sourceRef, &desc); pubErr != nil {
-		return fmt.Errorf("publish telegram interaction event: %w", pubErr)
-	}
-	// Note: MarkMessagesProcessed is NOT called here. The consumer's
-	// InteractionRecorder.HandleEvent marks the messages processed inside
-	// the same tx as the interaction insert — gives us atomicity between
-	// the interaction row and the telegram_message.interaction_id FK
-	// (plan Decision 10).
-	return nil
+func (a *telegramMessageStoreAdapter) MarkProcessed(ctx context.Context, messageIDs []uuid.UUID, interactionID uuid.UUID) error {
+	return a.repo.MarkMessagesProcessed(ctx, messageIDs, interactionID)
 }
 
-// publishForSession emits the message.received / message.sent event
-// corresponding to a freshly-created telegram interaction. Fresh-mutual
-// sessions carry Direction="mutual" in the payload so the consumer can
-// write a matching mutual row (plan Decision 6).
-//
-// Kind selection:
-//   - inbound session  → KindMessageReceived
-//   - outbound session → KindMessageSent
-//   - mutual session   → KindMessageReceived (arbitrary; the payload's
-//     Direction field carries the authoritative direction)
-//
-// SourceID = sourceRef so publisher-idempotency dedupes retries.
-func (e *AggregationEngine) publishForSession(
+// mapTelegramMessage projects a repository.TelegramMessage into the
+// source-neutral aggregation.Message. Preserving InteractionID is
+// critical for cross-batch explicit reply bridging.
+func mapTelegramMessage(m repository.TelegramMessage) aggregation.Message {
+	out := aggregation.Message{
+		ID:            m.ID,
+		ChatID:        strconv.FormatInt(m.TelegramChatID, 10),
+		IsOutgoing:    m.IsOutgoing,
+		SentAt:        m.SentAt,
+		ExternalID:    strconv.Itoa(int(m.TelegramMessageID)),
+		InteractionID: m.InteractionID,
+	}
+	if m.ReplyToMsgID != nil {
+		s := strconv.Itoa(int(*m.ReplyToMsgID))
+		out.ReplyTargetID = &s
+	}
+	return out
+}
+
+// interactionFinderAdapter wraps *repository.InteractionRepository and
+// exposes the source-neutral aggregation.InteractionFinder surface.
+// Lives in the telegram package (not the repository package) so the
+// repository type stays free of aggregation-package imports.
+type interactionFinderAdapter struct {
+	repo *repository.InteractionRepository
+}
+
+func (a *interactionFinderAdapter) FindRecentBySourceAndDirection(
 	ctx context.Context,
 	contactID uuid.UUID,
-	sess msgSession,
-	sourceRef string,
-	description *string,
-) error {
-	cid := contactID
-	messageAt := sess.lastSentAt()
-
-	var kind events.Kind
-	var payloadDirection string
-	switch sess.direction {
-	case repository.InteractionDirectionOutbound:
-		kind = events.KindMessageSent
-		payloadDirection = ""
-	case repository.InteractionDirectionInbound:
-		kind = events.KindMessageReceived
-		payloadDirection = ""
-	case repository.InteractionDirectionMutual:
-		kind = events.KindMessageReceived
-		payloadDirection = repository.InteractionDirectionMutual
-	default:
-		return fmt.Errorf("unexpected session direction %q", sess.direction)
-	}
-
-	// Build payload. Kind-specific type so events.Marshal validates the
-	// kind↔payload pairing. MessageIDs carries the telegram_message UUIDs
-	// so the consumer can mark them processed inside the interaction-insert
-	// tx (plan Decision 10).
-	msgIDs := sess.messageIDs()
-	var raw []byte
-	var marshalErr error
-	switch kind {
-	case events.KindMessageReceived:
-		msg, err := events.Marshal(kind, events.MessageReceivedPayload{
-			Version:           1,
-			ContactID:         &cid,
-			PeerRef:           fmt.Sprintf("tg:%d", sess.chatID),
-			MessageAt:         messageAt,
-			Description:       description,
-			ExternalMessageID: sourceRef,
-			Direction:         payloadDirection,
-			MessageIDs:        msgIDs,
-		})
-		raw, marshalErr = msg, err
-	case events.KindMessageSent:
-		msg, err := events.Marshal(kind, events.MessageSentPayload{
-			Version:           1,
-			ContactID:         &cid,
-			PeerRef:           fmt.Sprintf("tg:%d", sess.chatID),
-			MessageAt:         messageAt,
-			Description:       description,
-			ExternalMessageID: sourceRef,
-			Direction:         payloadDirection,
-			MessageIDs:        msgIDs,
-		})
-		raw, marshalErr = msg, err
-	}
-	if marshalErr != nil {
-		return fmt.Errorf("marshal %s: %w", kind, marshalErr)
-	}
-
-	env := &events.Envelope{
-		Source:     repository.InteractionSourceTelegram,
-		SourceID:   sourceRef,
-		Kind:       kind,
-		Payload:    raw,
-		ObservedAt: messageAt,
-	}
-	return e.eventBus.Publish(ctx, env)
+	source, direction, sourceRefPrefix string,
+	windowStart, windowEnd time.Time,
+) (*repository.Interaction, error) {
+	return a.repo.FindRecentInteractionBySourceAndDirection(ctx, contactID, source, direction, sourceRefPrefix, windowStart, windowEnd)
 }
 
-// groupIntoBursts groups consecutive same-direction messages within the burst window.
-func (e *AggregationEngine) groupIntoBursts(msgs []repository.TelegramMessage, chatID int64) []burst {
-	if len(msgs) == 0 {
-		return nil
-	}
-
-	var bursts []burst
-	current := burst{
-		direction: msgDirection(msgs[0]),
-		messages:  []repository.TelegramMessage{msgs[0]},
-		chatID:    chatID,
-	}
-
-	for i := 1; i < len(msgs); i++ {
-		dir := msgDirection(msgs[i])
-		gap := msgs[i].SentAt.Sub(msgs[i-1].SentAt)
-
-		if dir != current.direction || gap > time.Duration(e.burstWindowHours)*time.Hour {
-			bursts = append(bursts, current)
-			current = burst{
-				direction: dir,
-				messages:  []repository.TelegramMessage{msgs[i]},
-				chatID:    chatID,
-			}
-		} else {
-			current.messages = append(current.messages, msgs[i])
-		}
-	}
-	bursts = append(bursts, current)
-	return bursts
+func (a *interactionFinderAdapter) FindRecentOutboundBySource(
+	ctx context.Context,
+	contactID uuid.UUID,
+	source, sourceRefPrefix string,
+	windowStart, windowEnd time.Time,
+) (*repository.Interaction, error) {
+	return a.repo.FindRecentOutboundInteractionBySource(ctx, contactID, source, sourceRefPrefix, windowStart, windowEnd)
 }
 
-// resolveSessions merges bursts into sessions, applying reply bridging for batch mode.
-func (e *AggregationEngine) resolveSessions(bursts []burst) []msgSession {
-	if len(bursts) == 0 {
-		return nil
-	}
-
-	var sessions []msgSession
-
-	for i := 0; i < len(bursts); i++ {
-		b := bursts[i]
-
-		// Check if this inbound burst should bridge with the previous outbound session
-		if b.direction == repository.InteractionDirectionInbound && len(sessions) > 0 {
-			prev := &sessions[len(sessions)-1]
-			if prev.direction == repository.InteractionDirectionOutbound && prev.chatID == b.chatID {
-				shouldBridge := false
-
-				// Time-based bridging
-				gap := b.firstSentAt().Sub(prev.lastSentAt())
-				if gap <= time.Duration(e.replyBridgeHours)*time.Hour {
-					shouldBridge = true
-				}
-
-				// Explicit reply bridging
-				if !shouldBridge {
-					for _, msg := range b.messages {
-						if msg.ReplyToMsgID != nil {
-							for _, prevMsg := range prev.messages {
-								if prevMsg.TelegramMessageID == *msg.ReplyToMsgID {
-									shouldBridge = true
-									break
-								}
-							}
-							if shouldBridge {
-								break
-							}
-						}
-					}
-				}
-
-				if shouldBridge {
-					// Merge into mutual session
-					prev.direction = repository.InteractionDirectionMutual
-					prev.messages = append(prev.messages, b.messages...)
-					continue
-				}
-			}
-		}
-
-		sessions = append(sessions, msgSession{
-			direction: b.direction,
-			messages:  b.messages,
-			chatID:    b.chatID,
-			firstMsg:  b.firstMsgID(),
-		})
-	}
-
-	return sessions
-}
-
-// partitionByChat groups messages by telegram_chat_id.
-func partitionByChat(msgs []repository.TelegramMessage) map[int64][]repository.TelegramMessage {
-	result := make(map[int64][]repository.TelegramMessage)
-	for _, m := range msgs {
-		result[m.TelegramChatID] = append(result[m.TelegramChatID], m)
-	}
-	return result
-}
-
-func msgDirection(msg repository.TelegramMessage) string {
-	if msg.IsOutgoing {
-		return repository.InteractionDirectionOutbound
-	}
-	return repository.InteractionDirectionInbound
+func (a *interactionFinderAdapter) GetInteraction(ctx context.Context, id uuid.UUID) (*repository.Interaction, error) {
+	return a.repo.GetInteraction(ctx, id)
 }

--- a/backend/internal/telegram/aggregation.go
+++ b/backend/internal/telegram/aggregation.go
@@ -40,9 +40,9 @@ type AggregationEngine struct {
 }
 
 // NewAggregationEngine constructs the telegram facade over the shared
-// aggregator. eventBus is required in cutover (default post-PR-6).
-// Passing a nil *events.Bus makes the engine's session-create path
-// return an error — equivalent to the off/shadow modes documented in
+// aggregator. eventBus is required when cutover is enabled. Passing a
+// nil *events.Bus makes the engine's session-create path return an
+// error — equivalent to the off/shadow modes documented in
 // EventBusConfig (spec §3.9).
 //
 // CRITICAL: a nil *events.Bus is converted to the untyped-nil

--- a/backend/internal/telegram/aggregation_test.go
+++ b/backend/internal/telegram/aggregation_test.go
@@ -1,10 +1,10 @@
 package telegram
 
 import (
+	"strconv"
 	"testing"
-	"time"
 
-	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/messaging/aggregation"
 	"personal-crm/backend/internal/repository"
 
 	"github.com/google/uuid"
@@ -12,225 +12,80 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func makeMsg(id int32, chatID int64, outgoing bool, sentAt time.Time) repository.TelegramMessage {
-	return repository.TelegramMessage{
+// TestNewAggregationEngine_AcceptsNilEventBus is a defensive shim-level
+// smoke test that confirms the explicit "if bus != nil { pub = bus }"
+// nil-iface conversion is wired correctly. Without it, passing a nil
+// *events.Bus would defeat the engine's publisher==nil guard.
+//
+// The behavioural contract (createInteractionForSession returns the
+// publisher-required error when publisher is the nil interface value)
+// is locked in by TestEngine_FakeSource_NilPublisher_Errors in the
+// shared package.
+func TestNewAggregationEngine_AcceptsNilEventBus(t *testing.T) {
+	// Pure construction: no method invoked, so nil concrete repos are
+	// safe. The shim simply wraps them in adapter structs.
+	e := NewAggregationEngine(2, 48, nil, nil, nil, nil, nil)
+	require.NotNil(t, e)
+	require.NotNil(t, e.engine)
+}
+
+// TestTelegramAdapter_WireFormat locks in the Telegram-specific
+// source_ref / peer_ref / description bytes. The shared package has a
+// telegramShapedAdapter test (TestSessionKey_Stability_TelegramShape)
+// that asserts the same on a private copy; this test ensures the
+// production telegramAdapter (which is the one wired into
+// NewAggregationEngine) also produces the contract bytes.
+func TestTelegramAdapter_WireFormat(t *testing.T) {
+	a := telegramAdapter{}
+	assert.Equal(t, repository.InteractionSourceTelegram, a.SourceName())
+	assert.Equal(t, "tg:12345:50001", a.SourceRef("12345", "50001"))
+	assert.Equal(t, "tg:12345:%", a.SourceRefPrefix("12345"))
+	assert.Equal(t, "tg:12345", a.PeerRef("12345"))
+	assert.Equal(t, "Telegram outreach (3 messages)", a.Description(repository.InteractionDirectionOutbound, 3))
+	assert.Equal(t, "Telegram response (1 messages)", a.Description(repository.InteractionDirectionInbound, 1))
+	assert.Equal(t, "Telegram exchange (5 messages)", a.Description(repository.InteractionDirectionMutual, 5))
+}
+
+// TestMapTelegramMessage covers the row-mapping helper. The critical
+// invariant is that InteractionID flows through — without it, the
+// cross-batch explicit reply bridge silently fails.
+func TestMapTelegramMessage(t *testing.T) {
+	reply := int32(42)
+	interactionID := uuid.New()
+	src := repository.TelegramMessage{
 		ID:                uuid.New(),
-		TelegramMessageID: id,
-		TelegramChatID:    chatID,
-		IsOutgoing:        outgoing,
-		SentAt:            sentAt,
-	}
-}
-
-func TestGroupIntoBursts_SingleOutbound(t *testing.T) {
-	e := &AggregationEngine{burstWindowHours: 2}
-	base := accelerated.GetCurrentTime()
-	msgs := []repository.TelegramMessage{
-		makeMsg(1, 100, true, base),
-		makeMsg(2, 100, true, base.Add(10*time.Minute)),
-		makeMsg(3, 100, true, base.Add(30*time.Minute)),
+		TelegramMessageID: 9001,
+		TelegramChatID:    8675309,
+		IsOutgoing:        true,
+		ReplyToMsgID:      &reply,
+		InteractionID:     &interactionID,
 	}
 
-	bursts := e.groupIntoBursts(msgs, 100)
-	require.Len(t, bursts, 1)
-	assert.Equal(t, repository.InteractionDirectionOutbound, bursts[0].direction)
-	assert.Len(t, bursts[0].messages, 3)
-}
+	got := mapTelegramMessage(src)
+	assert.Equal(t, src.ID, got.ID)
+	assert.Equal(t, strconv.FormatInt(src.TelegramChatID, 10), got.ChatID)
+	assert.True(t, got.IsOutgoing)
+	assert.Equal(t, strconv.Itoa(int(src.TelegramMessageID)), got.ExternalID)
+	require.NotNil(t, got.ReplyTargetID)
+	assert.Equal(t, strconv.Itoa(int(reply)), *got.ReplyTargetID)
+	require.NotNil(t, got.InteractionID)
+	assert.Equal(t, interactionID, *got.InteractionID)
 
-func TestGroupIntoBursts_SingleInbound(t *testing.T) {
-	e := &AggregationEngine{burstWindowHours: 2}
-	base := accelerated.GetCurrentTime()
-	msgs := []repository.TelegramMessage{
-		makeMsg(1, 100, false, base),
-		makeMsg(2, 100, false, base.Add(5*time.Minute)),
+	// Nil reply / nil interaction.
+	src2 := repository.TelegramMessage{
+		ID:                uuid.New(),
+		TelegramMessageID: 1,
+		TelegramChatID:    2,
+		IsOutgoing:        false,
 	}
-
-	bursts := e.groupIntoBursts(msgs, 100)
-	require.Len(t, bursts, 1)
-	assert.Equal(t, repository.InteractionDirectionInbound, bursts[0].direction)
+	got2 := mapTelegramMessage(src2)
+	assert.Nil(t, got2.ReplyTargetID)
+	assert.Nil(t, got2.InteractionID)
 }
 
-func TestGroupIntoBursts_SplitByGap(t *testing.T) {
-	e := &AggregationEngine{burstWindowHours: 2}
-	base := accelerated.GetCurrentTime()
-	msgs := []repository.TelegramMessage{
-		makeMsg(1, 100, true, base),
-		makeMsg(2, 100, true, base.Add(3*time.Hour)), // >2h gap
-	}
-
-	bursts := e.groupIntoBursts(msgs, 100)
-	require.Len(t, bursts, 2)
-}
-
-func TestGroupIntoBursts_DirectionChangeSplits(t *testing.T) {
-	e := &AggregationEngine{burstWindowHours: 2}
-	base := accelerated.GetCurrentTime()
-	msgs := []repository.TelegramMessage{
-		makeMsg(1, 100, true, base),
-		makeMsg(2, 100, false, base.Add(5*time.Minute)), // direction change
-	}
-
-	bursts := e.groupIntoBursts(msgs, 100)
-	require.Len(t, bursts, 2)
-	assert.Equal(t, repository.InteractionDirectionOutbound, bursts[0].direction)
-	assert.Equal(t, repository.InteractionDirectionInbound, bursts[1].direction)
-}
-
-func TestResolveSessions_ReplyBridgeWithin48h(t *testing.T) {
-	e := &AggregationEngine{burstWindowHours: 2, replyBridgeHours: 48}
-	base := accelerated.GetCurrentTime()
-
-	bursts := []burst{
-		{
-			direction: repository.InteractionDirectionOutbound,
-			messages: []repository.TelegramMessage{
-				makeMsg(1, 100, true, base),
-				makeMsg(2, 100, true, base.Add(5*time.Minute)),
-			},
-			chatID: 100,
-		},
-		{
-			direction: repository.InteractionDirectionInbound,
-			messages: []repository.TelegramMessage{
-				makeMsg(3, 100, false, base.Add(1*time.Hour)), // within 48h
-			},
-			chatID: 100,
-		},
-	}
-
-	sessions := e.resolveSessions(bursts)
-	require.Len(t, sessions, 1)
-	assert.Equal(t, repository.InteractionDirectionMutual, sessions[0].direction)
-	assert.Len(t, sessions[0].messages, 3)
-}
-
-func TestResolveSessions_ReplyBridgeExpired(t *testing.T) {
-	e := &AggregationEngine{burstWindowHours: 2, replyBridgeHours: 48}
-	base := accelerated.GetCurrentTime()
-
-	bursts := []burst{
-		{
-			direction: repository.InteractionDirectionOutbound,
-			messages: []repository.TelegramMessage{
-				makeMsg(1, 100, true, base),
-			},
-			chatID: 100,
-		},
-		{
-			direction: repository.InteractionDirectionInbound,
-			messages: []repository.TelegramMessage{
-				makeMsg(2, 100, false, base.Add(49*time.Hour)), // >48h gap
-			},
-			chatID: 100,
-		},
-	}
-
-	sessions := e.resolveSessions(bursts)
-	require.Len(t, sessions, 2) // not bridged
-}
-
-func TestResolveSessions_ExplicitReplyBridges(t *testing.T) {
-	e := &AggregationEngine{burstWindowHours: 2, replyBridgeHours: 48}
-	base := accelerated.GetCurrentTime()
-
-	replyTo := int32(1)
-	bursts := []burst{
-		{
-			direction: repository.InteractionDirectionOutbound,
-			messages: []repository.TelegramMessage{
-				makeMsg(1, 100, true, base),
-			},
-			chatID: 100,
-		},
-		{
-			direction: repository.InteractionDirectionInbound,
-			messages: []repository.TelegramMessage{
-				{
-					ID:                uuid.New(),
-					TelegramMessageID: 2,
-					TelegramChatID:    100,
-					IsOutgoing:        false,
-					SentAt:            base.Add(72 * time.Hour), // >48h gap
-					ReplyToMsgID:      &replyTo,                 // explicit reply to msg 1
-				},
-			},
-			chatID: 100,
-		},
-	}
-
-	sessions := e.resolveSessions(bursts)
-	require.Len(t, sessions, 1) // bridged via explicit reply
-	assert.Equal(t, repository.InteractionDirectionMutual, sessions[0].direction)
-}
-
-func TestSessionKey_Stability(t *testing.T) {
-	sess := msgSession{
-		chatID:   12345,
-		firstMsg: 50001,
-	}
-	assert.Equal(t, "tg:12345:50001", sess.sourceRef())
-}
-
-func TestResolveSessions_ChatScoped(t *testing.T) {
-	e := &AggregationEngine{burstWindowHours: 2, replyBridgeHours: 48}
-	base := accelerated.GetCurrentTime()
-
-	// Messages from same contact in different chats should NOT merge
-	bursts := []burst{
-		{
-			direction: repository.InteractionDirectionOutbound,
-			messages:  []repository.TelegramMessage{makeMsg(1, 100, true, base)},
-			chatID:    100,
-		},
-		{
-			direction: repository.InteractionDirectionOutbound,
-			messages:  []repository.TelegramMessage{makeMsg(2, 200, true, base.Add(5*time.Minute))},
-			chatID:    200,
-		},
-	}
-
-	sessions := e.resolveSessions(bursts)
-	require.Len(t, sessions, 2) // separate chats = separate sessions
-}
-
-func TestResolveSessions_CrossChatNoBridge(t *testing.T) {
-	e := &AggregationEngine{burstWindowHours: 2, replyBridgeHours: 48}
-	base := accelerated.GetCurrentTime()
-
-	// Outbound in chat 100, inbound in chat 200 — should NOT bridge even within 48h
-	bursts := []burst{
-		{
-			direction: repository.InteractionDirectionOutbound,
-			messages:  []repository.TelegramMessage{makeMsg(1, 100, true, base)},
-			chatID:    100,
-		},
-		{
-			direction: repository.InteractionDirectionInbound,
-			messages:  []repository.TelegramMessage{makeMsg(2, 200, false, base.Add(1*time.Hour))},
-			chatID:    200,
-		},
-	}
-
-	sessions := e.resolveSessions(bursts)
-	require.Len(t, sessions, 2) // different chats — no bridging
-	assert.Equal(t, repository.InteractionDirectionOutbound, sessions[0].direction)
-	assert.Equal(t, repository.InteractionDirectionInbound, sessions[1].direction)
-}
-
-func TestPartitionByChat(t *testing.T) {
-	now := accelerated.GetCurrentTime()
-	msgs := []repository.TelegramMessage{
-		makeMsg(1, 100, true, now),
-		makeMsg(2, 200, true, now),
-		makeMsg(3, 100, false, now),
-	}
-
-	result := partitionByChat(msgs)
-	assert.Len(t, result[100], 2)
-	assert.Len(t, result[200], 1)
-}
-
-func TestMsgDirection(t *testing.T) {
-	assert.Equal(t, repository.InteractionDirectionOutbound, msgDirection(repository.TelegramMessage{IsOutgoing: true}))
-	assert.Equal(t, repository.InteractionDirectionInbound, msgDirection(repository.TelegramMessage{IsOutgoing: false}))
-}
+// Compile-time guard: telegramMessageStoreAdapter satisfies
+// aggregation.MessageStore and interactionFinderAdapter satisfies
+// aggregation.InteractionFinder. The test references the interface
+// types so go vet flags mismatches at build time.
+var _ aggregation.MessageStore = (*telegramMessageStoreAdapter)(nil)
+var _ aggregation.InteractionFinder = (*interactionFinderAdapter)(nil)

--- a/backend/tests/interaction_repository_source_filter_test.go
+++ b/backend/tests/interaction_repository_source_filter_test.go
@@ -1,0 +1,196 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"os"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInteractionRepository_FindRecentInteractionBySourceAndDirection_SourceFilter
+// exercises the new source-neutral interaction lookup queries against a real
+// database to prove the source parameter is honoured. PR2 does NOT widen the
+// interaction.source CHECK constraint, so the test mixes two already-allowed
+// sources (telegram + gcal) to verify the filter at the SQL level. PR3 can
+// extend coverage to the messages source once that value is added to the
+// CHECK list.
+func TestInteractionRepository_FindRecentInteractionBySourceAndDirection_SourceFilter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set")
+	}
+
+	ctx := context.Background()
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	t.Cleanup(func() { database.Close() })
+
+	contactRepo := repository.NewContactRepository(database.Queries)
+	interactionRepo := repository.NewInteractionRepository(database.Queries)
+
+	// testStripe=3 carves out a per-test subspace of chat IDs and source_ref
+	// prefixes that cannot collide with the inbound-coalesce (stripe=1) or
+	// explicit-reply-bridge (stripe=2) integration tests.
+	const testStripe = 3
+	seed := uint64((accelerated.GetCurrentTime().UnixNano() & 0x1FFFFF) << 11)
+	// nolint:gosec // test-only seed; math/rand is sufficient for ID disambiguation
+	seed |= uint64(rand.Int31n(2048))
+
+	tgChatID := int64(testStripe)<<32 | int64(seed)
+	tgRef := fmt.Sprintf("tg:%d:1", tgChatID)
+	tgPrefix := fmt.Sprintf("tg:%d:%%", tgChatID)
+
+	gcalRef := fmt.Sprintf("gcal:test-%d-%d", testStripe, seed)
+	gcalPrefix := fmt.Sprintf("gcal:test-%d-%d%%", testStripe, seed)
+	// Wider gcal cleanup pattern catches any orphaned rows from prior runs
+	// that crashed before the per-run cleanup ran.
+	gcalCleanupPrefix := fmt.Sprintf("gcal:test-%d-%%", testStripe)
+
+	t.Cleanup(func() {
+		_ = interactionRepo.HardDeleteInteractionsBySourceRefPrefix(ctx, repository.InteractionSourceTelegram, tgPrefix)
+		_ = interactionRepo.HardDeleteInteractionsBySourceRefPrefix(ctx, repository.InteractionSourceGCal, gcalCleanupPrefix)
+	})
+
+	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
+		FullName: fmt.Sprintf("source-filter-test-%d", seed),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = contactRepo.SoftDeleteContact(ctx, contact.ID) })
+
+	t0 := accelerated.GetCurrentTime().Add(-2 * time.Hour).Truncate(time.Microsecond)
+	windowStart := t0.Add(-1 * time.Hour)
+	windowEnd := t0.Add(1 * time.Hour)
+
+	// Insert one telegram inbound + one gcal inbound for the same contact
+	// in overlapping windows. The source filter must distinguish them.
+	_, err = interactionRepo.CreateInteraction(ctx, repository.CreateInteractionRequest{
+		ContactID:  contact.ID,
+		Source:     repository.InteractionSourceTelegram,
+		SourceRef:  &tgRef,
+		OccurredAt: t0,
+		Direction:  repository.InteractionDirectionInbound,
+	})
+	require.NoError(t, err)
+	_, err = interactionRepo.CreateInteraction(ctx, repository.CreateInteractionRequest{
+		ContactID:  contact.ID,
+		Source:     repository.InteractionSourceGCal,
+		SourceRef:  &gcalRef,
+		OccurredAt: t0,
+		Direction:  repository.InteractionDirectionInbound,
+	})
+	require.NoError(t, err)
+
+	t.Run("source=telegram returns telegram row", func(t *testing.T) {
+		got, err := interactionRepo.FindRecentInteractionBySourceAndDirection(
+			ctx, contact.ID,
+			repository.InteractionSourceTelegram, repository.InteractionDirectionInbound,
+			tgPrefix, windowStart, windowEnd,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, repository.InteractionSourceTelegram, got.Source)
+		require.NotNil(t, got.SourceRef)
+		assert.Equal(t, tgRef, *got.SourceRef)
+	})
+
+	t.Run("source=gcal returns gcal row", func(t *testing.T) {
+		got, err := interactionRepo.FindRecentInteractionBySourceAndDirection(
+			ctx, contact.ID,
+			repository.InteractionSourceGCal, repository.InteractionDirectionInbound,
+			gcalPrefix, windowStart, windowEnd,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, repository.InteractionSourceGCal, got.Source)
+		require.NotNil(t, got.SourceRef)
+		assert.Equal(t, gcalRef, *got.SourceRef)
+	})
+
+	t.Run("unknown source returns ErrNotFound", func(t *testing.T) {
+		_, err := interactionRepo.FindRecentInteractionBySourceAndDirection(
+			ctx, contact.ID,
+			repository.InteractionSourceTodoist, repository.InteractionDirectionOutbound,
+			fmt.Sprintf("todoist:test-%d-%%", seed),
+			windowStart, windowEnd,
+		)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, db.ErrNotFound), "expected ErrNotFound, got %v", err)
+	})
+
+	t.Run("non-matching prefix returns ErrNotFound", func(t *testing.T) {
+		// Use a tg prefix that does NOT match our inserted source_ref. Since
+		// this prefix overlaps the test's stripe but not its source_ref, no
+		// row should be returned (and no cross-test data lives in this
+		// stripe range).
+		nonMatchingPrefix := fmt.Sprintf("tg:%d:99999%%", tgChatID)
+		_, err := interactionRepo.FindRecentInteractionBySourceAndDirection(
+			ctx, contact.ID,
+			repository.InteractionSourceTelegram, repository.InteractionDirectionInbound,
+			nonMatchingPrefix, windowStart, windowEnd,
+		)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, db.ErrNotFound), "expected ErrNotFound, got %v", err)
+	})
+
+	t.Run("out-of-window returns ErrNotFound", func(t *testing.T) {
+		futureStart := t0.Add(10 * time.Hour)
+		futureEnd := t0.Add(20 * time.Hour)
+		_, err := interactionRepo.FindRecentInteractionBySourceAndDirection(
+			ctx, contact.ID,
+			repository.InteractionSourceTelegram, repository.InteractionDirectionInbound,
+			tgPrefix, futureStart, futureEnd,
+		)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, db.ErrNotFound), "expected ErrNotFound, got %v", err)
+	})
+
+	// FindRecentOutboundInteractionBySource has a hard-coded direction
+	// ('outbound') so the source filter is its only configurable axis.
+	t.Run("FindRecentOutboundInteractionBySource respects source", func(t *testing.T) {
+		// Add an outbound telegram row in the window.
+		obRef := fmt.Sprintf("tg:%d:2", tgChatID)
+		_, err := interactionRepo.CreateInteraction(ctx, repository.CreateInteractionRequest{
+			ContactID:  contact.ID,
+			Source:     repository.InteractionSourceTelegram,
+			SourceRef:  &obRef,
+			OccurredAt: t0.Add(5 * time.Minute),
+			Direction:  repository.InteractionDirectionOutbound,
+		})
+		require.NoError(t, err)
+
+		got, err := interactionRepo.FindRecentOutboundInteractionBySource(
+			ctx, contact.ID,
+			repository.InteractionSourceTelegram, tgPrefix, windowStart, windowEnd,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, repository.InteractionSourceTelegram, got.Source)
+		assert.Equal(t, repository.InteractionDirectionOutbound, got.Direction)
+
+		// Same query with source=gcal should not return the telegram row
+		// (gcal has no outbound rows here).
+		_, err = interactionRepo.FindRecentOutboundInteractionBySource(
+			ctx, contact.ID,
+			repository.InteractionSourceGCal, gcalPrefix, windowStart, windowEnd,
+		)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, db.ErrNotFound), "expected ErrNotFound, got %v", err)
+	})
+}

--- a/backend/tests/interaction_repository_source_filter_test.go
+++ b/backend/tests/interaction_repository_source_filter_test.go
@@ -19,12 +19,11 @@ import (
 )
 
 // TestInteractionRepository_FindRecentInteractionBySourceAndDirection_SourceFilter
-// exercises the new source-neutral interaction lookup queries against a real
-// database to prove the source parameter is honoured. PR2 does NOT widen the
-// interaction.source CHECK constraint, so the test mixes two already-allowed
-// sources (telegram + gcal) to verify the filter at the SQL level. PR3 can
-// extend coverage to the messages source once that value is added to the
-// CHECK list.
+// exercises the source-neutral interaction lookup queries against a real
+// database to prove the source parameter is honoured. The test mixes two
+// already-allowed sources (telegram + gcal) to verify the filter at the SQL
+// level; future migrations can widen the interaction.source CHECK list and
+// extend this coverage.
 func TestInteractionRepository_FindRecentInteractionBySourceAndDirection_SourceFilter(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")

--- a/backend/tests/telegram_aggregation_explicit_reply_bridge_test.go
+++ b/backend/tests/telegram_aggregation_explicit_reply_bridge_test.go
@@ -1,0 +1,149 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAggregation_IncrementalExplicitReplyBridge_CrossBatch exercises
+// the cross-batch tryExplicitReplyBridge path (lines 277-307 of the
+// pre-refactor aggregation.go) by setting up an outbound staging row
+// that's already been processed and linked to an existing outbound
+// interaction, then an inbound staging row whose reply_to_msg_id
+// points to that processed outbound row.
+//
+// The cross-batch path is what the shared engine's Message.InteractionID
+// plumbing exists to enable. The existing
+// TestAggregation_IncrementalExplicitReplyBridge integration test
+// covers a similar scenario via a single aggregation pass that marks
+// the outbound interaction during the same flow; this test forces a
+// >48h gap (no time-bridge possible) and verifies that the in-burst
+// explicit-reply branch in resolveSessions can NOT see the prior
+// outbound (it's not in the unprocessed batch), so the cross-batch
+// branch in tryExplicitReplyBridge is the only path that can promote
+// the interaction.
+//
+// Stripe-based IDs (testStripe=2) keep this disjoint from the
+// inbound-coalesce (=1) and source-filter (=3) tests.
+func TestAggregation_IncrementalExplicitReplyBridge_CrossBatch(t *testing.T) {
+	messageRepo, interactionRepo, contactRepo, _, engine, database := setupAggregationTest(t)
+	ctx := context.Background()
+
+	const testStripe = 2
+	seed := uint64((accelerated.GetCurrentTime().UnixNano() & 0x1FFFFF) << 11)
+	// nolint:gosec // test-only seed; math/rand is sufficient for ID disambiguation
+	seed |= uint64(rand.Int31n(2048))
+
+	chatID := int64(testStripe)<<32 | int64(seed)
+	msgIDBase := int32(testStripe*10_000_000) + int32(seed%1_000_000)
+	peerUserID := int64(testStripe*70_000_000) + int64(seed%1_000_000)
+	sourceRefPrefix := fmt.Sprintf("tg:%d:%%", chatID)
+	outboundSourceRef := fmt.Sprintf("tg:%d:%d", chatID, msgIDBase)
+
+	t.Cleanup(func() {
+		_ = messageRepo.HardDeleteByChatIDRange(ctx, chatID, chatID)
+		_ = interactionRepo.HardDeleteInteractionsBySourceRefPrefix(ctx, repository.InteractionSourceTelegram, sourceRefPrefix)
+		_, _ = database.Pool.Exec(ctx, "DELETE FROM event WHERE source = 'telegram' AND source_id LIKE $1", sourceRefPrefix)
+	})
+
+	contact := createTestContact(t, contactRepo, fmt.Sprintf("Explicit Reply Bridge %d", seed))
+	t.Cleanup(func() { _ = contactRepo.SoftDeleteContact(ctx, contact.ID) })
+
+	// 90h gap > 48h reply-bridge window — time-based bridging will NOT
+	// fire. Only the cross-batch explicit reply-bridge can promote.
+	t0 := accelerated.GetCurrentTime().Add(-100 * time.Hour).Truncate(time.Microsecond)
+	replyAt := t0.Add(90 * time.Hour)
+
+	// Step 1: create the outbound interaction directly (so we can
+	// capture its ID and link the staging row deterministically).
+	outboundIA, err := interactionRepo.CreateInteraction(ctx, repository.CreateInteractionRequest{
+		ContactID:  contact.ID,
+		Source:     repository.InteractionSourceTelegram,
+		SourceRef:  &outboundSourceRef,
+		OccurredAt: t0,
+		Direction:  repository.InteractionDirectionOutbound,
+	})
+	require.NoError(t, err)
+	outboundInteractionID := outboundIA.ID
+
+	// Step 2: insert the outbound staging row and mark it processed
+	// pointing at the outbound interaction. Now it is NOT in the
+	// unprocessed batch — only the inbound reply will appear in the
+	// next AggregateForContact call, forcing the cross-batch
+	// tryExplicitReplyBridge path.
+	outboundMsg := insertTestMessage(t, messageRepo, msgIDBase, chatID, true /*outgoing*/, t0, &contact.ID, peerUserID)
+	require.NoError(t, messageRepo.MarkMessagesProcessed(ctx, []uuid.UUID{outboundMsg.ID}, outboundInteractionID))
+
+	// Step 3: insert the inbound staging row with reply_to_msg_id
+	// pointing to the outbound's TelegramMessageID. >48h after the
+	// outbound.
+	replyToID := msgIDBase
+	text := "explicit reply"
+	_, err = messageRepo.UpsertMessage(ctx, repository.UpsertTelegramMessageParams{
+		TelegramMessageID: msgIDBase + 1,
+		TelegramChatID:    chatID,
+		ChatType:          "private",
+		MessageText:       &text,
+		MessageType:       "text",
+		SentAt:            replyAt,
+		IsOutgoing:        false,
+		PeerUserID:        ptrInt64(peerUserID),
+		ReplyToMsgID:      &replyToID,
+	})
+	require.NoError(t, err)
+	require.NoError(t, messageRepo.UpdateMessageContact(ctx, peerUserID, contact.ID))
+
+	preCount, err := interactionRepo.CountContactInteractions(ctx, contact.ID)
+	require.NoError(t, err)
+
+	// Step 4: aggregate. The outbound staging row is processed and
+	// invisible to the unprocessed list. The inbound row, alone in the
+	// batch, forms an inbound session whose ReplyTargetID matches the
+	// processed outbound's ExternalID via the shared engine's
+	// tryExplicitReplyBridge path — which reads Message.InteractionID
+	// off the referenced row to find the existing outbound interaction
+	// and promote it.
+	require.NoError(t, engine.AggregateForContact(ctx, contact.ID, chatID))
+
+	// Assert: still exactly preCount interactions, the outbound
+	// promoted to mutual, occurred_at at replyAt.
+	postCount, err := interactionRepo.CountContactInteractions(ctx, contact.ID)
+	require.NoError(t, err)
+	assert.Equal(t, preCount, postCount, "explicit reply bridge must promote, not create")
+
+	promoted, err := interactionRepo.GetInteraction(ctx, outboundInteractionID)
+	require.NoError(t, err)
+	assert.Equal(t, repository.InteractionDirectionMutual, promoted.Direction,
+		"explicit reply bridge must promote outbound → mutual")
+	assert.Equal(t, replyAt.UTC(), promoted.OccurredAt.UTC(),
+		"explicit reply bridge must advance occurred_at to the reply timestamp")
+
+	// The inbound staging row should be processed and linked to the
+	// promoted interaction.
+	inboundRow, err := messageRepo.GetMessage(ctx, chatID, msgIDBase+1)
+	require.NoError(t, err)
+	require.NotNil(t, inboundRow.ProcessedAt, "explicit reply bridge must mark inbound processed")
+	require.NotNil(t, inboundRow.InteractionID, "explicit reply bridge must link inbound to outbound interaction")
+	assert.Equal(t, outboundInteractionID, *inboundRow.InteractionID)
+
+	// And no message.received event was published for the inbound's
+	// would-be source_ref (the promote path consumes the message
+	// rather than going through the publisher).
+	eventRepo := repository.NewEventRepository(database.Queries)
+	wouldBeRef := fmt.Sprintf("tg:%d:%d", chatID, msgIDBase+1)
+	_, err = eventRepo.FindEventBySource(ctx, repository.InteractionSourceTelegram, wouldBeRef)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, db.ErrNotFound), "expected ErrNotFound for the would-be inbound event, got %v", err)
+}

--- a/backend/tests/telegram_aggregation_explicit_reply_bridge_test.go
+++ b/backend/tests/telegram_aggregation_explicit_reply_bridge_test.go
@@ -40,6 +40,7 @@ import (
 func TestAggregation_IncrementalExplicitReplyBridge_CrossBatch(t *testing.T) {
 	messageRepo, interactionRepo, contactRepo, _, engine, database := setupAggregationTest(t)
 	ctx := context.Background()
+	eventRepo := repository.NewEventRepository(database.Queries)
 
 	const testStripe = 2
 	seed := uint64((accelerated.GetCurrentTime().UnixNano() & 0x1FFFFF) << 11)
@@ -55,7 +56,10 @@ func TestAggregation_IncrementalExplicitReplyBridge_CrossBatch(t *testing.T) {
 	t.Cleanup(func() {
 		_ = messageRepo.HardDeleteByChatIDRange(ctx, chatID, chatID)
 		_ = interactionRepo.HardDeleteInteractionsBySourceRefPrefix(ctx, repository.InteractionSourceTelegram, sourceRefPrefix)
-		_, _ = database.Pool.Exec(ctx, "DELETE FROM event WHERE source = 'telegram' AND source_id LIKE $1", sourceRefPrefix)
+		// Event rows are dedup-keyed on (source, source_id); purge
+		// per-run envelopes via the test-only sqlc-backed wrapper so a
+		// re-run does not collide on the partial unique.
+		_ = eventRepo.HardDeleteEventsBySourceAndSourceIDPrefix(ctx, repository.InteractionSourceTelegram, sourceRefPrefix)
 	})
 
 	contact := createTestContact(t, contactRepo, fmt.Sprintf("Explicit Reply Bridge %d", seed))
@@ -66,8 +70,8 @@ func TestAggregation_IncrementalExplicitReplyBridge_CrossBatch(t *testing.T) {
 	t0 := accelerated.GetCurrentTime().Add(-100 * time.Hour).Truncate(time.Microsecond)
 	replyAt := t0.Add(90 * time.Hour)
 
-	// Step 1: create the outbound interaction directly (so we can
-	// capture its ID and link the staging row deterministically).
+	// Create the outbound interaction directly (so we can capture its
+	// ID and link the staging row deterministically).
 	outboundIA, err := interactionRepo.CreateInteraction(ctx, repository.CreateInteractionRequest{
 		ContactID:  contact.ID,
 		Source:     repository.InteractionSourceTelegram,
@@ -78,17 +82,16 @@ func TestAggregation_IncrementalExplicitReplyBridge_CrossBatch(t *testing.T) {
 	require.NoError(t, err)
 	outboundInteractionID := outboundIA.ID
 
-	// Step 2: insert the outbound staging row and mark it processed
-	// pointing at the outbound interaction. Now it is NOT in the
-	// unprocessed batch — only the inbound reply will appear in the
-	// next AggregateForContact call, forcing the cross-batch
+	// Insert the outbound staging row and mark it processed pointing
+	// at the outbound interaction. Now it is NOT in the unprocessed
+	// batch — only the inbound reply will appear in the next
+	// AggregateForContact call, forcing the cross-batch
 	// tryExplicitReplyBridge path.
 	outboundMsg := insertTestMessage(t, messageRepo, msgIDBase, chatID, true /*outgoing*/, t0, &contact.ID, peerUserID)
 	require.NoError(t, messageRepo.MarkMessagesProcessed(ctx, []uuid.UUID{outboundMsg.ID}, outboundInteractionID))
 
-	// Step 3: insert the inbound staging row with reply_to_msg_id
-	// pointing to the outbound's TelegramMessageID. >48h after the
-	// outbound.
+	// Insert the inbound staging row with reply_to_msg_id pointing to
+	// the outbound's TelegramMessageID, >48h after the outbound.
 	replyToID := msgIDBase
 	text := "explicit reply"
 	_, err = messageRepo.UpsertMessage(ctx, repository.UpsertTelegramMessageParams{
@@ -108,9 +111,9 @@ func TestAggregation_IncrementalExplicitReplyBridge_CrossBatch(t *testing.T) {
 	preCount, err := interactionRepo.CountContactInteractions(ctx, contact.ID)
 	require.NoError(t, err)
 
-	// Step 4: aggregate. The outbound staging row is processed and
-	// invisible to the unprocessed list. The inbound row, alone in the
-	// batch, forms an inbound session whose ReplyTargetID matches the
+	// Aggregate. The outbound staging row is processed and invisible
+	// to the unprocessed list. The inbound row, alone in the batch,
+	// forms an inbound session whose ReplyTargetID matches the
 	// processed outbound's ExternalID via the shared engine's
 	// tryExplicitReplyBridge path — which reads Message.InteractionID
 	// off the referenced row to find the existing outbound interaction
@@ -141,7 +144,6 @@ func TestAggregation_IncrementalExplicitReplyBridge_CrossBatch(t *testing.T) {
 	// And no message.received event was published for the inbound's
 	// would-be source_ref (the promote path consumes the message
 	// rather than going through the publisher).
-	eventRepo := repository.NewEventRepository(database.Queries)
 	wouldBeRef := fmt.Sprintf("tg:%d:%d", chatID, msgIDBase+1)
 	_, err = eventRepo.FindEventBySource(ctx, repository.InteractionSourceTelegram, wouldBeRef)
 	require.Error(t, err)

--- a/backend/tests/telegram_aggregation_inbound_coalesce_test.go
+++ b/backend/tests/telegram_aggregation_inbound_coalesce_test.go
@@ -1,0 +1,125 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAggregation_IncrementalInboundCoalesce covers the
+// same-direction inbound-extend branch of AggregateForContact (the old
+// aggregation.go lines 247-263). The existing
+// TestAggregation_IncrementalCoalescing covers outbound-extend; this
+// test fills the inbound-extend gap so "semantics preserved verbatim"
+// holds for both directions of same-direction coalescing.
+//
+// Stripe-based IDs (testStripe=1) keep chat IDs disjoint from the
+// other two new integration tests (explicit-reply-bridge=2, source-
+// filter=3) and from the existing aggregation tests (chat IDs 100-303).
+// Cleanup uses the new sqlc-backed HardDelete helpers per core.md rule
+// 2 (no raw SQL in Go).
+func TestAggregation_IncrementalInboundCoalesce(t *testing.T) {
+	messageRepo, interactionRepo, contactRepo, _, engine, database := setupAggregationTest(t)
+	ctx := context.Background()
+
+	const testStripe = 1
+	seed := uint64((accelerated.GetCurrentTime().UnixNano() & 0x1FFFFF) << 11)
+	// nolint:gosec // test-only seed; math/rand is sufficient for ID disambiguation
+	seed |= uint64(rand.Int31n(2048))
+
+	chatID := int64(testStripe)<<32 | int64(seed)
+	msgIDBase := int32(testStripe*10_000_000) + int32(seed%1_000_000)
+	peerUserID := int64(testStripe*70_000_000) + int64(seed%1_000_000)
+	sourceRefPrefix := fmt.Sprintf("tg:%d:%%", chatID)
+	baselineSourceRef := fmt.Sprintf("tg:%d:%d", chatID, msgIDBase)
+
+	t.Cleanup(func() {
+		_ = messageRepo.HardDeleteByChatIDRange(ctx, chatID, chatID)
+		_ = interactionRepo.HardDeleteInteractionsBySourceRefPrefix(ctx, repository.InteractionSourceTelegram, sourceRefPrefix)
+		// Event rows are dedup-keyed on (source, source_id). Clean any
+		// envelopes the create-path may have emitted under this test's
+		// source_ref prefix so a re-run does not collide.
+		_, _ = database.Pool.Exec(ctx, "DELETE FROM event WHERE source = 'telegram' AND source_id LIKE $1", sourceRefPrefix)
+	})
+
+	contact := createTestContact(t, contactRepo, fmt.Sprintf("Inbound Coalesce %d", seed))
+	t.Cleanup(func() { _ = contactRepo.SoftDeleteContact(ctx, contact.ID) })
+
+	t0 := accelerated.GetCurrentTime().Add(-2 * time.Hour).Truncate(time.Microsecond)
+
+	// Step 1: seed a baseline inbound interaction directly. Use the
+	// repository's CreateInteraction so we can capture the ID for
+	// assertions, and so we don't rely on the publisher path here.
+	baseline, err := interactionRepo.CreateInteraction(ctx, repository.CreateInteractionRequest{
+		ContactID:  contact.ID,
+		Source:     repository.InteractionSourceTelegram,
+		SourceRef:  &baselineSourceRef,
+		OccurredAt: t0,
+		Direction:  repository.InteractionDirectionInbound,
+	})
+	require.NoError(t, err)
+	baselineID := baseline.ID
+
+	preCount, err := interactionRepo.CountContactInteractions(ctx, contact.ID)
+	require.NoError(t, err)
+
+	// Step 2: insert an unprocessed inbound staging row in the same
+	// chat, inside the burst window (30 min later).
+	extendTime := t0.Add(30 * time.Minute)
+	insertTestMessage(t, messageRepo, msgIDBase+1, chatID, false /*outgoing*/, extendTime, &contact.ID, peerUserID)
+
+	// Step 3: aggregate — the engine should hit the inbound-extend
+	// branch and call ExtendInteraction on the baseline.
+	err = engine.AggregateForContact(ctx, contact.ID, chatID)
+	require.NoError(t, err)
+
+	// Assert: still exactly preCount interactions (no new row created),
+	// baseline's occurred_at advanced to extendTime, description
+	// reflects the inbound extend.
+	postCount, err := interactionRepo.CountContactInteractions(ctx, contact.ID)
+	require.NoError(t, err)
+	assert.Equal(t, preCount, postCount, "inbound extend must not create a new interaction")
+
+	got, err := interactionRepo.GetInteraction(ctx, baselineID)
+	require.NoError(t, err)
+	assert.Equal(t, repository.InteractionDirectionInbound, got.Direction,
+		"inbound extend must not change direction")
+	assert.Equal(t, extendTime.UTC(), got.OccurredAt.UTC(),
+		"inbound extend must advance occurred_at to the extend timestamp")
+	require.NotNil(t, got.Description)
+	assert.Equal(t, "Telegram response (1 messages)", *got.Description,
+		"description must follow the preserved Telegram format")
+
+	// Step 4: the staging row should now be processed and linked to
+	// the baseline interaction.
+	unprocessed, err := messageRepo.ListUnprocessedByContact(ctx, contact.ID)
+	require.NoError(t, err)
+	assert.Empty(t, unprocessed, "extend path must mark staging rows processed")
+
+	stagedRow, err := messageRepo.GetMessage(ctx, chatID, msgIDBase+1)
+	require.NoError(t, err)
+	require.NotNil(t, stagedRow.ProcessedAt, "extend path must set processed_at")
+	require.NotNil(t, stagedRow.InteractionID, "extend path must set interaction_id")
+	assert.Equal(t, baselineID, *stagedRow.InteractionID,
+		"extend path must link the staging row to the baseline interaction")
+
+	// Step 5: the extend path must NOT publish a message.received event
+	// for the extending message's source_ref (would-be source_ref is
+	// based on msgIDBase+1). Use FindEventBySource for a targeted query
+	// — avoids cross-query counts on the shared DB.
+	eventRepo := repository.NewEventRepository(database.Queries)
+	wouldBeRef := fmt.Sprintf("tg:%d:%d", chatID, msgIDBase+1)
+	_, err = eventRepo.FindEventBySource(ctx, repository.InteractionSourceTelegram, wouldBeRef)
+	require.Error(t, err, "extend path must not publish a create event for the inbound extension")
+	assert.True(t, errors.Is(err, db.ErrNotFound), "expected ErrNotFound for the missing extend event, got %v", err)
+}

--- a/backend/tests/telegram_aggregation_inbound_coalesce_test.go
+++ b/backend/tests/telegram_aggregation_inbound_coalesce_test.go
@@ -31,6 +31,7 @@ import (
 func TestAggregation_IncrementalInboundCoalesce(t *testing.T) {
 	messageRepo, interactionRepo, contactRepo, _, engine, database := setupAggregationTest(t)
 	ctx := context.Background()
+	eventRepo := repository.NewEventRepository(database.Queries)
 
 	const testStripe = 1
 	seed := uint64((accelerated.GetCurrentTime().UnixNano() & 0x1FFFFF) << 11)
@@ -48,8 +49,10 @@ func TestAggregation_IncrementalInboundCoalesce(t *testing.T) {
 		_ = interactionRepo.HardDeleteInteractionsBySourceRefPrefix(ctx, repository.InteractionSourceTelegram, sourceRefPrefix)
 		// Event rows are dedup-keyed on (source, source_id). Clean any
 		// envelopes the create-path may have emitted under this test's
-		// source_ref prefix so a re-run does not collide.
-		_, _ = database.Pool.Exec(ctx, "DELETE FROM event WHERE source = 'telegram' AND source_id LIKE $1", sourceRefPrefix)
+		// source_ref prefix so a re-run does not collide on the partial
+		// unique. Uses the test-only sqlc-backed wrapper to comply with
+		// the "no raw SQL in Go" rule.
+		_ = eventRepo.HardDeleteEventsBySourceAndSourceIDPrefix(ctx, repository.InteractionSourceTelegram, sourceRefPrefix)
 	})
 
 	contact := createTestContact(t, contactRepo, fmt.Sprintf("Inbound Coalesce %d", seed))
@@ -57,7 +60,7 @@ func TestAggregation_IncrementalInboundCoalesce(t *testing.T) {
 
 	t0 := accelerated.GetCurrentTime().Add(-2 * time.Hour).Truncate(time.Microsecond)
 
-	// Step 1: seed a baseline inbound interaction directly. Use the
+	// Seed a baseline inbound interaction directly. Use the
 	// repository's CreateInteraction so we can capture the ID for
 	// assertions, and so we don't rely on the publisher path here.
 	baseline, err := interactionRepo.CreateInteraction(ctx, repository.CreateInteractionRequest{
@@ -73,13 +76,13 @@ func TestAggregation_IncrementalInboundCoalesce(t *testing.T) {
 	preCount, err := interactionRepo.CountContactInteractions(ctx, contact.ID)
 	require.NoError(t, err)
 
-	// Step 2: insert an unprocessed inbound staging row in the same
-	// chat, inside the burst window (30 min later).
+	// Insert an unprocessed inbound staging row in the same chat,
+	// inside the burst window (30 min later).
 	extendTime := t0.Add(30 * time.Minute)
 	insertTestMessage(t, messageRepo, msgIDBase+1, chatID, false /*outgoing*/, extendTime, &contact.ID, peerUserID)
 
-	// Step 3: aggregate — the engine should hit the inbound-extend
-	// branch and call ExtendInteraction on the baseline.
+	// Aggregate — the engine should hit the inbound-extend branch and
+	// call ExtendInteraction on the baseline.
 	err = engine.AggregateForContact(ctx, contact.ID, chatID)
 	require.NoError(t, err)
 
@@ -100,8 +103,8 @@ func TestAggregation_IncrementalInboundCoalesce(t *testing.T) {
 	assert.Equal(t, "Telegram response (1 messages)", *got.Description,
 		"description must follow the preserved Telegram format")
 
-	// Step 4: the staging row should now be processed and linked to
-	// the baseline interaction.
+	// The staging row should now be processed and linked to the
+	// baseline interaction.
 	unprocessed, err := messageRepo.ListUnprocessedByContact(ctx, contact.ID)
 	require.NoError(t, err)
 	assert.Empty(t, unprocessed, "extend path must mark staging rows processed")
@@ -113,11 +116,10 @@ func TestAggregation_IncrementalInboundCoalesce(t *testing.T) {
 	assert.Equal(t, baselineID, *stagedRow.InteractionID,
 		"extend path must link the staging row to the baseline interaction")
 
-	// Step 5: the extend path must NOT publish a message.received event
-	// for the extending message's source_ref (would-be source_ref is
-	// based on msgIDBase+1). Use FindEventBySource for a targeted query
-	// — avoids cross-query counts on the shared DB.
-	eventRepo := repository.NewEventRepository(database.Queries)
+	// The extend path must NOT publish a message.received event for
+	// the extending message's source_ref (would-be source_ref is based
+	// on msgIDBase+1). Use FindEventBySource for a targeted query —
+	// avoids cross-query counts on the shared DB.
 	wouldBeRef := fmt.Sprintf("tg:%d:%d", chatID, msgIDBase+1)
 	_, err = eventRepo.FindEventBySource(ctx, repository.InteractionSourceTelegram, wouldBeRef)
 	require.Error(t, err, "extend path must not publish a create event for the inbound extension")


### PR DESCRIPTION
PR2 of the Mac daemon Phase 1 sequence (#73). **Pure refactor — semantics preserved verbatim.** Extracts the Telegram burst aggregator into a shared, source-parametric package so PR3+ can add a Messages adapter without re-touching aggregator core logic.

Predecessor: #301 (PR1 — Pi-side host foundation).

## Summary

- Adds `backend/internal/messaging/aggregation` with `Engine`, `Message`, and source-neutral interfaces (`SourceAdapter`, `MessageStore`, `InteractionFinder`, `InteractionPromoter`, `InteractionExtender`, `EventPublisher`).
- Lifts `groupIntoBursts`, `resolveSessions`, `tryExplicitReplyBridge`, `createInteractionForSession`, `publishForSession`, and `partitionByChat` out of `telegram/aggregation.go` and re-types them against the shared `Message` struct.
- Adds source-neutral sqlc queries `FindRecentInteractionBySourceAndDirection` and `FindRecentOutboundInteractionBySource` on `interaction`, plus test-only `HardDeleteInteractionsBySourceRefPrefix`, `HardDeleteTelegramMessagesByChatIDRange`, and `HardDeleteEventsBySourceAndSourceIDPrefix` cleanup helpers (sqlc-backed — no raw SQL in Go).
- Slims `telegram/aggregation.go` from ~524 LOC to a thin shim. `TelegramAdapter`, `telegramMessageStoreAdapter`, and `interactionFinderAdapter` reproduce the existing wire formats (`tg:<chatID>:<extID>`, `Telegram <label> (<n> messages)`) byte-for-byte. Exported signatures on `*telegram.AggregationEngine` are preserved so `manager.go`, `handlers.go`, `rematch.go`, `cmd/crm-api`, and integration tests compile without edits.
- `NewAggregationEngine` explicitly converts a possibly-nil `*events.Bus` to the `EventPublisher` interface via the `var pub … ; if bus != nil { pub = bus }` idiom to avoid the typed-nil-interface gotcha that would silently bypass the engine's publisher-required guard.
- Documents the `MessageStore` `SentAt ASC` ordering contract and adds a defensive in-place sort in the engine before burst derivation.
- Adds three new integration tests filling coverage gaps: inbound-extend coalesce, cross-batch explicit reply bridge with >48h gap, and the source-filter parameter on the new lookup queries. Stripe-based per-test ID subspaces keep IDs disjoint across reruns and across the new tests.
- Updates `.ai/patterns/sync.md` with a section describing the shared aggregator and the per-source adapter contract.

## Test plan

- [x] `make lint` (Go + frontend) — 0 issues
- [x] `make test-unit` — all green
- [x] `make e2e-db && make test-integration-fast` — all green
- [x] `make test-e2e-diff` — 58/58 green
- [x] Pre-push hooks (lint + tests + e2e) — all green
- [x] Codex local review — 3 rounds, RESULT=PASS on round 3

## Codex review history

- **Round 1 (FAIL, 5 findings):** identifiable hostname in spec example, raw SQL event cleanup in two test files, missing `MessageStore` ordering contract, "Step N" comments in new tests, missing patterns doc update.
- **Round 2 (FAIL, 1 finding):** lingering `PR2`/`PR3` references in `interfaces.go`, the new source-filter test, and the patterns doc.
- **Round 3 (PASS):** no findings.

## Refs

- Issue: #73
- Plan: `.ai/log/plan/mac-daemon-phase-1-pr2-aggregator-extraction.md` (went through 7 codex review rounds and 17 substantive plan revisions before implementation began)
- Spec: `.ai/spec/mac-daemon.md`