### PR TITLE
feat(linkage): coalesce same-meeting / dropped-redial candidates before disambiguation

### DIFF
--- a/.ai/spec/2026-05-31-agentic-ux-qa-and-behavior-ssot-design.md
+++ b/.ai/spec/2026-05-31-agentic-ux-qa-and-behavior-ssot-design.md
@@ -1,0 +1,161 @@
+# Agentic UX QA + Behavior SSOT — Umbrella Design
+
+**Date:** 2026-05-31
+**Status:** Umbrella design (architecture-level). Detailed sub-specs deferred to their own brainstorms.
+**Author:** spengrah (brainstormed with Claude)
+
+## Problem
+
+The deterministic Playwright E2E suite is brittle. ~70% of its assertions check literal copy, CSS classes, DOM structure, element counts, and ordering by visual position — exactly what changes when the UI is improved. This makes continuous UX improvement expensive: every restyle forces a test rewrite, even when the underlying behavior is unchanged. The current suite conflates two different jobs — *is the business logic correct?* and *has the UI not regressed?* — and the coupling makes both worse.
+
+At the same time there is no automated judgement of *UX quality* itself. The suite can confirm a button exists; it cannot tell you the empty state is confusing or the flow feels broken.
+
+## Goal
+
+Rebalance the testing pyramid into two tracks with clean responsibilities:
+
+1. **Deterministic tests own business-logic correctness** — stable, indifferent to how the UI looks. Re-oriented toward API-level / data-asserted verification. This also hardens the API surface for the **forthcoming MCP server**, which is just another API consumer.
+2. **An agentic layer owns UX quality** — judging the experience against intended behavior in a way that *survives UI change by construction*, because it asserts on intent and observable outcomes rather than DOM specifics.
+
+The connective tissue between both tracks is a **single source of truth (SSOT) of intended behavior**: durable, DOM-free intent specifications that deterministic tests, the QA agent, the MCP server, and documentation all reference.
+
+## Non-Goals
+
+- Pixel-perfect visual-regression testing. The oracle is *behavioral*, not visual. Vision is an optional escalation for genuinely visual defects, never the default path.
+- Auto-fixing. The QA loop **detects and reports**; it does not open fix-PRs (see "Issues, not fix-PRs").
+- Replacing the Go test suite. The Go suite is already a strong business-logic safety net (~465 test functions; ingest→match→interaction→cadence pipelines, imports, and matching covered end-to-end without a browser). This work leans on it and extends it at the HTTP/handler layer.
+- Deleting all UI coverage. A thin layer of resilient, data-asserting E2E remains for flows that genuinely need the frontend wired in.
+
+## Background: current-state findings
+
+These observations motivated the design and should be re-verified before each sub-project begins (code changes).
+
+- **Go suite is a strong logic net, weak at the HTTP edge.** End-to-end-without-browser coverage is strong for ingest pipelines (messages, phone calls, meeting notes, external contacts), contact matching/enrichment, cadence/followup state machines, import→contact flows, and mac-host auth. The gap: ~13 of 18 Gin handlers lack dedicated API-level tests (rematch, sync, calendar, todoist, search). That gap matters more now because the MCP server will exercise the same API surface.
+- **Playwright suite is ~70% brittle.** ~21 specs, ~130 tests, ~5,763 LOC. Roughly 70% of assertions are UI-regression (literal text, `toHaveClass`, DOM structure, counts in labels); ~25% mixed; ~5% genuinely resilient (API/data/route assertions). Only ~8 test blocks verify business logic that nothing else covers (e.g. rematch end-to-end, overdue cross-view consistency, a few import state transitions).
+- **Resilient infrastructure already exists to build on.** `frontend/tests/e2e/helpers/test-api.ts` (TestAPI seed/read helpers), backend test-only seed routes (`/seed/contacts`, `/seed/external-contacts`, `/seed/meeting-notes`, …) gated by `CRM_ENV`, `page.waitForResponse` patterns, role-based queries, `test-map.json` tag-based diff selection, and the `personal_crm_test` DB lifecycle.
+
+## Architecture: two tracks, four pieces
+
+```
+                    ┌─────────────────────────────────┐
+                    │   SSOT: durable intent specs     │
+                    │   (spec/, DOM-free, IDed)        │  ← single source of truth
+                    └─────────────────────────────────┘
+                       ▲            ▲            ▲
+        references     │            │            │   references
+        ┌──────────────┘            │            └──────────────┐
+        │                           │                           │
+┌───────────────────┐   ┌───────────────────────┐   ┌──────────────────────┐
+│ Track A:          │   │ Anti-drift:           │   │ Track B:             │
+│ deterministic     │   │ traceability + CI     │   │ agentic UX QA harness│
+│ tests (API-level/ │   │ coverage checks       │   │ (tours + judge →     │
+│ data-asserted)    │   │ (behavior IDs ↔ tests)│   │  GitHub issues)      │
+└───────────────────┘   └───────────────────────┘   └──────────────────────┘
+```
+
+The four implementable pieces:
+
+1. **The SSOT artifact + derivation** (the foundation everything consumes).
+2. **Track A — re-orient deterministic tests** toward API-level / data-asserted verification.
+3. **Anti-drift — traceability + CI coverage checks** keeping specs and tests in sync.
+4. **Track B — the agentic UX QA harness** (deterministic tours + model judge → GitHub issues).
+
+### Piece 1 — The SSOT (behavior intent specs)
+
+The oracle is a version-controlled corpus of **intended behaviors**, deliberately DOM-free so UI restyles never invalidate it.
+
+- **Organization:** one file per **domain**, drawn from the existing test/handler grouping — `contacts`, `interactions`, `cadence-followup`, `imports-matching`, `ingest`, `calendar-gcal`, `telegram`, `todoist`, `mac-host`, `notes`, `dashboard`.
+- **Per-behavior schema:** stable **ID** (e.g. `INT-003`); **type** (`business-logic` / `api` / `ux` / `invariant` / `data`) so each consumer filters to what it cares about; intent-level **Given/When/Then** (no selectors, no copy); **status** (`current` = faithfully describes today vs `proposed` = desired change); **coverage** (test references, the traceability seed); **provenance** (sources it was derived from).
+- **File maturity states:** `draft` (derived) → `reviewed` (curated) → `ratified` (trusted). The new paradigm switches on **per domain** as each file matures, rather than all-or-nothing.
+- **Location:** top-level **`spec/`** with a `spec/README.md` index — signals a first-class product artifact, not agent scratch.
+
+Each behavior survives any UI redesign, tells a deterministic test exactly what to assert, tells the QA agent what outcome to look for, and reads as documentation. The same corpus later informs the MCP server's contract and user-facing docs.
+
+**Build strategy:** derive draft behaviors from existing Go/E2E tests + handlers (agent drafts, human curates), then backfill domain-by-domain by priority. This grounds the SSOT in real current behavior, is the cheapest path, and audits existing coverage as a side effect.
+
+### Piece 2 — Track A: re-orient deterministic tests
+
+Shift business-logic verification off the DOM:
+
+- **Lean on the Go suite** as the primary logic net; close the HTTP-edge gap by adding API-level tests for the handlers that lack them (rematch, sync, calendar, todoist, search). This doubles as MCP-server hardening.
+- **Relax brittle Playwright** — strip `toHaveClass`, literal-copy, and DOM-structure assertions that only re-check, through the UI, what a backend test already covers.
+- **Keep a thin data-asserting E2E layer** for the ~8 flows where the browser genuinely adds coverage (e.g. rematch end-to-end job→poll→refresh, overdue cross-view consistency). Rewrite these to assert on API responses / network params / DB state via TestAPI, using role-based drivers — never layout or copy.
+- Lean (per the user) toward **API-level E2E and data-asserted** styles over DOM assertions.
+
+This track and the SSOT are mutually reinforcing: specs say what to assert; tests cite the behavior IDs they cover.
+
+### Piece 3 — Anti-drift: traceability + CI coverage checks
+
+Keep the SSOT honest without hard-blocking unrelated work:
+
+- Tests declare the **behavior IDs** they cover.
+- CI flags **orphan behaviors** (a `current` behavior with no covering test) and **dead IDs** (a test referencing a removed behavior).
+- A PR-review expectation that behavior changes update the relevant spec.
+
+This gives measurable drift detection rather than relying on discipline (the classic way SSOTs rot), while avoiding the noise/gaming of a hard "touch a spec file or CI fails" gate.
+
+### Piece 4 — Track B: the agentic UX QA harness
+
+The harness splits the job into a part machines do deterministically and a part that needs judgement — which is what makes it both reliable and cheap.
+
+- **Tours (deterministic, zero model quota):** assertion-free Playwright that walks each flow through its key states, seeding via the existing test routes, and **captures the accessibility tree (text, not pixels) plus recorded network responses** at each state. The tour navigates; it asserts nothing, so UI restyles don't break it. The tour *is* the relaxed E2E suite from Track A, doing double duty.
+- **Judge (model, high-volume, cheap):** for each relevant `(behavior × captured state)` pair, one small model call reads `intent-spec + a11y-snapshot (+ network)` and returns `pass | fail | unsure`, with observed-vs-expected and a draft issue on fail. This is *criticism, not agency* — the model never decides where to click — which is why a cheap model is sufficient.
+- **Reporter:** confirmed failures become **GitHub issues** (see below).
+- **Optional escalation:** vision (screenshots) only for genuinely visual behaviors (overlap, broken layout, contrast). Not the default.
+- **Optional add-on (deferred):** a sparse (e.g. weekly) free-form *agentic exploration* pass to hunt unknown-unknowns the scripted tours don't cover.
+
+#### Issues, not fix-PRs
+
+The loop opens **GitHub issues**, not fix-PRs. This is a deliberate modular seam: it decouples *detection* from *remediation*. Issues can be picked up manually, triaged, or later fed to a separate agentic remediation pipeline — your choice, wired up independently. It also avoids the worst failure mode of auto-fix bots: confidently-wrong PRs that cost more to review than they save.
+
+## Execution & cost model
+
+The hard constraint: **no metered Claude API pricing.** As of 2026-06-15, *any* programmatic Claude (`claude -p`, Agent SDK, GitHub Actions, third-party harnesses) leaves the subscription pool and bills at full API rates from a small non-rollover credit. Interactive terminal Claude is unaffected. This forks the project by brain:
+
+- **Build/curate phase → interactive Claude (now, $0).** Deriving the SSOT, relaxing tests, and building the harness skeleton are human-in-the-loop work — exactly right while the specs are unproven.
+- **Autonomous phase → `codex exec` ($0 at the margin, quota-bound).** Unlike Claude, `codex exec` runs under the **ChatGPT subscription**. Its cost is **quota** (token-based, rolling 5-hour + weekly windows) which is *shared with interactive coding* — not dollars. So the design minimizes quota burn.
+
+**Why the tour+judge split is quota-frugal:** tours navigate at **zero model quota** (deterministic Playwright). Quota is spent only on judging (high-volume, but small per-call and routed to the cheapest capable model) and issue authoring (low-volume, higher model).
+
+**Brain routing (all within one Codex subscription):**
+
+| Step | Model / effort | Rationale |
+|---|---|---|
+| Tour navigation | none (deterministic) | 0 quota |
+| Judge (high-volume) | **gpt-5.4-mini @ low** | ~30% of standard's quota → work lasts ~3.3× longer; judging is easy (read a11y tree, match one sentence, pass/fail). The ~4pt SWE-bench gap vs 5.5 is irrelevant for this task. |
+| Issue authoring (low-volume) | **gpt-5.5 @ medium** | Reasoning quality matters when writing a human-worthy issue; rare enough to afford. |
+
+Configured via named profiles in `config.toml` (or per-invocation `--model`/effort flags). *Note:* `gpt-5.3-codex` is the only model of the set supporting Codex **Cloud Tasks / Code Review** — keep documented as the option if the loop ever offloads to Codex Cloud instead of the VPS.
+
+**Cadence:** nightly full sweep (~3am) + optional per-PR diff-scoped run. A 3am sweep almost never overlaps interactive coding or a dev-sandbox session, so quota contention is minimal in practice.
+
+**Host:** prove the loop on the Pi (`raspberet`) under interactive Claude ($0), then graduate the autonomous `codex exec` loop to a **Hetzner CAX21** (4 vCPU / 8 GB ARM, ~€6.49/mo). The box doubles as general agent infra (dev-sandbox, experiments); since QA runs nightly and dev-sandbox runs daytime, they're temporally staggered and a small box suffices. Resize to **CAX31** (8 vCPU / 16 GB, ~€15.99/mo) on demand (Hetzner bills hourly with a monthly cap) if dev-sandbox sessions run hot. ARM matches the existing stack so images/scripts port cleanly from the Pi. Keep workloads in **separate containers** for hygiene — a hung 3am QA run shouldn't greet the morning's sandbox session with junk. The harness is **host-agnostic** ("a box with the repo, a seeded app, and Codex auth"), so the Pi-vs-VPS choice never leaks into its design.
+
+## Sequencing
+
+The SSOT is the foundation everything else consumes, so it goes first. Each piece below gets its own brainstorm → spec → plan → implementation cycle.
+
+1. **SSOT** — artifact schema, derivation pipeline, first domains derived + curated to `reviewed`.
+2. **Track A** — re-orient deterministic tests (API-level handler tests + Playwright relaxation), citing behavior IDs. Naturally interleaves with the MCP-server work.
+3. **Anti-drift** — traceability + CI coverage checks, once enough behaviors carry coverage links to be worth enforcing.
+4. **Track B** — the QA harness, proved on the Pi under interactive Claude, then graduated to `codex exec` on the VPS.
+
+## Key risks
+
+- **Spec quality is unproven.** The whole edifice rests on the intent specs being good oracles. Mitigation: prove the judge loop against real specs with a human in the loop ($0 interactive Claude) *before* investing in autonomous infra.
+- **Judge false positives/negatives.** A noisy judge erodes trust fast. Mitigation: `unsure` as a first-class verdict; start advisory; tune on a representative sweep before acting on issues automatically.
+- **Codex quota contention.** Even nightly, a large sweep could dent the coding bucket. Mitigation: mini@low judging, diff-scoping per-PR runs, deterministic (free) navigation, and measuring real burn before scaling cadence.
+- **SSOT drift.** Specs rot if maintenance relies on discipline. Mitigation: Piece 3's mechanical coverage checks.
+- **Derivation describes bugs as intent.** Deriving from current tests can codify present behavior as "intended." Mitigation: human curation gate (`draft`→`reviewed`), and the `current` vs `proposed` status to separate "is" from "ought."
+
+## Decisions locked (this brainstorm)
+
+- Two tracks: deterministic tests own business-logic correctness (API-level/data-asserted, also serving the MCP server); agentic layer owns UX quality.
+- Oracle = durable, DOM-free intent specs (the SSOT), one file per domain, behaviors with stable IDs + types + maturity states, in `spec/`.
+- Build the SSOT by deriving from existing tests/handlers → curate → backfill by priority.
+- Anti-drift via traceability + CI coverage checks (behavior IDs ↔ tests; flag orphans/dead IDs).
+- QA harness = assertion-free Playwright tours (0 model quota) capturing a11y snapshots + network → model judge → **GitHub issues** (not fix-PRs).
+- Brain: interactive Claude while proving it ($0); autonomous loop on `codex exec` under the ChatGPT subscription — gpt-5.4-mini@low judges, gpt-5.5@medium authors issues; agentic-explore deferred.
+- Cadence: nightly full sweep + optional per-PR diff-scoped run.
+- Host: prove on Pi `raspberet` → graduate to Hetzner CAX21 (resize to CAX31 on demand); shared agent infra; separate containers; host-agnostic design.
+- Deliverable of this brainstorm: this umbrella doc only. Detailed sub-specs deferred to their own brainstorms.

--- a/.ai/spec/llm-extraction-program.md
+++ b/.ai/spec/llm-extraction-program.md
@@ -1,0 +1,101 @@
+# LLM Extraction Program — North Star
+
+A program-level spec sitting *above* its implementation sub-projects. It defines the value, jobs-to-be-done, functional goals, principles, and decomposition for using LLM inference to extract relevant and valuable information from interaction data — including message and session/transcript content. Individual sub-projects (and the data-model work) get their own specs; this document is the shared reference they implement against.
+
+Related dependencies: Gmail integration ([#70](https://github.com/spengrah/PersonalCRM/issues/70)), gchat integration ([#337](https://github.com/spengrah/PersonalCRM/issues/337)), and the Anarlog session pipeline ([`mac-daemon-phase-2-anarlog-matching.md`](./mac-daemon-phase-2-anarlog-matching.md), which already anticipates a "future transcript pointer" on `meeting_note`).
+
+## North Star
+
+The CRM already collects a pile of conversational content — text messages, Telegram, calendar descriptions, and Anarlog meeting summaries — and extracts almost no meaning from it. An `interaction` is metadata-only (who, when, direction, source); a `contact` gets derived *timestamps* but nothing about *what was said, what matters to this person, or what you owe them*. This program turns that raw content into a **stateful, trustworthy understanding of each relationship** that informs how you show up — by reading content (not just metadata) to correct what the system gets wrong, surface what you should act on, and maintain a living sense of each person.
+
+The single moment this is all in service of: **the briefing** — "I'm about to call/meet/text someone; catch me up." Every extraction below feeds it.
+
+## Jobs to be done
+
+Five families of value, spanning two distinct kinds of work — **correction** (fix a signal the system already produces, badly) and **enrichment** (derive knowledge that exists nowhere today):
+
+- **Interpret / Correct** — read content to get the *interaction itself* right. The system flattens every message into a timestamped, directional event; conversations have *state* the metadata can't see. Correction jobs are self-validating: you feel it immediately when the CRM stops nagging you for a reply you don't owe.
+- **Act** — surface things you should *do*: commitments you made, open loops, follow-ups. Bidirectional — tasks in *your* court (your todo) and tasks in *their* court (a reason to nudge them).
+- **Prioritize** — make outreach smarter than fixed cadence: who's actually drifting and *why*, whether your set cadence matches reality.
+- **Remember** — facts and context about a person so you show up informed, especially *significant* moments (a job loss, an illness, a move, a milestone).
+- **Understand** — higher-altitude relationship signal: closeness, recurring themes, how a relationship is trending.
+
+The center of gravity is **action-producing** extraction (emit a corrected state, a flag, a task, a nudge), not passive trivia. A "knows their kid's name" file is only valuable insofar as it surfaces into the briefing.
+
+## Two modes + the keystone
+
+Everything produces value in one of two ways, consumed by one on-demand surface:
+
+- **Discrete extraction** — new content arrives → infer candidate item(s) → (review) → commit. Event-triggered, one-shot per piece of content. (Ball-in-court, substance filter, task extraction, big-things, drift.)
+- **Living-profile maintenance** — content continuously folds into an accumulated, kept-current understanding of each person. Stateful, never "done."
+- **The briefing (keystone)** — on-demand, reads *both* layers: the living profile plus the live open loops, at the moment before you reconnect.
+
+The shared backbone under every discrete job: **content → infer candidate items → surface for review → commit to state or fire an action.** Build that pipeline once; the jobs are different extractors plugged into it.
+
+## Functional goals
+
+Each goal names the content unit it operates on (the "unit-per-job" — extraction window is a property of the extractor, not a global choice) and the flow from what it reads to where it surfaces.
+
+| Goal | Family | Mode | Content unit | Reads → Emits → Surfaces |
+|------|--------|------|--------------|--------------------------|
+| Ball-in-court | Interpret/Correct | Discrete | Per-thread/conversation | Thread text → corrected "reply owed?" state → outreach queue (stops false nags) |
+| Substance vs. noise | Interpret/Correct | Discrete | Per-message/short-burst | Interaction content → a "meaningfulness" weight → cadence math, what counts as real contact |
+| Surface "big" moments | Remember + Prioritize | Discrete | Per-message / per-session | Messages, transcripts → flagged life-event → briefing, check-in prompt, profile |
+| Task extraction (bidirectional) | Act | Discrete | Per-conversation / per-meeting | Messages, transcripts → my-tasks **+** nudge-them tasks → Todoist, profile open-threads, briefing |
+| Dynamic cadence | Prioritize | Aggregate | Per-contact, time-windowed | Interaction pattern + substance → cadence-change suggestion → re-cadence prompt |
+| Drift-with-why | Prioritize + Understand | Aggregate | Per-contact, time-windowed | Recent history + content → drift alert **with reason** → outreach queue, check-in prompt |
+| Living relationship profile | Remember + Understand | Continuous | Continuous fold | All content over time → maintained profile buckets → contact page, briefing |
+| The briefing (keystone) | — consumer — | On-demand | Per-contact | Profile + open items → pre-interaction summary → MCP server (primary) + in-app surfaces |
+
+The living profile is made of a handful of buckets: **context/biography** (job, family, location, health, what's going on), **what they care about** (interests, values, recurring topics), **relationship texture** (closeness, how you met, shared history, inside references, the *real* cadence vs. the set one), **open threads** (where the discrete layer surfaces into the profile), and, eventually, **their network** (who they know — the connector angle).
+
+## Principles
+
+- **Ingest the rawest available signal.** Source-side summaries (e.g. Anarlog's local Qwen-generated summary) are ingested as *bonus metadata* — a cheap pre-filter, a display fallback — but never as the substrate. The transcript is the substrate. A summary is a lossy projection, and different jobs want different projections of the same content.
+- **Extract centrally.** One engine, one set of extractors, one review/provenance model across all sources. Sources are producers of raw content; the CRM is the single extraction brain.
+- **Provenance to raw.** Every emitted item — fact, task, state correction — links back to the source content that produced it, so it can be verified and trusted.
+- **Re-extractable / backfill-first.** Because raw is retained, a better extractor (or a new job invented later) can be re-run across the existing corpus. Upstream lossy extraction would forfeit this; we do not.
+- **Private, configurable inference endpoint.** Extractors call a configurable model API endpoint (OpenAI-compatible), with **per-job model selection** (a cheap model for the substance filter, a stronger one for profile synthesis). **Venice (private model endpoint — no logging, no retention) is the expected default**, and is what reconciles "send content to an LLM" with "local-first." The endpoint is swappable (local model, others). **Source-of-truth ≠ inference-location:** where the LLM runs is an independent, swappable choice; Anarlog's local model is potentially just one more endpoint the engine can call.
+- **Human review builds trust.** LLMs are wrong sometimes, and a wrong auto-correction erodes trust faster than no correction. Each job declares whether it auto-applies (self-validating corrections) or requires confirmation (tasks, profile facts, re-cadencing). The rollout/testing strategy is first-class, not an afterthought.
+- **Unit-per-job.** Each extractor declares its natural content window (per-message, per-thread, per-meeting, per-contact-aggregate, or continuous fold); the runtime batches accordingly.
+- **The briefing is structured/MCP-first.** It is queryable, composable data served to an agent — not primarily a rendered page. In-app UI is a secondary consumer of the same structured data.
+
+## Non-goals
+
+- **No phone-call/voicemail content extraction.** `phone_call` is metadata-only (direction, duration, answered/voicemail flags); no transcript or audio is ingested. Calls still inform cadence as metadata.
+- **No attachment/media-content extraction.** Only type/metadata tags, as today.
+- **No autonomous outward action.** The system surfaces tasks, nudges, and corrections for the user; it does not send messages or take outward action on the user's behalf. (Internal state corrections may auto-apply per the review model.)
+- **Not a generic chatbot over your data.** Scoped to the defined jobs and the briefing.
+- **No vendor lock-in and no logging/training endpoints.** Content only goes to a privacy-preserving, configurable endpoint.
+
+## Program decomposition
+
+Four sub-projects plus one cross-cutting pillar. Each sub-project gets its own spec.
+
+- **SP1 · Relationship data model (graph foundation).** Where extracted knowledge lives: the living-profile buckets, person↔person edges (the network/connector angle), fact provenance, and the staleness/contradiction/supersession model. Aligns with the planned graph re-architecture.
+- **SP2 · Ingestion / source completion.** The "fuel" foundation: Gmail ([#70](https://github.com/spengrah/PersonalCRM/issues/70)), Google Chat ([#337](https://github.com/spengrah/PersonalCRM/issues/337)), and Anarlog *raw transcripts* (extend the Mac daemon ingest to carry the transcript alongside the existing summary/memo). Messages and Telegram content already land today.
+- **SP3 · Extraction engine + extractors.** The shared backbone (*content → infer candidates → review → commit*), the configurable model-endpoint integration (Venice default, per-job model selection), the unit-per-job runtime, the individual extractors, and backfill.
+- **SP4 · Consuming surfaces.** The briefing served via an **MCP server (primary consumer)**, outreach-queue corrections, task surfacing into Todoist, the contact-page living profile, and big-thing / drift flags (likely via the existing needs-attention surface).
+- **Cross-cutting pillar (not a sub-project): trust / review / provenance.** The review model, auto-apply-vs-confirm thresholds, and rollout & testing strategy. Constrains SP3 and SP4 throughout.
+
+## Build sequence
+
+An A/B hybrid: front-load the *input* foundations (more fuel benefits everything, and these are already-planned dependencies) while proving the engine on a single self-validating job before investing in the data model and the diffuse-value enrichment layers.
+
+1. **Foundations + first proof.** Finish SP2 ingestion (Gmail, gchat, Anarlog transcripts) **and** ship the **ball-in-court** extractor on the existing relational model. Full fuel in; engine, configurable endpoint, and the review loop proven on a self-validating correction that earns trust cheaply.
+2. **SP1 — graph data model.** Profile buckets, edges, provenance, staleness/contradiction.
+3. **Discrete extractors + surfaces.** Substance filter (correction), task extraction (→ Todoist), big-things (enrichment).
+4. **Living profile + briefing + MCP server.** The capstone.
+5. **Aggregate jobs.** Dynamic cadence, drift-with-why.
+
+## Open questions
+
+Deferred to the relevant sub-project specs, but tracked here so they are not sleepwalked past:
+
+- **Staleness & contradiction model** (SP1): fact validity, supersession, decay. "Job-hunting" two years ago is stale; "lives in NYC" → "moved to LA" is a contradiction.
+- **Group / multi-party attribution**: who-said-what in group threads and multi-person meetings; whether a group message counts as contact with each participant. (May be eased by the graph model.)
+- **Review granularity & thresholds**: which jobs auto-apply vs. confirm; batch-review UX; whether review can happen via the MCP surface.
+- **Task reconciliation**: how extracted tasks/nudges reconcile with the existing Todoist outreach-task model (dedup, lifecycle, ownership).
+- **Profile representation**: regenerate-from-scratch vs. incremental fold; how the graph stores the buckets and their provenance.
+- **Relationship-type classification** (work / friend / family): needed to keep work noise out of a personal tool — in scope or out?
+- **Cost & scheduling**: real-time vs. nightly extraction; first-run backfill batch cost; per-job model matrix against Venice rate limits.

--- a/backend/internal/repository/calendar.go
+++ b/backend/internal/repository/calendar.go
@@ -420,6 +420,7 @@ func (r *CalendarEventRepository) FindLinkageCandidatesTx(ctx context.Context, t
 			ID:                 event.ID,
 			OccurredAt:         event.StartTime,
 			AttendeeContactIDs: event.MatchedContactIDs,
+			NormalizedTitle:    NormalizeCoalesceTitle(event.Title),
 		})
 	}
 	return out, nil

--- a/backend/internal/repository/linkage.go
+++ b/backend/internal/repository/linkage.go
@@ -5,6 +5,7 @@
 package repository
 
 import (
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -24,6 +25,35 @@ type LinkageCandidate struct {
 	OccurredAt         time.Time
 	AttendeeContactIDs []uuid.UUID
 	PeerContactID      *uuid.UUID
+
+	// Coalescing inputs — read only by the service-layer
+	// coalesceCandidates pass that collapses semantically-identical
+	// candidates within a kind before linkage classification. Populated
+	// by the two FindLinkageCandidatesTx projections from data they
+	// already read; left zero on any other construction site (which never
+	// feeds coalesceCandidates). Event candidates carry NormalizedTitle;
+	// phone_call candidates carry the rest.
+	NormalizedTitle string     // event: NormalizeCoalesceTitle(title); phone_call: ""
+	PeerNormalized  string     // phone_call: normalized peer number; event: ""
+	Service         string     // phone_call: voice/facetime_audio/...; event: ""
+	Direction       string     // phone_call: inbound/outbound; event: ""
+	DurationSeconds int32      // phone_call: call duration; event: 0
+	Answered        *bool      // phone_call: three-state (nil outbound / true / false); event: nil
+	InteractionID   *uuid.UUID // phone_call: linked interaction, if any; event: nil
+}
+
+// NormalizeCoalesceTitle normalizes a calendar event title for the
+// service-layer coalescing pass's same-meeting group key. It lowercases
+// and collapses internal/leading/trailing whitespace; a nil or
+// whitespace-only title normalizes to "". Exact normalized equality only
+// (no fuzzy matching), matching the "same normalized title" rule. Shared
+// between the calendar projection and the service-layer coalescer so both
+// derive identical keys.
+func NormalizeCoalesceTitle(title *string) string {
+	if title == nil {
+		return ""
+	}
+	return strings.ToLower(strings.Join(strings.Fields(*title), " "))
 }
 
 // ImpliedAttendeeSet returns the candidate's intrinsic participant

--- a/backend/internal/repository/phone_call.go
+++ b/backend/internal/repository/phone_call.go
@@ -231,10 +231,16 @@ func (r *PhoneCallRepository) FindLinkageCandidatesTx(ctx context.Context, tx pg
 		}
 		c := convertDbPhoneCall(row)
 		out = append(out, LinkageCandidate{
-			Kind:          LinkedKindPhoneCall,
-			ID:            c.ID,
-			OccurredAt:    c.StartedAt,
-			PeerContactID: c.MatchedContactID,
+			Kind:            LinkedKindPhoneCall,
+			ID:              c.ID,
+			OccurredAt:      c.StartedAt,
+			PeerContactID:   c.MatchedContactID,
+			PeerNormalized:  c.PeerNormalized,
+			Service:         c.Service,
+			Direction:       c.Direction,
+			DurationSeconds: c.DurationSeconds,
+			Answered:        c.Answered,
+			InteractionID:   c.InteractionID,
 		})
 	}
 	return out, nil

--- a/backend/internal/service/ingest.go
+++ b/backend/internal/service/ingest.go
@@ -1555,6 +1555,12 @@ func commonMeetingNoteInvariants(
 // rows. 15 minutes per sidecar spec §Linkage detection algorithm.
 const linkageWindow = 15 * time.Minute
 
+// phoneCoalesceWindow is the maximum gap between two same-number
+// phone_call candidates for them to be treated as one interaction (a
+// dropped/unanswered attempt + its redial, or two halves of one
+// dropped-and-resumed call). Tunable.
+const phoneCoalesceWindow = 5 * time.Minute
+
 // shouldRunInlineOnDuplicate is the dispatch-loop probe that allows
 // the inline handler to run even when Bus.PublishTx flagged the event
 // as a duplicate. For meeting_note.recorded specifically there are two
@@ -1905,6 +1911,7 @@ func (s *IngestService) handleMeetingNoteRecorded(
 		finalLinkedID           *uuid.UUID
 		desired                 []desiredInteraction
 		candidatesLen           int
+		coalescedLen            int
 		interactionsCreated     int
 		interactionsDropped     int
 		conflictSnapshot        []repository.ConflictCandidateSummary
@@ -1944,6 +1951,12 @@ func (s *IngestService) handleMeetingNoteRecorded(
 			candidates = append(candidates, pcCands...)
 		}
 		candidatesLen = len(candidates)
+		// Post-coalesce count for observability — coalescedLen < candidatesLen
+		// means coalescing collapsed a mirrored-meeting / dropped-redial
+		// pair. decideLinkage runs the same idempotent pass internally; the
+		// redundant call is cheap (window candidate sets are single digits)
+		// and side-effect-free.
+		coalescedLen = len(coalesceCandidates(candidates))
 		finalLinkageState, finalLinkedKind, finalLinkedID, desired, conflictSnapshot = decideLinkage(p, sessionID, candidates, resolvedTagged, titleMatched)
 		if len(conflictSnapshot) > 0 {
 			// Observability — log the top overlap whether or not we
@@ -2231,6 +2244,7 @@ func (s *IngestService) handleMeetingNoteRecorded(
 		Str("event", "linkage_decision").
 		Str("session_id", p.SourceID).
 		Int("candidates", candidatesLen).
+		Int("coalesced_candidates", coalescedLen).
 		Str("linkage_state", finalLinkageState).
 		Str("linked_kind", linkedKindStr).
 		Str("linked_id", linkedIDStr).
@@ -2251,6 +2265,173 @@ func (s *IngestService) handleMeetingNoteRecorded(
 		Msg("meeting_note linkage decision")
 
 	return needs, followUps, nil
+}
+
+// coalesceCandidates collapses semantically-identical linkage candidates
+// within a kind so that two equivalents become one, before decideLinkage
+// runs its 0/1/2+ classification. Two genuinely-distinct DB rows that
+// represent the same real-world interaction — the same calendar meeting
+// mirrored across two series/calendars (#370), or a dropped attempt + its
+// redial to the same number (#371) — would otherwise force a spurious
+// 2+ conflict. Cross-kind candidates are NEVER compared (an event and a
+// phone_call in the same window stay two candidates).
+//
+// Survivors are emitted in the original input order (a single pass over
+// the input keeps the kept candidate of each group), so the output is
+// deterministic and independent of map iteration order. The function is
+// idempotent and side-effect-free: a coalesced slice has no remaining
+// coalescible groups, so a second pass is a no-op.
+func coalesceCandidates(candidates []repository.LinkageCandidate) []repository.LinkageCandidate {
+	if len(candidates) < 2 {
+		return candidates
+	}
+
+	var events, calls []repository.LinkageCandidate
+	for _, c := range candidates {
+		switch c.Kind {
+		case repository.LinkedKindEvent:
+			events = append(events, c)
+		case repository.LinkedKindPhoneCall:
+			calls = append(calls, c)
+		}
+	}
+
+	keep := make(map[uuid.UUID]struct{}, len(candidates))
+	for id := range coalesceCalendar(events) {
+		keep[id] = struct{}{}
+	}
+	for id := range coalescePhone(calls) {
+		keep[id] = struct{}{}
+	}
+
+	out := make([]repository.LinkageCandidate, 0, len(candidates))
+	for _, c := range candidates {
+		// Kinds other than event/phone_call are never grouped (none exist
+		// today); pass them through untouched. Grouped kinds survive iff
+		// they are their group's chosen representative.
+		if c.Kind != repository.LinkedKindEvent && c.Kind != repository.LinkedKindPhoneCall {
+			out = append(out, c)
+			continue
+		}
+		if _, ok := keep[c.ID]; ok {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// coalesceCalendar returns the set of event-candidate IDs that survive
+// the #370 same-meeting coalescing rule. Candidates are grouped by
+// (NormalizedTitle, OccurredAt); within each group of 2+ the
+// representative is the one with the most matched attendees, tie-broken
+// by lowest ID. Empty-title candidates carry no semantic identity and are
+// never coalesced (each survives on its own). The group key derives from
+// the UTC instant so two times that .Equal share a key regardless of
+// location.
+func coalesceCalendar(events []repository.LinkageCandidate) map[uuid.UUID]struct{} {
+	keep := make(map[uuid.UUID]struct{}, len(events))
+	groups := make(map[string][]repository.LinkageCandidate)
+	for _, c := range events {
+		if c.NormalizedTitle == "" {
+			keep[c.ID] = struct{}{}
+			continue
+		}
+		key := c.NormalizedTitle + "\x00" + c.OccurredAt.UTC().Format(time.RFC3339Nano)
+		groups[key] = append(groups[key], c)
+	}
+	for _, group := range groups {
+		rep := pickCalendarRepresentative(group)
+		keep[rep] = struct{}{}
+	}
+	return keep
+}
+
+// pickCalendarRepresentative returns the ID of the representative of a
+// calendar group: most matched attendees, then lowest ID. Collects to a
+// slice and sorts (never relies on map iteration order).
+func pickCalendarRepresentative(group []repository.LinkageCandidate) uuid.UUID {
+	ranked := append([]repository.LinkageCandidate(nil), group...)
+	sort.Slice(ranked, func(i, j int) bool {
+		ai, aj := len(ranked[i].AttendeeContactIDs), len(ranked[j].AttendeeContactIDs)
+		if ai != aj {
+			return ai > aj
+		}
+		return ranked[i].ID.String() < ranked[j].ID.String()
+	})
+	return ranked[0].ID
+}
+
+// coalescePhone returns the set of phone_call-candidate IDs that survive
+// the #371 dropped-redial coalescing rule. Candidates are partitioned by
+// (PeerNormalized, Service, Direction) — all semantically-significant
+// dimensions, so opposite-direction or different-service same-number rows
+// never collapse. Within a partition, a sort-then-sweep single-linkage
+// cluster groups candidates whose consecutive gap is within
+// phoneCoalesceWindow; the representative of each cluster is the connected
+// (answered) / longest / interaction-linked call, tie-broken by lowest ID.
+// Candidates with an empty PeerNormalized carry no key and are never
+// coalesced.
+func coalescePhone(calls []repository.LinkageCandidate) map[uuid.UUID]struct{} {
+	keep := make(map[uuid.UUID]struct{}, len(calls))
+	partitions := make(map[string][]repository.LinkageCandidate)
+	for _, c := range calls {
+		if c.PeerNormalized == "" {
+			keep[c.ID] = struct{}{}
+			continue
+		}
+		key := c.PeerNormalized + "\x00" + c.Service + "\x00" + c.Direction
+		partitions[key] = append(partitions[key], c)
+	}
+	for _, partition := range partitions {
+		sort.Slice(partition, func(i, j int) bool {
+			if !partition[i].OccurredAt.Equal(partition[j].OccurredAt) {
+				return partition[i].OccurredAt.Before(partition[j].OccurredAt)
+			}
+			return partition[i].ID.String() < partition[j].ID.String()
+		})
+		// Single-linkage sweep: open a new cluster whenever the gap from
+		// the PREVIOUS candidate exceeds the window (gap-between-consecutive,
+		// not gap-from-anchor) — matches "redial seconds later, possibly
+		// several times".
+		cluster := []repository.LinkageCandidate{partition[0]}
+		flush := func() {
+			keep[pickPhoneRepresentative(cluster)] = struct{}{}
+		}
+		for i := 1; i < len(partition); i++ {
+			if partition[i].OccurredAt.Sub(partition[i-1].OccurredAt) > phoneCoalesceWindow {
+				flush()
+				cluster = []repository.LinkageCandidate{partition[i]}
+				continue
+			}
+			cluster = append(cluster, partition[i])
+		}
+		flush()
+	}
+	return keep
+}
+
+// pickPhoneRepresentative returns the ID of the representative of a phone
+// cluster: prefer answered/connected, then greatest DurationSeconds, then
+// a non-nil InteractionID, final tie-break lowest ID. Collects to a slice
+// and sorts (never relies on map iteration order).
+func pickPhoneRepresentative(cluster []repository.LinkageCandidate) uuid.UUID {
+	ranked := append([]repository.LinkageCandidate(nil), cluster...)
+	answered := func(c repository.LinkageCandidate) bool {
+		return c.Answered != nil && *c.Answered
+	}
+	sort.Slice(ranked, func(i, j int) bool {
+		if ai, aj := answered(ranked[i]), answered(ranked[j]); ai != aj {
+			return ai
+		}
+		if ranked[i].DurationSeconds != ranked[j].DurationSeconds {
+			return ranked[i].DurationSeconds > ranked[j].DurationSeconds
+		}
+		if hi, hj := ranked[i].InteractionID != nil, ranked[j].InteractionID != nil; hi != hj {
+			return hi
+		}
+		return ranked[i].ID.String() < ranked[j].ID.String()
+	})
+	return ranked[0].ID
 }
 
 // decideLinkage implements the spec's linkage-detection algorithm.
@@ -2285,6 +2466,10 @@ func decideLinkage(
 	resolvedTagged []resolvedTag,
 	titleMatched []resolvedTitle,
 ) (state string, linkedKind *string, linkedID *uuid.UUID, desired []desiredInteraction, snapshot []repository.ConflictCandidateSummary) {
+	// Collapse semantically-identical candidates within a kind before the
+	// 0/1/2+ classification — a mirrored meeting or dropped-redial pair
+	// becomes one candidate and flows into the existing auto-link path.
+	candidates = coalesceCandidates(candidates)
 	switch len(candidates) {
 	case 0:
 		if len(resolvedTagged) == 0 {

--- a/backend/internal/service/ingest_test.go
+++ b/backend/internal/service/ingest_test.go
@@ -1939,6 +1939,23 @@ func TestDecideLinkage_Phone_SameNumberDifferentDirection_StayTwo_Conflict(t *te
 	require.Len(t, snap, 2)
 }
 
+// TestDecideLinkage_Phone_SameNumberDifferentService_StayTwo_Conflict:
+// same number+direction, different service (voice vs FaceTime audio),
+// within window → not coalesced (Service is part of the partition key)
+// → conflict. Pins Service as a semantically-significant dimension so
+// dropping it from the key would regress this test.
+func TestDecideLinkage_Phone_SameNumberDifferentService_StayTwo_Conflict(t *testing.T) {
+	sessionID := uuid.New()
+	at := accelerated.GetCurrentTime()
+	cands := []repository.LinkageCandidate{
+		phoneCand("+15550000012", repository.PhoneCallServiceVoice, repository.PhoneCallDirectionInbound, at, coalesceBoolPtr(true), 60, nil),
+		phoneCand("+15550000012", repository.PhoneCallServiceFaceTimeAudio, repository.PhoneCallDirectionInbound, at.Add(30*time.Second), coalesceBoolPtr(true), 60, nil),
+	}
+	state, _, _, _, snap := decideLinkage(events.MeetingNoteRecordedPayload{}, sessionID, cands, nil, nil)
+	require.Equal(t, repository.LinkageStateConflictPending, state)
+	require.Len(t, snap, 2)
+}
+
 // TestDecideLinkage_Phone_EmptyPeerNormalized_StayTwo_Conflict: both peers
 // empty/unknown → never coalesced → conflict.
 func TestDecideLinkage_Phone_EmptyPeerNormalized_StayTwo_Conflict(t *testing.T) {
@@ -2024,7 +2041,9 @@ func TestDecideLinkage_CrossKind_OneEventOneCall_SameWindow_StayTwo_Conflict(t *
 }
 
 // TestCoalesceCandidates_Idempotent: coalescing a coalesced slice is a
-// no-op (Decision 6) — underpins the caller's double-call observability.
+// no-op — underpins the caller's double-call observability (the caller
+// counts post-coalesce candidates without changing decideLinkage's
+// internal pass).
 func TestCoalesceCandidates_Idempotent(t *testing.T) {
 	at := accelerated.GetCurrentTime()
 	cands := []repository.LinkageCandidate{

--- a/backend/internal/service/ingest_test.go
+++ b/backend/internal/service/ingest_test.go
@@ -1689,3 +1689,353 @@ func TestDecideLinkage_Step3_TiedTopFallsThroughToConflict(t *testing.T) {
 	require.Empty(t, desired)
 	require.Len(t, snap, 2)
 }
+
+// ----------------------------------------------------------------------------
+// coalesceCandidates — collapse same-meeting / dropped-redial candidates
+// ----------------------------------------------------------------------------
+
+func coalesceBoolPtr(b bool) *bool { return &b }
+
+func coalesceUUIDPtr(id uuid.UUID) *uuid.UUID { return &id }
+
+// TestNormalizeCoalesceTitle pins the title normalization shared between
+// the calendar projection and the service-layer coalescer. Exercised here
+// (service package) because make test-unit runs ./internal/service/... but
+// not ./internal/repository/....
+func TestNormalizeCoalesceTitle(t *testing.T) {
+	cases := []struct {
+		name string
+		in   *string
+		want string
+	}{
+		{"nil", nil, ""},
+		{"empty", stringPtr(""), ""},
+		{"trim", stringPtr("  Standup  "), "standup"},
+		{"collapse internal", stringPtr("Weekly   Sync"), "weekly sync"},
+		{"lowercase", stringPtr("WEEKLY sync"), "weekly sync"},
+		{"tabs and newlines", stringPtr("\tDaily\n"), "daily"},
+		{"whitespace only", stringPtr("   \t\n"), ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, repository.NormalizeCoalesceTitle(tc.in))
+		})
+	}
+}
+
+// eventCand builds an event LinkageCandidate with a normalized title.
+func eventCand(title string, occurredAt time.Time, attendees ...uuid.UUID) repository.LinkageCandidate {
+	return repository.LinkageCandidate{
+		Kind:               repository.LinkedKindEvent,
+		ID:                 uuid.New(),
+		OccurredAt:         occurredAt,
+		AttendeeContactIDs: attendees,
+		NormalizedTitle:    title,
+	}
+}
+
+// Calendar #370 ------------------------------------------------------------
+
+// TestDecideLinkage_Calendar_TwoSameTitleSameStart_CoalesceToOne_AutoLink:
+// two events, identical title + start, distinct rows/attendees → coalesced
+// to the most-attendees representative and auto-linked.
+func TestDecideLinkage_Calendar_TwoSameTitleSameStart_CoalesceToOne_AutoLink(t *testing.T) {
+	sessionID := uuid.New()
+	at := accelerated.GetCurrentTime()
+	more := eventCand("standup", at, uuid.New(), uuid.New())
+	fewer := eventCand("standup", at, uuid.New())
+	cands := []repository.LinkageCandidate{fewer, more}
+
+	state, kind, id, _, snap := decideLinkage(events.MeetingNoteRecordedPayload{}, sessionID, cands, nil, nil)
+	require.Equal(t, repository.LinkageStateLinked, state)
+	require.NotNil(t, kind)
+	require.Equal(t, repository.LinkedKindEvent, *kind)
+	require.NotNil(t, id)
+	require.Equal(t, more.ID, *id, "representative is the candidate with more attendees")
+	require.Empty(t, snap, "single survivor takes case 1 (no conflict snapshot)")
+}
+
+// TestDecideLinkage_Calendar_TwoSameTitleDifferentStart_StayTwo_Conflict:
+// same title, start 1 min apart → not coalesced → conflict.
+func TestDecideLinkage_Calendar_TwoSameTitleDifferentStart_StayTwo_Conflict(t *testing.T) {
+	sessionID := uuid.New()
+	at := accelerated.GetCurrentTime()
+	cands := []repository.LinkageCandidate{
+		eventCand("standup", at),
+		eventCand("standup", at.Add(time.Minute)),
+	}
+	state, _, _, _, snap := decideLinkage(events.MeetingNoteRecordedPayload{}, sessionID, cands, nil, nil)
+	require.Equal(t, repository.LinkageStateConflictPending, state)
+	require.Len(t, snap, 2)
+}
+
+// TestDecideLinkage_Calendar_TwoDifferentTitleSameStart_StayTwo_Conflict:
+// different titles, same start → not coalesced → conflict.
+func TestDecideLinkage_Calendar_TwoDifferentTitleSameStart_StayTwo_Conflict(t *testing.T) {
+	sessionID := uuid.New()
+	at := accelerated.GetCurrentTime()
+	cands := []repository.LinkageCandidate{
+		eventCand("standup", at),
+		eventCand("retro", at),
+	}
+	state, _, _, _, snap := decideLinkage(events.MeetingNoteRecordedPayload{}, sessionID, cands, nil, nil)
+	require.Equal(t, repository.LinkageStateConflictPending, state)
+	require.Len(t, snap, 2)
+}
+
+// TestDecideLinkage_Calendar_EmptyTitleSameStart_StayTwo_Conflict: both
+// titles empty → never coalesced (no semantic identity) → conflict. Guards
+// the empty-title rule and TestDecideLinkage_MultipleCandidates_ConflictPending.
+func TestDecideLinkage_Calendar_EmptyTitleSameStart_StayTwo_Conflict(t *testing.T) {
+	sessionID := uuid.New()
+	at := accelerated.GetCurrentTime()
+	cands := []repository.LinkageCandidate{
+		eventCand("", at),
+		eventCand("", at),
+	}
+	state, _, _, _, snap := decideLinkage(events.MeetingNoteRecordedPayload{}, sessionID, cands, nil, nil)
+	require.Equal(t, repository.LinkageStateConflictPending, state)
+	require.Len(t, snap, 2)
+}
+
+// TestDecideLinkage_Calendar_ThreeSameTitle_RepresentativeStableRegardlessOfOrder:
+// three same-group events; the most-attendees one wins, and a tie between
+// the other two breaks to lowest ID — stable across input order (map
+// iteration nondeterminism guard).
+func TestDecideLinkage_Calendar_ThreeSameTitle_RepresentativeStableRegardlessOfOrder(t *testing.T) {
+	sessionID := uuid.New()
+	at := accelerated.GetCurrentTime()
+	winner := eventCand("standup", at, uuid.New(), uuid.New()) // 2 attendees
+	tieA := eventCand("standup", at, uuid.New())               // 1 attendee
+	tieB := eventCand("standup", at, uuid.New())               // 1 attendee
+
+	orders := [][]repository.LinkageCandidate{
+		{winner, tieA, tieB},
+		{tieB, tieA, winner},
+		{tieA, winner, tieB},
+	}
+	for _, order := range orders {
+		state, _, id, _, _ := decideLinkage(events.MeetingNoteRecordedPayload{}, sessionID, order, nil, nil)
+		require.Equal(t, repository.LinkageStateLinked, state)
+		require.NotNil(t, id)
+		require.Equal(t, winner.ID, *id, "most-attendees candidate always wins regardless of order")
+	}
+
+	// Tie sub-case: two candidates, equal attendee counts → lowest ID wins.
+	t1 := eventCand("retro", at, uuid.New())
+	t2 := eventCand("retro", at, uuid.New())
+	expected := t1.ID
+	if t2.ID.String() < t1.ID.String() {
+		expected = t2.ID
+	}
+	for _, order := range [][]repository.LinkageCandidate{{t1, t2}, {t2, t1}} {
+		state, _, id, _, _ := decideLinkage(events.MeetingNoteRecordedPayload{}, sessionID, order, nil, nil)
+		require.Equal(t, repository.LinkageStateLinked, state)
+		require.NotNil(t, id)
+		require.Equal(t, expected, *id, "attendee-count tie breaks to lowest ID, stable across order")
+	}
+}
+
+// TestDecideLinkage_Calendar_DuplicatePairPlusDistinctThird_3to2_Conflict:
+// a true duplicate pair plus a genuinely-distinct third → coalesce 3→2 →
+// still conflict with a 2-entry snapshot. Guards against over-dropping.
+func TestDecideLinkage_Calendar_DuplicatePairPlusDistinctThird_3to2_Conflict(t *testing.T) {
+	sessionID := uuid.New()
+	at := accelerated.GetCurrentTime()
+	dupMore := eventCand("standup", at, uuid.New(), uuid.New())
+	dupFewer := eventCand("standup", at, uuid.New())
+	distinct := eventCand("retro", at)
+	cands := []repository.LinkageCandidate{dupMore, dupFewer, distinct}
+
+	state, _, _, _, snap := decideLinkage(events.MeetingNoteRecordedPayload{}, sessionID, cands, nil, nil)
+	require.Equal(t, repository.LinkageStateConflictPending, state)
+	require.Len(t, snap, 2, "duplicate pair collapses to one; distinct third remains")
+	gotIDs := map[uuid.UUID]struct{}{}
+	for _, s := range snap {
+		gotIDs[s.ID] = struct{}{}
+	}
+	require.Contains(t, gotIDs, dupMore.ID, "more-attendees survivor of the pair")
+	require.Contains(t, gotIDs, distinct.ID, "genuinely-distinct third candidate")
+	require.NotContains(t, gotIDs, dupFewer.ID, "dropped duplicate")
+}
+
+// Phone #371 ---------------------------------------------------------------
+
+// phoneCand builds a phone_call LinkageCandidate. answered/interaction may
+// be nil.
+func phoneCand(peer, service, direction string, at time.Time, answered *bool, duration int32, interaction *uuid.UUID) repository.LinkageCandidate {
+	return repository.LinkageCandidate{
+		Kind:            repository.LinkedKindPhoneCall,
+		ID:              uuid.New(),
+		OccurredAt:      at,
+		PeerNormalized:  peer,
+		Service:         service,
+		Direction:       direction,
+		Answered:        answered,
+		DurationSeconds: duration,
+		InteractionID:   interaction,
+	}
+}
+
+// TestDecideLinkage_Phone_TwoSameNumberWithinWindow_CoalesceToOne_AutoLinkToConnected:
+// a dropped attempt + connected redial 30s apart → coalesced to the
+// connected/longer call and auto-linked.
+func TestDecideLinkage_Phone_TwoSameNumberWithinWindow_CoalesceToOne_AutoLinkToConnected(t *testing.T) {
+	sessionID := uuid.New()
+	at := accelerated.GetCurrentTime()
+	dropped := phoneCand("+15550000001", repository.PhoneCallServiceVoice, repository.PhoneCallDirectionInbound, at, coalesceBoolPtr(false), 0, nil)
+	connected := phoneCand("+15550000001", repository.PhoneCallServiceVoice, repository.PhoneCallDirectionInbound, at.Add(30*time.Second), coalesceBoolPtr(true), 120, coalesceUUIDPtr(uuid.New()))
+	cands := []repository.LinkageCandidate{dropped, connected}
+
+	state, kind, id, _, snap := decideLinkage(events.MeetingNoteRecordedPayload{}, sessionID, cands, nil, nil)
+	require.Equal(t, repository.LinkageStateLinked, state)
+	require.NotNil(t, kind)
+	require.Equal(t, repository.LinkedKindPhoneCall, *kind)
+	require.NotNil(t, id)
+	require.Equal(t, connected.ID, *id, "representative is the answered/connected call")
+	require.Empty(t, snap)
+}
+
+// TestDecideLinkage_Phone_SameNumberOutsideWindow_StayTwo_Conflict: same
+// partition key, 6 min apart (> 5 min) → not coalesced → conflict.
+func TestDecideLinkage_Phone_SameNumberOutsideWindow_StayTwo_Conflict(t *testing.T) {
+	sessionID := uuid.New()
+	at := accelerated.GetCurrentTime()
+	cands := []repository.LinkageCandidate{
+		phoneCand("+15550000002", repository.PhoneCallServiceVoice, repository.PhoneCallDirectionInbound, at, coalesceBoolPtr(true), 60, nil),
+		phoneCand("+15550000002", repository.PhoneCallServiceVoice, repository.PhoneCallDirectionInbound, at.Add(6*time.Minute), coalesceBoolPtr(true), 60, nil),
+	}
+	state, _, _, _, snap := decideLinkage(events.MeetingNoteRecordedPayload{}, sessionID, cands, nil, nil)
+	require.Equal(t, repository.LinkageStateConflictPending, state)
+	require.Len(t, snap, 2)
+}
+
+// TestDecideLinkage_Phone_DifferentNumbers_StayTwo_Conflict: distinct
+// numbers, same time → not coalesced → conflict.
+func TestDecideLinkage_Phone_DifferentNumbers_StayTwo_Conflict(t *testing.T) {
+	sessionID := uuid.New()
+	at := accelerated.GetCurrentTime()
+	cands := []repository.LinkageCandidate{
+		phoneCand("+15550000003", repository.PhoneCallServiceVoice, repository.PhoneCallDirectionInbound, at, coalesceBoolPtr(true), 60, nil),
+		phoneCand("+15550000004", repository.PhoneCallServiceVoice, repository.PhoneCallDirectionInbound, at, coalesceBoolPtr(true), 60, nil),
+	}
+	state, _, _, _, snap := decideLinkage(events.MeetingNoteRecordedPayload{}, sessionID, cands, nil, nil)
+	require.Equal(t, repository.LinkageStateConflictPending, state)
+	require.Len(t, snap, 2)
+}
+
+// TestDecideLinkage_Phone_SameNumberDifferentDirection_StayTwo_Conflict:
+// same number+service, opposite directions, within window → not coalesced
+// (partition-key dimension guard) → conflict.
+func TestDecideLinkage_Phone_SameNumberDifferentDirection_StayTwo_Conflict(t *testing.T) {
+	sessionID := uuid.New()
+	at := accelerated.GetCurrentTime()
+	cands := []repository.LinkageCandidate{
+		phoneCand("+15550000005", repository.PhoneCallServiceVoice, repository.PhoneCallDirectionInbound, at, coalesceBoolPtr(false), 0, nil),
+		phoneCand("+15550000005", repository.PhoneCallServiceVoice, repository.PhoneCallDirectionOutbound, at.Add(30*time.Second), nil, 60, nil),
+	}
+	state, _, _, _, snap := decideLinkage(events.MeetingNoteRecordedPayload{}, sessionID, cands, nil, nil)
+	require.Equal(t, repository.LinkageStateConflictPending, state)
+	require.Len(t, snap, 2)
+}
+
+// TestDecideLinkage_Phone_EmptyPeerNormalized_StayTwo_Conflict: both peers
+// empty/unknown → never coalesced → conflict.
+func TestDecideLinkage_Phone_EmptyPeerNormalized_StayTwo_Conflict(t *testing.T) {
+	sessionID := uuid.New()
+	at := accelerated.GetCurrentTime()
+	cands := []repository.LinkageCandidate{
+		phoneCand("", repository.PhoneCallServiceVoice, repository.PhoneCallDirectionInbound, at, coalesceBoolPtr(true), 60, nil),
+		phoneCand("", repository.PhoneCallServiceVoice, repository.PhoneCallDirectionInbound, at.Add(30*time.Second), coalesceBoolPtr(true), 60, nil),
+	}
+	state, _, _, _, snap := decideLinkage(events.MeetingNoteRecordedPayload{}, sessionID, cands, nil, nil)
+	require.Equal(t, repository.LinkageStateConflictPending, state)
+	require.Len(t, snap, 2)
+}
+
+// TestDecideLinkage_Phone_RepresentativeTieBreak_DurationThenInteractionID:
+// two answered calls; one longer wins; a duration tie breaks to the one
+// with an InteractionID. Stable regardless of input order.
+func TestDecideLinkage_Phone_RepresentativeTieBreak_DurationThenInteractionID(t *testing.T) {
+	sessionID := uuid.New()
+	at := accelerated.GetCurrentTime()
+
+	// Duration tier: longer call wins.
+	longer := phoneCand("+15550000006", repository.PhoneCallServiceVoice, repository.PhoneCallDirectionInbound, at, coalesceBoolPtr(true), 180, nil)
+	shorter := phoneCand("+15550000006", repository.PhoneCallServiceVoice, repository.PhoneCallDirectionInbound, at.Add(20*time.Second), coalesceBoolPtr(true), 60, coalesceUUIDPtr(uuid.New()))
+	for _, order := range [][]repository.LinkageCandidate{{longer, shorter}, {shorter, longer}} {
+		state, _, id, _, _ := decideLinkage(events.MeetingNoteRecordedPayload{}, sessionID, order, nil, nil)
+		require.Equal(t, repository.LinkageStateLinked, state)
+		require.NotNil(t, id)
+		require.Equal(t, longer.ID, *id, "greater duration wins over InteractionID presence")
+	}
+
+	// InteractionID tier: equal duration, one has a linked interaction.
+	withInteraction := phoneCand("+15550000007", repository.PhoneCallServiceVoice, repository.PhoneCallDirectionInbound, at, coalesceBoolPtr(true), 90, coalesceUUIDPtr(uuid.New()))
+	without := phoneCand("+15550000007", repository.PhoneCallServiceVoice, repository.PhoneCallDirectionInbound, at.Add(20*time.Second), coalesceBoolPtr(true), 90, nil)
+	for _, order := range [][]repository.LinkageCandidate{{withInteraction, without}, {without, withInteraction}} {
+		state, _, id, _, _ := decideLinkage(events.MeetingNoteRecordedPayload{}, sessionID, order, nil, nil)
+		require.Equal(t, repository.LinkageStateLinked, state)
+		require.NotNil(t, id)
+		require.Equal(t, withInteraction.ID, *id, "duration tie breaks to the interaction-linked call")
+	}
+}
+
+// TestDecideLinkage_Phone_SingleLinkageCluster pins the consecutive-gap
+// sweep: A(0s),B(3m),C(6m) all chain into one cluster (A↔B and B↔C within
+// window, A↔C is not), but a single 6-min gap opens a second cluster.
+func TestDecideLinkage_Phone_SingleLinkageCluster(t *testing.T) {
+	sessionID := uuid.New()
+	at := accelerated.GetCurrentTime()
+
+	// Chain: three calls collapse to one via consecutive 3-min gaps.
+	a := phoneCand("+15550000008", repository.PhoneCallServiceVoice, repository.PhoneCallDirectionInbound, at, coalesceBoolPtr(false), 0, nil)
+	b := phoneCand("+15550000008", repository.PhoneCallServiceVoice, repository.PhoneCallDirectionInbound, at.Add(3*time.Minute), coalesceBoolPtr(true), 200, nil)
+	c := phoneCand("+15550000008", repository.PhoneCallServiceVoice, repository.PhoneCallDirectionInbound, at.Add(6*time.Minute), coalesceBoolPtr(false), 0, nil)
+	state, _, id, _, snap := decideLinkage(events.MeetingNoteRecordedPayload{}, sessionID, []repository.LinkageCandidate{a, b, c}, nil, nil)
+	require.Equal(t, repository.LinkageStateLinked, state, "single-linkage chain collapses to one cluster")
+	require.NotNil(t, id)
+	require.Equal(t, b.ID, *id, "connected/longest call across the cluster is the representative")
+	require.Empty(t, snap)
+
+	// Contrast: a single 6-min gap exceeds the window → two clusters.
+	d := phoneCand("+15550000009", repository.PhoneCallServiceVoice, repository.PhoneCallDirectionInbound, at, coalesceBoolPtr(true), 60, nil)
+	e := phoneCand("+15550000009", repository.PhoneCallServiceVoice, repository.PhoneCallDirectionInbound, at.Add(6*time.Minute), coalesceBoolPtr(true), 60, nil)
+	state2, _, _, _, snap2 := decideLinkage(events.MeetingNoteRecordedPayload{}, sessionID, []repository.LinkageCandidate{d, e}, nil, nil)
+	require.Equal(t, repository.LinkageStateConflictPending, state2)
+	require.Len(t, snap2, 2)
+}
+
+// Cross-kind guard ---------------------------------------------------------
+
+// TestDecideLinkage_CrossKind_OneEventOneCall_SameWindow_StayTwo_Conflict:
+// an event and a phone_call at the same instant are never coalesced across
+// kinds → conflict with a 2-entry snapshot.
+func TestDecideLinkage_CrossKind_OneEventOneCall_SameWindow_StayTwo_Conflict(t *testing.T) {
+	sessionID := uuid.New()
+	at := accelerated.GetCurrentTime()
+	cands := []repository.LinkageCandidate{
+		eventCand("standup", at),
+		phoneCand("+15550000010", repository.PhoneCallServiceVoice, repository.PhoneCallDirectionInbound, at, coalesceBoolPtr(true), 60, nil),
+	}
+	state, _, _, _, snap := decideLinkage(events.MeetingNoteRecordedPayload{}, sessionID, cands, nil, nil)
+	require.Equal(t, repository.LinkageStateConflictPending, state)
+	require.Len(t, snap, 2)
+}
+
+// TestCoalesceCandidates_Idempotent: coalescing a coalesced slice is a
+// no-op (Decision 6) — underpins the caller's double-call observability.
+func TestCoalesceCandidates_Idempotent(t *testing.T) {
+	at := accelerated.GetCurrentTime()
+	cands := []repository.LinkageCandidate{
+		eventCand("standup", at, uuid.New(), uuid.New()),
+		eventCand("standup", at, uuid.New()),
+		eventCand("retro", at),
+		phoneCand("+15550000011", repository.PhoneCallServiceVoice, repository.PhoneCallDirectionInbound, at, coalesceBoolPtr(false), 0, nil),
+		phoneCand("+15550000011", repository.PhoneCallServiceVoice, repository.PhoneCallDirectionInbound, at.Add(30*time.Second), coalesceBoolPtr(true), 120, nil),
+	}
+	once := coalesceCandidates(cands)
+	twice := coalesceCandidates(once)
+	require.Equal(t, len(once), len(twice), "second pass is a no-op")
+	require.Equal(t, once, twice)
+}

--- a/backend/internal/service/meeting_note.go
+++ b/backend/internal/service/meeting_note.go
@@ -443,6 +443,9 @@ func (s *MeetingNoteService) fetchCandidateAsLinkageTx(ctx context.Context, tx p
 			}
 			return nil, fmt.Errorf("read calendar event: %w", err)
 		}
+		// Coalescing-input fields intentionally left zero: this is a
+		// post-disambiguation projection of an already-chosen target and
+		// is never fed to coalesceCandidates.
 		return &repository.LinkageCandidate{
 			Kind:               repository.LinkedKindEvent,
 			ID:                 evt.ID,
@@ -462,6 +465,9 @@ func (s *MeetingNoteService) fetchCandidateAsLinkageTx(ctx context.Context, tx p
 			id := *call.MatchedContactID
 			peer = &id
 		}
+		// Coalescing-input fields intentionally left zero: this is a
+		// post-disambiguation projection of an already-chosen target and
+		// is never fed to coalesceCandidates.
 		return &repository.LinkageCandidate{
 			Kind:          repository.LinkedKindPhoneCall,
 			ID:            call.ID,

--- a/backend/tests/api/meeting_note_ingest_test.go
+++ b/backend/tests/api/meeting_note_ingest_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	cryptorand "crypto/rand"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -398,8 +399,18 @@ func (e *meetingNoteIngestEnv) seedAnarlogHumanResolvingTo(t *testing.T, email s
 
 // seedCalendarEventInWindow inserts a calendar_event row centered at
 // the given start time with the given matched_contact_ids. Returns the
-// inserted event ID.
+// inserted event ID. Delegates to seedCalendarEventInWindowWithTitle with
+// the default per-run title.
 func (e *meetingNoteIngestEnv) seedCalendarEventInWindow(t *testing.T, startTime time.Time, matchedContactIDs []uuid.UUID) uuid.UUID {
+	t.Helper()
+	return e.seedCalendarEventInWindowWithTitle(t, startTime, e.sourceIDPrefix+"Test Event", matchedContactIDs)
+}
+
+// seedCalendarEventInWindowWithTitle inserts a calendar_event row with a
+// caller-controlled title (used by coalescing tests, which key on the
+// normalized title) and a per-call random GcalEventID so each seeded row
+// is a distinct DB row. Returns the inserted event ID.
+func (e *meetingNoteIngestEnv) seedCalendarEventInWindowWithTitle(t *testing.T, startTime time.Time, title string, matchedContactIDs []uuid.UUID) uuid.UUID {
 	t.Helper()
 	ctx := context.Background()
 	suffix := uuid.NewString()[:8]
@@ -407,7 +418,7 @@ func (e *meetingNoteIngestEnv) seedCalendarEventInWindow(t *testing.T, startTime
 		GcalEventID:       e.sourceIDPrefix + "cal-" + suffix,
 		GcalCalendarID:    "primary",
 		GoogleAccountID:   "test-account",
-		Title:             stringPtr(e.sourceIDPrefix + "Test Event"),
+		Title:             stringPtr(title),
 		StartTime:         startTime,
 		EndTime:           startTime.Add(time.Hour),
 		Status:            "confirmed",
@@ -422,29 +433,63 @@ func (e *meetingNoteIngestEnv) seedCalendarEventInWindow(t *testing.T, startTime
 // seedPhoneCallInWindow inserts a phone_call row started at the given
 // time, scoped to the env's paired mac_host_id for cleanup, with an
 // optional matched_contact_id (the call's peer). Returns the inserted
-// phone_call ID. The synthetic call_unique_id embeds the env's source
-// prefix so cleanup-by-host_id finds the row deterministically.
+// phone_call ID. Delegates to seedPhoneCallInWindowFull with the default
+// voice/inbound/answered/60s shape.
 func (e *meetingNoteIngestEnv) seedPhoneCallInWindow(t *testing.T, startedAt time.Time, peerContactID *uuid.UUID) uuid.UUID {
+	t.Helper()
+	answered := true
+	return e.seedPhoneCallInWindowFull(t, startedAt, "+15550000000", repository.PhoneCallServiceVoice, repository.PhoneCallDirectionInbound, &answered, 60, peerContactID)
+}
+
+// seedPhoneCallInWindowFull inserts a phone_call row exposing every
+// discriminating field the coalescing rules key on — peerNormalized,
+// service, direction, answered, durationSeconds — so tests can drive the
+// (PeerNormalized, Service, Direction) partition key and representative
+// selection. The synthetic call_unique_id embeds the env's source prefix
+// and a per-call random suffix so each seeded row is a distinct DB row,
+// cleaned up by mac_host_id. Returns the inserted phone_call ID.
+func (e *meetingNoteIngestEnv) seedPhoneCallInWindowFull(t *testing.T, startedAt time.Time, peerNormalized, service, direction string, answered *bool, durationSeconds int32, peerContactID *uuid.UUID) uuid.UUID {
 	t.Helper()
 	ctx := context.Background()
 	suffix := uuid.NewString()[:8]
 	hostID := e.pairedHostID
-	answered := true
 	call, err := e.phoneCallRepo.UpsertCall(ctx, repository.UpsertPhoneCallParams{
 		CallUniqueID:     e.sourceIDPrefix + "call-" + suffix,
-		PeerHandle:       "+15550000000",
-		PeerNormalized:   "+15550000000",
-		Service:          repository.PhoneCallServiceVoice,
-		Direction:        repository.PhoneCallDirectionInbound,
-		Answered:         &answered,
+		PeerHandle:       peerNormalized,
+		PeerNormalized:   peerNormalized,
+		Service:          service,
+		Direction:        direction,
+		Answered:         answered,
 		HasVoicemail:     false,
-		DurationSeconds:  60,
+		DurationSeconds:  durationSeconds,
 		StartedAt:        startedAt,
 		MatchedContactID: peerContactID,
 		MacHostID:        &hostID,
 	})
 	require.NoError(t, err)
 	return call.ID
+}
+
+// coalesceWindowAnchor is a fixed far-past instant the coalescing tests
+// hang their per-run window bases off of. Far enough from the existing
+// time.Date(2026,5,...) conflict-test constants that the ±15-min windows
+// never overlap.
+var coalesceWindowAnchor = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// uniqueWindowBase returns a deterministic-but-run-unique instant for a
+// coalescing test's window, derived from the env's per-run random
+// sourceIDPrefix plus a per-test subOffset. Different runs land in
+// different windows (sourceIDPrefix is per-run random); within a run,
+// subOffsets ≥ 1 (hour) apart keep each test's ±15-min window disjoint.
+// This prevents an unrelated row from another test/run polluting the
+// window and flipping an expected 2→1 auto-link into a conflict.
+func (e *meetingNoteIngestEnv) uniqueWindowBase(subOffset int) time.Time {
+	sum := sha256.Sum256([]byte(e.sourceIDPrefix))
+	// Spread runs across ~100k hours (~11 years) so distinct runs almost
+	// never collide; the per-test subOffset (hours) keeps a run's tests
+	// well-separated.
+	runHours := int(binary.BigEndian.Uint32(sum[:4]) % 100000)
+	return coalesceWindowAnchor.Add(time.Duration(runHours+subOffset) * time.Hour)
 }
 
 // buildMNRecordedEvent constructs a meeting_note.recorded envelope ready
@@ -3003,9 +3048,13 @@ func TestResolveLink_PhoneCallPeerWalkinCorrect(t *testing.T) {
 	meetingAt := time.Date(2026, 5, 9, 11, 0, 0, 0, time.UTC)
 	// Two phone_call candidates so daemon-side lands in conflict_pending
 	// (case 2+ in decideLinkage). Each peer matches a different tagged
-	// contact, producing overlap=1 for both → no strict winner.
-	callA := env.seedPhoneCallInWindow(t, meetingAt.Add(1*time.Minute), &env.contactA)
-	env.seedPhoneCallInWindow(t, meetingAt.Add(2*time.Minute), &env.contactB)
+	// contact, producing overlap=1 for both → no strict winner. The two
+	// calls use DISTINCT peer numbers (a different real number resolves to
+	// each contact) so the dropped-redial coalescing pass does not collapse
+	// them — they are genuinely-different interactions, not a redial pair.
+	answered := true
+	callA := env.seedPhoneCallInWindowFull(t, meetingAt.Add(1*time.Minute), randomTestPhoneNumber(t), repository.PhoneCallServiceVoice, repository.PhoneCallDirectionInbound, &answered, 60, &env.contactA)
+	env.seedPhoneCallInWindowFull(t, meetingAt.Add(2*time.Minute), randomTestPhoneNumber(t), repository.PhoneCallServiceVoice, repository.PhoneCallDirectionInbound, &answered, 60, &env.contactB)
 
 	sessionUUID := env.newSessionUUID()
 	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Peer Walk-In Regression", []string{anarlogA, anarlogB})
@@ -3274,4 +3323,220 @@ func TestResolveLink_LinkThenResyncPreservesUserChoice(t *testing.T) {
 	require.Equal(t, eventA, *afterResync.LinkedID,
 		"linked_id stays pinned to the user's pick across re-sync")
 	require.Empty(t, afterResync.ConflictCandidates)
+}
+
+// ----------------------------------------------------------------------------
+// Candidate coalescing (#370 calendar mirror, #371 phone dropped-redial)
+// ----------------------------------------------------------------------------
+
+// randomTestPhoneNumber returns a per-call-unique +1555 number so phone
+// coalescing tests do not collide in the shared test DB's global phone
+// window query.
+func randomTestPhoneNumber(t *testing.T) string {
+	t.Helper()
+	var buf [4]byte
+	_, err := cryptorand.Read(buf[:])
+	require.NoError(t, err)
+	return fmt.Sprintf("+1555%07d", binary.BigEndian.Uint32(buf[:])%10000000)
+}
+
+// assertCalendarWindowExactly opens a read-only tx and asserts the
+// calendar linkage finder returns exactly the expected event IDs for the
+// ±linkageWindow around meetingAt — a loud backstop against an unrelated
+// row polluting the auto-link cases (where ConflictCandidates is empty by
+// design so membership cannot be asserted on the persisted row).
+func assertCalendarWindowExactly(t *testing.T, env *meetingNoteIngestEnv, meetingAt time.Time, expected ...uuid.UUID) {
+	t.Helper()
+	ctx := context.Background()
+	tx, err := env.database.Pool.Begin(ctx)
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback(ctx) }()
+	cands, err := env.calendarRepo.FindLinkageCandidatesTx(ctx, tx, meetingAt.Add(-15*time.Minute), meetingAt.Add(15*time.Minute))
+	require.NoError(t, err)
+	got := make([]uuid.UUID, 0, len(cands))
+	for _, c := range cands {
+		got = append(got, c.ID)
+	}
+	require.ElementsMatch(t, expected, got, "calendar window must contain exactly the seeded rows (no pollutant)")
+}
+
+// assertPhoneWindowExactly is the phone analogue of
+// assertCalendarWindowExactly.
+func assertPhoneWindowExactly(t *testing.T, env *meetingNoteIngestEnv, meetingAt time.Time, expected ...uuid.UUID) {
+	t.Helper()
+	ctx := context.Background()
+	tx, err := env.database.Pool.Begin(ctx)
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback(ctx) }()
+	cands, err := env.phoneCallRepo.FindLinkageCandidatesTx(ctx, tx, meetingAt.Add(-15*time.Minute), meetingAt.Add(15*time.Minute))
+	require.NoError(t, err)
+	got := make([]uuid.UUID, 0, len(cands))
+	for _, c := range cands {
+		got = append(got, c.ID)
+	}
+	require.ElementsMatch(t, expected, got, "phone window must contain exactly the seeded rows (no pollutant)")
+}
+
+// TestMeetingNote_CalendarCoalesce_SameMeetingMirrored: the same meeting
+// mirrored across two calendars/series (same title + start, distinct rows,
+// different matched-contact counts) coalesces to the more-attendees
+// representative and auto-links — no spurious conflict (#370).
+func TestMeetingNote_CalendarCoalesce_SameMeetingMirrored(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	meetingAt := env.uniqueWindowBase(1)
+	title := env.sourceIDPrefix + "Mirrored Standup"
+	rep := env.seedCalendarEventInWindowWithTitle(t, meetingAt, title, []uuid.UUID{env.contactA, env.contactB})
+	dup := env.seedCalendarEventInWindowWithTitle(t, meetingAt, title, []uuid.UUID{env.contactC})
+
+	assertCalendarWindowExactly(t, env, meetingAt, rep, dup)
+
+	sessionUUID := env.newSessionUUID()
+	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, title, nil)
+	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseMNIngestResp(t, w)
+	require.Equal(t, 1, resp.Accepted)
+	require.Empty(t, resp.NeedsAttention, "mirrored meeting coalesces and auto-links → no needs_attention")
+
+	row := findMeetingNoteRow(t, env, sessionUUID)
+	require.NotNil(t, row)
+	require.Equal(t, repository.LinkageStateLinked, row.LinkageState)
+	require.NotNil(t, row.LinkedKind)
+	require.Equal(t, repository.LinkedKindEvent, *row.LinkedKind)
+	require.NotNil(t, row.LinkedID)
+	require.Equal(t, rep, *row.LinkedID, "representative is the more-attendees mirror")
+	require.Empty(t, row.ConflictCandidates)
+}
+
+// TestMeetingNote_CalendarNoCoalesce_DifferentStart_StillConflict: two
+// same-title events 1 min apart are NOT coalesced (start differs) and
+// stay a conflict — guards against over-coalescing (#370 negative case).
+func TestMeetingNote_CalendarNoCoalesce_DifferentStart_StillConflict(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	meetingAt := env.uniqueWindowBase(2)
+	title := env.sourceIDPrefix + "Recurring Sync"
+	eventA := env.seedCalendarEventInWindowWithTitle(t, meetingAt, title, []uuid.UUID{env.contactA})
+	eventB := env.seedCalendarEventInWindowWithTitle(t, meetingAt.Add(time.Minute), title, []uuid.UUID{env.contactB})
+
+	sessionUUID := env.newSessionUUID()
+	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, title, nil)
+	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseMNIngestResp(t, w)
+	require.Equal(t, 1, resp.Accepted)
+	require.Len(t, resp.NeedsAttention, 1)
+	require.Equal(t, "conflict", resp.NeedsAttention[0].Reason)
+
+	row := findMeetingNoteRow(t, env, sessionUUID)
+	require.NotNil(t, row)
+	require.Equal(t, repository.LinkageStateConflictPending, row.LinkageState)
+	var snap []repository.ConflictCandidateSummary
+	require.NoError(t, json.Unmarshal(row.ConflictCandidates, &snap))
+	require.Len(t, snap, 2)
+	snapIDs := map[uuid.UUID]struct{}{}
+	for _, s := range snap {
+		snapIDs[s.ID] = struct{}{}
+	}
+	require.Contains(t, snapIDs, eventA)
+	require.Contains(t, snapIDs, eventB)
+}
+
+// TestMeetingNote_PhoneCoalesce_DroppedThenRedial: a dropped attempt
+// followed 30s later by the connected redial to the same number coalesces
+// to the connected call and auto-links — no spurious conflict (#371).
+func TestMeetingNote_PhoneCoalesce_DroppedThenRedial(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	meetingAt := env.uniqueWindowBase(3)
+	peer := randomTestPhoneNumber(t)
+	dropped := false
+	connected := true
+	droppedID := env.seedPhoneCallInWindowFull(t, meetingAt, peer, repository.PhoneCallServiceVoice, repository.PhoneCallDirectionInbound, &dropped, 0, nil)
+	connectedID := env.seedPhoneCallInWindowFull(t, meetingAt.Add(30*time.Second), peer, repository.PhoneCallServiceVoice, repository.PhoneCallDirectionInbound, &connected, 120, nil)
+
+	assertPhoneWindowExactly(t, env, meetingAt, droppedID, connectedID)
+
+	sessionUUID := env.newSessionUUID()
+	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, env.sourceIDPrefix+"Call Session", nil)
+	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseMNIngestResp(t, w)
+	require.Equal(t, 1, resp.Accepted)
+	require.Empty(t, resp.NeedsAttention, "dropped+redial coalesces and auto-links → no needs_attention")
+
+	row := findMeetingNoteRow(t, env, sessionUUID)
+	require.NotNil(t, row)
+	require.Equal(t, repository.LinkageStateLinked, row.LinkageState)
+	require.NotNil(t, row.LinkedKind)
+	require.Equal(t, repository.LinkedKindPhoneCall, *row.LinkedKind)
+	require.NotNil(t, row.LinkedID)
+	require.Equal(t, connectedID, *row.LinkedID, "representative is the connected call")
+	require.Empty(t, row.ConflictCandidates)
+}
+
+// TestMeetingNote_PhoneNoCoalesce_OutsideWindow_StillConflict: two
+// same-number calls 6 min apart (> phoneCoalesceWindow) are NOT coalesced
+// and stay a conflict (#371 negative case).
+func TestMeetingNote_PhoneNoCoalesce_OutsideWindow_StillConflict(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	meetingAt := env.uniqueWindowBase(4)
+	peer := randomTestPhoneNumber(t)
+	answered := true
+	callA := env.seedPhoneCallInWindowFull(t, meetingAt, peer, repository.PhoneCallServiceVoice, repository.PhoneCallDirectionInbound, &answered, 60, nil)
+	callB := env.seedPhoneCallInWindowFull(t, meetingAt.Add(6*time.Minute), peer, repository.PhoneCallServiceVoice, repository.PhoneCallDirectionInbound, &answered, 60, nil)
+
+	sessionUUID := env.newSessionUUID()
+	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, env.sourceIDPrefix+"Two Calls Session", nil)
+	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseMNIngestResp(t, w)
+	require.Equal(t, 1, resp.Accepted)
+	require.Len(t, resp.NeedsAttention, 1)
+	require.Equal(t, "conflict", resp.NeedsAttention[0].Reason)
+
+	row := findMeetingNoteRow(t, env, sessionUUID)
+	require.NotNil(t, row)
+	require.Equal(t, repository.LinkageStateConflictPending, row.LinkageState)
+	var snap []repository.ConflictCandidateSummary
+	require.NoError(t, json.Unmarshal(row.ConflictCandidates, &snap))
+	require.Len(t, snap, 2)
+	snapIDs := map[uuid.UUID]struct{}{}
+	for _, s := range snap {
+		snapIDs[s.ID] = struct{}{}
+	}
+	require.Contains(t, snapIDs, callA)
+	require.Contains(t, snapIDs, callB)
+}
+
+// TestMeetingNote_CrossKind_EventPlusCall_StillConflict: an event and a
+// phone_call in the same window are never coalesced across kinds and stay
+// a conflict (end-to-end cross-kind guard).
+func TestMeetingNote_CrossKind_EventPlusCall_StillConflict(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	meetingAt := env.uniqueWindowBase(5)
+	eventID := env.seedCalendarEventInWindowWithTitle(t, meetingAt, env.sourceIDPrefix+"Cross Kind Event", []uuid.UUID{env.contactA})
+	peer := randomTestPhoneNumber(t)
+	answered := true
+	callID := env.seedPhoneCallInWindowFull(t, meetingAt, peer, repository.PhoneCallServiceVoice, repository.PhoneCallDirectionInbound, &answered, 60, nil)
+
+	sessionUUID := env.newSessionUUID()
+	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, env.sourceIDPrefix+"Cross Kind Session", nil)
+	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseMNIngestResp(t, w)
+	require.Equal(t, 1, resp.Accepted)
+	require.Len(t, resp.NeedsAttention, 1)
+	require.Equal(t, "conflict", resp.NeedsAttention[0].Reason)
+
+	row := findMeetingNoteRow(t, env, sessionUUID)
+	require.NotNil(t, row)
+	require.Equal(t, repository.LinkageStateConflictPending, row.LinkageState)
+	var snap []repository.ConflictCandidateSummary
+	require.NoError(t, json.Unmarshal(row.ConflictCandidates, &snap))
+	require.Len(t, snap, 2)
+	snapIDs := map[uuid.UUID]struct{}{}
+	for _, s := range snap {
+		snapIDs[s.ID] = struct{}{}
+	}
+	require.Contains(t, snapIDs, eventID)
+	require.Contains(t, snapIDs, callID)
 }


### PR DESCRIPTION
Closes #370
Closes #371

## What & why

When a recorded session's linkage window contained two DB rows that represent the *same* real-world interaction, the daemon-side linkage path treated them as two distinct candidates and surfaced a spurious "which meeting was this?" conflict card. Two concrete cases: (a) one calendar meeting mirrored across two recurring series or two calendars/accounts (same normalized title, same start time, distinct event IDs), and (b) a dropped/unanswered call followed seconds later by the connected redial to the same number (two phone rows, distinct call IDs, same peer). Both are semantically one interaction, so forcing the user to disambiguate them is noise.

This adds a within-kind coalescing pass (`coalesceCandidates`) as the first statement of `decideLinkage`, before the existing 0/1/2+ classification. It collapses semantically-identical candidates *within a kind* so a duplicate pair becomes one candidate and flows into the existing auto-link path; everything downstream (disambiguation, conflict snapshot, persistence) is unchanged. Genuinely-distinct candidates — different title, different start, different number, far apart, or different kind — still conflict exactly as before. Cross-kind candidates (an event and a call in the same window) are never compared.

## How

- **Calendar rule (#370):** group by `(normalized title, start time)`; within a group the representative is the candidate with the most matched attendees, tie-broken by lowest ID. Empty-title events carry no semantic identity and are never coalesced.
- **Phone rule (#371):** partition by `(normalized peer, service, direction)` — all semantically-significant dimensions, so opposite-direction or different-service same-number rows never collapse — then a sort-then-sweep single-linkage cluster groups calls whose consecutive gap is within a tunable 5-minute window. The representative is the connected/longest/interaction-linked call, tie-broken by lowest ID. Empty-peer rows are never coalesced.
- **No new query, no migration, no API/frontend change.** Seven coalescing-input fields were threaded onto `LinkageCandidate`, populated by the two existing `FindLinkageCandidatesTx` projections from data they already read. Representative selection is fully deterministic (collect-to-slice + sort with a total-order ID tie-break; survivors emitted in original input order).
- **Observability:** the raw window count stays as `candidates`; a new `coalesced_candidates` log field reports the post-coalesce count, so a 2→1 auto-link is visible in logs.

## Tests

- Unit: a `NormalizeCoalesceTitle` table test plus a coalescing matrix driven through `decideLinkage` — same-title/same-start auto-link, different-start/different-title/empty-title negatives, three-way representative stability across input orders, mixed 3→2 reduction, phone within/outside window, different-number/direction/service negatives, empty-peer negative, representative tie-breaks, single-linkage cluster semantics, cross-kind guard, idempotence.
- Integration (through the real ingest path): mirrored-meeting auto-link, same-title-different-start conflict, dropped+redial auto-link, outside-window conflict, cross-kind conflict — each with per-run-unique window isolation and a candidate-finder backstop assertion to keep the shared test DB clean.
- One pre-existing integration test that seeded two same-number calls purely to force a conflict was updated to use distinct peer numbers (an impossible real-world scenario under the new rule); its walk-in assertion is unaffected.

## Note on commits

The first two commits are pre-existing `.ai/spec/*` design docs the maintainer directed to land as-is, isolated into their own `docs(spec):` commits before the feature commits.