### PR TITLE
feat(email): EmailInteractionConsumer + thread-day aggregation (phase 3)

### DIFF
--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -554,6 +554,22 @@ func run() int {
 	calendarDeclineHandler := consumer.NewCalendarDeclineHandler(interactionRepo, contactRepo)
 	river.AddWorker(riverWorkers, consumer.NewCalendarDeclineHandlerWorker(eventBus, database.Pool, calendarDeclineHandler))
 
+	// Email-interaction consumer: derives a per-(contact, thread, local-day)
+	// aggregated interaction from email.received / email.sent events + their
+	// comms_message content rows. contactService fills both the
+	// interactionWriter slot (create branch) and the emailAggregator slot
+	// (found-branch extend/promote). cadenceUpdater + followUpManager are the
+	// SAME instances the InteractionRecorder uses, so the create branch's
+	// inline cadence/follow-up apply shares the durable event-claim store.
+	// Registered unconditionally — no events route to it until the Gmail
+	// provider is registered + enabled (phase 5), so it is production-inert.
+	commsMessageRepo := repository.NewCommsMessageRepository(database.Queries)
+	emailInteractionConsumer := consumer.NewEmailInteractionConsumer(
+		contactService, commsMessageRepo, interactionRepo, contactService,
+		eventBus, cadenceUpdater, followUpManager,
+	)
+	river.AddWorker(riverWorkers, consumer.NewEmailInteractionConsumerWorker(eventBus, database.Pool, emailInteractionConsumer))
+
 	// Interaction-mode wiring gate. Cutover is the normal operating
 	// posture; off is the emergency-override retained so rollback can
 	// silence publisher-driven paths without a code change. A deploy in

--- a/backend/internal/consumer/consumerjobs/args.go
+++ b/backend/internal/consumer/consumerjobs/args.go
@@ -163,6 +163,23 @@ type CalendarDeclineHandlerJobArgs struct {
 // jobs.
 func (CalendarDeclineHandlerJobArgs) Kind() string { return "calendar_decline_handler" }
 
+// EmailInteractionConsumerJobArgs carries the event id that the
+// EmailInteractionConsumer worker should fetch and process. Enqueued for
+// every email.received / email.sent event by events.consumerJobsForKind.
+// No river:"unique" tag — the event table's (source, source_id) unique
+// index collapses cross-account / cursor-overlap duplicates of the SAME
+// (message, contact) into one enqueue at publish time, so river args
+// uniqueness would add nothing. Two DISTINCT messages in the same
+// (contact, thread, day) deliberately enqueue two distinct jobs; the
+// consumer serializes them with a per-source_ref advisory lock.
+type EmailInteractionConsumerJobArgs struct {
+	EventID uuid.UUID `json:"event_id"`
+}
+
+// Kind returns the river job-kind identifier for EmailInteractionConsumer
+// jobs.
+func (EmailInteractionConsumerJobArgs) Kind() string { return "email_interaction_consumer" }
+
 // RematchDispatcherJobArgs carries the event id + dedup-arg fields that
 // the RematchDispatcher worker processes. ContactID and RematchJobID
 // are duplicated from the event payload and carry the river:"unique"

--- a/backend/internal/consumer/email_interaction.go
+++ b/backend/internal/consumer/email_interaction.go
@@ -1,0 +1,383 @@
+package consumer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"personal-crm/backend/internal/consumer/consumerjobs"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
+)
+
+// commsLocator is the subset of *repository.CommsMessageRepository the
+// email consumer depends on: locate the content row by natural key inside
+// the worker tx, and link it to the derived interaction. Interface defined
+// here (consumer-side pattern) so unit tests can stub without a DB.
+type commsLocator interface {
+	GetMessageTx(ctx context.Context, tx pgx.Tx, source, externalID string, contactID uuid.UUID) (*repository.CommsMessage, error)
+	MarkProcessedTx(ctx context.Context, tx pgx.Tx, messageIDs []uuid.UUID, interactionID uuid.UUID, sessionRef string) (int64, error)
+}
+
+// emailInteractionFinder is the subset of *repository.InteractionRepository
+// the email consumer depends on for the aggregation branch: take the
+// per-source_ref serialization lock, then find the existing aggregate.
+type emailInteractionFinder interface {
+	AcquireSourceRefLockTx(ctx context.Context, tx pgx.Tx, sourceRef string) error
+	FindBySourceRefTx(ctx context.Context, tx pgx.Tx, contactID uuid.UUID, source, sourceRef string) (*repository.Interaction, error)
+}
+
+// emailAggregator is the subset of *service.ContactService the email
+// consumer depends on for the found-branch aggregation primitives. Both
+// methods write the supplied occurred_at unconditionally + apply cadence
+// inline + publish nothing; they return a nil-safe post-commit closure.
+type emailAggregator interface {
+	PromoteInteractionToMutualTx(ctx context.Context, tx pgx.Tx, interactionID, contactID uuid.UUID, replyAt time.Time) (func(context.Context), error)
+	ExtendInteractionTx(ctx context.Context, tx pgx.Tx, interactionID, contactID uuid.UUID, direction string, occurredAt time.Time, description *string) (func(context.Context), error)
+}
+
+// EmailInteractionConsumer is the event-bus consumer for email.received /
+// email.sent. It derives a per-(contact, thread, local-calendar-day)
+// aggregated interaction from the lightweight email event + its
+// comms_message content row, in one tx (spec §4.2 / §5.2):
+//
+//  1. Take a per-source_ref advisory lock so same-key jobs serialize (the
+//     forward-only occurred_at guard is a read-compute-write and must be
+//     atomic per aggregation key).
+//  2. Locate the comms_message by natural key inside the tx.
+//  3. Branch on FindBySourceRefTx(contact, "email", source_ref):
+//     - not found → create the interaction AND publish interaction.recorded
+//     (so CadenceUpdater + FollowUpManager run — cadence delivery path #1),
+//     reusing the InteractionRecorder's package-private create sequence.
+//     - found → extend (same direction) or promote-to-mutual
+//     (direction differs), both of which apply cadence inline and publish
+//     nothing (cadence delivery path #2).
+//  4. Link the content row via MarkProcessedTx on every branch.
+//
+// Inert in production until the Gmail provider is registered + enabled
+// (phase 5): no production code publishes email.* events, so this consumer
+// only fires when a test publishes one directly.
+type EmailInteractionConsumer struct {
+	writer       interactionWriter
+	comms        commsLocator
+	interactions emailInteractionFinder
+	aggregator   emailAggregator
+	bus          eventBusTx
+	cadence      cadenceDispatcher
+	followUp     followUpDispatcher
+}
+
+// NewEmailInteractionConsumer builds the consumer with narrow interfaces so
+// unit tests can stub them. Production wires the concrete ContactService
+// (as both interactionWriter and emailAggregator), CommsMessageRepository,
+// InteractionRepository, event Bus, CadenceUpdater, and FollowUpManager.
+func NewEmailInteractionConsumer(
+	writer interactionWriter,
+	comms commsLocator,
+	interactions emailInteractionFinder,
+	aggregator emailAggregator,
+	bus eventBusTx,
+	cadence cadenceDispatcher,
+	followUp followUpDispatcher,
+) *EmailInteractionConsumer {
+	return &EmailInteractionConsumer{
+		writer:       writer,
+		comms:        comms,
+		interactions: interactions,
+		aggregator:   aggregator,
+		bus:          bus,
+		cadence:      cadence,
+		followUp:     followUp,
+	}
+}
+
+// HandleEvent processes an email.received / email.sent envelope inside the
+// caller's tx. Returns a nil-safe post-commit closure (the FollowUpManager's
+// Todoist item_update runs outside the tx per core.md rule) and an error
+// (caller rolls back). See the EmailInteractionConsumer doc comment for the
+// branch contract.
+func (c *EmailInteractionConsumer) HandleEvent(ctx context.Context, tx pgx.Tx, env *events.Envelope) (func(context.Context), error) {
+	if env == nil {
+		return nil, errors.New("email_interaction: nil envelope")
+	}
+	if tx == nil {
+		return nil, errors.New("email_interaction: nil tx")
+	}
+	if env.Kind != events.KindEmailReceived && env.Kind != events.KindEmailSent {
+		return nil, fmt.Errorf("email_interaction: unsupported kind %q", env.Kind)
+	}
+
+	var p events.EmailEventPayload
+	if err := events.Unmarshal(env, &p); err != nil {
+		return nil, fmt.Errorf("unmarshal email payload: %w", err)
+	}
+
+	// Publisher-bug guards (mirroring CalendarDeclineHandler). The publisher
+	// resolves ContactID before PublishTx; a zero value here is a bug, not a
+	// legitimate state. ExternalID is required to locate the content row.
+	// Direction is constrained to {inbound, outbound} (the kind already
+	// implies it, but defend against a malformed publisher). SentAt anchors
+	// occurred_at + the forward-only compare.
+	if p.ContactID == uuid.Nil {
+		return nil, fmt.Errorf("email_interaction: empty contact_id (event %s)", env.ID)
+	}
+	if p.ExternalID == "" {
+		return nil, fmt.Errorf("email_interaction: empty external_id (event %s)", env.ID)
+	}
+	if p.Direction != repository.InteractionDirectionInbound && p.Direction != repository.InteractionDirectionOutbound {
+		return nil, fmt.Errorf("email_interaction: direction must be %q or %q, got %q (event %s)",
+			repository.InteractionDirectionInbound, repository.InteractionDirectionOutbound, p.Direction, env.ID)
+	}
+	if p.SentAt.IsZero() {
+		return nil, fmt.Errorf("email_interaction: zero sent_at (event %s)", env.ID)
+	}
+
+	// source_ref = "<contact_uuid>:<thread_id>:<local_day>". Built from the
+	// provider-computed LocalDay (already in time.Local at publish time),
+	// NOT re-derived from SentAt — the durable event row is a complete
+	// hand-off (spec §5.2 / Decision 5). An empty ThreadID still forms an
+	// internally-consistent "<uuid>::<day>" key, unique per contact/day;
+	// Gmail always sets threadId, so this is defensive only.
+	sourceRef := p.ContactID.String() + ":" + p.ThreadID + ":" + p.LocalDay
+
+	// Per-source_ref serialization lock (Decision 8), taken BEFORE the read
+	// so the whole find → branch → write (occurred_at) → mark is atomic per
+	// aggregation key. A second same-key job blocks here until the first
+	// commits, then sees the committed aggregate on its FindBySourceRefTx and
+	// takes the found branch — so the forward-only occurred_at guard never
+	// regresses under concurrency.
+	if err := c.interactions.AcquireSourceRefLockTx(ctx, tx, sourceRef); err != nil {
+		return nil, fmt.Errorf("acquire source_ref lock: %w", err)
+	}
+
+	// Locate the content row inside the tx (Decision 2). A miss is an
+	// anomaly — publish-before-mutate commits the content row in the SAME
+	// provider tx as the event, so by the time this job runs the row is
+	// committed and visible. ErrNotFound therefore means a content-row
+	// hard-delete (test cleanup) or DB inconsistency. We return an error so
+	// River retries (a transient race self-heals; a permanent miss discards
+	// the job after MaxAttempts, the correct loud failure — we do NOT
+	// silently drop an interaction the event says should exist). Contrast
+	// CalendarDeclineHandler, which treats ErrNotFound as benign because a
+	// future-decline legitimately has no interaction yet; email has no such
+	// legitimate-miss case.
+	commsMsg, err := c.comms.GetMessageTx(ctx, tx, repository.InteractionSourceEmail, p.ExternalID, p.ContactID)
+	if err != nil {
+		return nil, fmt.Errorf("locate comms_message for email event %s: %w", env.ID, err)
+	}
+
+	found, err := c.interactions.FindBySourceRefTx(ctx, tx, p.ContactID, repository.InteractionSourceEmail, sourceRef)
+	if err != nil && !errors.Is(err, db.ErrNotFound) {
+		return nil, fmt.Errorf("find email interaction by source_ref: %w", err)
+	}
+
+	var interactionID uuid.UUID
+	var postCommit func(context.Context)
+
+	if errors.Is(err, db.ErrNotFound) {
+		// Create branch (Decision 1): reuse the InteractionRecorder's
+		// package-private create sequence so the email create path is
+		// indistinguishable from any other recorded interaction.
+		ref := sourceRef
+		req := repository.RecordInteractionRequest{
+			ContactID:   p.ContactID,
+			Source:      repository.InteractionSourceEmail,
+			SourceRef:   &ref,
+			OccurredAt:  p.SentAt,
+			Description: p.Subject,
+			Direction:   p.Direction,
+		}
+		res, recordErr := c.writer.RecordInteractionTx(ctx, tx, true, req)
+		if recordErr != nil {
+			return nil, fmt.Errorf("record email interaction: %w", recordErr)
+		}
+
+		if res.IsReplay {
+			// A concurrent same-key job created the aggregate between our
+			// outer FindBySourceRefTx (not-found) and RecordInteractionTx's
+			// own internal source_ref dedup. With the advisory lock this
+			// cannot actually happen (the second job blocks until the first
+			// commits, so its outer find already sees the row). The
+			// fall-through is the correctness backstop that keeps the create
+			// branch sound even if the lock were removed: treat res.Interaction
+			// as the found row and apply this message's extend/promote +
+			// forward-only timestamp rather than silently marking it processed
+			// (a lost-update — Decision 1 P1 fix). No second interaction.recorded
+			// is published; the found path publishes nothing.
+			pc, aggErr := c.aggregate(ctx, tx, &p, res.Interaction)
+			if aggErr != nil {
+				return nil, aggErr
+			}
+			interactionID = res.Interaction.ID
+			postCommit = pc
+		} else {
+			// Fresh write: emit interaction.recorded atomically + inline-apply
+			// cadence + follow-up, exactly as InteractionRecorder does.
+			pc, emitErr := c.emitRecorded(ctx, tx, env, &p, res, req)
+			if emitErr != nil {
+				return nil, emitErr
+			}
+			interactionID = res.Interaction.ID
+			postCommit = pc
+		}
+	} else {
+		// Found branch: extend (same direction) or promote (direction
+		// differs). Both apply cadence inline and publish nothing.
+		pc, aggErr := c.aggregate(ctx, tx, &p, found)
+		if aggErr != nil {
+			return nil, aggErr
+		}
+		interactionID = found.ID
+		postCommit = pc
+	}
+
+	// Link the content row to the interaction it rolled into, on every
+	// branch (Decision 6). Zero affected means this message's own row was
+	// already processed on a prior run (genuine re-delivery) — benign under
+	// the tx-bound read + per-key lock, so we don't error on it.
+	if _, err := c.comms.MarkProcessedTx(ctx, tx, []uuid.UUID{commsMsg.ID}, interactionID, sourceRef); err != nil {
+		return nil, fmt.Errorf("mark comms_message processed: %w", err)
+	}
+
+	return postCommit, nil
+}
+
+// aggregate applies the found-branch extend/promote to an existing
+// interaction with the forward-only timestamp guard (Decision 4). Used by
+// both the genuine found branch and the create branch's res.IsReplay
+// fall-through.
+func (c *EmailInteractionConsumer) aggregate(
+	ctx context.Context, tx pgx.Tx, p *events.EmailEventPayload, found *repository.Interaction,
+) (func(context.Context), error) {
+	// Forward-only: only advance occurred_at when SentAt is strictly later
+	// than the stored value. Equal needs no write; an earlier (out-of-order
+	// backfill) SentAt holds the stored value so occurred_at never moves
+	// backward. found.OccurredAt is already UTC (normalized by
+	// convertDbInteraction); compare in UTC.
+	ts := found.OccurredAt
+	if p.SentAt.UTC().After(found.OccurredAt) {
+		ts = p.SentAt
+	}
+
+	if p.Direction != found.Direction {
+		// Direction differs → promote to mutual. Promote flips direction
+		// even when ts == found.OccurredAt (the held value), so an
+		// out-of-order mixed-direction backfill still promotes without
+		// moving occurred_at backward.
+		pc, err := c.aggregator.PromoteInteractionToMutualTx(ctx, tx, found.ID, p.ContactID, ts)
+		if err != nil {
+			return nil, fmt.Errorf("promote email interaction to mutual: %w", err)
+		}
+		return pc, nil
+	}
+
+	pc, err := c.aggregator.ExtendInteractionTx(ctx, tx, found.ID, p.ContactID, p.Direction, ts, p.Subject)
+	if err != nil {
+		return nil, fmt.Errorf("extend email interaction: %w", err)
+	}
+	return pc, nil
+}
+
+// emitRecorded runs the InteractionRecorder's fresh-write post-record
+// sequence for the email create branch: marshal the V3 interaction.recorded
+// payload, publish it in the same tx (so CadenceUpdater + FollowUpManager
+// get enqueued — cadence delivery path #1), then inline-apply cadence +
+// follow-up (the inline apply wins the durable event claim, so the async
+// workers no-op; the recorder pattern reused verbatim). Returns the
+// follow-up's post-commit closure (nil-safe).
+func (c *EmailInteractionConsumer) emitRecorded(
+	ctx context.Context, tx pgx.Tx, env *events.Envelope, p *events.EmailEventPayload,
+	res *repository.RecordInteractionResult, req repository.RecordInteractionRequest,
+) (func(context.Context), error) {
+	// Email never suppresses follow-ups (only kind=send task completions do).
+	recordedPayload, err := marshalRecordedPayload(res.Interaction, p.Direction, req, res.PrevCadence, res.CadenceAtEmit, false)
+	if err != nil {
+		return nil, fmt.Errorf("marshal interaction.recorded: %w", err)
+	}
+	recordedEnv := &events.Envelope{
+		Source:     repository.InteractionSourceEmail,
+		SourceID:   res.Interaction.ID.String(),
+		Kind:       events.KindInteractionRecorded,
+		Payload:    recordedPayload,
+		ObservedAt: req.OccurredAt,
+	}
+	if err := c.bus.PublishTx(ctx, tx, recordedEnv); err != nil {
+		return nil, fmt.Errorf("publish interaction.recorded: %w", err)
+	}
+	if c.cadence != nil {
+		if cadenceErr := c.cadence.HandleEvent(ctx, tx, recordedEnv); cadenceErr != nil {
+			return nil, fmt.Errorf("inline apply cadence: %w", cadenceErr)
+		}
+	}
+	var followUpPostCommit func(context.Context)
+	if c.followUp != nil {
+		pc, followUpErr := c.followUp.HandleEvent(ctx, tx, recordedEnv)
+		if followUpErr != nil {
+			return nil, fmt.Errorf("inline apply follow-up: %w", followUpErr)
+		}
+		followUpPostCommit = pc
+	}
+	return followUpPostCommit, nil
+}
+
+// --------------------------------------------------------------------------
+// River worker wrapper. Mirrors InteractionRecorderWorker: fetch the
+// envelope by id, open a fresh tx, call HandleEvent, then run the returned
+// post-commit closure after the tx commits.
+// --------------------------------------------------------------------------
+
+// EmailInteractionConsumerWorker is the river worker that dispatches queued
+// EmailInteractionConsumerJobArgs to EmailInteractionConsumer.HandleEvent.
+type EmailInteractionConsumerWorker struct {
+	river.WorkerDefaults[consumerjobs.EmailInteractionConsumerJobArgs]
+	bus      eventBusTx
+	pool     *pgxpool.Pool
+	consumer *EmailInteractionConsumer
+}
+
+// NewEmailInteractionConsumerWorker wires the worker to the concrete bus,
+// the application pgxpool, and the consumer instance.
+func NewEmailInteractionConsumerWorker(bus eventBusTx, pool *pgxpool.Pool, consumer *EmailInteractionConsumer) *EmailInteractionConsumerWorker {
+	return &EmailInteractionConsumerWorker{bus: bus, pool: pool, consumer: consumer}
+}
+
+// Work implements river.Worker. Fetches the event envelope by id, opens a
+// fresh tx, invokes HandleEvent, and runs the returned post-commit closure
+// after the tx commits. On error River retries per MaxAttempts (5 from the
+// InsertOpts in events.consumerJobsForKind).
+func (w *EmailInteractionConsumerWorker) Work(ctx context.Context, j *river.Job[consumerjobs.EmailInteractionConsumerJobArgs]) error {
+	env, err := w.bus.GetEvent(ctx, j.Args.EventID)
+	if err != nil {
+		return fmt.Errorf("fetch event %s: %w", j.Args.EventID, err)
+	}
+	var postCommit func(context.Context)
+	err = pgx.BeginTxFunc(ctx, w.pool, pgx.TxOptions{}, func(tx pgx.Tx) error {
+		pc, handleErr := w.consumer.HandleEvent(ctx, tx, env)
+		if handleErr != nil {
+			return handleErr
+		}
+		postCommit = pc
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if postCommit != nil {
+		postCommit(ctx)
+	}
+	return nil
+}
+
+// Timeout bounds a single email-consumer run. A lock + read + single
+// interaction insert/extend completes in ~10ms on the Pi; 30s is ample
+// headroom for pool saturation + retries.
+func (*EmailInteractionConsumerWorker) Timeout(*river.Job[consumerjobs.EmailInteractionConsumerJobArgs]) time.Duration {
+	return 30 * time.Second
+}

--- a/backend/internal/consumer/email_interaction_test.go
+++ b/backend/internal/consumer/email_interaction_test.go
@@ -1,0 +1,594 @@
+package consumer
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+)
+
+// -----------------------------------------------------------------------------
+// Stubs for the email consumer's narrow interfaces. A shared *callSeq records
+// the global call order across stubs so we can assert the advisory lock is
+// taken BEFORE the content read / find (Decision 8).
+// -----------------------------------------------------------------------------
+
+type callSeq struct{ order []string }
+
+func (c *callSeq) record(name string) { c.order = append(c.order, name) }
+
+// stubCommsLocator stubs commsLocator. getResult (when non-nil) is returned
+// by GetMessageTx; otherwise getErr (default: a fabricated row). markAffected
+// defaults to 1.
+type stubCommsLocator struct {
+	seq *callSeq
+
+	getResult *repository.CommsMessage
+	getErr    error
+
+	getCalls    int
+	lastGetKey  [2]string // source, externalID
+	lastGetCID  uuid.UUID
+	returnedRow *repository.CommsMessage // the row handed back by GetMessageTx
+	markCalls   int
+	lastMarkIDs []uuid.UUID
+	lastMarkInt uuid.UUID
+	lastMarkRef string
+	markAffect  int64
+	markErr     error
+}
+
+func (s *stubCommsLocator) GetMessageTx(_ context.Context, _ pgx.Tx, source, externalID string, contactID uuid.UUID) (*repository.CommsMessage, error) {
+	s.getCalls++
+	if s.seq != nil {
+		s.seq.record("get")
+	}
+	s.lastGetKey = [2]string{source, externalID}
+	s.lastGetCID = contactID
+	if s.getErr != nil {
+		return nil, s.getErr
+	}
+	row := s.getResult
+	if row == nil {
+		row = &repository.CommsMessage{ID: uuid.New(), Source: source, ExternalID: externalID, MatchedContactID: contactID}
+	}
+	s.returnedRow = row
+	return row, nil
+}
+
+func (s *stubCommsLocator) MarkProcessedTx(_ context.Context, _ pgx.Tx, messageIDs []uuid.UUID, interactionID uuid.UUID, sessionRef string) (int64, error) {
+	s.markCalls++
+	if s.seq != nil {
+		s.seq.record("mark")
+	}
+	s.lastMarkIDs = messageIDs
+	s.lastMarkInt = interactionID
+	s.lastMarkRef = sessionRef
+	if s.markErr != nil {
+		return 0, s.markErr
+	}
+	return s.markAffect, nil
+}
+
+// stubEmailFinder stubs emailInteractionFinder. found (when non-nil) is
+// returned by FindBySourceRefTx; otherwise findErr (default db.ErrNotFound).
+type stubEmailFinder struct {
+	seq *callSeq
+
+	found   *repository.Interaction
+	findErr error
+	lockErr error
+
+	lockCalls   int
+	lastLockRef string
+	findCalls   int
+	lastFindKey [2]string // source, sourceRef
+	lastFindCID uuid.UUID
+}
+
+func (s *stubEmailFinder) AcquireSourceRefLockTx(_ context.Context, _ pgx.Tx, sourceRef string) error {
+	s.lockCalls++
+	if s.seq != nil {
+		s.seq.record("lock")
+	}
+	s.lastLockRef = sourceRef
+	return s.lockErr
+}
+
+func (s *stubEmailFinder) FindBySourceRefTx(_ context.Context, _ pgx.Tx, contactID uuid.UUID, source, sourceRef string) (*repository.Interaction, error) {
+	s.findCalls++
+	if s.seq != nil {
+		s.seq.record("find")
+	}
+	s.lastFindKey = [2]string{source, sourceRef}
+	s.lastFindCID = contactID
+	if s.found != nil {
+		return s.found, nil
+	}
+	if s.findErr != nil {
+		return nil, s.findErr
+	}
+	return nil, db.ErrNotFound
+}
+
+// stubEmailAggregator stubs emailAggregator, recording which method ran +
+// the args (forward-only ts assertions read lastExtendTS / lastPromoteTS).
+type stubEmailAggregator struct {
+	seq *callSeq
+
+	promoteCalls  int
+	lastPromoteID uuid.UUID
+	lastPromoteTS time.Time
+	promotePC     func(context.Context)
+	promoteErr    error
+
+	extendCalls    int
+	lastExtendID   uuid.UUID
+	lastExtendTS   time.Time
+	lastExtendDir  string
+	lastExtendDesc *string
+	extendPC       func(context.Context)
+	extendErr      error
+}
+
+func (s *stubEmailAggregator) PromoteInteractionToMutualTx(_ context.Context, _ pgx.Tx, interactionID, _ uuid.UUID, replyAt time.Time) (func(context.Context), error) {
+	s.promoteCalls++
+	if s.seq != nil {
+		s.seq.record("promote")
+	}
+	s.lastPromoteID = interactionID
+	s.lastPromoteTS = replyAt
+	return s.promotePC, s.promoteErr
+}
+
+func (s *stubEmailAggregator) ExtendInteractionTx(_ context.Context, _ pgx.Tx, interactionID, _ uuid.UUID, direction string, occurredAt time.Time, description *string) (func(context.Context), error) {
+	s.extendCalls++
+	if s.seq != nil {
+		s.seq.record("extend")
+	}
+	s.lastExtendID = interactionID
+	s.lastExtendTS = occurredAt
+	s.lastExtendDir = direction
+	s.lastExtendDesc = description
+	return s.extendPC, s.extendErr
+}
+
+// -----------------------------------------------------------------------------
+// Test fixtures.
+// -----------------------------------------------------------------------------
+
+type emailStubs struct {
+	writer     *stubWriter
+	comms      *stubCommsLocator
+	finder     *stubEmailFinder
+	aggregator *stubEmailAggregator
+	bus        *stubBus
+	cadence    *stubCadence
+	followUp   *stubFollowUpDispatcher
+	seq        *callSeq
+}
+
+func newEmailConsumerWithStubs() (*EmailInteractionConsumer, *emailStubs) {
+	seq := &callSeq{}
+	s := &emailStubs{
+		writer:     &stubWriter{},
+		comms:      &stubCommsLocator{seq: seq, markAffect: 1},
+		finder:     &stubEmailFinder{seq: seq},
+		aggregator: &stubEmailAggregator{seq: seq},
+		bus:        &stubBus{},
+		cadence:    &stubCadence{},
+		followUp:   &stubFollowUpDispatcher{},
+		seq:        seq,
+	}
+	c := NewEmailInteractionConsumer(s.writer, s.comms, s.finder, s.aggregator, s.bus, s.cadence, s.followUp)
+	return c, s
+}
+
+var (
+	emailDay  = "2026-04-10"
+	emailSent = time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+)
+
+func mustEmailEnv(t *testing.T, kind events.Kind, p events.EmailEventPayload) *events.Envelope {
+	t.Helper()
+	raw, err := events.Marshal(kind, p)
+	require.NoError(t, err)
+	return &events.Envelope{
+		ID:         uuid.New(),
+		Source:     repository.InteractionSourceEmail,
+		SourceID:   p.ExternalID + ":" + p.ContactID.String(),
+		Kind:       kind,
+		Payload:    raw,
+		ObservedAt: p.SentAt,
+	}
+}
+
+func basePayload(cid uuid.UUID, direction string) events.EmailEventPayload {
+	subject := "Re: lunch"
+	return events.EmailEventPayload{
+		Version:    1,
+		ContactID:  cid,
+		ExternalID: "<msg-1@example.test>",
+		ThreadID:   "thread-1",
+		LocalDay:   emailDay,
+		SentAt:     emailSent,
+		Direction:  direction,
+		Subject:    &subject,
+	}
+}
+
+func expectedSourceRef(cid uuid.UUID, thread, day string) string {
+	return cid.String() + ":" + thread + ":" + day
+}
+
+// -----------------------------------------------------------------------------
+// Create branch.
+// -----------------------------------------------------------------------------
+
+func TestEmailConsumer_Create_Inbound_PublishesAndApplies(t *testing.T) {
+	cid := uuid.New()
+	c, s := newEmailConsumerWithStubs()
+	p := basePayload(cid, repository.InteractionDirectionInbound)
+	env := mustEmailEnv(t, events.KindEmailReceived, p)
+
+	pc, err := c.HandleEvent(context.Background(), nonNilTx(), env)
+	require.NoError(t, err)
+	require.Nil(t, pc, "no follow-up post-commit closure on this create (stub returns nil)")
+
+	// Create path: writer ran with publishesEvent=true, source=email, the
+	// computed source_ref, occurred_at=SentAt, direction passed through.
+	require.Equal(t, 1, s.writer.calls)
+	require.True(t, s.writer.lastPublishesEvent)
+	require.Equal(t, repository.InteractionSourceEmail, s.writer.lastReq.Source)
+	require.NotNil(t, s.writer.lastReq.SourceRef)
+	require.Equal(t, expectedSourceRef(cid, "thread-1", emailDay), *s.writer.lastReq.SourceRef)
+	require.Equal(t, emailSent, s.writer.lastReq.OccurredAt)
+	require.Equal(t, repository.InteractionDirectionInbound, s.writer.lastReq.Direction)
+	require.Equal(t, p.Subject, s.writer.lastReq.Description)
+
+	// interaction.recorded published once + cadence + follow-up applied inline.
+	require.Equal(t, 1, s.bus.publishCalls)
+	require.Equal(t, events.KindInteractionRecorded, s.bus.lastEnv.Kind)
+	require.Equal(t, repository.InteractionSourceEmail, s.bus.lastEnv.Source)
+	require.Equal(t, s.writer.lastCreated.ID.String(), s.bus.lastEnv.SourceID)
+	require.Equal(t, 1, s.cadence.calls)
+	require.Equal(t, 1, s.followUp.calls)
+
+	// Found-branch primitives NOT touched on create.
+	require.Zero(t, s.aggregator.extendCalls)
+	require.Zero(t, s.aggregator.promoteCalls)
+
+	// Content row linked to the created interaction.
+	require.Equal(t, 1, s.comms.markCalls)
+	require.Equal(t, []uuid.UUID{s.comms.returnedRow.ID}, s.comms.lastMarkIDs)
+	require.Equal(t, s.writer.lastCreated.ID, s.comms.lastMarkInt)
+	require.Equal(t, expectedSourceRef(cid, "thread-1", emailDay), s.comms.lastMarkRef)
+}
+
+func TestEmailConsumer_Create_ThreadsFollowUpPostCommit(t *testing.T) {
+	cid := uuid.New()
+	c, s := newEmailConsumerWithStubs()
+	ran := false
+	s.followUp.postCommit = func(context.Context) { ran = true }
+
+	env := mustEmailEnv(t, events.KindEmailReceived, basePayload(cid, repository.InteractionDirectionInbound))
+	pc, err := c.HandleEvent(context.Background(), nonNilTx(), env)
+	require.NoError(t, err)
+	require.NotNil(t, pc, "create branch returns the follow-up post-commit closure")
+	pc(context.Background())
+	require.True(t, ran, "returned closure invokes the follow-up post-commit")
+}
+
+// -----------------------------------------------------------------------------
+// Found branch — same direction → extend; different direction → promote.
+// -----------------------------------------------------------------------------
+
+func TestEmailConsumer_Found_SameDirection_Extends(t *testing.T) {
+	cid := uuid.New()
+	c, s := newEmailConsumerWithStubs()
+	s.finder.found = &repository.Interaction{
+		ID: uuid.New(), ContactID: cid, Source: repository.InteractionSourceEmail,
+		OccurredAt: emailSent.Add(-time.Hour), Direction: repository.InteractionDirectionInbound,
+	}
+
+	env := mustEmailEnv(t, events.KindEmailReceived, basePayload(cid, repository.InteractionDirectionInbound))
+	_, err := c.HandleEvent(context.Background(), nonNilTx(), env)
+	require.NoError(t, err)
+
+	require.Zero(t, s.writer.calls, "found branch never calls RecordInteractionTx")
+	require.Zero(t, s.bus.publishCalls, "found branch publishes nothing")
+	require.Equal(t, 1, s.aggregator.extendCalls)
+	require.Zero(t, s.aggregator.promoteCalls)
+	require.Equal(t, s.finder.found.ID, s.aggregator.lastExtendID)
+	require.Equal(t, repository.InteractionDirectionInbound, s.aggregator.lastExtendDir)
+	// SentAt is later than stored → ts advances to SentAt.
+	require.Equal(t, emailSent, s.aggregator.lastExtendTS)
+	require.Equal(t, 1, s.comms.markCalls)
+	require.Equal(t, s.finder.found.ID, s.comms.lastMarkInt)
+}
+
+func TestEmailConsumer_Found_DifferentDirection_Promotes(t *testing.T) {
+	cid := uuid.New()
+	c, s := newEmailConsumerWithStubs()
+	s.finder.found = &repository.Interaction{
+		ID: uuid.New(), ContactID: cid, Source: repository.InteractionSourceEmail,
+		OccurredAt: emailSent.Add(-time.Hour), Direction: repository.InteractionDirectionInbound,
+	}
+
+	// Inbound stored, now an outbound event → promote to mutual.
+	env := mustEmailEnv(t, events.KindEmailSent, basePayload(cid, repository.InteractionDirectionOutbound))
+	_, err := c.HandleEvent(context.Background(), nonNilTx(), env)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, s.aggregator.promoteCalls)
+	require.Zero(t, s.aggregator.extendCalls)
+	require.Equal(t, s.finder.found.ID, s.aggregator.lastPromoteID)
+	require.Equal(t, emailSent, s.aggregator.lastPromoteTS)
+	require.Zero(t, s.bus.publishCalls)
+	require.Equal(t, 1, s.comms.markCalls)
+}
+
+// -----------------------------------------------------------------------------
+// Forward-only timestamp guard (Decision 4).
+// -----------------------------------------------------------------------------
+
+func TestEmailConsumer_ForwardOnly_EarlierSentAt_HoldsStoredTS(t *testing.T) {
+	cid := uuid.New()
+	c, s := newEmailConsumerWithStubs()
+	stored := emailSent // T2
+	s.finder.found = &repository.Interaction{
+		ID: uuid.New(), ContactID: cid, Source: repository.InteractionSourceEmail,
+		OccurredAt: stored, Direction: repository.InteractionDirectionInbound,
+	}
+
+	// Out-of-order backfill: earlier SentAt (T1 < T2), same direction.
+	p := basePayload(cid, repository.InteractionDirectionInbound)
+	p.SentAt = stored.Add(-2 * time.Hour)
+	p.ExternalID = "<msg-earlier@example.test>"
+	env := mustEmailEnv(t, events.KindEmailReceived, p)
+
+	_, err := c.HandleEvent(context.Background(), nonNilTx(), env)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, s.aggregator.extendCalls)
+	require.Equal(t, stored, s.aggregator.lastExtendTS, "occurred_at must NOT move backward")
+}
+
+func TestEmailConsumer_ForwardOnly_EarlierMixedDirection_PromotesButHoldsTS(t *testing.T) {
+	cid := uuid.New()
+	c, s := newEmailConsumerWithStubs()
+	stored := emailSent
+	s.finder.found = &repository.Interaction{
+		ID: uuid.New(), ContactID: cid, Source: repository.InteractionSourceEmail,
+		OccurredAt: stored, Direction: repository.InteractionDirectionInbound,
+	}
+
+	// Earlier outbound backfill → promote but hold ts (direction flips, ts held).
+	p := basePayload(cid, repository.InteractionDirectionOutbound)
+	p.SentAt = stored.Add(-2 * time.Hour)
+	env := mustEmailEnv(t, events.KindEmailSent, p)
+
+	_, err := c.HandleEvent(context.Background(), nonNilTx(), env)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, s.aggregator.promoteCalls)
+	require.Equal(t, stored, s.aggregator.lastPromoteTS, "promote holds stored ts when SentAt is earlier")
+}
+
+func TestEmailConsumer_ForwardOnly_EqualSentAt_HoldsStoredTS(t *testing.T) {
+	cid := uuid.New()
+	c, s := newEmailConsumerWithStubs()
+	s.finder.found = &repository.Interaction{
+		ID: uuid.New(), ContactID: cid, Source: repository.InteractionSourceEmail,
+		OccurredAt: emailSent, Direction: repository.InteractionDirectionInbound,
+	}
+	env := mustEmailEnv(t, events.KindEmailReceived, basePayload(cid, repository.InteractionDirectionInbound))
+
+	_, err := c.HandleEvent(context.Background(), nonNilTx(), env)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, s.aggregator.extendCalls)
+	require.Equal(t, emailSent, s.aggregator.lastExtendTS, "equal SentAt holds the stored value")
+}
+
+// -----------------------------------------------------------------------------
+// source_ref construction + lookup keys (Decision 5).
+// -----------------------------------------------------------------------------
+
+func TestEmailConsumer_SourceRef_BuiltFromLocalDay(t *testing.T) {
+	cid := uuid.New()
+	c, s := newEmailConsumerWithStubs()
+	p := basePayload(cid, repository.InteractionDirectionInbound)
+	// SentAt is a different calendar day than LocalDay to prove LocalDay
+	// (not SentAt) drives the source_ref.
+	p.SentAt = time.Date(2026, 4, 11, 1, 0, 0, 0, time.UTC)
+	env := mustEmailEnv(t, events.KindEmailReceived, p)
+
+	_, err := c.HandleEvent(context.Background(), nonNilTx(), env)
+	require.NoError(t, err)
+
+	want := expectedSourceRef(cid, "thread-1", emailDay)
+	require.Equal(t, want, s.finder.lastLockRef, "lock key = source_ref from LocalDay")
+	require.Equal(t, [2]string{repository.InteractionSourceEmail, want}, s.finder.lastFindKey)
+	require.Equal(t, cid, s.finder.lastFindCID)
+	require.NotNil(t, s.writer.lastReq.SourceRef)
+	require.Equal(t, want, *s.writer.lastReq.SourceRef)
+}
+
+func TestEmailConsumer_SourceRef_EmptyThread(t *testing.T) {
+	cid := uuid.New()
+	c, s := newEmailConsumerWithStubs()
+	p := basePayload(cid, repository.InteractionDirectionInbound)
+	p.ThreadID = ""
+	env := mustEmailEnv(t, events.KindEmailReceived, p)
+
+	_, err := c.HandleEvent(context.Background(), nonNilTx(), env)
+	require.NoError(t, err)
+	require.Equal(t, expectedSourceRef(cid, "", emailDay), s.finder.lastLockRef)
+}
+
+// -----------------------------------------------------------------------------
+// Advisory lock ordering (Decision 8) + content read (Decision 2).
+// -----------------------------------------------------------------------------
+
+func TestEmailConsumer_LockTakenBeforeReadAndFind(t *testing.T) {
+	cid := uuid.New()
+	c, s := newEmailConsumerWithStubs()
+	env := mustEmailEnv(t, events.KindEmailReceived, basePayload(cid, repository.InteractionDirectionInbound))
+
+	_, err := c.HandleEvent(context.Background(), nonNilTx(), env)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, s.finder.lockCalls)
+	require.GreaterOrEqual(t, len(s.seq.order), 3)
+	require.Equal(t, "lock", s.seq.order[0], "advisory lock must be acquired first")
+	// get + find both come after the lock.
+	lockIdx, getIdx, findIdx := indexOf(s.seq.order, "lock"), indexOf(s.seq.order, "get"), indexOf(s.seq.order, "find")
+	require.Less(t, lockIdx, getIdx, "lock before content read")
+	require.Less(t, lockIdx, findIdx, "lock before find")
+}
+
+func indexOf(xs []string, want string) int {
+	for i, x := range xs {
+		if x == want {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestEmailConsumer_GetMessageNotFound_Errors(t *testing.T) {
+	cid := uuid.New()
+	c, s := newEmailConsumerWithStubs()
+	s.comms.getErr = db.ErrNotFound
+	env := mustEmailEnv(t, events.KindEmailReceived, basePayload(cid, repository.InteractionDirectionInbound))
+
+	_, err := c.HandleEvent(context.Background(), nonNilTx(), env)
+	require.Error(t, err, "ErrNotFound on content read is error-and-retry, not benign-skip")
+	require.Zero(t, s.writer.calls, "no interaction write when content row is missing")
+	require.Zero(t, s.aggregator.extendCalls)
+	require.Zero(t, s.aggregator.promoteCalls)
+	require.Zero(t, s.comms.markCalls)
+	// Lock still taken (before the read) — proves the read happens inside the lock.
+	require.Equal(t, 1, s.finder.lockCalls)
+}
+
+// -----------------------------------------------------------------------------
+// res.IsReplay create-branch fall-through (Decision 1 P1 fix).
+// -----------------------------------------------------------------------------
+
+func TestEmailConsumer_CreateBranch_IsReplay_FallsThroughToFound(t *testing.T) {
+	cid := uuid.New()
+	c, s := newEmailConsumerWithStubs()
+	// Outer find returns not-found (so we enter the create branch), but the
+	// writer reports IsReplay=true with an existing row (a concurrent same-key
+	// create slipped past). Must fall through to extend/promote, NOT no-op.
+	existing := &repository.Interaction{
+		ID: uuid.New(), ContactID: cid, Source: repository.InteractionSourceEmail,
+		OccurredAt: emailSent.Add(-time.Hour), Direction: repository.InteractionDirectionInbound,
+	}
+	s.writer.existing = existing
+
+	env := mustEmailEnv(t, events.KindEmailReceived, basePayload(cid, repository.InteractionDirectionInbound))
+	_, err := c.HandleEvent(context.Background(), nonNilTx(), env)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, s.writer.calls, "RecordInteractionTx was attempted")
+	require.Zero(t, s.bus.publishCalls, "no second interaction.recorded on the replay fall-through")
+	require.Equal(t, 1, s.aggregator.extendCalls, "fall-through applies the extend (same direction)")
+	require.Equal(t, existing.ID, s.aggregator.lastExtendID)
+	require.Equal(t, 1, s.comms.markCalls, "content row still linked")
+	require.Equal(t, existing.ID, s.comms.lastMarkInt)
+}
+
+func TestEmailConsumer_CreateBranch_IsReplay_MixedDirection_Promotes(t *testing.T) {
+	cid := uuid.New()
+	c, s := newEmailConsumerWithStubs()
+	existing := &repository.Interaction{
+		ID: uuid.New(), ContactID: cid, Source: repository.InteractionSourceEmail,
+		OccurredAt: emailSent.Add(-time.Hour), Direction: repository.InteractionDirectionInbound,
+	}
+	s.writer.existing = existing
+
+	env := mustEmailEnv(t, events.KindEmailSent, basePayload(cid, repository.InteractionDirectionOutbound))
+	_, err := c.HandleEvent(context.Background(), nonNilTx(), env)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, s.aggregator.promoteCalls, "replay fall-through promotes on direction mismatch")
+	require.Zero(t, s.bus.publishCalls)
+}
+
+// -----------------------------------------------------------------------------
+// Publisher-bug guards (Decision 5).
+// -----------------------------------------------------------------------------
+
+func TestEmailConsumer_PublisherBugGuards_Error(t *testing.T) {
+	cid := uuid.New()
+	cases := []struct {
+		name   string
+		mutate func(*events.EmailEventPayload)
+		kind   events.Kind
+	}{
+		{"nil contact_id", func(p *events.EmailEventPayload) { p.ContactID = uuid.Nil }, events.KindEmailReceived},
+		{"empty external_id", func(p *events.EmailEventPayload) { p.ExternalID = "" }, events.KindEmailReceived},
+		{"empty direction", func(p *events.EmailEventPayload) { p.Direction = "" }, events.KindEmailReceived},
+		{"invalid direction", func(p *events.EmailEventPayload) { p.Direction = "mutual" }, events.KindEmailReceived},
+		{"zero sent_at", func(p *events.EmailEventPayload) { p.SentAt = time.Time{} }, events.KindEmailReceived},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, s := newEmailConsumerWithStubs()
+			p := basePayload(cid, repository.InteractionDirectionInbound)
+			tc.mutate(&p)
+			env := mustEmailEnv(t, tc.kind, p)
+
+			_, err := c.HandleEvent(context.Background(), nonNilTx(), env)
+			require.Error(t, err)
+			require.Zero(t, s.finder.lockCalls, "no lock taken on a malformed payload")
+			require.Zero(t, s.comms.getCalls)
+			require.Zero(t, s.writer.calls)
+		})
+	}
+}
+
+func TestEmailConsumer_NilEnvelope_Errors(t *testing.T) {
+	c, _ := newEmailConsumerWithStubs()
+	_, err := c.HandleEvent(context.Background(), nonNilTx(), nil)
+	require.Error(t, err)
+}
+
+func TestEmailConsumer_NilTx_Errors(t *testing.T) {
+	cid := uuid.New()
+	c, _ := newEmailConsumerWithStubs()
+	env := mustEmailEnv(t, events.KindEmailReceived, basePayload(cid, repository.InteractionDirectionInbound))
+	_, err := c.HandleEvent(context.Background(), nil, env)
+	require.Error(t, err)
+}
+
+func TestEmailConsumer_WrongKind_Errors(t *testing.T) {
+	c, _ := newEmailConsumerWithStubs()
+	// Hand the consumer a non-email envelope; it must reject before any work.
+	env := &events.Envelope{ID: uuid.New(), Kind: events.KindMessageReceived, Source: "telegram"}
+	_, err := c.HandleEvent(context.Background(), nonNilTx(), env)
+	require.Error(t, err)
+}
+
+// lockErr propagates as an error.
+func TestEmailConsumer_LockError_Propagates(t *testing.T) {
+	cid := uuid.New()
+	c, s := newEmailConsumerWithStubs()
+	s.finder.lockErr = errors.New("lock failed")
+	env := mustEmailEnv(t, events.KindEmailReceived, basePayload(cid, repository.InteractionDirectionInbound))
+
+	_, err := c.HandleEvent(context.Background(), nonNilTx(), env)
+	require.Error(t, err)
+	require.Zero(t, s.comms.getCalls, "no read after a failed lock")
+}

--- a/backend/internal/db/interaction.sql.go
+++ b/backend/internal/db/interaction.sql.go
@@ -11,6 +11,25 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const AcquireSourceRefAggregateLock = `-- name: AcquireSourceRefAggregateLock :exec
+SELECT pg_advisory_xact_lock(hashtextextended($1::text, 0))
+`
+
+// Takes a transaction-scoped advisory lock keyed on an interaction
+// aggregation source_ref. Used by the email-interaction consumer to
+// serialize all jobs for the same (contact, thread, local-day)
+// aggregation key, so the read-compute-write of the forward-only
+// occurred_at guard is atomic per key. The lock auto-releases on
+// commit/rollback. hashtextextended folds the source_ref string into the
+// bigint advisory-lock key space; a rare hash collision only
+// over-serializes two unrelated keys (a perf cost), never
+// under-serializes (a correctness cost). Mirrors the per-account
+// sync-enqueue lock in external_sync.sql.
+func (q *Queries) AcquireSourceRefAggregateLock(ctx context.Context, lockKey string) error {
+	_, err := q.db.Exec(ctx, AcquireSourceRefAggregateLock, lockKey)
+	return err
+}
+
 const CountContactInteractions = `-- name: CountContactInteractions :one
 SELECT COUNT(*) FROM interaction
 WHERE contact_id = $1 AND deleted_at IS NULL

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -16,6 +16,17 @@ type Querier interface {
 	// can insert a fresh log row without leaving orphan 'running' rows behind.
 	// Requires migration 037 (widens the status CHECK).
 	AbandonRunningLogsForState(ctx context.Context, syncStateID pgtype.UUID) error
+	// Takes a transaction-scoped advisory lock keyed on an interaction
+	// aggregation source_ref. Used by the email-interaction consumer to
+	// serialize all jobs for the same (contact, thread, local-day)
+	// aggregation key, so the read-compute-write of the forward-only
+	// occurred_at guard is atomic per key. The lock auto-releases on
+	// commit/rollback. hashtextextended folds the source_ref string into the
+	// bigint advisory-lock key space; a rare hash collision only
+	// over-serializes two unrelated keys (a perf cost), never
+	// under-serializes (a correctness cost). Mirrors the per-account
+	// sync-enqueue lock in external_sync.sql.
+	AcquireSourceRefAggregateLock(ctx context.Context, lockKey string) error
 	AddContactTag(ctx context.Context, arg AddContactTagParams) error
 	// Atomically appends a contact to an event's matched_contact_ids iff it isn't
 	// already present. Does NOT reset last_contacted_updated — the rematch handler

--- a/backend/internal/db/queries/interaction.sql
+++ b/backend/internal/db/queries/interaction.sql
@@ -170,3 +170,16 @@ WHERE source = 'anarlog_sessions'
   AND source_ref LIKE sqlc.arg('source_ref_prefix')
   AND deleted_at IS NULL
 ORDER BY source_ref;
+
+-- name: AcquireSourceRefAggregateLock :exec
+-- Takes a transaction-scoped advisory lock keyed on an interaction
+-- aggregation source_ref. Used by the email-interaction consumer to
+-- serialize all jobs for the same (contact, thread, local-day)
+-- aggregation key, so the read-compute-write of the forward-only
+-- occurred_at guard is atomic per key. The lock auto-releases on
+-- commit/rollback. hashtextextended folds the source_ref string into the
+-- bigint advisory-lock key space; a rare hash collision only
+-- over-serializes two unrelated keys (a perf cost), never
+-- under-serializes (a correctness cost). Mirrors the per-account
+-- sync-enqueue lock in external_sync.sql.
+SELECT pg_advisory_xact_lock(hashtextextended(sqlc.arg('lock_key')::text, 0));

--- a/backend/internal/events/bus.go
+++ b/backend/internal/events/bus.go
@@ -59,6 +59,11 @@ type consumerJob struct {
 //     MaxAttempts=5 (soft-deletes the derived gcal interaction + recomputes
 //     the contact's date columns when a calendar event is declined/
 //     cancelled/user-removed upstream).
+//   - email.received / email.sent → EmailInteractionConsumer worker with
+//     MaxAttempts=5 (derives a per-(contact, thread, local-day) aggregated
+//     email interaction). Both kinds share one case (one job each). The
+//     consumer is production-inert until the Gmail provider is registered +
+//     enabled (phase 5) — no production code publishes email.* events.
 //   - task.skipped: no consumer yet wired.
 func consumerJobsForKind(env *Envelope) ([]consumerJob, error) {
 	switch env.Kind {
@@ -71,6 +76,11 @@ func consumerJobsForKind(env *Envelope) ([]consumerJob, error) {
 	case KindCalendarDeclined:
 		return []consumerJob{{
 			Args: consumerjobs.CalendarDeclineHandlerJobArgs{EventID: env.ID},
+			Opts: &river.InsertOpts{MaxAttempts: 5},
+		}}, nil
+	case KindEmailReceived, KindEmailSent:
+		return []consumerJob{{
+			Args: consumerjobs.EmailInteractionConsumerJobArgs{EventID: env.ID},
 			Opts: &river.InsertOpts{MaxAttempts: 5},
 		}}, nil
 	case KindInteractionRecorded:

--- a/backend/internal/events/bus_test.go
+++ b/backend/internal/events/bus_test.go
@@ -88,21 +88,17 @@ func TestConsumerJobsForKind_InteractionRecordedEnqueuesCadenceAndFollowUp(t *te
 //   - interaction.manual: inline-invoked by the manual UI handler
 //     (spec §3.4 "other consumers only").
 //   - task.skipped: consumer for that kind is not yet wired.
-//   - email.received / email.sent: published by GmailSyncProvider, but the
-//     email-interaction consumer + routing land in a later phase. Until then
-//     publishing is durable-but-unconsumed — the event-log row is inserted
-//     and zero consumer jobs are enqueued.
 //
 // (contact_methods.added HAS a consumer now — see the dedicated
 // TestConsumerJobsForKind_ContactMethodsAdded tests below.
 // calendar.declined HAS a consumer now — see
-// TestConsumerJobsForKind_CalendarDeclinedEnqueuesDeclineHandler.)
+// TestConsumerJobsForKind_CalendarDeclinedEnqueuesDeclineHandler.
+// email.received / email.sent HAVE a consumer now — see
+// TestConsumerJobsForKind_EmailEnqueuesEmailConsumer.)
 func TestConsumerJobsForKind_EmptyForDeferredKinds(t *testing.T) {
 	deferred := []Kind{
 		KindInteractionManual,
 		KindTaskSkipped,
-		KindEmailReceived,
-		KindEmailSent,
 	}
 	for _, k := range deferred {
 		t.Run(string(k), func(t *testing.T) {
@@ -130,6 +126,28 @@ func TestConsumerJobsForKind_CalendarDeclinedEnqueuesDeclineHandler(t *testing.T
 	require.Equal(t, "calendar_decline_handler", args.Kind())
 	require.NotNil(t, jobs[0].Opts, "InsertOpts must be set to pin MaxAttempts")
 	require.Equal(t, 5, jobs[0].Opts.MaxAttempts)
+}
+
+// TestConsumerJobsForKind_EmailEnqueuesEmailConsumer asserts that each of
+// email.received / email.sent enqueues exactly one EmailInteractionConsumer
+// river job with MaxAttempts=5 and the event id threaded through.
+func TestConsumerJobsForKind_EmailEnqueuesEmailConsumer(t *testing.T) {
+	for _, k := range []Kind{KindEmailReceived, KindEmailSent} {
+		t.Run(string(k), func(t *testing.T) {
+			eventID := uuid.New()
+			env := &Envelope{ID: eventID, Kind: k}
+			jobs, err := consumerJobsForKind(env)
+			require.NoError(t, err)
+			require.Len(t, jobs, 1, "kind %s should enqueue exactly one consumer job", k)
+
+			args, ok := jobs[0].Args.(consumerjobs.EmailInteractionConsumerJobArgs)
+			require.True(t, ok, "job args type must be EmailInteractionConsumerJobArgs, got %T", jobs[0].Args)
+			require.Equal(t, eventID, args.EventID)
+			require.Equal(t, "email_interaction_consumer", args.Kind())
+			require.NotNil(t, jobs[0].Opts, "InsertOpts must be set to pin MaxAttempts")
+			require.Equal(t, 5, jobs[0].Opts.MaxAttempts)
+		})
+	}
 }
 
 // TestConsumerJobsForKind_ContactMethodsAdded asserts the PR 10 routing:

--- a/backend/internal/google/gmail.go
+++ b/backend/internal/google/gmail.go
@@ -150,9 +150,11 @@ type qualifiedRow struct {
 }
 
 // GmailSyncProvider implements sync.SyncProvider for Gmail. It is currently
-// inert: it is NOT registered in main.go, and although it publishes
-// email.received/email.sent, those kinds have no registered consumer yet, so
-// publishing only writes the durable event-log row.
+// inert: it is NOT registered in main.go, so the scheduler enqueues no Gmail
+// sweeps and no email.received/email.sent event is ever published in prod.
+// (The email-interaction consumer that derives interactions from those kinds
+// is wired as of phase 3, but it can only fire once this provider is
+// registered + enabled in phase 5.)
 type GmailSyncProvider struct {
 	oauthService *OAuthService
 	commsRepo    *repository.CommsMessageRepository

--- a/backend/internal/repository/comms_message.go
+++ b/backend/internal/repository/comms_message.go
@@ -217,6 +217,27 @@ func (r *CommsMessageRepository) GetMessage(ctx context.Context, source, externa
 	return &msg, nil
 }
 
+// GetMessageTx is the tx-bound variant of GetMessage. The email-interaction
+// consumer uses it so the content-row read shares the worker's tx — the
+// whole read → branch → write → mark sequence runs on one consistent
+// snapshot (the "one tx" contract). Reuses the GetCommsMessage query via
+// db.New(tx); no new SQL. Returns db.ErrNotFound on miss.
+func (r *CommsMessageRepository) GetMessageTx(ctx context.Context, tx pgx.Tx, source, externalID string, contactID uuid.UUID) (*CommsMessage, error) {
+	dbMsg, err := db.New(tx).GetCommsMessage(ctx, db.GetCommsMessageParams{
+		Source:           source,
+		ExternalID:       externalID,
+		MatchedContactID: uuidToPgUUID(contactID),
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, db.ErrNotFound
+		}
+		return nil, err
+	}
+	msg := convertDbCommsMessage(dbMsg)
+	return &msg, nil
+}
+
 // GetByID retrieves a content row by id. Returns db.ErrNotFound on miss.
 func (r *CommsMessageRepository) GetByID(ctx context.Context, id uuid.UUID) (*CommsMessage, error) {
 	dbMsg, err := r.queries.GetCommsMessageByID(ctx, uuidToPgUUID(id))

--- a/backend/internal/repository/interaction.go
+++ b/backend/internal/repository/interaction.go
@@ -429,6 +429,18 @@ func (r *InteractionRepository) CreateInteractionTx(ctx context.Context, tx pgx.
 	return &interaction, nil
 }
 
+// AcquireSourceRefLockTx takes a transaction-scoped advisory lock keyed on
+// the interaction aggregation source_ref, inside the caller's tx. The
+// email-interaction consumer calls it before FindBySourceRefTx so all jobs
+// for the same (contact, thread, local-day) aggregation key serialize: a
+// second same-key job blocks until the first commits (releasing the lock),
+// then proceeds with a fresh read. This makes the forward-only occurred_at
+// read-compute-write atomic per key. Cross-key jobs hash to different keys
+// and never block each other. The lock auto-releases on commit/rollback.
+func (r *InteractionRepository) AcquireSourceRefLockTx(ctx context.Context, tx pgx.Tx, sourceRef string) error {
+	return db.New(tx).AcquireSourceRefAggregateLock(ctx, sourceRef)
+}
+
 // FindBySourceRefTx is the tx-threaded variant of FindBySourceRef. Used by
 // the consumer's HandleEvent to dedup inside the caller's tx.
 func (r *InteractionRepository) FindBySourceRefTx(ctx context.Context, tx pgx.Tx, contactID uuid.UUID, source string, sourceRef string) (*Interaction, error) {

--- a/backend/tests/email_interaction_integration_test.go
+++ b/backend/tests/email_interaction_integration_test.go
@@ -1,0 +1,594 @@
+// End-to-end coverage for the EmailInteractionConsumer (Gmail integration
+// phase 3). Each test publishes email.received / email.sent envelopes
+// directly via the live bus (the Gmail provider is not involved — phase 3
+// tests the consumer in isolation from the fetcher) and waits for the async
+// email_interaction_consumer worker to derive a per-(contact, thread,
+// local-day) aggregated interaction. The real CadenceUpdaterWorker is wired
+// so the create branch's cadence delivery (via async interaction.recorded)
+// is observable; the FollowUpManager runs in off-mode to drain its queue
+// cleanly. All assertions go through repositories (no raw SQL); timestamps
+// are accelerated.GetCurrentTime()-anchored; addresses are placeholders.
+package tests
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/consumer"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+)
+
+// emailEnv bundles a live bus + repos + the email consumer for the
+// integration suite.
+type emailEnv struct {
+	ctx             context.Context
+	database        *db.Database
+	bus             *events.Bus
+	emailConsumer   *consumer.EmailInteractionConsumer
+	contactRepo     *repository.ContactRepository
+	interactionRepo *repository.InteractionRepository
+	commsRepo       *repository.CommsMessageRepository
+	contactService  *service.ContactService
+}
+
+func newEmailEnv(t *testing.T, ctx context.Context) *emailEnv {
+	t.Helper()
+	if os.Getenv("DATABASE_URL") == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+	database, _ := newEventBusTestDB(t, ctx)
+
+	contactRepo := repository.NewContactRepository(database.Queries)
+	contactRepo.SetPool(database.Pool)
+	contactMethodRepo := repository.NewContactMethodRepository(database.Queries)
+	interactionRepo := repository.NewInteractionRepository(database.Queries)
+	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
+	commsRepo := repository.NewCommsMessageRepository(database.Queries)
+
+	// nil bus + nil rematch: the email consumer publishes interaction.recorded
+	// through the live bus the harness builds, not through the service.
+	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, nil, nil)
+
+	bus, emailConsumer := setupTestEventBusForEmail(t, ctx, database, contactService)
+
+	return &emailEnv{
+		ctx:             ctx,
+		database:        database,
+		bus:             bus,
+		emailConsumer:   emailConsumer,
+		contactRepo:     contactRepo,
+		interactionRepo: interactionRepo,
+		commsRepo:       commsRepo,
+		contactService:  contactService,
+	}
+}
+
+// newEmailTestContact creates a contact (with a weekly cadence so contact_by
+// rolls) and registers cleanup that hard-deletes its comms_message + email
+// interaction rows then soft-deletes the contact.
+func (e *emailEnv) newEmailTestContact(t *testing.T, name string) *repository.Contact {
+	t.Helper()
+	cadence := "weekly"
+	contact, err := e.contactRepo.CreateContact(e.ctx, repository.CreateContactRequest{
+		FullName: name,
+		Cadence:  &cadence,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = e.commsRepo.HardDeleteByContact(e.ctx, contact.ID)
+		_ = e.interactionRepo.HardDeleteInteractionsBySourceRefPrefix(e.ctx, repository.InteractionSourceEmail, contact.ID.String()+":%")
+		_ = e.contactRepo.SoftDeleteContact(e.ctx, contact.ID)
+	})
+	return contact
+}
+
+// seedCommsMessage upserts a comms_message content row for the contact and
+// returns it. The consumer locates this row by natural key inside its tx.
+func (e *emailEnv) seedCommsMessage(t *testing.T, contactID uuid.UUID, externalID, threadID, direction string, sentAt time.Time) *repository.CommsMessage {
+	t.Helper()
+	thread := threadID
+	subject := "Subject " + externalID
+	body := "body"
+	peer := "peer@example.test"
+	acct := "acct-a"
+	gmailID := "gm-" + externalID
+	msg, err := e.commsRepo.UpsertMessage(e.ctx, repository.UpsertCommsMessageParams{
+		Source:           repository.InteractionSourceEmail,
+		ExternalID:       externalID,
+		ThreadID:         &thread,
+		Subject:          &subject,
+		Body:             &body,
+		PeerHandle:       &peer,
+		PeerNormalized:   &peer,
+		Direction:        direction,
+		SentAt:           sentAt,
+		AccountID:        &acct,
+		MatchedContactID: contactID,
+		GmailMessageID:   &gmailID,
+	})
+	require.NoError(t, err)
+	return msg
+}
+
+func localDay(ts time.Time) string {
+	return ts.In(time.Local).Format("2006-01-02")
+}
+
+// localNoonAnchor returns a UTC timestamp that is local noon today, so the
+// per-test +Δhours offsets (≤ a few hours) stay within ONE time.Local
+// calendar day. Anchoring naively to GetCurrentTime() risks straddling a
+// local-day boundary (e.g. 23:05 local + 2h → next day), which would split
+// what should be one thread-day aggregate into two source_refs. occurred_at
+// is still anchored to real time so cadence math behaves; we only constrain
+// the calendar day.
+func localNoonAnchor() time.Time {
+	now := accelerated.GetCurrentTime().In(time.Local)
+	noon := time.Date(now.Year(), now.Month(), now.Day(), 12, 0, 0, 0, time.Local)
+	return noon.UTC().Truncate(time.Second)
+}
+
+func (e *emailEnv) publishEmail(t *testing.T, kind events.Kind, contactID uuid.UUID, externalID, threadID, direction string, sentAt time.Time) {
+	t.Helper()
+	subject := "Subject " + externalID
+	p := events.EmailEventPayload{
+		Version:    1,
+		ContactID:  contactID,
+		ExternalID: externalID,
+		ThreadID:   threadID,
+		LocalDay:   localDay(sentAt),
+		SentAt:     sentAt,
+		Direction:  direction,
+		Subject:    &subject,
+	}
+	raw, err := events.Marshal(kind, p)
+	require.NoError(t, err)
+	env := &events.Envelope{
+		Source:     repository.InteractionSourceEmail,
+		SourceID:   externalID + ":" + contactID.String(),
+		Kind:       kind,
+		Payload:    raw,
+		ObservedAt: sentAt,
+	}
+	require.NoError(t, e.bus.Publish(e.ctx, env))
+}
+
+func sourceRefFor(contactID uuid.UUID, threadID string, sentAt time.Time) string {
+	return contactID.String() + ":" + threadID + ":" + localDay(sentAt)
+}
+
+// waitForCommsProcessed polls until the comms_message row is linked to an
+// interaction (interaction_id + processed_at set), via the repository.
+func (e *emailEnv) waitForCommsProcessed(t *testing.T, externalID string, contactID uuid.UUID, timeout time.Duration) *repository.CommsMessage {
+	t.Helper()
+	deadline := accelerated.GetCurrentTime().Add(timeout)
+	for accelerated.GetCurrentTime().Before(deadline) {
+		msg, err := e.commsRepo.GetMessage(e.ctx, repository.InteractionSourceEmail, externalID, contactID)
+		require.NoError(t, err)
+		if msg.InteractionID != nil && msg.ProcessedAt != nil {
+			return msg
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for comms_message %s to be processed for contact %s", externalID, contactID)
+	return nil
+}
+
+// --- A. Create → cadence (inbound) ------------------------------------------
+
+func TestEmailIntegration_CreateInbound_AppliesCadence(t *testing.T) {
+	ctx := context.Background()
+	e := newEmailEnv(t, ctx)
+	contact := e.newEmailTestContact(t, "Email Inbound A")
+
+	sentAt := localNoonAnchor()
+	e.seedCommsMessage(t, contact.ID, "<a-1@example.test>", "thr-A", repository.InteractionDirectionInbound, sentAt)
+	e.publishEmail(t, events.KindEmailReceived, contact.ID, "<a-1@example.test>", "thr-A", repository.InteractionDirectionInbound, sentAt)
+
+	ref := sourceRefFor(contact.ID, "thr-A", sentAt)
+	got := waitForInteractionBySourceRef(t, ctx, e.interactionRepo, contact.ID, repository.InteractionSourceEmail, ref, defaultInteractionWaitTimeout)
+	require.Equal(t, repository.InteractionDirectionInbound, got.Direction)
+	require.WithinDuration(t, sentAt, got.OccurredAt, time.Second)
+
+	msg := e.waitForCommsProcessed(t, "<a-1@example.test>", contact.ID, defaultInteractionWaitTimeout)
+	require.Equal(t, got.ID, *msg.InteractionID)
+
+	// Cadence via async interaction.recorded: last_contacted bumps for inbound.
+	c := e.waitForLastContacted(t, contact.ID, defaultInteractionWaitTimeout)
+	require.NotNil(t, c.LastContacted)
+	require.WithinDuration(t, sentAt, *c.LastContacted, time.Second)
+}
+
+// --- B. Create → cadence (outbound) -----------------------------------------
+
+func TestEmailIntegration_CreateOutbound_AppliesOutreachCadence(t *testing.T) {
+	ctx := context.Background()
+	e := newEmailEnv(t, ctx)
+	contact := e.newEmailTestContact(t, "Email Outbound B")
+
+	sentAt := localNoonAnchor()
+	e.seedCommsMessage(t, contact.ID, "<b-1@example.test>", "thr-B", repository.InteractionDirectionOutbound, sentAt)
+	e.publishEmail(t, events.KindEmailSent, contact.ID, "<b-1@example.test>", "thr-B", repository.InteractionDirectionOutbound, sentAt)
+
+	ref := sourceRefFor(contact.ID, "thr-B", sentAt)
+	got := waitForInteractionBySourceRef(t, ctx, e.interactionRepo, contact.ID, repository.InteractionSourceEmail, ref, defaultInteractionWaitTimeout)
+	require.Equal(t, repository.InteractionDirectionOutbound, got.Direction)
+
+	// Outbound: last_outreach_at bumps; last_contacted does NOT.
+	c := e.waitForLastOutreach(t, contact.ID, defaultInteractionWaitTimeout)
+	require.NotNil(t, c.LastOutreachAt)
+	require.WithinDuration(t, sentAt, *c.LastOutreachAt, time.Second)
+	require.Nil(t, c.LastContacted, "outbound email must not bump last_contacted")
+}
+
+// --- C. Same thread+day extend ----------------------------------------------
+
+func TestEmailIntegration_SameThreadDay_Extends(t *testing.T) {
+	ctx := context.Background()
+	e := newEmailEnv(t, ctx)
+	contact := e.newEmailTestContact(t, "Email Extend C")
+
+	t1 := localNoonAnchor()
+	t2 := t1.Add(2 * time.Hour)
+	e.seedCommsMessage(t, contact.ID, "<c-1@example.test>", "thr-C", repository.InteractionDirectionInbound, t1)
+	e.seedCommsMessage(t, contact.ID, "<c-2@example.test>", "thr-C", repository.InteractionDirectionInbound, t2)
+
+	e.publishEmail(t, events.KindEmailReceived, contact.ID, "<c-1@example.test>", "thr-C", repository.InteractionDirectionInbound, t1)
+	ref := sourceRefFor(contact.ID, "thr-C", t1)
+	waitForInteractionBySourceRef(t, ctx, e.interactionRepo, contact.ID, repository.InteractionSourceEmail, ref, defaultInteractionWaitTimeout)
+	e.waitForCommsProcessed(t, "<c-1@example.test>", contact.ID, defaultInteractionWaitTimeout)
+
+	e.publishEmail(t, events.KindEmailReceived, contact.ID, "<c-2@example.test>", "thr-C", repository.InteractionDirectionInbound, t2)
+	e.waitForCommsProcessed(t, "<c-2@example.test>", contact.ID, defaultInteractionWaitTimeout)
+
+	// Still exactly one interaction (extend, not a new row); occurred_at = t2.
+	rows := e.listEmailInteractions(t, contact.ID)
+	require.Len(t, rows, 1, "same thread+day extends, no new interaction")
+	require.WithinDuration(t, t2, rows[0].OccurredAt, time.Second)
+
+	// Both content rows linked to the same interaction.
+	m1, err := e.commsRepo.GetMessage(ctx, repository.InteractionSourceEmail, "<c-1@example.test>", contact.ID)
+	require.NoError(t, err)
+	m2, err := e.commsRepo.GetMessage(ctx, repository.InteractionSourceEmail, "<c-2@example.test>", contact.ID)
+	require.NoError(t, err)
+	require.NotNil(t, m1.InteractionID)
+	require.NotNil(t, m2.InteractionID)
+	require.Equal(t, *m1.InteractionID, *m2.InteractionID)
+
+	// Cadence advanced to t2.
+	c := e.waitForLastContactedAtLeast(t, contact.ID, t2, defaultInteractionWaitTimeout)
+	require.WithinDuration(t, t2, *c.LastContacted, time.Second)
+}
+
+// --- D. Next calendar day → new interaction ---------------------------------
+
+func TestEmailIntegration_NextDay_NewInteraction(t *testing.T) {
+	ctx := context.Background()
+	e := newEmailEnv(t, ctx)
+	contact := e.newEmailTestContact(t, "Email NextDay D")
+
+	dayD := localNoonAnchor()
+	dayD1 := dayD.Add(24 * time.Hour)
+	e.seedCommsMessage(t, contact.ID, "<d-1@example.test>", "thr-D", repository.InteractionDirectionInbound, dayD)
+	e.seedCommsMessage(t, contact.ID, "<d-2@example.test>", "thr-D", repository.InteractionDirectionInbound, dayD1)
+
+	e.publishEmail(t, events.KindEmailReceived, contact.ID, "<d-1@example.test>", "thr-D", repository.InteractionDirectionInbound, dayD)
+	e.publishEmail(t, events.KindEmailReceived, contact.ID, "<d-2@example.test>", "thr-D", repository.InteractionDirectionInbound, dayD1)
+	e.waitForCommsProcessed(t, "<d-1@example.test>", contact.ID, defaultInteractionWaitTimeout)
+	e.waitForCommsProcessed(t, "<d-2@example.test>", contact.ID, defaultInteractionWaitTimeout)
+
+	rows := e.waitForEmailInteractionCount(t, contact.ID, 2, defaultInteractionWaitTimeout)
+	require.Len(t, rows, 2, "distinct local days → distinct source_refs → two interactions")
+	require.NotNil(t, rows[0].SourceRef)
+	require.NotNil(t, rows[1].SourceRef)
+	require.NotEqual(t, *rows[0].SourceRef, *rows[1].SourceRef)
+}
+
+// --- E. Mixed-direction same thread+day → promote to mutual -----------------
+
+func TestEmailIntegration_MixedDirection_PromotesToMutual(t *testing.T) {
+	ctx := context.Background()
+	e := newEmailEnv(t, ctx)
+	contact := e.newEmailTestContact(t, "Email Mutual E")
+
+	t1 := localNoonAnchor()
+	t2 := t1.Add(time.Hour)
+	e.seedCommsMessage(t, contact.ID, "<e-1@example.test>", "thr-E", repository.InteractionDirectionInbound, t1)
+	e.seedCommsMessage(t, contact.ID, "<e-2@example.test>", "thr-E", repository.InteractionDirectionOutbound, t2)
+
+	e.publishEmail(t, events.KindEmailReceived, contact.ID, "<e-1@example.test>", "thr-E", repository.InteractionDirectionInbound, t1)
+	e.waitForCommsProcessed(t, "<e-1@example.test>", contact.ID, defaultInteractionWaitTimeout)
+	e.publishEmail(t, events.KindEmailSent, contact.ID, "<e-2@example.test>", "thr-E", repository.InteractionDirectionOutbound, t2)
+	e.waitForCommsProcessed(t, "<e-2@example.test>", contact.ID, defaultInteractionWaitTimeout)
+
+	rows := e.listEmailInteractions(t, contact.ID)
+	require.Len(t, rows, 1, "mixed direction same thread+day → one interaction")
+	// Eventually promoted to mutual.
+	mutated := waitForInteractionDirection(t, ctx, e.interactionRepo, contact.ID, repository.InteractionDirectionMutual, defaultInteractionWaitTimeout)
+	require.Len(t, e.filterEmail(mutated), 1)
+	require.Equal(t, repository.InteractionDirectionMutual, e.filterEmail(mutated)[0].Direction)
+	require.WithinDuration(t, t2, e.filterEmail(mutated)[0].OccurredAt, time.Second)
+
+	// Mutual bumps last_contacted to t2.
+	c := e.waitForLastContactedAtLeast(t, contact.ID, t2, defaultInteractionWaitTimeout)
+	require.WithinDuration(t, t2, *c.LastContacted, time.Second)
+}
+
+// --- F. Out-of-order backfill does NOT move occurred_at backward ------------
+
+func TestEmailIntegration_OutOfOrderBackfill_NoBackwardMove(t *testing.T) {
+	ctx := context.Background()
+	e := newEmailEnv(t, ctx)
+	contact := e.newEmailTestContact(t, "Email Backfill F")
+
+	t1 := localNoonAnchor()
+	t2 := t1.Add(3 * time.Hour)
+	e.seedCommsMessage(t, contact.ID, "<f-late@example.test>", "thr-F", repository.InteractionDirectionInbound, t2)
+	e.seedCommsMessage(t, contact.ID, "<f-early@example.test>", "thr-F", repository.InteractionDirectionInbound, t1)
+	e.seedCommsMessage(t, contact.ID, "<f-early-out@example.test>", "thr-F", repository.InteractionDirectionOutbound, t1)
+
+	// Create with the LATER SentAt first.
+	e.publishEmail(t, events.KindEmailReceived, contact.ID, "<f-late@example.test>", "thr-F", repository.InteractionDirectionInbound, t2)
+	e.waitForCommsProcessed(t, "<f-late@example.test>", contact.ID, defaultInteractionWaitTimeout)
+
+	// Earlier same-direction backfill must NOT move occurred_at back to t1.
+	e.publishEmail(t, events.KindEmailReceived, contact.ID, "<f-early@example.test>", "thr-F", repository.InteractionDirectionInbound, t1)
+	e.waitForCommsProcessed(t, "<f-early@example.test>", contact.ID, defaultInteractionWaitTimeout)
+
+	rows := e.listEmailInteractions(t, contact.ID)
+	require.Len(t, rows, 1)
+	require.WithinDuration(t, t2, rows[0].OccurredAt, time.Second, "occurred_at stays at the later T2")
+	require.Equal(t, repository.InteractionDirectionInbound, rows[0].Direction)
+
+	// Earlier mixed-direction backfill → promotes to mutual but occurred_at held at t2.
+	e.publishEmail(t, events.KindEmailSent, contact.ID, "<f-early-out@example.test>", "thr-F", repository.InteractionDirectionOutbound, t1)
+	e.waitForCommsProcessed(t, "<f-early-out@example.test>", contact.ID, defaultInteractionWaitTimeout)
+	mutated := waitForInteractionDirection(t, ctx, e.interactionRepo, contact.ID, repository.InteractionDirectionMutual, defaultInteractionWaitTimeout)
+	emailRows := e.filterEmail(mutated)
+	require.Len(t, emailRows, 1)
+	require.WithinDuration(t, t2, emailRows[0].OccurredAt, time.Second, "promote holds occurred_at at T2")
+}
+
+// --- G. Re-delivery idempotency ---------------------------------------------
+
+func TestEmailIntegration_ReDelivery_Idempotent(t *testing.T) {
+	ctx := context.Background()
+	e := newEmailEnv(t, ctx)
+	contact := e.newEmailTestContact(t, "Email Idempotent G")
+
+	sentAt := localNoonAnchor()
+	e.seedCommsMessage(t, contact.ID, "<g-1@example.test>", "thr-G", repository.InteractionDirectionInbound, sentAt)
+
+	// Publish the same (source, source_id) envelope twice — the second
+	// Publish dedups at the event-table unique index (no second enqueue).
+	e.publishEmail(t, events.KindEmailReceived, contact.ID, "<g-1@example.test>", "thr-G", repository.InteractionDirectionInbound, sentAt)
+	ref := sourceRefFor(contact.ID, "thr-G", sentAt)
+	first := waitForInteractionBySourceRef(t, ctx, e.interactionRepo, contact.ID, repository.InteractionSourceEmail, ref, defaultInteractionWaitTimeout)
+	e.waitForCommsProcessed(t, "<g-1@example.test>", contact.ID, defaultInteractionWaitTimeout)
+
+	e.publishEmail(t, events.KindEmailReceived, contact.ID, "<g-1@example.test>", "thr-G", repository.InteractionDirectionInbound, sentAt)
+	// Give any (non-)enqueued re-run a chance to run.
+	time.Sleep(500 * time.Millisecond)
+
+	rows := e.listEmailInteractions(t, contact.ID)
+	require.Len(t, rows, 1, "re-delivery does not create a duplicate interaction")
+	require.Equal(t, first.ID, rows[0].ID)
+	require.WithinDuration(t, sentAt, rows[0].OccurredAt, time.Second, "occurred_at unchanged on re-delivery")
+}
+
+// --- H. Cross-account same Message-ID → exactly one interaction -------------
+
+func TestEmailIntegration_CrossAccountSameMessageID_OneInteraction(t *testing.T) {
+	ctx := context.Background()
+	e := newEmailEnv(t, ctx)
+	contact := e.newEmailTestContact(t, "Email CrossAcct H")
+
+	sentAt := localNoonAnchor()
+	e.seedCommsMessage(t, contact.ID, "<h-shared@example.test>", "thr-H", repository.InteractionDirectionInbound, sentAt)
+
+	// Two observations of the SAME message+contact share one event source_id
+	// (<message_id>:<contact_uuid>), so the second publish dedups.
+	e.publishEmail(t, events.KindEmailReceived, contact.ID, "<h-shared@example.test>", "thr-H", repository.InteractionDirectionInbound, sentAt)
+	e.publishEmail(t, events.KindEmailReceived, contact.ID, "<h-shared@example.test>", "thr-H", repository.InteractionDirectionInbound, sentAt)
+	e.waitForCommsProcessed(t, "<h-shared@example.test>", contact.ID, defaultInteractionWaitTimeout)
+	time.Sleep(300 * time.Millisecond)
+
+	rows := e.listEmailInteractions(t, contact.ID)
+	require.Len(t, rows, 1, "cross-account same Message-ID derives exactly one interaction")
+}
+
+// --- I. Match-only: consumer never creates a contact ------------------------
+
+func TestEmailIntegration_MatchOnly_NoContactCreation(t *testing.T) {
+	ctx := context.Background()
+	e := newEmailEnv(t, ctx)
+	contact := e.newEmailTestContact(t, "Email MatchOnly I")
+
+	before := e.countContacts(t)
+
+	sentAt := localNoonAnchor()
+	e.seedCommsMessage(t, contact.ID, "<i-1@example.test>", "thr-I", repository.InteractionDirectionInbound, sentAt)
+	e.publishEmail(t, events.KindEmailReceived, contact.ID, "<i-1@example.test>", "thr-I", repository.InteractionDirectionInbound, sentAt)
+	e.waitForCommsProcessed(t, "<i-1@example.test>", contact.ID, defaultInteractionWaitTimeout)
+
+	after := e.countContacts(t)
+	require.Equal(t, before, after, "consumer derives from a known contact; it never creates one")
+}
+
+// --- J. Concurrent same-thread+day jobs do NOT move occurred_at backward ----
+
+func TestEmailIntegration_Concurrent_NoBackwardMove(t *testing.T) {
+	ctx := context.Background()
+	e := newEmailEnv(t, ctx)
+	contact := e.newEmailTestContact(t, "Email Concurrent J")
+
+	t1 := localNoonAnchor()
+	t2 := t1.Add(2 * time.Hour)
+	m1 := e.seedCommsMessage(t, contact.ID, "<j-late@example.test>", "thr-J", repository.InteractionDirectionInbound, t2)
+	m2 := e.seedCommsMessage(t, contact.ID, "<j-early@example.test>", "thr-J", repository.InteractionDirectionInbound, t1)
+
+	// Drive two HandleEvent calls concurrently on separate txs against the
+	// same pool, each with the same source_ref. The advisory lock must force
+	// one to block until the other commits; the forward-only guard then keeps
+	// occurred_at at the LATER SentAt (t2) regardless of commit interleaving.
+	envLate := e.buildEnvelope(t, events.KindEmailReceived, contact.ID, "<j-late@example.test>", "thr-J", repository.InteractionDirectionInbound, t2)
+	envEarly := e.buildEnvelope(t, events.KindEmailReceived, contact.ID, "<j-early@example.test>", "thr-J", repository.InteractionDirectionInbound, t1)
+	// Insert both event rows so GetEvent inside the worker can resolve them
+	// (publish writes the event log row; the consumer fetches by id). Here we
+	// invoke HandleEvent directly, so we just need the comms rows seeded.
+	_ = m1
+	_ = m2
+
+	errCh := make(chan error, 2)
+	run := func(env *events.Envelope) {
+		err := pgx.BeginTxFunc(ctx, e.database.Pool, pgx.TxOptions{}, func(tx pgx.Tx) error {
+			_, herr := e.emailConsumer.HandleEvent(ctx, tx, env)
+			return herr
+		})
+		errCh <- err
+	}
+	go run(envLate)
+	go run(envEarly)
+	require.NoError(t, <-errCh)
+	require.NoError(t, <-errCh)
+
+	rows := e.listEmailInteractions(t, contact.ID)
+	require.Len(t, rows, 1, "concurrent same-thread+day jobs produce exactly one interaction")
+	require.WithinDuration(t, t2, rows[0].OccurredAt, time.Second, "occurred_at = later SentAt regardless of interleaving (no backward move)")
+
+	// Both content rows linked to the one interaction.
+	g1, err := e.commsRepo.GetMessage(ctx, repository.InteractionSourceEmail, "<j-late@example.test>", contact.ID)
+	require.NoError(t, err)
+	g2, err := e.commsRepo.GetMessage(ctx, repository.InteractionSourceEmail, "<j-early@example.test>", contact.ID)
+	require.NoError(t, err)
+	require.NotNil(t, g1.InteractionID)
+	require.NotNil(t, g2.InteractionID)
+	require.Equal(t, rows[0].ID, *g1.InteractionID)
+	require.Equal(t, rows[0].ID, *g2.InteractionID)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers (repository-only; no raw SQL).
+// ---------------------------------------------------------------------------
+
+func (e *emailEnv) buildEnvelope(t *testing.T, kind events.Kind, contactID uuid.UUID, externalID, threadID, direction string, sentAt time.Time) *events.Envelope {
+	t.Helper()
+	subject := "Subject " + externalID
+	p := events.EmailEventPayload{
+		Version:    1,
+		ContactID:  contactID,
+		ExternalID: externalID,
+		ThreadID:   threadID,
+		LocalDay:   localDay(sentAt),
+		SentAt:     sentAt,
+		Direction:  direction,
+		Subject:    &subject,
+	}
+	raw, err := events.Marshal(kind, p)
+	require.NoError(t, err)
+	return &events.Envelope{
+		ID:         uuid.New(),
+		Source:     repository.InteractionSourceEmail,
+		SourceID:   externalID + ":" + contactID.String(),
+		Kind:       kind,
+		Payload:    raw,
+		ObservedAt: sentAt,
+	}
+}
+
+// listEmailInteractions returns the contact's live email interactions.
+func (e *emailEnv) listEmailInteractions(t *testing.T, contactID uuid.UUID) []repository.Interaction {
+	t.Helper()
+	rows, err := e.interactionRepo.ListContactInteractions(e.ctx, contactID, 100, 0)
+	require.NoError(t, err)
+	return e.filterEmail(rows)
+}
+
+func (e *emailEnv) filterEmail(rows []repository.Interaction) []repository.Interaction {
+	out := make([]repository.Interaction, 0, len(rows))
+	for _, r := range rows {
+		if r.Source == repository.InteractionSourceEmail {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func (e *emailEnv) waitForEmailInteractionCount(t *testing.T, contactID uuid.UUID, want int, timeout time.Duration) []repository.Interaction {
+	t.Helper()
+	deadline := accelerated.GetCurrentTime().Add(timeout)
+	var last []repository.Interaction
+	for accelerated.GetCurrentTime().Before(deadline) {
+		last = e.listEmailInteractions(t, contactID)
+		if len(last) == want {
+			return last
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d email interactions (got %d) for contact %s", want, len(last), contactID)
+	return last
+}
+
+func (e *emailEnv) waitForLastContacted(t *testing.T, contactID uuid.UUID, timeout time.Duration) *repository.Contact {
+	t.Helper()
+	deadline := accelerated.GetCurrentTime().Add(timeout)
+	for accelerated.GetCurrentTime().Before(deadline) {
+		c, err := e.contactRepo.GetContact(e.ctx, contactID)
+		require.NoError(t, err)
+		if c.LastContacted != nil {
+			return c
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for last_contacted on contact %s", contactID)
+	return nil
+}
+
+func (e *emailEnv) waitForLastContactedAtLeast(t *testing.T, contactID uuid.UUID, atLeast time.Time, timeout time.Duration) *repository.Contact {
+	t.Helper()
+	deadline := accelerated.GetCurrentTime().Add(timeout)
+	for accelerated.GetCurrentTime().Before(deadline) {
+		c, err := e.contactRepo.GetContact(e.ctx, contactID)
+		require.NoError(t, err)
+		if c.LastContacted != nil && !c.LastContacted.Before(atLeast.Add(-time.Second)) {
+			return c
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for last_contacted >= %s on contact %s", atLeast, contactID)
+	return nil
+}
+
+func (e *emailEnv) waitForLastOutreach(t *testing.T, contactID uuid.UUID, timeout time.Duration) *repository.Contact {
+	t.Helper()
+	deadline := accelerated.GetCurrentTime().Add(timeout)
+	for accelerated.GetCurrentTime().Before(deadline) {
+		c, err := e.contactRepo.GetContact(e.ctx, contactID)
+		require.NoError(t, err)
+		if c.LastOutreachAt != nil {
+			return c
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for last_outreach_at on contact %s", contactID)
+	return nil
+}
+
+func (e *emailEnv) countContacts(t *testing.T) int64 {
+	t.Helper()
+	// Empty filters → global count. Used only for a single before/after delta
+	// within ONE test; package tests run serially (no t.Parallel), so no
+	// cross-test pollution lands between the two reads.
+	n, err := e.contactRepo.CountContacts(e.ctx, "", "")
+	require.NoError(t, err)
+	return n
+}

--- a/backend/tests/gmail_provider_integration_test.go
+++ b/backend/tests/gmail_provider_integration_test.go
@@ -15,8 +15,11 @@
 //   - nil-account guard;
 //   - cross-account set-union provenance merge through the provider/upsert path.
 //
-// email.* kinds have no registered consumer yet, so the bus's live river
-// client enqueues nothing for them — the events just land in the event-log.
+// email.* kinds route to the email_interaction_consumer job (Gmail phase 3);
+// this harness registers a no-op worker for that kind so the provider's
+// publishes enqueue legally. These tests assert on the durable event-log row
+// + content rows, not the derived interaction (that is the consumer's own
+// suite, email_interaction_integration_test.go).
 package tests
 
 import (
@@ -82,9 +85,10 @@ func newGmailProviderEnv(t *testing.T) *gmailProviderEnv {
 	eventRepo := repository.NewEventRepository(database.Queries)
 	contactService := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, contactTaskRepo, nil, nil)
 
-	// Live bus via the shared harness. email.* kinds enqueue no consumer jobs,
-	// so the harness's recorder/cadence/followup workers are irrelevant — the
-	// events just land in the event-log.
+	// Live bus via the shared harness. email.* kinds enqueue an
+	// email_interaction_consumer job, drained by the harness's no-op email
+	// worker — these tests assert on the durable event-log row + content
+	// rows, not the derived interaction.
 	bus := setupTestEventBus(t, ctx, database, contactService)
 
 	provider := google.NewGmailSyncProvider(nil, commsRepo, bus, database.Pool)

--- a/backend/tests/test_event_bus_harness_test.go
+++ b/backend/tests/test_event_bus_harness_test.go
@@ -71,6 +71,13 @@ func setupTestEventBus(
 	// no-op workers drain the queue without doing any work.
 	river.AddWorker(workers, &cadenceUpdaterNoopWorker{})
 	river.AddWorker(workers, &followUpManagerNoopWorker{})
+	// email.received / email.sent now route to the email_interaction_consumer
+	// kind (Gmail phase 3). Register a no-op worker so suites that publish
+	// email.* through this harness (e.g. the Gmail provider sweep tests, which
+	// assert on the durable event + content rows, not the derived interaction)
+	// can enqueue legally. Suites that want the REAL email consumer use
+	// setupTestEventBusForEmail.
+	river.AddWorker(workers, &emailInteractionNoopWorker{})
 
 	client, err := river.NewClient(riverpgxv5.New(database.Pool), &river.Config{
 		Queues: map[string]river.QueueConfig{
@@ -154,6 +161,7 @@ func setupTestEventBusWithRematch(
 	river.AddWorker(workers, interactionShim)
 	river.AddWorker(workers, &cadenceUpdaterNoopWorker{})
 	river.AddWorker(workers, &followUpManagerNoopWorker{})
+	river.AddWorker(workers, &emailInteractionNoopWorker{})
 	rematchShim := &deferredRematchWorker{}
 	river.AddWorker(workers, rematchShim)
 
@@ -196,6 +204,164 @@ func setupTestEventBusWithRematch(
 	})
 
 	return bus
+}
+
+// setupTestEventBusForEmail wires a live river client for the email
+// integration suite with THREE real workers (vs. the noop cadence/follow-up
+// of setupTestEventBus):
+//
+//  1. EmailInteractionConsumerWorker (subject under test) — registered for
+//     the email_interaction_consumer kind.
+//  2. The REAL CadenceUpdaterWorker, wired to the SAME CadenceUpdater
+//     instance the email consumer's create branch uses inline, so the async
+//     cadence_updater job enqueued by interaction.recorded actually writes
+//     cadence columns. (In practice the create branch's inline cadence apply
+//     wins the durable claim, so the async worker no-ops — but registering
+//     the real worker exercises the claim/no-op semantics exactly as prod,
+//     and catches a regression where the inline path stops firing.)
+//  3. A REAL FollowUpManagerWorker constructed in mode=off so the
+//     followup_manager job enqueued by interaction.recorded drains cleanly
+//     without Todoist wiring. The email consumer's inline followUp dep is
+//     wired to the same off-mode manager. Cadence — not follow-up task
+//     creation — is the load-bearing phase-3 assertion (§9), so off-mode
+//     keeps the harness lean while draining the queue legally.
+//
+// Chicken-and-egg: the bus needs the email consumer (which needs the
+// contactService as writer/aggregator), and the consumer needs the bus to
+// publish interaction.recorded. Resolved with the same shim pattern as
+// setupTestEventBus. Returns the live bus + the InteractionRepository
+// (callers assert via FindBySourceRef) + the CommsMessageRepository (callers
+// seed content rows + assert interaction_id/processed_at linkage).
+func setupTestEventBusForEmail(
+	t *testing.T,
+	ctx context.Context,
+	database *db.Database,
+	contactService *service.ContactService,
+) (*events.Bus, *consumer.EmailInteractionConsumer) {
+	t.Helper()
+
+	eventRepo := repository.NewEventRepository(database.Queries)
+	contactRepo := repository.NewContactRepository(database.Queries)
+	contactRepo.SetPool(database.Pool)
+	interactionRepo := repository.NewInteractionRepository(database.Queries)
+	commsMessageRepo := repository.NewCommsMessageRepository(database.Queries)
+	claimRepo := repository.NewEventConsumerClaimRepository(database.Queries)
+
+	cfg := config.TestConfig()
+	if cfg.River.WorkerConcurrency <= 0 {
+		cfg.River.WorkerConcurrency = 4
+	}
+
+	cadenceUpdater := consumer.NewCadenceUpdater(
+		claimRepo, contactRepo, database.Queries,
+		consumer.CadenceModeCutover,
+		false,
+	)
+	contactService.SetCadenceUpdater(cadenceUpdater)
+
+	// Off-mode FollowUpManager: cutover-only Todoist deps are nil (gated on
+	// mode == cutover per NewFollowUpManager's doc comment).
+	followUpManager := consumer.NewFollowUpManager(
+		consumer.FollowUpModeOff,
+		claimRepo, contactRepo, nil, nil, interactionRepo, nil,
+		database.Pool, nil, nil, "", cfg.Watchdog,
+	)
+
+	workers := river.NewWorkers()
+	emailShim := &deferredEmailWorker{}
+	river.AddWorker(workers, emailShim)
+	cadenceShim := &deferredCadenceWorker{}
+	river.AddWorker(workers, cadenceShim)
+	followUpShim := &deferredFollowUpWorker{}
+	river.AddWorker(workers, followUpShim)
+
+	client, err := river.NewClient(riverpgxv5.New(database.Pool), &river.Config{
+		Queues: map[string]river.QueueConfig{
+			river.QueueDefault: {MaxWorkers: cfg.River.WorkerConcurrency},
+		},
+		Workers:  workers,
+		TestOnly: true,
+	})
+	require.NoError(t, err)
+
+	bus := events.NewBus(database.Pool, client, eventRepo)
+
+	emailConsumer := consumer.NewEmailInteractionConsumer(
+		contactService, commsMessageRepo, interactionRepo, contactService,
+		bus, cadenceUpdater, followUpManager,
+	)
+	emailShim.real = consumer.NewEmailInteractionConsumerWorker(bus, database.Pool, emailConsumer)
+	cadenceShim.real = consumer.NewCadenceUpdaterWorker(bus, database.Pool, cadenceUpdater)
+	followUpShim.real = consumer.NewFollowUpManagerWorker(bus, database.Pool, followUpManager)
+
+	require.NoError(t, client.Start(ctx))
+	t.Cleanup(func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer stopCancel()
+		_ = client.Stop(stopCtx)
+	})
+
+	return bus, emailConsumer
+}
+
+// deferredEmailWorker / deferredCadenceWorker / deferredFollowUpWorker mirror
+// deferredRecorderWorker: register a River worker on the bundle before the
+// real worker (which needs the bus, which needs the client) exists.
+type deferredEmailWorker struct {
+	river.WorkerDefaults[consumerjobs.EmailInteractionConsumerJobArgs]
+	real *consumer.EmailInteractionConsumerWorker
+}
+
+func (w *deferredEmailWorker) Work(ctx context.Context, j *river.Job[consumerjobs.EmailInteractionConsumerJobArgs]) error {
+	if w.real == nil {
+		return fmt.Errorf("deferredEmailWorker invoked before real worker assignment")
+	}
+	return w.real.Work(ctx, j)
+}
+
+func (w *deferredEmailWorker) Timeout(j *river.Job[consumerjobs.EmailInteractionConsumerJobArgs]) time.Duration {
+	if w.real == nil {
+		return 30 * time.Second
+	}
+	return w.real.Timeout(j)
+}
+
+type deferredCadenceWorker struct {
+	river.WorkerDefaults[consumerjobs.CadenceUpdaterJobArgs]
+	real *consumer.CadenceUpdaterWorker
+}
+
+func (w *deferredCadenceWorker) Work(ctx context.Context, j *river.Job[consumerjobs.CadenceUpdaterJobArgs]) error {
+	if w.real == nil {
+		return fmt.Errorf("deferredCadenceWorker invoked before real worker assignment")
+	}
+	return w.real.Work(ctx, j)
+}
+
+func (w *deferredCadenceWorker) Timeout(j *river.Job[consumerjobs.CadenceUpdaterJobArgs]) time.Duration {
+	if w.real == nil {
+		return 30 * time.Second
+	}
+	return w.real.Timeout(j)
+}
+
+type deferredFollowUpWorker struct {
+	river.WorkerDefaults[consumerjobs.FollowUpManagerJobArgs]
+	real *consumer.FollowUpManagerWorker
+}
+
+func (w *deferredFollowUpWorker) Work(ctx context.Context, j *river.Job[consumerjobs.FollowUpManagerJobArgs]) error {
+	if w.real == nil {
+		return fmt.Errorf("deferredFollowUpWorker invoked before real worker assignment")
+	}
+	return w.real.Work(ctx, j)
+}
+
+func (w *deferredFollowUpWorker) Timeout(j *river.Job[consumerjobs.FollowUpManagerJobArgs]) time.Duration {
+	if w.real == nil {
+		return 30 * time.Second
+	}
+	return w.real.Timeout(j)
 }
 
 // deferredRematchWorker is the rematch counterpart to
@@ -302,6 +468,22 @@ func (*followUpManagerNoopWorker) Work(_ context.Context, _ *river.Job[consumerj
 }
 
 func (*followUpManagerNoopWorker) Timeout(_ *river.Job[consumerjobs.FollowUpManagerJobArgs]) time.Duration {
+	return 30 * time.Second
+}
+
+// emailInteractionNoopWorker satisfies the email_interaction_consumer kind
+// for harnesses that publish email.* but don't exercise the real email
+// consumer (e.g. the Gmail provider sweep tests). Drains the job without DB
+// side effects.
+type emailInteractionNoopWorker struct {
+	river.WorkerDefaults[consumerjobs.EmailInteractionConsumerJobArgs]
+}
+
+func (*emailInteractionNoopWorker) Work(_ context.Context, _ *river.Job[consumerjobs.EmailInteractionConsumerJobArgs]) error {
+	return nil
+}
+
+func (*emailInteractionNoopWorker) Timeout(_ *river.Job[consumerjobs.EmailInteractionConsumerJobArgs]) time.Duration {
 	return 30 * time.Second
 }
 


### PR DESCRIPTION
Phase 3 of the Gmail integration (#70). Adds the `EmailInteractionConsumer` that consumes `email.received` / `email.sent` and derives a per-`(contact, thread, local-calendar-day)` aggregated interaction, then routes those two kinds to it. Spec (SSOT): `.ai/spec/2026-06-01-gmail-integration-design.md` (§4.2 thread+day aggregation, §4.3 cadence two-path delivery, §5.2 data flow).

## What it does

In one tx the consumer:

1. Takes a per-`source_ref` `pg_advisory_xact_lock` (xact-scoped) serializing same-`(contact, thread, day)` jobs.
2. Reads the `comms_message` content row by natural key inside the tx (`GetMessageTx`); a miss is error-and-retry (email has no legitimate-miss case).
3. Branches on `FindBySourceRefTx`:
   - **not found → create**: insert the interaction and publish `interaction.recorded` (so `CadenceUpdater` + `FollowUpManager` run — cadence delivery path #1), reusing the `InteractionRecorder`'s package-private create sequence.
   - **found → extend/promote**: same-direction extends, direction-differs promotes-to-mutual; both apply cadence inline and publish nothing (cadence delivery path #2).
4. Links the content row via `MarkProcessedTx` on every branch.

## Concurrency correctness

Two distinct messages in the same `(contact, thread, day)` produce two distinct events → two river jobs that can run concurrently. The forward-only `occurred_at` guard is a read-compute-write, and the `Update*` SQL has no `GREATEST` on `occurred_at`, so without serialization a backward `occurred_at` move was possible (a real P0 the plan caught). Fixes:

- **Per-`source_ref` advisory lock** makes find → branch → write → mark atomic per aggregation key; the second same-key job blocks until the first commits, then takes the found branch with a fresh read.
- **Forward-only guard** advances `occurred_at` only when `SentAt` is strictly later than stored, so out-of-order backfill never regresses it (and a mixed-direction backfill still promotes while holding the timestamp).
- **`res.IsReplay` create-branch fall-through** to extend/promote (instead of a silent no-op) closes the lost-update race as a second backstop.
- Cadence columns are already SQL-side `GREATEST`-guarded, so only `interaction.occurred_at` needed the lock + guard.

The integration suite includes a concurrency case (two same-thread+day jobs, later-then-earlier `SentAt`) proving exactly one interaction with `occurred_at` = the later `SentAt` regardless of interleaving — the case fails without the lock, so it is load-bearing.

## Inertness

The email kinds are now **CONSUMED** (routed to the worker, registered unconditionally in `main.go`), but the feature stays **production-INERT**: `GmailSyncProvider` is unregistered (phase 5), so the scheduler enqueues no Gmail sweeps and no `email.*` event is ever published in prod. Same posture as `CalendarDeclineHandlerWorker`.

## Changes

- New `EmailInteractionConsumer` + `EmailInteractionConsumerWorker` (`backend/internal/consumer/email_interaction.go`).
- New primitives: tx-bound `GetMessageTx`, `AcquireSourceRefAggregateLock` sqlc query + `AcquireSourceRefLockTx` wrapper, `EmailInteractionConsumerJobArgs`.
- `consumerJobsForKind` routes `email.received` / `email.sent` → the consumer (MaxAttempts=5); routing test added, kinds dropped from the deferred-kinds list.
- `main.go` constructs + registers the worker (inert).
- Shared test harness gains a no-op `email_interaction_consumer` worker so the phase-2 Gmail provider tests can enqueue legally now that the kind is routed.

## Test plan

- Unit: every branch, lock-before-read ordering, forward-only edges (earlier/equal/mixed-direction), `IsReplay` fall-through, publisher-bug guards, `source_ref` from `LocalDay`.
- Integration (cases A–J): create→cadence (in/out), same-thread+day extend, next-day new interaction, mixed-direction promote, out-of-order no-backward-move, re-delivery idempotency, cross-account single interaction, match-only, and the concurrency case.
- `make lint`, `make test`, `make test-e2e-diff` all green; pre-push full suite green.

## Review notes

`/review-head` passed (P0=0, P1=0; reviewer empirically validated the advisory-lock serialization + forward-only guard against live test Postgres). Three P2/P3 findings accepted as non-blocking — notably the P2 that extend overwrites the interaction `description` with the latest message's subject is intended/benign for store-only email and deferred. Codex's `codex exec` plan/diff gate was usage-capped this session; the gates that ran were `/review-head` + a severity-tagged self-review + the empirical PG validation.