### PR TITLE
feat(anarlog): title parsing + discovery + orphan_title_augmented (phase 2 PR 4/6)

### DIFF
--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -34,6 +34,7 @@ import (
 	"syscall"
 	"time"
 
+	"personal-crm/backend/internal/anarlog"
 	"personal-crm/backend/internal/api"
 	"personal-crm/backend/internal/api/handlers"
 	"personal-crm/backend/internal/auth"
@@ -444,6 +445,13 @@ func run() int {
 	// contactService via the ContactInteractionRecorder interface for
 	// session-attributed interaction writes so cadence + follow-up
 	// fire correctly.
+	//
+	// anarlog title-extraction deps for the meeting_note.recorded inline
+	// handler: TitleMatcher disambiguates a single name token against
+	// the CRM contact table (trigram + collision-gap); DiscoveryWriter
+	// persists weak-candidate anarlog_title rows for unmatched tokens.
+	titleMatcher := anarlog.NewTitleMatcher(contactRepo)
+	titleDiscoveryWriter := anarlog.NewDiscoveryWriter(externalContactRepoForIngest)
 	ingestService := service.NewIngestService(
 		database,
 		eventBus,
@@ -461,6 +469,8 @@ func run() int {
 		contactService,
 		cadenceUpdater,
 		followUpManager,
+		titleMatcher,
+		titleDiscoveryWriter,
 	)
 	ingestHandler := handlers.NewIngestHandler(ingestService)
 

--- a/backend/internal/anarlog/discovery.go
+++ b/backend/internal/anarlog/discovery.go
@@ -1,0 +1,105 @@
+package anarlog
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+// titleCaser title-cases lowered tokens so on-disk display_name is
+// stable regardless of caller casing. Constructed once; safe for
+// concurrent use per the cases package contract.
+var titleCaser = cases.Title(language.English)
+
+// externalContactUpserter is the narrow interface the discovery writer
+// needs from ExternalContactRepository — UpsertTx only. Lets tests
+// hand-roll a mock without dragging in a full repository.
+type externalContactUpserter interface {
+	UpsertTx(ctx context.Context, tx pgx.Tx, req repository.UpsertExternalContactRequest) (*repository.ExternalContact, error)
+}
+
+// DiscoveryWriter persists anarlog_title weak-candidate rows via
+// ExternalContactRepository.UpsertTx. The repository is bound at
+// construction time.
+type DiscoveryWriter struct {
+	externalContactRepo externalContactUpserter
+}
+
+// NewDiscoveryWriter constructs a DiscoveryWriter bound to the given
+// repository (or any externalContactUpserter).
+func NewDiscoveryWriter(externalContactRepo externalContactUpserter) *DiscoveryWriter {
+	return &DiscoveryWriter{externalContactRepo: externalContactRepo}
+}
+
+// UpsertTitleCandidateTx writes an anarlog_title external_contact row
+// for the given session+token pair. The source_id is deterministic
+// (sha256 of normalizedToken || session_uuid string) so re-emit of the
+// same (session, token) hits ON CONFLICT and only refreshes
+// updated_at/synced_at.
+//
+// displayToken is the original-case token from ExtractNameTokens; the
+// writer internally title-cases it for the on-disk display_name + the
+// metadata.token_display field, so callers don't have to reason about
+// casing.
+func (w *DiscoveryWriter) UpsertTitleCandidateTx(
+	ctx context.Context,
+	tx pgx.Tx,
+	sessionUUID uuid.UUID,
+	normalizedToken, displayToken string,
+) error {
+	if normalizedToken == "" {
+		return fmt.Errorf("normalizedToken must be non-empty")
+	}
+	displayTitleCased := titleCaser.String(strings.ToLower(displayToken))
+	sourceID := computeAnarlogTitleSourceID(normalizedToken, sessionUUID)
+	now := accelerated.GetCurrentTime()
+
+	dn := displayTitleCased
+	req := repository.UpsertExternalContactRequest{
+		Source:      "anarlog_title",
+		SourceID:    sourceID,
+		DisplayName: &dn,
+		Metadata: map[string]any{
+			"session_uuid":     sessionUUID.String(),
+			"token_normalized": normalizedToken,
+			"token_display":    displayTitleCased,
+			"extracted_at":     now.UTC().Format("2006-01-02T15:04:05.000Z07:00"),
+		},
+		SyncedAt: &now,
+		// HostID intentionally nil: anarlog_title rows are Pi-generated
+		// weak candidates, never daemon-claimed. The UpsertExternalContact
+		// query's COALESCE(host_id, EXCLUDED.host_id) preserves any prior
+		// nil on update.
+		// LastContentHash intentionally nil: the deterministic source_id
+		// already encodes uniqueness; there is no daemon delete flow for
+		// these rows.
+	}
+	if _, err := w.externalContactRepo.UpsertTx(ctx, tx, req); err != nil {
+		return fmt.Errorf("upsert anarlog_title row: %w", err)
+	}
+	return nil
+}
+
+// computeAnarlogTitleSourceID returns the lowercase-hex SHA-256 of
+// (normalizedToken || sessionUUID.String()) per the spec recipe.
+// `||` is byte concatenation with NO separator (faithful to the spec
+// wording). normalizedToken is expected to be lowercased; the caller
+// is responsible for that contract.
+func computeAnarlogTitleSourceID(normalizedToken string, sessionUUID uuid.UUID) string {
+	var buf bytes.Buffer
+	buf.WriteString(normalizedToken)
+	buf.WriteString(sessionUUID.String())
+	sum := sha256.Sum256(buf.Bytes())
+	return hex.EncodeToString(sum[:])
+}

--- a/backend/internal/anarlog/discovery.go
+++ b/backend/internal/anarlog/discovery.go
@@ -13,14 +13,26 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 )
 
-// titleCaser title-cases lowered tokens so on-disk display_name is
-// stable regardless of caller casing. Constructed once; safe for
-// concurrent use per the cases package contract.
-var titleCaser = cases.Title(language.English)
+// asciiTitleCase lower-cases the input then upper-cases the first byte
+// if it's a-z. Concurrency-safe with no shared mutable state. The
+// extractor's keep regex (^[A-Z][a-zA-Z]{1,29}$) guarantees ASCII
+// input, so this byte-level approach is correct for every token the
+// discovery writer can receive.
+func asciiTitleCase(s string) string {
+	if s == "" {
+		return s
+	}
+	lower := strings.ToLower(s)
+	first := lower[0]
+	if first >= 'a' && first <= 'z' {
+		b := []byte(lower)
+		b[0] = first - 'a' + 'A'
+		return string(b)
+	}
+	return lower
+}
 
 // externalContactUpserter is the narrow interface the discovery writer
 // needs from ExternalContactRepository — UpsertTx only. Lets tests
@@ -61,7 +73,7 @@ func (w *DiscoveryWriter) UpsertTitleCandidateTx(
 	if normalizedToken == "" {
 		return fmt.Errorf("normalizedToken must be non-empty")
 	}
-	displayTitleCased := titleCaser.String(strings.ToLower(displayToken))
+	displayTitleCased := asciiTitleCase(displayToken)
 	sourceID := computeAnarlogTitleSourceID(normalizedToken, sessionUUID)
 	now := accelerated.GetCurrentTime()
 

--- a/backend/internal/anarlog/discovery_test.go
+++ b/backend/internal/anarlog/discovery_test.go
@@ -97,7 +97,7 @@ func TestUpsertTitleCandidateTx_TitleCaseNormalization(t *testing.T) {
 }
 
 // TestUpsertTitleCandidateTx_MetadataShape — verifies the four keys
-// the PR 7 UI contract depends on.
+// the downstream UI contract depends on.
 func TestUpsertTitleCandidateTx_MetadataShape(t *testing.T) {
 	mock := &mockExternalUpserter{}
 	w := NewDiscoveryWriter(mock)

--- a/backend/internal/anarlog/discovery_test.go
+++ b/backend/internal/anarlog/discovery_test.go
@@ -1,0 +1,176 @@
+package anarlog
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"testing"
+
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+type mockExternalUpserter struct {
+	captured repository.UpsertExternalContactRequest
+	calls    int
+	err      error
+}
+
+func (m *mockExternalUpserter) UpsertTx(_ context.Context, _ pgx.Tx, req repository.UpsertExternalContactRequest) (*repository.ExternalContact, error) {
+	m.calls++
+	m.captured = req
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &repository.ExternalContact{Source: req.Source, SourceID: req.SourceID}, nil
+}
+
+// TestComputeAnarlogTitleSourceID_Determinism — same inputs always
+// yield the same hex hash.
+func TestComputeAnarlogTitleSourceID_Determinism(t *testing.T) {
+	sid := uuid.MustParse("8a4f2c1e-1234-5678-9abc-def012345678")
+	first := computeAnarlogTitleSourceID("alice", sid)
+	for i := 0; i < 25; i++ {
+		got := computeAnarlogTitleSourceID("alice", sid)
+		if got != first {
+			t.Fatalf("non-deterministic: run 0 = %s, run %d = %s", first, i, got)
+		}
+	}
+}
+
+// TestComputeAnarlogTitleSourceID_SpecLiteralRecipe — hash matches a
+// hand-computed sha256(token || session_uuid_string) with no
+// separator. Regression test against drift in the recipe.
+func TestComputeAnarlogTitleSourceID_SpecLiteralRecipe(t *testing.T) {
+	sid := uuid.MustParse("8a4f2c1e-1234-5678-9abc-def012345678")
+	concat := "alice" + sid.String()
+	want := sha256.Sum256([]byte(concat))
+	wantHex := hex.EncodeToString(want[:])
+
+	got := computeAnarlogTitleSourceID("alice", sid)
+	if got != wantHex {
+		t.Errorf("source_id recipe drift:\n got  = %s\n want = %s", got, wantHex)
+	}
+}
+
+// TestComputeAnarlogTitleSourceID_DifferentSession — same token,
+// different sessions → different rows.
+func TestComputeAnarlogTitleSourceID_DifferentSession(t *testing.T) {
+	a := computeAnarlogTitleSourceID("alice", uuid.MustParse("8a4f2c1e-1234-5678-9abc-def012345678"))
+	b := computeAnarlogTitleSourceID("alice", uuid.MustParse("9b5e3d2f-1234-5678-9abc-def012345678"))
+	if a == b {
+		t.Errorf("different sessions collided: %s", a)
+	}
+}
+
+// TestComputeAnarlogTitleSourceID_DifferentToken — same session,
+// different tokens → different rows.
+func TestComputeAnarlogTitleSourceID_DifferentToken(t *testing.T) {
+	sid := uuid.MustParse("8a4f2c1e-1234-5678-9abc-def012345678")
+	a := computeAnarlogTitleSourceID("alice", sid)
+	b := computeAnarlogTitleSourceID("bob", sid)
+	if a == b {
+		t.Errorf("different tokens collided: %s", a)
+	}
+}
+
+// TestUpsertTitleCandidateTx_TitleCaseNormalization — caller passes
+// "ALICE", writer stores "Alice" in display_name + metadata.token_display.
+func TestUpsertTitleCandidateTx_TitleCaseNormalization(t *testing.T) {
+	mock := &mockExternalUpserter{}
+	w := NewDiscoveryWriter(mock)
+	sid := uuid.New()
+	err := w.UpsertTitleCandidateTx(context.Background(), nil, sid, "alice", "ALICE")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if mock.captured.DisplayName == nil || *mock.captured.DisplayName != "Alice" {
+		t.Errorf("display_name not title-cased: %+v", mock.captured.DisplayName)
+	}
+	td, _ := mock.captured.Metadata["token_display"].(string)
+	if td != "Alice" {
+		t.Errorf("metadata.token_display not title-cased: %q", td)
+	}
+}
+
+// TestUpsertTitleCandidateTx_MetadataShape — verifies the four keys
+// the PR 7 UI contract depends on.
+func TestUpsertTitleCandidateTx_MetadataShape(t *testing.T) {
+	mock := &mockExternalUpserter{}
+	w := NewDiscoveryWriter(mock)
+	sid := uuid.New()
+	err := w.UpsertTitleCandidateTx(context.Background(), nil, sid, "alice", "Alice")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	md := mock.captured.Metadata
+	if md == nil {
+		t.Fatalf("metadata was nil")
+	}
+	for _, key := range []string{"session_uuid", "token_normalized", "token_display", "extracted_at"} {
+		if _, ok := md[key]; !ok {
+			t.Errorf("metadata missing %q: got %+v", key, md)
+		}
+	}
+	if md["session_uuid"] != sid.String() {
+		t.Errorf("session_uuid mismatch: got %v", md["session_uuid"])
+	}
+	if md["token_normalized"] != "alice" {
+		t.Errorf("token_normalized mismatch: got %v", md["token_normalized"])
+	}
+}
+
+// TestUpsertTitleCandidateTx_SourceAndSourceID — verifies the request
+// shape passed to the repo: source="anarlog_title", deterministic
+// source_id.
+func TestUpsertTitleCandidateTx_SourceAndSourceID(t *testing.T) {
+	mock := &mockExternalUpserter{}
+	w := NewDiscoveryWriter(mock)
+	sid := uuid.MustParse("8a4f2c1e-1234-5678-9abc-def012345678")
+	err := w.UpsertTitleCandidateTx(context.Background(), nil, sid, "alice", "Alice")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if mock.captured.Source != "anarlog_title" {
+		t.Errorf("wrong source: %q", mock.captured.Source)
+	}
+	want := computeAnarlogTitleSourceID("alice", sid)
+	if mock.captured.SourceID != want {
+		t.Errorf("wrong source_id: got %q, want %q", mock.captured.SourceID, want)
+	}
+	if mock.captured.HostID != nil {
+		t.Errorf("HostID must be nil: got %+v", mock.captured.HostID)
+	}
+	if mock.captured.LastContentHash != nil {
+		t.Errorf("LastContentHash must be nil: got %+v", mock.captured.LastContentHash)
+	}
+}
+
+// TestUpsertTitleCandidateTx_RepoError surfaces errors to the caller.
+func TestUpsertTitleCandidateTx_RepoError(t *testing.T) {
+	mock := &mockExternalUpserter{err: errors.New("boom")}
+	w := NewDiscoveryWriter(mock)
+	sid := uuid.New()
+	err := w.UpsertTitleCandidateTx(context.Background(), nil, sid, "alice", "Alice")
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+}
+
+// TestUpsertTitleCandidateTx_EmptyNormalizedToken — defensive guard:
+// the caller is responsible for non-empty input.
+func TestUpsertTitleCandidateTx_EmptyNormalizedToken(t *testing.T) {
+	mock := &mockExternalUpserter{}
+	w := NewDiscoveryWriter(mock)
+	sid := uuid.New()
+	err := w.UpsertTitleCandidateTx(context.Background(), nil, sid, "", "Alice")
+	if err == nil {
+		t.Fatalf("expected error for empty normalizedToken, got nil")
+	}
+	if mock.calls != 0 {
+		t.Errorf("empty token should not invoke repo, got %d calls", mock.calls)
+	}
+}

--- a/backend/internal/anarlog/title.go
+++ b/backend/internal/anarlog/title.go
@@ -1,0 +1,201 @@
+// Package anarlog holds anarlog-specific domain heuristics that don't
+// belong in the generic matching/ normalization package. The two
+// initial surfaces are:
+//
+//   - ExtractNameTokens: a pure-Go heuristic that turns a session
+//     title (free-form string) into a list of normalized name tokens.
+//   - TitleMatcher: a service-layer wrapper around
+//     repository.ContactRepository.FindSimilarContacts that applies a
+//     trigram collision-gap rule for single-token disambiguation.
+//   - DiscoveryWriter: a service-layer wrapper around
+//     ExternalContactRepository.UpsertTx that writes weak
+//     anarlog_title discovery rows.
+package anarlog
+
+import (
+	"regexp"
+	"strings"
+)
+
+// keepTokenRegex enforces the spec's "starts with uppercase, alphabetic,
+// length 2..30" invariant on extracted tokens. ASCII-only by design;
+// diacritic / non-Latin names are silently dropped (spec philosophy:
+// "heuristics, not NLP"). The taggin path (anarlog_human_id) catches
+// names that fall through.
+var keepTokenRegex = regexp.MustCompile(`^[A-Z][a-zA-Z]{1,29}$`)
+
+// metaSingleWordTokens are word-boundary-stripped from titles. Order
+// doesn't matter; each is compiled to a `\b<word>\b` regex with case-
+// insensitive flag.
+var metaSingleWordTokens = []string{
+	"sync", "catchup", "chat", "call", "meeting",
+	"intro", "standup", "huddle", "check-in", "checkin",
+	"review",
+	"1:1", "1-1", "one-on-one",
+}
+
+// metaWeekdayTokens covers full + abbreviated weekday names. Word-
+// boundary matched so "Monica" doesn't match "mon".
+var metaWeekdayTokens = []string{
+	"monday", "tuesday", "wednesday", "thursday",
+	"friday", "saturday", "sunday",
+	"mon", "tue", "tues", "wed", "thu", "thur", "thurs", "fri", "sat", "sun",
+}
+
+// metaMonthTokens covers full + abbreviated month names. People literally
+// named May, June, April, March, August are dropped by this stripping —
+// accepted tradeoff per spec philosophy. The tagging path catches them.
+var metaMonthTokens = []string{
+	"january", "february", "march", "april", "may", "june",
+	"july", "august", "september", "october", "november", "december",
+	"jan", "feb", "mar", "apr", "jun", "jul", "aug", "sep", "sept",
+	"oct", "nov", "dec",
+}
+
+// metaTokensRegex is the combined `\b(...)\b` regex that strips all
+// single-word meta-tokens + weekday + month names case-insensitively in
+// a single pass. Compiled at package load.
+var metaTokensRegex = func() *regexp.Regexp {
+	all := make([]string, 0,
+		len(metaSingleWordTokens)+len(metaWeekdayTokens)+len(metaMonthTokens))
+	all = append(all, metaSingleWordTokens...)
+	all = append(all, metaWeekdayTokens...)
+	all = append(all, metaMonthTokens...)
+	escaped := make([]string, len(all))
+	for i, t := range all {
+		escaped[i] = regexp.QuoteMeta(t)
+	}
+	// (?i) case-insensitive, \b word boundary on both sides.
+	return regexp.MustCompile(`(?i)\b(` + strings.Join(escaped, "|") + `)\b`)
+}()
+
+// dateRegexes strip ISO dates, US numeric dates, and numeric month-day
+// patterns. Applied to the lowercased working copy so substring matches
+// in the original-case string at the same byte offsets are blanked.
+var dateRegexes = []*regexp.Regexp{
+	regexp.MustCompile(`\b\d{4}-\d{2}-\d{2}\b`),            // ISO 2026-05-27
+	regexp.MustCompile(`\b\d{1,2}/\d{1,2}(?:/\d{2,4})?\b`), // US 5/12 or 5/12/2026
+	regexp.MustCompile(`\b\d{1,2}-\d{1,2}\b`),              // numeric month-day 5-12
+}
+
+// multiCharSeparators are normalized to a single space BEFORE the final
+// whitespace split. Each entry is matched case-insensitively.
+var multiCharSeparators = []string{
+	" and ", " with ", " w/ ",
+}
+
+// singleCharSeparators are replaced with a space at the byte level
+// before strings.Fields splits on whitespace. `:` and `-` are intentional
+// even though they appear in some date / meta-token patterns — by the
+// time we run this step, those have already been stripped.
+var singleCharSeparators = []string{
+	"/", "&", "+", ":", "-",
+}
+
+// stopwords is an intentionally tiny case-insensitive drop list applied
+// AFTER the keepTokenRegex filter. Spec philosophy: "expand iteratively
+// from observed false positives in dogfooding." Items here would
+// otherwise pass the regex but are obviously not names.
+var stopwords = map[string]struct{}{
+	"re":   {},
+	"fwd":  {},
+	"test": {},
+	"demo": {},
+}
+
+// ExtractNameTokens turns a session title into a list of normalized
+// name tokens per the spec's heuristic. Returns an empty slice for
+// empty or whitespace-only inputs. Deterministic and side-effect-free.
+//
+// Token casing is preserved from the original title (so "Alice" stays
+// "Alice" for display purposes); callers needing the normalized form do
+// strings.ToLower themselves. Dedup is case-insensitive (first-seen
+// casing wins).
+func ExtractNameTokens(title string) []string {
+	if strings.TrimSpace(title) == "" {
+		return []string{}
+	}
+
+	// Lowercase working copy is used for meta-token + date stripping.
+	// We replace matches with spaces on the ORIGINAL-case string at the
+	// same byte offsets to preserve casing for the keep-regex.
+	lower := strings.ToLower(title)
+	working := []byte(title)
+
+	blankOut := func(start, end int) {
+		for i := start; i < end && i < len(working); i++ {
+			working[i] = ' '
+		}
+	}
+
+	// 1) Strip meta-tokens (single-word, weekday, month).
+	for _, m := range metaTokensRegex.FindAllStringIndex(lower, -1) {
+		blankOut(m[0], m[1])
+	}
+
+	// 2) Strip date patterns.
+	for _, re := range dateRegexes {
+		for _, m := range re.FindAllStringIndex(lower, -1) {
+			blankOut(m[0], m[1])
+		}
+	}
+
+	stripped := string(working)
+
+	// 3) Replace multi-char separators (case-insensitive) with whitespace.
+	for _, sep := range multiCharSeparators {
+		stripped = replaceFoldAll(stripped, sep, " ")
+	}
+
+	// 4) Replace single-char separators with whitespace.
+	for _, sep := range singleCharSeparators {
+		stripped = strings.ReplaceAll(stripped, sep, " ")
+	}
+
+	// 5) Split on whitespace.
+	rawTokens := strings.Fields(stripped)
+
+	// 6) Apply keep regex + stopword filter + dedup (case-insensitive).
+	out := make([]string, 0, len(rawTokens))
+	seen := make(map[string]struct{}, len(rawTokens))
+	for _, tok := range rawTokens {
+		if !keepTokenRegex.MatchString(tok) {
+			continue
+		}
+		lowered := strings.ToLower(tok)
+		if _, isStop := stopwords[lowered]; isStop {
+			continue
+		}
+		if _, dup := seen[lowered]; dup {
+			continue
+		}
+		seen[lowered] = struct{}{}
+		out = append(out, tok)
+	}
+	return out
+}
+
+// replaceFoldAll replaces every case-insensitive occurrence of `old`
+// in `s` with `new`. strings.ReplaceAll is case-sensitive; we need
+// case-fold for the multi-char separator pass.
+func replaceFoldAll(s, old, replacement string) string {
+	if old == "" {
+		return s
+	}
+	lower := strings.ToLower(s)
+	target := strings.ToLower(old)
+	var b strings.Builder
+	b.Grow(len(s))
+	i := 0
+	for i < len(s) {
+		idx := strings.Index(lower[i:], target)
+		if idx < 0 {
+			b.WriteString(s[i:])
+			break
+		}
+		b.WriteString(s[i : i+idx])
+		b.WriteString(replacement)
+		i += idx + len(old)
+	}
+	return b.String()
+}

--- a/backend/internal/anarlog/title.go
+++ b/backend/internal/anarlog/title.go
@@ -117,9 +117,16 @@ func ExtractNameTokens(title string) []string {
 
 	// Lowercase working copy is used for meta-token + date stripping.
 	// We replace matches with spaces on the ORIGINAL-case string at the
-	// same byte offsets to preserve casing for the keep-regex.
-	lower := strings.ToLower(title)
-	working := []byte(title)
+	// same byte offsets to preserve casing for the keep-regex. Both
+	// copies must therefore have IDENTICAL byte lengths — strings.ToLower
+	// on multi-byte UTF-8 (e.g. Turkish İ) can shrink/grow byte count
+	// and desynchronize the offsets, corrupting adjacent tokens. Spec
+	// says non-ASCII is silently dropped, so asciiSanitize replaces any
+	// non-ASCII byte with a `~` sentinel (chosen because it fails the
+	// keep-token regex, so any token containing it drops intact) in
+	// both copies. This guarantees offset alignment for the regex
+	// passes AND prevents corrupted partial-ASCII tokens.
+	lower, working := asciiSanitize(title)
 
 	blankOut := func(start, end int) {
 		for i := start; i < end && i < len(working); i++ {
@@ -172,6 +179,36 @@ func ExtractNameTokens(title string) []string {
 		out = append(out, tok)
 	}
 	return out
+}
+
+// asciiSanitize returns two byte-aligned copies of `s` with every
+// non-ASCII byte replaced by `~` (a sentinel that fails the keep-token
+// regex `^[A-Z][a-zA-Z]{1,29}$`, so any whitespace-bounded token that
+// originally contained non-ASCII bytes is dropped intact rather than
+// having its ASCII fragments emitted as corrupted partial tokens).
+// The first return value has ASCII letters lowercased; the second
+// preserves original casing. Both always have len == len(s). Used by
+// ExtractNameTokens so meta-token regex offsets computed against the
+// lowercase copy can be applied safely to the original-case copy.
+func asciiSanitize(s string) (lower string, original []byte) {
+	const nonASCIIMarker = '~'
+	original = make([]byte, len(s))
+	lowerBuf := make([]byte, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 0x80 {
+			original[i] = nonASCIIMarker
+			lowerBuf[i] = nonASCIIMarker
+			continue
+		}
+		original[i] = c
+		if c >= 'A' && c <= 'Z' {
+			lowerBuf[i] = c + ('a' - 'A')
+		} else {
+			lowerBuf[i] = c
+		}
+	}
+	return string(lowerBuf), original
 }
 
 // replaceFoldAll replaces every case-insensitive occurrence of `old`

--- a/backend/internal/anarlog/title.go
+++ b/backend/internal/anarlog/title.go
@@ -1,6 +1,5 @@
 // Package anarlog holds anarlog-specific domain heuristics that don't
-// belong in the generic matching/ normalization package. The two
-// initial surfaces are:
+// belong in the generic matching/ normalization package. Surfaces:
 //
 //   - ExtractNameTokens: a pure-Go heuristic that turns a session
 //     title (free-form string) into a list of normalized name tokens.
@@ -20,7 +19,7 @@ import (
 // keepTokenRegex enforces the spec's "starts with uppercase, alphabetic,
 // length 2..30" invariant on extracted tokens. ASCII-only by design;
 // diacritic / non-Latin names are silently dropped (spec philosophy:
-// "heuristics, not NLP"). The taggin path (anarlog_human_id) catches
+// "heuristics, not NLP"). The tagging path (anarlog_human_id) catches
 // names that fall through.
 var keepTokenRegex = regexp.MustCompile(`^[A-Z][a-zA-Z]{1,29}$`)
 

--- a/backend/internal/anarlog/title_matcher.go
+++ b/backend/internal/anarlog/title_matcher.go
@@ -23,10 +23,10 @@ const (
 
 	// titleConfidenceFloor is the minimum similarity required for the
 	// top match to be accepted. PostgreSQL pg_trgm.similarity() values
-	// for "Alice" against "Alice Smith" land in the ~0.38-0.45 range
-	// (verified against seeded test data); 0.38 catches the common
-	// case while leaving false positives bounded by the collision-gap.
-	// Re-tune iteratively from dogfooding (OPEN-T2).
+	// for a first-name token against a 2-part full_name land in the
+	// ~0.38-0.45 range; 0.38 catches the common case while leaving
+	// false positives bounded by the collision-gap. Tune iteratively
+	// against real-world dogfooding signal.
 	titleConfidenceFloor = 0.38
 
 	// titleFindLimit is the result-cap fed to FindSimilarContacts. The

--- a/backend/internal/anarlog/title_matcher.go
+++ b/backend/internal/anarlog/title_matcher.go
@@ -1,0 +1,99 @@
+package anarlog
+
+import (
+	"context"
+	"sort"
+
+	"personal-crm/backend/internal/repository"
+)
+
+const (
+	// titleMinSimilarity is the trigram-similarity threshold below which
+	// candidates are not even considered. Mirrors
+	// matching.ImportConfig.MinSimilarityThreshold (0.3).
+	titleMinSimilarity = 0.3
+
+	// titleCollisionGap is the required similarity gap between the top
+	// and runner-up matches. Tighter than the import-matcher's
+	// usernameMatchGap (0.15) because a single title name token has even
+	// less context than a username. Boundary rule: gap <=
+	// titleCollisionGap counts as AMBIGUOUS (drop). Pairs with TC-TM5
+	// (exact 0.20 gap → nil) and TC-TM6 (gap 0.21 → match).
+	titleCollisionGap = 0.20
+
+	// titleConfidenceFloor is the minimum similarity required for the
+	// top match to be accepted. PostgreSQL pg_trgm.similarity() values
+	// for "Alice" against "Alice Smith" land in the ~0.38-0.45 range
+	// (verified against seeded test data); 0.38 catches the common
+	// case while leaving false positives bounded by the collision-gap.
+	// Re-tune iteratively from dogfooding (OPEN-T2).
+	titleConfidenceFloor = 0.38
+
+	// titleFindLimit is the result-cap fed to FindSimilarContacts. The
+	// top 2 are needed for the gap test; 5 mirrors ImportMatchService.
+	titleFindLimit int32 = 5
+)
+
+// contactMatchFinder is the narrow interface the matcher needs from the
+// contact repository. Defined here so the matcher can be unit-tested
+// with a hand-rolled mock without dragging in a full repository.
+type contactMatchFinder interface {
+	FindSimilarContacts(ctx context.Context, name string, threshold float64, limit int32) ([]repository.ContactMatch, error)
+}
+
+// TitleMatcher applies the trigram collision-gap rule to a single
+// title-extracted name token. The contact repo is bound at
+// construction time.
+type TitleMatcher struct {
+	contactRepo contactMatchFinder
+}
+
+// NewTitleMatcher constructs a TitleMatcher with the given contact
+// repository (or any contactMatchFinder).
+func NewTitleMatcher(contactRepo contactMatchFinder) *TitleMatcher {
+	return &TitleMatcher{contactRepo: contactRepo}
+}
+
+// MatchTitleToken queries the contact repository for trigram-similar
+// names and returns the unique high-confidence match, or nil if the
+// match is ambiguous (collision-gap rule) / below the confidence floor
+// / no result at all.
+//
+// Returns (nil, nil) for an empty token — no DB call is made.
+func (m *TitleMatcher) MatchTitleToken(ctx context.Context, token string) (*repository.ContactMatch, error) {
+	if token == "" {
+		return nil, nil
+	}
+	matches, err := m.contactRepo.FindSimilarContacts(ctx, token, titleMinSimilarity, titleFindLimit)
+	if err != nil {
+		return nil, err
+	}
+	if len(matches) == 0 {
+		return nil, nil
+	}
+
+	// Stable sort: similarity desc, then contact_id asc as a tiebreaker
+	// so equal-similarity rows produce the same top-1 / top-2 across
+	// runs (Go map iteration is randomized; pg_trgm ORDER BY similarity
+	// can return tied scores in arbitrary order).
+	sort.SliceStable(matches, func(i, j int) bool {
+		if matches[i].Similarity != matches[j].Similarity {
+			return matches[i].Similarity > matches[j].Similarity
+		}
+		return matches[i].Contact.ID.String() < matches[j].Contact.ID.String()
+	})
+
+	top := matches[0]
+	if top.Similarity < titleConfidenceFloor {
+		return nil, nil
+	}
+	if len(matches) > 1 {
+		runner := matches[1]
+		// Strict less-or-equal: gap == titleCollisionGap counts as
+		// ambiguous and drops.
+		if top.Similarity-runner.Similarity <= titleCollisionGap {
+			return nil, nil
+		}
+	}
+	return &top, nil
+}

--- a/backend/internal/anarlog/title_matcher_test.go
+++ b/backend/internal/anarlog/title_matcher_test.go
@@ -1,0 +1,187 @@
+package anarlog
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+)
+
+// mockContactMatchFinder lets each test hand-craft the candidate list
+// returned by FindSimilarContacts (and record call sites).
+type mockContactMatchFinder struct {
+	matches []repository.ContactMatch
+	err     error
+	calls   int
+}
+
+func (m *mockContactMatchFinder) FindSimilarContacts(_ context.Context, _ string, _ float64, _ int32) ([]repository.ContactMatch, error) {
+	m.calls++
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.matches, nil
+}
+
+func contactMatch(id uuid.UUID, name string, similarity float64) repository.ContactMatch {
+	return repository.ContactMatch{
+		Contact: repository.Contact{
+			ID:       id,
+			FullName: name,
+		},
+		Similarity: similarity,
+	}
+}
+
+// TC-TM1 — no matches in the DB.
+func TestMatchTitleToken_NoMatches(t *testing.T) {
+	mock := &mockContactMatchFinder{matches: nil}
+	m := NewTitleMatcher(mock)
+	got, err := m.MatchTitleToken(context.Background(), "Alice")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil match, got %+v", got)
+	}
+}
+
+// TC-TM2 — single high-confidence match.
+func TestMatchTitleToken_SingleHighConfidence(t *testing.T) {
+	id := uuid.New()
+	mock := &mockContactMatchFinder{matches: []repository.ContactMatch{
+		contactMatch(id, "Alice Smith", 0.8),
+	}}
+	m := NewTitleMatcher(mock)
+	got, err := m.MatchTitleToken(context.Background(), "Alice")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("expected match, got nil")
+	}
+	if got.Contact.ID != id {
+		t.Errorf("wrong contact: %v", got.Contact.ID)
+	}
+}
+
+// TC-TM3 — below confidence floor.
+func TestMatchTitleToken_BelowConfidenceFloor(t *testing.T) {
+	id := uuid.New()
+	mock := &mockContactMatchFinder{matches: []repository.ContactMatch{
+		contactMatch(id, "Alice", 0.30),
+	}}
+	m := NewTitleMatcher(mock)
+	got, err := m.MatchTitleToken(context.Background(), "Alice")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for below-floor match, got %+v", got)
+	}
+}
+
+// TC-TM4 — gap too small (0.10 < 0.20).
+func TestMatchTitleToken_CollisionGapTooSmall(t *testing.T) {
+	mock := &mockContactMatchFinder{matches: []repository.ContactMatch{
+		contactMatch(uuid.New(), "Alice One", 0.7),
+		contactMatch(uuid.New(), "Alice Two", 0.6),
+	}}
+	m := NewTitleMatcher(mock)
+	got, err := m.MatchTitleToken(context.Background(), "Alice")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for ambiguous match, got %+v", got)
+	}
+}
+
+// TC-TM5 — gap exactly meets threshold (0.20). Strict-less-or-equal
+// means this should still drop.
+func TestMatchTitleToken_CollisionGapJustMeets(t *testing.T) {
+	mock := &mockContactMatchFinder{matches: []repository.ContactMatch{
+		contactMatch(uuid.New(), "Alice One", 0.7),
+		contactMatch(uuid.New(), "Alice Two", 0.5),
+	}}
+	m := NewTitleMatcher(mock)
+	got, err := m.MatchTitleToken(context.Background(), "Alice")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got != nil {
+		t.Errorf("gap of exactly 0.20 should be ambiguous, got %+v", got)
+	}
+}
+
+// TC-TM6 — gap exceeds threshold (0.21 > 0.20).
+func TestMatchTitleToken_CollisionGapExceeds(t *testing.T) {
+	topID := uuid.New()
+	mock := &mockContactMatchFinder{matches: []repository.ContactMatch{
+		contactMatch(topID, "Alice Top", 0.7),
+		contactMatch(uuid.New(), "Alice Runner", 0.49),
+	}}
+	m := NewTitleMatcher(mock)
+	got, err := m.MatchTitleToken(context.Background(), "Alice")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got == nil || got.Contact.ID != topID {
+		t.Errorf("expected top match, got %+v", got)
+	}
+}
+
+// TC-TM7 — tie-breaker stable: two same-similarity matches. Even if
+// they're above the floor, the gap is 0 so both should drop.
+func TestMatchTitleToken_TieBreakerStable(t *testing.T) {
+	// Use IDs where idA < idB lexicographically to verify the
+	// tie-breaker sort. Even though sort is stable, we still drop
+	// because the gap is 0.
+	idA := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	idB := uuid.MustParse("00000000-0000-0000-0000-000000000002")
+	mock := &mockContactMatchFinder{matches: []repository.ContactMatch{
+		// Feed reversed so the sort has to do work.
+		contactMatch(idB, "Alice B", 0.7),
+		contactMatch(idA, "Alice A", 0.7),
+	}}
+	m := NewTitleMatcher(mock)
+	got, err := m.MatchTitleToken(context.Background(), "Alice")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got != nil {
+		t.Errorf("equal-similarity ties should be ambiguous, got %+v", got)
+	}
+}
+
+// TC-TM8 — empty token short-circuits without a DB call.
+func TestMatchTitleToken_EmptyToken(t *testing.T) {
+	mock := &mockContactMatchFinder{}
+	m := NewTitleMatcher(mock)
+	got, err := m.MatchTitleToken(context.Background(), "")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got != nil {
+		t.Errorf("empty token should return nil, got %+v", got)
+	}
+	if mock.calls != 0 {
+		t.Errorf("empty token should not invoke repo, got %d calls", mock.calls)
+	}
+}
+
+// TestMatchTitleToken_RepoError surfaces DB errors to the caller.
+func TestMatchTitleToken_RepoError(t *testing.T) {
+	mock := &mockContactMatchFinder{err: errors.New("boom")}
+	m := NewTitleMatcher(mock)
+	got, err := m.MatchTitleToken(context.Background(), "Alice")
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if got != nil {
+		t.Errorf("expected nil match on error, got %+v", got)
+	}
+}

--- a/backend/internal/anarlog/title_test.go
+++ b/backend/internal/anarlog/title_test.go
@@ -1,0 +1,164 @@
+package anarlog
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestExtractNameTokens covers the D2 fixture table from the PR plan
+// plus the word-boundary cases added per Codex round-1 review.
+func TestExtractNameTokens(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		// Meta-token stripping.
+		{"strip_1to1", "Alice / Bob 1:1", []string{"Alice", "Bob"}},
+		{"strip_sync", "Alice sync", []string{"Alice"}},
+		{"strip_catchup", "Catchup with Alice and Bob", []string{"Alice", "Bob"}},
+		{"strip_intro", "intro Alice", []string{"Alice"}},
+		{"strip_standup", "Standup with Alice", []string{"Alice"}},
+		{"strip_huddle", "Huddle with Alice", []string{"Alice"}},
+		{"strip_check_in_hyphen", "Check-in with Alice", []string{"Alice"}},
+		{"strip_checkin", "Checkin with Alice", []string{"Alice"}},
+		{"strip_review_word", "Alice review", []string{"Alice"}},
+		{"strip_one_dash_one", "Alice 1-1", []string{"Alice"}},
+		{"strip_one_on_one", "Alice one-on-one", []string{"Alice"}},
+
+		// Date stripping.
+		{"strip_date_iso", "Alice / Bob 2026-05-12", []string{"Alice", "Bob"}},
+		{"strip_date_us", "Alice + Bob 5/12", []string{"Alice", "Bob"}},
+		{"strip_date_us_full", "Alice + Bob 5/12/2026", []string{"Alice", "Bob"}},
+		{"strip_date_us_two_digit_year", "Alice + Bob 5/12/26", []string{"Alice", "Bob"}},
+		{"strip_numeric_month_day", "Alice + Bob 5-12", []string{"Alice", "Bob"}},
+
+		// Month + weekday stripping.
+		{"strip_month", "Alice & Bob May review", []string{"Alice", "Bob"}},
+		{"strip_weekday", "Monday standup w/ Alice & Carol", []string{"Alice", "Carol"}},
+		{"strip_weekday_abbrev", "Mon w/ Alice", []string{"Alice"}},
+
+		// Separator splitting.
+		{"split_slash", "Alice/Bob", []string{"Alice", "Bob"}},
+		{"split_ampersand", "Alice & Bob", []string{"Alice", "Bob"}},
+		{"split_and_word", "Alice and Bob", []string{"Alice", "Bob"}},
+		{"split_with_word", "Catchup with Alice", []string{"Alice"}},
+		{"split_w_slash", "Sync w/ Alice", []string{"Alice"}},
+		{"split_plus", "Alice+Bob", []string{"Alice", "Bob"}},
+		{"split_hyphen", "Alice-Bob 1:1", []string{"Alice", "Bob"}},
+		{"split_colon", "Alice:Bob", []string{"Alice", "Bob"}},
+
+		// Keep-regex filtering.
+		{"keep_capitalized_only", "alice / bob", []string{}},
+		{"keep_alpha_only", "Alice / Bob123", []string{"Alice"}},
+		{"keep_length_min", "A / Bo", []string{"Bo"}},
+		{"keep_length_max", "Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa / Bob", []string{"Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "Bob"}}, // 30 chars passes
+		{"keep_length_reject_31", "Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa / Bob", []string{"Bob"}},                            // 31 chars rejected
+
+		// Stopwords.
+		{"stopword_re", "Re Alice", []string{"Alice"}},
+		{"stopword_fwd", "Fwd Alice", []string{"Alice"}},
+		{"stopword_test", "Test Alice", []string{"Alice"}},
+		{"stopword_demo", "Demo Alice", []string{"Alice"}},
+
+		// Dedup.
+		{"dedup_case_insensitive", "Alice & alice", []string{"Alice"}},
+		{"dedup_exact", "Alice and Alice", []string{"Alice"}},
+
+		// Empty / whitespace.
+		{"empty", "", []string{}},
+		{"whitespace_only", "   ", []string{}},
+
+		// Composite.
+		{"composite_meta_and_split", "1:1 catchup w/ Alice & Bob 2026-05-12", []string{"Alice", "Bob"}},
+
+		// Unicode (out of scope per spec).
+		{"unicode_diacritic_dropped", "José / Bob", []string{"Bob"}},
+
+		// Word-boundary protection (Codex round-1 P2#1).
+		{"word_boundary_monica", "Monica and Bob", []string{"Monica", "Bob"}},
+		{"word_boundary_callie", "Callie sync", []string{"Callie"}},
+		{"word_boundary_pranav", "Pranav sync", []string{"Pranav"}},
+		{"word_boundary_may_june_dropped", "May & June 1:1", []string{}},
+		{"word_boundary_april_dropped", "April review", []string{}},
+		{"word_boundary_january_february_dropped", "January / February", []string{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ExtractNameTokens(tc.input)
+			if len(got) == 0 && len(tc.want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("ExtractNameTokens(%q) = %v, want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestExtractNameTokens_PreservesEncounterOrder verifies the spec
+// invariant that tokens appear in the order they were encountered.
+func TestExtractNameTokens_PreservesEncounterOrder(t *testing.T) {
+	got := ExtractNameTokens("Charlie and Alice and Bob")
+	want := []string{"Charlie", "Alice", "Bob"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("encounter order broken: got %v, want %v", got, want)
+	}
+}
+
+// TestExtractNameTokens_DedupPreservesFirstCasing verifies that
+// case-insensitive dedup keeps the first-seen casing.
+func TestExtractNameTokens_DedupPreservesFirstCasing(t *testing.T) {
+	got := ExtractNameTokens("Alice and alice and ALICE")
+	if len(got) != 1 || got[0] != "Alice" {
+		t.Errorf("dedup should keep first-seen casing: got %v", got)
+	}
+}
+
+// TestExtractNameTokens_Determinism — same input always yields same
+// output (no map iteration leaking).
+func TestExtractNameTokens_Determinism(t *testing.T) {
+	input := "Alice / Bob / Carol / Dave / Erika"
+	first := ExtractNameTokens(input)
+	for i := 0; i < 50; i++ {
+		got := ExtractNameTokens(input)
+		if !reflect.DeepEqual(first, got) {
+			t.Fatalf("non-deterministic output: run 0 = %v, run %d = %v", first, i, got)
+		}
+	}
+}
+
+// TestExtractNameTokens_NoSideEffects — repeated calls don't pollute
+// package state. (Sanity check; the function is pure.)
+func TestExtractNameTokens_NoSideEffects(t *testing.T) {
+	_ = ExtractNameTokens("Alice")
+	_ = ExtractNameTokens("Bob")
+	got := ExtractNameTokens("Carol")
+	if !reflect.DeepEqual(got, []string{"Carol"}) {
+		t.Errorf("side-effect leak: got %v", got)
+	}
+}
+
+// Sanity: keepTokenRegex matches the documented invariants.
+func TestKeepTokenRegex(t *testing.T) {
+	cases := []struct {
+		in   string
+		keep bool
+	}{
+		{"Alice", true},
+		{"A", false},                     // too short
+		{"Ab", true},                     // length 2
+		{strings.Repeat("A", 30), true},  // length 30
+		{strings.Repeat("A", 31), false}, // length 31
+		{"alice", false},                 // lowercase first letter
+		{"Bob123", false},                // digit
+		{"Bob-Smith", false},             // hyphen
+	}
+	for _, tc := range cases {
+		got := keepTokenRegex.MatchString(tc.in)
+		if got != tc.keep {
+			t.Errorf("keepTokenRegex.MatchString(%q) = %v, want %v", tc.in, got, tc.keep)
+		}
+	}
+}

--- a/backend/internal/anarlog/title_test.go
+++ b/backend/internal/anarlog/title_test.go
@@ -6,8 +6,9 @@ import (
 	"testing"
 )
 
-// TestExtractNameTokens covers the D2 fixture table from the PR plan
-// plus the word-boundary cases added per Codex round-1 review.
+// TestExtractNameTokens covers meta-token stripping, separator
+// splitting, the keep regex, stopwords, dedup, and word-boundary
+// protection.
 func TestExtractNameTokens(t *testing.T) {
 	cases := []struct {
 		name  string
@@ -76,7 +77,8 @@ func TestExtractNameTokens(t *testing.T) {
 		// Unicode (out of scope per spec).
 		{"unicode_diacritic_dropped", "José / Bob", []string{"Bob"}},
 
-		// Word-boundary protection (Codex round-1 P2#1).
+		// Word-boundary protection: substring matches of meta-tokens
+		// in a real name must not strip the name.
 		{"word_boundary_monica", "Monica and Bob", []string{"Monica", "Bob"}},
 		{"word_boundary_callie", "Callie sync", []string{"Callie"}},
 		{"word_boundary_pranav", "Pranav sync", []string{"Pranav"}},

--- a/backend/internal/anarlog/title_test.go
+++ b/backend/internal/anarlog/title_test.go
@@ -85,6 +85,18 @@ func TestExtractNameTokens(t *testing.T) {
 		{"word_boundary_may_june_dropped", "May & June 1:1", []string{}},
 		{"word_boundary_april_dropped", "April review", []string{}},
 		{"word_boundary_january_february_dropped", "January / February", []string{}},
+
+		// Non-ASCII inputs are silently dropped per spec philosophy.
+		// Regression: a multi-byte rune whose strings.ToLower changes
+		// byte length (e.g. Turkish capital İ — 2 bytes — vs lowercase
+		// "i" — 1 byte) used to desynchronize the lowercase/working
+		// byte offsets and corrupt an adjacent ASCII token. Now the
+		// non-ASCII byte is sanitized to a space in both copies so the
+		// neighboring "Alice" survives intact.
+		{"non_ascii_letter_dropped_preserves_neighbor",
+			"İ Alice and Bob", []string{"Alice", "Bob"}},
+		{"non_ascii_pure_yields_empty",
+			"日本語", []string{}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/backend/internal/db/external_contact.sql.go
+++ b/backend/internal/db/external_contact.sql.go
@@ -14,6 +14,7 @@ import (
 const CountAllUnmatchedExternalContacts = `-- name: CountAllUnmatchedExternalContacts :one
 SELECT COUNT(*) FROM external_contact
 WHERE match_status = 'unmatched'
+  AND source != 'anarlog_title'
   AND duplicate_of_id IS NULL
   AND deleted_at IS NULL
 `
@@ -28,6 +29,7 @@ func (q *Queries) CountAllUnmatchedExternalContacts(ctx context.Context) (int64,
 const CountUnmatchedExternalContacts = `-- name: CountUnmatchedExternalContacts :one
 SELECT COUNT(*) FROM external_contact
 WHERE source = $1
+  AND source != 'anarlog_title'
   AND match_status = 'unmatched'
   AND duplicate_of_id IS NULL
   AND deleted_at IS NULL
@@ -490,6 +492,7 @@ func (q *Queries) IgnoreExternalContact(ctx context.Context, id pgtype.UUID) err
 const ListAllUnmatchedExternalContacts = `-- name: ListAllUnmatchedExternalContacts :many
 SELECT id, source, source_id, account_id, display_name, first_name, last_name, emails, phones, addresses, organization, job_title, birthday, photo_url, crm_contact_id, match_status, duplicate_of_id, etag, metadata, synced_at, created_at, updated_at, deleted_at, host_id, last_content_hash FROM external_contact
 WHERE match_status = 'unmatched'
+  AND source != 'anarlog_title'
   AND duplicate_of_id IS NULL
   AND deleted_at IS NULL
 ORDER BY source, display_name
@@ -764,6 +767,7 @@ func (q *Queries) ListKnownExternalContactIDsByHostAndSource(ctx context.Context
 const ListUnmatchedExternalContacts = `-- name: ListUnmatchedExternalContacts :many
 SELECT id, source, source_id, account_id, display_name, first_name, last_name, emails, phones, addresses, organization, job_title, birthday, photo_url, crm_contact_id, match_status, duplicate_of_id, etag, metadata, synced_at, created_at, updated_at, deleted_at, host_id, last_content_hash FROM external_contact
 WHERE source = $1
+  AND source != 'anarlog_title'
   AND match_status = 'unmatched'
   AND duplicate_of_id IS NULL
   AND deleted_at IS NULL
@@ -777,6 +781,9 @@ type ListUnmatchedExternalContactsParams struct {
 	Offset int32  `json:"offset"`
 }
 
+// The `source != 'anarlog_title'` filter excludes weak token-aggregated
+// discovery rows from the per-source Imports UI list. anarlog_title
+// rows are surfaced through a dedicated grouped-by-token UI surface.
 func (q *Queries) ListUnmatchedExternalContacts(ctx context.Context, arg ListUnmatchedExternalContactsParams) ([]*ExternalContact, error) {
 	rows, err := q.db.Query(ctx, ListUnmatchedExternalContacts, arg.Source, arg.Limit, arg.Offset)
 	if err != nil {

--- a/backend/internal/db/external_contact.sql.go
+++ b/backend/internal/db/external_contact.sql.go
@@ -35,6 +35,9 @@ WHERE source = $1
   AND deleted_at IS NULL
 `
 
+// Per-source count; mirrors ListUnmatched's anarlog_title exclusion
+// so list+count cardinality stays consistent regardless of caller-
+// supplied source.
 func (q *Queries) CountUnmatchedExternalContacts(ctx context.Context, source string) (int64, error) {
 	row := q.db.QueryRow(ctx, CountUnmatchedExternalContacts, source)
 	var count int64
@@ -781,9 +784,12 @@ type ListUnmatchedExternalContactsParams struct {
 	Offset int32  `json:"offset"`
 }
 
-// The `source != 'anarlog_title'` filter excludes weak token-aggregated
-// discovery rows from the per-source Imports UI list. anarlog_title
-// rows are surfaced through a dedicated grouped-by-token UI surface.
+// Per-source query; anarlog_title rows are intentionally NOT exposed
+// here — they live behind a dedicated grouped-by-token UI surface.
+// The `source != 'anarlog_title'` clause is defense-in-depth: if a
+// caller passes source='anarlog_title' (intentionally or via param
+// injection), this query returns empty rather than leaking weak
+// discovery rows into the per-source UI.
 func (q *Queries) ListUnmatchedExternalContacts(ctx context.Context, arg ListUnmatchedExternalContactsParams) ([]*ExternalContact, error) {
 	rows, err := q.db.Query(ctx, ListUnmatchedExternalContacts, arg.Source, arg.Limit, arg.Offset)
 	if err != nil {

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -133,6 +133,9 @@ type Querier interface {
 	CountTelegramMessagesByPeer(ctx context.Context) ([]*CountTelegramMessagesByPeerRow, error)
 	// Count messages for a single peer (for incremental discovery threshold check)
 	CountTelegramMessagesByPeerID(ctx context.Context, peerUserID pgtype.Int8) (*CountTelegramMessagesByPeerIDRow, error)
+	// Per-source count; mirrors ListUnmatched's anarlog_title exclusion
+	// so list+count cardinality stays consistent regardless of caller-
+	// supplied source.
 	CountUnmatchedExternalContacts(ctx context.Context, source string) (int64, error)
 	CountUnmatchedIdentities(ctx context.Context) (int64, error)
 	// Counts messages about to be linked for a given peer. Read BEFORE
@@ -715,9 +718,12 @@ type Querier interface {
 	ListTelegramChatConfigs(ctx context.Context) ([]*TelegramChatConfig, error)
 	ListTelegramChatConfigsForBackfill(ctx context.Context) ([]*TelegramChatConfig, error)
 	ListTelegramMessagesByChatUnprocessed(ctx context.Context, telegramChatID int64) ([]*TelegramMessage, error)
-	// The `source != 'anarlog_title'` filter excludes weak token-aggregated
-	// discovery rows from the per-source Imports UI list. anarlog_title
-	// rows are surfaced through a dedicated grouped-by-token UI surface.
+	// Per-source query; anarlog_title rows are intentionally NOT exposed
+	// here — they live behind a dedicated grouped-by-token UI surface.
+	// The `source != 'anarlog_title'` clause is defense-in-depth: if a
+	// caller passes source='anarlog_title' (intentionally or via param
+	// injection), this query returns empty rather than leaking weak
+	// discovery rows into the per-source UI.
 	ListUnmatchedExternalContacts(ctx context.Context, arg ListUnmatchedExternalContactsParams) ([]*ExternalContact, error)
 	ListUnmatchedIdentities(ctx context.Context, arg ListUnmatchedIdentitiesParams) ([]*ExternalIdentity, error)
 	// Distinct contact IDs with at least one eligible (unprocessed AND

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -715,6 +715,9 @@ type Querier interface {
 	ListTelegramChatConfigs(ctx context.Context) ([]*TelegramChatConfig, error)
 	ListTelegramChatConfigsForBackfill(ctx context.Context) ([]*TelegramChatConfig, error)
 	ListTelegramMessagesByChatUnprocessed(ctx context.Context, telegramChatID int64) ([]*TelegramMessage, error)
+	// The `source != 'anarlog_title'` filter excludes weak token-aggregated
+	// discovery rows from the per-source Imports UI list. anarlog_title
+	// rows are surfaced through a dedicated grouped-by-token UI surface.
 	ListUnmatchedExternalContacts(ctx context.Context, arg ListUnmatchedExternalContactsParams) ([]*ExternalContact, error)
 	ListUnmatchedIdentities(ctx context.Context, arg ListUnmatchedIdentitiesParams) ([]*ExternalIdentity, error)
 	// Distinct contact IDs with at least one eligible (unprocessed AND

--- a/backend/internal/db/queries/external_contact.sql
+++ b/backend/internal/db/queries/external_contact.sql
@@ -141,8 +141,12 @@ ORDER BY display_name
 LIMIT $3 OFFSET $4;
 
 -- name: ListUnmatchedExternalContacts :many
+-- The `source != 'anarlog_title'` filter excludes weak token-aggregated
+-- discovery rows from the per-source Imports UI list. anarlog_title
+-- rows are surfaced through a dedicated grouped-by-token UI surface.
 SELECT * FROM external_contact
 WHERE source = $1
+  AND source != 'anarlog_title'
   AND match_status = 'unmatched'
   AND duplicate_of_id IS NULL
   AND deleted_at IS NULL
@@ -152,6 +156,7 @@ LIMIT $2 OFFSET $3;
 -- name: ListAllUnmatchedExternalContacts :many
 SELECT * FROM external_contact
 WHERE match_status = 'unmatched'
+  AND source != 'anarlog_title'
   AND duplicate_of_id IS NULL
   AND deleted_at IS NULL
 ORDER BY source, display_name
@@ -160,6 +165,7 @@ LIMIT $1 OFFSET $2;
 -- name: CountUnmatchedExternalContacts :one
 SELECT COUNT(*) FROM external_contact
 WHERE source = $1
+  AND source != 'anarlog_title'
   AND match_status = 'unmatched'
   AND duplicate_of_id IS NULL
   AND deleted_at IS NULL;
@@ -167,6 +173,7 @@ WHERE source = $1
 -- name: CountAllUnmatchedExternalContacts :one
 SELECT COUNT(*) FROM external_contact
 WHERE match_status = 'unmatched'
+  AND source != 'anarlog_title'
   AND duplicate_of_id IS NULL
   AND deleted_at IS NULL;
 

--- a/backend/internal/db/queries/external_contact.sql
+++ b/backend/internal/db/queries/external_contact.sql
@@ -141,9 +141,12 @@ ORDER BY display_name
 LIMIT $3 OFFSET $4;
 
 -- name: ListUnmatchedExternalContacts :many
--- The `source != 'anarlog_title'` filter excludes weak token-aggregated
--- discovery rows from the per-source Imports UI list. anarlog_title
--- rows are surfaced through a dedicated grouped-by-token UI surface.
+-- Per-source query; anarlog_title rows are intentionally NOT exposed
+-- here — they live behind a dedicated grouped-by-token UI surface.
+-- The `source != 'anarlog_title'` clause is defense-in-depth: if a
+-- caller passes source='anarlog_title' (intentionally or via param
+-- injection), this query returns empty rather than leaking weak
+-- discovery rows into the per-source UI.
 SELECT * FROM external_contact
 WHERE source = $1
   AND source != 'anarlog_title'
@@ -163,6 +166,9 @@ ORDER BY source, display_name
 LIMIT $1 OFFSET $2;
 
 -- name: CountUnmatchedExternalContacts :one
+-- Per-source count; mirrors ListUnmatched's anarlog_title exclusion
+-- so list+count cardinality stays consistent regardless of caller-
+-- supplied source.
 SELECT COUNT(*) FROM external_contact
 WHERE source = $1
   AND source != 'anarlog_title'

--- a/backend/internal/service/ingest.go
+++ b/backend/internal/service/ingest.go
@@ -2294,6 +2294,9 @@ func (s *IngestService) handleMeetingNoteRecorded(
 		Int("tagged_unresolved", len(p.ParticipantIDs)-len(resolvedTagged)).
 		Int("interactions_created", interactionsCreated).
 		Int("interactions_dropped", interactionsDropped).
+		Int("title_tokens_extracted", len(titleTokens)).
+		Int("title_tokens_matched", len(titleMatched)).
+		Int("title_tokens_unmatched", len(titleUnmatched)).
 		Bool("revive_path", revivePath).
 		Bool("carry_forward", carryForward).
 		Bool("input_hash_changed", priorInputHash != newInputHash).

--- a/backend/internal/service/ingest.go
+++ b/backend/internal/service/ingest.go
@@ -53,6 +53,8 @@ const (
 	ingestRejectLinkageQueryFailed                = "LINKAGE_QUERY_FAILED"
 	ingestRejectParticipantResolveFailed          = "PARTICIPANT_RESOLVE_FAILED"
 	ingestRejectInteractionWriteFailed            = "INTERACTION_WRITE_FAILED"
+	ingestRejectTitleMatchFailed                  = "TITLE_MATCH_FAILED"
+	ingestRejectTitleDiscoveryUpsertFailed        = "TITLE_DISCOVERY_UPSERT_FAILED"
 )
 
 // ErrHostRevokedDuringBatch is returned by IngestBatch when the
@@ -263,6 +265,21 @@ type FollowUpApplier interface {
 	HandleEvent(ctx context.Context, tx pgx.Tx, env *events.Envelope) (postCommit func(context.Context), err error)
 }
 
+// IngestTitleMatcher is the narrow surface the meeting_note.recorded
+// handler uses to disambiguate a single title-extracted name token to
+// a CRM contact. Concrete is *anarlog.TitleMatcher.
+type IngestTitleMatcher interface {
+	MatchTitleToken(ctx context.Context, token string) (*repository.ContactMatch, error)
+}
+
+// IngestTitleDiscoveryWriter is the narrow surface the meeting_note
+// handler uses to persist anarlog_title weak-candidate rows for tokens
+// that didn't resolve to an existing CRM contact. Concrete is
+// *anarlog.DiscoveryWriter.
+type IngestTitleDiscoveryWriter interface {
+	UpsertTitleCandidateTx(ctx context.Context, tx pgx.Tx, sessionUUID uuid.UUID, normalizedToken, displayToken string) error
+}
+
 // IngestService persists pre-validated event envelopes inside a single
 // transaction. All envelopes in a batch commit together or roll back
 // together — spec §3.5 "all-or-nothing on unexpected errors."
@@ -295,6 +312,8 @@ type IngestService struct {
 	contactRecorder  ContactRecorder
 	cadence          CadenceApplier
 	followUp         FollowUpApplier
+	titleMatcher     IngestTitleMatcher
+	discovery        IngestTitleDiscoveryWriter
 }
 
 // NewIngestService builds an IngestService. Per-kind dependencies may
@@ -309,10 +328,11 @@ type IngestService struct {
 // concrete repository so the race window between auth and commit is
 // closed.
 //
-// meetingNotes/calendar/interactions/identityLookup/contactSvc are the
-// meeting_note.* inline handler's dependency set. Passing nil here is
-// supported for callers that don't need the meeting_note path; the
-// handler returns PAYLOAD_INVARIANT for missing wiring.
+// meetingNotes/calendar/interactions/identityLookup/contactSvc/
+// titleMatcher/discovery are the meeting_note.* inline handler's
+// dependency set. Passing nil here is supported for callers that don't
+// need the meeting_note path; the handler returns PAYLOAD_INVARIANT for
+// missing wiring.
 func NewIngestService(
 	database *db.Database,
 	bus *events.Bus,
@@ -330,6 +350,8 @@ func NewIngestService(
 	contactRecorder ContactRecorder,
 	cadence CadenceApplier,
 	followUp FollowUpApplier,
+	titleMatcher IngestTitleMatcher,
+	discovery IngestTitleDiscoveryWriter,
 ) *IngestService {
 	return &IngestService{
 		database:         database,
@@ -348,6 +370,8 @@ func NewIngestService(
 		contactRecorder:  contactRecorder,
 		cadence:          cadence,
 		followUp:         followUp,
+		titleMatcher:     titleMatcher,
+		discovery:        discovery,
 	}
 }
 
@@ -1781,7 +1805,8 @@ func (s *IngestService) handleMeetingNoteRecorded(
 	authenticatedHostID uuid.UUID,
 ) (*NeedsAttentionItem, []func(context.Context), *IngestPerEventRejection) {
 	if s.meetingNotes == nil || s.calendar == nil || s.interactions == nil ||
-		s.identityLookup == nil || s.contactSvc == nil {
+		s.identityLookup == nil || s.contactSvc == nil ||
+		s.titleMatcher == nil || s.discovery == nil {
 		return nil, nil, &IngestPerEventRejection{
 			Code:    ingestRejectPayloadInvariant,
 			Message: "ingest service was not configured for meeting_note processing",

--- a/backend/internal/service/ingest.go
+++ b/backend/internal/service/ingest.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/anarlog"
 	"personal-crm/backend/internal/consumer/consumerjobs"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/events"
@@ -1744,17 +1745,36 @@ func computeMeetingNoteInputHash(meetingAt time.Time, title *string, participant
 }
 
 // computeResolvedSetHash returns the lowercase-hex SHA-256 of a
-// stable canonicalization of the resolved contact-UUID set. Used to
-// detect when participant→contact resolution changes between events
-// for the same session (e.g., after a user imports a previously-
-// unmatched anarlog_humans candidate).
-func computeResolvedSetHash(contactIDs []uuid.UUID) (string, error) {
-	strs := make([]string, len(contactIDs))
-	for i, id := range contactIDs {
-		strs[i] = id.String()
+// stable canonicalization of the union of tag-resolved + title-matched
+// contact UUIDs. The union captures drift in EITHER resolution path:
+// participant→contact (existing) or title-token→contact (added with
+// the anarlog title-parsing surface) — a change in either bumps the
+// hash and forces carry-forward to fail so the interaction-diff loop
+// can reconcile the title-derived `:title:` interactions.
+//
+// Note: when titleMatchedIDs is empty (no title or no title matches),
+// the union reduces to taggedIDs alone and the hash equals the
+// pre-title recipe — legacy meeting_note rows with empty titles or
+// no title matches keep their carry-forward semantics unchanged.
+func computeResolvedSetHash(taggedIDs []uuid.UUID, titleMatchedIDs []uuid.UUID) (string, error) {
+	union := make([]string, 0, len(taggedIDs)+len(titleMatchedIDs))
+	seen := make(map[uuid.UUID]struct{}, len(taggedIDs)+len(titleMatchedIDs))
+	for _, id := range taggedIDs {
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		union = append(union, id.String())
 	}
-	sort.Strings(strs)
-	raw, err := json.Marshal(strs)
+	for _, id := range titleMatchedIDs {
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		union = append(union, id.String())
+	}
+	sort.Strings(union)
+	raw, err := json.Marshal(union)
 	if err != nil {
 		return "", fmt.Errorf("marshal resolved set: %w", err)
 	}
@@ -1773,6 +1793,18 @@ func computeResolvedSetHash(contactIDs []uuid.UUID) (string, error) {
 type resolvedTag struct {
 	AnarlogID string
 	ContactID uuid.UUID
+}
+
+// resolvedTitle is a title-extracted name token that fuzzy-matched a
+// single CRM contact (high-confidence per the collision-gap rule).
+// Token preserves original casing for display; NormalizedToken is the
+// lowercased form used as the dedup + grouping key. The handler
+// deduplicates against resolvedTagged so a tagged human who also
+// appears in the title doesn't produce a second interaction.
+type resolvedTitle struct {
+	Token           string
+	NormalizedToken string
+	ContactID       uuid.UUID
 }
 
 // desiredInteraction is a single (contact_id, source_ref) pair the
@@ -1888,9 +1920,55 @@ func (s *IngestService) handleMeetingNoteRecorded(
 		resolvedTagged = append(resolvedTagged, resolvedTag{AnarlogID: pid, ContactID: *contactID})
 	}
 
-	// 4. Compute hashes. Stable order: input hash uses sorted
-	//    participant_ids; resolved-set hash uses sorted resolved
-	//    contact_ids.
+	// 4. Extract + match title tokens. Runs UNCONDITIONALLY (i.e., not
+	//    gated on carryForward, which doesn't exist yet at this point)
+	//    because the title-matched contact_ids feed into the
+	//    resolved_set_hash that DETERMINES carryForward. titleMatched
+	//    is deduplicated against resolvedTagged so a tagged human who
+	//    also appears in the title produces only one interaction.
+	titleStr := ""
+	if p.Title != nil {
+		titleStr = *p.Title
+	}
+	titleTokens := anarlog.ExtractNameTokens(titleStr)
+	titleMatched := make([]resolvedTitle, 0, len(titleTokens))
+	titleUnmatched := make([]string, 0, len(titleTokens))
+	for _, token := range titleTokens {
+		match, mErr := s.titleMatcher.MatchTitleToken(ctx, token)
+		if mErr != nil {
+			return nil, nil, &IngestPerEventRejection{
+				Code:    ingestRejectTitleMatchFailed,
+				Message: fmt.Sprintf("match title token %q: %s", token, mErr.Error()),
+			}
+		}
+		if match == nil {
+			titleUnmatched = append(titleUnmatched, token)
+			continue
+		}
+		// Dedup against resolvedTagged so the same contact doesn't get
+		// two interactions (the tagged-anchor form is canonical; the
+		// title-derived form is redundant for that contact).
+		alreadyTagged := false
+		for _, t := range resolvedTagged {
+			if t.ContactID == match.Contact.ID {
+				alreadyTagged = true
+				break
+			}
+		}
+		if alreadyTagged {
+			continue
+		}
+		titleMatched = append(titleMatched, resolvedTitle{
+			Token:           token,
+			NormalizedToken: strings.ToLower(token),
+			ContactID:       match.Contact.ID,
+		})
+	}
+
+	// 5. Compute hashes. Stable order: input hash uses sorted
+	//    participant_ids; resolved-set hash uses sorted UNION of
+	//    tag-resolved + title-matched contact_ids so drift in either
+	//    resolution path invalidates carry-forward.
 	newInputHash, err := computeMeetingNoteInputHash(p.MeetingAt, p.Title, p.ParticipantIDs)
 	if err != nil {
 		return nil, nil, &IngestPerEventRejection{
@@ -1902,7 +1980,11 @@ func (s *IngestService) handleMeetingNoteRecorded(
 	for i, r := range resolvedTagged {
 		resolvedContactIDs[i] = r.ContactID
 	}
-	newResolvedSetHash, err := computeResolvedSetHash(resolvedContactIDs)
+	titleMatchedIDs := make([]uuid.UUID, len(titleMatched))
+	for i, tm := range titleMatched {
+		titleMatchedIDs[i] = tm.ContactID
+	}
+	newResolvedSetHash, err := computeResolvedSetHash(resolvedContactIDs, titleMatchedIDs)
 	if err != nil {
 		return nil, nil, &IngestPerEventRejection{
 			Code:    ingestRejectMeetingNoteUpsertFailed,
@@ -1949,7 +2031,7 @@ func (s *IngestService) handleMeetingNoteRecorded(
 			}
 		}
 		candidatesLen = len(candidates)
-		finalLinkageState, finalLinkedKind, finalLinkedID, desired = decideLinkage(p, sessionID, candidates, resolvedTagged)
+		finalLinkageState, finalLinkedKind, finalLinkedID, desired = decideLinkage(p, sessionID, candidates, resolvedTagged, titleMatched)
 	}
 
 	// 6. Write meeting_note row. Branch on first-insert / revive /
@@ -2158,7 +2240,23 @@ func (s *IngestService) handleMeetingNoteRecorded(
 		}
 	}
 
-	// 8. Single-point needs_attention computation. The caller appends
+	// 8. Discovery upsert for unmatched title tokens. Runs
+	//    UNCONDITIONALLY (not gated on !carryForward) so legacy
+	//    pre-title-parsing sessions whose hash happens to match under
+	//    both old and new recipes still backfill their discovery rows
+	//    on first re-ingest. The deterministic source_id (sha256 of
+	//    token||session_uuid) makes re-emit a cheap UPDATE refresh on
+	//    existing rows.
+	for _, token := range titleUnmatched {
+		if dErr := s.discovery.UpsertTitleCandidateTx(ctx, tx, sessionID, strings.ToLower(token), token); dErr != nil {
+			return nil, nil, &IngestPerEventRejection{
+				Code:    ingestRejectTitleDiscoveryUpsertFailed,
+				Message: fmt.Sprintf("upsert title candidate %q: %s", token, dErr.Error()),
+			}
+		}
+	}
+
+	// 9. Single-point needs_attention computation. The caller appends
 	//    this AFTER savepoint commit so a rollback path cannot leak an
 	//    item into the batch accumulator.
 	var needs *NeedsAttentionItem
@@ -2169,7 +2267,7 @@ func (s *IngestService) handleMeetingNoteRecorded(
 		needs = &NeedsAttentionItem{SessionID: p.SourceID, Reason: NeedsAttentionReasonOrphan}
 	}
 
-	// 9. Structured log line for observability.
+	// 10. Structured log line for observability.
 	priorInputHash := ""
 	priorResolvedSetHash := ""
 	if prior != nil {
@@ -2211,32 +2309,47 @@ func (s *IngestService) handleMeetingNoteRecorded(
 // interaction set.
 //
 //   - 0 candidates, no tagged humans → orphan_needs_review (no
-//     interactions).
-//   - 0 candidates, ≥1 resolved tagged human → linked_impromptu (one
-//     interaction per resolved contact).
+//     interactions). Title matches DO NOT promote a no-anchor orphan
+//     to augmented per spec invariant (tagged humans are the anchor).
+//   - 0 candidates, ≥1 resolved tagged human, 0 title-matched →
+//     linked_impromptu (one interaction per resolved contact).
+//   - 0 candidates, ≥1 resolved tagged human, ≥1 title-matched →
+//     orphan_title_augmented (tagged interactions PLUS one
+//     `:title:` interaction per title-matched contact).
 //   - 1 candidate → linked. A walk-in supplemental interaction is
 //     emitted for each resolved tagged contact NOT already in the
-//     event's matched_contact_ids.
-//   - 2+ candidates → conflict_pending. The current implementation
-//     never disambiguates; participant-signal scoring lands in a
-//     future revision.
+//     event's matched_contact_ids. Title matches DO NOT produce
+//     interactions in this state.
+//   - 2+ candidates → conflict_pending. Title matches DO NOT produce
+//     interactions in this state. Participant-signal scoring lands in
+//     a future revision.
 func decideLinkage(
 	p events.MeetingNoteRecordedPayload,
 	sessionID uuid.UUID,
 	candidates []repository.LinkageCandidate,
 	resolvedTagged []resolvedTag,
+	titleMatched []resolvedTitle,
 ) (state string, linkedKind *string, linkedID *uuid.UUID, desired []desiredInteraction) {
 	switch len(candidates) {
 	case 0:
 		if len(resolvedTagged) == 0 {
 			return repository.LinkageStateOrphanNeedsReview, nil, nil, nil
 		}
-		out := make([]desiredInteraction, 0, len(resolvedTagged))
+		out := make([]desiredInteraction, 0, len(resolvedTagged)+len(titleMatched))
 		for _, r := range resolvedTagged {
 			out = append(out, desiredInteraction{
 				ContactID: r.ContactID,
 				SourceRef: fmt.Sprintf("anarlog:%s:%s", sessionID.String(), r.ContactID.String()),
 			})
+		}
+		if len(titleMatched) > 0 {
+			for _, tm := range titleMatched {
+				out = append(out, desiredInteraction{
+					ContactID: tm.ContactID,
+					SourceRef: fmt.Sprintf("anarlog:%s:title:%s", sessionID.String(), tm.ContactID.String()),
+				})
+			}
+			return repository.LinkageStateOrphanTitleAugmented, nil, nil, out
 		}
 		return repository.LinkageStateLinkedImpromptu, nil, nil, out
 	case 1:

--- a/backend/internal/service/ingest_test.go
+++ b/backend/internal/service/ingest_test.go
@@ -1067,22 +1067,72 @@ func TestComputeResolvedSetHash_StableAcrossOrder(t *testing.T) {
 	id1 := uuid.New()
 	id2 := uuid.New()
 	id3 := uuid.New()
-	hashA, err := computeResolvedSetHash([]uuid.UUID{id1, id2, id3})
+	hashA, err := computeResolvedSetHash([]uuid.UUID{id1, id2, id3}, nil)
 	require.NoError(t, err)
-	hashB, err := computeResolvedSetHash([]uuid.UUID{id3, id1, id2})
+	hashB, err := computeResolvedSetHash([]uuid.UUID{id3, id1, id2}, nil)
 	require.NoError(t, err)
 	require.Equal(t, hashA, hashB)
+}
+
+// TestComputeResolvedSetHash_UnionsTaggedAndTitleMatched confirms the
+// hash includes BOTH tag-resolved and title-matched contact IDs so a
+// drift in either resolution path bumps the hash.
+func TestComputeResolvedSetHash_UnionsTaggedAndTitleMatched(t *testing.T) {
+	tagged := uuid.New()
+	titled := uuid.New()
+	taggedOnly, err := computeResolvedSetHash([]uuid.UUID{tagged}, nil)
+	require.NoError(t, err)
+	taggedAndTitled, err := computeResolvedSetHash([]uuid.UUID{tagged}, []uuid.UUID{titled})
+	require.NoError(t, err)
+	require.NotEqual(t, taggedOnly, taggedAndTitled,
+		"adding a title-matched contact must change the hash")
+
+	// Same set via different paths → same hash (dedup across slices).
+	viaTagged, err := computeResolvedSetHash([]uuid.UUID{tagged, titled}, nil)
+	require.NoError(t, err)
+	viaSplit, err := computeResolvedSetHash([]uuid.UUID{tagged}, []uuid.UUID{titled})
+	require.NoError(t, err)
+	require.Equal(t, viaTagged, viaSplit,
+		"hash depends on the union, not which slice contributed which id")
+}
+
+// TestComputeResolvedSetHash_EmptyTitleMatchedPreservesLegacyHash
+// confirms the carry-forward semantic stays intact for legacy rows
+// that have no title-matched contacts.
+func TestComputeResolvedSetHash_EmptyTitleMatchedPreservesLegacyHash(t *testing.T) {
+	tagged := uuid.New()
+	withNil, err := computeResolvedSetHash([]uuid.UUID{tagged}, nil)
+	require.NoError(t, err)
+	withEmpty, err := computeResolvedSetHash([]uuid.UUID{tagged}, []uuid.UUID{})
+	require.NoError(t, err)
+	require.Equal(t, withNil, withEmpty)
 }
 
 // TestDecideLinkage_NoCandidatesNoTagged returns orphan_needs_review
 // with no interactions.
 func TestDecideLinkage_NoCandidatesNoTagged(t *testing.T) {
 	sessionID := uuid.New()
-	state, kind, id, desired := decideLinkage(events.MeetingNoteRecordedPayload{}, sessionID, nil, nil)
+	state, kind, id, desired := decideLinkage(events.MeetingNoteRecordedPayload{}, sessionID, nil, nil, nil)
 	require.Equal(t, repository.LinkageStateOrphanNeedsReview, state)
 	require.Nil(t, kind)
 	require.Nil(t, id)
 	require.Empty(t, desired)
+}
+
+// TestDecideLinkage_NoCandidatesNoTaggedWithTitleMatches confirms the
+// spec invariant: title matches DO NOT promote a no-anchor orphan to
+// augmented (the anchor must be tagged humans).
+func TestDecideLinkage_NoCandidatesNoTaggedWithTitleMatches(t *testing.T) {
+	sessionID := uuid.New()
+	titled := uuid.New()
+	titleMatched := []resolvedTitle{
+		{Token: "Alice", NormalizedToken: "alice", ContactID: titled},
+	}
+	state, kind, id, desired := decideLinkage(events.MeetingNoteRecordedPayload{}, sessionID, nil, nil, titleMatched)
+	require.Equal(t, repository.LinkageStateOrphanNeedsReview, state)
+	require.Nil(t, kind)
+	require.Nil(t, id)
+	require.Empty(t, desired, "title matches alone never produce interactions")
 }
 
 // TestDecideLinkage_NoCandidatesWithTagged returns linked_impromptu and
@@ -1095,7 +1145,7 @@ func TestDecideLinkage_NoCandidatesWithTagged(t *testing.T) {
 		{AnarlogID: "human-a", ContactID: cA},
 		{AnarlogID: "human-b", ContactID: cB},
 	}
-	state, kind, id, desired := decideLinkage(events.MeetingNoteRecordedPayload{}, sessionID, nil, resolved)
+	state, kind, id, desired := decideLinkage(events.MeetingNoteRecordedPayload{}, sessionID, nil, resolved, nil)
 	require.Equal(t, repository.LinkageStateLinkedImpromptu, state)
 	require.Nil(t, kind)
 	require.Nil(t, id)
@@ -1105,6 +1155,29 @@ func TestDecideLinkage_NoCandidatesWithTagged(t *testing.T) {
 	gotRefs := []string{desired[0].SourceRef, desired[1].SourceRef}
 	require.Contains(t, gotRefs, refA)
 	require.Contains(t, gotRefs, refB)
+}
+
+// TestDecideLinkage_NoCandidatesWithTaggedAndTitleMatches returns
+// orphan_title_augmented with one tagged interaction PLUS one
+// `:title:` interaction per title-matched contact.
+func TestDecideLinkage_NoCandidatesWithTaggedAndTitleMatches(t *testing.T) {
+	sessionID := uuid.New()
+	cTagged := uuid.New()
+	cTitled := uuid.New()
+	resolved := []resolvedTag{{AnarlogID: "human-tagged", ContactID: cTagged}}
+	titleMatched := []resolvedTitle{
+		{Token: "Alice", NormalizedToken: "alice", ContactID: cTitled},
+	}
+	state, kind, id, desired := decideLinkage(events.MeetingNoteRecordedPayload{}, sessionID, nil, resolved, titleMatched)
+	require.Equal(t, repository.LinkageStateOrphanTitleAugmented, state)
+	require.Nil(t, kind)
+	require.Nil(t, id)
+	require.Len(t, desired, 2)
+	taggedRef := "anarlog:" + sessionID.String() + ":" + cTagged.String()
+	titleRef := "anarlog:" + sessionID.String() + ":title:" + cTitled.String()
+	gotRefs := []string{desired[0].SourceRef, desired[1].SourceRef}
+	require.Contains(t, gotRefs, taggedRef)
+	require.Contains(t, gotRefs, titleRef)
 }
 
 // TestDecideLinkage_OneCandidate_WalkinPresent_NoSupplement verifies
@@ -1120,7 +1193,7 @@ func TestDecideLinkage_OneCandidate_WalkinPresent_NoSupplement(t *testing.T) {
 		AttendeeContactIDs: []uuid.UUID{cA},
 	}
 	resolved := []resolvedTag{{AnarlogID: "human-a", ContactID: cA}}
-	state, kind, id, desired := decideLinkage(events.MeetingNoteRecordedPayload{}, sessionID, []repository.LinkageCandidate{cand}, resolved)
+	state, kind, id, desired := decideLinkage(events.MeetingNoteRecordedPayload{}, sessionID, []repository.LinkageCandidate{cand}, resolved, nil)
 	require.Equal(t, repository.LinkageStateLinked, state)
 	require.NotNil(t, kind)
 	require.Equal(t, "event", *kind)
@@ -1141,13 +1214,33 @@ func TestDecideLinkage_OneCandidate_TaggedNotInAttendees_AddsWalkin(t *testing.T
 		AttendeeContactIDs: []uuid.UUID{cA},
 	}
 	resolved := []resolvedTag{{AnarlogID: "human-b", ContactID: cB}}
-	state, kind, _, desired := decideLinkage(events.MeetingNoteRecordedPayload{}, sessionID, []repository.LinkageCandidate{cand}, resolved)
+	state, kind, _, desired := decideLinkage(events.MeetingNoteRecordedPayload{}, sessionID, []repository.LinkageCandidate{cand}, resolved, nil)
 	require.Equal(t, repository.LinkageStateLinked, state)
 	require.Equal(t, "event", *kind)
 	require.Len(t, desired, 1)
 	expectedRef := "anarlog:" + sessionID.String() + ":walkin:" + cB.String()
 	require.Equal(t, expectedRef, desired[0].SourceRef)
 	require.Equal(t, cB, desired[0].ContactID)
+}
+
+// TestDecideLinkage_OneCandidate_TitleMatchesDoNotProduceInteractions
+// verifies the spec invariant that title matches don't create
+// interactions in the linked state.
+func TestDecideLinkage_OneCandidate_TitleMatchesDoNotProduceInteractions(t *testing.T) {
+	sessionID := uuid.New()
+	cAttendee := uuid.New()
+	cTitled := uuid.New()
+	cand := repository.LinkageCandidate{
+		Kind:               "event",
+		ID:                 uuid.New(),
+		AttendeeContactIDs: []uuid.UUID{cAttendee},
+	}
+	titleMatched := []resolvedTitle{
+		{Token: "Alice", NormalizedToken: "alice", ContactID: cTitled},
+	}
+	state, _, _, desired := decideLinkage(events.MeetingNoteRecordedPayload{}, sessionID, []repository.LinkageCandidate{cand}, nil, titleMatched)
+	require.Equal(t, repository.LinkageStateLinked, state)
+	require.Empty(t, desired, "title matches must not produce interactions in linked state")
 }
 
 // TestDecideLinkage_MultipleCandidates_ConflictPending verifies the
@@ -1159,9 +1252,26 @@ func TestDecideLinkage_MultipleCandidates_ConflictPending(t *testing.T) {
 		{Kind: "event", ID: uuid.New()},
 		{Kind: "event", ID: uuid.New()},
 	}
-	state, kind, id, desired := decideLinkage(events.MeetingNoteRecordedPayload{}, sessionID, cands, nil)
+	state, kind, id, desired := decideLinkage(events.MeetingNoteRecordedPayload{}, sessionID, cands, nil, nil)
 	require.Equal(t, repository.LinkageStateConflictPending, state)
 	require.Nil(t, kind)
 	require.Nil(t, id)
+	require.Empty(t, desired)
+}
+
+// TestDecideLinkage_MultipleCandidates_TitleMatchesDoNotInteract
+// confirms title matches don't leak into conflict_pending state either.
+func TestDecideLinkage_MultipleCandidates_TitleMatchesDoNotInteract(t *testing.T) {
+	sessionID := uuid.New()
+	cands := []repository.LinkageCandidate{
+		{Kind: "event", ID: uuid.New()},
+		{Kind: "event", ID: uuid.New()},
+	}
+	titled := uuid.New()
+	titleMatched := []resolvedTitle{
+		{Token: "Alice", NormalizedToken: "alice", ContactID: titled},
+	}
+	state, _, _, desired := decideLinkage(events.MeetingNoteRecordedPayload{}, sessionID, cands, nil, titleMatched)
+	require.Equal(t, repository.LinkageStateConflictPending, state)
 	require.Empty(t, desired)
 }

--- a/backend/tests/api/external_contact_ingest_test.go
+++ b/backend/tests/api/external_contact_ingest_test.go
@@ -101,6 +101,8 @@ func setupExtContactIngestEnv(t *testing.T) *extContactIngestEnv {
 		nil,      // contactRecorder unused
 		nil,      // cadence unused
 		nil,      // followUp unused
+		nil,      // titleMatcher unused
+		nil,      // discovery unused
 	)
 	ingestHandler := handlers.NewIngestHandler(ingestService)
 

--- a/backend/tests/api/external_contact_savepoint_rollback_test.go
+++ b/backend/tests/api/external_contact_savepoint_rollback_test.go
@@ -100,7 +100,7 @@ func TestIngestExternalContact_SavepointRollback_OnMatchFailure(t *testing.T) {
 	// match-flip path errors after Bus.PublishTx + UpsertTx +
 	// MatchOrCreateTx have already written rows inside the savepoint.
 	failingWriter := &failingMatchExternalContactWriter{inner: externalRepo}
-	ingestService := service.NewIngestService(database, eventBus, identityService, nil, nil, failingWriter, hostRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	ingestService := service.NewIngestService(database, eventBus, identityService, nil, nil, failingWriter, hostRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	ingestHandler := handlers.NewIngestHandler(ingestService)
 
 	gin.SetMode(gin.TestMode)

--- a/backend/tests/api/ingest_host_liveness_test.go
+++ b/backend/tests/api/ingest_host_liveness_test.go
@@ -81,6 +81,8 @@ func TestIngest_HostRevokedMidTx_AbortsBatch(t *testing.T) {
 		nil, // contactRecorder unused
 		nil, // cadence unused
 		nil, // followUp unused
+		nil, // titleMatcher unused
+		nil, // discovery unused
 	)
 
 	// Build a structurally-valid envelope so the batch precondition
@@ -150,7 +152,7 @@ func TestIngest_HostLivenessNil_SkipsCheck(t *testing.T) {
 	eventBus := events.NewBus(database.Pool, nil, eventRepo)
 
 	// nil hostLiveness — recheck is skipped.
-	svc := service.NewIngestService(database, eventBus, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	svc := service.NewIngestService(database, eventBus, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	// An empty batch passes the precondition layer immediately and
 	// never opens a tx. The test confirms wiring without the recheck
@@ -257,7 +259,7 @@ func TestIngest_ConcurrentRevokeBlocksUntilBatchCommit(t *testing.T) {
 
 	eventRepo := repository.NewEventRepository(database.Queries)
 	eventBus := events.NewBus(database.Pool, nil, eventRepo)
-	svc := service.NewIngestService(database, eventBus, identityService, nil, nil, blocker, hostRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	svc := service.NewIngestService(database, eventBus, identityService, nil, nil, blocker, hostRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	entityID := "concurrent-revoke-" + uuid.NewString()[:8]
 	payload, err := events.Marshal(events.KindExternalContactUpserted, events.ExternalContactUpsertedPayload{

--- a/backend/tests/api/ingest_raw_message_e2e_test.go
+++ b/backend/tests/api/ingest_raw_message_e2e_test.go
@@ -144,7 +144,7 @@ func TestIngestRawMessage_E2E_StagesAggregatesAndCreatesInteraction(t *testing.T
 	recorderShim.real = consumer.NewInteractionRecorderWorker(bus, database.Pool, recorder, nil)
 
 	// Now wire the ingest service + handler.
-	ingestService := service.NewIngestService(database, bus, identityService, messagesRepo, riverClient, nil, hostRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	ingestService := service.NewIngestService(database, bus, identityService, messagesRepo, riverClient, nil, hostRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	ingestHandler := handlers.NewIngestHandler(ingestService)
 
 	gin.SetMode(gin.TestMode)

--- a/backend/tests/api/ingest_raw_message_test.go
+++ b/backend/tests/api/ingest_raw_message_test.go
@@ -130,6 +130,8 @@ func setupRawIngestEnv(t *testing.T) *ingestRawTestEnv {
 		nil, // contactRecorder unused
 		nil, // cadence unused
 		nil, // followUp unused
+		nil, // titleMatcher unused
+		nil, // discovery unused
 	)
 	ingestHandler := handlers.NewIngestHandler(ingestService)
 

--- a/backend/tests/api/ingest_test.go
+++ b/backend/tests/api/ingest_test.go
@@ -123,7 +123,7 @@ func setupIngestTestRouter(t *testing.T, enableIngest bool) *ingestTestSetup {
 	// safe — raw_message envelopes are rejected at the handler with
 	// PAYLOAD_INVALID before reaching the inline handler. nil
 	// hostLiveness skips the FOR UPDATE re-check (test path).
-	ingestService := service.NewIngestService(database, eventBus, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	ingestService := service.NewIngestService(database, eventBus, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	ingestHandler := handlers.NewIngestHandler(ingestService)
 
 	gin.SetMode(gin.TestMode)
@@ -699,7 +699,7 @@ func TestIngest_MidTxRollback_RollsBack_And_Returns500(t *testing.T) {
 	// so the rest of the suite isn't affected.
 	fake := &failingRepo{inner: setup.eventRepo, failOn: 3}
 	bus := setup.busFactory(fake)
-	ingestService := service.NewIngestService(setup.database, bus, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	ingestService := service.NewIngestService(setup.database, bus, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	handler := handlers.NewIngestHandler(ingestService)
 
 	cfg := config.TestConfig()

--- a/backend/tests/api/meeting_note_ingest_test.go
+++ b/backend/tests/api/meeting_note_ingest_test.go
@@ -1193,7 +1193,7 @@ func TestMeetingNote_ConcurrentFirstInsertConverges(t *testing.T) {
 }
 
 // ----------------------------------------------------------------------------
-// PR 4 — title-extraction + discovery integration tests.
+// Title-extraction + discovery integration tests.
 //
 // These tests use Q-prefixed synthetic alphabetic tokens to avoid trigram
 // cross-pollination on the shared test DB (per CLAUDE.md gotcha
@@ -1336,8 +1336,8 @@ func TestMeetingNote_TitleMatch_OrphanWithTagsAndTitleMatch(t *testing.T) {
 // ----------------------------------------------------------------------------
 // TC-T2 — orphan_with_tags_and_title_no_match: tagged Alice + title
 // "Alice / Carol" where Carol is NOT a CRM contact. State stays
-// linked_impromptu (PR 3 behavior); 1 interaction (Alice tagged); 1
-// anarlog_title row for "carol".
+// linked_impromptu (tagged-anchor without title-matched contacts);
+// 1 interaction (Alice tagged); 1 anarlog_title row for "carol".
 // ----------------------------------------------------------------------------
 func TestMeetingNote_TitleMatch_OrphanWithTagsAndTitleNoMatch(t *testing.T) {
 	env := setupMeetingNoteIngestEnv(t)
@@ -1861,7 +1861,7 @@ func TestMeetingNote_TitleMatch_SourceIDDeterministic(t *testing.T) {
 
 // ----------------------------------------------------------------------------
 // TC-T15 — metadata_shape: every anarlog_title row has the four
-// metadata keys PR 7's UI depends on.
+// metadata keys the downstream UI depends on.
 // ----------------------------------------------------------------------------
 func TestMeetingNote_TitleMatch_MetadataShape(t *testing.T) {
 	env := setupMeetingNoteIngestEnv(t)
@@ -1886,11 +1886,12 @@ func TestMeetingNote_TitleMatch_MetadataShape(t *testing.T) {
 }
 
 // ----------------------------------------------------------------------------
-// TC-T16 — regression_pr3_interactions_unchanged: a session with no
-// title content behaves exactly as PR 3 (one tagged interaction,
-// linked_impromptu, no anarlog_title rows).
+// TC-T16 — regression_unchanged_for_empty_title: a session with no
+// extractable tokens in the title behaves identically to the pre-
+// title-parsing path (one tagged interaction, linked_impromptu, no
+// anarlog_title rows).
 // ----------------------------------------------------------------------------
-func TestMeetingNote_TitleMatch_RegressionPR3UnchangedForEmptyTitle(t *testing.T) {
+func TestMeetingNote_TitleMatch_RegressionUnchangedForEmptyTitle(t *testing.T) {
 	env := setupMeetingNoteIngestEnv(t)
 	suffix := strings.TrimSuffix(strings.TrimPrefix(env.sourceIDPrefix, "mn-ingest-"), "-")
 	emailA := fmt.Sprintf("mn-test-0-%s@example.invalid", suffix)
@@ -1985,18 +1986,46 @@ func TestMeetingNote_TitleMatch_CountQueryExcludesAnarlogTitle(t *testing.T) {
 	require.Equal(t, int64(0), srcCount,
 		"CountUnmatched(anarlog_title) MUST be 0 — filter excludes all rows")
 
-	// CountAllUnmatched MUST NOT count this specific row. We verify by
-	// asserting the DisplayName-prefix count for our token is 0 in the
-	// list/count paths (the row exists in raw `external_contact` but is
-	// filtered out by the imports queries).
+	// Sanity: the raw row exists in external_contact (so the test
+	// isn't trivially passing on an empty DB).
 	titlePrefixCount := countAnarlogTitleRowsForToken(t, env, tokenJ)
 	require.Equal(t, int64(1), titlePrefixCount,
 		"the raw row exists in external_contact (sanity check)")
-	// And the imports-facing list/count for this source is empty:
+
+	// Per-source list MUST be empty (filter excludes all anarlog_title rows).
 	imports, err := env.externalRepo.ListUnmatched(ctx, "anarlog_title", 100, 0)
 	require.NoError(t, err)
 	require.Empty(t, imports,
 		"ListUnmatched(anarlog_title) MUST be empty — filter excludes all rows")
+
+	// CountAllUnmatched + ListAllUnmatched MUST also exclude the row.
+	// We assert by iterating the full unmatched-across-sources list and
+	// checking the deterministic source_id we just wrote is absent.
+	// This is an invariant check (no before/after delta on the count
+	// itself, which would be flaky on a shared DB), so it survives
+	// concurrent activity in other tests.
+	sid, err := uuid.Parse(sessionUUID)
+	require.NoError(t, err)
+	wroteSourceID := computeTestAnarlogTitleSourceID(strings.ToLower(tokenJ), sid)
+	allImports, err := env.externalRepo.ListAllUnmatched(ctx, 1000, 0)
+	require.NoError(t, err)
+	for _, row := range allImports {
+		require.NotEqual(t, "anarlog_title", row.Source,
+			"ListAllUnmatched MUST NOT include any anarlog_title rows: %+v", row)
+		require.NotEqual(t, wroteSourceID, row.SourceID,
+			"ListAllUnmatched MUST NOT include our specific anarlog_title row")
+	}
+	// CountAllUnmatched is harder to invariant-assert on a shared DB,
+	// but we can pin the relationship list+count parity by re-checking
+	// the count delta a delta-free way: after our write, CountAll is
+	// either unchanged or smaller-equal-than the prior list-length;
+	// either way, the all-imports list cannot contain our row, which
+	// is the only assertion that matters for the filter contract.
+	allCount, err := env.externalRepo.CountAllUnmatched(ctx)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, allCount, int64(0))
+	require.LessOrEqual(t, allCount, int64(len(allImports))+50,
+		"CountAllUnmatched must agree with ListAllUnmatched within shared-DB drift bounds")
 }
 
 // ----------------------------------------------------------------------------
@@ -2173,11 +2202,11 @@ func TestMeetingNote_TitleMatch_PreviouslyAmbiguousNowDisambiguated(t *testing.T
 // TC-T24 — legacy_session_backfills_discovery_on_carry_forward.
 // Simulates a pre-title-parsing ingest where a meeting_note row exists for a
 // title with unmatched tokens but NO companion anarlog_title rows
-// (because PR3 didn't write them). Re-ingesting the IDENTICAL payload
-// hits the bus-dedup path; the meeting_note inline-on-duplicate probe
-// re-enters the handler; hashes are unchanged so carry-forward fires;
-// Block B MUST still run unconditionally and backfill the discovery
-// row. Regression for the Block-B-runs-unconditionally invariant —
+// (because the prior code didn't write them). Re-ingesting the IDENTICAL
+// payload hits the bus-dedup path; the meeting_note inline-on-duplicate
+// probe re-enters the handler; hashes are unchanged so carry-forward
+// fires; Block B MUST still run unconditionally and backfill the
+// discovery row. Regression for the Block-B-runs-unconditionally invariant —
 // gating Block B on !carryForward would break this case.
 // ----------------------------------------------------------------------------
 func TestMeetingNote_TitleMatch_LegacySessionBackfillsDiscoveryOnCarryForward(t *testing.T) {

--- a/backend/tests/api/meeting_note_ingest_test.go
+++ b/backend/tests/api/meeting_note_ingest_test.go
@@ -1687,8 +1687,8 @@ func TestMeetingNote_TitleMatch_ResyncTitleChangeKeepsOldDiscoveryRows(t *testin
 // TC-T11 — carry_forward_skips_discovery_writes_only. Re-ingest of
 // identical payload hits carry-forward (no NEW anarlog_title rows
 // inserted because source_id is deterministic). updated_at MAY be
-// bumped on existing rows (Block B runs unconditionally per the
-// round-6 P1 fix); interaction-diff is skipped.
+// bumped on existing rows (Block B runs unconditionally so legacy
+// sessions backfill); interaction-diff is skipped.
 // ----------------------------------------------------------------------------
 func TestMeetingNote_TitleMatch_CarryForwardKeepsRows(t *testing.T) {
 	env := setupMeetingNoteIngestEnv(t)
@@ -1964,12 +1964,6 @@ func TestMeetingNote_TitleMatch_CountQueryExcludesAnarlogTitle(t *testing.T) {
 	env := setupMeetingNoteIngestEnv(t)
 	ctx := context.Background()
 
-	// Baseline counts.
-	allBefore, err := env.externalRepo.CountAllUnmatched(ctx)
-	require.NoError(t, err)
-	srcBefore, err := env.externalRepo.CountUnmatched(ctx, "anarlog_title")
-	require.NoError(t, err)
-
 	tokenJ := newTitleToken(t, env)
 	sessionUUID := env.newSessionUUID()
 	meetingAt := time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC)
@@ -1977,19 +1971,32 @@ func TestMeetingNote_TitleMatch_CountQueryExcludesAnarlogTitle(t *testing.T) {
 	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
 	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
 	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+	// Sanity: the row was actually persisted (so the test isn't trivially
+	// passing on an empty DB).
 	require.NotNil(t, getAnarlogTitleRow(t, env, strings.ToLower(tokenJ), sessionUUID))
 
-	// Counts must NOT have grown for the anarlog_title source-filtered
-	// query (the filter excludes the row) NOR for the all-sources
-	// count.
-	srcAfter, err := env.externalRepo.CountUnmatched(ctx, "anarlog_title")
+	// CountUnmatched("anarlog_title") MUST return 0 — the SQL filter
+	// (AND source != 'anarlog_title') zeroes out every row at the DB
+	// level regardless of what other tests in the shared DB are doing.
+	// This is a true invariant assertion, not a before/after delta, so
+	// it's resistant to parallel test pollution.
+	srcCount, err := env.externalRepo.CountUnmatched(ctx, "anarlog_title")
 	require.NoError(t, err)
-	require.Equal(t, srcBefore, srcAfter,
-		"CountUnmatched(anarlog_title) must not include anarlog_title rows")
-	allAfter, err := env.externalRepo.CountAllUnmatched(ctx)
+	require.Equal(t, int64(0), srcCount,
+		"CountUnmatched(anarlog_title) MUST be 0 — filter excludes all rows")
+
+	// CountAllUnmatched MUST NOT count this specific row. We verify by
+	// asserting the DisplayName-prefix count for our token is 0 in the
+	// list/count paths (the row exists in raw `external_contact` but is
+	// filtered out by the imports queries).
+	titlePrefixCount := countAnarlogTitleRowsForToken(t, env, tokenJ)
+	require.Equal(t, int64(1), titlePrefixCount,
+		"the raw row exists in external_contact (sanity check)")
+	// And the imports-facing list/count for this source is empty:
+	imports, err := env.externalRepo.ListUnmatched(ctx, "anarlog_title", 100, 0)
 	require.NoError(t, err)
-	require.Equal(t, allBefore, allAfter,
-		"CountAllUnmatched must not include anarlog_title rows")
+	require.Empty(t, imports,
+		"ListUnmatched(anarlog_title) MUST be empty — filter excludes all rows")
 }
 
 // ----------------------------------------------------------------------------
@@ -2163,38 +2170,54 @@ func TestMeetingNote_TitleMatch_PreviouslyAmbiguousNowDisambiguated(t *testing.T
 }
 
 // ----------------------------------------------------------------------------
-// TC-T24 — legacy_pr3_session_backfills_discovery_on_first_resync.
-// Manually seed a meeting_note row representing a PR-3-era state
-// (no anarlog_title rows for its title tokens), then re-ingest the
-// same payload. Verify the discovery rows ARE NOW written, proving
-// Block B's unconditional execution backfills legacy sessions.
+// TC-T24 — legacy_session_backfills_discovery_on_carry_forward.
+// Simulates a pre-title-parsing ingest where a meeting_note row exists for a
+// title with unmatched tokens but NO companion anarlog_title rows
+// (because PR3 didn't write them). Re-ingesting the IDENTICAL payload
+// hits the bus-dedup path; the meeting_note inline-on-duplicate probe
+// re-enters the handler; hashes are unchanged so carry-forward fires;
+// Block B MUST still run unconditionally and backfill the discovery
+// row. Regression for the Block-B-runs-unconditionally invariant —
+// gating Block B on !carryForward would break this case.
 // ----------------------------------------------------------------------------
-func TestMeetingNote_TitleMatch_LegacySessionBackfillsDiscoveryOnFirstResync(t *testing.T) {
+func TestMeetingNote_TitleMatch_LegacySessionBackfillsDiscoveryOnCarryForward(t *testing.T) {
 	env := setupMeetingNoteIngestEnv(t)
 	tokenK := newTitleToken(t, env)
 
-	// Seed a "legacy" meeting_note row via the ingest path (an empty
-	// title that the extractor can't tokenize) so the row exists with
-	// no anarlog_title companions. Then re-ingest with the unmatched
-	// token in the title.
 	sessionUUID := env.newSessionUUID()
 	meetingAt := time.Date(2026, 5, 12, 14, 0, 0, 0, time.UTC)
-	evEmpty := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "intro", nil)
-	w := postMNIngest(t, env, map[string]any{"events": []any{evEmpty}})
+	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, tokenK, nil)
+	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
 	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
 	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
-	// No anarlog_title row for tokenK yet (extractor produced none).
+	firstRow := getAnarlogTitleRow(t, env, strings.ToLower(tokenK), sessionUUID)
+	require.NotNil(t, firstRow, "first ingest creates the discovery row")
+	firstRowID := firstRow.ID
+
+	// Simulate the pre-title-parsing state by hard-deleting the discovery row.
+	// The meeting_note row's input_hash + resolved_set_hash are
+	// unchanged from the original ingest.
+	ctx := context.Background()
+	rowsDeleted, err := env.database.Queries.DeleteExternalContactsByDisplayNamePrefix(ctx, pgtype.Text{String: tokenK, Valid: true})
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, rowsDeleted, int64(1), "delete the pre-existing discovery row")
 	require.Nil(t, getAnarlogTitleRow(t, env, strings.ToLower(tokenK), sessionUUID),
-		"no discovery row yet — title 'intro' tokenizes to nothing")
+		"discovery row truly gone before the carry-forward re-ingest")
 
-	// Now re-ingest WITH the unmatched token in the title. input_hash
-	// changes, the handler runs Block A + Block B and the discovery row
-	// lands.
-	evWithToken := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, tokenK, nil)
-	w = postMNIngest(t, env, map[string]any{"events": []any{evWithToken}})
+	// Re-ingest IDENTICAL payload. Bus-dedup hits; the meeting_note
+	// shouldRunInlineOnDuplicate probe runs the handler again; carry-
+	// forward fires (input_hash + resolved_set_hash both match prior).
+	// Block B is gated on UNCONDITIONAL execution per the
+	// regression-target invariant, so the discovery row must reappear.
+	w = postMNIngest(t, env, map[string]any{"events": []any{ev}})
 	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
-	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+	resp := parseMNIngestResp(t, w)
+	require.Equal(t, 1, resp.Duplicate, "envelope dedups, but the handler still runs on the carry-forward path")
+	require.Empty(t, resp.Errors)
 
-	row := getAnarlogTitleRow(t, env, strings.ToLower(tokenK), sessionUUID)
-	require.NotNil(t, row, "legacy session backfills discovery row on first re-ingest with a tokenizable title")
+	backfilled := getAnarlogTitleRow(t, env, strings.ToLower(tokenK), sessionUUID)
+	require.NotNil(t, backfilled,
+		"Block B must run on the carry-forward path so legacy sessions backfill discovery rows")
+	require.NotEqual(t, firstRowID, backfilled.ID,
+		"this is a NEW row (hard-deleted prior) — proves Block B re-emitted via UPSERT")
 }

--- a/backend/tests/api/meeting_note_ingest_test.go
+++ b/backend/tests/api/meeting_note_ingest_test.go
@@ -3,6 +3,9 @@ package api
 import (
 	"bytes"
 	"context"
+	cryptorand "crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -26,6 +29,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
 )
 
@@ -65,6 +69,17 @@ type meetingNoteIngestEnv struct {
 	// prefix-cleanup; track them explicitly instead.
 	seededAnarlogIDs   []string
 	seededAnarlogIDsMu sync.Mutex
+	// titleTokenPrefixes tracks Q-prefixed synthetic name tokens
+	// allocated by tests via newTitleToken. Each prefix is the full
+	// 7-char token (e.g., "Qzpqxr"); cleanup uses these to scope
+	// contact + display_name deletes precisely to the test's own
+	// fixtures even when the shared DB has rows from other tests.
+	titleTokenPrefixes   []string
+	titleTokenPrefixesMu sync.Mutex
+	// seededTitleContactIDs tracks contact_ids seeded specifically for
+	// title-matching tests so they can be hard-deleted in cleanup.
+	seededTitleContactIDs   []uuid.UUID
+	seededTitleContactIDsMu sync.Mutex
 }
 
 // trackSession records the session UUID for targeted cleanup.
@@ -185,6 +200,7 @@ func setupMeetingNoteIngestEnv(t *testing.T) *meetingNoteIngestEnv {
 	importHandler := handlers.NewImportHandler(externalRepo, identityService, contactSvc, matchService, enrichmentSvc)
 	imports := router.Group("/api/v1/imports")
 	imports.POST("/candidates/:id/link", importHandler.LinkContact)
+	imports.GET("/candidates", importHandler.ListImportCandidates)
 
 	plain, _, err := macService.CreatePairingToken(ctx)
 	require.NoError(t, err)
@@ -257,10 +273,27 @@ func setupMeetingNoteIngestEnv(t *testing.T) *meetingNoteIngestEnv {
 		_, _ = database.Queries.DeleteExternalIdentitiesBySource(cleanCtx, "anarlog_humans")
 		_, _ = database.Queries.DeleteEventsBySource(cleanCtx, "anarlog_sessions")
 		_, _ = database.Queries.DeleteEventsBySource(cleanCtx, "anarlog_humans")
+		// Drop anarlog_title rows seeded by title-matching tests.
+		// display_name = TitleCase(token) so the Q-prefix scopes
+		// precisely to this test's own fixtures.
+		env.titleTokenPrefixesMu.Lock()
+		titlePrefixes := append([]string(nil), env.titleTokenPrefixes...)
+		env.titleTokenPrefixesMu.Unlock()
+		for _, prefix := range titlePrefixes {
+			_, _ = database.Queries.DeleteExternalContactsByDisplayNamePrefix(cleanCtx, pgtype.Text{String: prefix, Valid: true})
+		}
 		// Drop synthetic calendar events seeded by these tests.
 		_ = database.Queries.TestDeleteCalendarEventsByGcalEventIDPrefix(cleanCtx, env.sourceIDPrefix+"cal-")
 		// Drop seeded contacts + their methods.
 		for _, id := range []uuid.UUID{env.contactA, env.contactB, env.contactC} {
+			_ = contactMethodRepo.DeleteContactMethodsByContact(cleanCtx, id)
+			_ = contactRepo.HardDeleteContact(cleanCtx, id)
+		}
+		// Drop title-matching contacts seeded with Q-prefix names.
+		env.seededTitleContactIDsMu.Lock()
+		titleContactIDs := append([]uuid.UUID(nil), env.seededTitleContactIDs...)
+		env.seededTitleContactIDsMu.Unlock()
+		for _, id := range titleContactIDs {
 			_ = contactMethodRepo.DeleteContactMethodsByContact(cleanCtx, id)
 			_ = contactRepo.HardDeleteContact(cleanCtx, id)
 		}
@@ -1157,4 +1190,1011 @@ func TestMeetingNote_ConcurrentFirstInsertConverges(t *testing.T) {
 	// re-read+update path). Both are acceptable — we just assert no
 	// duplicates and no rejection.
 	require.Contains(t, []string{"Concurrent A", "Concurrent B"}, *row.Title)
+}
+
+// ----------------------------------------------------------------------------
+// PR 4 — title-extraction + discovery integration tests.
+//
+// These tests use Q-prefixed synthetic alphabetic tokens to avoid trigram
+// cross-pollination on the shared test DB (per CLAUDE.md gotcha
+// "Integration sub-test reuses identifying names across t.Run blocks").
+// Each newTitleToken call yields a unique 7-char alphabetic string that
+// passes the extractor's keep regex (^[A-Z][a-zA-Z]{1,29}$) and is rare
+// enough that no real contact name in the test DB would collide. The
+// 6-letter random suffix has 26^6 ≈ 309M entropy, eliminating
+// within-suite collisions.
+// ----------------------------------------------------------------------------
+
+// newTitleToken returns a unique 7-char Q-prefixed alphabetic string
+// suitable for use as a synthetic name token in title-extraction tests.
+// The token is registered in env.titleTokenPrefixes so t.Cleanup can
+// scope display_name + contact deletes precisely to the test's own
+// fixtures.
+func newTitleToken(t *testing.T, env *meetingNoteIngestEnv) string {
+	t.Helper()
+	var buf [6]byte
+	if _, err := cryptorand.Read(buf[:]); err != nil {
+		t.Fatalf("newTitleToken: rand.Read: %v", err)
+	}
+	const letters = "abcdefghijklmnopqrstuvwxyz"
+	out := []byte{'Q'}
+	for _, x := range buf {
+		out = append(out, letters[int(x)%26])
+	}
+	token := string(out)
+	env.titleTokenPrefixesMu.Lock()
+	env.titleTokenPrefixes = append(env.titleTokenPrefixes, token)
+	env.titleTokenPrefixesMu.Unlock()
+	return token
+}
+
+// seedTitleContact creates a CRM contact with full_name = name and
+// registers it for cleanup. Returns the contact UUID.
+func seedTitleContact(t *testing.T, env *meetingNoteIngestEnv, name string) uuid.UUID {
+	t.Helper()
+	ctx := context.Background()
+	c, err := env.contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: name})
+	require.NoError(t, err)
+	env.seededTitleContactIDsMu.Lock()
+	env.seededTitleContactIDs = append(env.seededTitleContactIDs, c.ID)
+	env.seededTitleContactIDsMu.Unlock()
+	return c.ID
+}
+
+// computeTestAnarlogTitleSourceID mirrors the discovery writer's
+// source_id recipe so tests can look up the deterministic row that the
+// writer produced for a (token, session) pair. Defined separately here
+// so the test asserts the contract independent of the implementation.
+func computeTestAnarlogTitleSourceID(normalizedToken string, sessionUUID uuid.UUID) string {
+	var buf bytes.Buffer
+	buf.WriteString(normalizedToken)
+	buf.WriteString(sessionUUID.String())
+	sum := sha256.Sum256(buf.Bytes())
+	return hex.EncodeToString(sum[:])
+}
+
+// getAnarlogTitleRow fetches the unique anarlog_title row for the
+// (normalizedToken, sessionUUID) pair. Returns nil when no row exists.
+func getAnarlogTitleRow(t *testing.T, env *meetingNoteIngestEnv, normalizedToken, sessionUUID string) *repository.ExternalContact {
+	t.Helper()
+	sid, err := uuid.Parse(sessionUUID)
+	require.NoError(t, err)
+	sourceID := computeTestAnarlogTitleSourceID(normalizedToken, sid)
+	row, gerr := env.externalRepo.GetBySource(context.Background(), "anarlog_title", sourceID, nil)
+	if gerr != nil {
+		return nil
+	}
+	return row
+}
+
+// countAnarlogTitleRowsForToken returns the number of anarlog_title
+// rows (live, by display_name prefix) for the given token. Used to
+// verify the deterministic source_id keeps re-emit idempotent —
+// re-emitting the same (token, session) should NOT create new rows.
+func countAnarlogTitleRowsForToken(t *testing.T, env *meetingNoteIngestEnv, tokenDisplay string) int64 {
+	t.Helper()
+	ctx := context.Background()
+	n, err := env.database.Queries.CountExternalContactsByDisplayNamePrefix(ctx, pgtype.Text{String: tokenDisplay, Valid: true})
+	require.NoError(t, err)
+	return n
+}
+
+// ----------------------------------------------------------------------------
+// TC-T1 — orphan_with_tags_and_title_match: tagged Alice + title
+// "Alice / Bob" where Bob is a CRM contact. State =
+// orphan_title_augmented; 2 interactions (Alice tagged-anchor, Bob
+// title); NO anarlog_title rows (both tokens matched contacts).
+// ----------------------------------------------------------------------------
+func TestMeetingNote_TitleMatch_OrphanWithTagsAndTitleMatch(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	suffix := strings.TrimSuffix(strings.TrimPrefix(env.sourceIDPrefix, "mn-ingest-"), "-")
+	emailA := fmt.Sprintf("mn-test-0-%s@example.invalid", suffix)
+	anarlogA := env.seedAnarlogHumanResolvingTo(t, emailA)
+
+	// contactA (tagged via anarlogA) — already in env.contactA via
+	// email match. Rename it to a Q-token so the extractor + matcher
+	// can pick "QtokenA" up unambiguously.
+	tokenA := newTitleToken(t, env)
+	tokenB := newTitleToken(t, env)
+	ctx := context.Background()
+	_, err := env.contactRepo.UpdateContact(ctx, env.contactA, repository.UpdateContactRequest{FullName: tokenA + " Smith"})
+	require.NoError(t, err)
+	contactB := seedTitleContact(t, env, tokenB+" Jones")
+
+	sessionUUID := env.newSessionUUID()
+	meetingAt := time.Date(2026, 5, 7, 14, 0, 0, 0, time.UTC)
+	title := tokenA + " / " + tokenB + " 1:1"
+	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, title, []string{anarlogA})
+	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseMNIngestResp(t, w)
+	require.Equal(t, 1, resp.Accepted)
+	require.Empty(t, resp.Errors, "no per-event rejections")
+
+	row := findMeetingNoteRow(t, env, sessionUUID)
+	require.NotNil(t, row)
+	require.Equal(t, repository.LinkageStateOrphanTitleAugmented, row.LinkageState)
+
+	ixs := listSessionInteractions(t, env, sessionUUID)
+	require.Len(t, ixs, 2)
+	gotRefs := make([]string, 0, 2)
+	for _, ix := range ixs {
+		require.NotNil(t, ix.SourceRef)
+		gotRefs = append(gotRefs, *ix.SourceRef)
+	}
+	require.Contains(t, gotRefs, "anarlog:"+sessionUUID+":"+env.contactA.String(),
+		"tagged anchor interaction for contactA")
+	require.Contains(t, gotRefs, "anarlog:"+sessionUUID+":title:"+contactB.String(),
+		"title-derived interaction for contactB")
+
+	// Neither token should produce a discovery row (both matched a CRM
+	// contact, so they're not weak candidates).
+	require.Nil(t, getAnarlogTitleRow(t, env, strings.ToLower(tokenA), sessionUUID))
+	require.Nil(t, getAnarlogTitleRow(t, env, strings.ToLower(tokenB), sessionUUID))
+}
+
+// ----------------------------------------------------------------------------
+// TC-T2 — orphan_with_tags_and_title_no_match: tagged Alice + title
+// "Alice / Carol" where Carol is NOT a CRM contact. State stays
+// linked_impromptu (PR 3 behavior); 1 interaction (Alice tagged); 1
+// anarlog_title row for "carol".
+// ----------------------------------------------------------------------------
+func TestMeetingNote_TitleMatch_OrphanWithTagsAndTitleNoMatch(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	suffix := strings.TrimSuffix(strings.TrimPrefix(env.sourceIDPrefix, "mn-ingest-"), "-")
+	emailA := fmt.Sprintf("mn-test-0-%s@example.invalid", suffix)
+	anarlogA := env.seedAnarlogHumanResolvingTo(t, emailA)
+
+	tokenA := newTitleToken(t, env) // matches contactA after rename
+	tokenC := newTitleToken(t, env) // no CRM contact
+	ctx := context.Background()
+	_, err := env.contactRepo.UpdateContact(ctx, env.contactA, repository.UpdateContactRequest{FullName: tokenA + " Smith"})
+	require.NoError(t, err)
+
+	sessionUUID := env.newSessionUUID()
+	meetingAt := time.Date(2026, 5, 7, 15, 0, 0, 0, time.UTC)
+	title := tokenA + " / " + tokenC
+	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, title, []string{anarlogA})
+	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+
+	row := findMeetingNoteRow(t, env, sessionUUID)
+	require.NotNil(t, row)
+	// tokenA matched contactA but is already tagged → titleMatched empty
+	// → state stays linked_impromptu.
+	require.Equal(t, repository.LinkageStateLinkedImpromptu, row.LinkageState)
+	require.Len(t, listSessionInteractions(t, env, sessionUUID), 1)
+
+	// tokenC has no contact match → anarlog_title row.
+	tcRow := getAnarlogTitleRow(t, env, strings.ToLower(tokenC), sessionUUID)
+	require.NotNil(t, tcRow, "anarlog_title row exists for unmatched token")
+	require.Equal(t, "anarlog_title", tcRow.Source)
+	require.NotNil(t, tcRow.DisplayName)
+	require.Equal(t, tokenC, *tcRow.DisplayName, "display_name is title-cased token")
+}
+
+// ----------------------------------------------------------------------------
+// TC-T3 — orphan_no_tags_with_title_matches: 0 tagged + title with
+// CRM-matching tokens → state stays orphan_needs_review, NO interactions
+// (spec invariant: title matches need a tagged anchor to produce
+// interactions). NO anarlog_title rows (tokens matched).
+// ----------------------------------------------------------------------------
+func TestMeetingNote_TitleMatch_OrphanNoTagsWithTitleMatches(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	tokenA := newTitleToken(t, env)
+	tokenB := newTitleToken(t, env)
+	contactA := seedTitleContact(t, env, tokenA+" Smith")
+	contactB := seedTitleContact(t, env, tokenB+" Jones")
+	_ = contactA
+	_ = contactB
+
+	sessionUUID := env.newSessionUUID()
+	meetingAt := time.Date(2026, 5, 7, 16, 0, 0, 0, time.UTC)
+	title := tokenA + " / " + tokenB
+	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, title, nil)
+	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseMNIngestResp(t, w)
+	require.Equal(t, 1, resp.Accepted)
+
+	row := findMeetingNoteRow(t, env, sessionUUID)
+	require.NotNil(t, row)
+	require.Equal(t, repository.LinkageStateOrphanNeedsReview, row.LinkageState)
+	require.Empty(t, listSessionInteractions(t, env, sessionUUID),
+		"no anchor → no interactions even with title matches")
+	require.Nil(t, getAnarlogTitleRow(t, env, strings.ToLower(tokenA), sessionUUID))
+	require.Nil(t, getAnarlogTitleRow(t, env, strings.ToLower(tokenB), sessionUUID))
+}
+
+// ----------------------------------------------------------------------------
+// TC-T4 — orphan_no_tags_with_title_unmatched: 0 tagged + title with
+// no CRM-matching tokens → state orphan_needs_review, NO interactions,
+// anarlog_title rows for BOTH unmatched tokens.
+// ----------------------------------------------------------------------------
+func TestMeetingNote_TitleMatch_OrphanNoTagsWithTitleUnmatched(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	tokenC := newTitleToken(t, env)
+	tokenD := newTitleToken(t, env)
+
+	sessionUUID := env.newSessionUUID()
+	meetingAt := time.Date(2026, 5, 7, 17, 0, 0, 0, time.UTC)
+	title := tokenC + " / " + tokenD
+	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, title, nil)
+	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+
+	row := findMeetingNoteRow(t, env, sessionUUID)
+	require.NotNil(t, row)
+	require.Equal(t, repository.LinkageStateOrphanNeedsReview, row.LinkageState)
+	require.Empty(t, listSessionInteractions(t, env, sessionUUID))
+
+	cRow := getAnarlogTitleRow(t, env, strings.ToLower(tokenC), sessionUUID)
+	require.NotNil(t, cRow)
+	dRow := getAnarlogTitleRow(t, env, strings.ToLower(tokenD), sessionUUID)
+	require.NotNil(t, dRow)
+}
+
+// ----------------------------------------------------------------------------
+// TC-T5 — linked_with_title_match: 1 calendar candidate + title with
+// a CRM-matching token. State stays linked. NO new interactions
+// (linked state's walk-in logic only fires for tagged humans, not
+// title matches). NO anarlog_title rows for matched tokens.
+// ----------------------------------------------------------------------------
+func TestMeetingNote_TitleMatch_LinkedWithTitleMatch(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	tokenA := newTitleToken(t, env)
+	tokenB := newTitleToken(t, env)
+	ctx := context.Background()
+	_, err := env.contactRepo.UpdateContact(ctx, env.contactA, repository.UpdateContactRequest{FullName: tokenA + " Smith"})
+	require.NoError(t, err)
+	_ = seedTitleContact(t, env, tokenB+" Jones")
+
+	meetingAt := time.Date(2026, 5, 8, 10, 0, 0, 0, time.UTC)
+	eventID := env.seedCalendarEventInWindow(t, meetingAt, []uuid.UUID{env.contactA})
+
+	sessionUUID := env.newSessionUUID()
+	title := tokenA + " / " + tokenB + " 1:1"
+	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, title, nil)
+	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+
+	row := findMeetingNoteRow(t, env, sessionUUID)
+	require.NotNil(t, row)
+	require.Equal(t, repository.LinkageStateLinked, row.LinkageState)
+	require.NotNil(t, row.LinkedID)
+	require.Equal(t, eventID, *row.LinkedID)
+	require.Empty(t, listSessionInteractions(t, env, sessionUUID),
+		"title matches in linked state must not produce interactions")
+	require.Nil(t, getAnarlogTitleRow(t, env, strings.ToLower(tokenA), sessionUUID))
+	require.Nil(t, getAnarlogTitleRow(t, env, strings.ToLower(tokenB), sessionUUID))
+}
+
+// ----------------------------------------------------------------------------
+// TC-T6 — linked_with_title_unmatched: linked state + title with
+// unmatched token. NO new interactions. 1 anarlog_title row for the
+// unmatched token.
+// ----------------------------------------------------------------------------
+func TestMeetingNote_TitleMatch_LinkedWithTitleUnmatched(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	tokenA := newTitleToken(t, env)
+	tokenE := newTitleToken(t, env)
+	ctx := context.Background()
+	_, err := env.contactRepo.UpdateContact(ctx, env.contactA, repository.UpdateContactRequest{FullName: tokenA + " Smith"})
+	require.NoError(t, err)
+
+	meetingAt := time.Date(2026, 5, 8, 11, 0, 0, 0, time.UTC)
+	env.seedCalendarEventInWindow(t, meetingAt, []uuid.UUID{env.contactA})
+
+	sessionUUID := env.newSessionUUID()
+	title := tokenA + " / " + tokenE
+	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, title, nil)
+	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+
+	row := findMeetingNoteRow(t, env, sessionUUID)
+	require.Equal(t, repository.LinkageStateLinked, row.LinkageState)
+	require.Empty(t, listSessionInteractions(t, env, sessionUUID))
+	eRow := getAnarlogTitleRow(t, env, strings.ToLower(tokenE), sessionUUID)
+	require.NotNil(t, eRow, "unmatched token in linked state still gets a discovery row")
+}
+
+// ----------------------------------------------------------------------------
+// TC-T7 — conflict_pending_with_title_matches: 2 candidates + title
+// with CRM-matching tokens. NO interactions, NO anarlog_title rows for
+// matched tokens.
+// ----------------------------------------------------------------------------
+func TestMeetingNote_TitleMatch_ConflictPendingWithTitleMatches(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	tokenA := newTitleToken(t, env)
+	tokenB := newTitleToken(t, env)
+	ctx := context.Background()
+	_, err := env.contactRepo.UpdateContact(ctx, env.contactA, repository.UpdateContactRequest{FullName: tokenA + " Smith"})
+	require.NoError(t, err)
+	_ = seedTitleContact(t, env, tokenB+" Jones")
+
+	meetingAt := time.Date(2026, 5, 9, 9, 0, 0, 0, time.UTC)
+	env.seedCalendarEventInWindow(t, meetingAt, []uuid.UUID{env.contactA})
+	env.seedCalendarEventInWindow(t, meetingAt.Add(5*time.Minute), []uuid.UUID{env.contactB})
+
+	sessionUUID := env.newSessionUUID()
+	title := tokenA + " / " + tokenB
+	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, title, nil)
+	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+
+	row := findMeetingNoteRow(t, env, sessionUUID)
+	require.Equal(t, repository.LinkageStateConflictPending, row.LinkageState)
+	require.Empty(t, listSessionInteractions(t, env, sessionUUID))
+	require.Nil(t, getAnarlogTitleRow(t, env, strings.ToLower(tokenA), sessionUUID))
+	require.Nil(t, getAnarlogTitleRow(t, env, strings.ToLower(tokenB), sessionUUID))
+}
+
+// ----------------------------------------------------------------------------
+// TC-T7b — conflict_pending_with_title_unmatched: 2 candidates + title
+// with unmatched tokens. NO interactions, 2 anarlog_title rows.
+// Confirms unmatched-token discovery fires in conflict_pending state.
+// ----------------------------------------------------------------------------
+func TestMeetingNote_TitleMatch_ConflictPendingWithTitleUnmatched(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	tokenC := newTitleToken(t, env)
+	tokenD := newTitleToken(t, env)
+
+	meetingAt := time.Date(2026, 5, 9, 10, 0, 0, 0, time.UTC)
+	env.seedCalendarEventInWindow(t, meetingAt, []uuid.UUID{env.contactA})
+	env.seedCalendarEventInWindow(t, meetingAt.Add(5*time.Minute), []uuid.UUID{env.contactB})
+
+	sessionUUID := env.newSessionUUID()
+	title := tokenC + " / " + tokenD
+	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, title, nil)
+	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+
+	row := findMeetingNoteRow(t, env, sessionUUID)
+	require.Equal(t, repository.LinkageStateConflictPending, row.LinkageState)
+	require.Empty(t, listSessionInteractions(t, env, sessionUUID))
+	require.NotNil(t, getAnarlogTitleRow(t, env, strings.ToLower(tokenC), sessionUUID))
+	require.NotNil(t, getAnarlogTitleRow(t, env, strings.ToLower(tokenD), sessionUUID))
+}
+
+// ----------------------------------------------------------------------------
+// TC-T8 — title_dedup_against_tagged: Alice is tagged AND title is
+// "Alice". Title-matched contact is deduplicated against tagged so
+// only the tagged-anchor interaction lands (no `:title:` interaction
+// for the same contact).
+// ----------------------------------------------------------------------------
+func TestMeetingNote_TitleMatch_DedupAgainstTagged(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	suffix := strings.TrimSuffix(strings.TrimPrefix(env.sourceIDPrefix, "mn-ingest-"), "-")
+	emailA := fmt.Sprintf("mn-test-0-%s@example.invalid", suffix)
+	anarlogA := env.seedAnarlogHumanResolvingTo(t, emailA)
+
+	tokenA := newTitleToken(t, env)
+	ctx := context.Background()
+	_, err := env.contactRepo.UpdateContact(ctx, env.contactA, repository.UpdateContactRequest{FullName: tokenA + " Smith"})
+	require.NoError(t, err)
+
+	sessionUUID := env.newSessionUUID()
+	meetingAt := time.Date(2026, 5, 9, 11, 0, 0, 0, time.UTC)
+	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, tokenA, []string{anarlogA})
+	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+
+	row := findMeetingNoteRow(t, env, sessionUUID)
+	require.Equal(t, repository.LinkageStateLinkedImpromptu, row.LinkageState,
+		"dedup empties titleMatched → state is linked_impromptu, not orphan_title_augmented")
+	ixs := listSessionInteractions(t, env, sessionUUID)
+	require.Len(t, ixs, 1)
+	require.NotNil(t, ixs[0].SourceRef)
+	require.Equal(t, "anarlog:"+sessionUUID+":"+env.contactA.String(), *ixs[0].SourceRef,
+		"tagged-anchor source_ref wins over title-derived")
+}
+
+// ----------------------------------------------------------------------------
+// TC-T9 — resync_title_change_drops_old_interaction. Initial title
+// "Alice / Bob" + tagged Carol → 3 interactions (Carol tagged, Alice
+// title, Bob title). Re-ingest with title "Alice" + tagged Carol
+// (Bob removed): Bob's title interaction soft-deleted; Carol+Alice
+// preserved.
+// ----------------------------------------------------------------------------
+func TestMeetingNote_TitleMatch_ResyncTitleChangeDropsOldInteraction(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	suffix := strings.TrimSuffix(strings.TrimPrefix(env.sourceIDPrefix, "mn-ingest-"), "-")
+	emailC := fmt.Sprintf("mn-test-2-%s@example.invalid", suffix)
+	anarlogC := env.seedAnarlogHumanResolvingTo(t, emailC)
+
+	tokenA := newTitleToken(t, env)
+	tokenB := newTitleToken(t, env)
+	contactA := seedTitleContact(t, env, tokenA+" Smith")
+	contactB := seedTitleContact(t, env, tokenB+" Jones")
+
+	sessionUUID := env.newSessionUUID()
+	meetingAt := time.Date(2026, 5, 10, 14, 0, 0, 0, time.UTC)
+	title1 := tokenA + " / " + tokenB
+	ev1 := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, title1, []string{anarlogC})
+	w := postMNIngest(t, env, map[string]any{"events": []any{ev1}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+	row := findMeetingNoteRow(t, env, sessionUUID)
+	require.Equal(t, repository.LinkageStateOrphanTitleAugmented, row.LinkageState)
+	require.Len(t, listSessionInteractions(t, env, sessionUUID), 3)
+
+	// Re-ingest with title containing only tokenA (Bob removed).
+	title2 := tokenA
+	ev2 := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, title2, []string{anarlogC})
+	w = postMNIngest(t, env, map[string]any{"events": []any{ev2}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+
+	after := listSessionInteractions(t, env, sessionUUID)
+	require.Len(t, after, 2, "Bob's title interaction soft-deleted; Carol+Alice preserved")
+	gotRefs := make([]string, 0, 2)
+	for _, ix := range after {
+		gotRefs = append(gotRefs, *ix.SourceRef)
+	}
+	require.Contains(t, gotRefs, "anarlog:"+sessionUUID+":"+env.contactC.String())
+	require.Contains(t, gotRefs, "anarlog:"+sessionUUID+":title:"+contactA.String())
+	require.NotContains(t, gotRefs, "anarlog:"+sessionUUID+":title:"+contactB.String())
+
+	row = findMeetingNoteRow(t, env, sessionUUID)
+	require.Equal(t, repository.LinkageStateOrphanTitleAugmented, row.LinkageState,
+		"still augmented because Alice still title-matches")
+}
+
+// ----------------------------------------------------------------------------
+// TC-T10 — resync_title_change_keeps_old_discovery_rows. Accept
+// leak-through per D6 — stale discovery rows from a renamed title
+// persist alongside new rows.
+// ----------------------------------------------------------------------------
+func TestMeetingNote_TitleMatch_ResyncTitleChangeKeepsOldDiscoveryRows(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	suffix := strings.TrimSuffix(strings.TrimPrefix(env.sourceIDPrefix, "mn-ingest-"), "-")
+	emailC := fmt.Sprintf("mn-test-2-%s@example.invalid", suffix)
+	anarlogC := env.seedAnarlogHumanResolvingTo(t, emailC)
+
+	tokenF := newTitleToken(t, env) // unmatched
+	tokenS := newTitleToken(t, env) // unmatched
+
+	sessionUUID := env.newSessionUUID()
+	meetingAt := time.Date(2026, 5, 10, 15, 0, 0, 0, time.UTC)
+	title1 := tokenF // a single unmatched token; extractor produces ["tokenF"]
+	ev1 := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, title1, []string{anarlogC})
+	w := postMNIngest(t, env, map[string]any{"events": []any{ev1}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+	require.NotNil(t, getAnarlogTitleRow(t, env, strings.ToLower(tokenF), sessionUUID))
+
+	// Re-ingest with title that has only tokenS (different token).
+	title2 := tokenS
+	ev2 := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, title2, []string{anarlogC})
+	w = postMNIngest(t, env, map[string]any{"events": []any{ev2}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+
+	// BOTH rows exist (stale tokenF + new tokenS).
+	require.NotNil(t, getAnarlogTitleRow(t, env, strings.ToLower(tokenF), sessionUUID),
+		"stale token row persists per accept-leak-through")
+	require.NotNil(t, getAnarlogTitleRow(t, env, strings.ToLower(tokenS), sessionUUID))
+}
+
+// ----------------------------------------------------------------------------
+// TC-T11 — carry_forward_skips_discovery_writes_only. Re-ingest of
+// identical payload hits carry-forward (no NEW anarlog_title rows
+// inserted because source_id is deterministic). updated_at MAY be
+// bumped on existing rows (Block B runs unconditionally per the
+// round-6 P1 fix); interaction-diff is skipped.
+// ----------------------------------------------------------------------------
+func TestMeetingNote_TitleMatch_CarryForwardKeepsRows(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	tokenF := newTitleToken(t, env)
+
+	sessionUUID := env.newSessionUUID()
+	meetingAt := time.Date(2026, 5, 10, 16, 0, 0, 0, time.UTC)
+	title := tokenF
+	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, title, nil)
+	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+	first := getAnarlogTitleRow(t, env, strings.ToLower(tokenF), sessionUUID)
+	require.NotNil(t, first)
+	firstID := first.ID
+
+	// Re-send identical payload — bus-dedup skips the inline handler.
+	w = postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseMNIngestResp(t, w)
+	require.Equal(t, 1, resp.Duplicate)
+
+	// Exactly ONE row for the (token, session) pair — deterministic
+	// source_id makes re-emit an idempotent UPDATE.
+	again := getAnarlogTitleRow(t, env, strings.ToLower(tokenF), sessionUUID)
+	require.NotNil(t, again)
+	require.Equal(t, firstID, again.ID, "same row, not a new one")
+}
+
+// ----------------------------------------------------------------------------
+// TC-T12 — revive_with_title_re_extracts. Record session with title
+// containing tokenA + tagged Carol → orphan_title_augmented. Delete
+// the session. Revive with a new title containing tokenB + tagged
+// Carol → new orphan_title_augmented state, tokenB's title interaction
+// created, tokenA's interaction stays soft-deleted.
+// ----------------------------------------------------------------------------
+func TestMeetingNote_TitleMatch_ReviveReExtracts(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	suffix := strings.TrimSuffix(strings.TrimPrefix(env.sourceIDPrefix, "mn-ingest-"), "-")
+	emailC := fmt.Sprintf("mn-test-2-%s@example.invalid", suffix)
+	anarlogC := env.seedAnarlogHumanResolvingTo(t, emailC)
+
+	tokenA := newTitleToken(t, env)
+	tokenB := newTitleToken(t, env)
+	contactA := seedTitleContact(t, env, tokenA+" Smith")
+	contactB := seedTitleContact(t, env, tokenB+" Jones")
+
+	sessionUUID := env.newSessionUUID()
+	meetingAt := time.Date(2026, 5, 11, 14, 0, 0, 0, time.UTC)
+	ev1 := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, tokenA, []string{anarlogC})
+	w := postMNIngest(t, env, map[string]any{"events": []any{ev1}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+	require.Len(t, listSessionInteractions(t, env, sessionUUID), 2,
+		"Carol tagged + Alice title")
+
+	// Delete.
+	row := findMeetingNoteRow(t, env, sessionUUID)
+	require.NotNil(t, row.LastContentHash)
+	del := buildMNDeletedEvent(t, env.pairedHostID, sessionUUID, *row.LastContentHash)
+	w = postMNIngest(t, env, map[string]any{"events": []any{del}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+	require.Empty(t, listSessionInteractions(t, env, sessionUUID))
+
+	// Revive with new title.
+	ev2 := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, tokenB, []string{anarlogC})
+	w = postMNIngest(t, env, map[string]any{"events": []any{ev2}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+
+	row = findMeetingNoteRow(t, env, sessionUUID)
+	require.Equal(t, repository.LinkageStateOrphanTitleAugmented, row.LinkageState)
+	after := listSessionInteractions(t, env, sessionUUID)
+	require.Len(t, after, 2, "Carol tagged + tokenB title")
+	gotRefs := make([]string, 0, 2)
+	for _, ix := range after {
+		gotRefs = append(gotRefs, *ix.SourceRef)
+	}
+	require.Contains(t, gotRefs, "anarlog:"+sessionUUID+":"+env.contactC.String())
+	require.Contains(t, gotRefs, "anarlog:"+sessionUUID+":title:"+contactB.String())
+	require.NotContains(t, gotRefs, "anarlog:"+sessionUUID+":title:"+contactA.String(),
+		"prior tokenA title interaction stays soft-deleted")
+}
+
+// ----------------------------------------------------------------------------
+// TC-T13 — host_ownership_skip_skips_title_work. A second mac host
+// pushes a meeting_note.recorded for a session already owned by host
+// A. The host-ownership guard returns silent no-op BEFORE title work
+// runs, so NO anarlog_title rows are inserted.
+// ----------------------------------------------------------------------------
+func TestMeetingNote_TitleMatch_HostOwnershipSkipsTitleWork(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	suffix := strings.TrimSuffix(strings.TrimPrefix(env.sourceIDPrefix, "mn-ingest-"), "-")
+	emailA := fmt.Sprintf("mn-test-0-%s@example.invalid", suffix)
+	anarlogA := env.seedAnarlogHumanResolvingTo(t, emailA)
+
+	tokenF := newTitleToken(t, env)
+
+	// Host A creates the session WITHOUT the unmatched token in title.
+	sessionUUID := env.newSessionUUID()
+	meetingAt := time.Date(2026, 5, 11, 15, 0, 0, 0, time.UTC)
+	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Initial", []string{anarlogA})
+	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+
+	// Host B pairs and pushes the SAME session UUID with a title that
+	// contains an unmatched token. The host-ownership guard must
+	// silently drop the event before any title work runs. The
+	// mac_host singleton index requires revoking host A first.
+	ctx := context.Background()
+	require.NoError(t, env.macService.RevokeHost(ctx, env.pairedHostID))
+	plain, _, err := env.macService.CreatePairingToken(ctx)
+	require.NoError(t, err)
+	pairB, err := env.macService.PairWithToken(ctx, plain, "host-b", "0.1.0", 1)
+	require.NoError(t, err)
+
+	titleWithUnmatched := tokenF + " review"
+	evB := buildMNRecordedEvent(t, pairB.HostID, sessionUUID, meetingAt, titleWithUnmatched, []string{anarlogA})
+	b, err := json.Marshal(map[string]any{"events": []any{evB}})
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/ingest/events", bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Mac-Host-ID", pairB.HostID.String())
+	req.Header.Set("Authorization", "Bearer "+pairB.APIKey)
+	rec := httptest.NewRecorder()
+	env.router.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+
+	// NO anarlog_title row for tokenF — title block didn't run.
+	require.Nil(t, getAnarlogTitleRow(t, env, strings.ToLower(tokenF), sessionUUID),
+		"host-ownership guard skipped title work")
+}
+
+// ----------------------------------------------------------------------------
+// TC-T14 — source_id_deterministic. Two separate batches emit the
+// same (token, session) → single anarlog_title row.
+// ----------------------------------------------------------------------------
+func TestMeetingNote_TitleMatch_SourceIDDeterministic(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	tokenG := newTitleToken(t, env)
+
+	sessionUUID := env.newSessionUUID()
+	meetingAt := time.Date(2026, 5, 11, 16, 0, 0, 0, time.UTC)
+	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, tokenG, nil)
+	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+	first := getAnarlogTitleRow(t, env, strings.ToLower(tokenG), sessionUUID)
+	require.NotNil(t, first)
+
+	// Re-emit same payload (a 2nd batch — bus dedups envelope, but we
+	// can also force a second inline run via revive).
+	row := findMeetingNoteRow(t, env, sessionUUID)
+	require.NotNil(t, row.LastContentHash)
+	del := buildMNDeletedEvent(t, env.pairedHostID, sessionUUID, *row.LastContentHash)
+	w = postMNIngest(t, env, map[string]any{"events": []any{del}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	w = postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	// Still only ONE row.
+	require.Equal(t, int64(1), countAnarlogTitleRowsForToken(t, env, tokenG),
+		"deterministic source_id keeps re-emit idempotent")
+	again := getAnarlogTitleRow(t, env, strings.ToLower(tokenG), sessionUUID)
+	require.NotNil(t, again)
+	require.Equal(t, first.ID, again.ID)
+}
+
+// ----------------------------------------------------------------------------
+// TC-T15 — metadata_shape: every anarlog_title row has the four
+// metadata keys PR 7's UI depends on.
+// ----------------------------------------------------------------------------
+func TestMeetingNote_TitleMatch_MetadataShape(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	tokenH := newTitleToken(t, env)
+
+	sessionUUID := env.newSessionUUID()
+	meetingAt := time.Date(2026, 5, 11, 17, 0, 0, 0, time.UTC)
+	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, tokenH, nil)
+	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+
+	row := getAnarlogTitleRow(t, env, strings.ToLower(tokenH), sessionUUID)
+	require.NotNil(t, row)
+	for _, key := range []string{"session_uuid", "token_normalized", "token_display", "extracted_at"} {
+		_, ok := row.Metadata[key]
+		require.True(t, ok, "metadata missing %q: %+v", key, row.Metadata)
+	}
+	require.Equal(t, sessionUUID, row.Metadata["session_uuid"])
+	require.Equal(t, strings.ToLower(tokenH), row.Metadata["token_normalized"])
+	require.Equal(t, tokenH, row.Metadata["token_display"])
+}
+
+// ----------------------------------------------------------------------------
+// TC-T16 — regression_pr3_interactions_unchanged: a session with no
+// title content behaves exactly as PR 3 (one tagged interaction,
+// linked_impromptu, no anarlog_title rows).
+// ----------------------------------------------------------------------------
+func TestMeetingNote_TitleMatch_RegressionPR3UnchangedForEmptyTitle(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	suffix := strings.TrimSuffix(strings.TrimPrefix(env.sourceIDPrefix, "mn-ingest-"), "-")
+	emailA := fmt.Sprintf("mn-test-0-%s@example.invalid", suffix)
+	anarlogA := env.seedAnarlogHumanResolvingTo(t, emailA)
+
+	sessionUUID := env.newSessionUUID()
+	meetingAt := time.Date(2026, 5, 11, 18, 0, 0, 0, time.UTC)
+	// Title is non-empty but has no extractable tokens (lowercased, no
+	// real names) — the extractor returns []string{}.
+	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "intro sync", []string{anarlogA})
+	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+
+	row := findMeetingNoteRow(t, env, sessionUUID)
+	require.Equal(t, repository.LinkageStateLinkedImpromptu, row.LinkageState)
+	require.Len(t, listSessionInteractions(t, env, sessionUUID), 1)
+}
+
+// ----------------------------------------------------------------------------
+// TC-T17 — regression_external_contact_ingest: an icloud_contacts
+// external_contact.upserted envelope still ingests cleanly.
+// ----------------------------------------------------------------------------
+func TestMeetingNote_TitleMatch_RegressionExternalContactIngest(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	// seedAnarlogHumanResolvingTo exercises the external_contact path
+	// (anarlog_humans). If it succeeds, the constructor signature
+	// extension didn't break that path.
+	suffix := strings.TrimSuffix(strings.TrimPrefix(env.sourceIDPrefix, "mn-ingest-"), "-")
+	emailA := fmt.Sprintf("mn-test-0-%s@example.invalid", suffix)
+	id := env.seedAnarlogHumanResolvingTo(t, emailA)
+	require.NotEmpty(t, id)
+}
+
+// ----------------------------------------------------------------------------
+// TC-T18 — imports_ui_excludes_anarlog_title_rows. After seeding an
+// anarlog_title row via meeting_note.recorded, the GET
+// /imports/candidates response must NOT include it.
+// ----------------------------------------------------------------------------
+func TestMeetingNote_TitleMatch_ImportsUIExcludesAnarlogTitle(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	tokenI := newTitleToken(t, env)
+
+	sessionUUID := env.newSessionUUID()
+	meetingAt := time.Date(2026, 5, 12, 9, 0, 0, 0, time.UTC)
+	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, tokenI, nil)
+	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+	// Confirm the row IS in the DB (so the test isn't trivially passing).
+	require.NotNil(t, getAnarlogTitleRow(t, env, strings.ToLower(tokenI), sessionUUID))
+
+	// GET /api/v1/imports/candidates — the filter must hide it.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/imports/candidates", nil)
+	rec := httptest.NewRecorder()
+	env.router.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+	body := rec.Body.String()
+	require.NotContains(t, body, tokenI,
+		"anarlog_title row leaked into imports candidates response")
+	require.NotContains(t, body, "anarlog_title",
+		"anarlog_title source string leaked into imports candidates response")
+}
+
+// ----------------------------------------------------------------------------
+// TC-T19 — count_query_excludes_anarlog_title_rows. The CountUnmatched
+// and CountAllUnmatched repository methods must not include
+// anarlog_title rows.
+// ----------------------------------------------------------------------------
+func TestMeetingNote_TitleMatch_CountQueryExcludesAnarlogTitle(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	ctx := context.Background()
+
+	// Baseline counts.
+	allBefore, err := env.externalRepo.CountAllUnmatched(ctx)
+	require.NoError(t, err)
+	srcBefore, err := env.externalRepo.CountUnmatched(ctx, "anarlog_title")
+	require.NoError(t, err)
+
+	tokenJ := newTitleToken(t, env)
+	sessionUUID := env.newSessionUUID()
+	meetingAt := time.Date(2026, 5, 12, 10, 0, 0, 0, time.UTC)
+	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, tokenJ, nil)
+	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+	require.NotNil(t, getAnarlogTitleRow(t, env, strings.ToLower(tokenJ), sessionUUID))
+
+	// Counts must NOT have grown for the anarlog_title source-filtered
+	// query (the filter excludes the row) NOR for the all-sources
+	// count.
+	srcAfter, err := env.externalRepo.CountUnmatched(ctx, "anarlog_title")
+	require.NoError(t, err)
+	require.Equal(t, srcBefore, srcAfter,
+		"CountUnmatched(anarlog_title) must not include anarlog_title rows")
+	allAfter, err := env.externalRepo.CountAllUnmatched(ctx)
+	require.NoError(t, err)
+	require.Equal(t, allBefore, allAfter,
+		"CountAllUnmatched must not include anarlog_title rows")
+}
+
+// ----------------------------------------------------------------------------
+// TC-T20 — daemon_cannot_push_anarlog_title_source. An
+// external_contact.upserted envelope with source='anarlog_title' is
+// rejected with PAYLOAD_INVARIANT.
+// ----------------------------------------------------------------------------
+func TestMeetingNote_TitleMatch_DaemonCannotPushAnarlogTitleSource(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	entityID := uuid.NewString()
+	dn := "Title Source Spoof"
+	p := events.ExternalContactUpsertedPayload{
+		Version:     1,
+		HostID:      env.pairedHostID,
+		Source:      "anarlog_title",
+		EntityID:    entityID,
+		DisplayName: &dn,
+	}
+	pBytes, err := events.Marshal(events.KindExternalContactUpserted, p)
+	require.NoError(t, err)
+	srcID := computeUpsertSourceID(t, entityID, pBytes)
+	body := map[string]any{
+		"events": []any{
+			map[string]any{
+				"source":      "anarlog_title",
+				"source_id":   srcID,
+				"kind":        string(events.KindExternalContactUpserted),
+				"payload":     json.RawMessage(pBytes),
+				"observed_at": accelerated.GetCurrentTime(),
+			},
+		},
+	}
+	b, err := json.Marshal(body)
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/ingest/events", bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Mac-Host-ID", env.pairedHostID.String())
+	req.Header.Set("Authorization", "Bearer "+env.pairedHostKey)
+	rec := httptest.NewRecorder()
+	env.router.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, "body: %s", rec.Body.String())
+	resp := parseMNIngestResp(t, rec)
+	require.Equal(t, 0, resp.Accepted, "rejection counts as not-accepted")
+	require.GreaterOrEqual(t, resp.Rejected, 1)
+	require.NotEmpty(t, resp.Errors)
+	require.Equal(t, "PAYLOAD_INVARIANT", resp.Errors[0].Code)
+}
+
+// ----------------------------------------------------------------------------
+// TC-T21 — contact_rename_invalidates_carry_forward. Tagged Carol +
+// title-matched Alice → 2 interactions. Rename Alice's contact so the
+// title no longer matches → re-ingest forces re-link → Alice's title
+// interaction soft-deleted, Carol's tagged interaction preserved.
+// ----------------------------------------------------------------------------
+func TestMeetingNote_TitleMatch_ContactRenameInvalidatesCarryForward(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	suffix := strings.TrimSuffix(strings.TrimPrefix(env.sourceIDPrefix, "mn-ingest-"), "-")
+	emailC := fmt.Sprintf("mn-test-2-%s@example.invalid", suffix)
+	anarlogC := env.seedAnarlogHumanResolvingTo(t, emailC)
+
+	tokenA := newTitleToken(t, env)
+	contactA := seedTitleContact(t, env, tokenA+" Smith")
+
+	sessionUUID := env.newSessionUUID()
+	meetingAt := time.Date(2026, 5, 12, 11, 0, 0, 0, time.UTC)
+	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, tokenA, []string{anarlogC})
+	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+	require.Len(t, listSessionInteractions(t, env, sessionUUID), 2,
+		"Carol tagged + Alice title")
+
+	// Rename contact so the trigram no longer matches the title token.
+	// Use a totally unrelated synthetic prefix.
+	renameToken := newTitleToken(t, env)
+	ctx := context.Background()
+	_, err := env.contactRepo.UpdateContact(ctx, contactA, repository.UpdateContactRequest{FullName: renameToken + " Renamed"})
+	require.NoError(t, err)
+
+	// Re-ingest identical payload — input_hash unchanged but
+	// resolved_set_hash differs (title now matches nothing) → re-link.
+	w = postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseMNIngestResp(t, w)
+	require.Equal(t, 1, resp.Duplicate,
+		"envelope is bus-dedup'd but the shouldRunInlineOnDuplicate probe runs the handler again")
+
+	after := listSessionInteractions(t, env, sessionUUID)
+	require.Len(t, after, 1, "Alice title interaction soft-deleted; Carol preserved")
+	require.Equal(t, "anarlog:"+sessionUUID+":"+env.contactC.String(), *after[0].SourceRef)
+}
+
+// ----------------------------------------------------------------------------
+// TC-T22 — new_same_name_contact_invalidates_carry_forward. Tagged
+// Carol + uniquely-matched Alice → 2 interactions. Add a 2nd same-name
+// contact → collision-gap drops the title-match → re-ingest forces
+// re-link → Alice's title interaction soft-deleted.
+// ----------------------------------------------------------------------------
+func TestMeetingNote_TitleMatch_NewSameNameContactInvalidatesCarryForward(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	suffix := strings.TrimSuffix(strings.TrimPrefix(env.sourceIDPrefix, "mn-ingest-"), "-")
+	emailC := fmt.Sprintf("mn-test-2-%s@example.invalid", suffix)
+	anarlogC := env.seedAnarlogHumanResolvingTo(t, emailC)
+
+	tokenA := newTitleToken(t, env)
+	_ = seedTitleContact(t, env, tokenA+" Smith")
+
+	sessionUUID := env.newSessionUUID()
+	meetingAt := time.Date(2026, 5, 12, 12, 0, 0, 0, time.UTC)
+	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, tokenA, []string{anarlogC})
+	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+	require.Len(t, listSessionInteractions(t, env, sessionUUID), 2)
+
+	// Add a 2nd contact with the same first-name token → collision-gap
+	// drops the match.
+	_ = seedTitleContact(t, env, tokenA+" Cooper")
+
+	// Re-ingest.
+	w = postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	after := listSessionInteractions(t, env, sessionUUID)
+	require.Len(t, after, 1, "Alice title interaction soft-deleted; Carol preserved")
+	require.Equal(t, "anarlog:"+sessionUUID+":"+env.contactC.String(), *after[0].SourceRef)
+}
+
+// ----------------------------------------------------------------------------
+// TC-T23 — previously_ambiguous_now_disambiguated. Two Alices exist;
+// tagged Carol + ambiguous title → 1 interaction (Carol only).
+// Soft-delete one Alice → re-ingest → unique match → 2 interactions
+// (Carol + Alice title).
+// ----------------------------------------------------------------------------
+func TestMeetingNote_TitleMatch_PreviouslyAmbiguousNowDisambiguated(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	suffix := strings.TrimSuffix(strings.TrimPrefix(env.sourceIDPrefix, "mn-ingest-"), "-")
+	emailC := fmt.Sprintf("mn-test-2-%s@example.invalid", suffix)
+	anarlogC := env.seedAnarlogHumanResolvingTo(t, emailC)
+
+	tokenA := newTitleToken(t, env)
+	contactA1 := seedTitleContact(t, env, tokenA+" Smith")
+	contactA2 := seedTitleContact(t, env, tokenA+" Cooper")
+	_ = contactA1
+
+	sessionUUID := env.newSessionUUID()
+	meetingAt := time.Date(2026, 5, 12, 13, 0, 0, 0, time.UTC)
+	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, tokenA, []string{anarlogC})
+	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+	require.Len(t, listSessionInteractions(t, env, sessionUUID), 1,
+		"ambiguous title → only Carol-tagged")
+
+	// Soft-delete contactA2 → match becomes unique.
+	ctx := context.Background()
+	require.NoError(t, env.contactRepo.SoftDeleteContact(ctx, contactA2))
+
+	// Re-ingest.
+	w = postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	after := listSessionInteractions(t, env, sessionUUID)
+	require.Len(t, after, 2, "Carol tagged + Alice title (now unique)")
+	gotRefs := make([]string, 0, 2)
+	for _, ix := range after {
+		gotRefs = append(gotRefs, *ix.SourceRef)
+	}
+	require.Contains(t, gotRefs, "anarlog:"+sessionUUID+":"+env.contactC.String())
+	require.Contains(t, gotRefs, "anarlog:"+sessionUUID+":title:"+contactA1.String())
+}
+
+// ----------------------------------------------------------------------------
+// TC-T24 — legacy_pr3_session_backfills_discovery_on_first_resync.
+// Manually seed a meeting_note row representing a PR-3-era state
+// (no anarlog_title rows for its title tokens), then re-ingest the
+// same payload. Verify the discovery rows ARE NOW written, proving
+// Block B's unconditional execution backfills legacy sessions.
+// ----------------------------------------------------------------------------
+func TestMeetingNote_TitleMatch_LegacySessionBackfillsDiscoveryOnFirstResync(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	tokenK := newTitleToken(t, env)
+
+	// Seed a "legacy" meeting_note row via the ingest path (an empty
+	// title that the extractor can't tokenize) so the row exists with
+	// no anarlog_title companions. Then re-ingest with the unmatched
+	// token in the title.
+	sessionUUID := env.newSessionUUID()
+	meetingAt := time.Date(2026, 5, 12, 14, 0, 0, 0, time.UTC)
+	evEmpty := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "intro", nil)
+	w := postMNIngest(t, env, map[string]any{"events": []any{evEmpty}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+	// No anarlog_title row for tokenK yet (extractor produced none).
+	require.Nil(t, getAnarlogTitleRow(t, env, strings.ToLower(tokenK), sessionUUID),
+		"no discovery row yet — title 'intro' tokenizes to nothing")
+
+	// Now re-ingest WITH the unmatched token in the title. input_hash
+	// changes, the handler runs Block A + Block B and the discovery row
+	// lands.
+	evWithToken := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, tokenK, nil)
+	w = postMNIngest(t, env, map[string]any{"events": []any{evWithToken}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted)
+
+	row := getAnarlogTitleRow(t, env, strings.ToLower(tokenK), sessionUUID)
+	require.NotNil(t, row, "legacy session backfills discovery row on first re-ingest with a tokenizable title")
 }

--- a/backend/tests/api/meeting_note_ingest_test.go
+++ b/backend/tests/api/meeting_note_ingest_test.go
@@ -1976,11 +1976,10 @@ func TestMeetingNote_TitleMatch_CountQueryExcludesAnarlogTitle(t *testing.T) {
 	// passing on an empty DB).
 	require.NotNil(t, getAnarlogTitleRow(t, env, strings.ToLower(tokenJ), sessionUUID))
 
-	// CountUnmatched("anarlog_title") MUST return 0 — the SQL filter
-	// (AND source != 'anarlog_title') zeroes out every row at the DB
-	// level regardless of what other tests in the shared DB are doing.
-	// This is a true invariant assertion, not a before/after delta, so
-	// it's resistant to parallel test pollution.
+	// CountUnmatched("anarlog_title") MUST return 0 — the defense-in-
+	// depth `source != 'anarlog_title'` filter zeroes out every row
+	// regardless of what other tests in the shared DB are doing. True
+	// invariant assertion, resistant to parallel test pollution.
 	srcCount, err := env.externalRepo.CountUnmatched(ctx, "anarlog_title")
 	require.NoError(t, err)
 	require.Equal(t, int64(0), srcCount,
@@ -2001,9 +2000,6 @@ func TestMeetingNote_TitleMatch_CountQueryExcludesAnarlogTitle(t *testing.T) {
 	// CountAllUnmatched + ListAllUnmatched MUST also exclude the row.
 	// We assert by iterating the full unmatched-across-sources list and
 	// checking the deterministic source_id we just wrote is absent.
-	// This is an invariant check (no before/after delta on the count
-	// itself, which would be flaky on a shared DB), so it survives
-	// concurrent activity in other tests.
 	sid, err := uuid.Parse(sessionUUID)
 	require.NoError(t, err)
 	wroteSourceID := computeTestAnarlogTitleSourceID(strings.ToLower(tokenJ), sid)
@@ -2015,12 +2011,6 @@ func TestMeetingNote_TitleMatch_CountQueryExcludesAnarlogTitle(t *testing.T) {
 		require.NotEqual(t, wroteSourceID, row.SourceID,
 			"ListAllUnmatched MUST NOT include our specific anarlog_title row")
 	}
-	// CountAllUnmatched is harder to invariant-assert on a shared DB,
-	// but we can pin the relationship list+count parity by re-checking
-	// the count delta a delta-free way: after our write, CountAll is
-	// either unchanged or smaller-equal-than the prior list-length;
-	// either way, the all-imports list cannot contain our row, which
-	// is the only assertion that matters for the filter contract.
 	allCount, err := env.externalRepo.CountAllUnmatched(ctx)
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, allCount, int64(0))

--- a/backend/tests/api/meeting_note_ingest_test.go
+++ b/backend/tests/api/meeting_note_ingest_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/anarlog"
 	"personal-crm/backend/internal/api"
 	"personal-crm/backend/internal/api/handlers"
 	"personal-crm/backend/internal/auth"
@@ -127,6 +128,8 @@ func setupMeetingNoteIngestEnv(t *testing.T) *meetingNoteIngestEnv {
 	contactSvc := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, eventBus, service.NewRematchService())
 	contactSvc.SetCadenceUpdater(wireCadenceUpdaterForAPITest(t, database, contactSvc))
 
+	titleMatcher := anarlog.NewTitleMatcher(contactRepo)
+	titleDiscoveryWriter := anarlog.NewDiscoveryWriter(externalRepo)
 	ingestService := service.NewIngestService(
 		database,
 		eventBus,
@@ -144,6 +147,8 @@ func setupMeetingNoteIngestEnv(t *testing.T) *meetingNoteIngestEnv {
 		nil, // contactRecorder unused
 		nil, // cadence unused
 		nil, // followUp unused
+		titleMatcher,
+		titleDiscoveryWriter,
 	)
 	ingestHandler := handlers.NewIngestHandler(ingestService)
 

--- a/backend/tests/api/phone_call_ingest_integration_test.go
+++ b/backend/tests/api/phone_call_ingest_integration_test.go
@@ -226,6 +226,8 @@ func setupPhoneCallIngestEnv(t *testing.T) *phoneCallIngestEnv {
 		contactService,
 		cadenceUpdater,
 		followUpManager,
+		nil, // titleMatcher unused on phone_call path
+		nil, // discovery unused
 	)
 	ingestHandler := handlers.NewIngestHandler(ingestService)
 


### PR DESCRIPTION
## Summary

PR 4 of 6 implementing [\`.ai/spec/mac-daemon-phase-2-anarlog-matching.md\`](.ai/spec/mac-daemon-phase-2-anarlog-matching.md). Title parsing + discovery flow + orphan-with-tagged-humans title-derived interactions.

- **\`ExtractNameTokens\`** ([\`backend/internal/anarlog/title.go\`](backend/internal/anarlog/title.go)) — pure-Go heuristic that turns session titles into a list of capitalized name tokens. Strips weekday/month/meta-token boilerplate, splits on common separators, drops stopwords. Non-ASCII inputs (e.g. Turkish İ, "José") are silently dropped per spec philosophy.
- **\`MatchByFullName\`** wrapper around the existing fuzzy matcher, with the spec's collision-gap rule for high-confidence single-match.
- **\`DiscoveryWriter\`** path for \`external_contact source='anarlog_title'\`, \`source_id = sha256(normalized_token || session_uuid)\`. Block B is unconditional (every recorded session that runs extraction upserts discovery rows for unmatched tokens), addressing legacy-session backfill.
- **\`decideLinkage\` extension** in \`handleMeetingNoteRecorded\` adds the \`orphan_title_augmented\` branch (0 candidates + ≥1 tagged human + ≥1 title-matched contact → tagged-human interaction(s) PLUS title-derived interaction(s) with \`source_ref='anarlog:<sid>:title:<contact>'\`).
- **Spec-invariant guard**: title tokens NEVER produce interactions in isolation — only when there's an anchor tagged human (state \`linked_impromptu\` → \`orphan_title_augmented\`). Verified by integration tests for the 0-tagged / 1-cand / 2+-cand branches.
- **Carry-forward drift fix** in re-sync: \`resolved_set_hash\` now factors in title-matched contacts so re-sync re-runs linkage when the title-derived implied set changes.

## What does NOT ship in this PR (lands in PR 5)

- Step 3 participant-signal disambiguation USING title tokens (PR 5 wires this into the 2+candidate branch)
- Conflict-resolution endpoints (PR 5)

## Test plan

- [x] \`make test-unit\` passes (anarlog unit suite + regression cases for non-ASCII edge cases including Turkish İ + pure non-ASCII)
- [x] \`make test-integration\` passes (24 \`TestMeetingNote_TitleMatch_*\` integration tests covering all linkage states + carry-forward + discovery upsert + invariant guards)
- [x] \`make test-frontend\` + \`make test-e2e-diff\` pass via pre-push hook
- [x] Codex review converged at round 2 PASS (P0=0, P1=0)
- [x] /review-head PASS after two rounds of P2/P3 cleanups (Turkish-İ byte-offset fix, redundant SQL filter removal, doc-comment sync)
- [ ] Post-merge: real-data soak — title extraction quality on the operator's actual session corpus is the gold standard

## Plan

\`.ai/log/plan/mac-daemon-phase-2-pr4-title-parsing-and-discovery.md\` (gitignored — local-only). Part of issue #74.