### PR TITLE
fix(ingest): skip identifiers that normalize to empty (#320)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -272,6 +272,9 @@ temp/
 tmp/
 *.temp
 
+# Local last-deployed SHAs (per-target change detection for deploy-all)
+.deploy-state/
+
 # Archive files (if they contain sensitive data)
 *.zip
 *.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -291,7 +291,7 @@ test: test-unit test-integration test-frontend
 
 test-unit:
 	@echo "Running backend unit tests..."
-	@cd backend && go test ./tests/... ./internal/matching/... ./internal/events/... -v -short
+	@cd backend && go test ./tests/... ./internal/matching/... ./internal/events/... ./internal/service/... -v -short
 
 test-integration-fast:
 	@echo "Running backend integration tests (default set)..."

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Personal CRM Makefile
 
-.PHONY: help setup dev build crm-admin mac-daemon test test-daemon-local clean docker-up docker-down docker-reset test-cadence-ultra test-cadence-fast prod staging testing start start-local stop restart reload status dev-stop dev-restart dev-api-stop dev-api-start dev-api-restart ci-build-backend ci-build-frontend ci-build ci-test test-e2e test-e2e-local test-e2e-diff e2e-db deploy setup-pi dev-native postgres-native sqlc smoke-test test-integration-fast test-integration-slow test-mac-host-migrations check-cadence-sole-writer check-followup-sole-writer check-rematch-sole-dispatcher
+.PHONY: help setup dev build crm-admin mac-daemon test test-daemon-local clean docker-up docker-down docker-reset test-cadence-ultra test-cadence-fast prod staging testing start start-local stop restart reload status dev-stop dev-restart dev-api-stop dev-api-start dev-api-restart ci-build-backend ci-build-frontend ci-build ci-test test-e2e test-e2e-local test-e2e-diff e2e-db deploy deploy-pi deploy-mac deploy-all setup-pi dev-native postgres-native sqlc smoke-test test-integration-fast test-integration-slow test-mac-host-migrations check-cadence-sole-writer check-followup-sole-writer check-rematch-sole-dispatcher
 
 # Repo root (supports running make from subdirectories).
 REPO_ROOT := $(shell git rev-parse --show-toplevel)
@@ -66,9 +66,12 @@ help:
 	@echo "  test-cadence-ultra - Test all cadences in minutes (testing env)"
 	@echo "  test-cadence-fast  - Test all cadences in hours (staging env)"
 	@echo ""
-	@echo "Raspberry Pi Deployment:"
-	@echo "  setup-pi - One-time Pi setup (create user, directories)"
-	@echo "  deploy   - Build and deploy to Pi (requires setup-pi first)"
+	@echo "Deployment:"
+	@echo "  setup-pi   - One-time Pi setup (create user, directories)"
+	@echo "  deploy-pi  - Build and deploy to Pi (requires setup-pi first)"
+	@echo "  deploy-mac - Build and install the Mac daemon (requires CRM_MAC_CODESIGN_IDENTITY)"
+	@echo "  deploy-all - Deploy Pi and Mac daemon — but only those whose source paths changed since last deploy"
+	@echo "  deploy     - Alias for deploy-pi"
 
 # Setup development environment (installs all dev dependencies)
 # Run this first when setting up a new development environment
@@ -616,9 +619,18 @@ status:
 		ls -lh logs/*.log 2>/dev/null | tail -5 || echo "  No log files found"; \
 	fi
 
-# Raspberry Pi Deployment
-deploy:
+# Deployment
+deploy-pi:
 	@./scripts/deploy.sh
+
+deploy-mac:
+	@./scripts/deploy-mac-daemon.sh
+
+deploy-all:
+	@./scripts/deploy-all.sh
+
+# Backwards-compat alias for `make deploy-pi`.
+deploy: deploy-pi
 
 setup-pi:
 	@./scripts/setup-pi.sh

--- a/backend/internal/service/ingest.go
+++ b/backend/internal/service/ingest.go
@@ -897,6 +897,16 @@ func (s *IngestService) handleExternalContactUpserted(
 		if em.Value == "" {
 			continue
 		}
+		// Skip values that normalize to empty (e.g. whitespace-only).
+		// Otherwise MatchOrCreateTx returns an error that the caller
+		// treats as a fatal envelope rejection, stalling daemon cursor
+		// advancement on a single junk field. The internal empty-check
+		// inside MatchOrCreateTx stays as defense-in-depth for other
+		// callers (e.g. handleRawMessage, where a single un-normalizable
+		// peer handle IS a fatal data-quality problem).
+		if identity.Normalize(em.Value, identity.IdentifierTypeEmail) == "" {
+			continue
+		}
 		result, err := s.identity.MatchOrCreateTx(ctx, tx, MatchRequest{
 			RawIdentifier: em.Value,
 			Type:          identity.IdentifierTypeEmail,
@@ -922,6 +932,15 @@ func (s *IngestService) handleExternalContactUpserted(
 	}
 	for _, ph := range p.Phones {
 		if ph.Value == "" {
+			continue
+		}
+		// Skip values that normalize to empty (e.g. "+", whitespace).
+		// Otherwise MatchOrCreateTx returns an error that the caller
+		// treats as a fatal envelope rejection, stalling daemon cursor
+		// advancement on a single junk field. The internal empty-check
+		// inside MatchOrCreateTx stays as defense-in-depth for other
+		// callers.
+		if identity.Normalize(ph.Value, identity.IdentifierTypePhone) == "" {
 			continue
 		}
 		result, err := s.identity.MatchOrCreateTx(ctx, tx, MatchRequest{

--- a/backend/internal/service/ingest_test.go
+++ b/backend/internal/service/ingest_test.go
@@ -8,6 +8,7 @@ import (
 	"personal-crm/backend/internal/accelerated"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/identity"
 	"personal-crm/backend/internal/repository"
 
 	"github.com/google/uuid"
@@ -435,15 +436,20 @@ func (s *stubExternalContactWriter) SoftDeleteTx(_ context.Context, _ pgx.Tx, _ 
 }
 
 // stubIdentityMatcher returns a configured MatchResult / error for
-// every MatchOrCreateTx call.
+// every MatchOrCreateTx call. requests records the inputs of each call
+// so tests can assert which raw values reached the matcher (used by the
+// "skip un-normalizable identifiers" tests, which need to prove that
+// junk values like "+" or "   " never even hit the matcher).
 type stubIdentityMatcher struct {
-	result *MatchResult
-	err    error
-	calls  int
+	result   *MatchResult
+	err      error
+	calls    int
+	requests []MatchRequest
 }
 
-func (s *stubIdentityMatcher) MatchOrCreateTx(_ context.Context, _ pgx.Tx, _ MatchRequest) (*MatchResult, error) {
+func (s *stubIdentityMatcher) MatchOrCreateTx(_ context.Context, _ pgx.Tx, req MatchRequest) (*MatchResult, error) {
 	s.calls++
+	s.requests = append(s.requests, req)
 	return s.result, s.err
 }
 
@@ -520,6 +526,181 @@ func TestHandleExternalContactUpserted_LiveUpsertSkipsRevive(t *testing.T) {
 	rej := svc.handleExternalContactUpserted(context.Background(), nil, env, hostID)
 	require.Nil(t, rej)
 	require.Equal(t, 0, stubExt.reviveCalls, "ReviveTx must NOT be called on a live first-insert")
+}
+
+// upsertEnvWithContactMethods builds an external_contact.upserted
+// envelope with the provided emails/phones. Mirrors validUpsertedEnv
+// but lets callers populate contact-method values, which the
+// un-normalizable-identifier tests need. The source_id hash is
+// recomputed over the actual payload bytes so the envelope would pass
+// verifyExternalContactInvariants if it were run (these unit tests
+// invoke handleExternalContactUpserted directly so the verifier is
+// bypassed regardless, but recomputing keeps the helper honest).
+func upsertEnvWithContactMethods(t *testing.T, host uuid.UUID, entityID string, emails, phones []string) *events.Envelope {
+	t.Helper()
+	em := make([]events.ExternalContactMethodValue, 0, len(emails))
+	for _, v := range emails {
+		em = append(em, events.ExternalContactMethodValue{Value: v})
+	}
+	ph := make([]events.ExternalContactMethodValue, 0, len(phones))
+	for _, v := range phones {
+		ph = append(ph, events.ExternalContactMethodValue{Value: v})
+	}
+	payload := mustMarshalExtUpsert(events.ExternalContactUpsertedPayload{
+		Version:  1,
+		HostID:   host,
+		Source:   "icloud_contacts",
+		EntityID: entityID,
+		Emails:   em,
+		Phones:   ph,
+	})
+	hashHex, err := ComputeContentHash(payload)
+	require.NoError(t, err)
+	return &events.Envelope{
+		Source:   "icloud_contacts",
+		SourceID: entityID + "@" + hashHex,
+		Kind:     events.KindExternalContactUpserted,
+		Payload:  payload,
+	}
+}
+
+// TestHandleExternalContactUpserted_SkipsPhonesThatNormalizeToEmpty
+// proves the call-site pre-check filters phones whose value normalizes
+// to empty (e.g. "+", whitespace-only) BEFORE invoking MatchOrCreateTx.
+// This is the unit-level proof that the cursor-stall fix avoids the
+// lower-layer "empty identifier after normalization" rejection — the
+// matcher never sees those values at all.
+func TestHandleExternalContactUpserted_SkipsPhonesThatNormalizeToEmpty(t *testing.T) {
+	rowID := uuid.New()
+	hostID := uuid.New()
+	liveRow := &repository.ExternalContact{
+		ID:          rowID,
+		Source:      "icloud_contacts",
+		SourceID:    "CN-junk-phone",
+		MatchStatus: repository.MatchStatusUnmatched,
+	}
+	stubExt := &stubExternalContactWriter{
+		getResp:    nil,
+		getErr:     db.ErrNotFound,
+		upsertResp: liveRow,
+	}
+	stubIdent := &stubIdentityMatcher{result: &MatchResult{}}
+
+	svc := &IngestService{
+		identity:         stubIdent,
+		externalContacts: stubExt,
+	}
+	env := upsertEnvWithContactMethods(t, hostID, "CN-junk-phone",
+		nil, []string{"+", "   ", "+15551234567"})
+	rej := svc.handleExternalContactUpserted(context.Background(), nil, env, hostID)
+	require.Nil(t, rej, "handler must not reject when junk phones are skipped")
+	require.Equal(t, 1, stubIdent.calls, "matcher must be invoked exactly once (for the valid phone)")
+	require.Len(t, stubIdent.requests, 1)
+	require.Equal(t, "+15551234567", stubIdent.requests[0].RawIdentifier)
+	require.Equal(t, identity.IdentifierTypePhone, stubIdent.requests[0].Type)
+}
+
+// TestHandleExternalContactUpserted_SkipsEmailsThatNormalizeToEmpty
+// mirrors the phone case for emails. Whitespace/tab-only values must
+// not reach MatchOrCreateTx.
+func TestHandleExternalContactUpserted_SkipsEmailsThatNormalizeToEmpty(t *testing.T) {
+	rowID := uuid.New()
+	hostID := uuid.New()
+	liveRow := &repository.ExternalContact{
+		ID:          rowID,
+		Source:      "icloud_contacts",
+		SourceID:    "CN-junk-email",
+		MatchStatus: repository.MatchStatusUnmatched,
+	}
+	stubExt := &stubExternalContactWriter{
+		getResp:    nil,
+		getErr:     db.ErrNotFound,
+		upsertResp: liveRow,
+	}
+	stubIdent := &stubIdentityMatcher{result: &MatchResult{}}
+
+	svc := &IngestService{
+		identity:         stubIdent,
+		externalContacts: stubExt,
+	}
+	env := upsertEnvWithContactMethods(t, hostID, "CN-junk-email",
+		[]string{"   ", "\t", "ok@example.com"}, nil)
+	rej := svc.handleExternalContactUpserted(context.Background(), nil, env, hostID)
+	require.Nil(t, rej, "handler must not reject when junk emails are skipped")
+	require.Equal(t, 1, stubIdent.calls, "matcher must be invoked exactly once (for the valid email)")
+	require.Len(t, stubIdent.requests, 1)
+	require.Equal(t, "ok@example.com", stubIdent.requests[0].RawIdentifier)
+	require.Equal(t, identity.IdentifierTypeEmail, stubIdent.requests[0].Type)
+}
+
+// TestHandleExternalContactUpserted_AllPhonesAndEmailsNormalizeToEmpty_NoMatcherCalls
+// proves that an envelope whose every identifier normalizes to empty
+// still ingests cleanly — no matcher calls, no rejection. This is the
+// "manual-review row" path the issue body endorses.
+func TestHandleExternalContactUpserted_AllPhonesAndEmailsNormalizeToEmpty_NoMatcherCalls(t *testing.T) {
+	rowID := uuid.New()
+	hostID := uuid.New()
+	liveRow := &repository.ExternalContact{
+		ID:          rowID,
+		Source:      "icloud_contacts",
+		SourceID:    "CN-all-junk",
+		MatchStatus: repository.MatchStatusUnmatched,
+	}
+	stubExt := &stubExternalContactWriter{
+		getResp:    nil,
+		getErr:     db.ErrNotFound,
+		upsertResp: liveRow,
+	}
+	stubIdent := &stubIdentityMatcher{result: &MatchResult{}}
+
+	svc := &IngestService{
+		identity:         stubIdent,
+		externalContacts: stubExt,
+	}
+	env := upsertEnvWithContactMethods(t, hostID, "CN-all-junk",
+		[]string{"\t"}, []string{"+"})
+	rej := svc.handleExternalContactUpserted(context.Background(), nil, env, hostID)
+	require.Nil(t, rej, "handler must accept envelope even if all identifiers normalize to empty")
+	require.Equal(t, 0, stubIdent.calls, "matcher must NOT be invoked when all identifiers are un-normalizable")
+}
+
+// TestHandleExternalContactUpserted_MixedJunkAndValid_CallsMatcherOnceWithValid
+// proves both loops run to completion and the matcher receives exactly
+// the two valid values, in source order (emails first, then phones).
+// This guards the cross-loop interaction documented in the plan: junk
+// in one loop must not short-circuit the other.
+func TestHandleExternalContactUpserted_MixedJunkAndValid_CallsMatcherOnceWithValid(t *testing.T) {
+	rowID := uuid.New()
+	hostID := uuid.New()
+	liveRow := &repository.ExternalContact{
+		ID:          rowID,
+		Source:      "icloud_contacts",
+		SourceID:    "CN-mixed",
+		MatchStatus: repository.MatchStatusUnmatched,
+	}
+	stubExt := &stubExternalContactWriter{
+		getResp:    nil,
+		getErr:     db.ErrNotFound,
+		upsertResp: liveRow,
+	}
+	stubIdent := &stubIdentityMatcher{result: &MatchResult{}}
+
+	svc := &IngestService{
+		identity:         stubIdent,
+		externalContacts: stubExt,
+	}
+	env := upsertEnvWithContactMethods(t, hostID, "CN-mixed",
+		[]string{"   ", "ok@example.com"},
+		[]string{"+", "+15551234567"})
+	rej := svc.handleExternalContactUpserted(context.Background(), nil, env, hostID)
+	require.Nil(t, rej)
+	require.Equal(t, 2, stubIdent.calls, "matcher must be invoked once per valid identifier")
+	require.Len(t, stubIdent.requests, 2)
+	// Emails loop runs first, then phones.
+	require.Equal(t, "ok@example.com", stubIdent.requests[0].RawIdentifier)
+	require.Equal(t, identity.IdentifierTypeEmail, stubIdent.requests[0].Type)
+	require.Equal(t, "+15551234567", stubIdent.requests[1].RawIdentifier)
+	require.Equal(t, identity.IdentifierTypePhone, stubIdent.requests[1].Type)
 }
 
 // TestVerifyExternalContactInvariants_HashMismatchRejected proves the

--- a/backend/internal/service/ingest_test.go
+++ b/backend/internal/service/ingest_test.go
@@ -635,8 +635,9 @@ func TestHandleExternalContactUpserted_SkipsEmailsThatNormalizeToEmpty(t *testin
 
 // TestHandleExternalContactUpserted_AllPhonesAndEmailsNormalizeToEmpty_NoMatcherCalls
 // proves that an envelope whose every identifier normalizes to empty
-// still ingests cleanly — no matcher calls, no rejection. This is the
-// "manual-review row" path the issue body endorses.
+// still ingests cleanly — no matcher calls, no rejection. The contact
+// lands as an external_contact row with zero linked identities,
+// available for manual review.
 func TestHandleExternalContactUpserted_AllPhonesAndEmailsNormalizeToEmpty_NoMatcherCalls(t *testing.T) {
 	rowID := uuid.New()
 	hostID := uuid.New()
@@ -667,8 +668,7 @@ func TestHandleExternalContactUpserted_AllPhonesAndEmailsNormalizeToEmpty_NoMatc
 // TestHandleExternalContactUpserted_MixedJunkAndValid_CallsMatcherOnceWithValid
 // proves both loops run to completion and the matcher receives exactly
 // the two valid values, in source order (emails first, then phones).
-// This guards the cross-loop interaction documented in the plan: junk
-// in one loop must not short-circuit the other.
+// Junk in one loop must not short-circuit the other.
 func TestHandleExternalContactUpserted_MixedJunkAndValid_CallsMatcherOnceWithValid(t *testing.T) {
 	rowID := uuid.New()
 	hostID := uuid.New()

--- a/backend/tests/api/external_contact_ingest_test.go
+++ b/backend/tests/api/external_contact_ingest_test.go
@@ -3,10 +3,13 @@ package api
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -17,6 +20,7 @@ import (
 	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/identity"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/service"
 
@@ -704,4 +708,353 @@ func TestIngestExternalContact_VersionTooHigh_Rejected(t *testing.T) {
 	require.Equal(t, 1, resp.Rejected)
 	require.Equal(t, "PAYLOAD_INVALID", resp.Errors[0].Code)
 	require.Contains(t, resp.Errors[0].Message, "upgrade Pi")
+}
+
+// ----------------------------------------------------------------------------
+// Un-normalizable identifier tests (issue #320)
+//
+// Regression coverage for the daemon cursor stall caused by per-event
+// rejections when a phone/email field normalized to the empty string
+// (e.g. "+", "   ", "\t"). All tests assert the envelope is accepted
+// and other (valid) identifiers in the same envelope still produce
+// identity rows / match the seeded contact.
+// ----------------------------------------------------------------------------
+
+// findSeededMethod returns the seeded contact_method value for the
+// given type ("email" or "phone"). Mirrors the inline lookups in
+// existing tests but in one place.
+func findSeededMethod(t *testing.T, env *extContactIngestEnv, methodType string) string {
+	t.Helper()
+	methods, err := env.cmRepo.ListContactMethodsByContact(context.Background(), env.seededContact)
+	require.NoError(t, err)
+	for _, m := range methods {
+		if m.Type == methodType {
+			return m.Value
+		}
+	}
+	t.Fatalf("no seeded %s on env.seededContact", methodType)
+	return ""
+}
+
+// addSeededPhoneWithUniqueDigits attaches a new phone contact_method
+// to env.seededContact whose normalized value embeds a high-entropy
+// digit sequence derived from sourceIDPrefix. The env's default
+// seeded phone uses uuid hex which can normalize to a short digit
+// string (e.g. all-letters suffix yields "+1555"), causing
+// ambiguity with other tests that share the same DB. Tests that
+// match via phone use this helper instead to avoid cross-test
+// collisions on value_normalized.
+func addSeededPhoneWithUniqueDigits(t *testing.T, env *extContactIngestEnv) string {
+	t.Helper()
+	// sourceIDPrefix is "ext-ingest-<uuid8>-"; hash to 10 digits.
+	h := sha256.Sum256([]byte(env.sourceIDPrefix))
+	var b strings.Builder
+	for _, by := range h {
+		if b.Len() >= 10 {
+			break
+		}
+		fmt.Fprintf(&b, "%d", int(by)%10)
+	}
+	phone := "+1" + b.String()
+	_, err := env.cmRepo.CreateContactMethod(context.Background(), repository.CreateContactMethodRequest{
+		ContactID: env.seededContact,
+		Type:      "phone",
+		Value:     phone,
+	})
+	require.NoError(t, err)
+	return phone
+}
+
+func TestIngestExternalContact_Upserted_PhoneJunkPlusValidMatching_MatchesContact(t *testing.T) {
+	env := setupExtContactIngestEnv(t)
+	ctx := context.Background()
+	entityID := env.sourceIDPrefix + "phone-junk-plus-valid"
+	seededPhone := addSeededPhoneWithUniqueDigits(t, env)
+
+	countBefore, err := env.identityRepo.CountBySource(ctx, "icloud_contacts")
+	require.NoError(t, err)
+
+	ev := buildExtUpsertEvent(t, env.pairedHostID, entityID, func(p *events.ExternalContactUpsertedPayload) {
+		p.Phones = []events.ExternalContactMethodValue{
+			{Value: "+"}, // normalizes to empty — must be silently skipped
+			{Value: seededPhone},
+		}
+	})
+	w := postIngestExt(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{ev},
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseIngestResp(t, w)
+	require.Equal(t, 1, resp.Accepted)
+	require.Equal(t, 0, resp.Rejected, "errors: %+v", resp.Errors)
+
+	row := findExtRow(t, env, entityID)
+	require.NotNil(t, row)
+	require.NotNil(t, row.CRMContactID, "valid phone must produce a match")
+	require.Equal(t, env.seededContact, *row.CRMContactID)
+	require.Equal(t, repository.MatchStatusMatched, row.MatchStatus)
+
+	countAfter, err := env.identityRepo.CountBySource(ctx, "icloud_contacts")
+	require.NoError(t, err)
+	require.Equal(t, int64(1), countAfter-countBefore,
+		"exactly one identity row must be created (for the valid phone, not for \"+\")")
+
+	// Confirm the row that bumped the count is the valid phone, not "+".
+	normalized := identity.Normalize(seededPhone, identity.IdentifierTypePhone)
+	got, err := env.identityRepo.GetByIdentifier(ctx, identity.IdentifierTypePhone, normalized, "icloud_contacts")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+}
+
+func TestIngestExternalContact_Upserted_AllPhonesNormalizeToEmpty_StillAccepts(t *testing.T) {
+	env := setupExtContactIngestEnv(t)
+	ctx := context.Background()
+	entityID := env.sourceIDPrefix + "phones-all-junk"
+
+	countBefore, err := env.identityRepo.CountBySource(ctx, "icloud_contacts")
+	require.NoError(t, err)
+
+	ev := buildExtUpsertEvent(t, env.pairedHostID, entityID, func(p *events.ExternalContactUpsertedPayload) {
+		p.Phones = []events.ExternalContactMethodValue{{Value: "+"}, {Value: "   "}}
+	})
+	w := postIngestExt(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{ev},
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseIngestResp(t, w)
+	require.Equal(t, 1, resp.Accepted)
+	require.Equal(t, 0, resp.Rejected, "errors: %+v", resp.Errors)
+
+	row := findExtRow(t, env, entityID)
+	require.NotNil(t, row)
+	require.Nil(t, row.CRMContactID, "no valid phone → no match")
+	require.Equal(t, repository.MatchStatusUnmatched, row.MatchStatus)
+
+	countAfter, err := env.identityRepo.CountBySource(ctx, "icloud_contacts")
+	require.NoError(t, err)
+	require.Equal(t, int64(0), countAfter-countBefore,
+		"no identity rows must be created when all phones normalize to empty")
+}
+
+// PhoneLiteralPlus is the exact value surfaced by the PR #318
+// hypothesis-validation run that originally exposed issue #320.
+func TestIngestExternalContact_Upserted_PhoneLiteralPlus_RegressionForSurfacedData(t *testing.T) {
+	env := setupExtContactIngestEnv(t)
+	ctx := context.Background()
+	entityID := env.sourceIDPrefix + "phone-literal-plus"
+
+	countBefore, err := env.identityRepo.CountBySource(ctx, "icloud_contacts")
+	require.NoError(t, err)
+
+	ev := buildExtUpsertEvent(t, env.pairedHostID, entityID, func(p *events.ExternalContactUpsertedPayload) {
+		p.Phones = []events.ExternalContactMethodValue{{Value: "+"}}
+	})
+	w := postIngestExt(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{ev},
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseIngestResp(t, w)
+	require.Equal(t, 1, resp.Accepted)
+	require.Equal(t, 0, resp.Rejected, "errors: %+v", resp.Errors)
+
+	row := findExtRow(t, env, entityID)
+	require.NotNil(t, row)
+	require.Nil(t, row.CRMContactID)
+	require.Equal(t, repository.MatchStatusUnmatched, row.MatchStatus)
+
+	countAfter, err := env.identityRepo.CountBySource(ctx, "icloud_contacts")
+	require.NoError(t, err)
+	require.Equal(t, int64(0), countAfter-countBefore)
+}
+
+func TestIngestExternalContact_Upserted_EmailJunkPlusValidMatching_MatchesContact(t *testing.T) {
+	env := setupExtContactIngestEnv(t)
+	ctx := context.Background()
+	entityID := env.sourceIDPrefix + "email-junk-plus-valid"
+	seededEmail := findSeededMethod(t, env, "email")
+
+	countBefore, err := env.identityRepo.CountBySource(ctx, "icloud_contacts")
+	require.NoError(t, err)
+
+	ev := buildExtUpsertEvent(t, env.pairedHostID, entityID, func(p *events.ExternalContactUpsertedPayload) {
+		p.Emails = []events.ExternalContactMethodValue{
+			{Value: "   "}, // normalizes to empty — must be silently skipped
+			{Value: seededEmail},
+		}
+	})
+	w := postIngestExt(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{ev},
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseIngestResp(t, w)
+	require.Equal(t, 1, resp.Accepted)
+	require.Equal(t, 0, resp.Rejected, "errors: %+v", resp.Errors)
+
+	row := findExtRow(t, env, entityID)
+	require.NotNil(t, row)
+	require.NotNil(t, row.CRMContactID, "valid email must produce a match")
+	require.Equal(t, env.seededContact, *row.CRMContactID)
+	require.Equal(t, repository.MatchStatusMatched, row.MatchStatus)
+
+	countAfter, err := env.identityRepo.CountBySource(ctx, "icloud_contacts")
+	require.NoError(t, err)
+	require.Equal(t, int64(1), countAfter-countBefore,
+		"exactly one identity row must be created (for the valid email)")
+
+	normalized := identity.Normalize(seededEmail, identity.IdentifierTypeEmail)
+	got, err := env.identityRepo.GetByIdentifier(ctx, identity.IdentifierTypeEmail, normalized, "icloud_contacts")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+}
+
+func TestIngestExternalContact_Upserted_AllEmailsNormalizeToEmpty_StillAccepts(t *testing.T) {
+	env := setupExtContactIngestEnv(t)
+	ctx := context.Background()
+	entityID := env.sourceIDPrefix + "emails-all-junk"
+
+	countBefore, err := env.identityRepo.CountBySource(ctx, "icloud_contacts")
+	require.NoError(t, err)
+
+	ev := buildExtUpsertEvent(t, env.pairedHostID, entityID, func(p *events.ExternalContactUpsertedPayload) {
+		p.Emails = []events.ExternalContactMethodValue{{Value: "   "}, {Value: "\t"}}
+	})
+	w := postIngestExt(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{ev},
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseIngestResp(t, w)
+	require.Equal(t, 1, resp.Accepted)
+	require.Equal(t, 0, resp.Rejected, "errors: %+v", resp.Errors)
+
+	row := findExtRow(t, env, entityID)
+	require.NotNil(t, row)
+	require.Nil(t, row.CRMContactID)
+	require.Equal(t, repository.MatchStatusUnmatched, row.MatchStatus)
+
+	countAfter, err := env.identityRepo.CountBySource(ctx, "icloud_contacts")
+	require.NoError(t, err)
+	require.Equal(t, int64(0), countAfter-countBefore)
+}
+
+// EmailWhitespaceOnly is the email-side regression equivalent of
+// PhoneLiteralPlus. Note: do NOT use "@" — that survives normalization
+// and would exercise a different code path.
+func TestIngestExternalContact_Upserted_EmailWhitespaceOnly_RegressionForJunkData(t *testing.T) {
+	env := setupExtContactIngestEnv(t)
+	ctx := context.Background()
+	entityID := env.sourceIDPrefix + "email-whitespace-only"
+
+	countBefore, err := env.identityRepo.CountBySource(ctx, "icloud_contacts")
+	require.NoError(t, err)
+
+	ev := buildExtUpsertEvent(t, env.pairedHostID, entityID, func(p *events.ExternalContactUpsertedPayload) {
+		p.Emails = []events.ExternalContactMethodValue{{Value: "   "}}
+	})
+	w := postIngestExt(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{ev},
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseIngestResp(t, w)
+	require.Equal(t, 1, resp.Accepted)
+	require.Equal(t, 0, resp.Rejected, "errors: %+v", resp.Errors)
+
+	row := findExtRow(t, env, entityID)
+	require.NotNil(t, row)
+	require.Nil(t, row.CRMContactID)
+	require.Equal(t, repository.MatchStatusUnmatched, row.MatchStatus)
+
+	countAfter, err := env.identityRepo.CountBySource(ctx, "icloud_contacts")
+	require.NoError(t, err)
+	require.Equal(t, int64(0), countAfter-countBefore)
+}
+
+// JunkEmailValidMatchingPhone proves the junk-email skip in the first
+// loop does NOT prevent the phone loop from running and matching.
+func TestIngestExternalContact_Upserted_JunkEmailValidMatchingPhone_MatchesViaPhone(t *testing.T) {
+	env := setupExtContactIngestEnv(t)
+	entityID := env.sourceIDPrefix + "junk-email-valid-phone"
+	seededPhone := addSeededPhoneWithUniqueDigits(t, env)
+
+	ev := buildExtUpsertEvent(t, env.pairedHostID, entityID, func(p *events.ExternalContactUpsertedPayload) {
+		p.Emails = []events.ExternalContactMethodValue{{Value: "   "}}
+		p.Phones = []events.ExternalContactMethodValue{{Value: seededPhone}}
+	})
+	w := postIngestExt(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{ev},
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseIngestResp(t, w)
+	require.Equal(t, 1, resp.Accepted)
+	require.Equal(t, 0, resp.Rejected, "errors: %+v", resp.Errors)
+
+	row := findExtRow(t, env, entityID)
+	require.NotNil(t, row)
+	require.NotNil(t, row.CRMContactID, "junk email must not block phone-based match")
+	require.Equal(t, env.seededContact, *row.CRMContactID)
+	require.Equal(t, repository.MatchStatusMatched, row.MatchStatus)
+}
+
+// ValidEmailMatchingThenJunkPhone proves the rollback path is gone:
+// pre-fix, a valid email match followed by a "+" phone would have
+// rolled back the whole savepoint (the inner empty-check tripped after
+// state was already written).
+func TestIngestExternalContact_Upserted_ValidEmailMatchingThenJunkPhone_StillAccepted(t *testing.T) {
+	env := setupExtContactIngestEnv(t)
+	entityID := env.sourceIDPrefix + "valid-email-junk-phone"
+	seededEmail := findSeededMethod(t, env, "email")
+
+	ev := buildExtUpsertEvent(t, env.pairedHostID, entityID, func(p *events.ExternalContactUpsertedPayload) {
+		p.Emails = []events.ExternalContactMethodValue{{Value: seededEmail}}
+		p.Phones = []events.ExternalContactMethodValue{{Value: "+"}}
+	})
+	w := postIngestExt(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{ev},
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseIngestResp(t, w)
+	require.Equal(t, 1, resp.Accepted)
+	require.Equal(t, 0, resp.Rejected, "errors: %+v", resp.Errors)
+
+	row := findExtRow(t, env, entityID)
+	require.NotNil(t, row)
+	require.NotNil(t, row.CRMContactID)
+	require.Equal(t, env.seededContact, *row.CRMContactID)
+	require.Equal(t, repository.MatchStatusMatched, row.MatchStatus)
+}
+
+// BatchWithJunkAndValidContacts is the direct regression for issue
+// #320's cursor-stall failure mode: one junk-only event and one
+// matching event in the same batch. Pre-fix, the junk event would
+// reject and the daemon would hold the cursor. Both must now accept.
+func TestIngestExternalContact_Upserted_BatchWithJunkAndValidContacts_BothLand(t *testing.T) {
+	env := setupExtContactIngestEnv(t)
+	entityIDJunk := env.sourceIDPrefix + "batch-junk"
+	entityIDValid := env.sourceIDPrefix + "batch-valid"
+	seededPhone := addSeededPhoneWithUniqueDigits(t, env)
+
+	evJunk := buildExtUpsertEvent(t, env.pairedHostID, entityIDJunk, func(p *events.ExternalContactUpsertedPayload) {
+		p.Phones = []events.ExternalContactMethodValue{{Value: "+"}}
+	})
+	evValid := buildExtUpsertEvent(t, env.pairedHostID, entityIDValid, func(p *events.ExternalContactUpsertedPayload) {
+		p.Phones = []events.ExternalContactMethodValue{{Value: seededPhone}}
+	})
+
+	w := postIngestExt(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{evJunk, evValid},
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseIngestResp(t, w)
+	require.Equal(t, 2, resp.Accepted, "both events must be accepted; errors: %+v", resp.Errors)
+	require.Equal(t, 0, resp.Rejected, "errors: %+v", resp.Errors)
+
+	rowJunk := findExtRow(t, env, entityIDJunk)
+	require.NotNil(t, rowJunk, "junk-only event must still materialize an external_contact row")
+	require.Nil(t, rowJunk.CRMContactID)
+	require.Equal(t, repository.MatchStatusUnmatched, rowJunk.MatchStatus)
+
+	rowValid := findExtRow(t, env, entityIDValid)
+	require.NotNil(t, rowValid)
+	require.NotNil(t, rowValid.CRMContactID, "valid event must match the seeded contact")
+	require.Equal(t, env.seededContact, *rowValid.CRMContactID)
+	require.Equal(t, repository.MatchStatusMatched, rowValid.MatchStatus)
 }

--- a/backend/tests/api/external_contact_ingest_test.go
+++ b/backend/tests/api/external_contact_ingest_test.go
@@ -711,7 +711,7 @@ func TestIngestExternalContact_VersionTooHigh_Rejected(t *testing.T) {
 }
 
 // ----------------------------------------------------------------------------
-// Un-normalizable identifier tests (issue #320)
+// Un-normalizable identifier tests
 //
 // Regression coverage for the daemon cursor stall caused by per-event
 // rejections when a phone/email field normalized to the empty string
@@ -836,8 +836,9 @@ func TestIngestExternalContact_Upserted_AllPhonesNormalizeToEmpty_StillAccepts(t
 		"no identity rows must be created when all phones normalize to empty")
 }
 
-// PhoneLiteralPlus is the exact value surfaced by the PR #318
-// hypothesis-validation run that originally exposed issue #320.
+// PhoneLiteralPlus is a regression test for a literal "+" phone
+// surfacing from real iCloud-contacts data: previously rejected as
+// IDENTITY_MATCH_FAILED, now silently skipped.
 func TestIngestExternalContact_Upserted_PhoneLiteralPlus_RegressionForSurfacedData(t *testing.T) {
 	env := setupExtContactIngestEnv(t)
 	ctx := context.Background()
@@ -1022,10 +1023,10 @@ func TestIngestExternalContact_Upserted_ValidEmailMatchingThenJunkPhone_StillAcc
 	require.Equal(t, repository.MatchStatusMatched, row.MatchStatus)
 }
 
-// BatchWithJunkAndValidContacts is the direct regression for issue
-// #320's cursor-stall failure mode: one junk-only event and one
-// matching event in the same batch. Pre-fix, the junk event would
-// reject and the daemon would hold the cursor. Both must now accept.
+// BatchWithJunkAndValidContacts is the direct regression for the
+// cursor-stall failure mode: one junk-only event and one matching
+// event in the same batch. Pre-fix, the junk event would reject and
+// the daemon would hold the iCloud cursor. Both must now accept.
 func TestIngestExternalContact_Upserted_BatchWithJunkAndValidContacts_BothLand(t *testing.T) {
 	env := setupExtContactIngestEnv(t)
 	entityIDJunk := env.sourceIDPrefix + "batch-junk"

--- a/scripts/deploy-all.sh
+++ b/scripts/deploy-all.sh
@@ -50,9 +50,13 @@ done
 mkdir -p "$STATE_DIR"
 HEAD_SHA="$(git rev-parse HEAD)"
 
-# Returns 0 (deploy) if state file is missing OR if `git diff` against
-# the recorded SHA reports changes on the given paths. Returns 1 (skip)
-# only when the diff is clean.
+# Returns 0 (deploy) if state file is missing OR if `git diff` reports
+# changes (tracked) OR if there are untracked files under the watched
+# paths. Returns 1 (skip) only when both checks are clean.
+#
+# `git diff --quiet` ignores untracked files, so a new source file
+# under a watched path would be silently skipped. The follow-up
+# `ls-files --others --exclude-standard` covers that gap.
 needs_deploy() {
     local state_file="$1"
     shift
@@ -66,11 +70,16 @@ needs_deploy() {
         echo "  warning: last-deployed SHA $last is not in this repo (rebased away?). Treating as changed." >&2
         return 0
     fi
-    if git diff --quiet "$last" -- "${paths[@]}"; then
-        return 1
-    else
+    if ! git diff --quiet "$last" -- "${paths[@]}"; then
         return 0
     fi
+    # Untracked files under watched paths count as a change.
+    local untracked
+    untracked="$(git ls-files --others --exclude-standard -- "${paths[@]}")"
+    if [ -n "$untracked" ]; then
+        return 0
+    fi
+    return 1
 }
 
 echo "=== Deploy-all (HEAD=$HEAD_SHA) ==="

--- a/scripts/deploy-all.sh
+++ b/scripts/deploy-all.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# Deploy CRM to the Pi and/or the Mac daemon, but only when their
+# respective source paths have changed since the last successful
+# deploy.
+#
+# Usage:
+#   ./scripts/deploy-all.sh              # deploy whatever changed
+#   ./scripts/deploy-all.sh --force-pi   # always deploy to Pi
+#   ./scripts/deploy-all.sh --force-mac  # always deploy Mac daemon
+#   ./scripts/deploy-all.sh --force      # both
+#
+# Change detection:
+#   Per-target last-deployed HEAD SHA stored in:
+#     .deploy-state/pi.sha
+#     .deploy-state/mac.sha
+#   For each target, `git diff --quiet <last-sha> -- <paths>` is the
+#   "has anything changed?" probe — includes uncommitted working-tree
+#   changes so a deploy-from-WIP works as expected.
+#
+# Paths watched per target:
+#   Pi:  backend/  frontend/  infra/  Makefile
+#        scripts/deploy.sh  scripts/setup-pi.sh
+#   Mac: mac-daemon/
+#
+# State files are gitignored (.deploy-state/) — wiping the dir
+# safely re-deploys everything on the next run.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_DIR"
+
+STATE_DIR=".deploy-state"
+PI_STATE="$STATE_DIR/pi.sha"
+MAC_STATE="$STATE_DIR/mac.sha"
+PI_PATHS=(backend frontend infra Makefile scripts/deploy.sh scripts/setup-pi.sh)
+MAC_PATHS=(mac-daemon)
+
+FORCE_PI=false
+FORCE_MAC=false
+for arg in "$@"; do
+    case $arg in
+        --force-pi)  FORCE_PI=true ;;
+        --force-mac) FORCE_MAC=true ;;
+        --force)     FORCE_PI=true; FORCE_MAC=true ;;
+        *) echo "unknown arg: $arg" >&2; exit 1 ;;
+    esac
+done
+
+mkdir -p "$STATE_DIR"
+HEAD_SHA="$(git rev-parse HEAD)"
+
+# Returns 0 (deploy) if state file is missing OR if `git diff` against
+# the recorded SHA reports changes on the given paths. Returns 1 (skip)
+# only when the diff is clean.
+needs_deploy() {
+    local state_file="$1"
+    shift
+    local paths=("$@")
+    if [ ! -f "$state_file" ]; then
+        return 0
+    fi
+    local last
+    last="$(cat "$state_file")"
+    if ! git rev-parse --verify --quiet "$last" >/dev/null; then
+        echo "  warning: last-deployed SHA $last is not in this repo (rebased away?). Treating as changed." >&2
+        return 0
+    fi
+    if git diff --quiet "$last" -- "${paths[@]}"; then
+        return 1
+    else
+        return 0
+    fi
+}
+
+echo "=== Deploy-all (HEAD=$HEAD_SHA) ==="
+echo ""
+
+# Pi
+if $FORCE_PI || needs_deploy "$PI_STATE" "${PI_PATHS[@]}"; then
+    if $FORCE_PI; then
+        echo ">>> Deploying to Pi (forced)"
+    else
+        echo ">>> Deploying to Pi"
+    fi
+    ./scripts/deploy.sh
+    echo "$HEAD_SHA" > "$PI_STATE"
+    echo "Pi: deployed at $HEAD_SHA"
+    echo ""
+else
+    echo "Pi:  no changes since $(cat "$PI_STATE") — skipping"
+    echo ""
+fi
+
+# Mac
+if $FORCE_MAC || needs_deploy "$MAC_STATE" "${MAC_PATHS[@]}"; then
+    if $FORCE_MAC; then
+        echo ">>> Deploying Mac daemon (forced)"
+    else
+        echo ">>> Deploying Mac daemon"
+    fi
+    ./scripts/deploy-mac-daemon.sh
+    echo "$HEAD_SHA" > "$MAC_STATE"
+    echo "Mac: deployed at $HEAD_SHA"
+    echo ""
+else
+    echo "Mac: no changes since $(cat "$MAC_STATE") — skipping"
+    echo ""
+fi
+
+echo "=== Done ==="

--- a/scripts/deploy-mac-daemon.sh
+++ b/scripts/deploy-mac-daemon.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# Build + install the Mac daemon locally.
+#
+# Usage: ./scripts/deploy-mac-daemon.sh
+#
+# Required env:
+#   CRM_MAC_CODESIGN_IDENTITY=<identity>
+#       Local self-signed Code Signing certificate to sign with.
+#       Using a stable cert keeps the designated requirement constant
+#       across rebuilds, which lets FDA grants survive (Contacts
+#       grants re-prompt regardless — TCC quirk).
+#       Set to "-" to force ad-hoc signing.
+#
+# Behavior:
+#   - First install (no bundle at install path): refuses with a
+#     message explaining that pairing requires interactive input
+#     (--pi-url / --pair / --hostname). Build is skipped in that
+#     case because the operator needs to invoke `crm-mac install`
+#     manually anyway.
+#   - Upgrade: runs `make mac-daemon` then `crm-mac install --upgrade`
+#     from the freshly-built build-dir binary.
+#   - Kickstarts the running daemon at the end so any new TCC state
+#     takes effect on the next tick.
+set -e
+
+if [ -z "${CRM_MAC_CODESIGN_IDENTITY:-}" ]; then
+    echo "Error: CRM_MAC_CODESIGN_IDENTITY is not set." >&2
+    echo "" >&2
+    echo "Export the name of your local self-signed Code Signing" >&2
+    echo "certificate, or set it to \"-\" to force ad-hoc signing:" >&2
+    echo "" >&2
+    echo "  export CRM_MAC_CODESIGN_IDENTITY=\"My Local Code Signing\"" >&2
+    echo "  ./scripts/deploy-mac-daemon.sh" >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+INSTALL_BUNDLE="$HOME/Library/Application Support/crm-mac/crm-mac.app"
+BUILD_BUNDLE="$PROJECT_DIR/mac-daemon/.build/release/crm-mac.app"
+BUILD_BINARY="$BUILD_BUNDLE/Contents/MacOS/crm-mac"
+DAEMON_LABEL="xyz.spengrah.crm-mac"
+
+cd "$PROJECT_DIR"
+
+echo "=== Mac daemon deploy ==="
+echo ""
+
+if [ ! -e "$INSTALL_BUNDLE" ]; then
+    echo "No existing install at $INSTALL_BUNDLE."
+    echo ""
+    echo "First install requires interactive pairing. Mint a token on the Pi:"
+    echo "  ssh <pi-host> 'crm-admin --mint-pairing-token'"
+    echo ""
+    echo "Then build and run install manually:"
+    echo "  make mac-daemon"
+    echo "  $BUILD_BINARY install \\"
+    echo "    --pi-url   <pi-url> \\"
+    echo "    --pair     <pairing-token> \\"
+    echo "    --hostname <label>"
+    exit 1
+fi
+
+echo "Existing install detected at $INSTALL_BUNDLE — running upgrade."
+echo ""
+
+echo "=== Building ==="
+make mac-daemon
+echo ""
+
+if [ ! -x "$BUILD_BINARY" ]; then
+    echo "Error: build did not produce $BUILD_BINARY" >&2
+    exit 1
+fi
+
+echo "=== Installing (upgrade) ==="
+"$BUILD_BINARY" install --upgrade
+echo ""
+
+echo "=== Kickstarting daemon ==="
+launchctl kickstart -k "gui/$(id -u)/$DAEMON_LABEL" || true
+echo ""
+
+echo "=== Verifying ==="
+sleep 2
+if launchctl print "gui/$(id -u)/$DAEMON_LABEL" >/dev/null 2>&1; then
+    echo "Daemon: registered with launchd"
+else
+    echo "Daemon: NOT found in launchd" >&2
+    exit 1
+fi
+
+echo ""
+echo "=== Mac daemon deploy complete ==="


### PR DESCRIPTION
## Summary

Closes #320. One un-normalizable phone or email value on an `external_contact.upserted` envelope (e.g. `"+"`, whitespace-only, vCard `<unknown>`) was being returned as a fatal `IDENTITY_MATCH_FAILED` rejection from `IngestService.handleExternalContactUpserted`. The Mac daemon holds the iCloud cursor on per-event rejections so a single junk field stalled cursor advancement for the entire page — every contact after it never landed either. The failure mode was surfaced empirically by the PR #318 hypothesis-validation run.

### The fix

Two pre-checks in `backend/internal/service/ingest.go` (the emails loop at L897 and the phones loop at L934). When `identity.Normalize(value, type) == ""`, `continue` silently. The internal empty-check inside `IdentityService.MatchOrCreateTx` is preserved as defense-in-depth so other callers (e.g. `handleRawMessage`, where a single un-normalizable peer handle IS fatal data) keep their fatal semantics.

The contact still ingests as an `external_contact` row with the raw payload in its `emails`/`phones` JSONB columns. No data is dropped — only the identity-row creation is skipped for the junk value.

### Bundled chore: deploy-all scripts

`f4b4d4a` (already on this branch) adds `scripts/deploy-all.sh` and `scripts/deploy-mac-daemon.sh` plus `make deploy-pi`/`deploy-mac`/`deploy-all` targets. State is tracked under `.deploy-state/` (gitignored) and each target is skipped if its watched paths haven't changed since the last successful deploy. This is unrelated to the ingest fix but ships in the same PR per workflow.

### Tests added

**Unit tests** (`backend/internal/service/ingest_test.go`, 4 new):
- `SkipsPhonesThatNormalizeToEmpty` — junk + valid phone → matcher invoked exactly once with the valid value
- `SkipsEmailsThatNormalizeToEmpty` — symmetric for emails
- `AllPhonesAndEmailsNormalizeToEmpty_NoMatcherCalls` — all-junk envelope → matcher never called, no rejection
- `MixedJunkAndValid_CallsMatcherOnceWithValid` — cross-loop, source order preserved (emails before phones)

`stubIdentityMatcher` gains a `requests []MatchRequest` field so tests can assert the raw values that reached the matcher.

**Integration tests** (`backend/tests/api/external_contact_ingest_test.go`, 9 new): phone, email, and cross-loop / batch coverage. The most important is `BatchWithJunkAndValidContacts_BothLand` — directly reproduces the cursor-stall scenario where one envelope with `phones=["+"]` previously rejected and blocked subsequent envelopes in the same batch.

A new helper `addSeededPhoneWithUniqueDigits` attaches a phone with high-entropy digits derived from `sourceIDPrefix` to the seeded contact. The env's default seeded phone (uuid hex) can normalize to a short digit string like `+1555` when the suffix happens to be all letters, causing intermittent `value_normalized` collisions on the shared test DB. Deterministic digits eliminate the flake.

### Makefile

`test-unit` extended to include `./internal/service/...` so the new unit tests (and any other pre-existing service-package tests) run under `make test-unit` and the pre-push gate. One-character change.

## Test plan

- [x] `cd backend && go build ./...` clean
- [x] `make lint` — 0 issues
- [x] `make test-unit` — all 4 new unit tests pass; pre-existing service-package tests included
- [x] `make test-integration-fast` — all 9 new integration tests pass; stable across multiple runs after `make e2e-db`
- [x] Codex review (xhigh effort, 2 rounds) → PASS
- [x] Local Claude review → PASS (`.ai/log/review/49fb0dafe3c0dbb85c1ac38f154bc998a0f1acdd.md`)
- [ ] CI green
- [ ] Human review

E2E intentionally not run as part of local verify — the fix is purely backend service-layer logic with no user-visible UI surface. CI runs the full E2E suite automatically.

## Reference

Plan: `.ai/log/plan/ingest-skip-unnormalizable-identifiers.md`