### PR TITLE
feat(ingest): meeting_note.* + linkage detection (anarlog phase 2 PR 3)

### DIFF
--- a/backend/cmd/crm-admin/main.go
+++ b/backend/cmd/crm-admin/main.go
@@ -335,7 +335,8 @@ func buildProductionDeps(ctx context.Context, cfg *config.Config, database *db.D
 		pairingTokenRepo,
 		syncRepo,
 		contactMethodLister,
-		externalContactRepo, // /known-ids reader
+		externalContactRepo, // /known-ids reader (external_contact)
+		repository.NewMeetingNoteRepository(database.Queries), // /known-ids reader (anarlog_sessions)
 		database.Pool,
 		0)
 

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -727,7 +727,7 @@ func run() int {
 		identityHandler = handlers.NewIdentityHandler(identityService)
 
 		// Initialize import handler
-		importHandler = handlers.NewImportHandler(externalContactRepo, identityRepoForIngest, contactService, importMatchService, enrichmentService)
+		importHandler = handlers.NewImportHandler(externalContactRepo, identityServiceForIngest, contactService, importMatchService, enrichmentService)
 
 		logger.Info().Msg("external sync infrastructure enabled")
 	}

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -304,16 +304,17 @@ func run() int {
 	// own MacHostService that wraps the same repo instance.
 	macHostRepoForIngest := repository.NewMacHostRepository(database.Queries)
 
-	ingestService := service.NewIngestService(
-		database,
-		eventBus,
-		identityServiceForIngest,
-		messagesMessageRepo,
-		riverClient,
-		externalContactRepoForIngest,
-		macHostRepoForIngest, // host-liveness re-check inside the batch tx
-	)
-	ingestHandler := handlers.NewIngestHandler(ingestService)
+	// meeting_note repo + calendar repo + identity repo for the inline
+	// meeting_note.recorded / .deleted handlers. Constructed
+	// unconditionally because the IngestService is always wired even
+	// when external sync is disabled — the Mac daemon can still post
+	// meeting_note.* on the host-auth path. The calendarRepo here is
+	// the same logical resource the feature-flagged
+	// google.NewCalendarRematchHandler block below constructs; safe to
+	// have two instances pointing at the same queries since
+	// CalendarEventRepository is stateless.
+	meetingNoteRepoForIngest := repository.NewMeetingNoteRepository(database.Queries)
+	calendarRepoForIngest := repository.NewCalendarEventRepository(database.Queries)
 
 	// Rematch service — constructed above ContactService so it can be
 	// passed as the RematchRegistry constructor arg. Handlers register
@@ -322,6 +323,26 @@ func run() int {
 
 	// Initialize services
 	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, eventBus, rematchService)
+
+	// ingestService is constructed AFTER contactService because the
+	// inline meeting_note.recorded handler routes session-attributed
+	// interaction writes through ContactService.RecordInteractionTx so
+	// cadence updates + follow-up evaluation fire correctly.
+	ingestService := service.NewIngestService(
+		database,
+		eventBus,
+		identityServiceForIngest,
+		messagesMessageRepo,
+		riverClient,
+		externalContactRepoForIngest,
+		macHostRepoForIngest, // host-liveness re-check inside the batch tx
+		meetingNoteRepoForIngest,
+		calendarRepoForIngest,
+		interactionRepo,
+		identityRepoForIngest,
+		contactService,
+	)
+	ingestHandler := handlers.NewIngestHandler(ingestService)
 
 	// Telegram message repo construction (hoisted above the
 	// InteractionRecorder wiring so the consumer can mark messages

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -911,7 +911,8 @@ func run() int {
 		pairingTokenRepo,
 		macSyncRepo,
 		contactMethodRepo,
-		externalContactRepoForIngest, // /known-ids reader
+		externalContactRepoForIngest, // /known-ids reader (external_contact)
+		meetingNoteRepoForIngest,     // /known-ids reader (anarlog_sessions)
 		database.Pool,
 		0, // default bcrypt cost
 	)

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -727,7 +727,7 @@ func run() int {
 		identityHandler = handlers.NewIdentityHandler(identityService)
 
 		// Initialize import handler
-		importHandler = handlers.NewImportHandler(externalContactRepo, contactService, importMatchService, enrichmentService)
+		importHandler = handlers.NewImportHandler(externalContactRepo, identityRepoForIngest, contactService, importMatchService, enrichmentService)
 
 		logger.Info().Msg("external sync infrastructure enabled")
 	}

--- a/backend/internal/api/handlers/import.go
+++ b/backend/internal/api/handlers/import.go
@@ -31,18 +31,16 @@ type PostImportHook interface {
 	OnPeerLinked(ctx context.Context, peerUserID int64, peerUsername string, contactID uuid.UUID) error
 }
 
-// ImportHandler intentionally holds direct repository references
-// (externalRepo, identityRepo) alongside service references. This
-// breaks the canonical handler→service→repository layering — kept as
-// a documented exception because the existing import flow already
-// reads/writes external_contact directly (GetByID, UpdateMatch,
-// Ignore) and bouncing those through a service wrapper would be
-// pure-passthrough code with no semantic gain. The identityRepo
-// dependency follows the same convention so the anarlog backfill
-// stays cohesive with the rest of the handler.
+// ImportHandler holds the dependencies the import endpoints need. It
+// keeps a direct externalRepo reference because the existing import
+// flow reads/writes external_contact across most methods (GetByID,
+// UpdateMatch, Ignore) and a passthrough service wrapper would add
+// indirection without semantic gain. The anarlog identity backfill is
+// routed through identitySvc so handler code does not call the
+// identity repository directly.
 type ImportHandler struct {
 	externalRepo   *repository.ExternalContactRepository
-	identityRepo   *repository.IdentityRepository
+	identitySvc    *service.IdentityService
 	contactSvc     *service.ContactService
 	matchSvc       *service.ImportMatchService
 	enricher       *service.EnrichmentService
@@ -50,21 +48,21 @@ type ImportHandler struct {
 	postImportHook PostImportHook
 }
 
-// NewImportHandler creates a new import handler. identityRepo may be
+// NewImportHandler creates a new import handler. identitySvc may be
 // nil for callers that don't exercise the anarlog_humans backfill
 // path; when nil the import flow silently skips the anarlog identity
 // update (the meeting_note re-sync path then re-resolves as unmatched,
 // which matches the no-backfill baseline behavior).
 func NewImportHandler(
 	externalRepo *repository.ExternalContactRepository,
-	identityRepo *repository.IdentityRepository,
+	identitySvc *service.IdentityService,
 	contactSvc *service.ContactService,
 	matchSvc *service.ImportMatchService,
 	enricher *service.EnrichmentService,
 ) *ImportHandler {
 	return &ImportHandler{
 		externalRepo: externalRepo,
-		identityRepo: identityRepo,
+		identitySvc:  identitySvc,
 		contactSvc:   contactSvc,
 		matchSvc:     matchSvc,
 		enricher:     enricher,
@@ -413,8 +411,14 @@ func (h *ImportHandler) ImportContact(c *gin.Context) {
 
 	// Anarlog-humans backfill: link the anarlog_human_id identity row
 	// to the imported contact so a future meeting_note.recorded re-sync
-	// resolves the human and produces the right interaction.
-	h.backfillAnarlogIdentity(ctx, external, contact.ID)
+	// resolves the human and produces the right interaction. Surfaces
+	// errors as 500 because a silent failure would leave the user with
+	// an imported contact whose anarlog sessions don't link to it.
+	if err := h.backfillAnarlogIdentity(ctx, external, contact.ID); err != nil {
+		logger.Error().Err(err).Str("external_id", id.String()).Msg("anarlog import backfill failed")
+		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to link anarlog identity to imported contact", err.Error())
+		return
+	}
 
 	api.SendSuccess(c, http.StatusCreated, response, nil)
 }
@@ -575,8 +579,13 @@ func (h *ImportHandler) LinkContact(c *gin.Context) {
 
 	// Anarlog-humans backfill: link the anarlog_human_id identity row
 	// to the linked contact so a future meeting_note.recorded re-sync
-	// resolves the human and produces the right interaction.
-	h.backfillAnarlogIdentity(ctx, external, crmContactID)
+	// resolves the human and produces the right interaction. Surfaces
+	// errors as 500 — see ImportContact above for the rationale.
+	if err := h.backfillAnarlogIdentity(ctx, external, crmContactID); err != nil {
+		logger.Error().Err(err).Str("external_id", id.String()).Msg("anarlog import backfill failed")
+		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to link anarlog identity to linked contact", err.Error())
+		return
+	}
 
 	api.SendSuccess(c, http.StatusOK, LinkContactResponse{
 		ExternalContact: updated,
@@ -603,42 +612,15 @@ func (h *ImportHandler) triggerPostImportHook(ctx context.Context, external *rep
 	}
 }
 
-// backfillAnarlogIdentity links the anarlog_human_id external_identity
-// row (planted by handleExternalContactUpserted at ingest time) to the
-// supplied CRM contact. Mirrors the email/phone identity-link logic
-// that already runs for other import paths. Best-effort: a failure
-// here logs a warning but does not roll back the import — the worst
-// outcome is that the next meeting_note.recorded re-sync resolves the
-// human as unmatched (the same as the no-backfill baseline).
-func (h *ImportHandler) backfillAnarlogIdentity(ctx context.Context, external *repository.ExternalContact, contactID uuid.UUID) {
-	if h.identityRepo == nil || external == nil || external.Source != "anarlog_humans" {
-		return
+// backfillAnarlogIdentity routes through IdentityService so the handler
+// stays free of direct repository calls. Returns nil + no-op when the
+// external_contact is not from the anarlog_humans source, or when
+// identitySvc is nil (test wiring).
+func (h *ImportHandler) backfillAnarlogIdentity(ctx context.Context, external *repository.ExternalContact, contactID uuid.UUID) error {
+	if h.identitySvc == nil || external == nil || external.Source != "anarlog_humans" {
+		return nil
 	}
-	identities, err := h.identityRepo.FindIdentitiesByAnarlogHumanID(ctx, external.SourceID)
-	if err != nil {
-		logger.Warn().Err(err).Str("anarlog_human_id", external.SourceID).Msg("anarlog import backfill: failed to lookup identity")
-		return
-	}
-	for _, ident := range identities {
-		// Skip identities that are already linked to a different
-		// contact — manual user intent should not be silently
-		// overwritten by an import.
-		if ident.ContactID != nil && *ident.ContactID != contactID {
-			logger.Warn().
-				Str("anarlog_human_id", external.SourceID).
-				Str("existing_contact_id", ident.ContactID.String()).
-				Str("import_contact_id", contactID.String()).
-				Msg("anarlog import backfill: identity already linked to different contact; skipping")
-			continue
-		}
-		if _, err := h.identityRepo.LinkToContact(ctx, repository.LinkIdentityRequest{
-			IdentityID: ident.ID,
-			ContactID:  contactID,
-			MatchType:  repository.MatchTypeManual,
-		}); err != nil {
-			logger.Warn().Err(err).Str("anarlog_human_id", external.SourceID).Msg("anarlog import backfill: failed to link identity")
-		}
-	}
+	return h.identitySvc.BackfillAnarlogIdentityForImport(ctx, external.SourceID, contactID)
 }
 
 // toEnrichmentMethodSelections converts handler selections to service format

--- a/backend/internal/api/handlers/import.go
+++ b/backend/internal/api/handlers/import.go
@@ -33,6 +33,7 @@ type PostImportHook interface {
 
 type ImportHandler struct {
 	externalRepo   *repository.ExternalContactRepository
+	identityRepo   *repository.IdentityRepository
 	contactSvc     *service.ContactService
 	matchSvc       *service.ImportMatchService
 	enricher       *service.EnrichmentService
@@ -40,15 +41,21 @@ type ImportHandler struct {
 	postImportHook PostImportHook
 }
 
-// NewImportHandler creates a new import handler
+// NewImportHandler creates a new import handler. identityRepo may be
+// nil for callers that don't exercise the anarlog_humans backfill
+// path; when nil the import flow silently skips the anarlog identity
+// update (the meeting_note re-sync path would then re-resolve as
+// unmatched, which is the pre-PR-3 behavior).
 func NewImportHandler(
 	externalRepo *repository.ExternalContactRepository,
+	identityRepo *repository.IdentityRepository,
 	contactSvc *service.ContactService,
 	matchSvc *service.ImportMatchService,
 	enricher *service.EnrichmentService,
 ) *ImportHandler {
 	return &ImportHandler{
 		externalRepo: externalRepo,
+		identityRepo: identityRepo,
 		contactSvc:   contactSvc,
 		matchSvc:     matchSvc,
 		enricher:     enricher,
@@ -395,6 +402,11 @@ func (h *ImportHandler) ImportContact(c *gin.Context) {
 	// Post-import hook: back-link Telegram message history
 	h.triggerPostImportHook(ctx, external, contact.ID)
 
+	// Anarlog-humans backfill: link the anarlog_human_id identity row
+	// to the imported contact so a future meeting_note.recorded re-sync
+	// resolves the human and produces the right interaction.
+	h.backfillAnarlogIdentity(ctx, external, contact.ID)
+
 	api.SendSuccess(c, http.StatusCreated, response, nil)
 }
 
@@ -552,6 +564,11 @@ func (h *ImportHandler) LinkContact(c *gin.Context) {
 	// Post-import hook: back-link Telegram message history
 	h.triggerPostImportHook(ctx, external, crmContactID)
 
+	// Anarlog-humans backfill: link the anarlog_human_id identity row
+	// to the linked contact so a future meeting_note.recorded re-sync
+	// resolves the human and produces the right interaction.
+	h.backfillAnarlogIdentity(ctx, external, crmContactID)
+
 	api.SendSuccess(c, http.StatusOK, LinkContactResponse{
 		ExternalContact: updated,
 		RematchJobID:    nilStringPtrFromUUID(rematchJobID),
@@ -574,6 +591,44 @@ func (h *ImportHandler) triggerPostImportHook(ctx context.Context, external *rep
 	}
 	if err := h.postImportHook.OnPeerLinked(ctx, peerUserID, peerUsername, contactID); err != nil {
 		logger.Warn().Err(err).Int64("peer_user_id", peerUserID).Msg("telegram: post-import hook failed")
+	}
+}
+
+// backfillAnarlogIdentity links the anarlog_human_id external_identity
+// row (planted by handleExternalContactUpserted at ingest time) to the
+// supplied CRM contact. Mirrors the email/phone identity-link logic
+// that already runs for other import paths. Best-effort: a failure
+// here logs a warning but does not roll back the import — the worst
+// outcome is that the next meeting_note.recorded re-sync still resolves
+// the human as unmatched, which is the pre-PR-3 behavior.
+func (h *ImportHandler) backfillAnarlogIdentity(ctx context.Context, external *repository.ExternalContact, contactID uuid.UUID) {
+	if h.identityRepo == nil || external == nil || external.Source != "anarlog_humans" {
+		return
+	}
+	identities, err := h.identityRepo.FindIdentitiesByAnarlogHumanID(ctx, external.SourceID)
+	if err != nil {
+		logger.Warn().Err(err).Str("anarlog_human_id", external.SourceID).Msg("anarlog import backfill: failed to lookup identity")
+		return
+	}
+	for _, ident := range identities {
+		// Skip identities that are already linked to a different
+		// contact — manual user intent should not be silently
+		// overwritten by an import.
+		if ident.ContactID != nil && *ident.ContactID != contactID {
+			logger.Warn().
+				Str("anarlog_human_id", external.SourceID).
+				Str("existing_contact_id", ident.ContactID.String()).
+				Str("import_contact_id", contactID.String()).
+				Msg("anarlog import backfill: identity already linked to different contact; skipping")
+			continue
+		}
+		if _, err := h.identityRepo.LinkToContact(ctx, repository.LinkIdentityRequest{
+			IdentityID: ident.ID,
+			ContactID:  contactID,
+			MatchType:  repository.MatchTypeManual,
+		}); err != nil {
+			logger.Warn().Err(err).Str("anarlog_human_id", external.SourceID).Msg("anarlog import backfill: failed to link identity")
+		}
 	}
 }
 

--- a/backend/internal/api/handlers/import.go
+++ b/backend/internal/api/handlers/import.go
@@ -31,6 +31,15 @@ type PostImportHook interface {
 	OnPeerLinked(ctx context.Context, peerUserID int64, peerUsername string, contactID uuid.UUID) error
 }
 
+// ImportHandler intentionally holds direct repository references
+// (externalRepo, identityRepo) alongside service references. This
+// breaks the canonical handler→service→repository layering — kept as
+// a documented exception because the existing import flow already
+// reads/writes external_contact directly (GetByID, UpdateMatch,
+// Ignore) and bouncing those through a service wrapper would be
+// pure-passthrough code with no semantic gain. The identityRepo
+// dependency follows the same convention so the anarlog backfill
+// stays cohesive with the rest of the handler.
 type ImportHandler struct {
 	externalRepo   *repository.ExternalContactRepository
 	identityRepo   *repository.IdentityRepository
@@ -44,8 +53,8 @@ type ImportHandler struct {
 // NewImportHandler creates a new import handler. identityRepo may be
 // nil for callers that don't exercise the anarlog_humans backfill
 // path; when nil the import flow silently skips the anarlog identity
-// update (the meeting_note re-sync path would then re-resolve as
-// unmatched, which is the pre-PR-3 behavior).
+// update (the meeting_note re-sync path then re-resolves as unmatched,
+// which matches the no-backfill baseline behavior).
 func NewImportHandler(
 	externalRepo *repository.ExternalContactRepository,
 	identityRepo *repository.IdentityRepository,
@@ -599,8 +608,8 @@ func (h *ImportHandler) triggerPostImportHook(ctx context.Context, external *rep
 // supplied CRM contact. Mirrors the email/phone identity-link logic
 // that already runs for other import paths. Best-effort: a failure
 // here logs a warning but does not roll back the import — the worst
-// outcome is that the next meeting_note.recorded re-sync still resolves
-// the human as unmatched, which is the pre-PR-3 behavior.
+// outcome is that the next meeting_note.recorded re-sync resolves the
+// human as unmatched (the same as the no-backfill baseline).
 func (h *ImportHandler) backfillAnarlogIdentity(ctx context.Context, external *repository.ExternalContact, contactID uuid.UUID) {
 	if h.identityRepo == nil || external == nil || external.Source != "anarlog_humans" {
 		return

--- a/backend/internal/api/handlers/ingest.go
+++ b/backend/internal/api/handlers/ingest.go
@@ -119,8 +119,7 @@ type IngestError struct {
 // NeedsAttention is populated by the meeting_note.recorded inline
 // handler when a session lands in a state requiring user attention
 // (conflict_pending or orphan_needs_review). Emitted with `omitempty`
-// so existing daemons unaware of the field see a backward-compatible
-// response; the Mac daemon consumes it in phase 2 PR 6.
+// so daemons unaware of the field see a backward-compatible response.
 type IngestResponse struct {
 	Accepted       int                  `json:"accepted"`
 	Duplicate      int                  `json:"duplicate"`
@@ -270,7 +269,8 @@ func (h *IngestHandler) IngestEvents(c *gin.Context) {
 
 	// Map the service-layer NeedsAttentionItem to the handler-layer
 	// JSON shape. omitempty on the response field means nil/empty
-	// slice produces a wire-compatible response for pre-PR-6 daemons.
+	// slice produces a wire-compatible response for daemons that
+	// haven't shipped the consumer yet.
 	var responseNeedsAttention []NeedsAttentionItem
 	if len(needsAttention) > 0 {
 		responseNeedsAttention = make([]NeedsAttentionItem, len(needsAttention))

--- a/backend/internal/api/handlers/ingest.go
+++ b/backend/internal/api/handlers/ingest.go
@@ -115,11 +115,26 @@ type IngestError struct {
 // IngestResponse matches the spec §3.5 happy-path shape literally —
 // deliberately NOT wrapped in api.APIResponse. External daemons are
 // contract consumers and the wrapping would be a spec deviation.
+//
+// NeedsAttention is populated by the meeting_note.recorded inline
+// handler when a session lands in a state requiring user attention
+// (conflict_pending or orphan_needs_review). Emitted with `omitempty`
+// so existing daemons unaware of the field see a backward-compatible
+// response; the Mac daemon consumes it in phase 2 PR 6.
 type IngestResponse struct {
-	Accepted  int           `json:"accepted"`
-	Duplicate int           `json:"duplicate"`
-	Rejected  int           `json:"rejected"`
-	Errors    []IngestError `json:"errors"`
+	Accepted       int                  `json:"accepted"`
+	Duplicate      int                  `json:"duplicate"`
+	Rejected       int                  `json:"rejected"`
+	Errors         []IngestError        `json:"errors"`
+	NeedsAttention []NeedsAttentionItem `json:"needs_attention,omitempty"`
+}
+
+// NeedsAttentionItem is the per-session attention record surfaced in
+// IngestResponse. SessionID is the anarlog session UUID; Reason is
+// one of "orphan" | "conflict" (mirrors the service-layer constants).
+type NeedsAttentionItem struct {
+	SessionID string `json:"session_id"`
+	Reason    string `json:"reason"`
 }
 
 // IngestEvents is the HTTP handler for POST /api/v1/ingest/events.
@@ -225,7 +240,7 @@ func (h *IngestHandler) IngestEvents(c *gin.Context) {
 		return
 	}
 
-	accepted, duplicate, perEventRejections, err := h.ingestService.IngestBatch(c.Request.Context(), envsToIngest, originalIndices, hostID)
+	accepted, duplicate, perEventRejections, needsAttention, err := h.ingestService.IngestBatch(c.Request.Context(), envsToIngest, originalIndices, hostID)
 	if err != nil {
 		// Host revoked between auth-middleware validation and the
 		// batch's tx-internal FOR UPDATE lock — return 401 so the
@@ -253,18 +268,34 @@ func (h *IngestHandler) IngestEvents(c *gin.Context) {
 		})
 	}
 
+	// Map the service-layer NeedsAttentionItem to the handler-layer
+	// JSON shape. omitempty on the response field means nil/empty
+	// slice produces a wire-compatible response for pre-PR-6 daemons.
+	var responseNeedsAttention []NeedsAttentionItem
+	if len(needsAttention) > 0 {
+		responseNeedsAttention = make([]NeedsAttentionItem, len(needsAttention))
+		for i, na := range needsAttention {
+			responseNeedsAttention[i] = NeedsAttentionItem{
+				SessionID: na.SessionID,
+				Reason:    na.Reason,
+			}
+		}
+	}
+
 	logger.Info().
 		Int("batch_size", len(req.Events)).
 		Int("accepted", accepted).
 		Int("duplicate", duplicate).
 		Int("rejected", len(ingestErrors)).
+		Int("needs_attention", len(responseNeedsAttention)).
 		Msg("event batch ingested")
 
 	c.JSON(http.StatusOK, IngestResponse{
-		Accepted:  accepted,
-		Duplicate: duplicate,
-		Rejected:  len(ingestErrors),
-		Errors:    ingestErrors,
+		Accepted:       accepted,
+		Duplicate:      duplicate,
+		Rejected:       len(ingestErrors),
+		Errors:         ingestErrors,
+		NeedsAttention: responseNeedsAttention,
 	})
 }
 

--- a/backend/internal/api/handlers/ingest.go
+++ b/backend/internal/api/handlers/ingest.go
@@ -57,6 +57,11 @@ const eventsRawMessageMaxKnownVersion = 1
 // "upgrade Pi" rejection semantics as raw_message.* (above).
 const eventsExternalContactMaxKnownVersion = 1
 
+// eventsMeetingNoteMaxKnownVersion is the highest meeting_note.*
+// payload Version the Pi knows how to process. Same "upgrade Pi"
+// rejection semantics as raw_message.* / external_contact.* above.
+const eventsMeetingNoteMaxKnownVersion = 1
+
 // IngestHandler exposes POST /api/v1/ingest/events. Registered only when
 // cfg.Features.EnableEventBusIngest is true (spec §3.9).
 type IngestHandler struct {
@@ -355,6 +360,25 @@ func validateIngestEvent(index int, ev IngestEventRequest) *IngestError {
 		}
 	}
 
+	// meeting_note.* kinds: same "upgrade Pi" version-envelope check as
+	// the other daemon-emitted kinds. ValidatePayload already enforces
+	// source_id parses as a UUID and host_id is non-zero — we add the
+	// payload-version check + empty source_id guard here so the daemon
+	// gets a clear MISSING_FIELD / PAYLOAD_INVALID rather than a
+	// service-layer PAYLOAD_INVARIANT for the same root cause.
+	if kind == events.KindMeetingNoteRecorded || kind == events.KindMeetingNoteDeleted {
+		if ev.SourceID == "" {
+			return &IngestError{
+				Index:   index,
+				Code:    ingestCodeMissingField,
+				Message: "source_id is required for meeting_note.* kinds",
+			}
+		}
+		if rerr := validateMeetingNotePayloadVersion(index, kind, ev); rerr != nil {
+			return rerr
+		}
+	}
+
 	return nil
 }
 
@@ -378,6 +402,28 @@ func validateExternalContactPayloadVersion(index int, kind events.Kind, ev Inges
 		return &IngestError{Index: index, Code: ingestCodePayloadInvalid,
 			Message: fmt.Sprintf("%s payload version %d exceeds max known %d; upgrade Pi",
 				kind, versionEnvelope.Version, eventsExternalContactMaxKnownVersion)}
+	}
+	return nil
+}
+
+// validateMeetingNotePayloadVersion enforces the version envelope on
+// both meeting_note.* kinds. Same shape and behaviour as the
+// external_contact variant above.
+func validateMeetingNotePayloadVersion(index int, kind events.Kind, ev IngestEventRequest) *IngestError {
+	var versionEnvelope struct {
+		Version int `json:"version"`
+	}
+	if err := json.Unmarshal(ev.Payload, &versionEnvelope); err != nil {
+		return &IngestError{Index: index, Code: ingestCodePayloadInvalid, Message: err.Error()}
+	}
+	if versionEnvelope.Version < 1 {
+		return &IngestError{Index: index, Code: ingestCodePayloadInvalid,
+			Message: fmt.Sprintf("%s payload: version must be >=1 (got %d)", kind, versionEnvelope.Version)}
+	}
+	if versionEnvelope.Version > eventsMeetingNoteMaxKnownVersion {
+		return &IngestError{Index: index, Code: ingestCodePayloadInvalid,
+			Message: fmt.Sprintf("%s payload version %d exceeds max known %d; upgrade Pi",
+				kind, versionEnvelope.Version, eventsMeetingNoteMaxKnownVersion)}
 	}
 	return nil
 }

--- a/backend/internal/db/calendar_event.sql.go
+++ b/backend/internal/db/calendar_event.sql.go
@@ -58,6 +58,65 @@ func (q *Queries) DeleteEventsByAccount(ctx context.Context, googleAccountID str
 	return err
 }
 
+const FindCalendarEventsInWindow = `-- name: FindCalendarEventsInWindow :many
+SELECT id, gcal_event_id, gcal_calendar_id, google_account_id, title, description, location, start_time, end_time, all_day, status, user_response, organizer_email, attendees, matched_contact_ids, synced_at, last_contacted_updated, created_at, updated_at, html_link FROM calendar_event
+WHERE start_time BETWEEN $1 AND $2
+  AND status != 'cancelled'
+ORDER BY start_time ASC
+`
+
+type FindCalendarEventsInWindowParams struct {
+	WindowStart pgtype.Timestamptz `json:"window_start"`
+	WindowEnd   pgtype.Timestamptz `json:"window_end"`
+}
+
+// Returns candidate calendar_event rows for the meeting_note.recorded
+// linkage-detection algorithm. Filters out cancelled events. Backed by
+// idx_calendar_event_start (partial index on start_time WHERE
+// status != 'cancelled' — already exists from migration 016). The
+// output includes matched_contact_ids so the linkage handler can
+// compute walk-in supplementals (Step 5).
+func (q *Queries) FindCalendarEventsInWindow(ctx context.Context, arg FindCalendarEventsInWindowParams) ([]*CalendarEvent, error) {
+	rows, err := q.db.Query(ctx, FindCalendarEventsInWindow, arg.WindowStart, arg.WindowEnd)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []*CalendarEvent{}
+	for rows.Next() {
+		var i CalendarEvent
+		if err := rows.Scan(
+			&i.ID,
+			&i.GcalEventID,
+			&i.GcalCalendarID,
+			&i.GoogleAccountID,
+			&i.Title,
+			&i.Description,
+			&i.Location,
+			&i.StartTime,
+			&i.EndTime,
+			&i.AllDay,
+			&i.Status,
+			&i.UserResponse,
+			&i.OrganizerEmail,
+			&i.Attendees,
+			&i.MatchedContactIds,
+			&i.SyncedAt,
+			&i.LastContactedUpdated,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.HtmlLink,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const FindEventsByAttendeeEmailUnmatchedForContact = `-- name: FindEventsByAttendeeEmailUnmatchedForContact :many
 SELECT id, gcal_event_id, gcal_calendar_id, google_account_id, title, description, location, start_time, end_time, all_day, status, user_response, organizer_email, attendees, matched_contact_ids, synced_at, last_contacted_updated, created_at, updated_at, html_link FROM calendar_event
 WHERE jsonb_array_lower_values(attendees, 'email') && ARRAY[LOWER($1::text)]

--- a/backend/internal/db/calendar_event.sql.go
+++ b/backend/internal/db/calendar_event.sql.go
@@ -75,7 +75,7 @@ type FindCalendarEventsInWindowParams struct {
 // idx_calendar_event_start (partial index on start_time WHERE
 // status != 'cancelled' — already exists from migration 016). The
 // output includes matched_contact_ids so the linkage handler can
-// compute walk-in supplementals (Step 5).
+// compute walk-in supplementals.
 func (q *Queries) FindCalendarEventsInWindow(ctx context.Context, arg FindCalendarEventsInWindowParams) ([]*CalendarEvent, error) {
 	rows, err := q.db.Query(ctx, FindCalendarEventsInWindow, arg.WindowStart, arg.WindowEnd)
 	if err != nil {

--- a/backend/internal/db/external_identity.sql.go
+++ b/backend/internal/db/external_identity.sql.go
@@ -77,6 +77,55 @@ func (q *Queries) DeleteIdentity(ctx context.Context, id pgtype.UUID) error {
 	return err
 }
 
+const FindIdentitiesByAnarlogHumanID = `-- name: FindIdentitiesByAnarlogHumanID :many
+SELECT id, identifier, identifier_type, raw_identifier, source, source_id, contact_id, match_type, match_confidence, display_name, last_seen_at, message_count, created_at, updated_at FROM external_identity
+WHERE identifier_type = 'anarlog_human_id'
+  AND source = 'anarlog_humans'
+  AND identifier = $1
+`
+
+// Used by the Import handler's anarlog backfill — when a user imports
+// an anarlog_humans external_contact, the associated anarlog_human_id
+// identity row's contact_id is linked to the imported CRM contact. The
+// (identifier, identifier_type, source) triple is unique so this
+// normally returns a 0- or 1-row slice; the list shape matches
+// FindIdentitiesByIdentifier for consistency with the existing
+// repository surface.
+func (q *Queries) FindIdentitiesByAnarlogHumanID(ctx context.Context, anarlogHumanID string) ([]*ExternalIdentity, error) {
+	rows, err := q.db.Query(ctx, FindIdentitiesByAnarlogHumanID, anarlogHumanID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []*ExternalIdentity{}
+	for rows.Next() {
+		var i ExternalIdentity
+		if err := rows.Scan(
+			&i.ID,
+			&i.Identifier,
+			&i.IdentifierType,
+			&i.RawIdentifier,
+			&i.Source,
+			&i.SourceID,
+			&i.ContactID,
+			&i.MatchType,
+			&i.MatchConfidence,
+			&i.DisplayName,
+			&i.LastSeenAt,
+			&i.MessageCount,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const FindIdentitiesByIdentifier = `-- name: FindIdentitiesByIdentifier :many
 SELECT id, identifier, identifier_type, raw_identifier, source, source_id, contact_id, match_type, match_confidence, display_name, last_seen_at, message_count, created_at, updated_at FROM external_identity
 WHERE identifier_type = $1 AND identifier = $2
@@ -120,6 +169,41 @@ func (q *Queries) FindIdentitiesByIdentifier(ctx context.Context, arg FindIdenti
 		return nil, err
 	}
 	return items, nil
+}
+
+const FindIdentityByAnarlogHumanID = `-- name: FindIdentityByAnarlogHumanID :one
+SELECT id, identifier, identifier_type, raw_identifier, source, source_id, contact_id, match_type, match_confidence, display_name, last_seen_at, message_count, created_at, updated_at FROM external_identity
+WHERE identifier_type = 'anarlog_human_id'
+  AND source = 'anarlog_humans'
+  AND identifier = $1
+`
+
+// Lookup hook used by the meeting_note.recorded inline handler to
+// resolve a payload's participant_ids (anarlog UUIDs) into CRM
+// contact_ids. The (identifier, identifier_type, source) triple is
+// unique, so this returns at most one row. The identifier_type is
+// pinned to 'anarlog_human_id' and the source to 'anarlog_humans'
+// (the only writer of these rows).
+func (q *Queries) FindIdentityByAnarlogHumanID(ctx context.Context, anarlogHumanID string) (*ExternalIdentity, error) {
+	row := q.db.QueryRow(ctx, FindIdentityByAnarlogHumanID, anarlogHumanID)
+	var i ExternalIdentity
+	err := row.Scan(
+		&i.ID,
+		&i.Identifier,
+		&i.IdentifierType,
+		&i.RawIdentifier,
+		&i.Source,
+		&i.SourceID,
+		&i.ContactID,
+		&i.MatchType,
+		&i.MatchConfidence,
+		&i.DisplayName,
+		&i.LastSeenAt,
+		&i.MessageCount,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return &i, err
 }
 
 const GetIdentityByID = `-- name: GetIdentityByID :one

--- a/backend/internal/db/interaction.sql.go
+++ b/backend/internal/db/interaction.sql.go
@@ -464,9 +464,10 @@ ORDER BY source_ref
 `
 
 // Returns all live interactions attributed to a specific anarlog session
-// (both Step 4 orphan-with-tags and Step 5 walk-in supplemental). Used by
-// the re-sync diff path in the meeting_note.recorded inline handler to
-// compute the (existing - desired) set that needs soft-deleting.
+// (both impromptu / orphan-with-tags entries and walk-in supplementals).
+// Used by the re-sync diff path in the meeting_note.recorded inline
+// handler to compute the (existing - desired) set that needs
+// soft-deleting.
 func (q *Queries) ListSessionAttributedInteractions(ctx context.Context, sourceRefPrefix pgtype.Text) ([]*Interaction, error) {
 	rows, err := q.db.Query(ctx, ListSessionAttributedInteractions, sourceRefPrefix)
 	if err != nil {

--- a/backend/internal/db/interaction.sql.go
+++ b/backend/internal/db/interaction.sql.go
@@ -455,6 +455,48 @@ func (q *Queries) ListContactInteractions(ctx context.Context, arg ListContactIn
 	return items, nil
 }
 
+const ListSessionAttributedInteractions = `-- name: ListSessionAttributedInteractions :many
+SELECT id, contact_id, source, source_ref, occurred_at, description, created_at, deleted_at, direction FROM interaction
+WHERE source = 'anarlog_sessions'
+  AND source_ref LIKE $1
+  AND deleted_at IS NULL
+ORDER BY source_ref
+`
+
+// Returns all live interactions attributed to a specific anarlog session
+// (both Step 4 orphan-with-tags and Step 5 walk-in supplemental). Used by
+// the re-sync diff path in the meeting_note.recorded inline handler to
+// compute the (existing - desired) set that needs soft-deleting.
+func (q *Queries) ListSessionAttributedInteractions(ctx context.Context, sourceRefPrefix pgtype.Text) ([]*Interaction, error) {
+	rows, err := q.db.Query(ctx, ListSessionAttributedInteractions, sourceRefPrefix)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []*Interaction{}
+	for rows.Next() {
+		var i Interaction
+		if err := rows.Scan(
+			&i.ID,
+			&i.ContactID,
+			&i.Source,
+			&i.SourceRef,
+			&i.OccurredAt,
+			&i.Description,
+			&i.CreatedAt,
+			&i.DeletedAt,
+			&i.Direction,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const SoftDeleteInteraction = `-- name: SoftDeleteInteraction :exec
 UPDATE interaction SET deleted_at = NOW()
 WHERE id = $1 AND deleted_at IS NULL

--- a/backend/internal/db/meeting_note.sql.go
+++ b/backend/internal/db/meeting_note.sql.go
@@ -52,9 +52,8 @@ FOR UPDATE
 // Tombstone-aware lookup that holds a row-level lock for the duration of
 // the caller's tx. Used by the meeting_note.recorded inline handler so a
 // concurrent re-sync for the same session UUID serializes behind the
-// first writer (see service/ingest.go handleMeetingNoteRecorded step 2).
-// Returns tombstoned rows too — the revive path inspects DeletedAt to
-// decide between revive and re-link branches.
+// first writer. Returns tombstoned rows too — the revive path inspects
+// DeletedAt to decide between revive and re-link branches.
 func (q *Queries) GetMeetingNoteBySessionIDForUpdate(ctx context.Context, anarlogSessionID pgtype.UUID) (*MeetingNote, error) {
 	row := q.db.QueryRow(ctx, GetMeetingNoteBySessionIDForUpdate, anarlogSessionID)
 	var i MeetingNote

--- a/backend/internal/db/meeting_note.sql.go
+++ b/backend/internal/db/meeting_note.sql.go
@@ -147,6 +147,7 @@ INSERT INTO meeting_note (
     $12,
     $13
 )
+ON CONFLICT (anarlog_session_id) WHERE deleted_at IS NULL DO NOTHING
 RETURNING id, anarlog_session_id, title, summary, memo, participants, mac_host_id, linked_kind, linked_id, linkage_state, deleted_at, created_at, input_hash, resolved_set_hash, last_content_hash, meeting_at
 `
 
@@ -173,6 +174,14 @@ type InsertMeetingNoteParams struct {
 // no DB-level default exists. input_hash / resolved_set_hash /
 // last_content_hash / meeting_at are supplied verbatim per the re-sync
 // diff algorithm (see service/ingest.go handleMeetingNoteRecorded).
+//
+// ON CONFLICT DO NOTHING handles the concurrent first-insert race against
+// the partial unique index idx_meeting_note_session_id WHERE deleted_at IS
+// NULL. When two concurrent batches try to first-insert the same session
+// UUID, one wins and the other receives zero rows back; the caller then
+// re-reads with FOR UPDATE and falls through to the update path. sqlc :one
+// returns ErrNoRows in that case, which the repository translates to
+// db.ErrNotFound.
 func (q *Queries) InsertMeetingNote(ctx context.Context, arg InsertMeetingNoteParams) (*MeetingNote, error) {
 	row := q.db.QueryRow(ctx, InsertMeetingNote,
 		arg.AnarlogSessionID,
@@ -283,9 +292,8 @@ type ReviveMeetingNoteParams struct {
 
 // Clears deleted_at + writes the full updatable column set in a single
 // statement so a tombstoned row that re-receives meeting_note.recorded
-// comes back live with the new content (round-1 P0#1 delete-revive
-// semantics). Defensive WHERE deleted_at IS NOT NULL keeps it idempotent
-// across concurrent revive races.
+// comes back live with the new content. Defensive WHERE deleted_at IS
+// NOT NULL keeps it idempotent across concurrent revive races.
 func (q *Queries) ReviveMeetingNote(ctx context.Context, arg ReviveMeetingNoteParams) (*MeetingNote, error) {
 	row := q.db.QueryRow(ctx, ReviveMeetingNote,
 		arg.Title,
@@ -334,6 +342,20 @@ WHERE anarlog_session_id = $1 AND deleted_at IS NULL
 // live row exists).
 func (q *Queries) SoftDeleteMeetingNoteBySessionID(ctx context.Context, anarlogSessionID pgtype.UUID) error {
 	_, err := q.db.Exec(ctx, SoftDeleteMeetingNoteBySessionID, anarlogSessionID)
+	return err
+}
+
+const TestHardDeleteMeetingNotesByHostID = `-- name: TestHardDeleteMeetingNotesByHostID :exec
+DELETE FROM meeting_note
+WHERE mac_host_id = $1
+`
+
+// TEST ONLY. Hard-deletes every meeting_note row owned by the given
+// mac_host. Used by t.Cleanup when the test seeds meeting_notes with
+// system-generated UUIDs (no exploitable prefix). Covers both live and
+// tombstoned rows.
+func (q *Queries) TestHardDeleteMeetingNotesByHostID(ctx context.Context, macHostID pgtype.UUID) error {
+	_, err := q.db.Exec(ctx, TestHardDeleteMeetingNotesByHostID, macHostID)
 	return err
 }
 

--- a/backend/internal/db/meeting_note.sql.go
+++ b/backend/internal/db/meeting_note.sql.go
@@ -12,7 +12,7 @@ import (
 )
 
 const GetMeetingNoteBySessionID = `-- name: GetMeetingNoteBySessionID :one
-SELECT id, anarlog_session_id, title, summary, memo, participants, mac_host_id, linked_kind, linked_id, linkage_state, deleted_at, created_at FROM meeting_note
+SELECT id, anarlog_session_id, title, summary, memo, participants, mac_host_id, linked_kind, linked_id, linkage_state, deleted_at, created_at, input_hash, resolved_set_hash, last_content_hash, meeting_at FROM meeting_note
 WHERE anarlog_session_id = $1
   AND deleted_at IS NULL
 `
@@ -35,6 +35,83 @@ func (q *Queries) GetMeetingNoteBySessionID(ctx context.Context, anarlogSessionI
 		&i.LinkageState,
 		&i.DeletedAt,
 		&i.CreatedAt,
+		&i.InputHash,
+		&i.ResolvedSetHash,
+		&i.LastContentHash,
+		&i.MeetingAt,
+	)
+	return &i, err
+}
+
+const GetMeetingNoteBySessionIDForUpdate = `-- name: GetMeetingNoteBySessionIDForUpdate :one
+SELECT id, anarlog_session_id, title, summary, memo, participants, mac_host_id, linked_kind, linked_id, linkage_state, deleted_at, created_at, input_hash, resolved_set_hash, last_content_hash, meeting_at FROM meeting_note
+WHERE anarlog_session_id = $1
+FOR UPDATE
+`
+
+// Tombstone-aware lookup that holds a row-level lock for the duration of
+// the caller's tx. Used by the meeting_note.recorded inline handler so a
+// concurrent re-sync for the same session UUID serializes behind the
+// first writer (see service/ingest.go handleMeetingNoteRecorded step 2).
+// Returns tombstoned rows too — the revive path inspects DeletedAt to
+// decide between revive and re-link branches.
+func (q *Queries) GetMeetingNoteBySessionIDForUpdate(ctx context.Context, anarlogSessionID pgtype.UUID) (*MeetingNote, error) {
+	row := q.db.QueryRow(ctx, GetMeetingNoteBySessionIDForUpdate, anarlogSessionID)
+	var i MeetingNote
+	err := row.Scan(
+		&i.ID,
+		&i.AnarlogSessionID,
+		&i.Title,
+		&i.Summary,
+		&i.Memo,
+		&i.Participants,
+		&i.MacHostID,
+		&i.LinkedKind,
+		&i.LinkedID,
+		&i.LinkageState,
+		&i.DeletedAt,
+		&i.CreatedAt,
+		&i.InputHash,
+		&i.ResolvedSetHash,
+		&i.LastContentHash,
+		&i.MeetingAt,
+	)
+	return &i, err
+}
+
+const GetTombstonedMeetingNoteBySessionID = `-- name: GetTombstonedMeetingNoteBySessionID :one
+SELECT id, anarlog_session_id, title, summary, memo, participants, mac_host_id, linked_kind, linked_id, linkage_state, deleted_at, created_at, input_hash, resolved_set_hash, last_content_hash, meeting_at FROM meeting_note
+WHERE anarlog_session_id = $1
+  AND deleted_at IS NOT NULL
+LIMIT 1
+`
+
+// Probe used by the dispatch loop's revive-bypass: when a duplicate
+// meeting_note.recorded event arrives (same source_id, content unchanged)
+// and a tombstoned row exists, the inline handler still runs so it can
+// revive instead of silently leaving the row tombstoned. Filters
+// explicitly to tombstoned rows because the live partial-unique index
+// already covers the live-row case.
+func (q *Queries) GetTombstonedMeetingNoteBySessionID(ctx context.Context, anarlogSessionID pgtype.UUID) (*MeetingNote, error) {
+	row := q.db.QueryRow(ctx, GetTombstonedMeetingNoteBySessionID, anarlogSessionID)
+	var i MeetingNote
+	err := row.Scan(
+		&i.ID,
+		&i.AnarlogSessionID,
+		&i.Title,
+		&i.Summary,
+		&i.Memo,
+		&i.Participants,
+		&i.MacHostID,
+		&i.LinkedKind,
+		&i.LinkedID,
+		&i.LinkageState,
+		&i.DeletedAt,
+		&i.CreatedAt,
+		&i.InputHash,
+		&i.ResolvedSetHash,
+		&i.LastContentHash,
+		&i.MeetingAt,
 	)
 	return &i, err
 }
@@ -50,7 +127,11 @@ INSERT INTO meeting_note (
     mac_host_id,
     linked_kind,
     linked_id,
-    linkage_state
+    linkage_state,
+    input_hash,
+    resolved_set_hash,
+    last_content_hash,
+    meeting_at
 ) VALUES (
     $1,
     $2,
@@ -60,28 +141,38 @@ INSERT INTO meeting_note (
     $6,
     $7,
     $8,
-    $9
+    $9,
+    $10,
+    $11,
+    $12,
+    $13
 )
-RETURNING id, anarlog_session_id, title, summary, memo, participants, mac_host_id, linked_kind, linked_id, linkage_state, deleted_at, created_at
+RETURNING id, anarlog_session_id, title, summary, memo, participants, mac_host_id, linked_kind, linked_id, linkage_state, deleted_at, created_at, input_hash, resolved_set_hash, last_content_hash, meeting_at
 `
 
 type InsertMeetingNoteParams struct {
-	AnarlogSessionID pgtype.UUID `json:"anarlog_session_id"`
-	Title            pgtype.Text `json:"title"`
-	Summary          pgtype.Text `json:"summary"`
-	Memo             pgtype.Text `json:"memo"`
-	Participants     []byte      `json:"participants"`
-	MacHostID        pgtype.UUID `json:"mac_host_id"`
-	LinkedKind       pgtype.Text `json:"linked_kind"`
-	LinkedID         pgtype.UUID `json:"linked_id"`
-	LinkageState     string      `json:"linkage_state"`
+	AnarlogSessionID pgtype.UUID        `json:"anarlog_session_id"`
+	Title            pgtype.Text        `json:"title"`
+	Summary          pgtype.Text        `json:"summary"`
+	Memo             pgtype.Text        `json:"memo"`
+	Participants     []byte             `json:"participants"`
+	MacHostID        pgtype.UUID        `json:"mac_host_id"`
+	LinkedKind       pgtype.Text        `json:"linked_kind"`
+	LinkedID         pgtype.UUID        `json:"linked_id"`
+	LinkageState     string             `json:"linkage_state"`
+	InputHash        string             `json:"input_hash"`
+	ResolvedSetHash  string             `json:"resolved_set_hash"`
+	LastContentHash  pgtype.Text        `json:"last_content_hash"`
+	MeetingAt        pgtype.Timestamptz `json:"meeting_at"`
 }
 
 // Meeting Note queries
 // Spec: .ai/spec/mac-daemon-phase-2-anarlog-matching.md
 // Inserts a meeting_note staging row. linkage_state must be supplied by the
 // caller (the ingest tx computes it from the linkage detection algorithm);
-// no DB-level default exists.
+// no DB-level default exists. input_hash / resolved_set_hash /
+// last_content_hash / meeting_at are supplied verbatim per the re-sync
+// diff algorithm (see service/ingest.go handleMeetingNoteRecorded).
 func (q *Queries) InsertMeetingNote(ctx context.Context, arg InsertMeetingNoteParams) (*MeetingNote, error) {
 	row := q.db.QueryRow(ctx, InsertMeetingNote,
 		arg.AnarlogSessionID,
@@ -93,6 +184,10 @@ func (q *Queries) InsertMeetingNote(ctx context.Context, arg InsertMeetingNotePa
 		arg.LinkedKind,
 		arg.LinkedID,
 		arg.LinkageState,
+		arg.InputHash,
+		arg.ResolvedSetHash,
+		arg.LastContentHash,
+		arg.MeetingAt,
 	)
 	var i MeetingNote
 	err := row.Scan(
@@ -108,6 +203,225 @@ func (q *Queries) InsertMeetingNote(ctx context.Context, arg InsertMeetingNotePa
 		&i.LinkageState,
 		&i.DeletedAt,
 		&i.CreatedAt,
+		&i.InputHash,
+		&i.ResolvedSetHash,
+		&i.LastContentHash,
+		&i.MeetingAt,
+	)
+	return &i, err
+}
+
+const ListKnownMeetingNoteIDsByHost = `-- name: ListKnownMeetingNoteIDsByHost :many
+SELECT anarlog_session_id::text AS source_id, last_content_hash
+FROM meeting_note
+WHERE mac_host_id = $1 AND deleted_at IS NULL
+ORDER BY source_id
+`
+
+type ListKnownMeetingNoteIDsByHostRow struct {
+	SourceID        string      `json:"source_id"`
+	LastContentHash pgtype.Text `json:"last_content_hash"`
+}
+
+// Returns (source_id, last_content_hash) for every live meeting_note
+// row owned by the given mac_host. Powers GET
+// /api/v1/host/:id/sync/anarlog_sessions/known-ids. Tombstoned rows are
+// excluded — the daemon's set-diff reconciliation requires that rows
+// the Pi has soft-deleted are NOT reported as known.
+func (q *Queries) ListKnownMeetingNoteIDsByHost(ctx context.Context, macHostID pgtype.UUID) ([]*ListKnownMeetingNoteIDsByHostRow, error) {
+	rows, err := q.db.Query(ctx, ListKnownMeetingNoteIDsByHost, macHostID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []*ListKnownMeetingNoteIDsByHostRow{}
+	for rows.Next() {
+		var i ListKnownMeetingNoteIDsByHostRow
+		if err := rows.Scan(&i.SourceID, &i.LastContentHash); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const ReviveMeetingNote = `-- name: ReviveMeetingNote :one
+UPDATE meeting_note SET
+    deleted_at        = NULL,
+    title             = $1,
+    summary           = $2,
+    memo              = $3,
+    participants      = $4,
+    linked_kind       = $5,
+    linked_id         = $6,
+    linkage_state     = $7,
+    input_hash        = $8,
+    resolved_set_hash = $9,
+    last_content_hash = $10,
+    meeting_at        = $11
+WHERE id = $12 AND deleted_at IS NOT NULL
+RETURNING id, anarlog_session_id, title, summary, memo, participants, mac_host_id, linked_kind, linked_id, linkage_state, deleted_at, created_at, input_hash, resolved_set_hash, last_content_hash, meeting_at
+`
+
+type ReviveMeetingNoteParams struct {
+	Title           pgtype.Text        `json:"title"`
+	Summary         pgtype.Text        `json:"summary"`
+	Memo            pgtype.Text        `json:"memo"`
+	Participants    []byte             `json:"participants"`
+	LinkedKind      pgtype.Text        `json:"linked_kind"`
+	LinkedID        pgtype.UUID        `json:"linked_id"`
+	LinkageState    string             `json:"linkage_state"`
+	InputHash       string             `json:"input_hash"`
+	ResolvedSetHash string             `json:"resolved_set_hash"`
+	LastContentHash pgtype.Text        `json:"last_content_hash"`
+	MeetingAt       pgtype.Timestamptz `json:"meeting_at"`
+	ID              pgtype.UUID        `json:"id"`
+}
+
+// Clears deleted_at + writes the full updatable column set in a single
+// statement so a tombstoned row that re-receives meeting_note.recorded
+// comes back live with the new content (round-1 P0#1 delete-revive
+// semantics). Defensive WHERE deleted_at IS NOT NULL keeps it idempotent
+// across concurrent revive races.
+func (q *Queries) ReviveMeetingNote(ctx context.Context, arg ReviveMeetingNoteParams) (*MeetingNote, error) {
+	row := q.db.QueryRow(ctx, ReviveMeetingNote,
+		arg.Title,
+		arg.Summary,
+		arg.Memo,
+		arg.Participants,
+		arg.LinkedKind,
+		arg.LinkedID,
+		arg.LinkageState,
+		arg.InputHash,
+		arg.ResolvedSetHash,
+		arg.LastContentHash,
+		arg.MeetingAt,
+		arg.ID,
+	)
+	var i MeetingNote
+	err := row.Scan(
+		&i.ID,
+		&i.AnarlogSessionID,
+		&i.Title,
+		&i.Summary,
+		&i.Memo,
+		&i.Participants,
+		&i.MacHostID,
+		&i.LinkedKind,
+		&i.LinkedID,
+		&i.LinkageState,
+		&i.DeletedAt,
+		&i.CreatedAt,
+		&i.InputHash,
+		&i.ResolvedSetHash,
+		&i.LastContentHash,
+		&i.MeetingAt,
+	)
+	return &i, err
+}
+
+const SoftDeleteMeetingNoteBySessionID = `-- name: SoftDeleteMeetingNoteBySessionID :exec
+UPDATE meeting_note SET deleted_at = NOW()
+WHERE anarlog_session_id = $1 AND deleted_at IS NULL
+`
+
+// Tombstones the live row for a session UUID. last_content_hash,
+// input_hash, meeting_at are preserved on the row so a future revive
+// has the prior content snapshot available. Idempotent (no-op when no
+// live row exists).
+func (q *Queries) SoftDeleteMeetingNoteBySessionID(ctx context.Context, anarlogSessionID pgtype.UUID) error {
+	_, err := q.db.Exec(ctx, SoftDeleteMeetingNoteBySessionID, anarlogSessionID)
+	return err
+}
+
+const TestHardDeleteMeetingNotesBySessionIDPrefix = `-- name: TestHardDeleteMeetingNotesBySessionIDPrefix :exec
+DELETE FROM meeting_note
+WHERE anarlog_session_id::text LIKE $1::text
+`
+
+// TEST ONLY. Hard-deletes meeting_note rows whose session UUID (as text)
+// starts with the given prefix. Used by t.Cleanup to remove fixtures
+// inserted by a test. Covers both live and tombstoned rows.
+func (q *Queries) TestHardDeleteMeetingNotesBySessionIDPrefix(ctx context.Context, sessionIDPrefix string) error {
+	_, err := q.db.Exec(ctx, TestHardDeleteMeetingNotesBySessionIDPrefix, sessionIDPrefix)
+	return err
+}
+
+const UpdateMeetingNoteOnResync = `-- name: UpdateMeetingNoteOnResync :one
+UPDATE meeting_note SET
+    title             = $1,
+    summary           = $2,
+    memo              = $3,
+    participants      = $4,
+    linked_kind       = $5,
+    linked_id         = $6,
+    linkage_state     = $7,
+    input_hash        = $8,
+    resolved_set_hash = $9,
+    last_content_hash = $10,
+    meeting_at        = $11
+WHERE id = $12 AND deleted_at IS NULL
+RETURNING id, anarlog_session_id, title, summary, memo, participants, mac_host_id, linked_kind, linked_id, linkage_state, deleted_at, created_at, input_hash, resolved_set_hash, last_content_hash, meeting_at
+`
+
+type UpdateMeetingNoteOnResyncParams struct {
+	Title           pgtype.Text        `json:"title"`
+	Summary         pgtype.Text        `json:"summary"`
+	Memo            pgtype.Text        `json:"memo"`
+	Participants    []byte             `json:"participants"`
+	LinkedKind      pgtype.Text        `json:"linked_kind"`
+	LinkedID        pgtype.UUID        `json:"linked_id"`
+	LinkageState    string             `json:"linkage_state"`
+	InputHash       string             `json:"input_hash"`
+	ResolvedSetHash string             `json:"resolved_set_hash"`
+	LastContentHash pgtype.Text        `json:"last_content_hash"`
+	MeetingAt       pgtype.Timestamptz `json:"meeting_at"`
+	ID              pgtype.UUID        `json:"id"`
+}
+
+// Single update query used for both carry-forward and re-link branches
+// of the re-sync algorithm. Caller controls the values: carry-forward
+// passes the prior linkage values, re-link passes the recomputed values.
+// Avoids two near-identical queries.
+//
+// The deleted_at filter prevents stomping on a tombstoned row (revive
+// runs its own UPDATE path that also clears deleted_at).
+func (q *Queries) UpdateMeetingNoteOnResync(ctx context.Context, arg UpdateMeetingNoteOnResyncParams) (*MeetingNote, error) {
+	row := q.db.QueryRow(ctx, UpdateMeetingNoteOnResync,
+		arg.Title,
+		arg.Summary,
+		arg.Memo,
+		arg.Participants,
+		arg.LinkedKind,
+		arg.LinkedID,
+		arg.LinkageState,
+		arg.InputHash,
+		arg.ResolvedSetHash,
+		arg.LastContentHash,
+		arg.MeetingAt,
+		arg.ID,
+	)
+	var i MeetingNote
+	err := row.Scan(
+		&i.ID,
+		&i.AnarlogSessionID,
+		&i.Title,
+		&i.Summary,
+		&i.Memo,
+		&i.Participants,
+		&i.MacHostID,
+		&i.LinkedKind,
+		&i.LinkedID,
+		&i.LinkageState,
+		&i.DeletedAt,
+		&i.CreatedAt,
+		&i.InputHash,
+		&i.ResolvedSetHash,
+		&i.LastContentHash,
+		&i.MeetingAt,
 	)
 	return &i, err
 }

--- a/backend/internal/db/models.go
+++ b/backend/internal/db/models.go
@@ -305,6 +305,14 @@ type MeetingNote struct {
 	LinkageState     string             `json:"linkage_state"`
 	DeletedAt        pgtype.Timestamptz `json:"deleted_at"`
 	CreatedAt        pgtype.Timestamptz `json:"created_at"`
+	// SHA-256(JCS({meeting_at, title, sorted(participant_ids)})). Used to detect when matching inputs change on re-sync.
+	InputHash string `json:"input_hash"`
+	// SHA-256(JCS(sorted(resolved_contact_uuids))). Used to detect when tagged-participant->contact resolution changes (e.g., after a user import), even when input_hash is unchanged.
+	ResolvedSetHash string `json:"resolved_set_hash"`
+	// Lowercase-hex SHA-256 of JCS-canonicalized payload (minus host_id) from the most recent meeting_note.recorded event. Powers GET /sync/anarlog_sessions/known-ids. NULL for legacy rows; daemon falls back to @deleted@unknown sentinel per spec.
+	LastContentHash pgtype.Text `json:"last_content_hash"`
+	// Session start time from the daemon payload meeting_at. Drives linkage window math, /imports conflict UI, and the input_hash recipe.
+	MeetingAt pgtype.Timestamptz `json:"meeting_at"`
 }
 
 type MessagesMessage struct {

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -577,6 +577,14 @@ type Querier interface {
 	// no DB-level default exists. input_hash / resolved_set_hash /
 	// last_content_hash / meeting_at are supplied verbatim per the re-sync
 	// diff algorithm (see service/ingest.go handleMeetingNoteRecorded).
+	//
+	// ON CONFLICT DO NOTHING handles the concurrent first-insert race against
+	// the partial unique index idx_meeting_note_session_id WHERE deleted_at IS
+	// NULL. When two concurrent batches try to first-insert the same session
+	// UUID, one wins and the other receives zero rows back; the caller then
+	// re-reads with FOR UPDATE and falls through to the update path. sqlc :one
+	// returns ErrNoRows in that case, which the repository translates to
+	// db.ErrNotFound.
 	InsertMeetingNote(ctx context.Context, arg InsertMeetingNoteParams) (*MeetingNote, error)
 	LinkIdentityToContact(ctx context.Context, arg LinkIdentityToContactParams) (*ExternalIdentity, error)
 	ListActiveMacHosts(ctx context.Context) ([]*MacHost, error)
@@ -775,9 +783,8 @@ type Querier interface {
 	ReviveExternalContact(ctx context.Context, id pgtype.UUID) (*ExternalContact, error)
 	// Clears deleted_at + writes the full updatable column set in a single
 	// statement so a tombstoned row that re-receives meeting_note.recorded
-	// comes back live with the new content (round-1 P0#1 delete-revive
-	// semantics). Defensive WHERE deleted_at IS NOT NULL keeps it idempotent
-	// across concurrent revive races.
+	// comes back live with the new content. Defensive WHERE deleted_at IS
+	// NOT NULL keeps it idempotent across concurrent revive races.
 	ReviveMeetingNote(ctx context.Context, arg ReviveMeetingNoteParams) (*MeetingNote, error)
 	RevokeMacHost(ctx context.Context, id pgtype.UUID) (*MacHost, error)
 	// Lightweight query returning only IDs with search for navigation
@@ -845,6 +852,11 @@ type Querier interface {
 	// TEST ONLY. Hard-deletes external_contact rows whose source_id starts with
 	// the given prefix. Used by t.Cleanup to remove fixtures inserted by a test.
 	TestDeleteExternalContactsBySourceIDPrefix(ctx context.Context, prefix string) error
+	// TEST ONLY. Hard-deletes every meeting_note row owned by the given
+	// mac_host. Used by t.Cleanup when the test seeds meeting_notes with
+	// system-generated UUIDs (no exploitable prefix). Covers both live and
+	// tombstoned rows.
+	TestHardDeleteMeetingNotesByHostID(ctx context.Context, macHostID pgtype.UUID) error
 	// TEST ONLY. Hard-deletes meeting_note rows whose session UUID (as text)
 	// starts with the given prefix. Used by t.Cleanup to remove fixtures
 	// inserted by a test. Covers both live and tombstoned rows.

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -260,6 +260,13 @@ type Querier interface {
 	// read-only operator diagnostics; the production dedupe path uses
 	// InsertEventConsumerClaim's rows-inserted signal instead of polling.
 	ExistsEventConsumerClaim(ctx context.Context, arg ExistsEventConsumerClaimParams) (bool, error)
+	// Returns candidate calendar_event rows for the meeting_note.recorded
+	// linkage-detection algorithm. Filters out cancelled events. Backed by
+	// idx_calendar_event_start (partial index on start_time WHERE
+	// status != 'cancelled' — already exists from migration 016). The
+	// output includes matched_contact_ids so the linkage handler can
+	// compute walk-in supplementals (Step 5).
+	FindCalendarEventsInWindow(ctx context.Context, arg FindCalendarEventsInWindowParams) ([]*CalendarEvent, error)
 	// peer_phone is stored raw from MTProto (typically digits only); contact_method
 	// value_normalized is E.164 with leading '+'. Compare on digits-only.
 	// Same DISTINCT ON ordering as the username variant — prefer rows with a
@@ -303,7 +310,22 @@ type Querier interface {
 	// gcal_attendee import candidates as matched after a CRM contact links them.
 	// Tombstoned candidates must not be rematched.
 	FindExternalContactsBySourceAndSourceID(ctx context.Context, arg FindExternalContactsBySourceAndSourceIDParams) ([]*ExternalContact, error)
+	// Used by the Import handler's anarlog backfill — when a user imports
+	// an anarlog_humans external_contact, the associated anarlog_human_id
+	// identity row's contact_id is linked to the imported CRM contact. The
+	// (identifier, identifier_type, source) triple is unique so this
+	// normally returns a 0- or 1-row slice; the list shape matches
+	// FindIdentitiesByIdentifier for consistency with the existing
+	// repository surface.
+	FindIdentitiesByAnarlogHumanID(ctx context.Context, anarlogHumanID string) ([]*ExternalIdentity, error)
 	FindIdentitiesByIdentifier(ctx context.Context, arg FindIdentitiesByIdentifierParams) ([]*ExternalIdentity, error)
+	// Lookup hook used by the meeting_note.recorded inline handler to
+	// resolve a payload's participant_ids (anarlog UUIDs) into CRM
+	// contact_ids. The (identifier, identifier_type, source) triple is
+	// unique, so this returns at most one row. The identifier_type is
+	// pinned to 'anarlog_human_id' and the source to 'anarlog_humans'
+	// (the only writer of these rows).
+	FindIdentityByAnarlogHumanID(ctx context.Context, anarlogHumanID string) (*ExternalIdentity, error)
 	// Find an existing interaction by contact, source, and source_ref (for deduplication)
 	FindInteractionBySourceRef(ctx context.Context, arg FindInteractionBySourceRefParams) (*Interaction, error)
 	// Find an existing manual interaction within a time window for a given
@@ -434,6 +456,13 @@ type Querier interface {
 	// Returns the live (non-soft-deleted) meeting_note row for a given anarlog
 	// session UUID. Used by the ingest path for dedup and re-sync detection.
 	GetMeetingNoteBySessionID(ctx context.Context, anarlogSessionID pgtype.UUID) (*MeetingNote, error)
+	// Tombstone-aware lookup that holds a row-level lock for the duration of
+	// the caller's tx. Used by the meeting_note.recorded inline handler so a
+	// concurrent re-sync for the same session UUID serializes behind the
+	// first writer (see service/ingest.go handleMeetingNoteRecorded step 2).
+	// Returns tombstoned rows too — the revive path inspects DeletedAt to
+	// decide between revive and re-link branches.
+	GetMeetingNoteBySessionIDForUpdate(ctx context.Context, anarlogSessionID pgtype.UUID) (*MeetingNote, error)
 	// Lookup by guid (primary external identifier). Used by reply-target
 	// resolution.
 	GetMessagesMessage(ctx context.Context, guid string) (*MessagesMessage, error)
@@ -479,6 +508,13 @@ type Querier interface {
 	GetTelegramMessage(ctx context.Context, arg GetTelegramMessageParams) (*TelegramMessage, error)
 	GetTelegramSession(ctx context.Context) (*TelegramSession, error)
 	GetTelegramUpdateState(ctx context.Context, userID int64) (*TelegramUpdateState, error)
+	// Probe used by the dispatch loop's revive-bypass: when a duplicate
+	// meeting_note.recorded event arrives (same source_id, content unchanged)
+	// and a tombstoned row exists, the inline handler still runs so it can
+	// revive instead of silently leaving the row tombstoned. Filters
+	// explicitly to tombstoned rows because the live partial-unique index
+	// already covers the live-row case.
+	GetTombstonedMeetingNoteBySessionID(ctx context.Context, anarlogSessionID pgtype.UUID) (*MeetingNote, error)
 	HardDeleteContact(ctx context.Context, id pgtype.UUID) error
 	// Test-only: hard-deletes event rows whose (source, source_id) match the
 	// given source and a LIKE-prefix on source_id. Used by integration tests
@@ -538,7 +574,9 @@ type Querier interface {
 	// Spec: .ai/spec/mac-daemon-phase-2-anarlog-matching.md
 	// Inserts a meeting_note staging row. linkage_state must be supplied by the
 	// caller (the ingest tx computes it from the linkage detection algorithm);
-	// no DB-level default exists.
+	// no DB-level default exists. input_hash / resolved_set_hash /
+	// last_content_hash / meeting_at are supplied verbatim per the re-sync
+	// diff algorithm (see service/ingest.go handleMeetingNoteRecorded).
 	InsertMeetingNote(ctx context.Context, arg InsertMeetingNoteParams) (*MeetingNote, error)
 	LinkIdentityToContact(ctx context.Context, arg LinkIdentityToContactParams) (*ExternalIdentity, error)
 	ListActiveMacHosts(ctx context.Context) ([]*MacHost, error)
@@ -613,6 +651,12 @@ type Querier interface {
 	// last_content_hash is NULL cause the daemon to fall back to the
 	// @deleted@unknown sentinel per the spec.
 	ListKnownExternalContactIDsByHostAndSource(ctx context.Context, arg ListKnownExternalContactIDsByHostAndSourceParams) ([]*ListKnownExternalContactIDsByHostAndSourceRow, error)
+	// Returns (source_id, last_content_hash) for every live meeting_note
+	// row owned by the given mac_host. Powers GET
+	// /api/v1/host/:id/sync/anarlog_sessions/known-ids. Tombstoned rows are
+	// excluded — the daemon's set-diff reconciliation requires that rows
+	// the Pi has soft-deleted are NOT reported as known.
+	ListKnownMeetingNoteIDsByHost(ctx context.Context, macHostID pgtype.UUID) ([]*ListKnownMeetingNoteIDsByHostRow, error)
 	ListMacHosts(ctx context.Context) ([]*MacHost, error)
 	// List all managed tasks for a provider (for reconciliation)
 	ListManagedContactTasks(ctx context.Context, provider string) ([]*ListManagedContactTasksRow, error)
@@ -626,6 +670,11 @@ type Querier interface {
 	// List past events that haven't updated last_contacted yet
 	ListPastEventsNeedingUpdate(ctx context.Context, arg ListPastEventsNeedingUpdateParams) ([]*CalendarEvent, error)
 	ListRecentSyncLogs(ctx context.Context, limit int32) ([]*ExternalSyncLog, error)
+	// Returns all live interactions attributed to a specific anarlog session
+	// (both Step 4 orphan-with-tags and Step 5 walk-in supplemental). Used by
+	// the re-sync diff path in the meeting_note.recorded inline handler to
+	// compute the (existing - desired) set that needs soft-deleting.
+	ListSessionAttributedInteractions(ctx context.Context, sourceRefPrefix pgtype.Text) ([]*Interaction, error)
 	// Lists rows with matched_contact_id IS NULL — i.e., rows that the
 	// ingest service accepted into staging but couldn't match to a contact
 	// at the time. The crm-admin --messages-rematch-stranded command
@@ -724,6 +773,12 @@ type Querier interface {
 	// NULL keeps the statement idempotent across concurrent revive races.
 	// Preserves crm_contact_id, match_status, and all content columns.
 	ReviveExternalContact(ctx context.Context, id pgtype.UUID) (*ExternalContact, error)
+	// Clears deleted_at + writes the full updatable column set in a single
+	// statement so a tombstoned row that re-receives meeting_note.recorded
+	// comes back live with the new content (round-1 P0#1 delete-revive
+	// semantics). Defensive WHERE deleted_at IS NOT NULL keeps it idempotent
+	// across concurrent revive races.
+	ReviveMeetingNote(ctx context.Context, arg ReviveMeetingNoteParams) (*MeetingNote, error)
 	RevokeMacHost(ctx context.Context, id pgtype.UUID) (*MacHost, error)
 	// Lightweight query returning only IDs with search for navigation
 	SearchContactIDs(ctx context.Context, arg SearchContactIDsParams) ([]pgtype.UUID, error)
@@ -777,6 +832,11 @@ type Querier interface {
 	// soft-delete contract.
 	SoftDeleteExternalContact(ctx context.Context, id pgtype.UUID) error
 	SoftDeleteInteraction(ctx context.Context, id pgtype.UUID) error
+	// Tombstones the live row for a session UUID. last_content_hash,
+	// input_hash, meeting_at are preserved on the row so a future revive
+	// has the prior content snapshot available. Idempotent (no-op when no
+	// live row exists).
+	SoftDeleteMeetingNoteBySessionID(ctx context.Context, anarlogSessionID pgtype.UUID) error
 	SoftDeleteTelegramChannelMessages(ctx context.Context, arg SoftDeleteTelegramChannelMessagesParams) error
 	SoftDeleteTelegramMessages(ctx context.Context, messageIds []int32) error
 	// TEST ONLY. Hard-deletes calendar_event rows whose gcal_event_id starts
@@ -785,6 +845,10 @@ type Querier interface {
 	// TEST ONLY. Hard-deletes external_contact rows whose source_id starts with
 	// the given prefix. Used by t.Cleanup to remove fixtures inserted by a test.
 	TestDeleteExternalContactsBySourceIDPrefix(ctx context.Context, prefix string) error
+	// TEST ONLY. Hard-deletes meeting_note rows whose session UUID (as text)
+	// starts with the given prefix. Used by t.Cleanup to remove fixtures
+	// inserted by a test. Covers both live and tombstoned rows.
+	TestHardDeleteMeetingNotesBySessionIDPrefix(ctx context.Context, sessionIDPrefix string) error
 	// TEST ONLY. Checks whether a named index exists. Used by the integration
 	// test as a structural guard that migration 045's GIN indexes are actually
 	// present (a behavior-only test would pass even if a future migration
@@ -914,6 +978,14 @@ type Querier interface {
 	UpdateMatchedContactForStrandedMessage(ctx context.Context, arg UpdateMatchedContactForStrandedMessageParams) error
 	// Update the matched contact IDs for an event
 	UpdateMatchedContacts(ctx context.Context, arg UpdateMatchedContactsParams) (*CalendarEvent, error)
+	// Single update query used for both carry-forward and re-link branches
+	// of the re-sync algorithm. Caller controls the values: carry-forward
+	// passes the prior linkage values, re-link passes the recomputed values.
+	// Avoids two near-identical queries.
+	//
+	// The deleted_at filter prevents stomping on a tombstoned row (revive
+	// runs its own UPDATE path that also clears deleted_at).
+	UpdateMeetingNoteOnResync(ctx context.Context, arg UpdateMeetingNoteOnResyncParams) (*MeetingNote, error)
 	UpdateNote(ctx context.Context, arg UpdateNoteParams) (*Note, error)
 	// Update only the token data (for token refresh)
 	UpdateOAuthCredentialTokens(ctx context.Context, arg UpdateOAuthCredentialTokensParams) (*OauthCredential, error)

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -265,7 +265,7 @@ type Querier interface {
 	// idx_calendar_event_start (partial index on start_time WHERE
 	// status != 'cancelled' — already exists from migration 016). The
 	// output includes matched_contact_ids so the linkage handler can
-	// compute walk-in supplementals (Step 5).
+	// compute walk-in supplementals.
 	FindCalendarEventsInWindow(ctx context.Context, arg FindCalendarEventsInWindowParams) ([]*CalendarEvent, error)
 	// peer_phone is stored raw from MTProto (typically digits only); contact_method
 	// value_normalized is E.164 with leading '+'. Compare on digits-only.
@@ -459,9 +459,8 @@ type Querier interface {
 	// Tombstone-aware lookup that holds a row-level lock for the duration of
 	// the caller's tx. Used by the meeting_note.recorded inline handler so a
 	// concurrent re-sync for the same session UUID serializes behind the
-	// first writer (see service/ingest.go handleMeetingNoteRecorded step 2).
-	// Returns tombstoned rows too — the revive path inspects DeletedAt to
-	// decide between revive and re-link branches.
+	// first writer. Returns tombstoned rows too — the revive path inspects
+	// DeletedAt to decide between revive and re-link branches.
 	GetMeetingNoteBySessionIDForUpdate(ctx context.Context, anarlogSessionID pgtype.UUID) (*MeetingNote, error)
 	// Lookup by guid (primary external identifier). Used by reply-target
 	// resolution.
@@ -679,9 +678,10 @@ type Querier interface {
 	ListPastEventsNeedingUpdate(ctx context.Context, arg ListPastEventsNeedingUpdateParams) ([]*CalendarEvent, error)
 	ListRecentSyncLogs(ctx context.Context, limit int32) ([]*ExternalSyncLog, error)
 	// Returns all live interactions attributed to a specific anarlog session
-	// (both Step 4 orphan-with-tags and Step 5 walk-in supplemental). Used by
-	// the re-sync diff path in the meeting_note.recorded inline handler to
-	// compute the (existing - desired) set that needs soft-deleting.
+	// (both impromptu / orphan-with-tags entries and walk-in supplementals).
+	// Used by the re-sync diff path in the meeting_note.recorded inline
+	// handler to compute the (existing - desired) set that needs
+	// soft-deleting.
 	ListSessionAttributedInteractions(ctx context.Context, sourceRefPrefix pgtype.Text) ([]*Interaction, error)
 	// Lists rows with matched_contact_id IS NULL — i.e., rows that the
 	// ingest service accepted into staging but couldn't match to a contact

--- a/backend/internal/db/queries/calendar_event.sql
+++ b/backend/internal/db/queries/calendar_event.sql
@@ -156,3 +156,15 @@ SET matched_contact_ids = array_append(matched_contact_ids, @contact_id::uuid),
     updated_at = NOW()
 WHERE id = @event_id::uuid
   AND NOT (@contact_id::uuid = ANY(matched_contact_ids));
+
+-- name: FindCalendarEventsInWindow :many
+-- Returns candidate calendar_event rows for the meeting_note.recorded
+-- linkage-detection algorithm. Filters out cancelled events. Backed by
+-- idx_calendar_event_start (partial index on start_time WHERE
+-- status != 'cancelled' — already exists from migration 016). The
+-- output includes matched_contact_ids so the linkage handler can
+-- compute walk-in supplementals (Step 5).
+SELECT * FROM calendar_event
+WHERE start_time BETWEEN sqlc.arg('window_start') AND sqlc.arg('window_end')
+  AND status != 'cancelled'
+ORDER BY start_time ASC;

--- a/backend/internal/db/queries/calendar_event.sql
+++ b/backend/internal/db/queries/calendar_event.sql
@@ -163,7 +163,7 @@ WHERE id = @event_id::uuid
 -- idx_calendar_event_start (partial index on start_time WHERE
 -- status != 'cancelled' — already exists from migration 016). The
 -- output includes matched_contact_ids so the linkage handler can
--- compute walk-in supplementals (Step 5).
+-- compute walk-in supplementals.
 SELECT * FROM calendar_event
 WHERE start_time BETWEEN sqlc.arg('window_start') AND sqlc.arg('window_end')
   AND status != 'cancelled'

--- a/backend/internal/db/queries/external_identity.sql
+++ b/backend/internal/db/queries/external_identity.sql
@@ -91,3 +91,28 @@ LIMIT $2 OFFSET $3;
 
 -- name: CountIdentitiesBySource :one
 SELECT COUNT(*) FROM external_identity WHERE source = $1;
+
+-- name: FindIdentityByAnarlogHumanID :one
+-- Lookup hook used by the meeting_note.recorded inline handler to
+-- resolve a payload's participant_ids (anarlog UUIDs) into CRM
+-- contact_ids. The (identifier, identifier_type, source) triple is
+-- unique, so this returns at most one row. The identifier_type is
+-- pinned to 'anarlog_human_id' and the source to 'anarlog_humans'
+-- (the only writer of these rows).
+SELECT * FROM external_identity
+WHERE identifier_type = 'anarlog_human_id'
+  AND source = 'anarlog_humans'
+  AND identifier = sqlc.arg('anarlog_human_id');
+
+-- name: FindIdentitiesByAnarlogHumanID :many
+-- Used by the Import handler's anarlog backfill — when a user imports
+-- an anarlog_humans external_contact, the associated anarlog_human_id
+-- identity row's contact_id is linked to the imported CRM contact. The
+-- (identifier, identifier_type, source) triple is unique so this
+-- normally returns a 0- or 1-row slice; the list shape matches
+-- FindIdentitiesByIdentifier for consistency with the existing
+-- repository surface.
+SELECT * FROM external_identity
+WHERE identifier_type = 'anarlog_human_id'
+  AND source = 'anarlog_humans'
+  AND identifier = sqlc.arg('anarlog_human_id');

--- a/backend/internal/db/queries/interaction.sql
+++ b/backend/internal/db/queries/interaction.sql
@@ -158,3 +158,14 @@ SELECT EXISTS (
       AND deleted_at IS NULL
     LIMIT 1
 ) AS has_response;
+
+-- name: ListSessionAttributedInteractions :many
+-- Returns all live interactions attributed to a specific anarlog session
+-- (both Step 4 orphan-with-tags and Step 5 walk-in supplemental). Used by
+-- the re-sync diff path in the meeting_note.recorded inline handler to
+-- compute the (existing - desired) set that needs soft-deleting.
+SELECT * FROM interaction
+WHERE source = 'anarlog_sessions'
+  AND source_ref LIKE sqlc.arg('source_ref_prefix')
+  AND deleted_at IS NULL
+ORDER BY source_ref;

--- a/backend/internal/db/queries/interaction.sql
+++ b/backend/internal/db/queries/interaction.sql
@@ -161,9 +161,10 @@ SELECT EXISTS (
 
 -- name: ListSessionAttributedInteractions :many
 -- Returns all live interactions attributed to a specific anarlog session
--- (both Step 4 orphan-with-tags and Step 5 walk-in supplemental). Used by
--- the re-sync diff path in the meeting_note.recorded inline handler to
--- compute the (existing - desired) set that needs soft-deleting.
+-- (both impromptu / orphan-with-tags entries and walk-in supplementals).
+-- Used by the re-sync diff path in the meeting_note.recorded inline
+-- handler to compute the (existing - desired) set that needs
+-- soft-deleting.
 SELECT * FROM interaction
 WHERE source = 'anarlog_sessions'
   AND source_ref LIKE sqlc.arg('source_ref_prefix')

--- a/backend/internal/db/queries/meeting_note.sql
+++ b/backend/internal/db/queries/meeting_note.sql
@@ -7,6 +7,14 @@
 -- no DB-level default exists. input_hash / resolved_set_hash /
 -- last_content_hash / meeting_at are supplied verbatim per the re-sync
 -- diff algorithm (see service/ingest.go handleMeetingNoteRecorded).
+--
+-- ON CONFLICT DO NOTHING handles the concurrent first-insert race against
+-- the partial unique index idx_meeting_note_session_id WHERE deleted_at IS
+-- NULL. When two concurrent batches try to first-insert the same session
+-- UUID, one wins and the other receives zero rows back; the caller then
+-- re-reads with FOR UPDATE and falls through to the update path. sqlc :one
+-- returns ErrNoRows in that case, which the repository translates to
+-- db.ErrNotFound.
 INSERT INTO meeting_note (
     anarlog_session_id,
     title,
@@ -36,6 +44,7 @@ INSERT INTO meeting_note (
     sqlc.arg('last_content_hash'),
     sqlc.arg('meeting_at')
 )
+ON CONFLICT (anarlog_session_id) WHERE deleted_at IS NULL DO NOTHING
 RETURNING *;
 
 -- name: GetMeetingNoteBySessionID :one
@@ -94,9 +103,8 @@ RETURNING *;
 -- name: ReviveMeetingNote :one
 -- Clears deleted_at + writes the full updatable column set in a single
 -- statement so a tombstoned row that re-receives meeting_note.recorded
--- comes back live with the new content (round-1 P0#1 delete-revive
--- semantics). Defensive WHERE deleted_at IS NOT NULL keeps it idempotent
--- across concurrent revive races.
+-- comes back live with the new content. Defensive WHERE deleted_at IS
+-- NOT NULL keeps it idempotent across concurrent revive races.
 UPDATE meeting_note SET
     deleted_at        = NULL,
     title             = sqlc.arg('title'),
@@ -138,3 +146,11 @@ ORDER BY source_id;
 -- inserted by a test. Covers both live and tombstoned rows.
 DELETE FROM meeting_note
 WHERE anarlog_session_id::text LIKE sqlc.arg('session_id_prefix')::text;
+
+-- name: TestHardDeleteMeetingNotesByHostID :exec
+-- TEST ONLY. Hard-deletes every meeting_note row owned by the given
+-- mac_host. Used by t.Cleanup when the test seeds meeting_notes with
+-- system-generated UUIDs (no exploitable prefix). Covers both live and
+-- tombstoned rows.
+DELETE FROM meeting_note
+WHERE mac_host_id = sqlc.arg('mac_host_id');

--- a/backend/internal/db/queries/meeting_note.sql
+++ b/backend/internal/db/queries/meeting_note.sql
@@ -4,7 +4,9 @@
 -- name: InsertMeetingNote :one
 -- Inserts a meeting_note staging row. linkage_state must be supplied by the
 -- caller (the ingest tx computes it from the linkage detection algorithm);
--- no DB-level default exists.
+-- no DB-level default exists. input_hash / resolved_set_hash /
+-- last_content_hash / meeting_at are supplied verbatim per the re-sync
+-- diff algorithm (see service/ingest.go handleMeetingNoteRecorded).
 INSERT INTO meeting_note (
     anarlog_session_id,
     title,
@@ -14,7 +16,11 @@ INSERT INTO meeting_note (
     mac_host_id,
     linked_kind,
     linked_id,
-    linkage_state
+    linkage_state,
+    input_hash,
+    resolved_set_hash,
+    last_content_hash,
+    meeting_at
 ) VALUES (
     sqlc.arg('anarlog_session_id'),
     sqlc.arg('title'),
@@ -24,7 +30,11 @@ INSERT INTO meeting_note (
     sqlc.arg('mac_host_id'),
     sqlc.arg('linked_kind'),
     sqlc.arg('linked_id'),
-    sqlc.arg('linkage_state')
+    sqlc.arg('linkage_state'),
+    sqlc.arg('input_hash'),
+    sqlc.arg('resolved_set_hash'),
+    sqlc.arg('last_content_hash'),
+    sqlc.arg('meeting_at')
 )
 RETURNING *;
 
@@ -34,3 +44,97 @@ RETURNING *;
 SELECT * FROM meeting_note
 WHERE anarlog_session_id = sqlc.arg('anarlog_session_id')
   AND deleted_at IS NULL;
+
+-- name: GetMeetingNoteBySessionIDForUpdate :one
+-- Tombstone-aware lookup that holds a row-level lock for the duration of
+-- the caller's tx. Used by the meeting_note.recorded inline handler so a
+-- concurrent re-sync for the same session UUID serializes behind the
+-- first writer (see service/ingest.go handleMeetingNoteRecorded step 2).
+-- Returns tombstoned rows too — the revive path inspects DeletedAt to
+-- decide between revive and re-link branches.
+SELECT * FROM meeting_note
+WHERE anarlog_session_id = sqlc.arg('anarlog_session_id')
+FOR UPDATE;
+
+-- name: GetTombstonedMeetingNoteBySessionID :one
+-- Probe used by the dispatch loop's revive-bypass: when a duplicate
+-- meeting_note.recorded event arrives (same source_id, content unchanged)
+-- and a tombstoned row exists, the inline handler still runs so it can
+-- revive instead of silently leaving the row tombstoned. Filters
+-- explicitly to tombstoned rows because the live partial-unique index
+-- already covers the live-row case.
+SELECT * FROM meeting_note
+WHERE anarlog_session_id = sqlc.arg('anarlog_session_id')
+  AND deleted_at IS NOT NULL
+LIMIT 1;
+
+-- name: UpdateMeetingNoteOnResync :one
+-- Single update query used for both carry-forward and re-link branches
+-- of the re-sync algorithm. Caller controls the values: carry-forward
+-- passes the prior linkage values, re-link passes the recomputed values.
+-- Avoids two near-identical queries.
+--
+-- The deleted_at filter prevents stomping on a tombstoned row (revive
+-- runs its own UPDATE path that also clears deleted_at).
+UPDATE meeting_note SET
+    title             = sqlc.arg('title'),
+    summary           = sqlc.arg('summary'),
+    memo              = sqlc.arg('memo'),
+    participants      = sqlc.arg('participants'),
+    linked_kind       = sqlc.arg('linked_kind'),
+    linked_id         = sqlc.arg('linked_id'),
+    linkage_state     = sqlc.arg('linkage_state'),
+    input_hash        = sqlc.arg('input_hash'),
+    resolved_set_hash = sqlc.arg('resolved_set_hash'),
+    last_content_hash = sqlc.arg('last_content_hash'),
+    meeting_at        = sqlc.arg('meeting_at')
+WHERE id = sqlc.arg('id') AND deleted_at IS NULL
+RETURNING *;
+
+-- name: ReviveMeetingNote :one
+-- Clears deleted_at + writes the full updatable column set in a single
+-- statement so a tombstoned row that re-receives meeting_note.recorded
+-- comes back live with the new content (round-1 P0#1 delete-revive
+-- semantics). Defensive WHERE deleted_at IS NOT NULL keeps it idempotent
+-- across concurrent revive races.
+UPDATE meeting_note SET
+    deleted_at        = NULL,
+    title             = sqlc.arg('title'),
+    summary           = sqlc.arg('summary'),
+    memo              = sqlc.arg('memo'),
+    participants      = sqlc.arg('participants'),
+    linked_kind       = sqlc.arg('linked_kind'),
+    linked_id         = sqlc.arg('linked_id'),
+    linkage_state     = sqlc.arg('linkage_state'),
+    input_hash        = sqlc.arg('input_hash'),
+    resolved_set_hash = sqlc.arg('resolved_set_hash'),
+    last_content_hash = sqlc.arg('last_content_hash'),
+    meeting_at        = sqlc.arg('meeting_at')
+WHERE id = sqlc.arg('id') AND deleted_at IS NOT NULL
+RETURNING *;
+
+-- name: SoftDeleteMeetingNoteBySessionID :exec
+-- Tombstones the live row for a session UUID. last_content_hash,
+-- input_hash, meeting_at are preserved on the row so a future revive
+-- has the prior content snapshot available. Idempotent (no-op when no
+-- live row exists).
+UPDATE meeting_note SET deleted_at = NOW()
+WHERE anarlog_session_id = sqlc.arg('anarlog_session_id') AND deleted_at IS NULL;
+
+-- name: ListKnownMeetingNoteIDsByHost :many
+-- Returns (source_id, last_content_hash) for every live meeting_note
+-- row owned by the given mac_host. Powers GET
+-- /api/v1/host/:id/sync/anarlog_sessions/known-ids. Tombstoned rows are
+-- excluded — the daemon's set-diff reconciliation requires that rows
+-- the Pi has soft-deleted are NOT reported as known.
+SELECT anarlog_session_id::text AS source_id, last_content_hash
+FROM meeting_note
+WHERE mac_host_id = sqlc.arg('mac_host_id') AND deleted_at IS NULL
+ORDER BY source_id;
+
+-- name: TestHardDeleteMeetingNotesBySessionIDPrefix :exec
+-- TEST ONLY. Hard-deletes meeting_note rows whose session UUID (as text)
+-- starts with the given prefix. Used by t.Cleanup to remove fixtures
+-- inserted by a test. Covers both live and tombstoned rows.
+DELETE FROM meeting_note
+WHERE anarlog_session_id::text LIKE sqlc.arg('session_id_prefix')::text;

--- a/backend/internal/db/queries/meeting_note.sql
+++ b/backend/internal/db/queries/meeting_note.sql
@@ -58,9 +58,8 @@ WHERE anarlog_session_id = sqlc.arg('anarlog_session_id')
 -- Tombstone-aware lookup that holds a row-level lock for the duration of
 -- the caller's tx. Used by the meeting_note.recorded inline handler so a
 -- concurrent re-sync for the same session UUID serializes behind the
--- first writer (see service/ingest.go handleMeetingNoteRecorded step 2).
--- Returns tombstoned rows too — the revive path inspects DeletedAt to
--- decide between revive and re-link branches.
+-- first writer. Returns tombstoned rows too — the revive path inspects
+-- DeletedAt to decide between revive and re-link branches.
 SELECT * FROM meeting_note
 WHERE anarlog_session_id = sqlc.arg('anarlog_session_id')
 FOR UPDATE;

--- a/backend/internal/events/kinds.go
+++ b/backend/internal/events/kinds.go
@@ -49,6 +49,16 @@ const (
 	// (source, source_id) dedup on retries.
 	KindExternalContactUpserted Kind = "external_contact.upserted"
 	KindExternalContactDeleted  Kind = "external_contact.deleted"
+
+	// Daemon-emitted meeting-note (anarlog session) events. Published
+	// by the Mac daemon's anarlog_sessions plugin. NOT consumed by any
+	// bus consumer — IngestService processes them inline within the
+	// per-event savepoint (linkage-detection algorithm: calendar window
+	// match, tagged-participant resolve, walk-in supplemental). See
+	// .ai/spec/mac-daemon-phase-2-anarlog-matching.md for the full
+	// linkage state machine.
+	KindMeetingNoteRecorded Kind = "meeting_note.recorded"
+	KindMeetingNoteDeleted  Kind = "meeting_note.deleted"
 )
 
 // AllKinds enumerates every defined Kind. Used by tests to guard that
@@ -69,6 +79,8 @@ var AllKinds = []Kind{
 	KindRawMessageSent,
 	KindExternalContactUpserted,
 	KindExternalContactDeleted,
+	KindMeetingNoteRecorded,
+	KindMeetingNoteDeleted,
 }
 
 // Envelope is the wire/DB shape passed through Bus.Publish. Payload is
@@ -386,6 +398,41 @@ type ExternalContactDeletedPayload struct {
 	EntityID string    `json:"entity_id"` // CNContact identifier
 }
 
+// MeetingNoteRecordedPayload is the payload for KindMeetingNoteRecorded,
+// emitted by the Mac daemon's anarlog_sessions plugin on a session
+// add/update. Inline-processed by IngestService (linkage detection +
+// re-sync diff + needs_attention surfacing). NOT consumed by any bus
+// consumer.
+//
+// SourceID is the anarlog session UUID (the envelope's source_id wraps
+// this with the content-hash suffix per spec line 362). ParticipantIDs
+// are anarlog_human UUIDs that the handler resolves to CRM contacts via
+// the external_identity row planted by the anarlog_humans path.
+type MeetingNoteRecordedPayload struct {
+	Version        int       `json:"version"`   // start at 1
+	HostID         uuid.UUID `json:"host_id"`   // authenticated host
+	Source         string    `json:"source"`    // "anarlog_sessions"
+	SourceID       string    `json:"source_id"` // anarlog session UUID
+	Title          *string   `json:"title,omitempty"`
+	MeetingAt      time.Time `json:"meeting_at"`
+	Summary        *string   `json:"summary,omitempty"`
+	Memo           *string   `json:"memo,omitempty"`
+	ParticipantIDs []string  `json:"participant_ids,omitempty"` // anarlog_human UUIDs
+	Tags           []string  `json:"tags,omitempty"`
+}
+
+// MeetingNoteDeletedPayload is the payload for KindMeetingNoteDeleted,
+// emitted on a session delete (or tombstone reconciliation). The
+// handler soft-deletes the meeting_note row AND explicitly soft-deletes
+// every session-attributed interaction (since UPDATE deleted_at does
+// NOT trigger ON DELETE CASCADE). Unknown session UUID → silent no-op.
+type MeetingNoteDeletedPayload struct {
+	Version  int       `json:"version"`   // start at 1
+	HostID   uuid.UUID `json:"host_id"`   // authenticated host
+	Source   string    `json:"source"`    // "anarlog_sessions"
+	SourceID string    `json:"source_id"` // anarlog session UUID
+}
+
 // kindPayloadTypes is the canonical Kind → payload-type registry used by
 // Marshal and Unmarshal to assert type-vs-kind consistency at runtime. Add
 // a row each time a new Kind + payload struct are introduced. Keep in sync
@@ -406,6 +453,8 @@ var kindPayloadTypes = map[Kind]reflect.Type{
 	KindRawMessageSent:          reflect.TypeOf(RawMessageSentPayload{}),
 	KindExternalContactUpserted: reflect.TypeOf(ExternalContactUpsertedPayload{}),
 	KindExternalContactDeleted:  reflect.TypeOf(ExternalContactDeletedPayload{}),
+	KindMeetingNoteRecorded:     reflect.TypeOf(MeetingNoteRecordedPayload{}),
+	KindMeetingNoteDeleted:      reflect.TypeOf(MeetingNoteDeletedPayload{}),
 }
 
 // IsKnownKind reports whether kind has a registered payload type. Used by
@@ -487,6 +536,30 @@ func ValidatePayload(env *Envelope) error {
 		}
 		if p.HostID == uuid.Nil {
 			return fmt.Errorf("validate %s: host_id is required", env.Kind)
+		}
+	case KindMeetingNoteRecorded:
+		p := dst.(*MeetingNoteRecordedPayload)
+		if p.HostID == uuid.Nil {
+			return fmt.Errorf("validate %s: host_id is required", env.Kind)
+		}
+		if _, err := uuid.Parse(p.SourceID); err != nil {
+			return fmt.Errorf("validate %s: source_id must be a UUID: %w", env.Kind, err)
+		}
+		if p.MeetingAt.IsZero() {
+			return fmt.Errorf("validate %s: meeting_at is required", env.Kind)
+		}
+		for i, pid := range p.ParticipantIDs {
+			if _, err := uuid.Parse(pid); err != nil {
+				return fmt.Errorf("validate %s: participant_ids[%d] not a UUID: %w", env.Kind, i, err)
+			}
+		}
+	case KindMeetingNoteDeleted:
+		p := dst.(*MeetingNoteDeletedPayload)
+		if p.HostID == uuid.Nil {
+			return fmt.Errorf("validate %s: host_id is required", env.Kind)
+		}
+		if _, err := uuid.Parse(p.SourceID); err != nil {
+			return fmt.Errorf("validate %s: source_id must be a UUID: %w", env.Kind, err)
 		}
 	}
 	return nil

--- a/backend/internal/events/kinds_test.go
+++ b/backend/internal/events/kinds_test.go
@@ -533,9 +533,10 @@ func TestKindPayloadTypes_CoversAllKinds(t *testing.T) {
 // deletions from AllKinds without updating the spec. Current spec (§3.2)
 // declares 10 base kinds (9 raw-signal + 1 derived), plus the two
 // daemon-emitted raw_message.* kinds (messages source), plus the two
-// external_contact.* kinds (iCloud Contacts source).
+// external_contact.* kinds (iCloud Contacts source), plus the two
+// meeting_note.* kinds (anarlog_sessions source).
 func TestAllKinds_ExpectedCount(t *testing.T) {
-	require.Len(t, AllKinds, 14)
+	require.Len(t, AllKinds, 16)
 }
 
 // TestIsKnownKind_CoversAllKinds is the positive side: every Kind declared
@@ -626,6 +627,20 @@ func buildCanonicalPayload(t *testing.T, kind Kind) json.RawMessage {
 		raw, err := Marshal(kind, ExternalContactDeletedPayload{
 			Version: 1, HostID: uuid.New(), Source: "icloud_contacts",
 			EntityID: "CN-canonical-2",
+		})
+		require.NoError(t, err)
+		return raw
+	case KindMeetingNoteRecorded:
+		raw, err := Marshal(kind, MeetingNoteRecordedPayload{
+			Version: 1, HostID: uuid.New(), Source: "anarlog_sessions",
+			SourceID: uuid.NewString(), MeetingAt: at,
+		})
+		require.NoError(t, err)
+		return raw
+	case KindMeetingNoteDeleted:
+		raw, err := Marshal(kind, MeetingNoteDeletedPayload{
+			Version: 1, HostID: uuid.New(), Source: "anarlog_sessions",
+			SourceID: uuid.NewString(),
 		})
 		require.NoError(t, err)
 		return raw
@@ -982,4 +997,139 @@ func TestExternalContactPayload_JSONShape(t *testing.T) {
 	require.False(t, hasBirthday, "birthday should be omitted when nil")
 	_, hasMetadata := asMap["metadata"]
 	require.False(t, hasMetadata, "metadata should be omitted when nil")
+}
+
+// ----------------------------------------------------------------------------
+// meeting_note.* payload tests.
+// ----------------------------------------------------------------------------
+
+func makeMeetingNoteRecordedRaw(t *testing.T, mutate func(*MeetingNoteRecordedPayload)) json.RawMessage {
+	t.Helper()
+	title := "Sample Session"
+	p := MeetingNoteRecordedPayload{
+		Version:        1,
+		HostID:         uuid.New(),
+		Source:         "anarlog_sessions",
+		SourceID:       uuid.NewString(),
+		Title:          &title,
+		MeetingAt:      time.Date(2026, 5, 1, 14, 30, 0, 0, time.UTC),
+		ParticipantIDs: []string{uuid.NewString(), uuid.NewString()},
+	}
+	if mutate != nil {
+		mutate(&p)
+	}
+	b, err := json.Marshal(p)
+	require.NoError(t, err)
+	return json.RawMessage(b)
+}
+
+func TestValidatePayload_MeetingNoteRecorded_AcceptsValid(t *testing.T) {
+	env := &Envelope{Kind: KindMeetingNoteRecorded, Payload: makeMeetingNoteRecordedRaw(t, nil)}
+	require.NoError(t, ValidatePayload(env))
+}
+
+func TestValidatePayload_MeetingNoteRecorded_RejectsZeroHostID(t *testing.T) {
+	env := &Envelope{Kind: KindMeetingNoteRecorded, Payload: makeMeetingNoteRecordedRaw(t, func(p *MeetingNoteRecordedPayload) {
+		p.HostID = uuid.Nil
+	})}
+	err := ValidatePayload(env)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "host_id is required")
+}
+
+func TestValidatePayload_MeetingNoteRecorded_RejectsNonUUIDSourceID(t *testing.T) {
+	env := &Envelope{Kind: KindMeetingNoteRecorded, Payload: makeMeetingNoteRecordedRaw(t, func(p *MeetingNoteRecordedPayload) {
+		p.SourceID = "not-a-uuid"
+	})}
+	err := ValidatePayload(env)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "source_id must be a UUID")
+}
+
+func TestValidatePayload_MeetingNoteRecorded_RejectsZeroMeetingAt(t *testing.T) {
+	env := &Envelope{Kind: KindMeetingNoteRecorded, Payload: makeMeetingNoteRecordedRaw(t, func(p *MeetingNoteRecordedPayload) {
+		p.MeetingAt = time.Time{}
+	})}
+	err := ValidatePayload(env)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "meeting_at is required")
+}
+
+func TestValidatePayload_MeetingNoteRecorded_RejectsNonUUIDParticipant(t *testing.T) {
+	env := &Envelope{Kind: KindMeetingNoteRecorded, Payload: makeMeetingNoteRecordedRaw(t, func(p *MeetingNoteRecordedPayload) {
+		p.ParticipantIDs = []string{uuid.NewString(), "not-a-uuid"}
+	})}
+	err := ValidatePayload(env)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "participant_ids[1] not a UUID")
+}
+
+func TestValidatePayload_MeetingNoteDeleted_AcceptsValid(t *testing.T) {
+	p := MeetingNoteDeletedPayload{
+		Version:  1,
+		HostID:   uuid.New(),
+		Source:   "anarlog_sessions",
+		SourceID: uuid.NewString(),
+	}
+	raw, err := json.Marshal(p)
+	require.NoError(t, err)
+	env := &Envelope{Kind: KindMeetingNoteDeleted, Payload: raw}
+	require.NoError(t, ValidatePayload(env))
+}
+
+func TestValidatePayload_MeetingNoteDeleted_RejectsZeroHostID(t *testing.T) {
+	p := MeetingNoteDeletedPayload{
+		Version:  1,
+		Source:   "anarlog_sessions",
+		SourceID: uuid.NewString(),
+	}
+	raw, err := json.Marshal(p)
+	require.NoError(t, err)
+	env := &Envelope{Kind: KindMeetingNoteDeleted, Payload: raw}
+	err = ValidatePayload(env)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "host_id is required")
+}
+
+func TestValidatePayload_MeetingNoteDeleted_RejectsNonUUIDSourceID(t *testing.T) {
+	p := MeetingNoteDeletedPayload{
+		Version:  1,
+		HostID:   uuid.New(),
+		Source:   "anarlog_sessions",
+		SourceID: "not-a-uuid",
+	}
+	raw, err := json.Marshal(p)
+	require.NoError(t, err)
+	env := &Envelope{Kind: KindMeetingNoteDeleted, Payload: raw}
+	err = ValidatePayload(env)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "source_id must be a UUID")
+}
+
+func TestMarshalUnmarshal_MeetingNoteRecorded_RoundTrip(t *testing.T) {
+	title := "Round-Trip Test"
+	summary := "session summary"
+	original := MeetingNoteRecordedPayload{
+		Version:        1,
+		HostID:         uuid.New(),
+		Source:         "anarlog_sessions",
+		SourceID:       uuid.NewString(),
+		Title:          &title,
+		MeetingAt:      time.Date(2026, 6, 1, 9, 0, 0, 0, time.UTC),
+		Summary:        &summary,
+		ParticipantIDs: []string{uuid.NewString(), uuid.NewString()},
+		Tags:           []string{"tag-a", "tag-b"},
+	}
+	raw, err := Marshal(KindMeetingNoteRecorded, original)
+	require.NoError(t, err)
+	env := &Envelope{Kind: KindMeetingNoteRecorded, Payload: raw}
+	var decoded MeetingNoteRecordedPayload
+	require.NoError(t, Unmarshal(env, &decoded))
+	require.Equal(t, original.SourceID, decoded.SourceID)
+	require.Equal(t, original.HostID, decoded.HostID)
+	require.Equal(t, original.ParticipantIDs, decoded.ParticipantIDs)
+	require.Equal(t, original.Tags, decoded.Tags)
+	require.True(t, original.MeetingAt.Equal(decoded.MeetingAt))
+	require.Equal(t, *original.Title, *decoded.Title)
+	require.Equal(t, *original.Summary, *decoded.Summary)
 }

--- a/backend/internal/identity/normalize.go
+++ b/backend/internal/identity/normalize.go
@@ -19,6 +19,15 @@ const (
 	IdentifierTypeIMessageEmail IdentifierType = "imessage_email"
 	IdentifierTypeIMessagePhone IdentifierType = "imessage_phone"
 	IdentifierTypeWhatsApp      IdentifierType = "whatsapp"
+	// IdentifierTypeAnarlogHuman is the anarlog-internal human UUID
+	// (UUID v4 string) emitted by the Mac daemon's anarlog_humans
+	// plugin. Used as the lookup key for resolving
+	// meeting_note.participant_ids into CRM contact_ids. Anarlog UUIDs
+	// are not normalizable (already canonical) and do not search
+	// against contact_method rows — the contact_id link comes from the
+	// associated external_contact's email/phone match (or from a user
+	// import via the Import handler).
+	IdentifierTypeAnarlogHuman IdentifierType = "anarlog_human_id"
 )
 
 // ContactMethodType represents contact method types from the contact_method table
@@ -36,9 +45,11 @@ var nonDigitRegex = regexp.MustCompile(`\D`)
 
 // Normalize returns the normalized form of an identifier based on its type.
 // Normalization rules:
-// - Email: lowercase, trim whitespace
-// - Phone: strip all non-digits, normalize to E.164 format
-// - Telegram: remove @ prefix, lowercase
+//   - Email: lowercase, trim whitespace
+//   - Phone: strip all non-digits, normalize to E.164 format
+//   - Telegram: remove @ prefix, lowercase
+//   - AnarlogHuman: trim whitespace, lowercase (UUIDs are case-insensitive;
+//     lowercasing keeps lookups deterministic against the daemon's emit form)
 func Normalize(raw string, idType IdentifierType) string {
 	switch idType {
 	case IdentifierTypeEmail, IdentifierTypeIMessageEmail:
@@ -47,6 +58,8 @@ func Normalize(raw string, idType IdentifierType) string {
 		return normalizePhone(raw)
 	case IdentifierTypeTelegram:
 		return normalizeTelegram(raw)
+	case IdentifierTypeAnarlogHuman:
+		return strings.ToLower(strings.TrimSpace(raw))
 	default:
 		return strings.TrimSpace(raw)
 	}

--- a/backend/internal/identity/normalize_test.go
+++ b/backend/internal/identity/normalize_test.go
@@ -179,6 +179,52 @@ func TestNormalizeWhatsApp(t *testing.T) {
 	assert.Equal(t, "+15551234567", result)
 }
 
+func TestNormalizeAnarlogHuman(t *testing.T) {
+	// Anarlog UUIDs are already canonical; Normalize trims whitespace
+	// and lowercases so case-mixed daemon emits compare equal to stored.
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "canonical uuid",
+			input:    "fe0e4dd9-30b3-4c2b-9c80-6c7eb1f44a91",
+			expected: "fe0e4dd9-30b3-4c2b-9c80-6c7eb1f44a91",
+		},
+		{
+			name:     "uppercase uuid",
+			input:    "FE0E4DD9-30B3-4C2B-9C80-6C7EB1F44A91",
+			expected: "fe0e4dd9-30b3-4c2b-9c80-6c7eb1f44a91",
+		},
+		{
+			name:     "with whitespace",
+			input:    "  fe0e4dd9-30b3-4c2b-9c80-6c7eb1f44a91  ",
+			expected: "fe0e4dd9-30b3-4c2b-9c80-6c7eb1f44a91",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Normalize(tt.input, IdentifierTypeAnarlogHuman)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestMapIdentifierTypeToContactMethodTypes_AnarlogHumanReturnsNil(t *testing.T) {
+	// Anarlog UUIDs do not search against contact_method rows directly
+	// — the contact_id linkage comes from the associated
+	// external_contact's email/phone match path. Returning nil keeps
+	// the identity-service search path short-circuiting.
+	result := MapIdentifierTypeToContactMethodTypes(IdentifierTypeAnarlogHuman)
+	assert.Nil(t, result)
+}
+
 func TestMapIdentifierTypeToContactMethodTypes(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/backend/internal/repository/calendar.go
+++ b/backend/internal/repository/calendar.go
@@ -375,3 +375,30 @@ func (r *CalendarEventRepository) AppendMatchedContact(ctx context.Context, even
 func (r *CalendarEventRepository) DeleteEventsByAccount(ctx context.Context, googleAccountID string) error {
 	return r.queries.DeleteEventsByAccount(ctx, googleAccountID)
 }
+
+// FindLinkageCandidatesTx returns candidate calendar_event rows for the
+// meeting_note.recorded inline handler's linkage-detection algorithm.
+// Filters cancelled events and orders by start_time ASC. PR 3 ships
+// with calendar-only candidates; when the phone_call table lands,
+// callers will combine this with PhoneCallRepository.FindLinkageCandidatesTx
+// and dedupe in the service layer. Caller owns the tx lifecycle.
+func (r *CalendarEventRepository) FindLinkageCandidatesTx(ctx context.Context, tx pgx.Tx, windowStart, windowEnd time.Time) ([]LinkageCandidate, error) {
+	rows, err := db.New(tx).FindCalendarEventsInWindow(ctx, db.FindCalendarEventsInWindowParams{
+		WindowStart: pgtype.Timestamptz{Time: windowStart, Valid: true},
+		WindowEnd:   pgtype.Timestamptz{Time: windowEnd, Valid: true},
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]LinkageCandidate, 0, len(rows))
+	for _, row := range rows {
+		event := convertDbCalendarEvent(row)
+		out = append(out, LinkageCandidate{
+			Kind:               "event",
+			ID:                 event.ID,
+			OccurredAt:         event.StartTime,
+			AttendeeContactIDs: event.MatchedContactIDs,
+		})
+	}
+	return out, nil
+}

--- a/backend/internal/repository/calendar.go
+++ b/backend/internal/repository/calendar.go
@@ -378,8 +378,8 @@ func (r *CalendarEventRepository) DeleteEventsByAccount(ctx context.Context, goo
 
 // FindLinkageCandidatesTx returns candidate calendar_event rows for the
 // meeting_note.recorded inline handler's linkage-detection algorithm.
-// Filters cancelled events and orders by start_time ASC. PR 3 ships
-// with calendar-only candidates; when the phone_call table lands,
+// Filters cancelled events and orders by start_time ASC. Calendar is
+// the only candidate dimension today; when the phone_call table lands,
 // callers will combine this with PhoneCallRepository.FindLinkageCandidatesTx
 // and dedupe in the service layer. Caller owns the tx lifecycle.
 func (r *CalendarEventRepository) FindLinkageCandidatesTx(ctx context.Context, tx pgx.Tx, windowStart, windowEnd time.Time) ([]LinkageCandidate, error) {

--- a/backend/internal/repository/identity.go
+++ b/backend/internal/repository/identity.go
@@ -468,3 +468,64 @@ func (r *IdentityRepository) UpdateMessageCount(ctx context.Context, id uuid.UUI
 	ident := convertDbIdentity(dbIdentity)
 	return &ident, nil
 }
+
+// LinkIdentityToContactTx is the tx-bound variant of LinkToContact.
+// Used by the inline external_contact handler's anarlog identity
+// registration path so the contact-id link commits atomically with the
+// external_contact upsert. Caller owns the tx lifecycle.
+func (r *IdentityRepository) LinkIdentityToContactTx(ctx context.Context, tx pgx.Tx, req LinkIdentityRequest) (*ExternalIdentity, error) {
+	params := db.LinkIdentityToContactParams{
+		ID:        uuidToPgUUID(req.IdentityID),
+		ContactID: uuidToPgUUID(req.ContactID),
+		MatchType: pgtype.Text{String: string(req.MatchType), Valid: true},
+	}
+	if req.MatchConfidence != nil {
+		params.MatchConfidence = pgtype.Float8{Float64: *req.MatchConfidence, Valid: true}
+	}
+	dbIdentity, err := db.New(tx).LinkIdentityToContact(ctx, params)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, db.ErrNotFound
+		}
+		return nil, err
+	}
+	ident := convertDbIdentity(dbIdentity)
+	return &ident, nil
+}
+
+// FindContactIDByAnarlogHumanIDTx returns the linked CRM contact_id for
+// a given anarlog_human_id identifier, or (nil, nil) when no identity
+// row exists or the row is unmatched. Used by the meeting_note.recorded
+// inline handler to resolve payload.participant_ids into contact_ids.
+// Caller owns the tx lifecycle.
+func (r *IdentityRepository) FindContactIDByAnarlogHumanIDTx(ctx context.Context, tx pgx.Tx, anarlogHumanID string) (*uuid.UUID, error) {
+	dbIdentity, err := db.New(tx).FindIdentityByAnarlogHumanID(ctx, anarlogHumanID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if !dbIdentity.ContactID.Valid {
+		return nil, nil
+	}
+	id := uuid.UUID(dbIdentity.ContactID.Bytes)
+	return &id, nil
+}
+
+// FindIdentitiesByAnarlogHumanID returns 0 or 1 external_identity rows
+// keyed by anarlog_human_id (the unique constraint on
+// (identifier, identifier_type, source) guarantees at most one). Used
+// by the Import handler's anarlog backfill to locate the identity row
+// to link to the imported CRM contact.
+func (r *IdentityRepository) FindIdentitiesByAnarlogHumanID(ctx context.Context, anarlogHumanID string) ([]ExternalIdentity, error) {
+	dbIdentities, err := r.queries.FindIdentitiesByAnarlogHumanID(ctx, anarlogHumanID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]ExternalIdentity, len(dbIdentities))
+	for i, di := range dbIdentities {
+		out[i] = convertDbIdentity(di)
+	}
+	return out, nil
+}

--- a/backend/internal/repository/interaction.go
+++ b/backend/internal/repository/interaction.go
@@ -206,6 +206,31 @@ func (r *InteractionRepository) SoftDeleteInteraction(ctx context.Context, id uu
 	return r.queries.SoftDeleteInteraction(ctx, uuidToPgUUID(id))
 }
 
+// SoftDeleteInteractionTx is the tx-bound variant of SoftDeleteInteraction.
+// Used by the meeting_note inline handler's re-sync diff path and the
+// meeting_note.deleted cascade so the soft-delete commits atomically
+// with the meeting_note row update.
+func (r *InteractionRepository) SoftDeleteInteractionTx(ctx context.Context, tx pgx.Tx, id uuid.UUID) error {
+	return db.New(tx).SoftDeleteInteraction(ctx, uuidToPgUUID(id))
+}
+
+// ListSessionAttributedInteractionsTx returns all live interactions
+// attributed to a specific anarlog session (source_ref starts with the
+// `anarlog:<session-uuid>:` prefix). Used by the re-sync diff path to
+// compute the (existing - desired) set that needs soft-deleting and by
+// the meeting_note.deleted cascade. Caller owns the tx lifecycle.
+func (r *InteractionRepository) ListSessionAttributedInteractionsTx(ctx context.Context, tx pgx.Tx, sourceRefPrefix string) ([]Interaction, error) {
+	dbInteractions, err := db.New(tx).ListSessionAttributedInteractions(ctx, pgtype.Text{String: sourceRefPrefix, Valid: true})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Interaction, len(dbInteractions))
+	for i, dbInteraction := range dbInteractions {
+		out[i] = convertDbInteraction(dbInteraction)
+	}
+	return out, nil
+}
+
 // FindBySourceRef finds an existing interaction by contact, source, and source_ref
 func (r *InteractionRepository) FindBySourceRef(ctx context.Context, contactID uuid.UUID, source string, sourceRef string) (*Interaction, error) {
 	dbInteraction, err := r.queries.FindInteractionBySourceRef(ctx, db.FindInteractionBySourceRefParams{

--- a/backend/internal/repository/linkage.go
+++ b/backend/internal/repository/linkage.go
@@ -1,0 +1,30 @@
+// Package repository — LinkageCandidate is the sum-type-shaped value
+// returned by linkage-detection queries. The kind tag (currently
+// "event") discriminates the rest of the fields. The phone_call kind
+// will activate when the phone_call table lands (phase 1.5); the
+// CalendarEventRepository.FindLinkageCandidatesTx method is the single
+// touch site that needs extending at that time.
+package repository
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// LinkageCandidate is a normalized candidate row used by the
+// meeting_note.recorded inline handler's linkage-detection algorithm.
+// Kind=="event" means the candidate came from calendar_event; Kind==
+// "phone_call" is reserved for the future phone_call table.
+//
+// Fields by kind:
+//   - "event":      AttendeeContactIDs populated (matched_contact_ids);
+//     PeerContactID nil.
+//   - "phone_call": PeerContactID populated; AttendeeContactIDs nil.
+type LinkageCandidate struct {
+	Kind               string
+	ID                 uuid.UUID
+	OccurredAt         time.Time
+	AttendeeContactIDs []uuid.UUID
+	PeerContactID      *uuid.UUID
+}

--- a/backend/internal/repository/meeting_note.go
+++ b/backend/internal/repository/meeting_note.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"time"
 
 	"personal-crm/backend/internal/db"
@@ -158,7 +159,14 @@ func convertDbMeetingNote(row *db.MeetingNote) (*MeetingNote, error) {
 	mn.DeletedAt = pgTimestamptzToTimePtr(row.DeletedAt)
 	if len(row.Participants) > 0 {
 		if err := json.Unmarshal(row.Participants, &mn.Participants); err != nil {
-			mn.Participants = []string{}
+			// Participants is a JSONB array we write ourselves via
+			// participantsJSON; a decode failure here means the column
+			// was corrupted or a non-array shape was inserted by a
+			// future writer. Surface the error rather than silently
+			// returning an empty list — downstream linkage logic
+			// would treat a corrupted row as "no tagged participants"
+			// and silently drop the user-visible tags.
+			return nil, fmt.Errorf("decode meeting_note.participants for id %s: %w", mn.ID, err)
 		}
 	} else {
 		mn.Participants = []string{}

--- a/backend/internal/repository/meeting_note.go
+++ b/backend/internal/repository/meeting_note.go
@@ -19,7 +19,7 @@ import (
 const (
 	LinkageStateLinked               = "linked"
 	LinkageStateLinkedImpromptu      = "linked_impromptu"
-	LinkageStateOrphanTitleAugmented = "orphan_title_augmented" // reserved for PR 4
+	LinkageStateOrphanTitleAugmented = "orphan_title_augmented" // reserved for the title-augmentation flow
 	LinkageStateOrphanNeedsReview    = "orphan_needs_review"
 	LinkageStateConflictPending      = "conflict_pending"
 )
@@ -95,8 +95,7 @@ type UpdateMeetingNoteOnResyncParams struct {
 
 // ReviveMeetingNoteParams is the same shape as the on-resync update,
 // but the underlying query also clears deleted_at. Used when a tombstoned
-// row re-receives meeting_note.recorded with the same source_id
-// (round-1 P0#1 delete-revive semantics).
+// row re-receives meeting_note.recorded with the same source_id.
 type ReviveMeetingNoteParams = UpdateMeetingNoteOnResyncParams
 
 // MeetingNoteRepository owns persistence for the meeting_note table.
@@ -177,7 +176,10 @@ func participantsJSON(parts []string) ([]byte, error) {
 }
 
 // InsertMeetingNoteTx inserts a first-insert meeting_note row inside the
-// caller's tx. Caller owns the tx lifecycle.
+// caller's tx. Caller owns the tx lifecycle. Returns (nil, db.ErrNotFound)
+// when a concurrent first-insert won the race against the partial unique
+// index (the SQL uses ON CONFLICT DO NOTHING). Callers handle the race by
+// re-reading the row with FOR UPDATE and falling through to the update path.
 func (r *MeetingNoteRepository) InsertMeetingNoteTx(ctx context.Context, tx pgx.Tx, params InsertMeetingNoteParams) (*MeetingNote, error) {
 	partsJSON, err := participantsJSON(params.Participants)
 	if err != nil {
@@ -199,6 +201,9 @@ func (r *MeetingNoteRepository) InsertMeetingNoteTx(ctx context.Context, tx pgx.
 		MeetingAt:        pgtype.Timestamptz{Time: params.MeetingAt, Valid: true},
 	})
 	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, db.ErrNotFound
+		}
 		return nil, err
 	}
 	return convertDbMeetingNote(row)
@@ -343,6 +348,14 @@ func (r *MeetingNoteRepository) ListKnownMeetingNoteSessionIDsByHost(ctx context
 // code must NOT call this.
 func (r *MeetingNoteRepository) TestHardDeleteBySessionIDPrefix(ctx context.Context, prefix string) error {
 	return r.queries.TestHardDeleteMeetingNotesBySessionIDPrefix(ctx, prefix)
+}
+
+// TestHardDeleteByHostID is a test-only cleanup helper that hard-deletes
+// every meeting_note row owned by a given mac_host. Used when the test
+// seeds rows with system-generated session UUIDs (no exploitable prefix).
+// Production code must NOT call this.
+func (r *MeetingNoteRepository) TestHardDeleteByHostID(ctx context.Context, hostID uuid.UUID) error {
+	return r.queries.TestHardDeleteMeetingNotesByHostID(ctx, uuidToPgUUID(hostID))
 }
 
 // nullableUUIDToPg converts a *uuid.UUID into a pgtype.UUID with

--- a/backend/internal/repository/meeting_note.go
+++ b/backend/internal/repository/meeting_note.go
@@ -1,0 +1,355 @@
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"personal-crm/backend/internal/db"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// Linkage state constants for meeting_note.linkage_state. Match the
+// CHECK constraint defined in migration 053. Kept here so the inline
+// handler in service/ingest.go does not embed magic strings.
+const (
+	LinkageStateLinked               = "linked"
+	LinkageStateLinkedImpromptu      = "linked_impromptu"
+	LinkageStateOrphanTitleAugmented = "orphan_title_augmented" // reserved for PR 4
+	LinkageStateOrphanNeedsReview    = "orphan_needs_review"
+	LinkageStateConflictPending      = "conflict_pending"
+)
+
+// Linked-kind constants. Match the CHECK constraint defined in migration
+// 053. PhoneCall is reserved for the deferred phase 1.5 phone_call table.
+const (
+	LinkedKindEvent     = "event"
+	LinkedKindPhoneCall = "phone_call"
+)
+
+// MeetingNote is the repository-layer view of a meeting_note row.
+// Participants is stored as a JSONB array of anarlog_human UUID strings
+// (the payload shape); typed as []string in Go so the caller does not
+// have to allocate a uuid.UUID slice for the linkage logic that only
+// needs identifier-string comparisons.
+type MeetingNote struct {
+	ID               uuid.UUID
+	AnarlogSessionID uuid.UUID
+	Title            *string
+	Summary          *string
+	Memo             *string
+	Participants     []string
+	MacHostID        *uuid.UUID
+	LinkedKind       *string
+	LinkedID         *uuid.UUID
+	LinkageState     string
+	InputHash        string
+	ResolvedSetHash  string
+	LastContentHash  *string
+	MeetingAt        time.Time
+	DeletedAt        *time.Time
+	CreatedAt        time.Time
+}
+
+// InsertMeetingNoteParams captures the per-row values the inline
+// handler supplies on first-insert. Hashes default to empty string only
+// at the migration boundary; the handler ALWAYS supplies real values.
+type InsertMeetingNoteParams struct {
+	AnarlogSessionID uuid.UUID
+	Title            *string
+	Summary          *string
+	Memo             *string
+	Participants     []string
+	MacHostID        *uuid.UUID
+	LinkedKind       *string
+	LinkedID         *uuid.UUID
+	LinkageState     string
+	InputHash        string
+	ResolvedSetHash  string
+	LastContentHash  *string
+	MeetingAt        time.Time
+}
+
+// UpdateMeetingNoteOnResyncParams is the value bag for both the
+// carry-forward and re-link branches of the re-sync algorithm. The
+// caller picks the right linkage values (carry-forward preserves
+// prior; re-link computes fresh).
+type UpdateMeetingNoteOnResyncParams struct {
+	ID              uuid.UUID
+	Title           *string
+	Summary         *string
+	Memo            *string
+	Participants    []string
+	LinkedKind      *string
+	LinkedID        *uuid.UUID
+	LinkageState    string
+	InputHash       string
+	ResolvedSetHash string
+	LastContentHash *string
+	MeetingAt       time.Time
+}
+
+// ReviveMeetingNoteParams is the same shape as the on-resync update,
+// but the underlying query also clears deleted_at. Used when a tombstoned
+// row re-receives meeting_note.recorded with the same source_id
+// (round-1 P0#1 delete-revive semantics).
+type ReviveMeetingNoteParams = UpdateMeetingNoteOnResyncParams
+
+// MeetingNoteRepository owns persistence for the meeting_note table.
+type MeetingNoteRepository struct {
+	queries db.Querier
+}
+
+// NewMeetingNoteRepository builds a MeetingNoteRepository over the
+// given querier.
+func NewMeetingNoteRepository(queries db.Querier) *MeetingNoteRepository {
+	return &MeetingNoteRepository{queries: queries}
+}
+
+// convertDbMeetingNote translates a generated db.MeetingNote row into the
+// repository's typed view.
+func convertDbMeetingNote(row *db.MeetingNote) (*MeetingNote, error) {
+	if row == nil {
+		return nil, nil
+	}
+	mn := &MeetingNote{
+		LinkageState:    row.LinkageState,
+		InputHash:       row.InputHash,
+		ResolvedSetHash: row.ResolvedSetHash,
+	}
+	if row.ID.Valid {
+		mn.ID = uuid.UUID(row.ID.Bytes)
+	}
+	if row.AnarlogSessionID.Valid {
+		mn.AnarlogSessionID = uuid.UUID(row.AnarlogSessionID.Bytes)
+	}
+	if row.Title.Valid {
+		mn.Title = &row.Title.String
+	}
+	if row.Summary.Valid {
+		mn.Summary = &row.Summary.String
+	}
+	if row.Memo.Valid {
+		mn.Memo = &row.Memo.String
+	}
+	if row.MacHostID.Valid {
+		id := uuid.UUID(row.MacHostID.Bytes)
+		mn.MacHostID = &id
+	}
+	if row.LinkedKind.Valid {
+		mn.LinkedKind = &row.LinkedKind.String
+	}
+	if row.LinkedID.Valid {
+		id := uuid.UUID(row.LinkedID.Bytes)
+		mn.LinkedID = &id
+	}
+	if row.LastContentHash.Valid {
+		mn.LastContentHash = &row.LastContentHash.String
+	}
+	if row.MeetingAt.Valid {
+		mn.MeetingAt = row.MeetingAt.Time.UTC()
+	}
+	if row.CreatedAt.Valid {
+		mn.CreatedAt = row.CreatedAt.Time.UTC()
+	}
+	mn.DeletedAt = pgTimestamptzToTimePtr(row.DeletedAt)
+	if len(row.Participants) > 0 {
+		if err := json.Unmarshal(row.Participants, &mn.Participants); err != nil {
+			mn.Participants = []string{}
+		}
+	} else {
+		mn.Participants = []string{}
+	}
+	return mn, nil
+}
+
+// participantsJSON encodes []string into a JSONB-compatible byte slice.
+// Nil/empty slices marshal as `[]` so the column never holds NULL.
+func participantsJSON(parts []string) ([]byte, error) {
+	if parts == nil {
+		return []byte("[]"), nil
+	}
+	return json.Marshal(parts)
+}
+
+// InsertMeetingNoteTx inserts a first-insert meeting_note row inside the
+// caller's tx. Caller owns the tx lifecycle.
+func (r *MeetingNoteRepository) InsertMeetingNoteTx(ctx context.Context, tx pgx.Tx, params InsertMeetingNoteParams) (*MeetingNote, error) {
+	partsJSON, err := participantsJSON(params.Participants)
+	if err != nil {
+		return nil, err
+	}
+	row, err := db.New(tx).InsertMeetingNote(ctx, db.InsertMeetingNoteParams{
+		AnarlogSessionID: uuidToPgUUID(params.AnarlogSessionID),
+		Title:            stringToPgText(params.Title),
+		Summary:          stringToPgText(params.Summary),
+		Memo:             stringToPgText(params.Memo),
+		Participants:     partsJSON,
+		MacHostID:        nullableUUIDToPg(params.MacHostID),
+		LinkedKind:       stringToPgText(params.LinkedKind),
+		LinkedID:         nullableUUIDToPg(params.LinkedID),
+		LinkageState:     params.LinkageState,
+		InputHash:        params.InputHash,
+		ResolvedSetHash:  params.ResolvedSetHash,
+		LastContentHash:  stringToPgText(params.LastContentHash),
+		MeetingAt:        pgtype.Timestamptz{Time: params.MeetingAt, Valid: true},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return convertDbMeetingNote(row)
+}
+
+// UpdateMeetingNoteOnResyncTx updates a live meeting_note row with the
+// new content + linkage values. Used by both the carry-forward and
+// re-link branches (the caller picks the values).
+func (r *MeetingNoteRepository) UpdateMeetingNoteOnResyncTx(ctx context.Context, tx pgx.Tx, params UpdateMeetingNoteOnResyncParams) (*MeetingNote, error) {
+	partsJSON, err := participantsJSON(params.Participants)
+	if err != nil {
+		return nil, err
+	}
+	row, err := db.New(tx).UpdateMeetingNoteOnResync(ctx, db.UpdateMeetingNoteOnResyncParams{
+		ID:              uuidToPgUUID(params.ID),
+		Title:           stringToPgText(params.Title),
+		Summary:         stringToPgText(params.Summary),
+		Memo:            stringToPgText(params.Memo),
+		Participants:    partsJSON,
+		LinkedKind:      stringToPgText(params.LinkedKind),
+		LinkedID:        nullableUUIDToPg(params.LinkedID),
+		LinkageState:    params.LinkageState,
+		InputHash:       params.InputHash,
+		ResolvedSetHash: params.ResolvedSetHash,
+		LastContentHash: stringToPgText(params.LastContentHash),
+		MeetingAt:       pgtype.Timestamptz{Time: params.MeetingAt, Valid: true},
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, db.ErrNotFound
+		}
+		return nil, err
+	}
+	return convertDbMeetingNote(row)
+}
+
+// ReviveMeetingNoteTx clears deleted_at and writes the new content +
+// linkage values in a single statement. Idempotent across concurrent
+// revive races via the defensive WHERE deleted_at IS NOT NULL.
+func (r *MeetingNoteRepository) ReviveMeetingNoteTx(ctx context.Context, tx pgx.Tx, params ReviveMeetingNoteParams) (*MeetingNote, error) {
+	partsJSON, err := participantsJSON(params.Participants)
+	if err != nil {
+		return nil, err
+	}
+	row, err := db.New(tx).ReviveMeetingNote(ctx, db.ReviveMeetingNoteParams{
+		ID:              uuidToPgUUID(params.ID),
+		Title:           stringToPgText(params.Title),
+		Summary:         stringToPgText(params.Summary),
+		Memo:            stringToPgText(params.Memo),
+		Participants:    partsJSON,
+		LinkedKind:      stringToPgText(params.LinkedKind),
+		LinkedID:        nullableUUIDToPg(params.LinkedID),
+		LinkageState:    params.LinkageState,
+		InputHash:       params.InputHash,
+		ResolvedSetHash: params.ResolvedSetHash,
+		LastContentHash: stringToPgText(params.LastContentHash),
+		MeetingAt:       pgtype.Timestamptz{Time: params.MeetingAt, Valid: true},
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, db.ErrNotFound
+		}
+		return nil, err
+	}
+	return convertDbMeetingNote(row)
+}
+
+// GetMeetingNoteBySessionIDTx returns the live meeting_note row for a
+// given anarlog session UUID. Returns (nil, db.ErrNotFound) when no
+// live row exists. Live-only — tombstoned rows are NOT returned.
+func (r *MeetingNoteRepository) GetMeetingNoteBySessionIDTx(ctx context.Context, tx pgx.Tx, sessionID uuid.UUID) (*MeetingNote, error) {
+	row, err := db.New(tx).GetMeetingNoteBySessionID(ctx, uuidToPgUUID(sessionID))
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, db.ErrNotFound
+		}
+		return nil, err
+	}
+	return convertDbMeetingNote(row)
+}
+
+// GetMeetingNoteBySessionIDForUpdateTx returns the meeting_note row
+// (including tombstoned) for a given session UUID and acquires a
+// row-level lock for the caller's tx. Used by the inline handler to
+// serialize concurrent re-syncs for the same session UUID.
+func (r *MeetingNoteRepository) GetMeetingNoteBySessionIDForUpdateTx(ctx context.Context, tx pgx.Tx, sessionID uuid.UUID) (*MeetingNote, error) {
+	row, err := db.New(tx).GetMeetingNoteBySessionIDForUpdate(ctx, uuidToPgUUID(sessionID))
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, db.ErrNotFound
+		}
+		return nil, err
+	}
+	return convertDbMeetingNote(row)
+}
+
+// GetTombstonedMeetingNoteBySessionIDTx returns the tombstoned row for
+// a given session UUID, or (nil, db.ErrNotFound) when none exists.
+// Used by the revive-bypass probe in the dispatch loop.
+func (r *MeetingNoteRepository) GetTombstonedMeetingNoteBySessionIDTx(ctx context.Context, tx pgx.Tx, sessionID uuid.UUID) (*MeetingNote, error) {
+	row, err := db.New(tx).GetTombstonedMeetingNoteBySessionID(ctx, uuidToPgUUID(sessionID))
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, db.ErrNotFound
+		}
+		return nil, err
+	}
+	return convertDbMeetingNote(row)
+}
+
+// SoftDeleteMeetingNoteBySessionIDTx tombstones the live row for a
+// given session UUID. Idempotent (no-op when no live row exists).
+func (r *MeetingNoteRepository) SoftDeleteMeetingNoteBySessionIDTx(ctx context.Context, tx pgx.Tx, sessionID uuid.UUID) error {
+	return db.New(tx).SoftDeleteMeetingNoteBySessionID(ctx, uuidToPgUUID(sessionID))
+}
+
+// ListKnownMeetingNoteSessionIDsByHost returns (source_id,
+// last_content_hash) for every live meeting_note row owned by the
+// given mac_host. Powers the anarlog_sessions arm of /known-ids.
+// Returns the SAME KnownExternalContactID DTO shape so the service
+// layer can dispatch uniformly across sources.
+func (r *MeetingNoteRepository) ListKnownMeetingNoteSessionIDsByHost(ctx context.Context, hostID uuid.UUID) ([]KnownExternalContactID, error) {
+	rows, err := r.queries.ListKnownMeetingNoteIDsByHost(ctx, uuidToPgUUID(hostID))
+	if err != nil {
+		return nil, err
+	}
+	out := make([]KnownExternalContactID, 0, len(rows))
+	for _, row := range rows {
+		entry := KnownExternalContactID{SourceID: row.SourceID}
+		if row.LastContentHash.Valid {
+			h := row.LastContentHash.String
+			entry.LastContentHash = &h
+		}
+		out = append(out, entry)
+	}
+	return out, nil
+}
+
+// TestHardDeleteBySessionIDPrefix is a test-only cleanup helper that
+// hard-deletes meeting_note rows whose session UUID (as text) starts
+// with the given prefix. Bypasses the tombstone contract — production
+// code must NOT call this.
+func (r *MeetingNoteRepository) TestHardDeleteBySessionIDPrefix(ctx context.Context, prefix string) error {
+	return r.queries.TestHardDeleteMeetingNotesBySessionIDPrefix(ctx, prefix)
+}
+
+// nullableUUIDToPg converts a *uuid.UUID into a pgtype.UUID with
+// Valid=false when the pointer is nil.
+func nullableUUIDToPg(id *uuid.UUID) pgtype.UUID {
+	if id == nil {
+		return pgtype.UUID{Valid: false}
+	}
+	return pgtype.UUID{Bytes: *id, Valid: true}
+}

--- a/backend/internal/service/identity.go
+++ b/backend/internal/service/identity.go
@@ -48,6 +48,42 @@ func NewIdentityService(identityRepo *repository.IdentityRepository) *IdentitySe
 	}
 }
 
+// BackfillAnarlogIdentityForImport links the external_identity row
+// keyed by an anarlog_human_id to the supplied CRM contact, mirroring
+// the email/phone identity-link logic that runs at external_contact
+// upsert time. Returns nil + no-op when no identity row exists yet,
+// or when the existing identity is already linked to a different
+// contact (manual user intent wins). Returns an error on any
+// underlying repository failure so the caller can surface a 500.
+//
+// Used by the import handler after a user-driven import/link of an
+// anarlog_humans external_contact. Keeps the handler clean of direct
+// repository.IdentityRepository calls.
+func (s *IdentityService) BackfillAnarlogIdentityForImport(ctx context.Context, anarlogHumanID string, contactID uuid.UUID) error {
+	identities, err := s.identityRepo.FindIdentitiesByAnarlogHumanID(ctx, anarlogHumanID)
+	if err != nil {
+		return fmt.Errorf("anarlog import backfill: lookup identity: %w", err)
+	}
+	for _, ident := range identities {
+		if ident.ContactID != nil && *ident.ContactID != contactID {
+			logger.Warn().
+				Str("anarlog_human_id", anarlogHumanID).
+				Str("existing_contact_id", ident.ContactID.String()).
+				Str("import_contact_id", contactID.String()).
+				Msg("anarlog import backfill: identity already linked to different contact; skipping")
+			continue
+		}
+		if _, err := s.identityRepo.LinkToContact(ctx, repository.LinkIdentityRequest{
+			IdentityID: ident.ID,
+			ContactID:  contactID,
+			MatchType:  repository.MatchTypeManual,
+		}); err != nil {
+			return fmt.Errorf("anarlog import backfill: link identity: %w", err)
+		}
+	}
+	return nil
+}
+
 // MatchOrCreate finds a matching contact or creates an unmatched identity record.
 // This is the main entry point for identity matching during sync operations.
 //

--- a/backend/internal/service/ingest.go
+++ b/backend/internal/service/ingest.go
@@ -1160,6 +1160,48 @@ func (s *IngestService) handleExternalContactUpserted(
 			matched = true
 		}
 	}
+
+	// Anarlog-humans identity registration. For source='anarlog_humans'
+	// only, write an external_identity row keyed by the anarlog_human_id
+	// itself so the meeting_note.recorded handler can resolve
+	// participant_ids → CRM contact_ids via FindContactIDByAnarlogHumanIDTx.
+	// If the email/phone path above resolved a contact_id, link the new
+	// identity row to it in the same tx. The Import-handler backfill
+	// (handlers/import.go) covers the "tag now, import later" path.
+	if env.Source == "anarlog_humans" && s.identityLookup != nil {
+		result, idErr := s.identity.MatchOrCreateTx(ctx, tx, MatchRequest{
+			RawIdentifier: p.EntityID,
+			Type:          identity.IdentifierTypeAnarlogHuman,
+			Source:        env.Source,
+			SourceID:      &p.EntityID,
+			DisplayName:   p.DisplayName,
+		})
+		if idErr != nil {
+			return &IngestPerEventRejection{
+				Code:    ingestRejectIdentityMatchFailed,
+				Message: fmt.Sprintf("identity match (anarlog_human_id): %s", idErr.Error()),
+			}
+		}
+		// If the external_contact's email/phone resolved a CRM contact
+		// AND the new anarlog identity row is unmatched, link it.
+		// Defensive guards: only link when both sides have populated
+		// pointers AND the identity row is genuinely unmatched (avoid
+		// clobbering a manual link from a prior import).
+		if external != nil && external.CRMContactID != nil &&
+			result != nil && result.Identity != nil && result.Identity.ContactID == nil {
+			if _, linkErr := s.identityLookup.LinkIdentityToContactTx(ctx, tx, repository.LinkIdentityRequest{
+				IdentityID: result.Identity.ID,
+				ContactID:  *external.CRMContactID,
+				MatchType:  repository.MatchTypeExact,
+			}); linkErr != nil {
+				return &IngestPerEventRejection{
+					Code:    ingestRejectIdentityMatchFailed,
+					Message: fmt.Sprintf("link anarlog_human_id identity to contact: %s", linkErr.Error()),
+				}
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/backend/internal/service/ingest.go
+++ b/backend/internal/service/ingest.go
@@ -122,14 +122,14 @@ type IngestPerEventRejection struct {
 // dispatch loop appends one item per qualifying event AFTER the
 // per-event savepoint commits successfully — never on the rollback
 // path. The handler maps this to the HTTP response's needs_attention
-// field for the daemon to consume in PR 6.
+// field for the daemon to consume.
 type NeedsAttentionItem struct {
 	SessionID string
 	Reason    string
 }
 
 // NeedsAttentionReason* are the canonical reason strings for
-// NeedsAttentionItem. The daemon pattern-matches on these in PR 6.
+// NeedsAttentionItem. The daemon pattern-matches on these.
 const (
 	NeedsAttentionReasonConflict = "conflict"
 	NeedsAttentionReasonOrphan   = "orphan"
@@ -197,12 +197,13 @@ type CalendarLinkageReader interface {
 }
 
 // InteractionWriter is the narrow surface for the re-sync diff path
-// (list session-attributed live interactions, soft-delete obsoletes)
-// and the meeting_note.deleted cascade. Concrete is
-// *repository.InteractionRepository.
+// (list session-attributed live interactions, soft-delete obsoletes,
+// refresh content fields when the payload changed) and the
+// meeting_note.deleted cascade. Concrete is *repository.InteractionRepository.
 type InteractionWriter interface {
 	ListSessionAttributedInteractionsTx(ctx context.Context, tx pgx.Tx, sourceRefPrefix string) ([]repository.Interaction, error)
 	SoftDeleteInteractionTx(ctx context.Context, tx pgx.Tx, id uuid.UUID) error
+	UpdateInteractionTimestampTx(ctx context.Context, tx pgx.Tx, id uuid.UUID, occurredAt time.Time, description *string) (*repository.Interaction, error)
 }
 
 // AnarlogIdentityLookup is the narrow surface used by the
@@ -450,6 +451,12 @@ func (s *IngestService) IngestBatch(
 
 	pendingAggregate := make(map[pendingAggregateKey]struct{})
 
+	// batchPostCommit accumulates post-commit closures returned by
+	// per-event handlers (currently only meeting_note.recorded routes
+	// session interactions through ContactService.RecordInteractionTx,
+	// whose FollowUpFn fires the FollowUpManager after commit).
+	var batchPostCommit []func(context.Context)
+
 	for i, env := range envs {
 		originalIdx := originalIndices[i]
 
@@ -537,15 +544,13 @@ func (s *IngestService) IngestBatch(
 		// content hash hasn't actually changed (external_contact).
 		// The guard makes a duplicate re-submit a true no-op.
 		//
-		// Exception (round-1 P0#1 — delete-revive): for
-		// meeting_note.recorded the spec-defined source_id is
-		// `<session_uuid>@<content_hash>`. A tombstoned session that
-		// is later re-recorded with identical content produces the
-		// SAME source_id and hits the bus-dedup path — without the
-		// revive-bypass probe the inline handler is skipped and the
-		// row stays tombstoned. shouldRunInlineOnDuplicate runs a
-		// tombstone-probe before the skip and runs the handler when
-		// a tombstoned row exists.
+		// Exception for meeting_note.recorded: the spec-defined
+		// source_id is `<session_uuid>@<content_hash>`. A tombstoned
+		// session that is later re-recorded with identical content
+		// produces the SAME source_id and hits the bus-dedup path —
+		// without the probe the inline handler is skipped and the row
+		// stays tombstoned. The same probe also covers participant
+		// resolution drift on live rows after an import.
 		runInline := !isDuplicate
 		if isDuplicate {
 			should, probeErr := s.shouldRunInlineOnDuplicate(ctx, sp, env)
@@ -561,8 +566,14 @@ func (s *IngestService) IngestBatch(
 		// Per-event optional accumulator items. Captured during the
 		// handler's run and appended to the batch-level slice ONLY
 		// after the savepoint commits — never on the rollback path
-		// (round-1 P2#1 single-point append).
+		// (single-point append).
 		var pendingNA *NeedsAttentionItem
+		// pendingFollowUps holds the post-commit closures returned by
+		// ContactService.RecordInteractionTx for any session-attributed
+		// interactions written by handleMeetingNoteRecorded. Executed
+		// once the outer tx commits so the cadence-task + Todoist side
+		// effects fire correctly.
+		var pendingFollowUps []func(context.Context)
 
 		if runInline {
 			switch {
@@ -598,7 +609,7 @@ func (s *IngestService) IngestBatch(
 					continue
 				}
 			case env.Kind == events.KindMeetingNoteRecorded:
-				naItem, rejection := s.handleMeetingNoteRecorded(ctx, sp, env, *hostID)
+				naItem, followUps, rejection := s.handleMeetingNoteRecorded(ctx, sp, env, *hostID)
 				if rejection != nil {
 					rejection.Index = originalIdx
 					perEventRejections = append(perEventRejections, *rejection)
@@ -608,6 +619,7 @@ func (s *IngestService) IngestBatch(
 					continue
 				}
 				pendingNA = naItem
+				pendingFollowUps = followUps
 			case env.Kind == events.KindMeetingNoteDeleted:
 				if rejection := s.handleMeetingNoteDeleted(ctx, sp, env, *hostID); rejection != nil {
 					rejection.Index = originalIdx
@@ -627,6 +639,12 @@ func (s *IngestService) IngestBatch(
 		// Post-commit: append the per-event needs_attention item, if any.
 		if pendingNA != nil {
 			needsAttention = append(needsAttention, *pendingNA)
+		}
+		// Collect post-commit follow-up closures for execution after
+		// the outer tx commits. Discarding them here would silently lose
+		// follow-up task side effects on session-attributed interactions.
+		if len(pendingFollowUps) > 0 {
+			batchPostCommit = append(batchPostCommit, pendingFollowUps...)
 		}
 
 		if isDuplicate {
@@ -661,6 +679,16 @@ func (s *IngestService) IngestBatch(
 
 	if commitErr := tx.Commit(ctx); commitErr != nil {
 		return 0, 0, nil, nil, fmt.Errorf("commit: %w", commitErr)
+	}
+	// Execute post-commit follow-up closures (FollowUpFn returned by
+	// ContactService.RecordInteractionTx). Run sequentially since
+	// FollowUpManager updates contact_task rows that may share a
+	// contact; the volume per batch is bounded by len(envs) so this
+	// is cheap. Each closure is itself best-effort: a failure inside
+	// the followup logic is logged inside FollowUpManager and does
+	// NOT roll back the batch (the interactions already committed).
+	for _, fn := range batchPostCommit {
+		fn(ctx)
 	}
 	return accepted, duplicate, perEventRejections, needsAttention, nil
 }
@@ -1529,17 +1557,23 @@ func commonMeetingNoteInvariants(
 // rows. 15 minutes per sidecar spec §Linkage detection algorithm.
 const linkageWindow = 15 * time.Minute
 
-// shouldRunInlineOnDuplicate is the revive-bypass probe used by the
-// dispatch loop. It returns true when the duplicate event MUST still
-// run the inline handler because the underlying row is tombstoned and
-// needs revive consideration (round-1 P0#1 — delete-revive for
-// meeting_note.recorded with identical content). For all other kinds
-// returns false (the existing "skip duplicates" semantics apply).
+// shouldRunInlineOnDuplicate is the dispatch-loop probe that allows
+// the inline handler to run even when Bus.PublishTx flagged the event
+// as a duplicate. For meeting_note.recorded specifically there are two
+// scenarios where the duplicate must NOT be a no-op:
 //
-// The probe is bounded: it only runs when env.Kind ==
-// KindMeetingNoteRecorded AND meetingNotes is wired. Other duplicate
-// events skip the inline handler unchanged, preserving the
-// external_contact "duplicate is a true no-op" contract.
+//  1. The underlying row is tombstoned and needs revive consideration
+//     (delete then re-record identical content scenario).
+//  2. The row is live but the participant→contact resolution may have
+//     drifted since the original ingest (the user imported a previously-
+//     unmatched anarlog_humans candidate, so the resolved_set_hash
+//     would now differ). The carry-forward branch detects whether work
+//     is actually needed via hash compare and short-circuits when not.
+//
+// Returning true unconditionally for live + tombstoned meeting_note
+// rows is safe: the handler's carry-forward branch is cheap (single
+// UPDATE on the content fields) when nothing changed. Other kinds keep
+// the "duplicate is a true no-op" contract.
 func (s *IngestService) shouldRunInlineOnDuplicate(ctx context.Context, tx pgx.Tx, env *events.Envelope) (bool, error) {
 	if env.Kind != events.KindMeetingNoteRecorded || s.meetingNotes == nil {
 		return false, nil
@@ -1549,20 +1583,25 @@ func (s *IngestService) shouldRunInlineOnDuplicate(ctx context.Context, tx pgx.T
 		// Decode failure here is unexpected — the dispatch loop already
 		// ran verifyMeetingNoteInvariants which decodes successfully.
 		// Surface as an error so the batch rolls back.
-		return false, fmt.Errorf("revive-bypass probe: decode payload: %w", err)
+		return false, fmt.Errorf("inline-on-duplicate probe: decode payload: %w", err)
 	}
 	sessionID, parseErr := uuid.Parse(p.SourceID)
 	if parseErr != nil {
-		return false, fmt.Errorf("revive-bypass probe: parse session UUID: %w", parseErr)
+		return false, fmt.Errorf("inline-on-duplicate probe: parse session UUID: %w", parseErr)
 	}
-	_, err := s.meetingNotes.GetTombstonedMeetingNoteBySessionIDTx(ctx, tx, sessionID)
+	// Tombstone-aware FOR UPDATE — returns the row whether live or
+	// soft-deleted. Either case means the inline handler should run.
+	// db.ErrNotFound is the no-prior-row case (e.g. concurrent first
+	// insert that lost the race) — in that case the original
+	// duplicate-skip semantics apply.
+	_, err := s.meetingNotes.GetMeetingNoteBySessionIDForUpdateTx(ctx, tx, sessionID)
 	if err == nil {
 		return true, nil
 	}
 	if errors.Is(err, db.ErrNotFound) {
 		return false, nil
 	}
-	return false, fmt.Errorf("revive-bypass probe: lookup tombstoned row: %w", err)
+	return false, fmt.Errorf("inline-on-duplicate probe: lookup row: %w", err)
 }
 
 // meetingNoteInputHashRecipe is the canonical (meeting_at, title,
@@ -1576,7 +1615,7 @@ type meetingNoteInputHashRecipe struct {
 
 // computeMeetingNoteInputHash returns the lowercase-hex SHA-256 of a
 // stable canonicalization of (meeting_at, title, sorted participant_ids).
-// Title is included so PR 4's title-parser does not have to migrate
+// Title is included so a future title-parser does not have to migrate
 // hashes. Summary and memo are intentionally excluded — they're content
 // fields, not matching inputs.
 func computeMeetingNoteInputHash(meetingAt time.Time, title *string, participantIDs []string) (string, error) {
@@ -1644,36 +1683,48 @@ type desiredInteraction struct {
 //
 // Implements the full linkage-detection algorithm per
 // .ai/spec/mac-daemon-phase-2-anarlog-matching.md §Linkage detection
-// (Steps 1, 2, 4, 5 — Step 3 disambiguation is PR 5). Re-sync diff and
-// the revive-on-tombstone branch share the same code path.
+// — Steps 1, 2, 4, 5. Participant-signal disambiguation (Step 3) is
+// deferred; the handler always lands on conflict_pending when 2+
+// calendar candidates match. Re-sync diff and the revive-on-tombstone
+// branch share the same code path.
 //
-// Returns (needsAttention, rejection): needsAttention is non-nil when
-// the final linkage_state requires user attention (conflict_pending or
-// orphan_needs_review). rejection != nil rolls back the savepoint.
+// Returns (needsAttention, followUps, rejection): needsAttention is
+// non-nil when the final linkage_state requires user attention
+// (conflict_pending or orphan_needs_review). followUps carries the
+// post-commit closures returned by RecordInteractionTx for the new
+// session-attributed interactions (so FollowUpManager fires after
+// the outer tx commits). rejection != nil rolls back the savepoint.
 func (s *IngestService) handleMeetingNoteRecorded(
 	ctx context.Context,
 	tx pgx.Tx,
 	env *events.Envelope,
 	authenticatedHostID uuid.UUID,
-) (*NeedsAttentionItem, *IngestPerEventRejection) {
+) (*NeedsAttentionItem, []func(context.Context), *IngestPerEventRejection) {
 	if s.meetingNotes == nil || s.calendar == nil || s.interactions == nil ||
 		s.identityLookup == nil || s.contactSvc == nil {
-		return nil, &IngestPerEventRejection{
+		return nil, nil, &IngestPerEventRejection{
 			Code:    ingestRejectPayloadInvariant,
 			Message: "ingest service was not configured for meeting_note processing",
 		}
 	}
 
+	// followUps accumulates post-commit closures returned by
+	// ContactService.RecordInteractionTx so the dispatch loop can run
+	// them after the outer tx commits. FollowUpManager updates
+	// contact_task rows + may schedule Todoist work; running it inside
+	// the tx would hold the lock across an external HTTP call.
+	var followUps []func(context.Context)
+
 	var p events.MeetingNoteRecordedPayload
 	if err := json.Unmarshal(env.Payload, &p); err != nil {
-		return nil, &IngestPerEventRejection{
+		return nil, nil, &IngestPerEventRejection{
 			Code:    ingestRejectPayloadInvalid,
 			Message: fmt.Sprintf("decode meeting_note.recorded payload: %s", err.Error()),
 		}
 	}
 	sessionID, parseErr := uuid.Parse(p.SourceID)
 	if parseErr != nil {
-		return nil, &IngestPerEventRejection{
+		return nil, nil, &IngestPerEventRejection{
 			Code:    ingestRejectPayloadInvalid,
 			Message: fmt.Sprintf("parse session UUID: %s", parseErr.Error()),
 		}
@@ -1690,7 +1741,7 @@ func (s *IngestService) handleMeetingNoteRecorded(
 	//    session UUID.
 	prior, getErr := s.meetingNotes.GetMeetingNoteBySessionIDForUpdateTx(ctx, tx, sessionID)
 	if getErr != nil && !errors.Is(getErr, db.ErrNotFound) {
-		return nil, &IngestPerEventRejection{
+		return nil, nil, &IngestPerEventRejection{
 			Code:    ingestRejectMeetingNoteUpsertFailed,
 			Message: fmt.Sprintf("pre-read meeting_note: %s", getErr.Error()),
 		}
@@ -1706,19 +1757,18 @@ func (s *IngestService) handleMeetingNoteRecorded(
 			Str("prior_host_id", prior.MacHostID.String()).
 			Str("authenticated_host_id", authenticatedHostID.String()).
 			Msg("meeting_note.recorded dropped: row owned by a different host")
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	// 3. Resolve tagged participants (anarlog_human UUIDs → CRM
 	//    contact_ids). Dedupe by contact_id so two anarlog humans
-	//    mapping to the same CRM contact produce ONE interaction
-	//    (round-1 P1#8 fix).
+	//    mapping to the same CRM contact produce ONE interaction.
 	resolvedTagged := make([]resolvedTag, 0, len(p.ParticipantIDs))
 	seenContactIDs := make(map[uuid.UUID]struct{}, len(p.ParticipantIDs))
 	for _, pid := range p.ParticipantIDs {
 		contactID, lookupErr := s.identityLookup.FindContactIDByAnarlogHumanIDTx(ctx, tx, pid)
 		if lookupErr != nil {
-			return nil, &IngestPerEventRejection{
+			return nil, nil, &IngestPerEventRejection{
 				Code:    ingestRejectParticipantResolveFailed,
 				Message: fmt.Sprintf("resolve participant %s: %s", pid, lookupErr.Error()),
 			}
@@ -1738,7 +1788,7 @@ func (s *IngestService) handleMeetingNoteRecorded(
 	//    contact_ids.
 	newInputHash, err := computeMeetingNoteInputHash(p.MeetingAt, p.Title, p.ParticipantIDs)
 	if err != nil {
-		return nil, &IngestPerEventRejection{
+		return nil, nil, &IngestPerEventRejection{
 			Code:    ingestRejectMeetingNoteUpsertFailed,
 			Message: fmt.Sprintf("compute input hash: %s", err.Error()),
 		}
@@ -1749,7 +1799,7 @@ func (s *IngestService) handleMeetingNoteRecorded(
 	}
 	newResolvedSetHash, err := computeResolvedSetHash(resolvedContactIDs)
 	if err != nil {
-		return nil, &IngestPerEventRejection{
+		return nil, nil, &IngestPerEventRejection{
 			Code:    ingestRejectMeetingNoteUpsertFailed,
 			Message: fmt.Sprintf("compute resolved set hash: %s", err.Error()),
 		}
@@ -1788,7 +1838,7 @@ func (s *IngestService) handleMeetingNoteRecorded(
 		windowEnd := p.MeetingAt.Add(linkageWindow)
 		candidates, candErr := s.calendar.FindLinkageCandidatesTx(ctx, tx, windowStart, windowEnd)
 		if candErr != nil {
-			return nil, &IngestPerEventRejection{
+			return nil, nil, &IngestPerEventRejection{
 				Code:    ingestRejectLinkageQueryFailed,
 				Message: fmt.Sprintf("find linkage candidates: %s", candErr.Error()),
 			}
@@ -1818,9 +1868,43 @@ func (s *IngestService) handleMeetingNoteRecorded(
 	switch {
 	case prior == nil:
 		if _, err := s.meetingNotes.InsertMeetingNoteTx(ctx, tx, params); err != nil {
-			return nil, &IngestPerEventRejection{
-				Code:    ingestRejectMeetingNoteUpsertFailed,
-				Message: fmt.Sprintf("insert meeting_note: %s", err.Error()),
+			if !errors.Is(err, db.ErrNotFound) {
+				return nil, nil, &IngestPerEventRejection{
+					Code:    ingestRejectMeetingNoteUpsertFailed,
+					Message: fmt.Sprintf("insert meeting_note: %s", err.Error()),
+				}
+			}
+			// Concurrent first-insert won the race against the partial
+			// unique index. Re-read the row (held with FOR UPDATE for
+			// the rest of this tx) and fall through to the update path
+			// so this event's content + linkage values land via UPDATE
+			// instead of erroring as PAYLOAD_INVARIANT.
+			racedRow, getErr := s.meetingNotes.GetMeetingNoteBySessionIDForUpdateTx(ctx, tx, sessionID)
+			if getErr != nil {
+				return nil, nil, &IngestPerEventRejection{
+					Code:    ingestRejectMeetingNoteUpsertFailed,
+					Message: fmt.Sprintf("re-read meeting_note after concurrent insert: %s", getErr.Error()),
+				}
+			}
+			updateParams := repository.UpdateMeetingNoteOnResyncParams{
+				ID:              racedRow.ID,
+				Title:           p.Title,
+				Summary:         p.Summary,
+				Memo:            p.Memo,
+				Participants:    p.ParticipantIDs,
+				LinkedKind:      finalLinkedKind,
+				LinkedID:        finalLinkedID,
+				LinkageState:    finalLinkageState,
+				InputHash:       newInputHash,
+				ResolvedSetHash: newResolvedSetHash,
+				LastContentHash: &contentHash,
+				MeetingAt:       p.MeetingAt,
+			}
+			if _, err := s.meetingNotes.UpdateMeetingNoteOnResyncTx(ctx, tx, updateParams); err != nil {
+				return nil, nil, &IngestPerEventRejection{
+					Code:    ingestRejectMeetingNoteUpsertFailed,
+					Message: fmt.Sprintf("update meeting_note after concurrent insert: %s", err.Error()),
+				}
 			}
 		}
 	case revivePath:
@@ -1839,7 +1923,7 @@ func (s *IngestService) handleMeetingNoteRecorded(
 			MeetingAt:       p.MeetingAt,
 		}
 		if _, err := s.meetingNotes.ReviveMeetingNoteTx(ctx, tx, reviveParams); err != nil {
-			return nil, &IngestPerEventRejection{
+			return nil, nil, &IngestPerEventRejection{
 				Code:    ingestRejectMeetingNoteUpsertFailed,
 				Message: fmt.Sprintf("revive meeting_note: %s", err.Error()),
 			}
@@ -1860,7 +1944,7 @@ func (s *IngestService) handleMeetingNoteRecorded(
 			MeetingAt:       p.MeetingAt,
 		}
 		if _, err := s.meetingNotes.UpdateMeetingNoteOnResyncTx(ctx, tx, updateParams); err != nil {
-			return nil, &IngestPerEventRejection{
+			return nil, nil, &IngestPerEventRejection{
 				Code:    ingestRejectMeetingNoteUpsertFailed,
 				Message: fmt.Sprintf("update meeting_note: %s", err.Error()),
 			}
@@ -1877,7 +1961,7 @@ func (s *IngestService) handleMeetingNoteRecorded(
 		sourceRefPrefix := fmt.Sprintf("anarlog:%s:%%", sessionID.String())
 		existing, listErr := s.interactions.ListSessionAttributedInteractionsTx(ctx, tx, sourceRefPrefix)
 		if listErr != nil {
-			return nil, &IngestPerEventRejection{
+			return nil, nil, &IngestPerEventRejection{
 				Code:    ingestRejectInteractionWriteFailed,
 				Message: fmt.Sprintf("list session-attributed interactions: %s", listErr.Error()),
 			}
@@ -1898,7 +1982,7 @@ func (s *IngestService) handleMeetingNoteRecorded(
 				continue
 			}
 			if err := s.interactions.SoftDeleteInteractionTx(ctx, tx, x.ID); err != nil {
-				return nil, &IngestPerEventRejection{
+				return nil, nil, &IngestPerEventRejection{
 					Code:    ingestRejectInteractionWriteFailed,
 					Message: fmt.Sprintf("soft-delete obsolete interaction: %s", err.Error()),
 				}
@@ -1910,8 +1994,34 @@ func (s *IngestService) handleMeetingNoteRecorded(
 				Msg("meeting_note re-sync soft-deleted obsolete session interaction")
 			interactionsDropped++
 		}
+		// in-both: existing source_ref still desired → refresh the
+		// content fields (occurred_at + description) when the payload
+		// changed so the timeline view reflects the latest meeting_at
+		// and title. Cadence updates are NOT re-applied here: the
+		// FindBySourceRefTx short-circuit inside RecordInteractionTx
+		// would return IsReplay=true on a re-INSERT anyway, and
+		// re-running cadence on a content-only edit would not change
+		// the result.
+		for ref, x := range existingByRef {
+			if _, want := desiredByRef[ref]; !want {
+				continue
+			}
+			needsRefresh := !x.OccurredAt.Equal(p.MeetingAt) ||
+				!stringPtrEqual(x.Description, p.Title)
+			if !needsRefresh {
+				continue
+			}
+			if _, err := s.interactions.UpdateInteractionTimestampTx(ctx, tx, x.ID, p.MeetingAt, p.Title); err != nil {
+				return nil, nil, &IngestPerEventRejection{
+					Code:    ingestRejectInteractionWriteFailed,
+					Message: fmt.Sprintf("refresh session interaction: %s", err.Error()),
+				}
+			}
+		}
 		// to_add = desired \ existing (route through ContactService so
-		// cadence + follow-up evaluation fire correctly — round-1 P1#2 fix).
+		// cadence + follow-up evaluation fire correctly). Capture the
+		// FollowUpFn closures so the dispatch loop can run them after
+		// the outer tx commits.
 		for ref, d := range desiredByRef {
 			if _, have := existingByRef[ref]; have {
 				continue
@@ -1925,17 +2035,23 @@ func (s *IngestService) handleMeetingNoteRecorded(
 				Description: p.Title,
 				Direction:   repository.InteractionDirectionMutual,
 			}
-			if _, err := s.contactSvc.RecordInteractionTx(ctx, tx, false, req); err != nil {
-				return nil, &IngestPerEventRejection{
+			res, err := s.contactSvc.RecordInteractionTx(ctx, tx, false, req)
+			if err != nil {
+				return nil, nil, &IngestPerEventRejection{
 					Code:    ingestRejectInteractionWriteFailed,
 					Message: fmt.Sprintf("record session interaction: %s", err.Error()),
 				}
+			}
+			if res != nil && res.FollowUpFn != nil {
+				followUps = append(followUps, res.FollowUpFn)
 			}
 			interactionsCreated++
 		}
 	}
 
-	// 8. Single-point needs_attention computation (round-1 P2#1).
+	// 8. Single-point needs_attention computation. The caller appends
+	//    this AFTER savepoint commit so a rollback path cannot leak an
+	//    item into the batch accumulator.
 	var needs *NeedsAttentionItem
 	switch finalLinkageState {
 	case repository.LinkageStateConflictPending:
@@ -1944,7 +2060,7 @@ func (s *IngestService) handleMeetingNoteRecorded(
 		needs = &NeedsAttentionItem{SessionID: p.SourceID, Reason: NeedsAttentionReasonOrphan}
 	}
 
-	// 9. Structured log line for observability (round-1 P2#4).
+	// 9. Structured log line for observability.
 	priorInputHash := ""
 	priorResolvedSetHash := ""
 	if prior != nil {
@@ -1977,13 +2093,13 @@ func (s *IngestService) handleMeetingNoteRecorded(
 		Bool("resolved_set_changed", priorResolvedSetHash != newResolvedSetHash).
 		Msg("meeting_note linkage decision")
 
-	return needs, nil
+	return needs, followUps, nil
 }
 
-// decideLinkage implements the spec's linkage-detection algorithm (Steps
-// 1, 2, 4, 5 — Step 3 disambiguation is PR 5). Returns the linkage
-// state, linked_kind/id pointers, and the desired session-attributed
-// interaction set.
+// decideLinkage implements the spec's linkage-detection algorithm
+// (Steps 1, 2, 4, 5 — participant-signal disambiguation is deferred).
+// Returns the linkage state, linked_kind/id pointers, and the desired
+// session-attributed interaction set.
 //
 //   - 0 candidates, no tagged humans → orphan_needs_review (no
 //     interactions).
@@ -1992,8 +2108,9 @@ func (s *IngestService) handleMeetingNoteRecorded(
 //   - 1 candidate → linked. Step 5 walk-in supplemental fires for each
 //     resolved tagged contact NOT already in the event's
 //     matched_contact_ids.
-//   - 2+ candidates → conflict_pending. PR 3 does NOT disambiguate;
-//     PR 5 introduces Step 3 participant-signal scoring.
+//   - 2+ candidates → conflict_pending. The current implementation
+//     never disambiguates; participant-signal scoring lands in a
+//     future revision.
 func decideLinkage(
 	p events.MeetingNoteRecordedPayload,
 	sessionID uuid.UUID,
@@ -2160,4 +2277,16 @@ func (s *IngestService) handleMeetingNoteDeleted(
 		}
 	}
 	return nil
+}
+
+// stringPtrEqual reports whether two *string pointers point to the
+// same string value (nil == nil; nil != "x").
+func stringPtrEqual(a, b *string) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
 }

--- a/backend/internal/service/ingest.go
+++ b/backend/internal/service/ingest.go
@@ -1684,11 +1684,10 @@ type desiredInteraction struct {
 // meeting_note.recorded envelope inside the per-event savepoint.
 //
 // Implements the full linkage-detection algorithm per
-// .ai/spec/mac-daemon-phase-2-anarlog-matching.md §Linkage detection
-// — Steps 1, 2, 4, 5. Participant-signal disambiguation (Step 3) is
-// deferred; the handler always lands on conflict_pending when 2+
-// calendar candidates match. Re-sync diff and the revive-on-tombstone
-// branch share the same code path.
+// .ai/spec/mac-daemon-phase-2-anarlog-matching.md §Linkage detection.
+// Participant-signal disambiguation is deferred; the handler always
+// lands on conflict_pending when 2+ calendar candidates match. Re-sync
+// diff and the revive-on-tombstone branch share the same code path.
 //
 // Returns (needsAttention, followUps, rejection): needsAttention is
 // non-nil when the final linkage_state requires user attention
@@ -2102,18 +2101,18 @@ func (s *IngestService) handleMeetingNoteRecorded(
 	return needs, followUps, nil
 }
 
-// decideLinkage implements the spec's linkage-detection algorithm
-// (Steps 1, 2, 4, 5 — participant-signal disambiguation is deferred).
-// Returns the linkage state, linked_kind/id pointers, and the desired
-// session-attributed interaction set.
+// decideLinkage implements the spec's linkage-detection algorithm.
+// Participant-signal disambiguation is deferred. Returns the linkage
+// state, linked_kind/id pointers, and the desired session-attributed
+// interaction set.
 //
 //   - 0 candidates, no tagged humans → orphan_needs_review (no
 //     interactions).
 //   - 0 candidates, ≥1 resolved tagged human → linked_impromptu (one
 //     interaction per resolved contact).
-//   - 1 candidate → linked. Step 5 walk-in supplemental fires for each
-//     resolved tagged contact NOT already in the event's
-//     matched_contact_ids.
+//   - 1 candidate → linked. A walk-in supplemental interaction is
+//     emitted for each resolved tagged contact NOT already in the
+//     event's matched_contact_ids.
 //   - 2+ candidates → conflict_pending. The current implementation
 //     never disambiguates; participant-signal scoring lands in a
 //     future revision.
@@ -2140,7 +2139,7 @@ func decideLinkage(
 		cand := candidates[0]
 		kind := cand.Kind
 		id := cand.ID
-		// Step 5 walk-in supplemental: per tagged contact NOT in event
+		// Walk-in supplemental: per tagged contact NOT in event
 		// attendees, add one walk-in interaction.
 		attendees := make(map[uuid.UUID]struct{}, len(cand.AttendeeContactIDs))
 		for _, aid := range cand.AttendeeContactIDs {

--- a/backend/internal/service/ingest.go
+++ b/backend/internal/service/ingest.go
@@ -1087,6 +1087,18 @@ func (s *IngestService) handleExternalContactUpserted(
 		external.MatchStatus == repository.MatchStatusUnmatched &&
 		external.DuplicateOfID == nil
 	matched := false
+	// matchedContactID tracks the CRM contact_id resolved by the
+	// email/phone match loops. The local `external` struct is from the
+	// initial UpsertTx and does NOT reflect the subsequent UpdateMatchTx
+	// write — capture the resolution separately so downstream logic
+	// (e.g., anarlog identity linking) sees the freshly-matched contact.
+	// On re-upsert / revive (canSetMatchOnRow=false) we fall back to the
+	// existing external.CRMContactID since that's the source of truth
+	// for the preserved match.
+	var matchedContactID *uuid.UUID
+	if external != nil && external.CRMContactID != nil {
+		matchedContactID = external.CRMContactID
+	}
 	for _, em := range p.Emails {
 		if em.Value == "" {
 			continue
@@ -1122,6 +1134,7 @@ func (s *IngestService) handleExternalContactUpserted(
 				}
 			}
 			matched = true
+			matchedContactID = result.ContactID
 		}
 	}
 	for _, ph := range p.Phones {
@@ -1158,6 +1171,7 @@ func (s *IngestService) handleExternalContactUpserted(
 				}
 			}
 			matched = true
+			matchedContactID = result.ContactID
 		}
 	}
 
@@ -1186,12 +1200,15 @@ func (s *IngestService) handleExternalContactUpserted(
 		// AND the new anarlog identity row is unmatched, link it.
 		// Defensive guards: only link when both sides have populated
 		// pointers AND the identity row is genuinely unmatched (avoid
-		// clobbering a manual link from a prior import).
-		if external != nil && external.CRMContactID != nil &&
+		// clobbering a manual link from a prior import). matchedContactID
+		// reflects the freshly-resolved contact from the email/phone
+		// loops above (the local external struct is stale across the
+		// UpdateMatchTx write).
+		if matchedContactID != nil &&
 			result != nil && result.Identity != nil && result.Identity.ContactID == nil {
 			if _, linkErr := s.identityLookup.LinkIdentityToContactTx(ctx, tx, repository.LinkIdentityRequest{
 				IdentityID: result.Identity.ID,
-				ContactID:  *external.CRMContactID,
+				ContactID:  *matchedContactID,
 				MatchType:  repository.MatchTypeExact,
 			}); linkErr != nil {
 				return &IngestPerEventRejection{

--- a/backend/internal/service/ingest.go
+++ b/backend/internal/service/ingest.go
@@ -197,13 +197,14 @@ type CalendarLinkageReader interface {
 }
 
 // InteractionWriter is the narrow surface for the re-sync diff path
-// (list session-attributed live interactions, soft-delete obsoletes,
-// refresh content fields when the payload changed) and the
-// meeting_note.deleted cascade. Concrete is *repository.InteractionRepository.
+// (list session-attributed live interactions, soft-delete obsoletes)
+// and the meeting_note.deleted cascade. Refreshes of existing
+// interactions go through ContactInteractionRecorder.ExtendInteractionTx
+// instead so cadence stays under the sole-writer invariant. Concrete
+// is *repository.InteractionRepository.
 type InteractionWriter interface {
 	ListSessionAttributedInteractionsTx(ctx context.Context, tx pgx.Tx, sourceRefPrefix string) ([]repository.Interaction, error)
 	SoftDeleteInteractionTx(ctx context.Context, tx pgx.Tx, id uuid.UUID) error
-	UpdateInteractionTimestampTx(ctx context.Context, tx pgx.Tx, id uuid.UUID, occurredAt time.Time, description *string) (*repository.Interaction, error)
 }
 
 // AnarlogIdentityLookup is the narrow surface used by the
@@ -220,10 +221,11 @@ type AnarlogIdentityLookup interface {
 
 // ContactInteractionRecorder is the narrow surface for routing
 // session-attributed interaction writes through the higher-level
-// ContactService.RecordInteractionTx (so cadence updates + follow-up
-// evaluation fire correctly). Concrete is *ContactService.
+// ContactService methods (so cadence updates + follow-up evaluation
+// fire correctly on both inserts and refreshes). Concrete is *ContactService.
 type ContactInteractionRecorder interface {
 	RecordInteractionTx(ctx context.Context, tx pgx.Tx, publishesEvent bool, req repository.RecordInteractionRequest) (*RecordInteractionResult, error)
+	ExtendInteractionTx(ctx context.Context, tx pgx.Tx, interactionID, contactID uuid.UUID, direction string, occurredAt time.Time, description *string) (func(context.Context), error)
 }
 
 // IngestService persists pre-validated event envelopes inside a single
@@ -1997,13 +1999,13 @@ func (s *IngestService) handleMeetingNoteRecorded(
 		// in-both: existing source_ref still desired → refresh the
 		// content fields (occurred_at + description) when the payload
 		// changed so the timeline view reflects the latest meeting_at
-		// and title. Cadence updates are NOT re-applied here: the
-		// FindBySourceRefTx short-circuit inside RecordInteractionTx
-		// would return IsReplay=true on a re-INSERT anyway, and
-		// re-running cadence on a content-only edit would not change
-		// the result.
-		for ref, x := range existingByRef {
-			if _, want := desiredByRef[ref]; !want {
+		// and title. Routes through ContactService.ExtendInteractionTx
+		// which re-applies cadence (last_contacted / contact_by) via
+		// the sole-writer path and returns a follow-up closure to run
+		// after commit — direct UPDATE would leave cadence stale.
+		for ref, d := range desiredByRef {
+			x, have := existingByRef[ref]
+			if !have {
 				continue
 			}
 			needsRefresh := !x.OccurredAt.Equal(p.MeetingAt) ||
@@ -2011,11 +2013,15 @@ func (s *IngestService) handleMeetingNoteRecorded(
 			if !needsRefresh {
 				continue
 			}
-			if _, err := s.interactions.UpdateInteractionTimestampTx(ctx, tx, x.ID, p.MeetingAt, p.Title); err != nil {
+			refreshFn, err := s.contactSvc.ExtendInteractionTx(ctx, tx, x.ID, d.ContactID, repository.InteractionDirectionMutual, p.MeetingAt, p.Title)
+			if err != nil {
 				return nil, nil, &IngestPerEventRejection{
 					Code:    ingestRejectInteractionWriteFailed,
 					Message: fmt.Sprintf("refresh session interaction: %s", err.Error()),
 				}
+			}
+			if refreshFn != nil {
+				followUps = append(followUps, refreshFn)
 			}
 		}
 		// to_add = desired \ existing (route through ContactService so

--- a/backend/internal/service/ingest.go
+++ b/backend/internal/service/ingest.go
@@ -5,10 +5,13 @@ package service
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -21,6 +24,7 @@ import (
 	"personal-crm/backend/internal/repository"
 
 	"github.com/google/uuid"
+	"github.com/gowebpki/jcs"
 	"github.com/jackc/pgx/v5"
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/rivertype"
@@ -42,6 +46,13 @@ const (
 	ingestRejectExternalContactDeleteFailed       = "EXTERNAL_CONTACT_DELETE_FAILED"
 	ingestRejectExternalContactHashMismatch       = "EXTERNAL_CONTACT_HASH_MISMATCH"
 	ingestRejectExternalContactDeleteHashMismatch = "EXTERNAL_CONTACT_DELETE_HASH_MISMATCH"
+	ingestRejectMeetingNoteUpsertFailed           = "MEETING_NOTE_UPSERT_FAILED"
+	ingestRejectMeetingNoteDeleteFailed           = "MEETING_NOTE_DELETE_FAILED"
+	ingestRejectMeetingNoteHashMismatch           = "MEETING_NOTE_HASH_MISMATCH"
+	ingestRejectMeetingNoteDeleteHashMismatch     = "MEETING_NOTE_DELETE_HASH_MISMATCH"
+	ingestRejectLinkageQueryFailed                = "LINKAGE_QUERY_FAILED"
+	ingestRejectParticipantResolveFailed          = "PARTICIPANT_RESOLVE_FAILED"
+	ingestRejectInteractionWriteFailed            = "INTERACTION_WRITE_FAILED"
 )
 
 // ErrHostRevokedDuringBatch is returned by IngestBatch when the
@@ -57,6 +68,15 @@ var ErrHostRevokedDuringBatch = errors.New("host revoked during ingest batch")
 // PAYLOAD_INVARIANT. Extend when a new daemon-side source ships.
 var allowedExternalContactSources = map[string]struct{}{
 	"icloud_contacts": {},
+	"anarlog_humans":  {},
+}
+
+// allowedMeetingNoteSources is the set of envelope.Source values the
+// meeting_note.* inline handler accepts. Currently only the
+// daemon-emitted anarlog_sessions source. Mismatches surface as
+// PAYLOAD_INVARIANT.
+var allowedMeetingNoteSources = map[string]struct{}{
+	"anarlog_sessions": {},
 }
 
 // reExternalContactUpsertSourceID matches the envelope SourceID shape
@@ -70,6 +90,22 @@ var reExternalContactUpsertSourceID = regexp.MustCompile(`^[^@]+@[a-f0-9]{64}$`)
 // `<entity_uuid>@deleted@<sha256-hex>` or `<entity_uuid>@deleted@unknown`.
 var reExternalContactDeleteSourceID = regexp.MustCompile(`^[^@]+@deleted@([a-f0-9]{64}|unknown)$`)
 
+// reMeetingNoteUpsertSourceID matches the envelope SourceID shape for
+// meeting_note.recorded events: `<session_uuid>@<sha256-hex>`. The
+// session-UUID portion is structurally checked by the regex; the
+// inline verifier additionally enforces it parses as a UUID.
+var reMeetingNoteUpsertSourceID = regexp.MustCompile(`^[^@]+@[a-f0-9]{64}$`)
+
+// reMeetingNoteDeleteSourceID matches the envelope SourceID shape for
+// meeting_note.deleted events: `<session_uuid>@deleted@<sha256-hex>` or
+// `<session_uuid>@deleted@unknown`.
+var reMeetingNoteDeleteSourceID = regexp.MustCompile(`^[^@]+@deleted@([a-f0-9]{64}|unknown)$`)
+
+// meetingNoteDeleteUnknownSuffix is the spec-defined fallback suffix
+// on meeting_note.deleted source_ids when the daemon has no local
+// cache of the prior content hash. Mirrors externalContactDeleteUnknownSuffix.
+const meetingNoteDeleteUnknownSuffix = "@deleted@unknown"
+
 // IngestPerEventRejection is a per-event domain rejection emitted by the
 // service-layer inline handlers. Index is the caller-original index from
 // originalIndices, NOT the compacted in-service position — so the HTTP
@@ -79,6 +115,25 @@ type IngestPerEventRejection struct {
 	Code    string
 	Message string
 }
+
+// NeedsAttentionItem is a service-layer record surfaced to the daemon
+// after a meeting_note.recorded event lands in a state that requires
+// user attention (conflict_pending or orphan_needs_review). The
+// dispatch loop appends one item per qualifying event AFTER the
+// per-event savepoint commits successfully — never on the rollback
+// path. The handler maps this to the HTTP response's needs_attention
+// field for the daemon to consume in PR 6.
+type NeedsAttentionItem struct {
+	SessionID string
+	Reason    string
+}
+
+// NeedsAttentionReason* are the canonical reason strings for
+// NeedsAttentionItem. The daemon pattern-matches on these in PR 6.
+const (
+	NeedsAttentionReasonConflict = "conflict"
+	NeedsAttentionReasonOrphan   = "orphan"
+)
 
 // JobInsertTxer is the narrow surface for transactional River inserts.
 // Concrete is *river.Client[pgx.Tx]. Interface keeps the service
@@ -123,6 +178,53 @@ type HostLivenessChecker interface {
 	GetActiveHostByIDForUpdateTx(ctx context.Context, tx pgx.Tx, id uuid.UUID) (*repository.MacHost, error)
 }
 
+// MeetingNoteWriter is the narrow surface for the meeting_note.*
+// inline handlers. Concrete is *repository.MeetingNoteRepository.
+type MeetingNoteWriter interface {
+	GetMeetingNoteBySessionIDForUpdateTx(ctx context.Context, tx pgx.Tx, sessionID uuid.UUID) (*repository.MeetingNote, error)
+	GetTombstonedMeetingNoteBySessionIDTx(ctx context.Context, tx pgx.Tx, sessionID uuid.UUID) (*repository.MeetingNote, error)
+	InsertMeetingNoteTx(ctx context.Context, tx pgx.Tx, params repository.InsertMeetingNoteParams) (*repository.MeetingNote, error)
+	UpdateMeetingNoteOnResyncTx(ctx context.Context, tx pgx.Tx, params repository.UpdateMeetingNoteOnResyncParams) (*repository.MeetingNote, error)
+	ReviveMeetingNoteTx(ctx context.Context, tx pgx.Tx, params repository.ReviveMeetingNoteParams) (*repository.MeetingNote, error)
+	SoftDeleteMeetingNoteBySessionIDTx(ctx context.Context, tx pgx.Tx, sessionID uuid.UUID) error
+}
+
+// CalendarLinkageReader is the narrow surface the meeting_note
+// handler needs to enumerate candidate calendar events in a time
+// window. Concrete is *repository.CalendarEventRepository.
+type CalendarLinkageReader interface {
+	FindLinkageCandidatesTx(ctx context.Context, tx pgx.Tx, windowStart, windowEnd time.Time) ([]repository.LinkageCandidate, error)
+}
+
+// InteractionWriter is the narrow surface for the re-sync diff path
+// (list session-attributed live interactions, soft-delete obsoletes)
+// and the meeting_note.deleted cascade. Concrete is
+// *repository.InteractionRepository.
+type InteractionWriter interface {
+	ListSessionAttributedInteractionsTx(ctx context.Context, tx pgx.Tx, sourceRefPrefix string) ([]repository.Interaction, error)
+	SoftDeleteInteractionTx(ctx context.Context, tx pgx.Tx, id uuid.UUID) error
+}
+
+// AnarlogIdentityLookup is the narrow surface used by the
+// meeting_note.recorded handler to resolve payload participant_ids
+// (anarlog_human UUIDs) into CRM contact_ids. Concrete is
+// *repository.IdentityRepository. Also covers the LinkTx variant used
+// by handleExternalContactUpserted to wire the anarlog identity row's
+// contact_id when the underlying external_contact's email/phone
+// resolved a contact.
+type AnarlogIdentityLookup interface {
+	FindContactIDByAnarlogHumanIDTx(ctx context.Context, tx pgx.Tx, anarlogHumanID string) (*uuid.UUID, error)
+	LinkIdentityToContactTx(ctx context.Context, tx pgx.Tx, req repository.LinkIdentityRequest) (*repository.ExternalIdentity, error)
+}
+
+// ContactInteractionRecorder is the narrow surface for routing
+// session-attributed interaction writes through the higher-level
+// ContactService.RecordInteractionTx (so cadence updates + follow-up
+// evaluation fire correctly). Concrete is *ContactService.
+type ContactInteractionRecorder interface {
+	RecordInteractionTx(ctx context.Context, tx pgx.Tx, publishesEvent bool, req repository.RecordInteractionRequest) (*RecordInteractionResult, error)
+}
+
 // IngestService persists pre-validated event envelopes inside a single
 // transaction. All envelopes in a batch commit together or roll back
 // together — spec §3.5 "all-or-nothing on unexpected errors."
@@ -146,6 +248,11 @@ type IngestService struct {
 	riverClient      JobInsertTxer
 	externalContacts ExternalContactWriter
 	hostLiveness     HostLivenessChecker
+	meetingNotes     MeetingNoteWriter
+	calendar         CalendarLinkageReader
+	interactions     InteractionWriter
+	identityLookup   AnarlogIdentityLookup
+	contactSvc       ContactInteractionRecorder
 }
 
 // NewIngestService builds an IngestService. Per-kind dependencies may
@@ -159,6 +266,11 @@ type IngestService struct {
 // batch trusts the auth-middleware's read. Production always wires a
 // concrete repository so the race window between auth and commit is
 // closed.
+//
+// meetingNotes/calendar/interactions/identityLookup/contactSvc are the
+// meeting_note.* inline handler's dependency set. Passing nil here is
+// supported for callers that don't need the meeting_note path; the
+// handler returns PAYLOAD_INVARIANT for missing wiring.
 func NewIngestService(
 	database *db.Database,
 	bus *events.Bus,
@@ -167,6 +279,11 @@ func NewIngestService(
 	riverClient JobInsertTxer,
 	externalContacts ExternalContactWriter,
 	hostLiveness HostLivenessChecker,
+	meetingNotes MeetingNoteWriter,
+	calendar CalendarLinkageReader,
+	interactions InteractionWriter,
+	identityLookup AnarlogIdentityLookup,
+	contactSvc ContactInteractionRecorder,
 ) *IngestService {
 	return &IngestService{
 		database:         database,
@@ -176,6 +293,11 @@ func NewIngestService(
 		riverClient:      riverClient,
 		externalContacts: externalContacts,
 		hostLiveness:     hostLiveness,
+		meetingNotes:     meetingNotes,
+		calendar:         calendar,
+		interactions:     interactions,
+		identityLookup:   identityLookup,
+		contactSvc:       contactSvc,
 	}
 }
 
@@ -193,6 +315,8 @@ var hostAuthAllowedKinds = map[events.Kind]struct{}{
 	events.KindRawMessageSent:          {},
 	events.KindExternalContactUpserted: {},
 	events.KindExternalContactDeleted:  {},
+	events.KindMeetingNoteRecorded:     {},
+	events.KindMeetingNoteDeleted:      {},
 }
 
 // isHostOnlyKind reports whether the kind is in the host-auth
@@ -220,6 +344,12 @@ func isExternalContactKind(k events.Kind) bool {
 	return k == events.KindExternalContactUpserted || k == events.KindExternalContactDeleted
 }
 
+// isMeetingNoteKind reports whether the kind is one of the
+// meeting_note.* daemon-emitted events.
+func isMeetingNoteKind(k events.Kind) bool {
+	return k == events.KindMeetingNoteRecorded || k == events.KindMeetingNoteDeleted
+}
+
 // pendingAggregateKey is the (source, contactID) pair used to dedupe
 // aggregator enqueues within a single batch.
 type pendingAggregateKey struct {
@@ -228,7 +358,7 @@ type pendingAggregateKey struct {
 }
 
 // IngestBatch persists envs in one pgx transaction. Returns
-// (accepted, duplicate, perEventRejections, err):
+// (accepted, duplicate, perEventRejections, needsAttention, err):
 //
 //   - accepted: number of envelopes whose INSERT produced a fresh row.
 //   - duplicate: number of envelopes whose INSERT hit the (source,
@@ -240,10 +370,14 @@ type pendingAggregateKey struct {
 //     caller-original position from originalIndices, so the handler can
 //     append them to the response's errors[] field with correct
 //     indexing.
+//   - needsAttention: meeting_note.recorded events whose final
+//     linkage_state requires user attention (conflict_pending or
+//     orphan_needs_review). Appended only after the per-event savepoint
+//     commits; nil when no qualifying events occurred.
 //   - err: any unexpected DB/infrastructure failure (begin-tx, publish-
 //     tx, savepoint commit, end-of-batch aggregator enqueue, outer
-//     commit). The whole tx rolls back in this case; counts are zero
-//     and perEventRejections is nil on error return.
+//     commit). The whole tx rolls back in this case; all return values
+//     are zero on error return.
 //
 // Precondition: every envelope MUST have env.ID == uuid.Nil on entry
 // (the env.ID-sentinel duplicate-detection contract relies on it).
@@ -260,22 +394,22 @@ func (s *IngestService) IngestBatch(
 	envs []*events.Envelope,
 	originalIndices []int,
 	hostID *uuid.UUID,
-) (accepted, duplicate int, perEventRejections []IngestPerEventRejection, err error) {
+) (accepted, duplicate int, perEventRejections []IngestPerEventRejection, needsAttention []NeedsAttentionItem, err error) {
 	if len(envs) == 0 {
-		return 0, 0, nil, nil
+		return 0, 0, nil, nil, nil
 	}
 	if len(originalIndices) != len(envs) {
-		return 0, 0, nil, fmt.Errorf(
+		return 0, 0, nil, nil, fmt.Errorf(
 			"ingest: originalIndices length %d does not match envs length %d",
 			len(originalIndices), len(envs))
 	}
 
 	for i, env := range envs {
 		if env == nil {
-			return 0, 0, nil, fmt.Errorf("ingest: envelope at index %d is nil", i)
+			return 0, 0, nil, nil, fmt.Errorf("ingest: envelope at index %d is nil", i)
 		}
 		if env.ID != uuid.Nil {
-			return 0, 0, nil, fmt.Errorf(
+			return 0, 0, nil, nil, fmt.Errorf(
 				"ingest: envelope at index %d has a pre-assigned ID; IngestBatch "+
 					"requires ID=uuid.Nil so the duplicate sentinel works", i)
 		}
@@ -283,7 +417,7 @@ func (s *IngestService) IngestBatch(
 
 	tx, err := s.database.Pool.Begin(ctx)
 	if err != nil {
-		return 0, 0, nil, fmt.Errorf("begin tx: %w", err)
+		return 0, 0, nil, nil, fmt.Errorf("begin tx: %w", err)
 	}
 	// Rollback on any non-commit return. Safe to call after Commit: pgx
 	// returns ErrTxClosed which we ignore. If rollback itself fails and no
@@ -308,9 +442,9 @@ func (s *IngestService) IngestBatch(
 	if hostID != nil && s.hostLiveness != nil {
 		if _, livenessErr := s.hostLiveness.GetActiveHostByIDForUpdateTx(ctx, tx, *hostID); livenessErr != nil {
 			if errors.Is(livenessErr, db.ErrNotFound) {
-				return 0, 0, nil, ErrHostRevokedDuringBatch
+				return 0, 0, nil, nil, ErrHostRevokedDuringBatch
 			}
-			return 0, 0, nil, fmt.Errorf("re-validate host liveness: %w", livenessErr)
+			return 0, 0, nil, nil, fmt.Errorf("re-validate host liveness: %w", livenessErr)
 		}
 	}
 
@@ -320,8 +454,9 @@ func (s *IngestService) IngestBatch(
 		originalIdx := originalIndices[i]
 
 		// Step 1 — host-auth allowlist enforcement.
-		//   * Host-only kinds (raw_message.*, external_contact.*) are
-		//     allowed ONLY on the host-auth path (hostID != nil).
+		//   * Host-only kinds (raw_message.*, external_contact.*,
+		//     meeting_note.*) are allowed ONLY on the host-auth path
+		//     (hostID != nil).
 		//   * Other kinds (Pi internal publishers) are allowed ONLY on
 		//     the global-key path (hostID == nil).
 		if hostID != nil {
@@ -329,7 +464,7 @@ func (s *IngestService) IngestBatch(
 				perEventRejections = append(perEventRejections, IngestPerEventRejection{
 					Index:   originalIdx,
 					Code:    ingestRejectUnsupportedHostAuthKind,
-					Message: fmt.Sprintf("kind %q not allowed on host-auth path; daemon only emits raw_message.* and external_contact.*", env.Kind),
+					Message: fmt.Sprintf("kind %q not allowed on host-auth path; daemon only emits raw_message.* / external_contact.* / meeting_note.*", env.Kind),
 				})
 				continue
 			}
@@ -359,6 +494,12 @@ func (s *IngestService) IngestBatch(
 				perEventRejections = append(perEventRejections, *rejection)
 				continue
 			}
+		} else if isMeetingNoteKind(env.Kind) {
+			if rejection := verifyMeetingNoteInvariants(env, *hostID); rejection != nil {
+				rejection.Index = originalIdx
+				perEventRejections = append(perEventRejections, *rejection)
+				continue
+			}
 		}
 
 		// Step 3 — open a savepoint so per-event domain failures roll
@@ -366,7 +507,7 @@ func (s *IngestService) IngestBatch(
 		// staging row) rather than poisoning the outer batch tx.
 		sp, spErr := tx.Begin(ctx)
 		if spErr != nil {
-			return 0, 0, nil, fmt.Errorf("begin savepoint for index %d (original %d): %w", i, originalIdx, spErr)
+			return 0, 0, nil, nil, fmt.Errorf("begin savepoint for index %d (original %d): %w", i, originalIdx, spErr)
 		}
 
 		// Step 4 — durable publish to event log. PublishTx is idempotent
@@ -380,22 +521,50 @@ func (s *IngestService) IngestBatch(
 		// to per-event rejection here.
 		if pubErr := s.bus.PublishTx(ctx, sp, env); pubErr != nil {
 			if rbErr := sp.Rollback(ctx); rbErr != nil {
-				return 0, 0, nil, fmt.Errorf("publish event index %d (original %d): %w (rollback: %v)", i, originalIdx, pubErr, rbErr)
+				return 0, 0, nil, nil, fmt.Errorf("publish event index %d (original %d): %w (rollback: %v)", i, originalIdx, pubErr, rbErr)
 			}
-			return 0, 0, nil, fmt.Errorf("publish event index %d (original %d): %w", i, originalIdx, pubErr)
+			return 0, 0, nil, nil, fmt.Errorf("publish event index %d (original %d): %w", i, originalIdx, pubErr)
 		}
 
 		isDuplicate := env.ID == uuid.Nil
 
 		// Step 5 — inline handler for daemon-emitted kinds. On
-		// duplicate (Step 4 detected a dedup hit) we SKIP the inline
-		// handler entirely: re-running identity-match + re-upserting
+		// duplicate (Step 4 detected a dedup hit) we normally SKIP the
+		// inline handler entirely: re-running identity-match + re-upserting
 		// staging on every duplicate would spuriously bump
 		// external_identity.last_seen_at and re-add the row to
 		// pendingAggregate (raw_message), or re-revive a row whose
 		// content hash hasn't actually changed (external_contact).
 		// The guard makes a duplicate re-submit a true no-op.
-		if !isDuplicate {
+		//
+		// Exception (round-1 P0#1 — delete-revive): for
+		// meeting_note.recorded the spec-defined source_id is
+		// `<session_uuid>@<content_hash>`. A tombstoned session that
+		// is later re-recorded with identical content produces the
+		// SAME source_id and hits the bus-dedup path — without the
+		// revive-bypass probe the inline handler is skipped and the
+		// row stays tombstoned. shouldRunInlineOnDuplicate runs a
+		// tombstone-probe before the skip and runs the handler when
+		// a tombstoned row exists.
+		runInline := !isDuplicate
+		if isDuplicate {
+			should, probeErr := s.shouldRunInlineOnDuplicate(ctx, sp, env)
+			if probeErr != nil {
+				if rbErr := sp.Rollback(ctx); rbErr != nil {
+					return 0, 0, nil, nil, fmt.Errorf("probe revive-bypass for index %d (original %d): %w (rollback: %v)", i, originalIdx, probeErr, rbErr)
+				}
+				return 0, 0, nil, nil, fmt.Errorf("probe revive-bypass for index %d (original %d): %w", i, originalIdx, probeErr)
+			}
+			runInline = should
+		}
+
+		// Per-event optional accumulator items. Captured during the
+		// handler's run and appended to the batch-level slice ONLY
+		// after the savepoint commits — never on the rollback path
+		// (round-1 P2#1 single-point append).
+		var pendingNA *NeedsAttentionItem
+
+		if runInline {
 			switch {
 			case isRawMessageKind(env.Kind):
 				contactID, rejection := s.handleRawMessage(ctx, sp, env, *hostID)
@@ -403,7 +572,7 @@ func (s *IngestService) IngestBatch(
 					rejection.Index = originalIdx
 					perEventRejections = append(perEventRejections, *rejection)
 					if rbErr := sp.Rollback(ctx); rbErr != nil {
-						return 0, 0, nil, fmt.Errorf("rollback savepoint for rejected index %d (original %d): %w", i, originalIdx, rbErr)
+						return 0, 0, nil, nil, fmt.Errorf("rollback savepoint for rejected index %d (original %d): %w", i, originalIdx, rbErr)
 					}
 					continue
 				}
@@ -415,7 +584,7 @@ func (s *IngestService) IngestBatch(
 					rejection.Index = originalIdx
 					perEventRejections = append(perEventRejections, *rejection)
 					if rbErr := sp.Rollback(ctx); rbErr != nil {
-						return 0, 0, nil, fmt.Errorf("rollback savepoint for rejected index %d (original %d): %w", i, originalIdx, rbErr)
+						return 0, 0, nil, nil, fmt.Errorf("rollback savepoint for rejected index %d (original %d): %w", i, originalIdx, rbErr)
 					}
 					continue
 				}
@@ -424,7 +593,27 @@ func (s *IngestService) IngestBatch(
 					rejection.Index = originalIdx
 					perEventRejections = append(perEventRejections, *rejection)
 					if rbErr := sp.Rollback(ctx); rbErr != nil {
-						return 0, 0, nil, fmt.Errorf("rollback savepoint for rejected index %d (original %d): %w", i, originalIdx, rbErr)
+						return 0, 0, nil, nil, fmt.Errorf("rollback savepoint for rejected index %d (original %d): %w", i, originalIdx, rbErr)
+					}
+					continue
+				}
+			case env.Kind == events.KindMeetingNoteRecorded:
+				naItem, rejection := s.handleMeetingNoteRecorded(ctx, sp, env, *hostID)
+				if rejection != nil {
+					rejection.Index = originalIdx
+					perEventRejections = append(perEventRejections, *rejection)
+					if rbErr := sp.Rollback(ctx); rbErr != nil {
+						return 0, 0, nil, nil, fmt.Errorf("rollback savepoint for rejected index %d (original %d): %w", i, originalIdx, rbErr)
+					}
+					continue
+				}
+				pendingNA = naItem
+			case env.Kind == events.KindMeetingNoteDeleted:
+				if rejection := s.handleMeetingNoteDeleted(ctx, sp, env, *hostID); rejection != nil {
+					rejection.Index = originalIdx
+					perEventRejections = append(perEventRejections, *rejection)
+					if rbErr := sp.Rollback(ctx); rbErr != nil {
+						return 0, 0, nil, nil, fmt.Errorf("rollback savepoint for rejected index %d (original %d): %w", i, originalIdx, rbErr)
 					}
 					continue
 				}
@@ -432,7 +621,12 @@ func (s *IngestService) IngestBatch(
 		}
 
 		if commitErr := sp.Commit(ctx); commitErr != nil {
-			return 0, 0, nil, fmt.Errorf("commit savepoint %d (original %d): %w", i, originalIdx, commitErr)
+			return 0, 0, nil, nil, fmt.Errorf("commit savepoint %d (original %d): %w", i, originalIdx, commitErr)
+		}
+
+		// Post-commit: append the per-event needs_attention item, if any.
+		if pendingNA != nil {
+			needsAttention = append(needsAttention, *pendingNA)
 		}
 
 		if isDuplicate {
@@ -460,15 +654,15 @@ func (s *IngestService) IngestBatch(
 		if _, insErr := s.riverClient.InsertTx(ctx, tx, args, &river.InsertOpts{
 			UniqueOpts: consumerjobs.MessagingAggregateUniqueOpts(),
 		}); insErr != nil {
-			return 0, 0, nil, fmt.Errorf("enqueue messaging aggregate (contact=%s source=%s): %w",
+			return 0, 0, nil, nil, fmt.Errorf("enqueue messaging aggregate (contact=%s source=%s): %w",
 				pair.ContactID, pair.Source, insErr)
 		}
 	}
 
 	if commitErr := tx.Commit(ctx); commitErr != nil {
-		return 0, 0, nil, fmt.Errorf("commit: %w", commitErr)
+		return 0, 0, nil, nil, fmt.Errorf("commit: %w", commitErr)
 	}
-	return accepted, duplicate, perEventRejections, nil
+	return accepted, duplicate, perEventRejections, needsAttention, nil
 }
 
 // handleRawMessage runs the per-event domain logic for raw_message.*
@@ -1138,4 +1332,773 @@ func toRepoAddressEntries(in []events.ExternalContactAddressValue) []repository.
 		})
 	}
 	return out
+}
+
+// verifyMeetingNoteInvariants enforces the cross-field consistency
+// properties for meeting_note.* envelopes. Returns a
+// *IngestPerEventRejection (caller fills in Index) on any violation,
+// nil on success.
+//
+// Properties checked (mirrors verifyExternalContactInvariants):
+//  1. payload decodes cleanly into the per-kind struct.
+//  2. payload.HostID matches the authenticated host.
+//  3. env.Source is in allowedMeetingNoteSources.
+//  4. payload.Source matches env.Source.
+//  5. payload.SourceID parses as a UUID.
+//  6. env.SourceID matches the kind's content-hash discriminator shape
+//     AND its entity prefix matches payload.SourceID.
+//  7. For upsert: recompute SHA-256(JCS(payload \ {host_id})) and assert
+//     it equals the 64-char hex suffix on env.SourceID. Mismatch is
+//     MEETING_NOTE_HASH_MISMATCH (delete uses the stored-hash lookup
+//     path inside the handler — same convention as external_contact).
+func verifyMeetingNoteInvariants(env *events.Envelope, authenticatedHostID uuid.UUID) *IngestPerEventRejection {
+	switch env.Kind {
+	case events.KindMeetingNoteRecorded:
+		var p events.MeetingNoteRecordedPayload
+		if err := json.Unmarshal(env.Payload, &p); err != nil {
+			return &IngestPerEventRejection{
+				Code:    ingestRejectPayloadInvalid,
+				Message: fmt.Sprintf("decode meeting_note.recorded payload: %s", err.Error()),
+			}
+		}
+		if rej := commonMeetingNoteInvariants(env, authenticatedHostID, p.HostID, p.Source, p.SourceID); rej != nil {
+			return rej
+		}
+		if !reMeetingNoteUpsertSourceID.MatchString(env.SourceID) {
+			return &IngestPerEventRejection{
+				Code:    ingestRejectPayloadInvariant,
+				Message: "meeting_note.recorded source_id must match <session_uuid>@<sha256-hex>",
+			}
+		}
+		if !strings.HasPrefix(env.SourceID, p.SourceID+"@") {
+			return &IngestPerEventRejection{
+				Code:    ingestRejectPayloadInvariant,
+				Message: "meeting_note.recorded source_id entity prefix does not match payload source_id",
+			}
+		}
+		computedHash, hashErr := ComputeContentHash(env.Payload)
+		if hashErr != nil {
+			return &IngestPerEventRejection{
+				Code:    ingestRejectPayloadInvalid,
+				Message: fmt.Sprintf("compute content hash: %s", hashErr.Error()),
+			}
+		}
+		claimedHash := env.SourceID[len(env.SourceID)-64:]
+		if computedHash != claimedHash {
+			return &IngestPerEventRejection{
+				Code:    ingestRejectMeetingNoteHashMismatch,
+				Message: fmt.Sprintf("source_id hash %s does not match computed JCS hash %s", claimedHash, computedHash),
+			}
+		}
+		return nil
+	case events.KindMeetingNoteDeleted:
+		var p events.MeetingNoteDeletedPayload
+		if err := json.Unmarshal(env.Payload, &p); err != nil {
+			return &IngestPerEventRejection{
+				Code:    ingestRejectPayloadInvalid,
+				Message: fmt.Sprintf("decode meeting_note.deleted payload: %s", err.Error()),
+			}
+		}
+		if rej := commonMeetingNoteInvariants(env, authenticatedHostID, p.HostID, p.Source, p.SourceID); rej != nil {
+			return rej
+		}
+		if !reMeetingNoteDeleteSourceID.MatchString(env.SourceID) {
+			return &IngestPerEventRejection{
+				Code:    ingestRejectPayloadInvariant,
+				Message: "meeting_note.deleted source_id must match <session_uuid>@deleted@<sha256-hex|unknown>",
+			}
+		}
+		if !strings.HasPrefix(env.SourceID, p.SourceID+"@deleted@") {
+			return &IngestPerEventRejection{
+				Code:    ingestRejectPayloadInvariant,
+				Message: "meeting_note.deleted source_id entity prefix does not match payload source_id",
+			}
+		}
+		return nil
+	default:
+		return &IngestPerEventRejection{
+			Code:    ingestRejectPayloadInvariant,
+			Message: fmt.Sprintf("verifyMeetingNoteInvariants: unexpected kind %q", env.Kind),
+		}
+	}
+}
+
+// commonMeetingNoteInvariants enforces the host/source/source_id
+// checks shared by both meeting_note.* kinds.
+func commonMeetingNoteInvariants(
+	env *events.Envelope,
+	authenticatedHostID uuid.UUID,
+	payloadHostID uuid.UUID,
+	payloadSource string,
+	payloadSourceID string,
+) *IngestPerEventRejection {
+	if payloadHostID != authenticatedHostID {
+		return &IngestPerEventRejection{
+			Code:    ingestRejectPayloadInvariant,
+			Message: "payload host_id does not match authenticated host",
+		}
+	}
+	if _, ok := allowedMeetingNoteSources[env.Source]; !ok {
+		return &IngestPerEventRejection{
+			Code:    ingestRejectPayloadInvariant,
+			Message: fmt.Sprintf("env.source %q not supported on meeting_note.* kinds", env.Source),
+		}
+	}
+	if payloadSource != env.Source {
+		return &IngestPerEventRejection{
+			Code:    ingestRejectPayloadInvariant,
+			Message: "payload source does not match envelope source",
+		}
+	}
+	if payloadSourceID == "" {
+		return &IngestPerEventRejection{
+			Code:    ingestRejectPayloadInvariant,
+			Message: "payload source_id is required",
+		}
+	}
+	if _, err := uuid.Parse(payloadSourceID); err != nil {
+		return &IngestPerEventRejection{
+			Code:    ingestRejectPayloadInvariant,
+			Message: fmt.Sprintf("payload source_id %q is not a UUID", payloadSourceID),
+		}
+	}
+	return nil
+}
+
+// linkageWindow is the symmetric ± window around payload.MeetingAt that
+// FindLinkageCandidatesTx searches for calendar (and future phone_call)
+// rows. 15 minutes per sidecar spec §Linkage detection algorithm.
+const linkageWindow = 15 * time.Minute
+
+// shouldRunInlineOnDuplicate is the revive-bypass probe used by the
+// dispatch loop. It returns true when the duplicate event MUST still
+// run the inline handler because the underlying row is tombstoned and
+// needs revive consideration (round-1 P0#1 — delete-revive for
+// meeting_note.recorded with identical content). For all other kinds
+// returns false (the existing "skip duplicates" semantics apply).
+//
+// The probe is bounded: it only runs when env.Kind ==
+// KindMeetingNoteRecorded AND meetingNotes is wired. Other duplicate
+// events skip the inline handler unchanged, preserving the
+// external_contact "duplicate is a true no-op" contract.
+func (s *IngestService) shouldRunInlineOnDuplicate(ctx context.Context, tx pgx.Tx, env *events.Envelope) (bool, error) {
+	if env.Kind != events.KindMeetingNoteRecorded || s.meetingNotes == nil {
+		return false, nil
+	}
+	var p events.MeetingNoteRecordedPayload
+	if err := json.Unmarshal(env.Payload, &p); err != nil {
+		// Decode failure here is unexpected — the dispatch loop already
+		// ran verifyMeetingNoteInvariants which decodes successfully.
+		// Surface as an error so the batch rolls back.
+		return false, fmt.Errorf("revive-bypass probe: decode payload: %w", err)
+	}
+	sessionID, parseErr := uuid.Parse(p.SourceID)
+	if parseErr != nil {
+		return false, fmt.Errorf("revive-bypass probe: parse session UUID: %w", parseErr)
+	}
+	_, err := s.meetingNotes.GetTombstonedMeetingNoteBySessionIDTx(ctx, tx, sessionID)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, db.ErrNotFound) {
+		return false, nil
+	}
+	return false, fmt.Errorf("revive-bypass probe: lookup tombstoned row: %w", err)
+}
+
+// meetingNoteInputHashRecipe is the canonical (meeting_at, title,
+// sorted participant_ids) tuple that the inline handler hashes to
+// detect "matching inputs changed" on re-sync.
+type meetingNoteInputHashRecipe struct {
+	MeetingAt      string   `json:"meeting_at"`
+	Title          *string  `json:"title"`
+	ParticipantIDs []string `json:"participant_ids"`
+}
+
+// computeMeetingNoteInputHash returns the lowercase-hex SHA-256 of a
+// stable canonicalization of (meeting_at, title, sorted participant_ids).
+// Title is included so PR 4's title-parser does not have to migrate
+// hashes. Summary and memo are intentionally excluded — they're content
+// fields, not matching inputs.
+func computeMeetingNoteInputHash(meetingAt time.Time, title *string, participantIDs []string) (string, error) {
+	sorted := append([]string(nil), participantIDs...)
+	sort.Strings(sorted)
+	recipe := meetingNoteInputHashRecipe{
+		MeetingAt:      meetingAt.UTC().Format(time.RFC3339Nano),
+		Title:          title,
+		ParticipantIDs: sorted,
+	}
+	raw, err := json.Marshal(recipe)
+	if err != nil {
+		return "", fmt.Errorf("marshal input hash recipe: %w", err)
+	}
+	canonical, err := jcs.Transform(raw)
+	if err != nil {
+		return "", fmt.Errorf("jcs canonicalize input hash recipe: %w", err)
+	}
+	sum := sha256.Sum256(canonical)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// computeResolvedSetHash returns the lowercase-hex SHA-256 of a
+// stable canonicalization of the resolved contact-UUID set. Used to
+// detect when participant→contact resolution changes between events
+// for the same session (e.g., after a user imports a previously-
+// unmatched anarlog_humans candidate).
+func computeResolvedSetHash(contactIDs []uuid.UUID) (string, error) {
+	strs := make([]string, len(contactIDs))
+	for i, id := range contactIDs {
+		strs[i] = id.String()
+	}
+	sort.Strings(strs)
+	raw, err := json.Marshal(strs)
+	if err != nil {
+		return "", fmt.Errorf("marshal resolved set: %w", err)
+	}
+	canonical, err := jcs.Transform(raw)
+	if err != nil {
+		return "", fmt.Errorf("jcs canonicalize resolved set: %w", err)
+	}
+	sum := sha256.Sum256(canonical)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// resolvedTag is the (anarlog_human_id, contact_id) pair produced by
+// the participant-resolution step. The handler deduplicates by
+// contact_id so two anarlog humans mapping to the same CRM contact
+// produce exactly one interaction.
+type resolvedTag struct {
+	AnarlogID string
+	ContactID uuid.UUID
+}
+
+// desiredInteraction is a single (contact_id, source_ref) pair the
+// linkage logic decided should be persisted. Computed before the
+// re-sync diff so we can compare against the existing set.
+type desiredInteraction struct {
+	ContactID uuid.UUID
+	SourceRef string
+}
+
+// handleMeetingNoteRecorded runs the per-event domain logic for a
+// meeting_note.recorded envelope inside the per-event savepoint.
+//
+// Implements the full linkage-detection algorithm per
+// .ai/spec/mac-daemon-phase-2-anarlog-matching.md §Linkage detection
+// (Steps 1, 2, 4, 5 — Step 3 disambiguation is PR 5). Re-sync diff and
+// the revive-on-tombstone branch share the same code path.
+//
+// Returns (needsAttention, rejection): needsAttention is non-nil when
+// the final linkage_state requires user attention (conflict_pending or
+// orphan_needs_review). rejection != nil rolls back the savepoint.
+func (s *IngestService) handleMeetingNoteRecorded(
+	ctx context.Context,
+	tx pgx.Tx,
+	env *events.Envelope,
+	authenticatedHostID uuid.UUID,
+) (*NeedsAttentionItem, *IngestPerEventRejection) {
+	if s.meetingNotes == nil || s.calendar == nil || s.interactions == nil ||
+		s.identityLookup == nil || s.contactSvc == nil {
+		return nil, &IngestPerEventRejection{
+			Code:    ingestRejectPayloadInvariant,
+			Message: "ingest service was not configured for meeting_note processing",
+		}
+	}
+
+	var p events.MeetingNoteRecordedPayload
+	if err := json.Unmarshal(env.Payload, &p); err != nil {
+		return nil, &IngestPerEventRejection{
+			Code:    ingestRejectPayloadInvalid,
+			Message: fmt.Sprintf("decode meeting_note.recorded payload: %s", err.Error()),
+		}
+	}
+	sessionID, parseErr := uuid.Parse(p.SourceID)
+	if parseErr != nil {
+		return nil, &IngestPerEventRejection{
+			Code:    ingestRejectPayloadInvalid,
+			Message: fmt.Sprintf("parse session UUID: %s", parseErr.Error()),
+		}
+	}
+
+	// content hash from envelope source_id (already verified upstream
+	// by verifyMeetingNoteInvariants → ComputeContentHash match).
+	contentHash := env.SourceID[len(env.SourceID)-64:]
+	payloadHostID := p.HostID
+	_ = payloadHostID // referenced for clarity in payload→insert mapping
+
+	// 1. Acquire row lock + read existing meeting_note row (tombstone-
+	//    aware). FOR UPDATE serializes concurrent re-syncs for the same
+	//    session UUID.
+	prior, getErr := s.meetingNotes.GetMeetingNoteBySessionIDForUpdateTx(ctx, tx, sessionID)
+	if getErr != nil && !errors.Is(getErr, db.ErrNotFound) {
+		return nil, &IngestPerEventRejection{
+			Code:    ingestRejectMeetingNoteUpsertFailed,
+			Message: fmt.Sprintf("pre-read meeting_note: %s", getErr.Error()),
+		}
+	}
+
+	// 2. Host-ownership guard. Mirrors handleExternalContactDeleted.
+	//    Non-NULL stored host_id that differs from authenticated host →
+	//    warn-log + silent no-op (rejection nil, needs_attention nil).
+	if prior != nil && prior.MacHostID != nil && *prior.MacHostID != authenticatedHostID {
+		logger.Warn().
+			Str("source", env.Source).
+			Str("session_id", p.SourceID).
+			Str("prior_host_id", prior.MacHostID.String()).
+			Str("authenticated_host_id", authenticatedHostID.String()).
+			Msg("meeting_note.recorded dropped: row owned by a different host")
+		return nil, nil
+	}
+
+	// 3. Resolve tagged participants (anarlog_human UUIDs → CRM
+	//    contact_ids). Dedupe by contact_id so two anarlog humans
+	//    mapping to the same CRM contact produce ONE interaction
+	//    (round-1 P1#8 fix).
+	resolvedTagged := make([]resolvedTag, 0, len(p.ParticipantIDs))
+	seenContactIDs := make(map[uuid.UUID]struct{}, len(p.ParticipantIDs))
+	for _, pid := range p.ParticipantIDs {
+		contactID, lookupErr := s.identityLookup.FindContactIDByAnarlogHumanIDTx(ctx, tx, pid)
+		if lookupErr != nil {
+			return nil, &IngestPerEventRejection{
+				Code:    ingestRejectParticipantResolveFailed,
+				Message: fmt.Sprintf("resolve participant %s: %s", pid, lookupErr.Error()),
+			}
+		}
+		if contactID == nil {
+			continue
+		}
+		if _, dup := seenContactIDs[*contactID]; dup {
+			continue
+		}
+		seenContactIDs[*contactID] = struct{}{}
+		resolvedTagged = append(resolvedTagged, resolvedTag{AnarlogID: pid, ContactID: *contactID})
+	}
+
+	// 4. Compute hashes. Stable order: input hash uses sorted
+	//    participant_ids; resolved-set hash uses sorted resolved
+	//    contact_ids.
+	newInputHash, err := computeMeetingNoteInputHash(p.MeetingAt, p.Title, p.ParticipantIDs)
+	if err != nil {
+		return nil, &IngestPerEventRejection{
+			Code:    ingestRejectMeetingNoteUpsertFailed,
+			Message: fmt.Sprintf("compute input hash: %s", err.Error()),
+		}
+	}
+	resolvedContactIDs := make([]uuid.UUID, len(resolvedTagged))
+	for i, r := range resolvedTagged {
+		resolvedContactIDs[i] = r.ContactID
+	}
+	newResolvedSetHash, err := computeResolvedSetHash(resolvedContactIDs)
+	if err != nil {
+		return nil, &IngestPerEventRejection{
+			Code:    ingestRejectMeetingNoteUpsertFailed,
+			Message: fmt.Sprintf("compute resolved set hash: %s", err.Error()),
+		}
+	}
+
+	// 5. Decide the branch:
+	//    a) prior == nil          → first-insert (run linkage + insert).
+	//    b) prior tombstoned      → revive (run linkage + revive update).
+	//    c) prior live, hashes
+	//       unchanged            → carry-forward (update content fields only).
+	//    d) prior live, any hash
+	//       changed              → re-link (run linkage + diff interactions).
+	revivePath := prior != nil && prior.DeletedAt != nil
+	carryForward := prior != nil && !revivePath &&
+		prior.InputHash == newInputHash &&
+		prior.ResolvedSetHash == newResolvedSetHash
+
+	var (
+		finalLinkageState   string
+		finalLinkedKind     *string
+		finalLinkedID       *uuid.UUID
+		desired             []desiredInteraction
+		candidatesLen       int
+		interactionsCreated int
+		interactionsDropped int
+	)
+
+	if carryForward {
+		// Preserve prior linkage. No interaction writes.
+		finalLinkageState = prior.LinkageState
+		finalLinkedKind = prior.LinkedKind
+		finalLinkedID = prior.LinkedID
+	} else {
+		// First-insert, revive, or re-link → run linkage fresh.
+		windowStart := p.MeetingAt.Add(-linkageWindow)
+		windowEnd := p.MeetingAt.Add(linkageWindow)
+		candidates, candErr := s.calendar.FindLinkageCandidatesTx(ctx, tx, windowStart, windowEnd)
+		if candErr != nil {
+			return nil, &IngestPerEventRejection{
+				Code:    ingestRejectLinkageQueryFailed,
+				Message: fmt.Sprintf("find linkage candidates: %s", candErr.Error()),
+			}
+		}
+		candidatesLen = len(candidates)
+		finalLinkageState, finalLinkedKind, finalLinkedID, desired = decideLinkage(p, sessionID, candidates, resolvedTagged)
+	}
+
+	// 6. Write meeting_note row. Branch on first-insert / revive /
+	//    carry-forward / re-link. The repository params are nearly
+	//    identical across branches; only the destination method differs.
+	params := repository.InsertMeetingNoteParams{
+		AnarlogSessionID: sessionID,
+		Title:            p.Title,
+		Summary:          p.Summary,
+		Memo:             p.Memo,
+		Participants:     p.ParticipantIDs,
+		MacHostID:        &authenticatedHostID,
+		LinkedKind:       finalLinkedKind,
+		LinkedID:         finalLinkedID,
+		LinkageState:     finalLinkageState,
+		InputHash:        newInputHash,
+		ResolvedSetHash:  newResolvedSetHash,
+		LastContentHash:  &contentHash,
+		MeetingAt:        p.MeetingAt,
+	}
+	switch {
+	case prior == nil:
+		if _, err := s.meetingNotes.InsertMeetingNoteTx(ctx, tx, params); err != nil {
+			return nil, &IngestPerEventRejection{
+				Code:    ingestRejectMeetingNoteUpsertFailed,
+				Message: fmt.Sprintf("insert meeting_note: %s", err.Error()),
+			}
+		}
+	case revivePath:
+		reviveParams := repository.ReviveMeetingNoteParams{
+			ID:              prior.ID,
+			Title:           p.Title,
+			Summary:         p.Summary,
+			Memo:            p.Memo,
+			Participants:    p.ParticipantIDs,
+			LinkedKind:      finalLinkedKind,
+			LinkedID:        finalLinkedID,
+			LinkageState:    finalLinkageState,
+			InputHash:       newInputHash,
+			ResolvedSetHash: newResolvedSetHash,
+			LastContentHash: &contentHash,
+			MeetingAt:       p.MeetingAt,
+		}
+		if _, err := s.meetingNotes.ReviveMeetingNoteTx(ctx, tx, reviveParams); err != nil {
+			return nil, &IngestPerEventRejection{
+				Code:    ingestRejectMeetingNoteUpsertFailed,
+				Message: fmt.Sprintf("revive meeting_note: %s", err.Error()),
+			}
+		}
+	default:
+		updateParams := repository.UpdateMeetingNoteOnResyncParams{
+			ID:              prior.ID,
+			Title:           p.Title,
+			Summary:         p.Summary,
+			Memo:            p.Memo,
+			Participants:    p.ParticipantIDs,
+			LinkedKind:      finalLinkedKind,
+			LinkedID:        finalLinkedID,
+			LinkageState:    finalLinkageState,
+			InputHash:       newInputHash,
+			ResolvedSetHash: newResolvedSetHash,
+			LastContentHash: &contentHash,
+			MeetingAt:       p.MeetingAt,
+		}
+		if _, err := s.meetingNotes.UpdateMeetingNoteOnResyncTx(ctx, tx, updateParams); err != nil {
+			return nil, &IngestPerEventRejection{
+				Code:    ingestRejectMeetingNoteUpsertFailed,
+				Message: fmt.Sprintf("update meeting_note: %s", err.Error()),
+			}
+		}
+	}
+
+	// 7. Apply interaction writes — carry-forward path skips both
+	//    sides; first-insert/revive insert the full desired set;
+	//    re-link diffs against the existing live set and adds/drops
+	//    accordingly. Calendar/phone-call interactions are NEVER
+	//    touched here — we filter by source='anarlog_sessions' +
+	//    source_ref prefix.
+	if !carryForward {
+		sourceRefPrefix := fmt.Sprintf("anarlog:%s:%%", sessionID.String())
+		existing, listErr := s.interactions.ListSessionAttributedInteractionsTx(ctx, tx, sourceRefPrefix)
+		if listErr != nil {
+			return nil, &IngestPerEventRejection{
+				Code:    ingestRejectInteractionWriteFailed,
+				Message: fmt.Sprintf("list session-attributed interactions: %s", listErr.Error()),
+			}
+		}
+		existingByRef := make(map[string]repository.Interaction, len(existing))
+		for _, x := range existing {
+			if x.SourceRef != nil {
+				existingByRef[*x.SourceRef] = x
+			}
+		}
+		desiredByRef := make(map[string]desiredInteraction, len(desired))
+		for _, d := range desired {
+			desiredByRef[d.SourceRef] = d
+		}
+		// to_drop = existing \ desired
+		for ref, x := range existingByRef {
+			if _, want := desiredByRef[ref]; want {
+				continue
+			}
+			if err := s.interactions.SoftDeleteInteractionTx(ctx, tx, x.ID); err != nil {
+				return nil, &IngestPerEventRejection{
+					Code:    ingestRejectInteractionWriteFailed,
+					Message: fmt.Sprintf("soft-delete obsolete interaction: %s", err.Error()),
+				}
+			}
+			logger.Warn().
+				Str("event", "session_re_sync_dropped").
+				Str("session_id", p.SourceID).
+				Str("source_ref", ref).
+				Msg("meeting_note re-sync soft-deleted obsolete session interaction")
+			interactionsDropped++
+		}
+		// to_add = desired \ existing (route through ContactService so
+		// cadence + follow-up evaluation fire correctly — round-1 P1#2 fix).
+		for ref, d := range desiredByRef {
+			if _, have := existingByRef[ref]; have {
+				continue
+			}
+			sourceRef := d.SourceRef
+			req := repository.RecordInteractionRequest{
+				ContactID:   d.ContactID,
+				Source:      repository.InteractionSourceAnarlogSessions,
+				SourceRef:   &sourceRef,
+				OccurredAt:  p.MeetingAt,
+				Description: p.Title,
+				Direction:   repository.InteractionDirectionMutual,
+			}
+			if _, err := s.contactSvc.RecordInteractionTx(ctx, tx, false, req); err != nil {
+				return nil, &IngestPerEventRejection{
+					Code:    ingestRejectInteractionWriteFailed,
+					Message: fmt.Sprintf("record session interaction: %s", err.Error()),
+				}
+			}
+			interactionsCreated++
+		}
+	}
+
+	// 8. Single-point needs_attention computation (round-1 P2#1).
+	var needs *NeedsAttentionItem
+	switch finalLinkageState {
+	case repository.LinkageStateConflictPending:
+		needs = &NeedsAttentionItem{SessionID: p.SourceID, Reason: NeedsAttentionReasonConflict}
+	case repository.LinkageStateOrphanNeedsReview:
+		needs = &NeedsAttentionItem{SessionID: p.SourceID, Reason: NeedsAttentionReasonOrphan}
+	}
+
+	// 9. Structured log line for observability (round-1 P2#4).
+	priorInputHash := ""
+	priorResolvedSetHash := ""
+	if prior != nil {
+		priorInputHash = prior.InputHash
+		priorResolvedSetHash = prior.ResolvedSetHash
+	}
+	linkedKindStr := ""
+	linkedIDStr := ""
+	if finalLinkedKind != nil {
+		linkedKindStr = *finalLinkedKind
+	}
+	if finalLinkedID != nil {
+		linkedIDStr = finalLinkedID.String()
+	}
+	logger.Info().
+		Str("event", "linkage_decision").
+		Str("session_id", p.SourceID).
+		Int("candidates", candidatesLen).
+		Str("linkage_state", finalLinkageState).
+		Str("linked_kind", linkedKindStr).
+		Str("linked_id", linkedIDStr).
+		Int("tagged_total", len(p.ParticipantIDs)).
+		Int("tagged_resolved", len(resolvedTagged)).
+		Int("tagged_unresolved", len(p.ParticipantIDs)-len(resolvedTagged)).
+		Int("interactions_created", interactionsCreated).
+		Int("interactions_dropped", interactionsDropped).
+		Bool("revive_path", revivePath).
+		Bool("carry_forward", carryForward).
+		Bool("input_hash_changed", priorInputHash != newInputHash).
+		Bool("resolved_set_changed", priorResolvedSetHash != newResolvedSetHash).
+		Msg("meeting_note linkage decision")
+
+	return needs, nil
+}
+
+// decideLinkage implements the spec's linkage-detection algorithm (Steps
+// 1, 2, 4, 5 — Step 3 disambiguation is PR 5). Returns the linkage
+// state, linked_kind/id pointers, and the desired session-attributed
+// interaction set.
+//
+//   - 0 candidates, no tagged humans → orphan_needs_review (no
+//     interactions).
+//   - 0 candidates, ≥1 resolved tagged human → linked_impromptu (one
+//     interaction per resolved contact).
+//   - 1 candidate → linked. Step 5 walk-in supplemental fires for each
+//     resolved tagged contact NOT already in the event's
+//     matched_contact_ids.
+//   - 2+ candidates → conflict_pending. PR 3 does NOT disambiguate;
+//     PR 5 introduces Step 3 participant-signal scoring.
+func decideLinkage(
+	p events.MeetingNoteRecordedPayload,
+	sessionID uuid.UUID,
+	candidates []repository.LinkageCandidate,
+	resolvedTagged []resolvedTag,
+) (state string, linkedKind *string, linkedID *uuid.UUID, desired []desiredInteraction) {
+	switch len(candidates) {
+	case 0:
+		if len(resolvedTagged) == 0 {
+			return repository.LinkageStateOrphanNeedsReview, nil, nil, nil
+		}
+		out := make([]desiredInteraction, 0, len(resolvedTagged))
+		for _, r := range resolvedTagged {
+			out = append(out, desiredInteraction{
+				ContactID: r.ContactID,
+				SourceRef: fmt.Sprintf("anarlog:%s:%s", sessionID.String(), r.ContactID.String()),
+			})
+		}
+		return repository.LinkageStateLinkedImpromptu, nil, nil, out
+	case 1:
+		cand := candidates[0]
+		kind := cand.Kind
+		id := cand.ID
+		// Step 5 walk-in supplemental: per tagged contact NOT in event
+		// attendees, add one walk-in interaction.
+		attendees := make(map[uuid.UUID]struct{}, len(cand.AttendeeContactIDs))
+		for _, aid := range cand.AttendeeContactIDs {
+			attendees[aid] = struct{}{}
+		}
+		walkins := make([]desiredInteraction, 0)
+		for _, r := range resolvedTagged {
+			if _, present := attendees[r.ContactID]; present {
+				continue
+			}
+			walkins = append(walkins, desiredInteraction{
+				ContactID: r.ContactID,
+				SourceRef: fmt.Sprintf("anarlog:%s:walkin:%s", sessionID.String(), r.ContactID.String()),
+			})
+		}
+		return repository.LinkageStateLinked, &kind, &id, walkins
+	default:
+		return repository.LinkageStateConflictPending, nil, nil, nil
+	}
+}
+
+// handleMeetingNoteDeleted runs the per-event domain logic for a
+// meeting_note.deleted envelope inside the per-event savepoint.
+//
+// Behavior:
+//   - Unknown session → silent no-op (event-log row preserved).
+//   - Already tombstoned → idempotent no-op.
+//   - Host-ownership mismatch → warn-log + silent no-op (mirrors
+//     handleExternalContactDeleted at service/ingest.go:1037).
+//   - Live row + hash-mismatch (and not @unknown sentinel, and stored
+//     hash non-NULL) → MEETING_NOTE_DELETE_HASH_MISMATCH.
+//   - Live row → soft-delete all session-attributed interactions
+//     (source='anarlog_sessions' AND source_ref LIKE 'anarlog:<sid>:%')
+//     and soft-delete the meeting_note row. The interaction cascade is
+//     explicit because UPDATE deleted_at does NOT trigger ON DELETE
+//     CASCADE (CLAUDE.md gotcha).
+func (s *IngestService) handleMeetingNoteDeleted(
+	ctx context.Context,
+	tx pgx.Tx,
+	env *events.Envelope,
+	authenticatedHostID uuid.UUID,
+) *IngestPerEventRejection {
+	if s.meetingNotes == nil || s.interactions == nil {
+		return &IngestPerEventRejection{
+			Code:    ingestRejectPayloadInvariant,
+			Message: "ingest service was not configured for meeting_note processing",
+		}
+	}
+
+	var p events.MeetingNoteDeletedPayload
+	if err := json.Unmarshal(env.Payload, &p); err != nil {
+		return &IngestPerEventRejection{
+			Code:    ingestRejectPayloadInvalid,
+			Message: fmt.Sprintf("decode meeting_note.deleted payload: %s", err.Error()),
+		}
+	}
+	sessionID, parseErr := uuid.Parse(p.SourceID)
+	if parseErr != nil {
+		return &IngestPerEventRejection{
+			Code:    ingestRejectPayloadInvalid,
+			Message: fmt.Sprintf("parse session UUID: %s", parseErr.Error()),
+		}
+	}
+
+	prior, getErr := s.meetingNotes.GetMeetingNoteBySessionIDForUpdateTx(ctx, tx, sessionID)
+	if getErr != nil {
+		if errors.Is(getErr, db.ErrNotFound) {
+			// Unknown session — silent no-op.
+			return nil
+		}
+		return &IngestPerEventRejection{
+			Code:    ingestRejectMeetingNoteDeleteFailed,
+			Message: fmt.Sprintf("pre-read meeting_note: %s", getErr.Error()),
+		}
+	}
+	if prior == nil || prior.DeletedAt != nil {
+		// Already tombstoned. Idempotent no-op.
+		return nil
+	}
+
+	// Host-ownership guard. Mirrors handleExternalContactDeleted.
+	if prior.MacHostID != nil && *prior.MacHostID != authenticatedHostID {
+		logger.Warn().
+			Str("source", env.Source).
+			Str("session_id", p.SourceID).
+			Str("prior_host_id", prior.MacHostID.String()).
+			Str("authenticated_host_id", authenticatedHostID.String()).
+			Msg("meeting_note.deleted dropped: row owned by a different host")
+		return nil
+	}
+
+	// Hash-mismatch check (same three exceptions as
+	// handleExternalContactDeleted: @unknown sentinel, NULL stored
+	// hash, already-tombstoned — handled above).
+	if !strings.HasSuffix(env.SourceID, meetingNoteDeleteUnknownSuffix) && prior.LastContentHash != nil {
+		claimed := env.SourceID[len(env.SourceID)-64:]
+		if *prior.LastContentHash != claimed {
+			return &IngestPerEventRejection{
+				Code: ingestRejectMeetingNoteDeleteHashMismatch,
+				Message: fmt.Sprintf(
+					"delete source_id hash %s does not match stored last_content_hash %s for session %s",
+					claimed, *prior.LastContentHash, p.SourceID),
+			}
+		}
+	}
+
+	// Cascade soft-delete to session-attributed interactions. UPDATE
+	// deleted_at does NOT trigger ON DELETE CASCADE — must do this
+	// explicitly (CLAUDE.md gotcha).
+	sourceRefPrefix := fmt.Sprintf("anarlog:%s:%%", sessionID.String())
+	existing, listErr := s.interactions.ListSessionAttributedInteractionsTx(ctx, tx, sourceRefPrefix)
+	if listErr != nil {
+		return &IngestPerEventRejection{
+			Code:    ingestRejectMeetingNoteDeleteFailed,
+			Message: fmt.Sprintf("list session-attributed interactions: %s", listErr.Error()),
+		}
+	}
+	for _, ix := range existing {
+		if err := s.interactions.SoftDeleteInteractionTx(ctx, tx, ix.ID); err != nil {
+			return &IngestPerEventRejection{
+				Code:    ingestRejectMeetingNoteDeleteFailed,
+				Message: fmt.Sprintf("soft-delete session interaction: %s", err.Error()),
+			}
+		}
+		ref := ""
+		if ix.SourceRef != nil {
+			ref = *ix.SourceRef
+		}
+		logger.Warn().
+			Str("event", "session_tombstoned").
+			Str("session_id", p.SourceID).
+			Str("source_ref", ref).
+			Msg("meeting_note tombstoned cascaded soft-delete to session interaction")
+	}
+
+	if err := s.meetingNotes.SoftDeleteMeetingNoteBySessionIDTx(ctx, tx, sessionID); err != nil {
+		return &IngestPerEventRejection{
+			Code:    ingestRejectMeetingNoteDeleteFailed,
+			Message: fmt.Sprintf("soft-delete meeting_note: %s", err.Error()),
+		}
+	}
+	return nil
 }

--- a/backend/internal/service/ingest_test.go
+++ b/backend/internal/service/ingest_test.go
@@ -996,7 +996,7 @@ func TestVerifyMeetingNoteInvariants_NonUUIDSourceID(t *testing.T) {
 	// runs the service-side check for defense-in-depth.
 	p := events.MeetingNoteRecordedPayload{
 		Version: 1, HostID: host, Source: "anarlog_sessions",
-		SourceID: "not-a-uuid", MeetingAt: time.Now(),
+		SourceID: "not-a-uuid", MeetingAt: accelerated.GetCurrentTime(),
 	}
 	pBytes, err := events.Marshal(events.KindMeetingNoteRecorded, p)
 	require.NoError(t, err)
@@ -1116,7 +1116,7 @@ func TestDecideLinkage_OneCandidate_WalkinPresent_NoSupplement(t *testing.T) {
 	cand := repository.LinkageCandidate{
 		Kind:               "event",
 		ID:                 uuid.New(),
-		OccurredAt:         time.Now(),
+		OccurredAt:         accelerated.GetCurrentTime(),
 		AttendeeContactIDs: []uuid.UUID{cA},
 	}
 	resolved := []resolvedTag{{AnarlogID: "human-a", ContactID: cA}}

--- a/backend/internal/service/ingest_test.go
+++ b/backend/internal/service/ingest_test.go
@@ -3,7 +3,9 @@ package service
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
+	"time"
 
 	"personal-crm/backend/internal/accelerated"
 	"personal-crm/backend/internal/db"
@@ -22,18 +24,20 @@ import (
 // pool, so the test proves the short-circuit works.
 func TestIngestService_EmptyBatch_FastPath(t *testing.T) {
 	svc := &IngestService{} // no DB, no bus — fast path must not touch them
-	accepted, duplicate, rejections, err := svc.IngestBatch(context.Background(), nil, nil, nil)
+	accepted, duplicate, rejections, needsAttention, err := svc.IngestBatch(context.Background(), nil, nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, 0, accepted)
 	require.Equal(t, 0, duplicate)
 	require.Empty(t, rejections)
+	require.Empty(t, needsAttention)
 
 	// Same for an explicit zero-length slice.
-	accepted, duplicate, rejections, err = svc.IngestBatch(context.Background(), []*events.Envelope{}, []int{}, nil)
+	accepted, duplicate, rejections, needsAttention, err = svc.IngestBatch(context.Background(), []*events.Envelope{}, []int{}, nil)
 	require.NoError(t, err)
 	require.Equal(t, 0, accepted)
 	require.Equal(t, 0, duplicate)
 	require.Empty(t, rejections)
+	require.Empty(t, needsAttention)
 }
 
 // TestIngestService_RejectsNilEnvelope guards against a caller bug where
@@ -41,7 +45,7 @@ func TestIngestService_EmptyBatch_FastPath(t *testing.T) {
 // inside the publish loop once a transaction is open.
 func TestIngestService_RejectsNilEnvelope(t *testing.T) {
 	svc := &IngestService{} // precondition check fires before DB access
-	_, _, _, err := svc.IngestBatch(context.Background(), []*events.Envelope{nil}, []int{0}, nil)
+	_, _, _, _, err := svc.IngestBatch(context.Background(), []*events.Envelope{nil}, []int{0}, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "envelope at index 0 is nil")
 }
@@ -54,7 +58,7 @@ func TestIngestService_RejectsNilEnvelope(t *testing.T) {
 func TestIngestService_RejectsPreAssignedID(t *testing.T) {
 	svc := &IngestService{} // precondition check fires before DB access
 	env := &events.Envelope{ID: uuid.New()}
-	_, _, _, err := svc.IngestBatch(context.Background(), []*events.Envelope{env}, []int{0}, nil)
+	_, _, _, _, err := svc.IngestBatch(context.Background(), []*events.Envelope{env}, []int{0}, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "pre-assigned ID")
 }
@@ -65,7 +69,7 @@ func TestIngestService_RejectsPreAssignedID(t *testing.T) {
 func TestIngestService_RejectsLenMismatchOnOriginalIndices(t *testing.T) {
 	svc := &IngestService{}
 	env := &events.Envelope{} // valid (uuid.Nil)
-	_, _, _, err := svc.IngestBatch(context.Background(), []*events.Envelope{env}, []int{0, 1}, nil)
+	_, _, _, _, err := svc.IngestBatch(context.Background(), []*events.Envelope{env}, []int{0, 1}, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "originalIndices length")
 }
@@ -322,7 +326,7 @@ func TestVerifyExternalContactInvariants_HostMismatch(t *testing.T) {
 func TestVerifyExternalContactInvariants_SourceMismatch(t *testing.T) {
 	host := uuid.New()
 	env := validUpsertedEnv(host, "CN-1")
-	env.Source = "anarlog_humans"
+	env.Source = "gcontacts" // not in allowedExternalContactSources
 	rej := verifyExternalContactInvariants(env, host)
 	require.NotNil(t, rej)
 	require.Contains(t, rej.Message, "not supported")
@@ -920,4 +924,244 @@ func (r *recordingExternalContactWriter) UpsertTx(
 	cp := req
 	r.lastUpsert = &cp
 	return r.stubExternalContactWriter.UpsertTx(ctx, tx, req)
+}
+
+// ----------------------------------------------------------------------------
+// meeting_note.* invariant + helper unit tests
+// ----------------------------------------------------------------------------
+
+// TestIsMeetingNoteKind exercises the kind-classifier helper.
+func TestIsMeetingNoteKind(t *testing.T) {
+	require.True(t, isMeetingNoteKind(events.KindMeetingNoteRecorded))
+	require.True(t, isMeetingNoteKind(events.KindMeetingNoteDeleted))
+	require.False(t, isMeetingNoteKind(events.KindExternalContactUpserted))
+	require.False(t, isMeetingNoteKind(events.KindMessageReceived))
+}
+
+// validMeetingNoteRecordedEnv constructs a structurally-valid envelope
+// for verifyMeetingNoteInvariants tests. The content hash is computed
+// per the canonical recipe so the verifier's hash check passes.
+func validMeetingNoteRecordedEnv(t *testing.T, host uuid.UUID, sessionUUID string) *events.Envelope {
+	t.Helper()
+	title := "Test Session"
+	p := events.MeetingNoteRecordedPayload{
+		Version:   1,
+		HostID:    host,
+		Source:    "anarlog_sessions",
+		SourceID:  sessionUUID,
+		Title:     &title,
+		MeetingAt: time.Date(2026, 5, 1, 14, 30, 0, 0, time.UTC),
+	}
+	pBytes, err := events.Marshal(events.KindMeetingNoteRecorded, p)
+	require.NoError(t, err)
+	hashHex, err := ComputeContentHash(pBytes)
+	require.NoError(t, err)
+	return &events.Envelope{
+		Source:   "anarlog_sessions",
+		SourceID: sessionUUID + "@" + hashHex,
+		Kind:     events.KindMeetingNoteRecorded,
+		Payload:  pBytes,
+	}
+}
+
+func TestVerifyMeetingNoteInvariants_HappyPath(t *testing.T) {
+	host := uuid.New()
+	env := validMeetingNoteRecordedEnv(t, host, uuid.NewString())
+	require.Nil(t, verifyMeetingNoteInvariants(env, host))
+}
+
+func TestVerifyMeetingNoteInvariants_HostMismatch(t *testing.T) {
+	authHost := uuid.New()
+	otherHost := uuid.New()
+	env := validMeetingNoteRecordedEnv(t, otherHost, uuid.NewString())
+	rej := verifyMeetingNoteInvariants(env, authHost)
+	require.NotNil(t, rej)
+	require.Equal(t, ingestRejectPayloadInvariant, rej.Code)
+	require.Contains(t, rej.Message, "host_id")
+}
+
+func TestVerifyMeetingNoteInvariants_SourceMismatch(t *testing.T) {
+	host := uuid.New()
+	env := validMeetingNoteRecordedEnv(t, host, uuid.NewString())
+	env.Source = "icloud_contacts" // not in allowedMeetingNoteSources
+	rej := verifyMeetingNoteInvariants(env, host)
+	require.NotNil(t, rej)
+	require.Contains(t, rej.Message, "not supported")
+}
+
+func TestVerifyMeetingNoteInvariants_NonUUIDSourceID(t *testing.T) {
+	host := uuid.New()
+	// Hand-craft payload with non-UUID source_id; ValidatePayload would
+	// also catch this at the handler boundary, but verifyMeetingNoteInvariants
+	// runs the service-side check for defense-in-depth.
+	p := events.MeetingNoteRecordedPayload{
+		Version: 1, HostID: host, Source: "anarlog_sessions",
+		SourceID: "not-a-uuid", MeetingAt: time.Now(),
+	}
+	pBytes, err := events.Marshal(events.KindMeetingNoteRecorded, p)
+	require.NoError(t, err)
+	env := &events.Envelope{Source: "anarlog_sessions", SourceID: "not-a-uuid@" + strings.Repeat("a", 64),
+		Kind: events.KindMeetingNoteRecorded, Payload: pBytes}
+	rej := verifyMeetingNoteInvariants(env, host)
+	require.NotNil(t, rej)
+	require.Contains(t, rej.Message, "not a UUID")
+}
+
+func TestVerifyMeetingNoteInvariants_HashMismatch(t *testing.T) {
+	host := uuid.New()
+	env := validMeetingNoteRecordedEnv(t, host, uuid.NewString())
+	// Tamper with the source_id hash suffix while keeping the regex shape.
+	tampered := env.SourceID[:len(env.SourceID)-64] + strings.Repeat("0", 64)
+	env.SourceID = tampered
+	rej := verifyMeetingNoteInvariants(env, host)
+	require.NotNil(t, rej)
+	require.Equal(t, ingestRejectMeetingNoteHashMismatch, rej.Code)
+}
+
+func TestVerifyMeetingNoteInvariants_DeleteAcceptsUnknownSentinel(t *testing.T) {
+	host := uuid.New()
+	sessionUUID := uuid.NewString()
+	p := events.MeetingNoteDeletedPayload{
+		Version: 1, HostID: host, Source: "anarlog_sessions", SourceID: sessionUUID,
+	}
+	pBytes, err := events.Marshal(events.KindMeetingNoteDeleted, p)
+	require.NoError(t, err)
+	env := &events.Envelope{Source: "anarlog_sessions", SourceID: sessionUUID + "@deleted@unknown",
+		Kind: events.KindMeetingNoteDeleted, Payload: pBytes}
+	require.Nil(t, verifyMeetingNoteInvariants(env, host))
+}
+
+// TestComputeMeetingNoteInputHash_StableAcrossOrder confirms that the
+// input hash is invariant under participant_id order — sorting happens
+// inside the recipe.
+func TestComputeMeetingNoteInputHash_StableAcrossOrder(t *testing.T) {
+	at := time.Date(2026, 5, 1, 14, 30, 0, 0, time.UTC)
+	title := "Same Title"
+	a := []string{"uuid-1", "uuid-2", "uuid-3"}
+	b := []string{"uuid-3", "uuid-1", "uuid-2"}
+	hashA, err := computeMeetingNoteInputHash(at, &title, a)
+	require.NoError(t, err)
+	hashB, err := computeMeetingNoteInputHash(at, &title, b)
+	require.NoError(t, err)
+	require.Equal(t, hashA, hashB)
+}
+
+// TestComputeMeetingNoteInputHash_TitleAffectsHash confirms the title
+// is part of the recipe — PR 4's title-parser does not have to
+// migrate hashes (round-1 P1#3 fix).
+func TestComputeMeetingNoteInputHash_TitleAffectsHash(t *testing.T) {
+	at := time.Date(2026, 5, 1, 14, 30, 0, 0, time.UTC)
+	ids := []string{"uuid-1"}
+	a := "Alpha"
+	b := "Bravo"
+	hashA, err := computeMeetingNoteInputHash(at, &a, ids)
+	require.NoError(t, err)
+	hashB, err := computeMeetingNoteInputHash(at, &b, ids)
+	require.NoError(t, err)
+	require.NotEqual(t, hashA, hashB)
+}
+
+// TestComputeResolvedSetHash_StableAcrossOrder confirms order
+// independence for the resolved-contact-id set hash.
+func TestComputeResolvedSetHash_StableAcrossOrder(t *testing.T) {
+	id1 := uuid.New()
+	id2 := uuid.New()
+	id3 := uuid.New()
+	hashA, err := computeResolvedSetHash([]uuid.UUID{id1, id2, id3})
+	require.NoError(t, err)
+	hashB, err := computeResolvedSetHash([]uuid.UUID{id3, id1, id2})
+	require.NoError(t, err)
+	require.Equal(t, hashA, hashB)
+}
+
+// TestDecideLinkage_NoCandidatesNoTagged returns orphan_needs_review
+// with no interactions.
+func TestDecideLinkage_NoCandidatesNoTagged(t *testing.T) {
+	sessionID := uuid.New()
+	state, kind, id, desired := decideLinkage(events.MeetingNoteRecordedPayload{}, sessionID, nil, nil)
+	require.Equal(t, repository.LinkageStateOrphanNeedsReview, state)
+	require.Nil(t, kind)
+	require.Nil(t, id)
+	require.Empty(t, desired)
+}
+
+// TestDecideLinkage_NoCandidatesWithTagged returns linked_impromptu and
+// one interaction per resolved tagged contact.
+func TestDecideLinkage_NoCandidatesWithTagged(t *testing.T) {
+	sessionID := uuid.New()
+	cA := uuid.New()
+	cB := uuid.New()
+	resolved := []resolvedTag{
+		{AnarlogID: "human-a", ContactID: cA},
+		{AnarlogID: "human-b", ContactID: cB},
+	}
+	state, kind, id, desired := decideLinkage(events.MeetingNoteRecordedPayload{}, sessionID, nil, resolved)
+	require.Equal(t, repository.LinkageStateLinkedImpromptu, state)
+	require.Nil(t, kind)
+	require.Nil(t, id)
+	require.Len(t, desired, 2)
+	refA := "anarlog:" + sessionID.String() + ":" + cA.String()
+	refB := "anarlog:" + sessionID.String() + ":" + cB.String()
+	gotRefs := []string{desired[0].SourceRef, desired[1].SourceRef}
+	require.Contains(t, gotRefs, refA)
+	require.Contains(t, gotRefs, refB)
+}
+
+// TestDecideLinkage_OneCandidate_WalkinPresent_NoSupplement verifies
+// that a tagged contact already in the event's matched_contact_ids
+// does NOT produce a walk-in interaction.
+func TestDecideLinkage_OneCandidate_WalkinPresent_NoSupplement(t *testing.T) {
+	sessionID := uuid.New()
+	cA := uuid.New()
+	cand := repository.LinkageCandidate{
+		Kind:               "event",
+		ID:                 uuid.New(),
+		OccurredAt:         time.Now(),
+		AttendeeContactIDs: []uuid.UUID{cA},
+	}
+	resolved := []resolvedTag{{AnarlogID: "human-a", ContactID: cA}}
+	state, kind, id, desired := decideLinkage(events.MeetingNoteRecordedPayload{}, sessionID, []repository.LinkageCandidate{cand}, resolved)
+	require.Equal(t, repository.LinkageStateLinked, state)
+	require.NotNil(t, kind)
+	require.Equal(t, "event", *kind)
+	require.NotNil(t, id)
+	require.Equal(t, cand.ID, *id)
+	require.Empty(t, desired, "tagged contact already in event attendees → no walk-in")
+}
+
+// TestDecideLinkage_OneCandidate_TaggedNotInAttendees_AddsWalkin
+// fires Step 5 walk-in supplemental for the missing contact.
+func TestDecideLinkage_OneCandidate_TaggedNotInAttendees_AddsWalkin(t *testing.T) {
+	sessionID := uuid.New()
+	cA := uuid.New() // in attendees
+	cB := uuid.New() // tagged but NOT in attendees → walk-in
+	cand := repository.LinkageCandidate{
+		Kind:               "event",
+		ID:                 uuid.New(),
+		AttendeeContactIDs: []uuid.UUID{cA},
+	}
+	resolved := []resolvedTag{{AnarlogID: "human-b", ContactID: cB}}
+	state, kind, _, desired := decideLinkage(events.MeetingNoteRecordedPayload{}, sessionID, []repository.LinkageCandidate{cand}, resolved)
+	require.Equal(t, repository.LinkageStateLinked, state)
+	require.Equal(t, "event", *kind)
+	require.Len(t, desired, 1)
+	expectedRef := "anarlog:" + sessionID.String() + ":walkin:" + cB.String()
+	require.Equal(t, expectedRef, desired[0].SourceRef)
+	require.Equal(t, cB, desired[0].ContactID)
+}
+
+// TestDecideLinkage_MultipleCandidates_ConflictPending verifies PR 3
+// always lands on conflict_pending for 2+ candidates (Step 3
+// disambiguation is PR 5).
+func TestDecideLinkage_MultipleCandidates_ConflictPending(t *testing.T) {
+	sessionID := uuid.New()
+	cands := []repository.LinkageCandidate{
+		{Kind: "event", ID: uuid.New()},
+		{Kind: "event", ID: uuid.New()},
+	}
+	state, kind, id, desired := decideLinkage(events.MeetingNoteRecordedPayload{}, sessionID, cands, nil)
+	require.Equal(t, repository.LinkageStateConflictPending, state)
+	require.Nil(t, kind)
+	require.Nil(t, id)
+	require.Empty(t, desired)
 }

--- a/backend/internal/service/ingest_test.go
+++ b/backend/internal/service/ingest_test.go
@@ -1047,8 +1047,8 @@ func TestComputeMeetingNoteInputHash_StableAcrossOrder(t *testing.T) {
 }
 
 // TestComputeMeetingNoteInputHash_TitleAffectsHash confirms the title
-// is part of the recipe — PR 4's title-parser does not have to
-// migrate hashes (round-1 P1#3 fix).
+// is part of the recipe — a future title-parser does not have to
+// migrate hashes.
 func TestComputeMeetingNoteInputHash_TitleAffectsHash(t *testing.T) {
 	at := time.Date(2026, 5, 1, 14, 30, 0, 0, time.UTC)
 	ids := []string{"uuid-1"}
@@ -1150,9 +1150,9 @@ func TestDecideLinkage_OneCandidate_TaggedNotInAttendees_AddsWalkin(t *testing.T
 	require.Equal(t, cB, desired[0].ContactID)
 }
 
-// TestDecideLinkage_MultipleCandidates_ConflictPending verifies PR 3
-// always lands on conflict_pending for 2+ candidates (Step 3
-// disambiguation is PR 5).
+// TestDecideLinkage_MultipleCandidates_ConflictPending verifies the
+// handler always lands on conflict_pending for 2+ candidates (the
+// participant-signal disambiguation flow is deferred).
 func TestDecideLinkage_MultipleCandidates_ConflictPending(t *testing.T) {
 	sessionID := uuid.New()
 	cands := []repository.LinkageCandidate{

--- a/backend/internal/service/ingest_test.go
+++ b/backend/internal/service/ingest_test.go
@@ -1130,7 +1130,7 @@ func TestDecideLinkage_OneCandidate_WalkinPresent_NoSupplement(t *testing.T) {
 }
 
 // TestDecideLinkage_OneCandidate_TaggedNotInAttendees_AddsWalkin
-// fires Step 5 walk-in supplemental for the missing contact.
+// fires the walk-in supplemental interaction for the missing contact.
 func TestDecideLinkage_OneCandidate_TaggedNotInAttendees_AddsWalkin(t *testing.T) {
 	sessionID := uuid.New()
 	cA := uuid.New() // in attendees

--- a/backend/internal/service/mac_host.go
+++ b/backend/internal/service/mac_host.go
@@ -88,6 +88,14 @@ type ExternalContactReader interface {
 	ListKnownIDsByHostAndSource(ctx context.Context, hostID uuid.UUID, source string) ([]KnownExternalContactID, error)
 }
 
+// MeetingNoteReader is the narrow surface MacHostService needs for the
+// anarlog_sessions arm of /known-ids. Concrete is
+// *repository.MeetingNoteRepository. Returns the same wire DTO shape
+// as ExternalContactReader so the handler treats both sources uniformly.
+type MeetingNoteReader interface {
+	ListKnownMeetingNoteSessionIDsByHost(ctx context.Context, hostID uuid.UUID) ([]KnownExternalContactID, error)
+}
+
 // MacHostService owns business logic for pairing, heartbeat, cursor
 // commit, and revoke-cascade. Stateless aside from the constructor-
 // injected dependencies — safe to share across requests.
@@ -97,22 +105,24 @@ type MacHostService struct {
 	syncRepo            *repository.SyncRepository
 	contactMethodRepo   ContactMethodLister
 	externalContactRepo ExternalContactReader
+	meetingNoteRepo     MeetingNoteReader
 	pool                *pgxpool.Pool
 	bcryptCost          int
 }
 
 // NewMacHostService constructs a service. bcryptCost defaults to
 // bcrypt.DefaultCost when 0 — at cost=10 the hash is ~50ms on a Pi 4,
-// fine for once-per-pair. contactMethodRepo and externalContactRepo
-// may be nil in test fixtures that don't exercise the corresponding
-// endpoint; the affected method returns a clear "not wired" error in
-// that state.
+// fine for once-per-pair. contactMethodRepo, externalContactRepo, and
+// meetingNoteRepo may be nil in test fixtures that don't exercise the
+// corresponding endpoint; the affected method returns a clear "not
+// wired" error in that state.
 func NewMacHostService(
 	hostRepo *repository.MacHostRepository,
 	tokenRepo *repository.MacHostPairingTokenRepository,
 	syncRepo *repository.SyncRepository,
 	contactMethodRepo ContactMethodLister,
 	externalContactRepo ExternalContactReader,
+	meetingNoteRepo MeetingNoteReader,
 	pool *pgxpool.Pool,
 	bcryptCost int,
 ) *MacHostService {
@@ -125,6 +135,7 @@ func NewMacHostService(
 		syncRepo:            syncRepo,
 		contactMethodRepo:   contactMethodRepo,
 		externalContactRepo: externalContactRepo,
+		meetingNoteRepo:     meetingNoteRepo,
 		pool:                pool,
 		bcryptCost:          bcryptCost,
 	}
@@ -165,24 +176,33 @@ func (s *MacHostService) KnownIdentifiers(ctx context.Context) (*KnownIdentifier
 	return &KnownIdentifiersResult{Phones: phones, Emails: emails}, nil
 }
 
-// KnownIDsForSource returns the per-(host, source) known
-// external_contact IDs and their last observed content hashes. Empty
-// slice on a fresh CRM or for sources without external_contact rows
-// (the handler validates the source against mac.IsAllowedPushSource
-// before dispatching). The slice is sorted by source_id for
-// deterministic responses (the underlying SQL query orders).
+// KnownIDsForSource returns the per-(host, source) known IDs and their
+// last observed content hashes. Empty slice on a fresh CRM or for
+// sources without rows. The handler validates the source against
+// mac.IsAllowedPushSource before dispatching. The slice is sorted by
+// source_id for deterministic responses.
 //
-// Used by the Mac daemon's tombstone-reconciliation flow after a
-// full CNContactStore scan: the daemon set-diffs its scan results
-// against the returned IDs and emits external_contact.deleted events
-// for entries that disappeared upstream. The last_content_hash
-// supplies the prior-hash component of the spec-defined delete
-// source_id (`<entity>@deleted@<prev_hash>`).
+// Dispatch:
+//   - source == "anarlog_sessions" → meeting_note repository.
+//   - any other allowed source → external_contact repository (current
+//     coverage: icloud_contacts, anarlog_humans).
+//
+// Used by the Mac daemon's tombstone-reconciliation flow after a full
+// upstream scan: the daemon set-diffs its scan results against the
+// returned IDs and emits *.deleted events for entries that disappeared.
+// The last_content_hash supplies the prior-hash component of the
+// spec-defined delete source_id (`<entity>@deleted@<prev_hash>`).
 func (s *MacHostService) KnownIDsForSource(
 	ctx context.Context,
 	hostID uuid.UUID,
 	source string,
 ) ([]KnownExternalContactID, error) {
+	if source == "anarlog_sessions" {
+		if s.meetingNoteRepo == nil {
+			return nil, fmt.Errorf("known IDs: meeting_note repository not wired")
+		}
+		return s.meetingNoteRepo.ListKnownMeetingNoteSessionIDsByHost(ctx, hostID)
+	}
 	if s.externalContactRepo == nil {
 		return nil, fmt.Errorf("known IDs: external_contact repository not wired")
 	}

--- a/backend/migrations/054_meeting_note_input_and_content_hash.down.sql
+++ b/backend/migrations/054_meeting_note_input_and_content_hash.down.sql
@@ -1,9 +1,9 @@
 -- Reverses 054_meeting_note_input_and_content_hash.up.sql.
 --
 -- Destructive: dropping these columns loses all stored hashes and the
--- session start time. Acceptable because PR 3 is forward-only and any
--- partial deployment that needs rollback also rolls back the producers
--- that populate these columns.
+-- session start time. Acceptable because the columns are forward-only
+-- additions and any partial deployment that needs rollback also rolls
+-- back the producers that populate them.
 
 ALTER TABLE meeting_note
     DROP CONSTRAINT IF EXISTS meeting_note_input_hash_check,

--- a/backend/migrations/054_meeting_note_input_and_content_hash.down.sql
+++ b/backend/migrations/054_meeting_note_input_and_content_hash.down.sql
@@ -1,0 +1,14 @@
+-- Reverses 054_meeting_note_input_and_content_hash.up.sql.
+--
+-- Destructive: dropping these columns loses all stored hashes and the
+-- session start time. Acceptable because PR 3 is forward-only and any
+-- partial deployment that needs rollback also rolls back the producers
+-- that populate these columns.
+
+ALTER TABLE meeting_note
+    DROP CONSTRAINT IF EXISTS meeting_note_input_hash_check,
+    DROP CONSTRAINT IF EXISTS meeting_note_resolved_set_hash_check,
+    DROP COLUMN IF EXISTS meeting_at,
+    DROP COLUMN IF EXISTS last_content_hash,
+    DROP COLUMN IF EXISTS resolved_set_hash,
+    DROP COLUMN IF EXISTS input_hash;

--- a/backend/migrations/054_meeting_note_input_and_content_hash.up.sql
+++ b/backend/migrations/054_meeting_note_input_and_content_hash.up.sql
@@ -1,0 +1,48 @@
+-- ============================================================================
+-- 054_meeting_note_input_and_content_hash: add input_hash, resolved_set_hash,
+-- last_content_hash, and meeting_at columns to meeting_note
+-- ============================================================================
+-- Spec: .ai/spec/mac-daemon-phase-2-anarlog-matching.md
+--
+-- The columns added here power the linkage-detection re-sync algorithm and the
+-- /known-ids endpoint:
+--
+--   * input_hash         SHA-256(JCS({meeting_at, title, sorted(participant_ids)})).
+--                        Detects "matching inputs changed" on re-sync without
+--                        re-running linkage on every duplicate event.
+--   * resolved_set_hash  SHA-256(JCS(sorted(resolved_contact_uuids))). Detects
+--                        when tagged-participant→contact resolution changes
+--                        even when input_hash is unchanged (e.g. after a user
+--                        imports an anarlog_humans candidate).
+--   * last_content_hash  Lowercase-hex SHA-256 of the most recent
+--                        meeting_note.recorded payload. Powers the daemon's
+--                        deterministic delete source_id construction via
+--                        /sync/anarlog_sessions/known-ids.
+--   * meeting_at         Session start time from the daemon payload's
+--                        meeting_at. Drives linkage window math, the
+--                        re-sync input_hash recipe, and the conflict UI.
+--
+-- Defaults exist purely for the migration boundary against any pre-existing
+-- meeting_note rows; in steady state every write supplies a real value
+-- (validators reject zero meeting_at / empty hashes). The CHECK constraints
+-- enforce lowercase-hex SHA-256 shape on the two hash columns.
+-- ============================================================================
+
+ALTER TABLE meeting_note
+    ADD COLUMN input_hash        TEXT        NOT NULL DEFAULT '',
+    ADD COLUMN resolved_set_hash TEXT        NOT NULL DEFAULT '',
+    ADD COLUMN last_content_hash TEXT,
+    ADD COLUMN meeting_at        TIMESTAMPTZ NOT NULL DEFAULT '1970-01-01T00:00:00Z',
+    ADD CONSTRAINT meeting_note_input_hash_check
+        CHECK (input_hash = '' OR input_hash ~ '^[a-f0-9]{64}$'),
+    ADD CONSTRAINT meeting_note_resolved_set_hash_check
+        CHECK (resolved_set_hash = '' OR resolved_set_hash ~ '^[a-f0-9]{64}$');
+
+COMMENT ON COLUMN meeting_note.input_hash IS
+    'SHA-256(JCS({meeting_at, title, sorted(participant_ids)})). Used to detect when matching inputs change on re-sync.';
+COMMENT ON COLUMN meeting_note.resolved_set_hash IS
+    'SHA-256(JCS(sorted(resolved_contact_uuids))). Used to detect when tagged-participant->contact resolution changes (e.g., after a user import), even when input_hash is unchanged.';
+COMMENT ON COLUMN meeting_note.last_content_hash IS
+    'Lowercase-hex SHA-256 of JCS-canonicalized payload (minus host_id) from the most recent meeting_note.recorded event. Powers GET /sync/anarlog_sessions/known-ids. NULL for legacy rows; daemon falls back to @deleted@unknown sentinel per spec.';
+COMMENT ON COLUMN meeting_note.meeting_at IS
+    'Session start time from the daemon payload meeting_at. Drives linkage window math, /imports conflict UI, and the input_hash recipe.';

--- a/backend/tests/api/external_contact_ingest_test.go
+++ b/backend/tests/api/external_contact_ingest_test.go
@@ -75,7 +75,7 @@ func setupExtContactIngestEnv(t *testing.T) *extContactIngestEnv {
 	syncRepo := repository.NewSyncRepositoryWithPool(database.Queries, database.Pool)
 	contactMethodRepo := repository.NewContactMethodRepository(database.Queries)
 	externalRepo := repository.NewExternalContactRepository(database.Queries)
-	macService := service.NewMacHostService(hostRepo, pairingRepo, syncRepo, contactMethodRepo, externalRepo, database.Pool, 4)
+	macService := service.NewMacHostService(hostRepo, pairingRepo, syncRepo, contactMethodRepo, externalRepo, nil, database.Pool, 4)
 
 	identityRepo := repository.NewIdentityRepository(database.Queries)
 	identityService := service.NewIdentityService(identityRepo)

--- a/backend/tests/api/external_contact_ingest_test.go
+++ b/backend/tests/api/external_contact_ingest_test.go
@@ -92,6 +92,11 @@ func setupExtContactIngestEnv(t *testing.T) *extContactIngestEnv {
 		nil, // riverClient unused
 		externalRepo,
 		hostRepo, // host-liveness re-check for the FOR UPDATE lock
+		nil,      // meetingNotes unused on external_contact path
+		nil,      // calendar unused
+		nil,      // interactions unused
+		nil,      // identityLookup unused
+		nil,      // contactSvc unused
 	)
 	ingestHandler := handlers.NewIngestHandler(ingestService)
 

--- a/backend/tests/api/external_contact_known_ids_test.go
+++ b/backend/tests/api/external_contact_known_ids_test.go
@@ -63,7 +63,7 @@ func setupKnownIDsByHostEnv(t *testing.T) *knownIDsByHostEnv {
 	syncRepo := repository.NewSyncRepositoryWithPool(database.Queries, database.Pool)
 	contactMethodRepo := repository.NewContactMethodRepository(database.Queries)
 	externalRepo := repository.NewExternalContactRepository(database.Queries)
-	macService := service.NewMacHostService(hostRepo, pairingRepo, syncRepo, contactMethodRepo, externalRepo, database.Pool, 4)
+	macService := service.NewMacHostService(hostRepo, pairingRepo, syncRepo, contactMethodRepo, externalRepo, nil, database.Pool, 4)
 
 	gin.SetMode(gin.TestMode)
 	router := gin.New()

--- a/backend/tests/api/external_contact_savepoint_rollback_test.go
+++ b/backend/tests/api/external_contact_savepoint_rollback_test.go
@@ -100,7 +100,7 @@ func TestIngestExternalContact_SavepointRollback_OnMatchFailure(t *testing.T) {
 	// match-flip path errors after Bus.PublishTx + UpsertTx +
 	// MatchOrCreateTx have already written rows inside the savepoint.
 	failingWriter := &failingMatchExternalContactWriter{inner: externalRepo}
-	ingestService := service.NewIngestService(database, eventBus, identityService, nil, nil, failingWriter, hostRepo)
+	ingestService := service.NewIngestService(database, eventBus, identityService, nil, nil, failingWriter, hostRepo, nil, nil, nil, nil, nil)
 	ingestHandler := handlers.NewIngestHandler(ingestService)
 
 	gin.SetMode(gin.TestMode)

--- a/backend/tests/api/external_contact_savepoint_rollback_test.go
+++ b/backend/tests/api/external_contact_savepoint_rollback_test.go
@@ -85,7 +85,7 @@ func TestIngestExternalContact_SavepointRollback_OnMatchFailure(t *testing.T) {
 	pairingRepo := repository.NewMacHostPairingTokenRepository(database.Queries)
 	syncRepo := repository.NewSyncRepositoryWithPool(database.Queries, database.Pool)
 	contactMethodRepo := repository.NewContactMethodRepository(database.Queries)
-	macService := service.NewMacHostService(hostRepo, pairingRepo, syncRepo, contactMethodRepo, nil, database.Pool, 4)
+	macService := service.NewMacHostService(hostRepo, pairingRepo, syncRepo, contactMethodRepo, nil, nil, database.Pool, 4)
 
 	identityRepo := repository.NewIdentityRepository(database.Queries)
 	identityService := service.NewIdentityService(identityRepo)

--- a/backend/tests/api/import_with_selections_test.go
+++ b/backend/tests/api/import_with_selections_test.go
@@ -58,7 +58,7 @@ func setupImportTestRouter() (*gin.Engine, *repository.ExternalContactRepository
 	enrichmentService.SetCadenceUpdater(cadenceUpdater)
 
 	// Create handler
-	importHandler := handlers.NewImportHandler(externalRepo, contactService, matchService, enrichmentService)
+	importHandler := handlers.NewImportHandler(externalRepo, nil, contactService, matchService, enrichmentService)
 
 	router := gin.New()
 	router.Use(api.RequestIDMiddleware())

--- a/backend/tests/api/ingest_host_liveness_test.go
+++ b/backend/tests/api/ingest_host_liveness_test.go
@@ -223,7 +223,7 @@ func TestIngest_ConcurrentRevokeBlocksUntilBatchCommit(t *testing.T) {
 	pairingRepo := repository.NewMacHostPairingTokenRepository(database.Queries)
 	syncRepo := repository.NewSyncRepositoryWithPool(database.Queries, database.Pool)
 	externalRepo := repository.NewExternalContactRepository(database.Queries)
-	macService := service.NewMacHostService(hostRepo, pairingRepo, syncRepo, nil, externalRepo, database.Pool, 4)
+	macService := service.NewMacHostService(hostRepo, pairingRepo, syncRepo, nil, externalRepo, nil, database.Pool, 4)
 	identityRepo := repository.NewIdentityRepository(database.Queries)
 	identityService := service.NewIdentityService(identityRepo)
 

--- a/backend/tests/api/ingest_host_liveness_test.go
+++ b/backend/tests/api/ingest_host_liveness_test.go
@@ -72,6 +72,11 @@ func TestIngest_HostRevokedMidTx_AbortsBatch(t *testing.T) {
 		nil, // river unused
 		externalRepo,
 		liveness,
+		nil, // meetingNotes unused
+		nil, // calendar unused
+		nil, // interactions unused
+		nil, // identityLookup unused
+		nil, // contactSvc unused
 	)
 
 	// Build a structurally-valid envelope so the batch precondition
@@ -96,7 +101,7 @@ func TestIngest_HostRevokedMidTx_AbortsBatch(t *testing.T) {
 		ObservedAt: accelerated.GetCurrentTime(),
 	}
 
-	accepted, duplicate, rejections, err := svc.IngestBatch(
+	accepted, duplicate, rejections, _, err := svc.IngestBatch(
 		ctx, []*events.Envelope{env}, []int{0}, &hostID,
 	)
 	require.Error(t, err, "batch must abort when liveness check reports revoked host")
@@ -141,12 +146,12 @@ func TestIngest_HostLivenessNil_SkipsCheck(t *testing.T) {
 	eventBus := events.NewBus(database.Pool, nil, eventRepo)
 
 	// nil hostLiveness — recheck is skipped.
-	svc := service.NewIngestService(database, eventBus, nil, nil, nil, nil, nil)
+	svc := service.NewIngestService(database, eventBus, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	// An empty batch passes the precondition layer immediately and
 	// never opens a tx. The test confirms wiring without the recheck
 	// does not panic.
-	accepted, duplicate, rejections, err := svc.IngestBatch(ctx, nil, nil, nil)
+	accepted, duplicate, rejections, _, err := svc.IngestBatch(ctx, nil, nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, 0, accepted)
 	require.Equal(t, 0, duplicate)
@@ -248,7 +253,7 @@ func TestIngest_ConcurrentRevokeBlocksUntilBatchCommit(t *testing.T) {
 
 	eventRepo := repository.NewEventRepository(database.Queries)
 	eventBus := events.NewBus(database.Pool, nil, eventRepo)
-	svc := service.NewIngestService(database, eventBus, identityService, nil, nil, blocker, hostRepo)
+	svc := service.NewIngestService(database, eventBus, identityService, nil, nil, blocker, hostRepo, nil, nil, nil, nil, nil)
 
 	entityID := "concurrent-revoke-" + uuid.NewString()[:8]
 	payload, err := events.Marshal(events.KindExternalContactUpserted, events.ExternalContactUpsertedPayload{
@@ -276,7 +281,7 @@ func TestIngest_ConcurrentRevokeBlocksUntilBatchCommit(t *testing.T) {
 	}
 	batchDone := make(chan batchResult, 1)
 	go func() {
-		acc, _, _, err := svc.IngestBatch(
+		acc, _, _, _, err := svc.IngestBatch(
 			ctx, []*events.Envelope{env}, []int{0}, &pair.HostID,
 		)
 		batchDone <- batchResult{accepted: acc, err: err}

--- a/backend/tests/api/ingest_raw_message_e2e_test.go
+++ b/backend/tests/api/ingest_raw_message_e2e_test.go
@@ -84,7 +84,7 @@ func TestIngestRawMessage_E2E_StagesAggregatesAndCreatesInteraction(t *testing.T
 	contactSvc := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, nil, rematchSvc)
 	cadenceUpdater := consumer.NewCadenceUpdater(claimRepo, contactRepo, database.Queries, consumer.CadenceModeCutover, false)
 	contactSvc.SetCadenceUpdater(cadenceUpdater)
-	macService := service.NewMacHostService(hostRepo, pairingRepo, syncRepo, nil, nil, database.Pool, 4)
+	macService := service.NewMacHostService(hostRepo, pairingRepo, syncRepo, nil, nil, nil, database.Pool, 4)
 
 	// River client — wires the real MessagingAggregateForContactWorker
 	// (so the e2e test runs through the aggregator), the

--- a/backend/tests/api/ingest_raw_message_e2e_test.go
+++ b/backend/tests/api/ingest_raw_message_e2e_test.go
@@ -144,7 +144,7 @@ func TestIngestRawMessage_E2E_StagesAggregatesAndCreatesInteraction(t *testing.T
 	recorderShim.real = consumer.NewInteractionRecorderWorker(bus, database.Pool, recorder, nil)
 
 	// Now wire the ingest service + handler.
-	ingestService := service.NewIngestService(database, bus, identityService, messagesRepo, riverClient, nil, hostRepo)
+	ingestService := service.NewIngestService(database, bus, identityService, messagesRepo, riverClient, nil, hostRepo, nil, nil, nil, nil, nil)
 	ingestHandler := handlers.NewIngestHandler(ingestService)
 
 	gin.SetMode(gin.TestMode)

--- a/backend/tests/api/ingest_raw_message_test.go
+++ b/backend/tests/api/ingest_raw_message_test.go
@@ -71,7 +71,7 @@ func setupRawIngestEnv(t *testing.T) *ingestRawTestEnv {
 	hostRepo := repository.NewMacHostRepository(database.Queries)
 	pairingRepo := repository.NewMacHostPairingTokenRepository(database.Queries)
 	syncRepo := repository.NewSyncRepositoryWithPool(database.Queries, database.Pool)
-	macService := service.NewMacHostService(hostRepo, pairingRepo, syncRepo, nil, nil, database.Pool, 4)
+	macService := service.NewMacHostService(hostRepo, pairingRepo, syncRepo, nil, nil, nil, database.Pool, 4)
 
 	identityRepo := repository.NewIdentityRepository(database.Queries)
 	identityService := service.NewIdentityService(identityRepo)

--- a/backend/tests/api/ingest_raw_message_test.go
+++ b/backend/tests/api/ingest_raw_message_test.go
@@ -121,6 +121,11 @@ func setupRawIngestEnv(t *testing.T) *ingestRawTestEnv {
 		riverClient,
 		nil,
 		hostRepo,
+		nil, // meetingNotes unused
+		nil, // calendar unused
+		nil, // interactions unused
+		nil, // identityLookup unused
+		nil, // contactSvc unused
 	)
 	ingestHandler := handlers.NewIngestHandler(ingestService)
 

--- a/backend/tests/api/ingest_test.go
+++ b/backend/tests/api/ingest_test.go
@@ -123,7 +123,7 @@ func setupIngestTestRouter(t *testing.T, enableIngest bool) *ingestTestSetup {
 	// safe — raw_message envelopes are rejected at the handler with
 	// PAYLOAD_INVALID before reaching the inline handler. nil
 	// hostLiveness skips the FOR UPDATE re-check (test path).
-	ingestService := service.NewIngestService(database, eventBus, nil, nil, nil, nil, nil)
+	ingestService := service.NewIngestService(database, eventBus, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	ingestHandler := handlers.NewIngestHandler(ingestService)
 
 	gin.SetMode(gin.TestMode)
@@ -699,7 +699,7 @@ func TestIngest_MidTxRollback_RollsBack_And_Returns500(t *testing.T) {
 	// so the rest of the suite isn't affected.
 	fake := &failingRepo{inner: setup.eventRepo, failOn: 3}
 	bus := setup.busFactory(fake)
-	ingestService := service.NewIngestService(setup.database, bus, nil, nil, nil, nil, nil)
+	ingestService := service.NewIngestService(setup.database, bus, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	handler := handlers.NewIngestHandler(ingestService)
 
 	cfg := config.TestConfig()

--- a/backend/tests/api/known_identifiers_test.go
+++ b/backend/tests/api/known_identifiers_test.go
@@ -55,7 +55,7 @@ func setupKnownIDsEnv(t *testing.T) *knownIDsEnv {
 	pairingRepo := repository.NewMacHostPairingTokenRepository(database.Queries)
 	syncRepo := repository.NewSyncRepositoryWithPool(database.Queries, database.Pool)
 	contactMethodRepo := repository.NewContactMethodRepository(database.Queries)
-	macService := service.NewMacHostService(hostRepo, pairingRepo, syncRepo, contactMethodRepo, nil, database.Pool, 4)
+	macService := service.NewMacHostService(hostRepo, pairingRepo, syncRepo, contactMethodRepo, nil, nil, database.Pool, 4)
 
 	contactRepo := repository.NewContactRepository(database.Queries)
 	contactRepo.SetPool(database.Pool)

--- a/backend/tests/api/mac_host_pairing_test.go
+++ b/backend/tests/api/mac_host_pairing_test.go
@@ -72,7 +72,7 @@ func setupMacHostEnv(t *testing.T) *macHostTestEnv {
 	// bcrypt cost 4 is the lowest bcrypt accepts; the speed makes
 	// integration test execution tolerable while still exercising the
 	// real bcrypt path.
-	macService := service.NewMacHostService(hostRepo, tokenRepo, syncRepo, nil, externalRepo, database.Pool, 4)
+	macService := service.NewMacHostService(hostRepo, tokenRepo, syncRepo, nil, externalRepo, nil, database.Pool, 4)
 	limiter := auth.NewPairingIPRateLimiter()
 	macHandler := handlers.NewMacHostHandler(macService, limiter)
 

--- a/backend/tests/api/meeting_note_ingest_test.go
+++ b/backend/tests/api/meeting_note_ingest_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -52,6 +53,28 @@ type meetingNoteIngestEnv struct {
 	contactA uuid.UUID // associated with anarlogHumanA via email match
 	contactB uuid.UUID // associated with anarlogHumanB via email match
 	contactC uuid.UUID // associated with anarlogHumanC via email match (used for RS2 drift)
+	// sessionUUIDs records every session UUID a test asks the env to
+	// remember via trackSession; t.Cleanup hard-deletes interactions
+	// scoped to those UUIDs only (no broad sweeps on the shared DB).
+	sessionUUIDs   []string
+	sessionUUIDsMu sync.Mutex
+}
+
+// trackSession records the session UUID for targeted cleanup.
+func (e *meetingNoteIngestEnv) trackSession(sessionUUID string) {
+	e.sessionUUIDsMu.Lock()
+	defer e.sessionUUIDsMu.Unlock()
+	e.sessionUUIDs = append(e.sessionUUIDs, sessionUUID)
+}
+
+// newSessionUUID generates a fresh session UUID AND registers it for
+// targeted cleanup. Tests must use this in place of uuid.NewString()
+// for every session they create so t.Cleanup can scope deletes
+// precisely (the shared test DB does not tolerate broad sweeps).
+func (e *meetingNoteIngestEnv) newSessionUUID() string {
+	sid := uuid.NewString()
+	e.trackSession(sid)
+	return sid
 }
 
 func setupMeetingNoteIngestEnv(t *testing.T) *meetingNoteIngestEnv {
@@ -144,7 +167,7 @@ func setupMeetingNoteIngestEnv(t *testing.T) *meetingNoteIngestEnv {
 	matchService := service.NewImportMatchService(contactRepo)
 	enrichmentSvc := service.NewEnrichmentService(database, contactRepo, contactMethodRepo, enrichmentRepo, nil, nil)
 	enrichmentSvc.SetCadenceUpdater(wireCadenceUpdaterForAPITest(t, database, contactSvc))
-	importHandler := handlers.NewImportHandler(externalRepo, identityRepo, contactSvc, matchService, enrichmentSvc)
+	importHandler := handlers.NewImportHandler(externalRepo, identityService, contactSvc, matchService, enrichmentSvc)
 	imports := router.Group("/api/v1/imports")
 	imports.POST("/candidates/:id/link", importHandler.LinkContact)
 
@@ -190,9 +213,16 @@ func setupMeetingNoteIngestEnv(t *testing.T) *meetingNoteIngestEnv {
 	t.Cleanup(func() {
 		cleanCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
-		// Drop interactions seeded by these tests (covers anarlog session refs).
-		_ = interactionRepo.HardDeleteInteractionsBySourceRefPrefix(cleanCtx, "anarlog_sessions", "anarlog:"+env.sourceIDPrefix+"%")
-		_ = interactionRepo.HardDeleteInteractionsBySourceRefPrefix(cleanCtx, "anarlog_sessions", "anarlog:%")
+		// Drop interactions for the session UUIDs this test created
+		// (scoped per-session — no broad anarlog:% sweep). Each test
+		// uses env.newSessionUUID() so the slice covers every session
+		// the test produced.
+		env.sessionUUIDsMu.Lock()
+		sessions := append([]string(nil), env.sessionUUIDs...)
+		env.sessionUUIDsMu.Unlock()
+		for _, sid := range sessions {
+			_ = interactionRepo.HardDeleteInteractionsBySourceRefPrefix(cleanCtx, "anarlog_sessions", "anarlog:"+sid+":%")
+		}
 		// Drop meeting_note rows seeded by these tests. Session UUIDs
 		// are caller-generated random UUIDs (no exploitable prefix), so
 		// scope by the paired mac_host_id this test created.
@@ -408,7 +438,7 @@ func listSessionInteractions(t *testing.T, env *meetingNoteIngestEnv, sessionUUI
 // ----------------------------------------------------------------------------
 func TestMeetingNote_OrphanNoTagged(t *testing.T) {
 	env := setupMeetingNoteIngestEnv(t)
-	sessionUUID := uuid.NewString()
+	sessionUUID := env.newSessionUUID()
 	meetingAt := time.Date(2026, 5, 1, 14, 30, 0, 0, time.UTC)
 	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Orphan Session", nil)
 	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
@@ -446,7 +476,7 @@ func TestMeetingNote_LinkedImpromptu(t *testing.T) {
 	anarlogA := env.seedAnarlogHumanResolvingTo(t, emailA)
 	anarlogB := env.seedAnarlogHumanResolvingTo(t, emailB)
 
-	sessionUUID := uuid.NewString()
+	sessionUUID := env.newSessionUUID()
 	meetingAt := time.Date(2026, 5, 1, 15, 0, 0, 0, time.UTC)
 	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Impromptu Session", []string{anarlogA, anarlogB})
 	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
@@ -483,7 +513,7 @@ func TestMeetingNote_OneCandidateNoTagged(t *testing.T) {
 	meetingAt := time.Date(2026, 5, 2, 10, 0, 0, 0, time.UTC)
 	eventID := env.seedCalendarEventInWindow(t, meetingAt, []uuid.UUID{env.contactA, env.contactB})
 
-	sessionUUID := uuid.NewString()
+	sessionUUID := env.newSessionUUID()
 	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Linked Session", nil)
 	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
 	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
@@ -517,7 +547,7 @@ func TestMeetingNote_OneCandidateWalkin(t *testing.T) {
 	emailB := fmt.Sprintf("mn-test-1-%s@example.invalid", suffix)
 	anarlogB := env.seedAnarlogHumanResolvingTo(t, emailB)
 
-	sessionUUID := uuid.NewString()
+	sessionUUID := env.newSessionUUID()
 	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Linked + Walkin", []string{anarlogB})
 	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
 	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
@@ -546,7 +576,7 @@ func TestMeetingNote_TwoCandidatesConflict(t *testing.T) {
 	env.seedCalendarEventInWindow(t, meetingAt, []uuid.UUID{env.contactA})
 	env.seedCalendarEventInWindow(t, meetingAt.Add(5*time.Minute), []uuid.UUID{env.contactB})
 
-	sessionUUID := uuid.NewString()
+	sessionUUID := env.newSessionUUID()
 	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Conflict Session", nil)
 	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
 	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
@@ -574,7 +604,7 @@ func TestMeetingNote_DeleteCascadesToInteractions(t *testing.T) {
 	emailA := fmt.Sprintf("mn-test-0-%s@example.invalid", suffix)
 	anarlogA := env.seedAnarlogHumanResolvingTo(t, emailA)
 
-	sessionUUID := uuid.NewString()
+	sessionUUID := env.newSessionUUID()
 	meetingAt := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
 	rec := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Will Delete", []string{anarlogA})
 	w := postMNIngest(t, env, map[string]any{"events": []any{rec}})
@@ -636,7 +666,7 @@ func TestMeetingNote_ResyncCarryForward(t *testing.T) {
 	emailA := fmt.Sprintf("mn-test-0-%s@example.invalid", suffix)
 	anarlogA := env.seedAnarlogHumanResolvingTo(t, emailA)
 
-	sessionUUID := uuid.NewString()
+	sessionUUID := env.newSessionUUID()
 	meetingAt := time.Date(2026, 5, 5, 14, 0, 0, 0, time.UTC)
 	rec := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Same Title", []string{anarlogA})
 	w := postMNIngest(t, env, map[string]any{"events": []any{rec}})
@@ -675,7 +705,7 @@ func TestMeetingNote_ResyncDiffsInteractions(t *testing.T) {
 	anarlogB := env.seedAnarlogHumanResolvingTo(t, emailB)
 	anarlogC := env.seedAnarlogHumanResolvingTo(t, emailC)
 
-	sessionUUID := uuid.NewString()
+	sessionUUID := env.newSessionUUID()
 	meetingAt := time.Date(2026, 5, 6, 14, 0, 0, 0, time.UTC)
 
 	rec1 := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Initial", []string{anarlogA, anarlogB})
@@ -713,7 +743,7 @@ func TestMeetingNote_ResyncRefreshesInteractionContent(t *testing.T) {
 	emailA := fmt.Sprintf("mn-test-0-%s@example.invalid", suffix)
 	anarlogA := env.seedAnarlogHumanResolvingTo(t, emailA)
 
-	sessionUUID := uuid.NewString()
+	sessionUUID := env.newSessionUUID()
 	firstMeetingAt := time.Date(2026, 5, 20, 14, 0, 0, 0, time.UTC)
 	rec1 := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, firstMeetingAt, "First Title", []string{anarlogA})
 	w := postMNIngest(t, env, map[string]any{"events": []any{rec1}})
@@ -759,7 +789,7 @@ func TestMeetingNote_DedupesByContactID(t *testing.T) {
 	anarlog2 := env.seedAnarlogHumanResolvingTo(t, emailA)
 	require.NotEqual(t, anarlog1, anarlog2)
 
-	sessionUUID := uuid.NewString()
+	sessionUUID := env.newSessionUUID()
 	meetingAt := time.Date(2026, 5, 7, 14, 0, 0, 0, time.UTC)
 	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Dedup Test", []string{anarlog1, anarlog2})
 	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
@@ -772,7 +802,7 @@ func TestMeetingNote_DedupesByContactID(t *testing.T) {
 }
 
 // ----------------------------------------------------------------------------
-// TC-IM1 (round-1 P1#4): import flow backfills the anarlog identity row;
+// TC-IM1: import flow backfills the anarlog identity row;
 // subsequent meeting_note re-sync resolves the human.
 // ----------------------------------------------------------------------------
 func TestMeetingNote_ImportBackfillResolvesOnResync(t *testing.T) {
@@ -786,7 +816,7 @@ func TestMeetingNote_ImportBackfillResolvesOnResync(t *testing.T) {
 
 	// First meeting_note.recorded → orphan_needs_review (unresolved tag,
 	// 0 candidates).
-	sessionUUID := uuid.NewString()
+	sessionUUID := env.newSessionUUID()
 	meetingAt := time.Date(2026, 5, 8, 14, 0, 0, 0, time.UTC)
 	rec1 := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Pre-Import", []string{anarlogX})
 	w := postMNIngest(t, env, map[string]any{"events": []any{rec1}})
@@ -849,7 +879,7 @@ func TestMeetingNote_ImportBackfillResolvesOnResync(t *testing.T) {
 }
 
 // ----------------------------------------------------------------------------
-// TC-RV1 (round-1 P0#1): delete then re-record identical content →
+// TC-RV1: delete then re-record identical content →
 // row revives (deleted_at cleared), interactions reinserted.
 // ----------------------------------------------------------------------------
 func TestMeetingNote_DeleteThenReviveIdenticalContent(t *testing.T) {
@@ -859,7 +889,7 @@ func TestMeetingNote_DeleteThenReviveIdenticalContent(t *testing.T) {
 	emailA := fmt.Sprintf("mn-test-0-%s@example.invalid", suffix)
 	anarlogA := env.seedAnarlogHumanResolvingTo(t, emailA)
 
-	sessionUUID := uuid.NewString()
+	sessionUUID := env.newSessionUUID()
 	meetingAt := time.Date(2026, 5, 9, 14, 0, 0, 0, time.UTC)
 	rec := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Revive Me", []string{anarlogA})
 
@@ -926,7 +956,7 @@ func TestMeetingNote_AnarlogHumanIdentityRegistered(t *testing.T) {
 func TestMeetingNote_KnownIDsForAnarlogSessions(t *testing.T) {
 	env := setupMeetingNoteIngestEnv(t)
 	meetingAt := time.Date(2026, 5, 10, 14, 0, 0, 0, time.UTC)
-	sessions := []string{uuid.NewString(), uuid.NewString(), uuid.NewString()}
+	sessions := []string{env.newSessionUUID(), env.newSessionUUID(), env.newSessionUUID()}
 	for _, sid := range sessions {
 		ev := buildMNRecordedEvent(t, env.pairedHostID, sid, meetingAt, "Known IDs Test", nil)
 		w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
@@ -962,4 +992,134 @@ func TestMeetingNote_KnownIDsForAnarlogSessions(t *testing.T) {
 	for _, sid := range sessions {
 		require.True(t, gotIDs[sid], "expected session %s in known-ids response", sid)
 	}
+}
+
+// ----------------------------------------------------------------------------
+// TC-D3: meeting_note.deleted with hash mismatch is rejected with
+// MEETING_NOTE_DELETE_HASH_MISMATCH (no cascade fires).
+// ----------------------------------------------------------------------------
+func TestMeetingNote_DeleteHashMismatchRejected(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	sessionUUID := env.newSessionUUID()
+	meetingAt := time.Date(2026, 5, 14, 9, 0, 0, 0, time.UTC)
+	rec := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Will Mismatch", nil)
+	w := postMNIngest(t, env, map[string]any{"events": []any{rec}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+
+	// Build a delete envelope with a hash that does NOT match the stored
+	// last_content_hash and is NOT the @unknown sentinel.
+	wrongHash := strings.Repeat("a", 64)
+	del := buildMNDeletedEvent(t, env.pairedHostID, sessionUUID, wrongHash)
+	w = postMNIngest(t, env, map[string]any{"events": []any{del}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseMNIngestResp(t, w)
+	require.Equal(t, 1, resp.Rejected)
+	require.Len(t, resp.Errors, 1)
+	require.Equal(t, "MEETING_NOTE_DELETE_HASH_MISMATCH", resp.Errors[0].Code)
+
+	// Row remains live + tracked.
+	row := findMeetingNoteRow(t, env, sessionUUID)
+	require.NotNil(t, row)
+	require.Nil(t, row.DeletedAt, "rejected delete must not tombstone the row")
+}
+
+// ----------------------------------------------------------------------------
+// TC-OW1: a cross-host meeting_note.deleted is a silent no-op (the host
+// that owns the row keeps it live).
+// ----------------------------------------------------------------------------
+func TestMeetingNote_DeleteCrossHostSilentNoOp(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	// Seed a session owned by env.pairedHostID.
+	sessionUUID := env.newSessionUUID()
+	meetingAt := time.Date(2026, 5, 14, 10, 0, 0, 0, time.UTC)
+	rec := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Owned by host A", nil)
+	w := postMNIngest(t, env, map[string]any{"events": []any{rec}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+
+	priorRow := findMeetingNoteRow(t, env, sessionUUID)
+	require.NotNil(t, priorRow)
+	require.NotNil(t, priorRow.LastContentHash)
+	priorHash := *priorRow.LastContentHash
+
+	// Pair a second host (B). The mac_host singleton index requires
+	// revoking the first one before pairing; production singleton
+	// behavior is what the cross-host guard ultimately defends against.
+	// For this test we just need a distinct host_id for the second
+	// auth path; revoke + re-pair simulates the scenario.
+	ctx := context.Background()
+	require.NoError(t, env.macService.RevokeHost(ctx, env.pairedHostID))
+	plainB, _, err := env.macService.CreatePairingToken(ctx)
+	require.NoError(t, err)
+	pairB, err := env.macService.PairWithToken(ctx, plainB, "meeting-note-test-B", "0.1.0", 1)
+	require.NoError(t, err)
+	require.NotEqual(t, env.pairedHostID, pairB.HostID)
+
+	// Host B tries to delete the row owned by host A. The handler logs
+	// a warn + silently no-ops; accepted=1, no DB change.
+	delBody := buildMNDeletedEvent(t, pairB.HostID, sessionUUID, priorHash)
+	bodyBytes, _ := json.Marshal(map[string]any{"events": []any{delBody}})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/ingest/events", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Mac-Host-ID", pairB.HostID.String())
+	req.Header.Set("Authorization", "Bearer "+pairB.APIKey)
+	wB := httptest.NewRecorder()
+	env.router.ServeHTTP(wB, req)
+	require.Equal(t, http.StatusOK, wB.Code, "body: %s", wB.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, wB).Accepted)
+
+	// Row still live + still owned by host A.
+	stillRow := findMeetingNoteRow(t, env, sessionUUID)
+	require.NotNil(t, stillRow)
+	require.Nil(t, stillRow.DeletedAt, "cross-host delete must NOT tombstone the row")
+	require.NotNil(t, stillRow.MacHostID)
+	require.Equal(t, env.pairedHostID, *stillRow.MacHostID, "ownership preserved")
+}
+
+// ----------------------------------------------------------------------------
+// TC-CR1: concurrent first-inserts for the same session UUID converge
+// via ON CONFLICT DO NOTHING + the re-read into the update path.
+// Uses two goroutines firing in parallel; a sync.WaitGroup serializes
+// the start so both batches' tx.Begin run within ~1ms.
+// ----------------------------------------------------------------------------
+func TestMeetingNote_ConcurrentFirstInsertConverges(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	sessionUUID := env.newSessionUUID()
+	meetingAt := time.Date(2026, 5, 15, 14, 0, 0, 0, time.UTC)
+
+	// Build two recorded events for the same session with DIFFERENT
+	// content (different titles → different content hashes → different
+	// envelope source_ids → both pass bus-dedup → both reach the
+	// insert path → one wins, the other falls through to update).
+	rec1 := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Concurrent A", nil)
+	rec2 := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Concurrent B", nil)
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	results := make(chan int, 2)
+	for _, ev := range []map[string]any{rec1, rec2} {
+		wg.Add(1)
+		go func(payload map[string]any) {
+			defer wg.Done()
+			<-start // release together
+			w := postMNIngest(t, env, map[string]any{"events": []any{payload}})
+			results <- w.Code
+		}(ev)
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+	for code := range results {
+		require.Equal(t, http.StatusOK, code, "both batches must succeed")
+	}
+
+	// Exactly ONE live meeting_note row exists.
+	row := findMeetingNoteRow(t, env, sessionUUID)
+	require.NotNil(t, row)
+	require.Nil(t, row.DeletedAt)
+	// Final state is one of the two payloads (last writer wins on the
+	// re-read+update path). Both are acceptable — we just assert no
+	// duplicates and no rejection.
+	require.Contains(t, []string{"Concurrent A", "Concurrent B"}, *row.Title)
 }

--- a/backend/tests/api/meeting_note_ingest_test.go
+++ b/backend/tests/api/meeting_note_ingest_test.go
@@ -58,6 +58,12 @@ type meetingNoteIngestEnv struct {
 	// scoped to those UUIDs only (no broad sweeps on the shared DB).
 	sessionUUIDs   []string
 	sessionUUIDsMu sync.Mutex
+	// seededAnarlogIDs tracks anarlog_humans external_contact source_ids
+	// (UUID strings) seeded by tests. ValidatePayload requires the IDs
+	// to parse as UUIDs so we cannot prefix them for the broader
+	// prefix-cleanup; track them explicitly instead.
+	seededAnarlogIDs   []string
+	seededAnarlogIDsMu sync.Mutex
 }
 
 // trackSession records the session UUID for targeted cleanup.
@@ -227,7 +233,17 @@ func setupMeetingNoteIngestEnv(t *testing.T) *meetingNoteIngestEnv {
 		// are caller-generated random UUIDs (no exploitable prefix), so
 		// scope by the paired mac_host_id this test created.
 		_ = meetingRepo.TestHardDeleteByHostID(cleanCtx, env.pairedHostID)
-		// Drop synthetic anarlog_humans external_contact rows.
+		// Drop anarlog_humans external_contact rows seeded by this test.
+		// ValidatePayload forces the source_id to be a UUID so we cannot
+		// share a single prefix; track the IDs explicitly instead.
+		env.seededAnarlogIDsMu.Lock()
+		anarlogIDs := append([]string(nil), env.seededAnarlogIDs...)
+		env.seededAnarlogIDsMu.Unlock()
+		for _, aid := range anarlogIDs {
+			_ = database.Queries.TestDeleteExternalContactsBySourceIDPrefix(cleanCtx, aid)
+		}
+		// Synthetic icloud_contacts seed cleanup keeps the prefix sweep
+		// for non-UUID source_ids (none in this file today, but harmless).
 		_ = database.Queries.TestDeleteExternalContactsBySourceIDPrefix(cleanCtx, env.sourceIDPrefix)
 		_, _ = database.Queries.DeleteExternalIdentitiesBySource(cleanCtx, "anarlog_humans")
 		_, _ = database.Queries.DeleteEventsBySource(cleanCtx, "anarlog_sessions")
@@ -256,6 +272,9 @@ func setupMeetingNoteIngestEnv(t *testing.T) *meetingNoteIngestEnv {
 func (e *meetingNoteIngestEnv) seedAnarlogHumanResolvingTo(t *testing.T, email string) string {
 	t.Helper()
 	anarlogID := uuid.NewString()
+	e.seededAnarlogIDsMu.Lock()
+	e.seededAnarlogIDs = append(e.seededAnarlogIDs, anarlogID)
+	e.seededAnarlogIDsMu.Unlock()
 	dn := "Tagged Human " + anarlogID[:8]
 	p := events.ExternalContactUpsertedPayload{
 		Version:     1,
@@ -1097,21 +1116,28 @@ func TestMeetingNote_ConcurrentFirstInsertConverges(t *testing.T) {
 
 	var wg sync.WaitGroup
 	start := make(chan struct{})
-	results := make(chan int, 2)
+	type result struct {
+		code int
+		resp ingestMNResponse
+	}
+	results := make(chan result, 2)
 	for _, ev := range []map[string]any{rec1, rec2} {
 		wg.Add(1)
 		go func(payload map[string]any) {
 			defer wg.Done()
 			<-start // release together
 			w := postMNIngest(t, env, map[string]any{"events": []any{payload}})
-			results <- w.Code
+			results <- result{code: w.Code, resp: parseMNIngestResp(t, w)}
 		}(ev)
 	}
 	close(start)
 	wg.Wait()
 	close(results)
-	for code := range results {
-		require.Equal(t, http.StatusOK, code, "both batches must succeed")
+	for r := range results {
+		require.Equal(t, http.StatusOK, r.code, "both batches must succeed")
+		require.Equal(t, 1, r.resp.Accepted, "each batch must accept its event (one inserts, the other re-reads + updates)")
+		require.Equal(t, 0, r.resp.Rejected, "no per-event rejection on conflict path")
+		require.Empty(t, r.resp.Errors, "no errors on conflict path")
 	}
 
 	// Exactly ONE live meeting_note row exists.

--- a/backend/tests/api/meeting_note_ingest_test.go
+++ b/backend/tests/api/meeting_note_ingest_test.go
@@ -1,0 +1,909 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/api"
+	"personal-crm/backend/internal/api/handlers"
+	"personal-crm/backend/internal/auth"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// ----------------------------------------------------------------------------
+// meeting_note.* ingest integration tests
+//
+// Each test seeds its own session UUIDs + per-run sourceIDPrefix so
+// parallel runs don't stomp each other. Cleanup hard-deletes by prefix.
+// ----------------------------------------------------------------------------
+
+type meetingNoteIngestEnv struct {
+	router         *gin.Engine
+	apiKey         string
+	database       *db.Database
+	macService     *service.MacHostService
+	externalRepo   *repository.ExternalContactRepository
+	meetingRepo    *repository.MeetingNoteRepository
+	contactRepo    *repository.ContactRepository
+	calendarRepo   *repository.CalendarEventRepository
+	interactionRep *repository.InteractionRepository
+	identityRepo   *repository.IdentityRepository
+	pairedHostID   uuid.UUID
+	pairedHostKey  string
+	sourceIDPrefix string // included in synthetic data so cleanup is targeted
+	// Seeded CRM contacts for tests that need a resolved tagged human.
+	contactA uuid.UUID // associated with anarlogHumanA via email match
+	contactB uuid.UUID // associated with anarlogHumanB via email match
+	contactC uuid.UUID // associated with anarlogHumanC via email match (used for RS2 drift)
+}
+
+func setupMeetingNoteIngestEnv(t *testing.T) *meetingNoteIngestEnv {
+	t.Helper()
+
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	ctx := context.Background()
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+	cfg.External.APIKey = macHostTestKey
+	cfg.Features.EnableEventBusIngest = true
+
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+
+	hostRepo := repository.NewMacHostRepository(database.Queries)
+	pairingRepo := repository.NewMacHostPairingTokenRepository(database.Queries)
+	syncRepo := repository.NewSyncRepositoryWithPool(database.Queries, database.Pool)
+	contactMethodRepo := repository.NewContactMethodRepository(database.Queries)
+	externalRepo := repository.NewExternalContactRepository(database.Queries)
+	meetingRepo := repository.NewMeetingNoteRepository(database.Queries)
+	macService := service.NewMacHostService(hostRepo, pairingRepo, syncRepo, contactMethodRepo, externalRepo, meetingRepo, database.Pool, 4)
+
+	identityRepo := repository.NewIdentityRepository(database.Queries)
+	identityService := service.NewIdentityService(identityRepo)
+	contactRepo := repository.NewContactRepository(database.Queries)
+	contactRepo.SetPool(database.Pool)
+	interactionRepo := repository.NewInteractionRepository(database.Queries)
+	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
+	calendarRepo := repository.NewCalendarEventRepository(database.Queries)
+
+	eventRepo := repository.NewEventRepository(database.Queries)
+	eventBus := events.NewBus(database.Pool, nil, eventRepo)
+
+	// ContactService is constructed without a CadenceUpdater here; the
+	// inline meeting_note handler calls RecordInteractionTx with
+	// publishesEvent=false which would normally require cadence. Wire a
+	// minimal cadence updater for completeness so the tests exercise the
+	// full path the production wiring uses.
+	contactSvc := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, eventBus, service.NewRematchService())
+	contactSvc.SetCadenceUpdater(wireCadenceUpdaterForAPITest(t, database, contactSvc))
+
+	ingestService := service.NewIngestService(
+		database,
+		eventBus,
+		identityService,
+		nil, // messagesRepo unused
+		nil, // riverClient unused
+		externalRepo,
+		hostRepo,
+		meetingRepo,
+		calendarRepo,
+		interactionRepo,
+		identityRepo,
+		contactSvc,
+	)
+	ingestHandler := handlers.NewIngestHandler(ingestService)
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(api.RequestIDMiddleware())
+	router.Use(api.LoggingMiddleware())
+	router.Use(api.CORSMiddleware(cfg.CORS))
+
+	limiter := auth.NewPairingIPRateLimiter()
+	macHandler := handlers.NewMacHostHandler(macService, limiter)
+	handlers.RegisterMacHostRoutes(router, handlers.MacHostRouteDeps{
+		HostRepo:    hostRepo,
+		Handler:     macHandler,
+		AuthLimiter: auth.DefaultMacHostAuthLimiterConfig(),
+	})
+
+	ingestAuth := auth.IngestAuthMiddleware(
+		auth.APIKeyMiddleware(cfg),
+		auth.MacHostAuthMiddleware(hostRepo, auth.DefaultPasswordComparator, auth.DefaultMacHostAuthLimiterConfig()),
+	)
+	ingestGroup := router.Group("/api/v1/ingest")
+	ingestGroup.Use(ingestAuth)
+	ingestGroup.POST("/events", ingestHandler.IngestEvents)
+
+	plain, _, err := macService.CreatePairingToken(ctx)
+	require.NoError(t, err)
+	pair, err := macService.PairWithToken(ctx, plain, "meeting-note-test", "0.1.0", 1)
+	require.NoError(t, err)
+
+	suffix := uuid.NewString()[:8]
+	env := &meetingNoteIngestEnv{
+		router:         router,
+		apiKey:         cfg.External.APIKey,
+		database:       database,
+		macService:     macService,
+		externalRepo:   externalRepo,
+		meetingRepo:    meetingRepo,
+		contactRepo:    contactRepo,
+		calendarRepo:   calendarRepo,
+		interactionRep: interactionRepo,
+		identityRepo:   identityRepo,
+		pairedHostID:   pair.HostID,
+		pairedHostKey:  pair.APIKey,
+		sourceIDPrefix: "mn-ingest-" + suffix + "-",
+	}
+
+	// Seed three CRM contacts each with a synthetic email that the
+	// meeting_note tests use to resolve anarlog_humans candidates into
+	// CRM contacts via the existing email-match path.
+	for i, slot := range []*uuid.UUID{&env.contactA, &env.contactB, &env.contactC} {
+		c, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
+			FullName: fmt.Sprintf("MN Test Contact %d %s", i, suffix),
+		})
+		require.NoError(t, err)
+		*slot = c.ID
+		_, err = contactMethodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
+			ContactID: c.ID,
+			Type:      "email",
+			Value:     fmt.Sprintf("mn-test-%d-%s@example.invalid", i, suffix),
+		})
+		require.NoError(t, err)
+	}
+
+	t.Cleanup(func() {
+		cleanCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		// Drop interactions seeded by these tests (covers anarlog session refs).
+		_ = interactionRepo.HardDeleteInteractionsBySourceRefPrefix(cleanCtx, "anarlog_sessions", "anarlog:"+env.sourceIDPrefix+"%")
+		_ = interactionRepo.HardDeleteInteractionsBySourceRefPrefix(cleanCtx, "anarlog_sessions", "anarlog:%")
+		// Drop meeting_note rows seeded by these tests (by session-UUID prefix).
+		_ = meetingRepo.TestHardDeleteBySessionIDPrefix(cleanCtx, env.sourceIDPrefix+"%")
+		// Drop synthetic anarlog_humans external_contact rows.
+		_ = database.Queries.TestDeleteExternalContactsBySourceIDPrefix(cleanCtx, env.sourceIDPrefix)
+		_, _ = database.Queries.DeleteExternalIdentitiesBySource(cleanCtx, "anarlog_humans")
+		_, _ = database.Queries.DeleteEventsBySource(cleanCtx, "anarlog_sessions")
+		_, _ = database.Queries.DeleteEventsBySource(cleanCtx, "anarlog_humans")
+		// Drop synthetic calendar events seeded by these tests.
+		_ = database.Queries.TestDeleteCalendarEventsByGcalEventIDPrefix(cleanCtx, env.sourceIDPrefix+"cal-")
+		// Drop seeded contacts + their methods.
+		for _, id := range []uuid.UUID{env.contactA, env.contactB, env.contactC} {
+			_ = contactMethodRepo.DeleteContactMethodsByContact(cleanCtx, id)
+			_ = contactRepo.HardDeleteContact(cleanCtx, id)
+		}
+		_, _ = database.Queries.DeleteAllMacHosts(cleanCtx)
+		_, _ = database.Queries.DeleteAllPairingTokens(cleanCtx)
+		database.Close()
+	})
+
+	return env
+}
+
+// seedAnarlogHumanResolvingTo upserts an anarlog_humans external_contact
+// (and the anarlog_human_id identity row + link to the contact) by
+// posting via the ingest endpoint. The email passed in must match a
+// contact_method on the target contactID so the existing email-match
+// path wires crm_contact_id. Returns the synthetic anarlog UUID used as
+// SourceID.
+func (e *meetingNoteIngestEnv) seedAnarlogHumanResolvingTo(t *testing.T, email string) string {
+	t.Helper()
+	anarlogID := uuid.NewString()
+	dn := "Tagged Human " + anarlogID[:8]
+	p := events.ExternalContactUpsertedPayload{
+		Version:     1,
+		HostID:      e.pairedHostID,
+		Source:      "anarlog_humans",
+		EntityID:    anarlogID,
+		DisplayName: &dn,
+		Emails:      []events.ExternalContactMethodValue{{Value: email}},
+	}
+	pBytes, err := events.Marshal(events.KindExternalContactUpserted, p)
+	require.NoError(t, err)
+	srcID := computeUpsertSourceID(t, anarlogID, pBytes)
+	body := map[string]any{
+		"events": []any{
+			map[string]any{
+				"source":      "anarlog_humans",
+				"source_id":   srcID,
+				"kind":        string(events.KindExternalContactUpserted),
+				"payload":     json.RawMessage(pBytes),
+				"observed_at": accelerated.GetCurrentTime(),
+			},
+		},
+	}
+	b, err := json.Marshal(body)
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/ingest/events", bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Mac-Host-ID", e.pairedHostID.String())
+	req.Header.Set("Authorization", "Bearer "+e.pairedHostKey)
+	w := httptest.NewRecorder()
+	e.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseIngestResp(t, w)
+	require.Equal(t, 1, resp.Accepted, "anarlog_humans upsert must be accepted")
+	return anarlogID
+}
+
+// seedCalendarEventInWindow inserts a calendar_event row centered at
+// the given start time with the given matched_contact_ids. Returns the
+// inserted event ID.
+func (e *meetingNoteIngestEnv) seedCalendarEventInWindow(t *testing.T, startTime time.Time, matchedContactIDs []uuid.UUID) uuid.UUID {
+	t.Helper()
+	ctx := context.Background()
+	suffix := uuid.NewString()[:8]
+	upserted, err := e.calendarRepo.Upsert(ctx, repository.UpsertCalendarEventRequest{
+		GcalEventID:       e.sourceIDPrefix + "cal-" + suffix,
+		GcalCalendarID:    "primary",
+		GoogleAccountID:   "test-account",
+		Title:             stringPtr(e.sourceIDPrefix + "Test Event"),
+		StartTime:         startTime,
+		EndTime:           startTime.Add(time.Hour),
+		Status:            "confirmed",
+		Attendees:         []repository.Attendee{},
+		MatchedContactIDs: matchedContactIDs,
+		SyncedAt:          accelerated.GetCurrentTime(),
+	})
+	require.NoError(t, err)
+	return upserted.ID
+}
+
+// buildMNRecordedEvent constructs a meeting_note.recorded envelope ready
+// for POST. The session_id, meeting_at, title, and participant_ids are
+// caller-controlled.
+func buildMNRecordedEvent(t *testing.T, hostID uuid.UUID, sessionUUID string, meetingAt time.Time, title string, participantIDs []string) map[string]any {
+	t.Helper()
+	tp := title
+	p := events.MeetingNoteRecordedPayload{
+		Version:        1,
+		HostID:         hostID,
+		Source:         "anarlog_sessions",
+		SourceID:       sessionUUID,
+		Title:          &tp,
+		MeetingAt:      meetingAt,
+		ParticipantIDs: participantIDs,
+	}
+	pBytes, err := events.Marshal(events.KindMeetingNoteRecorded, p)
+	require.NoError(t, err)
+	hashHex, err := service.ComputeContentHash(pBytes)
+	require.NoError(t, err)
+	return map[string]any{
+		"source":      "anarlog_sessions",
+		"source_id":   sessionUUID + "@" + hashHex,
+		"kind":        string(events.KindMeetingNoteRecorded),
+		"payload":     json.RawMessage(pBytes),
+		"observed_at": accelerated.GetCurrentTime(),
+	}
+}
+
+// buildMNDeletedEvent constructs a meeting_note.deleted envelope using
+// the supplied last_content_hash (or @unknown sentinel when empty).
+func buildMNDeletedEvent(t *testing.T, hostID uuid.UUID, sessionUUID, lastContentHash string) map[string]any {
+	t.Helper()
+	p := events.MeetingNoteDeletedPayload{
+		Version:  1,
+		HostID:   hostID,
+		Source:   "anarlog_sessions",
+		SourceID: sessionUUID,
+	}
+	pBytes, err := events.Marshal(events.KindMeetingNoteDeleted, p)
+	require.NoError(t, err)
+	suffix := "unknown"
+	if lastContentHash != "" {
+		suffix = lastContentHash
+	}
+	return map[string]any{
+		"source":      "anarlog_sessions",
+		"source_id":   sessionUUID + "@deleted@" + suffix,
+		"kind":        string(events.KindMeetingNoteDeleted),
+		"payload":     json.RawMessage(pBytes),
+		"observed_at": accelerated.GetCurrentTime(),
+	}
+}
+
+// ingestMNResponse adds the NeedsAttention field to the base ingest
+// response shape so tests can assert on it.
+type ingestMNResponse struct {
+	Accepted       int                           `json:"accepted"`
+	Duplicate      int                           `json:"duplicate"`
+	Rejected       int                           `json:"rejected"`
+	Errors         []handlers.IngestError        `json:"errors"`
+	NeedsAttention []handlers.NeedsAttentionItem `json:"needs_attention"`
+}
+
+func parseMNIngestResp(t *testing.T, w *httptest.ResponseRecorder) ingestMNResponse {
+	t.Helper()
+	var r ingestMNResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&r), "body: %s", w.Body.String())
+	return r
+}
+
+func postMNIngest(t *testing.T, env *meetingNoteIngestEnv, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	b, err := json.Marshal(body)
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/ingest/events", bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Mac-Host-ID", env.pairedHostID.String())
+	req.Header.Set("Authorization", "Bearer "+env.pairedHostKey)
+	w := httptest.NewRecorder()
+	env.router.ServeHTTP(w, req)
+	return w
+}
+
+// findMeetingNoteRow looks up a meeting_note row by session UUID via
+// the repository's tombstone-aware FOR-UPDATE-equivalent path; we use
+// the regular GetMeetingNoteBySessionID which only returns live rows.
+// For tombstone-aware lookups we open a tx and call the ForUpdate variant.
+func findMeetingNoteRow(t *testing.T, env *meetingNoteIngestEnv, sessionUUID string) *repository.MeetingNote {
+	t.Helper()
+	ctx := context.Background()
+	sid, err := uuid.Parse(sessionUUID)
+	require.NoError(t, err)
+	tx, err := env.database.Pool.Begin(ctx)
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback(ctx) }()
+	row, err := env.meetingRepo.GetMeetingNoteBySessionIDForUpdateTx(ctx, tx, sid)
+	if err == db.ErrNotFound {
+		return nil
+	}
+	require.NoError(t, err)
+	return row
+}
+
+// listSessionInteractions returns the live session-attributed interactions
+// (matching anarlog:<sid>:%) for the given session UUID.
+func listSessionInteractions(t *testing.T, env *meetingNoteIngestEnv, sessionUUID string) []repository.Interaction {
+	t.Helper()
+	ctx := context.Background()
+	tx, err := env.database.Pool.Begin(ctx)
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback(ctx) }()
+	out, err := env.interactionRep.ListSessionAttributedInteractionsTx(ctx, tx, "anarlog:"+sessionUUID+":%")
+	require.NoError(t, err)
+	return out
+}
+
+// ----------------------------------------------------------------------------
+// TC-L1: 0 candidates + 0 resolved tagged humans → orphan_needs_review,
+// no interactions, needs_attention contains the session with reason=orphan.
+// ----------------------------------------------------------------------------
+func TestMeetingNote_OrphanNoTagged(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	sessionUUID := uuid.NewString()
+	meetingAt := time.Date(2026, 5, 1, 14, 30, 0, 0, time.UTC)
+	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Orphan Session", nil)
+	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseMNIngestResp(t, w)
+	require.Equal(t, 1, resp.Accepted)
+	require.Equal(t, 0, resp.Rejected)
+
+	row := findMeetingNoteRow(t, env, sessionUUID)
+	require.NotNil(t, row)
+	require.Equal(t, repository.LinkageStateOrphanNeedsReview, row.LinkageState)
+	require.Nil(t, row.LinkedKind)
+	require.Nil(t, row.LinkedID)
+	require.True(t, meetingAt.Equal(row.MeetingAt))
+	require.NotEmpty(t, row.InputHash)
+	require.NotNil(t, row.LastContentHash)
+
+	require.Empty(t, listSessionInteractions(t, env, sessionUUID))
+	require.Len(t, resp.NeedsAttention, 1)
+	require.Equal(t, sessionUUID, resp.NeedsAttention[0].SessionID)
+	require.Equal(t, "orphan", resp.NeedsAttention[0].Reason)
+}
+
+// ----------------------------------------------------------------------------
+// TC-L2: 0 candidates + 2 resolved tagged humans → linked_impromptu, 2
+// interactions, no needs_attention.
+// ----------------------------------------------------------------------------
+func TestMeetingNote_LinkedImpromptu(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	// Resolve the seeded contacts via anarlog_humans seeding.
+	suffix := strings.TrimPrefix(env.sourceIDPrefix, "mn-ingest-")
+	suffix = strings.TrimSuffix(suffix, "-")
+	emailA := fmt.Sprintf("mn-test-0-%s@example.invalid", suffix)
+	emailB := fmt.Sprintf("mn-test-1-%s@example.invalid", suffix)
+	anarlogA := env.seedAnarlogHumanResolvingTo(t, emailA)
+	anarlogB := env.seedAnarlogHumanResolvingTo(t, emailB)
+
+	sessionUUID := uuid.NewString()
+	meetingAt := time.Date(2026, 5, 1, 15, 0, 0, 0, time.UTC)
+	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Impromptu Session", []string{anarlogA, anarlogB})
+	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseMNIngestResp(t, w)
+	require.Equal(t, 1, resp.Accepted)
+
+	row := findMeetingNoteRow(t, env, sessionUUID)
+	require.NotNil(t, row)
+	require.Equal(t, repository.LinkageStateLinkedImpromptu, row.LinkageState)
+	require.Nil(t, row.LinkedKind)
+
+	ixs := listSessionInteractions(t, env, sessionUUID)
+	require.Len(t, ixs, 2)
+	gotRefs := []string{}
+	for _, ix := range ixs {
+		require.NotNil(t, ix.SourceRef)
+		gotRefs = append(gotRefs, *ix.SourceRef)
+		require.Equal(t, "mutual", ix.Direction)
+		require.Equal(t, "anarlog_sessions", ix.Source)
+		require.True(t, meetingAt.Equal(ix.OccurredAt))
+	}
+	require.Contains(t, gotRefs, "anarlog:"+sessionUUID+":"+env.contactA.String())
+	require.Contains(t, gotRefs, "anarlog:"+sessionUUID+":"+env.contactB.String())
+	require.Empty(t, resp.NeedsAttention)
+}
+
+// ----------------------------------------------------------------------------
+// TC-L4: 1 candidate + no tagged humans → linked, no interactions, no
+// needs_attention.
+// ----------------------------------------------------------------------------
+func TestMeetingNote_OneCandidateNoTagged(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	meetingAt := time.Date(2026, 5, 2, 10, 0, 0, 0, time.UTC)
+	eventID := env.seedCalendarEventInWindow(t, meetingAt, []uuid.UUID{env.contactA, env.contactB})
+
+	sessionUUID := uuid.NewString()
+	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Linked Session", nil)
+	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseMNIngestResp(t, w)
+	require.Equal(t, 1, resp.Accepted)
+
+	row := findMeetingNoteRow(t, env, sessionUUID)
+	require.NotNil(t, row)
+	require.Equal(t, repository.LinkageStateLinked, row.LinkageState)
+	require.NotNil(t, row.LinkedKind)
+	require.Equal(t, "event", *row.LinkedKind)
+	require.NotNil(t, row.LinkedID)
+	require.Equal(t, eventID, *row.LinkedID)
+	require.Empty(t, listSessionInteractions(t, env, sessionUUID))
+	require.Empty(t, resp.NeedsAttention)
+}
+
+// ----------------------------------------------------------------------------
+// TC-L6: 1 candidate + tagged human NOT in attendees → linked + walk-in
+// interaction.
+// ----------------------------------------------------------------------------
+func TestMeetingNote_OneCandidateWalkin(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	meetingAt := time.Date(2026, 5, 2, 11, 0, 0, 0, time.UTC)
+	// Calendar event has contactA as attendee.
+	eventID := env.seedCalendarEventInWindow(t, meetingAt, []uuid.UUID{env.contactA})
+
+	// Tag contactB (NOT in attendees) → walk-in expected.
+	suffix := strings.TrimPrefix(env.sourceIDPrefix, "mn-ingest-")
+	suffix = strings.TrimSuffix(suffix, "-")
+	emailB := fmt.Sprintf("mn-test-1-%s@example.invalid", suffix)
+	anarlogB := env.seedAnarlogHumanResolvingTo(t, emailB)
+
+	sessionUUID := uuid.NewString()
+	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Linked + Walkin", []string{anarlogB})
+	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+
+	row := findMeetingNoteRow(t, env, sessionUUID)
+	require.NotNil(t, row)
+	require.Equal(t, repository.LinkageStateLinked, row.LinkageState)
+	require.NotNil(t, row.LinkedID)
+	require.Equal(t, eventID, *row.LinkedID)
+
+	ixs := listSessionInteractions(t, env, sessionUUID)
+	require.Len(t, ixs, 1, "exactly one walk-in interaction for contactB")
+	require.NotNil(t, ixs[0].SourceRef)
+	expectedRef := "anarlog:" + sessionUUID + ":walkin:" + env.contactB.String()
+	require.Equal(t, expectedRef, *ixs[0].SourceRef)
+}
+
+// ----------------------------------------------------------------------------
+// TC-L7: 2+ calendar candidates → conflict_pending, no interactions,
+// needs_attention with reason=conflict.
+// ----------------------------------------------------------------------------
+func TestMeetingNote_TwoCandidatesConflict(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	meetingAt := time.Date(2026, 5, 3, 9, 0, 0, 0, time.UTC)
+	env.seedCalendarEventInWindow(t, meetingAt, []uuid.UUID{env.contactA})
+	env.seedCalendarEventInWindow(t, meetingAt.Add(5*time.Minute), []uuid.UUID{env.contactB})
+
+	sessionUUID := uuid.NewString()
+	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Conflict Session", nil)
+	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseMNIngestResp(t, w)
+	require.Equal(t, 1, resp.Accepted)
+
+	row := findMeetingNoteRow(t, env, sessionUUID)
+	require.NotNil(t, row)
+	require.Equal(t, repository.LinkageStateConflictPending, row.LinkageState)
+	require.Nil(t, row.LinkedKind)
+	require.Nil(t, row.LinkedID)
+	require.Empty(t, listSessionInteractions(t, env, sessionUUID))
+	require.Len(t, resp.NeedsAttention, 1)
+	require.Equal(t, "conflict", resp.NeedsAttention[0].Reason)
+}
+
+// ----------------------------------------------------------------------------
+// TC-D1: meeting_note.deleted soft-deletes meeting_note + all
+// session-attributed interactions.
+// ----------------------------------------------------------------------------
+func TestMeetingNote_DeleteCascadesToInteractions(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	suffix := strings.TrimPrefix(env.sourceIDPrefix, "mn-ingest-")
+	suffix = strings.TrimSuffix(suffix, "-")
+	emailA := fmt.Sprintf("mn-test-0-%s@example.invalid", suffix)
+	anarlogA := env.seedAnarlogHumanResolvingTo(t, emailA)
+
+	sessionUUID := uuid.NewString()
+	meetingAt := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+	rec := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Will Delete", []string{anarlogA})
+	w := postMNIngest(t, env, map[string]any{"events": []any{rec}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+	require.Len(t, listSessionInteractions(t, env, sessionUUID), 1)
+
+	// Get the content hash to construct a valid delete source_id.
+	row := findMeetingNoteRow(t, env, sessionUUID)
+	require.NotNil(t, row)
+	require.NotNil(t, row.LastContentHash)
+
+	del := buildMNDeletedEvent(t, env.pairedHostID, sessionUUID, *row.LastContentHash)
+	w = postMNIngest(t, env, map[string]any{"events": []any{del}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+
+	// Live lookup returns nil; tombstoned row still exists.
+	ctx := context.Background()
+	sid, _ := uuid.Parse(sessionUUID)
+	tx, err := env.database.Pool.Begin(ctx)
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback(ctx) }()
+	liveRow, _ := env.meetingRepo.GetMeetingNoteBySessionIDTx(ctx, tx, sid)
+	require.Nil(t, liveRow, "live row must be gone after delete")
+	tomb, err := env.meetingRepo.GetTombstonedMeetingNoteBySessionIDTx(ctx, tx, sid)
+	require.NoError(t, err)
+	require.NotNil(t, tomb, "tombstoned row preserved for audit")
+	require.NotNil(t, tomb.DeletedAt)
+
+	// All session interactions tombstoned.
+	require.Empty(t, listSessionInteractions(t, env, sessionUUID))
+}
+
+// ----------------------------------------------------------------------------
+// TC-D2: meeting_note.deleted for unknown session → silent no-op
+// (accepted=1, no DB changes).
+// ----------------------------------------------------------------------------
+func TestMeetingNote_DeleteUnknownSilentNoOp(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	unknownSession := uuid.NewString()
+	del := buildMNDeletedEvent(t, env.pairedHostID, unknownSession, "")
+	w := postMNIngest(t, env, map[string]any{"events": []any{del}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseMNIngestResp(t, w)
+	require.Equal(t, 1, resp.Accepted)
+	require.Equal(t, 0, resp.Rejected)
+	require.Nil(t, findMeetingNoteRow(t, env, unknownSession))
+}
+
+// ----------------------------------------------------------------------------
+// TC-RS1: re-sync with unchanged inputs carries forward; interaction set
+// unchanged.
+// ----------------------------------------------------------------------------
+func TestMeetingNote_ResyncCarryForward(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	suffix := strings.TrimPrefix(env.sourceIDPrefix, "mn-ingest-")
+	suffix = strings.TrimSuffix(suffix, "-")
+	emailA := fmt.Sprintf("mn-test-0-%s@example.invalid", suffix)
+	anarlogA := env.seedAnarlogHumanResolvingTo(t, emailA)
+
+	sessionUUID := uuid.NewString()
+	meetingAt := time.Date(2026, 5, 5, 14, 0, 0, 0, time.UTC)
+	rec := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Same Title", []string{anarlogA})
+	w := postMNIngest(t, env, map[string]any{"events": []any{rec}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+	firstIxs := listSessionInteractions(t, env, sessionUUID)
+	require.Len(t, firstIxs, 1)
+	firstID := firstIxs[0].ID
+
+	// Re-send the SAME payload — bus-dedup will skip the inline handler
+	// (live row, content hash unchanged, so not a revive case). Tests
+	// the dispatch loop's duplicate guard.
+	w = postMNIngest(t, env, map[string]any{"events": []any{rec}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseMNIngestResp(t, w)
+	require.Equal(t, 1, resp.Duplicate)
+
+	// Interaction set unchanged.
+	afterIxs := listSessionInteractions(t, env, sessionUUID)
+	require.Len(t, afterIxs, 1)
+	require.Equal(t, firstID, afterIxs[0].ID)
+}
+
+// ----------------------------------------------------------------------------
+// TC-RS2: re-sync with changed participant_ids re-runs linkage and
+// diffs interactions (existing dropped, new inserted).
+// ----------------------------------------------------------------------------
+func TestMeetingNote_ResyncDiffsInteractions(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	suffix := strings.TrimPrefix(env.sourceIDPrefix, "mn-ingest-")
+	suffix = strings.TrimSuffix(suffix, "-")
+	emailA := fmt.Sprintf("mn-test-0-%s@example.invalid", suffix)
+	emailB := fmt.Sprintf("mn-test-1-%s@example.invalid", suffix)
+	emailC := fmt.Sprintf("mn-test-2-%s@example.invalid", suffix)
+	anarlogA := env.seedAnarlogHumanResolvingTo(t, emailA)
+	anarlogB := env.seedAnarlogHumanResolvingTo(t, emailB)
+	anarlogC := env.seedAnarlogHumanResolvingTo(t, emailC)
+
+	sessionUUID := uuid.NewString()
+	meetingAt := time.Date(2026, 5, 6, 14, 0, 0, 0, time.UTC)
+
+	rec1 := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Initial", []string{anarlogA, anarlogB})
+	w := postMNIngest(t, env, map[string]any{"events": []any{rec1}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+	require.Len(t, listSessionInteractions(t, env, sessionUUID), 2)
+
+	// Swap B for C — input_hash changes, linkage re-runs, diff fires.
+	rec2 := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Initial", []string{anarlogA, anarlogC})
+	w = postMNIngest(t, env, map[string]any{"events": []any{rec2}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+
+	ixs := listSessionInteractions(t, env, sessionUUID)
+	require.Len(t, ixs, 2)
+	gotRefs := []string{}
+	for _, ix := range ixs {
+		gotRefs = append(gotRefs, *ix.SourceRef)
+	}
+	require.Contains(t, gotRefs, "anarlog:"+sessionUUID+":"+env.contactA.String())
+	require.Contains(t, gotRefs, "anarlog:"+sessionUUID+":"+env.contactC.String())
+	require.NotContains(t, gotRefs, "anarlog:"+sessionUUID+":"+env.contactB.String())
+}
+
+// ----------------------------------------------------------------------------
+// TC-DD1 (round-1 P1#8): two anarlog_human_ids mapping to the same CRM
+// contact produce exactly ONE interaction.
+// ----------------------------------------------------------------------------
+func TestMeetingNote_DedupesByContactID(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	suffix := strings.TrimPrefix(env.sourceIDPrefix, "mn-ingest-")
+	suffix = strings.TrimSuffix(suffix, "-")
+	emailA := fmt.Sprintf("mn-test-0-%s@example.invalid", suffix)
+	// Two anarlog humans both carrying the SAME email → both resolve to
+	// contactA via the existing email-match path.
+	anarlog1 := env.seedAnarlogHumanResolvingTo(t, emailA)
+	anarlog2 := env.seedAnarlogHumanResolvingTo(t, emailA)
+	require.NotEqual(t, anarlog1, anarlog2)
+
+	sessionUUID := uuid.NewString()
+	meetingAt := time.Date(2026, 5, 7, 14, 0, 0, 0, time.UTC)
+	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Dedup Test", []string{anarlog1, anarlog2})
+	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+
+	ixs := listSessionInteractions(t, env, sessionUUID)
+	require.Len(t, ixs, 1, "two anarlog humans resolving to the same contact must produce ONE interaction")
+	require.Equal(t, "anarlog:"+sessionUUID+":"+env.contactA.String(), *ixs[0].SourceRef)
+}
+
+// ----------------------------------------------------------------------------
+// TC-IM1 (round-1 P1#4): import flow backfills the anarlog identity row;
+// subsequent meeting_note re-sync resolves the human.
+// ----------------------------------------------------------------------------
+func TestMeetingNote_ImportBackfillResolvesOnResync(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+
+	// Seed an anarlog_humans candidate that does NOT match any seeded
+	// contact (unique email) so it lands with crm_contact_id=NULL +
+	// identity row unmatched.
+	unmatchedEmail := "unmatched-" + uuid.NewString()[:8] + "@example.invalid"
+	anarlogX := env.seedAnarlogHumanResolvingTo(t, unmatchedEmail)
+
+	// First meeting_note.recorded → orphan_needs_review (unresolved tag,
+	// 0 candidates).
+	sessionUUID := uuid.NewString()
+	meetingAt := time.Date(2026, 5, 8, 14, 0, 0, 0, time.UTC)
+	rec1 := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Pre-Import", []string{anarlogX})
+	w := postMNIngest(t, env, map[string]any{"events": []any{rec1}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseMNIngestResp(t, w)
+	require.Equal(t, 1, resp.Accepted)
+	require.Len(t, resp.NeedsAttention, 1)
+	require.Equal(t, "orphan", resp.NeedsAttention[0].Reason)
+	require.Empty(t, listSessionInteractions(t, env, sessionUUID))
+
+	// Simulate user import via the repository LinkToContact + identity
+	// backfill. The handler-level import path is exercised by other
+	// tests; here we just need the side effect (identity row linked).
+	ctx := context.Background()
+	idents, err := env.identityRepo.FindIdentitiesByAnarlogHumanID(ctx, anarlogX)
+	require.NoError(t, err)
+	require.Len(t, idents, 1, "identity row planted at ingest time")
+	require.Nil(t, idents[0].ContactID, "unmatched before import")
+	_, err = env.identityRepo.LinkToContact(ctx, repository.LinkIdentityRequest{
+		IdentityID: idents[0].ID,
+		ContactID:  env.contactA,
+		MatchType:  repository.MatchTypeManual,
+	})
+	require.NoError(t, err)
+
+	// Re-send the same payload (same source_id since content didn't
+	// change) — bus-dedup will mark it duplicate, but the resolved-set
+	// hash now differs (was empty, now contains contactA), so the
+	// inline handler MUST run via the revive-bypass? Actually no: the
+	// revive-bypass only fires on tombstoned rows. The carry-forward
+	// gate compares input_hash AND resolved_set_hash. Resolved set
+	// changed, so the handler re-runs.
+	//
+	// But on a duplicate (same source_id), the dispatch loop skips the
+	// inline handler entirely unless shouldRunInlineOnDuplicate
+	// returns true. For non-tombstoned rows it returns false → the
+	// handler is skipped → resolved set drift is NOT picked up on a
+	// duplicate.
+	//
+	// The spec / plan calls for picking it up. The mechanism: the
+	// daemon sends a NEW source_id whenever the payload changes (the
+	// hash recipe). With identical participants + meeting_at + title,
+	// the content hash matches and the source_id matches → bus-dedup
+	// fires. The intended trigger for backfill-driven re-resolution
+	// is a SUBSEQUENT payload that does have content changes (e.g.,
+	// summary edit). Re-send with a slightly different title so the
+	// content hash differs.
+	rec2 := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Post-Import edit", []string{anarlogX})
+	w = postMNIngest(t, env, map[string]any{"events": []any{rec2}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp2 := parseMNIngestResp(t, w)
+	require.Equal(t, 1, resp2.Accepted, "different content hash → fresh event")
+
+	row := findMeetingNoteRow(t, env, sessionUUID)
+	require.NotNil(t, row)
+	require.Equal(t, repository.LinkageStateLinkedImpromptu, row.LinkageState,
+		"after import + re-sync, resolved tagged human → linked_impromptu")
+	ixs := listSessionInteractions(t, env, sessionUUID)
+	require.Len(t, ixs, 1)
+	require.Equal(t, "anarlog:"+sessionUUID+":"+env.contactA.String(), *ixs[0].SourceRef)
+}
+
+// ----------------------------------------------------------------------------
+// TC-RV1 (round-1 P0#1): delete then re-record identical content →
+// row revives (deleted_at cleared), interactions reinserted.
+// ----------------------------------------------------------------------------
+func TestMeetingNote_DeleteThenReviveIdenticalContent(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	suffix := strings.TrimPrefix(env.sourceIDPrefix, "mn-ingest-")
+	suffix = strings.TrimSuffix(suffix, "-")
+	emailA := fmt.Sprintf("mn-test-0-%s@example.invalid", suffix)
+	anarlogA := env.seedAnarlogHumanResolvingTo(t, emailA)
+
+	sessionUUID := uuid.NewString()
+	meetingAt := time.Date(2026, 5, 9, 14, 0, 0, 0, time.UTC)
+	rec := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Revive Me", []string{anarlogA})
+
+	// Initial insert.
+	w := postMNIngest(t, env, map[string]any{"events": []any{rec}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+	row := findMeetingNoteRow(t, env, sessionUUID)
+	require.NotNil(t, row)
+	require.NotNil(t, row.LastContentHash)
+	priorHash := *row.LastContentHash
+
+	// Delete.
+	del := buildMNDeletedEvent(t, env.pairedHostID, sessionUUID, priorHash)
+	w = postMNIngest(t, env, map[string]any{"events": []any{del}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+	require.Empty(t, listSessionInteractions(t, env, sessionUUID))
+
+	// Re-send the SAME recorded payload — source_id is identical, so
+	// bus-dedup hits, but the revive-bypass probe should detect the
+	// tombstone and run the handler anyway.
+	w = postMNIngest(t, env, map[string]any{"events": []any{rec}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseMNIngestResp(t, w)
+	require.Equal(t, 1, resp.Duplicate, "source_id matched → bus-dedup")
+	// But the row revived.
+	row = findMeetingNoteRow(t, env, sessionUUID)
+	require.NotNil(t, row)
+	require.Nil(t, row.DeletedAt, "revive cleared deleted_at")
+	require.Equal(t, repository.LinkageStateLinkedImpromptu, row.LinkageState)
+
+	// And one fresh interaction.
+	ixs := listSessionInteractions(t, env, sessionUUID)
+	require.Len(t, ixs, 1)
+}
+
+// ----------------------------------------------------------------------------
+// TC-A1: external_contact.upserted (source='anarlog_humans') creates
+// the external_contact row AND the external_identity row keyed by
+// anarlog_human_id.
+// ----------------------------------------------------------------------------
+func TestMeetingNote_AnarlogHumanIdentityRegistered(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	suffix := strings.TrimPrefix(env.sourceIDPrefix, "mn-ingest-")
+	suffix = strings.TrimSuffix(suffix, "-")
+	emailA := fmt.Sprintf("mn-test-0-%s@example.invalid", suffix)
+	anarlogID := env.seedAnarlogHumanResolvingTo(t, emailA)
+
+	// Identity row exists and is linked to contactA via the email-match
+	// + anarlog-link path in handleExternalContactUpserted.
+	ctx := context.Background()
+	idents, err := env.identityRepo.FindIdentitiesByAnarlogHumanID(ctx, anarlogID)
+	require.NoError(t, err)
+	require.Len(t, idents, 1)
+	require.NotNil(t, idents[0].ContactID)
+	require.Equal(t, env.contactA, *idents[0].ContactID)
+}
+
+// ----------------------------------------------------------------------------
+// TC-KI1: /known-ids?source=anarlog_sessions returns session UUIDs from
+// meeting_note.
+// ----------------------------------------------------------------------------
+func TestMeetingNote_KnownIDsForAnarlogSessions(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	meetingAt := time.Date(2026, 5, 10, 14, 0, 0, 0, time.UTC)
+	sessions := []string{uuid.NewString(), uuid.NewString(), uuid.NewString()}
+	for _, sid := range sessions {
+		ev := buildMNRecordedEvent(t, env.pairedHostID, sid, meetingAt, "Known IDs Test", nil)
+		w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
+		require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+		require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+	}
+
+	// GET /known-ids
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/host/"+env.pairedHostID.String()+"/sync/anarlog_sessions/known-ids", nil)
+	req.Header.Set("X-Mac-Host-ID", env.pairedHostID.String())
+	req.Header.Set("Authorization", "Bearer "+env.pairedHostKey)
+	w := httptest.NewRecorder()
+	env.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	type entry struct {
+		SourceID        string  `json:"source_id"`
+		LastContentHash *string `json:"last_content_hash"`
+	}
+	type resp struct {
+		Success bool `json:"success"`
+		Data    struct {
+			IDs []entry `json:"ids"`
+		} `json:"data"`
+	}
+	var r resp
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&r), "body: %s", w.Body.String())
+	gotIDs := make(map[string]bool)
+	for _, e := range r.Data.IDs {
+		gotIDs[e.SourceID] = true
+	}
+	for _, sid := range sessions {
+		require.True(t, gotIDs[sid], "expected session %s in known-ids response", sid)
+	}
+}

--- a/backend/tests/api/meeting_note_ingest_test.go
+++ b/backend/tests/api/meeting_note_ingest_test.go
@@ -136,6 +136,18 @@ func setupMeetingNoteIngestEnv(t *testing.T) *meetingNoteIngestEnv {
 	ingestGroup.Use(ingestAuth)
 	ingestGroup.POST("/events", ingestHandler.IngestEvents)
 
+	// Import handler wired so TestMeetingNote_ImportBackfillResolvesOnResync
+	// exercises the real /imports/:id/link path (the handler invokes
+	// backfillAnarlogIdentity which links the anarlog_human_id identity
+	// row to the imported contact).
+	enrichmentRepo := repository.NewEnrichmentRepository(database.Queries)
+	matchService := service.NewImportMatchService(contactRepo)
+	enrichmentSvc := service.NewEnrichmentService(database, contactRepo, contactMethodRepo, enrichmentRepo, nil, nil)
+	enrichmentSvc.SetCadenceUpdater(wireCadenceUpdaterForAPITest(t, database, contactSvc))
+	importHandler := handlers.NewImportHandler(externalRepo, identityRepo, contactSvc, matchService, enrichmentSvc)
+	imports := router.Group("/api/v1/imports")
+	imports.POST("/candidates/:id/link", importHandler.LinkContact)
+
 	plain, _, err := macService.CreatePairingToken(ctx)
 	require.NoError(t, err)
 	pair, err := macService.PairWithToken(ctx, plain, "meeting-note-test", "0.1.0", 1)
@@ -181,8 +193,10 @@ func setupMeetingNoteIngestEnv(t *testing.T) *meetingNoteIngestEnv {
 		// Drop interactions seeded by these tests (covers anarlog session refs).
 		_ = interactionRepo.HardDeleteInteractionsBySourceRefPrefix(cleanCtx, "anarlog_sessions", "anarlog:"+env.sourceIDPrefix+"%")
 		_ = interactionRepo.HardDeleteInteractionsBySourceRefPrefix(cleanCtx, "anarlog_sessions", "anarlog:%")
-		// Drop meeting_note rows seeded by these tests (by session-UUID prefix).
-		_ = meetingRepo.TestHardDeleteBySessionIDPrefix(cleanCtx, env.sourceIDPrefix+"%")
+		// Drop meeting_note rows seeded by these tests. Session UUIDs
+		// are caller-generated random UUIDs (no exploitable prefix), so
+		// scope by the paired mac_host_id this test created.
+		_ = meetingRepo.TestHardDeleteByHostID(cleanCtx, env.pairedHostID)
 		// Drop synthetic anarlog_humans external_contact rows.
 		_ = database.Queries.TestDeleteExternalContactsBySourceIDPrefix(cleanCtx, env.sourceIDPrefix)
 		_, _ = database.Queries.DeleteExternalIdentitiesBySource(cleanCtx, "anarlog_humans")
@@ -688,7 +702,50 @@ func TestMeetingNote_ResyncDiffsInteractions(t *testing.T) {
 }
 
 // ----------------------------------------------------------------------------
-// TC-DD1 (round-1 P1#8): two anarlog_human_ids mapping to the same CRM
+// Re-sync that changes meeting_at + title (without changing participants)
+// refreshes the existing session interactions' occurred_at + description
+// instead of leaving them stale.
+// ----------------------------------------------------------------------------
+func TestMeetingNote_ResyncRefreshesInteractionContent(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	suffix := strings.TrimPrefix(env.sourceIDPrefix, "mn-ingest-")
+	suffix = strings.TrimSuffix(suffix, "-")
+	emailA := fmt.Sprintf("mn-test-0-%s@example.invalid", suffix)
+	anarlogA := env.seedAnarlogHumanResolvingTo(t, emailA)
+
+	sessionUUID := uuid.NewString()
+	firstMeetingAt := time.Date(2026, 5, 20, 14, 0, 0, 0, time.UTC)
+	rec1 := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, firstMeetingAt, "First Title", []string{anarlogA})
+	w := postMNIngest(t, env, map[string]any{"events": []any{rec1}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+
+	before := listSessionInteractions(t, env, sessionUUID)
+	require.Len(t, before, 1)
+	require.True(t, firstMeetingAt.Equal(before[0].OccurredAt))
+	require.NotNil(t, before[0].Description)
+	require.Equal(t, "First Title", *before[0].Description)
+	beforeID := before[0].ID
+
+	// Re-sync with a different meeting_at + title. Same participant,
+	// same source_ref → the diff loop hits the in-both branch and
+	// refreshes occurred_at + description.
+	updatedMeetingAt := firstMeetingAt.Add(30 * time.Minute)
+	rec2 := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, updatedMeetingAt, "Updated Title", []string{anarlogA})
+	w = postMNIngest(t, env, map[string]any{"events": []any{rec2}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+
+	after := listSessionInteractions(t, env, sessionUUID)
+	require.Len(t, after, 1, "in-both diff must update, not drop+insert")
+	require.Equal(t, beforeID, after[0].ID, "same row updated in place")
+	require.True(t, updatedMeetingAt.Equal(after[0].OccurredAt), "occurred_at refreshed")
+	require.NotNil(t, after[0].Description)
+	require.Equal(t, "Updated Title", *after[0].Description)
+}
+
+// ----------------------------------------------------------------------------
+// TC-DD1: two anarlog_human_ids mapping to the same CRM
 // contact produce exactly ONE interaction.
 // ----------------------------------------------------------------------------
 func TestMeetingNote_DedupesByContactID(t *testing.T) {
@@ -740,48 +797,47 @@ func TestMeetingNote_ImportBackfillResolvesOnResync(t *testing.T) {
 	require.Equal(t, "orphan", resp.NeedsAttention[0].Reason)
 	require.Empty(t, listSessionInteractions(t, env, sessionUUID))
 
-	// Simulate user import via the repository LinkToContact + identity
-	// backfill. The handler-level import path is exercised by other
-	// tests; here we just need the side effect (identity row linked).
+	// Simulate user import via the actual /imports/:id/link handler
+	// endpoint. That handler calls backfillAnarlogIdentity which links
+	// the anarlog_human_id identity row to the imported contact —
+	// the exact path the production flow takes.
 	ctx := context.Background()
 	idents, err := env.identityRepo.FindIdentitiesByAnarlogHumanID(ctx, anarlogX)
 	require.NoError(t, err)
 	require.Len(t, idents, 1, "identity row planted at ingest time")
 	require.Nil(t, idents[0].ContactID, "unmatched before import")
-	_, err = env.identityRepo.LinkToContact(ctx, repository.LinkIdentityRequest{
-		IdentityID: idents[0].ID,
-		ContactID:  env.contactA,
-		MatchType:  repository.MatchTypeManual,
-	})
-	require.NoError(t, err)
 
-	// Re-send the same payload (same source_id since content didn't
-	// change) — bus-dedup will mark it duplicate, but the resolved-set
-	// hash now differs (was empty, now contains contactA), so the
-	// inline handler MUST run via the revive-bypass? Actually no: the
-	// revive-bypass only fires on tombstoned rows. The carry-forward
-	// gate compares input_hash AND resolved_set_hash. Resolved set
-	// changed, so the handler re-runs.
-	//
-	// But on a duplicate (same source_id), the dispatch loop skips the
-	// inline handler entirely unless shouldRunInlineOnDuplicate
-	// returns true. For non-tombstoned rows it returns false → the
-	// handler is skipped → resolved set drift is NOT picked up on a
-	// duplicate.
-	//
-	// The spec / plan calls for picking it up. The mechanism: the
-	// daemon sends a NEW source_id whenever the payload changes (the
-	// hash recipe). With identical participants + meeting_at + title,
-	// the content hash matches and the source_id matches → bus-dedup
-	// fires. The intended trigger for backfill-driven re-resolution
-	// is a SUBSEQUENT payload that does have content changes (e.g.,
-	// summary edit). Re-send with a slightly different title so the
-	// content hash differs.
-	rec2 := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Post-Import edit", []string{anarlogX})
-	w = postMNIngest(t, env, map[string]any{"events": []any{rec2}})
+	// Find the external_contact row for our anarlog candidate so we can
+	// POST to /imports/candidates/<id>/link.
+	external, err := env.externalRepo.GetBySource(ctx, "anarlog_humans", anarlogX, nil)
+	require.NoError(t, err)
+	require.NotNil(t, external)
+	linkReqBody, _ := json.Marshal(map[string]any{"crm_contact_id": env.contactA.String()})
+	linkReq := httptest.NewRequest(http.MethodPost,
+		"/api/v1/imports/candidates/"+external.ID.String()+"/link",
+		bytes.NewReader(linkReqBody))
+	linkReq.Header.Set("Content-Type", "application/json")
+	linkW := httptest.NewRecorder()
+	env.router.ServeHTTP(linkW, linkReq)
+	require.Equal(t, http.StatusOK, linkW.Code, "body: %s", linkW.Body.String())
+
+	// Verify backfill actually linked the identity row to contactA.
+	postIdents, err := env.identityRepo.FindIdentitiesByAnarlogHumanID(ctx, anarlogX)
+	require.NoError(t, err)
+	require.Len(t, postIdents, 1)
+	require.NotNil(t, postIdents[0].ContactID)
+	require.Equal(t, env.contactA, *postIdents[0].ContactID,
+		"import handler must backfill anarlog_human_id identity")
+
+	// Re-send the SAME payload (identical source_id). The dispatch
+	// loop's inline-on-duplicate probe must detect the live row and
+	// run the handler so the resolved-set-hash drift drives a re-link.
+	// Without this, an import after the first ingest would only take
+	// effect on a future content-changing event.
+	w = postMNIngest(t, env, map[string]any{"events": []any{rec1}})
 	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
 	resp2 := parseMNIngestResp(t, w)
-	require.Equal(t, 1, resp2.Accepted, "different content hash → fresh event")
+	require.Equal(t, 1, resp2.Duplicate, "identical source_id → bus dedup")
 
 	row := findMeetingNoteRow(t, env, sessionUUID)
 	require.NotNil(t, row)

--- a/backend/tests/telegram_import_suggestion_test.go
+++ b/backend/tests/telegram_import_suggestion_test.go
@@ -70,7 +70,7 @@ func setupTelegramImportSuggestionTest(t *testing.T) (
 	enrichmentService := service.NewEnrichmentService(database, contactRepo, contactMethodRepo, enrichmentRepo, nil, nil)
 	enrichmentService.SetCadenceUpdater(cadenceUpdater)
 
-	importHandler := handlers.NewImportHandler(externalRepo, contactService, matchService, enrichmentService)
+	importHandler := handlers.NewImportHandler(externalRepo, nil, contactService, matchService, enrichmentService)
 
 	gin.SetMode(gin.TestMode)
 	router := gin.New()


### PR DESCRIPTION
## Summary

Pi-side ingest acceptance for the daemon-emitted `meeting_note.{recorded,deleted}` event family plus baseline linkage detection per `.ai/spec/mac-daemon-phase-2-anarlog-matching.md`. Closes the third PR of the Anarlog phase 2 series; PR1 (#332) shipped the table + interaction source widening, PR2 (#333) shipped the daemon-side readers. With this PR the daemon's Anarlog plugin events stop rejecting at the ingest boundary and start producing linked interactions.

**What lands:**

- Migration `054` adds `input_hash`, `resolved_set_hash`, `last_content_hash`, and `meeting_at` columns to `meeting_note` — the inputs the re-sync algorithm needs to detect "matching inputs changed" and the prior-payload hash the daemon's deterministic delete `source_id` depends on.
- Two new event kinds `meeting_note.recorded` and `meeting_note.deleted` with payload structs, `AllKinds` + `kindPayloadTypes` registration, per-kind `ValidatePayload` branches, and handler-level Version envelope check.
- `IngestService.handleMeetingNoteRecorded` runs the spec's linkage algorithm — calendar candidates in a ±15 min window, tagged-participant resolution against `anarlog_human_id` identities, dedupe by `contact_id`, and one of `linked` / `linked_impromptu` / `orphan_needs_review` / `conflict_pending`. Walk-in supplemental interactions fire for tagged contacts not already in the matched event's attendees. Re-sync diff: input hash + resolved-set hash drive carry-forward vs. re-link; the in-both branch refreshes content fields via `ContactService.ExtendInteractionTx` so cadence + follow-up stay in lockstep.
- Revive-bypass dispatch: a `meeting_note.recorded` duplicate (same content hash → same `source_id`) still runs the inline handler when a row exists (live or tombstoned), so delete-then-revive-with-identical-content scenarios + post-import resolution drift both work.
- `handleMeetingNoteDeleted` cascades soft-deletes to session-attributed interactions (UPDATE deleted_at does NOT trigger FK cascades — CLAUDE.md gotcha).
- `external_contact.upserted (source='anarlog_humans')` now also plants an `external_identity` row keyed by the anarlog UUID, linked to the matched contact when email/phone resolved one. The Import handler's `LinkContact` / `ImportContact` flows route through `service.IdentityService.BackfillAnarlogIdentityForImport` so the "tag now, import later" flow closes correctly — backfill failures surface as 500 instead of silent.
- `GET /api/v1/host/:id/sync/anarlog_sessions/known-ids` returns session UUIDs + content hashes from `meeting_note` via a new dispatch arm in `MacHostService.KnownIDsForSource`.
- `IngestResponse` gains an optional `needs_attention: [{session_id, reason: "orphan"|"conflict"}]` field (with `omitempty` for backward compat) so a future daemon revision can raise macOS notifications without a polling endpoint.
- Concurrent first-insert race on the partial unique index handled via `INSERT ... ON CONFLICT DO NOTHING` + re-read with FOR UPDATE + fall through to update path.
- 18 integration tests covering: orphan, linked_impromptu, linked, walkin, conflict, delete cascade, delete-unknown silent no-op, hash-mismatch delete rejected, cross-host delete silent no-op, re-sync carry-forward, re-sync diff add/drop, re-sync refresh-content, dedup by contact_id, delete-then-revive, import backfill resolves on re-sync, `/known-ids` for anarlog_sessions, anarlog identity registration on upsert, concurrent first-insert convergence.

## Test plan

- [x] `make lint` — 0 issues
- [x] `make test-unit` — pass
- [x] `make test-integration` — pass (all 18 new `TestMeetingNote_*` tests + full suite)
- [x] `make test-frontend` — pass
- [x] `make test-e2e-diff` — pass
- [x] Codex review converged at PASS after 3 rounds (1 P0 + 8 P1 + 4 P2 + 1 P3 round 1; 2 P1 + 4 P2 round 2; 3 P2 round 3; all addressed).
- [x] Adversarial pre-push review at `abb3277` + polish at `41349ba` — PASS verdict.

Refs: #74, plan at `.ai/log/plan/mac-daemon-phase-2-pr3-pi-ingest-anarlog-baseline.md`, depends on #332 (merged) + #333 (merged).