### PR TITLE
feat(mac-daemon): SQLiteSnapshotReader helper + DataSourcePlugin heartbeat protocol

### DIFF
--- a/.ai/spec/mac-daemon.md
+++ b/.ai/spec/mac-daemon.md
@@ -139,7 +139,7 @@ The pairing token model means there's no admin/bootstrap key in widespread use �
 
 #### `phone_calls` (Phone + FaceTime via CallHistoryDB)
 
-- **Source:** `~/Library/Application Support/CallHistoryDB/CallHistory.storedata` (Core Data SQLite). Read-only via GRDB.swift with `?mode=ro` (NOT `immutable=1`); back-off on `SQLITE_BUSY` (the Phone/FaceTime apps hold a writer lock while a call is in progress). Unlike `chat.db` (which Messages.app checkpoints aggressively), macOS does not checkpoint CallHistoryDB's WAL on any predictable cadence — observed in production: `CallHistory.storedata` stale by days while `CallHistory.storedata-wal` is megabytes of live writes — so `immutable=1` would make the reader blind to recent calls. SQLITE_BUSY retries cover the concurrent-writer case; reopen-every-tick keeps each handle short-lived. Covers Continuity-mirrored iPhone voice calls, native macOS Phone-app calls (macOS Sequoia+), FaceTime audio, and FaceTime video — all unified in `ZCALLRECORD`.
+- **Source:** `~/Library/Application Support/CallHistoryDB/CallHistory.storedata` (Core Data SQLite). Read-only via GRDB.swift, opened through `SQLiteSnapshotReader.readOnlyURI(for:)` (the chokepoint that produces `?mode=ro`, NOT `immutable=1`); back-off on `SQLITE_BUSY` (the Phone/FaceTime apps hold a writer lock while a call is in progress). Unlike `chat.db` (which Messages.app checkpoints aggressively), macOS does not checkpoint CallHistoryDB's WAL on any predictable cadence — observed in production: `CallHistory.storedata` stale by days while `CallHistory.storedata-wal` is megabytes of live writes — so `immutable=1` would make the reader blind to recent calls. SQLITE_BUSY retries cover the concurrent-writer case; reopen-every-tick keeps each handle short-lived. Covers Continuity-mirrored iPhone voice calls, native macOS Phone-app calls (macOS Sequoia+), FaceTime audio, and FaceTime video — all unified in `ZCALLRECORD`.
 - **Cursor:** `MAX(ZDATE)` from `ZCALLRECORD` (Mac absolute time — seconds since 2001-01-01, converted to UTC at emit). Same `backfill_cursor` + `live_cursor` JSON shape as `messages`; install-time max is the live-cursor anchor.
 - **Identifier types emitted:** generic `phone` and `email`. Channel/provenance carried in `source='phone_calls'`, with the specific service (voice / facetime_audio / facetime_video) recorded in the `service` column on the `phone_call` staging row. The service enum derives from `ZSERVICE_PROVIDER` + `ZCALLTYPE` together: `com.apple.Telephony` → `voice`; `com.apple.FaceTime` + `ZCALLTYPE=8` → `facetime_audio`; `com.apple.FaceTime` + `ZCALLTYPE=16` → `facetime_video`. (`ZSERVICE_PROVIDER` alone is insufficient — empirically only two values exist on macOS Sequoia.) Rationale matches `messages`: identifier type describes identifier shape, source describes the integration; FaceTime-only handles (Apple IDs) naturally fall into `email`.
 - **Content:** per-call record — direction (`ZORIGINATED`: 1=outgoing), peer handle (`ZADDRESS`, normalized via existing `identity/normalize.go` E.164/email rules), service (derived from `ZSERVICE_PROVIDER` + `ZCALLTYPE` per above), answered (`ZANSWERED` — **reliable only for inbound**; see "connected outbound" rule below), duration in seconds (`ZDURATION`), voicemail-present flag (`ZHASMESSAGE` — macOS sets to 1 when an unanswered inbound call left a voicemail; verified empirically against a real CallHistoryDB to have zero false positives, all flagged rows being `ZANSWERED=0 ZORIGINATED=0`), call timestamp (`ZDATE`), unique ID (`ZUNIQUE_ID` — primary dedup key, globally unique per call across Continuity-paired devices). **Voicemail audio + transcripts are not stored on the Mac** — they remain on the paired iPhone; Continuity propagates only the presence flag. `ZHASMESSAGE` is therefore the only voicemail signal available to the daemon, and surfacing voicemail content (audio/transcript) on the contact timeline is explicitly out of scope until an iOS companion source exists.
@@ -170,7 +170,7 @@ The pairing token model means there's no admin/bootstrap key in widespread use �
 
 #### `whatsapp`
 
-- **Source:** `~/Library/Group Containers/group.net.whatsapp.WhatsApp.shared/` — primary DB `ChatStorage.sqlite`. Secondary: `ContactsV2.sqlite`, `ExtChatDB/ExtChatDatabase.sqlite`. Read-only via GRDB.swift with `?mode=ro` and backoff on `SQLITE_CANTOPEN`/`SQLITE_BUSY` (WhatsApp.app holds locks while running). **AUDIT before adding `immutable=1`:** validate WhatsApp's WAL-checkpoint cadence on the developer's machine first. `phone_calls` shipped with `immutable=1` and silently missed every WAL-resident write for 8+ days because macOS rarely checkpoints CallHistoryDB; WhatsApp.app may have the same pattern.
+- **Source:** `~/Library/Group Containers/group.net.whatsapp.WhatsApp.shared/` — primary DB `ChatStorage.sqlite`. Secondary: `ContactsV2.sqlite`, `ExtChatDB/ExtChatDatabase.sqlite`. Read-only via GRDB.swift and backoff on `SQLITE_CANTOPEN`/`SQLITE_BUSY` (WhatsApp.app holds locks while running). **Every live-DB open MUST go through `SQLiteSnapshotReader.readOnlyURI(for:)`** (the single chokepoint that produces the read-only WAL-aware `file://<path>?mode=ro` URI — no `immutable=1`, no `cache=shared`). NEVER add `immutable=1`: it tells SQLite to ignore the WAL and serve only the main-file snapshot, so an immutable reader silently misses every uncheckpointed write. `phone_calls` shipped with `immutable=1` and missed every WAL-resident write for 8+ days because macOS rarely checkpoints CallHistoryDB; WhatsApp.app may have the same WAL-cadence pattern, so the WAL-aware `mode=ro` shape is the correct default. Each of the multiple SQLite DBs here must route through the helper individually (the `SQLiteURILiteralGuardTests` grep enforces one `readOnlyURI(...)` call per file DB open).
 - **Cursor:** `ZWAMESSAGE.ZSORT` (monotonic integer, indexed).
 - **Identifier type emitted:** `whatsapp`. Rationale: `whatsapp` is both a `contact_method.type` (added in migration 008) and an identifier_type with dual-mapping behavior (matches `contact_method.whatsapp` AND `contact_method.phone`). Functional matching difference vs generic `phone` — preserves matches against contacts that have explicitly tagged WhatsApp methods.
 - **Content:** message body (`ZWAMESSAGE.ZTEXT`), `ZSTANZAID` (server-side message ID — primary dedup key across hosts), chat JID, sender JID, `ZISFROMME`, group membership via `ZWAGROUPMEMBER`, media type tag from `ZWAMEDIAITEM.ZMEDIATYPE`. Optional media metadata: filename, size, no content.
@@ -745,6 +745,7 @@ v1 ships across 8 PRs. PRs 1-5 are Pi-side (Go); PRs 6-8 are Mac-side (Swift). E
   }
   ```
 - `SourceContext` carries Pi client, cursor read/write, logger.
+- **Data sources conform to `DataSourcePlugin`, a sub-protocol of `SourcePlugin`** (added later). `DataSourcePlugin` requires `mutator`/`clock`/`logger` + a `performTick()` hook; its protocol extension provides the `tick()` witness that auto-persists the per-tick liveness heartbeat (`state.sources[id].lastScheduledAt`) before delegating to `performTick()`, so a data plugin cannot forget the on-disk heartbeat. Conformers implement `performTick()` ONLY — declaring a concrete `tick()` would shadow the extension default and silently disable the heartbeat (enforced by the conformance suite + a `func tick(`-ban grep). Operational loops (`HeartbeatLoop`, the notification reconcile loop) stay on the bare `SourcePlugin`. The bare snippet above is the base contract; the in-tree `SourcePlugin` shipped as `id`/`tickInterval`/`tick()`.
 
 **CI:**
 - New `mac-daemon-tests` job inside `.github/workflows/ci.yml` on `macos-15` (pinned).
@@ -780,7 +781,7 @@ Anchor only; full scope brainstormed before PR7 kicks off.
 - Live cursor (event-stream tail) + 30-day backwards scan on newly-known identifiers.
 - Backfill to 2026-01-01.
 - Event publishing: `raw_message.received` / `raw_message.sent` to `POST /api/v1/ingest/events`.
-- Conforms `MessagesSource` to `SourcePlugin` from PR6.
+- Conforms `MessagesSource` to `DataSourcePlugin` (the heartbeat-persisting sub-protocol of `SourcePlugin` from PR6).
 - Pi-side bits already merged in PR2/PR3/PR4.
 
 ##### PR8 — `icloud_contacts` source
@@ -791,7 +792,7 @@ Anchor only; full scope brainstormed before PR8 kicks off.
 - Container allowlist picker UX in `crm-mac install` and `crm-mac configure`.
 - Token expiration → full resync + tombstone reconciliation.
 - Event publishing: `external_contact.upserted` / `external_contact.deleted` to `POST /api/v1/ingest/events`.
-- Conforms `ICloudContactsSource` to `SourcePlugin` from PR6.
+- Conforms `ICloudContactsSource` to `DataSourcePlugin` (the heartbeat-persisting sub-protocol of `SourcePlugin` from PR6).
 - Pi-side bits already merged in PR5.
 
 ### v1.5 — Phone & FaceTime call history
@@ -799,14 +800,14 @@ Anchor only; full scope brainstormed before PR8 kicks off.
 Small follow-on to v1 that reuses every cross-cutting concern v1 paid for (FDA permission, pairing, `MacHostAuthMiddleware`, ingest-service inline-event pattern from `meeting_note`/`external_contact`, `known-identifiers` filter, push-strategy provider scheduling, Mac settings page). Adds one Swift source reader, one staging table, one set of event kinds, one migration. No aggregator changes (calls are 1:1 with interactions; no burst-windowing).
 
 **Daemon:**
-- Swift `PhoneCalls` reader (GRDB.swift, read-only): opens `~/Library/Application Support/CallHistoryDB/CallHistory.storedata` with `?mode=ro` (NOT `immutable=1` — macOS does not checkpoint CallHistoryDB's WAL frequently, so an immutable reader would miss days of calls); back-off on `SQLITE_BUSY`.
+- Swift `PhoneCalls` reader (GRDB.swift, read-only): opens `~/Library/Application Support/CallHistoryDB/CallHistory.storedata` through `SQLiteSnapshotReader.readOnlyURI(for:)` (`?mode=ro`, NOT `immutable=1` — macOS does not checkpoint CallHistoryDB's WAL frequently, so an immutable reader would miss days of calls); back-off on `SQLITE_BUSY`.
 - Schema validation via `PRAGMA table_info` on `ZCALLRECORD` at startup; mark reader unhealthy on column-name drift. Required columns at minimum: `ZUNIQUE_ID`, `ZDATE`, `ZADDRESS`, `ZORIGINATED`, `ZANSWERED`, `ZDURATION`, `ZSERVICE_PROVIDER`, `ZCALLTYPE`, `ZHASMESSAGE`. The reader must explicitly check `ZHASMESSAGE` is present (voicemail semantics depend on it) and refuse to start if missing (Phone/FaceTime DB has migrated in past macOS releases — defence-in-depth).
 - Cursor: `MAX(ZDATE)` from `ZCALLRECORD`. Same `backfill_cursor` + `live_cursor` JSON shape as `messages`.
 - Backfill to 2026-01-01.
 - Reuses the daemon-side `known-identifiers` filter + 30-day backwards-scan logic from v1's `messages` source (extract into a shared helper if not already factored out in PR7).
 - Service enum derivation: `ZSERVICE_PROVIDER + ZCALLTYPE` together — see source description above. Reader must reject unknown combinations with a structured warning rather than silently emitting a wrong service tag.
 - Event publishing: `call.received` / `call.sent` to `POST /api/v1/ingest/events`. Payload includes `has_voicemail` (`ZHASMESSAGE`), `answered` (`ZANSWERED`, inbound only), `duration_seconds` (`ZDURATION`), `service`, `direction`, `started_at`, `peer_handle`, `peer_normalized`, `call_unique_id`. All inbound rows that survive the known-identifiers filter are forwarded — including missed-no-voicemail — so the Pi can decide interaction creation centrally rather than the daemon embedding cadence policy.
-- Conforms `PhoneCallsSource` to `SourcePlugin` from PR6.
+- Conforms `PhoneCallsSource` to `DataSourcePlugin` (the heartbeat-persisting sub-protocol of `SourcePlugin` from PR6).
 
 **Pi backend:**
 - New `phone_call` staging table (globally unique on `call_unique_id`, `interaction_id` nullable).

--- a/mac-daemon/Package.swift
+++ b/mac-daemon/Package.swift
@@ -181,5 +181,21 @@ let package = Package(
                                    "CRMMacOrphanNotifications"]),
         .testTarget(name: "CRMMacOrphanNotificationsTests",
                     dependencies: ["CRMMacOrphanNotifications", "CRMMacPiClient"]),
+        // Cross-cutting conformance suite for DataSourcePlugin. Depends
+        // on the four source LIBRARY targets (Anarlog houses BOTH the
+        // humans + sessions plugins) plus Core/PiClient, and
+        // OrphanNotifications (a transitive dep of CRMMacAnarlogSource —
+        // SwiftPM does not propagate transitive deps to test targets, so
+        // list it explicitly, mirroring CRMMacAnarlogSourceTests).
+        .testTarget(name: "CRMMacConformanceTests",
+                    dependencies: [
+                        "CRMMacCore",
+                        "CRMMacPiClient",
+                        "CRMMacMessagesSource",
+                        "CRMMacPhoneCallsSource",
+                        "CRMMacIcloudContactsSource",
+                        "CRMMacAnarlogSource",
+                        "CRMMacOrphanNotifications",
+                    ]),
     ]
 )

--- a/mac-daemon/Sources/CRMMacAnarlogSource/AnarlogHumansSourcePlugin.swift
+++ b/mac-daemon/Sources/CRMMacAnarlogSource/AnarlogHumansSourcePlugin.swift
@@ -147,19 +147,22 @@ struct AnarlogTickRoute: Equatable {
     }
 }
 
-public actor AnarlogHumansSourcePlugin: SourcePlugin {
+public actor AnarlogHumansSourcePlugin: DataSourcePlugin {
     public nonisolated let id: SourceID = .anarlogHumans
     public nonisolated let tickInterval: TimeInterval
 
     private let piClient: PiClient
     private let auth: PiAuth
-    private let mutator: StateMutator
+    // nonisolated: read by the DataSourcePlugin extension's tick() from
+    // a nonisolated context. Sound because all three are immutable lets
+    // holding Sendable values (same pattern as `id`/`tickInterval`).
+    public nonisolated let mutator: StateMutator
     private let publisher: AnarlogHumansPublisher
     private let filesystem: AnarlogFilesystem
     private let configSource: AnarlogConfigSource
     private let healthRegistry: SourceHealthRegistry
-    private let logger: LoggerProtocol
-    private let clock: @Sendable () -> Date
+    public nonisolated let logger: LoggerProtocol
+    public nonisolated let clock: @Sendable () -> Date
 
     public init(
         tickInterval: TimeInterval = CRMMacAnarlogSource.humansTickInterval,
@@ -185,13 +188,18 @@ public actor AnarlogHumansSourcePlugin: SourcePlugin {
         self.clock = clock
     }
 
-    public func tick() async throws {
+    public func performTick() async throws {
         try await runTick()
     }
 
     private func runTick() async throws {
+        // The DataSourcePlugin extension already bumped state.json
+        // `lastScheduledAt` via `clock()` before performTick() ran.
+        // This `clock()` read feeds the in-memory heartbeat-payload
+        // registry snapshot; with a fixed test clock the two reads are
+        // equal, and in production the sub-ms drift is irrelevant for a
+        // coarse liveness timestamp.
         let tickStart = clock()
-        await updateScheduled(at: tickStart)
         await healthRegistry.update(
             id, healthSnapshot(enabled: true, lastScheduled: tickStart))
 
@@ -628,20 +636,6 @@ public actor AnarlogHumansSourcePlugin: SourcePlugin {
     }
 
     // MARK: - state mutators
-
-    private func updateScheduled(at date: Date) async {
-        do {
-            try await mutator.mutate { state in
-                var src = state.sources[self.id.rawValue] ?? SourceState()
-                src.lastScheduledAt = date
-                state.sources[self.id.rawValue] = src
-            }
-        } catch {
-            logger.warning("anarlog_humans tick: lastScheduledAt mutate failed", metadata: [
-                "error": .private(String(describing: error)),
-            ])
-        }
-    }
 
     private func commitCleanTick(
         cursor: String,

--- a/mac-daemon/Sources/CRMMacAnarlogSource/AnarlogSessionsSourcePlugin.swift
+++ b/mac-daemon/Sources/CRMMacAnarlogSource/AnarlogSessionsSourcePlugin.swift
@@ -23,20 +23,23 @@ import CRMMacCore
 import CRMMacOrphanNotifications
 import CRMMacPiClient
 
-public actor AnarlogSessionsSourcePlugin: SourcePlugin {
+public actor AnarlogSessionsSourcePlugin: DataSourcePlugin {
     public nonisolated let id: SourceID = .anarlogSessions
     public nonisolated let tickInterval: TimeInterval
 
     private let piClient: PiClient
     private let auth: PiAuth
-    private let mutator: StateMutator
+    // nonisolated: read by the DataSourcePlugin extension's tick() from
+    // a nonisolated context. Sound because all three are immutable lets
+    // holding Sendable values (same pattern as `id`/`tickInterval`).
+    public nonisolated let mutator: StateMutator
     private let publisher: AnarlogSessionsPublisher
     private let filesystem: AnarlogFilesystem
     private let configSource: AnarlogConfigSource
     private let healthRegistry: SourceHealthRegistry
     private let orphanNotificationCenter: OrphanNotificationCenter?
-    private let logger: LoggerProtocol
-    private let clock: @Sendable () -> Date
+    public nonisolated let logger: LoggerProtocol
+    public nonisolated let clock: @Sendable () -> Date
 
     // In-flight coalescing.
     private var tickInFlight: Bool = false
@@ -68,12 +71,19 @@ public actor AnarlogSessionsSourcePlugin: SourcePlugin {
         self.clock = clock
     }
 
-    public func tick() async throws {
+    public func performTick() async throws {
         // In-flight coalescing. The actor's serial mailbox
         // already prevents concurrent tick() bodies; this loop
         // additionally absorbs MULTIPLE pending requests while a tick
         // is running so the next tick fires exactly once after the
         // current one finishes.
+        //
+        // The DataSourcePlugin extension bumps state.json
+        // `lastScheduledAt` once per scheduler fire that enters tick()
+        // (BEFORE this method runs) — including a coalesced fire that
+        // only sets `pendingRequest` and early-returns below. That is
+        // strictly more liveness signal than before (every fire now
+        // records a state.json timestamp) and never less.
         if tickInFlight {
             pendingRequest = true
             return
@@ -87,8 +97,13 @@ public actor AnarlogSessionsSourcePlugin: SourcePlugin {
     }
 
     private func runTick() async throws {
+        // The DataSourcePlugin extension already bumped state.json
+        // `lastScheduledAt` via `clock()` before performTick() ran.
+        // This `clock()` read feeds the in-memory heartbeat-payload
+        // registry snapshot; with a fixed test clock the two reads are
+        // equal, and in production the sub-ms drift is irrelevant for a
+        // coarse liveness timestamp.
         let tickStart = clock()
-        await updateScheduled(at: tickStart)
         await healthRegistry.update(
             id, healthSnapshot(enabled: true, lastScheduled: tickStart))
 
@@ -665,20 +680,6 @@ public actor AnarlogSessionsSourcePlugin: SourcePlugin {
     }
 
     // MARK: - state mutators
-
-    private func updateScheduled(at date: Date) async {
-        do {
-            try await mutator.mutate { state in
-                var src = state.sources[self.id.rawValue] ?? SourceState()
-                src.lastScheduledAt = date
-                state.sources[self.id.rawValue] = src
-            }
-        } catch {
-            logger.warning("anarlog_sessions tick: lastScheduledAt mutate failed", metadata: [
-                "error": .private(String(describing: error)),
-            ])
-        }
-    }
 
     private func commitCleanTick(
         cursor: String,

--- a/mac-daemon/Sources/CRMMacCore/SQLiteSnapshotReader.swift
+++ b/mac-daemon/Sources/CRMMacCore/SQLiteSnapshotReader.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Owns the canonical read-only SQLite URI shape for every live macOS
+/// DB the daemon tails (chat.db, CallHistoryDB, and future WhatsApp).
+///
+/// The load-bearing invariant is the ABSENCE of `immutable=1`. Live
+/// macOS DBs are continuously written in WAL mode and macOS does not
+/// checkpoint them on any predictable cadence (CallHistoryDB has been
+/// observed stale by days while its -wal sidecar held megabytes of live
+/// writes). `immutable=1` tells SQLite to ignore the WAL and serve only
+/// the main-file snapshot, so an immutable reader silently misses every
+/// uncheckpointed write. `mode=ro` is WAL-aware and is the only flag we
+/// need.
+///
+/// We deliberately do NOT append `cache=shared`: GRDB only honours it
+/// for in-memory databases, and for a file-backed read-only
+/// DatabasePool (multiple connections) it is a no-op-to-harmful flag.
+/// `mode=ro`'s WAL-awareness — not a shared page cache — is what makes
+/// uncheckpointed writes visible.
+public enum SQLiteSnapshotReader {
+    /// Build the read-only, WAL-aware SQLite URI for a live macOS DB at
+    /// `path`. Pass the result to `DatabasePool(path:configuration:)`
+    /// with `Configuration.readonly = true`.
+    ///
+    /// `path` is percent-encoded for the URI path component so a path
+    /// containing a space, `?`, `#`, or `%` is treated as filename
+    /// bytes, not URI syntax (SQLite's `file:` parser splits on the
+    /// first `?`). SQLite percent-DEcodes the path component, so the
+    /// encoded form round-trips back to the original bytes and opens
+    /// the same file. The macOS DBs we tail live under `~/Library/...`
+    /// (a path that contains a space, e.g. `Application Support`), and
+    /// encoding is also free defense-in-depth for any future path with
+    /// URI-significant bytes — the helper is the single chokepoint, so
+    /// it is the right place to do it.
+    public static func readOnlyURI(for path: String) -> String {
+        let encoded = path.addingPercentEncoding(
+            withAllowedCharacters: pathAllowed) ?? path
+        return "file://\(encoded)?mode=ro"
+    }
+
+    /// Convenience overload for a file URL.
+    public static func readOnlyURI(for url: URL) -> String {
+        readOnlyURI(for: url.path)
+    }
+
+    /// `/` must survive (path separators); space, `?`, `#`, `%` must be
+    /// encoded. `urlPathAllowed` already excludes space/`?`/`#` and
+    /// encodes a raw `%` to `%25`, which is exactly what makes each of
+    /// those characters round-trip through SQLite's URI decoder.
+    private static let pathAllowed: CharacterSet = {
+        var set = CharacterSet.urlPathAllowed
+        set.insert("/")
+        return set
+    }()
+}

--- a/mac-daemon/Sources/CRMMacCore/SourcePlugin.swift
+++ b/mac-daemon/Sources/CRMMacCore/SourcePlugin.swift
@@ -59,6 +59,73 @@ public protocol SourcePlugin: AnyObject, Sendable {
     func tick() async throws
 }
 
+/// A SourcePlugin that tails an external data source and must persist a
+/// per-tick liveness heartbeat to `state.sources[id].lastScheduledAt`.
+///
+/// The protocol extension below provides a `tick()` default so
+/// individual data plugins CANNOT forget the state.json heartbeat: it
+/// bumps `lastScheduledAt` BEFORE delegating to `performTick()`,
+/// mirroring what each plugin used to do by hand. The bump runs before
+/// any early-return gate inside `performTick()` (e.g. the phone_calls
+/// protocol-version gate), preserving the prior contract that even a
+/// gated/aborted tick records a fresh scheduled-at.
+///
+/// IMPORTANT — dispatch: a conformer MUST NOT declare its own `tick()`.
+/// Swift resolves a protocol-requirement witness to the most-specific
+/// concrete declaration; a plugin-defined `tick()` would shadow this
+/// extension default when the plugin is used through `SourcePlugin`,
+/// silently disabling the heartbeat. Conformers implement `performTick()`
+/// ONLY. This is enforced two ways: (a) a source grep-test forbidding
+/// `func tick(` in any DataSourcePlugin conformer module, and (b) a
+/// conformance test calling `tick()` through a `SourcePlugin`-typed
+/// reference and asserting the bump occurred.
+///
+/// The extension ALSO does not own the in-memory SourceHealthRegistry
+/// update that feeds the Pi /heartbeat payload's `last_scheduled_at`
+/// (per-plugin snapshot shape); that stays in `performTick()` and is
+/// covered by the conformance test's registry assertion.
+///
+/// Operational-loop conformers (HeartbeatLoop, NotificationReconcileLoop)
+/// stay on bare `SourcePlugin` — they have no `mutator`/`clock` and must
+/// not write `lastScheduledAt`.
+public protocol DataSourcePlugin: SourcePlugin {
+    /// Serialized state writer shared process-wide.
+    var mutator: StateMutator { get }
+    /// Injected clock (tests pass a fixed clock).
+    var clock: @Sendable () -> Date { get }
+    /// Structured logger (heartbeat-write failures are logged + swallowed).
+    var logger: LoggerProtocol { get }
+
+    /// The plugin's real per-tick work. Replaces the old `tick()` body.
+    func performTick() async throws
+}
+
+public extension DataSourcePlugin {
+    /// Provided `tick()`: persist the liveness heartbeat, then run the
+    /// plugin's work. A state-write hiccup is logged + swallowed — it
+    /// must never abort the tick.
+    func tick() async throws {
+        await persistScheduledHeartbeat(at: clock())
+        try await performTick()
+    }
+
+    /// Bump `state.sources[id].lastScheduledAt`. Single canonical copy
+    /// replacing the five hand-written `updateScheduled(at:)` methods.
+    func persistScheduledHeartbeat(at date: Date) async {
+        do {
+            try await mutator.mutate { state in
+                var src = state.sources[id.rawValue] ?? SourceState()
+                src.lastScheduledAt = date
+                state.sources[id.rawValue] = src
+            }
+        } catch {
+            logger.warning("\(id.rawValue) tick: lastScheduledAt mutate failed", metadata: [
+                "error": .private(String(describing: error)),
+            ])
+        }
+    }
+}
+
 /// Wrapper holding the dependencies a plugin needs. Currently a tiny
 /// surface (just a logger); source-specific dependencies (PiClient,
 /// StateStore, contact-store accessors) land with each real reader.

--- a/mac-daemon/Sources/CRMMacIcloudContactsSource/ICloudContactsSourcePlugin.swift
+++ b/mac-daemon/Sources/CRMMacIcloudContactsSource/ICloudContactsSourcePlugin.swift
@@ -88,21 +88,24 @@ public struct ICloudContactsConfigStoreSource: ICloudContactsConfigSource {
     }
 }
 
-public actor ICloudContactsSourcePlugin: SourcePlugin {
+public actor ICloudContactsSourcePlugin: DataSourcePlugin {
     public nonisolated let id: SourceID = .icloudContacts
     public nonisolated let tickInterval: TimeInterval
 
     private let piClient: PiClient
     private let auth: PiAuth
-    private let mutator: StateMutator
+    // nonisolated: read by the DataSourcePlugin extension's tick() from
+    // a nonisolated context. Sound because all three are immutable lets
+    // holding Sendable values (same pattern as `id`/`tickInterval`).
+    public nonisolated let mutator: StateMutator
     private let publisher: ICloudContactsPublisher
     private let cache: ContactHashCache
     private let reader: ContactStoreReader
     private let authAdapter: ContactsAuthorizationAdapter
     private let configSource: ICloudContactsConfigSource
     private let healthRegistry: SourceHealthRegistry
-    private let logger: LoggerProtocol
-    private let clock: @Sendable () -> Date
+    public nonisolated let logger: LoggerProtocol
+    public nonisolated let clock: @Sendable () -> Date
 
     public init(
         tickInterval: TimeInterval = CRMMacIcloudContactsSource.defaultTickInterval,
@@ -132,7 +135,7 @@ public actor ICloudContactsSourcePlugin: SourcePlugin {
         self.clock = clock
     }
 
-    public func tick() async throws {
+    public func performTick() async throws {
         // Wrap the whole tick in a do/catch envelope so any abort
         // path (throw, early return, end-of-tick) deterministically
         // discards staged cache removals BEFORE the next tick can
@@ -151,12 +154,13 @@ public actor ICloudContactsSourcePlugin: SourcePlugin {
     }
 
     private func runTick() async throws {
+        // The DataSourcePlugin extension already bumped state.json
+        // `lastScheduledAt` via `clock()` before performTick() ran.
+        // This `clock()` read feeds the in-memory heartbeat-payload
+        // registry snapshot; with a fixed test clock the two reads are
+        // equal, and in production the sub-ms drift is irrelevant for a
+        // coarse liveness timestamp.
         let tickStart = clock()
-        // Bump lastScheduledAt for staleness diagnostics — a
-        // quiet-but-healthy source bumps this every tick even when
-        // no events are emitted. Doctor reads this AND lastPushedAt
-        // to surface a meaningful staleness signal.
-        await updateScheduled(at: tickStart)
         await healthRegistry.update(id, currentHealthSnapshot(
             enabled: true, lastScheduled: tickStart))
 
@@ -604,20 +608,6 @@ public actor ICloudContactsSourcePlugin: SourcePlugin {
     }
 
     // MARK: - state mutators
-
-    private func updateScheduled(at date: Date) async {
-        do {
-            try await mutator.mutate { state in
-                var src = state.sources[self.id.rawValue] ?? SourceState()
-                src.lastScheduledAt = date
-                state.sources[self.id.rawValue] = src
-            }
-        } catch {
-            logger.warning("icloud tick: lastScheduledAt mutate failed", metadata: [
-                "error": .private(String(describing: error)),
-            ])
-        }
-    }
 
     private func updatePushed(at date: Date) async {
         do {

--- a/mac-daemon/Sources/CRMMacMessagesSource/MessagesSourcePlugin.swift
+++ b/mac-daemon/Sources/CRMMacMessagesSource/MessagesSourcePlugin.swift
@@ -52,18 +52,21 @@ public struct MessagesSourceConfig: Sendable {
     }
 }
 
-public actor MessagesSourcePlugin: SourcePlugin {
+public actor MessagesSourcePlugin: DataSourcePlugin {
     public nonisolated let id: SourceID = .messages
     public nonisolated let tickInterval: TimeInterval
 
     private let config: MessagesSourceConfig
     private let piClient: PiClient
     private let auth: PiAuth
-    private let mutator: StateMutator
+    // nonisolated: read by the DataSourcePlugin extension's tick() from
+    // a nonisolated context. Sound because all three are immutable lets
+    // holding Sendable values (same pattern as `id`/`tickInterval`).
+    public nonisolated let mutator: StateMutator
     private let publisher: MessagesPublisher
     private let cache: KnownIdentifiersCache
-    private let logger: LoggerProtocol
-    private let clock: @Sendable () -> Date
+    public nonisolated let logger: LoggerProtocol
+    public nonisolated let clock: @Sendable () -> Date
     private let healthRegistry: SourceHealthRegistry
 
     /// Cached pool, opened lazily on first successful tick.
@@ -107,13 +110,14 @@ public actor MessagesSourcePlugin: SourcePlugin {
         self.clock = clock
     }
 
-    public func tick() async throws {
+    public func performTick() async throws {
+        // The DataSourcePlugin extension already bumped state.json
+        // `lastScheduledAt` via `clock()` before entering here. This
+        // second `clock()` read feeds the in-memory heartbeat-payload
+        // registry snapshot + budget math; with a fixed test clock the
+        // two reads are equal, and in production the sub-ms drift is
+        // irrelevant for a coarse liveness timestamp.
         let tickStart = clock()
-        // Persist lastScheduledAt to state.json BEFORE any pool-open
-        // / schema-check work so a healthy-but-quiet tick still bumps
-        // the on-disk timestamp. The in-memory healthRegistry update
-        // below is heartbeat-payload-only.
-        await updateScheduled(at: tickStart)
         await healthRegistry.update(id, await currentHealthSnapshot(
             enabled: true,
             lastScheduled: tickStart,
@@ -578,30 +582,6 @@ public actor MessagesSourcePlugin: SourcePlugin {
             src.backfillComplete = backfillComplete
             src.lastPushedAt = lastPushedAt
             state.sources["messages"] = src
-        }
-    }
-
-    /// Persist `lastScheduledAt` to state.json at the start of every
-    /// tick. Mirrors ICloudContactsSourcePlugin.updateScheduled(at:)
-    /// so state.sources["messages"].lastScheduledAt is a reliable
-    /// cross-source liveness signal — the in-memory
-    /// SourceHealthRegistry update (via `currentHealthSnapshot`) is
-    /// heartbeat-payload-only and never written to disk. Without this
-    /// persistence, Doctor / debugging tools see no recent scheduled-
-    /// at for messages even on a healthy-but-quiet tick. Failures
-    /// are logged-and-swallowed: a state.json write hiccup must not
-    /// abort the tick.
-    private func updateScheduled(at date: Date) async {
-        do {
-            try await mutator.mutate { state in
-                var src = state.sources[self.id.rawValue] ?? SourceState()
-                src.lastScheduledAt = date
-                state.sources[self.id.rawValue] = src
-            }
-        } catch {
-            logger.warning("messages tick: lastScheduledAt mutate failed", metadata: [
-                "error": .private(String(describing: error)),
-            ])
         }
     }
 

--- a/mac-daemon/Sources/CRMMacMessagesSource/MessagesSourcePlugin.swift
+++ b/mac-daemon/Sources/CRMMacMessagesSource/MessagesSourcePlugin.swift
@@ -507,10 +507,15 @@ public actor MessagesSourcePlugin: SourcePlugin {
         }
         var config = Configuration()
         config.readonly = true
-        // Don't add ?immutable=1 — Messages.app is actively writing.
+        // URI shape + WAL rationale (incl. why we must NOT use
+        // `immutable=1`) owned by `SQLiteSnapshotReader`.
+        // `Configuration.readonly` is defense-in-depth; the URI's
+        // `mode=ro` is the primary read-only/WAL-aware guard.
         let pool: DatabasePool
         do {
-            pool = try DatabasePool(path: self.config.chatDBPath.path, configuration: config)
+            pool = try DatabasePool(
+                path: SQLiteSnapshotReader.readOnlyURI(for: self.config.chatDBPath),
+                configuration: config)
         } catch let dbError as DatabaseError {
             // FDA / sandbox denial: SQLITE_AUTH (23), SQLITE_PERM (3),
             // or SQLITE_CANTOPEN (14). Distinguish from a transient

--- a/mac-daemon/Sources/CRMMacPhoneCallsSource/CallHistoryDBReader.swift
+++ b/mac-daemon/Sources/CRMMacPhoneCallsSource/CallHistoryDBReader.swift
@@ -1,14 +1,9 @@
 // CallHistoryDBReader — GRDB-backed read-only iterator over
 // CallHistoryDB ZCALLRECORD rows.
 //
-// Opens CallHistoryDB with `?mode=ro` (WAL-aware; NOT `immutable=1`).
-// Phone.app / FaceTime / Continuity write to CallHistoryDB
-// concurrently, and macOS does not checkpoint its WAL on any
-// predictable cadence, so an `immutable=1` reader would be blind to
-// every call until the WAL eventually folds into the main file.
-// Concurrent-writer contention surfaces as SQLITE_BUSY and is absorbed
-// by GRDB's default DatabasePool busy-retry policy; the daemon's
-// reopen-every-tick pattern keeps each handle short-lived.
+// Operates on an already-open `Database` the plugin hands in (opened
+// via `SQLiteSnapshotReader`, which owns the read-only WAL-aware URI
+// shape + the rationale for why we must NOT use `immutable=1`).
 //
 // Cursor primitive: (ZDATE, Z_PK) lexicographic pair. ZDATE is
 // Apple-epoch SECONDS since 2001-01-01 (Core Data's CFAbsoluteTime

--- a/mac-daemon/Sources/CRMMacPhoneCallsSource/PhoneCallsSourcePlugin.swift
+++ b/mac-daemon/Sources/CRMMacPhoneCallsSource/PhoneCallsSourcePlugin.swift
@@ -7,11 +7,9 @@
 //     inhibits emission of `call.*` events that an older Pi can't
 //     accept.
 //   - Check schema health: drift -> source_health unhealthy + return.
-//   - Open CallHistoryDB DatabasePool with `?mode=ro` (NOT
-//     `immutable=1`) fresh each tick. CallHistoryDB's WAL accumulates
-//     for days between macOS-driven checkpoints, and `immutable=1`
-//     hides every WAL-resident write from the reader, so we'd miss
-//     every call between checkpoints. Reopening per tick keeps the
+//   - Open CallHistoryDB DatabasePool fresh each tick via the
+//     read-only WAL-aware URI from `SQLiteSnapshotReader` (which owns
+//     the WAL-visibility rationale). Reopening per tick keeps the
 //     handle short-lived; SQLITE_BUSY retries cover concurrent
 //     writers (Phone.app / FaceTime / Continuity).
 //   - Load cursor: piClient.getCursor("phone_calls") -> decode into
@@ -585,31 +583,19 @@ public actor PhoneCallsSourcePlugin: SourcePlugin {
 
     private struct FDAError: Error {}
 
-    /// Open CallHistoryDB fresh every tick. We use `?mode=ro` and
-    /// deliberately do NOT pass `immutable=1` — Phone.app, FaceTime,
-    /// and Continuity write to CallHistoryDB while the daemon runs,
-    /// and `immutable=1` would tell SQLite to ignore the WAL entirely
-    /// and serve only the install-time snapshot of the main DB file.
-    /// macOS does not checkpoint CallHistoryDB's WAL on any
-    /// predictable cadence (we've observed `CallHistory.storedata`
-    /// stale by days while `CallHistory.storedata-wal` is megabytes
-    /// of live writes), so an immutable reader would silently miss
-    /// every call between checkpoints. The reopen-every-tick pattern
-    /// keeps each handle short-lived; transient writer-lock contention
-    /// surfaces as SQLITE_BUSY and is absorbed by GRDB's default
-    /// DatabasePool busy-retry policy.
+    /// Open CallHistoryDB fresh every tick. The reopen-every-tick
+    /// pattern keeps each handle short-lived; transient writer-lock
+    /// contention surfaces as SQLITE_BUSY and is absorbed by GRDB's
+    /// default DatabasePool busy-retry policy. The read-only,
+    /// WAL-aware URI shape (and the WAL-visibility rationale for why we
+    /// must NOT use `immutable=1`) is owned by `SQLiteSnapshotReader`.
     private func openFreshPool() async throws -> DatabasePool {
         var grdbConfig = Configuration()
         grdbConfig.readonly = true
-        // Open in WAL-aware read-only mode. GRDB's DatabasePool accepts
-        // a URI when prefixed with `file:`; SQLite parses the query
-        // string. We do NOT add `immutable=1` — see the doc comment
-        // above for the WAL-visibility rationale. The Messages plugin
-        // achieves the same WAL-aware read-only property via a bare
-        // path + `Configuration.readonly = true`; the URI vs bare-path
-        // shape is incidental, but the absence of `immutable=1` is
-        // the load-bearing invariant for picking up uncheckpointed writes.
-        let uri = Self.callHistoryDBURI(for: config.callHistoryDBPath)
+        // URI shape + WAL rationale owned by `SQLiteSnapshotReader`.
+        // `Configuration.readonly` is defense-in-depth; the URI's
+        // `mode=ro` is the primary read-only/WAL-aware guard.
+        let uri = SQLiteSnapshotReader.readOnlyURI(for: config.callHistoryDBPath)
         let pool: DatabasePool
         do {
             pool = try DatabasePool(path: uri, configuration: grdbConfig)
@@ -695,14 +681,6 @@ public actor PhoneCallsSourcePlugin: SourcePlugin {
                 "error": .private(String(describing: error)),
             ])
         }
-    }
-
-    /// Construct the SQLite URI used by `openFreshPool`. Exposed as a
-    /// static helper so tests can exercise the exact production URI
-    /// shape without re-implementing it; if this changes, both code
-    /// paths stay in sync.
-    internal static func callHistoryDBURI(for path: URL) -> String {
-        "file://\(path.path)?mode=ro"
     }
 
     // MARK: - health surface

--- a/mac-daemon/Sources/CRMMacPhoneCallsSource/PhoneCallsSourcePlugin.swift
+++ b/mac-daemon/Sources/CRMMacPhoneCallsSource/PhoneCallsSourcePlugin.swift
@@ -69,20 +69,23 @@ public struct PhoneCallsSourceConfig: Sendable {
 /// same normalizer without taking a cross-source dep.
 public typealias HandleCanonicalizer = @Sendable (String) -> String
 
-public actor PhoneCallsSourcePlugin: SourcePlugin {
+public actor PhoneCallsSourcePlugin: DataSourcePlugin {
     public nonisolated let id: SourceID = .phoneCalls
     public nonisolated let tickInterval: TimeInterval
 
     private let config: PhoneCallsSourceConfig
     private let piClient: PiClient
     private let auth: PiAuth
-    private let mutator: StateMutator
+    // nonisolated: read by the DataSourcePlugin extension's tick() from
+    // a nonisolated context. Sound because all three are immutable lets
+    // holding Sendable values (same pattern as `id`/`tickInterval`).
+    public nonisolated let mutator: StateMutator
     private let publisher: PhoneCallsPublisher
     private let cache: KnownIdentifiersCache
     private let canonicalizer: HandleCanonicalizer
     private let heartbeatStateProvider: HeartbeatStateProvider
-    private let logger: LoggerProtocol
-    private let clock: @Sendable () -> Date
+    public nonisolated let logger: LoggerProtocol
+    public nonisolated let clock: @Sendable () -> Date
     private let healthRegistry: SourceHealthRegistry
 
     /// Cached schema health. Validated on first successful open. We
@@ -148,13 +151,14 @@ public actor PhoneCallsSourcePlugin: SourcePlugin {
         self.clock = clock
     }
 
-    public func tick() async throws {
+    public func performTick() async throws {
+        // The DataSourcePlugin extension already bumped state.json
+        // `lastScheduledAt` via `clock()` before entering here. This
+        // second `clock()` read feeds the in-memory heartbeat-payload
+        // registry snapshot + budget math; with a fixed test clock the
+        // two reads are equal, and in production the sub-ms drift is
+        // irrelevant for a coarse liveness timestamp.
         let tickStart = clock()
-        // Persist lastScheduledAt to state.json BEFORE any gate /
-        // health-registry / pool-open work so a healthy-but-quiet tick
-        // still bumps the on-disk timestamp. The in-memory
-        // healthRegistry update below is heartbeat-payload-only.
-        await updateScheduled(at: tickStart)
         await healthRegistry.update(id, currentHealthSnapshot(
             enabled: true,
             lastScheduled: tickStart,
@@ -656,30 +660,6 @@ public actor PhoneCallsSourcePlugin: SourcePlugin {
             src.backfillComplete = backfillComplete
             src.lastPushedAt = lastPushedAt
             state.sources["phone_calls"] = src
-        }
-    }
-
-    /// Persist `lastScheduledAt` to state.json at the start of every
-    /// tick. Mirrors ICloudContactsSourcePlugin.updateScheduled(at:)
-    /// so state.sources["phone_calls"].lastScheduledAt is a reliable
-    /// cross-source liveness signal — the in-memory
-    /// SourceHealthRegistry update (via `currentHealthSnapshot`) is
-    /// heartbeat-payload-only and never written to disk. Without this
-    /// persistence, Doctor / debugging tools see no recent scheduled-
-    /// at for phone_calls even on a healthy-but-quiet tick. Failures
-    /// are logged-and-swallowed: a state.json write hiccup must not
-    /// abort the tick.
-    private func updateScheduled(at date: Date) async {
-        do {
-            try await mutator.mutate { state in
-                var src = state.sources[self.id.rawValue] ?? SourceState()
-                src.lastScheduledAt = date
-                state.sources[self.id.rawValue] = src
-            }
-        } catch {
-            logger.warning("phone_calls tick: lastScheduledAt mutate failed", metadata: [
-                "error": .private(String(describing: error)),
-            ])
         }
     }
 

--- a/mac-daemon/Tests/CRMMacConformanceTests/DataSourcePluginConformanceTests.swift
+++ b/mac-daemon/Tests/CRMMacConformanceTests/DataSourcePluginConformanceTests.swift
@@ -1,0 +1,482 @@
+// DataSourcePluginConformanceTests — the cross-cutting guard that
+// makes the DataSourcePlugin heartbeat contract un-forgettable for a
+// future sixth data source.
+//
+// Four layers, because no single mechanism is sufficient on its own:
+//
+//   (a) Per-plugin behavioral assertion through an `any SourcePlugin`
+//       reference. For each of the five concrete plugins, build a
+//       minimal instance whose performTick() short-circuits fast +
+//       harmlessly (gated / denied / not-configured / bogus path),
+//       bind it to `let plugin: any SourcePlugin = <concrete>`, call
+//       `plugin.tick()` through that protocol-typed reference (the SAME
+//       witness the production scheduler dispatches to), and assert
+//       BOTH writes: state.json `lastScheduledAt == T`, and the
+//       SourceHealthRegistry snapshot's `lastScheduledAt != nil` (the
+//       Pi /heartbeat-payload field). A plugin that (re)declares its
+//       own concrete `tick()` and forgets the bump fails the state.json
+//       assertion; a plugin that drops its healthRegistry.update(...)
+//       fails the registry assertion.
+//
+//   (b) Source grep guard: no `func tick(` declaration may exist in any
+//       of the four source-library-target directories (the witness must
+//       come from the CRMMacCore extension default, never a shadowing
+//       concrete tick()). Target-wide naming ban by design — `tick` is
+//       reserved vocabulary in these modules; a future non-plugin
+//       tick() must rename or tighten this guard to type-scoped
+//       matching.
+//
+//   (c) Enumeration completeness: ONE `expectedDataSources` literal,
+//       asserted simultaneously against (1) the SOURCE-derived set (a
+//       filesystem grep for `: DataSourcePlugin` conformers + their
+//       `id: SourceID = .<case>` literal) and (2) the BEHAVIOR-derived
+//       set collected in layer (a). A sixth source must appear in
+//       source, in the expected literal, AND in the behavioral loop, or
+//       some pair is unequal and this fails. The single literal lives
+//       ONLY here so it cannot be silenced by editing a duplicate copy.
+//
+//   (d) Extension-default + coalescing smoke tests using a tiny in-test
+//       stub conforming to DataSourcePlugin (a final class, since
+//       SourcePlugin: AnyObject forbids value types): assert the
+//       extension tick() bumps lastScheduledAt and calls performTick()
+//       exactly once, and that a coalescing-style stub that early-
+//       returns still records the state.json bump.
+import XCTest
+import Foundation
+import CRMMacCore
+import CRMMacPiClient
+@testable import CRMMacMessagesSource
+@testable import CRMMacPhoneCallsSource
+@testable import CRMMacIcloudContactsSource
+@testable import CRMMacAnarlogSource
+
+final class DataSourcePluginConformanceTests: XCTestCase {
+    /// The authoritative set of data sources. There is exactly ONE
+    /// copy of this literal in the whole test suite — do NOT duplicate
+    /// it into another target (a duplicate would let a sixth source be
+    /// silenced by editing only one copy while the other compares
+    /// old==old). Layer (c) asserts this against both the source-derived
+    /// and behavior-derived sets.
+    private static let expectedDataSources: Set<SourceID> = [
+        .messages, .phoneCalls, .icloudContacts, .anarlogHumans, .anarlogSessions,
+    ]
+
+    private let hostID = UUID(uuidString: "11111111-2222-3333-4444-555555555555")!
+    private let fixedInstant = Date(timeIntervalSince1970: 1_750_000_000)
+
+    // MARK: - per-test state wiring
+
+    /// Fresh on-disk StateStore + StateMutator in a unique temp dir
+    /// (mirrors PhoneCallsSourcePluginTests.makeMutator). Returns the
+    /// store too so the caller can read state.json back.
+    private func makeStateMutator() throws -> (StateMutator, StateStore) {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("crm-mac-conformance-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let stateURL = dir.appendingPathComponent("state.json")
+        let store = StateStore(fileURL: stateURL)
+        try store.save(DaemonState(schemaVersion: 1))
+        return (StateMutator(store: store), store)
+    }
+
+    private func clock() -> @Sendable () -> Date {
+        let instant = fixedInstant
+        return { instant }
+    }
+
+    private func auth() -> PiAuth { PiAuth(hostID: hostID, apiKey: "k") }
+
+    private func unreachablePiClient() -> PiClient {
+        PiClient(baseURL: URL(string: "https://example.invalid")!, logger: NoopLogger())
+    }
+
+    // MARK: - (a) per-plugin behavioral assertion
+
+    func testEveryDataPluginBumpsHeartbeatThroughSourcePluginWitness() async throws {
+        var behaviorallyTestedIDs: Set<SourceID> = []
+
+        for spec in try makePluginSpecs() {
+            // Bind to `any SourcePlugin` so we exercise the production
+            // witness, not a concrete-typed call.
+            let plugin: any SourcePlugin = spec.plugin
+            try await plugin.tick()
+
+            // (1) state.json — written by the extension's
+            // persistScheduledHeartbeat before performTick() ran.
+            let state = try await spec.mutator.read()
+            let persisted = state.sources[plugin.id.rawValue]?.lastScheduledAt
+            XCTAssertEqual(persisted, fixedInstant,
+                           "\(plugin.id.rawValue): tick() must persist " +
+                           "lastScheduledAt == T to state.json")
+
+            // (2) heartbeat-payload registry — written by the plugin's
+            // own healthRegistry.update(...) inside performTick().
+            let snap = await spec.registry.read(plugin.id)
+            XCTAssertNotNil(snap,
+                            "\(plugin.id.rawValue): performTick() must report a " +
+                            "SourceHealthRegistry snapshot")
+            XCTAssertNotNil(snap?.lastScheduledAt,
+                            "\(plugin.id.rawValue): the heartbeat-payload snapshot " +
+                            "must carry lastScheduledAt (feeds the Pi /heartbeat)")
+
+            behaviorallyTestedIDs.insert(plugin.id)
+        }
+
+        // Behavior-derived completeness (half of layer (c)).
+        XCTAssertEqual(behaviorallyTestedIDs, Self.expectedDataSources,
+                       "every expected data source must be behaviorally exercised; " +
+                       "a new conformer must be added to the instantiation loop")
+    }
+
+    // MARK: - (b) no `func tick(` in conformer modules
+
+    func testNoConcreteTickInDataSourceModules() throws {
+        let sourcesRoot = Self.resolveSourcesRoot()
+        let moduleDirs = [
+            "CRMMacMessagesSource", "CRMMacPhoneCallsSource",
+            "CRMMacIcloudContactsSource", "CRMMacAnarlogSource",
+        ].map { sourcesRoot.appendingPathComponent($0) }
+
+        var offenders: [String] = []
+        for dir in moduleDirs {
+            for fileURL in try Self.swiftFiles(under: dir) {
+                let code = try String(contentsOf: fileURL, encoding: .utf8)
+                if code.range(of: #"func\s+tick\s*\("#, options: .regularExpression) != nil {
+                    offenders.append(fileURL.lastPathComponent)
+                }
+            }
+        }
+        XCTAssertTrue(offenders.isEmpty,
+                      "DataSourcePlugin conformers must implement performTick(), NOT " +
+                      "tick() — a concrete tick() would shadow the CRMMacCore extension " +
+                      "default and silently disable the heartbeat. Offending file(s): " +
+                      offenders.joined(separator: ", "))
+    }
+
+    // MARK: - (c) source-derived enumeration completeness
+
+    /// Scanner assumption (documented convention): a DataSourcePlugin
+    /// conformer declares `: DataSourcePlugin` and its
+    /// `id: SourceID = .<case>` on single lines within the same source
+    /// file. All five current plugins satisfy this. A future conformer
+    /// in a different shape must either keep this form OR upgrade this
+    /// scanner to a real parse — flagged here so a regex miss surfaces
+    /// as a deliberate decision, not a silent gap.
+    func testSourceDerivedConformerSetMatchesExpected() throws {
+        let sourcesRoot = Self.resolveSourcesRoot()
+        var sourceDerived: Set<SourceID> = []
+        for fileURL in try Self.swiftFiles(under: sourcesRoot) {
+            let code = try String(contentsOf: fileURL, encoding: .utf8)
+            guard code.range(of: #":\s*DataSourcePlugin"#, options: .regularExpression) != nil
+            else { continue }
+            for rawCase in Self.idCaseLiterals(in: code) {
+                guard let id = Self.sourceID(forCaseName: rawCase) else {
+                    XCTFail("\(fileURL.lastPathComponent): unknown SourceID case " +
+                            "`.\(rawCase)` — update sourceID(forCaseName:) when adding a " +
+                            "SourceID case")
+                    continue
+                }
+                sourceDerived.insert(id)
+            }
+        }
+        XCTAssertEqual(sourceDerived, Self.expectedDataSources,
+                       "the set of `: DataSourcePlugin` conformers derived from Sources/ " +
+                       "must equal expectedDataSources; a new conformer must be added to " +
+                       "the expected literal (and to layer (a)'s loop)")
+    }
+
+    // MARK: - (d) extension-default + coalescing smoke
+
+    func testExtensionDefaultBumpsAndCallsPerformTickOnce() async throws {
+        let (mutator, _) = try makeStateMutator()
+        let stub = StubDataSource(id: .messages, mutator: mutator, clock: clock())
+        let plugin: any SourcePlugin = stub
+        try await plugin.tick()
+
+        let calls = stub.performTickCalls
+        XCTAssertEqual(calls, 1, "extension tick() must call performTick() exactly once")
+        let state = try await mutator.read()
+        XCTAssertEqual(state.sources[SourceID.messages.rawValue]?.lastScheduledAt,
+                       fixedInstant,
+                       "extension tick() must bump lastScheduledAt before performTick()")
+    }
+
+    func testCoalescingEarlyReturnStillBumpsStateJSON() async throws {
+        let (mutator, _) = try makeStateMutator()
+        // Simulate the Sessions coalescing branch: performTick() early-
+        // returns (tickInFlight). The extension's tick() still bumps
+        // state.json BEFORE performTick() runs, so the bump persists
+        // even on a coalesced fire.
+        let stub = StubDataSource(id: .anarlogSessions, mutator: mutator,
+                                  clock: clock(), earlyReturn: true)
+        let plugin: any SourcePlugin = stub
+        try await plugin.tick()
+
+        let calls = stub.performTickCalls
+        XCTAssertEqual(calls, 1, "performTick() is still entered (and early-returns)")
+        let state = try await mutator.read()
+        XCTAssertEqual(state.sources[SourceID.anarlogSessions.rawValue]?.lastScheduledAt,
+                       fixedInstant,
+                       "a coalesced fire that early-returns must still record a " +
+                       "state.json lastScheduledAt bump")
+    }
+
+    // MARK: - plugin construction (layer a)
+
+    private struct PluginSpec {
+        let plugin: any SourcePlugin
+        let mutator: StateMutator
+        let registry: SourceHealthRegistry
+    }
+
+    /// Build one short-circuiting instance of each of the five plugins.
+    /// Each reaches an early-return path right after the heartbeat bump:
+    ///   - Messages: bogus chat.db path -> open fails -> markUnhealthy.
+    ///   - PhoneCalls: Pi protocol_version too low -> gate returns.
+    ///   - iCloud: auth denied -> markUnhealthy.
+    ///   - Anarlog humans/sessions: not configured -> markUnhealthy.
+    /// In every case the extension persisted state.json BEFORE
+    /// performTick(), and performTick() reported a registry snapshot
+    /// carrying lastScheduledAt.
+    private func makePluginSpecs() throws -> [PluginSpec] {
+        var specs: [PluginSpec] = []
+
+        // Messages — bogus path.
+        do {
+            let (mutator, _) = try makeStateMutator()
+            let registry = SourceHealthRegistry()
+            let publisher = MessagesPublisher(
+                sender: { _, _ in IngestEventsData(accepted: 0, duplicate: 0, rejected: 0, errors: []) },
+                auth: auth(), logger: NoopLogger())
+            let plugin = MessagesSourcePlugin(
+                tickInterval: 60,
+                config: MessagesSourceConfig(
+                    chatDBPath: URL(fileURLWithPath: "/dev/null/nope"),
+                    backfillFloor: Date(timeIntervalSince1970: 0)),
+                piClient: unreachablePiClient(),
+                auth: auth(),
+                mutator: mutator,
+                publisher: publisher,
+                cache: KnownIdentifiersCache(),
+                healthRegistry: registry,
+                logger: NoopLogger(),
+                clock: clock())
+            specs.append(PluginSpec(plugin: plugin, mutator: mutator, registry: registry))
+        }
+
+        // PhoneCalls — protocol gate (Pi version below required).
+        do {
+            let (mutator, _) = try makeStateMutator()
+            let registry = SourceHealthRegistry()
+            let publisher = PhoneCallsPublisher(
+                sender: { _, _ in IngestEventsData(accepted: 0, duplicate: 0, rejected: 0, errors: []) },
+                auth: auth(), logger: NoopLogger())
+            let plugin = PhoneCallsSourcePlugin(
+                tickInterval: 60,
+                config: PhoneCallsSourceConfig(
+                    callHistoryDBPath: URL(fileURLWithPath: "/dev/null/nope"),
+                    backfillFloor: Date(timeIntervalSince1970: 0)),
+                piClient: unreachablePiClient(),
+                auth: auth(),
+                mutator: mutator,
+                publisher: publisher,
+                cache: KnownIdentifiersCache(),
+                canonicalizer: { $0 },
+                heartbeatStateProvider: InMemoryHeartbeatStateProvider(initial: 1),
+                healthRegistry: registry,
+                logger: NoopLogger(),
+                clock: clock())
+            specs.append(PluginSpec(plugin: plugin, mutator: mutator, registry: registry))
+        }
+
+        // iCloud — auth denied.
+        do {
+            let (mutator, _) = try makeStateMutator()
+            let registry = SourceHealthRegistry()
+            let dir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("crm-mac-conformance-icloud-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            let publisher = ICloudContactsPublisher(
+                sender: { _, _ in IngestEventsData(accepted: 0, duplicate: 0, rejected: 0, errors: []) },
+                auth: auth(), logger: NoopLogger())
+            let plugin = ICloudContactsSourcePlugin(
+                tickInterval: 900,
+                piClient: unreachablePiClient(),
+                auth: auth(),
+                mutator: mutator,
+                publisher: publisher,
+                cache: ContactHashCache(fileURL: dir.appendingPathComponent("cache.json")),
+                reader: NoopContactStoreReader(),
+                authAdapter: StubAuthAdapter(.denied),
+                configSource: NoopICloudConfigSource(),
+                healthRegistry: registry,
+                logger: NoopLogger(),
+                clock: clock())
+            specs.append(PluginSpec(plugin: plugin, mutator: mutator, registry: registry))
+        }
+
+        // Anarlog humans — not configured.
+        do {
+            let (mutator, _) = try makeStateMutator()
+            let registry = SourceHealthRegistry()
+            let publisher = AnarlogHumansPublisher(
+                sender: { _, _ in IngestEventsData(accepted: 0, duplicate: 0, rejected: 0, errors: []) },
+                auth: auth(), logger: NoopLogger())
+            let plugin = AnarlogHumansSourcePlugin(
+                tickInterval: 60,
+                piClient: unreachablePiClient(),
+                auth: auth(),
+                mutator: mutator,
+                publisher: publisher,
+                filesystem: NoopAnarlogFilesystem(),
+                configSource: NoopAnarlogConfigSource(),
+                healthRegistry: registry,
+                logger: NoopLogger(),
+                clock: clock())
+            specs.append(PluginSpec(plugin: plugin, mutator: mutator, registry: registry))
+        }
+
+        // Anarlog sessions — not configured.
+        do {
+            let (mutator, _) = try makeStateMutator()
+            let registry = SourceHealthRegistry()
+            let publisher = AnarlogSessionsPublisher(
+                sender: { _, _ in IngestEventsData(accepted: 0, duplicate: 0, rejected: 0, errors: []) },
+                auth: auth(), logger: NoopLogger())
+            let plugin = AnarlogSessionsSourcePlugin(
+                tickInterval: 60,
+                piClient: unreachablePiClient(),
+                auth: auth(),
+                mutator: mutator,
+                publisher: publisher,
+                filesystem: NoopAnarlogFilesystem(),
+                configSource: NoopAnarlogConfigSource(),
+                healthRegistry: registry,
+                logger: NoopLogger(),
+                clock: clock())
+            specs.append(PluginSpec(plugin: plugin, mutator: mutator, registry: registry))
+        }
+
+        return specs
+    }
+
+    // MARK: - filesystem-walk helpers
+
+    /// Resolve `mac-daemon/Sources` from THIS file's compile-time path.
+    /// File lives at mac-daemon/Tests/CRMMacConformanceTests/<file>.swift,
+    /// so three `deletingLastPathComponent()` reach mac-daemon/.
+    private static func resolveSourcesRoot() -> URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent() // CRMMacConformanceTests/
+            .deletingLastPathComponent() // Tests/
+            .deletingLastPathComponent() // mac-daemon/
+            .appendingPathComponent("Sources")
+    }
+
+    private static func swiftFiles(under root: URL) throws -> [URL] {
+        var result: [URL] = []
+        guard let enumerator = FileManager.default.enumerator(
+            at: root,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]) else {
+            return result
+        }
+        for case let url as URL in enumerator where url.pathExtension == "swift" {
+            result.append(url)
+        }
+        return result
+    }
+
+    /// Extract every `<x>` from `id: SourceID = .<x>` in `code`.
+    private static func idCaseLiterals(in code: String) -> [String] {
+        guard let regex = try? NSRegularExpression(
+            pattern: #"id:\s*SourceID\s*=\s*\.([A-Za-z0-9_]+)"#) else { return [] }
+        let ns = code as NSString
+        let matches = regex.matches(in: code, range: NSRange(location: 0, length: ns.length))
+        return matches.compactMap { m in
+            guard m.numberOfRanges > 1 else { return nil }
+            return ns.substring(with: m.range(at: 1))
+        }
+    }
+
+    /// Map a `SourceID.<case>` case name to its SourceID. Exhaustive
+    /// over the data-source cases; returns nil for an unknown case so
+    /// the test fails loudly rather than silently dropping a conformer.
+    private static func sourceID(forCaseName name: String) -> SourceID? {
+        switch name {
+        case "messages": return .messages
+        case "phoneCalls": return .phoneCalls
+        case "icloudContacts": return .icloudContacts
+        case "anarlogHumans": return .anarlogHumans
+        case "anarlogSessions": return .anarlogSessions
+        default: return nil
+        }
+    }
+}
+
+// MARK: - in-test stubs
+
+/// Minimal DataSourcePlugin for the extension-default smoke tests. A
+/// `final class` because DataSourcePlugin: SourcePlugin and SourcePlugin
+/// is `AnyObject` — a value type cannot conform. Mutable counter is
+/// guarded by the actor-like isolation of an `@unchecked Sendable`
+/// final class accessed only from a single test task; reads happen
+/// after the awaited tick() completes.
+private final class StubDataSource: DataSourcePlugin, @unchecked Sendable {
+    let id: SourceID
+    let tickInterval: TimeInterval = 60
+    let mutator: StateMutator
+    let clock: @Sendable () -> Date
+    let logger: LoggerProtocol = NoopLogger()
+    private let earlyReturn: Bool
+    private var _performTickCalls = 0
+
+    init(id: SourceID, mutator: StateMutator,
+         clock: @escaping @Sendable () -> Date, earlyReturn: Bool = false) {
+        self.id = id
+        self.mutator = mutator
+        self.clock = clock
+        self.earlyReturn = earlyReturn
+    }
+
+    func performTick() async throws {
+        _performTickCalls += 1
+        if earlyReturn { return }
+    }
+
+    /// Read after the awaited tick() completes — no concurrent access.
+    var performTickCalls: Int { _performTickCalls }
+}
+
+private struct NoopICloudConfigSource: ICloudContactsConfigSource {
+    func load() throws -> ICloudContactsConfig? { nil }
+}
+
+private final class StubAuthAdapter: ContactsAuthorizationAdapter, @unchecked Sendable {
+    private let status: ContactsAuthorizationStatus
+    init(_ status: ContactsAuthorizationStatus) { self.status = status }
+    func authorizationStatus() -> ContactsAuthorizationStatus { status }
+    func requestAccess() async throws -> Bool { false }
+}
+
+private struct NoopContactStoreReader: ContactStoreReader {
+    func listContainers() throws -> [ContainerInfo] { [] }
+    func fullFetch(containerIdentifiers: [String]) throws -> [ContactRecord] { [] }
+    func changeHistory(from token: Data?) throws -> ChangeHistoryResult {
+        ChangeHistoryResult(events: [], newToken: Data())
+    }
+    func currentToken() throws -> Data { Data() }
+}
+
+private struct NoopAnarlogConfigSource: AnarlogConfigSource {
+    func load() throws -> AnarlogConfig? { nil }
+}
+
+private struct NoopAnarlogFilesystem: AnarlogFilesystem {
+    func exists(_ path: String) -> Bool { false }
+    func isDirectory(_ path: String) -> Bool { false }
+    func isReadableDirectory(_ path: String) -> Bool { false }
+    func listDirectory(_ dir: String) throws -> [String] { [] }
+    func readFile(_ path: String) throws -> Data { Data() }
+    func mtime(_ path: String) -> Date? { nil }
+}

--- a/mac-daemon/Tests/CRMMacConformanceTests/DataSourcePluginConformanceTests.swift
+++ b/mac-daemon/Tests/CRMMacConformanceTests/DataSourcePluginConformanceTests.swift
@@ -180,7 +180,14 @@ final class DataSourcePluginConformanceTests: XCTestCase {
         var extractedIDCount = 0
         for fileURL in try Self.swiftFiles(under: sourcesRoot) {
             let code = try String(contentsOf: fileURL, encoding: .utf8)
-            guard code.range(of: #":\s*DataSourcePlugin"#, options: .regularExpression) != nil
+            // Match `DataSourcePlugin` in a conformance position —
+            // preceded by `:` (sole conformance) OR `,` (comma-separated
+            // multi-protocol clause, e.g. `: Foo, DataSourcePlugin`).
+            // `\b` after the name avoids matching a longer identifier.
+            // Does NOT match `protocol DataSourcePlugin:` (colon after)
+            // or `extension DataSourcePlugin` (no preceding `:`/`,`).
+            guard code.range(of: #"[:,]\s*DataSourcePlugin\b"#,
+                             options: .regularExpression) != nil
             else { continue }
             conformerFileCount += 1
             let cases = Self.idCaseLiterals(in: code)

--- a/mac-daemon/Tests/CRMMacConformanceTests/DataSourcePluginConformanceTests.swift
+++ b/mac-daemon/Tests/CRMMacConformanceTests/DataSourcePluginConformanceTests.swift
@@ -110,14 +110,20 @@ final class DataSourcePluginConformanceTests: XCTestCase {
                            "lastScheduledAt == T to state.json")
 
             // (2) heartbeat-payload registry — written by the plugin's
-            // own healthRegistry.update(...) inside performTick().
+            // own healthRegistry.update(...) inside performTick(). Each
+            // plugin's fast-path snapshot stamps lastScheduledAt from
+            // the same injected (fixed) clock — either the tick-start
+            // snapshot (gated PhoneCalls) or the markUnhealthy snapshot
+            // (the other four) — so the heartbeat-payload timestamp must
+            // be exactly T, not merely non-nil. A plugin that emits a
+            // stale/wrong heartbeat timestamp fails here.
             let snap = await spec.registry.read(plugin.id)
             XCTAssertNotNil(snap,
                             "\(plugin.id.rawValue): performTick() must report a " +
                             "SourceHealthRegistry snapshot")
-            XCTAssertNotNil(snap?.lastScheduledAt,
-                            "\(plugin.id.rawValue): the heartbeat-payload snapshot " +
-                            "must carry lastScheduledAt (feeds the Pi /heartbeat)")
+            XCTAssertEqual(snap?.lastScheduledAt, fixedInstant,
+                           "\(plugin.id.rawValue): the heartbeat-payload snapshot must " +
+                           "carry lastScheduledAt == T (feeds the Pi /heartbeat)")
 
             behaviorallyTestedIDs.insert(plugin.id)
         }
@@ -165,11 +171,21 @@ final class DataSourcePluginConformanceTests: XCTestCase {
     func testSourceDerivedConformerSetMatchesExpected() throws {
         let sourcesRoot = Self.resolveSourcesRoot()
         var sourceDerived: Set<SourceID> = []
+        // Track conformer files vs. successfully-extracted ids so a
+        // conformer whose declaration shape defeats the regex (extension
+        // conformance, comma-separated clause, computed id, id literal
+        // in another file) fails LOUDLY via the count check below rather
+        // than being silently invisible to the set comparison.
+        var conformerFileCount = 0
+        var extractedIDCount = 0
         for fileURL in try Self.swiftFiles(under: sourcesRoot) {
             let code = try String(contentsOf: fileURL, encoding: .utf8)
             guard code.range(of: #":\s*DataSourcePlugin"#, options: .regularExpression) != nil
             else { continue }
-            for rawCase in Self.idCaseLiterals(in: code) {
+            conformerFileCount += 1
+            let cases = Self.idCaseLiterals(in: code)
+            for rawCase in cases {
+                extractedIDCount += 1
                 guard let id = Self.sourceID(forCaseName: rawCase) else {
                     XCTFail("\(fileURL.lastPathComponent): unknown SourceID case " +
                             "`.\(rawCase)` — update sourceID(forCaseName:) when adding a " +
@@ -179,6 +195,18 @@ final class DataSourcePluginConformanceTests: XCTestCase {
                 sourceDerived.insert(id)
             }
         }
+        // One conformer file -> exactly one id literal -> one expected
+        // entry. Any mismatch means the scanner missed (or double-counted)
+        // a conformer; surface it instead of letting old==old pass.
+        XCTAssertEqual(conformerFileCount, Self.expectedDataSources.count,
+                       "found \(conformerFileCount) `: DataSourcePlugin` conformer " +
+                       "file(s) but expected \(Self.expectedDataSources.count) — a new " +
+                       "conformer must be wired into expectedDataSources + layer (a)'s loop")
+        XCTAssertEqual(extractedIDCount, conformerFileCount,
+                       "extracted \(extractedIDCount) id literal(s) from " +
+                       "\(conformerFileCount) conformer file(s) — a conformer whose " +
+                       "`id: SourceID = .<case>` form defeats the scanner must keep the " +
+                       "documented single-line form OR the scanner must be upgraded")
         XCTAssertEqual(sourceDerived, Self.expectedDataSources,
                        "the set of `: DataSourcePlugin` conformers derived from Sources/ " +
                        "must equal expectedDataSources; a new conformer must be added to " +

--- a/mac-daemon/Tests/CRMMacCoreTests/SQLiteURILiteralGuardTests.swift
+++ b/mac-daemon/Tests/CRMMacCoreTests/SQLiteURILiteralGuardTests.swift
@@ -9,10 +9,10 @@
 //
 // Family 1 — forbidden SQLite-URI string literals (the original bug
 //   class). A re-introduced `?mode=ro` literal, an `immutable=1` flag
-//   (which would re-blind the reader to WAL-resident writes — the #336
-//   regression), a `cache=shared` flag (deliberately never used), or a
-//   bare `file://` SQLite URI prefix anywhere in code other than the
-//   helper.
+//   (which would re-blind the reader to WAL-resident writes — the
+//   production regression that motivated this guard), a `cache=shared`
+//   flag (deliberately never used), or a bare `file://` SQLite URI
+//   prefix anywhere in code other than the helper.
 //
 // Family 2 — forbidden bare-path live-DB opens. A future
 //   `DatabasePool(path: config.whatsappDBPath.path, ...)` would slip
@@ -86,7 +86,8 @@ final class SQLiteURILiteralGuardTests: XCTestCase {
         // code (belt-and-suspenders; the helper uses neither).
         if code.contains("immutable=1") {
             out.append("\(filename): `immutable=1` forbidden — it re-blinds the " +
-                       "reader to WAL-resident writes (the #336 regression).")
+                       "reader to WAL-resident writes (the production regression " +
+                       "that motivated this guard).")
         }
         if code.contains("cache=shared") {
             out.append("\(filename): `cache=shared` forbidden — GRDB only honours it " +

--- a/mac-daemon/Tests/CRMMacCoreTests/SQLiteURILiteralGuardTests.swift
+++ b/mac-daemon/Tests/CRMMacCoreTests/SQLiteURILiteralGuardTests.swift
@@ -1,0 +1,254 @@
+// SQLiteURILiteralGuardTests — a source-tree grep guard that forbids
+// ad-hoc live-DB opens outside the single owner,
+// `SQLiteSnapshotReader.swift`.
+//
+// Every SQLite file the daemon opens is a read-only tail of a live
+// macOS store (chat.db, CallHistoryDB, future WhatsApp DBs). The local
+// convention is "all GRDB file opens go through SQLiteSnapshotReader",
+// so this guard forbids two regression shapes in production `Sources/`:
+//
+// Family 1 — forbidden SQLite-URI string literals (the original bug
+//   class). A re-introduced `?mode=ro` literal, an `immutable=1` flag
+//   (which would re-blind the reader to WAL-resident writes — the #336
+//   regression), a `cache=shared` flag (deliberately never used), or a
+//   bare `file://` SQLite URI prefix anywhere in code other than the
+//   helper.
+//
+// Family 2 — forbidden bare-path live-DB opens. A future
+//   `DatabasePool(path: config.whatsappDBPath.path, ...)` would slip
+//   past a URI-only grep, so any file that constructs a
+//   `DatabasePool(path:` or `DatabaseQueue(path:` MUST contain at least
+//   as many `SQLiteSnapshotReader.readOnlyURI(` calls as it has opens.
+//   This is file-level (not per-call dataflow) because the production
+//   call sites bind the URI to a local first
+//   (`let uri = SQLiteSnapshotReader.readOnlyURI(...); DatabasePool(path: uri, ...)`),
+//   so a same-call-argument rule would reject our own correct code. The
+//   call-count match (#opens <= #helper-calls) raises the bar from
+//   "one helper call covers any number of opens" to "every open needs
+//   its own helper call," which is sufficient for the single-DB-per-file
+//   present and the multi-DB WhatsApp future. It is an accepted, bounded
+//   limitation (a file with 2 opens + 2 helper calls whose wiring is
+//   crossed would still pass); upgrade to a per-call dataflow check if a
+//   future reader ever needs finer granularity.
+//
+// Comments are stripped (string-literal-aware) before scanning so the
+// reader doc comments and the Pi-URL `file://` rejection comments in
+// Config.swift / InstallRequestParser.swift do not trip the guard.
+//
+// Test targets are NOT scanned — only `Sources/` — so WAL-test writer
+// configs that use DatabaseQueue/DatabasePool directly are fine.
+import XCTest
+@testable import CRMMacCore
+
+final class SQLiteURILiteralGuardTests: XCTestCase {
+    /// Only file that may own a Family-1 SQLite URI literal. Family 2
+    /// needs no file allowlist — the per-file `readOnlyURI(` count is
+    /// the exception mechanism.
+    private static let family1AllowedFilenames: Set<String> = [
+        "SQLiteSnapshotReader.swift",
+    ]
+
+    func testNoAdHocLiveDBOpensOutsideHelper() throws {
+        let sourcesRoot = Self.resolveSourcesRoot()
+        XCTAssertTrue(FileManager.default.fileExists(atPath: sourcesRoot.path),
+                      "Sources root not found at \(sourcesRoot.path) — did the " +
+                      "test file move relative to mac-daemon/Sources?")
+
+        let swiftFiles = try Self.swiftFiles(under: sourcesRoot)
+        XCTAssertFalse(swiftFiles.isEmpty, "expected to find .swift files under Sources/")
+
+        var failures: [String] = []
+        for fileURL in swiftFiles {
+            let raw = try String(contentsOf: fileURL, encoding: .utf8)
+            let code = Self.strippingComments(raw)
+            let filename = fileURL.lastPathComponent
+
+            // Family 1 — forbidden URI literals (skip the helper).
+            if !Self.family1AllowedFilenames.contains(filename) {
+                failures.append(contentsOf: Self.family1Failures(code: code, filename: filename))
+            }
+
+            // Family 2 — bare-path opens must route through the helper.
+            failures.append(contentsOf: Self.family2Failures(code: code, filename: filename))
+        }
+
+        XCTAssertTrue(failures.isEmpty,
+                      "ad-hoc live-DB open(s) found — route every SQLite file open " +
+                      "through SQLiteSnapshotReader.readOnlyURI(for:):\n" +
+                      failures.joined(separator: "\n"))
+    }
+
+    // MARK: - Family 1
+
+    private static func family1Failures(code: String, filename: String) -> [String] {
+        var out: [String] = []
+        // `immutable=1` and `cache=shared` are forbidden anywhere in
+        // code (belt-and-suspenders; the helper uses neither).
+        if code.contains("immutable=1") {
+            out.append("\(filename): `immutable=1` forbidden — it re-blinds the " +
+                       "reader to WAL-resident writes (the #336 regression).")
+        }
+        if code.contains("cache=shared") {
+            out.append("\(filename): `cache=shared` forbidden — GRDB only honours it " +
+                       "for in-memory DBs; never use it for a file-backed reader.")
+        }
+        // `mode=ro` only appears in a SQLite URI literal; forbid it
+        // outside the helper.
+        if code.contains("mode=ro") {
+            out.append("\(filename): `mode=ro` URI literal forbidden outside " +
+                       "SQLiteSnapshotReader.")
+        }
+        // A `file://` immediately followed by a `\(` interpolation OR
+        // `?mode=ro` is the live-DB SQLite-URI shape. Scoping to that
+        // shape avoids tripping on any future `file://`-scheme literal
+        // that is NOT a SQLite open (none exist today). The
+        // interpolation check is a plain `contains`: in stripped source
+        // text, `file://\(...)` appears as the literal characters
+        // f i l e : / / \ ( — so `"file://\\("` (backslash + paren) is
+        // the exact byte sequence to find.
+        if code.contains("file://\\(")
+            || code.range(of: #"file://[^"\s]*\?mode=ro"#, options: .regularExpression) != nil {
+            out.append("\(filename): `file://...` SQLite URI literal forbidden outside " +
+                       "SQLiteSnapshotReader.")
+        }
+        return out
+    }
+
+    // MARK: - Family 2
+
+    private static func family2Failures(code: String, filename: String) -> [String] {
+        // Whitespace/newline-tolerant: a `DatabasePool(path:` or
+        // `DatabaseQueue(path:` call may wrap across lines after the
+        // open paren (`DatabasePool(\n    path: ...)`), so match the
+        // constructor + the `path:` first argument across any
+        // intervening whitespace.
+        let openCount = Self.regexCount(#"DatabasePool\(\s*path:"#, in: code)
+            + Self.regexCount(#"DatabaseQueue\(\s*path:"#, in: code)
+        if openCount == 0 { return [] }
+        let helperCount = Self.occurrences(of: "SQLiteSnapshotReader.readOnlyURI(", in: code)
+        if helperCount < openCount {
+            return ["\(filename): \(openCount) DatabasePool/Queue(path:) open(s) but only " +
+                    "\(helperCount) SQLiteSnapshotReader.readOnlyURI(...) call(s) — every " +
+                    "file DB open must route through the helper."]
+        }
+        return []
+    }
+
+    // MARK: - helpers
+
+    /// Resolve `mac-daemon/Sources` from THIS file's compile-time path.
+    /// File lives at mac-daemon/Tests/CRMMacCoreTests/<file>.swift, so
+    /// three `deletingLastPathComponent()` reach mac-daemon/.
+    private static func resolveSourcesRoot() -> URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent() // CRMMacCoreTests/
+            .deletingLastPathComponent() // Tests/
+            .deletingLastPathComponent() // mac-daemon/
+            .appendingPathComponent("Sources")
+    }
+
+    private static func swiftFiles(under root: URL) throws -> [URL] {
+        var result: [URL] = []
+        guard let enumerator = FileManager.default.enumerator(
+            at: root,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]) else {
+            return result
+        }
+        for case let url as URL in enumerator where url.pathExtension == "swift" {
+            result.append(url)
+        }
+        return result
+    }
+
+    private static func occurrences(of needle: String, in haystack: String) -> Int {
+        guard !needle.isEmpty else { return 0 }
+        var count = 0
+        var searchRange = haystack.startIndex..<haystack.endIndex
+        while let found = haystack.range(of: needle, range: searchRange) {
+            count += 1
+            searchRange = found.upperBound..<haystack.endIndex
+        }
+        return count
+    }
+
+    /// Count non-overlapping matches of `pattern`. `\s` in the pattern
+    /// matches newlines, so a call that wraps across lines is counted.
+    private static func regexCount(_ pattern: String, in haystack: String) -> Int {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return 0 }
+        let range = NSRange(haystack.startIndex..<haystack.endIndex, in: haystack)
+        return regex.numberOfMatches(in: haystack, range: range)
+    }
+
+    /// String-literal-aware comment stripper. Removes `//` line comments
+    /// and `/* ... */` block comments while preserving `//` that appears
+    /// inside a `"..."` string literal (e.g. `"https://..."`), so a
+    /// real SQLite URI literal in code is NOT destroyed by naive
+    /// `//`-stripping. Not a full Swift lexer (ignores `#"..."#` raw
+    /// strings and `'` — neither carries SQLite URIs in this codebase),
+    /// but exact for the shapes the guard must distinguish.
+    static func strippingComments(_ source: String) -> String {
+        enum Mode { case code, string, lineComment, blockComment }
+        var mode: Mode = .code
+        var out = String()
+        out.reserveCapacity(source.count)
+        let chars = Array(source)
+        var i = 0
+        while i < chars.count {
+            let c = chars[i]
+            let next: Character? = (i + 1 < chars.count) ? chars[i + 1] : nil
+            switch mode {
+            case .code:
+                if c == "/" && next == "/" {
+                    mode = .lineComment
+                    i += 2
+                } else if c == "/" && next == "*" {
+                    mode = .blockComment
+                    i += 2
+                } else if c == "\"" {
+                    out.append(c)
+                    mode = .string
+                    i += 1
+                } else {
+                    out.append(c)
+                    i += 1
+                }
+            case .string:
+                if c == "\\" {
+                    // Preserve escape sequences (incl. \( interpolation
+                    // open) verbatim — Family 1 keys off `file://\(`.
+                    out.append(c)
+                    if let n = next {
+                        out.append(n)
+                        i += 2
+                    } else {
+                        i += 1
+                    }
+                } else if c == "\"" {
+                    out.append(c)
+                    mode = .code
+                    i += 1
+                } else {
+                    out.append(c)
+                    i += 1
+                }
+            case .lineComment:
+                if c == "\n" {
+                    out.append(c)
+                    mode = .code
+                }
+                i += 1
+            case .blockComment:
+                if c == "*" && next == "/" {
+                    mode = .code
+                    i += 2
+                } else {
+                    // Preserve newlines so line structure is roughly kept.
+                    if c == "\n" { out.append(c) }
+                    i += 1
+                }
+            }
+        }
+        return out
+    }
+}

--- a/mac-daemon/Tests/CRMMacMessagesSourceTests/ChatDBWALVisibilityTests.swift
+++ b/mac-daemon/Tests/CRMMacMessagesSourceTests/ChatDBWALVisibilityTests.swift
@@ -2,11 +2,14 @@
 // read path (`SQLiteSnapshotReader.readOnlyURI`). Mirrors
 // CallHistoryDBWALVisibilityTests on the phone_calls side.
 //
-// Messages.app writes chat.db in WAL mode continuously, and macOS
-// does not checkpoint it on any predictable cadence. If the reader
-// were ever opened with `?...&immutable=1`, SQLite would serve only
-// the main DB file and ignore the -wal sidecar — blinding the daemon
-// to every message written since the last checkpoint.
+// Messages.app writes chat.db in WAL mode continuously. Even though
+// Messages.app checkpoints more aggressively than CallHistoryDB, any
+// write made since the last checkpoint lives in the -wal sidecar. If
+// the reader were ever opened with `?...&immutable=1`, SQLite would
+// serve only the main DB file and ignore the -wal sidecar — blinding
+// the daemon to every such uncheckpointed message. This locks in that
+// the bare-path -> SQLiteSnapshotReader URI conversion did not regress
+// WAL visibility, and guards against a future immutable=1 slip.
 //
 // This test exercises the production scenario end-to-end and is
 // deliberately FILE-BACKED (not InMemoryChatDB): an in-memory DB has

--- a/mac-daemon/Tests/CRMMacMessagesSourceTests/ChatDBWALVisibilityTests.swift
+++ b/mac-daemon/Tests/CRMMacMessagesSourceTests/ChatDBWALVisibilityTests.swift
@@ -1,0 +1,212 @@
+// Regression test for chat.db WAL visibility through the production
+// read path (`SQLiteSnapshotReader.readOnlyURI`). Mirrors
+// CallHistoryDBWALVisibilityTests on the phone_calls side.
+//
+// Messages.app writes chat.db in WAL mode continuously, and macOS
+// does not checkpoint it on any predictable cadence. If the reader
+// were ever opened with `?...&immutable=1`, SQLite would serve only
+// the main DB file and ignore the -wal sidecar — blinding the daemon
+// to every message written since the last checkpoint.
+//
+// This test exercises the production scenario end-to-end and is
+// deliberately FILE-BACKED (not InMemoryChatDB): an in-memory DB has
+// no -wal sidecar and cannot exercise WAL-resident-write visibility.
+//   1. Build a chat.db-shaped file from the committed schema fixture,
+//      insert N rows, force a checkpoint so they fold into the main
+//      file, close.
+//   2. Open a second writer, insert M more rows, close WITHOUT
+//      checkpointing — those rows live in the -wal sidecar.
+//   3. Open via the production URI builder and assert all N+M rows are
+//      visible through ChatDBReader.fetchPage.
+import XCTest
+import GRDB
+import CRMMacCore
+@testable import CRMMacMessagesSource
+
+final class ChatDBWALVisibilityTests: XCTestCase {
+    private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("crm-mac-chatdb-wal-test-\(UUID().uuidString)",
+                                    isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir,
+                                                withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let dir = tempDir {
+            try? FileManager.default.removeItem(at: dir)
+        }
+    }
+
+    /// Writer connections use WAL journal mode and no automatic
+    /// checkpoint so the test deterministically leaves
+    /// uncommitted-to-main rows in the WAL sidecar.
+    private func makeWriterConfig() -> Configuration {
+        var config = Configuration()
+        config.readonly = false
+        config.prepareDatabase { db in
+            try db.execute(sql: "PRAGMA journal_mode = WAL")
+            try db.execute(sql: "PRAGMA wal_autocheckpoint = 0")
+        }
+        return config
+    }
+
+    /// Load the committed chat.db schema fixture into a fresh
+    /// file-backed DB + seed the one handle + chat the reader joins to.
+    private func createSchema(at path: String) throws {
+        let bundle = Bundle.module
+        guard let scriptURL = bundle.url(forResource: "chat_db_schema",
+                                         withExtension: "sql",
+                                         subdirectory: "Fixtures") else {
+            throw NSError(domain: "ChatDBWALVisibilityTests", code: 1,
+                          userInfo: [NSLocalizedDescriptionKey:
+                                     "chat_db_schema.sql not found in Bundle.module/Fixtures"])
+        }
+        let script = try String(contentsOf: scriptURL, encoding: .utf8)
+        let queue = try DatabaseQueue(path: path, configuration: makeWriterConfig())
+        try queue.write { db in
+            try db.execute(sql: script)
+            // One inbound peer handle + one 1:1 chat the reader joins.
+            try db.execute(sql:
+                "INSERT INTO handle (ROWID, id, service) VALUES (1, '+15551234567', 'iMessage')")
+            try db.execute(sql:
+                "INSERT INTO chat (ROWID, guid, style) VALUES (1, 'chat-guid-1', 45)")
+        }
+    }
+
+    /// Insert one inbound message row + its chat_message_join. `date`
+    /// is Apple-epoch nanoseconds for a 2025 timestamp, comfortably
+    /// above the reader's corrupt-date sentinel floor.
+    private func insertMessage(
+        into queue: DatabaseQueue, rowID: Int64, guid: String, unixDate: TimeInterval
+    ) throws {
+        let appleDate = InMemoryChatDB.appleEpochNanos(unix: unixDate)
+        try queue.write { db in
+            try db.execute(sql: """
+                INSERT INTO message (ROWID, guid, text, handle_id, date,
+                                     is_from_me, cache_has_attachments)
+                VALUES (?, ?, 'hi', 1, ?, 0, 0)
+                """, arguments: [rowID, guid, appleDate])
+            try db.execute(sql:
+                "INSERT INTO chat_message_join (chat_id, message_id) VALUES (1, ?)",
+                arguments: [rowID])
+        }
+    }
+
+    /// 2025-01-01T00:00:00Z in UNIX seconds.
+    private let baseUnix: TimeInterval = 1_735_689_600
+
+    /// Production-path open: reuses `SQLiteSnapshotReader.readOnlyURI`
+    /// to build the exact URI production uses, so a future change to
+    /// the URI shape lands in both call sites simultaneously.
+    private func openProductionReader(at path: String) throws -> DatabasePool {
+        var config = Configuration()
+        config.readonly = true
+        let uri = SQLiteSnapshotReader.readOnlyURI(for: URL(fileURLWithPath: path))
+        return try DatabasePool(path: uri, configuration: config)
+    }
+
+    /// Core regression assertion: rows inserted via a separate writer
+    /// connection that did NOT checkpoint must still be visible to the
+    /// production-path reader. With `immutable=1` (the regression),
+    /// this fails — only the pre-checkpoint rows are returned.
+    func testReaderSeesWALResidentWrites() throws {
+        let dbPath = tempDir.appendingPathComponent("chat.db").path
+
+        // Step 1: schema + 3 rows + force a checkpoint into the main file.
+        try createSchema(at: dbPath)
+        do {
+            let queue = try DatabaseQueue(path: dbPath, configuration: makeWriterConfig())
+            for i in 0..<3 {
+                try insertMessage(into: queue, rowID: Int64(100 + i),
+                                  guid: "checkpoint-\(i)", unixDate: baseUnix + Double(i))
+            }
+            try queue.writeWithoutTransaction { db in
+                try db.execute(sql: "PRAGMA wal_checkpoint(TRUNCATE)")
+            }
+        }
+
+        // Step 2: second writer, 4 more rows, close WITHOUT checkpoint.
+        do {
+            let queue = try DatabaseQueue(path: dbPath, configuration: makeWriterConfig())
+            for i in 0..<4 {
+                try insertMessage(into: queue, rowID: Int64(200 + i),
+                                  guid: "wal-only-\(i)", unixDate: baseUnix + 100 + Double(i))
+            }
+        }
+
+        // Sanity: the -wal sidecar must actually exist, otherwise the
+        // test isn't exercising the regression.
+        let walPath = dbPath + "-wal"
+        XCTAssertTrue(FileManager.default.fileExists(atPath: walPath),
+                      "expected -wal sidecar to exist; otherwise the test " +
+                      "isn't exercising the WAL-visibility regression")
+
+        // Step 3: open via the production read path; assert all 7 rows.
+        let pool = try openProductionReader(at: dbPath)
+        let page = try pool.read { db in
+            try ChatDBReader.fetchPage(
+                db: db,
+                direction: .forwardFromExclusive(0),
+                limit: 100)
+        }
+        XCTAssertEqual(page.rows.count, 7,
+                       "reader must see both checkpointed (3) and WAL-only " +
+                       "(4) rows — total 7. Got \(page.rows.count). If this " +
+                       "fails with 3, `immutable=1` has been re-introduced " +
+                       "on chat.db.")
+        let guids = Set(page.rows.map { $0.guid })
+        XCTAssertTrue(guids.contains("checkpoint-0"))
+        XCTAssertTrue(guids.contains("wal-only-0"))
+        XCTAssertTrue(guids.contains("wal-only-3"))
+    }
+
+    /// Companion: a reader opened AFTER a writer adds an uncheckpointed
+    /// row past the prior live cursor still observes it. Mirrors the
+    /// daemon's per-tick "fetch rows past the committed live cursor".
+    func testReaderSeesNewWALRowsAfterCursorAdvance() throws {
+        let dbPath = tempDir.appendingPathComponent("chat.db").path
+        try createSchema(at: dbPath)
+
+        do {
+            let queue = try DatabaseQueue(path: dbPath, configuration: makeWriterConfig())
+            try insertMessage(into: queue, rowID: 100, guid: "initial",
+                              unixDate: baseUnix + 10)
+            try queue.writeWithoutTransaction { db in
+                try db.execute(sql: "PRAGMA wal_checkpoint(TRUNCATE)")
+            }
+        }
+
+        do {
+            let pool = try openProductionReader(at: dbPath)
+            let page = try pool.read { db in
+                try ChatDBReader.fetchPage(
+                    db: db, direction: .forwardFromExclusive(0), limit: 100)
+            }
+            XCTAssertEqual(page.rows.count, 1)
+            XCTAssertEqual(page.rows[0].guid, "initial")
+        }
+
+        // Writer adds a new row WITHOUT checkpointing.
+        do {
+            let queue = try DatabaseQueue(path: dbPath, configuration: makeWriterConfig())
+            try insertMessage(into: queue, rowID: 200, guid: "wal-new",
+                              unixDate: baseUnix + 20)
+        }
+
+        // Second reader open: must see the WAL-only row past the cursor.
+        do {
+            let pool = try openProductionReader(at: dbPath)
+            let page = try pool.read { db in
+                try ChatDBReader.fetchPage(
+                    db: db, direction: .forwardFromExclusive(100), limit: 100)
+            }
+            XCTAssertEqual(page.rows.count, 1,
+                           "reader must observe the WAL-only row past the " +
+                           "advanced cursor; got \(page.rows.count) rows")
+            XCTAssertEqual(page.rows[0].guid, "wal-new")
+        }
+    }
+}

--- a/mac-daemon/Tests/CRMMacPhoneCallsSourceTests/CallHistoryDBWALVisibilityTests.swift
+++ b/mac-daemon/Tests/CRMMacPhoneCallsSourceTests/CallHistoryDBWALVisibilityTests.swift
@@ -19,6 +19,7 @@
 // only N rows. With the fix, step 3 returns N+M.
 import XCTest
 import GRDB
+import CRMMacCore
 @testable import CRMMacPhoneCallsSource
 
 final class CallHistoryDBWALVisibilityTests: XCTestCase {
@@ -89,13 +90,13 @@ final class CallHistoryDBWALVisibilityTests: XCTestCase {
     /// 2025-01-01T00:00:00Z in Apple-epoch seconds.
     private let baseZDate: Double = 1_735_689_600 - 978_307_200
 
-    /// Production-path open: reuses `PhoneCallsSourcePlugin.callHistoryDBURI`
+    /// Production-path open: reuses `SQLiteSnapshotReader.readOnlyURI`
     /// to build the exact URI production uses, so a future change to the
     /// URI shape lands in both call sites simultaneously.
     private func openProductionReader(at path: String) throws -> DatabasePool {
         var config = Configuration()
         config.readonly = true
-        let uri = PhoneCallsSourcePlugin.callHistoryDBURI(for: URL(fileURLWithPath: path))
+        let uri = SQLiteSnapshotReader.readOnlyURI(for: URL(fileURLWithPath: path))
         return try DatabasePool(path: uri, configuration: config)
     }
 

--- a/mac-daemon/Tests/CRMMacPhoneCallsSourceTests/SQLiteSnapshotReaderTests.swift
+++ b/mac-daemon/Tests/CRMMacPhoneCallsSourceTests/SQLiteSnapshotReaderTests.swift
@@ -1,0 +1,113 @@
+// SQLiteSnapshotReaderTests — verifies the read-only WAL-aware URI the
+// helper produces opens the SAME file as a direct bare-path open, for
+// every path-byte class the helper's doc comment claims to support.
+//
+// The contract is load-bearing in production: the real macOS DBs live
+// under `~/Library/Application Support/...`, whose path contains a
+// SPACE — encoded to `%20` and round-tripped back by SQLite's `file:`
+// URI parser. The `%` case is the sharpest (a raw `%` is an invalid URI
+// escape; encoding it to `%25` is what makes it round-trip).
+//
+// Each test writes a row through a bare-path DatabaseQueue at the EXACT
+// special-character path, then opens via
+// `SQLiteSnapshotReader.readOnlyURI(for:)` and asserts the row is
+// visible — proving both opens resolve to the same file. (This test
+// lives in a test target, which the SQLiteURILiteralGuardTests grep
+// does NOT scan, so the bare-path writer open is allowed here.)
+//
+// If any case ever fails to round-trip via GRDB/SQLite, NARROW the
+// helper's documented contract to the characters that do work rather
+// than claiming broader support than this proves.
+import XCTest
+import GRDB
+import CRMMacCore
+
+final class SQLiteSnapshotReaderTests: XCTestCase {
+    private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("crm-mac-uri-test-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let dir = tempDir { try? FileManager.default.removeItem(at: dir) }
+    }
+
+    /// Create a one-row DB at `path` via a bare-path writer, then open
+    /// the SAME path through the helper URI and assert the row reads
+    /// back. Round-trip success proves the encoded URI resolves to the
+    /// exact same file as the bare path.
+    private func assertRoundTrips(path: String, file: StaticString = #filePath, line: UInt = #line) throws {
+        // Bare-path writer at the exact (unencoded) path.
+        do {
+            let queue = try DatabaseQueue(path: path)
+            try queue.write { db in
+                try db.execute(sql: "CREATE TABLE t (v TEXT NOT NULL)")
+                try db.execute(sql: "INSERT INTO t (v) VALUES ('sentinel')")
+            }
+        }
+
+        // Reader via the production URI builder.
+        var config = Configuration()
+        config.readonly = true
+        let uri = SQLiteSnapshotReader.readOnlyURI(for: path)
+        let pool = try DatabasePool(path: uri, configuration: config)
+        let value = try pool.read { db in
+            try String.fetchOne(db, sql: "SELECT v FROM t LIMIT 1")
+        }
+        XCTAssertEqual(value, "sentinel",
+                       "URI \(uri) must open the SAME file as bare path \(path)",
+                       file: file, line: line)
+    }
+
+    func testSpacePathRoundTrips() throws {
+        let dir = tempDir.appendingPathComponent("a b", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try assertRoundTrips(path: dir.appendingPathComponent("db.sqlite").path)
+    }
+
+    func testQuestionMarkPathRoundTrips() throws {
+        let dir = tempDir.appendingPathComponent("a?b", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try assertRoundTrips(path: dir.appendingPathComponent("db.sqlite").path)
+    }
+
+    func testHashPathRoundTrips() throws {
+        let dir = tempDir.appendingPathComponent("a#b", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try assertRoundTrips(path: dir.appendingPathComponent("db.sqlite").path)
+    }
+
+    func testPercentPathRoundTrips() throws {
+        // The sharpest case: a raw `%` is an invalid URI escape; the
+        // helper must encode it to `%25` to round-trip.
+        let dir = tempDir.appendingPathComponent("a%b", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try assertRoundTrips(path: dir.appendingPathComponent("db.sqlite").path)
+    }
+
+    func testApplicationSupportStylePathRoundTrips() throws {
+        // Mirrors the real production path shape (contains a space).
+        let dir = tempDir
+            .appendingPathComponent("Application Support", isDirectory: true)
+            .appendingPathComponent("CallHistoryDB", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try assertRoundTrips(path: dir.appendingPathComponent("CallHistory.storedata").path)
+    }
+
+    func testPlainAsciiPathIsTextuallyUnchangedAfterPrefix() {
+        // For an ASCII path free of URI-significant bytes, encoding is a
+        // no-op: the URI is just `file://<path>?mode=ro`.
+        let uri = SQLiteSnapshotReader.readOnlyURI(for: "/tmp/plain/db.sqlite")
+        XCTAssertEqual(uri, "file:///tmp/plain/db.sqlite?mode=ro")
+    }
+
+    func testURLOverloadMatchesStringOverload() {
+        let path = "/tmp/Application Support/x.sqlite"
+        XCTAssertEqual(
+            SQLiteSnapshotReader.readOnlyURI(for: URL(fileURLWithPath: path)),
+            SQLiteSnapshotReader.readOnlyURI(for: path))
+    }
+}


### PR DESCRIPTION
## Summary

Mac-daemon Swift-only change (issue #351) with two coupled refactors plus their mechanical guards:

- **`SQLiteSnapshotReader`** (new, in `CRMMacCore`) — the single chokepoint that builds the read-only, WAL-aware SQLite URI (`file://<percent-encoded-path>?mode=ro`) for every live macOS DB the daemon tails. PhoneCalls is repointed to it (its private `callHistoryDBURI` is deleted) and Messages is converted from a bare-path `DatabasePool(path:)` open to the helper. The load-bearing invariant is the absence of `immutable=1` (which would re-blind the reader to WAL-resident writes); `cache=shared` is also never used (GRDB honours it only for in-memory DBs).
- **`DataSourcePlugin`** (new sub-protocol of `SourcePlugin`, in `CRMMacCore`) — its extension provides the `tick()` witness that auto-persists the per-tick `state.sources[id].lastScheduledAt` liveness heartbeat before delegating to a new `performTick()` hook. All five data plugins (Messages, PhoneCalls, iCloud Contacts, Anarlog Humans, Anarlog Sessions) are migrated to `performTick()`, deleting the five hand-written `updateScheduled(at:)` copies, so the on-disk heartbeat bump is un-forgettable for a future sixth source. `mutator`/`clock`/`logger` are promoted to `public nonisolated let` on each actor (same pattern as the existing `nonisolated let id`/`tickInterval`). Each `performTick()` keeps its own `clock()` read and the `healthRegistry.update(...)` write that feeds the Pi `/heartbeat` payload — the extension owns only the state.json write. Operational loops (`HeartbeatLoop`, the notification reconcile loop) stay on the bare `SourcePlugin`.

## Settled design decisions (confirmed with the user during planning)

- **`mode=ro` only, no `cache=shared`** — production has never used `cache=shared`; for a file-backed read-only `DatabasePool`, `mode=ro` is already WAL-aware (proven by the existing CallHistoryDB WAL-visibility regression). The absence of `immutable=1` is the fix that mattered, not the presence of `cache=shared`.
- **Messages converted to the helper** — so the grep guard can forbid all ad-hoc live-DB opens (URI literals AND bare-path opens), not just URI literals.
- **`DataSourcePlugin` + `performTick()`** — de-duplicate the five `updateScheduled` copies into one protocol-extension-provided behavior and enforce it via tests, rather than just "adding the missing ones" (none were missing; all five already bumped the heartbeat by hand).

## Mechanical guards added

- `SQLiteURILiteralGuardTests` — walks `Sources/**/*.swift` (comments stripped, string-literal-aware) and fails on re-introduced SQLite-URI literals (`mode=ro`/`immutable=1`/`cache=shared`/`file://...`) outside the helper, and on any file whose `DatabasePool(path:)`/`DatabaseQueue(path:)` opens outnumber its `readOnlyURI(...)` calls (closes the future WhatsApp multi-DB-per-file gap).
- `DataSourcePluginConformanceTests` (new `CRMMacConformanceTests` target) — four layers: (a) per-plugin behavioral assertion through an `any SourcePlugin` reference that both state.json and the heartbeat-payload registry carry `lastScheduledAt == T`; (b) a `func tick(`-ban grep over the four source-library modules (a concrete `tick()` would shadow the extension default); (c) a single `expectedDataSources` literal asserted against both a source-derived conformer scan (with a loud-fail count check) and the behavior-derived set; (d) extension-default + coalescing smoke tests.
- `SQLiteSnapshotReaderTests` — special-character path round-trips (space, `?`, `#`, `%`, an `Application Support`-style path, plain ASCII, and URL/String overload parity).
- `ChatDBWALVisibilityTests` — file-backed Messages WAL-visibility regression mirroring the existing PhoneCalls one; `CallHistoryDBWALVisibilityTests` repointed to the helper.

## Test plan

- `swift build -c release -Xswiftc -warnings-as-errors` (CI's exact build gate) — passes locally after every commit.
- The full XCTest suite (`swift test`) first runs in **CI on `macos-15`** with full Xcode. This dev machine has only Command Line Tools, so XCTest cannot be compiled/run locally. The load-bearing test logic was independently validated with standalone non-XCTest Swift scripts: the grep guard (trips on all three regression shapes, passes the real tree), the special-character URI round-trips (validated against the SQLite C API with GRDB's exact `SQLITE_OPEN_READONLY | SQLITE_OPEN_URI` flags — all of space/`?`/`#`/`%`/`Application Support`/plain round-trip to the same file), and the conformer scanner counts (5 conformer files = 5 ids = 5 expected).
- Scope is exactly `mac-daemon/**` Swift + one doc edit (`.ai/spec/mac-daemon.md`). No `frontend/` or Go backend changes; the CI `mac-daemon-tests` job (path-filtered to `mac-daemon/**`) is the relevant gate.

## Known non-blocking follow-ups (review-head P2/P3)

These were surfaced by the pre-push review as non-blocking quality nits and are intentionally NOT addressed in this PR (to keep HEAD aligned with the review verdict):

- **[P2]** Sessions coalescing now persists `lastScheduledAt` on every fire (benign, "strictly more liveness signal"), but the in-flight/early-return path is tested only via the `StubDataSource`, not the real `AnarlogSessionsSourcePlugin` with `tickInFlight` actually set. Follow-up: add a focused `CRMMacAnarlogSourceTests` test driving two overlapping `tick()` calls.
- **[P2]** A conformance-suite comment names only the `markUnhealthy` snapshot as the `lastScheduledAt` stamper for Messages/iCloud/Anarlog, when the top-of-tick snapshot stamps it first (the assertion still holds). Comment-only reword.
- **[P2]** The Family-2 grep guard is a file-level count, not a per-call dataflow check — a future multi-DB file with crossed wiring (2 opens + 2 helper calls) would pass. Knowingly-bounded and documented in-file; re-check when the WhatsApp source lands.
- **[P3]** `SQLiteSnapshotReader` doc claims `cache=shared` is "no-op-to-harmful" but only substantiates the no-op half. Drop "to-harmful" or cite the concrete harm.
- **[P3]** `readOnlyURI(for:)`'s `?? path` fallback silently degrades to an un-encoded path on the (effectively unreachable) nil branch. Add a comment/precondition noting it's unreachable-by-construction.

Closes #351
