### PR TITLE
refactor(identity): required NormalizationPolicy on MatchOrCreateTx

### DIFF
--- a/backend/internal/service/identity.go
+++ b/backend/internal/service/identity.go
@@ -36,6 +36,34 @@ type MatchResult struct {
 	Cached    bool
 }
 
+// NormalizationPolicy controls how MatchOrCreateTx treats an identifier
+// that normalizes to the empty string.
+type NormalizationPolicy int
+
+const (
+	// NormalizationFailEmpty rejects an empty-after-normalization
+	// identifier with an error. Use for callers where each envelope
+	// carries exactly one identifier and an un-normalizable value is
+	// fatal data (e.g. raw_message / call peer handles): there is
+	// nothing to fall back to, and rejecting holds the daemon cursor
+	// for retry rather than silently dropping the event.
+	//
+	// This is the iota zero value deliberately: the parameter is
+	// required and positional so the zero value is never an implicit
+	// default, but if a struct literal or reflection path ever produced
+	// a zero value, failing (not silently dropping) is the correct
+	// fail-closed choice.
+	NormalizationFailEmpty NormalizationPolicy = iota
+
+	// NormalizationSkipEmpty treats an empty-after-normalization
+	// identifier as a no-op: MatchOrCreateTx returns (nil, nil) without
+	// touching the database. Use for callers that loop over many
+	// identifiers and want partial success (e.g. the external_contact
+	// emails/phones loops): one junk field must not reject the whole
+	// envelope.
+	NormalizationSkipEmpty
+)
+
 // IdentityService handles identity matching operations
 type IdentityService struct {
 	identityRepo *repository.IdentityRepository
@@ -215,10 +243,23 @@ func (s *IdentityService) recordKnownMatch(ctx context.Context, normalized strin
 // per-event rejection instead. The non-tx MatchOrCreate keeps its
 // existing forgiving behavior for the sync providers that already
 // depend on it.
-func (s *IdentityService) MatchOrCreateTx(ctx context.Context, tx pgx.Tx, req MatchRequest) (*MatchResult, error) {
+//
+// The policy parameter controls the empty-after-normalization case:
+//   - NormalizationFailEmpty returns an error (for single-identifier
+//     callers where an un-normalizable value is fatal data).
+//   - NormalizationSkipEmpty returns (nil, nil) without touching the
+//     database (for loop callers that want partial success). Callers
+//     under this policy must treat a nil result as "nothing to match";
+//     only this policy can return (nil, nil).
+func (s *IdentityService) MatchOrCreateTx(ctx context.Context, tx pgx.Tx, req MatchRequest, policy NormalizationPolicy) (*MatchResult, error) {
 	normalized := identity.Normalize(req.RawIdentifier, req.Type)
 	if normalized == "" {
-		return nil, fmt.Errorf("empty identifier after normalization")
+		switch policy {
+		case NormalizationSkipEmpty:
+			return nil, nil
+		default: // NormalizationFailEmpty (and the fail-closed zero value)
+			return nil, fmt.Errorf("empty identifier after normalization")
+		}
 	}
 
 	// Contact-driven mode is intentionally NOT supported on the tx

--- a/backend/internal/service/identity_policy_test.go
+++ b/backend/internal/service/identity_policy_test.go
@@ -1,0 +1,51 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"personal-crm/backend/internal/identity"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestMatchOrCreateTx_EmptyAfterNormalization_PolicyBranch is the
+// always-running (no-DB) proof of the empty-after-normalization policy
+// switch. The empty branch returns BEFORE MatchOrCreateTx touches the
+// repository or the tx (Normalize is pure; the empty-check precedes any
+// GetByIdentifierTx/findContactByMethodTx/UpsertTx), so a real
+// *IdentityService built with a nil repo and called with a nil tx never
+// dereferences either on this path.
+//
+//   - NormalizationFailEmpty -> error, nil result (the fatal callers).
+//   - NormalizationSkipEmpty -> (nil, nil) (the loop callers' no-op).
+func TestMatchOrCreateTx_EmptyAfterNormalization_PolicyBranch(t *testing.T) {
+	svc := NewIdentityService(nil) // nil repo: empty branch returns before any repo use
+	cases := []struct {
+		name    string
+		policy  NormalizationPolicy
+		wantErr bool
+	}{
+		{"FailEmpty returns error", NormalizationFailEmpty, true},
+		{"SkipEmpty returns nil,nil", NormalizationSkipEmpty, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// "+" normalizes to "" for phone; nil tx is never
+			// dereferenced on the empty branch.
+			res, err := svc.MatchOrCreateTx(context.Background(), nil, MatchRequest{
+				RawIdentifier: "+",
+				Type:          identity.IdentifierTypePhone,
+				Source:        "test",
+			}, tc.policy)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "empty identifier after normalization")
+			} else {
+				require.NoError(t, err)
+			}
+			// Both policies return a nil result on the empty branch.
+			require.Nil(t, res)
+		})
+	}
+}

--- a/backend/internal/service/ingest.go
+++ b/backend/internal/service/ingest.go
@@ -148,7 +148,7 @@ type JobInsertTxer interface {
 // IdentityMatcher is the narrow surface for the per-event identity
 // match call. Concrete is *IdentityService.
 type IdentityMatcher interface {
-	MatchOrCreateTx(ctx context.Context, tx pgx.Tx, req MatchRequest) (*MatchResult, error)
+	MatchOrCreateTx(ctx context.Context, tx pgx.Tx, req MatchRequest, policy NormalizationPolicy) (*MatchResult, error)
 }
 
 // MessagesUpserter is the narrow surface for the per-event staging
@@ -864,7 +864,10 @@ func (s *IngestService) handleRawMessage(
 		SourceID:      &p.Guid,
 		DisplayName:   p.PeerName,
 	}
-	matchResult, err := s.identity.MatchOrCreateTx(ctx, tx, matchReq)
+	// FailEmpty: a raw_message carries exactly one peer handle, so an
+	// un-normalizable handle is fatal data — reject the event (the
+	// daemon holds its cursor for retry) rather than dropping it.
+	matchResult, err := s.identity.MatchOrCreateTx(ctx, tx, matchReq, NormalizationFailEmpty)
 	if err != nil {
 		return nil, &IngestPerEventRejection{
 			Code:    ingestRejectIdentityMatchFailed,
@@ -1250,22 +1253,15 @@ func (s *IngestService) handleExternalContactUpserted(
 		if em.Value == "" {
 			continue
 		}
-		// Skip values that normalize to empty (e.g. whitespace-only).
-		// Otherwise MatchOrCreateTx returns an error that the caller
-		// treats as a fatal envelope rejection, stalling daemon cursor
-		// advancement on a single junk field. The internal empty-check
-		// inside MatchOrCreateTx stays as defense-in-depth for other
-		// callers (e.g. handleRawMessage, where a single un-normalizable
-		// peer handle IS a fatal data-quality problem).
-		if identity.Normalize(em.Value, identity.IdentifierTypeEmail) == "" {
-			continue
-		}
+		// SkipEmpty: a value that normalizes to empty (e.g. whitespace)
+		// is a no-op rather than an envelope rejection — one junk field
+		// must not reject the whole external_contact upsert.
 		result, err := s.identity.MatchOrCreateTx(ctx, tx, MatchRequest{
 			RawIdentifier: em.Value,
 			Type:          identity.IdentifierTypeEmail,
 			Source:        env.Source,
 			DisplayName:   p.DisplayName,
-		})
+		}, NormalizationSkipEmpty)
 		if err != nil {
 			return &IngestPerEventRejection{
 				Code:    ingestRejectIdentityMatchFailed,
@@ -1288,21 +1284,15 @@ func (s *IngestService) handleExternalContactUpserted(
 		if ph.Value == "" {
 			continue
 		}
-		// Skip values that normalize to empty (e.g. "+", whitespace).
-		// Otherwise MatchOrCreateTx returns an error that the caller
-		// treats as a fatal envelope rejection, stalling daemon cursor
-		// advancement on a single junk field. The internal empty-check
-		// inside MatchOrCreateTx stays as defense-in-depth for other
-		// callers.
-		if identity.Normalize(ph.Value, identity.IdentifierTypePhone) == "" {
-			continue
-		}
+		// SkipEmpty: a value that normalizes to empty (e.g. "+",
+		// whitespace) is a no-op rather than an envelope rejection — one
+		// junk field must not reject the whole external_contact upsert.
 		result, err := s.identity.MatchOrCreateTx(ctx, tx, MatchRequest{
 			RawIdentifier: ph.Value,
 			Type:          identity.IdentifierTypePhone,
 			Source:        env.Source,
 			DisplayName:   p.DisplayName,
-		})
+		}, NormalizationSkipEmpty)
 		if err != nil {
 			return &IngestPerEventRejection{
 				Code:    ingestRejectIdentityMatchFailed,
@@ -1330,13 +1320,18 @@ func (s *IngestService) handleExternalContactUpserted(
 	// identity row to it in the same tx. The Import-handler backfill
 	// (handlers/import.go) covers the "tag now, import later" path.
 	if env.Source == "anarlog_humans" && s.identityLookup != nil {
+		// FailEmpty: the anarlog_human_id is the single structural key
+		// the meeting_note resolution chain hangs on. A whitespace-only
+		// ID (which passes the upstream non-empty-string guard but
+		// normalizes to empty) is fatal data — reject the event rather
+		// than landing a row with no resolvable identity.
 		result, idErr := s.identity.MatchOrCreateTx(ctx, tx, MatchRequest{
 			RawIdentifier: p.EntityID,
 			Type:          identity.IdentifierTypeAnarlogHuman,
 			Source:        env.Source,
 			SourceID:      &p.EntityID,
 			DisplayName:   p.DisplayName,
-		})
+		}, NormalizationFailEmpty)
 		if idErr != nil {
 			return &IngestPerEventRejection{
 				Code:    ingestRejectIdentityMatchFailed,

--- a/backend/internal/service/ingest_call.go
+++ b/backend/internal/service/ingest_call.go
@@ -152,6 +152,10 @@ func (s *IngestService) handleCall(
 	// MatchOrCreateTx call uses RawIdentifier; identity.Normalize is
 	// invoked inside the match path so the raw + type pair are
 	// sufficient. The result.ContactID is nil on unmatched peer.
+	//
+	// FailEmpty: a call carries exactly one peer handle, so an
+	// un-normalizable handle is fatal data — reject the event (the
+	// daemon holds its cursor for retry) rather than dropping it.
 	idType := identity.DetectIdentifierType(p.PeerHandle)
 	matchReq := MatchRequest{
 		RawIdentifier: p.PeerHandle,
@@ -159,7 +163,7 @@ func (s *IngestService) handleCall(
 		Source:        env.Source,
 		SourceID:      &p.CallUniqueID,
 	}
-	matchResult, err := s.identity.MatchOrCreateTx(ctx, tx, matchReq)
+	matchResult, err := s.identity.MatchOrCreateTx(ctx, tx, matchReq, NormalizationFailEmpty)
 	if err != nil {
 		return nil, &IngestPerEventRejection{
 			Code:    ingestRejectIdentityMatchFailed,

--- a/backend/internal/service/ingest_call_test.go
+++ b/backend/internal/service/ingest_call_test.go
@@ -425,6 +425,9 @@ func TestHandleCall_MissedInboundNoVoicemail_SkipsInteractionEmit(t *testing.T) 
 	require.Len(t, h.phoneCalls.markProcessedArgs, 1, "row must be marked processed even when no interaction is created")
 	require.Nil(t, h.phoneCalls.markProcessedArgs[0].InteractionID, "missed-no-voicemail row keeps interaction_id NULL")
 	require.Empty(t, h.contactRecorder.calls, "contact recorder must NOT be called for missed-no-voicemail")
+	// handleCall carries exactly one peer handle, so it must declare
+	// FailEmpty: an un-normalizable handle is fatal data.
+	require.Equal(t, []NormalizationPolicy{NormalizationFailEmpty}, h.identity.policies)
 }
 
 // TestHandleCall_Outbound_ForcesAnsweredNullOnStaging (T11): outbound

--- a/backend/internal/service/ingest_test.go
+++ b/backend/internal/service/ingest_test.go
@@ -441,20 +441,62 @@ func (s *stubExternalContactWriter) SoftDeleteTx(_ context.Context, _ pgx.Tx, _ 
 
 // stubIdentityMatcher returns a configured MatchResult / error for
 // every MatchOrCreateTx call. requests records the inputs of each call
-// so tests can assert which raw values reached the matcher (used by the
-// "skip un-normalizable identifiers" tests, which need to prove that
-// junk values like "+" or "   " never even hit the matcher).
+// and policies records the policy each caller passed, so tests can
+// assert caller wiring (which policy each call site declares and that
+// junk values are now routed through the matcher under SkipEmpty).
+//
+// The stub does NOT call identity.Normalize — it returns whatever the
+// test configures — so the real normalization-driven skip is proven at
+// the unit (nil-repo) and integration layers, not here. resultsByRaw
+// lets a test return a genuine (nil, nil) for selected RawIdentifier
+// values (mimicking the real SkipEmpty contract) while returning a
+// populated result for others.
 type stubIdentityMatcher struct {
-	result   *MatchResult
-	err      error
-	calls    int
-	requests []MatchRequest
+	result       *MatchResult            // default result when resultsByRaw has no entry
+	resultsByRaw map[string]*MatchResult // per-RawIdentifier override; a nil value returns (nil, err)
+	err          error
+	calls        int
+	requests     []MatchRequest
+	policies     []NormalizationPolicy // parallel to requests
 }
 
-func (s *stubIdentityMatcher) MatchOrCreateTx(_ context.Context, _ pgx.Tx, req MatchRequest) (*MatchResult, error) {
+func (s *stubIdentityMatcher) MatchOrCreateTx(_ context.Context, _ pgx.Tx, req MatchRequest, policy NormalizationPolicy) (*MatchResult, error) {
 	s.calls++
 	s.requests = append(s.requests, req)
+	s.policies = append(s.policies, policy)
+	if s.resultsByRaw != nil {
+		if r, ok := s.resultsByRaw[req.RawIdentifier]; ok {
+			return r, s.err // r may be nil → (nil, err); with err==nil this is the (nil,nil) SkipEmpty contract
+		}
+	}
 	return s.result, s.err
+}
+
+// stubMessagesUpserter is a minimal MessagesUpserter for the
+// handleRawMessage unit test; it records nothing the test needs beyond a
+// non-error return so the handler runs past the identity match.
+type stubMessagesUpserter struct {
+	resp *repository.MessagesMessage
+	err  error
+}
+
+func (s *stubMessagesUpserter) UpsertMessageTx(_ context.Context, _ pgx.Tx, _ repository.UpsertMessagesMessageParams) (*repository.MessagesMessage, error) {
+	return s.resp, s.err
+}
+
+// stubAnarlogIdentityLookup is a minimal AnarlogIdentityLookup for the
+// anarlog-block unit test.
+type stubAnarlogIdentityLookup struct {
+	linkResp *repository.ExternalIdentity
+	linkErr  error
+}
+
+func (s *stubAnarlogIdentityLookup) FindContactIDByAnarlogHumanIDTx(_ context.Context, _ pgx.Tx, _ string) (*uuid.UUID, error) {
+	return nil, nil
+}
+
+func (s *stubAnarlogIdentityLookup) LinkIdentityToContactTx(_ context.Context, _ pgx.Tx, _ repository.LinkIdentityRequest) (*repository.ExternalIdentity, error) {
+	return s.linkResp, s.linkErr
 }
 
 // TestHandleExternalContactUpserted_PostUpsertTombstoneTriggersRevive
@@ -568,13 +610,14 @@ func upsertEnvWithContactMethods(t *testing.T, host uuid.UUID, entityID string, 
 	}
 }
 
-// TestHandleExternalContactUpserted_SkipsPhonesThatNormalizeToEmpty
-// proves the call-site pre-check filters phones whose value normalizes
-// to empty (e.g. "+", whitespace-only) BEFORE invoking MatchOrCreateTx.
-// This is the unit-level proof that the cursor-stall fix avoids the
-// lower-layer "empty identifier after normalization" rejection — the
-// matcher never sees those values at all.
-func TestHandleExternalContactUpserted_SkipsPhonesThatNormalizeToEmpty(t *testing.T) {
+// TestHandleExternalContactUpserted_PhonesLoopUsesSkipEmpty proves the
+// phones loop routes every non-literal-empty value through
+// MatchOrCreateTx under NormalizationSkipEmpty. Only the literal-empty
+// guard (ph.Value == "") still pre-filters at the call site; the
+// empty-after-normalization skip now happens inside the real matcher
+// (covered by the nil-repo unit test and the integration suite). The
+// stub does not normalize, so junk values like "+"/"   " reach it here.
+func TestHandleExternalContactUpserted_PhonesLoopUsesSkipEmpty(t *testing.T) {
 	rowID := uuid.New()
 	hostID := uuid.New()
 	liveRow := &repository.ExternalContact{
@@ -597,17 +640,25 @@ func TestHandleExternalContactUpserted_SkipsPhonesThatNormalizeToEmpty(t *testin
 	env := upsertEnvWithContactMethods(t, hostID, "CN-junk-phone",
 		nil, []string{"+", "   ", "+15551234567"})
 	rej := svc.handleExternalContactUpserted(context.Background(), nil, env, hostID)
-	require.Nil(t, rej, "handler must not reject when junk phones are skipped")
-	require.Equal(t, 1, stubIdent.calls, "matcher must be invoked exactly once (for the valid phone)")
-	require.Len(t, stubIdent.requests, 1)
-	require.Equal(t, "+15551234567", stubIdent.requests[0].RawIdentifier)
-	require.Equal(t, identity.IdentifierTypePhone, stubIdent.requests[0].Type)
+	require.Nil(t, rej, "handler must not reject under SkipEmpty")
+	// All three non-literal-empty phones reach the matcher; the real
+	// empty-after-normalization skip happens inside MatchOrCreateTx.
+	require.Equal(t, 3, stubIdent.calls)
+	require.Len(t, stubIdent.requests, 3)
+	require.Equal(t, []string{"+", "   ", "+15551234567"},
+		[]string{stubIdent.requests[0].RawIdentifier, stubIdent.requests[1].RawIdentifier, stubIdent.requests[2].RawIdentifier})
+	for i, pol := range stubIdent.policies {
+		require.Equal(t, NormalizationSkipEmpty, pol, "phone call %d must pass SkipEmpty", i)
+		require.Equal(t, identity.IdentifierTypePhone, stubIdent.requests[i].Type)
+	}
 }
 
-// TestHandleExternalContactUpserted_SkipsEmailsThatNormalizeToEmpty
-// mirrors the phone case for emails. Whitespace/tab-only values must
-// not reach MatchOrCreateTx.
-func TestHandleExternalContactUpserted_SkipsEmailsThatNormalizeToEmpty(t *testing.T) {
+// TestHandleExternalContactUpserted_EmailsLoopUsesSkipEmpty mirrors the
+// phone case for emails: every non-literal-empty value is routed through
+// MatchOrCreateTx under NormalizationSkipEmpty. The stub does not
+// normalize, so whitespace/tab-only values reach it here; the real skip
+// happens inside the matcher.
+func TestHandleExternalContactUpserted_EmailsLoopUsesSkipEmpty(t *testing.T) {
 	rowID := uuid.New()
 	hostID := uuid.New()
 	liveRow := &repository.ExternalContact{
@@ -630,19 +681,25 @@ func TestHandleExternalContactUpserted_SkipsEmailsThatNormalizeToEmpty(t *testin
 	env := upsertEnvWithContactMethods(t, hostID, "CN-junk-email",
 		[]string{"   ", "\t", "ok@example.com"}, nil)
 	rej := svc.handleExternalContactUpserted(context.Background(), nil, env, hostID)
-	require.Nil(t, rej, "handler must not reject when junk emails are skipped")
-	require.Equal(t, 1, stubIdent.calls, "matcher must be invoked exactly once (for the valid email)")
-	require.Len(t, stubIdent.requests, 1)
-	require.Equal(t, "ok@example.com", stubIdent.requests[0].RawIdentifier)
-	require.Equal(t, identity.IdentifierTypeEmail, stubIdent.requests[0].Type)
+	require.Nil(t, rej, "handler must not reject under SkipEmpty")
+	require.Equal(t, 3, stubIdent.calls)
+	require.Len(t, stubIdent.requests, 3)
+	require.Equal(t, []string{"   ", "\t", "ok@example.com"},
+		[]string{stubIdent.requests[0].RawIdentifier, stubIdent.requests[1].RawIdentifier, stubIdent.requests[2].RawIdentifier})
+	for i, pol := range stubIdent.policies {
+		require.Equal(t, NormalizationSkipEmpty, pol, "email call %d must pass SkipEmpty", i)
+		require.Equal(t, identity.IdentifierTypeEmail, stubIdent.requests[i].Type)
+	}
 }
 
-// TestHandleExternalContactUpserted_AllPhonesAndEmailsNormalizeToEmpty_NoMatcherCalls
-// proves that an envelope whose every identifier normalizes to empty
-// still ingests cleanly — no matcher calls, no rejection. The contact
-// lands as an external_contact row with zero linked identities,
-// available for manual review.
-func TestHandleExternalContactUpserted_AllPhonesAndEmailsNormalizeToEmpty_NoMatcherCalls(t *testing.T) {
+// TestHandleExternalContactUpserted_AllPhonesAndEmailsNormalizeToEmpty_StillAccepts
+// proves that an envelope whose every (non-literal-empty) identifier is
+// un-normalizable still ingests cleanly. Under the new design the junk
+// values DO reach MatchOrCreateTx (the per-loop guard is gone); the real
+// matcher no-ops them under SkipEmpty by returning (nil, nil). Here the
+// stub returns (nil, nil) for every value to mirror that contract, and
+// the handler must accept the envelope with no rejection.
+func TestHandleExternalContactUpserted_AllPhonesAndEmailsNormalizeToEmpty_StillAccepts(t *testing.T) {
 	rowID := uuid.New()
 	hostID := uuid.New()
 	liveRow := &repository.ExternalContact{
@@ -656,7 +713,11 @@ func TestHandleExternalContactUpserted_AllPhonesAndEmailsNormalizeToEmpty_NoMatc
 		getErr:     db.ErrNotFound,
 		upsertResp: liveRow,
 	}
-	stubIdent := &stubIdentityMatcher{result: &MatchResult{}}
+	// Every junk value maps to (nil, nil), mirroring the real SkipEmpty
+	// empty-after-normalization contract.
+	stubIdent := &stubIdentityMatcher{
+		resultsByRaw: map[string]*MatchResult{"\t": nil, "+": nil},
+	}
 
 	svc := &IngestService{
 		identity:         stubIdent,
@@ -666,16 +727,23 @@ func TestHandleExternalContactUpserted_AllPhonesAndEmailsNormalizeToEmpty_NoMatc
 		[]string{"\t"}, []string{"+"})
 	rej := svc.handleExternalContactUpserted(context.Background(), nil, env, hostID)
 	require.Nil(t, rej, "handler must accept envelope even if all identifiers normalize to empty")
-	require.Equal(t, 0, stubIdent.calls, "matcher must NOT be invoked when all identifiers are un-normalizable")
+	require.Equal(t, 2, stubIdent.calls, "both junk values now reach the matcher under SkipEmpty")
+	for i, pol := range stubIdent.policies {
+		require.Equal(t, NormalizationSkipEmpty, pol, "call %d must pass SkipEmpty", i)
+	}
 }
 
-// TestHandleExternalContactUpserted_MixedJunkAndValid_CallsMatcherOnceWithValid
-// proves both loops run to completion and the matcher receives exactly
-// the two valid values, in source order (emails first, then phones).
-// Junk in one loop must not short-circuit the other.
-func TestHandleExternalContactUpserted_MixedJunkAndValid_CallsMatcherOnceWithValid(t *testing.T) {
+// TestHandleExternalContactUpserted_MixedJunkAndValid_NilResultTolerance
+// proves both loops run to completion with every value routed through
+// the matcher under SkipEmpty, and that the match flow correctly treats
+// a (nil, nil) result (the SkipEmpty no-op for junk) as "no match" while
+// still acting on the populated result for the valid value. Junk in one
+// loop must not short-circuit the other, and the (nil, nil) returns must
+// not break the shared matched/canSetMatchOnRow flow.
+func TestHandleExternalContactUpserted_MixedJunkAndValid_NilResultTolerance(t *testing.T) {
 	rowID := uuid.New()
 	hostID := uuid.New()
+	matchedContactID := uuid.New()
 	liveRow := &repository.ExternalContact{
 		ID:          rowID,
 		Source:      "icloud_contacts",
@@ -686,8 +754,18 @@ func TestHandleExternalContactUpserted_MixedJunkAndValid_CallsMatcherOnceWithVal
 		getResp:    nil,
 		getErr:     db.ErrNotFound,
 		upsertResp: liveRow,
+		updateResp: liveRow, // UpdateMatchTx return is ignored by the handler
 	}
-	stubIdent := &stubIdentityMatcher{result: &MatchResult{}}
+	// Junk values return (nil, nil); the valid email returns a populated
+	// match so the email loop sets the external_contact match.
+	stubIdent := &stubIdentityMatcher{
+		resultsByRaw: map[string]*MatchResult{
+			"   ":            nil,
+			"+":              nil,
+			"ok@example.com": {ContactID: &matchedContactID},
+			"+15551234567":   {ContactID: &matchedContactID},
+		},
+	}
 
 	svc := &IngestService{
 		identity:         stubIdent,
@@ -698,13 +776,100 @@ func TestHandleExternalContactUpserted_MixedJunkAndValid_CallsMatcherOnceWithVal
 		[]string{"+", "+15551234567"})
 	rej := svc.handleExternalContactUpserted(context.Background(), nil, env, hostID)
 	require.Nil(t, rej)
-	require.Equal(t, 2, stubIdent.calls, "matcher must be invoked once per valid identifier")
-	require.Len(t, stubIdent.requests, 2)
-	// Emails loop runs first, then phones.
-	require.Equal(t, "ok@example.com", stubIdent.requests[0].RawIdentifier)
-	require.Equal(t, identity.IdentifierTypeEmail, stubIdent.requests[0].Type)
-	require.Equal(t, "+15551234567", stubIdent.requests[1].RawIdentifier)
-	require.Equal(t, identity.IdentifierTypePhone, stubIdent.requests[1].Type)
+	// All four non-literal-empty values reach the matcher in source order
+	// (emails loop first, then phones).
+	require.Equal(t, 4, stubIdent.calls)
+	require.Len(t, stubIdent.requests, 4)
+	require.Equal(t,
+		[]string{"   ", "ok@example.com", "+", "+15551234567"},
+		[]string{stubIdent.requests[0].RawIdentifier, stubIdent.requests[1].RawIdentifier, stubIdent.requests[2].RawIdentifier, stubIdent.requests[3].RawIdentifier})
+	for i, pol := range stubIdent.policies {
+		require.Equal(t, NormalizationSkipEmpty, pol, "call %d must pass SkipEmpty", i)
+	}
+	// The first populated match (the valid email) sets the match exactly
+	// once; the trailing (nil,nil) junk phone and the already-matched
+	// valid phone do not trigger a second UpdateMatchTx (matched=true).
+	require.Equal(t, 1, stubExt.updateCalls, "exactly one match set despite (nil,nil) junk results")
+}
+
+// TestHandleRawMessage_UsesFailEmptyPolicy proves handleRawMessage
+// declares NormalizationFailEmpty for its single peer-handle match: an
+// un-normalizable handle is fatal data, so the matcher must reject (not
+// silently skip) rather than hand back (nil, nil) to a nil-unsafe deref.
+func TestHandleRawMessage_UsesFailEmptyPolicy(t *testing.T) {
+	hostID := uuid.New()
+	stubIdent := &stubIdentityMatcher{result: &MatchResult{}}
+	svc := &IngestService{
+		identity: stubIdent,
+		messages: &stubMessagesUpserter{resp: &repository.MessagesMessage{}},
+	}
+	payload := mustMarshalRawMsg(events.RawMessageReceivedPayload{
+		Version:     1,
+		HostID:      hostID,
+		Source:      "messages",
+		Guid:        "guid-1",
+		ChatID:      "chat-1",
+		PeerHandle:  "+15551234567",
+		MessageType: "text",
+		SentAt:      accelerated.GetCurrentTime(),
+	})
+	env := &events.Envelope{
+		Source:   "messages",
+		SourceID: "guid-1",
+		Kind:     events.KindRawMessageReceived,
+		Payload:  payload,
+	}
+	_, rej := svc.handleRawMessage(context.Background(), nil, env, hostID)
+	require.Nil(t, rej)
+	require.Equal(t, []NormalizationPolicy{NormalizationFailEmpty}, stubIdent.policies)
+}
+
+// TestHandleExternalContactUpserted_AnarlogBlockUsesFailEmpty proves the
+// anarlog_humans block declares NormalizationFailEmpty: the
+// anarlog_human_id is the single structural key the meeting_note
+// resolution chain hangs on, so an un-normalizable id is fatal data.
+func TestHandleExternalContactUpserted_AnarlogBlockUsesFailEmpty(t *testing.T) {
+	rowID := uuid.New()
+	hostID := uuid.New()
+	liveRow := &repository.ExternalContact{
+		ID:          rowID,
+		Source:      "anarlog_humans",
+		SourceID:    "AH-1",
+		MatchStatus: repository.MatchStatusUnmatched,
+	}
+	stubExt := &stubExternalContactWriter{
+		getResp:    nil,
+		getErr:     db.ErrNotFound,
+		upsertResp: liveRow,
+	}
+	stubIdent := &stubIdentityMatcher{result: &MatchResult{}}
+	svc := &IngestService{
+		identity:         stubIdent,
+		externalContacts: stubExt,
+		identityLookup:   &stubAnarlogIdentityLookup{},
+	}
+	payload := mustMarshalExtUpsert(events.ExternalContactUpsertedPayload{
+		Version:  1,
+		HostID:   hostID,
+		Source:   "anarlog_humans",
+		EntityID: "AH-1",
+	})
+	// handleExternalContactUpserted extracts a 64-char content-hash
+	// suffix from SourceID for every source, so build a real one.
+	hashHex, err := ComputeContentHash(payload)
+	require.NoError(t, err)
+	env := &events.Envelope{
+		Source:   "anarlog_humans",
+		SourceID: "AH-1@" + hashHex,
+		Kind:     events.KindExternalContactUpserted,
+		Payload:  payload,
+	}
+	rej := svc.handleExternalContactUpserted(context.Background(), nil, env, hostID)
+	require.Nil(t, rej)
+	// Only the anarlog block calls the matcher (no emails/phones present).
+	require.Equal(t, []NormalizationPolicy{NormalizationFailEmpty}, stubIdent.policies)
+	require.Equal(t, "AH-1", stubIdent.requests[0].RawIdentifier)
+	require.Equal(t, identity.IdentifierTypeAnarlogHuman, stubIdent.requests[0].Type)
 }
 
 // TestVerifyExternalContactInvariants_HashMismatchRejected proves the

--- a/backend/tests/identity_integration_test.go
+++ b/backend/tests/identity_integration_test.go
@@ -517,3 +517,119 @@ func TestIdentityService_Integration(t *testing.T) {
 		assert.Equal(t, repository.MatchTypeUnmatched, unlinked.MatchType)
 	})
 }
+
+// TestIdentityService_NormalizationPolicy_Integration exercises the
+// MatchOrCreateTx policy parameter against a real database. Each
+// sub-test opens its own tx and rolls it back so the valid-input writes
+// never persist into the shared personal_crm_test DB.
+func TestIdentityService_NormalizationPolicy_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	ctx := context.Background()
+
+	// Migrations are applied once by TestMain.
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	if err != nil {
+		t.Skipf("Could not connect to database: %v", err)
+	}
+	defer database.Close()
+
+	identityRepo := repository.NewIdentityRepository(database.Queries)
+	identityService := service.NewIdentityService(identityRepo)
+
+	t.Run("FailEmpty_EmptyAfterNormalization_ReturnsError", func(t *testing.T) {
+		tx, err := database.Pool.Begin(ctx)
+		require.NoError(t, err)
+		defer func() { _ = tx.Rollback(ctx) }()
+
+		// "+" normalizes to "" for phone.
+		result, err := identityService.MatchOrCreateTx(ctx, tx, service.MatchRequest{
+			RawIdentifier: "+",
+			Type:          identity.IdentifierTypePhone,
+			Source:        "test_policy_fail_empty",
+		}, service.NormalizationFailEmpty)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "empty identifier after normalization")
+		require.Nil(t, result)
+	})
+
+	t.Run("SkipEmpty_EmptyAfterNormalization_ReturnsNilNil", func(t *testing.T) {
+		tx, err := database.Pool.Begin(ctx)
+		require.NoError(t, err)
+		defer func() { _ = tx.Rollback(ctx) }()
+
+		// Same junk input, SkipEmpty policy: the contract is (nil, nil).
+		// The end-to-end "junk leaves no identity row" guarantee is
+		// covered by the committed HTTP-stack tests under tests/api/.
+		result, err := identityService.MatchOrCreateTx(ctx, tx, service.MatchRequest{
+			RawIdentifier: "+",
+			Type:          identity.IdentifierTypePhone,
+			Source:        "test_policy_skip_empty",
+		}, service.NormalizationSkipEmpty)
+		require.NoError(t, err)
+		require.Nil(t, result)
+	})
+
+	t.Run("SkipEmpty_ValidIdentifier_BehavesNormally", func(t *testing.T) {
+		tx, err := database.Pool.Begin(ctx)
+		require.NoError(t, err)
+		defer func() { _ = tx.Rollback(ctx) }()
+
+		// Randomized source + identifier so the in-tx read-back cannot
+		// match a stale row left by a prior run in the shared test DB.
+		suffix := uuid.NewString()
+		rawEmail := "skip-valid-" + suffix + "@example.com"
+		source := "test_policy_skip_valid_" + suffix
+
+		result, err := identityService.MatchOrCreateTx(ctx, tx, service.MatchRequest{
+			RawIdentifier: rawEmail,
+			Type:          identity.IdentifierTypeEmail,
+			Source:        source,
+		}, service.NormalizationSkipEmpty)
+		require.NoError(t, err)
+		require.NotNil(t, result, "valid input under SkipEmpty must not no-op")
+		require.NotNil(t, result.Identity, "valid input must produce an identity row")
+
+		// Confirm the row exists in-tx before rollback.
+		normalized := identity.Normalize(rawEmail, identity.IdentifierTypeEmail)
+		readBack, err := identityRepo.GetByIdentifierTx(ctx, tx, identity.IdentifierTypeEmail, normalized, source)
+		require.NoError(t, err)
+		require.NotNil(t, readBack)
+		require.Equal(t, normalized, readBack.Identifier)
+	})
+
+	t.Run("FailEmpty_ValidIdentifier_BehavesNormally", func(t *testing.T) {
+		tx, err := database.Pool.Begin(ctx)
+		require.NoError(t, err)
+		defer func() { _ = tx.Rollback(ctx) }()
+
+		suffix := uuid.NewString()
+		rawEmail := "fail-valid-" + suffix + "@example.com"
+		source := "test_policy_fail_valid_" + suffix
+
+		result, err := identityService.MatchOrCreateTx(ctx, tx, service.MatchRequest{
+			RawIdentifier: rawEmail,
+			Type:          identity.IdentifierTypeEmail,
+			Source:        source,
+		}, service.NormalizationFailEmpty)
+		require.NoError(t, err)
+		require.NotNil(t, result, "valid input under FailEmpty preserves old behavior")
+		require.NotNil(t, result.Identity, "valid input must produce an identity row")
+
+		normalized := identity.Normalize(rawEmail, identity.IdentifierTypeEmail)
+		readBack, err := identityRepo.GetByIdentifierTx(ctx, tx, identity.IdentifierTypeEmail, normalized, source)
+		require.NoError(t, err)
+		require.NotNil(t, readBack)
+		require.Equal(t, normalized, readBack.Identifier)
+	})
+}


### PR DESCRIPTION
## Summary

Makes the empty-after-normalization policy on `IdentityService.MatchOrCreateTx` an **explicit, required positional parameter** so the compiler forces every caller to choose its semantics. Previously the policy was split between caller-side per-loop guards (in `ingest.go`) and an unconditional internal empty-check inside `MatchOrCreateTx`, leaving the intent undeclared at the type level — every future caller had to remember to add the right guard at its own loop.

Closes #354.

This is a **no-behavior-change refactor**: no schema change, no API surface change, no frontend change. It relocates and makes explicit a decision that already existed.

## What changed

- **New `NormalizationPolicy` enum** (`identity.go`): `NormalizationFailEmpty` (the `iota` zero value — fail-closed) returns an error on an empty-after-normalization identifier; `NormalizationSkipEmpty` returns `(nil, nil)` as a no-op without touching the database.
- **`MatchOrCreateTx` gains a required positional `policy` parameter.** The internal unconditional empty-check is replaced by a policy switch. A required positional param (no default, no variadic, no options struct) means `go build` fails if a caller is added without choosing a policy — that is the mechanical prevention the issue asks for.
- **`IdentityMatcher` interface** updated to match.
- **Caller wiring:** `handleRawMessage`, `handleCall`, and the `anarlog_humans` block use `NormalizationFailEmpty` (exactly one identifier per envelope; an un-normalizable value is fatal data — reject so the daemon holds its cursor for retry). The `external_contact` emails and phones loops use `NormalizationSkipEmpty` (N identifiers, partial success; one junk field must not reject the whole envelope).
- **Deleted** the two per-loop `if identity.Normalize(...) == "" { continue }` guards in the emails/phones loops and the unconditional internal empty-check, plus their stale design comments. The cheap literal-empty `if value == "" { continue }` pre-filter stays (behaviorally identical under SkipEmpty, avoids a `MatchRequest` allocation + interface call for the common blank-field case).

## Test plan

- **Unit (no DB, always runs):** `TestMatchOrCreateTx_EmptyAfterNormalization_PolicyBranch` — real `*IdentityService` with a nil repo + nil tx (the empty branch returns before touching either) proves `FailEmpty` → error and `SkipEmpty` → `(nil, nil)`.
- **Unit (handler wiring):** reworked the four prior junk-skip tests to assert the new SkipEmpty contract (junk now routes through the matcher and is no-op'd internally; the stub does not normalize) plus genuine `(nil, nil)` nil-result tolerance in the match flow; added `FailEmpty` policy assertions for the raw_message, call, and anarlog callers.
- **Integration (both policies × empty/valid):** `TestIdentityService_NormalizationPolicy_Integration` against a real DB; each sub-test uses its own tx + rollback and randomized source/identifier values so valid-input writes never persist into the shared test DB.
- **Regression (unchanged):** the existing `external_contact_ingest_test.go` HTTP-stack junk-skip suite + savepoint-rollback test keep passing under the new SkipEmpty path.
- **Compiler:** `go build ./...` confirms every caller passes a policy.

Local: `go build ./...`, `make lint`, `make test-unit`, and the integration matrix all green; full pre-push suite (lint + unit + integration + frontend + E2E) passed.

## Known non-blocking follow-ups (review-head P2/P3)

- **[P2]** The three FailEmpty handler tests assert the policy value but do not exercise the matcher-error → `IngestPerEventRejection` mapping at the handler layer; that mapping is proven transitively via the integration matrix and the SkipEmpty error path, not directly per-handler.
- **[P3]** The empty-input policy switch uses an explicit `default` arm rather than enumerating both constants (exhaustiveness nit).
- **[P3]** The FailEmpty rationale comment is duplicated across the raw_message and call call sites.

## Links

- Issue: #354
- Plan: `.ai/log/plan/identity-normalization-policy-param.md`