### PR TITLE
refactor(contacttask): repo-wide canonical CRM-marker primitive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
               - 'backend/**'
               - 'tests/**'
               - 'go.mod'
+              - 'scripts/**'
+              - 'Makefile'
+              - '.github/workflows/ci.yml'
             frontend:
               - 'frontend/**'
             mac_daemon:
@@ -84,6 +87,9 @@ jobs:
 
       - name: Check rematch sole-dispatcher invariant
         run: ./scripts/ci/rematch-sole-dispatcher-guard.sh
+
+      - name: Check CRM-marker construction invariant
+        run: ./scripts/ci/crm-marker-construction-guard.sh
 
       - name: Run unit tests
         working-directory: backend

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Personal CRM Makefile
 
-.PHONY: help setup dev build crm-admin mac-daemon test test-daemon-local clean docker-up docker-down docker-reset test-cadence-ultra test-cadence-fast prod staging testing start start-local stop restart reload status dev-stop dev-restart dev-api-stop dev-api-start dev-api-restart ci-build-backend ci-build-frontend ci-build ci-test test-e2e test-e2e-local test-e2e-diff e2e-db deploy deploy-pi deploy-mac deploy-all setup-pi dev-native postgres-native sqlc smoke-test test-integration-fast test-integration-slow test-mac-host-migrations check-cadence-sole-writer check-followup-sole-writer check-rematch-sole-dispatcher
+.PHONY: help setup dev build crm-admin mac-daemon test test-daemon-local clean docker-up docker-down docker-reset test-cadence-ultra test-cadence-fast prod staging testing start start-local stop restart reload status dev-stop dev-restart dev-api-stop dev-api-start dev-api-restart ci-build-backend ci-build-frontend ci-build ci-test test-e2e test-e2e-local test-e2e-diff e2e-db deploy deploy-pi deploy-mac deploy-all setup-pi dev-native postgres-native sqlc smoke-test test-integration-fast test-integration-slow test-mac-host-migrations check-cadence-sole-writer check-followup-sole-writer check-rematch-sole-dispatcher check-crm-marker-construction
 
 # Repo root (supports running make from subdirectories).
 REPO_ROOT := $(shell git rev-parse --show-toplevel)
@@ -291,7 +291,7 @@ test: test-unit test-integration test-frontend
 
 test-unit:
 	@echo "Running backend unit tests..."
-	@cd backend && go test ./tests/... ./internal/matching/... ./internal/events/... ./internal/service/... -v -short
+	@cd backend && go test ./tests/... ./internal/matching/... ./internal/events/... ./internal/service/... ./internal/contacttask/... -v -short
 
 test-integration-fast:
 	@echo "Running backend integration tests (default set)..."
@@ -359,7 +359,7 @@ lint-fix:
 	@echo "Running golangci-lint with auto-fix..."
 	@cd backend && $(GOLANGCI_LINT) run --fix ./...
 
-ci-test: lint check-cadence-sole-writer check-followup-sole-writer check-rematch-sole-dispatcher test-unit test-integration-fast test-frontend
+ci-test: lint check-cadence-sole-writer check-followup-sole-writer check-rematch-sole-dispatcher check-crm-marker-construction test-unit test-integration-fast test-frontend
 	@echo "✅ All CI tests passed"
 
 # Sole-writer guard: verifies only CadenceUpdater calls cadence-writing queries.
@@ -382,6 +382,13 @@ check-followup-sole-writer:
 # indicates a partial revert. See scripts/ci/rematch-sole-dispatcher-guard.sh.
 check-rematch-sole-dispatcher:
 	@$(REPO_ROOT)/scripts/ci/rematch-sole-dispatcher-guard.sh
+
+# CRM-marker construction guard: verifies the Todoist CRM-marker wire format
+# is built only in contacttask.EncodeMarker. Runs alongside the Go AST test
+# at backend/tests/crm_marker_construction_static_test.go. See
+# scripts/ci/crm-marker-construction-guard.sh.
+check-crm-marker-construction:
+	@$(REPO_ROOT)/scripts/ci/crm-marker-construction-guard.sh
 
 # Code generation
 sqlc:

--- a/backend/internal/consumer/followup_manager.go
+++ b/backend/internal/consumer/followup_manager.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -547,14 +546,12 @@ func (h *FollowUpManager) applyCreate(
 	deadlineStr := deadline.Format(todoist.DateFormat)
 	contactLink := fmt.Sprintf("%s/contacts/%s", h.frontendURL, p.ContactID.String())
 	content := fmt.Sprintf("Follow up: [%s](%s) (awaiting reply)", contact.FullName, contactLink)
-	marker := map[string]any{
-		"crm":        true,
-		"contact_id": p.ContactID.String(),
-		"kind":       contacttask.KindReachOut,
-		"lifecycle":  contacttask.LifecycleFollowUpLoop,
-		"instance":   settings.IntegrationInstanceID,
-	}
-	markerJSON, err := json.Marshal(marker)
+	markerJSON, err := contacttask.EncodeMarker(contacttask.CRMMarker{
+		ContactID: p.ContactID.String(),
+		Kind:      contacttask.KindReachOut,
+		Lifecycle: contacttask.LifecycleFollowUpLoop,
+		Instance:  settings.IntegrationInstanceID,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("marshal marker: %w", err)
 	}

--- a/backend/internal/contacttask/kinds.go
+++ b/backend/internal/contacttask/kinds.go
@@ -1,6 +1,9 @@
 // Package contacttask defines neutral constants for the orthogonal
-// (kind, lifecycle) axes on contact_task. Constants only — no DB, no
-// handlers — so any package can import without risking cycles.
+// (kind, lifecycle) axes on contact_task, plus the canonical CRM-marker
+// codec (EncodeMarker/DecodeMarker, see marker.go) that serializes those
+// constants into the JSON marker embedded in Todoist task descriptions.
+// Constants + a pure codec only — no DB, no handlers, no HTTP — so any
+// package can import without risking cycles.
 //
 // The two axes are independent dispatch surfaces:
 //   - kind tracks the semantic completion behaviour (interaction

--- a/backend/internal/contacttask/marker.go
+++ b/backend/internal/contacttask/marker.go
@@ -1,0 +1,125 @@
+package contacttask
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// CRMMarker is the parsed/structured form of the JSON marker embedded in a
+// Todoist task description. It is the single source of truth for the wire
+// shape that links a Todoist task back to a CRM contact and task taxonomy.
+//
+// The wire format is a JSON object with five keys, emitted in sorted-key
+// order by json.Marshal of a map[string]any:
+//
+//	{"contact_id":"<uuid>","crm":true,"instance":"<id>","kind":"<kind>","lifecycle":"<lifecycle>"}
+//
+// Instance is present on the wire and populated by DecodeMarker, but the
+// recovery policy in todoist.tryRecoverPendingTempID does not branch on it —
+// recovery keys on contact_id + lifecycle only.
+type CRMMarker struct {
+	ContactID string // required
+	Kind      string
+	Lifecycle string
+	Instance  string
+}
+
+// crmMarkerJSON is the on-the-wire JSON shape. Decode-only: encoding goes
+// through a map[string]any (see EncodeMarker) to guarantee sorted-key byte
+// output. The struct exists so DecodeMarker can unmarshal in one step.
+type crmMarkerJSON struct {
+	CRM       bool   `json:"crm"`
+	ContactID string `json:"contact_id"`
+	Kind      string `json:"kind"`
+	Lifecycle string `json:"lifecycle"`
+	Instance  string `json:"instance"`
+}
+
+// EncodeMarker returns the canonical JSON marker bytes for a managed task.
+//
+// It marshals a map[string]any so the output keys are emitted in sorted
+// order (contact_id, crm, instance, kind, lifecycle) — the exact byte layout
+// every encoder has emitted historically. The "crm":true literal and the
+// "instance" field are always present. This is the single sanctioned path
+// for constructing the marker; the construction guard enforces that no other
+// file builds it.
+func EncodeMarker(m CRMMarker) ([]byte, error) {
+	return json.Marshal(map[string]any{
+		"crm":        true,
+		"contact_id": m.ContactID,
+		"kind":       m.Kind,
+		"lifecycle":  m.Lifecycle,
+		"instance":   m.Instance,
+	})
+}
+
+// DecodeMarker extracts and normalizes a CRMMarker from a Todoist task
+// description. It is the ONLY public decode entry point. Returns
+// (marker, true) on a valid, normalized CRM marker; (zero, false) when no
+// valid marker is present OR the legacy kind is unknown.
+func DecodeMarker(description string) (CRMMarker, bool) {
+	m, ok := parseMarker(description)
+	if !ok {
+		return CRMMarker{}, false
+	}
+	return normalizeLegacyMarker(m)
+}
+
+// parseMarker extracts a raw CRMMarker from a task description. It unmarshals
+// the description as JSON; if that errs OR the parsed object is not a valid
+// CRM marker (!crm || contact_id == ""), it retries from the LAST '{' in the
+// description (handling markdown-prefixed markers). If the retry also fails
+// the same predicate, it returns (zero, false).
+func parseMarker(description string) (CRMMarker, bool) {
+	var raw crmMarkerJSON
+	descToTry := description
+	if err := json.Unmarshal([]byte(descToTry), &raw); err != nil || !raw.CRM || raw.ContactID == "" {
+		raw = crmMarkerJSON{}
+		if idx := strings.LastIndex(description, "{"); idx >= 0 {
+			descToTry = description[idx:]
+		}
+		if err := json.Unmarshal([]byte(descToTry), &raw); err != nil || !raw.CRM || raw.ContactID == "" {
+			return CRMMarker{}, false
+		}
+	}
+	return CRMMarker{
+		ContactID: raw.ContactID,
+		Kind:      raw.Kind,
+		Lifecycle: raw.Lifecycle,
+		Instance:  raw.Instance,
+	}, true
+}
+
+// normalizeLegacyMarker fills Lifecycle for legacy markers that predate the
+// (kind, lifecycle) split. It is a no-op when Lifecycle is already set.
+// Maps legacy kind -> (kind, lifecycle):
+//
+//	cadence|"" -> (reach_out, cadence_due)
+//	follow_up  -> (reach_out, followup_loop)
+//	action     -> (action, manual)
+//
+// Returns (normalized, true) when recognized, (m, false) when the legacy
+// kind is unknown (caller rejects).
+//
+// Legacy markers predate the (kind, lifecycle) split. Safe to delete this
+// translation once a deploy has cleared all in-flight Todoist tasks created
+// by pre-split code.
+func normalizeLegacyMarker(m CRMMarker) (CRMMarker, bool) {
+	if m.Lifecycle != "" {
+		return m, true
+	}
+	switch m.Kind {
+	case "cadence", "":
+		m.Kind = KindReachOut
+		m.Lifecycle = LifecycleCadenceDue
+	case "follow_up":
+		m.Kind = KindReachOut
+		m.Lifecycle = LifecycleFollowUpLoop
+	case KindAction:
+		m.Kind = KindAction
+		m.Lifecycle = LifecycleManual
+	default:
+		return m, false
+	}
+	return m, true
+}

--- a/backend/internal/contacttask/marker_test.go
+++ b/backend/internal/contacttask/marker_test.go
@@ -1,0 +1,196 @@
+package contacttask
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestEncodeMarker_GoldenBytes locks the exact wire bytes: sorted keys,
+// crm:true present, instance present. A regression that switches to a struct
+// encoder (field-declaration order) or drops instance would change these
+// bytes and break the Todoist wire format.
+func TestEncodeMarker_GoldenBytes(t *testing.T) {
+	got, err := EncodeMarker(CRMMarker{
+		ContactID: "11111111-2222-3333-4444-555555555555",
+		Kind:      KindReachOut,
+		Lifecycle: LifecycleCadenceDue,
+		Instance:  "inst-abc",
+	})
+	if err != nil {
+		t.Fatalf("EncodeMarker: %v", err)
+	}
+	want := `{"contact_id":"11111111-2222-3333-4444-555555555555","crm":true,"instance":"inst-abc","kind":"reach_out","lifecycle":"cadence_due"}`
+	if string(got) != want {
+		t.Fatalf("golden bytes mismatch:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+// TestEncodeDecode_RoundTrip covers every (kind, lifecycle) pair the codebase
+// emits today. EncodeMarker -> DecodeMarker must preserve the fields, and the
+// encoded bytes must carry the instance field.
+func TestEncodeDecode_RoundTrip(t *testing.T) {
+	const contactID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	const instance = "inst-123"
+
+	cases := []struct {
+		name      string
+		kind      string
+		lifecycle string
+	}{
+		{"reach_out/cadence_due", KindReachOut, LifecycleCadenceDue},
+		{"reach_out/followup_loop", KindReachOut, LifecycleFollowUpLoop},
+		{"reach_out/manual", KindReachOut, LifecycleManual},
+		{"send/manual", KindSend, LifecycleManual},
+		{"reminder/manual", KindReminder, LifecycleManual},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			encoded, err := EncodeMarker(CRMMarker{
+				ContactID: contactID,
+				Kind:      tc.kind,
+				Lifecycle: tc.lifecycle,
+				Instance:  instance,
+			})
+			if err != nil {
+				t.Fatalf("EncodeMarker: %v", err)
+			}
+
+			// The encoded bytes must contain the instance field on the wire.
+			var raw map[string]any
+			if err := json.Unmarshal(encoded, &raw); err != nil {
+				t.Fatalf("unmarshal encoded: %v", err)
+			}
+			if raw["instance"] != instance {
+				t.Fatalf("instance not on wire: got %v want %q", raw["instance"], instance)
+			}
+			if raw["crm"] != true {
+				t.Fatalf("crm not true on wire: got %v", raw["crm"])
+			}
+
+			m, ok := DecodeMarker(string(encoded))
+			if !ok {
+				t.Fatalf("DecodeMarker returned ok=false for %s", encoded)
+			}
+			if m.ContactID != contactID {
+				t.Errorf("ContactID: got %q want %q", m.ContactID, contactID)
+			}
+			if m.Kind != tc.kind {
+				t.Errorf("Kind: got %q want %q", m.Kind, tc.kind)
+			}
+			if m.Lifecycle != tc.lifecycle {
+				t.Errorf("Lifecycle: got %q want %q", m.Lifecycle, tc.lifecycle)
+			}
+			if m.Instance != instance {
+				t.Errorf("Instance: got %q want %q", m.Instance, instance)
+			}
+		})
+	}
+}
+
+// TestDecodeMarker_LegacyNormalization feeds legacy marker JSON (no lifecycle
+// field) directly to DecodeMarker and asserts the legacy kind normalizes to
+// the expected (kind, lifecycle). This locks the behavior moved out of
+// tryRecoverPendingTempID.
+func TestDecodeMarker_LegacyNormalization(t *testing.T) {
+	const contactID = "11111111-1111-1111-1111-111111111111"
+
+	cases := []struct {
+		name          string
+		legacyJSON    string
+		wantKind      string
+		wantLifecycle string
+	}{
+		{
+			name:          "legacy cadence",
+			legacyJSON:    `{"crm":true,"contact_id":"` + contactID + `","kind":"cadence"}`,
+			wantKind:      KindReachOut,
+			wantLifecycle: LifecycleCadenceDue,
+		},
+		{
+			name:          "legacy empty kind",
+			legacyJSON:    `{"crm":true,"contact_id":"` + contactID + `"}`,
+			wantKind:      KindReachOut,
+			wantLifecycle: LifecycleCadenceDue,
+		},
+		{
+			name:          "legacy follow_up",
+			legacyJSON:    `{"crm":true,"contact_id":"` + contactID + `","kind":"follow_up"}`,
+			wantKind:      KindReachOut,
+			wantLifecycle: LifecycleFollowUpLoop,
+		},
+		{
+			name:          "legacy action",
+			legacyJSON:    `{"crm":true,"contact_id":"` + contactID + `","kind":"action"}`,
+			wantKind:      KindAction,
+			wantLifecycle: LifecycleManual,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, ok := DecodeMarker(tc.legacyJSON)
+			if !ok {
+				t.Fatalf("DecodeMarker(%s) returned ok=false", tc.legacyJSON)
+			}
+			if m.ContactID != contactID {
+				t.Errorf("ContactID: got %q want %q", m.ContactID, contactID)
+			}
+			if m.Kind != tc.wantKind {
+				t.Errorf("Kind: got %q want %q", m.Kind, tc.wantKind)
+			}
+			if m.Lifecycle != tc.wantLifecycle {
+				t.Errorf("Lifecycle: got %q want %q", m.Lifecycle, tc.wantLifecycle)
+			}
+		})
+	}
+}
+
+// TestDecodeMarker_MarkdownPrefix asserts a description that prepends prose
+// or markdown before the JSON marker still parses via the last-'{' retry.
+func TestDecodeMarker_MarkdownPrefix(t *testing.T) {
+	const contactID = "22222222-2222-2222-2222-222222222222"
+	desc := "Some notes about the contact\n\n---\n" +
+		`{"crm":true,"contact_id":"` + contactID + `","kind":"reach_out","lifecycle":"manual","instance":"inst-x"}`
+
+	m, ok := DecodeMarker(desc)
+	if !ok {
+		t.Fatalf("DecodeMarker returned ok=false for markdown-prefixed marker")
+	}
+	if m.ContactID != contactID {
+		t.Errorf("ContactID: got %q want %q", m.ContactID, contactID)
+	}
+	if m.Kind != KindReachOut {
+		t.Errorf("Kind: got %q want %q", m.Kind, KindReachOut)
+	}
+	if m.Lifecycle != LifecycleManual {
+		t.Errorf("Lifecycle: got %q want %q", m.Lifecycle, LifecycleManual)
+	}
+	if m.Instance != "inst-x" {
+		t.Errorf("Instance: got %q want %q", m.Instance, "inst-x")
+	}
+}
+
+// TestDecodeMarker_Rejects covers the non-marker and invalid inputs that must
+// return (zero, false).
+func TestDecodeMarker_Rejects(t *testing.T) {
+	cases := []struct {
+		name string
+		desc string
+	}{
+		{"crm false", `{"crm":false,"contact_id":"33333333-3333-3333-3333-333333333333","kind":"cadence"}`},
+		{"empty contact_id", `{"crm":true,"contact_id":"","kind":"cadence"}`},
+		{"unknown legacy kind", `{"crm":true,"contact_id":"33333333-3333-3333-3333-333333333333","kind":"bogus"}`},
+		{"not json", `just some plain text with no marker`},
+		{"empty string", ``},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, ok := DecodeMarker(tc.desc)
+			if ok {
+				t.Fatalf("DecodeMarker(%q) returned ok=true (marker=%+v), want false", tc.desc, m)
+			}
+		})
+	}
+}

--- a/backend/internal/service/contact_task.go
+++ b/backend/internal/service/contact_task.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -166,17 +165,15 @@ func (s *ContactTaskService) CreateManualTask(ctx context.Context, req CreateMan
 		descBuilder.WriteString("\n\n---\n")
 	}
 
-	// Add CRM marker for sync identification (use json.Marshal for safety).
-	// Both kind and lifecycle are written; readers that ignore lifecycle
-	// continue to work and the backfill path translates legacy markers.
-	marker := map[string]any{
-		"crm":        true,
-		"contact_id": contact.ID.String(),
-		"kind":       req.Kind,
-		"lifecycle":  contacttask.LifecycleManual,
-		"instance":   settings.IntegrationInstanceID,
-	}
-	markerJSON, err := json.Marshal(marker)
+	// Add CRM marker for sync identification. Both kind and lifecycle are
+	// written; readers that ignore lifecycle continue to work and the
+	// backfill path translates legacy markers.
+	markerJSON, err := contacttask.EncodeMarker(contacttask.CRMMarker{
+		ContactID: contact.ID.String(),
+		Kind:      req.Kind,
+		Lifecycle: contacttask.LifecycleManual,
+		Instance:  settings.IntegrationInstanceID,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("marshal marker: %w", err)
 	}

--- a/backend/internal/todoist/provider.go
+++ b/backend/internal/todoist/provider.go
@@ -2,7 +2,6 @@ package todoist
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -1549,48 +1548,18 @@ func isPendingTempID(task *repository.ContactTask) bool {
 // parse above verifies the sync item belongs to the same contact + cadence
 // kind, so advancing ExternalTaskID = item.ID is safe.
 func (p *CadenceSyncProvider) tryRecoverPendingTempID(ctx context.Context, item SyncItem) (*repository.ContactTask, bool) {
-	// Parse CRM marker from description to get contact ID + kind/lifecycle.
-	type crmMarker struct {
-		CRM       bool   `json:"crm"`
-		ContactID string `json:"contact_id"`
-		Kind      string `json:"kind"`
-		Lifecycle string `json:"lifecycle"`
-	}
-	var marker crmMarker
-	descToTry := item.Description
-	if err := json.Unmarshal([]byte(descToTry), &marker); err != nil || !marker.CRM || marker.ContactID == "" {
-		marker = crmMarker{}
-		if idx := strings.LastIndex(item.Description, "{"); idx >= 0 {
-			descToTry = item.Description[idx:]
-		}
-		if err := json.Unmarshal([]byte(descToTry), &marker); err != nil || !marker.CRM || marker.ContactID == "" {
-			return nil, false
-		}
+	// Parse + normalize the CRM marker from the description to get the
+	// contact ID + (kind, lifecycle). DecodeMarker handles the markdown-
+	// prefix retry and legacy-kind translation; an unrecognized or absent
+	// marker yields ok=false.
+	marker, ok := contacttask.DecodeMarker(item.Description)
+	if !ok {
+		return nil, false
 	}
 
 	contactID, err := uuid.Parse(marker.ContactID)
 	if err != nil {
 		return nil, false
-	}
-
-	// Translate legacy markers (no lifecycle field) into the new
-	// (kind, lifecycle) shape. Recovery here is cadence-only; non-cadence
-	// markers fall through the gate below. The unconditional translation
-	// keeps the parsed marker fields useful for future debugging.
-	if marker.Lifecycle == "" {
-		switch marker.Kind {
-		case "cadence", "":
-			marker.Kind = contacttask.KindReachOut
-			marker.Lifecycle = contacttask.LifecycleCadenceDue
-		case "follow_up":
-			marker.Kind = contacttask.KindReachOut
-			marker.Lifecycle = contacttask.LifecycleFollowUpLoop
-		case "action":
-			marker.Kind = contacttask.KindAction
-			marker.Lifecycle = contacttask.LifecycleManual
-		default:
-			return nil, false
-		}
 	}
 
 	// Cadence-only recovery: follow-up and manual rows reconcile via the

--- a/backend/internal/todoist/provider.go
+++ b/backend/internal/todoist/provider.go
@@ -1682,14 +1682,12 @@ func (p *CadenceSyncProvider) createTaskCommand(contact *repository.Contact, set
 	// Build description with CRM marker (link is in title)
 	var descBuilder strings.Builder
 
-	marker := map[string]any{
-		"crm":        true,
-		"contact_id": contact.ID.String(),
-		"kind":       contacttask.KindReachOut,
-		"lifecycle":  contacttask.LifecycleCadenceDue,
-		"instance":   settings.IntegrationInstanceID,
-	}
-	markerJSON, err := json.Marshal(marker)
+	markerJSON, err := contacttask.EncodeMarker(contacttask.CRMMarker{
+		ContactID: contact.ID.String(),
+		Kind:      contacttask.KindReachOut,
+		Lifecycle: contacttask.LifecycleCadenceDue,
+		Instance:  settings.IntegrationInstanceID,
+	})
 	if err != nil {
 		logger.Error().Err(err).Str("contactId", contact.ID.String()).Msg("failed to marshal CRM marker - task may not sync properly")
 	}

--- a/backend/internal/todoist/provider.go
+++ b/backend/internal/todoist/provider.go
@@ -1031,9 +1031,9 @@ func setSyncedLastOutreachAt(metadata map[string]any, contact *repository.Contac
 
 // setPendingCreateState writes the pending-create key set: pending_temp_id +
 // synced_deadline (always), then BOTH synced_* keys (each gated on its own
-// contact field being non-nil). Used by the Group A "pending-create"
-// branches, which all write this identical shape. Allocates the map if nil
-// and returns it, preserving sibling keys.
+// contact field being non-nil). Used by the branches that queue a new Todoist
+// task, which all write this identical shape. Allocates the map if nil and
+// returns it, preserving sibling keys.
 func setPendingCreateState(metadata map[string]any, tempID, deadline string, contact *repository.Contact) map[string]any {
 	if metadata == nil {
 		metadata = make(map[string]any)

--- a/backend/internal/todoist/provider.go
+++ b/backend/internal/todoist/provider.go
@@ -850,18 +850,7 @@ func (p *CadenceSyncProvider) handleSkipTrigger(
 	// Update metadata. Preserve existing keys — pre-skip synced_deadline is
 	// consulted by the reconciler's skip-drift branch to close+recreate on
 	// HTTP failure.
-	metadata := task.Metadata
-	if metadata == nil {
-		metadata = make(map[string]any)
-	}
-	metadata[MetadataKeyPendingTempID] = replacementCmd.TempID
-	metadata[MetadataKeySyncedDeadline] = deadlineStr
-	if contact.LastContacted != nil {
-		metadata[MetadataKeySyncedLastContacted] = contact.LastContacted.Format(time.RFC3339)
-	}
-	if contact.LastOutreachAt != nil {
-		metadata[MetadataKeySyncedLastOutreachAt] = contact.LastOutreachAt.Format(time.RFC3339)
-	}
+	metadata := setPendingCreateState(task.Metadata, replacementCmd.TempID, deadlineStr, contact)
 	if _, err := p.contactTaskRepo.UpdateContactTaskMetadataTx(ctx, tx, task.ID, metadata); err != nil {
 		return processItemResult{Err: fmt.Errorf("update task metadata: %w", err)}
 	}
@@ -1011,6 +1000,51 @@ func (p *CadenceSyncProvider) handleActionTaskTriggers(
 	return processItemResult{Processed: true}
 }
 
+// setSyncedLastContacted writes ONLY synced_last_contacted into metadata when
+// contact.LastContacted is non-nil. It allocates the map if nil and returns
+// it, preserving any sibling keys (mutate-and-return, not replace).
+func setSyncedLastContacted(metadata map[string]any, contact *repository.Contact) map[string]any {
+	if metadata == nil {
+		metadata = make(map[string]any)
+	}
+	if contact.LastContacted != nil {
+		metadata[MetadataKeySyncedLastContacted] = contact.LastContacted.Format(time.RFC3339)
+	}
+	return metadata
+}
+
+// setSyncedLastOutreachAt writes ONLY synced_last_outreach_at into metadata
+// when contact.LastOutreachAt is non-nil. It must NOT touch
+// synced_last_contacted: the outreach-only backfill branches run before
+// wasContactedSinceSync, and refreshing synced_last_contacted there would
+// mask stale state and suppress a legitimate close+recreate. Allocates the
+// map if nil and returns it, preserving sibling keys.
+func setSyncedLastOutreachAt(metadata map[string]any, contact *repository.Contact) map[string]any {
+	if metadata == nil {
+		metadata = make(map[string]any)
+	}
+	if contact.LastOutreachAt != nil {
+		metadata[MetadataKeySyncedLastOutreachAt] = contact.LastOutreachAt.Format(time.RFC3339)
+	}
+	return metadata
+}
+
+// setPendingCreateState writes the pending-create key set: pending_temp_id +
+// synced_deadline (always), then BOTH synced_* keys (each gated on its own
+// contact field being non-nil). Used by the Group A "pending-create"
+// branches, which all write this identical shape. Allocates the map if nil
+// and returns it, preserving sibling keys.
+func setPendingCreateState(metadata map[string]any, tempID, deadline string, contact *repository.Contact) map[string]any {
+	if metadata == nil {
+		metadata = make(map[string]any)
+	}
+	metadata[MetadataKeyPendingTempID] = tempID
+	metadata[MetadataKeySyncedDeadline] = deadline
+	metadata = setSyncedLastContacted(metadata, contact)
+	metadata = setSyncedLastOutreachAt(metadata, contact)
+	return metadata
+}
+
 // reconcileContactTasks ensures all contacts with cadence have managed tasks
 // and that existing tasks have deadlines matching the contact's contact_by.
 //
@@ -1099,17 +1133,8 @@ func (p *CadenceSyncProvider) reconcileContactTasks(
 			cmd := p.createTaskCommand(&contact, settings, &currentDeadline)
 			commands = append(commands, cmd)
 
-			// Create task link (with temp_id, synced_deadline, and synced_last_contacted)
-			taskMetadata := map[string]any{
-				MetadataKeyPendingTempID:  cmd.TempID,
-				MetadataKeySyncedDeadline: currentDeadline,
-			}
-			if contact.LastContacted != nil {
-				taskMetadata[MetadataKeySyncedLastContacted] = contact.LastContacted.Format(time.RFC3339)
-			}
-			if contact.LastOutreachAt != nil {
-				taskMetadata[MetadataKeySyncedLastOutreachAt] = contact.LastOutreachAt.Format(time.RFC3339)
-			}
+			// Create task link (with temp_id, synced_deadline, and both synced_* keys)
+			taskMetadata := setPendingCreateState(make(map[string]any), cmd.TempID, currentDeadline, &contact)
 			_, createErr := p.contactTaskRepo.CreateContactTask(ctx, repository.CreateContactTaskRequest{
 				ContactID:      contact.ID,
 				Provider:       SourceName,
@@ -1176,13 +1201,7 @@ func (p *CadenceSyncProvider) closeOnOutreach(
 		}
 
 		// Update synced_last_outreach_at so we don't re-fire on the next tick
-		metadata := task.Metadata
-		if metadata == nil {
-			metadata = make(map[string]any)
-		}
-		if contact.LastOutreachAt != nil {
-			metadata[MetadataKeySyncedLastOutreachAt] = contact.LastOutreachAt.Format(time.RFC3339)
-		}
+		metadata := setSyncedLastOutreachAt(task.Metadata, contact)
 		if _, err := p.contactTaskRepo.UpdateContactTaskMetadata(ctx, task.ID, metadata); err != nil {
 			logger.Warn().Err(err).Str("contactId", contact.ID.String()).Msg("failed to update synced_last_outreach_at after outreach detection")
 		}
@@ -1197,11 +1216,7 @@ func (p *CadenceSyncProvider) closeOnOutreach(
 	// without this pre-gate path.
 	if _, hasSyncedLO := task.Metadata[MetadataKeySyncedLastOutreachAt].(string); !hasSyncedLO {
 		if contact.LastOutreachAt != nil {
-			metadata := task.Metadata
-			if metadata == nil {
-				metadata = make(map[string]any)
-			}
-			metadata[MetadataKeySyncedLastOutreachAt] = contact.LastOutreachAt.Format(time.RFC3339)
+			metadata := setSyncedLastOutreachAt(task.Metadata, contact)
 			if _, err := p.contactTaskRepo.UpdateContactTaskMetadata(ctx, task.ID, metadata); err != nil {
 				logger.Warn().Err(err).Str("contactId", contact.ID.String()).Msg("failed to backfill synced_last_outreach_at (pre-gate)")
 			} else {
@@ -1265,18 +1280,7 @@ func (p *CadenceSyncProvider) reconcileExistingTask(
 		// batch's temp_id_mapping response couldn't be applied via
 		// processTempIDMappings. Emitting the commands anyway would
 		// create a Todoist task with no way to map back to the contact_task.
-		metadata := task.Metadata
-		if metadata == nil {
-			metadata = make(map[string]any)
-		}
-		metadata[MetadataKeyPendingTempID] = cmd.TempID
-		metadata[MetadataKeySyncedDeadline] = currentDeadline
-		if contact.LastContacted != nil {
-			metadata[MetadataKeySyncedLastContacted] = contact.LastContacted.Format(time.RFC3339)
-		}
-		if contact.LastOutreachAt != nil {
-			metadata[MetadataKeySyncedLastOutreachAt] = contact.LastOutreachAt.Format(time.RFC3339)
-		}
+		metadata := setPendingCreateState(task.Metadata, cmd.TempID, currentDeadline, contact)
 		if _, err := p.contactTaskRepo.UpdateContactTaskMetadata(ctx, task.ID, metadata); err != nil {
 			logger.Warn().Err(err).
 				Str("contactId", contact.ID.String()).
@@ -1310,12 +1314,8 @@ func (p *CadenceSyncProvider) reconcileExistingTask(
 			metadata = make(map[string]any)
 		}
 		metadata[MetadataKeySyncedDeadline] = currentDeadline
-		if contact.LastContacted != nil {
-			metadata[MetadataKeySyncedLastContacted] = contact.LastContacted.Format(time.RFC3339)
-		}
-		if contact.LastOutreachAt != nil {
-			metadata[MetadataKeySyncedLastOutreachAt] = contact.LastOutreachAt.Format(time.RFC3339)
-		}
+		metadata = setSyncedLastContacted(metadata, contact)
+		metadata = setSyncedLastOutreachAt(metadata, contact)
 		if _, err := p.contactTaskRepo.UpdateContactTaskMetadata(ctx, task.ID, metadata); err != nil {
 			logger.Warn().Err(err).Str("contactId", contact.ID.String()).Msg("failed to backfill synced_deadline")
 		}
@@ -1327,14 +1327,7 @@ func (p *CadenceSyncProvider) reconcileExistingTask(
 	// meaning non-Todoist contacts would never be detected.
 	if _, hasSyncedLC := task.Metadata[MetadataKeySyncedLastContacted].(string); !hasSyncedLC {
 		if contact.LastContacted != nil {
-			metadata := task.Metadata
-			if metadata == nil {
-				metadata = make(map[string]any)
-			}
-			metadata[MetadataKeySyncedLastContacted] = contact.LastContacted.Format(time.RFC3339)
-			if contact.LastOutreachAt != nil {
-				metadata[MetadataKeySyncedLastOutreachAt] = contact.LastOutreachAt.Format(time.RFC3339)
-			}
+			metadata := setSyncedLastOutreachAt(setSyncedLastContacted(task.Metadata, contact), contact)
 			if _, err := p.contactTaskRepo.UpdateContactTaskMetadata(ctx, task.ID, metadata); err != nil {
 				logger.Warn().Err(err).Str("contactId", contact.ID.String()).Msg("failed to backfill synced_last_contacted")
 			} else {
@@ -1348,11 +1341,7 @@ func (p *CadenceSyncProvider) reconcileExistingTask(
 	// Without this, wasReachedOutSinceSync would always return false for legacy tasks.
 	if _, hasSyncedLO := task.Metadata[MetadataKeySyncedLastOutreachAt].(string); !hasSyncedLO {
 		if contact.LastOutreachAt != nil {
-			metadata := task.Metadata
-			if metadata == nil {
-				metadata = make(map[string]any)
-			}
-			metadata[MetadataKeySyncedLastOutreachAt] = contact.LastOutreachAt.Format(time.RFC3339)
+			metadata := setSyncedLastOutreachAt(task.Metadata, contact)
 			if _, err := p.contactTaskRepo.UpdateContactTaskMetadata(ctx, task.ID, metadata); err != nil {
 				logger.Warn().Err(err).Str("contactId", contact.ID.String()).Msg("failed to backfill synced_last_outreach_at")
 			} else {
@@ -1393,18 +1382,7 @@ func (p *CadenceSyncProvider) reconcileExistingTask(
 				commands = append(commands, cmd)
 
 				// Update metadata
-				metadata := task.Metadata
-				if metadata == nil {
-					metadata = make(map[string]any)
-				}
-				metadata[MetadataKeyPendingTempID] = cmd.TempID
-				metadata[MetadataKeySyncedDeadline] = deadlineStr
-				if contact.LastContacted != nil {
-					metadata[MetadataKeySyncedLastContacted] = contact.LastContacted.Format(time.RFC3339)
-				}
-				if contact.LastOutreachAt != nil {
-					metadata[MetadataKeySyncedLastOutreachAt] = contact.LastOutreachAt.Format(time.RFC3339)
-				}
+				metadata := setPendingCreateState(task.Metadata, cmd.TempID, deadlineStr, contact)
 				if _, err := p.contactTaskRepo.UpdateContactTaskMetadata(ctx, task.ID, metadata); err != nil {
 					logger.Warn().Err(err).Msg("failed to update metadata after non-Todoist contact")
 				}
@@ -1437,18 +1415,7 @@ func (p *CadenceSyncProvider) reconcileExistingTask(
 	// we'll have an orphaned task (no pending_temp_id to map). This is logged but not fatal
 	// because the sync is async - we can't roll back Todoist commands. The orphaned task
 	// will be cleaned up on the next full sync when it appears in items without a linked contact.
-	metadata := task.Metadata
-	if metadata == nil {
-		metadata = make(map[string]any)
-	}
-	metadata[MetadataKeyPendingTempID] = cmd.TempID
-	metadata[MetadataKeySyncedDeadline] = currentDeadline
-	if contact.LastContacted != nil {
-		metadata[MetadataKeySyncedLastContacted] = contact.LastContacted.Format(time.RFC3339)
-	}
-	if contact.LastOutreachAt != nil {
-		metadata[MetadataKeySyncedLastOutreachAt] = contact.LastOutreachAt.Format(time.RFC3339)
-	}
+	metadata := setPendingCreateState(task.Metadata, cmd.TempID, currentDeadline, contact)
 	if _, err := p.contactTaskRepo.UpdateContactTaskMetadata(ctx, task.ID, metadata); err != nil {
 		logger.Error().
 			Err(err).

--- a/backend/internal/todoist/provider_marker_callsite_test.go
+++ b/backend/internal/todoist/provider_marker_callsite_test.go
@@ -1,0 +1,36 @@
+package todoist
+
+import (
+	"testing"
+
+	"personal-crm/backend/internal/contacttask"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCreateTaskCommand_EmitsCadenceMarker locks the E1 call site: the cadence
+// item_add command's description must decode (via DecodeMarker) to
+// (reach_out, cadence_due) carrying the contact's id and the configured
+// integration instance. Guards that createTaskCommand passes the correct
+// fields to EncodeMarker, not just that the codec round-trips.
+func TestCreateTaskCommand_EmitsCadenceMarker(t *testing.T) {
+	env, cleanup := setupDismissalTest(t)
+	defer cleanup()
+
+	contact, _ := createDismissalContact(t, env, "E1Marker")
+
+	deadline := "2099-01-01"
+	cmd := env.provider.createTaskCommand(contact, env.settings, &deadline)
+
+	require.Equal(t, "item_add", cmd.Type)
+	desc, ok := cmd.Args["description"].(string)
+	require.True(t, ok, "item_add must carry a description with the CRM marker")
+
+	marker, ok := contacttask.DecodeMarker(desc)
+	require.True(t, ok, "description must decode as a CRM marker")
+	assert.Equal(t, contact.ID.String(), marker.ContactID)
+	assert.Equal(t, contacttask.KindReachOut, marker.Kind)
+	assert.Equal(t, contacttask.LifecycleCadenceDue, marker.Lifecycle)
+	assert.Equal(t, env.settings.IntegrationInstanceID, marker.Instance)
+}

--- a/backend/internal/todoist/provider_metadata_helpers_test.go
+++ b/backend/internal/todoist/provider_metadata_helpers_test.go
@@ -1,0 +1,120 @@
+package todoist
+
+import (
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSetSyncedLastOutreachAt_DoesNotTouchLastContacted is the helper-purity
+// unit test for the P1 fix. setSyncedLastOutreachAt must write ONLY
+// synced_last_outreach_at and leave any existing synced_last_contacted value
+// byte-identical — refreshing it here would mask stale state and suppress a
+// legitimate close+recreate in the deadlines-match drift path.
+func TestSetSyncedLastOutreachAt_DoesNotTouchLastContacted(t *testing.T) {
+	staleLC := "2023-01-01T00:00:00Z"
+	metadata := map[string]any{
+		MetadataKeySyncedLastContacted: staleLC,
+		"sibling_key":                  "preserve-me",
+	}
+
+	// The contact's LastContacted is set to a DIFFERENT value than the stale
+	// stored one: a regression that wrote contact.LastContacted into
+	// synced_last_contacted would change the stored value, so this assertion
+	// would catch it.
+	contacted := time.Date(2024, 5, 1, 9, 0, 0, 0, time.UTC)
+	outreach := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	contact := &repository.Contact{LastContacted: &contacted, LastOutreachAt: &outreach}
+
+	got := setSyncedLastOutreachAt(metadata, contact)
+
+	// synced_last_contacted must be untouched.
+	assert.Equal(t, staleLC, got[MetadataKeySyncedLastContacted],
+		"setSyncedLastOutreachAt must not modify synced_last_contacted")
+	// synced_last_outreach_at must be written.
+	assert.Equal(t, outreach.Format(time.RFC3339), got[MetadataKeySyncedLastOutreachAt],
+		"setSyncedLastOutreachAt must write synced_last_outreach_at")
+	// Sibling keys must survive (mutate-and-return, not replace).
+	assert.Equal(t, "preserve-me", got["sibling_key"],
+		"setSyncedLastOutreachAt must preserve sibling keys")
+}
+
+// TestSetSyncedLastOutreachAt_NilOutreach asserts the helper is a no-op for
+// the outreach key when contact.LastOutreachAt is nil (and still preserves
+// existing keys).
+func TestSetSyncedLastOutreachAt_NilOutreach(t *testing.T) {
+	metadata := map[string]any{MetadataKeySyncedLastContacted: "2023-01-01T00:00:00Z"}
+	contacted := time.Date(2024, 5, 1, 9, 0, 0, 0, time.UTC)
+	got := setSyncedLastOutreachAt(metadata, &repository.Contact{LastContacted: &contacted, LastOutreachAt: nil})
+	_, has := got[MetadataKeySyncedLastOutreachAt]
+	assert.False(t, has, "no synced_last_outreach_at should be written when LastOutreachAt is nil")
+	assert.Equal(t, "2023-01-01T00:00:00Z", got[MetadataKeySyncedLastContacted],
+		"setSyncedLastOutreachAt must not write synced_last_contacted even when contact has LastContacted")
+}
+
+// TestReconcileExistingTask_LOBackfillPreservesStaleLC is the behavioral guard
+// for the P1 fix. Setup: a managed cadence task with a STALE stored
+// synced_last_contacted, MISSING synced_last_outreach_at, and
+// synced_deadline == currentDeadline. The contact has both LastContacted
+// (advanced past the stale stored value) and LastOutreachAt set.
+//
+// reconcileExistingTask runs the synced_last_outreach_at-only backfill BEFORE
+// wasContactedSinceSync. If that backfill regressed to also writing
+// synced_last_contacted, it would refresh the stale value to the contact's
+// current LastContacted, wasContactedSinceSync would return false, and NO
+// close+recreate would be emitted. Asserting the close+recreate commands ARE
+// emitted proves the LO-only backfill preserved the stale synced_last_contacted
+// long enough for drift detection to fire.
+//
+// reconcileExistingTask is invoked directly (not via reconcileContactTasks) so
+// the closeOnOutreach pre-gate backfill — which would otherwise consume the
+// missing-synced_LO case first — does not pre-empt the path under test.
+func TestReconcileExistingTask_LOBackfillPreservesStaleLC(t *testing.T) {
+	env, cleanup := setupDismissalTest(t)
+	defer cleanup()
+
+	contact, snap := createDismissalContact(t, env, "LOBackfillPreserveLC")
+	require.NotNil(t, contact.LastContacted)
+	require.NotNil(t, contact.LastOutreachAt, "contact must have last_outreach_at for the LO backfill")
+
+	currentDeadline := contact.ContactBy.Format(DateFormat)
+
+	// Stale synced_last_contacted: well before the contact's current
+	// LastContacted, so wasContactedSinceSync (current > stored) can fire.
+	staleLC := snap.LastContacted.AddDate(0, 0, -30)
+
+	cadenceExtID := "td-cadence-lopreserve-" + uuid.New().String()[:8]
+	task := createCadenceTask(t, env, contact.ID, cadenceExtID, map[string]any{
+		MetadataKeySyncedDeadline:      currentDeadline,
+		MetadataKeySyncedLastContacted: staleLC.Format(time.RFC3339),
+		// deliberately omitted: MetadataKeySyncedLastOutreachAt (triggers the
+		// LO-only backfill inside reconcileExistingTask).
+	})
+
+	commands := env.provider.reconcileExistingTask(env.ctx, task, contact, env.settings, currentDeadline, false)
+
+	// The close+recreate pair must be emitted: close on the old external id,
+	// plus a fresh item_add. If the LO backfill had clobbered synced_LC,
+	// wasContactedSinceSync would have returned false and no commands fire.
+	var closedIDs []string
+	var addCount int
+	for _, cmd := range commands {
+		switch cmd.Type {
+		case "item_close":
+			if id, ok := cmd.Args["id"].(string); ok {
+				closedIDs = append(closedIDs, id)
+			}
+		case "item_add":
+			addCount++
+		}
+	}
+	assert.Contains(t, closedIDs, cadenceExtID,
+		"old cadence task must be closed (drift detected via preserved stale synced_last_contacted)")
+	assert.Equal(t, 1, addCount,
+		"a replacement cadence task must be created")
+}

--- a/backend/internal/todoist/provider_metadata_helpers_test.go
+++ b/backend/internal/todoist/provider_metadata_helpers_test.go
@@ -57,6 +57,75 @@ func TestSetSyncedLastOutreachAt_NilOutreach(t *testing.T) {
 		"setSyncedLastOutreachAt must not write synced_last_contacted even when contact has LastContacted")
 }
 
+// TestSetSyncedLastContacted_WritesLCOnlyAndPreservesSiblings asserts the
+// LC-only helper writes synced_last_contacted (when set), preserves sibling
+// keys (mutate-and-return), and is a no-op for the LC key when LastContacted
+// is nil.
+func TestSetSyncedLastContacted_WritesLCOnlyAndPreservesSiblings(t *testing.T) {
+	contacted := time.Date(2024, 5, 1, 9, 0, 0, 0, time.UTC)
+
+	t.Run("writes LC and preserves siblings", func(t *testing.T) {
+		metadata := map[string]any{
+			"sibling_key":                   "preserve-me",
+			MetadataKeySyncedLastOutreachAt: "2023-09-09T00:00:00Z",
+		}
+		got := setSyncedLastContacted(metadata, &repository.Contact{LastContacted: &contacted})
+		assert.Equal(t, contacted.Format(time.RFC3339), got[MetadataKeySyncedLastContacted],
+			"must write synced_last_contacted")
+		assert.Equal(t, "preserve-me", got["sibling_key"], "must preserve sibling keys")
+		assert.Equal(t, "2023-09-09T00:00:00Z", got[MetadataKeySyncedLastOutreachAt],
+			"must not touch synced_last_outreach_at")
+	})
+
+	t.Run("nil LastContacted is a no-op", func(t *testing.T) {
+		got := setSyncedLastContacted(map[string]any{"k": "v"}, &repository.Contact{LastContacted: nil})
+		_, has := got[MetadataKeySyncedLastContacted]
+		assert.False(t, has, "no synced_last_contacted should be written when LastContacted is nil")
+		assert.Equal(t, "v", got["k"], "must preserve existing keys")
+	})
+
+	t.Run("nil map is allocated", func(t *testing.T) {
+		got := setSyncedLastContacted(nil, &repository.Contact{LastContacted: &contacted})
+		require.NotNil(t, got)
+		assert.Equal(t, contacted.Format(time.RFC3339), got[MetadataKeySyncedLastContacted])
+	})
+}
+
+// TestSetPendingCreateState_WritesFullShape asserts the Group-A pending-create
+// helper writes pending_temp_id + synced_deadline + both synced_* keys (each
+// gated on its own contact field), preserves sibling keys, and gates the
+// synced_* keys correctly when the contact fields are nil.
+func TestSetPendingCreateState_WritesFullShape(t *testing.T) {
+	contacted := time.Date(2024, 5, 1, 9, 0, 0, 0, time.UTC)
+	outreach := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	t.Run("full shape with both contact fields set", func(t *testing.T) {
+		metadata := map[string]any{"marker_json": `{"crm":true}`}
+		got := setPendingCreateState(metadata, "temp-123", "2099-01-01", &repository.Contact{
+			LastContacted:  &contacted,
+			LastOutreachAt: &outreach,
+		})
+		assert.Equal(t, "temp-123", got[MetadataKeyPendingTempID])
+		assert.Equal(t, "2099-01-01", got[MetadataKeySyncedDeadline])
+		assert.Equal(t, contacted.Format(time.RFC3339), got[MetadataKeySyncedLastContacted])
+		assert.Equal(t, outreach.Format(time.RFC3339), got[MetadataKeySyncedLastOutreachAt])
+		assert.Equal(t, `{"crm":true}`, got["marker_json"], "must preserve sibling keys")
+	})
+
+	t.Run("synced_* keys gated on nil contact fields", func(t *testing.T) {
+		got := setPendingCreateState(nil, "temp-456", "2099-02-02", &repository.Contact{
+			LastContacted:  nil,
+			LastOutreachAt: nil,
+		})
+		assert.Equal(t, "temp-456", got[MetadataKeyPendingTempID])
+		assert.Equal(t, "2099-02-02", got[MetadataKeySyncedDeadline])
+		_, hasLC := got[MetadataKeySyncedLastContacted]
+		_, hasLO := got[MetadataKeySyncedLastOutreachAt]
+		assert.False(t, hasLC, "synced_last_contacted must be omitted when LastContacted is nil")
+		assert.False(t, hasLO, "synced_last_outreach_at must be omitted when LastOutreachAt is nil")
+	})
+}
+
 // TestReconcileExistingTask_LOBackfillPreservesStaleLC is the behavioral guard
 // for the P1 fix. Setup: a managed cadence task with a STALE stored
 // synced_last_contacted, MISSING synced_last_outreach_at, and

--- a/backend/internal/todoist/provider_metadata_helpers_test.go
+++ b/backend/internal/todoist/provider_metadata_helpers_test.go
@@ -12,10 +12,10 @@ import (
 )
 
 // TestSetSyncedLastOutreachAt_DoesNotTouchLastContacted is the helper-purity
-// unit test for the P1 fix. setSyncedLastOutreachAt must write ONLY
-// synced_last_outreach_at and leave any existing synced_last_contacted value
-// byte-identical — refreshing it here would mask stale state and suppress a
-// legitimate close+recreate in the deadlines-match drift path.
+// unit test for the asymmetry invariant. setSyncedLastOutreachAt must write
+// ONLY synced_last_outreach_at and leave any existing synced_last_contacted
+// value byte-identical — refreshing it here would mask stale state and
+// suppress a legitimate close+recreate in the deadlines-match drift path.
 func TestSetSyncedLastOutreachAt_DoesNotTouchLastContacted(t *testing.T) {
 	staleLC := "2023-01-01T00:00:00Z"
 	metadata := map[string]any{
@@ -91,10 +91,10 @@ func TestSetSyncedLastContacted_WritesLCOnlyAndPreservesSiblings(t *testing.T) {
 	})
 }
 
-// TestSetPendingCreateState_WritesFullShape asserts the Group-A pending-create
-// helper writes pending_temp_id + synced_deadline + both synced_* keys (each
-// gated on its own contact field), preserves sibling keys, and gates the
-// synced_* keys correctly when the contact fields are nil.
+// TestSetPendingCreateState_WritesFullShape asserts the pending-create helper
+// writes pending_temp_id + synced_deadline + both synced_* keys (each gated on
+// its own contact field), preserves sibling keys, and gates the synced_* keys
+// correctly when the contact fields are nil.
 func TestSetPendingCreateState_WritesFullShape(t *testing.T) {
 	contacted := time.Date(2024, 5, 1, 9, 0, 0, 0, time.UTC)
 	outreach := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
@@ -127,8 +127,8 @@ func TestSetPendingCreateState_WritesFullShape(t *testing.T) {
 }
 
 // TestReconcileExistingTask_LOBackfillPreservesStaleLC is the behavioral guard
-// for the P1 fix. Setup: a managed cadence task with a STALE stored
-// synced_last_contacted, MISSING synced_last_outreach_at, and
+// for the asymmetry invariant. Setup: a managed cadence task with a STALE
+// stored synced_last_contacted, MISSING synced_last_outreach_at, and
 // synced_deadline == currentDeadline. The contact has both LastContacted
 // (advanced past the stale stored value) and LastOutreachAt set.
 //

--- a/backend/tests/crm_marker_construction_static_test.go
+++ b/backend/tests/crm_marker_construction_static_test.go
@@ -17,10 +17,15 @@
 //	    string-literal index and a bool-true RHS) — an incrementally-built
 //	    marker map.
 //
+// Shape (a) is detected inside function bodies AND in top-level var/const
+// initializers (so a package-level `var x = map[string]any{"crm":true}` is not
+// a hole); shape (c) is detected inside function bodies (the only place
+// statements live).
+//
 // All must live ONLY in internal/contacttask/marker.go, and within that file
 // only inside the sanctioned declarations (allowedConstructionSites). A stray
-// marker construction added to an unrelated function — even inside marker.go
-// itself — trips the guard.
+// marker construction added to an unrelated function — or a top-level var —
+// even inside marker.go itself — trips the guard.
 package tests
 
 import (
@@ -47,6 +52,101 @@ var allowedConstructionSites = map[string]string{
 	"internal/contacttask/marker.go:crmMarkerJSON": "decode-only wire struct",
 }
 
+// markerViolation records one disallowed CRM-marker construction site.
+type markerViolation struct {
+	file string
+	line int
+	decl string
+	kind string
+}
+
+// findCRMMarkerConstructions scans one parsed file for CRM-marker
+// construction sites and returns any that fall outside allowedConstructionSites.
+// relSlash is the file's path relative to the backend module root (forward
+// slashes), used to build the allowlist key. Detection covers:
+//   - map composite literals with "crm":true, in function bodies AND top-level
+//     var/const initializers
+//   - index assignments `m["crm"] = true`, in function bodies
+//   - struct type declarations with a json:"crm" field tag
+//
+// Both the real-tree test and the negative self-test call this, so the two can
+// never drift apart.
+func findCRMMarkerConstructions(relSlash string, file *ast.File, fset *token.FileSet) []markerViolation {
+	var violations []markerViolation
+	record := func(declName string, pos token.Pos, kind string) {
+		key := relSlash + ":" + declName
+		if _, allowed := allowedConstructionSites[key]; allowed {
+			return
+		}
+		violations = append(violations, markerViolation{
+			file: relSlash,
+			line: fset.Position(pos).Line,
+			decl: declName,
+			kind: kind,
+		})
+	}
+
+	for _, decl := range file.Decls {
+		switch d := decl.(type) {
+		case *ast.FuncDecl:
+			if d.Body == nil {
+				continue
+			}
+			ast.Inspect(d.Body, func(n ast.Node) bool {
+				switch {
+				case isCRMMarkerMapLiteral(n):
+					record(d.Name.Name, n.Pos(), `map literal "crm":true`)
+				case isCRMMarkerIndexAssign(n):
+					record(d.Name.Name, n.Pos(), `index assignment ["crm"] = true`)
+				}
+				return true
+			})
+		case *ast.GenDecl:
+			switch d.Tok {
+			case token.TYPE:
+				for _, spec := range d.Specs {
+					ts, ok := spec.(*ast.TypeSpec)
+					if !ok {
+						continue
+					}
+					st, ok := ts.Type.(*ast.StructType)
+					if !ok {
+						continue
+					}
+					if !structHasCRMJSONTag(st) {
+						continue
+					}
+					record(ts.Name.Name, ts.Pos(), `struct field json:"crm"`)
+				}
+			case token.VAR, token.CONST:
+				// Top-level var/const with a composite-literal initializer
+				// (e.g. var x = map[string]any{"crm":true}). Walk each value
+				// expression; key the violation by the declared name so it
+				// lands in the same allowlist as the func/type sites.
+				for _, spec := range d.Specs {
+					vs, ok := spec.(*ast.ValueSpec)
+					if !ok {
+						continue
+					}
+					declName := "<anonymous>"
+					if len(vs.Names) > 0 {
+						declName = vs.Names[0].Name
+					}
+					for _, val := range vs.Values {
+						ast.Inspect(val, func(n ast.Node) bool {
+							if isCRMMarkerMapLiteral(n) {
+								record(declName, n.Pos(), `map literal "crm":true`)
+							}
+							return true
+						})
+					}
+				}
+			}
+		}
+	}
+	return violations
+}
+
 // TestCRMMarkerConstruction_OnlyAllowedSites walks the Go AST of
 // backend/internal + backend/cmd/crm-api and asserts every CRM-marker
 // construction (map literal with "crm":true, an index assignment
@@ -63,13 +163,7 @@ func TestCRMMarkerConstruction_OnlyAllowedSites(t *testing.T) {
 		filepath.Join(moduleRoot, "cmd", "crm-api"),
 	}
 
-	type violation struct {
-		file string
-		line int
-		decl string
-		kind string
-	}
-	var violations []violation
+	var violations []markerViolation
 
 	fset := token.NewFileSet()
 	for _, root := range roots {
@@ -103,63 +197,7 @@ func TestCRMMarkerConstruction_OnlyAllowedSites(t *testing.T) {
 				return err
 			}
 
-			for _, decl := range file.Decls {
-				switch d := decl.(type) {
-				case *ast.FuncDecl:
-					if d.Body == nil {
-						continue
-					}
-					ast.Inspect(d.Body, func(n ast.Node) bool {
-						var kind string
-						switch {
-						case isCRMMarkerMapLiteral(n):
-							kind = `map literal "crm":true`
-						case isCRMMarkerIndexAssign(n):
-							kind = `index assignment ["crm"] = true`
-						default:
-							return true
-						}
-						key := relSlash + ":" + d.Name.Name
-						if _, allowed := allowedConstructionSites[key]; allowed {
-							return true
-						}
-						violations = append(violations, violation{
-							file: relSlash,
-							line: fset.Position(n.Pos()).Line,
-							decl: d.Name.Name,
-							kind: kind,
-						})
-						return true
-					})
-				case *ast.GenDecl:
-					if d.Tok != token.TYPE {
-						continue
-					}
-					for _, spec := range d.Specs {
-						ts, ok := spec.(*ast.TypeSpec)
-						if !ok {
-							continue
-						}
-						st, ok := ts.Type.(*ast.StructType)
-						if !ok {
-							continue
-						}
-						if !structHasCRMJSONTag(st) {
-							continue
-						}
-						key := relSlash + ":" + ts.Name.Name
-						if _, allowed := allowedConstructionSites[key]; allowed {
-							continue
-						}
-						violations = append(violations, violation{
-							file: relSlash,
-							line: fset.Position(ts.Pos()).Line,
-							decl: ts.Name.Name,
-							kind: `struct field json:"crm"`,
-						})
-					}
-				}
-			}
+			violations = append(violations, findCRMMarkerConstructions(relSlash, file, fset)...)
 			return nil
 		}); err != nil {
 			t.Fatalf("walk %s: %v", root, err)
@@ -281,17 +319,18 @@ func structHasCRMJSONTag(st *ast.StructType) bool {
 }
 
 // TestCRMMarkerConstruction_NegativeGuardCatchesStray synthesizes tiny Go
-// snippets with a stray marker construction in an unallowlisted function, runs
-// the AST detection against each, and asserts a violation is reported. Covers
-// both the map-literal form and the incremental index-assignment form so a
-// future loosening of either detector fails loudly.
+// snippets with a stray marker construction outside the allowlist, runs the
+// SAME findCRMMarkerConstructions walk the real test uses, and asserts a
+// violation is reported. Covers the map-literal form (in a function and in a
+// top-level var), the incremental index-assignment form, and the struct-tag
+// form, so a future loosening of any detector fails loudly.
 func TestCRMMarkerConstruction_NegativeGuardCatchesStray(t *testing.T) {
 	cases := []struct {
 		name string
 		src  string
 	}{
 		{
-			name: "map literal",
+			name: "map literal in func",
 			src: `package poc
 
 func strayEncoder() map[string]any {
@@ -300,7 +339,7 @@ func strayEncoder() map[string]any {
 `,
 		},
 		{
-			name: "index assignment",
+			name: "index assignment in func",
 			src: `package poc
 
 func strayEncoder() map[string]any {
@@ -311,7 +350,27 @@ func strayEncoder() map[string]any {
 }
 `,
 		},
+		{
+			name: "top-level var initializer",
+			src: `package poc
+
+var strayMarker = map[string]any{"crm": true, "contact_id": "x"}
+`,
+		},
+		{
+			name: "struct field json tag",
+			src: `package poc
+
+type strayMarkerStruct struct {
+	CRM bool ` + "`json:\"crm\"`" + `
+}
+`,
+		},
 	}
+
+	// Use a relSlash NOT present in allowedConstructionSites so any detected
+	// construction counts as a violation.
+	const unallowlistedRel = "internal/poc/poc.go"
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -320,21 +379,8 @@ func strayEncoder() map[string]any {
 			if err != nil {
 				t.Fatalf("parse poc: %v", err)
 			}
-
-			var found bool
-			for _, decl := range file.Decls {
-				fn, ok := decl.(*ast.FuncDecl)
-				if !ok || fn.Body == nil {
-					continue
-				}
-				ast.Inspect(fn.Body, func(n ast.Node) bool {
-					if isCRMMarkerMapLiteral(n) || isCRMMarkerIndexAssign(n) {
-						found = true
-					}
-					return true
-				})
-			}
-			if !found {
+			got := findCRMMarkerConstructions(unallowlistedRel, file, fset)
+			if len(got) == 0 {
 				t.Fatalf("negative guard did not detect the stray %s — the real guard would let a new construction through", tc.name)
 			}
 		})

--- a/backend/tests/crm_marker_construction_static_test.go
+++ b/backend/tests/crm_marker_construction_static_test.go
@@ -1,0 +1,269 @@
+// Package tests — CRM-marker construction AST guard.
+//
+// Enforces that the Todoist CRM-marker wire format is constructed in exactly
+// one place: contacttask.EncodeMarker (and its CRMMarker type), in
+// backend/internal/contacttask/marker.go. This is the function-level
+// companion (the suspenders) to the grep guard at
+// scripts/ci/crm-marker-construction-guard.sh (the belt).
+//
+// Two construction shapes are detected:
+//
+//	(a) a map composite literal containing a "crm" string-literal key whose
+//	    value is the bool literal true — the form every inline encoder used.
+//	(b) a struct type declaration with a field carrying a `json:"crm"` tag —
+//	    a struct encoder reintroduced outside the primitive.
+//
+// Both must live ONLY in internal/contacttask/marker.go, and within that file
+// only inside the sanctioned declarations (allowedConstructionSites). A stray
+// marker construction added to an unrelated function — even inside marker.go
+// itself — trips the guard.
+package tests
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// allowedConstructionSites maps (file, enclosingDecl) -> justification. A
+// marker construction is accepted only when its enclosing top-level
+// declaration name is listed here. Keys use forward slashes relative to the
+// backend module root. enclosingDecl is the func name (for the map literal in
+// EncodeMarker) or the type name (for the CRMMarker / crmMarkerJSON struct).
+var allowedConstructionSites = map[string]string{
+	"internal/contacttask/marker.go:EncodeMarker":  "sole sanctioned encoder",
+	"internal/contacttask/marker.go:crmMarkerJSON": "decode-only wire struct",
+}
+
+// TestCRMMarkerConstruction_OnlyAllowedSites walks the Go AST of
+// backend/internal + backend/cmd/crm-api and asserts every CRM-marker
+// construction (map literal with "crm":true, or struct with a json:"crm" tag)
+// lives in allowedConstructionSites. Generated sqlc files and test files are
+// skipped.
+func TestCRMMarkerConstruction_OnlyAllowedSites(t *testing.T) {
+	moduleRoot, err := backendModuleRoot()
+	if err != nil {
+		t.Fatalf("locate backend module root: %v", err)
+	}
+
+	roots := []string{
+		filepath.Join(moduleRoot, "internal"),
+		filepath.Join(moduleRoot, "cmd", "crm-api"),
+	}
+
+	type violation struct {
+		file string
+		line int
+		decl string
+		kind string
+	}
+	var violations []violation
+
+	fset := token.NewFileSet()
+	for _, root := range roots {
+		if err := filepath.Walk(root, func(path string, info os.FileInfo, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if info.IsDir() {
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") {
+				return nil
+			}
+			if strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			if strings.HasSuffix(info.Name(), ".sql.go") ||
+				info.Name() == "querier.go" ||
+				info.Name() == "models.go" ||
+				info.Name() == "db.go" {
+				return nil
+			}
+			rel, err := filepath.Rel(moduleRoot, path)
+			if err != nil {
+				return err
+			}
+			relSlash := filepath.ToSlash(rel)
+
+			file, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+			if err != nil {
+				return err
+			}
+
+			for _, decl := range file.Decls {
+				switch d := decl.(type) {
+				case *ast.FuncDecl:
+					if d.Body == nil {
+						continue
+					}
+					ast.Inspect(d.Body, func(n ast.Node) bool {
+						if !isCRMMarkerMapLiteral(n) {
+							return true
+						}
+						key := relSlash + ":" + d.Name.Name
+						if _, allowed := allowedConstructionSites[key]; allowed {
+							return true
+						}
+						violations = append(violations, violation{
+							file: relSlash,
+							line: fset.Position(n.Pos()).Line,
+							decl: d.Name.Name,
+							kind: `map literal "crm":true`,
+						})
+						return true
+					})
+				case *ast.GenDecl:
+					if d.Tok != token.TYPE {
+						continue
+					}
+					for _, spec := range d.Specs {
+						ts, ok := spec.(*ast.TypeSpec)
+						if !ok {
+							continue
+						}
+						st, ok := ts.Type.(*ast.StructType)
+						if !ok {
+							continue
+						}
+						if !structHasCRMJSONTag(st) {
+							continue
+						}
+						key := relSlash + ":" + ts.Name.Name
+						if _, allowed := allowedConstructionSites[key]; allowed {
+							continue
+						}
+						violations = append(violations, violation{
+							file: relSlash,
+							line: fset.Position(ts.Pos()).Line,
+							decl: ts.Name.Name,
+							kind: `struct field json:"crm"`,
+						})
+					}
+				}
+			}
+			return nil
+		}); err != nil {
+			t.Fatalf("walk %s: %v", root, err)
+		}
+	}
+
+	if len(violations) > 0 {
+		sort.Slice(violations, func(i, j int) bool {
+			if violations[i].file != violations[j].file {
+				return violations[i].file < violations[j].file
+			}
+			return violations[i].line < violations[j].line
+		})
+		var msg strings.Builder
+		msg.WriteString("CRM-marker construction guard: marker construction found outside the allowlist.\n")
+		msg.WriteString("Build the marker via contacttask.EncodeMarker, or add a justified entry to allowedConstructionSites.\n\n")
+		for _, v := range violations {
+			msg.WriteString("  ")
+			msg.WriteString(v.file)
+			msg.WriteString(":")
+			msg.WriteString(strconv.Itoa(v.line))
+			msg.WriteString(" in ")
+			msg.WriteString(v.decl)
+			msg.WriteString(" — ")
+			msg.WriteString(v.kind)
+			msg.WriteString("\n")
+		}
+		t.Fatal(msg.String())
+	}
+}
+
+// isCRMMarkerMapLiteral reports whether n is a composite literal containing a
+// "crm" string-literal key whose value is the bool literal true.
+func isCRMMarkerMapLiteral(n ast.Node) bool {
+	cl, ok := n.(*ast.CompositeLit)
+	if !ok {
+		return false
+	}
+	for _, elt := range cl.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		key, ok := kv.Key.(*ast.BasicLit)
+		if !ok || key.Kind != token.STRING {
+			continue
+		}
+		unq, err := strconv.Unquote(key.Value)
+		if err != nil || unq != "crm" {
+			continue
+		}
+		if val, ok := kv.Value.(*ast.Ident); ok && val.Name == "true" {
+			return true
+		}
+	}
+	return false
+}
+
+// structHasCRMJSONTag reports whether the struct has any field tagged
+// `json:"crm"` (with or without options like `json:"crm,omitempty"`).
+func structHasCRMJSONTag(st *ast.StructType) bool {
+	if st.Fields == nil {
+		return false
+	}
+	for _, f := range st.Fields.List {
+		if f.Tag == nil {
+			continue
+		}
+		raw, err := strconv.Unquote(f.Tag.Value)
+		if err != nil {
+			continue
+		}
+		jsonTag := reflect.StructTag(raw).Get("json")
+		name := jsonTag
+		if i := strings.IndexByte(name, ','); i >= 0 {
+			name = name[:i]
+		}
+		if name == "crm" {
+			return true
+		}
+	}
+	return false
+}
+
+// TestCRMMarkerConstruction_NegativeGuardCatchesStray synthesizes a tiny Go
+// file with a stray "crm":true map literal in an unallowlisted function, runs
+// the same detection against it, and asserts a violation is reported. Without
+// this, a future loosening of the detector could silently pass.
+func TestCRMMarkerConstruction_NegativeGuardCatchesStray(t *testing.T) {
+	src := `package poc
+
+func strayEncoder() map[string]any {
+	return map[string]any{"crm": true, "contact_id": "x"}
+}
+`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "poc.go", src, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse poc: %v", err)
+	}
+
+	var found bool
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			if isCRMMarkerMapLiteral(n) {
+				found = true
+			}
+			return true
+		})
+	}
+	if !found {
+		t.Fatal("negative guard did not detect the stray marker literal — the real guard would let a new construction through")
+	}
+}

--- a/backend/tests/crm_marker_construction_static_test.go
+++ b/backend/tests/crm_marker_construction_static_test.go
@@ -6,14 +6,18 @@
 // companion (the suspenders) to the grep guard at
 // scripts/ci/crm-marker-construction-guard.sh (the belt).
 //
-// Two construction shapes are detected:
+// Three construction shapes are detected:
 //
 //	(a) a map composite literal containing a "crm" string-literal key whose
 //	    value is the bool literal true — the form every inline encoder used.
 //	(b) a struct type declaration with a field carrying a `json:"crm"` tag —
 //	    a struct encoder reintroduced outside the primitive.
+//	(c) an index-assignment statement of the form `<map>["crm"] = true`
+//	    (*ast.AssignStmt whose LHS is an *ast.IndexExpr with a "crm"
+//	    string-literal index and a bool-true RHS) — an incrementally-built
+//	    marker map.
 //
-// Both must live ONLY in internal/contacttask/marker.go, and within that file
+// All must live ONLY in internal/contacttask/marker.go, and within that file
 // only inside the sanctioned declarations (allowedConstructionSites). A stray
 // marker construction added to an unrelated function — even inside marker.go
 // itself — trips the guard.
@@ -24,6 +28,7 @@ import (
 	"go/parser"
 	"go/token"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -44,9 +49,9 @@ var allowedConstructionSites = map[string]string{
 
 // TestCRMMarkerConstruction_OnlyAllowedSites walks the Go AST of
 // backend/internal + backend/cmd/crm-api and asserts every CRM-marker
-// construction (map literal with "crm":true, or struct with a json:"crm" tag)
-// lives in allowedConstructionSites. Generated sqlc files and test files are
-// skipped.
+// construction (map literal with "crm":true, an index assignment
+// `m["crm"] = true`, or a struct with a json:"crm" tag) lives in
+// allowedConstructionSites. Generated sqlc files and test files are skipped.
 func TestCRMMarkerConstruction_OnlyAllowedSites(t *testing.T) {
 	moduleRoot, err := backendModuleRoot()
 	if err != nil {
@@ -105,7 +110,13 @@ func TestCRMMarkerConstruction_OnlyAllowedSites(t *testing.T) {
 						continue
 					}
 					ast.Inspect(d.Body, func(n ast.Node) bool {
-						if !isCRMMarkerMapLiteral(n) {
+						var kind string
+						switch {
+						case isCRMMarkerMapLiteral(n):
+							kind = `map literal "crm":true`
+						case isCRMMarkerIndexAssign(n):
+							kind = `index assignment ["crm"] = true`
+						default:
 							return true
 						}
 						key := relSlash + ":" + d.Name.Name
@@ -116,7 +127,7 @@ func TestCRMMarkerConstruction_OnlyAllowedSites(t *testing.T) {
 							file: relSlash,
 							line: fset.Position(n.Pos()).Line,
 							decl: d.Name.Name,
-							kind: `map literal "crm":true`,
+							kind: kind,
 						})
 						return true
 					})
@@ -207,6 +218,42 @@ func isCRMMarkerMapLiteral(n ast.Node) bool {
 	return false
 }
 
+// isCRMMarkerIndexAssign reports whether n is an assignment statement of the
+// form `<map>["crm"] = true` — an incrementally-built marker map. Matches both
+// `=` and `:=` assignments whose LHS is an index expression with a "crm"
+// string-literal index and whose corresponding RHS is the bool literal true.
+func isCRMMarkerIndexAssign(n ast.Node) bool {
+	assign, ok := n.(*ast.AssignStmt)
+	if !ok {
+		return false
+	}
+	for i, lhs := range assign.Lhs {
+		idx, ok := lhs.(*ast.IndexExpr)
+		if !ok {
+			continue
+		}
+		key, ok := idx.Index.(*ast.BasicLit)
+		if !ok || key.Kind != token.STRING {
+			continue
+		}
+		unq, err := strconv.Unquote(key.Value)
+		if err != nil || unq != "crm" {
+			continue
+		}
+		// Parallel-assignment safe: match the RHS at the same position when
+		// the counts line up; otherwise (e.g. multi-value call RHS) treat the
+		// "crm" index target as a hit conservatively.
+		if len(assign.Rhs) == len(assign.Lhs) {
+			if val, ok := assign.Rhs[i].(*ast.Ident); ok && val.Name == "true" {
+				return true
+			}
+			continue
+		}
+		return true
+	}
+	return false
+}
+
 // structHasCRMJSONTag reports whether the struct has any field tagged
 // `json:"crm"` (with or without options like `json:"crm,omitempty"`).
 func structHasCRMJSONTag(st *ast.StructType) bool {
@@ -233,37 +280,106 @@ func structHasCRMJSONTag(st *ast.StructType) bool {
 	return false
 }
 
-// TestCRMMarkerConstruction_NegativeGuardCatchesStray synthesizes a tiny Go
-// file with a stray "crm":true map literal in an unallowlisted function, runs
-// the same detection against it, and asserts a violation is reported. Without
-// this, a future loosening of the detector could silently pass.
+// TestCRMMarkerConstruction_NegativeGuardCatchesStray synthesizes tiny Go
+// snippets with a stray marker construction in an unallowlisted function, runs
+// the AST detection against each, and asserts a violation is reported. Covers
+// both the map-literal form and the incremental index-assignment form so a
+// future loosening of either detector fails loudly.
 func TestCRMMarkerConstruction_NegativeGuardCatchesStray(t *testing.T) {
-	src := `package poc
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "map literal",
+			src: `package poc
 
 func strayEncoder() map[string]any {
 	return map[string]any{"crm": true, "contact_id": "x"}
 }
-`
-	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, "poc.go", src, parser.SkipObjectResolution)
-	if err != nil {
-		t.Fatalf("parse poc: %v", err)
+`,
+		},
+		{
+			name: "index assignment",
+			src: `package poc
+
+func strayEncoder() map[string]any {
+	m := map[string]any{}
+	m["crm"] = true
+	m["contact_id"] = "x"
+	return m
+}
+`,
+		},
 	}
 
-	var found bool
-	for _, decl := range file.Decls {
-		fn, ok := decl.(*ast.FuncDecl)
-		if !ok || fn.Body == nil {
-			continue
-		}
-		ast.Inspect(fn.Body, func(n ast.Node) bool {
-			if isCRMMarkerMapLiteral(n) {
-				found = true
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, "poc.go", tc.src, parser.SkipObjectResolution)
+			if err != nil {
+				t.Fatalf("parse poc: %v", err)
 			}
-			return true
+
+			var found bool
+			for _, decl := range file.Decls {
+				fn, ok := decl.(*ast.FuncDecl)
+				if !ok || fn.Body == nil {
+					continue
+				}
+				ast.Inspect(fn.Body, func(n ast.Node) bool {
+					if isCRMMarkerMapLiteral(n) || isCRMMarkerIndexAssign(n) {
+						found = true
+					}
+					return true
+				})
+			}
+			if !found {
+				t.Fatalf("negative guard did not detect the stray %s — the real guard would let a new construction through", tc.name)
+			}
 		})
 	}
-	if !found {
-		t.Fatal("negative guard did not detect the stray marker literal — the real guard would let a new construction through")
+}
+
+// TestCRMMarkerGrepGuard_CatchesIndexAssignment runs the actual grep guard
+// script against a temporary stray file built with the incremental
+// `m["crm"] = true` form, and asserts the script exits non-zero. This proves
+// the belt (grep) layer covers pattern (d), complementing the AST suspenders
+// above. The stray file is written under backend/internal and removed after.
+func TestCRMMarkerGrepGuard_CatchesIndexAssignment(t *testing.T) {
+	moduleRoot, err := backendModuleRoot()
+	if err != nil {
+		t.Fatalf("locate backend module root: %v", err)
+	}
+	repoRoot := filepath.Dir(moduleRoot)
+	guard := filepath.Join(repoRoot, "scripts", "ci", "crm-marker-construction-guard.sh")
+	if _, statErr := os.Stat(guard); statErr != nil {
+		t.Fatalf("guard script not found at %s: %v", guard, statErr)
+	}
+
+	// Sanity: the guard must currently pass on the real tree (no false
+	// positives) before we inject the stray.
+	if out, runErr := exec.Command(guard).CombinedOutput(); runErr != nil {
+		t.Fatalf("guard unexpectedly failed on clean tree: %v\n%s", runErr, out)
+	}
+
+	strayDir := filepath.Join(moduleRoot, "internal", "todoist")
+	strayPath := filepath.Join(strayDir, "zz_crm_marker_grep_probe.go")
+	content := "package todoist\n\nfunc crmMarkerGrepProbe() map[string]any {\n\tm := map[string]any{}\n\tm[\"crm\"] = true\n\treturn m\n}\n"
+	if writeErr := os.WriteFile(strayPath, []byte(content), 0o644); writeErr != nil {
+		t.Fatalf("write stray probe: %v", writeErr)
+	}
+	defer func() {
+		if rmErr := os.Remove(strayPath); rmErr != nil {
+			t.Errorf("remove stray probe %s: %v", strayPath, rmErr)
+		}
+	}()
+
+	out, runErr := exec.Command(guard).CombinedOutput()
+	if runErr == nil {
+		t.Fatalf("grep guard did NOT flag the stray index-assignment marker; output:\n%s", out)
+	}
+	if !strings.Contains(string(out), "zz_crm_marker_grep_probe.go") {
+		t.Errorf("grep guard failed but did not name the stray file; output:\n%s", out)
 	}
 }

--- a/backend/tests/followup_manager_cutover_integration_test.go
+++ b/backend/tests/followup_manager_cutover_integration_test.go
@@ -458,6 +458,19 @@ func TestIntegration_FollowUpManager_OutboundFreshCreatesPendingRow(t *testing.T
 	require.NotNil(t, pending.IdempotencyKey, "step-1 insert must populate idempotency_key")
 	assert.NotEmpty(t, *pending.IdempotencyKey)
 
+	// E2 call-site wire-format lock: the stored marker_json must decode to
+	// (reach_out, followup_loop) with the contact's id and the configured
+	// integration instance — proving the follow-up create passes the correct
+	// fields to EncodeMarker.
+	markerJSON, ok := pending.Metadata["marker_json"].(string)
+	require.True(t, ok, "pending follow-up metadata must carry marker_json")
+	marker, ok := contacttask.DecodeMarker(markerJSON)
+	require.True(t, ok, "marker_json must decode as a CRM marker")
+	assert.Equal(t, contact.ID.String(), marker.ContactID)
+	assert.Equal(t, contacttask.KindReachOut, marker.Kind)
+	assert.Equal(t, contacttask.LifecycleFollowUpLoop, marker.Lifecycle)
+	assert.Equal(t, "inst-test", marker.Instance)
+
 	// river_job row: kind=todoist_followup_create, args contains contact_task_id.
 	n := env.countRiverJobsByKind(t, (consumerjobs.TodoistFollowUpCreateJobArgs{}).Kind(), pending.ID)
 	assert.Equal(t, 1, n, "a single TodoistFollowUpCreateJob must be enqueued in the same tx")

--- a/scripts/ci/crm-marker-construction-guard.sh
+++ b/scripts/ci/crm-marker-construction-guard.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# crm-marker-construction-guard.sh — grep guard for the CRM-marker
+# construction invariant.
+#
+# The Todoist CRM-marker wire format must be built in exactly one place:
+# contacttask.EncodeMarker (backend/internal/contacttask/marker.go). Any
+# other file that constructs the marker risks drifting the wire format
+# away from the single sanctioned encoder.
+#
+# Fingerprint (three patterns, OR'd together):
+#   (a) map-literal / JSON key  "crm" : true        — today's form
+#   (b) struct field tag        json:"crm"          — a struct encoder
+#   (c) escaped-string JSON     \"crm\":true        — hand-built literals
+#
+# Allowlist = exactly one file. After the refactor, no other file builds
+# the marker, so the only legitimate hit is the primitive. The companion
+# AST test (backend/tests/crm_marker_construction_static_test.go) enforces
+# function-level precision within that file.
+#
+# Mirrors scripts/check-cadence-sole-writer.sh and
+# scripts/ci/followup-sole-writer-guard.sh.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+ALLOWLIST=(
+  "backend/internal/contacttask/marker.go"
+)
+
+# (a) "crm" : true   (b) json:"crm"   (c) \"crm\":true
+PATTERN='"crm"[[:space:]]*:[[:space:]]*true|json:"crm"|\\"crm\\"[[:space:]]*:[[:space:]]*true'
+
+if command -v rg >/dev/null 2>&1; then
+  HITS=$(rg -l "$PATTERN" \
+    --glob '*.go' \
+    --glob '!**/*_test.go' \
+    --glob '!**/*.sql.go' \
+    --glob '!**/querier.go' \
+    --glob '!**/models.go' \
+    --glob '!**/db.go' \
+    backend/internal backend/cmd 2>/dev/null | sort -u || true)
+else
+  HITS=$(grep -lE "$PATTERN" \
+    -r --include='*.go' \
+    --exclude='*_test.go' \
+    --exclude='*.sql.go' \
+    --exclude='querier.go' \
+    --exclude='models.go' \
+    --exclude='db.go' \
+    backend/internal backend/cmd 2>/dev/null | sort -u || true)
+fi
+
+violation_count=0
+if [[ -n "$HITS" ]]; then
+  while IFS= read -r f; do
+    [[ -z "$f" ]] && continue
+    allowed=false
+    for a in "${ALLOWLIST[@]}"; do
+      if [[ "$f" == "$a" ]]; then
+        allowed=true
+        break
+      fi
+    done
+    if ! $allowed; then
+      echo "❌ CRM-marker construction guard: marker fingerprint found in non-allowlisted file: $f" >&2
+      if command -v rg >/dev/null 2>&1; then
+        rg -n "$PATTERN" "$f" >&2 | sed 's/^/      /'
+      else
+        grep -nE "$PATTERN" "$f" >&2 | sed 's/^/      /'
+      fi
+      violation_count=$((violation_count + 1))
+    fi
+  done <<< "$HITS"
+fi
+
+if (( violation_count > 0 )); then
+  echo >&2
+  echo "Fix: build the CRM marker via contacttask.EncodeMarker — it is the" >&2
+  echo "single sanctioned encoder. Do not inline the marker map/struct elsewhere." >&2
+  exit 1
+fi
+
+echo "✓ CRM-marker construction guard: marker fingerprint confined to contacttask/marker.go"

--- a/scripts/ci/crm-marker-construction-guard.sh
+++ b/scripts/ci/crm-marker-construction-guard.sh
@@ -7,10 +7,11 @@
 # other file that constructs the marker risks drifting the wire format
 # away from the single sanctioned encoder.
 #
-# Fingerprint (three patterns, OR'd together):
+# Fingerprint (four patterns, OR'd together):
 #   (a) map-literal / JSON key  "crm" : true        — today's form
 #   (b) struct field tag        json:"crm"          — a struct encoder
 #   (c) escaped-string JSON     \"crm\":true        — hand-built literals
+#   (d) index assignment        m["crm"] = true     — incremental build
 #
 # Allowlist = exactly one file. After the refactor, no other file builds
 # the marker, so the only legitimate hit is the primitive. The companion
@@ -28,8 +29,8 @@ ALLOWLIST=(
   "backend/internal/contacttask/marker.go"
 )
 
-# (a) "crm" : true   (b) json:"crm"   (c) \"crm\":true
-PATTERN='"crm"[[:space:]]*:[[:space:]]*true|json:"crm"|\\"crm\\"[[:space:]]*:[[:space:]]*true'
+# (a) "crm" : true   (b) json:"crm"   (c) \"crm\":true   (d) ["crm"] = true
+PATTERN='"crm"[[:space:]]*:[[:space:]]*true|json:"crm"|\\"crm\\"[[:space:]]*:[[:space:]]*true|\["crm"\][[:space:]]*=[[:space:]]*true'
 
 if command -v rg >/dev/null 2>&1; then
   HITS=$(rg -l "$PATTERN" \


### PR DESCRIPTION
Closes #345.

Introduces one canonical CRM-marker encoder/decoder in the leaf `internal/contacttask` package (`EncodeMarker` / `DecodeMarker`) and routes every marker producer and the single consumer through it: the three previously-independent encoder sites (`todoist/provider.go` `createTaskCommand`, `consumer/followup_manager.go`, `service/contact_task.go`) and the decoder in `tryRecoverPendingTempID`. Also consolidates `provider.go`'s hand-copied `synced_*` metadata bookkeeping into per-shape helpers (`setPendingCreateState` / `setSyncedLastContacted` / `setSyncedLastOutreachAt`), and adds a mechanical-prevention layer: a grep guard (`scripts/ci/crm-marker-construction-guard.sh`) + an AST allowlist test (`backend/tests/crm_marker_construction_static_test.go`) that together forbid ad-hoc marker construction outside the primitive (catching all four construction forms — composite literal, `json:"crm"` struct tag, `m["crm"]=true` index assignment, and top-level `var`), plus a round-trip encode→decode test. Wired into `make test-unit` / `make ci-test` / CI, with `scripts/**`, `Makefile`, and `.github/workflows/ci.yml` added to the backend paths-filter.

Notes:
- The issue's original "six inline paths" premise was stale — marker construction in `provider.go` had already been centralized. The genuinely valuable consolidation (one encoder + one decoder repo-wide) spans three packages, and that reframed scope was approved before implementation.
- This is a behavior-PRESERVING refactor. The marker JSON wire format is byte-identical (sorted-key map marshal), and the write-only `instance` field is still emitted exactly as before — verified by reproducing the pre-refactor encoders and diffing across cases including empty/escaped values.
- The legacy `kind=cadence|follow_up|action` decode variants are intentionally KEPT. Their removal is a deferred follow-up, valid only after a deploy clears all in-flight Todoist tasks.

Review: Codex returned RESULT=PASS (P0=0, P1=0) on the substantive logic; an independent Claude review-head pass (round 2) also returned PASS on the final HEAD, with byte-fidelity, the stale-`synced_last_contacted` invariant, legacy-decode equivalence, and guard completeness all verified empirically.

Known non-blocking follow-ups (review-head P3):
- The AST guard's `token.CONST` arm is dead code (Go consts can't hold map composite literals) — harmless, could be pruned.
- The variable-assembled-marker construction form is a documented guard blind spot, not yet pinned by a test.