### PR TITLE
feat(gmail): rematch fan-out + GmailRematchHandler backfill (phase 4)

### DIFF
--- a/backend/internal/google/gmail.go
+++ b/backend/internal/google/gmail.go
@@ -313,57 +313,17 @@ func (p *GmailSyncProvider) Sync(
 	}
 	chunks := buildORChunks(addresses, afterEpoch)
 
-	result := &sync.SyncResult{}
-	seen := make(map[string]struct{})
-	var maxInternalDateSecs int64
-	fetchedAny := false
-
-	for _, query := range chunks {
-		pageToken := ""
-		for {
-			refs, next, err := fetcher.ListMessageIDs(ctx, query, pageToken)
-			if err != nil {
-				// Hard failure: abort the sweep, return the prior cursor
-				// unchanged so the whole after:<prior> window re-runs.
-				return p.failResult(priorCursor), fmt.Errorf("list message ids: %w", err)
-			}
-			for _, ref := range refs {
-				if _, dup := seen[ref.ID]; dup {
-					continue // cross-chunk dedup: body already fetched this sweep
-				}
-				seen[ref.ID] = struct{}{}
-				fetchedAny = true
-
-				msg, err := fetcher.GetMessage(ctx, ref.ID)
-				if err != nil {
-					return p.failResult(priorCursor), fmt.Errorf("get message %s: %w", ref.ID, err)
-				}
-				rows, err := p.processMessage(ctx, msg, accountID, knownMap, meSet)
-				if err != nil {
-					return p.failResult(priorCursor), fmt.Errorf("process message %s: %w", ref.ID, err)
-				}
-				result.ItemsProcessed++
-
-				// Processed (even if zero qualifying rows) contributes its
-				// internalDate to the cursor advance.
-				if secs := msg.InternalDate / 1000; secs > maxInternalDateSecs {
-					maxInternalDateSecs = secs
-				}
-
-				for _, row := range rows {
-					if err := p.persistRow(ctx, row); err != nil {
-						return p.failResult(priorCursor), fmt.Errorf("persist row for message %s: %w", ref.ID, err)
-					}
-					result.ItemsMatched++
-				}
-			}
-			pageToken = next
-			if pageToken == "" {
-				break
-			}
-		}
+	processed, matched, maxInternalDateSecs, fetchedAny, err := p.scanChunks(ctx, fetcher, chunks, accountID, knownMap, meSet)
+	if err != nil {
+		// Hard failure: abort the sweep, return the prior cursor unchanged so
+		// the whole after:<prior> window re-runs next tick.
+		return p.failResult(priorCursor), fmt.Errorf("scan chunks: %w", err)
 	}
 
+	result := &sync.SyncResult{
+		ItemsProcessed: processed,
+		ItemsMatched:   matched,
+	}
 	result.NewCursor = computeNewCursor(fetchedAny, maxInternalDateSecs, priorCursorSecs, priorCursor, afterEpoch)
 
 	logger.Info().
@@ -375,6 +335,119 @@ func (p *GmailSyncProvider) Sync(
 		Msg("Gmail sync completed")
 
 	return result, nil
+}
+
+// scanChunks runs the fetch → per-call `seen` cross-chunk dedup → GetMessage →
+// processMessage → persistRow inner loop for one account against the given
+// chunk queries. It owns NEITHER cursor math NOR external_sync_state NOR
+// failResult — it returns the RAW error to the caller, which applies its own
+// failure semantics (Sync wraps it with failResult + cursor; ScanIdentifier
+// returns it directly).
+//
+// The `seen` set is created fresh INSIDE this call — a per-account, per-sweep
+// invariant (spec §3.1). Callers MUST NOT hoist it: a `seen` shared across
+// accounts would skip the same Message-ID in account B and defeat the
+// cross-account provenance merge.
+func (p *GmailSyncProvider) scanChunks(
+	ctx context.Context,
+	fetcher gmailFetcher,
+	chunks []string,
+	accountID string,
+	knownMap map[string][]uuid.UUID,
+	meSet map[string]struct{},
+) (processed, matched int, maxInternalDateSecs int64, fetchedAny bool, err error) {
+	seen := make(map[string]struct{})
+	for _, query := range chunks {
+		pageToken := ""
+		for {
+			refs, next, listErr := fetcher.ListMessageIDs(ctx, query, pageToken)
+			if listErr != nil {
+				return processed, matched, maxInternalDateSecs, fetchedAny, fmt.Errorf("list message ids: %w", listErr)
+			}
+			for _, ref := range refs {
+				if _, dup := seen[ref.ID]; dup {
+					continue // cross-chunk dedup: body already fetched this sweep
+				}
+				seen[ref.ID] = struct{}{}
+				fetchedAny = true
+
+				msg, getErr := fetcher.GetMessage(ctx, ref.ID)
+				if getErr != nil {
+					return processed, matched, maxInternalDateSecs, fetchedAny, fmt.Errorf("get message %s: %w", ref.ID, getErr)
+				}
+				rows, procErr := p.processMessage(ctx, msg, accountID, knownMap, meSet)
+				if procErr != nil {
+					return processed, matched, maxInternalDateSecs, fetchedAny, fmt.Errorf("process message %s: %w", ref.ID, procErr)
+				}
+				processed++
+
+				// Processed (even if zero qualifying rows) contributes its
+				// internalDate to the cursor advance.
+				if secs := msg.InternalDate / 1000; secs > maxInternalDateSecs {
+					maxInternalDateSecs = secs
+				}
+
+				for _, row := range rows {
+					if perr := p.persistRow(ctx, row); perr != nil {
+						return processed, matched, maxInternalDateSecs, fetchedAny, fmt.Errorf("persist row for message %s: %w", ref.ID, perr)
+					}
+					matched++
+				}
+			}
+			pageToken = next
+			if pageToken == "" {
+				break
+			}
+		}
+	}
+	return processed, matched, maxInternalDateSecs, fetchedAny, nil
+}
+
+// ScanIdentifier runs a one-shot, identifier-scoped historical Gmail scan for a
+// SINGLE normalized address against ONE connected account, reusing the
+// steady-state Sync pipeline (build chunk → list → per-sweep seen dedup →
+// GetMessage → processMessage → persistRow). It is the backfill seam for
+// GmailRematchHandler: it publishes email.received/sent + upserts comms_message
+// exactly as Sync does, but does NOT read or write external_sync_state
+// (steady-state cursors are not rewound — spec §3.3). Returns the number of
+// qualifying (message, contact) rows persisted.
+func (p *GmailSyncProvider) ScanIdentifier(
+	ctx context.Context,
+	accountID, addrNormalized string,
+	knownMap map[string][]uuid.UUID,
+	meSet map[string]struct{},
+	afterEpoch int64,
+) (matched int, err error) {
+	if p.bus == nil || p.pool == nil {
+		return 0, fmt.Errorf("gmail provider requires event bus and pool")
+	}
+
+	// A single address yields one OR-group → one chunk (or zero chunks if the
+	// address is sanitized away, e.g. malformed — nothing to scan).
+	chunks := buildORChunks([]string{addrNormalized}, afterEpoch)
+	if len(chunks) == 0 {
+		return 0, nil
+	}
+
+	fetcher, err := p.newFetcher(ctx, accountID)
+	if err != nil {
+		return 0, fmt.Errorf("build gmail fetcher: %w", err)
+	}
+
+	// scanChunks creates its own per-account `seen` set; no cursor math here.
+	_, matched, _, _, err = p.scanChunks(ctx, fetcher, chunks, accountID, knownMap, meSet)
+	if err != nil {
+		return matched, fmt.Errorf("scan identifier: %w", err)
+	}
+	return matched, nil
+}
+
+// MeSet builds the "me" set (the normalized address of every connected
+// account) via the provider's me-set factory. Exported so the rematch handler
+// can reuse the same seam tests override with SetMeSetForTest, routing an
+// injected me-set through with zero real OAuth.
+func (p *GmailSyncProvider) MeSet(ctx context.Context) (map[string]struct{}, error) {
+	return p.newMeSet(ctx)
 }
 
 // failResult returns a SyncResult that does NOT advance the cursor: NewCursor

--- a/backend/internal/google/gmail_rematch.go
+++ b/backend/internal/google/gmail_rematch.go
@@ -1,0 +1,123 @@
+package google
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	"personal-crm/backend/internal/logger"
+	"personal-crm/backend/internal/matching"
+	"personal-crm/backend/internal/repository"
+)
+
+// accountLister is the narrow account-enumeration seam the rematch handler
+// needs. Production satisfies it with *OAuthService; tests satisfy it with a
+// stub so the handler needs no real OAuth. Mirrors the consumer-side
+// narrow-interface convention.
+type accountLister interface {
+	ListAccounts(ctx context.Context) ([]repository.OAuthCredentialStatus, error)
+}
+
+// GmailRematchHandler implements service.RematchHandler for the "email"
+// identifier type. On contact_methods.added, it runs a one-shot
+// identifier-scoped historical Gmail scan across ALL connected Google accounts
+// for the newly-added address, publishing email.received/sent so the phase-3
+// EmailInteractionConsumer derives interactions. Match-only (never creates a
+// contact); fans out to every contact sharing the address. Steady-state account
+// cursors are NOT rewound (spec §3.3).
+//
+// INERT in production until phase 5: NOT registered in main.go. No production
+// code path constructs it.
+type GmailRematchHandler struct {
+	provider  *GmailSyncProvider                 // owns fetch/process/persist + bus + pool
+	accounts  accountLister                      // enumerate connected accounts (prod: *OAuthService)
+	commsRepo *repository.CommsMessageRepository // load known-contact map (ListEmailIdentitiesForSync)
+}
+
+// NewGmailRematchHandler constructs a GmailRematchHandler. Production passes the
+// *OAuthService as the accountLister.
+func NewGmailRematchHandler(p *GmailSyncProvider, accounts accountLister, comms *repository.CommsMessageRepository) *GmailRematchHandler {
+	return &GmailRematchHandler{
+		provider:  p,
+		accounts:  accounts,
+		commsRepo: comms,
+	}
+}
+
+// IdentifierType returns the contact_method type this handler binds to.
+func (h *GmailRematchHandler) IdentifierType() string { return "email" }
+
+// Rematch runs an identifier-scoped historical Gmail scan for the newly-added
+// address across every connected account. The scan is address-scoped, not
+// contact-scoped: it fans out to all contacts sharing the address via the
+// known-contact map (which already includes the just-added pair). contactID is
+// referenced only for log traceability.
+func (h *GmailRematchHandler) Rematch(ctx context.Context, contactID uuid.UUID, valueNormalized string) (int, error) {
+	// Defensive normalization, mirroring CalendarRematchHandler.
+	addr := matching.NormalizeEmail(valueNormalized)
+	if addr == "" {
+		return 0, nil
+	}
+
+	// Build the known-contact map ONCE from committed contact_method rows. The
+	// FULL map (not just {addr: [contactID]}) is required so processMessage's
+	// participant/direction resolution sees the complete A_C address set for
+	// each candidate contact — a shared address may already belong to several
+	// contacts, and a contact may have other addresses too. Reusing
+	// ListEmailIdentitiesForSync guarantees identical resolution semantics to
+	// the steady-state Sync.
+	identities, err := h.commsRepo.ListEmailIdentitiesForSync(ctx)
+	if err != nil {
+		return 0, err
+	}
+	knownMap := make(map[string][]uuid.UUID)
+	for _, id := range identities {
+		knownMap[id.ValueNormalized] = append(knownMap[id.ValueNormalized], id.ContactID)
+	}
+
+	// Build the me-set ONCE through the provider's seam (tests override it via
+	// SetMeSetForTest, so no real OAuth is touched).
+	meSet, err := h.provider.MeSet(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	// The rematch scan holds no per-account external_sync_state row and must
+	// not read/write one (spec §3.3), so it floors at the default backfill
+	// since-date directly. backfillSinceEpoch is unexported but in-package.
+	afterEpoch := backfillSinceEpoch(nil)
+
+	accounts, err := h.accounts.ListAccounts(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	matched := 0
+	allErrored := len(accounts) > 0
+	var lastErr error
+	for _, a := range accounts {
+		n, scanErr := h.provider.ScanIdentifier(ctx, a.AccountID, addr, knownMap, meSet, afterEpoch)
+		matched += n
+		if scanErr != nil {
+			// Continue-on-error: one account's Gmail outage should not fail the
+			// whole rematch (mirrors CalendarRematchHandler's housekeeping-error
+			// tolerance). Record the error in case every account fails.
+			lastErr = scanErr
+			logger.Warn().Err(scanErr).
+				Str("account", a.AccountID).
+				Str("contactId", contactID.String()).
+				Str("address", addr).
+				Msg("gmail rematch: account scan failed; continuing")
+			continue
+		}
+		allErrored = false
+	}
+
+	// Only fail the job (so River retries the whole method set) when EVERY
+	// account errored AND nothing matched — otherwise partial success returns
+	// nil and the job completes.
+	if allErrored && matched == 0 && lastErr != nil {
+		return 0, lastErr
+	}
+	return matched, nil
+}

--- a/backend/internal/service/rematch.go
+++ b/backend/internal/service/rematch.go
@@ -152,7 +152,10 @@ func (j *job) resetForRun() {
 // spawns Run on the detached context; production code publishes events
 // and relies on the consumer to dispatch.
 type RematchService struct {
-	handlers     map[string]RematchHandler
+	// handlers maps an identifier type to ALL handlers registered for it.
+	// Register appends, so a single type (e.g. "email") can fan out to
+	// multiple handlers — calendar and gmail both rematch "email" addresses.
+	handlers     map[string][]RematchHandler
 	jobs         sync.Map // uuid.UUID -> *job
 	contactLocks sync.Map // uuid.UUID -> *sync.Mutex
 
@@ -165,15 +168,18 @@ type RematchService struct {
 // Callers register handlers via Register before use.
 func NewRematchService() *RematchService {
 	return &RematchService{
-		handlers:    make(map[string]RematchHandler),
+		handlers:    make(map[string][]RematchHandler),
 		detachedCtx: func() context.Context { return context.Background() },
 	}
 }
 
 // Register adds a handler for a specific identifier type. Intended to be
-// called at startup before any jobs run.
+// called at startup before any jobs run. Multiple handlers may register for
+// the same type; each registration appends, and Run dispatches to all of
+// them in registration order.
 func (s *RematchService) Register(h RematchHandler) {
-	s.handlers[h.IdentifierType()] = h
+	t := h.IdentifierType()
+	s.handlers[t] = append(s.handlers[t], h)
 }
 
 // jobRetention bounds how long terminal jobs remain queryable via GetJob.
@@ -228,7 +234,7 @@ func (s *RematchService) EligibleMethods(methods []Method) []Method {
 	}
 	eligible := make([]Method, 0, len(methods))
 	for _, m := range methods {
-		if _, ok := s.handlers[m.Type]; ok {
+		if len(s.handlers[m.Type]) > 0 {
 			eligible = append(eligible, m)
 		}
 	}
@@ -245,7 +251,7 @@ func (s *RematchService) EligibleMethods(methods []Method) []Method {
 func (s *RematchService) StartRematchForContact(contactID uuid.UUID, methods []Method) uuid.UUID {
 	eligible := make([]Method, 0, len(methods))
 	for _, m := range methods {
-		if _, ok := s.handlers[m.Type]; ok {
+		if len(s.handlers[m.Type]) > 0 {
 			eligible = append(eligible, m)
 		}
 	}
@@ -330,20 +336,26 @@ func (s *RematchService) Run(ctx context.Context, jobID, contactID uuid.UUID, me
 	defer lock.Unlock()
 
 	for _, m := range j.methods {
-		handler, ok := s.handlers[m.Type]
-		if !ok {
+		hs := s.handlers[m.Type]
+		if len(hs) == 0 {
 			continue
 		}
-		n, handlerErr := handler.Rematch(ctx, contactID, m.Value)
-		if handlerErr != nil {
-			logger.Warn().Err(handlerErr).
-				Str("contactId", contactID.String()).
-				Str("type", m.Type).
-				Msg("rematch: handler failed")
-			j.setFailed(handlerErr)
-			return handlerErr
+		// Fan out to every handler registered for this type. Fail-fast on the
+		// first handler error (the job fails and River retries the whole method
+		// set); the matched count sums across all handlers. Handlers are
+		// idempotent, so a retry re-running an already-succeeded handler is safe.
+		for _, handler := range hs {
+			n, handlerErr := handler.Rematch(ctx, contactID, m.Value)
+			if handlerErr != nil {
+				logger.Warn().Err(handlerErr).
+					Str("contactId", contactID.String()).
+					Str("type", m.Type).
+					Msg("rematch: handler failed")
+				j.setFailed(handlerErr)
+				return handlerErr
+			}
+			j.addMatched(n)
 		}
-		j.addMatched(n)
 	}
 	j.setCompleted()
 	return nil

--- a/backend/internal/service/rematch_test.go
+++ b/backend/internal/service/rematch_test.go
@@ -330,7 +330,7 @@ func TestRun_RetryAfterFailure_ResetsState(t *testing.T) {
 	}
 
 	// Swap in a successful handler for the retry and re-run.
-	svc.handlers["email"] = &stubHandler{typ: "email", matched: 5}
+	svc.handlers["email"] = []RematchHandler{&stubHandler{typ: "email", matched: 5}}
 	if err := svc.Run(context.Background(), jobID, contactID, methods); err != nil {
 		t.Fatalf("second Run: %v", err)
 	}
@@ -522,5 +522,163 @@ func TestToRematchMethods(t *testing.T) {
 	out := toRematchMethods(in)
 	if len(out) != 2 || out[0].Value != "x@y.z" || out[1].Value != "+15551212" {
 		t.Fatalf("unexpected output: %+v", out)
+	}
+}
+
+// --- fan-out (multiple handlers per type) -----------------------------------
+
+// TestRegister_AppendsMultipleHandlersForSameType pins that Register appends
+// rather than overwrites, so a type can fan out to several handlers (calendar +
+// gmail both rematch "email").
+func TestRegister_AppendsMultipleHandlersForSameType(t *testing.T) {
+	svc := NewRematchService()
+	svc.Register(&stubHandler{typ: "email"})
+	svc.Register(&stubHandler{typ: "email"})
+	if got := len(svc.handlers["email"]); got != 2 {
+		t.Fatalf("expected 2 handlers registered for email, got %d", got)
+	}
+}
+
+// TestRun_FanOut_BothEmailHandlersFire pins that Run dispatches to every
+// handler registered for a method type and sums their matched counts.
+func TestRun_FanOut_BothEmailHandlersFire(t *testing.T) {
+	svc := NewRematchService()
+	h1 := &stubHandler{typ: "email", matched: 2}
+	h2 := &stubHandler{typ: "email", matched: 3}
+	svc.Register(h1)
+	svc.Register(h2)
+
+	jobID := uuid.New()
+	contactID := uuid.New()
+	if err := svc.Run(context.Background(), jobID, contactID, []Method{{Type: "email", Value: "a@b.c"}}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if h1.callCount() != 1 {
+		t.Fatalf("expected handler 1 to fire once, got %d", h1.callCount())
+	}
+	if h2.callCount() != 1 {
+		t.Fatalf("expected handler 2 to fire once, got %d", h2.callCount())
+	}
+	job, err := svc.GetJob(jobID)
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	if job.Status != JobStatusCompleted {
+		t.Fatalf("expected completed, got %s", job.Status)
+	}
+	if job.Matched != 5 {
+		t.Fatalf("expected Matched=5 (2+3 summed across handlers), got %d", job.Matched)
+	}
+}
+
+// TestRun_CalendarOnly_StillFires is the behavior-preserving invariant: with a
+// single handler registered for "email" (today's prod state — calendar only),
+// the refactor fires it exactly once and completes, identical to pre-refactor.
+func TestRun_CalendarOnly_StillFires(t *testing.T) {
+	svc := NewRematchService()
+	calendarLike := &stubHandler{typ: "email", matched: 7}
+	svc.Register(calendarLike)
+
+	jobID := uuid.New()
+	contactID := uuid.New()
+	if err := svc.Run(context.Background(), jobID, contactID, []Method{{Type: "email", Value: "a@b.c"}}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if calendarLike.callCount() != 1 {
+		t.Fatalf("expected the sole email handler to fire once, got %d", calendarLike.callCount())
+	}
+	job, err := svc.GetJob(jobID)
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	if job.Status != JobStatusCompleted {
+		t.Fatalf("expected completed, got %s", job.Status)
+	}
+	if job.Matched != 7 {
+		t.Fatalf("expected Matched=7, got %d", job.Matched)
+	}
+}
+
+// TestRun_FanOut_NonEmailTypesUnaffected pins that fan-out is per-type: two
+// email handlers both fire, the telegram handler fires once, and counts sum
+// correctly across types.
+func TestRun_FanOut_NonEmailTypesUnaffected(t *testing.T) {
+	svc := NewRematchService()
+	email1 := &stubHandler{typ: "email", matched: 1}
+	email2 := &stubHandler{typ: "email", matched: 1}
+	telegram := &stubHandler{typ: "telegram", matched: 4}
+	svc.Register(email1)
+	svc.Register(email2)
+	svc.Register(telegram)
+
+	jobID := uuid.New()
+	contactID := uuid.New()
+	methods := []Method{
+		{Type: "email", Value: "a@b.c"},
+		{Type: "telegram", Value: "alice"},
+	}
+	if err := svc.Run(context.Background(), jobID, contactID, methods); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if email1.callCount() != 1 || email2.callCount() != 1 {
+		t.Fatalf("expected both email handlers to fire once each, got %d and %d",
+			email1.callCount(), email2.callCount())
+	}
+	if telegram.callCount() != 1 {
+		t.Fatalf("expected telegram handler to fire once, got %d", telegram.callCount())
+	}
+	job, err := svc.GetJob(jobID)
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	if job.Matched != 6 {
+		t.Fatalf("expected Matched=6 (1+1 email + 4 telegram), got %d", job.Matched)
+	}
+}
+
+// TestRun_FanOut_FirstHandlerErrorFailsJob pins fail-fast across the fan-out:
+// the first handler's error fails the job and the second handler does NOT run.
+func TestRun_FanOut_FirstHandlerErrorFailsJob(t *testing.T) {
+	svc := NewRematchService()
+	errBoom := errors.New("boom")
+	failing := &stubHandler{typ: "email", err: errBoom}
+	second := &stubHandler{typ: "email", matched: 5}
+	svc.Register(failing)
+	svc.Register(second)
+
+	jobID := uuid.New()
+	runErr := svc.Run(context.Background(), jobID, uuid.New(), []Method{{Type: "email", Value: "a@b.c"}})
+	if !errors.Is(runErr, errBoom) {
+		t.Fatalf("expected Run to return the first handler's error, got %v", runErr)
+	}
+	if failing.callCount() != 1 {
+		t.Fatalf("expected failing handler to fire once, got %d", failing.callCount())
+	}
+	if second.callCount() != 0 {
+		t.Fatalf("expected second handler NOT to fire after fail-fast, got %d calls", second.callCount())
+	}
+	job, err := svc.GetJob(jobID)
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	if job.Status != JobStatusFailed {
+		t.Fatalf("expected failed, got %s", job.Status)
+	}
+}
+
+// TestEligibleMethods_PresenceViaSliceLen pins that the eligibility presence
+// check is len(handlers[type]) > 0 — with multiple email handlers registered,
+// email is eligible and an unhandled type (phone) is not.
+func TestEligibleMethods_PresenceViaSliceLen(t *testing.T) {
+	svc := NewRematchService()
+	svc.Register(&stubHandler{typ: "email"})
+	svc.Register(&stubHandler{typ: "email"})
+
+	got := svc.EligibleMethods([]Method{
+		{Type: "email", Value: "a@b.c"},
+		{Type: "phone", Value: "+15551212"},
+	})
+	if len(got) != 1 || got[0].Type != "email" {
+		t.Fatalf("expected only email eligible, got %+v", got)
 	}
 }

--- a/backend/tests/gmail_provider_integration_test.go
+++ b/backend/tests/gmail_provider_integration_test.go
@@ -565,3 +565,91 @@ func TestGmailProvider_CrossAccountProvenanceMerge(t *testing.T) {
 	require.Equal(t, gmailX, gmailIDs[accountX])
 	require.Equal(t, gmailY, gmailIDs[accountY])
 }
+
+// --- onboarding empty-cursor backfill window (spec §3.2) --------------------
+
+// TestGmailProvider_Onboarding_EmptyCursor_BackfillSince drives the full
+// onboarding seam through Sync end-to-end: a nil SyncCursor + a backfill_since
+// metadata override must (a) floor the scan query at the override epoch, (b)
+// persist a qualifying message dated after the floor, (c) advance the cursor to
+// the message's internalDate seconds, and (d) be idempotent on a second sweep
+// with the returned cursor. Complements (does not duplicate) the resolveAfterFloor
+// / computeNewCursor helper unit tests, which exercise the functions in isolation.
+func TestGmailProvider_Onboarding_EmptyCursor_BackfillSince(t *testing.T) {
+	e := newGmailProviderEnv(t)
+	suffix := uuid.NewString()[:8]
+	me := "me-" + suffix + "@example.com"
+	addrA := "a-" + suffix + "@example.com"
+	contactA := e.newEmailContactWithMethod(t, "Contact A "+suffix, addrA)
+
+	ext := "onb-" + suffix + "@example.com"
+	e.cleanupEvents(t, ext)
+
+	// backfill_since override floors the scan at 2026-03-01.
+	override := "2026-03-01"
+	overrideEpoch := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC).Unix()
+	// A message dated AFTER the floor must be scanned and persisted.
+	msgEpochSecs := time.Date(2026, 3, 15, 9, 0, 0, 0, time.UTC).Unix()
+	msg := gmailMsg("g-onb", "thr", addrA, []string{me}, nil, nil, "S", "body", "<"+ext+">", msgEpochSecs*1000)
+
+	// A query-recording fetcher proves the metadata override flows into the
+	// after:<epoch> floor (the query-agnostic fakeMessageStore returns the
+	// message regardless of query, so we capture the query explicitly here).
+	var capturedQueries []string
+	e.provider.SetFetcherFactoryForTest(google.NewFakeGmailFetcherFactoryForTest(google.FakeGmailFetcherFuncs{
+		ListMessageIDs: func(_ context.Context, query, pageToken string) ([]google.GmailMessageRefForTest, string, error) {
+			if pageToken != "" {
+				return nil, "", nil
+			}
+			capturedQueries = append(capturedQueries, query)
+			return []google.GmailMessageRefForTest{{ID: msg.Id, ThreadID: msg.ThreadId}}, "", nil
+		},
+		GetMessage: func(_ context.Context, id string) (*gmailapi.Message, error) {
+			if id == msg.Id {
+				return msg, nil
+			}
+			return nil, fmt.Errorf("message %s not found", id)
+		},
+	}))
+	e.provider.SetMeSetForTest(map[string]struct{}{me: {}})
+
+	// Onboarding: nil cursor + backfill_since metadata override.
+	state := &repository.SyncState{
+		Source:    "email",
+		AccountID: &me,
+		Metadata:  map[string]any{"backfill_since": override},
+	}
+
+	result, err := e.provider.Sync(e.ctx, state, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, result.ItemsProcessed)
+	require.Equal(t, 1, result.ItemsMatched)
+	require.Equal(t, fmt.Sprintf("%d", msgEpochSecs), result.NewCursor, "cursor advances to the message internalDate seconds")
+
+	// Query floored at the override epoch, not the default 2026-01-01.
+	require.NotEmpty(t, capturedQueries)
+	for _, q := range capturedQueries {
+		require.Contains(t, q, fmt.Sprintf("after:%d", overrideEpoch), "scan floors at the backfill_since override")
+	}
+
+	// Content row + event persisted.
+	rows, err := e.commsRepo.ListByContact(e.ctx, contactA.ID)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, ext, rows[0].ExternalID)
+	_, err = e.eventRepo.FindEventBySource(e.ctx, "email", ext+":"+contactA.ID.String())
+	require.NoError(t, err)
+
+	// Second sweep with the returned cursor is idempotent (no duplicate row).
+	state2 := &repository.SyncState{
+		Source:     "email",
+		AccountID:  &me,
+		SyncCursor: &result.NewCursor,
+		Metadata:   map[string]any{"backfill_since": override},
+	}
+	_, err = e.provider.Sync(e.ctx, state2, nil)
+	require.NoError(t, err)
+	rows, err = e.commsRepo.ListByContact(e.ctx, contactA.ID)
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "second sweep must not add a duplicate content row")
+}

--- a/backend/tests/gmail_rematch_integration_test.go
+++ b/backend/tests/gmail_rematch_integration_test.go
@@ -41,6 +41,11 @@ import (
 	gmailapi "google.golang.org/api/gmail/v1"
 )
 
+// Compile-time proof that GmailRematchHandler satisfies the rematch handler
+// interface phase 5 will register it under. The handler is unwired in phase 4,
+// so this is the only build site exercising the interface boundary until then.
+var _ service.RematchHandler = (*google.GmailRematchHandler)(nil)
+
 // gmailRematchEnv bundles the real handler + provider + email consumer harness.
 type gmailRematchEnv struct {
 	ctx             context.Context

--- a/backend/tests/gmail_rematch_integration_test.go
+++ b/backend/tests/gmail_rematch_integration_test.go
@@ -1,0 +1,462 @@
+// End-to-end coverage for GmailRematchHandler (Gmail integration phase 4).
+// These tests drive the REAL handler against a REAL events.Bus + database.Pool
+// and the REAL EmailInteractionConsumer (so derived interactions are asserted,
+// not just published events), with a FAKE gmailFetcher + injected me-set + a
+// stub accountLister (no OAuth touched). They prove the new-address backfill
+// seam:
+//   - a new address scan publishes email.* events that the consumer turns into
+//     interactions with the right direction + cadence columns;
+//   - match-only (an unknown participant never creates a contact);
+//   - fan-out to every contact sharing the address;
+//   - across multiple accounts the per-account `seen` set is NOT hoisted (each
+//     account is scanned; the interaction derives exactly once via dedup;
+//     provenance merges both accounts);
+//   - the rematch scan creates NO external_sync_state row (no cursor rewind);
+//   - the scan query floors at the backfill since-date and uses the
+//     single-address OR-group shape.
+//
+// Addresses are placeholders; timestamps are accelerated.GetCurrentTime()-safe
+// (the localNoonAnchor helper from the email suite); all assertions go through
+// repositories (no raw SQL).
+package tests
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/google"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	gmailapi "google.golang.org/api/gmail/v1"
+)
+
+// gmailRematchEnv bundles the real handler + provider + email consumer harness.
+type gmailRematchEnv struct {
+	ctx             context.Context
+	database        *db.Database
+	provider        *google.GmailSyncProvider
+	handler         *google.GmailRematchHandler
+	accounts        *stubAccountLister
+	bus             *events.Bus
+	commsRepo       *repository.CommsMessageRepository
+	contactRepo     *repository.ContactRepository
+	methodRepo      *repository.ContactMethodRepository
+	interactionRepo *repository.InteractionRepository
+	identityRepo    *repository.IdentityRepository
+	eventRepo       *repository.EventRepository
+	syncRepo        *repository.SyncRepository
+}
+
+// stubAccountLister satisfies google's accountLister seam with canned account
+// ids — no OAuth. Each id becomes an OAuthCredentialStatus with AccountID set.
+type stubAccountLister struct {
+	accountIDs []string
+}
+
+func (s *stubAccountLister) ListAccounts(_ context.Context) ([]repository.OAuthCredentialStatus, error) {
+	out := make([]repository.OAuthCredentialStatus, 0, len(s.accountIDs))
+	for _, id := range s.accountIDs {
+		out = append(out, repository.OAuthCredentialStatus{AccountID: id})
+	}
+	return out, nil
+}
+
+func newGmailRematchEnv(t *testing.T, accountIDs []string) *gmailRematchEnv {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	require.NoError(t, db.RunMigrations(ctx, databaseURL, getMigrationsPath()))
+
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	t.Cleanup(database.Close)
+
+	commsRepo := repository.NewCommsMessageRepository(database.Queries)
+	contactRepo := repository.NewContactRepository(database.Queries)
+	contactRepo.SetPool(database.Pool)
+	methodRepo := repository.NewContactMethodRepository(database.Queries)
+	interactionRepo := repository.NewInteractionRepository(database.Queries)
+	identityRepo := repository.NewIdentityRepository(database.Queries)
+	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
+	eventRepo := repository.NewEventRepository(database.Queries)
+	syncRepo := repository.NewSyncRepository(database.Queries)
+	contactService := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, contactTaskRepo, nil, nil)
+
+	// Real email consumer wired on the live bus so the handler's published
+	// email.* events are turned into interactions (not just logged).
+	bus, _ := setupTestEventBusForEmail(t, ctx, database, contactService)
+
+	provider := google.NewGmailSyncProvider(nil, commsRepo, bus, database.Pool)
+	accounts := &stubAccountLister{accountIDs: accountIDs}
+	handler := google.NewGmailRematchHandler(provider, accounts, commsRepo)
+
+	return &gmailRematchEnv{
+		ctx:             ctx,
+		database:        database,
+		provider:        provider,
+		handler:         handler,
+		accounts:        accounts,
+		bus:             bus,
+		commsRepo:       commsRepo,
+		contactRepo:     contactRepo,
+		methodRepo:      methodRepo,
+		interactionRepo: interactionRepo,
+		identityRepo:    identityRepo,
+		eventRepo:       eventRepo,
+		syncRepo:        syncRepo,
+	}
+}
+
+func (e *gmailRematchEnv) newContactWithEmail(t *testing.T, name, email string) *repository.Contact {
+	t.Helper()
+	cadence := "weekly"
+	contact, err := e.contactRepo.CreateContact(e.ctx, repository.CreateContactRequest{
+		FullName: name,
+		Cadence:  &cadence,
+	})
+	require.NoError(t, err)
+	_, err = e.methodRepo.CreateContactMethod(e.ctx, repository.CreateContactMethodRequest{
+		ContactID: contact.ID,
+		Type:      "email",
+		Value:     email,
+		IsPrimary: true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = e.commsRepo.HardDeleteByContact(e.ctx, contact.ID)
+		_ = e.interactionRepo.HardDeleteInteractionsBySourceRefPrefix(e.ctx, repository.InteractionSourceEmail, contact.ID.String()+":%")
+		_ = e.contactRepo.SoftDeleteContact(e.ctx, contact.ID)
+	})
+	return contact
+}
+
+func (e *gmailRematchEnv) cleanupEvents(t *testing.T, externalID string) {
+	t.Helper()
+	t.Cleanup(func() {
+		_ = e.eventRepo.HardDeleteEventsBySourceAndSourceIDPrefix(e.ctx, "email", externalID+"%")
+	})
+}
+
+// inject wires the fake store as the provider's fetcher + sets the me-set.
+func (e *gmailRematchEnv) inject(store *recordingMessageStore, meSet map[string]struct{}) {
+	e.provider.SetFetcherFactoryForTest(google.NewFakeGmailFetcherFactoryForTest(store.fetcherFuncs()))
+	e.provider.SetMeSetForTest(meSet)
+}
+
+// recordingMessageStore is a query-agnostic gmailFetcher that (a) returns all
+// registered messages for every non-empty query, (b) records the query strings
+// it received, and (c) counts GetMessage calls per id. The per-id counter is
+// the per-account-`seen` regression gate: a hoisted/global seen set would skip
+// account B's GetMessage and the count would be 1 instead of (num accounts).
+type recordingMessageStore struct {
+	messages []*gmailapi.Message
+	getCalls map[string]int
+	queries  []string
+}
+
+func newRecordingMessageStore(messages []*gmailapi.Message) *recordingMessageStore {
+	return &recordingMessageStore{messages: messages, getCalls: map[string]int{}}
+}
+
+func (s *recordingMessageStore) fetcherFuncs() google.FakeGmailFetcherFuncs {
+	return google.FakeGmailFetcherFuncs{
+		ListMessageIDs: func(_ context.Context, query, pageToken string) ([]google.GmailMessageRefForTest, string, error) {
+			if pageToken != "" {
+				return nil, "", nil
+			}
+			s.queries = append(s.queries, query)
+			refs := make([]google.GmailMessageRefForTest, 0, len(s.messages))
+			for _, m := range s.messages {
+				refs = append(refs, google.GmailMessageRefForTest{ID: m.Id, ThreadID: m.ThreadId})
+			}
+			return refs, "", nil
+		},
+		GetMessage: func(_ context.Context, id string) (*gmailapi.Message, error) {
+			s.getCalls[id]++
+			for _, m := range s.messages {
+				if m.Id == id {
+					return m, nil
+				}
+			}
+			return nil, nil
+		},
+	}
+}
+
+func (e *gmailRematchEnv) waitForCommsProcessed(t *testing.T, externalID string, contactID uuid.UUID) *repository.CommsMessage {
+	t.Helper()
+	deadline := accelerated.GetCurrentTime().Add(defaultInteractionWaitTimeout)
+	for accelerated.GetCurrentTime().Before(deadline) {
+		msg, err := e.commsRepo.GetMessage(e.ctx, repository.InteractionSourceEmail, externalID, contactID)
+		if err == nil && msg.InteractionID != nil && msg.ProcessedAt != nil {
+			return msg
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for comms_message %s to be processed for contact %s", externalID, contactID)
+	return nil
+}
+
+// listEmailInteractions returns the contact's live email interactions.
+func (e *gmailRematchEnv) listEmailInteractions(t *testing.T, contactID uuid.UUID) []repository.Interaction {
+	t.Helper()
+	rows, err := e.interactionRepo.ListContactInteractions(e.ctx, contactID, 100, 0)
+	require.NoError(t, err)
+	out := make([]repository.Interaction, 0, len(rows))
+	for _, r := range rows {
+		if r.Source == repository.InteractionSourceEmail {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// waitForLastContacted polls until the contact's last_contacted is set.
+func (e *gmailRematchEnv) waitForLastContacted(t *testing.T, contactID uuid.UUID) *repository.Contact {
+	t.Helper()
+	deadline := accelerated.GetCurrentTime().Add(defaultInteractionWaitTimeout)
+	for accelerated.GetCurrentTime().Before(deadline) {
+		c, err := e.contactRepo.GetContact(e.ctx, contactID)
+		require.NoError(t, err)
+		if c.LastContacted != nil && c.LastOutreachAt != nil {
+			return c
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for last_contacted + last_outreach_at on contact %s", contactID)
+	return nil
+}
+
+// --- Scenario 1: new-address scan derives interactions ----------------------
+
+func TestGmailRematch_NewAddressScan_DerivesInteractions(t *testing.T) {
+	e := newGmailRematchEnv(t, []string{"acct-" + uuid.NewString()[:8] + "@example.com"})
+	suffix := uuid.NewString()[:8]
+	me := e.accounts.accountIDs[0]
+	addrA := "a-" + suffix + "@example.com"
+	contactA := e.newContactWithEmail(t, "Contact A "+suffix, addrA)
+
+	inExt := "in-" + suffix + "@example.com"
+	outExt := "out-" + suffix + "@example.com"
+	e.cleanupEvents(t, inExt)
+	e.cleanupEvents(t, outExt)
+
+	sentAt := localNoonAnchor()
+	inbound := gmailMsg("g-in", "thr-in", addrA, []string{me}, nil, nil, "In", "hi", "<"+inExt+">", sentAt.UnixMilli())
+	outbound := gmailMsg("g-out", "thr-out", me, []string{addrA}, nil, nil, "Out", "yo", "<"+outExt+">", sentAt.Add(time.Hour).UnixMilli())
+	e.inject(newRecordingMessageStore([]*gmailapi.Message{inbound, outbound}), map[string]struct{}{me: {}})
+
+	matched, err := e.handler.Rematch(e.ctx, contactA.ID, addrA)
+	require.NoError(t, err)
+	require.Equal(t, 2, matched, "one inbound + one outbound row persisted")
+
+	// Content rows exist for both directions.
+	rows, err := e.commsRepo.ListByContact(e.ctx, contactA.ID)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+
+	// Events published.
+	inEnv, err := e.eventRepo.FindEventBySource(e.ctx, "email", inExt+":"+contactA.ID.String())
+	require.NoError(t, err)
+	require.Equal(t, events.KindEmailReceived, inEnv.Kind)
+	outEnv, err := e.eventRepo.FindEventBySource(e.ctx, "email", outExt+":"+contactA.ID.String())
+	require.NoError(t, err)
+	require.Equal(t, events.KindEmailSent, outEnv.Kind)
+
+	// Consumer derives interactions; cadence columns updated.
+	e.waitForCommsProcessed(t, inExt, contactA.ID)
+	e.waitForCommsProcessed(t, outExt, contactA.ID)
+
+	interactions := e.listEmailInteractions(t, contactA.ID)
+	require.NotEmpty(t, interactions, "consumer derived at least one interaction")
+
+	c := e.waitForLastContacted(t, contactA.ID)
+	require.NotNil(t, c.LastContacted, "inbound bumps last_contacted")
+	require.NotNil(t, c.LastOutreachAt, "outbound bumps last_outreach_at")
+}
+
+// --- Scenario 2: match-only (no contact creation) ---------------------------
+
+func TestGmailRematch_MatchOnly_NoContactCreated(t *testing.T) {
+	e := newGmailRematchEnv(t, []string{"acct-" + uuid.NewString()[:8] + "@example.com"})
+	suffix := uuid.NewString()[:8]
+	me := e.accounts.accountIDs[0]
+	addrA := "a-" + suffix + "@example.com"
+	unknown := "unknown-" + suffix + "@example.com"
+	contactA := e.newContactWithEmail(t, "Contact A "+suffix, addrA)
+
+	e.cleanupEvents(t, "mo-"+suffix+"@example.com")
+	// Message between "me" and an UNKNOWN address only (A is not a participant).
+	msg := gmailMsg("g-mo", "thr", unknown, []string{me}, nil, nil, "S", "body", "<mo-"+suffix+"@example.com>", localNoonAnchor().UnixMilli())
+	e.inject(newRecordingMessageStore([]*gmailapi.Message{msg}), map[string]struct{}{me: {}})
+
+	// Rematch for A's address, but the message has no A participant → no rows.
+	matched, err := e.handler.Rematch(e.ctx, contactA.ID, addrA)
+	require.NoError(t, err)
+	require.Equal(t, 0, matched)
+
+	rows, err := e.commsRepo.ListByContact(e.ctx, contactA.ID)
+	require.NoError(t, err)
+	require.Empty(t, rows, "no qualifying rows for A")
+
+	// The unknown address never produced a contact_method/contact.
+	matches, err := e.identityRepo.FindContactMethodsByValue(e.ctx, []string{"email"}, unknown)
+	require.NoError(t, err)
+	require.Empty(t, matches, "unknown address must not have produced a contact")
+}
+
+// --- Scenario 3: fan-out to multiple contacts sharing the address -----------
+
+func TestGmailRematch_FanOut_SharedAddress(t *testing.T) {
+	e := newGmailRematchEnv(t, []string{"acct-" + uuid.NewString()[:8] + "@example.com"})
+	suffix := uuid.NewString()[:8]
+	me := e.accounts.accountIDs[0]
+	shared := "shared-" + suffix + "@example.com"
+	c1 := e.newContactWithEmail(t, "Contact One "+suffix, shared)
+	c2 := e.newContactWithEmail(t, "Contact Two "+suffix, shared)
+
+	ext := "fan-" + suffix + "@example.com"
+	e.cleanupEvents(t, ext)
+	msg := gmailMsg("g-fan", "thr", shared, []string{me}, nil, nil, "S", "body", "<"+ext+">", localNoonAnchor().UnixMilli())
+	e.inject(newRecordingMessageStore([]*gmailapi.Message{msg}), map[string]struct{}{me: {}})
+
+	matched, err := e.handler.Rematch(e.ctx, c1.ID, shared)
+	require.NoError(t, err)
+	require.Equal(t, 2, matched, "one row per contact sharing the address")
+
+	// Two content rows (one per contact), two events.
+	rows1, err := e.commsRepo.ListByContact(e.ctx, c1.ID)
+	require.NoError(t, err)
+	require.Len(t, rows1, 1)
+	rows2, err := e.commsRepo.ListByContact(e.ctx, c2.ID)
+	require.NoError(t, err)
+	require.Len(t, rows2, 1)
+
+	_, err = e.eventRepo.FindEventBySource(e.ctx, "email", ext+":"+c1.ID.String())
+	require.NoError(t, err)
+	_, err = e.eventRepo.FindEventBySource(e.ctx, "email", ext+":"+c2.ID.String())
+	require.NoError(t, err)
+
+	// Both contacts get a derived interaction.
+	e.waitForCommsProcessed(t, ext, c1.ID)
+	e.waitForCommsProcessed(t, ext, c2.ID)
+	require.NotEmpty(t, e.listEmailInteractions(t, c1.ID))
+	require.NotEmpty(t, e.listEmailInteractions(t, c2.ID))
+}
+
+// --- Scenario 4: across multiple accounts (per-account `seen` not hoisted) --
+
+func TestGmailRematch_MultipleAccounts_PerAccountSeen(t *testing.T) {
+	suffix := uuid.NewString()[:8]
+	accountX := "x-" + suffix + "@example.com"
+	accountY := "y-" + suffix + "@example.com"
+	e := newGmailRematchEnv(t, []string{accountX, accountY})
+	addrA := "a-" + suffix + "@example.com"
+	contactA := e.newContactWithEmail(t, "Contact A "+suffix, addrA)
+
+	ext := "xacct-" + suffix + "@example.com"
+	e.cleanupEvents(t, ext)
+	// The SAME Message-ID observed in both mailboxes: same gmail message id so
+	// the fetcher's per-id counter measures cross-account scanning. Both
+	// accounts share the me-set so cross-account provenance detection fires.
+	sentAt := localNoonAnchor()
+	msg := gmailMsg("g-shared", "thr", addrA, []string{accountX, accountY}, nil, nil, "S", "body", "<"+ext+">", sentAt.UnixMilli())
+	store := newRecordingMessageStore([]*gmailapi.Message{msg})
+	e.inject(store, map[string]struct{}{accountX: {}, accountY: {}})
+
+	matched, err := e.handler.Rematch(e.ctx, contactA.ID, addrA)
+	require.NoError(t, err)
+	require.Equal(t, 2, matched, "both accounts persist a row (provenance merges; interaction dedups)")
+
+	// REGRESSION GATE: GetMessage("g-shared") fired once PER ACCOUNT (= 2),
+	// proving `seen` is per-ScanIdentifier/per-account and NOT hoisted. A
+	// global seen set would skip account Y and the count would be 1.
+	require.Equal(t, 2, store.getCalls["g-shared"], "message body fetched once per account (per-account seen)")
+
+	// Exactly one content row, provenance merged across BOTH accounts.
+	rows, err := e.commsRepo.ListByContact(e.ctx, contactA.ID)
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "cross-account same Message-ID collapses to one content row")
+
+	got, err := e.commsRepo.GetMessage(e.ctx, "email", ext, contactA.ID)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{accountX, accountY}, observedAccounts(t, got.SourceMetadata))
+
+	// Interaction derived exactly once (event (source, source_id) dedup).
+	e.waitForCommsProcessed(t, ext, contactA.ID)
+	time.Sleep(300 * time.Millisecond)
+	require.Len(t, e.listEmailInteractions(t, contactA.ID), 1, "cross-account same Message-ID derives one interaction")
+}
+
+// --- Scenario 5: no cursor side-effects -------------------------------------
+
+func TestGmailRematch_NoCursorSideEffects(t *testing.T) {
+	account := "acct-" + uuid.NewString()[:8] + "@example.com"
+	e := newGmailRematchEnv(t, []string{account})
+	suffix := uuid.NewString()[:8]
+	addrA := "a-" + suffix + "@example.com"
+	contactA := e.newContactWithEmail(t, "Contact A "+suffix, addrA)
+
+	ext := "nocur-" + suffix + "@example.com"
+	e.cleanupEvents(t, ext)
+	msg := gmailMsg("g-nocur", "thr", addrA, []string{account}, nil, nil, "S", "body", "<"+ext+">", localNoonAnchor().UnixMilli())
+	e.inject(newRecordingMessageStore([]*gmailapi.Message{msg}), map[string]struct{}{account: {}})
+
+	_, err := e.handler.Rematch(e.ctx, contactA.ID, addrA)
+	require.NoError(t, err)
+
+	// The rematch scan must NOT have created an external_sync_state row.
+	_, err = e.syncRepo.GetSyncStateBySource(e.ctx, "email", &account)
+	require.ErrorIs(t, err, db.ErrNotFound, "rematch must not create/touch an external_sync_state cursor row")
+}
+
+// --- Scenario 6: backfill floor honored + single-address OR-group -----------
+
+func TestGmailRematch_BackfillFloorAndQueryShape(t *testing.T) {
+	account := "acct-" + uuid.NewString()[:8] + "@example.com"
+	e := newGmailRematchEnv(t, []string{account})
+	suffix := uuid.NewString()[:8]
+	addrA := "a-" + suffix + "@example.com"
+	contactA := e.newContactWithEmail(t, "Contact A "+suffix, addrA)
+
+	ext := "shape-" + suffix + "@example.com"
+	e.cleanupEvents(t, ext)
+	msg := gmailMsg("g-shape", "thr", addrA, []string{account}, nil, nil, "S", "body", "<"+ext+">", localNoonAnchor().UnixMilli())
+	store := newRecordingMessageStore([]*gmailapi.Message{msg})
+	e.inject(store, map[string]struct{}{account: {}})
+
+	_, err := e.handler.Rematch(e.ctx, contactA.ID, addrA)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, store.queries, "the scan must have issued at least one list query")
+	backfillEpoch := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC).Unix()
+	for _, q := range store.queries {
+		require.Contains(t, q, "after:"+strconv.FormatInt(backfillEpoch, 10), "query floors at the default backfill since-date")
+		require.Contains(t, q, "category:primary", "query restricts to the primary category")
+		require.Contains(t, q, "from:"+addrA, "single-address OR-group includes from:")
+		require.Contains(t, q, "to:"+addrA, "single-address OR-group includes to:")
+		require.Contains(t, q, "cc:"+addrA, "single-address OR-group includes cc:")
+		require.Contains(t, q, "bcc:"+addrA, "single-address OR-group includes bcc:")
+		// One address → exactly one OR-group, so no second group separator.
+		require.False(t, strings.Contains(q, ") OR ("), "single address yields exactly one OR-group")
+	}
+}


### PR DESCRIPTION
Phase 4 of 5 for the Gmail integration (#70). Spec: `.ai/spec/2026-06-01-gmail-integration-design.md` (§3.2, §3.3, §5.1, §8 item 4). Phases 1–3 are merged on `main`.

## Summary

- **RematchService multi-handler refactor** (`internal/service/rematch.go`): `handlers` becomes `map[string][]RematchHandler`. `Register` appends; `Run` dispatches to every handler registered for a method type, preserving fail-fast (first handler error fails the job for River retry) and matched-sum semantics verbatim. `EligibleMethods` / `StartRematchForContact` presence checks use `len(...) > 0`. This is the only LIVE change in phase 4 — it is **behavior-preserving** for the calendar email rematch that is registered in production today (a single registered handler fires exactly once, identical to before).
- **`scanChunks` extraction + `ScanIdentifier` / `MeSet` seams** (`internal/google/gmail.go`): the `Sync` fetch → per-account `seen` dedup → GetMessage → processMessage → persistRow inner loop is extracted into a private `scanChunks` helper that returns the raw error (Sync keeps owning cursor math + `failResult`; `ScanIdentifier` returns the error directly, having no cursor). The `seen` set is created INSIDE `scanChunks` (per-account, per-sweep) so it is never hoisted across accounts. Pure refactor of `Sync` — the existing Gmail provider integration suite is the regression gate and stays green.
- **`GmailRematchHandler`** (`internal/google/gmail_rematch.go`, **inert / unwired**): a new `email` rematch handler that, on `contact_methods.added`, runs an identifier-scoped historical Gmail scan across all connected accounts for the newly-added address via `ScanIdentifier`, publishing `email.received`/`email.sent` so the phase-3 `EmailInteractionConsumer` derives interactions. Match-only (never creates a contact); fans out to every contact sharing the address; floors at the default backfill since-date and does NOT touch `external_sync_state` (no cursor rewind). An `accountLister` narrow interface seams account enumeration so tests need no real OAuth. Per-account continue-on-error.
- **Onboarding empty-cursor integration test** (`tests/gmail_provider_integration_test.go`): one new end-to-end test driving `Sync` with a nil cursor + a `backfill_since` metadata override; the onboarding plumbing itself already shipped in phase 2, so this is coverage only (no new production code).

## Inertness

The feature stays production-inert. `GmailRematchHandler` is **NOT registered in `cmd/crm-api/main.go`** — adding an email to a contact triggers zero Gmail work in production. Provider + rematch-handler registration and enablement reconciliation are all phase 5. Verified: zero `GmailRematchHandler` references in `main.go`; the only non-test occurrence is the constructor definition.

## Accepted review notes (two non-blocking P2s)

`/review-head` passed at `816a5af` (P0=0, P1=0, P2=2, P3=2 — all non-blocking).

- **Handler returns `nil` (no River retry) when all accounts error but some rows already persisted.** This is a deliberate plan decision (§3.2.2): if some work landed, the published events are durable and idempotent, so the job completes rather than retrying the whole fan-out. **To REVISIT when the handler is wired live in phase 5** — once it runs in production, confirm this partial-success-on-all-errors path is the behavior we want, or tighten it to fail-and-retry.
- The handler's interface satisfaction is otherwise only exercised at the phase-5 registration site; a test-only `var _ service.RematchHandler = (*google.GmailRematchHandler)(nil)` assertion was added to lock the signature against drift until then.

## Test plan

- `internal/service` fan-out unit tests: calendar-only still fires; both email handlers fire and sum counts; non-email types unaffected; first-handler-error fail-fast (second handler does not run); eligibility via slice-len.
- `tests/gmail_rematch_integration_test.go` (6 scenarios, real bus + real `EmailInteractionConsumer` + fake fetcher + stub `accountLister`): new-address scan derives inbound+outbound interactions and bumps cadence; match-only; fan-out to two contacts sharing one address; cross-account same Message-ID scans once per account (per-account `seen` regression gate), merges provenance, derives one interaction; no `external_sync_state` row created; query floors at the backfill since-date with the single-address OR-group shape.
- `tests/gmail_provider_integration_test.go`: onboarding empty-cursor backfill end-to-end.
- `go build ./cmd/crm-api` (+ single-file `main.go`), `make lint` (0 issues), `make test`, `make test-e2e-diff` (36 passed) all green; full pre-push suite (incl. full E2E) passed.

Closes nothing yet — #70 closes after phase 5.