### PR TITLE
fix(gmail): gate rematch on enabled email states + redact log PII

### DIFF
--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -561,8 +561,9 @@ func run() int {
 	// (found-branch extend/promote). cadenceUpdater + followUpManager are the
 	// SAME instances the InteractionRecorder uses, so the create branch's
 	// inline cadence/follow-up apply shares the durable event-claim store.
-	// Registered unconditionally — no events route to it until the Gmail
-	// provider is registered + enabled (phase 5), so it is production-inert.
+	// Registered unconditionally; it processes the email.received /
+	// email.sent events the Gmail provider publishes in production (and
+	// stays idle when no such event is routed, e.g. event-bus off mode).
 	commsMessageRepo := repository.NewCommsMessageRepository(database.Queries)
 	emailInteractionConsumer := consumer.NewEmailInteractionConsumer(
 		contactService, commsMessageRepo, interactionRepo, contactService,

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -805,9 +805,12 @@ func run() int {
 					database.Pool,
 				)
 				providerRegistry.Register(gmailProvider)
+				// syncRepo is the enabled-email-states lister: the rematch scan
+				// runs only over accounts whose email sync is enabled (the same
+				// gate the scheduler uses), not every connected OAuth account.
 				rematchService.Register(google.NewGmailRematchHandler(
 					gmailProvider,
-					googleOAuthService,
+					syncRepo,
 					commsMessageRepo,
 				))
 				logger.Info().Msg("Gmail sync provider + rematch handler registered")

--- a/backend/internal/consumer/email_interaction.go
+++ b/backend/internal/consumer/email_interaction.go
@@ -61,9 +61,8 @@ type emailAggregator interface {
 //     nothing (cadence delivery path #2).
 //  4. Link the content row via MarkProcessedTx on every branch.
 //
-// Inert in production until the Gmail provider is registered + enabled
-// (phase 5): no production code publishes email.* events, so this consumer
-// only fires when a test publishes one directly.
+// The Gmail provider publishes email.received/email.sent in production, so this
+// consumer derives the corresponding interaction from each such event.
 type EmailInteractionConsumer struct {
 	writer       interactionWriter
 	comms        commsLocator
@@ -142,12 +141,12 @@ func (c *EmailInteractionConsumer) HandleEvent(ctx context.Context, tx pgx.Tx, e
 	// source_ref = "<contact_uuid>:<thread_id>:<local_day>". Built from the
 	// provider-computed LocalDay (already in time.Local at publish time),
 	// NOT re-derived from SentAt — the durable event row is a complete
-	// hand-off (spec §5.2 / Decision 5). An empty ThreadID still forms an
+	// hand-off (spec §5.2). An empty ThreadID still forms an
 	// internally-consistent "<uuid>::<day>" key, unique per contact/day;
 	// Gmail always sets threadId, so this is defensive only.
 	sourceRef := p.ContactID.String() + ":" + p.ThreadID + ":" + p.LocalDay
 
-	// Per-source_ref serialization lock (Decision 8), taken BEFORE the read
+	// Per-source_ref serialization lock, taken BEFORE the read
 	// so the whole find → branch → write (occurred_at) → mark is atomic per
 	// aggregation key. A second same-key job blocks here until the first
 	// commits, then sees the committed aggregate on its FindBySourceRefTx and
@@ -157,7 +156,7 @@ func (c *EmailInteractionConsumer) HandleEvent(ctx context.Context, tx pgx.Tx, e
 		return nil, fmt.Errorf("acquire source_ref lock: %w", err)
 	}
 
-	// Locate the content row inside the tx (Decision 2). A miss is an
+	// Locate the content row inside the tx. A miss is an
 	// anomaly — publish-before-mutate commits the content row in the SAME
 	// provider tx as the event, so by the time this job runs the row is
 	// committed and visible. ErrNotFound therefore means a content-row
@@ -182,7 +181,7 @@ func (c *EmailInteractionConsumer) HandleEvent(ctx context.Context, tx pgx.Tx, e
 	var postCommit func(context.Context)
 
 	if errors.Is(err, db.ErrNotFound) {
-		// Create branch (Decision 1): reuse the InteractionRecorder's
+		// Create branch: reuse the InteractionRecorder's
 		// package-private create sequence so the email create path is
 		// indistinguishable from any other recorded interaction.
 		ref := sourceRef
@@ -209,7 +208,7 @@ func (c *EmailInteractionConsumer) HandleEvent(ctx context.Context, tx pgx.Tx, e
 			// branch sound even if the lock were removed: treat res.Interaction
 			// as the found row and apply this message's extend/promote +
 			// forward-only timestamp rather than silently marking it processed
-			// (a lost-update — Decision 1 P1 fix). No second interaction.recorded
+			// (which would be a lost update). No second interaction.recorded
 			// is published; the found path publishes nothing.
 			pc, aggErr := c.aggregate(ctx, tx, &p, res.Interaction)
 			if aggErr != nil {
@@ -239,7 +238,7 @@ func (c *EmailInteractionConsumer) HandleEvent(ctx context.Context, tx pgx.Tx, e
 	}
 
 	// Link the content row to the interaction it rolled into, on every
-	// branch (Decision 6). Zero affected means this message's own row was
+	// branch. Zero affected means this message's own row was
 	// already processed on a prior run (genuine re-delivery) — benign under
 	// the tx-bound read + per-key lock, so we don't error on it.
 	if _, err := c.comms.MarkProcessedTx(ctx, tx, []uuid.UUID{commsMsg.ID}, interactionID, sourceRef); err != nil {
@@ -250,7 +249,7 @@ func (c *EmailInteractionConsumer) HandleEvent(ctx context.Context, tx pgx.Tx, e
 }
 
 // aggregate applies the found-branch extend/promote to an existing
-// interaction with the forward-only timestamp guard (Decision 4). Used by
+// interaction with the forward-only timestamp guard. Used by
 // both the genuine found branch and the create branch's res.IsReplay
 // fall-through.
 func (c *EmailInteractionConsumer) aggregate(

--- a/backend/internal/events/bus.go
+++ b/backend/internal/events/bus.go
@@ -62,8 +62,8 @@ type consumerJob struct {
 //   - email.received / email.sent → EmailInteractionConsumer worker with
 //     MaxAttempts=5 (derives a per-(contact, thread, local-day) aggregated
 //     email interaction). Both kinds share one case (one job each). The
-//     consumer is production-inert until the Gmail provider is registered +
-//     enabled (phase 5) — no production code publishes email.* events.
+//     Gmail provider publishes these events in production; the consumer
+//     stays idle when no such event is routed (e.g. event-bus off mode).
 //   - task.skipped: no consumer yet wired.
 func consumerJobsForKind(env *Envelope) ([]consumerJob, error) {
 	switch env.Kind {

--- a/backend/internal/google/gmail.go
+++ b/backend/internal/google/gmail.go
@@ -105,7 +105,10 @@ func (f *gmailServiceFetcher) ListMessageIDs(ctx context.Context, query, pageTok
 func (f *gmailServiceFetcher) GetMessage(ctx context.Context, id string) (*gmail.Message, error) {
 	msg, err := f.svc.Users.Messages.Get(gmailUserID, id).Format("full").Context(ctx).Do()
 	if err != nil {
-		return nil, fmt.Errorf("get message %s: %w", id, err)
+		// id is a per-mailbox Gmail message id (third-party identifier); hash it
+		// so the error (which flows into River logs) carries no raw third-party
+		// reference while staying correlatable.
+		return nil, fmt.Errorf("get message %s: %w", hashIdentifier(id), err)
 	}
 	return msg, nil
 }
@@ -376,11 +379,13 @@ func (p *GmailSyncProvider) scanChunks(
 
 				msg, getErr := fetcher.GetMessage(ctx, ref.ID)
 				if getErr != nil {
-					return processed, matched, maxInternalDateSecs, fetchedAny, fmt.Errorf("get message %s: %w", ref.ID, getErr)
+					// ref.ID is a per-mailbox Gmail message id (third-party);
+					// hash it so the error in River logs carries no raw id.
+					return processed, matched, maxInternalDateSecs, fetchedAny, fmt.Errorf("get message %s: %w", hashIdentifier(ref.ID), getErr)
 				}
 				rows, procErr := p.processMessage(ctx, msg, accountID, knownMap, meSet)
 				if procErr != nil {
-					return processed, matched, maxInternalDateSecs, fetchedAny, fmt.Errorf("process message %s: %w", ref.ID, procErr)
+					return processed, matched, maxInternalDateSecs, fetchedAny, fmt.Errorf("process message %s: %w", hashIdentifier(ref.ID), procErr)
 				}
 				processed++
 
@@ -392,7 +397,7 @@ func (p *GmailSyncProvider) scanChunks(
 
 				for _, row := range rows {
 					if perr := p.persistRow(ctx, row); perr != nil {
-						return processed, matched, maxInternalDateSecs, fetchedAny, fmt.Errorf("persist row for message %s: %w", ref.ID, perr)
+						return processed, matched, maxInternalDateSecs, fetchedAny, fmt.Errorf("persist row for message %s: %w", hashIdentifier(ref.ID), perr)
 					}
 					matched++
 				}

--- a/backend/internal/google/gmail.go
+++ b/backend/internal/google/gmail.go
@@ -2,7 +2,9 @@ package google
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -149,12 +151,13 @@ type qualifiedRow struct {
 	Metadata       []byte
 }
 
-// GmailSyncProvider implements sync.SyncProvider for Gmail. It is currently
-// inert: it is NOT registered in main.go, so the scheduler enqueues no Gmail
-// sweeps and no email.received/email.sent event is ever published in prod.
-// (The email-interaction consumer that derives interactions from those kinds
-// is wired as of phase 3, but it can only fire once this provider is
-// registered + enabled in phase 5.)
+// GmailSyncProvider implements sync.SyncProvider for Gmail. It is store-only:
+// each qualifying message is upserted into comms_message and the matching
+// email.received/email.sent event is published in the same tx
+// (publish-before-mutate), and the EmailInteractionConsumer derives the
+// interaction from that event. The provider holds the event bus and pgxpool
+// directly because publish-before-mutate is its entire purpose; a nil bus or
+// pool is a programming error caught by the Sync guard (no off mode).
 type GmailSyncProvider struct {
 	oauthService *OAuthService
 	commsRepo    *repository.CommsMessageRepository
@@ -283,7 +286,7 @@ func (p *GmailSyncProvider) Sync(
 	for addr, contacts := range knownMap {
 		if len(contacts) > 1 {
 			logger.Debug().
-				Str("address", addr).
+				Str("address", hashIdentifier(addr)).
 				Int("contacts", len(contacts)).
 				Msg("gmail: ambiguous shared address maps to multiple contacts")
 		}
@@ -498,7 +501,9 @@ func (p *GmailSyncProvider) persistRow(ctx context.Context, row qualifiedRow) (e
 	defer func() {
 		if rollbackErr := tx.Rollback(ctx); rollbackErr != nil &&
 			!errors.Is(rollbackErr, pgx.ErrTxClosed) {
-			logger.Warn().Err(rollbackErr).Str("externalId", row.ExternalID).Msg("gmail: tx rollback failed")
+			// ExternalID is the RFC822 Message-ID, a third-party identifier, so
+			// it is dropped from the log; source keeps the line attributable.
+			logger.Warn().Err(rollbackErr).Str("source", GmailSourceName).Msg("gmail: tx rollback failed")
 		}
 	}()
 
@@ -593,7 +598,7 @@ func sanitizeAddresses(addresses []string) []string {
 			continue
 		}
 		if !emailSafeTermRegex.MatchString(a) {
-			logger.Debug().Str("address", a).Msg("gmail: skipping address unsafe for query term")
+			logger.Debug().Str("address", hashIdentifier(a)).Msg("gmail: skipping address unsafe for query term")
 			continue
 		}
 		out = append(out, a)
@@ -1057,6 +1062,22 @@ func buildMetadataJSON(htmlBody string, attachments []attachmentMeta, labels []s
 // measurement so the chunk builder governs the encoded GET-URL length.
 func urlQueryEscape(s string) string {
 	return url.QueryEscape(s)
+}
+
+// hashIdentifier returns a short, stable, non-reversible tag for a THIRD-PARTY
+// identifier (a contact's email address) so Gmail-path logs can correlate lines
+// for the same value within/across runs without writing a real third party's
+// address into the operator log. It is NEVER applied to the connected-account
+// (own-mailbox) address, which is operational provenance and logged raw. Empty
+// input returns "" so an empty field stays empty rather than hashing to a
+// constant. Lowercased before hashing so header-casing variants share one tag.
+func hashIdentifier(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(strings.ToLower(v)))
+	return "sha256:" + hex.EncodeToString(sum[:])[:12]
 }
 
 // --- Test-only shims. Production code must NOT call these. ---

--- a/backend/internal/google/gmail.go
+++ b/backend/internal/google/gmail.go
@@ -1151,6 +1151,17 @@ func NewFakeGmailFetcherFactoryForTest(funcs FakeGmailFetcherFuncs) func(ctx con
 	}
 }
 
+// NewFakeGmailFetcherFactoryByAccountForTest returns a fetcher factory that
+// picks the FakeGmailFetcherFuncs per accountID, so a cross-package test can
+// make one account's fetcher fail while another succeeds (the partial-failure
+// scan path) without reaching the unexported gmailFetcher. Production code must
+// NOT call this.
+func NewFakeGmailFetcherFactoryByAccountForTest(pick func(accountID string) FakeGmailFetcherFuncs) func(ctx context.Context, accountID string) (gmailFetcher, error) {
+	return func(_ context.Context, accountID string) (gmailFetcher, error) {
+		return &fakeGmailFetcher{funcs: pick(accountID)}, nil
+	}
+}
+
 // EncodeBase64URLForTest exposes the base64url encoding used for message body
 // data, so cross-package tests can build *gmail.Message bodies the provider
 // will decode. Production code must NOT call this.

--- a/backend/internal/google/gmail_redact_test.go
+++ b/backend/internal/google/gmail_redact_test.go
@@ -1,0 +1,41 @@
+package google
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestHashIdentifier covers the THIRD-PARTY redaction helper: empty stays
+// empty, lowercasing makes the tag case-insensitive, the output is a short
+// sha256: prefixed tag, and the raw input is never recoverable from the tag.
+// This is the testable slice of the PII fix; the own-account-stays-raw half is
+// pinned by the rematch partial-failure integration test (which asserts the raw
+// account id, not its hash, appears in the returned error).
+func TestHashIdentifier(t *testing.T) {
+	t.Run("empty stays empty", func(t *testing.T) {
+		require.Equal(t, "", hashIdentifier(""))
+		require.Equal(t, "", hashIdentifier("   "), "whitespace-only trims to empty")
+	})
+
+	t.Run("case-insensitive stability", func(t *testing.T) {
+		require.Equal(t, hashIdentifier("foo@example.com"), hashIdentifier("Foo@Example.com"))
+		require.Equal(t, hashIdentifier("foo@example.com"), hashIdentifier("  foo@example.com  "),
+			"surrounding whitespace is trimmed before hashing")
+	})
+
+	t.Run("shape and non-reversibility", func(t *testing.T) {
+		raw := "alice@example.com"
+		got := hashIdentifier(raw)
+		require.True(t, strings.HasPrefix(got, "sha256:"), "tag carries the sha256: prefix")
+		hexPart := strings.TrimPrefix(got, "sha256:")
+		require.Len(t, hexPart, 12, "tag uses exactly 12 hex chars")
+		require.NotContains(t, got, raw, "raw third-party address must not appear in the tag")
+		require.NotContains(t, got, "alice", "no fragment of the raw input leaks")
+	})
+
+	t.Run("distinct addresses get distinct tags", func(t *testing.T) {
+		require.NotEqual(t, hashIdentifier("a@example.com"), hashIdentifier("b@example.com"))
+	})
+}

--- a/backend/internal/google/gmail_rematch.go
+++ b/backend/internal/google/gmail_rematch.go
@@ -2,44 +2,45 @@ package google
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 
-	"personal-crm/backend/internal/logger"
 	"personal-crm/backend/internal/matching"
 	"personal-crm/backend/internal/repository"
 )
 
-// accountLister is the narrow account-enumeration seam the rematch handler
-// needs. Production satisfies it with *OAuthService; tests satisfy it with a
-// stub so the handler needs no real OAuth. Mirrors the consumer-side
-// narrow-interface convention.
-type accountLister interface {
-	ListAccounts(ctx context.Context) ([]repository.OAuthCredentialStatus, error)
+// emailSyncStateLister is the narrow seam the rematch handler uses to find the
+// accounts whose email sync is enabled. Production satisfies it with
+// *repository.SyncRepository; tests satisfy it with the real repository seeded
+// with enabled email sync states. Mirrors the consumer-side narrow-interface
+// convention.
+type emailSyncStateLister interface {
+	ListEnabledSyncStates(ctx context.Context) ([]repository.SyncState, error)
 }
 
 // GmailRematchHandler implements service.RematchHandler for the "email"
 // identifier type. On contact_methods.added, it runs a one-shot
-// identifier-scoped historical Gmail scan across ALL connected Google accounts
-// for the newly-added address, publishing email.received/sent so the phase-3
-// EmailInteractionConsumer derives interactions. Match-only (never creates a
-// contact); fans out to every contact sharing the address. Steady-state account
-// cursors are NOT rewound (spec §3.3).
-//
-// INERT in production until phase 5: NOT registered in main.go. No production
-// code path constructs it.
+// identifier-scoped historical Gmail scan for the newly-added address across
+// the connected accounts whose email sync is ENABLED, publishing
+// email.received/sent so the EmailInteractionConsumer derives interactions.
+// Match-only (never creates a contact); fans out to every contact sharing the
+// address via the known-contact map. Steady-state account cursors are NOT
+// rewound (spec §3.3).
 type GmailRematchHandler struct {
 	provider  *GmailSyncProvider                 // owns fetch/process/persist + bus + pool
-	accounts  accountLister                      // enumerate connected accounts (prod: *OAuthService)
+	states    emailSyncStateLister               // enumerate ENABLED email sync states (prod: *repository.SyncRepository)
 	commsRepo *repository.CommsMessageRepository // load known-contact map (ListEmailIdentitiesForSync)
 }
 
 // NewGmailRematchHandler constructs a GmailRematchHandler. Production passes the
-// *OAuthService as the accountLister.
-func NewGmailRematchHandler(p *GmailSyncProvider, accounts accountLister, comms *repository.CommsMessageRepository) *GmailRematchHandler {
+// *repository.SyncRepository as the enabled-email-states lister.
+func NewGmailRematchHandler(p *GmailSyncProvider, states emailSyncStateLister, comms *repository.CommsMessageRepository) *GmailRematchHandler {
 	return &GmailRematchHandler{
 		provider:  p,
-		accounts:  accounts,
+		states:    states,
 		commsRepo: comms,
 	}
 }
@@ -48,14 +49,37 @@ func NewGmailRematchHandler(p *GmailSyncProvider, accounts accountLister, comms 
 func (h *GmailRematchHandler) IdentifierType() string { return "email" }
 
 // Rematch runs an identifier-scoped historical Gmail scan for the newly-added
-// address across every connected account. The scan is address-scoped, not
-// contact-scoped: it fans out to all contacts sharing the address via the
-// known-contact map (which already includes the just-added pair). contactID is
-// referenced only for log traceability.
-func (h *GmailRematchHandler) Rematch(ctx context.Context, contactID uuid.UUID, valueNormalized string) (int, error) {
+// address across every connected account whose email sync is enabled. The scan
+// is address-scoped, not contact-scoped: it fans out to all contacts sharing
+// the address via the known-contact map (which already includes the just-added
+// pair). contactID is referenced only for the rematch fan-out semantics, not
+// logged.
+func (h *GmailRematchHandler) Rematch(ctx context.Context, _ uuid.UUID, valueNormalized string) (int, error) {
 	// Defensive normalization, mirroring CalendarRematchHandler.
 	addr := matching.NormalizeEmail(valueNormalized)
 	if addr == "" {
+		return 0, nil
+	}
+
+	// Gate on the enabled email sync states FIRST so the no-op path does zero
+	// work (no identity-map build, no me-set, no fetcher). Only scan accounts
+	// whose email sync is enabled and non-disabled — the same gate the
+	// scheduler uses (ListEnabledSyncStates: enabled = TRUE AND status !=
+	// 'disabled'). An account that is never enabled (or disabled by the user)
+	// must not be scanned by the rematch.
+	states, err := h.states.ListEnabledSyncStates(ctx)
+	if err != nil {
+		return 0, err
+	}
+	var emailStates []repository.SyncState
+	for _, st := range states {
+		if st.Source == GmailSourceName && st.AccountID != nil && strings.TrimSpace(*st.AccountID) != "" {
+			emailStates = append(emailStates, st)
+		}
+	}
+	if len(emailStates) == 0 {
+		// No enabled email account → nothing to scan. No-op (no map/me-set/
+		// fetcher work, no writes).
 		return 0, nil
 	}
 
@@ -82,42 +106,31 @@ func (h *GmailRematchHandler) Rematch(ctx context.Context, contactID uuid.UUID, 
 		return 0, err
 	}
 
-	// The rematch scan holds no per-account external_sync_state row and must
-	// not read/write one (spec §3.3), so it floors at the default backfill
-	// since-date directly. backfillSinceEpoch is unexported but in-package.
-	afterEpoch := backfillSinceEpoch(nil)
-
-	accounts, err := h.accounts.ListAccounts(ctx)
-	if err != nil {
-		return 0, err
-	}
-
+	// Scan each enabled account with its OWN backfill floor (per-state
+	// metadata["backfill_since"], default 2026-01-01 — NOT a hardcoded floor).
+	// Re-running the whole scan is safe: the comms_message upsert dedup + the
+	// event (source, source_id) unique collapse re-fetched messages, so a River
+	// retry that re-scans an already-succeeded account produces no duplicate
+	// rows/interactions. This makes "fail the job if ANY enabled account scan
+	// fails" safe — River retries the whole set, bounded by the job's
+	// MaxAttempts.
 	matched := 0
-	allErrored := len(accounts) > 0
-	var lastErr error
-	for _, a := range accounts {
-		n, scanErr := h.provider.ScanIdentifier(ctx, a.AccountID, addr, knownMap, meSet, afterEpoch)
+	var scanErrs []error
+	for _, st := range emailStates {
+		afterEpoch := backfillSinceEpoch(st.Metadata)
+		n, scanErr := h.provider.ScanIdentifier(ctx, *st.AccountID, addr, knownMap, meSet, afterEpoch)
 		matched += n
 		if scanErr != nil {
-			// Continue-on-error: one account's Gmail outage should not fail the
-			// whole rematch (mirrors CalendarRematchHandler's housekeeping-error
-			// tolerance). Record the error in case every account fails.
-			lastErr = scanErr
-			logger.Warn().Err(scanErr).
-				Str("account", a.AccountID).
-				Str("contactId", contactID.String()).
-				Str("address", addr).
-				Msg("gmail rematch: account scan failed; continuing")
-			continue
+			// The account id is the operator's OWN connected mailbox, kept raw
+			// for triage (operational provenance); the rematched contact
+			// address is third-party PII and is deliberately NOT included here.
+			scanErrs = append(scanErrs, fmt.Errorf("account %s: %w", *st.AccountID, scanErr))
 		}
-		allErrored = false
 	}
-
-	// Only fail the job (so River retries the whole method set) when EVERY
-	// account errored AND nothing matched — otherwise partial success returns
-	// nil and the job completes.
-	if allErrored && matched == 0 && lastErr != nil {
-		return 0, lastErr
+	if len(scanErrs) > 0 {
+		// ANY enabled-account scan failed → fail the job so River retries the
+		// whole set rather than permanently stranding that account's history.
+		return matched, errors.Join(scanErrs...)
 	}
 	return matched, nil
 }

--- a/backend/internal/service/email_reconcile.go
+++ b/backend/internal/service/email_reconcile.go
@@ -35,9 +35,8 @@ const (
 // GoogleAccountLister is the narrow account-enumeration seam
 // ReconcileEmailSyncStates needs. Production satisfies it with
 // *google.OAuthService; tests satisfy it with a stub so the reconciliation
-// needs no real OAuth. Mirrors the accountLister convention in
-// google/gmail_rematch.go and keeps the service package free of a google
-// import.
+// needs no real OAuth. Follows the narrow-interface convention used across the
+// google package and keeps the service package free of a google import.
 type GoogleAccountLister interface {
 	ListAccounts(ctx context.Context) ([]repository.OAuthCredentialStatus, error)
 }

--- a/backend/internal/service/rematch.go
+++ b/backend/internal/service/rematch.go
@@ -313,8 +313,9 @@ func (s *RematchService) pruneTerminalJobs() {
 func (s *RematchService) Run(ctx context.Context, jobID, contactID uuid.UUID, methods []Method) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
+			// contactId is a third-party contact UUID; jobId attributes the run
+			// without logging it.
 			logger.Error().
-				Str("contactId", contactID.String()).
 				Str("jobId", jobID.String()).
 				Interface("panic", r).
 				Msg("rematch: job panicked")
@@ -347,8 +348,10 @@ func (s *RematchService) Run(ctx context.Context, jobID, contactID uuid.UUID, me
 		for _, handler := range hs {
 			n, handlerErr := handler.Rematch(ctx, contactID, m.Value)
 			if handlerErr != nil {
+				// contactId is a third-party contact UUID; jobId + type attribute
+				// the failure without logging it.
 				logger.Warn().Err(handlerErr).
-					Str("contactId", contactID.String()).
+					Str("jobId", jobID.String()).
 					Str("type", m.Type).
 					Msg("rematch: handler failed")
 				j.setFailed(handlerErr)

--- a/backend/tests/gmail_rematch_integration_test.go
+++ b/backend/tests/gmail_rematch_integration_test.go
@@ -1,9 +1,9 @@
-// End-to-end coverage for GmailRematchHandler (Gmail integration phase 4).
+// End-to-end coverage for GmailRematchHandler.
 // These tests drive the REAL handler against a REAL events.Bus + database.Pool
 // and the REAL EmailInteractionConsumer (so derived interactions are asserted,
-// not just published events), with a FAKE gmailFetcher + injected me-set + a
-// stub accountLister (no OAuth touched). They prove the new-address backfill
-// seam:
+// not just published events), with a FAKE gmailFetcher + injected me-set + the
+// REAL SyncRepository seeded with enabled email sync states (no OAuth touched).
+// They prove the new-address backfill seam:
 //   - a new address scan publishes email.* events that the consumer turns into
 //     interactions with the right direction + cadence columns;
 //   - match-only (an unknown participant never creates a contact);
@@ -13,7 +13,19 @@
 //     provenance merges both accounts);
 //   - the rematch scan creates NO external_sync_state row (no cursor rewind);
 //   - the scan query floors at the backfill since-date and uses the
-//     single-address OR-group shape.
+//     single-address OR-group shape;
+//   - only ENABLED, non-disabled email accounts are scanned (no enabled state
+//     → no-op); any enabled-account scan failure surfaces an error;
+//   - each enabled account is scanned with its OWN metadata["backfill_since"].
+//
+// SHARED-DB CAUTION: ListEnabledSyncStates returns ALL enabled email states in
+// the shared personal_crm_test DB, so the handler scans every enabled email
+// account, not just this test's. Mitigations: each scenario seeds a per-test
+// random account id, the fake fetcher is account-agnostic (so a stray enabled
+// account only re-scans the same fake messages, collapsed by comms_message
+// upsert dedup keyed by (externalID, contactID)), every seeded state is
+// hard-deleted in t.Cleanup, and assertions are scoped to the test's OWN
+// freshly-created contact's rows — never a global state count.
 //
 // Addresses are placeholders; timestamps are accelerated.GetCurrentTime()-safe
 // (the localNoonAnchor helper from the email suite); all assertions go through
@@ -22,6 +34,7 @@ package tests
 
 import (
 	"context"
+	"errors"
 	"os"
 	"strconv"
 	"strings"
@@ -42,8 +55,7 @@ import (
 )
 
 // Compile-time proof that GmailRematchHandler satisfies the rematch handler
-// interface phase 5 will register it under. The handler is unwired in phase 4,
-// so this is the only build site exercising the interface boundary until then.
+// interface it is registered under.
 var _ service.RematchHandler = (*google.GmailRematchHandler)(nil)
 
 // gmailRematchEnv bundles the real handler + provider + email consumer harness.
@@ -52,7 +64,7 @@ type gmailRematchEnv struct {
 	database        *db.Database
 	provider        *google.GmailSyncProvider
 	handler         *google.GmailRematchHandler
-	accounts        *stubAccountLister
+	accountIDs      []string
 	bus             *events.Bus
 	commsRepo       *repository.CommsMessageRepository
 	contactRepo     *repository.ContactRepository
@@ -63,20 +75,9 @@ type gmailRematchEnv struct {
 	syncRepo        *repository.SyncRepository
 }
 
-// stubAccountLister satisfies google's accountLister seam with canned account
-// ids — no OAuth. Each id becomes an OAuthCredentialStatus with AccountID set.
-type stubAccountLister struct {
-	accountIDs []string
-}
-
-func (s *stubAccountLister) ListAccounts(_ context.Context) ([]repository.OAuthCredentialStatus, error) {
-	out := make([]repository.OAuthCredentialStatus, 0, len(s.accountIDs))
-	for _, id := range s.accountIDs {
-		out = append(out, repository.OAuthCredentialStatus{AccountID: id})
-	}
-	return out, nil
-}
-
+// newGmailRematchEnv builds the harness and seeds an ENABLED email sync state
+// (backfill_since=2026-01-01) for each accountID so the handler's enablement
+// gate scans them. Pass nil/empty to seed nothing (the no-op gate test).
 func newGmailRematchEnv(t *testing.T, accountIDs []string) *gmailRematchEnv {
 	t.Helper()
 	if testing.Short() {
@@ -111,15 +112,14 @@ func newGmailRematchEnv(t *testing.T, accountIDs []string) *gmailRematchEnv {
 	bus, _ := setupTestEventBusForEmail(t, ctx, database, contactService)
 
 	provider := google.NewGmailSyncProvider(nil, commsRepo, bus, database.Pool)
-	accounts := &stubAccountLister{accountIDs: accountIDs}
-	handler := google.NewGmailRematchHandler(provider, accounts, commsRepo)
+	handler := google.NewGmailRematchHandler(provider, syncRepo, commsRepo)
 
-	return &gmailRematchEnv{
+	env := &gmailRematchEnv{
 		ctx:             ctx,
 		database:        database,
 		provider:        provider,
 		handler:         handler,
-		accounts:        accounts,
+		accountIDs:      accountIDs,
 		bus:             bus,
 		commsRepo:       commsRepo,
 		contactRepo:     contactRepo,
@@ -129,6 +129,33 @@ func newGmailRematchEnv(t *testing.T, accountIDs []string) *gmailRematchEnv {
 		eventRepo:       eventRepo,
 		syncRepo:        syncRepo,
 	}
+
+	// Seed an enabled email sync state per account so the handler's enablement
+	// gate scans them (default backfill_since).
+	for _, id := range accountIDs {
+		env.seedEnabledEmailState(t, id, "2026-01-01")
+	}
+	return env
+}
+
+// seedEnabledEmailState creates an ENABLED (email, accountID) sync state with
+// metadata["backfill_since"]=backfillSince via the repository (sqlc-backed, no
+// raw SQL) and registers a hard-delete cleanup so the shared test DB does not
+// accumulate enabled email states that pollute other tests.
+func (e *gmailRematchEnv) seedEnabledEmailState(t *testing.T, accountID, backfillSince string) {
+	t.Helper()
+	acct := accountID
+	_, err := e.syncRepo.CreateSyncState(e.ctx, repository.CreateSyncStateRequest{
+		Source:    "email",
+		AccountID: &acct,
+		Enabled:   true,
+		Strategy:  repository.SyncStrategyContactDriven,
+		Metadata:  map[string]any{"backfill_since": backfillSince},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = e.syncRepo.DeleteSyncStatesByAccountID(e.ctx, accountID)
+	})
 }
 
 func (e *gmailRematchEnv) newContactWithEmail(t *testing.T, name, email string) *repository.Contact {
@@ -256,7 +283,7 @@ func (e *gmailRematchEnv) waitForLastContacted(t *testing.T, contactID uuid.UUID
 func TestGmailRematch_NewAddressScan_DerivesInteractions(t *testing.T) {
 	e := newGmailRematchEnv(t, []string{"acct-" + uuid.NewString()[:8] + "@example.com"})
 	suffix := uuid.NewString()[:8]
-	me := e.accounts.accountIDs[0]
+	me := e.accountIDs[0]
 	addrA := "a-" + suffix + "@example.com"
 	contactA := e.newContactWithEmail(t, "Contact A "+suffix, addrA)
 
@@ -304,7 +331,7 @@ func TestGmailRematch_NewAddressScan_DerivesInteractions(t *testing.T) {
 func TestGmailRematch_MatchOnly_NoContactCreated(t *testing.T) {
 	e := newGmailRematchEnv(t, []string{"acct-" + uuid.NewString()[:8] + "@example.com"})
 	suffix := uuid.NewString()[:8]
-	me := e.accounts.accountIDs[0]
+	me := e.accountIDs[0]
 	addrA := "a-" + suffix + "@example.com"
 	unknown := "unknown-" + suffix + "@example.com"
 	contactA := e.newContactWithEmail(t, "Contact A "+suffix, addrA)
@@ -334,7 +361,7 @@ func TestGmailRematch_MatchOnly_NoContactCreated(t *testing.T) {
 func TestGmailRematch_FanOut_SharedAddress(t *testing.T) {
 	e := newGmailRematchEnv(t, []string{"acct-" + uuid.NewString()[:8] + "@example.com"})
 	suffix := uuid.NewString()[:8]
-	me := e.accounts.accountIDs[0]
+	me := e.accountIDs[0]
 	shared := "shared-" + suffix + "@example.com"
 	c1 := e.newContactWithEmail(t, "Contact One "+suffix, shared)
 	c2 := e.newContactWithEmail(t, "Contact Two "+suffix, shared)
@@ -414,6 +441,11 @@ func TestGmailRematch_MultipleAccounts_PerAccountSeen(t *testing.T) {
 
 // --- Scenario 5: no cursor side-effects -------------------------------------
 
+// The rematch reads the enabled email sync state (the enablement gate) but must
+// never WRITE one: no cursor advance, no last_sync/last_successful_sync bump
+// (spec §3.3 — steady-state cursors are not rewound). The state is seeded by
+// the harness (the gate requires it); we assert its cursor/sync fields stay
+// untouched after a rematch that DID scan + persist rows.
 func TestGmailRematch_NoCursorSideEffects(t *testing.T) {
 	account := "acct-" + uuid.NewString()[:8] + "@example.com"
 	e := newGmailRematchEnv(t, []string{account})
@@ -426,12 +458,17 @@ func TestGmailRematch_NoCursorSideEffects(t *testing.T) {
 	msg := gmailMsg("g-nocur", "thr", addrA, []string{account}, nil, nil, "S", "body", "<"+ext+">", localNoonAnchor().UnixMilli())
 	e.inject(newRecordingMessageStore([]*gmailapi.Message{msg}), map[string]struct{}{account: {}})
 
-	_, err := e.handler.Rematch(e.ctx, contactA.ID, addrA)
+	matched, err := e.handler.Rematch(e.ctx, contactA.ID, addrA)
 	require.NoError(t, err)
+	require.Equal(t, 1, matched, "the rematch did scan and persist a row")
 
-	// The rematch scan must NOT have created an external_sync_state row.
-	_, err = e.syncRepo.GetSyncStateBySource(e.ctx, "email", &account)
-	require.ErrorIs(t, err, db.ErrNotFound, "rematch must not create/touch an external_sync_state cursor row")
+	// The seeded state's cursor + sync timestamps are untouched: the rematch
+	// does NOT advance or rewind the steady-state cursor.
+	st, err := e.syncRepo.GetSyncStateBySource(e.ctx, "email", &account)
+	require.NoError(t, err)
+	require.Nil(t, st.SyncCursor, "rematch must not write a cursor")
+	require.Nil(t, st.LastSyncAt, "rematch must not bump last_sync_at")
+	require.Nil(t, st.LastSuccessfulSyncAt, "rematch must not bump last_successful_sync_at")
 }
 
 // --- Scenario 6: backfill floor honored + single-address OR-group -----------
@@ -464,4 +501,198 @@ func TestGmailRematch_BackfillFloorAndQueryShape(t *testing.T) {
 		// One address → exactly one OR-group, so no second group separator.
 		require.False(t, strings.Contains(q, ") OR ("), "single address yields exactly one OR-group")
 	}
+}
+
+// --- Scenario 7: enablement gate — no enabled email state → no-op -----------
+
+// TestGmailRematch_NoEnabledState_NoOp proves the P0 enablement gate: when the
+// account has no enabled, non-disabled email sync state, the rematch is a no-op
+// — it never builds a fetcher (so the scan never runs) and writes nothing. Two
+// sub-cases: (a) no state at all, (b) a status='disabled' state.
+func TestGmailRematch_NoEnabledState_NoOp(t *testing.T) {
+	t.Run("no_state_at_all", func(t *testing.T) {
+		// Seed NO email state for this env (nil account list).
+		e := newGmailRematchEnv(t, nil)
+		suffix := uuid.NewString()[:8]
+		me := "acct-" + suffix + "@example.com"
+		addrA := "a-" + suffix + "@example.com"
+		contactA := e.newContactWithEmail(t, "Contact A "+suffix, addrA)
+
+		// A fetcher that WOULD return a qualifying message if it were ever
+		// consulted — the gate must prevent that.
+		msg := gmailMsg("g-gate-a", "thr", addrA, []string{me}, nil, nil, "S", "body", "<gate-a-"+suffix+"@example.com>", localNoonAnchor().UnixMilli())
+		store := newRecordingMessageStore([]*gmailapi.Message{msg})
+		e.inject(store, map[string]struct{}{me: {}})
+
+		matched, err := e.handler.Rematch(e.ctx, contactA.ID, addrA)
+		require.NoError(t, err)
+		require.Equal(t, 0, matched, "no enabled email state → no matches")
+		require.Empty(t, store.queries, "fetcher must never be consulted (gate ran before any scan)")
+		require.Empty(t, store.getCalls, "no message body fetched")
+
+		rows, err := e.commsRepo.ListByContact(e.ctx, contactA.ID)
+		require.NoError(t, err)
+		require.Empty(t, rows, "no qualifying rows written for the contact")
+	})
+
+	t.Run("disabled_state", func(t *testing.T) {
+		// Seed an email state for this account, then DISABLE it via the
+		// enable/disable path. ListEnabledSyncStates filters status='disabled'.
+		e := newGmailRematchEnv(t, nil)
+		suffix := uuid.NewString()[:8]
+		me := "acct-" + suffix + "@example.com"
+		addrA := "a-" + suffix + "@example.com"
+		contactA := e.newContactWithEmail(t, "Contact A "+suffix, addrA)
+
+		acct := me
+		created, err := e.syncRepo.CreateSyncState(e.ctx, repository.CreateSyncStateRequest{
+			Source:    "email",
+			AccountID: &acct,
+			Enabled:   true,
+			Status:    repository.SyncStatusDisabled,
+			Strategy:  repository.SyncStrategyContactDriven,
+			Metadata:  map[string]any{"backfill_since": "2026-01-01"},
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = e.syncRepo.DeleteSyncStatesByAccountID(e.ctx, acct) })
+
+		// Belt-and-suspenders: also flip enabled=false so neither gate clause
+		// admits it (ListEnabledSyncStates requires enabled=TRUE AND
+		// status!='disabled').
+		_, err = e.syncRepo.UpdateSyncStateEnabled(e.ctx, created.ID, false)
+		require.NoError(t, err)
+
+		msg := gmailMsg("g-gate-d", "thr", addrA, []string{me}, nil, nil, "S", "body", "<gate-d-"+suffix+"@example.com>", localNoonAnchor().UnixMilli())
+		store := newRecordingMessageStore([]*gmailapi.Message{msg})
+		e.inject(store, map[string]struct{}{me: {}})
+
+		matched, err := e.handler.Rematch(e.ctx, contactA.ID, addrA)
+		require.NoError(t, err)
+		require.Equal(t, 0, matched, "disabled email state → no matches")
+		require.Empty(t, store.queries, "disabled account must not be scanned")
+
+		rows, err := e.commsRepo.ListByContact(e.ctx, contactA.ID)
+		require.NoError(t, err)
+		require.Empty(t, rows, "no qualifying rows written for the contact")
+	})
+}
+
+// --- Scenario 8: partial failure → returns error (River retries) ------------
+
+// TestGmailRematch_PartialFailure_ReturnsError proves the P1 fail-on-any-error
+// behavior: two enabled accounts X and Y, X's scan errors, Y's succeeds. The
+// handler returns a non-nil error (so River retries the whole idempotent job)
+// while preserving Y's partial progress in `matched`. The error carries the
+// failing OWN-mailbox account id RAW (operator triage) and must NOT contain the
+// third-party contact address being rematched.
+func TestGmailRematch_PartialFailure_ReturnsError(t *testing.T) {
+	suffix := uuid.NewString()[:8]
+	accountX := "x-" + suffix + "@example.com"
+	accountY := "y-" + suffix + "@example.com"
+	e := newGmailRematchEnv(t, []string{accountX, accountY})
+	addrA := "a-" + suffix + "@example.com"
+	contactA := e.newContactWithEmail(t, "Contact A "+suffix, addrA)
+
+	ext := "pf-" + suffix + "@example.com"
+	e.cleanupEvents(t, ext)
+	msg := gmailMsg("g-pf", "thr", addrA, []string{accountY}, nil, nil, "S", "body", "<"+ext+">", localNoonAnchor().UnixMilli())
+
+	// Account-keyed fetcher factory: account X always fails its list call;
+	// account Y returns the qualifying message and records its query.
+	yStore := newRecordingMessageStore([]*gmailapi.Message{msg})
+	listErr := errors.New("simulated gmail list outage")
+	e.provider.SetFetcherFactoryForTest(google.NewFakeGmailFetcherFactoryByAccountForTest(func(accountID string) google.FakeGmailFetcherFuncs {
+		if accountID == accountX {
+			return google.FakeGmailFetcherFuncs{
+				ListMessageIDs: func(_ context.Context, _, _ string) ([]google.GmailMessageRefForTest, string, error) {
+					return nil, "", listErr
+				},
+				GetMessage: func(_ context.Context, _ string) (*gmailapi.Message, error) { return nil, nil },
+			}
+		}
+		return yStore.fetcherFuncs()
+	}))
+	e.provider.SetMeSetForTest(map[string]struct{}{accountX: {}, accountY: {}})
+
+	matched, err := e.handler.Rematch(e.ctx, contactA.ID, addrA)
+	require.Error(t, err, "any enabled-account scan failure must surface an error so River retries")
+	require.Equal(t, 1, matched, "account Y's successful row is still counted (partial progress preserved)")
+
+	// PII posture: own-mailbox account id RAW for triage, NO third-party address.
+	require.Contains(t, err.Error(), accountX, "error names the failing own-mailbox account id (raw, for triage)")
+	require.NotContains(t, err.Error(), addrA, "error must NOT leak the third-party contact address")
+
+	// Account Y's row was persisted despite X's failure.
+	rows, err := e.commsRepo.ListByContact(e.ctx, contactA.ID)
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "account Y's qualifying row persisted")
+}
+
+// --- Scenario 9: per-account backfill_since honored -------------------------
+
+// TestGmailRematch_PerAccountBackfillSince proves the P2 fix: each enabled
+// account is scanned with its OWN metadata["backfill_since"], not a hardcoded
+// default. The inverse of TestGmailRematch_BackfillFloorAndQueryShape.
+func TestGmailRematch_PerAccountBackfillSince(t *testing.T) {
+	t.Run("explicit_backfill_since", func(t *testing.T) {
+		// Seed NO default state; create one with an explicit non-default floor.
+		e := newGmailRematchEnv(t, nil)
+		suffix := uuid.NewString()[:8]
+		account := "acct-" + suffix + "@example.com"
+		e.seedEnabledEmailState(t, account, "2026-03-15")
+
+		addrA := "a-" + suffix + "@example.com"
+		contactA := e.newContactWithEmail(t, "Contact A "+suffix, addrA)
+		ext := "bf-" + suffix + "@example.com"
+		e.cleanupEvents(t, ext)
+		msg := gmailMsg("g-bf", "thr", addrA, []string{account}, nil, nil, "S", "body", "<"+ext+">", localNoonAnchor().UnixMilli())
+		store := newRecordingMessageStore([]*gmailapi.Message{msg})
+		e.inject(store, map[string]struct{}{account: {}})
+
+		_, err := e.handler.Rematch(e.ctx, contactA.ID, addrA)
+		require.NoError(t, err)
+
+		require.NotEmpty(t, store.queries, "the scan must have issued at least one list query")
+		wantEpoch := time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC).Unix()
+		defaultEpoch := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC).Unix()
+		for _, q := range store.queries {
+			require.Contains(t, q, "after:"+strconv.FormatInt(wantEpoch, 10), "query floors at the per-account backfill_since")
+			require.NotContains(t, q, "after:"+strconv.FormatInt(defaultEpoch, 10), "must NOT use the hardcoded default floor")
+		}
+	})
+
+	t.Run("absent_backfill_since_falls_back_to_default", func(t *testing.T) {
+		// An enabled state with empty metadata falls back to 2026-01-01 through
+		// the new per-state wiring (proves backfillSinceEpoch's default path).
+		e := newGmailRematchEnv(t, nil)
+		suffix := uuid.NewString()[:8]
+		account := "acct-" + suffix + "@example.com"
+		acct := account
+		_, err := e.syncRepo.CreateSyncState(e.ctx, repository.CreateSyncStateRequest{
+			Source:    "email",
+			AccountID: &acct,
+			Enabled:   true,
+			Strategy:  repository.SyncStrategyContactDriven,
+			// No metadata → no backfill_since key.
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = e.syncRepo.DeleteSyncStatesByAccountID(e.ctx, acct) })
+
+		addrA := "a-" + suffix + "@example.com"
+		contactA := e.newContactWithEmail(t, "Contact A "+suffix, addrA)
+		ext := "bfd-" + suffix + "@example.com"
+		e.cleanupEvents(t, ext)
+		msg := gmailMsg("g-bfd", "thr", addrA, []string{account}, nil, nil, "S", "body", "<"+ext+">", localNoonAnchor().UnixMilli())
+		store := newRecordingMessageStore([]*gmailapi.Message{msg})
+		e.inject(store, map[string]struct{}{account: {}})
+
+		_, err = e.handler.Rematch(e.ctx, contactA.ID, addrA)
+		require.NoError(t, err)
+
+		require.NotEmpty(t, store.queries, "the scan must have issued at least one list query")
+		defaultEpoch := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC).Unix()
+		for _, q := range store.queries {
+			require.Contains(t, q, "after:"+strconv.FormatInt(defaultEpoch, 10), "absent backfill_since falls back to the default floor")
+		}
+	})
 }


### PR DESCRIPTION
Pre-deploy fixes to the merged Gmail integration (#70, all phases on `main`), addressing a Codex review of the feature before it is deployed. Bug/safety fixes only — no feature changes. Calendar rematch and the `RematchService` fan-out are untouched in behavior.

## What this fixes

- **[P0] Rematch was bypassing the email-sync enablement gate.** `GmailRematchHandler` previously scanned every connected Google OAuth account. It now enumerates only enabled, non-disabled `source='email'` `external_sync_state` rows (via `ListEnabledSyncStates` — the same gate the scheduler uses), scans exactly those, and no-ops (zero work: no identity-map build, no me-set, no fetcher) when none are enabled.
- **[P1] Partial-account failure was silently swallowed.** Previously the job only failed when EVERY account errored and nothing matched. Now ANY enabled-account scan failure returns an error (`errors.Join`) so River retries the whole job rather than permanently stranding one account's history. Re-runs are idempotent (`comms_message` upsert dedup + event `(source, source_id)` unique), and `RematchService` already resets the matched count per attempt, so retries don't double-count.
- **Per-state `backfill_since`.** Each enabled account is scanned with its own `metadata["backfill_since"]` floor (default `2026-01-01`) instead of a hardcoded default.
- **Third-party PII redaction in logs/errors.** Contact email addresses are hashed via a new non-reversible `hashIdentifier`; Gmail/RFC822 message ids are dropped or hashed in the rollback warn and the scan error strings (which flow into River logs via the P1 `errors.Join`); the rematch dispatcher's handler-failure and panic logs drop the raw contact UUID (attributing by job id + method type). The operator's own connected-mailbox address stays **raw** as operational provenance — an explicit privacy decision for this single-user CRM.
- **Stale comment cleanup.** Removes now-false "inert / not registered / phase N" claims and `Decision N` scaffolding from the Gmail provider, rematch handler, email-interaction consumer, and the post-cutover comments in `main.go` / `events/bus.go`, plus a rename-rotted cross-reference in `email_reconcile.go`.

## Test plan

- New rematch integration scenarios: no enabled state / disabled state → no-op (fetcher never consulted); partial failure across two enabled accounts returns an error (failing own-mailbox account id raw, no third-party address leaked) while preserving partial progress; per-account `backfill_since` honored (explicit + absent-falls-back-to-default); no-cursor-side-effects updated to assert the seeded state's cursor/sync timestamps stay untouched.
- New `hashIdentifier` unit test (empty stays empty, case-insensitive, `sha256:` + 12 hex, non-reversible).
- Existing rematch tests migrated off the old account-lister seam to the real `SyncRepository` seeded with enabled email states (sqlc-backed fixtures, hard-deleted in cleanup).
- `make lint`, full `make test-unit`, and `make test-integration` (incl. `TestGmailRematch*`, `TestGmail*`, `TestReconcileEmail*`, `TestEmail*`) all pass locally; pre-push lint + unit + integration + frontend + E2E gates green.

## Review

Both gates passed before this PR opened: Codex review (substantive P0/P1 logic) and `/review-head` — final verdict at HEAD `e8c6d47` is P0=0, P1=0, P2=0 with one accepted P3 (a `hashIdentifier` doc-comment nit).

Closes part of the pre-deploy review for #70.