### PR TITLE
feat(calendar): remove events + derived interactions when declined/cancelled upstream

### DIFF
--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -467,7 +467,7 @@ func run() int {
 		// calendarRepoForIngest satisfies calendarEventLocker: the
 		// calendar.attended branch takes a FOR SHARE lock on the backing
 		// calendar_event so a concurrent decline DELETE cannot strand a
-		// false interaction (Decision 3a).
+		// false interaction.
 		calendarRepoForIngest,
 	)
 

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -464,6 +464,11 @@ func run() int {
 		eventBus,
 		cadenceUpdater,
 		followUpManager,
+		// calendarRepoForIngest satisfies calendarEventLocker: the
+		// calendar.attended branch takes a FOR SHARE lock on the backing
+		// calendar_event so a concurrent decline DELETE cannot strand a
+		// false interaction (Decision 3a).
+		calendarRepoForIngest,
 	)
 
 	// IngestService — hoisted here so the call.* inline handler can
@@ -539,6 +544,15 @@ func run() int {
 	// further down. Until that branch runs (or in test/no-telegram
 	// modes), the holder dispatches to a logged-warn no-op.
 	river.AddWorker(riverWorkers, consumer.NewInteractionRecorderWorker(eventBus, database.Pool, interactionRecorder, aggregatorReenqueuerHolder))
+
+	// Calendar decline consumer: when a stored calendar_event is
+	// declined / cancelled / user-removed upstream, the publisher removes
+	// the row + emits calendar.declined per matched contact; this consumer
+	// soft-deletes the derived gcal interaction and recomputes the contact's
+	// date columns. Registered unconditionally — no events route to it when
+	// the publisher (CalendarSyncProvider) is in off mode.
+	calendarDeclineHandler := consumer.NewCalendarDeclineHandler(interactionRepo, contactRepo)
+	river.AddWorker(riverWorkers, consumer.NewCalendarDeclineHandlerWorker(eventBus, database.Pool, calendarDeclineHandler))
 
 	// Interaction-mode wiring gate. Cutover is the normal operating
 	// posture; off is the emergency-override retained so rollback can
@@ -755,6 +769,7 @@ func run() int {
 				identityService,
 				externalContactRepo,
 				pubBus,
+				database.Pool,
 			)
 			providerRegistry.Register(gcalProvider)
 			logger.Info().Msg("Google Calendar sync provider registered")

--- a/backend/internal/consumer/calendar_decline_handler.go
+++ b/backend/internal/consumer/calendar_decline_handler.go
@@ -1,0 +1,160 @@
+package consumer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"personal-crm/backend/internal/consumer/consumerjobs"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
+)
+
+// declineInteractionRepo is the subset of *repository.InteractionRepository
+// the decline handler depends on: find the derived gcal interaction by its
+// source_ref (the internal calendar_event.ID UUID string) and soft-delete
+// it. Interface defined here (consumer-side pattern) so unit tests can stub
+// without a DB.
+type declineInteractionRepo interface {
+	FindBySourceRefTx(ctx context.Context, tx pgx.Tx, contactID uuid.UUID, source, sourceRef string) (*repository.Interaction, error)
+	SoftDeleteInteractionTx(ctx context.Context, tx pgx.Tx, id uuid.UUID) error
+}
+
+// declineContactRepo is the subset of *repository.ContactRepository the
+// decline handler depends on: surgically recompute the contact's date
+// columns after the derived interaction is soft-deleted.
+type declineContactRepo interface {
+	RecomputeContactDatesAfterDeleteTx(ctx context.Context, tx pgx.Tx, contactID uuid.UUID, deletedAt time.Time) error
+}
+
+// CalendarDeclineHandler is the event-bus consumer for calendar.declined.
+// When a stored calendar_event is declined / cancelled / user-removed
+// upstream, the publisher removes the calendar_event row and emits one
+// calendar.declined per matched contact; this consumer soft-deletes the
+// derived gcal interaction for that contact and recomputes the contact's
+// date columns.
+//
+// The payload's EventID is the INTERNAL calendar_event.ID UUID string —
+// the same value the forward path wrote into interaction.source_ref for
+// source='gcal' — so FindBySourceRefTx(contactID, "gcal", EventID) matches
+// the attended interaction exactly.
+type CalendarDeclineHandler struct {
+	interactions declineInteractionRepo
+	contacts     declineContactRepo
+}
+
+// NewCalendarDeclineHandler builds the consumer with narrow repository
+// interfaces so unit tests can stub them. Production wires the concrete
+// interaction + contact repositories.
+func NewCalendarDeclineHandler(interactions declineInteractionRepo, contacts declineContactRepo) *CalendarDeclineHandler {
+	return &CalendarDeclineHandler{interactions: interactions, contacts: contacts}
+}
+
+// HandleEvent processes a calendar.declined envelope inside the caller's tx.
+//
+//  1. Decode + validate the payload (ContactID non-nil, EventID non-empty —
+//     a publisher-bug guard).
+//  2. Find the live derived interaction by (ContactID, "gcal", EventID).
+//     ErrNotFound → no live interaction to remove (the common future-decline
+//     case + an already-cleaned replay). Return nil; no recompute.
+//  3. Capture its occurred_at, soft-delete it.
+//  4. Recompute the contact's date columns keyed on the deleted occurred_at.
+//     A db.ErrNotFound here (contact soft-deleted between publish and
+//     consume) is a benign no-op — the interaction is already gone and a
+//     deleted contact needs no recompute; do NOT propagate (would poison
+//     River retries).
+func (h *CalendarDeclineHandler) HandleEvent(ctx context.Context, tx pgx.Tx, env *events.Envelope) error {
+	if env == nil {
+		return errors.New("calendar_decline_handler: nil envelope")
+	}
+	if tx == nil {
+		return errors.New("calendar_decline_handler: nil tx")
+	}
+
+	var p events.CalendarDeclinedPayload
+	if err := events.Unmarshal(env, &p); err != nil {
+		return fmt.Errorf("unmarshal calendar.declined payload: %w", err)
+	}
+	if p.ContactID == uuid.Nil {
+		return fmt.Errorf("calendar.declined: empty contact_id (event %s)", env.ID)
+	}
+	if p.EventID == "" {
+		return fmt.Errorf("calendar.declined: empty event_id (event %s)", env.ID)
+	}
+
+	found, err := h.interactions.FindBySourceRefTx(ctx, tx, p.ContactID, repository.InteractionSourceGCal, p.EventID)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			// No live interaction to remove (future-decline that was never
+			// recorded, or an already-cleaned replay). Skip recompute so the
+			// dominant case stays write-free and unaffected contacts don't
+			// get a spurious updated_at bump.
+			return nil
+		}
+		return fmt.Errorf("find gcal interaction for decline: %w", err)
+	}
+
+	deletedOccurredAt := found.OccurredAt
+	if err := h.interactions.SoftDeleteInteractionTx(ctx, tx, found.ID); err != nil {
+		return fmt.Errorf("soft-delete gcal interaction: %w", err)
+	}
+
+	if err := h.contacts.RecomputeContactDatesAfterDeleteTx(ctx, tx, p.ContactID, deletedOccurredAt); err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			// Contact soft-deleted between publish and consume. The
+			// interaction is already soft-deleted; a deleted contact needs
+			// no recompute. Benign no-op — return nil so River does not
+			// retry-poison.
+			return nil
+		}
+		return fmt.Errorf("recompute contact dates after decline: %w", err)
+	}
+	return nil
+}
+
+// --------------------------------------------------------------------------
+// River worker wrapper. Mirrors InteractionRecorderWorker: fetch the
+// envelope by id, open a fresh tx, call HandleEvent. No post-commit closure
+// (the decline path performs no external I/O).
+// --------------------------------------------------------------------------
+
+// CalendarDeclineHandlerWorker is the river worker that dispatches queued
+// CalendarDeclineHandlerJobArgs to CalendarDeclineHandler.HandleEvent.
+type CalendarDeclineHandlerWorker struct {
+	river.WorkerDefaults[consumerjobs.CalendarDeclineHandlerJobArgs]
+	bus     eventBusTx
+	pool    *pgxpool.Pool
+	handler *CalendarDeclineHandler
+}
+
+// NewCalendarDeclineHandlerWorker wires the worker to the concrete bus, the
+// application pgxpool, and the consumer instance.
+func NewCalendarDeclineHandlerWorker(bus eventBusTx, pool *pgxpool.Pool, handler *CalendarDeclineHandler) *CalendarDeclineHandlerWorker {
+	return &CalendarDeclineHandlerWorker{bus: bus, pool: pool, handler: handler}
+}
+
+// Work implements river.Worker. Fetches the event envelope by id, opens a
+// fresh tx, and invokes HandleEvent. On error River retries per MaxAttempts
+// (5 from the InsertOpts in events.consumerJobsForKind).
+func (w *CalendarDeclineHandlerWorker) Work(ctx context.Context, j *river.Job[consumerjobs.CalendarDeclineHandlerJobArgs]) error {
+	env, err := w.bus.GetEvent(ctx, j.Args.EventID)
+	if err != nil {
+		return fmt.Errorf("fetch event %s: %w", j.Args.EventID, err)
+	}
+	return pgx.BeginTxFunc(ctx, w.pool, pgx.TxOptions{}, func(tx pgx.Tx) error {
+		return w.handler.HandleEvent(ctx, tx, env)
+	})
+}
+
+// Timeout bounds a single decline-handler run. A soft-delete + single-contact
+// recompute completes in ~10ms on the Pi; 30s is ample headroom.
+func (*CalendarDeclineHandlerWorker) Timeout(*river.Job[consumerjobs.CalendarDeclineHandlerJobArgs]) time.Duration {
+	return 30 * time.Second
+}

--- a/backend/internal/consumer/calendar_decline_handler_test.go
+++ b/backend/internal/consumer/calendar_decline_handler_test.go
@@ -1,0 +1,196 @@
+package consumer
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+)
+
+// stubDeclineInteractionRepo stubs declineInteractionRepo. `found` (when
+// non-nil) is returned by FindBySourceRefTx; otherwise findErr is returned
+// (default db.ErrNotFound). softDeleteCalls + softDeletedID record the
+// soft-delete.
+type stubDeclineInteractionRepo struct {
+	found   *repository.Interaction
+	findErr error
+
+	findCalls     int
+	lastFindKey   [3]string // contactID, source, sourceRef (stringified)
+	softDelCalls  int
+	softDeletedID uuid.UUID
+	softDelErr    error
+}
+
+func (s *stubDeclineInteractionRepo) FindBySourceRefTx(_ context.Context, _ pgx.Tx, contactID uuid.UUID, source, sourceRef string) (*repository.Interaction, error) {
+	s.findCalls++
+	s.lastFindKey = [3]string{contactID.String(), source, sourceRef}
+	if s.found != nil {
+		return s.found, nil
+	}
+	if s.findErr != nil {
+		return nil, s.findErr
+	}
+	return nil, db.ErrNotFound
+}
+
+func (s *stubDeclineInteractionRepo) SoftDeleteInteractionTx(_ context.Context, _ pgx.Tx, id uuid.UUID) error {
+	s.softDelCalls++
+	s.softDeletedID = id
+	return s.softDelErr
+}
+
+// stubDeclineContactRepo stubs declineContactRepo. recomputeErr is returned
+// from RecomputeContactDatesAfterDeleteTx; recomputeCalls + lastDeletedAt
+// record the call.
+type stubDeclineContactRepo struct {
+	recomputeCalls int
+	lastContactID  uuid.UUID
+	lastDeletedAt  time.Time
+	recomputeErr   error
+}
+
+func (s *stubDeclineContactRepo) RecomputeContactDatesAfterDeleteTx(_ context.Context, _ pgx.Tx, contactID uuid.UUID, deletedAt time.Time) error {
+	s.recomputeCalls++
+	s.lastContactID = contactID
+	s.lastDeletedAt = deletedAt
+	return s.recomputeErr
+}
+
+func mustDeclineEnv(t *testing.T, p events.CalendarDeclinedPayload) *events.Envelope {
+	t.Helper()
+	raw, err := events.Marshal(events.KindCalendarDeclined, p)
+	require.NoError(t, err)
+	return &events.Envelope{
+		ID:         uuid.New(),
+		Source:     "gcal",
+		SourceID:   "declined:" + p.EventID + ":" + p.ContactID.String(),
+		Kind:       events.KindCalendarDeclined,
+		Payload:    raw,
+		ObservedAt: p.OccurredAt,
+	}
+}
+
+// (a) interaction found → SoftDelete + Recompute both called.
+func TestCalendarDeclineHandler_InteractionFound_SoftDeletesAndRecomputes(t *testing.T) {
+	cid := uuid.New()
+	eventUUID := uuid.New().String()
+	occurredAt := time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC)
+	interactionID := uuid.New()
+
+	ir := &stubDeclineInteractionRepo{found: &repository.Interaction{
+		ID:         interactionID,
+		ContactID:  cid,
+		Source:     repository.InteractionSourceGCal,
+		OccurredAt: occurredAt,
+		Direction:  repository.InteractionDirectionMutual,
+	}}
+	cr := &stubDeclineContactRepo{}
+	h := NewCalendarDeclineHandler(ir, cr)
+
+	env := mustDeclineEnv(t, events.CalendarDeclinedPayload{
+		Version: 1, ContactID: cid, EventID: eventUUID, OccurredAt: occurredAt,
+	})
+	require.NoError(t, h.HandleEvent(context.Background(), nonNilTx(), env))
+
+	require.Equal(t, 1, ir.findCalls)
+	require.Equal(t, [3]string{cid.String(), "gcal", eventUUID}, ir.lastFindKey, "looks up by (contact, gcal, internal-UUID source_ref)")
+	require.Equal(t, 1, ir.softDelCalls)
+	require.Equal(t, interactionID, ir.softDeletedID)
+	require.Equal(t, 1, cr.recomputeCalls)
+	require.Equal(t, cid, cr.lastContactID)
+	require.Equal(t, occurredAt, cr.lastDeletedAt, "recompute keyed on the deleted interaction's occurred_at")
+}
+
+// (b) interaction not found → neither SoftDelete nor Recompute called.
+func TestCalendarDeclineHandler_InteractionNotFound_NoOp(t *testing.T) {
+	cid := uuid.New()
+	ir := &stubDeclineInteractionRepo{} // default findErr → db.ErrNotFound
+	cr := &stubDeclineContactRepo{}
+	h := NewCalendarDeclineHandler(ir, cr)
+
+	env := mustDeclineEnv(t, events.CalendarDeclinedPayload{
+		Version: 1, ContactID: cid, EventID: uuid.New().String(),
+		OccurredAt: time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC),
+	})
+	require.NoError(t, h.HandleEvent(context.Background(), nonNilTx(), env))
+
+	require.Equal(t, 1, ir.findCalls)
+	require.Zero(t, ir.softDelCalls, "no soft-delete when no live interaction")
+	require.Zero(t, cr.recomputeCalls, "no recompute when nothing was removed")
+}
+
+// (c) nil ContactID / empty EventID → error.
+func TestCalendarDeclineHandler_InvalidPayload_Errors(t *testing.T) {
+	ir := &stubDeclineInteractionRepo{}
+	cr := &stubDeclineContactRepo{}
+	h := NewCalendarDeclineHandler(ir, cr)
+
+	t.Run("nil contact_id", func(t *testing.T) {
+		env := mustDeclineEnv(t, events.CalendarDeclinedPayload{
+			Version: 1, ContactID: uuid.Nil, EventID: uuid.New().String(),
+			OccurredAt: time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC),
+		})
+		err := h.HandleEvent(context.Background(), nonNilTx(), env)
+		require.Error(t, err)
+		require.Zero(t, ir.findCalls)
+	})
+
+	t.Run("empty event_id", func(t *testing.T) {
+		env := mustDeclineEnv(t, events.CalendarDeclinedPayload{
+			Version: 1, ContactID: uuid.New(), EventID: "",
+			OccurredAt: time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC),
+		})
+		err := h.HandleEvent(context.Background(), nonNilTx(), env)
+		require.Error(t, err)
+	})
+}
+
+// (d) Recompute returns db.ErrNotFound (contact soft-deleted) → HandleEvent
+// returns nil (benign no-op, NOT an error — no retry poison). The interaction
+// was still soft-deleted.
+func TestCalendarDeclineHandler_RecomputeContactNotFound_BenignNoOp(t *testing.T) {
+	cid := uuid.New()
+	occurredAt := time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC)
+	ir := &stubDeclineInteractionRepo{found: &repository.Interaction{
+		ID:         uuid.New(),
+		ContactID:  cid,
+		Source:     repository.InteractionSourceGCal,
+		OccurredAt: occurredAt,
+		Direction:  repository.InteractionDirectionMutual,
+	}}
+	cr := &stubDeclineContactRepo{recomputeErr: db.ErrNotFound}
+	h := NewCalendarDeclineHandler(ir, cr)
+
+	env := mustDeclineEnv(t, events.CalendarDeclinedPayload{
+		Version: 1, ContactID: cid, EventID: uuid.New().String(), OccurredAt: occurredAt,
+	})
+	require.NoError(t, h.HandleEvent(context.Background(), nonNilTx(), env), "contact-not-found recompute is a benign no-op")
+	require.Equal(t, 1, ir.softDelCalls, "interaction still soft-deleted before recompute")
+	require.Equal(t, 1, cr.recomputeCalls)
+}
+
+// A non-ErrNotFound recompute error propagates (River retries).
+func TestCalendarDeclineHandler_RecomputeOtherError_Propagates(t *testing.T) {
+	cid := uuid.New()
+	occurredAt := time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC)
+	ir := &stubDeclineInteractionRepo{found: &repository.Interaction{
+		ID: uuid.New(), ContactID: cid, Source: repository.InteractionSourceGCal,
+		OccurredAt: occurredAt, Direction: repository.InteractionDirectionMutual,
+	}}
+	cr := &stubDeclineContactRepo{recomputeErr: errors.New("db down")}
+	h := NewCalendarDeclineHandler(ir, cr)
+
+	env := mustDeclineEnv(t, events.CalendarDeclinedPayload{
+		Version: 1, ContactID: cid, EventID: uuid.New().String(), OccurredAt: occurredAt,
+	})
+	require.Error(t, h.HandleEvent(context.Background(), nonNilTx(), env))
+}

--- a/backend/internal/consumer/consumerjobs/args.go
+++ b/backend/internal/consumer/consumerjobs/args.go
@@ -150,6 +150,19 @@ type MessagingAggregateSweeperArgs struct{}
 // Kind returns the river job-kind identifier for the sweeper.
 func (MessagingAggregateSweeperArgs) Kind() string { return "messaging_aggregate_sweeper" }
 
+// CalendarDeclineHandlerJobArgs carries the event id that the
+// CalendarDeclineHandler worker should fetch and process. Enqueued for
+// every calendar.declined event by events.consumerJobsForKind. No
+// river:"unique" tag — there is no stale-claim recovery path for this
+// kind (replay is idempotent at the FindBySourceRefTx layer).
+type CalendarDeclineHandlerJobArgs struct {
+	EventID uuid.UUID `json:"event_id"`
+}
+
+// Kind returns the river job-kind identifier for CalendarDeclineHandler
+// jobs.
+func (CalendarDeclineHandlerJobArgs) Kind() string { return "calendar_decline_handler" }
+
 // RematchDispatcherJobArgs carries the event id + dedup-arg fields that
 // the RematchDispatcher worker processes. ContactID and RematchJobID
 // are duplicated from the event payload and carry the river:"unique"

--- a/backend/internal/consumer/interaction_recorder.go
+++ b/backend/internal/consumer/interaction_recorder.go
@@ -98,6 +98,19 @@ type cadenceDispatcher interface {
 	HandleEvent(ctx context.Context, tx pgx.Tx, env *events.Envelope) error
 }
 
+// calendarEventLocker is the narrow dependency that serializes a
+// calendar.attended insert against a concurrent decline DELETE on the
+// backing calendar_event row. LockExistsByIDTx takes a FOR SHARE lock on
+// the row (held until the caller's tx commits) and reports whether it
+// exists: false means the row was already deleted (a decline committed
+// first), so the recorder skips the attended insert to avoid stranding a
+// false interaction. Satisfied by *repository.CalendarEventRepository.
+// Unit tests that don't exercise calendar.attended pass a stub returning
+// (true, nil).
+type calendarEventLocker interface {
+	LockExistsByIDTx(ctx context.Context, tx pgx.Tx, id uuid.UUID) (bool, error)
+}
+
 // followUpDispatcher is the subset of *FollowUpManager the recorder
 // needs for the inline-apply path. Returns a post-commit closure (non-
 // nil on the refresh branch) that the recorder folds into its own
@@ -119,11 +132,12 @@ type followUpDispatcher interface {
 // event finds the claim row and returns nil without mutating contact
 // state — closing the queued-worker replay hole for manual corrections.
 type InteractionRecorder struct {
-	writer   interactionWriter
-	staging  stagingProcessor
-	bus      eventBusTx
-	cadence  cadenceDispatcher
-	followUp followUpDispatcher
+	writer       interactionWriter
+	staging      stagingProcessor
+	bus          eventBusTx
+	cadence      cadenceDispatcher
+	followUp     followUpDispatcher
+	calendarLock calendarEventLocker
 }
 
 // NewInteractionRecorder builds the consumer. staging may be nil for
@@ -132,21 +146,27 @@ type InteractionRecorder struct {
 // apply is the seam that closes the queued-worker replay hole for
 // manual corrections. followUp is inline-invoked post-publish so the
 // manual UI stays synchronous and the queued delivery becomes a
-// durable no-op via event_consumer_claim. Tests that don't care
-// about cadence / follow-up pass nil stubs.
+// durable no-op via event_consumer_claim. calendarLock serializes the
+// calendar.attended insert against a concurrent decline DELETE on the
+// backing calendar_event row; when nil the recorder skips the lock check
+// (no calendar race protection — acceptable for tests that don't exercise
+// calendar.attended). Tests that don't care about cadence / follow-up pass
+// nil stubs.
 func NewInteractionRecorder(
 	writer interactionWriter,
 	staging stagingProcessor,
 	bus eventBusTx,
 	cadence cadenceDispatcher,
 	followUp followUpDispatcher,
+	calendarLock calendarEventLocker,
 ) *InteractionRecorder {
 	return &InteractionRecorder{
-		writer:   writer,
-		staging:  staging,
-		bus:      bus,
-		cadence:  cadence,
-		followUp: followUp,
+		writer:       writer,
+		staging:      staging,
+		bus:          bus,
+		cadence:      cadence,
+		followUp:     followUp,
+		calendarLock: calendarLock,
 	}
 }
 
@@ -184,6 +204,30 @@ func (r *InteractionRecorder) HandleEvent(ctx context.Context, tx pgx.Tx, env *e
 			Str("kind", string(env.Kind)).
 			Msg("consumer: contact_id unresolved for kind; dropping")
 		return nil, nil, fmt.Errorf("consumer: contact_id unresolved for kind %s", env.Kind)
+	}
+
+	// calendar.attended: serialize against a concurrent decline DELETE on
+	// the backing calendar_event row. A locking FOR SHARE read of the event
+	// (by the payload's internal-UUID source_ref) is held until this tx
+	// commits, so an interleaving decline DELETE either blocks (we insert,
+	// the decline then soft-deletes) or has already committed (the row is
+	// gone → we skip the insert, leaving no false interaction). Skipping a
+	// past-attended insert when the event was declined is exactly the
+	// desired outcome.
+	if env.Kind == events.KindCalendarAttended && r.calendarLock != nil && req.SourceRef != nil {
+		eventID, parseErr := uuid.Parse(*req.SourceRef)
+		if parseErr != nil {
+			return nil, nil, fmt.Errorf("calendar.attended: source_ref %q not a calendar_event UUID: %w", *req.SourceRef, parseErr)
+		}
+		exists, lockErr := r.calendarLock.LockExistsByIDTx(ctx, tx, eventID)
+		if lockErr != nil {
+			return nil, nil, fmt.Errorf("lock backing calendar_event: %w", lockErr)
+		}
+		if !exists {
+			// Backing calendar_event already deleted (decline won the race).
+			// Skip the insert; no interaction, nil postCommit.
+			return nil, nil, nil
+		}
 	}
 
 	// Delegate to ContactService.RecordInteractionTx — single source of

--- a/backend/internal/consumer/interaction_recorder_test.go
+++ b/backend/internal/consumer/interaction_recorder_test.go
@@ -178,16 +178,16 @@ func newRecorderWithStubs() (*InteractionRecorder, *stubWriter, *stubTGRepo, *st
 	c := &stubCadence{}
 	// calendarLock is nil here: existing tests use placeholder (non-UUID)
 	// EventIDs and don't exercise the attended-vs-decline race, so the lock
-	// check is skipped. The Decision-3a skip test constructs its own
-	// recorder with a stubCalendarLocker + a UUID EventID.
+	// check is skipped. The skip test constructs its own recorder with a
+	// stubCalendarLocker + a UUID EventID.
 	rec := NewInteractionRecorder(w, tg, b, c, nil, nil)
 	return rec, w, tg, b, c
 }
 
 // stubCalendarLocker stubs the calendarEventLocker dependency. `exists`
 // controls whether the backing calendar_event is reported present; tests
-// for the Decision-3a attended-vs-decline race set exists=false to assert
-// the recorder skips the insert.
+// for the attended-vs-decline race set exists=false to assert the recorder
+// skips the insert.
 type stubCalendarLocker struct {
 	exists  bool
 	calls   int
@@ -330,9 +330,9 @@ func TestHandleEvent_CalendarAttended_CutoverFreshWrite_NoMarkProcessed(t *testi
 }
 
 // TestHandleEvent_CalendarAttended_SkipsInsertWhenEventDeleted is the
-// Decision-3a unit guard: when the backing calendar_event was already
-// deleted (a decline won the race), the locking read reports the row gone
-// and the recorder skips the interaction insert entirely — no false
+// attended-after-delete unit guard: when the backing calendar_event was
+// already deleted (a decline won the race), the locking read reports the row
+// gone and the recorder skips the interaction insert entirely — no false
 // "attended" interaction is written.
 func TestHandleEvent_CalendarAttended_SkipsInsertWhenEventDeleted(t *testing.T) {
 	cid := uuid.New()
@@ -361,8 +361,9 @@ func TestHandleEvent_CalendarAttended_SkipsInsertWhenEventDeleted(t *testing.T) 
 }
 
 // TestHandleEvent_CalendarAttended_InsertsWhenEventPresent confirms the
-// happy path of the Decision-3a guard: when the backing calendar_event is
-// present (lock acquired), the recorder proceeds with the insert.
+// happy path of the attended-after-delete guard: when the backing
+// calendar_event is present (lock acquired), the recorder proceeds with the
+// insert.
 func TestHandleEvent_CalendarAttended_InsertsWhenEventPresent(t *testing.T) {
 	cid := uuid.New()
 	eventID := uuid.New()

--- a/backend/internal/consumer/interaction_recorder_test.go
+++ b/backend/internal/consumer/interaction_recorder_test.go
@@ -176,8 +176,32 @@ func newRecorderWithStubs() (*InteractionRecorder, *stubWriter, *stubTGRepo, *st
 	tg := &stubTGRepo{}
 	b := &stubBus{}
 	c := &stubCadence{}
-	rec := NewInteractionRecorder(w, tg, b, c, nil)
+	// calendarLock is nil here: existing tests use placeholder (non-UUID)
+	// EventIDs and don't exercise the attended-vs-decline race, so the lock
+	// check is skipped. The Decision-3a skip test constructs its own
+	// recorder with a stubCalendarLocker + a UUID EventID.
+	rec := NewInteractionRecorder(w, tg, b, c, nil, nil)
 	return rec, w, tg, b, c
+}
+
+// stubCalendarLocker stubs the calendarEventLocker dependency. `exists`
+// controls whether the backing calendar_event is reported present; tests
+// for the Decision-3a attended-vs-decline race set exists=false to assert
+// the recorder skips the insert.
+type stubCalendarLocker struct {
+	exists  bool
+	calls   int
+	lastID  uuid.UUID
+	returnE error
+}
+
+func (s *stubCalendarLocker) LockExistsByIDTx(_ context.Context, _ pgx.Tx, id uuid.UUID) (bool, error) {
+	s.calls++
+	s.lastID = id
+	if s.returnE != nil {
+		return false, s.returnE
+	}
+	return s.exists, nil
 }
 
 // stubCadence captures HandleEvent calls so tests can assert the
@@ -303,6 +327,62 @@ func TestHandleEvent_CalendarAttended_CutoverFreshWrite_NoMarkProcessed(t *testi
 	require.Nil(t, w.lastReq.Description, "calendar payload without Title leaves description nil")
 	require.Equal(t, 1, b.publishCalls)
 	require.Zero(t, tg.calls, "calendar kind does not mark telegram messages processed")
+}
+
+// TestHandleEvent_CalendarAttended_SkipsInsertWhenEventDeleted is the
+// Decision-3a unit guard: when the backing calendar_event was already
+// deleted (a decline won the race), the locking read reports the row gone
+// and the recorder skips the interaction insert entirely — no false
+// "attended" interaction is written.
+func TestHandleEvent_CalendarAttended_SkipsInsertWhenEventDeleted(t *testing.T) {
+	cid := uuid.New()
+	eventID := uuid.New()
+	w := &stubWriter{}
+	tg := &stubTGRepo{}
+	b := &stubBus{}
+	c := &stubCadence{}
+	locker := &stubCalendarLocker{exists: false}
+	rec := NewInteractionRecorder(w, tg, b, c, nil, locker)
+
+	env := mustEnv(t, events.KindCalendarAttended, events.CalendarAttendedPayload{
+		Version:    1,
+		ContactID:  cid,
+		EventID:    eventID.String(),
+		OccurredAt: time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC),
+	})
+	interaction, postCommit, err := rec.HandleEvent(context.Background(), nonNilTx(), env)
+	require.NoError(t, err)
+	require.Nil(t, interaction, "no interaction written when backing event deleted")
+	require.Nil(t, postCommit)
+	require.Equal(t, 1, locker.calls, "lock check ran once")
+	require.Equal(t, eventID, locker.lastID)
+	require.Zero(t, w.calls, "writer must not be invoked when the event is gone")
+	require.Zero(t, b.publishCalls, "no interaction.recorded published when skipped")
+}
+
+// TestHandleEvent_CalendarAttended_InsertsWhenEventPresent confirms the
+// happy path of the Decision-3a guard: when the backing calendar_event is
+// present (lock acquired), the recorder proceeds with the insert.
+func TestHandleEvent_CalendarAttended_InsertsWhenEventPresent(t *testing.T) {
+	cid := uuid.New()
+	eventID := uuid.New()
+	w := &stubWriter{}
+	tg := &stubTGRepo{}
+	b := &stubBus{}
+	c := &stubCadence{}
+	locker := &stubCalendarLocker{exists: true}
+	rec := NewInteractionRecorder(w, tg, b, c, nil, locker)
+
+	env := mustEnv(t, events.KindCalendarAttended, events.CalendarAttendedPayload{
+		Version:    1,
+		ContactID:  cid,
+		EventID:    eventID.String(),
+		OccurredAt: time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC),
+	})
+	_, _, err := rec.HandleEvent(context.Background(), nonNilTx(), env)
+	require.NoError(t, err)
+	require.Equal(t, 1, locker.calls)
+	require.Equal(t, 1, w.calls, "writer invoked when the event is present")
 }
 
 // TestHandleEvent_CalendarAttended_CopiesTitleToDescription asserts that

--- a/backend/internal/db/calendar_event.sql.go
+++ b/backend/internal/db/calendar_event.sql.go
@@ -47,6 +47,27 @@ func (q *Queries) CountEventsForContact(ctx context.Context, contactID pgtype.UU
 	return count, err
 }
 
+const DeleteCalendarEventByGcalID = `-- name: DeleteCalendarEventByGcalID :exec
+DELETE FROM calendar_event
+WHERE gcal_event_id = $1
+  AND gcal_calendar_id = $2
+  AND google_account_id = $3
+`
+
+type DeleteCalendarEventByGcalIDParams struct {
+	GcalEventID     string `json:"gcal_event_id"`
+	GcalCalendarID  string `json:"gcal_calendar_id"`
+	GoogleAccountID string `json:"google_account_id"`
+}
+
+// Hard-deletes the stored calendar_event row keyed by its Google identity
+// triple. Used by the decline/cancel remove branch. calendar_event has no
+// deleted_at column — removal is a hard DELETE (cf. DeleteEventsByAccount).
+func (q *Queries) DeleteCalendarEventByGcalID(ctx context.Context, arg DeleteCalendarEventByGcalIDParams) error {
+	_, err := q.db.Exec(ctx, DeleteCalendarEventByGcalID, arg.GcalEventID, arg.GcalCalendarID, arg.GoogleAccountID)
+	return err
+}
+
 const DeleteEventsByAccount = `-- name: DeleteEventsByAccount :exec
 DELETE FROM calendar_event
 WHERE google_account_id = $1
@@ -229,6 +250,45 @@ LIMIT 1
 // Look up an event by its UUID
 func (q *Queries) GetCalendarEventByID(ctx context.Context, id pgtype.UUID) (*CalendarEvent, error) {
 	row := q.db.QueryRow(ctx, GetCalendarEventByID, id)
+	var i CalendarEvent
+	err := row.Scan(
+		&i.ID,
+		&i.GcalEventID,
+		&i.GcalCalendarID,
+		&i.GoogleAccountID,
+		&i.Title,
+		&i.Description,
+		&i.Location,
+		&i.StartTime,
+		&i.EndTime,
+		&i.AllDay,
+		&i.Status,
+		&i.UserResponse,
+		&i.OrganizerEmail,
+		&i.Attendees,
+		&i.MatchedContactIds,
+		&i.SyncedAt,
+		&i.LastContactedUpdated,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.HtmlLink,
+	)
+	return &i, err
+}
+
+const GetCalendarEventByIDForShare = `-- name: GetCalendarEventByIDForShare :one
+SELECT id, gcal_event_id, gcal_calendar_id, google_account_id, title, description, location, start_time, end_time, all_day, status, user_response, organizer_email, attendees, matched_contact_ids, synced_at, last_contacted_updated, created_at, updated_at, html_link FROM calendar_event
+WHERE id = $1
+FOR SHARE
+`
+
+// Locking read used by the InteractionRecorder calendar.attended branch to
+// serialize against a concurrent decline DELETE on the same row. FOR SHARE
+// holds the row until the attended tx commits, so an interleaving decline
+// DELETE either blocks (attended inserts, decline then soft-deletes) or has
+// already committed (this read returns no row, attended skips the insert).
+func (q *Queries) GetCalendarEventByIDForShare(ctx context.Context, id pgtype.UUID) (*CalendarEvent, error) {
+	row := q.db.QueryRow(ctx, GetCalendarEventByIDForShare, id)
 	var i CalendarEvent
 	err := row.Scan(
 		&i.ID,
@@ -537,6 +597,32 @@ func (q *Queries) ListUpcomingEventsWithContacts(ctx context.Context, arg ListUp
 		return nil, err
 	}
 	return items, nil
+}
+
+const MarkCalendarEventCancelledByGcalID = `-- name: MarkCalendarEventCancelledByGcalID :exec
+UPDATE calendar_event
+SET status = 'cancelled',
+    updated_at = NOW()
+WHERE gcal_event_id = $1
+  AND gcal_calendar_id = $2
+  AND google_account_id = $3
+`
+
+type MarkCalendarEventCancelledByGcalIDParams struct {
+	GcalEventID     string `json:"gcal_event_id"`
+	GcalCalendarID  string `json:"gcal_calendar_id"`
+	GoogleAccountID string `json:"google_account_id"`
+}
+
+// Off-mode deferral for the decline remove branch: marks a stored event
+// cancelled (keyed by its Google identity triple) instead of deleting,
+// when the event bus is unavailable. status='cancelled' excludes the row
+// from ListPastEventsNeedingUpdate (status='confirmed') and from all
+// contact-facing reads (status != 'cancelled'), so it neither re-fires
+// calendar.attended nor strands an already-recorded interaction.
+func (q *Queries) MarkCalendarEventCancelledByGcalID(ctx context.Context, arg MarkCalendarEventCancelledByGcalIDParams) error {
+	_, err := q.db.Exec(ctx, MarkCalendarEventCancelledByGcalID, arg.GcalEventID, arg.GcalCalendarID, arg.GoogleAccountID)
+	return err
 }
 
 const MarkLastContactedUpdated = `-- name: MarkLastContactedUpdated :exec

--- a/backend/internal/db/calendar_event.sql.go
+++ b/backend/internal/db/calendar_event.sql.go
@@ -647,9 +647,9 @@ FOR UPDATE NOWAIT
 // TEST ONLY. Probe a calendar_event row with FOR UPDATE NOWAIT: returns the
 // row if no conflicting lock is held, or fails immediately (lock_not_available)
 // when another tx holds a conflicting lock (e.g. a FOR SHARE from the attended
-// branch). Used by the Decision-3a lock-serialization integration test to
-// prove the attended FOR SHARE conflicts with a concurrent FOR UPDATE without
-// a sleep/timeout. Production code must NOT call this.
+// branch). Used by the attended-vs-decline lock-serialization integration
+// test to prove the attended FOR SHARE conflicts with a concurrent FOR UPDATE
+// without a sleep/timeout. Production code must NOT call this.
 func (q *Queries) TestGetCalendarEventByIDForUpdateNoWait(ctx context.Context, id pgtype.UUID) (*CalendarEvent, error) {
 	row := q.db.QueryRow(ctx, TestGetCalendarEventByIDForUpdateNoWait, id)
 	var i CalendarEvent

--- a/backend/internal/db/calendar_event.sql.go
+++ b/backend/internal/db/calendar_event.sql.go
@@ -638,6 +638,46 @@ func (q *Queries) MarkLastContactedUpdated(ctx context.Context, id pgtype.UUID) 
 	return err
 }
 
+const TestGetCalendarEventByIDForUpdateNoWait = `-- name: TestGetCalendarEventByIDForUpdateNoWait :one
+SELECT id, gcal_event_id, gcal_calendar_id, google_account_id, title, description, location, start_time, end_time, all_day, status, user_response, organizer_email, attendees, matched_contact_ids, synced_at, last_contacted_updated, created_at, updated_at, html_link FROM calendar_event
+WHERE id = $1
+FOR UPDATE NOWAIT
+`
+
+// TEST ONLY. Probe a calendar_event row with FOR UPDATE NOWAIT: returns the
+// row if no conflicting lock is held, or fails immediately (lock_not_available)
+// when another tx holds a conflicting lock (e.g. a FOR SHARE from the attended
+// branch). Used by the Decision-3a lock-serialization integration test to
+// prove the attended FOR SHARE conflicts with a concurrent FOR UPDATE without
+// a sleep/timeout. Production code must NOT call this.
+func (q *Queries) TestGetCalendarEventByIDForUpdateNoWait(ctx context.Context, id pgtype.UUID) (*CalendarEvent, error) {
+	row := q.db.QueryRow(ctx, TestGetCalendarEventByIDForUpdateNoWait, id)
+	var i CalendarEvent
+	err := row.Scan(
+		&i.ID,
+		&i.GcalEventID,
+		&i.GcalCalendarID,
+		&i.GoogleAccountID,
+		&i.Title,
+		&i.Description,
+		&i.Location,
+		&i.StartTime,
+		&i.EndTime,
+		&i.AllDay,
+		&i.Status,
+		&i.UserResponse,
+		&i.OrganizerEmail,
+		&i.Attendees,
+		&i.MatchedContactIds,
+		&i.SyncedAt,
+		&i.LastContactedUpdated,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.HtmlLink,
+	)
+	return &i, err
+}
+
 const TestHardDeleteCalendarEventByID = `-- name: TestHardDeleteCalendarEventByID :exec
 DELETE FROM calendar_event WHERE id = $1
 `

--- a/backend/internal/db/contact.sql.go
+++ b/backend/internal/db/contact.sql.go
@@ -11,6 +11,76 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const ComputeContactDatesAfterDelete = `-- name: ComputeContactDatesAfterDelete :one
+WITH agg AS (
+  SELECT
+    MAX(occurred_at) FILTER (WHERE direction IN ('inbound','mutual'))  AS new_non_outbound,
+    MAX(occurred_at) FILTER (WHERE direction IN ('outbound','mutual')) AS new_outreach
+  FROM interaction
+  WHERE contact_id = $2 AND deleted_at IS NULL
+),
+locked AS (
+  SELECT id, last_contacted, last_interaction_at, last_response_at,
+         last_outreach_at, contact_by, cadence, created_at
+  FROM contact
+  WHERE id = $2 AND deleted_at IS NULL
+  FOR UPDATE
+)
+SELECT
+  (CASE WHEN c.last_contacted      = $1::timestamptz THEN agg.new_non_outbound ELSE c.last_contacted      END)::timestamptz AS new_last_contacted,
+  (CASE WHEN c.last_interaction_at = $1::timestamptz THEN agg.new_non_outbound ELSE c.last_interaction_at END)::timestamptz AS new_last_interaction_at,
+  (CASE WHEN c.last_response_at    = $1::timestamptz THEN agg.new_non_outbound ELSE c.last_response_at    END)::timestamptz AS new_last_response_at,
+  (CASE WHEN c.last_outreach_at    = $1::timestamptz THEN agg.new_outreach     ELSE c.last_outreach_at    END)::timestamptz AS new_last_outreach_at,
+  c.last_contacted AS old_last_contacted,
+  c.contact_by     AS old_contact_by,
+  c.cadence        AS cadence,
+  c.created_at     AS created_at
+FROM locked c, agg
+`
+
+type ComputeContactDatesAfterDeleteParams struct {
+	DeletedAtTs pgtype.Timestamptz `json:"deleted_at_ts"`
+	ID          pgtype.UUID        `json:"id"`
+}
+
+type ComputeContactDatesAfterDeleteRow struct {
+	NewLastContacted     pgtype.Timestamptz `json:"new_last_contacted"`
+	NewLastInteractionAt pgtype.Timestamptz `json:"new_last_interaction_at"`
+	NewLastResponseAt    pgtype.Timestamptz `json:"new_last_response_at"`
+	NewLastOutreachAt    pgtype.Timestamptz `json:"new_last_outreach_at"`
+	OldLastContacted     pgtype.Timestamptz `json:"old_last_contacted"`
+	OldContactBy         pgtype.Date        `json:"old_contact_by"`
+	Cadence              pgtype.Text        `json:"cadence"`
+	CreatedAt            pgtype.Timestamptz `json:"created_at"`
+}
+
+// Returns the surgically-recomputed timestamp columns (each touched ONLY
+// when the deleted interaction at @deleted_at_ts was its source: column =
+// @deleted_at_ts → MAX(remaining live interactions of its subset), NULL when
+// none remain; otherwise the existing value is preserved) plus the fields the
+// Go caller needs to decide contact_by (old_last_contacted, old_contact_by,
+// cadence, created_at). Direction subsets mirror CadenceApplyFlagsByDirection
+// in reverse. NO cadence/contact_by arithmetic here — that is computed in Go
+// via cadence.CalculateContactBy to match the forward writer exactly.
+// The contact row is locked FOR UPDATE so the read→Go-compute→write sequence
+// is serialized against any concurrent cadence/interaction writer on the same
+// contact (closes the lost-update window).
+func (q *Queries) ComputeContactDatesAfterDelete(ctx context.Context, arg ComputeContactDatesAfterDeleteParams) (*ComputeContactDatesAfterDeleteRow, error) {
+	row := q.db.QueryRow(ctx, ComputeContactDatesAfterDelete, arg.DeletedAtTs, arg.ID)
+	var i ComputeContactDatesAfterDeleteRow
+	err := row.Scan(
+		&i.NewLastContacted,
+		&i.NewLastInteractionAt,
+		&i.NewLastResponseAt,
+		&i.NewLastOutreachAt,
+		&i.OldLastContacted,
+		&i.OldContactBy,
+		&i.Cadence,
+		&i.CreatedAt,
+	)
+	return &i, err
+}
+
 const CountContacts = `-- name: CountContacts :one
 SELECT COUNT(*) FROM contact
 WHERE deleted_at IS NULL
@@ -1430,6 +1500,41 @@ func (q *Queries) UpdateContactResponseFields(ctx context.Context, arg UpdateCon
 		arg.IsManual,
 		arg.OccurredAt,
 		arg.ContactBy,
+		arg.ID,
+	)
+	return err
+}
+
+const WriteContactDatesAfterDelete = `-- name: WriteContactDatesAfterDelete :exec
+UPDATE contact SET
+  last_contacted      = $1::timestamptz,
+  last_interaction_at = $2::timestamptz,
+  last_response_at    = $3::timestamptz,
+  last_outreach_at    = $4::timestamptz,
+  contact_by          = $5::date,
+  updated_at = NOW()
+WHERE id = $6 AND deleted_at IS NULL
+`
+
+type WriteContactDatesAfterDeleteParams struct {
+	NewLastContacted     pgtype.Timestamptz `json:"new_last_contacted"`
+	NewLastInteractionAt pgtype.Timestamptz `json:"new_last_interaction_at"`
+	NewLastResponseAt    pgtype.Timestamptz `json:"new_last_response_at"`
+	NewLastOutreachAt    pgtype.Timestamptz `json:"new_last_outreach_at"`
+	NewContactBy         pgtype.Date        `json:"new_contact_by"`
+	ID                   pgtype.UUID        `json:"id"`
+}
+
+// Writes the recomputed date columns. contact_by is passed pre-computed by
+// the Go caller (cadence.CalculateContactBy, environment-aware) so the value
+// matches the forward writer exactly; this query does no cadence arithmetic.
+func (q *Queries) WriteContactDatesAfterDelete(ctx context.Context, arg WriteContactDatesAfterDeleteParams) error {
+	_, err := q.db.Exec(ctx, WriteContactDatesAfterDelete,
+		arg.NewLastContacted,
+		arg.NewLastInteractionAt,
+		arg.NewLastResponseAt,
+		arg.NewLastOutreachAt,
+		arg.NewContactBy,
 		arg.ID,
 	)
 	return err

--- a/backend/internal/db/contact.sql.go
+++ b/backend/internal/db/contact.sql.go
@@ -62,9 +62,11 @@ type ComputeContactDatesAfterDeleteRow struct {
 // cadence, created_at). Direction subsets mirror CadenceApplyFlagsByDirection
 // in reverse. NO cadence/contact_by arithmetic here — that is computed in Go
 // via cadence.CalculateContactBy to match the forward writer exactly.
-// The contact row is locked FOR UPDATE so the read→Go-compute→write sequence
-// is serialized against any concurrent cadence/interaction writer on the same
-// contact (closes the lost-update window).
+// MUST be preceded in the same tx by LockContactForDateRecompute so the
+// interaction aggregate is computed at a snapshot that already reflects any
+// concurrent writer that committed while waiting for the contact lock (the
+// FOR UPDATE retained below re-takes the held lock; the load-bearing
+// serialization is the prior LockContactForDateRecompute statement).
 func (q *Queries) ComputeContactDatesAfterDelete(ctx context.Context, arg ComputeContactDatesAfterDeleteParams) (*ComputeContactDatesAfterDeleteRow, error) {
 	row := q.db.QueryRow(ctx, ComputeContactDatesAfterDelete, arg.DeletedAtTs, arg.ID)
 	var i ComputeContactDatesAfterDeleteRow
@@ -770,6 +772,31 @@ func (q *Queries) ListOverdueContacts(ctx context.Context, arg ListOverdueContac
 	return items, nil
 }
 
+const LockContactForDateRecompute = `-- name: LockContactForDateRecompute :one
+SELECT id FROM contact
+WHERE id = $1 AND deleted_at IS NULL
+FOR UPDATE
+`
+
+// Acquires a FOR UPDATE lock on the contact row before the date recompute
+// reads the interaction aggregate. Run as a SEPARATE statement (in the
+// caller's tx) BEFORE ComputeContactDatesAfterDelete: once this lock is held
+// — waiting out any concurrent interaction/cadence writer, whose atomic
+// (interaction INSERT + contact UPDATE) tx takes a conflicting row lock —
+// the subsequent ComputeContactDatesAfterDelete statement runs at a fresh
+// READ COMMITTED snapshot that INCLUDES that writer's just-committed
+// interaction rows. Folding the lock into ComputeContactDatesAfterDelete's
+// CTE is NOT sufficient: FOR UPDATE re-reads only the locked contact row at
+// the post-wait snapshot, while the interaction aggregate in the same
+// statement still sees the statement's original snapshot, so a concurrently
+// committed interaction would be missed. Returns db.ErrNotFound (pgx.ErrNoRows)
+// when the contact was soft-deleted.
+func (q *Queries) LockContactForDateRecompute(ctx context.Context, id pgtype.UUID) (pgtype.UUID, error) {
+	row := q.db.QueryRow(ctx, LockContactForDateRecompute, id)
+	err := row.Scan(&id)
+	return id, err
+}
+
 const SearchContactIDs = `-- name: SearchContactIDs :many
 SELECT c.id FROM contact c
 LEFT JOIN (
@@ -1097,6 +1124,23 @@ WHERE id = $1 AND deleted_at IS NULL
 func (q *Queries) SoftDeleteContact(ctx context.Context, id pgtype.UUID) error {
 	_, err := q.db.Exec(ctx, SoftDeleteContact, id)
 	return err
+}
+
+const TestLockContactForUpdateNoWait = `-- name: TestLockContactForUpdateNoWait :one
+SELECT id FROM contact
+WHERE id = $1 AND deleted_at IS NULL
+FOR UPDATE NOWAIT
+`
+
+// TEST ONLY. Probe a contact row with FOR UPDATE NOWAIT: fails immediately
+// (lock_not_available) when another tx holds a conflicting lock on the row.
+// Used by the recompute lock-ordering regression test to prove (without a
+// sleep) that LockContactForDateRecompute is acquired as a blocking statement.
+// Production code must NOT call this.
+func (q *Queries) TestLockContactForUpdateNoWait(ctx context.Context, id pgtype.UUID) (pgtype.UUID, error) {
+	row := q.db.QueryRow(ctx, TestLockContactForUpdateNoWait, id)
+	err := row.Scan(&id)
+	return id, err
 }
 
 const UpdateContact = `-- name: UpdateContact :one

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -71,6 +71,18 @@ type Querier interface {
 	// transitions the row to completed.
 	CompleteFollowUpForContact(ctx context.Context, contactID pgtype.UUID) ([]*ContactTask, error)
 	CompleteSyncLog(ctx context.Context, arg CompleteSyncLogParams) (*ExternalSyncLog, error)
+	// Returns the surgically-recomputed timestamp columns (each touched ONLY
+	// when the deleted interaction at @deleted_at_ts was its source: column =
+	// @deleted_at_ts → MAX(remaining live interactions of its subset), NULL when
+	// none remain; otherwise the existing value is preserved) plus the fields the
+	// Go caller needs to decide contact_by (old_last_contacted, old_contact_by,
+	// cadence, created_at). Direction subsets mirror CadenceApplyFlagsByDirection
+	// in reverse. NO cadence/contact_by arithmetic here — that is computed in Go
+	// via cadence.CalculateContactBy to match the forward writer exactly.
+	// The contact row is locked FOR UPDATE so the read→Go-compute→write sequence
+	// is serialized against any concurrent cadence/interaction writer on the same
+	// contact (closes the lost-update window).
+	ComputeContactDatesAfterDelete(ctx context.Context, arg ComputeContactDatesAfterDeleteParams) (*ComputeContactDatesAfterDeleteRow, error)
 	CountAllUnmatchedExternalContacts(ctx context.Context) (int64, error)
 	CountContactInteractions(ctx context.Context, contactID pgtype.UUID) (int64, error)
 	CountContactNotes(ctx context.Context, contactID pgtype.UUID) (int64, error)
@@ -190,6 +202,10 @@ type Querier interface {
 	// packages in parallel against the shared test DB.
 	DeleteAllMacHosts(ctx context.Context) (int64, error)
 	DeleteAllPairingTokens(ctx context.Context) (int64, error)
+	// Hard-deletes the stored calendar_event row keyed by its Google identity
+	// triple. Used by the decline/cancel remove branch. calendar_event has no
+	// deleted_at column — removal is a hard DELETE (cf. DeleteEventsByAccount).
+	DeleteCalendarEventByGcalID(ctx context.Context, arg DeleteCalendarEventByGcalIDParams) error
 	DeleteCalendarEventsByGcalEventIdPrefix(ctx context.Context, dollar_1 pgtype.Text) (int64, error)
 	DeleteCalendarEventsByTitlePrefix(ctx context.Context, dollar_1 pgtype.Text) (int64, error)
 	DeleteContactMethodsByContact(ctx context.Context, contactID pgtype.UUID) error
@@ -426,6 +442,12 @@ type Querier interface {
 	GetCalendarEventByGcalID(ctx context.Context, arg GetCalendarEventByGcalIDParams) (*CalendarEvent, error)
 	// Look up an event by its UUID
 	GetCalendarEventByID(ctx context.Context, id pgtype.UUID) (*CalendarEvent, error)
+	// Locking read used by the InteractionRecorder calendar.attended branch to
+	// serialize against a concurrent decline DELETE on the same row. FOR SHARE
+	// holds the row until the attended tx commits, so an interleaving decline
+	// DELETE either blocks (attended inserts, decline then soft-deletes) or has
+	// already committed (this read returns no row, attended skips the insert).
+	GetCalendarEventByIDForShare(ctx context.Context, id pgtype.UUID) (*CalendarEvent, error)
 	// Contact queries
 	GetContact(ctx context.Context, id pgtype.UUID) (*Contact, error)
 	// Get a single note for a contact by category (e.g., 'notepad')
@@ -849,6 +871,13 @@ type Querier interface {
 	// surface a clean not-found when a concurrent resolve already claimed the
 	// group (zero rows).
 	MarkAnarlogTitleSiblingsMatchedByToken(ctx context.Context, arg MarkAnarlogTitleSiblingsMatchedByTokenParams) (int64, error)
+	// Off-mode deferral for the decline remove branch: marks a stored event
+	// cancelled (keyed by its Google identity triple) instead of deleting,
+	// when the event bus is unavailable. status='cancelled' excludes the row
+	// from ListPastEventsNeedingUpdate (status='confirmed') and from all
+	// contact-facing reads (status != 'cancelled'), so it neither re-fires
+	// calendar.attended nor strands an already-recorded interaction.
+	MarkCalendarEventCancelledByGcalID(ctx context.Context, arg MarkCalendarEventCancelledByGcalIDParams) error
 	// Mark an event as having updated last_contacted for its contacts
 	MarkLastContactedUpdated(ctx context.Context, id pgtype.UUID) error
 	// Non-tx variant. Mirror of MarkTelegramMessagesProcessed — used by the
@@ -1245,6 +1274,10 @@ type Querier interface {
 	// does NOT touch auth_state (which is managed by AuthSessionManager).
 	UpsertTelegramSessionData(ctx context.Context, arg UpsertTelegramSessionDataParams) (*TelegramSession, error)
 	UpsertTelegramUpdateState(ctx context.Context, arg UpsertTelegramUpdateStateParams) (*TelegramUpdateState, error)
+	// Writes the recomputed date columns. contact_by is passed pre-computed by
+	// the Go caller (cadence.CalculateContactBy, environment-aware) so the value
+	// matches the forward writer exactly; this query does no cadence arithmetic.
+	WriteContactDatesAfterDelete(ctx context.Context, arg WriteContactDatesAfterDeleteParams) error
 }
 
 var _ Querier = (*Queries)(nil)

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -1043,9 +1043,9 @@ type Querier interface {
 	// TEST ONLY. Probe a calendar_event row with FOR UPDATE NOWAIT: returns the
 	// row if no conflicting lock is held, or fails immediately (lock_not_available)
 	// when another tx holds a conflicting lock (e.g. a FOR SHARE from the attended
-	// branch). Used by the Decision-3a lock-serialization integration test to
-	// prove the attended FOR SHARE conflicts with a concurrent FOR UPDATE without
-	// a sleep/timeout. Production code must NOT call this.
+	// branch). Used by the attended-vs-decline lock-serialization integration
+	// test to prove the attended FOR SHARE conflicts with a concurrent FOR UPDATE
+	// without a sleep/timeout. Production code must NOT call this.
 	TestGetCalendarEventByIDForUpdateNoWait(ctx context.Context, id pgtype.UUID) (*CalendarEvent, error)
 	// TEST ONLY. Hard-deletes a calendar_event row by primary key. Used
 	// by integration tests that exercise the "target row vanished between

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -79,9 +79,11 @@ type Querier interface {
 	// cadence, created_at). Direction subsets mirror CadenceApplyFlagsByDirection
 	// in reverse. NO cadence/contact_by arithmetic here — that is computed in Go
 	// via cadence.CalculateContactBy to match the forward writer exactly.
-	// The contact row is locked FOR UPDATE so the read→Go-compute→write sequence
-	// is serialized against any concurrent cadence/interaction writer on the same
-	// contact (closes the lost-update window).
+	// MUST be preceded in the same tx by LockContactForDateRecompute so the
+	// interaction aggregate is computed at a snapshot that already reflects any
+	// concurrent writer that committed while waiting for the contact lock (the
+	// FOR UPDATE retained below re-takes the held lock; the load-bearing
+	// serialization is the prior LockContactForDateRecompute statement).
 	ComputeContactDatesAfterDelete(ctx context.Context, arg ComputeContactDatesAfterDeleteParams) (*ComputeContactDatesAfterDeleteRow, error)
 	CountAllUnmatchedExternalContacts(ctx context.Context) (int64, error)
 	CountContactInteractions(ctx context.Context, contactID pgtype.UUID) (int64, error)
@@ -851,6 +853,20 @@ type Querier interface {
 	ListUpcomingEventsForContact(ctx context.Context, arg ListUpcomingEventsForContactParams) ([]*CalendarEvent, error)
 	// List upcoming events that have matched CRM contacts
 	ListUpcomingEventsWithContacts(ctx context.Context, arg ListUpcomingEventsWithContactsParams) ([]*CalendarEvent, error)
+	// Acquires a FOR UPDATE lock on the contact row before the date recompute
+	// reads the interaction aggregate. Run as a SEPARATE statement (in the
+	// caller's tx) BEFORE ComputeContactDatesAfterDelete: once this lock is held
+	// — waiting out any concurrent interaction/cadence writer, whose atomic
+	// (interaction INSERT + contact UPDATE) tx takes a conflicting row lock —
+	// the subsequent ComputeContactDatesAfterDelete statement runs at a fresh
+	// READ COMMITTED snapshot that INCLUDES that writer's just-committed
+	// interaction rows. Folding the lock into ComputeContactDatesAfterDelete's
+	// CTE is NOT sufficient: FOR UPDATE re-reads only the locked contact row at
+	// the post-wait snapshot, while the interaction aggregate in the same
+	// statement still sees the statement's original snapshot, so a concurrently
+	// committed interaction would be missed. Returns db.ErrNotFound (pgx.ErrNoRows)
+	// when the contact was soft-deleted.
+	LockContactForDateRecompute(ctx context.Context, id pgtype.UUID) (pgtype.UUID, error)
 	// Single-statement batch mark for the action=ignore ("Not a person")
 	// resolve path: every live unmatched sibling for the token flips to
 	// 'ignored'. No crm_contact_id is set. Same predicate as the other two
@@ -1079,6 +1095,12 @@ type Querier interface {
 	// enforces. sqlc.narg('emails') makes the parameter nullable so callers can
 	// exercise the NULL JSONB column case.
 	TestInsertExternalContactRawEmails(ctx context.Context, arg TestInsertExternalContactRawEmailsParams) (*ExternalContact, error)
+	// TEST ONLY. Probe a contact row with FOR UPDATE NOWAIT: fails immediately
+	// (lock_not_available) when another tx holds a conflicting lock on the row.
+	// Used by the recompute lock-ordering regression test to prove (without a
+	// sleep) that LockContactForDateRecompute is acquired as a blocking statement.
+	// Production code must NOT call this.
+	TestLockContactForUpdateNoWait(ctx context.Context, id pgtype.UUID) (pgtype.UUID, error)
 	// TEST ONLY. Mirrors the legacy EXISTS / jsonb_array_elements form of
 	// FindEventsByAttendeeEmailUnmatchedForContact. Permanent regression guard.
 	// Callers must restrict input fixtures to well-formed JSONB arrays

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -1040,6 +1040,13 @@ type Querier interface {
 	// TEST ONLY. Hard-deletes external_contact rows whose source_id starts with
 	// the given prefix. Used by t.Cleanup to remove fixtures inserted by a test.
 	TestDeleteExternalContactsBySourceIDPrefix(ctx context.Context, prefix string) error
+	// TEST ONLY. Probe a calendar_event row with FOR UPDATE NOWAIT: returns the
+	// row if no conflicting lock is held, or fails immediately (lock_not_available)
+	// when another tx holds a conflicting lock (e.g. a FOR SHARE from the attended
+	// branch). Used by the Decision-3a lock-serialization integration test to
+	// prove the attended FOR SHARE conflicts with a concurrent FOR UPDATE without
+	// a sleep/timeout. Production code must NOT call this.
+	TestGetCalendarEventByIDForUpdateNoWait(ctx context.Context, id pgtype.UUID) (*CalendarEvent, error)
 	// TEST ONLY. Hard-deletes a calendar_event row by primary key. Used
 	// by integration tests that exercise the "target row vanished between
 	// snapshot and resolve-link" path. Production code must NOT call this.

--- a/backend/internal/db/queries/calendar_event.sql
+++ b/backend/internal/db/queries/calendar_event.sql
@@ -212,9 +212,9 @@ FOR SHARE;
 -- TEST ONLY. Probe a calendar_event row with FOR UPDATE NOWAIT: returns the
 -- row if no conflicting lock is held, or fails immediately (lock_not_available)
 -- when another tx holds a conflicting lock (e.g. a FOR SHARE from the attended
--- branch). Used by the Decision-3a lock-serialization integration test to
--- prove the attended FOR SHARE conflicts with a concurrent FOR UPDATE without
--- a sleep/timeout. Production code must NOT call this.
+-- branch). Used by the attended-vs-decline lock-serialization integration
+-- test to prove the attended FOR SHARE conflicts with a concurrent FOR UPDATE
+-- without a sleep/timeout. Production code must NOT call this.
 SELECT * FROM calendar_event
 WHERE id = $1
 FOR UPDATE NOWAIT;

--- a/backend/internal/db/queries/calendar_event.sql
+++ b/backend/internal/db/queries/calendar_event.sql
@@ -207,3 +207,14 @@ WHERE gcal_event_id = $1
 SELECT * FROM calendar_event
 WHERE id = $1
 FOR SHARE;
+
+-- name: TestGetCalendarEventByIDForUpdateNoWait :one
+-- TEST ONLY. Probe a calendar_event row with FOR UPDATE NOWAIT: returns the
+-- row if no conflicting lock is held, or fails immediately (lock_not_available)
+-- when another tx holds a conflicting lock (e.g. a FOR SHARE from the attended
+-- branch). Used by the Decision-3a lock-serialization integration test to
+-- prove the attended FOR SHARE conflicts with a concurrent FOR UPDATE without
+-- a sleep/timeout. Production code must NOT call this.
+SELECT * FROM calendar_event
+WHERE id = $1
+FOR UPDATE NOWAIT;

--- a/backend/internal/db/queries/calendar_event.sql
+++ b/backend/internal/db/queries/calendar_event.sql
@@ -174,3 +174,36 @@ SELECT * FROM calendar_event
 WHERE start_time BETWEEN sqlc.arg('window_start') AND sqlc.arg('window_end')
   AND status != 'cancelled'
 ORDER BY start_time ASC;
+
+-- name: DeleteCalendarEventByGcalID :exec
+-- Hard-deletes the stored calendar_event row keyed by its Google identity
+-- triple. Used by the decline/cancel remove branch. calendar_event has no
+-- deleted_at column — removal is a hard DELETE (cf. DeleteEventsByAccount).
+DELETE FROM calendar_event
+WHERE gcal_event_id = $1
+  AND gcal_calendar_id = $2
+  AND google_account_id = $3;
+
+-- name: MarkCalendarEventCancelledByGcalID :exec
+-- Off-mode deferral for the decline remove branch: marks a stored event
+-- cancelled (keyed by its Google identity triple) instead of deleting,
+-- when the event bus is unavailable. status='cancelled' excludes the row
+-- from ListPastEventsNeedingUpdate (status='confirmed') and from all
+-- contact-facing reads (status != 'cancelled'), so it neither re-fires
+-- calendar.attended nor strands an already-recorded interaction.
+UPDATE calendar_event
+SET status = 'cancelled',
+    updated_at = NOW()
+WHERE gcal_event_id = $1
+  AND gcal_calendar_id = $2
+  AND google_account_id = $3;
+
+-- name: GetCalendarEventByIDForShare :one
+-- Locking read used by the InteractionRecorder calendar.attended branch to
+-- serialize against a concurrent decline DELETE on the same row. FOR SHARE
+-- holds the row until the attended tx commits, so an interleaving decline
+-- DELETE either blocks (attended inserts, decline then soft-deletes) or has
+-- already committed (this read returns no row, attended skips the insert).
+SELECT * FROM calendar_event
+WHERE id = $1
+FOR SHARE;

--- a/backend/internal/db/queries/contact.sql
+++ b/backend/internal/db/queries/contact.sql
@@ -572,6 +572,34 @@ WHERE deleted_at IS NULL
 ORDER BY full_name ASC
 LIMIT $1;
 
+-- name: LockContactForDateRecompute :one
+-- Acquires a FOR UPDATE lock on the contact row before the date recompute
+-- reads the interaction aggregate. Run as a SEPARATE statement (in the
+-- caller's tx) BEFORE ComputeContactDatesAfterDelete: once this lock is held
+-- — waiting out any concurrent interaction/cadence writer, whose atomic
+-- (interaction INSERT + contact UPDATE) tx takes a conflicting row lock —
+-- the subsequent ComputeContactDatesAfterDelete statement runs at a fresh
+-- READ COMMITTED snapshot that INCLUDES that writer's just-committed
+-- interaction rows. Folding the lock into ComputeContactDatesAfterDelete's
+-- CTE is NOT sufficient: FOR UPDATE re-reads only the locked contact row at
+-- the post-wait snapshot, while the interaction aggregate in the same
+-- statement still sees the statement's original snapshot, so a concurrently
+-- committed interaction would be missed. Returns db.ErrNotFound (pgx.ErrNoRows)
+-- when the contact was soft-deleted.
+SELECT id FROM contact
+WHERE id = sqlc.arg(id) AND deleted_at IS NULL
+FOR UPDATE;
+
+-- name: TestLockContactForUpdateNoWait :one
+-- TEST ONLY. Probe a contact row with FOR UPDATE NOWAIT: fails immediately
+-- (lock_not_available) when another tx holds a conflicting lock on the row.
+-- Used by the recompute lock-ordering regression test to prove (without a
+-- sleep) that LockContactForDateRecompute is acquired as a blocking statement.
+-- Production code must NOT call this.
+SELECT id FROM contact
+WHERE id = sqlc.arg(id) AND deleted_at IS NULL
+FOR UPDATE NOWAIT;
+
 -- name: ComputeContactDatesAfterDelete :one
 -- Returns the surgically-recomputed timestamp columns (each touched ONLY
 -- when the deleted interaction at @deleted_at_ts was its source: column =
@@ -581,9 +609,11 @@ LIMIT $1;
 -- cadence, created_at). Direction subsets mirror CadenceApplyFlagsByDirection
 -- in reverse. NO cadence/contact_by arithmetic here — that is computed in Go
 -- via cadence.CalculateContactBy to match the forward writer exactly.
--- The contact row is locked FOR UPDATE so the read→Go-compute→write sequence
--- is serialized against any concurrent cadence/interaction writer on the same
--- contact (closes the lost-update window).
+-- MUST be preceded in the same tx by LockContactForDateRecompute so the
+-- interaction aggregate is computed at a snapshot that already reflects any
+-- concurrent writer that committed while waiting for the contact lock (the
+-- FOR UPDATE retained below re-takes the held lock; the load-bearing
+-- serialization is the prior LockContactForDateRecompute statement).
 WITH agg AS (
   SELECT
     MAX(occurred_at) FILTER (WHERE direction IN ('inbound','mutual'))  AS new_non_outbound,

--- a/backend/internal/db/queries/contact.sql
+++ b/backend/internal/db/queries/contact.sql
@@ -571,3 +571,53 @@ WHERE deleted_at IS NULL
   AND cadence != ''
 ORDER BY full_name ASC
 LIMIT $1;
+
+-- name: ComputeContactDatesAfterDelete :one
+-- Returns the surgically-recomputed timestamp columns (each touched ONLY
+-- when the deleted interaction at @deleted_at_ts was its source: column =
+-- @deleted_at_ts → MAX(remaining live interactions of its subset), NULL when
+-- none remain; otherwise the existing value is preserved) plus the fields the
+-- Go caller needs to decide contact_by (old_last_contacted, old_contact_by,
+-- cadence, created_at). Direction subsets mirror CadenceApplyFlagsByDirection
+-- in reverse. NO cadence/contact_by arithmetic here — that is computed in Go
+-- via cadence.CalculateContactBy to match the forward writer exactly.
+-- The contact row is locked FOR UPDATE so the read→Go-compute→write sequence
+-- is serialized against any concurrent cadence/interaction writer on the same
+-- contact (closes the lost-update window).
+WITH agg AS (
+  SELECT
+    MAX(occurred_at) FILTER (WHERE direction IN ('inbound','mutual'))  AS new_non_outbound,
+    MAX(occurred_at) FILTER (WHERE direction IN ('outbound','mutual')) AS new_outreach
+  FROM interaction
+  WHERE contact_id = sqlc.arg(id) AND deleted_at IS NULL
+),
+locked AS (
+  SELECT id, last_contacted, last_interaction_at, last_response_at,
+         last_outreach_at, contact_by, cadence, created_at
+  FROM contact
+  WHERE id = sqlc.arg(id) AND deleted_at IS NULL
+  FOR UPDATE
+)
+SELECT
+  (CASE WHEN c.last_contacted      = sqlc.arg(deleted_at_ts)::timestamptz THEN agg.new_non_outbound ELSE c.last_contacted      END)::timestamptz AS new_last_contacted,
+  (CASE WHEN c.last_interaction_at = sqlc.arg(deleted_at_ts)::timestamptz THEN agg.new_non_outbound ELSE c.last_interaction_at END)::timestamptz AS new_last_interaction_at,
+  (CASE WHEN c.last_response_at    = sqlc.arg(deleted_at_ts)::timestamptz THEN agg.new_non_outbound ELSE c.last_response_at    END)::timestamptz AS new_last_response_at,
+  (CASE WHEN c.last_outreach_at    = sqlc.arg(deleted_at_ts)::timestamptz THEN agg.new_outreach     ELSE c.last_outreach_at    END)::timestamptz AS new_last_outreach_at,
+  c.last_contacted AS old_last_contacted,
+  c.contact_by     AS old_contact_by,
+  c.cadence        AS cadence,
+  c.created_at     AS created_at
+FROM locked c, agg;
+
+-- name: WriteContactDatesAfterDelete :exec
+-- Writes the recomputed date columns. contact_by is passed pre-computed by
+-- the Go caller (cadence.CalculateContactBy, environment-aware) so the value
+-- matches the forward writer exactly; this query does no cadence arithmetic.
+UPDATE contact SET
+  last_contacted      = sqlc.narg(new_last_contacted)::timestamptz,
+  last_interaction_at = sqlc.narg(new_last_interaction_at)::timestamptz,
+  last_response_at    = sqlc.narg(new_last_response_at)::timestamptz,
+  last_outreach_at    = sqlc.narg(new_last_outreach_at)::timestamptz,
+  contact_by          = sqlc.narg(new_contact_by)::date,
+  updated_at = NOW()
+WHERE id = sqlc.arg(id) AND deleted_at IS NULL;

--- a/backend/internal/events/bus.go
+++ b/backend/internal/events/bus.go
@@ -55,13 +55,22 @@ type consumerJob struct {
 //     retries at enqueue time.
 //   - interaction.manual: inline-invoked by the manual UI handler; no
 //     async consumer.
-//   - calendar.declined, task.skipped: no consumer yet wired.
+//   - calendar.declined → CalendarDeclineHandler worker with
+//     MaxAttempts=5 (soft-deletes the derived gcal interaction + recomputes
+//     the contact's date columns when a calendar event is declined/
+//     cancelled/user-removed upstream).
+//   - task.skipped: no consumer yet wired.
 func consumerJobsForKind(env *Envelope) ([]consumerJob, error) {
 	switch env.Kind {
 	case KindMessageReceived, KindMessageSent, KindCalendarAttended,
 		KindTaskCompleted, KindTaskOutreachDetected:
 		return []consumerJob{{
 			Args: consumerjobs.InteractionRecorderJobArgs{EventID: env.ID},
+			Opts: &river.InsertOpts{MaxAttempts: 5},
+		}}, nil
+	case KindCalendarDeclined:
+		return []consumerJob{{
+			Args: consumerjobs.CalendarDeclineHandlerJobArgs{EventID: env.ID},
 			Opts: &river.InsertOpts{MaxAttempts: 5},
 		}}, nil
 	case KindInteractionRecorded:

--- a/backend/internal/events/bus_test.go
+++ b/backend/internal/events/bus_test.go
@@ -110,7 +110,7 @@ func TestConsumerJobsForKind_EmptyForDeferredKinds(t *testing.T) {
 
 // TestConsumerJobsForKind_CalendarDeclinedEnqueuesDeclineHandler asserts
 // that calendar.declined enqueues exactly one CalendarDeclineHandler river
-// job with MaxAttempts=5 (Decision 7).
+// job with MaxAttempts=5.
 func TestConsumerJobsForKind_CalendarDeclinedEnqueuesDeclineHandler(t *testing.T) {
 	eventID := uuid.New()
 	env := &Envelope{ID: eventID, Kind: KindCalendarDeclined}

--- a/backend/internal/events/bus_test.go
+++ b/backend/internal/events/bus_test.go
@@ -87,15 +87,15 @@ func TestConsumerJobsForKind_InteractionRecordedEnqueuesCadenceAndFollowUp(t *te
 // still have no active consumer return nil:
 //   - interaction.manual: inline-invoked by the manual UI handler
 //     (spec §3.4 "other consumers only").
-//   - calendar.declined, task.skipped: consumers for those kinds are
-//     not yet wired.
+//   - task.skipped: consumer for that kind is not yet wired.
 //
 // (contact_methods.added HAS a consumer now — see the dedicated
-// TestConsumerJobsForKind_ContactMethodsAdded tests below.)
+// TestConsumerJobsForKind_ContactMethodsAdded tests below.
+// calendar.declined HAS a consumer now — see
+// TestConsumerJobsForKind_CalendarDeclinedEnqueuesDeclineHandler.)
 func TestConsumerJobsForKind_EmptyForDeferredKinds(t *testing.T) {
 	deferred := []Kind{
 		KindInteractionManual,
-		KindCalendarDeclined,
 		KindTaskSkipped,
 	}
 	for _, k := range deferred {
@@ -106,6 +106,24 @@ func TestConsumerJobsForKind_EmptyForDeferredKinds(t *testing.T) {
 			require.Empty(t, jobs, "kind %s: expected empty consumer-job slice", k)
 		})
 	}
+}
+
+// TestConsumerJobsForKind_CalendarDeclinedEnqueuesDeclineHandler asserts
+// that calendar.declined enqueues exactly one CalendarDeclineHandler river
+// job with MaxAttempts=5 (Decision 7).
+func TestConsumerJobsForKind_CalendarDeclinedEnqueuesDeclineHandler(t *testing.T) {
+	eventID := uuid.New()
+	env := &Envelope{ID: eventID, Kind: KindCalendarDeclined}
+	jobs, err := consumerJobsForKind(env)
+	require.NoError(t, err)
+	require.Len(t, jobs, 1, "calendar.declined should enqueue exactly one consumer job")
+
+	args, ok := jobs[0].Args.(consumerjobs.CalendarDeclineHandlerJobArgs)
+	require.True(t, ok, "job args type must be CalendarDeclineHandlerJobArgs, got %T", jobs[0].Args)
+	require.Equal(t, eventID, args.EventID)
+	require.Equal(t, "calendar_decline_handler", args.Kind())
+	require.NotNil(t, jobs[0].Opts, "InsertOpts must be set to pin MaxAttempts")
+	require.Equal(t, 5, jobs[0].Opts.MaxAttempts)
 }
 
 // TestConsumerJobsForKind_ContactMethodsAdded asserts the PR 10 routing:

--- a/backend/internal/google/calendar.go
+++ b/backend/internal/google/calendar.go
@@ -126,6 +126,12 @@ type CalendarSyncProvider struct {
 	// dependency. Nil when mode=off — the remove branch then defers cleanup
 	// by marking the stored row cancelled instead of publishing + deleting.
 	pool *pgxpool.Pool
+	// declineBus is the bus used by the cutover decline remove branch's
+	// per-contact PublishTx. It defaults to eventBus; tests substitute a
+	// failing stub via setDeclineBusForTest to assert publish-before-delete
+	// (a publish failure must leave the calendar_event row intact). The
+	// off-mode gate keys off the concrete eventBus/pool fields, not this one.
+	declineBus busTx
 }
 
 // NewCalendarSyncProvider creates a new Google Calendar sync provider.
@@ -150,6 +156,7 @@ func NewCalendarSyncProvider(
 		externalContactRepo: externalContactRepo,
 		eventBus:            eventBus,
 		pool:                pool,
+		declineBus:          eventBus,
 	}
 }
 
@@ -363,13 +370,13 @@ func (p *CalendarSyncProvider) incrementalSync(
 
 // processEvent processes a single calendar event.
 //
-// The keep decision is evaluated BEFORE time parsing and the all-day skip
-// (Decision 1): incremental-sync deltas for cancelled/declined events can
-// arrive with empty Start.DateTime/End.DateTime (Google sends a minimal
-// stub), so the remove branch must run without depending on inbound times.
-// The CRM stores a calendar_event only while the user has it accepted AND
-// it is not cancelled; any sync that observes it otherwise removes the
-// stored copy + its derived interactions.
+// The keep decision is evaluated BEFORE time parsing and the all-day skip:
+// incremental-sync deltas for cancelled/declined events can arrive with empty
+// Start.DateTime/End.DateTime (Google sends a minimal stub), so the remove
+// branch must run without depending on inbound times. The CRM stores a
+// calendar_event only while the user has it accepted AND it is not cancelled;
+// any sync that observes it otherwise removes the stored copy + its derived
+// interactions.
 func (p *CalendarSyncProvider) processEvent(
 	ctx context.Context,
 	event *calendar.Event,
@@ -507,7 +514,7 @@ func (p *CalendarSyncProvider) removeDeclinedEvent(ctx context.Context, gcalEven
 
 	eventIDStr := stored.ID.String()
 	for _, contactID := range stored.MatchedContactIDs {
-		if pubErr := publishCalendarDeclinedTx(ctx, p.eventBus, tx, contactID, eventIDStr, stored.EndTime); pubErr != nil {
+		if pubErr := publishCalendarDeclinedTx(ctx, p.declineBus, tx, contactID, eventIDStr, stored.EndTime); pubErr != nil {
 			return fmt.Errorf("publish calendar.declined for contact %s: %w", contactID, pubErr)
 		}
 	}
@@ -526,6 +533,22 @@ func (p *CalendarSyncProvider) removeDeclinedEvent(ctx context.Context, gcalEven
 		Int("contacts", len(stored.MatchedContactIDs)).
 		Msg("calendar: removed declined/cancelled event + published decline per matched contact")
 	return nil
+}
+
+// RunProcessEventForTest drives the unexported processEvent entry point so
+// cross-package integration tests (package tests) can exercise the full
+// keep/remove gate + cutover remove branch end-to-end against a real DB +
+// bus + pool. Production code must NOT call this.
+func (p *CalendarSyncProvider) RunProcessEventForTest(ctx context.Context, event *calendar.Event, accountID string) error {
+	return p.processEvent(ctx, event, accountID)
+}
+
+// SetDeclineBusForTest substitutes the bus used by the cutover decline remove
+// branch's per-contact PublishTx so a test can assert publish-before-delete
+// (a failing PublishTx must leave the calendar_event row intact). Production
+// code must NOT call this.
+func (p *CalendarSyncProvider) SetDeclineBusForTest(b busTx) {
+	p.declineBus = b
 }
 
 // getUserResponse extracts the user's response status from an event

--- a/backend/internal/google/calendar.go
+++ b/backend/internal/google/calendar.go
@@ -2,12 +2,14 @@ package google
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 	"unicode"
 
 	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/events"
 	"personal-crm/backend/internal/identity"
 	"personal-crm/backend/internal/logger"
@@ -17,6 +19,8 @@ import (
 	"personal-crm/backend/internal/sync"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"google.golang.org/api/calendar/v3"
 	"google.golang.org/api/option"
 )
@@ -69,6 +73,10 @@ type calendarRepoInterface interface {
 	Upsert(ctx context.Context, req repository.UpsertCalendarEventRequest) (*repository.CalendarEvent, error)
 	ListPastEventsNeedingUpdate(ctx context.Context, before time.Time, limit int32) ([]repository.CalendarEvent, error)
 	MarkLastContactedUpdated(ctx context.Context, id uuid.UUID) error
+	// Decline/cancel remove branch.
+	GetByGcalID(ctx context.Context, gcalEventID, gcalCalendarID, googleAccountID string) (*repository.CalendarEvent, error)
+	DeleteByGcalIDTx(ctx context.Context, tx pgx.Tx, gcalEventID, gcalCalendarID, googleAccountID string) error
+	MarkCancelledByGcalID(ctx context.Context, gcalEventID, gcalCalendarID, googleAccountID string) error
 }
 
 // contactRepoInterface defines the methods needed from contact repository (for testability)
@@ -112,11 +120,19 @@ type CalendarSyncProvider struct {
 	// post-cutover — past-event publishes are skipped and
 	// last_contacted-from-calendar updates do NOT happen (spec §3.9).
 	eventBus *events.Bus
+	// pool is required by the cutover decline remove branch, which does
+	// N calendar.declined publishes + one calendar_event DELETE in a single
+	// atomic tx (publish-before-delete). Mirrors the Todoist provider's pool
+	// dependency. Nil when mode=off — the remove branch then defers cleanup
+	// by marking the stored row cancelled instead of publishing + deleting.
+	pool *pgxpool.Pool
 }
 
 // NewCalendarSyncProvider creates a new Google Calendar sync provider.
 // eventBus is required in cutover (default post-PR-6). Nil disables
-// past-event interaction writes entirely.
+// past-event interaction writes entirely. pool backs the decline remove
+// branch's atomic publish-before-delete tx; in off mode (nil eventBus or
+// nil pool) the branch defers cleanup via MarkCancelledByGcalID.
 func NewCalendarSyncProvider(
 	oauthService *OAuthService,
 	calendarRepo *repository.CalendarEventRepository,
@@ -124,6 +140,7 @@ func NewCalendarSyncProvider(
 	identityService *service.IdentityService,
 	externalContactRepo *repository.ExternalContactRepository,
 	eventBus *events.Bus,
+	pool *pgxpool.Pool,
 ) *CalendarSyncProvider {
 	return &CalendarSyncProvider{
 		oauthService:        oauthService,
@@ -132,6 +149,7 @@ func NewCalendarSyncProvider(
 		identityService:     identityService,
 		externalContactRepo: externalContactRepo,
 		eventBus:            eventBus,
+		pool:                pool,
 	}
 }
 
@@ -343,13 +361,36 @@ func (p *CalendarSyncProvider) incrementalSync(
 	return result, nil
 }
 
-// processEvent processes a single calendar event
+// processEvent processes a single calendar event.
+//
+// The keep decision is evaluated BEFORE time parsing and the all-day skip
+// (Decision 1): incremental-sync deltas for cancelled/declined events can
+// arrive with empty Start.DateTime/End.DateTime (Google sends a minimal
+// stub), so the remove branch must run without depending on inbound times.
+// The CRM stores a calendar_event only while the user has it accepted AND
+// it is not cancelled; any sync that observes it otherwise removes the
+// stored copy + its derived interactions.
 func (p *CalendarSyncProvider) processEvent(
 	ctx context.Context,
 	event *calendar.Event,
 	accountID string,
 ) error {
-	// Skip all-day events (holidays/birthdays, not meetings)
+	userResponse := p.getUserResponse(event, accountID)
+	status := getEventStatus(event)
+
+	keep := userResponse != nil && *userResponse == "accepted" && status != "cancelled"
+	if !keep {
+		// Decline / tentative / needsAction / user-removed / cancelled.
+		// Run the remove branch (keyed on event.Id, always present on any
+		// delta) BEFORE the all-day skip and the time parse: a previously-
+		// stored TIMED event arriving as a cancelled/declined stub (possibly
+		// all-day-shaped, possibly without DateTime) must still be cleaned up.
+		return p.removeDeclinedEvent(ctx, event.Id, accountID)
+	}
+
+	// Keep path. Skip all-day events (holidays/birthdays, not meetings).
+	// Accepted meetings always carry DateTime, so this is byte-for-byte
+	// identical to the pre-restructure keep-path behavior.
 	if event.Start.Date != "" {
 		logger.Debug().
 			Str("eventId", event.Id).
@@ -366,19 +407,6 @@ func (p *CalendarSyncProvider) processEvent(
 	endTime, err := time.Parse(time.RFC3339, event.End.DateTime)
 	if err != nil {
 		return fmt.Errorf("parse end time: %w", err)
-	}
-
-	// Determine user's response status
-	userResponse := p.getUserResponse(event, accountID)
-
-	// Only import events the user has firmly accepted
-	// Skip: declined, tentative, needsAction, and events where user is not an attendee
-	if userResponse == nil || *userResponse != "accepted" {
-		logger.Debug().
-			Str("eventId", event.Id).
-			Str("userResponse", ptrToStr(userResponse)).
-			Msg("skipping non-accepted event")
-		return nil
 	}
 
 	// Build attendee list
@@ -406,7 +434,7 @@ func (p *CalendarSyncProvider) processEvent(
 		StartTime:            startTime,
 		EndTime:              endTime,
 		AllDay:               false,
-		Status:               getEventStatus(event),
+		Status:               status,
 		UserResponse:         userResponse,
 		OrganizerEmail:       getOrganizerEmail(event),
 		Attendees:            attendees,
@@ -420,6 +448,83 @@ func (p *CalendarSyncProvider) processEvent(
 	if err != nil {
 		return fmt.Errorf("upsert calendar event: %w", err)
 	}
+	return nil
+}
+
+// removeDeclinedEvent removes a previously-stored calendar_event (and its
+// derived interactions) when the event is observed declined / tentative /
+// needsAction / user-removed / cancelled upstream. Keyed on the inbound
+// gcal event id (always present on any delta) — reads EndTime +
+// MatchedContactIDs from the STORED row, so it needs neither the inbound
+// Start/End DateTime nor the all-day discriminator.
+//
+// Cutover (eventBus + pool present): in ONE tx, publish a calendar.declined
+// per matched contact (carrying the stored row's INTERNAL ID so the decline
+// consumer's source_ref lookup matches), THEN delete the calendar_event.
+// Publish-before-delete: a publish failure rolls back the whole tx (event
+// rows + delete), and the next sync re-runs the branch cleanly. If the row
+// is already gone the next sync no-ops at GetByGcalID.
+//
+// Off mode (nil eventBus or nil pool): defer cleanup by marking the stored
+// row status='cancelled' rather than deleting. This stops re-firing
+// calendar.attended (ListPastEventsNeedingUpdate requires status='confirmed')
+// and hides the row from contact reads WITHOUT losing the only cleanup
+// handle for an already-recorded interaction — the cutover resume re-observes
+// the row and finishes the cleanup.
+func (p *CalendarSyncProvider) removeDeclinedEvent(ctx context.Context, gcalEventID, accountID string) error {
+	stored, err := p.calendarRepo.GetByGcalID(ctx, gcalEventID, "primary", accountID)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			// Never accepted/stored (the common case — the user has declined
+			// many invites that were never in the CRM). Do NOT emit a decline.
+			return nil
+		}
+		return fmt.Errorf("look up stored calendar event for decline: %w", err)
+	}
+
+	// Off mode: defer cleanup by marking cancelled (neither publish nor delete).
+	if p.eventBus == nil || p.pool == nil {
+		if err := p.calendarRepo.MarkCancelledByGcalID(ctx, gcalEventID, "primary", accountID); err != nil {
+			return fmt.Errorf("mark calendar event cancelled (off mode): %w", err)
+		}
+		logger.Debug().
+			Str("eventId", gcalEventID).
+			Msg("calendar: decline observed in off mode; marked stored event cancelled (deferred cleanup)")
+		return nil
+	}
+
+	// Cutover: publish-before-delete in one tx.
+	tx, err := p.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin decline tx: %w", err)
+	}
+	defer func() {
+		if rollbackErr := tx.Rollback(ctx); rollbackErr != nil &&
+			!errors.Is(rollbackErr, pgx.ErrTxClosed) {
+			logger.Warn().Err(rollbackErr).Str("eventId", gcalEventID).Msg("calendar: decline tx rollback failed")
+		}
+	}()
+
+	eventIDStr := stored.ID.String()
+	for _, contactID := range stored.MatchedContactIDs {
+		if pubErr := publishCalendarDeclinedTx(ctx, p.eventBus, tx, contactID, eventIDStr, stored.EndTime); pubErr != nil {
+			return fmt.Errorf("publish calendar.declined for contact %s: %w", contactID, pubErr)
+		}
+	}
+
+	if err := p.calendarRepo.DeleteByGcalIDTx(ctx, tx, gcalEventID, "primary", accountID); err != nil {
+		return fmt.Errorf("delete declined calendar event: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit decline tx: %w", err)
+	}
+
+	logger.Info().
+		Str("eventId", gcalEventID).
+		Str("internalId", eventIDStr).
+		Int("contacts", len(stored.MatchedContactIDs)).
+		Msg("calendar: removed declined/cancelled event + published decline per matched contact")
 	return nil
 }
 

--- a/backend/internal/google/calendar.go
+++ b/backend/internal/google/calendar.go
@@ -128,7 +128,7 @@ type CalendarSyncProvider struct {
 	pool *pgxpool.Pool
 	// declineBus is the bus used by the cutover decline remove branch's
 	// per-contact PublishTx. It defaults to eventBus; tests substitute a
-	// failing stub via setDeclineBusForTest to assert publish-before-delete
+	// failing stub via SetDeclineBusForTest to assert publish-before-delete
 	// (a publish failure must leave the calendar_event row intact). The
 	// off-mode gate keys off the concrete eventBus/pool fields, not this one.
 	declineBus busTx

--- a/backend/internal/google/calendar_decline_test.go
+++ b/backend/internal/google/calendar_decline_test.go
@@ -17,7 +17,7 @@ import (
 // mock-backed newTestProvider* factories leave eventBus + pool nil). The
 // cutover publish-before-delete + coexistence path is DB-backed and runs in
 // the CI integration suite, so it lives in
-// backend/tests/calendar_decline_removal_integration_test.go (driven through
+// backend/tests/calendar_decline_cutover_integration_test.go (driven through
 // RunProcessEventForTest with a real bus + pool).
 
 // TestProcessEvent_DeclinedEvent_OffMode_MarksCancelled asserts that a
@@ -79,10 +79,10 @@ func TestProcessEvent_DeclinedEvent_NeverStored_NoOp(t *testing.T) {
 }
 
 // TestProcessEvent_CancelledWithoutDateTime_ReachesRemoveBranch proves the
-// gate-before-parse fix (Decision 1): a cancelled delta arriving WITHOUT
-// Start/End DateTime still reaches the remove branch instead of erroring at
-// the time parse. The organizer is the user (synthesized "accepted"), so it
-// is the status='cancelled' clause that drives keep=false.
+// gate-before-parse fix: a cancelled delta arriving WITHOUT Start/End DateTime
+// still reaches the remove branch instead of erroring at the time parse. The
+// organizer is the user (synthesized "accepted"), so it is the
+// status='cancelled' clause that drives keep=false.
 func TestProcessEvent_CancelledWithoutDateTime_ReachesRemoveBranch(t *testing.T) {
 	ctx := context.Background()
 	storedID := uuid.New()

--- a/backend/internal/google/calendar_decline_test.go
+++ b/backend/internal/google/calendar_decline_test.go
@@ -1,0 +1,143 @@
+package google
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/calendar/v3"
+)
+
+// These mock-based tests exercise the OFF-mode remove branch (the
+// mock-backed newTestProvider* factories leave eventBus + pool nil). The
+// cutover publish+delete+coexistence path is covered by the DB-backed
+// tests in calendar_decline_cutover_test.go and backend/tests/.
+
+// TestProcessEvent_DeclinedEvent_OffMode_MarksCancelled asserts that a
+// declined event with a previously-stored row marks the row cancelled
+// (off-mode deferral) rather than publishing or deleting.
+func TestProcessEvent_DeclinedEvent_OffMode_MarksCancelled(t *testing.T) {
+	ctx := context.Background()
+	storedID := uuid.New()
+	mockCalRepo := &mockCalendarRepo{
+		getByGcalIDResult: &repository.CalendarEvent{
+			ID:                storedID,
+			GcalEventID:       "evt-declined",
+			MatchedContactIDs: []uuid.UUID{uuid.New()},
+			EndTime:           time.Date(2026, 4, 1, 11, 0, 0, 0, time.UTC),
+		},
+	}
+	provider := newTestProvider(mockCalRepo, &mockContactRepo{}, &mockIdentityService{})
+
+	event := &calendar.Event{
+		Id:     "evt-declined",
+		Status: "confirmed",
+		Start:  &calendar.EventDateTime{DateTime: "2026-04-01T10:00:00Z"},
+		End:    &calendar.EventDateTime{DateTime: "2026-04-01T11:00:00Z"},
+		Attendees: []*calendar.EventAttendee{
+			{Email: "user@example.com", Self: true, ResponseStatus: "declined"},
+		},
+	}
+
+	require.NoError(t, provider.processEvent(ctx, event, "user@example.com"))
+	require.True(t, mockCalRepo.getByGcalIDCalled, "remove branch looks up the stored row")
+	require.True(t, mockCalRepo.markCancelledCalled, "off mode marks the stored row cancelled")
+	require.False(t, mockCalRepo.deleteByGcalIDCalled, "off mode does not delete")
+	require.False(t, mockCalRepo.upsertCalled, "declined event is not upserted")
+}
+
+// TestProcessEvent_DeclinedEvent_NeverStored_NoOp asserts that a declined
+// event with no stored row is a clean no-op: no mark-cancelled, no delete,
+// no upsert. We must NOT emit a decline for events never in the CRM.
+func TestProcessEvent_DeclinedEvent_NeverStored_NoOp(t *testing.T) {
+	ctx := context.Background()
+	mockCalRepo := &mockCalendarRepo{getByGcalIDError: db.ErrNotFound}
+	provider := newTestProvider(mockCalRepo, &mockContactRepo{}, &mockIdentityService{})
+
+	event := &calendar.Event{
+		Id:     "evt-never-stored",
+		Status: "confirmed",
+		Start:  &calendar.EventDateTime{DateTime: "2026-04-01T10:00:00Z"},
+		End:    &calendar.EventDateTime{DateTime: "2026-04-01T11:00:00Z"},
+		Attendees: []*calendar.EventAttendee{
+			{Email: "user@example.com", Self: true, ResponseStatus: "declined"},
+		},
+	}
+
+	require.NoError(t, provider.processEvent(ctx, event, "user@example.com"))
+	require.True(t, mockCalRepo.getByGcalIDCalled)
+	require.False(t, mockCalRepo.markCancelledCalled, "no-op when the event was never stored")
+	require.False(t, mockCalRepo.deleteByGcalIDCalled)
+	require.False(t, mockCalRepo.upsertCalled)
+}
+
+// TestProcessEvent_CancelledWithoutDateTime_ReachesRemoveBranch proves the
+// gate-before-parse fix (Decision 1): a cancelled delta arriving WITHOUT
+// Start/End DateTime still reaches the remove branch instead of erroring at
+// the time parse. The organizer is the user (synthesized "accepted"), so it
+// is the status='cancelled' clause that drives keep=false.
+func TestProcessEvent_CancelledWithoutDateTime_ReachesRemoveBranch(t *testing.T) {
+	ctx := context.Background()
+	storedID := uuid.New()
+	mockCalRepo := &mockCalendarRepo{
+		getByGcalIDResult: &repository.CalendarEvent{
+			ID:                storedID,
+			GcalEventID:       "evt-cancelled",
+			MatchedContactIDs: []uuid.UUID{uuid.New()},
+			EndTime:           time.Date(2026, 4, 1, 11, 0, 0, 0, time.UTC),
+		},
+	}
+	provider := newTestProvider(mockCalRepo, &mockContactRepo{}, &mockIdentityService{})
+
+	// Cancelled stub: no Start/End DateTime (Google sends a minimal cancelled
+	// delta). User is the organizer → getUserResponse synthesizes "accepted",
+	// so keep=false comes from status="cancelled".
+	event := &calendar.Event{
+		Id:        "evt-cancelled",
+		Status:    "cancelled",
+		Start:     &calendar.EventDateTime{},
+		End:       &calendar.EventDateTime{},
+		Organizer: &calendar.EventOrganizer{Email: "user@example.com"},
+	}
+
+	require.NoError(t, provider.processEvent(ctx, event, "user@example.com"),
+		"remove branch must run without parsed Start/End DateTime")
+	require.True(t, mockCalRepo.getByGcalIDCalled, "remove branch reached despite missing DateTime")
+	require.True(t, mockCalRepo.markCancelledCalled, "off mode marks the stored row cancelled")
+	require.False(t, mockCalRepo.upsertCalled)
+}
+
+// TestProcessEvent_TentativeEvent_OffMode_MarksCancelled asserts the gate
+// also fires for tentative (non-accepted) responses, exercising the
+// userResponse != "accepted" clause.
+func TestProcessEvent_TentativeEvent_OffMode_MarksCancelled(t *testing.T) {
+	ctx := context.Background()
+	mockCalRepo := &mockCalendarRepo{
+		getByGcalIDResult: &repository.CalendarEvent{
+			ID:                uuid.New(),
+			GcalEventID:       "evt-tentative",
+			MatchedContactIDs: []uuid.UUID{uuid.New()},
+			EndTime:           time.Date(2026, 4, 1, 11, 0, 0, 0, time.UTC),
+		},
+	}
+	provider := newTestProvider(mockCalRepo, &mockContactRepo{}, &mockIdentityService{})
+
+	event := &calendar.Event{
+		Id:     "evt-tentative",
+		Status: "confirmed",
+		Start:  &calendar.EventDateTime{DateTime: "2026-04-01T10:00:00Z"},
+		End:    &calendar.EventDateTime{DateTime: "2026-04-01T11:00:00Z"},
+		Attendees: []*calendar.EventAttendee{
+			{Email: "user@example.com", Self: true, ResponseStatus: "tentative"},
+		},
+	}
+
+	require.NoError(t, provider.processEvent(ctx, event, "user@example.com"))
+	require.True(t, mockCalRepo.markCancelledCalled)
+	require.False(t, mockCalRepo.upsertCalled)
+}

--- a/backend/internal/google/calendar_decline_test.go
+++ b/backend/internal/google/calendar_decline_test.go
@@ -15,8 +15,10 @@ import (
 
 // These mock-based tests exercise the OFF-mode remove branch (the
 // mock-backed newTestProvider* factories leave eventBus + pool nil). The
-// cutover publish+delete+coexistence path is covered by the DB-backed
-// tests in calendar_decline_cutover_test.go and backend/tests/.
+// cutover publish-before-delete + coexistence path is DB-backed and runs in
+// the CI integration suite, so it lives in
+// backend/tests/calendar_decline_removal_integration_test.go (driven through
+// RunProcessEventForTest with a real bus + pool).
 
 // TestProcessEvent_DeclinedEvent_OffMode_MarksCancelled asserts that a
 // declined event with a previously-stored row marks the row cancelled

--- a/backend/internal/google/calendar_mocks_test.go
+++ b/backend/internal/google/calendar_mocks_test.go
@@ -8,6 +8,7 @@ import (
 	"personal-crm/backend/internal/service"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 )
 
 // mockCalendarRepo is a mock implementation of calendarRepoInterface
@@ -24,6 +25,17 @@ type mockCalendarRepo struct {
 	markUpdatedCalled bool
 	markUpdatedIDs    []uuid.UUID
 	markUpdatedError  error
+
+	// Decline/cancel remove branch.
+	getByGcalIDResult *repository.CalendarEvent
+	getByGcalIDError  error
+	getByGcalIDCalled bool
+
+	deleteByGcalIDCalled bool
+	deleteByGcalIDError  error
+
+	markCancelledCalled bool
+	markCancelledError  error
 }
 
 func (m *mockCalendarRepo) Upsert(ctx context.Context, req repository.UpsertCalendarEventRequest) (*repository.CalendarEvent, error) {
@@ -60,6 +72,24 @@ func (m *mockCalendarRepo) MarkLastContactedUpdated(ctx context.Context, id uuid
 	m.markUpdatedCalled = true
 	m.markUpdatedIDs = append(m.markUpdatedIDs, id)
 	return m.markUpdatedError
+}
+
+func (m *mockCalendarRepo) GetByGcalID(ctx context.Context, gcalEventID, gcalCalendarID, googleAccountID string) (*repository.CalendarEvent, error) {
+	m.getByGcalIDCalled = true
+	if m.getByGcalIDError != nil {
+		return nil, m.getByGcalIDError
+	}
+	return m.getByGcalIDResult, nil
+}
+
+func (m *mockCalendarRepo) DeleteByGcalIDTx(ctx context.Context, tx pgx.Tx, gcalEventID, gcalCalendarID, googleAccountID string) error {
+	m.deleteByGcalIDCalled = true
+	return m.deleteByGcalIDError
+}
+
+func (m *mockCalendarRepo) MarkCancelledByGcalID(ctx context.Context, gcalEventID, gcalCalendarID, googleAccountID string) error {
+	m.markCancelledCalled = true
+	return m.markCancelledError
 }
 
 // mockContactRepo is a mock implementation of contactRepoInterface

--- a/backend/internal/google/calendar_publish.go
+++ b/backend/internal/google/calendar_publish.go
@@ -9,6 +9,7 @@ import (
 	"personal-crm/backend/internal/repository"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 )
 
 // calendarEventPublisher is the subset of *events.Bus used by
@@ -16,6 +17,14 @@ import (
 // real bus or river client.
 type calendarEventPublisher interface {
 	Publish(ctx context.Context, env *events.Envelope) error
+}
+
+// busTx is the subset of *events.Bus used by publishCalendarDeclinedTx.
+// The decline remove branch needs N publishes + one DELETE in a single
+// atomic tx, so it publishes via PublishTx on the caller's tx rather than
+// Publish (which opens its own tx).
+type busTx interface {
+	PublishTx(ctx context.Context, tx pgx.Tx, env *events.Envelope) error
 }
 
 // publishCalendarAttended emits a calendar.attended event for a past
@@ -58,4 +67,53 @@ func publishCalendarAttended(
 		ObservedAt: occurredAt,
 	}
 	return bus.Publish(ctx, env)
+}
+
+// publishCalendarDeclinedTx emits a calendar.declined event for a
+// previously-stored calendar event that was declined / cancelled /
+// user-removed upstream, for a specific matched contact. Published on the
+// caller's tx (via PublishTx) so the N per-contact publishes + the
+// calendar_event DELETE commit atomically (publish-before-delete; see the
+// remove branch in CalendarSyncProvider.processEvent).
+//
+// eventIDStr is the INTERNAL calendar_event.ID UUID string (passed
+// stored.ID.String() by the remove branch), so the payload's EventID matches
+// the attended interaction's source_ref for source='gcal' — the decline
+// consumer's FindBySourceRefTx(contactID, "gcal", eventIDStr) finds the right
+// interaction.
+//
+// SourceID carries a "declined:" prefix so the event-log (source, source_id)
+// unique index does NOT collide with the calendar.attended row
+// ("<internal-uuid>:<contactID>"). Without the prefix, PublishTx would see
+// the attended row as a duplicate, return nil WITHOUT enqueuing the decline
+// handler, and the remove branch would delete the calendar_event — stranding
+// the false interaction with no consumer to clean it up. The "declined:"
+// namespace keeps both event rows + both consumers alive, while a second
+// decline for the same (event, contact) still dedups against the first.
+func publishCalendarDeclinedTx(
+	ctx context.Context,
+	bus busTx,
+	tx pgx.Tx,
+	contactID uuid.UUID,
+	eventIDStr string,
+	occurredAt time.Time,
+) error {
+	payload := events.CalendarDeclinedPayload{
+		Version:    1,
+		ContactID:  contactID,
+		EventID:    eventIDStr,
+		OccurredAt: occurredAt,
+	}
+	raw, err := events.Marshal(events.KindCalendarDeclined, payload)
+	if err != nil {
+		return fmt.Errorf("marshal calendar.declined: %w", err)
+	}
+	env := &events.Envelope{
+		Source:     repository.InteractionSourceGCal,
+		SourceID:   "declined:" + eventIDStr + ":" + contactID.String(),
+		Kind:       events.KindCalendarDeclined,
+		Payload:    raw,
+		ObservedAt: occurredAt,
+	}
+	return bus.PublishTx(ctx, tx, env)
 }

--- a/backend/internal/google/calendar_publish_test.go
+++ b/backend/internal/google/calendar_publish_test.go
@@ -10,6 +10,7 @@ import (
 	"personal-crm/backend/internal/repository"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/require"
 )
 
@@ -121,4 +122,66 @@ func TestPublishCalendarAttended_NilTitleOmittedFromJSON(t *testing.T) {
 	env := bus.calls[0]
 	require.NotContains(t, string(env.Payload), `"title"`,
 		"omitempty should elide nil title from payload JSON")
+}
+
+// capturingBusTx records every envelope passed to PublishTx. Used to assert
+// the calendar.declined envelope shape without running a full *events.Bus.
+// The tx is never dereferenced (the stub ignores it).
+type capturingBusTx struct {
+	calls []*events.Envelope
+}
+
+func (b *capturingBusTx) PublishTx(_ context.Context, _ pgx.Tx, env *events.Envelope) error {
+	b.calls = append(b.calls, env)
+	return nil
+}
+
+// TestPublishCalendarDeclinedTx_EnvelopeFields asserts the calendar.declined
+// envelope shape: Source=gcal, Kind=calendar.declined, ObservedAt=occurredAt,
+// payload EventID = the internal UUID. Critically, it asserts the SourceID
+// carries the "declined:" prefix (the P0-collision regression guard at the
+// publisher level — see publishCalendarDeclinedTx).
+func TestPublishCalendarDeclinedTx_EnvelopeFields(t *testing.T) {
+	bus := &capturingBusTx{}
+	internalUUID := uuid.NewString()
+	contact := uuid.New()
+	occurredAt := time.Date(2026, 4, 10, 15, 30, 0, 0, time.UTC)
+
+	require.NoError(t, publishCalendarDeclinedTx(context.Background(), bus, nil, contact, internalUUID, occurredAt))
+	require.Len(t, bus.calls, 1)
+
+	env := bus.calls[0]
+	require.Equal(t, repository.InteractionSourceGCal, env.Source)
+	require.Equal(t, events.KindCalendarDeclined, env.Kind)
+	require.True(t, occurredAt.Equal(env.ObservedAt))
+
+	// The declined: prefix keeps the decline event-log row disjoint from the
+	// attended row ("<internalUUID>:<contactID>"), so both consumers fire.
+	require.Equal(t, "declined:"+internalUUID+":"+contact.String(), env.SourceID)
+	require.True(t, strings.HasPrefix(env.SourceID, "declined:"),
+		"decline SourceID must carry the declined: prefix to avoid the attended-row collision")
+
+	var payload events.CalendarDeclinedPayload
+	require.NoError(t, events.Unmarshal(env, &payload))
+	require.Equal(t, contact, payload.ContactID)
+	require.Equal(t, internalUUID, payload.EventID,
+		"payload EventID must be the internal calendar_event.ID so the consumer's source_ref lookup matches")
+}
+
+// TestPublishCalendarDeclinedTx_SourceIDPerContact asserts two declines for
+// the same event but different contacts produce distinct (declined-prefixed)
+// SourceIDs, so each per-contact decline event row survives ingest.
+func TestPublishCalendarDeclinedTx_SourceIDPerContact(t *testing.T) {
+	bus := &capturingBusTx{}
+	internalUUID := uuid.NewString()
+	contactA := uuid.New()
+	contactB := uuid.New()
+	occurredAt := time.Date(2026, 4, 10, 15, 0, 0, 0, time.UTC)
+
+	require.NoError(t, publishCalendarDeclinedTx(context.Background(), bus, nil, contactA, internalUUID, occurredAt))
+	require.NoError(t, publishCalendarDeclinedTx(context.Background(), bus, nil, contactB, internalUUID, occurredAt))
+	require.Len(t, bus.calls, 2)
+	require.NotEqual(t, bus.calls[0].SourceID, bus.calls[1].SourceID)
+	require.Equal(t, "declined:"+internalUUID+":"+contactA.String(), bus.calls[0].SourceID)
+	require.Equal(t, "declined:"+internalUUID+":"+contactB.String(), bus.calls[1].SourceID)
 }

--- a/backend/internal/google/calendar_test.go
+++ b/backend/internal/google/calendar_test.go
@@ -275,8 +275,10 @@ func TestProcessEvent_SkipsAllDayEvents(t *testing.T) {
 	assert.True(t, isAllDay, "Event with Start.Date should be identified as all-day")
 }
 
-// TestProcessEvent_SkipsDeclinedEvents verifies that declined events are skipped
-func TestProcessEvent_SkipsDeclinedEvents(t *testing.T) {
+// TestGetUserResponse_DeclinedAttendee verifies getUserResponse reports a
+// declined self-attendee. The remove-branch behavior for declined events is
+// covered in calendar_decline_test.go.
+func TestGetUserResponse_DeclinedAttendee(t *testing.T) {
 	provider := NewCalendarSyncProvider(nil, nil, nil, nil, nil, nil, nil)
 	accountID := "user@example.com"
 

--- a/backend/internal/google/calendar_test.go
+++ b/backend/internal/google/calendar_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestCalendarSyncProvider_Config(t *testing.T) {
-	provider := NewCalendarSyncProvider(nil, nil, nil, nil, nil, nil)
+	provider := NewCalendarSyncProvider(nil, nil, nil, nil, nil, nil, nil)
 	config := provider.Config()
 
 	assert.Equal(t, CalendarSourceName, config.Name)
@@ -132,7 +132,7 @@ func TestStrPtrIfNotEmpty(t *testing.T) {
 }
 
 func TestCalendarSyncProvider_GetUserResponse(t *testing.T) {
-	provider := NewCalendarSyncProvider(nil, nil, nil, nil, nil, nil)
+	provider := NewCalendarSyncProvider(nil, nil, nil, nil, nil, nil, nil)
 	accountID := "user@example.com"
 
 	tests := []struct {
@@ -202,7 +202,7 @@ func TestCalendarSyncProvider_GetUserResponse(t *testing.T) {
 }
 
 func TestCalendarSyncProvider_BuildAttendeeList(t *testing.T) {
-	provider := NewCalendarSyncProvider(nil, nil, nil, nil, nil, nil)
+	provider := NewCalendarSyncProvider(nil, nil, nil, nil, nil, nil, nil)
 	accountID := "user@example.com"
 
 	event := &calendar.Event{
@@ -277,7 +277,7 @@ func TestProcessEvent_SkipsAllDayEvents(t *testing.T) {
 
 // TestProcessEvent_SkipsDeclinedEvents verifies that declined events are skipped
 func TestProcessEvent_SkipsDeclinedEvents(t *testing.T) {
-	provider := NewCalendarSyncProvider(nil, nil, nil, nil, nil, nil)
+	provider := NewCalendarSyncProvider(nil, nil, nil, nil, nil, nil, nil)
 	accountID := "user@example.com"
 
 	event := &calendar.Event{
@@ -346,7 +346,7 @@ func TestMatchAttendees_SkipsEmptyEmails(t *testing.T) {
 
 // TestBuildAttendeeList_EmptyAttendees verifies behavior with no attendees but an organizer
 func TestBuildAttendeeList_EmptyAttendees(t *testing.T) {
-	provider := NewCalendarSyncProvider(nil, nil, nil, nil, nil, nil)
+	provider := NewCalendarSyncProvider(nil, nil, nil, nil, nil, nil, nil)
 	accountID := "user@example.com"
 
 	event := &calendar.Event{
@@ -388,7 +388,7 @@ func TestEventStatusMapping(t *testing.T) {
 
 // TestUserResponse_MultipleAttendees verifies correct user identification among many attendees
 func TestUserResponse_MultipleAttendees(t *testing.T) {
-	provider := NewCalendarSyncProvider(nil, nil, nil, nil, nil, nil)
+	provider := NewCalendarSyncProvider(nil, nil, nil, nil, nil, nil, nil)
 
 	tests := []struct {
 		name      string
@@ -442,7 +442,7 @@ func TestUserResponse_MultipleAttendees(t *testing.T) {
 
 // TestBuildAttendeeList_OrganizerIdentification verifies organizer is correctly flagged
 func TestBuildAttendeeList_OrganizerIdentification(t *testing.T) {
-	provider := NewCalendarSyncProvider(nil, nil, nil, nil, nil, nil)
+	provider := NewCalendarSyncProvider(nil, nil, nil, nil, nil, nil, nil)
 	accountID := "user@example.com"
 
 	event := &calendar.Event{
@@ -483,7 +483,7 @@ func TestBuildAttendeeList_OrganizerIdentification(t *testing.T) {
 // TestBuildAttendeeList_OrganizerNotInAttendees verifies organizer is added when not in attendees list
 // This is the fix for issue #183 - organizers who aren't also attendees should still be matched
 func TestBuildAttendeeList_OrganizerNotInAttendees(t *testing.T) {
-	provider := NewCalendarSyncProvider(nil, nil, nil, nil, nil, nil)
+	provider := NewCalendarSyncProvider(nil, nil, nil, nil, nil, nil, nil)
 	accountID := "user@example.com"
 
 	// Event where the organizer (Bob) is NOT in the attendees list.
@@ -525,7 +525,7 @@ func TestBuildAttendeeList_OrganizerNotInAttendees(t *testing.T) {
 
 // TestBuildAttendeeList_OrganizerAlreadyInAttendees verifies organizer is not duplicated
 func TestBuildAttendeeList_OrganizerAlreadyInAttendees(t *testing.T) {
-	provider := NewCalendarSyncProvider(nil, nil, nil, nil, nil, nil)
+	provider := NewCalendarSyncProvider(nil, nil, nil, nil, nil, nil, nil)
 	accountID := "user@example.com"
 
 	// Event where organizer IS in the attendees list
@@ -565,7 +565,7 @@ func TestBuildAttendeeList_OrganizerAlreadyInAttendees(t *testing.T) {
 
 // TestBuildAttendeeList_OrganizerIsSelf verifies organizer is not added when they are self
 func TestBuildAttendeeList_OrganizerIsSelf(t *testing.T) {
-	provider := NewCalendarSyncProvider(nil, nil, nil, nil, nil, nil)
+	provider := NewCalendarSyncProvider(nil, nil, nil, nil, nil, nil, nil)
 	accountID := "user@example.com"
 
 	// User is the organizer but not in attendees list
@@ -592,7 +592,7 @@ func TestBuildAttendeeList_OrganizerIsSelf(t *testing.T) {
 
 // TestBuildAttendeeList_OrganizerEmailCaseInsensitive verifies case-insensitive duplicate detection
 func TestBuildAttendeeList_OrganizerEmailCaseInsensitive(t *testing.T) {
-	provider := NewCalendarSyncProvider(nil, nil, nil, nil, nil, nil)
+	provider := NewCalendarSyncProvider(nil, nil, nil, nil, nil, nil, nil)
 	accountID := "user@example.com"
 
 	// Organizer email has different case than in attendees list
@@ -618,7 +618,7 @@ func TestBuildAttendeeList_OrganizerEmailCaseInsensitive(t *testing.T) {
 
 // TestBuildAttendeeList_NoOrganizer verifies behavior when organizer is nil
 func TestBuildAttendeeList_NoOrganizer(t *testing.T) {
-	provider := NewCalendarSyncProvider(nil, nil, nil, nil, nil, nil)
+	provider := NewCalendarSyncProvider(nil, nil, nil, nil, nil, nil, nil)
 	accountID := "user@example.com"
 
 	event := &calendar.Event{
@@ -641,7 +641,7 @@ func TestBuildAttendeeList_NoOrganizer(t *testing.T) {
 
 // TestBuildAttendeeList_OrganizerEmptyEmail verifies behavior when organizer has empty email
 func TestBuildAttendeeList_OrganizerEmptyEmail(t *testing.T) {
-	provider := NewCalendarSyncProvider(nil, nil, nil, nil, nil, nil)
+	provider := NewCalendarSyncProvider(nil, nil, nil, nil, nil, nil, nil)
 	accountID := "user@example.com"
 
 	event := &calendar.Event{
@@ -668,7 +668,7 @@ func TestBuildAttendeeList_OrganizerEmptyEmail(t *testing.T) {
 // TestBuildAttendeeList_OrganizerSelfFlag verifies organizer is not added when Organizer.Self is true
 // even if organizer email differs from accountID (handles aliases and delegated calendars)
 func TestBuildAttendeeList_OrganizerSelfFlag(t *testing.T) {
-	provider := NewCalendarSyncProvider(nil, nil, nil, nil, nil, nil)
+	provider := NewCalendarSyncProvider(nil, nil, nil, nil, nil, nil, nil)
 	accountID := "user@example.com"
 
 	// Organizer uses an alias email but Self flag is true
@@ -1848,7 +1848,7 @@ func TestStoreUnmatchedAttendee_PreservesExistingDisplayName(t *testing.T) {
 
 // TestProcessEvent_OnlyAcceptsAcceptedEvents verifies that only accepted events are processed
 func TestProcessEvent_OnlyAcceptsAcceptedEvents(t *testing.T) {
-	provider := NewCalendarSyncProvider(nil, nil, nil, nil, nil, nil)
+	provider := NewCalendarSyncProvider(nil, nil, nil, nil, nil, nil, nil)
 	accountID := "user@example.com"
 
 	tests := []struct {
@@ -1894,7 +1894,7 @@ func TestProcessEvent_OnlyAcceptsAcceptedEvents(t *testing.T) {
 
 // TestProcessEvent_SkipsEventsWhereUserNotAttendee verifies events without user are skipped
 func TestProcessEvent_SkipsEventsWhereUserNotAttendee(t *testing.T) {
-	provider := NewCalendarSyncProvider(nil, nil, nil, nil, nil, nil)
+	provider := NewCalendarSyncProvider(nil, nil, nil, nil, nil, nil, nil)
 	accountID := "user@example.com"
 
 	event := &calendar.Event{

--- a/backend/internal/repository/calendar.go
+++ b/backend/internal/repository/calendar.go
@@ -454,6 +454,24 @@ func (r *CalendarEventRepository) GetByIDForShareTx(ctx context.Context, tx pgx.
 	return &event, nil
 }
 
+// TestGetByIDForUpdateNoWaitTx is a TEST-ONLY probe: it reads a
+// calendar_event with FOR UPDATE NOWAIT inside the caller's tx, returning a
+// lock-conflict error immediately (without blocking) when another tx holds
+// a conflicting lock on the row (e.g. the attended branch's FOR SHARE). Used
+// by the Decision-3a lock-serialization integration test. Production code
+// must NOT call this. Returns db.ErrNotFound when no row.
+func (r *CalendarEventRepository) TestGetByIDForUpdateNoWaitTx(ctx context.Context, tx pgx.Tx, id uuid.UUID) (*CalendarEvent, error) {
+	dbEvent, err := db.New(tx).TestGetCalendarEventByIDForUpdateNoWait(ctx, uuidToPgUUID(id))
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, db.ErrNotFound
+		}
+		return nil, err
+	}
+	event := convertDbCalendarEvent(dbEvent)
+	return &event, nil
+}
+
 // LockExistsByIDTx reports whether a calendar_event with the given UUID
 // exists, taking a FOR SHARE lock on it inside the caller's tx. Thin
 // adapter over GetByIDForShareTx that satisfies the InteractionRecorder's

--- a/backend/internal/repository/calendar.go
+++ b/backend/internal/repository/calendar.go
@@ -398,6 +398,80 @@ func (r *CalendarEventRepository) DeleteEventsByAccount(ctx context.Context, goo
 	return r.queries.DeleteEventsByAccount(ctx, googleAccountID)
 }
 
+// DeleteByGcalID hard-deletes the stored calendar_event row keyed by its
+// Google identity triple. Non-tx variant for completeness / future callers;
+// the decline remove branch uses DeleteByGcalIDTx. calendar_event has no
+// deleted_at column — removal is a hard DELETE.
+func (r *CalendarEventRepository) DeleteByGcalID(ctx context.Context, gcalEventID, gcalCalendarID, googleAccountID string) error {
+	return r.queries.DeleteCalendarEventByGcalID(ctx, db.DeleteCalendarEventByGcalIDParams{
+		GcalEventID:     gcalEventID,
+		GcalCalendarID:  gcalCalendarID,
+		GoogleAccountID: googleAccountID,
+	})
+}
+
+// DeleteByGcalIDTx is the tx-bound variant of DeleteByGcalID. Used by the
+// cutover decline remove branch so the delete commits atomically with the
+// calendar.declined publishes (publish-before-delete in one tx).
+func (r *CalendarEventRepository) DeleteByGcalIDTx(ctx context.Context, tx pgx.Tx, gcalEventID, gcalCalendarID, googleAccountID string) error {
+	return db.New(tx).DeleteCalendarEventByGcalID(ctx, db.DeleteCalendarEventByGcalIDParams{
+		GcalEventID:     gcalEventID,
+		GcalCalendarID:  gcalCalendarID,
+		GoogleAccountID: googleAccountID,
+	})
+}
+
+// MarkCancelledByGcalID marks the stored event cancelled (keyed by its
+// Google identity triple) instead of deleting it. Used by the off-mode
+// deferral branch of the decline remove path when the event bus is
+// unavailable: status='cancelled' excludes the row from re-firing
+// calendar.attended and from contact-facing reads without losing the row
+// (and any already-recorded interaction's only cleanup handle).
+func (r *CalendarEventRepository) MarkCancelledByGcalID(ctx context.Context, gcalEventID, gcalCalendarID, googleAccountID string) error {
+	return r.queries.MarkCalendarEventCancelledByGcalID(ctx, db.MarkCalendarEventCancelledByGcalIDParams{
+		GcalEventID:     gcalEventID,
+		GcalCalendarID:  gcalCalendarID,
+		GoogleAccountID: googleAccountID,
+	})
+}
+
+// GetByIDForShareTx is a locking read of a calendar_event by UUID inside
+// the caller's tx (SELECT ... FOR SHARE). Used by the InteractionRecorder
+// calendar.attended branch to serialize against a concurrent decline
+// DELETE on the same row: the FOR SHARE lock is held until the attended tx
+// commits, so an interleaving decline DELETE either blocks (attended
+// inserts first) or has already committed (this returns db.ErrNotFound and
+// the attended insert is skipped). Returns db.ErrNotFound when no row.
+func (r *CalendarEventRepository) GetByIDForShareTx(ctx context.Context, tx pgx.Tx, id uuid.UUID) (*CalendarEvent, error) {
+	dbEvent, err := db.New(tx).GetCalendarEventByIDForShare(ctx, uuidToPgUUID(id))
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, db.ErrNotFound
+		}
+		return nil, err
+	}
+	event := convertDbCalendarEvent(dbEvent)
+	return &event, nil
+}
+
+// LockExistsByIDTx reports whether a calendar_event with the given UUID
+// exists, taking a FOR SHARE lock on it inside the caller's tx. Thin
+// adapter over GetByIDForShareTx that satisfies the InteractionRecorder's
+// narrow calendarEventLocker interface (it only needs existence, not the
+// row). Returns (false, nil) for a missing row, (true, nil) when the row
+// is present (lock held until the tx commits), and (false, err) on any
+// other error.
+func (r *CalendarEventRepository) LockExistsByIDTx(ctx context.Context, tx pgx.Tx, id uuid.UUID) (bool, error) {
+	_, err := r.GetByIDForShareTx(ctx, tx, id)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
 // FindLinkageCandidatesTx returns candidate calendar_event rows for the
 // meeting_note.recorded inline handler's linkage-detection algorithm.
 // Filters cancelled events and orders by start_time ASC. Calendar is

--- a/backend/internal/repository/calendar.go
+++ b/backend/internal/repository/calendar.go
@@ -458,8 +458,8 @@ func (r *CalendarEventRepository) GetByIDForShareTx(ctx context.Context, tx pgx.
 // calendar_event with FOR UPDATE NOWAIT inside the caller's tx, returning a
 // lock-conflict error immediately (without blocking) when another tx holds
 // a conflicting lock on the row (e.g. the attended branch's FOR SHARE). Used
-// by the Decision-3a lock-serialization integration test. Production code
-// must NOT call this. Returns db.ErrNotFound when no row.
+// by the attended-vs-decline lock-serialization integration test. Production
+// code must NOT call this. Returns db.ErrNotFound when no row.
 func (r *CalendarEventRepository) TestGetByIDForUpdateNoWaitTx(ctx context.Context, tx pgx.Tx, id uuid.UUID) (*CalendarEvent, error) {
 	dbEvent, err := db.New(tx).TestGetCalendarEventByIDForUpdateNoWait(ctx, uuidToPgUUID(id))
 	if err != nil {

--- a/backend/internal/repository/contact.go
+++ b/backend/internal/repository/contact.go
@@ -849,3 +849,155 @@ func (r *ContactRepository) ListContactsWithContactBy(ctx context.Context, limit
 
 	return contacts, nil
 }
+
+// RecomputeContactDatesAfterDeleteTx surgically rolls back the contact's
+// date columns after a derived interaction at `deletedAt` was soft-deleted.
+// It is the REMOVAL counterpart to CadenceUpdater's additive forward path:
+// a timestamp column is touched ONLY when the removed interaction was its
+// source (column == deletedAt), rolling to MAX(remaining live interactions
+// of its direction subset) or NULL when none remain — preserving creation-
+// set values and still-live later interactions. contact_by is decided in Go
+// via cadence.CalculateContactBy (environment-aware) so it matches the
+// forward writer exactly and never clobbers a Todoist/user override.
+//
+// Orchestration (all on the caller's tx): ComputeContactDatesAfterDelete
+// (reads + FOR UPDATE locks the contact row, recomputes the timestamps) →
+// Go contact_by decision → WriteContactDatesAfterDelete. The FOR UPDATE lock
+// is held across the write so a concurrent cadence/interaction writer on the
+// same contact cannot interleave a stale overwrite.
+//
+// Returns db.ErrNotFound when the contact was soft-deleted between the
+// decline publish and consume (the read filters deleted_at IS NULL); the
+// caller treats that as a benign no-op (the interaction is already
+// soft-deleted; a deleted contact needs no recompute).
+func (r *ContactRepository) RecomputeContactDatesAfterDeleteTx(ctx context.Context, tx pgx.Tx, contactID uuid.UUID, deletedAt time.Time) error {
+	return recomputeContactDatesAfterDelete(ctx, db.New(tx), contactID, deletedAt)
+}
+
+// RecomputeContactDatesAfterDelete is the non-tx variant of
+// RecomputeContactDatesAfterDeleteTx, used for direct testing. The two
+// queries run on the repository's base querier rather than a caller tx.
+func (r *ContactRepository) RecomputeContactDatesAfterDelete(ctx context.Context, contactID uuid.UUID, deletedAt time.Time) error {
+	return recomputeContactDatesAfterDelete(ctx, r.queries, contactID, deletedAt)
+}
+
+// recomputeContactDatesAfterDelete is the shared orchestration body for the
+// tx and non-tx wrappers. Reads the recomputed timestamps + the fields the
+// contact_by decision needs, decides contact_by in Go, then writes.
+func recomputeContactDatesAfterDelete(ctx context.Context, q db.Querier, contactID uuid.UUID, deletedAt time.Time) error {
+	row, err := q.ComputeContactDatesAfterDelete(ctx, db.ComputeContactDatesAfterDeleteParams{
+		ID:          uuidToPgUUID(contactID),
+		DeletedAtTs: pgtype.Timestamptz{Time: deletedAt, Valid: true},
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return db.ErrNotFound
+		}
+		return err
+	}
+
+	newContactBy := decideContactByAfterDelete(row)
+
+	return q.WriteContactDatesAfterDelete(ctx, db.WriteContactDatesAfterDeleteParams{
+		NewLastContacted:     row.NewLastContacted,
+		NewLastInteractionAt: row.NewLastInteractionAt,
+		NewLastResponseAt:    row.NewLastResponseAt,
+		NewLastOutreachAt:    row.NewLastOutreachAt,
+		NewContactBy:         newContactBy,
+		ID:                   uuidToPgUUID(contactID),
+	})
+}
+
+// decideContactByAfterDelete computes the contact_by value to write after a
+// removal, mirroring the forward writer's environment-aware
+// cadence.CalculateContactBy. It NEVER clobbers a Todoist/user override:
+//
+//   - If last_contacted did not move (new == old) or there is no cadence,
+//     contact_by is preserved as-is.
+//   - Else, if the existing contact_by differs from what the cadence would
+//     have produced for old_last_contacted, a Todoist/user override landed
+//     since the interaction; contact_by is preserved.
+//   - Else (override-free), contact_by is re-derived from the new base
+//     (new_last_contacted, or created_at when it rolled to NULL) so the
+//     removed interaction's own contribution is undone exactly.
+func decideContactByAfterDelete(row *db.ComputeContactDatesAfterDeleteRow) pgtype.Date {
+	oldContactBy := row.OldContactBy
+
+	cadenceStr := ""
+	if row.Cadence.Valid {
+		cadenceStr = row.Cadence.String
+	}
+	if cadenceStr == "" {
+		return oldContactBy
+	}
+
+	oldLastContacted := pgTimestamptzToTimePtr(row.OldLastContacted)
+	newLastContacted := pgTimestamptzToTimePtr(row.NewLastContacted)
+
+	// last_contacted did not move → contact_by is not implicated; preserve.
+	if !lastContactedMoved(oldLastContacted, newLastContacted) {
+		return oldContactBy
+	}
+
+	cadenceType, err := cadence.ParseCadence(cadenceStr)
+	if err != nil {
+		return oldContactBy
+	}
+
+	// Override guard: if the stored contact_by differs from what the cadence
+	// would have produced for the old last_contacted, a Todoist/user override
+	// landed since the interaction; preserve it.
+	if oldLastContacted != nil && row.OldContactBy.Valid {
+		expectedOldCb := cadence.CalculateContactBy(*oldLastContacted, cadenceType)
+		if !contactByMatchesStoredDate(row.OldContactBy, expectedOldCb) {
+			return oldContactBy
+		}
+	}
+
+	// Override-free: re-derive contact_by from the new base. When
+	// last_contacted rolled to NULL, fall back to created_at so a cadence
+	// contact is never dropped from due tracking.
+	base := newLastContacted
+	if base == nil {
+		createdAt := pgTimestamptzToTimePtr(row.CreatedAt)
+		base = createdAt
+	}
+	if base == nil {
+		// No base to compute from (should not happen — created_at is NOT
+		// NULL). Preserve rather than write a garbage value.
+		return oldContactBy
+	}
+	newCb := cadence.CalculateContactBy(*base, cadenceType)
+	return pgtype.Date{Time: newCb, Valid: true}
+}
+
+// lastContactedMoved reports whether last_contacted changed between the
+// pre- and post-recompute values (including NULL transitions).
+func lastContactedMoved(old, new *time.Time) bool {
+	if old == nil && new == nil {
+		return false
+	}
+	if old == nil || new == nil {
+		return true
+	}
+	return !old.Equal(*new)
+}
+
+// contactByMatchesStoredDate reports whether the stored contact_by DATE
+// equals the cadence-derived expected value, compared at DATE precision.
+// contact_by is a DATE column, so the stored value is always day-precision
+// regardless of mode; the expected value is reduced to its date via
+// cadence.DateOnly (the same truncation the forward writer applies when it
+// stores contact_by). Comparing the resulting Y/M/D components mirrors the
+// existing contact_by parity tests (TestContactBy_* in backend/tests) and is
+// environment-independent. A mismatch means a Todoist/user override landed
+// since the interaction.
+func contactByMatchesStoredDate(stored pgtype.Date, expected time.Time) bool {
+	if !stored.Valid {
+		return false
+	}
+	sY, sM, sD := stored.Time.Date()
+	expectedDate := cadence.DateOnly(expected)
+	eY, eM, eD := expectedDate.Date()
+	return sY == eY && sM == eM && sD == eD
+}

--- a/backend/internal/repository/contact.go
+++ b/backend/internal/repository/contact.go
@@ -878,8 +878,20 @@ func (r *ContactRepository) RecomputeContactDatesAfterDeleteTx(ctx context.Conte
 }
 
 // RecomputeContactDatesAfterDelete is the non-tx variant of
-// RecomputeContactDatesAfterDeleteTx, used for direct testing. The two
-// queries run on the repository's base querier rather than a caller tx.
+// RecomputeContactDatesAfterDeleteTx, used for direct testing only. Its three
+// statements (LockContactForDateRecompute → ComputeContactDatesAfterDelete →
+// WriteContactDatesAfterDelete) run on the repository's base querier, i.e.
+// each in its own autocommit transaction.
+//
+// CONCURRENCY WARNING: because the statements do NOT share a transaction, the
+// LockContactForDateRecompute FOR UPDATE lock is released the instant that
+// statement commits — it does NOT hold across the aggregate read. This variant
+// therefore lacks the lock-then-aggregate serialization that closes the
+// concurrent-writer race, so it MUST NOT be wired into the production recompute
+// path. Production routes the recompute exclusively through
+// RecomputeContactDatesAfterDeleteTx, which holds the lock across all three
+// statements in the caller's single tx. This variant is safe only for
+// single-threaded direct tests.
 func (r *ContactRepository) RecomputeContactDatesAfterDelete(ctx context.Context, contactID uuid.UUID, deletedAt time.Time) error {
 	return recomputeContactDatesAfterDelete(ctx, r.queries, contactID, deletedAt)
 }

--- a/backend/internal/repository/contact.go
+++ b/backend/internal/repository/contact.go
@@ -860,11 +860,14 @@ func (r *ContactRepository) ListContactsWithContactBy(ctx context.Context, limit
 // via cadence.CalculateContactBy (environment-aware) so it matches the
 // forward writer exactly and never clobbers a Todoist/user override.
 //
-// Orchestration (all on the caller's tx): ComputeContactDatesAfterDelete
-// (reads + FOR UPDATE locks the contact row, recomputes the timestamps) →
-// Go contact_by decision → WriteContactDatesAfterDelete. The FOR UPDATE lock
-// is held across the write so a concurrent cadence/interaction writer on the
-// same contact cannot interleave a stale overwrite.
+// Orchestration (all on the caller's tx): LockContactForDateRecompute
+// (FOR UPDATE on the contact row, as a separate statement) →
+// ComputeContactDatesAfterDelete (interaction aggregate + contact read, now at
+// a snapshot that includes any writer that committed while we waited for the
+// lock) → Go contact_by decision → WriteContactDatesAfterDelete. The lock is
+// held across the write so a concurrent cadence/interaction writer on the same
+// contact cannot interleave a stale overwrite, and the aggregate cannot miss a
+// concurrently-inserted interaction.
 //
 // Returns db.ErrNotFound when the contact was soft-deleted between the
 // decline publish and consume (the read filters deleted_at IS NULL); the
@@ -881,10 +884,52 @@ func (r *ContactRepository) RecomputeContactDatesAfterDelete(ctx context.Context
 	return recomputeContactDatesAfterDelete(ctx, r.queries, contactID, deletedAt)
 }
 
+// LockContactForDateRecomputeTx acquires the contact-row FOR UPDATE lock
+// inside the caller's tx. Exposed so the recompute lock-ordering regression
+// test can hold the lock from a concurrent tx. Returns db.ErrNotFound when
+// the contact is soft-deleted.
+func (r *ContactRepository) LockContactForDateRecomputeTx(ctx context.Context, tx pgx.Tx, contactID uuid.UUID) error {
+	if _, err := db.New(tx).LockContactForDateRecompute(ctx, uuidToPgUUID(contactID)); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return db.ErrNotFound
+		}
+		return err
+	}
+	return nil
+}
+
+// TestLockContactForUpdateNoWaitTx is a TEST-ONLY probe: it reads the contact
+// row with FOR UPDATE NOWAIT inside the caller's tx, returning a lock-conflict
+// error immediately (without blocking) when another tx holds a conflicting
+// lock on the row. Used by the recompute lock-ordering regression test.
+// Production code must NOT call this. Returns db.ErrNotFound when no row.
+func (r *ContactRepository) TestLockContactForUpdateNoWaitTx(ctx context.Context, tx pgx.Tx, contactID uuid.UUID) error {
+	if _, err := db.New(tx).TestLockContactForUpdateNoWait(ctx, uuidToPgUUID(contactID)); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return db.ErrNotFound
+		}
+		return err
+	}
+	return nil
+}
+
 // recomputeContactDatesAfterDelete is the shared orchestration body for the
-// tx and non-tx wrappers. Reads the recomputed timestamps + the fields the
-// contact_by decision needs, decides contact_by in Go, then writes.
+// tx and non-tx wrappers. Locks the contact row, reads the recomputed
+// timestamps + the fields the contact_by decision needs, decides contact_by
+// in Go, then writes.
 func recomputeContactDatesAfterDelete(ctx context.Context, q db.Querier, contactID uuid.UUID, deletedAt time.Time) error {
+	// Acquire the contact-row lock as a SEPARATE statement first: once held
+	// (waiting out any concurrent interaction/cadence writer), the subsequent
+	// ComputeContactDatesAfterDelete runs at a fresh snapshot that includes
+	// that writer's just-committed interaction rows, so the aggregate cannot
+	// miss a concurrently-inserted interaction.
+	if _, err := q.LockContactForDateRecompute(ctx, uuidToPgUUID(contactID)); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return db.ErrNotFound
+		}
+		return err
+	}
+
 	row, err := q.ComputeContactDatesAfterDelete(ctx, db.ComputeContactDatesAfterDeleteParams{
 		ID:          uuidToPgUUID(contactID),
 		DeletedAtTs: pgtype.Timestamptz{Time: deletedAt, Valid: true},

--- a/backend/tests/api/ingest_raw_message_e2e_test.go
+++ b/backend/tests/api/ingest_raw_message_e2e_test.go
@@ -140,7 +140,7 @@ func TestIngestRawMessage_E2E_StagesAggregatesAndCreatesInteraction(t *testing.T
 	stagingRegistry := repository.NewStagingProcessorRegistry(map[string]repository.StagingProcessor{
 		repository.InteractionSourceMessages: repository.NewMessagesStagingProcessor(messagesRepo),
 	})
-	recorder := consumer.NewInteractionRecorder(contactSvc, stagingRegistry, bus, cadenceUpdater, nil)
+	recorder := consumer.NewInteractionRecorder(contactSvc, stagingRegistry, bus, cadenceUpdater, nil, repository.NewCalendarEventRepository(database.Queries))
 	recorderShim.real = consumer.NewInteractionRecorderWorker(bus, database.Pool, recorder, nil)
 
 	// Now wire the ingest service + handler.

--- a/backend/tests/api/manual_handler_helper_test.go
+++ b/backend/tests/api/manual_handler_helper_test.go
@@ -83,7 +83,7 @@ func buildManualHandlerForTest(ctx context.Context, database *db.Database, cfg *
 	stagingRegistry := repository.NewStagingProcessorRegistry(map[string]repository.StagingProcessor{
 		repository.InteractionSourceTelegram: repository.NewTelegramStagingProcessor(telegramMessageRepo),
 	})
-	recorder := consumer.NewInteractionRecorder(contactService, stagingRegistry, bus, cadenceUpdater, nil)
+	recorder := consumer.NewInteractionRecorder(contactService, stagingRegistry, bus, cadenceUpdater, nil, repository.NewCalendarEventRepository(database.Queries))
 	shim.real = consumer.NewInteractionRecorderWorker(bus, database.Pool, recorder, nil)
 
 	manualHandler := service.NewManualInteractionHandler(database.Pool, bus, recorder)

--- a/backend/tests/calendar_decline_cutover_integration_test.go
+++ b/backend/tests/calendar_decline_cutover_integration_test.go
@@ -216,7 +216,9 @@ func TestIntegration_DeclineCutover_RemovesEventAndInteractionThroughProcessEven
 	cad := "weekly"
 	contact := e.newContact(t, &cad)
 	gcalID := "evt-" + uuid.NewString()
-	endTime := accelerated.GetCurrentTime().AddDate(0, 0, -1) // past
+	// Truncate to microseconds so the Go anchor survives the timestamptz
+	// round-trip exactly (Postgres stores microsecond precision).
+	endTime := accelerated.GetCurrentTime().Truncate(time.Microsecond).AddDate(0, 0, -1) // past
 
 	stored := e.seedStoredEvent(t, gcalID, contact.ID, endTime)
 	internalRef := stored.ID.String()
@@ -285,7 +287,7 @@ func TestIntegration_DeclineCutover_PublishFailureLeavesRowIntact(t *testing.T) 
 
 	contact := e.newContact(t, nil)
 	gcalID := "evt-" + uuid.NewString()
-	endTime := accelerated.GetCurrentTime().AddDate(0, 0, -1)
+	endTime := accelerated.GetCurrentTime().Truncate(time.Microsecond).AddDate(0, 0, -1)
 	stored := e.seedStoredEvent(t, gcalID, contact.ID, endTime)
 
 	// Substitute a failing decline bus so the per-contact PublishTx errors

--- a/backend/tests/calendar_decline_cutover_integration_test.go
+++ b/backend/tests/calendar_decline_cutover_integration_test.go
@@ -1,0 +1,338 @@
+// End-to-end coverage for the cutover decline remove branch driven through
+// the REAL CalendarSyncProvider.processEvent (via RunProcessEventForTest)
+// with a real *events.Bus + database.Pool. The in-package google tests only
+// exercise the off-mode branch (nil bus/pool); these prove the cutover path:
+// processEvent gate → removeDeclinedEvent → pool.Begin → publishCalendarDeclinedTx
+// (per matched contact) → DeleteByGcalIDTx → Commit, including:
+//   - the calendar_event row is deleted;
+//   - a declined:-keyed event-log row lands and coexists with the attended row;
+//   - the derived gcal interaction is soft-deleted after the decline job
+//     drains, and the contact's date columns roll;
+//   - publish-before-delete: a failing PublishTx leaves the calendar_event
+//     row intact (the delete is rolled back).
+package tests
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/consumer"
+	"personal-crm/backend/internal/consumer/consumerjobs"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/google"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	calendarapi "google.golang.org/api/calendar/v3"
+)
+
+// declineCutoverEnv bundles a real provider + bus + repos for the cutover
+// remove-branch tests. The river client runs live with the
+// CalendarDeclineHandlerWorker registered so the declined job drains.
+type declineCutoverEnv struct {
+	ctx             context.Context
+	database        *db.Database
+	provider        *google.CalendarSyncProvider
+	bus             *events.Bus
+	contactRepo     *repository.ContactRepository
+	interactionRepo *repository.InteractionRepository
+	calendarRepo    *repository.CalendarEventRepository
+	eventRepo       *repository.EventRepository
+	cadenceUpdater  *consumer.CadenceUpdater
+	accountID       string
+}
+
+func newDeclineCutoverEnv(t *testing.T, ctx context.Context) *declineCutoverEnv {
+	t.Helper()
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+	require.NoError(t, db.RunMigrations(ctx, databaseURL, getMigrationsPath()))
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+	cfg.Database.MigrationsPath = getMigrationsPath()
+	if cfg.River.WorkerConcurrency <= 0 {
+		cfg.River.WorkerConcurrency = 4
+	}
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	t.Cleanup(func() { database.Close() })
+
+	contactRepo := repository.NewContactRepository(database.Queries)
+	contactRepo.SetPool(database.Pool)
+	interactionRepo := repository.NewInteractionRepository(database.Queries)
+	calendarRepo := repository.NewCalendarEventRepository(database.Queries)
+	eventRepo := repository.NewEventRepository(database.Queries)
+	claimRepo := repository.NewEventConsumerClaimRepository(database.Queries)
+	cadenceUpdater := consumer.NewCadenceUpdater(claimRepo, contactRepo, database.Queries, consumer.CadenceModeCutover, false)
+	declineHandler := consumer.NewCalendarDeclineHandler(interactionRepo, contactRepo)
+
+	// Live river client with the real CalendarDeclineHandlerWorker so the
+	// declined job drains after the provider publishes it.
+	workers := river.NewWorkers()
+	declineShim := &deferredDeclineWorker{}
+	river.AddWorker(workers, declineShim)
+	client, err := river.NewClient(riverpgxv5.New(database.Pool), &river.Config{
+		Queues:   map[string]river.QueueConfig{river.QueueDefault: {MaxWorkers: cfg.River.WorkerConcurrency}},
+		Workers:  workers,
+		TestOnly: true,
+	})
+	require.NoError(t, err)
+
+	bus := events.NewBus(database.Pool, client, eventRepo)
+	declineShim.real = consumer.NewCalendarDeclineHandlerWorker(bus, database.Pool, declineHandler)
+	require.NoError(t, client.Start(ctx))
+	t.Cleanup(func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer stopCancel()
+		_ = client.Stop(stopCtx)
+	})
+
+	provider := google.NewCalendarSyncProvider(nil, calendarRepo, contactRepo, nil, nil, bus, database.Pool)
+
+	accountID := "decline-cutover-" + uuid.NewString()
+	t.Cleanup(func() { _ = calendarRepo.DeleteEventsByAccount(ctx, accountID) })
+
+	return &declineCutoverEnv{
+		ctx:             ctx,
+		database:        database,
+		provider:        provider,
+		bus:             bus,
+		contactRepo:     contactRepo,
+		interactionRepo: interactionRepo,
+		calendarRepo:    calendarRepo,
+		eventRepo:       eventRepo,
+		cadenceUpdater:  cadenceUpdater,
+		accountID:       accountID,
+	}
+}
+
+// deferredDeclineWorker registers a CalendarDeclineHandler river worker
+// before the real worker exists (the bus needs the client, the worker needs
+// the bus). Work delegates to the real worker once assigned.
+type deferredDeclineWorker struct {
+	river.WorkerDefaults[consumerjobs.CalendarDeclineHandlerJobArgs]
+	real *consumer.CalendarDeclineHandlerWorker
+}
+
+func (w *deferredDeclineWorker) Work(ctx context.Context, j *river.Job[consumerjobs.CalendarDeclineHandlerJobArgs]) error {
+	if w.real == nil {
+		return errors.New("deferredDeclineWorker invoked before real worker assignment")
+	}
+	return w.real.Work(ctx, j)
+}
+
+func (w *deferredDeclineWorker) Timeout(j *river.Job[consumerjobs.CalendarDeclineHandlerJobArgs]) time.Duration {
+	return 30 * time.Second
+}
+
+func (e *declineCutoverEnv) newContact(t *testing.T, cadenceStr *string) repository.Contact {
+	t.Helper()
+	contact, err := e.contactRepo.CreateContact(e.ctx, repository.CreateContactRequest{
+		FullName: "decline-cutover-" + uuid.NewString()[:8],
+		Cadence:  cadenceStr,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = e.contactRepo.HardDeleteContact(e.ctx, contact.ID) })
+	return *contact
+}
+
+// seedStoredEvent upserts an accepted/confirmed calendar_event matched to the
+// contact and returns it. gcalID is the upstream Google id; the returned
+// internal UUID is what derived interactions reference as source_ref.
+func (e *declineCutoverEnv) seedStoredEvent(t *testing.T, gcalID string, contactID uuid.UUID, endTime time.Time) repository.CalendarEvent {
+	t.Helper()
+	title := "decline-cutover-event"
+	accepted := "accepted"
+	stored, err := e.calendarRepo.Upsert(e.ctx, repository.UpsertCalendarEventRequest{
+		GcalEventID:       gcalID,
+		GcalCalendarID:    "primary",
+		GoogleAccountID:   e.accountID,
+		Title:             &title,
+		StartTime:         endTime.Add(-time.Hour),
+		EndTime:           endTime,
+		Status:            "confirmed",
+		UserResponse:      &accepted,
+		Attendees:         []repository.Attendee{},
+		MatchedContactIDs: []uuid.UUID{contactID},
+		SyncedAt:          endTime,
+	})
+	require.NoError(t, err)
+	return *stored
+}
+
+// declinedSelfEvent builds a minimal cancelled/declined delta for the gcal id
+// (organizer is the user → getUserResponse synthesizes "accepted", so the
+// status="cancelled" clause drives keep=false). No Start/End DateTime, proving
+// the remove branch runs without parsed times.
+func cancelledSelfEvent(gcalID, accountID string) *calendarapi.Event {
+	return &calendarapi.Event{
+		Id:        gcalID,
+		Status:    "cancelled",
+		Start:     &calendarapi.EventDateTime{},
+		End:       &calendarapi.EventDateTime{},
+		Organizer: &calendarapi.EventOrganizer{Email: accountID},
+	}
+}
+
+// waitForInteractionGone polls until the interaction for (contact, source_ref)
+// is soft-deleted (FindBySourceRef returns ErrNotFound) or the timeout fires.
+func (e *declineCutoverEnv) waitForInteractionGone(t *testing.T, contactID uuid.UUID, sourceRef string, timeout time.Duration) {
+	t.Helper()
+	deadline := accelerated.GetCurrentTime().Add(timeout)
+	for accelerated.GetCurrentTime().Before(deadline) {
+		_, err := e.interactionRepo.FindBySourceRef(e.ctx, contactID, repository.InteractionSourceGCal, sourceRef)
+		if errors.Is(err, db.ErrNotFound) {
+			return
+		}
+		require.NoError(t, err)
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for interaction (contact=%s ref=%s) to be soft-deleted", contactID, sourceRef)
+}
+
+// TestIntegration_DeclineCutover_RemovesEventAndInteractionThroughProcessEvent
+// drives the real cutover remove branch through processEvent with a real bus +
+// pool and the live decline consumer, asserting the full chain.
+func TestIntegration_DeclineCutover_RemovesEventAndInteractionThroughProcessEvent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	ctx := context.Background()
+	e := newDeclineCutoverEnv(t, ctx)
+
+	cad := "weekly"
+	contact := e.newContact(t, &cad)
+	gcalID := "evt-" + uuid.NewString()
+	endTime := accelerated.GetCurrentTime().AddDate(0, 0, -1) // past
+
+	stored := e.seedStoredEvent(t, gcalID, contact.ID, endTime)
+	internalRef := stored.ID.String()
+
+	// Record the derived gcal interaction the production way (source_ref =
+	// internal calendar_event.ID) and apply cadence so the four contact date
+	// columns land. Also seed an attended event-log row so the coexistence
+	// assertion has the attended counterpart of the declined: key.
+	ref := internalRef
+	_, err := e.interactionRepo.CreateInteraction(ctx, repository.CreateInteractionRequest{
+		ContactID: contact.ID, Source: repository.InteractionSourceGCal, SourceRef: &ref,
+		OccurredAt: endTime, Direction: repository.InteractionDirectionMutual,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = e.interactionRepo.HardDeleteInteractionsBySourceRefPrefix(ctx, repository.InteractionSourceGCal, internalRef)
+	})
+	require.NoError(t, pgx.BeginTxFunc(ctx, e.database.Pool, pgx.TxOptions{}, func(tx pgx.Tx) error {
+		return e.cadenceUpdater.ApplyInteraction(ctx, tx, repository.ApplyInteractionRequest{
+			ContactID: contact.ID, Direction: repository.InteractionDirectionMutual,
+			Source: repository.InteractionSourceGCal, OccurredAt: endTime,
+		})
+	}))
+	attendedSourceID := internalRef + ":" + contact.ID.String()
+	e.seedAttendedEventRow(t, attendedSourceID, contact.ID, internalRef, endTime)
+
+	// Drive the REAL cutover remove branch through processEvent.
+	require.NoError(t, e.provider.RunProcessEventForTest(ctx, cancelledSelfEvent(gcalID, e.accountID), e.accountID))
+
+	// calendar_event row deleted.
+	_, err = e.calendarRepo.GetByGcalID(ctx, gcalID, "primary", e.accountID)
+	require.ErrorIs(t, err, db.ErrNotFound, "cutover remove branch deletes the stored calendar_event")
+
+	// declined: event-log row landed and coexists with the attended row.
+	declinedSourceID := "declined:" + internalRef + ":" + contact.ID.String()
+	declined, err := e.eventRepo.FindEventBySource(ctx, repository.InteractionSourceGCal, declinedSourceID)
+	require.NoError(t, err, "declined: event row published by the cutover branch")
+	require.Equal(t, events.KindCalendarDeclined, declined.Kind)
+	attended, err := e.eventRepo.FindEventBySource(ctx, repository.InteractionSourceGCal, attendedSourceID)
+	require.NoError(t, err, "attended event row still present (declined: prefix keeps them disjoint)")
+	require.NotEqual(t, attended.ID, declined.ID, "two distinct event-log rows coexist")
+	t.Cleanup(func() {
+		_ = e.eventRepo.HardDeleteEventsBySourceAndSourceIDPrefix(ctx, repository.InteractionSourceGCal, declinedSourceID)
+		_ = e.eventRepo.HardDeleteEventsBySourceAndSourceIDPrefix(ctx, repository.InteractionSourceGCal, attendedSourceID)
+	})
+
+	// The decline job drains → interaction soft-deleted + contact dates roll.
+	e.waitForInteractionGone(t, contact.ID, internalRef, 30*time.Second)
+
+	got, err := e.contactRepo.GetContact(ctx, contact.ID)
+	require.NoError(t, err)
+	assert.Nil(t, got.LastContacted, "contact date columns roll back after the decline job drains")
+	assert.Nil(t, got.LastOutreachAt)
+	require.NotNil(t, got.ContactBy, "contact_by falls back to created_at + cadence")
+}
+
+// TestIntegration_DeclineCutover_PublishFailureLeavesRowIntact proves
+// publish-before-delete: when PublishTx fails, the whole tx rolls back and the
+// calendar_event row survives (the delete never commits).
+func TestIntegration_DeclineCutover_PublishFailureLeavesRowIntact(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	ctx := context.Background()
+	e := newDeclineCutoverEnv(t, ctx)
+
+	contact := e.newContact(t, nil)
+	gcalID := "evt-" + uuid.NewString()
+	endTime := accelerated.GetCurrentTime().AddDate(0, 0, -1)
+	stored := e.seedStoredEvent(t, gcalID, contact.ID, endTime)
+
+	// Substitute a failing decline bus so the per-contact PublishTx errors
+	// BEFORE the delete. publish-before-delete means the delete must roll back.
+	e.provider.SetDeclineBusForTest(failingDeclineBus{})
+
+	err := e.provider.RunProcessEventForTest(ctx, cancelledSelfEvent(gcalID, e.accountID), e.accountID)
+	require.Error(t, err, "a failing PublishTx must surface as an error")
+
+	// The calendar_event row must still exist (delete rolled back with publish).
+	got, err := e.calendarRepo.GetByGcalID(ctx, gcalID, "primary", e.accountID)
+	require.NoError(t, err, "publish-before-delete: a publish failure leaves the calendar_event intact")
+	require.Equal(t, stored.ID, got.ID)
+
+	// And no declined: event row leaked.
+	declinedSourceID := "declined:" + stored.ID.String() + ":" + contact.ID.String()
+	_, err = e.eventRepo.FindEventBySource(ctx, repository.InteractionSourceGCal, declinedSourceID)
+	require.ErrorIs(t, err, db.ErrNotFound, "the rolled-back tx leaves no declined event-log row")
+}
+
+// failingDeclineBus is a busTx whose PublishTx always errors, used to assert
+// publish-before-delete ordering in the cutover remove branch.
+type failingDeclineBus struct{}
+
+func (failingDeclineBus) PublishTx(_ context.Context, _ pgx.Tx, _ *events.Envelope) error {
+	return errors.New("simulated publish failure")
+}
+
+// seedAttendedEventRow inserts a calendar.attended event-log row directly
+// (keyed <internalRef>:<contactID>) so the coexistence assertion has the
+// attended counterpart of the declined: key without driving the attended
+// consumer.
+func (e *declineCutoverEnv) seedAttendedEventRow(t *testing.T, sourceID string, contactID uuid.UUID, internalRef string, occurredAt time.Time) {
+	t.Helper()
+	raw, err := events.Marshal(events.KindCalendarAttended, events.CalendarAttendedPayload{
+		Version: 1, ContactID: contactID, EventID: internalRef, OccurredAt: occurredAt,
+	})
+	require.NoError(t, err)
+	env := &events.Envelope{
+		ID:         uuid.New(),
+		Source:     repository.InteractionSourceGCal,
+		SourceID:   sourceID,
+		Kind:       events.KindCalendarAttended,
+		Payload:    raw,
+		ObservedAt: occurredAt,
+	}
+	require.NoError(t, pgx.BeginTxFunc(e.ctx, e.database.Pool, pgx.TxOptions{}, func(tx pgx.Tx) error {
+		return e.eventRepo.InsertEvent(e.ctx, tx, env)
+	}))
+}

--- a/backend/tests/calendar_decline_removal_integration_test.go
+++ b/backend/tests/calendar_decline_removal_integration_test.go
@@ -48,11 +48,16 @@ type declineTestEnv struct {
 
 func newDeclineTestEnv(t *testing.T, ctx context.Context) *declineTestEnv {
 	t.Helper()
-	if os.Getenv("DATABASE_URL") == "" {
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
 		t.Skip("DATABASE_URL not set, skipping integration test")
 	}
+	// Provision schema explicitly (CI has bare PostgreSQL without a
+	// pre-existing schema) for parity with sibling integration tests and the
+	// documented gotcha; idempotent under the package TestMain harness.
+	require.NoError(t, db.RunMigrations(ctx, databaseURL, getMigrationsPath()))
 	cfg := config.TestConfig()
-	cfg.Database.URL = os.Getenv("DATABASE_URL")
+	cfg.Database.URL = databaseURL
 	cfg.Database.MigrationsPath = getMigrationsPath()
 	database, err := db.NewDatabase(ctx, cfg.Database)
 	require.NoError(t, err)

--- a/backend/tests/calendar_decline_removal_integration_test.go
+++ b/backend/tests/calendar_decline_removal_integration_test.go
@@ -1,0 +1,644 @@
+// Integration coverage for the calendar decline-removal path (issue #366):
+// when a stored calendar event is declined / cancelled / user-removed
+// upstream, the derived gcal interaction is soft-deleted and the contact's
+// date columns are surgically recomputed.
+//
+// These tests hit a real DB. They cover:
+//   - CalendarDeclineHandler consumer (soft-delete + recompute) end-to-end
+//   - the surgical RecomputeContactDatesAfterDelete query, per column +
+//     provenance-safety guards (creation value preserved, contact_by
+//     override preserved, NULL-out, per-direction, forward-writer parity)
+//   - decline replay idempotency
+//   - Decision-3a attended-after-delete guard (skip-when-deleted +
+//     FOR SHARE / FOR UPDATE lock serialization)
+//   - the declined: SourceID namespace coexisting with the attended row
+package tests
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/cadence"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/consumer"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// declineTestEnv bundles the repositories + consumer used by the
+// decline-removal integration tests.
+type declineTestEnv struct {
+	ctx             context.Context
+	database        *db.Database
+	contactRepo     *repository.ContactRepository
+	interactionRepo *repository.InteractionRepository
+	calendarRepo    *repository.CalendarEventRepository
+	cadenceUpdater  *consumer.CadenceUpdater
+	declineHandler  *consumer.CalendarDeclineHandler
+}
+
+func newDeclineTestEnv(t *testing.T, ctx context.Context) *declineTestEnv {
+	t.Helper()
+	if os.Getenv("DATABASE_URL") == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+	cfg := config.TestConfig()
+	cfg.Database.URL = os.Getenv("DATABASE_URL")
+	cfg.Database.MigrationsPath = getMigrationsPath()
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	t.Cleanup(func() { database.Close() })
+
+	contactRepo := repository.NewContactRepository(database.Queries)
+	contactRepo.SetPool(database.Pool)
+	interactionRepo := repository.NewInteractionRepository(database.Queries)
+	calendarRepo := repository.NewCalendarEventRepository(database.Queries)
+	claimRepo := repository.NewEventConsumerClaimRepository(database.Queries)
+	cadenceUpdater := consumer.NewCadenceUpdater(
+		claimRepo, contactRepo, database.Queries, consumer.CadenceModeCutover, false,
+	)
+	declineHandler := consumer.NewCalendarDeclineHandler(interactionRepo, contactRepo)
+
+	return &declineTestEnv{
+		ctx:             ctx,
+		database:        database,
+		contactRepo:     contactRepo,
+		interactionRepo: interactionRepo,
+		calendarRepo:    calendarRepo,
+		cadenceUpdater:  cadenceUpdater,
+		declineHandler:  declineHandler,
+	}
+}
+
+func (e *declineTestEnv) newContact(t *testing.T, cadenceStr *string, lastContacted *time.Time) repository.Contact {
+	t.Helper()
+	contact, err := e.contactRepo.CreateContact(e.ctx, repository.CreateContactRequest{
+		FullName:      "decline-removal-" + uuid.NewString()[:8],
+		Cadence:       cadenceStr,
+		LastContacted: lastContacted,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = e.contactRepo.HardDeleteContact(e.ctx, contact.ID) })
+	return *contact
+}
+
+// seedGcalInteraction creates a gcal interaction with the given source_ref
+// (the internal calendar_event.ID string) + direction + occurred_at, then
+// applies it through the real CadenceUpdater so the contact's date columns
+// land exactly as the forward path would set them.
+func (e *declineTestEnv) seedGcalInteraction(t *testing.T, contactID uuid.UUID, sourceRef, direction string, occurredAt time.Time) *repository.Interaction {
+	t.Helper()
+	ref := sourceRef
+	interaction, err := e.interactionRepo.CreateInteraction(e.ctx, repository.CreateInteractionRequest{
+		ContactID:  contactID,
+		Source:     repository.InteractionSourceGCal,
+		SourceRef:  &ref,
+		OccurredAt: occurredAt,
+		Direction:  direction,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = e.interactionRepo.HardDeleteInteractionsBySourceRefPrefix(e.ctx, repository.InteractionSourceGCal, sourceRef)
+	})
+
+	applyInTx(t, e.database, func(tx pgx.Tx) error {
+		return e.cadenceUpdater.ApplyInteraction(e.ctx, tx, repository.ApplyInteractionRequest{
+			ContactID:  contactID,
+			Direction:  direction,
+			Source:     repository.InteractionSourceGCal,
+			OccurredAt: occurredAt,
+		})
+	})
+	return interaction
+}
+
+// runDecline soft-deletes the interaction + recomputes the contact's date
+// columns via CalendarDeclineHandler.HandleEvent in a fresh tx (mirroring
+// the river worker). The envelope carries the internal-UUID source_ref.
+func (e *declineTestEnv) runDecline(t *testing.T, contactID uuid.UUID, sourceRef string, occurredAt time.Time) {
+	t.Helper()
+	payload := events.CalendarDeclinedPayload{
+		Version: 1, ContactID: contactID, EventID: sourceRef, OccurredAt: occurredAt,
+	}
+	raw, err := events.Marshal(events.KindCalendarDeclined, payload)
+	require.NoError(t, err)
+	env := &events.Envelope{
+		ID:         uuid.New(),
+		Source:     repository.InteractionSourceGCal,
+		SourceID:   "declined:" + sourceRef + ":" + contactID.String(),
+		Kind:       events.KindCalendarDeclined,
+		Payload:    raw,
+		ObservedAt: occurredAt,
+	}
+	require.NoError(t, pgx.BeginTxFunc(e.ctx, e.database.Pool, pgx.TxOptions{}, func(tx pgx.Tx) error {
+		return e.declineHandler.HandleEvent(e.ctx, tx, env)
+	}))
+}
+
+// Test 5: consumer-direct soft-delete + recompute.
+func TestIntegration_CalendarDecline_SoftDeletesAndRecomputes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	ctx := context.Background()
+	e := newDeclineTestEnv(t, ctx)
+
+	occurredAt := time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC)
+	contact := e.newContact(t, nil, nil)
+	sourceRef := uuid.NewString()
+	e.seedGcalInteraction(t, contact.ID, sourceRef, repository.InteractionDirectionMutual, occurredAt)
+
+	// Sanity: the forward path set the four columns to occurredAt.
+	pre, err := e.contactRepo.GetContact(ctx, contact.ID)
+	require.NoError(t, err)
+	require.NotNil(t, pre.LastContacted)
+	assert.Equal(t, occurredAt.UTC(), pre.LastContacted.UTC())
+
+	e.runDecline(t, contact.ID, sourceRef, occurredAt)
+
+	// Interaction soft-deleted.
+	_, err = e.interactionRepo.FindBySourceRef(ctx, contact.ID, repository.InteractionSourceGCal, sourceRef)
+	require.ErrorIs(t, err, db.ErrNotFound, "decline soft-deletes the derived interaction")
+
+	// Contact dates rolled to NULL (no remaining interactions, no cadence).
+	got, err := e.contactRepo.GetContact(ctx, contact.ID)
+	require.NoError(t, err)
+	assert.Nil(t, got.LastContacted, "last_contacted NULLs when the sourcing interaction is removed and none remain")
+	assert.Nil(t, got.LastInteractionAt)
+	assert.Nil(t, got.LastResponseAt)
+	assert.Nil(t, got.LastOutreachAt)
+}
+
+// Test 6(a): NULL-out (sourced + none remain) + contact_by from created_at.
+func TestIntegration_CalendarDecline_NullOutWithCadenceFallback(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	ctx := context.Background()
+	e := newDeclineTestEnv(t, ctx)
+
+	cad := "weekly"
+	// Anchor the interaction AFTER creation so it wins forward-max and truly
+	// sources last_contacted + contact_by (a past occurredAt would be blocked
+	// by the created_at-based contact_by floor, masking the rollback path).
+	occurredAt := accelerated.GetCurrentTime().AddDate(0, 0, 30)
+	// Contact created WITHOUT last_contacted so its only date source is the
+	// gcal interaction; contact_by initially derives from created_at.
+	contact := e.newContact(t, &cad, nil)
+	sourceRef := uuid.NewString()
+	e.seedGcalInteraction(t, contact.ID, sourceRef, repository.InteractionDirectionMutual, occurredAt)
+
+	require.NoError(t, e.interactionRepo.SoftDeleteInteraction(ctx, mustFindInteraction(t, e, contact.ID, sourceRef).ID))
+	require.NoError(t, e.contactRepo.RecomputeContactDatesAfterDelete(ctx, contact.ID, occurredAt))
+
+	got, err := e.contactRepo.GetContact(ctx, contact.ID)
+	require.NoError(t, err)
+	assert.Nil(t, got.LastContacted, "sourced + none remain → NULL")
+	assert.Nil(t, got.LastOutreachAt)
+	require.NotNil(t, got.ContactBy, "contact_by falls back to created_at + cadence, NOT NULL")
+	assertSameCadenceDate(t, cadence.CalculateContactBy(got.CreatedAt, cadence.CadenceWeekly), *got.ContactBy,
+		"contact_by re-derived from created_at after the sourcing interaction is removed")
+}
+
+// Test 6(b): cadence-unset variant → contact_by left as-is (NULL).
+func TestIntegration_CalendarDecline_NoCadence_ContactByStaysNil(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	ctx := context.Background()
+	e := newDeclineTestEnv(t, ctx)
+
+	occurredAt := time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC)
+	contact := e.newContact(t, nil, nil)
+	sourceRef := uuid.NewString()
+	e.seedGcalInteraction(t, contact.ID, sourceRef, repository.InteractionDirectionMutual, occurredAt)
+
+	require.NoError(t, e.interactionRepo.SoftDeleteInteraction(ctx, mustFindInteraction(t, e, contact.ID, sourceRef).ID))
+	require.NoError(t, e.contactRepo.RecomputeContactDatesAfterDelete(ctx, contact.ID, occurredAt))
+
+	got, err := e.contactRepo.GetContact(ctx, contact.ID)
+	require.NoError(t, err)
+	assert.Nil(t, got.ContactBy, "no cadence → contact_by untouched (stays nil)")
+}
+
+// Test 6(c): per-direction — inbound(earlier) + outbound(latest) + mutual
+// (middle) live; remove the mutual; last_outreach_at rolls to the outbound
+// time, the non-outbound columns roll to the inbound time.
+func TestIntegration_CalendarDecline_PerDirectionRollback(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	ctx := context.Background()
+	e := newDeclineTestEnv(t, ctx)
+
+	cad := "weekly"
+	// Anchor after creation so the mutual sources contact_by via forward-max.
+	base := accelerated.GetCurrentTime()
+	inbound := base.AddDate(0, 0, 10)
+	mutual := base.AddDate(0, 0, 20)
+	outbound := base.AddDate(0, 0, 30)
+	contact := e.newContact(t, &cad, nil)
+
+	inboundRef := uuid.NewString()
+	mutualRef := uuid.NewString()
+	outboundRef := uuid.NewString()
+	// Seed all three. Forward-max over the non-outbound subset {inbound,
+	// mutual} → last_contacted = mutual (Mar 10 > Mar 1). Over the
+	// outbound/mutual subset {mutual, outbound} → last_outreach_at = outbound
+	// (Mar 20 > Mar 10).
+	e.seedGcalInteraction(t, contact.ID, inboundRef, repository.InteractionDirectionInbound, inbound)
+	e.seedGcalInteraction(t, contact.ID, mutualRef, repository.InteractionDirectionMutual, mutual)
+	e.seedGcalInteraction(t, contact.ID, outboundRef, repository.InteractionDirectionOutbound, outbound)
+
+	// At this point: last_contacted = mutual (max non-outbound), last_outreach_at = outbound (max).
+	pre, err := e.contactRepo.GetContact(ctx, contact.ID)
+	require.NoError(t, err)
+	require.NotNil(t, pre.LastContacted)
+	assert.Equal(t, mutual.UTC(), pre.LastContacted.UTC())
+	require.NotNil(t, pre.LastOutreachAt)
+	assert.Equal(t, outbound.UTC(), pre.LastOutreachAt.UTC())
+
+	// Remove the mutual (it sourced last_contacted = mutual).
+	require.NoError(t, e.interactionRepo.SoftDeleteInteraction(ctx, mustFindInteraction(t, e, contact.ID, mutualRef).ID))
+	require.NoError(t, e.contactRepo.RecomputeContactDatesAfterDelete(ctx, contact.ID, mutual))
+
+	got, err := e.contactRepo.GetContact(ctx, contact.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.LastContacted)
+	assert.Equal(t, inbound.UTC(), got.LastContacted.UTC(), "non-outbound rolls to remaining inbound")
+	require.NotNil(t, got.LastResponseAt)
+	assert.Equal(t, inbound.UTC(), got.LastResponseAt.UTC())
+	require.NotNil(t, got.LastOutreachAt)
+	assert.Equal(t, outbound.UTC(), got.LastOutreachAt.UTC(), "outbound subset unchanged (outbound interaction still live)")
+	require.NotNil(t, got.ContactBy)
+	assertSameCadenceDate(t, cadence.CalculateContactBy(inbound, cadence.CadenceWeekly), *got.ContactBy,
+		"contact_by re-derived from the remaining inbound after the mutual is removed")
+}
+
+// Test 6(d): PROVENANCE GUARD — a creation-set last_contacted (no backing
+// interaction, distinct instant from the gcal occurred_at) is NOT erased.
+func TestIntegration_CalendarDecline_PreservesCreationValue(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	ctx := context.Background()
+	e := newDeclineTestEnv(t, ctx)
+
+	// Creation-set last_contacted distinct from the gcal occurred_at.
+	creationLC := time.Date(2026, 1, 1, 8, 0, 0, 0, time.UTC)
+	gcalOccurredAt := time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC)
+	contact := e.newContact(t, nil, &creationLC)
+
+	// Seed the gcal interaction but do NOT apply it (so last_contacted stays
+	// at the creation value, not the gcal time). The interaction exists with
+	// occurred_at = gcalOccurredAt; last_contacted = creationLC != gcalOccurredAt.
+	sourceRef := uuid.NewString()
+	ref := sourceRef
+	created, err := e.interactionRepo.CreateInteraction(ctx, repository.CreateInteractionRequest{
+		ContactID: contact.ID, Source: repository.InteractionSourceGCal, SourceRef: &ref,
+		OccurredAt: gcalOccurredAt, Direction: repository.InteractionDirectionMutual,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = e.interactionRepo.HardDeleteInteractionsBySourceRefPrefix(ctx, repository.InteractionSourceGCal, sourceRef)
+	})
+
+	require.NoError(t, e.interactionRepo.SoftDeleteInteraction(ctx, created.ID))
+	require.NoError(t, e.contactRepo.RecomputeContactDatesAfterDelete(ctx, contact.ID, gcalOccurredAt))
+
+	got, err := e.contactRepo.GetContact(ctx, contact.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.LastContacted)
+	assert.Equal(t, creationLC.UTC(), got.LastContacted.UTC(),
+		"creation-set last_contacted (!= deleted ts) must be preserved")
+}
+
+// Test 6(e): PROVENANCE GUARD — a Todoist/user contact_by override is
+// preserved even when the gcal interaction sourced last_contacted.
+func TestIntegration_CalendarDecline_PreservesContactByOverride(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	ctx := context.Background()
+	e := newDeclineTestEnv(t, ctx)
+
+	cad := "weekly"
+	// Anchor after creation so the interaction sources last_contacted.
+	occurredAt := accelerated.GetCurrentTime().AddDate(0, 0, 30)
+	contact := e.newContact(t, &cad, nil)
+	sourceRef := uuid.NewString()
+	e.seedGcalInteraction(t, contact.ID, sourceRef, repository.InteractionDirectionMutual, occurredAt)
+
+	// Apply a Todoist/user override AFTER the interaction: a contact_by that
+	// differs from CalculateContactBy(last_contacted=occurredAt, weekly).
+	override := time.Date(2026, 12, 25, 0, 0, 0, 0, time.UTC)
+	applyInTx(t, e.database, func(tx pgx.Tx) error {
+		return e.cadenceUpdater.ApplyContactByOverride(ctx, tx, contact.ID, &override)
+	})
+
+	require.NoError(t, e.interactionRepo.SoftDeleteInteraction(ctx, mustFindInteraction(t, e, contact.ID, sourceRef).ID))
+	require.NoError(t, e.contactRepo.RecomputeContactDatesAfterDelete(ctx, contact.ID, occurredAt))
+
+	got, err := e.contactRepo.GetContact(ctx, contact.ID)
+	require.NoError(t, err)
+	assert.Nil(t, got.LastContacted, "last_contacted rolls back (it was sourced by the removed interaction)")
+	require.NotNil(t, got.ContactBy)
+	assertSameRawDate(t, override, *got.ContactBy, "the contact_by override survives the decline recompute")
+}
+
+// Test 6(f): contact_by correctly rolled back when it still reflects the
+// removed interaction (no override since).
+func TestIntegration_CalendarDecline_RollsBackContactByWhenNoOverride(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	ctx := context.Background()
+	e := newDeclineTestEnv(t, ctx)
+
+	cad := "weekly"
+	// Anchor after creation so the interaction sources contact_by.
+	occurredAt := accelerated.GetCurrentTime().AddDate(0, 0, 30)
+	contact := e.newContact(t, &cad, nil)
+	sourceRef := uuid.NewString()
+	e.seedGcalInteraction(t, contact.ID, sourceRef, repository.InteractionDirectionMutual, occurredAt)
+
+	// Sanity: the interaction set contact_by = CalculateContactBy(occurredAt, weekly).
+	pre, err := e.contactRepo.GetContact(ctx, contact.ID)
+	require.NoError(t, err)
+	require.NotNil(t, pre.ContactBy)
+	assertSameCadenceDate(t, cadence.CalculateContactBy(occurredAt, cadence.CadenceWeekly), *pre.ContactBy,
+		"forward path set contact_by from the interaction's occurred_at")
+
+	require.NoError(t, e.interactionRepo.SoftDeleteInteraction(ctx, mustFindInteraction(t, e, contact.ID, sourceRef).ID))
+	require.NoError(t, e.contactRepo.RecomputeContactDatesAfterDelete(ctx, contact.ID, occurredAt))
+
+	got, err := e.contactRepo.GetContact(ctx, contact.ID)
+	require.NoError(t, err)
+	assert.Nil(t, got.LastContacted, "last_contacted NULLs (sourced + none remain)")
+	require.NotNil(t, got.ContactBy)
+	assertSameCadenceDate(t, cadence.CalculateContactBy(got.CreatedAt, cadence.CadenceWeekly), *got.ContactBy,
+		"contact_by re-derived from created_at (the removed interaction's own contribution undone)")
+}
+
+// Test 6(g): forward-writer parity — the recomputed contact_by equals what
+// the forward path would store for the equivalent base+cadence.
+func TestIntegration_CalendarDecline_ContactByForwardWriterParity(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	ctx := context.Background()
+	e := newDeclineTestEnv(t, ctx)
+
+	cad := "monthly"
+	occurredAt := accelerated.GetCurrentTime().AddDate(0, 0, 30)
+	contact := e.newContact(t, &cad, nil)
+	sourceRef := uuid.NewString()
+	e.seedGcalInteraction(t, contact.ID, sourceRef, repository.InteractionDirectionMutual, occurredAt)
+
+	require.NoError(t, e.interactionRepo.SoftDeleteInteraction(ctx, mustFindInteraction(t, e, contact.ID, sourceRef).ID))
+	require.NoError(t, e.contactRepo.RecomputeContactDatesAfterDelete(ctx, contact.ID, occurredAt))
+
+	got, err := e.contactRepo.GetContact(ctx, contact.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.ContactBy)
+
+	// Forward-writer reference: the recompute re-derives contact_by from the
+	// contact's own created_at; assert it matches CalculateContactBy(created_at,
+	// monthly) — the exact value the forward writer would store for that base.
+	assertSameCadenceDate(t, cadence.CalculateContactBy(got.CreatedAt, cadence.CadenceMonthly), *got.ContactBy,
+		"recompute contact_by matches the forward writer for the created_at + monthly base")
+}
+
+// Test 7: replay — delivering the same decline twice is a safe no-op.
+func TestIntegration_CalendarDecline_ReplayIsNoOp(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	ctx := context.Background()
+	e := newDeclineTestEnv(t, ctx)
+
+	occurredAt := time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC)
+	contact := e.newContact(t, nil, nil)
+	sourceRef := uuid.NewString()
+	e.seedGcalInteraction(t, contact.ID, sourceRef, repository.InteractionDirectionMutual, occurredAt)
+
+	e.runDecline(t, contact.ID, sourceRef, occurredAt)
+	// Second delivery: interaction already soft-deleted → FindBySourceRefTx
+	// returns ErrNotFound → no-op, no error.
+	e.runDecline(t, contact.ID, sourceRef, occurredAt)
+
+	got, err := e.contactRepo.GetContact(ctx, contact.ID)
+	require.NoError(t, err)
+	assert.Nil(t, got.LastContacted)
+}
+
+// Test 8(a): Decision-3a skip-when-deleted — calendar.attended whose backing
+// calendar_event was deleted → no interaction written.
+func TestIntegration_AttendedAfterDelete_SkipsInsert(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	ctx := context.Background()
+	e := newDeclineTestEnv(t, ctx)
+	contact := e.newContact(t, nil, nil)
+
+	// EventID points at a calendar_event that does NOT exist.
+	missingEventID := uuid.New()
+
+	var exists bool
+	require.NoError(t, pgx.BeginTxFunc(ctx, e.database.Pool, pgx.TxOptions{}, func(tx pgx.Tx) error {
+		var err error
+		exists, err = e.calendarRepo.LockExistsByIDTx(ctx, tx, missingEventID)
+		return err
+	}))
+	assert.False(t, exists, "LockExistsByIDTx reports a missing calendar_event as not present → attended insert is skipped")
+
+	// And no interaction exists for that source_ref.
+	_, err := e.interactionRepo.FindBySourceRef(ctx, contact.ID, repository.InteractionSourceGCal, missingEventID.String())
+	require.ErrorIs(t, err, db.ErrNotFound)
+}
+
+// Test 8(b): Decision-3a lock-serialization — the attended FOR SHARE
+// conflicts with a concurrent FOR UPDATE NOWAIT (proving the lock is held),
+// without sleeps. Then the decline DELETE soft-deletes the just-written
+// interaction; and the reverse order (decline-first) skips the attended insert.
+func TestIntegration_AttendedAfterDelete_LockSerialization(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	ctx := context.Background()
+	e := newDeclineTestEnv(t, ctx)
+	contact := e.newContact(t, nil, nil)
+
+	accountID := "decline-lock-" + uuid.NewString()
+	stored := e.seedCalendarEvent(t, accountID, contact.ID)
+
+	// Open attended tx A and acquire the FOR SHARE lock (do NOT commit yet).
+	txA, err := e.database.Pool.Begin(ctx)
+	require.NoError(t, err)
+	defer func() { _ = txA.Rollback(ctx) }()
+	existsA, err := e.calendarRepo.LockExistsByIDTx(ctx, txA, stored.ID)
+	require.NoError(t, err)
+	require.True(t, existsA, "attended FOR SHARE acquired on the present row")
+
+	// From tx B, FOR UPDATE NOWAIT must fail immediately (A holds FOR SHARE).
+	txB, err := e.database.Pool.Begin(ctx)
+	require.NoError(t, err)
+	_, probeErr := e.calendarRepo.TestGetByIDForUpdateNoWaitTx(ctx, txB, stored.ID)
+	require.Error(t, probeErr, "FOR UPDATE NOWAIT must conflict with the attended FOR SHARE held by tx A")
+	_ = txB.Rollback(ctx)
+
+	// Commit A (in production this is where the attended interaction insert
+	// would commit). Release the lock.
+	require.NoError(t, txA.Commit(ctx))
+
+	// Reverse order: decline DELETE commits first → attended FOR SHARE read
+	// returns no row → skip. Delete the event, then assert LockExistsByIDTx
+	// reports gone.
+	require.NoError(t, e.calendarRepo.DeleteByGcalID(ctx, stored.GcalEventID, "primary", accountID))
+	var existsAfterDelete bool
+	require.NoError(t, pgx.BeginTxFunc(ctx, e.database.Pool, pgx.TxOptions{}, func(tx pgx.Tx) error {
+		var err error
+		existsAfterDelete, err = e.calendarRepo.LockExistsByIDTx(ctx, tx, stored.ID)
+		return err
+	}))
+	assert.False(t, existsAfterDelete, "after the decline DELETE, the attended branch sees no row → skips the insert")
+}
+
+// Test: declined: SourceID coexists with the attended row (P0-collision
+// regression). Publishing both an attended and a declined event for the same
+// internal UUID + contact yields TWO distinct event-log rows.
+func TestIntegration_DeclineSourceID_CoexistsWithAttended(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	ctx := context.Background()
+	e := newDeclineTestEnv(t, ctx)
+
+	eventRepo := repository.NewEventRepository(e.database.Queries)
+	internalUUID := uuid.NewString()
+	contactID := uuid.New()
+	occurredAt := time.Date(2026, 3, 15, 11, 0, 0, 0, time.UTC)
+
+	attendedSourceID := internalUUID + ":" + contactID.String()
+	declinedSourceID := "declined:" + internalUUID + ":" + contactID.String()
+
+	insertEvent(t, ctx, e, eventRepo, attendedSourceID, events.KindCalendarAttended, attendedPayload(t, contactID, internalUUID, occurredAt))
+	insertEvent(t, ctx, e, eventRepo, declinedSourceID, events.KindCalendarDeclined, declinedPayload(t, contactID, internalUUID, occurredAt))
+	t.Cleanup(func() { hardDeleteEventBySource(t, ctx, e, attendedSourceID, declinedSourceID) })
+
+	attended, err := eventRepo.FindEventBySource(ctx, repository.InteractionSourceGCal, attendedSourceID)
+	require.NoError(t, err, "attended event row present")
+	declined, err := eventRepo.FindEventBySource(ctx, repository.InteractionSourceGCal, declinedSourceID)
+	require.NoError(t, err, "declined event row present (declined: prefix keeps it disjoint from attended)")
+	require.NotEqual(t, attended.ID, declined.ID, "two distinct event-log rows coexist")
+}
+
+// -----------------------------------------------------------------------------
+// helpers
+// -----------------------------------------------------------------------------
+
+func mustFindInteraction(t *testing.T, e *declineTestEnv, contactID uuid.UUID, sourceRef string) *repository.Interaction {
+	t.Helper()
+	got, err := e.interactionRepo.FindBySourceRef(e.ctx, contactID, repository.InteractionSourceGCal, sourceRef)
+	require.NoError(t, err)
+	return got
+}
+
+// assertSameCadenceDate compares a stored contact_by DATE against a
+// cadence-derived expected value (cadence.CalculateContactBy, local-midnight
+// in production). The forward writer stores DateOnly(expected) so the DB DATE
+// is the LOCAL calendar day of expected; reading it back yields UTC-midnight
+// of that day. So compare expected's LOCAL date against the stored value's
+// UTC date. Mirrors the contact_by parity assertions in
+// contact_by_integration_test.go.
+func assertSameCadenceDate(t *testing.T, expected, stored time.Time, msg string) {
+	t.Helper()
+	eY, eM, eD := cadence.DateOnly(expected).Date()
+	gY, gM, gD := stored.UTC().Date()
+	assert.Equalf(t, [3]int{eY, int(eM), eD}, [3]int{gY, int(gM), gD},
+		"expected DATE %04d-%02d-%02d, got %04d-%02d-%02d: %s", eY, eM, eD, gY, gM, gD, msg)
+}
+
+// assertSameRawDate compares a stored contact_by DATE against a raw
+// (override) date value. The override is written verbatim (UTC midnight), so
+// both reduce to a UTC calendar date.
+func assertSameRawDate(t *testing.T, expected, stored time.Time, msg string) {
+	t.Helper()
+	eY, eM, eD := expected.UTC().Date()
+	gY, gM, gD := stored.UTC().Date()
+	assert.Equalf(t, [3]int{eY, int(eM), eD}, [3]int{gY, int(gM), gD},
+		"expected DATE %04d-%02d-%02d, got %04d-%02d-%02d: %s", eY, eM, eD, gY, gM, gD, msg)
+}
+
+// seedCalendarEvent upserts a stored calendar_event with one matched contact.
+func (e *declineTestEnv) seedCalendarEvent(t *testing.T, accountID string, contactID uuid.UUID) repository.CalendarEvent {
+	t.Helper()
+	title := "decline-lock-event"
+	stored, err := e.calendarRepo.Upsert(e.ctx, repository.UpsertCalendarEventRequest{
+		GcalEventID:       "evt-" + uuid.NewString(),
+		GcalCalendarID:    "primary",
+		GoogleAccountID:   accountID,
+		Title:             &title,
+		StartTime:         time.Date(2026, 3, 1, 10, 0, 0, 0, time.UTC),
+		EndTime:           time.Date(2026, 3, 1, 11, 0, 0, 0, time.UTC),
+		Status:            "confirmed",
+		Attendees:         []repository.Attendee{},
+		MatchedContactIDs: []uuid.UUID{contactID},
+		SyncedAt:          time.Date(2026, 3, 1, 11, 0, 0, 0, time.UTC),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = e.calendarRepo.DeleteEventsByAccount(e.ctx, accountID) })
+	return *stored
+}
+
+func attendedPayload(t *testing.T, contactID uuid.UUID, eventID string, occurredAt time.Time) []byte {
+	t.Helper()
+	raw, err := events.Marshal(events.KindCalendarAttended, events.CalendarAttendedPayload{
+		Version: 1, ContactID: contactID, EventID: eventID, OccurredAt: occurredAt,
+	})
+	require.NoError(t, err)
+	return raw
+}
+
+func declinedPayload(t *testing.T, contactID uuid.UUID, eventID string, occurredAt time.Time) []byte {
+	t.Helper()
+	raw, err := events.Marshal(events.KindCalendarDeclined, events.CalendarDeclinedPayload{
+		Version: 1, ContactID: contactID, EventID: eventID, OccurredAt: occurredAt,
+	})
+	require.NoError(t, err)
+	return raw
+}
+
+func insertEvent(t *testing.T, ctx context.Context, e *declineTestEnv, eventRepo *repository.EventRepository, sourceID string, kind events.Kind, payload []byte) {
+	t.Helper()
+	env := &events.Envelope{
+		ID:         uuid.New(),
+		Source:     repository.InteractionSourceGCal,
+		SourceID:   sourceID,
+		Kind:       kind,
+		Payload:    payload,
+		ObservedAt: time.Date(2026, 3, 15, 11, 0, 0, 0, time.UTC),
+	}
+	require.NoError(t, pgx.BeginTxFunc(ctx, e.database.Pool, pgx.TxOptions{}, func(tx pgx.Tx) error {
+		return eventRepo.InsertEvent(ctx, tx, env)
+	}))
+}
+
+func hardDeleteEventBySource(t *testing.T, ctx context.Context, e *declineTestEnv, sourceIDs ...string) {
+	t.Helper()
+	eventRepo := repository.NewEventRepository(e.database.Queries)
+	for _, sid := range sourceIDs {
+		// Exact sourceID works as its own prefix.
+		_ = eventRepo.HardDeleteEventsBySourceAndSourceIDPrefix(ctx, repository.InteractionSourceGCal, sid)
+	}
+}

--- a/backend/tests/calendar_decline_removal_integration_test.go
+++ b/backend/tests/calendar_decline_removal_integration_test.go
@@ -9,7 +9,7 @@
 //     provenance-safety guards (creation value preserved, contact_by
 //     override preserved, NULL-out, per-direction, forward-writer parity)
 //   - decline replay idempotency
-//   - Decision-3a attended-after-delete guard (skip-when-deleted +
+//   - the attended-after-delete guard (skip-when-deleted +
 //     FOR SHARE / FOR UPDATE lock serialization)
 //   - the declined: SourceID namespace coexisting with the attended row
 package tests
@@ -446,8 +446,8 @@ func TestIntegration_CalendarDecline_ReplayIsNoOp(t *testing.T) {
 	assert.Nil(t, got.LastContacted)
 }
 
-// Test 8(a): Decision-3a skip-when-deleted — calendar.attended whose backing
-// calendar_event was deleted → no interaction written.
+// Test 8(a): attended-after-delete skip-when-deleted — calendar.attended whose
+// backing calendar_event was deleted → no interaction written.
 func TestIntegration_AttendedAfterDelete_SkipsInsert(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -472,7 +472,7 @@ func TestIntegration_AttendedAfterDelete_SkipsInsert(t *testing.T) {
 	require.ErrorIs(t, err, db.ErrNotFound)
 }
 
-// Test 8(b): Decision-3a lock-serialization — the attended FOR SHARE
+// Test 8(b): attended-after-delete lock-serialization — the attended FOR SHARE
 // conflicts with a concurrent FOR UPDATE NOWAIT (proving the lock is held),
 // without sleeps. Then the decline DELETE soft-deletes the just-written
 // interaction; and the reverse order (decline-first) skips the attended insert.

--- a/backend/tests/calendar_decline_removal_integration_test.go
+++ b/backend/tests/calendar_decline_removal_integration_test.go
@@ -195,7 +195,7 @@ func TestIntegration_CalendarDecline_NullOutWithCadenceFallback(t *testing.T) {
 	// Anchor the interaction AFTER creation so it wins forward-max and truly
 	// sources last_contacted + contact_by (a past occurredAt would be blocked
 	// by the created_at-based contact_by floor, masking the rollback path).
-	occurredAt := accelerated.GetCurrentTime().AddDate(0, 0, 30)
+	occurredAt := accelerated.GetCurrentTime().Truncate(time.Microsecond).AddDate(0, 0, 30)
 	// Contact created WITHOUT last_contacted so its only date source is the
 	// gcal interaction; contact_by initially derives from created_at.
 	contact := e.newContact(t, &cad, nil)
@@ -247,7 +247,9 @@ func TestIntegration_CalendarDecline_PerDirectionRollback(t *testing.T) {
 
 	cad := "weekly"
 	// Anchor after creation so the mutual sources contact_by via forward-max.
-	base := accelerated.GetCurrentTime()
+	// Truncate to microseconds so the Go-side anchors survive the
+	// timestamptz round-trip exactly (Postgres stores microsecond precision).
+	base := accelerated.GetCurrentTime().Truncate(time.Microsecond)
 	inbound := base.AddDate(0, 0, 10)
 	mutual := base.AddDate(0, 0, 20)
 	outbound := base.AddDate(0, 0, 30)
@@ -338,7 +340,7 @@ func TestIntegration_CalendarDecline_PreservesContactByOverride(t *testing.T) {
 
 	cad := "weekly"
 	// Anchor after creation so the interaction sources last_contacted.
-	occurredAt := accelerated.GetCurrentTime().AddDate(0, 0, 30)
+	occurredAt := accelerated.GetCurrentTime().Truncate(time.Microsecond).AddDate(0, 0, 30)
 	contact := e.newContact(t, &cad, nil)
 	sourceRef := uuid.NewString()
 	e.seedGcalInteraction(t, contact.ID, sourceRef, repository.InteractionDirectionMutual, occurredAt)
@@ -371,7 +373,7 @@ func TestIntegration_CalendarDecline_RollsBackContactByWhenNoOverride(t *testing
 
 	cad := "weekly"
 	// Anchor after creation so the interaction sources contact_by.
-	occurredAt := accelerated.GetCurrentTime().AddDate(0, 0, 30)
+	occurredAt := accelerated.GetCurrentTime().Truncate(time.Microsecond).AddDate(0, 0, 30)
 	contact := e.newContact(t, &cad, nil)
 	sourceRef := uuid.NewString()
 	e.seedGcalInteraction(t, contact.ID, sourceRef, repository.InteractionDirectionMutual, occurredAt)
@@ -404,7 +406,7 @@ func TestIntegration_CalendarDecline_ContactByForwardWriterParity(t *testing.T) 
 	e := newDeclineTestEnv(t, ctx)
 
 	cad := "monthly"
-	occurredAt := accelerated.GetCurrentTime().AddDate(0, 0, 30)
+	occurredAt := accelerated.GetCurrentTime().Truncate(time.Microsecond).AddDate(0, 0, 30)
 	contact := e.newContact(t, &cad, nil)
 	sourceRef := uuid.NewString()
 	e.seedGcalInteraction(t, contact.ID, sourceRef, repository.InteractionDirectionMutual, occurredAt)

--- a/backend/tests/calendar_decline_removal_integration_test.go
+++ b/backend/tests/calendar_decline_removal_integration_test.go
@@ -521,6 +521,100 @@ func TestIntegration_AttendedAfterDelete_LockSerialization(t *testing.T) {
 	assert.False(t, existsAfterDelete, "after the decline DELETE, the attended branch sees no row → skips the insert")
 }
 
+// TestIntegration_CalendarDecline_RecomputeSeesConcurrentInteraction is the
+// regression for the lock-then-aggregate ordering: the recompute acquires the
+// contact FOR UPDATE lock as a SEPARATE statement BEFORE reading the
+// interaction aggregate, so an interaction committed by a concurrent writer
+// (that held a conflicting contact lock) is NOT missed. Were the aggregate
+// folded into the FOR UPDATE statement, it would read the pre-wait snapshot
+// and roll last_contacted to NULL instead of to the concurrently-inserted
+// interaction.
+//
+// Deterministic interleave (no sleeps): tx A locks the contact + inserts a
+// new live inbound interaction (uncommitted); a goroutine starts the recompute
+// in tx B, which blocks on LockContactForDateRecompute; once B is provably
+// blocked (its lock probe from a third tx conflicts), commit A; B unblocks and
+// its aggregate must include A's interaction.
+func TestIntegration_CalendarDecline_RecomputeSeesConcurrentInteraction(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	ctx := context.Background()
+	e := newDeclineTestEnv(t, ctx)
+
+	base := accelerated.GetCurrentTime().Truncate(time.Microsecond)
+	mutualAt := base.AddDate(0, 0, 20)    // sources last_contacted, gets removed
+	concurrentAt := base.AddDate(0, 0, 5) // older inbound inserted concurrently
+	contact := e.newContact(t, nil, nil)
+
+	mutualRef := uuid.NewString()
+	e.seedGcalInteraction(t, contact.ID, mutualRef, repository.InteractionDirectionMutual, mutualAt)
+	// Soft-delete the sourcing mutual; without a remaining interaction the
+	// recompute would roll last_contacted to NULL.
+	require.NoError(t, e.interactionRepo.SoftDeleteInteraction(ctx, mustFindInteraction(t, e, contact.ID, mutualRef).ID))
+
+	// tx A: lock the contact (FOR UPDATE) + insert a new live inbound
+	// interaction, uncommitted. This is the concurrent writer.
+	concurrentRef := uuid.NewString()
+	t.Cleanup(func() {
+		_ = e.interactionRepo.HardDeleteInteractionsBySourceRefPrefix(ctx, repository.InteractionSourceGCal, concurrentRef)
+	})
+	txA, err := e.database.Pool.Begin(ctx)
+	require.NoError(t, err)
+	committedA := false
+	defer func() {
+		if !committedA {
+			_ = txA.Rollback(ctx)
+		}
+	}()
+	require.NoError(t, e.contactRepo.LockContactForDateRecomputeTx(ctx, txA, contact.ID))
+	ref := concurrentRef
+	_, err = e.interactionRepo.CreateInteractionTx(ctx, txA, repository.CreateInteractionRequest{
+		ContactID: contact.ID, Source: repository.InteractionSourceGCal, SourceRef: &ref,
+		OccurredAt: concurrentAt, Direction: repository.InteractionDirectionInbound,
+	})
+	require.NoError(t, err)
+
+	// Goroutine: run the recompute in its own tx B; it must block on the
+	// contact lock held by A.
+	recomputeDone := make(chan error, 1)
+	go func() {
+		recomputeDone <- pgx.BeginTxFunc(ctx, e.database.Pool, pgx.TxOptions{}, func(tx pgx.Tx) error {
+			return e.contactRepo.RecomputeContactDatesAfterDeleteTx(ctx, tx, contact.ID, mutualAt)
+		})
+	}()
+
+	// Prove B is blocked on the lock: a third tx's FOR UPDATE NOWAIT on the
+	// contact conflicts (A holds it). Also assert B has not finished yet.
+	require.Eventually(t, func() bool {
+		txC, err := e.database.Pool.Begin(ctx)
+		if err != nil {
+			return false
+		}
+		defer func() { _ = txC.Rollback(ctx) }()
+		conflict := e.contactRepo.TestLockContactForUpdateNoWaitTx(ctx, txC, contact.ID) != nil
+		return conflict
+	}, 5*time.Second, 20*time.Millisecond, "contact lock held by tx A (recompute tx B is blocked behind it)")
+	select {
+	case err := <-recomputeDone:
+		t.Fatalf("recompute completed before tx A committed (lock not acquired as a blocking statement): %v", err)
+	default:
+	}
+
+	// Commit A → its inbound interaction + lock release become visible. B
+	// unblocks and recomputes at a fresh snapshot that includes A's interaction.
+	require.NoError(t, txA.Commit(ctx))
+	committedA = true
+	require.NoError(t, <-recomputeDone, "recompute tx B completes after A commits")
+
+	got, err := e.contactRepo.GetContact(ctx, contact.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.LastContacted,
+		"recompute saw the concurrently-committed inbound interaction (would be NULL if the aggregate read the pre-lock snapshot)")
+	assert.Equal(t, concurrentAt.UTC(), got.LastContacted.UTC(),
+		"last_contacted rolls to the concurrently-inserted inbound interaction, not NULL")
+}
+
 // Test: declined: SourceID coexists with the attended row (P0-collision
 // regression). Publishing both an attended and a declined event for the same
 // internal UUID + contact yields TWO distinct event-log rows.

--- a/backend/tests/consumer_interaction_recorder_integration_test.go
+++ b/backend/tests/consumer_interaction_recorder_integration_test.go
@@ -201,9 +201,9 @@ func newConsumerTestEnv(t *testing.T, ctx context.Context) *consumerTestEnv {
 
 // seedCalendarEvent inserts a stored calendar_event matched to the contact
 // and returns its internal UUID. calendar.attended events carry this UUID as
-// their EventID/source_ref; the InteractionRecorder's Decision-3a lock check
-// requires the backing row to exist for the attended insert to proceed (in
-// production the attended publish always reads from calendar_event).
+// their EventID/source_ref; the InteractionRecorder's attended-after-delete
+// lock check requires the backing row to exist for the attended insert to
+// proceed (in production the attended publish always reads from calendar_event).
 func (e *consumerTestEnv) seedCalendarEvent(t *testing.T, contactID uuid.UUID) uuid.UUID {
 	t.Helper()
 	accountID := "attended-backing-" + uuid.NewString()
@@ -282,8 +282,8 @@ func TestIntegration_CalendarAttended_CutoverWritesInteraction(t *testing.T) {
 
 	contactID := env.newContact(t, "calendar-attended-cutover")
 	// EventID is the backing calendar_event's internal UUID (production
-	// reality); the recorder's Decision-3a lock check requires the row to
-	// exist for the attended insert to proceed.
+	// reality); the recorder's attended-after-delete lock check requires the
+	// row to exist for the attended insert to proceed.
 	eventIDStr := env.seedCalendarEvent(t, contactID).String()
 	// Publishers build SourceID as event-id ":" contact-id so one
 	// upstream event can fan out to multiple contacts without
@@ -518,9 +518,9 @@ func TestIntegration_MissingContact_ConsumerReturnsNotFound(t *testing.T) {
 	env := newConsumerTestEnv(t, ctx)
 
 	missingID := uuid.New()
-	// Seed a backing calendar_event so the Decision-3a lock check passes and
-	// the consumer reaches the contact-existence check (which is what this
-	// test exercises). The event's matched_contact_ids references the
+	// Seed a backing calendar_event so the attended-after-delete lock check
+	// passes and the consumer reaches the contact-existence check (which is
+	// what this test exercises). The event's matched_contact_ids references the
 	// not-yet-created contact (UUID array, not an FK).
 	eventIDStr := env.seedCalendarEvent(t, missingID).String()
 	sourceID := eventIDStr + ":" + missingID.String()

--- a/backend/tests/consumer_interaction_recorder_integration_test.go
+++ b/backend/tests/consumer_interaction_recorder_integration_test.go
@@ -180,7 +180,7 @@ func newConsumerTestEnv(t *testing.T, ctx context.Context) *consumerTestEnv {
 	stagingRegistry := repository.NewStagingProcessorRegistry(map[string]repository.StagingProcessor{
 		repository.InteractionSourceTelegram: repository.NewTelegramStagingProcessor(telegramMessageRepo),
 	})
-	recorder = consumer.NewInteractionRecorder(contactService, stagingRegistry, bus, cadenceUpdater, nil)
+	recorder = consumer.NewInteractionRecorder(contactService, stagingRegistry, bus, cadenceUpdater, nil, repository.NewCalendarEventRepository(database.Queries))
 
 	manualHandler := service.NewManualInteractionHandler(database.Pool, bus, recorder)
 

--- a/backend/tests/consumer_interaction_recorder_integration_test.go
+++ b/backend/tests/consumer_interaction_recorder_integration_test.go
@@ -33,6 +33,7 @@ type consumerTestEnv struct {
 	bus             *events.Bus
 	contactRepo     *repository.ContactRepository
 	interactionRepo *repository.InteractionRepository
+	calendarRepo    *repository.CalendarEventRepository
 	recorder        *consumer.InteractionRecorder
 	contactService  *service.ContactService
 	manualHandler   *service.ManualInteractionHandler
@@ -191,10 +192,37 @@ func newConsumerTestEnv(t *testing.T, ctx context.Context) *consumerTestEnv {
 		bus:             bus,
 		contactRepo:     contactRepo,
 		interactionRepo: interactionRepo,
+		calendarRepo:    repository.NewCalendarEventRepository(database.Queries),
 		recorder:        recorder,
 		contactService:  contactService,
 		manualHandler:   manualHandler,
 	}
+}
+
+// seedCalendarEvent inserts a stored calendar_event matched to the contact
+// and returns its internal UUID. calendar.attended events carry this UUID as
+// their EventID/source_ref; the InteractionRecorder's Decision-3a lock check
+// requires the backing row to exist for the attended insert to proceed (in
+// production the attended publish always reads from calendar_event).
+func (e *consumerTestEnv) seedCalendarEvent(t *testing.T, contactID uuid.UUID) uuid.UUID {
+	t.Helper()
+	accountID := "attended-backing-" + uuid.NewString()
+	title := "attended-backing-event"
+	stored, err := e.calendarRepo.Upsert(e.ctx, repository.UpsertCalendarEventRequest{
+		GcalEventID:       "evt-" + uuid.NewString(),
+		GcalCalendarID:    "primary",
+		GoogleAccountID:   accountID,
+		Title:             &title,
+		StartTime:         time.Date(2026, 4, 10, 11, 0, 0, 0, time.UTC),
+		EndTime:           time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC),
+		Status:            "confirmed",
+		Attendees:         []repository.Attendee{},
+		MatchedContactIDs: []uuid.UUID{contactID},
+		SyncedAt:          time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = e.calendarRepo.DeleteEventsByAccount(e.ctx, accountID) })
+	return stored.ID
 }
 
 func (e *consumerTestEnv) newContact(t *testing.T, name string) uuid.UUID {
@@ -253,7 +281,10 @@ func TestIntegration_CalendarAttended_CutoverWritesInteraction(t *testing.T) {
 	env := newConsumerTestEnv(t, ctx)
 
 	contactID := env.newContact(t, "calendar-attended-cutover")
-	eventIDStr := uuid.NewString()
+	// EventID is the backing calendar_event's internal UUID (production
+	// reality); the recorder's Decision-3a lock check requires the row to
+	// exist for the attended insert to proceed.
+	eventIDStr := env.seedCalendarEvent(t, contactID).String()
 	// Publishers build SourceID as event-id ":" contact-id so one
 	// upstream event can fan out to multiple contacts without
 	// colliding on the event table's (source, source_id) dedupe.
@@ -303,7 +334,7 @@ func TestIntegration_CalendarAttended_TitlePreservedInInteraction(t *testing.T) 
 	env := newConsumerTestEnv(t, ctx)
 
 	contactID := env.newContact(t, "calendar-attended-title")
-	eventIDStr := uuid.NewString()
+	eventIDStr := env.seedCalendarEvent(t, contactID).String()
 	sourceID := eventIDStr + ":" + contactID.String()
 	occurredAt := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
 	title := "Quarterly sync with Alice"
@@ -341,7 +372,7 @@ func TestIntegration_CalendarAttended_Replay(t *testing.T) {
 	env := newConsumerTestEnv(t, ctx)
 
 	contactID := env.newContact(t, "calendar-attended-replay")
-	eventIDStr := uuid.NewString()
+	eventIDStr := env.seedCalendarEvent(t, contactID).String()
 	sourceID := eventIDStr + ":" + contactID.String()
 	occurredAt := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
 
@@ -487,7 +518,11 @@ func TestIntegration_MissingContact_ConsumerReturnsNotFound(t *testing.T) {
 	env := newConsumerTestEnv(t, ctx)
 
 	missingID := uuid.New()
-	eventIDStr := uuid.NewString()
+	// Seed a backing calendar_event so the Decision-3a lock check passes and
+	// the consumer reaches the contact-existence check (which is what this
+	// test exercises). The event's matched_contact_ids references the
+	// not-yet-created contact (UUID array, not an FK).
+	eventIDStr := env.seedCalendarEvent(t, missingID).String()
 	sourceID := eventIDStr + ":" + missingID.String()
 	occurredAt := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
 

--- a/backend/tests/sole_writer_static_test.go
+++ b/backend/tests/sole_writer_static_test.go
@@ -64,6 +64,7 @@ var cadenceWritingSymbols = map[string]struct{}{
 	"UpdateContactCadenceUnconditional": {},
 	"UpdateContactBy":                   {},
 	"UpdateContactByTx":                 {},
+	"WriteContactDatesAfterDelete":      {},
 	// Include CreateContact + UpdateContact so a future regression
 	// that adds a cadence column to either query is caught. Selector
 	// matching alone would flag every service-layer wrapper caller;
@@ -117,6 +118,15 @@ var allowedCallSites = map[string]string{
 	"internal/repository/contact.go:UpdateContactResponseFieldsTx":     "legacy wrapper (no production callers post-cutover)",
 	"internal/repository/contact.go:UpdateContactMutualFields":         "legacy wrapper (no production callers post-cutover)",
 	"internal/repository/contact.go:UpdateContactMutualFieldsTx":       "legacy wrapper (no production callers post-cutover)",
+
+	// Removal-path recompute after soft-deleting a declined calendar
+	// interaction: surgical backward correction keyed on the deleted
+	// interaction's occurred_at, contact_by computed via
+	// cadence.CalculateContactBy to match the forward writer; distinct
+	// from CadenceUpdater's additive forward path. recomputeContactDatesAfterDelete
+	// is the shared body that calls WriteContactDatesAfterDelete; the two
+	// exported wrappers (RecomputeContactDatesAfterDelete[Tx]) delegate to it.
+	"internal/repository/contact.go:recomputeContactDatesAfterDelete": "removal-path recompute (declined calendar interaction); distinct from CadenceUpdater forward path",
 }
 
 // TestCadenceSoleWriter_OnlyAllowedFilesCallCadenceSQL walks the Go AST

--- a/backend/tests/test_event_bus_harness_test.go
+++ b/backend/tests/test_event_bus_harness_test.go
@@ -100,7 +100,7 @@ func setupTestEventBus(
 	stagingRegistry := repository.NewStagingProcessorRegistry(map[string]repository.StagingProcessor{
 		repository.InteractionSourceTelegram: repository.NewTelegramStagingProcessor(telegramMessageRepo),
 	})
-	recorder := consumer.NewInteractionRecorder(contactService, stagingRegistry, bus, cadenceUpdater, nil)
+	recorder := consumer.NewInteractionRecorder(contactService, stagingRegistry, bus, cadenceUpdater, nil, repository.NewCalendarEventRepository(database.Queries))
 	// Fill the shim's real worker now that bus + recorder exist.
 	shim.real = consumer.NewInteractionRecorderWorker(bus, database.Pool, recorder, nil)
 
@@ -180,7 +180,7 @@ func setupTestEventBusWithRematch(
 	stagingRegistry2 := repository.NewStagingProcessorRegistry(map[string]repository.StagingProcessor{
 		repository.InteractionSourceTelegram: repository.NewTelegramStagingProcessor(telegramMessageRepo),
 	})
-	recorder := consumer.NewInteractionRecorder(contactService, stagingRegistry2, bus, cadenceUpdater, nil)
+	recorder := consumer.NewInteractionRecorder(contactService, stagingRegistry2, bus, cadenceUpdater, nil, repository.NewCalendarEventRepository(database.Queries))
 	interactionShim.real = consumer.NewInteractionRecorderWorker(bus, database.Pool, recorder, nil)
 
 	rematchDispatcher := consumer.NewRematchDispatcher(rematchSvc)


### PR DESCRIPTION
Closes #366

## Problem

`CalendarSyncProvider.processEvent` early-returned for any event whose `user_response != "accepted"` without touching a previously-stored copy. So when an accepted event later transitioned to declined / tentative / needsAction (or the user was dropped as an attendee, or the organizer cancelled), the stale `calendar_event` row lived on, and once its start time passed `updateLastContactedForPastEvents` published `calendar.attended` and the `InteractionRecorder` wrote a false "attended" interaction. `calendar_event` has no `deleted_at` column, so removal is a hard `DELETE`.

## Approach

The CRM stores a `calendar_event` row only while the user has the event accepted and it is not cancelled. Any sync that observes the event in any other state removes the stored copy AND the interactions derived from it, then recomputes the affected contact's date columns.

- **Gate-before-parse `processEvent` restructure.** The keep/remove decision (`userResponse == "accepted" && status != "cancelled"`) is now evaluated BEFORE time parsing and the all-day skip. Incremental-sync deltas for cancelled/declined events can arrive as a minimal stub without `Start.DateTime`/`End.DateTime`, so the remove branch must not depend on inbound times. The keep path is byte-for-byte identical to before (accepted meetings always carry `DateTime`).
- **Cutover remove branch: publish-before-delete in one tx.** For a previously-stored event observed declined/cancelled, the branch opens a tx on the provider's pool and, in that one tx, publishes one `calendar.declined` per matched contact (carrying the stored row's internal `calendar_event.ID` UUID, so the consumer's `source_ref` lookup matches the attended interaction), then deletes the `calendar_event`. A publish failure rolls back the whole tx (event rows + delete) and the next sync re-runs cleanly. The `declined:` SourceID prefix keeps the decline event-log row in a disjoint namespace from the `calendar.attended` row, so both event rows and both consumers coexist (without the prefix, the event-log `(source, source_id)` unique would treat the decline as a duplicate of the attended row and silently drop it).
- **New `KindCalendarDeclined` consumer.** `CalendarDeclineHandler` soft-deletes the derived gcal interaction (`FindBySourceRefTx` on the internal UUID) and surgically recomputes the contact's date columns. Routed via `consumerJobsForKind` with `MaxAttempts=5`; replay-safe (a re-delivered decline finds the interaction already soft-deleted → no-op).
- **Per-direction, provenance-safe contact-date recompute.** A timestamp column is touched ONLY when the removed interaction was demonstrably its source (`column == deleted_occurred_at`); it then rolls to `MAX(occurred_at)` over the contact's remaining live interactions of that direction subset (`last_outreach_at` ← outbound/mutual; `last_contacted`/`last_interaction_at`/`last_response_at` ← inbound/mutual), or to NULL when none remain. This honors "NULL-out when none remain" while preserving a creation-set `last_contacted` (which has no backing interaction) and a Todoist/user `contact_by` override. `contact_by` is decided in Go via `cadence.CalculateContactBy` (environment-aware) — matching the forward writer exactly — and re-derived from `created_at` when `last_contacted` rolls to NULL so a cadence contact is never dropped from due tracking. The recompute query takes a `FOR UPDATE` lock on the contact row, held across the write, to serialize against any concurrent cadence writer.
- **`FOR SHARE` lock closes the attended-after-decline race deterministically.** The `InteractionRecorder` calendar.attended branch does a locking read (`SELECT ... FOR SHARE`) of the backing `calendar_event` before inserting; if the row is already gone (a decline `DELETE` committed first), it skips the insert, so no false interaction survives. The decline `DELETE` and the attended `FOR SHARE` take conflicting row locks, so neither interleaving can leave a surviving false interaction — no new schema, no reliance on timing.
- **Off-mode deferral.** When the event bus / pool is unavailable (emergency `off` mode), the remove branch marks the stored row `status='cancelled'` instead of deleting. That excludes it from re-firing `calendar.attended` and from contact-facing reads without losing the cleanup handle for an already-recorded interaction; the cutover resume re-observes the row and finishes the cleanup.

The recompute is the documented exception to the "CadenceUpdater is sole writer" invariant (it is a removal path, not the additive `interaction.recorded` forward path), inventoried in the `sole_writer_static_test.go` allowlist.

## Tests

- In-package `google` (mock-based, run under `go test -short`): off-mode mark-cancelled, never-stored no-op, cancelled-without-`DateTime` gate-before-parse, tentative; decline publisher envelope shape + `declined:` prefix + per-contact SourceID.
- Cross-package integration (`backend/tests/`, run under `make test-integration-fast`): consumer-direct soft-delete + recompute; per-column recompute incl. NULL-out, per-direction, creation-value-preserved, contact_by-override-preserved, rollback, forward-writer parity; replay no-op; the attended-after-delete skip + `FOR SHARE`/`FOR UPDATE NOWAIT` lock serialization; the declined/attended event-log coexistence; and an end-to-end cutover test that drives the real `processEvent` remove branch (real bus + pool + live decline consumer) plus a publish-failure test proving publish-before-delete leaves the `calendar_event` row intact.

## Note on the contact_by override-guard comparison

The override guard (`contactByMatchesStoredDate`) intentionally uses the forward writer's `cadence.DateOnly` / `time.Local` frame rather than a UTC frame, because that is exactly what the forward writer stores `contact_by` as, and it mirrors the existing `contact_by` parity tests. It inherits the codebase-wide UTC-server-TZ assumption (server runs in a TZ where `DateOnly` midnight and UTC midnight share a calendar day); documented here rather than changed in code.

## Out of scope (follow-ups)

- Events hard-deleted upstream (vanish from Google entirely, not declined/cancelled): capturing them reliably needs `ShowDeleted(true)` and is a separate change.
- Backfill of already-stranded rows from before this fix (hand-cleaned per the issue): a one-shot reconciliation is a deliberate follow-up. No new stranding can occur once this ships.