### PR TITLE
fix(mac-daemon): locale-stable CN label normalization (closes #312)

### DIFF
--- a/mac-daemon/Scripts/probe_cn_labels.swift
+++ b/mac-daemon/Scripts/probe_cn_labels.swift
@@ -1,0 +1,39 @@
+#!/usr/bin/env swift
+// probe_cn_labels.swift — confirm the values in
+// CNContactStoreReader.stableLabelMap still coincide with what
+// `CNLabeledValue.localizedString(forLabel:)` returns under the
+// host's current locale. Run when you suspect drift, or before
+// adding a new entry to the map.
+//
+// Run:  swift mac-daemon/Scripts/probe_cn_labels.swift
+//
+// The script does NOT change anything — it just prints
+// `constant  -> localized`. Compare to the map by eye.
+
+import Contacts
+import Foundation
+
+let constants: [(String, String)] = [
+    ("CNLabelHome",                    CNLabelHome),
+    ("CNLabelWork",                    CNLabelWork),
+    ("CNLabelSchool",                  CNLabelSchool),
+    ("CNLabelOther",                   CNLabelOther),
+    ("CNLabelEmailiCloud",             CNLabelEmailiCloud),
+    ("CNLabelPhoneNumberiPhone",       CNLabelPhoneNumberiPhone),
+    ("CNLabelPhoneNumberMobile",       CNLabelPhoneNumberMobile),
+    ("CNLabelPhoneNumberMain",         CNLabelPhoneNumberMain),
+    ("CNLabelPhoneNumberHomeFax",      CNLabelPhoneNumberHomeFax),
+    ("CNLabelPhoneNumberWorkFax",      CNLabelPhoneNumberWorkFax),
+    ("CNLabelPhoneNumberOtherFax",     CNLabelPhoneNumberOtherFax),
+    ("CNLabelPhoneNumberPager",        CNLabelPhoneNumberPager),
+    ("CNLabelPhoneNumberAppleWatch",   CNLabelPhoneNumberAppleWatch),
+    ("CNLabelDateAnniversary",         CNLabelDateAnniversary),
+    ("CNLabelURLAddressHomePage",      CNLabelURLAddressHomePage),
+]
+
+print("Locale: \(Locale.current.identifier)")
+print("---")
+for (name, value) in constants {
+    let localized = CNLabeledValue<NSString>.localizedString(forLabel: value).lowercased()
+    print("\(name.padding(toLength: 32, withPad: " ", startingAt: 0)) -> \(localized)")
+}

--- a/mac-daemon/Sources/CRMMacIcloudContactsSource/CNContactStoreReader.swift
+++ b/mac-daemon/Sources/CRMMacIcloudContactsSource/CNContactStoreReader.swift
@@ -344,14 +344,68 @@ public final class CNContactStoreReader: ContactStoreReader, @unchecked Sendable
             birthday: birthday)
     }
 
-    /// CNLabeledValue label normalization — strip Apple's
-    /// `<CNLabelHome>` wrapper down to `home`. Returns nil for an
-    /// empty label so the wire shape omits the key per the Pi's
-    /// omitempty contract.
+    /// CNLabeledValue label normalization — map Apple's well-known
+    /// `CNLabel*` constants to stable, lowercase, locale-independent
+    /// strings. Custom user labels (e.g. "Mom") pass through with the
+    /// wrapper stripped if present, then lowercased.
+    ///
+    /// The previous implementation used
+    /// `CNLabeledValue.localizedString(forLabel:)`, which is
+    /// locale-sensitive: the returned string depends on the host's
+    /// macOS language. Because the label is part of the canonicalized
+    /// payload that feeds SHA-256(JCS(...)), a locale change would
+    /// produce a different hash for an unchanged contact, triggering a
+    /// spurious re-sync and breaking `/known-ids` parity. The map
+    /// keeps the wire shape stable across locales.
     static func localizedLabel(_ raw: String?) -> String? {
         guard let raw, !raw.isEmpty else { return nil }
-        let localized = CNLabeledValue<NSString>.localizedString(forLabel: raw)
-        if localized.isEmpty { return nil }
-        return localized.lowercased()
+        if let mapped = stableLabelMap[raw] {
+            return mapped
+        }
+        // Unknown label. Strip Apple's `_$!<…>!$_` wrapper if present
+        // (covers any CNLabel* constant we haven't enumerated), then
+        // lowercase. Custom user labels lack the wrapper and pass
+        // through with only the lowercase step.
+        let unwrapped = stripCNLabelWrapper(raw)
+        if unwrapped.isEmpty { return nil }
+        return unwrapped.lowercased()
+    }
+
+    /// Stable mapping for the well-known Apple CN label constants.
+    /// Values match what `CNLabeledValue.localizedString(forLabel:)`
+    /// returned under `en_US` at the time this map was authored —
+    /// chosen so an English-locale user's hashes are unchanged across
+    /// the locale-fix migration.
+    private static let stableLabelMap: [String: String] = [
+        // Generic (used by emails, phones, addresses, URLs, dates, …)
+        CNLabelHome: "home",
+        CNLabelWork: "work",
+        CNLabelSchool: "school",
+        CNLabelOther: "other",
+        // Date-specific
+        CNLabelDateAnniversary: "anniversary",
+        // Email-specific
+        CNLabelEmailiCloud: "icloud",
+        // Phone-specific
+        CNLabelPhoneNumberiPhone: "iphone",
+        CNLabelPhoneNumberMobile: "mobile",
+        CNLabelPhoneNumberMain: "main",
+        CNLabelPhoneNumberHomeFax: "home fax",
+        CNLabelPhoneNumberWorkFax: "work fax",
+        CNLabelPhoneNumberOtherFax: "other fax",
+        CNLabelPhoneNumberPager: "pager",
+        // URL-specific
+        CNLabelURLAddressHomePage: "homepage",
+    ]
+
+    /// Strip Apple's `_$!<X>!$_` wrapper if present. Unknown wrapped
+    /// values get a deterministic shorthand instead of leaking the
+    /// raw wrapper into the wire payload.
+    private static func stripCNLabelWrapper(_ s: String) -> String {
+        let prefix = "_$!<"
+        let suffix = ">!$_"
+        guard s.hasPrefix(prefix), s.hasSuffix(suffix) else { return s }
+        let inner = s.dropFirst(prefix.count).dropLast(suffix.count)
+        return String(inner)
     }
 }

--- a/mac-daemon/Sources/CRMMacIcloudContactsSource/CNContactStoreReader.swift
+++ b/mac-daemon/Sources/CRMMacIcloudContactsSource/CNContactStoreReader.swift
@@ -357,6 +357,15 @@ public final class CNContactStoreReader: ContactStoreReader, @unchecked Sendable
     /// produce a different hash for an unchanged contact, triggering a
     /// spurious re-sync and breaking `/known-ids` parity. The map
     /// keeps the wire shape stable across locales.
+    ///
+    /// Migration: rows already on the Pi were hashed under the old
+    /// path. Contacts whose labels are all in `stableLabelMap` and
+    /// running under `en_US` see no drift. Any wrapped label NOT in
+    /// the map (a future Apple `CNLabel*` constant we haven't
+    /// enumerated, or a third-party-written wrapper string) will
+    /// re-hash on first sync after this change because the fallback
+    /// strips the wrapper while the old path emitted it raw. One-time
+    /// write amplification, not data loss.
     static func localizedLabel(_ raw: String?) -> String? {
         guard let raw, !raw.isEmpty else { return nil }
         if let mapped = stableLabelMap[raw] {
@@ -371,19 +380,23 @@ public final class CNContactStoreReader: ContactStoreReader, @unchecked Sendable
         return unwrapped.lowercased()
     }
 
-    /// Stable mapping for the well-known Apple CN label constants.
-    /// Values match what `CNLabeledValue.localizedString(forLabel:)`
-    /// returned under `en_US` at the time this map was authored —
-    /// chosen so an English-locale user's hashes are unchanged across
-    /// the locale-fix migration.
+    /// Stable, locale-independent mapping for Apple's well-known CN
+    /// label constants. The string values are the design contract —
+    /// the chosen shorthands happen to coincide with what
+    /// `CNLabeledValue.localizedString(forLabel:)` returns under
+    /// `en_US` (so `en_US` users see no migration hash drift), but the
+    /// invariant we promise is "stable across locales", NOT "tracks
+    /// Apple's localized output." Verify with
+    /// `mac-daemon/Scripts/probe_cn_labels.swift` if you need to
+    /// reconfirm against a current SDK.
     private static let stableLabelMap: [String: String] = [
-        // Generic (used by emails, phones, addresses, URLs, dates, …)
+        // --- Currently-exercised by ContactKeysToFetch (email, phone,
+        // postal address). ---
+        // Generic (used by emails, phones, addresses)
         CNLabelHome: "home",
         CNLabelWork: "work",
         CNLabelSchool: "school",
         CNLabelOther: "other",
-        // Date-specific
-        CNLabelDateAnniversary: "anniversary",
         // Email-specific
         CNLabelEmailiCloud: "icloud",
         // Phone-specific
@@ -394,7 +407,12 @@ public final class CNContactStoreReader: ContactStoreReader, @unchecked Sendable
         CNLabelPhoneNumberWorkFax: "work fax",
         CNLabelPhoneNumberOtherFax: "other fax",
         CNLabelPhoneNumberPager: "pager",
-        // URL-specific
+        CNLabelPhoneNumberAppleWatch: "apple watch",
+        // --- Forward-compat: not exercised today (contactKeysToFetch
+        // doesn't request URL or date-with-label fields), included so a
+        // future field addition doesn't silently fall to the fallback
+        // path. ---
+        CNLabelDateAnniversary: "anniversary",
         CNLabelURLAddressHomePage: "homepage",
     ]
 

--- a/mac-daemon/Tests/CRMMacIcloudContactsSourceTests/CNContactStoreReaderLabelTests.swift
+++ b/mac-daemon/Tests/CRMMacIcloudContactsSourceTests/CNContactStoreReaderLabelTests.swift
@@ -71,17 +71,32 @@ final class CNContactStoreReaderLabelTests: XCTestCase {
         // a pure dictionary lookup with no Locale access, so if the
         // source contains no call to `localizedString(forLabel:)`,
         // the function is locale-insensitive by construction. Greps
-        // the source rather than trying to swap Locale.current
-        // (which AppKit/Foundation makes effectively impossible
-        // mid-process anyway).
+        // the source (comments stripped) rather than trying to swap
+        // Locale.current (which AppKit/Foundation makes effectively
+        // impossible mid-process anyway).
         let sourceURL = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()           // Tests/CRMMacIcloudContactsSourceTests
             .deletingLastPathComponent()           // Tests
             .deletingLastPathComponent()           // mac-daemon
             .appendingPathComponent("Sources/CRMMacIcloudContactsSource/CNContactStoreReader.swift")
-        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: sourceURL.path),
+            "expected source at \(sourceURL.path); SPM layout may have changed")
+        let raw = try String(contentsOf: sourceURL, encoding: .utf8)
+        // Strip `// …` line-comments so doc-comment prose that
+        // mentions the API name doesn't trip the assertion. Naive
+        // (doesn't account for `//` inside string literals), but
+        // good enough — the source file has no string literals
+        // containing `//`.
+        let codeOnly = raw
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map { line -> String in
+                guard let commentStart = line.range(of: "//") else { return String(line) }
+                return String(line[..<commentStart.lowerBound])
+            }
+            .joined(separator: "\n")
         XCTAssertFalse(
-            source.contains("localizedString(forLabel:"),
+            codeOnly.contains("localizedString(forLabel:"),
             "CNContactStoreReader.swift must not call localizedString(forLabel:) — that call is locale-sensitive and breaks /known-ids hash parity across locales (#312).")
     }
 }

--- a/mac-daemon/Tests/CRMMacIcloudContactsSourceTests/CNContactStoreReaderLabelTests.swift
+++ b/mac-daemon/Tests/CRMMacIcloudContactsSourceTests/CNContactStoreReaderLabelTests.swift
@@ -1,0 +1,84 @@
+// CNContactStoreReaderLabelTests cover the locale-stable label
+// normalization. Pure-logic; no CNContactStore access required.
+//
+// The old implementation called
+// `CNLabeledValue<NSString>.localizedString(forLabel:)`, which is
+// locale-sensitive. Because the label string feeds the JCS+SHA-256
+// canonicalization that produces the content hash (and thus the
+// envelope's source_id), a locale flip would re-hash every contact
+// and break Pi-side `/known-ids` parity. These tests pin the new
+// mapping so a future regression that re-introduces locale lookups
+// would fail here even on an `en_US` runner.
+import XCTest
+import Contacts
+@testable import CRMMacIcloudContactsSource
+
+final class CNContactStoreReaderLabelTests: XCTestCase {
+
+    func testNilOrEmptyReturnsNil() {
+        XCTAssertNil(CNContactStoreReader.localizedLabel(nil))
+        XCTAssertNil(CNContactStoreReader.localizedLabel(""))
+    }
+
+    func testWellKnownGenericLabels() {
+        XCTAssertEqual(CNContactStoreReader.localizedLabel(CNLabelHome), "home")
+        XCTAssertEqual(CNContactStoreReader.localizedLabel(CNLabelWork), "work")
+        XCTAssertEqual(CNContactStoreReader.localizedLabel(CNLabelSchool), "school")
+        XCTAssertEqual(CNContactStoreReader.localizedLabel(CNLabelOther), "other")
+    }
+
+    func testWellKnownPhoneLabels() {
+        XCTAssertEqual(CNContactStoreReader.localizedLabel(CNLabelPhoneNumberiPhone), "iphone")
+        XCTAssertEqual(CNContactStoreReader.localizedLabel(CNLabelPhoneNumberMobile), "mobile")
+        XCTAssertEqual(CNContactStoreReader.localizedLabel(CNLabelPhoneNumberMain), "main")
+        XCTAssertEqual(CNContactStoreReader.localizedLabel(CNLabelPhoneNumberHomeFax), "home fax")
+        XCTAssertEqual(CNContactStoreReader.localizedLabel(CNLabelPhoneNumberWorkFax), "work fax")
+        XCTAssertEqual(CNContactStoreReader.localizedLabel(CNLabelPhoneNumberOtherFax), "other fax")
+        XCTAssertEqual(CNContactStoreReader.localizedLabel(CNLabelPhoneNumberPager), "pager")
+    }
+
+    func testWellKnownEmailAndUrlLabels() {
+        XCTAssertEqual(CNContactStoreReader.localizedLabel(CNLabelEmailiCloud), "icloud")
+        XCTAssertEqual(CNContactStoreReader.localizedLabel(CNLabelURLAddressHomePage), "homepage")
+    }
+
+    func testWellKnownDateLabel() {
+        XCTAssertEqual(CNContactStoreReader.localizedLabel(CNLabelDateAnniversary), "anniversary")
+    }
+
+    func testCustomLabelLowercases() {
+        // User-defined labels (e.g. "Mom") aren't in the map and
+        // don't have Apple's wrapper. They pass through with only
+        // the lowercase step.
+        XCTAssertEqual(CNContactStoreReader.localizedLabel("Mom"), "mom")
+        XCTAssertEqual(CNContactStoreReader.localizedLabel("Spencer's iPhone"), "spencer's iphone")
+    }
+
+    func testUnknownWrappedLabelStripsWrapper() {
+        // Defensive: if Apple ships a new CNLabel* constant we
+        // haven't enumerated, strip the `_$!<…>!$_` wrapper rather
+        // than emit it raw on the wire.
+        XCTAssertEqual(
+            CNContactStoreReader.localizedLabel("_$!<NewLabel>!$_"),
+            "newlabel")
+    }
+
+    func testLocaleInsensitive() {
+        // The whole point of #312. Switching the current locale to
+        // anything non-English MUST NOT change the mapped result.
+        // We exercise this via the same well-known input under a
+        // synthetic non-English locale; since the implementation
+        // does NOT consult Locale.current, the assertion holds.
+        let priorLocale = Locale.current
+        defer {
+            _ = priorLocale  // keep the reference; we don't actually swap
+        }
+        // The mapping is a plain Dictionary lookup — no Locale
+        // access. Re-asserting after touching Locale.current proves
+        // there's no hidden caching path that would silently leak
+        // locale state in.
+        _ = Locale(identifier: "tr_TR") // touch a non-Latin-default locale
+        XCTAssertEqual(CNContactStoreReader.localizedLabel(CNLabelHome), "home")
+        XCTAssertEqual(CNContactStoreReader.localizedLabel(CNLabelPhoneNumberMobile), "mobile")
+    }
+}

--- a/mac-daemon/Tests/CRMMacIcloudContactsSourceTests/CNContactStoreReaderLabelTests.swift
+++ b/mac-daemon/Tests/CRMMacIcloudContactsSourceTests/CNContactStoreReaderLabelTests.swift
@@ -35,6 +35,7 @@ final class CNContactStoreReaderLabelTests: XCTestCase {
         XCTAssertEqual(CNContactStoreReader.localizedLabel(CNLabelPhoneNumberWorkFax), "work fax")
         XCTAssertEqual(CNContactStoreReader.localizedLabel(CNLabelPhoneNumberOtherFax), "other fax")
         XCTAssertEqual(CNContactStoreReader.localizedLabel(CNLabelPhoneNumberPager), "pager")
+        XCTAssertEqual(CNContactStoreReader.localizedLabel(CNLabelPhoneNumberAppleWatch), "apple watch")
     }
 
     func testWellKnownEmailAndUrlLabels() {
@@ -63,22 +64,24 @@ final class CNContactStoreReaderLabelTests: XCTestCase {
             "newlabel")
     }
 
-    func testLocaleInsensitive() {
-        // The whole point of #312. Switching the current locale to
-        // anything non-English MUST NOT change the mapped result.
-        // We exercise this via the same well-known input under a
-        // synthetic non-English locale; since the implementation
-        // does NOT consult Locale.current, the assertion holds.
-        let priorLocale = Locale.current
-        defer {
-            _ = priorLocale  // keep the reference; we don't actually swap
-        }
-        // The mapping is a plain Dictionary lookup — no Locale
-        // access. Re-asserting after touching Locale.current proves
-        // there's no hidden caching path that would silently leak
-        // locale state in.
-        _ = Locale(identifier: "tr_TR") // touch a non-Latin-default locale
-        XCTAssertEqual(CNContactStoreReader.localizedLabel(CNLabelHome), "home")
-        XCTAssertEqual(CNContactStoreReader.localizedLabel(CNLabelPhoneNumberMobile), "mobile")
+    func testSourceDoesNotCallLocalizedString() throws {
+        // Structural guarantee for the locale-stability invariant:
+        // `CNContactStoreReader.swift` must not invoke
+        // `CNLabeledValue.localizedString(forLabel:)`. The mapping is
+        // a pure dictionary lookup with no Locale access, so if the
+        // source contains no call to `localizedString(forLabel:)`,
+        // the function is locale-insensitive by construction. Greps
+        // the source rather than trying to swap Locale.current
+        // (which AppKit/Foundation makes effectively impossible
+        // mid-process anyway).
+        let sourceURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()           // Tests/CRMMacIcloudContactsSourceTests
+            .deletingLastPathComponent()           // Tests
+            .deletingLastPathComponent()           // mac-daemon
+            .appendingPathComponent("Sources/CRMMacIcloudContactsSource/CNContactStoreReader.swift")
+        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+        XCTAssertFalse(
+            source.contains("localizedString(forLabel:"),
+            "CNContactStoreReader.swift must not call localizedString(forLabel:) — that call is locale-sensitive and breaks /known-ids hash parity across locales (#312).")
     }
 }

--- a/mac-daemon/Tests/CRMMacIcloudContactsSourceTests/ContentHashParityTests.swift
+++ b/mac-daemon/Tests/CRMMacIcloudContactsSourceTests/ContentHashParityTests.swift
@@ -10,6 +10,7 @@
 // step would surface here as a hash that differs from the
 // recorded value. Pure-logic; no I/O.
 import XCTest
+import Contacts
 import CRMMacCore
 @testable import CRMMacIcloudContactsSource
 

--- a/mac-daemon/Tests/CRMMacIcloudContactsSourceTests/ContentHashParityTests.swift
+++ b/mac-daemon/Tests/CRMMacIcloudContactsSourceTests/ContentHashParityTests.swift
@@ -154,6 +154,16 @@ final class ContentHashParityTests: XCTestCase {
         // reverts to localizedString(forLabel:) or drops an entry
         // from stableLabelMap), the literal-string hash stays the
         // same but the CN-routed hash drifts and this test fails.
+        //
+        // Phone labels deliberately include CNLabelPhoneNumberHomeFax
+        // and CNLabelPhoneNumberAppleWatch — both map to strings
+        // containing a space ("home fax", "apple watch"). The
+        // wrapper-strip fallback would produce "homefax" / unchanged
+        // wrapped-input respectively, so if either entry is dropped
+        // from stableLabelMap the hashes diverge and the test fails.
+        // (Picking only entries whose strip-and-lowercase fallback
+        // coincides with the map value — like CNLabelHome — would
+        // make map-drop regressions silent.)
         let viaCNConstants = ContactRecord(
             identifier: "id-locale",
             containerIdentifier: "container-1",
@@ -164,10 +174,18 @@ final class ContentHashParityTests: XCTestCase {
                 value: "home@example.com",
                 type: CNContactStoreReader.localizedLabel(CNLabelHome),
                 primary: true)],
-            phones: [ContactPhone(
-                value: "+10000000001",
-                type: CNContactStoreReader.localizedLabel(CNLabelPhoneNumberMobile),
-                primary: true)],
+            phones: [
+                ContactPhone(
+                    value: "+10000000001",
+                    type: CNContactStoreReader.localizedLabel(CNLabelPhoneNumberMobile),
+                    primary: true),
+                ContactPhone(
+                    value: "+10000000002",
+                    type: CNContactStoreReader.localizedLabel(CNLabelPhoneNumberHomeFax)),
+                ContactPhone(
+                    value: "+10000000003",
+                    type: CNContactStoreReader.localizedLabel(CNLabelPhoneNumberAppleWatch)),
+            ],
             addresses: [ContactAddress(
                 formatted: "100 Other St",
                 type: CNContactStoreReader.localizedLabel(CNLabelOther))])
@@ -178,7 +196,11 @@ final class ContentHashParityTests: XCTestCase {
             firstName: "Contact",
             lastName: "Locale",
             emails: [ContactEmail(value: "home@example.com", type: "home", primary: true)],
-            phones: [ContactPhone(value: "+10000000001", type: "mobile", primary: true)],
+            phones: [
+                ContactPhone(value: "+10000000001", type: "mobile", primary: true),
+                ContactPhone(value: "+10000000002", type: "home fax"),
+                ContactPhone(value: "+10000000003", type: "apple watch"),
+            ],
             addresses: [ContactAddress(formatted: "100 Other St", type: "other")])
         let hashCN = try hash(for: viaCNConstants)
         let hashLit = try hash(for: viaLiterals)

--- a/mac-daemon/Tests/CRMMacIcloudContactsSourceTests/ContentHashParityTests.swift
+++ b/mac-daemon/Tests/CRMMacIcloudContactsSourceTests/ContentHashParityTests.swift
@@ -145,6 +145,47 @@ final class ContentHashParityTests: XCTestCase {
                        "end-to-end shape→encode→hash must match the Go-side fixture")
     }
 
+    func testHashStableWhenLabelsCameFromCNConstants() throws {
+        // #312 regression guard: a record whose label strings were
+        // produced by routing CN constants through
+        // CNContactStoreReader.localizedLabel must hash identically
+        // to a record whose label strings were written as literals.
+        // If a future change reintroduces locale-sensitivity (e.g.
+        // reverts to localizedString(forLabel:) or drops an entry
+        // from stableLabelMap), the literal-string hash stays the
+        // same but the CN-routed hash drifts and this test fails.
+        let viaCNConstants = ContactRecord(
+            identifier: "id-locale",
+            containerIdentifier: "container-1",
+            displayName: "Contact Locale",
+            firstName: "Contact",
+            lastName: "Locale",
+            emails: [ContactEmail(
+                value: "home@example.com",
+                type: CNContactStoreReader.localizedLabel(CNLabelHome),
+                primary: true)],
+            phones: [ContactPhone(
+                value: "+10000000001",
+                type: CNContactStoreReader.localizedLabel(CNLabelPhoneNumberMobile),
+                primary: true)],
+            addresses: [ContactAddress(
+                formatted: "100 Other St",
+                type: CNContactStoreReader.localizedLabel(CNLabelOther))])
+        let viaLiterals = ContactRecord(
+            identifier: "id-locale",
+            containerIdentifier: "container-1",
+            displayName: "Contact Locale",
+            firstName: "Contact",
+            lastName: "Locale",
+            emails: [ContactEmail(value: "home@example.com", type: "home", primary: true)],
+            phones: [ContactPhone(value: "+10000000001", type: "mobile", primary: true)],
+            addresses: [ContactAddress(formatted: "100 Other St", type: "other")])
+        let hashCN = try hash(for: viaCNConstants)
+        let hashLit = try hash(for: viaLiterals)
+        XCTAssertEqual(hashCN, hashLit,
+                       "CN-routed labels must produce the same hash as the pinned literal mapping")
+    }
+
     func testHashIncludesEmailAndPhone() throws {
         let baseline = ContactRecord(
             identifier: "id-5",

--- a/mac-daemon/Tests/CRMMacIcloudContactsSourceTests/ContentHashParityTests.swift
+++ b/mac-daemon/Tests/CRMMacIcloudContactsSourceTests/ContentHashParityTests.swift
@@ -156,14 +156,16 @@ final class ContentHashParityTests: XCTestCase {
         // same but the CN-routed hash drifts and this test fails.
         //
         // Phone labels deliberately include CNLabelPhoneNumberHomeFax
-        // and CNLabelPhoneNumberAppleWatch — both map to strings
-        // containing a space ("home fax", "apple watch"). The
-        // wrapper-strip fallback would produce "homefax" / unchanged
-        // wrapped-input respectively, so if either entry is dropped
-        // from stableLabelMap the hashes diverge and the test fails.
+        // AND CNLabelPhoneNumberWorkFax. Both raw values use Apple's
+        // wrapper with an internal capitalization that the wrapper-
+        // strip fallback CANNOT recover — `_$!<HomeFAX>!$_` →
+        // `"homefax"` (no space), but the map value is `"home fax"`
+        // (with space). So if either entry is dropped from
+        // stableLabelMap the hashes diverge and the test fails.
         // (Picking only entries whose strip-and-lowercase fallback
-        // coincides with the map value — like CNLabelHome — would
-        // make map-drop regressions silent.)
+        // coincides with the map value — like CNLabelHome or
+        // CNLabelPhoneNumberAppleWatch (raw `"Apple Watch"`, no
+        // wrapper) — would make map-drop regressions silent.)
         let viaCNConstants = ContactRecord(
             identifier: "id-locale",
             containerIdentifier: "container-1",
@@ -184,7 +186,7 @@ final class ContentHashParityTests: XCTestCase {
                     type: CNContactStoreReader.localizedLabel(CNLabelPhoneNumberHomeFax)),
                 ContactPhone(
                     value: "+10000000003",
-                    type: CNContactStoreReader.localizedLabel(CNLabelPhoneNumberAppleWatch)),
+                    type: CNContactStoreReader.localizedLabel(CNLabelPhoneNumberWorkFax)),
             ],
             addresses: [ContactAddress(
                 formatted: "100 Other St",
@@ -199,7 +201,7 @@ final class ContentHashParityTests: XCTestCase {
             phones: [
                 ContactPhone(value: "+10000000001", type: "mobile", primary: true),
                 ContactPhone(value: "+10000000002", type: "home fax"),
-                ContactPhone(value: "+10000000003", type: "apple watch"),
+                ContactPhone(value: "+10000000003", type: "work fax"),
             ],
             addresses: [ContactAddress(formatted: "100 Other St", type: "other")])
         let hashCN = try hash(for: viaCNConstants)


### PR DESCRIPTION
Closes #312.

## Summary

`CNContactStoreReader.localizedLabel` was calling `CNLabeledValue.localizedString(forLabel:)`, which is locale-sensitive — the returned label string changes with the host's macOS language. Because the label feeds the JCS+SHA-256 content hash that produces each upsert envelope's `source_id`, any locale change would re-hash every contact and break Pi-side `/known-ids` parity until a fresh full resync caught up.

Replaces the locale lookup with:

1. **`stableLabelMap`** — a static dictionary mapping Apple's well-known `CNLabel*` constants to lowercase English shorthands. Values match what `en_US` returned before, so English-locale users see no migration drift.
2. **`stripCNLabelWrapper` fallback** — for any unenumerated wrapped constant, strip the `_$!<…>!$_` wrapper rather than emit it raw on the wire.
3. **Lowercase pass-through** for custom user labels (e.g. `"Mom"` → `"mom"`).

## Migration

- en_US users: no drift for any contact whose labels are all in the map. Contacts with custom labels also unchanged (the old code lowercased custom labels too).
- non-en_US users: re-emit every contact once on next sync. The new wire values are locale-independent; subsequent runs are steady-state.
- One-time write amplification, not data loss.

## Tests

Three layers of coverage:

| Test | What it pins |
|---|---|
| `CNContactStoreReaderLabelTests` (new file) | Each well-known CN constant maps to its expected lowercase shorthand. Custom labels lowercase. Wrapped unknown labels strip the wrapper. |
| `testSourceDoesNotCallLocalizedString` | Structural proof: `CNContactStoreReader.swift` does not contain a `localizedString(forLabel:` call (with comments stripped). Locale-insensitivity by construction. |
| `testHashStableWhenLabelsCameFromCNConstants` (in `ContentHashParityTests`) | End-to-end shape→encode→hash invariant: a record whose labels were produced by `localizedLabel(CNLabelHome)`, `localizedLabel(CNLabelPhoneNumberHomeFax)`, `localizedLabel(CNLabelPhoneNumberWorkFax)`, etc. hashes identically to a record whose labels are literal strings. Dropping any of HomeFax/WorkFax from `stableLabelMap` makes the CN-routed hash diverge (fallback yields `"homefax"`/`"workfax"`, map says `"home fax"`/`"work fax"`) and the test fails. |

Test inputs deliberately include the FAX constants whose wrap-strip fallback differs from the map entry — picking only entries where map and fallback coincide (like `CNLabelHome`, or the unwrapped `CNLabelPhoneNumberAppleWatch`) would make per-entry map-drop regressions silent.

## Operator tools

- `mac-daemon/Scripts/probe_cn_labels.swift` — re-print the localized-output values for each pinned CN constant under the current locale. Run when verifying the map's en_US shorthands against a new SDK.

## Self-review

Four iterations of `/review-head` (one initial + three follow-up fixes for findings, each captured in commit messages). Final verdict: 0 P0, 0 P1.

## Test plan

- [x] Source builds (`swift build -c release`)
- [x] Swift unit tests will run on CI's macos-15 `mac-daemon-tests` job
- [x] No backend / frontend changes (filters will skip)