### PR TITLE
feat(mac-daemon): PR5 — external_contact.* events + known-identifiers endpoint

### DIFF
--- a/.ai/patterns/sync.md
+++ b/.ai/patterns/sync.md
@@ -8,6 +8,7 @@
 | Google Calendar | `gcal` | `contact_driven` | `backend/internal/google/calendar.go` |
 | Todoist | `todoist` | `fetch_all` | `backend/internal/todoist/provider.go` |
 | Messages | `messages` | `push` | `backend/internal/messages/provider.go` |
+| iCloud Contacts | `icloud_contacts` | `push` | `backend/internal/icloudcontacts/provider.go` |
 
 Providers are registered in `backend/cmd/crm-api/main.go` via `providerRegistry.Register()`.
 

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -687,8 +687,8 @@ func run() int {
 
 		// Register the iCloud Contacts push provider. Same push-only
 		// semantics as Messages — data lands via the Mac daemon's
-		// external_contact.* events. Scheduler exclusion already
-		// enforced in PR1.
+		// external_contact.* events; the scheduler skips push providers
+		// in ListDueAccounts.
 		providerRegistry.Register(icloudcontacts.New())
 		logger.Info().Msg("iCloud Contacts push provider registered")
 

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -45,6 +45,7 @@ import (
 	"personal-crm/backend/internal/events"
 	"personal-crm/backend/internal/google"
 	"personal-crm/backend/internal/health"
+	"personal-crm/backend/internal/icloudcontacts"
 	"personal-crm/backend/internal/logger"
 	"personal-crm/backend/internal/messages"
 	"personal-crm/backend/internal/repository"
@@ -287,12 +288,22 @@ func run() int {
 	// savepoint.
 	messagesMessageRepo := repository.NewMessagesMessageRepository(database.Queries)
 
+	// External contact repo for the IngestService's inline
+	// external_contact.* handler (Mac daemon iCloud Contacts watcher
+	// path). Constructed unconditionally because the IngestService is
+	// always wired even when external sync is disabled — the daemon
+	// can still call /api/v1/ingest/events on a host-auth path. A
+	// later block under `if cfg.Features.EnableExternalSync` reuses
+	// the same instance for the Import / Calendar rematch wiring.
+	externalContactRepoForIngest := repository.NewExternalContactRepository(database.Queries)
+
 	ingestService := service.NewIngestService(
 		database,
 		eventBus,
 		identityServiceForIngest,
 		messagesMessageRepo,
 		riverClient,
+		externalContactRepoForIngest,
 	)
 	ingestHandler := handlers.NewIngestHandler(ingestService)
 
@@ -589,8 +600,11 @@ func run() int {
 			logger.Info().Msg("Todoist OAuth not configured (TODOIST_CLIENT_ID and TODOIST_CLIENT_SECRET required)")
 		}
 
-		// Initialize external contact repository
-		externalContactRepo = repository.NewExternalContactRepository(database.Queries)
+		// External contact repository — reuse the instance constructed
+		// at outer scope for the IngestService so all code paths share
+		// the same repo (no behavioral difference today; future stateful
+		// caching is centralized).
+		externalContactRepo = externalContactRepoForIngest
 
 		// Initialize identity service (enrichmentService is constructed at outer scope
 		// so the Telegram block can share it).
@@ -670,6 +684,13 @@ func run() int {
 		// strategy exclusion in ListDueAccounts ensures we never poll it.
 		providerRegistry.Register(messages.New())
 		logger.Info().Msg("Messages push provider registered")
+
+		// Register the iCloud Contacts push provider. Same push-only
+		// semantics as Messages — data lands via the Mac daemon's
+		// external_contact.* events. Scheduler exclusion already
+		// enforced in PR1.
+		providerRegistry.Register(icloudcontacts.New())
+		logger.Info().Msg("iCloud Contacts push provider registered")
 
 		syncService = service.NewSyncService(syncRepo, contactRepo, providerRegistry)
 
@@ -855,6 +876,7 @@ func run() int {
 		macHostRepo,
 		pairingTokenRepo,
 		macSyncRepo,
+		contactMethodRepo,
 		database.Pool,
 		0, // default bcrypt cost
 	)

--- a/backend/internal/api/handlers/ingest.go
+++ b/backend/internal/api/handlers/ingest.go
@@ -52,6 +52,11 @@ const (
 // dropped-field decode.
 const eventsRawMessageMaxKnownVersion = 1
 
+// eventsExternalContactMaxKnownVersion is the highest
+// external_contact.* payload Version the Pi knows how to process. Same
+// "upgrade Pi" rejection semantics as raw_message.* (above).
+const eventsExternalContactMaxKnownVersion = 1
+
 // IngestHandler exposes POST /api/v1/ingest/events. Registered only when
 // cfg.Features.EnableEventBusIngest is true (spec §3.9).
 type IngestHandler struct {
@@ -322,6 +327,49 @@ func validateIngestEvent(index int, ev IngestEventRequest) *IngestError {
 		}
 	}
 
+	// external_contact.* kinds: the payload version envelope is the
+	// daemon's "upgrade Pi" signal; reject zero/missing or too-high so
+	// the operator sees a clear PAYLOAD_INVALID rather than a silent
+	// dropped-field decode. The service-layer verifier enforces the
+	// source_id regex shape and source-allowlist (we don't duplicate
+	// that here).
+	if kind == events.KindExternalContactUpserted || kind == events.KindExternalContactDeleted {
+		if ev.SourceID == "" {
+			return &IngestError{
+				Index:   index,
+				Code:    ingestCodeMissingField,
+				Message: "source_id is required for external_contact.* kinds",
+			}
+		}
+		if rerr := validateExternalContactPayloadVersion(index, kind, ev); rerr != nil {
+			return rerr
+		}
+	}
+
+	return nil
+}
+
+// validateExternalContactPayloadVersion enforces the version envelope
+// on both external_contact.* kinds. Runs after ValidatePayload has
+// already passed (so the payload decodes into the typed struct).
+func validateExternalContactPayloadVersion(index int, kind events.Kind, ev IngestEventRequest) *IngestError {
+	// Both kinds carry Version at the same JSON key; decode just enough
+	// to read it.
+	var versionEnvelope struct {
+		Version int `json:"version"`
+	}
+	if err := json.Unmarshal(ev.Payload, &versionEnvelope); err != nil {
+		return &IngestError{Index: index, Code: ingestCodePayloadInvalid, Message: err.Error()}
+	}
+	if versionEnvelope.Version < 1 {
+		return &IngestError{Index: index, Code: ingestCodePayloadInvalid,
+			Message: fmt.Sprintf("%s payload: version must be >=1 (got %d)", kind, versionEnvelope.Version)}
+	}
+	if versionEnvelope.Version > eventsExternalContactMaxKnownVersion {
+		return &IngestError{Index: index, Code: ingestCodePayloadInvalid,
+			Message: fmt.Sprintf("%s payload version %d exceeds max known %d; upgrade Pi",
+				kind, versionEnvelope.Version, eventsExternalContactMaxKnownVersion)}
+	}
 	return nil
 }
 

--- a/backend/internal/api/handlers/mac_host.go
+++ b/backend/internal/api/handlers/mac_host.go
@@ -395,12 +395,14 @@ func (h *MacHostHandler) CommitCursor(c *gin.Context) {
 	api.SendInternalError(c, "commit cursor failed")
 }
 
-// KnownIDs is a stub for the daemon's per-source tombstone
-// reconciliation surface. Returns an empty list — daemon code is
-// forward-compatible because empty IDs is the expected response on a
-// fresh Pi. The body will be filled in once the daemon's token-
-// expiration recovery flow needs it (PR8+); PR5 leaves the stub
-// intact and ships the separate /known-identifiers endpoint below.
+// KnownIDs is a stub for the per-source tombstone reconciliation
+// surface. Returns an empty list — the wire shape is the daemon-
+// expected one and the empty list is the correct response on a fresh
+// Pi. The stub body is intentional today: the daemon does not exercise
+// this endpoint outside the token-expiration recovery flow, which is
+// not yet wired. The separate /known-identifiers endpoint below is
+// the cross-source canonical phone/email surface used on every
+// heartbeat.
 func (h *MacHostHandler) KnownIDs(c *gin.Context) {
 	source := c.Param("source")
 	if source == "" {

--- a/backend/internal/api/handlers/mac_host.go
+++ b/backend/internal/api/handlers/mac_host.go
@@ -31,6 +31,7 @@ type MacHostService interface {
 	ListActiveHosts(ctx context.Context) ([]*repository.MacHost, error)
 	GetHost(ctx context.Context, id uuid.UUID) (*repository.MacHost, error)
 	RevokeHost(ctx context.Context, id uuid.UUID) error
+	KnownIdentifiers(ctx context.Context) (*service.KnownIdentifiersResult, error)
 }
 
 // MacHostHandler handles Mac-daemon HTTP requests + admin UI requests
@@ -394,10 +395,12 @@ func (h *MacHostHandler) CommitCursor(c *gin.Context) {
 	api.SendInternalError(c, "commit cursor failed")
 }
 
-// KnownIDs is a stub for the daemon's external-contact synchronisation
-// surface. Returns an empty list — daemon code is forward-compatible
-// because empty IDs is the expected response on a fresh Pi. The body
-// will be filled in once the external_contact consumer ships.
+// KnownIDs is a stub for the daemon's per-source tombstone
+// reconciliation surface. Returns an empty list — daemon code is
+// forward-compatible because empty IDs is the expected response on a
+// fresh Pi. The body will be filled in once the daemon's token-
+// expiration recovery flow needs it (PR8+); PR5 leaves the stub
+// intact and ships the separate /known-identifiers endpoint below.
 func (h *MacHostHandler) KnownIDs(c *gin.Context) {
 	source := c.Param("source")
 	if source == "" {
@@ -409,6 +412,25 @@ func (h *MacHostHandler) KnownIDs(c *gin.Context) {
 		return
 	}
 	api.SendSuccess(c, http.StatusOK, gin.H{"ids": []string{}}, nil)
+}
+
+// KnownIdentifiers returns the cross-source canonical phone + email
+// set the daemon uses to filter incoming Apple Messages senders. The
+// daemon polls this endpoint on every heartbeat (~60s); the response
+// shape is `{"phones": ["..."], "emails": ["..."]}` with both arrays
+// alphabetically sorted and deduplicated. Empty arrays on a fresh CRM
+// are valid.
+//
+// Authentication is the host-bearer path (MacHostAuthMiddleware) —
+// the daemon is the only legitimate caller.
+func (h *MacHostHandler) KnownIdentifiers(c *gin.Context) {
+	result, err := h.svc.KnownIdentifiers(c.Request.Context())
+	if err != nil {
+		logger.Error().Err(err).Msg("known-identifiers: failed")
+		api.SendInternalError(c, "known identifiers failed")
+		return
+	}
+	api.SendSuccess(c, http.StatusOK, result, nil)
 }
 
 // ListHosts is the admin list view.

--- a/backend/internal/api/handlers/mac_host.go
+++ b/backend/internal/api/handlers/mac_host.go
@@ -418,10 +418,14 @@ func (h *MacHostHandler) KnownIDs(c *gin.Context) {
 
 // KnownIdentifiers returns the cross-source canonical phone + email
 // set the daemon uses to filter incoming Apple Messages senders. The
-// daemon polls this endpoint on every heartbeat (~60s); the response
-// shape is `{"phones": ["..."], "emails": ["..."]}` with both arrays
-// alphabetically sorted and deduplicated. Empty arrays on a fresh CRM
-// are valid.
+// daemon polls this endpoint on every heartbeat (~60s).
+//
+// Wire shape: the standard `{success, data, ...}` envelope from
+// api.SendSuccess. The data payload is `{"phones": ["..."], "emails":
+// ["..."]}` — both arrays alphabetically sorted and deduplicated, empty
+// arrays valid on a fresh CRM. The envelope is consistent with every
+// other mac-host endpoint (Pair, Heartbeat, GetCursor, KnownIDs,
+// admin endpoints).
 //
 // Authentication is the host-bearer path (MacHostAuthMiddleware) —
 // the daemon is the only legitimate caller.

--- a/backend/internal/api/handlers/mac_host_routes.go
+++ b/backend/internal/api/handlers/mac_host_routes.go
@@ -21,11 +21,12 @@ type MacHostRouteDeps struct {
 // RegisterMacHostRoutes wires the public + daemon-auth Mac-daemon route
 // surface onto the given router:
 //
-//   - POST /api/v1/host                          (public, IP rate-limited inside handler)
-//   - POST /api/v1/host/:id/heartbeat            (host bearer auth)
-//   - GET  /api/v1/host/:id/sync/:source/cursor  (host bearer auth)
-//   - POST /api/v1/host/:id/sync/:source/cursor  (host bearer auth)
-//   - GET  /api/v1/host/:id/sync/:source/known-ids (host bearer auth)
+//   - POST /api/v1/host                            (public, IP rate-limited inside handler)
+//   - POST /api/v1/host/:id/heartbeat              (host bearer auth)
+//   - GET  /api/v1/host/:id/sync/:source/cursor    (host bearer auth)
+//   - POST /api/v1/host/:id/sync/:source/cursor    (host bearer auth)
+//   - GET  /api/v1/host/:id/sync/:source/known-ids (host bearer auth; per-source tombstone reconciliation; stub)
+//   - GET  /api/v1/host/:id/known-identifiers      (host bearer auth; cross-source canonical phone/email set)
 //
 // Caller is responsible for adding the admin routes via
 // RegisterMacHostAdminRoutes against their own global-API-key-protected
@@ -44,6 +45,7 @@ func RegisterMacHostRoutes(router *gin.Engine, deps MacHostRouteDeps) {
 		macDaemon.GET("/host/:id/sync/:source/cursor", deps.Handler.GetCursor)
 		macDaemon.POST("/host/:id/sync/:source/cursor", deps.Handler.CommitCursor)
 		macDaemon.GET("/host/:id/sync/:source/known-ids", deps.Handler.KnownIDs)
+		macDaemon.GET("/host/:id/known-identifiers", deps.Handler.KnownIdentifiers)
 	}
 }
 

--- a/backend/internal/db/contact_method.sql.go
+++ b/backend/internal/db/contact_method.sql.go
@@ -119,6 +119,42 @@ func (q *Queries) FindMethodsByNormalizedValue(ctx context.Context, arg FindMeth
 	return items, nil
 }
 
+const ListCanonicalIdentifiersByType = `-- name: ListCanonicalIdentifiersByType :many
+SELECT DISTINCT cm.value_normalized
+FROM contact_method cm
+JOIN contact c ON c.id = cm.contact_id
+WHERE cm.type = ANY($1::text[])
+  AND cm.value_normalized <> ''
+  AND c.deleted_at IS NULL
+ORDER BY cm.value_normalized ASC
+`
+
+// Returns the deduplicated canonicalized value set for the given
+// contact_method types, scoped to non-deleted contacts. Ordered
+// alphabetically by value_normalized for deterministic daemon-side diff.
+// Used by GET /api/v1/host/:id/known-identifiers — the daemon needs the
+// SET of canonical phones/emails, not the contact mapping, so DISTINCT
+// collapses the same value across multiple contacts.
+func (q *Queries) ListCanonicalIdentifiersByType(ctx context.Context, dollar_1 []string) ([]string, error) {
+	rows, err := q.db.Query(ctx, ListCanonicalIdentifiersByType, dollar_1)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []string{}
+	for rows.Next() {
+		var value_normalized string
+		if err := rows.Scan(&value_normalized); err != nil {
+			return nil, err
+		}
+		items = append(items, value_normalized)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const ListContactMethodsByContact = `-- name: ListContactMethodsByContact :many
 
 SELECT id, contact_id, type, value, is_primary, created_at, updated_at, value_normalized FROM contact_method

--- a/backend/internal/db/external_contact.sql.go
+++ b/backend/internal/db/external_contact.sql.go
@@ -15,6 +15,7 @@ const CountAllUnmatchedExternalContacts = `-- name: CountAllUnmatchedExternalCon
 SELECT COUNT(*) FROM external_contact
 WHERE match_status = 'unmatched'
   AND duplicate_of_id IS NULL
+  AND deleted_at IS NULL
 `
 
 func (q *Queries) CountAllUnmatchedExternalContacts(ctx context.Context) (int64, error) {
@@ -29,6 +30,7 @@ SELECT COUNT(*) FROM external_contact
 WHERE source = $1
   AND match_status = 'unmatched'
   AND duplicate_of_id IS NULL
+  AND deleted_at IS NULL
 `
 
 func (q *Queries) CountUnmatchedExternalContacts(ctx context.Context, source string) (int64, error) {
@@ -124,9 +126,10 @@ func (q *Queries) DeleteExternalContactsBySourceAccount(ctx context.Context, arg
 }
 
 const FindExternalContactsByEmail = `-- name: FindExternalContactsByEmail :many
-SELECT id, source, source_id, account_id, display_name, first_name, last_name, emails, phones, addresses, organization, job_title, birthday, photo_url, crm_contact_id, match_status, duplicate_of_id, etag, metadata, synced_at, created_at, updated_at FROM external_contact
+SELECT id, source, source_id, account_id, display_name, first_name, last_name, emails, phones, addresses, organization, job_title, birthday, photo_url, crm_contact_id, match_status, duplicate_of_id, etag, metadata, synced_at, created_at, updated_at, deleted_at FROM external_contact
 WHERE emails @> $1::jsonb
   AND duplicate_of_id IS NULL
+  AND deleted_at IS NULL
 ORDER BY created_at
 `
 
@@ -162,6 +165,7 @@ func (q *Queries) FindExternalContactsByEmail(ctx context.Context, dollar_1 []by
 			&i.SyncedAt,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.DeletedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -174,15 +178,17 @@ func (q *Queries) FindExternalContactsByEmail(ctx context.Context, dollar_1 []by
 }
 
 const FindExternalContactsByNormalizedEmail = `-- name: FindExternalContactsByNormalizedEmail :many
-SELECT id, source, source_id, account_id, display_name, first_name, last_name, emails, phones, addresses, organization, job_title, birthday, photo_url, crm_contact_id, match_status, duplicate_of_id, etag, metadata, synced_at, created_at, updated_at FROM external_contact
+SELECT id, source, source_id, account_id, display_name, first_name, last_name, emails, phones, addresses, organization, job_title, birthday, photo_url, crm_contact_id, match_status, duplicate_of_id, etag, metadata, synced_at, created_at, updated_at, deleted_at FROM external_contact
 WHERE jsonb_array_lower_values(emails, 'value') && ARRAY[LOWER($1)]
   AND duplicate_of_id IS NULL
+  AND deleted_at IS NULL
 ORDER BY created_at
 `
 
 // Finds external contacts whose JSONB emails contain the given normalized
 // email value. Backed by idx_external_contact_emails_value_lower_gin via
-// the jsonb_array_lower_values helper.
+// the jsonb_array_lower_values helper. Tombstoned rows are excluded so
+// duplicate detection ignores soft-deleted candidates.
 func (q *Queries) FindExternalContactsByNormalizedEmail(ctx context.Context, lower string) ([]*ExternalContact, error) {
 	rows, err := q.db.Query(ctx, FindExternalContactsByNormalizedEmail, lower)
 	if err != nil {
@@ -215,6 +221,7 @@ func (q *Queries) FindExternalContactsByNormalizedEmail(ctx context.Context, low
 			&i.SyncedAt,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.DeletedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -227,10 +234,11 @@ func (q *Queries) FindExternalContactsByNormalizedEmail(ctx context.Context, low
 }
 
 const FindExternalContactsBySourceAndSourceID = `-- name: FindExternalContactsBySourceAndSourceID :many
-SELECT id, source, source_id, account_id, display_name, first_name, last_name, emails, phones, addresses, organization, job_title, birthday, photo_url, crm_contact_id, match_status, duplicate_of_id, etag, metadata, synced_at, created_at, updated_at FROM external_contact
+SELECT id, source, source_id, account_id, display_name, first_name, last_name, emails, phones, addresses, organization, job_title, birthday, photo_url, crm_contact_id, match_status, duplicate_of_id, etag, metadata, synced_at, created_at, updated_at, deleted_at FROM external_contact
 WHERE source = $1
   AND source_id = $2
   AND match_status = 'unmatched'
+  AND deleted_at IS NULL
 `
 
 type FindExternalContactsBySourceAndSourceIDParams struct {
@@ -241,6 +249,7 @@ type FindExternalContactsBySourceAndSourceIDParams struct {
 // Finds all unmatched external_contact rows for a (source, source_id) pair
 // regardless of account_id. Used by the calendar rematch handler to mark
 // gcal_attendee import candidates as matched after a CRM contact links them.
+// Tombstoned candidates must not be rematched.
 func (q *Queries) FindExternalContactsBySourceAndSourceID(ctx context.Context, arg FindExternalContactsBySourceAndSourceIDParams) ([]*ExternalContact, error) {
 	rows, err := q.db.Query(ctx, FindExternalContactsBySourceAndSourceID, arg.Source, arg.SourceID)
 	if err != nil {
@@ -273,6 +282,7 @@ func (q *Queries) FindExternalContactsBySourceAndSourceID(ctx context.Context, a
 			&i.SyncedAt,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.DeletedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -350,10 +360,13 @@ func (q *Queries) GetEnrichmentsForContact(ctx context.Context, contactID pgtype
 
 const GetExternalContact = `-- name: GetExternalContact :one
 
-SELECT id, source, source_id, account_id, display_name, first_name, last_name, emails, phones, addresses, organization, job_title, birthday, photo_url, crm_contact_id, match_status, duplicate_of_id, etag, metadata, synced_at, created_at, updated_at FROM external_contact WHERE id = $1
+SELECT id, source, source_id, account_id, display_name, first_name, last_name, emails, phones, addresses, organization, job_title, birthday, photo_url, crm_contact_id, match_status, duplicate_of_id, etag, metadata, synced_at, created_at, updated_at, deleted_at FROM external_contact
+WHERE id = $1
+  AND deleted_at IS NULL
 `
 
 // External Contact queries
+// Tombstoned rows are not retrievable by ID through normal flows.
 func (q *Queries) GetExternalContact(ctx context.Context, id pgtype.UUID) (*ExternalContact, error) {
 	row := q.db.QueryRow(ctx, GetExternalContact, id)
 	var i ExternalContact
@@ -380,12 +393,13 @@ func (q *Queries) GetExternalContact(ctx context.Context, id pgtype.UUID) (*Exte
 		&i.SyncedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.DeletedAt,
 	)
 	return &i, err
 }
 
 const GetExternalContactBySource = `-- name: GetExternalContactBySource :one
-SELECT id, source, source_id, account_id, display_name, first_name, last_name, emails, phones, addresses, organization, job_title, birthday, photo_url, crm_contact_id, match_status, duplicate_of_id, etag, metadata, synced_at, created_at, updated_at FROM external_contact
+SELECT id, source, source_id, account_id, display_name, first_name, last_name, emails, phones, addresses, organization, job_title, birthday, photo_url, crm_contact_id, match_status, duplicate_of_id, etag, metadata, synced_at, created_at, updated_at, deleted_at FROM external_contact
 WHERE source = $1 AND source_id = $2 AND COALESCE(account_id, '') = COALESCE($3, '')
 `
 
@@ -395,6 +409,11 @@ type GetExternalContactBySourceParams struct {
 	AccountID pgtype.Text `json:"account_id"`
 }
 
+// Tombstone-aware: returns tombstoned rows too. The mac-daemon ingest path
+// needs visibility into tombstoned rows so it can revive them on a fresh
+// external_contact.upserted event. Existing telegram / gcontacts callers
+// never tombstone, so the broader read does not affect them. Callers that
+// want live-only rows must check `DeletedAt == nil` after the call.
 func (q *Queries) GetExternalContactBySource(ctx context.Context, arg GetExternalContactBySourceParams) (*ExternalContact, error) {
 	row := q.db.QueryRow(ctx, GetExternalContactBySource, arg.Source, arg.SourceID, arg.AccountID)
 	var i ExternalContact
@@ -421,6 +440,7 @@ func (q *Queries) GetExternalContactBySource(ctx context.Context, arg GetExterna
 		&i.SyncedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.DeletedAt,
 	)
 	return &i, err
 }
@@ -457,9 +477,10 @@ func (q *Queries) IgnoreExternalContact(ctx context.Context, id pgtype.UUID) err
 }
 
 const ListAllUnmatchedExternalContacts = `-- name: ListAllUnmatchedExternalContacts :many
-SELECT id, source, source_id, account_id, display_name, first_name, last_name, emails, phones, addresses, organization, job_title, birthday, photo_url, crm_contact_id, match_status, duplicate_of_id, etag, metadata, synced_at, created_at, updated_at FROM external_contact
+SELECT id, source, source_id, account_id, display_name, first_name, last_name, emails, phones, addresses, organization, job_title, birthday, photo_url, crm_contact_id, match_status, duplicate_of_id, etag, metadata, synced_at, created_at, updated_at, deleted_at FROM external_contact
 WHERE match_status = 'unmatched'
   AND duplicate_of_id IS NULL
+  AND deleted_at IS NULL
 ORDER BY source, display_name
 LIMIT $1 OFFSET $2
 `
@@ -501,6 +522,7 @@ func (q *Queries) ListAllUnmatchedExternalContacts(ctx context.Context, arg List
 			&i.SyncedAt,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.DeletedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -555,8 +577,10 @@ func (q *Queries) ListEnrichmentsBySource(ctx context.Context, arg ListEnrichmen
 }
 
 const ListExternalContactsBySource = `-- name: ListExternalContactsBySource :many
-SELECT id, source, source_id, account_id, display_name, first_name, last_name, emails, phones, addresses, organization, job_title, birthday, photo_url, crm_contact_id, match_status, duplicate_of_id, etag, metadata, synced_at, created_at, updated_at FROM external_contact
-WHERE source = $1 AND ($2::text IS NULL OR account_id = $2)
+SELECT id, source, source_id, account_id, display_name, first_name, last_name, emails, phones, addresses, organization, job_title, birthday, photo_url, crm_contact_id, match_status, duplicate_of_id, etag, metadata, synced_at, created_at, updated_at, deleted_at FROM external_contact
+WHERE source = $1
+  AND ($2::text IS NULL OR account_id = $2)
+  AND deleted_at IS NULL
 ORDER BY display_name
 LIMIT $3 OFFSET $4
 `
@@ -605,6 +629,7 @@ func (q *Queries) ListExternalContactsBySource(ctx context.Context, arg ListExte
 			&i.SyncedAt,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.DeletedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -617,8 +642,9 @@ func (q *Queries) ListExternalContactsBySource(ctx context.Context, arg ListExte
 }
 
 const ListExternalContactsForCRMContact = `-- name: ListExternalContactsForCRMContact :many
-SELECT id, source, source_id, account_id, display_name, first_name, last_name, emails, phones, addresses, organization, job_title, birthday, photo_url, crm_contact_id, match_status, duplicate_of_id, etag, metadata, synced_at, created_at, updated_at FROM external_contact
+SELECT id, source, source_id, account_id, display_name, first_name, last_name, emails, phones, addresses, organization, job_title, birthday, photo_url, crm_contact_id, match_status, duplicate_of_id, etag, metadata, synced_at, created_at, updated_at, deleted_at FROM external_contact
 WHERE crm_contact_id = $1
+  AND deleted_at IS NULL
 ORDER BY source, account_id
 `
 
@@ -654,6 +680,7 @@ func (q *Queries) ListExternalContactsForCRMContact(ctx context.Context, crmCont
 			&i.SyncedAt,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.DeletedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -666,10 +693,11 @@ func (q *Queries) ListExternalContactsForCRMContact(ctx context.Context, crmCont
 }
 
 const ListUnmatchedExternalContacts = `-- name: ListUnmatchedExternalContacts :many
-SELECT id, source, source_id, account_id, display_name, first_name, last_name, emails, phones, addresses, organization, job_title, birthday, photo_url, crm_contact_id, match_status, duplicate_of_id, etag, metadata, synced_at, created_at, updated_at FROM external_contact
+SELECT id, source, source_id, account_id, display_name, first_name, last_name, emails, phones, addresses, organization, job_title, birthday, photo_url, crm_contact_id, match_status, duplicate_of_id, etag, metadata, synced_at, created_at, updated_at, deleted_at FROM external_contact
 WHERE source = $1
   AND match_status = 'unmatched'
   AND duplicate_of_id IS NULL
+  AND deleted_at IS NULL
 ORDER BY display_name
 LIMIT $2 OFFSET $3
 `
@@ -712,6 +740,7 @@ func (q *Queries) ListUnmatchedExternalContacts(ctx context.Context, arg ListUnm
 			&i.SyncedAt,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.DeletedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -721,6 +750,66 @@ func (q *Queries) ListUnmatchedExternalContacts(ctx context.Context, arg ListUnm
 		return nil, err
 	}
 	return items, nil
+}
+
+const ReviveExternalContact = `-- name: ReviveExternalContact :one
+UPDATE external_contact SET
+    deleted_at = NULL,
+    updated_at = NOW()
+WHERE id = $1
+  AND deleted_at IS NOT NULL
+RETURNING id, source, source_id, account_id, display_name, first_name, last_name, emails, phones, addresses, organization, job_title, birthday, photo_url, crm_contact_id, match_status, duplicate_of_id, etag, metadata, synced_at, created_at, updated_at, deleted_at
+`
+
+// Clears deleted_at on a tombstoned row. Defensive WHERE deleted_at IS NOT
+// NULL keeps the statement idempotent across concurrent revive races.
+// Preserves crm_contact_id, match_status, and all content columns.
+func (q *Queries) ReviveExternalContact(ctx context.Context, id pgtype.UUID) (*ExternalContact, error) {
+	row := q.db.QueryRow(ctx, ReviveExternalContact, id)
+	var i ExternalContact
+	err := row.Scan(
+		&i.ID,
+		&i.Source,
+		&i.SourceID,
+		&i.AccountID,
+		&i.DisplayName,
+		&i.FirstName,
+		&i.LastName,
+		&i.Emails,
+		&i.Phones,
+		&i.Addresses,
+		&i.Organization,
+		&i.JobTitle,
+		&i.Birthday,
+		&i.PhotoUrl,
+		&i.CrmContactID,
+		&i.MatchStatus,
+		&i.DuplicateOfID,
+		&i.Etag,
+		&i.Metadata,
+		&i.SyncedAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.DeletedAt,
+	)
+	return &i, err
+}
+
+const SoftDeleteExternalContact = `-- name: SoftDeleteExternalContact :exec
+UPDATE external_contact SET
+    deleted_at = NOW(),
+    updated_at = NOW()
+WHERE id = $1
+  AND deleted_at IS NULL
+`
+
+// Tombstones a live row. Defensive WHERE deleted_at IS NULL keeps the
+// statement idempotent against a concurrent delete. crm_contact_id,
+// match_status, and duplicate_of_id are preserved per the external_contact
+// soft-delete contract.
+func (q *Queries) SoftDeleteExternalContact(ctx context.Context, id pgtype.UUID) error {
+	_, err := q.db.Exec(ctx, SoftDeleteExternalContact, id)
+	return err
 }
 
 const UpdateExternalContactDuplicate = `-- name: UpdateExternalContactDuplicate :exec
@@ -746,7 +835,7 @@ UPDATE external_contact SET
     match_status = $3,
     updated_at = NOW()
 WHERE id = $1
-RETURNING id, source, source_id, account_id, display_name, first_name, last_name, emails, phones, addresses, organization, job_title, birthday, photo_url, crm_contact_id, match_status, duplicate_of_id, etag, metadata, synced_at, created_at, updated_at
+RETURNING id, source, source_id, account_id, display_name, first_name, last_name, emails, phones, addresses, organization, job_title, birthday, photo_url, crm_contact_id, match_status, duplicate_of_id, etag, metadata, synced_at, created_at, updated_at, deleted_at
 `
 
 type UpdateExternalContactMatchParams struct {
@@ -781,6 +870,7 @@ func (q *Queries) UpdateExternalContactMatch(ctx context.Context, arg UpdateExte
 		&i.SyncedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.DeletedAt,
 	)
 	return &i, err
 }
@@ -806,7 +896,7 @@ ON CONFLICT (source, source_id, COALESCE(account_id, '')) DO UPDATE SET
     metadata = EXCLUDED.metadata,
     synced_at = EXCLUDED.synced_at,
     updated_at = NOW()
-RETURNING id, source, source_id, account_id, display_name, first_name, last_name, emails, phones, addresses, organization, job_title, birthday, photo_url, crm_contact_id, match_status, duplicate_of_id, etag, metadata, synced_at, created_at, updated_at
+RETURNING id, source, source_id, account_id, display_name, first_name, last_name, emails, phones, addresses, organization, job_title, birthday, photo_url, crm_contact_id, match_status, duplicate_of_id, etag, metadata, synced_at, created_at, updated_at, deleted_at
 `
 
 type UpsertExternalContactParams struct {
@@ -877,6 +967,7 @@ func (q *Queries) UpsertExternalContact(ctx context.Context, arg UpsertExternalC
 		&i.SyncedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.DeletedAt,
 	)
 	return &i, err
 }
@@ -892,7 +983,7 @@ ON CONFLICT (source, source_id, COALESCE(account_id, '')) DO UPDATE SET
     metadata     = external_contact.metadata || EXCLUDED.metadata,
     synced_at    = EXCLUDED.synced_at,
     updated_at   = NOW()
-RETURNING id, source, source_id, account_id, display_name, first_name, last_name, emails, phones, addresses, organization, job_title, birthday, photo_url, crm_contact_id, match_status, duplicate_of_id, etag, metadata, synced_at, created_at, updated_at
+RETURNING id, source, source_id, account_id, display_name, first_name, last_name, emails, phones, addresses, organization, job_title, birthday, photo_url, crm_contact_id, match_status, duplicate_of_id, etag, metadata, synced_at, created_at, updated_at, deleted_at
 `
 
 type UpsertTelegramDiscoveryCandidateParams struct {
@@ -941,6 +1032,7 @@ func (q *Queries) UpsertTelegramDiscoveryCandidate(ctx context.Context, arg Upse
 		&i.SyncedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.DeletedAt,
 	)
 	return &i, err
 }

--- a/backend/internal/db/external_contact.sql.go
+++ b/backend/internal/db/external_contact.sql.go
@@ -469,6 +469,7 @@ UPDATE external_contact SET
     match_status = 'ignored',
     updated_at = NOW()
 WHERE id = $1
+  AND deleted_at IS NULL
 `
 
 func (q *Queries) IgnoreExternalContact(ctx context.Context, id pgtype.UUID) error {
@@ -817,6 +818,7 @@ UPDATE external_contact SET
     duplicate_of_id = $2,
     updated_at = NOW()
 WHERE id = $1
+  AND deleted_at IS NULL
 `
 
 type UpdateExternalContactDuplicateParams struct {
@@ -835,6 +837,7 @@ UPDATE external_contact SET
     match_status = $3,
     updated_at = NOW()
 WHERE id = $1
+  AND deleted_at IS NULL
 RETURNING id, source, source_id, account_id, display_name, first_name, last_name, emails, phones, addresses, organization, job_title, birthday, photo_url, crm_contact_id, match_status, duplicate_of_id, etag, metadata, synced_at, created_at, updated_at, deleted_at
 `
 
@@ -844,6 +847,9 @@ type UpdateExternalContactMatchParams struct {
 	MatchStatus  pgtype.Text `json:"match_status"`
 }
 
+// Filter `deleted_at IS NULL` so a tombstoned row cannot have its
+// match state mutated. A tombstoned row is invisible to every read
+// path; writes should be invisible too.
 func (q *Queries) UpdateExternalContactMatch(ctx context.Context, arg UpdateExternalContactMatchParams) (*ExternalContact, error) {
 	row := q.db.QueryRow(ctx, UpdateExternalContactMatch, arg.ID, arg.CrmContactID, arg.MatchStatus)
 	var i ExternalContact

--- a/backend/internal/db/models.go
+++ b/backend/internal/db/models.go
@@ -200,6 +200,7 @@ type ExternalContact struct {
 	SyncedAt      pgtype.Timestamptz `json:"synced_at"`
 	CreatedAt     pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt     pgtype.Timestamptz `json:"updated_at"`
+	DeletedAt     pgtype.Timestamptz `json:"deleted_at"`
 }
 
 type ExternalIdentity struct {

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -840,6 +840,9 @@ type Querier interface {
 	UpdateContactTaskMetadata(ctx context.Context, arg UpdateContactTaskMetadataParams) (*ContactTask, error)
 	UpdateContactTaskState(ctx context.Context, arg UpdateContactTaskStateParams) (*ContactTask, error)
 	UpdateExternalContactDuplicate(ctx context.Context, arg UpdateExternalContactDuplicateParams) error
+	// Filter `deleted_at IS NULL` so a tombstoned row cannot have its
+	// match state mutated. A tombstoned row is invisible to every read
+	// path; writes should be invisible too.
 	UpdateExternalContactMatch(ctx context.Context, arg UpdateExternalContactMatchParams) (*ExternalContact, error)
 	UpdateIdentityMessageCount(ctx context.Context, arg UpdateIdentityMessageCountParams) (*ExternalIdentity, error)
 	// Promote an outbound interaction to mutual when a reply arrives (in-place update)

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -281,11 +281,13 @@ type Querier interface {
 	FindExternalContactsByEmail(ctx context.Context, dollar_1 []byte) ([]*ExternalContact, error)
 	// Finds external contacts whose JSONB emails contain the given normalized
 	// email value. Backed by idx_external_contact_emails_value_lower_gin via
-	// the jsonb_array_lower_values helper.
+	// the jsonb_array_lower_values helper. Tombstoned rows are excluded so
+	// duplicate detection ignores soft-deleted candidates.
 	FindExternalContactsByNormalizedEmail(ctx context.Context, lower string) ([]*ExternalContact, error)
 	// Finds all unmatched external_contact rows for a (source, source_id) pair
 	// regardless of account_id. Used by the calendar rematch handler to mark
 	// gcal_attendee import candidates as matched after a CRM contact links them.
+	// Tombstoned candidates must not be rematched.
 	FindExternalContactsBySourceAndSourceID(ctx context.Context, arg FindExternalContactsBySourceAndSourceIDParams) ([]*ExternalContact, error)
 	FindIdentitiesByIdentifier(ctx context.Context, arg FindIdentitiesByIdentifierParams) ([]*ExternalIdentity, error)
 	// Find an existing interaction by contact, source, and source_ref (for deduplication)
@@ -377,7 +379,13 @@ type Querier interface {
 	GetEnrichmentsForContact(ctx context.Context, contactID pgtype.UUID) ([]*ContactEnrichment, error)
 	GetEvent(ctx context.Context, id pgtype.UUID) (*Event, error)
 	// External Contact queries
+	// Tombstoned rows are not retrievable by ID through normal flows.
 	GetExternalContact(ctx context.Context, id pgtype.UUID) (*ExternalContact, error)
+	// Tombstone-aware: returns tombstoned rows too. The mac-daemon ingest path
+	// needs visibility into tombstoned rows so it can revive them on a fresh
+	// external_contact.upserted event. Existing telegram / gcontacts callers
+	// never tombstone, so the broader read does not affect them. Callers that
+	// want live-only rows must check `DeletedAt == nil` after the call.
 	GetExternalContactBySource(ctx context.Context, arg GetExternalContactBySourceParams) (*ExternalContact, error)
 	// External identity queries for cross-platform contact identity matching
 	GetIdentityByID(ctx context.Context, id pgtype.UUID) (*ExternalIdentity, error)
@@ -507,6 +515,13 @@ type Querier interface {
 	// List all OAuth credentials
 	ListAllOAuthCredentials(ctx context.Context) ([]*OauthCredential, error)
 	ListAllUnmatchedExternalContacts(ctx context.Context, arg ListAllUnmatchedExternalContactsParams) ([]*ExternalContact, error)
+	// Returns the deduplicated canonicalized value set for the given
+	// contact_method types, scoped to non-deleted contacts. Ordered
+	// alphabetically by value_normalized for deterministic daemon-side diff.
+	// Used by GET /api/v1/host/:id/known-identifiers — the daemon needs the
+	// SET of canonical phones/emails, not the contact mapping, so DISTINCT
+	// collapses the same value across multiple contacts.
+	ListCanonicalIdentifiersByType(ctx context.Context, dollar_1 []string) ([]string, error)
 	// Lightweight query returning only IDs for navigation
 	ListContactIDs(ctx context.Context, arg ListContactIDsParams) ([]pgtype.UUID, error)
 	// Lightweight query returning only IDs with sorting for navigation
@@ -661,6 +676,10 @@ type Querier interface {
 	// Uses array_replace for efficient in-place replacement
 	ReplaceContactInCalendarEvents(ctx context.Context, arg ReplaceContactInCalendarEventsParams) error
 	ResetTelegramChatConfigBackfill(ctx context.Context, telegramChatID int64) error
+	// Clears deleted_at on a tombstoned row. Defensive WHERE deleted_at IS NOT
+	// NULL keeps the statement idempotent across concurrent revive races.
+	// Preserves crm_contact_id, match_status, and all content columns.
+	ReviveExternalContact(ctx context.Context, id pgtype.UUID) (*ExternalContact, error)
 	RevokeMacHost(ctx context.Context, id pgtype.UUID) (*MacHost, error)
 	// Lightweight query returning only IDs with search for navigation
 	SearchContactIDs(ctx context.Context, arg SearchContactIDsParams) ([]pgtype.UUID, error)
@@ -700,6 +719,11 @@ type Querier interface {
 	// consumer reads prev from the event payload (plan Decision 2a).
 	SnapshotContactCadenceFields(ctx context.Context, id pgtype.UUID) (*SnapshotContactCadenceFieldsRow, error)
 	SoftDeleteContact(ctx context.Context, id pgtype.UUID) error
+	// Tombstones a live row. Defensive WHERE deleted_at IS NULL keeps the
+	// statement idempotent against a concurrent delete. crm_contact_id,
+	// match_status, and duplicate_of_id are preserved per the external_contact
+	// soft-delete contract.
+	SoftDeleteExternalContact(ctx context.Context, id pgtype.UUID) error
 	SoftDeleteInteraction(ctx context.Context, id pgtype.UUID) error
 	SoftDeleteTelegramChannelMessages(ctx context.Context, arg SoftDeleteTelegramChannelMessagesParams) error
 	SoftDeleteTelegramMessages(ctx context.Context, messageIds []int32) error

--- a/backend/internal/db/queries/contact_method.sql
+++ b/backend/internal/db/queries/contact_method.sql
@@ -64,3 +64,18 @@ WHERE cm.id = $1
     WHERE c.id = cm.contact_id
       AND c.deleted_at IS NULL
   );
+
+-- name: ListCanonicalIdentifiersByType :many
+-- Returns the deduplicated canonicalized value set for the given
+-- contact_method types, scoped to non-deleted contacts. Ordered
+-- alphabetically by value_normalized for deterministic daemon-side diff.
+-- Used by GET /api/v1/host/:id/known-identifiers — the daemon needs the
+-- SET of canonical phones/emails, not the contact mapping, so DISTINCT
+-- collapses the same value across multiple contacts.
+SELECT DISTINCT cm.value_normalized
+FROM contact_method cm
+JOIN contact c ON c.id = cm.contact_id
+WHERE cm.type = ANY($1::text[])
+  AND cm.value_normalized <> ''
+  AND c.deleted_at IS NULL
+ORDER BY cm.value_normalized ASC;

--- a/backend/internal/db/queries/external_contact.sql
+++ b/backend/internal/db/queries/external_contact.sql
@@ -110,24 +110,30 @@ WHERE match_status = 'unmatched'
   AND deleted_at IS NULL;
 
 -- name: UpdateExternalContactMatch :one
+-- Filter `deleted_at IS NULL` so a tombstoned row cannot have its
+-- match state mutated. A tombstoned row is invisible to every read
+-- path; writes should be invisible too.
 UPDATE external_contact SET
     crm_contact_id = $2,
     match_status = $3,
     updated_at = NOW()
 WHERE id = $1
+  AND deleted_at IS NULL
 RETURNING *;
 
 -- name: UpdateExternalContactDuplicate :exec
 UPDATE external_contact SET
     duplicate_of_id = $2,
     updated_at = NOW()
-WHERE id = $1;
+WHERE id = $1
+  AND deleted_at IS NULL;
 
 -- name: IgnoreExternalContact :exec
 UPDATE external_contact SET
     match_status = 'ignored',
     updated_at = NOW()
-WHERE id = $1;
+WHERE id = $1
+  AND deleted_at IS NULL;
 
 -- name: FindExternalContactsByEmail :many
 SELECT * FROM external_contact

--- a/backend/internal/db/queries/external_contact.sql
+++ b/backend/internal/db/queries/external_contact.sql
@@ -1,18 +1,28 @@
 -- External Contact queries
 
 -- name: GetExternalContact :one
-SELECT * FROM external_contact WHERE id = $1;
+-- Tombstoned rows are not retrievable by ID through normal flows.
+SELECT * FROM external_contact
+WHERE id = $1
+  AND deleted_at IS NULL;
 
 -- name: FindExternalContactsBySourceAndSourceID :many
 -- Finds all unmatched external_contact rows for a (source, source_id) pair
 -- regardless of account_id. Used by the calendar rematch handler to mark
 -- gcal_attendee import candidates as matched after a CRM contact links them.
+-- Tombstoned candidates must not be rematched.
 SELECT * FROM external_contact
 WHERE source = sqlc.arg('source')
   AND source_id = sqlc.arg('source_id')
-  AND match_status = 'unmatched';
+  AND match_status = 'unmatched'
+  AND deleted_at IS NULL;
 
 -- name: GetExternalContactBySource :one
+-- Tombstone-aware: returns tombstoned rows too. The mac-daemon ingest path
+-- needs visibility into tombstoned rows so it can revive them on a fresh
+-- external_contact.upserted event. Existing telegram / gcontacts callers
+-- never tombstone, so the broader read does not affect them. Callers that
+-- want live-only rows must check `DeletedAt == nil` after the call.
 SELECT * FROM external_contact
 WHERE source = $1 AND source_id = $2 AND COALESCE(account_id, '') = COALESCE($3, '');
 
@@ -39,9 +49,33 @@ ON CONFLICT (source, source_id, COALESCE(account_id, '')) DO UPDATE SET
     updated_at = NOW()
 RETURNING *;
 
+-- name: ReviveExternalContact :one
+-- Clears deleted_at on a tombstoned row. Defensive WHERE deleted_at IS NOT
+-- NULL keeps the statement idempotent across concurrent revive races.
+-- Preserves crm_contact_id, match_status, and all content columns.
+UPDATE external_contact SET
+    deleted_at = NULL,
+    updated_at = NOW()
+WHERE id = $1
+  AND deleted_at IS NOT NULL
+RETURNING *;
+
+-- name: SoftDeleteExternalContact :exec
+-- Tombstones a live row. Defensive WHERE deleted_at IS NULL keeps the
+-- statement idempotent against a concurrent delete. crm_contact_id,
+-- match_status, and duplicate_of_id are preserved per the external_contact
+-- soft-delete contract.
+UPDATE external_contact SET
+    deleted_at = NOW(),
+    updated_at = NOW()
+WHERE id = $1
+  AND deleted_at IS NULL;
+
 -- name: ListExternalContactsBySource :many
 SELECT * FROM external_contact
-WHERE source = $1 AND ($2::text IS NULL OR account_id = $2)
+WHERE source = $1
+  AND ($2::text IS NULL OR account_id = $2)
+  AND deleted_at IS NULL
 ORDER BY display_name
 LIMIT $3 OFFSET $4;
 
@@ -50,6 +84,7 @@ SELECT * FROM external_contact
 WHERE source = $1
   AND match_status = 'unmatched'
   AND duplicate_of_id IS NULL
+  AND deleted_at IS NULL
 ORDER BY display_name
 LIMIT $2 OFFSET $3;
 
@@ -57,6 +92,7 @@ LIMIT $2 OFFSET $3;
 SELECT * FROM external_contact
 WHERE match_status = 'unmatched'
   AND duplicate_of_id IS NULL
+  AND deleted_at IS NULL
 ORDER BY source, display_name
 LIMIT $1 OFFSET $2;
 
@@ -64,12 +100,14 @@ LIMIT $1 OFFSET $2;
 SELECT COUNT(*) FROM external_contact
 WHERE source = $1
   AND match_status = 'unmatched'
-  AND duplicate_of_id IS NULL;
+  AND duplicate_of_id IS NULL
+  AND deleted_at IS NULL;
 
 -- name: CountAllUnmatchedExternalContacts :one
 SELECT COUNT(*) FROM external_contact
 WHERE match_status = 'unmatched'
-  AND duplicate_of_id IS NULL;
+  AND duplicate_of_id IS NULL
+  AND deleted_at IS NULL;
 
 -- name: UpdateExternalContactMatch :one
 UPDATE external_contact SET
@@ -95,20 +133,24 @@ WHERE id = $1;
 SELECT * FROM external_contact
 WHERE emails @> $1::jsonb
   AND duplicate_of_id IS NULL
+  AND deleted_at IS NULL
 ORDER BY created_at;
 
 -- name: FindExternalContactsByNormalizedEmail :many
 -- Finds external contacts whose JSONB emails contain the given normalized
 -- email value. Backed by idx_external_contact_emails_value_lower_gin via
--- the jsonb_array_lower_values helper.
+-- the jsonb_array_lower_values helper. Tombstoned rows are excluded so
+-- duplicate detection ignores soft-deleted candidates.
 SELECT * FROM external_contact
 WHERE jsonb_array_lower_values(emails, 'value') && ARRAY[LOWER($1)]
   AND duplicate_of_id IS NULL
+  AND deleted_at IS NULL
 ORDER BY created_at;
 
 -- name: ListExternalContactsForCRMContact :many
 SELECT * FROM external_contact
 WHERE crm_contact_id = $1
+  AND deleted_at IS NULL
 ORDER BY source, account_id;
 
 -- name: DeleteExternalContactsBySourceAccount :exec

--- a/backend/internal/db/queries/test.sql
+++ b/backend/internal/db/queries/test.sql
@@ -14,7 +14,9 @@ DELETE FROM external_contact WHERE source_id LIKE $1 || '%';
 SELECT COUNT(*) FROM contact WHERE full_name LIKE $1 || '%';
 
 -- name: CountExternalContactsByDisplayNamePrefix :one
-SELECT COUNT(*) FROM external_contact WHERE display_name LIKE $1 || '%';
+SELECT COUNT(*) FROM external_contact
+WHERE display_name LIKE $1 || '%'
+  AND deleted_at IS NULL;
 
 -- name: DeleteCalendarEventsByTitlePrefix :execrows
 DELETE FROM calendar_event WHERE title LIKE $1 || '%';

--- a/backend/internal/db/test.sql.go
+++ b/backend/internal/db/test.sql.go
@@ -23,7 +23,9 @@ func (q *Queries) CountContactsByNamePrefix(ctx context.Context, dollar_1 pgtype
 }
 
 const CountExternalContactsByDisplayNamePrefix = `-- name: CountExternalContactsByDisplayNamePrefix :one
-SELECT COUNT(*) FROM external_contact WHERE display_name LIKE $1 || '%'
+SELECT COUNT(*) FROM external_contact
+WHERE display_name LIKE $1 || '%'
+  AND deleted_at IS NULL
 `
 
 func (q *Queries) CountExternalContactsByDisplayNamePrefix(ctx context.Context, dollar_1 pgtype.Text) (int64, error) {

--- a/backend/internal/db/test_jsonb_fixtures.sql.go
+++ b/backend/internal/db/test_jsonb_fixtures.sql.go
@@ -116,7 +116,7 @@ const TestInsertExternalContactRawEmails = `-- name: TestInsertExternalContactRa
 
 INSERT INTO external_contact (source, source_id, display_name, emails)
 VALUES ($1::text, $2::text, $3::text, $4::jsonb)
-RETURNING id, source, source_id, account_id, display_name, first_name, last_name, emails, phones, addresses, organization, job_title, birthday, photo_url, crm_contact_id, match_status, duplicate_of_id, etag, metadata, synced_at, created_at, updated_at
+RETURNING id, source, source_id, account_id, display_name, first_name, last_name, emails, phones, addresses, organization, job_title, birthday, photo_url, crm_contact_id, match_status, duplicate_of_id, etag, metadata, synced_at, created_at, updated_at, deleted_at
 `
 
 type TestInsertExternalContactRawEmailsParams struct {
@@ -166,6 +166,7 @@ func (q *Queries) TestInsertExternalContactRawEmails(ctx context.Context, arg Te
 		&i.SyncedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.DeletedAt,
 	)
 	return &i, err
 }
@@ -232,7 +233,7 @@ func (q *Queries) TestParityFindEventsByAttendeeEmailUnmatchedForContactLegacy(c
 }
 
 const TestParityFindExternalContactsByNormalizedEmailLegacy = `-- name: TestParityFindExternalContactsByNormalizedEmailLegacy :many
-SELECT id, source, source_id, account_id, display_name, first_name, last_name, emails, phones, addresses, organization, job_title, birthday, photo_url, crm_contact_id, match_status, duplicate_of_id, etag, metadata, synced_at, created_at, updated_at FROM external_contact
+SELECT id, source, source_id, account_id, display_name, first_name, last_name, emails, phones, addresses, organization, job_title, birthday, photo_url, crm_contact_id, match_status, duplicate_of_id, etag, metadata, synced_at, created_at, updated_at, deleted_at FROM external_contact
 WHERE EXISTS (
     SELECT 1 FROM jsonb_array_elements(emails) AS e
     WHERE LOWER(e->>'value') = LOWER($1)
@@ -278,6 +279,7 @@ func (q *Queries) TestParityFindExternalContactsByNormalizedEmailLegacy(ctx cont
 			&i.SyncedAt,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.DeletedAt,
 		); err != nil {
 			return nil, err
 		}

--- a/backend/internal/events/kinds.go
+++ b/backend/internal/events/kinds.go
@@ -359,7 +359,7 @@ type ExternalContactAddressValue struct {
 type ExternalContactUpsertedPayload struct {
 	Version      int                           `json:"version"`   // start at 1
 	HostID       uuid.UUID                     `json:"host_id"`   // authenticated host
-	Source       string                        `json:"source"`    // "icloud_contacts" in PR5
+	Source       string                        `json:"source"`    // e.g. "icloud_contacts"
 	EntityID     string                        `json:"entity_id"` // CNContact identifier; column source_id
 	DisplayName  *string                       `json:"display_name,omitempty"`
 	FirstName    *string                       `json:"first_name,omitempty"`
@@ -382,7 +382,7 @@ type ExternalContactUpsertedPayload struct {
 type ExternalContactDeletedPayload struct {
 	Version  int       `json:"version"`   // start at 1
 	HostID   uuid.UUID `json:"host_id"`   // authenticated host
-	Source   string    `json:"source"`    // "icloud_contacts" in PR5
+	Source   string    `json:"source"`    // e.g. "icloud_contacts"
 	EntityID string    `json:"entity_id"` // CNContact identifier
 }
 

--- a/backend/internal/events/kinds.go
+++ b/backend/internal/events/kinds.go
@@ -39,6 +39,16 @@ const (
 	// dedup on retries.
 	KindRawMessageReceived Kind = "raw_message.received"
 	KindRawMessageSent     Kind = "raw_message.sent"
+
+	// Daemon-emitted external-contact events. Published by the Mac
+	// daemon's iCloud Contacts watcher against /api/v1/ingest/events
+	// with host-auth. NOT consumed by any bus consumer — IngestService
+	// processes them inline within the per-event savepoint (identity
+	// match per email/phone → external_contact upsert/tombstone with
+	// optional revive). The event-log row exists for audit +
+	// (source, source_id) dedup on retries.
+	KindExternalContactUpserted Kind = "external_contact.upserted"
+	KindExternalContactDeleted  Kind = "external_contact.deleted"
 )
 
 // AllKinds enumerates every defined Kind. Used by tests to guard that
@@ -57,6 +67,8 @@ var AllKinds = []Kind{
 	KindInteractionRecorded,
 	KindRawMessageReceived,
 	KindRawMessageSent,
+	KindExternalContactUpserted,
+	KindExternalContactDeleted,
 }
 
 // Envelope is the wire/DB shape passed through Bus.Publish. Payload is
@@ -314,24 +326,86 @@ type RawMessageReceivedPayload struct {
 // constant — used by the inline handler to set IsOutgoing on staging).
 type RawMessageSentPayload RawMessageReceivedPayload
 
+// ExternalContactMethodValue carries a single contact-method value
+// (email or phone) plus its display tags. Same shape used for both
+// emails[] and phones[] in ExternalContactUpsertedPayload.
+type ExternalContactMethodValue struct {
+	Value   string `json:"value"`             // raw, daemon-supplied
+	Type    string `json:"type,omitempty"`    // e.g. "home", "work"
+	Primary bool   `json:"primary,omitempty"` // true on the entity's primary
+}
+
+// ExternalContactAddressValue is the address shape in
+// ExternalContactUpsertedPayload. Metadata-only (no geocoding).
+type ExternalContactAddressValue struct {
+	Formatted string `json:"formatted"`
+	Type      string `json:"type,omitempty"`
+}
+
+// ExternalContactUpsertedPayload is the payload for
+// KindExternalContactUpserted, emitted by the Mac daemon on every
+// CNChangeHistoryFetchRequest add/update event for a contact in an
+// allow-listed container. Inline-processed by IngestService (identity
+// match per email/phone → external_contact upsert; revives a
+// tombstoned row when present).
+//
+// Version starts at 1. Additive fields are V1-compatible.
+//
+// Metadata is source-specific: the Mac daemon populates
+// `container_identifier` (which CNContainer this contact came from);
+// future sources populate their own keys. Persisted into
+// external_contact.metadata JSONB wholesale (NOT merged) — daemon owns
+// the contents.
+type ExternalContactUpsertedPayload struct {
+	Version      int                           `json:"version"`   // start at 1
+	HostID       uuid.UUID                     `json:"host_id"`   // authenticated host
+	Source       string                        `json:"source"`    // "icloud_contacts" in PR5
+	EntityID     string                        `json:"entity_id"` // CNContact identifier; column source_id
+	DisplayName  *string                       `json:"display_name,omitempty"`
+	FirstName    *string                       `json:"first_name,omitempty"`
+	LastName     *string                       `json:"last_name,omitempty"`
+	Emails       []ExternalContactMethodValue  `json:"emails,omitempty"`
+	Phones       []ExternalContactMethodValue  `json:"phones,omitempty"`
+	Addresses    []ExternalContactAddressValue `json:"addresses,omitempty"`
+	Organization *string                       `json:"organization,omitempty"`
+	JobTitle     *string                       `json:"job_title,omitempty"`
+	Birthday     *string                       `json:"birthday,omitempty"` // ISO date YYYY-MM-DD
+	PhotoURL     *string                       `json:"photo_url,omitempty"`
+	Metadata     map[string]any                `json:"metadata,omitempty"`
+}
+
+// ExternalContactDeletedPayload is the payload for
+// KindExternalContactDeleted, emitted on a CNChangeHistoryFetchRequest
+// delete (or tombstone reconciliation on a full resync). The handler
+// tombstones the row by id; an unknown entity is a silent no-op
+// (event-log row is durable for audit either way).
+type ExternalContactDeletedPayload struct {
+	Version  int       `json:"version"`   // start at 1
+	HostID   uuid.UUID `json:"host_id"`   // authenticated host
+	Source   string    `json:"source"`    // "icloud_contacts" in PR5
+	EntityID string    `json:"entity_id"` // CNContact identifier
+}
+
 // kindPayloadTypes is the canonical Kind → payload-type registry used by
 // Marshal and Unmarshal to assert type-vs-kind consistency at runtime. Add
 // a row each time a new Kind + payload struct are introduced. Keep in sync
 // with AllKinds (the unit test TestKindPayloadTypes_CoversAllKinds enforces
 // this invariant).
 var kindPayloadTypes = map[Kind]reflect.Type{
-	KindMessageReceived:      reflect.TypeOf(MessageReceivedPayload{}),
-	KindMessageSent:          reflect.TypeOf(MessageSentPayload{}),
-	KindCalendarAttended:     reflect.TypeOf(CalendarAttendedPayload{}),
-	KindCalendarDeclined:     reflect.TypeOf(CalendarDeclinedPayload{}),
-	KindTaskCompleted:        reflect.TypeOf(TaskCompletedPayload{}),
-	KindTaskSkipped:          reflect.TypeOf(TaskSkippedPayload{}),
-	KindTaskOutreachDetected: reflect.TypeOf(TaskOutreachDetectedPayload{}),
-	KindInteractionManual:    reflect.TypeOf(InteractionManualPayload{}),
-	KindContactMethodsAdded:  reflect.TypeOf(ContactMethodsAddedPayload{}),
-	KindInteractionRecorded:  reflect.TypeOf(InteractionRecordedPayload{}),
-	KindRawMessageReceived:   reflect.TypeOf(RawMessageReceivedPayload{}),
-	KindRawMessageSent:       reflect.TypeOf(RawMessageSentPayload{}),
+	KindMessageReceived:         reflect.TypeOf(MessageReceivedPayload{}),
+	KindMessageSent:             reflect.TypeOf(MessageSentPayload{}),
+	KindCalendarAttended:        reflect.TypeOf(CalendarAttendedPayload{}),
+	KindCalendarDeclined:        reflect.TypeOf(CalendarDeclinedPayload{}),
+	KindTaskCompleted:           reflect.TypeOf(TaskCompletedPayload{}),
+	KindTaskSkipped:             reflect.TypeOf(TaskSkippedPayload{}),
+	KindTaskOutreachDetected:    reflect.TypeOf(TaskOutreachDetectedPayload{}),
+	KindInteractionManual:       reflect.TypeOf(InteractionManualPayload{}),
+	KindContactMethodsAdded:     reflect.TypeOf(ContactMethodsAddedPayload{}),
+	KindInteractionRecorded:     reflect.TypeOf(InteractionRecordedPayload{}),
+	KindRawMessageReceived:      reflect.TypeOf(RawMessageReceivedPayload{}),
+	KindRawMessageSent:          reflect.TypeOf(RawMessageSentPayload{}),
+	KindExternalContactUpserted: reflect.TypeOf(ExternalContactUpsertedPayload{}),
+	KindExternalContactDeleted:  reflect.TypeOf(ExternalContactDeletedPayload{}),
 }
 
 // IsKnownKind reports whether kind has a registered payload type. Used by
@@ -392,6 +466,27 @@ func ValidatePayload(env *Envelope) error {
 		p := dst.(*RawMessageSentPayload)
 		if p.MessageType != "" && !IsCanonicalMessageType(p.MessageType) {
 			return fmt.Errorf("validate %s: message_type %q is not in the canonical set", env.Kind, p.MessageType)
+		}
+	case KindExternalContactUpserted:
+		p := dst.(*ExternalContactUpsertedPayload)
+		if p.EntityID == "" {
+			return fmt.Errorf("validate %s: entity_id is required", env.Kind)
+		}
+		if p.HostID == uuid.Nil {
+			return fmt.Errorf("validate %s: host_id is required", env.Kind)
+		}
+		if p.Birthday != nil && *p.Birthday != "" {
+			if _, err := time.Parse("2006-01-02", *p.Birthday); err != nil {
+				return fmt.Errorf("validate %s: birthday %q not in YYYY-MM-DD form", env.Kind, *p.Birthday)
+			}
+		}
+	case KindExternalContactDeleted:
+		p := dst.(*ExternalContactDeletedPayload)
+		if p.EntityID == "" {
+			return fmt.Errorf("validate %s: entity_id is required", env.Kind)
+		}
+		if p.HostID == uuid.Nil {
+			return fmt.Errorf("validate %s: host_id is required", env.Kind)
 		}
 	}
 	return nil

--- a/backend/internal/events/kinds_test.go
+++ b/backend/internal/events/kinds_test.go
@@ -531,10 +531,11 @@ func TestKindPayloadTypes_CoversAllKinds(t *testing.T) {
 
 // TestAllKinds_ExpectedCount guards against accidental Kind additions or
 // deletions from AllKinds without updating the spec. Current spec (§3.2)
-// declares 10 base kinds (9 raw-signal + 1 derived) plus the two
-// daemon-emitted raw_message.* kinds introduced for the messages source.
+// declares 10 base kinds (9 raw-signal + 1 derived), plus the two
+// daemon-emitted raw_message.* kinds (messages source), plus the two
+// external_contact.* kinds (iCloud Contacts source).
 func TestAllKinds_ExpectedCount(t *testing.T) {
-	require.Len(t, AllKinds, 12)
+	require.Len(t, AllKinds, 14)
 }
 
 // TestIsKnownKind_CoversAllKinds is the positive side: every Kind declared
@@ -611,6 +612,20 @@ func buildCanonicalPayload(t *testing.T, kind Kind) json.RawMessage {
 			Version: 1, HostID: uuid.New(), Source: "messages",
 			Guid: "g-2", ChatID: "iMessage;-;chat-x", PeerHandle: "+15551234567",
 			MessageType: "text", SentAt: at,
+		})
+		require.NoError(t, err)
+		return raw
+	case KindExternalContactUpserted:
+		raw, err := Marshal(kind, ExternalContactUpsertedPayload{
+			Version: 1, HostID: uuid.New(), Source: "icloud_contacts",
+			EntityID: "CN-canonical-1",
+		})
+		require.NoError(t, err)
+		return raw
+	case KindExternalContactDeleted:
+		raw, err := Marshal(kind, ExternalContactDeletedPayload{
+			Version: 1, HostID: uuid.New(), Source: "icloud_contacts",
+			EntityID: "CN-canonical-2",
 		})
 		require.NoError(t, err)
 		return raw
@@ -784,4 +799,187 @@ func TestValidatePayload_NullPayloadWithWhitespace(t *testing.T) {
 	err := ValidatePayload(env)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "got null")
+}
+
+// ----------------------------------------------------------------------------
+// external_contact.* payload tests (PR5).
+// ----------------------------------------------------------------------------
+
+func makeExternalContactUpsertedRaw(t *testing.T, mutate func(*ExternalContactUpsertedPayload)) json.RawMessage {
+	t.Helper()
+	bday := "1990-04-21"
+	dn := "Sample User"
+	p := ExternalContactUpsertedPayload{
+		Version:     1,
+		HostID:      uuid.New(),
+		Source:      "icloud_contacts",
+		EntityID:    "CN-entity-1",
+		DisplayName: &dn,
+		Emails:      []ExternalContactMethodValue{{Value: "u@example.com", Type: "home", Primary: true}},
+		Phones:      []ExternalContactMethodValue{{Value: "+15551234567", Type: "mobile"}},
+		Birthday:    &bday,
+	}
+	if mutate != nil {
+		mutate(&p)
+	}
+	b, err := json.Marshal(p)
+	require.NoError(t, err)
+	return json.RawMessage(b)
+}
+
+func TestValidatePayload_ExternalContactUpserted_AcceptsValid(t *testing.T) {
+	env := &Envelope{
+		Kind:    KindExternalContactUpserted,
+		Payload: makeExternalContactUpsertedRaw(t, nil),
+	}
+	require.NoError(t, ValidatePayload(env))
+}
+
+func TestValidatePayload_ExternalContactUpserted_RejectsEmptyEntityID(t *testing.T) {
+	env := &Envelope{
+		Kind: KindExternalContactUpserted,
+		Payload: makeExternalContactUpsertedRaw(t, func(p *ExternalContactUpsertedPayload) {
+			p.EntityID = ""
+		}),
+	}
+	err := ValidatePayload(env)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "entity_id is required")
+}
+
+func TestValidatePayload_ExternalContactUpserted_RejectsZeroHostID(t *testing.T) {
+	env := &Envelope{
+		Kind: KindExternalContactUpserted,
+		Payload: makeExternalContactUpsertedRaw(t, func(p *ExternalContactUpsertedPayload) {
+			p.HostID = uuid.Nil
+		}),
+	}
+	err := ValidatePayload(env)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "host_id is required")
+}
+
+func TestValidatePayload_ExternalContactUpserted_RejectsMalformedBirthday(t *testing.T) {
+	env := &Envelope{
+		Kind: KindExternalContactUpserted,
+		Payload: makeExternalContactUpsertedRaw(t, func(p *ExternalContactUpsertedPayload) {
+			bad := "1990/04/21"
+			p.Birthday = &bad
+		}),
+	}
+	err := ValidatePayload(env)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "birthday")
+}
+
+func TestValidatePayload_ExternalContactUpserted_OmittedBirthdayAccepted(t *testing.T) {
+	env := &Envelope{
+		Kind: KindExternalContactUpserted,
+		Payload: makeExternalContactUpsertedRaw(t, func(p *ExternalContactUpsertedPayload) {
+			p.Birthday = nil
+		}),
+	}
+	require.NoError(t, ValidatePayload(env))
+}
+
+func TestMarshalUnmarshal_ExternalContactUpserted_RoundTrip(t *testing.T) {
+	bday := "1990-04-21"
+	dn := "Sample User"
+	org := "ACME"
+	original := ExternalContactUpsertedPayload{
+		Version:      1,
+		HostID:       uuid.New(),
+		Source:       "icloud_contacts",
+		EntityID:     "CN-entity-2",
+		DisplayName:  &dn,
+		Emails:       []ExternalContactMethodValue{{Value: "u@example.com"}, {Value: "w@example.com", Type: "work"}},
+		Phones:       []ExternalContactMethodValue{{Value: "+15551234567", Primary: true}},
+		Addresses:    []ExternalContactAddressValue{{Formatted: "1 Test St", Type: "home"}},
+		Organization: &org,
+		Birthday:     &bday,
+		Metadata:     map[string]any{"container_identifier": "CN-container-1"},
+	}
+	raw, err := Marshal(KindExternalContactUpserted, original)
+	require.NoError(t, err)
+
+	env := &Envelope{Kind: KindExternalContactUpserted, Payload: raw}
+	var decoded ExternalContactUpsertedPayload
+	require.NoError(t, Unmarshal(env, &decoded))
+	require.Equal(t, original.EntityID, decoded.EntityID)
+	require.Equal(t, original.HostID, decoded.HostID)
+	require.Equal(t, original.Emails, decoded.Emails)
+	require.Equal(t, original.Phones, decoded.Phones)
+	require.Equal(t, original.Addresses, decoded.Addresses)
+	require.Equal(t, *original.Birthday, *decoded.Birthday)
+	require.Equal(t, original.Metadata, decoded.Metadata)
+}
+
+func TestValidatePayload_ExternalContactDeleted_AcceptsValid(t *testing.T) {
+	p := ExternalContactDeletedPayload{
+		Version:  1,
+		HostID:   uuid.New(),
+		Source:   "icloud_contacts",
+		EntityID: "CN-entity-3",
+	}
+	raw, err := json.Marshal(p)
+	require.NoError(t, err)
+	env := &Envelope{Kind: KindExternalContactDeleted, Payload: raw}
+	require.NoError(t, ValidatePayload(env))
+}
+
+func TestValidatePayload_ExternalContactDeleted_RejectsEmptyEntityID(t *testing.T) {
+	p := ExternalContactDeletedPayload{
+		Version: 1,
+		HostID:  uuid.New(),
+		Source:  "icloud_contacts",
+	}
+	raw, err := json.Marshal(p)
+	require.NoError(t, err)
+	env := &Envelope{Kind: KindExternalContactDeleted, Payload: raw}
+	err = ValidatePayload(env)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "entity_id is required")
+}
+
+func TestValidatePayload_ExternalContactDeleted_RejectsZeroHostID(t *testing.T) {
+	p := ExternalContactDeletedPayload{
+		Version:  1,
+		Source:   "icloud_contacts",
+		EntityID: "CN-entity-4",
+	}
+	raw, err := json.Marshal(p)
+	require.NoError(t, err)
+	env := &Envelope{Kind: KindExternalContactDeleted, Payload: raw}
+	err = ValidatePayload(env)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "host_id is required")
+}
+
+// TestExternalContactPayload_JSONShape locks the omitempty wire shape
+// for both new kinds — a future field rename or json tag drift would
+// break daemon compatibility silently.
+func TestExternalContactPayload_JSONShape(t *testing.T) {
+	hid := uuid.New()
+	p := ExternalContactUpsertedPayload{
+		Version:  1,
+		HostID:   hid,
+		Source:   "icloud_contacts",
+		EntityID: "CN-1",
+	}
+	b, err := json.Marshal(p)
+	require.NoError(t, err)
+	asMap := map[string]any{}
+	require.NoError(t, json.Unmarshal(b, &asMap))
+	// Required fields always present.
+	require.Equal(t, float64(1), asMap["version"])
+	require.Equal(t, hid.String(), asMap["host_id"])
+	require.Equal(t, "icloud_contacts", asMap["source"])
+	require.Equal(t, "CN-1", asMap["entity_id"])
+	// Omit-empty fields are absent.
+	_, hasEmails := asMap["emails"]
+	require.False(t, hasEmails, "emails should be omitted when empty")
+	_, hasBirthday := asMap["birthday"]
+	require.False(t, hasBirthday, "birthday should be omitted when nil")
+	_, hasMetadata := asMap["metadata"]
+	require.False(t, hasMetadata, "metadata should be omitted when nil")
 }

--- a/backend/internal/events/kinds_test.go
+++ b/backend/internal/events/kinds_test.go
@@ -802,7 +802,7 @@ func TestValidatePayload_NullPayloadWithWhitespace(t *testing.T) {
 }
 
 // ----------------------------------------------------------------------------
-// external_contact.* payload tests (PR5).
+// external_contact.* payload tests.
 // ----------------------------------------------------------------------------
 
 func makeExternalContactUpsertedRaw(t *testing.T, mutate func(*ExternalContactUpsertedPayload)) json.RawMessage {

--- a/backend/internal/icloudcontacts/provider.go
+++ b/backend/internal/icloudcontacts/provider.go
@@ -1,0 +1,65 @@
+// Package icloudcontacts contains the Pi-side wiring for the
+// "icloud_contacts" source — Apple iCloud Contacts data delivered via
+// the Mac daemon's push pipeline. The package is producer-agnostic; the
+// daemon itself lives outside this repo (Swift code in a sibling
+// project) and submits external_contact.* events to
+// /api/v1/ingest/events.
+package icloudcontacts
+
+import (
+	"context"
+
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/sync"
+)
+
+// SourceName is the canonical envelope source for iCloud Contacts
+// events. Exposed for symmetry with other source packages and used by
+// the IngestService's allow-list.
+const SourceName = "icloud_contacts"
+
+// Provider registers the "icloud_contacts" source with the sync
+// registry. The source is push-only: data lands via the daemon's
+// ingest POSTs (external_contact.upserted / .deleted), never via the
+// scheduler. The provider exists so:
+//
+//   - the scheduler's push-strategy exclusion has a registered entry to
+//     match against (instead of an implicit "any unknown source is
+//     pollable" gap);
+//   - the /api/v1/sync/providers endpoint reports the iCloud Contacts
+//     source in the registry list (no frontend consumes that endpoint
+//     today, but it's the correct ground truth for ops queries).
+//
+// Sync() is a no-op. ValidateCredentials() returns nil — the Mac
+// daemon authenticates on its own with the host-bearer key minted
+// during the pairing flow.
+type Provider struct{}
+
+// New constructs an iCloud Contacts provider.
+func New() *Provider { return &Provider{} }
+
+// Config implements sync.SyncProvider.
+func (p *Provider) Config() sync.SourceConfig {
+	return sync.SourceConfig{
+		Name:                 SourceName,
+		DisplayName:          "iCloud Contacts",
+		Strategy:             repository.SyncStrategyPush,
+		SupportsMultiAccount: false,
+		SupportsDiscovery:    false, // entity sync; daemon owns discovery via CNContactStore
+		DefaultInterval:      0,     // push: scheduler never enqueues
+	}
+}
+
+// Sync implements sync.SyncProvider. Push-strategy: data lands via
+// /api/v1/ingest/events. The scheduler already excludes us via
+// ListDueAccounts; the no-op return makes a direct invocation safe.
+func (p *Provider) Sync(_ context.Context, _ *repository.SyncState, _ []repository.Contact) (*sync.SyncResult, error) {
+	return &sync.SyncResult{}, nil
+}
+
+// ValidateCredentials implements sync.SyncProvider. No credentials are
+// stored on the Pi for the iCloud Contacts source — host-bearer auth
+// is the daemon's own concern.
+func (p *Provider) ValidateCredentials(_ context.Context, _ *string) error {
+	return nil
+}

--- a/backend/internal/icloudcontacts/provider_test.go
+++ b/backend/internal/icloudcontacts/provider_test.go
@@ -1,0 +1,39 @@
+package icloudcontacts
+
+import (
+	"context"
+	"testing"
+
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/sync"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Compile-time guard: Provider must satisfy sync.SyncProvider.
+var _ sync.SyncProvider = (*Provider)(nil)
+
+func TestProvider_Config(t *testing.T) {
+	cfg := New().Config()
+	require.Equal(t, "icloud_contacts", cfg.Name)
+	require.Equal(t, "iCloud Contacts", cfg.DisplayName)
+	require.Equal(t, repository.SyncStrategyPush, cfg.Strategy)
+	require.False(t, cfg.SupportsMultiAccount)
+	require.False(t, cfg.SupportsDiscovery)
+	require.Equal(t, int64(0), int64(cfg.DefaultInterval))
+}
+
+func TestProvider_SyncIsNoop(t *testing.T) {
+	result, err := New().Sync(context.Background(), nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, 0, result.ItemsProcessed)
+	require.Equal(t, 0, result.ItemsMatched)
+	require.Equal(t, 0, result.ItemsCreated)
+}
+
+func TestProvider_ValidateCredentialsIsNoop(t *testing.T) {
+	require.NoError(t, New().ValidateCredentials(context.Background(), nil))
+	acct := "ignored"
+	require.NoError(t, New().ValidateCredentials(context.Background(), &acct))
+}

--- a/backend/internal/repository/contact_method.go
+++ b/backend/internal/repository/contact_method.go
@@ -179,3 +179,18 @@ func (r *ContactMethodRepository) SetPrimary(ctx context.Context, id uuid.UUID, 
 		IsPrimary: pgtype.Bool{Bool: isPrimary, Valid: true},
 	})
 }
+
+// ListCanonicalIdentifiersByType returns the deduplicated, alphabetically
+// sorted set of canonical contact-method values for the given types,
+// scoped to non-deleted contacts. Backs GET /api/v1/host/:id/known-
+// identifiers — the daemon uses this to filter incoming Apple Messages
+// senders against the user's known contact set.
+//
+// types is typically ["email"] or ["phone"]. Empty value_normalized
+// entries (legacy rows / null normalization) are excluded.
+func (r *ContactMethodRepository) ListCanonicalIdentifiersByType(
+	ctx context.Context,
+	types []string,
+) ([]string, error) {
+	return r.queries.ListCanonicalIdentifiersByType(ctx, types)
+}

--- a/backend/internal/repository/external_contact.go
+++ b/backend/internal/repository/external_contact.go
@@ -419,7 +419,9 @@ func (r *ExternalContactRepository) CountAllUnmatched(ctx context.Context) (int6
 	return r.queries.CountAllUnmatchedExternalContacts(ctx)
 }
 
-// UpdateMatch updates the CRM contact ID and match status
+// UpdateMatch updates the CRM contact ID and match status. Returns
+// db.ErrNotFound when the target row is tombstoned (the underlying
+// query filters `deleted_at IS NULL`) or has been hard-deleted.
 func (r *ExternalContactRepository) UpdateMatch(ctx context.Context, id uuid.UUID, crmContactID *uuid.UUID, status MatchStatus) (*ExternalContact, error) {
 	var crmContactIDPg pgtype.UUID
 	if crmContactID != nil {
@@ -432,6 +434,9 @@ func (r *ExternalContactRepository) UpdateMatch(ctx context.Context, id uuid.UUI
 		MatchStatus:  pgtype.Text{String: string(status), Valid: true},
 	})
 	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, db.ErrNotFound
+		}
 		return nil, err
 	}
 	return convertDbExternalContact(dbContact)
@@ -566,6 +571,8 @@ func (r *ExternalContactRepository) UpsertTx(
 // UpdateMatchTx is the tx-bound variant of UpdateMatch. Used by the
 // mac-daemon ingest handler's first-insert path to set
 // crm_contact_id + match_status when an identity match succeeds.
+// Returns db.ErrNotFound when the target row is tombstoned (the
+// underlying query filters `deleted_at IS NULL`) or hard-deleted.
 // Caller owns the tx lifecycle.
 func (r *ExternalContactRepository) UpdateMatchTx(
 	ctx context.Context,
@@ -584,6 +591,9 @@ func (r *ExternalContactRepository) UpdateMatchTx(
 		MatchStatus:  pgtype.Text{String: string(status), Valid: true},
 	})
 	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, db.ErrNotFound
+		}
 		return nil, err
 	}
 	return convertDbExternalContact(dbContact)

--- a/backend/internal/repository/external_contact.go
+++ b/backend/internal/repository/external_contact.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -67,6 +68,11 @@ type ExternalContact struct {
 	SyncedAt      *time.Time     `json:"synced_at,omitempty"`
 	CreatedAt     time.Time      `json:"created_at"`
 	UpdatedAt     time.Time      `json:"updated_at"`
+	// DeletedAt is set when a soft-delete tombstones the row. Production
+	// read queries filter `deleted_at IS NULL` so a tombstoned row only
+	// surfaces through GetBySource (intentionally tombstone-aware for the
+	// mac-daemon revive path).
+	DeletedAt *time.Time `json:"deleted_at,omitempty"`
 }
 
 // UpsertTelegramDiscoveryCandidateRequest carries the Telegram-specific fields
@@ -211,6 +217,10 @@ func convertDbExternalContact(dbContact *db.ExternalContact) (*ExternalContact, 
 	if dbContact.UpdatedAt.Valid {
 		contact.UpdatedAt = dbContact.UpdatedAt.Time
 	}
+	if dbContact.DeletedAt.Valid {
+		t := dbContact.DeletedAt.Time
+		contact.DeletedAt = &t
+	}
 
 	return contact, nil
 }
@@ -250,7 +260,18 @@ func (r *ExternalContactRepository) GetBySource(ctx context.Context, source, sou
 
 // Upsert creates or updates an external contact
 func (r *ExternalContactRepository) Upsert(ctx context.Context, req UpsertExternalContactRequest) (*ExternalContact, error) {
-	// Marshal JSONB fields
+	dbContact, err := r.queries.UpsertExternalContact(ctx, buildUpsertExternalContactParams(req))
+	if err != nil {
+		return nil, err
+	}
+	return convertDbExternalContact(dbContact)
+}
+
+// buildUpsertExternalContactParams centralizes the pgtype + JSONB
+// conversion shared between Upsert (non-tx) and UpsertTx. Keeping it in
+// one place ensures both variants stay in lockstep — drift would
+// silently produce different on-disk shapes depending on caller.
+func buildUpsertExternalContactParams(req UpsertExternalContactRequest) db.UpsertExternalContactParams {
 	emailsJSON, _ := json.Marshal(req.Emails)
 	if req.Emails == nil {
 		emailsJSON = []byte("[]")
@@ -308,12 +329,7 @@ func (r *ExternalContactRepository) Upsert(ctx context.Context, req UpsertExtern
 	if req.SyncedAt != nil {
 		params.SyncedAt = pgtype.Timestamptz{Time: *req.SyncedAt, Valid: true}
 	}
-
-	dbContact, err := r.queries.UpsertExternalContact(ctx, params)
-	if err != nil {
-		return nil, err
-	}
-	return convertDbExternalContact(dbContact)
+	return params
 }
 
 // UpsertTelegramDiscoveryCandidate inserts or updates a Telegram discovery
@@ -496,4 +512,113 @@ func (r *ExternalContactRepository) ListForCRMContact(ctx context.Context, crmCo
 // Delete removes an external contact
 func (r *ExternalContactRepository) Delete(ctx context.Context, id uuid.UUID) error {
 	return r.queries.DeleteExternalContact(ctx, pgtype.UUID{Bytes: id, Valid: true})
+}
+
+// GetBySourceTx retrieves an external contact by (source, source_id,
+// account_id) within an active transaction. Tombstone-aware: returns
+// tombstoned rows too (caller inspects `DeletedAt != nil` to decide).
+// Returns (nil, db.ErrNotFound) on miss. Used by the mac-daemon ingest
+// service's inline external_contact.upserted / .deleted handlers — both
+// need visibility into tombstoned rows (upserted to revive, deleted to
+// confirm an existing tombstone for idempotent no-op).
+func (r *ExternalContactRepository) GetBySourceTx(
+	ctx context.Context,
+	tx pgx.Tx,
+	source, sourceID string,
+	accountID *string,
+) (*ExternalContact, error) {
+	var accountIDText pgtype.Text
+	if accountID != nil {
+		accountIDText = pgtype.Text{String: *accountID, Valid: true}
+	}
+	dbContact, err := db.New(tx).GetExternalContactBySource(ctx, db.GetExternalContactBySourceParams{
+		Source:    source,
+		SourceID:  sourceID,
+		AccountID: accountIDText,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, db.ErrNotFound
+		}
+		return nil, err
+	}
+	return convertDbExternalContact(dbContact)
+}
+
+// UpsertTx is the tx-bound variant of Upsert. Caller owns the tx
+// lifecycle. The underlying UpsertExternalContact query does NOT touch
+// deleted_at, crm_contact_id, or match_status on the UPDATE branch —
+// the revive path issues a separate ReviveTx call when the pre-read
+// detected a tombstone.
+func (r *ExternalContactRepository) UpsertTx(
+	ctx context.Context,
+	tx pgx.Tx,
+	req UpsertExternalContactRequest,
+) (*ExternalContact, error) {
+	params := buildUpsertExternalContactParams(req)
+	dbContact, err := db.New(tx).UpsertExternalContact(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+	return convertDbExternalContact(dbContact)
+}
+
+// UpdateMatchTx is the tx-bound variant of UpdateMatch. Used by the
+// mac-daemon ingest handler's first-insert path to set
+// crm_contact_id + match_status when an identity match succeeds.
+// Caller owns the tx lifecycle.
+func (r *ExternalContactRepository) UpdateMatchTx(
+	ctx context.Context,
+	tx pgx.Tx,
+	id uuid.UUID,
+	crmContactID *uuid.UUID,
+	status MatchStatus,
+) (*ExternalContact, error) {
+	var crmContactIDPg pgtype.UUID
+	if crmContactID != nil {
+		crmContactIDPg = pgtype.UUID{Bytes: *crmContactID, Valid: true}
+	}
+	dbContact, err := db.New(tx).UpdateExternalContactMatch(ctx, db.UpdateExternalContactMatchParams{
+		ID:           pgtype.UUID{Bytes: id, Valid: true},
+		CrmContactID: crmContactIDPg,
+		MatchStatus:  pgtype.Text{String: string(status), Valid: true},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return convertDbExternalContact(dbContact)
+}
+
+// ReviveTx clears `deleted_at` on a tombstoned row. The underlying SQL
+// has a defensive `WHERE deleted_at IS NOT NULL` predicate so a
+// concurrent revive that beat us is absorbed safely. Caller owns the
+// tx lifecycle. Returns db.ErrNotFound when the row is already live
+// (or does not exist) — callers should pre-check via GetBySourceTx to
+// avoid spurious not-found.
+func (r *ExternalContactRepository) ReviveTx(
+	ctx context.Context,
+	tx pgx.Tx,
+	id uuid.UUID,
+) (*ExternalContact, error) {
+	dbContact, err := db.New(tx).ReviveExternalContact(ctx, pgtype.UUID{Bytes: id, Valid: true})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, db.ErrNotFound
+		}
+		return nil, err
+	}
+	return convertDbExternalContact(dbContact)
+}
+
+// SoftDeleteTx tombstones a row by setting deleted_at = NOW(). The
+// underlying SQL has a defensive `WHERE deleted_at IS NULL` predicate
+// so calling it twice is an idempotent no-op (no error on already-
+// tombstoned rows). crm_contact_id, match_status, and duplicate_of_id
+// are preserved. Caller owns the tx lifecycle.
+func (r *ExternalContactRepository) SoftDeleteTx(
+	ctx context.Context,
+	tx pgx.Tx,
+	id uuid.UUID,
+) error {
+	return db.New(tx).SoftDeleteExternalContact(ctx, pgtype.UUID{Bytes: id, Valid: true})
 }

--- a/backend/internal/service/ingest.go
+++ b/backend/internal/service/ingest.go
@@ -8,11 +8,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
+	"strings"
+	"time"
 
+	"personal-crm/backend/internal/accelerated"
 	"personal-crm/backend/internal/consumer/consumerjobs"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/events"
 	"personal-crm/backend/internal/identity"
+	"personal-crm/backend/internal/logger"
 	"personal-crm/backend/internal/repository"
 
 	"github.com/google/uuid"
@@ -24,13 +29,37 @@ import (
 // Per-event rejection codes surfaced through perEventRejections so the
 // HTTP handler can translate them into the response's errors[] array.
 const (
-	ingestRejectUnsupportedHostAuthKind = "UNSUPPORTED_HOST_AUTH_KIND"
-	ingestRejectRawMessageRequiresHost  = "RAW_MESSAGE_REQUIRES_HOST_AUTH"
-	ingestRejectPayloadInvariant        = "PAYLOAD_INVARIANT"
-	ingestRejectPayloadInvalid          = "PAYLOAD_INVALID"
-	ingestRejectIdentityMatchFailed     = "IDENTITY_MATCH_FAILED"
-	ingestRejectStagingUpsertFailed     = "STAGING_UPSERT_FAILED"
+	ingestRejectUnsupportedHostAuthKind          = "UNSUPPORTED_HOST_AUTH_KIND"
+	ingestRejectHostOnlyRequiresHost             = "HOST_ONLY_REQUIRES_HOST_AUTH"
+	ingestRejectPayloadInvariant                 = "PAYLOAD_INVARIANT"
+	ingestRejectPayloadInvalid                   = "PAYLOAD_INVALID"
+	ingestRejectIdentityMatchFailed              = "IDENTITY_MATCH_FAILED"
+	ingestRejectStagingUpsertFailed              = "STAGING_UPSERT_FAILED"
+	ingestRejectExternalContactGetFailed         = "EXTERNAL_CONTACT_GET_FAILED"
+	ingestRejectExternalContactUpsertFailed      = "EXTERNAL_CONTACT_UPSERT_FAILED"
+	ingestRejectExternalContactReviveFailed      = "EXTERNAL_CONTACT_REVIVE_FAILED"
+	ingestRejectExternalContactUpdateMatchFailed = "EXTERNAL_CONTACT_UPDATE_MATCH_FAILED"
+	ingestRejectExternalContactDeleteFailed      = "EXTERNAL_CONTACT_DELETE_FAILED"
 )
+
+// allowedExternalContactSources is the set of envelope.Source values the
+// external_contact.* inline handler accepts. Limited to icloud_contacts
+// in PR5; anarlog_humans joins later. Mismatches surface as
+// PAYLOAD_INVARIANT.
+var allowedExternalContactSources = map[string]struct{}{
+	"icloud_contacts": {},
+}
+
+// reExternalContactUpsertSourceID matches the envelope SourceID shape
+// for external_contact.upserted events: `<entity_uuid>@<sha256-hex>`.
+// The entity portion may not contain `@`; the hash is exactly 64 hex
+// characters (SHA-256). Compiled once at package load.
+var reExternalContactUpsertSourceID = regexp.MustCompile(`^[^@]+@[a-f0-9]{64}$`)
+
+// reExternalContactDeleteSourceID matches the envelope SourceID shape
+// for external_contact.deleted events:
+// `<entity_uuid>@deleted@<sha256-hex>` or `<entity_uuid>@deleted@unknown`.
+var reExternalContactDeleteSourceID = regexp.MustCompile(`^[^@]+@deleted@([a-f0-9]{64}|unknown)$`)
 
 // IngestPerEventRejection is a per-event domain rejection emitted by the
 // service-layer inline handlers. Index is the caller-original index from
@@ -61,6 +90,20 @@ type MessagesUpserter interface {
 	UpsertMessageTx(ctx context.Context, tx pgx.Tx, params repository.UpsertMessagesMessageParams) (*repository.MessagesMessage, error)
 }
 
+// ExternalContactWriter is the narrow surface for the per-event
+// external_contact.* inline handlers. Concrete is
+// *repository.ExternalContactRepository. The interface keeps the
+// service testable — tests substitute a stub that errors at chosen
+// methods so the savepoint-rollback path can be exercised without a
+// live DB.
+type ExternalContactWriter interface {
+	GetBySourceTx(ctx context.Context, tx pgx.Tx, source, sourceID string, accountID *string) (*repository.ExternalContact, error)
+	UpsertTx(ctx context.Context, tx pgx.Tx, req repository.UpsertExternalContactRequest) (*repository.ExternalContact, error)
+	UpdateMatchTx(ctx context.Context, tx pgx.Tx, id uuid.UUID, crmContactID *uuid.UUID, status repository.MatchStatus) (*repository.ExternalContact, error)
+	ReviveTx(ctx context.Context, tx pgx.Tx, id uuid.UUID) (*repository.ExternalContact, error)
+	SoftDeleteTx(ctx context.Context, tx pgx.Tx, id uuid.UUID) error
+}
+
 // IngestService persists pre-validated event envelopes inside a single
 // transaction. All envelopes in a batch commit together or roll back
 // together — spec §3.5 "all-or-nothing on unexpected errors."
@@ -77,46 +120,51 @@ type MessagesUpserter interface {
 // failures (begin-tx, publish-tx, savepoint commit, end-of-batch
 // aggregator enqueue) abort the whole batch.
 type IngestService struct {
-	database    *db.Database
-	bus         *events.Bus
-	identity    IdentityMatcher
-	messages    MessagesUpserter
-	riverClient JobInsertTxer
+	database         *db.Database
+	bus              *events.Bus
+	identity         IdentityMatcher
+	messages         MessagesUpserter
+	riverClient      JobInsertTxer
+	externalContacts ExternalContactWriter
 }
 
-// NewIngestService builds an IngestService. The non-raw-message
-// dependencies (identity, messages, riverClient) may be nil — in that
-// case any raw_message.* envelope is per-event REJECTED with
-// PAYLOAD_INVARIANT explaining the missing wiring. Production
-// constructs all four; unit tests can pass nils for the irrelevant ones.
+// NewIngestService builds an IngestService. Per-kind dependencies may
+// be nil — in that case the corresponding inline handler rejects events
+// of that kind with PAYLOAD_INVARIANT explaining the missing wiring.
+// Production constructs all dependencies; unit tests can pass nils for
+// the kinds they don't exercise.
 func NewIngestService(
 	database *db.Database,
 	bus *events.Bus,
 	identityMatcher IdentityMatcher,
 	messages MessagesUpserter,
 	riverClient JobInsertTxer,
+	externalContacts ExternalContactWriter,
 ) *IngestService {
 	return &IngestService{
-		database:    database,
-		bus:         bus,
-		identity:    identityMatcher,
-		messages:    messages,
-		riverClient: riverClient,
+		database:         database,
+		bus:              bus,
+		identity:         identityMatcher,
+		messages:         messages,
+		riverClient:      riverClient,
+		externalContacts: externalContacts,
 	}
 }
 
 // hostAuthAllowedKinds is the single source of truth for which event
-// kinds may be submitted via the host-auth path. Currently only the
-// daemon-emitted raw_message.* kinds are allowed; new daemon-emitted
-// kinds extend the set as they land.
+// kinds may be submitted via the host-auth path. Daemon-emitted kinds
+// extend the set as they land. PR5 adds external_contact.upserted and
+// external_contact.deleted (the iCloud Contacts watcher path).
 //
 // Symmetric: kinds in this set are REJECTED on the global-API-key
-// path. Daemon-emitted raw_message.* is the ONLY producer path;
-// an internal Pi publisher writing a raw_message would either be a
-// bug or a hostile actor with the global key.
+// path. These kinds have exactly one producer — the Mac daemon — so
+// an internal Pi publisher writing one would either be a bug or a
+// hostile actor with the global key.
 var hostAuthAllowedKinds = map[events.Kind]struct{}{
-	events.KindRawMessageReceived: {},
-	events.KindRawMessageSent:     {},
+	events.KindRawMessageReceived:      {},
+	events.KindRawMessageSent:          {},
+	events.KindExternalContactUpserted: {},
+	events.KindExternalContactDeleted:  {},
 }
 
 // isHostAuthAllowedKind reports whether the kind is permitted on the
@@ -126,10 +174,28 @@ func isHostAuthAllowedKind(k events.Kind) bool {
 	return ok
 }
 
-// isRawMessageKind reports whether the kind is a daemon-emitted
-// raw_message.* event. Used for the symmetric global-key rejection.
+// isHostOnlyKind reports whether the kind is in the host-auth allowlist
+// (i.e., daemon-emitted only). Used for the symmetric global-key
+// rejection. Same predicate as isHostAuthAllowedKind — kept as a named
+// helper because the call site reads more clearly as
+// "isHostOnlyKind(k)" than "isHostAuthAllowedKind(k)" when the intent
+// is rejection rather than acceptance.
+func isHostOnlyKind(k events.Kind) bool {
+	_, ok := hostAuthAllowedKinds[k]
+	return ok
+}
+
+// isRawMessageKind reports whether the kind is one of the
+// raw_message.* daemon-emitted events. Used by the dispatch loop to
+// pick between handleRawMessage and the external_contact handlers.
 func isRawMessageKind(k events.Kind) bool {
 	return k == events.KindRawMessageReceived || k == events.KindRawMessageSent
+}
+
+// isExternalContactKind reports whether the kind is one of the
+// external_contact.* daemon-emitted events.
+func isExternalContactKind(k events.Kind) bool {
+	return k == events.KindExternalContactUpserted || k == events.KindExternalContactDeleted
 }
 
 // pendingAggregateKey is the (source, contactID) pair used to dedupe
@@ -213,33 +279,41 @@ func (s *IngestService) IngestBatch(
 		originalIdx := originalIndices[i]
 
 		// Step 1 — host-auth allowlist enforcement.
-		//   * raw_message.* allowed ONLY on the host-auth path (hostID != nil).
-		//   * other kinds allowed ONLY on the global-key path (hostID == nil).
+		//   * Host-only kinds (raw_message.*, external_contact.*) are
+		//     allowed ONLY on the host-auth path (hostID != nil).
+		//   * Other kinds (Pi internal publishers) are allowed ONLY on
+		//     the global-key path (hostID == nil).
 		if hostID != nil {
 			if !isHostAuthAllowedKind(env.Kind) {
 				perEventRejections = append(perEventRejections, IngestPerEventRejection{
 					Index:   originalIdx,
 					Code:    ingestRejectUnsupportedHostAuthKind,
-					Message: fmt.Sprintf("kind %q not allowed on host-auth path; daemon only emits raw_message.*", env.Kind),
+					Message: fmt.Sprintf("kind %q not allowed on host-auth path; daemon only emits raw_message.* and external_contact.*", env.Kind),
 				})
 				continue
 			}
-		} else if isRawMessageKind(env.Kind) {
+		} else if isHostOnlyKind(env.Kind) {
 			perEventRejections = append(perEventRejections, IngestPerEventRejection{
 				Index:   originalIdx,
-				Code:    ingestRejectRawMessageRequiresHost,
-				Message: "raw_message.* events require X-Mac-Host-ID auth path",
+				Code:    ingestRejectHostOnlyRequiresHost,
+				Message: fmt.Sprintf("kind %q requires X-Mac-Host-ID auth path", env.Kind),
 			})
 			continue
 		}
 
-		// Step 2 — payload-invariant cross-checks (raw_message only).
-		// Done BEFORE opening the savepoint so a clean failure doesn't
-		// even open one. The handler's pre-validation already enforced
-		// required-field presence; we cross-check the envelope/payload
-		// pair.
+		// Step 2 — payload-invariant cross-checks (daemon-emitted
+		// kinds only). Done BEFORE opening the savepoint so a clean
+		// failure doesn't even open one. The handler's pre-validation
+		// already enforced required-field presence; we cross-check the
+		// envelope/payload pair.
 		if isRawMessageKind(env.Kind) {
 			if rejection := verifyRawMessageInvariants(env, *hostID); rejection != nil {
+				rejection.Index = originalIdx
+				perEventRejections = append(perEventRejections, *rejection)
+				continue
+			}
+		} else if isExternalContactKind(env.Kind) {
+			if rejection := verifyExternalContactInvariants(env, *hostID); rejection != nil {
 				rejection.Index = originalIdx
 				perEventRejections = append(perEventRejections, *rejection)
 				continue
@@ -272,25 +346,47 @@ func (s *IngestService) IngestBatch(
 
 		isDuplicate := env.ID == uuid.Nil
 
-		// Step 5 — inline handler for raw_message kinds. On duplicate
-		// (Step 4 detected a dedup hit) we SKIP the inline handler
-		// entirely: re-running identity-match + re-upserting staging on
-		// every duplicate would spuriously bump
+		// Step 5 — inline handler for daemon-emitted kinds. On
+		// duplicate (Step 4 detected a dedup hit) we SKIP the inline
+		// handler entirely: re-running identity-match + re-upserting
+		// staging on every duplicate would spuriously bump
 		// external_identity.last_seen_at and re-add the row to
-		// pendingAggregate. Both are wasteful; the guard makes a
-		// duplicate re-submit a true no-op.
-		if !isDuplicate && isRawMessageKind(env.Kind) {
-			contactID, rejection := s.handleRawMessage(ctx, sp, env, *hostID)
-			if rejection != nil {
-				rejection.Index = originalIdx
-				perEventRejections = append(perEventRejections, *rejection)
-				if rbErr := sp.Rollback(ctx); rbErr != nil {
-					return 0, 0, nil, fmt.Errorf("rollback savepoint for rejected index %d (original %d): %w", i, originalIdx, rbErr)
+		// pendingAggregate (raw_message), or re-revive a row whose
+		// content hash hasn't actually changed (external_contact).
+		// The guard makes a duplicate re-submit a true no-op.
+		if !isDuplicate {
+			switch {
+			case isRawMessageKind(env.Kind):
+				contactID, rejection := s.handleRawMessage(ctx, sp, env, *hostID)
+				if rejection != nil {
+					rejection.Index = originalIdx
+					perEventRejections = append(perEventRejections, *rejection)
+					if rbErr := sp.Rollback(ctx); rbErr != nil {
+						return 0, 0, nil, fmt.Errorf("rollback savepoint for rejected index %d (original %d): %w", i, originalIdx, rbErr)
+					}
+					continue
 				}
-				continue
-			}
-			if contactID != nil {
-				pendingAggregate[pendingAggregateKey{Source: env.Source, ContactID: *contactID}] = struct{}{}
+				if contactID != nil {
+					pendingAggregate[pendingAggregateKey{Source: env.Source, ContactID: *contactID}] = struct{}{}
+				}
+			case env.Kind == events.KindExternalContactUpserted:
+				if rejection := s.handleExternalContactUpserted(ctx, sp, env, *hostID); rejection != nil {
+					rejection.Index = originalIdx
+					perEventRejections = append(perEventRejections, *rejection)
+					if rbErr := sp.Rollback(ctx); rbErr != nil {
+						return 0, 0, nil, fmt.Errorf("rollback savepoint for rejected index %d (original %d): %w", i, originalIdx, rbErr)
+					}
+					continue
+				}
+			case env.Kind == events.KindExternalContactDeleted:
+				if rejection := s.handleExternalContactDeleted(ctx, sp, env, *hostID); rejection != nil {
+					rejection.Index = originalIdx
+					perEventRejections = append(perEventRejections, *rejection)
+					if rbErr := sp.Rollback(ctx); rbErr != nil {
+						return 0, 0, nil, fmt.Errorf("rollback savepoint for rejected index %d (original %d): %w", i, originalIdx, rbErr)
+					}
+					continue
+				}
 			}
 		}
 
@@ -475,4 +571,403 @@ func verifyRawMessageInvariants(env *events.Envelope, authenticatedHostID uuid.U
 		}
 	}
 	return nil
+}
+
+// verifyExternalContactInvariants enforces the cross-field consistency
+// properties for external_contact.* envelopes. Returns a
+// *IngestPerEventRejection (caller fills in Index) on any violation,
+// nil on success.
+//
+// Properties checked:
+//  1. payload decodes cleanly into the per-kind struct.
+//  2. payload.HostID matches the authenticated host (no host
+//     cross-impersonation).
+//  3. env.Source is in the allowed set (PR5: icloud_contacts).
+//  4. payload.Source matches env.Source.
+//  5. payload.EntityID is non-empty.
+//  6. env.SourceID format matches the kind's content-hash discriminator
+//     shape AND its entity prefix matches payload.EntityID.
+func verifyExternalContactInvariants(env *events.Envelope, authenticatedHostID uuid.UUID) *IngestPerEventRejection {
+	switch env.Kind {
+	case events.KindExternalContactUpserted:
+		var p events.ExternalContactUpsertedPayload
+		if err := json.Unmarshal(env.Payload, &p); err != nil {
+			return &IngestPerEventRejection{
+				Code:    ingestRejectPayloadInvalid,
+				Message: fmt.Sprintf("decode external_contact.upserted payload: %s", err.Error()),
+			}
+		}
+		if rej := commonExternalContactInvariants(env, authenticatedHostID, p.HostID, p.Source, p.EntityID); rej != nil {
+			return rej
+		}
+		if !reExternalContactUpsertSourceID.MatchString(env.SourceID) {
+			return &IngestPerEventRejection{
+				Code:    ingestRejectPayloadInvariant,
+				Message: "external_contact.upserted source_id must match <entity>@<sha256-hex>",
+			}
+		}
+		if !strings.HasPrefix(env.SourceID, p.EntityID+"@") {
+			return &IngestPerEventRejection{
+				Code:    ingestRejectPayloadInvariant,
+				Message: "external_contact.upserted source_id entity prefix does not match payload entity_id",
+			}
+		}
+		return nil
+	case events.KindExternalContactDeleted:
+		var p events.ExternalContactDeletedPayload
+		if err := json.Unmarshal(env.Payload, &p); err != nil {
+			return &IngestPerEventRejection{
+				Code:    ingestRejectPayloadInvalid,
+				Message: fmt.Sprintf("decode external_contact.deleted payload: %s", err.Error()),
+			}
+		}
+		if rej := commonExternalContactInvariants(env, authenticatedHostID, p.HostID, p.Source, p.EntityID); rej != nil {
+			return rej
+		}
+		if !reExternalContactDeleteSourceID.MatchString(env.SourceID) {
+			return &IngestPerEventRejection{
+				Code:    ingestRejectPayloadInvariant,
+				Message: "external_contact.deleted source_id must match <entity>@deleted@<sha256-hex|unknown>",
+			}
+		}
+		if !strings.HasPrefix(env.SourceID, p.EntityID+"@deleted@") {
+			return &IngestPerEventRejection{
+				Code:    ingestRejectPayloadInvariant,
+				Message: "external_contact.deleted source_id entity prefix does not match payload entity_id",
+			}
+		}
+		return nil
+	default:
+		// Defence in depth — the dispatcher only routes
+		// external_contact.* kinds here.
+		return &IngestPerEventRejection{
+			Code:    ingestRejectPayloadInvariant,
+			Message: fmt.Sprintf("verifyExternalContactInvariants: unexpected kind %q", env.Kind),
+		}
+	}
+}
+
+// commonExternalContactInvariants enforces the host/source/entity_id
+// checks shared by both external_contact.* kinds. Returns a rejection
+// on any violation, nil on success.
+func commonExternalContactInvariants(
+	env *events.Envelope,
+	authenticatedHostID uuid.UUID,
+	payloadHostID uuid.UUID,
+	payloadSource string,
+	payloadEntityID string,
+) *IngestPerEventRejection {
+	if payloadHostID != authenticatedHostID {
+		return &IngestPerEventRejection{
+			Code:    ingestRejectPayloadInvariant,
+			Message: "payload host_id does not match authenticated host",
+		}
+	}
+	if _, ok := allowedExternalContactSources[env.Source]; !ok {
+		return &IngestPerEventRejection{
+			Code:    ingestRejectPayloadInvariant,
+			Message: fmt.Sprintf("env.source %q not supported on external_contact.* kinds", env.Source),
+		}
+	}
+	if payloadSource != env.Source {
+		return &IngestPerEventRejection{
+			Code:    ingestRejectPayloadInvariant,
+			Message: "payload source does not match envelope source",
+		}
+	}
+	if payloadEntityID == "" {
+		return &IngestPerEventRejection{
+			Code:    ingestRejectPayloadInvariant,
+			Message: "payload entity_id is required",
+		}
+	}
+	return nil
+}
+
+// handleExternalContactUpserted runs the per-event domain logic for an
+// external_contact.upserted envelope inside the per-event savepoint.
+//
+// Sequence:
+//  1. Pre-read by (source, entity_id, account_id=NULL) — distinguishes
+//     first-insert / re-upsert / revive paths.
+//  2. Upsert the external_contact row. UpsertExternalContact uses
+//     ON CONFLICT DO UPDATE; the underlying query does NOT touch
+//     deleted_at, crm_contact_id, or match_status.
+//  3. If the pre-read showed a tombstone, issue ReviveTx to clear
+//     deleted_at. Idempotent via the defensive WHERE clause.
+//  4. Identity match per (email, phone). On FIRST-INSERT, the first
+//     successful match sets crm_contact_id + match_status='matched' via
+//     UpdateMatchTx. On re-upsert / revive, the external_contact row's
+//     match state is preserved — identity rows are refreshed via
+//     MatchOrCreateTx but the external_contact UpdateMatchTx call is
+//     intentionally skipped (D-JC4).
+//
+// Returns nil on success; rejection != nil rolls back the savepoint.
+func (s *IngestService) handleExternalContactUpserted(
+	ctx context.Context,
+	tx pgx.Tx,
+	env *events.Envelope,
+	hostID uuid.UUID,
+) *IngestPerEventRejection {
+	if s.identity == nil || s.externalContacts == nil {
+		return &IngestPerEventRejection{
+			Code:    ingestRejectPayloadInvariant,
+			Message: "ingest service was not configured for external_contact processing",
+		}
+	}
+
+	var p events.ExternalContactUpsertedPayload
+	if err := json.Unmarshal(env.Payload, &p); err != nil {
+		return &IngestPerEventRejection{
+			Code:    ingestRejectPayloadInvalid,
+			Message: fmt.Sprintf("decode external_contact.upserted payload: %s", err.Error()),
+		}
+	}
+
+	// Soft check: warn when icloud_contacts upserts arrive without
+	// metadata (the daemon should always populate
+	// container_identifier). This is a developer-aid log; we don't
+	// reject — metadata is forward-extensible.
+	if env.Source == "icloud_contacts" && len(p.Metadata) == 0 {
+		logger.Warn().
+			Str("source", env.Source).
+			Str("entity_id", p.EntityID).
+			Str("host_id", hostID.String()).
+			Msg("external_contact.upserted carries empty metadata; daemon should populate container_identifier")
+	}
+
+	// Step 1: pre-read to determine first-insert / re-upsert / revive.
+	// GetBySourceTx is intentionally tombstone-aware.
+	prior, getErr := s.externalContacts.GetBySourceTx(ctx, tx, env.Source, p.EntityID, nil)
+	if getErr != nil && !errors.Is(getErr, db.ErrNotFound) {
+		return &IngestPerEventRejection{
+			Code:    ingestRejectExternalContactGetFailed,
+			Message: fmt.Sprintf("pre-read external_contact: %s", getErr.Error()),
+		}
+	}
+	firstInsert := errors.Is(getErr, db.ErrNotFound)
+	wasTombstoned := !firstInsert && prior != nil && prior.DeletedAt != nil
+
+	// Step 2: upsert the row. The query does not touch deleted_at,
+	// crm_contact_id, or match_status on the UPDATE branch.
+	birthday := parseExternalContactBirthday(p.Birthday)
+	syncedAt := accelerated.GetCurrentTime()
+	upsertReq := repository.UpsertExternalContactRequest{
+		Source:       env.Source,
+		SourceID:     p.EntityID,
+		AccountID:    nil, // icloud_contacts: NULL account_id (D-JC8)
+		DisplayName:  p.DisplayName,
+		FirstName:    p.FirstName,
+		LastName:     p.LastName,
+		Emails:       toRepoEmailEntries(p.Emails),
+		Phones:       toRepoPhoneEntries(p.Phones),
+		Addresses:    toRepoAddressEntries(p.Addresses),
+		Organization: p.Organization,
+		JobTitle:     p.JobTitle,
+		Birthday:     birthday,
+		PhotoURL:     p.PhotoURL,
+		Metadata:     p.Metadata,
+		SyncedAt:     &syncedAt,
+	}
+	external, err := s.externalContacts.UpsertTx(ctx, tx, upsertReq)
+	if err != nil {
+		return &IngestPerEventRejection{
+			Code:    ingestRejectExternalContactUpsertFailed,
+			Message: fmt.Sprintf("upsert external_contact: %s", err.Error()),
+		}
+	}
+
+	// Step 3: revive if the pre-read showed a tombstone.
+	if wasTombstoned {
+		revived, err := s.externalContacts.ReviveTx(ctx, tx, external.ID)
+		if err != nil && !errors.Is(err, db.ErrNotFound) {
+			return &IngestPerEventRejection{
+				Code:    ingestRejectExternalContactReviveFailed,
+				Message: fmt.Sprintf("revive external_contact: %s", err.Error()),
+			}
+		}
+		if revived != nil {
+			external = revived
+		}
+	}
+
+	// Step 4: identity match per (email, phone). Iterate the full
+	// set so external_identity rows get refreshed for every method,
+	// regardless of which one triggered the match. The
+	// external_contact.crm_contact_id / match_status update only fires
+	// on FIRST INSERT (D-JC4) and only on the first successful match.
+	matched := false
+	for _, em := range p.Emails {
+		if em.Value == "" {
+			continue
+		}
+		result, err := s.identity.MatchOrCreateTx(ctx, tx, MatchRequest{
+			RawIdentifier: em.Value,
+			Type:          identity.IdentifierTypeEmail,
+			Source:        env.Source,
+			DisplayName:   p.DisplayName,
+		})
+		if err != nil {
+			return &IngestPerEventRejection{
+				Code:    ingestRejectIdentityMatchFailed,
+				Message: fmt.Sprintf("identity match (email): %s", err.Error()),
+			}
+		}
+		if firstInsert && !matched && result != nil && result.ContactID != nil {
+			if _, err := s.externalContacts.UpdateMatchTx(ctx, tx,
+				external.ID, result.ContactID, repository.MatchStatusMatched); err != nil {
+				return &IngestPerEventRejection{
+					Code:    ingestRejectExternalContactUpdateMatchFailed,
+					Message: fmt.Sprintf("update external_contact match (email): %s", err.Error()),
+				}
+			}
+			matched = true
+		}
+	}
+	for _, ph := range p.Phones {
+		if ph.Value == "" {
+			continue
+		}
+		result, err := s.identity.MatchOrCreateTx(ctx, tx, MatchRequest{
+			RawIdentifier: ph.Value,
+			Type:          identity.IdentifierTypePhone,
+			Source:        env.Source,
+			DisplayName:   p.DisplayName,
+		})
+		if err != nil {
+			return &IngestPerEventRejection{
+				Code:    ingestRejectIdentityMatchFailed,
+				Message: fmt.Sprintf("identity match (phone): %s", err.Error()),
+			}
+		}
+		if firstInsert && !matched && result != nil && result.ContactID != nil {
+			if _, err := s.externalContacts.UpdateMatchTx(ctx, tx,
+				external.ID, result.ContactID, repository.MatchStatusMatched); err != nil {
+				return &IngestPerEventRejection{
+					Code:    ingestRejectExternalContactUpdateMatchFailed,
+					Message: fmt.Sprintf("update external_contact match (phone): %s", err.Error()),
+				}
+			}
+			matched = true
+		}
+	}
+	return nil
+}
+
+// handleExternalContactDeleted runs the per-event domain logic for an
+// external_contact.deleted envelope inside the per-event savepoint.
+//
+// Behavior:
+//   - Unknown entity → silent no-op (D-JC9). The event-log row from
+//     Bus.PublishTx is preserved for audit; no row materialization.
+//   - Already-tombstoned → idempotent silent no-op.
+//   - Live row → SoftDeleteTx sets deleted_at. crm_contact_id,
+//     match_status, and duplicate_of_id are preserved.
+func (s *IngestService) handleExternalContactDeleted(
+	ctx context.Context,
+	tx pgx.Tx,
+	env *events.Envelope,
+	_ uuid.UUID,
+) *IngestPerEventRejection {
+	if s.externalContacts == nil {
+		return &IngestPerEventRejection{
+			Code:    ingestRejectPayloadInvariant,
+			Message: "ingest service was not configured for external_contact processing",
+		}
+	}
+	var p events.ExternalContactDeletedPayload
+	if err := json.Unmarshal(env.Payload, &p); err != nil {
+		return &IngestPerEventRejection{
+			Code:    ingestRejectPayloadInvalid,
+			Message: fmt.Sprintf("decode external_contact.deleted payload: %s", err.Error()),
+		}
+	}
+	prior, getErr := s.externalContacts.GetBySourceTx(ctx, tx, env.Source, p.EntityID, nil)
+	if getErr != nil {
+		if errors.Is(getErr, db.ErrNotFound) {
+			// Unknown entity. Silent no-op — event-log row durable.
+			return nil
+		}
+		return &IngestPerEventRejection{
+			Code:    ingestRejectExternalContactGetFailed,
+			Message: fmt.Sprintf("pre-read external_contact: %s", getErr.Error()),
+		}
+	}
+	if prior == nil || prior.DeletedAt != nil {
+		// Already tombstoned. Idempotent no-op.
+		return nil
+	}
+	if err := s.externalContacts.SoftDeleteTx(ctx, tx, prior.ID); err != nil {
+		return &IngestPerEventRejection{
+			Code:    ingestRejectExternalContactDeleteFailed,
+			Message: fmt.Sprintf("soft-delete external_contact: %s", err.Error()),
+		}
+	}
+	return nil
+}
+
+// parseExternalContactBirthday parses the payload's *string Birthday
+// (ISO YYYY-MM-DD) into a *time.Time. ValidatePayload already rejected
+// malformed input at the boundary, but defence-in-depth — return nil
+// on parse failure so a downstream bug doesn't crash the handler.
+func parseExternalContactBirthday(s *string) *time.Time {
+	if s == nil || *s == "" {
+		return nil
+	}
+	t, err := time.Parse("2006-01-02", *s)
+	if err != nil {
+		return nil
+	}
+	return &t
+}
+
+// toRepoEmailEntries converts payload ExternalContactMethodValue slice
+// into the repository's EmailEntry slice. Identical shape; just the
+// package boundary.
+func toRepoEmailEntries(in []events.ExternalContactMethodValue) []repository.EmailEntry {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]repository.EmailEntry, 0, len(in))
+	for _, v := range in {
+		out = append(out, repository.EmailEntry{
+			Value:   v.Value,
+			Type:    v.Type,
+			Primary: v.Primary,
+		})
+	}
+	return out
+}
+
+// toRepoPhoneEntries converts payload ExternalContactMethodValue slice
+// into the repository's PhoneEntry slice.
+func toRepoPhoneEntries(in []events.ExternalContactMethodValue) []repository.PhoneEntry {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]repository.PhoneEntry, 0, len(in))
+	for _, v := range in {
+		out = append(out, repository.PhoneEntry{
+			Value:   v.Value,
+			Type:    v.Type,
+			Primary: v.Primary,
+		})
+	}
+	return out
+}
+
+// toRepoAddressEntries converts payload ExternalContactAddressValue
+// slice into the repository's AddressEntry slice.
+func toRepoAddressEntries(in []events.ExternalContactAddressValue) []repository.AddressEntry {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]repository.AddressEntry, 0, len(in))
+	for _, v := range in {
+		out = append(out, repository.AddressEntry{
+			Formatted: v.Formatted,
+			Type:      v.Type,
+		})
+	}
+	return out
 }

--- a/backend/internal/service/ingest.go
+++ b/backend/internal/service/ingest.go
@@ -730,7 +730,7 @@ func (s *IngestService) handleExternalContactUpserted(
 			Msg("external_contact.upserted carries empty metadata; daemon should populate container_identifier")
 	}
 
-	// Step 1: pre-read to determine first-insert / re-upsert / revive.
+	// Pre-read to determine first-insert / re-upsert / revive.
 	// GetBySourceTx is intentionally tombstone-aware.
 	prior, getErr := s.externalContacts.GetBySourceTx(ctx, tx, env.Source, p.EntityID, nil)
 	if getErr != nil && !errors.Is(getErr, db.ErrNotFound) {
@@ -742,7 +742,7 @@ func (s *IngestService) handleExternalContactUpserted(
 	firstInsert := errors.Is(getErr, db.ErrNotFound)
 	wasTombstoned := !firstInsert && prior != nil && prior.DeletedAt != nil
 
-	// Step 2: upsert the row. The query does not touch deleted_at,
+	// Upsert the row. The underlying query does not touch deleted_at,
 	// crm_contact_id, or match_status on the UPDATE branch.
 	birthday := parseExternalContactBirthday(p.Birthday)
 	syncedAt := accelerated.GetCurrentTime()
@@ -771,8 +771,13 @@ func (s *IngestService) handleExternalContactUpserted(
 		}
 	}
 
-	// Step 3: revive if the pre-read showed a tombstone.
-	if wasTombstoned {
+	// Revive if the row is tombstoned. We check BOTH the pre-read AND
+	// the post-upsert returned row's deleted_at — a concurrent delete
+	// that committed between our pre-read and our upsert leaves
+	// wasTombstoned=false even though the row is tombstoned at this
+	// point. The post-upsert check closes that race.
+	needsRevive := wasTombstoned || (external != nil && external.DeletedAt != nil)
+	if needsRevive {
 		revived, err := s.externalContacts.ReviveTx(ctx, tx, external.ID)
 		if err != nil && !errors.Is(err, db.ErrNotFound) {
 			return &IngestPerEventRejection{
@@ -785,22 +790,28 @@ func (s *IngestService) handleExternalContactUpserted(
 		}
 	}
 
-	// Step 4: identity match per (email, phone). Iterate the full
-	// set so external_identity rows get refreshed for every method,
-	// regardless of which one triggered the match. The
-	// external_contact.crm_contact_id / match_status update only fires
-	// on FIRST INSERT and only on the first successful match — see the
-	// godoc above for the rationale.
+	// Identity match per (email, phone). Iterate the full set so
+	// external_identity rows get refreshed for every method,
+	// regardless of which one triggered the match.
 	//
-	// Defensive: only flip match state when the UPSERT returned a row
-	// that does NOT already carry a crm_contact_id. The combination
-	// (firstInsert && CRMContactID == nil) closes a theoretical race
-	// where a concurrent INSERT lands between our pre-read and our
-	// UPSERT — the UPSERT's UPDATE branch then returns the other tx's
-	// crm_contact_id, and we must NOT clobber it with our own match
-	// result. Single-daemon ordering makes the race extremely
-	// unlikely, but the guard is cheap.
-	canSetMatchOnRow := firstInsert && external.CRMContactID == nil
+	// The external_contact.crm_contact_id / match_status update only
+	// fires on FIRST INSERT and only on the first successful match —
+	// re-upsert / revive preserves match state verbatim so a user's
+	// manually-resolved `imported` or `ignored` decision is not
+	// silently flipped on a content edit.
+	//
+	// Defensive guards (closing concurrent-INSERT-between-pre-read-and-
+	// upsert races):
+	//   - external.CRMContactID == nil: another tx may have set the
+	//     match; do not clobber.
+	//   - external.MatchStatus is unmatched: the user may have
+	//     `imported` / `ignored` the row manually; preserve that.
+	//   - external.DuplicateOfID == nil: the row is not marked as a
+	//     duplicate of another contact.
+	canSetMatchOnRow := firstInsert &&
+		external.CRMContactID == nil &&
+		external.MatchStatus == repository.MatchStatusUnmatched &&
+		external.DuplicateOfID == nil
 	matched := false
 	for _, em := range p.Emails {
 		if em.Value == "" {

--- a/backend/internal/service/ingest.go
+++ b/backend/internal/service/ingest.go
@@ -796,6 +796,16 @@ func (s *IngestService) handleExternalContactUpserted(
 	// regardless of which one triggered the match. The
 	// external_contact.crm_contact_id / match_status update only fires
 	// on FIRST INSERT (D-JC4) and only on the first successful match.
+	//
+	// Defensive: only flip match state when the UPSERT returned a row
+	// that does NOT already carry a crm_contact_id. The combination
+	// (firstInsert && CRMContactID == nil) closes a theoretical race
+	// where a concurrent INSERT lands between our pre-read and our
+	// UPSERT — the UPSERT's UPDATE branch then returns the other tx's
+	// crm_contact_id, and we must NOT clobber it with our own match
+	// result. Single-daemon ordering makes the race extremely
+	// unlikely, but the guard is cheap.
+	canSetMatchOnRow := firstInsert && external.CRMContactID == nil
 	matched := false
 	for _, em := range p.Emails {
 		if em.Value == "" {
@@ -813,7 +823,7 @@ func (s *IngestService) handleExternalContactUpserted(
 				Message: fmt.Sprintf("identity match (email): %s", err.Error()),
 			}
 		}
-		if firstInsert && !matched && result != nil && result.ContactID != nil {
+		if canSetMatchOnRow && !matched && result != nil && result.ContactID != nil {
 			if _, err := s.externalContacts.UpdateMatchTx(ctx, tx,
 				external.ID, result.ContactID, repository.MatchStatusMatched); err != nil {
 				return &IngestPerEventRejection{
@@ -840,7 +850,7 @@ func (s *IngestService) handleExternalContactUpserted(
 				Message: fmt.Sprintf("identity match (phone): %s", err.Error()),
 			}
 		}
-		if firstInsert && !matched && result != nil && result.ContactID != nil {
+		if canSetMatchOnRow && !matched && result != nil && result.ContactID != nil {
 			if _, err := s.externalContacts.UpdateMatchTx(ctx, tx,
 				external.ID, result.ContactID, repository.MatchStatusMatched); err != nil {
 				return &IngestPerEventRejection{

--- a/backend/internal/service/ingest.go
+++ b/backend/internal/service/ingest.go
@@ -43,9 +43,8 @@ const (
 )
 
 // allowedExternalContactSources is the set of envelope.Source values the
-// external_contact.* inline handler accepts. Limited to icloud_contacts
-// in PR5; anarlog_humans joins later. Mismatches surface as
-// PAYLOAD_INVARIANT.
+// external_contact.* inline handler accepts. Mismatches surface as
+// PAYLOAD_INVARIANT. Extend when a new daemon-side source ships.
 var allowedExternalContactSources = map[string]struct{}{
 	"icloud_contacts": {},
 }
@@ -153,8 +152,8 @@ func NewIngestService(
 
 // hostAuthAllowedKinds is the single source of truth for which event
 // kinds may be submitted via the host-auth path. Daemon-emitted kinds
-// extend the set as they land. PR5 adds external_contact.upserted and
-// external_contact.deleted (the iCloud Contacts watcher path).
+// extend the set as they land (currently raw_message.* for Messages
+// staging + external_contact.* for the iCloud Contacts watcher).
 //
 // Symmetric: kinds in this set are REJECTED on the global-API-key
 // path. These kinds have exactly one producer — the Mac daemon — so
@@ -167,19 +166,13 @@ var hostAuthAllowedKinds = map[events.Kind]struct{}{
 	events.KindExternalContactDeleted:  {},
 }
 
-// isHostAuthAllowedKind reports whether the kind is permitted on the
-// host-auth path.
-func isHostAuthAllowedKind(k events.Kind) bool {
-	_, ok := hostAuthAllowedKinds[k]
-	return ok
-}
-
-// isHostOnlyKind reports whether the kind is in the host-auth allowlist
-// (i.e., daemon-emitted only). Used for the symmetric global-key
-// rejection. Same predicate as isHostAuthAllowedKind — kept as a named
-// helper because the call site reads more clearly as
-// "isHostOnlyKind(k)" than "isHostAuthAllowedKind(k)" when the intent
-// is rejection rather than acceptance.
+// isHostOnlyKind reports whether the kind is in the host-auth
+// allowlist (i.e., daemon-emitted only). Used on BOTH sides of the
+// auth dispatch:
+//   - on the host-auth path, kinds NOT in this set are rejected as
+//     "host-auth doesn't accept this kind"
+//   - on the global-API-key path, kinds IN this set are rejected as
+//     "this kind requires host-auth"
 func isHostOnlyKind(k events.Kind) bool {
 	_, ok := hostAuthAllowedKinds[k]
 	return ok
@@ -284,7 +277,7 @@ func (s *IngestService) IngestBatch(
 		//   * Other kinds (Pi internal publishers) are allowed ONLY on
 		//     the global-key path (hostID == nil).
 		if hostID != nil {
-			if !isHostAuthAllowedKind(env.Kind) {
+			if !isHostOnlyKind(env.Kind) {
 				perEventRejections = append(perEventRejections, IngestPerEventRejection{
 					Index:   originalIdx,
 					Code:    ingestRejectUnsupportedHostAuthKind,
@@ -582,7 +575,7 @@ func verifyRawMessageInvariants(env *events.Envelope, authenticatedHostID uuid.U
 //  1. payload decodes cleanly into the per-kind struct.
 //  2. payload.HostID matches the authenticated host (no host
 //     cross-impersonation).
-//  3. env.Source is in the allowed set (PR5: icloud_contacts).
+//  3. env.Source is in allowedExternalContactSources.
 //  4. payload.Source matches env.Source.
 //  5. payload.EntityID is non-empty.
 //  6. env.SourceID format matches the kind's content-hash discriminator
@@ -700,7 +693,8 @@ func commonExternalContactInvariants(
 //     UpdateMatchTx. On re-upsert / revive, the external_contact row's
 //     match state is preserved — identity rows are refreshed via
 //     MatchOrCreateTx but the external_contact UpdateMatchTx call is
-//     intentionally skipped (D-JC4).
+//     intentionally skipped so a user's manually-resolved `imported` or
+//     `ignored` state is not silently flipped on a content edit.
 //
 // Returns nil on success; rejection != nil rolls back the savepoint.
 func (s *IngestService) handleExternalContactUpserted(
@@ -755,7 +749,7 @@ func (s *IngestService) handleExternalContactUpserted(
 	upsertReq := repository.UpsertExternalContactRequest{
 		Source:       env.Source,
 		SourceID:     p.EntityID,
-		AccountID:    nil, // icloud_contacts: NULL account_id (D-JC8)
+		AccountID:    nil, // icloud_contacts has no account_id concept
 		DisplayName:  p.DisplayName,
 		FirstName:    p.FirstName,
 		LastName:     p.LastName,
@@ -795,7 +789,8 @@ func (s *IngestService) handleExternalContactUpserted(
 	// set so external_identity rows get refreshed for every method,
 	// regardless of which one triggered the match. The
 	// external_contact.crm_contact_id / match_status update only fires
-	// on FIRST INSERT (D-JC4) and only on the first successful match.
+	// on FIRST INSERT and only on the first successful match — see the
+	// godoc above for the rationale.
 	//
 	// Defensive: only flip match state when the UPSERT returned a row
 	// that does NOT already carry a crm_contact_id. The combination
@@ -868,8 +863,11 @@ func (s *IngestService) handleExternalContactUpserted(
 // external_contact.deleted envelope inside the per-event savepoint.
 //
 // Behavior:
-//   - Unknown entity → silent no-op (D-JC9). The event-log row from
+//   - Unknown entity → silent no-op. The event-log row from
 //     Bus.PublishTx is preserved for audit; no row materialization.
+//     Rationale: a late-arriving delete after a never-upserted row
+//     (e.g., Pi was wiped, daemon resends a queued delete) must not
+//     stall the daemon's cursor.
 //   - Already-tombstoned → idempotent silent no-op.
 //   - Live row → SoftDeleteTx sets deleted_at. crm_contact_id,
 //     match_status, and duplicate_of_id are preserved.

--- a/backend/internal/service/ingest_test.go
+++ b/backend/internal/service/ingest_test.go
@@ -4,9 +4,13 @@ import (
 	"context"
 	"testing"
 
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/repository"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/require"
 )
 
@@ -380,4 +384,127 @@ func TestVerifyExternalContactInvariants_SourceIDEntityPrefixMismatch(t *testing
 	rej := verifyExternalContactInvariants(env, host)
 	require.NotNil(t, rej)
 	require.Contains(t, rej.Message, "entity prefix")
+}
+
+// stubExternalContactWriter records method invocations so tests can
+// drive narrow scenarios without a live DB. The pgx.Tx args are
+// ignored — the writer doesn't touch the DB at all.
+type stubExternalContactWriter struct {
+	getResp     *repository.ExternalContact
+	getErr      error
+	upsertResp  *repository.ExternalContact
+	upsertErr   error
+	updateResp  *repository.ExternalContact
+	updateErr   error
+	reviveResp  *repository.ExternalContact
+	reviveErr   error
+	softDelErr  error
+	reviveCalls int
+	updateCalls int
+}
+
+func (s *stubExternalContactWriter) GetBySourceTx(_ context.Context, _ pgx.Tx, _ string, _ string, _ *string) (*repository.ExternalContact, error) {
+	return s.getResp, s.getErr
+}
+func (s *stubExternalContactWriter) UpsertTx(_ context.Context, _ pgx.Tx, _ repository.UpsertExternalContactRequest) (*repository.ExternalContact, error) {
+	return s.upsertResp, s.upsertErr
+}
+func (s *stubExternalContactWriter) UpdateMatchTx(_ context.Context, _ pgx.Tx, _ uuid.UUID, _ *uuid.UUID, _ repository.MatchStatus) (*repository.ExternalContact, error) {
+	s.updateCalls++
+	return s.updateResp, s.updateErr
+}
+func (s *stubExternalContactWriter) ReviveTx(_ context.Context, _ pgx.Tx, _ uuid.UUID) (*repository.ExternalContact, error) {
+	s.reviveCalls++
+	return s.reviveResp, s.reviveErr
+}
+func (s *stubExternalContactWriter) SoftDeleteTx(_ context.Context, _ pgx.Tx, _ uuid.UUID) error {
+	return s.softDelErr
+}
+
+// stubIdentityMatcher returns a configured MatchResult / error for
+// every MatchOrCreateTx call.
+type stubIdentityMatcher struct {
+	result *MatchResult
+	err    error
+	calls  int
+}
+
+func (s *stubIdentityMatcher) MatchOrCreateTx(_ context.Context, _ pgx.Tx, _ MatchRequest) (*MatchResult, error) {
+	s.calls++
+	return s.result, s.err
+}
+
+// TestHandleExternalContactUpserted_PostUpsertTombstoneTriggersRevive
+// exercises the defensive race-recovery path: the pre-read returns
+// "not found" so wasTombstoned=false, but a concurrent delete
+// tombstoned the row between our pre-read and our upsert, so UpsertTx
+// returns a row with DeletedAt != nil. The handler MUST call ReviveTx
+// in that case (post-upsert deleted_at check), even though
+// wasTombstoned=false.
+func TestHandleExternalContactUpserted_PostUpsertTombstoneTriggersRevive(t *testing.T) {
+	rowID := uuid.New()
+	hostID := uuid.New()
+	deletedAt := accelerated.GetCurrentTime()
+	postUpsertRow := &repository.ExternalContact{
+		ID:          rowID,
+		Source:      "icloud_contacts",
+		SourceID:    "CN-race",
+		MatchStatus: repository.MatchStatusUnmatched,
+		DeletedAt:   &deletedAt, // concurrent delete tombstoned it
+	}
+	revivedRow := &repository.ExternalContact{
+		ID:          rowID,
+		Source:      "icloud_contacts",
+		SourceID:    "CN-race",
+		MatchStatus: repository.MatchStatusUnmatched,
+		DeletedAt:   nil, // ReviveTx cleared it
+	}
+	stubExt := &stubExternalContactWriter{
+		// Pre-read says "not found" — wasTombstoned will be false.
+		getResp:    nil,
+		getErr:     db.ErrNotFound,
+		upsertResp: postUpsertRow, // but post-upsert returns a tombstoned row
+		reviveResp: revivedRow,
+	}
+	stubIdent := &stubIdentityMatcher{result: &MatchResult{}}
+
+	svc := &IngestService{
+		identity:         stubIdent,
+		externalContacts: stubExt,
+	}
+	env := validUpsertedEnv(hostID, "CN-race")
+	rej := svc.handleExternalContactUpserted(context.Background(), nil, env, hostID)
+	require.Nil(t, rej, "handler must not reject when revive succeeds")
+	require.Equal(t, 1, stubExt.reviveCalls, "ReviveTx must be called when post-upsert row is tombstoned")
+}
+
+// TestHandleExternalContactUpserted_LiveUpsertSkipsRevive confirms the
+// happy path does not invoke ReviveTx — keeps the previous test honest
+// (a regression that always called ReviveTx would still pass the
+// other test, but fail this one).
+func TestHandleExternalContactUpserted_LiveUpsertSkipsRevive(t *testing.T) {
+	rowID := uuid.New()
+	hostID := uuid.New()
+	liveRow := &repository.ExternalContact{
+		ID:          rowID,
+		Source:      "icloud_contacts",
+		SourceID:    "CN-live",
+		MatchStatus: repository.MatchStatusUnmatched,
+		DeletedAt:   nil,
+	}
+	stubExt := &stubExternalContactWriter{
+		getResp:    nil,
+		getErr:     db.ErrNotFound,
+		upsertResp: liveRow,
+	}
+	stubIdent := &stubIdentityMatcher{result: &MatchResult{}}
+
+	svc := &IngestService{
+		identity:         stubIdent,
+		externalContacts: stubExt,
+	}
+	env := validUpsertedEnv(hostID, "CN-live")
+	rej := svc.handleExternalContactUpserted(context.Background(), nil, env, hostID)
+	require.Nil(t, rej)
+	require.Equal(t, 0, stubExt.reviveCalls, "ReviveTx must NOT be called on a live first-insert")
 }

--- a/backend/internal/service/ingest_test.go
+++ b/backend/internal/service/ingest_test.go
@@ -206,3 +206,178 @@ func mustMarshalRawMsg(p events.RawMessageReceivedPayload) []byte {
 	}
 	return b
 }
+
+// ----------------------------------------------------------------------------
+// external_contact.* unit tests (PR5).
+//
+// These tests cover the verifier + allowlist surface. End-to-end
+// savepoint behavior (revive, delete-no-op, identity match) is covered
+// by integration tests under backend/tests/api/.
+// ----------------------------------------------------------------------------
+
+func mustMarshalExtUpsert(p events.ExternalContactUpsertedPayload) []byte {
+	b, err := events.Marshal(events.KindExternalContactUpserted, p)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+func mustMarshalExtDelete(p events.ExternalContactDeletedPayload) []byte {
+	b, err := events.Marshal(events.KindExternalContactDeleted, p)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+// validUpsertedEnv returns a well-formed external_contact.upserted
+// envelope keyed off the given host + entity id. The source_id uses a
+// stable 64-char hex tail so it satisfies the regex shape.
+func validUpsertedEnv(host uuid.UUID, entityID string) *events.Envelope {
+	hashHex := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	return &events.Envelope{
+		Source:   "icloud_contacts",
+		SourceID: entityID + "@" + hashHex,
+		Kind:     events.KindExternalContactUpserted,
+		Payload: mustMarshalExtUpsert(events.ExternalContactUpsertedPayload{
+			Version:  1,
+			HostID:   host,
+			Source:   "icloud_contacts",
+			EntityID: entityID,
+		}),
+	}
+}
+
+// validDeletedEnv mirrors validUpsertedEnv for the deleted kind.
+func validDeletedEnv(host uuid.UUID, entityID string) *events.Envelope {
+	hashHex := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	return &events.Envelope{
+		Source:   "icloud_contacts",
+		SourceID: entityID + "@deleted@" + hashHex,
+		Kind:     events.KindExternalContactDeleted,
+		Payload: mustMarshalExtDelete(events.ExternalContactDeletedPayload{
+			Version:  1,
+			HostID:   host,
+			Source:   "icloud_contacts",
+			EntityID: entityID,
+		}),
+	}
+}
+
+func TestIsHostAuthAllowedKind_IncludesExternalContact(t *testing.T) {
+	require.True(t, isHostAuthAllowedKind(events.KindExternalContactUpserted))
+	require.True(t, isHostAuthAllowedKind(events.KindExternalContactDeleted))
+}
+
+func TestIsExternalContactKind(t *testing.T) {
+	require.True(t, isExternalContactKind(events.KindExternalContactUpserted))
+	require.True(t, isExternalContactKind(events.KindExternalContactDeleted))
+	require.False(t, isExternalContactKind(events.KindRawMessageReceived))
+	require.False(t, isExternalContactKind(events.KindMessageReceived))
+}
+
+func TestVerifyExternalContactInvariants_HappyPath_Upsert(t *testing.T) {
+	host := uuid.New()
+	require.Nil(t, verifyExternalContactInvariants(validUpsertedEnv(host, "CN-1"), host))
+}
+
+func TestVerifyExternalContactInvariants_HappyPath_Delete(t *testing.T) {
+	host := uuid.New()
+	require.Nil(t, verifyExternalContactInvariants(validDeletedEnv(host, "CN-1"), host))
+}
+
+func TestVerifyExternalContactInvariants_DeleteWithUnknownHash(t *testing.T) {
+	host := uuid.New()
+	env := validDeletedEnv(host, "CN-1")
+	env.SourceID = "CN-1@deleted@unknown"
+	require.Nil(t, verifyExternalContactInvariants(env, host))
+}
+
+func TestVerifyExternalContactInvariants_HostMismatch(t *testing.T) {
+	authHost := uuid.New()
+	other := uuid.New()
+	env := validUpsertedEnv(other, "CN-1")
+	rej := verifyExternalContactInvariants(env, authHost)
+	require.NotNil(t, rej)
+	require.Equal(t, ingestRejectPayloadInvariant, rej.Code)
+	require.Contains(t, rej.Message, "host_id")
+}
+
+func TestVerifyExternalContactInvariants_SourceMismatch(t *testing.T) {
+	host := uuid.New()
+	env := validUpsertedEnv(host, "CN-1")
+	env.Source = "anarlog_humans"
+	rej := verifyExternalContactInvariants(env, host)
+	require.NotNil(t, rej)
+	require.Contains(t, rej.Message, "not supported")
+}
+
+func TestVerifyExternalContactInvariants_PayloadVsEnvelopeSource(t *testing.T) {
+	host := uuid.New()
+	hashHex := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	env := &events.Envelope{
+		Source:   "icloud_contacts",
+		SourceID: "CN-1@" + hashHex,
+		Kind:     events.KindExternalContactUpserted,
+		Payload: mustMarshalExtUpsert(events.ExternalContactUpsertedPayload{
+			Version:  1,
+			HostID:   host,
+			Source:   "different",
+			EntityID: "CN-1",
+		}),
+	}
+	rej := verifyExternalContactInvariants(env, host)
+	require.NotNil(t, rej)
+	require.Contains(t, rej.Message, "payload source")
+}
+
+func TestVerifyExternalContactInvariants_EmptyEntityID(t *testing.T) {
+	host := uuid.New()
+	hashHex := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	env := &events.Envelope{
+		Source:   "icloud_contacts",
+		SourceID: "@" + hashHex,
+		Kind:     events.KindExternalContactUpserted,
+		Payload: mustMarshalExtUpsert(events.ExternalContactUpsertedPayload{
+			Version:  1,
+			HostID:   host,
+			Source:   "icloud_contacts",
+			EntityID: "",
+		}),
+	}
+	rej := verifyExternalContactInvariants(env, host)
+	require.NotNil(t, rej)
+	require.Contains(t, rej.Message, "entity_id is required")
+}
+
+func TestVerifyExternalContactInvariants_BadSourceIDShape_Upsert(t *testing.T) {
+	host := uuid.New()
+	env := validUpsertedEnv(host, "CN-1")
+	// SourceID with non-hex hash.
+	env.SourceID = "CN-1@notanhash"
+	rej := verifyExternalContactInvariants(env, host)
+	require.NotNil(t, rej)
+	require.Contains(t, rej.Message, "source_id")
+}
+
+func TestVerifyExternalContactInvariants_BadSourceIDShape_Delete(t *testing.T) {
+	host := uuid.New()
+	env := validDeletedEnv(host, "CN-1")
+	// Wrong scheme — missing the @deleted@ segment.
+	env.SourceID = "CN-1@" + "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	rej := verifyExternalContactInvariants(env, host)
+	require.NotNil(t, rej)
+	require.Contains(t, rej.Message, "source_id")
+}
+
+func TestVerifyExternalContactInvariants_SourceIDEntityPrefixMismatch(t *testing.T) {
+	host := uuid.New()
+	env := validUpsertedEnv(host, "CN-1")
+	hashHex := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	// Envelope says CN-2 but payload entity_id is CN-1.
+	env.SourceID = "CN-2@" + hashHex
+	rej := verifyExternalContactInvariants(env, host)
+	require.NotNil(t, rej)
+	require.Contains(t, rej.Message, "entity prefix")
+}

--- a/backend/internal/service/ingest_test.go
+++ b/backend/internal/service/ingest_test.go
@@ -72,12 +72,12 @@ func TestIngestService_RejectsLenMismatchOnOriginalIndices(t *testing.T) {
 // match + staging upsert, aggregator enqueue) are covered by the
 // integration tests under backend/tests/api/.
 
-// TestIsHostAuthAllowedKind_Whitelist verifies the allowlist contains
-// exactly the daemon-emitted raw_message.* kinds and rejects all
-// others. Locks the allowlist contract at the unit level.
-func TestIsHostAuthAllowedKind_Whitelist(t *testing.T) {
-	require.True(t, isHostAuthAllowedKind(events.KindRawMessageReceived))
-	require.True(t, isHostAuthAllowedKind(events.KindRawMessageSent))
+// TestIsHostOnlyKind_Whitelist verifies the allowlist contains exactly
+// the daemon-emitted raw_message.* + external_contact.* kinds and
+// rejects all others. Locks the allowlist contract at the unit level.
+func TestIsHostOnlyKind_Whitelist(t *testing.T) {
+	require.True(t, isHostOnlyKind(events.KindRawMessageReceived))
+	require.True(t, isHostOnlyKind(events.KindRawMessageSent))
 	// Sample of kinds that MUST NOT be allowed on host-auth.
 	for _, k := range []events.Kind{
 		events.KindMessageReceived,
@@ -88,7 +88,7 @@ func TestIsHostAuthAllowedKind_Whitelist(t *testing.T) {
 		events.KindContactMethodsAdded,
 		events.KindInteractionRecorded,
 	} {
-		require.False(t, isHostAuthAllowedKind(k), "kind %s must NOT be on host-auth allowlist", k)
+		require.False(t, isHostOnlyKind(k), "kind %s must NOT be on host-auth allowlist", k)
 	}
 }
 
@@ -208,11 +208,11 @@ func mustMarshalRawMsg(p events.RawMessageReceivedPayload) []byte {
 }
 
 // ----------------------------------------------------------------------------
-// external_contact.* unit tests (PR5).
+// external_contact.* unit tests.
 //
-// These tests cover the verifier + allowlist surface. End-to-end
-// savepoint behavior (revive, delete-no-op, identity match) is covered
-// by integration tests under backend/tests/api/.
+// These cover the verifier + allowlist surface. End-to-end savepoint
+// behavior (revive, delete-no-op, identity match) is covered by
+// integration tests under backend/tests/api/.
 // ----------------------------------------------------------------------------
 
 func mustMarshalExtUpsert(p events.ExternalContactUpsertedPayload) []byte {
@@ -265,9 +265,9 @@ func validDeletedEnv(host uuid.UUID, entityID string) *events.Envelope {
 	}
 }
 
-func TestIsHostAuthAllowedKind_IncludesExternalContact(t *testing.T) {
-	require.True(t, isHostAuthAllowedKind(events.KindExternalContactUpserted))
-	require.True(t, isHostAuthAllowedKind(events.KindExternalContactDeleted))
+func TestIsHostOnlyKind_IncludesExternalContact(t *testing.T) {
+	require.True(t, isHostOnlyKind(events.KindExternalContactUpserted))
+	require.True(t, isHostOnlyKind(events.KindExternalContactDeleted))
 }
 
 func TestIsExternalContactKind(t *testing.T) {

--- a/backend/internal/service/mac_host.go
+++ b/backend/internal/service/mac_host.go
@@ -66,24 +66,37 @@ var ErrPairingValidation = errors.New("pairing input validation failed")
 // the primary gate.
 var ErrUnknownPushSource = errors.New("unknown push source")
 
+// ContactMethodLister is the narrow interface MacHostService needs for
+// the /known-identifiers endpoint. Concrete is
+// *repository.ContactMethodRepository. Defined here so the service can
+// be unit-tested with a stub without depending on the full repo.
+type ContactMethodLister interface {
+	ListCanonicalIdentifiersByType(ctx context.Context, types []string) ([]string, error)
+}
+
 // MacHostService owns business logic for pairing, heartbeat, cursor
 // commit, and revoke-cascade. Stateless aside from the constructor-
 // injected dependencies — safe to share across requests.
 type MacHostService struct {
-	hostRepo   *repository.MacHostRepository
-	tokenRepo  *repository.MacHostPairingTokenRepository
-	syncRepo   *repository.SyncRepository
-	pool       *pgxpool.Pool
-	bcryptCost int
+	hostRepo          *repository.MacHostRepository
+	tokenRepo         *repository.MacHostPairingTokenRepository
+	syncRepo          *repository.SyncRepository
+	contactMethodRepo ContactMethodLister
+	pool              *pgxpool.Pool
+	bcryptCost        int
 }
 
 // NewMacHostService constructs a service. bcryptCost defaults to
 // bcrypt.DefaultCost when 0 — at cost=10 the hash is ~50ms on a Pi 4,
-// fine for once-per-pair.
+// fine for once-per-pair. contactMethodRepo may be nil in test fixtures
+// that don't exercise the /known-identifiers endpoint; the
+// KnownIdentifiers method returns a clear error when called in that
+// state.
 func NewMacHostService(
 	hostRepo *repository.MacHostRepository,
 	tokenRepo *repository.MacHostPairingTokenRepository,
 	syncRepo *repository.SyncRepository,
+	contactMethodRepo ContactMethodLister,
 	pool *pgxpool.Pool,
 	bcryptCost int,
 ) *MacHostService {
@@ -91,12 +104,48 @@ func NewMacHostService(
 		bcryptCost = bcrypt.DefaultCost
 	}
 	return &MacHostService{
-		hostRepo:   hostRepo,
-		tokenRepo:  tokenRepo,
-		syncRepo:   syncRepo,
-		pool:       pool,
-		bcryptCost: bcryptCost,
+		hostRepo:          hostRepo,
+		tokenRepo:         tokenRepo,
+		syncRepo:          syncRepo,
+		contactMethodRepo: contactMethodRepo,
+		pool:              pool,
+		bcryptCost:        bcryptCost,
 	}
+}
+
+// KnownIdentifiersResult is the cross-source identifier set returned to
+// the daemon. Both arrays are alphabetically sorted and deduplicated
+// (DISTINCT value_normalized across all contact_method rows that join
+// a non-deleted contact). Empty arrays on a fresh CRM.
+type KnownIdentifiersResult struct {
+	Phones []string `json:"phones"`
+	Emails []string `json:"emails"`
+}
+
+// KnownIdentifiers returns the canonical phone + email set the daemon
+// uses to filter incoming Apple Messages senders against the user's
+// known contacts. Two SQL queries (phones, emails) — cleaner than a
+// single union because the daemon receives them under separate JSON
+// keys.
+func (s *MacHostService) KnownIdentifiers(ctx context.Context) (*KnownIdentifiersResult, error) {
+	if s.contactMethodRepo == nil {
+		return nil, fmt.Errorf("known identifiers: contact_method repository not wired")
+	}
+	emails, err := s.contactMethodRepo.ListCanonicalIdentifiersByType(ctx, []string{"email"})
+	if err != nil {
+		return nil, fmt.Errorf("list canonical emails: %w", err)
+	}
+	phones, err := s.contactMethodRepo.ListCanonicalIdentifiersByType(ctx, []string{"phone"})
+	if err != nil {
+		return nil, fmt.Errorf("list canonical phones: %w", err)
+	}
+	if emails == nil {
+		emails = []string{}
+	}
+	if phones == nil {
+		phones = []string{}
+	}
+	return &KnownIdentifiersResult{Phones: phones, Emails: emails}, nil
 }
 
 // CreatePairingToken mints a new short-lived pairing token. Returns

--- a/backend/internal/service/mac_host_test.go
+++ b/backend/internal/service/mac_host_test.go
@@ -1,0 +1,120 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// stubContactMethodLister implements ContactMethodLister with caller-
+// supplied per-type return values. Used by KnownIdentifiers unit tests
+// to lock the response-assembly contract without a live DB.
+type stubContactMethodLister struct {
+	emails    []string
+	emailsErr error
+	phones    []string
+	phonesErr error
+
+	calls []string // recorded as "email" / "phone" in invocation order
+}
+
+func (s *stubContactMethodLister) ListCanonicalIdentifiersByType(_ context.Context, types []string) ([]string, error) {
+	if len(types) != 1 {
+		// The service only calls with a single type — track this so a
+		// test catches a regression to a union-style query.
+		s.calls = append(s.calls, "unexpected-multi-type")
+		return nil, errors.New("stub: unexpected multi-type call")
+	}
+	s.calls = append(s.calls, types[0])
+	switch types[0] {
+	case "email":
+		return s.emails, s.emailsErr
+	case "phone":
+		return s.phones, s.phonesErr
+	default:
+		return nil, errors.New("stub: unexpected type " + types[0])
+	}
+}
+
+func TestMacHostService_KnownIdentifiers_HappyPath(t *testing.T) {
+	stub := &stubContactMethodLister{
+		emails: []string{"a@example.com", "b@example.com"},
+		phones: []string{"+15550001111", "+15550002222"},
+	}
+	svc := &MacHostService{contactMethodRepo: stub}
+	res, err := svc.KnownIdentifiers(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.Equal(t, []string{"+15550001111", "+15550002222"}, res.Phones)
+	require.Equal(t, []string{"a@example.com", "b@example.com"}, res.Emails)
+	// Both types must be queried separately.
+	require.ElementsMatch(t, []string{"email", "phone"}, stub.calls)
+}
+
+func TestMacHostService_KnownIdentifiers_EmptyDB(t *testing.T) {
+	stub := &stubContactMethodLister{
+		emails: []string{},
+		phones: []string{},
+	}
+	svc := &MacHostService{contactMethodRepo: stub}
+	res, err := svc.KnownIdentifiers(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.Equal(t, []string{}, res.Emails)
+	require.Equal(t, []string{}, res.Phones)
+}
+
+func TestMacHostService_KnownIdentifiers_NilSlicesBecomeEmpty(t *testing.T) {
+	// A repo that returns nil (not []string{}) on no rows must still
+	// produce JSON-friendly empty arrays so the daemon doesn't have to
+	// special-case `null`.
+	stub := &stubContactMethodLister{
+		emails: nil,
+		phones: nil,
+	}
+	svc := &MacHostService{contactMethodRepo: stub}
+	res, err := svc.KnownIdentifiers(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.NotNil(t, res.Emails, "emails should be empty slice, never nil")
+	require.NotNil(t, res.Phones, "phones should be empty slice, never nil")
+	require.Len(t, res.Emails, 0)
+	require.Len(t, res.Phones, 0)
+}
+
+func TestMacHostService_KnownIdentifiers_EmailErrorSurfaces(t *testing.T) {
+	stub := &stubContactMethodLister{
+		emailsErr: errors.New("db: connection refused"),
+		phones:    []string{},
+	}
+	svc := &MacHostService{contactMethodRepo: stub}
+	res, err := svc.KnownIdentifiers(context.Background())
+	require.Error(t, err)
+	require.Nil(t, res)
+	require.Contains(t, err.Error(), "list canonical emails")
+}
+
+func TestMacHostService_KnownIdentifiers_PhoneErrorSurfaces(t *testing.T) {
+	stub := &stubContactMethodLister{
+		emails:    []string{},
+		phonesErr: errors.New("db: connection refused"),
+	}
+	svc := &MacHostService{contactMethodRepo: stub}
+	res, err := svc.KnownIdentifiers(context.Background())
+	require.Error(t, err)
+	require.Nil(t, res)
+	require.Contains(t, err.Error(), "list canonical phones")
+}
+
+func TestMacHostService_KnownIdentifiers_NilRepoErrors(t *testing.T) {
+	// Wiring guard: a service constructed without a contact_method repo
+	// returns a clear error instead of panicking when the endpoint is
+	// hit. Production main.go always wires it; test fixtures that don't
+	// exercise the endpoint pass nil.
+	svc := &MacHostService{contactMethodRepo: nil}
+	_, err := svc.KnownIdentifiers(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "contact_method repository not wired")
+}

--- a/backend/migrations/050_external_contact_deleted_at.down.sql
+++ b/backend/migrations/050_external_contact_deleted_at.down.sql
@@ -1,0 +1,22 @@
+-- 050_external_contact_deleted_at.down.sql
+
+-- Defensive: refuse to drop the column if any rows are tombstoned. A
+-- tombstoned row becoming live on column drop would be a silent data
+-- corruption (rows re-appear in import UI / dedup queries).
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM external_contact WHERE deleted_at IS NOT NULL) THEN
+        RAISE EXCEPTION 'cannot drop deleted_at: % tombstoned rows still exist',
+            (SELECT count(*) FROM external_contact WHERE deleted_at IS NOT NULL);
+    END IF;
+END $$;
+
+DROP INDEX IF EXISTS idx_external_contact_live_crm_contact;
+DROP INDEX IF EXISTS idx_external_contact_unmatched;
+
+-- Restore the original (pre-050) partial index from migration 014.
+CREATE INDEX idx_external_contact_unmatched
+    ON external_contact(source, match_status)
+    WHERE match_status = 'unmatched';
+
+ALTER TABLE external_contact DROP COLUMN deleted_at;

--- a/backend/migrations/050_external_contact_deleted_at.up.sql
+++ b/backend/migrations/050_external_contact_deleted_at.up.sql
@@ -1,0 +1,29 @@
+-- 050_external_contact_deleted_at.up.sql
+-- Mac daemon: tombstone semantics for external_contact via deleted_at.
+-- Spec: .ai/spec/mac-daemon.md §2 iCloud Contacts (deletion handling),
+-- §3 external_contact rules.
+--
+-- The column gives the inline external_contact.deleted handler a
+-- soft-delete target; every existing read query against external_contact
+-- is updated in the same PR to filter `deleted_at IS NULL`. Existing rows
+-- (gcontacts, gcal_attendee, telegram) backfill with deleted_at = NULL
+-- by column default.
+
+ALTER TABLE external_contact ADD COLUMN deleted_at TIMESTAMPTZ;
+
+-- Replace the existing unmatched-source partial index with a deleted_at-
+-- gated variant. The new partial predicate adds AND deleted_at IS NULL so
+-- tombstoned rows are excluded from the highest-traffic Import-UI query.
+DROP INDEX IF EXISTS idx_external_contact_unmatched;
+CREATE INDEX idx_external_contact_unmatched
+    ON external_contact(source, match_status)
+    WHERE match_status = 'unmatched'
+      AND deleted_at IS NULL;
+
+-- Partial index for the per-CRM-contact list query. Keeps
+-- ListExternalContactsForCRMContact tight when (rare) tombstoned rows
+-- accumulate.
+CREATE INDEX idx_external_contact_live_crm_contact
+    ON external_contact(crm_contact_id)
+    WHERE deleted_at IS NULL
+      AND crm_contact_id IS NOT NULL;

--- a/backend/tests/api/external_contact_ingest_test.go
+++ b/backend/tests/api/external_contact_ingest_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 // ----------------------------------------------------------------------------
-// external_contact.* ingest integration tests (PR5)
+// external_contact.* ingest integration tests
 // ----------------------------------------------------------------------------
 
 // extContactIngestEnv bundles the wired stack for external_contact
@@ -345,8 +345,8 @@ func TestIngestExternalContact_Upserted_ReUpsertPreservesMatchState(t *testing.T
 
 	// Re-upsert with a different email (no longer matching the
 	// original seeded contact). The external_contact row's match state
-	// must be preserved (D-JC4) — crm_contact_id stays pinned to the
-	// seeded contact.
+	// must be preserved — crm_contact_id stays pinned to the seeded
+	// contact even though the new payload's emails don't match it.
 	ev2 := buildExtUpsertEvent(t, env.pairedHostID, entityID, func(p *events.ExternalContactUpsertedPayload) {
 		p.Emails = []events.ExternalContactMethodValue{{Value: "unrelated-edit@example.invalid"}}
 	})

--- a/backend/tests/api/external_contact_ingest_test.go
+++ b/backend/tests/api/external_contact_ingest_test.go
@@ -577,3 +577,35 @@ func TestIngestExternalContact_BadSourceIDFormat_Rejected(t *testing.T) {
 	require.Equal(t, 1, resp.Rejected)
 	require.Equal(t, "PAYLOAD_INVARIANT", resp.Errors[0].Code)
 }
+
+func TestIngestExternalContact_VersionZero_Rejected(t *testing.T) {
+	env := setupExtContactIngestEnv(t)
+	entityID := env.sourceIDPrefix + "v0"
+	ev := buildExtUpsertEvent(t, env.pairedHostID, entityID, func(p *events.ExternalContactUpsertedPayload) {
+		p.Version = 0 // wire-shape forbidden — Version must be >= 1
+	})
+	w := postIngestExt(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{ev},
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseIngestResp(t, w)
+	require.Equal(t, 1, resp.Rejected)
+	require.Equal(t, "PAYLOAD_INVALID", resp.Errors[0].Code)
+	require.Contains(t, resp.Errors[0].Message, "version")
+}
+
+func TestIngestExternalContact_VersionTooHigh_Rejected(t *testing.T) {
+	env := setupExtContactIngestEnv(t)
+	entityID := env.sourceIDPrefix + "vhigh"
+	ev := buildExtUpsertEvent(t, env.pairedHostID, entityID, func(p *events.ExternalContactUpsertedPayload) {
+		p.Version = 999 // future daemon — operator must upgrade Pi
+	})
+	w := postIngestExt(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{ev},
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseIngestResp(t, w)
+	require.Equal(t, 1, resp.Rejected)
+	require.Equal(t, "PAYLOAD_INVALID", resp.Errors[0].Code)
+	require.Contains(t, resp.Errors[0].Message, "upgrade Pi")
+}

--- a/backend/tests/api/external_contact_ingest_test.go
+++ b/backend/tests/api/external_contact_ingest_test.go
@@ -1,0 +1,579 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/api"
+	"personal-crm/backend/internal/api/handlers"
+	"personal-crm/backend/internal/auth"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// ----------------------------------------------------------------------------
+// external_contact.* ingest integration tests (PR5)
+// ----------------------------------------------------------------------------
+
+// extContactIngestEnv bundles the wired stack for external_contact
+// ingest integration tests. Smaller than the raw_message env because we
+// don't need a River client (external_contact handlers do not enqueue
+// aggregator jobs).
+type extContactIngestEnv struct {
+	router         *gin.Engine
+	apiKey         string
+	database       *db.Database
+	macService     *service.MacHostService
+	externalRepo   *repository.ExternalContactRepository
+	contactRepo    *repository.ContactRepository
+	cmRepo         *repository.ContactMethodRepository
+	identityRepo   *repository.IdentityRepository
+	eventRepo      *repository.EventRepository
+	pairedHostID   uuid.UUID
+	pairedHostKey  string
+	seededContact  uuid.UUID // contact with email + phone matching test fixtures
+	sourceIDPrefix string    // unique prefix per test so cleanup is targeted
+}
+
+func setupExtContactIngestEnv(t *testing.T) *extContactIngestEnv {
+	t.Helper()
+
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	ctx := context.Background()
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+	cfg.External.APIKey = macHostTestKey
+	cfg.Features.EnableEventBusIngest = true
+
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+
+	hostRepo := repository.NewMacHostRepository(database.Queries)
+	pairingRepo := repository.NewMacHostPairingTokenRepository(database.Queries)
+	syncRepo := repository.NewSyncRepositoryWithPool(database.Queries, database.Pool)
+	contactMethodRepo := repository.NewContactMethodRepository(database.Queries)
+	macService := service.NewMacHostService(hostRepo, pairingRepo, syncRepo, contactMethodRepo, database.Pool, 4)
+
+	identityRepo := repository.NewIdentityRepository(database.Queries)
+	identityService := service.NewIdentityService(identityRepo)
+	contactRepo := repository.NewContactRepository(database.Queries)
+	contactRepo.SetPool(database.Pool)
+	externalRepo := repository.NewExternalContactRepository(database.Queries)
+
+	eventRepo := repository.NewEventRepository(database.Queries)
+	eventBus := events.NewBus(database.Pool, nil, eventRepo) // no river client needed for external_contact path
+	ingestService := service.NewIngestService(
+		database,
+		eventBus,
+		identityService,
+		nil, // messagesRepo unused on external_contact path
+		nil, // riverClient unused
+		externalRepo,
+	)
+	ingestHandler := handlers.NewIngestHandler(ingestService)
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(api.RequestIDMiddleware())
+	router.Use(api.LoggingMiddleware())
+	router.Use(api.CORSMiddleware(cfg.CORS))
+
+	limiter := auth.NewPairingIPRateLimiter()
+	macHandler := handlers.NewMacHostHandler(macService, limiter)
+	handlers.RegisterMacHostRoutes(router, handlers.MacHostRouteDeps{
+		HostRepo:    hostRepo,
+		Handler:     macHandler,
+		AuthLimiter: auth.DefaultMacHostAuthLimiterConfig(),
+	})
+
+	ingestAuth := auth.IngestAuthMiddleware(
+		auth.APIKeyMiddleware(cfg),
+		auth.MacHostAuthMiddleware(hostRepo, auth.DefaultPasswordComparator, auth.DefaultMacHostAuthLimiterConfig()),
+	)
+	ingestGroup := router.Group("/api/v1/ingest")
+	ingestGroup.Use(ingestAuth)
+	ingestGroup.POST("/events", ingestHandler.IngestEvents)
+
+	// Pair a host.
+	plain, _, err := macService.CreatePairingToken(ctx)
+	require.NoError(t, err)
+	pair, err := macService.PairWithToken(ctx, plain, "ext-contact-test", "0.1.0", 1)
+	require.NoError(t, err)
+
+	// Seed a contact + email + phone. Tests can match these with their
+	// upsert payloads. Per-run randomized name avoids cross-test
+	// pollution on a shared DB.
+	suffix := uuid.NewString()[:8]
+	created, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
+		FullName: "Ext Contact Test " + suffix,
+	})
+	require.NoError(t, err)
+	contactID := created.ID
+	_, err = contactMethodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
+		ContactID: contactID,
+		Type:      "email",
+		Value:     "ext-contact-" + suffix + "@example.com",
+	})
+	require.NoError(t, err)
+	_, err = contactMethodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
+		ContactID: contactID,
+		Type:      "phone",
+		Value:     "+1555" + suffix[:7],
+	})
+	require.NoError(t, err)
+
+	env := &extContactIngestEnv{
+		router:         router,
+		apiKey:         cfg.External.APIKey,
+		database:       database,
+		macService:     macService,
+		externalRepo:   externalRepo,
+		contactRepo:    contactRepo,
+		cmRepo:         contactMethodRepo,
+		identityRepo:   identityRepo,
+		eventRepo:      eventRepo,
+		pairedHostID:   pair.HostID,
+		pairedHostKey:  pair.APIKey,
+		seededContact:  contactID,
+		sourceIDPrefix: "ext-ingest-" + suffix + "-",
+	}
+
+	t.Cleanup(func() {
+		cleanCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		// Drop external_contact rows seeded by this test, including
+		// tombstoned ones (uses hard DELETE).
+		_ = database.Queries.TestDeleteExternalContactsBySourceIDPrefix(cleanCtx, env.sourceIDPrefix)
+		// Drop event-log rows under our source.
+		_, _ = database.Queries.DeleteEventsBySource(cleanCtx, "icloud_contacts")
+		_, _ = database.Queries.DeleteExternalIdentitiesBySource(cleanCtx, "icloud_contacts")
+		_ = contactMethodRepo.DeleteContactMethodsByContact(cleanCtx, env.seededContact)
+		_ = contactRepo.HardDeleteContact(cleanCtx, env.seededContact)
+		_, _ = database.Queries.DeleteAllMacHosts(cleanCtx)
+		_, _ = database.Queries.DeleteAllPairingTokens(cleanCtx)
+		database.Close()
+	})
+
+	return env
+}
+
+// canonicalUpsertSourceID synthesizes a valid envelope source_id for an
+// upserted event. Hash content is opaque to the Pi; we just need the
+// regex shape to pass.
+func canonicalUpsertSourceID(entityID string) string {
+	return entityID + "@" + "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+}
+
+// canonicalDeleteSourceID synthesizes a valid envelope source_id for a
+// deleted event.
+func canonicalDeleteSourceID(entityID string) string {
+	return entityID + "@deleted@unknown"
+}
+
+func buildExtUpsertEvent(t *testing.T, hostID uuid.UUID, entityID string, mutate func(*events.ExternalContactUpsertedPayload)) map[string]any {
+	t.Helper()
+	now := accelerated.GetCurrentTime()
+	dn := "Sample User"
+	p := events.ExternalContactUpsertedPayload{
+		Version:     1,
+		HostID:      hostID,
+		Source:      "icloud_contacts",
+		EntityID:    entityID,
+		DisplayName: &dn,
+		Metadata:    map[string]any{"container_identifier": "test-container"},
+	}
+	if mutate != nil {
+		mutate(&p)
+	}
+	pBytes, err := events.Marshal(events.KindExternalContactUpserted, p)
+	require.NoError(t, err)
+	return map[string]any{
+		"source":      "icloud_contacts",
+		"source_id":   canonicalUpsertSourceID(entityID),
+		"kind":        string(events.KindExternalContactUpserted),
+		"payload":     json.RawMessage(pBytes),
+		"observed_at": now,
+	}
+}
+
+func buildExtDeleteEvent(t *testing.T, hostID uuid.UUID, entityID string) map[string]any {
+	t.Helper()
+	now := accelerated.GetCurrentTime()
+	p := events.ExternalContactDeletedPayload{
+		Version:  1,
+		HostID:   hostID,
+		Source:   "icloud_contacts",
+		EntityID: entityID,
+	}
+	pBytes, err := events.Marshal(events.KindExternalContactDeleted, p)
+	require.NoError(t, err)
+	return map[string]any{
+		"source":      "icloud_contacts",
+		"source_id":   canonicalDeleteSourceID(entityID),
+		"kind":        string(events.KindExternalContactDeleted),
+		"payload":     json.RawMessage(pBytes),
+		"observed_at": now,
+	}
+}
+
+func postIngestExt(t *testing.T, env *extContactIngestEnv, hostID *uuid.UUID, hostKey string, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	b, err := json.Marshal(body)
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/ingest/events", bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	if hostID != nil {
+		req.Header.Set("X-Mac-Host-ID", hostID.String())
+		req.Header.Set("Authorization", "Bearer "+hostKey)
+	} else {
+		req.Header.Set("X-API-Key", env.apiKey)
+	}
+	w := httptest.NewRecorder()
+	env.router.ServeHTTP(w, req)
+	return w
+}
+
+// findExtRow looks up an external_contact row by (source=icloud_contacts,
+// source_id=entityID). Returns nil/nil-error when the row is absent.
+// Tombstone-aware via the existing GetBySource (which deliberately
+// returns tombstoned rows so the inline handler can revive them).
+func findExtRow(t *testing.T, env *extContactIngestEnv, entityID string) *repository.ExternalContact {
+	t.Helper()
+	row, err := env.externalRepo.GetBySource(context.Background(), "icloud_contacts", entityID, nil)
+	require.NoError(t, err)
+	return row
+}
+
+func TestIngestExternalContact_Upserted_FirstInsert_NoMatch(t *testing.T) {
+	env := setupExtContactIngestEnv(t)
+	entityID := env.sourceIDPrefix + "no-match"
+	ev := buildExtUpsertEvent(t, env.pairedHostID, entityID, func(p *events.ExternalContactUpsertedPayload) {
+		p.Emails = []events.ExternalContactMethodValue{{Value: "nobody-here@example.invalid"}}
+	})
+	w := postIngestExt(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{ev},
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseIngestResp(t, w)
+	require.Equal(t, 1, resp.Accepted)
+	require.Equal(t, 0, resp.Rejected)
+
+	row := findExtRow(t, env, entityID)
+	require.NotNil(t, row)
+	require.Nil(t, row.CRMContactID, "no email match → no crm_contact_id")
+	require.Equal(t, repository.MatchStatusUnmatched, row.MatchStatus)
+	require.Nil(t, row.DeletedAt)
+}
+
+func TestIngestExternalContact_Upserted_FirstInsert_EmailMatch(t *testing.T) {
+	env := setupExtContactIngestEnv(t)
+	entityID := env.sourceIDPrefix + "email-match"
+
+	// Pull the email that was seeded for env.seededContact.
+	methods, err := env.cmRepo.ListContactMethodsByContact(context.Background(), env.seededContact)
+	require.NoError(t, err)
+	var seededEmail string
+	for _, m := range methods {
+		if m.Type == "email" {
+			seededEmail = m.Value
+			break
+		}
+	}
+	require.NotEmpty(t, seededEmail)
+
+	ev := buildExtUpsertEvent(t, env.pairedHostID, entityID, func(p *events.ExternalContactUpsertedPayload) {
+		p.Emails = []events.ExternalContactMethodValue{{Value: seededEmail}}
+	})
+	w := postIngestExt(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{ev},
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseIngestResp(t, w).Accepted)
+
+	row := findExtRow(t, env, entityID)
+	require.NotNil(t, row)
+	require.NotNil(t, row.CRMContactID, "email match → crm_contact_id should be set")
+	require.Equal(t, env.seededContact, *row.CRMContactID)
+	require.Equal(t, repository.MatchStatusMatched, row.MatchStatus)
+}
+
+func TestIngestExternalContact_Upserted_ReUpsertPreservesMatchState(t *testing.T) {
+	env := setupExtContactIngestEnv(t)
+	entityID := env.sourceIDPrefix + "preserve"
+	methods, err := env.cmRepo.ListContactMethodsByContact(context.Background(), env.seededContact)
+	require.NoError(t, err)
+	var seededEmail string
+	for _, m := range methods {
+		if m.Type == "email" {
+			seededEmail = m.Value
+			break
+		}
+	}
+
+	// First insert with a match.
+	ev1 := buildExtUpsertEvent(t, env.pairedHostID, entityID, func(p *events.ExternalContactUpsertedPayload) {
+		p.Emails = []events.ExternalContactMethodValue{{Value: seededEmail}}
+	})
+	w := postIngestExt(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{ev1},
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, 1, parseIngestResp(t, w).Accepted)
+
+	row1 := findExtRow(t, env, entityID)
+	require.NotNil(t, row1)
+	require.NotNil(t, row1.CRMContactID)
+	originalCRM := *row1.CRMContactID
+
+	// Re-upsert with a different email (no longer matching the
+	// original seeded contact). The external_contact row's match state
+	// must be preserved (D-JC4) — crm_contact_id stays pinned to the
+	// seeded contact.
+	ev2 := buildExtUpsertEvent(t, env.pairedHostID, entityID, func(p *events.ExternalContactUpsertedPayload) {
+		p.Emails = []events.ExternalContactMethodValue{{Value: "unrelated-edit@example.invalid"}}
+	})
+	// Different source_id (different content hash) so the dedup hash
+	// doesn't skip the inline handler.
+	ev2["source_id"] = entityID + "@" + "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+
+	w = postIngestExt(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{ev2},
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseIngestResp(t, w).Accepted)
+
+	row2 := findExtRow(t, env, entityID)
+	require.NotNil(t, row2)
+	require.NotNil(t, row2.CRMContactID, "re-upsert must preserve crm_contact_id")
+	require.Equal(t, originalCRM, *row2.CRMContactID)
+	require.Equal(t, repository.MatchStatusMatched, row2.MatchStatus)
+}
+
+func TestIngestExternalContact_Upserted_RevivesTombstone(t *testing.T) {
+	env := setupExtContactIngestEnv(t)
+	entityID := env.sourceIDPrefix + "revive"
+
+	// Plant a live row, tombstone it, then upsert and assert revive.
+	ctx := context.Background()
+	syncedAt := accelerated.GetCurrentTime()
+	first, err := env.externalRepo.Upsert(ctx, repository.UpsertExternalContactRequest{
+		Source:   "icloud_contacts",
+		SourceID: entityID,
+		Emails:   []repository.EmailEntry{{Value: "tombstone-seed@example.invalid"}},
+		SyncedAt: &syncedAt,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, first)
+
+	// Tombstone via a tx. Use a fresh tx so we exercise SoftDeleteTx.
+	tx, err := env.database.Pool.Begin(ctx)
+	require.NoError(t, err)
+	require.NoError(t, env.externalRepo.SoftDeleteTx(ctx, tx, first.ID))
+	require.NoError(t, tx.Commit(ctx))
+
+	pre := findExtRow(t, env, entityID)
+	require.NotNil(t, pre)
+	require.NotNil(t, pre.DeletedAt, "fixture must be tombstoned before the upsert event")
+
+	// Now post an upsert event.
+	ev := buildExtUpsertEvent(t, env.pairedHostID, entityID, func(p *events.ExternalContactUpsertedPayload) {
+		p.Emails = []events.ExternalContactMethodValue{{Value: "revived@example.invalid"}}
+	})
+	w := postIngestExt(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{ev},
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseIngestResp(t, w).Accepted)
+
+	post := findExtRow(t, env, entityID)
+	require.NotNil(t, post)
+	require.Nil(t, post.DeletedAt, "tombstoned row should be revived (deleted_at = NULL)")
+}
+
+func TestIngestExternalContact_Deleted_SetsDeletedAt(t *testing.T) {
+	env := setupExtContactIngestEnv(t)
+	entityID := env.sourceIDPrefix + "delete"
+
+	// Seed: upsert first, then delete.
+	upEv := buildExtUpsertEvent(t, env.pairedHostID, entityID, nil)
+	w := postIngestExt(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{upEv},
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, 1, parseIngestResp(t, w).Accepted)
+	require.Nil(t, findExtRow(t, env, entityID).DeletedAt)
+
+	delEv := buildExtDeleteEvent(t, env.pairedHostID, entityID)
+	w = postIngestExt(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{delEv},
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseIngestResp(t, w)
+	require.Equal(t, 1, resp.Accepted)
+	require.Equal(t, 0, resp.Rejected)
+
+	row := findExtRow(t, env, entityID)
+	require.NotNil(t, row, "soft-delete must preserve the row")
+	require.NotNil(t, row.DeletedAt, "delete event must set deleted_at")
+}
+
+func TestIngestExternalContact_Deleted_NoExistingRow_NoOp(t *testing.T) {
+	env := setupExtContactIngestEnv(t)
+	entityID := env.sourceIDPrefix + "delete-unknown"
+	delEv := buildExtDeleteEvent(t, env.pairedHostID, entityID)
+	w := postIngestExt(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{delEv},
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseIngestResp(t, w)
+	require.Equal(t, 1, resp.Accepted, "delete for unknown entity must still be accepted (event-log durable)")
+	require.Equal(t, 0, resp.Rejected, "errors: %+v", resp.Errors)
+
+	// No row materializes for the unknown delete.
+	require.Nil(t, findExtRow(t, env, entityID))
+
+	// But the event-log row should exist (audit trail).
+	logged, err := env.eventRepo.FindEventBySource(
+		context.Background(), "icloud_contacts", canonicalDeleteSourceID(entityID))
+	require.NoError(t, err)
+	require.NotNil(t, logged, "event-log row must persist for the no-op delete (audit)")
+}
+
+func TestIngestExternalContact_Deleted_AlreadyTombstoned_NoOp(t *testing.T) {
+	env := setupExtContactIngestEnv(t)
+	entityID := env.sourceIDPrefix + "delete-twice"
+	upEv := buildExtUpsertEvent(t, env.pairedHostID, entityID, nil)
+	require.Equal(t, 1, parseIngestResp(t, postIngestExt(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{upEv},
+	})).Accepted)
+
+	// First delete — content hash A.
+	delEvA := buildExtDeleteEvent(t, env.pairedHostID, entityID)
+	w := postIngestExt(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{delEvA},
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, 1, parseIngestResp(t, w).Accepted)
+	deletedAtA := findExtRow(t, env, entityID).DeletedAt
+	require.NotNil(t, deletedAtA)
+
+	// Second delete with a different source_id (different prev hash so
+	// event-log dedup doesn't swallow it). Should be silently no-op at
+	// the row level — deleted_at unchanged.
+	delEvB := map[string]any{}
+	for k, v := range delEvA {
+		delEvB[k] = v
+	}
+	delEvB["source_id"] = entityID + "@deleted@" + "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+	w = postIngestExt(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{delEvB},
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseIngestResp(t, w).Accepted)
+
+	row := findExtRow(t, env, entityID)
+	require.NotNil(t, row)
+	require.NotNil(t, row.DeletedAt)
+	require.Equal(t, deletedAtA.UnixMilli(), row.DeletedAt.UnixMilli(),
+		"second delete must not bump deleted_at on an already-tombstoned row")
+}
+
+func TestIngestExternalContact_Upserted_DuplicateContentHash_DedupSkipsHandler(t *testing.T) {
+	env := setupExtContactIngestEnv(t)
+	entityID := env.sourceIDPrefix + "dedup"
+	ev := buildExtUpsertEvent(t, env.pairedHostID, entityID, nil)
+
+	w := postIngestExt(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{ev},
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, 1, parseIngestResp(t, w).Accepted)
+	row1 := findExtRow(t, env, entityID)
+	require.NotNil(t, row1)
+
+	// Re-post the exact same event (same source_id, same content hash).
+	w = postIngestExt(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{ev},
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	resp := parseIngestResp(t, w)
+	require.Equal(t, 0, resp.Accepted)
+	require.Equal(t, 1, resp.Duplicate)
+	require.Equal(t, 0, resp.Rejected)
+}
+
+func TestIngestExternalContact_GlobalKeyPath_RejectedHostOnly(t *testing.T) {
+	env := setupExtContactIngestEnv(t)
+	entityID := env.sourceIDPrefix + "global-key"
+	ev := buildExtUpsertEvent(t, env.pairedHostID, entityID, nil)
+	w := postIngestExt(t, env, nil, "", map[string]any{
+		"events": []any{ev},
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseIngestResp(t, w)
+	require.Equal(t, 0, resp.Accepted)
+	require.Equal(t, 1, resp.Rejected)
+	require.Len(t, resp.Errors, 1)
+	require.Equal(t, "HOST_ONLY_REQUIRES_HOST_AUTH", resp.Errors[0].Code)
+}
+
+func TestIngestExternalContact_HostAuth_UnsupportedSource(t *testing.T) {
+	env := setupExtContactIngestEnv(t)
+	entityID := env.sourceIDPrefix + "wrong-source"
+	ev := buildExtUpsertEvent(t, env.pairedHostID, entityID, nil)
+	ev["source"] = "anarlog_humans"
+	w := postIngestExt(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{ev},
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseIngestResp(t, w)
+	require.Equal(t, 0, resp.Accepted)
+	require.Equal(t, 1, resp.Rejected)
+	require.Len(t, resp.Errors, 1)
+	require.Equal(t, "PAYLOAD_INVARIANT", resp.Errors[0].Code)
+}
+
+func TestIngestExternalContact_HostMismatch_Rejected(t *testing.T) {
+	env := setupExtContactIngestEnv(t)
+	entityID := env.sourceIDPrefix + "host-mismatch"
+	ev := buildExtUpsertEvent(t, uuid.New() /* random host id */, entityID, nil)
+	w := postIngestExt(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{ev},
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseIngestResp(t, w)
+	require.Equal(t, 1, resp.Rejected)
+	require.Equal(t, "PAYLOAD_INVARIANT", resp.Errors[0].Code)
+}
+
+func TestIngestExternalContact_BadSourceIDFormat_Rejected(t *testing.T) {
+	env := setupExtContactIngestEnv(t)
+	entityID := env.sourceIDPrefix + "bad-source-id"
+	ev := buildExtUpsertEvent(t, env.pairedHostID, entityID, nil)
+	ev["source_id"] = entityID + "@not-a-hash"
+	w := postIngestExt(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{ev},
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseIngestResp(t, w)
+	require.Equal(t, 1, resp.Rejected)
+	require.Equal(t, "PAYLOAD_INVARIANT", resp.Errors[0].Code)
+}

--- a/backend/tests/api/external_contact_savepoint_rollback_test.go
+++ b/backend/tests/api/external_contact_savepoint_rollback_test.go
@@ -1,0 +1,213 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/api"
+	"personal-crm/backend/internal/api/handlers"
+	"personal-crm/backend/internal/auth"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+)
+
+// failingMatchExternalContactWriter wraps a real repository and
+// intentionally fails UpdateMatchTx. Used to drive the savepoint-
+// rollback test: a failure mid-handler must roll back the
+// (Bus.PublishTx + UpsertTx + identity rows) writes inside the same
+// savepoint so no partial state lands.
+type failingMatchExternalContactWriter struct {
+	inner *repository.ExternalContactRepository
+}
+
+func (f *failingMatchExternalContactWriter) GetBySourceTx(ctx context.Context, tx pgx.Tx, source, sourceID string, accountID *string) (*repository.ExternalContact, error) {
+	return f.inner.GetBySourceTx(ctx, tx, source, sourceID, accountID)
+}
+func (f *failingMatchExternalContactWriter) UpsertTx(ctx context.Context, tx pgx.Tx, req repository.UpsertExternalContactRequest) (*repository.ExternalContact, error) {
+	return f.inner.UpsertTx(ctx, tx, req)
+}
+func (f *failingMatchExternalContactWriter) UpdateMatchTx(_ context.Context, _ pgx.Tx, _ uuid.UUID, _ *uuid.UUID, _ repository.MatchStatus) (*repository.ExternalContact, error) {
+	return nil, errors.New("simulated UpdateMatchTx failure")
+}
+func (f *failingMatchExternalContactWriter) ReviveTx(ctx context.Context, tx pgx.Tx, id uuid.UUID) (*repository.ExternalContact, error) {
+	return f.inner.ReviveTx(ctx, tx, id)
+}
+func (f *failingMatchExternalContactWriter) SoftDeleteTx(ctx context.Context, tx pgx.Tx, id uuid.UUID) error {
+	return f.inner.SoftDeleteTx(ctx, tx, id)
+}
+
+// TestIngestExternalContact_SavepointRollback_OnMatchFailure asserts
+// that when the inline handler fails partway through (UpdateMatchTx
+// errors), the savepoint rolls back EVERY write inside it:
+//
+//  1. external_contact row was NOT inserted.
+//  2. external_identity rows from in-handler MatchOrCreateTx calls
+//     were NOT inserted.
+//  3. The event-log row was NOT persisted either — Bus.PublishTx is
+//     called INSIDE the same savepoint, so rollback undoes that too.
+//
+// Documents the intentional tradeoff: a daemon retry on the same
+// event will re-execute the handler (no event-log dedup suppresses
+// it), which is the same contract raw_message.* follows.
+func TestIngestExternalContact_SavepointRollback_OnMatchFailure(t *testing.T) {
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+	ctx := context.Background()
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+	cfg.External.APIKey = macHostTestKey
+	cfg.Features.EnableEventBusIngest = true
+
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	t.Cleanup(func() { database.Close() })
+
+	hostRepo := repository.NewMacHostRepository(database.Queries)
+	pairingRepo := repository.NewMacHostPairingTokenRepository(database.Queries)
+	syncRepo := repository.NewSyncRepositoryWithPool(database.Queries, database.Pool)
+	contactMethodRepo := repository.NewContactMethodRepository(database.Queries)
+	macService := service.NewMacHostService(hostRepo, pairingRepo, syncRepo, contactMethodRepo, database.Pool, 4)
+
+	identityRepo := repository.NewIdentityRepository(database.Queries)
+	identityService := service.NewIdentityService(identityRepo)
+	contactRepo := repository.NewContactRepository(database.Queries)
+	contactRepo.SetPool(database.Pool)
+	externalRepo := repository.NewExternalContactRepository(database.Queries)
+
+	eventRepo := repository.NewEventRepository(database.Queries)
+	eventBus := events.NewBus(database.Pool, nil, eventRepo)
+
+	// Wire the failing stub for UpdateMatchTx so the inline handler's
+	// match-flip path errors after Bus.PublishTx + UpsertTx +
+	// MatchOrCreateTx have already written rows inside the savepoint.
+	failingWriter := &failingMatchExternalContactWriter{inner: externalRepo}
+	ingestService := service.NewIngestService(database, eventBus, identityService, nil, nil, failingWriter)
+	ingestHandler := handlers.NewIngestHandler(ingestService)
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(api.RequestIDMiddleware())
+	router.Use(api.LoggingMiddleware())
+	router.Use(api.CORSMiddleware(cfg.CORS))
+	limiter := auth.NewPairingIPRateLimiter()
+	macHandler := handlers.NewMacHostHandler(macService, limiter)
+	handlers.RegisterMacHostRoutes(router, handlers.MacHostRouteDeps{
+		HostRepo:    hostRepo,
+		Handler:     macHandler,
+		AuthLimiter: auth.DefaultMacHostAuthLimiterConfig(),
+	})
+	ingestAuth := auth.IngestAuthMiddleware(
+		auth.APIKeyMiddleware(cfg),
+		auth.MacHostAuthMiddleware(hostRepo, auth.DefaultPasswordComparator, auth.DefaultMacHostAuthLimiterConfig()),
+	)
+	g := router.Group("/api/v1/ingest")
+	g.Use(ingestAuth)
+	g.POST("/events", ingestHandler.IngestEvents)
+
+	// Pair a host.
+	plain, _, err := macService.CreatePairingToken(ctx)
+	require.NoError(t, err)
+	pair, err := macService.PairWithToken(ctx, plain, "rollback-test", "0.1.0", 1)
+	require.NoError(t, err)
+
+	// Seed a CRM contact with an email; that match triggers the
+	// failing UpdateMatchTx.
+	suffix := uuid.NewString()[:8]
+	created, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
+		FullName: "Rollback Test " + suffix,
+	})
+	require.NoError(t, err)
+	seededEmail := "rollback-" + suffix + "@example.invalid"
+	_, err = contactMethodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
+		ContactID: created.ID,
+		Type:      "email",
+		Value:     seededEmail,
+	})
+	require.NoError(t, err)
+
+	sourceIDPrefix := "rollback-" + suffix + "-"
+	t.Cleanup(func() {
+		cleanCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_ = database.Queries.TestDeleteExternalContactsBySourceIDPrefix(cleanCtx, sourceIDPrefix)
+		_, _ = database.Queries.DeleteEventsBySource(cleanCtx, "icloud_contacts")
+		_, _ = database.Queries.DeleteExternalIdentitiesBySource(cleanCtx, "icloud_contacts")
+		_ = contactMethodRepo.DeleteContactMethodsByContact(cleanCtx, created.ID)
+		_ = contactRepo.HardDeleteContact(cleanCtx, created.ID)
+		_, _ = database.Queries.DeleteAllMacHosts(cleanCtx)
+		_, _ = database.Queries.DeleteAllPairingTokens(cleanCtx)
+	})
+
+	// Build an upsert event whose email matches the seeded contact —
+	// the inline handler will get past UpsertTx + MatchOrCreateTx and
+	// then fail at UpdateMatchTx (the stub).
+	entityID := sourceIDPrefix + "match-fail"
+	hashHex := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	now := accelerated.GetCurrentTime()
+	dn := "Sample Rollback"
+	p := events.ExternalContactUpsertedPayload{
+		Version:     1,
+		HostID:      pair.HostID,
+		Source:      "icloud_contacts",
+		EntityID:    entityID,
+		DisplayName: &dn,
+		Emails:      []events.ExternalContactMethodValue{{Value: seededEmail}},
+		Metadata:    map[string]any{"container_identifier": "rollback-test"},
+	}
+	pBytes, err := events.Marshal(events.KindExternalContactUpserted, p)
+	require.NoError(t, err)
+	ev := map[string]any{
+		"source":      "icloud_contacts",
+		"source_id":   entityID + "@" + hashHex,
+		"kind":        string(events.KindExternalContactUpserted),
+		"payload":     json.RawMessage(pBytes),
+		"observed_at": now,
+	}
+
+	body, err := json.Marshal(map[string]any{"events": []any{ev}})
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/ingest/events", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Mac-Host-ID", pair.HostID.String())
+	req.Header.Set("Authorization", "Bearer "+pair.APIKey)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	var resp handlers.IngestResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	require.Equal(t, 0, resp.Accepted, "match-failure must NOT count as accepted")
+	require.Equal(t, 1, resp.Rejected)
+	require.Len(t, resp.Errors, 1)
+	require.Equal(t, "EXTERNAL_CONTACT_UPDATE_MATCH_FAILED", resp.Errors[0].Code)
+
+	// 1. No external_contact row was committed.
+	row, err := externalRepo.GetBySource(ctx, "icloud_contacts", entityID, nil)
+	require.NoError(t, err)
+	require.Nil(t, row, "external_contact row must not be committed after savepoint rollback")
+
+	// 2. No event-log row was committed (Bus.PublishTx ran inside the
+	//    savepoint, so rollback undoes it too).
+	logged, err := eventRepo.FindEventBySource(ctx, "icloud_contacts", entityID+"@"+hashHex)
+	require.Error(t, err, "event-log row must not be committed after savepoint rollback")
+	require.True(t, errors.Is(err, db.ErrNotFound), "expected ErrNotFound, got %v", err)
+	require.Nil(t, logged)
+}

--- a/backend/tests/api/external_contact_savepoint_rollback_test.go
+++ b/backend/tests/api/external_contact_savepoint_rollback_test.go
@@ -18,6 +18,7 @@ import (
 	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/identity"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/service"
 
@@ -210,4 +211,14 @@ func TestIngestExternalContact_SavepointRollback_OnMatchFailure(t *testing.T) {
 	require.Error(t, err, "event-log row must not be committed after savepoint rollback")
 	require.True(t, errors.Is(err, db.ErrNotFound), "expected ErrNotFound, got %v", err)
 	require.Nil(t, logged)
+
+	// 3. No external_identity row was committed. The handler called
+	//    MatchOrCreateTx on the seeded email BEFORE UpdateMatchTx
+	//    failed; that call writes an external_identity row inside the
+	//    same savepoint. Rollback must undo it.
+	ident, err := identityRepo.GetByIdentifier(ctx,
+		identity.IdentifierTypeEmail, seededEmail, "icloud_contacts")
+	require.Error(t, err, "external_identity row must not be committed after savepoint rollback")
+	require.True(t, errors.Is(err, db.ErrNotFound), "expected ErrNotFound, got %v", err)
+	require.Nil(t, ident)
 }

--- a/backend/tests/api/ingest_raw_message_e2e_test.go
+++ b/backend/tests/api/ingest_raw_message_e2e_test.go
@@ -84,7 +84,7 @@ func TestIngestRawMessage_E2E_StagesAggregatesAndCreatesInteraction(t *testing.T
 	contactSvc := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, nil, rematchSvc)
 	cadenceUpdater := consumer.NewCadenceUpdater(claimRepo, contactRepo, database.Queries, consumer.CadenceModeCutover, false)
 	contactSvc.SetCadenceUpdater(cadenceUpdater)
-	macService := service.NewMacHostService(hostRepo, pairingRepo, syncRepo, database.Pool, 4)
+	macService := service.NewMacHostService(hostRepo, pairingRepo, syncRepo, nil, database.Pool, 4)
 
 	// River client — wires the real MessagingAggregateForContactWorker
 	// (so the e2e test runs through the aggregator), the
@@ -144,7 +144,7 @@ func TestIngestRawMessage_E2E_StagesAggregatesAndCreatesInteraction(t *testing.T
 	recorderShim.real = consumer.NewInteractionRecorderWorker(bus, database.Pool, recorder, nil)
 
 	// Now wire the ingest service + handler.
-	ingestService := service.NewIngestService(database, bus, identityService, messagesRepo, riverClient)
+	ingestService := service.NewIngestService(database, bus, identityService, messagesRepo, riverClient, nil)
 	ingestHandler := handlers.NewIngestHandler(ingestService)
 
 	gin.SetMode(gin.TestMode)

--- a/backend/tests/api/ingest_raw_message_test.go
+++ b/backend/tests/api/ingest_raw_message_test.go
@@ -71,7 +71,7 @@ func setupRawIngestEnv(t *testing.T) *ingestRawTestEnv {
 	hostRepo := repository.NewMacHostRepository(database.Queries)
 	pairingRepo := repository.NewMacHostPairingTokenRepository(database.Queries)
 	syncRepo := repository.NewSyncRepositoryWithPool(database.Queries, database.Pool)
-	macService := service.NewMacHostService(hostRepo, pairingRepo, syncRepo, database.Pool, 4)
+	macService := service.NewMacHostService(hostRepo, pairingRepo, syncRepo, nil, database.Pool, 4)
 
 	identityRepo := repository.NewIdentityRepository(database.Queries)
 	identityService := service.NewIdentityService(identityRepo)
@@ -119,6 +119,7 @@ func setupRawIngestEnv(t *testing.T) *ingestRawTestEnv {
 		identityService,
 		messagesRepo,
 		riverClient,
+		nil,
 	)
 	ingestHandler := handlers.NewIngestHandler(ingestService)
 
@@ -396,7 +397,7 @@ func TestIngestRawMessage_UnmatchedPeer_StagedWithoutContactNoJob(t *testing.T) 
 
 // TestIngestRawMessage_GlobalKeyPath_RejectedWithCode asserts that
 // raw_message.* events submitted via the global API key (no
-// X-Mac-Host-ID) are REJECTED per-event with RAW_MESSAGE_REQUIRES_HOST_AUTH.
+// X-Mac-Host-ID) are REJECTED per-event with HOST_ONLY_REQUIRES_HOST_AUTH.
 func TestIngestRawMessage_GlobalKeyPath_RejectedWithCode(t *testing.T) {
 	env := setupRawIngestEnv(t)
 	guid := "test-guid-" + uuid.NewString()
@@ -410,7 +411,7 @@ func TestIngestRawMessage_GlobalKeyPath_RejectedWithCode(t *testing.T) {
 	require.Equal(t, 0, resp.Accepted)
 	require.Equal(t, 1, resp.Rejected)
 	require.Len(t, resp.Errors, 1)
-	require.Equal(t, "RAW_MESSAGE_REQUIRES_HOST_AUTH", resp.Errors[0].Code)
+	require.Equal(t, "HOST_ONLY_REQUIRES_HOST_AUTH", resp.Errors[0].Code)
 }
 
 // TestIngestRawMessage_HostAuthForeignKind_Rejected asserts a non-

--- a/backend/tests/api/ingest_test.go
+++ b/backend/tests/api/ingest_test.go
@@ -122,7 +122,7 @@ func setupIngestTestRouter(t *testing.T, enableIngest bool) *ingestTestSetup {
 	// don't exercise raw_message kinds; passing nil for those deps is
 	// safe — raw_message envelopes are rejected at the handler with
 	// PAYLOAD_INVALID before reaching the inline handler.
-	ingestService := service.NewIngestService(database, eventBus, nil, nil, nil)
+	ingestService := service.NewIngestService(database, eventBus, nil, nil, nil, nil)
 	ingestHandler := handlers.NewIngestHandler(ingestService)
 
 	gin.SetMode(gin.TestMode)
@@ -698,7 +698,7 @@ func TestIngest_MidTxRollback_RollsBack_And_Returns500(t *testing.T) {
 	// so the rest of the suite isn't affected.
 	fake := &failingRepo{inner: setup.eventRepo, failOn: 3}
 	bus := setup.busFactory(fake)
-	ingestService := service.NewIngestService(setup.database, bus, nil, nil, nil)
+	ingestService := service.NewIngestService(setup.database, bus, nil, nil, nil, nil)
 	handler := handlers.NewIngestHandler(ingestService)
 
 	cfg := config.TestConfig()

--- a/backend/tests/api/known_identifiers_test.go
+++ b/backend/tests/api/known_identifiers_test.go
@@ -1,0 +1,268 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/api"
+	"personal-crm/backend/internal/api/handlers"
+	"personal-crm/backend/internal/auth"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// ----------------------------------------------------------------------------
+// GET /api/v1/host/:id/known-identifiers integration tests
+// ----------------------------------------------------------------------------
+
+type knownIDsEnv struct {
+	router         *gin.Engine
+	database       *db.Database
+	macService     *service.MacHostService
+	contactRepo    *repository.ContactRepository
+	cmRepo         *repository.ContactMethodRepository
+	pairedHostID   uuid.UUID
+	pairedHostKey  string
+	seededContacts []uuid.UUID
+}
+
+func setupKnownIDsEnv(t *testing.T) *knownIDsEnv {
+	t.Helper()
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+	ctx := context.Background()
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+	cfg.External.APIKey = macHostTestKey
+
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+
+	hostRepo := repository.NewMacHostRepository(database.Queries)
+	pairingRepo := repository.NewMacHostPairingTokenRepository(database.Queries)
+	syncRepo := repository.NewSyncRepositoryWithPool(database.Queries, database.Pool)
+	contactMethodRepo := repository.NewContactMethodRepository(database.Queries)
+	macService := service.NewMacHostService(hostRepo, pairingRepo, syncRepo, contactMethodRepo, database.Pool, 4)
+
+	contactRepo := repository.NewContactRepository(database.Queries)
+	contactRepo.SetPool(database.Pool)
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(api.RequestIDMiddleware())
+	router.Use(api.LoggingMiddleware())
+	router.Use(api.CORSMiddleware(cfg.CORS))
+
+	limiter := auth.NewPairingIPRateLimiter()
+	macHandler := handlers.NewMacHostHandler(macService, limiter)
+	handlers.RegisterMacHostRoutes(router, handlers.MacHostRouteDeps{
+		HostRepo:    hostRepo,
+		Handler:     macHandler,
+		AuthLimiter: auth.DefaultMacHostAuthLimiterConfig(),
+	})
+
+	plain, _, err := macService.CreatePairingToken(ctx)
+	require.NoError(t, err)
+	pair, err := macService.PairWithToken(ctx, plain, "known-ids-test", "0.1.0", 1)
+	require.NoError(t, err)
+
+	env := &knownIDsEnv{
+		router:        router,
+		database:      database,
+		macService:    macService,
+		contactRepo:   contactRepo,
+		cmRepo:        contactMethodRepo,
+		pairedHostID:  pair.HostID,
+		pairedHostKey: pair.APIKey,
+	}
+
+	t.Cleanup(func() {
+		cleanCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		for _, id := range env.seededContacts {
+			_ = contactMethodRepo.DeleteContactMethodsByContact(cleanCtx, id)
+			_ = contactRepo.HardDeleteContact(cleanCtx, id)
+		}
+		_, _ = database.Queries.DeleteAllMacHosts(cleanCtx)
+		_, _ = database.Queries.DeleteAllPairingTokens(cleanCtx)
+		database.Close()
+	})
+	return env
+}
+
+// seedKnownIDsContact creates a CRM contact with the supplied methods.
+// Each method tuple is (type, value).
+func (e *knownIDsEnv) seedKnownIDsContact(t *testing.T, name string, methods [][2]string) uuid.UUID {
+	t.Helper()
+	ctx := context.Background()
+	created, err := e.contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: name})
+	require.NoError(t, err)
+	for _, m := range methods {
+		_, err := e.cmRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
+			ContactID: created.ID,
+			Type:      m[0],
+			Value:     m[1],
+		})
+		require.NoError(t, err)
+	}
+	e.seededContacts = append(e.seededContacts, created.ID)
+	return created.ID
+}
+
+func getKnownIdentifiers(t *testing.T, env *knownIDsEnv, hostID, hostKey string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/host/"+hostID+"/known-identifiers", nil)
+	if hostID != "" {
+		req.Header.Set("X-Mac-Host-ID", hostID)
+	}
+	if hostKey != "" {
+		req.Header.Set("Authorization", "Bearer "+hostKey)
+	}
+	w := httptest.NewRecorder()
+	env.router.ServeHTTP(w, req)
+	return w
+}
+
+type knownIDsResp struct {
+	Success bool `json:"success"`
+	Data    struct {
+		Phones []string `json:"phones"`
+		Emails []string `json:"emails"`
+	} `json:"data"`
+}
+
+func parseKnownIDsResp(t *testing.T, w *httptest.ResponseRecorder) knownIDsResp {
+	t.Helper()
+	var r knownIDsResp
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&r), "body: %s", w.Body.String())
+	return r
+}
+
+func TestKnownIdentifiers_Auth_Missing_401(t *testing.T) {
+	env := setupKnownIDsEnv(t)
+	w := getKnownIdentifiers(t, env, env.pairedHostID.String(), "")
+	require.Equal(t, http.StatusUnauthorized, w.Code, "body: %s", w.Body.String())
+}
+
+func TestKnownIdentifiers_Auth_WrongKey_401(t *testing.T) {
+	env := setupKnownIDsEnv(t)
+	w := getKnownIdentifiers(t, env, env.pairedHostID.String(), "deadbeef")
+	require.Equal(t, http.StatusUnauthorized, w.Code, "body: %s", w.Body.String())
+}
+
+func TestKnownIdentifiers_HappyPath_ReturnsSortedDistinctSets(t *testing.T) {
+	env := setupKnownIDsEnv(t)
+	// Two contacts with overlapping phones (different normalized values).
+	env.seedKnownIDsContact(t, "Known IDs A "+uuid.NewString()[:6], [][2]string{
+		{"email", "alpha-" + uuid.NewString()[:6] + "@example.invalid"},
+		{"phone", "+15550009999"},
+	})
+	env.seedKnownIDsContact(t, "Known IDs B "+uuid.NewString()[:6], [][2]string{
+		{"email", "beta-" + uuid.NewString()[:6] + "@example.invalid"},
+		{"phone", "+15550009999"}, // same phone — DISTINCT collapses
+		{"phone", "+15550008888"},
+	})
+
+	w := getKnownIdentifiers(t, env, env.pairedHostID.String(), env.pairedHostKey)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	r := parseKnownIDsResp(t, w)
+	require.True(t, r.Success)
+
+	// Phones: duplicate collapses to one entry; sorted ascending.
+	require.Contains(t, r.Data.Phones, "+15550009999")
+	require.Contains(t, r.Data.Phones, "+15550008888")
+	// 8888 sorts before 9999.
+	pos8 := indexOf(r.Data.Phones, "+15550008888")
+	pos9 := indexOf(r.Data.Phones, "+15550009999")
+	require.True(t, pos8 < pos9, "phones must be sorted ASC; got %v", r.Data.Phones)
+	require.Equal(t, 1, occurrences(r.Data.Phones, "+15550009999"),
+		"distinct semantics: same number on two contacts should appear once")
+}
+
+func TestKnownIdentifiers_ExcludesSoftDeletedContact(t *testing.T) {
+	env := setupKnownIDsEnv(t)
+	ctx := context.Background()
+	suffix := uuid.NewString()[:8]
+	live := env.seedKnownIDsContact(t, "KnownIDs Live "+suffix, [][2]string{
+		{"email", "live-" + suffix + "@example.invalid"},
+	})
+	deleted := env.seedKnownIDsContact(t, "KnownIDs Deleted "+suffix, [][2]string{
+		{"email", "deleted-" + suffix + "@example.invalid"},
+	})
+	require.NoError(t, env.contactRepo.SoftDeleteContact(ctx, deleted))
+
+	w := getKnownIdentifiers(t, env, env.pairedHostID.String(), env.pairedHostKey)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	r := parseKnownIDsResp(t, w)
+	require.Contains(t, r.Data.Emails, "live-"+suffix+"@example.invalid")
+	require.NotContains(t, r.Data.Emails, "deleted-"+suffix+"@example.invalid",
+		"soft-deleted contact's emails must not appear in known-identifiers")
+	_ = live // keep referenced
+}
+
+func TestKnownIdentifiers_OnlyEmailAndPhoneTypes(t *testing.T) {
+	env := setupKnownIDsEnv(t)
+	suffix := uuid.NewString()[:8]
+	env.seedKnownIDsContact(t, "KnownIDs Types "+suffix, [][2]string{
+		{"email", "types-" + suffix + "@example.invalid"},
+		{"phone", "+15551110000"},
+		{"telegram", "@types-" + suffix},
+		{"whatsapp", "+15551110000"},
+	})
+
+	w := getKnownIdentifiers(t, env, env.pairedHostID.String(), env.pairedHostKey)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	r := parseKnownIDsResp(t, w)
+	require.Contains(t, r.Data.Emails, "types-"+suffix+"@example.invalid")
+	require.Contains(t, r.Data.Phones, "+15551110000")
+	// Telegram / WhatsApp handles must NOT leak into either array.
+	for _, v := range r.Data.Emails {
+		require.NotContains(t, v, "@types-"+suffix, "telegram handle should not appear in emails")
+	}
+}
+
+func TestKnownIdentifiers_EmptyArraysOnFreshHost(t *testing.T) {
+	env := setupKnownIDsEnv(t)
+	// No contacts seeded for this test (the cleanup ensures isolation
+	// on a per-test basis from prior tests' contacts because each test
+	// hard-deletes its own seeded rows in t.Cleanup).
+	w := getKnownIdentifiers(t, env, env.pairedHostID.String(), env.pairedHostKey)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	r := parseKnownIDsResp(t, w)
+	require.NotNil(t, r.Data.Phones)
+	require.NotNil(t, r.Data.Emails)
+}
+
+// indexOf returns the position of needle in slice, or -1 if absent.
+func indexOf(s []string, needle string) int {
+	for i, v := range s {
+		if v == needle {
+			return i
+		}
+	}
+	return -1
+}
+
+// occurrences counts how many times needle appears in slice.
+func occurrences(s []string, needle string) int {
+	n := 0
+	for _, v := range s {
+		if v == needle {
+			n++
+		}
+	}
+	return n
+}

--- a/backend/tests/api/mac_host_pairing_test.go
+++ b/backend/tests/api/mac_host_pairing_test.go
@@ -71,7 +71,7 @@ func setupMacHostEnv(t *testing.T) *macHostTestEnv {
 	// bcrypt cost 4 is the lowest bcrypt accepts; the speed makes
 	// integration test execution tolerable while still exercising the
 	// real bcrypt path.
-	macService := service.NewMacHostService(hostRepo, tokenRepo, syncRepo, database.Pool, 4)
+	macService := service.NewMacHostService(hostRepo, tokenRepo, syncRepo, nil, database.Pool, 4)
 	limiter := auth.NewPairingIPRateLimiter()
 	macHandler := handlers.NewMacHostHandler(macService, limiter)
 

--- a/backend/tests/external_contact_soft_delete_sweep_test.go
+++ b/backend/tests/external_contact_soft_delete_sweep_test.go
@@ -1,0 +1,460 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// extSweepFixtures bundles two rows (live + tombstoned) plus the
+// repository so every audited read query can run a uniform assertion:
+// the live row is returned, the tombstoned row is not.
+type extSweepFixtures struct {
+	repo        *repository.ExternalContactRepository
+	live        *repository.ExternalContact
+	tombstoned  *repository.ExternalContact
+	matchingCRM uuid.UUID
+}
+
+// seedExtSweepFixtures inserts one live + one tombstoned external_contact row
+// sharing source / matching attributes (so every read query has a non-trivial
+// candidate set). The tombstoned row is created live then soft-deleted via
+// SoftDeleteTx. Cleanup uses prefix-hard-delete.
+func seedExtSweepFixtures(t *testing.T) *extSweepFixtures {
+	t.Helper()
+
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	ctx := context.Background()
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	t.Cleanup(func() { database.Close() })
+
+	repo := repository.NewExternalContactRepository(database.Queries)
+	contactRepo := repository.NewContactRepository(database.Queries)
+	contactRepo.SetPool(database.Pool)
+
+	// Unique prefix per test run so concurrent tests don't collide.
+	prefix := "sweep-" + uuid.NewString()[:8] + "-"
+
+	// Seed a CRM contact the live external_contact row links to. The
+	// ListForCRMContact assertion needs this association.
+	crm, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
+		FullName: "Sweep Test " + prefix,
+	})
+	require.NoError(t, err)
+
+	syncedAt := time.Now()
+	emailValue := "sweep-shared-" + prefix + "@example.invalid"
+	liveReq := repository.UpsertExternalContactRequest{
+		Source:   "gcontacts", // arbitrary; the soft-delete filter is source-agnostic
+		SourceID: prefix + "live",
+		Emails:   []repository.EmailEntry{{Value: emailValue}},
+		SyncedAt: &syncedAt,
+	}
+	live, err := repo.Upsert(ctx, liveReq)
+	require.NoError(t, err)
+	// Mark live row as matched so the per-CRM-contact + unmatched
+	// queries each see the expected partition.
+	matched, err := repo.UpdateMatch(ctx, live.ID, &crm.ID, repository.MatchStatusMatched)
+	require.NoError(t, err)
+	live = matched
+
+	tombReq := repository.UpsertExternalContactRequest{
+		Source:   "gcontacts",
+		SourceID: prefix + "tombstone",
+		Emails:   []repository.EmailEntry{{Value: emailValue}},
+		SyncedAt: &syncedAt,
+	}
+	tomb, err := repo.Upsert(ctx, tombReq)
+	require.NoError(t, err)
+	// Tombstone via SoftDeleteTx. Per .ai/rules/core.md we use the
+	// repository's sqlc-backed tx method, not raw SQL.
+	tx, err := database.Pool.Begin(ctx)
+	require.NoError(t, err)
+	require.NoError(t, repo.SoftDeleteTx(ctx, tx, tomb.ID))
+	require.NoError(t, tx.Commit(ctx))
+
+	// Re-fetch the tombstoned row via the tombstone-aware GetBySource
+	// so the test holds onto the post-soft-delete struct.
+	post, err := repo.GetBySource(ctx, "gcontacts", tombReq.SourceID, nil)
+	require.NoError(t, err)
+	require.NotNil(t, post)
+	require.NotNil(t, post.DeletedAt, "fixture must be tombstoned after SoftDeleteTx")
+	tomb = post
+
+	t.Cleanup(func() {
+		cleanCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		// Hard delete the rows we seeded (covers tombstoned + live).
+		_ = database.Queries.TestDeleteExternalContactsBySourceIDPrefix(cleanCtx, prefix)
+		_ = contactRepo.HardDeleteContact(cleanCtx, crm.ID)
+	})
+
+	return &extSweepFixtures{
+		repo:        repo,
+		live:        live,
+		tombstoned:  tomb,
+		matchingCRM: crm.ID,
+	}
+}
+
+func TestExternalContactSweep_GetByID_LiveRowReturned(t *testing.T) {
+	fx := seedExtSweepFixtures(t)
+	row, err := fx.repo.GetByID(context.Background(), fx.live.ID)
+	require.NoError(t, err)
+	require.NotNil(t, row)
+	require.Equal(t, fx.live.ID, row.ID)
+}
+
+func TestExternalContactSweep_GetByID_TombstonedRowAbsent(t *testing.T) {
+	fx := seedExtSweepFixtures(t)
+	row, err := fx.repo.GetByID(context.Background(), fx.tombstoned.ID)
+	require.NoError(t, err)
+	require.Nil(t, row, "GetByID must not return a tombstoned row through normal flows")
+}
+
+func TestExternalContactSweep_GetBySource_TombstoneAware(t *testing.T) {
+	fx := seedExtSweepFixtures(t)
+	// Live row reachable.
+	live, err := fx.repo.GetBySource(context.Background(), fx.live.Source, fx.live.SourceID, nil)
+	require.NoError(t, err)
+	require.NotNil(t, live)
+	require.Nil(t, live.DeletedAt)
+	// Tombstoned row INTENTIONALLY visible via GetBySource — the
+	// mac-daemon revive path depends on this. Callers that want
+	// live-only rows must filter on DeletedAt themselves.
+	tomb, err := fx.repo.GetBySource(context.Background(), fx.tombstoned.Source, fx.tombstoned.SourceID, nil)
+	require.NoError(t, err)
+	require.NotNil(t, tomb)
+	require.NotNil(t, tomb.DeletedAt)
+}
+
+func TestExternalContactSweep_FindBySourceAndSourceID_FiltersTombstone(t *testing.T) {
+	fx := seedExtSweepFixtures(t)
+	// Use the tombstoned row's source_id; FindBySourceAndSourceID is
+	// the rematch query and must NEVER return a tombstoned candidate.
+	results, err := fx.repo.FindBySourceAndSourceID(
+		context.Background(), fx.tombstoned.Source, fx.tombstoned.SourceID)
+	require.NoError(t, err)
+	for _, r := range results {
+		require.NotEqual(t, fx.tombstoned.ID, r.ID, "rematch must not surface a tombstoned candidate")
+	}
+}
+
+func TestExternalContactSweep_ListUnmatched_FiltersTombstone(t *testing.T) {
+	// Re-seed but with both rows unmatched so the predicate fires.
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+	ctx := context.Background()
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	t.Cleanup(func() { database.Close() })
+
+	repo := repository.NewExternalContactRepository(database.Queries)
+	prefix := "sweep-unm-" + uuid.NewString()[:8] + "-"
+	syncedAt := time.Now()
+
+	live, err := repo.Upsert(ctx, repository.UpsertExternalContactRequest{
+		Source:   "gcontacts",
+		SourceID: prefix + "live",
+		SyncedAt: &syncedAt,
+	})
+	require.NoError(t, err)
+	tomb, err := repo.Upsert(ctx, repository.UpsertExternalContactRequest{
+		Source:   "gcontacts",
+		SourceID: prefix + "tomb",
+		SyncedAt: &syncedAt,
+	})
+	require.NoError(t, err)
+	tx, err := database.Pool.Begin(ctx)
+	require.NoError(t, err)
+	require.NoError(t, repo.SoftDeleteTx(ctx, tx, tomb.ID))
+	require.NoError(t, tx.Commit(ctx))
+	t.Cleanup(func() {
+		cleanCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_ = database.Queries.TestDeleteExternalContactsBySourceIDPrefix(cleanCtx, prefix)
+	})
+
+	listed, err := repo.ListUnmatched(ctx, "gcontacts", 1000, 0)
+	require.NoError(t, err)
+	foundLive := false
+	for _, r := range listed {
+		if r.ID == tomb.ID {
+			t.Fatalf("ListUnmatched must not return tombstoned row")
+		}
+		if r.ID == live.ID {
+			foundLive = true
+		}
+	}
+	require.True(t, foundLive, "ListUnmatched must return the live row")
+}
+
+func TestExternalContactSweep_ListAllUnmatched_FiltersTombstone(t *testing.T) {
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+	ctx := context.Background()
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	t.Cleanup(func() { database.Close() })
+
+	repo := repository.NewExternalContactRepository(database.Queries)
+	prefix := "sweep-allunm-" + uuid.NewString()[:8] + "-"
+	syncedAt := time.Now()
+	live, err := repo.Upsert(ctx, repository.UpsertExternalContactRequest{
+		Source: "gcontacts", SourceID: prefix + "live", SyncedAt: &syncedAt,
+	})
+	require.NoError(t, err)
+	tomb, err := repo.Upsert(ctx, repository.UpsertExternalContactRequest{
+		Source: "gcontacts", SourceID: prefix + "tomb", SyncedAt: &syncedAt,
+	})
+	require.NoError(t, err)
+	tx, err := database.Pool.Begin(ctx)
+	require.NoError(t, err)
+	require.NoError(t, repo.SoftDeleteTx(ctx, tx, tomb.ID))
+	require.NoError(t, tx.Commit(ctx))
+	t.Cleanup(func() {
+		cleanCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_ = database.Queries.TestDeleteExternalContactsBySourceIDPrefix(cleanCtx, prefix)
+	})
+
+	listed, err := repo.ListAllUnmatched(ctx, 1000, 0)
+	require.NoError(t, err)
+	foundLive := false
+	for _, r := range listed {
+		if r.ID == tomb.ID {
+			t.Fatalf("ListAllUnmatched must not return tombstoned row")
+		}
+		if r.ID == live.ID {
+			foundLive = true
+		}
+	}
+	require.True(t, foundLive)
+}
+
+func TestExternalContactSweep_CountUnmatched_ExcludesTombstone(t *testing.T) {
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+	ctx := context.Background()
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	t.Cleanup(func() { database.Close() })
+
+	repo := repository.NewExternalContactRepository(database.Queries)
+	// Use a unique source per-run so counts are bounded.
+	source := "sweep-src-" + strings.ReplaceAll(uuid.NewString()[:8], "-", "")
+	prefix := "sweep-cnt-" + uuid.NewString()[:8] + "-"
+	syncedAt := time.Now()
+	_, err = repo.Upsert(ctx, repository.UpsertExternalContactRequest{
+		Source: source, SourceID: prefix + "live-a", SyncedAt: &syncedAt,
+	})
+	require.NoError(t, err)
+	_, err = repo.Upsert(ctx, repository.UpsertExternalContactRequest{
+		Source: source, SourceID: prefix + "live-b", SyncedAt: &syncedAt,
+	})
+	require.NoError(t, err)
+	tomb, err := repo.Upsert(ctx, repository.UpsertExternalContactRequest{
+		Source: source, SourceID: prefix + "tomb", SyncedAt: &syncedAt,
+	})
+	require.NoError(t, err)
+	tx, err := database.Pool.Begin(ctx)
+	require.NoError(t, err)
+	require.NoError(t, repo.SoftDeleteTx(ctx, tx, tomb.ID))
+	require.NoError(t, tx.Commit(ctx))
+	t.Cleanup(func() {
+		cleanCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_ = database.Queries.TestDeleteExternalContactsBySourceIDPrefix(cleanCtx, prefix)
+	})
+
+	count, err := repo.CountUnmatched(ctx, source)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), count, "tombstoned row must not be counted")
+}
+
+func TestExternalContactSweep_FindByNormalizedEmail_FiltersTombstone(t *testing.T) {
+	fx := seedExtSweepFixtures(t)
+	// The seed planted the same email on both rows. The matched (live)
+	// row's email is at index 0.
+	require.NotEmpty(t, fx.live.Emails)
+	target := fx.live.Emails[0].Value
+	results, err := fx.repo.FindByNormalizedEmail(context.Background(), target)
+	require.NoError(t, err)
+	for _, r := range results {
+		require.NotEqual(t, fx.tombstoned.ID, r.ID, "duplicate-email lookup must skip tombstoned rows")
+	}
+}
+
+func TestExternalContactSweep_ListForCRMContact_FiltersTombstone(t *testing.T) {
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+	ctx := context.Background()
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	t.Cleanup(func() { database.Close() })
+
+	repo := repository.NewExternalContactRepository(database.Queries)
+	contactRepo := repository.NewContactRepository(database.Queries)
+	contactRepo.SetPool(database.Pool)
+	prefix := "sweep-crm-" + uuid.NewString()[:8] + "-"
+	syncedAt := time.Now()
+
+	crm, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: "Sweep CRM " + prefix})
+	require.NoError(t, err)
+
+	live, err := repo.Upsert(ctx, repository.UpsertExternalContactRequest{
+		Source: "gcontacts", SourceID: prefix + "live", SyncedAt: &syncedAt,
+	})
+	require.NoError(t, err)
+	_, err = repo.UpdateMatch(ctx, live.ID, &crm.ID, repository.MatchStatusMatched)
+	require.NoError(t, err)
+	tomb, err := repo.Upsert(ctx, repository.UpsertExternalContactRequest{
+		Source: "gcontacts", SourceID: prefix + "tomb", SyncedAt: &syncedAt,
+	})
+	require.NoError(t, err)
+	_, err = repo.UpdateMatch(ctx, tomb.ID, &crm.ID, repository.MatchStatusMatched)
+	require.NoError(t, err)
+	tx, err := database.Pool.Begin(ctx)
+	require.NoError(t, err)
+	require.NoError(t, repo.SoftDeleteTx(ctx, tx, tomb.ID))
+	require.NoError(t, tx.Commit(ctx))
+	t.Cleanup(func() {
+		cleanCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_ = database.Queries.TestDeleteExternalContactsBySourceIDPrefix(cleanCtx, prefix)
+		_ = contactRepo.HardDeleteContact(cleanCtx, crm.ID)
+	})
+
+	results, err := repo.ListForCRMContact(ctx, crm.ID)
+	require.NoError(t, err)
+	require.Len(t, results, 1, "tombstoned external_contact must not surface in ListForCRMContact")
+	require.Equal(t, live.ID, results[0].ID)
+}
+
+func TestExternalContactSweep_RoundTrip_ReviveAfterSoftDelete(t *testing.T) {
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+	ctx := context.Background()
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	t.Cleanup(func() { database.Close() })
+
+	repo := repository.NewExternalContactRepository(database.Queries)
+	contactRepo := repository.NewContactRepository(database.Queries)
+	contactRepo.SetPool(database.Pool)
+	prefix := "sweep-rt-" + uuid.NewString()[:8] + "-"
+	syncedAt := time.Now()
+
+	crm, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: "RT " + prefix})
+	require.NoError(t, err)
+	row, err := repo.Upsert(ctx, repository.UpsertExternalContactRequest{
+		Source: "icloud_contacts", SourceID: prefix + "live", SyncedAt: &syncedAt,
+	})
+	require.NoError(t, err)
+	_, err = repo.UpdateMatch(ctx, row.ID, &crm.ID, repository.MatchStatusMatched)
+	require.NoError(t, err)
+	tx, err := database.Pool.Begin(ctx)
+	require.NoError(t, err)
+	require.NoError(t, repo.SoftDeleteTx(ctx, tx, row.ID))
+	require.NoError(t, tx.Commit(ctx))
+	t.Cleanup(func() {
+		cleanCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_ = database.Queries.TestDeleteExternalContactsBySourceIDPrefix(cleanCtx, prefix)
+		_ = contactRepo.HardDeleteContact(cleanCtx, crm.ID)
+	})
+
+	tombstoned, err := repo.GetBySource(ctx, "icloud_contacts", row.SourceID, nil)
+	require.NoError(t, err)
+	require.NotNil(t, tombstoned)
+	require.NotNil(t, tombstoned.DeletedAt)
+	preservedCRM := tombstoned.CRMContactID
+	preservedStatus := tombstoned.MatchStatus
+
+	// Revive.
+	tx, err = database.Pool.Begin(ctx)
+	require.NoError(t, err)
+	revived, err := repo.ReviveTx(ctx, tx, tombstoned.ID)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit(ctx))
+	require.NotNil(t, revived)
+	require.Nil(t, revived.DeletedAt)
+	require.Equal(t, preservedCRM, revived.CRMContactID, "revive must preserve crm_contact_id")
+	require.Equal(t, preservedStatus, revived.MatchStatus, "revive must preserve match_status")
+}
+
+func TestExternalContactSweep_GetByID_AccountIDNullSemantics(t *testing.T) {
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+	ctx := context.Background()
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	t.Cleanup(func() { database.Close() })
+
+	repo := repository.NewExternalContactRepository(database.Queries)
+	prefix := "sweep-acct-" + uuid.NewString()[:8] + "-"
+	syncedAt := time.Now()
+
+	// account_id = NULL (icloud_contacts shape).
+	_, err = repo.Upsert(ctx, repository.UpsertExternalContactRequest{
+		Source: "icloud_contacts", SourceID: prefix + "x", SyncedAt: &syncedAt,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		cleanCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_ = database.Queries.TestDeleteExternalContactsBySourceIDPrefix(cleanCtx, prefix)
+	})
+
+	// Lookup with accountID=nil must find the row.
+	found, err := repo.GetBySource(ctx, "icloud_contacts", prefix+"x", nil)
+	require.NoError(t, err)
+	require.NotNil(t, found)
+	require.Nil(t, found.AccountID)
+
+	// Lookup with accountID="some-acct" must NOT find the same row.
+	otherAcct := "some-acct"
+	notFound, err := repo.GetBySource(ctx, "icloud_contacts", prefix+"x", &otherAcct)
+	require.NoError(t, err)
+	require.Nil(t, notFound, "GetBySource with a non-null accountID must not match a NULL-account row")
+}

--- a/backend/tests/external_contact_soft_delete_sweep_test.go
+++ b/backend/tests/external_contact_soft_delete_sweep_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"personal-crm/backend/internal/accelerated"
 	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/repository"
@@ -58,7 +59,7 @@ func seedExtSweepFixtures(t *testing.T) *extSweepFixtures {
 	})
 	require.NoError(t, err)
 
-	syncedAt := time.Now()
+	syncedAt := accelerated.GetCurrentTime()
 	emailValue := "sweep-shared-" + prefix + "@example.invalid"
 	liveReq := repository.UpsertExternalContactRequest{
 		Source:   "gcontacts", // arbitrary; the soft-delete filter is source-agnostic
@@ -171,7 +172,7 @@ func TestExternalContactSweep_ListUnmatched_FiltersTombstone(t *testing.T) {
 
 	repo := repository.NewExternalContactRepository(database.Queries)
 	prefix := "sweep-unm-" + uuid.NewString()[:8] + "-"
-	syncedAt := time.Now()
+	syncedAt := accelerated.GetCurrentTime()
 
 	live, err := repo.Upsert(ctx, repository.UpsertExternalContactRequest{
 		Source:   "gcontacts",
@@ -223,7 +224,7 @@ func TestExternalContactSweep_ListAllUnmatched_FiltersTombstone(t *testing.T) {
 
 	repo := repository.NewExternalContactRepository(database.Queries)
 	prefix := "sweep-allunm-" + uuid.NewString()[:8] + "-"
-	syncedAt := time.Now()
+	syncedAt := accelerated.GetCurrentTime()
 	live, err := repo.Upsert(ctx, repository.UpsertExternalContactRequest{
 		Source: "gcontacts", SourceID: prefix + "live", SyncedAt: &syncedAt,
 	})
@@ -272,7 +273,7 @@ func TestExternalContactSweep_CountUnmatched_ExcludesTombstone(t *testing.T) {
 	// Use a unique source per-run so counts are bounded.
 	source := "sweep-src-" + strings.ReplaceAll(uuid.NewString()[:8], "-", "")
 	prefix := "sweep-cnt-" + uuid.NewString()[:8] + "-"
-	syncedAt := time.Now()
+	syncedAt := accelerated.GetCurrentTime()
 	_, err = repo.Upsert(ctx, repository.UpsertExternalContactRequest{
 		Source: source, SourceID: prefix + "live-a", SyncedAt: &syncedAt,
 	})
@@ -329,7 +330,7 @@ func TestExternalContactSweep_ListForCRMContact_FiltersTombstone(t *testing.T) {
 	contactRepo := repository.NewContactRepository(database.Queries)
 	contactRepo.SetPool(database.Pool)
 	prefix := "sweep-crm-" + uuid.NewString()[:8] + "-"
-	syncedAt := time.Now()
+	syncedAt := accelerated.GetCurrentTime()
 
 	crm, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: "Sweep CRM " + prefix})
 	require.NoError(t, err)
@@ -379,7 +380,7 @@ func TestExternalContactSweep_RoundTrip_ReviveAfterSoftDelete(t *testing.T) {
 	contactRepo := repository.NewContactRepository(database.Queries)
 	contactRepo.SetPool(database.Pool)
 	prefix := "sweep-rt-" + uuid.NewString()[:8] + "-"
-	syncedAt := time.Now()
+	syncedAt := accelerated.GetCurrentTime()
 
 	crm, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: "RT " + prefix})
 	require.NoError(t, err)
@@ -433,7 +434,7 @@ func TestExternalContactSweep_GetByID_AccountIDNullSemantics(t *testing.T) {
 
 	repo := repository.NewExternalContactRepository(database.Queries)
 	prefix := "sweep-acct-" + uuid.NewString()[:8] + "-"
-	syncedAt := time.Now()
+	syncedAt := accelerated.GetCurrentTime()
 
 	// account_id = NULL (icloud_contacts shape).
 	_, err = repo.Upsert(ctx, repository.UpsertExternalContactRequest{


### PR DESCRIPTION
## Summary

PR5 of Mac daemon Phase 1. Lands the iCloud Contacts data path on the Pi:
- Two daemon-emitted event kinds (`external_contact.upserted`, `external_contact.deleted`) with typed payloads, registered in `kindPayloadTypes` + `AllKinds`.
- Inline ingest handlers inside the existing per-event savepoint pattern (no bus consumer, no River jobs). The handlers identity-match per (email, phone), preserve match state on re-upsert / revive, and silently no-op on unknown / already-tombstoned delete events while preserving the event-log audit row.
- `external_contact.deleted_at` schema (migration 050) with two deleted_at-gated partial indexes, plus a comprehensive soft-delete sweep across the SQL surface — all read queries filter `deleted_at IS NULL` (`GetExternalContactBySource` intentionally remains tombstone-aware so the inline handler can revive); the three id-keyed write queries (`UpdateExternalContactMatch`, `UpdateExternalContactDuplicate`, `IgnoreExternalContact`) also filter `deleted_at IS NULL` so a tombstoned row cannot have its match state mutated.
- New tx-bound repository methods: `GetBySourceTx`, `UpsertTx`, `UpdateMatchTx`, `ReviveTx`, `SoftDeleteTx`.
- `GET /api/v1/host/:id/known-identifiers` endpoint body: cross-source canonical phone + email set, distinct + alphabetically sorted, scoped to non-deleted contacts. Backed by a new `ListCanonicalIdentifiersByType` sqlc query.
- `icloud_contacts` push provider stub registered alongside `messages`.
- Comprehensive unit + integration test coverage including a savepoint-rollback test driven by a stub that errors at `UpdateMatchTx`.

Plan: `.ai/log/plan/mac-daemon-phase-1-pr5-external-contact-events-and-known-identifiers.md`
Issue: #73

## Review history

- The Claude Code Review CI step caught two findings (PR-citation comments + duplicate `isHostAuthAllowedKind`/`isHostOnlyKind` helpers); both addressed.
- Local Codex adversarial review (xhigh) ran on the post-Claude branch and produced one P1 (response-shape concern — see "Disputed Codex findings" below) plus six P2 findings; the genuine P2s were addressed in this PR. See "Codex review fixes" for the per-finding accounting.
- The CI `Codex Review` workflow on this repo is **not in use** — the corresponding job shows `skipping` because the workflow is gated off at the path/config level, not because of a deferred run. Earlier PR-description copy that claimed "the CI Codex reviewer will fire on PR open" was incorrect and has been replaced.

## Codex review fixes

- **Revive race (P2):** `handleExternalContactUpserted` now reads `deleted_at` from BOTH the pre-read AND the post-upsert returned row. A delete that commits between the pre-read and the upsert previously left the row tombstoned because `wasTombstoned=false`. Fix: `needsRevive := wasTombstoned || (external != nil && external.DeletedAt != nil)`.
- **Race guard expanded (P2):** the first-insert match-flip gate now requires `firstInsert && CRMContactID == nil && MatchStatus == unmatched && DuplicateOfID == nil`. The earlier guard only checked `CRMContactID == nil` and could clobber a user's manually-resolved `imported` / `ignored` decision or overwrite a `duplicate_of_id` link in the concurrent-INSERT race window.
- **Payload version envelope (P2):** added handler-side version validation for `external_contact.*` mirroring the raw_message path. Zero/missing → `PAYLOAD_INVALID` with a "version must be >=1" message; future version → "upgrade Pi" message.
- **Soft-delete write-path sweep (P2):** `UpdateExternalContactMatch`, `UpdateExternalContactDuplicate`, `IgnoreExternalContact` now filter `WHERE id = $1 AND deleted_at IS NULL`. The repository's `UpdateMatch` / `UpdateMatchTx` translate `pgx.ErrNoRows` → `db.ErrNotFound` so callers can detect the "row is tombstoned" case if needed.
- **Savepoint-rollback test (P2):** new integration test (`backend/tests/api/external_contact_savepoint_rollback_test.go`) injects a `failingMatchExternalContactWriter` that errors at `UpdateMatchTx`. Asserts (1) no `external_contact` row materializes; (2) no event-log row persists (Bus.PublishTx runs inside the same savepoint).
- **"Step N" scaffolding (P3):** dropped from the new `handleExternalContactUpserted` body. The pre-existing "Step 1...Step 6" labels in the outer `IngestBatch` loop are PR4 scope and left for a future cleanup PR.

## Disputed Codex findings

- **P1 — "/known-identifiers wraps the response in `{success, data}`":** the spec uses `{phones, emails}` as shorthand for the *data* portion of the standard envelope; every other Mac-host endpoint in the file (Pair, Heartbeat, GetCursor, KnownIDs stub, admin endpoints) uses the same `api.SendSuccess` wrapper. The daemon (Swift, in a sibling project) is built around this envelope across all endpoints. Changing this endpoint alone would be inconsistent. The integration test locks in the wrapper. Not fixed — defended as intentional.
- **"All eight commits unsigned":** false positive. `git log --format='%h %G?'` reports `G` (good signature) for every commit on the branch — Codex appears to have run with a trust config that didn't recognize the signing key.

## Autonomous Decisions

Implemented overnight under explicit user authorization. The planner's 15 documented judgment calls are respected. Additional implementer-side decisions:

- **Constructor signature changes** to `service.NewMacHostService` and `service.NewIngestService` (positional `contactMethodRepo` + `externalContacts` deps). All call sites in `cmd/crm-api/main.go` + 3 integration test setups updated. Options-struct refactor rejected as out-of-scope churn for a single new dep.
- **Rejection code rename:** `RAW_MESSAGE_REQUIRES_HOST_AUTH` → `HOST_ONLY_REQUIRES_HOST_AUTH`. The set is no longer raw-message-only.
- **Helper consolidation:** `isHostAuthAllowedKind` collapsed into `isHostOnlyKind` after the Claude reviewer correctly flagged the duplicate.
- **`buildUpsertExternalContactParams` helper** extracted from `Upsert` so `UpsertTx` shares the pgtype + JSONB conversion. Mirrors the `buildUpsertMessagesMessageParams` pattern.
- **`ExternalContactRepository` reuse in main.go:** the IngestService is wired before the `EnableExternalSync` block, so the repo is constructed at outer scope and the `EnableExternalSync` block re-uses that instance.
- **E2E smoke test for `/known-identifiers` skipped:** the Go integration test exercises the full composite-auth router + JSON shape. Playwright fixtures for the host-bearer auth path would require non-trivial test seeding and the endpoint has no UI to dogfood.

## Test plan

- [x] `make sqlc` regenerates cleanly
- [x] `go build ./...` passes
- [x] `make lint` passes
- [x] `make test-unit` passes
- [x] `make test-integration` passes (all new tests + no regressions)
- [x] `make test-frontend` passes (260 tests)
- [x] `make test-e2e-diff` passes (82 chromium tests)
- [x] Migration 050 applies cleanly to a fresh test DB
- [x] Soft-delete sweep test exercises every audited READ query path; write-path sweep proven by `UpdateMatchTx` returning `db.ErrNotFound` on a tombstoned target
- [x] `/known-identifiers` integration test covers auth, dedup, sort, soft-deleted exclusion, type filtering, empty-host
- [x] External contact ingest integration test covers first-insert (no match + email match), re-upsert preserves match state, tombstone revive (incl. concurrent-delete-between-pre-read-and-upsert race), delete sets deleted_at, unknown-entity delete is no-op (event-log durable), idempotent re-delete, content-hash dedup, host-only auth rejection, host mismatch, unsupported source, malformed source_id, version=0 rejected, version=999 rejected
- [x] Savepoint rollback test: failure mid-handler rolls back external_contact row + event-log row
