### PR TITLE
feat(mac-daemon): file-backed API key store, replaces Keychain

### DIFF
--- a/mac-daemon/README.md
+++ b/mac-daemon/README.md
@@ -67,7 +67,7 @@ Without this permission, the daemon cannot read `~/Library/Messages/chat.db` and
 
 ```bash
 ./mac-daemon/.build/release/crm-mac doctor
-# PASS  keychain: api-key present
+# PASS  api-key: present
 # PASS  launchctl: service registered
 # PASS  config_state: host=mac-1 schemaVersion=1
 # PASS  pi_reachability: phones=N emails=N

--- a/mac-daemon/Sources/CRMMacLifecycle/DaemonPaths.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/DaemonPaths.swift
@@ -46,4 +46,8 @@ public struct LifecyclePaths: Equatable {
     /// daemon-running state.  Defaults to the config dir so the same
     /// folder hosts config / state / pid.
     public var runtimeDirPath: String { configDirPath }
+
+    /// On-disk plaintext file holding the daemon's API key (0600).
+    /// Replaces the prior macOS Keychain entry — see FileAPIKeyStore.
+    public var apiKeyFilePath: String { "\(configDirPath)/api-key" }
 }

--- a/mac-daemon/Sources/CRMMacLifecycle/Doctor.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/Doctor.swift
@@ -245,11 +245,11 @@ public struct Doctor {
     private func checkKeychain() -> CheckResult {
         do {
             _ = try deps.keychain.readAPIKey()
-            return CheckResult(name: "keychain", status: .pass, details: "api-key present")
+            return CheckResult(name: "api-key", status: .pass, details: "present")
         } catch let e as KeychainStoreError where e == .notFound {
-            return CheckResult(name: "keychain", status: .fail, details: "api-key not present")
+            return CheckResult(name: "api-key", status: .fail, details: "not present")
         } catch {
-            return CheckResult(name: "keychain", status: .fail, details: String(describing: error))
+            return CheckResult(name: "api-key", status: .fail, details: String(describing: error))
         }
     }
 

--- a/mac-daemon/Sources/CRMMacLifecycle/Installer.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/Installer.swift
@@ -121,6 +121,12 @@ public struct InstallerDependencies {
     public let piClientFactory: (URL) -> PiClient
     public let clock: ClockAdapter
     public let logger: LoggerProtocol
+    /// One-shot migration source for installs that predate the
+    /// file-backed FileAPIKeyStore. When non-nil and `keychain` is
+    /// empty, runUpgrade / runRegisterOnly copy from this into
+    /// `keychain` and then delete the legacy entry. Production wires
+    /// the real macOS Keychain; tests leave it nil.
+    public let legacyKeychain: KeychainStore?
 
     public init(
         paths: LifecyclePaths,
@@ -130,7 +136,8 @@ public struct InstallerDependencies {
         launchctl: LaunchctlRunner,
         piClientFactory: @escaping (URL) -> PiClient,
         clock: ClockAdapter,
-        logger: LoggerProtocol
+        logger: LoggerProtocol,
+        legacyKeychain: KeychainStore? = nil
     ) {
         self.paths = paths
         self.filesystem = filesystem
@@ -140,6 +147,7 @@ public struct InstallerDependencies {
         self.piClientFactory = piClientFactory
         self.clock = clock
         self.logger = logger
+        self.legacyKeychain = legacyKeychain
     }
 }
 
@@ -308,6 +316,7 @@ public struct Installer {
         guard deps.filesystem.fileExists(at: deps.paths.configFilePath) else {
             throw InstallError.noExistingInstall
         }
+        try migrateLegacyKeychainIfNeeded()
         guard (try? deps.keychain.readAPIKey()) != nil else {
             throw InstallError.noExistingInstall
         }
@@ -354,6 +363,7 @@ public struct Installer {
         guard deps.filesystem.fileExists(at: deps.paths.configFilePath) else {
             throw InstallError.noExistingInstall
         }
+        try migrateLegacyKeychainIfNeeded()
         guard (try? deps.keychain.readAPIKey()) != nil else {
             throw InstallError.noExistingInstall
         }
@@ -369,6 +379,49 @@ public struct Installer {
     }
 
     // MARK: - shared helpers
+
+    /// One-shot copy of the API key from the legacy macOS Keychain
+    /// into the file-backed FileAPIKeyStore. Idempotent — when the
+    /// primary store already has a value, returns immediately and
+    /// does NOT touch the legacy entry. Once the value has been
+    /// safely written to disk, the legacy Keychain entry is deleted
+    /// best-effort so a later rebuild doesn't re-prompt.
+    private func migrateLegacyKeychainIfNeeded() throws {
+        if (try? deps.keychain.readAPIKey()) != nil {
+            return
+        }
+        guard let legacy = deps.legacyKeychain else {
+            return
+        }
+        let value: String
+        do {
+            value = try legacy.readAPIKey()
+        } catch KeychainStoreError.notFound {
+            return
+        } catch {
+            throw InstallError.keychainFailed(
+                "read legacy keychain: \(error)")
+        }
+        do {
+            try deps.keychain.writeAPIKey(value)
+        } catch {
+            throw InstallError.keychainFailed(
+                "write api-key file during migration: \(error)")
+        }
+        do {
+            try legacy.deleteAPIKey()
+        } catch {
+            // Non-fatal: file is the new source of truth; a stale
+            // Keychain entry can be cleared with `security delete-
+            // generic-password -s xyz.spengrah.crm-mac`.
+            deps.logger.warning("migration: legacy keychain delete failed (non-fatal)", metadata: [
+                "error": .private(String(describing: error)),
+            ])
+        }
+        deps.logger.info("migration: api-key copied from legacy Keychain to file", metadata: [
+            "path": .public(deps.paths.apiKeyFilePath),
+        ])
+    }
 
     /// Preflight detection — returns true when any of the install
     /// artifacts exist, to refuse fresh-install on top of an existing

--- a/mac-daemon/Sources/CRMMacSystem/FileAPIKeyStore.swift
+++ b/mac-daemon/Sources/CRMMacSystem/FileAPIKeyStore.swift
@@ -1,0 +1,90 @@
+// FileAPIKeyStore stores the daemon's API key in a plain UTF-8 file
+// at the configured path, with 0600 perms. The file lives under the
+// daemon's config dir (sibling of config.json / state.json) so a
+// single `rm -rf ~/Library/Application\ Support/crm-mac/` cleans up
+// everything.
+//
+// Threat model: same as ~/.aws/credentials and ~/.config/gh/hosts.yml
+// — anyone with read access to the user account can read the key.
+// We trade macOS Keychain's encryption at rest for the elimination
+// of the "allow this app to access?" dialog that hangs the daemon
+// every time the binary's CDHash changes (which is every rebuild
+// under ad-hoc codesign).
+//
+// Writes go through a temp file + rename so a crash mid-write can't
+// leave a half-written key on disk.
+import Foundation
+import CRMMacLifecycle
+
+public struct FileAPIKeyStore: KeychainStore {
+    private let path: String
+    private let fm = FileManager.default
+
+    public init(path: String) {
+        self.path = path
+    }
+
+    public func readAPIKey() throws -> String {
+        guard fm.fileExists(atPath: path) else {
+            throw KeychainStoreError.notFound
+        }
+        let url = URL(fileURLWithPath: path)
+        let data: Data
+        do {
+            data = try Data(contentsOf: url)
+        } catch {
+            throw KeychainStoreError.other("read failed: \(error)")
+        }
+        guard let s = String(data: data, encoding: .utf8) else {
+            throw KeychainStoreError.other("api-key file is not utf8")
+        }
+        // Trim a trailing newline if a human edited the file with
+        // `echo > api-key`. Embedded whitespace stays intact.
+        return s.hasSuffix("\n") ? String(s.dropLast()) : s
+    }
+
+    public func writeAPIKey(_ value: String) throws {
+        let parentDir = (path as NSString).deletingLastPathComponent
+        do {
+            try fm.createDirectory(
+                atPath: parentDir, withIntermediateDirectories: true)
+        } catch {
+            throw KeychainStoreError.other("mkdir parent: \(error)")
+        }
+        let tmpPath = "\(path).tmp.\(UUID().uuidString)"
+        let data = Data(value.utf8)
+        do {
+            try data.write(to: URL(fileURLWithPath: tmpPath), options: .atomic)
+        } catch {
+            throw KeychainStoreError.other("write tmp: \(error)")
+        }
+        do {
+            try fm.setAttributes(
+                [.posixPermissions: 0o600], ofItemAtPath: tmpPath)
+        } catch {
+            try? fm.removeItem(atPath: tmpPath)
+            throw KeychainStoreError.other("chmod tmp: \(error)")
+        }
+        do {
+            if fm.fileExists(atPath: path) {
+                _ = try fm.replaceItemAt(
+                    URL(fileURLWithPath: path),
+                    withItemAt: URL(fileURLWithPath: tmpPath))
+            } else {
+                try fm.moveItem(atPath: tmpPath, toPath: path)
+            }
+        } catch {
+            try? fm.removeItem(atPath: tmpPath)
+            throw KeychainStoreError.other("rename: \(error)")
+        }
+    }
+
+    public func deleteAPIKey() throws {
+        guard fm.fileExists(atPath: path) else { return }
+        do {
+            try fm.removeItem(atPath: path)
+        } catch {
+            throw KeychainStoreError.other("delete: \(error)")
+        }
+    }
+}

--- a/mac-daemon/Sources/CRMMacSystem/LaunchAgent.swift
+++ b/mac-daemon/Sources/CRMMacSystem/LaunchAgent.swift
@@ -50,4 +50,9 @@ public struct DaemonPaths {
     public var runtimeDir: URL {
         configDir
     }
+    /// On-disk plaintext file holding the daemon's API key (0600).
+    /// Replaces the prior macOS Keychain entry — see FileAPIKeyStore.
+    public var apiKeyFile: URL {
+        configDir.appendingPathComponent("api-key")
+    }
 }

--- a/mac-daemon/Sources/crm-mac/App/ProductionContext.swift
+++ b/mac-daemon/Sources/crm-mac/App/ProductionContext.swift
@@ -34,7 +34,7 @@ struct ProductionContext {
         self.logger = OSLogLogger()
         self.filesystem = ProductionFilesystemAdapter()
         self.executable = ProductionExecutableAdapter()
-        self.keychain = ProductionKeychainStore()
+        self.keychain = FileAPIKeyStore(path: systemPaths.apiKeyFile.path)
         self.launchctl = ProductionLaunchctlRunner()
         self.clock = SystemClock()
         self.exitHandler = SystemExitHandler()
@@ -53,7 +53,8 @@ struct ProductionContext {
             launchctl: launchctl,
             piClientFactory: { url in self.piClientFactory(url) },
             clock: clock,
-            logger: logger))
+            logger: logger,
+            legacyKeychain: ProductionKeychainStore()))
     }
 
     func uninstaller() -> Uninstaller {

--- a/mac-daemon/Sources/crm-mac/Commands/DoctorCommand.swift
+++ b/mac-daemon/Sources/crm-mac/Commands/DoctorCommand.swift
@@ -7,7 +7,7 @@ import CRMMacLifecycle
 struct DoctorCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "doctor",
-        abstract: "Run health checks: Keychain, launchctl, Pi reachability, config + state files.")
+        abstract: "Run health checks: api-key file, launchctl, Pi reachability, config + state files.")
 
     mutating func run() async throws {
         let ctx = ProductionContext()

--- a/mac-daemon/Tests/CRMMacLifecycleTests/DoctorTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/DoctorTests.swift
@@ -86,7 +86,7 @@ final class DoctorTests: XCTestCase {
             launchctl: FakeLaunchctlRunner(),
             piClient: { _ in PiClient(baseURL: URL(string: "https://x")!, transport: LifecycleMockTransport([]).asTransport(), sleep: noopSleep) }))
         let report = await doctor.run()
-        let keychain = report.results.first(where: { $0.name == "keychain" })!
+        let keychain = report.results.first(where: { $0.name == "api-key" })!
         XCTAssertEqual(keychain.status, .fail)
     }
 

--- a/mac-daemon/Tests/CRMMacLifecycleTests/InstallerUpgradeTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/InstallerUpgradeTests.swift
@@ -51,6 +51,53 @@ final class InstallerUpgradeTests: XCTestCase {
         }
     }
 
+    func testUpgradeMigratesLegacyKeychainToPrimary() async throws {
+        let paths = TestPaths.make()
+        let fs = InMemoryFilesystem()
+        fs.seedFile(at: "/tmp/source/crm-mac")
+        try fs.write(Data("old binary".utf8), to: paths.binaryPath)
+        let config = DaemonConfig(
+            piURL: URL(string: "https://pi.example.test")!,
+            hostID: UUID(uuidString: "11111111-2222-3333-4444-555555555555")!,
+            hostname: "mac-1",
+            installedAt: Date(timeIntervalSince1970: 1_700_000_000))
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        try fs.write(try encoder.encode(config), to: paths.configFilePath)
+        // Primary (file-store stand-in) starts empty; legacy holds the key.
+        let primary = InMemoryKeychainStore()
+        let legacy = InMemoryKeychainStore(initial: "migrating-key")
+        let launchctl = FakeLaunchctlRunner()
+        let installer = Installer(InstallerDependencies(
+            paths: paths,
+            filesystem: fs,
+            executable: FakeExecutableAdapter(currentExecutablePath: "/tmp/source/crm-mac"),
+            keychain: primary,
+            launchctl: launchctl,
+            piClientFactory: { url in
+                PiClient(
+                    baseURL: url,
+                    transport: LifecycleMockTransport([]).asTransport(),
+                    sleep: noopSleep)
+            },
+            clock: FixedClock(),
+            logger: NoopLogger(),
+            legacyKeychain: legacy))
+        _ = try await installer.run(InstallRequest(
+            piURL: URL(string: "https://pi.example.test")!,
+            pairingToken: "ignored",
+            hostname: "ignored",
+            upgrade: true))
+        XCTAssertEqual(try primary.readAPIKey(), "migrating-key",
+            "migration must copy legacy key into primary store")
+        XCTAssertThrowsError(try legacy.readAPIKey(),
+            "migration must delete legacy entry post-copy") { error in
+            guard let e = error as? KeychainStoreError, e == .notFound else {
+                XCTFail("expected .notFound, got \(error)"); return
+            }
+        }
+    }
+
     private func prepareExistingInstall() throws -> (Installer, InMemoryFilesystem, FakeLaunchctlRunner, InMemoryKeychainStore, LifecyclePaths, LifecycleMockTransport) {
         let paths = TestPaths.make()
         let fs = InMemoryFilesystem()

--- a/mac-daemon/Tests/CRMMacSystemTests/DaemonPathsTests.swift
+++ b/mac-daemon/Tests/CRMMacSystemTests/DaemonPathsTests.swift
@@ -11,5 +11,6 @@ final class DaemonPathsTests: XCTestCase {
         XCTAssertEqual(paths.plistPath.path, "/Users/alice/Library/LaunchAgents/\(Daemon.label).plist")
         XCTAssertEqual(paths.stdoutLog.path, "/Users/alice/Library/Logs/crm-mac/stdout.log")
         XCTAssertEqual(paths.stderrLog.path, "/Users/alice/Library/Logs/crm-mac/stderr.log")
+        XCTAssertEqual(paths.apiKeyFile.path, "/Users/alice/Library/Application Support/crm-mac/api-key")
     }
 }

--- a/mac-daemon/Tests/CRMMacSystemTests/FileAPIKeyStoreTests.swift
+++ b/mac-daemon/Tests/CRMMacSystemTests/FileAPIKeyStoreTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+@testable import CRMMacSystem
+import CRMMacLifecycle
+
+final class FileAPIKeyStoreTests: XCTestCase {
+    private var tmpDir: URL!
+    private var keyPath: String!
+    private var store: FileAPIKeyStore!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tmpDir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("FileAPIKeyStoreTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: tmpDir, withIntermediateDirectories: true)
+        keyPath = tmpDir.appendingPathComponent("api-key").path
+        store = FileAPIKeyStore(path: keyPath)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tmpDir)
+        try super.tearDownWithError()
+    }
+
+    func testReadMissingFileThrowsNotFound() {
+        XCTAssertThrowsError(try store.readAPIKey()) { error in
+            guard let kErr = error as? KeychainStoreError, kErr == .notFound else {
+                XCTFail("expected .notFound, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testWriteReadRoundtrip() throws {
+        try store.writeAPIKey("s3cret-value")
+        XCTAssertEqual(try store.readAPIKey(), "s3cret-value")
+    }
+
+    func testWriteCreatesFileWith0600Perms() throws {
+        try store.writeAPIKey("abc")
+        let attrs = try FileManager.default.attributesOfItem(atPath: keyPath)
+        let perms = (attrs[.posixPermissions] as? NSNumber)?.intValue
+        XCTAssertEqual(perms, 0o600)
+    }
+
+    func testWriteIsIdempotentAndReplacesValue() throws {
+        try store.writeAPIKey("first")
+        try store.writeAPIKey("second")
+        XCTAssertEqual(try store.readAPIKey(), "second")
+    }
+
+    func testWriteCreatesParentDirectoryIfAbsent() throws {
+        let nested = tmpDir.appendingPathComponent("nested/dir/api-key").path
+        let nestedStore = FileAPIKeyStore(path: nested)
+        try nestedStore.writeAPIKey("nested-val")
+        XCTAssertEqual(try nestedStore.readAPIKey(), "nested-val")
+    }
+
+    func testDeleteRemovesFile() throws {
+        try store.writeAPIKey("to-be-deleted")
+        try store.deleteAPIKey()
+        XCTAssertFalse(FileManager.default.fileExists(atPath: keyPath))
+    }
+
+    func testDeleteIsIdempotentWhenAbsent() throws {
+        try store.deleteAPIKey()
+        try store.deleteAPIKey()
+    }
+
+    func testReadStripsTrailingNewline() throws {
+        // Simulate `echo "key" > api-key` from a human shell.
+        try "human-edit\n".data(using: .utf8)!
+            .write(to: URL(fileURLWithPath: keyPath))
+        XCTAssertEqual(try store.readAPIKey(), "human-edit")
+    }
+
+    func testReadPreservesEmbeddedWhitespace() throws {
+        try store.writeAPIKey("has spaces and\ttabs")
+        XCTAssertEqual(try store.readAPIKey(), "has spaces and\ttabs")
+    }
+
+    func testWriteDoesNotLeaveTempFileBehind() throws {
+        try store.writeAPIKey("clean")
+        let contents = try FileManager.default.contentsOfDirectory(atPath: tmpDir.path)
+        XCTAssertEqual(contents.filter { $0.contains(".tmp.") }, [])
+    }
+}


### PR DESCRIPTION
## Summary

- Replaces the daemon's macOS Keychain API-key storage with a 0600 plaintext file at `${configDir}/api-key`, eliminating the launchd-vs-Keychain hang that blocks the daemon on every rebuild
- One-shot legacy-Keychain → file migration runs in `install --upgrade` / `--register-only`
- Tracks the underlying TCC instability separately in #316 (.app bundle / Developer ID work)

## Why

The Keychain entry's ACL is tied to the binary's CDHash. Ad-hoc codesign produces a new CDHash on every `make mac-daemon`, so every `install --upgrade` triggered a "allow access?" prompt. Because launchd-spawned background agents can't render dialogs, the upgraded daemon would hang indefinitely in `SecItemCopyMatching` on startup (sample trace in this session's debugging confirmed this).

The fix: store the API key in a plain file with 0600 perms via atomic temp+rename. Same threat model as `~/.aws/credentials` / `~/.config/gh/hosts.yml` — anyone with read access to the user account can read the key.

## Migration

`crm-mac install --upgrade` (and `--register-only`) now runs a one-shot helper: if the primary store is empty but the legacy Keychain entry exists, copy → file, then delete the legacy entry. Idempotent — future upgrades see the file populated and skip the legacy read entirely. The legacy `ProductionKeychainStore` is retained behind a new `legacyKeychain: KeychainStore?` dep on `InstallerDependencies` (production wires the real Keychain; tests leave it nil).

## Test plan

- [x] `swift build` — local Mac, clean
- [x] End-to-end on real Mac: `make mac-daemon` → `install --upgrade` → daemon restarted under launchd, no Keychain hang, migration log line `migration: api-key copied from legacy Keychain to file`, legacy entry verified deleted via `security find-generic-password`
- [x] `crm-mac doctor` — PASS on all checks including the renamed `api-key: present`
- [x] New tests added (run by CI on `macos-15`):
  - `FileAPIKeyStoreTests` — round-trip, idempotent write, 0600 perms, missing-file `.notFound`, trailing-newline strip, embedded whitespace preserved, no leftover temp files, parent-dir creation
  - `DaemonPathsTests` — new `apiKeyFile` URL assertion
  - `InstallerUpgradeTests.testUpgradeMigratesLegacyKeychainToPrimary` — covers the migration path
  - `DoctorTests` — updated to the new `api-key` check name
- [ ] CI green

## Follow-ups

- #316 — wrap daemon in `.app` bundle (or buy Developer ID) to stabilize TCC grants across rebuilds for `icloud_contacts` and `messages`. Out of scope for this PR.