### PR TITLE
test(sync): harden TestSyncWorker_RescueOnCrash full-suite flake

### DIFF
--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -541,6 +541,12 @@ type Querier interface {
 	GetPhoneCallByID(ctx context.Context, id pgtype.UUID) (*PhoneCall, error)
 	// Lookup by call_unique_id. Returns ErrNoRows on miss.
 	GetPhoneCallByUniqueID(ctx context.Context, callUniqueID string) (*PhoneCall, error)
+	// Test assertion — returns the river_job.state for a single job id. Used by
+	// rescue-on-crash polling to wait out River's async completer
+	// (running->completed lands after the worker returns). River exposes no
+	// production sqlc layer; this is the test-boundary seam, mirroring the
+	// existing CountRiverJobsByKind test query.
+	GetRiverJobStateByID(ctx context.Context, id int64) (RiverJobState, error)
 	GetSyncLog(ctx context.Context, id pgtype.UUID) (*ExternalSyncLog, error)
 	// External Sync State Queries
 	GetSyncState(ctx context.Context, id pgtype.UUID) (*ExternalSyncState, error)
@@ -944,6 +950,20 @@ type Querier interface {
 	SoftDeleteMeetingNoteBySessionID(ctx context.Context, anarlogSessionID pgtype.UUID) error
 	SoftDeleteTelegramChannelMessages(ctx context.Context, arg SoftDeleteTelegramChannelMessagesParams) error
 	SoftDeleteTelegramMessages(ctx context.Context, messageIds []int32) error
+	// Test setup — drop ALL river_job rows, but ONLY when connected to a
+	// per-package clone DB (current_database() matching the clone-name prefix).
+	// The rescue-on-crash test calls this to clear foreign-kind leftovers (e.g.
+	// interaction_recorder) created by earlier tests in the same per-package
+	// clone, which its live River client would otherwise fetch and churn on,
+	// widening the completer race. Fail-closed by construction: on a shared test
+	// DB or the dev DB the WHERE is false and it deletes nothing, so a manual
+	// no-tag run pointed at a real database can never wipe its queue. The prefix
+	// mirrors clonePrefix in internal/testdb (cannot import that build-tagged
+	// package from an untagged test file). EVERY underscore in the prefix is
+	// escaped so each is matched literally, not as a LIKE single-char wildcard —
+	// for a broad delete the guard must match the exact clone-name prefix, not a
+	// looser pattern.
+	SweepRiverJobsInCloneForTest(ctx context.Context) (int64, error)
 	// TEST ONLY. Hard-deletes calendar_event rows whose gcal_event_id starts
 	// with the given prefix. Used by t.Cleanup to remove fixtures.
 	TestDeleteCalendarEventsByGcalEventIDPrefix(ctx context.Context, prefix string) error

--- a/backend/internal/db/queries/test.sql
+++ b/backend/internal/db/queries/test.sql
@@ -139,6 +139,31 @@ SELECT COUNT(*) FROM river_job WHERE kind = @kind AND finalized_at IS NULL;
 -- pollution is bounded by DeleteRiverJobsByKindAny in test cleanup.
 SELECT COUNT(*) FROM river_job WHERE kind = @kind;
 
+-- name: GetRiverJobStateByID :one
+-- Test assertion — returns the river_job.state for a single job id. Used by
+-- rescue-on-crash polling to wait out River's async completer
+-- (running->completed lands after the worker returns). River exposes no
+-- production sqlc layer; this is the test-boundary seam, mirroring the
+-- existing CountRiverJobsByKind test query.
+SELECT state FROM river_job WHERE id = @id;
+
+-- name: SweepRiverJobsInCloneForTest :execrows
+-- Test setup — drop ALL river_job rows, but ONLY when connected to a
+-- per-package clone DB (current_database() matching the clone-name prefix).
+-- The rescue-on-crash test calls this to clear foreign-kind leftovers (e.g.
+-- interaction_recorder) created by earlier tests in the same per-package
+-- clone, which its live River client would otherwise fetch and churn on,
+-- widening the completer race. Fail-closed by construction: on a shared test
+-- DB or the dev DB the WHERE is false and it deletes nothing, so a manual
+-- no-tag run pointed at a real database can never wipe its queue. The prefix
+-- mirrors clonePrefix in internal/testdb (cannot import that build-tagged
+-- package from an untagged test file). EVERY underscore in the prefix is
+-- escaped so each is matched literally, not as a LIKE single-char wildcard —
+-- for a broad delete the guard must match the exact clone-name prefix, not a
+-- looser pattern.
+DELETE FROM river_job
+WHERE current_database() LIKE 'personal\_crm\_test\_clone\_%' ESCAPE '\';
+
 -- name: DeleteInteractionsByContactAndSource :execrows
 -- Test teardown — drops interactions seeded by a test under the given
 -- (contact_id, source) pair. Scoped to the seeded contact so production

--- a/backend/internal/db/test.sql.go
+++ b/backend/internal/db/test.sql.go
@@ -340,6 +340,22 @@ func (q *Queries) GetInteractionSourceCheckDef(ctx context.Context) (string, err
 	return constraint_def, err
 }
 
+const GetRiverJobStateByID = `-- name: GetRiverJobStateByID :one
+SELECT state FROM river_job WHERE id = $1
+`
+
+// Test assertion — returns the river_job.state for a single job id. Used by
+// rescue-on-crash polling to wait out River's async completer
+// (running->completed lands after the worker returns). River exposes no
+// production sqlc layer; this is the test-boundary seam, mirroring the
+// existing CountRiverJobsByKind test query.
+func (q *Queries) GetRiverJobStateByID(ctx context.Context, id int64) (RiverJobState, error) {
+	row := q.db.QueryRow(ctx, GetRiverJobStateByID, id)
+	var state RiverJobState
+	err := row.Scan(&state)
+	return state, err
+}
+
 const SeedExternalSyncState = `-- name: SeedExternalSyncState :one
 INSERT INTO external_sync_state
     (source, account_id, enabled, status, strategy, next_sync_at)
@@ -494,4 +510,30 @@ func (q *Queries) SeedRevokedMacHost(ctx context.Context, arg SeedRevokedMacHost
 		&i.ApiKeyRotatedAt,
 	)
 	return &i, err
+}
+
+const SweepRiverJobsInCloneForTest = `-- name: SweepRiverJobsInCloneForTest :execrows
+DELETE FROM river_job
+WHERE current_database() LIKE 'personal\_crm\_test\_clone\_%' ESCAPE '\'
+`
+
+// Test setup — drop ALL river_job rows, but ONLY when connected to a
+// per-package clone DB (current_database() matching the clone-name prefix).
+// The rescue-on-crash test calls this to clear foreign-kind leftovers (e.g.
+// interaction_recorder) created by earlier tests in the same per-package
+// clone, which its live River client would otherwise fetch and churn on,
+// widening the completer race. Fail-closed by construction: on a shared test
+// DB or the dev DB the WHERE is false and it deletes nothing, so a manual
+// no-tag run pointed at a real database can never wipe its queue. The prefix
+// mirrors clonePrefix in internal/testdb (cannot import that build-tagged
+// package from an untagged test file). EVERY underscore in the prefix is
+// escaped so each is matched literally, not as a LIKE single-char wildcard —
+// for a broad delete the guard must match the exact clone-name prefix, not a
+// looser pattern.
+func (q *Queries) SweepRiverJobsInCloneForTest(ctx context.Context) (int64, error) {
+	result, err := q.db.Exec(ctx, SweepRiverJobsInCloneForTest)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }

--- a/backend/tests/sync_worker_leased_retry_test.go
+++ b/backend/tests/sync_worker_leased_retry_test.go
@@ -333,6 +333,34 @@ type syncLogPool interface {
 	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
 }
 
+// waitForRiverJobState polls river_job for the given job id until its state
+// equals want, or the ctx deadline fires. River's completer writes the
+// running->completed transition asynchronously after the worker callback
+// returns, so a single un-polled read can observe a stale 'running'. Mirrors
+// waitForSyncLogStatus. Real wall-clock time per the polling-wait rule (not
+// business-logic time, so not accelerated.GetCurrentTime). Reads through the
+// test-only sqlc query, not raw SQL.
+func waitForRiverJobState(t *testing.T, ctx context.Context, queries *db.Queries, jobID int64, want db.RiverJobState) {
+	t.Helper()
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+	var last db.RiverJobState
+	for {
+		state, err := queries.GetRiverJobStateByID(ctx, jobID)
+		if err == nil {
+			last = state
+			if state == want {
+				return
+			}
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("timed out waiting for river_job id=%d state=%q (last observed %q, err=%v)", jobID, want, last, err)
+		case <-ticker.C:
+		}
+	}
+}
+
 // TestSyncWorker_RescueOnCrash simulates the #208 scenario: a worker
 // begins processing a job, writes a `status='running'` external_sync_log
 // row, and then the process dies before CompleteSyncLog fires. The
@@ -370,9 +398,19 @@ func TestSyncWorker_RescueOnCrash(t *testing.T) {
 	t.Cleanup(func() { database.Close() })
 
 	source := "retry_test_rescue_on_crash"
-	// Clean up any leftovers from a prior test run.
-	_, _ = database.Pool.Exec(ctx,
-		`DELETE FROM river_job WHERE kind = 'sync_provider_account' AND (args->>'source') = $1`, source)
+	// Sweep ALL river_job rows in this package clone before starting our own
+	// client. Leftover rows of foreign kinds (e.g. interaction_recorder) from
+	// earlier tests in the same per-package clone would otherwise be fetched by
+	// this test's live River client, adding completer/maintenance churn that
+	// widens the completer race below. Tests in this package run serially (no
+	// t.Parallel); the sweep runs before this test starts its own client, so it
+	// races no live producer of this test. The query is fail-closed (deletes
+	// only on a clone DB), so on a non-clone DB it is a harmless no-op and the
+	// test's own t.Cleanup still scrubs this test's source-scoped rows.
+	sweepCtx, sweepCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer sweepCancel()
+	_, err = database.Queries.SweepRiverJobsInCloneForTest(sweepCtx)
+	require.NoError(t, err, "sweep river_job in package clone")
 	_, _ = database.Pool.Exec(ctx, `DELETE FROM external_sync_log WHERE source = $1`, source)
 	_, _ = database.Pool.Exec(ctx, `DELETE FROM external_sync_state WHERE source = $1`, source)
 
@@ -445,9 +483,12 @@ func TestSyncWorker_RescueOnCrash(t *testing.T) {
 	require.NoError(t, err)
 	svc.SetRiverEnqueuer(client)
 
-	startCtx, startCancel := context.WithTimeout(ctx, 10*time.Second)
-	defer startCancel()
-	require.NoError(t, client.Start(startCtx))
+	// Start with the root ctx, never a timeout-derived context: River binds its
+	// fetch/work loops (and the JobRescuer maintenance service) to the context
+	// passed to Start (BaseStartStop.StartInit wraps it with WithCancelCause), so
+	// a start-deadline cancel can silently stop fetching. (Documented project
+	// gotcha; applies to test harnesses too.)
+	require.NoError(t, client.Start(ctx))
 	t.Cleanup(func() {
 		stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer stopCancel()
@@ -498,14 +539,13 @@ func TestSyncWorker_RescueOnCrash(t *testing.T) {
 	assert.Equal(t, repository.SyncStatusIdle, updatedState.Status,
 		"status must land on 'idle' after rescue")
 
-	// Assertion 4: the same river_job row we seeded ended up completed.
-	// This is what proves the rescuer (not a fresh Insert) drove the
-	// retry — if the row had been stuck forever, its final state would
-	// still be 'running'.
-	var finalJobState string
-	require.NoError(t, database.Pool.QueryRow(ctx,
-		`SELECT state FROM river_job WHERE id = $1`, insertedJobID,
-	).Scan(&finalJobState))
-	assert.Equal(t, "completed", finalJobState,
-		"the seeded stuck job should have been rescued and completed")
+	// Assertion 4: the same river_job row we seeded ended up completed. River's
+	// completer flushes running->completed asynchronously after the worker
+	// returns, so poll rather than read once (the un-polled read raced the
+	// completer under full-suite load). A genuine "stuck forever" regression
+	// still fails loudly via the helper's t.Fatalf on deadline. This is also
+	// what proves the rescuer (not a fresh Insert) drove the retry.
+	jobStateCtx, jobStateCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer jobStateCancel()
+	waitForRiverJobState(t, jobStateCtx, database.Queries, insertedJobID, db.RiverJobStateCompleted)
 }


### PR DESCRIPTION
## Summary

Fast-follow to #360 (template-DB-per-package isolation). After that isolation work landed, one residual integration-test flake remained: `TestSyncWorker_RescueOnCrash` in `backend/tests/sync_worker_leased_retry_test.go` flaked ~50% under the FULL `make test-integration` (LONG_TESTS) suite, but 0/17 in slow-only isolation runs. It only flaked in the full-suite context, and only in the pre-push gate — PR CI's "Backend Tests" job runs `make test-integration-fast` (no LONG_TESTS), which skips this test entirely via `requireLongTests(t)`.

## Root cause

Assertion 4 read the seeded job's `river_job.state` exactly once and asserted `== "completed"`, with no poll loop. River's completer writes the `running -> completed` transition asynchronously after the worker callback returns. Under full-suite load the worker finished and the `external_sync_log` success row committed (clearing the existing wait-gate) before River's completer flushed `completed`, so the un-polled read caught `running` and the assertion failed. The poll-with-timeout hardening that fixed the earlier `external_sync_log` assertions (`waitForSyncLogStatus`) was never extended to assertion 4's `river_job` read. A secondary symptom (`Unhandled job kind interaction_recorder` from foreign-kind `river_job` rows left by earlier tests in the same per-package clone) added completer/maintenance churn that widened the race window.

## Fixes (test-tree only, no production source)

- **A — poll assertion 4.** Replace the single un-polled read with a bounded poll (`waitForRiverJobState`, mirroring `waitForSyncLogStatus`) that reads `river_job.state` until it equals `completed` or a 10s deadline fires. Reads via a new test-only sqlc query `GetRiverJobStateByID` (river_job already has a test-only sqlc seam, so this follows the core "use sqlc, not raw SQL" rule for new code). The helper `t.Fatalf`s on deadline with the last-observed state, so a genuine "stuck forever in running" regression still fails loudly.
- **B — fail-closed clone-guarded queue sweep.** New test-only sqlc query `SweepRiverJobsInCloneForTest` drops all `river_job` rows but is fail-closed in SQL: the `WHERE current_database() LIKE 'personal\_crm\_test\_clone\_%'` only matches a per-package clone DB, so on a shared/dev DB it deletes nothing. Run at setup to clear foreign-kind leftovers (e.g. `interaction_recorder`) that this test's live River client would otherwise fetch and churn on. The source-scoped `external_sync_log`/`external_sync_state` deletes and the `t.Cleanup` block are unchanged.
- **C — root-context `client.Start`.** Start the River client with the root context instead of a 10s-timeout context. River binds its fetch/work loops (and the JobRescuer maintenance service) to the context passed to `Start` (documented project gotcha). This is defensive hardening, not the measured cause — the rescuer fires on its initial tick within the first few seconds, well inside the old 10s window — but it closes a latent vector and removes a documented anti-pattern from the test being touched. It changes `Start`, not `Stop`; the graceful `client.Stop` cleanup is untouched.

## Verification

A single green run proves nothing for a ~50% flake, and PR CI does not run this test at all (LONG_TESTS-gated). The proof is local full-suite stress-verification:

- **8/8 full `make test-integration` (LONG_TESTS) runs clean** — zero `TestSyncWorker_RescueOnCrash` failures, zero collateral failures across the whole suite. Rescue test completed in 2.0–5.6s per run.
- Secondary symptom (`Unhandled job kind interaction_recorder`) confirmed absent from the rescue test's own output region across all 8 runs.
- A 9th full-suite LONG_TESTS run via the pre-push hook also passed.
- Codex review (effort xhigh): 0 findings at any severity.
- `/review-head`: PASS (P0=0, P1=0).
- `make lint` 0 issues; `make sqlc` no diff; `go vet` clean tagged + untagged; `go build ./cmd/crm-api` OK.

## CI note

PR CI's "Backend Tests" job runs `make test-integration-fast` and **skips this test** (LONG_TESTS-gated). Green CI here only confirms nothing else broke — it is NOT the proof of the fix. The local 8x full-suite stress run plus the pre-push full-suite run are the proof.

## Test plan

- [x] 8x full `make test-integration` (LONG_TESTS), 0 RescueOnCrash failures, 0 collateral failures
- [x] Secondary symptom gone from rescue test region across all 8 runs
- [x] `make lint`, `make sqlc` (no diff), `go vet` (both tag configs), `go build ./cmd/crm-api`
- [x] `make test-unit` builds the untagged `./tests/...` (no build-tagged import introduced)