### PR TITLE
test(db): lint + regression guard against duplicated SELECT column lists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,9 @@ jobs:
       - name: Check CRM-marker construction invariant
         run: ./scripts/ci/crm-marker-construction-guard.sh
 
+      - name: Check sqlc SELECT-list duplication invariant
+        run: ./scripts/ci/sqlc-select-list-guard.sh
+
       - name: Check ingest-registry descriptor invariant
         run: ./scripts/check-ingest-registry.sh
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Personal CRM Makefile
 
-.PHONY: help setup dev build crm-admin mac-daemon test test-daemon-local clean docker-up docker-down docker-reset test-cadence-ultra test-cadence-fast prod staging testing start start-local stop restart reload status dev-stop dev-restart dev-api-stop dev-api-start dev-api-restart ci-build-backend ci-build-frontend ci-build ci-test test-e2e test-e2e-local test-e2e-diff e2e-db deploy deploy-pi deploy-mac deploy-all setup-pi dev-native postgres-native sqlc smoke-test test-integration-fast test-integration-slow test-mac-host-migrations check-cadence-sole-writer check-followup-sole-writer check-rematch-sole-dispatcher check-crm-marker-construction lint-ingest-registry
+.PHONY: help setup dev build crm-admin mac-daemon test test-daemon-local clean docker-up docker-down docker-reset test-cadence-ultra test-cadence-fast prod staging testing start start-local stop restart reload status dev-stop dev-restart dev-api-stop dev-api-start dev-api-restart ci-build-backend ci-build-frontend ci-build ci-test test-e2e test-e2e-local test-e2e-diff e2e-db deploy deploy-pi deploy-mac deploy-all setup-pi dev-native postgres-native sqlc smoke-test test-integration-fast test-integration-slow test-mac-host-migrations check-cadence-sole-writer check-followup-sole-writer check-rematch-sole-dispatcher check-crm-marker-construction check-sqlc-select-lists lint-ingest-registry
 
 # Repo root (supports running make from subdirectories).
 REPO_ROOT := $(shell git rev-parse --show-toplevel)
@@ -367,7 +367,7 @@ lint-fix:
 lint-ingest-registry:
 	@$(REPO_ROOT)/scripts/check-ingest-registry.sh
 
-ci-test: lint check-cadence-sole-writer check-followup-sole-writer check-rematch-sole-dispatcher check-crm-marker-construction test-unit test-integration-fast test-frontend
+ci-test: lint check-cadence-sole-writer check-followup-sole-writer check-rematch-sole-dispatcher check-crm-marker-construction check-sqlc-select-lists test-unit test-integration-fast test-frontend
 	@echo "✅ All CI tests passed"
 
 # Sole-writer guard: verifies only CadenceUpdater calls cadence-writing queries.
@@ -397,6 +397,14 @@ check-rematch-sole-dispatcher:
 # scripts/ci/crm-marker-construction-guard.sh.
 check-crm-marker-construction:
 	@$(REPO_ROOT)/scripts/ci/crm-marker-construction-guard.sh
+
+# Duplicated-SELECT-list guard: fails if an identical explicit >=3-column
+# SELECT projection of the same table appears in 2+ source queries (use
+# SELECT * for full-row reads). Runs alongside the Go test at
+# backend/tests/sqlc_select_list_static_test.go (authoritative parser). See
+# scripts/ci/sqlc-select-list-guard.sh.
+check-sqlc-select-lists:
+	@$(REPO_ROOT)/scripts/ci/sqlc-select-list-guard.sh
 
 # Code generation
 sqlc:

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -551,6 +551,10 @@ type Querier interface {
 	GetTelegramChannelState(ctx context.Context, channelID int64) (*TelegramChannelState, error)
 	GetTelegramChatConfig(ctx context.Context, telegramChatID int64) (*TelegramChatConfig, error)
 	GetTelegramMessage(ctx context.Context, arg GetTelegramMessageParams) (*TelegramMessage, error)
+	// Test-only: fetches a row by id WITHOUT the deleted_at IS NULL filter, so the
+	// all-fields-populated test can read back a row whose deleted_at is set.
+	// Production code MUST NOT call this (it would return soft-deleted rows).
+	GetTelegramMessageByIDForTest(ctx context.Context, id pgtype.UUID) (*TelegramMessage, error)
 	GetTelegramSession(ctx context.Context) (*TelegramSession, error)
 	GetTelegramUpdateState(ctx context.Context, userID int64) (*TelegramUpdateState, error)
 	// Probe used by the dispatch loop's revive-bypass: when a duplicate
@@ -619,6 +623,13 @@ type Querier interface {
 	// already holds the claim. Callers treat 0 as "someone else wrote this
 	// event; return nil without mutating state".
 	InsertEventConsumerClaim(ctx context.Context, arg InsertEventConsumerClaimParams) (int64, error)
+	// Test-only: inserts a telegram_message row with EVERY column explicitly set
+	// (including the system-managed columns UpsertTelegramMessage leaves NULL:
+	// matched_contact_id, interaction_id, processed_at, deleted_at, claimed_at,
+	// claimed_session_ref). Used by the all-fields-populated regression test so a
+	// future explicit SELECT list that drops a column is caught by a non-zero read.
+	// Production code MUST NOT call this.
+	InsertFullTelegramMessageForTest(ctx context.Context, arg InsertFullTelegramMessageForTestParams) (*TelegramMessage, error)
 	// First-commit insert path. ON CONFLICT DO NOTHING handles the
 	// concurrent-first-write race: the loser gets zero rows, re-reads the
 	// now-committed state, and surfaces ErrCursorBaseMismatch with the

--- a/backend/internal/db/queries/telegram_message.sql
+++ b/backend/internal/db/queries/telegram_message.sql
@@ -297,3 +297,33 @@ WHERE peer_user_id = @peer_user_id
 DELETE FROM telegram_message
 WHERE telegram_chat_id >= sqlc.arg(lo)
   AND telegram_chat_id <= sqlc.arg(hi);
+
+-- name: InsertFullTelegramMessageForTest :one
+-- Test-only: inserts a telegram_message row with EVERY column explicitly set
+-- (including the system-managed columns UpsertTelegramMessage leaves NULL:
+-- matched_contact_id, interaction_id, processed_at, deleted_at, claimed_at,
+-- claimed_session_ref). Used by the all-fields-populated regression test so a
+-- future explicit SELECT list that drops a column is caught by a non-zero read.
+-- Production code MUST NOT call this.
+INSERT INTO telegram_message (
+    telegram_message_id, telegram_chat_id, chat_type, chat_title,
+    message_text, message_type, sent_at, edited_at, is_outgoing,
+    reply_to_msg_id, peer_user_id, peer_username, peer_first_name,
+    peer_last_name, peer_phone, matched_contact_id, interaction_id,
+    processed_at, deleted_at, peer_entity_resolved, claimed_at,
+    claimed_session_ref
+) VALUES (
+    @telegram_message_id, @telegram_chat_id, @chat_type, @chat_title,
+    @message_text, @message_type, @sent_at, @edited_at, @is_outgoing,
+    @reply_to_msg_id, @peer_user_id, @peer_username, @peer_first_name,
+    @peer_last_name, @peer_phone, @matched_contact_id, @interaction_id,
+    @processed_at, @deleted_at, @peer_entity_resolved, @claimed_at,
+    @claimed_session_ref
+)
+RETURNING *;
+
+-- name: GetTelegramMessageByIDForTest :one
+-- Test-only: fetches a row by id WITHOUT the deleted_at IS NULL filter, so the
+-- all-fields-populated test can read back a row whose deleted_at is set.
+-- Production code MUST NOT call this (it would return soft-deleted rows).
+SELECT * FROM telegram_message WHERE id = @id;

--- a/backend/internal/db/telegram_message.sql.go
+++ b/backend/internal/db/telegram_message.sql.go
@@ -394,6 +394,45 @@ func (q *Queries) GetTelegramMessage(ctx context.Context, arg GetTelegramMessage
 	return &i, err
 }
 
+const GetTelegramMessageByIDForTest = `-- name: GetTelegramMessageByIDForTest :one
+SELECT id, telegram_message_id, telegram_chat_id, chat_type, chat_title, message_text, message_type, sent_at, edited_at, is_outgoing, reply_to_msg_id, peer_user_id, peer_username, peer_first_name, peer_last_name, peer_phone, matched_contact_id, interaction_id, processed_at, deleted_at, created_at, peer_entity_resolved, claimed_at, claimed_session_ref FROM telegram_message WHERE id = $1
+`
+
+// Test-only: fetches a row by id WITHOUT the deleted_at IS NULL filter, so the
+// all-fields-populated test can read back a row whose deleted_at is set.
+// Production code MUST NOT call this (it would return soft-deleted rows).
+func (q *Queries) GetTelegramMessageByIDForTest(ctx context.Context, id pgtype.UUID) (*TelegramMessage, error) {
+	row := q.db.QueryRow(ctx, GetTelegramMessageByIDForTest, id)
+	var i TelegramMessage
+	err := row.Scan(
+		&i.ID,
+		&i.TelegramMessageID,
+		&i.TelegramChatID,
+		&i.ChatType,
+		&i.ChatTitle,
+		&i.MessageText,
+		&i.MessageType,
+		&i.SentAt,
+		&i.EditedAt,
+		&i.IsOutgoing,
+		&i.ReplyToMsgID,
+		&i.PeerUserID,
+		&i.PeerUsername,
+		&i.PeerFirstName,
+		&i.PeerLastName,
+		&i.PeerPhone,
+		&i.MatchedContactID,
+		&i.InteractionID,
+		&i.ProcessedAt,
+		&i.DeletedAt,
+		&i.CreatedAt,
+		&i.PeerEntityResolved,
+		&i.ClaimedAt,
+		&i.ClaimedSessionRef,
+	)
+	return &i, err
+}
+
 const HardDeleteTelegramMessagesByChatIDRange = `-- name: HardDeleteTelegramMessagesByChatIDRange :exec
 
 DELETE FROM telegram_message
@@ -416,6 +455,111 @@ type HardDeleteTelegramMessagesByChatIDRangeParams struct {
 func (q *Queries) HardDeleteTelegramMessagesByChatIDRange(ctx context.Context, arg HardDeleteTelegramMessagesByChatIDRangeParams) error {
 	_, err := q.db.Exec(ctx, HardDeleteTelegramMessagesByChatIDRange, arg.Lo, arg.Hi)
 	return err
+}
+
+const InsertFullTelegramMessageForTest = `-- name: InsertFullTelegramMessageForTest :one
+INSERT INTO telegram_message (
+    telegram_message_id, telegram_chat_id, chat_type, chat_title,
+    message_text, message_type, sent_at, edited_at, is_outgoing,
+    reply_to_msg_id, peer_user_id, peer_username, peer_first_name,
+    peer_last_name, peer_phone, matched_contact_id, interaction_id,
+    processed_at, deleted_at, peer_entity_resolved, claimed_at,
+    claimed_session_ref
+) VALUES (
+    $1, $2, $3, $4,
+    $5, $6, $7, $8, $9,
+    $10, $11, $12, $13,
+    $14, $15, $16, $17,
+    $18, $19, $20, $21,
+    $22
+)
+RETURNING id, telegram_message_id, telegram_chat_id, chat_type, chat_title, message_text, message_type, sent_at, edited_at, is_outgoing, reply_to_msg_id, peer_user_id, peer_username, peer_first_name, peer_last_name, peer_phone, matched_contact_id, interaction_id, processed_at, deleted_at, created_at, peer_entity_resolved, claimed_at, claimed_session_ref
+`
+
+type InsertFullTelegramMessageForTestParams struct {
+	TelegramMessageID  int32              `json:"telegram_message_id"`
+	TelegramChatID     int64              `json:"telegram_chat_id"`
+	ChatType           string             `json:"chat_type"`
+	ChatTitle          pgtype.Text        `json:"chat_title"`
+	MessageText        pgtype.Text        `json:"message_text"`
+	MessageType        string             `json:"message_type"`
+	SentAt             pgtype.Timestamptz `json:"sent_at"`
+	EditedAt           pgtype.Timestamptz `json:"edited_at"`
+	IsOutgoing         bool               `json:"is_outgoing"`
+	ReplyToMsgID       pgtype.Int4        `json:"reply_to_msg_id"`
+	PeerUserID         pgtype.Int8        `json:"peer_user_id"`
+	PeerUsername       pgtype.Text        `json:"peer_username"`
+	PeerFirstName      pgtype.Text        `json:"peer_first_name"`
+	PeerLastName       pgtype.Text        `json:"peer_last_name"`
+	PeerPhone          pgtype.Text        `json:"peer_phone"`
+	MatchedContactID   pgtype.UUID        `json:"matched_contact_id"`
+	InteractionID      pgtype.UUID        `json:"interaction_id"`
+	ProcessedAt        pgtype.Timestamptz `json:"processed_at"`
+	DeletedAt          pgtype.Timestamptz `json:"deleted_at"`
+	PeerEntityResolved bool               `json:"peer_entity_resolved"`
+	ClaimedAt          pgtype.Timestamptz `json:"claimed_at"`
+	ClaimedSessionRef  pgtype.Text        `json:"claimed_session_ref"`
+}
+
+// Test-only: inserts a telegram_message row with EVERY column explicitly set
+// (including the system-managed columns UpsertTelegramMessage leaves NULL:
+// matched_contact_id, interaction_id, processed_at, deleted_at, claimed_at,
+// claimed_session_ref). Used by the all-fields-populated regression test so a
+// future explicit SELECT list that drops a column is caught by a non-zero read.
+// Production code MUST NOT call this.
+func (q *Queries) InsertFullTelegramMessageForTest(ctx context.Context, arg InsertFullTelegramMessageForTestParams) (*TelegramMessage, error) {
+	row := q.db.QueryRow(ctx, InsertFullTelegramMessageForTest,
+		arg.TelegramMessageID,
+		arg.TelegramChatID,
+		arg.ChatType,
+		arg.ChatTitle,
+		arg.MessageText,
+		arg.MessageType,
+		arg.SentAt,
+		arg.EditedAt,
+		arg.IsOutgoing,
+		arg.ReplyToMsgID,
+		arg.PeerUserID,
+		arg.PeerUsername,
+		arg.PeerFirstName,
+		arg.PeerLastName,
+		arg.PeerPhone,
+		arg.MatchedContactID,
+		arg.InteractionID,
+		arg.ProcessedAt,
+		arg.DeletedAt,
+		arg.PeerEntityResolved,
+		arg.ClaimedAt,
+		arg.ClaimedSessionRef,
+	)
+	var i TelegramMessage
+	err := row.Scan(
+		&i.ID,
+		&i.TelegramMessageID,
+		&i.TelegramChatID,
+		&i.ChatType,
+		&i.ChatTitle,
+		&i.MessageText,
+		&i.MessageType,
+		&i.SentAt,
+		&i.EditedAt,
+		&i.IsOutgoing,
+		&i.ReplyToMsgID,
+		&i.PeerUserID,
+		&i.PeerUsername,
+		&i.PeerFirstName,
+		&i.PeerLastName,
+		&i.PeerPhone,
+		&i.MatchedContactID,
+		&i.InteractionID,
+		&i.ProcessedAt,
+		&i.DeletedAt,
+		&i.CreatedAt,
+		&i.PeerEntityResolved,
+		&i.ClaimedAt,
+		&i.ClaimedSessionRef,
+	)
+	return &i, err
 }
 
 const ListDistinctUnmatchedPeers = `-- name: ListDistinctUnmatchedPeers :many

--- a/backend/tests/sqlc_select_list_static_test.go
+++ b/backend/tests/sqlc_select_list_static_test.go
@@ -1,0 +1,411 @@
+// Package tests — sqlc source-SQL projection-duplication lint.
+//
+// Enforces the convention that full-row reads use SELECT * rather than a
+// hand-maintained explicit column list. A repeated multi-column explicit
+// projection of the same table is the duplication smell this lints against:
+// it means humans are maintaining parallel column lists by hand, and adding a
+// column requires editing every copy in lockstep (the exact maintenance cost
+// the convention eliminates). SELECT * delegates that expansion to sqlc's
+// codegen, so a new column flows to every full-row query for free.
+//
+// Scope: this analyzer reads ONLY the SOURCE query files in
+// backend/internal/db/queries/*.sql — never the generated *.sql.go. sqlc
+// expands SELECT * into a flat explicit column list at codegen time, so the
+// generated files are full of identical column lists that are harmless
+// auto-generated output. Humans edit the .sql source; that is where the
+// duplication cost lives and where the lint belongs.
+//
+// What trips it: an identical explicit (non-*) SELECT projection of N >= 3
+// columns of the same table appearing in 2+ queries, unless allowlisted. A
+// single explicit projection is fine (a genuine one-off narrow projection).
+//
+// Limitation (v1): only the outermost/first SELECT projection of each query is
+// considered; projections inside subqueries/CTEs are out of scope. The
+// companion integration test (telegram_message_all_fields_test.go) catches the
+// downstream consequence — a dropped column read back as zero — regardless of
+// how the SELECT was written, so the two layers are complementary.
+//
+// This is the Go counterpart (the authoritative parser) to the grep guard at
+// scripts/ci/sqlc-select-list-guard.sh, mirroring the belt-and-suspenders
+// convention of the sibling static guards.
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// allowedDuplicateProjections maps a duplicate-projection fingerprint to its
+// justification. A fingerprint is "<table>|<normalized-col-list>". Entries here
+// are deliberate narrow projections that legitimately repeat and must NOT be
+// converted to SELECT *.
+var allowedDuplicateProjections = map[string]string{
+	// GetOAuthCredentialStatus + ListOAuthCredentialStatuses deliberately omit
+	// the encrypted-token columns (access_token_encrypted,
+	// refresh_token_encrypted, encryption_nonce, token_type). Converting to
+	// SELECT * would start selecting secret material — a security regression.
+	"oauth_credential|account_id, account_name, created_at, expires_at, id, provider, scopes, updated_at": "intentional narrow projection excluding encrypted token columns; SELECT * would leak secrets",
+}
+
+// selectProjection holds one query's extracted SELECT projection.
+type selectProjection struct {
+	queryName string
+	file      string
+	table     string
+	// normalized is the column list with whitespace collapsed, lowercased, and
+	// columns sorted, so two lists with the same columns in a different order
+	// or spacing fingerprint identically.
+	normalized string
+	numColumns int
+}
+
+var (
+	// Splits a query block's leading marker line: "-- name: Foo :one".
+	queryNameRe = regexp.MustCompile(`(?m)^--\s*name:\s*(\S+)`)
+	// Captures the first SELECT ... FROM <table>. The projection is captured
+	// non-greedily up to the first top-level FROM; depth handling below rejects
+	// matches where the FROM was inside parentheses.
+	selectFromRe = regexp.MustCompile(`(?is)\bSELECT\b(.*?)\bFROM\b\s+([a-z_][a-z0-9_]*)`)
+)
+
+// TestNoDuplicatedFullRowSelectLists walks backend/internal/db/queries/*.sql,
+// extracts each query's top-level SELECT projection, and fails if any identical
+// explicit (non-*) >=3-column projection of the same table appears in 2+
+// queries unless allowlisted. Runs DB-free (pure file parsing) so it executes
+// under make test-unit and -short.
+func TestNoDuplicatedFullRowSelectLists(t *testing.T) {
+	moduleRoot, err := backendModuleRoot()
+	if err != nil {
+		t.Fatalf("locate backend module root: %v", err)
+	}
+	queriesDir := filepath.Join(moduleRoot, "internal", "db", "queries")
+
+	files, err := filepath.Glob(filepath.Join(queriesDir, "*.sql"))
+	if err != nil {
+		t.Fatalf("glob query files: %v", err)
+	}
+	if len(files) == 0 {
+		t.Fatalf("no .sql query files found under %s", queriesDir)
+	}
+	sort.Strings(files)
+
+	// fingerprint -> projections that share it.
+	byFingerprint := map[string][]selectProjection{}
+	for _, file := range files {
+		content, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		rel := filepath.Base(file)
+		for _, proj := range extractSelectProjections(rel, string(content)) {
+			if proj.numColumns < 3 {
+				continue
+			}
+			fp := proj.table + "|" + proj.normalized
+			byFingerprint[fp] = append(byFingerprint[fp], proj)
+		}
+	}
+
+	var violations []string
+	for fp, projs := range byFingerprint {
+		if len(projs) < 2 {
+			continue
+		}
+		if _, ok := allowedDuplicateProjections[fp]; ok {
+			continue
+		}
+		sort.Slice(projs, func(i, j int) bool {
+			if projs[i].file != projs[j].file {
+				return projs[i].file < projs[j].file
+			}
+			return projs[i].queryName < projs[j].queryName
+		})
+		names := make([]string, len(projs))
+		for i, p := range projs {
+			names[i] = p.file + ":" + p.queryName
+		}
+		violations = append(violations,
+			"  table "+projs[0].table+" — identical "+itoa(projs[0].numColumns)+
+				"-column explicit projection in: "+strings.Join(names, ", ")+
+				"\n    columns: "+projs[0].normalized)
+	}
+
+	if len(violations) > 0 {
+		sort.Strings(violations)
+		t.Fatalf("duplicated explicit SELECT column list(s) found in source SQL.\n"+
+			"Use SELECT * for full-row reads (sqlc expands it; adding a column needs no query edit),\n"+
+			"or, for a deliberate narrow projection, add a justified entry to allowedDuplicateProjections.\n\n%s",
+			strings.Join(violations, "\n"))
+	}
+}
+
+// extractSelectProjections splits the file into query blocks on -- name:
+// markers and extracts the top-level SELECT projection from each block whose
+// query is a SELECT. Blocks whose projection is *, DISTINCT ON, a bare
+// DISTINCT, aggregate-only, or a SELECT 1 existence probe are skipped (they are
+// not hand-maintained full-row column lists). Exported for the negative
+// self-test so the detector and its test can never drift.
+func extractSelectProjections(file, content string) []selectProjection {
+	markers := queryNameRe.FindAllStringSubmatchIndex(content, -1)
+	if len(markers) == 0 {
+		return nil
+	}
+	var out []selectProjection
+	for i, m := range markers {
+		name := content[m[2]:m[3]]
+		blockStart := m[0]
+		blockEnd := len(content)
+		if i+1 < len(markers) {
+			blockEnd = markers[i+1][0]
+		}
+		block := content[blockStart:blockEnd]
+		proj, ok := parseProjection(block)
+		if !ok {
+			continue
+		}
+		proj.queryName = name
+		proj.file = file
+		out = append(out, proj)
+	}
+	return out
+}
+
+// parseProjection extracts the top-level SELECT projection from a single query
+// block. Returns ok=false for blocks that are not a parseable full-row-style
+// explicit projection (non-SELECT, SELECT *, DISTINCT, aggregate-only,
+// existence probe, or a FROM nested inside parentheses).
+func parseProjection(block string) (selectProjection, bool) {
+	match := selectFromRe.FindStringSubmatch(block)
+	if match == nil {
+		return selectProjection{}, false
+	}
+	projection := strings.TrimSpace(match[1])
+	table := strings.ToLower(match[2])
+
+	// Reject when the captured SELECT...FROM straddles a parenthesis boundary
+	// (e.g. SELECT ... (SELECT x FROM y) ...): the projection segment must be
+	// balanced, otherwise the FROM we matched belongs to a subquery, not the
+	// outer SELECT.
+	if !parensBalanced(projection) {
+		return selectProjection{}, false
+	}
+
+	lower := strings.ToLower(projection)
+	switch {
+	case projection == "*":
+		return selectProjection{}, false
+	case strings.HasPrefix(lower, "distinct on"):
+		// DISTINCT ON (...) col, col — distinct-row reads, not a full-row list.
+		return selectProjection{}, false
+	case strings.HasPrefix(lower, "distinct"):
+		return selectProjection{}, false
+	case lower == "1" || lower == "1 ":
+		return selectProjection{}, false
+	}
+
+	cols := splitTopLevel(projection)
+	// An aggregate-only / expression projection (every term contains a call or
+	// is the bare * ) is not a hand-maintained column list. We only flag plain
+	// bare-identifier column lists; if any column is a bare identifier we still
+	// fingerprint, but skip if the projection has zero plain columns.
+	if !hasPlainColumn(cols) {
+		return selectProjection{}, false
+	}
+
+	normalized := normalizeColumns(cols)
+	return selectProjection{
+		table:      table,
+		normalized: normalized,
+		numColumns: len(cols),
+	}, true
+}
+
+// hasPlainColumn reports whether at least one column is a bare identifier
+// (no function call, no AS alias, no *). A projection consisting entirely of
+// aggregates/expressions (COUNT(*), MAX(x), ...) is not a column list.
+func hasPlainColumn(cols []string) bool {
+	for _, c := range cols {
+		c = strings.TrimSpace(strings.ToLower(c))
+		if c == "" || c == "*" {
+			continue
+		}
+		if strings.ContainsAny(c, "(") {
+			continue
+		}
+		if strings.Contains(c, " as ") {
+			continue
+		}
+		// A bare identifier (possibly schema-qualified) with no spaces.
+		if !strings.ContainsAny(c, " \t") {
+			return true
+		}
+	}
+	return false
+}
+
+// normalizeColumns lowercases, trims, and sorts the columns so two lists with
+// the same members fingerprint identically regardless of order or spacing.
+func normalizeColumns(cols []string) string {
+	norm := make([]string, 0, len(cols))
+	for _, c := range cols {
+		c = strings.TrimSpace(strings.ToLower(c))
+		c = strings.Join(strings.Fields(c), " ")
+		if c == "" {
+			continue
+		}
+		norm = append(norm, c)
+	}
+	sort.Strings(norm)
+	return strings.Join(norm, ", ")
+}
+
+// splitTopLevel splits a projection on commas that are not inside parentheses.
+func splitTopLevel(s string) []string {
+	var parts []string
+	depth := 0
+	start := 0
+	for i, r := range s {
+		switch r {
+		case '(':
+			depth++
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			if depth == 0 {
+				parts = append(parts, s[start:i])
+				start = i + 1
+			}
+		}
+	}
+	parts = append(parts, s[start:])
+	// Drop trailing empties.
+	out := parts[:0]
+	for _, p := range parts {
+		if strings.TrimSpace(p) != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// parensBalanced reports whether s has matched parentheses.
+func parensBalanced(s string) bool {
+	depth := 0
+	for _, r := range s {
+		switch r {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth < 0 {
+				return false
+			}
+		}
+	}
+	return depth == 0
+}
+
+// itoa is a tiny strconv.Itoa to keep the import list minimal.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}
+
+// TestSelectListDetector_FlagsSyntheticDuplicate feeds the SAME analyzer the
+// real test uses a synthetic file containing an identical 3-column explicit
+// projection in two queries, and asserts the detector reports both — proving
+// the detector is live (not a no-op). A second case proves SELECT * is NOT
+// flagged.
+func TestSelectListDetector_FlagsSyntheticDuplicate(t *testing.T) {
+	const dupSrc = `-- name: GetWidgetA :one
+SELECT alpha, beta, gamma FROM widget WHERE id = $1;
+
+-- name: GetWidgetB :one
+SELECT alpha, beta, gamma FROM widget WHERE name = $1;
+`
+	projs := extractSelectProjections("synthetic.sql", dupSrc)
+	if len(projs) != 2 {
+		t.Fatalf("expected 2 projections from synthetic duplicate, got %d: %+v", len(projs), projs)
+	}
+	fp := func(p selectProjection) string { return p.table + "|" + p.normalized }
+	if projs[0].numColumns != 3 {
+		t.Errorf("expected 3 columns, got %d", projs[0].numColumns)
+	}
+	if fp(projs[0]) != fp(projs[1]) {
+		t.Errorf("expected identical fingerprints, got %q vs %q", fp(projs[0]), fp(projs[1]))
+	}
+
+	const starSrc = `-- name: GetWidgetStarA :one
+SELECT * FROM widget WHERE id = $1;
+
+-- name: GetWidgetStarB :one
+SELECT * FROM widget WHERE name = $1;
+`
+	starProjs := extractSelectProjections("synthetic_star.sql", starSrc)
+	if len(starProjs) != 0 {
+		t.Errorf("SELECT * must not be extracted as an explicit projection, got %d: %+v", len(starProjs), starProjs)
+	}
+}
+
+// TestSelectListDetector_SkipsNonFullRowShapes asserts the shapes that must NOT
+// be flagged are correctly skipped: DISTINCT ON, aggregate-only, SELECT 1,
+// and single-occurrence narrow projections (a lone explicit projection is
+// fine; only 2+ identical ones are the smell).
+func TestSelectListDetector_SkipsNonFullRowShapes(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "distinct on",
+			src: `-- name: GetDistinct :many
+SELECT DISTINCT ON (peer_id) peer_id, a, b, c FROM widget;`,
+		},
+		{
+			name: "aggregate only",
+			src: `-- name: CountThings :one
+SELECT COUNT(*) as total, MAX(sent_at) as last, MIN(sent_at) as first FROM widget;`,
+		},
+		{
+			name: "existence probe",
+			src: `-- name: Probe :one
+SELECT 1 FROM widget WHERE id = $1;`,
+		},
+		{
+			name: "star",
+			src: `-- name: GetAll :one
+SELECT * FROM widget WHERE id = $1;`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			projs := extractSelectProjections("synthetic.sql", tc.src)
+			if len(projs) != 0 {
+				t.Errorf("%s must be skipped, but detector extracted: %+v", tc.name, projs)
+			}
+		})
+	}
+}

--- a/backend/tests/sqlc_select_list_static_test.go
+++ b/backend/tests/sqlc_select_list_static_test.go
@@ -66,10 +66,8 @@ type selectProjection struct {
 var (
 	// Splits a query block's leading marker line: "-- name: Foo :one".
 	queryNameRe = regexp.MustCompile(`(?m)^--\s*name:\s*(\S+)`)
-	// Captures the first SELECT ... FROM <table>. The projection is captured
-	// non-greedily up to the first top-level FROM; depth handling below rejects
-	// matches where the FROM was inside parentheses.
-	selectFromRe = regexp.MustCompile(`(?is)\bSELECT\b(.*?)\bFROM\b\s+([a-z_][a-z0-9_]*)`)
+	// Matches the table identifier immediately after a FROM keyword.
+	tableNameRe = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*`)
 )
 
 // TestNoDuplicatedFullRowSelectLists walks backend/internal/db/queries/*.sql,
@@ -174,25 +172,41 @@ func extractSelectProjections(file, content string) []selectProjection {
 	return out
 }
 
-// parseProjection extracts the top-level SELECT projection from a single query
-// block. Returns ok=false for blocks that are not a parseable full-row-style
-// explicit projection (non-SELECT, SELECT *, DISTINCT, aggregate-only,
-// existence probe, or a FROM nested inside parentheses).
+// parseProjection extracts the OUTERMOST (top-level) SELECT projection from a
+// single query block. CTEs (WITH ... AS (SELECT ...)) and subqueries are
+// nested inside parentheses, so their SELECTs sit at paren-depth >= 1; the main
+// query's SELECT is the first SELECT keyword at depth 0. We scan to that SELECT
+// (so WITH queries are checked at their real outer projection, not skipped),
+// then capture the projection up to the matching top-level FROM. Returns
+// ok=false for blocks that are not a parseable full-row-style explicit
+// projection (non-SELECT, SELECT *, DISTINCT, aggregate-only, existence probe,
+// or a query with no top-level FROM).
 func parseProjection(block string) (selectProjection, bool) {
-	match := selectFromRe.FindStringSubmatch(block)
-	if match == nil {
-		return selectProjection{}, false
-	}
-	projection := strings.TrimSpace(match[1])
-	table := strings.ToLower(match[2])
+	// Strip line comments so the -- name: marker and inline comments don't
+	// confuse keyword scanning. Comments run to end of line.
+	clean := stripLineComments(block)
 
-	// Reject when the captured SELECT...FROM straddles a parenthesis boundary
-	// (e.g. SELECT ... (SELECT x FROM y) ...): the projection segment must be
-	// balanced, otherwise the FROM we matched belongs to a subquery, not the
-	// outer SELECT.
-	if !parensBalanced(projection) {
+	selStart, ok := findTopLevelKeyword(clean, "select", 0)
+	if !ok {
 		return selectProjection{}, false
 	}
+	afterSelect := selStart + len("select")
+
+	fromStart, ok := findTopLevelKeyword(clean, "from", afterSelect)
+	if !ok {
+		// No top-level FROM (e.g. SELECT without FROM) — nothing to fingerprint.
+		return selectProjection{}, false
+	}
+
+	projection := strings.TrimSpace(clean[afterSelect:fromStart])
+
+	// Read the table identifier after FROM.
+	afterFrom := strings.TrimLeft(clean[fromStart+len("from"):], " \t\n")
+	tableMatch := tableNameRe.FindString(afterFrom)
+	if tableMatch == "" {
+		return selectProjection{}, false
+	}
+	table := strings.ToLower(tableMatch)
 
 	lower := strings.ToLower(projection)
 	switch {
@@ -294,21 +308,70 @@ func splitTopLevel(s string) []string {
 	return out
 }
 
-// parensBalanced reports whether s has matched parentheses.
-func parensBalanced(s string) bool {
+// stripLineComments removes -- line comments (the comment runs to end of
+// line). String literals in these query files do not contain "--", so a naive
+// strip is safe and keeps keyword scanning from tripping over the -- name:
+// marker and inline comments.
+func stripLineComments(s string) string {
+	var b strings.Builder
+	for _, line := range strings.Split(s, "\n") {
+		if idx := strings.Index(line, "--"); idx >= 0 {
+			line = line[:idx]
+		}
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+// findTopLevelKeyword returns the byte index of the first occurrence of the
+// (lowercase) SQL keyword at paren-depth 0 at or after start, matched
+// case-insensitively and bounded by non-identifier characters. Depth-0 scoping
+// is what lets the analyzer skip CTE/subquery SELECTs (which sit inside
+// parentheses) and find the main query's outer SELECT/FROM.
+func findTopLevelKeyword(s, keyword string, start int) (int, bool) {
 	depth := 0
-	for _, r := range s {
-		switch r {
+	lower := strings.ToLower(s)
+	for i := start; i < len(s); i++ {
+		switch s[i] {
 		case '(':
 			depth++
+			continue
 		case ')':
-			depth--
-			if depth < 0 {
-				return false
+			if depth > 0 {
+				depth--
 			}
+			continue
 		}
+		if depth != 0 {
+			continue
+		}
+		if i+len(keyword) > len(s) {
+			break
+		}
+		if lower[i:i+len(keyword)] != keyword {
+			continue
+		}
+		// Word-boundary check: the char before and after must not be an
+		// identifier character.
+		if i > 0 && isIdentByte(s[i-1]) {
+			continue
+		}
+		after := i + len(keyword)
+		if after < len(s) && isIdentByte(s[after]) {
+			continue
+		}
+		return i, true
 	}
-	return depth == 0
+	return 0, false
+}
+
+// isIdentByte reports whether b can be part of a SQL identifier.
+func isIdentByte(b byte) bool {
+	return b == '_' ||
+		(b >= 'a' && b <= 'z') ||
+		(b >= 'A' && b <= 'Z') ||
+		(b >= '0' && b <= '9')
 }
 
 // itoa is a tiny strconv.Itoa to keep the import list minimal.
@@ -370,6 +433,42 @@ SELECT * FROM widget WHERE name = $1;
 	}
 }
 
+// TestSelectListDetector_ReachesOuterSelectOfCTE proves the analyzer examines
+// the OUTER projection of a WITH (CTE) query rather than locking onto the
+// CTE's inner SELECT. Two WITH queries whose outer SELECT shares an identical
+// bare-column projection must fingerprint identically — a false-negative hole
+// that existed when the analyzer matched the first SELECT in the block.
+func TestSelectListDetector_ReachesOuterSelectOfCTE(t *testing.T) {
+	const cteDupSrc = `-- name: WithQueryA :many
+WITH names AS (
+  SELECT unnest($1::text[]) as nm
+)
+SELECT alpha, beta, gamma FROM widget WHERE id = $2;
+
+-- name: WithQueryB :many
+WITH names AS (
+  SELECT unnest($1::text[]) as nm
+)
+SELECT alpha, beta, gamma FROM widget WHERE name = $2;
+`
+	projs := extractSelectProjections("synthetic_cte.sql", cteDupSrc)
+	if len(projs) != 2 {
+		t.Fatalf("expected 2 outer projections from CTE queries, got %d: %+v", len(projs), projs)
+	}
+	for _, p := range projs {
+		if p.table != "widget" {
+			t.Errorf("expected outer table 'widget', got %q (analyzer locked onto the CTE's inner SELECT)", p.table)
+		}
+		if p.numColumns != 3 {
+			t.Errorf("expected 3 outer columns, got %d", p.numColumns)
+		}
+	}
+	fp := func(p selectProjection) string { return p.table + "|" + p.normalized }
+	if fp(projs[0]) != fp(projs[1]) {
+		t.Errorf("expected identical outer-projection fingerprints, got %q vs %q", fp(projs[0]), fp(projs[1]))
+	}
+}
+
 // TestSelectListDetector_SkipsNonFullRowShapes asserts the shapes that must NOT
 // be flagged are correctly skipped: DISTINCT ON, aggregate-only, SELECT 1,
 // and single-occurrence narrow projections (a lone explicit projection is
@@ -398,6 +497,19 @@ SELECT 1 FROM widget WHERE id = $1;`,
 			name: "star",
 			src: `-- name: GetAll :one
 SELECT * FROM widget WHERE id = $1;`,
+		},
+		{
+			// A WITH query whose outer projection is all aliased expressions
+			// (the shape of contact.sql's FindSimilarContactsBatch) is not a
+			// hand-maintained bare-column list, so it must be skipped — but the
+			// analyzer must still reach the outer SELECT to make that call.
+			name: "cte aliased-expression outer projection",
+			src: `-- name: BatchThing :many
+WITH cand AS (
+  SELECT unnest($1::text[]) as nm
+)
+SELECT c.id::text as cid, c.name::text as cname, similarity(c.name, cand.nm) as sim
+FROM widget c CROSS JOIN cand;`,
 		},
 	}
 	for _, tc := range cases {

--- a/backend/tests/telegram_message_all_fields_test.go
+++ b/backend/tests/telegram_message_all_fields_test.go
@@ -72,19 +72,28 @@ func TestTelegramMessage_AllFieldsPopulatedOnRead(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Per-run chat-ID range for clean cleanup. The range is a single chat ID
-	// here; HardDeleteTelegramMessagesByChatIDRange purges [lo, hi] inclusive.
+	// Dedicated chat-ID for this test. HardDeleteTelegramMessagesByChatIDRange
+	// purges [lo, hi] inclusive.
 	const chatID int64 = 920001
+
+	purgeRow := func() {
+		_ = database.Queries.HardDeleteTelegramMessagesByChatIDRange(ctx, db.HardDeleteTelegramMessagesByChatIDRangeParams{
+			Lo: chatID,
+			Hi: chatID,
+		})
+	}
+	// Pre-clean: an interrupted prior run could have left this row behind, and
+	// InsertFullTelegramMessageForTest would then hit the
+	// (telegram_chat_id, telegram_message_id) unique before this run gets to
+	// prove anything. Purge first.
+	purgeRow()
 
 	t.Cleanup(func() {
 		// Hard-delete the seeded message first (it FK-references the
 		// interaction and contact via ON DELETE SET NULL, so order is not
 		// strictly required, but deleting the child first keeps cleanup
 		// independent of FK rules).
-		_ = database.Queries.HardDeleteTelegramMessagesByChatIDRange(ctx, db.HardDeleteTelegramMessagesByChatIDRangeParams{
-			Lo: chatID,
-			Hi: chatID,
-		})
+		purgeRow()
 		_ = interactionRepo.SoftDeleteInteraction(ctx, interaction.ID)
 		_ = contactRepo.SoftDeleteContact(ctx, contact.ID)
 	})

--- a/backend/tests/telegram_message_all_fields_test.go
+++ b/backend/tests/telegram_message_all_fields_test.go
@@ -1,0 +1,178 @@
+// Package tests — telegram_message all-fields-populated regression test.
+//
+// This is a live tripwire for the "forgot to add the column to one SELECT"
+// failure mode. A full-row read goes through sqlc's generated row.Scan, which
+// assigns each column to a struct field positionally; if a future refactor
+// replaces SELECT * with an explicit column list that drops a column, the
+// dropped field reads back at its Go zero value even though everything still
+// compiles. This test seeds a row with EVERY column non-zero and reflects over
+// the read-back db.TelegramMessage, failing with the field name if any field
+// is zero — naming the dropped column directly.
+//
+// The assertion target is the generated db.TelegramMessage (not the
+// hand-mapped repository.TelegramMessage), because the scan layer is where the
+// dropped-column regression manifests.
+package tests
+
+import (
+	"context"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTelegramMessage_AllFieldsPopulatedOnRead(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set")
+	}
+
+	// Migrations are applied once by TestMain.
+
+	ctx := context.Background()
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	defer database.Close()
+
+	contactRepo := repository.NewContactRepository(database.Queries)
+	interactionRepo := repository.NewInteractionRepository(database.Queries)
+
+	// A real contact + interaction so matched_contact_id / interaction_id FKs
+	// resolve. The interaction is hung off the contact.
+	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
+		FullName: "All Fields Probe Contact",
+	})
+	require.NoError(t, err)
+
+	occurredAt := accelerated.GetCurrentTime().Truncate(time.Microsecond)
+	direction := "inbound"
+	sourceRef := "telegram:all-fields-probe"
+	interaction, err := interactionRepo.CreateInteraction(ctx, repository.CreateInteractionRequest{
+		ContactID:  contact.ID,
+		Source:     "telegram",
+		SourceRef:  &sourceRef,
+		OccurredAt: occurredAt,
+		Direction:  direction,
+	})
+	require.NoError(t, err)
+
+	// Per-run chat-ID range for clean cleanup. The range is a single chat ID
+	// here; HardDeleteTelegramMessagesByChatIDRange purges [lo, hi] inclusive.
+	const chatID int64 = 920001
+
+	t.Cleanup(func() {
+		// Hard-delete the seeded message first (it FK-references the
+		// interaction and contact via ON DELETE SET NULL, so order is not
+		// strictly required, but deleting the child first keeps cleanup
+		// independent of FK rules).
+		_ = database.Queries.HardDeleteTelegramMessagesByChatIDRange(ctx, db.HardDeleteTelegramMessagesByChatIDRangeParams{
+			Lo: chatID,
+			Hi: chatID,
+		})
+		_ = interactionRepo.SoftDeleteInteraction(ctx, interaction.ID)
+		_ = contactRepo.SoftDeleteContact(ctx, contact.ID)
+	})
+
+	// A non-zero time distinct from createdAt's default, used for every
+	// nullable timestamp column.
+	ts := pgtype.Timestamptz{Time: occurredAt, Valid: true}
+
+	inserted, err := database.Queries.InsertFullTelegramMessageForTest(ctx, db.InsertFullTelegramMessageForTestParams{
+		TelegramMessageID:  920001,
+		TelegramChatID:     chatID,
+		ChatType:           "private",
+		ChatTitle:          pgtype.Text{String: "Probe Chat", Valid: true},
+		MessageText:        pgtype.Text{String: "probe message text", Valid: true},
+		MessageType:        "text",
+		SentAt:             ts,
+		EditedAt:           ts,
+		IsOutgoing:         true,
+		ReplyToMsgID:       pgtype.Int4{Int32: 919999, Valid: true},
+		PeerUserID:         pgtype.Int8{Int64: 778899, Valid: true},
+		PeerUsername:       pgtype.Text{String: "probe_user", Valid: true},
+		PeerFirstName:      pgtype.Text{String: "Probe", Valid: true},
+		PeerLastName:       pgtype.Text{String: "User", Valid: true},
+		PeerPhone:          pgtype.Text{String: "15555550100", Valid: true},
+		MatchedContactID:   pgtype.UUID{Bytes: contact.ID, Valid: true},
+		InteractionID:      pgtype.UUID{Bytes: interaction.ID, Valid: true},
+		ProcessedAt:        ts,
+		DeletedAt:          ts,
+		PeerEntityResolved: true,
+		ClaimedAt:          ts,
+		ClaimedSessionRef:  pgtype.Text{String: "probe-session-ref", Valid: true},
+	})
+	require.NoError(t, err)
+
+	// Read back via the test-only SELECT * (no deleted_at filter, so the
+	// soft-deleted row is still returned). This is the exact scan path a
+	// production full-row read uses.
+	row, err := database.Queries.GetTelegramMessageByIDForTest(ctx, inserted.ID)
+	require.NoError(t, err)
+
+	// Reflect over every exported field of the returned db.TelegramMessage and
+	// assert none is left at its Go zero value. A dropped column in a future
+	// explicit SELECT list surfaces here as a zero field, named explicitly.
+	rv := reflect.ValueOf(*row)
+	rt := rv.Type()
+	for i := 0; i < rt.NumField(); i++ {
+		field := rt.Field(i)
+		assertFieldPopulated(t, field.Name, rv.Field(i))
+	}
+}
+
+// assertFieldPopulated fails the test if v is at its zero value. pgtype.*
+// wrapper types (which all carry a Valid bool plus an inner value field) are
+// checked by asserting Valid is true AND at least one non-Valid field is
+// non-zero; plain scalars are checked directly. The field name is included in
+// the failure so a dropped SELECT column is named.
+func assertFieldPopulated(t *testing.T, name string, v reflect.Value) {
+	t.Helper()
+
+	// pgtype wrappers are structs with a bool field named "Valid". Detect that
+	// shape generically rather than enumerating every pgtype.* type.
+	if v.Kind() == reflect.Struct {
+		if valid := v.FieldByName("Valid"); valid.IsValid() && valid.Kind() == reflect.Bool {
+			if !valid.Bool() {
+				t.Errorf("field %s: pgtype value is not Valid (column likely missing from the SELECT list)", name)
+				return
+			}
+			// At least one non-Valid field must be non-zero, otherwise the
+			// inner value was never scanned.
+			vt := v.Type()
+			innerPopulated := false
+			for i := 0; i < vt.NumField(); i++ {
+				if vt.Field(i).Name == "Valid" {
+					continue
+				}
+				if !v.Field(i).IsZero() {
+					innerPopulated = true
+					break
+				}
+			}
+			if !innerPopulated {
+				t.Errorf("field %s: pgtype value is Valid but its inner value is zero (column likely missing from the SELECT list)", name)
+			}
+			return
+		}
+	}
+
+	if v.IsZero() {
+		t.Errorf("field %s read back as the zero value — a SELECT list is likely missing this column", name)
+	}
+}

--- a/scripts/ci/sqlc-select-list-guard.sh
+++ b/scripts/ci/sqlc-select-list-guard.sh
@@ -167,6 +167,10 @@ DUP_FINGERPRINTS=$(
 )
 
 violation_count=0
+# Feed the loop via process substitution (a pipe/FD, NOT a here-document temp
+# file) so the guard cannot fail open if /tmp is read-only — a here-string
+# would silently skip the loop and still exit 0. The loop runs in the current
+# shell (not a pipe subshell) so violation_count survives.
 while IFS= read -r fp; do
   [[ -z "$fp" ]] && continue
   if is_allowlisted "$fp"; then
@@ -186,7 +190,7 @@ while IFS= read -r fp; do
   echo "      queries: $locs" >&2
   echo "      columns: $cols" >&2
   violation_count=$((violation_count + 1))
-done <<< "$DUP_FINGERPRINTS"
+done < <(printf '%s\n' "$DUP_FINGERPRINTS")
 
 if (( violation_count > 0 )); then
   echo >&2

--- a/scripts/ci/sqlc-select-list-guard.sh
+++ b/scripts/ci/sqlc-select-list-guard.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# sqlc-select-list-guard.sh — grep/awk guard for the duplicated-SELECT-list
+# invariant (#348).
+#
+# Full-row reads must use SELECT * (sqlc expands it at codegen time, so adding
+# a column needs no query edit). A repeated explicit multi-column projection of
+# the same table is the duplication smell to avoid — it forces lockstep edits
+# of parallel column lists when a column is added.
+#
+# This guard scans ONLY the SOURCE query files in
+# backend/internal/db/queries/*.sql — never the generated *.sql.go (those are
+# full of identical column lists that sqlc auto-expands from SELECT *, which is
+# harmless). It flags any identical explicit (non-*) SELECT projection of >= 3
+# columns that appears in 2+ queries and is not allowlisted.
+#
+# This is the reviewer-visible CI signal; the authoritative check is the Go
+# test backend/tests/sqlc_select_list_static_test.go (it parses SQL more
+# robustly). Mirrors scripts/ci/crm-marker-construction-guard.sh and
+# scripts/ci/followup-sole-writer-guard.sh.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+QUERIES_DIR="backend/internal/db/queries"
+
+# Allowlist of normalized fingerprints (table|sorted-lowercased-columns) that
+# legitimately repeat. Keep in sync with allowedDuplicateProjections in the Go
+# test.
+#   oauth_credential status projection: intentionally omits encrypted-token
+#   columns; SELECT * would leak secrets.
+ALLOWLIST=(
+  "oauth_credential|account_id, account_name, created_at, expires_at, id, provider, scopes, updated_at"
+)
+
+is_allowlisted() {
+  local fp="$1"
+  local a
+  for a in "${ALLOWLIST[@]}"; do
+    [[ "$fp" == "$a" ]] && return 0
+  done
+  return 1
+}
+
+# Emit one line "<table>|<sorted col list>\t<file>:<query>" per qualifying
+# query. The awk script accumulates each query's full text (queries are
+# delimited by "-- name:" markers and a trailing ";"), then extracts the first
+# top-level SELECT...FROM projection and fingerprints it. Skips SELECT *,
+# DISTINCT, aggregate-only, and SELECT 1 — the same shapes the Go test skips.
+extract_one_file() {
+  awk -v fname="$1" '
+    function trim(s) { gsub(/^[ \t\n]+|[ \t\n]+$/, "", s); return s }
+    function emit(   text, sp, fp, after, table, proj, depth, i, ch, cur, n, parts, c, cols, k, key, j, out, ncols, hasplain) {
+      text = buf
+      buf = ""
+      if (qname == "") return
+      # Find the first SELECT (case-insensitive).
+      if (!match(text, /[sS][eE][lL][eE][cC][tT][ \t\n]/)) return
+      text = substr(text, RSTART + RLENGTH)
+      # Walk to the first top-level FROM, accumulating the projection.
+      depth = 0; proj = ""; table = ""; i = 1
+      while (i <= length(text)) {
+        # Top-level FROM keyword bounded by non-word chars.
+        if (depth == 0 && toupper(substr(text, i, 4)) == "FROM" \
+            && (i == 1 || substr(text, i-1, 1) ~ /[ \t\n(]/) \
+            && (substr(text, i+4, 1) ~ /[ \t\n]/)) {
+          after = trim(substr(text, i + 4))
+          if (match(after, /^[a-zA-Z_][a-zA-Z0-9_]*/))
+            table = tolower(substr(after, RSTART, RLENGTH))
+          break
+        }
+        ch = substr(text, i, 1)
+        if (ch == "(") depth++
+        else if (ch == ")") { if (depth > 0) depth-- }
+        proj = proj ch
+        i++
+      }
+      proj = trim(proj)
+      if (proj == "" || table == "") return
+      if (proj == "*") return
+      if (tolower(proj) ~ /^distinct/) return
+      if (proj == "1") return
+      # Split projection on top-level commas.
+      depth = 0; cur = ""; n = 0
+      for (i = 1; i <= length(proj); i++) {
+        ch = substr(proj, i, 1)
+        if (ch == "(") depth++
+        else if (ch == ")") { if (depth > 0) depth-- }
+        if (ch == "," && depth == 0) { parts[++n] = cur; cur = "" }
+        else cur = cur ch
+      }
+      parts[++n] = cur
+      # Keep bare-identifier columns; require at least one plain column.
+      k = 0; hasplain = 0
+      for (i = 1; i <= n; i++) {
+        c = tolower(trim(parts[i]))
+        if (c == "" || c == "*") continue
+        if (index(c, "(") > 0) continue
+        if (index(c, " as ") > 0) continue
+        cols[++k] = c
+        if (c !~ /[ \t]/) hasplain = 1
+      }
+      ncols = k
+      delete parts
+      if (hasplain == 0 || ncols < 3) { delete cols; return }
+      # Insertion-sort columns for an order-independent fingerprint.
+      for (i = 2; i <= ncols; i++) {
+        key = cols[i]; j = i - 1
+        while (j >= 1 && cols[j] > key) { cols[j+1] = cols[j]; j-- }
+        cols[j+1] = key
+      }
+      out = cols[1]
+      for (i = 2; i <= ncols; i++) out = out ", " cols[i]
+      delete cols
+      printf "%s|%s\t%s:%s\n", table, out, fname, qname
+    }
+    /^--[ \t]*name:/ {
+      emit()
+      qname = $3
+      next
+    }
+    {
+      line = $0
+      sub(/--.*/, "", line)   # strip line comments
+      buf = buf " " line
+    }
+    END { emit() }
+  ' "$1"
+}
+
+# Collect "<fingerprint>\t<file>:<query>" lines across all source files.
+# Avoids bash-4 associative arrays for portability to the system bash 3.2.
+ALL=""
+while IFS= read -r f; do
+  ALL+="$(extract_one_file "$f")"$'\n'
+done < <(find "$QUERIES_DIR" -name '*.sql' | sort)
+
+# Fingerprints (field 1) that occur 2+ times across distinct queries.
+DUP_FINGERPRINTS=$(
+  printf '%s' "$ALL" \
+    | grep -v '^[[:space:]]*$' \
+    | cut -d$'\t' -f1 \
+    | sort \
+    | uniq -c \
+    | awk '$1 >= 2 { $1=""; sub(/^ /, ""); print }'
+)
+
+violation_count=0
+while IFS= read -r fp; do
+  [[ -z "$fp" ]] && continue
+  if is_allowlisted "$fp"; then
+    continue
+  fi
+  table="${fp%%|*}"
+  cols="${fp#*|}"
+  # Gather the query locations sharing this fingerprint.
+  locs=$(
+    printf '%s' "$ALL" \
+      | grep -F "$fp"$'\t' \
+      | cut -d$'\t' -f2 \
+      | paste -sd, - \
+      | sed 's/,/, /g'
+  )
+  echo "❌ sqlc SELECT-list guard: identical explicit projection of table '$table' in 2+ queries:" >&2
+  echo "      queries: $locs" >&2
+  echo "      columns: $cols" >&2
+  violation_count=$((violation_count + 1))
+done <<< "$DUP_FINGERPRINTS"
+
+if (( violation_count > 0 )); then
+  echo >&2
+  echo "Fix: use SELECT * for full-row reads (sqlc expands it; adding a column" >&2
+  echo "needs no query edit), or add a justified allowlist entry for a genuine" >&2
+  echo "narrow projection. See backend/tests/sqlc_select_list_static_test.go." >&2
+  exit 1
+fi
+
+echo "✓ sqlc SELECT-list guard: no un-allowlisted duplicated explicit SELECT column lists"

--- a/scripts/ci/sqlc-select-list-guard.sh
+++ b/scripts/ci/sqlc-select-list-guard.sh
@@ -42,27 +42,44 @@ is_allowlisted() {
   return 1
 }
 
-# Emit one line "<table>|<sorted col list>\t<file>:<query>" per qualifying
-# query. The awk script accumulates each query's full text (queries are
-# delimited by "-- name:" markers and a trailing ";"), then extracts the first
-# top-level SELECT...FROM projection and fingerprints it. Skips SELECT *,
-# DISTINCT, aggregate-only, and SELECT 1 — the same shapes the Go test skips.
+# Emit one line "<table>|<sorted col list>\t<file>:<line>:<query>" per
+# qualifying query (line = the -- name: marker line). The awk script
+# accumulates each query's full text (queries are delimited by "-- name:"
+# markers), then extracts the outermost top-level SELECT...FROM projection and
+# fingerprints it. Skips SELECT *, DISTINCT, aggregate-only, and SELECT 1 — the
+# same shapes the Go test skips — and like the Go test reaches the outer SELECT
+# of a WITH (CTE) query rather than the CTE's inner SELECT.
 extract_one_file() {
   awk -v fname="$1" '
     function trim(s) { gsub(/^[ \t\n]+|[ \t\n]+$/, "", s); return s }
-    function emit(   text, sp, fp, after, table, proj, depth, i, ch, cur, n, parts, c, cols, k, key, j, out, ncols, hasplain) {
+    function emit(   text, sp, fp, after, table, proj, depth, i, ch, cur, n, parts, c, cols, k, key, j, out, ncols, hasplain, selpos) {
       text = buf
       buf = ""
       if (qname == "") return
-      # Find the first SELECT (case-insensitive).
-      if (!match(text, /[sS][eE][lL][eE][cC][tT][ \t\n]/)) return
-      text = substr(text, RSTART + RLENGTH)
+      # Find the OUTERMOST SELECT — the first SELECT at paren-depth 0. CTEs
+      # (WITH ... AS (SELECT ...)) and subqueries nest their SELECT inside
+      # parentheses (depth >= 1), so depth-0 scoping skips them and lands on
+      # the main outer SELECT. Mirrors findTopLevelKeyword in the Go test.
+      depth = 0; selpos = 0
+      for (i = 1; i <= length(text); i++) {
+        ch = substr(text, i, 1)
+        if (ch == "(") { depth++; continue }
+        if (ch == ")") { if (depth > 0) depth--; continue }
+        if (depth == 0 && toupper(substr(text, i, 6)) == "SELECT" \
+            && (i == 1 || substr(text, i-1, 1) ~ /[^a-zA-Z0-9_]/) \
+            && (substr(text, i+6, 1) ~ /[ \t\n]/)) {
+          selpos = i + 6
+          break
+        }
+      }
+      if (selpos == 0) return
+      text = substr(text, selpos)
       # Walk to the first top-level FROM, accumulating the projection.
       depth = 0; proj = ""; table = ""; i = 1
       while (i <= length(text)) {
         # Top-level FROM keyword bounded by non-word chars.
         if (depth == 0 && toupper(substr(text, i, 4)) == "FROM" \
-            && (i == 1 || substr(text, i-1, 1) ~ /[ \t\n(]/) \
+            && (i == 1 || substr(text, i-1, 1) ~ /[^a-zA-Z0-9_]/) \
             && (substr(text, i+4, 1) ~ /[ \t\n]/)) {
           after = trim(substr(text, i + 4))
           if (match(after, /^[a-zA-Z_][a-zA-Z0-9_]*/))
@@ -90,15 +107,18 @@ extract_one_file() {
         else cur = cur ch
       }
       parts[++n] = cur
-      # Keep bare-identifier columns; require at least one plain column.
+      # Keep ALL top-level terms (columns AND expressions) with whitespace
+      # collapsed — matching the Go test, which fingerprints the full term
+      # list. Track whether at least one term is a bare identifier (the
+      # hasPlainColumn gate); a projection of only expressions/aggregates is
+      # not a hand-maintained column list and is skipped.
       k = 0; hasplain = 0
       for (i = 1; i <= n; i++) {
         c = tolower(trim(parts[i]))
+        gsub(/[ \t]+/, " ", c)
         if (c == "" || c == "*") continue
-        if (index(c, "(") > 0) continue
-        if (index(c, " as ") > 0) continue
         cols[++k] = c
-        if (c !~ /[ \t]/) hasplain = 1
+        if (index(c, "(") == 0 && index(c, " as ") == 0 && c !~ /[ \t]/) hasplain = 1
       }
       ncols = k
       delete parts
@@ -112,11 +132,12 @@ extract_one_file() {
       out = cols[1]
       for (i = 2; i <= ncols; i++) out = out ", " cols[i]
       delete cols
-      printf "%s|%s\t%s:%s\n", table, out, fname, qname
+      printf "%s|%s\t%s:%d:%s\n", table, out, fname, qline, qname
     }
     /^--[ \t]*name:/ {
       emit()
       qname = $3
+      qline = FNR
       next
     }
     {
@@ -128,7 +149,7 @@ extract_one_file() {
   ' "$1"
 }
 
-# Collect "<fingerprint>\t<file>:<query>" lines across all source files.
+# Collect "<fingerprint>\t<file>:<line>:<query>" lines across all source files.
 # Avoids bash-4 associative arrays for portability to the system bash 3.2.
 ALL=""
 while IFS= read -r f; do


### PR DESCRIPTION
## Context

Closes #348.

Issue #348's headline deliverable — collapse the duplicated `telegram_message` SELECT column lists via `sqlc.embed` — was **already satisfied**. `backend/internal/db/queries/telegram_message.sql` already uses `SELECT *` / `RETURNING *` for every full-row query, so sqlc auto-expands the flat column list at codegen time with zero manual maintenance: adding a column and running `make sqlc` regenerates all of them. The "duplicated SELECT lists" the issue cites live only in the generated `telegram_message.sql.go`, which is not a human-editing cost. `sqlc.embed(telegram_message)` would actively regress this — it nests columns under a `TelegramMessage` sub-struct (`row.TelegramMessage.Field`), changing the flat `*db.TelegramMessage` return type and forcing churn at every Scan/convert call site.

So this PR delivers the issue's **durable value** instead, with zero production query-body changes.

## What changed

**1. Source-SQL duplication lint.** A Go static test (`backend/tests/sqlc_select_list_static_test.go`) plus a parallel bash guard (`scripts/ci/sqlc-select-list-guard.sh`) that flag any identical explicit (non-`*`) ≥3-column `SELECT` projection of the same table appearing in 2+ source queries. The lint scans ONLY `backend/internal/db/queries/*.sql` (where humans edit), never the generated `.sql.go` (which is full of harmless auto-expanded lists). Both analyzers scan to the first `SELECT` at paren-depth 0, so a `WITH`/CTE query is checked at its outer projection rather than the CTE's inner SELECT. There is exactly one pre-existing source-level duplicate, which is allowlisted: the oauth credential-status projection (`GetOAuthCredentialStatus` + `ListOAuthCredentialStatuses`) deliberately omits the encrypted-token columns, so `SELECT *` would leak secret material. The lint therefore enforces repo-wide immediately and stays green on merge. Wired into the `ci-test` Makefile target, the `.PHONY` line, and the backend CI job; the backend paths-filter already covers `scripts/**`, `Makefile`, and `backend/**`.

**2. All-fields-populated regression test.** `backend/tests/telegram_message_all_fields_test.go` seeds a `telegram_message` row with every column non-zero, reads it back via `SELECT *`, and reflects over the returned `db.TelegramMessage` asserting no field is left at its Go zero value. This is a live tripwire for the "forgot to add the column to one explicit SELECT list" failure mode: a dropped column reads back zero at the scan layer and the test names the missing field.

**3. Two additive test-only sqlc queries** backing the regression test: `InsertFullTelegramMessageForTest` (every column as a param, including the system-managed columns `UpsertTelegramMessage` leaves NULL) and `GetTelegramMessageByIDForTest` (no `deleted_at` filter, so a soft-deleted row is still readable). The generated diff is purely additive — the existing query strings and Scan sites are byte-identical, confirming no `SELECT *` query needed conversion.

No production query bodies changed. No `frontend/` changes. No `sqlc.embed` introduced.

## Test plan

- `go build ./...` + `go vet ./...` clean
- `make lint` — 0 issues
- `make test-unit` — green (includes the static lint test + self-tests proving the detector flags a synthetic duplicate, reaches the CTE outer SELECT, and skips `SELECT *` / `DISTINCT ON` / aggregate-only / existence-probe shapes)
- `make test-integration` (LONG_TESTS=1, clean DB) — green; `TestTelegramMessage_AllFieldsPopulatedOnRead` passes
- `make check-sqlc-select-lists` — exit 0 on the real tree; verified it exits 1 (naming `file:line:query`) on a synthetic duplicate, the oauth case un-allowlisted, and a CTE-outer duplicate

## Known non-blocking follow-ups (review-head P2/P3)

- **P2:** the regression test's reflection check cannot distinguish a column that is legitimately zero-valued from one dropped by a SELECT list. Mitigated by seeding every column with a non-zero value, so the only way a field reads back zero is a genuine scan-layer omission.
- **P3:** the guard's header comment cites `(#348)`, which is inconsistent with the sibling guards' convention of not embedding PR/issue references in source comments. Should be stripped in a follow-up.