### PR TITLE
fix(deploy-mac): re-register from installed binary (SMAppService cache)

### DIFF
--- a/scripts/deploy-mac-daemon.sh
+++ b/scripts/deploy-mac-daemon.sh
@@ -77,18 +77,41 @@ echo "=== Installing (upgrade) ==="
 "$BUILD_BINARY" install --upgrade
 echo ""
 
-echo "=== Kickstarting daemon ==="
-launchctl kickstart -k "gui/$(id -u)/$DAEMON_LABEL" || true
+# `install --upgrade` copies a correctly-substituted bundle into the install
+# path, but `SMAppService.register()` reads the CALLING binary's containing-
+# bundle plist — which is the build-dir bundle, whose plist still has the
+# literal `__INSTALL_PREFIX__` placeholder (it's the operator's install path
+# that gets baked in only at install-time-rendering of the install-path
+# bundle's plist). launchd then tries to exec the literal placeholder path
+# and crashes with EX_CONFIG, with the daemon visibly "Lost" on the Pi.
+#
+# Defeat the cache by booting out the stale registration and re-registering
+# from the INSTALLED binary, whose containing-bundle plist already has the
+# real path substituted in.
+INSTALLED_BIN="$INSTALL_BUNDLE/Contents/MacOS/crm-mac"
+echo "=== Re-registering from installed binary (SMAppService cache workaround) ==="
+launchctl bootout "gui/$(id -u)/$DAEMON_LABEL" 2>/dev/null || true
+sleep 1
+"$INSTALLED_BIN" install --register-only
 echo ""
 
 echo "=== Verifying ==="
 sleep 2
-if launchctl print "gui/$(id -u)/$DAEMON_LABEL" >/dev/null 2>&1; then
-    echo "Daemon: registered with launchd"
-else
-    echo "Daemon: NOT found in launchd" >&2
-    exit 1
-fi
+program="$(launchctl print "gui/$(id -u)/$DAEMON_LABEL" 2>/dev/null | awk -F'= ' '/^\tprogram /{print $2}')"
+case "$program" in
+    "")
+        echo "Daemon: NOT found in launchd" >&2
+        exit 1
+        ;;
+    *__INSTALL_PREFIX__*)
+        echo "Daemon: SMAppService still has __INSTALL_PREFIX__ cached at $program" >&2
+        echo "(the bootout+register-from-installed dance did not take effect)" >&2
+        exit 1
+        ;;
+    *)
+        echo "Daemon registered: $program"
+        ;;
+esac
 
 echo ""
 echo "=== Mac daemon deploy complete ==="

--- a/scripts/deploy-mac-daemon.sh
+++ b/scripts/deploy-mac-daemon.sh
@@ -108,10 +108,19 @@ case "$program" in
         echo "(the bootout+register-from-installed dance did not take effect)" >&2
         exit 1
         ;;
-    *)
-        echo "Daemon registered: $program"
-        ;;
 esac
+# Exact-match guard: a non-empty, non-placeholder `program` could still be
+# pointing at the build-dir bundle or some stale path. Anything but the
+# expected install-path binary means SMAppService is caching something we
+# don't control, which is exactly the failure shape this script is meant to
+# prevent.
+if [ "$program" != "$INSTALLED_BIN" ]; then
+    echo "Daemon: registered program does not match expected install path" >&2
+    echo "  expected: $INSTALLED_BIN" >&2
+    echo "  actual:   $program" >&2
+    exit 1
+fi
+echo "Daemon registered: $program"
 
 echo ""
 echo "=== Mac daemon deploy complete ==="


### PR DESCRIPTION
## Summary

Fixes a regression that surfaced overnight: the daemon stopped heartbeating ~16h after yesterday's deploy and showed as "Lost" on the Pi. Root cause was the SMAppService plist-cache bug we hit during PR #318's hypothesis validation — running `install --upgrade` from the build-dir binary leaves SMAppService pointing at the build-dir bundle's plist (which still has the literal `__INSTALL_PREFIX__` placeholder). After the daemon's first natural restart, launchd tried to exec the literal placeholder path and crashed with `EX_CONFIG`. KeepAlive gave up after two retries; we didn't notice until the next morning.

The workaround was discovered + proven during the PR #318 validation but never baked into the deploy script. This bakes it in: after `install --upgrade`, bootout the stale registration and re-register from the INSTALLED binary (whose containing-bundle plist has the real path substituted in). Verification step now fails loudly if the registered `program` still contains `__INSTALL_PREFIX__`.

## Validation

- Empirically replayed locally: `scripts/deploy-mac-daemon.sh` ran clean, daemon process `pid=9594`, `state=running`, `program = /Users/.../crm-mac.app/Contents/MacOS/crm-mac` (no placeholder), `runs=1`, `last exit code = (never exited)`.
- Live host was recovered manually before the script fix (`launchctl bootout` + register-from-installed-binary).

## Review

`/review-head` returned PASS (0×P0, 0×P1, 3×P2, 2×P3). The P2 findings are real-but-non-blocking and worth a follow-up:
- bootout doesn't necessarily clear SMAppService's own state — workaround relies on register-only re-publishing
- `launchctl print` parsing is officially unsupported by Apple; could read the plist on disk via PlistBuddy instead
- verification should assert exact-match on `\$INSTALLED_BIN` rather than just "not placeholder"

P3s are `set -o pipefail` + comments on the `sleep` magic numbers. Full review at `.ai/log/review/a0e318da80c1497065e5efe4dfdddc06317f04db.md`.