### PR TITLE
refactor(service): daemonFamily SourceDescriptor registry for push sources

### DIFF
--- a/.ai/patterns/sync.md
+++ b/.ai/patterns/sync.md
@@ -9,8 +9,22 @@
 | Todoist | `todoist` | `fetch_all` | `backend/internal/todoist/provider.go` |
 | Messages | `messages` | `push` | `backend/internal/messages/provider.go` |
 | iCloud Contacts | `icloud_contacts` | `push` | `backend/internal/icloudcontacts/provider.go` |
+| Phone & FaceTime | `phone_calls` | `push` | `backend/internal/phonecalls/provider.go` |
 
-Providers are registered in `backend/cmd/crm-api/main.go` via `providerRegistry.Register()`.
+The poll-strategy providers register themselves in
+`backend/cmd/crm-api/main.go` via `providerRegistry.Register()`. The three
+**push** providers register through one helper,
+`push.RegisterPushProviders(providerRegistry)`
+(`backend/internal/push/push.go`), which main.go calls once.
+
+**Not every push source has a provider stub.** The `anarlog_humans` and
+`anarlog_sessions` push sources are accepted by the ingest pipeline but
+have NO `SyncProvider` registration by design — they are not poll-able and
+the scheduler never needs a push-strategy entry to skip for them. So the
+ProviderRegistry covers exactly three of the five push sources. The
+daemonFamily descriptor's `providerStubSources` field encodes which
+sources MUST have a stub; the agreement test cross-checks it against the
+registry built by `push.RegisterPushProviders`.
 
 ### Sync Strategies
 
@@ -25,6 +39,55 @@ Push-strategy rows live in `external_sync_state` keyed by
 `(source, account_id)` where `account_id = mac_host.id`. The daemon owns
 the cursor JSON shape; the Pi treats it as opaque TEXT. The three-stage
 transactional CAS lives in `SyncRepository.CommitMacHostCursor`.
+
+### Daemon Event Families (the descriptor table)
+
+Daemon-push events (the ones submitted with host-auth, never on the
+global-API-key path) are grouped into four **families**, one descriptor
+per family, in `backend/internal/service/ingest_registry.go`:
+
+| Family | Kinds | Allowed sources | Stub sources | Writes interactions |
+|--------|-------|-----------------|--------------|---------------------|
+| `raw_message` | `raw_message.received/.sent` | `messages` | `messages` | yes (`messages`) |
+| `external_contact` | `external_contact.upserted/.deleted` | `icloud_contacts`, `anarlog_humans` | `icloud_contacts` | no |
+| `meeting_note` | `meeting_note.recorded/.deleted` | `anarlog_sessions` | — (none) | yes (`anarlog_sessions`) |
+| `call` | `call.received/.sent` | `phone_calls` | `phone_calls` | yes (`phone_calls`) |
+
+The `daemonFamily` table is the single source of truth for: the host-auth
+allowlist (`isHostOnlyKind` is derived — a kind is host-only iff it has a
+`kindToFamily` entry), the per-family invariant verifier, the per-family
+allowed envelope-source set, and the inline-dispatch routing. The
+`IngestBatch` Step-2 invariant routing and Step-5 inline dispatch are
+single `kindToFamily[env.Kind]` lookups.
+
+**Adding a new push source** = add or extend a descriptor entry here, then
+update the agreement test's expected literals. The pieces that live in
+other packages (`events.AllKinds`/`kindPayloadTypes`,
+`mac.AllowedPushSources`, the `interaction.source` SQL CHECK, the provider
+stubs) are NOT driven from this table — the import graph forbids it — but
+they are cross-checked against it:
+
+- `TestDaemonFamilies_AgreeWithRegistries`
+  (`backend/internal/service/ingest_registry_test.go`, `package
+  service_test`) asserts the descriptor agrees set-for-set with
+  `events.AllKinds`/`kindPayloadTypes`, `mac.AllowedPushSources`, the
+  `repository.InteractionSource*` constants, and the registry built by
+  `push.RegisterPushProviders`, plus per-family mapping pins that catch
+  cross-family metadata swaps.
+- `TestInteractionSourceCheck_AgreesWithDescriptorAndConstants`
+  (`backend/tests/`, live-DB) parses the live `interaction_source_check`
+  via `pg_get_constraintdef` and asserts it equals the
+  `InteractionSource*` constants set-for-set, and that every
+  interaction-writing family's `interactionSource` is in it. The CHECK is
+  KEPT (not migrated to a lookup table) — it mixes daemon-push and
+  Pi-internal sources, a different concern from this table.
+
+**Grep guard:** `scripts/check-ingest-registry.sh` (wired into `make lint`
++ `make ci-test` + a CI step) fails if the `IngestBatch` body names any
+event kind (constant or dotted string literal) or any per-family
+predicate. Routing must go through the descriptor table; a stray
+`events.KindFoo` inside `IngestBatch` is a lint failure. Handler/verifier
+bodies OUTSIDE `IngestBatch` legitimately name kinds and are out of scope.
 
 ---
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,9 @@ jobs:
       - name: Check CRM-marker construction invariant
         run: ./scripts/ci/crm-marker-construction-guard.sh
 
+      - name: Check ingest-registry descriptor invariant
+        run: ./scripts/check-ingest-registry.sh
+
       - name: Run unit tests
         working-directory: backend
         run: go test -short -v ./...

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Personal CRM Makefile
 
-.PHONY: help setup dev build crm-admin mac-daemon test test-daemon-local clean docker-up docker-down docker-reset test-cadence-ultra test-cadence-fast prod staging testing start start-local stop restart reload status dev-stop dev-restart dev-api-stop dev-api-start dev-api-restart ci-build-backend ci-build-frontend ci-build ci-test test-e2e test-e2e-local test-e2e-diff e2e-db deploy deploy-pi deploy-mac deploy-all setup-pi dev-native postgres-native sqlc smoke-test test-integration-fast test-integration-slow test-mac-host-migrations check-cadence-sole-writer check-followup-sole-writer check-rematch-sole-dispatcher check-crm-marker-construction
+.PHONY: help setup dev build crm-admin mac-daemon test test-daemon-local clean docker-up docker-down docker-reset test-cadence-ultra test-cadence-fast prod staging testing start start-local stop restart reload status dev-stop dev-restart dev-api-stop dev-api-start dev-api-restart ci-build-backend ci-build-frontend ci-build ci-test test-e2e test-e2e-local test-e2e-diff e2e-db deploy deploy-pi deploy-mac deploy-all setup-pi dev-native postgres-native sqlc smoke-test test-integration-fast test-integration-slow test-mac-host-migrations check-cadence-sole-writer check-followup-sole-writer check-rematch-sole-dispatcher check-crm-marker-construction lint-ingest-registry
 
 # Repo root (supports running make from subdirectories).
 REPO_ROOT := $(shell git rev-parse --show-toplevel)
@@ -351,13 +351,21 @@ ci-build: ci-build-backend ci-build-frontend
 # Linting
 GOLANGCI_LINT := $(shell which golangci-lint 2>/dev/null || echo $$(go env GOPATH)/bin/golangci-lint)
 
-lint:
+lint: lint-ingest-registry
 	@echo "Running golangci-lint..."
 	@cd backend && $(GOLANGCI_LINT) run ./...
 
 lint-fix:
 	@echo "Running golangci-lint with auto-fix..."
 	@cd backend && $(GOLANGCI_LINT) run --fix ./...
+
+# Grep guard for #342's descriptor table: fails if the IngestBatch body
+# names any event kind (constant or dotted literal) or per-family
+# predicate — routing must go through the daemonFamily kindToFamily
+# table. See scripts/check-ingest-registry.sh and the agreement test
+# backend/internal/service/ingest_registry_test.go.
+lint-ingest-registry:
+	@$(REPO_ROOT)/scripts/check-ingest-registry.sh
 
 ci-test: lint check-cadence-sole-writer check-followup-sole-writer check-rematch-sole-dispatcher check-crm-marker-construction test-unit test-integration-fast test-frontend
 	@echo "✅ All CI tests passed"

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -46,10 +46,9 @@ import (
 	"personal-crm/backend/internal/events"
 	"personal-crm/backend/internal/google"
 	"personal-crm/backend/internal/health"
-	"personal-crm/backend/internal/icloudcontacts"
 	"personal-crm/backend/internal/logger"
 	"personal-crm/backend/internal/messages"
-	"personal-crm/backend/internal/phonecalls"
+	"personal-crm/backend/internal/push"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/scheduler"
 	"personal-crm/backend/internal/service"
@@ -794,25 +793,13 @@ func run() int {
 			logger.Info().Msg("Contact task handler initialized")
 		}
 
-		// Register the Messages push provider. The source is push-only —
-		// data lands via /api/v1/ingest/events from the Mac daemon, never
-		// via the scheduler — so Sync() is a no-op. The scheduler's push-
-		// strategy exclusion in ListDueAccounts ensures we never poll it.
-		providerRegistry.Register(messages.New())
-		logger.Info().Msg("Messages push provider registered")
-
-		// Register the iCloud Contacts push provider. Same push-only
-		// semantics as Messages — data lands via the Mac daemon's
-		// external_contact.* events; the scheduler skips push providers
-		// in ListDueAccounts.
-		providerRegistry.Register(icloudcontacts.New())
-		logger.Info().Msg("iCloud Contacts push provider registered")
-
-		// Register the Phone & FaceTime call-history push provider
-		// (phase 1.5). Same push-only semantics — data lands via the
-		// Mac daemon's call.received / call.sent events.
-		providerRegistry.Register(phonecalls.New())
-		logger.Info().Msg("Phone & FaceTime push provider registered")
+		// Register every Mac-daemon push-source provider. Each is
+		// push-only — data lands via /api/v1/ingest/events, never via the
+		// scheduler (ListDueAccounts skips push strategy) — so Sync() is a
+		// no-op. The registration lives in one helper so the daemonFamily
+		// agreement test can cross-check it against the descriptor table.
+		push.RegisterPushProviders(providerRegistry)
+		logger.Info().Msg("Push providers registered (messages, icloud_contacts, phone_calls)")
 
 		syncService = service.NewSyncService(syncRepo, contactRepo, providerRegistry)
 

--- a/backend/internal/db/models.go
+++ b/backend/internal/db/models.go
@@ -370,6 +370,12 @@ type OauthCredential struct {
 	UpdatedAt             pgtype.Timestamptz `json:"updated_at"`
 }
 
+type PgConstraint struct {
+	Oid      pgtype.Uint32 `json:"oid"`
+	Conname  string        `json:"conname"`
+	Conrelid pgtype.Uint32 `json:"conrelid"`
+}
+
 type PhoneCall struct {
 	ID               pgtype.UUID        `json:"id"`
 	CallUniqueID     string             `json:"call_unique_id"`

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -458,6 +458,15 @@ type Querier interface {
 	GetIdentityByIdentifier(ctx context.Context, arg GetIdentityByIdentifierParams) (*ExternalIdentity, error)
 	// Interaction queries
 	GetInteraction(ctx context.Context, id pgtype.UUID) (*Interaction, error)
+	// Test assertion — returns the rendered definition of the
+	// interaction_source_check CHECK constraint via pg_get_constraintdef.
+	// Scoped by (conrelid, conname) because constraint names are NOT
+	// globally unique — scoping to the interaction relation avoids a future
+	// cross-table/-schema name collision. The descriptor-vs-CHECK agreement
+	// test parses the returned ARRAY[...] string literals to assert the
+	// live CHECK set equals the repository.InteractionSource* constants.
+	// Read-only catalog access; production code never calls this.
+	GetInteractionSourceCheckDef(ctx context.Context) (string, error)
 	// Legacy lookup for action-kind rows (no new creator path; preserved for
 	// pre-migration rows). Multiple action rows are possible per
 	// contact/provider; this returns the most recent.

--- a/backend/internal/db/queries/test.sql
+++ b/backend/internal/db/queries/test.sql
@@ -152,3 +152,17 @@ DELETE FROM interaction WHERE contact_id = @contact_id AND source = @source;
 -- table's interaction_id points to.
 SELECT COUNT(*) FROM interaction
 WHERE id = @id AND contact_id = @contact_id AND source = @source;
+
+-- name: GetInteractionSourceCheckDef :one
+-- Test assertion — returns the rendered definition of the
+-- interaction_source_check CHECK constraint via pg_get_constraintdef.
+-- Scoped by (conrelid, conname) because constraint names are NOT
+-- globally unique — scoping to the interaction relation avoids a future
+-- cross-table/-schema name collision. The descriptor-vs-CHECK agreement
+-- test parses the returned ARRAY[...] string literals to assert the
+-- live CHECK set equals the repository.InteractionSource* constants.
+-- Read-only catalog access; production code never calls this.
+SELECT pg_get_constraintdef(c.oid)::text AS constraint_def
+FROM pg_constraint c
+WHERE c.conrelid = 'interaction'::regclass
+  AND c.conname = 'interaction_source_check';

--- a/backend/internal/db/test.sql.go
+++ b/backend/internal/db/test.sql.go
@@ -318,6 +318,28 @@ func (q *Queries) DeleteTelegramMessagesByPeerUserID(ctx context.Context, peerUs
 	return result.RowsAffected(), nil
 }
 
+const GetInteractionSourceCheckDef = `-- name: GetInteractionSourceCheckDef :one
+SELECT pg_get_constraintdef(c.oid)::text AS constraint_def
+FROM pg_constraint c
+WHERE c.conrelid = 'interaction'::regclass
+  AND c.conname = 'interaction_source_check'
+`
+
+// Test assertion — returns the rendered definition of the
+// interaction_source_check CHECK constraint via pg_get_constraintdef.
+// Scoped by (conrelid, conname) because constraint names are NOT
+// globally unique — scoping to the interaction relation avoids a future
+// cross-table/-schema name collision. The descriptor-vs-CHECK agreement
+// test parses the returned ARRAY[...] string literals to assert the
+// live CHECK set equals the repository.InteractionSource* constants.
+// Read-only catalog access; production code never calls this.
+func (q *Queries) GetInteractionSourceCheckDef(ctx context.Context) (string, error) {
+	row := q.db.QueryRow(ctx, GetInteractionSourceCheckDef)
+	var constraint_def string
+	err := row.Scan(&constraint_def)
+	return constraint_def, err
+}
+
 const SeedExternalSyncState = `-- name: SeedExternalSyncState :one
 INSERT INTO external_sync_state
     (source, account_id, enabled, status, strategy, next_sync_at)

--- a/backend/internal/push/push.go
+++ b/backend/internal/push/push.go
@@ -1,0 +1,31 @@
+// Package push wires the Mac-daemon push-source providers into the sync
+// ProviderRegistry. It is a thin leaf package: it imports the three push
+// source packages (messages, icloudcontacts, phonecalls) plus sync, and
+// nothing imports it back. Centralizing the registration here keeps the
+// "register every push provider" step in one place that the agreement
+// test can exercise against the daemonFamily descriptor table, and lets
+// main.go register all push providers with a single call.
+//
+// The package deliberately lives outside service: messages already
+// imports service, so a service→messages edge would create a cycle.
+package push
+
+import (
+	"personal-crm/backend/internal/icloudcontacts"
+	"personal-crm/backend/internal/messages"
+	"personal-crm/backend/internal/phonecalls"
+	"personal-crm/backend/internal/sync"
+)
+
+// RegisterPushProviders registers every Mac-daemon push-source provider
+// into reg. Each provider is push-only (Sync is a no-op; data lands via
+// /api/v1/ingest/events), and exists so the scheduler's push-strategy
+// exclusion and the /api/v1/sync/providers ground-truth list both have a
+// registered entry per source. The anarlog push sources
+// (anarlog_humans, anarlog_sessions) intentionally have no provider stub
+// — they are not represented here.
+func RegisterPushProviders(reg *sync.ProviderRegistry) {
+	reg.Register(messages.New())
+	reg.Register(icloudcontacts.New())
+	reg.Register(phonecalls.New())
+}

--- a/backend/internal/repository/interaction.go
+++ b/backend/internal/repository/interaction.go
@@ -382,6 +382,16 @@ func (r *InteractionRepository) HardDeleteInteractionsBySourceRefPrefix(ctx cont
 	})
 }
 
+// GetInteractionSourceCheckDef is a test-only helper returning the live
+// rendered definition of the interaction_source_check CHECK constraint
+// (via pg_get_constraintdef). The descriptor-vs-CHECK agreement test
+// parses the returned ARRAY[...] string literals to assert the live
+// CHECK set matches the InteractionSource* constants set-for-set.
+// Read-only catalog access; production code never calls this.
+func (r *InteractionRepository) GetInteractionSourceCheckDef(ctx context.Context) (string, error) {
+	return r.queries.GetInteractionSourceCheckDef(ctx)
+}
+
 // UpdateInteractionTimestamp extends an existing interaction's occurred_at and description.
 func (r *InteractionRepository) UpdateInteractionTimestamp(ctx context.Context, id uuid.UUID, occurredAt time.Time, description *string) (*Interaction, error) {
 	dbInteraction, err := r.queries.UpdateInteractionTimestamp(ctx, db.UpdateInteractionTimestampParams{

--- a/backend/internal/service/ingest.go
+++ b/backend/internal/service/ingest.go
@@ -66,22 +66,6 @@ const (
 // MacHostHandler.CommitCursor.
 var ErrHostRevokedDuringBatch = errors.New("host revoked during ingest batch")
 
-// allowedExternalContactSources is the set of envelope.Source values the
-// external_contact.* inline handler accepts. Mismatches surface as
-// PAYLOAD_INVARIANT. Extend when a new daemon-side source ships.
-var allowedExternalContactSources = map[string]struct{}{
-	"icloud_contacts": {},
-	"anarlog_humans":  {},
-}
-
-// allowedMeetingNoteSources is the set of envelope.Source values the
-// meeting_note.* inline handler accepts. Currently only the
-// daemon-emitted anarlog_sessions source. Mismatches surface as
-// PAYLOAD_INVARIANT.
-var allowedMeetingNoteSources = map[string]struct{}{
-	"anarlog_sessions": {},
-}
-
 // reExternalContactUpsertSourceID matches the envelope SourceID shape
 // for external_contact.upserted events: `<entity_uuid>@<sha256-hex>`.
 // The entity portion may not contain `@`; the hash is exactly 64 hex
@@ -389,61 +373,22 @@ func NewIngestService(
 	}
 }
 
-// hostAuthAllowedKinds is the single source of truth for which event
-// kinds may be submitted via the host-auth path. Daemon-emitted kinds
-// extend the set as they land (currently raw_message.* for Messages
-// staging + external_contact.* for the iCloud Contacts watcher).
-//
-// Symmetric: kinds in this set are REJECTED on the global-API-key
-// path. These kinds have exactly one producer — the Mac daemon — so
-// an internal Pi publisher writing one would either be a bug or a
-// hostile actor with the global key.
-var hostAuthAllowedKinds = map[events.Kind]struct{}{
-	events.KindRawMessageReceived:      {},
-	events.KindRawMessageSent:          {},
-	events.KindExternalContactUpserted: {},
-	events.KindExternalContactDeleted:  {},
-	events.KindMeetingNoteRecorded:     {},
-	events.KindMeetingNoteDeleted:      {},
-	events.KindCallReceived:            {},
-	events.KindCallSent:                {},
-}
-
-// isHostOnlyKind reports whether the kind is in the host-auth
-// allowlist (i.e., daemon-emitted only). Used on BOTH sides of the
+// isHostOnlyKind reports whether the kind is a daemon-push kind (i.e.,
+// belongs to one of the daemonFamilies, so it may be submitted ONLY via
+// the host-auth path). Derived from the descriptor table — a kind is
+// host-only iff it has a kindToFamily entry. Used on BOTH sides of the
 // auth dispatch:
-//   - on the host-auth path, kinds NOT in this set are rejected as
+//   - on the host-auth path, kinds NOT host-only are rejected as
 //     "host-auth doesn't accept this kind"
-//   - on the global-API-key path, kinds IN this set are rejected as
+//   - on the global-API-key path, host-only kinds are rejected as
 //     "this kind requires host-auth"
+//
+// These kinds have exactly one producer — the Mac daemon — so an
+// internal Pi publisher writing one would either be a bug or a hostile
+// actor with the global key.
 func isHostOnlyKind(k events.Kind) bool {
-	_, ok := hostAuthAllowedKinds[k]
+	_, ok := kindToFamily[k]
 	return ok
-}
-
-// isRawMessageKind reports whether the kind is one of the
-// raw_message.* daemon-emitted events. Used by the dispatch loop to
-// pick between handleRawMessage and the external_contact handlers.
-func isRawMessageKind(k events.Kind) bool {
-	return k == events.KindRawMessageReceived || k == events.KindRawMessageSent
-}
-
-// isExternalContactKind reports whether the kind is one of the
-// external_contact.* daemon-emitted events.
-func isExternalContactKind(k events.Kind) bool {
-	return k == events.KindExternalContactUpserted || k == events.KindExternalContactDeleted
-}
-
-// isMeetingNoteKind reports whether the kind is one of the
-// meeting_note.* daemon-emitted events.
-func isMeetingNoteKind(k events.Kind) bool {
-	return k == events.KindMeetingNoteRecorded || k == events.KindMeetingNoteDeleted
-}
-
-// isCallKind reports whether the kind is one of the call.* daemon-emitted
-// phone-call events.
-func isCallKind(k events.Kind) bool {
-	return k == events.KindCallReceived || k == events.KindCallSent
 }
 
 // pendingAggregateKey is the (source, contactID) pair used to dedupe
@@ -587,27 +532,10 @@ func (s *IngestService) IngestBatch(
 		// kinds only). Done BEFORE opening the savepoint so a clean
 		// failure doesn't even open one. The handler's pre-validation
 		// already enforced required-field presence; we cross-check the
-		// envelope/payload pair.
-		if isRawMessageKind(env.Kind) {
-			if rejection := verifyRawMessageInvariants(env, *hostID); rejection != nil {
-				rejection.Index = originalIdx
-				perEventRejections = append(perEventRejections, *rejection)
-				continue
-			}
-		} else if isExternalContactKind(env.Kind) {
-			if rejection := verifyExternalContactInvariants(env, *hostID); rejection != nil {
-				rejection.Index = originalIdx
-				perEventRejections = append(perEventRejections, *rejection)
-				continue
-			}
-		} else if isMeetingNoteKind(env.Kind) {
-			if rejection := verifyMeetingNoteInvariants(env, *hostID); rejection != nil {
-				rejection.Index = originalIdx
-				perEventRejections = append(perEventRejections, *rejection)
-				continue
-			}
-		} else if isCallKind(env.Kind) {
-			if rejection := verifyCallInvariants(env, *hostID); rejection != nil {
+		// envelope/payload pair. Routing is table-driven: the family
+		// descriptor owns which verifier runs for the kind.
+		if fam, ok := kindToFamily[env.Kind]; ok {
+			if rejection := fam.verify(env, *hostID); rejection != nil {
 				rejection.Index = originalIdx
 				perEventRejections = append(perEventRejections, *rejection)
 				continue
@@ -681,9 +609,15 @@ func (s *IngestService) IngestBatch(
 		var pendingFollowUps []func(context.Context)
 
 		if runInline {
-			switch {
-			case isRawMessageKind(env.Kind):
-				contactID, rejection := s.handleRawMessage(ctx, sp, env, *hostID)
+			// Inline dispatch is table-driven: the family descriptor owns
+			// which handler runs for the kind and threads its outputs back
+			// through the uniform dispatch tuple. The post-handler
+			// bookkeeping (rollback on rejection, pendingAggregate for
+			// raw_message, pendingNA/pendingFollowUps for meeting_note,
+			// batchPostCommit for call) is identical to the prior per-arm
+			// switch — only the routing is centralized.
+			if fam, ok := kindToFamily[env.Kind]; ok {
+				contactID, naItem, postCommits, rejection := fam.dispatch(s, ctx, sp, env, *hostID)
 				if rejection != nil {
 					rejection.Index = originalIdx
 					perEventRejections = append(perEventRejections, *rejection)
@@ -695,58 +629,8 @@ func (s *IngestService) IngestBatch(
 				if contactID != nil {
 					pendingAggregate[pendingAggregateKey{Source: env.Source, ContactID: *contactID}] = struct{}{}
 				}
-			case env.Kind == events.KindExternalContactUpserted:
-				if rejection := s.handleExternalContactUpserted(ctx, sp, env, *hostID); rejection != nil {
-					rejection.Index = originalIdx
-					perEventRejections = append(perEventRejections, *rejection)
-					if rbErr := sp.Rollback(ctx); rbErr != nil {
-						return 0, 0, nil, nil, fmt.Errorf("rollback savepoint for rejected index %d (original %d): %w", i, originalIdx, rbErr)
-					}
-					continue
-				}
-			case env.Kind == events.KindExternalContactDeleted:
-				if rejection := s.handleExternalContactDeleted(ctx, sp, env, *hostID); rejection != nil {
-					rejection.Index = originalIdx
-					perEventRejections = append(perEventRejections, *rejection)
-					if rbErr := sp.Rollback(ctx); rbErr != nil {
-						return 0, 0, nil, nil, fmt.Errorf("rollback savepoint for rejected index %d (original %d): %w", i, originalIdx, rbErr)
-					}
-					continue
-				}
-			case env.Kind == events.KindMeetingNoteRecorded:
-				naItem, followUps, rejection := s.handleMeetingNoteRecorded(ctx, sp, env, *hostID)
-				if rejection != nil {
-					rejection.Index = originalIdx
-					perEventRejections = append(perEventRejections, *rejection)
-					if rbErr := sp.Rollback(ctx); rbErr != nil {
-						return 0, 0, nil, nil, fmt.Errorf("rollback savepoint for rejected index %d (original %d): %w", i, originalIdx, rbErr)
-					}
-					continue
-				}
 				pendingNA = naItem
-				pendingFollowUps = followUps
-			case env.Kind == events.KindMeetingNoteDeleted:
-				if rejection := s.handleMeetingNoteDeleted(ctx, sp, env, *hostID); rejection != nil {
-					rejection.Index = originalIdx
-					perEventRejections = append(perEventRejections, *rejection)
-					if rbErr := sp.Rollback(ctx); rbErr != nil {
-						return 0, 0, nil, nil, fmt.Errorf("rollback savepoint for rejected index %d (original %d): %w", i, originalIdx, rbErr)
-					}
-					continue
-				}
-			case isCallKind(env.Kind):
-				postCommit, rejection := s.handleCall(ctx, sp, env, *hostID, env.Kind == events.KindCallSent)
-				if rejection != nil {
-					rejection.Index = originalIdx
-					perEventRejections = append(perEventRejections, *rejection)
-					if rbErr := sp.Rollback(ctx); rbErr != nil {
-						return 0, 0, nil, nil, fmt.Errorf("rollback savepoint for rejected index %d (original %d): %w", i, originalIdx, rbErr)
-					}
-					continue
-				}
-				if postCommit != nil {
-					batchPostCommit = append(batchPostCommit, postCommit)
-				}
+				pendingFollowUps = postCommits
 			}
 		}
 
@@ -931,7 +815,7 @@ func verifyRawMessageInvariants(env *events.Envelope, authenticatedHostID uuid.U
 			Message: "payload host_id does not match authenticated host",
 		}
 	}
-	if env.Source != "messages" {
+	if _, ok := rawMessageAllowedSources[env.Source]; !ok {
 		return &IngestPerEventRejection{
 			Code:    ingestRejectPayloadInvariant,
 			Message: fmt.Sprintf("env.source %q not supported on raw_message kinds", env.Source),
@@ -1067,7 +951,7 @@ func commonExternalContactInvariants(
 			Message: "payload host_id does not match authenticated host",
 		}
 	}
-	if _, ok := allowedExternalContactSources[env.Source]; !ok {
+	if _, ok := externalContactAllowedSources[env.Source]; !ok {
 		return &IngestPerEventRejection{
 			Code:    ingestRejectPayloadInvariant,
 			Message: fmt.Sprintf("env.source %q not supported on external_contact.* kinds", env.Source),
@@ -1639,7 +1523,7 @@ func commonMeetingNoteInvariants(
 			Message: "payload host_id does not match authenticated host",
 		}
 	}
-	if _, ok := allowedMeetingNoteSources[env.Source]; !ok {
+	if _, ok := meetingNoteAllowedSources[env.Source]; !ok {
 		return &IngestPerEventRejection{
 			Code:    ingestRejectPayloadInvariant,
 			Message: fmt.Sprintf("env.source %q not supported on meeting_note.* kinds", env.Source),

--- a/backend/internal/service/ingest.go
+++ b/backend/internal/service/ingest.go
@@ -851,7 +851,7 @@ func verifyRawMessageInvariants(env *events.Envelope, authenticatedHostID uuid.U
 //  1. payload decodes cleanly into the per-kind struct.
 //  2. payload.HostID matches the authenticated host (no host
 //     cross-impersonation).
-//  3. env.Source is in allowedExternalContactSources.
+//  3. env.Source is in the external_contact family's allowed sources.
 //  4. payload.Source matches env.Source.
 //  5. payload.EntityID is non-empty.
 //  6. env.SourceID format matches the kind's content-hash discriminator
@@ -1427,7 +1427,7 @@ func toRepoAddressEntries(in []events.ExternalContactAddressValue) []repository.
 // Properties checked (mirrors verifyExternalContactInvariants):
 //  1. payload decodes cleanly into the per-kind struct.
 //  2. payload.HostID matches the authenticated host.
-//  3. env.Source is in allowedMeetingNoteSources.
+//  3. env.Source is in the meeting_note family's allowed sources.
 //  4. payload.Source matches env.Source.
 //  5. payload.SourceID parses as a UUID.
 //  6. env.SourceID matches the kind's content-hash discriminator shape

--- a/backend/internal/service/ingest_call.go
+++ b/backend/internal/service/ingest_call.go
@@ -22,7 +22,7 @@ import (
 //  1. Payload decodes cleanly into CallPayload.
 //  2. payload.HostID matches the authenticated host (no host
 //     cross-impersonation).
-//  3. env.Source is in allowedCallSources.
+//  3. env.Source is in the call family's allowed sources.
 //  4. payload.Source matches env.Source.
 //  5. payload.CallUniqueID is non-empty and equals env.SourceID (so
 //     event-log dedup key and staging-table dedup key are the same

--- a/backend/internal/service/ingest_call.go
+++ b/backend/internal/service/ingest_call.go
@@ -14,13 +14,6 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
-// allowedCallSources is the set of envelope.Source values the call.*
-// inline handler accepts. Mismatches surface as PAYLOAD_INVARIANT.
-// Extend when a new daemon-side phone-call source ships.
-var allowedCallSources = map[string]struct{}{
-	repository.InteractionSourcePhoneCalls: {},
-}
-
 // verifyCallInvariants enforces the cross-field consistency properties
 // for call.* envelopes. Returns a *IngestPerEventRejection (caller fills
 // in Index) on any violation, nil on success.
@@ -52,7 +45,7 @@ func verifyCallInvariants(env *events.Envelope, authenticatedHostID uuid.UUID) *
 			Message: "payload host_id does not match authenticated host",
 		}
 	}
-	if _, ok := allowedCallSources[env.Source]; !ok {
+	if _, ok := callAllowedSources[env.Source]; !ok {
 		return &IngestPerEventRejection{
 			Code:    ingestRejectPayloadInvariant,
 			Message: fmt.Sprintf("env.source %q not supported on call kinds", env.Source),

--- a/backend/internal/service/ingest_call_test.go
+++ b/backend/internal/service/ingest_call_test.go
@@ -154,7 +154,7 @@ func TestVerifyCallInvariants_HostIDMismatch(t *testing.T) {
 func TestVerifyCallInvariants_RejectsUnknownSource(t *testing.T) {
 	host := uuid.New()
 	env := validCallEnv(t, events.KindCallReceived, host, "uniq-4")
-	env.Source = "skype" // not in allowedCallSources
+	env.Source = "skype" // not in the call family's allowed sources
 	rej := verifyCallInvariants(env, host)
 	require.NotNil(t, rej)
 	require.Equal(t, ingestRejectPayloadInvariant, rej.Code)
@@ -224,14 +224,14 @@ func TestVerifyCallInvariants_RejectsUnnormalizablePeer(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// isCallKind / isHostOnlyKind allowlist tests (T8, T9 — partial).
+// call kind routing / isHostOnlyKind allowlist tests (T8, T9 — partial).
 // ---------------------------------------------------------------------------
 
-func TestIsCallKind(t *testing.T) {
-	require.True(t, isCallKind(events.KindCallReceived))
-	require.True(t, isCallKind(events.KindCallSent))
-	require.False(t, isCallKind(events.KindRawMessageReceived))
-	require.False(t, isCallKind(events.KindExternalContactUpserted))
+func TestCallKindRouting(t *testing.T) {
+	require.Equal(t, "call", kindToFamily[events.KindCallReceived].name)
+	require.Equal(t, "call", kindToFamily[events.KindCallSent].name)
+	require.Equal(t, "raw_message", kindToFamily[events.KindRawMessageReceived].name)
+	require.Equal(t, "external_contact", kindToFamily[events.KindExternalContactUpserted].name)
 }
 
 func TestIsHostOnlyKind_IncludesCalls(t *testing.T) {

--- a/backend/internal/service/ingest_registry.go
+++ b/backend/internal/service/ingest_registry.go
@@ -1,0 +1,281 @@
+package service
+
+import (
+	"context"
+	"sort"
+
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// daemonFamily is the single descriptor for one daemon-emitted event
+// family (raw_message.*, external_contact.*, meeting_note.*, call.*).
+// One entry per family in daemonFamilies. The table is the source of
+// truth for the host-auth allowlist, the inline-dispatch routing, the
+// per-family invariant verifier, and the per-family allowed envelope
+// source set. Pieces in other packages (events.AllKinds,
+// mac.AllowedPushSources, the interaction.source SQL CHECK, the provider
+// stubs) are cross-checked against this table by the agreement tests
+// rather than driven from it — the import graph forbids inverting those
+// dependencies into this package.
+type daemonFamily struct {
+	// name is a human label, e.g. "raw_message".
+	name string
+	// kinds are the host-only kinds in this family. raw_message.*,
+	// external_contact.*, meeting_note.*, and call.* each have 2 kinds.
+	kinds []events.Kind
+	// allowedSources is the set of envelope.Source values this family
+	// accepts. external_contact.* accepts two sources (icloud_contacts,
+	// anarlog_humans); the other three families accept exactly one. The
+	// per-family verify function reads this set instead of a package-var
+	// or an inline literal.
+	allowedSources map[string]struct{}
+	// providerStubSources is the subset of allowedSources that MUST have
+	// a push ProviderRegistry stub registered (messages, icloud_contacts,
+	// phone_calls). The anarlog sources are deliberately absent — they
+	// have no stub by design. The agreement test cross-checks this subset
+	// against the live registry built by push.RegisterPushProviders().
+	providerStubSources map[string]struct{}
+	// writesInteractions is true iff this family produces interaction
+	// rows (raw_message / meeting_note / call); false for
+	// external_contact. Paired with interactionSource:
+	// writesInteractions == true REQUIRES a non-empty interactionSource
+	// and vice versa.
+	writesInteractions bool
+	// interactionSource is the repository.InteractionSource* value this
+	// family's interactions carry; "" when writesInteractions is false.
+	interactionSource string
+	// verify runs the family's cross-field invariant checks before the
+	// per-event savepoint opens. Returns a non-nil rejection (caller fills
+	// in Index) on any violation.
+	verify func(env *events.Envelope, hostID uuid.UUID) *IngestPerEventRejection
+	// dispatch runs the family's inline handler inside the per-event
+	// savepoint. The return tuple is the union of what the four families
+	// produce; each family populates only its relevant fields:
+	//   - contactID: raw_message aggregator enqueue key; nil otherwise.
+	//   - needsAttention: meeting_note.recorded only; nil otherwise.
+	//   - postCommits: call + meeting_note follow-up closures; nil
+	//     otherwise.
+	//   - rejection: non-nil on a domain refusal (caller rolls back the
+	//     savepoint).
+	dispatch func(s *IngestService, ctx context.Context, sp pgx.Tx, env *events.Envelope, hostID uuid.UUID) (
+		contactID *uuid.UUID,
+		needsAttention *NeedsAttentionItem,
+		postCommits []func(context.Context),
+		rejection *IngestPerEventRejection,
+	)
+}
+
+// Per-family allowed-source sets. Defined as standalone vars (rather
+// than inline in the family literals) so the verify functions can read
+// them directly without creating a package-init cycle: a verify function
+// references its source set, and the family literal references the same
+// set AND the verify function — referencing the set var directly keeps
+// the function out of the family's init dependency chain. The family's
+// allowedSources field points at the same map, so there is exactly one
+// source-of-truth set per family.
+var (
+	rawMessageAllowedSources      = map[string]struct{}{"messages": {}}
+	externalContactAllowedSources = map[string]struct{}{"icloud_contacts": {}, "anarlog_humans": {}}
+	meetingNoteAllowedSources     = map[string]struct{}{"anarlog_sessions": {}}
+	callAllowedSources            = map[string]struct{}{repository.InteractionSourcePhoneCalls: {}}
+)
+
+// rawMessageFamily descriptor — raw_message.received / raw_message.sent.
+// Source "messages" (the only raw_message source today). Interactions
+// are written asynchronously by the aggregator using
+// InteractionSourceMessages, so the family writes interactions even
+// though handleRawMessage itself only stages.
+var rawMessageFamily = daemonFamily{
+	name:                "raw_message",
+	kinds:               []events.Kind{events.KindRawMessageReceived, events.KindRawMessageSent},
+	allowedSources:      rawMessageAllowedSources,
+	providerStubSources: map[string]struct{}{"messages": {}},
+	writesInteractions:  true,
+	interactionSource:   repository.InteractionSourceMessages,
+	verify:              verifyRawMessageInvariants,
+	dispatch: func(s *IngestService, ctx context.Context, sp pgx.Tx, env *events.Envelope, hostID uuid.UUID) (
+		*uuid.UUID, *NeedsAttentionItem, []func(context.Context), *IngestPerEventRejection,
+	) {
+		contactID, rejection := s.handleRawMessage(ctx, sp, env, hostID)
+		return contactID, nil, nil, rejection
+	},
+}
+
+// externalContactFamily descriptor — external_contact.upserted /
+// external_contact.deleted. Accepts two sources (icloud_contacts has a
+// provider stub; anarlog_humans does not). Produces no interaction rows.
+var externalContactFamily = daemonFamily{
+	name:                "external_contact",
+	kinds:               []events.Kind{events.KindExternalContactUpserted, events.KindExternalContactDeleted},
+	allowedSources:      externalContactAllowedSources,
+	providerStubSources: map[string]struct{}{"icloud_contacts": {}},
+	writesInteractions:  false,
+	interactionSource:   "",
+	verify:              verifyExternalContactInvariants,
+	dispatch: func(s *IngestService, ctx context.Context, sp pgx.Tx, env *events.Envelope, hostID uuid.UUID) (
+		*uuid.UUID, *NeedsAttentionItem, []func(context.Context), *IngestPerEventRejection,
+	) {
+		switch env.Kind {
+		case events.KindExternalContactUpserted:
+			return nil, nil, nil, s.handleExternalContactUpserted(ctx, sp, env, hostID)
+		case events.KindExternalContactDeleted:
+			return nil, nil, nil, s.handleExternalContactDeleted(ctx, sp, env, hostID)
+		default:
+			return nil, nil, nil, &IngestPerEventRejection{
+				Code:    ingestRejectPayloadInvariant,
+				Message: "external_contact dispatch: unexpected kind",
+			}
+		}
+	},
+}
+
+// meetingNoteFamily descriptor — meeting_note.recorded /
+// meeting_note.deleted. Source "anarlog_sessions" has NO provider stub by
+// design, so providerStubSources is empty. recorded writes session-
+// attributed interactions (InteractionSourceAnarlogSessions).
+var meetingNoteFamily = daemonFamily{
+	name:                "meeting_note",
+	kinds:               []events.Kind{events.KindMeetingNoteRecorded, events.KindMeetingNoteDeleted},
+	allowedSources:      meetingNoteAllowedSources,
+	providerStubSources: map[string]struct{}{},
+	writesInteractions:  true,
+	interactionSource:   repository.InteractionSourceAnarlogSessions,
+	verify:              verifyMeetingNoteInvariants,
+	dispatch: func(s *IngestService, ctx context.Context, sp pgx.Tx, env *events.Envelope, hostID uuid.UUID) (
+		*uuid.UUID, *NeedsAttentionItem, []func(context.Context), *IngestPerEventRejection,
+	) {
+		switch env.Kind {
+		case events.KindMeetingNoteRecorded:
+			naItem, followUps, rejection := s.handleMeetingNoteRecorded(ctx, sp, env, hostID)
+			return nil, naItem, followUps, rejection
+		case events.KindMeetingNoteDeleted:
+			return nil, nil, nil, s.handleMeetingNoteDeleted(ctx, sp, env, hostID)
+		default:
+			return nil, nil, nil, &IngestPerEventRejection{
+				Code:    ingestRejectPayloadInvariant,
+				Message: "meeting_note dispatch: unexpected kind",
+			}
+		}
+	},
+}
+
+// callFamily descriptor — call.received / call.sent. Source "phone_calls"
+// has a provider stub. Writes interactions (InteractionSourcePhoneCalls).
+// The kind→isOutbound decision (KindCallSent) lives entirely inside this
+// dispatch wrapper so IngestBatch carries no kind reference.
+var callFamily = daemonFamily{
+	name:                "call",
+	kinds:               []events.Kind{events.KindCallReceived, events.KindCallSent},
+	allowedSources:      callAllowedSources,
+	providerStubSources: map[string]struct{}{repository.InteractionSourcePhoneCalls: {}},
+	writesInteractions:  true,
+	interactionSource:   repository.InteractionSourcePhoneCalls,
+	verify:              verifyCallInvariants,
+	dispatch: func(s *IngestService, ctx context.Context, sp pgx.Tx, env *events.Envelope, hostID uuid.UUID) (
+		*uuid.UUID, *NeedsAttentionItem, []func(context.Context), *IngestPerEventRejection,
+	) {
+		isOutbound := env.Kind == events.KindCallSent
+		postCommit, rejection := s.handleCall(ctx, sp, env, hostID, isOutbound)
+		if rejection != nil {
+			return nil, nil, nil, rejection
+		}
+		if postCommit != nil {
+			return nil, nil, []func(context.Context){postCommit}, nil
+		}
+		return nil, nil, nil, nil
+	},
+}
+
+// daemonFamilies is the single source of truth for the daemon-push event
+// families. Built once at package init.
+var daemonFamilies = []daemonFamily{
+	rawMessageFamily,
+	externalContactFamily,
+	meetingNoteFamily,
+	callFamily,
+}
+
+// kindToFamily indexes every family kind → its descriptor. Built from
+// daemonFamilies at package init. A kind appears in at most one family
+// (enforced by the agreement test's partition check).
+var kindToFamily = buildKindToFamilyIndex(daemonFamilies)
+
+// buildKindToFamilyIndex flattens daemonFamilies into a kind→descriptor
+// lookup. Panics on a duplicate kind across families — a programming
+// error in the table definition that must fail loudly at startup.
+func buildKindToFamilyIndex(families []daemonFamily) map[events.Kind]*daemonFamily {
+	index := make(map[events.Kind]*daemonFamily)
+	for i := range families {
+		fam := &families[i]
+		for _, k := range fam.kinds {
+			if _, dup := index[k]; dup {
+				panic("daemonFamilies: kind " + string(k) + " appears in more than one family")
+			}
+			index[k] = fam
+		}
+	}
+	return index
+}
+
+// DaemonFamilyView is a read-only, copy-safe projection of one daemon
+// event family descriptor, exported solely for cross-package agreement
+// tests and read-only diagnostics. It must NOT be used as production
+// routing input outside the service package — routing goes through the
+// internal kindToFamily table. All slices are defensive copies and
+// deterministically sorted (the internal allowedSources /
+// providerStubSources are Go maps with randomized iteration order, so
+// the accessor sorts every copied slice — AllowedSources /
+// ProviderStubSources by string, Kinds by string) so callers can
+// deep-equal against a sorted expected literal without flakiness.
+type DaemonFamilyView struct {
+	Name                string
+	Kinds               []events.Kind // sorted
+	AllowedSources      []string      // sorted
+	ProviderStubSources []string      // sorted
+	WritesInteractions  bool
+	InteractionSource   string
+}
+
+// DaemonFamilyViews returns a defensive, deterministically-sorted copy of
+// the descriptor table (families ordered by Name). The internal
+// daemonFamily struct (with the verify/dispatch func fields) stays
+// unexported; only this data-shaped view is exported so both the
+// service_test agreement test and the backend/tests integration test can
+// read the table without seeing routing internals.
+func DaemonFamilyViews() []DaemonFamilyView {
+	views := make([]DaemonFamilyView, 0, len(daemonFamilies))
+	for i := range daemonFamilies {
+		fam := &daemonFamilies[i]
+
+		kinds := make([]events.Kind, len(fam.kinds))
+		copy(kinds, fam.kinds)
+		sort.Slice(kinds, func(a, b int) bool { return kinds[a] < kinds[b] })
+
+		views = append(views, DaemonFamilyView{
+			Name:                fam.name,
+			Kinds:               kinds,
+			AllowedSources:      sortedKeys(fam.allowedSources),
+			ProviderStubSources: sortedKeys(fam.providerStubSources),
+			WritesInteractions:  fam.writesInteractions,
+			InteractionSource:   fam.interactionSource,
+		})
+	}
+	sort.Slice(views, func(a, b int) bool { return views[a].Name < views[b].Name })
+	return views
+}
+
+// sortedKeys returns the keys of a set map as a sorted slice. Returns an
+// empty (non-nil) slice for an empty map so DeepEqual comparisons against
+// an empty expected literal are stable.
+func sortedKeys(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/backend/internal/service/ingest_registry_test.go
+++ b/backend/internal/service/ingest_registry_test.go
@@ -15,9 +15,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestDaemonFamilies_AgreeWithRegistries is the centerpiece "mechanical
-// prevention" for #342. It reads service.DaemonFamilyViews() and asserts
-// the descriptor table agrees set-for-set (and per-family mapping-for-
+// TestDaemonFamilies_AgreeWithRegistries is the centerpiece mechanical
+// guard against the daemon-push "add a source in N places" ritual
+// drifting. It reads service.DaemonFamilyViews() and asserts the
+// descriptor table agrees set-for-set (and per-family mapping-for-
 // mapping) with every other place the daemon-push ritual is duplicated:
 // events.AllKinds / kindPayloadTypes, mac.AllowedPushSources, the
 // repository.InteractionSource* constants, and the push ProviderRegistry

--- a/backend/internal/service/ingest_registry_test.go
+++ b/backend/internal/service/ingest_registry_test.go
@@ -1,0 +1,216 @@
+package service_test
+
+import (
+	"sort"
+	"testing"
+
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/mac"
+	"personal-crm/backend/internal/push"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+	"personal-crm/backend/internal/sync"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDaemonFamilies_AgreeWithRegistries is the centerpiece "mechanical
+// prevention" for #342. It reads service.DaemonFamilyViews() and asserts
+// the descriptor table agrees set-for-set (and per-family mapping-for-
+// mapping) with every other place the daemon-push ritual is duplicated:
+// events.AllKinds / kindPayloadTypes, mac.AllowedPushSources, the
+// repository.InteractionSource* constants, and the push ProviderRegistry
+// stubs built by push.RegisterPushProviders.
+//
+// The test lives in package service_test because it imports push, which
+// transitively imports service — an internal package service test could
+// not (cycle). External test packages are separate from package service
+// for Go's cycle rule, so service_test may import both.
+func TestDaemonFamilies_AgreeWithRegistries(t *testing.T) {
+	views := service.DaemonFamilyViews()
+	require.Len(t, views, 4, "expected exactly four daemon families")
+
+	// expectedDaemonPushKinds is the canonical set of the 8 daemon-push
+	// kinds. Pinned here so adding a kind to a family without updating
+	// this list (or vice versa) fails loudly.
+	expectedDaemonPushKinds := []events.Kind{
+		events.KindRawMessageReceived, events.KindRawMessageSent,
+		events.KindExternalContactUpserted, events.KindExternalContactDeleted,
+		events.KindMeetingNoteRecorded, events.KindMeetingNoteDeleted,
+		events.KindCallReceived, events.KindCallSent,
+	}
+
+	// --- Assertion 1: union of family kinds == the 8 daemon-push kinds,
+	// AND each is a member of events.AllKinds. ---
+	allKindsSet := make(map[events.Kind]struct{}, len(events.AllKinds))
+	for _, k := range events.AllKinds {
+		allKindsSet[k] = struct{}{}
+	}
+	unionKinds := make([]events.Kind, 0, 8)
+	for _, v := range views {
+		unionKinds = append(unionKinds, v.Kinds...)
+	}
+	assert.ElementsMatch(t, expectedDaemonPushKinds, unionKinds,
+		"union of family kinds must equal the 8 daemon-push kinds")
+	for _, k := range unionKinds {
+		_, ok := allKindsSet[k]
+		assert.Truef(t, ok, "family kind %q must be in events.AllKinds", k)
+	}
+
+	// --- Assertion 2: every family kind has a registered payload type
+	// (events.IsKnownKind covers kindPayloadTypes). ---
+	for _, k := range unionKinds {
+		assert.Truef(t, events.IsKnownKind(k),
+			"family kind %q must have a registered payload type (kindPayloadTypes)", k)
+	}
+
+	// --- Assertion 3: union of allowedSources == mac.AllowedPushSources
+	// exactly (5 sources). Ties the kind-side and source-side together. ---
+	unionSources := make([]string, 0)
+	for _, v := range views {
+		unionSources = append(unionSources, v.AllowedSources...)
+	}
+	expectedPushSources := make([]string, 0, len(mac.AllowedPushSources))
+	for s := range mac.AllowedPushSources {
+		expectedPushSources = append(expectedPushSources, s)
+	}
+	assert.ElementsMatch(t, expectedPushSources, unionSources,
+		"union of family allowedSources must equal mac.AllowedPushSources")
+
+	// --- Assertion 4: interaction-source agreement (Go-side). ---
+	// 4a: every non-empty interactionSource is a repository.InteractionSource* constant.
+	allInteractionSources := map[string]struct{}{
+		repository.InteractionSourceManual:          {},
+		repository.InteractionSourceGCal:            {},
+		repository.InteractionSourceTodoist:         {},
+		repository.InteractionSourceTelegram:        {},
+		repository.InteractionSourceMessages:        {},
+		repository.InteractionSourceAnarlogSessions: {},
+		repository.InteractionSourcePhoneCalls:      {},
+	}
+	// 4b: writesInteractions <=> non-empty interactionSource (both directions).
+	pushInteractionSources := make([]string, 0)
+	for _, v := range views {
+		if v.WritesInteractions {
+			assert.NotEmptyf(t, v.InteractionSource,
+				"family %q writes interactions but has empty interactionSource", v.Name)
+			_, known := allInteractionSources[v.InteractionSource]
+			assert.Truef(t, known,
+				"family %q interactionSource %q is not a repository.InteractionSource* constant",
+				v.Name, v.InteractionSource)
+			pushInteractionSources = append(pushInteractionSources, v.InteractionSource)
+		} else {
+			assert.Emptyf(t, v.InteractionSource,
+				"family %q does not write interactions but has interactionSource %q",
+				v.Name, v.InteractionSource)
+		}
+	}
+	// 4c: the set of descriptor push interactionSource values equals exactly
+	// the set of PUSH repository.InteractionSource* constants. The 4
+	// Pi-internal constants (manual/gcal/todoist/telegram) are out of
+	// descriptor scope — daemon-push families never carry them.
+	expectedPushInteractionSources := []string{
+		repository.InteractionSourceMessages,
+		repository.InteractionSourceAnarlogSessions,
+		repository.InteractionSourcePhoneCalls,
+	}
+	assert.ElementsMatch(t, expectedPushInteractionSources, pushInteractionSources,
+		"descriptor push interactionSource set must equal the push InteractionSource* constants")
+
+	// --- Assertion 5: provider-stub completeness against the REAL
+	// push.RegisterPushProviders helper. ---
+	reg := sync.NewProviderRegistry()
+	push.RegisterPushProviders(reg)
+	pushStrategyNames := make(map[string]struct{})
+	for _, cfg := range reg.List() {
+		if cfg.Strategy == repository.SyncStrategyPush {
+			pushStrategyNames[cfg.Name] = struct{}{}
+		}
+	}
+	// 5a: every providerStubSources member is a registered push provider.
+	stubUnion := make(map[string]struct{})
+	for _, v := range views {
+		for _, src := range v.ProviderStubSources {
+			stubUnion[src] = struct{}{}
+			// must be a subset of the family's own allowedSources.
+			assert.Containsf(t, v.AllowedSources, src,
+				"family %q providerStubSources member %q must be in its allowedSources", v.Name, src)
+			_, registered := pushStrategyNames[src]
+			assert.Truef(t, registered,
+				"providerStubSources member %q has no push provider registered by RegisterPushProviders", src)
+		}
+	}
+	// 5b: conversely every registered push-strategy provider is covered by
+	// some providerStubSources set.
+	for name := range pushStrategyNames {
+		_, covered := stubUnion[name]
+		assert.Truef(t, covered,
+			"registered push provider %q is not covered by any family's providerStubSources", name)
+	}
+
+	// --- Assertion 6: no two families share a kind (partition check). ---
+	seenKind := make(map[events.Kind]string)
+	for _, v := range views {
+		for _, k := range v.Kinds {
+			if prev, dup := seenKind[k]; dup {
+				t.Fatalf("kind %q appears in both family %q and family %q", k, prev, v.Name)
+			}
+			seenKind[k] = v.Name
+		}
+	}
+
+	// --- Assertion 7: per-family mapping pins (catch cross-family
+	// metadata swaps that the set-union checks above would miss). Because
+	// DaemonFamilyViews() returns sorted slices, compare each view to its
+	// expected literal by Name with require.Equal. ---
+	expectedByName := map[string]service.DaemonFamilyView{
+		"raw_message": {
+			Name:                "raw_message",
+			Kinds:               sortedKinds(events.KindRawMessageReceived, events.KindRawMessageSent),
+			AllowedSources:      []string{"messages"},
+			ProviderStubSources: []string{"messages"},
+			WritesInteractions:  true,
+			InteractionSource:   repository.InteractionSourceMessages,
+		},
+		"external_contact": {
+			Name:                "external_contact",
+			Kinds:               sortedKinds(events.KindExternalContactDeleted, events.KindExternalContactUpserted),
+			AllowedSources:      []string{"anarlog_humans", "icloud_contacts"},
+			ProviderStubSources: []string{"icloud_contacts"},
+			WritesInteractions:  false,
+			InteractionSource:   "",
+		},
+		"meeting_note": {
+			Name:                "meeting_note",
+			Kinds:               sortedKinds(events.KindMeetingNoteDeleted, events.KindMeetingNoteRecorded),
+			AllowedSources:      []string{"anarlog_sessions"},
+			ProviderStubSources: []string{},
+			WritesInteractions:  true,
+			InteractionSource:   repository.InteractionSourceAnarlogSessions,
+		},
+		"call": {
+			Name:                "call",
+			Kinds:               sortedKinds(events.KindCallReceived, events.KindCallSent),
+			AllowedSources:      []string{repository.InteractionSourcePhoneCalls},
+			ProviderStubSources: []string{repository.InteractionSourcePhoneCalls},
+			WritesInteractions:  true,
+			InteractionSource:   repository.InteractionSourcePhoneCalls,
+		},
+	}
+	require.Len(t, expectedByName, len(views))
+	for _, v := range views {
+		expected, ok := expectedByName[v.Name]
+		require.Truef(t, ok, "unexpected family %q in DaemonFamilyViews", v.Name)
+		require.Equalf(t, expected, v, "family %q descriptor does not match its expected mapping", v.Name)
+	}
+}
+
+// sortedKinds returns the given kinds sorted by string, matching the
+// ordering DaemonFamilyViews() applies to the Kinds slice.
+func sortedKinds(kinds ...events.Kind) []events.Kind {
+	out := make([]events.Kind, len(kinds))
+	copy(out, kinds)
+	sort.Slice(out, func(a, b int) bool { return out[a] < out[b] })
+	return out
+}

--- a/backend/internal/service/ingest_test.go
+++ b/backend/internal/service/ingest_test.go
@@ -82,9 +82,12 @@ func TestIngestService_RejectsLenMismatchOnOriginalIndices(t *testing.T) {
 // match + staging upsert, aggregator enqueue) are covered by the
 // integration tests under backend/tests/api/.
 
-// TestIsHostOnlyKind_Whitelist verifies the allowlist contains exactly
-// the daemon-emitted raw_message.* + external_contact.* kinds and
-// rejects all others. Locks the allowlist contract at the unit level.
+// TestIsHostOnlyKind_Whitelist verifies the allowlist contains the
+// daemon-emitted kinds (raw_message.* / external_contact.* /
+// meeting_note.* / call.*) and rejects all others. Locks the allowlist
+// contract at the unit level. (external_contact.* / meeting_note.* /
+// call.* membership is asserted by the dedicated TestIsHostOnlyKind_*
+// tests below.)
 func TestIsHostOnlyKind_Whitelist(t *testing.T) {
 	require.True(t, isHostOnlyKind(events.KindRawMessageReceived))
 	require.True(t, isHostOnlyKind(events.KindRawMessageSent))

--- a/backend/internal/service/ingest_test.go
+++ b/backend/internal/service/ingest_test.go
@@ -102,12 +102,16 @@ func TestIsHostOnlyKind_Whitelist(t *testing.T) {
 	}
 }
 
-// TestIsRawMessageKind verifies the helper.
-func TestIsRawMessageKind(t *testing.T) {
-	require.True(t, isRawMessageKind(events.KindRawMessageReceived))
-	require.True(t, isRawMessageKind(events.KindRawMessageSent))
-	require.False(t, isRawMessageKind(events.KindMessageReceived))
-	require.False(t, isRawMessageKind(events.KindCalendarAttended))
+// TestRawMessageKindRouting verifies the raw_message.* kinds route to
+// the raw_message family via the descriptor table and that unrelated
+// kinds do not.
+func TestRawMessageKindRouting(t *testing.T) {
+	require.Equal(t, "raw_message", kindToFamily[events.KindRawMessageReceived].name)
+	require.Equal(t, "raw_message", kindToFamily[events.KindRawMessageSent].name)
+	_, ok := kindToFamily[events.KindMessageReceived]
+	require.False(t, ok)
+	_, ok = kindToFamily[events.KindCalendarAttended]
+	require.False(t, ok)
 }
 
 // TestVerifyRawMessageInvariants_HappyPath confirms a well-formed
@@ -289,11 +293,12 @@ func TestIsHostOnlyKind_IncludesExternalContact(t *testing.T) {
 	require.True(t, isHostOnlyKind(events.KindExternalContactDeleted))
 }
 
-func TestIsExternalContactKind(t *testing.T) {
-	require.True(t, isExternalContactKind(events.KindExternalContactUpserted))
-	require.True(t, isExternalContactKind(events.KindExternalContactDeleted))
-	require.False(t, isExternalContactKind(events.KindRawMessageReceived))
-	require.False(t, isExternalContactKind(events.KindMessageReceived))
+func TestExternalContactKindRouting(t *testing.T) {
+	require.Equal(t, "external_contact", kindToFamily[events.KindExternalContactUpserted].name)
+	require.Equal(t, "external_contact", kindToFamily[events.KindExternalContactDeleted].name)
+	require.Equal(t, "raw_message", kindToFamily[events.KindRawMessageReceived].name)
+	_, ok := kindToFamily[events.KindMessageReceived]
+	require.False(t, ok)
 }
 
 func TestVerifyExternalContactInvariants_HappyPath_Upsert(t *testing.T) {
@@ -326,7 +331,7 @@ func TestVerifyExternalContactInvariants_HostMismatch(t *testing.T) {
 func TestVerifyExternalContactInvariants_SourceMismatch(t *testing.T) {
 	host := uuid.New()
 	env := validUpsertedEnv(host, "CN-1")
-	env.Source = "gcontacts" // not in allowedExternalContactSources
+	env.Source = "gcontacts" // not in the external_contact family's allowed sources
 	rej := verifyExternalContactInvariants(env, host)
 	require.NotNil(t, rej)
 	require.Contains(t, rej.Message, "not supported")
@@ -1096,11 +1101,12 @@ func (r *recordingExternalContactWriter) UpsertTx(
 // ----------------------------------------------------------------------------
 
 // TestIsMeetingNoteKind exercises the kind-classifier helper.
-func TestIsMeetingNoteKind(t *testing.T) {
-	require.True(t, isMeetingNoteKind(events.KindMeetingNoteRecorded))
-	require.True(t, isMeetingNoteKind(events.KindMeetingNoteDeleted))
-	require.False(t, isMeetingNoteKind(events.KindExternalContactUpserted))
-	require.False(t, isMeetingNoteKind(events.KindMessageReceived))
+func TestMeetingNoteKindRouting(t *testing.T) {
+	require.Equal(t, "meeting_note", kindToFamily[events.KindMeetingNoteRecorded].name)
+	require.Equal(t, "meeting_note", kindToFamily[events.KindMeetingNoteDeleted].name)
+	require.Equal(t, "external_contact", kindToFamily[events.KindExternalContactUpserted].name)
+	_, ok := kindToFamily[events.KindMessageReceived]
+	require.False(t, ok)
 }
 
 // validMeetingNoteRecordedEnv constructs a structurally-valid envelope
@@ -1148,7 +1154,7 @@ func TestVerifyMeetingNoteInvariants_HostMismatch(t *testing.T) {
 func TestVerifyMeetingNoteInvariants_SourceMismatch(t *testing.T) {
 	host := uuid.New()
 	env := validMeetingNoteRecordedEnv(t, host, uuid.NewString())
-	env.Source = "icloud_contacts" // not in allowedMeetingNoteSources
+	env.Source = "icloud_contacts" // not in the meeting_note family's allowed sources
 	rej := verifyMeetingNoteInvariants(env, host)
 	require.NotNil(t, rej)
 	require.Contains(t, rej.Message, "not supported")

--- a/backend/sqlc_schema/pg_catalog.sql
+++ b/backend/sqlc_schema/pg_catalog.sql
@@ -1,0 +1,20 @@
+-- Auxiliary schema file for sqlc only. PostgreSQL provides the system
+-- catalog pg_constraint and the pg_get_constraintdef() function at
+-- runtime; sqlc v1.30.0 does not model them, so the read-only catalog
+-- query GetInteractionSourceCheckDef (internal/db/queries/test.sql)
+-- fails to compile without these minimal stub declarations.
+--
+-- We declare only the columns + function signature that query touches.
+-- This file is intentionally NOT under backend/migrations/ so
+-- golang-migrate never applies it to a real database — the live catalog
+-- is always the source of truth at runtime.
+
+CREATE TABLE pg_constraint (
+    oid      oid NOT NULL,
+    conname  text NOT NULL,
+    conrelid oid NOT NULL
+);
+
+CREATE FUNCTION pg_get_constraintdef(constraint_oid oid) RETURNS text AS $$
+    SELECT ''::text;
+$$ LANGUAGE sql;

--- a/backend/tests/ingest_registry_guard_static_test.go
+++ b/backend/tests/ingest_registry_guard_static_test.go
@@ -1,0 +1,134 @@
+// Package tests — ingest-registry grep guard self-test.
+//
+// The grep guard scripts/check-ingest-registry.sh asserts the IngestBatch
+// function body in backend/internal/service/ingest.go names no event kind
+// (constant or dotted string literal) and no per-family predicate —
+// routing must go through the daemonFamily descriptor table's kindToFamily
+// lookups. This test is the suspenders to that belt: it runs the ACTUAL
+// guard script and proves it (a) passes on the real tree, (b) catches a
+// synthetic violation injected into the IngestBatch body, and (c) ignores
+// a kind reference outside the body. Without this, a future regression in
+// the awk region extractor (e.g. mis-delimiting and scanning an empty
+// body) could let the guard silently pass on everything.
+//
+// Models scripts/ci/crm-marker-construction-guard.sh's companion test
+// TestCRMMarkerGrepGuard_CatchesIndexAssignment.
+package tests
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// ingestRegistryGuardPath returns the absolute path to the guard script.
+func ingestRegistryGuardPath(t *testing.T) string {
+	t.Helper()
+	moduleRoot, err := backendModuleRoot()
+	if err != nil {
+		t.Fatalf("locate backend module root: %v", err)
+	}
+	repoRoot := filepath.Dir(moduleRoot)
+	guard := filepath.Join(repoRoot, "scripts", "check-ingest-registry.sh")
+	if _, statErr := os.Stat(guard); statErr != nil {
+		t.Fatalf("guard script not found at %s: %v", guard, statErr)
+	}
+	return guard
+}
+
+// TestIngestRegistryGuard_PassesOnRealTree confirms the guard exits zero on
+// the actual ingest.go — a false positive here would block every push.
+func TestIngestRegistryGuard_PassesOnRealTree(t *testing.T) {
+	guard := ingestRegistryGuardPath(t)
+	if out, runErr := exec.Command(guard).CombinedOutput(); runErr != nil {
+		t.Fatalf("guard unexpectedly failed on the real tree: %v\n%s", runErr, out)
+	}
+}
+
+// TestIngestRegistryGuard_CatchesViolations runs the actual guard against
+// synthetic fixtures whose IngestBatch body names a kind in each of the
+// three forbidden forms (constant, dotted string literal, per-family
+// predicate call) and asserts the guard exits non-zero. A fixture whose
+// kind reference lives OUTSIDE the IngestBatch body must pass — that proves
+// the guard is scoped to the body, not the whole file.
+func TestIngestRegistryGuard_CatchesViolations(t *testing.T) {
+	guard := ingestRegistryGuardPath(t)
+
+	cases := []struct {
+		name      string
+		body      string
+		wantBlock bool
+	}{
+		{
+			name: "kind constant inside IngestBatch",
+			body: `package service
+
+func (s *IngestService) IngestBatch(ctx context.Context) error {
+	if env.Kind == events.KindCallSent {
+		return nil
+	}
+	return nil
+}
+`,
+			wantBlock: true,
+		},
+		{
+			name: "dotted kind literal inside IngestBatch",
+			body: `package service
+
+func (s *IngestService) IngestBatch(ctx context.Context) error {
+	_ = "raw_message.received"
+	return nil
+}
+`,
+			wantBlock: true,
+		},
+		{
+			name: "per-family predicate call inside IngestBatch",
+			body: `package service
+
+func (s *IngestService) IngestBatch(ctx context.Context) error {
+	if isCallKind(env.Kind) {
+		return nil
+	}
+	return nil
+}
+`,
+			wantBlock: true,
+		},
+		{
+			name: "kind reference outside IngestBatch passes",
+			body: `package service
+
+func (s *IngestService) IngestBatch(ctx context.Context) error {
+	if fam, ok := kindToFamily[env.Kind]; ok {
+		_ = fam
+	}
+	return nil
+}
+
+func handleRawMessage() {
+	_ = events.KindRawMessageSent
+	_ = "call.sent"
+	_ = isCallKind(nil)
+}
+`,
+			wantBlock: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := filepath.Join(t.TempDir(), "ingest_fixture.go")
+			if writeErr := os.WriteFile(fixture, []byte(tc.body), 0o644); writeErr != nil {
+				t.Fatalf("write fixture: %v", writeErr)
+			}
+			out, runErr := exec.Command(guard, fixture).CombinedOutput()
+			blocked := runErr != nil
+			if blocked != tc.wantBlock {
+				t.Fatalf("guard block=%v, want %v; output:\n%s", blocked, tc.wantBlock, out)
+			}
+		})
+	}
+}

--- a/backend/tests/interaction_source_descriptor_check_test.go
+++ b/backend/tests/interaction_source_descriptor_check_test.go
@@ -17,19 +17,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// checkDefShapeRe asserts the rendered constraint is the expected
-// `source = ANY (ARRAY[...]::text)` form. PostgreSQL 16 renders an
-// IN (...) CHECK this way; if a future PG ever renders it as IN (...)
-// the test fails loudly here rather than silently mis-parsing.
-var checkDefShapeRe = regexp.MustCompile(`source = ANY \(ARRAY\[.*\]\)`)
+// checkDefShapeRe asserts the rendered constraint is EXACTLY the
+// `CHECK ((source = ANY (ARRAY[...])))` form PostgreSQL 16 produces for a
+// single source-membership predicate. The pattern is fully anchored
+// (^...$) so a widened constraint that bolts an extra permissive clause
+// onto the ANY (e.g. `... OR source = 'x'`) fails the shape match instead
+// of slipping through a substring search — the literal parser only sees
+// the ARRAY members, so without this anchor an added OR-clause would
+// widen the live set undetected. If a future PG ever renders it as
+// IN (...) the test also fails loudly here rather than mis-parsing.
+var checkDefShapeRe = regexp.MustCompile(`^CHECK \(\(source = ANY \(ARRAY\[[^]]*\]\)\)\)$`)
 
 // checkDefLiteralRe extracts each quoted source literal from the rendered
 // ARRAY[...] — every element is `'value'::text`.
 var checkDefLiteralRe = regexp.MustCompile(`'([^']+)'::text`)
 
 // TestInteractionSourceCheck_AgreesWithDescriptorAndConstants is the
-// live-DB half of #342 Decision 1. It parses the actual
-// interaction_source_check membership from the running PostgreSQL via
+// live-DB half of the interaction.source agreement: the CHECK constraint
+// is kept (not migrated to a lookup table), so this test pins it. It
+// parses the actual interaction_source_check membership from the running
+// PostgreSQL via
 // pg_get_constraintdef and asserts, set-for-set:
 //
 //	live CHECK set  ==  all repository.InteractionSource* constants

--- a/backend/tests/interaction_source_descriptor_check_test.go
+++ b/backend/tests/interaction_source_descriptor_check_test.go
@@ -1,0 +1,163 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"regexp"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// checkDefShapeRe asserts the rendered constraint is the expected
+// `source = ANY (ARRAY[...]::text)` form. PostgreSQL 16 renders an
+// IN (...) CHECK this way; if a future PG ever renders it as IN (...)
+// the test fails loudly here rather than silently mis-parsing.
+var checkDefShapeRe = regexp.MustCompile(`source = ANY \(ARRAY\[.*\]\)`)
+
+// checkDefLiteralRe extracts each quoted source literal from the rendered
+// ARRAY[...] — every element is `'value'::text`.
+var checkDefLiteralRe = regexp.MustCompile(`'([^']+)'::text`)
+
+// TestInteractionSourceCheck_AgreesWithDescriptorAndConstants is the
+// live-DB half of #342 Decision 1. It parses the actual
+// interaction_source_check membership from the running PostgreSQL via
+// pg_get_constraintdef and asserts, set-for-set:
+//
+//	live CHECK set  ==  all repository.InteractionSource* constants
+//
+// in BOTH directions (a constant missing from the DB enum AND an
+// accidental DB widening beyond the constants both fail), then asserts
+// every daemon-push family that writes interactions carries an
+// interactionSource present in the live CHECK set. Closes the loop three
+// ways: descriptor ↔ Go constants ↔ live DB CHECK.
+func TestInteractionSourceCheck_AgreesWithDescriptorAndConstants(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set")
+	}
+	ctx := context.Background()
+
+	// CI runs against a bare PostgreSQL — run migrations before opening
+	// the pool so the interaction table + its CHECK exist. (TestMain in
+	// this package also runs them; this is idempotent and keeps the test
+	// self-contained.)
+	require.NoError(t, db.RunMigrations(ctx, databaseURL, getMigrationsPath()))
+
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	defer database.Close()
+
+	interactionRepo := repository.NewInteractionRepository(database.Queries)
+
+	// --- Parse the live CHECK membership. ---
+	def, err := interactionRepo.GetInteractionSourceCheckDef(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, def, "interaction_source_check definition must be non-empty")
+	require.Regexp(t, checkDefShapeRe, def,
+		"unexpected CHECK render shape (parser expects source = ANY (ARRAY[...])): %q", def)
+
+	matches := checkDefLiteralRe.FindAllStringSubmatch(def, -1)
+	require.NotEmpty(t, matches, "expected at least one quoted source literal in: %q", def)
+	liveSet := make(map[string]struct{}, len(matches))
+	for _, m := range matches {
+		liveSet[m[1]] = struct{}{}
+	}
+
+	// --- Assert live set == all 7 InteractionSource* constants (both
+	// directions). ---
+	allConstants := []string{
+		repository.InteractionSourceManual,
+		repository.InteractionSourceGCal,
+		repository.InteractionSourceTodoist,
+		repository.InteractionSourceTelegram,
+		repository.InteractionSourceMessages,
+		repository.InteractionSourceAnarlogSessions,
+		repository.InteractionSourcePhoneCalls,
+	}
+	constantSet := make(map[string]struct{}, len(allConstants))
+	for _, c := range allConstants {
+		constantSet[c] = struct{}{}
+	}
+	for c := range constantSet {
+		_, ok := liveSet[c]
+		assert.Truef(t, ok, "InteractionSource* constant %q missing from live CHECK set", c)
+	}
+	for s := range liveSet {
+		_, ok := constantSet[s]
+		assert.Truef(t, ok, "live CHECK source %q has no matching InteractionSource* constant (DB widened?)", s)
+	}
+
+	// --- Assert every push family that writes interactions carries an
+	// interactionSource present in the live CHECK set (descriptor → CHECK
+	// link). Read through the PRODUCTION accessor — backend/tests links
+	// the production service archive and cannot see test-only exports. ---
+	for _, v := range service.DaemonFamilyViews() {
+		if !v.WritesInteractions {
+			continue
+		}
+		_, ok := liveSet[v.InteractionSource]
+		assert.Truef(t, ok,
+			"family %q interactionSource %q is not in the live interaction_source_check set",
+			v.Name, v.InteractionSource)
+	}
+}
+
+// TestInteractionSourceCheck_AcceptsPhoneCalls is a belt-and-suspenders
+// acceptance smoke-insert for one push source (phone_calls), reusing the
+// data-loss-guard cleanup convention from
+// interaction_source_messages_check_test.go: HARD-delete the seeded row
+// before closing the DB handle (soft-delete is insufficient — the
+// down-migration data-loss guard counts rows regardless of deleted_at).
+func TestInteractionSourceCheck_AcceptsPhoneCalls(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	defer database.Close()
+
+	interactionRepo := repository.NewInteractionRepository(database.Queries)
+	contactRepo := repository.NewContactRepository(database.Queries)
+
+	suffix := randomSuffix(t)
+	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
+		FullName: "Test PhoneCalls Source CHECK " + suffix,
+	})
+	require.NoError(t, err)
+	defer func() {
+		_ = interactionRepo.HardDeleteInteractionsBySourceRefPrefix(ctx, repository.InteractionSourcePhoneCalls, "phone-calls-test-%")
+		_ = contactRepo.SoftDeleteContact(ctx, contact.ID)
+	}()
+
+	ref := "phone-calls-test-" + suffix
+	interaction, err := interactionRepo.CreateInteraction(ctx, repository.CreateInteractionRequest{
+		ContactID:  contact.ID,
+		Source:     repository.InteractionSourcePhoneCalls,
+		SourceRef:  &ref,
+		OccurredAt: accelerated.GetCurrentTime().Truncate(time.Microsecond),
+		Direction:  repository.InteractionDirectionInbound,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, repository.InteractionSourcePhoneCalls, interaction.Source)
+}

--- a/scripts/check-ingest-registry.sh
+++ b/scripts/check-ingest-registry.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# check-ingest-registry.sh — grep guard for #342's descriptor table.
+# check-ingest-registry.sh — grep guard for the daemonFamily descriptor
+# table.
 #
 # Enforces that the IngestBatch function body in
 # backend/internal/service/ingest.go routes EVERY daemon-push kind

--- a/scripts/check-ingest-registry.sh
+++ b/scripts/check-ingest-registry.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# check-ingest-registry.sh — grep guard for #342's descriptor table.
+#
+# Enforces that the IngestBatch function body in
+# backend/internal/service/ingest.go routes EVERY daemon-push kind
+# through the daemonFamily descriptor table (kindToFamily lookups) and
+# never re-introduces a parallel routing seam. The body must contain:
+#   (a) no events.Kind* constant references (events\.Kind[A-Z]);
+#   (b) no dotted kind string literals (double-quoted OR backtick-raw),
+#       e.g. "raw_message.received" / `call.sent`;
+#   (c) no legacy per-family predicate calls
+#       (isRawMessageKind / isExternalContactKind / isMeetingNoteKind /
+#        isCallKind) — these were deleted in favor of kindToFamily and
+#        must not come back as a parallel routing path.
+#
+# Scope is ONLY the IngestBatch body (between its signature line and its
+# lone top-level closing brace). Handler/verifier functions OUTSIDE
+# IngestBatch legitimately name kinds (e.g. handleRawMessage's IsOutgoing,
+# the verify switches, shouldRunInlineOnDuplicate) and are NOT scanned.
+#
+# New routing must go through ingest_registry.go's descriptor table; see
+# .ai/patterns/sync.md "Daemon event families".
+#
+# Exits 0 when the IngestBatch body is kind-reference-free, 1 otherwise.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+TARGET="backend/internal/service/ingest.go"
+
+if [[ ! -f "$TARGET" ]]; then
+  echo "❌ ingest-registry guard: $TARGET not found" >&2
+  exit 1
+fi
+
+# Extract the IngestBatch body: from the function signature line through
+# its lone top-level closing brace (a `}` at column 0). Inner braces are
+# indented, so `^}$` matches only the function's own close.
+BODY=$(awk '
+  /^func \(s \*IngestService\) IngestBatch\(/ { f = 1 }
+  f { print }
+  f && /^}$/ { exit }
+' "$TARGET")
+
+if [[ -z "$BODY" ]]; then
+  echo "❌ ingest-registry guard: could not locate the IngestBatch function body in $TARGET" >&2
+  echo "   (the awk region extractor keys on 'func (s *IngestService) IngestBatch(' and the" >&2
+  echo "   function's lone top-level closing brace — check that signature/format is intact)" >&2
+  exit 1
+fi
+
+# Three forbidden patterns, scoped to the extracted body.
+CONST_PATTERN='events\.Kind[A-Z]'
+LITERAL_PATTERN='["`](raw_message|external_contact|meeting_note|call|message|task|calendar|interaction|contact_methods)\.[a-z_]+'
+PREDICATE_PATTERN='\b(isRawMessageKind|isExternalContactKind|isMeetingNoteKind|isCallKind)\b'
+
+COMBINED="${CONST_PATTERN}|${LITERAL_PATTERN}|${PREDICATE_PATTERN}"
+
+HITS=$(printf '%s\n' "$BODY" | grep -nE "$COMBINED" || true)
+
+if [[ -n "$HITS" ]]; then
+  echo "❌ ingest-registry guard: kind reference(s) found inside the IngestBatch body:" >&2
+  printf '%s\n' "$HITS" | sed 's/^/   /' >&2
+  echo >&2
+  echo "IngestBatch routing must go through the daemonFamily descriptor table" >&2
+  echo "(kindToFamily lookups in backend/internal/service/ingest_registry.go)." >&2
+  echo "Do NOT name event kinds, dotted kind literals, or per-family predicates" >&2
+  echo "in the IngestBatch body. See .ai/patterns/sync.md 'Daemon event families'." >&2
+  exit 1
+fi
+
+echo "✓ ingest-registry guard: IngestBatch body is kind-reference-free"

--- a/scripts/check-ingest-registry.sh
+++ b/scripts/check-ingest-registry.sh
@@ -27,7 +27,12 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-TARGET="backend/internal/service/ingest.go"
+# Target defaults to the production ingest.go. An optional first argument
+# overrides it so the companion self-test
+# (backend/tests/ingest_registry_guard_static_test.go) can point the guard
+# at a synthetic fixture and confirm it actually catches a violation.
+# Production callers (Makefile, CI) pass no argument.
+TARGET="${1:-backend/internal/service/ingest.go}"
 
 if [[ ! -f "$TARGET" ]]; then
   echo "❌ ingest-registry guard: $TARGET not found" >&2


### PR DESCRIPTION
## Summary

Behavior-preserving refactor consolidating the "add a daemon push source" ritual behind one `daemonFamily` SourceDescriptor table.

Previously, adding a push-data source meant editing the host-auth allowlist, four per-family `isXKind` predicates, the per-family invariant-routing chain, the inline-dispatch switch, and three per-family source-allowlist vars (plus one inline literal) — all scattered across `ingest.go`/`ingest_call.go`, with no mechanical check that the parallel lists stayed in sync. This PR centralizes that contract.

### What changed

- **One descriptor table** (`backend/internal/service/ingest_registry.go`): a `daemonFamily` entry per family (`raw_message`, `external_contact`, `meeting_note`, `call`) owns the kinds, the allowed envelope-source set, the provider-stub subset, the interaction-source value, the invariant verifier, and the inline dispatch handler. Built once at init into a `kindToFamily` index.
- **Dispatch collapsed to lookups**: `IngestBatch` Step-2 (invariant routing) and Step-5 (inline dispatch) are now single `kindToFamily[env.Kind]` lookups instead of predicate chains and a 6-arm switch. The per-event bookkeeping (pendingAggregate for raw_message, needs-attention + follow-up closures for meeting_note, post-commit closures for call, rollback-on-rejection) is preserved verbatim.
- **Derived predicates**: `isHostOnlyKind` is now derived (a kind is host-only iff it has a `kindToFamily` entry); the four `isRawMessageKind`/`isExternalContactKind`/`isMeetingNoteKind`/`isCallKind` predicates and the `hostAuthAllowedKinds` map are removed. The four verifiers read their allowed-source set from the descriptor instead of package vars / an inline literal.
- **Cycle-safe push registration**: a new leaf package `backend/internal/push` exposes `RegisterPushProviders(reg)` (importing the three provider packages + `sync`); `main.go` calls it once. The descriptor table lives in `service` (its handlers are `*IngestService` methods), and a production `service.DaemonFamilyViews()` read-only accessor lets external test packages read it without inverting the import graph (`messages` already imports `service`, so the helper cannot live in `service`).
- **Mechanical prevention** (the point of the refactor):
  - `TestDaemonFamilies_AgreeWithRegistries` (`package service_test`) asserts the descriptor set-for-set (and per-family mapping-for-mapping) against `events.AllKinds` / `kindPayloadTypes`, `mac.AllowedPushSources`, the `repository.InteractionSource*` constants, and the push provider registry built by `push.RegisterPushProviders`.
  - `TestInteractionSourceCheck_AgreesWithDescriptorAndConstants` (live-DB) parses the actual `interaction_source_check` via `pg_get_constraintdef` and asserts it equals the `InteractionSource*` constants set-for-set (both directions — catches a missing constant AND a DB widening), and that every interaction-writing family's source is in it.
  - A grep guard (`scripts/check-ingest-registry.sh`, wired into `make lint` + `make ci-test` + a CI step) bans stray `events.Kind*` constants, dotted kind string literals, and per-family predicate calls inside the `IngestBatch` body — routing must go through the descriptor table. A companion self-test (`backend/tests/ingest_registry_guard_static_test.go`) runs the real script against synthetic fixtures to prove it catches each form and is scoped to the body.
- **Docs**: `.ai/patterns/sync.md` refreshed — provider table now lists `phone_calls`, documents the descriptor table, the agreement tests, and the guard.

### Deliberate non-changes (decisions)

- **The `interaction.source` SQL CHECK is KEPT** (no schema migration). It mixes daemon-push and Pi-internal sources (`manual`/`gcal`/`todoist`/`telegram`) and omits two push sources that never write interactions — a different concern from the push-source registry, so it is cross-checked by the agreement test rather than migrated to a descriptor-driven lookup table. (User-approved decision.)
- **The `messages` / `icloudcontacts` provider stubs are intentionally kept** (not deleted). They carry real `SourceConfig` and back the scheduler's push-strategy exclusion + the `/api/v1/sync/providers` ground-truth list; only their registration moved into the extracted helper. The `anarlog_*` push sources have no stub by design.

This is behavior-preserving: ingest dispatch, validation, the host-auth allowlist, and the source map are identical before/after. The existing ingest integration tests under `backend/tests/api/` pass unchanged.

## Test plan

- `make test-unit` — green (incl. the new agreement test + grep-guard self-test).
- `make test-integration` — green on a clean DB (incl. the new live-DB CHECK agreement test).
- `make lint` — green, incl. the new `lint-ingest-registry` grep guard.
- `go build ./...` + `go vet ./...` — clean.

## Known non-blocking follow-ups (review-head P2/P3)

1. The live-DB CHECK test can be `go test`-cached when only DB state changes between runs (harmless in CI, which runs against a fresh DB).
2. Two unreachable defensive `default` arms in the dispatch wrappers (`external_contact` / `meeting_note`) — kept as belt-and-suspenders since the verifier already constrains the kind set.
3. A Makefile comment still cites the issue number (should be stripped per the repo's no-PR-scaffolding-in-source convention).
4. A stale "kind-classifier helper" doc comment on a renamed routing test.

Closes #342
