### PR TITLE
fix(mac-daemon): version orphan/conflict notification ids (close TOCTOU race)

### DIFF
--- a/mac-daemon/Sources/CRMMacCore/DaemonState.swift
+++ b/mac-daemon/Sources/CRMMacCore/DaemonState.swift
@@ -99,15 +99,20 @@ public struct DaemonState: Codable, Equatable, Sendable {
 /// Tracks an orphan or conflict notification the daemon has surfaced
 /// (or attempted to surface) for a session that needs CRM attention.
 ///
-/// `deliveryState` is tri-state. `"queued"` means the OS accepted the
-/// `add(_:)` call. `"denied"` means user-notification authorization
+/// `deliveryState` is tri-state. `"queued"` means the OS accepted
+/// the `add(_:)` call AND the post-add confirmation persisted the
+/// transition. `"denied"` means user-notification authorization
 /// was denied at add time, so the notification never reached the
-/// user. `"failed"` means `add(_:)` threw a non-permission error.
-/// Both `"denied"` and `"failed"` entries are RE-ATTEMPTED on the
-/// next consume() / reconcile() call for the same (sessionUUID,
-/// reason) — this prevents the permanent missed-notification trap
-/// that would occur if we treated "in the pending list" as a hard
-/// de-dup signal.
+/// user. `"failed"` covers three sub-cases: (a) `add(_:)` threw a
+/// non-permission error, (b) the entry is mid-raise (the in-flight
+/// pre-add persist marks 'failed' to seed retry semantics if the
+/// process crashes before confirmation), (c) the post-add
+/// confirmation persist failed. In all three cases the same retry
+/// posture applies. Both `"denied"` and `"failed"` entries are
+/// RE-ATTEMPTED on the next consume() / reconcile() call for the
+/// same (sessionUUID, reason) — this prevents the permanent
+/// missed-notification trap that would occur if we treated "in
+/// the pending list" as a hard de-dup signal.
 ///
 /// `mutationSequence` is a monotonic ordering token assigned on
 /// every mutation. Replaces wall-clock comparison for the

--- a/mac-daemon/Sources/CRMMacCore/DaemonState.swift
+++ b/mac-daemon/Sources/CRMMacCore/DaemonState.swift
@@ -119,19 +119,32 @@ public struct PendingOrphanNotification: Codable, Equatable, Sendable {
     public let notifiedAt: Date
     public var deliveryState: String   // "queued" | "denied" | "failed"
     public var mutationSequence: UInt64
+    /// Sequence component baked into the OS notification's identifier
+    /// the last time `presenter.add(_:)` was called for this entry.
+    /// `nil` when no OS notification was ever queued for the entry
+    /// (e.g. denied authorization, persist-only states, legacy
+    /// entries from pre-versioned daemon builds). Distinct from
+    /// `mutationSequence` because state transitions (e.g. failed →
+    /// queued after add success) bump `mutationSequence` for the
+    /// race guard but must NOT change the OS-side identifier the
+    /// notification was minted with — otherwise stale-remove can't
+    /// target the original notification.
+    public var osIdentifierSequence: UInt64?
 
     public init(
         sessionUUID: String,
         reason: String,
         notifiedAt: Date,
         deliveryState: String,
-        mutationSequence: UInt64
+        mutationSequence: UInt64,
+        osIdentifierSequence: UInt64? = nil
     ) {
         self.sessionUUID = sessionUUID
         self.reason = reason
         self.notifiedAt = notifiedAt
         self.deliveryState = deliveryState
         self.mutationSequence = mutationSequence
+        self.osIdentifierSequence = osIdentifierSequence
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -140,6 +153,7 @@ public struct PendingOrphanNotification: Codable, Equatable, Sendable {
         case notifiedAt
         case deliveryState
         case mutationSequence
+        case osIdentifierSequence
     }
 
     public init(from decoder: Decoder) throws {
@@ -159,6 +173,13 @@ public struct PendingOrphanNotification: Codable, Equatable, Sendable {
         // safely remove them.
         self.mutationSequence = try c.decodeIfPresent(
             UInt64.self, forKey: .mutationSequence) ?? 0
+        // Older entries lack this field — decoded as nil. The
+        // startup legacy-notification sweep handles the resulting
+        // gap: any pre-versioned OS notification is removed from
+        // Notification Center and the matching persisted entry is
+        // downgraded so a re-raise mints a fresh versioned id.
+        self.osIdentifierSequence = try c.decodeIfPresent(
+            UInt64.self, forKey: .osIdentifierSequence)
     }
 }
 

--- a/mac-daemon/Sources/CRMMacCore/StateMutator.swift
+++ b/mac-daemon/Sources/CRMMacCore/StateMutator.swift
@@ -33,6 +33,21 @@ public actor StateMutator {
         try store.save(state)
     }
 
+    /// Variant of `mutate(_:)` that lets the closure surface a
+    /// derived value from inside the serialized read-modify-write —
+    /// useful when the caller needs to know, e.g., the sequence
+    /// number assigned during the mutation. The persisted state is
+    /// saved before the value is returned. The return value must be
+    /// Sendable so it can cross the actor boundary safely.
+    public func mutateReturning<T: Sendable>(
+        _ change: @Sendable (inout DaemonState) throws -> T
+    ) async throws -> T {
+        var state = try store.load()
+        let value = try change(&state)
+        try store.save(state)
+        return value
+    }
+
     /// Load the current state without modifying it. Convenience for
     /// callers that need a consistent read alongside a separate mutate.
     public func read() async throws -> DaemonState {

--- a/mac-daemon/Sources/CRMMacOrphanNotifications/LinkageStateMapping.swift
+++ b/mac-daemon/Sources/CRMMacOrphanNotifications/LinkageStateMapping.swift
@@ -39,11 +39,38 @@ public func mapLinkageStateToReason(_ linkageState: String) -> String? {
     }
 }
 
-/// Composes a stable per-(reason, sessionUUID) identifier for the
+/// Composes a per-(reason, sessionUUID, sequence) identifier for the
 /// OS notification. Distinct identifiers for orphan vs conflict on
-/// the same session prevent the OS from silently replacing one
-/// with the other — `UNUserNotificationCenter.add(_:)` REPLACES a
-/// request with an existing identifier.
-public func notificationIdentifier(reason: String, sessionUUID: String) -> String {
-    "\(reason):\(sessionUUID)"
+/// the same session prevent the OS from silently replacing one with
+/// the other — `UNUserNotificationCenter.add(_:)` REPLACES a request
+/// with an existing identifier.
+///
+/// The trailing sequence component is the entry's mutationSequence
+/// at the moment the OS request was issued. Including it eliminates
+/// a reconcile-vs-consume TOCTOU race: when the reconcile loop
+/// removes a stale notification, it removes the identifier for the
+/// sequence it observed in the snapshot — a freshly-raised
+/// notification at a higher sequence has a different identifier and
+/// is not collaterally stripped from Notification Center.
+public func notificationIdentifier(
+    reason: String,
+    sessionUUID: String,
+    sequence: UInt64
+) -> String {
+    "\(reason):\(sessionUUID):\(sequence)"
+}
+
+/// True iff the identifier was minted by an older daemon build that
+/// used the unversioned `<reason>:<uuid>` scheme. New identifiers
+/// have a trailing `:<sequence>` component, so a legacy id splits
+/// to exactly two `:`-separated fields and starts with a known
+/// reason prefix. UUIDs use hyphens, never colons, so this split is
+/// reliable. Used at daemon startup to sweep ghost notifications
+/// the new code can't track.
+public func isLegacyNotificationIdentifier(_ id: String) -> Bool {
+    let parts = id.split(separator: ":", omittingEmptySubsequences: false)
+    guard parts.count == 2 else { return false }
+    let prefix = String(parts[0])
+    return prefix == NotificationReason.orphan ||
+        prefix == NotificationReason.conflict
 }

--- a/mac-daemon/Sources/CRMMacOrphanNotifications/OrphanNotificationCenter.swift
+++ b/mac-daemon/Sources/CRMMacOrphanNotifications/OrphanNotificationCenter.swift
@@ -98,12 +98,16 @@ public actor OrphanNotificationCenter {
 
     /// Sweep Notification Center for ghost notifications minted by
     /// older daemon builds that used the unversioned
-    /// `<reason>:<uuid>` identifier scheme. Operators upgrading from
-    /// pre-versioned builds otherwise see notifications the new
-    /// code can't track (the new scheme is `<reason>:<uuid>:<seq>`,
-    /// so the legacy ids never match a remove call from this
-    /// version). Best-effort — wired into daemon startup once and
-    /// safe to run even when there's nothing to clean up.
+    /// `<reason>:<uuid>` identifier scheme, AND downgrade any
+    /// matching persisted entries so the next reconcile re-raises
+    /// them with versioned identifiers. Without the persisted-state
+    /// half of this sweep, a `queued` entry left over from a
+    /// pre-versioned build would be no-op'd by reconcile (which
+    /// treats queued entries as already-delivered) and the user
+    /// would silently lose the notification on upgrade.
+    ///
+    /// Best-effort — wired into daemon startup once and safe to run
+    /// even when there's nothing to clean up.
     public func cleanupLegacyOSNotifications() async {
         let delivered = await presenter.getDeliveredIdentifiers()
         let pending = await presenter.getPendingIdentifiers()
@@ -115,10 +119,50 @@ public actor OrphanNotificationCenter {
         if !legacyPending.isEmpty {
             await presenter.removePending(withIdentifiers: legacyPending)
         }
-        if !legacyDelivered.isEmpty || !legacyPending.isEmpty {
+
+        // Downgrade persisted entries that were minted before
+        // osIdentifierSequence existed. Two markers identify a
+        // legacy entry: (a) osIdentifierSequence is nil while
+        // deliveryState is 'queued' (queued entries written by the
+        // new code always carry osIdentifierSequence), or (b)
+        // mutationSequence is 0 (the decoded-default for entries
+        // written before sequencing existed at all). Both cases
+        // mean the OS notification — if any — was minted with a
+        // legacy identifier the new code can't target via
+        // stale-remove. Downgrading to 'failed' enrolls them in
+        // the retry loop so reconcile re-raises with a versioned id.
+        let downgradedCount: Int
+        do {
+            downgradedCount = try await mutator.mutateReturning { state -> Int in
+                var count = 0
+                for idx in state.pendingOrphanNotifications.indices {
+                    let e = state.pendingOrphanNotifications[idx]
+                    let isQueued = e.deliveryState == PendingDeliveryState.queued
+                    let lacksOSSequence = e.osIdentifierSequence == nil
+                    let legacyEntry = e.mutationSequence == 0
+                    guard isQueued && (lacksOSSequence || legacyEntry) else { continue }
+                    state.notificationMutationSequence &+= 1
+                    let seq = state.notificationMutationSequence
+                    state.pendingOrphanNotifications[idx].deliveryState =
+                        PendingDeliveryState.failed
+                    state.pendingOrphanNotifications[idx].mutationSequence = seq
+                    state.pendingOrphanNotifications[idx].osIdentifierSequence = nil
+                    count += 1
+                }
+                return count
+            }
+        } catch {
+            logger.warning("orphan-notify: legacy persisted-state downgrade failed", metadata: [
+                "error": .private(String(describing: error)),
+            ])
+            return
+        }
+
+        if !legacyDelivered.isEmpty || !legacyPending.isEmpty || downgradedCount > 0 {
             logger.info("orphan-notify: cleaned up legacy unversioned notifications", metadata: [
                 "delivered_count": .public(String(legacyDelivered.count)),
                 "pending_count": .public(String(legacyPending.count)),
+                "downgraded_persisted_count": .public(String(downgradedCount)),
             ])
         }
     }
@@ -407,24 +451,31 @@ public actor OrphanNotificationCenter {
             _ = await upsertPending(
                 sessionUUID: sessionUUID,
                 reason: reason,
-                deliveryState: PendingDeliveryState.denied)
+                deliveryState: PendingDeliveryState.denied,
+                osIdentifierSequence: nil)
             return
         }
 
-        // Persist first so the assigned mutationSequence can be
-        // baked into the OS identifier. Ordering matters: if the
-        // process crashes between the persist and the presenter.add,
-        // the next reconcile sees a "queued" entry with no OS-side
-        // notification and re-raises (denied/failed entries are
-        // re-attempted; queued aren't, so we briefly accept a window
-        // where the queued state slightly precedes the OS-side
-        // request — the alternative would either (a) leave the OS
-        // notification untraceable or (b) require an "in-flight"
-        // sub-state, both worse than this trade).
-        let assignedSeq = await upsertPending(
+        // Optimistically persist as 'failed' first to (a) allocate
+        // the mutationSequence used in the OS identifier and (b)
+        // close the crash window — if the daemon dies between this
+        // write and presenter.add returning, the persisted entry is
+        // already in the retry state and the next reconcile re-raises.
+        // The OS-identifier sequence is recorded only after we
+        // actually issue the OS call, so a daemon crash leaves no
+        // osIdentifierSequence pointing at a non-existent OS
+        // notification.
+        let preAddResult = await upsertPendingPreAdd(
             sessionUUID: sessionUUID,
-            reason: reason,
-            deliveryState: PendingDeliveryState.queued)
+            reason: reason)
+        guard preAddResult.persisted else {
+            // Persist failed → don't issue the OS call. We'd have
+            // no reliable way to track it (no sequence to bake into
+            // the identifier; no persisted entry to drive
+            // stale-remove). The next reconcile re-attempts.
+            return
+        }
+        let assignedSeq = preAddResult.sequence
         let identifier = notificationIdentifier(
             reason: reason,
             sessionUUID: sessionUUID,
@@ -438,16 +489,25 @@ public actor OrphanNotificationCenter {
         do {
             try await presenter.add(spec)
         } catch {
-            logger.warning("orphan-notify: presenter.add threw; persisting as 'failed'", metadata: [
+            logger.warning("orphan-notify: presenter.add threw; entry remains 'failed' for retry", metadata: [
                 "session_uuid": .private(sessionUUID),
                 "reason": .public(reason),
                 "error": .private(String(describing: error)),
             ])
-            _ = await upsertPending(
-                sessionUUID: sessionUUID,
-                reason: reason,
-                deliveryState: PendingDeliveryState.failed)
+            // Entry already persisted as 'failed' by the pre-add
+            // step. The next consume() or reconcile() will retry.
+            return
         }
+        // Confirm success: transition state to 'queued' and record
+        // the OS identifier's sequence so stale-remove can target
+        // the actual OS notification. The mutationSequence bumps
+        // (concurrent-mutation race guard) but the
+        // osIdentifierSequence stays at the value baked into the
+        // identifier we just gave the OS.
+        await confirmPostAdd(
+            sessionUUID: sessionUUID,
+            reason: reason,
+            osIdentifierSequence: assignedSeq)
     }
 
     /// Remove the OS notification + persisted entry for a
@@ -491,23 +551,32 @@ public actor OrphanNotificationCenter {
             return
         }
 
-        // Build the identifier from the ENTRY's mutationSequence,
-        // not from maxSequence. A concurrent consume() that lands
-        // between this read and the OS removal will mint a NEW
-        // identifier (different sequence component) and the
-        // freshly-raised OS notification is therefore not stripped
-        // by the call below.
-        let identifier = notificationIdentifier(
-            reason: reason,
-            sessionUUID: sessionUUID,
-            sequence: entry.mutationSequence)
-
-        // OS cleanup first. If it returns, follow with the
-        // persisted-state cleanup. The persisted entry serves as
-        // the retry signal: until removed, the next reconcile
-        // sees it and re-attempts OS cleanup.
-        await presenter.removeDelivered(withIdentifiers: [identifier])
-        await presenter.removePending(withIdentifiers: [identifier])
+        // Build the identifier from the ENTRY's
+        // osIdentifierSequence — the sequence actually baked into
+        // the OS notification when presenter.add was called. Using
+        // mutationSequence would drift if the entry was upserted
+        // (e.g. failed → queued confirmation) after the add. A
+        // concurrent consume() that lands between this read and the
+        // OS removal will mint a NEW identifier (different sequence
+        // component) and the freshly-raised OS notification is
+        // therefore not stripped by the call below.
+        //
+        // If osIdentifierSequence is nil, no OS notification was
+        // ever queued for this entry (denied / failed / legacy
+        // pre-versioned entry) — skip the OS-side removal but still
+        // clean up persisted state.
+        if let osSeq = entry.osIdentifierSequence {
+            let identifier = notificationIdentifier(
+                reason: reason,
+                sessionUUID: sessionUUID,
+                sequence: osSeq)
+            // OS cleanup first. If it returns, follow with the
+            // persisted-state cleanup. The persisted entry serves
+            // as the retry signal: until removed, the next reconcile
+            // sees it and re-attempts OS cleanup.
+            await presenter.removeDelivered(withIdentifiers: [identifier])
+            await presenter.removePending(withIdentifiers: [identifier])
+        }
         do {
             try await mutator.mutate { state in
                 // Re-check the sequence inside the mutator closure
@@ -538,19 +607,16 @@ public actor OrphanNotificationCenter {
     // MARK: - persistence helpers
 
     /// Upserts the (sessionUUID, reason) entry with the given
-    /// deliveryState and returns the mutationSequence assigned by
-    /// this upsert. The returned value is the authoritative sequence
-    /// the caller must use when minting the OS-side identifier —
-    /// embedding it in the identifier is the key to the
-    /// reconcile-vs-consume race fix. Returns 0 on persist failure;
-    /// callers treat that as a no-OS-id fallback (an identifier
-    /// with sequence=0 still differs from prior sequences and
-    /// won't collide with a fresh raise).
+    /// deliveryState. Bumps `mutationSequence` for the race guard.
+    /// Returns the assigned sequence, or 0 on persist failure
+    /// (callers must check via the `osIdentifierSequence` argument
+    /// before relying on the return value for an OS-side call).
     @discardableResult
     private func upsertPending(
         sessionUUID: String,
         reason: String,
-        deliveryState: String
+        deliveryState: String,
+        osIdentifierSequence: UInt64?
     ) async -> UInt64 {
         let now = clock()
         do {
@@ -562,6 +628,9 @@ public actor OrphanNotificationCenter {
                 }) {
                     state.pendingOrphanNotifications[idx].deliveryState = deliveryState
                     state.pendingOrphanNotifications[idx].mutationSequence = seq
+                    if let osSeq = osIdentifierSequence {
+                        state.pendingOrphanNotifications[idx].osIdentifierSequence = osSeq
+                    }
                     // notifiedAt is preserved from the original
                     // raise — the entry is the same notification
                     // semantically, just with updated delivery
@@ -573,7 +642,8 @@ public actor OrphanNotificationCenter {
                             reason: reason,
                             notifiedAt: now,
                             deliveryState: deliveryState,
-                            mutationSequence: seq))
+                            mutationSequence: seq,
+                            osIdentifierSequence: osIdentifierSequence))
                 }
                 return seq
             }
@@ -583,6 +653,72 @@ public actor OrphanNotificationCenter {
             ])
             return 0
         }
+    }
+
+    /// Pre-add upsert: persist the entry as 'failed' (the retry
+    /// state) before issuing the OS call. Returns the assigned
+    /// sequence + a flag indicating persistence success. On persist
+    /// failure (flag=false) the caller MUST NOT call presenter.add,
+    /// because there's no persisted entry to drive a later stale-
+    /// remove. The 'failed' state is the same one used after a
+    /// real presenter.add error; reconcile re-raises it on the next
+    /// pass, so a daemon crash between this write and the OS call
+    /// is fully self-healing.
+    private func upsertPendingPreAdd(
+        sessionUUID: String,
+        reason: String
+    ) async -> (persisted: Bool, sequence: UInt64) {
+        let now = clock()
+        do {
+            let seq = try await mutator.mutateReturning { state -> UInt64 in
+                state.notificationMutationSequence &+= 1
+                let seq = state.notificationMutationSequence
+                if let idx = state.pendingOrphanNotifications.firstIndex(where: {
+                    $0.sessionUUID == sessionUUID && $0.reason == reason
+                }) {
+                    state.pendingOrphanNotifications[idx].deliveryState =
+                        PendingDeliveryState.failed
+                    state.pendingOrphanNotifications[idx].mutationSequence = seq
+                    // osIdentifierSequence is NOT updated here — the
+                    // OS call hasn't been made yet. confirmPostAdd
+                    // sets it on success.
+                } else {
+                    state.pendingOrphanNotifications.append(
+                        PendingOrphanNotification(
+                            sessionUUID: sessionUUID,
+                            reason: reason,
+                            notifiedAt: now,
+                            deliveryState: PendingDeliveryState.failed,
+                            mutationSequence: seq,
+                            osIdentifierSequence: nil))
+                }
+                return seq
+            }
+            return (persisted: true, sequence: seq)
+        } catch {
+            logger.warning("orphan-notify: pre-add persist failed; OS call skipped", metadata: [
+                "error": .private(String(describing: error)),
+                "session_uuid": .private(sessionUUID),
+                "reason": .public(reason),
+            ])
+            return (persisted: false, sequence: 0)
+        }
+    }
+
+    /// Post-add confirmation: presenter.add succeeded; transition
+    /// the entry to 'queued' and stamp the OS identifier's sequence
+    /// onto the entry so future stale-remove calls can target the
+    /// actual OS notification.
+    private func confirmPostAdd(
+        sessionUUID: String,
+        reason: String,
+        osIdentifierSequence: UInt64
+    ) async {
+        _ = await upsertPending(
+            sessionUUID: sessionUUID,
+            reason: reason,
+            deliveryState: PendingDeliveryState.queued,
+            osIdentifierSequence: osIdentifierSequence)
     }
 
     private func maybeResetAuthorizationCacheIfAnyNotQueued() async {

--- a/mac-daemon/Sources/CRMMacOrphanNotifications/OrphanNotificationCenter.swift
+++ b/mac-daemon/Sources/CRMMacOrphanNotifications/OrphanNotificationCenter.swift
@@ -108,41 +108,94 @@ public actor OrphanNotificationCenter {
         await presenter.setDelegate(UserNotificationDelegateRef(d))
     }
 
-    /// Sweep Notification Center for ghost notifications minted by
-    /// older daemon builds that used the unversioned
-    /// `<reason>:<uuid>` identifier scheme, AND downgrade any
-    /// matching persisted entries so the next reconcile re-raises
-    /// them with versioned identifiers. Without the persisted-state
-    /// half of this sweep, a `queued` entry left over from a
-    /// pre-versioned build would be no-op'd by reconcile (which
-    /// treats queued entries as already-delivered) and the user
-    /// would silently lose the notification on upgrade.
+    /// Startup sweep that reconciles Notification Center with the
+    /// daemon's persisted state. Removes two classes of ghost
+    /// notifications:
     ///
-    /// Best-effort — wired into daemon startup once and safe to run
-    /// even when there's nothing to clean up.
+    /// 1. Legacy unversioned ids (`<reason>:<uuid>`) minted by
+    ///    pre-versioning daemon builds. The new code can't target
+    ///    these via stale-remove because its identifiers are
+    ///    versioned.
+    ///
+    /// 2. Orphaned versioned ids (`<reason>:<uuid>:<seq>`) that no
+    ///    persisted entry's `osIdentifierSequence` references.
+    ///    These accrue when a daemon crash lands between
+    ///    `presenter.add` succeeding and the post-add confirm
+    ///    persisting — the OS keeps the notification but the
+    ///    persisted entry is `failed` with `osIdentifierSequence:
+    ///    nil`, so reconcile re-raises and a NEW versioned
+    ///    notification appears alongside the orphaned one.
+    ///
+    /// Also downgrades persisted `queued` entries whose
+    /// `osIdentifierSequence` is nil (or whose `mutationSequence`
+    /// is 0 from pre-sequencing builds) so reconcile re-raises
+    /// with a versioned identifier. Without this, an upgraded
+    /// operator would silently lose the notification when the
+    /// legacy OS id was swept.
+    ///
+    /// Best-effort — wired into daemon startup once and safe to
+    /// run even when there's nothing to clean up.
     public func cleanupLegacyOSNotifications() async {
         let delivered = await presenter.getDeliveredIdentifiers()
         let pending = await presenter.getPendingIdentifiers()
-        let legacyDelivered = delivered.filter { isLegacyNotificationIdentifier($0) }
-        let legacyPending = pending.filter { isLegacyNotificationIdentifier($0) }
-        if !legacyDelivered.isEmpty {
-            await presenter.removeDelivered(withIdentifiers: legacyDelivered)
-        }
-        if !legacyPending.isEmpty {
-            await presenter.removePending(withIdentifiers: legacyPending)
+
+        // Build the set of identifiers persisted state EXPECTS to
+        // exist on the OS side: queued entries with a known
+        // osIdentifierSequence. Anything else with an
+        // orphan:/conflict: prefix is a ghost (legacy or
+        // crash-orphaned) and gets swept.
+        let expectedIdentifiers: Set<String>
+        do {
+            expectedIdentifiers = try await mutator.read()
+                .pendingOrphanNotifications
+                .reduce(into: Set<String>()) { acc, entry in
+                    guard entry.deliveryState == PendingDeliveryState.queued,
+                          let osSeq = entry.osIdentifierSequence else { return }
+                    acc.insert(notificationIdentifier(
+                        reason: entry.reason,
+                        sessionUUID: entry.sessionUUID,
+                        sequence: osSeq))
+                }
+        } catch {
+            logger.warning("orphan-notify: startup sweep read failed", metadata: [
+                "error": .private(String(describing: error)),
+            ])
+            return
         }
 
-        // Downgrade persisted entries that were minted before
-        // osIdentifierSequence existed. Two markers identify a
-        // legacy entry: (a) osIdentifierSequence is nil while
-        // deliveryState is 'queued' (queued entries written by the
-        // new code always carry osIdentifierSequence), or (b)
-        // mutationSequence is 0 (the decoded-default for entries
-        // written before sequencing existed at all). Both cases
-        // mean the OS notification — if any — was minted with a
-        // legacy identifier the new code can't target via
-        // stale-remove. Downgrading to 'failed' enrolls them in
-        // the retry loop so reconcile re-raises with a versioned id.
+        // An id is a "ghost" iff it claims to be one of ours
+        // (orphan: or conflict: prefix) AND isn't in the expected
+        // set. This catches both legacy unversioned ids and
+        // orphaned versioned ids in a single pass.
+        func isGhost(_ id: String) -> Bool {
+            if expectedIdentifiers.contains(id) { return false }
+            if isLegacyNotificationIdentifier(id) { return true }
+            // Versioned id whose sequence isn't expected by state.
+            let parts = id.split(separator: ":", omittingEmptySubsequences: false)
+            guard parts.count == 3 else { return false }
+            let prefix = String(parts[0])
+            return prefix == NotificationReason.orphan ||
+                prefix == NotificationReason.conflict
+        }
+
+        let ghostDelivered = delivered.filter(isGhost)
+        let ghostPending = pending.filter(isGhost)
+        if !ghostDelivered.isEmpty {
+            await presenter.removeDelivered(withIdentifiers: ghostDelivered)
+        }
+        if !ghostPending.isEmpty {
+            await presenter.removePending(withIdentifiers: ghostPending)
+        }
+
+        // Downgrade persisted entries that lack a usable
+        // osIdentifierSequence while still appearing 'queued'.
+        // Two markers identify these: (a) osIdentifierSequence is
+        // nil (legacy decode, or post-crash where the pre-add
+        // persist landed but confirm didn't), or (b)
+        // mutationSequence is 0 (decoded-default for pre-
+        // sequencing entries). Both cases mean reconcile would
+        // treat the entry as already-delivered and never re-raise.
+        // Downgrading to 'failed' enrolls them in the retry loop.
         let downgradedCount: Int
         do {
             downgradedCount = try await mutator.mutateReturning { state -> Int in
@@ -164,16 +217,16 @@ public actor OrphanNotificationCenter {
                 return count
             }
         } catch {
-            logger.warning("orphan-notify: legacy persisted-state downgrade failed", metadata: [
+            logger.warning("orphan-notify: startup sweep persisted-state downgrade failed", metadata: [
                 "error": .private(String(describing: error)),
             ])
             return
         }
 
-        if !legacyDelivered.isEmpty || !legacyPending.isEmpty || downgradedCount > 0 {
-            logger.info("orphan-notify: cleaned up legacy unversioned notifications", metadata: [
-                "delivered_count": .public(String(legacyDelivered.count)),
-                "pending_count": .public(String(legacyPending.count)),
+        if !ghostDelivered.isEmpty || !ghostPending.isEmpty || downgradedCount > 0 {
+            logger.info("orphan-notify: startup sweep removed ghost notifications", metadata: [
+                "delivered_count": .public(String(ghostDelivered.count)),
+                "pending_count": .public(String(ghostPending.count)),
                 "downgraded_persisted_count": .public(String(downgradedCount)),
             ])
         }

--- a/mac-daemon/Sources/CRMMacOrphanNotifications/OrphanNotificationCenter.swift
+++ b/mac-daemon/Sources/CRMMacOrphanNotifications/OrphanNotificationCenter.swift
@@ -96,6 +96,33 @@ public actor OrphanNotificationCenter {
         await presenter.setDelegate(UserNotificationDelegateRef(d))
     }
 
+    /// Sweep Notification Center for ghost notifications minted by
+    /// older daemon builds that used the unversioned
+    /// `<reason>:<uuid>` identifier scheme. Operators upgrading from
+    /// pre-versioned builds otherwise see notifications the new
+    /// code can't track (the new scheme is `<reason>:<uuid>:<seq>`,
+    /// so the legacy ids never match a remove call from this
+    /// version). Best-effort — wired into daemon startup once and
+    /// safe to run even when there's nothing to clean up.
+    public func cleanupLegacyOSNotifications() async {
+        let delivered = await presenter.getDeliveredIdentifiers()
+        let pending = await presenter.getPendingIdentifiers()
+        let legacyDelivered = delivered.filter { isLegacyNotificationIdentifier($0) }
+        let legacyPending = pending.filter { isLegacyNotificationIdentifier($0) }
+        if !legacyDelivered.isEmpty {
+            await presenter.removeDelivered(withIdentifiers: legacyDelivered)
+        }
+        if !legacyPending.isEmpty {
+            await presenter.removePending(withIdentifiers: legacyPending)
+        }
+        if !legacyDelivered.isEmpty || !legacyPending.isEmpty {
+            logger.info("orphan-notify: cleaned up legacy unversioned notifications", metadata: [
+                "delivered_count": .public(String(legacyDelivered.count)),
+                "pending_count": .public(String(legacyPending.count)),
+            ])
+        }
+    }
+
     // Test-only accessor: returns true when a delegate has been
     // installed. Used by the delegate-retention regression test.
     public func hasDelegateInstalled() -> Bool {
@@ -126,7 +153,11 @@ public actor OrphanNotificationCenter {
         await maybeResetAuthorizationCacheIfAnyNotQueued()
 
         for item in items {
-            let key = notificationIdentifier(reason: item.reason, sessionUUID: item.sessionID)
+            // Within-batch dedup is keyed on the sequence-independent
+            // pair so two identical items in one batch produce a single
+            // raise. The OS-side identifier is sequence-versioned
+            // separately when the request is actually queued.
+            let key = "\(item.reason):\(item.sessionID)"
             if seenWithinBatch.contains(key) { continue }
             seenWithinBatch.insert(key)
 
@@ -190,8 +221,12 @@ public actor OrphanNotificationCenter {
             return
         }
 
-        // Build the Pi-set keyed by (uuid, reason). Drop entries
-        // whose linkage_state isn't a recognized value.
+        // Build the Pi-set keyed by (reason, uuid). Drop entries
+        // whose linkage_state isn't a recognized value. The match
+        // key is sequence-independent because the Pi side has no
+        // notion of the daemon's sequence — matching across snapshot
+        // vs Pi must be done on the semantic pair, with sequence
+        // only baked into the OS-side identifier at request time.
         var piByKey: [String: NotificationReconcileItem] = [:]
         for pi in piItems {
             guard let reason = mapLinkageStateToReason(pi.linkageState) else {
@@ -200,7 +235,7 @@ public actor OrphanNotificationCenter {
                 ])
                 continue
             }
-            let key = notificationIdentifier(
+            let key = matchKey(
                 reason: reason,
                 sessionUUID: pi.anarlogSessionID.lowercased())
             piByKey[key] = pi
@@ -219,7 +254,7 @@ public actor OrphanNotificationCenter {
         // the snapshot.
         let snapByKey: [String: PendingOrphanNotification] = Dictionary(
             uniqueKeysWithValues: snapshot.entries.map {
-                (notificationIdentifier(reason: $0.reason, sessionUUID: $0.sessionUUID), $0)
+                (matchKey(reason: $0.reason, sessionUUID: $0.sessionUUID), $0)
             })
         for (key, pi) in piByKey {
             guard let reason = mapLinkageStateToReason(pi.linkageState) else { continue }
@@ -254,7 +289,7 @@ public actor OrphanNotificationCenter {
         // so a concurrent upsert that lands between the snapshot
         // and the OS-side removal is still preserved.
         for snap in snapshot.entries {
-            let key = notificationIdentifier(reason: snap.reason, sessionUUID: snap.sessionUUID)
+            let key = matchKey(reason: snap.reason, sessionUUID: snap.sessionUUID)
             if piKeys.contains(key) { continue }
             if snap.mutationSequence > snapshot.sequence { continue }
             await removeNotificationIfStale(
@@ -363,20 +398,37 @@ public actor OrphanNotificationCenter {
     ) async {
         // Ask for authorization (lazy first-use).
         let granted = await ensureAuthorization()
-        let identifier = notificationIdentifier(reason: reason, sessionUUID: sessionUUID)
 
         if !granted {
             logger.warning("orphan-notify: authorization denied; persisting as 'denied'", metadata: [
                 "session_uuid": .private(sessionUUID),
                 "reason": .public(reason),
             ])
-            await upsertPending(
+            _ = await upsertPending(
                 sessionUUID: sessionUUID,
                 reason: reason,
                 deliveryState: PendingDeliveryState.denied)
             return
         }
 
+        // Persist first so the assigned mutationSequence can be
+        // baked into the OS identifier. Ordering matters: if the
+        // process crashes between the persist and the presenter.add,
+        // the next reconcile sees a "queued" entry with no OS-side
+        // notification and re-raises (denied/failed entries are
+        // re-attempted; queued aren't, so we briefly accept a window
+        // where the queued state slightly precedes the OS-side
+        // request — the alternative would either (a) leave the OS
+        // notification untraceable or (b) require an "in-flight"
+        // sub-state, both worse than this trade).
+        let assignedSeq = await upsertPending(
+            sessionUUID: sessionUUID,
+            reason: reason,
+            deliveryState: PendingDeliveryState.queued)
+        let identifier = notificationIdentifier(
+            reason: reason,
+            sessionUUID: sessionUUID,
+            sequence: assignedSeq)
         let spec = makeSpec(
             identifier: identifier,
             sessionUUID: sessionUUID,
@@ -385,17 +437,13 @@ public actor OrphanNotificationCenter {
             createdAt: createdAt)
         do {
             try await presenter.add(spec)
-            await upsertPending(
-                sessionUUID: sessionUUID,
-                reason: reason,
-                deliveryState: PendingDeliveryState.queued)
         } catch {
             logger.warning("orphan-notify: presenter.add threw; persisting as 'failed'", metadata: [
                 "session_uuid": .private(sessionUUID),
                 "reason": .public(reason),
                 "error": .private(String(describing: error)),
             ])
-            await upsertPending(
+            _ = await upsertPending(
                 sessionUUID: sessionUUID,
                 reason: reason,
                 deliveryState: PendingDeliveryState.failed)
@@ -422,8 +470,6 @@ public actor OrphanNotificationCenter {
         reason: String,
         maxSequence: UInt64
     ) async {
-        let identifier = notificationIdentifier(reason: reason, sessionUUID: sessionUUID)
-
         // Decide whether to remove by reading the current state.
         // Swift 6 strict-concurrency forbids mutating captured
         // vars inside the mutator closure, so we read here and
@@ -444,6 +490,17 @@ public actor OrphanNotificationCenter {
             // the sequence above maxSequence — preserve.
             return
         }
+
+        // Build the identifier from the ENTRY's mutationSequence,
+        // not from maxSequence. A concurrent consume() that lands
+        // between this read and the OS removal will mint a NEW
+        // identifier (different sequence component) and the
+        // freshly-raised OS notification is therefore not stripped
+        // by the call below.
+        let identifier = notificationIdentifier(
+            reason: reason,
+            sessionUUID: sessionUUID,
+            sequence: entry.mutationSequence)
 
         // OS cleanup first. If it returns, follow with the
         // persisted-state cleanup. The persisted entry serves as
@@ -480,14 +537,24 @@ public actor OrphanNotificationCenter {
 
     // MARK: - persistence helpers
 
+    /// Upserts the (sessionUUID, reason) entry with the given
+    /// deliveryState and returns the mutationSequence assigned by
+    /// this upsert. The returned value is the authoritative sequence
+    /// the caller must use when minting the OS-side identifier —
+    /// embedding it in the identifier is the key to the
+    /// reconcile-vs-consume race fix. Returns 0 on persist failure;
+    /// callers treat that as a no-OS-id fallback (an identifier
+    /// with sequence=0 still differs from prior sequences and
+    /// won't collide with a fresh raise).
+    @discardableResult
     private func upsertPending(
         sessionUUID: String,
         reason: String,
         deliveryState: String
-    ) async {
+    ) async -> UInt64 {
         let now = clock()
         do {
-            try await mutator.mutate { state in
+            return try await mutator.mutateReturning { state -> UInt64 in
                 state.notificationMutationSequence &+= 1
                 let seq = state.notificationMutationSequence
                 if let idx = state.pendingOrphanNotifications.firstIndex(where: {
@@ -508,11 +575,13 @@ public actor OrphanNotificationCenter {
                             deliveryState: deliveryState,
                             mutationSequence: seq))
                 }
+                return seq
             }
         } catch {
             logger.warning("orphan-notify: upsert persist failed", metadata: [
                 "error": .private(String(describing: error)),
             ])
+            return 0
         }
     }
 
@@ -591,6 +660,17 @@ public actor OrphanNotificationCenter {
         f.dateStyle = .short
         f.timeStyle = .short
         return " at \(f.string(from: date))"
+    }
+
+    /// Sequence-independent semantic key used for cross-snapshot
+    /// matching (Pi-truth ↔ persisted snapshot). The OS-side
+    /// identifier carries an extra sequence component for race
+    /// safety; matching across snapshots is on the semantic pair
+    /// only (a snapshot at sequence S and a Pi response describing
+    /// the same session must map to the same key regardless of
+    /// the snapshot's sequence).
+    private func matchKey(reason: String, sessionUUID: String) -> String {
+        "\(reason):\(sessionUUID)"
     }
 
     private static func parseRFC3339(_ s: String) -> Date? {

--- a/mac-daemon/Sources/CRMMacOrphanNotifications/OrphanNotificationCenter.swift
+++ b/mac-daemon/Sources/CRMMacOrphanNotifications/OrphanNotificationCenter.swift
@@ -65,6 +65,18 @@ public actor OrphanNotificationCenter {
     // owner of this strength the delegate deallocates at the
     // next await boundary and taps stop firing.
     private var delegate: OrphanNotificationDelegate?
+    // Set of (reason, sessionUUID) pairs currently mid-raise.
+    // Swift actors are reentrant across await boundaries, so a
+    // concurrent consume()/reconcile() can land between our pre-
+    // add persist (which marks the entry 'failed' to seed the
+    // retry semantics) and the presenter.add suspension point.
+    // Without this guard, the reentrant call would see 'failed'
+    // and start a parallel raise — producing two OS notifications
+    // for the same key, only one of which has its sequence tracked
+    // for later stale-remove. Membership is per actor instance and
+    // is keyed on the same semantic pair the rest of the actor
+    // uses for entry identity.
+    private var raisesInFlight: Set<String> = []
 
     public init(
         presenter: UserNotificationPresenter,
@@ -440,6 +452,20 @@ public actor OrphanNotificationCenter {
         title: String?,
         createdAt: Date?
     ) async {
+        // Reentrancy guard: a concurrent consume()/reconcile() that
+        // lands at the same key while this raise is awaiting the
+        // OS call must not start a parallel raise. The pre-add
+        // persist marks the entry 'failed' (retry state), which is
+        // exactly the trigger that would normally cause re-raise —
+        // so we need a separate in-actor signal that "a raise is
+        // already in progress for this key, stand down".
+        let raiseKey = matchKey(reason: reason, sessionUUID: sessionUUID)
+        if raisesInFlight.contains(raiseKey) {
+            return
+        }
+        raisesInFlight.insert(raiseKey)
+        defer { raisesInFlight.remove(raiseKey) }
+
         // Ask for authorization (lazy first-use).
         let granted = await ensureAuthorization()
 
@@ -504,10 +530,28 @@ public actor OrphanNotificationCenter {
         // (concurrent-mutation race guard) but the
         // osIdentifierSequence stays at the value baked into the
         // identifier we just gave the OS.
-        await confirmPostAdd(
+        let confirmed = await confirmPostAdd(
             sessionUUID: sessionUUID,
             reason: reason,
             osIdentifierSequence: assignedSeq)
+        if !confirmed {
+            // Persist failed AFTER the OS already accepted the
+            // request. We now have an OS notification with no
+            // tracked osIdentifierSequence in persisted state, so
+            // future stale-remove would miss it. Best-effort:
+            // remove the notification we just queued (we still
+            // know its identifier locally). Worst case the user
+            // briefly sees the notification before this cleanup
+            // fires — preferable to a permanently-untracked
+            // ghost. The persisted entry remains 'failed' so the
+            // next retry can re-attempt the full cycle.
+            logger.warning("orphan-notify: confirm persist failed; removing untrackable OS notification", metadata: [
+                "session_uuid": .private(sessionUUID),
+                "reason": .public(reason),
+            ])
+            await presenter.removeDelivered(withIdentifiers: [identifier])
+            await presenter.removePending(withIdentifiers: [identifier])
+        }
     }
 
     /// Remove the OS notification + persisted entry for a
@@ -708,17 +752,19 @@ public actor OrphanNotificationCenter {
     /// Post-add confirmation: presenter.add succeeded; transition
     /// the entry to 'queued' and stamp the OS identifier's sequence
     /// onto the entry so future stale-remove calls can target the
-    /// actual OS notification.
+    /// actual OS notification. Returns true on persist success.
+    @discardableResult
     private func confirmPostAdd(
         sessionUUID: String,
         reason: String,
         osIdentifierSequence: UInt64
-    ) async {
-        _ = await upsertPending(
+    ) async -> Bool {
+        let seq = await upsertPending(
             sessionUUID: sessionUUID,
             reason: reason,
             deliveryState: PendingDeliveryState.queued,
             osIdentifierSequence: osIdentifierSequence)
+        return seq != 0
     }
 
     private func maybeResetAuthorizationCacheIfAnyNotQueued() async {

--- a/mac-daemon/Sources/CRMMacOrphanNotifications/OrphanNotificationCenter.swift
+++ b/mac-daemon/Sources/CRMMacOrphanNotifications/OrphanNotificationCenter.swift
@@ -278,7 +278,7 @@ public actor OrphanNotificationCenter {
             // pair so two identical items in one batch produce a single
             // raise. The OS-side identifier is sequence-versioned
             // separately when the request is actually queued.
-            let key = "\(item.reason):\(item.sessionID)"
+            let key = matchKey(reason: item.reason, sessionUUID: item.sessionID)
             if seenWithinBatch.contains(key) { continue }
             seenWithinBatch.insert(key)
 

--- a/mac-daemon/Sources/CRMMacOrphanNotifications/OrphanNotificationCenter.swift
+++ b/mac-daemon/Sources/CRMMacOrphanNotifications/OrphanNotificationCenter.swift
@@ -180,22 +180,25 @@ public actor OrphanNotificationCenter {
 
         let ghostDelivered = delivered.filter(isGhost)
         let ghostPending = pending.filter(isGhost)
-        if !ghostDelivered.isEmpty {
-            await presenter.removeDelivered(withIdentifiers: ghostDelivered)
-        }
-        if !ghostPending.isEmpty {
-            await presenter.removePending(withIdentifiers: ghostPending)
-        }
 
-        // Downgrade persisted entries that lack a usable
-        // osIdentifierSequence while still appearing 'queued'.
-        // Two markers identify these: (a) osIdentifierSequence is
-        // nil (legacy decode, or post-crash where the pre-add
-        // persist landed but confirm didn't), or (b)
-        // mutationSequence is 0 (decoded-default for pre-
-        // sequencing entries). Both cases mean reconcile would
-        // treat the entry as already-delivered and never re-raise.
-        // Downgrading to 'failed' enrolls them in the retry loop.
+        // Downgrade persisted entries FIRST, before any OS-side
+        // removal. If the persist fails (next block returns early
+        // on error), we leave the OS notifications alone too —
+        // otherwise a downgrade-failure-after-OS-removal would
+        // strand the entry in 'queued', reconcile would treat it
+        // as already-delivered, and the user would silently lose
+        // the notification with no retry path.
+        //
+        // The downgrade targets persisted entries that lack a
+        // usable osIdentifierSequence while still appearing
+        // 'queued'. Two markers identify these: (a)
+        // osIdentifierSequence is nil (legacy decode, or post-
+        // crash where the pre-add persist landed but confirm
+        // didn't), or (b) mutationSequence is 0 (decoded-default
+        // for pre-sequencing entries). Both cases mean reconcile
+        // would treat the entry as already-delivered and never
+        // re-raise. Downgrading to 'failed' enrolls them in the
+        // retry loop.
         let downgradedCount: Int
         do {
             downgradedCount = try await mutator.mutateReturning { state -> Int in
@@ -217,10 +220,19 @@ public actor OrphanNotificationCenter {
                 return count
             }
         } catch {
-            logger.warning("orphan-notify: startup sweep persisted-state downgrade failed", metadata: [
+            logger.warning("orphan-notify: startup sweep persisted-state downgrade failed; OS side untouched", metadata: [
                 "error": .private(String(describing: error)),
             ])
             return
+        }
+
+        // Persisted state is now consistent. Safe to remove the
+        // OS-side ghosts.
+        if !ghostDelivered.isEmpty {
+            await presenter.removeDelivered(withIdentifiers: ghostDelivered)
+        }
+        if !ghostPending.isEmpty {
+            await presenter.removePending(withIdentifiers: ghostPending)
         }
 
         if !ghostDelivered.isEmpty || !ghostPending.isEmpty || downgradedCount > 0 {

--- a/mac-daemon/Sources/CRMMacOrphanNotifications/UserNotificationPresenter.swift
+++ b/mac-daemon/Sources/CRMMacOrphanNotifications/UserNotificationPresenter.swift
@@ -83,6 +83,18 @@ public protocol UserNotificationPresenter: Sendable {
     /// a raw non-Sendable class reference into an actor-isolated
     /// implementation.
     func setDelegate(_ ref: UserNotificationDelegateRef?) async
+
+    /// Identifiers of notifications the OS has already delivered to
+    /// Notification Center. Returns identifier strings only (the
+    /// caller never needs the full UNNotification, which isn't
+    /// Sendable). Used by the startup migration sweep to find
+    /// ghost notifications minted by older daemon builds.
+    func getDeliveredIdentifiers() async -> [String]
+
+    /// Identifiers of notifications enqueued with the OS but not yet
+    /// delivered. Same shape as `getDeliveredIdentifiers()` for the
+    /// pending queue.
+    func getPendingIdentifiers() async -> [String]
 }
 
 /// Production conformance — wraps `UNUserNotificationCenter.current()`.
@@ -131,5 +143,17 @@ public final class UserNotificationCenterPresenter: UserNotificationPresenter, @
     public func setDelegate(_ ref: UserNotificationDelegateRef?) async {
         let center = UNUserNotificationCenter.current()
         center.delegate = ref?.value
+    }
+
+    public func getDeliveredIdentifiers() async -> [String] {
+        let center = UNUserNotificationCenter.current()
+        let delivered = await center.deliveredNotifications()
+        return delivered.map { $0.request.identifier }
+    }
+
+    public func getPendingIdentifiers() async -> [String] {
+        let center = UNUserNotificationCenter.current()
+        let pending = await center.pendingNotificationRequests()
+        return pending.map { $0.identifier }
     }
 }

--- a/mac-daemon/Sources/crm-mac/Commands/DaemonCommand.swift
+++ b/mac-daemon/Sources/crm-mac/Commands/DaemonCommand.swift
@@ -212,6 +212,10 @@ struct DaemonCommand: AsyncParsableCommand {
             logger: logger,
             clock: { orphanClock.now() })
         await orphanNotificationCenter.installDelegate()
+        // One-time cleanup of any unversioned notifications minted
+        // by older daemon builds. Operators upgrading otherwise see
+        // ghost notifications the new code can't track.
+        await orphanNotificationCenter.cleanupLegacyOSNotifications()
         let reconcileLoopPlugin = NotificationReconcileLoopPlugin(
             center: orphanNotificationCenter,
             logger: logger)

--- a/mac-daemon/Tests/CRMMacAnarlogSourceTests/AnarlogSessionsPluginOrphanForwardingTests.swift
+++ b/mac-daemon/Tests/CRMMacAnarlogSourceTests/AnarlogSessionsPluginOrphanForwardingTests.swift
@@ -106,7 +106,7 @@ final class AnarlogSessionsPluginOrphanForwardingTests: XCTestCase {
         let calls = await fakePresenter.recordedCalls()
         XCTAssertEqual(calls.count, 1,
                        "plugin should forward outcome.needsAttention to center")
-        XCTAssertEqual(calls[0].identifier, "orphan:\(Self.sessionUUIDA)")
+        XCTAssertEqual(calls[0].identifier, "orphan:\(Self.sessionUUIDA):1")
         XCTAssertTrue(calls[0].body.contains("Forwarded Session"))
 
         try? FileManager.default.removeItem(atPath: stateURL.path)
@@ -178,6 +178,8 @@ private actor FakeFwdPresenter: UserNotificationPresenter {
     func removeDelivered(withIdentifiers ids: [String]) async {}
     func removePending(withIdentifiers ids: [String]) async {}
     func setDelegate(_ ref: UserNotificationDelegateRef?) async {}
+    func getDeliveredIdentifiers() async -> [String] { [] }
+    func getPendingIdentifiers() async -> [String] { [] }
 }
 
 private struct FakeFwdOpener: WorkspaceOpener {

--- a/mac-daemon/Tests/CRMMacOrphanNotificationsTests/OrphanNotificationCenterTests.swift
+++ b/mac-daemon/Tests/CRMMacOrphanNotificationsTests/OrphanNotificationCenterTests.swift
@@ -639,13 +639,15 @@ final class OrphanNotificationCenterTests: XCTestCase {
 
     /// Regression for the reconcile-vs-consume TOCTOU race. The
     /// stale-remove path MUST mint the OS identifier from the
-    /// observed entry's mutationSequence — NOT from `maxSequence`,
-    /// the latest snapshot sequence, or anything else. A
-    /// concurrent consume() that lands between snapshot and OS-
-    /// removal will upsert a fresh entry at a HIGHER sequence;
-    /// because that fresh OS notification's identifier carries
-    /// the higher sequence, the stale-remove call (which carries
-    /// the lower sequence) cannot collaterally strip it.
+    /// observed entry's osIdentifierSequence — NOT from
+    /// mutationSequence, `maxSequence`, the latest snapshot
+    /// sequence, or anything else. A concurrent consume() that
+    /// lands between snapshot and OS-removal will upsert a fresh
+    /// entry at a higher mutationSequence; because that fresh OS
+    /// notification's identifier carries its OWN osIdentifierSequence
+    /// (assigned at presenter.add time), the stale-remove call —
+    /// targeting the observed entry's recorded osIdentifierSequence —
+    /// cannot collaterally strip the new notification.
     func testStaleRemovalIdentifierCarriesEntryRecordedSequence() async throws {
         let presenter = FakeUserNotificationPresenter(authorizationResult: true)
         try await mutator.mutate { state in
@@ -867,30 +869,51 @@ final class OrphanNotificationCenterTests: XCTestCase {
     /// sequence numbers and only the last confirmed sequence would
     /// be tracked, leaving an orphaned OS notification.
     ///
-    /// Run multiple consume() calls concurrently via TaskGroup. The
-    /// FakeUserNotificationPresenter's `add(_:)` is an `await` on
-    /// its own actor, so concurrent center.consume(...) tasks can
-    /// interleave at that suspension point — exactly the reentrancy
-    /// window the guard protects against.
+    /// Uses the FakeUserNotificationPresenter's add-gate to
+    /// deterministically hold the first raise inside presenter.add
+    /// — i.e. AFTER the pre-add persist marked the entry 'failed'
+    /// and AFTER the entry was inserted into raisesInFlight. While
+    /// parked there, we kick off a second consume(); without the
+    /// in-flight guard it would observe the 'failed' entry and
+    /// start a parallel raise. The test fails if the second
+    /// consume issues an additional presenter.add call.
     func testConcurrentConsumesForSameKeyDedupViaInFlightGuard() async throws {
         let presenter = FakeUserNotificationPresenter(authorizationResult: true)
         let center = makeCenter(presenter: presenter)
         let item = NotificationConsumeItem(sessionID: Self.session1, reason: "orphan")
+
+        // Arm the gate so the first consume parks inside add().
+        await presenter.armAddGate()
+
         let centerRef = center
         let itemRef = item
-        await withTaskGroup(of: Void.self) { group in
-            for _ in 0..<8 {
-                group.addTask {
-                    await centerRef.consume(needsAttention: [itemRef])
-                }
-            }
+        // Kick off the first consume in a background task; it
+        // parks at presenter.add holding raisesInFlight.
+        let firstTask = Task {
+            await centerRef.consume(needsAttention: [itemRef])
         }
+
+        // Wait until the first consume is actually inside add()
+        // (not just scheduled). Bounded poll — total budget 2s.
+        var pollAttempts = 0
+        while await presenter.addsCurrentlyAwaitingGate() == 0 {
+            pollAttempts += 1
+            XCTAssertLessThan(pollAttempts, 200, "first consume never reached presenter.add")
+            try await Task.sleep(nanoseconds: 10_000_000)  // 10ms
+        }
+
+        // Second consume should hit the in-flight guard and skip.
+        // (This await completes synchronously through the actor;
+        // no add() suspension since the guard returns early.)
+        await center.consume(needsAttention: [item])
+
+        // Release the gate so the first consume can finish.
+        await presenter.releaseAddGate()
+        _ = await firstTask.value
+
         let calls = await presenter.recordedAddCalls()
         XCTAssertEqual(calls.count, 1,
-            "concurrent consumes for the same (reason, session) must dedup to a single raise")
-        // Verify state is internally consistent: exactly one entry,
-        // queued, with an osIdentifierSequence that matches the
-        // single OS-side raise.
+            "second consume must dedup via raisesInFlight while first is mid-add")
         let state = try stateStore.load()
         XCTAssertEqual(state.pendingOrphanNotifications.count, 1)
         XCTAssertEqual(state.pendingOrphanNotifications[0].deliveryState, "queued")

--- a/mac-daemon/Tests/CRMMacOrphanNotificationsTests/OrphanNotificationCenterTests.swift
+++ b/mac-daemon/Tests/CRMMacOrphanNotificationsTests/OrphanNotificationCenterTests.swift
@@ -79,7 +79,7 @@ final class OrphanNotificationCenterTests: XCTestCase {
         ])
         let calls = await presenter.recordedAddCalls()
         XCTAssertEqual(calls.count, 1)
-        XCTAssertEqual(calls[0].identifier, "orphan:\(Self.session1)")
+        XCTAssertEqual(calls[0].identifier, "orphan:\(Self.session1):1")
         XCTAssertEqual(calls[0].title, "Untagged session")
         XCTAssertTrue(calls[0].body.contains("Tag participants in Anarlog"))
         XCTAssertTrue(calls[0].body.contains("Synthetic Test Session"))
@@ -104,7 +104,7 @@ final class OrphanNotificationCenterTests: XCTestCase {
         ])
         let calls = await presenter.recordedAddCalls()
         XCTAssertEqual(calls.count, 1)
-        XCTAssertEqual(calls[0].identifier, "conflict:\(Self.session1)")
+        XCTAssertEqual(calls[0].identifier, "conflict:\(Self.session1):1")
         XCTAssertEqual(calls[0].title, "Session needs CRM attention")
         XCTAssertEqual(calls[0].userInfo["reason"], "conflict")
     }
@@ -257,9 +257,10 @@ final class OrphanNotificationCenterTests: XCTestCase {
         })
         await center.reconcile()
         // Self.session1 was already queued → no re-raise. Self.session2 is new → raised.
+        // Snapshot's sequence was 1; the new upsert increments to 2.
         let calls = await presenter.recordedAddCalls()
         XCTAssertEqual(calls.count, 1)
-        XCTAssertEqual(calls[0].identifier, "conflict:\(Self.session2)")
+        XCTAssertEqual(calls[0].identifier, "conflict:\(Self.session2):2")
         let state = try stateStore.load()
         XCTAssertEqual(state.pendingOrphanNotifications.count, 2)
     }
@@ -296,9 +297,9 @@ final class OrphanNotificationCenterTests: XCTestCase {
         let removedDelivered = await presenter.recordedRemoveDelivered()
         let removedPending = await presenter.recordedRemovePending()
         XCTAssertEqual(removedDelivered.count, 1)
-        XCTAssertEqual(removedDelivered[0], ["conflict:\(Self.session2)"])
+        XCTAssertEqual(removedDelivered[0], ["conflict:\(Self.session2):2"])
         XCTAssertEqual(removedPending.count, 1)
-        XCTAssertEqual(removedPending[0], ["conflict:\(Self.session2)"])
+        XCTAssertEqual(removedPending[0], ["conflict:\(Self.session2):2"])
         let state = try stateStore.load()
         XCTAssertEqual(state.pendingOrphanNotifications.count, 1)
         XCTAssertEqual(state.pendingOrphanNotifications[0].sessionUUID, Self.session1)
@@ -527,7 +528,8 @@ final class OrphanNotificationCenterTests: XCTestCase {
         await center.reconcile()
         let calls = await presenter.recordedAddCalls()
         XCTAssertEqual(calls.count, 1, "denied entry re-raised on reconcile")
-        XCTAssertEqual(calls[0].identifier, "orphan:\(Self.session1)")
+        // Snapshot's sequence was 5; the re-raise upsert increments to 6.
+        XCTAssertEqual(calls[0].identifier, "orphan:\(Self.session1):6")
         let state = try stateStore.load()
         XCTAssertEqual(state.pendingOrphanNotifications[0].deliveryState, "queued")
         XCTAssertGreaterThan(state.pendingOrphanNotifications[0].mutationSequence, 5)
@@ -560,9 +562,12 @@ final class OrphanNotificationCenterTests: XCTestCase {
         let adds = await presenter.recordedAddCalls()
         let removed = await presenter.recordedRemoveDelivered()
         XCTAssertEqual(adds.count, 1)
-        XCTAssertEqual(adds[0].identifier, "conflict:\(Self.session1)")
+        // Snapshot's sequence was 1; the new-reason upsert increments to 2.
+        XCTAssertEqual(adds[0].identifier, "conflict:\(Self.session1):2")
         XCTAssertEqual(removed.count, 1)
-        XCTAssertEqual(removed[0], ["orphan:\(Self.session1)"])
+        // Stale-remove targets the legacy-reason entry's recorded
+        // sequence (1 from the seed), not the latest sequence.
+        XCTAssertEqual(removed[0], ["orphan:\(Self.session1):1"])
         let state = try stateStore.load()
         XCTAssertEqual(state.pendingOrphanNotifications.count, 1)
         XCTAssertEqual(state.pendingOrphanNotifications[0].reason, "conflict")
@@ -617,5 +622,127 @@ final class OrphanNotificationCenterTests: XCTestCase {
         XCTAssertEqual(delegateCount, 1)
         let stored = await presenter.currentDelegate()
         XCTAssertNotNil(stored)
+    }
+
+    // MARK: - TC-OC26: stale removal uses entry's own sequence
+
+    /// Regression for the reconcile-vs-consume TOCTOU race. The
+    /// stale-remove path MUST mint the OS identifier from the
+    /// observed entry's mutationSequence — NOT from `maxSequence`,
+    /// the latest snapshot sequence, or anything else. A
+    /// concurrent consume() that lands between snapshot and OS-
+    /// removal will upsert a fresh entry at a HIGHER sequence;
+    /// because that fresh OS notification's identifier carries
+    /// the higher sequence, the stale-remove call (which carries
+    /// the lower sequence) cannot collaterally strip it.
+    func testStaleRemovalIdentifierCarriesEntryRecordedSequence() async throws {
+        let presenter = FakeUserNotificationPresenter(authorizationResult: true)
+        try await mutator.mutate { state in
+            // Snapshot sequence = 5, but the stale entry was upserted
+            // at sequence 3 (an earlier mutation). The remove
+            // identifier must carry "3", not "5".
+            state.notificationMutationSequence = 5
+            state.pendingOrphanNotifications = [
+                PendingOrphanNotification(
+                    sessionUUID: Self.session1, reason: "orphan",
+                    notifiedAt: Date(timeIntervalSince1970: 1_715_000_000),
+                    deliveryState: "queued", mutationSequence: 3),
+            ]
+        }
+        // Pi returns empty → triggers stale-removal path.
+        let center = makeCenter(presenter: presenter, fetcher: { [] })
+        await center.reconcile()
+
+        let removedDelivered = await presenter.recordedRemoveDelivered()
+        let removedPending = await presenter.recordedRemovePending()
+        XCTAssertEqual(removedDelivered.count, 1)
+        XCTAssertEqual(removedDelivered[0], ["orphan:\(Self.session1):3"],
+                       "stale-remove identifier must carry the entry's recorded sequence (3)")
+        XCTAssertEqual(removedPending.count, 1)
+        XCTAssertEqual(removedPending[0], ["orphan:\(Self.session1):3"],
+                       "stale-remove identifier must carry the entry's recorded sequence (3)")
+    }
+
+    // MARK: - TC-OC27: race-survival — fresh raise has different identifier from stale remove
+
+    /// Even when a concurrent consume() lands at the same key
+    /// between the snapshot and the OS-side removal, the fresh
+    /// raise's OS identifier MUST differ from the stale remove's
+    /// identifier (different sequence component). This proves the
+    /// versioned-identifier scheme severs the cross-contamination
+    /// vector even if interleaving were possible inside actor
+    /// isolation.
+    ///
+    /// We can't deterministically interleave inside an actor
+    /// (await boundaries serialize), so we simulate the race
+    /// outcome: seed two entries at the same (reason, uuid) at
+    /// distinct sequences and assert the identifiers a raise and a
+    /// remove WOULD mint are non-overlapping.
+    func testRaceSurvivalFreshRaiseIdentifierDiffersFromStaleRemove() async throws {
+        let staleSequence: UInt64 = 7
+        let freshSequence: UInt64 = 8
+        let staleIdentifier = notificationIdentifier(
+            reason: "orphan", sessionUUID: Self.session1, sequence: staleSequence)
+        let freshIdentifier = notificationIdentifier(
+            reason: "orphan", sessionUUID: Self.session1, sequence: freshSequence)
+        XCTAssertNotEqual(staleIdentifier, freshIdentifier,
+            "stale-remove identifier and fresh-raise identifier must differ")
+        // Sanity-check the format: the trailing sequence must be the
+        // only differentiator (same prefix, different suffix).
+        XCTAssertTrue(staleIdentifier.hasPrefix("orphan:\(Self.session1):"))
+        XCTAssertTrue(freshIdentifier.hasPrefix("orphan:\(Self.session1):"))
+        XCTAssertTrue(staleIdentifier.hasSuffix(":\(staleSequence)"))
+        XCTAssertTrue(freshIdentifier.hasSuffix(":\(freshSequence)"))
+    }
+
+    // MARK: - TC-OC28: legacy-notification migration sweep
+
+    /// Operators upgrading from a pre-versioned daemon build may
+    /// have unversioned `<reason>:<uuid>` notifications still
+    /// resident in Notification Center. The new code never mints
+    /// or tracks those ids, so it must explicitly clean them up on
+    /// startup. Otherwise the user sees ghost notifications that
+    /// never disappear.
+    func testCleanupLegacyOSNotificationsRemovesUnversionedIDs() async throws {
+        let presenter = FakeUserNotificationPresenter(authorizationResult: true)
+        await presenter.seedDeliveredIdentifiers([
+            "orphan:\(Self.session1)",
+            "conflict:\(Self.session2):4",            // versioned — keep
+            "orphan:\(Self.session3)",
+            "crm-mac-prod-presenter-test-xyz",        // unrelated — keep
+        ])
+        await presenter.seedPendingIdentifiers([
+            "conflict:\(Self.session1)",
+            "orphan:\(Self.session2):9",              // versioned — keep
+        ])
+        let center = makeCenter(presenter: presenter)
+
+        await center.cleanupLegacyOSNotifications()
+
+        let removedDelivered = await presenter.recordedRemoveDelivered()
+        let removedPending = await presenter.recordedRemovePending()
+        XCTAssertEqual(removedDelivered.count, 1)
+        XCTAssertEqual(Set(removedDelivered[0]),
+                       Set(["orphan:\(Self.session1)", "orphan:\(Self.session3)"]),
+                       "only unversioned orphan/conflict ids should be swept")
+        XCTAssertEqual(removedPending.count, 1)
+        XCTAssertEqual(removedPending[0], ["conflict:\(Self.session1)"])
+    }
+
+    func testCleanupLegacyOSNotificationsIsNoOpWhenNothingLegacy() async throws {
+        let presenter = FakeUserNotificationPresenter(authorizationResult: true)
+        await presenter.seedDeliveredIdentifiers([
+            "orphan:\(Self.session1):1",
+            "conflict:\(Self.session2):2",
+        ])
+        await presenter.seedPendingIdentifiers([])
+        let center = makeCenter(presenter: presenter)
+
+        await center.cleanupLegacyOSNotifications()
+
+        let removedDelivered = await presenter.recordedRemoveDelivered()
+        let removedPending = await presenter.recordedRemovePending()
+        XCTAssertTrue(removedDelivered.isEmpty)
+        XCTAssertTrue(removedPending.isEmpty)
     }
 }

--- a/mac-daemon/Tests/CRMMacOrphanNotificationsTests/OrphanNotificationCenterTests.swift
+++ b/mac-daemon/Tests/CRMMacOrphanNotificationsTests/OrphanNotificationCenterTests.swift
@@ -237,7 +237,8 @@ final class OrphanNotificationCenterTests: XCTestCase {
                 PendingOrphanNotification(
                     sessionUUID: Self.session1, reason: "orphan",
                     notifiedAt: Date(timeIntervalSince1970: 1_715_000_000),
-                    deliveryState: "queued", mutationSequence: 1),
+                    deliveryState: "queued", mutationSequence: 1,
+                    osIdentifierSequence: 1),
             ]
         }
         // Pi returns Self.session1 + Self.session2.
@@ -269,18 +270,21 @@ final class OrphanNotificationCenterTests: XCTestCase {
 
     func testReconcileRemovesStaleEntries() async throws {
         let presenter = FakeUserNotificationPresenter(authorizationResult: true)
-        // Pre-seed two entries.
+        // Pre-seed two entries — both with osIdentifierSequence set
+        // because both represent live queued OS notifications.
         try await mutator.mutate { state in
             state.notificationMutationSequence = 2
             state.pendingOrphanNotifications = [
                 PendingOrphanNotification(
                     sessionUUID: Self.session1, reason: "orphan",
                     notifiedAt: Date(timeIntervalSince1970: 1_715_000_000),
-                    deliveryState: "queued", mutationSequence: 1),
+                    deliveryState: "queued", mutationSequence: 1,
+                    osIdentifierSequence: 1),
                 PendingOrphanNotification(
                     sessionUUID: Self.session2, reason: "conflict",
                     notifiedAt: Date(timeIntervalSince1970: 1_715_000_000),
-                    deliveryState: "queued", mutationSequence: 2),
+                    deliveryState: "queued", mutationSequence: 2,
+                    osIdentifierSequence: 2),
             ]
         }
         // Pi returns only Self.session1 → Self.session2 should be removed.
@@ -314,7 +318,8 @@ final class OrphanNotificationCenterTests: XCTestCase {
                 PendingOrphanNotification(
                     sessionUUID: Self.session1, reason: "orphan",
                     notifiedAt: Date(timeIntervalSince1970: 1_715_000_000),
-                    deliveryState: "queued", mutationSequence: 1),
+                    deliveryState: "queued", mutationSequence: 1,
+                    osIdentifierSequence: 1),
             ]
         }
         let center = makeCenter(presenter: presenter, fetcher: {
@@ -339,7 +344,8 @@ final class OrphanNotificationCenterTests: XCTestCase {
                 PendingOrphanNotification(
                     sessionUUID: Self.session1, reason: "orphan",
                     notifiedAt: Date(timeIntervalSince1970: 1_715_000_000),
-                    deliveryState: "queued", mutationSequence: 1),
+                    deliveryState: "queued", mutationSequence: 1,
+                    osIdentifierSequence: 1),
             ]
         }
         let center = makeCenter(presenter: presenter, fetcher: {
@@ -423,12 +429,14 @@ final class OrphanNotificationCenterTests: XCTestCase {
                 PendingOrphanNotification(
                     sessionUUID: Self.session1, reason: "orphan",
                     notifiedAt: Date(timeIntervalSince1970: 1_715_000_000),
-                    deliveryState: "queued", mutationSequence: 1),
+                    deliveryState: "queued", mutationSequence: 1,
+                    osIdentifierSequence: 1),
                 // Y arrived after snapshot — sequence > snapshotSequence.
                 PendingOrphanNotification(
                     sessionUUID: Self.session2, reason: "orphan",
                     notifiedAt: Date(timeIntervalSince1970: 1_715_000_001),
-                    deliveryState: "queued", mutationSequence: 99),
+                    deliveryState: "queued", mutationSequence: 99,
+                    osIdentifierSequence: 99),
             ]
         }
         let center = makeCenter(presenter: presenter, fetcher: { [] })
@@ -464,7 +472,8 @@ final class OrphanNotificationCenterTests: XCTestCase {
                 PendingOrphanNotification(
                     sessionUUID: Self.session1, reason: "orphan",
                     notifiedAt: Date(timeIntervalSince1970: 1_715_000_000),
-                    deliveryState: "queued", mutationSequence: 1),
+                    deliveryState: "queued", mutationSequence: 1,
+                    osIdentifierSequence: 1),
             ]
         }
 
@@ -513,7 +522,8 @@ final class OrphanNotificationCenterTests: XCTestCase {
                 PendingOrphanNotification(
                     sessionUUID: Self.session1, reason: "orphan",
                     notifiedAt: Date(timeIntervalSince1970: 1_715_000_000),
-                    deliveryState: "denied", mutationSequence: 5),
+                    deliveryState: "denied", mutationSequence: 5,
+                    osIdentifierSequence: nil),
             ]
         }
         let center = makeCenter(presenter: presenter, fetcher: {
@@ -545,7 +555,8 @@ final class OrphanNotificationCenterTests: XCTestCase {
                 PendingOrphanNotification(
                     sessionUUID: Self.session1, reason: "orphan",
                     notifiedAt: Date(timeIntervalSince1970: 1_715_000_000),
-                    deliveryState: "queued", mutationSequence: 1),
+                    deliveryState: "queued", mutationSequence: 1,
+                    osIdentifierSequence: 1),
             ]
         }
         // Pi now says the same session is conflict (reason flipped).
@@ -638,15 +649,19 @@ final class OrphanNotificationCenterTests: XCTestCase {
     func testStaleRemovalIdentifierCarriesEntryRecordedSequence() async throws {
         let presenter = FakeUserNotificationPresenter(authorizationResult: true)
         try await mutator.mutate { state in
-            // Snapshot sequence = 5, but the stale entry was upserted
-            // at sequence 3 (an earlier mutation). The remove
-            // identifier must carry "3", not "5".
+            // Snapshot sequence = 5, but the stale entry's OS
+            // notification was minted at sequence 3 (an earlier
+            // raise). The remove identifier must carry "3", not "5"
+            // — i.e. the entry's osIdentifierSequence, not its
+            // current mutationSequence and not the snapshot's
+            // sequence.
             state.notificationMutationSequence = 5
             state.pendingOrphanNotifications = [
                 PendingOrphanNotification(
                     sessionUUID: Self.session1, reason: "orphan",
                     notifiedAt: Date(timeIntervalSince1970: 1_715_000_000),
-                    deliveryState: "queued", mutationSequence: 3),
+                    deliveryState: "queued", mutationSequence: 4,
+                    osIdentifierSequence: 3),
             ]
         }
         // Pi returns empty → triggers stale-removal path.
@@ -657,10 +672,10 @@ final class OrphanNotificationCenterTests: XCTestCase {
         let removedPending = await presenter.recordedRemovePending()
         XCTAssertEqual(removedDelivered.count, 1)
         XCTAssertEqual(removedDelivered[0], ["orphan:\(Self.session1):3"],
-                       "stale-remove identifier must carry the entry's recorded sequence (3)")
+                       "stale-remove identifier must carry the entry's osIdentifierSequence (3)")
         XCTAssertEqual(removedPending.count, 1)
         XCTAssertEqual(removedPending[0], ["orphan:\(Self.session1):3"],
-                       "stale-remove identifier must carry the entry's recorded sequence (3)")
+                       "stale-remove identifier must carry the entry's osIdentifierSequence (3)")
     }
 
     // MARK: - TC-OC27: race-survival — fresh raise has different identifier from stale remove
@@ -744,5 +759,92 @@ final class OrphanNotificationCenterTests: XCTestCase {
         let removedPending = await presenter.recordedRemovePending()
         XCTAssertTrue(removedDelivered.isEmpty)
         XCTAssertTrue(removedPending.isEmpty)
+    }
+
+    // MARK: - TC-OC29: legacy persisted entries are downgraded so reconcile re-raises
+
+    /// A pre-versioned daemon build's persisted `queued` entry has
+    /// no `osIdentifierSequence`. Reconcile treats `queued` entries
+    /// as already-delivered no-ops, so without an explicit
+    /// downgrade the user would silently lose the notification on
+    /// upgrade (the OS notification gets swept away by the
+    /// legacy-id sweep, but the persisted state still says
+    /// `queued` so reconcile doesn't re-raise). The cleanup must
+    /// downgrade these to `failed` to enroll them in the retry loop.
+    func testCleanupLegacyOSNotificationsDowngradesQueuedEntriesWithoutOSIDSequence() async throws {
+        let presenter = FakeUserNotificationPresenter(authorizationResult: true)
+        await presenter.seedDeliveredIdentifiers([])
+        await presenter.seedPendingIdentifiers([])
+        try await mutator.mutate { state in
+            state.notificationMutationSequence = 5
+            state.pendingOrphanNotifications = [
+                // Legacy: queued but no osIdentifierSequence.
+                PendingOrphanNotification(
+                    sessionUUID: Self.session1, reason: "orphan",
+                    notifiedAt: Date(timeIntervalSince1970: 1_715_000_000),
+                    deliveryState: "queued", mutationSequence: 5,
+                    osIdentifierSequence: nil),
+                // Fully-versioned: queued with osIdentifierSequence
+                // — must be left alone.
+                PendingOrphanNotification(
+                    sessionUUID: Self.session2, reason: "conflict",
+                    notifiedAt: Date(timeIntervalSince1970: 1_715_000_000),
+                    deliveryState: "queued", mutationSequence: 5,
+                    osIdentifierSequence: 5),
+                // Already in retry state — must be left alone (it's
+                // already enrolled in the retry loop).
+                PendingOrphanNotification(
+                    sessionUUID: Self.session3, reason: "orphan",
+                    notifiedAt: Date(timeIntervalSince1970: 1_715_000_000),
+                    deliveryState: "denied", mutationSequence: 5,
+                    osIdentifierSequence: nil),
+            ]
+        }
+        let center = makeCenter(presenter: presenter)
+
+        await center.cleanupLegacyOSNotifications()
+
+        let state = try stateStore.load()
+        let bySession = Dictionary(
+            uniqueKeysWithValues: state.pendingOrphanNotifications.map {
+                ($0.sessionUUID, $0)
+            })
+        XCTAssertEqual(bySession[Self.session1]?.deliveryState, "failed",
+                       "legacy queued entry without osIdentifierSequence must be downgraded")
+        XCTAssertGreaterThan(bySession[Self.session1]?.mutationSequence ?? 0, 5,
+                             "downgrade must bump mutationSequence to refresh the race guard")
+        XCTAssertEqual(bySession[Self.session2]?.deliveryState, "queued",
+                       "versioned queued entry must be left alone")
+        XCTAssertEqual(bySession[Self.session2]?.osIdentifierSequence, 5,
+                       "versioned queued entry's osIdentifierSequence must be preserved")
+        XCTAssertEqual(bySession[Self.session3]?.deliveryState, "denied",
+                       "non-queued entries must be left alone (already retrying)")
+    }
+
+    /// Entries written by builds older than sequencing itself
+    /// decode with mutationSequence=0. Treat these as legacy too —
+    /// the OS notification (if any) was minted with the unversioned
+    /// scheme and the legacy-id sweep just removed it.
+    func testCleanupLegacyOSNotificationsDowngradesEntriesWithZeroSequence() async throws {
+        let presenter = FakeUserNotificationPresenter(authorizationResult: true)
+        await presenter.seedDeliveredIdentifiers([])
+        await presenter.seedPendingIdentifiers([])
+        try await mutator.mutate { state in
+            state.notificationMutationSequence = 0
+            state.pendingOrphanNotifications = [
+                PendingOrphanNotification(
+                    sessionUUID: Self.session1, reason: "orphan",
+                    notifiedAt: Date(timeIntervalSince1970: 1_715_000_000),
+                    deliveryState: "queued", mutationSequence: 0,
+                    osIdentifierSequence: nil),
+            ]
+        }
+        let center = makeCenter(presenter: presenter)
+
+        await center.cleanupLegacyOSNotifications()
+
+        let state = try stateStore.load()
+        XCTAssertEqual(state.pendingOrphanNotifications.count, 1)
+        XCTAssertEqual(state.pendingOrphanNotifications[0].deliveryState, "failed")
     }
 }

--- a/mac-daemon/Tests/CRMMacOrphanNotificationsTests/OrphanNotificationCenterTests.swift
+++ b/mac-daemon/Tests/CRMMacOrphanNotificationsTests/OrphanNotificationCenterTests.swift
@@ -720,15 +720,33 @@ final class OrphanNotificationCenterTests: XCTestCase {
     /// never disappear.
     func testCleanupLegacyOSNotificationsRemovesUnversionedIDs() async throws {
         let presenter = FakeUserNotificationPresenter(authorizationResult: true)
+        // Seed persisted state with two entries whose
+        // osIdentifierSequence matches versioned OS ids that
+        // should be PRESERVED (they're tracked).
+        try await mutator.mutate { state in
+            state.notificationMutationSequence = 9
+            state.pendingOrphanNotifications = [
+                PendingOrphanNotification(
+                    sessionUUID: Self.session2, reason: "conflict",
+                    notifiedAt: Date(timeIntervalSince1970: 1_715_000_000),
+                    deliveryState: "queued", mutationSequence: 4,
+                    osIdentifierSequence: 4),
+                PendingOrphanNotification(
+                    sessionUUID: Self.session2, reason: "orphan",
+                    notifiedAt: Date(timeIntervalSince1970: 1_715_000_000),
+                    deliveryState: "queued", mutationSequence: 9,
+                    osIdentifierSequence: 9),
+            ]
+        }
         await presenter.seedDeliveredIdentifiers([
-            "orphan:\(Self.session1)",
-            "conflict:\(Self.session2):4",            // versioned — keep
-            "orphan:\(Self.session3)",
+            "orphan:\(Self.session1)",                // unversioned — ghost
+            "conflict:\(Self.session2):4",            // tracked — keep
+            "orphan:\(Self.session3)",                // unversioned — ghost
             "crm-mac-prod-presenter-test-xyz",        // unrelated — keep
         ])
         await presenter.seedPendingIdentifiers([
-            "conflict:\(Self.session1)",
-            "orphan:\(Self.session2):9",              // versioned — keep
+            "conflict:\(Self.session1)",              // unversioned — ghost
+            "orphan:\(Self.session2):9",              // tracked — keep
         ])
         let center = makeCenter(presenter: presenter)
 
@@ -739,13 +757,30 @@ final class OrphanNotificationCenterTests: XCTestCase {
         XCTAssertEqual(removedDelivered.count, 1)
         XCTAssertEqual(Set(removedDelivered[0]),
                        Set(["orphan:\(Self.session1)", "orphan:\(Self.session3)"]),
-                       "only unversioned orphan/conflict ids should be swept")
+                       "only unversioned (or otherwise untracked) orphan/conflict ids should be swept")
         XCTAssertEqual(removedPending.count, 1)
         XCTAssertEqual(removedPending[0], ["conflict:\(Self.session1)"])
     }
 
-    func testCleanupLegacyOSNotificationsIsNoOpWhenNothingLegacy() async throws {
+    func testCleanupLegacyOSNotificationsIsNoOpWhenAllVersionedAndTracked() async throws {
         let presenter = FakeUserNotificationPresenter(authorizationResult: true)
+        // Seed persisted state so the versioned OS ids below are
+        // recognized as tracked (not ghosts).
+        try await mutator.mutate { state in
+            state.notificationMutationSequence = 2
+            state.pendingOrphanNotifications = [
+                PendingOrphanNotification(
+                    sessionUUID: Self.session1, reason: "orphan",
+                    notifiedAt: Date(timeIntervalSince1970: 1_715_000_000),
+                    deliveryState: "queued", mutationSequence: 1,
+                    osIdentifierSequence: 1),
+                PendingOrphanNotification(
+                    sessionUUID: Self.session2, reason: "conflict",
+                    notifiedAt: Date(timeIntervalSince1970: 1_715_000_000),
+                    deliveryState: "queued", mutationSequence: 2,
+                    osIdentifierSequence: 2),
+            ]
+        }
         await presenter.seedDeliveredIdentifiers([
             "orphan:\(Self.session1):1",
             "conflict:\(Self.session2):2",
@@ -823,26 +858,52 @@ final class OrphanNotificationCenterTests: XCTestCase {
 
     // MARK: - TC-OC30: reentrant raise guard
 
-    /// Reentrancy regression. With the new persist-failed-first
-    /// flow, a concurrent consume() that lands at the same key
-    /// after the pre-add persist (which marks 'failed') but before
-    /// the OS call returns must NOT start a parallel raise — the
-    /// in-actor `raisesInFlight` guard skips it. Without the guard,
-    /// both raises would queue OS notifications with consecutive
+    /// Reentrancy regression. With the persist-failed-first flow,
+    /// a concurrent consume() that lands at the same key after the
+    /// pre-add persist (which marks 'failed') but before the OS
+    /// call returns must NOT start a parallel raise — the in-actor
+    /// `raisesInFlight` guard skips it. Without the guard, both
+    /// raises would queue OS notifications with consecutive
     /// sequence numbers and only the last confirmed sequence would
     /// be tracked, leaving an orphaned OS notification.
     ///
-    /// We can't deterministically interleave two awaits on the
-    /// same actor, so we use the FakeUserNotificationPresenter's
-    /// recording semantics: a fast-firing consume that lands while
-    /// another raise is mid-flight must be skipped, leaving exactly
-    /// one OS add call per key per logical raise.
-    ///
-    /// The looser invariant test: starting two consume(...) calls
-    /// for the same key back-to-back should produce exactly one OS
-    /// raise, not two (the second observes 'queued' or in-flight
-    /// and skips).
-    func testConsecutiveConsumesForSameKeyProduceSingleRaise() async throws {
+    /// Run multiple consume() calls concurrently via TaskGroup. The
+    /// FakeUserNotificationPresenter's `add(_:)` is an `await` on
+    /// its own actor, so concurrent center.consume(...) tasks can
+    /// interleave at that suspension point — exactly the reentrancy
+    /// window the guard protects against.
+    func testConcurrentConsumesForSameKeyDedupViaInFlightGuard() async throws {
+        let presenter = FakeUserNotificationPresenter(authorizationResult: true)
+        let center = makeCenter(presenter: presenter)
+        let item = NotificationConsumeItem(sessionID: Self.session1, reason: "orphan")
+        let centerRef = center
+        let itemRef = item
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<8 {
+                group.addTask {
+                    await centerRef.consume(needsAttention: [itemRef])
+                }
+            }
+        }
+        let calls = await presenter.recordedAddCalls()
+        XCTAssertEqual(calls.count, 1,
+            "concurrent consumes for the same (reason, session) must dedup to a single raise")
+        // Verify state is internally consistent: exactly one entry,
+        // queued, with an osIdentifierSequence that matches the
+        // single OS-side raise.
+        let state = try stateStore.load()
+        XCTAssertEqual(state.pendingOrphanNotifications.count, 1)
+        XCTAssertEqual(state.pendingOrphanNotifications[0].deliveryState, "queued")
+        XCTAssertNotNil(state.pendingOrphanNotifications[0].osIdentifierSequence)
+        let osSeq = state.pendingOrphanNotifications[0].osIdentifierSequence!
+        XCTAssertEqual(calls[0].identifier, "orphan:\(Self.session1):\(osSeq)")
+    }
+
+    /// Sequential consumes for the same key after the first one
+    /// confirmed 'queued' should also dedup — the entry is now
+    /// queued, so raiseIfNotAlreadyQueued short-circuits before
+    /// the in-flight guard even comes into play.
+    func testSequentialConsumesAfterFirstQueuedDedupViaQueuedShortCircuit() async throws {
         let presenter = FakeUserNotificationPresenter(authorizationResult: true)
         let center = makeCenter(presenter: presenter)
         let item = NotificationConsumeItem(sessionID: Self.session1, reason: "orphan")
@@ -851,7 +912,48 @@ final class OrphanNotificationCenterTests: XCTestCase {
         await center.consume(needsAttention: [item])
         let calls = await presenter.recordedAddCalls()
         XCTAssertEqual(calls.count, 1,
-            "subsequent consumes for the same (reason, session) must dedup against the first raise")
+            "subsequent consumes for the same (reason, session) must dedup against the queued entry")
+    }
+
+    // MARK: - TC-OC31: crash-orphaned versioned ids are swept
+
+    /// Daemon crash window: presenter.add succeeded (OS has the
+    /// versioned notification) but confirmPostAdd never ran, so
+    /// persisted state retains the pre-add 'failed' entry with
+    /// osIdentifierSequence=nil. On restart, the startup sweep
+    /// must remove the orphaned versioned OS notification (no
+    /// persisted entry references its sequence), otherwise a
+    /// reconcile re-raise would queue a SECOND versioned id
+    /// alongside the first and the orphan would never be cleaned.
+    func testCleanupLegacyOSNotificationsRemovesCrashOrphanedVersionedIDs() async throws {
+        let presenter = FakeUserNotificationPresenter(authorizationResult: true)
+        try await mutator.mutate { state in
+            state.notificationMutationSequence = 4
+            state.pendingOrphanNotifications = [
+                // Crash-window survivor: pre-add persist landed
+                // ('failed'), OS add succeeded, but confirm never
+                // wrote the osIdentifierSequence.
+                PendingOrphanNotification(
+                    sessionUUID: Self.session1, reason: "orphan",
+                    notifiedAt: Date(timeIntervalSince1970: 1_715_000_000),
+                    deliveryState: "failed", mutationSequence: 4,
+                    osIdentifierSequence: nil),
+            ]
+        }
+        // The OS still has the versioned notification from before
+        // the crash. Persisted state doesn't know about it.
+        await presenter.seedDeliveredIdentifiers([
+            "orphan:\(Self.session1):4",
+        ])
+        await presenter.seedPendingIdentifiers([])
+        let center = makeCenter(presenter: presenter)
+
+        await center.cleanupLegacyOSNotifications()
+
+        let removedDelivered = await presenter.recordedRemoveDelivered()
+        XCTAssertEqual(removedDelivered.count, 1,
+            "crash-orphaned versioned id must be swept")
+        XCTAssertEqual(removedDelivered[0], ["orphan:\(Self.session1):4"])
     }
 
     /// Entries written by builds older than sequencing itself

--- a/mac-daemon/Tests/CRMMacOrphanNotificationsTests/OrphanNotificationCenterTests.swift
+++ b/mac-daemon/Tests/CRMMacOrphanNotificationsTests/OrphanNotificationCenterTests.swift
@@ -821,6 +821,39 @@ final class OrphanNotificationCenterTests: XCTestCase {
                        "non-queued entries must be left alone (already retrying)")
     }
 
+    // MARK: - TC-OC30: reentrant raise guard
+
+    /// Reentrancy regression. With the new persist-failed-first
+    /// flow, a concurrent consume() that lands at the same key
+    /// after the pre-add persist (which marks 'failed') but before
+    /// the OS call returns must NOT start a parallel raise — the
+    /// in-actor `raisesInFlight` guard skips it. Without the guard,
+    /// both raises would queue OS notifications with consecutive
+    /// sequence numbers and only the last confirmed sequence would
+    /// be tracked, leaving an orphaned OS notification.
+    ///
+    /// We can't deterministically interleave two awaits on the
+    /// same actor, so we use the FakeUserNotificationPresenter's
+    /// recording semantics: a fast-firing consume that lands while
+    /// another raise is mid-flight must be skipped, leaving exactly
+    /// one OS add call per key per logical raise.
+    ///
+    /// The looser invariant test: starting two consume(...) calls
+    /// for the same key back-to-back should produce exactly one OS
+    /// raise, not two (the second observes 'queued' or in-flight
+    /// and skips).
+    func testConsecutiveConsumesForSameKeyProduceSingleRaise() async throws {
+        let presenter = FakeUserNotificationPresenter(authorizationResult: true)
+        let center = makeCenter(presenter: presenter)
+        let item = NotificationConsumeItem(sessionID: Self.session1, reason: "orphan")
+        await center.consume(needsAttention: [item])
+        await center.consume(needsAttention: [item])
+        await center.consume(needsAttention: [item])
+        let calls = await presenter.recordedAddCalls()
+        XCTAssertEqual(calls.count, 1,
+            "subsequent consumes for the same (reason, session) must dedup against the first raise")
+    }
+
     /// Entries written by builds older than sequencing itself
     /// decode with mutationSequence=0. Treat these as legacy too —
     /// the OS notification (if any) was minted with the unversioned

--- a/mac-daemon/Tests/CRMMacOrphanNotificationsTests/PureHelpersTests.swift
+++ b/mac-daemon/Tests/CRMMacOrphanNotificationsTests/PureHelpersTests.swift
@@ -27,15 +27,17 @@ final class PureHelpersTests: XCTestCase {
     func testIdentifierForOrphan() {
         XCTAssertEqual(
             notificationIdentifier(reason: "orphan",
-                                   sessionUUID: "deadbeef-1111-2222-3333-444455556666"),
-            "orphan:deadbeef-1111-2222-3333-444455556666")
+                                   sessionUUID: "deadbeef-1111-2222-3333-444455556666",
+                                   sequence: 7),
+            "orphan:deadbeef-1111-2222-3333-444455556666:7")
     }
 
     func testIdentifierForConflict() {
         XCTAssertEqual(
             notificationIdentifier(reason: "conflict",
-                                   sessionUUID: "deadbeef-1111-2222-3333-444455556666"),
-            "conflict:deadbeef-1111-2222-3333-444455556666")
+                                   sessionUUID: "deadbeef-1111-2222-3333-444455556666",
+                                   sequence: 42),
+            "conflict:deadbeef-1111-2222-3333-444455556666:42")
     }
 
     func testIdentifierDistinctAcrossReasons() {
@@ -45,8 +47,50 @@ final class PureHelpersTests: XCTestCase {
         // the OS replaces an orphan with a conflict (or vice
         // versa) silently.
         XCTAssertNotEqual(
-            notificationIdentifier(reason: "orphan", sessionUUID: uuid),
-            notificationIdentifier(reason: "conflict", sessionUUID: uuid))
+            notificationIdentifier(reason: "orphan", sessionUUID: uuid, sequence: 1),
+            notificationIdentifier(reason: "conflict", sessionUUID: uuid, sequence: 1))
+    }
+
+    func testIdentifierDistinctAcrossSequencesForSameReasonAndSession() {
+        // Critical invariant for the reconcile-vs-consume race fix:
+        // two different mutationSequence values for the same
+        // (reason, sessionUUID) MUST produce distinct identifiers,
+        // so a stale-remove targeting sequence N cannot collaterally
+        // strip a freshly-raised notification at sequence N+1.
+        let uuid = "deadbeef-1111-2222-3333-444455556666"
+        XCTAssertNotEqual(
+            notificationIdentifier(reason: "orphan", sessionUUID: uuid, sequence: 5),
+            notificationIdentifier(reason: "orphan", sessionUUID: uuid, sequence: 6))
+    }
+
+    // MARK: - isLegacyNotificationIdentifier
+
+    func testLegacyIdentifierDetectionForOrphan() {
+        XCTAssertTrue(isLegacyNotificationIdentifier(
+            "orphan:deadbeef-1111-2222-3333-444455556666"))
+    }
+
+    func testLegacyIdentifierDetectionForConflict() {
+        XCTAssertTrue(isLegacyNotificationIdentifier(
+            "conflict:deadbeef-1111-2222-3333-444455556666"))
+    }
+
+    func testVersionedIdentifierIsNotLegacy() {
+        // The new scheme has three colon-separated components.
+        XCTAssertFalse(isLegacyNotificationIdentifier(
+            "orphan:deadbeef-1111-2222-3333-444455556666:1"))
+        XCTAssertFalse(isLegacyNotificationIdentifier(
+            "conflict:deadbeef-1111-2222-3333-444455556666:99"))
+    }
+
+    func testUnrelatedIdentifierIsNotLegacy() {
+        // Other identifier prefixes (or arbitrary strings) must
+        // never be treated as legacy orphan/conflict ids.
+        XCTAssertFalse(isLegacyNotificationIdentifier(
+            "crm-mac-prod-presenter-test-deadbeef"))
+        XCTAssertFalse(isLegacyNotificationIdentifier("foo:bar"))
+        XCTAssertFalse(isLegacyNotificationIdentifier(""))
+        XCTAssertFalse(isLegacyNotificationIdentifier("orphan"))
     }
 
     // MARK: - clickTargetURL

--- a/mac-daemon/Tests/CRMMacOrphanNotificationsTests/SmokeTests.swift
+++ b/mac-daemon/Tests/CRMMacOrphanNotificationsTests/SmokeTests.swift
@@ -99,7 +99,7 @@ final class SmokeTests: XCTestCase {
         let calls = await fakePresenter.recordedAddCalls()
         XCTAssertEqual(calls.count, 1, "exactly one notification should be queued")
         let request = calls[0]
-        XCTAssertEqual(request.identifier, "orphan:\(Self.session1)")
+        XCTAssertEqual(request.identifier, "orphan:\(Self.session1):1")
         XCTAssertEqual(request.title, "Untagged session")
         XCTAssertTrue(request.body.contains("Tag participants in Anarlog"))
         XCTAssertTrue(request.body.contains("Synthetic Smoke Session"))
@@ -162,18 +162,22 @@ final class SmokeTests: XCTestCase {
 
         await center.reconcile()
 
-        // One add for Self.session3 (new).
+        // One add for Self.session3 (new). The snapshot's sequence
+        // was 2; the new upsert increments to 3.
         let adds = await presenter.recordedAddCalls()
         XCTAssertEqual(adds.count, 1)
-        XCTAssertEqual(adds[0].identifier, "orphan:\(Self.session3)")
+        XCTAssertEqual(adds[0].identifier, "orphan:\(Self.session3):3")
 
-        // One delivered + one pending removal for Self.session2 (stale).
+        // One delivered + one pending removal for Self.session2
+        // (stale). The remove identifier carries the ENTRY's
+        // mutationSequence (2 from the seed), not the snapshot's
+        // sequence — see OrphanNotificationCenter.removeNotificationIfStale.
         let removedDelivered = await presenter.recordedRemoveDelivered()
         let removedPending = await presenter.recordedRemovePending()
         XCTAssertEqual(removedDelivered.count, 1)
-        XCTAssertEqual(removedDelivered[0], ["orphan:\(Self.session2)"])
+        XCTAssertEqual(removedDelivered[0], ["orphan:\(Self.session2):2"])
         XCTAssertEqual(removedPending.count, 1)
-        XCTAssertEqual(removedPending[0], ["orphan:\(Self.session2)"])
+        XCTAssertEqual(removedPending[0], ["orphan:\(Self.session2):2"])
 
         let state = try stateStore.load()
         let keys = Set(state.pendingOrphanNotifications.map {

--- a/mac-daemon/Tests/CRMMacOrphanNotificationsTests/SmokeTests.swift
+++ b/mac-daemon/Tests/CRMMacOrphanNotificationsTests/SmokeTests.swift
@@ -54,7 +54,8 @@ final class SmokeTests: XCTestCase {
     ///
     /// This is the literal "synthesize an orphan ingest response,
     /// assert UNUserNotificationCenter has the expected request
-    /// queued" check the user requires as a PR 6 acceptance gate.
+    /// queued" check that gates acceptance of the orphan-
+    /// notification flow.
     func testOrphanIngestResponseQueuesNotification() async throws {
         let fakePresenter = FakeUserNotificationPresenter(authorizationResult: true)
         let sessionDir = URL(fileURLWithPath: "/tmp/anarlog/sessions/\(Self.session1)")
@@ -127,11 +128,13 @@ final class SmokeTests: XCTestCase {
                 PendingOrphanNotification(
                     sessionUUID: Self.session1, reason: "conflict",
                     notifiedAt: Date(timeIntervalSince1970: 1_715_000_000),
-                    deliveryState: "queued", mutationSequence: 1),
+                    deliveryState: "queued", mutationSequence: 1,
+                    osIdentifierSequence: 1),
                 PendingOrphanNotification(
                     sessionUUID: Self.session2, reason: "orphan",
                     notifiedAt: Date(timeIntervalSince1970: 1_715_000_000),
-                    deliveryState: "queued", mutationSequence: 2),
+                    deliveryState: "queued", mutationSequence: 2,
+                    osIdentifierSequence: 2),
             ]
         }
 

--- a/mac-daemon/Tests/CRMMacOrphanNotificationsTests/SmokeTests.swift
+++ b/mac-daemon/Tests/CRMMacOrphanNotificationsTests/SmokeTests.swift
@@ -173,7 +173,7 @@ final class SmokeTests: XCTestCase {
 
         // One delivered + one pending removal for Self.session2
         // (stale). The remove identifier carries the ENTRY's
-        // mutationSequence (2 from the seed), not the snapshot's
+        // osIdentifierSequence (2 from the seed), not the snapshot's
         // sequence — see OrphanNotificationCenter.removeNotificationIfStale.
         let removedDelivered = await presenter.recordedRemoveDelivered()
         let removedPending = await presenter.recordedRemovePending()

--- a/mac-daemon/Tests/CRMMacOrphanNotificationsTests/Support/FakeUserNotificationPresenter.swift
+++ b/mac-daemon/Tests/CRMMacOrphanNotificationsTests/Support/FakeUserNotificationPresenter.swift
@@ -23,6 +23,8 @@ public actor FakeUserNotificationPresenter: UserNotificationPresenter {
     public private(set) var setDelegateCalls: Int = 0
     public private(set) var requestAuthorizationCalls: Int = 0
     private var lastDelegate: DelegateRef?
+    private var seededDelivered: [String] = []
+    private var seededPending: [String] = []
 
     public init(authorizationResult: Bool = true, addError: Error? = nil) {
         self.authorizationResult = authorizationResult
@@ -35,6 +37,18 @@ public actor FakeUserNotificationPresenter: UserNotificationPresenter {
 
     public func setAddError(_ value: Error?) {
         self.addError = value
+    }
+
+    /// Seed the identifiers `getDeliveredIdentifiers()` will return —
+    /// used by the legacy-notification-sweep test to simulate
+    /// pre-versioned ids already in Notification Center.
+    public func seedDeliveredIdentifiers(_ ids: [String]) {
+        seededDelivered = ids
+    }
+
+    /// Seed the identifiers `getPendingIdentifiers()` will return.
+    public func seedPendingIdentifiers(_ ids: [String]) {
+        seededPending = ids
     }
 
     /// Test accessor — returns the recorded list of add() specs.
@@ -71,5 +85,13 @@ public actor FakeUserNotificationPresenter: UserNotificationPresenter {
     public func setDelegate(_ ref: UserNotificationDelegateRef?) async {
         setDelegateCalls += 1
         lastDelegate = ref
+    }
+
+    public func getDeliveredIdentifiers() async -> [String] {
+        seededDelivered
+    }
+
+    public func getPendingIdentifiers() async -> [String] {
+        seededPending
     }
 }

--- a/mac-daemon/Tests/CRMMacOrphanNotificationsTests/Support/FakeUserNotificationPresenter.swift
+++ b/mac-daemon/Tests/CRMMacOrphanNotificationsTests/Support/FakeUserNotificationPresenter.swift
@@ -104,7 +104,16 @@ public actor FakeUserNotificationPresenter: UserNotificationPresenter {
 
     public func add(_ spec: NotificationRequestSpec) async throws {
         addCalls.append(spec)
-        if addGateArmed {
+        // Gate only the FIRST add(_:) call after armAddGate(); any
+        // subsequent call returns immediately. This keeps the
+        // reentrancy test deterministic: if raisesInFlight regresses
+        // and a second add(_:) lands while the first is parked, it
+        // won't get stuck waiting on the same single-slot
+        // continuation — instead it returns, the test sees a second
+        // recorded call, and fails cleanly with the expected
+        // assertion mismatch.
+        if addGateArmed && addGate == nil {
+            addGateArmed = false
             addsAwaitingGate += 1
             await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
                 addGate = cont

--- a/mac-daemon/Tests/CRMMacOrphanNotificationsTests/Support/FakeUserNotificationPresenter.swift
+++ b/mac-daemon/Tests/CRMMacOrphanNotificationsTests/Support/FakeUserNotificationPresenter.swift
@@ -25,6 +25,15 @@ public actor FakeUserNotificationPresenter: UserNotificationPresenter {
     private var lastDelegate: DelegateRef?
     private var seededDelivered: [String] = []
     private var seededPending: [String] = []
+    // Gate used by the reentrancy test: when set, add(_:) parks
+    // the caller on this continuation until releaseAddGate() is
+    // called. Lets the test deterministically hold the first
+    // raise mid-flight (after the pre-add persist, before the
+    // confirmPostAdd write) and then run additional consume()
+    // calls to verify they hit the raisesInFlight guard.
+    private var addGate: CheckedContinuation<Void, Never>?
+    private var addGateArmed: Bool = false
+    private var addsAwaitingGate: Int = 0
 
     public init(authorizationResult: Bool = true, addError: Error? = nil) {
         self.authorizationResult = authorizationResult
@@ -51,6 +60,32 @@ public actor FakeUserNotificationPresenter: UserNotificationPresenter {
         seededPending = ids
     }
 
+    /// Arm the add-gate. While armed, the next add(_:) call will
+    /// suspend on a continuation; releaseAddGate() resumes it.
+    /// Used by tests to deterministically hold a raise mid-flight.
+    public func armAddGate() {
+        addGateArmed = true
+    }
+
+    /// Release a single waiter parked on the add-gate (if any) and
+    /// disarm the gate so subsequent add(_:) calls return
+    /// immediately. Idempotent and safe to call even if no waiter
+    /// is parked.
+    public func releaseAddGate() {
+        addGateArmed = false
+        if let cont = addGate {
+            addGate = nil
+            cont.resume()
+        }
+    }
+
+    /// Number of add(_:) calls currently parked on the gate. Tests
+    /// poll this to confirm the first raise is mid-flight before
+    /// kicking off the second.
+    public func addsCurrentlyAwaitingGate() -> Int {
+        addsAwaitingGate
+    }
+
     /// Test accessor — returns the recorded list of add() specs.
     public func recordedAddCalls() -> [NotificationRequestSpec] { addCalls }
 
@@ -69,6 +104,13 @@ public actor FakeUserNotificationPresenter: UserNotificationPresenter {
 
     public func add(_ spec: NotificationRequestSpec) async throws {
         addCalls.append(spec)
+        if addGateArmed {
+            addsAwaitingGate += 1
+            await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+                addGate = cont
+            }
+            addsAwaitingGate -= 1
+        }
         if let err = addError {
             throw err
         }


### PR DESCRIPTION
## Summary

Follow-up to #339. Closes the TOCTOU race in \`OrphanNotificationCenter.removeNotificationIfStale\` by versioning the OS notification identifier: \`orphan:<uuid>\` → \`orphan:<uuid>:<seq>\` (same for \`conflict:\`).

## The bug

\`removeNotificationIfStale\` would read an entry's sequence, suspend across two \`await presenter.remove*()\` calls, then re-check the persisted sequence inside the mutator closure. The persisted-state guard was correct, but the OS-side removes targeted the bare \`orphan:<uuid>\` identifier — so a concurrent \`consume()\` that landed a fresh add between the suspension points would have its OS notification stripped, even though its persisted entry was preserved. Net effect: user never saw the fresh orphan notification.

## The fix

Version the identifier so stale-remove targets \`<reason>:<uuid>:<oldseq>\` and the concurrent consume's add targets \`<reason>:<uuid>:<newseq>\` — different identifier strings, OS-side remove cannot collide with the fresh add by construction.

7 commits — Codex converged after 4 review rounds addressing edge cases the initial fix uncovered:
- Core identifier-versioning change (\`f5b7e89\`)
- Persist-before-OS-add crash window (\`e4e4a1a\`)
- Reentrant raise + confirm-persist failure guard (\`93fa35e\`)
- Startup sweep for crash-orphaned versioned identifiers AND legacy unversioned ones (\`56b52d4\`)
- Persist-before-OS ordering for the sweep itself + deterministic reentrant test (\`fa8b2d6\`)
- Single-shot add-gate to prevent test hang on regression (\`83e15ab\`)
- \`matchKey\` helper de-duplication (\`367905e\`)

## Migration

On daemon startup, a one-time sweep removes both:
- Legacy unversioned \`orphan:<uuid>\` / \`conflict:<uuid>\` notifications (left over from pre-fix daemon)
- Crash-orphaned versioned notifications whose persisted entry no longer exists

So operators upgrading don't see ghost notifications the new code can't track.

## Regression test

\`TC-OC26 testStaleRemovalIdentifierCarriesEntryRecordedSequence\` asserts the stale-remove identifier carries the entry's own \`osIdentifierSequence\`. Would fail against the pre-fix unversioned identifier scheme.

## Test plan

- [x] \`swift build\` clean
- [x] /review-head PASS at \`367905e\` (P0=0, P1=0, P2=0, P3=0)
- [x] Codex review converged across 4 rounds
- [x] Regression test exercises the race contract
- [ ] Post-merge: deploy daemon, watch Notification Center across a real orphan-then-resolved cycle to confirm no ghost notifications