### PR TITLE
fix(ingest): host-scope external_contact.deleted (closes #310)

### DIFF
--- a/backend/internal/service/ingest.go
+++ b/backend/internal/service/ingest.go
@@ -976,7 +976,7 @@ func (s *IngestService) handleExternalContactDeleted(
 	ctx context.Context,
 	tx pgx.Tx,
 	env *events.Envelope,
-	_ uuid.UUID,
+	authenticatedHostID uuid.UUID,
 ) *IngestPerEventRejection {
 	if s.externalContacts == nil {
 		return &IngestPerEventRejection{
@@ -1004,6 +1004,16 @@ func (s *IngestService) handleExternalContactDeleted(
 	}
 	if prior == nil || prior.DeletedAt != nil {
 		// Already tombstoned. Idempotent no-op.
+		return nil
+	}
+	// Host-scope guard: don't let host B tombstone a row owned by host A.
+	// The payload-host check in commonExternalContactInvariants only verifies
+	// the daemon's own claim; this check verifies the stored row's owner.
+	// NULL prior.HostID = legacy row (pre-migration 052 or non-mac source)
+	// → pass through so the self-heal-on-upsert path keeps working.
+	// Silent no-op (not a rejection) so a stranded post-re-pair delete in
+	// the daemon's event queue doesn't stall the cursor.
+	if prior.HostID != nil && *prior.HostID != authenticatedHostID {
 		return nil
 	}
 	// Validate the source_id hash suffix against the row's stored

--- a/backend/internal/service/ingest.go
+++ b/backend/internal/service/ingest.go
@@ -1009,11 +1009,19 @@ func (s *IngestService) handleExternalContactDeleted(
 	// Host-scope guard: don't let host B tombstone a row owned by host A.
 	// The payload-host check in commonExternalContactInvariants only verifies
 	// the daemon's own claim; this check verifies the stored row's owner.
-	// NULL prior.HostID = legacy row (pre-migration 052 or non-mac source)
-	// → pass through so the self-heal-on-upsert path keeps working.
+	// NULL prior.HostID = legacy row (pre-migration 052 or non-mac source);
+	// pass through so the self-heal-on-upsert path keeps working.
 	// Silent no-op (not a rejection) so a stranded post-re-pair delete in
-	// the daemon's event queue doesn't stall the cursor.
+	// the daemon's event queue doesn't stall the cursor; warn-log so the
+	// operator has a breadcrumb when this fires (hypothetical today;
+	// realistic if a second Mac is ever paired).
 	if prior.HostID != nil && *prior.HostID != authenticatedHostID {
+		logger.Warn().
+			Str("source", env.Source).
+			Str("entity_id", p.EntityID).
+			Str("prior_host_id", prior.HostID.String()).
+			Str("authenticated_host_id", authenticatedHostID.String()).
+			Msg("external_contact.deleted dropped: row owned by a different host")
 		return nil
 	}
 	// Validate the source_id hash suffix against the row's stored

--- a/backend/internal/service/ingest_test.go
+++ b/backend/internal/service/ingest_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"personal-crm/backend/internal/accelerated"
@@ -689,6 +690,39 @@ func TestHandleExternalContactDeleted_NullStoredHashAccepted(t *testing.T) {
 	}
 	rej := svc.handleExternalContactDeleted(context.Background(), nil, env, uuid.UUID{})
 	require.Nil(t, rej, "legacy row with NULL stored hash must accept any delete hash")
+}
+
+// TestHandleExternalContactDeleted_CrossHostNoOp proves the host-scope
+// guard: when prior.HostID != authenticatedHostID, the handler returns
+// nil (silent no-op) without calling SoftDeleteTx. softDelErr is set to
+// a sentinel; if the guard didn't fire, that error would surface as a
+// rejection.
+func TestHandleExternalContactDeleted_CrossHostNoOp(t *testing.T) {
+	hostA := uuid.New()
+	hostB := uuid.New()
+	storedHash := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	storedRow := &repository.ExternalContact{
+		ID:              uuid.New(),
+		Source:          "icloud_contacts",
+		SourceID:        "CN-xhost",
+		HostID:          &hostA,
+		LastContentHash: &storedHash,
+	}
+	stubExt := &stubExternalContactWriter{
+		getResp:    storedRow,
+		softDelErr: errors.New("SoftDeleteTx must not be called"),
+	}
+	svc := &IngestService{externalContacts: stubExt}
+	env := &events.Envelope{
+		Source:   "icloud_contacts",
+		SourceID: "CN-xhost@deleted@" + storedHash,
+		Kind:     events.KindExternalContactDeleted,
+		Payload: mustMarshalExtDelete(events.ExternalContactDeletedPayload{
+			Version: 1, HostID: hostB, Source: "icloud_contacts", EntityID: "CN-xhost",
+		}),
+	}
+	rej := svc.handleExternalContactDeleted(context.Background(), nil, env, hostB)
+	require.Nil(t, rej, "cross-host delete must be a silent no-op")
 }
 
 // recordingExternalContactWriter wraps stubExternalContactWriter to

--- a/backend/tests/api/external_contact_ingest_test.go
+++ b/backend/tests/api/external_contact_ingest_test.go
@@ -504,6 +504,91 @@ func TestIngestExternalContact_Deleted_AlreadyTombstoned_NoOp(t *testing.T) {
 		"second delete must not bump deleted_at on an already-tombstoned row")
 }
 
+func TestIngestExternalContact_Deleted_CrossHost_NoOp(t *testing.T) {
+	env := setupExtContactIngestEnv(t)
+	ctx := context.Background()
+	entityID := env.sourceIDPrefix + "cross-host-delete"
+
+	// Host A (the env's paired host) creates the row.
+	hostA := env.pairedHostID
+	upEv := buildExtUpsertEvent(t, hostA, entityID, nil)
+	w := postIngestExt(t, env, &hostA, env.pairedHostKey, map[string]any{
+		"events": []any{upEv},
+	})
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, 1, parseIngestResp(t, w).Accepted)
+	rowBefore := findExtRow(t, env, entityID)
+	require.NotNil(t, rowBefore)
+	require.Nil(t, rowBefore.DeletedAt)
+	require.NotNil(t, rowBefore.HostID)
+	require.Equal(t, hostA, *rowBefore.HostID, "row must be owned by host A")
+
+	// Revoke A so B can pair (idx_mac_host_singleton allows one active host).
+	require.NoError(t, env.macService.RevokeHost(ctx, hostA))
+
+	// Pair host B.
+	plainB, _, err := env.macService.CreatePairingToken(ctx)
+	require.NoError(t, err)
+	pairB, err := env.macService.PairWithToken(ctx, plainB, "host-b-delete", "0.1.0", 1)
+	require.NoError(t, err)
+
+	// Host B emits a delete for host A's row. Uses the @unknown sentinel,
+	// which is the realistic post-re-pair shape (B's daemon has no local
+	// cache of A's prior content hash).
+	delEv := buildExtDeleteEvent(t, pairB.HostID, entityID)
+	w = postIngestExt(t, env, &pairB.HostID, pairB.APIKey, map[string]any{
+		"events": []any{delEv},
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseIngestResp(t, w)
+	require.Equal(t, 1, resp.Accepted, "cross-host delete is a silent no-op, counted as accepted")
+	require.Equal(t, 0, resp.Rejected, "errors: %+v", resp.Errors)
+
+	// Row must remain live — host B cannot tombstone a row owned by A.
+	rowAfter := findExtRow(t, env, entityID)
+	require.NotNil(t, rowAfter, "row must still exist")
+	require.Nil(t, rowAfter.DeletedAt, "cross-host delete must NOT tombstone the row")
+	require.NotNil(t, rowAfter.HostID)
+	require.Equal(t, hostA, *rowAfter.HostID, "host ownership unchanged")
+}
+
+func TestIngestExternalContact_Deleted_LegacyNullHost_SoftDeletes(t *testing.T) {
+	env := setupExtContactIngestEnv(t)
+	ctx := context.Background()
+	entityID := env.sourceIDPrefix + "legacy-null-host-delete"
+
+	// Seed a row directly with NULL host_id (simulates pre-migration-052
+	// rows, or rows from sources that don't set host_id).
+	sourceID := entityID
+	syncedAt := accelerated.GetCurrentTime()
+	tx, err := env.database.Pool.Begin(ctx)
+	require.NoError(t, err)
+	_, err = env.externalRepo.UpsertTx(ctx, tx, repository.UpsertExternalContactRequest{
+		Source:   "icloud_contacts",
+		SourceID: sourceID,
+		HostID:   nil, // legacy NULL
+		SyncedAt: &syncedAt,
+	})
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit(ctx))
+
+	// The currently-paired host emits a delete for the legacy row.
+	delEv := buildExtDeleteEvent(t, env.pairedHostID, entityID)
+	w := postIngestExt(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{delEv},
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseIngestResp(t, w)
+	require.Equal(t, 1, resp.Accepted)
+	require.Equal(t, 0, resp.Rejected, "errors: %+v", resp.Errors)
+
+	// NULL prior.HostID must pass through the host-scope guard so the
+	// existing soft-delete path keeps working.
+	row := findExtRow(t, env, entityID)
+	require.NotNil(t, row)
+	require.NotNil(t, row.DeletedAt, "NULL-host_id row must still be soft-deletable")
+}
+
 func TestIngestExternalContact_Upserted_DuplicateContentHash_DedupSkipsHandler(t *testing.T) {
 	env := setupExtContactIngestEnv(t)
 	entityID := env.sourceIDPrefix + "dedup"

--- a/backend/tests/api/external_contact_ingest_test.go
+++ b/backend/tests/api/external_contact_ingest_test.go
@@ -583,7 +583,10 @@ func TestIngestExternalContact_Deleted_LegacyNullHost_SoftDeletes(t *testing.T) 
 	require.Equal(t, 0, resp.Rejected, "errors: %+v", resp.Errors)
 
 	// NULL prior.HostID must pass through the host-scope guard so the
-	// existing soft-delete path keeps working.
+	// existing soft-delete path keeps working. Note: this assertion holds
+	// both with AND without the fix (the guard's `prior.HostID != nil`
+	// check short-circuits on NULL). The test exists as a forward-looking
+	// guard against a future regression that drops NULL through the guard.
 	row := findExtRow(t, env, entityID)
 	require.NotNil(t, row)
 	require.NotNil(t, row.DeletedAt, "NULL-host_id row must still be soft-deletable")


### PR DESCRIPTION
Closes #310.

## Summary

`handleExternalContactDeleted` was ignoring its `authenticatedHostID` parameter — a paired host could tombstone any `external_contact` row matching `(source, source_id)` regardless of which host actually owned it. The `commonExternalContactInvariants` check only verifies the daemon's own claim (`payload.host_id == authenticated host`), which is necessary but not sufficient to authorize a delete.

Adds a host-scope guard after the prior-row read:

```go
if prior.HostID != nil && *prior.HostID != authenticatedHostID {
    logger.Warn().…Msg("external_contact.deleted dropped: row owned by a different host")
    return nil
}
```

## Behavior

| Case | Before | After |
|---|---|---|
| Host B deletes a row owned by host A | Tombstoned | Silent no-op + warn-log |
| Host B deletes a row B itself owns | Tombstoned | Tombstoned (unchanged) |
| Any host deletes a NULL-`host_id` legacy row | Tombstoned | Tombstoned (unchanged) |

Silent no-op (not a rejection) so a stranded post-re-pair delete in the daemon's event queue doesn't stall the cursor. The warn-log gives the operator a breadcrumb when this fires.

## Tests

Three new tests covering the issue's acceptance criteria:

- **Unit:** `TestHandleExternalContactDeleted_CrossHostNoOp` — uses `softDelErr` as a sentinel; if the guard didn't fire, `SoftDeleteTx` would surface the error as a rejection. Verifies the guard runs before the hash check (codepath ordering).
- **Integration:** `TestIngestExternalContact_Deleted_CrossHost_NoOp` — pairs host B after revoking host A, sends a delete from B for A's row, asserts the row stays live.
- **Integration:** `TestIngestExternalContact_Deleted_LegacyNullHost_SoftDeletes` — forward-looking regression guard that the NULL-`host_id` pass-through keeps working.

Red-test sanity check: stashed the fix, re-ran the cross-host integration test — confirmed it tombstoned the row without the guard.

## Risk

Today: none (single-host operation). If a second Mac is ever paired: closes the cross-host delete authorization gap surfaced by adversarial review of PR8a.

## Self-review

Ran `/review-head` on cc63a7d before pushing; addressed both P2 findings in the follow-up commit b874f38 (warn-log + honest comment on the legacy-NULL test). Two P3s remain documented and deferred:

- Em-dash style nit in the inline comment.
- Integration variant for cross-host delete with a hash-matching (non-`@unknown`) source_id — already covered by the unit test, deferred until multi-host actually ships.

## Test plan

- [x] `make test-unit` passes
- [x] `make test-integration` passes (focused: all `TestIngestExternalContact_Deleted_*`; full suite passed in pre-push)
- [x] `make test-frontend` passes
- [x] `make test-e2e-diff` passes