### PR TITLE
feat(gmail): add inert GmailSyncProvider + email event kinds (phase 2)

### DIFF
--- a/backend/internal/events/bus_test.go
+++ b/backend/internal/events/bus_test.go
@@ -88,6 +88,10 @@ func TestConsumerJobsForKind_InteractionRecordedEnqueuesCadenceAndFollowUp(t *te
 //   - interaction.manual: inline-invoked by the manual UI handler
 //     (spec §3.4 "other consumers only").
 //   - task.skipped: consumer for that kind is not yet wired.
+//   - email.received / email.sent: published by GmailSyncProvider, but the
+//     email-interaction consumer + routing land in a later phase. Until then
+//     publishing is durable-but-unconsumed — the event-log row is inserted
+//     and zero consumer jobs are enqueued.
 //
 // (contact_methods.added HAS a consumer now — see the dedicated
 // TestConsumerJobsForKind_ContactMethodsAdded tests below.
@@ -97,6 +101,8 @@ func TestConsumerJobsForKind_EmptyForDeferredKinds(t *testing.T) {
 	deferred := []Kind{
 		KindInteractionManual,
 		KindTaskSkipped,
+		KindEmailReceived,
+		KindEmailSent,
 	}
 	for _, k := range deferred {
 		t.Run(string(k), func(t *testing.T) {

--- a/backend/internal/events/kinds.go
+++ b/backend/internal/events/kinds.go
@@ -26,6 +26,16 @@ const (
 	KindInteractionManual    Kind = "interaction.manual"
 	KindContactMethodsAdded  Kind = "contact_methods.added"
 
+	// Email raw-signal events — published by the Gmail sync provider
+	// (backend/internal/google/gmail.go) per qualifying (message, contact,
+	// direction). Lightweight payload (EmailEventPayload); the full body /
+	// subject / html live in comms_message. These kinds have NO registered
+	// consumer in consumerJobsForKind yet, so publishing them is durable but
+	// unconsumed (the event-log row lands, no job is enqueued) until the
+	// phase-3 email-interaction consumer is wired.
+	KindEmailReceived Kind = "email.received"
+	KindEmailSent     Kind = "email.sent"
+
 	// Derived event — emitted by the InteractionRecorder consumer (spec
 	// §3.4.1) atomically with an interaction row insert. PR 2 declares
 	// the constant; PR 5 introduces the consumer that emits it.
@@ -85,6 +95,8 @@ var AllKinds = []Kind{
 	KindTaskOutreachDetected,
 	KindInteractionManual,
 	KindContactMethodsAdded,
+	KindEmailReceived,
+	KindEmailSent,
 	KindInteractionRecorded,
 	KindRawMessageReceived,
 	KindRawMessageSent,
@@ -238,6 +250,29 @@ type ContactMethodsAddedPayload struct {
 	ContactID    uuid.UUID          `json:"contact_id"`
 	Methods      []ContactMethodRef `json:"methods"`
 	RematchJobID uuid.UUID          `json:"rematch_job_id"`
+}
+
+// EmailEventPayload is the payload for KindEmailReceived and KindEmailSent,
+// published by the Gmail sync provider. Lightweight — ids + metadata only;
+// the full body / subject / html live in comms_message (located by a later
+// consumer via the natural key external_id + matched_contact_id). One struct
+// serves both kinds; the discriminator is the kind, mirroring CallPayload.
+//
+// LocalDay is the calendar day of SentAt in the server's time.Local (the
+// timezone backend/internal/cadence/date.go uses for date-only cadence math).
+// It is carried so a later thread-day aggregation consumer can build the
+// "<contact>:<thread>:<day>" source_ref without re-deriving the timezone.
+// ThreadID and Subject are likewise derived once at publish time from data the
+// provider already has, keeping the durable event row a complete hand-off.
+type EmailEventPayload struct {
+	Version    int       `json:"version"` // start at 1
+	ContactID  uuid.UUID `json:"contact_id"`
+	ExternalID string    `json:"external_id"` // RFC822 Message-ID or nomsgid fallback
+	ThreadID   string    `json:"thread_id"`   // Gmail threadId
+	LocalDay   string    `json:"local_day"`   // YYYY-MM-DD in time.Local
+	SentAt     time.Time `json:"sent_at"`
+	Direction  string    `json:"direction"` // "inbound" | "outbound" (mirrors kind)
+	Subject    *string   `json:"subject,omitempty"`
 }
 
 // InteractionRecordedPayload is the payload for KindInteractionRecorded,
@@ -510,6 +545,8 @@ var kindPayloadTypes = map[Kind]reflect.Type{
 	KindTaskOutreachDetected:    reflect.TypeOf(TaskOutreachDetectedPayload{}),
 	KindInteractionManual:       reflect.TypeOf(InteractionManualPayload{}),
 	KindContactMethodsAdded:     reflect.TypeOf(ContactMethodsAddedPayload{}),
+	KindEmailReceived:           reflect.TypeOf(EmailEventPayload{}),
+	KindEmailSent:               reflect.TypeOf(EmailEventPayload{}),
 	KindInteractionRecorded:     reflect.TypeOf(InteractionRecordedPayload{}),
 	KindRawMessageReceived:      reflect.TypeOf(RawMessageReceivedPayload{}),
 	KindRawMessageSent:          reflect.TypeOf(RawMessageSentPayload{}),

--- a/backend/internal/events/kinds.go
+++ b/backend/internal/events/kinds.go
@@ -32,7 +32,7 @@ const (
 	// subject / html live in comms_message. These kinds have NO registered
 	// consumer in consumerJobsForKind yet, so publishing them is durable but
 	// unconsumed (the event-log row lands, no job is enqueued) until the
-	// phase-3 email-interaction consumer is wired.
+	// email-interaction consumer is wired.
 	KindEmailReceived Kind = "email.received"
 	KindEmailSent     Kind = "email.sent"
 

--- a/backend/internal/events/kinds_test.go
+++ b/backend/internal/events/kinds_test.go
@@ -301,6 +301,67 @@ func TestMarshalUnmarshal_ContactMethodsAdded(t *testing.T) {
 	require.Equal(t, original, decoded)
 }
 
+// TestMarshalUnmarshal_EmailEventPayload round-trips an EmailEventPayload
+// under both email kinds, asserting every field survives including the
+// optional Subject pointer. One struct serves both kinds; the kind is the
+// only discriminator.
+func TestMarshalUnmarshal_EmailEventPayload(t *testing.T) {
+	subject := "Lunch next week?"
+	cid := uuid.New()
+
+	t.Run("received", func(t *testing.T) {
+		original := EmailEventPayload{
+			Version:    1,
+			ContactID:  cid,
+			ExternalID: "<msg-abc@example.com>",
+			ThreadID:   "thread-xyz",
+			LocalDay:   "2026-04-10",
+			SentAt:     time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC),
+			Direction:  "inbound",
+			Subject:    &subject,
+		}
+		raw, err := Marshal(KindEmailReceived, original)
+		require.NoError(t, err)
+		env := &Envelope{Kind: KindEmailReceived, Payload: raw}
+		var decoded EmailEventPayload
+		require.NoError(t, Unmarshal(env, &decoded))
+		require.Equal(t, original, decoded)
+	})
+
+	t.Run("sent_nil_subject", func(t *testing.T) {
+		original := EmailEventPayload{
+			Version:    1,
+			ContactID:  cid,
+			ExternalID: "nomsgid:user@example.com:gmail-1",
+			ThreadID:   "thread-2",
+			LocalDay:   "2026-04-11",
+			SentAt:     time.Date(2026, 4, 11, 9, 30, 0, 0, time.UTC),
+			Direction:  "outbound",
+		}
+		raw, err := Marshal(KindEmailSent, original)
+		require.NoError(t, err)
+		require.NotContains(t, string(raw), "subject",
+			"omitempty should elide a nil Subject from JSON")
+		env := &Envelope{Kind: KindEmailSent, Payload: raw}
+		var decoded EmailEventPayload
+		require.NoError(t, Unmarshal(env, &decoded))
+		require.Equal(t, original, decoded)
+		require.Nil(t, decoded.Subject)
+	})
+
+	t.Run("kind_mismatch_on_unmarshal", func(t *testing.T) {
+		raw, err := Marshal(KindEmailReceived, EmailEventPayload{Version: 1, ContactID: cid})
+		require.NoError(t, err)
+		// Decoding an email.received envelope into the calendar payload type
+		// must be rejected by the registry's kind-vs-type guard.
+		env := &Envelope{Kind: KindEmailReceived, Payload: raw}
+		var wrong CalendarAttendedPayload
+		err = Unmarshal(env, &wrong)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "decodes to")
+	})
+}
+
 func TestMarshalUnmarshal_InteractionRecorded(t *testing.T) {
 	ref := "tg:123:456"
 	original := InteractionRecordedPayload{
@@ -535,9 +596,10 @@ func TestKindPayloadTypes_CoversAllKinds(t *testing.T) {
 // daemon-emitted raw_message.* kinds (messages source), plus the two
 // external_contact.* kinds (iCloud Contacts source), plus the two
 // meeting_note.* kinds (anarlog_sessions source), plus the two call.*
-// kinds (phone_calls source, v1.5).
+// kinds (phone_calls source, v1.5), plus the two email.* kinds (Gmail
+// source, published by GmailSyncProvider).
 func TestAllKinds_ExpectedCount(t *testing.T) {
-	require.Len(t, AllKinds, 18)
+	require.Len(t, AllKinds, 20)
 }
 
 // TestIsKnownKind_CoversAllKinds is the positive side: every Kind declared
@@ -595,6 +657,14 @@ func buildCanonicalPayload(t *testing.T, kind Kind) json.RawMessage {
 		return raw
 	case KindContactMethodsAdded:
 		raw, err := Marshal(kind, ContactMethodsAddedPayload{Version: 1, ContactID: cid, Methods: []ContactMethodRef{{Type: "email", Value: "a@b.com"}}, RematchJobID: uuid.New()})
+		require.NoError(t, err)
+		return raw
+	case KindEmailReceived, KindEmailSent:
+		direction := "inbound"
+		if kind == KindEmailSent {
+			direction = "outbound"
+		}
+		raw, err := Marshal(kind, EmailEventPayload{Version: 1, ContactID: cid, ExternalID: "<msg-1@example.com>", ThreadID: "thread-1", LocalDay: "2026-04-10", SentAt: at, Direction: direction})
 		require.NoError(t, err)
 		return raw
 	case KindInteractionRecorded:

--- a/backend/internal/google/gmail.go
+++ b/backend/internal/google/gmail.go
@@ -54,7 +54,7 @@ const (
 // the handler-level email validator, but the external-enrichment path
 // (BuildMethodsFromExternal) does not validate, so a stray space, quote, or
 // paren could corrupt the OR-group. We restrict to a conservative email-safe
-// set and skip anything else (D5 query-term sanitization).
+// set and skip anything else.
 var emailSafeTermRegex = regexp.MustCompile(`^[a-z0-9@._+%-]+$`)
 
 // htmlTagRegex strips HTML tags during the text/html → plaintext fallback.
@@ -118,7 +118,7 @@ type attachmentMeta struct {
 
 // emailMetadata is the non-provenance JSON the provider assembles into
 // comms_message.source_metadata. The provenance keys (observed_accounts,
-// account_gmail_ids) are added by the phase-1 upsert query, NOT here.
+// account_gmail_ids) are added by the UpsertCommsMessage query, NOT here.
 type emailMetadata struct {
 	HTML        string           `json:"html,omitempty"`
 	Attachments []attachmentMeta `json:"attachments,omitempty"`
@@ -149,8 +149,8 @@ type qualifiedRow struct {
 	Metadata       []byte
 }
 
-// GmailSyncProvider implements sync.SyncProvider for Gmail. It is fully inert
-// in phase 2: it is NOT registered in main.go, and although it publishes
+// GmailSyncProvider implements sync.SyncProvider for Gmail. It is currently
+// inert: it is NOT registered in main.go, and although it publishes
 // email.received/email.sent, those kinds have no registered consumer yet, so
 // publishing only writes the durable event-log row.
 type GmailSyncProvider struct {
@@ -170,7 +170,7 @@ type GmailSyncProvider struct {
 	// newMeSet builds the "me" set (the normalized address of every connected
 	// account). Defaulted to an impl that calls oauthService.ListAccounts;
 	// tests override via SetMeSetForTest so the M-set is injected with no OAuth
-	// state — symmetric with newFetcher (D4).
+	// state — symmetric with newFetcher.
 	newMeSet func(ctx context.Context) (map[string]struct{}, error)
 }
 
@@ -322,12 +322,12 @@ func (p *GmailSyncProvider) Sync(
 			refs, next, err := fetcher.ListMessageIDs(ctx, query, pageToken)
 			if err != nil {
 				// Hard failure: abort the sweep, return the prior cursor
-				// unchanged so the whole after:<prior> window re-runs (D10).
+				// unchanged so the whole after:<prior> window re-runs.
 				return p.failResult(priorCursor), fmt.Errorf("list message ids: %w", err)
 			}
 			for _, ref := range refs {
 				if _, dup := seen[ref.ID]; dup {
-					continue // cross-chunk dedup: body already fetched (D6)
+					continue // cross-chunk dedup: body already fetched this sweep
 				}
 				seen[ref.ID] = struct{}{}
 				fetchedAny = true
@@ -343,7 +343,7 @@ func (p *GmailSyncProvider) Sync(
 				result.ItemsProcessed++
 
 				// Processed (even if zero qualifying rows) contributes its
-				// internalDate to the cursor advance (D11).
+				// internalDate to the cursor advance.
 				if secs := msg.InternalDate / 1000; secs > maxInternalDateSecs {
 					maxInternalDateSecs = secs
 				}
@@ -376,9 +376,9 @@ func (p *GmailSyncProvider) Sync(
 }
 
 // failResult returns a SyncResult that does NOT advance the cursor: NewCursor
-// is the prior cursor verbatim so the after:<prior> window re-runs next tick
-// (D10). A blank prior cursor stays blank — there is nothing to advance past on
-// a first-sweep failure, and the next tick re-derives the onboarding floor.
+// is the prior cursor verbatim so the after:<prior> window re-runs next tick.
+// A blank prior cursor stays blank — there is nothing to advance past on a
+// first-sweep failure, and the next tick re-derives the onboarding floor.
 func (p *GmailSyncProvider) failResult(priorCursor string) *sync.SyncResult {
 	return &sync.SyncResult{NewCursor: priorCursor}
 }
@@ -388,7 +388,7 @@ func (p *GmailSyncProvider) failResult(priorCursor string) *sync.SyncResult {
 // Each row is its own tx so a single bad message can't strand a whole sweep and
 // no tx spans network I/O (content is already in memory). SourceID is
 // per-(message, contact) so a message qualifying N contacts produces N distinct
-// event rows (D10).
+// event rows (avoids the multi-entity (source, source_id) collapse).
 func (p *GmailSyncProvider) persistRow(ctx context.Context, row qualifiedRow) (err error) {
 	kind := events.KindEmailReceived
 	if row.Direction == "outbound" {
@@ -484,7 +484,7 @@ func backfillSinceEpoch(metadata map[string]any) int64 {
 	return t.Unix()
 }
 
-// computeNewCursor implements the cursor-write contract (D11). It NEVER returns
+// computeNewCursor implements the cursor-write contract. It NEVER returns
 // an empty string (an empty NewCursor would NULL-clear the stored cursor and
 // trigger a full re-backfill):
 //   - ≥1 message fetched: advance to max(maxInternalDateSecs, priorCursorSecs),
@@ -509,7 +509,7 @@ func computeNewCursor(fetchedAny bool, maxInternalDateSecs, priorCursorSecs int6
 // sanitizeAddresses filters the address list to terms safe to embed in a Gmail
 // `q` operator. Addresses that are empty, contain whitespace, or contain a
 // character outside the conservative email-safe set are dropped (and logged) so
-// a single malformed contact_method can't corrupt a chunk query (D5).
+// a single malformed contact_method can't corrupt a chunk query.
 func sanitizeAddresses(addresses []string) []string {
 	out := make([]string, 0, len(addresses))
 	for _, a := range addresses {
@@ -622,7 +622,7 @@ func (p *GmailSyncProvider) processMessage(
 
 	// Ordered, deduped recipient buckets (raw+normalized aligned) for the
 	// deterministic outbound peer-handle precedence (To, then Cc, then Bcc;
-	// header order within a bucket) (D8).
+	// header order within a bucket).
 	orderedRecipients := buildOrderedRecipients(toRaw, toNorm, ccRaw, ccNorm, bccRaw, bccNorm)
 
 	contentSubject := strPtrIfNotEmpty(subject)
@@ -713,7 +713,7 @@ type orderedRecipient struct {
 
 // buildOrderedRecipients concatenates the recipient buckets in fixed order (To,
 // Cc, Bcc), each in header-listed order, deduping by normalized address so a
-// repeated address keeps its first (highest-precedence) position (D8).
+// repeated address keeps its first (highest-precedence) position.
 func buildOrderedRecipients(toRaw, toNorm, ccRaw, ccNorm, bccRaw, bccNorm []string) []orderedRecipient {
 	var out []orderedRecipient
 	seen := make(map[string]struct{})
@@ -739,7 +739,7 @@ func buildOrderedRecipients(toRaw, toNorm, ccRaw, ccNorm, bccRaw, bccNorm []stri
 // firstContactRecipient returns the first ordered recipient whose normalized
 // address is in the contact's address set, giving the deterministic outbound
 // peer-handle (To wins over Cc wins over Bcc; first-listed wins within a
-// bucket) (D8).
+// bucket).
 func firstContactRecipient(recipients []orderedRecipient, addrSet map[string]struct{}) (raw, normalized string, ok bool) {
 	for _, r := range recipients {
 		if _, in := addrSet[r.normalized]; in {
@@ -856,13 +856,26 @@ func epochMillisToTime(millis int64) time.Time {
 	return time.UnixMilli(millis).UTC()
 }
 
+// isAttachmentPart reports whether a MIME part is an attachment: it has a
+// filename, or its body is an external attachment referenced by AttachmentId
+// (inline images and some forwarded parts carry an attachment id without a
+// filename). Either signal means the part's bytes live out-of-band, so we
+// record metadata only and never treat it as the message body.
+func isAttachmentPart(part *gmail.MessagePart) bool {
+	if part.Filename != "" {
+		return true
+	}
+	return part.Body != nil && part.Body.AttachmentId != ""
+}
+
 // extractContent MIME-walks payload, returning the canonical plaintext body,
 // the raw HTML body (when present), and attachment metadata. It prefers the
 // first text/plain part; if none exists anywhere, it strips the first text/html
 // part to plaintext for the body and retains the raw HTML. A part is an
-// attachment when it has a non-empty filename; only metadata is collected (no
-// content is fetched). Returns an error only on a base64 decode failure of a
-// chosen body part.
+// attachment when it has a non-empty filename and/or a Body.AttachmentId
+// (inline attachments often carry an attachment id without a filename); only
+// metadata is collected (no content is fetched). Returns an error only on a
+// base64 decode failure of a chosen body part.
 func extractContent(payload *gmail.MessagePart) (body, htmlBody string, attachments []attachmentMeta, err error) {
 	if payload == nil {
 		return "", "", nil, nil
@@ -874,7 +887,7 @@ func extractContent(payload *gmail.MessagePart) (body, htmlBody string, attachme
 			return
 		}
 		mimeType := strings.ToLower(part.MimeType)
-		if part.Filename != "" {
+		if isAttachmentPart(part) {
 			size := int64(0)
 			if part.Body != nil {
 				size = part.Body.Size
@@ -944,8 +957,8 @@ func stripHTML(s string) string {
 
 // buildMetadataJSON assembles the non-provenance source_metadata JSON the
 // provider owns (html, attachments, labels, from/to/cc/bcc). The provenance
-// keys (observed_accounts, account_gmail_ids) are added by the phase-1 upsert
-// query, not here.
+// keys (observed_accounts, account_gmail_ids) are added by the
+// UpsertCommsMessage query, not here.
 func buildMetadataJSON(htmlBody string, attachments []attachmentMeta, labels []string, fromRaw string, toRaw, ccRaw, bccRaw []string) []byte {
 	meta := emailMetadata{
 		HTML:        htmlBody,
@@ -993,7 +1006,7 @@ func (p *GmailSyncProvider) SetFetcherFactoryForTest(factory func(ctx context.Co
 }
 
 // SetMeSetForTest overrides the me-set factory so tests inject the connected-
-// account address set with no OAuth state (D4).
+// account address set with no OAuth state.
 func (p *GmailSyncProvider) SetMeSetForTest(meSet map[string]struct{}) {
 	p.newMeSet = func(context.Context) (map[string]struct{}, error) {
 		return meSet, nil

--- a/backend/internal/google/gmail.go
+++ b/backend/internal/google/gmail.go
@@ -1000,7 +1000,7 @@ func (p *GmailSyncProvider) RunProcessMessageForTest(
 }
 
 // SetFetcherFactoryForTest overrides the per-account fetcher factory so tests
-// inject a fake gmailFetcher with no OAuth/token state (the OAuth seam, D1).
+// inject a fake gmailFetcher with no OAuth/token state (the OAuth seam).
 func (p *GmailSyncProvider) SetFetcherFactoryForTest(factory func(ctx context.Context, accountID string) (gmailFetcher, error)) {
 	p.newFetcher = factory
 }

--- a/backend/internal/google/gmail.go
+++ b/backend/internal/google/gmail.go
@@ -1,0 +1,1058 @@
+package google
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"html"
+	"net/mail"
+	"net/url"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/logger"
+	"personal-crm/backend/internal/matching"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/sync"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"google.golang.org/api/gmail/v1"
+	"google.golang.org/api/option"
+)
+
+const (
+	// GmailSourceName is the source identifier for Gmail. It matches the
+	// external_sync_state.source, comms_message.source, and interaction.source
+	// value 'email' (spec §6.2/§6.3).
+	GmailSourceName = "email"
+	// GmailDefaultInterval is the default sync interval for Gmail (every 15
+	// minutes), matching the calendar provider's tick.
+	GmailDefaultInterval = 15 * time.Minute
+	// gmailCategoryFilter restricts the search to the Primary category, the
+	// only category that carries 1:1 correspondence (spec §2.2).
+	gmailCategoryFilter = "category:primary"
+	// gmailChunkByteCap caps the URL-encoded length of a single chunk query at
+	// ~6 KB, well under the practical ~8 KB GET-URL limit (spec §3.1/§7).
+	gmailChunkByteCap = 6000
+	// gmailDefaultBackfillSince is the onboarding floor used when an account
+	// has no cursor and no metadata override (spec §3.2/§7).
+	gmailDefaultBackfillSince = "2026-01-01"
+	// gmailUserID is Gmail's special-value alias for the authenticated account.
+	gmailUserID = "me"
+)
+
+// emailSafeTermRegex matches an address that is safe to embed verbatim in a
+// Gmail `q` operator term. Stored value_normalized values usually come through
+// the handler-level email validator, but the external-enrichment path
+// (BuildMethodsFromExternal) does not validate, so a stray space, quote, or
+// paren could corrupt the OR-group. We restrict to a conservative email-safe
+// set and skip anything else (D5 query-term sanitization).
+var emailSafeTermRegex = regexp.MustCompile(`^[a-z0-9@._+%-]+$`)
+
+// htmlTagRegex strips HTML tags during the text/html → plaintext fallback.
+var htmlTagRegex = regexp.MustCompile(`(?s)<[^>]*>`)
+
+// gmailMessageRef is a (id, threadId) stub returned by users.messages.list.
+type gmailMessageRef struct {
+	ID       string
+	ThreadID string
+}
+
+// gmailFetcher is the narrow Gmail read surface the provider needs. The real
+// implementation (gmailServiceFetcher) wraps *gmail.Service; tests inject a
+// fake returning canned list pages and messages, so unit/integration tests
+// never touch HTTP or OAuth. The *gmail.Message type stays in the signature so
+// tests exercise the real MIME-walk / header-extraction code against real
+// library structs.
+type gmailFetcher interface {
+	// ListMessageIDs returns one page of (id, threadId) stubs for the query.
+	ListMessageIDs(ctx context.Context, query, pageToken string) (ids []gmailMessageRef, nextPageToken string, err error)
+	// GetMessage fetches one message with format=full.
+	GetMessage(ctx context.Context, id string) (*gmail.Message, error)
+}
+
+// gmailServiceFetcher is the production gmailFetcher backed by *gmail.Service.
+type gmailServiceFetcher struct {
+	svc *gmail.Service
+}
+
+func (f *gmailServiceFetcher) ListMessageIDs(ctx context.Context, query, pageToken string) ([]gmailMessageRef, string, error) {
+	call := f.svc.Users.Messages.List(gmailUserID).Q(query)
+	if pageToken != "" {
+		call = call.PageToken(pageToken)
+	}
+	resp, err := call.Context(ctx).Do()
+	if err != nil {
+		return nil, "", fmt.Errorf("list messages: %w", err)
+	}
+	refs := make([]gmailMessageRef, 0, len(resp.Messages))
+	for _, m := range resp.Messages {
+		refs = append(refs, gmailMessageRef{ID: m.Id, ThreadID: m.ThreadId})
+	}
+	return refs, resp.NextPageToken, nil
+}
+
+func (f *gmailServiceFetcher) GetMessage(ctx context.Context, id string) (*gmail.Message, error) {
+	msg, err := f.svc.Users.Messages.Get(gmailUserID, id).Format("full").Context(ctx).Do()
+	if err != nil {
+		return nil, fmt.Errorf("get message %s: %w", id, err)
+	}
+	return msg, nil
+}
+
+// attachmentMeta is the metadata-only descriptor for one message attachment.
+// No content is ever fetched (spec §2.2).
+type attachmentMeta struct {
+	Filename string `json:"filename"`
+	MimeType string `json:"mime_type"`
+	Size     int64  `json:"size"`
+}
+
+// emailMetadata is the non-provenance JSON the provider assembles into
+// comms_message.source_metadata. The provenance keys (observed_accounts,
+// account_gmail_ids) are added by the phase-1 upsert query, NOT here.
+type emailMetadata struct {
+	HTML        string           `json:"html,omitempty"`
+	Attachments []attachmentMeta `json:"attachments,omitempty"`
+	Labels      []string         `json:"labels,omitempty"`
+	From        string           `json:"from,omitempty"`
+	To          []string         `json:"to,omitempty"`
+	Cc          []string         `json:"cc,omitempty"`
+	Bcc         []string         `json:"bcc,omitempty"`
+}
+
+// qualifiedRow is the provider's internal per-(message, contact, direction)
+// result. Returning it from RunProcessMessageForTest lets unit tests assert
+// resolution + content extraction without a DB or bus.
+type qualifiedRow struct {
+	ContactID      uuid.UUID
+	Direction      string
+	ExternalID     string
+	ThreadID       string
+	Subject        *string
+	Body           *string
+	Snippet        *string
+	PeerHandle     string
+	PeerNormalized string
+	LocalDay       string
+	SentAt         time.Time
+	AccountID      string
+	GmailMessageID string
+	Metadata       []byte
+}
+
+// GmailSyncProvider implements sync.SyncProvider for Gmail. It is fully inert
+// in phase 2: it is NOT registered in main.go, and although it publishes
+// email.received/email.sent, those kinds have no registered consumer yet, so
+// publishing only writes the durable event-log row.
+type GmailSyncProvider struct {
+	oauthService *OAuthService
+	commsRepo    *repository.CommsMessageRepository
+	bus          busTx
+	pool         *pgxpool.Pool
+
+	// newFetcher builds the per-account gmailFetcher, encapsulating the OAuth
+	// call (GetClientForAccount + gmail.NewService). Defaulted to the real
+	// *gmail.Service-backed factory in the constructor; tests override via
+	// SetFetcherFactoryForTest so a fake fetcher is injected with NO OAuth /
+	// token state. Keyed by accountID so the integration path never needs a
+	// stored credential.
+	newFetcher func(ctx context.Context, accountID string) (gmailFetcher, error)
+
+	// newMeSet builds the "me" set (the normalized address of every connected
+	// account). Defaulted to an impl that calls oauthService.ListAccounts;
+	// tests override via SetMeSetForTest so the M-set is injected with no OAuth
+	// state — symmetric with newFetcher (D4).
+	newMeSet func(ctx context.Context) (map[string]struct{}, error)
+}
+
+// NewGmailSyncProvider builds the Gmail provider. bus and pool are REQUIRED:
+// the provider's entire purpose is publish-before-mutate, so a nil bus or pool
+// is a programming error caught by the Sync guard. This differs from the
+// calendar provider's off-mode (nil bus = skip publish); Gmail has no off mode.
+func NewGmailSyncProvider(
+	oauthService *OAuthService,
+	commsRepo *repository.CommsMessageRepository,
+	bus *events.Bus,
+	pool *pgxpool.Pool,
+) *GmailSyncProvider {
+	p := &GmailSyncProvider{
+		oauthService: oauthService,
+		commsRepo:    commsRepo,
+		bus:          bus,
+		pool:         pool,
+	}
+	p.newFetcher = func(ctx context.Context, accountID string) (gmailFetcher, error) {
+		client, err := oauthService.GetClientForAccount(ctx, accountID)
+		if err != nil {
+			return nil, fmt.Errorf("get OAuth client: %w", err)
+		}
+		svc, err := gmail.NewService(ctx, option.WithHTTPClient(client))
+		if err != nil {
+			return nil, fmt.Errorf("create Gmail service: %w", err)
+		}
+		return &gmailServiceFetcher{svc: svc}, nil
+	}
+	p.newMeSet = func(ctx context.Context) (map[string]struct{}, error) {
+		accounts, err := oauthService.ListAccounts(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("list accounts: %w", err)
+		}
+		meSet := make(map[string]struct{}, len(accounts))
+		for _, a := range accounts {
+			normalized := matching.NormalizeEmail(a.AccountID)
+			if normalized != "" {
+				meSet[normalized] = struct{}{}
+			}
+		}
+		return meSet, nil
+	}
+	return p
+}
+
+// Config returns the provider's configuration.
+func (p *GmailSyncProvider) Config() sync.SourceConfig {
+	return sync.SourceConfig{
+		Name:                 GmailSourceName,
+		DisplayName:          "Gmail",
+		Strategy:             repository.SyncStrategyContactDriven,
+		SupportsMultiAccount: true,
+		SupportsDiscovery:    false,
+		DefaultInterval:      GmailDefaultInterval,
+	}
+}
+
+// ValidateCredentials checks the Google credentials are valid for the account.
+func (p *GmailSyncProvider) ValidateCredentials(ctx context.Context, accountID *string) error {
+	if accountID == nil {
+		accounts, err := p.oauthService.ListAccounts(ctx)
+		if err != nil {
+			return fmt.Errorf("list accounts: %w", err)
+		}
+		if len(accounts) == 0 {
+			return fmt.Errorf("no Google accounts connected")
+		}
+		return nil
+	}
+	if _, err := p.oauthService.GetClientForAccount(ctx, *accountID); err != nil {
+		return fmt.Errorf("get OAuth client for account: %w", err)
+	}
+	return nil
+}
+
+// Sync performs a Gmail sweep for one account. The framework's contacts slice
+// is ignored (not hydrated with methods); the provider loads its own
+// known-contact map via ListEmailIdentitiesForSync (spec §3.1).
+func (p *GmailSyncProvider) Sync(
+	ctx context.Context,
+	state *repository.SyncState,
+	_ []repository.Contact,
+) (*sync.SyncResult, error) {
+	if p.bus == nil || p.pool == nil {
+		return nil, fmt.Errorf("gmail provider requires event bus and pool")
+	}
+	if state.AccountID == nil {
+		return nil, fmt.Errorf("account ID required for Gmail sync")
+	}
+	accountID := *state.AccountID
+
+	logger.Info().
+		Str("source", GmailSourceName).
+		Str("account", accountID).
+		Msg("starting Gmail sync")
+
+	// Known-contact map: normalized email → []contact_id (many-to-one).
+	identities, err := p.commsRepo.ListEmailIdentitiesForSync(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list email identities: %w", err)
+	}
+	knownMap := make(map[string][]uuid.UUID)
+	for _, id := range identities {
+		knownMap[id.ValueNormalized] = append(knownMap[id.ValueNormalized], id.ContactID)
+	}
+	for addr, contacts := range knownMap {
+		if len(contacts) > 1 {
+			logger.Debug().
+				Str("address", addr).
+				Int("contacts", len(contacts)).
+				Msg("gmail: ambiguous shared address maps to multiple contacts")
+		}
+	}
+
+	meSet, err := p.newMeSet(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("build me-set: %w", err)
+	}
+
+	fetcher, err := p.newFetcher(ctx, accountID)
+	if err != nil {
+		return nil, fmt.Errorf("build gmail fetcher: %w", err)
+	}
+
+	// Resolve the after: floor. An empty cursor means onboarding — fall back to
+	// backfill_since (default 2026-01-01) converted to epoch seconds.
+	priorCursor := ""
+	if state.SyncCursor != nil {
+		priorCursor = *state.SyncCursor
+	}
+	priorCursorSecs, afterEpoch := resolveAfterFloor(priorCursor, state.Metadata)
+
+	addresses := make([]string, 0, len(knownMap))
+	for addr := range knownMap {
+		addresses = append(addresses, addr)
+	}
+	chunks := buildORChunks(addresses, afterEpoch)
+
+	result := &sync.SyncResult{}
+	seen := make(map[string]struct{})
+	var maxInternalDateSecs int64
+	fetchedAny := false
+
+	for _, query := range chunks {
+		pageToken := ""
+		for {
+			refs, next, err := fetcher.ListMessageIDs(ctx, query, pageToken)
+			if err != nil {
+				// Hard failure: abort the sweep, return the prior cursor
+				// unchanged so the whole after:<prior> window re-runs (D10).
+				return p.failResult(priorCursor), fmt.Errorf("list message ids: %w", err)
+			}
+			for _, ref := range refs {
+				if _, dup := seen[ref.ID]; dup {
+					continue // cross-chunk dedup: body already fetched (D6)
+				}
+				seen[ref.ID] = struct{}{}
+				fetchedAny = true
+
+				msg, err := fetcher.GetMessage(ctx, ref.ID)
+				if err != nil {
+					return p.failResult(priorCursor), fmt.Errorf("get message %s: %w", ref.ID, err)
+				}
+				rows, err := p.processMessage(ctx, msg, accountID, knownMap, meSet)
+				if err != nil {
+					return p.failResult(priorCursor), fmt.Errorf("process message %s: %w", ref.ID, err)
+				}
+				result.ItemsProcessed++
+
+				// Processed (even if zero qualifying rows) contributes its
+				// internalDate to the cursor advance (D11).
+				if secs := msg.InternalDate / 1000; secs > maxInternalDateSecs {
+					maxInternalDateSecs = secs
+				}
+
+				for _, row := range rows {
+					if err := p.persistRow(ctx, row); err != nil {
+						return p.failResult(priorCursor), fmt.Errorf("persist row for message %s: %w", ref.ID, err)
+					}
+					result.ItemsMatched++
+				}
+			}
+			pageToken = next
+			if pageToken == "" {
+				break
+			}
+		}
+	}
+
+	result.NewCursor = computeNewCursor(fetchedAny, maxInternalDateSecs, priorCursorSecs, priorCursor, afterEpoch)
+
+	logger.Info().
+		Str("source", GmailSourceName).
+		Str("account", accountID).
+		Int("processed", result.ItemsProcessed).
+		Int("matched", result.ItemsMatched).
+		Str("cursor", result.NewCursor).
+		Msg("Gmail sync completed")
+
+	return result, nil
+}
+
+// failResult returns a SyncResult that does NOT advance the cursor: NewCursor
+// is the prior cursor verbatim so the after:<prior> window re-runs next tick
+// (D10). A blank prior cursor stays blank — there is nothing to advance past on
+// a first-sweep failure, and the next tick re-derives the onboarding floor.
+func (p *GmailSyncProvider) failResult(priorCursor string) *sync.SyncResult {
+	return &sync.SyncResult{NewCursor: priorCursor}
+}
+
+// persistRow writes one qualifying (message, contact, direction) in a single
+// tx: publish-before-mutate (event publish, then content upsert), then commit.
+// Each row is its own tx so a single bad message can't strand a whole sweep and
+// no tx spans network I/O (content is already in memory). SourceID is
+// per-(message, contact) so a message qualifying N contacts produces N distinct
+// event rows (D10).
+func (p *GmailSyncProvider) persistRow(ctx context.Context, row qualifiedRow) (err error) {
+	kind := events.KindEmailReceived
+	if row.Direction == "outbound" {
+		kind = events.KindEmailSent
+	}
+	payload := events.EmailEventPayload{
+		Version:    1,
+		ContactID:  row.ContactID,
+		ExternalID: row.ExternalID,
+		ThreadID:   row.ThreadID,
+		LocalDay:   row.LocalDay,
+		SentAt:     row.SentAt,
+		Direction:  row.Direction,
+		Subject:    row.Subject,
+	}
+	raw, err := events.Marshal(kind, payload)
+	if err != nil {
+		return fmt.Errorf("marshal %s: %w", kind, err)
+	}
+	env := &events.Envelope{
+		Source:     repository.InteractionSourceEmail,
+		SourceID:   row.ExternalID + ":" + row.ContactID.String(),
+		Kind:       kind,
+		Payload:    raw,
+		ObservedAt: row.SentAt,
+	}
+
+	tx, err := p.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() {
+		if rollbackErr := tx.Rollback(ctx); rollbackErr != nil &&
+			!errors.Is(rollbackErr, pgx.ErrTxClosed) {
+			logger.Warn().Err(rollbackErr).Str("externalId", row.ExternalID).Msg("gmail: tx rollback failed")
+		}
+	}()
+
+	// Publish-before-mutate: a publish failure rolls back the content upsert.
+	if err := p.bus.PublishTx(ctx, tx, env); err != nil {
+		return fmt.Errorf("publish %s: %w", kind, err)
+	}
+
+	if _, err := p.commsRepo.UpsertMessageTx(ctx, tx, repository.UpsertCommsMessageParams{
+		Source:           repository.InteractionSourceEmail,
+		ExternalID:       row.ExternalID,
+		ThreadID:         &row.ThreadID,
+		Subject:          row.Subject,
+		Body:             row.Body,
+		Snippet:          row.Snippet,
+		PeerHandle:       &row.PeerHandle,
+		PeerNormalized:   &row.PeerNormalized,
+		Direction:        row.Direction,
+		SentAt:           row.SentAt,
+		AccountID:        &row.AccountID,
+		SourceMetadata:   row.Metadata,
+		MatchedContactID: row.ContactID,
+		GmailMessageID:   &row.GmailMessageID,
+	}); err != nil {
+		return fmt.Errorf("upsert comms_message: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit tx: %w", err)
+	}
+	return nil
+}
+
+// resolveAfterFloor derives the after:<epoch> floor and the prior cursor in
+// epoch seconds. On an empty/unparseable cursor (onboarding) the floor is
+// backfill_since (default 2026-01-01), and priorCursorSecs is 0. On a numeric
+// cursor the floor is that value and priorCursorSecs mirrors it.
+func resolveAfterFloor(cursor string, metadata map[string]any) (priorCursorSecs, afterEpoch int64) {
+	if secs, err := strconv.ParseInt(strings.TrimSpace(cursor), 10, 64); err == nil && secs > 0 {
+		return secs, secs
+	}
+	return 0, backfillSinceEpoch(metadata)
+}
+
+// backfillSinceEpoch reads metadata["backfill_since"] (a YYYY-MM-DD string,
+// default 2026-01-01) and converts it to epoch seconds in UTC.
+func backfillSinceEpoch(metadata map[string]any) int64 {
+	since := gmailDefaultBackfillSince
+	if metadata != nil {
+		if v, ok := metadata["backfill_since"].(string); ok && strings.TrimSpace(v) != "" {
+			since = strings.TrimSpace(v)
+		}
+	}
+	t, err := time.Parse("2006-01-02", since)
+	if err != nil {
+		t, _ = time.Parse("2006-01-02", gmailDefaultBackfillSince)
+	}
+	return t.Unix()
+}
+
+// computeNewCursor implements the cursor-write contract (D11). It NEVER returns
+// an empty string (an empty NewCursor would NULL-clear the stored cursor and
+// trigger a full re-backfill):
+//   - ≥1 message fetched: advance to max(maxInternalDateSecs, priorCursorSecs),
+//     monotonic so an out-of-order older message can't pull the floor back.
+//   - zero messages fetched: re-write the prior cursor verbatim (idempotent
+//     no-advance); on an empty prior cursor, write the backfill_since epoch so
+//     the next sweep doesn't re-scan from the dawn of time.
+func computeNewCursor(fetchedAny bool, maxInternalDateSecs, priorCursorSecs int64, priorCursor string, afterEpoch int64) string {
+	if fetchedAny {
+		advanced := maxInternalDateSecs
+		if priorCursorSecs > advanced {
+			advanced = priorCursorSecs
+		}
+		return strconv.FormatInt(advanced, 10)
+	}
+	if strings.TrimSpace(priorCursor) != "" {
+		return priorCursor
+	}
+	return strconv.FormatInt(afterEpoch, 10)
+}
+
+// sanitizeAddresses filters the address list to terms safe to embed in a Gmail
+// `q` operator. Addresses that are empty, contain whitespace, or contain a
+// character outside the conservative email-safe set are dropped (and logged) so
+// a single malformed contact_method can't corrupt a chunk query (D5).
+func sanitizeAddresses(addresses []string) []string {
+	out := make([]string, 0, len(addresses))
+	for _, a := range addresses {
+		a = strings.TrimSpace(a)
+		if a == "" {
+			continue
+		}
+		if !emailSafeTermRegex.MatchString(a) {
+			logger.Debug().Str("address", a).Msg("gmail: skipping address unsafe for query term")
+			continue
+		}
+		out = append(out, a)
+	}
+	return out
+}
+
+// buildORChunks builds byte-budgeted chunk queries. Each address contributes
+// one group `(from:a OR to:a OR cc:a OR bcc:a)`; groups are greedily packed
+// (joined by ` OR `) into a chunk while the URL-encoded length of the full
+// candidate query stays ≤ gmailChunkByteCap. A group that alone exceeds the cap
+// still forms its own chunk (groups are never split — splitting would break the
+// participant-dimension coverage invariant). Addresses are sorted for
+// deterministic chunk contents. Returns no chunks for an empty address list.
+func buildORChunks(addresses []string, afterEpoch int64) []string {
+	safe := sanitizeAddresses(addresses)
+	if len(safe) == 0 {
+		return nil
+	}
+	sort.Strings(safe)
+
+	prefix := fmt.Sprintf("%s after:%d", gmailCategoryFilter, afterEpoch)
+
+	var chunks []string
+	var groups []string
+	flush := func() {
+		if len(groups) == 0 {
+			return
+		}
+		chunks = append(chunks, fmt.Sprintf("%s (%s)", prefix, strings.Join(groups, " OR ")))
+		groups = nil
+	}
+	for _, a := range safe {
+		group := fmt.Sprintf("(from:%s OR to:%s OR cc:%s OR bcc:%s)", a, a, a, a)
+		candidate := append(append([]string{}, groups...), group)
+		query := fmt.Sprintf("%s (%s)", prefix, strings.Join(candidate, " OR "))
+		if len(groups) > 0 && encodedLen(query) > gmailChunkByteCap {
+			flush()
+		}
+		groups = append(groups, group)
+	}
+	flush()
+	return chunks
+}
+
+// encodedLen returns the URL-encoded byte length of a query — the dimension the
+// byte cap governs (matches the practical GET-URL limit the spec cites).
+func encodedLen(q string) int {
+	return len(urlQueryEscape(q))
+}
+
+// processMessage extracts content, resolves qualifying (contact, direction)
+// participants per spec §4.1, and returns one qualifiedRow per qualifying
+// (contact, direction). A non-qualifying (bystander) message returns zero rows
+// and no error. Returns an error only on a hard extraction failure (base64
+// decode of the chosen body part).
+func (p *GmailSyncProvider) processMessage(
+	_ context.Context,
+	msg *gmail.Message,
+	accountID string,
+	knownMap map[string][]uuid.UUID,
+	meSet map[string]struct{},
+) ([]qualifiedRow, error) {
+	body, htmlBody, attachments, err := extractContent(msg.Payload)
+	if err != nil {
+		return nil, fmt.Errorf("extract content: %w", err)
+	}
+
+	headers := newHeaderLookup(msg.Payload)
+	subject := headers.first("Subject")
+	fromRaw, fromNorm := parseSingleAddress(headers.first("From"))
+	toRaw, toNorm := parseAddressList(headers.first("To"))
+	ccRaw, ccNorm := parseAddressList(headers.first("Cc"))
+	bccRaw, bccNorm := parseAddressList(headers.first("Bcc"))
+
+	externalID := extractExternalID(headers, accountID, msg.Id)
+	localDay := computeLocalDay(epochMillisToTime(msg.InternalDate), time.Local)
+	sentAt := epochMillisToTime(msg.InternalDate)
+
+	metadata := buildMetadataJSON(htmlBody, attachments, msg.LabelIds, fromRaw, toRaw, ccRaw, bccRaw)
+
+	// Recipient set R (normalized To ∪ Cc ∪ Bcc), and whether M ∩ R ≠ ∅.
+	recipientSet := make(map[string]struct{})
+	for _, n := range toNorm {
+		recipientSet[n] = struct{}{}
+	}
+	for _, n := range ccNorm {
+		recipientSet[n] = struct{}{}
+	}
+	for _, n := range bccNorm {
+		recipientSet[n] = struct{}{}
+	}
+	meInR := false
+	for n := range recipientSet {
+		if _, ok := meSet[n]; ok {
+			meInR = true
+			break
+		}
+	}
+	_, fromIsMe := meSet[fromNorm]
+
+	// Ordered, deduped recipient buckets (raw+normalized aligned) for the
+	// deterministic outbound peer-handle precedence (To, then Cc, then Bcc;
+	// header order within a bucket) (D8).
+	orderedRecipients := buildOrderedRecipients(toRaw, toNorm, ccRaw, ccNorm, bccRaw, bccNorm)
+
+	contentSubject := strPtrIfNotEmpty(subject)
+	contentBody := strPtrIfNotEmpty(body)
+	contentSnippet := strPtrIfNotEmpty(msg.Snippet)
+
+	// Candidate contacts: every contact sharing a matched address in {f} ∪ R.
+	candidateContacts := make(map[uuid.UUID]struct{})
+	if cs, ok := knownMap[fromNorm]; ok {
+		for _, c := range cs {
+			candidateContacts[c] = struct{}{}
+		}
+	}
+	for n := range recipientSet {
+		if cs, ok := knownMap[n]; ok {
+			for _, c := range cs {
+				candidateContacts[c] = struct{}{}
+			}
+		}
+	}
+
+	var rows []qualifiedRow
+	for contactID := range candidateContacts {
+		addrSet := contactAddressSet(knownMap, contactID)
+
+		// Inbound for C iff f ∈ A_C AND M ∩ R ≠ ∅.
+		if _, fromIsContact := addrSet[fromNorm]; fromIsContact && meInR {
+			rows = append(rows, qualifiedRow{
+				ContactID:      contactID,
+				Direction:      "inbound",
+				ExternalID:     externalID,
+				ThreadID:       msg.ThreadId,
+				Subject:        contentSubject,
+				Body:           contentBody,
+				Snippet:        contentSnippet,
+				PeerHandle:     fromRaw,
+				PeerNormalized: fromNorm,
+				LocalDay:       localDay,
+				SentAt:         sentAt,
+				AccountID:      accountID,
+				GmailMessageID: msg.Id,
+				Metadata:       metadata,
+			})
+			continue // a message can't be both inbound and outbound for the same C
+		}
+
+		// Outbound for C iff f ∈ M AND A_C ∩ R ≠ ∅.
+		if fromIsMe {
+			if rawPeer, normPeer, ok := firstContactRecipient(orderedRecipients, addrSet); ok {
+				rows = append(rows, qualifiedRow{
+					ContactID:      contactID,
+					Direction:      "outbound",
+					ExternalID:     externalID,
+					ThreadID:       msg.ThreadId,
+					Subject:        contentSubject,
+					Body:           contentBody,
+					Snippet:        contentSnippet,
+					PeerHandle:     rawPeer,
+					PeerNormalized: normPeer,
+					LocalDay:       localDay,
+					SentAt:         sentAt,
+					AccountID:      accountID,
+					GmailMessageID: msg.Id,
+					Metadata:       metadata,
+				})
+			}
+		}
+		// Otherwise C is a bystander — skip (spec §4.1).
+	}
+
+	// Deterministic ordering of rows (contact id, then direction) so multi-row
+	// messages persist in a stable order.
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].ContactID != rows[j].ContactID {
+			return rows[i].ContactID.String() < rows[j].ContactID.String()
+		}
+		return rows[i].Direction < rows[j].Direction
+	})
+	return rows, nil
+}
+
+// orderedRecipient is one recipient address with its raw + normalized forms,
+// preserving header order across the To → Cc → Bcc buckets.
+type orderedRecipient struct {
+	raw        string
+	normalized string
+}
+
+// buildOrderedRecipients concatenates the recipient buckets in fixed order (To,
+// Cc, Bcc), each in header-listed order, deduping by normalized address so a
+// repeated address keeps its first (highest-precedence) position (D8).
+func buildOrderedRecipients(toRaw, toNorm, ccRaw, ccNorm, bccRaw, bccNorm []string) []orderedRecipient {
+	var out []orderedRecipient
+	seen := make(map[string]struct{})
+	add := func(raws, norms []string) {
+		for i := range norms {
+			n := norms[i]
+			if n == "" {
+				continue
+			}
+			if _, dup := seen[n]; dup {
+				continue
+			}
+			seen[n] = struct{}{}
+			out = append(out, orderedRecipient{raw: raws[i], normalized: n})
+		}
+	}
+	add(toRaw, toNorm)
+	add(ccRaw, ccNorm)
+	add(bccRaw, bccNorm)
+	return out
+}
+
+// firstContactRecipient returns the first ordered recipient whose normalized
+// address is in the contact's address set, giving the deterministic outbound
+// peer-handle (To wins over Cc wins over Bcc; first-listed wins within a
+// bucket) (D8).
+func firstContactRecipient(recipients []orderedRecipient, addrSet map[string]struct{}) (raw, normalized string, ok bool) {
+	for _, r := range recipients {
+		if _, in := addrSet[r.normalized]; in {
+			return r.raw, r.normalized, true
+		}
+	}
+	return "", "", false
+}
+
+// contactAddressSet returns the normalized address set A_C for a contact (the
+// known-map keys that map to it).
+func contactAddressSet(knownMap map[string][]uuid.UUID, contactID uuid.UUID) map[string]struct{} {
+	out := make(map[string]struct{})
+	for addr, contacts := range knownMap {
+		for _, c := range contacts {
+			if c == contactID {
+				out[addr] = struct{}{}
+				break
+			}
+		}
+	}
+	return out
+}
+
+// headerLookup provides case-insensitive access to a message part's headers.
+type headerLookup struct {
+	headers []*gmail.MessagePartHeader
+}
+
+func newHeaderLookup(payload *gmail.MessagePart) headerLookup {
+	if payload == nil {
+		return headerLookup{}
+	}
+	return headerLookup{headers: payload.Headers}
+}
+
+// first returns the first header value matching name (case-insensitive), or "".
+func (h headerLookup) first(name string) string {
+	for _, hdr := range h.headers {
+		if strings.EqualFold(hdr.Name, name) {
+			return hdr.Value
+		}
+	}
+	return ""
+}
+
+// parseSingleAddress parses a single-address header (From). Returns the raw and
+// normalized address. On parse failure it falls back to trimming the raw value.
+func parseSingleAddress(header string) (raw, normalized string) {
+	header = strings.TrimSpace(header)
+	if header == "" {
+		return "", ""
+	}
+	if addr, err := mail.ParseAddress(header); err == nil {
+		return addr.Address, matching.NormalizeEmail(addr.Address)
+	}
+	return header, matching.NormalizeEmail(header)
+}
+
+// parseAddressList parses an address-list header (To/Cc/Bcc) robustly. On a
+// ParseAddressList failure it falls back to a lenient comma-split so a single
+// malformed recipient doesn't drop the whole list. Raw and normalized slices
+// are index-aligned.
+func parseAddressList(header string) (raws, normalized []string) {
+	header = strings.TrimSpace(header)
+	if header == "" {
+		return nil, nil
+	}
+	if addrs, err := mail.ParseAddressList(header); err == nil {
+		for _, a := range addrs {
+			raws = append(raws, a.Address)
+			normalized = append(normalized, matching.NormalizeEmail(a.Address))
+		}
+		return raws, normalized
+	}
+	for _, part := range strings.Split(header, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		raw := part
+		if addr, err := mail.ParseAddress(part); err == nil {
+			raw = addr.Address
+		}
+		raws = append(raws, raw)
+		normalized = append(normalized, matching.NormalizeEmail(raw))
+	}
+	return raws, normalized
+}
+
+// extractExternalID reads the RFC822 Message-ID header (trimming surrounding
+// <> and whitespace). If absent/empty it synthesizes a deterministic
+// nomsgid:<account_id>:<gmail_message_id> fallback (spec §5.4).
+func extractExternalID(headers headerLookup, accountID, gmailID string) string {
+	msgID := strings.TrimSpace(headers.first("Message-ID"))
+	if msgID == "" {
+		msgID = strings.TrimSpace(headers.first("Message-Id"))
+	}
+	msgID = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(msgID, "<"), ">"))
+	if msgID != "" {
+		return msgID
+	}
+	return fmt.Sprintf("nomsgid:%s:%s", accountID, gmailID)
+}
+
+// computeLocalDay returns the calendar day of sentAt in loc (the server's
+// time.Local for cadence math), formatted YYYY-MM-DD (spec §4.2).
+func computeLocalDay(sentAt time.Time, loc *time.Location) string {
+	return sentAt.In(loc).Format("2006-01-02")
+}
+
+// epochMillisToTime converts Gmail's internalDate (epoch millis) to a UTC time.
+func epochMillisToTime(millis int64) time.Time {
+	return time.UnixMilli(millis).UTC()
+}
+
+// extractContent MIME-walks payload, returning the canonical plaintext body,
+// the raw HTML body (when present), and attachment metadata. It prefers the
+// first text/plain part; if none exists anywhere, it strips the first text/html
+// part to plaintext for the body and retains the raw HTML. A part is an
+// attachment when it has a non-empty filename; only metadata is collected (no
+// content is fetched). Returns an error only on a base64 decode failure of a
+// chosen body part.
+func extractContent(payload *gmail.MessagePart) (body, htmlBody string, attachments []attachmentMeta, err error) {
+	if payload == nil {
+		return "", "", nil, nil
+	}
+	var firstPlain, firstHTML *gmail.MessagePart
+	var walk func(part *gmail.MessagePart)
+	walk = func(part *gmail.MessagePart) {
+		if part == nil {
+			return
+		}
+		mimeType := strings.ToLower(part.MimeType)
+		if part.Filename != "" {
+			size := int64(0)
+			if part.Body != nil {
+				size = part.Body.Size
+			}
+			attachments = append(attachments, attachmentMeta{
+				Filename: part.Filename,
+				MimeType: part.MimeType,
+				Size:     size,
+			})
+		} else if mimeType == "text/plain" && firstPlain == nil {
+			firstPlain = part
+		} else if mimeType == "text/html" && firstHTML == nil {
+			firstHTML = part
+		}
+		for _, child := range part.Parts {
+			walk(child)
+		}
+	}
+	walk(payload)
+
+	if firstPlain != nil {
+		decoded, derr := decodePartBody(firstPlain.Body)
+		if derr != nil {
+			return "", "", nil, fmt.Errorf("decode text/plain: %w", derr)
+		}
+		body = decoded
+	}
+	if firstHTML != nil {
+		decoded, derr := decodePartBody(firstHTML.Body)
+		if derr != nil {
+			return "", "", nil, fmt.Errorf("decode text/html: %w", derr)
+		}
+		htmlBody = decoded
+		if body == "" {
+			body = stripHTML(decoded)
+		}
+	}
+	return body, htmlBody, attachments, nil
+}
+
+// decodePartBody decodes a MIME part body. Gmail uses base64url (RFC 4648 §5);
+// missing padding is tolerated via a RawURLEncoding fallback. An empty body
+// decodes to "".
+func decodePartBody(b *gmail.MessagePartBody) (string, error) {
+	if b == nil || b.Data == "" {
+		return "", nil
+	}
+	if decoded, err := base64.URLEncoding.DecodeString(b.Data); err == nil {
+		return string(decoded), nil
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(b.Data)
+	if err != nil {
+		return "", fmt.Errorf("base64url decode: %w", err)
+	}
+	return string(decoded), nil
+}
+
+// stripHTML reduces an HTML body to conservative plaintext: tags removed, basic
+// entities unescaped, whitespace collapsed. The high-fidelity HTML is retained
+// verbatim in source_metadata.html, so this only feeds the canonical body when
+// no text/plain part exists.
+func stripHTML(s string) string {
+	s = htmlTagRegex.ReplaceAllString(s, " ")
+	s = html.UnescapeString(s)
+	return strings.TrimSpace(strings.Join(strings.Fields(s), " "))
+}
+
+// buildMetadataJSON assembles the non-provenance source_metadata JSON the
+// provider owns (html, attachments, labels, from/to/cc/bcc). The provenance
+// keys (observed_accounts, account_gmail_ids) are added by the phase-1 upsert
+// query, not here.
+func buildMetadataJSON(htmlBody string, attachments []attachmentMeta, labels []string, fromRaw string, toRaw, ccRaw, bccRaw []string) []byte {
+	meta := emailMetadata{
+		HTML:        htmlBody,
+		Attachments: attachments,
+		Labels:      labels,
+		From:        fromRaw,
+		To:          toRaw,
+		Cc:          ccRaw,
+		Bcc:         bccRaw,
+	}
+	b, err := json.Marshal(meta)
+	if err != nil {
+		// emailMetadata is composed entirely of marshalable types, so this is
+		// unreachable; fall back to an empty object to keep the upsert valid.
+		return []byte("{}")
+	}
+	return b
+}
+
+// urlQueryEscape is a thin wrapper over url.QueryEscape used by the byte-cap
+// measurement so the chunk builder governs the encoded GET-URL length.
+func urlQueryEscape(s string) string {
+	return url.QueryEscape(s)
+}
+
+// --- Test-only shims. Production code must NOT call these. ---
+
+// RunProcessMessageForTest drives the unexported processMessage entry point so
+// cross-package tests can assert participant/direction resolution + content
+// extraction against real *gmail.Message structs without a DB or bus.
+func (p *GmailSyncProvider) RunProcessMessageForTest(
+	ctx context.Context,
+	msg *gmail.Message,
+	accountID string,
+	knownMap map[string][]uuid.UUID,
+	meSet map[string]struct{},
+) ([]qualifiedRow, error) {
+	return p.processMessage(ctx, msg, accountID, knownMap, meSet)
+}
+
+// SetFetcherFactoryForTest overrides the per-account fetcher factory so tests
+// inject a fake gmailFetcher with no OAuth/token state (the OAuth seam, D1).
+func (p *GmailSyncProvider) SetFetcherFactoryForTest(factory func(ctx context.Context, accountID string) (gmailFetcher, error)) {
+	p.newFetcher = factory
+}
+
+// SetMeSetForTest overrides the me-set factory so tests inject the connected-
+// account address set with no OAuth state (D4).
+func (p *GmailSyncProvider) SetMeSetForTest(meSet map[string]struct{}) {
+	p.newMeSet = func(context.Context) (map[string]struct{}, error) {
+		return meSet, nil
+	}
+}
+
+// SetBusForTest substitutes the publish bus so a test can assert
+// publish-before-mutate (a failing PublishTx must leave no comms_message row).
+func (p *GmailSyncProvider) SetBusForTest(b busTx) {
+	p.bus = b
+}
+
+// GmailMessageRefForTest is the exported alias of the internal (id, threadId)
+// stub, so cross-package tests can build canned list pages without reaching the
+// unexported gmailMessageRef.
+type GmailMessageRefForTest = gmailMessageRef
+
+// FakeGmailFetcherFuncs lets a cross-package test supply a fake gmailFetcher by
+// closures, since the gmailFetcher interface is unexported. Both funcs must be
+// set. Build the fetcher with NewFakeGmailFetcherForTest and inject the
+// resulting factory via SetFetcherFactoryForTest.
+type FakeGmailFetcherFuncs struct {
+	ListMessageIDs func(ctx context.Context, query, pageToken string) ([]GmailMessageRefForTest, string, error)
+	GetMessage     func(ctx context.Context, id string) (*gmail.Message, error)
+}
+
+type fakeGmailFetcher struct {
+	funcs FakeGmailFetcherFuncs
+}
+
+func (f *fakeGmailFetcher) ListMessageIDs(ctx context.Context, query, pageToken string) ([]gmailMessageRef, string, error) {
+	return f.funcs.ListMessageIDs(ctx, query, pageToken)
+}
+
+func (f *fakeGmailFetcher) GetMessage(ctx context.Context, id string) (*gmail.Message, error) {
+	return f.funcs.GetMessage(ctx, id)
+}
+
+// NewFakeGmailFetcherFactoryForTest returns a fetcher factory (accountID-keyed,
+// the SetFetcherFactoryForTest shape) that always yields the same closure-backed
+// fake fetcher, with NO OAuth/token state. Production code must NOT call this.
+func NewFakeGmailFetcherFactoryForTest(funcs FakeGmailFetcherFuncs) func(ctx context.Context, accountID string) (gmailFetcher, error) {
+	fetcher := &fakeGmailFetcher{funcs: funcs}
+	return func(context.Context, string) (gmailFetcher, error) {
+		return fetcher, nil
+	}
+}
+
+// EncodeBase64URLForTest exposes the base64url encoding used for message body
+// data, so cross-package tests can build *gmail.Message bodies the provider
+// will decode. Production code must NOT call this.
+func EncodeBase64URLForTest(s string) string {
+	return base64.URLEncoding.EncodeToString([]byte(s))
+}
+
+// BuildORChunksForTest exposes the byte-budgeted chunk builder so a
+// cross-package integration test can assert how many OR-chunks a given address
+// set produces (e.g., to prove a cross-chunk dedup scenario is meaningful).
+// Production code must NOT call this.
+func BuildORChunksForTest(addresses []string, afterEpoch int64) []string {
+	return buildORChunks(addresses, afterEpoch)
+}

--- a/backend/internal/google/gmail_test.go
+++ b/backend/internal/google/gmail_test.go
@@ -108,7 +108,7 @@ func (f *fakeFetcher) GetMessage(_ context.Context, id string) (*gmail.Message, 
 	return msg, nil
 }
 
-// --- D3: Config ---
+// --- Config ---
 
 func TestGmailSyncProvider_Config(t *testing.T) {
 	p := NewGmailSyncProvider(nil, nil, nil, nil)
@@ -121,7 +121,7 @@ func TestGmailSyncProvider_Config(t *testing.T) {
 	require.Equal(t, GmailDefaultInterval, cfg.DefaultInterval)
 }
 
-// --- §7.1.1: OR-chunk byte budgeting + sanitization ---
+// --- OR-chunk byte budgeting + sanitization ---
 
 func TestBuildORChunks_BasicShapeAndPrefix(t *testing.T) {
 	chunks := buildORChunks([]string{"b@example.com", "a@example.com"}, 1700000000)
@@ -196,7 +196,7 @@ func TestSanitizeAddresses_OnlyMalformed_Empty(t *testing.T) {
 	require.Empty(t, sanitizeAddresses([]string{"a b@example.com", "x()@example.com", "  "}))
 }
 
-// --- §7.1.3: MIME body extraction ---
+// --- MIME body extraction ---
 
 func TestExtractContent_PlainTextOnly(t *testing.T) {
 	body, htmlBody, atts, err := extractContent(plainTextPart("hello world"))
@@ -287,7 +287,30 @@ func TestExtractContent_NilPayload(t *testing.T) {
 	require.Empty(t, atts)
 }
 
-// --- §7.1.4: Message-ID extraction + fallback ---
+func TestExtractContent_AttachmentIDWithoutFilename_StillCollected(t *testing.T) {
+	// Inline images and some forwarded parts carry an AttachmentId but no
+	// filename — they must still be recorded as attachment metadata and must
+	// NOT be treated as the message body.
+	payload := &gmail.MessagePart{
+		MimeType: "multipart/mixed",
+		Parts: []*gmail.MessagePart{
+			plainTextPart("body text"),
+			{
+				MimeType: "image/png",
+				Body:     &gmail.MessagePartBody{AttachmentId: "att-inline-1", Size: 512},
+			},
+		},
+	}
+	body, _, atts, err := extractContent(payload)
+	require.NoError(t, err)
+	require.Equal(t, "body text", body)
+	require.Len(t, atts, 1)
+	require.Equal(t, "image/png", atts[0].MimeType)
+	require.Equal(t, int64(512), atts[0].Size)
+	require.Empty(t, atts[0].Filename)
+}
+
+// --- Message-ID extraction + fallback ---
 
 func TestExtractExternalID_PresentTrimmed(t *testing.T) {
 	h := newHeaderLookup(&gmail.MessagePart{Headers: []*gmail.MessagePartHeader{
@@ -308,7 +331,7 @@ func TestExtractExternalID_CaseInsensitiveHeaderName(t *testing.T) {
 	require.Equal(t, "lower@example.com", extractExternalID(h, "me@example.com", "gmail-1"))
 }
 
-// --- §7.1.5: participant/direction rule ---
+// --- participant/direction rule ---
 
 func buildMessage(t *testing.T, id, threadID, from string, to, cc, bcc []string, subject, body, msgID string, internalDateMillis int64) *gmail.Message {
 	t.Helper()
@@ -470,7 +493,7 @@ func TestProcessMessage_InboundForA_RecipientBNotQualifying(t *testing.T) {
 	require.Equal(t, "inbound", rows[0].Direction)
 }
 
-// --- §7.1.6: ambiguous shared-address fan-out ---
+// --- ambiguous shared-address fan-out ---
 
 func TestProcessMessage_AmbiguousSharedAddress_FansOut(t *testing.T) {
 	p := newProviderForResolution()
@@ -494,7 +517,7 @@ func TestProcessMessage_AmbiguousSharedAddress_FansOut(t *testing.T) {
 	require.True(t, ids[contactB])
 }
 
-// --- §7.1.5 (display-name parsing) + peer-handle precedence (D8) ---
+// --- display-name parsing + peer-handle precedence ---
 
 func TestProcessMessage_PeerHandlePrecedence_ToWinsOverCc(t *testing.T) {
 	p := newProviderForResolution()
@@ -613,7 +636,7 @@ func TestProcessMessage_MetadataCarriesAttachmentsAndHTML(t *testing.T) {
 	require.Equal(t, []string{"me@example.com"}, meta.To)
 }
 
-// --- §7.1.7: local_day boundary in time.Local (incl. DST) ---
+// --- local_day boundary in time.Local (incl. DST) ---
 
 func TestComputeLocalDay_PureForm_AcrossMidnight(t *testing.T) {
 	loc, err := time.LoadLocation("America/New_York")
@@ -652,7 +675,7 @@ func TestComputeLocalDay_ReadsGlobalTimeLocal(t *testing.T) {
 	require.Equal(t, "2026-11-01", computeLocalDay(instant, time.Local))
 }
 
-// --- cursor helpers (D11) ---
+// --- cursor helpers ---
 
 func TestComputeNewCursor_FetchedAdvancesMonotonic(t *testing.T) {
 	// max(maxInternalDate, prior) — never below prior.
@@ -688,14 +711,38 @@ func TestResolveAfterFloor_EmptyCursor_MetadataOverride(t *testing.T) {
 	require.Equal(t, expected, after)
 }
 
-// --- §7.1.2: cross-chunk seen dedup (fetcher call count) at the Sync seam ---
-// (Full Sync sweep is exercised in the integration test; here we assert the
-// dedup mechanic directly against the fake fetcher.)
+// --- cross-chunk seen dedup ---
+//
+// The per-id `seen` set lives inside Sync, whose body fetch + persist need a
+// real bus + pool, so the end-to-end "body fetched once across chunks"
+// assertion lives in the integration test (TestGmailProvider_CrossChunkSeenDedup).
+// Here we unit-test the precondition that makes that scenario reachable: the
+// chunk builder splits a large address set across multiple OR-chunks, and the
+// fake fetcher hands the SAME message id back from more than one chunk query —
+// which is exactly when Sync's seen set must suppress the duplicate body fetch.
 
-func TestFakeFetcher_RecordsGetCalls(t *testing.T) {
+func TestCrossChunkDedup_Precondition_SameIDFromTwoChunks(t *testing.T) {
+	// A large address set forces multiple OR-chunks.
+	var addrs []string
+	for i := 0; i < 200; i++ {
+		addrs = append(addrs, fmt.Sprintf("user%03d@example.com", i))
+	}
+	chunks := buildORChunks(addrs, 1700000000)
+	require.Greater(t, len(chunks), 1, "address set must span multiple chunks")
+
+	// A message returned by both the first and the last chunk query.
 	f := newFakeFetcher()
-	f.messages["g1"] = &gmail.Message{Id: "g1"}
-	_, _ = f.GetMessage(context.Background(), "g1")
-	_, _ = f.GetMessage(context.Background(), "g1")
-	require.Equal(t, 2, f.getCalls["g1"])
+	f.messages["g-span"] = &gmail.Message{Id: "g-span"}
+	f.listPages[chunks[0]] = [][]gmailMessageRef{{{ID: "g-span"}}}
+	f.listPages[chunks[len(chunks)-1]] = [][]gmailMessageRef{{{ID: "g-span"}}}
+
+	// Both chunk queries hand back the same id (the cross-chunk duplicate Sync's
+	// seen set must collapse to a single GetMessage).
+	page0, _, err := f.ListMessageIDs(context.Background(), chunks[0], "")
+	require.NoError(t, err)
+	pageN, _, err := f.ListMessageIDs(context.Background(), chunks[len(chunks)-1], "")
+	require.NoError(t, err)
+	require.Len(t, page0, 1)
+	require.Len(t, pageN, 1)
+	require.Equal(t, page0[0].ID, pageN[0].ID)
 }

--- a/backend/internal/google/gmail_test.go
+++ b/backend/internal/google/gmail_test.go
@@ -1,0 +1,701 @@
+package google
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/gmail/v1"
+)
+
+// --- test helpers ---
+
+// b64url encodes s as a Gmail-style base64url string (with padding).
+func b64url(s string) string {
+	return base64.URLEncoding.EncodeToString([]byte(s))
+}
+
+// header builds a gmail header.
+func header(name, value string) *gmail.MessagePartHeader {
+	return &gmail.MessagePartHeader{Name: name, Value: value}
+}
+
+// plainTextPart builds a text/plain leaf part.
+func plainTextPart(body string) *gmail.MessagePart {
+	return &gmail.MessagePart{
+		MimeType: "text/plain",
+		Body:     &gmail.MessagePartBody{Data: b64url(body), Size: int64(len(body))},
+	}
+}
+
+// htmlPart builds a text/html leaf part.
+func htmlPart(body string) *gmail.MessagePart {
+	return &gmail.MessagePart{
+		MimeType: "text/html",
+		Body:     &gmail.MessagePartBody{Data: b64url(body), Size: int64(len(body))},
+	}
+}
+
+// attachmentPart builds an attachment leaf part (filename + attachmentId, no
+// inline content).
+func attachmentPart(filename, mime string, size int64) *gmail.MessagePart {
+	return &gmail.MessagePart{
+		MimeType: mime,
+		Filename: filename,
+		Body:     &gmail.MessagePartBody{AttachmentId: "att-" + filename, Size: size},
+	}
+}
+
+// fakeFetcher is an in-memory gmailFetcher. listPages maps a query → ordered
+// list pages (each a slice of refs); messages maps id → message. getCalls
+// records per-id GetMessage call counts. getErrIDs forces GetMessage to error
+// for the given ids.
+type fakeFetcher struct {
+	listPages map[string][][]gmailMessageRef
+	messages  map[string]*gmail.Message
+	getCalls  map[string]int
+	getErrIDs map[string]struct{}
+	listErr   error
+}
+
+func newFakeFetcher() *fakeFetcher {
+	return &fakeFetcher{
+		listPages: map[string][][]gmailMessageRef{},
+		messages:  map[string]*gmail.Message{},
+		getCalls:  map[string]int{},
+		getErrIDs: map[string]struct{}{},
+	}
+}
+
+func (f *fakeFetcher) ListMessageIDs(_ context.Context, query, pageToken string) ([]gmailMessageRef, string, error) {
+	if f.listErr != nil {
+		return nil, "", f.listErr
+	}
+	pages := f.listPages[query]
+	idx := 0
+	if pageToken != "" {
+		// pageToken encodes the page index as "p<n>".
+		if _, err := fmt.Sscanf(pageToken, "p%d", &idx); err != nil {
+			return nil, "", fmt.Errorf("bad page token %q: %w", pageToken, err)
+		}
+	}
+	if idx >= len(pages) {
+		return nil, "", nil
+	}
+	next := ""
+	if idx+1 < len(pages) {
+		next = fmt.Sprintf("p%d", idx+1)
+	}
+	return pages[idx], next, nil
+}
+
+func (f *fakeFetcher) GetMessage(_ context.Context, id string) (*gmail.Message, error) {
+	f.getCalls[id]++
+	if _, bad := f.getErrIDs[id]; bad {
+		return nil, fmt.Errorf("forced get error for %s", id)
+	}
+	msg, ok := f.messages[id]
+	if !ok {
+		return nil, fmt.Errorf("message %s not found", id)
+	}
+	return msg, nil
+}
+
+// --- D3: Config ---
+
+func TestGmailSyncProvider_Config(t *testing.T) {
+	p := NewGmailSyncProvider(nil, nil, nil, nil)
+	cfg := p.Config()
+	require.Equal(t, GmailSourceName, cfg.Name)
+	require.Equal(t, "email", cfg.Name)
+	require.Equal(t, "Gmail", cfg.DisplayName)
+	require.True(t, cfg.SupportsMultiAccount)
+	require.False(t, cfg.SupportsDiscovery)
+	require.Equal(t, GmailDefaultInterval, cfg.DefaultInterval)
+}
+
+// --- §7.1.1: OR-chunk byte budgeting + sanitization ---
+
+func TestBuildORChunks_BasicShapeAndPrefix(t *testing.T) {
+	chunks := buildORChunks([]string{"b@example.com", "a@example.com"}, 1700000000)
+	require.Len(t, chunks, 1)
+	q := chunks[0]
+	require.True(t, strings.HasPrefix(q, "category:primary after:1700000000 ("), "got %q", q)
+	// Sorted: a before b.
+	require.Less(t, strings.Index(q, "a@example.com"), strings.Index(q, "b@example.com"))
+	require.Contains(t, q, "(from:a@example.com OR to:a@example.com OR cc:a@example.com OR bcc:a@example.com)")
+	require.LessOrEqual(t, len(url.QueryEscape(q)), gmailChunkByteCap)
+}
+
+func TestBuildORChunks_EmptyList_NoChunks(t *testing.T) {
+	require.Empty(t, buildORChunks(nil, 1700000000))
+	require.Empty(t, buildORChunks([]string{}, 1700000000))
+}
+
+func TestBuildORChunks_Deterministic(t *testing.T) {
+	addrs := []string{"c@example.com", "a@example.com", "b@example.com"}
+	first := buildORChunks(addrs, 1700000000)
+	second := buildORChunks([]string{"b@example.com", "c@example.com", "a@example.com"}, 1700000000)
+	require.Equal(t, first, second)
+}
+
+func TestBuildORChunks_CrossingCapForcesNewChunk(t *testing.T) {
+	// Build enough addresses that the (k+1)-th group tips over the cap.
+	var addrs []string
+	for i := 0; i < 200; i++ {
+		addrs = append(addrs, fmt.Sprintf("user%03d@example.com", i))
+	}
+	chunks := buildORChunks(addrs, 1700000000)
+	require.Greater(t, len(chunks), 1, "expected the address set to span multiple chunks")
+	for _, c := range chunks {
+		require.LessOrEqual(t, len(url.QueryEscape(c)), gmailChunkByteCap, "chunk exceeds byte cap: %q", c)
+	}
+	// Every address appears in exactly one chunk.
+	joined := strings.Join(chunks, " ")
+	for _, a := range addrs {
+		require.Equal(t, 1, strings.Count(joined, "from:"+a+" "), "address %s should appear once", a)
+	}
+}
+
+func TestBuildORChunks_SingleOversizedGroupGetsOwnChunk(t *testing.T) {
+	// A pathologically long (but email-safe) local part whose single group
+	// alone exceeds the cap still forms one chunk (groups are never split).
+	long := strings.Repeat("a", gmailChunkByteCap) + "@example.com"
+	chunks := buildORChunks([]string{long}, 1700000000)
+	require.Len(t, chunks, 1)
+	require.Contains(t, chunks[0], "from:"+long)
+}
+
+func TestBuildORChunks_SanitizesMalformedAddresses(t *testing.T) {
+	addrs := []string{
+		"clean@example.com",
+		"has space@example.com", // whitespace → dropped
+		"paren(@example.com",    // ( → dropped
+		"quote\"@example.com",   // " → dropped
+		"",                      // empty → dropped
+		"second@example.com",
+	}
+	chunks := buildORChunks(addrs, 1700000000)
+	require.Len(t, chunks, 1)
+	q := chunks[0]
+	require.Contains(t, q, "from:clean@example.com")
+	require.Contains(t, q, "from:second@example.com")
+	require.NotContains(t, q, "has space")
+	require.NotContains(t, q, "paren(")
+	require.NotContains(t, q, "quote\"")
+}
+
+func TestSanitizeAddresses_OnlyMalformed_Empty(t *testing.T) {
+	require.Empty(t, sanitizeAddresses([]string{"a b@example.com", "x()@example.com", "  "}))
+}
+
+// --- §7.1.3: MIME body extraction ---
+
+func TestExtractContent_PlainTextOnly(t *testing.T) {
+	body, htmlBody, atts, err := extractContent(plainTextPart("hello world"))
+	require.NoError(t, err)
+	require.Equal(t, "hello world", body)
+	require.Empty(t, htmlBody)
+	require.Empty(t, atts)
+}
+
+func TestExtractContent_HTMLOnly_StripsToBody_RetainsHTML(t *testing.T) {
+	raw := "<html><body><p>Hi &amp; bye</p><br></body></html>"
+	body, htmlBody, _, err := extractContent(htmlPart(raw))
+	require.NoError(t, err)
+	require.Equal(t, "Hi & bye", body)
+	require.Equal(t, raw, htmlBody)
+}
+
+func TestExtractContent_MultipartAlternative_PrefersPlain_RetainsHTML(t *testing.T) {
+	payload := &gmail.MessagePart{
+		MimeType: "multipart/alternative",
+		Parts: []*gmail.MessagePart{
+			plainTextPart("plain body"),
+			htmlPart("<p>html body</p>"),
+		},
+	}
+	body, htmlBody, _, err := extractContent(payload)
+	require.NoError(t, err)
+	require.Equal(t, "plain body", body)
+	require.Equal(t, "<p>html body</p>", htmlBody)
+}
+
+func TestExtractContent_MultipartMixed_BodyPlusAttachment(t *testing.T) {
+	payload := &gmail.MessagePart{
+		MimeType: "multipart/mixed",
+		Parts: []*gmail.MessagePart{
+			plainTextPart("see attached"),
+			attachmentPart("report.pdf", "application/pdf", 2048),
+		},
+	}
+	body, _, atts, err := extractContent(payload)
+	require.NoError(t, err)
+	require.Equal(t, "see attached", body)
+	require.Len(t, atts, 1)
+	require.Equal(t, attachmentMeta{Filename: "report.pdf", MimeType: "application/pdf", Size: 2048}, atts[0])
+}
+
+func TestExtractContent_NestedMultipartRecursion(t *testing.T) {
+	payload := &gmail.MessagePart{
+		MimeType: "multipart/mixed",
+		Parts: []*gmail.MessagePart{
+			{
+				MimeType: "multipart/alternative",
+				Parts: []*gmail.MessagePart{
+					plainTextPart("nested plain"),
+					htmlPart("<p>nested html</p>"),
+				},
+			},
+			attachmentPart("a.png", "image/png", 99),
+		},
+	}
+	body, htmlBody, atts, err := extractContent(payload)
+	require.NoError(t, err)
+	require.Equal(t, "nested plain", body)
+	require.Equal(t, "<p>nested html</p>", htmlBody)
+	require.Len(t, atts, 1)
+}
+
+func TestExtractContent_Base64URL_MissingPaddingTolerated(t *testing.T) {
+	// "hi!" base64url is "aGkh" (no padding needed); use a value that requires
+	// padding then strip it to exercise the RawURLEncoding fallback.
+	full := base64.URLEncoding.EncodeToString([]byte("padme"))
+	require.Contains(t, full, "=", "test fixture should require padding")
+	stripped := strings.TrimRight(full, "=")
+	part := &gmail.MessagePart{
+		MimeType: "text/plain",
+		Body:     &gmail.MessagePartBody{Data: stripped},
+	}
+	body, _, _, err := extractContent(part)
+	require.NoError(t, err)
+	require.Equal(t, "padme", body)
+}
+
+func TestExtractContent_NilPayload(t *testing.T) {
+	body, htmlBody, atts, err := extractContent(nil)
+	require.NoError(t, err)
+	require.Empty(t, body)
+	require.Empty(t, htmlBody)
+	require.Empty(t, atts)
+}
+
+// --- §7.1.4: Message-ID extraction + fallback ---
+
+func TestExtractExternalID_PresentTrimmed(t *testing.T) {
+	h := newHeaderLookup(&gmail.MessagePart{Headers: []*gmail.MessagePartHeader{
+		header("Message-ID", "  <abc123@mail.example.com>  "),
+	}})
+	require.Equal(t, "abc123@mail.example.com", extractExternalID(h, "me@example.com", "gmail-1"))
+}
+
+func TestExtractExternalID_AbsentFallback(t *testing.T) {
+	h := newHeaderLookup(&gmail.MessagePart{Headers: nil})
+	require.Equal(t, "nomsgid:me@example.com:gmail-1", extractExternalID(h, "me@example.com", "gmail-1"))
+}
+
+func TestExtractExternalID_CaseInsensitiveHeaderName(t *testing.T) {
+	h := newHeaderLookup(&gmail.MessagePart{Headers: []*gmail.MessagePartHeader{
+		header("message-id", "<lower@example.com>"),
+	}})
+	require.Equal(t, "lower@example.com", extractExternalID(h, "me@example.com", "gmail-1"))
+}
+
+// --- §7.1.5: participant/direction rule ---
+
+func buildMessage(t *testing.T, id, threadID, from string, to, cc, bcc []string, subject, body, msgID string, internalDateMillis int64) *gmail.Message {
+	t.Helper()
+	headers := []*gmail.MessagePartHeader{header("From", from)}
+	if len(to) > 0 {
+		headers = append(headers, header("To", strings.Join(to, ", ")))
+	}
+	if len(cc) > 0 {
+		headers = append(headers, header("Cc", strings.Join(cc, ", ")))
+	}
+	if len(bcc) > 0 {
+		headers = append(headers, header("Bcc", strings.Join(bcc, ", ")))
+	}
+	if subject != "" {
+		headers = append(headers, header("Subject", subject))
+	}
+	if msgID != "" {
+		headers = append(headers, header("Message-ID", msgID))
+	}
+	return &gmail.Message{
+		Id:           id,
+		ThreadId:     threadID,
+		InternalDate: internalDateMillis,
+		Snippet:      "snippet",
+		LabelIds:     []string{"INBOX", "CATEGORY_PERSONAL"},
+		Payload: &gmail.MessagePart{
+			MimeType: "text/plain",
+			Headers:  headers,
+			Body:     &gmail.MessagePartBody{Data: b64url(body), Size: int64(len(body))},
+		},
+	}
+}
+
+func newProviderForResolution() *GmailSyncProvider {
+	return NewGmailSyncProvider(nil, nil, nil, nil)
+}
+
+func TestProcessMessage_Inbound(t *testing.T) {
+	p := newProviderForResolution()
+	contactA := uuid.New()
+	knownMap := map[string][]uuid.UUID{"contact@example.com": {contactA}}
+	meSet := map[string]struct{}{"me@example.com": {}}
+	msg := buildMessage(t, "g1", "t1", "Contact A <contact@example.com>",
+		[]string{"me@example.com"}, nil, nil, "Hi", "hello", "<m1@example.com>", 1700000000000)
+
+	rows, err := p.RunProcessMessageForTest(context.Background(), msg, "me@example.com", knownMap, meSet)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, "inbound", rows[0].Direction)
+	require.Equal(t, contactA, rows[0].ContactID)
+	require.Equal(t, "contact@example.com", rows[0].PeerNormalized)
+	require.Equal(t, "m1@example.com", rows[0].ExternalID)
+	require.Equal(t, "hello", *rows[0].Body)
+}
+
+func TestProcessMessage_Outbound_To(t *testing.T) {
+	p := newProviderForResolution()
+	contactA := uuid.New()
+	knownMap := map[string][]uuid.UUID{"contact@example.com": {contactA}}
+	meSet := map[string]struct{}{"me@example.com": {}}
+	msg := buildMessage(t, "g1", "t1", "me@example.com",
+		[]string{"contact@example.com"}, nil, nil, "Re", "yo", "<m2@example.com>", 1700000000000)
+
+	rows, err := p.RunProcessMessageForTest(context.Background(), msg, "me@example.com", knownMap, meSet)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, "outbound", rows[0].Direction)
+	require.Equal(t, "contact@example.com", rows[0].PeerNormalized)
+}
+
+func TestProcessMessage_Outbound_ViaCcAndBcc(t *testing.T) {
+	p := newProviderForResolution()
+	meSet := map[string]struct{}{"me@example.com": {}}
+
+	t.Run("cc", func(t *testing.T) {
+		contactA := uuid.New()
+		knownMap := map[string][]uuid.UUID{"contact@example.com": {contactA}}
+		msg := buildMessage(t, "g1", "t1", "me@example.com",
+			[]string{"other@example.com"}, []string{"contact@example.com"}, nil, "S", "b", "<c1@example.com>", 1700000000000)
+		rows, err := p.RunProcessMessageForTest(context.Background(), msg, "me@example.com", knownMap, meSet)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		require.Equal(t, "outbound", rows[0].Direction)
+		require.Equal(t, "contact@example.com", rows[0].PeerNormalized)
+	})
+
+	t.Run("bcc", func(t *testing.T) {
+		contactA := uuid.New()
+		knownMap := map[string][]uuid.UUID{"contact@example.com": {contactA}}
+		msg := buildMessage(t, "g2", "t2", "me@example.com",
+			[]string{"other@example.com"}, nil, []string{"contact@example.com"}, "S", "b", "<c2@example.com>", 1700000000000)
+		rows, err := p.RunProcessMessageForTest(context.Background(), msg, "me@example.com", knownMap, meSet)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		require.Equal(t, "outbound", rows[0].Direction)
+		require.Equal(t, "contact@example.com", rows[0].PeerNormalized)
+	})
+}
+
+func TestProcessMessage_GroupOutbound_TwoContacts(t *testing.T) {
+	p := newProviderForResolution()
+	contactA := uuid.New()
+	contactB := uuid.New()
+	knownMap := map[string][]uuid.UUID{
+		"a@example.com": {contactA},
+		"b@example.com": {contactB},
+	}
+	meSet := map[string]struct{}{"me@example.com": {}}
+	msg := buildMessage(t, "g1", "t1", "me@example.com",
+		[]string{"a@example.com", "b@example.com"}, nil, nil, "S", "hi both", "<g@example.com>", 1700000000000)
+
+	rows, err := p.RunProcessMessageForTest(context.Background(), msg, "me@example.com", knownMap, meSet)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	dirs := map[uuid.UUID]string{}
+	peers := map[uuid.UUID]string{}
+	for _, r := range rows {
+		dirs[r.ContactID] = r.Direction
+		peers[r.ContactID] = r.PeerNormalized
+	}
+	require.Equal(t, "outbound", dirs[contactA])
+	require.Equal(t, "outbound", dirs[contactB])
+	require.Equal(t, "a@example.com", peers[contactA])
+	require.Equal(t, "b@example.com", peers[contactB])
+}
+
+func TestProcessMessage_Bystander_Skipped(t *testing.T) {
+	p := newProviderForResolution()
+	contactA := uuid.New()
+	// Known contact only co-Cc'd by a third party; thread not to/from me.
+	knownMap := map[string][]uuid.UUID{"contact@example.com": {contactA}}
+	meSet := map[string]struct{}{"me@example.com": {}}
+	msg := buildMessage(t, "g1", "t1", "third@example.com",
+		[]string{"other@example.com"}, []string{"contact@example.com"}, nil, "S", "b", "<by@example.com>", 1700000000000)
+
+	rows, err := p.RunProcessMessageForTest(context.Background(), msg, "me@example.com", knownMap, meSet)
+	require.NoError(t, err)
+	require.Empty(t, rows)
+}
+
+func TestProcessMessage_InboundForA_RecipientBNotQualifying(t *testing.T) {
+	p := newProviderForResolution()
+	contactA := uuid.New()
+	contactB := uuid.New()
+	// from=contactA, To={me, contactB}: A is inbound (A wrote, I received).
+	// B is a recipient with from ∉ A_B and from ∉ M → B is a bystander.
+	knownMap := map[string][]uuid.UUID{
+		"a@example.com": {contactA},
+		"b@example.com": {contactB},
+	}
+	meSet := map[string]struct{}{"me@example.com": {}}
+	msg := buildMessage(t, "g1", "t1", "a@example.com",
+		[]string{"me@example.com", "b@example.com"}, nil, nil, "S", "b", "<ab@example.com>", 1700000000000)
+
+	rows, err := p.RunProcessMessageForTest(context.Background(), msg, "me@example.com", knownMap, meSet)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, contactA, rows[0].ContactID)
+	require.Equal(t, "inbound", rows[0].Direction)
+}
+
+// --- §7.1.6: ambiguous shared-address fan-out ---
+
+func TestProcessMessage_AmbiguousSharedAddress_FansOut(t *testing.T) {
+	p := newProviderForResolution()
+	contactA := uuid.New()
+	contactB := uuid.New()
+	knownMap := map[string][]uuid.UUID{"shared@example.com": {contactA, contactB}}
+	meSet := map[string]struct{}{"me@example.com": {}}
+	msg := buildMessage(t, "g1", "t1", "shared@example.com",
+		[]string{"me@example.com"}, nil, nil, "S", "b", "<sh@example.com>", 1700000000000)
+
+	rows, err := p.RunProcessMessageForTest(context.Background(), msg, "me@example.com", knownMap, meSet)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	ids := map[uuid.UUID]bool{}
+	for _, r := range rows {
+		require.Equal(t, "inbound", r.Direction)
+		require.Equal(t, "sh@example.com", r.ExternalID)
+		ids[r.ContactID] = true
+	}
+	require.True(t, ids[contactA])
+	require.True(t, ids[contactB])
+}
+
+// --- §7.1.5 (display-name parsing) + peer-handle precedence (D8) ---
+
+func TestProcessMessage_PeerHandlePrecedence_ToWinsOverCc(t *testing.T) {
+	p := newProviderForResolution()
+	contactA := uuid.New()
+	// Contact has two aliases; one in To, one in Cc. To must win.
+	knownMap := map[string][]uuid.UUID{
+		"primary@example.com": {contactA},
+		"alias@example.com":   {contactA},
+	}
+	meSet := map[string]struct{}{"me@example.com": {}}
+	msg := buildMessage(t, "g1", "t1", "me@example.com",
+		[]string{"primary@example.com"}, []string{"alias@example.com"}, nil, "S", "b", "<pp@example.com>", 1700000000000)
+
+	rows, err := p.RunProcessMessageForTest(context.Background(), msg, "me@example.com", knownMap, meSet)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, "primary@example.com", rows[0].PeerNormalized)
+}
+
+func TestProcessMessage_PeerHandlePrecedence_FirstListedWinsInBucket(t *testing.T) {
+	p := newProviderForResolution()
+	contactA := uuid.New()
+	knownMap := map[string][]uuid.UUID{
+		"first@example.com":  {contactA},
+		"second@example.com": {contactA},
+	}
+	meSet := map[string]struct{}{"me@example.com": {}}
+	// Both in To; first listed must win.
+	msg := buildMessage(t, "g1", "t1", "me@example.com",
+		[]string{"first@example.com", "second@example.com"}, nil, nil, "S", "b", "<fl@example.com>", 1700000000000)
+
+	rows, err := p.RunProcessMessageForTest(context.Background(), msg, "me@example.com", knownMap, meSet)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, "first@example.com", rows[0].PeerNormalized)
+}
+
+func TestProcessMessage_DisplayNameHeaders_Parsed(t *testing.T) {
+	p := newProviderForResolution()
+	contactA := uuid.New()
+	knownMap := map[string][]uuid.UUID{"contact@example.com": {contactA}}
+	meSet := map[string]struct{}{"me@example.com": {}}
+	msg := buildMessage(t, "g1", "t1", "\"Contact A\" <contact@example.com>",
+		[]string{"\"My Self\" <me@example.com>"}, nil, nil, "S", "b", "<dn@example.com>", 1700000000000)
+
+	rows, err := p.RunProcessMessageForTest(context.Background(), msg, "me@example.com", knownMap, meSet)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, "inbound", rows[0].Direction)
+	require.Equal(t, "contact@example.com", rows[0].PeerHandle)
+	require.Equal(t, "contact@example.com", rows[0].PeerNormalized)
+}
+
+func TestProcessMessage_DedupAddressInToAndCc(t *testing.T) {
+	p := newProviderForResolution()
+	contactA := uuid.New()
+	knownMap := map[string][]uuid.UUID{"contact@example.com": {contactA}}
+	meSet := map[string]struct{}{"me@example.com": {}}
+	// contact appears in both To and Cc → one outbound row.
+	msg := buildMessage(t, "g1", "t1", "me@example.com",
+		[]string{"contact@example.com"}, []string{"contact@example.com"}, nil, "S", "b", "<dd@example.com>", 1700000000000)
+
+	rows, err := p.RunProcessMessageForTest(context.Background(), msg, "me@example.com", knownMap, meSet)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+}
+
+func TestProcessMessage_NomsgidFallbackInResolution(t *testing.T) {
+	p := newProviderForResolution()
+	contactA := uuid.New()
+	knownMap := map[string][]uuid.UUID{"contact@example.com": {contactA}}
+	meSet := map[string]struct{}{"me@example.com": {}}
+	msg := buildMessage(t, "gmail-xyz", "t1", "contact@example.com",
+		[]string{"me@example.com"}, nil, nil, "S", "b", "", 1700000000000)
+
+	rows, err := p.RunProcessMessageForTest(context.Background(), msg, "me@example.com", knownMap, meSet)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, "nomsgid:me@example.com:gmail-xyz", rows[0].ExternalID)
+}
+
+func TestProcessMessage_MetadataCarriesAttachmentsAndHTML(t *testing.T) {
+	p := newProviderForResolution()
+	contactA := uuid.New()
+	knownMap := map[string][]uuid.UUID{"contact@example.com": {contactA}}
+	meSet := map[string]struct{}{"me@example.com": {}}
+	msg := &gmail.Message{
+		Id:           "g1",
+		ThreadId:     "t1",
+		InternalDate: 1700000000000,
+		LabelIds:     []string{"INBOX"},
+		Payload: &gmail.MessagePart{
+			MimeType: "multipart/mixed",
+			Headers: []*gmail.MessagePartHeader{
+				header("From", "contact@example.com"),
+				header("To", "me@example.com"),
+				header("Message-ID", "<meta@example.com>"),
+			},
+			Parts: []*gmail.MessagePart{
+				htmlPart("<p>body</p>"),
+				attachmentPart("file.pdf", "application/pdf", 10),
+			},
+		},
+	}
+	rows, err := p.RunProcessMessageForTest(context.Background(), msg, "me@example.com", knownMap, meSet)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+
+	var meta emailMetadata
+	require.NoError(t, json.Unmarshal(rows[0].Metadata, &meta))
+	require.Equal(t, "<p>body</p>", meta.HTML)
+	require.Len(t, meta.Attachments, 1)
+	require.Equal(t, "file.pdf", meta.Attachments[0].Filename)
+	require.Equal(t, []string{"INBOX"}, meta.Labels)
+	require.Equal(t, "contact@example.com", meta.From)
+	require.Equal(t, []string{"me@example.com"}, meta.To)
+}
+
+// --- §7.1.7: local_day boundary in time.Local (incl. DST) ---
+
+func TestComputeLocalDay_PureForm_AcrossMidnight(t *testing.T) {
+	loc, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+	// 2026-03-01 23:30 local is still 2026-03-01 even though UTC has rolled to 03-02.
+	beforeMidnight := time.Date(2026, 3, 1, 23, 30, 0, 0, loc)
+	afterMidnight := time.Date(2026, 3, 2, 0, 30, 0, 0, loc)
+	require.Equal(t, "2026-03-01", computeLocalDay(beforeMidnight.UTC(), loc))
+	require.Equal(t, "2026-03-02", computeLocalDay(afterMidnight.UTC(), loc))
+}
+
+func TestComputeLocalDay_DST_SpringForwardAndFallBack(t *testing.T) {
+	loc, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+
+	// Spring forward 2026: 2026-03-08, clocks jump 2 AM → 3 AM.
+	springInstant := time.Date(2026, 3, 8, 3, 30, 0, 0, loc)
+	require.Equal(t, "2026-03-08", computeLocalDay(springInstant.UTC(), loc))
+
+	// Fall back 2026: 2026-11-01, 1 AM repeats. A 23:30-local instant stays on
+	// the civil day even though its UTC date has rolled over.
+	fallInstant := time.Date(2026, 11, 1, 23, 30, 0, 0, loc)
+	require.Equal(t, "2026-11-01", computeLocalDay(fallInstant.UTC(), loc))
+}
+
+func TestComputeLocalDay_ReadsGlobalTimeLocal(t *testing.T) {
+	// This variant exercises the time.Local code path the provider uses.
+	// time.Local is process-global, so this test is intentionally NOT parallel.
+	loc, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+	orig := time.Local
+	time.Local = loc
+	t.Cleanup(func() { time.Local = orig })
+
+	instant := time.Date(2026, 11, 1, 23, 30, 0, 0, loc).UTC()
+	require.Equal(t, "2026-11-01", computeLocalDay(instant, time.Local))
+}
+
+// --- cursor helpers (D11) ---
+
+func TestComputeNewCursor_FetchedAdvancesMonotonic(t *testing.T) {
+	// max(maxInternalDate, prior) — never below prior.
+	require.Equal(t, "200", computeNewCursor(true, 200, 100, "100", 50))
+	require.Equal(t, "100", computeNewCursor(true, 80, 100, "100", 50), "out-of-order older message must not pull floor back")
+}
+
+func TestComputeNewCursor_ZeroFetched_PreservesPriorCursor(t *testing.T) {
+	require.Equal(t, "12345", computeNewCursor(false, 0, 12345, "12345", 50))
+}
+
+func TestComputeNewCursor_ZeroFetched_EmptyPrior_WritesBackfillEpoch(t *testing.T) {
+	require.Equal(t, "1735689600", computeNewCursor(false, 0, 0, "", 1735689600))
+}
+
+func TestResolveAfterFloor_NumericCursor(t *testing.T) {
+	prior, after := resolveAfterFloor("1700000000", nil)
+	require.Equal(t, int64(1700000000), prior)
+	require.Equal(t, int64(1700000000), after)
+}
+
+func TestResolveAfterFloor_EmptyCursor_UsesBackfillSince(t *testing.T) {
+	expected := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC).Unix()
+	prior, after := resolveAfterFloor("", nil)
+	require.Equal(t, int64(0), prior)
+	require.Equal(t, expected, after)
+}
+
+func TestResolveAfterFloor_EmptyCursor_MetadataOverride(t *testing.T) {
+	expected := time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC).Unix()
+	prior, after := resolveAfterFloor("", map[string]any{"backfill_since": "2026-03-15"})
+	require.Equal(t, int64(0), prior)
+	require.Equal(t, expected, after)
+}
+
+// --- §7.1.2: cross-chunk seen dedup (fetcher call count) at the Sync seam ---
+// (Full Sync sweep is exercised in the integration test; here we assert the
+// dedup mechanic directly against the fake fetcher.)
+
+func TestFakeFetcher_RecordsGetCalls(t *testing.T) {
+	f := newFakeFetcher()
+	f.messages["g1"] = &gmail.Message{Id: "g1"}
+	_, _ = f.GetMessage(context.Background(), "g1")
+	_, _ = f.GetMessage(context.Background(), "g1")
+	require.Equal(t, 2, f.getCalls["g1"])
+}

--- a/backend/tests/gmail_provider_integration_test.go
+++ b/backend/tests/gmail_provider_integration_test.go
@@ -1,0 +1,563 @@
+// End-to-end coverage for the Gmail sync provider (phase 2), driven through
+// the REAL GmailSyncProvider.Sync with a real *events.Bus + database.Pool and a
+// FAKE gmailFetcher + injected M-set (no stored OAuth credential needed). The
+// in-package google tests exercise the pure helpers + processMessage; these
+// prove the full sweep: fetch → resolve → publish-before-mutate upsert →
+// cursor advance, including:
+//   - content rows + durable email.* event rows land per qualifying (msg, contact);
+//   - cross-chunk seen dedup body-fetches a message once;
+//   - match-only (unknown participant never creates a contact);
+//   - cursor-overlap idempotency (no duplicate rows / events / provenance growth);
+//   - publish-before-mutate (a failing PublishTx leaves no content row);
+//   - nomsgid fallback persistence;
+//   - cursor edge cases (all-bystander advances; zero-fetched preserves; hard
+//     failure leaves cursor unchanged);
+//   - nil-account guard;
+//   - cross-account set-union provenance merge through the provider/upsert path.
+//
+// email.* kinds have no registered consumer in phase 2, so the bus's live river
+// client enqueues nothing for them — the events just land in the event-log.
+package tests
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/google"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+	gmailapi "google.golang.org/api/gmail/v1"
+)
+
+// gmailProviderEnv bundles a real provider + bus + repos for the sweep tests.
+type gmailProviderEnv struct {
+	ctx          context.Context
+	database     *db.Database
+	provider     *google.GmailSyncProvider
+	bus          *events.Bus
+	commsRepo    *repository.CommsMessageRepository
+	contactRepo  *repository.ContactRepository
+	methodRepo   *repository.ContactMethodRepository
+	identityRepo *repository.IdentityRepository
+	eventRepo    *repository.EventRepository
+}
+
+func newGmailProviderEnv(t *testing.T) *gmailProviderEnv {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	require.NoError(t, db.RunMigrations(ctx, databaseURL, getMigrationsPath()))
+
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	t.Cleanup(database.Close)
+
+	commsRepo := repository.NewCommsMessageRepository(database.Queries)
+	contactRepo := repository.NewContactRepository(database.Queries)
+	contactRepo.SetPool(database.Pool)
+	methodRepo := repository.NewContactMethodRepository(database.Queries)
+	identityRepo := repository.NewIdentityRepository(database.Queries)
+	interactionRepo := repository.NewInteractionRepository(database.Queries)
+	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
+	eventRepo := repository.NewEventRepository(database.Queries)
+	contactService := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, contactTaskRepo, nil, nil)
+
+	// Live bus via the shared harness. For phase-2 email.* kinds enqueue no
+	// consumer jobs, so the harness's recorder/cadence/followup workers are
+	// irrelevant — the events just land in the event-log.
+	bus := setupTestEventBus(t, ctx, database, contactService)
+
+	provider := google.NewGmailSyncProvider(nil, commsRepo, bus, database.Pool)
+
+	return &gmailProviderEnv{
+		ctx:          ctx,
+		database:     database,
+		provider:     provider,
+		bus:          bus,
+		commsRepo:    commsRepo,
+		contactRepo:  contactRepo,
+		methodRepo:   methodRepo,
+		identityRepo: identityRepo,
+		eventRepo:    eventRepo,
+	}
+}
+
+// newEmailContactWithMethod creates a contact with one email method and
+// registers cleanup (hard-delete content + soft-delete contact).
+func (e *gmailProviderEnv) newEmailContactWithMethod(t *testing.T, name, email string) *repository.Contact {
+	t.Helper()
+	contact, err := e.contactRepo.CreateContact(e.ctx, repository.CreateContactRequest{FullName: name})
+	require.NoError(t, err)
+	_, err = e.methodRepo.CreateContactMethod(e.ctx, repository.CreateContactMethodRequest{
+		ContactID: contact.ID,
+		Type:      "email",
+		Value:     email,
+		IsPrimary: true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = e.commsRepo.HardDeleteByContact(e.ctx, contact.ID)
+		_ = e.contactRepo.SoftDeleteContact(e.ctx, contact.ID)
+	})
+	return contact
+}
+
+// cleanupEvents registers cleanup of the durable-but-unconsumed event rows for
+// a given externalID. The email.* SourceID is "<externalID>:<contactID>", so a
+// "<externalID>%" prefix scopes the delete to this test's events.
+func (e *gmailProviderEnv) cleanupEvents(t *testing.T, externalID string) {
+	t.Helper()
+	t.Cleanup(func() {
+		_ = e.eventRepo.HardDeleteEventsBySourceAndSourceIDPrefix(e.ctx, "email", externalID+"%")
+	})
+}
+
+// fakeMessageStore backs a query-agnostic gmailFetcher: every non-empty query
+// returns ALL registered message stubs (one page), and GetMessage looks up by
+// id. Cross-chunk dedup is exercised by the provider's per-id seen set, which
+// we assert via the GetMessage call counter. forcedGetErr makes GetMessage fail
+// for specific ids (hard-failure tests).
+type fakeMessageStore struct {
+	messages     []*gmailapi.Message
+	getCalls     map[string]int
+	forcedGetErr map[string]struct{}
+}
+
+func newFakeMessageStore(messages []*gmailapi.Message) *fakeMessageStore {
+	return &fakeMessageStore{
+		messages:     messages,
+		getCalls:     map[string]int{},
+		forcedGetErr: map[string]struct{}{},
+	}
+}
+
+func (s *fakeMessageStore) fetcherFuncs() google.FakeGmailFetcherFuncs {
+	return google.FakeGmailFetcherFuncs{
+		ListMessageIDs: func(_ context.Context, query, pageToken string) ([]google.GmailMessageRefForTest, string, error) {
+			if pageToken != "" {
+				return nil, "", nil
+			}
+			refs := make([]google.GmailMessageRefForTest, 0, len(s.messages))
+			for _, m := range s.messages {
+				refs = append(refs, google.GmailMessageRefForTest{ID: m.Id, ThreadID: m.ThreadId})
+			}
+			return refs, "", nil
+		},
+		GetMessage: func(_ context.Context, id string) (*gmailapi.Message, error) {
+			s.getCalls[id]++
+			if _, bad := s.forcedGetErr[id]; bad {
+				return nil, fmt.Errorf("forced get error for %s", id)
+			}
+			for _, m := range s.messages {
+				if m.Id == id {
+					return m, nil
+				}
+			}
+			return nil, fmt.Errorf("message %s not found", id)
+		},
+	}
+}
+
+// inject wires the store as the provider's fetcher + sets the me-set.
+func (e *gmailProviderEnv) inject(store *fakeMessageStore, meSet map[string]struct{}) {
+	e.provider.SetFetcherFactoryForTest(google.NewFakeGmailFetcherFactoryForTest(store.fetcherFuncs()))
+	e.provider.SetMeSetForTest(meSet)
+}
+
+// gmailMsg builds a text/plain *gmail.Message for the fake fetcher.
+func gmailMsg(id, threadID, from string, to, cc, bcc []string, subject, body, msgID string, internalMillis int64) *gmailapi.Message {
+	headers := []*gmailapi.MessagePartHeader{{Name: "From", Value: from}}
+	if len(to) > 0 {
+		headers = append(headers, &gmailapi.MessagePartHeader{Name: "To", Value: strings.Join(to, ", ")})
+	}
+	if len(cc) > 0 {
+		headers = append(headers, &gmailapi.MessagePartHeader{Name: "Cc", Value: strings.Join(cc, ", ")})
+	}
+	if len(bcc) > 0 {
+		headers = append(headers, &gmailapi.MessagePartHeader{Name: "Bcc", Value: strings.Join(bcc, ", ")})
+	}
+	if subject != "" {
+		headers = append(headers, &gmailapi.MessagePartHeader{Name: "Subject", Value: subject})
+	}
+	if msgID != "" {
+		headers = append(headers, &gmailapi.MessagePartHeader{Name: "Message-ID", Value: msgID})
+	}
+	body64 := google.EncodeBase64URLForTest(body)
+	return &gmailapi.Message{
+		Id:           id,
+		ThreadId:     threadID,
+		InternalDate: internalMillis,
+		Snippet:      "snippet",
+		LabelIds:     []string{"INBOX"},
+		Payload: &gmailapi.MessagePart{
+			MimeType: "text/plain",
+			Headers:  headers,
+			Body:     &gmailapi.MessagePartBody{Data: body64, Size: int64(len(body))},
+		},
+	}
+}
+
+// failingBus is a busTx stub whose PublishTx always errors — used to assert
+// publish-before-mutate (the content upsert must roll back).
+type failingBus struct{}
+
+func (failingBus) PublishTx(_ context.Context, _ pgx.Tx, _ *events.Envelope) error {
+	return errors.New("forced publish failure")
+}
+
+func syncState(accountID, cursor string) *repository.SyncState {
+	st := &repository.SyncState{Source: "email", AccountID: &accountID}
+	if cursor != "" {
+		st.SyncCursor = &cursor
+	}
+	return st
+}
+
+// --- §7.2.1: full sweep → content rows + events ---
+
+func TestGmailProvider_FullSweep_ContentAndEvents(t *testing.T) {
+	e := newGmailProviderEnv(t)
+	suffix := uuid.NewString()[:8]
+	me := "me-" + suffix + "@example.com"
+	addrA := "a-" + suffix + "@example.com"
+	addrB := "b-" + suffix + "@example.com"
+	contactA := e.newEmailContactWithMethod(t, "Contact A "+suffix, addrA)
+	contactB := e.newEmailContactWithMethod(t, "Contact B "+suffix, addrB)
+
+	inMsgID := "<in-" + suffix + "@example.com>"
+	outMsgID := "<out-" + suffix + "@example.com>"
+	e.cleanupEvents(t, "in-"+suffix+"@example.com")
+	e.cleanupEvents(t, "out-"+suffix+"@example.com")
+
+	inbound := gmailMsg("g-in", "thr-in", addrA, []string{me}, nil, nil, "Inbound subj", "hello from A", inMsgID, 1700000100000)
+	outbound := gmailMsg("g-out", "thr-out", me, []string{addrB}, nil, nil, "Outbound subj", "hi to B", outMsgID, 1700000200000)
+	e.inject(newFakeMessageStore([]*gmailapi.Message{inbound, outbound}), map[string]struct{}{me: {}})
+
+	result, err := e.provider.Sync(e.ctx, syncState(me, ""), nil)
+	require.NoError(t, err)
+	require.Equal(t, 2, result.ItemsProcessed)
+	require.Equal(t, 2, result.ItemsMatched)
+	require.Equal(t, "1700000200", result.NewCursor) // max internalDate (epoch secs)
+
+	aRows, err := e.commsRepo.ListByContact(e.ctx, contactA.ID)
+	require.NoError(t, err)
+	require.Len(t, aRows, 1)
+	require.Equal(t, "inbound", aRows[0].Direction)
+	require.Equal(t, "in-"+suffix+"@example.com", aRows[0].ExternalID)
+	require.Equal(t, "thr-in", *aRows[0].ThreadID)
+	require.Equal(t, "Inbound subj", *aRows[0].Subject)
+	require.Equal(t, "hello from A", *aRows[0].Body)
+	require.Equal(t, addrA, *aRows[0].PeerNormalized)
+	require.Equal(t, me, *aRows[0].AccountID)
+
+	bRows, err := e.commsRepo.ListByContact(e.ctx, contactB.ID)
+	require.NoError(t, err)
+	require.Len(t, bRows, 1)
+	require.Equal(t, "outbound", bRows[0].Direction)
+	require.Equal(t, addrB, *bRows[0].PeerNormalized)
+
+	inEnv, err := e.eventRepo.FindEventBySource(e.ctx, "email", "in-"+suffix+"@example.com:"+contactA.ID.String())
+	require.NoError(t, err)
+	require.Equal(t, events.KindEmailReceived, inEnv.Kind)
+	var inPayload events.EmailEventPayload
+	require.NoError(t, events.Unmarshal(inEnv, &inPayload))
+	require.Equal(t, contactA.ID, inPayload.ContactID)
+	require.Equal(t, "inbound", inPayload.Direction)
+	require.Equal(t, "thr-in", inPayload.ThreadID)
+
+	outEnv, err := e.eventRepo.FindEventBySource(e.ctx, "email", "out-"+suffix+"@example.com:"+contactB.ID.String())
+	require.NoError(t, err)
+	require.Equal(t, events.KindEmailSent, outEnv.Kind)
+}
+
+// --- §7.2.2: cross-chunk seen dedup at sweep level ---
+
+func TestGmailProvider_CrossChunkSeenDedup(t *testing.T) {
+	e := newGmailProviderEnv(t)
+	suffix := uuid.NewString()[:8]
+	me := "me-" + suffix + "@example.com"
+
+	// Many known contacts force the provider to build MORE THAN ONE OR-chunk;
+	// the query-agnostic fake returns the single spanning message for every
+	// chunk query, so the per-id seen set is what prevents a second body fetch.
+	const n = 250
+	var addrs []string
+	for i := 0; i < n; i++ {
+		addr := fmt.Sprintf("c%03d-%s@example.com", i, suffix)
+		addrs = append(addrs, addr)
+		e.newEmailContactWithMethod(t, fmt.Sprintf("Contact %03d %s", i, suffix), addr)
+	}
+
+	msgID := "<span-" + suffix + "@example.com>"
+	e.cleanupEvents(t, "span-"+suffix+"@example.com")
+	// Inbound from the first known contact to me.
+	msg := gmailMsg("g-span", "thr", addrs[0], []string{me}, nil, nil, "S", "body", msgID, 1700000300000)
+
+	store := newFakeMessageStore([]*gmailapi.Message{msg})
+	e.inject(store, map[string]struct{}{me: {}})
+
+	// Sanity: the provider must have built >1 chunk for this to be meaningful.
+	chunks := google.BuildORChunksForTest(addrs, 0)
+	require.Greater(t, len(chunks), 1, "test requires multiple OR-chunks")
+
+	_, err := e.provider.Sync(e.ctx, syncState(me, ""), nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, store.getCalls["g-span"], "body should be fetched exactly once across chunks")
+}
+
+// --- §7.2.3: match-only (unknown participant never creates a contact) ---
+
+func TestGmailProvider_MatchOnly_NoContactCreated(t *testing.T) {
+	e := newGmailProviderEnv(t)
+	suffix := uuid.NewString()[:8]
+	me := "me-" + suffix + "@example.com"
+	addrA := "a-" + suffix + "@example.com"
+	unknown := "unknown-" + suffix + "@example.com"
+	contactA := e.newEmailContactWithMethod(t, "Contact A "+suffix, addrA)
+
+	e.cleanupEvents(t, "mo-"+suffix+"@example.com")
+	msg := gmailMsg("g-mo", "thr", addrA, []string{me, unknown}, nil, nil, "S", "body", "<mo-"+suffix+"@example.com>", 1700000400000)
+	e.inject(newFakeMessageStore([]*gmailapi.Message{msg}), map[string]struct{}{me: {}})
+
+	_, err := e.provider.Sync(e.ctx, syncState(me, ""), nil)
+	require.NoError(t, err)
+
+	aRows, err := e.commsRepo.ListByContact(e.ctx, contactA.ID)
+	require.NoError(t, err)
+	require.Len(t, aRows, 1)
+
+	// The unknown address has no contact_method/contact (look it up by
+	// normalized value — assert per-query, not via a global contact count).
+	matches, err := e.identityRepo.FindContactMethodsByValue(e.ctx, []string{"email"}, unknown)
+	require.NoError(t, err)
+	require.Empty(t, matches, "unknown address must not have produced a contact")
+}
+
+// --- §7.2.4: cursor-overlap idempotency ---
+
+func TestGmailProvider_CursorOverlapIdempotent(t *testing.T) {
+	e := newGmailProviderEnv(t)
+	suffix := uuid.NewString()[:8]
+	me := "me-" + suffix + "@example.com"
+	addrA := "a-" + suffix + "@example.com"
+	contactA := e.newEmailContactWithMethod(t, "Contact A "+suffix, addrA)
+
+	e.cleanupEvents(t, "idem-"+suffix+"@example.com")
+	msg := gmailMsg("g-idem", "thr", addrA, []string{me}, nil, nil, "S", "body", "<idem-"+suffix+"@example.com>", 1700000500000)
+	e.inject(newFakeMessageStore([]*gmailapi.Message{msg}), map[string]struct{}{me: {}})
+
+	_, err := e.provider.Sync(e.ctx, syncState(me, ""), nil)
+	require.NoError(t, err)
+	_, err = e.provider.Sync(e.ctx, syncState(me, ""), nil)
+	require.NoError(t, err)
+
+	aRows, err := e.commsRepo.ListByContact(e.ctx, contactA.ID)
+	require.NoError(t, err)
+	require.Len(t, aRows, 1, "second sweep must not add a duplicate content row")
+
+	got, err := e.commsRepo.GetMessage(e.ctx, "email", "idem-"+suffix+"@example.com", contactA.ID)
+	require.NoError(t, err)
+	require.Equal(t, []string{me}, observedAccounts(t, got.SourceMetadata))
+}
+
+// --- §7.2.5: publish-before-mutate ---
+
+func TestGmailProvider_PublishBeforeMutate_RollsBack(t *testing.T) {
+	e := newGmailProviderEnv(t)
+	suffix := uuid.NewString()[:8]
+	me := "me-" + suffix + "@example.com"
+	addrA := "a-" + suffix + "@example.com"
+	contactA := e.newEmailContactWithMethod(t, "Contact A "+suffix, addrA)
+
+	e.cleanupEvents(t, "pbm-"+suffix+"@example.com")
+	msg := gmailMsg("g-pbm", "thr", addrA, []string{me}, nil, nil, "S", "body", "<pbm-"+suffix+"@example.com>", 1700000600000)
+	e.inject(newFakeMessageStore([]*gmailapi.Message{msg}), map[string]struct{}{me: {}})
+
+	e.provider.SetBusForTest(failingBus{})
+	_, err := e.provider.Sync(e.ctx, syncState(me, ""), nil)
+	require.Error(t, err, "a failing PublishTx must surface as a sync error")
+
+	aRows, err := e.commsRepo.ListByContact(e.ctx, contactA.ID)
+	require.NoError(t, err)
+	require.Empty(t, aRows, "the content upsert must have rolled back with the failed publish")
+}
+
+// --- §7.2.6: nomsgid fallback persistence ---
+
+func TestGmailProvider_NomsgidFallback(t *testing.T) {
+	e := newGmailProviderEnv(t)
+	suffix := uuid.NewString()[:8]
+	me := "me-" + suffix + "@example.com"
+	addrA := "a-" + suffix + "@example.com"
+	contactA := e.newEmailContactWithMethod(t, "Contact A "+suffix, addrA)
+
+	gmailID := "g-nomsgid-" + suffix
+	expectedExternal := "nomsgid:" + me + ":" + gmailID
+	e.cleanupEvents(t, expectedExternal)
+	msg := gmailMsg(gmailID, "thr", addrA, []string{me}, nil, nil, "S", "body", "", 1700000700000)
+	e.inject(newFakeMessageStore([]*gmailapi.Message{msg}), map[string]struct{}{me: {}})
+
+	_, err := e.provider.Sync(e.ctx, syncState(me, ""), nil)
+	require.NoError(t, err)
+
+	aRows, err := e.commsRepo.ListByContact(e.ctx, contactA.ID)
+	require.NoError(t, err)
+	require.Len(t, aRows, 1)
+	require.Equal(t, expectedExternal, aRows[0].ExternalID)
+
+	env, err := e.eventRepo.FindEventBySource(e.ctx, "email", expectedExternal+":"+contactA.ID.String())
+	require.NoError(t, err)
+	require.Equal(t, events.KindEmailReceived, env.Kind)
+}
+
+// --- §7.2.7: cursor edge cases ---
+
+func TestGmailProvider_AllBystanderSweepAdvancesCursor(t *testing.T) {
+	e := newGmailProviderEnv(t)
+	suffix := uuid.NewString()[:8]
+	me := "me-" + suffix + "@example.com"
+	addrA := "a-" + suffix + "@example.com"
+	contactA := e.newEmailContactWithMethod(t, "Contact A "+suffix, addrA)
+
+	e.cleanupEvents(t, "by-"+suffix+"@example.com")
+	// A is only co-Cc'd by a third party; thread not to/from me → bystander.
+	msg := gmailMsg("g-by", "thr", "third-"+suffix+"@example.com",
+		[]string{"other-" + suffix + "@example.com"}, []string{addrA}, nil, "S", "body", "<by-"+suffix+"@example.com>", 1700000800000)
+	e.inject(newFakeMessageStore([]*gmailapi.Message{msg}), map[string]struct{}{me: {}})
+
+	result, err := e.provider.Sync(e.ctx, syncState(me, ""), nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, result.ItemsProcessed)
+	require.Equal(t, 0, result.ItemsMatched)
+	require.Equal(t, "1700000800", result.NewCursor, "processed-but-not-persisted message still advances the cursor")
+
+	aRows, err := e.commsRepo.ListByContact(e.ctx, contactA.ID)
+	require.NoError(t, err)
+	require.Empty(t, aRows)
+}
+
+func TestGmailProvider_ZeroFetchedPreservesCursor(t *testing.T) {
+	e := newGmailProviderEnv(t)
+	suffix := uuid.NewString()[:8]
+	me := "me-" + suffix + "@example.com"
+	addrA := "a-" + suffix + "@example.com"
+	_ = e.newEmailContactWithMethod(t, "Contact A "+suffix, addrA)
+
+	e.inject(newFakeMessageStore(nil), map[string]struct{}{me: {}})
+
+	// With a prior cursor, the same value is re-written verbatim.
+	result, err := e.provider.Sync(e.ctx, syncState(me, "1699999999"), nil)
+	require.NoError(t, err)
+	require.Equal(t, "1699999999", result.NewCursor)
+
+	// With an empty prior cursor (onboarding, nothing fetched), the
+	// backfill_since epoch is written (never empty → no NULL-clear).
+	result, err = e.provider.Sync(e.ctx, syncState(me, ""), nil)
+	require.NoError(t, err)
+	expectedBackfill := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC).Unix()
+	require.Equal(t, fmt.Sprintf("%d", expectedBackfill), result.NewCursor)
+}
+
+func TestGmailProvider_HardFailureLeavesCursorUnchanged(t *testing.T) {
+	e := newGmailProviderEnv(t)
+	suffix := uuid.NewString()[:8]
+	me := "me-" + suffix + "@example.com"
+	addrA := "a-" + suffix + "@example.com"
+	contactA := e.newEmailContactWithMethod(t, "Contact A "+suffix, addrA)
+
+	e.cleanupEvents(t, "hf-"+suffix+"@example.com")
+	msg := gmailMsg("g-hf", "thr", addrA, []string{me}, nil, nil, "S", "body", "<hf-"+suffix+"@example.com>", 1700000900000)
+	store := newFakeMessageStore([]*gmailapi.Message{msg})
+	store.forcedGetErr["g-hf"] = struct{}{}
+	e.inject(store, map[string]struct{}{me: {}})
+
+	priorCursor := "1699999000"
+	result, err := e.provider.Sync(e.ctx, syncState(me, priorCursor), nil)
+	require.Error(t, err)
+	require.Equal(t, priorCursor, result.NewCursor, "hard failure must NOT advance the cursor")
+
+	aRows, err := e.commsRepo.ListByContact(e.ctx, contactA.ID)
+	require.NoError(t, err)
+	require.Empty(t, aRows)
+
+	// Clearing the failure: the re-run advances normally.
+	delete(store.forcedGetErr, "g-hf")
+	result, err = e.provider.Sync(e.ctx, syncState(me, priorCursor), nil)
+	require.NoError(t, err)
+	require.Equal(t, "1700000900", result.NewCursor)
+}
+
+// --- §7.2.8: nil-account guard ---
+
+func TestGmailProvider_NilAccount_Errors(t *testing.T) {
+	e := newGmailProviderEnv(t)
+	state := &repository.SyncState{Source: "email"}
+	result, err := e.provider.Sync(e.ctx, state, nil)
+	require.Error(t, err)
+	require.Nil(t, result)
+}
+
+// --- §7.2.9: cross-account provenance set-union MERGE ---
+
+func TestGmailProvider_CrossAccountProvenanceMerge(t *testing.T) {
+	e := newGmailProviderEnv(t)
+	suffix := uuid.NewString()[:8]
+	accountX := "x-" + suffix + "@example.com"
+	accountY := "y-" + suffix + "@example.com"
+	addrA := "a-" + suffix + "@example.com"
+	contactA := e.newEmailContactWithMethod(t, "Contact A "+suffix, addrA)
+
+	e.cleanupEvents(t, "xacct-"+suffix+"@example.com")
+	msgID := "<xacct-" + suffix + "@example.com>"
+
+	// Same RFC822 Message-ID observed in both mailboxes, with a different
+	// per-mailbox gmail id each sweep. Both accounts share the same "me" set so
+	// cross-account detection works.
+	gmailX := "gmail-x-" + suffix
+	gmailY := "gmail-y-" + suffix
+	msgX := gmailMsg(gmailX, "thr", addrA, []string{accountX}, nil, nil, "S", "body", msgID, 1700001000000)
+	msgY := gmailMsg(gmailY, "thr", addrA, []string{accountY}, nil, nil, "S", "body", msgID, 1700001000000)
+	meSet := map[string]struct{}{accountX: {}, accountY: {}}
+
+	// Sweep account X.
+	e.inject(newFakeMessageStore([]*gmailapi.Message{msgX}), meSet)
+	_, err := e.provider.Sync(e.ctx, syncState(accountX, ""), nil)
+	require.NoError(t, err)
+
+	// Sweep account Y.
+	e.inject(newFakeMessageStore([]*gmailapi.Message{msgY}), meSet)
+	_, err = e.provider.Sync(e.ctx, syncState(accountY, ""), nil)
+	require.NoError(t, err)
+
+	// Exactly one content row, provenance merged across both accounts.
+	rows, err := e.commsRepo.ListByContact(e.ctx, contactA.ID)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+
+	got, err := e.commsRepo.GetMessage(e.ctx, "email", "xacct-"+suffix+"@example.com", contactA.ID)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{accountX, accountY}, observedAccounts(t, got.SourceMetadata))
+	gmailIDs := accountGmailIDs(t, got.SourceMetadata)
+	require.Equal(t, gmailX, gmailIDs[accountX])
+	require.Equal(t, gmailY, gmailIDs[accountY])
+}

--- a/backend/tests/gmail_provider_integration_test.go
+++ b/backend/tests/gmail_provider_integration_test.go
@@ -1,4 +1,4 @@
-// End-to-end coverage for the Gmail sync provider (phase 2), driven through
+// End-to-end coverage for the inert Gmail sync provider, driven through
 // the REAL GmailSyncProvider.Sync with a real *events.Bus + database.Pool and a
 // FAKE gmailFetcher + injected M-set (no stored OAuth credential needed). The
 // in-package google tests exercise the pure helpers + processMessage; these
@@ -15,7 +15,7 @@
 //   - nil-account guard;
 //   - cross-account set-union provenance merge through the provider/upsert path.
 //
-// email.* kinds have no registered consumer in phase 2, so the bus's live river
+// email.* kinds have no registered consumer yet, so the bus's live river
 // client enqueues nothing for them — the events just land in the event-log.
 package tests
 
@@ -82,9 +82,9 @@ func newGmailProviderEnv(t *testing.T) *gmailProviderEnv {
 	eventRepo := repository.NewEventRepository(database.Queries)
 	contactService := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, contactTaskRepo, nil, nil)
 
-	// Live bus via the shared harness. For phase-2 email.* kinds enqueue no
-	// consumer jobs, so the harness's recorder/cadence/followup workers are
-	// irrelevant — the events just land in the event-log.
+	// Live bus via the shared harness. email.* kinds enqueue no consumer jobs,
+	// so the harness's recorder/cadence/followup workers are irrelevant — the
+	// events just land in the event-log.
 	bus := setupTestEventBus(t, ctx, database, contactService)
 
 	provider := google.NewGmailSyncProvider(nil, commsRepo, bus, database.Pool)
@@ -233,7 +233,7 @@ func syncState(accountID, cursor string) *repository.SyncState {
 	return st
 }
 
-// --- §7.2.1: full sweep → content rows + events ---
+// --- full sweep → content rows + events ---
 
 func TestGmailProvider_FullSweep_ContentAndEvents(t *testing.T) {
 	e := newGmailProviderEnv(t)
@@ -290,7 +290,7 @@ func TestGmailProvider_FullSweep_ContentAndEvents(t *testing.T) {
 	require.Equal(t, events.KindEmailSent, outEnv.Kind)
 }
 
-// --- §7.2.2: cross-chunk seen dedup at sweep level ---
+// --- cross-chunk seen dedup at sweep level ---
 
 func TestGmailProvider_CrossChunkSeenDedup(t *testing.T) {
 	e := newGmailProviderEnv(t)
@@ -325,7 +325,7 @@ func TestGmailProvider_CrossChunkSeenDedup(t *testing.T) {
 	require.Equal(t, 1, store.getCalls["g-span"], "body should be fetched exactly once across chunks")
 }
 
-// --- §7.2.3: match-only (unknown participant never creates a contact) ---
+// --- match-only (unknown participant never creates a contact) ---
 
 func TestGmailProvider_MatchOnly_NoContactCreated(t *testing.T) {
 	e := newGmailProviderEnv(t)
@@ -353,7 +353,7 @@ func TestGmailProvider_MatchOnly_NoContactCreated(t *testing.T) {
 	require.Empty(t, matches, "unknown address must not have produced a contact")
 }
 
-// --- §7.2.4: cursor-overlap idempotency ---
+// --- cursor-overlap idempotency ---
 
 func TestGmailProvider_CursorOverlapIdempotent(t *testing.T) {
 	e := newGmailProviderEnv(t)
@@ -380,7 +380,7 @@ func TestGmailProvider_CursorOverlapIdempotent(t *testing.T) {
 	require.Equal(t, []string{me}, observedAccounts(t, got.SourceMetadata))
 }
 
-// --- §7.2.5: publish-before-mutate ---
+// --- publish-before-mutate ---
 
 func TestGmailProvider_PublishBeforeMutate_RollsBack(t *testing.T) {
 	e := newGmailProviderEnv(t)
@@ -402,7 +402,7 @@ func TestGmailProvider_PublishBeforeMutate_RollsBack(t *testing.T) {
 	require.Empty(t, aRows, "the content upsert must have rolled back with the failed publish")
 }
 
-// --- §7.2.6: nomsgid fallback persistence ---
+// --- nomsgid fallback persistence ---
 
 func TestGmailProvider_NomsgidFallback(t *testing.T) {
 	e := newGmailProviderEnv(t)
@@ -430,7 +430,7 @@ func TestGmailProvider_NomsgidFallback(t *testing.T) {
 	require.Equal(t, events.KindEmailReceived, env.Kind)
 }
 
-// --- §7.2.7: cursor edge cases ---
+// --- cursor edge cases ---
 
 func TestGmailProvider_AllBystanderSweepAdvancesCursor(t *testing.T) {
 	e := newGmailProviderEnv(t)
@@ -507,7 +507,7 @@ func TestGmailProvider_HardFailureLeavesCursorUnchanged(t *testing.T) {
 	require.Equal(t, "1700000900", result.NewCursor)
 }
 
-// --- §7.2.8: nil-account guard ---
+// --- nil-account guard ---
 
 func TestGmailProvider_NilAccount_Errors(t *testing.T) {
 	e := newGmailProviderEnv(t)
@@ -517,7 +517,7 @@ func TestGmailProvider_NilAccount_Errors(t *testing.T) {
 	require.Nil(t, result)
 }
 
-// --- §7.2.9: cross-account provenance set-union MERGE ---
+// --- cross-account provenance set-union MERGE ---
 
 func TestGmailProvider_CrossAccountProvenanceMerge(t *testing.T) {
 	e := newGmailProviderEnv(t)


### PR DESCRIPTION
Phase 2 of 5 of the Gmail integration (#70). Builds the steady-state `GmailSyncProvider` and the email event kinds it publishes. Phase 1 (the `comms_message` table + `CommsMessageRepository` + `ListEmailIdentitiesForSync`) is already merged on `main` (#382).

**Spec (SSOT):** `.ai/spec/2026-06-01-gmail-integration-design.md` — §3 (Fetch Strategy), §4 (Direction & Aggregation), §5 (Technical Spec), §8 item 2.

## Provider is fully INERT

This phase deliberately does NOT activate anything in production:
- The provider is **not registered** in `cmd/crm-api/main.go` (registration + enablement reconciliation is phase 5).
- The new `email.received`/`email.sent` kinds have **no consumer** and **no `consumerJobsForKind` routing** (the email-interaction consumer + aggregation is phase 3). Publishing them is durable-but-unconsumed: `PublishTx` accepts the kind and inserts the event-log row, but zero consumer jobs are enqueued.

Because the provider is unregistered, nothing calls `Sync` in production, so no `email.*` events exist until phase 5.

## Changes

**Event kinds (`internal/events/kinds.go`)**
- `KindEmailReceived` / `KindEmailSent` constants + `AllKinds` membership + `kindPayloadTypes` registry rows.
- `EmailEventPayload` — one lightweight struct (ids + metadata only) serving both kinds; the full body/subject/html live in `comms_message`. Carries `LocalDay` (calendar day of `sent_at` in `time.Local`), `ThreadID`, and `Subject` so the future consumer needs no payload-version bump.
- Test guards updated: `AllKinds` count 18→20, `buildCanonicalPayload` case, an `EmailEventPayload` round-trip test, and the deferred-kinds inertness test extended to assert zero consumer jobs for the email kinds.

**Provider (`internal/google/gmail.go`)**
- Loads its own known-contact map (`normalized_email → []contact_id`) via the phase-1 `ListEmailIdentitiesForSync` (the framework's `contacts` slice is ignored).
- Byte-budgeted `(from/to/cc/bcc)` OR-chunk builder over `category:primary after:<cursor>`, with query-term sanitization so a malformed stored address can't corrupt a chunk.
- Pages `messages.list` per chunk with a per-sweep `seen` set so each id's body is fetched once across chunks.
- MIME-walks each message for body (prefer `text/plain`, else strip `text/html`) + attachment metadata (filename/mime/size, no content); inline parts with an attachment id but no filename are still recorded.
- Resolves participant direction per spec §4.1 (inbound/outbound vs the connected-account "me" set; fan-out to all contacts sharing a matched address; match-only, never creates a contact), with deterministic peer-handle precedence (To > Cc > Bcc, header order within a bucket).
- Extracts the RFC822 `Message-ID` with a deterministic `nomsgid:<account>:<gmail_id>` fallback.
- Per qualifying `(message, contact, direction)`: one tx, publish-before-mutate (publish `email.*` → upsert the `comms_message` content row via the phase-1 repository → commit). `SourceID` is per-`(message, contact)` to avoid the multi-entity `(source, source_id)` collapse.
- Cursor advance is processed-not-persisted and never returns an empty string (which would NULL-clear the stored cursor); a hard failure aborts the sweep without advancing so the `after:<prior>` window re-runs idempotently.
- OAuth is fully behind two overridable factories (`newFetcher` keyed by accountID, `newMeSet`) so tests inject a fake fetcher + me-set with no stored credential.

## Test plan

- **Unit (`internal/google/gmail_test.go`):** OR-chunk byte budgeting + sanitization, MIME extraction (plain/html/multipart/nested/attachments incl. attachment-id-only, base64url missing-padding), Message-ID + fallback, the participant matrix (inbound/outbound/cc/bcc/group/bystander), ambiguous shared-address fan-out, peer-handle precedence, `local_day` across a real-IANA-zone DST boundary, cursor helpers, nil-account.
- **Integration (`tests/gmail_provider_integration_test.go`):** full sweep → content rows + durable events; cross-chunk `seen` dedup; match-only (no contact created); cursor-overlap idempotency; publish-before-mutate rollback; `nomsgid` fallback; cursor edge cases (all-bystander advances, zero-fetched preserves, hard-failure leaves unchanged); nil-account guard; cross-account set-union provenance merge through the provider/upsert path. Uses the real DB + a real `*events.Bus` with a fake `gmailFetcher` + injected M-set (no stored OAuth credential).
- `make lint`, `make test` (unit + integration + frontend), `make test-e2e-diff`, single-file `cmd/crm-api/main.go` build, and `go build ./...` all green.

## Review

Local Codex review converged at PASS (P0=0, P1=0) after one fix round (attachment-id-only parts; comment scaffolding cleanup) plus a polish-only comment edit. The pre-push `/review-head` gate passed at `e7c8a2e` (P0=0, P1=0, P2=2, P3=3 — all non-blocking and accepted as optional/documented).