### PR TITLE
feat(mac-daemon): 30-day identifier-scoped backwards scan (messages + phone_calls)

### DIFF
--- a/mac-daemon/README.md
+++ b/mac-daemon/README.md
@@ -299,6 +299,18 @@ crm-mac start
 
 `--since` accepts a simple duration: `30d`, `12h`, `60m`, `3600s`.
 
+### `crm-mac call-history scan --identifier <handle> [--since 30d]`
+
+Queue a one-shot backwards scan over the Phone & FaceTime call history for a specific phone/email handle — the call-history analogue of `messages scan`.
+
+```bash
+crm-mac stop
+crm-mac call-history scan --identifier "+1-555-123-4567" --since 30d
+crm-mac start
+```
+
+`--since` accepts the same simple durations as `messages scan` (`30d`, `12h`, `60m`, `3600s`). The queued scan survives a daemon restart (it persists in the phone_calls cursor) and is drained on the next tick. `crm-mac status` shows the pending count under `phone_calls → pending_scans`. Event-log `(source, source_id)` dedup absorbs any overlap with natural backfill.
+
 ### `crm-mac configure anarlog ...`
 
 Configure the Anarlog notes reader sources. Both `anarlog_humans` and `anarlog_sessions` share a single root path (typically `~/Documents/notes/meetings`) and each has its own enable flag — both default false. The daemon must be stopped for all mutations.
@@ -360,6 +372,8 @@ The daemon acquires a POSIX advisory lock on `~/Library/Application Support/crm-
 
 ## Limitations (v1)
 
-- **Daemon-down + contact added → no auto-scan.** The daemon's known-identifiers cache hash detects offline contact-list changes but does NOT auto-queue a 30-day scan for every new identifier. Run `crm-mac messages scan --identifier <X>` manually if you want backfill for a specific newly-added contact.
+- **Automatic 30-day identifier-scoped backwards scan.** When a contact is added (online OR while the daemon was offline), both the messages and phone_calls sources auto-queue a 30-day backwards scan for each genuinely-new identifier and forward any matches. Offline additions are detected via a precise per-source diff against a persisted baseline (`current − persisted`), so ONLY real additions are scanned — never the whole identifier set. The first restart after upgrading to this build is a baseline-establishing event: it seeds the per-source baseline and enqueues zero scans; subsequent restarts diff against it. `crm-mac messages scan` / `crm-mac call-history scan` remain available for targeted manual scans.
+  - **Persisted-baseline at-rest footprint.** To compute the offline diff, the daemon persists each source's canonical known-identifier set (E.164 phones / lowercased emails — the same minimal representation already held in memory) into the protected `state.json`. No new identifier data leaves the Mac; this is local state only.
+  - **Accepted single-writer trade.** The persisted baseline is written by a single writer (the heartbeat refresher), and it never advances past an identifier whose scan isn't yet durable — so a genuinely-new identifier's scan is never lost across a crash. The deliberate residual: if the daemon restarts in the narrow window after an identifier is scanned online but before the next heartbeat persists the advanced baseline, that identifier may be re-enqueued for ONE redundant scan. It is bounded (one extra scan) and fully absorbed by the Pi's `(source, source_id)` event-log dedup — wasted work only, never a duplicate interaction.
 - **Outbound group attribution.** For outbound group messages the daemon attributes the outreach to the first non-self handle by `chat_handle_join.ROWID` order. v1 simplification: every outbound group message attributes to the same arbitrary peer.
 - **Outbound messages currently not emitted.** The reader's fetch query joins on `message.handle_id`, which is NULL for outbound rows in chat.db.

--- a/mac-daemon/Sources/CRMMacCore/DaemonState.swift
+++ b/mac-daemon/Sources/CRMMacCore/DaemonState.swift
@@ -49,6 +49,18 @@ public struct DaemonState: Codable, Equatable, Sendable {
     /// Additive Codable field — defaults to 0 for existing
     /// `state.json` files written before this field existed.
     public var notificationMutationSequence: UInt64
+    /// Per-source persisted known-identifiers baseline, keyed by source
+    /// id (`"messages"`, `"phone_calls"`). Written ONLY by the
+    /// heartbeat refresher; read at daemon start to seed each source's
+    /// in-memory diff baseline so an offline restart enqueues 30-day
+    /// scans for the precise `current − persisted` delta only.
+    ///
+    /// Additive Codable field — defaults to nil for existing
+    /// `state.json` files written before this field existed. A nil map,
+    /// OR an absent key for a given source, is that source's
+    /// upgrade-boundary signal: the first heartbeat seeds the baseline
+    /// and enqueues NO scans.
+    public var knownIdentifierBaselines: [String: KnownIdentifiersBaseline]?
 
     public init(
         schemaVersion: Int = 1,
@@ -57,7 +69,8 @@ public struct DaemonState: Codable, Equatable, Sendable {
         lastKnownPiProtocolVersion: Int32? = nil,
         sources: [String: SourceState] = [:],
         pendingOrphanNotifications: [PendingOrphanNotification] = [],
-        notificationMutationSequence: UInt64 = 0
+        notificationMutationSequence: UInt64 = 0,
+        knownIdentifierBaselines: [String: KnownIdentifiersBaseline]? = nil
     ) {
         self.schemaVersion = schemaVersion
         self.hostID = hostID
@@ -66,6 +79,7 @@ public struct DaemonState: Codable, Equatable, Sendable {
         self.sources = sources
         self.pendingOrphanNotifications = pendingOrphanNotifications
         self.notificationMutationSequence = notificationMutationSequence
+        self.knownIdentifierBaselines = knownIdentifierBaselines
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -76,6 +90,7 @@ public struct DaemonState: Codable, Equatable, Sendable {
         case sources
         case pendingOrphanNotifications
         case notificationMutationSequence
+        case knownIdentifierBaselines
     }
 
     public init(from decoder: Decoder) throws {
@@ -92,6 +107,9 @@ public struct DaemonState: Codable, Equatable, Sendable {
             forKey: .pendingOrphanNotifications) ?? []
         self.notificationMutationSequence = try c.decodeIfPresent(
             UInt64.self, forKey: .notificationMutationSequence) ?? 0
+        self.knownIdentifierBaselines = try c.decodeIfPresent(
+            [String: KnownIdentifiersBaseline].self,
+            forKey: .knownIdentifierBaselines)
     }
 }
 

--- a/mac-daemon/Sources/CRMMacCore/KnownIdentifiersBaseline.swift
+++ b/mac-daemon/Sources/CRMMacCore/KnownIdentifiersBaseline.swift
@@ -1,0 +1,50 @@
+// KnownIdentifiersBaseline — the persisted shape of one source's
+// known-identifiers baseline.
+//
+// On daemon restart the composition root reads each source's baseline
+// from DaemonState.knownIdentifierBaselines and seeds the in-memory
+// KnownIdentifiersCache diff baseline. The heartbeat refresher is the
+// SOLE writer of the persisted baseline; it advances the baseline to
+// the observed known set MINUS any identifier still owed a durable scan
+// enqueue (see KnownIdentifiersCache.persistableBaseline).
+//
+// Storing the canonical handle list lets the daemon compute a PRECISE
+// `current − persisted` delta after an offline restart and enqueue a
+// 30-day backwards scan ONLY for genuine additions — never the naive
+// "set changed → re-scan everything" replay storm.
+//
+// PII-at-rest footprint: the canonical handle list is the minimal
+// representation the cache already holds in memory; it lives in the
+// same protected state.json as the rest of the daemon state.
+import Foundation
+
+public struct KnownIdentifiersBaseline: Codable, Equatable, Sendable {
+    /// Sorted canonical handle list (E.164 phones / lowercased emails).
+    public var canonical: [String]
+
+    /// When this source's baseline was first established. Observability
+    /// only — not consumed by the diff logic. Preserved across refresher
+    /// writes so it records the first-seed time, not the last update.
+    public var establishedAt: Date
+
+    public init(canonical: [String], establishedAt: Date) {
+        self.canonical = canonical
+        self.establishedAt = establishedAt
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case canonical
+        case establishedAt = "established_at"
+    }
+
+    /// Materialize the canonical list as an unordered Set for diffing.
+    public func toSet() -> Set<String> {
+        Set(canonical)
+    }
+
+    /// Build a baseline from an unordered set, sorting the canonical
+    /// list so the persisted JSON is deterministic across runs.
+    public static func from(set: Set<String>, establishedAt: Date) -> KnownIdentifiersBaseline {
+        KnownIdentifiersBaseline(canonical: set.sorted(), establishedAt: establishedAt)
+    }
+}

--- a/mac-daemon/Sources/CRMMacCore/KnownIdentifiersBaseline.swift
+++ b/mac-daemon/Sources/CRMMacCore/KnownIdentifiersBaseline.swift
@@ -48,3 +48,43 @@ public struct KnownIdentifiersBaseline: Codable, Equatable, Sendable {
         KnownIdentifiersBaseline(canonical: set.sorted(), establishedAt: establishedAt)
     }
 }
+
+/// Persist each consumer's writable baseline into
+/// DaemonState.knownIdentifierBaselines (single writer). For each
+/// consumer it reads `cache.persistableBaseline` — the observed known
+/// set MINUS identifiers still owed a durable scan enqueue — and plain-
+/// assigns it when it differs from the persisted value. The write is
+/// idempotent (no-op when unchanged) and preserves `establishedAt`
+/// across writes so it records the first-seed time, not the last update.
+///
+/// This is the heartbeat refresher's persist step. It lives here, called
+/// by both the production refresher and its focused test, so the test
+/// exercises the real code path rather than a replica.
+public func persistKnownIdentifierBaselines(
+    cache: KnownIdentifiersCache,
+    consumers: Set<SourceID>,
+    mutator: StateMutator,
+    now: @Sendable () -> Date
+) async throws {
+    for consumer in consumers {
+        // Capture the immutable observed set OUTSIDE the synchronous
+        // mutate closure (no actor read in-closure).
+        guard let observed = await cache.persistableBaseline(for: consumer) else {
+            continue
+        }
+        let key = consumer.rawValue
+        let sorted = observed.sorted()
+        let seedTime = now()
+        try await mutator.mutate { state in
+            var map = state.knownIdentifierBaselines ?? [:]
+            let existing = map[key]
+            // No-op when unchanged (idempotent).
+            if existing?.canonical == sorted { return }
+            map[key] = KnownIdentifiersBaseline(
+                canonical: sorted,
+                // Preserve the first-seed time across writes.
+                establishedAt: existing?.establishedAt ?? seedTime)
+            state.knownIdentifierBaselines = map
+        }
+    }
+}

--- a/mac-daemon/Sources/CRMMacCore/KnownIdentifiersCache.swift
+++ b/mac-daemon/Sources/CRMMacCore/KnownIdentifiersCache.swift
@@ -1,50 +1,98 @@
-// KnownIdentifiersCache — in-memory canonicalized handle set + diff.
+// KnownIdentifiersCache — in-memory canonicalized handle set + per-
+// source diff.
 //
 // The cache stores normalized phone+email identifiers received from
 // the Pi via GET /api/v1/host/:id/known-identifiers. It serves two
 // purposes:
 //
-//   1. Sender filter — every chat.db row goes through `contains` before
-//      payload shaping; non-members are dropped. This is an OPTIMIZATION
-//      (per spec §2 + the spec), not a contract:
-//      the Pi's handleRawMessage still accepts events with no matching
-//      contact_method, staging the row with NULL contact_id. Daemon-side
-//      filter just reduces noise.
+//   1. Sender filter — every chat.db / CallHistoryDB row goes through
+//      `contains` before payload shaping; non-members are dropped. This
+//      is an OPTIMIZATION (the Pi's ingest still accepts events with no
+//      matching contact_method, staging the row with NULL contact_id);
+//      the daemon-side filter just reduces noise.
 //
 //   2. Newly-known-contact detection — every heartbeat tick refreshes
-//      the cache; `diff` reports identifiers that appeared since the
-//      last fetch so the messages plugin can enqueue a 30-day backwards
-//      scan for each.
+//      the cache; each source's `drainNewlyAdded(for:)` reports
+//      identifiers that appeared since that source last drained so the
+//      source plugin can enqueue a 30-day backwards scan for each.
 //
-// Restart semantics: the cache is in-memory; on daemon
-// restart it starts empty and is repopulated by the first heartbeat
-// fetch. To avoid replaying the full set as "new" on every restart, the
-// daemon persists the SHA-256 hash of the sorted canonical set inside
-// the cursor JSON. On restart, the freshly-fetched set's hash is
-// compared to the persisted one; if equal -> normal operation, if
-// different -> log info, do NOT auto-queue scans for every member.
-// The operator runs `crm-mac messages scan --identifier <X>` manually
-// for any contacts added during downtime.
+// Per-source design. The cache is SHARED across both messages and
+// phone_calls (one instance, constructed at the composition root). Each
+// source has its own DIFF baseline + newly-added bucket so one source
+// draining a newly-added identifier does NOT empty the other's view.
+//
+// Restart / persistence semantics. The in-memory state is rebuilt each
+// process start. To enqueue 30-day scans for ONLY the identifiers added
+// while the daemon was offline (never the whole set), each source's
+// diff baseline is seeded at construction from the persisted
+// DaemonState.knownIdentifierBaselines. The heartbeat refresher is the
+// SOLE writer of the persisted baseline; it reads `persistableBaseline`
+// (the observed set minus identifiers still owed a durable scan) and
+// plain-assigns it. The source tick NEVER writes the persisted
+// baseline — it only clears an identifier's "owed" status via the
+// drain → commit → confirmDrained flow so the next refresher persist
+// can include it.
+//
+// Baseline tri-state (per source). A source's diff baseline is either
+// ABSENT (key missing → `noBaseline` → seed on first fetch, enqueue
+// nothing) or PRESENT (a Set, possibly empty → diff precisely). A
+// present-but-empty baseline is a REAL empty baseline (an empty CRM),
+// NOT the same as absent: a later identifier appearing offline diffs
+// against `∅` and IS scanned.
 import Foundation
 import CryptoKit
 
 public actor KnownIdentifiersCache {
+    /// The current known set (drives `contains` sender filter).
     private var canonicalSet: Set<String> = []
-    /// Identifiers added by the last `replace(with:)` call.  The
-    /// MessagesSourcePlugin reads this on its next tick to queue a
-    /// 30-day backwards scan for each newly-added contact (per spec
-    /// §"newly-known scan trigger").
-    private var pendingNewlyAdded: Set<String> = []
+    /// True once the FIRST `replace(with:)` has run, regardless of
+    /// whether the fetched set was empty. Distinguishes "no fetch yet"
+    /// from "fetched an empty set" for the Phase-B scan-readiness gate.
+    private var fetched: Bool = false
+    /// The fixed set of consumers (source ids) passed at construction.
+    private let consumers: Set<SourceID>
+    /// Each consumer's DIFF baseline. Key ABSENT = `noBaseline` (seed
+    /// on first fetch, no scans). Key PRESENT (possibly empty Set) =
+    /// real baseline (diff precisely). Trails the latest fetch after
+    /// the first fetch for an established consumer.
+    private var baseline: [SourceID: Set<String>] = [:]
+    /// Per-consumer newly-added bucket — identifiers observed-as-new but
+    /// not yet drained by that consumer's source tick.
+    private var pendingNewlyAdded: [SourceID: Set<String>] = [:]
+    /// Per-consumer scan-queue-drain holding set. `drainNewlyAdded`
+    /// MOVES the bucket here; `confirmDrained` clears it after the
+    /// Phase-A cursor commit; `returnInFlight` rolls it back on commit
+    /// failure. Together `pendingNewlyAdded[S] ∪ inFlight[S]` = S's
+    /// "owed scans", which `persistableBaseline` subtracts.
+    private var inFlight: [SourceID: Set<String>] = [:]
 
-    public init(initial: Set<String> = []) {
+    /// Construct the cache. `consumers` + `baselines` are fixed at
+    /// construction (the async composition root). Plugins do NOT
+    /// self-register. A source absent from `baselines` starts
+    /// `noBaseline` (seed-on-first-fetch, upgrade boundary).
+    public init(
+        initial: Set<String> = [],
+        baselines: [SourceID: Set<String>] = [:],
+        consumers: Set<SourceID> = []
+    ) {
         self.canonicalSet = initial
+        self.consumers = consumers
+        self.baseline = baselines
     }
 
-    /// True when no fetch has populated the cache yet. The messages tick
-    /// must skip emitting work in that case (sender filter would drop
-    /// everything; we want at-most-one wasted tick on cold start).
+    /// True when no fetch has populated the cache yet. The row-emitting
+    /// batches skip when this is false (sender filter would drop
+    /// everything; at-most-one wasted tick on cold start).
     public var isPopulated: Bool {
         !canonicalSet.isEmpty
+    }
+
+    /// True once the first `replace(with:)` has run (even of an empty
+    /// set). Gates Phase-B scan execution: a not-yet-fetched cache must
+    /// NOT adjudicate (drop) pending scans, but an empty-but-fetched
+    /// CRM must.
+    public var hasFetched: Bool {
+        fetched
     }
 
     /// O(1) membership check.
@@ -57,45 +105,110 @@ public actor KnownIdentifiersCache {
         canonicalSet
     }
 
-    /// Replace the cache contents and return the set of new
-    /// identifiers (newly-fetched - previously-cached). The previous
-    /// contents are dropped. Identifiers removed from the new fetch
-    /// (Pi-side deletions) are NOT returned — diff is one-way (only
-    /// additions), matching the spec's "trigger 30-day scan on new
-    /// contact" semantics.
+    /// Replace the cache contents and update each consumer's diff
+    /// baseline + newly-added bucket.
     ///
-    /// Side effect: appends `added` into the internal newly-added
-    /// queue so the messages plugin can drain it on its next tick.
-    /// On first call (cache was empty), the entire `fetched` set is
-    /// returned but NOT appended to the queue — the initial population
-    /// must not enqueue a scan for every existing contact (that's
-    /// what backfill is for; the spec cold
-    /// start).
-    @discardableResult
-    public func replace(with fetched: Set<String>) -> Set<String> {
-        let wasEmpty = canonicalSet.isEmpty
-        let added = fetched.subtracting(canonicalSet)
-        canonicalSet = fetched
-        if !wasEmpty {
-            pendingNewlyAdded.formUnion(added)
+    /// For each consumer S:
+    ///   - If `baseline[S]` is ABSENT (`noBaseline`): seed
+    ///     `baseline[S] = fetched` (even if empty) and enqueue NOTHING.
+    ///     The upgrade boundary / first fetch never replays the set.
+    ///   - Else (present, possibly empty): `added = fetched − baseline[S]
+    ///     − inFlight[S]` (excluding in-flight so a drained-but-not-yet-
+    ///     confirmed identifier isn't re-added to the bucket); append
+    ///     `added` to S's bucket; then `baseline[S] = fetched` (the diff
+    ///     baseline trails the latest fetch — additions AND removals
+    ///     fold in for the NEXT diff).
+    public func replace(with fetchedSet: Set<String>) {
+        for consumer in consumers {
+            if baseline[consumer] == nil {
+                // noBaseline → seed, enqueue nothing.
+                baseline[consumer] = fetchedSet
+            } else {
+                let added = fetchedSet
+                    .subtracting(baseline[consumer] ?? [])
+                    .subtracting(inFlight[consumer] ?? [])
+                if !added.isEmpty {
+                    pendingNewlyAdded[consumer, default: []].formUnion(added)
+                }
+                baseline[consumer] = fetchedSet
+            }
         }
-        return added
+        canonicalSet = fetchedSet
+        fetched = true
     }
 
-    /// Drain the newly-added queue. The messages plugin calls this at
-    /// the top of each tick to schedule scans for contacts added since
-    /// the last drain.
-    public func drainNewlyAdded() -> Set<String> {
-        let drained = pendingNewlyAdded
-        pendingNewlyAdded.removeAll()
+    /// Drain consumer `id`'s newly-added bucket NON-DESTRUCTIVELY:
+    /// MOVES it into `inFlight[id]` and returns it. The source tick
+    /// enqueues a scan per returned identifier and commits the cursor;
+    /// on success it calls `confirmDrained(for:)`, on failure
+    /// `returnInFlight(for:)`. Empty if the consumer was just seeded
+    /// (`noBaseline`) this cycle.
+    public func drainNewlyAdded(for id: SourceID) -> Set<String> {
+        let drained = pendingNewlyAdded[id] ?? []
+        pendingNewlyAdded[id] = []
+        if !drained.isEmpty {
+            inFlight[id, default: []].formUnion(drained)
+        }
         return drained
+    }
+
+    /// Clear consumer `id`'s in-flight holding set after its Phase-A
+    /// cursor commit succeeds. The drained identifiers are now durably
+    /// enqueued, so they leave the "owed" set and become eligible for
+    /// the next refresher persist. NO baseline argument, NO baseline
+    /// side effect.
+    public func confirmDrained(for id: SourceID) {
+        let confirmed = inFlight[id] ?? []
+        inFlight[id] = []
+        // Defensive: an identifier re-detected as new between drain and
+        // confirm could be sitting in pendingNewlyAdded; subtract the
+        // confirmed set so it isn't re-scanned redundantly. (The
+        // refresher's `replace` already excludes inFlight, so this is
+        // belt-and-suspenders.)
+        if !confirmed.isEmpty, let bucket = pendingNewlyAdded[id], !bucket.isEmpty {
+            pendingNewlyAdded[id] = bucket.subtracting(confirmed)
+        }
+    }
+
+    /// Roll consumer `id`'s in-flight set back into its newly-added
+    /// bucket after a Phase-A cursor-commit failure, so the next tick
+    /// re-drains. Idempotent.
+    public func returnInFlight(for id: SourceID) {
+        let held = inFlight[id] ?? []
+        inFlight[id] = []
+        if !held.isEmpty {
+            pendingNewlyAdded[id, default: []].formUnion(held)
+        }
+    }
+
+    /// The in-memory DIFF baseline for consumer `id` (nil if
+    /// `noBaseline`). Drives `added` in `replace`. Used by tests; the
+    /// refresher persists the narrower `persistableBaseline`.
+    public func baseline(for id: SourceID) -> Set<String>? {
+        baseline[id]
+    }
+
+    /// The WRITABLE baseline for consumer `id`: `baseline[id] −
+    /// pendingNewlyAdded[id] − inFlight[id]` (nil if `noBaseline`) — the
+    /// observed set MINUS identifiers still owed a durable scan enqueue.
+    /// The refresher (sole persisted-baseline writer) reads this as an
+    /// immutable Sendable value OUTSIDE its synchronous mutate closure,
+    /// then plain-assigns it. Excluding owed scans guarantees the
+    /// persisted baseline never advances past an identifier whose 30-day
+    /// scan isn't durable yet, so a crash before the scan is committed
+    /// leaves the restart delta able to re-detect and re-enqueue it.
+    public func persistableBaseline(for id: SourceID) -> Set<String>? {
+        guard let base = baseline[id] else { return nil }
+        return base
+            .subtracting(pendingNewlyAdded[id] ?? [])
+            .subtracting(inFlight[id] ?? [])
     }
 }
 
 /// SHA-256 hash of the sorted canonical set, hex-encoded lowercase.
 ///
-/// Used in MessagesCursor.knownIdentifiersHash for restart-time change
-/// detection.  Sorting before hashing makes the hash
+/// Retained for the dead `knownIdentifiersHash` cursor field (its
+/// removal is out of scope). Sorting before hashing makes the hash
 /// deterministic regardless of insertion order.
 public enum KnownIdentifiersHash {
     public static func sha256Hex(of set: Set<String>) -> String {

--- a/mac-daemon/Sources/CRMMacCore/MessagesCursorWire.swift
+++ b/mac-daemon/Sources/CRMMacCore/MessagesCursorWire.swift
@@ -96,14 +96,31 @@ public struct MessagesCursorPendingScan: Codable, Equatable, Sendable {
     /// Lower bound for the scan window (chat.db message.date >= since).
     public let since: Date
 
-    public init(normalizedHandle: String, since: Date) {
+    /// Resume coordinate: the LOWEST chat.db `message.ROWID` already
+    /// confirmed-published for this scan. The next page reads
+    /// `... AND ROWID < progressBelowRowID` (descending walk). Nil
+    /// means "not started" — scan from the most recent matching row.
+    /// Additive Codable field; operator-CLI-queued and pre-existing
+    /// entries decode as nil.
+    public let progressBelowRowID: Int64?
+
+    public init(normalizedHandle: String, since: Date, progressBelowRowID: Int64? = nil) {
         self.normalizedHandle = normalizedHandle
         self.since = since
+        self.progressBelowRowID = progressBelowRowID
     }
 
     enum CodingKeys: String, CodingKey {
-        case normalizedHandle = "normalized_handle"
+        case normalizedHandle  = "normalized_handle"
         case since
+        case progressBelowRowID = "progress_below_rowid"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.normalizedHandle = try c.decode(String.self, forKey: .normalizedHandle)
+        self.since = try c.decode(Date.self, forKey: .since)
+        self.progressBelowRowID = try c.decodeIfPresent(Int64.self, forKey: .progressBelowRowID)
     }
 }
 

--- a/mac-daemon/Sources/CRMMacCore/PhoneCallsCursorWire.swift
+++ b/mac-daemon/Sources/CRMMacCore/PhoneCallsCursorWire.swift
@@ -22,11 +22,13 @@
 // truncate to whole seconds and cause backfill descent to skip rows
 // and live descent to duplicate them across restart.
 //
-// Unlike MessagesCursorWire, this struct does NOT carry a pendingScans
-// queue. The 30-day identifier-scoped scan is deferred to a follow-up;
-// the natural-backfill-descent + sender-filter posture matches the
-// merged messages plugin's behavior. The knownIdentifiersHash IS
-// carried for restart-time change detection.
+// Like MessagesCursorWire, this struct carries a pendingScans queue —
+// operator-queued and auto-queued 30-day identifier-scoped backwards
+// scans the next tick drains. The field is additive: cursor JSON
+// written before it existed decodes the array as empty. The
+// knownIdentifiersHash field is retained (dead) for restart-time change
+// detection; the persisted per-source baseline in DaemonState
+// supersedes its intended role.
 import Foundation
 
 public struct PhoneCallsCursorWire: Codable, Equatable, Sendable {
@@ -65,14 +67,24 @@ public struct PhoneCallsCursorWire: Codable, Equatable, Sendable {
 
     /// SHA-256 (lowercase hex) of the sorted canonical known-
     /// identifiers set as of the last successful heartbeat-diff.
-    /// Used after restart to detect changes; v1.5 does not consume
-    /// this on diff (recorded for future use).
+    /// Retained (dead) for the dead-field compatibility; the persisted
+    /// per-source baseline in DaemonState supersedes its intended role.
     public var knownIdentifiersHash: String?
+
+    /// Operator-queued AND auto-queued one-shot 30-day backwards scans
+    /// the next tick should drain. Persisted so a `scan` subcommand or
+    /// a newly-known-identifier scan survives a daemon restart. Capped
+    /// at `pendingScansCap`; older entries dropped on overflow.
+    public var pendingScans: [PhoneCallsCursorPendingScan]
 
     /// 2026-01-01T00:00:00Z — the spec-defined backfill floor.
     /// Matches MessagesCursorWire.defaultBackfillFloor by design;
     /// CallHistoryDB and chat.db share the same chronological floor.
     public static let defaultBackfillFloor = Date(timeIntervalSince1970: 1_767_225_600)
+
+    /// Cap on pending scans persisted in the cursor JSON. Matches
+    /// MessagesCursorWire.pendingScansCap.
+    public static let pendingScansCap: Int = 256
 
     public init(
         backfillCursorZDate: Double? = nil,
@@ -83,6 +95,7 @@ public struct PhoneCallsCursorWire: Codable, Equatable, Sendable {
         installMaxZPK: Int64? = nil,
         backfillFloorSentAt: Date,
         backfillComplete: Bool = false,
+        pendingScans: [PhoneCallsCursorPendingScan] = [],
         knownIdentifiersHash: String? = nil
     ) {
         self.backfillCursorZDate = backfillCursorZDate
@@ -93,6 +106,7 @@ public struct PhoneCallsCursorWire: Codable, Equatable, Sendable {
         self.installMaxZPK = installMaxZPK
         self.backfillFloorSentAt = backfillFloorSentAt
         self.backfillComplete = backfillComplete
+        self.pendingScans = pendingScans
         self.knownIdentifiersHash = knownIdentifiersHash
     }
 
@@ -105,7 +119,76 @@ public struct PhoneCallsCursorWire: Codable, Equatable, Sendable {
         case installMaxZPK        = "install_max_z_pk"
         case backfillFloorSentAt  = "backfill_floor_sent_at"
         case backfillComplete     = "backfill_complete"
+        case pendingScans         = "pending_scans"
         case knownIdentifiersHash = "known_identifiers_hash"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.backfillCursorZDate = try c.decodeIfPresent(Double.self, forKey: .backfillCursorZDate)
+        self.backfillCursorZPK = try c.decodeIfPresent(Int64.self, forKey: .backfillCursorZPK)
+        self.liveCursorZDate = try c.decodeIfPresent(Double.self, forKey: .liveCursorZDate)
+        self.liveCursorZPK = try c.decodeIfPresent(Int64.self, forKey: .liveCursorZPK)
+        self.installMaxZDate = try c.decodeIfPresent(Double.self, forKey: .installMaxZDate)
+        self.installMaxZPK = try c.decodeIfPresent(Int64.self, forKey: .installMaxZPK)
+        self.backfillFloorSentAt = try c.decode(Date.self, forKey: .backfillFloorSentAt)
+        self.backfillComplete = try c.decodeIfPresent(Bool.self, forKey: .backfillComplete) ?? false
+        // Additive: cursor JSON written before pendingScans existed
+        // decodes the array as empty.
+        self.pendingScans = try c.decodeIfPresent(
+            [PhoneCallsCursorPendingScan].self, forKey: .pendingScans) ?? []
+        self.knownIdentifiersHash = try c.decodeIfPresent(
+            String.self, forKey: .knownIdentifiersHash)
+    }
+}
+
+/// One queued targeted scan for the phone_calls source. Mirrors
+/// MessagesCursorPendingScan but with the CallHistoryDB `(ZDATE, Z_PK)`
+/// progress primitive instead of a single ROWID.
+public struct PhoneCallsCursorPendingScan: Codable, Equatable, Sendable {
+    /// Canonicalized phone/email handle to scan for. Already passed
+    /// through HandleNormalization.canonicalize at queue time.
+    public let normalizedHandle: String
+
+    /// Lower bound for the scan window (CallHistoryDB ZDATE Apple-epoch
+    /// seconds >= since).
+    public let since: Date
+
+    /// Resume coordinate (ZDATE component): the LOWEST `ZDATE` already
+    /// confirmed-published for this scan. Paired with `progressBelowZPK`
+    /// as a `(ZDATE, Z_PK)` lexicographic bound. Nil means "not
+    /// started". Additive Codable field.
+    public let progressBelowZDate: Double?
+
+    /// Resume coordinate (Z_PK component) paired with
+    /// `progressBelowZDate`. Nil iff `progressBelowZDate` is nil.
+    public let progressBelowZPK: Int64?
+
+    public init(
+        normalizedHandle: String,
+        since: Date,
+        progressBelowZDate: Double? = nil,
+        progressBelowZPK: Int64? = nil
+    ) {
+        self.normalizedHandle = normalizedHandle
+        self.since = since
+        self.progressBelowZDate = progressBelowZDate
+        self.progressBelowZPK = progressBelowZPK
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case normalizedHandle  = "normalized_handle"
+        case since
+        case progressBelowZDate = "progress_below_zdate"
+        case progressBelowZPK   = "progress_below_z_pk"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.normalizedHandle = try c.decode(String.self, forKey: .normalizedHandle)
+        self.since = try c.decode(Date.self, forKey: .since)
+        self.progressBelowZDate = try c.decodeIfPresent(Double.self, forKey: .progressBelowZDate)
+        self.progressBelowZPK = try c.decodeIfPresent(Int64.self, forKey: .progressBelowZPK)
     }
 }
 

--- a/mac-daemon/Sources/CRMMacLifecycle/CallHistoryOps.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/CallHistoryOps.swift
@@ -124,14 +124,14 @@ public final class CallHistoryOps: Sendable {
         let current = try await piClient.getCursor(auth: auth, source: "phone_calls")
         var working = (try? PhoneCallsCursorWireCodec.decode(current.cursor))
             ?? PhoneCallsCursorWire(backfillFloorSentAt: backfillFloor)
-        let sinceDate = Date().addingTimeInterval(-since)
-        let scan = PhoneCallsCursorPendingScan(normalizedHandle: canonical, since: sinceDate)
-        // Bounded queue: drop oldest on overflow.
-        if working.pendingScans.count >= PhoneCallsCursorWire.pendingScansCap {
-            working.pendingScans.removeFirst()
-            logger.warning("call-history scan: pending-scan cap reached; dropped oldest", metadata: [:])
-        }
-        working.pendingScans.append(scan)
+        // Never scan below the backfill floor — rows older than it are
+        // never emitted, so a wider `--since` would just waste work.
+        let sinceDate = max(Date().addingTimeInterval(-since), backfillFloor)
+        // Coverage-dedup: at most one entry per handle, keeping the WIDER
+        // window. A wider window resets progress so the larger range is
+        // re-walked; an equal-or-narrower window leaves the existing
+        // entry untouched. Mirrors the source tick's merge.
+        mergePendingScan(into: &working.pendingScans, handle: canonical, since: sinceDate)
         let nextJSON = try PhoneCallsCursorWireCodec.encode(working)
         do {
             try await piClient.commitCursor(
@@ -150,6 +150,29 @@ public final class CallHistoryOps: Sendable {
         logger.info("call-history scan: pending scan queued", metadata: [
             "handle": .private(canonical),
         ])
+    }
+
+    /// Merge identifier `handle` into a pendingScans list with
+    /// COVERAGE-DEDUP (at most one entry per handle, keeping the wider
+    /// window) + cap (drop oldest on overflow). Keeps the operator path
+    /// idempotent and consistent with the source tick's merge.
+    private func mergePendingScan(
+        into scans: inout [PhoneCallsCursorPendingScan],
+        handle: String,
+        since: Date
+    ) {
+        if let idx = scans.firstIndex(where: { $0.normalizedHandle == handle }) {
+            if since < scans[idx].since {
+                scans[idx] = PhoneCallsCursorPendingScan(
+                    normalizedHandle: handle, since: since)
+            }
+            return
+        }
+        scans.append(PhoneCallsCursorPendingScan(normalizedHandle: handle, since: since))
+        if scans.count > PhoneCallsCursorWire.pendingScansCap {
+            scans.removeFirst(scans.count - PhoneCallsCursorWire.pendingScansCap)
+            logger.warning("call-history scan: pending-scan cap reached; dropped oldest", metadata: [:])
+        }
     }
 
     private func acquireOrThrow() throws {

--- a/mac-daemon/Sources/CRMMacLifecycle/CallHistoryOps.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/CallHistoryOps.swift
@@ -1,17 +1,17 @@
-// CallHistoryOps — body of the CLI ops subcommand:
+// CallHistoryOps — body of the CLI ops subcommands:
 //   crm-mac call-history backfill --restart [--yes]
+//   crm-mac call-history scan --identifier <handle> [--since <duration>]
 //
-// Modifies the Pi-side phone_calls cursor via the GET -> mutate -> POST
-// CAS-commit flow. Mutating local state.json only would be silently
-// overwritten on the daemon's next tick when it re-fetches the
+// Both modify the Pi-side phone_calls cursor via the GET -> mutate ->
+// POST CAS-commit flow. Mutating local state.json only would be
+// silently overwritten on the daemon's next tick when it re-fetches the
 // (unchanged) cursor.
 //
-// Daemon-running guard: acquires the daemon's pidfile lock before any
-// Pi calls. If the daemon is up, the lock acquire throws and we
+// Daemon-running guard: both acquire the daemon's pidfile lock before
+// any Pi calls. If the daemon is up, the lock acquire throws and we
 // surface a user-facing message.
 //
-// This mirrors MessagesOps.backfillRestart's contract on a different
-// source.
+// This mirrors MessagesOps' contract on a different source.
 import Foundation
 import CRMMacCore
 import CRMMacPiClient
@@ -21,6 +21,7 @@ public enum CallHistoryOpsError: Error, Equatable, CustomStringConvertible {
     case piUnreachable(underlying: String)
     case cursorConflict
     case userDeclined
+    case invalidIdentifier(String)
     case opDescription(String)
 
     public var description: String {
@@ -33,6 +34,8 @@ public enum CallHistoryOpsError: Error, Equatable, CustomStringConvertible {
             return "cursor conflict: the daemon (or another ops) raced with this command. Retry."
         case .userDeclined:
             return "operator declined; no changes made."
+        case .invalidIdentifier(let s):
+            return "invalid identifier: \(s)"
         case .opDescription(let s):
             return s
         }
@@ -107,11 +110,72 @@ public final class CallHistoryOps: Sendable {
         logger.info("call-history backfill --restart: cursor reset", metadata: [:])
     }
 
+    /// Queue a targeted backwards scan for `identifier`. The next daemon
+    /// tick (operator-initiated start) drains the queue.
+    public func scan(identifier: String, since: TimeInterval) async throws {
+        let canonical = HandleNormalization.canonicalize(identifier)
+        if canonical.isEmpty {
+            throw CallHistoryOpsError.invalidIdentifier(identifier)
+        }
+
+        try acquireOrThrow()
+        defer { pidfileLock.release() }
+
+        let current = try await piClient.getCursor(auth: auth, source: "phone_calls")
+        var working = (try? PhoneCallsCursorWireCodec.decode(current.cursor))
+            ?? PhoneCallsCursorWire(backfillFloorSentAt: backfillFloor)
+        let sinceDate = Date().addingTimeInterval(-since)
+        let scan = PhoneCallsCursorPendingScan(normalizedHandle: canonical, since: sinceDate)
+        // Bounded queue: drop oldest on overflow.
+        if working.pendingScans.count >= PhoneCallsCursorWire.pendingScansCap {
+            working.pendingScans.removeFirst()
+            logger.warning("call-history scan: pending-scan cap reached; dropped oldest", metadata: [:])
+        }
+        working.pendingScans.append(scan)
+        let nextJSON = try PhoneCallsCursorWireCodec.encode(working)
+        do {
+            try await piClient.commitCursor(
+                auth: auth,
+                source: "phone_calls",
+                cursor: nextJSON,
+                baseCursor: current.cursor,
+                cursorEpoch: current.cursorEpoch,
+                backfillComplete: working.backfillComplete)
+        } catch PiClientError.cursorConflict {
+            throw CallHistoryOpsError.cursorConflict
+        } catch {
+            throw CallHistoryOpsError.piUnreachable(
+                underlying: String(describing: error))
+        }
+        logger.info("call-history scan: pending scan queued", metadata: [
+            "handle": .private(canonical),
+        ])
+    }
+
     private func acquireOrThrow() throws {
         do {
             try pidfileLock.acquire()
         } catch PidfileError.alreadyHeld(let pid) {
             throw CallHistoryOpsError.daemonRunning(pid: pid)
+        }
+    }
+
+    /// Helper for HandleNormalization, re-exported so tests don't need
+    /// to import CRMMacPhoneCallsSource (this target is Foundation-only
+    /// and stays free of GRDB).
+    ///
+    /// Returns the canonical form, mirroring
+    /// CRMMacMessagesSource.HandleNormalization.canonicalize. Email
+    /// shape (`@`) -> lowercase + trim; otherwise treat as phone +
+    /// normalize to E.164 (NANP for 10-digit).
+    private enum HandleNormalization {
+        static func canonicalize(_ raw: String) -> String {
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty { return "" }
+            if trimmed.contains("@") {
+                return NormalizationParity.normalizeEmail(trimmed)
+            }
+            return NormalizationParity.normalizePhoneE164(trimmed)
         }
     }
 }

--- a/mac-daemon/Sources/CRMMacLifecycle/MessagesOps.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/MessagesOps.swift
@@ -135,14 +135,14 @@ public final class MessagesOps: Sendable {
         let current = try await piClient.getCursor(auth: auth, source: "messages")
         var working = (try? MessagesCursorCodec.decode(current.cursor))
             ?? MessagesCursor(backfillFloorSentAt: backfillFloor)
-        let sinceDate = Date().addingTimeInterval(-since)
-        let scan = PendingScan(normalizedHandle: canonical, since: sinceDate)
-        // Bounded queue: drop oldest on overflow.
-        if working.pendingScans.count >= MessagesCursor.pendingScansCap {
-            working.pendingScans.removeFirst()
-            logger.warning("messages scan: pending-scan cap reached; dropped oldest", metadata: [:])
-        }
-        working.pendingScans.append(scan)
+        // Never scan below the backfill floor — rows older than it are
+        // never emitted, so a wider `--since` would just waste work.
+        let sinceDate = max(Date().addingTimeInterval(-since), backfillFloor)
+        // Coverage-dedup: at most one entry per handle, keeping the WIDER
+        // window. A wider window resets progress so the larger range is
+        // re-walked; an equal-or-narrower window leaves the existing
+        // entry untouched. Mirrors the source tick's merge.
+        mergePendingScan(into: &working.pendingScans, handle: canonical, since: sinceDate)
         let nextJSON = try MessagesCursorCodec.encode(working)
         do {
             try await piClient.commitCursor(
@@ -161,6 +161,28 @@ public final class MessagesOps: Sendable {
         logger.info("messages scan: pending scan queued", metadata: [
             "handle": .private(canonical),
         ])
+    }
+
+    /// Merge identifier `handle` into a pendingScans list with
+    /// COVERAGE-DEDUP (at most one entry per handle, keeping the wider
+    /// window) + cap (drop oldest on overflow). Keeps the operator path
+    /// idempotent and consistent with the source tick's merge.
+    private func mergePendingScan(
+        into scans: inout [PendingScan],
+        handle: String,
+        since: Date
+    ) {
+        if let idx = scans.firstIndex(where: { $0.normalizedHandle == handle }) {
+            if since < scans[idx].since {
+                scans[idx] = PendingScan(normalizedHandle: handle, since: since)
+            }
+            return
+        }
+        scans.append(PendingScan(normalizedHandle: handle, since: since))
+        if scans.count > MessagesCursor.pendingScansCap {
+            scans.removeFirst(scans.count - MessagesCursor.pendingScansCap)
+            logger.warning("messages scan: pending-scan cap reached; dropped oldest", metadata: [:])
+        }
     }
 
     private func acquireOrThrow() throws {

--- a/mac-daemon/Sources/CRMMacLifecycle/Status.swift
+++ b/mac-daemon/Sources/CRMMacLifecycle/Status.swift
@@ -249,6 +249,7 @@ public struct PhoneCallsSourceStatus: Equatable {
     public let installMaxZDate: Double?
     public let installMaxZPK: Int64?
     public let backfillComplete: Bool
+    public let pendingScansCount: Int
 
     public init(
         liveCursorZDate: Double?,
@@ -257,7 +258,8 @@ public struct PhoneCallsSourceStatus: Equatable {
         backfillCursorZPK: Int64?,
         installMaxZDate: Double?,
         installMaxZPK: Int64?,
-        backfillComplete: Bool
+        backfillComplete: Bool,
+        pendingScansCount: Int
     ) {
         self.liveCursorZDate = liveCursorZDate
         self.liveCursorZPK = liveCursorZPK
@@ -266,6 +268,7 @@ public struct PhoneCallsSourceStatus: Equatable {
         self.installMaxZDate = installMaxZDate
         self.installMaxZPK = installMaxZPK
         self.backfillComplete = backfillComplete
+        self.pendingScansCount = pendingScansCount
     }
 
     /// Decoder mirroring PhoneCallsCursorWire's CodingKeys.
@@ -277,6 +280,7 @@ public struct PhoneCallsSourceStatus: Equatable {
         let installMaxZDate: Double?
         let installMaxZPK: Int64?
         let backfillComplete: Bool?
+        let pendingScans: [PendingScan]?
 
         enum CodingKeys: String, CodingKey {
             case backfillCursorZDate = "backfill_cursor_zdate"
@@ -286,6 +290,16 @@ public struct PhoneCallsSourceStatus: Equatable {
             case installMaxZDate     = "install_max_zdate"
             case installMaxZPK       = "install_max_z_pk"
             case backfillComplete    = "backfill_complete"
+            case pendingScans        = "pending_scans"
+        }
+
+        struct PendingScan: Decodable {
+            let normalizedHandle: String?
+            let since: Date?
+            enum CodingKeys: String, CodingKey {
+                case normalizedHandle = "normalized_handle"
+                case since
+            }
         }
     }
 
@@ -306,7 +320,8 @@ public struct PhoneCallsSourceStatus: Equatable {
             backfillCursorZPK: parsed.backfillCursorZPK,
             installMaxZDate: parsed.installMaxZDate,
             installMaxZPK: parsed.installMaxZPK,
-            backfillComplete: parsed.backfillComplete ?? false)
+            backfillComplete: parsed.backfillComplete ?? false,
+            pendingScansCount: parsed.pendingScans?.count ?? 0)
     }
 }
 

--- a/mac-daemon/Sources/CRMMacMessagesSource/ChatDBReader.swift
+++ b/mac-daemon/Sources/CRMMacMessagesSource/ChatDBReader.swift
@@ -115,7 +115,80 @@ public final class ChatDBReader {
     /// Sentinel below which chat.db dates are treated as corrupt and
     /// skipped (with a warning). Equivalent to ~2017-09 in nanoseconds
     /// since the Apple epoch.
-    private static let dateSentinelFloor: Int64 = 500_000_000_000_000_000
+    static let dateSentinelFloor: Int64 = 500_000_000_000_000_000
+
+    /// The shared SELECT column list + JOINs used by both the
+    /// ROWID-ranged page reader and the identifier-scoped scan reader.
+    /// Callers append their own WHERE / ORDER BY / LIMIT. Keeping the
+    /// projection in one place means the two readers can never drift in
+    /// which columns they shape a `ChatDBMessage` from.
+    static let selectColumnsAndJoins = """
+        SELECT
+            message.ROWID                         AS msg_rowid,
+            message.guid                          AS msg_guid,
+            message.text                          AS msg_text,
+            message.is_from_me                    AS msg_is_from_me,
+            message.date                          AS msg_date,
+            message.associated_message_guid       AS msg_reply_to_guid,
+            message.handle_id                     AS msg_handle_id,
+            handle.id                             AS hnd_id,
+            chat.guid                             AS chat_guid,
+            chat.style                            AS chat_style,
+            att.uti                               AS att_uti,
+            att.mime_type                         AS att_mime,
+            att.transfer_name                     AS att_name,
+            att.total_bytes                       AS att_size
+        FROM message
+        LEFT JOIN handle               ON handle.ROWID = message.handle_id
+        LEFT JOIN chat_message_join    ON chat_message_join.message_id = message.ROWID
+        LEFT JOIN chat                 ON chat.ROWID = chat_message_join.chat_id
+        LEFT JOIN (
+            SELECT message_id, attachment_id, MIN(ROWID) AS primary_join_rowid
+            FROM message_attachment_join
+            GROUP BY message_id
+        ) AS maj_primary                ON maj_primary.message_id = message.ROWID
+        LEFT JOIN attachment AS att     ON att.ROWID = maj_primary.attachment_id
+        """
+
+    /// Map one fetched GRDB row (aliased per `selectColumnsAndJoins`) to
+    /// a `ChatDBMessage`. Returns nil for rows that should be SKIPPED:
+    /// missing rowid/guid/date, NULL/empty handle (system messages,
+    /// outbound), or a corrupt/sentinel date. The caller still tracks
+    /// every inspected ROWID (including skipped) for cursor advance.
+    static func mapMessageRow(_ row: Row) -> ChatDBMessage? {
+        guard let rowID: Int64 = row["msg_rowid"],
+              let rawDate: Int64 = row["msg_date"],
+              let guid: String = row["msg_guid"] else {
+            return nil
+        }
+        // Skip rows with no handle (system messages, outbound) — no peer
+        // to attribute to and the Pi would no-match anyway.
+        let handleRaw: String = (row["hnd_id"] as String?) ?? ""
+        if handleRaw.isEmpty { return nil }
+        // Skip corrupt/sentinel date rows (date == 0 or < ~2017).
+        if rawDate < Self.dateSentinelFloor { return nil }
+        let sentAt = Date(timeIntervalSince1970:
+            Self.appleEpochOffset + Double(rawDate) / 1e9)
+
+        let isFromMeRaw: Int64 = (row["msg_is_from_me"] as Int64?) ?? 0
+        let chatStyle: Int64 = (row["chat_style"] as Int64?) ?? 0
+
+        return ChatDBMessage(
+            rowID: rowID,
+            guid: guid,
+            chatGUID: row["chat_guid"],
+            peerHandleRaw: handleRaw,
+            text: row["msg_text"],
+            isFromMe: isFromMeRaw != 0,
+            // style 43 is a group chat per Apple's internal convention.
+            isGroup: chatStyle == 43,
+            sentAt: sentAt,
+            replyToGUID: row["msg_reply_to_guid"],
+            primaryAttachmentUTI: row["att_uti"],
+            primaryAttachmentMimeType: row["att_mime"],
+            primaryAttachmentTransferName: row["att_name"],
+            primaryAttachmentTotalBytes: row["att_size"])
+    }
 
     /// max message.ROWID currently in the database.
     public static func maxROWID(db: Database) throws -> Int64? {
@@ -162,35 +235,8 @@ public final class ChatDBReader {
             bound = upper
         }
 
-        // GRDB row dictionary access uses column aliases; we use
-        // explicit aliases to keep the per-row mapping deterministic
-        // and resilient to JOIN column-name collisions on (e.g.) ROWID.
         let sql = """
-            SELECT
-                message.ROWID                         AS msg_rowid,
-                message.guid                          AS msg_guid,
-                message.text                          AS msg_text,
-                message.is_from_me                    AS msg_is_from_me,
-                message.date                          AS msg_date,
-                message.associated_message_guid       AS msg_reply_to_guid,
-                message.handle_id                     AS msg_handle_id,
-                handle.id                             AS hnd_id,
-                chat.guid                             AS chat_guid,
-                chat.style                            AS chat_style,
-                att.uti                               AS att_uti,
-                att.mime_type                         AS att_mime,
-                att.transfer_name                     AS att_name,
-                att.total_bytes                       AS att_size
-            FROM message
-            LEFT JOIN handle               ON handle.ROWID = message.handle_id
-            LEFT JOIN chat_message_join    ON chat_message_join.message_id = message.ROWID
-            LEFT JOIN chat                 ON chat.ROWID = chat_message_join.chat_id
-            LEFT JOIN (
-                SELECT message_id, attachment_id, MIN(ROWID) AS primary_join_rowid
-                FROM message_attachment_join
-                GROUP BY message_id
-            ) AS maj_primary                ON maj_primary.message_id = message.ROWID
-            LEFT JOIN attachment AS att     ON att.ROWID = maj_primary.attachment_id
+            \(Self.selectColumnsAndJoins)
             WHERE \(condition)
             ORDER BY \(order)
             LIMIT ?
@@ -203,64 +249,22 @@ public final class ChatDBReader {
         results.reserveCapacity(rows.count)
 
         for row in rows {
-            guard let rowID: Int64 = row["msg_rowid"],
-                  let rawDate: Int64 = row["msg_date"] else {
-                continue
-            }
             // Track every ROWID we saw, including skipped ones — the
             // caller needs this so cursor advance doesn't stall on a
-            // page where every row got filtered out.
+            // page where every row got filtered out. A row missing the
+            // ROWID or date is not a real message row and is not counted
+            // toward the scanned bounds (matches the pre-extraction
+            // behavior so backfillComplete still flips correctly).
+            guard let rowID: Int64 = row["msg_rowid"],
+                  row["msg_date"] as Int64? != nil else {
+                continue
+            }
             scannedMin = min(scannedMin ?? rowID, rowID)
             scannedMax = max(scannedMax ?? rowID, rowID)
 
-            guard let guid: String = row["msg_guid"] else { continue }
-            // Skip rows with no handle (system messages, etc.) — they
-            // have no peer to attribute to and the Pi would no-match
-            // anyway.
-            let handleRaw: String = (row["hnd_id"] as String?) ?? ""
-            if handleRaw.isEmpty {
-                continue
+            if let mapped = Self.mapMessageRow(row) {
+                results.append(mapped)
             }
-
-            // Skip corrupt/sentinel date rows. The Apple-epoch
-            // nanoseconds convention is hard-coded; rows with date == 0
-            // or date < ~2017 are treated as corrupt.
-            if rawDate < Self.dateSentinelFloor {
-                continue
-            }
-            let sentAt = Date(timeIntervalSince1970:
-                Self.appleEpochOffset + Double(rawDate) / 1e9)
-
-            let isFromMeRaw: Int64 = (row["msg_is_from_me"] as Int64?) ?? 0
-            let isFromMe = isFromMeRaw != 0
-
-            let chatGUID: String? = row["chat_guid"]
-            // style 43 is a group chat per Apple's internal convention.
-            let chatStyle: Int64 = (row["chat_style"] as Int64?) ?? 0
-            let isGroup = chatStyle == 43
-
-            let text: String? = row["msg_text"]
-            let replyTo: String? = row["msg_reply_to_guid"]
-
-            let primaryUTI: String? = row["att_uti"]
-            let primaryMime: String? = row["att_mime"]
-            let primaryName: String? = row["att_name"]
-            let primarySize: Int64? = row["att_size"]
-
-            results.append(ChatDBMessage(
-                rowID: rowID,
-                guid: guid,
-                chatGUID: chatGUID,
-                peerHandleRaw: handleRaw,
-                text: text,
-                isFromMe: isFromMe,
-                isGroup: isGroup,
-                sentAt: sentAt,
-                replyToGUID: replyTo,
-                primaryAttachmentUTI: primaryUTI,
-                primaryAttachmentMimeType: primaryMime,
-                primaryAttachmentTransferName: primaryName,
-                primaryAttachmentTotalBytes: primarySize))
         }
         let bounds: (min: Int64, max: Int64)? = {
             if let lo = scannedMin, let hi = scannedMax {

--- a/mac-daemon/Sources/CRMMacMessagesSource/MessagesScanReader.swift
+++ b/mac-daemon/Sources/CRMMacMessagesSource/MessagesScanReader.swift
@@ -1,0 +1,139 @@
+// MessagesScanReader — identifier-scoped, date-bounded, resumable scan
+// over chat.db `message` rows for a single canonical handle.
+//
+// chat.db has NO index on `handle.id` or `message.date`, so a naive
+// `WHERE handle.id = ?` scan would full-table-scan AND miss alternate
+// spellings of the same canonical handle (one canonical phone number can
+// map to several `handle.ROWID`s: "+15550000001", "(555) 000-0001", …).
+//
+// The scan therefore runs in two passes:
+//
+//   1. Resolve handle ROWIDs. `SELECT ROWID, id FROM handle` is small
+//      (one row per distinct raw handle the mailbox has ever seen),
+//      canonicalize each `id` in Swift, and keep the ROWIDs whose
+//      canonical form equals the target. This canonicalization CANNOT
+//      happen in SQL — it is the same `HandleNormalization` the sender
+//      filter uses.
+//
+//   2. Scan messages. `message.handle_id IN (resolvedROWIDs) AND
+//      message.date >= sinceNanos [AND message.ROWID < progressBelowRowID]`
+//      ordered `ROWID DESC`, budget-limited. The `message` table has a
+//      PRIMARY KEY on ROWID; the `handle_id IN (...)` predicate over a
+//      tiny ROWID set plus the bounded 30-day `date` range, paged by
+//      budget, keeps each tick's work bounded.
+//
+// The scan is RESUMABLE: passing `progressBelowRowID` walks the next
+// page strictly below the lowest ROWID already confirmed-published, so a
+// scan whose result set exceeds one tick's budget completes across ticks
+// without dropping rows.
+import Foundation
+import GRDB
+
+/// Result of one scan page.
+public struct MessagesScanPage: Equatable, Sendable {
+    /// The kept rows (skip filters already applied), ROWID descending.
+    public let rows: [ChatDBMessage]
+    /// True if SQL returned fewer than `limit` rows — i.e. the scan has
+    /// no more matching rows below this page (exhausted).
+    public let exhausted: Bool
+    /// Lowest `message.ROWID` inspected in this page (including skipped
+    /// rows), or nil if SQL returned zero rows. The caller advances the
+    /// scan's progress to this so the next page resumes strictly below
+    /// it. Tracking EVERY inspected ROWID (not just kept) means a page
+    /// of all-skipped rows still advances and doesn't stall.
+    public let lowestRowID: Int64?
+
+    public init(rows: [ChatDBMessage], exhausted: Bool, lowestRowID: Int64?) {
+        self.rows = rows
+        self.exhausted = exhausted
+        self.lowestRowID = lowestRowID
+    }
+}
+
+public enum MessagesScanReader {
+    /// Resolve the set of `handle.ROWID`s whose canonical form equals
+    /// `canonicalHandle`. One canonical handle can map to several raw
+    /// `handle.id` spellings, so all matching ROWIDs are returned.
+    public static func resolveHandleROWIDs(
+        db: Database,
+        canonicalHandle: String
+    ) throws -> [Int64] {
+        let rows = try Row.fetchAll(db, sql: "SELECT ROWID AS rowid, id AS hid FROM handle")
+        var matches: [Int64] = []
+        for row in rows {
+            guard let rowID: Int64 = row["rowid"],
+                  let rawID: String = row["hid"] else {
+                continue
+            }
+            if HandleNormalization.canonicalize(rawID) == canonicalHandle {
+                matches.append(rowID)
+            }
+        }
+        return matches
+    }
+
+    /// Fetch one budget-limited page of messages for `canonicalHandle`
+    /// at-or-after `since`, descending by ROWID, resuming strictly below
+    /// `progressBelowRowID` when set.
+    ///
+    /// Returns an EMPTY exhausted page (no rows, lowestRowID nil) when
+    /// the handle resolves to zero ROWIDs (no chat.db history for it).
+    public static func scanPage(
+        db: Database,
+        canonicalHandle: String,
+        since: Date,
+        progressBelowRowID: Int64?,
+        limit: Int
+    ) throws -> MessagesScanPage {
+        precondition(limit > 0, "limit must be > 0")
+
+        let handleROWIDs = try resolveHandleROWIDs(db: db, canonicalHandle: canonicalHandle)
+        if handleROWIDs.isEmpty {
+            return MessagesScanPage(rows: [], exhausted: true, lowestRowID: nil)
+        }
+
+        // Convert the Date lower bound to chat.db's Apple-epoch
+        // NANOSECONDS unit.
+        let sinceNanos = Int64(
+            (since.timeIntervalSince1970 - ChatDBReader.appleEpochOffset) * 1e9)
+
+        // Build the `handle_id IN (?, ?, …)` placeholder list.
+        let placeholders = Array(repeating: "?", count: handleROWIDs.count).joined(separator: ", ")
+        var conditions = [
+            "message.handle_id IN (\(placeholders))",
+            "message.date >= ?",
+        ]
+        var arguments: [DatabaseValueConvertible] = handleROWIDs
+        arguments.append(sinceNanos)
+        if let progress = progressBelowRowID {
+            conditions.append("message.ROWID < ?")
+            arguments.append(progress)
+        }
+        arguments.append(limit)
+
+        let sql = """
+            \(ChatDBReader.selectColumnsAndJoins)
+            WHERE \(conditions.joined(separator: " AND "))
+            ORDER BY message.ROWID DESC
+            LIMIT ?
+            """
+
+        let rows = try Row.fetchAll(db, sql: sql, arguments: StatementArguments(arguments))
+
+        var kept: [ChatDBMessage] = []
+        kept.reserveCapacity(rows.count)
+        var lowest: Int64?
+        for row in rows {
+            if let rowID: Int64 = row["msg_rowid"] {
+                lowest = min(lowest ?? rowID, rowID)
+            }
+            if let mapped = ChatDBReader.mapMessageRow(row) {
+                kept.append(mapped)
+            }
+        }
+        return MessagesScanPage(
+            rows: kept,
+            exhausted: rows.count < limit,
+            lowestRowID: lowest)
+    }
+}

--- a/mac-daemon/Sources/CRMMacMessagesSource/MessagesSourcePlugin.swift
+++ b/mac-daemon/Sources/CRMMacMessagesSource/MessagesSourcePlugin.swift
@@ -199,7 +199,7 @@ public actor MessagesSourcePlugin: DataSourcePlugin {
         // a future PR ships true identifier-scoped scans. README
         // documents this v1 behavior; tests cover the persistence
         // semantics.
-        let newlyAdded = await cache.drainNewlyAdded()
+        let newlyAdded = await cache.drainNewlyAdded(for: id)
         if !newlyAdded.isEmpty {
             logger.info("messages tick: newly-known contacts detected", metadata: [
                 "count": .public(String(newlyAdded.count)),

--- a/mac-daemon/Sources/CRMMacMessagesSource/MessagesSourcePlugin.swift
+++ b/mac-daemon/Sources/CRMMacMessagesSource/MessagesSourcePlugin.swift
@@ -180,9 +180,14 @@ public actor MessagesSourcePlugin: DataSourcePlugin {
         // Phase B — execute pending scans (resumable), gated on
         // hasFetched (NOT isPopulated). An empty-but-fetched CRM still
         // adjudicates pending scans (drops an operator scan for a
-        // now-removed contact); a not-yet-fetched cache defers them.
+        // now-removed contact); a not-yet-fetched cache defers them. A
+        // scan-commit conflict aborts the rest of the tick: `working` is
+        // now stale relative to the refreshed Pi cursor, so the
+        // row-emitting batches + final commit must NOT run against it.
         if await cache.hasFetched {
-            await runPendingScans(pool: pool, working: &working)
+            if await runPendingScans(pool: pool, working: &working) == .aborted {
+                return
+            }
         }
 
         // Sender filter ready?  If the known-identifiers cache hasn't
@@ -421,8 +426,12 @@ public actor MessagesSourcePlugin: DataSourcePlugin {
     /// advance the entry's progress (still queued) or dequeue it on
     /// confirmed exhaustion. Re-commits the cursor after each entry's
     /// progress/dequeue so a crash recovers from the persisted cursor.
-    private func runPendingScans(pool: DatabasePool, working: inout MessagesCursor) async {
-        guard !working.pendingScans.isEmpty else { return }
+    ///
+    /// Returns `.aborted` on a scan-commit conflict/failure: `working`
+    /// is then stale relative to the refreshed Pi cursor, so the caller
+    /// must stop the tick rather than re-commit it.
+    private func runPendingScans(pool: DatabasePool, working: inout MessagesCursor) async -> ScanEnqueueResult {
+        guard !working.pendingScans.isEmpty else { return .ok }
         // Iterate by handle snapshot; mutate working.pendingScans in
         // place as each entry advances or completes.
         let handles = working.pendingScans.map(\.normalizedHandle)
@@ -432,15 +441,15 @@ public actor MessagesSourcePlugin: DataSourcePlugin {
             guard let entry = working.pendingScans.first(where: { $0.normalizedHandle == handle }) else {
                 continue
             }
-            // Membership check (R4): drop scans for handles not in the
-            // current known set — operator typo / removed contact.
+            // Membership check: drop scans for handles not in the current
+            // known set — operator typo / removed contact.
             let known = await cache.contains(handle)
             if !known {
                 working.pendingScans.removeAll { $0.normalizedHandle == handle }
                 logger.warning("messages scan: handle not in known set; dropping", metadata: [
                     "handle": .private(handle),
                 ])
-                if case .aborted = await commitAfterScanMutation(working) { return }
+                if case .aborted = await commitAfterScanMutation(working) { return .aborted }
                 continue
             }
 
@@ -457,7 +466,7 @@ public actor MessagesSourcePlugin: DataSourcePlugin {
                 }
             } catch let dbError as DatabaseError where isFDAError(dbError) {
                 await markUnhealthy(reason: "fda_required")
-                return
+                return .aborted
             } catch {
                 logger.warning("messages scan: read failed; holding entry", metadata: [
                     "error": .private(String(describing: error)),
@@ -498,8 +507,9 @@ public actor MessagesSourcePlugin: DataSourcePlugin {
                         progressBelowRowID: lowest)
                 }
             }
-            if case .aborted = await commitAfterScanMutation(working) { return }
+            if case .aborted = await commitAfterScanMutation(working) { return .aborted }
         }
+        return .ok
     }
 
     /// Commit `working` after a scan entry's progress/dequeue mutation.

--- a/mac-daemon/Sources/CRMMacMessagesSource/MessagesSourcePlugin.swift
+++ b/mac-daemon/Sources/CRMMacMessagesSource/MessagesSourcePlugin.swift
@@ -454,13 +454,18 @@ public actor MessagesSourcePlugin: DataSourcePlugin {
             }
 
             let limit = min(scanBudget, MessagesPublisher.maxEventsPerBatch)
+            // Never scan below the backfill floor at EXECUTION time —
+            // defense-in-depth against any already-committed entry whose
+            // `since` predates the floor (e.g. queued by an older build).
+            // Rows below the floor are never emitted.
+            let scanSince = max(entry.since, config.backfillFloor)
             let page: MessagesScanPage
             do {
                 page = try await pool.read { db in
                     try MessagesScanReader.scanPage(
                         db: db,
                         canonicalHandle: handle,
-                        since: entry.since,
+                        since: scanSince,
                         progressBelowRowID: entry.progressBelowRowID,
                         limit: limit)
                 }

--- a/mac-daemon/Sources/CRMMacMessagesSource/MessagesSourcePlugin.swift
+++ b/mac-daemon/Sources/CRMMacMessagesSource/MessagesSourcePlugin.swift
@@ -6,23 +6,35 @@
 //   2. Open chat.db DatabasePool (cached on first successful open).
 //   3. If no cached cursor: piClient.getMessagesCursor(...) -> decode
 //      into MessagesCursor; cache locally via StateMutator.
-//   4. If installMaxRowID == nil: capture MAX(ROWID) into the in-memory
-//      MessagesCursor (uncommitted; committed in step 8).
-//   5. Drain pendingScans (from cursor JSON): for each, run targeted
-//      30-day scan -> publish via MessagesPublisher.
-//   6. If backfillComplete == false: run a backfill batch (budget-
+//   4. Phase A — durable scan enqueue: drain the known-identifiers
+//      cache's newly-added bucket (non-destructive), coverage-dedup +
+//      cap them into pendingScans with a 30-day window, and commit the
+//      cursor BEFORE executing any scan. On success confirm the drain;
+//      on failure return it so the next tick re-enqueues.
+//   5. Phase B — execute pending scans (gated on cache.hasFetched, NOT
+//      isPopulated): membership-check each entry, walk one budget-
+//      limited page via MessagesScanReader (resumable via the entry's
+//      progress), publish, advance progress or dequeue on exhaustion,
+//      re-commit. Runs BEFORE the row-emitting batches.
+//   6. If the known-identifiers cache is not populated, skip the
+//      row-emitting batches (the scan phases already ran).
+//   7. If installMaxRowID == nil: capture MAX(ROWID) into the in-memory
+//      MessagesCursor (uncommitted; committed in step 10).
+//   8. If backfillComplete == false: run a backfill batch (budget-
 //      bound) -> publish -> advance backfillCursor downward.
-//   7. Run live batch (remaining budget): read message.ROWID > liveCursor
+//   9. Run live batch (remaining budget): read message.ROWID > liveCursor
 //      -> publish -> advance liveCursor upward.
-//   8. If the in-memory cursor changed AND every batch had
+//  10. If the in-memory cursor changed AND every batch had
 //      rejected == 0: commitMessagesCursor; on success write through
 //      to local state.json via StateMutator. On 409: refresh + abort.
 //      On transport error: log + leave local cache untouched -> return.
-//   9. Update source_health snapshot via the shared registry.
+//  11. Update source_health snapshot via the shared registry.
 //
 // The plugin is the single owner of the GRDB DatabasePool, the
 // KnownIdentifiersCache, and the messages source's slot in
 // SourceState. All writes to state.json funnel through StateMutator.
+// The plugin NEVER writes the persisted known-identifiers baseline —
+// that is the heartbeat refresher's job (single-writer model).
 import Foundation
 import GRDB
 import CRMMacCore
@@ -150,16 +162,39 @@ public actor MessagesSourcePlugin: DataSourcePlugin {
             return
         }
 
+        var working = cursor
+
+        // Phase A — durable scan enqueue (commit-first).
+        // Drain the cache's newly-added bucket NON-DESTRUCTIVELY and
+        // merge it into working.pendingScans (coverage-dedup + cap),
+        // then commit the cursor with the enlarged queue BEFORE any scan
+        // executes. On commit success the drained identifiers are
+        // confirmed (durably enqueued); on failure they are returned to
+        // the cache so the next tick re-enqueues. This runs regardless
+        // of isPopulated — a newly-known identifier must be durably
+        // queued even on a tick where the row-emitting batches skip.
+        if await runScanEnqueue(working: &working) == .aborted {
+            return
+        }
+
+        // Phase B — execute pending scans (resumable), gated on
+        // hasFetched (NOT isPopulated). An empty-but-fetched CRM still
+        // adjudicates pending scans (drops an operator scan for a
+        // now-removed contact); a not-yet-fetched cache defers them.
+        if await cache.hasFetched {
+            await runPendingScans(pool: pool, working: &working)
+        }
+
         // Sender filter ready?  If the known-identifiers cache hasn't
-        // been populated yet, skip the tick (heartbeat will fill it).
+        // been populated yet, skip the row-emitting batches (heartbeat
+        // will fill it). The scan phases above already ran.
         let populated = await cache.isPopulated
         if !populated {
-            logger.debug("messages tick: known-identifiers cache empty; skipping", metadata: [:])
+            logger.debug("messages tick: known-identifiers cache empty; skipping batches", metadata: [:])
             return
         }
 
         // Capture install-time MAX(ROWID) if needed.
-        var working = cursor
         if working.installMaxRowID == nil {
             do {
                 let maxROWID = try await pool.read { try ChatDBReader.maxROWID(db: $0) } ?? 0
@@ -180,36 +215,6 @@ public actor MessagesSourcePlugin: DataSourcePlugin {
             now: tickStart)
         var hadRejection = false
         var hadUnconfirmed = false
-
-        // Pending-scan + newly-known handling.
-        //
-        // V1 simplification: chat.db doesn't support an efficient
-        // identifier-scoped query, so the daemon doesn't execute
-        // identifier-scoped backwards scans. Both the operator-queued
-        // pendingScans (in the cursor JSON) and the in-memory
-        // newly-added queue are surfaced via logs + status output
-        // but NOT consumed here.
-        //
-        // The natural backfill descent already walks every message
-        // back to backfillFloorSentAt and the sender filter
-        // (KnownIdentifiersCache.contains) makes sure new contacts'
-        // messages emit as soon as backfill reaches them. The
-        // pendingScans queue is therefore kept (not cleared) so the
-        // operator can see queued items via `crm-mac status` until
-        // a future PR ships true identifier-scoped scans. README
-        // documents this v1 behavior; tests cover the persistence
-        // semantics.
-        let newlyAdded = await cache.drainNewlyAdded(for: id)
-        if !newlyAdded.isEmpty {
-            logger.info("messages tick: newly-known contacts detected", metadata: [
-                "count": .public(String(newlyAdded.count)),
-            ])
-        }
-        if !working.pendingScans.isEmpty {
-            logger.info("messages tick: pending scans observed (not executed in v1)", metadata: [
-                "count": .public(String(working.pendingScans.count)),
-            ])
-        }
 
         // Backfill batch (descending).
         if !working.backfillComplete, budget.rowsRemaining > 0 {
@@ -237,39 +242,17 @@ public actor MessagesSourcePlugin: DataSourcePlugin {
         // failed rows.
         let cursorChanged = working != cursor
         if cursorChanged && !hadRejection && !hadUnconfirmed {
-            do {
-                let newJSON = try MessagesCursorCodec.encode(working)
-                try await piClient.commitCursor(
-                    auth: auth,
-                    source: "messages",
-                    cursor: newJSON,
-                    baseCursor: lastCommittedCursorJSON,
-                    cursorEpoch: cachedEpoch,
-                    backfillComplete: working.backfillComplete)
-                // Cache locally via StateMutator (write-through).
-                try await writeThroughCursor(
-                    newJSON,
-                    epoch: cachedEpoch,
-                    backfillComplete: working.backfillComplete,
-                    lastPushedAt: clock())
-                cachedCursor = working
-                lastCommittedCursorJSON = newJSON
+            switch await commitWorking(working) {
+            case .committed:
                 logger.debug("messages tick: cursor committed", metadata: [
                     "live_cursor": .public(String(working.liveCursor ?? 0)),
                     "backfill_cursor": .public(working.backfillCursor.map(String.init) ?? "nil"),
                     "backfill_complete": .public(String(working.backfillComplete)),
                 ])
-            } catch let PiClientError.cursorConflict(_, current) {
-                logger.info("messages tick: cursor conflict, refreshing", metadata: [
-                    "current_epoch": .public(current.currentEpoch.map(String.init) ?? "nil"),
-                ])
-                // Best-effort refresh; abort the tick.
+            case .conflict:
                 _ = try? await loadOrFetchCursor(forceRefresh: true)
                 return
-            } catch {
-                logger.warning("messages tick: cursor commit failed", metadata: [
-                    "error": .private(String(describing: error)),
-                ])
+            case .failed:
                 return
             }
         } else if hadRejection {
@@ -292,6 +275,249 @@ public actor MessagesSourcePlugin: DataSourcePlugin {
             pushed: working.liveCursor,
             backfillComplete: working.backfillComplete))
     }
+
+    // MARK: - cursor commit helper
+
+    /// Result of a CAS cursor commit.
+    private enum CommitResult {
+        case committed
+        case conflict
+        case failed
+    }
+
+    /// CAS-commit `working` to the Pi (base = lastCommittedCursorJSON),
+    /// write through to local state.json, and update the in-memory
+    /// cache (`cachedCursor` / `lastCommittedCursorJSON`). Used by the
+    /// scan phases AND the final backfill/live commit so the CAS base
+    /// and write-through stay in lockstep across multiple commits per
+    /// tick.
+    private func commitWorking(_ working: MessagesCursor) async -> CommitResult {
+        let newJSON: String
+        do {
+            newJSON = try MessagesCursorCodec.encode(working)
+        } catch {
+            logger.warning("messages tick: cursor encode failed", metadata: [
+                "error": .private(String(describing: error)),
+            ])
+            return .failed
+        }
+        do {
+            try await piClient.commitCursor(
+                auth: auth,
+                source: "messages",
+                cursor: newJSON,
+                baseCursor: lastCommittedCursorJSON,
+                cursorEpoch: cachedEpoch,
+                backfillComplete: working.backfillComplete)
+            try await writeThroughCursor(
+                newJSON,
+                epoch: cachedEpoch,
+                backfillComplete: working.backfillComplete,
+                lastPushedAt: clock())
+            cachedCursor = working
+            lastCommittedCursorJSON = newJSON
+            return .committed
+        } catch let PiClientError.cursorConflict(_, current) {
+            logger.info("messages tick: cursor conflict, refreshing", metadata: [
+                "current_epoch": .public(current.currentEpoch.map(String.init) ?? "nil"),
+            ])
+            return .conflict
+        } catch {
+            logger.warning("messages tick: cursor commit failed", metadata: [
+                "error": .private(String(describing: error)),
+            ])
+            return .failed
+        }
+    }
+
+    // MARK: - Phase A: durable scan enqueue
+
+    private enum ScanEnqueueResult {
+        case ok
+        case aborted
+    }
+
+    /// Drain the cache's newly-added bucket (non-destructive), merge it
+    /// into `working.pendingScans` (coverage-dedup + cap) with a 30-day
+    /// window, and commit the cursor BEFORE any scan executes. On commit
+    /// success the drained identifiers are confirmed in the cache; on
+    /// failure they are returned so the next tick re-enqueues. Returns
+    /// `.aborted` when the tick must stop (commit failure/conflict).
+    private func runScanEnqueue(working: inout MessagesCursor) async -> ScanEnqueueResult {
+        let drained = await cache.drainNewlyAdded(for: id)
+        if drained.isEmpty {
+            return .ok
+        }
+        logger.info("messages tick: newly-known contacts detected", metadata: [
+            "count": .public(String(drained.count)),
+        ])
+        // Sort canonical-ascending so drop-oldest + queue order are
+        // deterministic across runs (the bucket is an unordered Set).
+        let since = clock().addingTimeInterval(-Self.scanWindowSeconds)
+        let floor = config.backfillFloor
+        let scanSince = max(since, floor)
+        for handle in drained.sorted() {
+            mergePendingScan(
+                into: &working.pendingScans,
+                handle: handle,
+                since: scanSince)
+        }
+        switch await commitWorking(working) {
+        case .committed:
+            // Durably enqueued — the drained identifiers leave the
+            // cache's owed set, eligible for the next refresher persist.
+            await cache.confirmDrained(for: id)
+            return .ok
+        case .conflict:
+            // Not durable — return the drained identifiers so the next
+            // tick re-enqueues. The tick aborts (working is discarded).
+            await cache.returnInFlight(for: id)
+            _ = try? await loadOrFetchCursor(forceRefresh: true)
+            return .aborted
+        case .failed:
+            await cache.returnInFlight(for: id)
+            return .aborted
+        }
+    }
+
+    /// Merge identifier `handle` into a pendingScans list with
+    /// COVERAGE-DEDUP: at most one entry per handle, keeping the WIDER
+    /// window. A wider window (earlier `since`) resets progress to nil
+    /// so the larger range is re-walked; an equal-or-narrower window
+    /// leaves the existing entry (and its progress) untouched.
+    private func mergePendingScan(
+        into scans: inout [PendingScan],
+        handle: String,
+        since: Date
+    ) {
+        if let idx = scans.firstIndex(where: { $0.normalizedHandle == handle }) {
+            let existing = scans[idx]
+            if since < existing.since {
+                // Wider window: widen + reset progress to re-walk.
+                scans[idx] = PendingScan(
+                    normalizedHandle: handle,
+                    since: since,
+                    progressBelowRowID: nil)
+            }
+            // Equal-or-narrower: keep the existing entry + its progress.
+            return
+        }
+        var next = scans
+        next.append(PendingScan(normalizedHandle: handle, since: since, progressBelowRowID: nil))
+        // Bounded queue: drop oldest on overflow.
+        if next.count > MessagesCursor.pendingScansCap {
+            next.removeFirst(next.count - MessagesCursor.pendingScansCap)
+            logger.warning("messages tick: pending-scan cap reached; dropped oldest", metadata: [:])
+        }
+        scans = next
+    }
+
+    // MARK: - Phase B: execute pending scans
+
+    /// Execute the pending scans in `working.pendingScans` (resumable,
+    /// budget-bound). For each entry: membership-check against the known
+    /// set (drop unknown handles), walk one budget-limited page
+    /// descending from the entry's progress, publish, then either
+    /// advance the entry's progress (still queued) or dequeue it on
+    /// confirmed exhaustion. Re-commits the cursor after each entry's
+    /// progress/dequeue so a crash recovers from the persisted cursor.
+    private func runPendingScans(pool: DatabasePool, working: inout MessagesCursor) async {
+        guard !working.pendingScans.isEmpty else { return }
+        // Iterate by handle snapshot; mutate working.pendingScans in
+        // place as each entry advances or completes.
+        let handles = working.pendingScans.map(\.normalizedHandle)
+        var scanBudget = config.maxRowsPerTick
+        for handle in handles {
+            if scanBudget <= 0 { break }
+            guard let entry = working.pendingScans.first(where: { $0.normalizedHandle == handle }) else {
+                continue
+            }
+            // Membership check (R4): drop scans for handles not in the
+            // current known set — operator typo / removed contact.
+            let known = await cache.contains(handle)
+            if !known {
+                working.pendingScans.removeAll { $0.normalizedHandle == handle }
+                logger.warning("messages scan: handle not in known set; dropping", metadata: [
+                    "handle": .private(handle),
+                ])
+                if case .aborted = await commitAfterScanMutation(working) { return }
+                continue
+            }
+
+            let limit = min(scanBudget, MessagesPublisher.maxEventsPerBatch)
+            let page: MessagesScanPage
+            do {
+                page = try await pool.read { db in
+                    try MessagesScanReader.scanPage(
+                        db: db,
+                        canonicalHandle: handle,
+                        since: entry.since,
+                        progressBelowRowID: entry.progressBelowRowID,
+                        limit: limit)
+                }
+            } catch let dbError as DatabaseError where isFDAError(dbError) {
+                await markUnhealthy(reason: "fda_required")
+                return
+            } catch {
+                logger.warning("messages scan: read failed; holding entry", metadata: [
+                    "error": .private(String(describing: error)),
+                ])
+                continue
+            }
+
+            scanBudget -= page.rows.count
+
+            let publishItems = await filterAndShape(rows: page.rows, isBackfill: true)
+            let outcome = await publisher.publish(items: publishItems)
+
+            let confirmed: Bool
+            if publishItems.isEmpty {
+                confirmed = true
+            } else {
+                confirmed = outcome.rejected.isEmpty && outcome.unconfirmed == 0
+            }
+            if !confirmed {
+                // Publish failure: leave progress unchanged so the next
+                // tick retries from the same coordinate. Event-log dedup
+                // absorbs any re-emit.
+                logger.warning("messages scan: publish unconfirmed; holding progress", metadata: [
+                    "handle": .private(handle),
+                ])
+                continue
+            }
+
+            if page.exhausted {
+                // Final short page confirmed-published → dequeue.
+                working.pendingScans.removeAll { $0.normalizedHandle == handle }
+            } else if let lowest = page.lowestRowID {
+                // Advance progress; entry stays queued for the next tick.
+                if let idx = working.pendingScans.firstIndex(where: { $0.normalizedHandle == handle }) {
+                    working.pendingScans[idx] = PendingScan(
+                        normalizedHandle: handle,
+                        since: entry.since,
+                        progressBelowRowID: lowest)
+                }
+            }
+            if case .aborted = await commitAfterScanMutation(working) { return }
+        }
+    }
+
+    /// Commit `working` after a scan entry's progress/dequeue mutation.
+    /// A conflict refreshes + aborts the remaining scans this tick.
+    private func commitAfterScanMutation(_ working: MessagesCursor) async -> ScanEnqueueResult {
+        switch await commitWorking(working) {
+        case .committed:
+            return .ok
+        case .conflict:
+            _ = try? await loadOrFetchCursor(forceRefresh: true)
+            return .aborted
+        case .failed:
+            return .aborted
+        }
+    }
+
+    /// Automatic newly-known scans always use a 30-day window.
+    private static let scanWindowSeconds: TimeInterval = 30 * 24 * 60 * 60
 
     // MARK: - per-tick batch runners
 

--- a/mac-daemon/Sources/CRMMacPhoneCallsSource/CRMMacPhoneCallsSource.swift
+++ b/mac-daemon/Sources/CRMMacPhoneCallsSource/CRMMacPhoneCallsSource.swift
@@ -9,6 +9,7 @@
 //   - ServiceDerivation.swift     (ZSERVICE_PROVIDER, ZCALLTYPE) -> service
 //   - CallHistoryDBSchema.swift   whitelist + drift detection
 //   - CallHistoryDBReader.swift   GRDB-backed row iterator
+//   - CallHistoryScanReader.swift identifier-scoped resumable scan
 //   - PayloadShaping.swift        ZCALLRECORD row -> CallPayload
 //   - PhoneCallsCursor.swift      typealiases pointing at CRMMacCore wire
 //   - PhoneCallsPublisher.swift   /ingest/events batching

--- a/mac-daemon/Sources/CRMMacPhoneCallsSource/CallHistoryDBReader.swift
+++ b/mac-daemon/Sources/CRMMacPhoneCallsSource/CallHistoryDBReader.swift
@@ -130,6 +130,124 @@ public enum CallHistoryDBReader {
         return CallCursorPoint(zdate: zd, zPK: pk)
     }
 
+    /// Shared SELECT column list (aliased) for ZCALLRECORD reads. Both
+    /// `fetchPage` and the identifier-scoped `CallHistoryScanReader`
+    /// project the same columns so `mapRow` can map either's rows.
+    static let selectColumns = """
+        SELECT
+            Z_PK              AS z_pk,
+            ZUNIQUE_ID        AS unique_id,
+            ZADDRESS          AS address,
+            ZORIGINATED       AS originated,
+            ZANSWERED         AS answered,
+            ZDURATION         AS duration,
+            ZSERVICE_PROVIDER AS service_provider,
+            ZCALLTYPE         AS call_type,
+            ZHASMESSAGE       AS has_message,
+            ZDATE             AS zdate
+        FROM ZCALLRECORD
+        """
+
+    /// Outcome of mapping one fetched row (aliased per `selectColumns`).
+    enum MappedRow {
+        /// Row had no usable (ZDATE, Z_PK) coordinate — not even
+        /// counted toward scanned bounds.
+        case malformed
+        /// Row inspected at `point` but skipped (corrupt date, empty
+        /// address, unmappable service). `serviceUnknown` is true only
+        /// for the service-derivation-failed case.
+        case skipped(point: CallCursorPoint, serviceUnknown: Bool)
+        /// Row kept; `point` is its (ZDATE, Z_PK) coordinate.
+        case kept(CallHistoryRow, point: CallCursorPoint)
+    }
+
+    /// Map one fetched GRDB row (aliased per `selectColumns`) to a
+    /// `MappedRow`, applying every per-row skip filter (corrupt ZDATE,
+    /// empty address, unmappable service). Shared by `fetchPage` and
+    /// `CallHistoryScanReader` so both apply identical filtering.
+    static func mapRow(_ row: Row) -> MappedRow {
+        guard let zPK: Int64 = row["z_pk"],
+              let zdate: Double = row["zdate"] else {
+            return .malformed
+        }
+        let point = CallCursorPoint(zdate: zdate, zPK: zPK)
+
+        // Corrupt date sentinel: zdate <= 0 or below the ~2016-Nov
+        // floor. These rows are very rare in real data and almost
+        // always indicate corruption.
+        if zdate <= 0 || zdate < Self.dateSentinelFloor {
+            return .skipped(point: point, serviceUnknown: false)
+        }
+
+        guard let uniqueID: String = row["unique_id"], !uniqueID.isEmpty else {
+            return .skipped(point: point, serviceUnknown: false)
+        }
+
+        let address: String? = row["address"]
+        let trimmedAddress = address?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let trimmedAddress, !trimmedAddress.isEmpty else {
+            // Missing/empty address: skip — no peer to attribute to.
+            return .skipped(point: point, serviceUnknown: false)
+        }
+
+        let originatedRaw: Int64 = (row["originated"] as Int64?) ?? 0
+        let originated = originatedRaw != 0
+
+        let answeredColumn: Int64? = row["answered"]
+        let answered: Bool? = {
+            if originated {
+                // Outbound: ZANSWERED is unreliable; force NULL.
+                return nil
+            }
+            guard let v = answeredColumn else { return false }
+            return v != 0
+        }()
+
+        let durationRaw: Double = (row["duration"] as Double?) ?? 0
+        let duration = Int32(max(0, durationRaw.rounded()))
+
+        let provider: String? = row["service_provider"]
+        let callType: Int64? = row["call_type"]
+        // Service derivation is purely a row-level concern; we run it
+        // here so the reader can count unknown-service rows and skip
+        // them before payload shaping touches them.
+        if ServiceDerivation.resolve(provider: provider, callType: callType) == nil {
+            return .skipped(point: point, serviceUnknown: true)
+        }
+
+        let hasMessageRaw: Int64 = (row["has_message"] as Int64?) ?? 0
+        // ZHASMESSAGE is inbound-only on iOS/macOS (the column is
+        // reused for outbound greetings, which we don't surface).
+        // Force false outbound regardless of source data.
+        let hasMessage = !originated && hasMessageRaw != 0
+
+        let startedAt = Date(timeIntervalSince1970: Self.appleEpochOffset + zdate)
+
+        return .kept(CallHistoryRow(
+            zPK: zPK,
+            uniqueID: uniqueID,
+            address: trimmedAddress,
+            originated: originated,
+            answered: answered,
+            duration: duration,
+            serviceProvider: provider,
+            callType: callType,
+            hasMessage: hasMessage,
+            startedAt: startedAt), point: point)
+    }
+
+    /// Choose the lexicographically smaller/larger of an optional
+    /// running bound and a new point. Exposed package-internal so
+    /// `CallHistoryScanReader` can track its lowest inspected point.
+    static func lexExtend(
+        _ current: CallCursorPoint?,
+        _ point: CallCursorPoint,
+        choose: LexChoice
+    ) -> CallCursorPoint {
+        guard let current else { return point }
+        return lex(current, point, choose: choose)
+    }
+
     /// Fetch up to `limit` rows in `direction` order. The reader applies
     /// every per-row skip filter (empty ZADDRESS, corrupt ZDATE,
     /// unmappable service) and reports a service_unknown counter.
@@ -158,18 +276,7 @@ public enum CallHistoryDBReader {
         }
 
         let sql = """
-            SELECT
-                Z_PK              AS z_pk,
-                ZUNIQUE_ID        AS unique_id,
-                ZADDRESS          AS address,
-                ZORIGINATED       AS originated,
-                ZANSWERED         AS answered,
-                ZDURATION         AS duration,
-                ZSERVICE_PROVIDER AS service_provider,
-                ZCALLTYPE         AS call_type,
-                ZHASMESSAGE       AS has_message,
-                ZDATE             AS zdate
-            FROM ZCALLRECORD
+            \(Self.selectColumns)
             WHERE \(whereClause)
             ORDER BY \(order)
             LIMIT ?
@@ -185,82 +292,21 @@ public enum CallHistoryDBReader {
         var scannedMax: CallCursorPoint?
 
         for row in rawRows {
-            guard let zPK: Int64 = row["z_pk"],
-                  let zdate: Double = row["zdate"] else {
+            switch mapRow(row) {
+            case .malformed:
                 continue
+            case .skipped(let point, let unknown):
+                // Track every (ZDATE, Z_PK) we inspected, even rows we
+                // ultimately skip. The caller advances the cursor past
+                // skipped rows so all-rejected pages don't stall.
+                scannedMin = lexExtend(scannedMin, point, choose: .min)
+                scannedMax = lexExtend(scannedMax, point, choose: .max)
+                if unknown { serviceUnknown += 1 }
+            case .kept(let mapped, let point):
+                scannedMin = lexExtend(scannedMin, point, choose: .min)
+                scannedMax = lexExtend(scannedMax, point, choose: .max)
+                kept.append(mapped)
             }
-            // Track every (ZDATE, Z_PK) we inspected, even rows we
-            // ultimately skip. The caller advances the cursor past
-            // skipped rows so all-rejected pages don't stall.
-            let point = CallCursorPoint(zdate: zdate, zPK: zPK)
-            if scannedMin == nil { scannedMin = point }
-            if scannedMax == nil { scannedMax = point }
-            scannedMin = lex(scannedMin!, point, choose: .min)
-            scannedMax = lex(scannedMax!, point, choose: .max)
-
-            // Corrupt date sentinel: zdate <= 0 or below the
-            // ~2016-Nov floor. These rows are very rare in real data
-            // and almost always indicate corruption.
-            if zdate <= 0 || zdate < Self.dateSentinelFloor {
-                continue
-            }
-
-            guard let uniqueID: String = row["unique_id"], !uniqueID.isEmpty else {
-                continue
-            }
-
-            let address: String? = row["address"]
-            let trimmedAddress = address?.trimmingCharacters(in: .whitespacesAndNewlines)
-            if trimmedAddress == nil || trimmedAddress!.isEmpty {
-                // Missing/empty address: skip — no peer to attribute to.
-                continue
-            }
-
-            let originatedRaw: Int64 = (row["originated"] as Int64?) ?? 0
-            let originated = originatedRaw != 0
-
-            let answeredColumn: Int64? = row["answered"]
-            let answered: Bool? = {
-                if originated {
-                    // Outbound: ZANSWERED is unreliable; force NULL.
-                    return nil
-                }
-                guard let v = answeredColumn else { return false }
-                return v != 0
-            }()
-
-            let durationRaw: Double = (row["duration"] as Double?) ?? 0
-            let duration = Int32(max(0, durationRaw.rounded()))
-
-            let provider: String? = row["service_provider"]
-            let callType: Int64? = row["call_type"]
-            // Service derivation is purely a row-level concern; we run
-            // it here so the reader can count unknown-service rows and
-            // skip them before payload shaping touches them.
-            if ServiceDerivation.resolve(provider: provider, callType: callType) == nil {
-                serviceUnknown += 1
-                continue
-            }
-
-            let hasMessageRaw: Int64 = (row["has_message"] as Int64?) ?? 0
-            // ZHASMESSAGE is inbound-only on iOS/macOS (the column is
-            // reused for outbound greetings, which we don't surface).
-            // Force false outbound regardless of source data.
-            let hasMessage = !originated && hasMessageRaw != 0
-
-            let startedAt = Date(timeIntervalSince1970: Self.appleEpochOffset + zdate)
-
-            kept.append(CallHistoryRow(
-                zPK: zPK,
-                uniqueID: uniqueID,
-                address: trimmedAddress,
-                originated: originated,
-                answered: answered,
-                duration: duration,
-                serviceProvider: provider,
-                callType: callType,
-                hasMessage: hasMessage,
-                startedAt: startedAt))
         }
 
         let bounds: (min: CallCursorPoint, max: CallCursorPoint)?
@@ -278,7 +324,7 @@ public enum CallHistoryDBReader {
 
     // MARK: - lex compare helpers
 
-    private enum LexChoice { case min, max }
+    enum LexChoice { case min, max }
     private static func lex(_ a: CallCursorPoint, _ b: CallCursorPoint,
                              choose: LexChoice) -> CallCursorPoint {
         let cmp: Bool

--- a/mac-daemon/Sources/CRMMacPhoneCallsSource/CallHistoryScanReader.swift
+++ b/mac-daemon/Sources/CRMMacPhoneCallsSource/CallHistoryScanReader.swift
@@ -1,0 +1,154 @@
+// CallHistoryScanReader — identifier-scoped, date-bounded, resumable
+// scan over CallHistoryDB ZCALLRECORD rows for a single canonical
+// handle.
+//
+// Unlike chat.db, CallHistoryDB indexes ZADDRESS, so a handle-scoped
+// scan is index-assisted. But ZADDRESS is raw/uncanonicalized — one
+// canonical handle (e.g. "+15550000001") can be stored under several
+// raw spellings ("+15550000001", "(555) 000-0001", …). A naive
+// `WHERE ZADDRESS = ?` would miss alternate spellings AND can't
+// canonicalize inside SQL.
+//
+// The scan therefore runs in two passes:
+//
+//   1. Resolve matching raw addresses. `SELECT DISTINCT ZADDRESS FROM
+//      ZCALLRECORD` is bounded (one row per distinct raw address seen),
+//      canonicalize each in Swift, and keep the raw values whose
+//      canonical form equals the target. This is the same
+//      canonicalizer the sender filter uses; it CANNOT run in SQL.
+//
+//   2. Scan calls. `ZADDRESS IN (resolved) AND ZDATE >= sinceSeconds
+//      [AND (ZDATE, Z_PK) < progress]` ordered `(ZDATE, Z_PK) DESC`,
+//      budget-limited. The ZADDRESS index keeps each page cheap.
+//
+// The scan is RESUMABLE: passing the `(progressBelowZDate,
+// progressBelowZPK)` pair walks the next page strictly below the lowest
+// `(ZDATE, Z_PK)` already confirmed-published, so a scan whose result
+// set exceeds one tick's budget completes across ticks without dropping
+// rows.
+//
+// ZDATE is Apple-epoch SECONDS (Double), not chat.db's nanoseconds —
+// the `since` Date lower bound is converted to that unit here.
+import Foundation
+import GRDB
+
+/// Result of one phone-scan page.
+public struct CallHistoryScanPage: Equatable, Sendable {
+    /// The kept rows (skip filters already applied), (ZDATE, Z_PK)
+    /// descending.
+    public let rows: [CallHistoryRow]
+    /// True if SQL returned fewer than `limit` rows — i.e. the scan has
+    /// no more matching rows below this page (exhausted).
+    public let exhausted: Bool
+    /// Lowest (ZDATE, Z_PK) inspected in this page (including skipped
+    /// rows), or nil if SQL returned zero rows. The caller advances the
+    /// scan's progress to this so the next page resumes strictly below
+    /// it. Tracking EVERY inspected coordinate (not just kept) means a
+    /// page of all-skipped rows still advances and doesn't stall.
+    public let lowestPoint: CallCursorPoint?
+
+    public init(rows: [CallHistoryRow], exhausted: Bool, lowestPoint: CallCursorPoint?) {
+        self.rows = rows
+        self.exhausted = exhausted
+        self.lowestPoint = lowestPoint
+    }
+}
+
+public enum CallHistoryScanReader {
+    /// Resolve the set of distinct raw ZADDRESS values whose canonical
+    /// form equals `canonicalHandle`. One canonical handle can map to
+    /// several raw spellings, so all matching raw values are returned.
+    /// `canonicalizer` is the same normalizer the sender filter uses.
+    public static func resolveAddresses(
+        db: Database,
+        canonicalHandle: String,
+        canonicalizer: (String) -> String
+    ) throws -> [String] {
+        let rows = try Row.fetchAll(
+            db, sql: "SELECT DISTINCT ZADDRESS AS addr FROM ZCALLRECORD WHERE ZADDRESS IS NOT NULL")
+        var matches: [String] = []
+        for row in rows {
+            guard let raw: String = row["addr"] else { continue }
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty { continue }
+            if canonicalizer(trimmed) == canonicalHandle {
+                matches.append(raw)
+            }
+        }
+        return matches
+    }
+
+    /// Fetch one budget-limited page of calls for `canonicalHandle`
+    /// at-or-after `since`, descending by (ZDATE, Z_PK), resuming
+    /// strictly below `(progressBelowZDate, progressBelowZPK)` when set.
+    ///
+    /// Returns an EMPTY exhausted page (no rows, lowestPoint nil) when
+    /// the handle resolves to zero raw addresses (no call history for
+    /// it).
+    public static func scanPage(
+        db: Database,
+        canonicalHandle: String,
+        canonicalizer: (String) -> String,
+        since: Date,
+        progressBelowZDate: Double?,
+        progressBelowZPK: Int64?,
+        limit: Int
+    ) throws -> CallHistoryScanPage {
+        precondition(limit > 0, "limit must be > 0")
+
+        let addresses = try resolveAddresses(
+            db: db, canonicalHandle: canonicalHandle, canonicalizer: canonicalizer)
+        if addresses.isEmpty {
+            return CallHistoryScanPage(rows: [], exhausted: true, lowestPoint: nil)
+        }
+
+        // Convert the Date lower bound to CallHistoryDB's Apple-epoch
+        // SECONDS unit.
+        let sinceSeconds = since.timeIntervalSince1970 - CallHistoryDBReader.appleEpochOffset
+
+        let placeholders = Array(repeating: "?", count: addresses.count).joined(separator: ", ")
+        var conditions = [
+            "ZADDRESS IN (\(placeholders))",
+            "ZDATE >= ?",
+        ]
+        var arguments: [DatabaseValueConvertible] = addresses
+        arguments.append(sinceSeconds)
+        // Resume bound: strictly below the lowest (ZDATE, Z_PK) already
+        // published. The pair must be supplied together.
+        if let pZDate = progressBelowZDate, let pZPK = progressBelowZPK {
+            conditions.append("((ZDATE < ?) OR (ZDATE = ? AND Z_PK < ?))")
+            arguments.append(pZDate)
+            arguments.append(pZDate)
+            arguments.append(pZPK)
+        }
+        arguments.append(Int64(limit))
+
+        let sql = """
+            \(CallHistoryDBReader.selectColumns)
+            WHERE \(conditions.joined(separator: " AND "))
+            ORDER BY ZDATE DESC, Z_PK DESC
+            LIMIT ?
+            """
+
+        let rawRows = try Row.fetchAll(db, sql: sql, arguments: StatementArguments(arguments))
+
+        var kept: [CallHistoryRow] = []
+        kept.reserveCapacity(rawRows.count)
+        var lowest: CallCursorPoint?
+        for row in rawRows {
+            switch CallHistoryDBReader.mapRow(row) {
+            case .malformed:
+                continue
+            case .skipped(let point, _):
+                lowest = CallHistoryDBReader.lexExtend(lowest, point, choose: .min)
+            case .kept(let mapped, let point):
+                lowest = CallHistoryDBReader.lexExtend(lowest, point, choose: .min)
+                kept.append(mapped)
+            }
+        }
+        return CallHistoryScanPage(
+            rows: kept,
+            exhausted: rawRows.count < limit,
+            lowestPoint: lowest)
+    }
+}

--- a/mac-daemon/Sources/CRMMacPhoneCallsSource/CallHistoryScanReader.swift
+++ b/mac-daemon/Sources/CRMMacPhoneCallsSource/CallHistoryScanReader.swift
@@ -138,6 +138,13 @@ public enum CallHistoryScanReader {
         for row in rawRows {
             switch CallHistoryDBReader.mapRow(row) {
             case .malformed:
+                // Unreachable on this query path: `.malformed` means a
+                // NULL/unreadable (ZDATE, Z_PK), but the WHERE clause
+                // requires `ZDATE >= ?` (NULL fails the comparison) and
+                // Z_PK is the non-null primary key. No coordinate to
+                // advance `lowest` past, so a page that somehow held one
+                // could not move the resume bound — guard the invariant.
+                assertionFailure("scan query returned a malformed (null-coordinate) call row")
                 continue
             case .skipped(let point, _):
                 lowest = CallHistoryDBReader.lexExtend(lowest, point, choose: .min)

--- a/mac-daemon/Sources/CRMMacPhoneCallsSource/PhoneCallsSourcePlugin.swift
+++ b/mac-daemon/Sources/CRMMacPhoneCallsSource/PhoneCallsSourcePlugin.swift
@@ -268,7 +268,7 @@ public actor PhoneCallsSourcePlugin: DataSourcePlugin {
         // Identifier-scoped 30-day backwards scan is deferred — we
         // observe the newly-added queue for visibility but do NOT
         // consume it (parity with the merged messages plugin).
-        let newlyAdded = await cache.drainNewlyAdded()
+        let newlyAdded = await cache.drainNewlyAdded(for: id)
         if !newlyAdded.isEmpty {
             logger.info("phone_calls tick: newly-known contacts detected", metadata: [
                 "count": .public(String(newlyAdded.count)),

--- a/mac-daemon/Sources/CRMMacPhoneCallsSource/PhoneCallsSourcePlugin.swift
+++ b/mac-daemon/Sources/CRMMacPhoneCallsSource/PhoneCallsSourcePlugin.swift
@@ -14,14 +14,24 @@
 //     writers (Phone.app / FaceTime / Continuity).
 //   - Load cursor: piClient.getCursor("phone_calls") -> decode into
 //     PhoneCallsCursor; cache locally via StateMutator.
+//   - Phase A — durable scan enqueue: drain the known-identifiers
+//     cache's newly-added bucket (non-destructive), coverage-dedup +
+//     cap them into pendingScans with a 30-day window, and commit the
+//     cursor BEFORE executing any scan. On success confirm the drain;
+//     on failure return it so the next tick re-enqueues. Runs
+//     regardless of isPopulated.
+//   - Phase B — execute pending scans (gated on cache.hasFetched, NOT
+//     isPopulated): membership-check each entry, walk one budget-
+//     limited page via CallHistoryScanReader (resumable via the
+//     entry's (ZDATE, Z_PK) progress), publish, advance progress or
+//     dequeue on exhaustion, re-commit. Runs BEFORE the row-emitting
+//     batches.
 //   - Capture install-time MAX(ZDATE, Z_PK) on the first tick. The
 //     live cursor starts at (install_max.zdate, install_max.zPK - 1)
 //     so the first live tick's tuple tie-break includes the
 //     install_max row itself.
 //   - Sender filter: bail if KnownIdentifiersCache isn't populated
-//     yet (heartbeat will fill it). The newly-added queue is observed
-//     + logged but not consumed — identifier-scoped scans are
-//     deferred to a follow-up.
+//     yet (heartbeat will fill it) — the scan phases above already ran.
 //   - Backfill batch (descending) + live batch (ascending), each
 //     bounded by the shared PhoneCallsBudget.
 //   - If the in-memory cursor changed AND every batch was confirmed
@@ -31,7 +41,9 @@
 //
 // The plugin is the single owner of the GRDB DatabasePool, but shares
 // the KnownIdentifiersCache (in CRMMacCore) with CRMMacMessagesSource.
-// All writes to state.json funnel through StateMutator.
+// All writes to state.json funnel through StateMutator. The plugin
+// NEVER writes the persisted known-identifiers baseline — that is the
+// heartbeat refresher's job (single-writer model).
 import Foundation
 import GRDB
 import CRMMacCore
@@ -213,7 +225,32 @@ public actor PhoneCallsSourcePlugin: DataSourcePlugin {
             return
         }
 
-        // Sender filter populated?
+        var working = cursor
+
+        // Phase A — durable scan enqueue (commit-first). Drain the
+        // cache's newly-added bucket NON-DESTRUCTIVELY and merge it into
+        // working.pendingScans (coverage-dedup + cap), then commit the
+        // cursor with the enlarged queue BEFORE any scan executes. On
+        // commit success the drained identifiers are confirmed; on
+        // failure they are returned to the cache so the next tick
+        // re-enqueues. Runs regardless of isPopulated — a newly-known
+        // identifier must be durably queued even on a tick where the
+        // row-emitting batches skip.
+        if await runScanEnqueue(working: &working) == .aborted {
+            return
+        }
+
+        // Phase B — execute pending scans (resumable), gated on
+        // hasFetched (NOT isPopulated). An empty-but-fetched CRM still
+        // adjudicates pending scans (drops an operator scan for a
+        // now-removed contact); a not-yet-fetched cache defers them.
+        if await cache.hasFetched {
+            await runPendingScans(pool: pool, working: &working)
+        }
+
+        // Sender filter populated?  If the known-identifiers cache
+        // hasn't been populated yet, skip the row-emitting batches
+        // (heartbeat will fill it). The scan phases above already ran.
         let populated = await cache.isPopulated
         if !populated {
             logger.debug("phone_calls tick: known-identifiers cache empty; skipping", metadata: [:])
@@ -232,7 +269,6 @@ public actor PhoneCallsSourcePlugin: DataSourcePlugin {
         // backwardFromExclusive and live at the same tuple via
         // forwardFromExclusive — would skip the install_max row
         // forever.
-        var working = cursor
         if working.installMaxZDate == nil {
             do {
                 let maxPoint = try await pool.read { try CallHistoryDBReader.maxZDate(db: $0) }
@@ -265,16 +301,6 @@ public actor PhoneCallsSourcePlugin: DataSourcePlugin {
         var hadRejection = false
         var hadUnconfirmed = false
 
-        // Identifier-scoped 30-day backwards scan is deferred — we
-        // observe the newly-added queue for visibility but do NOT
-        // consume it (parity with the merged messages plugin).
-        let newlyAdded = await cache.drainNewlyAdded(for: id)
-        if !newlyAdded.isEmpty {
-            logger.info("phone_calls tick: newly-known contacts detected", metadata: [
-                "count": .public(String(newlyAdded.count)),
-            ])
-        }
-
         // Backfill batch (descending).
         if !working.backfillComplete, budget.rowsRemaining > 0 {
             let outcome = await runBackfillBatch(
@@ -299,38 +325,17 @@ public actor PhoneCallsSourcePlugin: DataSourcePlugin {
         // item we tried to publish was confirmed.
         let cursorChanged = working != cursor
         if cursorChanged && !hadRejection && !hadUnconfirmed {
-            do {
-                let newJSON = try PhoneCallsCursorCodec.encode(working)
-                try await piClient.commitCursor(
-                    auth: auth,
-                    source: "phone_calls",
-                    cursor: newJSON,
-                    baseCursor: lastCommittedCursorJSON,
-                    cursorEpoch: cachedEpoch,
-                    backfillComplete: working.backfillComplete)
-                let pushedAt = clock()
-                try await writeThroughCursor(
-                    newJSON,
-                    epoch: cachedEpoch,
-                    backfillComplete: working.backfillComplete,
-                    lastPushedAt: pushedAt)
-                cachedCursor = working
-                lastCommittedCursorJSON = newJSON
-                stickyLastPushedAt = pushedAt
+            switch await commitWorking(working) {
+            case .committed:
+                stickyLastPushedAt = clock()
                 stickyPushedCursor = formatLiveCursor(working) ?? stickyPushedCursor
                 logger.debug("phone_calls tick: cursor committed", metadata: [
                     "backfill_complete": .public(String(working.backfillComplete)),
                 ])
-            } catch let PiClientError.cursorConflict(_, current) {
-                logger.info("phone_calls tick: cursor conflict, refreshing", metadata: [
-                    "current_epoch": .public(current.currentEpoch.map(String.init) ?? "nil"),
-                ])
+            case .conflict:
                 _ = try? await loadOrFetchCursor(forceRefresh: true)
                 return
-            } catch {
-                logger.warning("phone_calls tick: cursor commit failed", metadata: [
-                    "error": .private(String(describing: error)),
-                ])
+            case .failed:
                 return
             }
         } else if hadRejection {
@@ -349,6 +354,253 @@ public actor PhoneCallsSourcePlugin: DataSourcePlugin {
             pushedCursorString: stickyPushedCursor,
             backfillComplete: working.backfillComplete))
     }
+
+    // MARK: - cursor commit helper
+
+    /// Result of a CAS cursor commit.
+    private enum CommitResult {
+        case committed
+        case conflict
+        case failed
+    }
+
+    /// CAS-commit `working` to the Pi (base = lastCommittedCursorJSON),
+    /// write through to local state.json, and update the in-memory
+    /// cache (`cachedCursor` / `lastCommittedCursorJSON`). Used by the
+    /// scan phases AND the final backfill/live commit so the CAS base
+    /// and write-through stay in lockstep across multiple commits per
+    /// tick. Does NOT touch the sticky health fields — the caller
+    /// updates those on a committed result for the row-emitting path.
+    private func commitWorking(_ working: PhoneCallsCursor) async -> CommitResult {
+        let newJSON: String
+        do {
+            newJSON = try PhoneCallsCursorCodec.encode(working)
+        } catch {
+            logger.warning("phone_calls tick: cursor encode failed", metadata: [
+                "error": .private(String(describing: error)),
+            ])
+            return .failed
+        }
+        do {
+            try await piClient.commitCursor(
+                auth: auth,
+                source: "phone_calls",
+                cursor: newJSON,
+                baseCursor: lastCommittedCursorJSON,
+                cursorEpoch: cachedEpoch,
+                backfillComplete: working.backfillComplete)
+            try await writeThroughCursor(
+                newJSON,
+                epoch: cachedEpoch,
+                backfillComplete: working.backfillComplete,
+                lastPushedAt: clock())
+            cachedCursor = working
+            lastCommittedCursorJSON = newJSON
+            return .committed
+        } catch let PiClientError.cursorConflict(_, current) {
+            logger.info("phone_calls tick: cursor conflict, refreshing", metadata: [
+                "current_epoch": .public(current.currentEpoch.map(String.init) ?? "nil"),
+            ])
+            return .conflict
+        } catch {
+            logger.warning("phone_calls tick: cursor commit failed", metadata: [
+                "error": .private(String(describing: error)),
+            ])
+            return .failed
+        }
+    }
+
+    // MARK: - Phase A: durable scan enqueue
+
+    private enum ScanEnqueueResult {
+        case ok
+        case aborted
+    }
+
+    /// Drain the cache's newly-added bucket (non-destructive), merge it
+    /// into `working.pendingScans` (coverage-dedup + cap) with a 30-day
+    /// window, and commit the cursor BEFORE any scan executes. On commit
+    /// success the drained identifiers are confirmed in the cache; on
+    /// failure they are returned so the next tick re-enqueues. Returns
+    /// `.aborted` when the tick must stop (commit failure/conflict).
+    private func runScanEnqueue(working: inout PhoneCallsCursor) async -> ScanEnqueueResult {
+        let drained = await cache.drainNewlyAdded(for: id)
+        if drained.isEmpty {
+            return .ok
+        }
+        logger.info("phone_calls tick: newly-known contacts detected", metadata: [
+            "count": .public(String(drained.count)),
+        ])
+        // Sort canonical-ascending so drop-oldest + queue order are
+        // deterministic across runs (the bucket is an unordered Set).
+        let since = clock().addingTimeInterval(-Self.scanWindowSeconds)
+        let scanSince = max(since, config.backfillFloor)
+        for handle in drained.sorted() {
+            mergePendingScan(
+                into: &working.pendingScans,
+                handle: handle,
+                since: scanSince)
+        }
+        switch await commitWorking(working) {
+        case .committed:
+            // Durably enqueued — the drained identifiers leave the
+            // cache's owed set, eligible for the next refresher persist.
+            await cache.confirmDrained(for: id)
+            return .ok
+        case .conflict:
+            // Not durable — return the drained identifiers so the next
+            // tick re-enqueues. The tick aborts (working is discarded).
+            await cache.returnInFlight(for: id)
+            _ = try? await loadOrFetchCursor(forceRefresh: true)
+            return .aborted
+        case .failed:
+            await cache.returnInFlight(for: id)
+            return .aborted
+        }
+    }
+
+    /// Merge identifier `handle` into a pendingScans list with
+    /// COVERAGE-DEDUP: at most one entry per handle, keeping the WIDER
+    /// window. A wider window (earlier `since`) resets progress to nil
+    /// so the larger range is re-walked; an equal-or-narrower window
+    /// leaves the existing entry (and its progress) untouched.
+    private func mergePendingScan(
+        into scans: inout [PhoneCallsCursorPendingScan],
+        handle: String,
+        since: Date
+    ) {
+        if let idx = scans.firstIndex(where: { $0.normalizedHandle == handle }) {
+            let existing = scans[idx]
+            if since < existing.since {
+                // Wider window: widen + reset progress to re-walk.
+                scans[idx] = PhoneCallsCursorPendingScan(
+                    normalizedHandle: handle,
+                    since: since,
+                    progressBelowZDate: nil,
+                    progressBelowZPK: nil)
+            }
+            // Equal-or-narrower: keep the existing entry + its progress.
+            return
+        }
+        var next = scans
+        next.append(PhoneCallsCursorPendingScan(normalizedHandle: handle, since: since))
+        // Bounded queue: drop oldest on overflow.
+        if next.count > PhoneCallsCursor.pendingScansCap {
+            next.removeFirst(next.count - PhoneCallsCursor.pendingScansCap)
+            logger.warning("phone_calls tick: pending-scan cap reached; dropped oldest", metadata: [:])
+        }
+        scans = next
+    }
+
+    // MARK: - Phase B: execute pending scans
+
+    /// Execute the pending scans in `working.pendingScans` (resumable,
+    /// budget-bound). For each entry: membership-check against the known
+    /// set (drop unknown handles), walk one budget-limited page
+    /// descending from the entry's (ZDATE, Z_PK) progress, publish, then
+    /// either advance the entry's progress (still queued) or dequeue it
+    /// on confirmed exhaustion. Re-commits the cursor after each entry's
+    /// progress/dequeue so a crash recovers from the persisted cursor.
+    private func runPendingScans(pool: DatabasePool, working: inout PhoneCallsCursor) async {
+        guard !working.pendingScans.isEmpty else { return }
+        // Iterate by handle snapshot; mutate working.pendingScans in
+        // place as each entry advances or completes.
+        let handles = working.pendingScans.map(\.normalizedHandle)
+        var scanBudget = config.maxRowsPerTick
+        for handle in handles {
+            if scanBudget <= 0 { break }
+            guard let entry = working.pendingScans.first(where: { $0.normalizedHandle == handle }) else {
+                continue
+            }
+            // Membership check: drop scans for handles not in the
+            // current known set — operator typo / removed contact.
+            let known = await cache.contains(handle)
+            if !known {
+                working.pendingScans.removeAll { $0.normalizedHandle == handle }
+                logger.warning("phone_calls scan: handle not in known set; dropping", metadata: [
+                    "handle": .private(handle),
+                ])
+                if case .aborted = await commitAfterScanMutation(working) { return }
+                continue
+            }
+
+            let limit = min(scanBudget, PhoneCallsPublisher.maxEventsPerBatch)
+            let page: CallHistoryScanPage
+            do {
+                page = try await pool.read { [canonicalizer] db in
+                    try CallHistoryScanReader.scanPage(
+                        db: db,
+                        canonicalHandle: handle,
+                        canonicalizer: canonicalizer,
+                        since: entry.since,
+                        progressBelowZDate: entry.progressBelowZDate,
+                        progressBelowZPK: entry.progressBelowZPK,
+                        limit: limit)
+                }
+            } catch let dbError as DatabaseError where isFDAError(dbError) {
+                await markUnhealthy(reason: "fda_required")
+                return
+            } catch {
+                logger.warning("phone_calls scan: read failed; holding entry", metadata: [
+                    "error": .private(String(describing: error)),
+                ])
+                continue
+            }
+
+            scanBudget -= page.rows.count
+
+            let publishItems = await filterAndShape(rows: page.rows)
+            let outcome = await publisher.publish(items: publishItems)
+
+            let confirmed: Bool
+            if publishItems.isEmpty {
+                confirmed = true
+            } else {
+                confirmed = outcome.rejected.isEmpty && outcome.unconfirmed == 0
+            }
+            if !confirmed {
+                // Publish failure: leave progress unchanged so the next
+                // tick retries from the same coordinate. Event-log dedup
+                // absorbs any re-emit.
+                logger.warning("phone_calls scan: publish unconfirmed; holding progress", metadata: [
+                    "handle": .private(handle),
+                ])
+                continue
+            }
+
+            if page.exhausted {
+                // Final short page confirmed-published → dequeue.
+                working.pendingScans.removeAll { $0.normalizedHandle == handle }
+            } else if let lowest = page.lowestPoint {
+                // Advance progress; entry stays queued for the next tick.
+                if let idx = working.pendingScans.firstIndex(where: { $0.normalizedHandle == handle }) {
+                    working.pendingScans[idx] = PhoneCallsCursorPendingScan(
+                        normalizedHandle: handle,
+                        since: entry.since,
+                        progressBelowZDate: lowest.zdate,
+                        progressBelowZPK: lowest.zPK)
+                }
+            }
+            if case .aborted = await commitAfterScanMutation(working) { return }
+        }
+    }
+
+    /// Commit `working` after a scan entry's progress/dequeue mutation.
+    /// A conflict refreshes + aborts the remaining scans this tick.
+    private func commitAfterScanMutation(_ working: PhoneCallsCursor) async -> ScanEnqueueResult {
+        switch await commitWorking(working) {
+        case .committed:
+            return .ok
+        case .conflict:
+            _ = try? await loadOrFetchCursor(forceRefresh: true)
+            return .aborted
+        case .failed:
+            return .aborted
+        }
+    }
+
+    /// Automatic newly-known scans always use a 30-day window.
+    private static let scanWindowSeconds: TimeInterval = 30 * 24 * 60 * 60
 
     // MARK: - per-tick batch runners
 

--- a/mac-daemon/Sources/CRMMacPhoneCallsSource/PhoneCallsSourcePlugin.swift
+++ b/mac-daemon/Sources/CRMMacPhoneCallsSource/PhoneCallsSourcePlugin.swift
@@ -534,6 +534,11 @@ public actor PhoneCallsSourcePlugin: DataSourcePlugin {
             }
 
             let limit = min(scanBudget, PhoneCallsPublisher.maxEventsPerBatch)
+            // Never scan below the backfill floor at EXECUTION time —
+            // defense-in-depth against any already-committed entry whose
+            // `since` predates the floor (e.g. queued by an older build).
+            // Rows below the floor are never emitted.
+            let scanSince = max(entry.since, config.backfillFloor)
             let page: CallHistoryScanPage
             do {
                 page = try await pool.read { [canonicalizer] db in
@@ -541,7 +546,7 @@ public actor PhoneCallsSourcePlugin: DataSourcePlugin {
                         db: db,
                         canonicalHandle: handle,
                         canonicalizer: canonicalizer,
-                        since: entry.since,
+                        since: scanSince,
                         progressBelowZDate: entry.progressBelowZDate,
                         progressBelowZPK: entry.progressBelowZPK,
                         limit: limit)

--- a/mac-daemon/Sources/CRMMacPhoneCallsSource/PhoneCallsSourcePlugin.swift
+++ b/mac-daemon/Sources/CRMMacPhoneCallsSource/PhoneCallsSourcePlugin.swift
@@ -243,9 +243,14 @@ public actor PhoneCallsSourcePlugin: DataSourcePlugin {
         // Phase B — execute pending scans (resumable), gated on
         // hasFetched (NOT isPopulated). An empty-but-fetched CRM still
         // adjudicates pending scans (drops an operator scan for a
-        // now-removed contact); a not-yet-fetched cache defers them.
+        // now-removed contact); a not-yet-fetched cache defers them. A
+        // scan-commit conflict aborts the rest of the tick: `working` is
+        // now stale relative to the refreshed Pi cursor, so the
+        // row-emitting batches + final commit must NOT run against it.
         if await cache.hasFetched {
-            await runPendingScans(pool: pool, working: &working)
+            if await runPendingScans(pool: pool, working: &working) == .aborted {
+                return
+            }
         }
 
         // Sender filter populated?  If the known-identifiers cache
@@ -501,8 +506,12 @@ public actor PhoneCallsSourcePlugin: DataSourcePlugin {
     /// either advance the entry's progress (still queued) or dequeue it
     /// on confirmed exhaustion. Re-commits the cursor after each entry's
     /// progress/dequeue so a crash recovers from the persisted cursor.
-    private func runPendingScans(pool: DatabasePool, working: inout PhoneCallsCursor) async {
-        guard !working.pendingScans.isEmpty else { return }
+    ///
+    /// Returns `.aborted` on a scan-commit conflict/failure: `working`
+    /// is then stale relative to the refreshed Pi cursor, so the caller
+    /// must stop the tick rather than re-commit it.
+    private func runPendingScans(pool: DatabasePool, working: inout PhoneCallsCursor) async -> ScanEnqueueResult {
+        guard !working.pendingScans.isEmpty else { return .ok }
         // Iterate by handle snapshot; mutate working.pendingScans in
         // place as each entry advances or completes.
         let handles = working.pendingScans.map(\.normalizedHandle)
@@ -520,7 +529,7 @@ public actor PhoneCallsSourcePlugin: DataSourcePlugin {
                 logger.warning("phone_calls scan: handle not in known set; dropping", metadata: [
                     "handle": .private(handle),
                 ])
-                if case .aborted = await commitAfterScanMutation(working) { return }
+                if case .aborted = await commitAfterScanMutation(working) { return .aborted }
                 continue
             }
 
@@ -539,7 +548,7 @@ public actor PhoneCallsSourcePlugin: DataSourcePlugin {
                 }
             } catch let dbError as DatabaseError where isFDAError(dbError) {
                 await markUnhealthy(reason: "fda_required")
-                return
+                return .aborted
             } catch {
                 logger.warning("phone_calls scan: read failed; holding entry", metadata: [
                     "error": .private(String(describing: error)),
@@ -581,8 +590,9 @@ public actor PhoneCallsSourcePlugin: DataSourcePlugin {
                         progressBelowZPK: lowest.zPK)
                 }
             }
-            if case .aborted = await commitAfterScanMutation(working) { return }
+            if case .aborted = await commitAfterScanMutation(working) { return .aborted }
         }
+        return .ok
     }
 
     /// Commit `working` after a scan entry's progress/dequeue mutation.

--- a/mac-daemon/Sources/crm-mac/Commands/CallHistoryCommand.swift
+++ b/mac-daemon/Sources/crm-mac/Commands/CallHistoryCommand.swift
@@ -3,9 +3,11 @@
 //
 // Top-level:
 //   crm-mac call-history backfill --restart [--yes]
+//   crm-mac call-history scan --identifier <handle> [--since <duration>]
 //   crm-mac call-history status
 //
-// `backfill` refuses to run while the daemon is up (pidfile-lock guard).
+// `backfill` + `scan` refuse to run while the daemon is up (pidfile-lock
+// guard) and commit Pi-side via the GET -> mutate -> POST CAS flow.
 // `status` is a read-only convenience that mirrors the phone_calls
 // slice of `crm-mac status` for callers who only want the source-
 // specific lines.
@@ -27,6 +29,7 @@ struct CallHistoryCommand: ParsableCommand {
         abstract: "Operator commands for the Phone & FaceTime call-history source.",
         subcommands: [
             CallHistoryBackfillCommand.self,
+            CallHistoryScanCommand.self,
             CallHistoryStatusCommand.self,
         ])
 }
@@ -53,6 +56,7 @@ struct CallHistoryStatusCommand: ParsableCommand {
             print("backfill_cursor=\(backfillDate) (Z_PK=\(phoneCalls.backfillCursorZPK.map(String.init) ?? "nil"))")
             print("install_max=\(installMax) (Z_PK=\(phoneCalls.installMaxZPK.map(String.init) ?? "nil"))")
             print("backfill_complete=\(phoneCalls.backfillComplete)")
+            print("pending_scans=\(phoneCalls.pendingScansCount)")
         } else {
             print("(no cursor committed yet)")
         }
@@ -83,6 +87,51 @@ struct CallHistoryBackfillCommand: AsyncParsableCommand {
         } catch let err as CallHistoryOpsError {
             FileHandle.standardError.write(Data("\(err.description)\n".utf8))
             throw ExitCode(4)
+        }
+    }
+}
+
+struct CallHistoryScanCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "scan",
+        abstract: "Queue a backwards scan for a specific identifier.")
+
+    @Option(name: .long, help: "Phone or email handle to scan for. Normalized before queuing.")
+    var identifier: String
+
+    @Option(name: .long,
+             help: "Scan window. ISO-8601 duration (e.g. '30d') or unset for default 30d.")
+    var since: String = "30d"
+
+    mutating func run() async throws {
+        let seconds = try parseSince(since)
+        let ops = try makeCallHistoryOps()
+        do {
+            try await ops.scan(identifier: identifier, since: seconds)
+            print("scan queued for \(identifier) (since=\(since)). Start the daemon to drain.")
+        } catch let err as CallHistoryOpsError {
+            FileHandle.standardError.write(Data("\(err.description)\n".utf8))
+            throw ExitCode(4)
+        }
+    }
+
+    /// Parse a simple duration like "30d", "12h", "60m", "3600s".
+    private func parseSince(_ raw: String) throws -> TimeInterval {
+        let s = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let unit = s.last else {
+            throw ValidationError("invalid --since: \(raw)")
+        }
+        let numericPart = String(s.dropLast())
+        guard let value = Double(numericPart), value >= 0 else {
+            throw ValidationError("invalid --since: \(raw)")
+        }
+        switch unit {
+        case "s": return value
+        case "m": return value * 60
+        case "h": return value * 60 * 60
+        case "d": return value * 60 * 60 * 24
+        default:
+            throw ValidationError("invalid --since unit (expected s/m/h/d): \(raw)")
         }
     }
 }

--- a/mac-daemon/Sources/crm-mac/Commands/CallHistoryCommand.swift
+++ b/mac-daemon/Sources/crm-mac/Commands/CallHistoryCommand.swift
@@ -100,7 +100,7 @@ struct CallHistoryScanCommand: AsyncParsableCommand {
     var identifier: String
 
     @Option(name: .long,
-             help: "Scan window. ISO-8601 duration (e.g. '30d') or unset for default 30d.")
+             help: "Scan window as <number><unit> where unit is s/m/h/d (e.g. '30d'); default 30d.")
     var since: String = "30d"
 
     mutating func run() async throws {

--- a/mac-daemon/Sources/crm-mac/Commands/DaemonCommand.swift
+++ b/mac-daemon/Sources/crm-mac/Commands/DaemonCommand.swift
@@ -71,7 +71,24 @@ struct DaemonCommand: AsyncParsableCommand {
         let chatDBPath = URL(fileURLWithPath: NSHomeDirectory())
             .appendingPathComponent("Library/Messages/chat.db")
         let backfillFloor = MessagesCursorWire.defaultBackfillFloor
-        let knownIdentifiersCache = KnownIdentifiersCache()
+
+        // Known-identifiers cache, shared by messages + phone_calls.
+        // Seed each consumer's DIFF baseline from the persisted
+        // DaemonState.knownIdentifierBaselines so an offline-restart
+        // diff enqueues 30-day scans ONLY for genuine additions. A
+        // source ABSENT from the persisted map starts `noBaseline`
+        // (upgrade boundary → seed-on-first-fetch, no scans). The
+        // refresher is the SOLE writer of the persisted baseline.
+        let knownIdentifierConsumers: Set<SourceID> = [.messages, .phoneCalls]
+        var seededBaselines: [SourceID: Set<String>] = [:]
+        if let persisted = (try? await stateMutator.read())?.knownIdentifierBaselines {
+            for (key, value) in persisted {
+                seededBaselines[SourceID(rawValue: key)] = value.toSet()
+            }
+        }
+        let knownIdentifiersCache = KnownIdentifiersCache(
+            baselines: seededBaselines,
+            consumers: knownIdentifierConsumers)
         let publisher = MessagesPublisher(
             sender: { [piClient] auth, body in
                 try await piClient.ingestEvents(auth: auth, body: body)
@@ -92,8 +109,17 @@ struct DaemonCommand: AsyncParsableCommand {
             logger: logger)
 
         // KnownIdentifiers refresher: after each heartbeat, fetch the
-        // canonical phone+email set + replace the cache.
-        let refresher: KnownIdentifiersRefresher = { [piClient] in
+        // canonical phone+email set + replace the cache. The refresher
+        // is ALSO the SOLE writer of the persisted per-source baseline:
+        // after replace, it reads each source's `persistableBaseline`
+        // (the observed set MINUS identifiers still owed a durable scan
+        // enqueue) and plain-assigns it to
+        // DaemonState.knownIdentifierBaselines when it differs. The
+        // owed-scan exclusion guarantees the persisted baseline never
+        // advances past an identifier whose 30-day scan isn't durable
+        // yet. The source tick NEVER writes this field.
+        let baselineClock = ctx.clock
+        let refresher: KnownIdentifiersRefresher = { [piClient, stateMutator, logger, baselineClock] in
             let result = try await piClient.knownIdentifiers(auth: auth)
             var canonical: Set<String> = []
             for phone in result.phones {
@@ -105,6 +131,35 @@ struct DaemonCommand: AsyncParsableCommand {
                 if !n.isEmpty { canonical.insert(n) }
             }
             await knownIdentifiersCache.replace(with: canonical)
+
+            // Persist each consumer's writable baseline (single writer).
+            for consumer in knownIdentifierConsumers {
+                // Capture the immutable observed set OUTSIDE the
+                // synchronous mutate closure (no actor read in-closure).
+                guard let observed = await knownIdentifiersCache.persistableBaseline(for: consumer) else {
+                    continue
+                }
+                let key = consumer.rawValue
+                let sorted = observed.sorted()
+                do {
+                    try await stateMutator.mutate { state in
+                        var map = state.knownIdentifierBaselines ?? [:]
+                        let existing = map[key]
+                        // No-op when unchanged (idempotent).
+                        if existing?.canonical == sorted { return }
+                        map[key] = KnownIdentifiersBaseline(
+                            canonical: sorted,
+                            // Preserve the first-seed time across writes.
+                            establishedAt: existing?.establishedAt ?? baselineClock.now())
+                        state.knownIdentifierBaselines = map
+                    }
+                } catch {
+                    logger.warning("known-identifiers baseline persist failed", metadata: [
+                        "source": .public(key),
+                        "error": .private(String(describing: error)),
+                    ])
+                }
+            }
         }
 
         let healthProvider = RegistryHealthProvider(

--- a/mac-daemon/Sources/crm-mac/Commands/DaemonCommand.swift
+++ b/mac-daemon/Sources/crm-mac/Commands/DaemonCommand.swift
@@ -104,7 +104,7 @@ struct DaemonCommand: AsyncParsableCommand {
                 let n = HandleNormalization.canonicalize(email)
                 if !n.isEmpty { canonical.insert(n) }
             }
-            _ = await knownIdentifiersCache.replace(with: canonical)
+            await knownIdentifiersCache.replace(with: canonical)
         }
 
         let healthProvider = RegistryHealthProvider(

--- a/mac-daemon/Sources/crm-mac/Commands/DaemonCommand.swift
+++ b/mac-daemon/Sources/crm-mac/Commands/DaemonCommand.swift
@@ -133,32 +133,16 @@ struct DaemonCommand: AsyncParsableCommand {
             await knownIdentifiersCache.replace(with: canonical)
 
             // Persist each consumer's writable baseline (single writer).
-            for consumer in knownIdentifierConsumers {
-                // Capture the immutable observed set OUTSIDE the
-                // synchronous mutate closure (no actor read in-closure).
-                guard let observed = await knownIdentifiersCache.persistableBaseline(for: consumer) else {
-                    continue
-                }
-                let key = consumer.rawValue
-                let sorted = observed.sorted()
-                do {
-                    try await stateMutator.mutate { state in
-                        var map = state.knownIdentifierBaselines ?? [:]
-                        let existing = map[key]
-                        // No-op when unchanged (idempotent).
-                        if existing?.canonical == sorted { return }
-                        map[key] = KnownIdentifiersBaseline(
-                            canonical: sorted,
-                            // Preserve the first-seed time across writes.
-                            establishedAt: existing?.establishedAt ?? baselineClock.now())
-                        state.knownIdentifierBaselines = map
-                    }
-                } catch {
-                    logger.warning("known-identifiers baseline persist failed", metadata: [
-                        "source": .public(key),
-                        "error": .private(String(describing: error)),
-                    ])
-                }
+            do {
+                try await persistKnownIdentifierBaselines(
+                    cache: knownIdentifiersCache,
+                    consumers: knownIdentifierConsumers,
+                    mutator: stateMutator,
+                    now: { baselineClock.now() })
+            } catch {
+                logger.warning("known-identifiers baseline persist failed", metadata: [
+                    "error": .private(String(describing: error)),
+                ])
             }
         }
 

--- a/mac-daemon/Sources/crm-mac/Commands/MessagesCommand.swift
+++ b/mac-daemon/Sources/crm-mac/Commands/MessagesCommand.swift
@@ -61,7 +61,7 @@ struct MessagesScanCommand: AsyncParsableCommand {
     var identifier: String
 
     @Option(name: .long,
-             help: "Scan window. ISO-8601 duration (e.g. '30d') or unset for default 30d.")
+             help: "Scan window as <number><unit> where unit is s/m/h/d (e.g. '30d'); default 30d.")
     var since: String = "30d"
 
     mutating func run() async throws {

--- a/mac-daemon/Sources/crm-mac/Commands/StatusCommand.swift
+++ b/mac-daemon/Sources/crm-mac/Commands/StatusCommand.swift
@@ -75,6 +75,7 @@ struct StatusCommand: ParsableCommand {
             print("    backfill_cursor:    \(backfillDate) (Z_PK=\(phoneCalls.backfillCursorZPK.map(String.init) ?? "nil"))")
             print("    install_max:        \(installMax) (Z_PK=\(phoneCalls.installMaxZPK.map(String.init) ?? "nil"))")
             print("    backfill_complete:  \(phoneCalls.backfillComplete)")
+            print("    pending_scans:      \(phoneCalls.pendingScansCount)")
         } else {
             print("  phone_calls: (no cursor committed yet)")
         }

--- a/mac-daemon/Tests/CRMMacCoreTests/KnownIdentifiersBaselinePersistenceTests.swift
+++ b/mac-daemon/Tests/CRMMacCoreTests/KnownIdentifiersBaselinePersistenceTests.swift
@@ -1,0 +1,151 @@
+// KnownIdentifiersBaselinePersistenceTests — exercises the
+// single-writer baseline-persistence sequence the DaemonCommand
+// heartbeat refresher runs: after cache.replace, read each source's
+// `persistableBaseline` and idempotently assign it to
+// DaemonState.knownIdentifierBaselines, preserving `establishedAt`.
+//
+// The DaemonCommand closure itself isn't unit-testable in isolation, so
+// this focused harness replicates its exact persist logic against a
+// real StateMutator + temp StateStore + the production cache, asserting
+// the single-writer invariants from the plan.
+//
+// Synthetic handles only (+15550000001, +15550000002); no real PII.
+import XCTest
+import Foundation
+@testable import CRMMacCore
+
+final class KnownIdentifiersBaselinePersistenceTests: XCTestCase {
+    private var tempDir: URL!
+    private let fixedNow = Date(timeIntervalSince1970: 1_779_000_000)
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("crm-mac-baseline-persist-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tempDir)
+        try super.tearDownWithError()
+    }
+
+    private func makeMutator() throws -> StateMutator {
+        let store = StateStore(fileURL: tempDir.appendingPathComponent("state.json"))
+        try store.save(DaemonState(schemaVersion: 1))
+        return StateMutator(store: store)
+    }
+
+    /// Replicates the DaemonCommand refresher's per-source persist step:
+    /// read persistableBaseline OUTSIDE the mutate closure, then plain-
+    /// assign it inside (idempotent, establishedAt preserved).
+    private func persistBaselines(
+        cache: KnownIdentifiersCache,
+        consumers: Set<SourceID>,
+        mutator: StateMutator,
+        now: Date
+    ) async throws {
+        for consumer in consumers {
+            guard let observed = await cache.persistableBaseline(for: consumer) else {
+                continue
+            }
+            let key = consumer.rawValue
+            let sorted = observed.sorted()
+            try await mutator.mutate { state in
+                var map = state.knownIdentifierBaselines ?? [:]
+                let existing = map[key]
+                if existing?.canonical == sorted { return }
+                map[key] = KnownIdentifiersBaseline(
+                    canonical: sorted,
+                    establishedAt: existing?.establishedAt ?? now)
+                state.knownIdentifierBaselines = map
+            }
+        }
+    }
+
+    // MARK: - first-upgrade seed persists full set with zero scans
+
+    func testFirstUpgradeSeedPersistsFullSet() async throws {
+        let mutator = try makeMutator()
+        let cache = KnownIdentifiersCache(
+            baselines: [:], consumers: [.messages, .phoneCalls])
+        // First fetch seeds the baseline (noBaseline → seed, zero scans).
+        await cache.replace(with: ["+15550000001", "+15550000002"])
+
+        try await persistBaselines(cache: cache, consumers: [.messages, .phoneCalls],
+                                   mutator: mutator, now: fixedNow)
+
+        let state = try await mutator.read()
+        let messages = state.knownIdentifierBaselines?["messages"]
+        XCTAssertEqual(messages?.canonical, ["+15550000001", "+15550000002"])
+        XCTAssertEqual(messages?.establishedAt, fixedNow)
+        // No scans were enqueued on the seed.
+        let drained = await cache.drainNewlyAdded(for: .messages)
+        XCTAssertTrue(drained.isEmpty, "first-upgrade seed enqueues no scans")
+    }
+
+    // MARK: - idempotent no-op when unchanged
+
+    func testRepeatedPersistIsIdempotentAndPreservesEstablishedAt() async throws {
+        let mutator = try makeMutator()
+        let cache = KnownIdentifiersCache(
+            baselines: [.messages: []], consumers: [.messages])
+        await cache.replace(with: ["+15550000001"])
+
+        try await persistBaselines(cache: cache, consumers: [.messages],
+                                   mutator: mutator, now: fixedNow)
+        let first = try await mutator.read().knownIdentifierBaselines?["messages"]
+        XCTAssertEqual(first?.establishedAt, fixedNow)
+
+        // A second persist with a DIFFERENT `now` must NOT change the
+        // baseline (unchanged set → no-op) nor bump establishedAt.
+        let laterNow = fixedNow.addingTimeInterval(3600)
+        try await persistBaselines(cache: cache, consumers: [.messages],
+                                   mutator: mutator, now: laterNow)
+        let second = try await mutator.read().knownIdentifierBaselines?["messages"]
+        XCTAssertEqual(second?.canonical, ["+15550000001"])
+        XCTAssertEqual(second?.establishedAt, fixedNow,
+                       "establishedAt preserved across idempotent persists")
+    }
+
+    // MARK: - owed scan excluded until durably enqueued
+
+    func testOwedScanExcludedFromPersistUntilConfirmed() async throws {
+        let mutator = try makeMutator()
+        let cache = KnownIdentifiersCache(
+            baselines: [.messages: ["+15550000001"]], consumers: [.messages])
+        // X appears new → in pendingNewlyAdded → owed → excluded.
+        await cache.replace(with: ["+15550000001", "+15550000002"])
+
+        try await persistBaselines(cache: cache, consumers: [.messages],
+                                   mutator: mutator, now: fixedNow)
+        let beforeConfirm = try await mutator.read().knownIdentifierBaselines?["messages"]
+        XCTAssertEqual(beforeConfirm?.canonical, ["+15550000001"],
+                       "owed-but-not-durable X excluded from persisted baseline")
+
+        // Source tick durably enqueues X: drain (→ inFlight) then confirm.
+        _ = await cache.drainNewlyAdded(for: .messages)
+        await cache.confirmDrained(for: .messages)
+
+        try await persistBaselines(cache: cache, consumers: [.messages],
+                                   mutator: mutator, now: fixedNow)
+        let afterConfirm = try await mutator.read().knownIdentifierBaselines?["messages"]
+        XCTAssertEqual(afterConfirm?.canonical, ["+15550000001", "+15550000002"],
+                       "baseline advances to include X once its scan is durable")
+    }
+
+    // MARK: - removal shrinks the persisted baseline
+
+    func testRemovalShrinksPersistedBaseline() async throws {
+        let mutator = try makeMutator()
+        let cache = KnownIdentifiersCache(
+            baselines: [.messages: ["+15550000001", "+15550000002"]], consumers: [.messages])
+        // A removal: only +...0001 remains.
+        await cache.replace(with: ["+15550000001"])
+
+        try await persistBaselines(cache: cache, consumers: [.messages],
+                                   mutator: mutator, now: fixedNow)
+        let state = try await mutator.read().knownIdentifierBaselines?["messages"]
+        XCTAssertEqual(state?.canonical, ["+15550000001"], "removal persists the shrunk set")
+    }
+}

--- a/mac-daemon/Tests/CRMMacCoreTests/KnownIdentifiersBaselinePersistenceTests.swift
+++ b/mac-daemon/Tests/CRMMacCoreTests/KnownIdentifiersBaselinePersistenceTests.swift
@@ -4,10 +4,11 @@
 // `persistableBaseline` and idempotently assign it to
 // DaemonState.knownIdentifierBaselines, preserving `establishedAt`.
 //
-// The DaemonCommand closure itself isn't unit-testable in isolation, so
-// this focused harness replicates its exact persist logic against a
-// real StateMutator + temp StateStore + the production cache, asserting
-// the single-writer invariants from the plan.
+// These tests invoke the SAME `persistKnownIdentifierBaselines` function
+// the production refresher calls (the DaemonCommand closure itself isn't
+// unit-testable in isolation), driving it against a real StateMutator +
+// temp StateStore + the production cache and asserting the single-writer
+// invariants from the plan.
 //
 // Synthetic handles only (+15550000001, +15550000002); no real PII.
 import XCTest
@@ -36,31 +37,15 @@ final class KnownIdentifiersBaselinePersistenceTests: XCTestCase {
         return StateMutator(store: store)
     }
 
-    /// Replicates the DaemonCommand refresher's per-source persist step:
-    /// read persistableBaseline OUTSIDE the mutate closure, then plain-
-    /// assign it inside (idempotent, establishedAt preserved).
+    /// Drives the production refresher persist step with a fixed clock.
     private func persistBaselines(
         cache: KnownIdentifiersCache,
         consumers: Set<SourceID>,
         mutator: StateMutator,
         now: Date
     ) async throws {
-        for consumer in consumers {
-            guard let observed = await cache.persistableBaseline(for: consumer) else {
-                continue
-            }
-            let key = consumer.rawValue
-            let sorted = observed.sorted()
-            try await mutator.mutate { state in
-                var map = state.knownIdentifierBaselines ?? [:]
-                let existing = map[key]
-                if existing?.canonical == sorted { return }
-                map[key] = KnownIdentifiersBaseline(
-                    canonical: sorted,
-                    establishedAt: existing?.establishedAt ?? now)
-                state.knownIdentifierBaselines = map
-            }
-        }
+        try await persistKnownIdentifierBaselines(
+            cache: cache, consumers: consumers, mutator: mutator, now: { now })
     }
 
     // MARK: - first-upgrade seed persists full set with zero scans
@@ -91,10 +76,15 @@ final class KnownIdentifiersBaselinePersistenceTests: XCTestCase {
         let cache = KnownIdentifiersCache(
             baselines: [.messages: []], consumers: [.messages])
         await cache.replace(with: ["+15550000001"])
+        // The identifier is owed a scan until its source tick durably
+        // enqueues it; drain + confirm so it joins the writable baseline.
+        _ = await cache.drainNewlyAdded(for: .messages)
+        await cache.confirmDrained(for: .messages)
 
         try await persistBaselines(cache: cache, consumers: [.messages],
                                    mutator: mutator, now: fixedNow)
         let first = try await mutator.read().knownIdentifierBaselines?["messages"]
+        XCTAssertEqual(first?.canonical, ["+15550000001"])
         XCTAssertEqual(first?.establishedAt, fixedNow)
 
         // A second persist with a DIFFERENT `now` must NOT change the

--- a/mac-daemon/Tests/CRMMacCoreTests/KnownIdentifiersCacheTests.swift
+++ b/mac-daemon/Tests/CRMMacCoreTests/KnownIdentifiersCacheTests.swift
@@ -6,45 +6,62 @@ final class KnownIdentifiersCacheTests: XCTestCase {
         let cache = KnownIdentifiersCache()
         let populated = await cache.isPopulated
         XCTAssertFalse(populated)
-        let contains = await cache.contains("+15551234567")
+        let fetched = await cache.hasFetched
+        XCTAssertFalse(fetched)
+        let contains = await cache.contains("+15550000001")
         XCTAssertFalse(contains)
     }
 
-    func testReplaceFromEmpty() async {
-        let cache = KnownIdentifiersCache()
-        let added = await cache.replace(with: ["+15551234567", "foo@example.com"])
-        XCTAssertEqual(added, ["+15551234567", "foo@example.com"])
+    func testReplacePopulatesAndMarksFetched() async {
+        let cache = KnownIdentifiersCache(consumers: [.messages])
+        await cache.replace(with: ["+15550000001", "foo@example.com"])
         let populated = await cache.isPopulated
         XCTAssertTrue(populated)
-        let hasPhone = await cache.contains("+15551234567")
+        let fetched = await cache.hasFetched
+        XCTAssertTrue(fetched)
+        let hasPhone = await cache.contains("+15550000001")
         XCTAssertTrue(hasPhone)
     }
 
-    func testDiffEqualSetsIsEmpty() async {
-        let cache = KnownIdentifiersCache(initial: ["a@example.com", "b@example.com"])
-        let added = await cache.replace(with: ["a@example.com", "b@example.com"])
-        XCTAssertTrue(added.isEmpty)
+    func testFirstFetchSeedsBaselineWithoutDraining() async {
+        // A consumer with no prior baseline (noBaseline) seeds on the
+        // first fetch and enqueues nothing — no replay storm.
+        let cache = KnownIdentifiersCache(consumers: [.messages])
+        await cache.replace(with: ["a@example.com", "b@example.com"])
+        let drained = await cache.drainNewlyAdded(for: .messages)
+        XCTAssertTrue(drained.isEmpty)
+        let base = await cache.baseline(for: .messages)
+        XCTAssertEqual(base, ["a@example.com", "b@example.com"])
     }
 
-    func testDiffAdditionsOnly() async {
-        let cache = KnownIdentifiersCache(initial: ["a@example.com"])
-        let added = await cache.replace(with: ["a@example.com", "b@example.com"])
-        XCTAssertEqual(added, ["b@example.com"])
+    func testDiffAdditionsOnlyAfterSeed() async {
+        let cache = KnownIdentifiersCache(
+            baselines: [.messages: ["a@example.com"]],
+            consumers: [.messages])
+        await cache.replace(with: ["a@example.com", "b@example.com"])
+        let drained = await cache.drainNewlyAdded(for: .messages)
+        XCTAssertEqual(drained, ["b@example.com"])
     }
 
-    func testRemovalsAreNotInDiff() async {
-        // Pi deleted a contact; cache shrinks. Diff is one-way (only
-        // additions); the removed identifier is dropped silently.
-        let cache = KnownIdentifiersCache(initial: ["a@example.com", "b@example.com"])
-        let added = await cache.replace(with: ["a@example.com"])
-        XCTAssertTrue(added.isEmpty)
+    func testRemovalsAreNotDrained() async {
+        // Pi deleted a contact; cache shrinks. The diff is one-way
+        // (additions only); the removed identifier is not drained, and
+        // the canonical set + diff baseline both shrink.
+        let cache = KnownIdentifiersCache(
+            baselines: [.messages: ["a@example.com", "b@example.com"]],
+            consumers: [.messages])
+        await cache.replace(with: ["a@example.com"])
+        let drained = await cache.drainNewlyAdded(for: .messages)
+        XCTAssertTrue(drained.isEmpty)
         let snapshot = await cache.snapshot()
         XCTAssertEqual(snapshot, ["a@example.com"])
+        let base = await cache.baseline(for: .messages)
+        XCTAssertEqual(base, ["a@example.com"])
     }
 
     func testKnownIdentifiersHashDeterministic() {
-        let set1: Set<String> = ["+15551234567", "foo@example.com", "bar@example.com"]
-        let set2: Set<String> = ["bar@example.com", "+15551234567", "foo@example.com"]
+        let set1: Set<String> = ["+15550000001", "foo@example.com", "bar@example.com"]
+        let set2: Set<String> = ["bar@example.com", "+15550000001", "foo@example.com"]
         // Set is unordered but hash sorts before digesting -> same hash.
         XCTAssertEqual(
             KnownIdentifiersHash.sha256Hex(of: set1),

--- a/mac-daemon/Tests/CRMMacCoreTests/KnownIdentifiersRestartDeltaTests.swift
+++ b/mac-daemon/Tests/CRMMacCoreTests/KnownIdentifiersRestartDeltaTests.swift
@@ -69,7 +69,7 @@ final class KnownIdentifiersRestartDeltaTests: XCTestCase {
         XCTAssertEqual(baseM, ["+15550000001", "+15550000002"])
     }
 
-    // MARK: - per-source independence (R9)
+    // MARK: - per-source independence
 
     func testPerSourceIndependentDrain() async {
         // After a replace adding {C}, messages drains {C} AND phone_calls
@@ -101,7 +101,7 @@ final class KnownIdentifiersRestartDeltaTests: XCTestCase {
         XCTAssertEqual(drainedAfterReadd, ["+15550000003"])
     }
 
-    // MARK: - non-destructive scan-queue drain (R1)
+    // MARK: - non-destructive scan-queue drain
 
     func testNonDestructiveDrainRollbackViaReturnInFlight() async {
         let cache = KnownIdentifiersCache(
@@ -166,7 +166,7 @@ final class KnownIdentifiersRestartDeltaTests: XCTestCase {
         XCTAssertEqual(drained, ["+15550000009"])
     }
 
-    // MARK: - persistableBaseline (single-writer P0 fix)
+    // MARK: - persistableBaseline (single-writer baseline)
 
     func testPersistableBaselineNilWhenNoBaseline() async {
         let cache = KnownIdentifiersCache(consumers: [.messages])

--- a/mac-daemon/Tests/CRMMacCoreTests/KnownIdentifiersRestartDeltaTests.swift
+++ b/mac-daemon/Tests/CRMMacCoreTests/KnownIdentifiersRestartDeltaTests.swift
@@ -1,0 +1,240 @@
+// KnownIdentifiersRestartDeltaTests — the per-source diff baseline +
+// non-destructive scan-queue drain + persistableBaseline semantics that
+// drive the targeted offline-restart auto-scan.
+//
+// Synthetic handles only (+15550000001 etc.); no real PII.
+import XCTest
+@testable import CRMMacCore
+
+final class KnownIdentifiersRestartDeltaTests: XCTestCase {
+    private let bothSources: Set<SourceID> = [.messages, .phoneCalls]
+
+    // MARK: - tri-state baseline
+
+    func testBaselineAbsentOnFirstUpgradeSeedsNoScans() async {
+        // No persisted baseline → first replace seeds the set as the
+        // baseline and enqueues NO scans for either source.
+        let cache = KnownIdentifiersCache(consumers: bothSources)
+        await cache.replace(with: ["+15550000001", "+15550000002", "+15550000003"])
+        let m = await cache.drainNewlyAdded(for: .messages)
+        let p = await cache.drainNewlyAdded(for: .phoneCalls)
+        XCTAssertTrue(m.isEmpty)
+        XCTAssertTrue(p.isEmpty)
+        let baseM = await cache.baseline(for: .messages)
+        XCTAssertEqual(baseM, ["+15550000001", "+15550000002", "+15550000003"])
+    }
+
+    func testBaselinePresentButEmptyDoesScan() async {
+        // A REAL empty baseline (empty CRM that later gains a contact)
+        // is NOT the same as absent — the new identifier IS scanned.
+        let cache = KnownIdentifiersCache(
+            baselines: [.messages: [], .phoneCalls: []],
+            consumers: bothSources)
+        await cache.replace(with: ["+15550000009"])
+        let m = await cache.drainNewlyAdded(for: .messages)
+        let p = await cache.drainNewlyAdded(for: .phoneCalls)
+        XCTAssertEqual(m, ["+15550000009"])
+        XCTAssertEqual(p, ["+15550000009"])
+    }
+
+    func testPreciseDeltaOnSecondRestart() async {
+        let cache = KnownIdentifiersCache(
+            baselines: [
+                .messages: ["+15550000001", "+15550000002"],
+                .phoneCalls: ["+15550000001", "+15550000002"],
+            ],
+            consumers: bothSources)
+        await cache.replace(with: ["+15550000001", "+15550000002", "+15550000003"])
+        let m = await cache.drainNewlyAdded(for: .messages)
+        let p = await cache.drainNewlyAdded(for: .phoneCalls)
+        XCTAssertEqual(m, ["+15550000003"])
+        XCTAssertEqual(p, ["+15550000003"])
+        let baseM = await cache.baseline(for: .messages)
+        XCTAssertEqual(baseM, ["+15550000001", "+15550000002", "+15550000003"])
+    }
+
+    func testRemovalDoesNotScan() async {
+        let cache = KnownIdentifiersCache(
+            baselines: [
+                .messages: ["+15550000001", "+15550000002", "+15550000003"],
+                .phoneCalls: ["+15550000001", "+15550000002", "+15550000003"],
+            ],
+            consumers: bothSources)
+        await cache.replace(with: ["+15550000001", "+15550000002"])
+        let m = await cache.drainNewlyAdded(for: .messages)
+        let p = await cache.drainNewlyAdded(for: .phoneCalls)
+        XCTAssertTrue(m.isEmpty)
+        XCTAssertTrue(p.isEmpty)
+        let baseM = await cache.baseline(for: .messages)
+        XCTAssertEqual(baseM, ["+15550000001", "+15550000002"])
+    }
+
+    // MARK: - per-source independence (R9)
+
+    func testPerSourceIndependentDrain() async {
+        // After a replace adding {C}, messages drains {C} AND phone_calls
+        // STILL drains {C} — neither empties the other.
+        let cache = KnownIdentifiersCache(
+            baselines: [
+                .messages: ["+15550000001"],
+                .phoneCalls: ["+15550000001"],
+            ],
+            consumers: bothSources)
+        await cache.replace(with: ["+15550000001", "+15550000003"])
+        let m = await cache.drainNewlyAdded(for: .messages)
+        XCTAssertEqual(m, ["+15550000003"])
+        let p = await cache.drainNewlyAdded(for: .phoneCalls)
+        XCTAssertEqual(p, ["+15550000003"], "phone_calls drain not emptied by messages drain")
+    }
+
+    func testBaselineTrailsLatestFetchDeleteThenReadd() async {
+        // baseline {A,B,C}; replace({A,B}) → baseline {A,B}, drains ∅;
+        // later replace({A,B,C}) → drains {C} (re-add detected as new).
+        let cache = KnownIdentifiersCache(
+            baselines: [.messages: ["+15550000001", "+15550000002", "+15550000003"]],
+            consumers: [.messages])
+        await cache.replace(with: ["+15550000001", "+15550000002"])
+        let drainedAfterRemoval = await cache.drainNewlyAdded(for: .messages)
+        XCTAssertTrue(drainedAfterRemoval.isEmpty)
+        await cache.replace(with: ["+15550000001", "+15550000002", "+15550000003"])
+        let drainedAfterReadd = await cache.drainNewlyAdded(for: .messages)
+        XCTAssertEqual(drainedAfterReadd, ["+15550000003"])
+    }
+
+    // MARK: - non-destructive scan-queue drain (R1)
+
+    func testNonDestructiveDrainRollbackViaReturnInFlight() async {
+        let cache = KnownIdentifiersCache(
+            baselines: [.messages: ["+15550000001"]],
+            consumers: [.messages])
+        await cache.replace(with: ["+15550000001", "+15550000003"])
+        let drained = await cache.drainNewlyAdded(for: .messages)
+        XCTAssertEqual(drained, ["+15550000003"])
+        // WITHOUT confirm: a re-drain sees nothing (it's in-flight).
+        let reDrainBeforeReturn = await cache.drainNewlyAdded(for: .messages)
+        XCTAssertTrue(reDrainBeforeReturn.isEmpty)
+        // returnInFlight rolls it back so the next drain re-returns it.
+        await cache.returnInFlight(for: .messages)
+        let reDrain = await cache.drainNewlyAdded(for: .messages)
+        XCTAssertEqual(reDrain, ["+15550000003"])
+    }
+
+    func testConfirmDrainedClearsInFlightNoBaselineSideEffect() async {
+        let cache = KnownIdentifiersCache(
+            baselines: [.messages: ["+15550000001"]],
+            consumers: [.messages])
+        await cache.replace(with: ["+15550000001", "+15550000003"])
+        _ = await cache.drainNewlyAdded(for: .messages)
+        await cache.confirmDrained(for: .messages)
+        // After confirm, returnInFlight is a no-op and the bucket is
+        // empty — the identifier is durably enqueued.
+        await cache.returnInFlight(for: .messages)
+        let reDrain = await cache.drainNewlyAdded(for: .messages)
+        XCTAssertTrue(reDrain.isEmpty)
+        // confirmDrained has NO baseline side effect — baseline still
+        // trails the latest fetch.
+        let base = await cache.baseline(for: .messages)
+        XCTAssertEqual(base, ["+15550000001", "+15550000003"])
+    }
+
+    func testInFlightExcludedFromReAdd() async {
+        // Drain {B} (in-flight, not confirmed); replace({A,B}) again →
+        // the bucket does NOT re-contain {B} (excluded via − inFlight).
+        let cache = KnownIdentifiersCache(
+            baselines: [.messages: ["+15550000001"]],
+            consumers: [.messages])
+        await cache.replace(with: ["+15550000001", "+15550000002"])
+        let drained = await cache.drainNewlyAdded(for: .messages)
+        XCTAssertEqual(drained, ["+15550000002"])
+        // Same set re-fetched while B is still in-flight.
+        await cache.replace(with: ["+15550000001", "+15550000002"])
+        let reDrain = await cache.drainNewlyAdded(for: .messages)
+        XCTAssertTrue(reDrain.isEmpty, "in-flight B must not re-enter the bucket")
+    }
+
+    func testEmptyCRMSeedsPresentEmptyBaseline() async {
+        // First replace(∅) marks fetched + seeds baseline ∅; a later
+        // replace({X}) drains {X} (NOT a fresh first-upgrade seed).
+        let cache = KnownIdentifiersCache(consumers: [.messages])
+        await cache.replace(with: [])
+        let fetched = await cache.hasFetched
+        XCTAssertTrue(fetched)
+        let base = await cache.baseline(for: .messages)
+        XCTAssertEqual(base, [])
+        await cache.replace(with: ["+15550000009"])
+        let drained = await cache.drainNewlyAdded(for: .messages)
+        XCTAssertEqual(drained, ["+15550000009"])
+    }
+
+    // MARK: - persistableBaseline (single-writer P0 fix)
+
+    func testPersistableBaselineNilWhenNoBaseline() async {
+        let cache = KnownIdentifiersCache(consumers: [.messages])
+        let pb = await cache.persistableBaseline(for: .messages)
+        XCTAssertNil(pb, "noBaseline → nil persistable baseline")
+    }
+
+    func testFirstUpgradeSeedPersistsFullSetWithZeroScans() async {
+        // First-upgrade replace → pendingNewlyAdded empty →
+        // persistableBaseline == fetched (full seed persists, zero
+        // scans).
+        let cache = KnownIdentifiersCache(consumers: [.messages])
+        await cache.replace(with: ["+15550000001", "+15550000002"])
+        let pb = await cache.persistableBaseline(for: .messages)
+        XCTAssertEqual(pb, ["+15550000001", "+15550000002"])
+        let drained = await cache.drainNewlyAdded(for: .messages)
+        XCTAssertTrue(drained.isEmpty)
+    }
+
+    func testOwedScanExcludedFromPersistableUntilDurablyEnqueued() async {
+        // replace({A,X}) against baseline {A} → X in pendingNewlyAdded →
+        // persistableBaseline == {A} (X EXCLUDED).
+        let cache = KnownIdentifiersCache(
+            baselines: [.messages: ["+15550000001"]],
+            consumers: [.messages])
+        await cache.replace(with: ["+15550000001", "+15550000009"])
+        let pbBeforeDrain = await cache.persistableBaseline(for: .messages)
+        XCTAssertEqual(pbBeforeDrain, ["+15550000001"], "owed-but-not-drained X excluded")
+
+        // Drain moves X to in-flight: still owed, still excluded.
+        let drained = await cache.drainNewlyAdded(for: .messages)
+        XCTAssertEqual(drained, ["+15550000009"])
+        let pbInFlight = await cache.persistableBaseline(for: .messages)
+        XCTAssertEqual(pbInFlight, ["+15550000001"], "in-flight X still excluded")
+
+        // After confirmDrained (scan durably committed), X is in neither
+        // owed set → persistableBaseline advances to include it.
+        await cache.confirmDrained(for: .messages)
+        let pbAfterConfirm = await cache.persistableBaseline(for: .messages)
+        XCTAssertEqual(pbAfterConfirm, ["+15550000001", "+15550000009"])
+    }
+
+    func testCrashBeforeDurableEnqueueReEnqueuesOnRestart() async {
+        // Simulate the P0: refresher persists {A} (X excluded). A crash
+        // before the source tick durably commits X. Restart re-seeds
+        // baseline {A}; replace({A,X}) re-detects X as new.
+        let preCrash = KnownIdentifiersCache(
+            baselines: [.messages: ["+15550000001"]],
+            consumers: [.messages])
+        await preCrash.replace(with: ["+15550000001", "+15550000009"])
+        let persisted = await preCrash.persistableBaseline(for: .messages) ?? []
+        XCTAssertEqual(persisted, ["+15550000001"])
+
+        // Restart with the persisted baseline {A} (X was NOT persisted).
+        let postCrash = KnownIdentifiersCache(
+            baselines: [.messages: persisted],
+            consumers: [.messages])
+        await postCrash.replace(with: ["+15550000001", "+15550000009"])
+        let reDetected = await postCrash.drainNewlyAdded(for: .messages)
+        XCTAssertEqual(reDetected, ["+15550000009"], "X re-enqueued — scan not lost")
+    }
+
+    func testRemovalShrinksPersistableBaseline() async {
+        let cache = KnownIdentifiersCache(
+            baselines: [.messages: ["+15550000001", "+15550000002"]],
+            consumers: [.messages])
+        await cache.replace(with: ["+15550000001"])
+        let pb = await cache.persistableBaseline(for: .messages)
+        XCTAssertEqual(pb, ["+15550000001"], "removal folds into persistable baseline")
+    }
+}

--- a/mac-daemon/Tests/CRMMacLifecycleTests/CallHistoryOpsScanTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/CallHistoryOpsScanTests.swift
@@ -185,4 +185,78 @@ final class CallHistoryOpsScanTests: XCTestCase {
             committed?.pendingScans.contains { $0.normalizedHandle == "+15550000000" } ?? true,
             "oldest entry dropped")
     }
+
+    // MARK: - floor clamp on an over-wide --since
+
+    func testScanClampsOverWideSinceToFloor() async throws {
+        // A 100-year --since would reach far below the 2026-01-01 floor;
+        // the queued entry's `since` must be clamped to the floor.
+        let emptyCursor = "{\"backfill_floor_sent_at\":\"2026-01-01T00:00:00Z\"}"
+        let transport = LifecycleMockTransport([
+            .respond(status: 200, data: getCursorResponse(emptyCursor)),
+            .respond(status: 200, data: Data(#"{"success":true,"data":{"ok":true}}"#.utf8)),
+        ])
+        let ops = makeOps(transport)
+        try await ops.scan(identifier: "+15550000001", since: 100 * 365 * 86400)
+
+        let committed = try committedCursor(transport)
+        XCTAssertEqual(committed?.pendingScans.first?.since, backfillFloor,
+                       "over-wide --since clamped to the backfill floor")
+    }
+
+    // MARK: - coverage-dedup (wider widens + resets, narrower preserved)
+
+    func testScanCoverageDedupWidensAndResetsProgress() async throws {
+        // Seed a NARROW entry (since = now − 1 day) with progress
+        // advanced, anchored to the real clock so a wider --since always
+        // widens regardless of the absolute test date.
+        let narrowSince = Date().addingTimeInterval(-86400) // now − 1 day
+        var seeded = PhoneCallsCursorWire(backfillFloorSentAt: backfillFloor)
+        seeded.pendingScans.append(PhoneCallsCursorPendingScan(
+            normalizedHandle: "+15550000001",
+            since: narrowSince,
+            progressBelowZDate: 800_000_000,
+            progressBelowZPK: 42))
+        let seededJSON = try PhoneCallsCursorWireCodec.encode(seeded)
+        let transport = LifecycleMockTransport([
+            .respond(status: 200, data: getCursorResponse(seededJSON)),
+            .respond(status: 200, data: Data(#"{"success":true,"data":{"ok":true}}"#.utf8)),
+        ])
+        let ops = makeOps(transport)
+        // A wider 60-day scan (now − 60d < now − 1d) widens + resets.
+        try await ops.scan(identifier: "+15550000001", since: 60 * 86400)
+
+        let committed = try committedCursor(transport)
+        XCTAssertEqual(committed?.pendingScans.count, 1, "one merged entry, no duplicate")
+        let entry = try XCTUnwrap(committed?.pendingScans.first)
+        XCTAssertLessThan(entry.since, narrowSince, "window widened to the earlier since")
+        XCTAssertNil(entry.progressBelowZDate, "wider window resets progress")
+        XCTAssertNil(entry.progressBelowZPK, "wider window resets progress")
+    }
+
+    func testScanCoverageDedupNarrowerPreservesExistingProgress() async throws {
+        // Seed a WIDE entry (since at the floor) with progress advanced.
+        var seeded = PhoneCallsCursorWire(backfillFloorSentAt: backfillFloor)
+        seeded.pendingScans.append(PhoneCallsCursorPendingScan(
+            normalizedHandle: "+15550000001",
+            since: backfillFloor,
+            progressBelowZDate: 800_000_000,
+            progressBelowZPK: 42))
+        let seededJSON = try PhoneCallsCursorWireCodec.encode(seeded)
+        let transport = LifecycleMockTransport([
+            .respond(status: 200, data: getCursorResponse(seededJSON)),
+            .respond(status: 200, data: Data(#"{"success":true,"data":{"ok":true}}"#.utf8)),
+        ])
+        let ops = makeOps(transport)
+        // A NARROWER 2-day scan must NOT shrink the window or reset
+        // progress.
+        try await ops.scan(identifier: "+15550000001", since: 2 * 86400)
+
+        let committed = try committedCursor(transport)
+        XCTAssertEqual(committed?.pendingScans.count, 1, "one entry, no duplicate")
+        let entry = try XCTUnwrap(committed?.pendingScans.first)
+        XCTAssertEqual(entry.since, backfillFloor, "narrower window does not shrink the entry")
+        XCTAssertEqual(entry.progressBelowZDate, 800_000_000, "existing progress preserved")
+        XCTAssertEqual(entry.progressBelowZPK, 42, "existing progress preserved")
+    }
 }

--- a/mac-daemon/Tests/CRMMacLifecycleTests/CallHistoryOpsScanTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/CallHistoryOpsScanTests.swift
@@ -1,0 +1,188 @@
+// CallHistoryOpsScanTests — focused tests on the call-history scan
+// cursor-mutation logic (CAS commit, pidfile guard, identifier
+// normalization, cap), mirroring MessagesCLIOpsTests' scan coverage on
+// the phone_calls source.
+//
+// Tests pass through a real PidfileLock + a URLProtocol-mocked PiClient.
+//
+// Synthetic handles only (+15550000001); no real PII.
+import XCTest
+import Foundation
+import CRMMacCore
+@testable import CRMMacLifecycle
+@testable import CRMMacPiClient
+
+final class CallHistoryOpsScanTests: XCTestCase {
+    private let auth = PiAuth(
+        hostID: UUID(uuidString: "11111111-2222-3333-4444-555555555555")!,
+        apiKey: "k")
+    private let backfillFloor = PhoneCallsCursorWire.defaultBackfillFloor
+    private var tempDir: URL!
+    private var pidfileURL: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("crm-mac-callhistory-cliops-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        pidfileURL = tempDir.appendingPathComponent("daemon.pid")
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tempDir)
+        try super.tearDownWithError()
+    }
+
+    private func makeOps(_ transport: LifecycleMockTransport) -> CallHistoryOps {
+        let piClient = PiClient(baseURL: URL(string: "https://pi.example.test")!,
+                                transport: transport.asTransport(), sleep: noopSleep)
+        return CallHistoryOps(
+            piClient: piClient,
+            auth: auth,
+            pidfileLock: PidfileLock(path: pidfileURL),
+            logger: NoopLogger(),
+            backfillFloor: backfillFloor)
+    }
+
+    /// A GET-cursor response carrying `cursor` verbatim.
+    private func getCursorResponse(_ cursor: String, epoch: Int64 = 7) -> Data {
+        let encoded = String(decoding: try! JSONEncoder().encode(cursor), as: UTF8.self)
+        return Data("""
+            {"success":true,"data":{"cursor":\(encoded),"cursor_epoch":\(epoch),"backfill_complete":false}}
+            """.utf8)
+    }
+
+    /// Decode the committed cursor from the LAST POST /cursor invocation.
+    private func committedCursor(_ transport: LifecycleMockTransport) throws -> PhoneCallsCursorWire? {
+        let posts = transport.invocations.filter {
+            $0.httpMethod == "POST" && ($0.url?.path.hasSuffix("/cursor") ?? false)
+        }
+        guard let last = posts.last, let body = last.httpBody,
+              let obj = try JSONSerialization.jsonObject(with: body) as? [String: Any],
+              let cursorStr = obj["cursor"] as? String else {
+            return nil
+        }
+        return try PhoneCallsCursorWireCodec.decode(cursorStr)
+    }
+
+    // MARK: - happy path
+
+    func testScanAppendsPendingScan() async throws {
+        let emptyCursor = "{\"backfill_floor_sent_at\":\"2026-01-01T00:00:00Z\"}"
+        let transport = LifecycleMockTransport([
+            .respond(status: 200, data: getCursorResponse(emptyCursor)),
+            .respond(status: 200, data: Data(#"{"success":true,"data":{"ok":true}}"#.utf8)),
+        ])
+        let ops = makeOps(transport)
+        try await ops.scan(identifier: "+1-555-000-0001", since: 30 * 86400)
+
+        let committed = try committedCursor(transport)
+        XCTAssertEqual(committed?.pendingScans.count, 1)
+        XCTAssertEqual(committed?.pendingScans.first?.normalizedHandle, "+15550000001")
+    }
+
+    // MARK: - invalid identifier
+
+    func testScanInvalidIdentifier() async throws {
+        let ops = makeOps(LifecycleMockTransport([]))
+        do {
+            try await ops.scan(identifier: "   ", since: 86400)
+            XCTFail("expected invalidIdentifier")
+        } catch CallHistoryOpsError.invalidIdentifier {
+            // OK
+        } catch {
+            XCTFail("got \(error)")
+        }
+    }
+
+    // MARK: - daemon-running guard
+
+    func testScanRefusedWhenDaemonRunning() async throws {
+        // Hold the pidfile lock to simulate the daemon being up.
+        let daemonLock = PidfileLock(path: pidfileURL)
+        try daemonLock.acquire()
+        defer { daemonLock.release() }
+
+        let ops = makeOps(LifecycleMockTransport([]))
+        do {
+            try await ops.scan(identifier: "+15550000001", since: 86400)
+            XCTFail("expected daemonRunning")
+        } catch let CallHistoryOpsError.daemonRunning(pid) {
+            XCTAssertEqual(pid, getpid())
+        } catch {
+            XCTFail("got \(error)")
+        }
+    }
+
+    // MARK: - cursor conflict
+
+    func testScanConflictPropagates() async throws {
+        let emptyCursor = "{\"backfill_floor_sent_at\":\"2026-01-01T00:00:00Z\"}"
+        let conflictJSON = Data(#"""
+            {"success":false,
+             "error":{"code":"EPOCH_MISMATCH","message":"epoch mismatch"},
+             "data":{"current_cursor":"x","current_epoch":9}}
+            """#.utf8)
+        let transport = LifecycleMockTransport([
+            .respond(status: 200, data: getCursorResponse(emptyCursor)),
+            .respond(status: 409, data: conflictJSON),
+        ])
+        let ops = makeOps(transport)
+        do {
+            try await ops.scan(identifier: "+15550000001", since: 86400)
+            XCTFail("expected cursorConflict")
+        } catch CallHistoryOpsError.cursorConflict {
+            // OK
+        } catch {
+            XCTFail("got \(error)")
+        }
+    }
+
+    // MARK: - Pi unreachable
+
+    func testScanPiUnreachablePropagates() async throws {
+        let emptyCursor = "{\"backfill_floor_sent_at\":\"2026-01-01T00:00:00Z\"}"
+        let transport = LifecycleMockTransport([
+            .respond(status: 200, data: getCursorResponse(emptyCursor)),
+            .fail(URLError(.notConnectedToInternet)),
+        ])
+        let ops = makeOps(transport)
+        do {
+            try await ops.scan(identifier: "+15550000001", since: 86400)
+            XCTFail("expected piUnreachable")
+        } catch CallHistoryOpsError.piUnreachable {
+            // OK
+        } catch {
+            XCTFail("got \(error)")
+        }
+    }
+
+    // MARK: - cap drops oldest
+
+    func testScanCapDropsOldest() async throws {
+        // Pre-fill the GET cursor with pendingScansCap entries; the new
+        // scan must drop the oldest so the queue stays at cap.
+        let cap = PhoneCallsCursorWire.pendingScansCap
+        var seeded = PhoneCallsCursorWire(backfillFloorSentAt: backfillFloor)
+        for i in 0..<cap {
+            seeded.pendingScans.append(PhoneCallsCursorPendingScan(
+                normalizedHandle: "+1555000\(String(format: "%04d", i))",
+                since: Date(timeIntervalSince1970: 1_700_000_000)))
+        }
+        let seededJSON = try PhoneCallsCursorWireCodec.encode(seeded)
+        let transport = LifecycleMockTransport([
+            .respond(status: 200, data: getCursorResponse(seededJSON)),
+            .respond(status: 200, data: Data(#"{"success":true,"data":{"ok":true}}"#.utf8)),
+        ])
+        let ops = makeOps(transport)
+        try await ops.scan(identifier: "+15559999999", since: 86400)
+
+        let committed = try committedCursor(transport)
+        XCTAssertEqual(committed?.pendingScans.count, cap, "queue stays at cap")
+        // The oldest (index 0) was dropped; the new handle is at the tail.
+        XCTAssertEqual(committed?.pendingScans.last?.normalizedHandle, "+15559999999")
+        XCTAssertFalse(
+            committed?.pendingScans.contains { $0.normalizedHandle == "+15550000000" } ?? true,
+            "oldest entry dropped")
+    }
+}

--- a/mac-daemon/Tests/CRMMacLifecycleTests/MessagesCLIOpsTests.swift
+++ b/mac-daemon/Tests/CRMMacLifecycleTests/MessagesCLIOpsTests.swift
@@ -43,6 +43,38 @@ final class MessagesCLIOpsTests: XCTestCase {
                         transport: transport, sleep: noopSleep)
     }
 
+    /// Like `client(_:)` but returns the transport too, so a test can
+    /// inspect the committed cursor body.
+    private func clientWithTransport(
+        _ steps: [LifecycleMockTransport.Step]
+    ) -> (PiClient, LifecycleMockTransport) {
+        let transport = LifecycleMockTransport(steps)
+        let pi = PiClient(baseURL: URL(string: "https://pi.example.test")!,
+                          transport: transport.asTransport(), sleep: noopSleep)
+        return (pi, transport)
+    }
+
+    /// A GET-cursor response carrying `cursor` verbatim.
+    private func getCursorResponse(_ cursor: String, epoch: Int64 = 7) -> Data {
+        let encoded = String(decoding: try! JSONEncoder().encode(cursor), as: UTF8.self)
+        return Data("""
+            {"success":true,"data":{"cursor":\(encoded),"cursor_epoch":\(epoch),"backfill_complete":false}}
+            """.utf8)
+    }
+
+    /// Decode the committed cursor from the LAST POST /cursor invocation.
+    private func committedCursor(_ transport: LifecycleMockTransport) throws -> MessagesCursorWire? {
+        let posts = transport.invocations.filter {
+            $0.httpMethod == "POST" && ($0.url?.path.hasSuffix("/cursor") ?? false)
+        }
+        guard let last = posts.last, let body = last.httpBody,
+              let obj = try JSONSerialization.jsonObject(with: body) as? [String: Any],
+              let cursorStr = obj["cursor"] as? String else {
+            return nil
+        }
+        return try MessagesCursorWireCodec.decode(cursorStr)
+    }
+
     // MARK: - backfill --restart
 
     func testBackfillRestartHappyPathWithYes() async throws {
@@ -137,25 +169,80 @@ final class MessagesCLIOpsTests: XCTestCase {
 
     // MARK: - scan
 
-    func testScanAppendsPendingScan() async throws {
-        let getCursorJSON = Data(#"""
-            {"success":true,
-             "data":{"cursor":"{\"backfill_floor_sent_at\":\"2026-01-01T00:00:00Z\"}",
-                     "cursor_epoch":7,
-                     "backfill_complete":false}}
-            """#.utf8)
-        let commitJSON = Data(#"{"success":true,"data":{"ok":true}}"#.utf8)
-        let piClient = client([
-            .respond(status: 200, data: getCursorJSON),
-            .respond(status: 200, data: commitJSON),
-        ])
-        let ops = MessagesOps(
+    private func makeOps(_ piClient: PiClient) -> MessagesOps {
+        MessagesOps(
             piClient: piClient,
             auth: auth,
             pidfileLock: PidfileLock(path: pidfileURL),
             logger: NoopLogger(),
             backfillFloor: backfillFloor)
-        try await ops.scan(identifier: "+1-555-123-4567", since: 30 * 86400)
+    }
+
+    private let emptyCursorJSON = "{\"backfill_floor_sent_at\":\"2026-01-01T00:00:00Z\"}"
+
+    func testScanAppendsPendingScan() async throws {
+        let (pi, transport) = clientWithTransport([
+            .respond(status: 200, data: getCursorResponse(emptyCursorJSON)),
+            .respond(status: 200, data: Data(#"{"success":true,"data":{"ok":true}}"#.utf8)),
+        ])
+        try await makeOps(pi).scan(identifier: "+1-555-123-4567", since: 30 * 86400)
+
+        let committed = try committedCursor(transport)
+        XCTAssertEqual(committed?.pendingScans.count, 1)
+        XCTAssertEqual(committed?.pendingScans.first?.normalizedHandle, "+15551234567")
+    }
+
+    func testScanClampsOverWideSinceToFloor() async throws {
+        // A 100-year --since would reach far below the 2026-01-01 floor;
+        // the queued entry's `since` must be clamped to the floor.
+        let (pi, transport) = clientWithTransport([
+            .respond(status: 200, data: getCursorResponse(emptyCursorJSON)),
+            .respond(status: 200, data: Data(#"{"success":true,"data":{"ok":true}}"#.utf8)),
+        ])
+        try await makeOps(pi).scan(identifier: "+15551234567", since: 100 * 365 * 86400)
+
+        let committed = try committedCursor(transport)
+        XCTAssertEqual(committed?.pendingScans.first?.since, backfillFloor,
+                       "over-wide --since clamped to the backfill floor")
+    }
+
+    func testScanCoverageDedupWidensAndResetsProgress() async throws {
+        // Seed a NARROW entry (since = now − 1 day) with progress
+        // advanced; a wider --since must widen + reset progress.
+        let narrowSince = Date().addingTimeInterval(-86400)
+        var seeded = MessagesCursorWire(backfillFloorSentAt: backfillFloor)
+        seeded.pendingScans.append(MessagesCursorPendingScan(
+            normalizedHandle: "+15551234567", since: narrowSince, progressBelowRowID: 42))
+        let (pi, transport) = clientWithTransport([
+            .respond(status: 200, data: getCursorResponse(try MessagesCursorWireCodec.encode(seeded))),
+            .respond(status: 200, data: Data(#"{"success":true,"data":{"ok":true}}"#.utf8)),
+        ])
+        try await makeOps(pi).scan(identifier: "+15551234567", since: 60 * 86400)
+
+        let committed = try committedCursor(transport)
+        XCTAssertEqual(committed?.pendingScans.count, 1, "one merged entry, no duplicate")
+        let entry = try XCTUnwrap(committed?.pendingScans.first)
+        XCTAssertLessThan(entry.since, narrowSince, "window widened to the earlier since")
+        XCTAssertNil(entry.progressBelowRowID, "wider window resets progress")
+    }
+
+    func testScanCoverageDedupNarrowerPreservesExistingProgress() async throws {
+        // Seed a WIDE entry (since at the floor) with progress advanced;
+        // a narrower --since must NOT shrink the window or reset progress.
+        var seeded = MessagesCursorWire(backfillFloorSentAt: backfillFloor)
+        seeded.pendingScans.append(MessagesCursorPendingScan(
+            normalizedHandle: "+15551234567", since: backfillFloor, progressBelowRowID: 42))
+        let (pi, transport) = clientWithTransport([
+            .respond(status: 200, data: getCursorResponse(try MessagesCursorWireCodec.encode(seeded))),
+            .respond(status: 200, data: Data(#"{"success":true,"data":{"ok":true}}"#.utf8)),
+        ])
+        try await makeOps(pi).scan(identifier: "+15551234567", since: 2 * 86400)
+
+        let committed = try committedCursor(transport)
+        XCTAssertEqual(committed?.pendingScans.count, 1, "one entry, no duplicate")
+        let entry = try XCTUnwrap(committed?.pendingScans.first)
+        XCTAssertEqual(entry.since, backfillFloor, "narrower window does not shrink the entry")
+        XCTAssertEqual(entry.progressBelowRowID, 42, "existing progress preserved")
     }
 
     func testScanInvalidIdentifier() async throws {

--- a/mac-daemon/Tests/CRMMacMessagesSourceTests/MessagesCursorTests.swift
+++ b/mac-daemon/Tests/CRMMacMessagesSourceTests/MessagesCursorTests.swift
@@ -73,4 +73,39 @@ final class MessagesCursorTests: XCTestCase {
     func testPendingScansCapConstant() {
         XCTAssertEqual(MessagesCursor.pendingScansCap, 256)
     }
+
+    func testPendingScanProgressRoundTrip() throws {
+        let original = MessagesCursor(
+            backfillFloorSentAt: floor,
+            pendingScans: [
+                PendingScan(normalizedHandle: "+15550000001",
+                            since: Date(timeIntervalSince1970: 1_775_000_000),
+                            progressBelowRowID: 4242),
+            ])
+        let encoded = try MessagesCursorCodec.encode(original)
+        XCTAssertTrue(encoded.contains("\"progress_below_rowid\""))
+        let decoded = try MessagesCursorCodec.decode(encoded)
+        XCTAssertEqual(decoded, original)
+        XCTAssertEqual(decoded?.pendingScans.first?.progressBelowRowID, 4242)
+    }
+
+    func testPendingScanWithoutProgressDecodesNil() throws {
+        // An operator-CLI-queued or pre-existing entry omits the
+        // progress field → nil ("not started").
+        let json = """
+            {
+                "backfill_floor_sent_at": "2026-01-01T00:00:00Z",
+                "backfill_complete": false,
+                "pending_scans": [
+                    {
+                        "normalized_handle": "+15550000001",
+                        "since": "2026-04-01T00:00:00Z"
+                    }
+                ]
+            }
+            """
+        let decoded = try MessagesCursorCodec.decode(json)
+        let scan = try XCTUnwrap(decoded?.pendingScans.first)
+        XCTAssertNil(scan.progressBelowRowID)
+    }
 }

--- a/mac-daemon/Tests/CRMMacMessagesSourceTests/MessagesScanExecutionTests.swift
+++ b/mac-daemon/Tests/CRMMacMessagesSourceTests/MessagesScanExecutionTests.swift
@@ -147,7 +147,7 @@ final class MessagesScanExecutionTests: XCTestCase {
         // scan row published (Phase A durability): the first committed
         // cursor that carried the handle was committed before the first
         // ingest event.
-        let firstEnqueueIndex = await transport.firstCommitIndexContaining("+15550000001")
+        let firstEnqueueIndex = transport.firstCommitIndexContaining("+15550000001")
         XCTAssertNotNil(firstEnqueueIndex, "a committed cursor must carry the enqueued scan")
 
         // The scanned message published with the right kind/source_id.
@@ -162,7 +162,7 @@ final class MessagesScanExecutionTests: XCTestCase {
 
         // After a fully-exhausted scan, the final committed cursor has an
         // empty pendingScans (the entry dequeued).
-        let finalCursor = await transport.currentDecodedCursor()
+        let finalCursor = transport.currentDecodedCursor()
         XCTAssertEqual(finalCursor?.pendingScans.count, 0,
                        "exhausted scan dequeued")
     }
@@ -226,7 +226,7 @@ final class MessagesScanExecutionTests: XCTestCase {
         let scanned = await sink.scannedSourceIDs()
         XCTAssertEqual(scanned, Set((100...104).map { "g\($0)" }),
                        "every scanned row published across the multi-tick walk")
-        let finalCursor = await transport.currentDecodedCursor()
+        let finalCursor = transport.currentDecodedCursor()
         XCTAssertEqual(finalCursor?.pendingScans.count, 0, "scan dequeued once exhausted")
     }
 
@@ -256,7 +256,7 @@ final class MessagesScanExecutionTests: XCTestCase {
 
         try await plugin.tick()
 
-        let finalCursor = await transport.currentDecodedCursor()
+        let finalCursor = transport.currentDecodedCursor()
         XCTAssertEqual(finalCursor?.pendingScans.count, 1, "scan entry still queued after abort")
         XCTAssertNil(finalCursor?.pendingScans.first?.progressBelowRowID,
                      "Phase-B progress NOT durably committed under conflict; no stale overwrite")
@@ -296,7 +296,7 @@ final class MessagesScanExecutionTests: XCTestCase {
 
         let events = await sink.allEvents()
         XCTAssertTrue(events.isEmpty, "unknown-handle scan publishes nothing")
-        let finalCursor = await transport.currentDecodedCursor()
+        let finalCursor = transport.currentDecodedCursor()
         XCTAssertEqual(finalCursor?.pendingScans.count, 0, "unknown-handle entry dropped")
     }
 
@@ -332,7 +332,7 @@ final class MessagesScanExecutionTests: XCTestCase {
         XCTAssertTrue(events.isEmpty, "no publish on a not-yet-fetched cache")
         // The entry survives — the seeded cursor is unchanged in the
         // transport (no commit removed it).
-        let finalCursor = await transport.currentDecodedCursor()
+        let finalCursor = transport.currentDecodedCursor()
         XCTAssertEqual(finalCursor?.pendingScans.count, 1,
                        "durable scan preserved on a startup-race tick")
     }
@@ -380,7 +380,7 @@ final class MessagesScanExecutionTests: XCTestCase {
                       "window-widen reset progress so the row is re-walked")
         // Exactly one merged entry existed (no duplicate); it dequeued
         // after exhaustion.
-        let finalCursor = await transport.currentDecodedCursor()
+        let finalCursor = transport.currentDecodedCursor()
         XCTAssertEqual(finalCursor?.pendingScans.count, 0)
     }
 }
@@ -426,7 +426,7 @@ final class StatefulCursorTransport: @unchecked Sendable {
             }
             // Cursor GET.
             if method == "GET", url.path.hasSuffix("/cursor") {
-                lock.lock(); let cur = currentCursor; lock.unlock()
+                let cur = lock.withLock { currentCursor }
                 let body = """
                     {"success":true,"data":{"cursor":\(Self.jsonString(cur)),"cursor_epoch":0,"backfill_complete":false}}
                     """
@@ -437,7 +437,10 @@ final class StatefulCursorTransport: @unchecked Sendable {
                 if failCommits {
                     return (Data(#"{"error":{"code":"boom","message":"forced"}}"#.utf8), http(500))
                 }
-                lock.lock(); commitAttempts += 1; let attempt = commitAttempts; lock.unlock()
+                let attempt = lock.withLock { () -> Int in
+                    commitAttempts += 1
+                    return commitAttempts
+                }
                 if let target = conflictOnlyAt, attempt == target {
                     let body = """
                         {"success":false,
@@ -449,10 +452,10 @@ final class StatefulCursorTransport: @unchecked Sendable {
                 if let bodyData = request.httpBody,
                    let obj = try? JSONSerialization.jsonObject(with: bodyData) as? [String: Any],
                    let cursor = obj["cursor"] as? String {
-                    lock.lock()
-                    currentCursor = cursor
-                    committedCursors.append(cursor)
-                    lock.unlock()
+                    lock.withLock {
+                        currentCursor = cursor
+                        committedCursors.append(cursor)
+                    }
                 }
                 return (Data(#"{"success":true,"data":{"ok":true}}"#.utf8), http(200))
             }

--- a/mac-daemon/Tests/CRMMacMessagesSourceTests/MessagesScanExecutionTests.swift
+++ b/mac-daemon/Tests/CRMMacMessagesSourceTests/MessagesScanExecutionTests.swift
@@ -1,0 +1,437 @@
+// MessagesScanExecutionTests — Phase A (durable scan enqueue) + Phase B
+// (resumable scan execution) end-to-end against a fake PiClient, an
+// in-memory chat.db, and a real StateMutator over a temp StateStore.
+//
+// Synthetic handles only (+15550000001, test@example.com); no real PII.
+import XCTest
+import Foundation
+import GRDB
+import CRMMacCore
+import CRMMacPiClient
+@testable import CRMMacMessagesSource
+
+final class MessagesScanExecutionTests: XCTestCase {
+    private let auth = PiAuth(
+        hostID: UUID(uuidString: "11111111-2222-3333-4444-555555555555")!,
+        apiKey: "k")
+    private let backfillFloor = MessagesCursorWire.defaultBackfillFloor
+    // A fixed clock so the 30-day window is deterministic. 2026-05-20.
+    private let fixedNow = Date(timeIntervalSince1970: 1_779_000_000)
+    private let scannedUnix: TimeInterval = 1_777_680_000 // 2026-05-02
+    private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("crm-mac-scan-exec-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tempDir)
+        try super.tearDownWithError()
+    }
+
+    private func makeStateStore() -> StateStore {
+        StateStore(fileURL: tempDir.appendingPathComponent("state.json"))
+    }
+
+    /// A cursor with backfill complete + live cursor past every seeded
+    /// message, so the row-emitting batches are no-ops and ONLY the scan
+    /// publishes. Lets the scan-execution assertions isolate Phase B.
+    private func inactiveBatchCursor(
+        pendingScans: [PendingScan] = []
+    ) -> MessagesCursor {
+        MessagesCursor(
+            backfillCursor: 0,
+            liveCursor: 100_000,
+            installMaxRowID: 100_000,
+            backfillFloorSentAt: backfillFloor,
+            backfillComplete: true,
+            pendingScans: pendingScans)
+    }
+
+    /// Build an on-disk chat.db with one handle + `count` messages under
+    /// it at consecutive ROWIDs starting at 100.
+    private func makeChatDB(messageCount: Int, handle: String = "+15550000001") throws -> URL {
+        let dbURL = tempDir.appendingPathComponent("chat.db")
+        let bundle = Bundle.module
+        guard let scriptURL = bundle.url(forResource: "chat_db_schema",
+                                          withExtension: "sql",
+                                          subdirectory: "Fixtures") else {
+            throw XCTSkip("chat_db_schema.sql not in test bundle")
+        }
+        let script = try String(contentsOf: scriptURL, encoding: .utf8)
+        let queue = try DatabaseQueue(path: dbURL.path)
+        let appleNanos = Int64((scannedUnix - 978_307_200) * 1e9)
+        try queue.write { db in
+            try db.execute(sql: script)
+            try db.execute(sql:
+                "INSERT INTO handle (ROWID, id, service) VALUES (1, ?, 'iMessage')",
+                arguments: [handle])
+            try db.execute(sql:
+                "INSERT INTO chat (ROWID, guid, style, chat_identifier) VALUES (10, 'c', 45, ?)",
+                arguments: [handle])
+            for i in 0..<messageCount {
+                let rowID = 100 + i
+                try db.execute(sql:
+                    "INSERT INTO message (ROWID, guid, text, handle_id, date, " +
+                    "is_from_me, cache_has_attachments, associated_message_guid) " +
+                    "VALUES (?, ?, 'hi', 1, ?, 0, 0, NULL)",
+                    arguments: [rowID, "g\(rowID)", appleNanos])
+                try db.execute(sql:
+                    "INSERT INTO chat_message_join (chat_id, message_id) VALUES (10, ?)",
+                    arguments: [rowID])
+            }
+        }
+        return dbURL
+    }
+
+    private func makePlugin(
+        dbURL: URL,
+        store: StateStore,
+        cache: KnownIdentifiersCache,
+        transport: StatefulCursorTransport,
+        publisherSink: PublisherSink,
+        maxRowsPerTick: Int = 500
+    ) -> MessagesSourcePlugin {
+        let now = fixedNow
+        let piClient = PiClient(
+            baseURL: URL(string: "https://pi.example.test")!,
+            transport: transport.asTransport(),
+            sleep: { _ in })
+        let publisher = MessagesPublisher(
+            sender: { _, body in
+                await publisherSink.record(body.events)
+                return IngestEventsData(
+                    accepted: body.events.count, duplicate: 0, rejected: 0, errors: [])
+            },
+            auth: auth, logger: NoopLogger())
+        return MessagesSourcePlugin(
+            tickInterval: 60,
+            config: MessagesSourceConfig(
+                chatDBPath: dbURL,
+                backfillFloor: backfillFloor,
+                maxRowsPerTick: maxRowsPerTick),
+            piClient: piClient,
+            auth: auth,
+            mutator: StateMutator(store: store),
+            publisher: publisher,
+            cache: cache,
+            healthRegistry: SourceHealthRegistry(),
+            logger: NoopLogger(),
+            clock: { now })
+    }
+
+    // MARK: - Phase A durability + scan execution
+
+    func testNewlyKnownEnqueuesDurablyThenScansAndPublishes() async throws {
+        let dbURL = try makeChatDB(messageCount: 1)
+        let store = makeStateStore()
+        let seeded = inactiveBatchCursor()
+        try store.save(DaemonState(schemaVersion: 1))
+        let cache = KnownIdentifiersCache(
+            baselines: [.messages: []], consumers: [.messages])
+        // A heartbeat fetch surfaces the new identifier.
+        await cache.replace(with: ["+15550000001"])
+
+        let transport = StatefulCursorTransport(
+            initialCursor: try MessagesCursorCodec.encode(seeded))
+        let sink = PublisherSink()
+        let plugin = makePlugin(dbURL: dbURL, store: store, cache: cache,
+                                transport: transport, publisherSink: sink)
+
+        try await plugin.tick()
+
+        // The cursor was committed with the pendingScans entry BEFORE any
+        // scan row published (Phase A durability): the first committed
+        // cursor that carried the handle was committed before the first
+        // ingest event.
+        let firstEnqueueIndex = await transport.firstCommitIndexContaining("+15550000001")
+        XCTAssertNotNil(firstEnqueueIndex, "a committed cursor must carry the enqueued scan")
+
+        // The scanned message published with the right kind/source_id.
+        let events = await sink.allEvents()
+        XCTAssertTrue(events.contains { $0.sourceID == "g100" && $0.kind == "raw_message.received" },
+                      "scanned message published")
+
+        // The source tick did NOT write the persisted baseline.
+        let state = try store.load()
+        XCTAssertNil(state.knownIdentifierBaselines,
+                     "source tick must not write knownIdentifierBaselines")
+
+        // After a fully-exhausted scan, the final committed cursor has an
+        // empty pendingScans (the entry dequeued).
+        let finalCursor = await transport.currentDecodedCursor()
+        XCTAssertEqual(finalCursor?.pendingScans.count, 0,
+                       "exhausted scan dequeued")
+    }
+
+    // MARK: - Phase A failure rolls back
+
+    func testPhaseAFailureReturnsIdentifierForReEnqueue() async throws {
+        let dbURL = try makeChatDB(messageCount: 1)
+        let store = makeStateStore()
+        try store.save(DaemonState(schemaVersion: 1))
+        let cache = KnownIdentifiersCache(
+            baselines: [.messages: []], consumers: [.messages])
+        await cache.replace(with: ["+15550000001"])
+
+        // Transport fails every commit → Phase A cannot persist.
+        let transport = StatefulCursorTransport(failCommits: true)
+        let sink = PublisherSink()
+        let plugin = makePlugin(dbURL: dbURL, store: store, cache: cache,
+                                transport: transport, publisherSink: sink)
+
+        try await plugin.tick()
+
+        // No scan executed (Phase A aborted before Phase B).
+        let events = await sink.allEvents()
+        XCTAssertTrue(events.isEmpty, "no scan rows published when Phase A fails")
+
+        // The identifier was returned to the cache → a subsequent drain
+        // re-returns it for re-enqueue.
+        let reDrained = await cache.drainNewlyAdded(for: .messages)
+        XCTAssertEqual(reDrained, ["+15550000001"], "identifier returned for re-enqueue")
+    }
+
+    // MARK: - resumable / larger-than-budget
+
+    func testResumableScanAcrossTicksDropsNoRows() async throws {
+        // 5 matching messages, budget 2 → 3 ticks to fully walk.
+        let dbURL = try makeChatDB(messageCount: 5)
+        let store = makeStateStore()
+        let seeded = inactiveBatchCursor()
+        try store.save(DaemonState(schemaVersion: 1))
+        let cache = KnownIdentifiersCache(
+            baselines: [.messages: []], consumers: [.messages])
+        await cache.replace(with: ["+15550000001"])
+
+        let transport = StatefulCursorTransport(
+            initialCursor: try MessagesCursorCodec.encode(seeded))
+        let sink = PublisherSink()
+        // Small budget forces a multi-page scan. The row-emitting
+        // batches are inactive (backfill complete + live past every row),
+        // so ONLY the scan publishes.
+        let plugin = makePlugin(dbURL: dbURL, store: store, cache: cache,
+                                transport: transport, publisherSink: sink,
+                                maxRowsPerTick: 2)
+
+        // Three ticks: subsequent ticks have an empty drain but resume
+        // the persisted pendingScans entry.
+        for _ in 0..<3 {
+            try await plugin.tick()
+        }
+
+        let scanned = await sink.scannedSourceIDs()
+        XCTAssertEqual(scanned, Set((100...104).map { "g\($0)" }),
+                       "every scanned row published across the multi-tick walk")
+        let finalCursor = await transport.currentDecodedCursor()
+        XCTAssertEqual(finalCursor?.pendingScans.count, 0, "scan dequeued once exhausted")
+    }
+
+    // MARK: - membership gate (hasFetched vs isPopulated)
+
+    func testUnknownHandleDroppedWhenFetched() async throws {
+        // An operator pre-seeded a scan for a handle NOT in the known
+        // set. With hasFetched true (even on an empty CRM), Phase B drops
+        // it without publishing.
+        let dbURL = try makeChatDB(messageCount: 1, handle: "+15550000001")
+        let store = makeStateStore()
+        // Seed the cursor with a pending scan for an unknown handle.
+        let seededCursor = MessagesCursor(
+            backfillFloorSentAt: backfillFloor,
+            pendingScans: [
+                PendingScan(normalizedHandle: "+15557777777",
+                            since: Date(timeIntervalSince1970: scannedUnix - 86_400)),
+            ])
+        var st = DaemonState(schemaVersion: 1)
+        st.sources["messages"] = SourceState(cursor: try MessagesCursorCodec.encode(seededCursor))
+        try store.save(st)
+
+        let cache = KnownIdentifiersCache(
+            baselines: [.messages: []], consumers: [.messages])
+        // Empty CRM but FETCHED.
+        await cache.replace(with: [])
+
+        let transport = StatefulCursorTransport(
+            initialCursor: try MessagesCursorCodec.encode(seededCursor))
+        let sink = PublisherSink()
+        let plugin = makePlugin(dbURL: dbURL, store: store, cache: cache,
+                                transport: transport, publisherSink: sink)
+
+        try await plugin.tick()
+
+        let events = await sink.allEvents()
+        XCTAssertTrue(events.isEmpty, "unknown-handle scan publishes nothing")
+        let finalCursor = await transport.currentDecodedCursor()
+        XCTAssertEqual(finalCursor?.pendingScans.count, 0, "unknown-handle entry dropped")
+    }
+
+    func testUnknownHandleDeferredWhenNotFetched() async throws {
+        // Same seeded scan, but the cache has NOT fetched yet (no
+        // heartbeat). Phase B must NOT drop it — it survives for a later
+        // tick.
+        let dbURL = try makeChatDB(messageCount: 1, handle: "+15550000001")
+        let store = makeStateStore()
+        let seededCursor = MessagesCursor(
+            backfillFloorSentAt: backfillFloor,
+            pendingScans: [
+                PendingScan(normalizedHandle: "+15557777777",
+                            since: Date(timeIntervalSince1970: scannedUnix - 86_400)),
+            ])
+        var st = DaemonState(schemaVersion: 1)
+        st.sources["messages"] = SourceState(cursor: try MessagesCursorCodec.encode(seededCursor))
+        try store.save(st)
+
+        // Cache never fetched (hasFetched == false). isPopulated false too.
+        let cache = KnownIdentifiersCache(
+            baselines: [.messages: []], consumers: [.messages])
+
+        let transport = StatefulCursorTransport(
+            initialCursor: try MessagesCursorCodec.encode(seededCursor))
+        let sink = PublisherSink()
+        let plugin = makePlugin(dbURL: dbURL, store: store, cache: cache,
+                                transport: transport, publisherSink: sink)
+
+        try await plugin.tick()
+
+        let events = await sink.allEvents()
+        XCTAssertTrue(events.isEmpty, "no publish on a not-yet-fetched cache")
+        // The entry survives — the seeded cursor is unchanged in the
+        // transport (no commit removed it).
+        let finalCursor = await transport.currentDecodedCursor()
+        XCTAssertEqual(finalCursor?.pendingScans.count, 1,
+                       "durable scan preserved on a startup-race tick")
+    }
+
+    // MARK: - coverage-dedup widens window
+
+    func testCoverageDedupWidensNarrowOperatorEntry() async throws {
+        // A narrow operator entry (since = now-2d, progress advanced)
+        // for the handle, then an auto 30-day enqueue for the same handle
+        // → ONE merged entry widened to 30 days with progress reset.
+        let dbURL = try makeChatDB(messageCount: 1)
+        let store = makeStateStore()
+        let narrowSince = fixedNow.addingTimeInterval(-2 * 86_400)
+        let seededCursor = MessagesCursor(
+            backfillFloorSentAt: backfillFloor,
+            pendingScans: [
+                PendingScan(normalizedHandle: "+15550000001",
+                            since: narrowSince,
+                            progressBelowRowID: 50),
+            ])
+        var st = DaemonState(schemaVersion: 1)
+        st.sources["messages"] = SourceState(cursor: try MessagesCursorCodec.encode(seededCursor))
+        try store.save(st)
+
+        let cache = KnownIdentifiersCache(
+            baselines: [.messages: []], consumers: [.messages])
+        await cache.replace(with: ["+15550000001"])
+
+        let transport = StatefulCursorTransport(
+            initialCursor: try MessagesCursorCodec.encode(seededCursor))
+        let sink = PublisherSink()
+        let plugin = makePlugin(dbURL: dbURL, store: store, cache: cache,
+                                transport: transport, publisherSink: sink)
+
+        try await plugin.tick()
+
+        // The narrow seeded entry (since = now-2d, progress < 50) would
+        // match nothing: the 2026-05-02 message is older than 2 days AND
+        // its ROWID 100 is above the progress bound. The auto 30-day
+        // enqueue coverage-merges into the same handle, widening the
+        // window and resetting progress to nil, so ROWID 100 is re-walked
+        // and published.
+        let scanned = await sink.scannedSourceIDs()
+        XCTAssertTrue(scanned.contains("g100"),
+                      "window-widen reset progress so the row is re-walked")
+        // Exactly one merged entry existed (no duplicate); it dequeued
+        // after exhaustion.
+        let finalCursor = await transport.currentDecodedCursor()
+        XCTAssertEqual(finalCursor?.pendingScans.count, 0)
+    }
+}
+
+/// Records the IngestEvents the publisher sends, in order.
+actor PublisherSink {
+    private var events: [IngestEvent] = []
+    func record(_ batch: [IngestEvent]) { events.append(contentsOf: batch) }
+    func allEvents() -> [IngestEvent] { events }
+    func scannedSourceIDs() -> Set<String> { Set(events.map(\.sourceID)) }
+}
+
+/// Stateful fake transport for the cursor GET/commit flow. Holds the
+/// current cursor JSON; GET returns it, POST commit updates it and
+/// records the committed cursor. Ingest events are NOT routed here —
+/// the publisher uses its own injected sender.
+final class StatefulCursorTransport: @unchecked Sendable {
+    private let lock = NSLock()
+    private var currentCursor: String
+    private var committedCursors: [String] = []
+    private let failCommits: Bool
+
+    init(initialCursor: String = "", failCommits: Bool = false) {
+        self.currentCursor = initialCursor
+        self.failCommits = failCommits
+    }
+
+    func asTransport() -> TransportFunc {
+        return { [self] request in
+            let url = request.url ?? URL(string: "https://test.invalid")!
+            let method = request.httpMethod ?? "GET"
+            func http(_ status: Int) -> HTTPURLResponse {
+                HTTPURLResponse(url: url, statusCode: status, httpVersion: "HTTP/1.1",
+                                headerFields: ["Content-Type": "application/json"])!
+            }
+            // Cursor GET.
+            if method == "GET", url.path.hasSuffix("/cursor") {
+                lock.lock(); let cur = currentCursor; lock.unlock()
+                let body = """
+                    {"success":true,"data":{"cursor":\(Self.jsonString(cur)),"cursor_epoch":0,"backfill_complete":false}}
+                    """
+                return (Data(body.utf8), http(200))
+            }
+            // Cursor commit.
+            if method == "POST", url.path.hasSuffix("/cursor") {
+                if failCommits {
+                    return (Data(#"{"error":{"code":"boom","message":"forced"}}"#.utf8), http(500))
+                }
+                if let bodyData = request.httpBody,
+                   let obj = try? JSONSerialization.jsonObject(with: bodyData) as? [String: Any],
+                   let cursor = obj["cursor"] as? String {
+                    lock.lock()
+                    currentCursor = cursor
+                    committedCursors.append(cursor)
+                    lock.unlock()
+                }
+                return (Data(#"{"success":true,"data":{"ok":true}}"#.utf8), http(200))
+            }
+            // Any other path (shouldn't happen in these tests).
+            return (Data(#"{"success":true,"data":{}}"#.utf8), http(200))
+        }
+    }
+
+    func currentDecodedCursor() -> MessagesCursorWire? {
+        lock.lock(); let cur = currentCursor; lock.unlock()
+        return try? MessagesCursorWireCodec.decode(cur)
+    }
+
+    /// Index of the first committed cursor whose pendingScans carries
+    /// `handle`, or nil.
+    func firstCommitIndexContaining(_ handle: String) -> Int? {
+        lock.lock(); let commits = committedCursors; lock.unlock()
+        for (i, json) in commits.enumerated() {
+            if let decoded = try? MessagesCursorWireCodec.decode(json),
+               decoded.pendingScans.contains(where: { $0.normalizedHandle == handle }) {
+                return i
+            }
+        }
+        return nil
+    }
+
+    private static func jsonString(_ s: String) -> String {
+        let data = try? JSONEncoder().encode(s)
+        return data.map { String(decoding: $0, as: UTF8.self) } ?? "\"\""
+    }
+}

--- a/mac-daemon/Tests/CRMMacMessagesSourceTests/MessagesScanExecutionTests.swift
+++ b/mac-daemon/Tests/CRMMacMessagesSourceTests/MessagesScanExecutionTests.swift
@@ -230,6 +230,38 @@ final class MessagesScanExecutionTests: XCTestCase {
         XCTAssertEqual(finalCursor?.pendingScans.count, 0, "scan dequeued once exhausted")
     }
 
+    // MARK: - Phase B conflict aborts the tick
+
+    func testPhaseBConflictAbortsTickWithoutOverwriting() async throws {
+        // 5 messages, budget 2. Commit #1 = Phase A enqueue (succeeds).
+        // Commit #2 = Phase B progress advance → forced 409 conflict
+        // (ONLY commit #2; a later commit would succeed). A regressed
+        // plugin that continued past the conflict would land a STALE
+        // final commit carrying advanced progress, failing the assertion.
+        let dbURL = try makeChatDB(messageCount: 5)
+        let store = makeStateStore()
+        let seeded = inactiveBatchCursor()
+        try store.save(DaemonState(schemaVersion: 1))
+        let cache = KnownIdentifiersCache(
+            baselines: [.messages: []], consumers: [.messages])
+        await cache.replace(with: ["+15550000001"])
+
+        let transport = StatefulCursorTransport(
+            initialCursor: try MessagesCursorCodec.encode(seeded),
+            conflictOnlyAt: 2)
+        let sink = PublisherSink()
+        let plugin = makePlugin(dbURL: dbURL, store: store, cache: cache,
+                                transport: transport, publisherSink: sink,
+                                maxRowsPerTick: 2)
+
+        try await plugin.tick()
+
+        let finalCursor = await transport.currentDecodedCursor()
+        XCTAssertEqual(finalCursor?.pendingScans.count, 1, "scan entry still queued after abort")
+        XCTAssertNil(finalCursor?.pendingScans.first?.progressBelowRowID,
+                     "Phase-B progress NOT durably committed under conflict; no stale overwrite")
+    }
+
     // MARK: - membership gate (hasFetched vs isPopulated)
 
     func testUnknownHandleDroppedWhenFetched() async throws {
@@ -369,11 +401,19 @@ final class StatefulCursorTransport: @unchecked Sendable {
     private let lock = NSLock()
     private var currentCursor: String
     private var committedCursors: [String] = []
+    private var commitAttempts = 0
     private let failCommits: Bool
+    /// When set, ONLY the (1-based) commit at exactly this index returns
+    /// a 409 cursor-conflict (cursor NOT updated); later commits succeed.
+    /// Forcing the conflict on a SINGLE commit lets the Phase-B abort
+    /// test detect a regression where a buggy plugin continues past the
+    /// conflict and lands a STALE final commit that would SUCCEED.
+    private let conflictOnlyAt: Int?
 
-    init(initialCursor: String = "", failCommits: Bool = false) {
+    init(initialCursor: String = "", failCommits: Bool = false, conflictOnlyAt: Int? = nil) {
         self.currentCursor = initialCursor
         self.failCommits = failCommits
+        self.conflictOnlyAt = conflictOnlyAt
     }
 
     func asTransport() -> TransportFunc {
@@ -396,6 +436,15 @@ final class StatefulCursorTransport: @unchecked Sendable {
             if method == "POST", url.path.hasSuffix("/cursor") {
                 if failCommits {
                     return (Data(#"{"error":{"code":"boom","message":"forced"}}"#.utf8), http(500))
+                }
+                lock.lock(); commitAttempts += 1; let attempt = commitAttempts; lock.unlock()
+                if let target = conflictOnlyAt, attempt == target {
+                    let body = """
+                        {"success":false,
+                         "error":{"code":"EPOCH_MISMATCH","message":"epoch mismatch"},
+                         "data":{"current_cursor":\(Self.jsonString(currentCursor)),"current_epoch":9}}
+                        """
+                    return (Data(body.utf8), http(409))
                 }
                 if let bodyData = request.httpBody,
                    let obj = try? JSONSerialization.jsonObject(with: bodyData) as? [String: Any],

--- a/mac-daemon/Tests/CRMMacMessagesSourceTests/MessagesScanReaderTests.swift
+++ b/mac-daemon/Tests/CRMMacMessagesSourceTests/MessagesScanReaderTests.swift
@@ -1,0 +1,216 @@
+// MessagesScanReaderTests — the identifier-scoped, date-bounded,
+// resumable scan reader over chat.db.
+//
+// Synthetic handles only (+15550000001, test@example.com); no real PII.
+import XCTest
+import GRDB
+@testable import CRMMacMessagesSource
+
+final class MessagesScanReaderTests: XCTestCase {
+    // 2026-04-01 UTC — comfortably inside the 30-day window for the
+    // tests that use a 2026-05 `since`, and after the backfill floor.
+    private let unixApr2026: TimeInterval = 1_775_001_600 // 2026-04-01
+    private let unixMay2026: TimeInterval = 1_777_680_000 // 2026-05-02
+
+    private func insertHandle(db: Database, rowID: Int64, id: String) throws {
+        try db.execute(
+            sql: "INSERT INTO handle (ROWID, id, service) VALUES (?, ?, 'iMessage')",
+            arguments: [rowID, id])
+    }
+
+    private func insertMessage(
+        db: Database,
+        rowID: Int64,
+        guid: String,
+        handleID: Int64,
+        unixDate: TimeInterval,
+        chatRowID: Int64,
+        chatGUID: String,
+        chatStyle: Int64 = 45
+    ) throws {
+        // Create the chat row once per chatRowID (ignore duplicates).
+        try db.execute(
+            sql: "INSERT OR IGNORE INTO chat (ROWID, guid, style, chat_identifier) VALUES (?, ?, ?, ?)",
+            arguments: [chatRowID, chatGUID, chatStyle, chatGUID])
+        let appleNanos = InMemoryChatDB.appleEpochNanos(unix: unixDate)
+        try db.execute(
+            sql: """
+                INSERT INTO message (ROWID, guid, text, handle_id, date,
+                                     is_from_me, cache_has_attachments,
+                                     associated_message_guid)
+                VALUES (?, ?, 'hi', ?, ?, 0, 0, NULL)
+                """,
+            arguments: [rowID, guid, handleID, appleNanos])
+        try db.execute(
+            sql: "INSERT INTO chat_message_join (chat_id, message_id) VALUES (?, ?)",
+            arguments: [chatRowID, rowID])
+    }
+
+    // MARK: - handle ROWID resolution (alternate spellings)
+
+    func testResolvesMultipleROWIDsForOneCanonicalHandle() throws {
+        let queue = try InMemoryChatDB.makeQueue()
+        try queue.write { db in
+            // Two raw spellings of the SAME canonical number.
+            try insertHandle(db: db, rowID: 1, id: "+15550000001")
+            try insertHandle(db: db, rowID: 2, id: "(555) 000-0001")
+            // An unrelated handle.
+            try insertHandle(db: db, rowID: 3, id: "+15559999999")
+        }
+        let resolved = try queue.read { db in
+            try MessagesScanReader.resolveHandleROWIDs(db: db, canonicalHandle: "+15550000001")
+        }
+        XCTAssertEqual(Set(resolved), [1, 2])
+    }
+
+    func testScanFindsRowsUnderAllSpellings() throws {
+        let queue = try InMemoryChatDB.makeQueue()
+        try queue.write { db in
+            try insertHandle(db: db, rowID: 1, id: "+15550000001")
+            try insertHandle(db: db, rowID: 2, id: "(555) 000-0001")
+            try insertMessage(db: db, rowID: 100, guid: "g1", handleID: 1,
+                              unixDate: unixApr2026, chatRowID: 10,
+                              chatGUID: "chatA")
+            try insertMessage(db: db, rowID: 101, guid: "g2", handleID: 2,
+                              unixDate: unixApr2026, chatRowID: 11,
+                              chatGUID: "chatB")
+        }
+        let page = try queue.read { db in
+            try MessagesScanReader.scanPage(
+                db: db, canonicalHandle: "+15550000001",
+                since: Date(timeIntervalSince1970: 1_767_225_600),
+                progressBelowRowID: nil, limit: 100)
+        }
+        XCTAssertEqual(Set(page.rows.map(\.guid)), ["g1", "g2"])
+        XCTAssertTrue(page.exhausted)
+    }
+
+    // MARK: - date window boundary
+
+    func testDateWindowBoundary() throws {
+        let queue = try InMemoryChatDB.makeQueue()
+        let sinceUnix = unixMay2026
+        try queue.write { db in
+            try insertHandle(db: db, rowID: 1, id: "+15550000001")
+            // Exactly at `since` → included.
+            try insertMessage(db: db, rowID: 100, guid: "at", handleID: 1,
+                              unixDate: sinceUnix, chatRowID: 10, chatGUID: "c")
+            // Just below `since` → excluded.
+            try insertMessage(db: db, rowID: 101, guid: "below", handleID: 1,
+                              unixDate: sinceUnix - 60, chatRowID: 10, chatGUID: "c")
+            // Well above `since` → included.
+            try insertMessage(db: db, rowID: 102, guid: "above", handleID: 1,
+                              unixDate: sinceUnix + 86_400, chatRowID: 10, chatGUID: "c")
+        }
+        let page = try queue.read { db in
+            try MessagesScanReader.scanPage(
+                db: db, canonicalHandle: "+15550000001",
+                since: Date(timeIntervalSince1970: sinceUnix),
+                progressBelowRowID: nil, limit: 100)
+        }
+        XCTAssertEqual(Set(page.rows.map(\.guid)), ["at", "above"])
+    }
+
+    // MARK: - no match
+
+    func testNoMatchHandleReturnsEmptyExhausted() throws {
+        let queue = try InMemoryChatDB.makeQueue()
+        try queue.write { db in
+            try insertHandle(db: db, rowID: 1, id: "+15550000001")
+            try insertMessage(db: db, rowID: 100, guid: "g1", handleID: 1,
+                              unixDate: unixApr2026, chatRowID: 10, chatGUID: "c")
+        }
+        let page = try queue.read { db in
+            try MessagesScanReader.scanPage(
+                db: db, canonicalHandle: "+15558888888",
+                since: Date(timeIntervalSince1970: 1_767_225_600),
+                progressBelowRowID: nil, limit: 100)
+        }
+        XCTAssertTrue(page.rows.isEmpty)
+        XCTAssertTrue(page.exhausted)
+        XCTAssertNil(page.lowestRowID)
+    }
+
+    // MARK: - group rows
+
+    func testGroupChatRowUnderScannedHandleIsReturned() throws {
+        let queue = try InMemoryChatDB.makeQueue()
+        try queue.write { db in
+            try insertHandle(db: db, rowID: 1, id: "+15550000001")
+            // style 43 = group chat.
+            try insertMessage(db: db, rowID: 100, guid: "grp", handleID: 1,
+                              unixDate: unixApr2026, chatRowID: 20,
+                              chatGUID: "groupX", chatStyle: 43)
+        }
+        let page = try queue.read { db in
+            try MessagesScanReader.scanPage(
+                db: db, canonicalHandle: "+15550000001",
+                since: Date(timeIntervalSince1970: 1_767_225_600),
+                progressBelowRowID: nil, limit: 100)
+        }
+        let row = try XCTUnwrap(page.rows.first)
+        XCTAssertEqual(row.guid, "grp")
+        XCTAssertTrue(row.isGroup)
+    }
+
+    // MARK: - budget / resumability
+
+    func testBudgetLimitAndResumeBelowProgress() throws {
+        let queue = try InMemoryChatDB.makeQueue()
+        try queue.write { db in
+            try insertHandle(db: db, rowID: 1, id: "+15550000001")
+            for i in 0..<5 {
+                try insertMessage(db: db, rowID: Int64(200 + i), guid: "g\(i)",
+                                  handleID: 1, unixDate: unixApr2026,
+                                  chatRowID: 10, chatGUID: "c")
+            }
+        }
+        // First page: budget 2 → highest two ROWIDs (descending), not
+        // exhausted.
+        let first = try queue.read { db in
+            try MessagesScanReader.scanPage(
+                db: db, canonicalHandle: "+15550000001",
+                since: Date(timeIntervalSince1970: 1_767_225_600),
+                progressBelowRowID: nil, limit: 2)
+        }
+        XCTAssertEqual(first.rows.map(\.rowID), [204, 203])
+        XCTAssertFalse(first.exhausted)
+        XCTAssertEqual(first.lowestRowID, 203)
+
+        // Resume strictly below the lowest of the first page.
+        let second = try queue.read { db in
+            try MessagesScanReader.scanPage(
+                db: db, canonicalHandle: "+15550000001",
+                since: Date(timeIntervalSince1970: 1_767_225_600),
+                progressBelowRowID: first.lowestRowID, limit: 2)
+        }
+        XCTAssertEqual(second.rows.map(\.rowID), [202, 201])
+        XCTAssertFalse(second.exhausted)
+
+        // Final page returns the last row and reports exhausted.
+        let third = try queue.read { db in
+            try MessagesScanReader.scanPage(
+                db: db, canonicalHandle: "+15550000001",
+                since: Date(timeIntervalSince1970: 1_767_225_600),
+                progressBelowRowID: second.lowestRowID, limit: 2)
+        }
+        XCTAssertEqual(third.rows.map(\.rowID), [200])
+        XCTAssertTrue(third.exhausted)
+    }
+
+    func testEmailHandleScan() throws {
+        let queue = try InMemoryChatDB.makeQueue()
+        try queue.write { db in
+            try insertHandle(db: db, rowID: 1, id: "Test@Example.com")
+            try insertMessage(db: db, rowID: 100, guid: "e1", handleID: 1,
+                              unixDate: unixApr2026, chatRowID: 10, chatGUID: "c")
+        }
+        let page = try queue.read { db in
+            try MessagesScanReader.scanPage(
+                db: db, canonicalHandle: "test@example.com",
+                since: Date(timeIntervalSince1970: 1_767_225_600),
+                progressBelowRowID: nil, limit: 100)
+        }
+        XCTAssertEqual(page.rows.map(\.guid), ["e1"])
+    }
+}

--- a/mac-daemon/Tests/CRMMacPhoneCallsSourceTests/CallHistoryScanExecutionTests.swift
+++ b/mac-daemon/Tests/CRMMacPhoneCallsSourceTests/CallHistoryScanExecutionTests.swift
@@ -1,0 +1,464 @@
+// CallHistoryScanExecutionTests — Phase A (durable scan enqueue) +
+// Phase B (resumable scan execution) end-to-end against a fake
+// PiClient, an on-disk CallHistoryDB the plugin opens itself, and a
+// real StateMutator over a temp StateStore.
+//
+// Synthetic handles only (+15550000001, test@example.com); no real PII.
+import XCTest
+import Foundation
+import GRDB
+import CRMMacCore
+import CRMMacPiClient
+@testable import CRMMacPhoneCallsSource
+
+final class CallHistoryScanExecutionTests: XCTestCase {
+    private let auth = PiAuth(
+        hostID: UUID(uuidString: "11111111-2222-3333-4444-555555555555")!,
+        apiKey: "k")
+    private let backfillFloor = PhoneCallsCursorWire.defaultBackfillFloor
+    // A fixed clock so the 30-day window is deterministic. 2026-05-20.
+    private let fixedNow = Date(timeIntervalSince1970: 1_779_000_000)
+    private let scannedUnix: TimeInterval = 1_777_680_000 // 2026-05-02
+    private var tempDir: URL!
+
+    /// Production-parity canonicalizer injected into the plugin + the
+    /// scan reader (phone -> E.164, email -> lowercased).
+    private let canonicalize: @Sendable (String) -> String = { raw in
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty { return "" }
+        if trimmed.contains("@") {
+            return NormalizationParity.normalizeEmail(trimmed)
+        }
+        return NormalizationParity.normalizePhoneE164(trimmed)
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("crm-mac-phone-scan-exec-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tempDir)
+        try super.tearDownWithError()
+    }
+
+    private func makeStateStore() -> StateStore {
+        StateStore(fileURL: tempDir.appendingPathComponent("state.json"))
+    }
+
+    /// A cursor with backfill complete + live cursor past every seeded
+    /// call, so the row-emitting batches are no-ops and ONLY the scan
+    /// publishes. Lets the scan-execution assertions isolate Phase B.
+    private func inactiveBatchCursor(
+        pendingScans: [PhoneCallsCursorPendingScan] = []
+    ) -> PhoneCallsCursor {
+        let highZDate = InMemoryCallHistoryDB.appleEpochSeconds(unix: fixedNow.timeIntervalSince1970)
+        return PhoneCallsCursor(
+            backfillCursorZDate: 0,
+            backfillCursorZPK: 0,
+            liveCursorZDate: highZDate,
+            liveCursorZPK: 1_000_000,
+            installMaxZDate: highZDate,
+            installMaxZPK: 1_000_000,
+            backfillFloorSentAt: backfillFloor,
+            backfillComplete: true,
+            pendingScans: pendingScans)
+    }
+
+    /// Build an on-disk CallHistoryDB (full fixture schema, so the
+    /// plugin's schema validator passes) with `count` calls under one
+    /// handle at consecutive Z_PKs starting at 100, all at `scannedUnix`
+    /// + i seconds.
+    private func makeCallHistoryDB(callCount: Int, handle: String = "+15550000001") throws -> URL {
+        let dbURL = tempDir.appendingPathComponent("CallHistory.storedata")
+        let bundle = Bundle.module
+        guard let scriptURL = bundle.url(forResource: "call_history_db_schema",
+                                          withExtension: "sql",
+                                          subdirectory: "Fixtures") else {
+            throw XCTSkip("call_history_db_schema.sql not in test bundle")
+        }
+        let script = try String(contentsOf: scriptURL, encoding: .utf8)
+        let queue = try DatabaseQueue(path: dbURL.path)
+        try queue.write { db in
+            try db.execute(sql: script)
+            for i in 0..<callCount {
+                let zPK = 100 + i
+                let zdate = InMemoryCallHistoryDB.appleEpochSeconds(
+                    unix: scannedUnix + TimeInterval(i))
+                try db.execute(sql: """
+                    INSERT INTO ZCALLRECORD (
+                        Z_PK, ZUNIQUE_ID, ZDATE, ZADDRESS,
+                        ZORIGINATED, ZANSWERED, ZDURATION,
+                        ZSERVICE_PROVIDER, ZCALLTYPE, ZHASMESSAGE)
+                    VALUES (?, ?, ?, ?, 0, 1, 30, 'com.apple.Telephony', 0, 0)
+                    """,
+                    arguments: [zPK, "u\(zPK)", zdate, handle])
+            }
+        }
+        return dbURL
+    }
+
+    private func makePlugin(
+        dbURL: URL,
+        store: StateStore,
+        cache: KnownIdentifiersCache,
+        transport: PhoneStatefulCursorTransport,
+        publisherSink: PhonePublisherSink,
+        maxRowsPerTick: Int = 500
+    ) -> PhoneCallsSourcePlugin {
+        let now = fixedNow
+        let piClient = PiClient(
+            baseURL: URL(string: "https://pi.example.test")!,
+            transport: transport.asTransport(),
+            sleep: { _ in })
+        let publisher = PhoneCallsPublisher(
+            sender: { _, body in
+                await publisherSink.record(body.events)
+                return IngestEventsData(
+                    accepted: body.events.count, duplicate: 0, rejected: 0, errors: [])
+            },
+            auth: auth, logger: NoopLogger())
+        return PhoneCallsSourcePlugin(
+            tickInterval: 60,
+            config: PhoneCallsSourceConfig(
+                callHistoryDBPath: dbURL,
+                backfillFloor: backfillFloor,
+                maxRowsPerTick: maxRowsPerTick),
+            piClient: piClient,
+            auth: auth,
+            mutator: StateMutator(store: store),
+            publisher: publisher,
+            cache: cache,
+            canonicalizer: canonicalize,
+            heartbeatStateProvider: InMemoryHeartbeatStateProvider(initial: 2),
+            healthRegistry: SourceHealthRegistry(),
+            logger: NoopLogger(),
+            clock: { now })
+    }
+
+    // MARK: - Phase A durability + scan execution
+
+    func testNewlyKnownEnqueuesDurablyThenScansAndPublishes() async throws {
+        let dbURL = try makeCallHistoryDB(callCount: 1)
+        let store = makeStateStore()
+        let seeded = inactiveBatchCursor()
+        try store.save(DaemonState(schemaVersion: 1))
+        let cache = KnownIdentifiersCache(
+            baselines: [.phoneCalls: []], consumers: [.phoneCalls])
+        // A heartbeat fetch surfaces the new identifier.
+        await cache.replace(with: ["+15550000001"])
+
+        let transport = PhoneStatefulCursorTransport(
+            initialCursor: try PhoneCallsCursorCodec.encode(seeded))
+        let sink = PhonePublisherSink()
+        let plugin = makePlugin(dbURL: dbURL, store: store, cache: cache,
+                                transport: transport, publisherSink: sink)
+
+        try await plugin.tick()
+
+        // The cursor was committed with the pendingScans entry BEFORE any
+        // scan row published (Phase A durability).
+        let firstEnqueueIndex = await transport.firstCommitIndexContaining("+15550000001")
+        XCTAssertNotNil(firstEnqueueIndex, "a committed cursor must carry the enqueued scan")
+
+        // The scanned call published with the right kind/source_id.
+        let events = await sink.allEvents()
+        XCTAssertTrue(events.contains { $0.sourceID == "u100" && $0.kind == "call.received" },
+                      "scanned call published")
+
+        // The source tick did NOT write the persisted baseline.
+        let state = try store.load()
+        XCTAssertNil(state.knownIdentifierBaselines,
+                     "source tick must not write knownIdentifierBaselines")
+
+        // After a fully-exhausted scan, the final committed cursor has an
+        // empty pendingScans (the entry dequeued).
+        let finalCursor = await transport.currentDecodedCursor()
+        XCTAssertEqual(finalCursor?.pendingScans.count, 0,
+                       "exhausted scan dequeued")
+    }
+
+    // MARK: - Phase A failure rolls back
+
+    func testPhaseAFailureReturnsIdentifierForReEnqueue() async throws {
+        let dbURL = try makeCallHistoryDB(callCount: 1)
+        let store = makeStateStore()
+        try store.save(DaemonState(schemaVersion: 1))
+        let cache = KnownIdentifiersCache(
+            baselines: [.phoneCalls: []], consumers: [.phoneCalls])
+        await cache.replace(with: ["+15550000001"])
+
+        // Transport fails every commit → Phase A cannot persist.
+        let transport = PhoneStatefulCursorTransport(failCommits: true)
+        let sink = PhonePublisherSink()
+        let plugin = makePlugin(dbURL: dbURL, store: store, cache: cache,
+                                transport: transport, publisherSink: sink)
+
+        try await plugin.tick()
+
+        // No scan executed (Phase A aborted before Phase B).
+        let events = await sink.allEvents()
+        XCTAssertTrue(events.isEmpty, "no scan rows published when Phase A fails")
+
+        // The identifier was returned to the cache → a subsequent drain
+        // re-returns it for re-enqueue.
+        let reDrained = await cache.drainNewlyAdded(for: .phoneCalls)
+        XCTAssertEqual(reDrained, ["+15550000001"], "identifier returned for re-enqueue")
+    }
+
+    // MARK: - resumable / larger-than-budget
+
+    func testResumableScanAcrossTicksDropsNoRows() async throws {
+        // 5 matching calls, budget 2 → 3 ticks to fully walk.
+        let dbURL = try makeCallHistoryDB(callCount: 5)
+        let store = makeStateStore()
+        let seeded = inactiveBatchCursor()
+        try store.save(DaemonState(schemaVersion: 1))
+        let cache = KnownIdentifiersCache(
+            baselines: [.phoneCalls: []], consumers: [.phoneCalls])
+        await cache.replace(with: ["+15550000001"])
+
+        let transport = PhoneStatefulCursorTransport(
+            initialCursor: try PhoneCallsCursorCodec.encode(seeded))
+        let sink = PhonePublisherSink()
+        let plugin = makePlugin(dbURL: dbURL, store: store, cache: cache,
+                                transport: transport, publisherSink: sink,
+                                maxRowsPerTick: 2)
+
+        for _ in 0..<3 {
+            try await plugin.tick()
+        }
+
+        let scanned = await sink.scannedSourceIDs()
+        XCTAssertEqual(scanned, Set((100...104).map { "u\($0)" }),
+                       "every scanned row published across the multi-tick walk")
+        let finalCursor = await transport.currentDecodedCursor()
+        XCTAssertEqual(finalCursor?.pendingScans.count, 0, "scan dequeued once exhausted")
+    }
+
+    // MARK: - membership gate (hasFetched vs isPopulated)
+
+    func testUnknownHandleDroppedWhenFetched() async throws {
+        let dbURL = try makeCallHistoryDB(callCount: 1, handle: "+15550000001")
+        let store = makeStateStore()
+        let seededCursor = inactiveBatchCursor(pendingScans: [
+            PhoneCallsCursorPendingScan(
+                normalizedHandle: "+15557777777",
+                since: Date(timeIntervalSince1970: scannedUnix - 86_400)),
+        ])
+        var st = DaemonState(schemaVersion: 1)
+        st.sources["phone_calls"] = SourceState(cursor: try PhoneCallsCursorCodec.encode(seededCursor))
+        try store.save(st)
+
+        let cache = KnownIdentifiersCache(
+            baselines: [.phoneCalls: []], consumers: [.phoneCalls])
+        // Empty CRM but FETCHED.
+        await cache.replace(with: [])
+
+        let transport = PhoneStatefulCursorTransport(
+            initialCursor: try PhoneCallsCursorCodec.encode(seededCursor))
+        let sink = PhonePublisherSink()
+        let plugin = makePlugin(dbURL: dbURL, store: store, cache: cache,
+                                transport: transport, publisherSink: sink)
+
+        try await plugin.tick()
+
+        let events = await sink.allEvents()
+        XCTAssertTrue(events.isEmpty, "unknown-handle scan publishes nothing")
+        let finalCursor = await transport.currentDecodedCursor()
+        XCTAssertEqual(finalCursor?.pendingScans.count, 0, "unknown-handle entry dropped")
+    }
+
+    func testUnknownHandleDeferredWhenNotFetched() async throws {
+        let dbURL = try makeCallHistoryDB(callCount: 1, handle: "+15550000001")
+        let store = makeStateStore()
+        let seededCursor = inactiveBatchCursor(pendingScans: [
+            PhoneCallsCursorPendingScan(
+                normalizedHandle: "+15557777777",
+                since: Date(timeIntervalSince1970: scannedUnix - 86_400)),
+        ])
+        var st = DaemonState(schemaVersion: 1)
+        st.sources["phone_calls"] = SourceState(cursor: try PhoneCallsCursorCodec.encode(seededCursor))
+        try store.save(st)
+
+        // Cache never fetched (hasFetched == false). isPopulated false too.
+        let cache = KnownIdentifiersCache(
+            baselines: [.phoneCalls: []], consumers: [.phoneCalls])
+
+        let transport = PhoneStatefulCursorTransport(
+            initialCursor: try PhoneCallsCursorCodec.encode(seededCursor))
+        let sink = PhonePublisherSink()
+        let plugin = makePlugin(dbURL: dbURL, store: store, cache: cache,
+                                transport: transport, publisherSink: sink)
+
+        try await plugin.tick()
+
+        let events = await sink.allEvents()
+        XCTAssertTrue(events.isEmpty, "no publish on a not-yet-fetched cache")
+        let finalCursor = await transport.currentDecodedCursor()
+        XCTAssertEqual(finalCursor?.pendingScans.count, 1,
+                       "durable scan preserved on a startup-race tick")
+    }
+
+    // MARK: - coverage-dedup widens window
+
+    func testCoverageDedupWidensNarrowOperatorEntry() async throws {
+        // A narrow operator entry (since = now-2d, progress advanced past
+        // the row) for the handle, then an auto 30-day enqueue for the
+        // same handle → ONE merged entry widened to 30 days, progress
+        // reset, so the older row is re-walked and published.
+        let dbURL = try makeCallHistoryDB(callCount: 1)
+        let store = makeStateStore()
+        let narrowSince = fixedNow.addingTimeInterval(-2 * 86_400)
+        // Progress coordinate strictly ABOVE the seeded call so the
+        // narrow entry alone would match nothing.
+        let aboveZDate = InMemoryCallHistoryDB.appleEpochSeconds(unix: fixedNow.timeIntervalSince1970)
+        let seededCursor = inactiveBatchCursor(pendingScans: [
+            PhoneCallsCursorPendingScan(
+                normalizedHandle: "+15550000001",
+                since: narrowSince,
+                progressBelowZDate: aboveZDate,
+                progressBelowZPK: 50),
+        ])
+        var st = DaemonState(schemaVersion: 1)
+        st.sources["phone_calls"] = SourceState(cursor: try PhoneCallsCursorCodec.encode(seededCursor))
+        try store.save(st)
+
+        let cache = KnownIdentifiersCache(
+            baselines: [.phoneCalls: []], consumers: [.phoneCalls])
+        await cache.replace(with: ["+15550000001"])
+
+        let transport = PhoneStatefulCursorTransport(
+            initialCursor: try PhoneCallsCursorCodec.encode(seededCursor))
+        let sink = PhonePublisherSink()
+        let plugin = makePlugin(dbURL: dbURL, store: store, cache: cache,
+                                transport: transport, publisherSink: sink)
+
+        try await plugin.tick()
+
+        // The auto 30-day enqueue coverage-merges into the same handle,
+        // widening the window (now-30d covers 2026-05-02) and resetting
+        // progress to nil, so the call is re-walked and published.
+        let scanned = await sink.scannedSourceIDs()
+        XCTAssertTrue(scanned.contains("u100"),
+                      "window-widen reset progress so the row is re-walked")
+        let finalCursor = await transport.currentDecodedCursor()
+        XCTAssertEqual(finalCursor?.pendingScans.count, 0)
+    }
+
+    // MARK: - operator-queued scan executes identically
+
+    func testOperatorQueuedScanExecutesForKnownHandle() async throws {
+        // A pre-seeded operator scan (no progress) for a KNOWN handle
+        // executes identically to an auto-queued one.
+        let dbURL = try makeCallHistoryDB(callCount: 1)
+        let store = makeStateStore()
+        let seededCursor = inactiveBatchCursor(pendingScans: [
+            PhoneCallsCursorPendingScan(
+                normalizedHandle: "+15550000001",
+                since: Date(timeIntervalSince1970: scannedUnix - 86_400)),
+        ])
+        var st = DaemonState(schemaVersion: 1)
+        st.sources["phone_calls"] = SourceState(cursor: try PhoneCallsCursorCodec.encode(seededCursor))
+        try store.save(st)
+
+        let cache = KnownIdentifiersCache(
+            baselines: [.phoneCalls: ["+15550000001"]], consumers: [.phoneCalls])
+        await cache.replace(with: ["+15550000001"])
+
+        let transport = PhoneStatefulCursorTransport(
+            initialCursor: try PhoneCallsCursorCodec.encode(seededCursor))
+        let sink = PhonePublisherSink()
+        let plugin = makePlugin(dbURL: dbURL, store: store, cache: cache,
+                                transport: transport, publisherSink: sink)
+
+        try await plugin.tick()
+
+        let scanned = await sink.scannedSourceIDs()
+        XCTAssertTrue(scanned.contains("u100"), "operator-queued scan published the call")
+        let finalCursor = await transport.currentDecodedCursor()
+        XCTAssertEqual(finalCursor?.pendingScans.count, 0, "operator scan dequeued on exhaustion")
+    }
+}
+
+/// Records the IngestEvents the publisher sends, in order.
+actor PhonePublisherSink {
+    private var events: [IngestEvent] = []
+    func record(_ batch: [IngestEvent]) { events.append(contentsOf: batch) }
+    func allEvents() -> [IngestEvent] { events }
+    func scannedSourceIDs() -> Set<String> { Set(events.map(\.sourceID)) }
+}
+
+/// Stateful fake transport for the phone_calls cursor GET/commit flow.
+/// Holds the current cursor JSON; GET returns it, POST commit updates it
+/// and records the committed cursor. Ingest events are NOT routed here —
+/// the publisher uses its own injected sender.
+final class PhoneStatefulCursorTransport: @unchecked Sendable {
+    private let lock = NSLock()
+    private var currentCursor: String
+    private var committedCursors: [String] = []
+    private let failCommits: Bool
+
+    init(initialCursor: String = "", failCommits: Bool = false) {
+        self.currentCursor = initialCursor
+        self.failCommits = failCommits
+    }
+
+    func asTransport() -> TransportFunc {
+        return { [self] request in
+            let url = request.url ?? URL(string: "https://test.invalid")!
+            let method = request.httpMethod ?? "GET"
+            func http(_ status: Int) -> HTTPURLResponse {
+                HTTPURLResponse(url: url, statusCode: status, httpVersion: "HTTP/1.1",
+                                headerFields: ["Content-Type": "application/json"])!
+            }
+            if method == "GET", url.path.hasSuffix("/cursor") {
+                lock.lock(); let cur = currentCursor; lock.unlock()
+                let body = """
+                    {"success":true,"data":{"cursor":\(Self.jsonString(cur)),"cursor_epoch":0,"backfill_complete":false}}
+                    """
+                return (Data(body.utf8), http(200))
+            }
+            if method == "POST", url.path.hasSuffix("/cursor") {
+                if failCommits {
+                    return (Data(#"{"error":{"code":"boom","message":"forced"}}"#.utf8), http(500))
+                }
+                if let bodyData = request.httpBody,
+                   let obj = try? JSONSerialization.jsonObject(with: bodyData) as? [String: Any],
+                   let cursor = obj["cursor"] as? String {
+                    lock.lock()
+                    currentCursor = cursor
+                    committedCursors.append(cursor)
+                    lock.unlock()
+                }
+                return (Data(#"{"success":true,"data":{"ok":true}}"#.utf8), http(200))
+            }
+            return (Data(#"{"success":true,"data":{}}"#.utf8), http(200))
+        }
+    }
+
+    func currentDecodedCursor() -> PhoneCallsCursorWire? {
+        lock.lock(); let cur = currentCursor; lock.unlock()
+        return try? PhoneCallsCursorWireCodec.decode(cur)
+    }
+
+    /// Index of the first committed cursor whose pendingScans carries
+    /// `handle`, or nil.
+    func firstCommitIndexContaining(_ handle: String) -> Int? {
+        lock.lock(); let commits = committedCursors; lock.unlock()
+        for (i, json) in commits.enumerated() {
+            if let decoded = try? PhoneCallsCursorWireCodec.decode(json),
+               decoded.pendingScans.contains(where: { $0.normalizedHandle == handle }) {
+                return i
+            }
+        }
+        return nil
+    }
+
+    private static func jsonString(_ s: String) -> String {
+        let data = try? JSONEncoder().encode(s)
+        return data.map { String(decoding: $0, as: UTF8.self) } ?? "\"\""
+    }
+}

--- a/mac-daemon/Tests/CRMMacPhoneCallsSourceTests/CallHistoryScanExecutionTests.swift
+++ b/mac-daemon/Tests/CRMMacPhoneCallsSourceTests/CallHistoryScanExecutionTests.swift
@@ -160,7 +160,7 @@ final class CallHistoryScanExecutionTests: XCTestCase {
 
         // The cursor was committed with the pendingScans entry BEFORE any
         // scan row published (Phase A durability).
-        let firstEnqueueIndex = await transport.firstCommitIndexContaining("+15550000001")
+        let firstEnqueueIndex = transport.firstCommitIndexContaining("+15550000001")
         XCTAssertNotNil(firstEnqueueIndex, "a committed cursor must carry the enqueued scan")
 
         // The scanned call published with the right kind/source_id.
@@ -175,7 +175,7 @@ final class CallHistoryScanExecutionTests: XCTestCase {
 
         // After a fully-exhausted scan, the final committed cursor has an
         // empty pendingScans (the entry dequeued).
-        let finalCursor = await transport.currentDecodedCursor()
+        let finalCursor = transport.currentDecodedCursor()
         XCTAssertEqual(finalCursor?.pendingScans.count, 0,
                        "exhausted scan dequeued")
     }
@@ -234,7 +234,7 @@ final class CallHistoryScanExecutionTests: XCTestCase {
         let scanned = await sink.scannedSourceIDs()
         XCTAssertEqual(scanned, Set((100...104).map { "u\($0)" }),
                        "every scanned row published across the multi-tick walk")
-        let finalCursor = await transport.currentDecodedCursor()
+        let finalCursor = transport.currentDecodedCursor()
         XCTAssertEqual(finalCursor?.pendingScans.count, 0, "scan dequeued once exhausted")
     }
 
@@ -267,7 +267,7 @@ final class CallHistoryScanExecutionTests: XCTestCase {
 
         let events = await sink.allEvents()
         XCTAssertTrue(events.isEmpty, "unknown-handle scan publishes nothing")
-        let finalCursor = await transport.currentDecodedCursor()
+        let finalCursor = transport.currentDecodedCursor()
         XCTAssertEqual(finalCursor?.pendingScans.count, 0, "unknown-handle entry dropped")
     }
 
@@ -297,7 +297,7 @@ final class CallHistoryScanExecutionTests: XCTestCase {
 
         let events = await sink.allEvents()
         XCTAssertTrue(events.isEmpty, "no publish on a not-yet-fetched cache")
-        let finalCursor = await transport.currentDecodedCursor()
+        let finalCursor = transport.currentDecodedCursor()
         XCTAssertEqual(finalCursor?.pendingScans.count, 1,
                        "durable scan preserved on a startup-race tick")
     }
@@ -344,7 +344,7 @@ final class CallHistoryScanExecutionTests: XCTestCase {
         let scanned = await sink.scannedSourceIDs()
         XCTAssertTrue(scanned.contains("u100"),
                       "window-widen reset progress so the row is re-walked")
-        let finalCursor = await transport.currentDecodedCursor()
+        let finalCursor = transport.currentDecodedCursor()
         XCTAssertEqual(finalCursor?.pendingScans.count, 0)
     }
 
@@ -378,7 +378,7 @@ final class CallHistoryScanExecutionTests: XCTestCase {
 
         let scanned = await sink.scannedSourceIDs()
         XCTAssertTrue(scanned.contains("u100"), "operator-queued scan published the call")
-        let finalCursor = await transport.currentDecodedCursor()
+        let finalCursor = transport.currentDecodedCursor()
         XCTAssertEqual(finalCursor?.pendingScans.count, 0, "operator scan dequeued on exhaustion")
     }
 
@@ -413,7 +413,7 @@ final class CallHistoryScanExecutionTests: XCTestCase {
         // The persisted cursor reflects ONLY the Phase-A enqueue commit:
         // one pending scan, nil progress (the rejected Phase-B commit
         // never advanced it, AND no stale final commit landed).
-        let finalCursor = await transport.currentDecodedCursor()
+        let finalCursor = transport.currentDecodedCursor()
         XCTAssertEqual(finalCursor?.pendingScans.count, 1, "scan entry still queued after abort")
         XCTAssertNil(finalCursor?.pendingScans.first?.progressBelowZDate,
                      "Phase-B progress NOT durably committed under conflict; no stale overwrite")
@@ -462,7 +462,7 @@ final class PhoneStatefulCursorTransport: @unchecked Sendable {
                                 headerFields: ["Content-Type": "application/json"])!
             }
             if method == "GET", url.path.hasSuffix("/cursor") {
-                lock.lock(); let cur = currentCursor; lock.unlock()
+                let cur = lock.withLock { currentCursor }
                 let body = """
                     {"success":true,"data":{"cursor":\(Self.jsonString(cur)),"cursor_epoch":0,"backfill_complete":false}}
                     """
@@ -472,7 +472,10 @@ final class PhoneStatefulCursorTransport: @unchecked Sendable {
                 if failCommits {
                     return (Data(#"{"error":{"code":"boom","message":"forced"}}"#.utf8), http(500))
                 }
-                lock.lock(); commitAttempts += 1; let attempt = commitAttempts; lock.unlock()
+                let attempt = lock.withLock { () -> Int in
+                    commitAttempts += 1
+                    return commitAttempts
+                }
                 if let target = conflictOnlyAt, attempt == target {
                     // 409 cursor-conflict: cursor NOT updated (the daemon
                     // refreshes its base + aborts the tick).
@@ -486,10 +489,10 @@ final class PhoneStatefulCursorTransport: @unchecked Sendable {
                 if let bodyData = request.httpBody,
                    let obj = try? JSONSerialization.jsonObject(with: bodyData) as? [String: Any],
                    let cursor = obj["cursor"] as? String {
-                    lock.lock()
-                    currentCursor = cursor
-                    committedCursors.append(cursor)
-                    lock.unlock()
+                    lock.withLock {
+                        currentCursor = cursor
+                        committedCursors.append(cursor)
+                    }
                 }
                 return (Data(#"{"success":true,"data":{"ok":true}}"#.utf8), http(200))
             }

--- a/mac-daemon/Tests/CRMMacPhoneCallsSourceTests/CallHistoryScanExecutionTests.swift
+++ b/mac-daemon/Tests/CRMMacPhoneCallsSourceTests/CallHistoryScanExecutionTests.swift
@@ -381,6 +381,41 @@ final class CallHistoryScanExecutionTests: XCTestCase {
         let finalCursor = await transport.currentDecodedCursor()
         XCTAssertEqual(finalCursor?.pendingScans.count, 0, "operator scan dequeued on exhaustion")
     }
+
+    // MARK: - Phase B conflict aborts the tick
+
+    func testPhaseBConflictAbortsTickWithoutOverwriting() async throws {
+        // 5 calls, budget 2. Commit #1 = Phase A enqueue (succeeds).
+        // Commit #2 = Phase B progress advance → forced 409 conflict.
+        // The tick must abort: the Phase-B progress is NOT durably
+        // committed, and the row-emitting batches + final commit must
+        // NOT run against the now-stale working cursor.
+        let dbURL = try makeCallHistoryDB(callCount: 5)
+        let store = makeStateStore()
+        let seeded = inactiveBatchCursor()
+        try store.save(DaemonState(schemaVersion: 1))
+        let cache = KnownIdentifiersCache(
+            baselines: [.phoneCalls: []], consumers: [.phoneCalls])
+        await cache.replace(with: ["+15550000001"])
+
+        let transport = PhoneStatefulCursorTransport(
+            initialCursor: try PhoneCallsCursorCodec.encode(seeded),
+            conflictAtOrAfter: 2)
+        let sink = PhonePublisherSink()
+        let plugin = makePlugin(dbURL: dbURL, store: store, cache: cache,
+                                transport: transport, publisherSink: sink,
+                                maxRowsPerTick: 2)
+
+        try await plugin.tick()
+
+        // The persisted cursor reflects ONLY the Phase-A enqueue commit:
+        // one pending scan, nil progress (the rejected Phase-B commit
+        // never advanced it).
+        let finalCursor = await transport.currentDecodedCursor()
+        XCTAssertEqual(finalCursor?.pendingScans.count, 1, "scan entry still queued after abort")
+        XCTAssertNil(finalCursor?.pendingScans.first?.progressBelowZDate,
+                     "Phase-B progress NOT durably committed under conflict")
+    }
 }
 
 /// Records the IngestEvents the publisher sends, in order.
@@ -399,11 +434,18 @@ final class PhoneStatefulCursorTransport: @unchecked Sendable {
     private let lock = NSLock()
     private var currentCursor: String
     private var committedCursors: [String] = []
+    private var commitAttempts = 0
     private let failCommits: Bool
+    /// When set, the (1-based) commit at this index and beyond returns a
+    /// 409 cursor-conflict (the cursor is NOT updated). Lets tests force
+    /// a conflict on a SPECIFIC commit (e.g. the Phase-B re-commit) while
+    /// earlier commits succeed.
+    private let conflictAtOrAfter: Int?
 
-    init(initialCursor: String = "", failCommits: Bool = false) {
+    init(initialCursor: String = "", failCommits: Bool = false, conflictAtOrAfter: Int? = nil) {
         self.currentCursor = initialCursor
         self.failCommits = failCommits
+        self.conflictAtOrAfter = conflictAtOrAfter
     }
 
     func asTransport() -> TransportFunc {
@@ -424,6 +466,17 @@ final class PhoneStatefulCursorTransport: @unchecked Sendable {
             if method == "POST", url.path.hasSuffix("/cursor") {
                 if failCommits {
                     return (Data(#"{"error":{"code":"boom","message":"forced"}}"#.utf8), http(500))
+                }
+                lock.lock(); commitAttempts += 1; let attempt = commitAttempts; lock.unlock()
+                if let threshold = conflictAtOrAfter, attempt >= threshold {
+                    // 409 cursor-conflict: cursor NOT updated (the daemon
+                    // refreshes its base + aborts the tick).
+                    let body = """
+                        {"success":false,
+                         "error":{"code":"EPOCH_MISMATCH","message":"epoch mismatch"},
+                         "data":{"current_cursor":\(Self.jsonString(currentCursor)),"current_epoch":9}}
+                        """
+                    return (Data(body.utf8), http(409))
                 }
                 if let bodyData = request.httpBody,
                    let obj = try? JSONSerialization.jsonObject(with: bodyData) as? [String: Any],

--- a/mac-daemon/Tests/CRMMacPhoneCallsSourceTests/CallHistoryScanExecutionTests.swift
+++ b/mac-daemon/Tests/CRMMacPhoneCallsSourceTests/CallHistoryScanExecutionTests.swift
@@ -387,9 +387,11 @@ final class CallHistoryScanExecutionTests: XCTestCase {
     func testPhaseBConflictAbortsTickWithoutOverwriting() async throws {
         // 5 calls, budget 2. Commit #1 = Phase A enqueue (succeeds).
         // Commit #2 = Phase B progress advance → forced 409 conflict.
-        // The tick must abort: the Phase-B progress is NOT durably
-        // committed, and the row-emitting batches + final commit must
-        // NOT run against the now-stale working cursor.
+        // ONLY commit #2 conflicts; a later commit would SUCCEED — so a
+        // regressed plugin that continued past the conflict would land a
+        // STALE final commit (#3) carrying the advanced Phase-B progress,
+        // failing the nil-progress assertion below. The fixed plugin
+        // aborts the tick, so commit #3 never happens.
         let dbURL = try makeCallHistoryDB(callCount: 5)
         let store = makeStateStore()
         let seeded = inactiveBatchCursor()
@@ -400,7 +402,7 @@ final class CallHistoryScanExecutionTests: XCTestCase {
 
         let transport = PhoneStatefulCursorTransport(
             initialCursor: try PhoneCallsCursorCodec.encode(seeded),
-            conflictAtOrAfter: 2)
+            conflictOnlyAt: 2)
         let sink = PhonePublisherSink()
         let plugin = makePlugin(dbURL: dbURL, store: store, cache: cache,
                                 transport: transport, publisherSink: sink,
@@ -410,11 +412,11 @@ final class CallHistoryScanExecutionTests: XCTestCase {
 
         // The persisted cursor reflects ONLY the Phase-A enqueue commit:
         // one pending scan, nil progress (the rejected Phase-B commit
-        // never advanced it).
+        // never advanced it, AND no stale final commit landed).
         let finalCursor = await transport.currentDecodedCursor()
         XCTAssertEqual(finalCursor?.pendingScans.count, 1, "scan entry still queued after abort")
         XCTAssertNil(finalCursor?.pendingScans.first?.progressBelowZDate,
-                     "Phase-B progress NOT durably committed under conflict")
+                     "Phase-B progress NOT durably committed under conflict; no stale overwrite")
     }
 }
 
@@ -436,16 +438,19 @@ final class PhoneStatefulCursorTransport: @unchecked Sendable {
     private var committedCursors: [String] = []
     private var commitAttempts = 0
     private let failCommits: Bool
-    /// When set, the (1-based) commit at this index and beyond returns a
-    /// 409 cursor-conflict (the cursor is NOT updated). Lets tests force
-    /// a conflict on a SPECIFIC commit (e.g. the Phase-B re-commit) while
-    /// earlier commits succeed.
-    private let conflictAtOrAfter: Int?
+    /// When set, ONLY the (1-based) commit at exactly this index returns
+    /// a 409 cursor-conflict; the cursor is NOT updated for it but later
+    /// commits succeed normally. Forcing the conflict on a SINGLE commit
+    /// (not "at-or-after") is deliberate: it lets the Phase-B abort test
+    /// detect a regression where a buggy plugin continues after the
+    /// conflict and lands a STALE final commit — that later commit would
+    /// SUCCEED and overwrite, failing the assertion.
+    private let conflictOnlyAt: Int?
 
-    init(initialCursor: String = "", failCommits: Bool = false, conflictAtOrAfter: Int? = nil) {
+    init(initialCursor: String = "", failCommits: Bool = false, conflictOnlyAt: Int? = nil) {
         self.currentCursor = initialCursor
         self.failCommits = failCommits
-        self.conflictAtOrAfter = conflictAtOrAfter
+        self.conflictOnlyAt = conflictOnlyAt
     }
 
     func asTransport() -> TransportFunc {
@@ -468,7 +473,7 @@ final class PhoneStatefulCursorTransport: @unchecked Sendable {
                     return (Data(#"{"error":{"code":"boom","message":"forced"}}"#.utf8), http(500))
                 }
                 lock.lock(); commitAttempts += 1; let attempt = commitAttempts; lock.unlock()
-                if let threshold = conflictAtOrAfter, attempt >= threshold {
+                if let target = conflictOnlyAt, attempt == target {
                     // 409 cursor-conflict: cursor NOT updated (the daemon
                     // refreshes its base + aborts the tick).
                     let body = """

--- a/mac-daemon/Tests/CRMMacPhoneCallsSourceTests/CallHistoryScanReaderTests.swift
+++ b/mac-daemon/Tests/CRMMacPhoneCallsSourceTests/CallHistoryScanReaderTests.swift
@@ -245,11 +245,14 @@ final class CallHistoryScanReaderTests: XCTestCase {
         XCTAssertFalse(first.exhausted)
         XCTAssertEqual(first.lowestPoint?.zPK, 30)
 
+        // limit 2 so the single remaining row returns 1 < 2 → exhausted
+        // (a limit-1 page returning exactly 1 row would NOT yet report
+        // exhaustion — it takes a following empty page to confirm).
         let second = try scan(queue, handle: "+15550000001",
                               sinceUnix: unixFloor2026,
                               progressBelowZDate: first.lowestPoint?.zdate,
                               progressBelowZPK: first.lowestPoint?.zPK,
-                              limit: 1)
+                              limit: 2)
         XCTAssertEqual(second.rows.map(\.uniqueID), ["good"])
         XCTAssertTrue(second.exhausted)
     }

--- a/mac-daemon/Tests/CRMMacPhoneCallsSourceTests/CallHistoryScanReaderTests.swift
+++ b/mac-daemon/Tests/CRMMacPhoneCallsSourceTests/CallHistoryScanReaderTests.swift
@@ -1,0 +1,256 @@
+// CallHistoryScanReaderTests — the identifier-scoped, date-bounded,
+// resumable ZADDRESS scan reader over CallHistoryDB.
+//
+// Synthetic handles only (+15550000001, test@example.com); no real PII.
+import XCTest
+import GRDB
+import CRMMacCore
+@testable import CRMMacPhoneCallsSource
+
+final class CallHistoryScanReaderTests: XCTestCase {
+    // 2026-04-01 UTC — inside the 30-day window for the 2026-05 `since`
+    // tests, and after the backfill floor.
+    private let unixApr2026: TimeInterval = 1_775_001_600 // 2026-04-01
+    private let unixMay2026: TimeInterval = 1_777_680_000 // 2026-05-02
+    // 2026-01-01 floor in UNIX seconds.
+    private let unixFloor2026: TimeInterval = 1_767_225_600
+
+    /// Production-parity canonicalizer (phone -> E.164, email ->
+    /// lowercased). Mirrors the closure the plugin injects.
+    private let canonicalize: (String) -> String = { raw in
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty { return "" }
+        if trimmed.contains("@") {
+            return NormalizationParity.normalizeEmail(trimmed)
+        }
+        return NormalizationParity.normalizePhoneE164(trimmed)
+    }
+
+    private func insertCall(
+        db: Database,
+        zPK: Int64,
+        uniqueID: String,
+        address: String?,
+        unixDate: TimeInterval,
+        originated: Bool = false,
+        serviceProvider: String? = "com.apple.Telephony",
+        callType: Int64? = 0
+    ) throws {
+        let zdate = InMemoryCallHistoryDB.appleEpochSeconds(unix: unixDate)
+        try db.execute(
+            sql: """
+                INSERT INTO ZCALLRECORD (
+                    Z_PK, ZUNIQUE_ID, ZDATE, ZADDRESS,
+                    ZORIGINATED, ZANSWERED, ZDURATION,
+                    ZSERVICE_PROVIDER, ZCALLTYPE, ZHASMESSAGE)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+            arguments: [
+                zPK, uniqueID, zdate, address,
+                originated ? 1 : 0, originated ? nil : 1, 30,
+                serviceProvider, callType, 0,
+            ])
+    }
+
+    private func scan(
+        _ queue: DatabaseQueue,
+        handle: String,
+        sinceUnix: TimeInterval,
+        progressBelowZDate: Double? = nil,
+        progressBelowZPK: Int64? = nil,
+        limit: Int = 100
+    ) throws -> CallHistoryScanPage {
+        try queue.read { db in
+            try CallHistoryScanReader.scanPage(
+                db: db,
+                canonicalHandle: handle,
+                canonicalizer: canonicalize,
+                since: Date(timeIntervalSince1970: sinceUnix),
+                progressBelowZDate: progressBelowZDate,
+                progressBelowZPK: progressBelowZPK,
+                limit: limit)
+        }
+    }
+
+    // MARK: - address resolution (alternate spellings)
+
+    func testResolvesMultipleRawAddressesForOneCanonicalHandle() throws {
+        let queue = try InMemoryCallHistoryDB.makeQueue()
+        try queue.write { db in
+            // Two raw spellings of the SAME canonical number + an
+            // unrelated address.
+            try insertCall(db: db, zPK: 1, uniqueID: "u1", address: "+15550000001",
+                           unixDate: unixApr2026)
+            try insertCall(db: db, zPK: 2, uniqueID: "u2", address: "(555) 000-0001",
+                           unixDate: unixApr2026)
+            try insertCall(db: db, zPK: 3, uniqueID: "u3", address: "+15559999999",
+                           unixDate: unixApr2026)
+        }
+        let resolved = try queue.read { db in
+            try CallHistoryScanReader.resolveAddresses(
+                db: db, canonicalHandle: "+15550000001", canonicalizer: canonicalize)
+        }
+        XCTAssertEqual(Set(resolved), ["+15550000001", "(555) 000-0001"])
+    }
+
+    func testScanFindsRowsUnderAllSpellings() throws {
+        let queue = try InMemoryCallHistoryDB.makeQueue()
+        try queue.write { db in
+            try insertCall(db: db, zPK: 1, uniqueID: "u1", address: "+15550000001",
+                           unixDate: unixApr2026)
+            try insertCall(db: db, zPK: 2, uniqueID: "u2", address: "(555) 000-0001",
+                           unixDate: unixApr2026 + 10)
+        }
+        let page = try scan(queue, handle: "+15550000001", sinceUnix: unixFloor2026)
+        XCTAssertEqual(Set(page.rows.map(\.uniqueID)), ["u1", "u2"])
+        XCTAssertTrue(page.exhausted)
+    }
+
+    // MARK: - date window boundary
+
+    func testDateWindowBoundary() throws {
+        let queue = try InMemoryCallHistoryDB.makeQueue()
+        let sinceUnix = unixMay2026
+        try queue.write { db in
+            // Exactly at `since` → included.
+            try insertCall(db: db, zPK: 1, uniqueID: "at", address: "+15550000001",
+                           unixDate: sinceUnix)
+            // Just below `since` → excluded.
+            try insertCall(db: db, zPK: 2, uniqueID: "below", address: "+15550000001",
+                           unixDate: sinceUnix - 60)
+            // Well above `since` → included.
+            try insertCall(db: db, zPK: 3, uniqueID: "above", address: "+15550000001",
+                           unixDate: sinceUnix + 86_400)
+        }
+        let page = try scan(queue, handle: "+15550000001", sinceUnix: sinceUnix)
+        XCTAssertEqual(Set(page.rows.map(\.uniqueID)), ["at", "above"])
+    }
+
+    // MARK: - no match
+
+    func testNoMatchHandleReturnsEmptyExhausted() throws {
+        let queue = try InMemoryCallHistoryDB.makeQueue()
+        try queue.write { db in
+            try insertCall(db: db, zPK: 1, uniqueID: "u1", address: "+15550000001",
+                           unixDate: unixApr2026)
+        }
+        let page = try scan(queue, handle: "+15558888888", sinceUnix: unixFloor2026)
+        XCTAssertTrue(page.rows.isEmpty)
+        XCTAssertTrue(page.exhausted)
+        XCTAssertNil(page.lowestPoint)
+    }
+
+    // MARK: - email handle
+
+    func testEmailHandleScan() throws {
+        let queue = try InMemoryCallHistoryDB.makeQueue()
+        try queue.write { db in
+            // FaceTime call keyed on an email address (mixed case).
+            try insertCall(db: db, zPK: 1, uniqueID: "e1", address: "Test@Example.com",
+                           unixDate: unixApr2026,
+                           serviceProvider: "com.apple.FaceTime", callType: 8)
+        }
+        let page = try scan(queue, handle: "test@example.com", sinceUnix: unixFloor2026)
+        XCTAssertEqual(page.rows.map(\.uniqueID), ["e1"])
+    }
+
+    // MARK: - budget / resumability via (ZDATE, Z_PK)
+
+    func testBudgetLimitAndResumeBelowProgress() throws {
+        let queue = try InMemoryCallHistoryDB.makeQueue()
+        // Five calls at strictly increasing ZDATE so the (ZDATE, Z_PK)
+        // descending walk is deterministic.
+        try queue.write { db in
+            for i in 0..<5 {
+                try insertCall(db: db, zPK: Int64(200 + i), uniqueID: "u\(i)",
+                               address: "+15550000001",
+                               unixDate: unixApr2026 + TimeInterval(i * 10))
+            }
+        }
+        // First page: budget 2 → two highest (ZDATE, Z_PK), not
+        // exhausted.
+        let first = try scan(queue, handle: "+15550000001",
+                             sinceUnix: unixFloor2026, limit: 2)
+        XCTAssertEqual(first.rows.map(\.uniqueID), ["u4", "u3"])
+        XCTAssertFalse(first.exhausted)
+        XCTAssertEqual(first.lowestPoint?.zPK, 203)
+
+        // Resume strictly below the lowest of the first page.
+        let second = try scan(queue, handle: "+15550000001",
+                              sinceUnix: unixFloor2026,
+                              progressBelowZDate: first.lowestPoint?.zdate,
+                              progressBelowZPK: first.lowestPoint?.zPK,
+                              limit: 2)
+        XCTAssertEqual(second.rows.map(\.uniqueID), ["u2", "u1"])
+        XCTAssertFalse(second.exhausted)
+
+        // Final page returns the last row and reports exhausted.
+        let third = try scan(queue, handle: "+15550000001",
+                             sinceUnix: unixFloor2026,
+                             progressBelowZDate: second.lowestPoint?.zdate,
+                             progressBelowZPK: second.lowestPoint?.zPK,
+                             limit: 2)
+        XCTAssertEqual(third.rows.map(\.uniqueID), ["u0"])
+        XCTAssertTrue(third.exhausted)
+    }
+
+    // MARK: - (ZDATE, Z_PK) tie-break within the same second
+
+    func testProgressTieBreaksOnZPKWithinSameZDate() throws {
+        let queue = try InMemoryCallHistoryDB.makeQueue()
+        // Three calls sharing one ZDATE; the Z_PK tie-break must page
+        // through them without skipping or repeating.
+        try queue.write { db in
+            try insertCall(db: db, zPK: 10, uniqueID: "a", address: "+15550000001",
+                           unixDate: unixApr2026)
+            try insertCall(db: db, zPK: 11, uniqueID: "b", address: "+15550000001",
+                           unixDate: unixApr2026)
+            try insertCall(db: db, zPK: 12, uniqueID: "c", address: "+15550000001",
+                           unixDate: unixApr2026)
+        }
+        let first = try scan(queue, handle: "+15550000001",
+                             sinceUnix: unixFloor2026, limit: 2)
+        XCTAssertEqual(first.rows.map(\.uniqueID), ["c", "b"])
+        XCTAssertFalse(first.exhausted)
+        XCTAssertEqual(first.lowestPoint?.zPK, 11)
+
+        let second = try scan(queue, handle: "+15550000001",
+                              sinceUnix: unixFloor2026,
+                              progressBelowZDate: first.lowestPoint?.zdate,
+                              progressBelowZPK: first.lowestPoint?.zPK,
+                              limit: 2)
+        XCTAssertEqual(second.rows.map(\.uniqueID), ["a"])
+        XCTAssertTrue(second.exhausted)
+    }
+
+    // MARK: - skipped rows still advance lowestPoint
+
+    func testServiceUnknownRowAdvancesLowestPointButIsNotReturned() throws {
+        let queue = try InMemoryCallHistoryDB.makeQueue()
+        try queue.write { db in
+            // Higher ZDATE: unmappable service → skipped, but its point
+            // must advance the resume coordinate so the page doesn't
+            // stall on it.
+            try insertCall(db: db, zPK: 30, uniqueID: "unknown", address: "+15550000001",
+                           unixDate: unixApr2026 + 100,
+                           serviceProvider: "com.unknown.thing", callType: 999)
+            try insertCall(db: db, zPK: 31, uniqueID: "good", address: "+15550000001",
+                           unixDate: unixApr2026)
+        }
+        let first = try scan(queue, handle: "+15550000001",
+                             sinceUnix: unixFloor2026, limit: 1)
+        // The first (highest) row is the unknown-service one: skipped,
+        // not returned, but inspected — so lowestPoint advances to it.
+        XCTAssertTrue(first.rows.isEmpty)
+        XCTAssertFalse(first.exhausted)
+        XCTAssertEqual(first.lowestPoint?.zPK, 30)
+
+        let second = try scan(queue, handle: "+15550000001",
+                              sinceUnix: unixFloor2026,
+                              progressBelowZDate: first.lowestPoint?.zdate,
+                              progressBelowZPK: first.lowestPoint?.zPK,
+                              limit: 1)
+        XCTAssertEqual(second.rows.map(\.uniqueID), ["good"])
+        XCTAssertTrue(second.exhausted)
+    }
+}

--- a/mac-daemon/Tests/CRMMacPhoneCallsSourceTests/PhoneCallsCursorWirePendingScansTests.swift
+++ b/mac-daemon/Tests/CRMMacPhoneCallsSourceTests/PhoneCallsCursorWirePendingScansTests.swift
@@ -1,0 +1,91 @@
+// PhoneCallsCursorWirePendingScansTests — backward-compatible decode of
+// the additive pendingScans queue + per-entry progress fields.
+//
+// Synthetic handles only (+15550000001 etc.); no real PII.
+import XCTest
+import CRMMacCore
+@testable import CRMMacPhoneCallsSource
+
+final class PhoneCallsCursorWirePendingScansTests: XCTestCase {
+    func testOldJSONWithoutPendingScansDecodesEmpty() throws {
+        // A cursor JSON written before pending_scans existed must decode
+        // with an empty queue, not throw.
+        let json = """
+            {
+                "backfill_floor_sent_at": "2026-01-01T00:00:00Z",
+                "backfill_complete": false
+            }
+            """
+        let decoded = try PhoneCallsCursorCodec.decode(json)
+        XCTAssertNotNil(decoded)
+        XCTAssertEqual(decoded?.pendingScans, [])
+    }
+
+    func testOldEntryWithoutProgressDecodesNilProgress() throws {
+        // An operator-CLI-queued entry omits the progress fields → nil.
+        let json = """
+            {
+                "backfill_floor_sent_at": "2026-01-01T00:00:00Z",
+                "backfill_complete": false,
+                "pending_scans": [
+                    {
+                        "normalized_handle": "+15550000001",
+                        "since": "2026-04-01T00:00:00Z"
+                    }
+                ]
+            }
+            """
+        let decoded = try PhoneCallsCursorCodec.decode(json)
+        let scan = try XCTUnwrap(decoded?.pendingScans.first)
+        XCTAssertEqual(scan.normalizedHandle, "+15550000001")
+        XCTAssertNil(scan.progressBelowZDate)
+        XCTAssertNil(scan.progressBelowZPK)
+    }
+
+    func testRoundTripWithProgress() throws {
+        let original = PhoneCallsCursor(
+            backfillFloorSentAt: PhoneCallsCursor.defaultBackfillFloor,
+            pendingScans: [
+                PhoneCallsCursorPendingScan(
+                    normalizedHandle: "+15550000001",
+                    since: Date(timeIntervalSince1970: 1_775_000_000),
+                    progressBelowZDate: 771_692_400.654321,
+                    progressBelowZPK: 100),
+                PhoneCallsCursorPendingScan(
+                    normalizedHandle: "test@example.com",
+                    since: Date(timeIntervalSince1970: 1_775_000_000)),
+            ])
+        let json = try PhoneCallsCursorCodec.encode(original)
+        let decoded = try PhoneCallsCursorCodec.decode(json)
+        XCTAssertEqual(decoded, original)
+        // Sub-second ZDATE progress survives the Double round-trip.
+        XCTAssertEqual(decoded?.pendingScans.first?.progressBelowZDate, 771_692_400.654321)
+        // Second entry's progress stays nil.
+        XCTAssertNil(decoded?.pendingScans.last?.progressBelowZPK)
+    }
+
+    func testPendingScansUsesSnakeCaseKeys() throws {
+        let cursor = PhoneCallsCursor(
+            backfillFloorSentAt: PhoneCallsCursor.defaultBackfillFloor,
+            pendingScans: [
+                PhoneCallsCursorPendingScan(
+                    normalizedHandle: "+15550000001",
+                    since: Date(timeIntervalSince1970: 1_775_000_000),
+                    progressBelowZDate: 1.0,
+                    progressBelowZPK: 2),
+            ])
+        let json = try PhoneCallsCursorCodec.encode(cursor)
+        XCTAssertTrue(json.contains("\"pending_scans\""))
+        XCTAssertTrue(json.contains("\"normalized_handle\""))
+        XCTAssertTrue(json.contains("\"progress_below_zdate\""))
+        XCTAssertTrue(json.contains("\"progress_below_z_pk\""))
+    }
+
+    func testCapEnforcedOnEncode() throws {
+        // The cap is enforced by the queue wrapper / ops paths, not the
+        // wire struct itself; this test documents the constant matches
+        // the messages cap so both sources behave identically.
+        XCTAssertEqual(PhoneCallsCursor.pendingScansCap, 256)
+        XCTAssertEqual(MessagesCursorWire.pendingScansCap, PhoneCallsCursor.pendingScansCap)
+    }
+}


### PR DESCRIPTION
Closes #328.

Replaces the V1 "log-but-never-execute" newly-known-identifier handling in both daemon sources with a real 30-day identifier-scoped backwards scan, plus the restart-persistence infra to auto-scan offline-added contacts precisely.

## What ships

- **Messages auto-scan execution.** Drain the known-identifiers cache's newly-added bucket, enqueue a 30-day `pendingScans` entry per identifier, and execute an identifier+date-scoped query against chat.db (which has no per-handle index, so the reader resolves `handle.ROWID`s first, then scans `message.handle_id IN (...) AND date >= since`). Resumable across ticks via a `progressBelowRowID` cursor.
- **phone_calls auto-scan execution.** Symmetric flow with a new index-assisted `CallHistoryScanReader` (`SELECT DISTINCT ZADDRESS` canonicalization pre-pass, then `ZADDRESS IN (...) AND ZDATE >= since` paged descending by `(ZDATE, Z_PK)`, resumable). The `PhoneCallsCursorWire` gains `pendingScans` with backward-compatible decode (older cursor JSON lacking the field decodes as empty).
- **Two-phase durability (both sources).** Phase A durably commits the enlarged `pendingScans` to the Pi cursor BEFORE executing any scan (non-destructive cache drain + confirm/return on commit success/failure). Phase B executes resumable, budget-bound pages, advancing progress or dequeuing only on confirmed-published exhaustion. A scan-commit conflict aborts the rest of the tick so a stale cursor is never re-committed. Scans are membership-gated on `cache.hasFetched` (not `isPopulated`) and clamped to the 2026-01-01 backfill floor at execution time.
- **phone_calls operator CLI parity.** `crm-mac call-history scan --identifier <h> [--since 30d]` mirroring `crm-mac messages scan`, with coverage-dedup + floor clamp on the queued entry. `crm-mac status` now shows phone_calls `pending_scans`.
- **Targeted offline-restart auto-scan (Option B, single-writer).** The composition root seeds each source's diff baseline from a persisted per-source known-identifiers set, so on restart the daemon enqueues 30-day scans ONLY for the precise `current − persisted` delta — never the naive replay-everything storm. The persisted baseline has exactly one writer (the heartbeat refresher), which persists `observed − owed-scans` so a crash before a scan is durable never loses it. The first post-upgrade restart seeds the baseline and enqueues zero scans.

## Test plan

- New Swift tests cover: the resumable readers (alternate-spelling resolution, date-window boundary, `(ZDATE,Z_PK)` tie-break, exhaustion, skipped-row advance); plugin execution (Phase-A durability, Phase-A rollback, resumable multi-tick walk dropping no rows, membership gate on `hasFetched` vs `isPopulated`, coverage-dedup window widening, Phase-B-conflict-aborts-tick); the single-writer baseline persistence (first-upgrade seed, idempotent no-op preserving `establishedAt`, owed-scan exclusion until durable, removal shrink); CLI scan ops (canonicalization, cap drop-oldest, daemon-running guard, CAS conflict, Pi-unreachable, floor clamp, coverage-dedup); and backward-compatible cursor decode.
- `swift build -c release -Xswiftc -warnings-as-errors` is clean locally. The full `swift test` suite runs on CI's `mac-daemon-tests` job (macos-15) — the local environment has CommandLineTools only (no XCTest), so CI is the binding Swift test gate.

## Notes

- No Pi backend (Go) changes — the scan reuses the existing `/api/v1/ingest/events` path and `(source, source_id)` event-log dedup absorbs any overlap with natural backfill.
- README updated: documents the new `call-history scan` command and rewrites the prior "offline-added contact → no auto-scan" limitation as resolved, including the persisted-baseline at-rest footprint and the accepted single-writer redundant-re-enqueue trade.