### PR TITLE
fix(mac-daemon): doctor reports honestly + configure containers skips Contacts

### DIFF
--- a/mac-daemon/Sources/CRMMacLifecycle/AllowlistConfigureFlow.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/AllowlistConfigureFlow.swift
@@ -1,0 +1,152 @@
+// AllowlistConfigureFlow centralises the dispatch decision for
+// every place the daemon CLI mutates the iCloud Contacts CNContainer
+// allowlist:
+//
+//   - `crm-mac install`'s post-pair Contacts/picker flow
+//   - `crm-mac install --re-request-permission` re-runs
+//   - `crm-mac configure containers` (interactive picker)
+//   - `crm-mac configure containers --containers <uuid,…>`
+//   - `crm-mac configure containers --list`
+//
+// The contract this flow enforces is the regression guard for
+// issue #322: non-interactive `--containers <uuid,…>` modes must
+// NOT invoke the Contacts framework. Shell-spawned CLI subcommands
+// hit the parent terminal's TCC permission, not the daemon's
+// bundle-attributed permission, so calling `requestAccess()` /
+// `listContainers()` would fail with a misleading error. The
+// non-interactive path trusts the operator-supplied UUIDs; the
+// daemon's next tick under launchd is the authoritative validation
+// point.
+//
+// Adapters are injected as closures so tests can substitute
+// call-counting spies and assert zero invocations on the
+// non-interactive branches. Production callers (in the executable
+// target) pass closures that build the real CRMMacSystem adapters.
+import Foundation
+import CRMMacCore
+
+public struct AllowlistConfigureFlow: Sendable {
+    public enum Mode: Equatable, Sendable {
+        /// Fresh-install post-pair; the operator just paired and is
+        /// picking the initial allowlist from the picker UI.
+        case freshInstallInteractive
+        /// Fresh-install post-pair with operator-supplied UUIDs.
+        case freshInstallNonInteractive(rawContainers: String)
+        /// `--re-request-permission` re-running the picker against
+        /// an existing config.
+        case reRequestPermissionInteractive
+        /// `--re-request-permission` with operator-supplied UUIDs.
+        case reRequestPermissionNonInteractive(rawContainers: String)
+        /// `configure containers` interactive picker run.
+        case configureInteractive
+        /// `configure containers --containers <uuid,…>`
+        /// non-interactive run.
+        case configureNonInteractive(rawContainers: String)
+        /// `configure containers --list` enumerate-only mode.
+        case configureList
+    }
+
+    public enum Outcome: Equatable {
+        case wrote(pickedIDs: [String])
+        /// `picked == existing`; neither state nor config was
+        /// modified. Both the writer and the flow propagate this so
+        /// the CLI wrappers can print "No allowlist changes
+        /// detected." instead of "Allowlist updated.".
+        case noOp
+        case listed(visible: [ContainerInfo])
+        /// Interactive write succeeded with a non-noop diff.
+        case completedInteractive(pickedIDs: [String])
+    }
+
+    public let mode: Mode
+    public let configStore: ConfigStore
+    public let stateStore: StateStore
+    /// Closure that returns the production auth adapter. Invoked
+    /// ONLY on interactive modes — never on non-interactive or
+    /// `configureList` modes. Tests assert this via a spy that
+    /// counts invocations of `authorizationStatus()` /
+    /// `requestAccess()`.
+    public let authAdapter: @Sendable () -> ContactsAuthorizationAdapter
+    /// Closure that returns the production container enumerator.
+    /// Invoked ONLY on interactive modes AND `configureList`;
+    /// never on non-interactive modes.
+    public let enumerator: @Sendable () -> ContactContainerEnumerator
+    /// Interactive picker. Called only on interactive modes, after
+    /// auth + enumeration succeed. Closures may throw
+    /// `AllowlistConfigureFlowError.userAborted` to abort the run
+    /// (e.g. the configure-containers y/N decline path) or any
+    /// other error which is propagated to the caller verbatim.
+    public let interactivePicker: @Sendable (_ visible: [ContainerInfo]) throws -> [String]
+
+    public init(
+        mode: Mode,
+        configStore: ConfigStore,
+        stateStore: StateStore,
+        authAdapter: @escaping @Sendable () -> ContactsAuthorizationAdapter,
+        enumerator: @escaping @Sendable () -> ContactContainerEnumerator,
+        interactivePicker: @escaping @Sendable (_ visible: [ContainerInfo]) throws -> [String]
+    ) {
+        self.mode = mode
+        self.configStore = configStore
+        self.stateStore = stateStore
+        self.authAdapter = authAdapter
+        self.enumerator = enumerator
+        self.interactivePicker = interactivePicker
+    }
+
+    public func run() async throws -> Outcome {
+        switch mode {
+        case .freshInstallNonInteractive(let raw),
+             .reRequestPermissionNonInteractive(let raw),
+             .configureNonInteractive(let raw):
+            // Non-interactive: NO Contacts framework calls.
+            let pickedIDs = ContainerAllowlistInput.parse(raw)
+            let writer = NonInteractiveAllowlistWriter(
+                configStore: configStore,
+                stateStore: stateStore,
+                mutatingExistingConfig: !mode.isFreshInstall)
+            switch try await writer.write(pickedIDs: pickedIDs) {
+            case .wrote(let ids): return .wrote(pickedIDs: ids)
+            case .noOp: return .noOp
+            }
+        case .configureList:
+            let visible = try enumerator().listContainers()
+            return .listed(visible: visible)
+        case .freshInstallInteractive,
+             .reRequestPermissionInteractive,
+             .configureInteractive:
+            let granted = try await authAdapter().requestAccess()
+            guard granted else {
+                throw AllowlistConfigureFlowError.permissionDenied
+            }
+            let visible = try enumerator().listContainers()
+            let pickedIDs = try interactivePicker(visible)
+            let writer = NonInteractiveAllowlistWriter(
+                configStore: configStore,
+                stateStore: stateStore,
+                mutatingExistingConfig: !mode.isFreshInstall)
+            switch try await writer.write(pickedIDs: pickedIDs) {
+            case .wrote: return .completedInteractive(pickedIDs: pickedIDs)
+            case .noOp:  return .noOp
+            }
+        }
+    }
+}
+
+public enum AllowlistConfigureFlowError: Error, Equatable {
+    case permissionDenied
+    /// Thrown by the `interactivePicker` closure (configure
+    /// containers only) when the user declines the y/N diff
+    /// confirmation. The flow does not raise this itself; it only
+    /// propagates from the closure.
+    case userAborted
+}
+
+extension AllowlistConfigureFlow.Mode {
+    public var isFreshInstall: Bool {
+        switch self {
+        case .freshInstallInteractive, .freshInstallNonInteractive: return true
+        default: return false
+        }
+    }
+}

--- a/mac-daemon/Sources/CRMMacLifecycle/AllowlistConfigureFlow.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/AllowlistConfigureFlow.swift
@@ -8,15 +8,14 @@
 //   - `crm-mac configure containers --containers <uuid,…>`
 //   - `crm-mac configure containers --list`
 //
-// The contract this flow enforces is the regression guard for
-// issue #322: non-interactive `--containers <uuid,…>` modes must
-// NOT invoke the Contacts framework. Shell-spawned CLI subcommands
-// hit the parent terminal's TCC permission, not the daemon's
-// bundle-attributed permission, so calling `requestAccess()` /
-// `listContainers()` would fail with a misleading error. The
-// non-interactive path trusts the operator-supplied UUIDs; the
-// daemon's next tick under launchd is the authoritative validation
-// point.
+// The contract this flow enforces: non-interactive `--containers
+// <uuid,…>` modes must NOT invoke the Contacts framework.
+// Shell-spawned CLI subcommands hit the parent terminal's TCC
+// permission, not the daemon's bundle-attributed permission, so
+// calling `requestAccess()` / `listContainers()` would fail with a
+// misleading error. The non-interactive path trusts the
+// operator-supplied UUIDs; the daemon's next tick under launchd is
+// the authoritative validation point.
 //
 // Adapters are injected as closures so tests can substitute
 // call-counting spies and assert zero invocations on the

--- a/mac-daemon/Sources/CRMMacLifecycle/ContainerAllowlistInput.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/ContainerAllowlistInput.swift
@@ -16,6 +16,16 @@ import Foundation
 public enum ContainerAllowlistInput {
     /// Split a comma-separated string into trimmed, non-empty
     /// identifier entries. Empty input returns an empty array.
+    ///
+    /// NOTE: an input that parses to `[]` (e.g. `""`, `",,,"`,
+    /// `"   "`) when paired with an existing non-empty allowlist
+    /// is a deliberate request to CLEAR the allowlist — the
+    /// non-interactive write path will bump the recovery flag and
+    /// the daemon will tombstone every previously-synced contact
+    /// on the next tick. There is no confirmation prompt; the
+    /// non-interactive path trusts the operator's stated intent.
+    /// Callers that want a confirmation step should use the
+    /// interactive picker instead.
     public static func parse(_ raw: String) -> [String] {
         raw.split(separator: ",", omittingEmptySubsequences: false)
             .map { $0.trimmingCharacters(in: .whitespaces) }

--- a/mac-daemon/Sources/CRMMacLifecycle/ContainerAllowlistInput.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/ContainerAllowlistInput.swift
@@ -1,0 +1,24 @@
+// ContainerAllowlistInput parses the operator-supplied
+// comma-separated CNContainer identifier list used by both
+// `crm-mac install --containers <uuid,uuid,…>` and
+// `crm-mac configure containers --containers <uuid,uuid,…>`.
+//
+// Pure string-massaging: trim whitespace per entry, drop empty
+// entries. Validation against the visible CNContainer list
+// deliberately does NOT happen here — the non-interactive flow's
+// whole point is to skip the (shell-context-broken) enumeration
+// step. The daemon's next tick, attributed to the bundle ID under
+// launchd, is the authoritative validation point; an unknown UUID
+// surfaces there as a recovery-requested failure visible via the
+// honest allowlist message in `crm-mac doctor`.
+import Foundation
+
+public enum ContainerAllowlistInput {
+    /// Split a comma-separated string into trimmed, non-empty
+    /// identifier entries. Empty input returns an empty array.
+    public static func parse(_ raw: String) -> [String] {
+        raw.split(separator: ",", omittingEmptySubsequences: false)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+    }
+}

--- a/mac-daemon/Sources/CRMMacLifecycle/Doctor.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/Doctor.swift
@@ -135,6 +135,17 @@ public struct Doctor {
         var results: [CheckResult] = []
 
         // 1. Permission.
+        //
+        // `.denied` and `.notDetermined` reads from a shell-spawned
+        // doctor process carry NO information about the daemon's
+        // actual TCC state — they're attributed to the parent
+        // terminal, which typically has no Contacts grant. The
+        // launchd-attributed daemon is authoritative, so we WARN with
+        // a message that points the operator at `crm-mac status`
+        // instead of telling them to grant the terminal Contacts
+        // access (which would defeat the bundle-attribution model).
+        // `.restricted` stays FAIL because MDM / parental-controls
+        // really is process-independent.
         let status = deps.contactsAuth.authorizationStatus()
         switch status {
         case .authorized, .limited:
@@ -145,8 +156,8 @@ public struct Doctor {
         case .denied:
             results.append(CheckResult(
                 name: "icloud_contacts.permission",
-                status: .fail,
-                details: "denied — re-run `crm-mac install --re-request-permission`"))
+                status: .warn,
+                details: "indeterminate from shell context — daemon is authoritative. Check `crm-mac status` for the daemon's last-tick auth state."))
         case .restricted:
             results.append(CheckResult(
                 name: "icloud_contacts.permission",
@@ -156,42 +167,57 @@ public struct Doctor {
             results.append(CheckResult(
                 name: "icloud_contacts.permission",
                 status: .warn,
-                details: "not determined — run `crm-mac install --re-request-permission`"))
+                details: "indeterminate from shell context — daemon is authoritative. If the daemon has never ticked, run `crm-mac install --re-request-permission` from this same shell."))
         }
 
         // 2. Allowlist sanity.
+        //
+        // Same shell-attribution caveat as the permission read —
+        // `listContainers()` from a shell-spawned doctor can fail
+        // with `.notAuthorized` even when the daemon under launchd
+        // is fully authorized and ticking. The previous catch
+        // assigned `visible = []`, which made every configured ID
+        // look like an "orphan" — a high-friction false positive.
+        // Now we report enumeration unavailability as its own WARN
+        // state and skip the orphan computation. Either error branch
+        // must fall through to the last-tick check below; neither
+        // may early-return, so a transient enumeration failure
+        // doesn't suppress the unrelated last-tick result.
         if allowlist.isEmpty {
             results.append(CheckResult(
                 name: "icloud_contacts.allowlist",
                 status: .warn,
                 details: "no containers configured; run `crm-mac configure containers`"))
         } else {
-            let visible: [ContainerInfo]
+            let allowlistCheck: CheckResult
             do {
-                visible = try deps.containerEnumerator.listContainers()
+                let visible = try deps.containerEnumerator.listContainers()
+                let visibleIDs = Set(visible.map(\.identifier))
+                let orphans = allowlist.filter { !visibleIDs.contains($0) }
+                if orphans.isEmpty {
+                    allowlistCheck = CheckResult(
+                        name: "icloud_contacts.allowlist",
+                        status: .pass,
+                        details: "\(allowlist.count) container(s) configured; all visible")
+                } else {
+                    let orphanList = orphans.joined(separator: ",")
+                    allowlistCheck = CheckResult(
+                        name: "icloud_contacts.allowlist",
+                        status: .warn,
+                        details: "\(orphans.count) orphaned identifier(s) (no longer visible): \(orphanList)")
+                }
             } catch ContactContainerEnumeratorError.notAuthorized {
-                visible = []
+                allowlistCheck = CheckResult(
+                    name: "icloud_contacts.allowlist",
+                    status: .warn,
+                    details: "\(allowlist.count) configured (visibility check unavailable from shell context — daemon is authoritative)")
             } catch {
-                results.append(CheckResult(
+                allowlistCheck = CheckResult(
                     name: "icloud_contacts.allowlist",
                     status: .warn,
-                    details: "container enumeration failed: \(error)"))
-                return results
+                    details: "container enumeration failed: \(error)")
             }
-            let visibleIDs = Set(visible.map(\.identifier))
-            let orphans = allowlist.filter { !visibleIDs.contains($0) }
-            if orphans.isEmpty {
-                results.append(CheckResult(
-                    name: "icloud_contacts.allowlist",
-                    status: .pass,
-                    details: "\(allowlist.count) container(s) configured; all visible"))
-            } else {
-                let orphanList = orphans.joined(separator: ",")
-                results.append(CheckResult(
-                    name: "icloud_contacts.allowlist",
-                    status: .warn,
-                    details: "\(orphans.count) orphaned identifier(s) (no longer visible): \(orphanList)"))
-            }
+            results.append(allowlistCheck)
         }
 
         // 3. Last-tick age.

--- a/mac-daemon/Sources/CRMMacLifecycle/Doctor.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/Doctor.swift
@@ -207,10 +207,24 @@ public struct Doctor {
                         details: "\(orphans.count) orphaned identifier(s) (no longer visible): \(orphanList)")
                 }
             } catch ContactContainerEnumeratorError.notAuthorized {
-                allowlistCheck = CheckResult(
-                    name: "icloud_contacts.allowlist",
-                    status: .warn,
-                    details: "\(allowlist.count) configured (visibility check unavailable from shell context — daemon is authoritative)")
+                // `.restricted` blocks Contacts process-wide (MDM /
+                // parental controls), NOT just from the shell. When
+                // the auth read just told us `.restricted`,
+                // attributing the enumeration failure to "shell
+                // context" would lull the operator into ignoring a
+                // genuine hard failure. Report it as a restriction
+                // instead.
+                if status == .restricted {
+                    allowlistCheck = CheckResult(
+                        name: "icloud_contacts.allowlist",
+                        status: .fail,
+                        details: "\(allowlist.count) configured (visibility check blocked by MDM / parental controls)")
+                } else {
+                    allowlistCheck = CheckResult(
+                        name: "icloud_contacts.allowlist",
+                        status: .warn,
+                        details: "\(allowlist.count) configured (visibility check unavailable from shell context — daemon is authoritative)")
+                }
             } catch {
                 allowlistCheck = CheckResult(
                     name: "icloud_contacts.allowlist",

--- a/mac-daemon/Sources/CRMMacLifecycle/NonInteractiveAllowlistWriter.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/NonInteractiveAllowlistWriter.swift
@@ -35,6 +35,28 @@ public enum NonInteractiveAllowlistWriteOutcome: Equatable {
     case noOp
 }
 
+/// Failures surfaced by `NonInteractiveAllowlistWriter.write(_:)`.
+/// Distinguishes the two write phases so CLI wrappers can emit
+/// phase-specific recovery guidance.
+public enum NonInteractiveAllowlistWriteError: Error {
+    /// The state-write (recovery flag) failed. No config-write was
+    /// attempted; the existing allowlist is intact and no recovery
+    /// cycle has been triggered.
+    case stateWriteFailed(underlying: Error)
+    /// The state-write succeeded (recovery flag IS set) but the
+    /// subsequent config-write failed. The existing config.json is
+    /// intact (atomic-rename), but the next tick will see the
+    /// recovery flag and reconcile against the OLD allowlist. The
+    /// operator should re-run the same command to complete the
+    /// swap.
+    case configWriteFailedAfterStateWrite(underlying: Error)
+    /// Config-write failed and no state-write happened (either the
+    /// caller passed `mutatingExistingConfig: false` with an empty
+    /// existing allowlist, OR the no-op short-circuit fired). No
+    /// recovery cycle is pending.
+    case configWriteFailed(underlying: Error)
+}
+
 public struct NonInteractiveAllowlistWriter {
     public let configStore: ConfigStore
     public let stateStore: StateStore
@@ -58,26 +80,43 @@ public struct NonInteractiveAllowlistWriter {
 
     /// Apply the caller-provided allowlist. Returns `.noOp` when
     /// the new set equals the existing set; in that case neither
-    /// the recovery flag nor the config file is touched.
+    /// the recovery flag nor the config file is touched. Failures
+    /// surface as typed `NonInteractiveAllowlistWriteError` cases
+    /// so CLI wrappers can emit phase-specific recovery guidance.
     public func write(pickedIDs: [String]) async throws -> NonInteractiveAllowlistWriteOutcome {
         let existing = (try? configStore.loadICloudContactsConfig()?.containers) ?? []
         if Set(existing) == Set(pickedIDs) {
             return .noOp
         }
-        if mutatingExistingConfig || !existing.isEmpty {
+        let stateWriteHappened = mutatingExistingConfig || !existing.isEmpty
+        if stateWriteHappened {
             // State-write FIRST. Crash between state and config
             // writes → daemon recovers against OLD allowlist on
             // next tick (still correct; idempotent).
             let mutator = StateMutator(store: stateStore)
-            try await mutator.mutate { state in
-                var src = state.sources["icloud_contacts"] ?? SourceState()
-                src.lastError = "recovery_requested:allowlist_changed"
-                src.lastErrorAt = Date()
-                state.sources["icloud_contacts"] = src
+            do {
+                try await mutator.mutate { state in
+                    var src = state.sources["icloud_contacts"] ?? SourceState()
+                    src.lastError = "recovery_requested:allowlist_changed"
+                    src.lastErrorAt = Date()
+                    state.sources["icloud_contacts"] = src
+                }
+            } catch {
+                throw NonInteractiveAllowlistWriteError.stateWriteFailed(
+                    underlying: error)
             }
         }
-        try configStore.saveICloudContactsConfig(
-            ICloudContactsConfig(containers: pickedIDs))
+        do {
+            try configStore.saveICloudContactsConfig(
+                ICloudContactsConfig(containers: pickedIDs))
+        } catch {
+            if stateWriteHappened {
+                throw NonInteractiveAllowlistWriteError
+                    .configWriteFailedAfterStateWrite(underlying: error)
+            }
+            throw NonInteractiveAllowlistWriteError
+                .configWriteFailed(underlying: error)
+        }
         return .wrote(pickedIDs: pickedIDs)
     }
 }

--- a/mac-daemon/Sources/CRMMacLifecycle/NonInteractiveAllowlistWriter.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/NonInteractiveAllowlistWriter.swift
@@ -1,0 +1,83 @@
+// NonInteractiveAllowlistWriter performs the state-then-config
+// write of an iCloud Contacts CNContainer allowlist WITHOUT
+// touching the Contacts framework.
+//
+// Why it exists: the daemon under launchd is the only process
+// context where CNContactStore is attributed to the bundle ID
+// (`xyz.spengrah.crm-mac`); shell-spawned CLI subcommands hit the
+// parent terminal's TCC permission, which typically lacks
+// Contacts access. The non-interactive path (`--containers
+// <uuid,uuid,…>`) trusts the operator-supplied identifiers, writes
+// the allowlist, and lets the daemon's next tick validate against
+// the live CNContainer list.
+//
+// Type signature deliberately excludes any ContactsAuthorizationAdapter
+// or ContactContainerEnumerator parameter — that absence is the
+// contract this writer enforces. If a future contributor reintroduces
+// a Contacts-framework call into the non-interactive path, it can't
+// route through this struct.
+//
+// Crash-safety contract (matches `configure containers`'s interactive
+// flow): on a non-empty diff, the recovery flag is bumped in
+// `state.json` FIRST, then `config.json` is replaced. A crash
+// between the two leaves the daemon recovering against the OLD
+// allowlist on next tick — still correct. A `.noOp` outcome
+// (picked == existing) skips both writes entirely so a no-op
+// re-request-permission run does NOT trigger a spurious recovery
+// cycle.
+import Foundation
+import CRMMacCore
+
+public enum NonInteractiveAllowlistWriteOutcome: Equatable {
+    case wrote(pickedIDs: [String])
+    /// New allowlist equals existing. No state or config write
+    /// happens; recovery flag is NOT bumped.
+    case noOp
+}
+
+public struct NonInteractiveAllowlistWriter {
+    public let configStore: ConfigStore
+    public let stateStore: StateStore
+    /// True when the caller is mutating an existing config (the
+    /// daemon may already be running with the old allowlist).
+    /// Drives the recovery-flag bump alongside the non-empty
+    /// existing-allowlist guard. Fresh-install callers pass false;
+    /// `--re-request-permission` and `configure containers` pass
+    /// true.
+    public let mutatingExistingConfig: Bool
+
+    public init(
+        configStore: ConfigStore,
+        stateStore: StateStore,
+        mutatingExistingConfig: Bool
+    ) {
+        self.configStore = configStore
+        self.stateStore = stateStore
+        self.mutatingExistingConfig = mutatingExistingConfig
+    }
+
+    /// Apply the caller-provided allowlist. Returns `.noOp` when
+    /// the new set equals the existing set; in that case neither
+    /// the recovery flag nor the config file is touched.
+    public func write(pickedIDs: [String]) async throws -> NonInteractiveAllowlistWriteOutcome {
+        let existing = (try? configStore.loadICloudContactsConfig()?.containers) ?? []
+        if Set(existing) == Set(pickedIDs) {
+            return .noOp
+        }
+        if mutatingExistingConfig || !existing.isEmpty {
+            // State-write FIRST. Crash between state and config
+            // writes → daemon recovers against OLD allowlist on
+            // next tick (still correct; idempotent).
+            let mutator = StateMutator(store: stateStore)
+            try await mutator.mutate { state in
+                var src = state.sources["icloud_contacts"] ?? SourceState()
+                src.lastError = "recovery_requested:allowlist_changed"
+                src.lastErrorAt = Date()
+                state.sources["icloud_contacts"] = src
+            }
+        }
+        try configStore.saveICloudContactsConfig(
+            ICloudContactsConfig(containers: pickedIDs))
+        return .wrote(pickedIDs: pickedIDs)
+    }
+}

--- a/mac-daemon/Sources/crm-mac/Commands/ConfigureCommand.swift
+++ b/mac-daemon/Sources/crm-mac/Commands/ConfigureCommand.swift
@@ -4,23 +4,31 @@
 // subcommands.
 //
 // Allowlist-mutation flow:
-//   1. Enumerate current CNContainers.
-//   2. Run the picker (or accept --containers <id1>,<id2>).
-//   3. Diff against the existing allowlist.
-//   4. On non-empty diff: prompt [y/N]; on yes:
-//      4a. Write the recovery flag into state.json FIRST.
-//      4b. Write the updated config.json SECOND.
-//      4c. DO NOT reset cursor; DO NOT clear hash cache. The
-//          recovery flow consumes both.
+//   - List mode (`--list`): enumerate CNContainers, print TSV, exit.
+//     Requires Contacts permission to enumerate.
+//   - Interactive: enumerate → picker UI → diff → y/N → state-then-
+//     config write.
+//   - Non-interactive (`--containers <uuid,…>`): SKIP enumeration
+//     entirely; trust the operator-supplied UUIDs and write the
+//     allowlist. Skipping enumeration is what makes this path work
+//     from a shell where Contacts permission is attributed to the
+//     parent terminal rather than the daemon's bundle. The daemon's
+//     next tick under launchd validates against the live container
+//     list and surfaces invalid UUIDs as a recovery-requested
+//     failure. See issue #322.
 //
-// The state-then-config ordering is the crash-safety contract: a
-// crash between 4a and 4b leaves the daemon recovering against the
-// OLD allowlist on the next tick — still correct (tombstones
-// removed-upstream contacts, emits no spurious wrong-allowlist
-// contacts). A second `configure containers` run reapplies and
-// completes the swap; idempotent. The reversed order would produce
-// the wrong-allowlist + no-recovery state the recovery flow is
-// designed to avoid.
+// The dispatch (which mode runs which sequence) lives in
+// `AllowlistConfigureFlow` in CRMMacLifecycle so the regression
+// guard for #322 — non-interactive modes make zero Contacts calls
+// — can be unit-tested. The executable target has no test target
+// by design.
+//
+// Crash-safety: on a non-empty diff, the recovery flag in
+// `state.json` is bumped FIRST, then `config.json` is replaced.
+// A crash between the two leaves the daemon recovering against
+// the OLD allowlist on next tick — still correct. The
+// state-then-config ordering lives inside
+// `NonInteractiveAllowlistWriter`.
 import Foundation
 import ArgumentParser
 import CRMMacCore
@@ -61,58 +69,131 @@ struct ContainersSubcommand: ParsableCommand {
         // mutation doesn't race against an in-flight tick.
         try requireDaemonNotRunning(paths: ctx.paths)
 
+        let mode: AllowlistConfigureFlow.Mode = list
+            ? .configureList
+            : (containers.isEmpty
+                ? .configureInteractive
+                : .configureNonInteractive(rawContainers: containers))
+        let configURL = URL(fileURLWithPath: ctx.paths.configFilePath)
+        // Bind production adapters into Sendable-conformant locals
+        // so the closures captured by `AllowlistConfigureFlow` don't
+        // need to retain the non-Sendable ProductionContext.
+        let auth = ctx.contactsAuthAdapter()
         let enumerator = ctx.contactContainerEnumerator()
-        let visible: [ContainerInfo]
+        let flow = AllowlistConfigureFlow(
+            mode: mode,
+            configStore: ConfigStore(fileURL: configURL),
+            stateStore: StateStore(fileURL: URL(fileURLWithPath: ctx.paths.stateFilePath)),
+            authAdapter: { auth },
+            enumerator: { enumerator },
+            interactivePicker: { visible in
+                try Self.confirmAndPick(visible: visible, configURL: configURL)
+            })
         do {
-            visible = try enumerator.listContainers()
+            let outcome = try Self.runFlowSync(flow: flow)
+            switch outcome {
+            case .listed(let visible):
+                for c in visible {
+                    let typeLabel = Self.label(for: c.type)
+                    let defaultFlag = c.defaultIncluded ? "default" : "skip"
+                    print("\(c.identifier)\t\(typeLabel)\t\(c.name)\t\(defaultFlag)")
+                }
+            case .wrote, .completedInteractive:
+                print("Allowlist updated. Run `crm-mac status` to confirm the next tick performs the reconciliation.")
+            case .noOp:
+                print("No allowlist changes detected.")
+            }
+        } catch AllowlistConfigureFlowError.permissionDenied {
+            // Interactive picker path only — non-interactive bypasses
+            // the auth prompt.
+            FileHandle.standardError.write(Data(
+                "Contacts permission denied. Open: System Settings -> Privacy & Security -> Contacts -> enable crm-mac\n".utf8))
+            throw ExitCode(1)
         } catch ContactContainerEnumeratorError.notAuthorized {
+            // Interactive or --list modes only — non-interactive
+            // doesn't call the enumerator. Preserves prior wording.
             FileHandle.standardError.write(Data(
                 "Contacts permission missing. Run `crm-mac install --re-request-permission` to grant.\n".utf8))
             throw ExitCode(1)
-        } catch {
+        } catch let e as ContactContainerEnumeratorError {
             FileHandle.standardError.write(Data(
-                "container enumeration failed: \(error)\n".utf8))
+                "container enumeration failed: \(e)\n".utf8))
             throw ExitCode(1)
+        } catch AllowlistConfigureFlowError.userAborted {
+            print("Aborted; no changes written.")
+        } catch let e as ContainerPickerError {
+            FileHandle.standardError.write(Data("\(e)\n".utf8))
+            throw ExitCode(2)
+        } catch {
+            FileHandle.standardError.write(Data("\(error)\n".utf8))
+            throw ExitCode(2)
         }
+    }
 
-        if list {
-            for c in visible {
-                let typeLabel = Self.label(for: c.type)
-                let defaultFlag = c.defaultIncluded ? "default" : "skip"
-                print("\(c.identifier)\t\(typeLabel)\t\(c.name)\t\(defaultFlag)")
-            }
-            return
+    /// Bridge async `flow.run()` into the synchronous
+    /// `ParsableCommand.run()` flow via a DispatchSemaphore.
+    /// The Result is captured through a mutable holder marked
+    /// `@unchecked Sendable`: the Task body owns the write and the
+    /// outer thread reads only after `sem.wait()`, so no actual race
+    /// is possible. Swift 6's strict concurrency check cannot prove
+    /// this happens-before relationship across the
+    /// DispatchSemaphore, so the holder is the smallest unchecked
+    /// boundary.
+    private static func runFlowSync(
+        flow: AllowlistConfigureFlow
+    ) throws -> AllowlistConfigureFlow.Outcome {
+        final class ResultBox: @unchecked Sendable {
+            var result: Result<AllowlistConfigureFlow.Outcome, Error>?
         }
-
-        // Resolve the picked identifiers (interactive picker OR
-        // --containers flag).
-        let pickedIDs: [String]
-        if !containers.isEmpty {
-            pickedIDs = try Self.resolveNonInteractive(
-                raw: containers, visible: visible)
-        } else {
-            FileHandle.standardOutput.write(Data(
-                ContainerPicker.render(visible).utf8))
-            let line = readLine() ?? ""
+        let box = ResultBox()
+        let sem = DispatchSemaphore(value: 0)
+        Task {
             do {
-                pickedIDs = try ContainerPicker.parse(input: line, containers: visible)
+                let outcome = try await flow.run()
+                box.result = .success(outcome)
             } catch {
-                FileHandle.standardError.write(Data(
-                    "\(error)\n".utf8))
-                throw ExitCode(2)
+                box.result = .failure(error)
             }
+            sem.signal()
         }
+        sem.wait()
+        switch box.result {
+        case .success(let outcome): return outcome
+        case .failure(let error): throw error
+        case .none:
+            // Defensive — the Task body always sets one of the two.
+            throw AllowlistConfigureFlowError.userAborted
+        }
+    }
+
+    /// Interactive picker for the `configure containers` flow:
+    /// renders the picker UI, parses operator input, diffs against
+    /// the existing allowlist, and prompts y/N. Throws
+    /// `AllowlistConfigureFlowError.userAborted` on a no-confirm
+    /// answer; throws `ContainerPickerError` on bad input.
+    private static func confirmAndPick(
+        visible: [ContainerInfo],
+        configURL: URL
+    ) throws -> [String] {
+        FileHandle.standardOutput.write(Data(
+            ContainerPicker.render(visible).utf8))
+        let line = readLine() ?? ""
+        let pickedIDs = try ContainerPicker.parse(input: line, containers: visible)
 
         // Diff against the existing allowlist.
-        let configStore = ConfigStore(fileURL: URL(fileURLWithPath: ctx.paths.configFilePath))
-        let existingAllowlist = (try? configStore.loadICloudContactsConfig()?.containers) ?? []
+        let existingAllowlist = (try? ConfigStore(fileURL: configURL)
+            .loadICloudContactsConfig()?.containers) ?? []
         let existing = Set(existingAllowlist)
         let picked = Set(pickedIDs)
         let added = picked.subtracting(existing)
         let removed = existing.subtracting(picked)
         if added.isEmpty && removed.isEmpty {
-            print("No allowlist changes detected.")
-            return
+            // No-op: still return the picked IDs so the writer
+            // observes picked == existing and yields `.noOp`,
+            // which the outer switch maps to the "No allowlist
+            // changes detected." line. Avoids a custom early-exit
+            // path here.
+            return pickedIDs
         }
 
         print("Planned allowlist changes:")
@@ -134,79 +215,9 @@ struct ContainersSubcommand: ParsableCommand {
         print("Continue? [y/N] ", terminator: "")
         let answer = (readLine() ?? "").lowercased()
         if answer != "y" && answer != "yes" {
-            print("Aborted; no changes written.")
-            return
+            throw AllowlistConfigureFlowError.userAborted
         }
-
-        // Crash-safety ordering: state-write FIRST, config-write
-        // SECOND. A crash between the two leaves the daemon
-        // recovering against the OLD allowlist on its next tick —
-        // still correct (tombstones removed-upstream contacts). A
-        // second run reapplies the picker output and completes the
-        // swap; idempotent.
-        let stateStore = StateStore(fileURL: URL(fileURLWithPath: ctx.paths.stateFilePath))
-        let mutator = StateMutator(store: stateStore)
-        do {
-            try Self.runStateUpdate(mutator: mutator)
-        } catch {
-            FileHandle.standardError.write(Data(
-                "Failed to set recovery flag in state.json: \(error)\n".utf8))
-            throw ExitCode(1)
-        }
-
-        do {
-            try configStore.saveICloudContactsConfig(
-                ICloudContactsConfig(containers: pickedIDs))
-        } catch {
-            FileHandle.standardError.write(Data(
-                "Failed to write config.json: \(error)\n  (Recovery flag is set; re-run `crm-mac configure containers` to retry.)\n".utf8))
-            throw ExitCode(1)
-        }
-
-        print("Allowlist updated. Run `crm-mac status` to confirm the next tick performs the reconciliation.")
-    }
-
-    private static func runStateUpdate(mutator: StateMutator) throws {
-        // Bridge async into the synchronous CLI run() flow. Pattern
-        // mirrors MessagesCommand for the same reason.
-        let sem = DispatchSemaphore(value: 0)
-        nonisolated(unsafe) var mutateError: Error?
-        Task {
-            do {
-                try await mutator.mutate { state in
-                    var src = state.sources["icloud_contacts"] ?? SourceState()
-                    src.lastError = "recovery_requested:allowlist_changed"
-                    src.lastErrorAt = Date()
-                    state.sources["icloud_contacts"] = src
-                }
-            } catch {
-                mutateError = error
-            }
-            sem.signal()
-        }
-        sem.wait()
-        if let e = mutateError { throw e }
-    }
-
-    private static func resolveNonInteractive(
-        raw: String,
-        visible: [ContainerInfo]
-    ) throws -> [String] {
-        let visibleIDs = Set(visible.map(\.identifier))
-        let parts = raw.split(separator: ",").map {
-            $0.trimmingCharacters(in: .whitespaces)
-        }
-        if parts.isEmpty {
-            return ContainerPicker.defaults(for: visible)
-        }
-        for id in parts {
-            if !visibleIDs.contains(id) {
-                FileHandle.standardError.write(Data(
-                    "container identifier \(id) is not in the visible CNContainer list. Run `crm-mac configure containers --list` to see available IDs.\n".utf8))
-                throw ExitCode(2)
-            }
-        }
-        return parts
+        return pickedIDs
     }
 
     private static func label(for kind: ContainerKind) -> String {

--- a/mac-daemon/Sources/crm-mac/Commands/ConfigureCommand.swift
+++ b/mac-daemon/Sources/crm-mac/Commands/ConfigureCommand.swift
@@ -163,6 +163,15 @@ struct ContainersSubcommand: ParsableCommand {
     /// this happens-before relationship across the
     /// DispatchSemaphore, so the holder is the smallest unchecked
     /// boundary.
+    /// Internal-only sentinel for the (effectively unreachable)
+    /// case where the Task body neither succeeds nor throws but
+    /// the semaphore is somehow signalled. Throwing a distinct
+    /// error makes a future regression surface at the actual fault
+    /// point instead of looking like a user-aborted picker run.
+    private enum RunFlowSyncFailure: Error {
+        case taskDidNotComplete
+    }
+
     private static func runFlowSync(
         flow: AllowlistConfigureFlow
     ) throws -> AllowlistConfigureFlow.Outcome {
@@ -185,8 +194,10 @@ struct ContainersSubcommand: ParsableCommand {
         case .success(let outcome): return outcome
         case .failure(let error): throw error
         case .none:
-            // Defensive — the Task body always sets one of the two.
-            throw AllowlistConfigureFlowError.userAborted
+            // Defensive — the Task body always sets one of the
+            // two before signalling. If it didn't, we want a
+            // distinct error that surfaces the fault point.
+            throw RunFlowSyncFailure.taskDidNotComplete
         }
     }
 

--- a/mac-daemon/Sources/crm-mac/Commands/ConfigureCommand.swift
+++ b/mac-daemon/Sources/crm-mac/Commands/ConfigureCommand.swift
@@ -15,13 +15,12 @@
 //     parent terminal rather than the daemon's bundle. The daemon's
 //     next tick under launchd validates against the live container
 //     list and surfaces invalid UUIDs as a recovery-requested
-//     failure. See issue #322.
+//     failure.
 //
 // The dispatch (which mode runs which sequence) lives in
-// `AllowlistConfigureFlow` in CRMMacLifecycle so the regression
-// guard for #322 — non-interactive modes make zero Contacts calls
-// — can be unit-tested. The executable target has no test target
-// by design.
+// `AllowlistConfigureFlow` in CRMMacLifecycle so the zero-Contacts-
+// calls contract on the non-interactive paths can be unit-tested.
+// The executable target has no test target by design.
 //
 // Crash-safety: on a non-empty diff, the recovery flag in
 // `state.json` is bumped FIRST, then `config.json` is replaced.
@@ -75,17 +74,23 @@ struct ContainersSubcommand: ParsableCommand {
                 ? .configureInteractive
                 : .configureNonInteractive(rawContainers: containers))
         let configURL = URL(fileURLWithPath: ctx.paths.configFilePath)
-        // Bind production adapters into Sendable-conformant locals
-        // so the closures captured by `AllowlistConfigureFlow` don't
-        // need to retain the non-Sendable ProductionContext.
-        let auth = ctx.contactsAuthAdapter()
-        let enumerator = ctx.contactContainerEnumerator()
+        // Wire the production adapter factories as lazy closures.
+        // The flow only invokes them on interactive / list modes;
+        // the non-interactive branch never constructs an adapter,
+        // which is the structural regression guard for the
+        // shell-context Contacts permission issue.
+        let authFactory: @Sendable () -> ContactsAuthorizationAdapter = {
+            ProductionContext().contactsAuthAdapter()
+        }
+        let enumeratorFactory: @Sendable () -> ContactContainerEnumerator = {
+            ProductionContext().contactContainerEnumerator()
+        }
         let flow = AllowlistConfigureFlow(
             mode: mode,
             configStore: ConfigStore(fileURL: configURL),
             stateStore: StateStore(fileURL: URL(fileURLWithPath: ctx.paths.stateFilePath)),
-            authAdapter: { auth },
-            enumerator: { enumerator },
+            authAdapter: authFactory,
+            enumerator: enumeratorFactory,
             interactivePicker: { visible in
                 try Self.confirmAndPick(visible: visible, configURL: configURL)
             })
@@ -124,6 +129,25 @@ struct ContainersSubcommand: ParsableCommand {
         } catch let e as ContainerPickerError {
             FileHandle.standardError.write(Data("\(e)\n".utf8))
             throw ExitCode(2)
+        } catch let e as NonInteractiveAllowlistWriteError {
+            // Phase-specific recovery guidance for the partial-write
+            // case: the recovery flag is set in state.json but
+            // config.json was not replaced. The operator should
+            // re-run this command to complete the swap; the next
+            // tick will reconcile against the OLD allowlist
+            // meanwhile (still correct, idempotent).
+            switch e {
+            case .stateWriteFailed(let underlying):
+                FileHandle.standardError.write(Data(
+                    "Failed to set recovery flag in state.json: \(underlying)\n".utf8))
+            case .configWriteFailedAfterStateWrite(let underlying):
+                FileHandle.standardError.write(Data(
+                    "Failed to write config.json: \(underlying)\n  (Recovery flag is set; re-run `crm-mac configure containers` to retry.)\n".utf8))
+            case .configWriteFailed(let underlying):
+                FileHandle.standardError.write(Data(
+                    "Failed to write config.json: \(underlying)\n".utf8))
+            }
+            throw ExitCode(1)
         } catch {
             FileHandle.standardError.write(Data("\(error)\n".utf8))
             throw ExitCode(2)

--- a/mac-daemon/Sources/crm-mac/Commands/InstallCommand.swift
+++ b/mac-daemon/Sources/crm-mac/Commands/InstallCommand.swift
@@ -10,6 +10,15 @@
 // step). `--containers <id1>,<id2>` is the non-interactive form for
 // scripted installs that know the exact CNContainer identifiers
 // from a prior `crm-mac configure containers --list` run.
+//
+// The post-pair flow is dispatched through `AllowlistConfigureFlow`
+// (in CRMMacLifecycle). The flow's Mode encodes whether this is a
+// fresh install or `--re-request-permission`, and whether the
+// operator supplied `--containers` (non-interactive) or wants the
+// picker (interactive). Non-interactive modes deliberately make
+// ZERO Contacts framework calls — see issue #322 — which is why
+// the dispatch lives in the testable lifecycle library rather than
+// inline here.
 import Foundation
 import ArgumentParser
 import CRMMacCore
@@ -100,19 +109,54 @@ struct InstallCommand: AsyncParsableCommand {
     }
 
     /// Permission + picker flow. Called as part of fresh install AND
-    /// via --re-request-permission. When the call site is updating
-    /// an existing config (i.e. the daemon may already be running
-    /// with the old allowlist), the writer sets the recovery flag
-    /// FIRST so the next tick reconciles against the new allowlist
-    /// via /known-ids rather than silently advancing past stale
-    /// state.
+    /// via --re-request-permission. The dispatch (interactive vs
+    /// non-interactive, fresh vs re-request) happens inside
+    /// `AllowlistConfigureFlow`; this wrapper only constructs the
+    /// flow with the appropriate `Mode` and surfaces flow errors as
+    /// stderr + exit codes that match the prior behaviour.
     private func runContactsPermissionFlow(
         ctx: ProductionContext,
         mutatingExistingConfig: Bool
     ) async throws {
-        let authAdapter = ctx.contactsAuthAdapter()
-        let granted = try await authAdapter.requestAccess()
-        if !granted {
+        let mode: AllowlistConfigureFlow.Mode
+        if mutatingExistingConfig {
+            mode = containers.isEmpty
+                ? .reRequestPermissionInteractive
+                : .reRequestPermissionNonInteractive(rawContainers: containers)
+        } else {
+            mode = containers.isEmpty
+                ? .freshInstallInteractive
+                : .freshInstallNonInteractive(rawContainers: containers)
+        }
+        // Bind production adapters into Sendable-conformant locals
+        // so the closures captured by `AllowlistConfigureFlow` don't
+        // need to retain the non-Sendable ProductionContext.
+        let auth = ctx.contactsAuthAdapter()
+        let enumerator = ctx.contactContainerEnumerator()
+        let flow = AllowlistConfigureFlow(
+            mode: mode,
+            configStore: ConfigStore(fileURL: URL(fileURLWithPath: ctx.paths.configFilePath)),
+            stateStore: StateStore(fileURL: URL(fileURLWithPath: ctx.paths.stateFilePath)),
+            authAdapter: { auth },
+            enumerator: { enumerator },
+            interactivePicker: { visible in
+                FileHandle.standardOutput.write(Data(
+                    ContainerPicker.render(visible).utf8))
+                let line = readLine() ?? ""
+                return try ContainerPicker.parse(input: line, containers: visible)
+            })
+        do {
+            let outcome = try await flow.run()
+            switch outcome {
+            case .wrote(let ids), .completedInteractive(let ids):
+                print("iCloud Contacts allowlist saved (\(ids.count) container(s)).")
+            case .noOp:
+                print("No allowlist changes detected.")
+            case .listed:
+                // Unreachable: install flow never uses .configureList.
+                break
+            }
+        } catch AllowlistConfigureFlowError.permissionDenied {
             FileHandle.standardError.write(Data(
                 """
                 Contacts permission denied.
@@ -120,59 +164,24 @@ struct InstallCommand: AsyncParsableCommand {
                 Then run: crm-mac install --re-request-permission
                 """.utf8))
             throw ExitCode(1)
-        }
-        // Permission granted. Run picker.
-        let enumerator = ctx.contactContainerEnumerator()
-        let visible: [ContainerInfo]
-        do {
-            visible = try enumerator.listContainers()
-        } catch {
+        } catch let e as ContactContainerEnumeratorError {
+            // Enumeration failure on the interactive path (the
+            // non-interactive flow doesn't call the enumerator).
             FileHandle.standardError.write(Data(
-                "container enumeration failed: \(error)\n".utf8))
+                "container enumeration failed: \(e)\n".utf8))
             throw ExitCode(1)
+        } catch let e as ContainerPickerError {
+            // Interactive picker input parsing failed.
+            FileHandle.standardError.write(Data("\(e)\n".utf8))
+            throw ExitCode(2)
         }
-        let pickedIDs: [String]
-        if !containers.isEmpty {
-            pickedIDs = try Self.resolveNonInteractive(raw: containers, visible: visible)
-        } else {
-            FileHandle.standardOutput.write(Data(
-                ContainerPicker.render(visible).utf8))
-            let line = readLine() ?? ""
-            do {
-                pickedIDs = try ContainerPicker.parse(input: line, containers: visible)
-            } catch {
-                FileHandle.standardError.write(Data("\(error)\n".utf8))
-                throw ExitCode(2)
-            }
-        }
-        let configStore = ConfigStore(
-            fileURL: URL(fileURLWithPath: ctx.paths.configFilePath))
-        if mutatingExistingConfig {
-            // State-write FIRST per the same crash-safety contract
-            // the `configure containers` subcommand follows. A crash
-            // between state and config writes leaves the daemon
-            // recovering against the OLD allowlist on the next tick
-            // — still correct.
-            let stateStore = StateStore(
-                fileURL: URL(fileURLWithPath: ctx.paths.stateFilePath))
-            let mutator = StateMutator(store: stateStore)
-            try await mutator.mutate { state in
-                var src = state.sources["icloud_contacts"] ?? SourceState()
-                src.lastError = "recovery_requested:allowlist_changed"
-                src.lastErrorAt = Date()
-                state.sources["icloud_contacts"] = src
-            }
-        }
-        try configStore.saveICloudContactsConfig(
-            ICloudContactsConfig(containers: pickedIDs))
-        print("iCloud Contacts allowlist saved (\(pickedIDs.count) container(s)).")
     }
 
     /// Re-request-permission-only flow. Re-runs the permission prompt
     /// and picker WITHOUT touching the existing pair. Used when an
     /// initial install was aborted at the permission step. Treated
     /// as an existing-config mutation so the recovery flag is set
-    /// before any allowlist write.
+    /// before any allowlist write (when the diff is non-empty).
     private func runReRequestPermissionOnly(ctx: ProductionContext) async throws {
         guard FileManager.default.fileExists(atPath: ctx.paths.configFilePath) else {
             FileHandle.standardError.write(Data(
@@ -181,23 +190,5 @@ struct InstallCommand: AsyncParsableCommand {
         }
         try await runContactsPermissionFlow(
             ctx: ctx, mutatingExistingConfig: true)
-    }
-
-    private static func resolveNonInteractive(
-        raw: String,
-        visible: [ContainerInfo]
-    ) throws -> [String] {
-        let visibleIDs = Set(visible.map(\.identifier))
-        let parts = raw.split(separator: ",").map {
-            $0.trimmingCharacters(in: .whitespaces)
-        }
-        for id in parts {
-            if !visibleIDs.contains(id) {
-                FileHandle.standardError.write(Data(
-                    "container identifier \(id) is not in the visible CNContainer list. Run `crm-mac configure containers --list` to see available IDs.\n".utf8))
-                throw ExitCode(2)
-            }
-        }
-        return parts
     }
 }

--- a/mac-daemon/Sources/crm-mac/Commands/InstallCommand.swift
+++ b/mac-daemon/Sources/crm-mac/Commands/InstallCommand.swift
@@ -16,9 +16,10 @@
 // fresh install or `--re-request-permission`, and whether the
 // operator supplied `--containers` (non-interactive) or wants the
 // picker (interactive). Non-interactive modes deliberately make
-// ZERO Contacts framework calls — see issue #322 — which is why
-// the dispatch lives in the testable lifecycle library rather than
-// inline here.
+// ZERO Contacts framework calls (the shell-context TCC
+// attribution would otherwise fail with a misleading error), which
+// is why the dispatch lives in the testable lifecycle library
+// rather than inline here.
 import Foundation
 import ArgumentParser
 import CRMMacCore
@@ -128,17 +129,23 @@ struct InstallCommand: AsyncParsableCommand {
                 ? .freshInstallInteractive
                 : .freshInstallNonInteractive(rawContainers: containers)
         }
-        // Bind production adapters into Sendable-conformant locals
-        // so the closures captured by `AllowlistConfigureFlow` don't
-        // need to retain the non-Sendable ProductionContext.
-        let auth = ctx.contactsAuthAdapter()
-        let enumerator = ctx.contactContainerEnumerator()
+        // Wire the production adapter factories as lazy closures.
+        // The flow only invokes them on interactive / list modes;
+        // the non-interactive branch never constructs an adapter,
+        // which is the structural regression guard for the
+        // shell-context Contacts permission issue.
+        let authFactory: @Sendable () -> ContactsAuthorizationAdapter = {
+            ProductionContext().contactsAuthAdapter()
+        }
+        let enumeratorFactory: @Sendable () -> ContactContainerEnumerator = {
+            ProductionContext().contactContainerEnumerator()
+        }
         let flow = AllowlistConfigureFlow(
             mode: mode,
             configStore: ConfigStore(fileURL: URL(fileURLWithPath: ctx.paths.configFilePath)),
             stateStore: StateStore(fileURL: URL(fileURLWithPath: ctx.paths.stateFilePath)),
-            authAdapter: { auth },
-            enumerator: { enumerator },
+            authAdapter: authFactory,
+            enumerator: enumeratorFactory,
             interactivePicker: { visible in
                 FileHandle.standardOutput.write(Data(
                     ContainerPicker.render(visible).utf8))
@@ -174,6 +181,24 @@ struct InstallCommand: AsyncParsableCommand {
             // Interactive picker input parsing failed.
             FileHandle.standardError.write(Data("\(e)\n".utf8))
             throw ExitCode(2)
+        } catch let e as NonInteractiveAllowlistWriteError {
+            // Phase-specific recovery guidance for state/config
+            // partial-writes. Mirrors the configure-containers
+            // wrapper so a `--re-request-permission` run that
+            // half-completes points the operator at the right
+            // retry path.
+            switch e {
+            case .stateWriteFailed(let underlying):
+                FileHandle.standardError.write(Data(
+                    "Failed to set recovery flag in state.json: \(underlying)\n".utf8))
+            case .configWriteFailedAfterStateWrite(let underlying):
+                FileHandle.standardError.write(Data(
+                    "Failed to write config.json: \(underlying)\n  (Recovery flag is set; re-run `crm-mac install --re-request-permission` to retry.)\n".utf8))
+            case .configWriteFailed(let underlying):
+                FileHandle.standardError.write(Data(
+                    "Failed to write config.json: \(underlying)\n".utf8))
+            }
+            throw ExitCode(1)
         }
     }
 

--- a/mac-daemon/Tests/CRMMacLifecycleTests/AllowlistConfigureFlowTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/AllowlistConfigureFlowTests.swift
@@ -1,0 +1,324 @@
+// Tests for `AllowlistConfigureFlow` — the dispatcher that decides,
+// per Mode, whether to invoke the Contacts framework adapters
+// before writing the allowlist. The control-flow boundary
+// assertion is the regression guard for issue #322: non-interactive
+// modes must make ZERO calls to the auth adapter or container
+// enumerator.
+//
+// Coverage matrix (11 rows total):
+//
+//   | Mode                                | Picked vs existing | Auth | Enum | Outcome                  |
+//   |-------------------------------------|--------------------|------|------|--------------------------|
+//   | freshInstallNonInteractive          | differ             | 0    | 0    | .wrote                   |
+//   | reRequestPermissionNonInteractive   | differ             | 0    | 0    | .wrote                   |
+//   | configureNonInteractive             | differ             | 0    | 0    | .wrote                   |
+//   | configureNonInteractive             | equal (no-op)      | 0    | 0    | .noOp                    |
+//   | freshInstallInteractive             | (no existing)      | 1    | 1    | .completedInteractive    |
+//   | reRequestPermissionInteractive      | differ             | 1    | 1    | .completedInteractive    |
+//   | reRequestPermissionInteractive      | equal (no-op)      | 1    | 1    | .noOp                    |
+//   | configureInteractive                | differ             | 1    | 1    | .completedInteractive    |
+//   | configureInteractive                | equal (no-op)      | 1    | 1    | .noOp                    |
+//   | configureList                       | n/a                | 0    | 1    | .listed                  |
+//   | configureInteractive (denied)       | n/a                | 1    | 0    | throws .permissionDenied |
+import XCTest
+import Foundation
+import CRMMacCore
+@testable import CRMMacLifecycle
+
+final class AllowlistConfigureFlowTests: XCTestCase {
+    private var tempDir: URL!
+    private var stateURL: URL!
+    private var configURL: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("allowlist-flow-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        stateURL = tempDir.appendingPathComponent("state.json")
+        configURL = tempDir.appendingPathComponent("config.json")
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tempDir)
+        try super.tearDownWithError()
+    }
+
+    // MARK: - helpers
+
+    private func seedConfig(containers: [String]?) throws {
+        let sources: DaemonSourcesConfig? = containers.map {
+            DaemonSourcesConfig(icloudContacts: ICloudContactsConfig(containers: $0))
+        }
+        let cfg = DaemonConfig(
+            piURL: URL(string: "https://test.invalid")!,
+            hostID: UUID(uuidString: "11111111-2222-3333-4444-555555555555")!,
+            hostname: "host",
+            installedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            sources: sources)
+        try ConfigStore(fileURL: configURL).save(cfg)
+    }
+
+    private func seedEmptyState() throws {
+        try StateStore(fileURL: stateURL).initializeIfMissing()
+    }
+
+    private func makeFlow(
+        mode: AllowlistConfigureFlow.Mode,
+        authSpy: CallCountingContactsAuth,
+        enumSpy: CallCountingContactEnumerator,
+        picker: (@Sendable ([ContainerInfo]) throws -> [String])? = nil
+    ) -> AllowlistConfigureFlow {
+        let defaultPicker: @Sendable ([ContainerInfo]) throws -> [String] = { visible in
+            visible.map(\.identifier)
+        }
+        return AllowlistConfigureFlow(
+            mode: mode,
+            configStore: ConfigStore(fileURL: configURL),
+            stateStore: StateStore(fileURL: stateURL),
+            authAdapter: { authSpy },
+            enumerator: { enumSpy },
+            interactivePicker: picker ?? defaultPicker)
+    }
+
+    private func readState() throws -> DaemonState {
+        try StateStore(fileURL: stateURL).load()
+    }
+
+    // MARK: - non-interactive: zero Contacts calls (issue #322 regression guard)
+
+    func testFreshInstallNonInteractiveMakesZeroContactsCalls() async throws {
+        try seedConfig(containers: nil)
+        try seedEmptyState()
+        let authSpy = CallCountingContactsAuth()
+        let enumSpy = CallCountingContactEnumerator()
+        let flow = makeFlow(
+            mode: .freshInstallNonInteractive(rawContainers: "uuid-1"),
+            authSpy: authSpy, enumSpy: enumSpy)
+
+        let outcome = try await flow.run()
+
+        XCTAssertEqual(outcome, .wrote(pickedIDs: ["uuid-1"]))
+        XCTAssertEqual(authSpy.authStatusCalls, 0)
+        XCTAssertEqual(authSpy.requestAccessCalls, 0,
+                       "non-interactive must not call requestAccess()")
+        XCTAssertEqual(enumSpy.listContainersCalls, 0,
+                       "non-interactive must not call listContainers()")
+    }
+
+    func testReRequestPermissionNonInteractiveMakesZeroContactsCalls() async throws {
+        try seedConfig(containers: ["old-1"])
+        try seedEmptyState()
+        let authSpy = CallCountingContactsAuth()
+        let enumSpy = CallCountingContactEnumerator()
+        let flow = makeFlow(
+            mode: .reRequestPermissionNonInteractive(rawContainers: "new-1"),
+            authSpy: authSpy, enumSpy: enumSpy)
+
+        let outcome = try await flow.run()
+
+        XCTAssertEqual(outcome, .wrote(pickedIDs: ["new-1"]))
+        XCTAssertEqual(authSpy.requestAccessCalls, 0)
+        XCTAssertEqual(enumSpy.listContainersCalls, 0)
+    }
+
+    func testConfigureNonInteractiveMakesZeroContactsCalls() async throws {
+        try seedConfig(containers: ["old-1"])
+        try seedEmptyState()
+        let authSpy = CallCountingContactsAuth()
+        let enumSpy = CallCountingContactEnumerator()
+        let flow = makeFlow(
+            mode: .configureNonInteractive(rawContainers: "new-1"),
+            authSpy: authSpy, enumSpy: enumSpy)
+
+        let outcome = try await flow.run()
+
+        XCTAssertEqual(outcome, .wrote(pickedIDs: ["new-1"]))
+        XCTAssertEqual(authSpy.requestAccessCalls, 0)
+        XCTAssertEqual(enumSpy.listContainersCalls, 0)
+    }
+
+    func testConfigureNonInteractiveEqualSetReturnsNoOp() async throws {
+        try seedConfig(containers: ["X"])
+        try seedEmptyState()
+        let authSpy = CallCountingContactsAuth()
+        let enumSpy = CallCountingContactEnumerator()
+        let flow = makeFlow(
+            mode: .configureNonInteractive(rawContainers: "X"),
+            authSpy: authSpy, enumSpy: enumSpy)
+
+        let outcome = try await flow.run()
+
+        XCTAssertEqual(outcome, .noOp)
+        XCTAssertEqual(authSpy.requestAccessCalls, 0)
+        XCTAssertEqual(enumSpy.listContainersCalls, 0)
+        let state = try readState()
+        XCTAssertNil(state.sources["icloud_contacts"]?.lastError,
+                     "no-op must not bump recovery flag")
+    }
+
+    // MARK: - interactive: must call auth + enumerator
+
+    func testFreshInstallInteractiveCallsAuthAndEnumerator() async throws {
+        try seedConfig(containers: nil)
+        try seedEmptyState()
+        let authSpy = CallCountingContactsAuth(grantOnRequest: true)
+        let enumSpy = CallCountingContactEnumerator(containers: [
+            ContainerInfo(identifier: "c1", name: "iCloud", type: .cardDAV, defaultIncluded: true),
+        ])
+        let flow = makeFlow(
+            mode: .freshInstallInteractive,
+            authSpy: authSpy, enumSpy: enumSpy)
+
+        let outcome = try await flow.run()
+
+        if case .completedInteractive(let ids) = outcome {
+            XCTAssertEqual(ids, ["c1"])
+        } else {
+            XCTFail("expected .completedInteractive, got \(outcome)")
+        }
+        XCTAssertEqual(authSpy.requestAccessCalls, 1)
+        XCTAssertEqual(enumSpy.listContainersCalls, 1)
+    }
+
+    func testReRequestPermissionInteractiveCallsAuthAndEnumeratorWhenDiffers() async throws {
+        try seedConfig(containers: ["old"])
+        try seedEmptyState()
+        let authSpy = CallCountingContactsAuth(grantOnRequest: true)
+        let enumSpy = CallCountingContactEnumerator(containers: [
+            ContainerInfo(identifier: "new", name: "iCloud", type: .cardDAV, defaultIncluded: true),
+        ])
+        let flow = makeFlow(
+            mode: .reRequestPermissionInteractive,
+            authSpy: authSpy, enumSpy: enumSpy)
+
+        let outcome = try await flow.run()
+
+        if case .completedInteractive(let ids) = outcome {
+            XCTAssertEqual(ids, ["new"])
+        } else {
+            XCTFail("expected .completedInteractive, got \(outcome)")
+        }
+        XCTAssertEqual(authSpy.requestAccessCalls, 1)
+        XCTAssertEqual(enumSpy.listContainersCalls, 1)
+    }
+
+    func testReRequestPermissionInteractiveEqualSetReturnsNoOp() async throws {
+        // Regression guard for the codex-round-3 P1: interactive
+        // no-op MUST propagate as Outcome.noOp, not collapse to
+        // .completedInteractive. The CLI wrapper's outcome switch
+        // distinguishes between "Allowlist updated" and "No
+        // allowlist changes detected" on this case.
+        try seedConfig(containers: ["X"])
+        try seedEmptyState()
+        let authSpy = CallCountingContactsAuth(grantOnRequest: true)
+        let enumSpy = CallCountingContactEnumerator(containers: [
+            ContainerInfo(identifier: "X", name: "iCloud", type: .cardDAV, defaultIncluded: true),
+        ])
+        let flow = makeFlow(
+            mode: .reRequestPermissionInteractive,
+            authSpy: authSpy, enumSpy: enumSpy)
+
+        let outcome = try await flow.run()
+
+        XCTAssertEqual(outcome, .noOp)
+        XCTAssertEqual(authSpy.requestAccessCalls, 1)
+        XCTAssertEqual(enumSpy.listContainersCalls, 1)
+        let state = try readState()
+        XCTAssertNil(state.sources["icloud_contacts"]?.lastError,
+                     "interactive no-op must not bump recovery flag")
+    }
+
+    func testConfigureInteractiveCallsAuthAndEnumerator() async throws {
+        try seedConfig(containers: ["old"])
+        try seedEmptyState()
+        let authSpy = CallCountingContactsAuth(grantOnRequest: true)
+        let enumSpy = CallCountingContactEnumerator(containers: [
+            ContainerInfo(identifier: "new", name: "iCloud", type: .cardDAV, defaultIncluded: true),
+        ])
+        let flow = makeFlow(
+            mode: .configureInteractive,
+            authSpy: authSpy, enumSpy: enumSpy)
+
+        let outcome = try await flow.run()
+
+        if case .completedInteractive(let ids) = outcome {
+            XCTAssertEqual(ids, ["new"])
+        } else {
+            XCTFail("expected .completedInteractive, got \(outcome)")
+        }
+        XCTAssertEqual(authSpy.requestAccessCalls, 1)
+        XCTAssertEqual(enumSpy.listContainersCalls, 1)
+    }
+
+    func testConfigureInteractiveEqualSetReturnsNoOp() async throws {
+        // Regression guard for the codex-round-3 P1: see the
+        // re-request-permission counterpart above.
+        try seedConfig(containers: ["X"])
+        try seedEmptyState()
+        let authSpy = CallCountingContactsAuth(grantOnRequest: true)
+        let enumSpy = CallCountingContactEnumerator(containers: [
+            ContainerInfo(identifier: "X", name: "iCloud", type: .cardDAV, defaultIncluded: true),
+        ])
+        let flow = makeFlow(
+            mode: .configureInteractive,
+            authSpy: authSpy, enumSpy: enumSpy)
+
+        let outcome = try await flow.run()
+
+        XCTAssertEqual(outcome, .noOp)
+        XCTAssertEqual(authSpy.requestAccessCalls, 1)
+        XCTAssertEqual(enumSpy.listContainersCalls, 1)
+        let state = try readState()
+        XCTAssertNil(state.sources["icloud_contacts"]?.lastError,
+                     "interactive no-op must not bump recovery flag")
+    }
+
+    // MARK: - configureList: enumerate only
+
+    func testConfigureListCallsEnumeratorButNotAuth() async throws {
+        try seedConfig(containers: nil)
+        try seedEmptyState()
+        let authSpy = CallCountingContactsAuth()
+        let enumSpy = CallCountingContactEnumerator(containers: [
+            ContainerInfo(identifier: "c1", name: "iCloud", type: .cardDAV, defaultIncluded: true),
+        ])
+        let flow = makeFlow(
+            mode: .configureList,
+            authSpy: authSpy, enumSpy: enumSpy)
+
+        let outcome = try await flow.run()
+
+        if case .listed(let visible) = outcome {
+            XCTAssertEqual(visible.count, 1)
+            XCTAssertEqual(visible.first?.identifier, "c1")
+        } else {
+            XCTFail("expected .listed, got \(outcome)")
+        }
+        XCTAssertEqual(authSpy.requestAccessCalls, 0,
+                       "--list is a read-only enumerate; no permission prompt")
+        XCTAssertEqual(enumSpy.listContainersCalls, 1)
+    }
+
+    // MARK: - permission-denied
+
+    func testInteractivePermissionDeniedThrows() async throws {
+        try seedConfig(containers: nil)
+        try seedEmptyState()
+        let authSpy = CallCountingContactsAuth(grantOnRequest: false)
+        let enumSpy = CallCountingContactEnumerator()
+        let flow = makeFlow(
+            mode: .configureInteractive,
+            authSpy: authSpy, enumSpy: enumSpy)
+
+        do {
+            _ = try await flow.run()
+            XCTFail("expected AllowlistConfigureFlowError.permissionDenied")
+        } catch AllowlistConfigureFlowError.permissionDenied {
+            // expected
+        }
+        XCTAssertEqual(authSpy.requestAccessCalls, 1)
+        XCTAssertEqual(enumSpy.listContainersCalls, 0,
+                       "enumeration must not run when permission is denied")
+    }
+}

--- a/mac-daemon/Tests/CRMMacLifecycleTests/AllowlistConfigureFlowTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/AllowlistConfigureFlowTests.swift
@@ -1,9 +1,9 @@
 // Tests for `AllowlistConfigureFlow` — the dispatcher that decides,
 // per Mode, whether to invoke the Contacts framework adapters
 // before writing the allowlist. The control-flow boundary
-// assertion is the regression guard for issue #322: non-interactive
-// modes must make ZERO calls to the auth adapter or container
-// enumerator.
+// assertion: non-interactive modes must make ZERO calls to the
+// auth adapter or container enumerator (shell-context TCC
+// attribution would otherwise produce misleading errors).
 //
 // Coverage matrix (11 rows total):
 //
@@ -85,7 +85,7 @@ final class AllowlistConfigureFlowTests: XCTestCase {
         try StateStore(fileURL: stateURL).load()
     }
 
-    // MARK: - non-interactive: zero Contacts calls (issue #322 regression guard)
+    // MARK: - non-interactive: zero Contacts calls (regression guard)
 
     func testFreshInstallNonInteractiveMakesZeroContactsCalls() async throws {
         try seedConfig(containers: nil)
@@ -204,11 +204,12 @@ final class AllowlistConfigureFlowTests: XCTestCase {
     }
 
     func testReRequestPermissionInteractiveEqualSetReturnsNoOp() async throws {
-        // Regression guard for the codex-round-3 P1: interactive
-        // no-op MUST propagate as Outcome.noOp, not collapse to
-        // .completedInteractive. The CLI wrapper's outcome switch
-        // distinguishes between "Allowlist updated" and "No
-        // allowlist changes detected" on this case.
+        // Interactive no-op MUST propagate as Outcome.noOp, not
+        // collapse to .completedInteractive. The CLI wrapper's
+        // outcome switch distinguishes between "Allowlist updated"
+        // and "No allowlist changes detected" on this case — and a
+        // re-request-permission run that confirms the same
+        // allowlist must NOT trigger a spurious recovery cycle.
         try seedConfig(containers: ["X"])
         try seedEmptyState()
         let authSpy = CallCountingContactsAuth(grantOnRequest: true)
@@ -252,8 +253,10 @@ final class AllowlistConfigureFlowTests: XCTestCase {
     }
 
     func testConfigureInteractiveEqualSetReturnsNoOp() async throws {
-        // Regression guard for the codex-round-3 P1: see the
-        // re-request-permission counterpart above.
+        // Same invariant as the re-request-permission counterpart
+        // above: a `configure containers` interactive run that
+        // picks the existing allowlist must yield Outcome.noOp and
+        // skip the recovery flag bump.
         try seedConfig(containers: ["X"])
         try seedEmptyState()
         let authSpy = CallCountingContactsAuth(grantOnRequest: true)

--- a/mac-daemon/Tests/CRMMacLifecycleTests/ContainerAllowlistInputTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/ContainerAllowlistInputTests.swift
@@ -1,0 +1,30 @@
+// Pure-logic tests for `ContainerAllowlistInput.parse(_:)`. The
+// parser is the input side of the non-interactive
+// `--containers <uuid,uuid,…>` flow. Validation against the visible
+// CNContainer list deliberately does NOT happen here (see issue
+// #322); these tests just lock in the trim + drop-empty behaviour.
+import XCTest
+@testable import CRMMacLifecycle
+
+final class ContainerAllowlistInputTests: XCTestCase {
+
+    func testParseTrimsWhitespace() {
+        XCTAssertEqual(
+            ContainerAllowlistInput.parse("a , b,c "),
+            ["a", "b", "c"])
+    }
+
+    func testParseDropsEmptyEntries() {
+        XCTAssertEqual(
+            ContainerAllowlistInput.parse("a,,b,"),
+            ["a", "b"])
+    }
+
+    func testParseEmptyInputReturnsEmpty() {
+        // Callers gate on `containers.isEmpty` before invoking the
+        // non-interactive branch, so empty input shouldn't reach
+        // parse in practice — but the function should still be
+        // well-defined for defensive callers.
+        XCTAssertEqual(ContainerAllowlistInput.parse(""), [])
+    }
+}

--- a/mac-daemon/Tests/CRMMacLifecycleTests/ContainerAllowlistInputTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/ContainerAllowlistInputTests.swift
@@ -1,8 +1,10 @@
 // Pure-logic tests for `ContainerAllowlistInput.parse(_:)`. The
 // parser is the input side of the non-interactive
 // `--containers <uuid,uuid,…>` flow. Validation against the visible
-// CNContainer list deliberately does NOT happen here (see issue
-// #322); these tests just lock in the trim + drop-empty behaviour.
+// CNContainer list deliberately does NOT happen here (the
+// non-interactive path skips enumeration entirely so it works from
+// a shell context); these tests just lock in the trim +
+// drop-empty behaviour.
 import XCTest
 @testable import CRMMacLifecycle
 

--- a/mac-daemon/Tests/CRMMacLifecycleTests/DoctorIcloudContactsTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/DoctorIcloudContactsTests.swift
@@ -29,10 +29,17 @@ final class DoctorIcloudContactsTests: XCTestCase {
         XCTAssertEqual(check.status, .pass)
     }
 
-    func testPermissionDeniedFails() async throws {
+    func testPermissionDeniedWarnsAsIndeterminate() async throws {
+        // `.denied` from a shell-spawned doctor reflects only the
+        // parent terminal's TCC state, not the daemon's — so the
+        // doctor reports it as WARN with a "daemon is authoritative"
+        // hint instead of FAIL.
         let r = await runDoctor(authStatus: .denied)
         let check = r.results.first(where: { $0.name == "icloud_contacts.permission" })!
-        XCTAssertEqual(check.status, .fail)
+        XCTAssertEqual(check.status, .warn)
+        XCTAssertTrue(
+            check.details.contains("indeterminate from shell context"),
+            "expected indeterminate-from-shell-context wording, got: \(check.details)")
     }
 
     func testPermissionRestrictedFails() async throws {
@@ -45,6 +52,9 @@ final class DoctorIcloudContactsTests: XCTestCase {
         let r = await runDoctor(authStatus: .notDetermined)
         let check = r.results.first(where: { $0.name == "icloud_contacts.permission" })!
         XCTAssertEqual(check.status, .warn)
+        XCTAssertTrue(
+            check.details.contains("indeterminate from shell context"),
+            "expected indeterminate-from-shell-context wording, got: \(check.details)")
     }
 
     // MARK: - allowlist
@@ -78,6 +88,65 @@ final class DoctorIcloudContactsTests: XCTestCase {
         let check = r.results.first(where: { $0.name == "icloud_contacts.allowlist" })!
         XCTAssertEqual(check.status, .warn)
         XCTAssertTrue(check.details.contains("c2"))
+    }
+
+    func testAllowlistEnumerationNotAuthorizedEmitsShellContextWarning() async throws {
+        // Regression for #321: a shell-spawned doctor previously
+        // caught `.notAuthorized` and set `visible = []`, turning
+        // every configured ID into a phantom "orphan". The new code
+        // reports the enumeration as unavailable instead, AND falls
+        // through to the last-tick check.
+        let now = Date(timeIntervalSince1970: 2_000_000_000)
+        let r = await runDoctor(
+            allowlist: ["c1", "c2"],
+            enumerator: StubContactContainerEnumerator(
+                thrownError: ContactContainerEnumeratorError.notAuthorized),
+            sourceState: SourceState(lastScheduledAt: now.addingTimeInterval(-30)),
+            clock: FixedClock(now))
+
+        let check = r.results.first(where: { $0.name == "icloud_contacts.allowlist" })!
+        XCTAssertEqual(check.status, .warn)
+        XCTAssertTrue(
+            check.details.contains("2 configured"),
+            "expected count of configured IDs, got: \(check.details)")
+        XCTAssertTrue(
+            check.details.contains("visibility check unavailable from shell context"),
+            "expected shell-context wording, got: \(check.details)")
+        XCTAssertFalse(
+            check.details.contains("orphaned"),
+            "must NOT report orphans when enumeration is unavailable")
+
+        // Regression assertion: the legacy `return results` path
+        // suppressed last_tick when enumeration failed. The
+        // refactored flow must emit it.
+        XCTAssertNotNil(
+            r.results.first(where: { $0.name == "icloud_contacts.last_tick" }),
+            "icloud_contacts.last_tick must be present even when enumeration is unavailable")
+    }
+
+    func testAllowlistUnderlyingEnumeratorErrorStillWarnsGenerically() async throws {
+        // Regression coverage for the previously-latent `.underlying`
+        // early-return bug: a generic enumeration failure used to
+        // short-circuit out of checkICloudContacts before the
+        // last-tick block. The refactored flow must surface BOTH the
+        // generic-enumeration WARN and the last-tick result.
+        let now = Date(timeIntervalSince1970: 2_000_000_000)
+        let r = await runDoctor(
+            allowlist: ["c1"],
+            enumerator: StubContactContainerEnumerator(
+                thrownError: ContactContainerEnumeratorError.underlying("disk gremlins")),
+            sourceState: SourceState(lastScheduledAt: now.addingTimeInterval(-30)),
+            clock: FixedClock(now))
+
+        let check = r.results.first(where: { $0.name == "icloud_contacts.allowlist" })!
+        XCTAssertEqual(check.status, .warn)
+        XCTAssertTrue(
+            check.details.contains("container enumeration failed"),
+            "expected generic enumeration-failed wording, got: \(check.details)")
+
+        XCTAssertNotNil(
+            r.results.first(where: { $0.name == "icloud_contacts.last_tick" }),
+            "icloud_contacts.last_tick must be present even on generic enumeration failure")
     }
 
     // MARK: - last_tick

--- a/mac-daemon/Tests/CRMMacLifecycleTests/DoctorIcloudContactsTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/DoctorIcloudContactsTests.swift
@@ -124,6 +124,34 @@ final class DoctorIcloudContactsTests: XCTestCase {
             "icloud_contacts.last_tick must be present even when enumeration is unavailable")
     }
 
+    func testAllowlistEnumerationNotAuthorizedUnderRestrictedAuthFailsAsRestriction() async throws {
+        // When the permission read returns `.restricted` (MDM /
+        // parental controls), an enumeration `.notAuthorized`
+        // throw is NOT a shell-context attribution issue — the
+        // restriction applies process-wide including the daemon.
+        // The allowlist message must reflect that, otherwise the
+        // operator may dismiss a hard failure as a shell-context
+        // quirk.
+        let now = Date(timeIntervalSince1970: 2_000_000_000)
+        let r = await runDoctor(
+            authStatus: .restricted,
+            allowlist: ["c1"],
+            enumerator: StubContactContainerEnumerator(
+                thrownError: ContactContainerEnumeratorError.notAuthorized),
+            sourceState: SourceState(lastScheduledAt: now.addingTimeInterval(-30)),
+            clock: FixedClock(now))
+
+        let check = r.results.first(where: { $0.name == "icloud_contacts.allowlist" })!
+        XCTAssertEqual(check.status, .fail,
+                       "restricted MDM is a hard failure, not a shell-context warning")
+        XCTAssertTrue(
+            check.details.contains("MDM"),
+            "expected restriction-specific wording, got: \(check.details)")
+        XCTAssertFalse(
+            check.details.contains("shell context"),
+            "must NOT attribute restriction to shell context")
+    }
+
     func testAllowlistUnderlyingEnumeratorErrorStillWarnsGenerically() async throws {
         // Regression coverage for the previously-latent `.underlying`
         // early-return bug: a generic enumeration failure used to

--- a/mac-daemon/Tests/CRMMacLifecycleTests/DoctorIcloudContactsTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/DoctorIcloudContactsTests.swift
@@ -91,7 +91,7 @@ final class DoctorIcloudContactsTests: XCTestCase {
     }
 
     func testAllowlistEnumerationNotAuthorizedEmitsShellContextWarning() async throws {
-        // Regression for #321: a shell-spawned doctor previously
+        // Regression test: a shell-spawned doctor previously
         // caught `.notAuthorized` and set `visible = []`, turning
         // every configured ID into a phantom "orphan". The new code
         // reports the enumeration as unavailable instead, AND falls

--- a/mac-daemon/Tests/CRMMacLifecycleTests/Fakes/CallCountingContactEnumerator.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/Fakes/CallCountingContactEnumerator.swift
@@ -2,7 +2,8 @@
 // ContactContainerEnumerator and increments a per-method
 // invocation counter. Used by `AllowlistConfigureFlowTests` to
 // assert that non-interactive modes make ZERO container-enumeration
-// calls — the regression guard for issue #322.
+// calls (the structural regression guard for shell-context
+// Contacts permission errors).
 import Foundation
 import CRMMacCore
 @testable import CRMMacLifecycle

--- a/mac-daemon/Tests/CRMMacLifecycleTests/Fakes/CallCountingContactEnumerator.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/Fakes/CallCountingContactEnumerator.swift
@@ -1,0 +1,28 @@
+// CallCountingContactEnumerator wraps a synthetic
+// ContactContainerEnumerator and increments a per-method
+// invocation counter. Used by `AllowlistConfigureFlowTests` to
+// assert that non-interactive modes make ZERO container-enumeration
+// calls — the regression guard for issue #322.
+import Foundation
+import CRMMacCore
+@testable import CRMMacLifecycle
+
+public final class CallCountingContactEnumerator: ContactContainerEnumerator, @unchecked Sendable {
+    public var listContainersCalls = 0
+    public var stubbedContainers: [ContainerInfo]
+    public var thrownError: Error?
+
+    public init(
+        containers: [ContainerInfo] = [],
+        thrownError: Error? = nil
+    ) {
+        self.stubbedContainers = containers
+        self.thrownError = thrownError
+    }
+
+    public func listContainers() throws -> [ContainerInfo] {
+        listContainersCalls += 1
+        if let err = thrownError { throw err }
+        return stubbedContainers
+    }
+}

--- a/mac-daemon/Tests/CRMMacLifecycleTests/Fakes/CallCountingContactsAuth.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/Fakes/CallCountingContactsAuth.swift
@@ -1,8 +1,8 @@
 // CallCountingContactsAuth wraps a synthetic ContactsAuthorization
 // adapter and increments per-method invocation counters. Used by
 // `AllowlistConfigureFlowTests` to assert that non-interactive
-// modes make ZERO Contacts authorization calls — the regression
-// guard for issue #322.
+// modes make ZERO Contacts authorization calls (the structural
+// regression guard for shell-context Contacts permission errors).
 import Foundation
 import CRMMacCore
 

--- a/mac-daemon/Tests/CRMMacLifecycleTests/Fakes/CallCountingContactsAuth.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/Fakes/CallCountingContactsAuth.swift
@@ -1,0 +1,32 @@
+// CallCountingContactsAuth wraps a synthetic ContactsAuthorization
+// adapter and increments per-method invocation counters. Used by
+// `AllowlistConfigureFlowTests` to assert that non-interactive
+// modes make ZERO Contacts authorization calls — the regression
+// guard for issue #322.
+import Foundation
+import CRMMacCore
+
+public final class CallCountingContactsAuth: ContactsAuthorizationAdapter, @unchecked Sendable {
+    public var authStatusCalls = 0
+    public var requestAccessCalls = 0
+    public var grantOnRequest: Bool
+    public var stubbedStatus: ContactsAuthorizationStatus
+
+    public init(
+        stubbedStatus: ContactsAuthorizationStatus = .authorized,
+        grantOnRequest: Bool = true
+    ) {
+        self.stubbedStatus = stubbedStatus
+        self.grantOnRequest = grantOnRequest
+    }
+
+    public func authorizationStatus() -> ContactsAuthorizationStatus {
+        authStatusCalls += 1
+        return stubbedStatus
+    }
+
+    public func requestAccess() async throws -> Bool {
+        requestAccessCalls += 1
+        return grantOnRequest
+    }
+}

--- a/mac-daemon/Tests/CRMMacLifecycleTests/NonInteractiveAllowlistWriterTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/NonInteractiveAllowlistWriterTests.swift
@@ -200,8 +200,12 @@ final class NonInteractiveAllowlistWriterTests: XCTestCase {
         do {
             _ = try await writer.write(pickedIDs: ["B"])
             XCTFail("expected write to throw when config path is unwritable")
+        } catch NonInteractiveAllowlistWriteError.configWriteFailedAfterStateWrite {
+            // expected: state-write succeeded, config-write failed
+            // → callers should surface the "recovery flag is set;
+            // re-run to retry" guidance.
         } catch {
-            // expected
+            XCTFail("expected configWriteFailedAfterStateWrite, got: \(error)")
         }
 
         // State write ran first and persisted.
@@ -210,6 +214,39 @@ final class NonInteractiveAllowlistWriterTests: XCTestCase {
             state.sources["icloud_contacts"]?.lastError,
             "recovery_requested:allowlist_changed",
             "state-write must persist even when the subsequent config-write fails")
+    }
+
+    // MARK: - 5b. error-classification for fresh-install config-fail
+
+    func testWriteOnFreshInstallSurfacesPlainConfigWriteFailedError() async throws {
+        // Fresh-install + no existing allowlist + sabotaged config
+        // path: no state-write should run, and the resulting error
+        // should be the plain `.configWriteFailed` variant (NOT the
+        // partial-write variant). This drives the CLI wrapper to
+        // emit the simpler "Failed to write config.json" message
+        // without the "recovery flag is set; re-run" guidance.
+        try seedEmptyState()
+        let badConfigURL = tempDir.appendingPathComponent("config-as-dir")
+        try FileManager.default.createDirectory(at: badConfigURL, withIntermediateDirectories: true)
+        let writer = NonInteractiveAllowlistWriter(
+            configStore: ConfigStore(fileURL: badConfigURL),
+            stateStore: StateStore(fileURL: stateURL),
+            mutatingExistingConfig: false)
+
+        do {
+            _ = try await writer.write(pickedIDs: ["X"])
+            XCTFail("expected configWriteFailed")
+        } catch NonInteractiveAllowlistWriteError.configWriteFailed {
+            // expected
+        } catch {
+            XCTFail("expected configWriteFailed, got: \(error)")
+        }
+
+        // No state-write fired.
+        let state = try readState()
+        XCTAssertNil(
+            state.sources["icloud_contacts"]?.lastError,
+            "fresh install with no existing allowlist must not bump the recovery flag")
     }
 
     // MARK: - 6. type-signature regression guard
@@ -226,10 +263,12 @@ final class NonInteractiveAllowlistWriterTests: XCTestCase {
         let writerType: NonInteractiveAllowlistWriter.Type = NonInteractiveAllowlistWriter.self
         XCTAssertNotNil(writerType)
 
-        // Belt-and-suspenders: grep the writer source file for any
-        // re-introduced Contacts adapter symbols. The test source
-        // and the writer source live in the same git tree; resolve
-        // the writer's path relative to this test file.
+        // Belt-and-suspenders: grep the writer source file's
+        // executable code (after stripping line and block comments)
+        // for any re-introduced Contacts adapter symbols. Comments
+        // are allowed to mention these symbols by name as part of
+        // the contract documentation; what matters is that no
+        // production code path imports or invokes them.
         let testFile = URL(fileURLWithPath: #filePath)
         let writerSource = testFile
             .deletingLastPathComponent()                 // CRMMacLifecycleTests
@@ -241,6 +280,7 @@ final class NonInteractiveAllowlistWriterTests: XCTestCase {
             XCTFail("could not read writer source at \(writerSource.path)")
             return
         }
+        let codeOnly = Self.stripSwiftComments(text)
         let forbiddenSymbols = [
             "ContactsAuthorizationAdapter",
             "ContactContainerEnumerator",
@@ -249,10 +289,55 @@ final class NonInteractiveAllowlistWriterTests: XCTestCase {
         ]
         for symbol in forbiddenSymbols {
             XCTAssertFalse(
-                text.contains(symbol),
-                "NonInteractiveAllowlistWriter must not reference \(symbol) — this would re-introduce the issue #322 regression. See \(writerSource.path) for context.")
+                codeOnly.contains(symbol),
+                "NonInteractiveAllowlistWriter must not reference \(symbol) in executable code. See \(writerSource.path).")
         }
-        // Allow "Contacts framework" to appear in a comment, but
-        // not the actual symbols above.
+    }
+
+    /// Remove `//` line comments and `/* … */` block comments from
+    /// a Swift source string. Naive (no string-literal awareness)
+    /// but sufficient for the writer file which has no string
+    /// literals containing the forbidden symbols.
+    private static func stripSwiftComments(_ source: String) -> String {
+        var result = ""
+        var i = source.startIndex
+        var inBlockComment = false
+        var inLineComment = false
+        while i < source.endIndex {
+            let c = source[i]
+            let next = source.index(after: i) < source.endIndex
+                ? source[source.index(after: i)]
+                : Character("\0")
+            if inBlockComment {
+                if c == "*" && next == "/" {
+                    inBlockComment = false
+                    i = source.index(i, offsetBy: 2)
+                    continue
+                }
+                i = source.index(after: i)
+                continue
+            }
+            if inLineComment {
+                if c == "\n" {
+                    inLineComment = false
+                    result.append(c)
+                }
+                i = source.index(after: i)
+                continue
+            }
+            if c == "/" && next == "/" {
+                inLineComment = true
+                i = source.index(i, offsetBy: 2)
+                continue
+            }
+            if c == "/" && next == "*" {
+                inBlockComment = true
+                i = source.index(i, offsetBy: 2)
+                continue
+            }
+            result.append(c)
+            i = source.index(after: i)
+        }
+        return result
     }
 }

--- a/mac-daemon/Tests/CRMMacLifecycleTests/NonInteractiveAllowlistWriterTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/NonInteractiveAllowlistWriterTests.swift
@@ -1,0 +1,258 @@
+// Tests for `NonInteractiveAllowlistWriter` — the testable writer
+// that lives between the CLI non-interactive `--containers` flag
+// and the ConfigStore + StateStore. The writer's type signature
+// deliberately excludes any ContactsAuthorizationAdapter or
+// ContactContainerEnumerator parameter; this file documents and
+// locks in that contract (test 6 below).
+//
+// Coverage:
+//   1. Writing a new allowlist that differs from the existing one
+//      bumps the recovery flag (when mutatingExistingConfig is true).
+//   2. No-op short-circuit: picked == existing returns .noOp and
+//      does NOT bump the recovery flag — the deliberate behaviour
+//      improvement over the prior InstallCommand.runContactsPermissionFlow
+//      which bumped unconditionally on --re-request-permission.
+//   3. Fresh-install (mutatingExistingConfig: false, existing
+//      allowlist absent) does NOT bump the recovery flag.
+//   4. Defensive case: mutatingExistingConfig: false but existing
+//      allowlist non-empty — bump the flag anyway because the
+//      daemon may already be running with the old allowlist.
+//   5. Crash-safety: a forced ConfigStore.save failure leaves the
+//      state file's recovery flag set, proving state-write ran
+//      first.
+//   6. Type-signature regression guard: a no-body test that
+//      references the writer's initializer to break the build if
+//      a Contacts adapter parameter is ever added.
+import XCTest
+import Foundation
+import CRMMacCore
+@testable import CRMMacLifecycle
+
+final class NonInteractiveAllowlistWriterTests: XCTestCase {
+    private var tempDir: URL!
+    private var stateURL: URL!
+    private var configURL: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("non-interactive-writer-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        stateURL = tempDir.appendingPathComponent("state.json")
+        configURL = tempDir.appendingPathComponent("config.json")
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tempDir)
+        try super.tearDownWithError()
+    }
+
+    // MARK: - helpers
+
+    private func seedConfig(containers: [String]?) throws {
+        let sources: DaemonSourcesConfig? = containers.map {
+            DaemonSourcesConfig(icloudContacts: ICloudContactsConfig(containers: $0))
+        }
+        let cfg = DaemonConfig(
+            piURL: URL(string: "https://test.invalid")!,
+            hostID: UUID(uuidString: "11111111-2222-3333-4444-555555555555")!,
+            hostname: "host",
+            installedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            sources: sources)
+        try ConfigStore(fileURL: configURL).save(cfg)
+    }
+
+    private func seedEmptyState() throws {
+        try StateStore(fileURL: stateURL).initializeIfMissing()
+    }
+
+    private func readState() throws -> DaemonState {
+        try StateStore(fileURL: stateURL).load()
+    }
+
+    private func readConfig() throws -> DaemonConfig {
+        try ConfigStore(fileURL: configURL).load()
+    }
+
+    private func makeWriter(mutatingExistingConfig: Bool) -> NonInteractiveAllowlistWriter {
+        NonInteractiveAllowlistWriter(
+            configStore: ConfigStore(fileURL: configURL),
+            stateStore: StateStore(fileURL: stateURL),
+            mutatingExistingConfig: mutatingExistingConfig)
+    }
+
+    // MARK: - 1. mutating-existing path
+
+    func testWriteWritesConfigAndBumpsRecoveryFlagWhenMutatingExisting() async throws {
+        try seedConfig(containers: ["A"])
+        try seedEmptyState()
+
+        let writer = makeWriter(mutatingExistingConfig: true)
+        let outcome = try await writer.write(pickedIDs: ["B"])
+
+        XCTAssertEqual(outcome, .wrote(pickedIDs: ["B"]))
+        let cfg = try readConfig()
+        XCTAssertEqual(cfg.sources?.icloudContacts?.containers, ["B"])
+        let state = try readState()
+        XCTAssertEqual(
+            state.sources["icloud_contacts"]?.lastError,
+            "recovery_requested:allowlist_changed",
+            "recovery flag must be set when mutating an existing config")
+    }
+
+    // MARK: - 2. no-op short-circuit
+
+    func testWriteReturnsNoOpWhenSetsMatch() async throws {
+        // Seed existing config ["A", "B"]; pick same set in
+        // different order. Writer should yield .noOp WITHOUT
+        // bumping the recovery flag. This locks in the deliberate
+        // semantic improvement over the prior install flow which
+        // bumped unconditionally on --re-request-permission.
+        try seedConfig(containers: ["A", "B"])
+        try seedEmptyState()
+        let configBytesBefore = try Data(contentsOf: configURL)
+
+        let writer = makeWriter(mutatingExistingConfig: true)
+        let outcome = try await writer.write(pickedIDs: ["B", "A"])
+
+        XCTAssertEqual(outcome, .noOp)
+        let state = try readState()
+        XCTAssertNil(
+            state.sources["icloud_contacts"]?.lastError,
+            "no-op must NOT trigger a recovery flag bump")
+        XCTAssertEqual(
+            try Data(contentsOf: configURL),
+            configBytesBefore,
+            "no-op must NOT touch config.json on disk")
+    }
+
+    // MARK: - 3. fresh-install path
+
+    func testWriteOnFreshInstallSkipsRecoveryFlag() async throws {
+        // Preconditions match the production installer's invariant:
+        // a config.json exists (installer.run writes it before
+        // runContactsPermissionFlow is called) but the
+        // sources.icloud_contacts sub-key is absent. State file
+        // exists but has no icloud_contacts entry.
+        try seedConfig(containers: nil)
+        try seedEmptyState()
+
+        let writer = makeWriter(mutatingExistingConfig: false)
+        let outcome = try await writer.write(pickedIDs: ["X"])
+
+        XCTAssertEqual(outcome, .wrote(pickedIDs: ["X"]))
+        let cfg = try readConfig()
+        XCTAssertEqual(cfg.sources?.icloudContacts?.containers, ["X"])
+        let state = try readState()
+        XCTAssertNil(
+            state.sources["icloud_contacts"]?.lastError,
+            "fresh install must NOT trigger a recovery flag bump")
+    }
+
+    // MARK: - 4. defensive: non-empty existing + mutatingExistingConfig=false
+
+    func testWriteOnExistingConfigBumpsRecoveryFlagEvenWhenMutatingExistingFalse() async throws {
+        // Hypothetical caller passes mutatingExistingConfig=false
+        // even though the existing allowlist is non-empty (a
+        // corrupted-state or programmer-error scenario). The writer
+        // is defensively safer than today: bump the flag because
+        // the daemon may already be running with the old allowlist.
+        try seedConfig(containers: ["A"])
+        try seedEmptyState()
+
+        let writer = makeWriter(mutatingExistingConfig: false)
+        let outcome = try await writer.write(pickedIDs: ["B"])
+
+        XCTAssertEqual(outcome, .wrote(pickedIDs: ["B"]))
+        let state = try readState()
+        XCTAssertEqual(
+            state.sources["icloud_contacts"]?.lastError,
+            "recovery_requested:allowlist_changed",
+            "non-empty existing allowlist must trigger a recovery flag bump regardless of mutatingExistingConfig")
+    }
+
+    // MARK: - 5. crash-safety: state-first then config
+
+    func testWriteCrashSafetyStateFirstThenConfig() async throws {
+        // Seed valid state but point the writer at a configStore
+        // whose save path is unwritable. The StateMutator runs
+        // first against the real state file and succeeds; the
+        // configStore.save throws second. After the failure the
+        // state file MUST still have the recovery flag set —
+        // proving state-write ran before config-write.
+        try seedEmptyState()
+        // The "config store" the writer holds points at a directory,
+        // so `loadICloudContactsConfig()` throws and is folded to
+        // [] by the writer's `(try? …) ?? []`. The subsequent
+        // `save(_:)` then also fails — the path is a directory.
+        // `mutatingExistingConfig: true` keeps the state-write
+        // branch active regardless of `existing` being empty.
+        let badConfigURL = tempDir.appendingPathComponent("config-as-dir")
+        try FileManager.default.createDirectory(at: badConfigURL, withIntermediateDirectories: true)
+        let configStore = ConfigStore(fileURL: badConfigURL)
+        let stateStore = StateStore(fileURL: stateURL)
+
+        let writer = NonInteractiveAllowlistWriter(
+            configStore: configStore,
+            stateStore: stateStore,
+            mutatingExistingConfig: true)
+
+        do {
+            _ = try await writer.write(pickedIDs: ["B"])
+            XCTFail("expected write to throw when config path is unwritable")
+        } catch {
+            // expected
+        }
+
+        // State write ran first and persisted.
+        let state = try readState()
+        XCTAssertEqual(
+            state.sources["icloud_contacts"]?.lastError,
+            "recovery_requested:allowlist_changed",
+            "state-write must persist even when the subsequent config-write fails")
+    }
+
+    // MARK: - 6. type-signature regression guard
+
+    func testWriterTypeSignatureExcludesContactsAdapters() {
+        // The point of `NonInteractiveAllowlistWriter` is that its
+        // initializer accepts ONLY ConfigStore + StateStore + Bool.
+        // If a future contributor adds a ContactsAuthorizationAdapter
+        // or ContactContainerEnumerator parameter, this file (and
+        // every production call site) breaks the build until the
+        // change is reverted. The reference below to the
+        // metatype proves the type is still in scope; the real
+        // assertion is structural at compile time.
+        let writerType: NonInteractiveAllowlistWriter.Type = NonInteractiveAllowlistWriter.self
+        XCTAssertNotNil(writerType)
+
+        // Belt-and-suspenders: grep the writer source file for any
+        // re-introduced Contacts adapter symbols. The test source
+        // and the writer source live in the same git tree; resolve
+        // the writer's path relative to this test file.
+        let testFile = URL(fileURLWithPath: #filePath)
+        let writerSource = testFile
+            .deletingLastPathComponent()                 // CRMMacLifecycleTests
+            .deletingLastPathComponent()                 // Tests
+            .deletingLastPathComponent()                 // mac-daemon
+            .appendingPathComponent("Sources/CRMMacLifecycle/NonInteractiveAllowlistWriter.swift")
+        guard let bytes = try? Data(contentsOf: writerSource),
+              let text = String(data: bytes, encoding: .utf8) else {
+            XCTFail("could not read writer source at \(writerSource.path)")
+            return
+        }
+        let forbiddenSymbols = [
+            "ContactsAuthorizationAdapter",
+            "ContactContainerEnumerator",
+            "requestAccess",
+            "listContainers",
+        ]
+        for symbol in forbiddenSymbols {
+            XCTAssertFalse(
+                text.contains(symbol),
+                "NonInteractiveAllowlistWriter must not reference \(symbol) — this would re-introduce the issue #322 regression. See \(writerSource.path) for context.")
+        }
+        // Allow "Contacts framework" to appear in a comment, but
+        // not the actual symbols above.
+    }
+}

--- a/mac-daemon/Tests/CRMMacLifecycleTests/NonInteractiveAllowlistWriterTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/NonInteractiveAllowlistWriterTests.swift
@@ -216,6 +216,44 @@ final class NonInteractiveAllowlistWriterTests: XCTestCase {
             "state-write must persist even when the subsequent config-write fails")
     }
 
+    // MARK: - 5a. error-classification for state-write failure
+
+    func testWriteStateWriteFailureBubblesUpTypedError() async throws {
+        // Seed an existing allowlist so the state-write branch
+        // runs. Then sabotage the state file by replacing it with
+        // a directory at the same path. The mutator's load() will
+        // throw, the writer should map that to
+        // `.stateWriteFailed`, and the config write should NOT
+        // have happened.
+        try seedConfig(containers: ["A"])
+        let configBytesBefore = try Data(contentsOf: configURL)
+
+        // Point the state store at a directory so any save attempt
+        // throws.
+        try FileManager.default.createDirectory(at: stateURL, withIntermediateDirectories: true)
+
+        let writer = NonInteractiveAllowlistWriter(
+            configStore: ConfigStore(fileURL: configURL),
+            stateStore: StateStore(fileURL: stateURL),
+            mutatingExistingConfig: true)
+
+        do {
+            _ = try await writer.write(pickedIDs: ["B"])
+            XCTFail("expected stateWriteFailed")
+        } catch NonInteractiveAllowlistWriteError.stateWriteFailed {
+            // expected
+        } catch {
+            XCTFail("expected stateWriteFailed, got: \(error)")
+        }
+
+        // Config bytes unchanged — the state-write failure aborted
+        // before the config-write was attempted.
+        XCTAssertEqual(
+            try Data(contentsOf: configURL),
+            configBytesBefore,
+            "config.json must NOT change when the state-write fails first")
+    }
+
     // MARK: - 5b. error-classification for fresh-install config-fail
 
     func testWriteOnFreshInstallSurfacesPlainConfigWriteFailedError() async throws {
@@ -295,9 +333,13 @@ final class NonInteractiveAllowlistWriterTests: XCTestCase {
     }
 
     /// Remove `//` line comments and `/* … */` block comments from
-    /// a Swift source string. Naive (no string-literal awareness)
-    /// but sufficient for the writer file which has no string
-    /// literals containing the forbidden symbols.
+    /// a Swift source string. Deliberately naive — no string-
+    /// literal awareness, no nested-block-comment support. If a
+    /// future writer source adds a string literal containing the
+    /// substrings `//` or `/*`, the stripper will mis-handle it
+    /// and the test may false-pass or false-fail. The writer
+    /// currently has no such literals; if that changes, extend
+    /// this helper before re-running the test.
     private static func stripSwiftComments(_ source: String) -> String {
         var result = ""
         var i = source.startIndex


### PR DESCRIPTION
## Summary
Closes #321 — `crm-mac doctor` no longer reports false-positive `"orphaned"` identifiers or pushes the operator at `--re-request-permission` when run from a shell with the parent terminal lacking Contacts permission.
Closes #322 — `crm-mac configure containers --containers <uuid,…>` and `crm-mac install --containers <uuid,…>` no longer invoke `requestAccess()` / `listContainers()` on the non-interactive path; the operator-supplied UUIDs are trusted and validated by the daemon's next tick under launchd.

Shared root cause: shell-spawned CLI subcommands hit the parent terminal's TCC permission attribution rather than the daemon's bundle ID (`xyz.spengrah.crm-mac`). The daemon under launchd is always correctly attributed and healthy.

## Approach
- **Doctor (#321):** remap `.denied` and `.notDetermined` permission reads to WARN with "indeterminate from shell context — daemon is authoritative" wording. Restructure the allowlist `do/catch` so a `.notAuthorized` enumeration error emits a distinct "visibility check unavailable" WARN and falls through to the last-tick check (fixing a latent `return results` bug in the `.underlying` branch at the same time). `.restricted` stays FAIL because MDM / parental-controls is genuinely process-independent.
- **Configure / install (#322):** extract dispatch into a new testable `AllowlistConfigureFlow` in `CRMMacLifecycle` with closure-injected adapters. Non-interactive modes go through `NonInteractiveAllowlistWriter` whose type signature (ConfigStore + StateStore + Bool only) physically excludes Contacts-framework parameters. Interactive modes continue to invoke `requestAccess()` + `listContainers()`. The control-flow boundary is exercised by `AllowlistConfigureFlowTests` with call-counting auth + enumerator spies asserting zero invocations on all three non-interactive modes.
- **Semantic improvement bundled in:** an interactive picker run that yields `picked == existing` (re-request-permission confirms the same allowlist) now correctly returns `Outcome.noOp` and skips the recovery flag bump, fixing a latent issue where the daemon would trigger a spurious tombstone-and-reconcile cycle.

## Behaviour changes operators should be aware of
- `crm-mac doctor` exit code on a shell-spawned `.denied` read: previously 1 (FAIL counted), now 0 (WARN). External scripts that gate on the exit code will silently start passing where they used to fail. This is the intended behaviour — the prior FAIL was a false positive from shell context.
- `crm-mac configure containers --containers ""` (or any string parsing to `[]`) against a non-empty existing allowlist is now a destructive request: the recovery flag bumps and the daemon tombstones every previously-synced contact on next tick. The non-interactive path deliberately trusts the operator. Use the interactive picker if a confirmation prompt is desired.

## Test plan
- [x] `make mac-daemon` — release build with bundle assembly + ad-hoc codesign succeeds locally.
- [x] `make test-daemon-local` — XCTest is unavailable in the local CLT-only environment, so this is validated by CI (macos-15 / Xcode 16).
- [x] Local Codex review: 2 rounds, round-2 RESULT=PASS.
- [x] Local `/review-head` Claude review: RESULT=PASS, 3×P2 + 2×P3 addressed inline.
- [x] CI: backend tests skipped (mac-daemon/** not in `test-triggers.yml`), mac-daemon CI runs full `swift test` + smoke `--help` step.
- [ ] Manual operator verification post-merge (per #321 / #322 issue bodies):
  - `crm-mac doctor` from shell prints `"N configured (visibility check unavailable from shell context — daemon is authoritative)"` instead of `"N orphaned"`.
  - `crm-mac configure containers --containers <known-good-uuid>` from a shell with Contacts permission denied succeeds and writes config.json.
  - `crm-mac configure containers` (no flag) from shell still emits the existing "Contacts permission missing" message on the interactive path.

## Test coverage added
- `DoctorIcloudContactsTests` — 3 new cases including `.notAuthorized` regression assertions for last-tick presence.
- `NonInteractiveAllowlistWriterTests` — 7 cases covering happy-path write, no-op short-circuit, fresh-install skip-recovery, defensive-recovery-flag-bump, all three error variants (`stateWriteFailed`, `configWriteFailedAfterStateWrite`, `configWriteFailed`), and a structural type-signature regression guard.
- `AllowlistConfigureFlowTests` — 11 cases covering the full coverage matrix of (mode × picked-vs-existing) with auth + enumerator call counts asserted on each row.
- `ContainerAllowlistInputTests` — 3 pure-logic cases.

## Plan reference
`.ai/log/plan/mac-daemon-doctor-and-configure-cli-fix.md` (Codex-approved at round 4)