### PR TITLE
fix(meeting-note): resolve orphan via "Log as impromptu" (orphan_needs_review → linked_impromptu)

### DIFF
--- a/backend/internal/db/meeting_note.sql.go
+++ b/backend/internal/db/meeting_note.sql.go
@@ -31,7 +31,7 @@ type ClearMeetingNoteConflictParams struct {
 }
 
 // Promotes a row in EITHER attention state (conflict_pending or
-// orphan_needs_review) to a "none of these" Step 4 outcome. For a
+// orphan_needs_review) to a "none of these" outcome. For a
 // conflict_pending row the caller derives the outcome from decideLinkage
 // (linked_impromptu / orphan_title_augmented / orphan_needs_review); for
 // an orphan_needs_review row the caller forces linked_impromptu (the

--- a/backend/internal/db/meeting_note.sql.go
+++ b/backend/internal/db/meeting_note.sql.go
@@ -20,7 +20,7 @@ UPDATE meeting_note SET
     resolved_set_hash   = $2
 WHERE id = $3
   AND deleted_at IS NULL
-  AND linkage_state = 'conflict_pending'
+  AND linkage_state IN ('conflict_pending', 'orphan_needs_review')
 RETURNING id, anarlog_session_id, title, summary, memo, participants, mac_host_id, linked_kind, linked_id, linkage_state, deleted_at, created_at, input_hash, resolved_set_hash, last_content_hash, meeting_at, conflict_candidates
 `
 
@@ -30,13 +30,17 @@ type ClearMeetingNoteConflictParams struct {
 	ID                 pgtype.UUID `json:"id"`
 }
 
-// Promotes a conflict_pending row to the "none of these" Step 4 outcome
-// (linked_impromptu / orphan_title_augmented / orphan_needs_review).
-// Caller supplies the new state AND the new resolved_set_hash so the
-// next daemon-side carry-forward correctly preserves the user's
-// decision when matching inputs haven't changed. Clears linked_kind,
-// linked_id, conflict_candidates. Returns pgx.ErrNoRows when the row
-// is not in conflict_pending.
+// Promotes a row in EITHER attention state (conflict_pending or
+// orphan_needs_review) to a "none of these" Step 4 outcome. For a
+// conflict_pending row the caller derives the outcome from decideLinkage
+// (linked_impromptu / orphan_title_augmented / orphan_needs_review); for
+// an orphan_needs_review row the caller forces linked_impromptu (the
+// "Log as impromptu" action). Caller supplies the new state AND the new
+// resolved_set_hash so the next daemon-side carry-forward correctly
+// preserves the user's decision when matching inputs haven't changed.
+// Clears linked_kind, linked_id, conflict_candidates. Returns
+// pgx.ErrNoRows when the row is in neither attention state (terminal,
+// soft-deleted, or missing).
 func (q *Queries) ClearMeetingNoteConflict(ctx context.Context, arg ClearMeetingNoteConflictParams) (*MeetingNote, error) {
 	row := q.db.QueryRow(ctx, ClearMeetingNoteConflict, arg.NewState, arg.NewResolvedSetHash, arg.ID)
 	var i MeetingNote

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -45,7 +45,7 @@ type Querier interface {
 	// partial claims and roll back.
 	ClaimTelegramMessages(ctx context.Context, arg ClaimTelegramMessagesParams) ([]pgtype.UUID, error)
 	// Promotes a row in EITHER attention state (conflict_pending or
-	// orphan_needs_review) to a "none of these" Step 4 outcome. For a
+	// orphan_needs_review) to a "none of these" outcome. For a
 	// conflict_pending row the caller derives the outcome from decideLinkage
 	// (linked_impromptu / orphan_title_augmented / orphan_needs_review); for
 	// an orphan_needs_review row the caller forces linked_impromptu (the

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -44,13 +44,17 @@ type Querier interface {
 	// the row IDs actually claimed (RETURNING id) so the caller can detect
 	// partial claims and roll back.
 	ClaimTelegramMessages(ctx context.Context, arg ClaimTelegramMessagesParams) ([]pgtype.UUID, error)
-	// Promotes a conflict_pending row to the "none of these" Step 4 outcome
-	// (linked_impromptu / orphan_title_augmented / orphan_needs_review).
-	// Caller supplies the new state AND the new resolved_set_hash so the
-	// next daemon-side carry-forward correctly preserves the user's
-	// decision when matching inputs haven't changed. Clears linked_kind,
-	// linked_id, conflict_candidates. Returns pgx.ErrNoRows when the row
-	// is not in conflict_pending.
+	// Promotes a row in EITHER attention state (conflict_pending or
+	// orphan_needs_review) to a "none of these" Step 4 outcome. For a
+	// conflict_pending row the caller derives the outcome from decideLinkage
+	// (linked_impromptu / orphan_title_augmented / orphan_needs_review); for
+	// an orphan_needs_review row the caller forces linked_impromptu (the
+	// "Log as impromptu" action). Caller supplies the new state AND the new
+	// resolved_set_hash so the next daemon-side carry-forward correctly
+	// preserves the user's decision when matching inputs haven't changed.
+	// Clears linked_kind, linked_id, conflict_candidates. Returns
+	// pgx.ErrNoRows when the row is in neither attention state (terminal,
+	// soft-deleted, or missing).
 	ClearMeetingNoteConflict(ctx context.Context, arg ClearMeetingNoteConflictParams) (*MeetingNote, error)
 	// Defensive recovery branch: clears claim columns for rows still
 	// carrying the expected stale session_ref. Used when the engine

--- a/backend/internal/db/queries/meeting_note.sql
+++ b/backend/internal/db/queries/meeting_note.sql
@@ -196,7 +196,7 @@ RETURNING *;
 
 -- name: ClearMeetingNoteConflict :one
 -- Promotes a row in EITHER attention state (conflict_pending or
--- orphan_needs_review) to a "none of these" Step 4 outcome. For a
+-- orphan_needs_review) to a "none of these" outcome. For a
 -- conflict_pending row the caller derives the outcome from decideLinkage
 -- (linked_impromptu / orphan_title_augmented / orphan_needs_review); for
 -- an orphan_needs_review row the caller forces linked_impromptu (the

--- a/backend/internal/db/queries/meeting_note.sql
+++ b/backend/internal/db/queries/meeting_note.sql
@@ -195,13 +195,17 @@ WHERE id = sqlc.arg('id')
 RETURNING *;
 
 -- name: ClearMeetingNoteConflict :one
--- Promotes a conflict_pending row to the "none of these" Step 4 outcome
--- (linked_impromptu / orphan_title_augmented / orphan_needs_review).
--- Caller supplies the new state AND the new resolved_set_hash so the
--- next daemon-side carry-forward correctly preserves the user's
--- decision when matching inputs haven't changed. Clears linked_kind,
--- linked_id, conflict_candidates. Returns pgx.ErrNoRows when the row
--- is not in conflict_pending.
+-- Promotes a row in EITHER attention state (conflict_pending or
+-- orphan_needs_review) to a "none of these" Step 4 outcome. For a
+-- conflict_pending row the caller derives the outcome from decideLinkage
+-- (linked_impromptu / orphan_title_augmented / orphan_needs_review); for
+-- an orphan_needs_review row the caller forces linked_impromptu (the
+-- "Log as impromptu" action). Caller supplies the new state AND the new
+-- resolved_set_hash so the next daemon-side carry-forward correctly
+-- preserves the user's decision when matching inputs haven't changed.
+-- Clears linked_kind, linked_id, conflict_candidates. Returns
+-- pgx.ErrNoRows when the row is in neither attention state (terminal,
+-- soft-deleted, or missing).
 UPDATE meeting_note SET
     linked_kind         = NULL,
     linked_id           = NULL,
@@ -210,7 +214,7 @@ UPDATE meeting_note SET
     resolved_set_hash   = sqlc.arg('new_resolved_set_hash')
 WHERE id = sqlc.arg('id')
   AND deleted_at IS NULL
-  AND linkage_state = 'conflict_pending'
+  AND linkage_state IN ('conflict_pending', 'orphan_needs_review')
 RETURNING *;
 
 -- name: TestHardDeleteMeetingNotesByHostID :exec

--- a/backend/internal/repository/meeting_note.go
+++ b/backend/internal/repository/meeting_note.go
@@ -455,8 +455,12 @@ func (r *MeetingNoteRepository) ResolveMeetingNoteToLinkedTx(ctx context.Context
 
 // ClearMeetingNoteConflictTx clears (linked_kind, linked_id,
 // conflict_candidates) and sets linkage_state + resolved_set_hash to
-// the caller-supplied values. State-guarded to conflict_pending —
-// returns db.ErrNotFound when the row has moved on (caller maps to 409).
+// the caller-supplied values. State-guarded to the attention states
+// (conflict_pending or orphan_needs_review) — returns db.ErrNotFound
+// when the row has moved on to a terminal state (caller maps to 409).
+// Despite the name, this also promotes orphan_needs_review rows (the
+// "Log as impromptu" path forces linked_impromptu); the name is kept
+// to avoid rippling a rename through the generated db package.
 //
 // The caller passes the freshly-computed resolved_set_hash so the next
 // daemon-side carry-forward correctly preserves the user's decision

--- a/backend/internal/service/ingest.go
+++ b/backend/internal/service/ingest.go
@@ -2475,13 +2475,7 @@ func decideLinkage(
 		if len(resolvedTagged) == 0 {
 			return repository.LinkageStateOrphanNeedsReview, nil, nil, nil, nil
 		}
-		out := make([]desiredInteraction, 0, len(resolvedTagged)+len(titleMatched))
-		for _, r := range resolvedTagged {
-			out = append(out, desiredInteraction{
-				ContactID: r.ContactID,
-				SourceRef: fmt.Sprintf("anarlog:%s:%s", sessionID.String(), r.ContactID.String()),
-			})
-		}
+		out := taggedImpromptuInteractions(sessionID, resolvedTagged)
 		if len(titleMatched) > 0 {
 			for _, tm := range titleMatched {
 				out = append(out, desiredInteraction{
@@ -2512,6 +2506,23 @@ func decideLinkage(
 		}
 		return repository.LinkageStateConflictPending, nil, nil, nil, snap
 	}
+}
+
+// taggedImpromptuInteractions builds one impromptu desiredInteraction per
+// resolved tagged contact with the canonical
+// `anarlog:<session>:<contact>` source_ref. Shared by decideLinkage's
+// zero-candidate branch and the user-driven "Log as impromptu" resolve so
+// the two paths cannot drift in how they shape the tagged interaction set.
+// Returns an empty (non-nil) slice for empty input.
+func taggedImpromptuInteractions(sessionID uuid.UUID, tagged []resolvedTag) []desiredInteraction {
+	out := make([]desiredInteraction, 0, len(tagged))
+	for _, r := range tagged {
+		out = append(out, desiredInteraction{
+			ContactID: r.ContactID,
+			SourceRef: fmt.Sprintf("anarlog:%s:%s", sessionID.String(), r.ContactID.String()),
+		})
+	}
+	return out
 }
 
 // stepFiveWalkins emits one walk-in supplemental desiredInteraction per

--- a/backend/internal/service/ingest_test.go
+++ b/backend/internal/service/ingest_test.go
@@ -2058,3 +2058,37 @@ func TestCoalesceCandidates_Idempotent(t *testing.T) {
 	require.Equal(t, len(once), len(twice), "second pass is a no-op")
 	require.Equal(t, once, twice)
 }
+
+// TestTaggedImpromptuInteractions: the shared helper emits one
+// desiredInteraction per tagged contact with the canonical
+// anarlog:<session>:<contact> source_ref, and an empty (non-nil) slice
+// for empty input. Pins the contract shared by decideLinkage case-0 and
+// resolveOrphanToImpromptu so the two paths cannot drift.
+func TestTaggedImpromptuInteractions(t *testing.T) {
+	session := uuid.New()
+	cA := uuid.New()
+	cB := uuid.New()
+
+	t.Run("empty input → empty non-nil slice", func(t *testing.T) {
+		got := taggedImpromptuInteractions(session, nil)
+		require.NotNil(t, got)
+		require.Empty(t, got)
+	})
+
+	t.Run("one interaction per tagged contact with canonical source_ref", func(t *testing.T) {
+		tagged := []resolvedTag{
+			{AnarlogID: uuid.NewString(), ContactID: cA},
+			{AnarlogID: uuid.NewString(), ContactID: cB},
+		}
+		got := taggedImpromptuInteractions(session, tagged)
+		require.Len(t, got, 2)
+		require.Equal(t, cA, got[0].ContactID)
+		require.Equal(t, "anarlog:"+session.String()+":"+cA.String(), got[0].SourceRef)
+		require.Equal(t, cB, got[1].ContactID)
+		require.Equal(t, "anarlog:"+session.String()+":"+cB.String(), got[1].SourceRef)
+		// No :title: refs — this helper only shapes tagged interactions.
+		for _, d := range got {
+			require.NotContains(t, d.SourceRef, ":title:")
+		}
+	})
+}

--- a/backend/internal/service/meeting_note.go
+++ b/backend/internal/service/meeting_note.go
@@ -66,7 +66,8 @@ type ContactNameReader interface {
 var ErrResolveLinkRowNotFound = errors.New("meeting_note not found")
 
 // ErrResolveLinkNotPending is returned when the row exists but is not in
-// linkage_state = 'conflict_pending'. Handler maps to 409.
+// one of the resolvable attention states (conflict_pending or
+// orphan_needs_review) — i.e. a terminal state. Handler maps to 409.
 var ErrResolveLinkNotPending = errors.New("meeting_note is not awaiting conflict resolution")
 
 // ErrResolveLinkSnapshotMissing is returned when the row is in
@@ -175,27 +176,46 @@ func (s *MeetingNoteService) ResolveLink(ctx context.Context, mnID uuid.UUID, in
 			}
 			return fmt.Errorf("read meeting_note: %w", err)
 		}
-		if prior.LinkageState != repository.LinkageStateConflictPending {
-			return ErrResolveLinkNotPending
-		}
-
-		if input != nil {
-			res, created, fus, ferr := s.resolveToLinked(ctx, tx, prior, *input)
+		// Only the two attention states are resolvable. conflict_pending
+		// runs the candidate-driven flow; orphan_needs_review accepts only
+		// the "Log as impromptu" (none_of_these) action. Any other state
+		// (terminal, soft-deleted, missing) is rejected as 409/404.
+		switch prior.LinkageState {
+		case repository.LinkageStateConflictPending:
+			if input != nil {
+				res, created, fus, ferr := s.resolveToLinked(ctx, tx, prior, *input)
+				if ferr != nil {
+					return ferr
+				}
+				result = &ResolveLinkResult{MeetingNote: res, InteractionsCreated: created}
+				followUps = fus
+				return nil
+			}
+			res, created, fus, ferr := s.resolveNoneOfThese(ctx, tx, prior)
 			if ferr != nil {
 				return ferr
 			}
 			result = &ResolveLinkResult{MeetingNote: res, InteractionsCreated: created}
 			followUps = fus
 			return nil
+		case repository.LinkageStateOrphanNeedsReview:
+			// An orphan has no candidate snapshot, so action="link" is
+			// meaningless — reject it as a non-candidate before reaching the
+			// forced-impromptu write. The orphan card never sends "link", so
+			// this is defense-in-depth against a malformed client.
+			if input != nil {
+				return ErrResolveLinkIDNotCandidate
+			}
+			res, created, fus, ferr := s.resolveOrphanToImpromptu(ctx, tx, prior)
+			if ferr != nil {
+				return ferr
+			}
+			result = &ResolveLinkResult{MeetingNote: res, InteractionsCreated: created}
+			followUps = fus
+			return nil
+		default:
+			return ErrResolveLinkNotPending
 		}
-
-		res, created, fus, ferr := s.resolveNoneOfThese(ctx, tx, prior)
-		if ferr != nil {
-			return ferr
-		}
-		result = &ResolveLinkResult{MeetingNote: res, InteractionsCreated: created}
-		followUps = fus
-		return nil
 	})
 	if txErr != nil {
 		return nil, txErr
@@ -350,6 +370,122 @@ func (s *MeetingNoteService) resolveNoneOfThese(ctx context.Context, tx pgx.Tx, 
 	}
 
 	updated, err := s.meetingWriter.ClearMeetingNoteConflictTx(ctx, tx, prior.ID, newState, newResolvedSetHash)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return nil, nil, nil, ErrResolveLinkNotPending
+		}
+		return nil, nil, nil, fmt.Errorf("clear meeting_note conflict: %w", err)
+	}
+	return updated, created, followUps, nil
+}
+
+// resolveOrphanToImpromptu implements the "Log as impromptu" action on an
+// orphan_needs_review row. Unlike resolveNoneOfThese (which re-runs
+// decideLinkage and lets the zero-candidate sub-machine pick the state),
+// this FORCES linked_impromptu — the user has explicitly declared the
+// session a real meeting, and a participant-less orphan would otherwise
+// recompute straight back to orphan_needs_review and never leave the
+// queue.
+//
+// To keep the forced linked_impromptu state truthful, the branch creates
+// ONLY tagged-participant interactions, never title-derived ones (a
+// `:title:` interaction would, per spec, demand orphan_title_augmented).
+// It still runs the full title-match loop, but title matches feed the
+// resolved_set_hash ONLY — matched tokens produce no interaction, and
+// unmatched tokens are upserted as weak discovery candidates. The
+// persisted hash is computed over the UNION of tag-resolved ∪
+// title-matched contact IDs, byte-for-byte the recipe the daemon
+// recomputes (computeResolvedSetHash) — so an identical re-sync carries
+// the user's linked_impromptu decision forward via carry-forward instead
+// of recomputing a divergent orphan_title_augmented and creating a
+// `:title:` interaction.
+//
+// For a genuine orphan (no resolvable participants) resolvedTagged is
+// empty, desired is empty, and the row lands linked_impromptu with zero
+// interactions — a terminal outcome reached only via explicit user
+// decision, which the daemon path never produces on its own.
+func (s *MeetingNoteService) resolveOrphanToImpromptu(ctx context.Context, tx pgx.Tx, prior *repository.MeetingNote) (*repository.MeetingNote, []CreatedInteraction, []func(context.Context), error) {
+	resolvedTagged, err := s.reResolveTagged(ctx, tx, prior.Participants)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// Tagged-participant interactions only — never title-derived.
+	desired := taggedImpromptuInteractions(prior.AnarlogSessionID, resolvedTagged)
+
+	// Run the full title-match loop (same recipe as resolveNoneOfThese)
+	// purely to collect title-matched contact IDs for the hash and to
+	// upsert unmatched tokens to discovery. Matched tokens deliberately
+	// produce no interaction here.
+	titleStr := ""
+	if prior.Title != nil {
+		titleStr = *prior.Title
+	}
+	titleTokens := anarlog.ExtractNameTokens(titleStr)
+	titleMatchedIDs := make([]uuid.UUID, 0, len(titleTokens))
+	titleUnmatched := make([]string, 0, len(titleTokens))
+	for _, token := range titleTokens {
+		if s.titleMatcher == nil {
+			titleUnmatched = append(titleUnmatched, token)
+			continue
+		}
+		match, mErr := s.titleMatcher.MatchTitleToken(ctx, token)
+		if mErr != nil {
+			return nil, nil, nil, fmt.Errorf("match title token %q: %w", token, mErr)
+		}
+		if match == nil {
+			titleUnmatched = append(titleUnmatched, token)
+			continue
+		}
+		// Dedup against resolvedTagged so a title token that is also a
+		// tagged participant contributes its interaction via the tagged
+		// path and is excluded from the title-matched set (same dedup the
+		// daemon does), preventing a double-count in the union hash.
+		alreadyTagged := false
+		for _, r := range resolvedTagged {
+			if r.ContactID == match.Contact.ID {
+				alreadyTagged = true
+				break
+			}
+		}
+		if alreadyTagged {
+			continue
+		}
+		titleMatchedIDs = append(titleMatchedIDs, match.Contact.ID)
+	}
+
+	resolvedIDs := make([]uuid.UUID, len(resolvedTagged))
+	for i, r := range resolvedTagged {
+		resolvedIDs[i] = r.ContactID
+	}
+	// Hash over the UNION (tag-resolved ∪ title-matched) — the same recipe
+	// the daemon recomputes on re-sync — even though title matches created
+	// no interaction. Hashing the tagged set alone would flip the row to
+	// orphan_title_augmented on the next identical sync and undo the user's
+	// decision.
+	newResolvedSetHash, err := computeResolvedSetHash(resolvedIDs, titleMatchedIDs)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("compute resolved set hash: %w", err)
+	}
+
+	created, followUps, err := s.writeDesiredInteractions(ctx, tx, prior, desired)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// Surface unmatched title tokens as weak discovery candidates — the
+	// same rows the daemon-side ingest path would have created.
+	if s.titleDiscovery != nil {
+		for _, token := range titleUnmatched {
+			if dErr := s.titleDiscovery.UpsertTitleCandidateTx(ctx, tx, prior.AnarlogSessionID, strings.ToLower(token), token); dErr != nil {
+				return nil, nil, nil, fmt.Errorf("upsert title candidate %q: %w", token, dErr)
+			}
+		}
+	}
+
+	// Force linked_impromptu regardless of whether desired is empty — this
+	// is the behavioral difference from resolveNoneOfThese.
+	updated, err := s.meetingWriter.ClearMeetingNoteConflictTx(ctx, tx, prior.ID, repository.LinkageStateLinkedImpromptu, newResolvedSetHash)
 	if err != nil {
 		if errors.Is(err, db.ErrNotFound) {
 			return nil, nil, nil, ErrResolveLinkNotPending

--- a/backend/tests/api/meeting_note_ingest_test.go
+++ b/backend/tests/api/meeting_note_ingest_test.go
@@ -3153,6 +3153,294 @@ func TestResolveLink_NoneOfTheseToOrphanTitleAugmented(t *testing.T) {
 	require.Contains(t, gotRefs, titleRef, "title-derived interaction created")
 }
 
+// resolveLinkResponse is the resolve-link success envelope, sufficient
+// to assert on interactions_created.
+type resolveLinkResponse struct {
+	Success bool `json:"success"`
+	Data    struct {
+		MeetingNote         json.RawMessage `json:"meeting_note"`
+		InteractionsCreated []struct {
+			ContactID string `json:"contact_id"`
+			SourceRef string `json:"source_ref"`
+		} `json:"interactions_created"`
+	} `json:"data"`
+}
+
+func parseResolveLinkResp(t *testing.T, w *httptest.ResponseRecorder) resolveLinkResponse {
+	t.Helper()
+	var r resolveLinkResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&r), "body: %s", w.Body.String())
+	return r
+}
+
+// buildMNRecordedEventWithSummary is buildMNRecordedEvent plus a Summary
+// field. Used to drive a content-changing re-sync (different
+// last_content_hash) while keeping the matching inputs (title,
+// participants, meeting_at → input_hash + resolved_set_hash) unchanged.
+func buildMNRecordedEventWithSummary(t *testing.T, hostID uuid.UUID, sessionUUID string, meetingAt time.Time, title, summary string, participantIDs []string) map[string]any {
+	t.Helper()
+	tp := title
+	sm := summary
+	p := events.MeetingNoteRecordedPayload{
+		Version:        1,
+		HostID:         hostID,
+		Source:         "anarlog_sessions",
+		SourceID:       sessionUUID,
+		Title:          &tp,
+		Summary:        &sm,
+		MeetingAt:      meetingAt,
+		ParticipantIDs: participantIDs,
+	}
+	pBytes, err := events.Marshal(events.KindMeetingNoteRecorded, p)
+	require.NoError(t, err)
+	hashHex, err := service.ComputeContentHash(pBytes)
+	require.NoError(t, err)
+	return map[string]any{
+		"source":      "anarlog_sessions",
+		"source_id":   sessionUUID + "@" + hashHex,
+		"kind":        string(events.KindMeetingNoteRecorded),
+		"payload":     json.RawMessage(pBytes),
+		"observed_at": accelerated.GetCurrentTime(),
+	}
+}
+
+// TestResolveLink_OrphanToImpromptu_Success — an orphan_needs_review row
+// (no candidates, no resolvable tagged humans) resolves to
+// linked_impromptu via "Log as impromptu" (none_of_these). State flips,
+// pointers stay nil, and no interaction is created (no resolved
+// participant to attach one to). The row also leaves the
+// needs-attention list.
+func TestResolveLink_OrphanToImpromptu_Success(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	sessionUUID := env.newSessionUUID()
+	meetingAt := time.Date(2026, 5, 11, 9, 0, 0, 0, time.UTC)
+	// No candidate, no participants → orphan_needs_review.
+	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Orphan To Impromptu", nil)
+	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	row := findMeetingNoteRow(t, env, sessionUUID)
+	require.NotNil(t, row)
+	require.Equal(t, repository.LinkageStateOrphanNeedsReview, row.LinkageState, "sanity: lands orphan")
+
+	w = postResolveLink(t, env, row.ID.String(), map[string]any{"action": "none_of_these"})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseResolveLinkResp(t, w)
+	require.Empty(t, resp.Data.InteractionsCreated, "no resolved participant → no interaction")
+
+	updated := findMeetingNoteRow(t, env, sessionUUID)
+	require.NotNil(t, updated)
+	require.Equal(t, repository.LinkageStateLinkedImpromptu, updated.LinkageState)
+	require.Nil(t, updated.LinkedKind)
+	require.Nil(t, updated.LinkedID)
+	require.Empty(t, updated.ConflictCandidates)
+	require.Empty(t, listSessionInteractions(t, env, sessionUUID))
+
+	// The resolved row left the needs-attention set.
+	naW := getNeedsAttention(t, env, env.pairedHostID.String())
+	require.Equal(t, http.StatusOK, naW.Code, "body: %s", naW.Body.String())
+	require.NotContains(t, naW.Body.String(), sessionUUID,
+		"resolved orphan must leave the needs-attention list")
+}
+
+// TestResolveLink_TerminalStatesReturn409 — the widened IN(...) guard
+// must still reject every terminal state. Table-driven over linked,
+// linked_impromptu, and orphan_title_augmented (the last shares the
+// orphan_ prefix and is the trap a sloppy LIKE 'orphan_%' guard would
+// admit). Each → 409.
+func TestResolveLink_TerminalStatesReturn409(t *testing.T) {
+	cases := []struct {
+		name  string
+		drive func(t *testing.T, env *meetingNoteIngestEnv) *repository.MeetingNote
+	}{
+		{
+			name: "linked",
+			drive: func(t *testing.T, env *meetingNoteIngestEnv) *repository.MeetingNote {
+				meetingAt := time.Date(2026, 5, 11, 10, 0, 0, 0, time.UTC)
+				env.seedCalendarEventInWindow(t, meetingAt, []uuid.UUID{env.contactA})
+				sessionUUID := env.newSessionUUID()
+				ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Terminal Linked", nil)
+				w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
+				require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+				row := findMeetingNoteRow(t, env, sessionUUID)
+				require.NotNil(t, row)
+				require.Equal(t, repository.LinkageStateLinked, row.LinkageState, "single candidate auto-links")
+				return row
+			},
+		},
+		{
+			name: "linked_impromptu",
+			drive: func(t *testing.T, env *meetingNoteIngestEnv) *repository.MeetingNote {
+				suffix := strings.TrimSuffix(strings.TrimPrefix(env.sourceIDPrefix, "mn-ingest-"), "-")
+				anarlogA := env.seedAnarlogHumanResolvingTo(t, fmt.Sprintf("mn-test-0-%s@example.invalid", suffix))
+				meetingAt := time.Date(2026, 5, 11, 11, 0, 0, 0, time.UTC)
+				sessionUUID := env.newSessionUUID()
+				ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Terminal Impromptu", []string{anarlogA})
+				w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
+				require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+				row := findMeetingNoteRow(t, env, sessionUUID)
+				require.NotNil(t, row)
+				require.Equal(t, repository.LinkageStateLinkedImpromptu, row.LinkageState)
+				return row
+			},
+		},
+		{
+			name: "orphan_title_augmented",
+			drive: func(t *testing.T, env *meetingNoteIngestEnv) *repository.MeetingNote {
+				suffix := strings.TrimSuffix(strings.TrimPrefix(env.sourceIDPrefix, "mn-ingest-"), "-")
+				anarlogA := env.seedAnarlogHumanResolvingTo(t, fmt.Sprintf("mn-test-0-%s@example.invalid", suffix))
+				tokenT := newTitleToken(t, env)
+				seedTitleContact(t, env, tokenT+" Brown")
+				meetingAt := time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC)
+				sessionUUID := env.newSessionUUID()
+				ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, tokenT+" sync", []string{anarlogA})
+				w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
+				require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+				row := findMeetingNoteRow(t, env, sessionUUID)
+				require.NotNil(t, row)
+				require.Equal(t, repository.LinkageStateOrphanTitleAugmented, row.LinkageState,
+					"tagged + matched title → orphan_title_augmented")
+				return row
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := setupMeetingNoteIngestEnv(t)
+			row := tc.drive(t, env)
+			w := postResolveLink(t, env, row.ID.String(), map[string]any{"action": "none_of_these"})
+			require.Equal(t, http.StatusConflict, w.Code,
+				"terminal state %s must 409 — body: %s", tc.name, w.Body.String())
+		})
+	}
+}
+
+// TestResolveLink_OrphanLinkActionRejected — action="link" on an orphan
+// (which has no candidate snapshot) is rejected as 400, not 500.
+func TestResolveLink_OrphanLinkActionRejected(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+	sessionUUID := env.newSessionUUID()
+	meetingAt := time.Date(2026, 5, 11, 13, 0, 0, 0, time.UTC)
+	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Orphan Link Rejected", nil)
+	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	row := findMeetingNoteRow(t, env, sessionUUID)
+	require.NotNil(t, row)
+	require.Equal(t, repository.LinkageStateOrphanNeedsReview, row.LinkageState)
+
+	w = postResolveLink(t, env, row.ID.String(), map[string]any{
+		"action": "link",
+		"kind":   "event",
+		"id":     uuid.NewString(),
+	})
+	require.Equal(t, http.StatusBadRequest, w.Code, "body: %s", w.Body.String())
+
+	// State unchanged — the rejected link is a no-op.
+	after := findMeetingNoteRow(t, env, sessionUUID)
+	require.NotNil(t, after)
+	require.Equal(t, repository.LinkageStateOrphanNeedsReview, after.LinkageState)
+}
+
+// TestResolveLink_OrphanToImpromptu_WithNewlyResolvableParticipant —
+// exercises the state↔interaction invariant AND the union-hash
+// carry-forward fix. Two DISTINCT contacts: T (the tagged human, made
+// resolvable AFTER ingest via import) and M (a title-matched contact,
+// resolvable from the title throughout). At ingest no tags resolve → the
+// row is orphan_needs_review even though M title-matches. After T is
+// imported, "Log as impromptu" creates exactly one interaction (T's
+// tagged anchor) and NO :title: interaction for M, and persists the
+// union hash so a content-changing re-sync carries linked_impromptu
+// forward instead of flipping to orphan_title_augmented.
+func TestResolveLink_OrphanToImpromptu_WithNewlyResolvableParticipant(t *testing.T) {
+	env := setupMeetingNoteIngestEnv(t)
+
+	// M — title-matched contact, distinct from T, resolvable from the
+	// title throughout.
+	tokenM := newTitleToken(t, env)
+	contactM := seedTitleContact(t, env, tokenM+" Vance")
+
+	// T — tagged human that is NOT resolvable at ingest (unique email, no
+	// matching contact yet).
+	unmatchedEmail := "unmatched-" + uuid.NewString()[:8] + "@example.invalid"
+	anarlogT := env.seedAnarlogHumanResolvingTo(t, unmatchedEmail)
+
+	sessionUUID := env.newSessionUUID()
+	meetingAt := time.Date(2026, 5, 11, 14, 0, 0, 0, time.UTC)
+	title := tokenM + " sync"
+	rec := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, title, []string{anarlogT})
+	w := postMNIngest(t, env, map[string]any{"events": []any{rec}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	// At ingest: T unresolved, title alone doesn't lift the orphan.
+	row := findMeetingNoteRow(t, env, sessionUUID)
+	require.NotNil(t, row)
+	require.Equal(t, repository.LinkageStateOrphanNeedsReview, row.LinkageState,
+		"title match alone does not promote a no-tag orphan")
+	require.Empty(t, listSessionInteractions(t, env, sessionUUID))
+
+	// Make T resolvable via the real import/link handler (links T's
+	// anarlog_human identity to env.contactA).
+	ctx := context.Background()
+	external, err := env.externalRepo.GetBySource(ctx, "anarlog_humans", anarlogT, nil)
+	require.NoError(t, err)
+	require.NotNil(t, external)
+	linkBody, _ := json.Marshal(map[string]any{"crm_contact_id": env.contactA.String()})
+	linkReq := httptest.NewRequest(http.MethodPost,
+		"/api/v1/imports/candidates/"+external.ID.String()+"/link",
+		bytes.NewReader(linkBody))
+	linkReq.Header.Set("Content-Type", "application/json")
+	linkW := httptest.NewRecorder()
+	env.router.ServeHTTP(linkW, linkReq)
+	require.Equal(t, http.StatusOK, linkW.Code, "body: %s", linkW.Body.String())
+
+	// "Log as impromptu" on the orphan.
+	w = postResolveLink(t, env, row.ID.String(), map[string]any{"action": "none_of_these"})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseResolveLinkResp(t, w)
+	require.Len(t, resp.Data.InteractionsCreated, 1, "exactly one interaction — T's tagged anchor")
+	require.Equal(t, "anarlog:"+sessionUUID+":"+env.contactA.String(), resp.Data.InteractionsCreated[0].SourceRef)
+
+	updated := findMeetingNoteRow(t, env, sessionUUID)
+	require.NotNil(t, updated)
+	require.Equal(t, repository.LinkageStateLinkedImpromptu, updated.LinkageState)
+
+	// The invariant: no :title: interaction for M (tagged-only rule).
+	ixs := listSessionInteractions(t, env, sessionUUID)
+	require.Len(t, ixs, 1, "tagged interaction only; no title-derived interaction")
+	titleRefM := "anarlog:" + sessionUUID + ":title:" + contactM.String()
+	for _, ix := range ixs {
+		require.NotNil(t, ix.SourceRef)
+		require.NotContains(t, *ix.SourceRef, ":title:", "no title-derived interaction in a forced-impromptu row")
+		require.NotEqual(t, titleRefM, *ix.SourceRef)
+	}
+
+	// Carry-forward guard (asserted behaviorally): re-ingest with the SAME
+	// matching inputs (title, participants, meeting_at → input_hash +
+	// union resolved_set_hash unchanged) but a CHANGED summary so
+	// last_content_hash differs and a genuine re-ingest runs the
+	// carry-forward branch. The row must STAY linked_impromptu and gain no
+	// :title: interaction for M. Had the resolve persisted hash(T) only,
+	// the re-ingest's hash(T ∪ M) would mismatch, fail carry-forward,
+	// re-run decideLinkage, and flip to orphan_title_augmented + create
+	// M's :title: interaction.
+	rec2 := buildMNRecordedEventWithSummary(t, env.pairedHostID, sessionUUID, meetingAt, title, "content changed for re-sync", []string{anarlogT})
+	w = postMNIngest(t, env, map[string]any{"events": []any{rec2}})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	require.Equal(t, 1, parseMNIngestResp(t, w).Accepted, "changed content → genuine re-ingest, not bus-dedup")
+
+	afterResync := findMeetingNoteRow(t, env, sessionUUID)
+	require.NotNil(t, afterResync)
+	require.Equal(t, repository.LinkageStateLinkedImpromptu, afterResync.LinkageState,
+		"union-hash carry-forward preserves the user's impromptu decision")
+	resyncIxs := listSessionInteractions(t, env, sessionUUID)
+	require.Len(t, resyncIxs, 1, "carry-forward creates no new interaction")
+	for _, ix := range resyncIxs {
+		require.NotNil(t, ix.SourceRef)
+		require.NotContains(t, *ix.SourceRef, ":title:", "no title interaction appears on re-sync")
+	}
+}
+
 // TestResolveLink_SnapshotMissingReturns422 (TC-SV10) — defensive
 // branch: a row in conflict_pending with conflict_candidates NULL must
 // fail with ErrResolveLinkSnapshotMissing → 422. The production ingest

--- a/frontend/tests/e2e/imports-interactions.spec.ts
+++ b/frontend/tests/e2e/imports-interactions.spec.ts
@@ -75,28 +75,41 @@ test.describe('Imports Interactions tab @area:imports', () => {
     await expect(page).toHaveURL(/tab=interactions/)
   })
 
-  test('wires the orphan "Log as impromptu" action to the resolve-link endpoint', async ({
+  test('resolves the orphan via "Log as impromptu" (orphan_needs_review → linked_impromptu)', async ({
     page,
   }) => {
-    // NOTE: the resolve-link endpoint only transitions conflict_pending rows;
-    // resolving an orphan_needs_review row through it returns 409 today. That
-    // backend state-machine gap is tracked separately in issue #368. This test
-    // asserts the orphan card's action is present and dispatches the
-    // resolve-link request (the UI deliverable), without asserting the
-    // backend transition.
+    // The backend now transitions orphan_needs_review → linked_impromptu on
+    // resolve-link {none_of_these}, so the card actually leaves the queue.
+    // Both seeded orphans share meeting_at and the list orders only by
+    // meeting_at DESC, so we bind the click + assertions to titleA's card by
+    // its heading (never list position) and scope the disappearance check to
+    // the card heading (the success toast is a separate element and cannot
+    // satisfy a heading locator).
     await page.goto('/imports?tab=interactions')
     await page.waitForLoadState('domcontentloaded')
-    await expect(page.getByText(titleA).first()).toBeVisible({ timeout: 10000 })
 
-    const dispatched = page.waitForRequest(
-      req => req.method() === 'POST' && req.url().includes('/resolve-link')
+    const headingA = page.getByRole('heading', { name: titleA })
+    const headingB = page.getByRole('heading', { name: titleB })
+    await expect(headingA).toBeVisible({ timeout: 10000 })
+
+    // The orphan card for titleA — scope the button click to it so list
+    // order can't pick the wrong card.
+    const cardA = page
+      .locator('div.border-l-gray-300')
+      .filter({ has: page.getByRole('heading', { name: titleA }) })
+
+    // Register the response wait BEFORE the click so a fast 200 isn't missed.
+    const responsePromise = page.waitForResponse(
+      res => res.url().includes('/resolve-link') && res.request().method() === 'POST',
+      { timeout: 10000 }
     )
-    await page
-      .getByRole('button', { name: /Log as impromptu/ })
-      .first()
-      .click()
-    const req = await dispatched
-    expect(req.postDataJSON()).toMatchObject({ action: 'none_of_these' })
+    await cardA.getByRole('button', { name: /Log as impromptu/ }).click()
+    const res = await responsePromise
+    expect(res.status()).toBe(200)
+
+    // The resolved card leaves the queue; the untouched sibling stays.
+    await expect(headingA).toHaveCount(0, { timeout: 10000 })
+    await expect(headingB).toBeVisible()
   })
 
   test('scrolls to and highlights the ?session deep-linked card', async ({ page }) => {


### PR DESCRIPTION
Closes #368

## Summary

The Imports → Interactions orphan card's "Log as impromptu" action posted `resolve-link {action: "none_of_these"}`, but the merged backend hard-gated every resolve path on `linkage_state = 'conflict_pending'`, so resolving an `orphan_needs_review` row returned 409 and the card could never leave the queue. This PR makes that action work end-to-end: the row now transitions `orphan_needs_review → linked_impromptu`.

## Changes

- **SQL guard widened (additively).** `ClearMeetingNoteConflict` now accepts `linkage_state IN ('conflict_pending', 'orphan_needs_review')` — the same pair `ListMeetingNotesNeedingAttention` already filters on. Terminal states (`linked`, `linked_impromptu`, `orphan_title_augmented`), soft-deleted, and missing rows still fail the guard → 409/404. The `action: "link"` query is untouched.
- **New `resolveOrphanToImpromptu` service branch.** It FORCES `linked_impromptu` rather than re-running `decideLinkage` (a participant-less orphan would recompute straight back to `orphan_needs_review` and never leave the queue). It creates ONLY tagged-participant interactions, never title-derived (`:title:`) ones, so the forced state stays truthful per the state↔interaction invariant.
- **Union `resolved_set_hash`.** The persisted hash is computed over the UNION of tag-resolved ∪ title-matched contact IDs — byte-for-byte the recipe the daemon recomputes on re-sync. This means an identical re-sync is a clean carry-forward that preserves `linked_impromptu`, instead of recomputing a divergent hash, failing carry-forward, and silently flipping the row to `orphan_title_augmented` on the next sync.
- **Shared helper.** The tagged-interaction construction is extracted into `taggedImpromptuInteractions`, called by both `decideLinkage`'s zero-candidate branch and the new resolve branch so they cannot drift. The conflict-path code (`link` and `none_of_these`) is not edited and is behaviorally unchanged.

No schema change, no migration, no new API surface, no frontend component change.

## Test plan

- **Backend integration** (`tests/api/meeting_note_ingest_test.go`): orphan→impromptu success (state flip, no interaction, leaves needs-attention); table-driven terminal-state 409 guard over `linked` / `linked_impromptu` / `orphan_title_augmented`; `action: "link"` on an orphan rejected as 400; newly-resolvable-participant case pinning the tagged-only invariant (no `:title:` interaction) plus union-hash carry-forward across a content-changing re-sync.
- **Backend unit**: focused test for the shared `taggedImpromptuInteractions` helper.
- **Frontend E2E** (`imports-interactions.spec.ts`): the orphan spec now asserts the real transition — scopes the click to the card by heading, waits for the 200 response, then asserts the card leaves the queue while the untouched sibling stays.
- Local gate green: lint, unit, integration, frontend, and diff-selected E2E.

Plan: `.ai/log/plan/orphan-resolve-link-impromptu.md`