### PR TITLE
feat(mac-daemon): wrap as crm-mac.app + SMAppService.register()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,7 @@ jobs:
         # test-target dependencies are brittle under SPM.
         run: |
           ./.build/release/crm-mac --help
-          for cmd in daemon install uninstall doctor status configure; do
+          for cmd in daemon install uninstall doctor status configure messages stop start; do
             ./.build/release/crm-mac $cmd --help
           done
 
@@ -222,12 +222,12 @@ jobs:
 
       - name: Smoke — NSContactsUsageDescription embedded in __info_plist
         working-directory: mac-daemon
-        # Per plan D-JC12: SPM has no first-class Info.plist support
-        # for command-line executables. We embed via linker
-        # -sectcreate; if the flag silently drops out (Package.swift
-        # rewrite, SPM behavior change, etc.) the Contacts framework
-        # has no usage description and the consent prompt fails to
-        # appear on first requestAccess. Catch the regression here.
+        # SPM has no first-class Info.plist support for command-line
+        # executables. We embed via linker -sectcreate; if the flag
+        # silently drops out (Package.swift rewrite, SPM behavior
+        # change, etc.) the Contacts framework has no usage description
+        # and the consent prompt fails to appear on first
+        # requestAccess. Catch the regression here.
         run: |
           if ! otool -s __TEXT __info_plist .build/release/crm-mac | grep -q .; then
             echo "FAIL: __TEXT,__info_plist section is empty"
@@ -237,6 +237,63 @@ jobs:
             echo "FAIL: NSContactsUsageDescription key missing from binary"
             exit 1
           fi
+
+      - name: Smoke — bundle assembly under CLT-compatible tools
+        working-directory: mac-daemon
+        # Drives Scripts/assemble_bundle.sh against the release Mach-O.
+        # Asserts bundle structure, plist validity, codesign identifier
+        # parity on both inner Mach-O and outer bundle, and per-key
+        # equality between the source-tree Info.plist and the
+        # assembled bundle's Info.plist (NOT byte-identity — the
+        # install-path code-path uses PropertyListSerialization which
+        # may reorder keys; only key/value equality matters per the
+        # plan's D22).
+        run: |
+          bash Scripts/assemble_bundle.sh \
+            .build/release/crm-mac \
+            .build/release/crm-mac.app \
+            Sources/crm-mac/Info.plist
+          # Bundle structure exists.
+          test -f .build/release/crm-mac.app/Contents/Info.plist
+          test -f .build/release/crm-mac.app/Contents/MacOS/crm-mac
+          test -f .build/release/crm-mac.app/Contents/Library/LaunchAgents/xyz.spengrah.crm-mac.plist
+          # Plists parse.
+          plutil -lint .build/release/crm-mac.app/Contents/Info.plist
+          plutil -lint .build/release/crm-mac.app/Contents/Library/LaunchAgents/xyz.spengrah.crm-mac.plist
+          # Per-key value match between source-tree Info.plist and the
+          # assembled bundle's Info.plist.
+          for key in CFBundleIdentifier CFBundleName CFBundleExecutable CFBundleVersion CFBundleShortVersionString CFBundlePackageType CFBundleInfoDictionaryVersion LSUIElement LSMinimumSystemVersion NSContactsUsageDescription; do
+            src=$(plutil -extract "$key" raw Sources/crm-mac/Info.plist)
+            dst=$(plutil -extract "$key" raw .build/release/crm-mac.app/Contents/Info.plist)
+            if [ "$src" != "$dst" ]; then
+              echo "FAIL: Info.plist key $key differs between source ($src) and bundle ($dst)"
+              exit 1
+            fi
+          done
+          # CFBundleIdentifier in the bundle matches the daemon label.
+          test "$(plutil -extract CFBundleIdentifier raw .build/release/crm-mac.app/Contents/Info.plist)" = "xyz.spengrah.crm-mac"
+          # Outer bundle codesign valid.
+          codesign --verify --strict --deep .build/release/crm-mac.app
+          # Inner Mach-O identifier matches (D5 two-pass sign).
+          codesign --display --verbose=2 .build/release/crm-mac.app/Contents/MacOS/crm-mac 2>&1 \
+            | grep -qE "^Identifier=xyz\.spengrah\.crm-mac$"
+          # Outer bundle identifier matches.
+          codesign --display --verbose=2 .build/release/crm-mac.app 2>&1 \
+            | grep -qE "^Identifier=xyz\.spengrah\.crm-mac$"
+
+      - name: Integration tests — bundle assembly parity + atomic swap
+        working-directory: mac-daemon
+        # Real-Foundation integration tests gated by env var. Covers:
+        #   - BundleAssemblyParityTests: shell + Swift assembly produce
+        #     byte-identical bundles given the same source-tree inputs.
+        #   - BundleSwapAtomicityTests: upgrade-path backup-rename-swap
+        #     uses only empty/absent destinations (no ENOTEMPTY trap).
+        # These tests aren't safe under the default --parallel test
+        # runner because they shell out + write to a tmp dir; opt-in
+        # via env var keeps them out of normal `swift test` runs.
+        env:
+          CRM_MAC_INTEGRATION_TESTS: "1"
+        run: swift test --filter 'BundleAssemblyParityTests|BundleSwapAtomicityTests'
 
   e2e-tests:
     name: E2E Tests

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ help:
 	@echo "  dev-native  - Start dev servers with native PostgreSQL (no Docker)"
 	@echo "  build       - Build both frontend and backend"
 	@echo "  crm-admin   - Build the operator-only admin CLI (backend/crm-admin)"
-	@echo "  mac-daemon  - Build the macOS daemon binary (mac-daemon/.build/release/crm-mac, ad-hoc signed)"
+	@echo "  mac-daemon  - Build the macOS daemon app bundle (mac-daemon/.build/release/crm-mac.app, ad-hoc signed)"
 	@echo "  sqlc        - Regenerate sqlc code from SQL queries"
 	@echo "  lint        - Run all linters (backend + frontend)"
 	@echo "  clean       - Clean build artifacts"
@@ -258,16 +258,21 @@ crm-admin:
 	@cd backend && go build -o crm-admin cmd/crm-admin/main.go
 	@echo "✓ crm-admin built at backend/crm-admin"
 
-# Mac daemon binary. Built locally on a Mac; not wired into `make
-# build` because the Pi-side build pipeline has no Swift toolchain.
-# Produces an ad-hoc-signed release binary at
-# mac-daemon/.build/release/crm-mac. First Gatekeeper launch may
-# require System Settings -> Privacy & Security approval.
+# Mac daemon. Built locally on a Mac; not wired into `make build`
+# because the Pi-side build pipeline has no Swift toolchain.
+# Produces an ad-hoc-signed crm-mac.app bundle at
+# mac-daemon/.build/release/crm-mac.app (per the SMAppService
+# architecture in .ai/log/plan/mac-daemon-app-bundle-rewrite.md).
+# Bundle assembly is delegated to Scripts/assemble_bundle.sh — only
+# Command Line Tools (no full Xcode) are required.
 mac-daemon:
 	@echo "Building crm-mac (release)..."
 	@cd mac-daemon && swift build -c release
-	@codesign -s - --force mac-daemon/.build/release/crm-mac
-	@echo "✓ crm-mac built at mac-daemon/.build/release/crm-mac"
+	@bash mac-daemon/Scripts/assemble_bundle.sh \
+		mac-daemon/.build/release/crm-mac \
+		mac-daemon/.build/release/crm-mac.app \
+		mac-daemon/Sources/crm-mac/Info.plist
+	@echo "✓ crm-mac.app built at mac-daemon/.build/release/crm-mac.app"
 
 # Run Mac daemon Swift tests locally. Requires Xcode 16 (Swift 6 toolchain).
 # A CI-skipped chat.db smoke test reads ~/Library/Messages/chat.db; that

--- a/mac-daemon/README.md
+++ b/mac-daemon/README.md
@@ -1,13 +1,13 @@
 # crm-mac — Personal CRM Mac daemon
 
-Single-binary Swift daemon that ingests Apple Messages + iCloud Contacts from a Mac and pushes events to the Pi-side Personal CRM API. Phase 1 (this PR is PR6) lands the daemon framework only — no source readers yet. PR7 adds the `messages` source; PR8 adds `icloud_contacts`.
+Single-binary Swift daemon that ingests Apple Messages + iCloud Contacts from a Mac and pushes events to the Pi-side Personal CRM API.
 
 See `../.ai/spec/mac-daemon.md` for the authoritative scope. This README covers local install + smoke procedures only.
 
 ## Requirements
 
-- macOS 13+ (the package targets `macOS(.v13)`).
-- Xcode Command Line Tools or a full Xcode install (the latter is required for `swift test` — Command Line Tools ship Swift but not XCTest).
+- macOS 14+ (the package targets `macOS(.v14)`; SMAppService requires macOS 13+ at minimum).
+- Xcode Command Line Tools or a full Xcode install. `swift test` requires XCTest (full Xcode); `swift build` plus the bundle-assembly script work on CLT only.
 - A running Pi-side `crm-api` reachable from the Mac (typically via Tailscale).
 
 ## Build
@@ -18,11 +18,11 @@ From the repo root:
 make mac-daemon
 ```
 
-This runs `swift build -c release` from `mac-daemon/` and ad-hoc codesigns the resulting binary. Output: `mac-daemon/.build/release/crm-mac`.
+This runs `swift build -c release` from `mac-daemon/`, then assembles + ad-hoc codesigns `crm-mac.app` via `mac-daemon/Scripts/assemble_bundle.sh`. Output: `mac-daemon/.build/release/crm-mac.app`. The script uses CLT-shipped tools only (no `xcodebuild`).
 
 ## Pair + install (manual smoke)
 
-The PR6 Definition of Done. Replace `<pi-host>` with your Pi's reachable hostname (typically a Tailscale name) and `<pi-url>` with the Pi's HTTPS base URL.
+Replace `<pi-host>` with your Pi's reachable hostname and `<pi-url>` with the Pi's HTTPS base URL.
 
 **On the Pi:** mint a single-use pairing token.
 
@@ -40,25 +40,25 @@ cd /srv/personalcrm
 # note: paste into `crm-mac install --pair <token>` within 10 minutes
 ```
 
-The pairing token is single-use and short-lived (10 minutes). The `--hostname-label` flag is operator-side terminal context only — it is NOT persisted server-side. The Mac daemon supplies its own hostname at pair time via `crm-mac install --hostname`.
+The pairing token is single-use and short-lived (10 minutes).
 
-**On the Mac:** install the daemon.
+**On the Mac:** install the daemon. Run the binary from inside the freshly-built bundle so SMAppService picks up the bundle context.
 
 ```bash
-./mac-daemon/.build/release/crm-mac install \
+./mac-daemon/.build/release/crm-mac.app/Contents/MacOS/crm-mac install \
     --pair <token> \
     --pi-url <pi-url> \
     --hostname mac-1
 ```
 
-`--hostname` is REQUIRED on fresh install. Pick a non-PII label (`mac-1`, `work-mac`, `home-laptop`). The value is stored in the Pi's `mac_host` table and shown in the settings UI.
+`--hostname` is REQUIRED on fresh install. Pick a non-PII label (`mac-1`, `work-mac`, `home-laptop`).
 
-The first launch may trip Gatekeeper because the binary is ad-hoc signed. If it does, the daemon will print a hint pointing at **System Settings → Privacy & Security → "crm-mac was blocked..." → Open Anyway.**
+After install, macOS will surface the agent in **System Settings → General → Login Items → Allow in Background**. If the daemon fails to start, check that the "crm-mac" entry is toggled on. The bundle is ad-hoc signed — first launch may surface a Gatekeeper prompt; allow it once.
 
-Before testing the `messages` source, grant **Full Disk Access** to the installed daemon binary:
+Before testing the `messages` source, grant **Full Disk Access** to the installed bundle:
 
 1. Open **System Settings → Privacy & Security → Full Disk Access**.
-2. Click **+** and add `~/Library/Application Support/crm-mac/bin/crm-mac`.
+2. Click **+** and add `~/Library/Application Support/crm-mac/crm-mac.app`.
 3. Ensure the new `crm-mac` entry is enabled.
 
 Without this permission, the daemon cannot read `~/Library/Messages/chat.db` and the messages source reports `fda_required`.
@@ -66,9 +66,9 @@ Without this permission, the daemon cannot read `~/Library/Messages/chat.db` and
 ## Verify
 
 ```bash
-./mac-daemon/.build/release/crm-mac doctor
+~/Library/Application\ Support/crm-mac/crm-mac.app/Contents/MacOS/crm-mac doctor
 # PASS  api-key: present
-# PASS  launchctl: service registered
+# PASS  agent_service: registered (enabled)
 # PASS  config_state: host=mac-1 schemaVersion=1
 # PASS  pi_reachability: phones=N emails=N
 ```
@@ -76,18 +76,18 @@ Without this permission, the daemon cannot read `~/Library/Messages/chat.db` and
 Exit code = number of FAIL entries.
 
 ```bash
-launchctl print gui/$(id -u)/xyz.spengrah.crm-mac >/dev/null && echo "registered"
-# registered
+~/Library/Application\ Support/crm-mac/crm-mac.app/Contents/MacOS/crm-mac doctor | grep agent_service
 ```
 
-We deliberately do NOT parse any specific line from `launchctl print` output — the human-readable format is informational, not API.
+We deliberately do NOT shell out to `launchctl print` for verification — SMAppService is the authoritative API and `agentService.currentStatus` surfaces the same state.
 
 ## Status
 
 ```bash
-./mac-daemon/.build/release/crm-mac status
+~/Library/Application\ Support/crm-mac/crm-mac.app/Contents/MacOS/crm-mac status
 # installed=true
 # registered=true
+# registration_status=enabled
 # hostname=mac-1
 # pi_url=<pi-url>
 # host_id=<uuid>
@@ -95,33 +95,42 @@ We deliberately do NOT parse any specific line from `launchctl print` output —
 # last_heartbeat_at=2026-05-13T16:00:00Z
 ```
 
-## Reboot smoke
+`registration_status` distinguishes `enabled`, `requires_approval`, `not_registered`, `not_found`.
 
-To verify Keychain access from the launchd context (the daemon runs under launchd; the Keychain is unlocked after first interactive login of the boot session per `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`):
+## Reboot smoke
 
 ```bash
 sudo shutdown -r now
-# After login, wait ~60s for the heartbeat tick:
-./mac-daemon/.build/release/crm-mac status
-# last_heartbeat_at should be recent.
+# After login, wait ~60s for the heartbeat tick.
+crm-mac status
 ```
 
 ## Upgrade
 
-To replace the installed binary in place without re-pairing:
-
 ```bash
 make mac-daemon
-./mac-daemon/.build/release/crm-mac install --upgrade
+~/Library/Application\ Support/crm-mac/crm-mac.app/Contents/MacOS/crm-mac install --upgrade
 ```
 
-`--upgrade` reads the existing `config.json` + Keychain api-key, bootouts the running daemon, atomic-renames the new binary into place, and re-bootstraps launchd. It does NOT call `POST /host`.
+`--upgrade` reads the existing `config.json` + api-key, stops the running daemon (SMAppService.unregister + SIGTERM-and-poll), backs up the existing bundle, assembles the new one at a tmp path, atomic-renames it into place, substitutes the install-prefix placeholder in the embedded LaunchAgents plist, and re-registers via SMAppService. It does NOT call `POST /host`.
 
-Because local builds are ad-hoc signed, macOS may ask you to approve Keychain access again after replacing the installed binary with a rebuilt one.
+The bundle ID (`xyz.spengrah.crm-mac`) is the TCC attribution key — Contacts + Full Disk Access grants should survive `make mac-daemon` rebuilds as long as the bundle ID and codesign identifier match between rebuilds. (This is the engineering hypothesis the rewrite is built on; if a rebuild surfaces a permission re-prompt, see Troubleshooting.)
+
+## Stop / start (maintenance windows)
+
+Operator workflows that mutate cursor state (e.g. `messages backfill --restart`, `messages scan`) refuse while the daemon is running. Stop the daemon, run the op, then start:
+
+```bash
+crm-mac stop
+crm-mac messages backfill --restart
+crm-mac start
+```
+
+`crm-mac stop` calls SMAppService.unregister + SIGTERM the daemon process + polls the pidfile. `crm-mac start` re-registers via SMAppService + polls for the `.enabled` status.
 
 ## Recovery scenarios
 
-**Pi unreachable during fresh install (network drop after Pi commit).** The pair tx may have committed before the daemon got the response back. The Pi-side host row exists but the daemon doesn't know its `host_id` or `api_key`:
+**Pi unreachable during fresh install (network drop after Pi commit).** The pair tx may have committed before the daemon got the response back:
 
 ```bash
 ssh <pi-host> "sudo -u crm bash -lc '
@@ -130,46 +139,40 @@ set -a
 set +a
 cd /srv/personalcrm
 ./backend/bin/crm-admin --list-hosts
-'"
-# id=<uuid> hostname=mac-1 created_at=... last_heartbeat_at=never
-ssh <pi-host> "sudo -u crm bash -lc '
-set -a
-. /srv/personalcrm/.env
-set +a
-cd /srv/personalcrm
 ./backend/bin/crm-admin --revoke-host <uuid>
 '"
-# revoked host_id=<uuid>
 # Then re-mint a token and re-install.
 ```
 
-**Post-pair persistence failure (Keychain write, state write, or atomic-rename failed).** Local state is partially populated:
+**Post-pair persistence failure (api-key write, state write, or atomic-rename failed).**
 
 ```bash
-./mac-daemon/.build/release/crm-mac uninstall --purge
-ssh <pi-host> "sudo -u crm bash -lc '
-set -a
-. /srv/personalcrm/.env
-set +a
-cd /srv/personalcrm
-./backend/bin/crm-admin --revoke-host <host_id>
-'"
-# Re-mint a token and re-install.
+crm-mac uninstall --purge
+# Then on the Pi: --revoke-host <uuid>, re-mint, re-install.
 ```
 
-**`launchctl bootstrap` failed (binary + config + Keychain + state all in place; only launchd registration failed).** The binary IS installed:
+**SMAppService.register failed (bundle in place; only registration step failed).** Address the underlying issue (typically: approve the agent in System Settings → Login Items), then:
 
 ```bash
-# Address the underlying issue (System Settings -> Privacy & Security).
-./mac-daemon/.build/release/crm-mac install --register-only
+crm-mac install --register-only
 ```
+
+**Legacy bare-binary install detected.** The first run of a post-rewrite binary against an existing pre-rewrite install will trigger automatic migration: stop the legacy daemon, bootout the legacy launchd registration, assemble the new bundle, register, then delete the legacy plist + bare binary. Operator-facing UX: `crm-mac install --upgrade` Just Works. If the migration fails partway (e.g. legacy bootout reports the registration is still loaded), the operator manually runs `launchctl bootout gui/$(id -u)/xyz.spengrah.crm-mac` and re-runs `--upgrade`.
 
 ## Uninstall
 
 ```bash
-./mac-daemon/.build/release/crm-mac uninstall --purge
-# bootouts launchd, removes plist, deletes Keychain entry, removes
-# config.json + state.json + installed binary.
+crm-mac uninstall
+# daemon_stopped=true
+# unregister_invoked=true
+# bundle_deleted=true
+# keychain_deleted=true
+# legacy_plist_deleted=false
+# legacy_binary_deleted=false
+# purged=false
+
+crm-mac uninstall --purge
+# Also removes config.json + state.json + logs + icloud hash cache.
 ```
 
 The Pi-side `mac_host` row is NOT touched — run `crm-admin --revoke-host <uuid>` on the Pi if you want to remove the row.
@@ -178,12 +181,15 @@ The Pi-side `mac_host` row is NOT touched — run `crm-admin --revoke-host <uuid
 
 | Item | Path |
 |---|---|
-| Binary (after install) | `~/Library/Application Support/crm-mac/bin/crm-mac` |
-| LaunchAgent plist | `~/Library/LaunchAgents/xyz.spengrah.crm-mac.plist` |
+| Bundle (after install) | `~/Library/Application Support/crm-mac/crm-mac.app` |
+| Daemon binary inside bundle | `~/Library/Application Support/crm-mac/crm-mac.app/Contents/MacOS/crm-mac` |
+| Embedded LaunchAgent plist | `~/Library/Application Support/crm-mac/crm-mac.app/Contents/Library/LaunchAgents/xyz.spengrah.crm-mac.plist` |
 | config.json | `~/Library/Application Support/crm-mac/config.json` |
 | state.json | `~/Library/Application Support/crm-mac/state.json` |
+| api-key file | `~/Library/Application Support/crm-mac/api-key` |
+| icloud_contacts_hashes.json | `~/Library/Application Support/crm-mac/icloud_contacts_hashes.json` |
 | stdout/stderr logs | `~/Library/Logs/crm-mac/{stdout,stderr}.log` |
-| Keychain entry | service `xyz.spengrah.crm-mac`, account `api-key` |
+| Bundle identifier (TCC keying) | `xyz.spengrah.crm-mac` |
 | Unified log subsystem | `xyz.spengrah.crm-mac` |
 
 To tail the unified log:
@@ -192,124 +198,84 @@ To tail the unified log:
 log stream --predicate 'subsystem == "xyz.spengrah.crm-mac"' --info
 ```
 
-## Spec deviation notes
+## Troubleshooting
 
-- **`cursor_epoch` is NOT in Keychain** (spec lists it; PR6 puts it in `state.json` instead). It's an opaque integer the Pi increments on backup-restore — not a secret, no security guarantee from Keychain storage, and putting it on disk avoids a Keychain write per source-poll. The Pi's cursor + epoch remain the source of truth; PR7/PR8 refresh from heartbeat responses and handle `cursor_epoch` mismatch by refetching Pi state rather than trusting local cache.
-- **Bare CLI binary, not an `.app` bundle.** PR6 uses classic `launchctl bootstrap gui/<uid> <plist>` rather than `SMAppService.agent`, which expects the plist to be a resource of the calling main app bundle. See `.ai/log/plan/mac-daemon-phase-1-pr6-daemon-skeleton.md` D14 for the rationale.
-- **CI pinned to `macos-15`**, not `macos-latest`. Eliminates the silent image-migration risk; an image deprecation will surface as a loud CI failure in a follow-up PR.
+**Contacts or Full Disk Access re-prompts after `make mac-daemon && crm-mac install --upgrade`.** TCC for bundled apps keys on the bundle ID + codesign identifier. Confirm both are stable across rebuilds:
+
+```bash
+codesign --display --verbose=2 ~/Library/Application\ Support/crm-mac/crm-mac.app/Contents/MacOS/crm-mac 2>&1 | grep Identifier
+# Identifier=xyz.spengrah.crm-mac
+codesign --display --verbose=2 ~/Library/Application\ Support/crm-mac/crm-mac.app 2>&1 | grep Identifier
+# Identifier=xyz.spengrah.crm-mac
+```
+
+If either shows a different identifier (e.g. `crm-mac-<random>`), the two-pass codesign didn't take effect — debug `mac-daemon/Scripts/assemble_bundle.sh`.
+
+If the identifiers are correct but TCC still re-prompts, try moving the bundle to `~/Applications/crm-mac.app` (some macOS internals treat `~/Library/Application Support/` differently from `~/Applications/` for SMAppService-managed agents — undocumented).
 
 ## Testing
 
-Unit + lifecycle tests run on CI via `.github/workflows/mac-daemon.yml` on `macos-15`. To run locally:
+Unit + lifecycle tests run on CI via `.github/workflows/ci.yml` on `macos-15`. To run locally:
 
 ```bash
 cd mac-daemon
 swift test
 ```
 
-`swift test` requires XCTest, which ships with the full Xcode (not the Command Line Tools subset). The `KeychainProductionTests` are skipped in CI (`XCTSkipIf(CI=true)`) — they exercise SecItem* against the developer's keychain using a per-run test account.
+`swift test` requires XCTest, which ships with the full Xcode (not the Command Line Tools subset).
 
-You can also run via the project Makefile:
+A subset of opt-in tests exercises the real Foundation FilesystemAdapter + the bundle-assembly shell script. They are gated by an env var:
+
+```bash
+cd mac-daemon
+CRM_MAC_INTEGRATION_TESTS=1 swift test \
+    --filter 'BundleAssemblyParityTests|BundleSwapAtomicityTests'
+```
+
+CI runs these in a dedicated step after the regular `swift test` invocation.
+
+You can also run the full local suite via the project Makefile:
 
 ```bash
 make test-daemon-local
 ```
 
-## Operator commands (PR7)
+## Operator commands
 
 ### `crm-mac messages backfill --restart`
 
-Reset the messages cursor to install-time state so the daemon re-walks all historical messages back to the 2026-01-01 backfill floor. The command refuses while the daemon is running (it would race with the daemon's own cursor commits). Stop the daemon, run the command, then restart:
+Reset the messages cursor. Stop the daemon, run the command, then start:
 
 ```bash
-launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/xyz.spengrah.crm-mac.plist
+crm-mac stop
 crm-mac messages backfill --restart       # prompts for "yes"
 crm-mac messages backfill --restart --yes # scripted / no prompt
-launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/xyz.spengrah.crm-mac.plist
+crm-mac start
 ```
-
-This produces duplicate-but-deduplicated events on the Pi (event-log `(source, source_id)` dedup absorbs the overlap; no contact-side effect, but visible in `/api/v1/host/:id` logs).
 
 ### `crm-mac messages scan --identifier <handle> [--since 30d]`
 
-Queue a one-shot backwards scan for a specific phone/email handle. The scan request is persisted Pi-side via the cursor JSON. **v1 limitation:** the daemon's source plugin observes pending-scan requests via `crm-mac status` and logs them on each tick, but does NOT yet execute identifier-scoped backwards scans (chat.db has no indexed-by-handle reader; a full scan would be required). The regular backfill descent walks every message back to the `backfill_floor_sent_at` floor anyway, so a newly-added contact's historical messages will arrive once backfill reaches them. The scan command is wired through so a future PR can ship the actual scan execution without an additional protocol change. Same daemon-running guard as `backfill`.
+Queue a one-shot backwards scan for a specific phone/email handle.
 
 ```bash
-launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/xyz.spengrah.crm-mac.plist
+crm-mac stop
 crm-mac messages scan --identifier "+1-555-123-4567" --since 30d
-launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/xyz.spengrah.crm-mac.plist
+crm-mac start
 ```
 
 `--since` accepts a simple duration: `30d`, `12h`, `60m`, `3600s`.
 
 ## Daemon-running guard
 
-PR7 introduces a POSIX advisory lock on `~/Library/Application Support/crm-mac/daemon.pid`. The daemon acquires it on start, the ops subcommands acquire-or-refuse it before mutating cursor state. Stale PID recovery is automatic — if the daemon crashed without releasing the lock, the next daemon startup (or CLI op) detects the dead PID, unlinks the pidfile, and re-acquires.
+The daemon acquires a POSIX advisory lock on `~/Library/Application Support/crm-mac/daemon.pid` on start; the ops subcommands acquire-or-refuse it before mutating cursor state. Stale PID recovery is automatic — if the daemon crashed without releasing the lock, the next startup detects the dead PID, unlinks the pidfile, and re-acquires.
 
-## Live smoke test (PR7)
+## Spec deviation notes
 
-Pre-req: daemon paired to a live Pi; Full Disk Access granted to the installed `crm-mac` binary; messages tick disabled or running on its scheduled cadence. If `./mac-daemon/.build/release/crm-mac status` reports `installed=false`, complete **Pair + install (manual smoke)** above before starting this procedure.
-
-This is a live ingestion smoke, not a dry run. Once the Pi ingest route is enabled and the daemon is running, the daemon publishes new messages immediately and also starts bounded historical backfill toward the configured floor.
-
-1. **Pick a fixture contact** — one whose primary phone/email is in the canonical `known-identifiers` set.
-
-2. **Pre-state — capture last_contacted on the Pi:**
-
-   ```bash
-   ssh <pi-host> 'docker exec crm-postgres psql -U crm_user -d personal_crm \
-       -c "SELECT id, last_contacted FROM contact WHERE id = '<uuid>';"'
-   ```
-
-3. **Ensure the installed daemon is running the PR7 binary.** If you just completed a fresh install from this checkout, skip this step. If this Mac already had an older installed daemon, upgrade it in place:
-
-   ```bash
-   make mac-daemon
-   ./mac-daemon/.build/release/crm-mac install --upgrade
-   ```
-
-4. **Receive a real inbound iMessage** from the fixture contact. Outbound rows are not emitted yet; see **Limitations (v1)** below.
-
-5. **Wait two messages-tick cadences** (~3 minutes).
-
-6. **Verify events arrived on the Pi:**
-
-   ```bash
-   ssh <pi-host> 'sudo journalctl -u personalcrm-backend --since "10 min ago" --no-pager' \
-       | grep -i raw_message
-   ```
-
-   Expect: at least one `raw_message.received` event with `accepted=1`.
-
-7. **Verify the interaction row** was created on the Pi:
-
-   ```bash
-   ssh <pi-host> 'docker exec crm-postgres psql -U crm_user -d personal_crm \
-       -c "SELECT id, contact_id, source, direction, occurred_at \
-           FROM interaction \
-           WHERE contact_id = '<uuid>' AND source = '"'"'messages'"'"' \
-           ORDER BY occurred_at DESC LIMIT 5;"'
-   ```
-
-   Expect: >= 1 row with `source=messages`, `direction=inbound`, recent `occurred_at`.
-
-8. **Verify last_contacted advanced:**
-
-   ```bash
-   ssh <pi-host> 'docker exec crm-postgres psql -U crm_user -d personal_crm \
-       -c "SELECT last_contacted FROM contact WHERE id = '<uuid>';"'
-   ```
-
-9. **Verify the messages source health:**
-
-   ```bash
-   ./mac-daemon/.build/release/crm-mac status
-   ```
-
-   Expect: messages source `live_cursor` advanced; `backfill_complete` either false (still descending) or true; no `last_error`.
+- **CI pinned to `macos-15`**, not `macos-latest`. Eliminates the silent image-migration risk; an image deprecation will surface as a loud CI failure in a follow-up PR.
+- **TCC stability.** The bundle identifier `xyz.spengrah.crm-mac` is the responsible-process key TCC uses for the daemon. The two-pass codesign in `Scripts/assemble_bundle.sh` (inner Mach-O with `--identifier xyz.spengrah.crm-mac`, then bundle seal) ensures the identifier is stable across rebuilds. See Troubleshooting if a rebuild surfaces a permission re-prompt.
 
 ## Limitations (v1)
 
-- **Daemon-down + contact added → no auto-scan.** Plan §R9: the daemon's known-identifiers cache hash detects offline contact-list changes but does NOT auto-queue a 30-day scan for every new identifier (it would defeat the optimization on every restart). Run `crm-mac messages scan --identifier <X>` manually if you want backfill for a specific newly-added contact.
-- **Outbound group attribution.** For outbound group messages the daemon attributes the outreach to the first non-self handle by `chat_handle_join.ROWID` order. This is a v1 simplification: every outbound group message attributes to the same arbitrary peer, so one group member's `last_outreach_at` advances on every outbound group message while others' do not.
-- **Outbound messages currently not emitted.** The reader's fetch query joins on `message.handle_id`, which is NULL for outbound rows in chat.db; outbound peer resolution requires a separate path through `outboundGroupPeer`, deferred to a follow-up. Inbound emission is fully wired.
+- **Daemon-down + contact added → no auto-scan.** The daemon's known-identifiers cache hash detects offline contact-list changes but does NOT auto-queue a 30-day scan for every new identifier. Run `crm-mac messages scan --identifier <X>` manually if you want backfill for a specific newly-added contact.
+- **Outbound group attribution.** For outbound group messages the daemon attributes the outreach to the first non-self handle by `chat_handle_join.ROWID` order. v1 simplification: every outbound group message attributes to the same arbitrary peer.
+- **Outbound messages currently not emitted.** The reader's fetch query joins on `message.handle_id`, which is NULL for outbound rows in chat.db.

--- a/mac-daemon/Scripts/assemble_bundle.sh
+++ b/mac-daemon/Scripts/assemble_bundle.sh
@@ -35,7 +35,7 @@
 # Command Line Tools (no full Xcode required): mkdir, cp, chmod,
 # plutil, codesign. No xcodebuild, no swiftc invocation, no lipo.
 #
-# Two-pass codesign per plan D5:
+# Two-pass codesign:
 #   1. Inner Mach-O signed with explicit --identifier xyz.spengrah.crm-mac
 #      (so TCC keys on the bundle ID, not a build-host-derived suffix).
 #   2. Outer bundle seal (no --deep; the inner binary was signed first).
@@ -137,7 +137,7 @@ EOF
 plutil -lint "${BUNDLE_PATH}/Contents/Info.plist" >/dev/null
 plutil -lint "${BUNDLE_PATH}/Contents/Library/LaunchAgents/${LAUNCH_AGENTS_PLIST_NAME}" >/dev/null
 
-# Two-pass codesign (plan D5).
+# Two-pass codesign.
 codesign --force --sign - \
     --identifier "${BUNDLE_IDENTIFIER}" \
     "${BUNDLE_PATH}/Contents/MacOS/crm-mac"

--- a/mac-daemon/Scripts/assemble_bundle.sh
+++ b/mac-daemon/Scripts/assemble_bundle.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Assemble crm-mac.app from a built Mach-O + Info.plist source.
+#
+# Usage: assemble_bundle.sh <macho_path> <bundle_path> <info_plist_source>
+#
+# Inputs:
+#   - <macho_path>        Path to the release Mach-O (e.g. .build/release/crm-mac).
+#   - <bundle_path>       Final bundle path (e.g. .build/release/crm-mac.app).
+#                         If present, removed and replaced.
+#   - <info_plist_source> Path to the canonical Info.plist
+#                         (mac-daemon/Sources/crm-mac/Info.plist).
+#
+# Output: a fully-assembled, ad-hoc-codesigned crm-mac.app bundle at
+# <bundle_path> with:
+#
+#   crm-mac.app/Contents/
+#     Info.plist                          <- byte-identical copy of <info_plist_source>
+#     MacOS/crm-mac                       <- copy of <macho_path>, chmod +x
+#     Library/LaunchAgents/
+#       xyz.spengrah.crm-mac.plist        <- LaunchAgent plist with
+#                                            __INSTALL_PREFIX__ placeholder
+#
+# The LaunchAgents plist uses __INSTALL_PREFIX__ as a placeholder for
+# the install-time bundle path (the operator's
+# `~/Library/Application Support/crm-mac/crm-mac.app`). At install
+# time the Swift installer substitutes the placeholder with the real
+# install path before SMAppService registers the bundle. The
+# build-time artifact is never registered with launchd from the
+# .build/release/ directory itself.
+#
+# Logs + config-dir paths in the LaunchAgent plist use the build-time
+# $HOME directly; they're never read by macOS from the build artifact.
+#
+# This script intentionally uses ONLY tools that ship with the Xcode
+# Command Line Tools (no full Xcode required): mkdir, cp, chmod,
+# plutil, codesign. No xcodebuild, no swiftc invocation, no lipo.
+#
+# Two-pass codesign per plan D5:
+#   1. Inner Mach-O signed with explicit --identifier xyz.spengrah.crm-mac
+#      (so TCC keys on the bundle ID, not a build-host-derived suffix).
+#   2. Outer bundle seal (no --deep; the inner binary was signed first).
+#
+# Verifications:
+#   - codesign --verify --strict --deep on the bundle (--deep is
+#     Apple-recommended for VERIFICATION only).
+#   - Inner Mach-O Identifier= line matches xyz.spengrah.crm-mac.
+#   - Outer bundle Identifier= line matches xyz.spengrah.crm-mac.
+set -euo pipefail
+
+if [ "$#" -ne 3 ]; then
+    echo "usage: $0 <macho_path> <bundle_path> <info_plist_source>" >&2
+    exit 1
+fi
+
+MACHO_PATH="$1"
+BUNDLE_PATH="$2"
+INFO_PLIST_SOURCE="$3"
+BUNDLE_IDENTIFIER="xyz.spengrah.crm-mac"
+LAUNCH_AGENTS_PLIST_NAME="${BUNDLE_IDENTIFIER}.plist"
+
+# Defensive: refuse if no Xcode/CLT is selected. xcode-select -p prints
+# the active developer dir on stdout; we only care that it is non-empty.
+# Either CLT (/Library/Developer/CommandLineTools) or a full Xcode path
+# is fine — the tools we need (codesign, plutil) ship in both.
+XCODE_SELECT_PATH="$(xcode-select -p 2>/dev/null || true)"
+if [ -z "${XCODE_SELECT_PATH}" ]; then
+    echo "FAIL: xcode-select -p returned empty. Install Xcode Command Line Tools (xcode-select --install) or set DEVELOPER_DIR." >&2
+    exit 1
+fi
+
+if [ ! -x "${MACHO_PATH}" ]; then
+    echo "FAIL: Mach-O input '${MACHO_PATH}' does not exist or is not executable" >&2
+    exit 1
+fi
+
+if [ ! -f "${INFO_PLIST_SOURCE}" ]; then
+    echo "FAIL: Info.plist source '${INFO_PLIST_SOURCE}' does not exist" >&2
+    exit 1
+fi
+
+# Idempotent rebuild: nuke any leftover bundle from a prior run.
+rm -rf "${BUNDLE_PATH}"
+mkdir -p "${BUNDLE_PATH}/Contents/MacOS" \
+    "${BUNDLE_PATH}/Contents/Library/LaunchAgents"
+
+# Stage the Mach-O.
+cp "${MACHO_PATH}" "${BUNDLE_PATH}/Contents/MacOS/crm-mac"
+chmod +x "${BUNDLE_PATH}/Contents/MacOS/crm-mac"
+
+# Copy Info.plist verbatim from the source tree. This is byte-identical
+# to the source file by construction (cp(1) preserves bytes).
+cp "${INFO_PLIST_SOURCE}" "${BUNDLE_PATH}/Contents/Info.plist"
+
+# Write the LaunchAgents plist. The binary path contains the
+# __INSTALL_PREFIX__ placeholder; the Swift installer substitutes the
+# real install-time bundle path at install time. The logs / config-dir
+# values use the build-time $HOME directly — the build-time artifact
+# is never loaded into launchd from .build/release/ so these values
+# are advisory.
+BUILD_HOME="${HOME:-/Users/runner}"
+cat > "${BUNDLE_PATH}/Contents/Library/LaunchAgents/${LAUNCH_AGENTS_PLIST_NAME}" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>${BUNDLE_IDENTIFIER}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__INSTALL_PREFIX__/Contents/MacOS/crm-mac</string>
+        <string>daemon</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <dict>
+        <key>Crashed</key>
+        <true/>
+    </dict>
+    <key>ProcessType</key>
+    <string>Background</string>
+    <key>StandardOutPath</key>
+    <string>${BUILD_HOME}/Library/Logs/crm-mac/stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>${BUILD_HOME}/Library/Logs/crm-mac/stderr.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>CRM_MAC_CONFIG_DIR</key>
+        <string>${BUILD_HOME}/Library/Application Support/crm-mac</string>
+    </dict>
+</dict>
+</plist>
+EOF
+
+# Lint both plists. plutil refuses to lint a malformed plist and exits
+# non-zero; -euo pipefail at the top makes that fatal.
+plutil -lint "${BUNDLE_PATH}/Contents/Info.plist" >/dev/null
+plutil -lint "${BUNDLE_PATH}/Contents/Library/LaunchAgents/${LAUNCH_AGENTS_PLIST_NAME}" >/dev/null
+
+# Two-pass codesign (plan D5).
+codesign --force --sign - \
+    --identifier "${BUNDLE_IDENTIFIER}" \
+    "${BUNDLE_PATH}/Contents/MacOS/crm-mac"
+codesign --force --sign - "${BUNDLE_PATH}"
+
+# Triple verification.
+codesign --verify --strict --deep "${BUNDLE_PATH}"
+inner_identifier="$(codesign --display --verbose=2 "${BUNDLE_PATH}/Contents/MacOS/crm-mac" 2>&1 | awk -F= '/^Identifier=/ {print $2}')"
+if [ "${inner_identifier}" != "${BUNDLE_IDENTIFIER}" ]; then
+    echo "FAIL: inner Mach-O Identifier=${inner_identifier}; expected ${BUNDLE_IDENTIFIER}" >&2
+    exit 1
+fi
+outer_identifier="$(codesign --display --verbose=2 "${BUNDLE_PATH}" 2>&1 | awk -F= '/^Identifier=/ {print $2}')"
+if [ "${outer_identifier}" != "${BUNDLE_IDENTIFIER}" ]; then
+    echo "FAIL: outer bundle Identifier=${outer_identifier}; expected ${BUNDLE_IDENTIFIER}" >&2
+    exit 1
+fi

--- a/mac-daemon/Sources/CRMMacCore/ContactsAuthorizationAdapter.swift
+++ b/mac-daemon/Sources/CRMMacCore/ContactsAuthorizationAdapter.swift
@@ -30,7 +30,12 @@ public protocol ContactsAuthorizationAdapter: Sendable {
     func authorizationStatus() -> ContactsAuthorizationStatus
 
     /// Prompt the user for Contacts access. Returns true on grant,
-    /// false on denial. Called only by `crm-mac install` —
-    /// daemon ticks must NOT prompt (the daemon runs headless).
+    /// false on denial. Called by both `crm-mac install` AND the
+    /// daemon's per-tick auth probe when status is `.notDetermined`.
+    /// Calling from the launchd-spawned daemon is what attributes
+    /// the TCC grant to the bundle ID (`xyz.spengrah.crm-mac`); the
+    /// shell-spawned install path attributes to the parent terminal
+    /// and is kept only as the user-driven entry point on a fresh
+    /// pair.
     func requestAccess() async throws -> Bool
 }

--- a/mac-daemon/Sources/CRMMacIcloudContactsSource/ICloudContactsSourcePlugin.swift
+++ b/mac-daemon/Sources/CRMMacIcloudContactsSource/ICloudContactsSourcePlugin.swift
@@ -168,12 +168,33 @@ public actor ICloudContactsSourcePlugin: SourcePlugin {
             await self.cache.discardPendingRemovals()
         }
 
-        // Authorization probe.
+        // Authorization probe. On `.notDetermined` we trigger
+        // `requestAccess` from the launchd-spawned daemon process so
+        // TCC attributes the grant to the bundle ID
+        // (`responsible == requesting == xyz.spengrah.crm-mac`) and
+        // the grant survives rebuilds. Shell-launched callers (e.g.
+        // `crm-mac install --re-request-permission`) attribute to the
+        // parent terminal instead, so the daemon is the canonical
+        // prompt site.
         let authStatus = authAdapter.authorizationStatus()
         switch authStatus {
         case .authorized, .limited:
             break
-        case .notDetermined, .denied, .restricted:
+        case .notDetermined:
+            let granted: Bool
+            do {
+                granted = try await authAdapter.requestAccess()
+            } catch {
+                await abortDiscard()
+                await markUnhealthy(reason: "contacts_permission:request_failed")
+                return
+            }
+            if !granted {
+                await abortDiscard()
+                await markUnhealthy(reason: "contacts_permission:denied")
+                return
+            }
+        case .denied, .restricted:
             await abortDiscard()
             await markUnhealthy(reason: "contacts_permission:\(authStatus)")
             return

--- a/mac-daemon/Sources/CRMMacLifecycle/Adapters/AgentService.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/Adapters/AgentService.swift
@@ -1,5 +1,5 @@
 // AgentService abstracts the SMAppService API surface the
-// install/upgrade/uninstall/doctor/status workflows need (plan D3).
+// install/upgrade/uninstall/doctor/status workflows need.
 // Production impl `ProductionAgentService` (CRMMacSystem) wraps
 // `SMAppService.agent(plistName:)`. The protocol lives in
 // CRMMacLifecycle so the workflows don't depend on the
@@ -83,7 +83,7 @@ public protocol AgentService {
     /// to `AgentServiceError.registrationFailed(requiresApproval: true)`.
     /// All other errors throw `.registrationFailed(requiresApproval: false)`.
     /// See `ProductionAgentService.register()` for the error mapping
-    /// implementation (plan D21).
+    /// implementation.
     func register() throws -> AgentRegisterOutcome
 
     /// Unregister the agent. Async because Apple's

--- a/mac-daemon/Sources/CRMMacLifecycle/Adapters/AgentService.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/Adapters/AgentService.swift
@@ -1,0 +1,102 @@
+// AgentService abstracts the SMAppService API surface the
+// install/upgrade/uninstall/doctor/status workflows need (plan D3).
+// Production impl `ProductionAgentService` (CRMMacSystem) wraps
+// `SMAppService.agent(plistName:)`. The protocol lives in
+// CRMMacLifecycle so the workflows don't depend on the
+// ServiceManagement framework — only the production adapter does.
+//
+// Replaces the previous `LaunchctlRunner` shape, which spoke in
+// launchctl exit codes. The new surface is typed (status enum,
+// outcome enum, typed error) so the workflows can branch on
+// "requires approval" vs. "already registered" vs. "bundle missing"
+// without parsing strings.
+//
+// The launchctl path is kept (LaunchctlRunner / ProductionLaunchctlRunner)
+// for the legacy migration cleanup ONLY — bootout the pre-bundle
+// launchd registration and delete the legacy plist.
+import Foundation
+
+/// Outcome of `AgentService.register()`. Apple's
+/// `SMAppService.register()` throws on re-registration; the production
+/// wrapper maps that specific failure mode to `.alreadyRegistered`
+/// (it's a no-op from the system's perspective but observable from
+/// the caller's — e.g. StartCommand prints a different hint).
+public enum AgentRegisterOutcome: Equatable {
+    /// Apple's `register()` succeeded; the agent is newly bootstrapped.
+    case registered
+    /// Apple's `register()` returned `kSMErrorAlreadyRegistered`. The
+    /// agent was already registered before this call. From the
+    /// system's perspective this is a no-op; from the caller's
+    /// perspective the outcome is observable.
+    case alreadyRegistered
+}
+
+/// Wire type for `SMAppService.Status`. The protocol lives in
+/// CRMMacLifecycle so workflows can branch on these cases without
+/// importing the ServiceManagement framework.
+public enum AgentServiceStatus: String, Equatable {
+    /// Service is registered and the agent is allowed to run.
+    case enabled
+    /// Service is registered but the user has not yet approved it in
+    /// System Settings → General → Login Items → Allow in Background.
+    case requiresApproval = "requires_approval"
+    /// Service is not yet registered or has been unregistered.
+    case notRegistered = "not_registered"
+    /// The bundle / embedded plist is missing or unreachable.
+    case notFound = "not_found"
+}
+
+public enum AgentServiceError: Error, CustomStringConvertible {
+    /// `register()` failed. The production adapter maps
+    /// `kSMErrorLaunchDeniedByUser` (operator denied in Login Items)
+    /// to `requiresApproval: true`; all other failures surface with
+    /// `requiresApproval: false` and the underlying error string.
+    case registrationFailed(message: String, requiresApproval: Bool)
+    /// `unregister()` failed.
+    case unregistrationFailed(String)
+    /// The bundle is missing or unreachable from the caller's
+    /// perspective. Distinct from `.registrationFailed` because the
+    /// operator's recovery path differs (re-run install --upgrade
+    /// vs. approve in System Settings).
+    case bundleNotFound(String)
+
+    public var description: String {
+        switch self {
+        case .registrationFailed(let m, let approval):
+            let suffix = approval
+                ? " — approve crm-mac in System Settings → General → Login Items → Allow in Background, then re-run."
+                : ""
+            return "agent registration failed: \(m)\(suffix)"
+        case .unregistrationFailed(let m):
+            return "agent unregistration failed: \(m)"
+        case .bundleNotFound(let m):
+            return "agent bundle not found: \(m)"
+        }
+    }
+}
+
+public protocol AgentService {
+    /// Register the agent with SMAppService. Apple's
+    /// `SMAppService.register()` throws on re-registration; the
+    /// production wrapper maps `kSMErrorAlreadyRegistered` to the
+    /// `.alreadyRegistered` outcome and `kSMErrorLaunchDeniedByUser`
+    /// to `AgentServiceError.registrationFailed(requiresApproval: true)`.
+    /// All other errors throw `.registrationFailed(requiresApproval: false)`.
+    /// See `ProductionAgentService.register()` for the error mapping
+    /// implementation (plan D21).
+    func register() throws -> AgentRegisterOutcome
+
+    /// Unregister the agent. Async because Apple's
+    /// `SMAppService.unregister(completionHandler:)` is callback-based;
+    /// the wrapper bridges via a checked continuation. The Installer
+    /// + Uninstaller combine this with a SIGTERM-then-poll on the
+    /// pidfile (via ProcessSignaller) since `unregister` only removes
+    /// the launchd registration — it does NOT terminate an
+    /// already-running daemon process.
+    func unregister() async throws
+
+    /// Inspect the current registration state.  Used by Doctor +
+    /// Status to surface to the operator without making a network
+    /// call.
+    func currentStatus() -> AgentServiceStatus
+}

--- a/mac-daemon/Sources/CRMMacLifecycle/Adapters/ExecutableAdapter.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/Adapters/ExecutableAdapter.swift
@@ -23,6 +23,16 @@ public protocol ExecutableAdapter {
     /// installer to stage `crm-mac` from wherever the operator
     /// invoked it.
     func currentExecutablePath() throws -> String
-    /// Run `codesign -s - --force --preserve-metadata=... <path>`.
+    /// Single-Mach-O ad-hoc sign. Used during the legacy migration
+    /// cleanup path only — the bare-binary install pre-PR8c.
+    /// `codesign -s - --force --preserve-metadata=... <path>`.
     func adhocCodesign(path: String) throws
+    /// Two-pass ad-hoc sign of a complete `.app` bundle (plan D5):
+    ///   1. `codesign --force --sign - --identifier <id> <bundle>/Contents/MacOS/crm-mac`
+    ///   2. `codesign --force --sign - <bundle>`
+    /// The explicit `--identifier` on pass 1 is the property TCC
+    /// keys on for bundled apps — without it the inner Mach-O can
+    /// keep a build-host-derived identifier (e.g. `crm-mac-<hash>`)
+    /// that churns on every rebuild.
+    func adhocCodesignBundle(bundlePath: String, identifier: String) throws
 }

--- a/mac-daemon/Sources/CRMMacLifecycle/Adapters/ExecutableAdapter.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/Adapters/ExecutableAdapter.swift
@@ -27,7 +27,7 @@ public protocol ExecutableAdapter {
     /// cleanup path only — the bare-binary install pre-PR8c.
     /// `codesign -s - --force --preserve-metadata=... <path>`.
     func adhocCodesign(path: String) throws
-    /// Two-pass ad-hoc sign of a complete `.app` bundle (plan D5):
+    /// Two-pass ad-hoc sign of a complete `.app` bundle:
     ///   1. `codesign --force --sign - --identifier <id> <bundle>/Contents/MacOS/crm-mac`
     ///   2. `codesign --force --sign - <bundle>`
     /// The explicit `--identifier` on pass 1 is the property TCC

--- a/mac-daemon/Sources/CRMMacLifecycle/Adapters/ProcessSignaller.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/Adapters/ProcessSignaller.swift
@@ -1,0 +1,49 @@
+// ProcessSignaller stops a running daemon process: send SIGTERM,
+// then poll the daemon's pidfile until the flock releases (or until
+// a timeout elapses). Used by Installer (upgrade path) and Uninstaller
+// — SMAppService.unregister tells launchd "don't restart on next
+// boot" but does NOT terminate an already-running process.
+//
+// The pidfile-release primitive matches the daemon's own
+// `PidfileLock.acquire()` flock(LOCK_EX | LOCK_NB) call in
+// `mac-daemon/Sources/CRMMacCore/PidfileLock.swift`. We open the
+// pidfile and attempt the same lock; if it succeeds the daemon has
+// exited and we release immediately. If it would block, the daemon
+// is still holding it.
+//
+// This protocol lives in CRMMacLifecycle so the workflows that
+// orchestrate stop-the-daemon are testable with the FakeProcessSignaller.
+// Production impl `ProductionProcessSignaller` is in CRMMacSystem
+// (the POSIX kill/flock calls).
+import Foundation
+
+public enum ProcessSignallerError: Error, CustomStringConvertible {
+    /// `kill(pid, SIGTERM)` returned non-zero with an errno other than
+    /// ESRCH (no-such-process — benign, the daemon already exited).
+    case killFailed(errno: Int32)
+
+    public var description: String {
+        switch self {
+        case .killFailed(let e):
+            return "kill(SIGTERM) failed: errno=\(e)"
+        }
+    }
+}
+
+public protocol ProcessSignaller {
+    /// Send SIGTERM to the given pid. Errors other than ESRCH (no
+    /// such process — benign, daemon already exited) throw.
+    func sendSIGTERM(pid: pid_t) throws
+
+    /// Wait until the pidfile at `path` is no longer locked, or until
+    /// `timeoutSeconds` elapses. Returns true when the lock was
+    /// acquirable (daemon exited or pidfile absent); false on
+    /// timeout (daemon still running after `timeoutSeconds`).
+    ///
+    /// Implementation contract (production): poll every 200ms by
+    /// opening the pidfile and attempting `flock(fd, LOCK_EX |
+    /// LOCK_NB)`. On success, release immediately + return true.
+    /// On EWOULDBLOCK, sleep + retry. ENOENT (pidfile absent) is
+    /// treated as released (returns true immediately).
+    func waitForPidfileRelease(path: String, timeoutSeconds: TimeInterval) async -> Bool
+}

--- a/mac-daemon/Sources/CRMMacLifecycle/BundleAssembler.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/BundleAssembler.swift
@@ -12,7 +12,7 @@
 //     Library/LaunchAgents/
 //       xyz.spengrah.crm-mac.plist      <- input.launchAgentPlistContent (string)
 //
-// Two-pass codesign (per plan D5) is delegated to
+// Two-pass codesign is delegated to
 // `ExecutableAdapter.adhocCodesignBundle(bundlePath:identifier:)`.
 //
 // The caller is responsible for the tmp-path-then-rename pattern; this
@@ -119,7 +119,7 @@ public struct BundleAssembler {
             Data(input.launchAgentPlistContent.utf8),
             to: launchAgentDest)
 
-        // 5. Two-pass ad-hoc codesign per plan D5: inner Mach-O with
+        // 5. Two-pass ad-hoc codesign: inner Mach-O with
         //    an explicit `--identifier <bundle-id>` (so TCC keys on
         //    the bundle ID), then bundle seal. Wrapped in the
         //    ExecutableAdapter so tests can record + script the

--- a/mac-daemon/Sources/CRMMacLifecycle/BundleAssembler.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/BundleAssembler.swift
@@ -34,10 +34,13 @@ public struct BundleAssemblerInput: Equatable {
     /// ~/Library/Application Support/crm-mac/crm-mac.app).
     public let bundlePath: String
     /// LaunchAgents plist content. The caller renders it (typically
-    /// via LaunchAgentPlist.render() with the install-time paths AND
-    /// the `__INSTALL_PREFIX__` placeholder for the binary). The
-    /// placeholder substitution is the Installer's concern, NOT
-    /// BundleAssembler's — this method writes the string verbatim.
+    /// via LaunchAgentPlist.render() with the final install-time
+    /// bundle path embedded directly) and this method writes the
+    /// string verbatim. The plist is sealed by the bundle codesign
+    /// pass below, so the caller MUST embed the real install path
+    /// before assemble() runs — modifying the plist after assemble()
+    /// returns would invalidate the codesign seal and SMAppService
+    /// would refuse to load the bundle.
     public let launchAgentPlistContent: String
     /// Info.plist content as raw bytes. The production caller passes
     /// `PropertyListSerialization.data(...)` output rendered from
@@ -111,8 +114,10 @@ public struct BundleAssembler {
         try filesystem.write(input.infoPlistContent, to: infoPlistDest)
 
         // 4. Write the LaunchAgents plist verbatim from the
-        //    caller-provided string. Placeholder substitution
-        //    (`__INSTALL_PREFIX__`) is the Installer's concern.
+        //    caller-provided string. The caller must embed the final
+        //    install-time bundle path before assemble() — the plist is
+        //    a sealed resource under the codesign manifest written in
+        //    step 5.
         let launchAgentDest =
             "\(input.bundlePath)/\(Self.launchAgentPlistRelativePath)"
         try filesystem.write(

--- a/mac-daemon/Sources/CRMMacLifecycle/BundleAssembler.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/BundleAssembler.swift
@@ -1,0 +1,131 @@
+// BundleAssembler stages a crm-mac.app bundle into the filesystem via
+// FilesystemAdapter + ExecutableAdapter. The shell-script equivalent
+// at `Scripts/assemble_bundle.sh` covers the build-time path (no
+// Swift adapters available there); BundleAssembler covers the
+// install-time path inside the running daemon binary.
+//
+// Layout written by `assemble(_:)`:
+//
+//   <bundlePath>/Contents/
+//     Info.plist                        <- input.infoPlistContent (raw bytes)
+//     MacOS/crm-mac                     <- copy of input.machoSourcePath, chmod +x
+//     Library/LaunchAgents/
+//       xyz.spengrah.crm-mac.plist      <- input.launchAgentPlistContent (string)
+//
+// Two-pass codesign (per plan D5) is delegated to
+// `ExecutableAdapter.adhocCodesignBundle(bundlePath:identifier:)`.
+//
+// The caller is responsible for the tmp-path-then-rename pattern; this
+// method writes directly to `bundlePath`. Failure recovery (rollback
+// of a partial write) is the caller's job — every step is idempotent
+// from the caller's perspective (re-running with the same input
+// overwrites the partial output).
+import Foundation
+
+/// Inputs for `BundleAssembler.assemble(_:)`. All fields are
+/// provided by the caller so this type doesn't take a dependency on
+/// LaunchAgentPlist (whose render needs install-time paths the
+/// assembler doesn't otherwise know).
+public struct BundleAssemblerInput: Equatable {
+    /// Source Mach-O to be staged into Contents/MacOS/. Typically
+    /// the currently-running binary at Bundle.main.executablePath.
+    public let machoSourcePath: String
+    /// Final bundle path (e.g.
+    /// ~/Library/Application Support/crm-mac/crm-mac.app).
+    public let bundlePath: String
+    /// LaunchAgents plist content. The caller renders it (typically
+    /// via LaunchAgentPlist.render() with the install-time paths AND
+    /// the `__INSTALL_PREFIX__` placeholder for the binary). The
+    /// placeholder substitution is the Installer's concern, NOT
+    /// BundleAssembler's — this method writes the string verbatim.
+    public let launchAgentPlistContent: String
+    /// Info.plist content as raw bytes. The production caller passes
+    /// `PropertyListSerialization.data(...)` output rendered from
+    /// `Bundle.main.infoDictionary`; tests pass fixture bytes
+    /// directly. The dict on the install-time path resolves from the
+    /// Mach-O `__TEXT,__info_plist` section (fresh install) or
+    /// `Contents/Info.plist` (upgrade running from a bundle).
+    public let infoPlistContent: Data
+    /// Codesign identifier for the inner Mach-O. Always
+    /// `Daemon.label` in production; parameterized for tests.
+    public let codesignIdentifier: String
+
+    public init(
+        machoSourcePath: String,
+        bundlePath: String,
+        launchAgentPlistContent: String,
+        infoPlistContent: Data,
+        codesignIdentifier: String
+    ) {
+        self.machoSourcePath = machoSourcePath
+        self.bundlePath = bundlePath
+        self.launchAgentPlistContent = launchAgentPlistContent
+        self.infoPlistContent = infoPlistContent
+        self.codesignIdentifier = codesignIdentifier
+    }
+}
+
+public struct BundleAssembler {
+    public let filesystem: FilesystemAdapter
+    public let executable: ExecutableAdapter
+
+    public init(filesystem: FilesystemAdapter, executable: ExecutableAdapter) {
+        self.filesystem = filesystem
+        self.executable = executable
+    }
+
+    /// LaunchAgent plist filename inside the bundle:
+    /// `Contents/Library/LaunchAgents/xyz.spengrah.crm-mac.plist`.
+    /// Matches `Daemon.label + ".plist"`.
+    public static let launchAgentPlistFilename = "\(Daemon.label).plist"
+
+    /// Subpath of Contents/Info.plist inside the bundle.
+    public static let infoPlistRelativePath = "Contents/Info.plist"
+
+    /// Subpath of Contents/MacOS/crm-mac inside the bundle.
+    public static let machoRelativePath = "Contents/MacOS/crm-mac"
+
+    /// Subpath of the embedded LaunchAgents plist inside the bundle.
+    public static let launchAgentPlistRelativePath =
+        "Contents/Library/LaunchAgents/\(Daemon.label).plist"
+
+    /// Assemble the bundle. Writes directly to `input.bundlePath`.
+    public func assemble(_ input: BundleAssemblerInput) throws {
+        // 1. Create the directory skeleton (idempotent — createDirectory
+        //    is `mkdir -p`).
+        let contentsDir = "\(input.bundlePath)/Contents"
+        let macOSDir = "\(contentsDir)/MacOS"
+        let launchAgentsDir = "\(contentsDir)/Library/LaunchAgents"
+        try filesystem.createDirectory(at: input.bundlePath)
+        try filesystem.createDirectory(at: contentsDir)
+        try filesystem.createDirectory(at: macOSDir)
+        try filesystem.createDirectory(at: launchAgentsDir)
+
+        // 2. Stage the Mach-O.
+        let machoDest = "\(input.bundlePath)/\(Self.machoRelativePath)"
+        try filesystem.copy(from: input.machoSourcePath, to: machoDest)
+        try filesystem.makeExecutable(at: machoDest)
+
+        // 3. Write Info.plist verbatim from the caller-provided bytes.
+        let infoPlistDest = "\(input.bundlePath)/\(Self.infoPlistRelativePath)"
+        try filesystem.write(input.infoPlistContent, to: infoPlistDest)
+
+        // 4. Write the LaunchAgents plist verbatim from the
+        //    caller-provided string. Placeholder substitution
+        //    (`__INSTALL_PREFIX__`) is the Installer's concern.
+        let launchAgentDest =
+            "\(input.bundlePath)/\(Self.launchAgentPlistRelativePath)"
+        try filesystem.write(
+            Data(input.launchAgentPlistContent.utf8),
+            to: launchAgentDest)
+
+        // 5. Two-pass ad-hoc codesign per plan D5: inner Mach-O with
+        //    an explicit `--identifier <bundle-id>` (so TCC keys on
+        //    the bundle ID), then bundle seal. Wrapped in the
+        //    ExecutableAdapter so tests can record + script the
+        //    codesign invocation without shelling out.
+        try executable.adhocCodesignBundle(
+            bundlePath: input.bundlePath,
+            identifier: input.codesignIdentifier)
+    }
+}

--- a/mac-daemon/Sources/CRMMacLifecycle/DaemonPaths.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/DaemonPaths.swift
@@ -3,43 +3,94 @@
 // workflows don't take a dependency on the system target. The
 // production composition root (ProductionContext) builds an instance
 // from CRMMacSystem.DaemonPaths.
+//
+// The bundle paths (bundleAppPath, bundleBinaryPath, bundlePlistPath,
+// bundleInfoPlistPath) point at the assembled `crm-mac.app` under
+// `~/Library/Application Support/crm-mac/`. The legacy paths
+// (legacyBinaryPath = `~/.../bin/crm-mac`, legacyPlistPath =
+// `~/Library/LaunchAgents/<label>.plist`) are kept for one-shot
+// migration detection + cleanup. The pre-rewrite fields `binaryPath`
+// and `plistPath` are retained as aliases for the legacy locations
+// (NOT the bundle locations) during the transition; downstream
+// callers are being migrated to use the explicit `bundleBinaryPath`
+// / `legacyBinaryPath` / `bundlePlistPath` / `legacyPlistPath` names
+// where the distinction matters.
 import Foundation
 
 public struct LifecyclePaths: Equatable {
     public let configDirPath: String
     public let binDirPath: String
-    public let binaryPath: String
     public let configFilePath: String
     public let stateFilePath: String
     public let launchAgentsDirPath: String
-    public let plistPath: String
     public let logsDirPath: String
     public let stdoutLogPath: String
     public let stderrLogPath: String
 
+    /// Final installed bundle path
+    /// (`~/Library/Application Support/crm-mac/crm-mac.app`).
+    public let bundleAppPath: String
+    /// Daemon binary inside the bundle
+    /// (`<bundleAppPath>/Contents/MacOS/crm-mac`).
+    public let bundleBinaryPath: String
+    /// Embedded LaunchAgent plist inside the bundle
+    /// (`<bundleAppPath>/Contents/Library/LaunchAgents/<label>.plist`).
+    public let bundlePlistPath: String
+    /// Embedded Info.plist inside the bundle
+    /// (`<bundleAppPath>/Contents/Info.plist`).
+    public let bundleInfoPlistPath: String
+
+    /// Pre-bundle bare-binary location used by the legacy install.
+    /// Migration detects + removes this file.
+    public let legacyBinaryPath: String
+    /// Pre-bundle LaunchAgent plist location used by the legacy
+    /// install (`~/Library/LaunchAgents/<label>.plist`). Migration
+    /// bootouts the legacy launchd registration + removes the file.
+    public let legacyPlistPath: String
+
     public init(
         configDirPath: String,
         binDirPath: String,
-        binaryPath: String,
         configFilePath: String,
         stateFilePath: String,
         launchAgentsDirPath: String,
-        plistPath: String,
         logsDirPath: String,
         stdoutLogPath: String,
-        stderrLogPath: String
+        stderrLogPath: String,
+        bundleAppPath: String,
+        bundleBinaryPath: String,
+        bundlePlistPath: String,
+        bundleInfoPlistPath: String,
+        legacyBinaryPath: String,
+        legacyPlistPath: String
     ) {
         self.configDirPath = configDirPath
         self.binDirPath = binDirPath
-        self.binaryPath = binaryPath
         self.configFilePath = configFilePath
         self.stateFilePath = stateFilePath
         self.launchAgentsDirPath = launchAgentsDirPath
-        self.plistPath = plistPath
         self.logsDirPath = logsDirPath
         self.stdoutLogPath = stdoutLogPath
         self.stderrLogPath = stderrLogPath
+        self.bundleAppPath = bundleAppPath
+        self.bundleBinaryPath = bundleBinaryPath
+        self.bundlePlistPath = bundlePlistPath
+        self.bundleInfoPlistPath = bundleInfoPlistPath
+        self.legacyBinaryPath = legacyBinaryPath
+        self.legacyPlistPath = legacyPlistPath
     }
+
+    /// Pre-rewrite name for the bare-binary path. Now aliased to
+    /// `legacyBinaryPath` so existing call sites that probe for the
+    /// legacy bare binary keep working while the Installer rewrite
+    /// is rolled out commit-by-commit.
+    public var binaryPath: String { legacyBinaryPath }
+
+    /// Pre-rewrite name for the launchd plist file. Now aliased to
+    /// `legacyPlistPath`. Once the installer rewrite lands, the
+    /// bundle's embedded plist supersedes this — SMAppService reads
+    /// the plist from inside the bundle, not from this location.
+    public var plistPath: String { legacyPlistPath }
 
     /// Daemon-runtime directory.  The daemon's PidfileLock writes
     /// `daemon.pid` here so the CLI ops subcommands can detect the
@@ -50,4 +101,9 @@ public struct LifecyclePaths: Equatable {
     /// On-disk plaintext file holding the daemon's API key (0600).
     /// Replaces the prior macOS Keychain entry — see FileAPIKeyStore.
     public var apiKeyFilePath: String { "\(configDirPath)/api-key" }
+
+    /// Daemon pidfile path. The daemon's PidfileLock writes its pid
+    /// here; the Installer/Uninstaller read it to send SIGTERM via
+    /// ProcessSignaller.
+    public var pidfilePath: String { "\(runtimeDirPath)/daemon.pid" }
 }

--- a/mac-daemon/Sources/CRMMacLifecycle/DaemonPaths.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/DaemonPaths.swift
@@ -80,17 +80,23 @@ public struct LifecyclePaths: Equatable {
         self.legacyPlistPath = legacyPlistPath
     }
 
-    /// Pre-rewrite name for the bare-binary path. Now aliased to
-    /// `legacyBinaryPath` so existing call sites that probe for the
-    /// legacy bare binary keep working while the Installer rewrite
-    /// is rolled out commit-by-commit.
-    public var binaryPath: String { legacyBinaryPath }
+    /// Deprecated alias for `bundleBinaryPath`. The post-rewrite
+    /// daemon binary lives inside the bundle at
+    /// `<bundleAppPath>/Contents/MacOS/crm-mac`; out-of-tree callers
+    /// reading `binaryPath` should see THAT location (not the legacy
+    /// bare binary). The legacy bare binary remains accessible via
+    /// `legacyBinaryPath` for migration code.
+    @available(*, deprecated, message: "Use bundleBinaryPath (or legacyBinaryPath for migration probes)")
+    public var binaryPath: String { bundleBinaryPath }
 
-    /// Pre-rewrite name for the launchd plist file. Now aliased to
-    /// `legacyPlistPath`. Once the installer rewrite lands, the
-    /// bundle's embedded plist supersedes this — SMAppService reads
-    /// the plist from inside the bundle, not from this location.
-    public var plistPath: String { legacyPlistPath }
+    /// Deprecated alias for `bundlePlistPath`. The post-rewrite
+    /// LaunchAgent plist lives inside the bundle at
+    /// `<bundleAppPath>/Contents/Library/LaunchAgents/<label>.plist`;
+    /// out-of-tree callers reading `plistPath` should see THAT
+    /// location. The legacy launchd plist remains accessible via
+    /// `legacyPlistPath` for migration cleanup.
+    @available(*, deprecated, message: "Use bundlePlistPath (or legacyPlistPath for migration cleanup)")
+    public var plistPath: String { bundlePlistPath }
 
     /// Daemon-runtime directory.  The daemon's PidfileLock writes
     /// `daemon.pid` here so the CLI ops subcommands can detect the

--- a/mac-daemon/Sources/CRMMacLifecycle/DaemonPaths.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/DaemonPaths.swift
@@ -9,12 +9,10 @@
 // `~/Library/Application Support/crm-mac/`. The legacy paths
 // (legacyBinaryPath = `~/.../bin/crm-mac`, legacyPlistPath =
 // `~/Library/LaunchAgents/<label>.plist`) are kept for one-shot
-// migration detection + cleanup. The pre-rewrite fields `binaryPath`
-// and `plistPath` are retained as aliases for the legacy locations
-// (NOT the bundle locations) during the transition; downstream
-// callers are being migrated to use the explicit `bundleBinaryPath`
-// / `legacyBinaryPath` / `bundlePlistPath` / `legacyPlistPath` names
-// where the distinction matters.
+// migration detection + cleanup. The pre-rewrite `binaryPath` and
+// `plistPath` fields are retained as DEPRECATED aliases for the
+// BUNDLE locations (per plan D12); the legacy locations have their
+// own dedicated `legacyBinaryPath` / `legacyPlistPath` accessors.
 import Foundation
 
 public struct LifecyclePaths: Equatable {

--- a/mac-daemon/Sources/CRMMacLifecycle/DaemonPaths.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/DaemonPaths.swift
@@ -11,7 +11,7 @@
 // `~/Library/LaunchAgents/<label>.plist`) are kept for one-shot
 // migration detection + cleanup. The pre-rewrite `binaryPath` and
 // `plistPath` fields are retained as DEPRECATED aliases for the
-// BUNDLE locations (per plan D12); the legacy locations have their
+// BUNDLE locations; the legacy locations have their
 // own dedicated `legacyBinaryPath` / `legacyPlistPath` accessors.
 import Foundation
 

--- a/mac-daemon/Sources/CRMMacLifecycle/Doctor.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/Doctor.swift
@@ -1,12 +1,13 @@
 // Doctor implements `crm-mac doctor`.
 //
-// Four checks:
-//   1. Keychain access (read api-key)
-//   2. Launchd agent presence (`launchctl print` exit 0)
+// Four core checks (plan D10):
+//   1. api-key file (read api-key file)
+//   2. Agent service registration (AgentService.currentStatus)
 //   3. Pi reachability (GET /known-identifiers; 200=PASS, 401=FAIL,
 //      5xx=WARN, network=WARN)
 //   4. Config + state file presence (both parse; state has correct
 //      schemaVersion)
+// Plus three icloud_contacts checks (permission, allowlist, last-tick).
 //
 // Output: array of CheckResult { name, status, details }; exit code
 // equals the number of FAIL entries.
@@ -48,7 +49,7 @@ public struct DoctorDependencies {
     public let paths: LifecyclePaths
     public let filesystem: FilesystemAdapter
     public let keychain: KeychainStore
-    public let launchctl: LaunchctlRunner
+    public let agentService: AgentService
     public let piClientFactory: (URL) -> PiClient
     /// Contacts framework adapters used by the icloud_contacts check.
     /// Tests inject stubs.
@@ -64,7 +65,7 @@ public struct DoctorDependencies {
         paths: LifecyclePaths,
         filesystem: FilesystemAdapter,
         keychain: KeychainStore,
-        launchctl: LaunchctlRunner,
+        agentService: AgentService,
         piClientFactory: @escaping (URL) -> PiClient,
         contactsAuth: ContactsAuthorizationAdapter,
         containerEnumerator: ContactContainerEnumerator,
@@ -75,7 +76,7 @@ public struct DoctorDependencies {
         self.paths = paths
         self.filesystem = filesystem
         self.keychain = keychain
-        self.launchctl = launchctl
+        self.agentService = agentService
         self.piClientFactory = piClientFactory
         self.contactsAuth = contactsAuth
         self.containerEnumerator = containerEnumerator
@@ -94,7 +95,7 @@ public struct Doctor {
     public func run() async -> DoctorReport {
         var results: [CheckResult] = []
         results.append(checkKeychain())
-        results.append(checkLaunchctl())
+        results.append(checkAgentService())
 
         let configCheck = checkConfigAndState()
         results.append(configCheck.result)
@@ -253,21 +254,28 @@ public struct Doctor {
         }
     }
 
-    private func checkLaunchctl() -> CheckResult {
-        do {
-            let inv = try deps.launchctl.printService(label: Daemon.label)
-            if inv.exitCode == 0 {
-                return CheckResult(name: "launchctl", status: .pass, details: "service registered")
-            }
+    private func checkAgentService() -> CheckResult {
+        switch deps.agentService.currentStatus() {
+        case .enabled:
             return CheckResult(
-                name: "launchctl",
-                status: .warn,
-                details: "service not registered (exit \(inv.exitCode))")
-        } catch {
+                name: "agent_service",
+                status: .pass,
+                details: "registered (enabled)")
+        case .requiresApproval:
             return CheckResult(
-                name: "launchctl",
+                name: "agent_service",
                 status: .warn,
-                details: "launchctl invocation failed: \(error)")
+                details: "requires approval — System Settings → General → Login Items → Allow in Background → crm-mac")
+        case .notRegistered:
+            return CheckResult(
+                name: "agent_service",
+                status: .warn,
+                details: "not registered; run `crm-mac install --register-only`")
+        case .notFound:
+            return CheckResult(
+                name: "agent_service",
+                status: .fail,
+                details: "bundle missing at \(deps.paths.bundleAppPath); re-run `crm-mac install --upgrade`")
         }
     }
 

--- a/mac-daemon/Sources/CRMMacLifecycle/Doctor.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/Doctor.swift
@@ -1,6 +1,6 @@
 // Doctor implements `crm-mac doctor`.
 //
-// Four core checks (plan D10):
+// Four core checks:
 //   1. api-key file (read api-key file)
 //   2. Agent service registration (AgentService.currentStatus)
 //   3. Pi reachability (GET /known-identifiers; 200=PASS, 401=FAIL,

--- a/mac-daemon/Sources/CRMMacLifecycle/Installer.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/Installer.swift
@@ -7,18 +7,21 @@
 //   2. Preflight: refuse if existing install detected.
 //   3. mkdir -p config/logs directories (NO bin/ — the bare-binary
 //      install location is migration-only).
-//   4. Assemble the new bundle at a tmp path
-//      (`<configDir>/crm-mac.app.tmp.<pid>`) via BundleAssembler.
+//   4. Render the LaunchAgent plist with the final install-time
+//      bundle path embedded directly, then assemble the new bundle at
+//      a tmp path (`<configDir>/crm-mac.app.tmp.<pid>`) via
+//      BundleAssembler. The embedded plist is a sealed resource under
+//      the bundle codesign manifest — embedding the real path BEFORE
+//      codesign keeps the seal intact so subsequent
+//      `SMAppService.register()` calls (e.g. `--register-only`
+//      retries) pass codesign validation.
 //   5. POST /api/v1/host on the Pi.
 //   6. Persist config.json, api-key file, state.json.
 //   7. Atomic-rename tmp bundle to the install path
 //      (`<configDir>/crm-mac.app`). Destination is absent — preflight
 //      refused otherwise — so it's a same-parent, empty-destination
 //      rename (atomic on APFS).
-//   8. Substitute `__INSTALL_PREFIX__` placeholder in the bundle's
-//      embedded LaunchAgents plist with the real install-time bundle
-//      path.
-//   9. Register the agent with SMAppService.
+//   8. Register the agent with SMAppService.
 //
 // Upgrade sequence (backup-rename-swap):
 //   - Validate; read existing config; check legacy migration.
@@ -29,7 +32,7 @@
 //   - Assemble new bundle at crm-mac.app.tmp.<pid>.
 //   - Atomic-rename tmp bundle -> crm-mac.app (destination absent
 //     again because the prior rename moved the old one).
-//   - Substitute placeholder + register.
+//   - Register.
 //   - rm -rf crm-mac.app.backup.<pid> (best-effort).
 //   - On any failure between assemble and register: rm -rf tmp
 //     bundle AND rename backup back to crm-mac.app (rollback). If
@@ -257,12 +260,6 @@ public struct Installer {
         self.deps = deps
     }
 
-    /// Placeholder string the build-time shell script writes into the
-    /// embedded LaunchAgents plist for the binary path. The installer
-    /// substitutes this with the real install-time bundle path before
-    /// SMAppService.register reads it.
-    public static let installPrefixPlaceholder = "__INSTALL_PREFIX__"
-
     public func run(_ request: InstallRequest) async throws -> InstallSummary {
         if request.upgrade && request.registerOnly {
             throw InstallError.unexpected("--upgrade and --register-only are mutually exclusive")
@@ -307,7 +304,8 @@ public struct Installer {
             throw InstallError.unexpected("currentExecutablePath: \(error)")
         }
         let tmpBundle = tmpBundlePath()
-        let launchAgentContent = renderPlaceholderLaunchAgentContent()
+        let launchAgentContent = renderLaunchAgentContent(
+            bundlePath: deps.paths.bundleAppPath)
         let infoPlistContent = try loadInfoPlistContent()
         do {
             try deps.bundleAssembler.assemble(BundleAssemblerInput(
@@ -388,15 +386,6 @@ public struct Installer {
                 hostID: pairResult.hostID,
                 stage: "rename tmp bundle -> install",
                 underlying: String(describing: error))
-        }
-
-        // Substitute placeholder in the bundle's embedded plist.
-        do {
-            try substituteInstallPrefixPlaceholder(
-                bundlePath: deps.paths.bundleAppPath)
-        } catch {
-            throw InstallError.filesystemFailed(
-                "substitute install prefix: \(error)")
         }
 
         // Register the agent.
@@ -481,7 +470,8 @@ public struct Installer {
                 newBundleAtFinalPath: false)
         }
         let tmpBundle = tmpBundlePath()
-        let launchAgentContent = renderPlaceholderLaunchAgentContent()
+        let launchAgentContent = renderLaunchAgentContent(
+            bundlePath: deps.paths.bundleAppPath)
         let infoPlistContent: Data
         do {
             infoPlistContent = try loadInfoPlistContent()
@@ -530,20 +520,8 @@ public struct Installer {
                 newBundleAtFinalPath: false)
         }
 
-        // Substitute placeholder + register. Rollback on any
-        // failure between here and the end of register: remove the
-        // new bundle, restore the backup.
-        do {
-            try substituteInstallPrefixPlaceholder(
-                bundlePath: deps.paths.bundleAppPath)
-        } catch {
-            try rollbackUpgrade(
-                originalError: InstallError.filesystemFailed("substitute install prefix: \(error)"),
-                tmpBundle: nil,
-                backupPath: backupPath,
-                hadExisting: hadExistingBundle,
-                newBundleAtFinalPath: true)
-        }
+        // Register. Rollback on any failure: remove the new bundle,
+        // restore the backup.
         do {
             try registerAgent()
         } catch {
@@ -616,11 +594,9 @@ public struct Installer {
             throw InstallError.noExistingInstall
         }
 
-        // Substitute placeholder (idempotent — already-substituted
-        // plists are a no-op) + register. ANY thrown error from
-        // substitution is a real filesystem failure and propagates.
-        try substituteInstallPrefixPlaceholder(
-            bundlePath: deps.paths.bundleAppPath)
+        // Register the already-installed bundle. The bundle's embedded
+        // plist already references the real install path (rendered at
+        // assembly time, sealed by codesign).
         try registerAgent()
         // Partial-migration retry case: if a prior --upgrade got
         // through assemble + rename but the register failed, the
@@ -776,9 +752,9 @@ public struct Installer {
         }
     }
 
-    /// Bundle assembly + atomic-rename + substitute placeholder +
-    /// register. Used by the migration path; the fresh install flow
-    /// inlines its own version (which also does pair + persist).
+    /// Bundle assembly + atomic-rename + register. Used by the
+    /// migration path; the fresh install flow inlines its own version
+    /// (which also does pair + persist).
     private func assembleAndRegisterNewBundle() async throws {
         let sourcePath: String
         do {
@@ -791,7 +767,8 @@ public struct Installer {
             try? deps.filesystem.createDirectory(at: dir)
         }
         let tmpBundle = tmpBundlePath()
-        let launchAgentContent = renderPlaceholderLaunchAgentContent()
+        let launchAgentContent = renderLaunchAgentContent(
+            bundlePath: deps.paths.bundleAppPath)
         let infoPlistContent = try loadInfoPlistContent()
         do {
             try deps.bundleAssembler.assemble(BundleAssemblerInput(
@@ -815,13 +792,6 @@ public struct Installer {
             try? deps.filesystem.remove(at: tmpBundle)
             throw InstallError.filesystemFailed(
                 "rename tmp bundle -> install: \(error)")
-        }
-        do {
-            try substituteInstallPrefixPlaceholder(
-                bundlePath: deps.paths.bundleAppPath)
-        } catch {
-            throw InstallError.filesystemFailed(
-                "substitute install prefix: \(error)")
         }
         try registerAgent()
     }
@@ -903,51 +873,16 @@ public struct Installer {
         }
     }
 
-    /// Replace `__INSTALL_PREFIX__` in the bundle's embedded
-    /// LaunchAgents plist with the real install-time bundle path.
-    /// The bundle path is XML-escaped (via `xmlEscapePlistString`)
-    /// before substitution — home directories containing `&`, `<`,
-    /// `>`, `"`, or `'` would otherwise produce an invalid plist
-    /// even though the renderer claims to handle those characters.
-    /// Idempotent: re-running on an already-substituted plist (no
-    /// placeholder present) is a no-op success.
-    private func substituteInstallPrefixPlaceholder(bundlePath: String) throws {
-        let plistFile = "\(bundlePath)/\(BundleAssembler.launchAgentPlistRelativePath)"
-        let data: Data
-        do {
-            data = try deps.filesystem.read(from: plistFile)
-        } catch {
-            throw InstallError.filesystemFailed(
-                "read embedded plist: \(error)")
-        }
-        let original = String(data: data, encoding: .utf8) ?? ""
-        let escapedReplacement = xmlEscapePlistString(bundlePath)
-        let substituted = original.replacingOccurrences(
-            of: Self.installPrefixPlaceholder,
-            with: escapedReplacement)
-        if substituted == original {
-            // Already substituted — idempotent no-op.
-            return
-        }
-        do {
-            try deps.filesystem.write(
-                Data(substituted.utf8), to: plistFile)
-        } catch {
-            throw InstallError.filesystemFailed(
-                "write substituted plist: \(error)")
-        }
-    }
-
-    /// Render the templated LaunchAgent plist content. Uses
-    /// `__INSTALL_PREFIX__` for the binary-path component so
-    /// `substituteInstallPrefixPlaceholder` can rewrite it post-
-    /// rename. Logs + config dir use the real install-time paths
-    /// (computed from configDirPath / logsDirPath) — those don't
-    /// need substitution.
-    private func renderPlaceholderLaunchAgentContent() -> String {
+    /// Render the LaunchAgent plist content with the final install-
+    /// time bundle path embedded directly. The plist is a sealed
+    /// resource under the bundle codesign manifest — embedding the
+    /// real path BEFORE the bundle is codesigned (rather than
+    /// substituting after) keeps the seal intact so subsequent
+    /// `SMAppService.register()` calls pass codesign validation.
+    private func renderLaunchAgentContent(bundlePath: String) -> String {
         let plist = LaunchAgentPlist(
             label: Daemon.label,
-            binaryPath: "\(Self.installPrefixPlaceholder)/\(BundleAssembler.machoRelativePath)",
+            binaryPath: "\(bundlePath)/\(BundleAssembler.machoRelativePath)",
             configDirPath: deps.paths.configDirPath,
             stdoutPath: deps.paths.stdoutLogPath,
             stderrPath: deps.paths.stderrLogPath)

--- a/mac-daemon/Sources/CRMMacLifecycle/Installer.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/Installer.swift
@@ -117,6 +117,14 @@ public enum InstallError: Error, CustomStringConvertible {
     /// grace period. Operator must manually run
     /// `launchctl bootout gui/$(id -u)/<label>` and re-run.
     case legacyBootoutFailed(stderr: String)
+    /// Upgrade hit two failures in a row: the original failure that
+    /// triggered rollback, plus a restore-backup failure. The
+    /// operator now has no bundle at the final install path — the
+    /// backup is still at `crm-mac.app.backup.<pid>`. The
+    /// `originalError` describes what tripped the rollback;
+    /// `backupPath` carries the location of the surviving backup so
+    /// the operator can manually `mv` it back.
+    case upgradeRollbackFailed(originalError: String, restoreError: String, backupPath: String)
     case filesystemFailed(String)
     case codesignFailed(String)
     case keychainFailed(String)
@@ -154,6 +162,9 @@ public enum InstallError: Error, CustomStringConvertible {
         case .legacyBootoutFailed(let stderr):
             return "legacy launchd registration could not be bootouted: \(stderr). " +
                 "Recovery: `launchctl bootout gui/$(id -u)/\(Daemon.label)`, then re-run `crm-mac install --upgrade`."
+        case .upgradeRollbackFailed(let original, let restore, let backup):
+            return "upgrade rollback failed. Original failure: \(original). Restore backup also failed: \(restore). " +
+                "The previous bundle is still at \(backup); to recover, manually `mv \(backup) \(backup.replacingOccurrences(of: ".backup.\(ProcessInfo.processInfo.processIdentifier)", with: ""))` (or the equivalent for your shell), then re-run `crm-mac install --register-only`."
         case .filesystemFailed(let m): return "filesystem: \(m)"
         case .codesignFailed(let m): return "codesign: \(m)"
         case .keychainFailed(let m): return "keychain: \(m)"
@@ -402,8 +413,21 @@ public struct Installer {
         // If a legacy bare-binary install is present, run the one-shot
         // migration. This stops the legacy daemon + bootouts the
         // legacy launchd registration BEFORE bundle assembly because
-        // the labels collide.
-        try await runLegacyMigrationIfNeeded()
+        // the labels collide. On success the migration already
+        // assembled + registered the new bundle; clean up legacy
+        // artifacts and return.
+        let migrated = try await runLegacyMigrationIfNeeded()
+        if migrated {
+            cleanupLegacyArtifactsIfAny()
+            deps.logger.info("install: legacy migration complete", metadata: [
+                "host_id": .private(cfg.hostID.uuidString),
+            ])
+            return InstallSummary(
+                hostID: cfg.hostID,
+                cursorEpoch: 0,
+                bundleBinaryPath: deps.paths.bundleBinaryPath,
+                bundleAppPath: deps.paths.bundleAppPath)
+        }
 
         // U2. Stop the running daemon (if any). On a fresh
         // SMAppService-managed install the agentService.unregister is
@@ -434,8 +458,12 @@ public struct Installer {
         do {
             sourcePath = try deps.executable.currentExecutablePath()
         } catch {
-            try? restoreBundleBackup(from: backupPath, hadExisting: hadExistingBundle)
-            throw InstallError.unexpected("currentExecutablePath: \(error)")
+            try rollbackUpgrade(
+                originalError: InstallError.unexpected("currentExecutablePath: \(error)"),
+                tmpBundle: nil,
+                backupPath: backupPath,
+                hadExisting: hadExistingBundle,
+                newBundleAtFinalPath: false)
         }
         let tmpBundle = tmpBundlePath()
         let launchAgentContent = renderPlaceholderLaunchAgentContent()
@@ -443,9 +471,12 @@ public struct Installer {
         do {
             infoPlistContent = try loadInfoPlistContent()
         } catch {
-            try? restoreBundleBackup(from: backupPath, hadExisting: hadExistingBundle)
-            throw InstallError.filesystemFailed(
-                "load info.plist content: \(error)")
+            try rollbackUpgrade(
+                originalError: InstallError.filesystemFailed("load info.plist content: \(error)"),
+                tmpBundle: nil,
+                backupPath: backupPath,
+                hadExisting: hadExistingBundle,
+                newBundleAtFinalPath: false)
         }
         do {
             try deps.bundleAssembler.assemble(BundleAssemblerInput(
@@ -455,13 +486,19 @@ public struct Installer {
                 infoPlistContent: infoPlistContent,
                 codesignIdentifier: Daemon.label))
         } catch let err as ExecutableAdapterError {
-            try? deps.filesystem.remove(at: tmpBundle)
-            try? restoreBundleBackup(from: backupPath, hadExisting: hadExistingBundle)
-            throw InstallError.codesignFailed("\(err)")
+            try rollbackUpgrade(
+                originalError: InstallError.codesignFailed("\(err)"),
+                tmpBundle: tmpBundle,
+                backupPath: backupPath,
+                hadExisting: hadExistingBundle,
+                newBundleAtFinalPath: false)
         } catch {
-            try? deps.filesystem.remove(at: tmpBundle)
-            try? restoreBundleBackup(from: backupPath, hadExisting: hadExistingBundle)
-            throw InstallError.filesystemFailed("assemble bundle: \(error)")
+            try rollbackUpgrade(
+                originalError: InstallError.filesystemFailed("assemble bundle: \(error)"),
+                tmpBundle: tmpBundle,
+                backupPath: backupPath,
+                hadExisting: hadExistingBundle,
+                newBundleAtFinalPath: false)
         }
 
         // U5. Atomic-rename tmp bundle -> final path.
@@ -470,10 +507,12 @@ public struct Installer {
                 from: tmpBundle,
                 to: deps.paths.bundleAppPath)
         } catch {
-            try? deps.filesystem.remove(at: tmpBundle)
-            try? restoreBundleBackup(from: backupPath, hadExisting: hadExistingBundle)
-            throw InstallError.filesystemFailed(
-                "rename tmp bundle -> install: \(error)")
+            try rollbackUpgrade(
+                originalError: InstallError.filesystemFailed("rename tmp bundle -> install: \(error)"),
+                tmpBundle: tmpBundle,
+                backupPath: backupPath,
+                hadExisting: hadExistingBundle,
+                newBundleAtFinalPath: false)
         }
 
         // U6. Substitute placeholder + register. Rollback on any
@@ -483,10 +522,12 @@ public struct Installer {
             try substituteInstallPrefixPlaceholder(
                 bundlePath: deps.paths.bundleAppPath)
         } catch {
-            try? deps.filesystem.remove(at: deps.paths.bundleAppPath)
-            try? restoreBundleBackup(from: backupPath, hadExisting: hadExistingBundle)
-            throw InstallError.filesystemFailed(
-                "substitute install prefix: \(error)")
+            try rollbackUpgrade(
+                originalError: InstallError.filesystemFailed("substitute install prefix: \(error)"),
+                tmpBundle: nil,
+                backupPath: backupPath,
+                hadExisting: hadExistingBundle,
+                newBundleAtFinalPath: true)
         }
         do {
             try registerAgent()
@@ -494,9 +535,12 @@ public struct Installer {
             // Register failed — restore the previous install so the
             // operator isn't left with a stopped daemon + new bundle
             // they can't run. Surface the original register error.
-            try? deps.filesystem.remove(at: deps.paths.bundleAppPath)
-            try? restoreBundleBackup(from: backupPath, hadExisting: hadExistingBundle)
-            throw error
+            try rollbackUpgrade(
+                originalError: error,
+                tmpBundle: nil,
+                backupPath: backupPath,
+                hadExisting: hadExistingBundle,
+                newBundleAtFinalPath: true)
         }
 
         // U7. Cleanup backup (best-effort).
@@ -526,10 +570,18 @@ public struct Installer {
         }
         let cfg = try readConfig()
 
-        // If a legacy install is present and the bundle is NOT yet in
-        // place, run migration. The migration assembles the bundle +
-        // registers; we fall through to the no-op-register below.
-        try await runLegacyMigrationIfNeeded()
+        // If a legacy install is present and no bundle is in place,
+        // run the full migration. It assembles + registers; afterwards
+        // we sweep the legacy files.
+        let migrated = try await runLegacyMigrationIfNeeded()
+        if migrated {
+            cleanupLegacyArtifactsIfAny()
+            return InstallSummary(
+                hostID: cfg.hostID,
+                cursorEpoch: 0,
+                bundleBinaryPath: deps.paths.bundleBinaryPath,
+                bundleAppPath: deps.paths.bundleAppPath)
+        }
 
         // Refuse if the bundle is missing — register-only registers
         // an EXISTING bundle; if it's not there, the operator wants
@@ -538,14 +590,18 @@ public struct Installer {
             throw InstallError.noExistingInstall
         }
 
-        // Substitute placeholder. The helper is idempotent
-        // (already-substituted plist is a no-op) so successful runs
-        // surface no error; ANY thrown error here is a real
-        // filesystem failure and must bubble up rather than be
-        // silently swallowed.
+        // Substitute placeholder (idempotent — already-substituted
+        // plists are a no-op) + register. ANY thrown error from
+        // substitution is a real filesystem failure and propagates.
         try substituteInstallPrefixPlaceholder(
             bundlePath: deps.paths.bundleAppPath)
         try registerAgent()
+        // Partial-migration retry case: if a prior --upgrade got
+        // through assemble + rename but the register failed, the
+        // legacy plist + bare binary are still on disk and step 7
+        // never completed. Sweep them now that register succeeded.
+        // No-op on a fresh install where no legacy artifacts exist.
+        cleanupLegacyArtifactsIfAny()
         return InstallSummary(
             hostID: cfg.hostID,
             cursorEpoch: 0,
@@ -561,20 +617,22 @@ public struct Installer {
     ///   (2) NO bundle at paths.bundleAppPath
     ///   (3) at least one user-data file present (config/state/api-key)
     ///
-    /// On a partial-migration re-entry (the bundle is already in place
-    /// because a prior `--upgrade` got past step 4 but the register
-    /// failed and the operator now reruns `--register-only`), we
-    /// short-circuit the build-the-new half (steps 2-6) but ALWAYS
-    /// run step 7 cleanup if legacy artifacts are still present.
-    /// Leaving the legacy plist on disk is not just cosmetic — macOS
-    /// can re-load it from `~/Library/LaunchAgents/` on next login
-    /// and resurrect the bare-binary service the migration was meant
-    /// to retire.
-    private func runLegacyMigrationIfNeeded() async throws {
+    /// Steps 1-6 only — stop the legacy daemon, bootout the legacy
+    /// launchd registration, assemble the new bundle, register via
+    /// SMAppService. Returns true iff a full migration ran (so the
+    /// caller knows the rest of upgrade/register-only is unneeded).
+    ///
+    /// Step 7 (delete legacy plist + bare binary) is run by the
+    /// CALLER after a successful register, via
+    /// `cleanupLegacyArtifactsIfAny()`. The split matters because a
+    /// partial-migration retry needs to attempt register FIRST and
+    /// only sweep the legacy files if it succeeds — otherwise the
+    /// legacy plist could be deleted while the new bundle is still
+    /// unregistered, leaving the operator with no working install
+    /// even though the legacy install was viable.
+    private func runLegacyMigrationIfNeeded() async throws -> Bool {
         let hasLegacyBinary = deps.filesystem.fileExists(
             at: deps.paths.legacyBinaryPath)
-        let hasLegacyPlist = deps.filesystem.fileExists(
-            at: deps.paths.legacyPlistPath)
         let hasNewBundle = deps.filesystem.fileExists(
             at: deps.paths.bundleAppPath)
         let hasUserData =
@@ -582,34 +640,44 @@ public struct Installer {
             deps.filesystem.fileExists(at: deps.paths.stateFilePath) ||
             ((try? deps.keychain.readAPIKey()) != nil)
 
-        if hasLegacyBinary, !hasNewBundle, hasUserData {
-            // Full migration path.
-            // D7 step 2a — stop the legacy daemon.
-            try await stopLegacyDaemon()
-            // D7 step 2b + 2c — bootout legacy registration + verify gone.
-            try bootoutLegacyAndVerify()
-            // D7 steps 3-6 — assemble the bundle + register.
-            try await assembleAndRegisterNewBundle()
-            // Fall through to step 7 cleanup below.
-        } else if hasNewBundle, hasLegacyBinary || hasLegacyPlist {
-            // Partial-migration recovery: a prior migration assembled
-            // the bundle but didn't finish the cleanup half. Just run
-            // the cleanup (step 7).
-            deps.logger.info("legacy migration: cleaning up leftover artifacts after prior partial migration", metadata: [:])
-        } else {
-            return
+        guard hasLegacyBinary, !hasNewBundle, hasUserData else {
+            return false
         }
+        // D7 step 2a — stop the legacy daemon.
+        try await stopLegacyDaemon()
+        // D7 step 2b + 2c — bootout legacy registration + verify gone.
+        try bootoutLegacyAndVerify()
+        // D7 steps 3-6 — assemble the bundle + register. Cleanup is
+        // deferred to the caller's post-register hook so a register
+        // failure leaves the legacy files in place for the retry.
+        try await assembleAndRegisterNewBundle()
+        return true
+    }
 
-        // D7 step 7 — best-effort cleanup of legacy files.
+    /// D7 step 7 — best-effort delete of legacy plist + bare binary.
+    /// Idempotent and tolerant of "already gone". Called by the
+    /// caller AFTER a successful register so a register-failure
+    /// retry path can still find the legacy artifacts and have them
+    /// participate in the next migration attempt.
+    ///
+    /// Leaving the legacy plist on disk is not just cosmetic — macOS
+    /// can re-load it from `~/Library/LaunchAgents/` on next login
+    /// and resurrect the bare-binary service the migration was meant
+    /// to retire. The post-register cleanup is what guarantees that
+    /// doesn't happen on a successful migration.
+    private func cleanupLegacyArtifactsIfAny() {
+        var didCleanup = false
         if deps.filesystem.fileExists(at: deps.paths.legacyPlistPath) {
             try? deps.filesystem.remove(at: deps.paths.legacyPlistPath)
+            didCleanup = true
         }
         if deps.filesystem.fileExists(at: deps.paths.legacyBinaryPath) {
             try? deps.filesystem.remove(at: deps.paths.legacyBinaryPath)
+            didCleanup = true
         }
-        // Tolerate leftover bin/ directory; operator's --purge sweeps it.
-
-        deps.logger.info("legacy migration: complete", metadata: [:])
+        if didCleanup {
+            deps.logger.info("legacy migration: cleanup complete", metadata: [:])
+        }
     }
 
     /// D7 step 2a — read the legacy pidfile (same path as the new
@@ -915,6 +983,37 @@ public struct Installer {
             ])
             throw error
         }
+    }
+
+    /// Best-effort cleanup-then-restore for the upgrade-path
+    /// rollback. Removes the tmp/new bundle (if present), restores
+    /// the backup, throws back the original failure on success — or
+    /// a composed `upgradeRollbackFailed` if the restore itself fails.
+    /// Callers `throw try rollbackUpgrade(...)` — the helper always
+    /// terminates the call with a throw.
+    private func rollbackUpgrade(
+        originalError: Error,
+        tmpBundle: String?,
+        backupPath: String,
+        hadExisting: Bool,
+        newBundleAtFinalPath: Bool
+    ) throws -> Never {
+        if let tmp = tmpBundle, deps.filesystem.fileExists(at: tmp) {
+            try? deps.filesystem.remove(at: tmp)
+        }
+        if newBundleAtFinalPath,
+           deps.filesystem.fileExists(at: deps.paths.bundleAppPath) {
+            try? deps.filesystem.remove(at: deps.paths.bundleAppPath)
+        }
+        do {
+            try restoreBundleBackup(from: backupPath, hadExisting: hadExisting)
+        } catch let restoreError {
+            throw InstallError.upgradeRollbackFailed(
+                originalError: String(describing: originalError),
+                restoreError: String(describing: restoreError),
+                backupPath: backupPath)
+        }
+        throw originalError
     }
 
     /// One-shot copy of the API key from the legacy macOS Keychain

--- a/mac-daemon/Sources/CRMMacLifecycle/Installer.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/Installer.swift
@@ -476,21 +476,28 @@ public struct Installer {
                 "rename tmp bundle -> install: \(error)")
         }
 
-        // U6. Substitute placeholder + register.
+        // U6. Substitute placeholder + register. Rollback on any
+        // failure between here and the end of register: remove the
+        // new bundle, restore the backup.
         do {
             try substituteInstallPrefixPlaceholder(
                 bundlePath: deps.paths.bundleAppPath)
         } catch {
-            // Rollback: move the new bundle out of the way, restore
-            // backup. The placeholder substitution is a pure-Swift
-            // string replace + write; failure here is rare (write
-            // failure injection in tests) but recoverable.
             try? deps.filesystem.remove(at: deps.paths.bundleAppPath)
             try? restoreBundleBackup(from: backupPath, hadExisting: hadExistingBundle)
             throw InstallError.filesystemFailed(
                 "substitute install prefix: \(error)")
         }
-        try registerAgent()
+        do {
+            try registerAgent()
+        } catch {
+            // Register failed — restore the previous install so the
+            // operator isn't left with a stopped daemon + new bundle
+            // they can't run. Surface the original register error.
+            try? deps.filesystem.remove(at: deps.paths.bundleAppPath)
+            try? restoreBundleBackup(from: backupPath, hadExisting: hadExistingBundle)
+            throw error
+        }
 
         // U7. Cleanup backup (best-effort).
         if hadExistingBundle {
@@ -531,21 +538,13 @@ public struct Installer {
             throw InstallError.noExistingInstall
         }
 
-        // Substitute placeholder (idempotent — second-run on an
-        // already-substituted plist is a no-op).
-        do {
-            try substituteInstallPrefixPlaceholder(
-                bundlePath: deps.paths.bundleAppPath)
-        } catch {
-            // Ignore "no placeholder found" errors — happens on the
-            // post-migration retry path. Other write failures bubble.
-            if let fsErr = error as? FilesystemError {
-                throw InstallError.filesystemFailed(
-                    "substitute install prefix: \(fsErr)")
-            }
-            // Else (e.g., InstallError.unexpected from the
-            // already-substituted-no-placeholder branch): tolerate.
-        }
+        // Substitute placeholder. The helper is idempotent
+        // (already-substituted plist is a no-op) so successful runs
+        // surface no error; ANY thrown error here is a real
+        // filesystem failure and must bubble up rather than be
+        // silently swallowed.
+        try substituteInstallPrefixPlaceholder(
+            bundlePath: deps.paths.bundleAppPath)
         try registerAgent()
         return InstallSummary(
             hostID: cfg.hostID,
@@ -557,33 +556,49 @@ public struct Installer {
     // MARK: - legacy migration
 
     /// Detect + migrate a pre-rewrite bare-binary install (plan D7).
-    /// Three-signal detection:
+    /// Full migration runs when all three signals hold:
     ///   (1) legacy binary at paths.legacyBinaryPath
     ///   (2) NO bundle at paths.bundleAppPath
     ///   (3) at least one user-data file present (config/state/api-key)
-    /// Runs ONLY when all three hold; falls through otherwise.
+    ///
+    /// On a partial-migration re-entry (the bundle is already in place
+    /// because a prior `--upgrade` got past step 4 but the register
+    /// failed and the operator now reruns `--register-only`), we
+    /// short-circuit the build-the-new half (steps 2-6) but ALWAYS
+    /// run step 7 cleanup if legacy artifacts are still present.
+    /// Leaving the legacy plist on disk is not just cosmetic — macOS
+    /// can re-load it from `~/Library/LaunchAgents/` on next login
+    /// and resurrect the bare-binary service the migration was meant
+    /// to retire.
     private func runLegacyMigrationIfNeeded() async throws {
         let hasLegacyBinary = deps.filesystem.fileExists(
             at: deps.paths.legacyBinaryPath)
+        let hasLegacyPlist = deps.filesystem.fileExists(
+            at: deps.paths.legacyPlistPath)
         let hasNewBundle = deps.filesystem.fileExists(
             at: deps.paths.bundleAppPath)
         let hasUserData =
             deps.filesystem.fileExists(at: deps.paths.configFilePath) ||
             deps.filesystem.fileExists(at: deps.paths.stateFilePath) ||
             ((try? deps.keychain.readAPIKey()) != nil)
-        guard hasLegacyBinary, !hasNewBundle, hasUserData else {
+
+        if hasLegacyBinary, !hasNewBundle, hasUserData {
+            // Full migration path.
+            // D7 step 2a — stop the legacy daemon.
+            try await stopLegacyDaemon()
+            // D7 step 2b + 2c — bootout legacy registration + verify gone.
+            try bootoutLegacyAndVerify()
+            // D7 steps 3-6 — assemble the bundle + register.
+            try await assembleAndRegisterNewBundle()
+            // Fall through to step 7 cleanup below.
+        } else if hasNewBundle, hasLegacyBinary || hasLegacyPlist {
+            // Partial-migration recovery: a prior migration assembled
+            // the bundle but didn't finish the cleanup half. Just run
+            // the cleanup (step 7).
+            deps.logger.info("legacy migration: cleaning up leftover artifacts after prior partial migration", metadata: [:])
+        } else {
             return
         }
-
-        // D7 step 2a — stop the legacy daemon.
-        try await stopLegacyDaemon()
-        // D7 step 2b + 2c — bootout legacy registration + verify gone.
-        try bootoutLegacyAndVerify()
-
-        // D7 steps 3-6 — assemble the bundle + register. Reuse the
-        // fresh-install assembly + register helpers via a private
-        // sub-flow.
-        try await assembleAndRegisterNewBundle()
 
         // D7 step 7 — best-effort cleanup of legacy files.
         if deps.filesystem.fileExists(at: deps.paths.legacyPlistPath) {
@@ -600,32 +615,34 @@ public struct Installer {
     /// D7 step 2a — read the legacy pidfile (same path as the new
     /// install — the daemon writes to <configDir>/daemon.pid) and
     /// send SIGTERM; poll for release.
+    ///
+    /// A present-but-malformed pidfile is NOT treated as "not
+    /// running" — the daemon may be alive and we just can't parse its
+    /// pid. The flock probe is the authoritative running-or-not
+    /// check; we skip SIGTERM but still poll.
     private func stopLegacyDaemon() async throws {
-        // The pidfile path is shared between legacy + new install
-        // (both daemons write to <configDir>/daemon.pid).
         let pidfilePath = deps.paths.pidfilePath
         guard deps.filesystem.fileExists(at: pidfilePath) else {
             // No pidfile — legacy daemon not running. Benign.
             return
         }
-        let pidData: Data
-        do {
-            pidData = try deps.filesystem.read(from: pidfilePath)
-        } catch {
-            // Pidfile vanished between exists() and read() — race;
-            // treat as not running.
-            return
-        }
-        let raw = String(data: pidData, encoding: .utf8) ?? ""
-        guard let pid = pid_t(raw.trimmingCharacters(in: .whitespacesAndNewlines)) else {
-            return
-        }
-        do {
-            try deps.processSignaller.sendSIGTERM(pid: pid)
-        } catch {
-            deps.logger.warning("legacy migration: SIGTERM failed (continuing)", metadata: [
-                "pid": .public("\(pid)"),
-                "error": .private("\(error)"),
+        var pid: pid_t = 0
+        if let pidData = try? deps.filesystem.read(from: pidfilePath),
+           let raw = String(data: pidData, encoding: .utf8),
+           let parsed = pid_t(raw.trimmingCharacters(in: .whitespacesAndNewlines)),
+           parsed > 0 {
+            pid = parsed
+            do {
+                try deps.processSignaller.sendSIGTERM(pid: pid)
+            } catch {
+                deps.logger.warning("legacy migration: SIGTERM failed (continuing)", metadata: [
+                    "pid": .public("\(pid)"),
+                    "error": .private("\(error)"),
+                ])
+            }
+        } else {
+            deps.logger.warning("legacy migration: pidfile present but unreadable/malformed; relying on flock probe", metadata: [
+                "path": .private(pidfilePath),
             ])
         }
         let released = await deps.processSignaller.waitForPidfileRelease(
@@ -746,13 +763,17 @@ public struct Installer {
 
     /// Stop the running daemon: unregister via SMAppService, SIGTERM
     /// the process via ProcessSignaller, poll the pidfile.
+    ///
+    /// If the pidfile exists but its contents are unparseable, the
+    /// flock probe is the authoritative running-or-not check (the
+    /// daemon's PidfileLock holds the same lock the probe acquires).
+    /// We skip SIGTERM but still poll — and if the poll times out,
+    /// surface `daemonStillRunning(pid: 0)` so the upgrade fails
+    /// loudly instead of stomping on a still-running daemon.
     private func stopRunningDaemon() async throws {
         do {
             try await deps.agentService.unregister()
         } catch {
-            // Tolerate — SMAppService.unregister can fail benignly
-            // (not registered). The SIGTERM-and-poll below is the
-            // authoritative stop.
             deps.logger.warning(
                 "stop daemon: agentService.unregister failed (continuing)",
                 metadata: ["error": .private("\(error)")])
@@ -761,22 +782,23 @@ public struct Installer {
         guard deps.filesystem.fileExists(at: pidfilePath) else {
             return
         }
-        let pidData: Data
-        do {
-            pidData = try deps.filesystem.read(from: pidfilePath)
-        } catch {
-            return
-        }
-        let raw = String(data: pidData, encoding: .utf8) ?? ""
-        guard let pid = pid_t(raw.trimmingCharacters(in: .whitespacesAndNewlines)) else {
-            return
-        }
-        do {
-            try deps.processSignaller.sendSIGTERM(pid: pid)
-        } catch {
-            deps.logger.warning(
-                "stop daemon: SIGTERM failed (continuing)",
-                metadata: ["pid": .public("\(pid)"), "error": .private("\(error)")])
+        var pid: pid_t = 0
+        if let pidData = try? deps.filesystem.read(from: pidfilePath),
+           let raw = String(data: pidData, encoding: .utf8),
+           let parsed = pid_t(raw.trimmingCharacters(in: .whitespacesAndNewlines)),
+           parsed > 0 {
+            pid = parsed
+            do {
+                try deps.processSignaller.sendSIGTERM(pid: pid)
+            } catch {
+                deps.logger.warning(
+                    "stop daemon: SIGTERM failed (continuing)",
+                    metadata: ["pid": .public("\(pid)"), "error": .private("\(error)")])
+            }
+        } else {
+            deps.logger.warning("stop daemon: pidfile present but unreadable/malformed; relying on flock probe", metadata: [
+                "path": .private(pidfilePath),
+            ])
         }
         let released = await deps.processSignaller.waitForPidfileRelease(
             path: pidfilePath,
@@ -788,6 +810,10 @@ public struct Installer {
 
     /// Replace `__INSTALL_PREFIX__` in the bundle's embedded
     /// LaunchAgents plist with the real install-time bundle path.
+    /// The bundle path is XML-escaped (via `xmlEscapePlistString`)
+    /// before substitution — home directories containing `&`, `<`,
+    /// `>`, `"`, or `'` would otherwise produce an invalid plist
+    /// even though the renderer claims to handle those characters.
     /// Idempotent: re-running on an already-substituted plist (no
     /// placeholder present) is a no-op success.
     private func substituteInstallPrefixPlaceholder(bundlePath: String) throws {
@@ -800,9 +826,10 @@ public struct Installer {
                 "read embedded plist: \(error)")
         }
         let original = String(data: data, encoding: .utf8) ?? ""
+        let escapedReplacement = xmlEscapePlistString(bundlePath)
         let substituted = original.replacingOccurrences(
             of: Self.installPrefixPlaceholder,
-            with: bundlePath)
+            with: escapedReplacement)
         if substituted == original {
             // Already substituted — idempotent no-op.
             return
@@ -870,11 +897,23 @@ public struct Installer {
         return "\(deps.paths.configDirPath)/crm-mac.app.backup.\(ProcessInfo.processInfo.processIdentifier)"
     }
 
+    /// Restore the previous bundle from `<crm-mac.app>.backup.<pid>`
+    /// during an upgrade rollback. Surfaces the rename failure so the
+    /// caller knows the operator now has neither bundle in place
+    /// (left only with the backup) — distinguish that from the
+    /// happy-rollback case.
     private func restoreBundleBackup(from backupPath: String, hadExisting: Bool) throws {
         guard hadExisting else { return }
-        if deps.filesystem.fileExists(at: backupPath) {
-            try? deps.filesystem.rename(
+        guard deps.filesystem.fileExists(at: backupPath) else { return }
+        do {
+            try deps.filesystem.rename(
                 from: backupPath, to: deps.paths.bundleAppPath)
+        } catch {
+            deps.logger.error("upgrade rollback: restore backup failed", metadata: [
+                "backup": .private(backupPath),
+                "error": .private("\(error)"),
+            ])
+            throw error
         }
     }
 

--- a/mac-daemon/Sources/CRMMacLifecycle/Installer.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/Installer.swift
@@ -1,21 +1,46 @@
 // Installer implements `crm-mac install`, `--upgrade`, and
-// `--register-only`.
+// `--register-only` against the SMAppService + crm-mac.app bundle
+// architecture (plan D7, D8).
 //
-// The fresh-install sequence:
+// Fresh-install sequence (plan D8 fresh-install table):
 //   1. Validate inputs.
-//   2. Preflight: refuse if existing install detected unless
-//      --upgrade or --register-only set.
-//   3. mkdir -p config/bin/logs directories.
-//   4. Stage running binary to a temp path; chmod +x; codesign.
+//   2. Preflight: refuse if existing install detected.
+//   3. mkdir -p config/logs directories (NO bin/ — the bare-binary
+//      install location is migration-only).
+//   4. Assemble the new bundle at a tmp path
+//      (`<configDir>/crm-mac.app.tmp.<pid>`) via BundleAssembler.
 //   5. POST /api/v1/host on the Pi.
-//   6. Persist config.json, Keychain api-key, state.json.
-//   7. Atomic-rename temp binary to install path.
-//   8. Write plist + launchctl bootstrap.
+//   6. Persist config.json, api-key file, state.json.
+//   7. Atomic-rename tmp bundle to the install path
+//      (`<configDir>/crm-mac.app`). Destination is absent — preflight
+//      refused otherwise — so it's a same-parent, empty-destination
+//      rename (atomic on APFS).
+//   8. Substitute `__INSTALL_PREFIX__` placeholder in the bundle's
+//      embedded LaunchAgents plist with the real install-time bundle
+//      path.
+//   9. Register the agent with SMAppService.
 //
-// On any failure inside steps 5-6, the temp binary is unlinked. On
-// any failure inside step 7 (rare — same-fs rename), the temp binary
-// is unlinked and operator runs uninstall --purge. On step 8 failure,
-// binary is in place; operator runs `crm-mac install --register-only`.
+// Upgrade sequence (plan D8 U1-U8 — backup-rename-swap):
+//   U1. Validate; read existing config; check legacy migration.
+//   U2. Stop the running daemon (SMAppService.unregister + SIGTERM
+//       via ProcessSignaller; pidfile-poll up to 10s).
+//   U3. Rename existing crm-mac.app -> crm-mac.app.backup.<pid>
+//       (same-parent, empty-destination rename — atomic).
+//   U4. Assemble new bundle at crm-mac.app.tmp.<pid>.
+//   U5. Atomic-rename tmp bundle -> crm-mac.app (destination absent
+//       again because U3 moved the old one).
+//   U6. Substitute placeholder + register.
+//   U7. rm -rf crm-mac.app.backup.<pid> (best-effort).
+//   U8. On any failure between U4 and U6: rm -rf tmp bundle AND
+//       rename backup back to crm-mac.app (rollback).
+//
+// Legacy migration (plan D7 — runLegacyMigrationIfNeeded()):
+//   Detects a pre-bundle bare-binary install
+//   (~/.../bin/crm-mac + ~/Library/LaunchAgents/<label>.plist) and
+//   stops the legacy daemon + bootouts the legacy launchd
+//   registration BEFORE bundle assembly (labels collide between
+//   legacy and SMAppService registrations). After register, deletes
+//   the legacy plist file + bare binary best-effort.
 import Foundation
 import CRMMacCore
 import CRMMacPiClient
@@ -45,15 +70,28 @@ public struct InstallRequest: Equatable {
 public struct InstallSummary: Equatable {
     public let hostID: UUID
     public let cursorEpoch: Int64
-    public let binaryPath: String
-    public let plistPath: String
+    /// Path to the installed daemon binary inside the bundle:
+    /// `<bundleAppPath>/Contents/MacOS/crm-mac`.
+    public let bundleBinaryPath: String
+    /// Path to the assembled bundle: `<bundleAppPath>`. Includes the
+    /// `.app` extension.
+    public let bundleAppPath: String
 
-    public init(hostID: UUID, cursorEpoch: Int64, binaryPath: String, plistPath: String) {
+    public init(
+        hostID: UUID,
+        cursorEpoch: Int64,
+        bundleBinaryPath: String,
+        bundleAppPath: String
+    ) {
         self.hostID = hostID
         self.cursorEpoch = cursorEpoch
-        self.binaryPath = binaryPath
-        self.plistPath = plistPath
+        self.bundleBinaryPath = bundleBinaryPath
+        self.bundleAppPath = bundleAppPath
     }
+
+    /// Pre-rewrite alias preserved for caller print statements that
+    /// historically rendered the binary path.
+    public var binaryPath: String { bundleBinaryPath }
 }
 
 public enum InstallError: Error, CustomStringConvertible {
@@ -61,19 +99,24 @@ public enum InstallError: Error, CustomStringConvertible {
     case invalidPairingToken
     case alreadyInstalled
     case noExistingInstall
-    /// Pair surfaced a typed Pi error (410/409/4xx). Recovery is the
-    /// typed-error specific path (mint a new token, revoke the
-    /// existing host, etc.).
     case pairFailed(PiClientError)
-    /// Pair failed at the transport layer or with a 5xx — the Pi may
-    /// or may not have committed the host row. Operator must run
-    /// `crm-admin --list-hosts` to disambiguate.
     case ambiguousPair(underlying: String)
-    /// Post-pair local persistence (config, Keychain, state, or
-    /// atomic rename) failed AFTER the Pi committed. The host ID is
-    /// carried so the recovery message names it.
     case persistFailed(hostID: UUID, stage: String, underlying: String)
-    case launchctlFailed(exitCode: Int32, stderr: String)
+    /// SMAppService.register() failed. `requiresApproval=true` when
+    /// the underlying NSError code matches
+    /// `kSMErrorLaunchDeniedByUser` (operator denied in
+    /// System Settings → Login Items). All other failures surface
+    /// with `requiresApproval=false`.
+    case agentRegistrationFailed(message: String, requiresApproval: Bool)
+    /// Stop-the-running-daemon timed out during upgrade or migration.
+    /// `pid` is read from the pidfile so the operator can `kill -TERM
+    /// <pid>` manually.
+    case daemonStillRunning(pid: pid_t)
+    /// Legacy launchctl bootout verification (D7 step 2c) reported
+    /// the legacy registration is STILL loaded after the 2-second
+    /// grace period. Operator must manually run
+    /// `launchctl bootout gui/$(id -u)/<label>` and re-run.
+    case legacyBootoutFailed(stderr: String)
     case filesystemFailed(String)
     case codesignFailed(String)
     case keychainFailed(String)
@@ -100,8 +143,17 @@ public enum InstallError: Error, CustomStringConvertible {
                 "To recover: (1) run `crm-mac uninstall --purge` to clear partial local state, " +
                 "(2) on the Pi run `crm-admin --revoke-host \(id.uuidString.lowercased())`, " +
                 "(3) re-mint a token and re-run `crm-mac install`."
-        case .launchctlFailed(let code, let stderr):
-            return "launchctl bootstrap failed (exit \(code)): \(stderr). Binary is installed; run `crm-mac install --register-only` after fixing the underlying issue (System Settings -> Privacy & Security)."
+        case .agentRegistrationFailed(let m, let approval):
+            let suffix = approval
+                ? " Approve crm-mac in System Settings → General → Login Items → Allow in Background, then re-run `crm-mac install --register-only`."
+                : " Address the underlying issue, then re-run `crm-mac install --register-only`."
+            return "agent registration failed: \(m).\(suffix)"
+        case .daemonStillRunning(let pid):
+            return "the running crm-mac daemon (pid=\(pid)) did not exit within the SIGTERM grace period. " +
+                "Recovery: `kill -TERM \(pid)` (or `kill -9 \(pid)` if it's stuck), then re-run."
+        case .legacyBootoutFailed(let stderr):
+            return "legacy launchd registration could not be bootouted: \(stderr). " +
+                "Recovery: `launchctl bootout gui/$(id -u)/\(Daemon.label)`, then re-run `crm-mac install --upgrade`."
         case .filesystemFailed(let m): return "filesystem: \(m)"
         case .codesignFailed(let m): return "codesign: \(m)"
         case .keychainFailed(let m): return "keychain: \(m)"
@@ -110,44 +162,65 @@ public enum InstallError: Error, CustomStringConvertible {
     }
 }
 
-/// All collaborators an Installer needs. Test code instantiates with
-/// fakes; production wires through CRMMacSystem implementations.
+/// All collaborators an Installer needs.
 public struct InstallerDependencies {
     public let paths: LifecyclePaths
     public let filesystem: FilesystemAdapter
     public let executable: ExecutableAdapter
     public let keychain: KeychainStore
-    public let launchctl: LaunchctlRunner
+    public let agentService: AgentService
+    public let processSignaller: ProcessSignaller
+    public let bundleAssembler: BundleAssembler
     public let piClientFactory: (URL) -> PiClient
     public let clock: ClockAdapter
     public let logger: LoggerProtocol
     /// One-shot migration source for installs that predate the
     /// file-backed FileAPIKeyStore. When non-nil and `keychain` is
     /// empty, runUpgrade / runRegisterOnly copy from this into
-    /// `keychain` and then delete the legacy entry. Production wires
-    /// the real macOS Keychain; tests leave it nil.
+    /// `keychain` and then delete the legacy entry.
     public let legacyKeychain: KeychainStore?
+    /// Legacy launchctl runner — used only by the migration path
+    /// (D7 step 2) to bootout the pre-bundle launchd registration.
+    /// Nil in tests that don't exercise migration.
+    public let legacyLaunchctl: LaunchctlRunner?
+
+    /// Timeout (seconds) for the SIGTERM + pidfile-poll on upgrade
+    /// + migration. Default 10s. Override in tests for faster runs.
+    public let stopDaemonTimeoutSeconds: TimeInterval
+    /// Grace period (seconds) after legacy bootout before the
+    /// printService verification probe (D7 step 2c).
+    public let legacyBootoutGraceSeconds: TimeInterval
 
     public init(
         paths: LifecyclePaths,
         filesystem: FilesystemAdapter,
         executable: ExecutableAdapter,
         keychain: KeychainStore,
-        launchctl: LaunchctlRunner,
+        agentService: AgentService,
+        processSignaller: ProcessSignaller,
+        bundleAssembler: BundleAssembler,
         piClientFactory: @escaping (URL) -> PiClient,
         clock: ClockAdapter,
         logger: LoggerProtocol,
-        legacyKeychain: KeychainStore? = nil
+        legacyKeychain: KeychainStore? = nil,
+        legacyLaunchctl: LaunchctlRunner? = nil,
+        stopDaemonTimeoutSeconds: TimeInterval = 10,
+        legacyBootoutGraceSeconds: TimeInterval = 2
     ) {
         self.paths = paths
         self.filesystem = filesystem
         self.executable = executable
         self.keychain = keychain
-        self.launchctl = launchctl
+        self.agentService = agentService
+        self.processSignaller = processSignaller
+        self.bundleAssembler = bundleAssembler
         self.piClientFactory = piClientFactory
         self.clock = clock
         self.logger = logger
         self.legacyKeychain = legacyKeychain
+        self.legacyLaunchctl = legacyLaunchctl
+        self.stopDaemonTimeoutSeconds = stopDaemonTimeoutSeconds
+        self.legacyBootoutGraceSeconds = legacyBootoutGraceSeconds
     }
 }
 
@@ -158,6 +231,12 @@ public struct Installer {
         self.deps = deps
     }
 
+    /// Placeholder string the build-time shell script writes into the
+    /// embedded LaunchAgents plist for the binary path. The installer
+    /// substitutes this with the real install-time bundle path before
+    /// SMAppService.register reads it.
+    public static let installPrefixPlaceholder = "__INSTALL_PREFIX__"
+
     public func run(_ request: InstallRequest) async throws -> InstallSummary {
         if request.upgrade && request.registerOnly {
             throw InstallError.unexpected("--upgrade and --register-only are mutually exclusive")
@@ -166,7 +245,7 @@ public struct Installer {
             return try await runUpgrade()
         }
         if request.registerOnly {
-            return try runRegisterOnly()
+            return try await runRegisterOnly()
         }
         return try await runFreshInstall(request)
     }
@@ -184,8 +263,9 @@ public struct Installer {
             throw InstallError.alreadyInstalled
         }
 
-        // Create supporting directories.
-        for dir in [deps.paths.configDirPath, deps.paths.binDirPath, deps.paths.logsDirPath, deps.paths.launchAgentsDirPath] {
+        // Create supporting directories. NO bin/ — bare binary
+        // location is migration-only.
+        for dir in [deps.paths.configDirPath, deps.paths.logsDirPath] {
             do {
                 try deps.filesystem.createDirectory(at: dir)
             } catch {
@@ -193,26 +273,29 @@ public struct Installer {
             }
         }
 
-        // Stage the running executable to a temp path.
+        // Assemble the new bundle at a tmp path.
         let sourcePath: String
         do {
             sourcePath = try deps.executable.currentExecutablePath()
         } catch {
             throw InstallError.unexpected("currentExecutablePath: \(error)")
         }
-        let tempPath = "\(deps.paths.binDirPath)/crm-mac.tmp.\(ProcessInfo.processInfo.processIdentifier)"
+        let tmpBundle = tmpBundlePath()
+        let launchAgentContent = renderPlaceholderLaunchAgentContent()
+        let infoPlistContent = try loadInfoPlistContent()
         do {
-            try deps.filesystem.copy(from: sourcePath, to: tempPath)
-            try deps.filesystem.makeExecutable(at: tempPath)
+            try deps.bundleAssembler.assemble(BundleAssemblerInput(
+                machoSourcePath: sourcePath,
+                bundlePath: tmpBundle,
+                launchAgentPlistContent: launchAgentContent,
+                infoPlistContent: infoPlistContent,
+                codesignIdentifier: Daemon.label))
+        } catch let err as ExecutableAdapterError {
+            try? deps.filesystem.remove(at: tmpBundle)
+            throw InstallError.codesignFailed("\(err)")
         } catch {
-            try? deps.filesystem.remove(at: tempPath)
-            throw InstallError.filesystemFailed("stage temp binary: \(error)")
-        }
-        do {
-            try deps.executable.adhocCodesign(path: tempPath)
-        } catch {
-            try? deps.filesystem.remove(at: tempPath)
-            throw InstallError.codesignFailed("\(error)")
+            try? deps.filesystem.remove(at: tmpBundle)
+            throw InstallError.filesystemFailed("assemble bundle: \(error)")
         }
 
         // Pair with the Pi.
@@ -225,12 +308,8 @@ public struct Installer {
                 daemonVersion: Daemon.version,
                 protocolVersion: Daemon.protocolVersion)
         } catch let piErr as PiClientError {
-            try? deps.filesystem.remove(at: tempPath)
+            try? deps.filesystem.remove(at: tmpBundle)
             deps.logger.error("pair failed", metadata: ["error": .private(String(describing: piErr))])
-            // Transport / 5xx failures are ambiguous — the Pi may
-            // have committed before the response was lost. Surface a
-            // distinct error so the operator gets the list-hosts
-            // recovery path.
             switch piErr {
             case .transport, .serverError:
                 throw InstallError.ambiguousPair(underlying: String(describing: piErr))
@@ -238,13 +317,11 @@ public struct Installer {
                 throw InstallError.pairFailed(piErr)
             }
         } catch {
-            try? deps.filesystem.remove(at: tempPath)
+            try? deps.filesystem.remove(at: tmpBundle)
             throw InstallError.ambiguousPair(underlying: String(describing: error))
         }
 
-        // Persist config + Keychain + state. On ANY failure unlink the
-        // temp binary and surface persistFailed (with the paired host
-        // ID) so the operator's recovery path is clear.
+        // Persist config + api-key + state.
         do {
             let cfg = DaemonConfig(
                 piURL: request.piURL,
@@ -262,52 +339,52 @@ public struct Installer {
             }
             try writeInitialState(hostID: pairResult.hostID)
         } catch let pErr as InstallError {
-            try? deps.filesystem.remove(at: tempPath)
+            try? deps.filesystem.remove(at: tmpBundle)
             throw pErr
         } catch {
-            try? deps.filesystem.remove(at: tempPath)
+            try? deps.filesystem.remove(at: tmpBundle)
             throw InstallError.persistFailed(
                 hostID: pairResult.hostID,
                 stage: "post-pair persistence",
                 underlying: String(describing: error))
         }
 
-        // Atomic-rename the temp binary into place. Final step
-        // before launchd registration; any failure beyond this point
-        // leaves the binary installed and recovery is
-        // `crm-mac install --register-only`.
+        // Atomic-rename tmp bundle to the install path. Destination
+        // is absent (preflight refused otherwise) — same-parent,
+        // empty-destination rename.
         do {
-            try deps.filesystem.rename(from: tempPath, to: deps.paths.binaryPath)
+            try deps.filesystem.rename(
+                from: tmpBundle,
+                to: deps.paths.bundleAppPath)
         } catch {
-            try? deps.filesystem.remove(at: tempPath)
+            try? deps.filesystem.remove(at: tmpBundle)
             throw InstallError.persistFailed(
                 hostID: pairResult.hostID,
-                stage: "rename temp -> install",
+                stage: "rename tmp bundle -> install",
                 underlying: String(describing: error))
         }
 
-        // Write plist + launchctl bootstrap. Both happen AFTER the
-        // binary + config + Keychain + state are durably installed,
-        // so any failure here leaves the install in a state where
-        // `crm-mac install --register-only` is the recovery path.
+        // Substitute placeholder in the bundle's embedded plist.
         do {
-            try writePlist()
-        } catch let fsErr {
-            throw InstallError.launchctlFailed(
-                exitCode: -1,
-                stderr: "write plist: \(fsErr)")
+            try substituteInstallPrefixPlaceholder(
+                bundlePath: deps.paths.bundleAppPath)
+        } catch {
+            throw InstallError.filesystemFailed(
+                "substitute install prefix: \(error)")
         }
-        try bootstrapAgent()
+
+        // Register the agent.
+        try registerAgent()
 
         deps.logger.info("install: complete", metadata: [
             "host_id": .private(pairResult.hostID.uuidString),
-            "binary": .private(deps.paths.binaryPath),
+            "bundle": .private(deps.paths.bundleAppPath),
         ])
         return InstallSummary(
             hostID: pairResult.hostID,
             cursorEpoch: pairResult.cursorEpoch,
-            binaryPath: deps.paths.binaryPath,
-            plistPath: deps.paths.plistPath)
+            bundleBinaryPath: deps.paths.bundleBinaryPath,
+            bundleAppPath: deps.paths.bundleAppPath)
     }
 
     // MARK: - upgrade
@@ -322,44 +399,117 @@ public struct Installer {
         }
         let cfg = try readConfig()
 
-        // Bootout the running daemon so we can replace the binary.
-        // Failure here is tolerable — bootout returns non-zero when
-        // service isn't loaded, which is fine for upgrade.
-        _ = try? deps.launchctl.bootout(label: Daemon.label)
+        // If a legacy bare-binary install is present, run the one-shot
+        // migration. This stops the legacy daemon + bootouts the
+        // legacy launchd registration BEFORE bundle assembly because
+        // the labels collide.
+        try await runLegacyMigrationIfNeeded()
 
-        // Stage + atomic-rename over the install path.
+        // U2. Stop the running daemon (if any). On a fresh
+        // SMAppService-managed install the agentService.unregister is
+        // the canonical way to ask launchd to stop relaunching the
+        // daemon; SIGTERM + pidfile-poll handles the actual process
+        // exit because SMAppService.unregister does NOT terminate
+        // running processes.
+        try await stopRunningDaemon()
+
+        // U3. Backup the existing bundle (if present — fresh upgrade
+        // after a `--register-only` failure may have no bundle).
+        let backupPath = backupBundlePath()
+        let hadExistingBundle = deps.filesystem.fileExists(
+            at: deps.paths.bundleAppPath)
+        if hadExistingBundle {
+            do {
+                try deps.filesystem.rename(
+                    from: deps.paths.bundleAppPath,
+                    to: backupPath)
+            } catch {
+                throw InstallError.filesystemFailed(
+                    "rename existing bundle to backup: \(error)")
+            }
+        }
+
+        // U4. Assemble new bundle at tmp path.
         let sourcePath: String
         do {
             sourcePath = try deps.executable.currentExecutablePath()
         } catch {
+            try? restoreBundleBackup(from: backupPath, hadExisting: hadExistingBundle)
             throw InstallError.unexpected("currentExecutablePath: \(error)")
         }
-        let tempPath = "\(deps.paths.binDirPath)/crm-mac.tmp.\(ProcessInfo.processInfo.processIdentifier)"
+        let tmpBundle = tmpBundlePath()
+        let launchAgentContent = renderPlaceholderLaunchAgentContent()
+        let infoPlistContent: Data
         do {
-            try deps.filesystem.copy(from: sourcePath, to: tempPath)
-            try deps.filesystem.makeExecutable(at: tempPath)
-            try deps.executable.adhocCodesign(path: tempPath)
-            try deps.filesystem.rename(from: tempPath, to: deps.paths.binaryPath)
+            infoPlistContent = try loadInfoPlistContent()
         } catch {
-            try? deps.filesystem.remove(at: tempPath)
-            throw InstallError.filesystemFailed("upgrade rename: \(error)")
+            try? restoreBundleBackup(from: backupPath, hadExisting: hadExistingBundle)
+            throw InstallError.filesystemFailed(
+                "load info.plist content: \(error)")
         }
-        try writePlist()
-        try bootstrapAgent()
+        do {
+            try deps.bundleAssembler.assemble(BundleAssemblerInput(
+                machoSourcePath: sourcePath,
+                bundlePath: tmpBundle,
+                launchAgentPlistContent: launchAgentContent,
+                infoPlistContent: infoPlistContent,
+                codesignIdentifier: Daemon.label))
+        } catch let err as ExecutableAdapterError {
+            try? deps.filesystem.remove(at: tmpBundle)
+            try? restoreBundleBackup(from: backupPath, hadExisting: hadExistingBundle)
+            throw InstallError.codesignFailed("\(err)")
+        } catch {
+            try? deps.filesystem.remove(at: tmpBundle)
+            try? restoreBundleBackup(from: backupPath, hadExisting: hadExistingBundle)
+            throw InstallError.filesystemFailed("assemble bundle: \(error)")
+        }
+
+        // U5. Atomic-rename tmp bundle -> final path.
+        do {
+            try deps.filesystem.rename(
+                from: tmpBundle,
+                to: deps.paths.bundleAppPath)
+        } catch {
+            try? deps.filesystem.remove(at: tmpBundle)
+            try? restoreBundleBackup(from: backupPath, hadExisting: hadExistingBundle)
+            throw InstallError.filesystemFailed(
+                "rename tmp bundle -> install: \(error)")
+        }
+
+        // U6. Substitute placeholder + register.
+        do {
+            try substituteInstallPrefixPlaceholder(
+                bundlePath: deps.paths.bundleAppPath)
+        } catch {
+            // Rollback: move the new bundle out of the way, restore
+            // backup. The placeholder substitution is a pure-Swift
+            // string replace + write; failure here is rare (write
+            // failure injection in tests) but recoverable.
+            try? deps.filesystem.remove(at: deps.paths.bundleAppPath)
+            try? restoreBundleBackup(from: backupPath, hadExisting: hadExistingBundle)
+            throw InstallError.filesystemFailed(
+                "substitute install prefix: \(error)")
+        }
+        try registerAgent()
+
+        // U7. Cleanup backup (best-effort).
+        if hadExistingBundle {
+            try? deps.filesystem.remove(at: backupPath)
+        }
 
         deps.logger.info("install: upgrade complete", metadata: [
             "host_id": .private(cfg.hostID.uuidString),
         ])
         return InstallSummary(
             hostID: cfg.hostID,
-            cursorEpoch: 0,  // unknown without a heartbeat round-trip
-            binaryPath: deps.paths.binaryPath,
-            plistPath: deps.paths.plistPath)
+            cursorEpoch: 0,
+            bundleBinaryPath: deps.paths.bundleBinaryPath,
+            bundleAppPath: deps.paths.bundleAppPath)
     }
 
     // MARK: - register-only
 
-    private func runRegisterOnly() throws -> InstallSummary {
+    private func runRegisterOnly() async throws -> InstallSummary {
         guard deps.filesystem.fileExists(at: deps.paths.configFilePath) else {
             throw InstallError.noExistingInstall
         }
@@ -369,23 +519,368 @@ public struct Installer {
         }
         let cfg = try readConfig()
 
-        try writePlist()
-        try bootstrapAgent()
+        // If a legacy install is present and the bundle is NOT yet in
+        // place, run migration. The migration assembles the bundle +
+        // registers; we fall through to the no-op-register below.
+        try await runLegacyMigrationIfNeeded()
+
+        // Refuse if the bundle is missing — register-only registers
+        // an EXISTING bundle; if it's not there, the operator wants
+        // --upgrade (which reassembles).
+        guard deps.filesystem.fileExists(at: deps.paths.bundleAppPath) else {
+            throw InstallError.noExistingInstall
+        }
+
+        // Substitute placeholder (idempotent — second-run on an
+        // already-substituted plist is a no-op).
+        do {
+            try substituteInstallPrefixPlaceholder(
+                bundlePath: deps.paths.bundleAppPath)
+        } catch {
+            // Ignore "no placeholder found" errors — happens on the
+            // post-migration retry path. Other write failures bubble.
+            if let fsErr = error as? FilesystemError {
+                throw InstallError.filesystemFailed(
+                    "substitute install prefix: \(fsErr)")
+            }
+            // Else (e.g., InstallError.unexpected from the
+            // already-substituted-no-placeholder branch): tolerate.
+        }
+        try registerAgent()
         return InstallSummary(
             hostID: cfg.hostID,
             cursorEpoch: 0,
-            binaryPath: deps.paths.binaryPath,
-            plistPath: deps.paths.plistPath)
+            bundleBinaryPath: deps.paths.bundleBinaryPath,
+            bundleAppPath: deps.paths.bundleAppPath)
+    }
+
+    // MARK: - legacy migration
+
+    /// Detect + migrate a pre-rewrite bare-binary install (plan D7).
+    /// Three-signal detection:
+    ///   (1) legacy binary at paths.legacyBinaryPath
+    ///   (2) NO bundle at paths.bundleAppPath
+    ///   (3) at least one user-data file present (config/state/api-key)
+    /// Runs ONLY when all three hold; falls through otherwise.
+    private func runLegacyMigrationIfNeeded() async throws {
+        let hasLegacyBinary = deps.filesystem.fileExists(
+            at: deps.paths.legacyBinaryPath)
+        let hasNewBundle = deps.filesystem.fileExists(
+            at: deps.paths.bundleAppPath)
+        let hasUserData =
+            deps.filesystem.fileExists(at: deps.paths.configFilePath) ||
+            deps.filesystem.fileExists(at: deps.paths.stateFilePath) ||
+            ((try? deps.keychain.readAPIKey()) != nil)
+        guard hasLegacyBinary, !hasNewBundle, hasUserData else {
+            return
+        }
+
+        // D7 step 2a — stop the legacy daemon.
+        try await stopLegacyDaemon()
+        // D7 step 2b + 2c — bootout legacy registration + verify gone.
+        try bootoutLegacyAndVerify()
+
+        // D7 steps 3-6 — assemble the bundle + register. Reuse the
+        // fresh-install assembly + register helpers via a private
+        // sub-flow.
+        try await assembleAndRegisterNewBundle()
+
+        // D7 step 7 — best-effort cleanup of legacy files.
+        if deps.filesystem.fileExists(at: deps.paths.legacyPlistPath) {
+            try? deps.filesystem.remove(at: deps.paths.legacyPlistPath)
+        }
+        if deps.filesystem.fileExists(at: deps.paths.legacyBinaryPath) {
+            try? deps.filesystem.remove(at: deps.paths.legacyBinaryPath)
+        }
+        // Tolerate leftover bin/ directory; operator's --purge sweeps it.
+
+        deps.logger.info("legacy migration: complete", metadata: [:])
+    }
+
+    /// D7 step 2a — read the legacy pidfile (same path as the new
+    /// install — the daemon writes to <configDir>/daemon.pid) and
+    /// send SIGTERM; poll for release.
+    private func stopLegacyDaemon() async throws {
+        // The pidfile path is shared between legacy + new install
+        // (both daemons write to <configDir>/daemon.pid).
+        let pidfilePath = deps.paths.pidfilePath
+        guard deps.filesystem.fileExists(at: pidfilePath) else {
+            // No pidfile — legacy daemon not running. Benign.
+            return
+        }
+        let pidData: Data
+        do {
+            pidData = try deps.filesystem.read(from: pidfilePath)
+        } catch {
+            // Pidfile vanished between exists() and read() — race;
+            // treat as not running.
+            return
+        }
+        let raw = String(data: pidData, encoding: .utf8) ?? ""
+        guard let pid = pid_t(raw.trimmingCharacters(in: .whitespacesAndNewlines)) else {
+            return
+        }
+        do {
+            try deps.processSignaller.sendSIGTERM(pid: pid)
+        } catch {
+            deps.logger.warning("legacy migration: SIGTERM failed (continuing)", metadata: [
+                "pid": .public("\(pid)"),
+                "error": .private("\(error)"),
+            ])
+        }
+        let released = await deps.processSignaller.waitForPidfileRelease(
+            path: pidfilePath,
+            timeoutSeconds: deps.stopDaemonTimeoutSeconds)
+        if !released {
+            throw InstallError.daemonStillRunning(pid: pid)
+        }
+    }
+
+    /// D7 steps 2b + 2c — bootout legacy launchd registration; verify
+    /// gone via printService probe after grace period.
+    private func bootoutLegacyAndVerify() throws {
+        guard let legacy = deps.legacyLaunchctl else {
+            // No legacy launchctl wired — happens in tests that
+            // don't exercise migration. Treat as already-unloaded.
+            return
+        }
+        let bootoutResult = (try? legacy.bootout(label: Daemon.label))
+            ?? LaunchctlInvocation(arguments: [], exitCode: -1)
+        // D7 step 2c — wait then probe. The grace period is held
+        // open synchronously here because the rest of the migration
+        // (bundle assembly + register) IS the next step; there's no
+        // gain to async-sleeping just this section.
+        Thread.sleep(forTimeInterval: deps.legacyBootoutGraceSeconds)
+        let probe: LaunchctlInvocation
+        do {
+            probe = try legacy.printService(label: Daemon.label)
+        } catch {
+            // Probe failed — best-effort treat as not registered.
+            return
+        }
+        if probe.exitCode == 0 {
+            throw InstallError.legacyBootoutFailed(stderr: bootoutResult.stderr)
+        }
+    }
+
+    /// D7 steps 3-6 — bundle assembly + atomic-rename + substitute
+    /// placeholder + register. Used by the migration path; the fresh
+    /// install flow inlines its own version (which also does
+    /// pair + persist).
+    private func assembleAndRegisterNewBundle() async throws {
+        let sourcePath: String
+        do {
+            sourcePath = try deps.executable.currentExecutablePath()
+        } catch {
+            throw InstallError.unexpected("currentExecutablePath: \(error)")
+        }
+        // Create supporting dirs (idempotent).
+        for dir in [deps.paths.configDirPath, deps.paths.logsDirPath] {
+            try? deps.filesystem.createDirectory(at: dir)
+        }
+        let tmpBundle = tmpBundlePath()
+        let launchAgentContent = renderPlaceholderLaunchAgentContent()
+        let infoPlistContent = try loadInfoPlistContent()
+        do {
+            try deps.bundleAssembler.assemble(BundleAssemblerInput(
+                machoSourcePath: sourcePath,
+                bundlePath: tmpBundle,
+                launchAgentPlistContent: launchAgentContent,
+                infoPlistContent: infoPlistContent,
+                codesignIdentifier: Daemon.label))
+        } catch let err as ExecutableAdapterError {
+            try? deps.filesystem.remove(at: tmpBundle)
+            throw InstallError.codesignFailed("\(err)")
+        } catch {
+            try? deps.filesystem.remove(at: tmpBundle)
+            throw InstallError.filesystemFailed("assemble bundle: \(error)")
+        }
+        do {
+            try deps.filesystem.rename(
+                from: tmpBundle,
+                to: deps.paths.bundleAppPath)
+        } catch {
+            try? deps.filesystem.remove(at: tmpBundle)
+            throw InstallError.filesystemFailed(
+                "rename tmp bundle -> install: \(error)")
+        }
+        do {
+            try substituteInstallPrefixPlaceholder(
+                bundlePath: deps.paths.bundleAppPath)
+        } catch {
+            throw InstallError.filesystemFailed(
+                "substitute install prefix: \(error)")
+        }
+        try registerAgent()
     }
 
     // MARK: - shared helpers
 
+    /// Wrap `agentService.register()`. The wrapper returns an outcome
+    /// enum (registered / alreadyRegistered) — both are success cases
+    /// from the workflow's perspective.
+    private func registerAgent() throws {
+        let outcome: AgentRegisterOutcome
+        do {
+            outcome = try deps.agentService.register()
+        } catch let err as AgentServiceError {
+            switch err {
+            case .registrationFailed(let m, let approval):
+                throw InstallError.agentRegistrationFailed(
+                    message: m, requiresApproval: approval)
+            case .unregistrationFailed, .bundleNotFound:
+                throw InstallError.agentRegistrationFailed(
+                    message: "\(err)", requiresApproval: false)
+            }
+        } catch {
+            throw InstallError.agentRegistrationFailed(
+                message: "\(error)", requiresApproval: false)
+        }
+        switch outcome {
+        case .registered:
+            deps.logger.info("agent registered", metadata: [:])
+        case .alreadyRegistered:
+            deps.logger.info("agent already registered (no-op)", metadata: [:])
+        }
+    }
+
+    /// Stop the running daemon: unregister via SMAppService, SIGTERM
+    /// the process via ProcessSignaller, poll the pidfile.
+    private func stopRunningDaemon() async throws {
+        do {
+            try await deps.agentService.unregister()
+        } catch {
+            // Tolerate — SMAppService.unregister can fail benignly
+            // (not registered). The SIGTERM-and-poll below is the
+            // authoritative stop.
+            deps.logger.warning(
+                "stop daemon: agentService.unregister failed (continuing)",
+                metadata: ["error": .private("\(error)")])
+        }
+        let pidfilePath = deps.paths.pidfilePath
+        guard deps.filesystem.fileExists(at: pidfilePath) else {
+            return
+        }
+        let pidData: Data
+        do {
+            pidData = try deps.filesystem.read(from: pidfilePath)
+        } catch {
+            return
+        }
+        let raw = String(data: pidData, encoding: .utf8) ?? ""
+        guard let pid = pid_t(raw.trimmingCharacters(in: .whitespacesAndNewlines)) else {
+            return
+        }
+        do {
+            try deps.processSignaller.sendSIGTERM(pid: pid)
+        } catch {
+            deps.logger.warning(
+                "stop daemon: SIGTERM failed (continuing)",
+                metadata: ["pid": .public("\(pid)"), "error": .private("\(error)")])
+        }
+        let released = await deps.processSignaller.waitForPidfileRelease(
+            path: pidfilePath,
+            timeoutSeconds: deps.stopDaemonTimeoutSeconds)
+        if !released {
+            throw InstallError.daemonStillRunning(pid: pid)
+        }
+    }
+
+    /// Replace `__INSTALL_PREFIX__` in the bundle's embedded
+    /// LaunchAgents plist with the real install-time bundle path.
+    /// Idempotent: re-running on an already-substituted plist (no
+    /// placeholder present) is a no-op success.
+    private func substituteInstallPrefixPlaceholder(bundlePath: String) throws {
+        let plistFile = "\(bundlePath)/\(BundleAssembler.launchAgentPlistRelativePath)"
+        let data: Data
+        do {
+            data = try deps.filesystem.read(from: plistFile)
+        } catch {
+            throw InstallError.filesystemFailed(
+                "read embedded plist: \(error)")
+        }
+        let original = String(data: data, encoding: .utf8) ?? ""
+        let substituted = original.replacingOccurrences(
+            of: Self.installPrefixPlaceholder,
+            with: bundlePath)
+        if substituted == original {
+            // Already substituted — idempotent no-op.
+            return
+        }
+        do {
+            try deps.filesystem.write(
+                Data(substituted.utf8), to: plistFile)
+        } catch {
+            throw InstallError.filesystemFailed(
+                "write substituted plist: \(error)")
+        }
+    }
+
+    /// Render the templated LaunchAgent plist content. Uses
+    /// `__INSTALL_PREFIX__` for the binary-path component so
+    /// `substituteInstallPrefixPlaceholder` can rewrite it post-
+    /// rename. Logs + config dir use the real install-time paths
+    /// (computed from configDirPath / logsDirPath) — those don't
+    /// need substitution.
+    private func renderPlaceholderLaunchAgentContent() -> String {
+        let plist = LaunchAgentPlist(
+            label: Daemon.label,
+            binaryPath: "\(Self.installPrefixPlaceholder)/\(BundleAssembler.machoRelativePath)",
+            configDirPath: deps.paths.configDirPath,
+            stdoutPath: deps.paths.stdoutLogPath,
+            stderrPath: deps.paths.stderrLogPath)
+        return plist.render()
+    }
+
+    /// Load the canonical Info.plist bytes from `Bundle.main`. The
+    /// running binary's Mach-O has the file embedded via
+    /// `__TEXT,__info_plist` (linker flag in Package.swift). On the
+    /// upgrade path the running binary IS already in a bundle, so
+    /// `Bundle.main.infoDictionary` resolves from
+    /// `Contents/Info.plist`. Either path surfaces the same dict.
+    /// Re-serialize to XML for the assembled bundle.
+    ///
+    /// CAUTION: this method exists so production install + upgrade
+    /// can read the canonical Info.plist. Tests use the
+    /// `infoPlistContent` injection on `BundleAssemblerInput`
+    /// directly via fixture bytes — `Bundle.main.infoDictionary`
+    /// from a unit-test process resolves to the test runner's
+    /// bundle, NOT crm-mac's.
+    private func loadInfoPlistContent() throws -> Data {
+        guard let dict = Bundle.main.infoDictionary, !dict.isEmpty else {
+            throw InstallError.unexpected(
+                "Bundle.main.infoDictionary is empty — the running binary is missing the embedded Info.plist section. " +
+                "Check that `make mac-daemon` ran the linker -sectcreate flag.")
+        }
+        do {
+            return try PropertyListSerialization.data(
+                fromPropertyList: dict,
+                format: .xml,
+                options: 0)
+        } catch {
+            throw InstallError.unexpected("serialize Info.plist: \(error)")
+        }
+    }
+
+    private func tmpBundlePath() -> String {
+        return "\(deps.paths.configDirPath)/crm-mac.app.tmp.\(ProcessInfo.processInfo.processIdentifier)"
+    }
+
+    private func backupBundlePath() -> String {
+        return "\(deps.paths.configDirPath)/crm-mac.app.backup.\(ProcessInfo.processInfo.processIdentifier)"
+    }
+
+    private func restoreBundleBackup(from backupPath: String, hadExisting: Bool) throws {
+        guard hadExisting else { return }
+        if deps.filesystem.fileExists(at: backupPath) {
+            try? deps.filesystem.rename(
+                from: backupPath, to: deps.paths.bundleAppPath)
+        }
+    }
+
     /// One-shot copy of the API key from the legacy macOS Keychain
-    /// into the file-backed FileAPIKeyStore. Idempotent — when the
-    /// primary store already has a value, returns immediately and
-    /// does NOT touch the legacy entry. Once the value has been
-    /// safely written to disk, the legacy Keychain entry is deleted
-    /// best-effort so a later rebuild doesn't re-prompt.
+    /// into the file-backed FileAPIKeyStore. Same logic as the
+    /// pre-rewrite Installer.
     private func migrateLegacyKeychainIfNeeded() throws {
         if (try? deps.keychain.readAPIKey()) != nil {
             return
@@ -411,9 +906,6 @@ public struct Installer {
         do {
             try legacy.deleteAPIKey()
         } catch {
-            // Non-fatal: file is the new source of truth; a stale
-            // Keychain entry can be cleared with `security delete-
-            // generic-password -s xyz.spengrah.crm-mac`.
             deps.logger.warning("migration: legacy keychain delete failed (non-fatal)", metadata: [
                 "error": .private(String(describing: error)),
             ])
@@ -423,28 +915,19 @@ public struct Installer {
         ])
     }
 
-    /// Preflight detection — returns true when any of the install
-    /// artifacts exist, to refuse fresh-install on top of an existing
-    /// one.
+    /// Preflight detection — refuses fresh-install when artifacts
+    /// from an existing install are detected. Probes:
+    ///   - bundle present at bundleAppPath
+    ///   - legacy bare binary at legacyBinaryPath
+    ///   - config.json present
+    ///   - api-key file present
+    ///   - agent service reports `.enabled`
     private func existingInstallDetected() -> Bool {
-        if deps.filesystem.fileExists(at: deps.paths.binaryPath) { return true }
+        if deps.filesystem.fileExists(at: deps.paths.bundleAppPath) { return true }
+        if deps.filesystem.fileExists(at: deps.paths.legacyBinaryPath) { return true }
         if deps.filesystem.fileExists(at: deps.paths.configFilePath) { return true }
         if (try? deps.keychain.readAPIKey()) != nil { return true }
-        // Conservative on launchctl spawn failure: treat the probe as
-        // inconclusive and refuse fresh install. The operator can then
-        // use --register-only or --upgrade (both bypass preflight) or
-        // run `crm-mac uninstall --purge` to start clean. Failing
-        // open here would let install proceed on top of a leftover
-        // registration we couldn't see.
-        do {
-            let inv = try deps.launchctl.printService(label: Daemon.label)
-            if inv.exitCode == 0 {
-                return true
-            }
-        } catch {
-            deps.logger.warning("install: launchctl probe failed; treating as existing-install for safety", metadata: [
-                "error": .private(String(describing: error)),
-            ])
+        if deps.agentService.currentStatus() == .enabled {
             return true
         }
         return false
@@ -512,32 +995,6 @@ public struct Installer {
                 hostID: hostID,
                 stage: "write state",
                 underlying: String(describing: error))
-        }
-    }
-
-    private func writePlist() throws {
-        let plist = LaunchAgentPlist(
-            label: Daemon.label,
-            binaryPath: deps.paths.binaryPath,
-            configDirPath: deps.paths.configDirPath,
-            stdoutPath: deps.paths.stdoutLogPath,
-            stderrPath: deps.paths.stderrLogPath).render()
-        do {
-            try deps.filesystem.write(Data(plist.utf8), to: deps.paths.plistPath)
-        } catch {
-            throw InstallError.filesystemFailed("write plist: \(error)")
-        }
-    }
-
-    private func bootstrapAgent() throws {
-        let inv: LaunchctlInvocation
-        do {
-            inv = try deps.launchctl.bootstrap(plistPath: deps.paths.plistPath)
-        } catch {
-            throw InstallError.launchctlFailed(exitCode: -1, stderr: String(describing: error))
-        }
-        if inv.exitCode != 0 {
-            throw InstallError.launchctlFailed(exitCode: inv.exitCode, stderr: inv.stderr)
         }
     }
 }

--- a/mac-daemon/Sources/CRMMacLifecycle/Installer.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/Installer.swift
@@ -162,6 +162,15 @@ public enum InstallError: Error, CustomStringConvertible {
                 : " Address the underlying issue, then re-run `crm-mac install --register-only`."
             return "agent registration failed: \(m).\(suffix)"
         case .daemonStillRunning(let pid):
+            if pid <= 0 {
+                // pid 0 / negative pid: the pidfile was malformed or
+                // unreadable. Telling the operator to `kill -TERM 0`
+                // would target the current process group on POSIX —
+                // catastrophic; could kill unrelated shell/session
+                // processes. Surface the safer recovery path.
+                return "the crm-mac daemon's pidfile was present but unreadable, and the lock did not release within the SIGTERM grace period. " +
+                    "Recovery: identify the daemon process with `pgrep -f crm-mac` then `kill -TERM <pid>` (or `kill -9 <pid>` if stuck), then re-run."
+            }
             return "the running crm-mac daemon (pid=\(pid)) did not exit within the SIGTERM grace period. " +
                 "Recovery: `kill -TERM \(pid)` (or `kill -9 \(pid)` if it's stuck), then re-run."
         case .legacyBootoutFailed(let stderr):
@@ -1030,6 +1039,26 @@ public struct Installer {
                 originalError: String(describing: originalError),
                 restoreError: String(describing: restoreError),
                 backupPath: backupPath)
+        }
+        // The upgrade path called agentService.unregister() before
+        // touching the bundle (to stop the running daemon). After a
+        // successful backup restore the old bundle is back on disk
+        // but is unregistered, so launchd won't relaunch it. Re-register
+        // best-effort so the operator isn't stuck with a stopped
+        // service after a rollback. Re-register failures here are
+        // logged but not folded into the original error — the caller
+        // already has a useful actionable message, and the operator's
+        // worst case after a re-register failure is the same as a
+        // partial-install register failure (run `crm-mac install
+        // --register-only` to retry).
+        if hadExisting {
+            do {
+                _ = try deps.agentService.register()
+            } catch {
+                deps.logger.warning(
+                    "upgrade rollback: re-register of restored backup failed (operator must run `crm-mac install --register-only`)",
+                    metadata: ["error": .private("\(error)")])
+            }
         }
         throw originalError
     }

--- a/mac-daemon/Sources/CRMMacLifecycle/Installer.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/Installer.swift
@@ -1,8 +1,8 @@
 // Installer implements `crm-mac install`, `--upgrade`, and
 // `--register-only` against the SMAppService + crm-mac.app bundle
-// architecture (plan D7, D8).
+// architecture.
 //
-// Fresh-install sequence (plan D8 fresh-install table):
+// Fresh-install sequence:
 //   1. Validate inputs.
 //   2. Preflight: refuse if existing install detected.
 //   3. mkdir -p config/logs directories (NO bin/ — the bare-binary
@@ -20,7 +20,7 @@
 //      path.
 //   9. Register the agent with SMAppService.
 //
-// Upgrade sequence (plan D8 U1-U8 — backup-rename-swap):
+// Upgrade sequence (backup-rename-swap):
 //   U1. Validate; read existing config; check legacy migration.
 //   U2. Stop the running daemon (SMAppService.unregister + SIGTERM
 //       via ProcessSignaller; pidfile-poll up to 10s).
@@ -32,15 +32,20 @@
 //   U6. Substitute placeholder + register.
 //   U7. rm -rf crm-mac.app.backup.<pid> (best-effort).
 //   U8. On any failure between U4 and U6: rm -rf tmp bundle AND
-//       rename backup back to crm-mac.app (rollback).
+//       rename backup back to crm-mac.app (rollback). If the restore
+//       itself fails the composed `upgradeRollbackFailed` error
+//       carries both the original failure and the restore failure.
 //
-// Legacy migration (plan D7 — runLegacyMigrationIfNeeded()):
+// Legacy migration (`runLegacyMigrationIfNeeded`):
 //   Detects a pre-bundle bare-binary install
 //   (~/.../bin/crm-mac + ~/Library/LaunchAgents/<label>.plist) and
 //   stops the legacy daemon + bootouts the legacy launchd
 //   registration BEFORE bundle assembly (labels collide between
 //   legacy and SMAppService registrations). After register, deletes
-//   the legacy plist file + bare binary best-effort.
+//   the legacy plist file + bare binary best-effort via
+//   `cleanupLegacyArtifactsIfAny`. The cleanup runs only on a
+//   successful register so a partial-migration retry can still see
+//   the legacy files.
 import Foundation
 import CRMMacCore
 import CRMMacPiClient
@@ -112,10 +117,10 @@ public enum InstallError: Error, CustomStringConvertible {
     /// `pid` is read from the pidfile so the operator can `kill -TERM
     /// <pid>` manually.
     case daemonStillRunning(pid: pid_t)
-    /// Legacy launchctl bootout verification (D7 step 2c) reported
-    /// the legacy registration is STILL loaded after the 2-second
-    /// grace period. Operator must manually run
-    /// `launchctl bootout gui/$(id -u)/<label>` and re-run.
+    /// Legacy launchctl bootout verification reported the legacy
+    /// registration is STILL loaded after the grace period. Operator
+    /// must manually run `launchctl bootout gui/$(id -u)/<label>`
+    /// and re-run.
     case legacyBootoutFailed(stderr: String)
     /// Upgrade hit two failures in a row: the original failure that
     /// triggered rollback, plus a restore-backup failure. The
@@ -190,16 +195,17 @@ public struct InstallerDependencies {
     /// empty, runUpgrade / runRegisterOnly copy from this into
     /// `keychain` and then delete the legacy entry.
     public let legacyKeychain: KeychainStore?
-    /// Legacy launchctl runner — used only by the migration path
-    /// (D7 step 2) to bootout the pre-bundle launchd registration.
-    /// Nil in tests that don't exercise migration.
+    /// Legacy launchctl runner — used only by the migration path to
+    /// bootout the pre-bundle launchd registration. Nil in tests
+    /// that don't exercise migration.
     public let legacyLaunchctl: LaunchctlRunner?
 
     /// Timeout (seconds) for the SIGTERM + pidfile-poll on upgrade
     /// + migration. Default 10s. Override in tests for faster runs.
     public let stopDaemonTimeoutSeconds: TimeInterval
     /// Grace period (seconds) after legacy bootout before the
-    /// printService verification probe (D7 step 2c).
+    /// printService verification probe in the migration's legacy
+    /// bootout check.
     public let legacyBootoutGraceSeconds: TimeInterval
 
     public init(
@@ -548,6 +554,17 @@ public struct Installer {
             try? deps.filesystem.remove(at: backupPath)
         }
 
+        // Partial-migration retry: if the operator reruns
+        // `--upgrade` (rather than `--register-only`) after a prior
+        // legacy-migration register failure, the bundle already
+        // existed at this entry so the migration short-circuit
+        // didn't fire; the normal upgrade path just succeeded.
+        // Legacy artifacts may still be on disk from the earlier
+        // partial migration — sweep them now that the new bundle is
+        // registered. No-op on a fresh upgrade where no legacy
+        // artifacts exist.
+        cleanupLegacyArtifactsIfAny()
+
         deps.logger.info("install: upgrade complete", metadata: [
             "host_id": .private(cfg.hostID.uuidString),
         ])
@@ -611,7 +628,7 @@ public struct Installer {
 
     // MARK: - legacy migration
 
-    /// Detect + migrate a pre-rewrite bare-binary install (plan D7).
+    /// Detect + migrate a pre-rewrite bare-binary install.
     /// Full migration runs when all three signals hold:
     ///   (1) legacy binary at paths.legacyBinaryPath
     ///   (2) NO bundle at paths.bundleAppPath
@@ -643,18 +660,18 @@ public struct Installer {
         guard hasLegacyBinary, !hasNewBundle, hasUserData else {
             return false
         }
-        // D7 step 2a — stop the legacy daemon.
+        // Stop the legacy daemon.
         try await stopLegacyDaemon()
-        // D7 step 2b + 2c — bootout legacy registration + verify gone.
+        // Bootout legacy registration + verify gone.
         try bootoutLegacyAndVerify()
-        // D7 steps 3-6 — assemble the bundle + register. Cleanup is
-        // deferred to the caller's post-register hook so a register
-        // failure leaves the legacy files in place for the retry.
+        // Assemble the bundle + register. Cleanup is deferred to the
+        // caller's post-register hook so a register failure leaves
+        // the legacy files in place for the retry.
         try await assembleAndRegisterNewBundle()
         return true
     }
 
-    /// D7 step 7 — best-effort delete of legacy plist + bare binary.
+    /// Best-effort delete of legacy plist + bare binary.
     /// Idempotent and tolerant of "already gone". Called by the
     /// caller AFTER a successful register so a register-failure
     /// retry path can still find the legacy artifacts and have them
@@ -680,9 +697,9 @@ public struct Installer {
         }
     }
 
-    /// D7 step 2a — read the legacy pidfile (same path as the new
-    /// install — the daemon writes to <configDir>/daemon.pid) and
-    /// send SIGTERM; poll for release.
+    /// Stop the legacy daemon: read the legacy pidfile (same path
+    /// as the new install — the daemon writes to
+    /// <configDir>/daemon.pid) and send SIGTERM; poll for release.
     ///
     /// A present-but-malformed pidfile is NOT treated as "not
     /// running" — the daemon may be alive and we just can't parse its
@@ -721,8 +738,10 @@ public struct Installer {
         }
     }
 
-    /// D7 steps 2b + 2c — bootout legacy launchd registration; verify
-    /// gone via printService probe after grace period.
+    /// Bootout the legacy launchd registration; verify gone via a
+    /// `printService` probe after the configured grace period. If
+    /// the legacy registration is still loaded the migration fails
+    /// with `InstallError.legacyBootoutFailed`.
     private func bootoutLegacyAndVerify() throws {
         guard let legacy = deps.legacyLaunchctl else {
             // No legacy launchctl wired — happens in tests that
@@ -731,7 +750,7 @@ public struct Installer {
         }
         let bootoutResult = (try? legacy.bootout(label: Daemon.label))
             ?? LaunchctlInvocation(arguments: [], exitCode: -1)
-        // D7 step 2c — wait then probe. The grace period is held
+        // Wait then probe. The grace period is held
         // open synchronously here because the rest of the migration
         // (bundle assembly + register) IS the next step; there's no
         // gain to async-sleeping just this section.
@@ -748,10 +767,9 @@ public struct Installer {
         }
     }
 
-    /// D7 steps 3-6 — bundle assembly + atomic-rename + substitute
-    /// placeholder + register. Used by the migration path; the fresh
-    /// install flow inlines its own version (which also does
-    /// pair + persist).
+    /// Bundle assembly + atomic-rename + substitute placeholder +
+    /// register. Used by the migration path; the fresh install flow
+    /// inlines its own version (which also does pair + persist).
     private func assembleAndRegisterNewBundle() async throws {
         let sourcePath: String
         do {

--- a/mac-daemon/Sources/CRMMacLifecycle/Installer.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/Installer.swift
@@ -21,20 +21,20 @@
 //   9. Register the agent with SMAppService.
 //
 // Upgrade sequence (backup-rename-swap):
-//   U1. Validate; read existing config; check legacy migration.
-//   U2. Stop the running daemon (SMAppService.unregister + SIGTERM
-//       via ProcessSignaller; pidfile-poll up to 10s).
-//   U3. Rename existing crm-mac.app -> crm-mac.app.backup.<pid>
-//       (same-parent, empty-destination rename — atomic).
-//   U4. Assemble new bundle at crm-mac.app.tmp.<pid>.
-//   U5. Atomic-rename tmp bundle -> crm-mac.app (destination absent
-//       again because U3 moved the old one).
-//   U6. Substitute placeholder + register.
-//   U7. rm -rf crm-mac.app.backup.<pid> (best-effort).
-//   U8. On any failure between U4 and U6: rm -rf tmp bundle AND
-//       rename backup back to crm-mac.app (rollback). If the restore
-//       itself fails the composed `upgradeRollbackFailed` error
-//       carries both the original failure and the restore failure.
+//   - Validate; read existing config; check legacy migration.
+//   - Stop the running daemon (SMAppService.unregister + SIGTERM
+//     via ProcessSignaller; pidfile-poll up to 10s).
+//   - Rename existing crm-mac.app -> crm-mac.app.backup.<pid>
+//     (same-parent, empty-destination rename — atomic).
+//   - Assemble new bundle at crm-mac.app.tmp.<pid>.
+//   - Atomic-rename tmp bundle -> crm-mac.app (destination absent
+//     again because the prior rename moved the old one).
+//   - Substitute placeholder + register.
+//   - rm -rf crm-mac.app.backup.<pid> (best-effort).
+//   - On any failure between assemble and register: rm -rf tmp
+//     bundle AND rename backup back to crm-mac.app (rollback). If
+//     the restore itself fails the composed `upgradeRollbackFailed`
+//     error carries both the original failure and the restore failure.
 //
 // Legacy migration (`runLegacyMigrationIfNeeded`):
 //   Detects a pre-bundle bare-binary install
@@ -435,7 +435,7 @@ public struct Installer {
                 bundleAppPath: deps.paths.bundleAppPath)
         }
 
-        // U2. Stop the running daemon (if any). On a fresh
+        // Stop the running daemon (if any). On a fresh
         // SMAppService-managed install the agentService.unregister is
         // the canonical way to ask launchd to stop relaunching the
         // daemon; SIGTERM + pidfile-poll handles the actual process
@@ -443,7 +443,7 @@ public struct Installer {
         // running processes.
         try await stopRunningDaemon()
 
-        // U3. Backup the existing bundle (if present — fresh upgrade
+        // Backup the existing bundle (if present — fresh upgrade
         // after a `--register-only` failure may have no bundle).
         let backupPath = backupBundlePath()
         let hadExistingBundle = deps.filesystem.fileExists(
@@ -459,7 +459,7 @@ public struct Installer {
             }
         }
 
-        // U4. Assemble new bundle at tmp path.
+        // Assemble new bundle at tmp path.
         let sourcePath: String
         do {
             sourcePath = try deps.executable.currentExecutablePath()
@@ -507,7 +507,7 @@ public struct Installer {
                 newBundleAtFinalPath: false)
         }
 
-        // U5. Atomic-rename tmp bundle -> final path.
+        // Atomic-rename tmp bundle -> final path.
         do {
             try deps.filesystem.rename(
                 from: tmpBundle,
@@ -521,7 +521,7 @@ public struct Installer {
                 newBundleAtFinalPath: false)
         }
 
-        // U6. Substitute placeholder + register. Rollback on any
+        // Substitute placeholder + register. Rollback on any
         // failure between here and the end of register: remove the
         // new bundle, restore the backup.
         do {
@@ -549,7 +549,7 @@ public struct Installer {
                 newBundleAtFinalPath: true)
         }
 
-        // U7. Cleanup backup (best-effort).
+        // Cleanup backup (best-effort).
         if hadExistingBundle {
             try? deps.filesystem.remove(at: backupPath)
         }

--- a/mac-daemon/Sources/CRMMacLifecycle/LaunchAgentPlist.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/LaunchAgentPlist.swift
@@ -75,7 +75,12 @@ public struct LaunchAgentPlist: Equatable {
 /// Minimal XML escaping for plist `<string>` values. Replaces the
 /// five XML-significant characters so an unusual home directory
 /// path (e.g., `/Users/o'malley`) cannot produce a malformed plist.
-private func xmlEscape(_ s: String) -> String {
+/// Public so the installer can apply the same escaping when
+/// substituting `__INSTALL_PREFIX__` post-render — every path that
+/// lands inside `<string>...</string>` must be escaped, regardless
+/// of whether it went through `LaunchAgentPlist.render()` or was
+/// interpolated afterwards.
+public func xmlEscapePlistString(_ s: String) -> String {
     var out = ""
     out.reserveCapacity(s.count)
     for c in s {
@@ -90,3 +95,7 @@ private func xmlEscape(_ s: String) -> String {
     }
     return out
 }
+
+/// Internal alias preserved for the existing `LaunchAgentPlist.render`
+/// call sites.
+private func xmlEscape(_ s: String) -> String { xmlEscapePlistString(s) }

--- a/mac-daemon/Sources/CRMMacLifecycle/LaunchAgentPlist.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/LaunchAgentPlist.swift
@@ -75,12 +75,7 @@ public struct LaunchAgentPlist: Equatable {
 /// Minimal XML escaping for plist `<string>` values. Replaces the
 /// five XML-significant characters so an unusual home directory
 /// path (e.g., `/Users/o'malley`) cannot produce a malformed plist.
-/// Public so the installer can apply the same escaping when
-/// substituting `__INSTALL_PREFIX__` post-render — every path that
-/// lands inside `<string>...</string>` must be escaped, regardless
-/// of whether it went through `LaunchAgentPlist.render()` or was
-/// interpolated afterwards.
-public func xmlEscapePlistString(_ s: String) -> String {
+private func xmlEscape(_ s: String) -> String {
     var out = ""
     out.reserveCapacity(s.count)
     for c in s {
@@ -95,7 +90,3 @@ public func xmlEscapePlistString(_ s: String) -> String {
     }
     return out
 }
-
-/// Internal alias preserved for the existing `LaunchAgentPlist.render`
-/// call sites.
-private func xmlEscape(_ s: String) -> String { xmlEscapePlistString(s) }

--- a/mac-daemon/Sources/CRMMacLifecycle/Status.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/Status.swift
@@ -8,7 +8,7 @@ import CRMMacCore
 public struct StatusReport: Equatable {
     public let installed: Bool
     public let registered: Bool
-    /// Detailed agent-service registration state (plan D11). Lets the
+    /// Detailed agent-service registration state. Lets the
     /// rendered output distinguish "not registered" from "requires
     /// approval" — both surface as `registered: false`.
     public let registrationStatus: AgentServiceStatus

--- a/mac-daemon/Sources/CRMMacLifecycle/Status.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/Status.swift
@@ -1,15 +1,17 @@
 // Status implements `crm-mac status`. Shows the daemon's known
-// state without making any network call. The
-// launchctl status is an exit-code-only signal — we do NOT parse the
-// `state = running` line from launchctl print (that's informational,
-// not API).
+// state without making any network call. Reads the agent service
+// registration status via AgentService (replaces the previous
+// launchctl printService probe).
 import Foundation
 import CRMMacCore
 
 public struct StatusReport: Equatable {
     public let installed: Bool
     public let registered: Bool
-    public let registeredExitCode: Int32
+    /// Detailed agent-service registration state (plan D11). Lets the
+    /// rendered output distinguish "not registered" from "requires
+    /// approval" — both surface as `registered: false`.
+    public let registrationStatus: AgentServiceStatus
     public let configHostname: String?
     public let configPiURL: String?
     public let hostID: UUID?
@@ -28,7 +30,7 @@ public struct StatusReport: Equatable {
     public init(
         installed: Bool,
         registered: Bool,
-        registeredExitCode: Int32,
+        registrationStatus: AgentServiceStatus,
         configHostname: String?,
         configPiURL: String?,
         hostID: UUID?,
@@ -39,7 +41,7 @@ public struct StatusReport: Equatable {
     ) {
         self.installed = installed
         self.registered = registered
-        self.registeredExitCode = registeredExitCode
+        self.registrationStatus = registrationStatus
         self.configHostname = configHostname
         self.configPiURL = configPiURL
         self.hostID = hostID
@@ -155,16 +157,16 @@ public struct MessagesSourceStatus: Equatable {
 public struct StatusDependencies {
     public let paths: LifecyclePaths
     public let filesystem: FilesystemAdapter
-    public let launchctl: LaunchctlRunner
+    public let agentService: AgentService
 
     public init(
         paths: LifecyclePaths,
         filesystem: FilesystemAdapter,
-        launchctl: LaunchctlRunner
+        agentService: AgentService
     ) {
         self.paths = paths
         self.filesystem = filesystem
-        self.launchctl = launchctl
+        self.agentService = agentService
     }
 }
 
@@ -175,14 +177,15 @@ public struct Status {
     }
 
     public func run() -> StatusReport {
-        let installed = deps.filesystem.fileExists(at: deps.paths.binaryPath)
+        // Installed = the bundle is present on disk. Pre-rewrite this
+        // probed the bare-binary path; post-rewrite the bundle path
+        // is the source of truth. The legacy-binary case is a stale
+        // install in transition; treated as not-yet-installed-with-
+        // bundle.
+        let installed = deps.filesystem.fileExists(at: deps.paths.bundleAppPath)
 
-        var registered = false
-        var registeredExit: Int32 = -1
-        if let inv = try? deps.launchctl.printService(label: Daemon.label) {
-            registeredExit = inv.exitCode
-            registered = inv.exitCode == 0
-        }
+        let regStatus = deps.agentService.currentStatus()
+        let registered = regStatus == .enabled
 
         var configHostname: String?
         var configPiURL: String?
@@ -222,10 +225,6 @@ public struct Status {
                         recoveryRequested: (lastError ?? "").hasPrefix("recovery_requested:"),
                         lastError: lastError)
                 } else if icloudContainerCount > 0 {
-                    // Config has containers but state has never
-                    // recorded a tick — surface a placeholder so
-                    // operators see the source is configured but
-                    // hasn't run.
                     icloudStatus = ICloudContactsSourceStatus(
                         lastScheduledAt: nil,
                         lastPushedAt: nil,
@@ -239,7 +238,7 @@ public struct Status {
         return StatusReport(
             installed: installed,
             registered: registered,
-            registeredExitCode: registeredExit,
+            registrationStatus: regStatus,
             configHostname: configHostname,
             configPiURL: configPiURL,
             hostID: hostID,

--- a/mac-daemon/Sources/CRMMacLifecycle/StopStartOps.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/StopStartOps.swift
@@ -1,5 +1,5 @@
 // StopStartOps — the dependency-injected logic for the `crm-mac stop`
-// and `crm-mac start` subcommands (plan D26). Keeps the ArgumentParser
+// and `crm-mac start` subcommands. Keeps the ArgumentParser
 // shells thin: command parses flags, builds the dependency struct,
 // delegates here.
 import Foundation

--- a/mac-daemon/Sources/CRMMacLifecycle/StopStartOps.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/StopStartOps.swift
@@ -1,0 +1,157 @@
+// StopStartOps — the dependency-injected logic for the `crm-mac stop`
+// and `crm-mac start` subcommands (plan D26). Keeps the ArgumentParser
+// shells thin: command parses flags, builds the dependency struct,
+// delegates here.
+import Foundation
+import CRMMacCore
+
+public struct StopOpsDependencies {
+    public let paths: LifecyclePaths
+    public let filesystem: FilesystemAdapter
+    public let agentService: AgentService
+    public let processSignaller: ProcessSignaller
+    public let logger: LoggerProtocol
+
+    public init(
+        paths: LifecyclePaths,
+        filesystem: FilesystemAdapter,
+        agentService: AgentService,
+        processSignaller: ProcessSignaller,
+        logger: LoggerProtocol
+    ) {
+        self.paths = paths
+        self.filesystem = filesystem
+        self.agentService = agentService
+        self.processSignaller = processSignaller
+        self.logger = logger
+    }
+}
+
+public struct StopOpsResult: Equatable {
+    public let stopped: Bool
+    public let pid: pid_t
+    public let unregisterInvoked: Bool
+
+    public init(stopped: Bool, pid: pid_t, unregisterInvoked: Bool) {
+        self.stopped = stopped
+        self.pid = pid
+        self.unregisterInvoked = unregisterInvoked
+    }
+}
+
+public enum StopOps {
+    public static func run(
+        _ deps: StopOpsDependencies,
+        timeoutSeconds: TimeInterval
+    ) async -> StopOpsResult {
+        var unregisterInvoked = false
+        do {
+            try await deps.agentService.unregister()
+            unregisterInvoked = true
+        } catch {
+            unregisterInvoked = true
+            deps.logger.warning("stop: agentService.unregister failed (continuing)", metadata: [
+                "error": .private("\(error)"),
+            ])
+        }
+
+        var pid: pid_t = 0
+        if deps.filesystem.fileExists(at: deps.paths.pidfilePath) {
+            if let data = try? deps.filesystem.read(from: deps.paths.pidfilePath),
+               let raw = String(data: data, encoding: .utf8),
+               let parsed = pid_t(raw.trimmingCharacters(in: .whitespacesAndNewlines)) {
+                pid = parsed
+                do {
+                    try deps.processSignaller.sendSIGTERM(pid: pid)
+                } catch {
+                    deps.logger.warning("stop: SIGTERM failed (continuing)", metadata: [
+                        "pid": .public("\(pid)"),
+                        "error": .private("\(error)"),
+                    ])
+                }
+            }
+        }
+        let stopped: Bool
+        if pid == 0 {
+            stopped = true
+        } else {
+            stopped = await deps.processSignaller.waitForPidfileRelease(
+                path: deps.paths.pidfilePath,
+                timeoutSeconds: timeoutSeconds)
+        }
+        return StopOpsResult(
+            stopped: stopped,
+            pid: pid,
+            unregisterInvoked: unregisterInvoked)
+    }
+}
+
+public struct StartOpsDependencies {
+    public let agentService: AgentService
+    public let logger: LoggerProtocol
+
+    public init(
+        agentService: AgentService,
+        logger: LoggerProtocol
+    ) {
+        self.agentService = agentService
+        self.logger = logger
+    }
+}
+
+public struct StartOpsResult: Equatable {
+    public let outcome: AgentRegisterOutcome
+    public let finalStatus: AgentServiceStatus
+    public let started: Bool
+
+    public init(
+        outcome: AgentRegisterOutcome,
+        finalStatus: AgentServiceStatus,
+        started: Bool
+    ) {
+        self.outcome = outcome
+        self.finalStatus = finalStatus
+        self.started = started
+    }
+}
+
+public enum StartOpsError: Error, CustomStringConvertible {
+    case registerFailed(AgentServiceError)
+    public var description: String {
+        switch self {
+        case .registerFailed(let e): return "register failed: \(e)"
+        }
+    }
+}
+
+public enum StartOps {
+    /// Register; then poll `currentStatus()` for `.enabled` until
+    /// `statusPollTimeoutSeconds` elapses. `started` is true iff the
+    /// final status is `.enabled`.
+    public static func run(
+        _ deps: StartOpsDependencies,
+        statusPollTimeoutSeconds: TimeInterval,
+        statusPollIntervalNs: UInt64 = 200_000_000
+    ) async throws -> StartOpsResult {
+        let outcome: AgentRegisterOutcome
+        do {
+            outcome = try deps.agentService.register()
+        } catch let err as AgentServiceError {
+            throw StartOpsError.registerFailed(err)
+        } catch {
+            throw StartOpsError.registerFailed(.registrationFailed(
+                message: "\(error)", requiresApproval: false))
+        }
+
+        let deadline = Date().addingTimeInterval(statusPollTimeoutSeconds)
+        var status = deps.agentService.currentStatus()
+        while status != .enabled, Date() < deadline {
+            try? await Task.sleep(nanoseconds: statusPollIntervalNs)
+            status = deps.agentService.currentStatus()
+        }
+        return StartOpsResult(
+            outcome: outcome,
+            finalStatus: status,
+            started: status == .enabled)
+    }
+}

--- a/mac-daemon/Sources/CRMMacLifecycle/StopStartOps.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/StopStartOps.swift
@@ -55,11 +55,19 @@ public enum StopOps {
             ])
         }
 
+        // Decide whether a daemon process is running. A present pidfile
+        // is the signal — we don't conclude "not running" just because
+        // we couldn't parse the pid. If parsing fails we skip the
+        // SIGTERM but still poll the flock (the canonical
+        // "is the daemon alive" probe). If the file is absent the
+        // daemon is definitely not running.
         var pid: pid_t = 0
-        if deps.filesystem.fileExists(at: deps.paths.pidfilePath) {
+        let pidfilePresent = deps.filesystem.fileExists(at: deps.paths.pidfilePath)
+        if pidfilePresent {
             if let data = try? deps.filesystem.read(from: deps.paths.pidfilePath),
                let raw = String(data: data, encoding: .utf8),
-               let parsed = pid_t(raw.trimmingCharacters(in: .whitespacesAndNewlines)) {
+               let parsed = pid_t(raw.trimmingCharacters(in: .whitespacesAndNewlines)),
+               parsed > 0 {
                 pid = parsed
                 do {
                     try deps.processSignaller.sendSIGTERM(pid: pid)
@@ -69,10 +77,17 @@ public enum StopOps {
                         "error": .private("\(error)"),
                     ])
                 }
+            } else {
+                // Pidfile exists but we couldn't parse a pid. Don't
+                // claim a clean stop without verification — fall
+                // through to the flock probe, which is authoritative.
+                deps.logger.warning("stop: pidfile present but unreadable/malformed; relying on flock probe", metadata: [
+                    "path": .private(deps.paths.pidfilePath),
+                ])
             }
         }
         let stopped: Bool
-        if pid == 0 {
+        if !pidfilePresent {
             stopped = true
         } else {
             stopped = await deps.processSignaller.waitForPidfileRelease(

--- a/mac-daemon/Sources/CRMMacLifecycle/Uninstaller.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/Uninstaller.swift
@@ -1,6 +1,6 @@
 // Uninstaller implements `crm-mac uninstall`.
 //
-// Default uninstall (plan D9):
+// Default uninstall:
 //   1. Stop the running daemon (SIGTERM via ProcessSignaller +
 //      pidfile-poll up to 10s). Tolerant — uninstall continues even
 //      if the daemon doesn't exit cleanly.

--- a/mac-daemon/Sources/CRMMacLifecycle/Uninstaller.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/Uninstaller.swift
@@ -196,27 +196,31 @@ public struct Uninstaller {
     /// SIGTERM the running daemon if a pidfile is present; poll for
     /// release. Returns true on clean stop or no-pidfile; false on
     /// timeout. Tolerant — never throws.
+    ///
+    /// A present-but-malformed pidfile is NOT treated as "not
+    /// running" — the daemon may be alive and the pidfile is just
+    /// unparseable. We skip SIGTERM but still rely on the flock
+    /// probe (the canonical "is the daemon alive" check).
     private func stopRunningDaemonTolerant() async -> Bool {
         let pidfilePath = deps.paths.pidfilePath
         guard deps.filesystem.fileExists(at: pidfilePath) else {
             return true
         }
-        let pidData: Data
-        do {
-            pidData = try deps.filesystem.read(from: pidfilePath)
-        } catch {
-            return true
-        }
-        let raw = String(data: pidData, encoding: .utf8) ?? ""
-        guard let pid = pid_t(raw.trimmingCharacters(in: .whitespacesAndNewlines)) else {
-            return true
-        }
-        do {
-            try deps.processSignaller.sendSIGTERM(pid: pid)
-        } catch {
-            deps.logger.warning("uninstall: SIGTERM failed (continuing)", metadata: [
-                "pid": .public("\(pid)"),
-                "error": .private("\(error)"),
+        if let pidData = try? deps.filesystem.read(from: pidfilePath),
+           let raw = String(data: pidData, encoding: .utf8),
+           let pid = pid_t(raw.trimmingCharacters(in: .whitespacesAndNewlines)),
+           pid > 0 {
+            do {
+                try deps.processSignaller.sendSIGTERM(pid: pid)
+            } catch {
+                deps.logger.warning("uninstall: SIGTERM failed (continuing)", metadata: [
+                    "pid": .public("\(pid)"),
+                    "error": .private("\(error)"),
+                ])
+            }
+        } else {
+            deps.logger.warning("uninstall: pidfile present but unreadable/malformed; relying on flock probe", metadata: [
+                "path": .private(pidfilePath),
             ])
         }
         return await deps.processSignaller.waitForPidfileRelease(

--- a/mac-daemon/Sources/CRMMacLifecycle/Uninstaller.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/Uninstaller.swift
@@ -1,14 +1,21 @@
 // Uninstaller implements `crm-mac uninstall`.
 //
-// Default uninstall:
-//   1. launchctl bootout (tolerates non-zero — service may not be loaded)
-//   2. delete plist file
-//   3. delete Keychain entry
-// Does NOT remove config.json / state.json / installed binary.
+// Default uninstall (plan D9):
+//   1. Stop the running daemon (SIGTERM via ProcessSignaller +
+//      pidfile-poll up to 10s). Tolerant — uninstall continues even
+//      if the daemon doesn't exit cleanly.
+//   2. SMAppService.unregister (tolerant of "not registered" errors).
+//   3. Delete the bundle directory at paths.bundleAppPath
+//      (recursive).
+//   4. Delete the api-key entry.
+//   5. Legacy cleanup (unconditional, best-effort): bootout the
+//      legacy launchctl registration if the legacy plist exists;
+//      delete the legacy plist file + legacy bare binary if present.
 //
 // With --purge:
-//   4. additionally remove config.json, state.json, installed binary,
-//      logs (best-effort)
+//   6. additionally remove config.json, state.json, logs, the
+//      icloud_contacts hash cache, and (on purge) the legacy bin/
+//      directory if empty.
 //
 // Pi-side mac_host row is NOT touched — `crm-admin --revoke-host <id>`
 // is the Pi-side knob.
@@ -23,23 +30,45 @@ public struct UninstallRequest: Equatable {
 }
 
 public struct UninstallSummary: Equatable {
-    public let bootoutInvoked: Bool
-    public let bootoutExitCode: Int32
-    public let plistDeleted: Bool
+    /// True iff the SIGTERM + pidfile poll succeeded (or no pidfile
+    /// was present). False if the daemon refused to stop within the
+    /// timeout — uninstall continues regardless; operator can
+    /// `kill -9` separately.
+    public let daemonStopped: Bool
+    /// True iff `agentService.unregister()` was called. The call may
+    /// have thrown an "already not registered" error and still
+    /// returns true here — this field tracks invocation, not
+    /// success.
+    public let unregisterInvoked: Bool
+    /// True iff the bundle directory existed and was removed.
+    public let bundleDeleted: Bool
+    /// True iff the api-key entry existed and was deleted.
     public let keychainDeleted: Bool
+    /// True iff the legacy launchd plist file at
+    /// ~/Library/LaunchAgents/<label>.plist existed and was removed.
+    /// False on a fresh install with no legacy artifacts (the common
+    /// post-rewrite case).
+    public let legacyPlistDeleted: Bool
+    /// True iff the legacy bare binary at <configDir>/bin/crm-mac
+    /// existed and was removed.
+    public let legacyBinaryDeleted: Bool
     public let purged: Bool
 
     public init(
-        bootoutInvoked: Bool,
-        bootoutExitCode: Int32,
-        plistDeleted: Bool,
+        daemonStopped: Bool,
+        unregisterInvoked: Bool,
+        bundleDeleted: Bool,
         keychainDeleted: Bool,
+        legacyPlistDeleted: Bool,
+        legacyBinaryDeleted: Bool,
         purged: Bool
     ) {
-        self.bootoutInvoked = bootoutInvoked
-        self.bootoutExitCode = bootoutExitCode
-        self.plistDeleted = plistDeleted
+        self.daemonStopped = daemonStopped
+        self.unregisterInvoked = unregisterInvoked
+        self.bundleDeleted = bundleDeleted
         self.keychainDeleted = keychainDeleted
+        self.legacyPlistDeleted = legacyPlistDeleted
+        self.legacyBinaryDeleted = legacyBinaryDeleted
         self.purged = purged
     }
 }
@@ -48,21 +77,34 @@ public struct UninstallerDependencies {
     public let paths: LifecyclePaths
     public let filesystem: FilesystemAdapter
     public let keychain: KeychainStore
-    public let launchctl: LaunchctlRunner
+    public let agentService: AgentService
+    public let processSignaller: ProcessSignaller
     public let logger: LoggerProtocol
+    /// Legacy launchctl runner for cleaning up pre-rewrite installs.
+    /// Nil in tests that don't seed legacy artifacts.
+    public let legacyLaunchctl: LaunchctlRunner?
+    /// Timeout (seconds) for the stop-daemon SIGTERM + pidfile poll.
+    /// Default 10s.
+    public let stopDaemonTimeoutSeconds: TimeInterval
 
     public init(
         paths: LifecyclePaths,
         filesystem: FilesystemAdapter,
         keychain: KeychainStore,
-        launchctl: LaunchctlRunner,
-        logger: LoggerProtocol
+        agentService: AgentService,
+        processSignaller: ProcessSignaller,
+        logger: LoggerProtocol,
+        legacyLaunchctl: LaunchctlRunner? = nil,
+        stopDaemonTimeoutSeconds: TimeInterval = 10
     ) {
         self.paths = paths
         self.filesystem = filesystem
         self.keychain = keychain
-        self.launchctl = launchctl
+        self.agentService = agentService
+        self.processSignaller = processSignaller
         self.logger = logger
+        self.legacyLaunchctl = legacyLaunchctl
+        self.stopDaemonTimeoutSeconds = stopDaemonTimeoutSeconds
     }
 }
 
@@ -73,28 +115,38 @@ public struct Uninstaller {
         self.deps = deps
     }
 
-    public func run(_ request: UninstallRequest) throws -> UninstallSummary {
-        // bootout — tolerate non-zero (service may not be loaded).
-        var bootoutExit: Int32 = 0
-        var bootoutInvoked = false
+    public func run(_ request: UninstallRequest) async throws -> UninstallSummary {
+        // 1. Stop the running daemon. Tolerant of failure — the
+        // uninstall continues so config + plist cleanup still runs.
+        let daemonStopped = await stopRunningDaemonTolerant()
+
+        // 2. Unregister via SMAppService. Tolerant of
+        // "already-not-registered" errors.
+        var unregisterInvoked = false
         do {
-            let inv = try deps.launchctl.bootout(label: Daemon.label)
-            bootoutInvoked = true
-            bootoutExit = inv.exitCode
+            try await deps.agentService.unregister()
+            unregisterInvoked = true
         } catch {
-            deps.logger.warning("uninstall: bootout invocation failed", metadata: [
+            unregisterInvoked = true  // we DID call it; it just threw
+            deps.logger.warning("uninstall: agentService.unregister failed (continuing)", metadata: [
                 "error": .private(String(describing: error)),
             ])
         }
 
-        // Delete plist.
-        var plistDeleted = false
-        if deps.filesystem.fileExists(at: deps.paths.plistPath) {
-            try deps.filesystem.remove(at: deps.paths.plistPath)
-            plistDeleted = true
+        // 3. Delete the bundle directory.
+        var bundleDeleted = false
+        if deps.filesystem.fileExists(at: deps.paths.bundleAppPath) {
+            do {
+                try deps.filesystem.remove(at: deps.paths.bundleAppPath)
+                bundleDeleted = true
+            } catch {
+                deps.logger.warning("uninstall: bundle delete failed", metadata: [
+                    "error": .private(String(describing: error)),
+                ])
+            }
         }
 
-        // Delete Keychain entry.
+        // 4. Delete api-key.
         var keychainDeleted = false
         do {
             try deps.keychain.deleteAPIKey()
@@ -105,17 +157,17 @@ public struct Uninstaller {
             ])
         }
 
+        // 5. Legacy cleanup (best-effort).
+        let (legacyPlistDeleted, legacyBinaryDeleted) = cleanupLegacyArtifacts()
+
+        // 6. Purge — remove user-data + logs + icloud hash cache.
         var purged = false
         if request.purge {
-            // The icloud_contacts hash cache lives alongside config.json
-            // + state.json; include it in the purge so a re-pair on
-            // the same Mac starts with no stale prior-hash bindings.
             let icloudHashCachePath = URL(fileURLWithPath: deps.paths.configDirPath)
                 .appendingPathComponent("icloud_contacts_hashes.json").path
             for path in [
                 deps.paths.configFilePath,
                 deps.paths.stateFilePath,
-                deps.paths.binaryPath,
                 deps.paths.stdoutLogPath,
                 deps.paths.stderrLogPath,
                 icloudHashCachePath,
@@ -124,14 +176,84 @@ public struct Uninstaller {
                     try? deps.filesystem.remove(at: path)
                 }
             }
+            // Drop the legacy bin/ dir (empty by this point).
+            if deps.filesystem.fileExists(at: deps.paths.binDirPath) {
+                try? deps.filesystem.remove(at: deps.paths.binDirPath)
+            }
             purged = true
         }
 
         return UninstallSummary(
-            bootoutInvoked: bootoutInvoked,
-            bootoutExitCode: bootoutExit,
-            plistDeleted: plistDeleted,
+            daemonStopped: daemonStopped,
+            unregisterInvoked: unregisterInvoked,
+            bundleDeleted: bundleDeleted,
             keychainDeleted: keychainDeleted,
+            legacyPlistDeleted: legacyPlistDeleted,
+            legacyBinaryDeleted: legacyBinaryDeleted,
             purged: purged)
+    }
+
+    /// SIGTERM the running daemon if a pidfile is present; poll for
+    /// release. Returns true on clean stop or no-pidfile; false on
+    /// timeout. Tolerant — never throws.
+    private func stopRunningDaemonTolerant() async -> Bool {
+        let pidfilePath = deps.paths.pidfilePath
+        guard deps.filesystem.fileExists(at: pidfilePath) else {
+            return true
+        }
+        let pidData: Data
+        do {
+            pidData = try deps.filesystem.read(from: pidfilePath)
+        } catch {
+            return true
+        }
+        let raw = String(data: pidData, encoding: .utf8) ?? ""
+        guard let pid = pid_t(raw.trimmingCharacters(in: .whitespacesAndNewlines)) else {
+            return true
+        }
+        do {
+            try deps.processSignaller.sendSIGTERM(pid: pid)
+        } catch {
+            deps.logger.warning("uninstall: SIGTERM failed (continuing)", metadata: [
+                "pid": .public("\(pid)"),
+                "error": .private("\(error)"),
+            ])
+        }
+        return await deps.processSignaller.waitForPidfileRelease(
+            path: pidfilePath,
+            timeoutSeconds: deps.stopDaemonTimeoutSeconds)
+    }
+
+    /// Best-effort delete of legacy launchd plist + legacy bare
+    /// binary. Returns (plistDeleted, binaryDeleted).
+    private func cleanupLegacyArtifacts() -> (Bool, Bool) {
+        var plistDeleted = false
+        var binaryDeleted = false
+        if deps.filesystem.fileExists(at: deps.paths.legacyPlistPath) {
+            // Bootout the legacy registration if launchctl is wired
+            // (tolerant of non-zero — service may not be loaded).
+            if let legacy = deps.legacyLaunchctl {
+                _ = try? legacy.bootout(label: Daemon.label)
+            }
+            do {
+                try deps.filesystem.remove(at: deps.paths.legacyPlistPath)
+                plistDeleted = true
+            } catch {
+                deps.logger.warning("uninstall: legacy plist delete failed", metadata: [
+                    "error": .private(String(describing: error)),
+                ])
+            }
+        }
+        if deps.filesystem.fileExists(at: deps.paths.legacyBinaryPath) {
+            do {
+                try deps.filesystem.remove(at: deps.paths.legacyBinaryPath)
+                binaryDeleted = true
+            } catch {
+                deps.logger.warning("uninstall: legacy binary delete failed", metadata: [
+                    "error": .private(String(describing: error)),
+                ])
+            }
+        }
+        return (plistDeleted, binaryDeleted)
     }
 }

--- a/mac-daemon/Sources/CRMMacSystem/LaunchAgent.swift
+++ b/mac-daemon/Sources/CRMMacSystem/LaunchAgent.swift
@@ -1,6 +1,12 @@
 // User-domain path bundle for the production install. The plist
 // generator itself lives in CRMMacLifecycle as a pure-string render
 // shared by Installer + tests.
+//
+// As of the SMAppService rewrite the install target is a
+// `crm-mac.app` bundle under `~/Library/Application Support/crm-mac/`
+// rather than a bare binary under `bin/`. The legacy paths
+// (legacyBinaryPath / legacyPlistPath) are kept for one-shot
+// migration detection + cleanup.
 import Foundation
 import CRMMacLifecycle
 
@@ -19,9 +25,6 @@ public struct DaemonPaths {
     public var binDir: URL {
         configDir.appendingPathComponent("bin", isDirectory: true)
     }
-    public var binaryPath: URL {
-        binDir.appendingPathComponent("crm-mac")
-    }
     public var configFile: URL {
         configDir.appendingPathComponent("config.json")
     }
@@ -30,9 +33,6 @@ public struct DaemonPaths {
     }
     public var launchAgentsDir: URL {
         home.appendingPathComponent("Library/LaunchAgents", isDirectory: true)
-    }
-    public var plistPath: URL {
-        launchAgentsDir.appendingPathComponent("\(Daemon.label).plist")
     }
     public var logsDir: URL {
         home.appendingPathComponent("Library/Logs/crm-mac", isDirectory: true)
@@ -43,6 +43,40 @@ public struct DaemonPaths {
     public var stderrLog: URL {
         logsDir.appendingPathComponent("stderr.log")
     }
+
+    // Bundle (new install layout — SMAppService).
+    public var bundleApp: URL {
+        configDir.appendingPathComponent("crm-mac.app", isDirectory: true)
+    }
+    public var bundleBinary: URL {
+        bundleApp.appendingPathComponent("Contents/MacOS/crm-mac")
+    }
+    public var bundlePlist: URL {
+        bundleApp.appendingPathComponent("Contents/Library/LaunchAgents/\(Daemon.label).plist")
+    }
+    public var bundleInfoPlist: URL {
+        bundleApp.appendingPathComponent("Contents/Info.plist")
+    }
+
+    // Legacy paths (kept for migration detection + cleanup).
+    public var legacyBinary: URL {
+        binDir.appendingPathComponent("crm-mac")
+    }
+    public var legacyPlist: URL {
+        launchAgentsDir.appendingPathComponent("\(Daemon.label).plist")
+    }
+
+    /// Pre-rewrite name for the bare-binary path. Aliased to
+    /// `legacyBinary`. Existing call sites that probe for the legacy
+    /// bare binary keep working while the Installer rewrite is
+    /// rolled out commit-by-commit.
+    public var binaryPath: URL { legacyBinary }
+
+    /// Pre-rewrite name for the launchd plist file. Aliased to
+    /// `legacyPlist`. Post-rewrite the bundle's embedded plist
+    /// supersedes this — SMAppService reads from inside the bundle.
+    public var plistPath: URL { legacyPlist }
+
     /// Daemon-runtime directory.  The daemon's PidfileLock writes
     /// `daemon.pid` here so the CLI ops subcommands can detect the
     /// daemon-running state.  Defaults to the configDir so the same

--- a/mac-daemon/Sources/CRMMacSystem/LaunchAgent.swift
+++ b/mac-daemon/Sources/CRMMacSystem/LaunchAgent.swift
@@ -66,16 +66,18 @@ public struct DaemonPaths {
         launchAgentsDir.appendingPathComponent("\(Daemon.label).plist")
     }
 
-    /// Pre-rewrite name for the bare-binary path. Aliased to
-    /// `legacyBinary`. Existing call sites that probe for the legacy
-    /// bare binary keep working while the Installer rewrite is
-    /// rolled out commit-by-commit.
-    public var binaryPath: URL { legacyBinary }
+    /// Deprecated alias for `bundleBinary`. Out-of-tree callers
+    /// reading `binaryPath` should see the in-bundle binary path
+    /// (NOT the legacy bare binary, which has its own dedicated
+    /// accessor `legacyBinary`).
+    @available(*, deprecated, message: "Use bundleBinary (or legacyBinary for migration probes)")
+    public var binaryPath: URL { bundleBinary }
 
-    /// Pre-rewrite name for the launchd plist file. Aliased to
-    /// `legacyPlist`. Post-rewrite the bundle's embedded plist
-    /// supersedes this — SMAppService reads from inside the bundle.
-    public var plistPath: URL { legacyPlist }
+    /// Deprecated alias for `bundlePlist`. Out-of-tree callers
+    /// reading `plistPath` should see the in-bundle plist path.
+    /// The legacy launchd plist remains accessible via `legacyPlist`.
+    @available(*, deprecated, message: "Use bundlePlist (or legacyPlist for migration cleanup)")
+    public var plistPath: URL { bundlePlist }
 
     /// Daemon-runtime directory.  The daemon's PidfileLock writes
     /// `daemon.pid` here so the CLI ops subcommands can detect the

--- a/mac-daemon/Sources/CRMMacSystem/ProductionAgentService.swift
+++ b/mac-daemon/Sources/CRMMacSystem/ProductionAgentService.swift
@@ -1,6 +1,6 @@
-// ProductionAgentService wraps `SMAppService.agent(plistName:)`
-// (per plan D21). Lives in CRMMacSystem so the lifecycle target
-// stays Foundation-only.
+// ProductionAgentService wraps `SMAppService.agent(plistName:)`.
+// Lives in CRMMacSystem so the lifecycle target stays
+// Foundation-only.
 //
 // Tested manually only — SMAppService can't actually register in CI
 // because there's no real bundle on disk and TCC/admin can't be

--- a/mac-daemon/Sources/CRMMacSystem/ProductionAgentService.swift
+++ b/mac-daemon/Sources/CRMMacSystem/ProductionAgentService.swift
@@ -1,0 +1,96 @@
+// ProductionAgentService wraps `SMAppService.agent(plistName:)`
+// (per plan D21). Lives in CRMMacSystem so the lifecycle target
+// stays Foundation-only.
+//
+// Tested manually only — SMAppService can't actually register in CI
+// because there's no real bundle on disk and TCC/admin can't be
+// scripted. The CI surface for AgentService is the FakeAgentService
+// in CRMMacLifecycleTests. The Hypothesis Validation procedure in
+// the PR description exercises the production wrapper on the
+// operator's Mac.
+import Foundation
+import ServiceManagement
+import CRMMacLifecycle
+
+@available(macOS 13.0, *)
+public struct ProductionAgentService: AgentService {
+    public let plistName: String
+
+    public init(plistName: String) {
+        self.plistName = plistName
+    }
+
+    public func register() throws -> AgentRegisterOutcome {
+        let svc = SMAppService.agent(plistName: plistName)
+        do {
+            try svc.register()
+            return .registered
+        } catch {
+            // ServiceManagement exports the error-code constants as
+            // Int32 (Apple's OSStatus-style):
+            //   - kSMErrorAlreadyRegistered  (macOS 13+)
+            //   - kSMErrorLaunchDeniedByUser (macOS 13+)
+            // The error DOMAIN constant `SMAppServiceErrorDomain` is
+            // macOS-15-only (header annotation
+            // `API_AVAILABLE(macos(15.0))`). Package.swift targets
+            // macOS 14, so we cannot reference the symbol directly.
+            // We use the literal string "SMAppServiceErrorDomain"
+            // (the stable runtime value of the constant — verified
+            // against ServiceManagement.framework on macOS 13-15).
+            // Scoping the code switch to this domain prevents
+            // misclassifying an unrelated NSError that happens to
+            // have a colliding `code` value.
+            //
+            // CAVEAT: if Apple ever renames the underlying domain
+            // string in a future SDK (highly unlikely — would break
+            // every existing SMAppService client), this branch
+            // silently stops matching and the wrapper falls through
+            // to the generic registrationFailed path. The Hypothesis
+            // Validation procedure catches this regression because an
+            // already-registered re-register would surface as a
+            // registrationFailed rather than the expected no-op.
+            let ns = error as NSError
+            if ns.domain == "SMAppServiceErrorDomain" {
+                switch ns.code {
+                case Int(kSMErrorAlreadyRegistered):
+                    return .alreadyRegistered
+                case Int(kSMErrorLaunchDeniedByUser):
+                    throw AgentServiceError.registrationFailed(
+                        message: String(describing: error),
+                        requiresApproval: true)
+                default:
+                    break
+                }
+            }
+            throw AgentServiceError.registrationFailed(
+                message: String(describing: error),
+                requiresApproval: false)
+        }
+    }
+
+    public func unregister() async throws {
+        let svc = SMAppService.agent(plistName: plistName)
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            svc.unregister { err in
+                if let err = err {
+                    continuation.resume(
+                        throwing: AgentServiceError.unregistrationFailed(
+                            String(describing: err)))
+                } else {
+                    continuation.resume(returning: ())
+                }
+            }
+        }
+    }
+
+    public func currentStatus() -> AgentServiceStatus {
+        let svc = SMAppService.agent(plistName: plistName)
+        switch svc.status {
+        case .enabled: return .enabled
+        case .requiresApproval: return .requiresApproval
+        case .notFound: return .notFound
+        case .notRegistered: return .notRegistered
+        @unknown default: return .notRegistered
+        }
+    }
+}

--- a/mac-daemon/Sources/CRMMacSystem/ProductionExecutableAdapter.swift
+++ b/mac-daemon/Sources/CRMMacSystem/ProductionExecutableAdapter.swift
@@ -18,25 +18,60 @@ public struct ProductionExecutableAdapter: ExecutableAdapter {
     }
 
     public func adhocCodesign(path: String) throws {
+        try runCodesign(
+            arguments: [
+                "-s", "-",
+                "--force",
+                "--preserve-metadata=identifier,entitlements,flags,runtime",
+                path,
+            ],
+            errorPrefix: "")
+    }
+
+    public func adhocCodesignBundle(bundlePath: String, identifier: String) throws {
+        // Pass 1: inner Mach-O with an explicit --identifier. This
+        // overrides whatever identifier Swift's build pipeline embedded
+        // (typically the executable name + a build-host-derived
+        // suffix) so the codesign-recorded identifier matches the
+        // bundle ID exactly. TCC for bundled apps keys on this value.
+        let innerMachoPath = "\(bundlePath)/\(BundleAssembler.machoRelativePath)"
+        try runCodesign(
+            arguments: [
+                "--force",
+                "--sign", "-",
+                "--identifier", identifier,
+                innerMachoPath,
+            ],
+            errorPrefix: "inner mach-o ")
+        // Pass 2: bundle seal (no --deep; the inner binary was signed
+        // in pass 1. --deep is officially discouraged by Apple for
+        // signing and reserved for VERIFY-only).
+        try runCodesign(
+            arguments: [
+                "--force",
+                "--sign", "-",
+                bundlePath,
+            ],
+            errorPrefix: "bundle seal ")
+    }
+
+    private func runCodesign(arguments: [String], errorPrefix: String) throws {
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: codesignPath)
-        proc.arguments = [
-            "-s", "-",
-            "--force",
-            "--preserve-metadata=identifier,entitlements,flags,runtime",
-            path,
-        ]
+        proc.arguments = arguments
         let errPipe = Pipe()
         proc.standardError = errPipe
         do {
             try proc.run()
         } catch {
-            throw ExecutableAdapterError.codesignFailed("spawn: \(error.localizedDescription)")
+            throw ExecutableAdapterError.codesignFailed(
+                "\(errorPrefix)spawn: \(error.localizedDescription)")
         }
         proc.waitUntilExit()
         if proc.terminationStatus != 0 {
             let stderr = String(data: errPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-            throw ExecutableAdapterError.codesignFailed("exit \(proc.terminationStatus): \(stderr)")
+            throw ExecutableAdapterError.codesignFailed(
+                "\(errorPrefix)exit \(proc.terminationStatus): \(stderr)")
         }
     }
 }

--- a/mac-daemon/Sources/CRMMacSystem/ProductionProcessSignaller.swift
+++ b/mac-daemon/Sources/CRMMacSystem/ProductionProcessSignaller.swift
@@ -1,6 +1,6 @@
-// ProductionProcessSignaller: POSIX kill + flock primitives (plan
-// D24). Lives in CRMMacSystem so the lifecycle target stays
-// Foundation-only (Darwin imports + raw fcntl/flock here).
+// ProductionProcessSignaller: POSIX kill + flock primitives. Lives
+// in CRMMacSystem so the lifecycle target stays Foundation-only
+// (Darwin imports + raw fcntl/flock here).
 //
 // `waitForPidfileRelease` matches the daemon's `PidfileLock.acquire()`
 // primitive (mac-daemon/Sources/CRMMacCore/PidfileLock.swift): open

--- a/mac-daemon/Sources/CRMMacSystem/ProductionProcessSignaller.swift
+++ b/mac-daemon/Sources/CRMMacSystem/ProductionProcessSignaller.swift
@@ -1,0 +1,72 @@
+// ProductionProcessSignaller: POSIX kill + flock primitives (plan
+// D24). Lives in CRMMacSystem so the lifecycle target stays
+// Foundation-only (Darwin imports + raw fcntl/flock here).
+//
+// `waitForPidfileRelease` matches the daemon's `PidfileLock.acquire()`
+// primitive (mac-daemon/Sources/CRMMacCore/PidfileLock.swift): open
+// the pidfile, attempt `flock(LOCK_EX | LOCK_NB)`, release
+// immediately on success. If the lock acquire succeeds the daemon
+// has exited; if it would block, the daemon is still holding it.
+//
+// Alternative considered: read pid from the file + kill(pid, 0) to
+// test process existence. Rejected because it races with rapid pid
+// reuse on long-running systems — the flock-acquire-and-release
+// primitive matches what the daemon itself uses to detect stale
+// pidfiles.
+import Foundation
+import Darwin
+import CRMMacLifecycle
+
+public struct ProductionProcessSignaller: ProcessSignaller {
+    /// Poll interval for `waitForPidfileRelease`. Exposed for tests
+    /// in CRMMacSystemTests that want a tighter loop than the
+    /// production 200ms cadence.
+    public let pollIntervalNs: UInt64
+
+    public init(pollIntervalNs: UInt64 = 200_000_000) {
+        self.pollIntervalNs = pollIntervalNs
+    }
+
+    public func sendSIGTERM(pid: pid_t) throws {
+        let result = kill(pid, SIGTERM)
+        if result != 0 {
+            let err = errno
+            if err == ESRCH {
+                // No such process — daemon already exited. Benign.
+                return
+            }
+            throw ProcessSignallerError.killFailed(errno: err)
+        }
+    }
+
+    public func waitForPidfileRelease(
+        path: String,
+        timeoutSeconds: TimeInterval
+    ) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeoutSeconds)
+        while Date() < deadline {
+            // Open pidfile readonly. If it's gone, the daemon
+            // already cleaned up; treat as released.
+            let fd = open(path, O_RDONLY)
+            if fd < 0 {
+                let err = errno
+                if err == ENOENT { return true }
+                // Other open errors: best-effort treat as still held,
+                // sleep + retry until the deadline.
+                try? await Task.sleep(nanoseconds: pollIntervalNs)
+                continue
+            }
+            let lockResult = flock(fd, LOCK_EX | LOCK_NB)
+            if lockResult == 0 {
+                _ = flock(fd, LOCK_UN)
+                close(fd)
+                return true
+            }
+            close(fd)
+            // EWOULDBLOCK (or any other lock failure) — daemon still
+            // holds it; sleep + retry.
+            try? await Task.sleep(nanoseconds: pollIntervalNs)
+        }
+        return false
+    }
+}

--- a/mac-daemon/Sources/crm-mac/App/ProductionContext.swift
+++ b/mac-daemon/Sources/crm-mac/App/ProductionContext.swift
@@ -23,14 +23,18 @@ struct ProductionContext {
         self.paths = LifecyclePaths(
             configDirPath: systemPaths.configDir.path,
             binDirPath: systemPaths.binDir.path,
-            binaryPath: systemPaths.binaryPath.path,
             configFilePath: systemPaths.configFile.path,
             stateFilePath: systemPaths.stateFile.path,
             launchAgentsDirPath: systemPaths.launchAgentsDir.path,
-            plistPath: systemPaths.plistPath.path,
             logsDirPath: systemPaths.logsDir.path,
             stdoutLogPath: systemPaths.stdoutLog.path,
-            stderrLogPath: systemPaths.stderrLog.path)
+            stderrLogPath: systemPaths.stderrLog.path,
+            bundleAppPath: systemPaths.bundleApp.path,
+            bundleBinaryPath: systemPaths.bundleBinary.path,
+            bundlePlistPath: systemPaths.bundlePlist.path,
+            bundleInfoPlistPath: systemPaths.bundleInfoPlist.path,
+            legacyBinaryPath: systemPaths.legacyBinary.path,
+            legacyPlistPath: systemPaths.legacyPlist.path)
         self.logger = OSLogLogger()
         self.filesystem = ProductionFilesystemAdapter()
         self.executable = ProductionExecutableAdapter()

--- a/mac-daemon/Sources/crm-mac/App/ProductionContext.swift
+++ b/mac-daemon/Sources/crm-mac/App/ProductionContext.swift
@@ -14,7 +14,13 @@ struct ProductionContext {
     let filesystem: FilesystemAdapter
     let executable: ExecutableAdapter
     let keychain: KeychainStore
-    let launchctl: LaunchctlRunner
+    let agentService: AgentService
+    let processSignaller: ProcessSignaller
+    let bundleAssembler: BundleAssembler
+    /// Legacy launchctl runner — only used by the one-shot migration
+    /// + uninstall's legacy-cleanup path. Stays wired even after the
+    /// migration runs because uninstall can run more than once.
+    let legacyLaunchctl: LaunchctlRunner
     let clock: ClockAdapter
     let exitHandler: ExitHandler
 
@@ -36,10 +42,21 @@ struct ProductionContext {
             legacyBinaryPath: systemPaths.legacyBinary.path,
             legacyPlistPath: systemPaths.legacyPlist.path)
         self.logger = OSLogLogger()
-        self.filesystem = ProductionFilesystemAdapter()
-        self.executable = ProductionExecutableAdapter()
+        let fs = ProductionFilesystemAdapter()
+        let exec = ProductionExecutableAdapter()
+        self.filesystem = fs
+        self.executable = exec
         self.keychain = FileAPIKeyStore(path: systemPaths.apiKeyFile.path)
-        self.launchctl = ProductionLaunchctlRunner()
+        if #available(macOS 13.0, *) {
+            self.agentService = ProductionAgentService(
+                plistName: "\(Daemon.label).plist")
+        } else {
+            fatalError("crm-mac requires macOS 13+ for SMAppService")
+        }
+        self.processSignaller = ProductionProcessSignaller()
+        self.bundleAssembler = BundleAssembler(
+            filesystem: fs, executable: exec)
+        self.legacyLaunchctl = ProductionLaunchctlRunner()
         self.clock = SystemClock()
         self.exitHandler = SystemExitHandler()
     }
@@ -54,11 +71,14 @@ struct ProductionContext {
             filesystem: filesystem,
             executable: executable,
             keychain: keychain,
-            launchctl: launchctl,
+            agentService: agentService,
+            processSignaller: processSignaller,
+            bundleAssembler: bundleAssembler,
             piClientFactory: { url in self.piClientFactory(url) },
             clock: clock,
             logger: logger,
-            legacyKeychain: ProductionKeychainStore()))
+            legacyKeychain: ProductionKeychainStore(),
+            legacyLaunchctl: legacyLaunchctl))
     }
 
     func uninstaller() -> Uninstaller {
@@ -66,8 +86,10 @@ struct ProductionContext {
             paths: paths,
             filesystem: filesystem,
             keychain: keychain,
-            launchctl: launchctl,
-            logger: logger))
+            agentService: agentService,
+            processSignaller: processSignaller,
+            logger: logger,
+            legacyLaunchctl: legacyLaunchctl))
     }
 
     func doctor() -> Doctor {
@@ -75,7 +97,7 @@ struct ProductionContext {
             paths: paths,
             filesystem: filesystem,
             keychain: keychain,
-            launchctl: launchctl,
+            agentService: agentService,
             piClientFactory: { url in self.piClientFactory(url) },
             contactsAuth: contactsAuthAdapter(),
             containerEnumerator: contactContainerEnumerator(),
@@ -88,7 +110,7 @@ struct ProductionContext {
         Status(StatusDependencies(
             paths: paths,
             filesystem: filesystem,
-            launchctl: launchctl))
+            agentService: agentService))
     }
 
     func contactsAuthAdapter() -> ContactsAuthorizationAdapter {

--- a/mac-daemon/Sources/crm-mac/CRMMacCommand.swift
+++ b/mac-daemon/Sources/crm-mac/CRMMacCommand.swift
@@ -18,5 +18,7 @@ struct CRMMacCommand: AsyncParsableCommand {
             StatusCommand.self,
             ConfigureCommand.self,
             MessagesCommand.self,
+            StopCommand.self,
+            StartCommand.self,
         ])
 }

--- a/mac-daemon/Sources/crm-mac/Commands/ConfigureCommand.swift
+++ b/mac-daemon/Sources/crm-mac/Commands/ConfigureCommand.swift
@@ -226,6 +226,6 @@ private func requireDaemonNotRunning(paths: LifecyclePaths) throws {
         .appendingPathComponent("daemon.pid").path
     guard FileManager.default.fileExists(atPath: pidPath) else { return }
     FileHandle.standardError.write(Data(
-        "crm-mac daemon appears to be running (pidfile at \(pidPath)). Stop it first: launchctl bootout gui/$(id -u) \(Daemon.label)\n".utf8))
+        "crm-mac daemon appears to be running (pidfile at \(pidPath)). Stop it first: `crm-mac stop`.\n".utf8))
     throw ExitCode(3)
 }

--- a/mac-daemon/Sources/crm-mac/Commands/DoctorCommand.swift
+++ b/mac-daemon/Sources/crm-mac/Commands/DoctorCommand.swift
@@ -7,7 +7,7 @@ import CRMMacLifecycle
 struct DoctorCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "doctor",
-        abstract: "Run health checks: api-key file, launchctl, Pi reachability, config + state files.")
+        abstract: "Run health checks: api-key file, agent registration, Pi reachability, config + state files.")
 
     mutating func run() async throws {
         let ctx = ProductionContext()

--- a/mac-daemon/Sources/crm-mac/Commands/InstallCommand.swift
+++ b/mac-daemon/Sources/crm-mac/Commands/InstallCommand.swift
@@ -75,8 +75,8 @@ struct InstallCommand: AsyncParsableCommand {
         let summary = try await installer.run(request)
         print("install complete")
         print("  host_id=\(summary.hostID.uuidString.lowercased())")
-        print("  binary=\(summary.binaryPath)")
-        print("  plist=\(summary.plistPath)")
+        print("  bundle=\(summary.bundleAppPath)")
+        print("  binary=\(summary.bundleBinaryPath)")
         print("")
 
         // Post-pair: request Contacts permission + run the container
@@ -94,8 +94,9 @@ struct InstallCommand: AsyncParsableCommand {
         }
 
         print("")
-        print("First launch on this Mac may be blocked by Gatekeeper. If so:")
-        print("  System Settings -> Privacy & Security -> scroll to \"crm-mac was blocked...\" -> Open Anyway")
+        print("If launchd reports the bundle requires approval, open:")
+        print("  System Settings -> General -> Login Items -> Allow in Background -> enable crm-mac")
+        print("Then re-run `crm-mac install --register-only`.")
     }
 
     /// Permission + picker flow. Called as part of fresh install AND

--- a/mac-daemon/Sources/crm-mac/Commands/StartCommand.swift
+++ b/mac-daemon/Sources/crm-mac/Commands/StartCommand.swift
@@ -1,0 +1,56 @@
+// `crm-mac start` re-registers the agent after `crm-mac stop` (plan
+// D26). Delegates to CRMMacLifecycle.StartOps so the logic is testable
+// against FakeAgentService.
+import ArgumentParser
+import Foundation
+import CRMMacLifecycle
+
+struct StartCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "start",
+        abstract: "Re-register the crm-mac agent after a maintenance stop.")
+
+    @Option(name: .long, help: "Status-poll timeout (seconds) waiting for .enabled. Default 5.")
+    var statusPollTimeout: Double = 5
+
+    mutating func run() async throws {
+        let ctx = ProductionContext()
+        let result: StartOpsResult
+        do {
+            result = try await StartOps.run(
+                StartOpsDependencies(
+                    agentService: ctx.agentService,
+                    logger: ctx.logger),
+                statusPollTimeoutSeconds: statusPollTimeout)
+        } catch let err as StartOpsError {
+            FileHandle.standardError.write(Data("\(err)\n".utf8))
+            throw ExitCode(1)
+        }
+
+        let outcomeStr: String
+        switch result.outcome {
+        case .registered:        outcomeStr = "registered"
+        case .alreadyRegistered: outcomeStr = "already_registered"
+        }
+        print("register_outcome=\(outcomeStr)")
+        print("status=\(result.finalStatus.rawValue)")
+        print("started=\(result.started)")
+        if result.started {
+            return
+        }
+        switch result.finalStatus {
+        case .requiresApproval:
+            FileHandle.standardError.write(Data(
+                "agent requires approval. Open System Settings → General → Login Items → Allow in Background → enable crm-mac, then re-run `crm-mac start`.\n".utf8))
+        case .notRegistered:
+            FileHandle.standardError.write(Data(
+                "register call returned no error but status is not_registered. Check `crm-mac doctor` and Console.app SMAppService logs.\n".utf8))
+        case .notFound:
+            FileHandle.standardError.write(Data(
+                "bundle missing at \(ctx.paths.bundleAppPath); run `crm-mac install --upgrade`.\n".utf8))
+        case .enabled:
+            break
+        }
+        throw ExitCode(1)
+    }
+}

--- a/mac-daemon/Sources/crm-mac/Commands/StartCommand.swift
+++ b/mac-daemon/Sources/crm-mac/Commands/StartCommand.swift
@@ -1,5 +1,5 @@
-// `crm-mac start` re-registers the agent after `crm-mac stop` (plan
-// D26). Delegates to CRMMacLifecycle.StartOps so the logic is testable
+// `crm-mac start` re-registers the agent after `crm-mac stop`.
+// Delegates to CRMMacLifecycle.StartOps so the logic is testable
 // against FakeAgentService.
 import ArgumentParser
 import Foundation

--- a/mac-daemon/Sources/crm-mac/Commands/StatusCommand.swift
+++ b/mac-daemon/Sources/crm-mac/Commands/StatusCommand.swift
@@ -15,6 +15,7 @@ struct StatusCommand: ParsableCommand {
         let report = ctx.status().run()
         print("installed=\(report.installed)")
         print("registered=\(report.registered)")
+        print("registration_status=\(report.registrationStatus.rawValue)")
         if let hostname = report.configHostname {
             print("hostname=\(hostname)")
         }

--- a/mac-daemon/Sources/crm-mac/Commands/StopCommand.swift
+++ b/mac-daemon/Sources/crm-mac/Commands/StopCommand.swift
@@ -1,0 +1,36 @@
+// `crm-mac stop` halts the running daemon for the duration of an
+// operator maintenance window (plan D26). Delegates to
+// CRMMacLifecycle.StopOps so the logic is testable against the
+// FakeAgentService + FakeProcessSignaller.
+import ArgumentParser
+import Foundation
+import CRMMacLifecycle
+
+struct StopCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "stop",
+        abstract: "Stop the running crm-mac daemon (for backfill/scan/maintenance ops).")
+
+    @Option(name: .long, help: "Stop-window timeout in seconds. Default 10.")
+    var timeout: Double = 10
+
+    mutating func run() async throws {
+        let ctx = ProductionContext()
+        let result = await StopOps.run(
+            StopOpsDependencies(
+                paths: ctx.paths,
+                filesystem: ctx.filesystem,
+                agentService: ctx.agentService,
+                processSignaller: ctx.processSignaller,
+                logger: ctx.logger),
+            timeoutSeconds: timeout)
+        print("stopped=\(result.stopped)")
+        print("pid=\(result.pid)")
+        print("unregister_invoked=\(result.unregisterInvoked)")
+        if !result.stopped {
+            FileHandle.standardError.write(Data(
+                "daemon did not exit within \(Int(timeout))s. Investigate: `ps -p \(result.pid)`. Manual recovery: `kill -9 \(result.pid)`.\n".utf8))
+            throw ExitCode(1)
+        }
+    }
+}

--- a/mac-daemon/Sources/crm-mac/Commands/StopCommand.swift
+++ b/mac-daemon/Sources/crm-mac/Commands/StopCommand.swift
@@ -1,5 +1,5 @@
 // `crm-mac stop` halts the running daemon for the duration of an
-// operator maintenance window (plan D26). Delegates to
+// operator maintenance window. Delegates to
 // CRMMacLifecycle.StopOps so the logic is testable against the
 // FakeAgentService + FakeProcessSignaller.
 import ArgumentParser

--- a/mac-daemon/Sources/crm-mac/Commands/UninstallCommand.swift
+++ b/mac-daemon/Sources/crm-mac/Commands/UninstallCommand.swift
@@ -1,28 +1,32 @@
 // `crm-mac uninstall` parses --purge and delegates to
-// CRMMacLifecycle.Uninstaller.
+// CRMMacLifecycle.Uninstaller. Async because Uninstaller.run() is
+// async — agentService.unregister + pidfile-poll wait both need to
+// await.
 import ArgumentParser
 import CRMMacLifecycle
 
-struct UninstallCommand: ParsableCommand {
+struct UninstallCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "uninstall",
-        abstract: "Remove the launchd agent, plist, and Keychain entry. --purge also removes config and state.")
+        abstract: "Unregister the agent, remove the bundle, and delete the api-key. --purge also removes config and state.")
 
-    @Flag(name: .long, help: "Also remove config.json, state.json, and the installed binary.")
+    @Flag(name: .long, help: "Also remove config.json, state.json, logs, and the icloud hash cache.")
     var purge: Bool = false
 
-    mutating func run() throws {
+    mutating func run() async throws {
         let ctx = ProductionContext()
-        let summary = try ctx.uninstaller().run(UninstallRequest(purge: purge))
+        let summary = try await ctx.uninstaller().run(UninstallRequest(purge: purge))
         print("uninstall complete")
-        print("  bootout_invoked=\(summary.bootoutInvoked)")
-        print("  bootout_exit_code=\(summary.bootoutExitCode)")
-        print("  plist_deleted=\(summary.plistDeleted)")
+        print("  daemon_stopped=\(summary.daemonStopped)")
+        print("  unregister_invoked=\(summary.unregisterInvoked)")
+        print("  bundle_deleted=\(summary.bundleDeleted)")
         print("  keychain_deleted=\(summary.keychainDeleted)")
+        print("  legacy_plist_deleted=\(summary.legacyPlistDeleted)")
+        print("  legacy_binary_deleted=\(summary.legacyBinaryDeleted)")
         print("  purged=\(summary.purged)")
         if !purge {
             print("")
-            print("Run `crm-mac uninstall --purge` to also delete config.json + state.json + binary.")
+            print("Run `crm-mac uninstall --purge` to also delete config.json + state.json + logs.")
         }
     }
 }

--- a/mac-daemon/Sources/crm-mac/Info.plist
+++ b/mac-daemon/Sources/crm-mac/Info.plist
@@ -6,6 +6,20 @@
 	<string>xyz.spengrah.crm-mac</string>
 	<key>CFBundleName</key>
 	<string>crm-mac</string>
+	<key>CFBundleExecutable</key>
+	<string>crm-mac</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.1.0</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>LSUIElement</key>
+	<true/>
+	<key>LSMinimumSystemVersion</key>
+	<string>14.0</string>
 	<key>NSContactsUsageDescription</key>
 	<string>Personal CRM uses your Contacts to sync your iCloud Contacts to your Pi-based CRM. Data stays between your Mac and your Pi.</string>
 </dict>

--- a/mac-daemon/Tests/CRMMacIcloudContactsSourceTests/ICloudContactsSourcePluginTests.swift
+++ b/mac-daemon/Tests/CRMMacIcloudContactsSourceTests/ICloudContactsSourcePluginTests.swift
@@ -79,14 +79,24 @@ final class ICloudContactsSourcePluginTests: XCTestCase {
 
     private final class StubAuthAdapter: ContactsAuthorizationAdapter, @unchecked Sendable {
         let status: ContactsAuthorizationStatus
-        init(_ status: ContactsAuthorizationStatus = .authorized) {
+        let requestAccessResult: Result<Bool, Error>
+        private let recordedRequestAccessCalls = NSCountedSet()
+        init(
+            _ status: ContactsAuthorizationStatus = .authorized,
+            requestAccess: Result<Bool, Error> = .success(true)
+        ) {
             self.status = status
+            self.requestAccessResult = requestAccess
         }
         func authorizationStatus() -> ContactsAuthorizationStatus { status }
         func requestAccess() async throws -> Bool {
-            XCTFail("daemon must NOT call requestAccess; install is the only caller")
-            return false
+            recordedRequestAccessCalls.add("call")
+            switch requestAccessResult {
+            case .success(let v): return v
+            case .failure(let e): throw e
+            }
         }
+        var requestAccessCallCount: Int { recordedRequestAccessCalls.count(for: "call") }
     }
 
     // MARK: - config stub
@@ -244,6 +254,7 @@ final class ICloudContactsSourcePluginTests: XCTestCase {
     private func makePlugin(
         reader: ContactStoreReader,
         authStatus: ContactsAuthorizationStatus = .authorized,
+        authAdapter: StubAuthAdapter? = nil,
         config: ICloudContactsConfigSource? = nil,
         pi: ScriptedPi,
         cacheURL: URL,
@@ -281,7 +292,7 @@ final class ICloudContactsSourcePluginTests: XCTestCase {
             publisher: pub,
             cache: cache,
             reader: reader,
-            authAdapter: StubAuthAdapter(authStatus),
+            authAdapter: authAdapter ?? StubAuthAdapter(authStatus),
             configSource: cfg,
             healthRegistry: registry,
             logger: NoopLogger(),
@@ -312,7 +323,7 @@ final class ICloudContactsSourcePluginTests: XCTestCase {
         XCTAssertFalse(transport.commitWasAttempted)
     }
 
-    func testNotDeterminedMarksUnhealthy() async throws {
+    func testNotDeterminedRequestsAccessAndMarksDeniedWhenUserDeclines() async throws {
         let dir = tempDir()
         defer { try? FileManager.default.removeItem(at: dir) }
         let pi = ScriptedPi(
@@ -320,13 +331,41 @@ final class ICloudContactsSourcePluginTests: XCTestCase {
             knownIDs: KnownIDsData(ids: []),
             ingestResult: IngestEventsData(accepted: 0, duplicate: 0, rejected: 0, errors: []),
             cursorCommitThrows: nil, ingestThrows: nil)
+        let auth = StubAuthAdapter(.notDetermined, requestAccess: .success(false))
         let (plugin, _, _, registry, _) = makePlugin(
-            reader: StubReader(), authStatus: .notDetermined, pi: pi,
+            reader: StubReader(), authAdapter: auth, pi: pi,
             cacheURL: dir.appendingPathComponent("cache.json"),
             stateURL: dir.appendingPathComponent("state.json"))
         try await plugin.tick()
+        XCTAssertEqual(auth.requestAccessCallCount, 1,
+                       "daemon must prompt under launchd attribution on .notDetermined")
         let snap = await registry.read(.icloudContacts)
-        XCTAssertEqual(snap?.lastError, "contacts_permission:notDetermined")
+        XCTAssertEqual(snap?.lastError, "contacts_permission:denied",
+                       "post-decline state must be the .denied reason, not .notDetermined")
+    }
+
+    func testNotDeterminedProceedsPastAuthOnGrant() async throws {
+        let dir = tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let pi = ScriptedPi(
+            cursorGet: SourceCursorState(cursor: "", cursorEpoch: 0, backfillComplete: false),
+            knownIDs: KnownIDsData(ids: []),
+            ingestResult: IngestEventsData(accepted: 0, duplicate: 0, rejected: 0, errors: []),
+            cursorCommitThrows: nil, ingestThrows: nil)
+        let auth = StubAuthAdapter(.notDetermined, requestAccess: .success(true))
+        let (plugin, _, _, registry, _) = makePlugin(
+            reader: StubReader(), authAdapter: auth, pi: pi,
+            cacheURL: dir.appendingPathComponent("cache.json"),
+            stateURL: dir.appendingPathComponent("state.json"))
+        try await plugin.tick()
+        XCTAssertEqual(auth.requestAccessCallCount, 1)
+        let snap = await registry.read(.icloudContacts)
+        // Tick proceeded past the auth probe. The default StubReader
+        // returns no contacts so the tick succeeds without ingesting;
+        // either way, lastError must NOT be a contacts_permission*
+        // marker.
+        XCTAssertFalse(snap?.lastError?.hasPrefix("contacts_permission") ?? false,
+                       "tick must clear the auth probe and proceed; got lastError=\(snap?.lastError ?? "nil")")
     }
 
     func testNoContainersMarksUnhealthy() async throws {

--- a/mac-daemon/Tests/CRMMacLifecycleTests/BundleAssemblerTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/BundleAssemblerTests.swift
@@ -1,0 +1,134 @@
+// BundleAssemblerTests exercise the Swift install-time bundle
+// assembly logic (per plan D14). The shell-script equivalent
+// (`Scripts/assemble_bundle.sh`) is exercised by
+// `BundleAssemblyParityTests` in CRMMacSystemTests (real Foundation
+// adapter, env-gated). These tests use the InMemoryFilesystem fake
+// + FakeExecutableAdapter so they run in any CI environment.
+import XCTest
+@testable import CRMMacLifecycle
+
+final class BundleAssemblerTests: XCTestCase {
+
+    private static let fixtureInfoPlistBytes: Data = {
+        let xml = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>CFBundleIdentifier</key>
+            <string>xyz.spengrah.crm-mac</string>
+        </dict>
+        </plist>
+        """
+        return Data(xml.utf8)
+    }()
+
+    private static let fixtureLaunchAgentContent: String = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <plist version="1.0">
+        <dict>
+            <key>Label</key>
+            <string>xyz.spengrah.crm-mac</string>
+            <key>ProgramArguments</key>
+            <array>
+                <string>__INSTALL_PREFIX__/Contents/MacOS/crm-mac</string>
+                <string>daemon</string>
+            </array>
+        </dict>
+        </plist>
+        """
+
+    private func makeInput(bundlePath: String) -> BundleAssemblerInput {
+        BundleAssemblerInput(
+            machoSourcePath: "/tmp/source/crm-mac",
+            bundlePath: bundlePath,
+            launchAgentPlistContent: Self.fixtureLaunchAgentContent,
+            infoPlistContent: Self.fixtureInfoPlistBytes,
+            codesignIdentifier: Daemon.label)
+    }
+
+    func testAssembleProducesCompleteBundleStructure() throws {
+        let fs = InMemoryFilesystem()
+        fs.seedFile(at: "/tmp/source/crm-mac")
+        let exec = FakeExecutableAdapter()
+        let assembler = BundleAssembler(filesystem: fs, executable: exec)
+        let bundlePath = "/tmp/install/crm-mac.app"
+        try assembler.assemble(makeInput(bundlePath: bundlePath))
+
+        XCTAssertTrue(fs.fileExists(at: bundlePath))
+        XCTAssertTrue(fs.fileExists(at: "\(bundlePath)/Contents"))
+        XCTAssertTrue(fs.fileExists(at: "\(bundlePath)/Contents/MacOS"))
+        XCTAssertTrue(fs.fileExists(at: "\(bundlePath)/Contents/Library/LaunchAgents"))
+        XCTAssertTrue(fs.fileExists(at: "\(bundlePath)/Contents/MacOS/crm-mac"))
+        XCTAssertTrue(fs.fileExists(at: "\(bundlePath)/Contents/Info.plist"))
+        XCTAssertTrue(fs.fileExists(at: "\(bundlePath)/Contents/Library/LaunchAgents/\(Daemon.label).plist"))
+    }
+
+    func testMachoIsExecutableAfterAssemble() throws {
+        let fs = InMemoryFilesystem()
+        fs.seedFile(at: "/tmp/source/crm-mac")
+        let exec = FakeExecutableAdapter()
+        let assembler = BundleAssembler(filesystem: fs, executable: exec)
+        let bundlePath = "/tmp/install/crm-mac.app"
+        try assembler.assemble(makeInput(bundlePath: bundlePath))
+        let machoDest = "\(bundlePath)/Contents/MacOS/crm-mac"
+        XCTAssertTrue(fs.madeExecutable.contains(machoDest))
+    }
+
+    func testCodesignInvokedOnceWithBundleAndIdentifier() throws {
+        let fs = InMemoryFilesystem()
+        fs.seedFile(at: "/tmp/source/crm-mac")
+        let exec = FakeExecutableAdapter()
+        let assembler = BundleAssembler(filesystem: fs, executable: exec)
+        let bundlePath = "/tmp/install/crm-mac.app"
+        try assembler.assemble(makeInput(bundlePath: bundlePath))
+        XCTAssertEqual(exec.bundleCodesignCalls.count, 1)
+        XCTAssertEqual(exec.bundleCodesignCalls.first?.bundlePath, bundlePath)
+        XCTAssertEqual(exec.bundleCodesignCalls.first?.identifier, Daemon.label)
+        // The single-Mach-O path is NOT used by BundleAssembler.
+        XCTAssertEqual(exec.codesignCalls.count, 0)
+    }
+
+    func testInfoPlistContentMatchesInput() throws {
+        let fs = InMemoryFilesystem()
+        fs.seedFile(at: "/tmp/source/crm-mac")
+        let exec = FakeExecutableAdapter()
+        let assembler = BundleAssembler(filesystem: fs, executable: exec)
+        let bundlePath = "/tmp/install/crm-mac.app"
+        try assembler.assemble(makeInput(bundlePath: bundlePath))
+        let written = try fs.read(from: "\(bundlePath)/Contents/Info.plist")
+        XCTAssertEqual(written, Self.fixtureInfoPlistBytes)
+    }
+
+    func testLaunchAgentPlistContentMatchesInput() throws {
+        let fs = InMemoryFilesystem()
+        fs.seedFile(at: "/tmp/source/crm-mac")
+        let exec = FakeExecutableAdapter()
+        let assembler = BundleAssembler(filesystem: fs, executable: exec)
+        let bundlePath = "/tmp/install/crm-mac.app"
+        try assembler.assemble(makeInput(bundlePath: bundlePath))
+        let written = try fs.read(
+            from: "\(bundlePath)/Contents/Library/LaunchAgents/\(Daemon.label).plist")
+        XCTAssertEqual(written, Data(Self.fixtureLaunchAgentContent.utf8))
+    }
+
+    func testCodesignFailurePropagates() throws {
+        let fs = InMemoryFilesystem()
+        fs.seedFile(at: "/tmp/source/crm-mac")
+        let exec = FakeExecutableAdapter()
+        exec.failBundleCodesignWith = "injected codesign failure"
+        let assembler = BundleAssembler(filesystem: fs, executable: exec)
+        let bundlePath = "/tmp/install/crm-mac.app"
+        XCTAssertThrowsError(try assembler.assemble(makeInput(bundlePath: bundlePath))) { error in
+            guard let e = error as? ExecutableAdapterError else {
+                XCTFail("expected ExecutableAdapterError, got \(error)")
+                return
+            }
+            if case .codesignFailed(let m) = e {
+                XCTAssertTrue(m.contains("injected codesign failure"))
+            } else {
+                XCTFail("expected codesignFailed, got \(e)")
+            }
+        }
+    }
+}

--- a/mac-daemon/Tests/CRMMacLifecycleTests/BundleAssemblerTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/BundleAssemblerTests.swift
@@ -1,5 +1,5 @@
 // BundleAssemblerTests exercise the Swift install-time bundle
-// assembly logic (per plan D14). The shell-script equivalent
+// assembly logic. The shell-script equivalent
 // (`Scripts/assemble_bundle.sh`) is exercised by
 // `BundleAssemblyParityTests` in CRMMacSystemTests (real Foundation
 // adapter, env-gated). These tests use the InMemoryFilesystem fake

--- a/mac-daemon/Tests/CRMMacLifecycleTests/BundleAssemblerTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/BundleAssemblerTests.swift
@@ -31,7 +31,7 @@ final class BundleAssemblerTests: XCTestCase {
             <string>xyz.spengrah.crm-mac</string>
             <key>ProgramArguments</key>
             <array>
-                <string>__INSTALL_PREFIX__/Contents/MacOS/crm-mac</string>
+                <string>/tmp/install/crm-mac.app/Contents/MacOS/crm-mac</string>
                 <string>daemon</string>
             </array>
         </dict>

--- a/mac-daemon/Tests/CRMMacLifecycleTests/DaemonStartupTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/DaemonStartupTests.swift
@@ -63,14 +63,18 @@ final class DaemonStartupTests: XCTestCase {
         let paths = LifecyclePaths(
             configDirPath: tempDir.path,
             binDirPath: "/dev/null",
-            binaryPath: "/dev/null",
             configFilePath: configURL.path,
             stateFilePath: stateURL.path,
             launchAgentsDirPath: "/dev/null",
-            plistPath: "/dev/null",
             logsDirPath: "/dev/null",
             stdoutLogPath: "/dev/null",
-            stderrLogPath: "/dev/null")
+            stderrLogPath: "/dev/null",
+            bundleAppPath: "/dev/null",
+            bundleBinaryPath: "/dev/null",
+            bundlePlistPath: "/dev/null",
+            bundleInfoPlistPath: "/dev/null",
+            legacyBinaryPath: "/dev/null",
+            legacyPlistPath: "/dev/null")
         let startup = DaemonStartup(paths: paths, keychain: keychain, logger: NoopLogger())
         let artifacts = try startup.run()
         XCTAssertEqual(artifacts.config.hostname, "mac-1")
@@ -84,14 +88,18 @@ final class DaemonStartupTests: XCTestCase {
         let paths = LifecyclePaths(
             configDirPath: tempDir.path,
             binDirPath: "/dev/null",
-            binaryPath: "/dev/null",
             configFilePath: tempDir.appendingPathComponent("config.json").path,
             stateFilePath: tempDir.appendingPathComponent("state.json").path,
             launchAgentsDirPath: "/dev/null",
-            plistPath: "/dev/null",
             logsDirPath: "/dev/null",
             stdoutLogPath: "/dev/null",
-            stderrLogPath: "/dev/null")
+            stderrLogPath: "/dev/null",
+            bundleAppPath: "/dev/null",
+            bundleBinaryPath: "/dev/null",
+            bundlePlistPath: "/dev/null",
+            bundleInfoPlistPath: "/dev/null",
+            legacyBinaryPath: "/dev/null",
+            legacyPlistPath: "/dev/null")
         let startup = DaemonStartup(
             paths: paths,
             keychain: InMemoryKeychainStore(initial: "k"),
@@ -119,14 +127,18 @@ final class DaemonStartupTests: XCTestCase {
         let paths = LifecyclePaths(
             configDirPath: tempDir.path,
             binDirPath: "/dev/null",
-            binaryPath: "/dev/null",
             configFilePath: configURL.path,
             stateFilePath: tempDir.appendingPathComponent("state.json").path,
             launchAgentsDirPath: "/dev/null",
-            plistPath: "/dev/null",
             logsDirPath: "/dev/null",
             stdoutLogPath: "/dev/null",
-            stderrLogPath: "/dev/null")
+            stderrLogPath: "/dev/null",
+            bundleAppPath: "/dev/null",
+            bundleBinaryPath: "/dev/null",
+            bundlePlistPath: "/dev/null",
+            bundleInfoPlistPath: "/dev/null",
+            legacyBinaryPath: "/dev/null",
+            legacyPlistPath: "/dev/null")
         // Empty keychain — no api-key.
         let startup = DaemonStartup(
             paths: paths,
@@ -155,14 +167,18 @@ final class DaemonStartupTests: XCTestCase {
         let paths = LifecyclePaths(
             configDirPath: tempDir.path,
             binDirPath: "/dev/null",
-            binaryPath: "/dev/null",
             configFilePath: configURL.path,
             stateFilePath: tempDir.appendingPathComponent("state.json").path,
             launchAgentsDirPath: "/dev/null",
-            plistPath: "/dev/null",
             logsDirPath: "/dev/null",
             stdoutLogPath: "/dev/null",
-            stderrLogPath: "/dev/null")
+            stderrLogPath: "/dev/null",
+            bundleAppPath: "/dev/null",
+            bundleBinaryPath: "/dev/null",
+            bundlePlistPath: "/dev/null",
+            bundleInfoPlistPath: "/dev/null",
+            legacyBinaryPath: "/dev/null",
+            legacyPlistPath: "/dev/null")
         let startup = DaemonStartup(
             paths: paths,
             keychain: InMemoryKeychainStore(initial: "k"),

--- a/mac-daemon/Tests/CRMMacLifecycleTests/DaemonVersionInSyncTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/DaemonVersionInSyncTests.swift
@@ -1,0 +1,28 @@
+// DaemonVersionInSyncTests guards against drift between
+// `Daemon.version` (Swift constant in CRMMacLifecycle/Daemon.swift) and
+// `CFBundleShortVersionString` in Sources/crm-mac/Info.plist. The two
+// must match because the daemon emits Daemon.version in pair/heartbeat
+// payloads, while macOS reads CFBundleShortVersionString from the
+// bundled Info.plist for system-level reporting. A future bump that
+// updates one but not the other surfaces here as a test failure.
+import XCTest
+@testable import CRMMacLifecycle
+
+final class DaemonVersionInSyncTests: XCTestCase {
+    func testDaemonVersionMatchesCFBundleShortVersionString() throws {
+        let url = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // CRMMacLifecycleTests/
+            .deletingLastPathComponent()  // Tests/
+            .deletingLastPathComponent()  // mac-daemon/
+            .appendingPathComponent("Sources/crm-mac/Info.plist")
+        let data = try Data(contentsOf: url)
+        let any = try PropertyListSerialization.propertyList(
+            from: data, options: [], format: nil)
+        let dict = any as! [String: Any]
+        let plistVersion = dict["CFBundleShortVersionString"] as? String ?? ""
+        XCTAssertEqual(
+            plistVersion,
+            Daemon.version,
+            "Info.plist CFBundleShortVersionString (\(plistVersion)) must match Daemon.version (\(Daemon.version))")
+    }
+}

--- a/mac-daemon/Tests/CRMMacLifecycleTests/DoctorIcloudContactsTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/DoctorIcloudContactsTests.swift
@@ -148,13 +148,13 @@ final class DoctorIcloudContactsTests: XCTestCase {
         encoder.dateEncodingStrategy = .iso8601
         try! fs.write(try! encoder.encode(config), to: paths.configFilePath)
         try! fs.write(try! encoder.encode(state), to: paths.stateFilePath)
-        var script = FakeLaunchctlRunner.Script()
-        script.printService = [0]
+        var script = FakeAgentService.Script()
+        script.statusSequence = [.enabled]
         let deps = DoctorDependencies(
             paths: paths,
             filesystem: fs,
             keychain: InMemoryKeychainStore(initial: "key"),
-            launchctl: FakeLaunchctlRunner(script: script),
+            agentService: FakeAgentService(script: script),
             piClientFactory: { url in
                 PiClient(
                     baseURL: url,

--- a/mac-daemon/Tests/CRMMacLifecycleTests/DoctorTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/DoctorTests.swift
@@ -12,7 +12,7 @@ final class DoctorTests: XCTestCase {
         paths: LifecyclePaths,
         fs: FilesystemAdapter,
         keychain: KeychainStore,
-        launchctl: LaunchctlRunner,
+        agentService: AgentService,
         piClient: @escaping (URL) -> PiClient,
         contactsAuth: ContactsAuthorizationAdapter? = nil,
         containerEnumerator: ContactContainerEnumerator? = nil,
@@ -22,7 +22,7 @@ final class DoctorTests: XCTestCase {
             paths: paths,
             filesystem: fs,
             keychain: keychain,
-            launchctl: launchctl,
+            agentService: agentService,
             piClientFactory: piClient,
             contactsAuth: contactsAuth ?? StubContactsAuthorizationAdapter(),
             containerEnumerator: containerEnumerator ?? StubContactContainerEnumerator(),
@@ -45,16 +45,13 @@ final class DoctorTests: XCTestCase {
         try fs.write(try encoder.encode(config), to: paths.configFilePath)
         try fs.write(try encoder.encode(state), to: paths.stateFilePath)
         let keychain = InMemoryKeychainStore(initial: "key")
-        // The fake's default printService is exit 1 (unregistered);
-        // this test wants the four core checks to PASS, so override
-        // the launchctl probe to "registered".
-        var script = FakeLaunchctlRunner.Script()
-        script.printService = [0]
+        var script = FakeAgentService.Script()
+        script.statusSequence = [.enabled]
         let doctor = Doctor(makeDeps(
             paths: paths,
             fs: fs,
             keychain: keychain,
-            launchctl: FakeLaunchctlRunner(script: script),
+            agentService: FakeAgentService(script: script),
             piClient: { url in
                 PiClient(
                     baseURL: url,
@@ -62,12 +59,6 @@ final class DoctorTests: XCTestCase {
                     sleep: noopSleep)
             }))
         let report = await doctor.run()
-        // 4 core checks (keychain, launchctl, config_state, pi_reachability)
-        // + 3 icloud_contacts checks (permission, allowlist, last_tick).
-        // All four core pass; icloud permission passes (default
-        // .authorized stub) but allowlist + last_tick are non-PASS
-        // because the test config has no icloud allowlist + no
-        // SourceState for icloud_contacts.
         XCTAssertEqual(report.failCount, 0,
                        "no FAILs expected (icloud checks are WARN at worst)")
         let names = report.results.map(\.name)
@@ -83,7 +74,7 @@ final class DoctorTests: XCTestCase {
             paths: paths,
             fs: fs,
             keychain: InMemoryKeychainStore(),
-            launchctl: FakeLaunchctlRunner(),
+            agentService: FakeAgentService(),
             piClient: { _ in PiClient(baseURL: URL(string: "https://x")!, transport: LifecycleMockTransport([]).asTransport(), sleep: noopSleep) }))
         let report = await doctor.run()
         let keychain = report.results.first(where: { $0.name == "api-key" })!
@@ -107,7 +98,7 @@ final class DoctorTests: XCTestCase {
             paths: paths,
             fs: fs,
             keychain: InMemoryKeychainStore(initial: "key"),
-            launchctl: FakeLaunchctlRunner(),
+            agentService: FakeAgentService(),
             piClient: { _ in
                 PiClient(
                     baseURL: URL(string: "https://pi.example.test")!,
@@ -130,7 +121,6 @@ final class DoctorTests: XCTestCase {
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         try fs.write(try encoder.encode(config), to: paths.configFilePath)
-        // Schema version 99
         let stateJSON = Data("""
         {"schemaVersion": 99, "sources": {}}
         """.utf8)
@@ -139,26 +129,61 @@ final class DoctorTests: XCTestCase {
             paths: paths,
             fs: fs,
             keychain: InMemoryKeychainStore(initial: "key"),
-            launchctl: FakeLaunchctlRunner(),
+            agentService: FakeAgentService(),
             piClient: { _ in PiClient(baseURL: URL(string: "https://x")!, transport: LifecycleMockTransport([]).asTransport(), sleep: noopSleep) }))
         let report = await doctor.run()
         let configCheck = report.results.first(where: { $0.name == "config_state" })!
         XCTAssertEqual(configCheck.status, .fail)
     }
 
-    func testLaunchctlNotRegisteredWarns() async {
+    func testAgentServiceNotRegisteredWarns() async {
         let paths = TestPaths.make()
         let fs = InMemoryFilesystem()
-        var script = FakeLaunchctlRunner.Script()
-        script.printService = [1]
+        var script = FakeAgentService.Script()
+        script.statusSequence = [.notRegistered]
         let doctor = Doctor(makeDeps(
             paths: paths,
             fs: fs,
             keychain: InMemoryKeychainStore(),
-            launchctl: FakeLaunchctlRunner(script: script),
+            agentService: FakeAgentService(script: script),
             piClient: { _ in PiClient(baseURL: URL(string: "https://x")!, transport: LifecycleMockTransport([]).asTransport(), sleep: noopSleep) }))
         let report = await doctor.run()
-        let lc = report.results.first(where: { $0.name == "launchctl" })!
-        XCTAssertEqual(lc.status, .warn)
+        let check = report.results.first(where: { $0.name == "agent_service" })!
+        XCTAssertEqual(check.status, .warn)
+    }
+
+    func testAgentServiceRequiresApprovalWarns() async {
+        let paths = TestPaths.make()
+        let fs = InMemoryFilesystem()
+        var script = FakeAgentService.Script()
+        script.statusSequence = [.requiresApproval]
+        let doctor = Doctor(makeDeps(
+            paths: paths,
+            fs: fs,
+            keychain: InMemoryKeychainStore(),
+            agentService: FakeAgentService(script: script),
+            piClient: { _ in PiClient(baseURL: URL(string: "https://x")!, transport: LifecycleMockTransport([]).asTransport(), sleep: noopSleep) }))
+        let report = await doctor.run()
+        let check = report.results.first(where: { $0.name == "agent_service" })!
+        XCTAssertEqual(check.status, .warn)
+        XCTAssertTrue(check.details.lowercased().contains("approve"),
+            "requires-approval WARN must mention 'approve' for operator guidance")
+    }
+
+    func testAgentServiceNotFoundFails() async {
+        let paths = TestPaths.make()
+        let fs = InMemoryFilesystem()
+        var script = FakeAgentService.Script()
+        script.statusSequence = [.notFound]
+        let doctor = Doctor(makeDeps(
+            paths: paths,
+            fs: fs,
+            keychain: InMemoryKeychainStore(),
+            agentService: FakeAgentService(script: script),
+            piClient: { _ in PiClient(baseURL: URL(string: "https://x")!, transport: LifecycleMockTransport([]).asTransport(), sleep: noopSleep) }))
+        let report = await doctor.run()
+        let check = report.results.first(where: { $0.name == "agent_service" })!
+        XCTAssertEqual(check.status, .fail)
+        XCTAssertTrue(check.details.contains(paths.bundleAppPath))
     }
 }

--- a/mac-daemon/Tests/CRMMacLifecycleTests/DoctorTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/DoctorTests.swift
@@ -166,8 +166,8 @@ final class DoctorTests: XCTestCase {
         let report = await doctor.run()
         let check = report.results.first(where: { $0.name == "agent_service" })!
         XCTAssertEqual(check.status, .warn)
-        XCTAssertTrue(check.details.lowercased().contains("approve"),
-            "requires-approval WARN must mention 'approve' for operator guidance")
+        XCTAssertTrue(check.details.lowercased().contains("approv"),
+            "requires-approval WARN must mention 'approv*' for operator guidance")
     }
 
     func testAgentServiceNotFoundFails() async {

--- a/mac-daemon/Tests/CRMMacLifecycleTests/Fakes/FakeAgentService.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/Fakes/FakeAgentService.swift
@@ -1,0 +1,66 @@
+import Foundation
+@testable import CRMMacLifecycle
+
+/// FakeAgentService records calls + returns scripted outcomes/errors.
+/// Default behavior models a clean system: not registered; register()
+/// succeeds and returns `.registered`; currentStatus() returns
+/// `.notRegistered`. Tests override fields on `script` to model
+/// already-registered, requires-approval, etc.
+public final class FakeAgentService: AgentService, @unchecked Sendable {
+    public struct Script {
+        /// Sequence of statuses returned by `currentStatus()`. The
+        /// fake pops the head; if the array empties, the last value
+        /// repeats. Default: `[.notRegistered]`.
+        public var statusSequence: [AgentServiceStatus] = [.notRegistered]
+        /// Outcome value returned from `register()` on success.
+        /// Default `.registered`; tests set `.alreadyRegistered` to
+        /// model re-register or `--register-only` on an already-good
+        /// install.
+        public var nextRegisterOutcome: AgentRegisterOutcome = .registered
+        /// If non-nil, `register()` throws this error instead of
+        /// returning the outcome.
+        public var registerThrows: AgentServiceError?
+        /// If non-nil, `unregister()` throws this error.
+        public var unregisterThrows: AgentServiceError?
+        public init() {}
+    }
+
+    public var script: Script
+    public private(set) var registerCalls: Int = 0
+    /// Of the register calls, how many returned `.alreadyRegistered`.
+    /// Drives StartCommand's "already registered" message tests.
+    public private(set) var registerAlreadyRegisteredCount: Int = 0
+    public private(set) var unregisterCalls: Int = 0
+    public private(set) var statusCalls: Int = 0
+
+    public init(script: Script = Script()) {
+        self.script = script
+    }
+
+    public func register() throws -> AgentRegisterOutcome {
+        registerCalls += 1
+        if let err = script.registerThrows {
+            throw err
+        }
+        let outcome = script.nextRegisterOutcome
+        if outcome == .alreadyRegistered {
+            registerAlreadyRegisteredCount += 1
+        }
+        return outcome
+    }
+
+    public func unregister() async throws {
+        unregisterCalls += 1
+        if let err = script.unregisterThrows {
+            throw err
+        }
+    }
+
+    public func currentStatus() -> AgentServiceStatus {
+        statusCalls += 1
+        if script.statusSequence.count > 1 {
+            return script.statusSequence.removeFirst()
+        }
+        return script.statusSequence.first ?? .notRegistered
+    }
+}

--- a/mac-daemon/Tests/CRMMacLifecycleTests/Fakes/FakeExecutableAdapter.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/Fakes/FakeExecutableAdapter.swift
@@ -2,9 +2,24 @@ import Foundation
 @testable import CRMMacLifecycle
 
 public final class FakeExecutableAdapter: ExecutableAdapter, @unchecked Sendable {
+    public struct BundleCodesignCall: Equatable {
+        public let bundlePath: String
+        public let identifier: String
+    }
+
+    /// Records calls to the legacy single-Mach-O `adhocCodesign(path:)`.
     public private(set) var codesignCalls: [String] = []
+    /// Records calls to the two-pass `adhocCodesignBundle(...)` per
+    /// plan D5. Tests assert on these separately from the single-Mach-O
+    /// calls — the bundle path means the fresh-install / upgrade
+    /// flow is in use, while the single-Mach-O path is migration-only.
+    public private(set) var bundleCodesignCalls: [BundleCodesignCall] = []
     public var pathToReport: String?
     public var failCodesignWith: String?
+    /// If non-nil, `adhocCodesignBundle` throws with this reason. Lets
+    /// tests exercise the bundle-assembly failure path independently
+    /// of the single-Mach-O legacy path.
+    public var failBundleCodesignWith: String?
 
     public init(currentExecutablePath: String = "/tmp/source/crm-mac") {
         self.pathToReport = currentExecutablePath
@@ -20,6 +35,14 @@ public final class FakeExecutableAdapter: ExecutableAdapter, @unchecked Sendable
     public func adhocCodesign(path: String) throws {
         codesignCalls.append(path)
         if let reason = failCodesignWith {
+            throw ExecutableAdapterError.codesignFailed(reason)
+        }
+    }
+
+    public func adhocCodesignBundle(bundlePath: String, identifier: String) throws {
+        bundleCodesignCalls.append(BundleCodesignCall(
+            bundlePath: bundlePath, identifier: identifier))
+        if let reason = failBundleCodesignWith {
             throw ExecutableAdapterError.codesignFailed(reason)
         }
     }

--- a/mac-daemon/Tests/CRMMacLifecycleTests/Fakes/FakeExecutableAdapter.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/Fakes/FakeExecutableAdapter.swift
@@ -9,8 +9,8 @@ public final class FakeExecutableAdapter: ExecutableAdapter, @unchecked Sendable
 
     /// Records calls to the legacy single-Mach-O `adhocCodesign(path:)`.
     public private(set) var codesignCalls: [String] = []
-    /// Records calls to the two-pass `adhocCodesignBundle(...)` per
-    /// plan D5. Tests assert on these separately from the single-Mach-O
+    /// Records calls to the two-pass `adhocCodesignBundle(...)`.
+    /// Tests assert on these separately from the single-Mach-O
     /// calls — the bundle path means the fresh-install / upgrade
     /// flow is in use, while the single-Mach-O path is migration-only.
     public private(set) var bundleCodesignCalls: [BundleCodesignCall] = []

--- a/mac-daemon/Tests/CRMMacLifecycleTests/Fakes/FakeProcessSignaller.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/Fakes/FakeProcessSignaller.swift
@@ -1,0 +1,33 @@
+import Foundation
+@testable import CRMMacLifecycle
+
+/// FakeProcessSignaller records sigterm + wait calls and returns a
+/// scripted "released" result. Default: every wait returns true
+/// (daemon stopped cleanly). Tests set `nextPidfileReleaseResult =
+/// false` to model the daemon-refuses-to-stop branch.
+public final class FakeProcessSignaller: ProcessSignaller, @unchecked Sendable {
+    public var nextPidfileReleaseResult: Bool = true
+    /// If non-nil, `sendSIGTERM` throws this on the next invocation.
+    public var sendSIGTERMThrowsOnce: ProcessSignallerError?
+
+    public private(set) var sigtermCalls: [pid_t] = []
+    public private(set) var waitForPidfileReleaseCalls: [String] = []
+
+    public init() {}
+
+    public func sendSIGTERM(pid: pid_t) throws {
+        sigtermCalls.append(pid)
+        if let err = sendSIGTERMThrowsOnce {
+            sendSIGTERMThrowsOnce = nil
+            throw err
+        }
+    }
+
+    public func waitForPidfileRelease(
+        path: String,
+        timeoutSeconds: TimeInterval
+    ) async -> Bool {
+        waitForPidfileReleaseCalls.append(path)
+        return nextPidfileReleaseResult
+    }
+}

--- a/mac-daemon/Tests/CRMMacLifecycleTests/Fakes/InMemoryFilesystem.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/Fakes/InMemoryFilesystem.swift
@@ -34,17 +34,74 @@ public final class InMemoryFilesystem: FilesystemAdapter, @unchecked Sendable {
         entries[to] = data
     }
 
+    /// Atomic rename. Supports both file paths and directory paths.
+    /// A directory rename moves the directory entry AND every entry
+    /// (file or sub-directory) whose path begins with the source path
+    /// followed by `/`.
+    ///
+    /// Mimics POSIX `rename(2)` semantics on a NON-EMPTY destination
+    /// directory by throwing `FilesystemError.ioError("destination
+    /// not empty")` — this catches a class of production mistakes
+    /// where the installer accidentally calls rename with a non-empty
+    /// destination instead of using the backup-rename-then-swap
+    /// pattern (plan D8). For files, an existing destination is
+    /// overwritten (the production adapter uses replaceItemAt for
+    /// files, which IS atomic-replace).
     public func rename(from: String, to: String) throws {
-        guard let data = entries[from] else {
+        // File case: simple atomic replace.
+        if let data = entries[from] {
+            entries[to] = data
+            entries.removeValue(forKey: from)
+            return
+        }
+        // Directory case.
+        guard dirs.contains(from) else {
             throw FilesystemError.notFound(from)
         }
-        entries[to] = data
-        entries.removeValue(forKey: from)
+        // Mimic ENOTEMPTY: if the destination directory exists and
+        // has any children, refuse. Empty destination directories are
+        // tolerated (the production `FileManager.moveItem` to an
+        // empty existing dir on the same filesystem behaves similarly
+        // under APFS; we keep the fake strict to surface bugs).
+        if dirs.contains(to) {
+            let prefix = "\(to)/"
+            let hasChildFiles = entries.keys.contains(where: { $0.hasPrefix(prefix) })
+            let hasChildDirs = dirs.contains(where: { $0 != to && $0.hasPrefix(prefix) })
+            if hasChildFiles || hasChildDirs {
+                throw FilesystemError.ioError(
+                    "destination not empty: \(to)")
+            }
+        }
+        let fromPrefix = "\(from)/"
+        // Move all sub-dir entries.
+        let movedDirs = dirs.filter { $0.hasPrefix(fromPrefix) }
+        for d in movedDirs {
+            let suffix = String(d.dropFirst(from.count))  // includes leading "/"
+            dirs.insert("\(to)\(suffix)")
+            dirs.remove(d)
+        }
+        // Move all file entries.
+        let movedFiles = entries.keys.filter { $0.hasPrefix(fromPrefix) }
+        for f in movedFiles {
+            let suffix = String(f.dropFirst(from.count))  // includes leading "/"
+            entries["\(to)\(suffix)"] = entries[f]
+            entries.removeValue(forKey: f)
+        }
+        // Move the dir entry itself.
+        dirs.insert(to)
+        dirs.remove(from)
     }
 
     public func remove(at path: String) throws {
+        // Always remove the named entry (file or dir).
         entries.removeValue(forKey: path)
         dirs.remove(path)
+        // Recursive on directories: drop every descendant path.
+        let prefix = "\(path)/"
+        let childFiles = entries.keys.filter { $0.hasPrefix(prefix) }
+        for f in childFiles { entries.removeValue(forKey: f) }
+        let childDirs = dirs.filter { $0.hasPrefix(prefix) }
+        for d in childDirs { dirs.remove(d) }
     }
 
     public func makeExecutable(at path: String) throws {

--- a/mac-daemon/Tests/CRMMacLifecycleTests/Fakes/InMemoryFilesystem.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/Fakes/InMemoryFilesystem.swift
@@ -44,7 +44,7 @@ public final class InMemoryFilesystem: FilesystemAdapter, @unchecked Sendable {
     /// not empty")` — this catches a class of production mistakes
     /// where the installer accidentally calls rename with a non-empty
     /// destination instead of using the backup-rename-then-swap
-    /// pattern (plan D8). For files, an existing destination is
+    /// pattern. For files, an existing destination is
     /// overwritten (the production adapter uses replaceItemAt for
     /// files, which IS atomic-replace).
     public func rename(from: String, to: String) throws {

--- a/mac-daemon/Tests/CRMMacLifecycleTests/Fakes/TestPaths.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/Fakes/TestPaths.swift
@@ -11,16 +11,21 @@ struct TestPaths {
         let binDir = "\(configDir)/bin"
         let logsDir = "\(root)/Library/Logs/crm-mac"
         let agentsDir = "\(root)/Library/LaunchAgents"
+        let bundleApp = "\(configDir)/crm-mac.app"
         return LifecyclePaths(
             configDirPath: configDir,
             binDirPath: binDir,
-            binaryPath: "\(binDir)/crm-mac",
             configFilePath: "\(configDir)/config.json",
             stateFilePath: "\(configDir)/state.json",
             launchAgentsDirPath: agentsDir,
-            plistPath: "\(agentsDir)/\(Daemon.label).plist",
             logsDirPath: logsDir,
             stdoutLogPath: "\(logsDir)/stdout.log",
-            stderrLogPath: "\(logsDir)/stderr.log")
+            stderrLogPath: "\(logsDir)/stderr.log",
+            bundleAppPath: bundleApp,
+            bundleBinaryPath: "\(bundleApp)/Contents/MacOS/crm-mac",
+            bundlePlistPath: "\(bundleApp)/Contents/Library/LaunchAgents/\(Daemon.label).plist",
+            bundleInfoPlistPath: "\(bundleApp)/Contents/Info.plist",
+            legacyBinaryPath: "\(binDir)/crm-mac",
+            legacyPlistPath: "\(agentsDir)/\(Daemon.label).plist")
     }
 }

--- a/mac-daemon/Tests/CRMMacLifecycleTests/InMemoryFilesystemTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/InMemoryFilesystemTests.swift
@@ -1,5 +1,5 @@
 // InMemoryFilesystemTests exercise the in-memory FilesystemAdapter
-// fake's directory-rename support (plan D14). The InMemoryFilesystem
+// fake's directory-rename support. The InMemoryFilesystem
 // is now used by tests covering the upgrade-path bundle swap (D8) and
 // by BundleAssemblerTests; both rely on `rename` working on
 // directories, not just files.
@@ -51,7 +51,7 @@ final class InMemoryFilesystemTests: XCTestCase {
         // directory — mirrors POSIX rename(2) ENOTEMPTY. This catches
         // a class of production mistakes where the installer
         // accidentally calls rename with a non-empty destination
-        // instead of using backup-rename-then-swap (plan D8 U3-U5).
+        // instead of using the upgrade-path backup-rename-then-swap.
         let fs = InMemoryFilesystem()
         try fs.createDirectory(at: "/src")
         try fs.write(Data("a".utf8), to: "/src/a")

--- a/mac-daemon/Tests/CRMMacLifecycleTests/InMemoryFilesystemTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/InMemoryFilesystemTests.swift
@@ -1,0 +1,114 @@
+// InMemoryFilesystemTests exercise the in-memory FilesystemAdapter
+// fake's directory-rename support (plan D14). The InMemoryFilesystem
+// is now used by tests covering the upgrade-path bundle swap (D8) and
+// by BundleAssemblerTests; both rely on `rename` working on
+// directories, not just files.
+import XCTest
+@testable import CRMMacLifecycle
+
+final class InMemoryFilesystemTests: XCTestCase {
+
+    func testRenameDirectoryMovesAllChildren() throws {
+        let fs = InMemoryFilesystem()
+        try fs.createDirectory(at: "/a")
+        try fs.write(Data("x".utf8), to: "/a/x")
+        try fs.createDirectory(at: "/a/sub")
+        try fs.write(Data("y".utf8), to: "/a/sub/y")
+
+        try fs.rename(from: "/a", to: "/b")
+
+        XCTAssertTrue(fs.fileExists(at: "/b"))
+        XCTAssertTrue(fs.fileExists(at: "/b/x"))
+        XCTAssertTrue(fs.fileExists(at: "/b/sub"))
+        XCTAssertTrue(fs.fileExists(at: "/b/sub/y"))
+        XCTAssertFalse(fs.fileExists(at: "/a"))
+        XCTAssertFalse(fs.fileExists(at: "/a/x"))
+        XCTAssertFalse(fs.fileExists(at: "/a/sub"))
+        XCTAssertFalse(fs.fileExists(at: "/a/sub/y"))
+    }
+
+    func testRenameDirectoryMovesNestedSubdirs() throws {
+        let fs = InMemoryFilesystem()
+        try fs.createDirectory(at: "/root/Contents/Library/LaunchAgents")
+        try fs.write(Data("info".utf8), to: "/root/Contents/Info.plist")
+        try fs.write(Data("macho".utf8), to: "/root/Contents/MacOS/crm-mac")
+        try fs.createDirectory(at: "/root/Contents/MacOS")
+        try fs.write(Data("plist".utf8), to: "/root/Contents/Library/LaunchAgents/xyz.plist")
+
+        try fs.rename(from: "/root", to: "/installed")
+
+        XCTAssertTrue(fs.fileExists(at: "/installed/Contents/Info.plist"))
+        XCTAssertTrue(fs.fileExists(at: "/installed/Contents/MacOS/crm-mac"))
+        XCTAssertTrue(fs.fileExists(at: "/installed/Contents/Library/LaunchAgents/xyz.plist"))
+        XCTAssertTrue(fs.fileExists(at: "/installed/Contents/Library/LaunchAgents"))
+        XCTAssertTrue(fs.fileExists(at: "/installed/Contents/MacOS"))
+        XCTAssertFalse(fs.fileExists(at: "/root"))
+        XCTAssertFalse(fs.fileExists(at: "/root/Contents/Info.plist"))
+    }
+
+    func testRenameDirectoryToExistingPathFailsLikeENOTEMPTY() throws {
+        // The fake refuses to overwrite a non-empty destination
+        // directory — mirrors POSIX rename(2) ENOTEMPTY. This catches
+        // a class of production mistakes where the installer
+        // accidentally calls rename with a non-empty destination
+        // instead of using backup-rename-then-swap (plan D8 U3-U5).
+        let fs = InMemoryFilesystem()
+        try fs.createDirectory(at: "/src")
+        try fs.write(Data("a".utf8), to: "/src/a")
+        try fs.createDirectory(at: "/dst")
+        try fs.write(Data("b".utf8), to: "/dst/b")
+
+        XCTAssertThrowsError(try fs.rename(from: "/src", to: "/dst")) { error in
+            guard let e = error as? FilesystemError else {
+                XCTFail("expected FilesystemError, got \(error)")
+                return
+            }
+            if case .ioError(let m) = e {
+                XCTAssertTrue(m.contains("not empty"),
+                    "expected 'not empty' in error, got '\(m)'")
+            } else {
+                XCTFail("expected ioError, got \(e)")
+            }
+        }
+        // Source unmoved.
+        XCTAssertTrue(fs.fileExists(at: "/src/a"))
+        XCTAssertTrue(fs.fileExists(at: "/dst/b"))
+    }
+
+    func testRenameDirectoryToEmptyExistingPathSucceeds() throws {
+        // An empty destination dir is fine — same behavior as
+        // FileManager.moveItem on APFS.
+        let fs = InMemoryFilesystem()
+        try fs.createDirectory(at: "/src")
+        try fs.write(Data("a".utf8), to: "/src/a")
+        try fs.createDirectory(at: "/dst")  // empty
+
+        try fs.rename(from: "/src", to: "/dst")
+        XCTAssertTrue(fs.fileExists(at: "/dst/a"))
+        XCTAssertFalse(fs.fileExists(at: "/src/a"))
+    }
+
+    func testRenameMissingSourceThrowsNotFound() {
+        let fs = InMemoryFilesystem()
+        XCTAssertThrowsError(try fs.rename(from: "/nope", to: "/elsewhere")) { error in
+            guard let e = error as? FilesystemError, case .notFound = e else {
+                XCTFail("expected notFound, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testRemoveDirectoryDropsAllDescendants() throws {
+        let fs = InMemoryFilesystem()
+        try fs.createDirectory(at: "/a/b/c")
+        try fs.write(Data("x".utf8), to: "/a/file")
+        try fs.write(Data("y".utf8), to: "/a/b/c/leaf")
+
+        try fs.remove(at: "/a")
+        XCTAssertFalse(fs.fileExists(at: "/a"))
+        XCTAssertFalse(fs.fileExists(at: "/a/file"))
+        XCTAssertFalse(fs.fileExists(at: "/a/b"))
+        XCTAssertFalse(fs.fileExists(at: "/a/b/c"))
+        XCTAssertFalse(fs.fileExists(at: "/a/b/c/leaf"))
+    }
+}

--- a/mac-daemon/Tests/CRMMacLifecycleTests/InMemoryFilesystemTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/InMemoryFilesystemTests.swift
@@ -1,6 +1,6 @@
 // InMemoryFilesystemTests exercise the in-memory FilesystemAdapter
 // fake's directory-rename support. The InMemoryFilesystem
-// is now used by tests covering the upgrade-path bundle swap (D8) and
+// is used by tests covering the upgrade-path bundle swap and
 // by BundleAssemblerTests; both rely on `rename` working on
 // directories, not just files.
 import XCTest

--- a/mac-daemon/Tests/CRMMacLifecycleTests/InfoPlistFixtureTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/InfoPlistFixtureTests.swift
@@ -1,0 +1,97 @@
+// InfoPlistFixtureTests validates the canonical Info.plist source file
+// at mac-daemon/Sources/crm-mac/Info.plist. The file is the single
+// source of truth for both the linker -sectcreate embed AND the bundle
+// assembly (per plan D15 + D22). The test reads it directly via
+// #filePath + relative descent rather than as a SwiftPM resource —
+// the file is a BUILD-TIME input to the executable target, not a
+// runtime resource of any test target.
+import XCTest
+@testable import CRMMacLifecycle
+
+final class InfoPlistFixtureTests: XCTestCase {
+    /// The 10 required keys per plan D2.
+    private static let requiredKeys: [String] = [
+        "CFBundleIdentifier",
+        "CFBundleName",
+        "CFBundleExecutable",
+        "CFBundleVersion",
+        "CFBundleShortVersionString",
+        "CFBundlePackageType",
+        "CFBundleInfoDictionaryVersion",
+        "LSUIElement",
+        "LSMinimumSystemVersion",
+        "NSContactsUsageDescription",
+    ]
+
+    /// Resolve the canonical Info.plist by walking up from this test
+    /// file. The directory layout is fixed by the SwiftPM package:
+    ///   mac-daemon/Tests/CRMMacLifecycleTests/InfoPlistFixtureTests.swift
+    ///   mac-daemon/Sources/crm-mac/Info.plist
+    /// Both are package-root relative; we walk up 3 levels from the
+    /// test file and descend into Sources/crm-mac/.
+    private func loadInfoPlist() throws -> [String: Any] {
+        let url = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // CRMMacLifecycleTests/
+            .deletingLastPathComponent()  // Tests/
+            .deletingLastPathComponent()  // mac-daemon/
+            .appendingPathComponent("Sources/crm-mac/Info.plist")
+        let data = try Data(contentsOf: url)
+        let any = try PropertyListSerialization.propertyList(
+            from: data, options: [], format: nil)
+        guard let dict = any as? [String: Any] else {
+            throw NSError(
+                domain: "InfoPlistFixtureTests",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Info.plist did not parse to a dict"])
+        }
+        return dict
+    }
+
+    func testSourceFileParsesAsPropertyList() throws {
+        let dict = try loadInfoPlist()
+        XCTAssertFalse(dict.isEmpty, "Info.plist must parse to a non-empty dict")
+    }
+
+    func testRequiredKeysPresent() throws {
+        let dict = try loadInfoPlist()
+        for key in Self.requiredKeys {
+            XCTAssertNotNil(dict[key], "Info.plist must contain key \(key)")
+        }
+    }
+
+    func testCFBundleIdentifierMatchesDaemonLabel() throws {
+        let dict = try loadInfoPlist()
+        XCTAssertEqual(dict["CFBundleIdentifier"] as? String, Daemon.label)
+    }
+
+    func testLSUIElementIsTrue() throws {
+        let dict = try loadInfoPlist()
+        // plist <true/> decodes as Bool true (or NSNumber 1).
+        if let b = dict["LSUIElement"] as? Bool {
+            XCTAssertTrue(b, "LSUIElement must be true (agent app behavior)")
+        } else if let n = dict["LSUIElement"] as? NSNumber {
+            XCTAssertEqual(n.boolValue, true)
+        } else {
+            XCTFail("LSUIElement is not a Bool/NSNumber: \(String(describing: dict["LSUIElement"]))")
+        }
+    }
+
+    func testNSContactsUsageDescriptionNonEmpty() throws {
+        let dict = try loadInfoPlist()
+        let value = dict["NSContactsUsageDescription"] as? String ?? ""
+        XCTAssertFalse(value.isEmpty,
+            "NSContactsUsageDescription must be a non-empty user-facing string")
+    }
+
+    func testLSMinimumSystemVersionAtLeast14() throws {
+        let dict = try loadInfoPlist()
+        // Plan targets macOS 14. A future bump to macOS 15 is fine;
+        // a regression below 14 would break SMAppService API usage.
+        let raw = dict["LSMinimumSystemVersion"] as? String ?? ""
+        XCTAssertFalse(raw.isEmpty)
+        let major = raw.split(separator: ".").first.map(String.init) ?? ""
+        let majorInt = Int(major) ?? 0
+        XCTAssertGreaterThanOrEqual(majorInt, 14,
+            "LSMinimumSystemVersion must be 14.0 or greater (SMAppService requires macOS 13+; Package.swift targets 14)")
+    }
+}

--- a/mac-daemon/Tests/CRMMacLifecycleTests/InfoPlistFixtureTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/InfoPlistFixtureTests.swift
@@ -1,7 +1,7 @@
 // InfoPlistFixtureTests validates the canonical Info.plist source file
 // at mac-daemon/Sources/crm-mac/Info.plist. The file is the single
 // source of truth for both the linker -sectcreate embed AND the bundle
-// assembly (per plan D15 + D22). The test reads it directly via
+// assembly. The test reads it directly via
 // #filePath + relative descent rather than as a SwiftPM resource —
 // the file is a BUILD-TIME input to the executable target, not a
 // runtime resource of any test target.
@@ -9,7 +9,10 @@ import XCTest
 @testable import CRMMacLifecycle
 
 final class InfoPlistFixtureTests: XCTestCase {
-    /// The 10 required keys per plan D2.
+    /// The 10 required Info.plist keys for a valid agent app
+    /// bundle: identifier + name + executable + version + short
+    /// version + package type + dict version + LSUIElement +
+    /// minimum system version + contacts usage description.
     private static let requiredKeys: [String] = [
         "CFBundleIdentifier",
         "CFBundleName",

--- a/mac-daemon/Tests/CRMMacLifecycleTests/InstallerFailurePathsTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/InstallerFailurePathsTests.swift
@@ -6,10 +6,10 @@ import CRMMacCore
 final class InstallerFailurePathsTests: XCTestCase {
     private func makeInstaller(
         transport: LifecycleMockTransport,
-        launchctl: FakeLaunchctlRunner = FakeLaunchctlRunner(),
+        agentService: FakeAgentService = FakeAgentService(),
         keychain: InMemoryKeychainStore = InMemoryKeychainStore(),
         executable: FakeExecutableAdapter? = nil
-    ) -> (Installer, InMemoryFilesystem, FakeLaunchctlRunner, InMemoryKeychainStore, LifecyclePaths) {
+    ) -> (Installer, InMemoryFilesystem, FakeAgentService, InMemoryKeychainStore, LifecyclePaths, FakeExecutableAdapter) {
         let paths = TestPaths.make()
         let fs = InMemoryFilesystem()
         fs.seedFile(at: "/tmp/source/crm-mac")
@@ -19,7 +19,9 @@ final class InstallerFailurePathsTests: XCTestCase {
             filesystem: fs,
             executable: exec,
             keychain: keychain,
-            launchctl: launchctl,
+            agentService: agentService,
+            processSignaller: FakeProcessSignaller(),
+            bundleAssembler: BundleAssembler(filesystem: fs, executable: exec),
             piClientFactory: { url in
                 PiClient(
                     baseURL: url,
@@ -28,12 +30,12 @@ final class InstallerFailurePathsTests: XCTestCase {
             },
             clock: FixedClock(),
             logger: NoopLogger()))
-        return (installer, fs, launchctl, keychain, paths)
+        return (installer, fs, agentService, keychain, paths, exec)
     }
 
-    func test410CleansTempBinaryAndDoesNotPersist() async {
+    func test410CleansTempBundleAndDoesNotPersist() async {
         let transport = LifecycleMockTransport([.respond(status: 410, data: pair410JSON)])
-        let (installer, fs, launchctl, keychain, paths) = makeInstaller(transport: transport)
+        let (installer, fs, agentService, keychain, paths, _) = makeInstaller(transport: transport)
 
         do {
             _ = try await installer.run(InstallRequest(
@@ -46,21 +48,22 @@ final class InstallerFailurePathsTests: XCTestCase {
         } catch {
             XCTFail("got \(error)")
         }
-        // No artifact at the install location.
-        XCTAssertFalse(fs.fileExists(at: paths.binaryPath))
-        // No tmp file remaining.
+        // No bundle at install location.
+        XCTAssertFalse(fs.fileExists(at: paths.bundleAppPath))
+        // No tmp.
         XCTAssertFalse(fs.allPaths.contains(where: { $0.contains(".tmp.") }))
+        XCTAssertFalse(fs.allDirs.contains(where: { $0.contains(".tmp.") }))
         // No config / state / Keychain side effects.
         XCTAssertFalse(fs.fileExists(at: paths.configFilePath))
         XCTAssertFalse(fs.fileExists(at: paths.stateFilePath))
         XCTAssertNil(keychain.currentValue)
-        // No launchctl bootstrap attempted.
-        XCTAssertEqual(launchctl.bootstrapCalls.count, 0)
+        // No agent registration attempted.
+        XCTAssertEqual(agentService.registerCalls, 0)
     }
 
-    func test409CleansTempBinary() async {
+    func test409CleansTempBundle() async {
         let transport = LifecycleMockTransport([.respond(status: 409, data: pair409JSON)])
-        let (installer, fs, _, _, paths) = makeInstaller(transport: transport)
+        let (installer, fs, _, _, paths, _) = makeInstaller(transport: transport)
         do {
             _ = try await installer.run(InstallRequest(
                 piURL: URL(string: "https://pi.example.test")!,
@@ -72,18 +75,15 @@ final class InstallerFailurePathsTests: XCTestCase {
         } catch {
             XCTFail("got \(error)")
         }
-        XCTAssertFalse(fs.fileExists(at: paths.binaryPath))
-        XCTAssertFalse(fs.allPaths.contains(where: { $0.contains(".tmp.") }))
+        XCTAssertFalse(fs.fileExists(at: paths.bundleAppPath))
+        XCTAssertFalse(fs.allDirs.contains(where: { $0.contains(".tmp.") }))
     }
 
-    func test5xxCleansTempBinaryAndSurfacesAmbiguous() async {
-        // Pair is no-retry so we expect only 1 attempt; 5xx now
-        // surfaces as ambiguousPair so the operator gets the
-        // list-hosts recovery guidance.
+    func test5xxCleansTempBundleAndSurfacesAmbiguous() async {
         let transport = LifecycleMockTransport([
             .respond(status: 502, data: Data("{}".utf8)),
         ])
-        let (installer, fs, _, _, paths) = makeInstaller(transport: transport)
+        let (installer, fs, _, _, paths, _) = makeInstaller(transport: transport)
         do {
             _ = try await installer.run(InstallRequest(
                 piURL: URL(string: "https://pi.example.test")!,
@@ -95,7 +95,7 @@ final class InstallerFailurePathsTests: XCTestCase {
         } catch {
             XCTFail("got \(error)")
         }
-        XCTAssertFalse(fs.fileExists(at: paths.binaryPath))
+        XCTAssertFalse(fs.fileExists(at: paths.bundleAppPath))
         XCTAssertEqual(transport.invocations.count, 1, "pair must not retry on 5xx")
     }
 
@@ -103,7 +103,7 @@ final class InstallerFailurePathsTests: XCTestCase {
         let transport = LifecycleMockTransport([
             .fail(URLError(.timedOut)),
         ])
-        let (installer, fs, _, _, paths) = makeInstaller(transport: transport)
+        let (installer, fs, _, _, paths, _) = makeInstaller(transport: transport)
         do {
             _ = try await installer.run(InstallRequest(
                 piURL: URL(string: "https://pi.example.test")!,
@@ -115,87 +115,14 @@ final class InstallerFailurePathsTests: XCTestCase {
         } catch {
             XCTFail("got \(error)")
         }
-        XCTAssertFalse(fs.fileExists(at: paths.binaryPath))
+        XCTAssertFalse(fs.fileExists(at: paths.bundleAppPath))
     }
 
-    func testPlistWriteFailureLeavesBinaryInPlaceAsLaunchctlFailed() async throws {
-        let transport = LifecycleMockTransport([.respond(status: 200, data: pair200JSON)])
-        let paths = TestPaths.make()
-        let fs = InMemoryFilesystem()
-        fs.seedFile(at: "/tmp/source/crm-mac")
-        // Fail writes specifically at the plist path. The binary,
-        // config, keychain, and state are all already written by then.
-        fs.failWritesAtPath = paths.plistPath
-        let keychain = InMemoryKeychainStore()
-        let launchctl = FakeLaunchctlRunner()
-        let installer = Installer(InstallerDependencies(
-            paths: paths,
-            filesystem: fs,
-            executable: FakeExecutableAdapter(currentExecutablePath: "/tmp/source/crm-mac"),
-            keychain: keychain,
-            launchctl: launchctl,
-            piClientFactory: { url in
-                PiClient(
-                    baseURL: url,
-                    transport: transport.asTransport(),
-                    sleep: noopSleep)
-            },
-            clock: FixedClock(),
-            logger: NoopLogger()))
-        do {
-            _ = try await installer.run(InstallRequest(
-                piURL: URL(string: "https://pi.example.test")!,
-                pairingToken: "tk",
-                hostname: "mac-1"))
-            XCTFail("expected launchctlFailed")
-        } catch InstallError.launchctlFailed(_, let stderr) {
-            XCTAssertTrue(stderr.contains("write plist"), "expected plist context in error, got \(stderr)")
-        } catch {
-            XCTFail("got \(error)")
-        }
-        // Binary IS in place; config + Keychain + state too. Operator
-        // recovers via `crm-mac install --register-only` after fixing
-        // the underlying filesystem issue.
-        XCTAssertTrue(fs.fileExists(at: paths.binaryPath))
-        XCTAssertTrue(fs.fileExists(at: paths.configFilePath))
-        XCTAssertTrue(fs.fileExists(at: paths.stateFilePath))
-        XCTAssertEqual(keychain.currentValue, "k")
-        // launchctl bootstrap was NOT called (we failed before it).
-        XCTAssertEqual(launchctl.bootstrapCalls.count, 0)
-    }
-
-    func testLaunchctlBootstrapFailureLeavesBinaryInPlace() async throws {
-        let transport = LifecycleMockTransport([.respond(status: 200, data: pair200JSON)])
-        var script = FakeLaunchctlRunner.Script()
-        script.bootstrap = [42]
-        let launchctl = FakeLaunchctlRunner(script: script)
-        let (installer, fs, _, keychain, paths) = makeInstaller(
-            transport: transport,
-            launchctl: launchctl)
-        do {
-            _ = try await installer.run(InstallRequest(
-                piURL: URL(string: "https://pi.example.test")!,
-                pairingToken: "tk",
-                hostname: "mac-1"))
-            XCTFail("expected throw")
-        } catch InstallError.launchctlFailed(let code, _) {
-            XCTAssertEqual(code, 42)
-        } catch {
-            XCTFail("got \(error)")
-        }
-        // Binary IS in place. Config + Keychain + state present. Operator
-        // recovers via `crm-mac install --register-only`.
-        XCTAssertTrue(fs.fileExists(at: paths.binaryPath))
-        XCTAssertTrue(fs.fileExists(at: paths.configFilePath))
-        XCTAssertTrue(fs.fileExists(at: paths.stateFilePath))
-        XCTAssertEqual(keychain.currentValue, "k")
-    }
-
-    func testCodesignFailureCleansTempBinaryNoPair() async {
+    func testBundleAssemblyFailureCleansTmpAndDoesNotPair() async {
         let transport = LifecycleMockTransport([.respond(status: 200, data: pair200JSON)])
         let exec = FakeExecutableAdapter(currentExecutablePath: "/tmp/source/crm-mac")
-        exec.failCodesignWith = "ad-hoc signing requires Mac developer mode"
-        let (installer, fs, _, _, paths) = makeInstaller(transport: transport, executable: exec)
+        exec.failBundleCodesignWith = "injected codesign failure"
+        let (installer, fs, _, _, paths, _) = makeInstaller(transport: transport, executable: exec)
         do {
             _ = try await installer.run(InstallRequest(
                 piURL: URL(string: "https://pi.example.test")!,
@@ -207,9 +134,76 @@ final class InstallerFailurePathsTests: XCTestCase {
         } catch {
             XCTFail("got \(error)")
         }
-        XCTAssertFalse(fs.fileExists(at: paths.binaryPath))
-        XCTAssertFalse(fs.allPaths.contains(where: { $0.contains(".tmp.") }))
-        // Pair was NOT attempted — codesign failure is pre-pair.
+        // No bundle at final path; no tmp left over; no pair attempt.
+        XCTAssertFalse(fs.fileExists(at: paths.bundleAppPath))
+        XCTAssertFalse(fs.allDirs.contains(where: { $0.contains(".tmp.") }))
+        XCTAssertEqual(transport.invocations.count, 0)
+    }
+
+    func testAgentRegistrationFailureLeavesBundleInPlace() async throws {
+        let transport = LifecycleMockTransport([.respond(status: 200, data: pair200JSON)])
+        var script = FakeAgentService.Script()
+        script.registerThrows = .registrationFailed(
+            message: "requires approval", requiresApproval: true)
+        let agent = FakeAgentService(script: script)
+        let (installer, fs, _, keychain, paths, _) = makeInstaller(
+            transport: transport,
+            agentService: agent)
+        do {
+            _ = try await installer.run(InstallRequest(
+                piURL: URL(string: "https://pi.example.test")!,
+                pairingToken: "tk",
+                hostname: "mac-1"))
+            XCTFail("expected throw")
+        } catch InstallError.agentRegistrationFailed(_, let requiresApproval) {
+            XCTAssertTrue(requiresApproval)
+        } catch {
+            XCTFail("got \(error)")
+        }
+        // Bundle, config, state, keychain all in place.
+        XCTAssertTrue(fs.fileExists(at: paths.bundleAppPath))
+        XCTAssertTrue(fs.fileExists(at: paths.configFilePath))
+        XCTAssertTrue(fs.fileExists(at: paths.stateFilePath))
+        XCTAssertEqual(keychain.currentValue, "k")
+    }
+
+    func testInfoPlistWriteFailureCleansTmpAndDoesNotPair() async {
+        // Inject a failure when the assembler writes Info.plist into
+        // the tmp bundle. Assembly fails before pair.
+        let transport = LifecycleMockTransport([.respond(status: 200, data: pair200JSON)])
+        let paths = TestPaths.make()
+        let fs = InMemoryFilesystem()
+        fs.seedFile(at: "/tmp/source/crm-mac")
+        // Compute the expected tmp Info.plist path.
+        let tmpInfoPlist =
+            "\(paths.configDirPath)/crm-mac.app.tmp.\(ProcessInfo.processInfo.processIdentifier)/Contents/Info.plist"
+        fs.failWritesAtPath = tmpInfoPlist
+        let exec = FakeExecutableAdapter(currentExecutablePath: "/tmp/source/crm-mac")
+        let installer = Installer(InstallerDependencies(
+            paths: paths,
+            filesystem: fs,
+            executable: exec,
+            keychain: InMemoryKeychainStore(),
+            agentService: FakeAgentService(),
+            processSignaller: FakeProcessSignaller(),
+            bundleAssembler: BundleAssembler(filesystem: fs, executable: exec),
+            piClientFactory: { url in
+                PiClient(baseURL: url, transport: transport.asTransport(), sleep: noopSleep)
+            },
+            clock: FixedClock(),
+            logger: NoopLogger()))
+        do {
+            _ = try await installer.run(InstallRequest(
+                piURL: URL(string: "https://pi.example.test")!,
+                pairingToken: "tk",
+                hostname: "mac-1"))
+            XCTFail("expected throw")
+        } catch InstallError.filesystemFailed {
+            // ok
+        } catch {
+            XCTFail("got \(error)")
+        }
+        XCTAssertFalse(fs.fileExists(at: paths.bundleAppPath))
         XCTAssertEqual(transport.invocations.count, 0)
     }
 }

--- a/mac-daemon/Tests/CRMMacLifecycleTests/InstallerFreshInstallTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/InstallerFreshInstallTests.swift
@@ -65,14 +65,15 @@ final class InstallerFreshInstallTests: XCTestCase {
         XCTAssertEqual(keychain.currentValue, "k")
         // SMAppService.register was called.
         XCTAssertEqual(agentService.registerCalls, 1)
-        // Placeholder substitution happened — the embedded plist no
-        // longer contains __INSTALL_PREFIX__.
+        // The embedded plist references the real install-time bundle
+        // path — rendered with the path embedded BEFORE the bundle
+        // codesign pass so the seal stays intact.
         let plistContent = try fs.read(from: paths.bundlePlistPath)
         let plistStr = String(data: plistContent, encoding: .utf8) ?? ""
         XCTAssertFalse(plistStr.contains("__INSTALL_PREFIX__"),
-            "installer must substitute the placeholder")
+            "installer must not leave a placeholder in the embedded plist")
         XCTAssertTrue(plistStr.contains(paths.bundleAppPath),
-            "installer must substitute with the real bundle path")
+            "embedded plist must reference the real install-time bundle path")
     }
 
     func testDirectoriesCreated() async throws {

--- a/mac-daemon/Tests/CRMMacLifecycleTests/InstallerFreshInstallTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/InstallerFreshInstallTests.swift
@@ -4,20 +4,24 @@ import CRMMacCore
 @testable import CRMMacPiClient
 
 final class InstallerFreshInstallTests: XCTestCase {
-    func testHappyPathPersistsAndBootstraps() async throws {
+    func testHappyPathPersistsAndRegisters() async throws {
         let paths = TestPaths.make()
         let fs = InMemoryFilesystem()
         fs.seedFile(at: "/tmp/source/crm-mac")
         let keychain = InMemoryKeychainStore()
-        let launchctl = FakeLaunchctlRunner()
+        let agentService = FakeAgentService()
+        let signaller = FakeProcessSignaller()
         let transport = LifecycleMockTransport([.respond(status: 200, data: pair200JSON)])
         let exec = FakeExecutableAdapter(currentExecutablePath: "/tmp/source/crm-mac")
+        let assembler = BundleAssembler(filesystem: fs, executable: exec)
         let installer = Installer(InstallerDependencies(
             paths: paths,
             filesystem: fs,
             executable: exec,
             keychain: keychain,
-            launchctl: launchctl,
+            agentService: agentService,
+            processSignaller: signaller,
+            bundleAssembler: assembler,
             piClientFactory: { url in
                 PiClient(
                     baseURL: url,
@@ -32,62 +36,65 @@ final class InstallerFreshInstallTests: XCTestCase {
             pairingToken: "tk",
             hostname: "mac-1"))
 
-        XCTAssertEqual(summary.binaryPath, paths.binaryPath)
-        XCTAssertEqual(summary.plistPath, paths.plistPath)
-
-        // Binary is at its final location.
-        XCTAssertTrue(fs.fileExists(at: paths.binaryPath))
+        XCTAssertEqual(summary.bundleBinaryPath, paths.bundleBinaryPath)
+        XCTAssertEqual(summary.bundleAppPath, paths.bundleAppPath)
+        // Bundle structure is in place.
+        XCTAssertTrue(fs.fileExists(at: paths.bundleAppPath))
+        XCTAssertTrue(fs.fileExists(at: paths.bundleBinaryPath))
+        XCTAssertTrue(fs.fileExists(at: paths.bundlePlistPath))
+        XCTAssertTrue(fs.fileExists(at: paths.bundleInfoPlistPath))
         // No leftover tmp.
         XCTAssertFalse(fs.allPaths.contains(where: { $0.contains(".tmp.") }))
-        // Codesign was invoked.
-        XCTAssertEqual(exec.codesignCalls.count, 1)
-        // Config exists and parses with the expected hostname.
+        XCTAssertFalse(fs.allDirs.contains(where: { $0.contains(".tmp.") }))
+        // Bundle codesign was invoked once with the right identifier.
+        XCTAssertEqual(exec.bundleCodesignCalls.count, 1)
+        XCTAssertEqual(exec.bundleCodesignCalls.first?.identifier, Daemon.label)
+        // Single-Mach-O codesign (legacy path) was NOT used.
+        XCTAssertEqual(exec.codesignCalls.count, 0)
+        // Config exists + parses.
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         let configData = try fs.read(from: paths.configFilePath)
         let cfg = try decoder.decode(DaemonConfig.self, from: configData)
         XCTAssertEqual(cfg.hostname, "mac-1")
-        // State exists and parses with schema version 1.
+        // State exists + parses with schema version 1.
         let stateData = try fs.read(from: paths.stateFilePath)
         let state = try decoder.decode(DaemonState.self, from: stateData)
         XCTAssertEqual(state.schemaVersion, 1)
-        // Keychain holds the api key.
+        // Api-key persisted.
         XCTAssertEqual(keychain.currentValue, "k")
-        // Plist + bootstrap.
-        XCTAssertTrue(fs.fileExists(at: paths.plistPath))
-        XCTAssertEqual(launchctl.bootstrapCalls.count, 1)
+        // SMAppService.register was called.
+        XCTAssertEqual(agentService.registerCalls, 1)
+        // Placeholder substitution happened — the embedded plist no
+        // longer contains __INSTALL_PREFIX__.
+        let plistContent = try fs.read(from: paths.bundlePlistPath)
+        let plistStr = String(data: plistContent, encoding: .utf8) ?? ""
+        XCTAssertFalse(plistStr.contains("__INSTALL_PREFIX__"),
+            "installer must substitute the placeholder")
+        XCTAssertTrue(plistStr.contains(paths.bundleAppPath),
+            "installer must substitute with the real bundle path")
     }
 
     func testDirectoriesCreated() async throws {
         let paths = TestPaths.make()
         let fs = InMemoryFilesystem()
         fs.seedFile(at: "/tmp/source/crm-mac")
-        let installer = Installer(InstallerDependencies(
-            paths: paths,
-            filesystem: fs,
-            executable: FakeExecutableAdapter(currentExecutablePath: "/tmp/source/crm-mac"),
-            keychain: InMemoryKeychainStore(),
-            launchctl: FakeLaunchctlRunner(),
-            piClientFactory: { url in
-                PiClient(
-                    baseURL: url,
-                    transport: LifecycleMockTransport([.respond(status: 200, data: pair200JSON)]).asTransport(),
-                    sleep: noopSleep)
-            },
-            clock: FixedClock(),
-            logger: NoopLogger()))
+        let exec = FakeExecutableAdapter(currentExecutablePath: "/tmp/source/crm-mac")
+        let installer = makeInstaller(paths: paths, fs: fs, exec: exec)
         _ = try await installer.run(InstallRequest(
             piURL: URL(string: "https://pi.example.test")!,
             pairingToken: "tk",
             hostname: "mac-1"))
         XCTAssertTrue(fs.allDirs.contains(paths.configDirPath))
-        XCTAssertTrue(fs.allDirs.contains(paths.binDirPath))
         XCTAssertTrue(fs.allDirs.contains(paths.logsDirPath))
-        XCTAssertTrue(fs.allDirs.contains(paths.launchAgentsDirPath))
+        XCTAssertTrue(fs.allDirs.contains(paths.bundleAppPath))
+        // Legacy bin/ is NOT created on fresh install.
+        XCTAssertFalse(fs.allDirs.contains(paths.binDirPath),
+            "fresh install must NOT create legacy bin/ directory")
     }
 
     func testRequiresHostname() async {
-        let installer = makeInstaller(transportSteps: [])
+        let installer = makeInstaller()
         do {
             _ = try await installer.run(InstallRequest(
                 piURL: URL(string: "https://pi.example.test")!,
@@ -102,7 +109,7 @@ final class InstallerFreshInstallTests: XCTestCase {
     }
 
     func testEmptyPairingTokenRejected() async {
-        let installer = makeInstaller(transportSteps: [])
+        let installer = makeInstaller()
         do {
             _ = try await installer.run(InstallRequest(
                 piURL: URL(string: "https://pi.example.test")!,
@@ -118,20 +125,30 @@ final class InstallerFreshInstallTests: XCTestCase {
 
     // MARK: - helpers
 
-    private func makeInstaller(transportSteps: [LifecycleMockTransport.Step]) -> Installer {
-        let paths = TestPaths.make()
-        let fs = InMemoryFilesystem()
-        fs.seedFile(at: "/tmp/source/crm-mac")
+    private func makeInstaller(
+        paths: LifecyclePaths? = nil,
+        fs: InMemoryFilesystem? = nil,
+        exec: FakeExecutableAdapter? = nil
+    ) -> Installer {
+        let p = paths ?? TestPaths.make()
+        let f = fs ?? {
+            let x = InMemoryFilesystem()
+            x.seedFile(at: "/tmp/source/crm-mac")
+            return x
+        }()
+        let e = exec ?? FakeExecutableAdapter(currentExecutablePath: "/tmp/source/crm-mac")
         return Installer(InstallerDependencies(
-            paths: paths,
-            filesystem: fs,
-            executable: FakeExecutableAdapter(currentExecutablePath: "/tmp/source/crm-mac"),
+            paths: p,
+            filesystem: f,
+            executable: e,
             keychain: InMemoryKeychainStore(),
-            launchctl: FakeLaunchctlRunner(),
+            agentService: FakeAgentService(),
+            processSignaller: FakeProcessSignaller(),
+            bundleAssembler: BundleAssembler(filesystem: f, executable: e),
             piClientFactory: { url in
                 PiClient(
                     baseURL: url,
-                    transport: LifecycleMockTransport(transportSteps).asTransport(),
+                    transport: LifecycleMockTransport([.respond(status: 200, data: pair200JSON)]).asTransport(),
                     sleep: noopSleep)
             },
             clock: FixedClock(),

--- a/mac-daemon/Tests/CRMMacLifecycleTests/InstallerPlaceholderSubstitutionTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/InstallerPlaceholderSubstitutionTests.swift
@@ -1,0 +1,107 @@
+// InstallerPlaceholderSubstitutionTests cover the
+// `__INSTALL_PREFIX__` substitution step (plan D7 step 5, D14
+// InstallerPlaceholderSubstitutionTests). The build-time shell
+// script writes the placeholder; the install-time Swift code
+// substitutes it with the real bundle app path before
+// SMAppService.register reads the file.
+//
+// Substitution is exercised through the public Installer surface
+// (fresh install runs assembly + atomic-rename + substitution +
+// register end-to-end). Direct unit-testing of the private
+// substituteInstallPrefixPlaceholder helper would require exposing
+// it; the end-to-end assertion is sufficient.
+import XCTest
+@testable import CRMMacLifecycle
+@testable import CRMMacPiClient
+
+final class InstallerPlaceholderSubstitutionTests: XCTestCase {
+
+    func testInstallerSubstitutesPlaceholderAfterAssembly() async throws {
+        let paths = TestPaths.make()
+        let fs = InMemoryFilesystem()
+        fs.seedFile(at: "/tmp/source/crm-mac")
+        let exec = FakeExecutableAdapter(currentExecutablePath: "/tmp/source/crm-mac")
+        let installer = Installer(InstallerDependencies(
+            paths: paths,
+            filesystem: fs,
+            executable: exec,
+            keychain: InMemoryKeychainStore(),
+            agentService: FakeAgentService(),
+            processSignaller: FakeProcessSignaller(),
+            bundleAssembler: BundleAssembler(filesystem: fs, executable: exec),
+            piClientFactory: { url in
+                PiClient(baseURL: url, transport: LifecycleMockTransport([.respond(status: 200, data: pair200JSON)]).asTransport(), sleep: noopSleep)
+            },
+            clock: FixedClock(),
+            logger: NoopLogger()))
+        _ = try await installer.run(InstallRequest(
+            piURL: URL(string: "https://x")!,
+            pairingToken: "tk",
+            hostname: "mac-1"))
+
+        // The substituted plist contains the real install-time bundle
+        // path, NOT the placeholder.
+        let plistData = try fs.read(from: paths.bundlePlistPath)
+        let plistStr = String(data: plistData, encoding: .utf8) ?? ""
+        XCTAssertFalse(plistStr.contains(Installer.installPrefixPlaceholder),
+            "installer must substitute the placeholder")
+        XCTAssertTrue(plistStr.contains(paths.bundleAppPath),
+            "installer must substitute with the real bundle path")
+        // PropertyListSerialization parses it.
+        XCTAssertNoThrow(
+            try PropertyListSerialization.propertyList(from: plistData, options: [], format: nil),
+            "substituted plist must still parse as a valid plist")
+    }
+
+    func testSubstitutionIdempotentViaRegisterOnly() async throws {
+        // Set up an already-installed bundle whose embedded plist
+        // has the placeholder already replaced. Run register-only
+        // (which calls the substitute helper) — a second run on the
+        // same install must be a no-op (no placeholder to substitute).
+        let paths = TestPaths.make()
+        let fs = InMemoryFilesystem()
+        fs.seedFile(at: "/tmp/source/crm-mac")
+        // Existing bundle with the placeholder already substituted.
+        let alreadySubstituted = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <plist version="1.0"><dict>
+        <key>ProgramArguments</key>
+        <array><string>\(paths.bundleAppPath)/Contents/MacOS/crm-mac</string></array>
+        </dict></plist>
+        """
+        try fs.createDirectory(at: paths.bundleAppPath)
+        try fs.write(Data("bin".utf8), to: paths.bundleBinaryPath)
+        try fs.write(Data(alreadySubstituted.utf8), to: paths.bundlePlistPath)
+        let cfg = DaemonConfig(
+            piURL: URL(string: "https://x")!,
+            hostID: UUID(),
+            hostname: "mac-1",
+            installedAt: Date())
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        try fs.write(try encoder.encode(cfg), to: paths.configFilePath)
+        let keychain = InMemoryKeychainStore(initial: "k")
+        let exec = FakeExecutableAdapter(currentExecutablePath: "/tmp/source/crm-mac")
+        let installer = Installer(InstallerDependencies(
+            paths: paths,
+            filesystem: fs,
+            executable: exec,
+            keychain: keychain,
+            agentService: FakeAgentService(),
+            processSignaller: FakeProcessSignaller(),
+            bundleAssembler: BundleAssembler(filesystem: fs, executable: exec),
+            piClientFactory: { url in
+                PiClient(baseURL: url, transport: LifecycleMockTransport([]).asTransport(), sleep: noopSleep)
+            },
+            clock: FixedClock(),
+            logger: NoopLogger()))
+        _ = try await installer.run(InstallRequest(
+            piURL: URL(string: "https://x")!,
+            pairingToken: "ignored",
+            hostname: "ignored",
+            registerOnly: true))
+        // File unchanged — idempotent.
+        let post = try fs.read(from: paths.bundlePlistPath)
+        XCTAssertEqual(post, Data(alreadySubstituted.utf8))
+    }
+}

--- a/mac-daemon/Tests/CRMMacLifecycleTests/InstallerPlaceholderSubstitutionTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/InstallerPlaceholderSubstitutionTests.swift
@@ -53,6 +53,65 @@ final class InstallerPlaceholderSubstitutionTests: XCTestCase {
             "substituted plist must still parse as a valid plist")
     }
 
+    func testSubstitutionXMLEscapesUnusualPaths() async throws {
+        // Per Codex r6 #5: substituting a raw bundle path into
+        // already-rendered XML breaks `LaunchAgentPlist`'s
+        // XML-escape guarantee for unusual home directory characters
+        // (`&`, `<`, `>`, `"`, `'`). The installer must apply the
+        // same escape function during substitution so the resulting
+        // plist still parses.
+        let paths = LifecyclePaths(
+            configDirPath: "/tmp/o&malley/cfg",
+            binDirPath: "/tmp/o&malley/cfg/bin",
+            configFilePath: "/tmp/o&malley/cfg/config.json",
+            stateFilePath: "/tmp/o&malley/cfg/state.json",
+            launchAgentsDirPath: "/tmp/o&malley/LaunchAgents",
+            logsDirPath: "/tmp/o&malley/logs",
+            stdoutLogPath: "/tmp/o&malley/logs/stdout.log",
+            stderrLogPath: "/tmp/o&malley/logs/stderr.log",
+            // The bundle app path contains `&` — XML-significant.
+            bundleAppPath: "/tmp/o&malley/cfg/crm-mac.app",
+            bundleBinaryPath: "/tmp/o&malley/cfg/crm-mac.app/Contents/MacOS/crm-mac",
+            bundlePlistPath: "/tmp/o&malley/cfg/crm-mac.app/Contents/Library/LaunchAgents/\(Daemon.label).plist",
+            bundleInfoPlistPath: "/tmp/o&malley/cfg/crm-mac.app/Contents/Info.plist",
+            legacyBinaryPath: "/tmp/o&malley/cfg/bin/crm-mac",
+            legacyPlistPath: "/tmp/o&malley/LaunchAgents/\(Daemon.label).plist")
+        let fs = InMemoryFilesystem()
+        fs.seedFile(at: "/tmp/source/crm-mac")
+        let exec = FakeExecutableAdapter(currentExecutablePath: "/tmp/source/crm-mac")
+        let installer = Installer(InstallerDependencies(
+            paths: paths,
+            filesystem: fs,
+            executable: exec,
+            keychain: InMemoryKeychainStore(),
+            agentService: FakeAgentService(),
+            processSignaller: FakeProcessSignaller(),
+            bundleAssembler: BundleAssembler(filesystem: fs, executable: exec),
+            piClientFactory: { url in
+                PiClient(baseURL: url, transport: LifecycleMockTransport([.respond(status: 200, data: pair200JSON)]).asTransport(), sleep: noopSleep)
+            },
+            clock: FixedClock(),
+            logger: NoopLogger()))
+        _ = try await installer.run(InstallRequest(
+            piURL: URL(string: "https://x")!,
+            pairingToken: "tk",
+            hostname: "mac-1"))
+        // The embedded plist must parse — proves the substitution
+        // didn't break the XML.
+        let plistData = try fs.read(from: paths.bundlePlistPath)
+        XCTAssertNoThrow(
+            try PropertyListSerialization.propertyList(from: plistData, options: [], format: nil),
+            "substitution must XML-escape the bundle path")
+        // The decoded ProgramArguments[0] must round-trip back to the
+        // raw bundle binary path (the escape is invisible to the
+        // plist parser).
+        let parsed = try PropertyListSerialization.propertyList(
+            from: plistData, options: [], format: nil) as! [String: Any]
+        let args = parsed["ProgramArguments"] as! [String]
+        XCTAssertEqual(args.first, paths.bundleBinaryPath,
+            "decoded ProgramArguments[0] must equal the raw bundleBinaryPath after XML-decode")
+    }
+
     func testSubstitutionIdempotentViaRegisterOnly() async throws {
         // Set up an already-installed bundle whose embedded plist
         // has the placeholder already replaced. Run register-only

--- a/mac-daemon/Tests/CRMMacLifecycleTests/InstallerPlaceholderSubstitutionTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/InstallerPlaceholderSubstitutionTests.swift
@@ -1,26 +1,37 @@
-// InstallerPlaceholderSubstitutionTests cover the
-// `__INSTALL_PREFIX__` substitution step. The build-time shell
-// script writes the placeholder; the install-time Swift code
-// substitutes it with the real bundle app path before
-// SMAppService.register reads the file.
+// InstallerLaunchAgentEmbeddingTests prove the embedded LaunchAgent
+// plist references the real install-time bundle path AT the moment
+// the bundle is codesigned — not after. The plist is a sealed
+// resource under the bundle codesign manifest; modifying it after
+// `adhocCodesignBundle` runs invalidates the seal and SMAppService
+// rejects the bundle on subsequent register() calls
+// ("Codesigning failure loading plist ... code: -67054").
 //
-// Substitution is exercised through the public Installer surface
-// (fresh install runs assembly + atomic-rename + substitution +
-// register end-to-end). Direct unit-testing of the private
-// substituteInstallPrefixPlaceholder helper would require exposing
-// it; the end-to-end assertion is sufficient.
+// The earlier implementation rendered the plist with an
+// __INSTALL_PREFIX__ placeholder, codesigned the bundle, then
+// rewrote the plist post-codesign. The end-to-end install appeared
+// to succeed (SMAppService accepts the initial submit without
+// strict codesign validation) but `crm-mac install --register-only`
+// and `crm-mac doctor` failed downstream. These tests pin the
+// invariant that codesign-time plist content == final plist
+// content.
 import XCTest
 import CRMMacCore
 @testable import CRMMacLifecycle
 @testable import CRMMacPiClient
 
-final class InstallerPlaceholderSubstitutionTests: XCTestCase {
+final class InstallerLaunchAgentEmbeddingTests: XCTestCase {
 
-    func testInstallerSubstitutesPlaceholderAfterAssembly() async throws {
+    func testPlistEmbedsRealBundlePathAtCodesignTime() async throws {
         let paths = TestPaths.make()
         let fs = InMemoryFilesystem()
         fs.seedFile(at: "/tmp/source/crm-mac")
-        let exec = FakeExecutableAdapter(currentExecutablePath: "/tmp/source/crm-mac")
+        // Snapshot the embedded plist content when the bundle is
+        // codesigned. If the installer modifies the plist after
+        // codesign returns, the snapshot will diverge from the final
+        // on-disk plist — and we'll catch it.
+        let exec = SnapshottingFakeExecutableAdapter(
+            currentExecutablePath: "/tmp/source/crm-mac",
+            filesystem: fs)
         let installer = Installer(InstallerDependencies(
             paths: paths,
             filesystem: fs,
@@ -39,26 +50,40 @@ final class InstallerPlaceholderSubstitutionTests: XCTestCase {
             pairingToken: "tk",
             hostname: "mac-1"))
 
-        // The substituted plist contains the real install-time bundle
-        // path, NOT the placeholder.
-        let plistData = try fs.read(from: paths.bundlePlistPath)
-        let plistStr = String(data: plistData, encoding: .utf8) ?? ""
-        XCTAssertFalse(plistStr.contains(Installer.installPrefixPlaceholder),
-            "installer must substitute the placeholder")
-        XCTAssertTrue(plistStr.contains(paths.bundleAppPath),
-            "installer must substitute with the real bundle path")
-        // PropertyListSerialization parses it.
+        XCTAssertEqual(exec.bundleCodesignCalls.count, 1)
+        guard let snapshot = exec.plistAtCodesignTime else {
+            return XCTFail("codesign snapshot was not captured — bundle codesign step did not run")
+        }
+        let snapshotStr = String(data: snapshot, encoding: .utf8) ?? ""
+        // Codesign-time plist must already contain the real bundle
+        // path — NOT the placeholder. Any future regression that
+        // reintroduces post-codesign substitution will fail here.
+        XCTAssertFalse(snapshotStr.contains("__INSTALL_PREFIX__"),
+            "embedded plist must contain the real bundle path at codesign time")
+        XCTAssertTrue(snapshotStr.contains(paths.bundleAppPath),
+            "embedded plist must reference the install path at codesign time")
+        XCTAssertTrue(snapshotStr.contains("\(paths.bundleAppPath)/Contents/MacOS/crm-mac"),
+            "embedded plist's ProgramArguments[0] must point at the install-time binary")
+
+        // Final on-disk plist (post-rename) must be byte-identical to
+        // the codesign-time snapshot — proves no mutation between
+        // codesign and the end of install.
+        let finalPlist = try fs.read(from: paths.bundlePlistPath)
+        XCTAssertEqual(snapshot, finalPlist,
+            "plist content must NOT change between codesign and final install — would invalidate the codesign seal")
+
+        // Plist must still parse as a valid plist.
         XCTAssertNoThrow(
-            try PropertyListSerialization.propertyList(from: plistData, options: [], format: nil),
-            "substituted plist must still parse as a valid plist")
+            try PropertyListSerialization.propertyList(from: finalPlist, options: [], format: nil),
+            "embedded plist must be a valid plist")
     }
 
-    func testSubstitutionXMLEscapesUnusualPaths() async throws {
-        // Substituting a raw bundle path into already-rendered XML
-        // breaks `LaunchAgentPlist`'s XML-escape guarantee for
-        // unusual home directory characters (`&`, `<`, `>`, `"`,
-        // `'`). The installer must apply the same escape function
-        // during substitution so the resulting plist still parses.
+    func testPlistXMLEscapesUnusualPaths() async throws {
+        // Embedding a raw bundle path into the plist must XML-escape
+        // characters like `&`, `<`, `>`, `"`, `'`. The
+        // LaunchAgentPlist renderer handles this — this test pins
+        // that the installer goes through the renderer (not a raw
+        // string-concat) for unusual home directory paths.
         let paths = LifecyclePaths(
             configDirPath: "/tmp/o&malley/cfg",
             binDirPath: "/tmp/o&malley/cfg/bin",
@@ -68,7 +93,6 @@ final class InstallerPlaceholderSubstitutionTests: XCTestCase {
             logsDirPath: "/tmp/o&malley/logs",
             stdoutLogPath: "/tmp/o&malley/logs/stdout.log",
             stderrLogPath: "/tmp/o&malley/logs/stderr.log",
-            // The bundle app path contains `&` — XML-significant.
             bundleAppPath: "/tmp/o&malley/cfg/crm-mac.app",
             bundleBinaryPath: "/tmp/o&malley/cfg/crm-mac.app/Contents/MacOS/crm-mac",
             bundlePlistPath: "/tmp/o&malley/cfg/crm-mac.app/Contents/Library/LaunchAgents/\(Daemon.label).plist",
@@ -95,71 +119,49 @@ final class InstallerPlaceholderSubstitutionTests: XCTestCase {
             piURL: URL(string: "https://x")!,
             pairingToken: "tk",
             hostname: "mac-1"))
-        // The embedded plist must parse — proves the substitution
-        // didn't break the XML.
         let plistData = try fs.read(from: paths.bundlePlistPath)
         XCTAssertNoThrow(
             try PropertyListSerialization.propertyList(from: plistData, options: [], format: nil),
-            "substitution must XML-escape the bundle path")
-        // The decoded ProgramArguments[0] must round-trip back to the
-        // raw bundle binary path (the escape is invisible to the
-        // plist parser).
+            "embedded plist must XML-escape the bundle path")
+        // ProgramArguments[0] must round-trip back to the raw bundle
+        // binary path (the escape is invisible to the plist parser).
         let parsed = try PropertyListSerialization.propertyList(
             from: plistData, options: [], format: nil) as! [String: Any]
         let args = parsed["ProgramArguments"] as! [String]
         XCTAssertEqual(args.first, paths.bundleBinaryPath,
             "decoded ProgramArguments[0] must equal the raw bundleBinaryPath after XML-decode")
     }
+}
 
-    func testSubstitutionIdempotentViaRegisterOnly() async throws {
-        // Set up an already-installed bundle whose embedded plist
-        // has the placeholder already replaced. Run register-only
-        // (which calls the substitute helper) — a second run on the
-        // same install must be a no-op (no placeholder to substitute).
-        let paths = TestPaths.make()
-        let fs = InMemoryFilesystem()
-        fs.seedFile(at: "/tmp/source/crm-mac")
-        // Existing bundle with the placeholder already substituted.
-        let alreadySubstituted = """
-        <?xml version="1.0" encoding="UTF-8"?>
-        <plist version="1.0"><dict>
-        <key>ProgramArguments</key>
-        <array><string>\(paths.bundleAppPath)/Contents/MacOS/crm-mac</string></array>
-        </dict></plist>
-        """
-        try fs.createDirectory(at: paths.bundleAppPath)
-        try fs.write(Data("bin".utf8), to: paths.bundleBinaryPath)
-        try fs.write(Data(alreadySubstituted.utf8), to: paths.bundlePlistPath)
-        let cfg = DaemonConfig(
-            piURL: URL(string: "https://x")!,
-            hostID: UUID(),
-            hostname: "mac-1",
-            installedAt: Date())
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
-        try fs.write(try encoder.encode(cfg), to: paths.configFilePath)
-        let keychain = InMemoryKeychainStore(initial: "k")
-        let exec = FakeExecutableAdapter(currentExecutablePath: "/tmp/source/crm-mac")
-        let installer = Installer(InstallerDependencies(
-            paths: paths,
-            filesystem: fs,
-            executable: exec,
-            keychain: keychain,
-            agentService: FakeAgentService(),
-            processSignaller: FakeProcessSignaller(),
-            bundleAssembler: BundleAssembler(filesystem: fs, executable: exec),
-            piClientFactory: { url in
-                PiClient(baseURL: url, transport: LifecycleMockTransport([]).asTransport(), sleep: noopSleep)
-            },
-            clock: FixedClock(),
-            logger: NoopLogger()))
-        _ = try await installer.run(InstallRequest(
-            piURL: URL(string: "https://x")!,
-            pairingToken: "ignored",
-            hostname: "ignored",
-            registerOnly: true))
-        // File unchanged — idempotent.
-        let post = try fs.read(from: paths.bundlePlistPath)
-        XCTAssertEqual(post, Data(alreadySubstituted.utf8))
+/// Test double that snapshots the embedded LaunchAgent plist at the
+/// instant `adhocCodesignBundle` is called. Lets a test assert what
+/// the codesign pass actually sealed, separately from what the final
+/// on-disk plist contains.
+final class SnapshottingFakeExecutableAdapter: ExecutableAdapter, @unchecked Sendable {
+    private let inner: FakeExecutableAdapter
+    private let filesystem: InMemoryFilesystem
+    private(set) var plistAtCodesignTime: Data?
+
+    init(currentExecutablePath: String, filesystem: InMemoryFilesystem) {
+        self.inner = FakeExecutableAdapter(currentExecutablePath: currentExecutablePath)
+        self.filesystem = filesystem
+    }
+
+    var bundleCodesignCalls: [FakeExecutableAdapter.BundleCodesignCall] {
+        inner.bundleCodesignCalls
+    }
+
+    func currentExecutablePath() throws -> String {
+        try inner.currentExecutablePath()
+    }
+
+    func adhocCodesign(path: String) throws {
+        try inner.adhocCodesign(path: path)
+    }
+
+    func adhocCodesignBundle(bundlePath: String, identifier: String) throws {
+        let plistPath = "\(bundlePath)/\(BundleAssembler.launchAgentPlistRelativePath)"
+        plistAtCodesignTime = try? filesystem.read(from: plistPath)
+        try inner.adhocCodesignBundle(bundlePath: bundlePath, identifier: identifier)
     }
 }

--- a/mac-daemon/Tests/CRMMacLifecycleTests/InstallerPlaceholderSubstitutionTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/InstallerPlaceholderSubstitutionTests.swift
@@ -1,6 +1,5 @@
 // InstallerPlaceholderSubstitutionTests cover the
-// `__INSTALL_PREFIX__` substitution step (plan D7 step 5, D14
-// InstallerPlaceholderSubstitutionTests). The build-time shell
+// `__INSTALL_PREFIX__` substitution step. The build-time shell
 // script writes the placeholder; the install-time Swift code
 // substitutes it with the real bundle app path before
 // SMAppService.register reads the file.
@@ -54,12 +53,11 @@ final class InstallerPlaceholderSubstitutionTests: XCTestCase {
     }
 
     func testSubstitutionXMLEscapesUnusualPaths() async throws {
-        // Per Codex r6 #5: substituting a raw bundle path into
-        // already-rendered XML breaks `LaunchAgentPlist`'s
-        // XML-escape guarantee for unusual home directory characters
-        // (`&`, `<`, `>`, `"`, `'`). The installer must apply the
-        // same escape function during substitution so the resulting
-        // plist still parses.
+        // Substituting a raw bundle path into already-rendered XML
+        // breaks `LaunchAgentPlist`'s XML-escape guarantee for
+        // unusual home directory characters (`&`, `<`, `>`, `"`,
+        // `'`). The installer must apply the same escape function
+        // during substitution so the resulting plist still parses.
         let paths = LifecyclePaths(
             configDirPath: "/tmp/o&malley/cfg",
             binDirPath: "/tmp/o&malley/cfg/bin",

--- a/mac-daemon/Tests/CRMMacLifecycleTests/InstallerPlaceholderSubstitutionTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/InstallerPlaceholderSubstitutionTests.swift
@@ -10,6 +10,7 @@
 // substituteInstallPrefixPlaceholder helper would require exposing
 // it; the end-to-end assertion is sufficient.
 import XCTest
+import CRMMacCore
 @testable import CRMMacLifecycle
 @testable import CRMMacPiClient
 

--- a/mac-daemon/Tests/CRMMacLifecycleTests/InstallerPreflightTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/InstallerPreflightTests.swift
@@ -4,11 +4,20 @@ import CRMMacCore
 @testable import CRMMacPiClient
 
 final class InstallerPreflightTests: XCTestCase {
-    func testRefusesOnExistingBinary() async {
+    func testRefusesOnExistingBundle() async {
         let paths = TestPaths.make()
         let fs = InMemoryFilesystem()
         fs.seedFile(at: "/tmp/source/crm-mac")
-        try? fs.write(Data(), to: paths.binaryPath)
+        try? fs.createDirectory(at: paths.bundleAppPath)
+        let installer = makeInstaller(paths: paths, fs: fs)
+        await assertThrowsAlreadyInstalled(installer)
+    }
+
+    func testRefusesOnExistingLegacyBinary() async {
+        let paths = TestPaths.make()
+        let fs = InMemoryFilesystem()
+        fs.seedFile(at: "/tmp/source/crm-mac")
+        try? fs.write(Data("old".utf8), to: paths.legacyBinaryPath)
         let installer = makeInstaller(paths: paths, fs: fs)
         await assertThrowsAlreadyInstalled(installer)
     }
@@ -31,29 +40,14 @@ final class InstallerPreflightTests: XCTestCase {
         await assertThrowsAlreadyInstalled(installer)
     }
 
-    func testRefusesWhenLaunchctlSpawnFails() async {
-        // The launchctl probe throws (spawn failure) — preflight
-        // treats the inconclusive probe as "existing install" and
-        // refuses, rather than failing open.
+    func testRefusesWhenAgentServiceReportsEnabled() async {
         let paths = TestPaths.make()
         let fs = InMemoryFilesystem()
         fs.seedFile(at: "/tmp/source/crm-mac")
-        let launchctl = FakeLaunchctlRunner()
-        launchctl.printServiceThrowsOnce = NSError(
-            domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "spawn refused"])
-        let installer = makeInstaller(paths: paths, fs: fs, launchctl: launchctl)
-        await assertThrowsAlreadyInstalled(installer)
-    }
-
-    func testRefusesWhenLaunchctlReportsRegistered() async {
-        let paths = TestPaths.make()
-        let fs = InMemoryFilesystem()
-        fs.seedFile(at: "/tmp/source/crm-mac")
-        var script = FakeLaunchctlRunner.Script()
-        // bootstrap default 0 is fine; printService 0 means "registered"
-        script.printService = [0]
-        let launchctl = FakeLaunchctlRunner(script: script)
-        let installer = makeInstaller(paths: paths, fs: fs, launchctl: launchctl)
+        var script = FakeAgentService.Script()
+        script.statusSequence = [.enabled]
+        let agent = FakeAgentService(script: script)
+        let installer = makeInstaller(paths: paths, fs: fs, agentService: agent)
         await assertThrowsAlreadyInstalled(installer)
     }
 
@@ -61,7 +55,8 @@ final class InstallerPreflightTests: XCTestCase {
         let paths = TestPaths.make()
         let fs = InMemoryFilesystem()
         fs.seedFile(at: "/tmp/source/crm-mac")
-        // Pretend an install exists.
+        try fs.createDirectory(at: paths.bundleAppPath)
+        try fs.write(Data("old".utf8), to: paths.bundleBinaryPath)
         let config = DaemonConfig(
             piURL: URL(string: "https://pi.example.test")!,
             hostID: UUID(uuidString: "11111111-2222-3333-4444-555555555555")!,
@@ -71,13 +66,15 @@ final class InstallerPreflightTests: XCTestCase {
         encoder.dateEncodingStrategy = .iso8601
         try fs.write(try encoder.encode(config), to: paths.configFilePath)
         let keychain = InMemoryKeychainStore(initial: "existing-key")
-        let launchctl = FakeLaunchctlRunner()
+        let exec = FakeExecutableAdapter(currentExecutablePath: "/tmp/source/crm-mac")
         let installer = Installer(InstallerDependencies(
             paths: paths,
             filesystem: fs,
-            executable: FakeExecutableAdapter(currentExecutablePath: "/tmp/source/crm-mac"),
+            executable: exec,
             keychain: keychain,
-            launchctl: launchctl,
+            agentService: FakeAgentService(),
+            processSignaller: FakeProcessSignaller(),
+            bundleAssembler: BundleAssembler(filesystem: fs, executable: exec),
             piClientFactory: { url in
                 PiClient(
                     baseURL: url,
@@ -92,9 +89,6 @@ final class InstallerPreflightTests: XCTestCase {
             pairingToken: "ignored",
             hostname: "ignored",
             upgrade: true))
-        // Upgrade does NOT POST /host — assert no transport activity.
-        // (LifecycleMockTransport throws on use; reaching here means it
-        // wasn't called.)
     }
 
     // MARK: - helpers
@@ -103,14 +97,17 @@ final class InstallerPreflightTests: XCTestCase {
         paths: LifecyclePaths,
         fs: InMemoryFilesystem,
         keychain: InMemoryKeychainStore = InMemoryKeychainStore(),
-        launchctl: FakeLaunchctlRunner = FakeLaunchctlRunner()
+        agentService: FakeAgentService = FakeAgentService()
     ) -> Installer {
-        Installer(InstallerDependencies(
+        let exec = FakeExecutableAdapter(currentExecutablePath: "/tmp/source/crm-mac")
+        return Installer(InstallerDependencies(
             paths: paths,
             filesystem: fs,
-            executable: FakeExecutableAdapter(currentExecutablePath: "/tmp/source/crm-mac"),
+            executable: exec,
             keychain: keychain,
-            launchctl: launchctl,
+            agentService: agentService,
+            processSignaller: FakeProcessSignaller(),
+            bundleAssembler: BundleAssembler(filesystem: fs, executable: exec),
             piClientFactory: { url in
                 PiClient(
                     baseURL: url,

--- a/mac-daemon/Tests/CRMMacLifecycleTests/InstallerRegisterOnlyTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/InstallerRegisterOnlyTests.swift
@@ -12,8 +12,8 @@ final class InstallerRegisterOnlyTests: XCTestCase {
         try fs.createDirectory(at: paths.bundleAppPath)
         let originalBinary = Data("untouched binary".utf8)
         try fs.write(originalBinary, to: paths.bundleBinaryPath)
-        // Existing embedded plist with placeholder already substituted
-        // (re-running register-only on a healthy install is the
+        // Existing embedded plist already references the install
+        // path (re-running register-only on a healthy install is the
         // common case).
         try fs.write(
             Data("<plist>installed</plist>".utf8),

--- a/mac-daemon/Tests/CRMMacLifecycleTests/InstallerRegisterOnlyTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/InstallerRegisterOnlyTests.swift
@@ -63,7 +63,7 @@ final class InstallerRegisterOnlyTests: XCTestCase {
         XCTAssertEqual(exec.bundleCodesignCalls.count, 0)
     }
 
-    func testRegisterOnlyRequiresExistingBundle() async {
+    func testRegisterOnlyRequiresExistingBundle() async throws {
         // Config present + api-key present, but bundle missing — the
         // operator wants `--upgrade`, not register-only.
         let paths = TestPaths.make()
@@ -76,7 +76,8 @@ final class InstallerRegisterOnlyTests: XCTestCase {
             installedAt: Date())
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
-        try? fs.write(try? encoder.encode(config), to: paths.configFilePath)
+        let configData = try encoder.encode(config)
+        try fs.write(configData, to: paths.configFilePath)
         let exec = FakeExecutableAdapter(currentExecutablePath: "/tmp/source/crm-mac")
         let installer = Installer(InstallerDependencies(
             paths: paths,

--- a/mac-daemon/Tests/CRMMacLifecycleTests/InstallerRegisterOnlyTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/InstallerRegisterOnlyTests.swift
@@ -4,12 +4,20 @@ import CRMMacCore
 @testable import CRMMacPiClient
 
 final class InstallerRegisterOnlyTests: XCTestCase {
-    func testRegisterOnlyDoesNotTouchBinaryOrKeychain() async throws {
+    func testRegisterOnlyDoesNotTouchBundleOrKeychain() async throws {
         let paths = TestPaths.make()
         let fs = InMemoryFilesystem()
         fs.seedFile(at: "/tmp/source/crm-mac")
+        // Existing bundle on disk.
+        try fs.createDirectory(at: paths.bundleAppPath)
         let originalBinary = Data("untouched binary".utf8)
-        try fs.write(originalBinary, to: paths.binaryPath)
+        try fs.write(originalBinary, to: paths.bundleBinaryPath)
+        // Existing embedded plist with placeholder already substituted
+        // (re-running register-only on a healthy install is the
+        // common case).
+        try fs.write(
+            Data("<plist>installed</plist>".utf8),
+            to: paths.bundlePlistPath)
         let config = DaemonConfig(
             piURL: URL(string: "https://pi.example.test")!,
             hostID: UUID(uuidString: "11111111-2222-3333-4444-555555555555")!,
@@ -19,14 +27,16 @@ final class InstallerRegisterOnlyTests: XCTestCase {
         encoder.dateEncodingStrategy = .iso8601
         try fs.write(try encoder.encode(config), to: paths.configFilePath)
         let keychain = InMemoryKeychainStore(initial: "existing-key")
-        let launchctl = FakeLaunchctlRunner()
+        let agentService = FakeAgentService()
         let exec = FakeExecutableAdapter(currentExecutablePath: "/tmp/source/crm-mac")
         let installer = Installer(InstallerDependencies(
             paths: paths,
             filesystem: fs,
             executable: exec,
             keychain: keychain,
-            launchctl: launchctl,
+            agentService: agentService,
+            processSignaller: FakeProcessSignaller(),
+            bundleAssembler: BundleAssembler(filesystem: fs, executable: exec),
             piClientFactory: { url in
                 PiClient(
                     baseURL: url,
@@ -41,14 +51,99 @@ final class InstallerRegisterOnlyTests: XCTestCase {
             pairingToken: "ignored",
             hostname: "ignored",
             registerOnly: true))
-        XCTAssertEqual(summary.binaryPath, paths.binaryPath)
+        XCTAssertEqual(summary.bundleBinaryPath, paths.bundleBinaryPath)
         // Binary content unchanged.
-        XCTAssertEqual(try fs.read(from: paths.binaryPath), originalBinary)
+        XCTAssertEqual(try fs.read(from: paths.bundleBinaryPath), originalBinary)
         // Keychain unchanged.
         XCTAssertEqual(keychain.currentValue, "existing-key")
-        // bootstrap was called, NO bootout.
-        XCTAssertEqual(launchctl.bootstrapCalls.count, 1)
-        XCTAssertEqual(launchctl.bootoutCalls.count, 0)
-        XCTAssertEqual(exec.codesignCalls.count, 0)
+        // register was called; unregister was NOT.
+        XCTAssertEqual(agentService.registerCalls, 1)
+        XCTAssertEqual(agentService.unregisterCalls, 0)
+        // No re-assembly: bundle codesign was NOT called.
+        XCTAssertEqual(exec.bundleCodesignCalls.count, 0)
+    }
+
+    func testRegisterOnlyRequiresExistingBundle() async {
+        // Config present + api-key present, but bundle missing — the
+        // operator wants `--upgrade`, not register-only.
+        let paths = TestPaths.make()
+        let fs = InMemoryFilesystem()
+        fs.seedFile(at: "/tmp/source/crm-mac")
+        let config = DaemonConfig(
+            piURL: URL(string: "https://pi.example.test")!,
+            hostID: UUID(),
+            hostname: "mac-1",
+            installedAt: Date())
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        try? fs.write(try? encoder.encode(config), to: paths.configFilePath)
+        let exec = FakeExecutableAdapter(currentExecutablePath: "/tmp/source/crm-mac")
+        let installer = Installer(InstallerDependencies(
+            paths: paths,
+            filesystem: fs,
+            executable: exec,
+            keychain: InMemoryKeychainStore(initial: "existing-key"),
+            agentService: FakeAgentService(),
+            processSignaller: FakeProcessSignaller(),
+            bundleAssembler: BundleAssembler(filesystem: fs, executable: exec),
+            piClientFactory: { url in
+                PiClient(baseURL: url, transport: LifecycleMockTransport([]).asTransport(), sleep: noopSleep)
+            },
+            clock: FixedClock(),
+            logger: NoopLogger()))
+        do {
+            _ = try await installer.run(InstallRequest(
+                piURL: URL(string: "https://x")!,
+                pairingToken: "x", hostname: "x", registerOnly: true))
+            XCTFail("expected noExistingInstall")
+        } catch InstallError.noExistingInstall {
+            // ok
+        } catch {
+            XCTFail("got \(error)")
+        }
+    }
+
+    func testRegisterOnlyToleratesAlreadyRegistered() async throws {
+        // Existing bundle + script the FakeAgentService to return
+        // .alreadyRegistered. Register-only should succeed.
+        let paths = TestPaths.make()
+        let fs = InMemoryFilesystem()
+        fs.seedFile(at: "/tmp/source/crm-mac")
+        try fs.createDirectory(at: paths.bundleAppPath)
+        try fs.write(Data("bin".utf8), to: paths.bundleBinaryPath)
+        try fs.write(Data("<plist/>".utf8), to: paths.bundlePlistPath)
+        let config = DaemonConfig(
+            piURL: URL(string: "https://pi.example.test")!,
+            hostID: UUID(),
+            hostname: "mac-1",
+            installedAt: Date())
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        try fs.write(try encoder.encode(config), to: paths.configFilePath)
+        let keychain = InMemoryKeychainStore(initial: "k")
+        var script = FakeAgentService.Script()
+        script.nextRegisterOutcome = .alreadyRegistered
+        let agent = FakeAgentService(script: script)
+        let exec = FakeExecutableAdapter(currentExecutablePath: "/tmp/source/crm-mac")
+        let installer = Installer(InstallerDependencies(
+            paths: paths,
+            filesystem: fs,
+            executable: exec,
+            keychain: keychain,
+            agentService: agent,
+            processSignaller: FakeProcessSignaller(),
+            bundleAssembler: BundleAssembler(filesystem: fs, executable: exec),
+            piClientFactory: { url in
+                PiClient(baseURL: url, transport: LifecycleMockTransport([]).asTransport(), sleep: noopSleep)
+            },
+            clock: FixedClock(),
+            logger: NoopLogger()))
+        _ = try await installer.run(InstallRequest(
+            piURL: URL(string: "https://x")!,
+            pairingToken: "x",
+            hostname: "x",
+            registerOnly: true))
+        XCTAssertEqual(agent.registerCalls, 1)
+        XCTAssertEqual(agent.registerAlreadyRegisteredCount, 1)
     }
 }

--- a/mac-daemon/Tests/CRMMacLifecycleTests/InstallerRollbackFailureTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/InstallerRollbackFailureTests.swift
@@ -85,7 +85,11 @@ final class InstallerRollbackFailureTests: XCTestCase {
                 upgrade: true))
             XCTFail("expected upgradeRollbackFailed")
         } catch InstallError.upgradeRollbackFailed(let original, let restore, let backup) {
-            XCTAssertTrue(original.contains("registrationFailed") || original.contains("agentRegistrationFailed"),
+            // The original error is the InstallError.agentRegistrationFailed
+            // case; its `description` renders "agent registration failed: ..."
+            // (lowercase). The composed-error path passes that rendered
+            // string through `String(describing:)`.
+            XCTAssertTrue(original.lowercased().contains("registration") || original.lowercased().contains("registrationfailed"),
                 "original error must describe the register failure; got \(original)")
             XCTAssertTrue(restore.contains("injected rename failure"),
                 "restore error must describe the rename failure; got \(restore)")

--- a/mac-daemon/Tests/CRMMacLifecycleTests/InstallerRollbackFailureTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/InstallerRollbackFailureTests.swift
@@ -1,5 +1,5 @@
 // InstallerRollbackFailureTests cover the `upgradeRollbackFailed`
-// composed-error path (plan D8 U8 + Codex round-2 #1). If the
+// composed-error path. If the
 // initial register fails AND the backup-restore rename ALSO fails,
 // the installer must surface BOTH errors so the operator knows the
 // previous bundle is stranded at `<bundle>.backup.<pid>`.

--- a/mac-daemon/Tests/CRMMacLifecycleTests/InstallerRollbackFailureTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/InstallerRollbackFailureTests.swift
@@ -7,6 +7,7 @@
 // Uses a FilesystemAdapter that delegates to InMemoryFilesystem but
 // injects a one-shot rename failure for the restore step.
 import XCTest
+import CRMMacCore
 @testable import CRMMacLifecycle
 @testable import CRMMacPiClient
 

--- a/mac-daemon/Tests/CRMMacLifecycleTests/InstallerRollbackFailureTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/InstallerRollbackFailureTests.swift
@@ -1,0 +1,97 @@
+// InstallerRollbackFailureTests cover the `upgradeRollbackFailed`
+// composed-error path (plan D8 U8 + Codex round-2 #1). If the
+// initial register fails AND the backup-restore rename ALSO fails,
+// the installer must surface BOTH errors so the operator knows the
+// previous bundle is stranded at `<bundle>.backup.<pid>`.
+//
+// Uses a FilesystemAdapter that delegates to InMemoryFilesystem but
+// injects a one-shot rename failure for the restore step.
+import XCTest
+@testable import CRMMacLifecycle
+@testable import CRMMacPiClient
+
+/// Filesystem fake that delegates to an underlying `InMemoryFilesystem`
+/// and fails a rename when the source path matches a configured
+/// prefix. Used to exercise the upgrade rollback's
+/// restore-backup-failure branch.
+final class RenameFailingFilesystem: FilesystemAdapter, @unchecked Sendable {
+    let underlying: InMemoryFilesystem
+    /// If non-nil, any rename whose `from` path begins with this
+    /// prefix throws an injected ioError instead of succeeding.
+    var failRenameFromPrefix: String?
+
+    init(_ underlying: InMemoryFilesystem) {
+        self.underlying = underlying
+    }
+    func createDirectory(at path: String) throws { try underlying.createDirectory(at: path) }
+    func copy(from src: String, to dst: String) throws { try underlying.copy(from: src, to: dst) }
+    func rename(from src: String, to dst: String) throws {
+        if let prefix = failRenameFromPrefix, src.hasPrefix(prefix) {
+            throw FilesystemError.ioError("injected rename failure for \(src)")
+        }
+        try underlying.rename(from: src, to: dst)
+    }
+    func remove(at path: String) throws { try underlying.remove(at: path) }
+    func makeExecutable(at path: String) throws { try underlying.makeExecutable(at: path) }
+    func fileExists(at path: String) -> Bool { underlying.fileExists(at: path) }
+    func write(_ data: Data, to path: String) throws { try underlying.write(data, to: path) }
+    func read(from path: String) throws -> Data { try underlying.read(from: path) }
+}
+
+final class InstallerRollbackFailureTests: XCTestCase {
+    func testUpgradeRollbackFailureSurfacesComposedError() async throws {
+        let paths = TestPaths.make()
+        let inner = InMemoryFilesystem()
+        inner.seedFile(at: "/tmp/source/crm-mac")
+        try inner.createDirectory(at: paths.bundleAppPath)
+        try inner.write(Data("old-bin".utf8), to: paths.bundleBinaryPath)
+        let config = DaemonConfig(
+            piURL: URL(string: "https://x")!,
+            hostID: UUID(),
+            hostname: "mac-1",
+            installedAt: Date())
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        try inner.write(try encoder.encode(config), to: paths.configFilePath)
+        let fs = RenameFailingFilesystem(inner)
+        // Make any rename from the backup path fail.
+        let backupPrefix = "\(paths.configDirPath)/crm-mac.app.backup."
+        fs.failRenameFromPrefix = backupPrefix
+
+        var script = FakeAgentService.Script()
+        script.registerThrows = .registrationFailed(
+            message: "denied", requiresApproval: true)
+        let agent = FakeAgentService(script: script)
+        let exec = FakeExecutableAdapter(currentExecutablePath: "/tmp/source/crm-mac")
+        let installer = Installer(InstallerDependencies(
+            paths: paths,
+            filesystem: fs,
+            executable: exec,
+            keychain: InMemoryKeychainStore(initial: "k"),
+            agentService: agent,
+            processSignaller: FakeProcessSignaller(),
+            bundleAssembler: BundleAssembler(filesystem: fs, executable: exec),
+            piClientFactory: { url in
+                PiClient(baseURL: url, transport: LifecycleMockTransport([]).asTransport(), sleep: noopSleep)
+            },
+            clock: FixedClock(),
+            logger: NoopLogger()))
+        do {
+            _ = try await installer.run(InstallRequest(
+                piURL: URL(string: "https://x")!,
+                pairingToken: "ignored",
+                hostname: "ignored",
+                upgrade: true))
+            XCTFail("expected upgradeRollbackFailed")
+        } catch InstallError.upgradeRollbackFailed(let original, let restore, let backup) {
+            XCTAssertTrue(original.contains("registrationFailed") || original.contains("agentRegistrationFailed"),
+                "original error must describe the register failure; got \(original)")
+            XCTAssertTrue(restore.contains("injected rename failure"),
+                "restore error must describe the rename failure; got \(restore)")
+            XCTAssertTrue(backup.hasPrefix(backupPrefix),
+                "composed error must carry the surviving backup path; got \(backup)")
+        } catch {
+            XCTFail("got \(error)")
+        }
+    }
+}

--- a/mac-daemon/Tests/CRMMacLifecycleTests/InstallerUpgradeStopsRunningDaemonTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/InstallerUpgradeStopsRunningDaemonTests.swift
@@ -53,6 +53,32 @@ final class InstallerUpgradeStopsRunningDaemonTests: XCTestCase {
         XCTAssertEqual(unchanged, Data("old binary".utf8))
     }
 
+    func testUpgradeMalformedPidfileStillRequiresFlockProbe() async throws {
+        // Per Codex r6 #3 (round-2): a present-but-unparseable
+        // pidfile during upgrade is NOT treated as "daemon not
+        // running". The flock probe is authoritative; if it reports
+        // the lock is still held the upgrade fails with
+        // daemonStillRunning(pid: 0) rather than stomping on a
+        // still-running daemon.
+        let (installer, _, _, signaller, _) = try makeUpgradeHarness(
+            pidfileContents: "garbage-not-a-pid")
+        signaller.nextPidfileReleaseResult = false
+        do {
+            _ = try await installer.run(InstallRequest(
+                piURL: URL(string: "https://x")!,
+                pairingToken: "ignored",
+                hostname: "ignored",
+                upgrade: true))
+            XCTFail("expected daemonStillRunning")
+        } catch InstallError.daemonStillRunning(let pid) {
+            XCTAssertEqual(pid, 0, "unparseable pidfile → pid surfaces as 0")
+        } catch {
+            XCTFail("got \(error)")
+        }
+        // Critically: no SIGTERM was sent (we couldn't parse a pid).
+        XCTAssertEqual(signaller.sigtermCalls.count, 0)
+    }
+
     func testUpgradeSkipsSIGTERMWhenNoPidfile() async throws {
         // No pidfile -> no SIGTERM call. The unregister is still
         // invoked because that's a separate SMAppService call.

--- a/mac-daemon/Tests/CRMMacLifecycleTests/InstallerUpgradeStopsRunningDaemonTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/InstallerUpgradeStopsRunningDaemonTests.swift
@@ -1,5 +1,5 @@
 // InstallerUpgradeStopsRunningDaemonTests cover the stop-the-running-
-// daemon step on the upgrade path (plan D7, D8 U2, D24). The Installer
+// daemon step on the upgrade path. The Installer
 // reads the pidfile, sends SIGTERM via ProcessSignaller, and polls
 // for release. Failure during the poll surfaces as
 // InstallError.daemonStillRunning(pid:).
@@ -54,12 +54,11 @@ final class InstallerUpgradeStopsRunningDaemonTests: XCTestCase {
     }
 
     func testUpgradeMalformedPidfileStillRequiresFlockProbe() async throws {
-        // Per Codex r6 #3 (round-2): a present-but-unparseable
-        // pidfile during upgrade is NOT treated as "daemon not
-        // running". The flock probe is authoritative; if it reports
-        // the lock is still held the upgrade fails with
-        // daemonStillRunning(pid: 0) rather than stomping on a
-        // still-running daemon.
+        // A present-but-unparseable pidfile during upgrade is NOT
+        // treated as "daemon not running". The flock probe is
+        // authoritative; if it reports the lock is still held the
+        // upgrade fails with daemonStillRunning(pid: 0) rather than
+        // stomping on a still-running daemon.
         let (installer, _, _, signaller, _) = try makeUpgradeHarness(
             pidfileContents: "garbage-not-a-pid")
         signaller.nextPidfileReleaseResult = false

--- a/mac-daemon/Tests/CRMMacLifecycleTests/InstallerUpgradeStopsRunningDaemonTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/InstallerUpgradeStopsRunningDaemonTests.swift
@@ -1,0 +1,111 @@
+// InstallerUpgradeStopsRunningDaemonTests cover the stop-the-running-
+// daemon step on the upgrade path (plan D7, D8 U2, D24). The Installer
+// reads the pidfile, sends SIGTERM via ProcessSignaller, and polls
+// for release. Failure during the poll surfaces as
+// InstallError.daemonStillRunning(pid:).
+import XCTest
+import CRMMacCore
+@testable import CRMMacLifecycle
+@testable import CRMMacPiClient
+
+final class InstallerUpgradeStopsRunningDaemonTests: XCTestCase {
+
+    func testUpgradeStopsRunningDaemonBeforeReplacement() async throws {
+        let (installer, fs, agentService, signaller, paths) = try makeUpgradeHarness(
+            pidfileContents: "98765")
+
+        _ = try await installer.run(InstallRequest(
+            piURL: URL(string: "https://x")!,
+            pairingToken: "ignored",
+            hostname: "ignored",
+            upgrade: true))
+
+        // SIGTERM was sent to the recorded pid.
+        XCTAssertEqual(signaller.sigtermCalls, [98765])
+        // Wait was called on the pidfile path.
+        XCTAssertEqual(signaller.waitForPidfileReleaseCalls, [paths.pidfilePath])
+        // SMAppService.unregister was called (D8 U2).
+        XCTAssertGreaterThanOrEqual(agentService.unregisterCalls, 1)
+        // Bundle in place after upgrade.
+        XCTAssertTrue(fs.fileExists(at: paths.bundleAppPath))
+    }
+
+    func testUpgradeFailsCleanlyWhenDaemonRefusesToStop() async throws {
+        let (installer, fs, _, signaller, paths) = try makeUpgradeHarness(
+            pidfileContents: "98765")
+        signaller.nextPidfileReleaseResult = false
+
+        do {
+            _ = try await installer.run(InstallRequest(
+                piURL: URL(string: "https://x")!,
+                pairingToken: "ignored",
+                hostname: "ignored",
+                upgrade: true))
+            XCTFail("expected daemonStillRunning")
+        } catch InstallError.daemonStillRunning(let pid) {
+            XCTAssertEqual(pid, 98765)
+        } catch {
+            XCTFail("got \(error)")
+        }
+        // Bundle UNCHANGED — no backup-then-swap started because we
+        // refused before U3.
+        let unchanged = try fs.read(from: paths.bundleBinaryPath)
+        XCTAssertEqual(unchanged, Data("old binary".utf8))
+    }
+
+    func testUpgradeSkipsSIGTERMWhenNoPidfile() async throws {
+        // No pidfile -> no SIGTERM call. The unregister is still
+        // invoked because that's a separate SMAppService call.
+        let (installer, _, agentService, signaller, _) = try makeUpgradeHarness(
+            pidfileContents: nil)
+        _ = try await installer.run(InstallRequest(
+            piURL: URL(string: "https://x")!,
+            pairingToken: "ignored",
+            hostname: "ignored",
+            upgrade: true))
+        XCTAssertEqual(signaller.sigtermCalls.count, 0)
+        XCTAssertGreaterThanOrEqual(agentService.unregisterCalls, 1)
+    }
+
+    // MARK: - helper
+
+    private func makeUpgradeHarness(
+        pidfileContents: String?
+    ) throws -> (Installer, InMemoryFilesystem, FakeAgentService, FakeProcessSignaller, LifecyclePaths) {
+        let paths = TestPaths.make()
+        let fs = InMemoryFilesystem()
+        fs.seedFile(at: "/tmp/source/crm-mac")
+        try fs.createDirectory(at: paths.bundleAppPath)
+        try fs.write(Data("old binary".utf8), to: paths.bundleBinaryPath)
+        if let pid = pidfileContents {
+            try fs.write(Data(pid.utf8), to: paths.pidfilePath)
+        }
+        let config = DaemonConfig(
+            piURL: URL(string: "https://pi.example.test")!,
+            hostID: UUID(uuidString: "11111111-2222-3333-4444-555555555555")!,
+            hostname: "mac-1",
+            installedAt: Date())
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        try fs.write(try encoder.encode(config), to: paths.configFilePath)
+
+        let agentService = FakeAgentService()
+        let signaller = FakeProcessSignaller()
+        let exec = FakeExecutableAdapter(currentExecutablePath: "/tmp/source/crm-mac")
+        let installer = Installer(InstallerDependencies(
+            paths: paths,
+            filesystem: fs,
+            executable: exec,
+            keychain: InMemoryKeychainStore(initial: "k"),
+            agentService: agentService,
+            processSignaller: signaller,
+            bundleAssembler: BundleAssembler(filesystem: fs, executable: exec),
+            piClientFactory: { url in
+                PiClient(baseURL: url, transport: LifecycleMockTransport([]).asTransport(), sleep: noopSleep)
+            },
+            clock: FixedClock(),
+            logger: NoopLogger(),
+            stopDaemonTimeoutSeconds: 1))
+        return (installer, fs, agentService, signaller, paths)
+    }
+}

--- a/mac-daemon/Tests/CRMMacLifecycleTests/InstallerUpgradeStopsRunningDaemonTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/InstallerUpgradeStopsRunningDaemonTests.swift
@@ -24,7 +24,8 @@ final class InstallerUpgradeStopsRunningDaemonTests: XCTestCase {
         XCTAssertEqual(signaller.sigtermCalls, [98765])
         // Wait was called on the pidfile path.
         XCTAssertEqual(signaller.waitForPidfileReleaseCalls, [paths.pidfilePath])
-        // SMAppService.unregister was called (D8 U2).
+        // SMAppService.unregister was called as part of the
+        // stop-the-running-daemon step.
         XCTAssertGreaterThanOrEqual(agentService.unregisterCalls, 1)
         // Bundle in place after upgrade.
         XCTAssertTrue(fs.fileExists(at: paths.bundleAppPath))
@@ -47,8 +48,8 @@ final class InstallerUpgradeStopsRunningDaemonTests: XCTestCase {
         } catch {
             XCTFail("got \(error)")
         }
-        // Bundle UNCHANGED — no backup-then-swap started because we
-        // refused before U3.
+        // Bundle UNCHANGED — no backup-then-swap started because the
+        // stop step refused before the backup-rename.
         let unchanged = try fs.read(from: paths.bundleBinaryPath)
         XCTAssertEqual(unchanged, Data("old binary".utf8))
     }

--- a/mac-daemon/Tests/CRMMacLifecycleTests/InstallerUpgradeTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/InstallerUpgradeTests.swift
@@ -5,30 +5,33 @@ import CRMMacCore
 
 final class InstallerUpgradeTests: XCTestCase {
     func testUpgradeDoesNotPostHost() async throws {
-        let (installer, fs, launchctl, _, paths, transport) = try prepareExistingInstall()
+        let (installer, fs, agentService, _, paths, transport, _) = try prepareExistingInstall()
         let summary = try await installer.run(InstallRequest(
             piURL: URL(string: "https://pi.example.test")!,
             pairingToken: "ignored",
             hostname: "ignored",
             upgrade: true))
         XCTAssertEqual(transport.invocations.count, 0, "upgrade must NOT call POST /host")
-        XCTAssertTrue(fs.fileExists(at: paths.binaryPath))
-        // bootout then bootstrap.
-        XCTAssertEqual(launchctl.bootoutCalls.count, 1)
-        XCTAssertEqual(launchctl.bootstrapCalls.count, 1)
-        XCTAssertEqual(summary.binaryPath, paths.binaryPath)
+        XCTAssertTrue(fs.fileExists(at: paths.bundleAppPath))
+        XCTAssertTrue(fs.fileExists(at: paths.bundleBinaryPath))
+        XCTAssertGreaterThanOrEqual(agentService.unregisterCalls, 1)
+        XCTAssertGreaterThanOrEqual(agentService.registerCalls, 1)
+        XCTAssertEqual(summary.bundleBinaryPath, paths.bundleBinaryPath)
     }
 
     func testUpgradeRefusesWithNoExistingInstall() async {
         let paths = TestPaths.make()
         let fs = InMemoryFilesystem()
         fs.seedFile(at: "/tmp/source/crm-mac")
+        let exec = FakeExecutableAdapter(currentExecutablePath: "/tmp/source/crm-mac")
         let installer = Installer(InstallerDependencies(
             paths: paths,
             filesystem: fs,
-            executable: FakeExecutableAdapter(currentExecutablePath: "/tmp/source/crm-mac"),
+            executable: exec,
             keychain: InMemoryKeychainStore(),
-            launchctl: FakeLaunchctlRunner(),
+            agentService: FakeAgentService(),
+            processSignaller: FakeProcessSignaller(),
+            bundleAssembler: BundleAssembler(filesystem: fs, executable: exec),
             piClientFactory: { url in
                 PiClient(
                     baseURL: url,
@@ -55,7 +58,9 @@ final class InstallerUpgradeTests: XCTestCase {
         let paths = TestPaths.make()
         let fs = InMemoryFilesystem()
         fs.seedFile(at: "/tmp/source/crm-mac")
-        try fs.write(Data("old binary".utf8), to: paths.binaryPath)
+        // Pre-existing bundle from a prior install.
+        try fs.createDirectory(at: paths.bundleAppPath)
+        try fs.write(Data("old binary".utf8), to: paths.bundleBinaryPath)
         let config = DaemonConfig(
             piURL: URL(string: "https://pi.example.test")!,
             hostID: UUID(uuidString: "11111111-2222-3333-4444-555555555555")!,
@@ -67,13 +72,15 @@ final class InstallerUpgradeTests: XCTestCase {
         // Primary (file-store stand-in) starts empty; legacy holds the key.
         let primary = InMemoryKeychainStore()
         let legacy = InMemoryKeychainStore(initial: "migrating-key")
-        let launchctl = FakeLaunchctlRunner()
+        let exec = FakeExecutableAdapter(currentExecutablePath: "/tmp/source/crm-mac")
         let installer = Installer(InstallerDependencies(
             paths: paths,
             filesystem: fs,
-            executable: FakeExecutableAdapter(currentExecutablePath: "/tmp/source/crm-mac"),
+            executable: exec,
             keychain: primary,
-            launchctl: launchctl,
+            agentService: FakeAgentService(),
+            processSignaller: FakeProcessSignaller(),
+            bundleAssembler: BundleAssembler(filesystem: fs, executable: exec),
             piClientFactory: { url in
                 PiClient(
                     baseURL: url,
@@ -98,12 +105,70 @@ final class InstallerUpgradeTests: XCTestCase {
         }
     }
 
-    private func prepareExistingInstall() throws -> (Installer, InMemoryFilesystem, FakeLaunchctlRunner, InMemoryKeychainStore, LifecyclePaths, LifecycleMockTransport) {
+    func testUpgradeAtomicallyReplacesExistingBundle() async throws {
+        let (installer, fs, _, _, paths, _, _) = try prepareExistingInstall(
+            bundleFiles: [
+                ("Contents/Info.plist", Data("old-info".utf8)),
+                ("Contents/MacOS/crm-mac", Data("old-binary".utf8)),
+                ("Contents/Library/LaunchAgents/\(Daemon.label).plist", Data("old-plist".utf8)),
+            ])
+        _ = try await installer.run(InstallRequest(
+            piURL: URL(string: "https://pi.example.test")!,
+            pairingToken: "ignored",
+            hostname: "ignored",
+            upgrade: true))
+        XCTAssertTrue(fs.fileExists(at: paths.bundleAppPath))
+        // No leftover .tmp. or .backup. dirs.
+        XCTAssertFalse(fs.allDirs.contains(where: { $0.contains(".tmp.") }))
+        XCTAssertFalse(fs.allDirs.contains(where: { $0.contains(".backup.") }))
+        XCTAssertFalse(fs.allPaths.contains(where: { $0.contains(".tmp.") }))
+        XCTAssertFalse(fs.allPaths.contains(where: { $0.contains(".backup.") }))
+        // New binary content replaces old.
+        let newBinary = try fs.read(from: paths.bundleBinaryPath)
+        XCTAssertNotEqual(newBinary, Data("old-binary".utf8),
+            "upgrade must replace the old bundle content with the new")
+    }
+
+    func testUpgradeAssemblyFailureRollsBackToOldBundle() async throws {
+        let oldInfoBytes = Data("old-info".utf8)
+        let (installer, fs, _, _, paths, _, exec) = try prepareExistingInstall(
+            bundleFiles: [
+                ("Contents/Info.plist", oldInfoBytes),
+                ("Contents/MacOS/crm-mac", Data("old-binary".utf8)),
+            ])
+        exec.failBundleCodesignWith = "injected codesign failure"
+        do {
+            _ = try await installer.run(InstallRequest(
+                piURL: URL(string: "https://pi.example.test")!,
+                pairingToken: "ignored",
+                hostname: "ignored",
+                upgrade: true))
+            XCTFail("expected upgrade to fail")
+        } catch InstallError.codesignFailed {
+            // ok
+        } catch {
+            XCTFail("got \(error)")
+        }
+        // Old bundle restored.
+        let restored = try fs.read(from: "\(paths.bundleAppPath)/Contents/Info.plist")
+        XCTAssertEqual(restored, oldInfoBytes,
+            "rollback must restore the original bundle content")
+        XCTAssertFalse(fs.allDirs.contains(where: { $0.contains(".tmp.") }))
+        XCTAssertFalse(fs.allDirs.contains(where: { $0.contains(".backup.") }))
+    }
+
+    private func prepareExistingInstall(
+        bundleFiles: [(String, Data)] = []
+    ) throws -> (Installer, InMemoryFilesystem, FakeAgentService, InMemoryKeychainStore, LifecyclePaths, LifecycleMockTransport, FakeExecutableAdapter) {
         let paths = TestPaths.make()
         let fs = InMemoryFilesystem()
         fs.seedFile(at: "/tmp/source/crm-mac")
-        // Pretend an install exists.
-        try fs.write(Data("old binary".utf8), to: paths.binaryPath)
+        try fs.createDirectory(at: paths.bundleAppPath)
+        try fs.write(Data("old binary".utf8), to: paths.bundleBinaryPath)
+        for (rel, data) in bundleFiles {
+            let path = "\(paths.bundleAppPath)/\(rel)"
+            try fs.write(data, to: path)
+        }
         let config = DaemonConfig(
             piURL: URL(string: "https://pi.example.test")!,
             hostID: UUID(uuidString: "11111111-2222-3333-4444-555555555555")!,
@@ -114,14 +179,17 @@ final class InstallerUpgradeTests: XCTestCase {
         try fs.write(try encoder.encode(config), to: paths.configFilePath)
 
         let keychain = InMemoryKeychainStore(initial: "existing-key")
-        let launchctl = FakeLaunchctlRunner()
+        let agentService = FakeAgentService()
         let transport = LifecycleMockTransport([])
+        let exec = FakeExecutableAdapter(currentExecutablePath: "/tmp/source/crm-mac")
         let installer = Installer(InstallerDependencies(
             paths: paths,
             filesystem: fs,
-            executable: FakeExecutableAdapter(currentExecutablePath: "/tmp/source/crm-mac"),
+            executable: exec,
             keychain: keychain,
-            launchctl: launchctl,
+            agentService: agentService,
+            processSignaller: FakeProcessSignaller(),
+            bundleAssembler: BundleAssembler(filesystem: fs, executable: exec),
             piClientFactory: { url in
                 PiClient(
                     baseURL: url,
@@ -130,6 +198,6 @@ final class InstallerUpgradeTests: XCTestCase {
             },
             clock: FixedClock(),
             logger: NoopLogger()))
-        return (installer, fs, launchctl, keychain, paths, transport)
+        return (installer, fs, agentService, keychain, paths, transport, exec)
     }
 }

--- a/mac-daemon/Tests/CRMMacLifecycleTests/InstallerUpgradeTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/InstallerUpgradeTests.swift
@@ -164,6 +164,15 @@ final class InstallerUpgradeTests: XCTestCase {
         // No tmp or backup left behind.
         XCTAssertFalse(fs.allDirs.contains(where: { $0.contains(".tmp.") }))
         XCTAssertFalse(fs.allDirs.contains(where: { $0.contains(".backup.") }))
+        // The rollback must attempt to re-register the restored bundle
+        // (best-effort) — otherwise launchd has no record of the agent
+        // after the upgrade-time unregister, and the daemon stays
+        // stopped despite the file-level rollback succeeding. Total
+        // register calls: 1 (initial, which threw) + 1 (rollback
+        // re-register, which also throws because the fake still has
+        // registerThrows set) = 2.
+        XCTAssertGreaterThanOrEqual(agent.registerCalls, 2,
+            "rollback must attempt to re-register the restored backup")
     }
 
     func testUpgradeAssemblyFailureRollsBackToOldBundle() async throws {

--- a/mac-daemon/Tests/CRMMacLifecycleTests/InstallerUpgradeTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/InstallerUpgradeTests.swift
@@ -130,10 +130,10 @@ final class InstallerUpgradeTests: XCTestCase {
     }
 
     func testUpgradeRegistrationFailureRollsBackToOldBundle() async throws {
-        // Per plan D8 U6/U8 + Codex r6 #1: a register failure during
-        // upgrade must restore the previous install (rollback the
-        // backup-rename-swap) so the operator isn't left with a
-        // stopped daemon + new bundle they can't run.
+        // A register failure during upgrade must restore the
+        // previous install (rollback the backup-rename-swap) so the
+        // operator isn't left with a stopped daemon + new bundle
+        // they can't run.
         let oldInfoBytes = Data("old-info".utf8)
         let (installer, fs, agent, _, paths, _, _) = try prepareExistingInstall(
             bundleFiles: [

--- a/mac-daemon/Tests/CRMMacLifecycleTests/InstallerUpgradeTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/InstallerUpgradeTests.swift
@@ -129,6 +129,43 @@ final class InstallerUpgradeTests: XCTestCase {
             "upgrade must replace the old bundle content with the new")
     }
 
+    func testUpgradeRegistrationFailureRollsBackToOldBundle() async throws {
+        // Per plan D8 U6/U8 + Codex r6 #1: a register failure during
+        // upgrade must restore the previous install (rollback the
+        // backup-rename-swap) so the operator isn't left with a
+        // stopped daemon + new bundle they can't run.
+        let oldInfoBytes = Data("old-info".utf8)
+        let (installer, fs, agent, _, paths, _, _) = try prepareExistingInstall(
+            bundleFiles: [
+                ("Contents/Info.plist", oldInfoBytes),
+                ("Contents/MacOS/crm-mac", Data("old-binary".utf8)),
+            ])
+        // Make register throw — the swap should have completed first
+        // (so the new bundle is briefly at the final path) then roll
+        // back.
+        agent.script.registerThrows = .registrationFailed(
+            message: "requires approval", requiresApproval: true)
+        do {
+            _ = try await installer.run(InstallRequest(
+                piURL: URL(string: "https://x")!,
+                pairingToken: "ignored",
+                hostname: "ignored",
+                upgrade: true))
+            XCTFail("expected agentRegistrationFailed")
+        } catch InstallError.agentRegistrationFailed {
+            // ok
+        } catch {
+            XCTFail("got \(error)")
+        }
+        // Old bundle restored at the final path.
+        let restored = try fs.read(from: "\(paths.bundleAppPath)/Contents/Info.plist")
+        XCTAssertEqual(restored, oldInfoBytes,
+            "register-failure rollback must restore the original bundle content")
+        // No tmp or backup left behind.
+        XCTAssertFalse(fs.allDirs.contains(where: { $0.contains(".tmp.") }))
+        XCTAssertFalse(fs.allDirs.contains(where: { $0.contains(".backup.") }))
+    }
+
     func testUpgradeAssemblyFailureRollsBackToOldBundle() async throws {
         let oldInfoBytes = Data("old-info".utf8)
         let (installer, fs, _, _, paths, _, exec) = try prepareExistingInstall(

--- a/mac-daemon/Tests/CRMMacLifecycleTests/LaunchAgentPlistTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/LaunchAgentPlistTests.swift
@@ -3,9 +3,11 @@ import XCTest
 
 final class LaunchAgentPlistTests: XCTestCase {
     func testRenderMatchesGoldenFixture() {
+        // Post-rewrite the binary lives inside the bundle, so the
+        // fixture uses the new in-bundle path.
         let plist = LaunchAgentPlist(
             label: Daemon.label,
-            binaryPath: "/Users/example/Library/Application Support/crm-mac/bin/crm-mac",
+            binaryPath: "/Users/example/Library/Application Support/crm-mac/crm-mac.app/Contents/MacOS/crm-mac",
             configDirPath: "/Users/example/Library/Application Support/crm-mac",
             stdoutPath: "/Users/example/Library/Logs/crm-mac/stdout.log",
             stderrPath: "/Users/example/Library/Logs/crm-mac/stderr.log")
@@ -18,7 +20,7 @@ final class LaunchAgentPlistTests: XCTestCase {
             <string>xyz.spengrah.crm-mac</string>
             <key>ProgramArguments</key>
             <array>
-                <string>/Users/example/Library/Application Support/crm-mac/bin/crm-mac</string>
+                <string>/Users/example/Library/Application Support/crm-mac/crm-mac.app/Contents/MacOS/crm-mac</string>
                 <string>daemon</string>
             </array>
             <key>RunAtLoad</key>

--- a/mac-daemon/Tests/CRMMacLifecycleTests/LegacyMigrationTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/LegacyMigrationTests.swift
@@ -1,0 +1,231 @@
+// LegacyMigrationTests exercise the runLegacyMigrationIfNeeded()
+// path on the Installer's upgrade + register-only flows (plan D7).
+//
+// The migration runs ONLY when all three signals hold:
+//   1. legacy binary at paths.legacyBinaryPath
+//   2. NO bundle at paths.bundleAppPath
+//   3. user-data present (config or state or api-key)
+//
+// Step order (D7 step 2 BEFORE bundle assembly because legacy +
+// SMAppService share the launchd label):
+//   2a. SIGTERM legacy daemon + pidfile-poll
+//   2b. legacyLaunchctl.bootout
+//   2c. printService probe after grace period (fail if still loaded)
+//   3-4. Assemble bundle at tmp + atomic-rename
+//   5. Substitute __INSTALL_PREFIX__ placeholder
+//   6. SMAppService.register
+//   7a/7b. Delete legacy plist + legacy binary (best-effort).
+import XCTest
+import CRMMacCore
+@testable import CRMMacLifecycle
+@testable import CRMMacPiClient
+
+final class LegacyMigrationTests: XCTestCase {
+
+    func testUpgradeFromBareBinaryStopsDaemonUnloadsLegacyAssemblesBundleRegisters() async throws {
+        let (installer, fs, agentService, signaller, launchctl, paths, _) =
+            try makeLegacyInstall()
+        // Pidfile present so the migration's SIGTERM path is exercised.
+        try fs.write(Data("12345".utf8), to: paths.pidfilePath)
+
+        _ = try await installer.run(InstallRequest(
+            piURL: URL(string: "https://x")!,
+            pairingToken: "ignored",
+            hostname: "ignored",
+            upgrade: true))
+
+        // 2a — SIGTERM called on the pidfile pid.
+        XCTAssertEqual(signaller.sigtermCalls, [12345])
+        // 2b/2c — legacyLaunchctl bootout + printService called.
+        XCTAssertGreaterThanOrEqual(launchctl.bootoutCalls.count, 1)
+        XCTAssertGreaterThanOrEqual(launchctl.printServiceCalls.count, 1)
+        // 3-4 — bundle exists at final path.
+        XCTAssertTrue(fs.fileExists(at: paths.bundleAppPath))
+        // 6 — register called.
+        XCTAssertGreaterThanOrEqual(agentService.registerCalls, 1)
+        // 7 — legacy plist + binary gone.
+        XCTAssertFalse(fs.fileExists(at: paths.legacyPlistPath))
+        XCTAssertFalse(fs.fileExists(at: paths.legacyBinaryPath))
+        // Config, state, api-key untouched.
+        XCTAssertTrue(fs.fileExists(at: paths.configFilePath))
+    }
+
+    func testRegisterOnlyAlsoRunsLegacyMigration() async throws {
+        let (installer, fs, agentService, _, _, paths, _) = try makeLegacyInstall()
+        _ = try await installer.run(InstallRequest(
+            piURL: URL(string: "https://x")!,
+            pairingToken: "ignored",
+            hostname: "ignored",
+            registerOnly: true))
+        XCTAssertTrue(fs.fileExists(at: paths.bundleAppPath))
+        XCTAssertGreaterThanOrEqual(agentService.registerCalls, 1)
+        XCTAssertFalse(fs.fileExists(at: paths.legacyBinaryPath))
+    }
+
+    func testMigrationDoesNotFireOnFreshInstall() async throws {
+        // No legacy artifacts seeded; run fresh install — migration
+        // path must not execute.
+        let paths = TestPaths.make()
+        let fs = InMemoryFilesystem()
+        fs.seedFile(at: "/tmp/source/crm-mac")
+        let agentService = FakeAgentService()
+        let signaller = FakeProcessSignaller()
+        let launchctl = FakeLaunchctlRunner()
+        let exec = FakeExecutableAdapter(currentExecutablePath: "/tmp/source/crm-mac")
+        let installer = Installer(InstallerDependencies(
+            paths: paths,
+            filesystem: fs,
+            executable: exec,
+            keychain: InMemoryKeychainStore(),
+            agentService: agentService,
+            processSignaller: signaller,
+            bundleAssembler: BundleAssembler(filesystem: fs, executable: exec),
+            piClientFactory: { url in
+                PiClient(baseURL: url,
+                         transport: LifecycleMockTransport([.respond(status: 200, data: pair200JSON)]).asTransport(),
+                         sleep: noopSleep)
+            },
+            clock: FixedClock(),
+            logger: NoopLogger(),
+            legacyLaunchctl: launchctl))
+        _ = try await installer.run(InstallRequest(
+            piURL: URL(string: "https://x")!,
+            pairingToken: "tk",
+            hostname: "mac-1"))
+        // Migration path NOT entered: no SIGTERM, no legacy bootout.
+        XCTAssertEqual(signaller.sigtermCalls.count, 0)
+        XCTAssertEqual(launchctl.bootoutCalls.count, 0)
+    }
+
+    func testMigrationLegacyBootoutFailureSurfacesTypedError() async throws {
+        // Legacy launchctl bootout exit-code is not by itself decisive
+        // (D7 step 2b tolerates non-zero); the printService probe in
+        // step 2c is what fails the migration. Script:
+        //   bootout = [99]    (non-zero, ignored)
+        //   printService = [0] (service still loaded — fatal)
+        let (installer, fs, _, _, launchctl, paths, _) = try makeLegacyInstall()
+        var script = FakeLaunchctlRunner.Script()
+        script.bootout = [99]
+        script.printService = [0]  // still loaded after grace period
+        launchctl.script = script
+        do {
+            _ = try await installer.run(InstallRequest(
+                piURL: URL(string: "https://x")!,
+                pairingToken: "ignored",
+                hostname: "ignored",
+                upgrade: true))
+            XCTFail("expected legacyBootoutFailed")
+        } catch InstallError.legacyBootoutFailed {
+            // ok
+        } catch {
+            XCTFail("got \(error)")
+        }
+        // Bundle NOT assembled — legacy artifacts still on disk.
+        XCTAssertFalse(fs.fileExists(at: paths.bundleAppPath))
+        XCTAssertTrue(fs.fileExists(at: paths.legacyBinaryPath))
+        XCTAssertTrue(fs.fileExists(at: paths.legacyPlistPath))
+    }
+
+    func testMigrationDaemonRefusesToStopFailsCleanly() async throws {
+        // Pidfile present + ProcessSignaller's wait returns false ->
+        // migration aborts with daemonStillRunning.
+        let (installer, fs, _, signaller, _, paths, _) = try makeLegacyInstall()
+        try fs.write(Data("12345".utf8), to: paths.pidfilePath)
+        signaller.nextPidfileReleaseResult = false
+        do {
+            _ = try await installer.run(InstallRequest(
+                piURL: URL(string: "https://x")!,
+                pairingToken: "ignored",
+                hostname: "ignored",
+                upgrade: true))
+            XCTFail("expected daemonStillRunning")
+        } catch InstallError.daemonStillRunning(let pid) {
+            XCTAssertEqual(pid, 12345)
+        } catch {
+            XCTFail("got \(error)")
+        }
+        // Legacy install fully intact.
+        XCTAssertTrue(fs.fileExists(at: paths.legacyBinaryPath))
+        XCTAssertTrue(fs.fileExists(at: paths.legacyPlistPath))
+        XCTAssertFalse(fs.fileExists(at: paths.bundleAppPath))
+    }
+
+    func testMigrationBundleAssemblyFailureLeavesLegacyUnloadedForRetry() async throws {
+        let (installer, fs, _, _, _, paths, exec) = try makeLegacyInstall()
+        // Inject codesign failure during the migration's bundle
+        // assembly step.
+        exec.failBundleCodesignWith = "injected codesign failure"
+        do {
+            _ = try await installer.run(InstallRequest(
+                piURL: URL(string: "https://x")!,
+                pairingToken: "ignored",
+                hostname: "ignored",
+                upgrade: true))
+            XCTFail("expected codesignFailed")
+        } catch InstallError.codesignFailed {
+            // ok
+        } catch {
+            XCTFail("got \(error)")
+        }
+        // Legacy artifacts still on disk (step 7 never ran). No
+        // partial bundle.
+        XCTAssertFalse(fs.fileExists(at: paths.bundleAppPath))
+        XCTAssertTrue(fs.fileExists(at: paths.legacyBinaryPath))
+        XCTAssertTrue(fs.fileExists(at: paths.legacyPlistPath))
+    }
+
+    // MARK: - helpers
+
+    private typealias LegacyHarness = (
+        installer: Installer,
+        fs: InMemoryFilesystem,
+        agentService: FakeAgentService,
+        signaller: FakeProcessSignaller,
+        launchctl: FakeLaunchctlRunner,
+        paths: LifecyclePaths,
+        exec: FakeExecutableAdapter
+    )
+
+    private func makeLegacyInstall() throws -> LegacyHarness {
+        let paths = TestPaths.make()
+        let fs = InMemoryFilesystem()
+        fs.seedFile(at: "/tmp/source/crm-mac")
+        // Legacy artifacts.
+        try fs.write(Data("legacy bin".utf8), to: paths.legacyBinaryPath)
+        try fs.write(Data("legacy plist".utf8), to: paths.legacyPlistPath)
+        // User data (signal 3).
+        let cfg = DaemonConfig(
+            piURL: URL(string: "https://pi.example.test")!,
+            hostID: UUID(uuidString: "11111111-2222-3333-4444-555555555555")!,
+            hostname: "mac-1",
+            installedAt: Date())
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        try fs.write(try encoder.encode(cfg), to: paths.configFilePath)
+
+        let agentService = FakeAgentService()
+        let signaller = FakeProcessSignaller()
+        let launchctl = FakeLaunchctlRunner()
+        let exec = FakeExecutableAdapter(currentExecutablePath: "/tmp/source/crm-mac")
+        let installer = Installer(InstallerDependencies(
+            paths: paths,
+            filesystem: fs,
+            executable: exec,
+            keychain: InMemoryKeychainStore(initial: "k"),
+            agentService: agentService,
+            processSignaller: signaller,
+            bundleAssembler: BundleAssembler(filesystem: fs, executable: exec),
+            piClientFactory: { url in
+                PiClient(baseURL: url, transport: LifecycleMockTransport([]).asTransport(), sleep: noopSleep)
+            },
+            clock: FixedClock(),
+            logger: NoopLogger(),
+            legacyLaunchctl: launchctl,
+            // Shrink the bootout-grace + stop-daemon timeouts so the
+            // tests run fast.
+            stopDaemonTimeoutSeconds: 1,
+            legacyBootoutGraceSeconds: 0.05)
+        )
+        return (installer, fs, agentService, signaller, launchctl, paths, exec)
+    }
+}

--- a/mac-daemon/Tests/CRMMacLifecycleTests/LegacyMigrationTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/LegacyMigrationTests.swift
@@ -150,6 +150,51 @@ final class LegacyMigrationTests: XCTestCase {
         XCTAssertFalse(fs.fileExists(at: paths.bundleAppPath))
     }
 
+    func testMigrationRegisterFailureRetryCleansLegacyArtifacts() async throws {
+        // Per Codex r6 #2: if a migration assembles the bundle but
+        // register fails, a subsequent --register-only retry must
+        // complete the step-7 cleanup (delete legacy plist + binary).
+        // Otherwise the legacy launchd plist survives in
+        // ~/Library/LaunchAgents/ and can be auto-loaded on the
+        // next login, resurrecting the bare-binary service the
+        // migration was meant to retire.
+        let (installer, fs, agentService, _, _, paths, _) = try makeLegacyInstall()
+        // First attempt: register throws.
+        agentService.script.registerThrows = .registrationFailed(
+            message: "denied", requiresApproval: true)
+        do {
+            _ = try await installer.run(InstallRequest(
+                piURL: URL(string: "https://x")!,
+                pairingToken: "ignored",
+                hostname: "ignored",
+                upgrade: true))
+            XCTFail("expected agentRegistrationFailed on first attempt")
+        } catch InstallError.agentRegistrationFailed {
+            // ok — bundle assembled, register failed.
+        } catch {
+            XCTFail("first attempt: got \(error)")
+        }
+        // Bundle IS in place; legacy artifacts still on disk because
+        // step 7 didn't run.
+        XCTAssertTrue(fs.fileExists(at: paths.bundleAppPath))
+        XCTAssertTrue(fs.fileExists(at: paths.legacyBinaryPath))
+        XCTAssertTrue(fs.fileExists(at: paths.legacyPlistPath))
+
+        // Second attempt: clear the script error and retry via
+        // --register-only. The migration's step 7 cleanup must run
+        // even though the build-the-new half is skipped.
+        agentService.script.registerThrows = nil
+        _ = try await installer.run(InstallRequest(
+            piURL: URL(string: "https://x")!,
+            pairingToken: "ignored",
+            hostname: "ignored",
+            registerOnly: true))
+        XCTAssertFalse(fs.fileExists(at: paths.legacyBinaryPath),
+            "register-only retry must delete the legacy binary")
+        XCTAssertFalse(fs.fileExists(at: paths.legacyPlistPath),
+            "register-only retry must delete the legacy plist — otherwise launchd can auto-load it on next login")
+    }
+
     func testMigrationBundleAssemblyFailureLeavesLegacyUnloadedForRetry() async throws {
         let (installer, fs, _, _, _, paths, exec) = try makeLegacyInstall()
         // Inject codesign failure during the migration's bundle

--- a/mac-daemon/Tests/CRMMacLifecycleTests/LegacyMigrationTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/LegacyMigrationTests.swift
@@ -1,20 +1,20 @@
 // LegacyMigrationTests exercise the runLegacyMigrationIfNeeded()
-// path on the Installer's upgrade + register-only flows (plan D7).
+// path on the Installer's upgrade + register-only flows.
 //
 // The migration runs ONLY when all three signals hold:
 //   1. legacy binary at paths.legacyBinaryPath
 //   2. NO bundle at paths.bundleAppPath
 //   3. user-data present (config or state or api-key)
 //
-// Step order (D7 step 2 BEFORE bundle assembly because legacy +
-// SMAppService share the launchd label):
-//   2a. SIGTERM legacy daemon + pidfile-poll
-//   2b. legacyLaunchctl.bootout
-//   2c. printService probe after grace period (fail if still loaded)
-//   3-4. Assemble bundle at tmp + atomic-rename
-//   5. Substitute __INSTALL_PREFIX__ placeholder
-//   6. SMAppService.register
-//   7a/7b. Delete legacy plist + legacy binary (best-effort).
+// Step order (legacy stop + bootout BEFORE bundle assembly because
+// legacy + SMAppService share the launchd label):
+//   - SIGTERM legacy daemon + pidfile-poll
+//   - legacyLaunchctl.bootout
+//   - printService probe after grace period (fail if still loaded)
+//   - Assemble bundle at tmp + atomic-rename
+//   - Substitute __INSTALL_PREFIX__ placeholder
+//   - SMAppService.register
+//   - Delete legacy plist + legacy binary (best-effort, post-register).
 import XCTest
 import CRMMacCore
 @testable import CRMMacLifecycle
@@ -99,7 +99,7 @@ final class LegacyMigrationTests: XCTestCase {
 
     func testMigrationLegacyBootoutFailureSurfacesTypedError() async throws {
         // Legacy launchctl bootout exit-code is not by itself decisive
-        // (D7 step 2b tolerates non-zero); the printService probe in
+        // (the bootout step tolerates non-zero); the printService probe in
         // step 2c is what fails the migration. Script:
         //   bootout = [99]    (non-zero, ignored)
         //   printService = [0] (service still loaded — fatal)
@@ -127,10 +127,10 @@ final class LegacyMigrationTests: XCTestCase {
     }
 
     func testMigrationMalformedPidfileStillRequiresFlockProbe() async throws {
-        // Per Codex r6 #3 (round-2): malformed pidfile on the
-        // migration path must surface daemonStillRunning when the
-        // flock probe says held — same contract as the upgrade and
-        // uninstall paths.
+        // Malformed pidfile on the migration path must surface
+        // daemonStillRunning when the flock probe says held — same
+        // contract as the upgrade and uninstall paths. A malformed
+        // pidfile must NOT short-circuit to "daemon not running".
         let (installer, fs, _, signaller, _, paths, _) = try makeLegacyInstall()
         try fs.write(Data("not-a-pid".utf8), to: paths.pidfilePath)
         signaller.nextPidfileReleaseResult = false
@@ -176,10 +176,57 @@ final class LegacyMigrationTests: XCTestCase {
         XCTAssertFalse(fs.fileExists(at: paths.bundleAppPath))
     }
 
+    func testUpgradeRetryAfterPartialMigrationCleansLegacyArtifacts() async throws {
+        // A partial migration left the bundle in place + the legacy
+        // plist + binary on disk. The operator reruns with
+        // `--upgrade` (rather than `--register-only`). The upgrade
+        // path's normal swap completes; the post-swap cleanup hook
+        // must still sweep the legacy artifacts so the abandoned
+        // ~/Library/LaunchAgents/<label>.plist doesn't get re-loaded
+        // on next login.
+        let (installer, fs, agentService, _, _, paths, _) = try makeLegacyInstall()
+        // First attempt: register throws.
+        agentService.script.registerThrows = .registrationFailed(
+            message: "denied", requiresApproval: true)
+        do {
+            _ = try await installer.run(InstallRequest(
+                piURL: URL(string: "https://x")!,
+                pairingToken: "ignored",
+                hostname: "ignored",
+                upgrade: true))
+            XCTFail("expected first attempt to fail")
+        } catch InstallError.agentRegistrationFailed {
+            // ok — partial migration state: bundle assembled, register
+            // failed, legacy artifacts still on disk.
+        } catch {
+            XCTFail("first attempt: got \(error)")
+        }
+        XCTAssertTrue(fs.fileExists(at: paths.bundleAppPath))
+        XCTAssertTrue(fs.fileExists(at: paths.legacyBinaryPath))
+        XCTAssertTrue(fs.fileExists(at: paths.legacyPlistPath))
+
+        // Second attempt: clear the register error and retry via
+        // `--upgrade` (the operator's natural choice if they forgot
+        // about the register-only flag). The normal upgrade path
+        // runs (migration short-circuit doesn't fire because the
+        // bundle is already in place); the cleanup hook at the end
+        // of runUpgrade still sweeps the legacy files.
+        agentService.script.registerThrows = nil
+        _ = try await installer.run(InstallRequest(
+            piURL: URL(string: "https://x")!,
+            pairingToken: "ignored",
+            hostname: "ignored",
+            upgrade: true))
+        XCTAssertFalse(fs.fileExists(at: paths.legacyBinaryPath),
+            "upgrade retry must delete the legacy binary")
+        XCTAssertFalse(fs.fileExists(at: paths.legacyPlistPath),
+            "upgrade retry must delete the legacy plist — otherwise launchd can auto-load it on next login")
+    }
+
     func testMigrationRegisterFailureRetryCleansLegacyArtifacts() async throws {
-        // Per Codex r6 #2: if a migration assembles the bundle but
-        // register fails, a subsequent --register-only retry must
-        // complete the step-7 cleanup (delete legacy plist + binary).
+        // If a migration assembles the bundle but register fails, a
+        // subsequent --register-only retry must complete the cleanup
+        // (delete legacy plist + binary).
         // Otherwise the legacy launchd plist survives in
         // ~/Library/LaunchAgents/ and can be auto-loaded on the
         // next login, resurrecting the bare-binary service the

--- a/mac-daemon/Tests/CRMMacLifecycleTests/LegacyMigrationTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/LegacyMigrationTests.swift
@@ -126,6 +126,32 @@ final class LegacyMigrationTests: XCTestCase {
         XCTAssertTrue(fs.fileExists(at: paths.legacyPlistPath))
     }
 
+    func testMigrationMalformedPidfileStillRequiresFlockProbe() async throws {
+        // Per Codex r6 #3 (round-2): malformed pidfile on the
+        // migration path must surface daemonStillRunning when the
+        // flock probe says held — same contract as the upgrade and
+        // uninstall paths.
+        let (installer, fs, _, signaller, _, paths, _) = try makeLegacyInstall()
+        try fs.write(Data("not-a-pid".utf8), to: paths.pidfilePath)
+        signaller.nextPidfileReleaseResult = false
+        do {
+            _ = try await installer.run(InstallRequest(
+                piURL: URL(string: "https://x")!,
+                pairingToken: "ignored",
+                hostname: "ignored",
+                upgrade: true))
+            XCTFail("expected daemonStillRunning")
+        } catch InstallError.daemonStillRunning(let pid) {
+            XCTAssertEqual(pid, 0, "unparseable pidfile → pid=0")
+        } catch {
+            XCTFail("got \(error)")
+        }
+        XCTAssertEqual(signaller.sigtermCalls.count, 0)
+        // Legacy install intact (migration didn't proceed).
+        XCTAssertTrue(fs.fileExists(at: paths.legacyBinaryPath))
+        XCTAssertFalse(fs.fileExists(at: paths.bundleAppPath))
+    }
+
     func testMigrationDaemonRefusesToStopFailsCleanly() async throws {
         // Pidfile present + ProcessSignaller's wait returns false ->
         // migration aborts with daemonStillRunning.

--- a/mac-daemon/Tests/CRMMacLifecycleTests/LegacyMigrationTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/LegacyMigrationTests.swift
@@ -11,8 +11,8 @@
 //   - SIGTERM legacy daemon + pidfile-poll
 //   - legacyLaunchctl.bootout
 //   - printService probe after grace period (fail if still loaded)
-//   - Assemble bundle at tmp + atomic-rename
-//   - Substitute __INSTALL_PREFIX__ placeholder
+//   - Assemble bundle at tmp (plist embeds the final install path
+//     BEFORE codesign so the seal stays intact) + atomic-rename
 //   - SMAppService.register
 //   - Delete legacy plist + legacy binary (best-effort, post-register).
 import XCTest

--- a/mac-daemon/Tests/CRMMacLifecycleTests/StatusTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/StatusTests.swift
@@ -6,7 +6,8 @@ final class StatusTests: XCTestCase {
     func testReportsInstalledAndRegistered() throws {
         let paths = TestPaths.make()
         let fs = InMemoryFilesystem()
-        try fs.write(Data("binary".utf8), to: paths.binaryPath)
+        try fs.createDirectory(at: paths.bundleAppPath)
+        try fs.write(Data("bin".utf8), to: paths.bundleBinaryPath)
         let config = DaemonConfig(
             piURL: URL(string: "https://pi.example.test")!,
             hostID: UUID(uuidString: "11111111-2222-3333-4444-555555555555")!,
@@ -21,17 +22,16 @@ final class StatusTests: XCTestCase {
             lastHeartbeatAt: Date(timeIntervalSince1970: 1_700_001_000))
         try fs.write(try encoder.encode(state), to: paths.stateFilePath)
 
-        // The fake's default printService is exit 1 (unregistered);
-        // this test wants the registered path, so override to exit 0.
-        var script = FakeLaunchctlRunner.Script()
-        script.printService = [0]
+        var script = FakeAgentService.Script()
+        script.statusSequence = [.enabled]
         let status = Status(StatusDependencies(
             paths: paths,
             filesystem: fs,
-            launchctl: FakeLaunchctlRunner(script: script)))
+            agentService: FakeAgentService(script: script)))
         let report = status.run()
         XCTAssertTrue(report.installed)
         XCTAssertTrue(report.registered)
+        XCTAssertEqual(report.registrationStatus, .enabled)
         XCTAssertEqual(report.configHostname, "mac-1")
         XCTAssertEqual(report.hostID, config.hostID)
         XCTAssertEqual(report.stateSchemaVersion, 1)
@@ -41,16 +41,35 @@ final class StatusTests: XCTestCase {
     func testReportsNotInstalledOnFreshSystem() {
         let paths = TestPaths.make()
         let fs = InMemoryFilesystem()
-        var script = FakeLaunchctlRunner.Script()
-        script.printService = [1]
+        var script = FakeAgentService.Script()
+        script.statusSequence = [.notRegistered]
         let status = Status(StatusDependencies(
             paths: paths,
             filesystem: fs,
-            launchctl: FakeLaunchctlRunner(script: script)))
+            agentService: FakeAgentService(script: script)))
         let report = status.run()
         XCTAssertFalse(report.installed)
         XCTAssertFalse(report.registered)
+        XCTAssertEqual(report.registrationStatus, .notRegistered)
         XCTAssertNil(report.configHostname)
+    }
+
+    func testReportsRequiresApprovalDistinctFromNotRegistered() throws {
+        // Bundle present but agent registration requires approval.
+        let paths = TestPaths.make()
+        let fs = InMemoryFilesystem()
+        try fs.createDirectory(at: paths.bundleAppPath)
+        try fs.write(Data("bin".utf8), to: paths.bundleBinaryPath)
+        var script = FakeAgentService.Script()
+        script.statusSequence = [.requiresApproval]
+        let status = Status(StatusDependencies(
+            paths: paths,
+            filesystem: fs,
+            agentService: FakeAgentService(script: script)))
+        let report = status.run()
+        XCTAssertTrue(report.installed)
+        XCTAssertFalse(report.registered)
+        XCTAssertEqual(report.registrationStatus, .requiresApproval)
     }
 
     // MARK: - icloud_contacts row
@@ -62,7 +81,7 @@ final class StatusTests: XCTestCase {
         let report = Status(StatusDependencies(
             paths: paths,
             filesystem: fs,
-            launchctl: FakeLaunchctlRunner())).run()
+            agentService: FakeAgentService())).run()
         XCTAssertNil(report.icloudContacts,
                      "no containers configured + no source state → omit row")
     }
@@ -75,7 +94,7 @@ final class StatusTests: XCTestCase {
         let report = Status(StatusDependencies(
             paths: paths,
             filesystem: fs,
-            launchctl: FakeLaunchctlRunner())).run()
+            agentService: FakeAgentService())).run()
         let icloud = report.icloudContacts!
         XCTAssertEqual(icloud.containerCount, 2)
         XCTAssertNil(icloud.lastScheduledAt)
@@ -93,7 +112,7 @@ final class StatusTests: XCTestCase {
         let report = Status(StatusDependencies(
             paths: paths,
             filesystem: fs,
-            launchctl: FakeLaunchctlRunner())).run()
+            agentService: FakeAgentService())).run()
         let icloud = report.icloudContacts!
         XCTAssertTrue(icloud.recoveryRequested)
         XCTAssertEqual(icloud.lastError, "recovery_requested:allowlist_changed")
@@ -110,7 +129,7 @@ final class StatusTests: XCTestCase {
         let report = Status(StatusDependencies(
             paths: paths,
             filesystem: fs,
-            launchctl: FakeLaunchctlRunner())).run()
+            agentService: FakeAgentService())).run()
         let icloud = report.icloudContacts!
         XCTAssertFalse(icloud.recoveryRequested)
         XCTAssertEqual(icloud.lastError, "contacts_permission:denied")
@@ -119,7 +138,8 @@ final class StatusTests: XCTestCase {
     // MARK: - helpers
 
     private func seedConfigOnly(paths: LifecyclePaths, fs: InMemoryFilesystem) throws {
-        try fs.write(Data("binary".utf8), to: paths.binaryPath)
+        try fs.createDirectory(at: paths.bundleAppPath)
+        try fs.write(Data("bin".utf8), to: paths.bundleBinaryPath)
     }
 
     private func seedConfig(

--- a/mac-daemon/Tests/CRMMacLifecycleTests/StatusTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/StatusTests.swift
@@ -31,7 +31,7 @@ final class StatusTests: XCTestCase {
         let report = status.run()
         XCTAssertTrue(report.installed)
         XCTAssertTrue(report.registered)
-        XCTAssertEqual(report.registrationStatus, .enabled)
+        XCTAssertEqual(report.registrationStatus, AgentServiceStatus.enabled)
         XCTAssertEqual(report.configHostname, "mac-1")
         XCTAssertEqual(report.hostID, config.hostID)
         XCTAssertEqual(report.stateSchemaVersion, 1)
@@ -50,7 +50,7 @@ final class StatusTests: XCTestCase {
         let report = status.run()
         XCTAssertFalse(report.installed)
         XCTAssertFalse(report.registered)
-        XCTAssertEqual(report.registrationStatus, .notRegistered)
+        XCTAssertEqual(report.registrationStatus, AgentServiceStatus.notRegistered)
         XCTAssertNil(report.configHostname)
     }
 
@@ -69,7 +69,7 @@ final class StatusTests: XCTestCase {
         let report = status.run()
         XCTAssertTrue(report.installed)
         XCTAssertFalse(report.registered)
-        XCTAssertEqual(report.registrationStatus, .requiresApproval)
+        XCTAssertEqual(report.registrationStatus, AgentServiceStatus.requiresApproval)
     }
 
     // MARK: - icloud_contacts row

--- a/mac-daemon/Tests/CRMMacLifecycleTests/StopStartTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/StopStartTests.swift
@@ -50,6 +50,31 @@ final class StopStartTests: XCTestCase {
             "release returned false → stop result must reflect timeout")
     }
 
+    func testStopMalformedPidfileRequiresFlockProbe() async throws {
+        // Per Codex r6 #3: a present-but-unparseable pidfile must
+        // NOT be treated as "daemon not running". The flock probe is
+        // the authoritative running check; if it reports the lock
+        // is still held (release returns false), stop reports
+        // stopped=false even though we never sent SIGTERM.
+        let paths = TestPaths.make()
+        let fs = InMemoryFilesystem()
+        try fs.write(Data("garbage-not-a-pid".utf8), to: paths.pidfilePath)
+        let signaller = FakeProcessSignaller()
+        signaller.nextPidfileReleaseResult = false  // daemon still alive
+        let result = await StopOps.run(
+            StopOpsDependencies(
+                paths: paths,
+                filesystem: fs,
+                agentService: FakeAgentService(),
+                processSignaller: signaller,
+                logger: NoopLogger()),
+            timeoutSeconds: 1)
+        XCTAssertEqual(signaller.sigtermCalls.count, 0,
+            "no SIGTERM when pid is unparseable")
+        XCTAssertFalse(result.stopped,
+            "malformed pidfile + flock probe says held → must report stopped=false")
+    }
+
     func testStopHandlesAbsentPidfile() async {
         let paths = TestPaths.make()
         let fs = InMemoryFilesystem()

--- a/mac-daemon/Tests/CRMMacLifecycleTests/StopStartTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/StopStartTests.swift
@@ -1,0 +1,167 @@
+// StopStartTests cover the StopOps + StartOps logic that powers
+// `crm-mac stop` and `crm-mac start` (plan D26). The ArgumentParser
+// shells in mac-daemon/Sources/crm-mac/Commands/{Stop,Start}Command.swift
+// are thin — they only build the dependency struct, delegate to
+// StopOps/StartOps, and print the result lines. The logic-under-test
+// lives in CRMMacLifecycle.
+import XCTest
+@testable import CRMMacLifecycle
+
+final class StopStartTests: XCTestCase {
+
+    // MARK: - stop
+
+    func testStopUnregistersAndSignals() async throws {
+        let paths = TestPaths.make()
+        let fs = InMemoryFilesystem()
+        try fs.write(Data("12345".utf8), to: paths.pidfilePath)
+        let agent = FakeAgentService()
+        let signaller = FakeProcessSignaller()
+        let result = await StopOps.run(
+            StopOpsDependencies(
+                paths: paths,
+                filesystem: fs,
+                agentService: agent,
+                processSignaller: signaller,
+                logger: NoopLogger()),
+            timeoutSeconds: 1)
+        XCTAssertEqual(agent.unregisterCalls, 1)
+        XCTAssertEqual(signaller.sigtermCalls, [12345])
+        XCTAssertTrue(result.stopped)
+        XCTAssertEqual(result.pid, 12345)
+        XCTAssertTrue(result.unregisterInvoked)
+    }
+
+    func testStopReturnsExitCode1OnTimeout() async {
+        let paths = TestPaths.make()
+        let fs = InMemoryFilesystem()
+        try? fs.write(Data("12345".utf8), to: paths.pidfilePath)
+        let signaller = FakeProcessSignaller()
+        signaller.nextPidfileReleaseResult = false
+        let result = await StopOps.run(
+            StopOpsDependencies(
+                paths: paths,
+                filesystem: fs,
+                agentService: FakeAgentService(),
+                processSignaller: signaller,
+                logger: NoopLogger()),
+            timeoutSeconds: 1)
+        XCTAssertFalse(result.stopped,
+            "release returned false → stop result must reflect timeout")
+    }
+
+    func testStopHandlesAbsentPidfile() async {
+        let paths = TestPaths.make()
+        let fs = InMemoryFilesystem()
+        let signaller = FakeProcessSignaller()
+        let result = await StopOps.run(
+            StopOpsDependencies(
+                paths: paths,
+                filesystem: fs,
+                agentService: FakeAgentService(),
+                processSignaller: signaller,
+                logger: NoopLogger()),
+            timeoutSeconds: 1)
+        XCTAssertEqual(signaller.sigtermCalls.count, 0)
+        XCTAssertTrue(result.stopped)
+        XCTAssertEqual(result.pid, 0)
+    }
+
+    func testStopToleratesUnregisterThrow() async {
+        let paths = TestPaths.make()
+        let fs = InMemoryFilesystem()
+        var script = FakeAgentService.Script()
+        script.unregisterThrows = .unregistrationFailed("not registered")
+        let agent = FakeAgentService(script: script)
+        let result = await StopOps.run(
+            StopOpsDependencies(
+                paths: paths,
+                filesystem: fs,
+                agentService: agent,
+                processSignaller: FakeProcessSignaller(),
+                logger: NoopLogger()),
+            timeoutSeconds: 1)
+        // The throw is logged but stop continues; flag is true
+        // because we DID invoke unregister.
+        XCTAssertTrue(result.unregisterInvoked)
+        XCTAssertTrue(result.stopped)
+    }
+
+    // MARK: - start
+
+    func testStartRegistersAndVerifiesEnabled() async throws {
+        var script = FakeAgentService.Script()
+        script.statusSequence = [.enabled]
+        let agent = FakeAgentService(script: script)
+        let result = try await StartOps.run(
+            StartOpsDependencies(agentService: agent, logger: NoopLogger()),
+            statusPollTimeoutSeconds: 1,
+            statusPollIntervalNs: 50_000_000)
+        XCTAssertEqual(agent.registerCalls, 1)
+        XCTAssertEqual(result.outcome, .registered)
+        XCTAssertEqual(result.finalStatus, .enabled)
+        XCTAssertTrue(result.started)
+    }
+
+    func testStartReportsAlreadyRegistered() async throws {
+        var script = FakeAgentService.Script()
+        script.nextRegisterOutcome = .alreadyRegistered
+        script.statusSequence = [.enabled]
+        let agent = FakeAgentService(script: script)
+        let result = try await StartOps.run(
+            StartOpsDependencies(agentService: agent, logger: NoopLogger()),
+            statusPollTimeoutSeconds: 1,
+            statusPollIntervalNs: 50_000_000)
+        XCTAssertEqual(result.outcome, .alreadyRegistered)
+        XCTAssertEqual(result.finalStatus, .enabled)
+        XCTAssertTrue(result.started)
+    }
+
+    func testStartExitCode1OnRequiresApproval() async throws {
+        // register succeeds, but currentStatus stays .requiresApproval
+        // throughout the poll window.
+        var script = FakeAgentService.Script()
+        script.statusSequence = [.requiresApproval]
+        let agent = FakeAgentService(script: script)
+        let result = try await StartOps.run(
+            StartOpsDependencies(agentService: agent, logger: NoopLogger()),
+            statusPollTimeoutSeconds: 0.3,
+            statusPollIntervalNs: 50_000_000)
+        XCTAssertFalse(result.started)
+        XCTAssertEqual(result.finalStatus, .requiresApproval)
+    }
+
+    func testStartExitCode1OnPostRegisterNotEnabled() async throws {
+        var script = FakeAgentService.Script()
+        script.statusSequence = [.notRegistered]
+        let agent = FakeAgentService(script: script)
+        let result = try await StartOps.run(
+            StartOpsDependencies(agentService: agent, logger: NoopLogger()),
+            statusPollTimeoutSeconds: 0.3,
+            statusPollIntervalNs: 50_000_000)
+        XCTAssertFalse(result.started)
+        XCTAssertEqual(result.finalStatus, .notRegistered)
+    }
+
+    func testStartSurfacesRegisterFailure() async {
+        var script = FakeAgentService.Script()
+        script.registerThrows = .registrationFailed(
+            message: "denied", requiresApproval: true)
+        let agent = FakeAgentService(script: script)
+        do {
+            _ = try await StartOps.run(
+                StartOpsDependencies(agentService: agent, logger: NoopLogger()),
+                statusPollTimeoutSeconds: 1,
+                statusPollIntervalNs: 50_000_000)
+            XCTFail("expected throw")
+        } catch let err as StartOpsError {
+            if case .registerFailed = err {
+                // ok
+            } else {
+                XCTFail("expected registerFailed, got \(err)")
+            }
+        } catch {
+            XCTFail("expected StartOpsError, got \(error)")
+        }
+    }
+}

--- a/mac-daemon/Tests/CRMMacLifecycleTests/StopStartTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/StopStartTests.swift
@@ -5,6 +5,7 @@
 // StopOps/StartOps, and print the result lines. The logic-under-test
 // lives in CRMMacLifecycle.
 import XCTest
+import CRMMacCore
 @testable import CRMMacLifecycle
 
 final class StopStartTests: XCTestCase {
@@ -123,8 +124,8 @@ final class StopStartTests: XCTestCase {
             statusPollTimeoutSeconds: 1,
             statusPollIntervalNs: 50_000_000)
         XCTAssertEqual(agent.registerCalls, 1)
-        XCTAssertEqual(result.outcome, .registered)
-        XCTAssertEqual(result.finalStatus, .enabled)
+        XCTAssertEqual(result.outcome, AgentRegisterOutcome.registered)
+        XCTAssertEqual(result.finalStatus, AgentServiceStatus.enabled)
         XCTAssertTrue(result.started)
     }
 
@@ -137,8 +138,8 @@ final class StopStartTests: XCTestCase {
             StartOpsDependencies(agentService: agent, logger: NoopLogger()),
             statusPollTimeoutSeconds: 1,
             statusPollIntervalNs: 50_000_000)
-        XCTAssertEqual(result.outcome, .alreadyRegistered)
-        XCTAssertEqual(result.finalStatus, .enabled)
+        XCTAssertEqual(result.outcome, AgentRegisterOutcome.alreadyRegistered)
+        XCTAssertEqual(result.finalStatus, AgentServiceStatus.enabled)
         XCTAssertTrue(result.started)
     }
 
@@ -153,7 +154,7 @@ final class StopStartTests: XCTestCase {
             statusPollTimeoutSeconds: 0.3,
             statusPollIntervalNs: 50_000_000)
         XCTAssertFalse(result.started)
-        XCTAssertEqual(result.finalStatus, .requiresApproval)
+        XCTAssertEqual(result.finalStatus, AgentServiceStatus.requiresApproval)
     }
 
     func testStartExitCode1OnPostRegisterNotEnabled() async throws {
@@ -165,7 +166,7 @@ final class StopStartTests: XCTestCase {
             statusPollTimeoutSeconds: 0.3,
             statusPollIntervalNs: 50_000_000)
         XCTAssertFalse(result.started)
-        XCTAssertEqual(result.finalStatus, .notRegistered)
+        XCTAssertEqual(result.finalStatus, AgentServiceStatus.notRegistered)
     }
 
     func testStartSurfacesRegisterFailure() async {

--- a/mac-daemon/Tests/CRMMacLifecycleTests/StopStartTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/StopStartTests.swift
@@ -1,5 +1,5 @@
 // StopStartTests cover the StopOps + StartOps logic that powers
-// `crm-mac stop` and `crm-mac start` (plan D26). The ArgumentParser
+// `crm-mac stop` and `crm-mac start`. The ArgumentParser
 // shells in mac-daemon/Sources/crm-mac/Commands/{Stop,Start}Command.swift
 // are thin — they only build the dependency struct, delegate to
 // StopOps/StartOps, and print the result lines. The logic-under-test
@@ -51,11 +51,11 @@ final class StopStartTests: XCTestCase {
     }
 
     func testStopMalformedPidfileRequiresFlockProbe() async throws {
-        // Per Codex r6 #3: a present-but-unparseable pidfile must
-        // NOT be treated as "daemon not running". The flock probe is
-        // the authoritative running check; if it reports the lock
-        // is still held (release returns false), stop reports
-        // stopped=false even though we never sent SIGTERM.
+        // A present-but-unparseable pidfile must NOT be treated as
+        // "daemon not running". The flock probe is the authoritative
+        // running check; if it reports the lock is still held
+        // (release returns false), stop reports stopped=false even
+        // though we never sent SIGTERM.
         let paths = TestPaths.make()
         let fs = InMemoryFilesystem()
         try fs.write(Data("garbage-not-a-pid".utf8), to: paths.pidfilePath)

--- a/mac-daemon/Tests/CRMMacLifecycleTests/UninstallerTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/UninstallerTests.swift
@@ -3,41 +3,44 @@ import CRMMacCore
 @testable import CRMMacLifecycle
 
 final class UninstallerTests: XCTestCase {
-    func testDefaultRemovesPlistAndKeychain() throws {
+    func testDefaultRemovesBundleAndKeychain() async throws {
         let paths = TestPaths.make()
         let fs = InMemoryFilesystem()
-        try fs.write(Data("plist".utf8), to: paths.plistPath)
+        try fs.createDirectory(at: paths.bundleAppPath)
+        try fs.write(Data("bin".utf8), to: paths.bundleBinaryPath)
+        try fs.write(Data("plist".utf8), to: paths.bundlePlistPath)
+        try fs.write(Data("info".utf8), to: paths.bundleInfoPlistPath)
         try fs.write(Data("config".utf8), to: paths.configFilePath)
-        try fs.write(Data("binary".utf8), to: paths.binaryPath)
         let keychain = InMemoryKeychainStore(initial: "key")
-        let launchctl = FakeLaunchctlRunner()
+        let agentService = FakeAgentService()
         let uninstaller = Uninstaller(UninstallerDependencies(
             paths: paths,
             filesystem: fs,
             keychain: keychain,
-            launchctl: launchctl,
+            agentService: agentService,
+            processSignaller: FakeProcessSignaller(),
             logger: NoopLogger()))
 
-        let summary = try uninstaller.run(UninstallRequest())
-        XCTAssertTrue(summary.bootoutInvoked)
-        XCTAssertTrue(summary.plistDeleted)
+        let summary = try await uninstaller.run(UninstallRequest())
+        XCTAssertTrue(summary.unregisterInvoked)
+        XCTAssertTrue(summary.bundleDeleted)
         XCTAssertTrue(summary.keychainDeleted)
         XCTAssertFalse(summary.purged)
-        XCTAssertEqual(launchctl.bootoutCalls.count, 1)
-        XCTAssertFalse(fs.fileExists(at: paths.plistPath))
+        XCTAssertEqual(agentService.unregisterCalls, 1)
+        XCTAssertFalse(fs.fileExists(at: paths.bundleAppPath))
+        XCTAssertFalse(fs.fileExists(at: paths.bundleBinaryPath))
         XCTAssertNil(keychain.currentValue)
-        // config + binary still present (no --purge).
+        // config still present (no --purge).
         XCTAssertTrue(fs.fileExists(at: paths.configFilePath))
-        XCTAssertTrue(fs.fileExists(at: paths.binaryPath))
     }
 
-    func testPurgeRemovesEverything() throws {
+    func testPurgeRemovesEverything() async throws {
         let paths = TestPaths.make()
         let fs = InMemoryFilesystem()
-        try fs.write(Data("plist".utf8), to: paths.plistPath)
+        try fs.createDirectory(at: paths.bundleAppPath)
+        try fs.write(Data("bin".utf8), to: paths.bundleBinaryPath)
         try fs.write(Data("config".utf8), to: paths.configFilePath)
         try fs.write(Data("state".utf8), to: paths.stateFilePath)
-        try fs.write(Data("binary".utf8), to: paths.binaryPath)
         let icloudHashCachePath = URL(fileURLWithPath: paths.configDirPath)
             .appendingPathComponent("icloud_contacts_hashes.json").path
         try fs.write(Data("{\"schema_version\":1,\"hashes\":{}}".utf8),
@@ -47,22 +50,23 @@ final class UninstallerTests: XCTestCase {
             paths: paths,
             filesystem: fs,
             keychain: keychain,
-            launchctl: FakeLaunchctlRunner(),
+            agentService: FakeAgentService(),
+            processSignaller: FakeProcessSignaller(),
             logger: NoopLogger()))
 
-        let summary = try uninstaller.run(UninstallRequest(purge: true))
+        let summary = try await uninstaller.run(UninstallRequest(purge: true))
         XCTAssertTrue(summary.purged)
         XCTAssertFalse(fs.fileExists(at: paths.configFilePath))
         XCTAssertFalse(fs.fileExists(at: paths.stateFilePath))
-        XCTAssertFalse(fs.fileExists(at: paths.binaryPath))
+        XCTAssertFalse(fs.fileExists(at: paths.bundleAppPath))
         XCTAssertFalse(fs.fileExists(at: icloudHashCachePath),
                        "purge must include icloud_contacts_hashes.json so a re-pair starts clean")
     }
 
-    func testPurgeLeavesIcloudHashCacheWhenNotPurging() throws {
+    func testPurgeLeavesIcloudHashCacheWhenNotPurging() async throws {
         let paths = TestPaths.make()
         let fs = InMemoryFilesystem()
-        try fs.write(Data("plist".utf8), to: paths.plistPath)
+        try fs.createDirectory(at: paths.bundleAppPath)
         let icloudHashCachePath = URL(fileURLWithPath: paths.configDirPath)
             .appendingPathComponent("icloud_contacts_hashes.json").path
         try fs.write(Data("{\"schema_version\":1,\"hashes\":{}}".utf8),
@@ -71,57 +75,89 @@ final class UninstallerTests: XCTestCase {
             paths: paths,
             filesystem: fs,
             keychain: InMemoryKeychainStore(initial: "k"),
-            launchctl: FakeLaunchctlRunner(),
+            agentService: FakeAgentService(),
+            processSignaller: FakeProcessSignaller(),
             logger: NoopLogger()))
-        _ = try uninstaller.run(UninstallRequest(purge: false))
+        _ = try await uninstaller.run(UninstallRequest(purge: false))
         XCTAssertTrue(fs.fileExists(at: icloudHashCachePath),
                       "default uninstall preserves icloud hash cache")
     }
 
-    func testPlistAlreadyAbsentSurfacesAsNotDeleted() throws {
+    func testBundleAlreadyAbsentSurfacesAsNotDeleted() async throws {
         let paths = TestPaths.make()
         let fs = InMemoryFilesystem()
-        // No plist seeded.
+        // No bundle seeded.
         let uninstaller = Uninstaller(UninstallerDependencies(
             paths: paths,
             filesystem: fs,
             keychain: InMemoryKeychainStore(initial: "k"),
-            launchctl: FakeLaunchctlRunner(),
+            agentService: FakeAgentService(),
+            processSignaller: FakeProcessSignaller(),
             logger: NoopLogger()))
-        let summary = try uninstaller.run(UninstallRequest())
-        XCTAssertFalse(summary.plistDeleted, "plist was already absent")
+        let summary = try await uninstaller.run(UninstallRequest())
+        XCTAssertFalse(summary.bundleDeleted, "bundle was already absent")
         XCTAssertTrue(summary.keychainDeleted)
     }
 
-    func testKeychainAlreadyAbsentStillSucceeds() throws {
+    func testKeychainAlreadyAbsentStillSucceeds() async throws {
         let paths = TestPaths.make()
         let fs = InMemoryFilesystem()
-        // No initial Keychain value; deleteAPIKey is idempotent.
         let keychain = InMemoryKeychainStore()
         let uninstaller = Uninstaller(UninstallerDependencies(
             paths: paths,
             filesystem: fs,
             keychain: keychain,
-            launchctl: FakeLaunchctlRunner(),
+            agentService: FakeAgentService(),
+            processSignaller: FakeProcessSignaller(),
             logger: NoopLogger()))
-        let summary = try uninstaller.run(UninstallRequest())
+        let summary = try await uninstaller.run(UninstallRequest())
         XCTAssertTrue(summary.keychainDeleted, "delete on missing entry is a successful no-op")
     }
 
-    func testBootoutNonZeroExitIsTolerated() throws {
+    func testUnregisterErrorIsTolerated() async throws {
         let paths = TestPaths.make()
         let fs = InMemoryFilesystem()
-        var script = FakeLaunchctlRunner.Script()
-        script.bootout = [3]
-        let launchctl = FakeLaunchctlRunner(script: script)
+        try fs.createDirectory(at: paths.bundleAppPath)
+        try fs.write(Data("bin".utf8), to: paths.bundleBinaryPath)
+        var script = FakeAgentService.Script()
+        script.unregisterThrows = .unregistrationFailed("not registered")
+        let agent = FakeAgentService(script: script)
         let uninstaller = Uninstaller(UninstallerDependencies(
             paths: paths,
             filesystem: fs,
-            keychain: InMemoryKeychainStore(),
-            launchctl: launchctl,
+            keychain: InMemoryKeychainStore(initial: "k"),
+            agentService: agent,
+            processSignaller: FakeProcessSignaller(),
             logger: NoopLogger()))
-        let summary = try uninstaller.run(UninstallRequest())
-        XCTAssertEqual(summary.bootoutExitCode, 3)
-        XCTAssertTrue(summary.bootoutInvoked)
+        let summary = try await uninstaller.run(UninstallRequest())
+        // Continues even though unregister threw.
+        XCTAssertTrue(summary.unregisterInvoked)
+        XCTAssertTrue(summary.bundleDeleted)
+        XCTAssertTrue(summary.keychainDeleted)
+    }
+
+    func testLegacyArtifactsCleanedUp() async throws {
+        let paths = TestPaths.make()
+        let fs = InMemoryFilesystem()
+        // Seed both legacy artifacts + a new bundle (post-migration
+        // could-have-been-state where uninstall sweeps the leftovers).
+        try fs.write(Data("legacy plist".utf8), to: paths.legacyPlistPath)
+        try fs.write(Data("legacy bin".utf8), to: paths.legacyBinaryPath)
+        try fs.createDirectory(at: paths.bundleAppPath)
+        try fs.write(Data("new bin".utf8), to: paths.bundleBinaryPath)
+        let uninstaller = Uninstaller(UninstallerDependencies(
+            paths: paths,
+            filesystem: fs,
+            keychain: InMemoryKeychainStore(initial: "k"),
+            agentService: FakeAgentService(),
+            processSignaller: FakeProcessSignaller(),
+            logger: NoopLogger(),
+            legacyLaunchctl: FakeLaunchctlRunner()))
+        let summary = try await uninstaller.run(UninstallRequest())
+        XCTAssertTrue(summary.legacyPlistDeleted)
+        XCTAssertTrue(summary.legacyBinaryDeleted)
+        XCTAssertFalse(fs.fileExists(at: paths.legacyPlistPath))
+        XCTAssertFalse(fs.fileExists(at: paths.legacyBinaryPath))
+        XCTAssertFalse(fs.fileExists(at: paths.bundleAppPath))
     }
 }

--- a/mac-daemon/Tests/CRMMacLifecycleTests/UninstallerTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/UninstallerTests.swift
@@ -137,9 +137,9 @@ final class UninstallerTests: XCTestCase {
     }
 
     func testUninstallMalformedPidfileStillProbesFlock() async throws {
-        // Per Codex r6 #3 (round-2): a present-but-unparseable
-        // pidfile during uninstall must NOT short-circuit to
-        // daemon_stopped=true. The flock probe is authoritative.
+        // A present-but-unparseable pidfile during uninstall must
+        // NOT short-circuit to daemon_stopped=true. The flock probe
+        // is authoritative.
         let paths = TestPaths.make()
         let fs = InMemoryFilesystem()
         try fs.write(Data("garbage-not-a-pid".utf8), to: paths.pidfilePath)

--- a/mac-daemon/Tests/CRMMacLifecycleTests/UninstallerTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/UninstallerTests.swift
@@ -136,6 +136,35 @@ final class UninstallerTests: XCTestCase {
         XCTAssertTrue(summary.keychainDeleted)
     }
 
+    func testUninstallMalformedPidfileStillProbesFlock() async throws {
+        // Per Codex r6 #3 (round-2): a present-but-unparseable
+        // pidfile during uninstall must NOT short-circuit to
+        // daemon_stopped=true. The flock probe is authoritative.
+        let paths = TestPaths.make()
+        let fs = InMemoryFilesystem()
+        try fs.write(Data("garbage-not-a-pid".utf8), to: paths.pidfilePath)
+        try fs.createDirectory(at: paths.bundleAppPath)
+        try fs.write(Data("bin".utf8), to: paths.bundleBinaryPath)
+        let signaller = FakeProcessSignaller()
+        signaller.nextPidfileReleaseResult = false  // lock still held
+        let uninstaller = Uninstaller(UninstallerDependencies(
+            paths: paths,
+            filesystem: fs,
+            keychain: InMemoryKeychainStore(initial: "k"),
+            agentService: FakeAgentService(),
+            processSignaller: signaller,
+            logger: NoopLogger()))
+        let summary = try await uninstaller.run(UninstallRequest())
+        XCTAssertEqual(signaller.sigtermCalls.count, 0,
+            "no SIGTERM when pid is unparseable")
+        XCTAssertFalse(summary.daemonStopped,
+            "malformed pidfile + flock held → daemon_stopped must be false")
+        // Uninstall is tolerant: bundle still removed even when
+        // daemon_stopped=false (mirrors today's behavior on
+        // unregister-error tolerance).
+        XCTAssertTrue(summary.bundleDeleted)
+    }
+
     func testLegacyArtifactsCleanedUp() async throws {
         let paths = TestPaths.make()
         let fs = InMemoryFilesystem()

--- a/mac-daemon/Tests/CRMMacSystemTests/BundleAssemblyParityTests.swift
+++ b/mac-daemon/Tests/CRMMacSystemTests/BundleAssemblyParityTests.swift
@@ -1,7 +1,7 @@
 // BundleAssemblyParityTests proves the shell-script bundle-assembly
 // (`mac-daemon/Scripts/assemble_bundle.sh`) and the Swift
 // `BundleAssembler` produce byte-identical bundles when given the
-// SAME source-tree inputs (plan D14).
+// SAME source-tree inputs.
 //
 // Opt-in via the `CRM_MAC_INTEGRATION_TESTS=1` env var. The test
 // shells out to /bin/bash + writes to a tmp work dir + invokes

--- a/mac-daemon/Tests/CRMMacSystemTests/BundleAssemblyParityTests.swift
+++ b/mac-daemon/Tests/CRMMacSystemTests/BundleAssemblyParityTests.swift
@@ -1,0 +1,211 @@
+// BundleAssemblyParityTests proves the shell-script bundle-assembly
+// (`mac-daemon/Scripts/assemble_bundle.sh`) and the Swift
+// `BundleAssembler` produce byte-identical bundles when given the
+// SAME source-tree inputs (plan D14).
+//
+// Opt-in via the `CRM_MAC_INTEGRATION_TESTS=1` env var. The test
+// shells out to /bin/bash + writes to a tmp work dir + invokes
+// /usr/bin/codesign — it's not safe to run in arbitrary CI matrices.
+// CI sets the env var explicitly in a dedicated step.
+import XCTest
+import CryptoKit
+import CRMMacLifecycle
+@testable import CRMMacSystem
+
+final class BundleAssemblyParityTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        try XCTSkipUnless(
+            ProcessInfo.processInfo.environment["CRM_MAC_INTEGRATION_TESTS"] == "1",
+            "BundleAssemblyParityTests requires CRM_MAC_INTEGRATION_TESTS=1; skipping under default test run.")
+    }
+
+    func testShellAndSwiftBundlesAreByteIdentical() throws {
+        let workDir = try makeTempWorkDir()
+        defer { try? FileManager.default.removeItem(at: workDir) }
+
+        // Use /bin/echo as the minimal Mach-O input — it's a real
+        // signed Mach-O in /bin, small, present on every macOS host.
+        // The actual contents don't matter for byte-identity; we just
+        // need a valid Mach-O the codesign call can sign.
+        let machoSource = workDir.appendingPathComponent("crm-mac")
+        try FileManager.default.copyItem(
+            at: URL(fileURLWithPath: "/bin/echo"),
+            to: machoSource)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: machoSource.path)
+
+        // Locate the source-tree Info.plist relative to this test
+        // file. Same #filePath descent used by InfoPlistFixtureTests.
+        let infoPlistURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // CRMMacSystemTests/
+            .deletingLastPathComponent()  // Tests/
+            .deletingLastPathComponent()  // mac-daemon/
+            .appendingPathComponent("Sources/crm-mac/Info.plist")
+        let scriptURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Scripts/assemble_bundle.sh")
+
+        let shellBundle = workDir.appendingPathComponent("shell-bundle.app")
+        let swiftBundle = workDir.appendingPathComponent("swift-bundle.app")
+
+        // Render the LaunchAgent plist exactly as the shell script
+        // would: the shell uses the build-time $HOME for logs +
+        // config-dir paths. We pass the SAME values to the Swift
+        // implementation via `launchAgentPlistContent`.
+        let buildHome = ProcessInfo.processInfo.environment["HOME"]
+            ?? "/Users/runner"
+        let launchAgentContent = Self.renderShellEquivalentLaunchAgent(
+            buildHome: buildHome)
+
+        // Invoke the shell script.
+        try runShellAssemble(
+            scriptURL: scriptURL,
+            machoSource: machoSource,
+            bundlePath: shellBundle,
+            infoPlistSource: infoPlistURL)
+
+        // Invoke the Swift BundleAssembler. Use the SAME
+        // infoPlistContent (raw bytes of the source-tree file) as the
+        // shell-script reads.
+        let infoPlistBytes = try Data(contentsOf: infoPlistURL)
+        let fs = ProductionFilesystemAdapter()
+        let exec = ProductionExecutableAdapter()
+        let assembler = BundleAssembler(filesystem: fs, executable: exec)
+        try assembler.assemble(BundleAssemblerInput(
+            machoSourcePath: machoSource.path,
+            bundlePath: swiftBundle.path,
+            launchAgentPlistContent: launchAgentContent,
+            infoPlistContent: infoPlistBytes,
+            codesignIdentifier: Daemon.label))
+
+        // Walk both trees; assert file-list parity. The codesign
+        // signature blobs in `Contents/_CodeSignature/CodeResources`
+        // contain a build-time timestamp that intentionally drifts
+        // between calls — we exclude that path from the byte-identity
+        // assertion. The presence/absence of the file IS asserted
+        // (both must produce it).
+        let shellPaths = try enumerateRelativePaths(under: shellBundle)
+        let swiftPaths = try enumerateRelativePaths(under: swiftBundle)
+        XCTAssertEqual(
+            shellPaths.sorted(),
+            swiftPaths.sorted(),
+            "shell and swift produced different file lists")
+
+        // For every non-_CodeSignature file: assert SHA-256 matches.
+        for rel in shellPaths.sorted() where !rel.hasPrefix("Contents/_CodeSignature/") {
+            let shellSha = try sha256(of: shellBundle.appendingPathComponent(rel))
+            let swiftSha = try sha256(of: swiftBundle.appendingPathComponent(rel))
+            XCTAssertEqual(
+                shellSha, swiftSha,
+                "byte mismatch at \(rel): shell=\(shellSha) swift=\(swiftSha)")
+        }
+    }
+
+    // MARK: - helpers
+
+    private static func renderShellEquivalentLaunchAgent(buildHome: String) -> String {
+        // Mirrors the heredoc in Scripts/assemble_bundle.sh exactly.
+        // Any divergence between this string and the shell script's
+        // output is what we're hunting — the SHA-256 check below
+        // surfaces it.
+        return """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>Label</key>
+            <string>\(Daemon.label)</string>
+            <key>ProgramArguments</key>
+            <array>
+                <string>__INSTALL_PREFIX__/Contents/MacOS/crm-mac</string>
+                <string>daemon</string>
+            </array>
+            <key>RunAtLoad</key>
+            <true/>
+            <key>KeepAlive</key>
+            <dict>
+                <key>Crashed</key>
+                <true/>
+            </dict>
+            <key>ProcessType</key>
+            <string>Background</string>
+            <key>StandardOutPath</key>
+            <string>\(buildHome)/Library/Logs/crm-mac/stdout.log</string>
+            <key>StandardErrorPath</key>
+            <string>\(buildHome)/Library/Logs/crm-mac/stderr.log</string>
+            <key>EnvironmentVariables</key>
+            <dict>
+                <key>CRM_MAC_CONFIG_DIR</key>
+                <string>\(buildHome)/Library/Application Support/crm-mac</string>
+            </dict>
+        </dict>
+        </plist>
+
+        """
+    }
+
+    private func makeTempWorkDir() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("crm-mac-parity-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func runShellAssemble(
+        scriptURL: URL,
+        machoSource: URL,
+        bundlePath: URL,
+        infoPlistSource: URL
+    ) throws {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/bin/bash")
+        proc.arguments = [
+            scriptURL.path,
+            machoSource.path,
+            bundlePath.path,
+            infoPlistSource.path,
+        ]
+        let outPipe = Pipe(), errPipe = Pipe()
+        proc.standardOutput = outPipe
+        proc.standardError = errPipe
+        try proc.run()
+        proc.waitUntilExit()
+        if proc.terminationStatus != 0 {
+            let err = String(data: errPipe.fileHandleForReading.readDataToEndOfFile(),
+                             encoding: .utf8) ?? ""
+            XCTFail("assemble_bundle.sh exit \(proc.terminationStatus): \(err)")
+        }
+    }
+
+    private func enumerateRelativePaths(under root: URL) throws -> [String] {
+        guard let enumerator = FileManager.default.enumerator(
+            at: root,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: []) else {
+            return []
+        }
+        var out: [String] = []
+        let prefix = root.path + "/"
+        for case let url as URL in enumerator {
+            // Skip directories — we compare files by SHA-256 below;
+            // directory existence is implied by file presence.
+            let resourceValues = try url.resourceValues(forKeys: [.isDirectoryKey])
+            if resourceValues.isDirectory == true { continue }
+            let p = url.path
+            guard p.hasPrefix(prefix) else { continue }
+            out.append(String(p.dropFirst(prefix.count)))
+        }
+        return out
+    }
+
+    private func sha256(of url: URL) throws -> String {
+        let data = try Data(contentsOf: url)
+        let digest = SHA256.hash(data: data)
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/mac-daemon/Tests/CRMMacSystemTests/BundleCodesignSealTests.swift
+++ b/mac-daemon/Tests/CRMMacSystemTests/BundleCodesignSealTests.swift
@@ -1,0 +1,123 @@
+// BundleCodesignSealTests prove that the install-time bundle
+// assembly produces a bundle whose codesign seal stays intact —
+// i.e. a real `codesign --verify` against the assembled bundle
+// exits 0.
+//
+// Regression coverage for the placeholder-substitution ordering bug:
+// an earlier implementation wrote the embedded LaunchAgent plist with
+// an __INSTALL_PREFIX__ placeholder, codesigned the bundle, then
+// substituted the placeholder with the real bundle path after
+// codesign — invalidating the seal. SMAppService accepted the first
+// register() on a freshly-installed bundle but `crm-mac install
+// --register-only` and `crm-mac doctor` failed with
+// "Codesigning failure loading plist ... code: -67054" because
+// they go through stricter codesign validation.
+//
+// Opt-in via CRM_MAC_INTEGRATION_TESTS=1. Shells out to
+// /usr/bin/codesign + writes to a tmp work dir; not safe to run in
+// arbitrary CI matrices.
+import XCTest
+import CRMMacLifecycle
+@testable import CRMMacSystem
+
+final class BundleCodesignSealTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        try XCTSkipUnless(
+            ProcessInfo.processInfo.environment["CRM_MAC_INTEGRATION_TESTS"] == "1",
+            "BundleCodesignSealTests requires CRM_MAC_INTEGRATION_TESTS=1; skipping under default test run.")
+    }
+
+    func testAssembledBundleVerifiesUnderCodesign() throws {
+        let workDir = try makeTempWorkDir()
+        defer { try? FileManager.default.removeItem(at: workDir) }
+
+        // Use /bin/echo as the minimal Mach-O input (same approach as
+        // BundleAssemblyParityTests — a real signed Mach-O the
+        // codesign call can re-sign).
+        let machoSource = workDir.appendingPathComponent("crm-mac")
+        try FileManager.default.copyItem(
+            at: URL(fileURLWithPath: "/bin/echo"),
+            to: machoSource)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: machoSource.path)
+
+        // Locate the source-tree Info.plist relative to this test file.
+        let infoPlistURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // CRMMacSystemTests/
+            .deletingLastPathComponent()  // Tests/
+            .deletingLastPathComponent()  // mac-daemon/
+            .appendingPathComponent("Sources/crm-mac/Info.plist")
+        let infoPlistBytes = try Data(contentsOf: infoPlistURL)
+
+        let bundlePath = workDir.appendingPathComponent("crm-mac.app").path
+
+        // Render the LaunchAgent plist with the real bundle path
+        // embedded — same as the installer's renderLaunchAgentContent.
+        // The bug we're regressing against was: render with a
+        // placeholder, codesign, then rewrite post-codesign. If a
+        // future change reintroduces that ordering, the
+        // `codesign --verify` step below will fail because rewriting
+        // a sealed resource invalidates the bundle's
+        // Contents/_CodeSignature/CodeResources manifest.
+        let launchAgentContent = LaunchAgentPlist(
+            label: Daemon.label,
+            binaryPath: "\(bundlePath)/Contents/MacOS/crm-mac",
+            configDirPath: "\(workDir.path)/cfg",
+            stdoutPath: "\(workDir.path)/logs/stdout.log",
+            stderrPath: "\(workDir.path)/logs/stderr.log"
+        ).render()
+
+        let fs = ProductionFilesystemAdapter()
+        let exec = ProductionExecutableAdapter()
+        let assembler = BundleAssembler(filesystem: fs, executable: exec)
+        try assembler.assemble(BundleAssemblerInput(
+            machoSourcePath: machoSource.path,
+            bundlePath: bundlePath,
+            launchAgentPlistContent: launchAgentContent,
+            infoPlistContent: infoPlistBytes,
+            codesignIdentifier: Daemon.label))
+
+        // The actual regression assertion: `codesign --verify` must
+        // exit 0. A broken seal (the bug we're guarding against)
+        // surfaces as exit 1 with "a sealed resource is missing or
+        // invalid" pointing at the embedded LaunchAgent plist.
+        let verify = runCodesignVerify(bundlePath: bundlePath)
+        XCTAssertEqual(verify.exitCode, 0,
+            "codesign --verify failed (exit=\(verify.exitCode)) — embedded LaunchAgent plist seal is broken. stderr: \(verify.stderr)")
+    }
+
+    // MARK: - helpers
+
+    private struct CodesignResult {
+        let exitCode: Int32
+        let stderr: String
+    }
+
+    private func runCodesignVerify(bundlePath: String) -> CodesignResult {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/codesign")
+        proc.arguments = ["--verify", "--verbose", bundlePath]
+        let errPipe = Pipe()
+        proc.standardError = errPipe
+        do {
+            try proc.run()
+        } catch {
+            return CodesignResult(exitCode: -1, stderr: "spawn failed: \(error.localizedDescription)")
+        }
+        proc.waitUntilExit()
+        let stderr = String(
+            data: errPipe.fileHandleForReading.readDataToEndOfFile(),
+            encoding: .utf8) ?? ""
+        return CodesignResult(exitCode: proc.terminationStatus, stderr: stderr)
+    }
+
+    private func makeTempWorkDir() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("crm-mac-seal-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: url, withIntermediateDirectories: true)
+        return url
+    }
+}

--- a/mac-daemon/Tests/CRMMacSystemTests/BundleSwapAtomicityTests.swift
+++ b/mac-daemon/Tests/CRMMacSystemTests/BundleSwapAtomicityTests.swift
@@ -1,0 +1,101 @@
+// BundleSwapAtomicityTests exercise the upgrade-path bundle swap
+// (D8 U3-U7) against the REAL ProductionFilesystemAdapter, in a
+// tmp work dir. Every individual rename uses an empty/absent
+// destination (the plan deliberately avoids POSIX rename(2)'s
+// ENOTEMPTY trap by going backup-rename-then-swap rather than
+// rename-onto-non-empty).
+//
+// Opt-in via CRM_MAC_INTEGRATION_TESTS=1. Writes to a tmp work dir
+// + shells out indirectly through codesign during the assembly half;
+// not safe to run by default in CI.
+import XCTest
+import CRMMacLifecycle
+@testable import CRMMacSystem
+
+final class BundleSwapAtomicityTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        try XCTSkipUnless(
+            ProcessInfo.processInfo.environment["CRM_MAC_INTEGRATION_TESTS"] == "1",
+            "BundleSwapAtomicityTests requires CRM_MAC_INTEGRATION_TESTS=1; skipping under default test run.")
+    }
+
+    func testBackupSwapSequenceUsesEmptyDestinations() throws {
+        let workDir = try makeTempWorkDir()
+        defer { try? FileManager.default.removeItem(at: workDir) }
+
+        let fs = ProductionFilesystemAdapter()
+        let bundle = workDir.appendingPathComponent("crm-mac.app").path
+        let backup = workDir.appendingPathComponent("crm-mac.app.backup.\(getpid())").path
+        let tmp = workDir.appendingPathComponent("crm-mac.app.tmp.\(getpid())").path
+
+        // Seed an "old bundle" — non-empty directory with N files
+        // mirroring the real bundle layout.
+        try fs.createDirectory(at: bundle)
+        try fs.createDirectory(at: "\(bundle)/Contents/MacOS")
+        try fs.write(Data("old-binary".utf8), to: "\(bundle)/Contents/MacOS/crm-mac")
+        try fs.createDirectory(at: "\(bundle)/Contents")
+        try fs.write(Data("old-info".utf8), to: "\(bundle)/Contents/Info.plist")
+
+        // U3 — rename old to backup (destination absent; atomic).
+        try fs.rename(from: bundle, to: backup)
+        XCTAssertFalse(fs.fileExists(at: bundle))
+        XCTAssertTrue(fs.fileExists(at: backup))
+
+        // U4 — assemble new at tmp.
+        try fs.createDirectory(at: tmp)
+        try fs.createDirectory(at: "\(tmp)/Contents/MacOS")
+        try fs.write(Data("new-binary".utf8), to: "\(tmp)/Contents/MacOS/crm-mac")
+        try fs.createDirectory(at: "\(tmp)/Contents")
+        try fs.write(Data("new-info".utf8), to: "\(tmp)/Contents/Info.plist")
+
+        // U5 — rename tmp to final (destination absent again because
+        // U3 moved the old one).
+        try fs.rename(from: tmp, to: bundle)
+        XCTAssertTrue(fs.fileExists(at: bundle))
+        XCTAssertEqual(
+            try fs.read(from: "\(bundle)/Contents/MacOS/crm-mac"),
+            Data("new-binary".utf8))
+
+        // U7 — best-effort cleanup of backup.
+        try fs.remove(at: backup)
+        XCTAssertFalse(fs.fileExists(at: backup))
+    }
+
+    func testRollbackRestoresOldBundleAfterAssemblyFailure() throws {
+        // Simulate an assembly failure between U3 (rename old to
+        // backup) and U5 (rename tmp to final): the installer would
+        // remove the tmp bundle + rename backup back to final. The
+        // production rename calls underneath are what we're proving
+        // atomic here.
+        let workDir = try makeTempWorkDir()
+        defer { try? FileManager.default.removeItem(at: workDir) }
+
+        let fs = ProductionFilesystemAdapter()
+        let bundle = workDir.appendingPathComponent("crm-mac.app").path
+        let backup = workDir.appendingPathComponent("crm-mac.app.backup.\(getpid())").path
+
+        // Seed an "old bundle".
+        try fs.createDirectory(at: bundle)
+        try fs.write(Data("old".utf8), to: "\(bundle)/marker")
+
+        // U3 — rename to backup.
+        try fs.rename(from: bundle, to: backup)
+        XCTAssertFalse(fs.fileExists(at: bundle))
+
+        // Simulate assembly failure: rollback restores the backup.
+        try fs.rename(from: backup, to: bundle)
+
+        XCTAssertTrue(fs.fileExists(at: bundle))
+        XCTAssertEqual(try fs.read(from: "\(bundle)/marker"), Data("old".utf8))
+        XCTAssertFalse(fs.fileExists(at: backup))
+    }
+
+    private func makeTempWorkDir() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("crm-mac-swap-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: url, withIntermediateDirectories: true)
+        return url
+    }
+}

--- a/mac-daemon/Tests/CRMMacSystemTests/BundleSwapAtomicityTests.swift
+++ b/mac-daemon/Tests/CRMMacSystemTests/BundleSwapAtomicityTests.swift
@@ -1,9 +1,8 @@
 // BundleSwapAtomicityTests exercise the upgrade-path bundle swap
-// (D8 U3-U7) against the REAL ProductionFilesystemAdapter, in a
-// tmp work dir. Every individual rename uses an empty/absent
-// destination (the plan deliberately avoids POSIX rename(2)'s
-// ENOTEMPTY trap by going backup-rename-then-swap rather than
-// rename-onto-non-empty).
+// against the REAL ProductionFilesystemAdapter in a tmp work dir.
+// Every individual rename uses an empty/absent destination — the
+// upgrade flow deliberately avoids POSIX rename(2)'s ENOTEMPTY trap
+// by going backup-rename-then-swap rather than rename-onto-non-empty.
 //
 // Opt-in via CRM_MAC_INTEGRATION_TESTS=1. Writes to a tmp work dir
 // + shells out indirectly through codesign during the assembly half;
@@ -37,35 +36,35 @@ final class BundleSwapAtomicityTests: XCTestCase {
         try fs.createDirectory(at: "\(bundle)/Contents")
         try fs.write(Data("old-info".utf8), to: "\(bundle)/Contents/Info.plist")
 
-        // U3 — rename old to backup (destination absent; atomic).
+        // Rename old to backup (destination absent; atomic).
         try fs.rename(from: bundle, to: backup)
         XCTAssertFalse(fs.fileExists(at: bundle))
         XCTAssertTrue(fs.fileExists(at: backup))
 
-        // U4 — assemble new at tmp.
+        // Assemble new at tmp.
         try fs.createDirectory(at: tmp)
         try fs.createDirectory(at: "\(tmp)/Contents/MacOS")
         try fs.write(Data("new-binary".utf8), to: "\(tmp)/Contents/MacOS/crm-mac")
         try fs.createDirectory(at: "\(tmp)/Contents")
         try fs.write(Data("new-info".utf8), to: "\(tmp)/Contents/Info.plist")
 
-        // U5 — rename tmp to final (destination absent again because
-        // U3 moved the old one).
+        // Rename tmp to final (destination absent again because the
+        // prior rename moved the old one).
         try fs.rename(from: tmp, to: bundle)
         XCTAssertTrue(fs.fileExists(at: bundle))
         XCTAssertEqual(
             try fs.read(from: "\(bundle)/Contents/MacOS/crm-mac"),
             Data("new-binary".utf8))
 
-        // U7 — best-effort cleanup of backup.
+        // Best-effort cleanup of backup.
         try fs.remove(at: backup)
         XCTAssertFalse(fs.fileExists(at: backup))
     }
 
     func testRollbackRestoresOldBundleAfterAssemblyFailure() throws {
-        // Simulate an assembly failure between U3 (rename old to
-        // backup) and U5 (rename tmp to final): the installer would
-        // remove the tmp bundle + rename backup back to final. The
+        // Simulate an assembly failure between the rename-to-backup
+        // and rename-tmp-to-final steps: the installer would remove
+        // the tmp bundle + rename backup back to final. The
         // production rename calls underneath are what we're proving
         // atomic here.
         let workDir = try makeTempWorkDir()
@@ -79,7 +78,7 @@ final class BundleSwapAtomicityTests: XCTestCase {
         try fs.createDirectory(at: bundle)
         try fs.write(Data("old".utf8), to: "\(bundle)/marker")
 
-        // U3 — rename to backup.
+        // Rename to backup.
         try fs.rename(from: bundle, to: backup)
         XCTAssertFalse(fs.fileExists(at: bundle))
 

--- a/mac-daemon/Tests/CRMMacSystemTests/DaemonPathsTests.swift
+++ b/mac-daemon/Tests/CRMMacSystemTests/DaemonPathsTests.swift
@@ -36,11 +36,11 @@ final class DaemonPathsTests: XCTestCase {
     }
 
     func testDeprecatedAliasesPointAtBundleLocations() {
-        // Per plan D12: the deprecated `binaryPath` / `plistPath`
-        // aliases point at the BUNDLE locations (the post-rewrite
-        // canonical paths), not at the legacy bare-binary / plist
-        // locations. The legacy locations remain accessible via the
-        // dedicated `legacyBinary` / `legacyPlist` accessors.
+        // The deprecated `binaryPath` / `plistPath` aliases point at
+        // the BUNDLE locations (the post-rewrite canonical paths),
+        // not at the legacy bare-binary / plist locations. The
+        // legacy locations remain accessible via the dedicated
+        // `legacyBinary` / `legacyPlist` accessors.
         let home = URL(fileURLWithPath: "/Users/alice")
         let paths = DaemonPaths(home: home)
         // Use the deprecated property to assert the alias still maps

--- a/mac-daemon/Tests/CRMMacSystemTests/DaemonPathsTests.swift
+++ b/mac-daemon/Tests/CRMMacSystemTests/DaemonPathsTests.swift
@@ -6,11 +6,43 @@ final class DaemonPathsTests: XCTestCase {
     func testExpandsHome() {
         let home = URL(fileURLWithPath: "/Users/alice")
         let paths = DaemonPaths(home: home)
-        XCTAssertEqual(paths.configDir.path, "/Users/alice/Library/Application Support/crm-mac")
-        XCTAssertEqual(paths.binaryPath.path, "/Users/alice/Library/Application Support/crm-mac/bin/crm-mac")
-        XCTAssertEqual(paths.plistPath.path, "/Users/alice/Library/LaunchAgents/\(Daemon.label).plist")
+        XCTAssertEqual(
+            paths.configDir.path,
+            "/Users/alice/Library/Application Support/crm-mac")
+        // Bundle layout (new install location — SMAppService).
+        XCTAssertEqual(
+            paths.bundleApp.path,
+            "/Users/alice/Library/Application Support/crm-mac/crm-mac.app")
+        XCTAssertEqual(
+            paths.bundleBinary.path,
+            "/Users/alice/Library/Application Support/crm-mac/crm-mac.app/Contents/MacOS/crm-mac")
+        XCTAssertEqual(
+            paths.bundleInfoPlist.path,
+            "/Users/alice/Library/Application Support/crm-mac/crm-mac.app/Contents/Info.plist")
+        XCTAssertEqual(
+            paths.bundlePlist.path,
+            "/Users/alice/Library/Application Support/crm-mac/crm-mac.app/Contents/Library/LaunchAgents/\(Daemon.label).plist")
+        // Legacy paths (kept for migration detection).
+        XCTAssertEqual(
+            paths.legacyBinary.path,
+            "/Users/alice/Library/Application Support/crm-mac/bin/crm-mac")
+        XCTAssertEqual(
+            paths.legacyPlist.path,
+            "/Users/alice/Library/LaunchAgents/\(Daemon.label).plist")
+        // Other paths unchanged.
         XCTAssertEqual(paths.stdoutLog.path, "/Users/alice/Library/Logs/crm-mac/stdout.log")
         XCTAssertEqual(paths.stderrLog.path, "/Users/alice/Library/Logs/crm-mac/stderr.log")
         XCTAssertEqual(paths.apiKeyFile.path, "/Users/alice/Library/Application Support/crm-mac/api-key")
+    }
+
+    func testLegacyAliasesMirrorLegacyPaths() {
+        // Pre-rewrite deprecated aliases. Kept while the Installer
+        // rewrite is rolled out commit-by-commit. Both must point at
+        // the LEGACY locations so existing call sites preserve their
+        // semantics.
+        let home = URL(fileURLWithPath: "/Users/alice")
+        let paths = DaemonPaths(home: home)
+        XCTAssertEqual(paths.binaryPath, paths.legacyBinary)
+        XCTAssertEqual(paths.plistPath, paths.legacyPlist)
     }
 }

--- a/mac-daemon/Tests/CRMMacSystemTests/DaemonPathsTests.swift
+++ b/mac-daemon/Tests/CRMMacSystemTests/DaemonPathsTests.swift
@@ -35,14 +35,20 @@ final class DaemonPathsTests: XCTestCase {
         XCTAssertEqual(paths.apiKeyFile.path, "/Users/alice/Library/Application Support/crm-mac/api-key")
     }
 
-    func testLegacyAliasesMirrorLegacyPaths() {
-        // Pre-rewrite deprecated aliases. Kept while the Installer
-        // rewrite is rolled out commit-by-commit. Both must point at
-        // the LEGACY locations so existing call sites preserve their
-        // semantics.
+    func testDeprecatedAliasesPointAtBundleLocations() {
+        // Per plan D12: the deprecated `binaryPath` / `plistPath`
+        // aliases point at the BUNDLE locations (the post-rewrite
+        // canonical paths), not at the legacy bare-binary / plist
+        // locations. The legacy locations remain accessible via the
+        // dedicated `legacyBinary` / `legacyPlist` accessors.
         let home = URL(fileURLWithPath: "/Users/alice")
         let paths = DaemonPaths(home: home)
-        XCTAssertEqual(paths.binaryPath, paths.legacyBinary)
-        XCTAssertEqual(paths.plistPath, paths.legacyPlist)
+        // Use the deprecated property to assert the alias still maps
+        // to the bundle path.
+        XCTAssertEqual(paths.binaryPath, paths.bundleBinary)
+        XCTAssertEqual(paths.plistPath, paths.bundlePlist)
+        // Legacy paths are separate.
+        XCTAssertNotEqual(paths.binaryPath, paths.legacyBinary)
+        XCTAssertNotEqual(paths.plistPath, paths.legacyPlist)
     }
 }


### PR DESCRIPTION
## Summary

Wraps the Mac daemon as a `crm-mac.app` bundle (under `~/Library/Application Support/crm-mac/`) and replaces `launchctl bootstrap`/`bootout` with `SMAppService.register()`/`unregister()`. The bundle identifier `xyz.spengrah.crm-mac` becomes the TCC attribution key, with a two-pass ad-hoc codesign (`--identifier xyz.spengrah.crm-mac` on the inner Mach-O + outer bundle seal) so the identifier stays stable across rebuilds. References #316 (issue stays open — see Hypothesis validation result below).

- New abstractions in CRMMacLifecycle: `AgentService` (typed SMAppService surface), `ProcessSignaller` (SIGTERM + flock-based pidfile-release primitive), `BundleAssembler` (Swift install-time bundle assembly via FilesystemAdapter + ExecutableAdapter).
- Build path: `Scripts/assemble_bundle.sh` runs on Command Line Tools only (no Xcode dependency) — `mkdir` / `cp` / `chmod` / `plutil` / `codesign`. Triple verification (`--verify --strict --deep` plus inner + outer identifier grep).
- Install / upgrade / register-only / uninstall rewritten around the bundle layout. Upgrade uses backup-rename-swap (every individual rename uses an empty/absent destination, sidestepping `rename(2)` `ENOTEMPTY`); rollback restores the backup on any failure between assemble and register, surfacing a composed `upgradeRollbackFailed` if the restore itself fails.
- One-shot migration from the legacy bare-binary install: stops the legacy daemon (SIGTERM + flock-poll), bootouts the legacy launchd registration with a `printService` verification probe, assembles + registers the new bundle, then deletes the legacy plist + binary post-register (partial-migration retries on both `--upgrade` and `--register-only` re-run the cleanup so the abandoned `~/Library/LaunchAgents/<label>.plist` can't be auto-loaded on next login).
- New operator subcommands `crm-mac stop` / `crm-mac start` bracket maintenance windows; replace prior `launchctl bootout`/`bootstrap` operator instructions in the README + error messages.
- Doctor surfaces `agent_service` registration status (enabled / requires_approval / not_registered / not_found) instead of parsing `launchctl print` exit codes.

## Hypothesis validation

The TCC stability claim is the engineering hypothesis this PR is built on. Apple documents the SMAppService + bundle architecture but does NOT explicitly promise "ad-hoc rebuilt bundles preserve Contacts + FDA grants across rebuilds." The plan section "Hypothesis validation" documents the empirical procedure: fresh install → grant Contacts + FDA → modify a source file → `make mac-daemon` → `crm-mac install --upgrade` → confirm `crm-mac doctor` is still all PASS with no permission re-prompts.

**Hypothesis validation result: PARTIAL — issue #316 stays open.** Ran the procedure end-to-end on macOS 14 with ad-hoc signing. Findings:

- ✅ Bundle attribution layer works as intended. The launchd-spawned daemon's TCC requests show `requesting=xyz.spengrah.crm-mac` with no terminal in the responsibility chain. Contacts re-prompts attribute to `crm-mac.app`, not Ghostty or any parent shell. The Login Items toggle in System Settings becomes the canonical "Allow in Background" surface.
- ❌ TCC grants do NOT survive rebuilds on ad-hoc signatures. tccd's log states the failure explicitly: `Failed to match existing code requirement for subject xyz.spengrah.crm-mac and service kTCCServiceAddressBook` with old + new CDHash both printed. Same pattern fires against `kTCCServiceSystemPolicyAllFiles` (FDA). Root cause: ad-hoc-signed bundles get a designated requirement that embeds the CDHash; TCC's grant lookup keys on `(bundle_id, designated_requirement)`, so a rebuild produces a new designated requirement and TCC treats the bundle as a new app.

Diagnostic ladder from the plan:
- **(a) Codesign identifier:** PASS. `Identifier=xyz.spengrah.crm-mac` on both inner Mach-O and outer bundle. Not the cause.
- **(b) Bundle location:** not attempted. The TCC log message names the code-requirement match as the failure point, which is independent of the bundle's path on disk.
- **(c) Tiny-installer-app pattern:** not attempted, not expected to help. That pattern changes who calls `SMAppService.register()`, not the designated requirement of the daemon binary.
- **(d) Developer ID alternative:** would fix the underlying issue. With a Developer ID Application certificate, the designated requirement becomes `anchor apple generic and certificate leaf[subject.OU] = <team>`, which is stable across CDHash changes. Costs $99/year + a new Apple Developer account; tracked separately on #316.

**Bug surfaced + fixed during validation:** commit `c7fedfd` — fresh-install + upgrade were codesigning the bundle BEFORE substituting `__INSTALL_PREFIX__` in the embedded plist, which broke the bundle's resource seal post-write. Subsequent `SMAppService.register()` calls failed with `-67054` codesigning errors. Fix: embed the real install path at render time (the placeholder pattern is unnecessary because the install path is statically known).

**Architecture change surfaced + applied during validation:** commit `ca98de5` — the launchd-spawned daemon now triggers the Contacts prompt via `requestAccess()` in the per-tick auth probe on `.notDetermined`. Previously the prompt was only triggered from the shell-launched install command, which inherits the parent terminal's TCC responsibility chain (so the grant attributed to Ghostty, not the bundle). With this change the prompt is bundle-attributed end-to-end.

**Why proceed despite the negative result on the main hypothesis.** The improved re-prompt UX is a real ergonomic win on its own, even without grant persistence: re-prompts are clean OS dialogs attributed to the bundle ID rather than menu-clicking through System Settings. The FDA caveat (apps cannot prompt for Full Disk Access, so each rebuild still requires a manual drag into System Settings → Privacy & Security → Full Disk Access) is the largest remaining ergonomic gap and is not solved here — only a stable codesign identity would fix it.

## Test plan

- [x] `swift build -c release -Xswiftc -warnings-as-errors` clean (no XCTest available locally)
- [x] `make mac-daemon` produces `crm-mac.app` with the correct structure + codesign identifier
- [x] `bash Scripts/assemble_bundle.sh` smoke succeeds against the release Mach-O
- [x] All `--help` subcommands exit 0 (including new `stop` / `start`)
- [x] Per-key Info.plist comparison between source-tree file and assembled bundle's `Contents/Info.plist`
- [x] Operator ran the Hypothesis Validation procedure on a real Mac (macOS 14): bundle-attribution PASS, CDHash-stability FAIL, codesign-after-substitution bug found + fixed inline, daemon-triggers-prompt change applied + verified
- [x] CI: `swift test` runs the full unit suite (CRMMacLifecycleTests + CRMMacSystemTests + new auth-probe regression test in CRMMacIcloudContactsSourceTests)
- [x] CI: opt-in integration tests (`CRM_MAC_INTEGRATION_TESTS=1`) run `BundleAssemblyParityTests` + `BundleSwapAtomicityTests` + `BundleCodesignSealTests` against real Foundation
- [x] CI: bundle-assembly smoke step (structure + plist lint + per-key match + codesign verify + identifier on inner + outer)

## Plan + design

- Plan: `.ai/log/plan/mac-daemon-app-bundle-rewrite.md` (9 Codex review rounds; landed at PASS; Validation outcome section appended post-empirical-run)
- Local Codex review rounds on the branch: 5 (PASS); Claude /review-head: 0×P0, 0×P1, 4×P2, 2×P3 (`.ai/log/review/a68aaf4265c2457385913edf086a0611d8a27f44.md`)

## Commits

```
84d04cc feat(mac-daemon): expand Info.plist to 10-key bundle set
6bdbf9c feat(mac-daemon): bundle assembly primitives (shell + Swift)
087a8ac feat(mac-daemon): AgentService + ProcessSignaller abstractions
76ce18b refactor(mac-daemon): add bundle-aware path fields, keep legacy aliases
6b50ba1 feat(mac-daemon): rewrite lifecycle workflows for SMAppService
529994d test(mac-daemon): legacy migration + bundle swap atomicity coverage
9e8f5f0 feat(mac-daemon): add `crm-mac stop` + `crm-mac start` subcommands
172c099 docs(mac-daemon): README rewrite + CI bundle-assembly smoke
5fc47dc fix(mac-daemon): address Codex round-1 review findings
b6237f2 fix(mac-daemon): address Codex round-2 review findings
d0c6d44 fix(mac-daemon): address Codex round-3 review findings
a68aaf4 fix(mac-daemon): finish provenance-comment cleanup
c7fedfd fix(mac-daemon): embed install path before bundle codesign  (validation-surfaced bug)
ca98de5 fix(mac-daemon): trigger Contacts prompt from launchd-spawned daemon  (validation-surfaced architecture gap)
```
