### PR TITLE
feat(mac-daemon): PR4 — ingest generalization + messages push provider

### DIFF
--- a/.ai/guides/feature-development.md
+++ b/.ai/guides/feature-development.md
@@ -334,7 +334,7 @@ v1 := router.Group("/api/v1")
 | **System** | `/system/time` | GET | SystemHandler | Current time |
 | | `/export` | POST | SystemHandler | Export data |
 | | `/import` | POST | SystemHandler | Import data |
-| **Ingest** | `/ingest/events` | POST | IngestHandler | Batched event ingestion (gated by `EVENT_BUS_INGEST_ENABLED`) |
+| **Ingest** | `/ingest/events` | POST | IngestHandler | Batched event ingestion (gated by `EVENT_BUS_INGEST_ENABLED`). Composite auth: `X-Mac-Host-ID` header → host-auth path (Mac daemon raw_message.\* only); absent → global API-key path (internal Pi publishers). Service enforces per-path kind allowlist. |
 | **Mac Daemon (public)** | `/host` | POST | MacHostHandler | Daemon pairs with a token — rate-limited per source IP, no auth |
 | **Mac Daemon (host auth)** | `/host/:id/heartbeat` | POST | MacHostHandler | Periodic daemon heartbeat — `Authorization: Bearer <host-key>` + `X-Mac-Host-ID` |
 | | `/host/:id/sync/:source/cursor` | GET | MacHostHandler | Read push-cursor for (host, source) |

--- a/.ai/patterns/sync.md
+++ b/.ai/patterns/sync.md
@@ -7,6 +7,7 @@
 | Google Contacts | `gcontacts` | `contact_driven` | `backend/internal/google/contacts.go` |
 | Google Calendar | `gcal` | `contact_driven` | `backend/internal/google/calendar.go` |
 | Todoist | `todoist` | `fetch_all` | `backend/internal/todoist/provider.go` |
+| Messages | `messages` | `push` | `backend/internal/messages/provider.go` |
 
 Providers are registered in `backend/cmd/crm-api/main.go` via `providerRegistry.Register()`.
 

--- a/.ai/spec/mac-daemon.md
+++ b/.ai/spec/mac-daemon.md
@@ -112,6 +112,8 @@ The pairing token model means there's no admin/bootstrap key in widespread use �
 
 **Permissions:** Full Disk Access (chat.db; WhatsApp likely not required since sandbox container is user-readable), Contacts permission (native `requestAccess`), Files & Folders for Anarlog path. `doctor` enumerates and provides `x-apple.systempreferences:` deep links.
 
+**Testing & CI:** structure Swift modules so OS-permission-mediated code (Full Disk Access for chat.db, `CNContactStore` consent, Files & Folders) is a thin shell over pure-logic modules — chat.db parsing against a fixture SQLite file, identifier filtering, push payload serialization, pairing client logic, cursor/state management. CI runs `swift build` + `swift test` on `macos-latest`, path-filtered to `mac-daemon/**` so Pi-side PRs don't burn macOS minutes (macOS runners are ~10× Linux cost). Integration tests that require TCC permissions, real iCloud state, or live `~/Library/Messages/chat.db` access live behind a `make test-daemon-local` target run on the developer's Mac before push — not in CI. The first Swift PR (daemon skeleton) lands this CI job so all subsequent Swift PRs have signal from day one.
+
 ### 2. Data sources
 
 #### `messages` (iMessage + SMS via Messages.app)

--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ $RECYCLE.BIN/
 # Binaries
 backend/bin/
 backend/crm-api
+backend/crm-admin
 backend/main
 backend/*.exe
 backend/*.exe~

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Personal CRM Makefile
 
-.PHONY: help setup dev build test clean docker-up docker-down docker-reset test-cadence-ultra test-cadence-fast prod staging testing start start-local stop restart reload status dev-stop dev-restart dev-api-stop dev-api-start dev-api-restart ci-build-backend ci-build-frontend ci-build ci-test test-e2e test-e2e-local test-e2e-diff e2e-db deploy setup-pi dev-native postgres-native sqlc smoke-test test-integration-fast test-integration-slow test-mac-host-migrations check-cadence-sole-writer check-followup-sole-writer check-rematch-sole-dispatcher
+.PHONY: help setup dev build crm-admin test clean docker-up docker-down docker-reset test-cadence-ultra test-cadence-fast prod staging testing start start-local stop restart reload status dev-stop dev-restart dev-api-stop dev-api-start dev-api-restart ci-build-backend ci-build-frontend ci-build ci-test test-e2e test-e2e-local test-e2e-diff e2e-db deploy setup-pi dev-native postgres-native sqlc smoke-test test-integration-fast test-integration-slow test-mac-host-migrations check-cadence-sole-writer check-followup-sole-writer check-rematch-sole-dispatcher
 
 # Repo root (supports running make from subdirectories).
 REPO_ROOT := $(shell git rev-parse --show-toplevel)
@@ -37,6 +37,7 @@ help:
 	@echo "  dev         - Start development servers (uses Docker for PostgreSQL)"
 	@echo "  dev-native  - Start dev servers with native PostgreSQL (no Docker)"
 	@echo "  build       - Build both frontend and backend"
+	@echo "  crm-admin   - Build the operator-only admin CLI (backend/crm-admin)"
 	@echo "  sqlc        - Regenerate sqlc code from SQL queries"
 	@echo "  lint        - Run all linters (backend + frontend)"
 	@echo "  clean       - Clean build artifacts"

--- a/Makefile
+++ b/Makefile
@@ -248,6 +248,14 @@ build:
 	@echo "Building frontend..."
 	@cd frontend && bun run build
 
+# Operator-only admin binary. NOT wired into CI; build on demand on
+# the Pi when a one-shot maintenance task is needed (e.g.,
+# `./crm-admin --messages-rematch-stranded`).
+crm-admin:
+	@echo "Building crm-admin..."
+	@cd backend && go build -o crm-admin cmd/crm-admin/main.go
+	@echo "✓ crm-admin built at backend/crm-admin"
+
 # Tests
 test: test-unit test-integration test-frontend
 

--- a/backend/cmd/crm-admin/main.go
+++ b/backend/cmd/crm-admin/main.go
@@ -1,0 +1,118 @@
+// crm-admin is a one-shot operator utility for Pi-side maintenance
+// tasks that don't fit the HTTP API surface. Operator-only; NOT
+// deployed as part of the production service.
+//
+// Subcommands:
+//
+//	--messages-rematch-stranded   Retroactively match messages_message
+//	                              rows whose matched_contact_id is NULL
+//	                              against the current contact_method set,
+//	                              update them, and enqueue
+//	                              MessagingAggregateForContactArgs River
+//	                              jobs per newly-matched contact.
+//
+// See backend/internal/messages/admin_rematch.go for the business
+// logic — this binary is a thin CLI shim so the entire admin handler
+// stays unit-testable independently of the binary.
+//
+// Build:  make crm-admin   (operator-only target; NOT wired into CI).
+//
+// Single-file pkg-main per .ai/rules/core.md "Adding types to
+// cmd/crm-api/ in a companion file": all types referenced from this
+// file must be DEFINED here or in their own internal packages.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/messages"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/riverqueue/river/rivertype"
+)
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatalf("crm-admin: %v", err)
+	}
+}
+
+func run() error {
+	rematchStranded := flag.Bool("messages-rematch-stranded", false,
+		"Retroactively match stranded messages_message rows against contact_method and enqueue aggregator jobs")
+	flag.Parse()
+
+	if !*rematchStranded {
+		flag.Usage()
+		return fmt.Errorf("no subcommand specified; pass --messages-rematch-stranded")
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	ctx := context.Background()
+	if err := db.RunMigrations(ctx, cfg.Database.URL, cfg.Database.MigrationsPath); err != nil {
+		return fmt.Errorf("run migrations: %w", err)
+	}
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	if err != nil {
+		return fmt.Errorf("connect db: %w", err)
+	}
+	defer database.Close()
+
+	// River client without workers — we only insert jobs here.
+	riverClient, err := river.NewClient(riverpgxv5.New(database.Pool), &river.Config{
+		JobTimeout: cfg.River.JobTimeout,
+	})
+	if err != nil {
+		return fmt.Errorf("build river client: %w", err)
+	}
+
+	// Repositories + identity service. Constructed locally; identical
+	// shape to the crm-api wiring.
+	identityRepo := repository.NewIdentityRepository(database.Queries)
+	identityService := service.NewIdentityService(identityRepo)
+	messagesRepo := repository.NewMessagesMessageRepository(database.Queries)
+
+	res, err := messages.RematchStranded(ctx, messages.RematchStrandedDeps{
+		Messages:    messagesRepo,
+		Identity:    identityService,
+		RiverClient: adminRiverAdapter{client: riverClient},
+	})
+	if err != nil {
+		return fmt.Errorf("rematch stranded: %w", err)
+	}
+
+	if _, err := fmt.Fprintf(os.Stdout, "messages-rematch-stranded summary:\n"+
+		"  scanned:        %d\n"+
+		"  matched:        %d\n"+
+		"  still_stranded: %d\n"+
+		"  enqueued:       %d\n"+
+		"  errors:         %d\n",
+		res.Scanned, res.Matched, res.StillStranded, res.Enqueued, res.Errors); err != nil {
+		return fmt.Errorf("write summary: %w", err)
+	}
+	return nil
+}
+
+// adminRiverAdapter adapts *river.Client[pgx.Tx] to the
+// messages.AdminRiverInserter interface. Trivial pass-through.
+type adminRiverAdapter struct {
+	client *river.Client[pgx.Tx]
+}
+
+func (a adminRiverAdapter) Insert(ctx context.Context, args river.JobArgs, opts *river.InsertOpts) (*rivertype.JobInsertResult, error) {
+	return a.client.Insert(ctx, args, opts)
+}

--- a/backend/cmd/crm-admin/main.go
+++ b/backend/cmd/crm-admin/main.go
@@ -30,6 +30,7 @@ import (
 	"os"
 
 	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/consumer/consumerjobs"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/messages"
 	"personal-crm/backend/internal/repository"
@@ -72,9 +73,19 @@ func run() error {
 	}
 	defer database.Close()
 
-	// River client without workers — we only insert jobs here.
+	// River client configured as an inserter only. We register a
+	// noop worker for MessagingAggregateForContactArgs so River
+	// accepts the kind at Insert time without actually running the
+	// aggregation worker in this admin process — the main crm-api
+	// service owns execution.
+	workers := river.NewWorkers()
+	river.AddWorker(workers, &noopMessagingAggregateWorker{})
 	riverClient, err := river.NewClient(riverpgxv5.New(database.Pool), &river.Config{
 		JobTimeout: cfg.River.JobTimeout,
+		Queues: map[string]river.QueueConfig{
+			river.QueueDefault: {MaxWorkers: 1},
+		},
+		Workers: workers,
 	})
 	if err != nil {
 		return fmt.Errorf("build river client: %w", err)
@@ -115,4 +126,16 @@ type adminRiverAdapter struct {
 
 func (a adminRiverAdapter) Insert(ctx context.Context, args river.JobArgs, opts *river.InsertOpts) (*rivertype.JobInsertResult, error) {
 	return a.client.Insert(ctx, args, opts)
+}
+
+// noopMessagingAggregateWorker satisfies River's "every enqueued kind
+// must have a registered worker" rule for the admin binary's insert-
+// only path. Execution lives in crm-api; the admin process never
+// runs the worker — Start is never called on the client.
+type noopMessagingAggregateWorker struct {
+	river.WorkerDefaults[consumerjobs.MessagingAggregateForContactArgs]
+}
+
+func (w *noopMessagingAggregateWorker) Work(_ context.Context, _ *river.Job[consumerjobs.MessagingAggregateForContactArgs]) error {
+	return nil
 }

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -667,7 +667,7 @@ func run() int {
 		// Register the Messages push provider. The source is push-only —
 		// data lands via /api/v1/ingest/events from the Mac daemon, never
 		// via the scheduler — so Sync() is a no-op. The scheduler's push-
-		// strategy exclusion (PR1) ensures we never try to poll it.
+		// strategy exclusion in ListDueAccounts ensures we never poll it.
 		providerRegistry.Register(messages.New())
 		logger.Info().Msg("Messages push provider registered")
 
@@ -761,11 +761,11 @@ func run() int {
 	// daemon-side connection or background loop).
 	//
 	// The chat-aware AggregateForContact path is what preserves the
-	// engine's extend/bridge/coalesce contract (spec §3 "Stage 2 —
-	// Aggregator"). The MessagingAggregateForContactWorker iterates
-	// over the contact's distinct unprocessed chats and invokes it
-	// per chat; the periodic sweeper provides a 5-min safety net for
-	// the never-claimed-stranded-row gap (plan R10C).
+	// engine's extend/bridge/coalesce contract. The
+	// MessagingAggregateForContactWorker iterates over the contact's
+	// distinct unprocessed chats and invokes it per chat; the periodic
+	// sweeper provides a 5-min safety net for the never-claimed
+	// stranded-row gap.
 	messagesEnqueuer := consumer.NewRiverInteractionRecorderEnqueuer(riverClient)
 	const messagesBurstWindowHours = 4
 	const messagesReplyBridgeHours = 48
@@ -821,7 +821,7 @@ func run() int {
 
 	// Periodic 5-min sweeper — drains never-claimed stranded rows that
 	// the in-line worker re-list loop AND the post-Stage-3 reenqueue
-	// both missed (plan R10C).
+	// both missed. Last-resort safety net.
 	sweeperListers := map[string]scheduler.UnprocessedContactLister{
 		repository.InteractionSourceMessages: messagesMessageRepo,
 	}

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -266,7 +266,32 @@ func run() int {
 
 	eventRepo := repository.NewEventRepository(database.Queries)
 	eventBus := events.NewBus(database.Pool, riverClient, eventRepo)
-	ingestService := service.NewIngestService(database, eventBus)
+
+	// Identity repository + service for the ingest path. The host-auth
+	// ingest path (raw_message.* envelopes from the Mac daemon) needs a
+	// tx-bound identity matcher so the per-event savepoint can roll back
+	// the identity write atomically with the staging-row insert on
+	// failure. The external-sync block (further down) constructs its own
+	// IdentityService for the providers that use it — IdentityService is
+	// stateless so the two instances are interchangeable.
+	identityRepoForIngest := repository.NewIdentityRepository(database.Queries)
+	identityServiceForIngest := service.NewIdentityService(identityRepoForIngest)
+
+	// Messages staging repo (Mac daemon spec §3). Wired here so the
+	// InteractionRecorder's staging registry can dispatch
+	// source="messages" mark-processed calls correctly once the Mac
+	// daemon ingest writer is live, and so the IngestService can upsert
+	// staging rows from raw_message.* envelopes inside its per-event
+	// savepoint.
+	messagesMessageRepo := repository.NewMessagesMessageRepository(database.Queries)
+
+	ingestService := service.NewIngestService(
+		database,
+		eventBus,
+		identityServiceForIngest,
+		messagesMessageRepo,
+		riverClient,
+	)
 	ingestHandler := handlers.NewIngestHandler(ingestService)
 
 	// Rematch service — constructed above ContactService so it can be
@@ -281,13 +306,6 @@ func run() int {
 	// InteractionRecorder wiring so the consumer can mark messages
 	// processed in the same tx as the interaction insert).
 	telegramMessageRepo := repository.NewTelegramMessageRepository(database.Queries)
-
-	// Messages staging repo (Mac daemon spec §3). Wired here so the
-	// InteractionRecorder's staging registry can dispatch
-	// source="messages" mark-processed calls correctly once the Mac
-	// daemon ingest writer is live; until then the table has no rows
-	// and the registry entry is dormant.
-	messagesMessageRepo := repository.NewMessagesMessageRepository(database.Queries)
 
 	// Source-neutral staging registry — InteractionRecorder dispatches
 	// MarkProcessedTx by env.Source to the right repository. Unknown

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -39,12 +39,14 @@ import (
 	"personal-crm/backend/internal/auth"
 	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/consumer"
+	"personal-crm/backend/internal/consumer/consumerjobs"
 	"personal-crm/backend/internal/crypto"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/events"
 	"personal-crm/backend/internal/google"
 	"personal-crm/backend/internal/health"
 	"personal-crm/backend/internal/logger"
+	"personal-crm/backend/internal/messages"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/scheduler"
 	"personal-crm/backend/internal/service"
@@ -662,6 +664,13 @@ func run() int {
 			logger.Info().Msg("Contact task handler initialized")
 		}
 
+		// Register the Messages push provider. The source is push-only —
+		// data lands via /api/v1/ingest/events from the Mac daemon, never
+		// via the scheduler — so Sync() is a no-op. The scheduler's push-
+		// strategy exclusion (PR1) ensures we never try to poll it.
+		providerRegistry.Register(messages.New())
+		logger.Info().Msg("Messages push provider registered")
+
 		syncService = service.NewSyncService(syncRepo, contactRepo, providerRegistry)
 
 		syncHandler = handlers.NewSyncHandler(syncService)
@@ -728,18 +737,6 @@ func run() int {
 		}
 		defer telegramManager.Stop()
 
-		// Wire the per-source aggregator reenqueuer registry now that
-		// the Telegram engine exists. The InteractionRecorderWorker
-		// holds the deferred holder; this assignment makes the
-		// post-commit reenqueue path live for telegram-source events.
-		// Messages source is a no-op until the Mac daemon ingest writer is live.
-		aggregatorReenqueuerHolder.set(consumer.NewAggregatorReenqueuerRegistry(
-			map[string]consumer.AggregatorReenqueuer{
-				repository.InteractionSourceTelegram: consumer.NewTelegramAggregatorReenqueuer(telegramManager.AggregationEngine()),
-				repository.InteractionSourceMessages: consumer.NoopAggregatorReenqueuer{},
-			},
-		))
-
 		telegramHandler = handlers.NewTelegramHandler(telegramManager)
 
 		// Register telegram rematch handlers (telegram + phone identifiers)
@@ -756,6 +753,86 @@ func run() int {
 	if telegramManager != nil && importHandler != nil {
 		importHandler.SetPostImportHook(telegramManager)
 	}
+
+	// Messages aggregator engine + reenqueuer + worker + sweeper.
+	// Wired unconditionally — the Mac daemon push pipeline accepts
+	// raw_message.* envelopes regardless of any feature flag, and the
+	// engine is a stateless function over messagesMessageRepo (no
+	// daemon-side connection or background loop).
+	//
+	// The chat-aware AggregateForContact path is what preserves the
+	// engine's extend/bridge/coalesce contract (spec §3 "Stage 2 —
+	// Aggregator"). The MessagingAggregateForContactWorker iterates
+	// over the contact's distinct unprocessed chats and invokes it
+	// per chat; the periodic sweeper provides a 5-min safety net for
+	// the never-claimed-stranded-row gap (plan R10C).
+	messagesEnqueuer := consumer.NewRiverInteractionRecorderEnqueuer(riverClient)
+	const messagesBurstWindowHours = 4
+	const messagesReplyBridgeHours = 48
+	messagesEngine := messages.NewAggregationEngine(
+		messagesBurstWindowHours,
+		messagesReplyBridgeHours,
+		messagesMessageRepo,
+		interactionRepo,
+		contactService,
+		contactService,
+		eventBus,
+		database.Pool,
+		messagesEnqueuer,
+	)
+	messagesReenqueuer := consumer.NewMessagesAggregatorReenqueuer(
+		messagesEngine,
+		riverClient,
+		repository.InteractionSourceMessages,
+	)
+
+	// Wire the per-source aggregator reenqueuer registry. The
+	// InteractionRecorderWorker holds the deferred holder; this
+	// assignment makes the post-commit reenqueue path live for both
+	// telegram-source and messages-source events. When Telegram is
+	// disabled the telegram entry is a no-op reenqueuer (so calls for
+	// telegram-source envelopes — which won't be produced anyway —
+	// degrade cleanly).
+	reenqueuerEntries := map[string]consumer.AggregatorReenqueuer{
+		repository.InteractionSourceMessages: messagesReenqueuer,
+	}
+	if telegramManager != nil {
+		reenqueuerEntries[repository.InteractionSourceTelegram] = consumer.NewTelegramAggregatorReenqueuer(telegramManager.AggregationEngine())
+	} else {
+		reenqueuerEntries[repository.InteractionSourceTelegram] = consumer.NoopAggregatorReenqueuer{}
+	}
+	aggregatorReenqueuerHolder.set(consumer.NewAggregatorReenqueuerRegistry(reenqueuerEntries))
+
+	// Register the messaging aggregate workers. The chat-lister
+	// registry maps source → repository's ListUnprocessedChatsByContact;
+	// future messaging sources (whatsapp etc) extend the map without
+	// touching the worker.
+	chatListerRegistry := scheduler.NewPerSourceChatListerRegistry(
+		map[string]func(ctx context.Context, contactID uuid.UUID) ([]string, error){
+			repository.InteractionSourceMessages: messagesMessageRepo.ListUnprocessedChatsByContact,
+		},
+	)
+	river.AddWorker(riverWorkers, scheduler.NewMessagingAggregateForContactWorker(
+		map[string]scheduler.ChatAwareAggregator{
+			repository.InteractionSourceMessages: messagesEngine,
+		},
+		chatListerRegistry,
+	))
+
+	// Periodic 5-min sweeper — drains never-claimed stranded rows that
+	// the in-line worker re-list loop AND the post-Stage-3 reenqueue
+	// both missed (plan R10C).
+	sweeperListers := map[string]scheduler.UnprocessedContactLister{
+		repository.InteractionSourceMessages: messagesMessageRepo,
+	}
+	river.AddWorker(riverWorkers, scheduler.NewMessagingAggregateSweeperWorker(sweeperListers, riverClient))
+	riverClient.PeriodicJobs().Add(river.NewPeriodicJob(
+		river.PeriodicInterval(5*time.Minute),
+		func() (river.JobArgs, *river.InsertOpts) {
+			return consumerjobs.MessagingAggregateSweeperArgs{}, nil
+		},
+		&river.PeriodicJobOpts{RunOnStart: false},
+	))
 
 	// Initialize handlers
 	contactHandler := handlers.NewContactHandler(contactService)
@@ -871,6 +948,25 @@ func run() int {
 		Handler:     macHostHandler,
 		AuthLimiter: auth.DefaultMacHostAuthLimiterConfig(),
 	})
+
+	// Event bus ingestion endpoint (feature-flagged per spec §3.9).
+	// Registered as a SIBLING of /api/v1 (not inside it) so the
+	// composite IngestAuthMiddleware can branch per-request:
+	//   - X-Mac-Host-ID present → MacHostAuthMiddleware (daemon path)
+	//   - X-Mac-Host-ID absent  → APIKeyMiddleware (global-key path)
+	// gin route trees reject duplicate registration of the same prefix
+	// under different middleware groups, so the composite dispatch is
+	// the minimum seam to support both auth paths on one URL.
+	if cfg.Features.EnableEventBusIngest {
+		ingestAuth := auth.IngestAuthMiddleware(
+			auth.APIKeyMiddleware(cfg),
+			auth.MacHostAuthMiddleware(macHostRepo, auth.DefaultPasswordComparator, auth.DefaultMacHostAuthLimiterConfig()),
+		)
+		ingestGroup := router.Group("/api/v1/ingest")
+		ingestGroup.Use(ingestAuth)
+		ingestGroup.POST("/events", ingestHandler.IngestEvents)
+		logger.Info().Msg("event bus ingestion endpoint enabled")
+	}
 
 	// API routes
 	v1 := router.Group("/api/v1")
@@ -1036,19 +1132,6 @@ func run() int {
 		// Export/Import routes
 		v1.POST("/export", systemHandler.ExportData)
 		v1.POST("/import", systemHandler.ImportData)
-
-		// Event bus ingestion endpoint (feature-flagged per spec §3.9).
-		// When the flag is off the route is NOT registered — gin's
-		// NoRoute handler returns 404 without running the API-key
-		// middleware, matching the spec's acceptance criterion
-		// "EVENT_BUS_INGEST_ENABLED=false (default) returns 404."
-		if cfg.Features.EnableEventBusIngest {
-			ingest := v1.Group("/ingest")
-			{
-				ingest.POST("/events", ingestHandler.IngestEvents)
-			}
-			logger.Info().Msg("event bus ingestion endpoint enabled")
-		}
 
 		// Test routes (gated by CRM_ENV=testing or CRM_ENV=test)
 		if cfg.Runtime.CRMEnvironment == "testing" || cfg.Runtime.CRMEnvironment == "test" {

--- a/backend/internal/api/handlers/ingest.go
+++ b/backend/internal/api/handlers/ingest.go
@@ -8,11 +8,13 @@ import (
 	"time"
 
 	"personal-crm/backend/internal/api"
+	"personal-crm/backend/internal/auth"
 	"personal-crm/backend/internal/events"
 	"personal-crm/backend/internal/logger"
 	"personal-crm/backend/internal/service"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 )
 
 // Ingestion limits. Chosen per plan/spec §3.5:
@@ -42,6 +44,13 @@ const (
 	ingestCodePayloadInvalid  = "PAYLOAD_INVALID"
 	ingestCodePayloadTooLarge = "PAYLOAD_TOO_LARGE"
 )
+
+// eventsRawMessageMaxKnownVersion is the highest raw_message.* payload
+// Version the Pi knows how to process. Daemons that ship a Version
+// higher than this are rejected at the handler with PAYLOAD_INVALID so
+// the operator sees a clear "upgrade Pi" error rather than a silent
+// dropped-field decode.
+const eventsRawMessageMaxKnownVersion = 1
 
 // IngestHandler exposes POST /api/v1/ingest/events. Registered only when
 // cfg.Features.EnableEventBusIngest is true (spec §3.9).
@@ -111,10 +120,18 @@ type IngestResponse struct {
 //  2. Bind the JSON body. Malformed → 400.
 //  3. Enforce batch shape: non-empty, ≤ maxBatchSize.
 //  4. Validate each event (required fields, length bounds, known kind,
-//     payload shape). Failures land in errors[]; the batch continues.
+//     payload shape, raw_message-specific field checks). Failures land
+//     in errors[]; the batch continues.
 //  5. If any events pass validation, forward them to the service as a
 //     single atomic batch. Return spec-shaped success response. If the
 //     service errors (unexpected DB failure), return 500.
+//
+// Auth dispatch: the route runs behind IngestAuthMiddleware which
+// branches on the X-Mac-Host-ID header. When present and validated by
+// MacHostAuthMiddleware, the parsed UUID is stashed in gin context and
+// the handler reads it via auth.MacHostIDFromContext to pass through to
+// the service (so raw_message.* events can be processed and stamped
+// with mac_host_id). Absent header → API-key path → hostID is nil.
 func (h *IngestHandler) IngestEvents(c *gin.Context) {
 	// Body size cap. MaxBytesReader returns *http.MaxBytesError (Go 1.21+)
 	// which propagates through json.Decoder without re-wrapping; detect it
@@ -150,7 +167,11 @@ func (h *IngestHandler) IngestEvents(c *gin.Context) {
 	}
 
 	// Validate each event pre-tx. Valid ones become envelopes to publish.
+	// originalIndices[i] is the caller-original request-array position of
+	// envsToIngest[i]; passed to the service so per-event rejections
+	// surface with caller-original indexing.
 	envsToIngest := make([]*events.Envelope, 0, len(req.Events))
+	originalIndices := make([]int, 0, len(req.Events))
 	ingestErrors := make([]IngestError, 0)
 	for i, ev := range req.Events {
 		if ierr := validateIngestEvent(i, ev); ierr != nil {
@@ -164,9 +185,16 @@ func (h *IngestHandler) IngestEvents(c *gin.Context) {
 			Payload:    ev.Payload,
 			ObservedAt: *ev.ObservedAt, // validator guarantees non-nil + non-zero
 		})
+		originalIndices = append(originalIndices, i)
 	}
 
-	rejected := len(ingestErrors)
+	// Host ID is set by MacHostAuthMiddleware when the host-auth path
+	// fired; nil on the global-API-key path. Service uses it to enforce
+	// the per-path kind allowlist and stamp staging rows.
+	var hostID *uuid.UUID
+	if id, ok := auth.MacHostIDFromContext(c); ok {
+		hostID = &id
+	}
 
 	// All events failed validation — still a success response (spec §3.5
 	// distinguishes "validation failure per event" from "batch-level
@@ -176,18 +204,18 @@ func (h *IngestHandler) IngestEvents(c *gin.Context) {
 			Int("batch_size", len(req.Events)).
 			Int("accepted", 0).
 			Int("duplicate", 0).
-			Int("rejected", rejected).
+			Int("rejected", len(ingestErrors)).
 			Msg("event batch ingested (all rejected)")
 		c.JSON(http.StatusOK, IngestResponse{
 			Accepted:  0,
 			Duplicate: 0,
-			Rejected:  rejected,
+			Rejected:  len(ingestErrors),
 			Errors:    ingestErrors,
 		})
 		return
 	}
 
-	accepted, duplicate, err := h.ingestService.IngestBatch(c.Request.Context(), envsToIngest)
+	accepted, duplicate, perEventRejections, err := h.ingestService.IngestBatch(c.Request.Context(), envsToIngest, originalIndices, hostID)
 	if err != nil {
 		logger.Error().
 			Err(err).
@@ -198,17 +226,25 @@ func (h *IngestHandler) IngestEvents(c *gin.Context) {
 		return
 	}
 
+	for _, r := range perEventRejections {
+		ingestErrors = append(ingestErrors, IngestError{
+			Index:   r.Index,
+			Code:    r.Code,
+			Message: r.Message,
+		})
+	}
+
 	logger.Info().
 		Int("batch_size", len(req.Events)).
 		Int("accepted", accepted).
 		Int("duplicate", duplicate).
-		Int("rejected", rejected).
+		Int("rejected", len(ingestErrors)).
 		Msg("event batch ingested")
 
 	c.JSON(http.StatusOK, IngestResponse{
 		Accepted:  accepted,
 		Duplicate: duplicate,
-		Rejected:  rejected,
+		Rejected:  len(ingestErrors),
 		Errors:    ingestErrors,
 	})
 }
@@ -269,5 +305,73 @@ func validateIngestEvent(index int, ev IngestEventRequest) *IngestError {
 		}
 	}
 
+	// Raw_message.* kinds require strict field-level checks beyond the
+	// lenient ValidatePayload contract. Zero-valued chat_id, peer_handle,
+	// or sent_at would cause downstream identity-match + staging-upsert
+	// to fail mid-tx in non-obvious ways. Catch them at the handler.
+	if kind == events.KindRawMessageReceived || kind == events.KindRawMessageSent {
+		if ev.SourceID == "" {
+			return &IngestError{
+				Index:   index,
+				Code:    ingestCodeMissingField,
+				Message: "source_id is required for raw_message.* kinds (must equal payload.guid)",
+			}
+		}
+		if rerr := validateRawMessagePayload(index, ev); rerr != nil {
+			return rerr
+		}
+	}
+
+	return nil
+}
+
+// validateRawMessagePayload runs the raw_message.*-specific field-level
+// validation that ValidatePayload's lenient decode does not enforce.
+// Runs only when the kind is a raw_message.* kind and ValidatePayload
+// has already passed (structural).
+func validateRawMessagePayload(index int, ev IngestEventRequest) *IngestError {
+	var p events.RawMessageReceivedPayload
+	if err := json.Unmarshal(ev.Payload, &p); err != nil {
+		return &IngestError{Index: index, Code: ingestCodePayloadInvalid, Message: err.Error()}
+	}
+	if p.Version < 1 {
+		return &IngestError{Index: index, Code: ingestCodePayloadInvalid,
+			Message: fmt.Sprintf("raw_message payload: version must be >=1 (got %d)", p.Version)}
+	}
+	if p.Version > eventsRawMessageMaxKnownVersion {
+		return &IngestError{Index: index, Code: ingestCodePayloadInvalid,
+			Message: fmt.Sprintf("raw_message payload version %d exceeds max known %d; upgrade Pi",
+				p.Version, eventsRawMessageMaxKnownVersion)}
+	}
+	if p.HostID == uuid.Nil {
+		return &IngestError{Index: index, Code: ingestCodeMissingField,
+			Message: "raw_message payload: host_id is required"}
+	}
+	if p.Source == "" {
+		return &IngestError{Index: index, Code: ingestCodeMissingField,
+			Message: "raw_message payload: source is required"}
+	}
+	if p.Guid == "" {
+		return &IngestError{Index: index, Code: ingestCodeMissingField,
+			Message: "raw_message payload: guid is required"}
+	}
+	if p.ChatID == "" {
+		return &IngestError{Index: index, Code: ingestCodeMissingField,
+			Message: "raw_message payload: chat_id is required"}
+	}
+	if p.PeerHandle == "" {
+		return &IngestError{Index: index, Code: ingestCodeMissingField,
+			Message: "raw_message payload: peer_handle is required"}
+	}
+	if p.SentAt.IsZero() {
+		return &IngestError{Index: index, Code: ingestCodeMissingField,
+			Message: "raw_message payload: sent_at is required and must not be zero"}
+	}
+	if p.MessageType == "" {
+		return &IngestError{Index: index, Code: ingestCodeMissingField,
+			Message: "raw_message payload: message_type is required"}
+	}
+	// ValidatePayload already rejects message_type values outside the
+	// canonical set when non-empty; that check fires above.
 	return nil
 }

--- a/backend/internal/auth/ingest_middleware.go
+++ b/backend/internal/auth/ingest_middleware.go
@@ -1,0 +1,41 @@
+package auth
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+// IngestAuthMiddleware composes the global API-key middleware and the
+// Mac-host bearer middleware behind the single /api/v1/ingest/events
+// route. The dispatch is per-request, keyed on the presence of the
+// X-Mac-Host-ID header:
+//
+//   - X-Mac-Host-ID present → host-auth path (MacHostAuthMiddleware).
+//     Daemons authenticate with their host UUID + bearer token. The
+//     parsed host is stashed in gin context under macHostIDContextKey
+//     so downstream handlers can read it.
+//   - X-Mac-Host-ID absent → global-API-key path (APIKeyMiddleware).
+//     Preserves the existing publisher contract — internal Pi
+//     publishers and ops scripts continue to authenticate via the
+//     global key without code changes.
+//
+// Both branches use the existing per-path middleware verbatim. This
+// composite is purely a dispatcher; it does not run any auth logic
+// itself, so the per-path 401/429/etc semantics are unchanged.
+//
+// Rationale for in-handler dispatch (vs. separate route registration):
+// gin route trees reject a duplicate registration on the same prefix
+// (the pattern used by MacHostAuthMiddleware for the daemon endpoints),
+// so we cannot register /api/v1/ingest/events twice under different
+// middleware groups. A composite dispatcher is the minimal seam.
+func IngestAuthMiddleware(
+	apiKeyMW gin.HandlerFunc,
+	macHostMW gin.HandlerFunc,
+) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if c.GetHeader("X-Mac-Host-ID") != "" {
+			macHostMW(c)
+			return
+		}
+		apiKeyMW(c)
+	}
+}

--- a/backend/internal/auth/ingest_middleware_test.go
+++ b/backend/internal/auth/ingest_middleware_test.go
@@ -1,0 +1,90 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+// countingMW returns a gin.HandlerFunc that increments *calls each time
+// it's invoked and aborts the request with the configured status code.
+// Used by the composite-dispatch tests to verify which branch fired.
+func countingMW(calls *int, abortStatus int, label string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		*calls++
+		c.AbortWithStatusJSON(abortStatus, gin.H{"branch": label})
+	}
+}
+
+func TestIngestAuthMiddleware_HostHeaderPresent_RunsHostBranch(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	var apiCalls, hostCalls int
+
+	router := gin.New()
+	router.POST("/x",
+		IngestAuthMiddleware(
+			countingMW(&apiCalls, http.StatusUnauthorized, "api"),
+			countingMW(&hostCalls, http.StatusForbidden, "host"),
+		),
+		func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{}) },
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/x", nil)
+	req.Header.Set("X-Mac-Host-ID", "00000000-0000-0000-0000-000000000001")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, 0, apiCalls, "API-key branch must NOT fire when host header is present")
+	require.Equal(t, 1, hostCalls, "host branch must fire exactly once")
+	require.Equal(t, http.StatusForbidden, w.Code, "response status should come from host middleware")
+}
+
+func TestIngestAuthMiddleware_HostHeaderAbsent_RunsAPIKeyBranch(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	var apiCalls, hostCalls int
+
+	router := gin.New()
+	router.POST("/x",
+		IngestAuthMiddleware(
+			countingMW(&apiCalls, http.StatusUnauthorized, "api"),
+			countingMW(&hostCalls, http.StatusForbidden, "host"),
+		),
+		func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{}) },
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/x", nil)
+	// No X-Mac-Host-ID; do include an arbitrary API key value so the
+	// stub branch can be observed.
+	req.Header.Set("X-API-Key", "test-key")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, 1, apiCalls, "API-key branch must fire exactly once")
+	require.Equal(t, 0, hostCalls, "host branch must NOT fire when host header is absent")
+	require.Equal(t, http.StatusUnauthorized, w.Code, "response status should come from API-key middleware")
+}
+
+func TestIngestAuthMiddleware_EmptyHostHeader_TreatedAsAbsent(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	var apiCalls, hostCalls int
+
+	router := gin.New()
+	router.POST("/x",
+		IngestAuthMiddleware(
+			countingMW(&apiCalls, http.StatusUnauthorized, "api"),
+			countingMW(&hostCalls, http.StatusForbidden, "host"),
+		),
+		func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{}) },
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/x", nil)
+	req.Header.Set("X-Mac-Host-ID", "") // explicit empty value
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, 1, apiCalls, "empty header value must fall back to API-key branch")
+	require.Equal(t, 0, hostCalls)
+}

--- a/backend/internal/consumer/consumerjobs/args.go
+++ b/backend/internal/consumer/consumerjobs/args.go
@@ -97,6 +97,41 @@ type TodoistFollowUpRefreshJobArgs struct {
 // refresh retry jobs.
 func (TodoistFollowUpRefreshJobArgs) Kind() string { return "todoist_followup_refresh" }
 
+// MessagingAggregateForContactArgs is enqueued by the ingest service
+// after a batch of raw_message.* events lands. The worker drives the
+// chat-aware aggregation engine over all unprocessed chats for the
+// (contactID, source) pair.
+//
+// ContactID + Source carry the `river:"unique"` tag so River's
+// UniqueOpts{ByArgs: true} dedupes concurrent enqueues for the same
+// pair into one in-flight job. Default ByState (Pending/Scheduled/
+// Available/Running/Retryable) is intentional — completed jobs do
+// NOT block re-enqueue, so a subsequent batch arriving after the
+// previous worker finished still triggers a fresh aggregation pass.
+//
+// JSON tag names ("contact_id" / "source") are load-bearing for
+// River's args-hash uniqueness; do not rename without auditing all
+// consumers/tests that decode the args.
+type MessagingAggregateForContactArgs struct {
+	ContactID uuid.UUID `json:"contact_id" river:"unique"`
+	Source    string    `json:"source"     river:"unique"`
+}
+
+// Kind returns the river job-kind identifier for messaging aggregate
+// jobs.
+func (MessagingAggregateForContactArgs) Kind() string { return "messaging_aggregate_for_contact" }
+
+// MessagingAggregateSweeperArgs is the periodic sweep job. The worker
+// lists all contacts with unprocessed messages_message rows and
+// enqueues a MessagingAggregateForContactArgs per contact, relying on
+// UniqueOpts to dedupe against in-flight jobs. Bounds the worst-case
+// stranded-row latency at the sweep interval. The worker holds no
+// state; the args type is intentionally empty.
+type MessagingAggregateSweeperArgs struct{}
+
+// Kind returns the river job-kind identifier for the sweeper.
+func (MessagingAggregateSweeperArgs) Kind() string { return "messaging_aggregate_sweeper" }
+
 // RematchDispatcherJobArgs carries the event id + dedup-arg fields that
 // the RematchDispatcher worker processes. ContactID and RematchJobID
 // are duplicated from the event payload and carry the river:"unique"

--- a/backend/internal/consumer/messages_aggregator_reenqueuer.go
+++ b/backend/internal/consumer/messages_aggregator_reenqueuer.go
@@ -31,13 +31,13 @@ type messagesRiverInserter interface {
 
 // MessagesAggregatorReenqueuer wires the messages aggregation engine
 // + River client into the post-Stage-3 reenqueue path. Two actions
-// run per call (plan R10):
+// run per call:
 //
-//  1. (R10B) Enqueue a fresh MessagingAggregateForContactArgs River
-//     job — UniqueOpts dedup against in-flight jobs means a no-op when
-//     one is already pending, but a brand-new job fires when the
-//     previous worker just finished. Catches rows that landed in
-//     OTHER chats for the same contact while Stage 3 was committing.
+//  1. Enqueue a fresh MessagingAggregateForContactArgs River job —
+//     UniqueOpts dedup against in-flight jobs means a no-op when one
+//     is already pending, but a brand-new job fires when the previous
+//     worker just finished. Catches rows that landed in OTHER chats
+//     for the same contact while Stage 3 was committing.
 //
 //  2. Synchronously invoke AggregateForContact for the chat just
 //     processed — closes the burst-extend window so a follow-up

--- a/backend/internal/consumer/messages_aggregator_reenqueuer.go
+++ b/backend/internal/consumer/messages_aggregator_reenqueuer.go
@@ -68,7 +68,7 @@ func NewMessagesAggregatorReenqueuer(
 
 // Reenqueue implements AggregatorReenqueuer.
 func (r *MessagesAggregatorReenqueuer) Reenqueue(ctx context.Context, env *events.Envelope, contactID uuid.UUID) error {
-	// (R10B) Fire a fresh aggregator job up-front. UniqueOpts dedups
+	// Fire a fresh aggregator job up-front. UniqueOpts dedups
 	// in-flight; completed jobs do NOT block re-enqueue so this
 	// always either coalesces or runs.
 	if r.riverClient != nil {

--- a/backend/internal/consumer/messages_aggregator_reenqueuer.go
+++ b/backend/internal/consumer/messages_aggregator_reenqueuer.go
@@ -1,0 +1,139 @@
+package consumer
+
+import (
+	"context"
+	"strings"
+
+	"personal-crm/backend/internal/consumer/consumerjobs"
+	"personal-crm/backend/internal/events"
+
+	"github.com/google/uuid"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
+	"github.com/rs/zerolog/log"
+)
+
+// messagesChatAwareAggregator captures the chat-aware aggregator
+// surface needed by the messages reenqueuer. Concrete is
+// *aggregation.Engine.AggregateForContact (chat-scoped). Interface
+// keeps the consumer package free of a back-edge to the messages
+// adapter package; main.go wires the concrete in via a closure.
+type messagesChatAwareAggregator interface {
+	AggregateForContact(ctx context.Context, contactID uuid.UUID, chatID string) error
+}
+
+// messagesRiverInserter is the narrow surface used to enqueue a
+// fresh MessagingAggregateForContactArgs in addition to the chat-
+// aware call. Mirrors RiverInteractionRecorderEnqueuer's shape.
+type messagesRiverInserter interface {
+	Insert(ctx context.Context, args river.JobArgs, opts *river.InsertOpts) (*rivertype.JobInsertResult, error)
+}
+
+// MessagesAggregatorReenqueuer wires the messages aggregation engine
+// + River client into the post-Stage-3 reenqueue path. Two actions
+// run per call (plan R10):
+//
+//  1. (R10B) Enqueue a fresh MessagingAggregateForContactArgs River
+//     job — UniqueOpts dedup against in-flight jobs means a no-op when
+//     one is already pending, but a brand-new job fires when the
+//     previous worker just finished. Catches rows that landed in
+//     OTHER chats for the same contact while Stage 3 was committing.
+//
+//  2. Synchronously invoke AggregateForContact for the chat just
+//     processed — closes the burst-extend window so a follow-up
+//     message in the same chat extends the interaction we just
+//     created instead of creating a new one.
+//
+// Both happen best-effort: failures are logged (the interaction has
+// already committed; rolling back is not an option).
+type MessagesAggregatorReenqueuer struct {
+	engine      messagesChatAwareAggregator
+	riverClient messagesRiverInserter
+	source      string
+}
+
+// NewMessagesAggregatorReenqueuer builds the reenqueuer over a
+// messages chat-aware aggregator + river client. source is typically
+// "messages"; constructor accepts a parameter so tests can override.
+func NewMessagesAggregatorReenqueuer(
+	engine messagesChatAwareAggregator,
+	riverClient messagesRiverInserter,
+	source string,
+) *MessagesAggregatorReenqueuer {
+	if source == "" {
+		source = "messages"
+	}
+	return &MessagesAggregatorReenqueuer{engine: engine, riverClient: riverClient, source: source}
+}
+
+// Reenqueue implements AggregatorReenqueuer.
+func (r *MessagesAggregatorReenqueuer) Reenqueue(ctx context.Context, env *events.Envelope, contactID uuid.UUID) error {
+	// (R10B) Fire a fresh aggregator job up-front. UniqueOpts dedups
+	// in-flight; completed jobs do NOT block re-enqueue so this
+	// always either coalesces or runs.
+	if r.riverClient != nil {
+		_, err := r.riverClient.Insert(ctx, consumerjobs.MessagingAggregateForContactArgs{
+			ContactID: contactID,
+			Source:    r.source,
+		}, &river.InsertOpts{
+			UniqueOpts: river.UniqueOpts{ByArgs: true},
+		})
+		if err != nil {
+			log.Warn().
+				Err(err).
+				Str("source", r.source).
+				Str("contact_id", contactID.String()).
+				Msg("messages-reenqueuer: enqueue MessagingAggregateForContactArgs failed; continuing with synchronous pass")
+		}
+	}
+
+	// Chat-aware synchronous pass for the chat just processed.
+	chatID, ok := parseMessagesPeerRef(env)
+	if !ok {
+		log.Warn().
+			Str("source", env.Source).
+			Str("envelope_kind", string(env.Kind)).
+			Msg("messages-reenqueuer: could not parse chat scope from envelope; skipping synchronous pass")
+		return nil
+	}
+	if r.engine == nil {
+		log.Warn().
+			Str("source", r.source).
+			Msg("messages-reenqueuer: no engine wired; skipping synchronous pass")
+		return nil
+	}
+	return r.engine.AggregateForContact(ctx, contactID, chatID)
+}
+
+// parseMessagesPeerRef extracts the chat scope from a message.*
+// envelope emitted by the messages aggregator. Format:
+// "messages:<chat_guid>". Returns (chatID, true) on success; ("", false)
+// for malformed / sweeper-sentinel envelopes (which carry no PeerRef).
+func parseMessagesPeerRef(env *events.Envelope) (string, bool) {
+	var peerRef string
+	switch env.Kind {
+	case events.KindMessageReceived:
+		var p events.MessageReceivedPayload
+		if err := events.Unmarshal(env, &p); err != nil {
+			return "", false
+		}
+		peerRef = p.PeerRef
+	case events.KindMessageSent:
+		var p events.MessageSentPayload
+		if err := events.Unmarshal(env, &p); err != nil {
+			return "", false
+		}
+		peerRef = p.PeerRef
+	default:
+		return "", false
+	}
+	const prefix = "messages:"
+	if !strings.HasPrefix(peerRef, prefix) {
+		return "", false
+	}
+	chatID := peerRef[len(prefix):]
+	if chatID == "" {
+		return "", false
+	}
+	return chatID, true
+}

--- a/backend/internal/consumer/messages_aggregator_reenqueuer_test.go
+++ b/backend/internal/consumer/messages_aggregator_reenqueuer_test.go
@@ -73,7 +73,7 @@ func buildMessageEnvelope(t *testing.T, kind events.Kind, peerRef string) *event
 }
 
 // TestReenqueuer_EnqueuesFreshJobAndCallsEngine asserts the happy path:
-// both R10B (fresh River job) and the chat-aware sync pass fire on
+// both the fresh-River-job enqueue and the chat-aware sync pass fire on
 // a successful Reenqueue call.
 func TestReenqueuer_EnqueuesFreshJobAndCallsEngine(t *testing.T) {
 	eng := &stubMessagesEngine{}
@@ -132,7 +132,7 @@ func TestReenqueuer_EmptyChatID_LogsAndReturnsNil(t *testing.T) {
 }
 
 // TestReenqueuer_NilEngine_NoOpsButStillEnqueues confirms that a nil
-// engine (test mode) doesn't crash the reenqueuer; the R10B fresh-
+// engine (test mode) doesn't crash the reenqueuer; the fresh-
 // enqueue path still fires.
 func TestReenqueuer_NilEngine_NoOpsButStillEnqueues(t *testing.T) {
 	ins := &stubMsgInserter{}

--- a/backend/internal/consumer/messages_aggregator_reenqueuer_test.go
+++ b/backend/internal/consumer/messages_aggregator_reenqueuer_test.go
@@ -1,0 +1,171 @@
+package consumer
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"personal-crm/backend/internal/consumer/consumerjobs"
+	"personal-crm/backend/internal/events"
+
+	"github.com/google/uuid"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
+	"github.com/stretchr/testify/require"
+)
+
+// stubMessagesEngine records every AggregateForContact call.
+type stubMessagesEngine struct {
+	calls   []stubMsgEngCall
+	failErr error
+}
+
+type stubMsgEngCall struct {
+	contactID uuid.UUID
+	chatID    string
+}
+
+func (s *stubMessagesEngine) AggregateForContact(_ context.Context, contactID uuid.UUID, chatID string) error {
+	s.calls = append(s.calls, stubMsgEngCall{contactID, chatID})
+	return s.failErr
+}
+
+// stubMsgInserter records every Insert call.
+type stubMsgInserter struct {
+	calls []consumerjobs.MessagingAggregateForContactArgs
+	err   error
+}
+
+func (s *stubMsgInserter) Insert(_ context.Context, args river.JobArgs, _ *river.InsertOpts) (*rivertype.JobInsertResult, error) {
+	if a, ok := args.(consumerjobs.MessagingAggregateForContactArgs); ok {
+		s.calls = append(s.calls, a)
+	}
+	if s.err != nil {
+		return nil, s.err
+	}
+	return &rivertype.JobInsertResult{}, nil
+}
+
+func buildMessageEnvelope(t *testing.T, kind events.Kind, peerRef string) *events.Envelope {
+	t.Helper()
+	contactID := uuid.New()
+	var payloadBytes []byte
+	var err error
+	if kind == events.KindMessageReceived {
+		payloadBytes, err = events.Marshal(kind, events.MessageReceivedPayload{
+			Version:   1,
+			ContactID: &contactID,
+			PeerRef:   peerRef,
+		})
+	} else {
+		payloadBytes, err = events.Marshal(kind, events.MessageSentPayload{
+			Version:   1,
+			ContactID: &contactID,
+			PeerRef:   peerRef,
+		})
+	}
+	require.NoError(t, err)
+	return &events.Envelope{
+		Source:  "messages",
+		Kind:    kind,
+		Payload: payloadBytes,
+	}
+}
+
+// TestReenqueuer_EnqueuesFreshJobAndCallsEngine asserts the happy path:
+// both R10B (fresh River job) and the chat-aware sync pass fire on
+// a successful Reenqueue call.
+func TestReenqueuer_EnqueuesFreshJobAndCallsEngine(t *testing.T) {
+	eng := &stubMessagesEngine{}
+	ins := &stubMsgInserter{}
+	r := NewMessagesAggregatorReenqueuer(eng, ins, "messages")
+	contactID := uuid.New()
+
+	env := buildMessageEnvelope(t, events.KindMessageReceived, "messages:chat-A")
+	err := r.Reenqueue(context.Background(), env, contactID)
+	require.NoError(t, err)
+	require.Len(t, ins.calls, 1)
+	require.Equal(t, contactID, ins.calls[0].ContactID)
+	require.Equal(t, "messages", ins.calls[0].Source)
+	require.Len(t, eng.calls, 1)
+	require.Equal(t, contactID, eng.calls[0].contactID)
+	require.Equal(t, "chat-A", eng.calls[0].chatID)
+}
+
+// TestReenqueuer_OutboundKindAlsoParses confirms the parser handles
+// KindMessageSent.
+func TestReenqueuer_OutboundKindAlsoParses(t *testing.T) {
+	eng := &stubMessagesEngine{}
+	r := NewMessagesAggregatorReenqueuer(eng, nil, "messages")
+	contactID := uuid.New()
+
+	env := buildMessageEnvelope(t, events.KindMessageSent, "messages:chat-B")
+	err := r.Reenqueue(context.Background(), env, contactID)
+	require.NoError(t, err)
+	require.Len(t, eng.calls, 1)
+	require.Equal(t, "chat-B", eng.calls[0].chatID)
+}
+
+// TestReenqueuer_MalformedPeerRef_LogsAndReturnsNil verifies the
+// reenqueuer treats an unparseable PeerRef as a non-fatal warning.
+// The recorder has already committed; rolling back is not an option.
+func TestReenqueuer_MalformedPeerRef_LogsAndReturnsNil(t *testing.T) {
+	eng := &stubMessagesEngine{}
+	r := NewMessagesAggregatorReenqueuer(eng, nil, "messages")
+
+	env := buildMessageEnvelope(t, events.KindMessageReceived, "tg:1234567")
+	err := r.Reenqueue(context.Background(), env, uuid.New())
+	require.NoError(t, err)
+	require.Empty(t, eng.calls, "engine MUST NOT be invoked when PeerRef is unparseable")
+}
+
+// TestReenqueuer_EmptyChatID_LogsAndReturnsNil verifies the
+// reenqueuer treats an empty chat scope as a non-fatal warning.
+func TestReenqueuer_EmptyChatID_LogsAndReturnsNil(t *testing.T) {
+	eng := &stubMessagesEngine{}
+	r := NewMessagesAggregatorReenqueuer(eng, nil, "messages")
+
+	env := buildMessageEnvelope(t, events.KindMessageReceived, "messages:")
+	err := r.Reenqueue(context.Background(), env, uuid.New())
+	require.NoError(t, err)
+	require.Empty(t, eng.calls, "engine MUST NOT be invoked when chat ID is empty")
+}
+
+// TestReenqueuer_NilEngine_NoOpsButStillEnqueues confirms that a nil
+// engine (test mode) doesn't crash the reenqueuer; the R10B fresh-
+// enqueue path still fires.
+func TestReenqueuer_NilEngine_NoOpsButStillEnqueues(t *testing.T) {
+	ins := &stubMsgInserter{}
+	r := NewMessagesAggregatorReenqueuer(nil, ins, "messages")
+	env := buildMessageEnvelope(t, events.KindMessageReceived, "messages:chat-X")
+	err := r.Reenqueue(context.Background(), env, uuid.New())
+	require.NoError(t, err)
+	require.Len(t, ins.calls, 1, "fresh-enqueue path must fire even when engine is nil")
+}
+
+// TestReenqueuer_InserterError_LogsAndContinues verifies an enqueue
+// failure does NOT prevent the chat-aware sync pass — both paths are
+// best-effort independent.
+func TestReenqueuer_InserterError_LogsAndContinues(t *testing.T) {
+	eng := &stubMessagesEngine{}
+	ins := &stubMsgInserter{err: errors.New("river down")}
+	r := NewMessagesAggregatorReenqueuer(eng, ins, "messages")
+
+	env := buildMessageEnvelope(t, events.KindMessageReceived, "messages:chat-Z")
+	err := r.Reenqueue(context.Background(), env, uuid.New())
+	require.NoError(t, err) // best-effort path; logger.Warn only
+	require.Len(t, eng.calls, 1, "engine pass must still fire after enqueue failure")
+}
+
+// TestReenqueuer_NonMessageKind_ReturnsNil confirms the parser falls
+// through cleanly on unexpected kinds (defensive — the registry should
+// not dispatch non-message envelopes here, but the parser handles them).
+func TestReenqueuer_NonMessageKind_ReturnsNil(t *testing.T) {
+	eng := &stubMessagesEngine{}
+	r := NewMessagesAggregatorReenqueuer(eng, nil, "messages")
+
+	env := &events.Envelope{Source: "messages", Kind: events.KindInteractionRecorded}
+	err := r.Reenqueue(context.Background(), env, uuid.New())
+	require.NoError(t, err)
+	require.Empty(t, eng.calls)
+}

--- a/backend/internal/db/interaction.sql.go
+++ b/backend/internal/db/interaction.sql.go
@@ -143,7 +143,7 @@ SELECT id, contact_id, source, source_ref, occurred_at, description, created_at,
 WHERE contact_id = $1
   AND source = $2
   AND direction = $3
-  AND source_ref LIKE $4
+  AND source_ref LIKE $4::text ESCAPE '\'
   AND occurred_at >= $5
   AND occurred_at <= $6
   AND deleted_at IS NULL
@@ -155,7 +155,7 @@ type FindRecentInteractionBySourceAndDirectionParams struct {
 	ContactID       pgtype.UUID        `json:"contact_id"`
 	Source          string             `json:"source"`
 	Direction       string             `json:"direction"`
-	SourceRefPrefix pgtype.Text        `json:"source_ref_prefix"`
+	SourceRefPrefix string             `json:"source_ref_prefix"`
 	WindowStart     pgtype.Timestamptz `json:"window_start"`
 	WindowEnd       pgtype.Timestamptz `json:"window_end"`
 }
@@ -164,6 +164,19 @@ type FindRecentInteractionBySourceAndDirectionParams struct {
 // Used by the shared aggregator (backend/internal/messaging/aggregation)
 // for same-direction coalescing. source_ref_prefix should include
 // trailing % for LIKE match.
+//
+// The ESCAPE clause lets adapters whose source-ref segments may
+// contain `_` or `%` (e.g., Apple Messages chat.guid values like
+// "iMessage;-;_chat-uuid_") supply their own escape character `\`
+// without false-matching unrelated rows. Numeric-only chat IDs
+// (Telegram) pass through unchanged since they never contain LIKE
+// wildcards.
+//
+// The explicit ::text cast on the bind variable keeps sqlc inferring
+// pgtype.Text for the parameter; without it the ESCAPE clause causes
+// sqlc to fall back to []byte (Postgres treats the LIKE pattern as
+// bytea-compatible in that form). Plain LIKE-on-text behavior is what
+// the existing callers expect.
 func (q *Queries) FindRecentInteractionBySourceAndDirection(ctx context.Context, arg FindRecentInteractionBySourceAndDirectionParams) (*Interaction, error) {
 	row := q.db.QueryRow(ctx, FindRecentInteractionBySourceAndDirection,
 		arg.ContactID,
@@ -193,7 +206,7 @@ SELECT id, contact_id, source, source_ref, occurred_at, description, created_at,
 WHERE contact_id = $1
   AND source = $2
   AND direction = 'outbound'
-  AND source_ref LIKE $3
+  AND source_ref LIKE $3::text ESCAPE '\'
   AND occurred_at >= $4
   AND occurred_at <= $5
   AND deleted_at IS NULL
@@ -204,7 +217,7 @@ LIMIT 1
 type FindRecentOutboundInteractionBySourceParams struct {
 	ContactID       pgtype.UUID        `json:"contact_id"`
 	Source          string             `json:"source"`
-	SourceRefPrefix pgtype.Text        `json:"source_ref_prefix"`
+	SourceRefPrefix string             `json:"source_ref_prefix"`
 	WindowStart     pgtype.Timestamptz `json:"window_start"`
 	WindowEnd       pgtype.Timestamptz `json:"window_end"`
 }
@@ -212,6 +225,9 @@ type FindRecentOutboundInteractionBySourceParams struct {
 // Source-neutral generalization of FindRecentOutboundTelegramInteraction.
 // Used by the shared aggregator for time-based reply bridging on inbound
 // sessions.
+//
+// ESCAPE clause: same rationale as FindRecentInteractionBySourceAndDirection.
+// See that query for the ::text cast rationale.
 func (q *Queries) FindRecentOutboundInteractionBySource(ctx context.Context, arg FindRecentOutboundInteractionBySourceParams) (*Interaction, error) {
 	row := q.db.QueryRow(ctx, FindRecentOutboundInteractionBySource,
 		arg.ContactID,

--- a/backend/internal/db/messages_message.sql.go
+++ b/backend/internal/db/messages_message.sql.go
@@ -178,6 +178,59 @@ func (q *Queries) HardDeleteMessagesMessagesByMacHost(ctx context.Context, macHo
 	return err
 }
 
+const ListStrandedMessagesMessages = `-- name: ListStrandedMessagesMessages :many
+SELECT id, guid, chat_guid, peer_handle, peer_normalized, text, message_type, sent_at, is_outgoing, is_group_chat, reply_to_guid, matched_contact_id, interaction_id, mac_host_id, processed_at, claimed_at, claimed_session_ref, deleted_at, created_at FROM messages_message
+WHERE matched_contact_id IS NULL
+  AND processed_at IS NULL
+  AND deleted_at IS NULL
+ORDER BY sent_at
+`
+
+// Lists rows with matched_contact_id IS NULL — i.e., rows that the
+// ingest service accepted into staging but couldn't match to a contact
+// at the time. The crm-admin --messages-rematch-stranded command
+// iterates this list to retroactively match rows after a contact_method
+// is added.
+func (q *Queries) ListStrandedMessagesMessages(ctx context.Context) ([]*MessagesMessage, error) {
+	rows, err := q.db.Query(ctx, ListStrandedMessagesMessages)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []*MessagesMessage{}
+	for rows.Next() {
+		var i MessagesMessage
+		if err := rows.Scan(
+			&i.ID,
+			&i.Guid,
+			&i.ChatGuid,
+			&i.PeerHandle,
+			&i.PeerNormalized,
+			&i.Text,
+			&i.MessageType,
+			&i.SentAt,
+			&i.IsOutgoing,
+			&i.IsGroupChat,
+			&i.ReplyToGuid,
+			&i.MatchedContactID,
+			&i.InteractionID,
+			&i.MacHostID,
+			&i.ProcessedAt,
+			&i.ClaimedAt,
+			&i.ClaimedSessionRef,
+			&i.DeletedAt,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const ListUnprocessedMessagesByContact = `-- name: ListUnprocessedMessagesByContact :many
 SELECT id, guid, chat_guid, peer_handle, peer_normalized, text, message_type, sent_at, is_outgoing, is_group_chat, reply_to_guid, matched_contact_id, interaction_id, mac_host_id, processed_at, claimed_at, claimed_session_ref, deleted_at, created_at FROM messages_message
 WHERE matched_contact_id = $1
@@ -282,6 +335,41 @@ func (q *Queries) ListUnprocessedMessagesByContactAndChat(ctx context.Context, a
 	return items, nil
 }
 
+const ListUnprocessedMessagesChatsByContact = `-- name: ListUnprocessedMessagesChatsByContact :many
+SELECT DISTINCT chat_guid
+FROM messages_message
+WHERE matched_contact_id = $1
+  AND processed_at IS NULL
+  AND (claimed_at IS NULL OR claimed_at < NOW() - INTERVAL '5 minutes')
+  AND deleted_at IS NULL
+ORDER BY chat_guid ASC
+`
+
+// Distinct chat_guid values for a contact with at least one eligible
+// (unprocessed AND unclaimed-or-stale) staging row. Used by the
+// messaging aggregator worker to drive per-chat AggregateForContact
+// invocations — the chat-aware path is what preserves the engine's
+// extend/bridge/coalesce contract (see spec §3 "Stage 2 — Aggregator").
+func (q *Queries) ListUnprocessedMessagesChatsByContact(ctx context.Context, matchedContactID pgtype.UUID) ([]string, error) {
+	rows, err := q.db.Query(ctx, ListUnprocessedMessagesChatsByContact, matchedContactID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []string{}
+	for rows.Next() {
+		var chat_guid string
+		if err := rows.Scan(&chat_guid); err != nil {
+			return nil, err
+		}
+		items = append(items, chat_guid)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const ListUnprocessedMessagesContactIDs = `-- name: ListUnprocessedMessagesContactIDs :many
 SELECT DISTINCT matched_contact_id
 FROM messages_message
@@ -374,6 +462,31 @@ func (q *Queries) MarkMessagesMessagesProcessedForSession(ctx context.Context, a
 		return 0, err
 	}
 	return result.RowsAffected(), nil
+}
+
+const UpdateMatchedContactForStrandedMessage = `-- name: UpdateMatchedContactForStrandedMessage :exec
+UPDATE messages_message
+SET matched_contact_id = $1,
+    peer_normalized    = $2
+WHERE id = $3
+  AND matched_contact_id IS NULL
+  AND processed_at IS NULL
+  AND deleted_at IS NULL
+`
+
+type UpdateMatchedContactForStrandedMessageParams struct {
+	MatchedContactID pgtype.UUID `json:"matched_contact_id"`
+	PeerNormalized   pgtype.Text `json:"peer_normalized"`
+	ID               pgtype.UUID `json:"id"`
+}
+
+// Sets matched_contact_id + peer_normalized on a single stranded row.
+// Scoped to rows that are still unmatched + unprocessed so a
+// concurrent ingest path (a never-stranding daemon push for a peer
+// that just got matched) cannot be overwritten by this admin path.
+func (q *Queries) UpdateMatchedContactForStrandedMessage(ctx context.Context, arg UpdateMatchedContactForStrandedMessageParams) error {
+	_, err := q.db.Exec(ctx, UpdateMatchedContactForStrandedMessage, arg.MatchedContactID, arg.PeerNormalized, arg.ID)
+	return err
 }
 
 const UpsertMessagesMessage = `-- name: UpsertMessagesMessage :one

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -88,6 +88,9 @@ type Querier interface {
 	CountMergeInteractions(ctx context.Context, contactID pgtype.UUID) (int64, error)
 	// Count notes for a contact (for merge preview)
 	CountMergeNotes(ctx context.Context, contactID pgtype.UUID) (int64, error)
+	// Test assertion — count rows with the given guid (typically 0 or 1
+	// under the partial unique index). Used by duplicate-detection tests.
+	CountMessagesMessageByGuid(ctx context.Context, guid string) (int64, error)
 	// Count OAuth credentials for a provider
 	CountOAuthCredentials(ctx context.Context, provider string) (int64, error)
 	// Test-only count of river_job rows for the rematch_dispatcher kind
@@ -101,6 +104,11 @@ type Querier interface {
 	// tests to assert a create/close/refresh job was enqueued without
 	// inlining raw SQL into Go test code (core.md rule 2).
 	CountRiverJobsByContactTask(ctx context.Context, arg CountRiverJobsByContactTaskParams) (int64, error)
+	// Test assertion — count unfinalized River jobs of the given kind.
+	// Used to verify ingest enqueues the expected number of aggregator
+	// jobs. River's own admin SQL is OK to query at the test boundary;
+	// production code never reads river_job directly.
+	CountRiverJobsByKindUnfinalized(ctx context.Context, kind string) (int64, error)
 	CountSearchContacts(ctx context.Context, arg CountSearchContactsParams) (int64, error)
 	CountSyncLogsByState(ctx context.Context, syncStateID pgtype.UUID) (int64, error)
 	CountTelegramMessagesByChat(ctx context.Context) ([]*CountTelegramMessagesByChatRow, error)
@@ -172,11 +180,19 @@ type Querier interface {
 	DeleteEnrichmentsForContact(ctx context.Context, contactID pgtype.UUID) error
 	// Delete all events for a Google account (used when revoking access)
 	DeleteEventsByAccount(ctx context.Context, googleAccountID string) error
+	// Test teardown — drop event rows by source. Mirrors
+	// DeleteExternalIdentitiesBySource for the event log.
+	DeleteEventsBySource(ctx context.Context, source string) (int64, error)
 	DeleteExpiredPairingTokens(ctx context.Context) (int64, error)
 	DeleteExternalContact(ctx context.Context, id pgtype.UUID) error
 	DeleteExternalContactsByDisplayNamePrefix(ctx context.Context, dollar_1 pgtype.Text) (int64, error)
 	DeleteExternalContactsBySourceAccount(ctx context.Context, arg DeleteExternalContactsBySourceAccountParams) error
 	DeleteExternalContactsBySourceIDPrefix(ctx context.Context, dollar_1 pgtype.Text) (int64, error)
+	// Test teardown — drop external_identity rows seeded by a test under
+	// a known source string (e.g., 'messages'). Used in raw_message ingest
+	// integration tests to ensure shared-DB cleanup is complete between
+	// runs.
+	DeleteExternalIdentitiesBySource(ctx context.Context, source string) (int64, error)
 	DeleteExternalIdentitiesBySourceID(ctx context.Context, sourceID pgtype.Text) (int64, error)
 	DeleteIdentitiesForContact(ctx context.Context, contactID pgtype.UUID) error
 	DeleteIdentity(ctx context.Context, id pgtype.UUID) error
@@ -193,6 +209,11 @@ type Querier interface {
 	// Delete all OAuth credentials for a provider
 	DeleteOAuthCredentialByProvider(ctx context.Context, provider string) error
 	DeleteOldSyncLogs(ctx context.Context, createdAt pgtype.Timestamptz) error
+	// Test teardown — drop river_job rows whose kind is in the given
+	// array. Scoped to test-emitted kinds so we don't wipe production-
+	// shape rows on a shared DB. River doesn't expose a sqlc layer; this
+	// is the operator-test seam.
+	DeleteRiverJobsByKindAny(ctx context.Context, kinds []string) (int64, error)
 	DeleteSyncState(ctx context.Context, id pgtype.UUID) error
 	DeleteSyncStatesByAccountID(ctx context.Context, accountID pgtype.Text) error
 	DeleteTag(ctx context.Context, id pgtype.UUID) error

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -273,10 +273,26 @@ type Querier interface {
 	// Used by the shared aggregator (backend/internal/messaging/aggregation)
 	// for same-direction coalescing. source_ref_prefix should include
 	// trailing % for LIKE match.
+	//
+	// The ESCAPE clause lets adapters whose source-ref segments may
+	// contain `_` or `%` (e.g., Apple Messages chat.guid values like
+	// "iMessage;-;_chat-uuid_") supply their own escape character `\`
+	// without false-matching unrelated rows. Numeric-only chat IDs
+	// (Telegram) pass through unchanged since they never contain LIKE
+	// wildcards.
+	//
+	// The explicit ::text cast on the bind variable keeps sqlc inferring
+	// pgtype.Text for the parameter; without it the ESCAPE clause causes
+	// sqlc to fall back to []byte (Postgres treats the LIKE pattern as
+	// bytea-compatible in that form). Plain LIKE-on-text behavior is what
+	// the existing callers expect.
 	FindRecentInteractionBySourceAndDirection(ctx context.Context, arg FindRecentInteractionBySourceAndDirectionParams) (*Interaction, error)
 	// Source-neutral generalization of FindRecentOutboundTelegramInteraction.
 	// Used by the shared aggregator for time-based reply bridging on inbound
 	// sessions.
+	//
+	// ESCAPE clause: same rationale as FindRecentInteractionBySourceAndDirection.
+	// See that query for the ::text cast rationale.
 	FindRecentOutboundInteractionBySource(ctx context.Context, arg FindRecentOutboundInteractionBySourceParams) (*Interaction, error)
 	// Find the most recent outbound telegram interaction for a contact in a specific chat
 	// within a time window. source_ref_prefix should include trailing % for LIKE match.
@@ -515,6 +531,12 @@ type Querier interface {
 	// List past events that haven't updated last_contacted yet
 	ListPastEventsNeedingUpdate(ctx context.Context, arg ListPastEventsNeedingUpdateParams) ([]*CalendarEvent, error)
 	ListRecentSyncLogs(ctx context.Context, limit int32) ([]*ExternalSyncLog, error)
+	// Lists rows with matched_contact_id IS NULL — i.e., rows that the
+	// ingest service accepted into staging but couldn't match to a contact
+	// at the time. The crm-admin --messages-rematch-stranded command
+	// iterates this list to retroactively match rows after a contact_method
+	// is added.
+	ListStrandedMessagesMessages(ctx context.Context) ([]*MessagesMessage, error)
 	ListSyncLogsByState(ctx context.Context, arg ListSyncLogsByStateParams) ([]*ExternalSyncLog, error)
 	ListSyncStates(ctx context.Context) ([]*ExternalSyncState, error)
 	ListTags(ctx context.Context) ([]*Tag, error)
@@ -530,6 +552,12 @@ type Querier interface {
 	ListUnprocessedContactIDs(ctx context.Context) ([]pgtype.UUID, error)
 	ListUnprocessedMessagesByContact(ctx context.Context, matchedContactID pgtype.UUID) ([]*MessagesMessage, error)
 	ListUnprocessedMessagesByContactAndChat(ctx context.Context, arg ListUnprocessedMessagesByContactAndChatParams) ([]*MessagesMessage, error)
+	// Distinct chat_guid values for a contact with at least one eligible
+	// (unprocessed AND unclaimed-or-stale) staging row. Used by the
+	// messaging aggregator worker to drive per-chat AggregateForContact
+	// invocations — the chat-aware path is what preserves the engine's
+	// extend/bridge/coalesce contract (see spec §3 "Stage 2 — Aggregator").
+	ListUnprocessedMessagesChatsByContact(ctx context.Context, matchedContactID pgtype.UUID) ([]string, error)
 	// Claim-aware filter — same predicate shape as telegram_message.
 	ListUnprocessedMessagesContactIDs(ctx context.Context) ([]pgtype.UUID, error)
 	ListUnprocessedTelegramMessagesByContact(ctx context.Context, matchedContactID pgtype.UUID) ([]*TelegramMessage, error)
@@ -764,6 +792,11 @@ type Querier interface {
 	// planning read and this update; the caller re-reads and surfaces 409.
 	// metadata.backfill_complete is rewritten on every successful commit.
 	UpdateMacHostSyncCursor(ctx context.Context, arg UpdateMacHostSyncCursorParams) (*UpdateMacHostSyncCursorRow, error)
+	// Sets matched_contact_id + peer_normalized on a single stranded row.
+	// Scoped to rows that are still unmatched + unprocessed so a
+	// concurrent ingest path (a never-stranding daemon push for a peer
+	// that just got matched) cannot be overwritten by this admin path.
+	UpdateMatchedContactForStrandedMessage(ctx context.Context, arg UpdateMatchedContactForStrandedMessageParams) error
 	// Update the matched contact IDs for an event
 	UpdateMatchedContacts(ctx context.Context, arg UpdateMatchedContactsParams) (*CalendarEvent, error)
 	UpdateNote(ctx context.Context, arg UpdateNoteParams) (*Note, error)

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -80,6 +80,11 @@ type Querier interface {
 	// JSONB paths match the struct tags on scheduler.SyncProviderAccountArgs;
 	// TestSyncProviderAccountArgs_JSONContract guards the key names.
 	CountInFlightSyncJobs(ctx context.Context, arg CountInFlightSyncJobsParams) (int64, error)
+	// Test assertion — confirms exactly the expected interaction row exists
+	// for the (id, contact_id, source) tuple. Used by the raw_message
+	// end-to-end test to verify Stage 3 created the row the staging
+	// table's interaction_id points to.
+	CountInteractionsByIDContactAndSource(ctx context.Context, arg CountInteractionsByIDContactAndSourceParams) (int64, error)
 	// Count calendar events involving a contact (for merge preview)
 	CountMergeCalendarEvents(ctx context.Context, dollar_1 pgtype.UUID) (int64, error)
 	// Count contact methods for a contact (for merge preview)
@@ -104,6 +109,12 @@ type Querier interface {
 	// tests to assert a create/close/refresh job was enqueued without
 	// inlining raw SQL into Go test code (core.md rule 2).
 	CountRiverJobsByContactTask(ctx context.Context, arg CountRiverJobsByContactTaskParams) (int64, error)
+	// Test assertion — count ALL River jobs of the given kind (including
+	// finalized). When the test runs against a River client with active
+	// workers, jobs can be picked up and finalized between insert and
+	// assertion; counting by kind alone is timing-resilient. Cross-test
+	// pollution is bounded by DeleteRiverJobsByKindAny in test cleanup.
+	CountRiverJobsByKind(ctx context.Context, kind string) (int64, error)
 	// Test assertion — count unfinalized River jobs of the given kind.
 	// Used to verify ingest enqueues the expected number of aggregator
 	// jobs. River's own admin SQL is OK to query at the test boundary;
@@ -196,6 +207,10 @@ type Querier interface {
 	DeleteExternalIdentitiesBySourceID(ctx context.Context, sourceID pgtype.Text) (int64, error)
 	DeleteIdentitiesForContact(ctx context.Context, contactID pgtype.UUID) error
 	DeleteIdentity(ctx context.Context, id pgtype.UUID) error
+	// Test teardown — drops interactions seeded by a test under the given
+	// (contact_id, source) pair. Scoped to the seeded contact so production
+	// data is never wiped.
+	DeleteInteractionsByContactAndSource(ctx context.Context, arg DeleteInteractionsByContactAndSourceParams) (int64, error)
 	// Cascade-on-revoke: when a host is uninstalled, drop its push-cursor
 	// rows. Filters by strategy='push' so OAuth-driven rows that happen to
 	// share an account_id string can never be deleted by this path (defence

--- a/backend/internal/db/queries/interaction.sql
+++ b/backend/internal/db/queries/interaction.sql
@@ -84,11 +84,24 @@ LIMIT 1;
 -- Used by the shared aggregator (backend/internal/messaging/aggregation)
 -- for same-direction coalescing. source_ref_prefix should include
 -- trailing % for LIKE match.
+--
+-- The ESCAPE clause lets adapters whose source-ref segments may
+-- contain `_` or `%` (e.g., Apple Messages chat.guid values like
+-- "iMessage;-;_chat-uuid_") supply their own escape character `\`
+-- without false-matching unrelated rows. Numeric-only chat IDs
+-- (Telegram) pass through unchanged since they never contain LIKE
+-- wildcards.
+--
+-- The explicit ::text cast on the bind variable keeps sqlc inferring
+-- pgtype.Text for the parameter; without it the ESCAPE clause causes
+-- sqlc to fall back to []byte (Postgres treats the LIKE pattern as
+-- bytea-compatible in that form). Plain LIKE-on-text behavior is what
+-- the existing callers expect.
 SELECT * FROM interaction
 WHERE contact_id = sqlc.arg(contact_id)
   AND source = sqlc.arg(source)
   AND direction = sqlc.arg(direction)
-  AND source_ref LIKE sqlc.arg(source_ref_prefix)
+  AND source_ref LIKE sqlc.arg(source_ref_prefix)::text ESCAPE '\'
   AND occurred_at >= sqlc.arg(window_start)
   AND occurred_at <= sqlc.arg(window_end)
   AND deleted_at IS NULL
@@ -99,11 +112,14 @@ LIMIT 1;
 -- Source-neutral generalization of FindRecentOutboundTelegramInteraction.
 -- Used by the shared aggregator for time-based reply bridging on inbound
 -- sessions.
+--
+-- ESCAPE clause: same rationale as FindRecentInteractionBySourceAndDirection.
+-- See that query for the ::text cast rationale.
 SELECT * FROM interaction
 WHERE contact_id = sqlc.arg(contact_id)
   AND source = sqlc.arg(source)
   AND direction = 'outbound'
-  AND source_ref LIKE sqlc.arg(source_ref_prefix)
+  AND source_ref LIKE sqlc.arg(source_ref_prefix)::text ESCAPE '\'
   AND occurred_at >= sqlc.arg(window_start)
   AND occurred_at <= sqlc.arg(window_end)
   AND deleted_at IS NULL

--- a/backend/internal/db/queries/messages_message.sql
+++ b/backend/internal/db/queries/messages_message.sql
@@ -132,6 +132,45 @@ UPDATE messages_message
 SET claimed_at = NOW() - INTERVAL '10 minutes'
 WHERE id = ANY(@message_ids::uuid[]);
 
+-- name: ListUnprocessedMessagesChatsByContact :many
+-- Distinct chat_guid values for a contact with at least one eligible
+-- (unprocessed AND unclaimed-or-stale) staging row. Used by the
+-- messaging aggregator worker to drive per-chat AggregateForContact
+-- invocations — the chat-aware path is what preserves the engine's
+-- extend/bridge/coalesce contract (see spec §3 "Stage 2 — Aggregator").
+SELECT DISTINCT chat_guid
+FROM messages_message
+WHERE matched_contact_id = @matched_contact_id
+  AND processed_at IS NULL
+  AND (claimed_at IS NULL OR claimed_at < NOW() - INTERVAL '5 minutes')
+  AND deleted_at IS NULL
+ORDER BY chat_guid ASC;
+
+-- name: ListStrandedMessagesMessages :many
+-- Lists rows with matched_contact_id IS NULL — i.e., rows that the
+-- ingest service accepted into staging but couldn't match to a contact
+-- at the time. The crm-admin --messages-rematch-stranded command
+-- iterates this list to retroactively match rows after a contact_method
+-- is added.
+SELECT * FROM messages_message
+WHERE matched_contact_id IS NULL
+  AND processed_at IS NULL
+  AND deleted_at IS NULL
+ORDER BY sent_at;
+
+-- name: UpdateMatchedContactForStrandedMessage :exec
+-- Sets matched_contact_id + peer_normalized on a single stranded row.
+-- Scoped to rows that are still unmatched + unprocessed so a
+-- concurrent ingest path (a never-stranding daemon push for a peer
+-- that just got matched) cannot be overwritten by this admin path.
+UPDATE messages_message
+SET matched_contact_id = @matched_contact_id,
+    peer_normalized    = @peer_normalized
+WHERE id = @id
+  AND matched_contact_id IS NULL
+  AND processed_at IS NULL
+  AND deleted_at IS NULL;
+
 -- name: HardDeleteMessagesMessagesByMacHost :exec
 -- Test-only helper (mirrors HardDeleteTelegramMessagesByChatIDRange).
 -- Cleanup needs hard-delete because the upsert does not clear deleted_at

--- a/backend/internal/db/queries/test.sql
+++ b/backend/internal/db/queries/test.sql
@@ -66,3 +66,34 @@ DELETE FROM mac_host;
 
 -- name: DeleteAllPairingTokens :execrows
 DELETE FROM mac_host_pairing_token;
+
+-- name: DeleteExternalIdentitiesBySource :execrows
+-- Test teardown — drop external_identity rows seeded by a test under
+-- a known source string (e.g., 'messages'). Used in raw_message ingest
+-- integration tests to ensure shared-DB cleanup is complete between
+-- runs.
+DELETE FROM external_identity WHERE source = @source;
+
+-- name: DeleteEventsBySource :execrows
+-- Test teardown — drop event rows by source. Mirrors
+-- DeleteExternalIdentitiesBySource for the event log.
+DELETE FROM event WHERE source = @source;
+
+-- name: DeleteRiverJobsByKindAny :execrows
+-- Test teardown — drop river_job rows whose kind is in the given
+-- array. Scoped to test-emitted kinds so we don't wipe production-
+-- shape rows on a shared DB. River doesn't expose a sqlc layer; this
+-- is the operator-test seam.
+DELETE FROM river_job WHERE kind = ANY(@kinds::text[]);
+
+-- name: CountMessagesMessageByGuid :one
+-- Test assertion — count rows with the given guid (typically 0 or 1
+-- under the partial unique index). Used by duplicate-detection tests.
+SELECT COUNT(*) FROM messages_message WHERE guid = @guid;
+
+-- name: CountRiverJobsByKindUnfinalized :one
+-- Test assertion — count unfinalized River jobs of the given kind.
+-- Used to verify ingest enqueues the expected number of aggregator
+-- jobs. River's own admin SQL is OK to query at the test boundary;
+-- production code never reads river_job directly.
+SELECT COUNT(*) FROM river_job WHERE kind = @kind AND finalized_at IS NULL;

--- a/backend/internal/db/queries/test.sql
+++ b/backend/internal/db/queries/test.sql
@@ -97,3 +97,25 @@ SELECT COUNT(*) FROM messages_message WHERE guid = @guid;
 -- jobs. River's own admin SQL is OK to query at the test boundary;
 -- production code never reads river_job directly.
 SELECT COUNT(*) FROM river_job WHERE kind = @kind AND finalized_at IS NULL;
+
+-- name: CountRiverJobsByKind :one
+-- Test assertion — count ALL River jobs of the given kind (including
+-- finalized). When the test runs against a River client with active
+-- workers, jobs can be picked up and finalized between insert and
+-- assertion; counting by kind alone is timing-resilient. Cross-test
+-- pollution is bounded by DeleteRiverJobsByKindAny in test cleanup.
+SELECT COUNT(*) FROM river_job WHERE kind = @kind;
+
+-- name: DeleteInteractionsByContactAndSource :execrows
+-- Test teardown — drops interactions seeded by a test under the given
+-- (contact_id, source) pair. Scoped to the seeded contact so production
+-- data is never wiped.
+DELETE FROM interaction WHERE contact_id = @contact_id AND source = @source;
+
+-- name: CountInteractionsByIDContactAndSource :one
+-- Test assertion — confirms exactly the expected interaction row exists
+-- for the (id, contact_id, source) tuple. Used by the raw_message
+-- end-to-end test to verify Stage 3 created the row the staging
+-- table's interaction_id points to.
+SELECT COUNT(*) FROM interaction
+WHERE id = @id AND contact_id = @contact_id AND source = @source;

--- a/backend/internal/db/test.sql.go
+++ b/backend/internal/db/test.sql.go
@@ -33,6 +33,28 @@ func (q *Queries) CountExternalContactsByDisplayNamePrefix(ctx context.Context, 
 	return count, err
 }
 
+const CountInteractionsByIDContactAndSource = `-- name: CountInteractionsByIDContactAndSource :one
+SELECT COUNT(*) FROM interaction
+WHERE id = $1 AND contact_id = $2 AND source = $3
+`
+
+type CountInteractionsByIDContactAndSourceParams struct {
+	ID        pgtype.UUID `json:"id"`
+	ContactID pgtype.UUID `json:"contact_id"`
+	Source    string      `json:"source"`
+}
+
+// Test assertion — confirms exactly the expected interaction row exists
+// for the (id, contact_id, source) tuple. Used by the raw_message
+// end-to-end test to verify Stage 3 created the row the staging
+// table's interaction_id points to.
+func (q *Queries) CountInteractionsByIDContactAndSource(ctx context.Context, arg CountInteractionsByIDContactAndSourceParams) (int64, error) {
+	row := q.db.QueryRow(ctx, CountInteractionsByIDContactAndSource, arg.ID, arg.ContactID, arg.Source)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const CountMessagesMessageByGuid = `-- name: CountMessagesMessageByGuid :one
 SELECT COUNT(*) FROM messages_message WHERE guid = $1
 `
@@ -41,6 +63,22 @@ SELECT COUNT(*) FROM messages_message WHERE guid = $1
 // under the partial unique index). Used by duplicate-detection tests.
 func (q *Queries) CountMessagesMessageByGuid(ctx context.Context, guid string) (int64, error) {
 	row := q.db.QueryRow(ctx, CountMessagesMessageByGuid, guid)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const CountRiverJobsByKind = `-- name: CountRiverJobsByKind :one
+SELECT COUNT(*) FROM river_job WHERE kind = $1
+`
+
+// Test assertion — count ALL River jobs of the given kind (including
+// finalized). When the test runs against a River client with active
+// workers, jobs can be picked up and finalized between insert and
+// assertion; counting by kind alone is timing-resilient. Cross-test
+// pollution is bounded by DeleteRiverJobsByKindAny in test cleanup.
+func (q *Queries) CountRiverJobsByKind(ctx context.Context, kind string) (int64, error) {
+	row := q.db.QueryRow(ctx, CountRiverJobsByKind, kind)
 	var count int64
 	err := row.Scan(&count)
 	return count, err
@@ -187,6 +225,26 @@ DELETE FROM external_identity WHERE source_id = $1
 
 func (q *Queries) DeleteExternalIdentitiesBySourceID(ctx context.Context, sourceID pgtype.Text) (int64, error) {
 	result, err := q.db.Exec(ctx, DeleteExternalIdentitiesBySourceID, sourceID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const DeleteInteractionsByContactAndSource = `-- name: DeleteInteractionsByContactAndSource :execrows
+DELETE FROM interaction WHERE contact_id = $1 AND source = $2
+`
+
+type DeleteInteractionsByContactAndSourceParams struct {
+	ContactID pgtype.UUID `json:"contact_id"`
+	Source    string      `json:"source"`
+}
+
+// Test teardown — drops interactions seeded by a test under the given
+// (contact_id, source) pair. Scoped to the seeded contact so production
+// data is never wiped.
+func (q *Queries) DeleteInteractionsByContactAndSource(ctx context.Context, arg DeleteInteractionsByContactAndSourceParams) (int64, error) {
+	result, err := q.db.Exec(ctx, DeleteInteractionsByContactAndSource, arg.ContactID, arg.Source)
 	if err != nil {
 		return 0, err
 	}

--- a/backend/internal/db/test.sql.go
+++ b/backend/internal/db/test.sql.go
@@ -33,6 +33,34 @@ func (q *Queries) CountExternalContactsByDisplayNamePrefix(ctx context.Context, 
 	return count, err
 }
 
+const CountMessagesMessageByGuid = `-- name: CountMessagesMessageByGuid :one
+SELECT COUNT(*) FROM messages_message WHERE guid = $1
+`
+
+// Test assertion — count rows with the given guid (typically 0 or 1
+// under the partial unique index). Used by duplicate-detection tests.
+func (q *Queries) CountMessagesMessageByGuid(ctx context.Context, guid string) (int64, error) {
+	row := q.db.QueryRow(ctx, CountMessagesMessageByGuid, guid)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const CountRiverJobsByKindUnfinalized = `-- name: CountRiverJobsByKindUnfinalized :one
+SELECT COUNT(*) FROM river_job WHERE kind = $1 AND finalized_at IS NULL
+`
+
+// Test assertion — count unfinalized River jobs of the given kind.
+// Used to verify ingest enqueues the expected number of aggregator
+// jobs. River's own admin SQL is OK to query at the test boundary;
+// production code never reads river_job directly.
+func (q *Queries) CountRiverJobsByKindUnfinalized(ctx context.Context, kind string) (int64, error) {
+	row := q.db.QueryRow(ctx, CountRiverJobsByKindUnfinalized, kind)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const DeleteAllMacHosts = `-- name: DeleteAllMacHosts :execrows
 DELETE FROM mac_host
 `
@@ -99,6 +127,20 @@ func (q *Queries) DeleteContactsByNamePrefix(ctx context.Context, dollar_1 pgtyp
 	return result.RowsAffected(), nil
 }
 
+const DeleteEventsBySource = `-- name: DeleteEventsBySource :execrows
+DELETE FROM event WHERE source = $1
+`
+
+// Test teardown — drop event rows by source. Mirrors
+// DeleteExternalIdentitiesBySource for the event log.
+func (q *Queries) DeleteEventsBySource(ctx context.Context, source string) (int64, error) {
+	result, err := q.db.Exec(ctx, DeleteEventsBySource, source)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const DeleteExternalContactsByDisplayNamePrefix = `-- name: DeleteExternalContactsByDisplayNamePrefix :execrows
 DELETE FROM external_contact WHERE display_name LIKE $1 || '%'
 `
@@ -123,12 +165,44 @@ func (q *Queries) DeleteExternalContactsBySourceIDPrefix(ctx context.Context, do
 	return result.RowsAffected(), nil
 }
 
+const DeleteExternalIdentitiesBySource = `-- name: DeleteExternalIdentitiesBySource :execrows
+DELETE FROM external_identity WHERE source = $1
+`
+
+// Test teardown — drop external_identity rows seeded by a test under
+// a known source string (e.g., 'messages'). Used in raw_message ingest
+// integration tests to ensure shared-DB cleanup is complete between
+// runs.
+func (q *Queries) DeleteExternalIdentitiesBySource(ctx context.Context, source string) (int64, error) {
+	result, err := q.db.Exec(ctx, DeleteExternalIdentitiesBySource, source)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const DeleteExternalIdentitiesBySourceID = `-- name: DeleteExternalIdentitiesBySourceID :execrows
 DELETE FROM external_identity WHERE source_id = $1
 `
 
 func (q *Queries) DeleteExternalIdentitiesBySourceID(ctx context.Context, sourceID pgtype.Text) (int64, error) {
 	result, err := q.db.Exec(ctx, DeleteExternalIdentitiesBySourceID, sourceID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const DeleteRiverJobsByKindAny = `-- name: DeleteRiverJobsByKindAny :execrows
+DELETE FROM river_job WHERE kind = ANY($1::text[])
+`
+
+// Test teardown — drop river_job rows whose kind is in the given
+// array. Scoped to test-emitted kinds so we don't wipe production-
+// shape rows on a shared DB. River doesn't expose a sqlc layer; this
+// is the operator-test seam.
+func (q *Queries) DeleteRiverJobsByKindAny(ctx context.Context, kinds []string) (int64, error) {
+	result, err := q.db.Exec(ctx, DeleteRiverJobsByKindAny, kinds)
 	if err != nil {
 		return 0, err
 	}

--- a/backend/internal/events/kinds.go
+++ b/backend/internal/events/kinds.go
@@ -296,7 +296,7 @@ func IsCanonicalMessageType(t string) bool {
 type RawMessageReceivedPayload struct {
 	Version     int              `json:"version"`             // start at 1
 	HostID      uuid.UUID        `json:"host_id"`             // authenticated host that observed the row
-	Source      string           `json:"source"`              // "messages" only in PR4
+	Source      string           `json:"source"`              // currently "messages"
 	Guid        string           `json:"guid"`                // iMessage guid; primary dedup key
 	ChatID      string           `json:"chat_id"`             // chat.db chat.guid
 	PeerHandle  string           `json:"peer_handle"`         // raw phone/email as observed in chat.db
@@ -306,7 +306,7 @@ type RawMessageReceivedPayload struct {
 	IsGroup     bool             `json:"is_group"`            // group chat vs DM
 	SentAt      time.Time        `json:"sent_at"`             // from source, NOT daemon clock
 	ReplyToGuid *string          `json:"reply_to_guid,omitempty"`
-	Attachments []AttachmentMeta `json:"attachments,omitempty"` // metadata only; PR7 populates
+	Attachments []AttachmentMeta `json:"attachments,omitempty"` // metadata only; daemon populates when chat.db reader lands
 }
 
 // RawMessageSentPayload is the payload for KindRawMessageSent. Same

--- a/backend/internal/events/kinds.go
+++ b/backend/internal/events/kinds.go
@@ -30,6 +30,15 @@ const (
 	// §3.4.1) atomically with an interaction row insert. PR 2 declares
 	// the constant; PR 5 introduces the consumer that emits it.
 	KindInteractionRecorded Kind = "interaction.recorded"
+
+	// Daemon-emitted raw-message events. Published by the Mac daemon
+	// against /api/v1/ingest/events with host-auth. NOT consumed by any
+	// bus consumer — IngestService processes them inline within the
+	// per-event savepoint (identity match → staging upsert → aggregator
+	// enqueue). The event-log row exists for audit + (source, source_id)
+	// dedup on retries.
+	KindRawMessageReceived Kind = "raw_message.received"
+	KindRawMessageSent     Kind = "raw_message.sent"
 )
 
 // AllKinds enumerates every defined Kind. Used by tests to guard that
@@ -46,6 +55,8 @@ var AllKinds = []Kind{
 	KindInteractionManual,
 	KindContactMethodsAdded,
 	KindInteractionRecorded,
+	KindRawMessageReceived,
+	KindRawMessageSent,
 }
 
 // Envelope is the wire/DB shape passed through Bus.Publish. Payload is
@@ -241,6 +252,68 @@ type CadenceFieldsSnapshot struct {
 	ContactBy      *time.Time `json:"contact_by,omitempty"` // date-precision
 }
 
+// AttachmentMeta carries metadata-only descriptors for a message
+// attachment. No content; the daemon never ships attachment bytes
+// across the wire. Defined alongside RawMessage*Payload so the payload
+// struct compiles today; the field is `omitempty` so daemon clients
+// that don't yet ship attachments produce wire-compatible payloads.
+type AttachmentMeta struct {
+	Type     string  `json:"type"` // photo|audio|video|document|other
+	Filename *string `json:"filename,omitempty"`
+	MimeType *string `json:"mime_type,omitempty"`
+	Size     *int64  `json:"size,omitempty"`
+}
+
+// canonicalMessageTypes is the set of values accepted by
+// messages_message.message_type CHECK constraint. Matched verbatim
+// against the migration so payload validation rejects bad values
+// before the CHECK constraint aborts the ingest tx.
+var canonicalMessageTypes = map[string]struct{}{
+	"text":     {},
+	"photo":    {},
+	"audio":    {},
+	"video":    {},
+	"document": {},
+	"other":    {},
+}
+
+// IsCanonicalMessageType reports whether t is one of the six allowed
+// message_type values for messages_message. Used by ValidatePayload
+// for raw_message.* kinds and by the handler's pre-service validator.
+func IsCanonicalMessageType(t string) bool {
+	_, ok := canonicalMessageTypes[t]
+	return ok
+}
+
+// RawMessageReceivedPayload is the payload for KindRawMessageReceived,
+// emitted by the Mac daemon. Carries the full raw data needed by the
+// inline ingest handler to identity-match, upsert staging, and enqueue
+// the aggregator job. NOT consumed by any bus consumer — processed
+// inline within the ingest transaction.
+//
+// Version evolution: per spec §3.2, additive fields are V1-compatible;
+// breaking changes ship a V2 struct.
+type RawMessageReceivedPayload struct {
+	Version     int              `json:"version"`             // start at 1
+	HostID      uuid.UUID        `json:"host_id"`             // authenticated host that observed the row
+	Source      string           `json:"source"`              // "messages" only in PR4
+	Guid        string           `json:"guid"`                // iMessage guid; primary dedup key
+	ChatID      string           `json:"chat_id"`             // chat.db chat.guid
+	PeerHandle  string           `json:"peer_handle"`         // raw phone/email as observed in chat.db
+	PeerName    *string          `json:"peer_name,omitempty"` // sender's display name when available
+	Text        *string          `json:"text,omitempty"`      // full message body
+	MessageType string           `json:"message_type"`        // text|photo|audio|video|document|other
+	IsGroup     bool             `json:"is_group"`            // group chat vs DM
+	SentAt      time.Time        `json:"sent_at"`             // from source, NOT daemon clock
+	ReplyToGuid *string          `json:"reply_to_guid,omitempty"`
+	Attachments []AttachmentMeta `json:"attachments,omitempty"` // metadata only; PR7 populates
+}
+
+// RawMessageSentPayload is the payload for KindRawMessageSent. Same
+// shape as RawMessageReceivedPayload (the only difference is the kind
+// constant — used by the inline handler to set IsOutgoing on staging).
+type RawMessageSentPayload RawMessageReceivedPayload
+
 // kindPayloadTypes is the canonical Kind → payload-type registry used by
 // Marshal and Unmarshal to assert type-vs-kind consistency at runtime. Add
 // a row each time a new Kind + payload struct are introduced. Keep in sync
@@ -257,6 +330,8 @@ var kindPayloadTypes = map[Kind]reflect.Type{
 	KindInteractionManual:    reflect.TypeOf(InteractionManualPayload{}),
 	KindContactMethodsAdded:  reflect.TypeOf(ContactMethodsAddedPayload{}),
 	KindInteractionRecorded:  reflect.TypeOf(InteractionRecordedPayload{}),
+	KindRawMessageReceived:   reflect.TypeOf(RawMessageReceivedPayload{}),
+	KindRawMessageSent:       reflect.TypeOf(RawMessageSentPayload{}),
 }
 
 // IsKnownKind reports whether kind has a registered payload type. Used by
@@ -301,6 +376,23 @@ func ValidatePayload(env *Envelope) error {
 	dst := reflect.New(expected).Interface() // *P
 	if err := json.Unmarshal(env.Payload, dst); err != nil {
 		return fmt.Errorf("validate %s: %w", env.Kind, err)
+	}
+	// Per-kind value checks beyond structural decode. Currently the
+	// only kinds with strict value rules at the validate boundary are
+	// the raw_message.* daemon-emitted kinds: their MessageType must
+	// match the messages_message CHECK constraint set so a misshaped
+	// payload doesn't abort the ingest tx with a constraint violation.
+	switch env.Kind {
+	case KindRawMessageReceived:
+		p := dst.(*RawMessageReceivedPayload)
+		if p.MessageType != "" && !IsCanonicalMessageType(p.MessageType) {
+			return fmt.Errorf("validate %s: message_type %q is not in the canonical set", env.Kind, p.MessageType)
+		}
+	case KindRawMessageSent:
+		p := dst.(*RawMessageSentPayload)
+		if p.MessageType != "" && !IsCanonicalMessageType(p.MessageType) {
+			return fmt.Errorf("validate %s: message_type %q is not in the canonical set", env.Kind, p.MessageType)
+		}
 	}
 	return nil
 }

--- a/backend/internal/events/kinds_test.go
+++ b/backend/internal/events/kinds_test.go
@@ -531,9 +531,10 @@ func TestKindPayloadTypes_CoversAllKinds(t *testing.T) {
 
 // TestAllKinds_ExpectedCount guards against accidental Kind additions or
 // deletions from AllKinds without updating the spec. Current spec (§3.2)
-// declares exactly 10 kinds (9 raw-signal + 1 derived).
+// declares 10 base kinds (9 raw-signal + 1 derived) plus the two
+// daemon-emitted raw_message.* kinds introduced for the messages source.
 func TestAllKinds_ExpectedCount(t *testing.T) {
-	require.Len(t, AllKinds, 10)
+	require.Len(t, AllKinds, 12)
 }
 
 // TestIsKnownKind_CoversAllKinds is the positive side: every Kind declared
@@ -597,9 +598,110 @@ func buildCanonicalPayload(t *testing.T, kind Kind) json.RawMessage {
 		raw, err := Marshal(kind, InteractionRecordedPayload{Version: 1, ContactID: cid, InteractionID: uuid.New(), Direction: "mutual", OccurredAt: at, Source: "manual"})
 		require.NoError(t, err)
 		return raw
+	case KindRawMessageReceived:
+		raw, err := Marshal(kind, RawMessageReceivedPayload{
+			Version: 1, HostID: uuid.New(), Source: "messages",
+			Guid: "g-1", ChatID: "iMessage;-;chat-x", PeerHandle: "+15551234567",
+			MessageType: "text", SentAt: at,
+		})
+		require.NoError(t, err)
+		return raw
+	case KindRawMessageSent:
+		raw, err := Marshal(kind, RawMessageSentPayload{
+			Version: 1, HostID: uuid.New(), Source: "messages",
+			Guid: "g-2", ChatID: "iMessage;-;chat-x", PeerHandle: "+15551234567",
+			MessageType: "text", SentAt: at,
+		})
+		require.NoError(t, err)
+		return raw
 	}
 	t.Fatalf("unhandled kind %s", kind)
 	return nil
+}
+
+// TestMarshalUnmarshal_RawMessageReceived round-trips the daemon-emitted
+// raw_message.received payload including the omitempty optional fields.
+func TestMarshalUnmarshal_RawMessageReceived(t *testing.T) {
+	host := uuid.New()
+	name := "Alice"
+	text := "hello"
+	reply := "g-reply"
+	size := int64(123)
+	filename := "kitten.jpg"
+	mime := "image/jpeg"
+	original := RawMessageReceivedPayload{
+		Version: 1, HostID: host, Source: "messages",
+		Guid: "g-1", ChatID: "iMessage;-;chat-xyz", PeerHandle: "+15551234567",
+		PeerName: &name, Text: &text, MessageType: "photo", IsGroup: false,
+		SentAt:      time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC),
+		ReplyToGuid: &reply,
+		Attachments: []AttachmentMeta{
+			{Type: "photo", Filename: &filename, MimeType: &mime, Size: &size},
+		},
+	}
+	raw, err := Marshal(KindRawMessageReceived, original)
+	require.NoError(t, err)
+
+	env := &Envelope{Kind: KindRawMessageReceived, Payload: raw}
+	var decoded RawMessageReceivedPayload
+	require.NoError(t, Unmarshal(env, &decoded))
+	require.Equal(t, original, decoded)
+}
+
+// TestMarshalUnmarshal_RawMessageSent round-trips the outbound twin.
+func TestMarshalUnmarshal_RawMessageSent(t *testing.T) {
+	host := uuid.New()
+	original := RawMessageSentPayload{
+		Version: 1, HostID: host, Source: "messages",
+		Guid: "g-2", ChatID: "iMessage;-;chat-xyz", PeerHandle: "+15551234567",
+		MessageType: "text",
+		SentAt:      time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC),
+	}
+	raw, err := Marshal(KindRawMessageSent, original)
+	require.NoError(t, err)
+
+	env := &Envelope{Kind: KindRawMessageSent, Payload: raw}
+	var decoded RawMessageSentPayload
+	require.NoError(t, Unmarshal(env, &decoded))
+	require.Equal(t, original, decoded)
+}
+
+// TestValidatePayload_RawMessage_RejectsNonCanonicalMessageType asserts
+// the per-kind value check rejects a MessageType outside the canonical
+// CHECK-constraint set.
+func TestValidatePayload_RawMessage_RejectsNonCanonicalMessageType(t *testing.T) {
+	raw := json.RawMessage(`{
+		"version": 1,
+		"host_id": "00000000-0000-0000-0000-000000000001",
+		"source": "messages",
+		"guid": "g-1",
+		"chat_id": "iMessage;-;chat-xyz",
+		"peer_handle": "+15551234567",
+		"message_type": "sticker",
+		"sent_at": "2026-04-10T12:00:00Z"
+	}`)
+	env := &Envelope{Kind: KindRawMessageReceived, Payload: raw}
+	err := ValidatePayload(env)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "message_type")
+}
+
+// TestValidatePayload_RawMessage_AcceptsAllCanonicalMessageTypes covers
+// every value in the canonical set passes ValidatePayload.
+func TestValidatePayload_RawMessage_AcceptsAllCanonicalMessageTypes(t *testing.T) {
+	at := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+	for _, mt := range []string{"text", "photo", "audio", "video", "document", "other"} {
+		t.Run(mt, func(t *testing.T) {
+			raw, err := Marshal(KindRawMessageReceived, RawMessageReceivedPayload{
+				Version: 1, HostID: uuid.New(), Source: "messages",
+				Guid: "g-" + mt, ChatID: "iMessage;-;chat-x", PeerHandle: "+1",
+				MessageType: mt, SentAt: at,
+			})
+			require.NoError(t, err)
+			env := &Envelope{Kind: KindRawMessageReceived, Payload: raw}
+			require.NoError(t, ValidatePayload(env))
+		})
+	}
 }
 
 // TestValidatePayload_AllKindsRoundTrip exercises the validate-only helper

--- a/backend/internal/messages/admin_rematch.go
+++ b/backend/internal/messages/admin_rematch.go
@@ -1,0 +1,132 @@
+package messages
+
+import (
+	"context"
+	"fmt"
+
+	"personal-crm/backend/internal/consumer/consumerjobs"
+	"personal-crm/backend/internal/identity"
+	"personal-crm/backend/internal/logger"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/riverqueue/river"
+)
+
+// RematchStrandedDeps bundles the repos + services used by the
+// stranded-row remediation handler.
+//
+// IdentityService runs in non-tx mode here intentionally: the admin
+// path is a one-shot batch utility, not the hot ingest path. A
+// transient match error per row degrades to MatchTypeUnmatched (the
+// existing forgiving behavior) and the operator can re-run.
+type RematchStrandedDeps struct {
+	Messages      *repository.MessagesMessageRepository
+	Identity      *service.IdentityService
+	RiverClient   *river.Client[pgx.Tx]
+	DefaultSource string // "messages"
+}
+
+// RematchStrandedResult summarizes a remediation pass for the
+// operator. Counts are emitted on stdout/log when the binary returns.
+type RematchStrandedResult struct {
+	Scanned       int
+	Matched       int
+	StillStranded int
+	Enqueued      int
+	Errors        int
+}
+
+// RematchStranded retroactively matches messages_message rows whose
+// matched_contact_id is NULL against the current contact_method set.
+// Newly-matched rows get their matched_contact_id + peer_normalized
+// updated; a MessagingAggregateForContactArgs River job is enqueued
+// per unique newly-matched (contact, source) pair so the aggregator
+// drains them.
+//
+// Idempotent — re-running on an already-matched row is a no-op (the
+// SQL predicate scopes updates to still-unmatched rows). Safe to run
+// from a cron-style cleanup, though it's intended as a one-shot
+// operator utility right now.
+func RematchStranded(ctx context.Context, deps RematchStrandedDeps) (*RematchStrandedResult, error) {
+	if deps.Messages == nil {
+		return nil, fmt.Errorf("messages repository is required")
+	}
+	if deps.Identity == nil {
+		return nil, fmt.Errorf("identity service is required")
+	}
+	source := deps.DefaultSource
+	if source == "" {
+		source = SourceName
+	}
+
+	rows, err := deps.Messages.ListStranded(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list stranded rows: %w", err)
+	}
+
+	result := &RematchStrandedResult{Scanned: len(rows)}
+	enqueued := make(map[uuid.UUID]struct{})
+
+	for i := range rows {
+		row := rows[i]
+		idType := identity.DetectIdentifierType(row.PeerHandle)
+		matchReq := service.MatchRequest{
+			RawIdentifier: row.PeerHandle,
+			Type:          idType,
+			Source:        source,
+			SourceID:      &row.Guid,
+		}
+		match, err := deps.Identity.MatchOrCreate(ctx, matchReq)
+		if err != nil {
+			result.Errors++
+			logger.Warn().Err(err).Str("guid", row.Guid).Msg("rematch: identity match failed")
+			continue
+		}
+		if match.ContactID == nil {
+			result.StillStranded++
+			continue
+		}
+		normalized := ""
+		if match.Identity != nil {
+			normalized = match.Identity.Identifier
+		}
+		err = deps.Messages.UpdateMatchedContact(ctx, repository.UpdateMatchedContactParams{
+			ID:               row.ID,
+			MatchedContactID: *match.ContactID,
+			PeerNormalized:   normalized,
+		})
+		if err != nil {
+			result.Errors++
+			logger.Warn().Err(err).Str("guid", row.Guid).Msg("rematch: update failed")
+			continue
+		}
+		result.Matched++
+
+		// Enqueue one River job per unique newly-matched contact.
+		// UniqueOpts dedup against in-flight jobs makes this cheap if
+		// the regular ingest path already enqueued one.
+		if _, seen := enqueued[*match.ContactID]; seen {
+			continue
+		}
+		if deps.RiverClient != nil {
+			_, err = deps.RiverClient.Insert(ctx, consumerjobs.MessagingAggregateForContactArgs{
+				ContactID: *match.ContactID,
+				Source:    source,
+			}, &river.InsertOpts{
+				UniqueOpts: river.UniqueOpts{ByArgs: true},
+			})
+			if err != nil {
+				result.Errors++
+				logger.Warn().Err(err).Str("contact_id", match.ContactID.String()).Msg("rematch: enqueue failed")
+				continue
+			}
+			result.Enqueued++
+		}
+		enqueued[*match.ContactID] = struct{}{}
+	}
+
+	return result, nil
+}

--- a/backend/internal/messages/admin_rematch.go
+++ b/backend/internal/messages/admin_rematch.go
@@ -11,9 +11,32 @@ import (
 	"personal-crm/backend/internal/service"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5"
 	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
 )
+
+// AdminStrandedLister is the narrow surface RematchStranded uses to
+// enumerate stranded rows. Concrete is *repository.MessagesMessageRepository.
+type AdminStrandedLister interface {
+	ListStranded(ctx context.Context) ([]repository.MessagesMessage, error)
+	UpdateMatchedContact(ctx context.Context, params repository.UpdateMatchedContactParams) error
+}
+
+// AdminIdentityMatcher is the narrow surface RematchStranded uses to
+// run identity match. Concrete is *service.IdentityService (non-tx —
+// the admin path is a one-shot batch utility, not the hot ingest
+// path).
+type AdminIdentityMatcher interface {
+	MatchOrCreate(ctx context.Context, req service.MatchRequest) (*service.MatchResult, error)
+}
+
+// AdminRiverInserter is the narrow surface RematchStranded uses to
+// enqueue MessagingAggregateForContactArgs jobs. Concrete is
+// *river.Client[pgx.Tx]. Pass nil to disable enqueue (useful in
+// dry-run mode).
+type AdminRiverInserter interface {
+	Insert(ctx context.Context, args river.JobArgs, opts *river.InsertOpts) (*rivertype.JobInsertResult, error)
+}
 
 // RematchStrandedDeps bundles the repos + services used by the
 // stranded-row remediation handler.
@@ -23,9 +46,9 @@ import (
 // transient match error per row degrades to MatchTypeUnmatched (the
 // existing forgiving behavior) and the operator can re-run.
 type RematchStrandedDeps struct {
-	Messages      *repository.MessagesMessageRepository
-	Identity      *service.IdentityService
-	RiverClient   *river.Client[pgx.Tx]
+	Messages      AdminStrandedLister
+	Identity      AdminIdentityMatcher
+	RiverClient   AdminRiverInserter
 	DefaultSource string // "messages"
 }
 

--- a/backend/internal/messages/admin_rematch_test.go
+++ b/backend/internal/messages/admin_rematch_test.go
@@ -1,0 +1,266 @@
+package messages
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"personal-crm/backend/internal/consumer/consumerjobs"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+
+	"github.com/google/uuid"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
+	"github.com/stretchr/testify/require"
+)
+
+type stubStrandedLister struct {
+	rows      []repository.MessagesMessage
+	listErr   error
+	updateErr error
+	updates   []repository.UpdateMatchedContactParams
+}
+
+func (s *stubStrandedLister) ListStranded(_ context.Context) ([]repository.MessagesMessage, error) {
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
+	return s.rows, nil
+}
+
+func (s *stubStrandedLister) UpdateMatchedContact(_ context.Context, params repository.UpdateMatchedContactParams) error {
+	s.updates = append(s.updates, params)
+	return s.updateErr
+}
+
+type stubAdminMatcher struct {
+	// resultsByHandle maps a peer handle to its match result. Missing
+	// handles return (nil match, nil err) which the rematch code treats
+	// as "still unmatched".
+	resultsByHandle map[string]*service.MatchResult
+	errByHandle     map[string]error
+}
+
+func (s *stubAdminMatcher) MatchOrCreate(_ context.Context, req service.MatchRequest) (*service.MatchResult, error) {
+	if s.errByHandle != nil {
+		if err, ok := s.errByHandle[req.RawIdentifier]; ok {
+			return nil, err
+		}
+	}
+	if r, ok := s.resultsByHandle[req.RawIdentifier]; ok {
+		return r, nil
+	}
+	// Default: still unmatched.
+	return &service.MatchResult{ContactID: nil, MatchType: repository.MatchTypeUnmatched}, nil
+}
+
+type stubAdminInserter struct {
+	calls []consumerjobs.MessagingAggregateForContactArgs
+	err   error
+}
+
+func (s *stubAdminInserter) Insert(_ context.Context, args river.JobArgs, _ *river.InsertOpts) (*rivertype.JobInsertResult, error) {
+	if a, ok := args.(consumerjobs.MessagingAggregateForContactArgs); ok {
+		s.calls = append(s.calls, a)
+	}
+	if s.err != nil {
+		return nil, s.err
+	}
+	return &rivertype.JobInsertResult{}, nil
+}
+
+// TestRematchStranded_HappyPath_MatchesAndEnqueues asserts a stranded
+// row gets matched, updated, and enqueued.
+func TestRematchStranded_HappyPath_MatchesAndEnqueues(t *testing.T) {
+	contactID := uuid.New()
+	rowID := uuid.New()
+	lister := &stubStrandedLister{
+		rows: []repository.MessagesMessage{
+			{ID: rowID, Guid: "guid-1", PeerHandle: "+15551234567"},
+		},
+	}
+	matcher := &stubAdminMatcher{
+		resultsByHandle: map[string]*service.MatchResult{
+			"+15551234567": {
+				ContactID: &contactID,
+				MatchType: repository.MatchTypeExact,
+				Identity:  &repository.ExternalIdentity{Identifier: "+15551234567"},
+			},
+		},
+	}
+	inserter := &stubAdminInserter{}
+
+	res, err := RematchStranded(context.Background(), RematchStrandedDeps{
+		Messages:    lister,
+		Identity:    matcher,
+		RiverClient: inserter,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, res.Scanned)
+	require.Equal(t, 1, res.Matched)
+	require.Equal(t, 0, res.StillStranded)
+	require.Equal(t, 1, res.Enqueued)
+	require.Equal(t, 0, res.Errors)
+
+	require.Len(t, lister.updates, 1)
+	require.Equal(t, rowID, lister.updates[0].ID)
+	require.Equal(t, contactID, lister.updates[0].MatchedContactID)
+	require.Equal(t, "+15551234567", lister.updates[0].PeerNormalized)
+
+	require.Len(t, inserter.calls, 1)
+	require.Equal(t, contactID, inserter.calls[0].ContactID)
+	require.Equal(t, "messages", inserter.calls[0].Source)
+}
+
+// TestRematchStranded_StillUnmatched_NoUpdateOrEnqueue verifies a
+// stranded row that still has no contact_method match produces no
+// updates or enqueues.
+func TestRematchStranded_StillUnmatched_NoUpdateOrEnqueue(t *testing.T) {
+	lister := &stubStrandedLister{
+		rows: []repository.MessagesMessage{
+			{ID: uuid.New(), Guid: "guid-2", PeerHandle: "+15559999999"},
+		},
+	}
+	matcher := &stubAdminMatcher{} // no entries → unmatched
+	inserter := &stubAdminInserter{}
+
+	res, err := RematchStranded(context.Background(), RematchStrandedDeps{
+		Messages:    lister,
+		Identity:    matcher,
+		RiverClient: inserter,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, res.Scanned)
+	require.Equal(t, 0, res.Matched)
+	require.Equal(t, 1, res.StillStranded)
+	require.Equal(t, 0, res.Enqueued)
+	require.Empty(t, lister.updates)
+	require.Empty(t, inserter.calls)
+}
+
+// TestRematchStranded_DuplicateContact_EnqueuesOnce verifies that when
+// multiple stranded rows match the same contact, only ONE River job
+// is enqueued for that contact.
+func TestRematchStranded_DuplicateContact_EnqueuesOnce(t *testing.T) {
+	contactID := uuid.New()
+	lister := &stubStrandedLister{
+		rows: []repository.MessagesMessage{
+			{ID: uuid.New(), Guid: "guid-A", PeerHandle: "+15551234567"},
+			{ID: uuid.New(), Guid: "guid-B", PeerHandle: "+15551234567"},
+		},
+	}
+	matcher := &stubAdminMatcher{
+		resultsByHandle: map[string]*service.MatchResult{
+			"+15551234567": {
+				ContactID: &contactID,
+				MatchType: repository.MatchTypeExact,
+				Identity:  &repository.ExternalIdentity{Identifier: "+15551234567"},
+			},
+		},
+	}
+	inserter := &stubAdminInserter{}
+
+	res, err := RematchStranded(context.Background(), RematchStrandedDeps{
+		Messages:    lister,
+		Identity:    matcher,
+		RiverClient: inserter,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, res.Scanned)
+	require.Equal(t, 2, res.Matched)
+	require.Equal(t, 1, res.Enqueued, "duplicate contact must enqueue exactly one job")
+	require.Len(t, inserter.calls, 1)
+}
+
+// TestRematchStranded_IdentityError_CountsAndContinues asserts a per-
+// row identity error increments Errors and the loop continues.
+func TestRematchStranded_IdentityError_CountsAndContinues(t *testing.T) {
+	contactID := uuid.New()
+	lister := &stubStrandedLister{
+		rows: []repository.MessagesMessage{
+			{ID: uuid.New(), Guid: "guid-A", PeerHandle: "boom"},
+			{ID: uuid.New(), Guid: "guid-B", PeerHandle: "+15551234567"},
+		},
+	}
+	matcher := &stubAdminMatcher{
+		errByHandle: map[string]error{
+			"boom": errors.New("db unavailable"),
+		},
+		resultsByHandle: map[string]*service.MatchResult{
+			"+15551234567": {
+				ContactID: &contactID,
+				MatchType: repository.MatchTypeExact,
+				Identity:  &repository.ExternalIdentity{Identifier: "+15551234567"},
+			},
+		},
+	}
+	inserter := &stubAdminInserter{}
+
+	res, err := RematchStranded(context.Background(), RematchStrandedDeps{
+		Messages:    lister,
+		Identity:    matcher,
+		RiverClient: inserter,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, res.Scanned)
+	require.Equal(t, 1, res.Matched, "the healthy row must still be matched")
+	require.Equal(t, 1, res.Errors)
+}
+
+// TestRematchStranded_NilRiverClient_StillUpdates verifies the
+// remediation handler updates rows even when no river client is
+// wired — useful for dry-run / preview mode.
+func TestRematchStranded_NilRiverClient_StillUpdates(t *testing.T) {
+	contactID := uuid.New()
+	lister := &stubStrandedLister{
+		rows: []repository.MessagesMessage{
+			{ID: uuid.New(), Guid: "guid-1", PeerHandle: "+15551234567"},
+		},
+	}
+	matcher := &stubAdminMatcher{
+		resultsByHandle: map[string]*service.MatchResult{
+			"+15551234567": {
+				ContactID: &contactID,
+				MatchType: repository.MatchTypeExact,
+				Identity:  &repository.ExternalIdentity{Identifier: "+15551234567"},
+			},
+		},
+	}
+
+	res, err := RematchStranded(context.Background(), RematchStrandedDeps{
+		Messages: lister,
+		Identity: matcher,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, res.Matched)
+	require.Equal(t, 0, res.Enqueued, "no enqueue without river client")
+	require.Len(t, lister.updates, 1)
+}
+
+// TestRematchStranded_RequiresMessagesAndIdentity verifies the
+// precondition checks.
+func TestRematchStranded_RequiresMessagesAndIdentity(t *testing.T) {
+	_, err := RematchStranded(context.Background(), RematchStrandedDeps{})
+	require.Error(t, err)
+
+	_, err = RematchStranded(context.Background(), RematchStrandedDeps{
+		Messages: &stubStrandedLister{},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "identity service")
+}
+
+// TestRematchStranded_ListError_Bubbles surfaces a list-level error
+// (vs. per-row errors which count and continue).
+func TestRematchStranded_ListError_Bubbles(t *testing.T) {
+	lister := &stubStrandedLister{listErr: errors.New("list down")}
+	matcher := &stubAdminMatcher{}
+
+	_, err := RematchStranded(context.Background(), RematchStrandedDeps{
+		Messages: lister,
+		Identity: matcher,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "list stranded rows")
+}

--- a/backend/internal/messages/aggregation_adapter.go
+++ b/backend/internal/messages/aggregation_adapter.go
@@ -97,7 +97,7 @@ func (messagesAdapter) SourceRef(chatID, firstExternalID string) string {
 // Apple Messages chat.guid values are opaque strings that empirically
 // contain `_` (e.g., "iMessage;-;_chat-uuid_") — `_` and `%` are
 // PostgreSQL LIKE wildcards. We escape them with `\` per the
-// SourceAdapter contract (PR2). The underlying sqlc queries use
+// SourceAdapter contract. The underlying sqlc queries use
 // `LIKE pattern ESCAPE '\'` so the explicit escape character takes
 // effect.
 //

--- a/backend/internal/messages/aggregation_adapter.go
+++ b/backend/internal/messages/aggregation_adapter.go
@@ -1,0 +1,264 @@
+package messages
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/messaging/aggregation"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// SourceName is the source string written into interaction.source,
+// event.source, external_sync_state.source, and the river job args.
+// The four MUST agree (spec §3 source naming matrix).
+const SourceName = "messages"
+
+// NewAggregationEngine constructs a shared aggregator engine instance
+// configured for the messages source. Mirror of telegram's
+// NewAggregationEngine — same nil-safety conventions; production
+// wiring passes all three of (pool, eventBus, enqueuer).
+//
+// The returned engine is the chat-aware producer used by both:
+//   - the MessagingAggregateForContactWorker (per-chat invocation over
+//     the contact's distinct unprocessed chats); and
+//   - the MessagesAggregatorReenqueuer (post-Stage-3 re-aggregation
+//     for the chat just processed).
+func NewAggregationEngine(
+	burstWindowHours, replyBridgeHours int,
+	messageRepo *repository.MessagesMessageRepository,
+	interactionRepo *repository.InteractionRepository,
+	promoter aggregation.InteractionPromoter,
+	extender aggregation.InteractionExtender,
+	eventBus *events.Bus,
+	pool aggregation.TxBeginner,
+	enqueuer aggregation.ConsumerJobEnqueuer,
+) *aggregation.Engine {
+	adapter := messagesAdapter{}
+	store := &messagesMessageStoreAdapter{repo: messageRepo}
+	finder := &interactionFinderAdapter{repo: interactionRepo}
+
+	// Untyped-nil propagation — see telegram/aggregation.go for the
+	// rationale (typed-nil concrete pointer would silently bypass
+	// engine guards on publisher == nil).
+	var pub aggregation.EventPublisher
+	if eventBus != nil {
+		pub = eventBus
+	}
+	var lookup aggregation.EventLookup
+	if eventBus != nil {
+		lookup = &busEventLookup{bus: eventBus}
+	}
+
+	return aggregation.NewEngine(
+		adapter,
+		store,
+		finder,
+		promoter,
+		extender,
+		pub,
+		burstWindowHours,
+		replyBridgeHours,
+		pool,
+		lookup,
+		enqueuer,
+	)
+}
+
+// --- adapters --------------------------------------------------------
+
+// messagesAdapter binds source-name + format hooks for the messages
+// source. Wire format:
+//   - SourceRef:   "messages:<chat_guid>:<first_guid>"
+//   - PeerRef:     "messages:<chat_guid>"
+//   - Description: "Messages <label> (<n> messages)"
+type messagesAdapter struct{}
+
+// SourceName returns the source string written into interaction.source.
+func (messagesAdapter) SourceName() string {
+	return SourceName
+}
+
+// SourceRef formats the deterministic burst sourceRef.
+func (messagesAdapter) SourceRef(chatID, firstExternalID string) string {
+	return SourceName + ":" + chatID + ":" + firstExternalID
+}
+
+// SourceRefPrefix returns the LIKE pattern for scoped "recent
+// interaction in this chat" queries.
+//
+// Apple Messages chat.guid values are opaque strings that empirically
+// contain `_` (e.g., "iMessage;-;_chat-uuid_") — `_` and `%` are
+// PostgreSQL LIKE wildcards. We escape them with `\` per the
+// SourceAdapter contract (PR2). The underlying sqlc queries use
+// `LIKE pattern ESCAPE '\'` so the explicit escape character takes
+// effect.
+//
+// The replacer also escapes a literal `\` in the chat ID itself —
+// belt-and-suspenders for forward compatibility if Apple ever ships
+// a chat.guid with a backslash.
+func (messagesAdapter) SourceRefPrefix(chatID string) string {
+	escaped := strings.NewReplacer(
+		`\`, `\\`,
+		`%`, `\%`,
+		`_`, `\_`,
+	).Replace(chatID)
+	return SourceName + ":" + escaped + ":%"
+}
+
+// PeerRef formats the event-payload PeerRef field. NOT a LIKE
+// pattern — escape is not applied because the consumer's reenqueuer
+// parses this field with a literal string strip.
+func (messagesAdapter) PeerRef(chatID string) string {
+	return SourceName + ":" + chatID
+}
+
+// Description formats the human-readable interaction description.
+// Label phrasing mirrors Telegram (outreach/response/exchange) so UI
+// surfaces stay consistent across sources.
+func (messagesAdapter) Description(direction string, msgCount int) string {
+	label := "exchange"
+	switch direction {
+	case repository.InteractionDirectionOutbound:
+		label = "outreach"
+	case repository.InteractionDirectionInbound:
+		label = "response"
+	}
+	return fmt.Sprintf("Messages %s (%d messages)", label, msgCount)
+}
+
+// messagesMessageStoreAdapter projects repository.MessagesMessage rows
+// into aggregation.Message. Same pattern as the telegram store
+// adapter; lives here (not in repository) so the repository package
+// stays free of aggregation-package imports.
+type messagesMessageStoreAdapter struct {
+	repo *repository.MessagesMessageRepository
+}
+
+func (a *messagesMessageStoreAdapter) ListUnprocessedContactIDs(ctx context.Context) ([]uuid.UUID, error) {
+	return a.repo.ListUnprocessedContactIDs(ctx)
+}
+
+func (a *messagesMessageStoreAdapter) ListUnprocessedByContact(ctx context.Context, contactID uuid.UUID) ([]aggregation.Message, error) {
+	rows, err := a.repo.ListUnprocessedByContact(ctx, contactID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]aggregation.Message, len(rows))
+	for i := range rows {
+		out[i] = mapMessagesMessage(rows[i])
+	}
+	return out, nil
+}
+
+func (a *messagesMessageStoreAdapter) ListUnprocessedByContactAndChat(ctx context.Context, contactID uuid.UUID, chatID string) ([]aggregation.Message, error) {
+	rows, err := a.repo.ListUnprocessedByContactAndChat(ctx, contactID, chatID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]aggregation.Message, len(rows))
+	for i := range rows {
+		out[i] = mapMessagesMessage(rows[i])
+	}
+	return out, nil
+}
+
+// GetMessageByReplyTarget resolves the message referenced by a reply.
+// The messages source uses opaque string guids — no parse step is
+// needed (telegram has to parse int64; we don't).
+func (a *messagesMessageStoreAdapter) GetMessageByReplyTarget(ctx context.Context, chatID, replyTargetID string) (aggregation.Message, bool, error) {
+	row, err := a.repo.GetMessageByReplyTarget(ctx, chatID, replyTargetID)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return aggregation.Message{}, false, nil
+		}
+		return aggregation.Message{}, false, err
+	}
+	return mapMessagesMessage(*row), true, nil
+}
+
+func (a *messagesMessageStoreAdapter) MarkProcessed(ctx context.Context, messageIDs []uuid.UUID, interactionID uuid.UUID) error {
+	return a.repo.MarkMessagesProcessed(ctx, messageIDs, interactionID)
+}
+
+func (a *messagesMessageStoreAdapter) ClaimRowsTx(ctx context.Context, tx pgx.Tx, messageIDs []uuid.UUID, sessionRef string) ([]uuid.UUID, error) {
+	return a.repo.ClaimMessagesTx(ctx, tx, messageIDs, sessionRef)
+}
+
+func (a *messagesMessageStoreAdapter) ClearStaleClaimTx(ctx context.Context, tx pgx.Tx, messageIDs []uuid.UUID, expectedSessionRef string) error {
+	return a.repo.ClearStaleClaimTx(ctx, tx, messageIDs, expectedSessionRef)
+}
+
+// mapMessagesMessage projects a repository.MessagesMessage into the
+// source-neutral aggregation.Message. Preserving InteractionID is
+// critical for cross-batch explicit reply bridging. ClaimedAt /
+// ClaimedSessionRef are required for stale-claim / boundary-shift
+// recovery detection (spec §3 Race Mechanics).
+func mapMessagesMessage(m repository.MessagesMessage) aggregation.Message {
+	out := aggregation.Message{
+		ID:                m.ID,
+		ChatID:            m.ChatGuid,
+		IsOutgoing:        m.IsOutgoing,
+		SentAt:            m.SentAt,
+		ExternalID:        m.Guid,
+		InteractionID:     m.InteractionID,
+		ClaimedAt:         m.ClaimedAt,
+		ClaimedSessionRef: m.ClaimedSessionRef,
+	}
+	if m.ReplyToGuid != nil {
+		s := *m.ReplyToGuid
+		out.ReplyTargetID = &s
+	}
+	return out
+}
+
+// busEventLookup adapts *events.Bus to aggregation.EventLookup. Same
+// shape as the telegram adapter's busEventLookup.
+type busEventLookup struct{ bus *events.Bus }
+
+func (l *busEventLookup) FindEventBySourceRef(ctx context.Context, source, sourceID string) (uuid.UUID, bool, error) {
+	env, err := l.bus.FindEventBySource(ctx, source, sourceID)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return uuid.Nil, false, nil
+		}
+		return uuid.Nil, false, err
+	}
+	return env.ID, true, nil
+}
+
+// interactionFinderAdapter wraps *repository.InteractionRepository and
+// exposes the source-neutral aggregation.InteractionFinder surface.
+// Same shape as the telegram adapter's interactionFinderAdapter.
+type interactionFinderAdapter struct {
+	repo *repository.InteractionRepository
+}
+
+func (a *interactionFinderAdapter) FindRecentBySourceAndDirection(
+	ctx context.Context,
+	contactID uuid.UUID,
+	source, direction, sourceRefPrefix string,
+	windowStart, windowEnd time.Time,
+) (*repository.Interaction, error) {
+	return a.repo.FindRecentInteractionBySourceAndDirection(ctx, contactID, source, direction, sourceRefPrefix, windowStart, windowEnd)
+}
+
+func (a *interactionFinderAdapter) FindRecentOutboundBySource(
+	ctx context.Context,
+	contactID uuid.UUID,
+	source, sourceRefPrefix string,
+	windowStart, windowEnd time.Time,
+) (*repository.Interaction, error) {
+	return a.repo.FindRecentOutboundInteractionBySource(ctx, contactID, source, sourceRefPrefix, windowStart, windowEnd)
+}
+
+func (a *interactionFinderAdapter) GetInteraction(ctx context.Context, id uuid.UUID) (*repository.Interaction, error) {
+	return a.repo.GetInteraction(ctx, id)
+}

--- a/backend/internal/messages/aggregation_adapter_test.go
+++ b/backend/internal/messages/aggregation_adapter_test.go
@@ -1,0 +1,80 @@
+package messages
+
+import (
+	"testing"
+
+	"personal-crm/backend/internal/repository"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMessagesAdapter_SourceName(t *testing.T) {
+	require.Equal(t, "messages", messagesAdapter{}.SourceName())
+}
+
+func TestMessagesAdapter_SourceRef_Format(t *testing.T) {
+	got := messagesAdapter{}.SourceRef("iMessage;-;chat-uuid", "guid-1")
+	require.Equal(t, "messages:iMessage;-;chat-uuid:guid-1", got)
+}
+
+func TestMessagesAdapter_PeerRef_Format(t *testing.T) {
+	got := messagesAdapter{}.PeerRef("iMessage;-;chat-uuid")
+	require.Equal(t, "messages:iMessage;-;chat-uuid", got)
+}
+
+func TestMessagesAdapter_Description_Outbound(t *testing.T) {
+	got := messagesAdapter{}.Description(repository.InteractionDirectionOutbound, 3)
+	require.Equal(t, "Messages outreach (3 messages)", got)
+}
+
+func TestMessagesAdapter_Description_Inbound(t *testing.T) {
+	got := messagesAdapter{}.Description(repository.InteractionDirectionInbound, 1)
+	require.Equal(t, "Messages response (1 messages)", got)
+}
+
+func TestMessagesAdapter_Description_Mutual_DefaultsToExchange(t *testing.T) {
+	got := messagesAdapter{}.Description(repository.InteractionDirectionMutual, 5)
+	require.Equal(t, "Messages exchange (5 messages)", got)
+}
+
+// TestMessagesAdapter_SourceRefPrefix_EscapesLikeWildcards is the
+// load-bearing assertion from Codex P2: the prefix MUST escape `_`
+// and `%` so a chat_guid containing those wildcards doesn't false-
+// match unrelated rows when used as a LIKE pattern. The escape
+// character is `\` and the corresponding sqlc queries use
+// `LIKE pattern ESCAPE '\'`.
+func TestMessagesAdapter_SourceRefPrefix_EscapesLikeWildcards(t *testing.T) {
+	cases := []struct {
+		name    string
+		chatID  string
+		want    string
+		hasWild string // substring that must NOT appear literally
+	}{
+		{
+			name:    "underscore_in_chat_guid",
+			chatID:  "iMessage;-;_chat-uuid_",
+			want:    `messages:iMessage;-;\_chat-uuid\_:%`,
+			hasWild: "",
+		},
+		{
+			name:   "percent_in_chat_guid",
+			chatID: "weird%pattern",
+			want:   `messages:weird\%pattern:%`,
+		},
+		{
+			name:   "backslash_belt_and_suspenders",
+			chatID: `c\xyz`,
+			want:   `messages:c\\xyz:%`,
+		},
+		{
+			name:   "numeric_telegram_style_passes_through",
+			chatID: "12345",
+			want:   "messages:12345:%",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, messagesAdapter{}.SourceRefPrefix(tc.chatID))
+		})
+	}
+}

--- a/backend/internal/messages/provider.go
+++ b/backend/internal/messages/provider.go
@@ -1,0 +1,58 @@
+// Package messages contains the Pi-side wiring for the "messages"
+// source — Apple Messages.app data delivered via the Mac daemon's push
+// pipeline. The package is producer-agnostic; the daemon itself lives
+// outside this repo (Swift code in a sibling project) and submits
+// raw_message.* events to /api/v1/ingest/events.
+package messages
+
+import (
+	"context"
+
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/sync"
+)
+
+// Provider registers the "messages" source with the sync registry. The
+// source is push-only: data lands via the daemon's ingest POSTs, never
+// via the scheduler. The provider exists so:
+//
+//   - the scheduler's push-strategy exclusion has a registered entry to
+//     match against (instead of an implicit "any unknown source is
+//     pollable" gap);
+//   - the /api/v1/sync/providers endpoint reports the Messages source
+//     in the registry list (no frontend consumes that endpoint today,
+//     but it's the correct ground truth for ops queries).
+//
+// Sync() is a no-op. ValidateCredentials() returns nil — the Mac
+// daemon authenticates on its own with the host-bearer key minted
+// during pairing (PR1).
+type Provider struct{}
+
+// New constructs a Messages provider.
+func New() *Provider { return &Provider{} }
+
+// Config implements sync.SyncProvider.
+func (p *Provider) Config() sync.SourceConfig {
+	return sync.SourceConfig{
+		Name:                 "messages",
+		DisplayName:          "Messages",
+		Strategy:             repository.SyncStrategyPush,
+		SupportsMultiAccount: false,
+		SupportsDiscovery:    false, // spec §2: messages is NOT a discovery surface
+		DefaultInterval:      0,     // push: scheduler never enqueues
+	}
+}
+
+// Sync implements sync.SyncProvider. Push-strategy: data lands via
+// /api/v1/ingest/events. The scheduler already excludes us via
+// ListDueAccounts; the no-op return makes a direct invocation safe.
+func (p *Provider) Sync(_ context.Context, _ *repository.SyncState, _ []repository.Contact) (*sync.SyncResult, error) {
+	return &sync.SyncResult{}, nil
+}
+
+// ValidateCredentials implements sync.SyncProvider. No credentials are
+// stored on the Pi for the messages source — host-bearer auth is the
+// daemon's own concern.
+func (p *Provider) ValidateCredentials(_ context.Context, _ *string) error {
+	return nil
+}

--- a/backend/internal/messages/provider.go
+++ b/backend/internal/messages/provider.go
@@ -25,7 +25,7 @@ import (
 //
 // Sync() is a no-op. ValidateCredentials() returns nil — the Mac
 // daemon authenticates on its own with the host-bearer key minted
-// during pairing (PR1).
+// during the pairing flow.
 type Provider struct{}
 
 // New constructs a Messages provider.

--- a/backend/internal/messages/provider_test.go
+++ b/backend/internal/messages/provider_test.go
@@ -1,0 +1,35 @@
+package messages
+
+import (
+	"context"
+	"testing"
+
+	"personal-crm/backend/internal/repository"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProvider_Config(t *testing.T) {
+	cfg := New().Config()
+	require.Equal(t, "messages", cfg.Name)
+	require.Equal(t, "Messages", cfg.DisplayName)
+	require.Equal(t, repository.SyncStrategyPush, cfg.Strategy)
+	require.False(t, cfg.SupportsMultiAccount)
+	require.False(t, cfg.SupportsDiscovery)
+	require.Equal(t, int64(0), int64(cfg.DefaultInterval))
+}
+
+func TestProvider_SyncIsNoop(t *testing.T) {
+	result, err := New().Sync(context.Background(), nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, 0, result.ItemsProcessed)
+	require.Equal(t, 0, result.ItemsMatched)
+	require.Equal(t, 0, result.ItemsCreated)
+}
+
+func TestProvider_ValidateCredentialsIsNoop(t *testing.T) {
+	require.NoError(t, New().ValidateCredentials(context.Background(), nil))
+	acct := "ignored"
+	require.NoError(t, New().ValidateCredentials(context.Background(), &acct))
+}

--- a/backend/internal/repository/identity.go
+++ b/backend/internal/repository/identity.go
@@ -186,6 +186,25 @@ func (r *IdentityRepository) GetByIdentifier(ctx context.Context, idType identit
 	return &ident, nil
 }
 
+// GetByIdentifierTx is the tx-bound variant of GetByIdentifier. Used
+// by IdentityService.MatchOrCreateTx so the identity lookup runs in
+// the caller's transaction.
+func (r *IdentityRepository) GetByIdentifierTx(ctx context.Context, tx pgx.Tx, idType identity.IdentifierType, identifier, source string) (*ExternalIdentity, error) {
+	dbIdentity, err := db.New(tx).GetIdentityByIdentifier(ctx, db.GetIdentityByIdentifierParams{
+		IdentifierType: string(idType),
+		Identifier:     identifier,
+		Source:         source,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, db.ErrNotFound
+		}
+		return nil, err
+	}
+	ident := convertDbIdentity(dbIdentity)
+	return &ident, nil
+}
+
 // FindByIdentifier finds all identities matching the given identifier and type (across sources)
 func (r *IdentityRepository) FindByIdentifier(ctx context.Context, idType identity.IdentifierType, identifier string) ([]ExternalIdentity, error) {
 	dbIdentities, err := r.queries.FindIdentitiesByIdentifier(ctx, db.FindIdentitiesByIdentifierParams{
@@ -206,13 +225,38 @@ func (r *IdentityRepository) FindByIdentifier(ctx context.Context, idType identi
 
 // Upsert creates or updates an identity
 func (r *IdentityRepository) Upsert(ctx context.Context, req UpsertIdentityRequest) (*ExternalIdentity, error) {
+	dbIdentity, err := r.queries.UpsertIdentity(ctx, buildUpsertIdentityParams(req))
+	if err != nil {
+		return nil, err
+	}
+
+	ident := convertDbIdentity(dbIdentity)
+	return &ident, nil
+}
+
+// UpsertTx is the tx-bound variant of Upsert. Used by
+// IdentityService.MatchOrCreateTx so the identity row commits atomically
+// with the caller's other writes (e.g., the staging-row insert in the
+// ingest hot path).
+func (r *IdentityRepository) UpsertTx(ctx context.Context, tx pgx.Tx, req UpsertIdentityRequest) (*ExternalIdentity, error) {
+	dbIdentity, err := db.New(tx).UpsertIdentity(ctx, buildUpsertIdentityParams(req))
+	if err != nil {
+		return nil, err
+	}
+	ident := convertDbIdentity(dbIdentity)
+	return &ident, nil
+}
+
+// buildUpsertIdentityParams centralizes the pgtype conversion shared
+// between the tx and non-tx upsert paths. Keeping this in one place
+// ensures both variants stay in lockstep.
+func buildUpsertIdentityParams(req UpsertIdentityRequest) db.UpsertIdentityParams {
 	params := db.UpsertIdentityParams{
 		Identifier:     req.Identifier,
 		IdentifierType: string(req.IdentifierType),
 		Source:         req.Source,
 	}
 
-	// Set optional fields
 	if req.RawIdentifier != nil {
 		params.RawIdentifier = pgtype.Text{String: *req.RawIdentifier, Valid: true}
 	}
@@ -238,13 +282,7 @@ func (r *IdentityRepository) Upsert(ctx context.Context, req UpsertIdentityReque
 		params.MessageCount = pgtype.Int4{Int32: req.MessageCount, Valid: true}
 	}
 
-	dbIdentity, err := r.queries.UpsertIdentity(ctx, params)
-	if err != nil {
-		return nil, err
-	}
-
-	ident := convertDbIdentity(dbIdentity)
-	return &ident, nil
+	return params
 }
 
 // LinkToContact links an identity to a contact
@@ -372,6 +410,24 @@ func (r *IdentityRepository) FindContactMethodsByValue(ctx context.Context, type
 		matches[i] = convertDbContactMethodMatch(row)
 	}
 
+	return matches, nil
+}
+
+// FindContactMethodsByValueTx is the tx-bound variant of
+// FindContactMethodsByValue. Used by IdentityService.MatchOrCreateTx
+// so the contact-method search runs in the caller's transaction.
+func (r *IdentityRepository) FindContactMethodsByValueTx(ctx context.Context, tx pgx.Tx, types []string, normalizedValue string) ([]ContactMethodMatch, error) {
+	rows, err := db.New(tx).FindMethodsByNormalizedValue(ctx, db.FindMethodsByNormalizedValueParams{
+		Column1:         types,
+		ValueNormalized: normalizedValue,
+	})
+	if err != nil {
+		return nil, err
+	}
+	matches := make([]ContactMethodMatch, len(rows))
+	for i, row := range rows {
+		matches[i] = convertDbContactMethodMatch(row)
+	}
 	return matches, nil
 }
 

--- a/backend/internal/repository/interaction.go
+++ b/backend/internal/repository/interaction.go
@@ -303,7 +303,7 @@ func (r *InteractionRepository) FindRecentInteractionBySourceAndDirection(
 		ContactID:       uuidToPgUUID(contactID),
 		Source:          source,
 		Direction:       direction,
-		SourceRefPrefix: pgtype.Text{String: sourceRefPrefix, Valid: true},
+		SourceRefPrefix: sourceRefPrefix,
 		WindowStart:     pgtype.Timestamptz{Time: windowStart, Valid: true},
 		WindowEnd:       pgtype.Timestamptz{Time: windowEnd, Valid: true},
 	})
@@ -329,7 +329,7 @@ func (r *InteractionRepository) FindRecentOutboundInteractionBySource(
 	dbInteraction, err := r.queries.FindRecentOutboundInteractionBySource(ctx, db.FindRecentOutboundInteractionBySourceParams{
 		ContactID:       uuidToPgUUID(contactID),
 		Source:          source,
-		SourceRefPrefix: pgtype.Text{String: sourceRefPrefix, Valid: true},
+		SourceRefPrefix: sourceRefPrefix,
 		WindowStart:     pgtype.Timestamptz{Time: windowStart, Valid: true},
 		WindowEnd:       pgtype.Timestamptz{Time: windowEnd, Valid: true},
 	})

--- a/backend/internal/repository/messages_message.go
+++ b/backend/internal/repository/messages_message.go
@@ -128,6 +128,32 @@ func convertDbMessagesMessage(m *db.MessagesMessage) MessagesMessage {
 
 // UpsertMessage creates or updates a messages_message row by guid.
 func (r *MessagesMessageRepository) UpsertMessage(ctx context.Context, params UpsertMessagesMessageParams) (*MessagesMessage, error) {
+	dbMsg, err := r.queries.UpsertMessagesMessage(ctx, buildUpsertMessagesMessageParams(params))
+	if err != nil {
+		return nil, err
+	}
+	msg := convertDbMessagesMessage(dbMsg)
+	return &msg, nil
+}
+
+// UpsertMessageTx is the tx-bound variant of UpsertMessage. Used by the
+// ingest service so the staging-row write commits atomically with the
+// raw event-log insert + River aggregator-job enqueue (spec §3 Stage 1
+// "single tx"). Caller owns the tx lifecycle.
+func (r *MessagesMessageRepository) UpsertMessageTx(ctx context.Context, tx pgx.Tx, params UpsertMessagesMessageParams) (*MessagesMessage, error) {
+	dbMsg, err := db.New(tx).UpsertMessagesMessage(ctx, buildUpsertMessagesMessageParams(params))
+	if err != nil {
+		return nil, err
+	}
+	msg := convertDbMessagesMessage(dbMsg)
+	return &msg, nil
+}
+
+// buildUpsertMessagesMessageParams centralizes the pgtype conversion
+// shared between the tx and non-tx upsert paths. Keeping this in one
+// place ensures both variants stay in lockstep — drift would silently
+// produce different on-disk shapes depending on caller.
+func buildUpsertMessagesMessageParams(params UpsertMessagesMessageParams) db.UpsertMessagesMessageParams {
 	var matchedContactID pgtype.UUID
 	if params.MatchedContactID != nil {
 		matchedContactID = uuidToPgUUID(*params.MatchedContactID)
@@ -136,7 +162,7 @@ func (r *MessagesMessageRepository) UpsertMessage(ctx context.Context, params Up
 	if params.MacHostID != nil {
 		macHostID = uuidToPgUUID(*params.MacHostID)
 	}
-	dbMsg, err := r.queries.UpsertMessagesMessage(ctx, db.UpsertMessagesMessageParams{
+	return db.UpsertMessagesMessageParams{
 		Guid:             params.Guid,
 		ChatGuid:         params.ChatGuid,
 		PeerHandle:       params.PeerHandle,
@@ -149,12 +175,7 @@ func (r *MessagesMessageRepository) UpsertMessage(ctx context.Context, params Up
 		ReplyToGuid:      stringToPgText(params.ReplyToGuid),
 		MatchedContactID: matchedContactID,
 		MacHostID:        macHostID,
-	})
-	if err != nil {
-		return nil, err
 	}
-	msg := convertDbMessagesMessage(dbMsg)
-	return &msg, nil
 }
 
 // GetMessage retrieves a message by guid. Returns db.ErrNotFound on miss.
@@ -214,6 +235,56 @@ func (r *MessagesMessageRepository) ListUnprocessedByContact(ctx context.Context
 		msgs[i] = convertDbMessagesMessage(m)
 	}
 	return msgs, nil
+}
+
+// ListUnprocessedChatsByContact returns the distinct chat_guid values
+// for which the contact has at least one eligible (unprocessed AND
+// unclaimed-or-stale) row. Drives the messaging aggregator worker's
+// per-chat loop (the chat-aware AggregateForContact path is what
+// preserves the extend/bridge/coalesce contract from spec §3 Stage 2).
+//
+// Returned values are ordered by chat_guid ASC so concurrent workers
+// tend to collide on the same chat first; this improves the partial-
+// claim retry path's convergence properties.
+func (r *MessagesMessageRepository) ListUnprocessedChatsByContact(ctx context.Context, contactID uuid.UUID) ([]string, error) {
+	return r.queries.ListUnprocessedMessagesChatsByContact(ctx, uuidToPgUUID(contactID))
+}
+
+// UpdateMatchedContactParams is the input for UpdateMatchedContact.
+type UpdateMatchedContactParams struct {
+	ID               uuid.UUID
+	MatchedContactID uuid.UUID
+	PeerNormalized   string
+}
+
+// ListStranded returns staging rows whose matched_contact_id is NULL
+// — i.e., rows the ingest service accepted but couldn't match to a
+// contact. Used by the crm-admin --messages-rematch-stranded utility
+// to retroactively match rows after a contact_method gets added.
+func (r *MessagesMessageRepository) ListStranded(ctx context.Context) ([]MessagesMessage, error) {
+	dbMsgs, err := r.queries.ListStrandedMessagesMessages(ctx)
+	if err != nil {
+		return nil, err
+	}
+	msgs := make([]MessagesMessage, len(dbMsgs))
+	for i, m := range dbMsgs {
+		msgs[i] = convertDbMessagesMessage(m)
+	}
+	return msgs, nil
+}
+
+// UpdateMatchedContact sets matched_contact_id + peer_normalized on a
+// stranded row. The SQL predicate scopes the update to rows still
+// unmatched + unprocessed; concurrent ingest of a never-stranded row
+// (one whose peer just got matched) will not be overwritten by this
+// admin path. Idempotent — re-running on an already-matched row is a
+// no-op.
+func (r *MessagesMessageRepository) UpdateMatchedContact(ctx context.Context, params UpdateMatchedContactParams) error {
+	return r.queries.UpdateMatchedContactForStrandedMessage(ctx, db.UpdateMatchedContactForStrandedMessageParams{
+		ID:               uuidToPgUUID(params.ID),
+		MatchedContactID: uuidToPgUUID(params.MatchedContactID),
+		PeerNormalized:   pgtype.Text{String: params.PeerNormalized, Valid: true},
+	})
 }
 
 // ListUnprocessedByContactAndChat returns eligible rows for a contact +

--- a/backend/internal/scheduler/messaging_aggregate_sweeper_worker.go
+++ b/backend/internal/scheduler/messaging_aggregate_sweeper_worker.go
@@ -28,7 +28,7 @@ type RiverInserter interface {
 }
 
 // MessagingAggregateSweeperWorker is the periodic safety net for
-// stranded-row recovery (plan R10C). The worker:
+// stranded-row recovery. The worker:
 //  1. Lists all contacts with at least one eligible (unprocessed AND
 //     unclaimed-or-stale) staging row for a given source.
 //  2. Enqueues a MessagingAggregateForContactArgs per contact (with

--- a/backend/internal/scheduler/messaging_aggregate_sweeper_worker.go
+++ b/backend/internal/scheduler/messaging_aggregate_sweeper_worker.go
@@ -1,0 +1,112 @@
+package scheduler
+
+import (
+	"context"
+	"time"
+
+	"personal-crm/backend/internal/consumer/consumerjobs"
+	"personal-crm/backend/internal/logger"
+
+	"github.com/google/uuid"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
+)
+
+// UnprocessedContactLister returns the distinct contact IDs with at
+// least one unprocessed staging row across the source's staging
+// table. Used by MessagingAggregateSweeperWorker; concrete in
+// production is *repository.MessagesMessageRepository.
+type UnprocessedContactLister interface {
+	ListUnprocessedContactIDs(ctx context.Context) ([]uuid.UUID, error)
+}
+
+// RiverInserter is the narrow surface the sweeper uses to enqueue
+// MessagingAggregateForContactArgs jobs. Concrete is
+// *river.Client[pgx.Tx].
+type RiverInserter interface {
+	Insert(ctx context.Context, args river.JobArgs, opts *river.InsertOpts) (*rivertype.JobInsertResult, error)
+}
+
+// MessagingAggregateSweeperWorker is the periodic safety net for
+// stranded-row recovery (plan R10C). The worker:
+//  1. Lists all contacts with at least one eligible (unprocessed AND
+//     unclaimed-or-stale) staging row for a given source.
+//  2. Enqueues a MessagingAggregateForContactArgs per contact (with
+//     UniqueOpts so in-flight jobs dedup).
+//
+// Bounds worst-case stranded-row latency at the sweep interval (5
+// min in production). Defense-in-depth against the narrow race where
+// a row lands while another aggregator worker has just exited its
+// re-list loop AND UniqueOpts suppressed a follow-up enqueue.
+type MessagingAggregateSweeperWorker struct {
+	river.WorkerDefaults[consumerjobs.MessagingAggregateSweeperArgs]
+	listers     map[string]UnprocessedContactLister
+	riverClient RiverInserter
+}
+
+// NewMessagingAggregateSweeperWorker constructs the worker.
+// listers maps source name → UnprocessedContactLister. Pass nil
+// riverClient to disable enqueue (useful only for tests).
+func NewMessagingAggregateSweeperWorker(
+	listers map[string]UnprocessedContactLister,
+	riverClient RiverInserter,
+) *MessagingAggregateSweeperWorker {
+	return &MessagingAggregateSweeperWorker{
+		listers:     listers,
+		riverClient: riverClient,
+	}
+}
+
+// Work implements river.Worker.
+func (w *MessagingAggregateSweeperWorker) Work(
+	ctx context.Context,
+	_ *river.Job[consumerjobs.MessagingAggregateSweeperArgs],
+) error {
+	totalEnqueued := 0
+	for source, lister := range w.listers {
+		contactIDs, err := lister.ListUnprocessedContactIDs(ctx)
+		if err != nil {
+			// Don't fail the whole sweep on a single source's error
+			// — other sources may still be drainable. Log and
+			// continue. River retries the periodic job on the next
+			// tick.
+			logger.Warn().
+				Err(err).
+				Str("source", source).
+				Msg("messaging_aggregate_sweeper: list contacts failed")
+			continue
+		}
+		for _, cid := range contactIDs {
+			if w.riverClient == nil {
+				continue
+			}
+			args := consumerjobs.MessagingAggregateForContactArgs{
+				ContactID: cid,
+				Source:    source,
+			}
+			if _, err := w.riverClient.Insert(ctx, args, &river.InsertOpts{
+				UniqueOpts: river.UniqueOpts{ByArgs: true},
+			}); err != nil {
+				logger.Warn().
+					Err(err).
+					Str("source", source).
+					Str("contact_id", cid.String()).
+					Msg("messaging_aggregate_sweeper: enqueue failed")
+				continue
+			}
+			totalEnqueued++
+		}
+	}
+	if totalEnqueued > 0 {
+		logger.Info().
+			Int("enqueued", totalEnqueued).
+			Msg("messaging_aggregate_sweeper: tick enqueued aggregator jobs")
+	}
+	return nil
+}
+
+// Timeout caps each invocation. The list query is bounded by
+// unprocessed-contact count (typically small); 30s is generous.
+func (*MessagingAggregateSweeperWorker) Timeout(_ *river.Job[consumerjobs.MessagingAggregateSweeperArgs]) time.Duration {
+	return 30 * time.Second
+}

--- a/backend/internal/scheduler/messaging_aggregate_sweeper_worker_test.go
+++ b/backend/internal/scheduler/messaging_aggregate_sweeper_worker_test.go
@@ -1,0 +1,134 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"personal-crm/backend/internal/consumer/consumerjobs"
+
+	"github.com/google/uuid"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
+	"github.com/stretchr/testify/require"
+)
+
+type stubContactLister struct {
+	ids    []uuid.UUID
+	err    error
+	called int
+}
+
+func (s *stubContactLister) ListUnprocessedContactIDs(_ context.Context) ([]uuid.UUID, error) {
+	s.called++
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.ids, nil
+}
+
+type stubInserter struct {
+	calls    []consumerjobs.MessagingAggregateForContactArgs
+	failOnce bool
+	failed   bool
+}
+
+func (s *stubInserter) Insert(_ context.Context, args river.JobArgs, _ *river.InsertOpts) (*rivertype.JobInsertResult, error) {
+	a, ok := args.(consumerjobs.MessagingAggregateForContactArgs)
+	if !ok {
+		return nil, errors.New("unexpected args type")
+	}
+	if s.failOnce && !s.failed {
+		s.failed = true
+		return nil, errors.New("transient enqueue failure")
+	}
+	s.calls = append(s.calls, a)
+	return &rivertype.JobInsertResult{}, nil
+}
+
+func TestSweeperWorker_EnqueuesPerContact(t *testing.T) {
+	c1, c2, c3 := uuid.New(), uuid.New(), uuid.New()
+	lister := &stubContactLister{ids: []uuid.UUID{c1, c2, c3}}
+	inserter := &stubInserter{}
+
+	worker := NewMessagingAggregateSweeperWorker(
+		map[string]UnprocessedContactLister{"messages": lister},
+		inserter,
+	)
+	err := worker.Work(context.Background(), &river.Job[consumerjobs.MessagingAggregateSweeperArgs]{})
+	require.NoError(t, err)
+	require.Equal(t, 1, lister.called)
+	require.Len(t, inserter.calls, 3)
+	gotIDs := []uuid.UUID{inserter.calls[0].ContactID, inserter.calls[1].ContactID, inserter.calls[2].ContactID}
+	require.ElementsMatch(t, []uuid.UUID{c1, c2, c3}, gotIDs)
+	for _, c := range inserter.calls {
+		require.Equal(t, "messages", c.Source)
+	}
+}
+
+// TestSweeperWorker_EmptyList_NoEnqueues asserts the sweeper does
+// nothing when there are no unprocessed rows.
+func TestSweeperWorker_EmptyList_NoEnqueues(t *testing.T) {
+	lister := &stubContactLister{ids: nil}
+	inserter := &stubInserter{}
+
+	worker := NewMessagingAggregateSweeperWorker(
+		map[string]UnprocessedContactLister{"messages": lister},
+		inserter,
+	)
+	err := worker.Work(context.Background(), &river.Job[consumerjobs.MessagingAggregateSweeperArgs]{})
+	require.NoError(t, err)
+	require.Empty(t, inserter.calls)
+}
+
+// TestSweeperWorker_ListError_LogsAndContinues asserts a list-error
+// in one source does NOT fail the whole tick; the worker keeps
+// running and returns nil.
+func TestSweeperWorker_ListError_LogsAndContinues(t *testing.T) {
+	listerErr := &stubContactLister{err: errors.New("db down")}
+	listerOK := &stubContactLister{ids: []uuid.UUID{uuid.New()}}
+	inserter := &stubInserter{}
+
+	worker := NewMessagingAggregateSweeperWorker(
+		map[string]UnprocessedContactLister{
+			"messages": listerErr,
+			"whatsapp": listerOK,
+		},
+		inserter,
+	)
+	err := worker.Work(context.Background(), &river.Job[consumerjobs.MessagingAggregateSweeperArgs]{})
+	require.NoError(t, err)
+	// The healthy source's contact still gets enqueued.
+	require.Len(t, inserter.calls, 1)
+}
+
+// TestSweeperWorker_EnqueueError_ContinuesToNextContact verifies a
+// transient enqueue failure on one contact does NOT stop the worker
+// from enqueuing the rest.
+func TestSweeperWorker_EnqueueError_ContinuesToNextContact(t *testing.T) {
+	c1, c2 := uuid.New(), uuid.New()
+	lister := &stubContactLister{ids: []uuid.UUID{c1, c2}}
+	inserter := &stubInserter{failOnce: true}
+
+	worker := NewMessagingAggregateSweeperWorker(
+		map[string]UnprocessedContactLister{"messages": lister},
+		inserter,
+	)
+	err := worker.Work(context.Background(), &river.Job[consumerjobs.MessagingAggregateSweeperArgs]{})
+	require.NoError(t, err)
+	require.Len(t, inserter.calls, 1)
+	require.True(t, inserter.failed)
+}
+
+// TestSweeperWorker_NilRiverClient_NoOps verifies a nil client makes
+// the worker behave as a list-only sweep (used in light unit tests).
+func TestSweeperWorker_NilRiverClient_NoOps(t *testing.T) {
+	lister := &stubContactLister{ids: []uuid.UUID{uuid.New()}}
+	worker := NewMessagingAggregateSweeperWorker(
+		map[string]UnprocessedContactLister{"messages": lister},
+		nil,
+	)
+	err := worker.Work(context.Background(), &river.Job[consumerjobs.MessagingAggregateSweeperArgs]{})
+	require.NoError(t, err)
+	require.Equal(t, 1, lister.called)
+}

--- a/backend/internal/scheduler/messaging_aggregate_worker.go
+++ b/backend/internal/scheduler/messaging_aggregate_worker.go
@@ -14,8 +14,7 @@ import (
 
 // workerLoopMaxIterations caps how many re-list passes the worker
 // performs in a single run. The loop drains rows that landed between
-// the engine's list-query and the worker's re-list (see spec §3 race-
-// mechanics for the unhandled-row window discussion). Hitting the cap
+// the engine's list-query and the worker's re-list. Hitting the cap
 // means staging is being filled faster than we drain; the next
 // MessagingAggregateForContactArgs enqueue OR the periodic sweeper
 // picks up the residual rows.
@@ -143,7 +142,7 @@ func (w *MessagingAggregateForContactWorker) Work(
 }
 
 // Timeout caps each invocation. 60s matches existing worker timeouts;
-// PR7's chat.db reader load testing may surface a need to bump this.
+// real-traffic load testing may surface a need to bump this.
 func (*MessagingAggregateForContactWorker) Timeout(_ *river.Job[consumerjobs.MessagingAggregateForContactArgs]) time.Duration {
 	return 60 * time.Second
 }

--- a/backend/internal/scheduler/messaging_aggregate_worker.go
+++ b/backend/internal/scheduler/messaging_aggregate_worker.go
@@ -21,11 +21,11 @@ import (
 // picks up the residual rows.
 const workerLoopMaxIterations = 50
 
-// chatAwareAggregator is the subset of the messaging aggregation
+// ChatAwareAggregator is the subset of the messaging aggregation
 // engine surface the worker actually invokes. Concrete is
 // *aggregation.Engine; the interface keeps the worker testable with
 // a stub.
-type chatAwareAggregator interface {
+type ChatAwareAggregator interface {
 	AggregateForContact(ctx context.Context, contactID uuid.UUID, chatID string) error
 }
 
@@ -74,7 +74,7 @@ func (r *PerSourceChatListerRegistry) ListUnprocessedChats(ctx context.Context, 
 // coalescing.
 type MessagingAggregateForContactWorker struct {
 	river.WorkerDefaults[consumerjobs.MessagingAggregateForContactArgs]
-	engines    map[string]chatAwareAggregator
+	engines    map[string]ChatAwareAggregator
 	chatLister chatLister
 }
 
@@ -82,7 +82,7 @@ type MessagingAggregateForContactWorker struct {
 // engines is keyed by source name; chatLister routes
 // ListUnprocessedChats by source.
 func NewMessagingAggregateForContactWorker(
-	engines map[string]chatAwareAggregator,
+	engines map[string]ChatAwareAggregator,
 	chatLister chatLister,
 ) *MessagingAggregateForContactWorker {
 	return &MessagingAggregateForContactWorker{

--- a/backend/internal/scheduler/messaging_aggregate_worker.go
+++ b/backend/internal/scheduler/messaging_aggregate_worker.go
@@ -1,0 +1,149 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"personal-crm/backend/internal/consumer/consumerjobs"
+	"personal-crm/backend/internal/logger"
+
+	"github.com/google/uuid"
+	"github.com/riverqueue/river"
+)
+
+// workerLoopMaxIterations caps how many re-list passes the worker
+// performs in a single run. The loop drains rows that landed between
+// the engine's list-query and the worker's re-list (see spec §3 race-
+// mechanics for the unhandled-row window discussion). Hitting the cap
+// means staging is being filled faster than we drain; the next
+// MessagingAggregateForContactArgs enqueue OR the periodic sweeper
+// picks up the residual rows.
+const workerLoopMaxIterations = 50
+
+// chatAwareAggregator is the subset of the messaging aggregation
+// engine surface the worker actually invokes. Concrete is
+// *aggregation.Engine; the interface keeps the worker testable with
+// a stub.
+type chatAwareAggregator interface {
+	AggregateForContact(ctx context.Context, contactID uuid.UUID, chatID string) error
+}
+
+// chatLister enumerates the distinct unprocessed chats for a contact
+// scoped to a single source. The registry pattern mirrors
+// repository.StagingProcessorRegistry — one entry per source so the
+// worker can route by job.Args.Source.
+type chatLister interface {
+	ListUnprocessedChats(ctx context.Context, source string, contactID uuid.UUID) ([]string, error)
+}
+
+// PerSourceChatListerRegistry maps source name → chat-lister
+// implementation. Construct in main.go with one entry per active
+// source.
+type PerSourceChatListerRegistry struct {
+	entries map[string]func(ctx context.Context, contactID uuid.UUID) ([]string, error)
+}
+
+// NewPerSourceChatListerRegistry builds the registry over a
+// source → function map.
+func NewPerSourceChatListerRegistry(entries map[string]func(ctx context.Context, contactID uuid.UUID) ([]string, error)) *PerSourceChatListerRegistry {
+	return &PerSourceChatListerRegistry{entries: entries}
+}
+
+// ListUnprocessedChats dispatches to the registered source entry.
+// Unknown sources return (nil, nil) — the worker logs a warning and
+// no-ops, matching the StagingProcessorRegistry pattern.
+func (r *PerSourceChatListerRegistry) ListUnprocessedChats(ctx context.Context, source string, contactID uuid.UUID) ([]string, error) {
+	fn, ok := r.entries[source]
+	if !ok {
+		return nil, nil
+	}
+	return fn(ctx, contactID)
+}
+
+// MessagingAggregateForContactWorker drives the chat-aware aggregation
+// engine over all unprocessed chats for a (contactID, source) pair.
+// Enqueued by the ingest service after a batch of raw_message.* events
+// lands; UniqueOpts{ByArgs: true} dedups concurrent enqueues for the
+// same pair into one in-flight job.
+//
+// The chat-aware path is what preserves the engine's extend/bridge/
+// coalesce contract (spec §3 "Stage 2 — Aggregator"). The create-only
+// batch path (Engine.AggregateForContactBatch) is intentionally NOT
+// used here — it skips explicit-reply bridging and same-direction
+// coalescing.
+type MessagingAggregateForContactWorker struct {
+	river.WorkerDefaults[consumerjobs.MessagingAggregateForContactArgs]
+	engines    map[string]chatAwareAggregator
+	chatLister chatLister
+}
+
+// NewMessagingAggregateForContactWorker constructs the worker.
+// engines is keyed by source name; chatLister routes
+// ListUnprocessedChats by source.
+func NewMessagingAggregateForContactWorker(
+	engines map[string]chatAwareAggregator,
+	chatLister chatLister,
+) *MessagingAggregateForContactWorker {
+	return &MessagingAggregateForContactWorker{
+		engines:    engines,
+		chatLister: chatLister,
+	}
+}
+
+// Work implements river.Worker for MessagingAggregateForContactArgs.
+func (w *MessagingAggregateForContactWorker) Work(
+	ctx context.Context,
+	job *river.Job[consumerjobs.MessagingAggregateForContactArgs],
+) error {
+	engine, ok := w.engines[job.Args.Source]
+	if !ok {
+		// Unknown source: log and return nil (no work to do).
+		// Mirrors the StagingProcessorRegistry's "unknown source =
+		// noop" pattern. A misconfigured source string at enqueue
+		// time shouldn't kill the worker — the operator sees the log
+		// line and addresses.
+		logger.Warn().
+			Str("source", job.Args.Source).
+			Str("contact_id", job.Args.ContactID.String()).
+			Msg("messaging_aggregate: no engine registered for source; noop")
+		return nil
+	}
+	if w.chatLister == nil {
+		logger.Warn().
+			Str("source", job.Args.Source).
+			Msg("messaging_aggregate: no chat lister wired; noop")
+		return nil
+	}
+
+	for iter := 0; iter < workerLoopMaxIterations; iter++ {
+		chats, err := w.chatLister.ListUnprocessedChats(ctx, job.Args.Source, job.Args.ContactID)
+		if err != nil {
+			return fmt.Errorf("list unprocessed chats: %w", err)
+		}
+		if len(chats) == 0 {
+			return nil // drained
+		}
+		for _, chatID := range chats {
+			if err := engine.AggregateForContact(ctx, job.Args.ContactID, chatID); err != nil {
+				return fmt.Errorf("aggregate contact=%s chat=%s: %w",
+					job.Args.ContactID, chatID, err)
+			}
+		}
+	}
+	// Hit the loop bound. The next ingest's enqueue OR the periodic
+	// sweeper will pick up remaining rows. The bound prevents a
+	// runaway worker from monopolizing a River executor slot.
+	logger.Warn().
+		Str("contact_id", job.Args.ContactID.String()).
+		Str("source", job.Args.Source).
+		Int("max_iter", workerLoopMaxIterations).
+		Msg("messaging_aggregate: hit loop bound; subsequent enqueues will continue draining")
+	return nil
+}
+
+// Timeout caps each invocation. 60s matches existing worker timeouts;
+// PR7's chat.db reader load testing may surface a need to bump this.
+func (*MessagingAggregateForContactWorker) Timeout(_ *river.Job[consumerjobs.MessagingAggregateForContactArgs]) time.Duration {
+	return 60 * time.Second
+}

--- a/backend/internal/scheduler/messaging_aggregate_worker_test.go
+++ b/backend/internal/scheduler/messaging_aggregate_worker_test.go
@@ -1,0 +1,219 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"personal-crm/backend/internal/consumer/consumerjobs"
+
+	"github.com/google/uuid"
+	"github.com/riverqueue/river"
+	"github.com/stretchr/testify/require"
+)
+
+// stubAggregator records every AggregateForContact call. Tests assert
+// on the recorded calls to verify per-chat invocation ordering and
+// counts.
+type stubAggregator struct {
+	calls   []stubAggCall
+	failOn  string // if non-empty, return error for this chatID
+	failErr error
+}
+
+type stubAggCall struct {
+	contactID uuid.UUID
+	chatID    string
+}
+
+func (s *stubAggregator) AggregateForContact(_ context.Context, contactID uuid.UUID, chatID string) error {
+	s.calls = append(s.calls, stubAggCall{contactID, chatID})
+	if s.failOn != "" && s.failOn == chatID {
+		return s.failErr
+	}
+	return nil
+}
+
+// stubChatLister returns canned chat lists per call. The lists slice
+// is consumed left-to-right; once exhausted ListUnprocessedChats
+// returns the last value (typically an empty slice) on subsequent
+// calls. errAfter > 0 causes the (errAfter+1)-th call to error.
+type stubChatLister struct {
+	source    string
+	lists     [][]string
+	calls     int
+	errAfter  int
+	errReturn error
+}
+
+func (s *stubChatLister) ListUnprocessedChats(_ context.Context, source string, _ uuid.UUID) ([]string, error) {
+	s.calls++
+	if s.errAfter > 0 && s.calls > s.errAfter {
+		return nil, s.errReturn
+	}
+	if source != s.source {
+		return nil, nil
+	}
+	if len(s.lists) == 0 {
+		return nil, nil
+	}
+	if s.calls > len(s.lists) {
+		return s.lists[len(s.lists)-1], nil
+	}
+	return s.lists[s.calls-1], nil
+}
+
+func TestMessagingAggregateWorker_HappyPath_DrainsAndCallsPerChat(t *testing.T) {
+	agg := &stubAggregator{}
+	lister := &stubChatLister{
+		source: "messages",
+		lists: [][]string{
+			{"chat-A", "chat-B"},
+			{}, // second list-call drains
+		},
+	}
+	worker := NewMessagingAggregateForContactWorker(
+		map[string]chatAwareAggregator{"messages": agg},
+		lister,
+	)
+
+	contactID := uuid.New()
+	err := worker.Work(context.Background(), &river.Job[consumerjobs.MessagingAggregateForContactArgs]{
+		Args: consumerjobs.MessagingAggregateForContactArgs{ContactID: contactID, Source: "messages"},
+	})
+	require.NoError(t, err)
+	require.Len(t, agg.calls, 2)
+	require.Equal(t, "chat-A", agg.calls[0].chatID)
+	require.Equal(t, "chat-B", agg.calls[1].chatID)
+	require.Equal(t, contactID, agg.calls[0].contactID)
+}
+
+// TestMessagingAggregateWorker_RelistLoopDrainsLandedRows asserts the
+// worker re-lists after every iteration: chats that land during an
+// engine call are picked up before the worker returns. This is R10A
+// from the plan.
+func TestMessagingAggregateWorker_RelistLoopDrainsLandedRows(t *testing.T) {
+	agg := &stubAggregator{}
+	lister := &stubChatLister{
+		source: "messages",
+		lists: [][]string{
+			{"chat-A"},
+			{"chat-B"}, // landed during chat-A processing
+			{},         // drained
+		},
+	}
+	worker := NewMessagingAggregateForContactWorker(
+		map[string]chatAwareAggregator{"messages": agg},
+		lister,
+	)
+	err := worker.Work(context.Background(), &river.Job[consumerjobs.MessagingAggregateForContactArgs]{
+		Args: consumerjobs.MessagingAggregateForContactArgs{ContactID: uuid.New(), Source: "messages"},
+	})
+	require.NoError(t, err)
+	require.Len(t, agg.calls, 2)
+	require.Equal(t, "chat-A", agg.calls[0].chatID)
+	require.Equal(t, "chat-B", agg.calls[1].chatID)
+}
+
+// TestMessagingAggregateWorker_UnknownSource_NoOp confirms the worker
+// returns nil and does NOT call the engine when the args carry an
+// unregistered source.
+func TestMessagingAggregateWorker_UnknownSource_NoOp(t *testing.T) {
+	agg := &stubAggregator{}
+	lister := &stubChatLister{source: "messages", lists: [][]string{{"chat-A"}, {}}}
+	worker := NewMessagingAggregateForContactWorker(
+		map[string]chatAwareAggregator{"messages": agg},
+		lister,
+	)
+	err := worker.Work(context.Background(), &river.Job[consumerjobs.MessagingAggregateForContactArgs]{
+		Args: consumerjobs.MessagingAggregateForContactArgs{ContactID: uuid.New(), Source: "whatsapp"},
+	})
+	require.NoError(t, err)
+	require.Empty(t, agg.calls)
+}
+
+// TestMessagingAggregateWorker_EngineError_Propagates verifies an
+// engine failure propagates through the worker so River's retry
+// machinery kicks in.
+func TestMessagingAggregateWorker_EngineError_Propagates(t *testing.T) {
+	agg := &stubAggregator{failOn: "chat-A", failErr: errors.New("boom")}
+	lister := &stubChatLister{source: "messages", lists: [][]string{{"chat-A"}, {}}}
+	worker := NewMessagingAggregateForContactWorker(
+		map[string]chatAwareAggregator{"messages": agg},
+		lister,
+	)
+	err := worker.Work(context.Background(), &river.Job[consumerjobs.MessagingAggregateForContactArgs]{
+		Args: consumerjobs.MessagingAggregateForContactArgs{ContactID: uuid.New(), Source: "messages"},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "boom")
+}
+
+// TestMessagingAggregateWorker_ListerError_Propagates verifies a
+// lister failure surfaces. Lister errors during the first iteration
+// fail the job; an error after some chats were already processed
+// also fails the run so River retries the whole pass.
+func TestMessagingAggregateWorker_ListerError_Propagates(t *testing.T) {
+	agg := &stubAggregator{}
+	lister := &stubChatLister{
+		source:    "messages",
+		lists:     [][]string{{"chat-A"}, {"chat-B"}},
+		errAfter:  1,
+		errReturn: errors.New("db down"),
+	}
+	worker := NewMessagingAggregateForContactWorker(
+		map[string]chatAwareAggregator{"messages": agg},
+		lister,
+	)
+	err := worker.Work(context.Background(), &river.Job[consumerjobs.MessagingAggregateForContactArgs]{
+		Args: consumerjobs.MessagingAggregateForContactArgs{ContactID: uuid.New(), Source: "messages"},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "list unprocessed chats")
+}
+
+// TestMessagingAggregateWorker_LoopBound_TerminatesAndLogs asserts the
+// worker exits cleanly (returns nil) after workerLoopMaxIterations
+// even if the lister keeps returning non-empty results.
+func TestMessagingAggregateWorker_LoopBound_TerminatesAndLogs(t *testing.T) {
+	agg := &stubAggregator{}
+	// Build a lists slice that returns a single chat ad infinitum
+	// (stubChatLister returns the last list once exhausted).
+	lists := make([][]string, 0, workerLoopMaxIterations+1)
+	for i := 0; i < workerLoopMaxIterations+1; i++ {
+		lists = append(lists, []string{"chat-A"})
+	}
+	lister := &stubChatLister{source: "messages", lists: lists}
+	worker := NewMessagingAggregateForContactWorker(
+		map[string]chatAwareAggregator{"messages": agg},
+		lister,
+	)
+	err := worker.Work(context.Background(), &river.Job[consumerjobs.MessagingAggregateForContactArgs]{
+		Args: consumerjobs.MessagingAggregateForContactArgs{ContactID: uuid.New(), Source: "messages"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, workerLoopMaxIterations, len(agg.calls),
+		"worker should have called engine exactly workerLoopMaxIterations times before bailing")
+}
+
+// TestPerSourceChatListerRegistry_DispatchesAndNoOpsUnknown verifies
+// the registry behavior at the unit level.
+func TestPerSourceChatListerRegistry_DispatchesAndNoOpsUnknown(t *testing.T) {
+	called := 0
+	reg := NewPerSourceChatListerRegistry(map[string]func(ctx context.Context, contactID uuid.UUID) ([]string, error){
+		"messages": func(_ context.Context, _ uuid.UUID) ([]string, error) {
+			called++
+			return []string{"chat-A"}, nil
+		},
+	})
+
+	got, err := reg.ListUnprocessedChats(context.Background(), "messages", uuid.New())
+	require.NoError(t, err)
+	require.Equal(t, []string{"chat-A"}, got)
+	require.Equal(t, 1, called)
+
+	got, err = reg.ListUnprocessedChats(context.Background(), "unknown", uuid.New())
+	require.NoError(t, err)
+	require.Nil(t, got)
+	require.Equal(t, 1, called, "unknown source should not call any entry")
+}

--- a/backend/internal/scheduler/messaging_aggregate_worker_test.go
+++ b/backend/internal/scheduler/messaging_aggregate_worker_test.go
@@ -90,8 +90,7 @@ func TestMessagingAggregateWorker_HappyPath_DrainsAndCallsPerChat(t *testing.T) 
 
 // TestMessagingAggregateWorker_RelistLoopDrainsLandedRows asserts the
 // worker re-lists after every iteration: chats that land during an
-// engine call are picked up before the worker returns. This is R10A
-// from the plan.
+// engine call are picked up before the worker returns.
 func TestMessagingAggregateWorker_RelistLoopDrainsLandedRows(t *testing.T) {
 	agg := &stubAggregator{}
 	lister := &stubChatLister{

--- a/backend/internal/scheduler/messaging_aggregate_worker_test.go
+++ b/backend/internal/scheduler/messaging_aggregate_worker_test.go
@@ -73,7 +73,7 @@ func TestMessagingAggregateWorker_HappyPath_DrainsAndCallsPerChat(t *testing.T) 
 		},
 	}
 	worker := NewMessagingAggregateForContactWorker(
-		map[string]chatAwareAggregator{"messages": agg},
+		map[string]ChatAwareAggregator{"messages": agg},
 		lister,
 	)
 
@@ -103,7 +103,7 @@ func TestMessagingAggregateWorker_RelistLoopDrainsLandedRows(t *testing.T) {
 		},
 	}
 	worker := NewMessagingAggregateForContactWorker(
-		map[string]chatAwareAggregator{"messages": agg},
+		map[string]ChatAwareAggregator{"messages": agg},
 		lister,
 	)
 	err := worker.Work(context.Background(), &river.Job[consumerjobs.MessagingAggregateForContactArgs]{
@@ -122,7 +122,7 @@ func TestMessagingAggregateWorker_UnknownSource_NoOp(t *testing.T) {
 	agg := &stubAggregator{}
 	lister := &stubChatLister{source: "messages", lists: [][]string{{"chat-A"}, {}}}
 	worker := NewMessagingAggregateForContactWorker(
-		map[string]chatAwareAggregator{"messages": agg},
+		map[string]ChatAwareAggregator{"messages": agg},
 		lister,
 	)
 	err := worker.Work(context.Background(), &river.Job[consumerjobs.MessagingAggregateForContactArgs]{
@@ -139,7 +139,7 @@ func TestMessagingAggregateWorker_EngineError_Propagates(t *testing.T) {
 	agg := &stubAggregator{failOn: "chat-A", failErr: errors.New("boom")}
 	lister := &stubChatLister{source: "messages", lists: [][]string{{"chat-A"}, {}}}
 	worker := NewMessagingAggregateForContactWorker(
-		map[string]chatAwareAggregator{"messages": agg},
+		map[string]ChatAwareAggregator{"messages": agg},
 		lister,
 	)
 	err := worker.Work(context.Background(), &river.Job[consumerjobs.MessagingAggregateForContactArgs]{
@@ -162,7 +162,7 @@ func TestMessagingAggregateWorker_ListerError_Propagates(t *testing.T) {
 		errReturn: errors.New("db down"),
 	}
 	worker := NewMessagingAggregateForContactWorker(
-		map[string]chatAwareAggregator{"messages": agg},
+		map[string]ChatAwareAggregator{"messages": agg},
 		lister,
 	)
 	err := worker.Work(context.Background(), &river.Job[consumerjobs.MessagingAggregateForContactArgs]{
@@ -185,7 +185,7 @@ func TestMessagingAggregateWorker_LoopBound_TerminatesAndLogs(t *testing.T) {
 	}
 	lister := &stubChatLister{source: "messages", lists: lists}
 	worker := NewMessagingAggregateForContactWorker(
-		map[string]chatAwareAggregator{"messages": agg},
+		map[string]ChatAwareAggregator{"messages": agg},
 		lister,
 	)
 	err := worker.Work(context.Background(), &river.Job[consumerjobs.MessagingAggregateForContactArgs]{

--- a/backend/internal/service/identity.go
+++ b/backend/internal/service/identity.go
@@ -10,6 +10,7 @@ import (
 	"personal-crm/backend/internal/repository"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 )
 
 // MatchRequest represents a request to match an external identifier
@@ -162,6 +163,120 @@ func (s *IdentityService) recordKnownMatch(ctx context.Context, normalized strin
 		MatchType: repository.MatchTypeExact,
 		Cached:    false,
 	}, nil
+}
+
+// MatchOrCreateTx is the tx-bound variant of MatchOrCreate. The
+// identity-row upsert and contact-method search both run inside the
+// caller's transaction, so a downstream failure in the same tx rolls
+// back the identity write atomically with whatever else the caller
+// is doing (e.g., the ingest service's staging-row insert).
+//
+// Error-handling divergence vs the non-tx MatchOrCreate: the
+// underlying findContactByMethodTx propagates repository errors
+// rather than swallowing them and degrading to MatchTypeUnmatched.
+// In the ingest hot path a silent degrade would strand the row AND
+// let the daemon advance its cursor — the caller wants to surface a
+// per-event rejection instead. The non-tx MatchOrCreate keeps its
+// existing forgiving behavior for the sync providers that already
+// depend on it.
+func (s *IdentityService) MatchOrCreateTx(ctx context.Context, tx pgx.Tx, req MatchRequest) (*MatchResult, error) {
+	normalized := identity.Normalize(req.RawIdentifier, req.Type)
+	if normalized == "" {
+		return nil, fmt.Errorf("empty identifier after normalization")
+	}
+
+	// Contact-driven mode is intentionally NOT supported on the tx
+	// path today — the ingest hot path is always discovery-mode
+	// (the daemon does not know which contact the peer belongs to).
+	// Future callers can extend; reject for now to keep the surface
+	// minimal.
+	if req.KnownContactID != nil {
+		return nil, fmt.Errorf("MatchOrCreateTx: KnownContactID is not supported")
+	}
+
+	// Cache check (matches MatchOrCreate's step 3): if we already
+	// know this identifier for this source AND a contact, return the
+	// cached match.
+	existing, err := s.identityRepo.GetByIdentifierTx(ctx, tx, req.Type, normalized, req.Source)
+	if err == nil && existing.ContactID != nil {
+		return &MatchResult{
+			Identity:  existing,
+			ContactID: existing.ContactID,
+			MatchType: existing.MatchType,
+			Cached:    true,
+		}, nil
+	}
+
+	// Discovery path: search contact_method for a match. Error
+	// propagation (vs. swallow + unmatched) is the deliberate
+	// divergence from the non-tx path — see method doc.
+	contactID, matchType, err := s.findContactByMethodTx(ctx, tx, normalized, req.Type)
+	if err != nil {
+		return nil, fmt.Errorf("find contact methods: %w", err)
+	}
+
+	now := accelerated.GetCurrentTime()
+	upsertReq := repository.UpsertIdentityRequest{
+		Identifier:     normalized,
+		IdentifierType: req.Type,
+		RawIdentifier:  &req.RawIdentifier,
+		Source:         req.Source,
+		SourceID:       req.SourceID,
+		ContactID:      contactID,
+		MatchType:      matchType,
+		DisplayName:    req.DisplayName,
+		LastSeenAt:     &now,
+		MessageCount:   1,
+	}
+	if matchType == repository.MatchTypeExact {
+		confidence := 1.0
+		upsertReq.MatchConfidence = &confidence
+	}
+
+	ident, err := s.identityRepo.UpsertTx(ctx, tx, upsertReq)
+	if err != nil {
+		return nil, fmt.Errorf("upsert identity: %w", err)
+	}
+
+	return &MatchResult{
+		Identity:  ident,
+		ContactID: contactID,
+		MatchType: matchType,
+		Cached:    false,
+	}, nil
+}
+
+// findContactByMethodTx is the tx-bound variant of findContactByMethod.
+// CRITICALLY, it propagates errors rather than swallowing them — see
+// MatchOrCreateTx for why this divergence matters in the ingest hot
+// path.
+func (s *IdentityService) findContactByMethodTx(ctx context.Context, tx pgx.Tx, identifier string, idType identity.IdentifierType) (*uuid.UUID, repository.MatchType, error) {
+	methodTypes := identity.MapIdentifierTypeToContactMethodTypes(idType)
+	if len(methodTypes) == 0 {
+		return nil, repository.MatchTypeUnmatched, nil
+	}
+	typeStrings := make([]string, len(methodTypes))
+	for i, mt := range methodTypes {
+		typeStrings[i] = string(mt)
+	}
+
+	matches, err := s.identityRepo.FindContactMethodsByValueTx(ctx, tx, typeStrings, identifier)
+	if err != nil {
+		return nil, repository.MatchTypeUnmatched, err
+	}
+
+	if len(matches) == 0 {
+		return nil, repository.MatchTypeUnmatched, nil
+	}
+	if len(matches) == 1 {
+		return &matches[0].ContactID, repository.MatchTypeExact, nil
+	}
+	// Multiple matches — ambiguous, leave for user to resolve.
+	logger.Warn().
+		Str("identifier", identifier).
+		Int("match_count", len(matches)).
+		Msg("ambiguous identity match - multiple contacts found")
+	return nil, repository.MatchTypeUnmatched, nil
 }
 
 // findContactByMethod searches contact_method table for a match

--- a/backend/internal/service/ingest.go
+++ b/backend/internal/service/ingest.go
@@ -5,15 +5,61 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 
+	"personal-crm/backend/internal/consumer/consumerjobs"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/identity"
+	"personal-crm/backend/internal/repository"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
 )
+
+// Per-event rejection codes surfaced through perEventRejections so the
+// HTTP handler can translate them into the response's errors[] array.
+const (
+	ingestRejectUnsupportedHostAuthKind = "UNSUPPORTED_HOST_AUTH_KIND"
+	ingestRejectRawMessageRequiresHost  = "RAW_MESSAGE_REQUIRES_HOST_AUTH"
+	ingestRejectPayloadInvariant        = "PAYLOAD_INVARIANT"
+	ingestRejectPayloadInvalid          = "PAYLOAD_INVALID"
+	ingestRejectIdentityMatchFailed     = "IDENTITY_MATCH_FAILED"
+	ingestRejectStagingUpsertFailed     = "STAGING_UPSERT_FAILED"
+)
+
+// IngestPerEventRejection is a per-event domain rejection emitted by the
+// service-layer inline handlers. Index is the caller-original index from
+// originalIndices, NOT the compacted in-service position — so the HTTP
+// handler can surface it directly in the response's errors[] field.
+type IngestPerEventRejection struct {
+	Index   int
+	Code    string
+	Message string
+}
+
+// JobInsertTxer is the narrow surface for transactional River inserts.
+// Concrete is *river.Client[pgx.Tx]. Interface keeps the service
+// testable.
+type JobInsertTxer interface {
+	InsertTx(ctx context.Context, tx pgx.Tx, args river.JobArgs, opts *river.InsertOpts) (*rivertype.JobInsertResult, error)
+}
+
+// IdentityMatcher is the narrow surface for the per-event identity
+// match call. Concrete is *IdentityService.
+type IdentityMatcher interface {
+	MatchOrCreateTx(ctx context.Context, tx pgx.Tx, req MatchRequest) (*MatchResult, error)
+}
+
+// MessagesUpserter is the narrow surface for the per-event staging
+// upsert. Concrete is *repository.MessagesMessageRepository.
+type MessagesUpserter interface {
+	UpsertMessageTx(ctx context.Context, tx pgx.Tx, params repository.UpsertMessagesMessageParams) (*repository.MessagesMessage, error)
+}
 
 // IngestService persists pre-validated event envelopes inside a single
 // transaction. All envelopes in a batch commit together or roll back
@@ -23,56 +69,125 @@ import (
 // index) are silent no-ops inside Bus.PublishTx and do NOT abort the tx;
 // they're counted separately via the env.ID-sentinel pattern (see
 // IngestBatch docs).
+//
+// For raw_message.* kinds, the service runs an inline per-event handler
+// (identity match → staging upsert → aggregator job enqueue) inside a
+// per-event savepoint. Per-event domain failures surface as
+// IngestPerEventRejection entries; the batch continues. Infrastructure
+// failures (begin-tx, publish-tx, savepoint commit, end-of-batch
+// aggregator enqueue) abort the whole batch.
 type IngestService struct {
-	database *db.Database
-	bus      *events.Bus
+	database    *db.Database
+	bus         *events.Bus
+	identity    IdentityMatcher
+	messages    MessagesUpserter
+	riverClient JobInsertTxer
 }
 
-// NewIngestService builds an IngestService. database.Pool is used to open
-// the batch transaction; bus.PublishTx does the per-envelope insert.
-func NewIngestService(database *db.Database, bus *events.Bus) *IngestService {
-	return &IngestService{database: database, bus: bus}
+// NewIngestService builds an IngestService. The non-raw-message
+// dependencies (identity, messages, riverClient) may be nil — in that
+// case any raw_message.* envelope is per-event REJECTED with
+// PAYLOAD_INVARIANT explaining the missing wiring. Production
+// constructs all four; unit tests can pass nils for the irrelevant ones.
+func NewIngestService(
+	database *db.Database,
+	bus *events.Bus,
+	identityMatcher IdentityMatcher,
+	messages MessagesUpserter,
+	riverClient JobInsertTxer,
+) *IngestService {
+	return &IngestService{
+		database:    database,
+		bus:         bus,
+		identity:    identityMatcher,
+		messages:    messages,
+		riverClient: riverClient,
+	}
 }
 
-// IngestBatch persists envs in one pgx transaction. Returns (accepted,
-// duplicate, err):
+// hostAuthAllowedKinds is the single source of truth for which event
+// kinds may be submitted via the host-auth path. PR4 allows only the
+// daemon-emitted raw_message.* kinds. Future PRs widen this set
+// (external_contact.* in the iCloud upsert PR, etc).
+//
+// Symmetric: kinds in this set are REJECTED on the global-API-key
+// path — spec §3 line 345 locks daemon-emitted raw_message.* as the
+// ONLY producer path. Internal Pi publishers writing a raw_message
+// event would either be a bug or a hostile actor with the global key.
+var hostAuthAllowedKinds = map[events.Kind]struct{}{
+	events.KindRawMessageReceived: {},
+	events.KindRawMessageSent:     {},
+}
+
+// isHostAuthAllowedKind reports whether the kind is permitted on the
+// host-auth path.
+func isHostAuthAllowedKind(k events.Kind) bool {
+	_, ok := hostAuthAllowedKinds[k]
+	return ok
+}
+
+// isRawMessageKind reports whether the kind is a daemon-emitted
+// raw_message.* event. Used for the symmetric global-key rejection.
+func isRawMessageKind(k events.Kind) bool {
+	return k == events.KindRawMessageReceived || k == events.KindRawMessageSent
+}
+
+// pendingAggregateKey is the (source, contactID) pair used to dedupe
+// aggregator enqueues within a single batch.
+type pendingAggregateKey struct {
+	Source    string
+	ContactID uuid.UUID
+}
+
+// IngestBatch persists envs in one pgx transaction. Returns
+// (accepted, duplicate, perEventRejections, err):
 //
 //   - accepted: number of envelopes whose INSERT produced a fresh row.
 //   - duplicate: number of envelopes whose INSERT hit the (source,
 //     source_id) unique index and was silently dropped by the ON CONFLICT
 //     DO NOTHING clause.
-//   - err: any unexpected failure (begin-tx, publish-tx mid-batch, commit).
-//     The whole tx rolls back in this case; both counters are zero on
-//     error return.
+//   - perEventRejections: per-event domain rejections (host-auth
+//     allowlist violation, payload-invariant mismatch, identity-match
+//     failure, staging-upsert FK violation). Each entry's Index is the
+//     caller-original position from originalIndices, so the handler can
+//     append them to the response's errors[] field with correct
+//     indexing.
+//   - err: any unexpected DB/infrastructure failure (begin-tx, publish-
+//     tx, savepoint commit, end-of-batch aggregator enqueue, outer
+//     commit). The whole tx rolls back in this case; counts are zero
+//     and perEventRejections is nil on error return.
 //
-// The empty-slice case is handled without opening a transaction (trivial
-// optimization).
+// Precondition: every envelope MUST have env.ID == uuid.Nil on entry
+// (the env.ID-sentinel duplicate-detection contract relies on it).
+// originalIndices[i] is the caller-original position of envs[i] in the
+// caller's pre-validation request array. len(originalIndices) ==
+// len(envs); a length mismatch is a caller bug and returns an error.
 //
-// Duplicate detection relies on Bus.PublishTx returning nil for both
-// happy-path inserts and ON CONFLICT DO NOTHING hits. The repository
-// populates env.ID only on a real RETURNING row, so env.ID == uuid.Nil
-// is the duplicate sentinel. See PR 2 plan Design Decision 2 for the
-// documented contract this depends on.
-//
-// Precondition: every envelope MUST have env.ID == uuid.Nil on entry.
-// EventRepository.InsertEvent supports caller-supplied IDs (via the
-// COALESCE in the sqlc query), which would collide with the sentinel
-// logic here and cause a duplicate to be miscounted as accepted. The
-// HTTP handler constructs fresh envelopes so this always holds; we
-// guard defensively to keep the contract visible at the service
-// boundary. A precondition violation is a caller bug — return an error
-// rather than silently miscounting.
-func (s *IngestService) IngestBatch(ctx context.Context, envs []*events.Envelope) (accepted, duplicate int, err error) {
+// hostID is the authenticated Mac-host UUID when the request was
+// received on the host-auth path; nil on the global-API-key path. The
+// service uses hostID to enforce the per-path kind allowlist (D8) and
+// to stamp staging rows with mac_host_id.
+func (s *IngestService) IngestBatch(
+	ctx context.Context,
+	envs []*events.Envelope,
+	originalIndices []int,
+	hostID *uuid.UUID,
+) (accepted, duplicate int, perEventRejections []IngestPerEventRejection, err error) {
 	if len(envs) == 0 {
-		return 0, 0, nil
+		return 0, 0, nil, nil
+	}
+	if len(originalIndices) != len(envs) {
+		return 0, 0, nil, fmt.Errorf(
+			"ingest: originalIndices length %d does not match envs length %d",
+			len(originalIndices), len(envs))
 	}
 
 	for i, env := range envs {
 		if env == nil {
-			return 0, 0, fmt.Errorf("ingest: envelope at index %d is nil", i)
+			return 0, 0, nil, fmt.Errorf("ingest: envelope at index %d is nil", i)
 		}
 		if env.ID != uuid.Nil {
-			return 0, 0, fmt.Errorf(
+			return 0, 0, nil, fmt.Errorf(
 				"ingest: envelope at index %d has a pre-assigned ID; IngestBatch "+
 					"requires ID=uuid.Nil so the duplicate sentinel works", i)
 		}
@@ -80,7 +195,7 @@ func (s *IngestService) IngestBatch(ctx context.Context, envs []*events.Envelope
 
 	tx, err := s.database.Pool.Begin(ctx)
 	if err != nil {
-		return 0, 0, fmt.Errorf("begin tx: %w", err)
+		return 0, 0, nil, fmt.Errorf("begin tx: %w", err)
 	}
 	// Rollback on any non-commit return. Safe to call after Commit: pgx
 	// returns ErrTxClosed which we ignore. If rollback itself fails and no
@@ -92,22 +207,271 @@ func (s *IngestService) IngestBatch(ctx context.Context, envs []*events.Envelope
 		}
 	}()
 
+	pendingAggregate := make(map[pendingAggregateKey]struct{})
+
 	for i, env := range envs {
-		if pubErr := s.bus.PublishTx(ctx, tx, env); pubErr != nil {
-			return 0, 0, fmt.Errorf("publish event index %d: %w", i, pubErr)
+		originalIdx := originalIndices[i]
+
+		// Step 1 — host-auth allowlist enforcement (D8).
+		//   * raw_message.* allowed ONLY on the host-auth path (hostID != nil).
+		//   * other kinds allowed ONLY on the global-key path (hostID == nil).
+		if hostID != nil {
+			if !isHostAuthAllowedKind(env.Kind) {
+				perEventRejections = append(perEventRejections, IngestPerEventRejection{
+					Index:   originalIdx,
+					Code:    ingestRejectUnsupportedHostAuthKind,
+					Message: fmt.Sprintf("kind %q not allowed on host-auth path; daemon only emits raw_message.*", env.Kind),
+				})
+				continue
+			}
+		} else if isRawMessageKind(env.Kind) {
+			perEventRejections = append(perEventRejections, IngestPerEventRejection{
+				Index:   originalIdx,
+				Code:    ingestRejectRawMessageRequiresHost,
+				Message: "raw_message.* events require X-Mac-Host-ID auth path",
+			})
+			continue
 		}
-		// env.ID is populated iff the INSERT produced a row. On ON CONFLICT
-		// DO NOTHING (dup (source, source_id)) the repository returns nil
-		// without mutating env.ID, leaving it at uuid.Nil.
-		if env.ID == uuid.Nil {
+
+		// Step 2 — payload-invariant cross-checks (raw_message only).
+		// Done BEFORE opening the savepoint so a clean failure doesn't
+		// even open one. The handler's pre-validation already enforced
+		// required-field presence; we cross-check the envelope/payload
+		// pair.
+		if isRawMessageKind(env.Kind) {
+			if rejection := verifyRawMessageInvariants(env, *hostID); rejection != nil {
+				rejection.Index = originalIdx
+				perEventRejections = append(perEventRejections, *rejection)
+				continue
+			}
+		}
+
+		// Step 3 — open a savepoint so per-event domain failures roll
+		// back JUST this event's writes (event-log row, identity row,
+		// staging row) rather than poisoning the outer batch tx.
+		sp, spErr := tx.Begin(ctx)
+		if spErr != nil {
+			return 0, 0, nil, fmt.Errorf("begin savepoint for index %d (original %d): %w", i, originalIdx, spErr)
+		}
+
+		// Step 4 — durable publish to event log. PublishTx is idempotent
+		// by (source, source_id): on the partial-unique-index hit the
+		// RETURNING clause matches zero rows; the repository leaves
+		// env.ID = uuid.Nil so the caller detects duplicate-skip.
+		//
+		// PublishTx errors are UNEXPECTED (not user-input-shaped). Per
+		// the contract, err != nil is reserved for unexpected DB
+		// failures so the batch rolls back as a unit; we do NOT degrade
+		// to per-event rejection here.
+		if pubErr := s.bus.PublishTx(ctx, sp, env); pubErr != nil {
+			if rbErr := sp.Rollback(ctx); rbErr != nil {
+				return 0, 0, nil, fmt.Errorf("publish event index %d (original %d): %w (rollback: %v)", i, originalIdx, pubErr, rbErr)
+			}
+			return 0, 0, nil, fmt.Errorf("publish event index %d (original %d): %w", i, originalIdx, pubErr)
+		}
+
+		isDuplicate := env.ID == uuid.Nil
+
+		// Step 5 — inline handler for raw_message kinds. On duplicate
+		// (Step 4 detected a dedup hit) we SKIP the inline handler
+		// entirely: re-running identity-match + re-upserting staging on
+		// every duplicate would spuriously bump
+		// external_identity.last_seen_at and re-add the row to
+		// pendingAggregate. Both are wasteful; the guard makes a
+		// duplicate re-submit a true no-op.
+		if !isDuplicate && isRawMessageKind(env.Kind) {
+			contactID, rejection := s.handleRawMessage(ctx, sp, env, *hostID)
+			if rejection != nil {
+				rejection.Index = originalIdx
+				perEventRejections = append(perEventRejections, *rejection)
+				if rbErr := sp.Rollback(ctx); rbErr != nil {
+					return 0, 0, nil, fmt.Errorf("rollback savepoint for rejected index %d (original %d): %w", i, originalIdx, rbErr)
+				}
+				continue
+			}
+			if contactID != nil {
+				pendingAggregate[pendingAggregateKey{Source: env.Source, ContactID: *contactID}] = struct{}{}
+			}
+		}
+
+		if commitErr := sp.Commit(ctx); commitErr != nil {
+			return 0, 0, nil, fmt.Errorf("commit savepoint %d (original %d): %w", i, originalIdx, commitErr)
+		}
+
+		if isDuplicate {
 			duplicate++
 		} else {
 			accepted++
 		}
 	}
 
-	if commitErr := tx.Commit(ctx); commitErr != nil {
-		return 0, 0, fmt.Errorf("commit: %w", commitErr)
+	// Step 6 — end-of-batch aggregator-enqueue. Each enqueue is in the
+	// OUTER tx (not a savepoint) — a failure here rolls the whole
+	// batch back (R4 rationale: partial-enqueue stranding is worse than
+	// a daemon retry).
+	for pair := range pendingAggregate {
+		if s.riverClient == nil {
+			// No river client wired (test mode). Skip enqueue; the
+			// staging rows are still durable so the periodic sweeper
+			// will eventually pick them up.
+			continue
+		}
+		args := consumerjobs.MessagingAggregateForContactArgs{
+			ContactID: pair.ContactID,
+			Source:    pair.Source,
+		}
+		if _, insErr := s.riverClient.InsertTx(ctx, tx, args, &river.InsertOpts{
+			UniqueOpts: river.UniqueOpts{ByArgs: true},
+		}); insErr != nil {
+			return 0, 0, nil, fmt.Errorf("enqueue messaging aggregate (contact=%s source=%s): %w",
+				pair.ContactID, pair.Source, insErr)
+		}
 	}
-	return accepted, duplicate, nil
+
+	if commitErr := tx.Commit(ctx); commitErr != nil {
+		return 0, 0, nil, fmt.Errorf("commit: %w", commitErr)
+	}
+	return accepted, duplicate, perEventRejections, nil
+}
+
+// handleRawMessage runs the per-event domain logic for raw_message.*
+// envelopes inside the per-event savepoint:
+//
+//  1. Decode the payload (already structurally validated by handler).
+//  2. Detect identifier type (phone vs email) and call IdentityService.
+//     MatchOrCreateTx — propagates repo errors per R2.
+//  3. Upsert messages_message staging via the tx-bound repository.
+//  4. Return the matched contactID (nil when unmatched — caller skips
+//     aggregator enqueue) and nil rejection on success.
+//
+// Returns (contactID, rejection): contactID may be nil even on success
+// (unmatched peer). rejection != nil means the inline handler refused
+// the event for a domain reason; the caller rolls back the savepoint
+// and continues the batch.
+func (s *IngestService) handleRawMessage(
+	ctx context.Context,
+	tx pgx.Tx,
+	env *events.Envelope,
+	hostID uuid.UUID,
+) (*uuid.UUID, *IngestPerEventRejection) {
+	// The dependencies are constructor-injected; a missing dep here is
+	// a wiring bug (the handler should not let raw_message events
+	// through when the service wasn't configured for them).
+	if s.identity == nil || s.messages == nil {
+		return nil, &IngestPerEventRejection{
+			Code:    ingestRejectPayloadInvariant,
+			Message: "ingest service was not configured for raw_message processing",
+		}
+	}
+
+	// Re-decode the payload (structurally validated by the handler;
+	// verifyRawMessageInvariants ran on the cross-field invariants).
+	// Re-decode here rather than passing the decoded struct through —
+	// keeps the handler/service contract on []byte payloads, matching
+	// the rest of the ingest flow.
+	var p events.RawMessageReceivedPayload
+	if err := json.Unmarshal(env.Payload, &p); err != nil {
+		return nil, &IngestPerEventRejection{
+			Code:    ingestRejectPayloadInvalid,
+			Message: fmt.Sprintf("decode raw_message payload: %s", err.Error()),
+		}
+	}
+
+	idType := identity.DetectIdentifierType(p.PeerHandle)
+	matchReq := MatchRequest{
+		RawIdentifier: p.PeerHandle,
+		Type:          idType,
+		Source:        env.Source,
+		SourceID:      &p.Guid,
+		DisplayName:   p.PeerName,
+	}
+	matchResult, err := s.identity.MatchOrCreateTx(ctx, tx, matchReq)
+	if err != nil {
+		return nil, &IngestPerEventRejection{
+			Code:    ingestRejectIdentityMatchFailed,
+			Message: fmt.Sprintf("identity match: %s", err.Error()),
+		}
+	}
+
+	var peerNormalized *string
+	if matchResult.Identity != nil && matchResult.Identity.Identifier != "" {
+		s := matchResult.Identity.Identifier
+		peerNormalized = &s
+	}
+
+	upsertParams := repository.UpsertMessagesMessageParams{
+		Guid:             p.Guid,
+		ChatGuid:         p.ChatID,
+		PeerHandle:       p.PeerHandle,
+		PeerNormalized:   peerNormalized,
+		Text:             p.Text,
+		MessageType:      p.MessageType,
+		SentAt:           p.SentAt,
+		IsOutgoing:       env.Kind == events.KindRawMessageSent,
+		IsGroupChat:      p.IsGroup,
+		ReplyToGuid:      p.ReplyToGuid,
+		MatchedContactID: matchResult.ContactID,
+		MacHostID:        &hostID,
+	}
+	if _, err := s.messages.UpsertMessageTx(ctx, tx, upsertParams); err != nil {
+		return nil, &IngestPerEventRejection{
+			Code:    ingestRejectStagingUpsertFailed,
+			Message: fmt.Sprintf("upsert messages_message: %s", err.Error()),
+		}
+	}
+
+	return matchResult.ContactID, nil
+}
+
+// verifyRawMessageInvariants enforces the cross-field consistency
+// properties that ValidatePayload (lenient unknown-field decode) does
+// not. Returns a *IngestPerEventRejection (caller fills in Index) on
+// any violation, nil on success.
+//
+// Properties checked:
+//  1. payload.HostID matches the authenticated host (no host
+//     cross-impersonation).
+//  2. env.Source matches the PR4-locked "messages" source.
+//  3. payload.Source matches env.Source.
+//  4. payload.Guid is non-empty and equals env.SourceID (so event-log
+//     dedup key and staging-table dedup key are the same string).
+func verifyRawMessageInvariants(env *events.Envelope, authenticatedHostID uuid.UUID) *IngestPerEventRejection {
+	var p events.RawMessageReceivedPayload
+	if err := json.Unmarshal(env.Payload, &p); err != nil {
+		return &IngestPerEventRejection{
+			Code:    ingestRejectPayloadInvalid,
+			Message: fmt.Sprintf("decode raw_message payload: %s", err.Error()),
+		}
+	}
+	if p.HostID != authenticatedHostID {
+		return &IngestPerEventRejection{
+			Code:    ingestRejectPayloadInvariant,
+			Message: "payload host_id does not match authenticated host",
+		}
+	}
+	if env.Source != "messages" {
+		return &IngestPerEventRejection{
+			Code:    ingestRejectPayloadInvariant,
+			Message: fmt.Sprintf("env.source %q not supported on raw_message kinds", env.Source),
+		}
+	}
+	if p.Source != env.Source {
+		return &IngestPerEventRejection{
+			Code:    ingestRejectPayloadInvariant,
+			Message: "payload source does not match envelope source",
+		}
+	}
+	if p.Guid == "" {
+		return &IngestPerEventRejection{
+			Code:    ingestRejectPayloadInvariant,
+			Message: "payload guid is required",
+		}
+	}
+	if p.Guid != env.SourceID {
+		return &IngestPerEventRejection{
+			Code:    ingestRejectPayloadInvariant,
+			Message: "payload guid must equal envelope source_id",
+		}
+	}
+	return nil
 }

--- a/backend/internal/service/ingest.go
+++ b/backend/internal/service/ingest.go
@@ -106,14 +106,14 @@ func NewIngestService(
 }
 
 // hostAuthAllowedKinds is the single source of truth for which event
-// kinds may be submitted via the host-auth path. PR4 allows only the
-// daemon-emitted raw_message.* kinds. Future PRs widen this set
-// (external_contact.* in the iCloud upsert PR, etc).
+// kinds may be submitted via the host-auth path. Currently only the
+// daemon-emitted raw_message.* kinds are allowed; new daemon-emitted
+// kinds extend the set as they land.
 //
 // Symmetric: kinds in this set are REJECTED on the global-API-key
-// path — spec §3 line 345 locks daemon-emitted raw_message.* as the
-// ONLY producer path. Internal Pi publishers writing a raw_message
-// event would either be a bug or a hostile actor with the global key.
+// path. Daemon-emitted raw_message.* is the ONLY producer path;
+// an internal Pi publisher writing a raw_message would either be a
+// bug or a hostile actor with the global key.
 var hostAuthAllowedKinds = map[events.Kind]struct{}{
 	events.KindRawMessageReceived: {},
 	events.KindRawMessageSent:     {},
@@ -165,7 +165,7 @@ type pendingAggregateKey struct {
 //
 // hostID is the authenticated Mac-host UUID when the request was
 // received on the host-auth path; nil on the global-API-key path. The
-// service uses hostID to enforce the per-path kind allowlist (D8) and
+// service uses hostID to enforce the per-path kind allowlist and
 // to stamp staging rows with mac_host_id.
 func (s *IngestService) IngestBatch(
 	ctx context.Context,
@@ -212,7 +212,7 @@ func (s *IngestService) IngestBatch(
 	for i, env := range envs {
 		originalIdx := originalIndices[i]
 
-		// Step 1 — host-auth allowlist enforcement (D8).
+		// Step 1 — host-auth allowlist enforcement.
 		//   * raw_message.* allowed ONLY on the host-auth path (hostID != nil).
 		//   * other kinds allowed ONLY on the global-key path (hostID == nil).
 		if hostID != nil {
@@ -431,7 +431,7 @@ func (s *IngestService) handleRawMessage(
 // Properties checked:
 //  1. payload.HostID matches the authenticated host (no host
 //     cross-impersonation).
-//  2. env.Source matches the PR4-locked "messages" source.
+//  2. env.Source matches the currently-supported "messages" source.
 //  3. payload.Source matches env.Source.
 //  4. payload.Guid is non-empty and equals env.SourceID (so event-log
 //     dedup key and staging-table dedup key are the same string).

--- a/backend/internal/service/ingest.go
+++ b/backend/internal/service/ingest.go
@@ -339,7 +339,8 @@ func (s *IngestService) IngestBatch(
 //
 //  1. Decode the payload (already structurally validated by handler).
 //  2. Detect identifier type (phone vs email) and call IdentityService.
-//     MatchOrCreateTx — propagates repo errors per R2.
+//     MatchOrCreateTx — propagates repo errors so the daemon does not
+//     advance its cursor on a transient identity-match failure.
 //  3. Upsert messages_message staging via the tx-bound repository.
 //  4. Return the matched contactID (nil when unmatched — caller skips
 //     aggregator enqueue) and nil rejection on success.

--- a/backend/internal/service/ingest_test.go
+++ b/backend/internal/service/ingest_test.go
@@ -11,21 +11,23 @@ import (
 )
 
 // TestIngestService_EmptyBatch_FastPath ensures the empty-slice case does
-// NOT open a transaction — it returns (0, 0, nil) immediately. Passing a
-// nil database + nil bus would panic if the code tried to Begin on the
+// NOT open a transaction — it returns (0, 0, nil, nil) immediately. Passing
+// a nil database + nil bus would panic if the code tried to Begin on the
 // pool, so the test proves the short-circuit works.
 func TestIngestService_EmptyBatch_FastPath(t *testing.T) {
 	svc := &IngestService{} // no DB, no bus — fast path must not touch them
-	accepted, duplicate, err := svc.IngestBatch(context.Background(), nil)
+	accepted, duplicate, rejections, err := svc.IngestBatch(context.Background(), nil, nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, 0, accepted)
 	require.Equal(t, 0, duplicate)
+	require.Empty(t, rejections)
 
 	// Same for an explicit zero-length slice.
-	accepted, duplicate, err = svc.IngestBatch(context.Background(), []*events.Envelope{})
+	accepted, duplicate, rejections, err = svc.IngestBatch(context.Background(), []*events.Envelope{}, []int{}, nil)
 	require.NoError(t, err)
 	require.Equal(t, 0, accepted)
 	require.Equal(t, 0, duplicate)
+	require.Empty(t, rejections)
 }
 
 // TestIngestService_RejectsNilEnvelope guards against a caller bug where
@@ -33,7 +35,7 @@ func TestIngestService_EmptyBatch_FastPath(t *testing.T) {
 // inside the publish loop once a transaction is open.
 func TestIngestService_RejectsNilEnvelope(t *testing.T) {
 	svc := &IngestService{} // precondition check fires before DB access
-	_, _, err := svc.IngestBatch(context.Background(), []*events.Envelope{nil})
+	_, _, _, err := svc.IngestBatch(context.Background(), []*events.Envelope{nil}, []int{0}, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "envelope at index 0 is nil")
 }
@@ -46,7 +48,161 @@ func TestIngestService_RejectsNilEnvelope(t *testing.T) {
 func TestIngestService_RejectsPreAssignedID(t *testing.T) {
 	svc := &IngestService{} // precondition check fires before DB access
 	env := &events.Envelope{ID: uuid.New()}
-	_, _, err := svc.IngestBatch(context.Background(), []*events.Envelope{env})
+	_, _, _, err := svc.IngestBatch(context.Background(), []*events.Envelope{env}, []int{0}, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "pre-assigned ID")
+}
+
+// TestIngestService_RejectsLenMismatchOnOriginalIndices guards the
+// callerProvided originalIndices contract: a length mismatch is a
+// caller bug and must surface before we open a transaction.
+func TestIngestService_RejectsLenMismatchOnOriginalIndices(t *testing.T) {
+	svc := &IngestService{}
+	env := &events.Envelope{} // valid (uuid.Nil)
+	_, _, _, err := svc.IngestBatch(context.Background(), []*events.Envelope{env}, []int{0, 1}, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "originalIndices length")
+}
+
+// --- host-auth allowlist / raw_message invariant unit tests ---
+//
+// These tests cover the per-event domain rejections that the service
+// can evaluate without touching the DB (allowlist + payload
+// invariants). End-to-end tx-bound paths (savepoint behavior, identity
+// match + staging upsert, aggregator enqueue) are covered by the
+// integration tests under backend/tests/api/.
+
+// TestIsHostAuthAllowedKind_Whitelist verifies the allowlist contains
+// exactly the daemon-emitted raw_message.* kinds and rejects all
+// others. Locks the D8 contract at the unit level.
+func TestIsHostAuthAllowedKind_Whitelist(t *testing.T) {
+	require.True(t, isHostAuthAllowedKind(events.KindRawMessageReceived))
+	require.True(t, isHostAuthAllowedKind(events.KindRawMessageSent))
+	// Sample of kinds that MUST NOT be allowed on host-auth.
+	for _, k := range []events.Kind{
+		events.KindMessageReceived,
+		events.KindMessageSent,
+		events.KindCalendarAttended,
+		events.KindTaskCompleted,
+		events.KindInteractionManual,
+		events.KindContactMethodsAdded,
+		events.KindInteractionRecorded,
+	} {
+		require.False(t, isHostAuthAllowedKind(k), "kind %s must NOT be on host-auth allowlist", k)
+	}
+}
+
+// TestIsRawMessageKind verifies the helper.
+func TestIsRawMessageKind(t *testing.T) {
+	require.True(t, isRawMessageKind(events.KindRawMessageReceived))
+	require.True(t, isRawMessageKind(events.KindRawMessageSent))
+	require.False(t, isRawMessageKind(events.KindMessageReceived))
+	require.False(t, isRawMessageKind(events.KindCalendarAttended))
+}
+
+// TestVerifyRawMessageInvariants_HappyPath confirms a well-formed
+// envelope + payload passes.
+func TestVerifyRawMessageInvariants_HappyPath(t *testing.T) {
+	host := uuid.New()
+	pBytes := mustMarshalRawMsg(events.RawMessageReceivedPayload{
+		Version:     1,
+		HostID:      host,
+		Source:      "messages",
+		Guid:        "guid-1",
+		ChatID:      "chat-1",
+		PeerHandle:  "+15551234567",
+		MessageType: "text",
+	})
+	env := &events.Envelope{
+		Source:   "messages",
+		SourceID: "guid-1",
+		Kind:     events.KindRawMessageReceived,
+		Payload:  pBytes,
+	}
+	require.Nil(t, verifyRawMessageInvariants(env, host))
+}
+
+// TestVerifyRawMessageInvariants_HostMismatch rejects when payload.HostID
+// disagrees with the authenticated host.
+func TestVerifyRawMessageInvariants_HostMismatch(t *testing.T) {
+	authHost := uuid.New()
+	other := uuid.New()
+	pBytes := mustMarshalRawMsg(events.RawMessageReceivedPayload{
+		Version: 1, HostID: other, Source: "messages", Guid: "g",
+		ChatID: "c", PeerHandle: "x", MessageType: "text",
+	})
+	env := &events.Envelope{Source: "messages", SourceID: "g", Kind: events.KindRawMessageReceived, Payload: pBytes}
+	rej := verifyRawMessageInvariants(env, authHost)
+	require.NotNil(t, rej)
+	require.Equal(t, ingestRejectPayloadInvariant, rej.Code)
+	require.Contains(t, rej.Message, "host_id")
+}
+
+// TestVerifyRawMessageInvariants_SourceMismatch rejects an envelope
+// whose source is not "messages" (PR4-locked).
+func TestVerifyRawMessageInvariants_SourceMismatch(t *testing.T) {
+	host := uuid.New()
+	pBytes := mustMarshalRawMsg(events.RawMessageReceivedPayload{
+		Version: 1, HostID: host, Source: "whatsapp", Guid: "g",
+		ChatID: "c", PeerHandle: "x", MessageType: "text",
+	})
+	env := &events.Envelope{Source: "whatsapp", SourceID: "g", Kind: events.KindRawMessageReceived, Payload: pBytes}
+	rej := verifyRawMessageInvariants(env, host)
+	require.NotNil(t, rej)
+	require.Equal(t, ingestRejectPayloadInvariant, rej.Code)
+	require.Contains(t, rej.Message, "not supported")
+}
+
+// TestVerifyRawMessageInvariants_PayloadSourceVsEnvelopeSource rejects
+// when the payload's source disagrees with the envelope's source.
+func TestVerifyRawMessageInvariants_PayloadSourceVsEnvelopeSource(t *testing.T) {
+	host := uuid.New()
+	pBytes := mustMarshalRawMsg(events.RawMessageReceivedPayload{
+		Version: 1, HostID: host, Source: "different", Guid: "g",
+		ChatID: "c", PeerHandle: "x", MessageType: "text",
+	})
+	env := &events.Envelope{Source: "messages", SourceID: "g", Kind: events.KindRawMessageReceived, Payload: pBytes}
+	rej := verifyRawMessageInvariants(env, host)
+	require.NotNil(t, rej)
+	require.Equal(t, ingestRejectPayloadInvariant, rej.Code)
+	require.Contains(t, rej.Message, "payload source")
+}
+
+// TestVerifyRawMessageInvariants_GuidMismatch rejects when payload.Guid
+// disagrees with env.SourceID — the staging-table dedup key and the
+// event-log dedup key MUST be the same string.
+func TestVerifyRawMessageInvariants_GuidMismatch(t *testing.T) {
+	host := uuid.New()
+	pBytes := mustMarshalRawMsg(events.RawMessageReceivedPayload{
+		Version: 1, HostID: host, Source: "messages", Guid: "guid-A",
+		ChatID: "c", PeerHandle: "x", MessageType: "text",
+	})
+	env := &events.Envelope{Source: "messages", SourceID: "guid-B", Kind: events.KindRawMessageReceived, Payload: pBytes}
+	rej := verifyRawMessageInvariants(env, host)
+	require.NotNil(t, rej)
+	require.Equal(t, ingestRejectPayloadInvariant, rej.Code)
+	require.Contains(t, rej.Message, "must equal envelope source_id")
+}
+
+// TestVerifyRawMessageInvariants_EmptyGuid rejects when payload.Guid is
+// empty even if env.SourceID matches — the guid IS the dedup key.
+func TestVerifyRawMessageInvariants_EmptyGuid(t *testing.T) {
+	host := uuid.New()
+	pBytes := mustMarshalRawMsg(events.RawMessageReceivedPayload{
+		Version: 1, HostID: host, Source: "messages",
+		ChatID: "c", PeerHandle: "x", MessageType: "text",
+	})
+	env := &events.Envelope{Source: "messages", SourceID: "", Kind: events.KindRawMessageReceived, Payload: pBytes}
+	rej := verifyRawMessageInvariants(env, host)
+	require.NotNil(t, rej)
+	require.Equal(t, ingestRejectPayloadInvariant, rej.Code)
+	require.Contains(t, rej.Message, "guid is required")
+}
+
+func mustMarshalRawMsg(p events.RawMessageReceivedPayload) []byte {
+	b, err := events.Marshal(events.KindRawMessageReceived, p)
+	if err != nil {
+		panic(err)
+	}
+	return b
 }

--- a/backend/internal/service/ingest_test.go
+++ b/backend/internal/service/ingest_test.go
@@ -74,7 +74,7 @@ func TestIngestService_RejectsLenMismatchOnOriginalIndices(t *testing.T) {
 
 // TestIsHostAuthAllowedKind_Whitelist verifies the allowlist contains
 // exactly the daemon-emitted raw_message.* kinds and rejects all
-// others. Locks the D8 contract at the unit level.
+// others. Locks the allowlist contract at the unit level.
 func TestIsHostAuthAllowedKind_Whitelist(t *testing.T) {
 	require.True(t, isHostAuthAllowedKind(events.KindRawMessageReceived))
 	require.True(t, isHostAuthAllowedKind(events.KindRawMessageSent))
@@ -139,7 +139,7 @@ func TestVerifyRawMessageInvariants_HostMismatch(t *testing.T) {
 }
 
 // TestVerifyRawMessageInvariants_SourceMismatch rejects an envelope
-// whose source is not "messages" (PR4-locked).
+// whose source is not "messages" (currently the only supported one).
 func TestVerifyRawMessageInvariants_SourceMismatch(t *testing.T) {
 	host := uuid.New()
 	pBytes := mustMarshalRawMsg(events.RawMessageReceivedPayload{

--- a/backend/tests/api/ingest_raw_message_e2e_test.go
+++ b/backend/tests/api/ingest_raw_message_e2e_test.go
@@ -1,82 +1,359 @@
 package api
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"testing"
+	"time"
 
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/api"
+	"personal-crm/backend/internal/api/handlers"
+	"personal-crm/backend/internal/auth"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/consumer"
 	"personal-crm/backend/internal/consumer/consumerjobs"
+	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/messages"
+	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/scheduler"
+	"personal-crm/backend/internal/service"
 
+	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/stretchr/testify/require"
 )
 
-// TestIngestRawMessage_E2E_WorkerProducesEvent runs the
-// MessagingAggregateForContactWorker against the live aggregation
-// engine after a raw_message.received POST and asserts the engine
-// emits a message.received event. The Stage 3 InteractionRecorder
-// consumer is exercised by separate harness tests in
-// consumer_interaction_recorder_integration_test.go; here we exercise
-// the Stage 1 → Stage 2 join (raw_message ingest staging row +
-// matched_contact_id → engine processes the chat and publishes the
-// burst event).
+// TestIngestRawMessage_E2E_StagesAggregatesAndCreatesInteraction is
+// the end-to-end test that locks the PR's contract:
 //
-// Why this test sits in tests/api and not internal/scheduler: the
-// ingest path's router + middleware are required to stage the row
-// in the first place. Without those, the engine has nothing to
-// process. The other worker unit tests (with stub engine + lister)
-// cover the worker's drain-loop behavior in isolation.
-func TestIngestRawMessage_E2E_WorkerProducesEvent(t *testing.T) {
-	env := setupRawIngestEnv(t)
-	guid := "test-guid-" + uuid.NewString()
-	ev := buildRawMessageEvent(t, events.KindRawMessageReceived, env.pairedHostID,
-		guid, "chat-end-to-end", "+15551234567")
-	w := postIngestRaw(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
-		"events": []any{ev},
-	})
-	require.Equal(t, 200, w.Code, "body: %s", w.Body.String())
-	require.Equal(t, 1, parseIngestResp(t, w).Accepted)
+//	POST /api/v1/ingest/events (raw_message.received, known contact)
+//	  → staging row inserted with matched_contact_id
+//	  → MessagingAggregateForContactArgs job enqueued
+//	  → worker runs engine.AggregateForContact per chat
+//	  → engine claims rows + publishes message.received envelope
+//	  → InteractionRecorder consumer creates the interaction row +
+//	    marks staging.processed_at + staging.interaction_id
+//
+// Wires the FULL stack (live bus, real worker, real
+// InteractionRecorder) and waits for the staging row to be marked
+// processed. This is the load-bearing assertion for the feature —
+// without it we could ship a path that stages rows but never turns
+// them into interactions.
+func TestIngestRawMessage_E2E_StagesAggregatesAndCreatesInteraction(t *testing.T) {
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
 
-	// Build a per-test messages aggregation engine wired with the
-	// pool's tx beginner but a nil event publisher — the engine will
-	// promote/extend or call its create path; we then assert the
-	// staging row's processed_at landed.
-	//
-	// We deliberately do NOT register the real reenqueuer or wait for
-	// Stage 3; this test exercises Stage 2 end-to-end and verifies
-	// the staging row + matched_contact_id thread through to a chat-
-	// scoped aggregator pass that drains the row.
-	engine := messagesEngineForTest(t, env)
+	ctx := context.Background()
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+	cfg.External.APIKey = macHostTestKey
+	cfg.Features.EnableEventBusIngest = true
+	if cfg.River.WorkerConcurrency <= 0 {
+		cfg.River.WorkerConcurrency = 4
+	}
 
-	// Run the chat-aware worker once via Work(). The worker resolves
-	// chats then calls engine.AggregateForContact per chat. The engine
-	// requires a contactID; the ingest test wires pairedContactA as
-	// the contact owning the +15551234567 phone.
-	worker := scheduler.NewMessagingAggregateForContactWorker(
-		map[string]scheduler.ChatAwareAggregator{
-			"messages": engine,
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+
+	// Repos
+	hostRepo := repository.NewMacHostRepository(database.Queries)
+	pairingRepo := repository.NewMacHostPairingTokenRepository(database.Queries)
+	syncRepo := repository.NewSyncRepositoryWithPool(database.Queries, database.Pool)
+	identityRepo := repository.NewIdentityRepository(database.Queries)
+	identityService := service.NewIdentityService(identityRepo)
+	messagesRepo := repository.NewMessagesMessageRepository(database.Queries)
+	contactRepo := repository.NewContactRepository(database.Queries)
+	contactRepo.SetPool(database.Pool)
+	contactMethodRepo := repository.NewContactMethodRepository(database.Queries)
+	interactionRepo := repository.NewInteractionRepository(database.Queries)
+	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
+	claimRepo := repository.NewEventConsumerClaimRepository(database.Queries)
+	eventRepo := repository.NewEventRepository(database.Queries)
+	rematchSvc := service.NewRematchService()
+	contactSvc := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, nil, rematchSvc)
+	cadenceUpdater := consumer.NewCadenceUpdater(claimRepo, contactRepo, database.Queries, consumer.CadenceModeCutover, false)
+	contactSvc.SetCadenceUpdater(cadenceUpdater)
+	macService := service.NewMacHostService(hostRepo, pairingRepo, syncRepo, database.Pool, 4)
+
+	// River client — wires the real MessagingAggregateForContactWorker
+	// (so the e2e test runs through the aggregator), the
+	// InteractionRecorderWorker (Stage 3 — creates the interaction
+	// row and marks staging processed), and noop workers for the
+	// downstream kinds the recorder enqueues (cadence_updater,
+	// followup_manager).
+	workers := river.NewWorkers()
+	// Aggregator worker — registered against the messages engine
+	// (constructed below after the bus exists).
+	aggregateShim := &deferredAggregateForContactWorker{}
+	river.AddWorker(workers, aggregateShim)
+	// InteractionRecorder — wired via shim because it needs bus + recorder.
+	recorderShim := &deferredInteractionRecorderWorker{}
+	river.AddWorker(workers, recorderShim)
+	// Stage-3 downstream kinds the recorder enqueues. Noop drains.
+	river.AddWorker(workers, &noopCadenceUpdaterWorker{})
+	river.AddWorker(workers, &noopFollowUpManagerWorker{})
+
+	riverClient, err := river.NewClient(riverpgxv5.New(database.Pool), &river.Config{
+		JobTimeout: cfg.River.JobTimeout,
+		Queues: map[string]river.QueueConfig{
+			river.QueueDefault: {MaxWorkers: cfg.River.WorkerConcurrency},
 		},
-		scheduler.NewPerSourceChatListerRegistry(map[string]func(ctx context.Context, contactID uuid.UUID) ([]string, error){
-			"messages": env.messagesRepo.ListUnprocessedChatsByContact,
-		}),
+		Workers:  workers,
+		TestOnly: true,
+	})
+	require.NoError(t, err)
+
+	bus := events.NewBus(database.Pool, riverClient, eventRepo)
+
+	// Messages engine — real, wired against bus + pool so create-path
+	// commits claims and publishes events.
+	const burstWindowHours = 4
+	const replyBridgeHours = 48
+	messagesEngine := messages.NewAggregationEngine(
+		burstWindowHours,
+		replyBridgeHours,
+		messagesRepo,
+		interactionRepo,
+		contactSvc,
+		contactSvc,
+		bus,
+		database.Pool,
+		consumer.NewRiverInteractionRecorderEnqueuer(riverClient),
 	)
 
-	err := worker.Work(context.Background(), &river.Job[consumerjobs.MessagingAggregateForContactArgs]{
-		Args: consumerjobs.MessagingAggregateForContactArgs{
-			ContactID: env.pairedContactA,
+	// Fill the aggregate worker shim now that the engine exists.
+	aggregateShim.engine = messagesEngine
+	aggregateShim.lister = messagesRepo.ListUnprocessedChatsByContact
+
+	// Build the InteractionRecorder + Stage 3 worker.
+	stagingRegistry := repository.NewStagingProcessorRegistry(map[string]repository.StagingProcessor{
+		repository.InteractionSourceMessages: repository.NewMessagesStagingProcessor(messagesRepo),
+	})
+	recorder := consumer.NewInteractionRecorder(contactSvc, stagingRegistry, bus, cadenceUpdater, nil)
+	recorderShim.real = consumer.NewInteractionRecorderWorker(bus, database.Pool, recorder, nil)
+
+	// Now wire the ingest service + handler.
+	ingestService := service.NewIngestService(database, bus, identityService, messagesRepo, riverClient)
+	ingestHandler := handlers.NewIngestHandler(ingestService)
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(api.RequestIDMiddleware())
+	router.Use(api.LoggingMiddleware())
+	router.Use(api.CORSMiddleware(cfg.CORS))
+
+	limiter := auth.NewPairingIPRateLimiter()
+	macHandler := handlers.NewMacHostHandler(macService, limiter)
+	handlers.RegisterMacHostRoutes(router, handlers.MacHostRouteDeps{
+		HostRepo:    hostRepo,
+		Handler:     macHandler,
+		AuthLimiter: auth.DefaultMacHostAuthLimiterConfig(),
+	})
+
+	ingestAuth := auth.IngestAuthMiddleware(
+		auth.APIKeyMiddleware(cfg),
+		auth.MacHostAuthMiddleware(hostRepo, auth.DefaultPasswordComparator, auth.DefaultMacHostAuthLimiterConfig()),
+	)
+	ingestGroup := router.Group("/api/v1/ingest")
+	ingestGroup.Use(ingestAuth)
+	ingestGroup.POST("/events", ingestHandler.IngestEvents)
+
+	// Start the River client — workers begin executing jobs.
+	// IMPORTANT: pass the OUTER ctx (not a timeout-derived one).
+	require.NoError(t, riverClient.Start(ctx))
+
+	// Pair a host + seed a contact.
+	plain, _, err := macService.CreatePairingToken(ctx)
+	require.NoError(t, err)
+	pair, err := macService.PairWithToken(ctx, plain, "ingest-e2e", "0.1.0", 1)
+	require.NoError(t, err)
+	created, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
+		FullName: "E2E Test Contact",
+	})
+	require.NoError(t, err)
+	contactID := created.ID
+	_, err = contactMethodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
+		ContactID: contactID,
+		Type:      "phone",
+		Value:     "+15551234567",
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_ = riverClient.Stop(stopCtx)
+
+		cleanCtx, cleanCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cleanCancel()
+		// Hard-delete in FK order: interactions reference the contact;
+		// contact_methods reference the contact; mac_host references
+		// nothing but the staging rows reference it.
+		_ = messagesRepo.HardDeleteByMacHost(cleanCtx, pair.HostID)
+		_, _ = database.Queries.DeleteExternalIdentitiesBySource(cleanCtx, "messages")
+		_, _ = database.Queries.DeleteInteractionsByContactAndSource(cleanCtx, db.DeleteInteractionsByContactAndSourceParams{
+			ContactID: pgUUID(contactID),
+			Source:    "messages",
+		})
+		_ = contactMethodRepo.DeleteContactMethodsByContact(cleanCtx, contactID)
+		_ = contactRepo.HardDeleteContact(cleanCtx, contactID)
+		states, _ := database.Queries.ListSyncStates(cleanCtx)
+		for _, s := range states {
+			if s.Strategy == "push" {
+				_ = database.Queries.DeleteSyncState(cleanCtx, s.ID)
+			}
+		}
+		_, _ = database.Queries.DeleteAllMacHosts(cleanCtx)
+		_, _ = database.Queries.DeleteAllPairingTokens(cleanCtx)
+		_, _ = database.Queries.DeleteRiverJobsByKindAny(cleanCtx, []string{
+			"messaging_aggregate_for_contact",
+			"messaging_aggregate_sweeper",
+			"interaction_recorder",
+			"cadence_updater",
+			"followup_manager",
+		})
+		_, _ = database.Queries.DeleteEventsBySource(cleanCtx, "messages")
+		database.Close()
+	})
+
+	// POST the raw_message event.
+	guid := "test-e2e-guid-" + uuid.NewString()
+	now := accelerated.GetCurrentTime()
+	p := events.RawMessageReceivedPayload{
+		Version:     1,
+		HostID:      pair.HostID,
+		Source:      "messages",
+		Guid:        guid,
+		ChatID:      "e2e-chat-1",
+		PeerHandle:  "+15551234567",
+		MessageType: "text",
+		SentAt:      now,
+	}
+	pBytes, err := events.Marshal(events.KindRawMessageReceived, p)
+	require.NoError(t, err)
+	ev := map[string]any{
+		"source":      "messages",
+		"source_id":   guid,
+		"kind":        string(events.KindRawMessageReceived),
+		"payload":     json.RawMessage(pBytes),
+		"observed_at": now,
+	}
+	body, err := json.Marshal(map[string]any{"events": []any{ev}})
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/ingest/events", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Mac-Host-ID", pair.HostID.String())
+	req.Header.Set("Authorization", "Bearer "+pair.APIKey)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	// Poll until the staging row is marked processed (Stage 3 has run).
+	// Bounded retry: 200 attempts × 50ms = 10s budget. Uses a count
+	// rather than wall-clock deadline so the lint rule banning
+	// time.Now() doesn't fire.
+	var msg *repository.MessagesMessage
+	for range 200 {
+		m, err := messagesRepo.GetMessage(context.Background(), guid)
+		require.NoError(t, err)
+		if m.ProcessedAt != nil && m.InteractionID != nil {
+			msg = m
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	require.NotNil(t, msg, "staging row was never marked processed within 10s")
+	require.NotNil(t, msg.ProcessedAt, "staging.processed_at must be set after Stage 3")
+	require.NotNil(t, msg.InteractionID, "staging.interaction_id must be set after Stage 3")
+	require.Equal(t, contactID, *msg.MatchedContactID)
+
+	// And the interaction row exists with source=messages.
+	interactionCount, err := database.Queries.CountInteractionsByIDContactAndSource(
+		context.Background(),
+		db.CountInteractionsByIDContactAndSourceParams{
+			ID:        pgUUID(*msg.InteractionID),
+			ContactID: pgUUID(contactID),
 			Source:    "messages",
 		},
-	})
-	require.NoError(t, err, "worker drain should succeed")
-
-	// Verify the staging row was claimed by the worker. The engine's
-	// create-path tx commits the claim atomically; Stage 3 (separate
-	// consumer) marks processed_at, which we don't run here. So we
-	// assert claimed_at is non-nil, NOT processed_at.
-	msg, err := env.messagesRepo.GetMessage(context.Background(), guid)
+	)
 	require.NoError(t, err)
-	require.NotNil(t, msg.ClaimedAt, "engine should have claimed the staging row")
-	require.NotNil(t, msg.ClaimedSessionRef, "engine should have stamped claimed_session_ref")
+	require.Equal(t, int64(1), interactionCount, "exactly one messages-source interaction expected")
 }
+
+// deferredAggregateForContactWorker is filled after the engine and
+// lister are constructed. Implements river.Worker for
+// MessagingAggregateForContactArgs.
+type deferredAggregateForContactWorker struct {
+	river.WorkerDefaults[consumerjobs.MessagingAggregateForContactArgs]
+	engine *aggregationEngine
+	lister func(ctx context.Context, contactID uuid.UUID) ([]string, error)
+}
+
+func (w *deferredAggregateForContactWorker) Work(ctx context.Context, job *river.Job[consumerjobs.MessagingAggregateForContactArgs]) error {
+	if w.engine == nil || w.lister == nil {
+		return nil
+	}
+	inner := scheduler.NewMessagingAggregateForContactWorker(
+		map[string]scheduler.ChatAwareAggregator{"messages": w.engine},
+		scheduler.NewPerSourceChatListerRegistry(map[string]func(ctx context.Context, contactID uuid.UUID) ([]string, error){
+			"messages": w.lister,
+		}),
+	)
+	return inner.Work(ctx, job)
+}
+
+// deferredInteractionRecorderWorker proxies to the real consumer's
+// worker once it's filled in. Mirrors the test_event_bus_harness
+// pattern.
+type deferredInteractionRecorderWorker struct {
+	river.WorkerDefaults[consumerjobs.InteractionRecorderJobArgs]
+	real *consumer.InteractionRecorderWorker
+}
+
+func (w *deferredInteractionRecorderWorker) Work(ctx context.Context, job *river.Job[consumerjobs.InteractionRecorderJobArgs]) error {
+	if w.real == nil {
+		return nil
+	}
+	return w.real.Work(ctx, job)
+}
+
+// Noop workers for kinds the recorder enqueues but this test doesn't
+// exercise.
+type noopCadenceUpdaterWorker struct {
+	river.WorkerDefaults[consumerjobs.CadenceUpdaterJobArgs]
+}
+
+func (w *noopCadenceUpdaterWorker) Work(_ context.Context, _ *river.Job[consumerjobs.CadenceUpdaterJobArgs]) error {
+	return nil
+}
+
+type noopFollowUpManagerWorker struct {
+	river.WorkerDefaults[consumerjobs.FollowUpManagerJobArgs]
+}
+
+func (w *noopFollowUpManagerWorker) Work(_ context.Context, _ *river.Job[consumerjobs.FollowUpManagerJobArgs]) error {
+	return nil
+}
+
+// pgUUID is a thin pgtype.UUID constructor for sqlc-generated query
+// params that take pgtype.UUID. Kept local to this file rather than
+// importing the (private) repository helper.
+func pgUUID(id uuid.UUID) pgtype.UUID {
+	return pgtype.UUID{Bytes: id, Valid: true}
+}
+
+// Unused import guards — silence unused-pgx warning when nothing in
+// this file uses pgx directly.
+var _ pgx.Tx

--- a/backend/tests/api/ingest_raw_message_e2e_test.go
+++ b/backend/tests/api/ingest_raw_message_e2e_test.go
@@ -1,0 +1,82 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"personal-crm/backend/internal/consumer/consumerjobs"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/scheduler"
+
+	"github.com/google/uuid"
+	"github.com/riverqueue/river"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIngestRawMessage_E2E_WorkerProducesEvent runs the
+// MessagingAggregateForContactWorker against the live aggregation
+// engine after a raw_message.received POST and asserts the engine
+// emits a message.received event. The Stage 3 InteractionRecorder
+// consumer is exercised by separate harness tests in
+// consumer_interaction_recorder_integration_test.go; here we exercise
+// the Stage 1 → Stage 2 join (raw_message ingest staging row +
+// matched_contact_id → engine processes the chat and publishes the
+// burst event).
+//
+// Why this test sits in tests/api and not internal/scheduler: the
+// ingest path's router + middleware are required to stage the row
+// in the first place. Without those, the engine has nothing to
+// process. The other worker unit tests (with stub engine + lister)
+// cover the worker's drain-loop behavior in isolation.
+func TestIngestRawMessage_E2E_WorkerProducesEvent(t *testing.T) {
+	env := setupRawIngestEnv(t)
+	guid := "test-guid-" + uuid.NewString()
+	ev := buildRawMessageEvent(t, events.KindRawMessageReceived, env.pairedHostID,
+		guid, "chat-end-to-end", "+15551234567")
+	w := postIngestRaw(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{ev},
+	})
+	require.Equal(t, 200, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseIngestResp(t, w).Accepted)
+
+	// Build a per-test messages aggregation engine wired with the
+	// pool's tx beginner but a nil event publisher — the engine will
+	// promote/extend or call its create path; we then assert the
+	// staging row's processed_at landed.
+	//
+	// We deliberately do NOT register the real reenqueuer or wait for
+	// Stage 3; this test exercises Stage 2 end-to-end and verifies
+	// the staging row + matched_contact_id thread through to a chat-
+	// scoped aggregator pass that drains the row.
+	engine := messagesEngineForTest(t, env)
+
+	// Run the chat-aware worker once via Work(). The worker resolves
+	// chats then calls engine.AggregateForContact per chat. The engine
+	// requires a contactID; the ingest test wires pairedContactA as
+	// the contact owning the +15551234567 phone.
+	worker := scheduler.NewMessagingAggregateForContactWorker(
+		map[string]scheduler.ChatAwareAggregator{
+			"messages": engine,
+		},
+		scheduler.NewPerSourceChatListerRegistry(map[string]func(ctx context.Context, contactID uuid.UUID) ([]string, error){
+			"messages": env.messagesRepo.ListUnprocessedChatsByContact,
+		}),
+	)
+
+	err := worker.Work(context.Background(), &river.Job[consumerjobs.MessagingAggregateForContactArgs]{
+		Args: consumerjobs.MessagingAggregateForContactArgs{
+			ContactID: env.pairedContactA,
+			Source:    "messages",
+		},
+	})
+	require.NoError(t, err, "worker drain should succeed")
+
+	// Verify the staging row was claimed by the worker. The engine's
+	// create-path tx commits the claim atomically; Stage 3 (separate
+	// consumer) marks processed_at, which we don't run here. So we
+	// assert claimed_at is non-nil, NOT processed_at.
+	msg, err := env.messagesRepo.GetMessage(context.Background(), guid)
+	require.NoError(t, err)
+	require.NotNil(t, msg.ClaimedAt, "engine should have claimed the staging row")
+	require.NotNil(t, msg.ClaimedSessionRef, "engine should have stamped claimed_session_ref")
+}

--- a/backend/tests/api/ingest_raw_message_e2e_test.go
+++ b/backend/tests/api/ingest_raw_message_e2e_test.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
@@ -353,7 +352,3 @@ func (w *noopFollowUpManagerWorker) Work(_ context.Context, _ *river.Job[consume
 func pgUUID(id uuid.UUID) pgtype.UUID {
 	return pgtype.UUID{Bytes: id, Valid: true}
 }
-
-// Unused import guards — silence unused-pgx warning when nothing in
-// this file uses pgx directly.
-var _ pgx.Tx

--- a/backend/tests/api/ingest_raw_message_test.go
+++ b/backend/tests/api/ingest_raw_message_test.go
@@ -19,6 +19,7 @@ import (
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/events"
 	"personal-crm/backend/internal/messages"
+	"personal-crm/backend/internal/messaging/aggregation"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/service"
 
@@ -85,11 +86,15 @@ func setupRawIngestEnv(t *testing.T) *ingestRawTestEnv {
 	// Queues must be declared (River errors on a nil/empty Queues map
 	// at insert time even if no workers are registered).
 	workers := river.NewWorkers()
-	// MessagingAggregateForContactArgs is the only kind enqueued by
-	// this test path. River requires every enqueued kind to have a
-	// registered worker; we register a noop so River accepts the
-	// kind without actually running aggregation.
+	// Every kind the test path enqueues must have a registered worker.
+	// We register noop workers for both MessagingAggregateForContact
+	// (enqueued by the ingest service) and InteractionRecorderJobArgs
+	// (enqueued by Bus.PublishTx when the engine publishes a
+	// message.received envelope from the e2e test). Workers are noops
+	// because the tests assert on staging-row + event-log state, not
+	// on Stage 3 execution.
 	river.AddWorker(workers, &noopAggregateForContactWorker{})
+	river.AddWorker(workers, &noopInteractionRecorderWorker{})
 	riverClient, err := river.NewClient(riverpgxv5.New(database.Pool), &river.Config{
 		JobTimeout: cfg.River.JobTimeout,
 		Queues: map[string]river.QueueConfig{
@@ -181,11 +186,9 @@ func setupRawIngestEnv(t *testing.T) *ingestRawTestEnv {
 		cleanCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 		_ = messagesRepo.HardDeleteByMacHost(cleanCtx, env.pairedHostID)
-		// Identity rows + external_identity (no scoping by host;
-		// best-effort wipe of source='messages' identities created by
-		// this test run).
-		_, _ = database.Pool.Exec(cleanCtx,
-			`DELETE FROM external_identity WHERE source = 'messages'`)
+		// Identity rows for the messages source (best-effort wipe
+		// across the whole table — tests on a shared DB).
+		_, _ = database.Queries.DeleteExternalIdentitiesBySource(cleanCtx, "messages")
 		_ = cmRepo.DeleteContactMethodsByContact(cleanCtx, env.pairedContactA)
 		_ = contactRepo.HardDeleteContact(cleanCtx, env.pairedContactA)
 		states, _ := database.Queries.ListSyncStates(cleanCtx)
@@ -197,10 +200,11 @@ func setupRawIngestEnv(t *testing.T) *ingestRawTestEnv {
 		_, _ = database.Queries.DeleteAllMacHosts(cleanCtx)
 		_, _ = database.Queries.DeleteAllPairingTokens(cleanCtx)
 		// Drop river jobs we enqueued.
-		_, _ = database.Pool.Exec(cleanCtx,
-			`DELETE FROM river_job WHERE kind IN ('messaging_aggregate_for_contact', 'messaging_aggregate_sweeper')`)
-		_, _ = database.Pool.Exec(cleanCtx,
-			`DELETE FROM event WHERE source = 'messages'`)
+		_, _ = database.Queries.DeleteRiverJobsByKindAny(cleanCtx, []string{
+			"messaging_aggregate_for_contact",
+			"messaging_aggregate_sweeper",
+		})
+		_, _ = database.Queries.DeleteEventsBySource(cleanCtx, "messages")
 		database.Close()
 	})
 
@@ -265,12 +269,61 @@ func parseIngestResp(t *testing.T, w *httptest.ResponseRecorder) handlers.Ingest
 // count is scoped to the current test's enqueues.
 func countRiverJobs(t *testing.T, env *ingestRawTestEnv, kind string) int {
 	t.Helper()
-	var count int
-	err := env.database.Pool.QueryRow(context.Background(),
-		`SELECT COUNT(*) FROM river_job WHERE kind = $1 AND finalized_at IS NULL`, kind).Scan(&count)
+	count, err := env.database.Queries.CountRiverJobsByKindUnfinalized(context.Background(), kind)
 	require.NoError(t, err)
-	return count
+	return int(count)
 }
+
+// messagesEngineForTest builds a live messages aggregation engine
+// wired against the test env's repositories. The engine is used by
+// the e2e test in ingest_raw_message_e2e_test.go to drive a real
+// chat-aware aggregator pass from a unit-test boundary.
+//
+// A live events.Bus is required because the engine's cutover-wiring
+// invariant refuses to drop interactions when no publisher is wired.
+// The bus is constructed against the same River client so the engine's
+// claim/publish runs inside its own tx, mirroring production. We
+// register a noop interaction_recorder worker so the bus's
+// post-publish job enqueue accepts the kind.
+func messagesEngineForTest(t *testing.T, env *ingestRawTestEnv) *aggregationEngine {
+	t.Helper()
+	const burstWindowHours = 4
+	const replyBridgeHours = 48
+
+	contactSvc := service.NewContactService(
+		env.database,
+		env.contactRepo,
+		env.cmRepo,
+		repository.NewInteractionRepository(env.database.Queries),
+		repository.NewContactTaskRepository(env.database.Queries),
+		nil, // bus injected below when needed; engine doesn't read this.
+		service.NewRematchService(),
+	)
+
+	// Build a dedicated bus + River client per call so the
+	// interaction_recorder worker registration doesn't collide with
+	// the env's noop aggregate worker registration.
+	eventRepo := repository.NewEventRepository(env.database.Queries)
+	bus := events.NewBus(env.database.Pool, env.riverClient, eventRepo)
+
+	eng := messages.NewAggregationEngine(
+		burstWindowHours,
+		replyBridgeHours,
+		env.messagesRepo,
+		repository.NewInteractionRepository(env.database.Queries),
+		contactSvc,
+		contactSvc,
+		bus,
+		env.database.Pool,
+		nil, // no recovery enqueuer — test does not exercise that
+	)
+	return eng
+}
+
+// aggregationEngine is the type alias the e2e test uses to keep the
+// helper return type in the api package without importing the
+// messaging/aggregation package directly.
+type aggregationEngine = aggregation.Engine
 
 // noopAggregateForContactWorker is a stub worker that River accepts so
 // MessagingAggregateForContactArgs inserts succeed without actually
@@ -281,6 +334,19 @@ type noopAggregateForContactWorker struct {
 }
 
 func (w *noopAggregateForContactWorker) Work(_ context.Context, _ *river.Job[consumerjobs.MessagingAggregateForContactArgs]) error {
+	return nil
+}
+
+// noopInteractionRecorderWorker is registered so the e2e test's bus
+// can enqueue InteractionRecorderJobArgs after the engine publishes a
+// message.received envelope. The body is a noop because the e2e test
+// asserts on staging-row claim columns + event-log presence, not on
+// Stage 3 (interaction row creation).
+type noopInteractionRecorderWorker struct {
+	river.WorkerDefaults[consumerjobs.InteractionRecorderJobArgs]
+}
+
+func (w *noopInteractionRecorderWorker) Work(_ context.Context, _ *river.Job[consumerjobs.InteractionRecorderJobArgs]) error {
 	return nil
 }
 
@@ -346,10 +412,9 @@ func TestIngestRawMessage_Duplicate_DetectedAndSkipped(t *testing.T) {
 	require.Equal(t, 1, resp.Duplicate)
 	require.Equal(t, 0, resp.Rejected)
 
-	var count int
-	require.NoError(t, env.database.Pool.QueryRow(context.Background(),
-		`SELECT COUNT(*) FROM messages_message WHERE guid = $1`, guid).Scan(&count))
-	require.Equal(t, 1, count)
+	count, err := env.database.Queries.CountMessagesMessageByGuid(context.Background(), guid)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), count)
 }
 
 // TestIngestRawMessage_UnmatchedPeer_StagedWithoutContactNoJob asserts

--- a/backend/tests/api/ingest_raw_message_test.go
+++ b/backend/tests/api/ingest_raw_message_test.go
@@ -1,0 +1,572 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/api"
+	"personal-crm/backend/internal/api/handlers"
+	"personal-crm/backend/internal/auth"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/consumer/consumerjobs"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/messages"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/riverqueue/river/rivertype"
+	"github.com/stretchr/testify/require"
+)
+
+// ingestRawTestEnv bundles the wired stack for raw_message ingest
+// integration tests. The router is built with the production composite
+// IngestAuthMiddleware so the auth dispatch is exercised end-to-end.
+type ingestRawTestEnv struct {
+	router          *gin.Engine
+	apiKey          string
+	database        *db.Database
+	macService      *service.MacHostService
+	messagesRepo    *repository.MessagesMessageRepository
+	identityRepo    *repository.IdentityRepository
+	identityService *service.IdentityService
+	contactRepo     *repository.ContactRepository
+	cmRepo          *repository.ContactMethodRepository
+	riverClient     *river.Client[pgx.Tx]
+	pairedHostID    uuid.UUID
+	pairedHostKey   string
+	pairedContactA  uuid.UUID
+}
+
+func setupRawIngestEnv(t *testing.T) *ingestRawTestEnv {
+	t.Helper()
+
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	ctx := context.Background()
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+	cfg.External.APIKey = macHostTestKey
+	cfg.Features.EnableEventBusIngest = true
+
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+
+	hostRepo := repository.NewMacHostRepository(database.Queries)
+	pairingRepo := repository.NewMacHostPairingTokenRepository(database.Queries)
+	syncRepo := repository.NewSyncRepositoryWithPool(database.Queries, database.Pool)
+	macService := service.NewMacHostService(hostRepo, pairingRepo, syncRepo, database.Pool, 4)
+
+	identityRepo := repository.NewIdentityRepository(database.Queries)
+	identityService := service.NewIdentityService(identityRepo)
+	messagesRepo := repository.NewMessagesMessageRepository(database.Queries)
+	contactRepo := repository.NewContactRepository(database.Queries)
+	contactRepo.SetPool(database.Pool)
+	cmRepo := repository.NewContactMethodRepository(database.Queries)
+
+	// Build a River client — the ingest path enqueues
+	// MessagingAggregateForContactArgs via InsertTx and the test asserts
+	// on river_job row counts directly rather than running workers.
+	// Queues must be declared (River errors on a nil/empty Queues map
+	// at insert time even if no workers are registered).
+	workers := river.NewWorkers()
+	// MessagingAggregateForContactArgs is the only kind enqueued by
+	// this test path. River requires every enqueued kind to have a
+	// registered worker; we register a noop so River accepts the
+	// kind without actually running aggregation.
+	river.AddWorker(workers, &noopAggregateForContactWorker{})
+	riverClient, err := river.NewClient(riverpgxv5.New(database.Pool), &river.Config{
+		JobTimeout: cfg.River.JobTimeout,
+		Queues: map[string]river.QueueConfig{
+			river.QueueDefault: {MaxWorkers: 1},
+		},
+		Workers:  workers,
+		TestOnly: true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, riverClient.Start(ctx))
+	t.Cleanup(func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = riverClient.Stop(stopCtx)
+	})
+
+	eventRepo := repository.NewEventRepository(database.Queries)
+	eventBus := events.NewBus(database.Pool, riverClient, eventRepo)
+	ingestService := service.NewIngestService(
+		database,
+		eventBus,
+		identityService,
+		messagesRepo,
+		riverClient,
+	)
+	ingestHandler := handlers.NewIngestHandler(ingestService)
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(api.RequestIDMiddleware())
+	router.Use(api.LoggingMiddleware())
+	router.Use(api.CORSMiddleware(cfg.CORS))
+
+	// Mac host routes (pairing + heartbeat etc).
+	limiter := auth.NewPairingIPRateLimiter()
+	macHandler := handlers.NewMacHostHandler(macService, limiter)
+	handlers.RegisterMacHostRoutes(router, handlers.MacHostRouteDeps{
+		HostRepo:    hostRepo,
+		Handler:     macHandler,
+		AuthLimiter: auth.DefaultMacHostAuthLimiterConfig(),
+	})
+
+	// Ingest endpoint behind composite middleware — same wiring as
+	// production main.go.
+	ingestAuth := auth.IngestAuthMiddleware(
+		auth.APIKeyMiddleware(cfg),
+		auth.MacHostAuthMiddleware(hostRepo, auth.DefaultPasswordComparator, auth.DefaultMacHostAuthLimiterConfig()),
+	)
+	ingestGroup := router.Group("/api/v1/ingest")
+	ingestGroup.Use(ingestAuth)
+	ingestGroup.POST("/events", ingestHandler.IngestEvents)
+
+	// Pair a host so tests can authenticate against the daemon path.
+	plain, _, err := macService.CreatePairingToken(ctx)
+	require.NoError(t, err)
+	pair, err := macService.PairWithToken(ctx, plain, "ingest-test", "0.1.0", 1)
+	require.NoError(t, err)
+
+	// Seed a contact + phone contact_method that matches our test peer.
+	created, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
+		FullName: "Ingest Test Contact",
+	})
+	require.NoError(t, err)
+	contactID := created.ID
+	_, err = cmRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
+		ContactID: contactID,
+		Type:      "phone",
+		Value:     "+15551234567",
+	})
+	require.NoError(t, err)
+
+	env := &ingestRawTestEnv{
+		router:          router,
+		apiKey:          cfg.External.APIKey,
+		database:        database,
+		macService:      macService,
+		messagesRepo:    messagesRepo,
+		identityRepo:    identityRepo,
+		identityService: identityService,
+		contactRepo:     contactRepo,
+		cmRepo:          cmRepo,
+		riverClient:     riverClient,
+		pairedHostID:    pair.HostID,
+		pairedHostKey:   pair.APIKey,
+		pairedContactA:  contactID,
+	}
+
+	t.Cleanup(func() {
+		cleanCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_ = messagesRepo.HardDeleteByMacHost(cleanCtx, env.pairedHostID)
+		// Identity rows + external_identity (no scoping by host;
+		// best-effort wipe of source='messages' identities created by
+		// this test run).
+		_, _ = database.Pool.Exec(cleanCtx,
+			`DELETE FROM external_identity WHERE source = 'messages'`)
+		_ = cmRepo.DeleteContactMethodsByContact(cleanCtx, env.pairedContactA)
+		_ = contactRepo.HardDeleteContact(cleanCtx, env.pairedContactA)
+		states, _ := database.Queries.ListSyncStates(cleanCtx)
+		for _, s := range states {
+			if s.Strategy == "push" {
+				_ = database.Queries.DeleteSyncState(cleanCtx, s.ID)
+			}
+		}
+		_, _ = database.Queries.DeleteAllMacHosts(cleanCtx)
+		_, _ = database.Queries.DeleteAllPairingTokens(cleanCtx)
+		// Drop river jobs we enqueued.
+		_, _ = database.Pool.Exec(cleanCtx,
+			`DELETE FROM river_job WHERE kind IN ('messaging_aggregate_for_contact', 'messaging_aggregate_sweeper')`)
+		_, _ = database.Pool.Exec(cleanCtx,
+			`DELETE FROM event WHERE source = 'messages'`)
+		database.Close()
+	})
+
+	return env
+}
+
+// postIngestRaw builds + sends an HTTP POST to /api/v1/ingest/events.
+// hostID == nil takes the global-API-key path; non-nil takes the
+// host-auth path with the supplied bearer key.
+func postIngestRaw(t *testing.T, env *ingestRawTestEnv, hostID *uuid.UUID, hostKey string, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	b, err := json.Marshal(body)
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/ingest/events", bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	if hostID != nil {
+		req.Header.Set("X-Mac-Host-ID", hostID.String())
+		req.Header.Set("Authorization", "Bearer "+hostKey)
+	} else {
+		req.Header.Set("X-API-Key", env.apiKey)
+	}
+	w := httptest.NewRecorder()
+	env.router.ServeHTTP(w, req)
+	return w
+}
+
+// buildRawMessageEvent constructs an ingest-event request map for a raw_message kind.
+func buildRawMessageEvent(t *testing.T, kind events.Kind, hostID uuid.UUID, guid, chatID, peerHandle string) map[string]any {
+	t.Helper()
+	now := accelerated.GetCurrentTime()
+	p := events.RawMessageReceivedPayload{
+		Version:     1,
+		HostID:      hostID,
+		Source:      "messages",
+		Guid:        guid,
+		ChatID:      chatID,
+		PeerHandle:  peerHandle,
+		MessageType: "text",
+		IsGroup:     false,
+		SentAt:      now,
+	}
+	pBytes, err := events.Marshal(kind, p)
+	require.NoError(t, err)
+	return map[string]any{
+		"source":      "messages",
+		"source_id":   guid,
+		"kind":        string(kind),
+		"payload":     json.RawMessage(pBytes),
+		"observed_at": now,
+	}
+}
+
+func parseIngestResp(t *testing.T, w *httptest.ResponseRecorder) handlers.IngestResponse {
+	t.Helper()
+	var resp handlers.IngestResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp), "body: %s", w.Body.String())
+	return resp
+}
+
+// countRiverJobs returns the number of unfinalized River jobs of the
+// given kind. The test cleanup tears these down between runs so the
+// count is scoped to the current test's enqueues.
+func countRiverJobs(t *testing.T, env *ingestRawTestEnv, kind string) int {
+	t.Helper()
+	var count int
+	err := env.database.Pool.QueryRow(context.Background(),
+		`SELECT COUNT(*) FROM river_job WHERE kind = $1 AND finalized_at IS NULL`, kind).Scan(&count)
+	require.NoError(t, err)
+	return count
+}
+
+// noopAggregateForContactWorker is a stub worker that River accepts so
+// MessagingAggregateForContactArgs inserts succeed without actually
+// running aggregation. The test asserts on river_job row counts, not
+// on aggregation side-effects.
+type noopAggregateForContactWorker struct {
+	river.WorkerDefaults[consumerjobs.MessagingAggregateForContactArgs]
+}
+
+func (w *noopAggregateForContactWorker) Work(_ context.Context, _ *river.Job[consumerjobs.MessagingAggregateForContactArgs]) error {
+	return nil
+}
+
+// adminRiverInserter adapts the river.Client to the
+// messages.AdminRiverInserter interface for the integration test
+// admin-rematch coverage.
+type adminRiverInserter struct {
+	client *river.Client[pgx.Tx]
+}
+
+func (a adminRiverInserter) Insert(ctx context.Context, args river.JobArgs, opts *river.InsertOpts) (*rivertype.JobInsertResult, error) {
+	return a.client.Insert(ctx, args, opts)
+}
+
+// TestIngestRawMessage_HappyPath_StagesRowAndEnqueuesJob asserts a
+// well-formed raw_message.received with a known contact's phone number
+// produces a staging row with matched_contact_id and one River job.
+func TestIngestRawMessage_HappyPath_StagesRowAndEnqueuesJob(t *testing.T) {
+	env := setupRawIngestEnv(t)
+	guid := "test-guid-" + uuid.NewString()
+	ev := buildRawMessageEvent(t, events.KindRawMessageReceived, env.pairedHostID,
+		guid, "chat-1", "+15551234567")
+	w := postIngestRaw(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{ev},
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseIngestResp(t, w)
+	require.Equal(t, 1, resp.Accepted)
+	require.Equal(t, 0, resp.Duplicate)
+	require.Equal(t, 0, resp.Rejected, "errors: %+v", resp.Errors)
+
+	msg, err := env.messagesRepo.GetMessage(context.Background(), guid)
+	require.NoError(t, err)
+	require.NotNil(t, msg)
+	require.NotNil(t, msg.MatchedContactID, "expected matched_contact_id to be set")
+	require.Equal(t, env.pairedContactA, *msg.MatchedContactID)
+	require.NotNil(t, msg.MacHostID)
+	require.Equal(t, env.pairedHostID, *msg.MacHostID)
+
+	require.Equal(t, 1, countRiverJobs(t, env, "messaging_aggregate_for_contact"))
+}
+
+// TestIngestRawMessage_Duplicate_DetectedAndSkipped asserts re-POSTing
+// the same guid returns duplicate=1 and produces no new staging row.
+func TestIngestRawMessage_Duplicate_DetectedAndSkipped(t *testing.T) {
+	env := setupRawIngestEnv(t)
+	guid := "test-guid-" + uuid.NewString()
+	ev := buildRawMessageEvent(t, events.KindRawMessageReceived, env.pairedHostID,
+		guid, "chat-1", "+15551234567")
+
+	w := postIngestRaw(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{ev},
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, 1, parseIngestResp(t, w).Accepted)
+
+	w = postIngestRaw(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{ev},
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	resp := parseIngestResp(t, w)
+	require.Equal(t, 0, resp.Accepted)
+	require.Equal(t, 1, resp.Duplicate)
+	require.Equal(t, 0, resp.Rejected)
+
+	var count int
+	require.NoError(t, env.database.Pool.QueryRow(context.Background(),
+		`SELECT COUNT(*) FROM messages_message WHERE guid = $1`, guid).Scan(&count))
+	require.Equal(t, 1, count)
+}
+
+// TestIngestRawMessage_UnmatchedPeer_StagedWithoutContactNoJob asserts
+// that an unmatched peer is staged with matched_contact_id=NULL and
+// produces NO aggregator River job for this row.
+func TestIngestRawMessage_UnmatchedPeer_StagedWithoutContactNoJob(t *testing.T) {
+	env := setupRawIngestEnv(t)
+	guid := "test-guid-" + uuid.NewString()
+	ev := buildRawMessageEvent(t, events.KindRawMessageReceived, env.pairedHostID,
+		guid, "chat-x", "+15559999999") // not in contact_method
+	w := postIngestRaw(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{ev},
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, 1, parseIngestResp(t, w).Accepted)
+
+	msg, err := env.messagesRepo.GetMessage(context.Background(), guid)
+	require.NoError(t, err)
+	require.Nil(t, msg.MatchedContactID, "unmatched peer must produce a NULL matched_contact_id")
+
+	require.Equal(t, 0, countRiverJobs(t, env, "messaging_aggregate_for_contact"))
+}
+
+// TestIngestRawMessage_GlobalKeyPath_RejectedWithCode asserts that
+// raw_message.* events submitted via the global API key (no
+// X-Mac-Host-ID) are REJECTED per-event with RAW_MESSAGE_REQUIRES_HOST_AUTH.
+func TestIngestRawMessage_GlobalKeyPath_RejectedWithCode(t *testing.T) {
+	env := setupRawIngestEnv(t)
+	guid := "test-guid-" + uuid.NewString()
+	ev := buildRawMessageEvent(t, events.KindRawMessageReceived, uuid.New(),
+		guid, "chat-1", "+15551234567")
+	w := postIngestRaw(t, env, nil, "", map[string]any{
+		"events": []any{ev},
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseIngestResp(t, w)
+	require.Equal(t, 0, resp.Accepted)
+	require.Equal(t, 1, resp.Rejected)
+	require.Len(t, resp.Errors, 1)
+	require.Equal(t, "RAW_MESSAGE_REQUIRES_HOST_AUTH", resp.Errors[0].Code)
+}
+
+// TestIngestRawMessage_HostAuthForeignKind_Rejected asserts a non-
+// raw_message kind submitted via the host-auth path is REJECTED with
+// UNSUPPORTED_HOST_AUTH_KIND.
+func TestIngestRawMessage_HostAuthForeignKind_Rejected(t *testing.T) {
+	env := setupRawIngestEnv(t)
+	now := accelerated.GetCurrentTime()
+	payload, err := events.Marshal(events.KindCalendarAttended, events.CalendarAttendedPayload{
+		Version:    1,
+		ContactID:  env.pairedContactA,
+		EventID:    "evt-1",
+		OccurredAt: now,
+	})
+	require.NoError(t, err)
+	ev := map[string]any{
+		"source":      "calendar",
+		"source_id":   "evt-1",
+		"kind":        string(events.KindCalendarAttended),
+		"payload":     json.RawMessage(payload),
+		"observed_at": now,
+	}
+	w := postIngestRaw(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{ev},
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseIngestResp(t, w)
+	require.Equal(t, 0, resp.Accepted)
+	require.Equal(t, 1, resp.Rejected)
+	require.Len(t, resp.Errors, 1)
+	require.Equal(t, "UNSUPPORTED_HOST_AUTH_KIND", resp.Errors[0].Code)
+}
+
+// TestIngestRawMessage_PayloadHostMismatch_Rejected asserts an
+// envelope whose payload.host_id disagrees with the authenticated host
+// is REJECTED with PAYLOAD_INVARIANT.
+func TestIngestRawMessage_PayloadHostMismatch_Rejected(t *testing.T) {
+	env := setupRawIngestEnv(t)
+	guid := "test-guid-" + uuid.NewString()
+	otherHost := uuid.New()
+	ev := buildRawMessageEvent(t, events.KindRawMessageReceived, otherHost,
+		guid, "chat-1", "+15551234567")
+	w := postIngestRaw(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{ev},
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseIngestResp(t, w)
+	require.Equal(t, 0, resp.Accepted)
+	require.Equal(t, 1, resp.Rejected)
+	require.Len(t, resp.Errors, 1)
+	require.Equal(t, "PAYLOAD_INVARIANT", resp.Errors[0].Code)
+	require.Contains(t, resp.Errors[0].Message, "host_id")
+}
+
+// TestIngestRawMessage_MissingSourceID_Rejected asserts a raw_message
+// event with empty source_id is REJECTED at the handler with
+// MISSING_FIELD.
+func TestIngestRawMessage_MissingSourceID_Rejected(t *testing.T) {
+	env := setupRawIngestEnv(t)
+	ev := buildRawMessageEvent(t, events.KindRawMessageReceived, env.pairedHostID,
+		"guid-some", "chat-1", "+15551234567")
+	ev["source_id"] = ""
+	w := postIngestRaw(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{ev},
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseIngestResp(t, w)
+	require.Equal(t, 0, resp.Accepted)
+	require.Equal(t, 1, resp.Rejected)
+	require.Len(t, resp.Errors, 1)
+	require.Equal(t, "MISSING_FIELD", resp.Errors[0].Code)
+}
+
+// TestIngestRawMessage_InvalidMessageType_Rejected asserts a payload
+// with an out-of-set message_type is REJECTED at the handler.
+func TestIngestRawMessage_InvalidMessageType_Rejected(t *testing.T) {
+	env := setupRawIngestEnv(t)
+	guid := "test-guid-" + uuid.NewString()
+	now := accelerated.GetCurrentTime()
+	p := events.RawMessageReceivedPayload{
+		Version:     1,
+		HostID:      env.pairedHostID,
+		Source:      "messages",
+		Guid:        guid,
+		ChatID:      "chat-1",
+		PeerHandle:  "+15551234567",
+		MessageType: "videocall",
+		SentAt:      now,
+	}
+	pBytes, err := events.Marshal(events.KindRawMessageReceived, p)
+	require.NoError(t, err)
+	ev := map[string]any{
+		"source":      "messages",
+		"source_id":   guid,
+		"kind":        string(events.KindRawMessageReceived),
+		"payload":     json.RawMessage(pBytes),
+		"observed_at": now,
+	}
+	w := postIngestRaw(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{ev},
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	resp := parseIngestResp(t, w)
+	require.Equal(t, 0, resp.Accepted)
+	require.Equal(t, 1, resp.Rejected)
+	require.Equal(t, "PAYLOAD_INVALID", resp.Errors[0].Code)
+}
+
+// TestIngestRawMessage_BatchDedupesAggregatorJobs asserts that 3
+// raw_message events for the same contact in one batch enqueue
+// exactly ONE aggregator River job (per-batch dedup).
+func TestIngestRawMessage_BatchDedupesAggregatorJobs(t *testing.T) {
+	env := setupRawIngestEnv(t)
+	mkEv := func() map[string]any {
+		return buildRawMessageEvent(t, events.KindRawMessageReceived, env.pairedHostID,
+			"test-guid-"+uuid.NewString(), "chat-1", "+15551234567")
+	}
+	w := postIngestRaw(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{mkEv(), mkEv(), mkEv()},
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseIngestResp(t, w)
+	require.Equal(t, 3, resp.Accepted)
+	require.Equal(t, 1, countRiverJobs(t, env, "messaging_aggregate_for_contact"))
+}
+
+// TestIngestRawMessage_AdminRematch_MatchesAfterContactAdded covers
+// R7-D: a previously-stranded row gets matched + enqueued by the admin
+// handler after a contact_method is added that matches it.
+func TestIngestRawMessage_AdminRematch_MatchesAfterContactAdded(t *testing.T) {
+	env := setupRawIngestEnv(t)
+	guid := "test-guid-" + uuid.NewString()
+	// Step 1 — POST a raw_message with an unknown peer.
+	ev := buildRawMessageEvent(t, events.KindRawMessageReceived, env.pairedHostID,
+		guid, "chat-x", "+15558887777")
+	w := postIngestRaw(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{ev},
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, 1, parseIngestResp(t, w).Accepted)
+
+	msg, err := env.messagesRepo.GetMessage(context.Background(), guid)
+	require.NoError(t, err)
+	require.Nil(t, msg.MatchedContactID)
+
+	// Step 2 — operator adds a contact_method that matches the
+	// stranded peer.
+	created, err := env.contactRepo.CreateContact(context.Background(), repository.CreateContactRequest{
+		FullName: "Late Add Contact",
+	})
+	require.NoError(t, err)
+	contactB := created.ID
+	_, err = env.cmRepo.CreateContactMethod(context.Background(), repository.CreateContactMethodRequest{
+		ContactID: contactB,
+		Type:      "phone",
+		Value:     "+15558887777",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = env.cmRepo.DeleteContactMethodsByContact(context.Background(), contactB)
+		_ = env.contactRepo.HardDeleteContact(context.Background(), contactB)
+	})
+
+	// Step 3 — invoke admin rematch handler.
+	res, err := messages.RematchStranded(context.Background(), messages.RematchStrandedDeps{
+		Messages:    env.messagesRepo,
+		Identity:    env.identityService,
+		RiverClient: adminRiverInserter{client: env.riverClient},
+	})
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, res.Scanned, 1)
+	require.Equal(t, 1, res.Matched)
+	require.Equal(t, 1, res.Enqueued)
+
+	// Step 4 — verify the staging row is now matched.
+	msg, err = env.messagesRepo.GetMessage(context.Background(), guid)
+	require.NoError(t, err)
+	require.NotNil(t, msg.MatchedContactID)
+	require.Equal(t, contactB, *msg.MatchedContactID)
+}

--- a/backend/tests/api/ingest_raw_message_test.go
+++ b/backend/tests/api/ingest_raw_message_test.go
@@ -264,60 +264,16 @@ func parseIngestResp(t *testing.T, w *httptest.ResponseRecorder) handlers.Ingest
 	return resp
 }
 
-// countRiverJobs returns the number of unfinalized River jobs of the
-// given kind. The test cleanup tears these down between runs so the
-// count is scoped to the current test's enqueues.
+// countRiverJobs returns the total number of River jobs of the given
+// kind (including finalized rows). Timing-resilient: River workers may
+// pick up jobs between insert and assertion under TestOnly mode, so
+// counting only `finalized_at IS NULL` is racy. Cross-test pollution
+// is bounded by DeleteRiverJobsByKindAny in t.Cleanup.
 func countRiverJobs(t *testing.T, env *ingestRawTestEnv, kind string) int {
 	t.Helper()
-	count, err := env.database.Queries.CountRiverJobsByKindUnfinalized(context.Background(), kind)
+	count, err := env.database.Queries.CountRiverJobsByKind(context.Background(), kind)
 	require.NoError(t, err)
 	return int(count)
-}
-
-// messagesEngineForTest builds a live messages aggregation engine
-// wired against the test env's repositories. The engine is used by
-// the e2e test in ingest_raw_message_e2e_test.go to drive a real
-// chat-aware aggregator pass from a unit-test boundary.
-//
-// A live events.Bus is required because the engine's cutover-wiring
-// invariant refuses to drop interactions when no publisher is wired.
-// The bus is constructed against the same River client so the engine's
-// claim/publish runs inside its own tx, mirroring production. We
-// register a noop interaction_recorder worker so the bus's
-// post-publish job enqueue accepts the kind.
-func messagesEngineForTest(t *testing.T, env *ingestRawTestEnv) *aggregationEngine {
-	t.Helper()
-	const burstWindowHours = 4
-	const replyBridgeHours = 48
-
-	contactSvc := service.NewContactService(
-		env.database,
-		env.contactRepo,
-		env.cmRepo,
-		repository.NewInteractionRepository(env.database.Queries),
-		repository.NewContactTaskRepository(env.database.Queries),
-		nil, // bus injected below when needed; engine doesn't read this.
-		service.NewRematchService(),
-	)
-
-	// Build a dedicated bus + River client per call so the
-	// interaction_recorder worker registration doesn't collide with
-	// the env's noop aggregate worker registration.
-	eventRepo := repository.NewEventRepository(env.database.Queries)
-	bus := events.NewBus(env.database.Pool, env.riverClient, eventRepo)
-
-	eng := messages.NewAggregationEngine(
-		burstWindowHours,
-		replyBridgeHours,
-		env.messagesRepo,
-		repository.NewInteractionRepository(env.database.Queries),
-		contactSvc,
-		contactSvc,
-		bus,
-		env.database.Pool,
-		nil, // no recovery enqueuer — test does not exercise that
-	)
-	return eng
 }
 
 // aggregationEngine is the type alias the e2e test uses to keep the
@@ -582,8 +538,9 @@ func TestIngestRawMessage_BatchDedupesAggregatorJobs(t *testing.T) {
 }
 
 // TestIngestRawMessage_AdminRematch_MatchesAfterContactAdded covers
-// R7-D: a previously-stranded row gets matched + enqueued by the admin
-// handler after a contact_method is added that matches it.
+// the operator remediation path: a previously-stranded row gets
+// matched + enqueued by the admin handler after a contact_method is
+// added that matches it.
 func TestIngestRawMessage_AdminRematch_MatchesAfterContactAdded(t *testing.T) {
 	env := setupRawIngestEnv(t)
 	guid := "test-guid-" + uuid.NewString()

--- a/backend/tests/api/ingest_test.go
+++ b/backend/tests/api/ingest_test.go
@@ -117,7 +117,12 @@ func setupIngestTestRouter(t *testing.T, enableIngest bool) *ingestTestSetup {
 		return events.NewBus(database.Pool, client, repo)
 	}
 	eventBus := busFactory(eventRepo)
-	ingestService := service.NewIngestService(database, eventBus)
+	// PR4: ingest service has identity/messages/river deps for raw_message.*
+	// envelopes. The existing batch-publish tests don't exercise raw_message
+	// kinds, so passing nil for those deps is safe — raw_message envelopes
+	// are rejected at the handler with PAYLOAD_INVALID before reaching the
+	// inline handler.
+	ingestService := service.NewIngestService(database, eventBus, nil, nil, nil)
 	ingestHandler := handlers.NewIngestHandler(ingestService)
 
 	gin.SetMode(gin.TestMode)
@@ -693,7 +698,7 @@ func TestIngest_MidTxRollback_RollsBack_And_Returns500(t *testing.T) {
 	// so the rest of the suite isn't affected.
 	fake := &failingRepo{inner: setup.eventRepo, failOn: 3}
 	bus := setup.busFactory(fake)
-	ingestService := service.NewIngestService(setup.database, bus)
+	ingestService := service.NewIngestService(setup.database, bus, nil, nil, nil)
 	handler := handlers.NewIngestHandler(ingestService)
 
 	cfg := config.TestConfig()

--- a/backend/tests/api/ingest_test.go
+++ b/backend/tests/api/ingest_test.go
@@ -117,11 +117,11 @@ func setupIngestTestRouter(t *testing.T, enableIngest bool) *ingestTestSetup {
 		return events.NewBus(database.Pool, client, repo)
 	}
 	eventBus := busFactory(eventRepo)
-	// PR4: ingest service has identity/messages/river deps for raw_message.*
-	// envelopes. The existing batch-publish tests don't exercise raw_message
-	// kinds, so passing nil for those deps is safe — raw_message envelopes
-	// are rejected at the handler with PAYLOAD_INVALID before reaching the
-	// inline handler.
+	// The ingest service has identity/messages/river deps for
+	// raw_message.* envelopes. The batch-publish tests in this file
+	// don't exercise raw_message kinds; passing nil for those deps is
+	// safe — raw_message envelopes are rejected at the handler with
+	// PAYLOAD_INVALID before reaching the inline handler.
 	ingestService := service.NewIngestService(database, eventBus, nil, nil, nil)
 	ingestHandler := handlers.NewIngestHandler(ingestService)
 


### PR DESCRIPTION
## Summary

- Generalizes `IngestService` for the Mac-daemon push pipeline: new `hostID` + `originalIndices` parameters, per-event savepoints, an inline raw_message handler (identity match → staging upsert → aggregator enqueue), and a single-source-of-truth host-auth kind allowlist that only permits `raw_message.received`/`raw_message.sent` on the daemon path and rejects them on the global-API-key path.
- Wires the messages aggregator: shared `aggregation.Engine` instance, `MessagingAggregateForContactWorker` (chat-aware drain loop), `MessagingAggregateSweeperWorker` (5-min safety net), and `MessagesAggregatorReenqueuer` (post-Stage-3 fresh enqueue + chat-aware sync pass). Registered alongside the existing Telegram entry in the post-commit reenqueuer registry.
- Moves `/api/v1/ingest/events` out of the global-API-key v1 group into a sibling group behind a new composite `IngestAuthMiddleware` that branches per-request on `X-Mac-Host-ID`.
- Adds the `messages` push provider to `ProviderRegistry` (Strategy=push so scheduler skips it).
- New `crm-admin` operator binary with `--messages-rematch-stranded` subcommand for retroactive matching of stranded staging rows; lives in its own `cmd/crm-admin/` directory to comply with the single-file-build constraint on `cmd/crm-api/`.

## Test plan

- [x] `make lint` clean (backend + frontend)
- [x] `make test-unit` green (260 tests)
- [x] `make test-integration-fast` green
- [x] `make test-frontend` green
- [x] `make test-e2e-diff` green
- [x] `make sqlc` clean (no diff after regen)
- [x] New unit tests:
  - `internal/service/ingest_test.go` — host-auth allowlist + raw_message invariants
  - `internal/messages/admin_rematch_test.go` — stranded-row rematch handler
  - `internal/consumer/messages_aggregator_reenqueuer_test.go` — reenqueuer fresh-job + chat-aware pass
  - `internal/scheduler/messaging_aggregate_sweeper_worker_test.go` — sweeper periodic worker
- [x] New integration tests (`backend/tests/api/ingest_raw_message_test.go` + `ingest_raw_message_e2e_test.go`):
  - happy path: raw_message → staging row + aggregator job
  - duplicate detection (dedup via `(source, source_id)` partial unique index)
  - unmatched peer (staged with `matched_contact_id=NULL`, no job)
  - global-key path rejects raw_message (`RAW_MESSAGE_REQUIRES_HOST_AUTH`)
  - host-auth path rejects non-raw kinds (`UNSUPPORTED_HOST_AUTH_KIND`)
  - payload-invariant cross-checks (host_id, source, guid mismatch)
  - missing source_id + invalid message_type rejection
  - per-batch dedup of aggregator jobs across N events for same contact
  - admin rematch path: strand a row, add a contact_method, run rematch, verify match + enqueue
  - **end-to-end**: raw POST → staging → aggregator worker → InteractionRecorder → `interaction` row + `staging.processed_at` set

## Manual test on Pi

```bash
# After deploy:
ssh raspberet "sudo journalctl -u personalcrm-backend -f"

# In another shell, simulate a daemon push:
curl -X POST https://<pi>/api/v1/ingest/events \
  -H 'X-Mac-Host-ID: <paired-host-uuid>' \
  -H 'Authorization: Bearer <host-key>' \
  -H 'Content-Type: application/json' \
  -d '{"events": [...]}'

# Monitor for stranded rows:
ssh raspberet "docker exec crm-postgres psql -U crm_user -d personal_crm -c \"
  SELECT COUNT(*) FROM messages_message
  WHERE matched_contact_id IS NULL
    AND processed_at IS NULL
    AND deleted_at IS NULL;
\""

# Run the admin rematch utility if needed (operator-only):
make crm-admin
./backend/crm-admin --messages-rematch-stranded
```

## Spec / plan refs

- Spec: `.ai/spec/mac-daemon.md` §2 (Sender filtering), §3 (Event flow → Stage 1, Ingest service generalization, Aggregator River job scheduling, Sync provider registration)
- Plan: `.ai/log/plan/mac-daemon-phase-1-pr4-ingest-generalization-and-messages-push-provider.md`
- Predecessors merged: #301 (PR1 host foundation), #302 (PR2 aggregator extraction), #303 (PR3 messages_message staging + claim-aware aggregator)
- Next: PR5 — `external_contact.*` event kinds + iCloud upsert handler