### PR TITLE
feat(gmail): correspondence enrichment source

### DIFF
--- a/.ai/spec/2026-06-02-gmail-correspondence-enrichment-design.md
+++ b/.ai/spec/2026-06-02-gmail-correspondence-enrichment-design.md
@@ -1,0 +1,111 @@
+# Gmail Correspondence Enrichment — Functional & Technical Design
+
+**Status:** Draft v1
+**Last Updated:** 2026-06-02
+**Part of:** Contact-method enrichment suggestions (`.ai/spec/2026-06-02-contact-method-enrichment-suggestions-design.md`) — that umbrella doc owns the shared, pluggable spine (a producer writes `external_contact` rows with a `source` tag → `ImportMatchService` computes `suggested_match` → People-tab `CandidateCard` → `ImportLinkModal` link/import/ignore + `MethodSelector` + `ConflictResolver` → `EnrichContactFromExternalWithSelections` → `CreateContactMethod` → `KindContactMethodsAdded` → `GmailRematchHandler` backfill). This doc details the `gmail_correspondence` **source** only.
+**Depends on:** the Gmail category-filter fix shipped AND a `comms_message` backfill run — until then this source has no input data (see §2 / §11).
+
+---
+
+## 1. Overview
+
+### What
+
+A producer that mines the **participants of already-ingested known-contact email threads** to discover email addresses that belong to **existing** CRM contacts but aren't on their record, and surfaces each as a **link** candidate in the existing People-import tab. It never creates new contacts; it never fetches mail beyond what the sync already pulled.
+
+### Why
+
+The Gmail integration ingests mail for **known addresses only** (match-or-skip), so a contact who emails from an address not yet on their record is invisible — and the structured address books (gcontacts/icloud) can't supply addresses that were never saved. Mining the mail stream is the only signal for these. Validated on the user's main account: a 217-message known-contact sample surfaced ~30 strong candidates, ~28 of them real.
+
+### Non-goals
+
+- No new-contact creation (addresses whose display name does **not** strong-match an existing contact are out of scope — those net-new people are the separate future discovery program).
+- No new Gmail fetching, no broad scan, no per-contact name search, no AI/signature parsing.
+
+---
+
+## 2. Input & dependency
+
+Reads the `to` / `cc` / `bcc` participant lists already stored in `comms_message.source_metadata` for ingested known-contact messages (plus the `From`). **No new Gmail API calls** — it rides whatever the email sync already fetched.
+
+Hard dependency: `comms_message` is empty until the **category-filter fix** (`category:primary` → `-category:promotions -category:social -category:updates -category:forums`) ships and a backfill runs. Until then this producer is correct but yields nothing.
+
+---
+
+## 3. Algorithm
+
+1. Load the **known-address set** (every email `contact_method.value_normalized`) and the **own-account set** (connected-account addresses from `external_sync_state` where `source='email'`).
+2. Over ingested known-contact messages (bounded by a watermark or a recent window), collect every participant `(display_name, address)` from From/To/Cc/Bcc.
+3. Drop addresses that are known or own-account.
+4. For each remaining **unknown** address whose display name has **≥2 tokens** (a full name, not a bare first name), trigram-match the display name to CRM contacts (reuse `contactRepo.FindSimilarContacts`). If the best similarity is **≥ 0.60**, it qualifies.
+5. Skip if the address is already a `contact_method` on any contact, or an `ignored` `gmail_correspondence` row already exists for it (sticky ignore).
+6. Upsert an `external_contact`: `source='gmail_correspondence'`, `source_id=<normalized address>`, `display_name=<observed name>`, `emails=[address]`, `host_id=<Pi host>`, `metadata={ display_names_seen, co_occurring_contact, message_count }`.
+
+`source_id = address` gives natural per-address dedup. The existing `ImportMatchService` recomputes `suggested_match` at list time from the same trigram + method-overlap scoring used by every source, so no bespoke suggestion plumbing is needed.
+
+---
+
+## 4. Matching gate (empirically calibrated)
+
+**sim ≥ 0.60 AND display name has ≥2 tokens.** On the validation sample this gate gave ~93% precision (28/30 strong candidates real); everything below 0.60 was a *net-new* person spuriously partial-matching an existing contact, and bare first names are the main noise source. A regression test pins this gate so any future loosening is a conscious choice. Co-occurrence of the unknown address with the *matched contact's own* known address (strongest "this is their alternate address" signal) is computed as a confidence/sort booster, not a gate.
+
+---
+
+## 5. Resolution flow
+
+The candidate appears in the People tab with its auto-computed suggested contact and evidence (observed display name, co-occurring contact, message count). The user **links** it → `MethodSelector` adds the email → `KindContactMethodsAdded` → `GmailRematchHandler` backfills that address's history from the backfill floor. **Import is hidden** for this source (no new contacts). **Ignore** is sticky.
+
+Multiple addresses for one person produce multiple rows, each independently confirmable (native to per-address rows + `MethodSelector`).
+
+---
+
+## 6. Generation cadence
+
+A producer that runs after the email sync (or on a periodic tick) over recently-ingested `comms_message`. Idempotent: re-runs upsert the same `(host_id, source, source_id)` rows and skip already-known / already-ignored addresses. Decision deferred to planning: an email-ingestion consumer vs. a scheduled reconciliation pass — both read the same stored participants; a scheduled pass is simpler to re-tune and decouples discovery from the ingestion hot path.
+
+---
+
+## 7. Components
+
+| Component | Location (new unless noted) | Responsibility |
+|-----------|------------------------------|----------------|
+| `GmailCorrespondenceSuggester` | `backend/internal/google/` | Reads `comms_message` participants, applies the §4 gate, upserts `gmail_correspondence` `external_contact` rows |
+| Link-only restriction + source label | frontend `ImportLinkModal` / source-display (modify) | Hide `import` for this source; label + evidence display |
+
+Reused (no change): `ImportMatchService`, `ImportLinkModal` / `MethodSelector` / `ConflictResolver`, `EnrichmentService`, `CreateContactMethod`, `KindContactMethodsAdded` + `RematchService` + `GmailRematchHandler`, sticky ignore.
+
+---
+
+## 8. Data
+
+`external_contact` reused unchanged: new `source` value `'gmail_correspondence'`; `source_id` = normalized address; evidence in `metadata`. No schema change, no new table.
+
+---
+
+## 9. Guardrails
+
+sim/token gate (§4); skip addresses already on a contact; sticky ignore (`match_status='ignored'`); link-only (no new contacts); dedup by `source_id`; fully reversible (unlink). The producer writes only `external_contact` candidate rows — it never mutates a contact directly; all contact changes go through the user-confirmed link flow.
+
+---
+
+## 10. Testing strategy
+
+- **Unit:** the §4 gate (sim ≥ 0.60 and ≥2 tokens; reject bare first names and sub-threshold); dedup by address; skip-known / skip-already-ignored; participant extraction from `comms_message.source_metadata`.
+- **Integration:** producer over seeded `comms_message` → `gmail_correspondence` rows with the expected `suggested_match`; link → `EnrichContactFromExternalWithSelections` → `CreateContactMethod` → `KindContactMethodsAdded` → `GmailRematchHandler` backfill; sticky-ignore prevents re-suggestion; `import` not offered.
+- **E2E:** a `gmail_correspondence` candidate appears in the People tab and link adds the method.
+- Repo rules: `accelerated.GetCurrentTime()`, sqlc-only (incl. fixtures), no PII in tests/fixtures.
+
+---
+
+## 11. Sequencing
+
+This source is **gated on the category-filter fix being shipped and a `comms_message` backfill having run** (otherwise no input). It reuses the suggestion spine, so landing the address-book source/leak-fix first proves that spine end-to-end before this plugs in. It is **UI-bearing** (People-tab cards + the link-only restriction), so its PR requires human review and must not be auto-merged.
+
+---
+
+## 12. Open questions & future work
+
+- Generation cadence: ingestion consumer vs. scheduled pass (§6).
+- Confidence display / queue sorting and how prominently to show evidence.
+- Whether co-occurrence-with-the-matched-contact's-own-address should graduate from a sort booster to a gate if precision needs tightening.
+- This source's gate is the bridge to the future **new-contact discovery program**: the sub-0.60 / no-match correspondents (net-new people) would feed that program's `import` path, reusing this same producer with a different resolution action.

--- a/backend/cmd/crm-admin/main.go
+++ b/backend/cmd/crm-admin/main.go
@@ -467,7 +467,7 @@ func runReconcileAddressBookMethods(ctx context.Context, deps adminDeps) error {
 const correspondenceBackfillFloor = "2026-01-01"
 
 // runRederiveCorrespondenceNames runs the one-time historical catchup in two
-// ordered phases over the full range (2b.4): (1) re-fetch + additively backfill
+// ordered phases over the full range: (1) re-fetch + additively backfill
 // participant display names, then (2) a full-range gmail_correspondence
 // producer pass so the now-named backlog surfaces as candidates. Phase 2 runs
 // even when phase 1 had per-row failures — successfully re-derived older rows
@@ -598,8 +598,8 @@ func buildProductionDeps(ctx context.Context, cfg *config.Config, database *db.D
 	// LAZY: build the correspondence re-derivation stack ONLY for
 	// --rederive-correspondence-names. google.NewOAuthService errors when
 	// Google creds are absent; building it unconditionally would break every
-	// other subcommand on a Google-less host (the P1 fix). The Gmail provider
-	// is constructed with the real event bus + pool, but the re-derive seams
+	// other subcommand on a Google-less host. The Gmail provider is
+	// constructed with the real event bus + pool, but the re-derive seams
 	// (RefetchParticipantNames, MeSet) and the producer (Run) never publish, so
 	// no email events are emitted by this one-shot binary.
 	if opts.rederiveCorrespondence {

--- a/backend/cmd/crm-admin/main.go
+++ b/backend/cmd/crm-admin/main.go
@@ -149,7 +149,7 @@ type correspondenceScanner interface {
 	Run(ctx context.Context, since time.Time) (int, error)
 }
 
-// adminDeps groups the four subcommand dependencies. Tests inject
+// adminDeps groups the per-subcommand dependencies. Tests inject
 // fakes for each interface; the production wiring builds a single
 // MacHostService and a small adapter for rematch.
 type adminDeps struct {

--- a/backend/cmd/crm-admin/main.go
+++ b/backend/cmd/crm-admin/main.go
@@ -30,6 +30,20 @@
 //	                              method (bounded; user-recoverable by
 //	                              deleting the method).
 //
+//	--rederive-correspondence-names
+//	                              One-time catchup for the gmail_correspondence
+//	                              source: re-fetch already-ingested email
+//	                              messages from Gmail and additively populate
+//	                              participant display names in comms_message
+//	                              metadata (preserving all existing content +
+//	                              provenance), then run a full-range producer
+//	                              pass so the historical backlog surfaces as
+//	                              link candidates. Continue-on-error; exits
+//	                              non-zero iff any row FAILED (Skipped* do not
+//	                              fail). Idempotent — safe to re-run. Requires
+//	                              Google OAuth credentials; built lazily so
+//	                              other subcommands work on Google-less hosts.
+//
 //	--mint-pairing-token          Mint a single-use pairing token for
 //	                              `crm-mac install --pair`. Optional
 //	                              --hostname-label is operator-side
@@ -78,6 +92,7 @@ import (
 	"personal-crm/backend/internal/consumer/consumerjobs"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/google"
 	"personal-crm/backend/internal/messages"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/service"
@@ -119,6 +134,21 @@ type reconcileRunner interface {
 	ReconcileAllAddressBookMethods(ctx context.Context) (service.ReconcileAllResult, error)
 }
 
+// rederiveRunner is the narrow interface --rederive-correspondence-names needs
+// for step 1 (re-fetch + additive name backfill). Production wires this to
+// *google.CorrespondenceNameRederiveService.RederiveNames.
+type rederiveRunner interface {
+	RederiveNames(ctx context.Context, since time.Time) (google.CorrespondenceRederiveResult, error)
+}
+
+// correspondenceScanner is the narrow interface --rederive-correspondence-names
+// needs for step 2 (the one-time full-range producer pass over the re-derived
+// backlog). Production wires this to
+// *google.GmailCorrespondenceSuggester.Run.
+type correspondenceScanner interface {
+	Run(ctx context.Context, since time.Time) (int, error)
+}
+
 // adminDeps groups the four subcommand dependencies. Tests inject
 // fakes for each interface; the production wiring builds a single
 // MacHostService and a small adapter for rematch.
@@ -128,20 +158,27 @@ type adminDeps struct {
 	revoker   hostRevoker
 	rematch   rematchRunner
 	reconcile reconcileRunner
-	stdout    io.Writer
-	stderr    io.Writer
+	// rederive + correspondence are built LAZILY (only when
+	// --rederive-correspondence-names is set) because they require Google OAuth
+	// credentials; building them unconditionally would break every other
+	// subcommand on a Google-less host. Nil for all other subcommands.
+	rederive       rederiveRunner
+	correspondence correspondenceScanner
+	stdout         io.Writer
+	stderr         io.Writer
 }
 
 // runOptions captures parsed flags. Exposed as a struct so tests can
 // drive run() directly without re-parsing argv.
 type runOptions struct {
-	rematchStranded      bool
-	reconcileAddressBook bool
-	mintPairingToken     bool
-	hostnameLabel        string
-	listHosts            bool
-	revokeHostID         string
-	rotateHostID         string
+	rematchStranded        bool
+	reconcileAddressBook   bool
+	rederiveCorrespondence bool
+	mintPairingToken       bool
+	hostnameLabel          string
+	listHosts              bool
+	revokeHostID           string
+	rotateHostID           string
 }
 
 func main() {
@@ -176,7 +213,7 @@ func runMain(args []string) error {
 	}
 	defer database.Close()
 
-	deps, cleanup, err := buildProductionDeps(ctx, cfg, database)
+	deps, cleanup, err := buildProductionDeps(ctx, cfg, database, opts)
 	if err != nil {
 		return err
 	}
@@ -198,6 +235,9 @@ func validateSubcommand(opts runOptions) error {
 	if opts.reconcileAddressBook {
 		active++
 	}
+	if opts.rederiveCorrespondence {
+		active++
+	}
 	if opts.mintPairingToken {
 		active++
 	}
@@ -212,11 +252,11 @@ func validateSubcommand(opts runOptions) error {
 	}
 	if active == 0 {
 		return errors.New("no subcommand specified; pass exactly one of " +
-			"--messages-rematch-stranded, --reconcile-address-book-methods, --mint-pairing-token, --list-hosts, --revoke-host <uuid>, --rotate-host-key <uuid>")
+			"--messages-rematch-stranded, --reconcile-address-book-methods, --rederive-correspondence-names, --mint-pairing-token, --list-hosts, --revoke-host <uuid>, --rotate-host-key <uuid>")
 	}
 	if active > 1 {
 		return errors.New("subcommand flags are mutually exclusive; pass exactly one of " +
-			"--messages-rematch-stranded, --reconcile-address-book-methods, --mint-pairing-token, --list-hosts, --revoke-host <uuid>, --rotate-host-key <uuid>")
+			"--messages-rematch-stranded, --reconcile-address-book-methods, --rederive-correspondence-names, --mint-pairing-token, --list-hosts, --revoke-host <uuid>, --rotate-host-key <uuid>")
 	}
 	return nil
 }
@@ -232,6 +272,12 @@ func parseArgs(args []string) (runOptions, error) {
 		"One-time catchup: re-propagate address-book (gcontacts/icloud) methods "+
 			"missing from already-linked contacts (auto-apply for matched, record "+
 			"suggestion for imported). Continue-on-error; exits non-zero iff any row failed.")
+	fs.BoolVar(&opts.rederiveCorrespondence, "rederive-correspondence-names", false,
+		"One-time catchup: re-fetch already-ingested email messages from Gmail and "+
+			"additively populate participant display names in comms_message metadata, "+
+			"then run a full-range gmail_correspondence producer pass so the historical "+
+			"backlog surfaces as link candidates. Continue-on-error; exits non-zero iff "+
+			"any row failed. Idempotent — safe to re-run. Requires Google OAuth creds.")
 	fs.BoolVar(&opts.mintPairingToken, "mint-pairing-token", false,
 		"Mint a single-use pairing token for `crm-mac install --pair`.")
 	fs.StringVar(&opts.hostnameLabel, "hostname-label", "",
@@ -271,6 +317,8 @@ func run(ctx context.Context, opts runOptions, deps adminDeps) error {
 		return runRematchStranded(ctx, deps)
 	case opts.reconcileAddressBook:
 		return runReconcileAddressBookMethods(ctx, deps)
+	case opts.rederiveCorrespondence:
+		return runRederiveCorrespondenceNames(ctx, deps)
 	}
 	return errors.New("unreachable")
 }
@@ -412,9 +460,59 @@ func runReconcileAddressBookMethods(ctx context.Context, deps adminDeps) error {
 	return nil
 }
 
+// correspondenceBackfillFloor is the lower bound for the one-time
+// re-derivation + full-range producer pass. It matches the Gmail onboarding
+// backfill floor (the earliest mail the integration ever ingested), so the
+// catchup covers the entire stored backlog.
+const correspondenceBackfillFloor = "2026-01-01"
+
+// runRederiveCorrespondenceNames runs the one-time historical catchup in two
+// ordered phases over the full range (2b.4): (1) re-fetch + additively backfill
+// participant display names, then (2) a full-range gmail_correspondence
+// producer pass so the now-named backlog surfaces as candidates. Phase 2 runs
+// even when phase 1 had per-row failures — successfully re-derived older rows
+// must still be evaluated. Prints a counts-only summary; returns a non-nil
+// error iff any row FAILED (Skipped* outcomes do NOT fail the run), so the
+// operator can fix the cause and re-run safely (idempotent).
+func runRederiveCorrespondenceNames(ctx context.Context, deps adminDeps) error {
+	since, err := time.Parse("2006-01-02", correspondenceBackfillFloor)
+	if err != nil {
+		return fmt.Errorf("parse backfill floor: %w", err)
+	}
+
+	res, err := deps.rederive.RederiveNames(ctx, since)
+	if err != nil {
+		return fmt.Errorf("rederive correspondence names: %w", err)
+	}
+
+	// Full-range producer pass — runs regardless of phase-1 per-row failures.
+	upserted, err := deps.correspondence.Run(ctx, since)
+	if err != nil {
+		return fmt.Errorf("correspondence producer pass: %w", err)
+	}
+
+	if _, err := fmt.Fprintf(deps.stdout, "rederive-correspondence-names summary:\n"+
+		"  scanned:              %d\n"+
+		"  rederived:            %d\n"+
+		"  skipped_no_gmail_id:  %d\n"+
+		"  skipped_unavailable:  %d\n"+
+		"  failed:               %d\n"+
+		"  candidates_upserted:  %d\n",
+		res.Scanned, res.Rederived, res.SkippedNoGmailID, res.SkippedUnavailable, res.Failed, upserted); err != nil {
+		return fmt.Errorf("write summary: %w", err)
+	}
+	if res.Failed > 0 {
+		return fmt.Errorf("%d row(s) failed to re-derive (see logs); re-run after fixing the cause", res.Failed)
+	}
+	return nil
+}
+
 // buildProductionDeps wires up the production service stack. Returns
-// a cleanup function to call before exit (releases the river client).
-func buildProductionDeps(ctx context.Context, cfg *config.Config, database *db.Database) (adminDeps, func(), error) {
+// a cleanup function to call before exit (releases the river client). opts
+// gates lazily-built dependencies: the correspondence re-derivation stack
+// requires Google OAuth and is built ONLY when --rederive-correspondence-names
+// is set, so every other subcommand keeps working on a Google-less host.
+func buildProductionDeps(ctx context.Context, cfg *config.Config, database *db.Database, opts runOptions) (adminDeps, func(), error) {
 	// River client configured as an inserter only. We register a
 	// noop worker for MessagingAggregateForContactArgs so River
 	// accepts the kind at Insert time without actually running the
@@ -489,14 +587,38 @@ func buildProductionDeps(ctx context.Context, cfg *config.Config, database *db.D
 		enrichmentService, contactRepo, contactMethodRepo, externalContactRepo,
 	)
 
-	cleanup := func() {}
-	return adminDeps{
+	deps := adminDeps{
 		tokens:    hostService,
 		hosts:     hostService,
 		revoker:   hostService,
 		rematch:   rematch,
 		reconcile: addressBookReconcile,
-	}, cleanup, nil
+	}
+
+	// LAZY: build the correspondence re-derivation stack ONLY for
+	// --rederive-correspondence-names. google.NewOAuthService errors when
+	// Google creds are absent; building it unconditionally would break every
+	// other subcommand on a Google-less host (the P1 fix). The Gmail provider
+	// is constructed with the real event bus + pool, but the re-derive seams
+	// (RefetchParticipantNames, MeSet) and the producer (Run) never publish, so
+	// no email events are emitted by this one-shot binary.
+	if opts.rederiveCorrespondence {
+		oauthRepo := repository.NewOAuthRepository(database.Queries)
+		syncRepo := repository.NewSyncRepository(database.Queries)
+		oauthService, err := google.NewOAuthService(cfg, oauthRepo, syncRepo)
+		if err != nil {
+			return adminDeps{}, nil, fmt.Errorf("--rederive-correspondence-names requires Google OAuth credentials: %w", err)
+		}
+		commsRepo := repository.NewCommsMessageRepository(database.Queries)
+		gmailProvider := google.NewGmailSyncProvider(oauthService, commsRepo, eventBus, database.Pool)
+		deps.rederive = google.NewCorrespondenceNameRederiveService(commsRepo, gmailProvider)
+		deps.correspondence = google.NewGmailCorrespondenceSuggester(
+			commsRepo, contactRepo, externalContactRepo, gmailProvider.MeSet,
+		)
+	}
+
+	cleanup := func() {}
+	return deps, cleanup, nil
 }
 
 // rematchAdapter wraps messages.RematchStranded so it conforms to

--- a/backend/cmd/crm-admin/main_test.go
+++ b/backend/cmd/crm-admin/main_test.go
@@ -647,3 +647,23 @@ func TestRunRederiveCorrespondenceNamesRederiveErrorSkipsProducer(t *testing.T) 
 		t.Fatalf("expected producer NOT to run after a hard re-derive error, log=%v", *log)
 	}
 }
+
+func TestRunRederiveCorrespondenceNamesProducerErrorFails(t *testing.T) {
+	deps, _, _, _, _, _ := newTestDeps()
+	log := &[]string{}
+	deps.rederive = &fakeRederiveRunner{
+		result: google.CorrespondenceRederiveResult{Scanned: 3, Rederived: 3},
+		log:    log,
+	}
+	// The full-range producer pass fails (e.g. a DB outage); the catchup must
+	// surface that as a non-zero exit even though re-derivation itself succeeded.
+	deps.correspondence = &fakeCorrespondenceScanner{err: errors.New("scan failed"), log: log}
+
+	err := run(context.Background(), runOptions{rederiveCorrespondence: true}, deps)
+	if err == nil {
+		t.Fatal("expected error when the full-range producer pass errors")
+	}
+	if len(*log) != 2 || (*log)[1] != "producer" {
+		t.Fatalf("expected the producer pass to run after a clean re-derive, log=%v", *log)
+	}
+}

--- a/backend/cmd/crm-admin/main_test.go
+++ b/backend/cmd/crm-admin/main_test.go
@@ -611,7 +611,7 @@ func TestRunRederiveCorrespondenceNamesFailedExitsNonZero(t *testing.T) {
 	deps, stdout, _, _, _, _ := newTestDeps()
 	log := &[]string{}
 	// Partial failure: some rows failed, but successfully re-derived rows must
-	// still get the full-range producer pass (P2).
+	// still get the full-range producer pass.
 	deps.rederive = &fakeRederiveRunner{
 		result: google.CorrespondenceRederiveResult{Scanned: 5, Rederived: 3, Failed: 2},
 		log:    log,

--- a/backend/cmd/crm-admin/main_test.go
+++ b/backend/cmd/crm-admin/main_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"personal-crm/backend/internal/google"
 	"personal-crm/backend/internal/messages"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/service"
@@ -504,6 +505,15 @@ func TestParseArgsAllFlags(t *testing.T) {
 				}
 			},
 		},
+		{
+			"rederive-correspondence-names",
+			[]string{"--rederive-correspondence-names"},
+			func(t *testing.T, o runOptions) {
+				if !o.rederiveCorrespondence {
+					t.Fatal("rederive-correspondence-names flag not set")
+				}
+			},
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -513,5 +523,127 @@ func TestParseArgsAllFlags(t *testing.T) {
 			}
 			c.validate(t, opts)
 		})
+	}
+}
+
+// --- --rederive-correspondence-names dispatch tests ---
+
+type fakeRederiveRunner struct {
+	result google.CorrespondenceRederiveResult
+	err    error
+	since  time.Time
+	log    *[]string
+}
+
+func (f *fakeRederiveRunner) RederiveNames(_ context.Context, since time.Time) (google.CorrespondenceRederiveResult, error) {
+	f.since = since
+	if f.log != nil {
+		*f.log = append(*f.log, "rederive")
+	}
+	if f.err != nil {
+		return google.CorrespondenceRederiveResult{}, f.err
+	}
+	return f.result, nil
+}
+
+type fakeCorrespondenceScanner struct {
+	upserted int
+	err      error
+	since    time.Time
+	log      *[]string
+}
+
+func (f *fakeCorrespondenceScanner) Run(_ context.Context, since time.Time) (int, error) {
+	f.since = since
+	if f.log != nil {
+		*f.log = append(*f.log, "producer")
+	}
+	if f.err != nil {
+		return 0, f.err
+	}
+	return f.upserted, nil
+}
+
+func TestRunRederiveCorrespondenceNamesHappyAndOrdering(t *testing.T) {
+	deps, stdout, _, _, _, _ := newTestDeps()
+	log := &[]string{}
+	rederive := &fakeRederiveRunner{
+		result: google.CorrespondenceRederiveResult{
+			Scanned: 12, Rederived: 9, SkippedNoGmailID: 2, SkippedUnavailable: 1, Failed: 0,
+		},
+		log: log,
+	}
+	scanner := &fakeCorrespondenceScanner{upserted: 4, log: log}
+	deps.rederive = rederive
+	deps.correspondence = scanner
+
+	err := run(context.Background(), runOptions{rederiveCorrespondence: true}, deps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Ordering: re-derive FIRST, then the full-range producer pass.
+	if len(*log) != 2 || (*log)[0] != "rederive" || (*log)[1] != "producer" {
+		t.Fatalf("expected [rederive producer], got %v", *log)
+	}
+	// Both phases use the same full-range floor (2026-01-01).
+	if !rederive.since.Equal(scanner.since) {
+		t.Fatalf("phases used different since: %v vs %v", rederive.since, scanner.since)
+	}
+	if rederive.since.Format("2006-01-02") != correspondenceBackfillFloor {
+		t.Fatalf("expected since=%s, got %v", correspondenceBackfillFloor, rederive.since)
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"scanned:              12",
+		"rederived:            9",
+		"skipped_no_gmail_id:  2",
+		"skipped_unavailable:  1",
+		"failed:               0",
+		"candidates_upserted:  4",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q: %s", want, out)
+		}
+	}
+}
+
+func TestRunRederiveCorrespondenceNamesFailedExitsNonZero(t *testing.T) {
+	deps, stdout, _, _, _, _ := newTestDeps()
+	log := &[]string{}
+	// Partial failure: some rows failed, but successfully re-derived rows must
+	// still get the full-range producer pass (P2).
+	deps.rederive = &fakeRederiveRunner{
+		result: google.CorrespondenceRederiveResult{Scanned: 5, Rederived: 3, Failed: 2},
+		log:    log,
+	}
+	scanner := &fakeCorrespondenceScanner{upserted: 1, log: log}
+	deps.correspondence = scanner
+
+	err := run(context.Background(), runOptions{rederiveCorrespondence: true}, deps)
+	if err == nil {
+		t.Fatal("expected non-nil error when some rows failed")
+	}
+	// The producer pass still ran despite the failures.
+	if len(*log) != 2 || (*log)[1] != "producer" {
+		t.Fatalf("expected producer to run after partial failure, log=%v", *log)
+	}
+	if !strings.Contains(stdout.String(), "failed:               2") {
+		t.Fatalf("expected summary printed with failed count, got %q", stdout.String())
+	}
+}
+
+func TestRunRederiveCorrespondenceNamesRederiveErrorSkipsProducer(t *testing.T) {
+	deps, _, _, _, _, _ := newTestDeps()
+	log := &[]string{}
+	deps.rederive = &fakeRederiveRunner{err: errors.New("list failed"), log: log}
+	deps.correspondence = &fakeCorrespondenceScanner{log: log}
+
+	err := run(context.Background(), runOptions{rederiveCorrespondence: true}, deps)
+	if err == nil {
+		t.Fatal("expected error when the re-derive phase hard-errors")
+	}
+	// A hard error in phase 1 aborts before the producer pass.
+	if len(*log) != 1 || (*log)[0] != "rederive" {
+		t.Fatalf("expected producer NOT to run after a hard re-derive error, log=%v", *log)
 	}
 }

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -709,6 +709,12 @@ func run() int {
 	var googleOAuthService *google.OAuthService
 	var todoistOAuthService *todoist.OAuthService
 	var externalContactRepo *repository.ExternalContactRepository
+	// gmailCorrespondenceSuggester is declared at the outer function scope so
+	// the periodic-job registration block (~300 lines below) can see it; it is
+	// assigned only inside the nested pubBus != nil Gmail block and stays nil in
+	// off-mode / no-OAuth deployments. The registration site nil-checks it
+	// before adding the worker (mirrors syncService's declare-assign-nil-check).
+	var gmailCorrespondenceSuggester *google.GmailCorrespondenceSuggester
 
 	if cfg.Features.EnableExternalSync {
 		syncRepo := repository.NewSyncRepositoryWithPool(database.Queries, database.Pool)
@@ -829,7 +835,18 @@ func run() int {
 					syncRepo,
 					commsMessageRepo,
 				))
-				logger.Info().Msg("Gmail sync provider + rematch handler registered")
+				// Correspondence-enrichment producer: mines stored email
+				// participants for unknown addresses that strong-match an existing
+				// contact, surfacing each as a link-only candidate. Reuses the
+				// provider's MeSet seam for the own-account set. Assigned to the
+				// outer var so the periodic-job block can register its scan worker.
+				gmailCorrespondenceSuggester = google.NewGmailCorrespondenceSuggester(
+					commsMessageRepo,
+					contactRepo,
+					externalContactRepo,
+					gmailProvider.MeSet,
+				)
+				logger.Info().Msg("Gmail sync provider + rematch handler + correspondence suggester registered")
 			} else {
 				logger.Warn().Msg("Gmail provider NOT registered: event-bus interaction mode=off (pubBus nil)")
 			}
@@ -1148,6 +1165,23 @@ func run() int {
 			river.PeriodicInterval(5*time.Minute),
 			func() (river.JobArgs, *river.InsertOpts) {
 				return scheduler.SchedulerTickArgs{}, nil
+			},
+			&river.PeriodicJobOpts{RunOnStart: true},
+		))
+	}
+
+	// Register the gmail_correspondence scan periodic job (6h). Guarded on the
+	// suggester being non-nil (only set in cutover mode with Gmail OAuth), so
+	// off-mode / no-OAuth deployments never register a worker over a nil
+	// scanner. RunOnStart so the discovery pass runs at boot.
+	if cfg.Features.EnableExternalSync && gmailCorrespondenceSuggester != nil {
+		river.AddWorker(riverWorkers, scheduler.NewGmailCorrespondenceScanWorker(
+			gmailCorrespondenceSuggester, google.CorrespondenceWindow,
+		))
+		riverClient.PeriodicJobs().Add(river.NewPeriodicJob(
+			river.PeriodicInterval(6*time.Hour),
+			func() (river.JobArgs, *river.InsertOpts) {
+				return scheduler.GmailCorrespondenceScanArgs{}, nil
 			},
 			&river.PeriodicJobOpts{RunOnStart: true},
 		))

--- a/backend/internal/db/comms_message.sql.go
+++ b/backend/internal/db/comms_message.sql.go
@@ -163,12 +163,13 @@ func (q *Queries) HardDeleteCommsMessagesByContact(ctx context.Context, matchedC
 }
 
 const ListCommsMessageParticipantsSince = `-- name: ListCommsMessageParticipantsSince :many
-SELECT matched_contact_id, sent_at, source_metadata
-FROM comms_message
-WHERE source = 'email'
-  AND deleted_at IS NULL
-  AND sent_at >= $1
-ORDER BY sent_at DESC, id
+SELECT cm.matched_contact_id, cm.sent_at, cm.source_metadata
+FROM comms_message cm
+JOIN contact c ON c.id = cm.matched_contact_id AND c.deleted_at IS NULL
+WHERE cm.source = 'email'
+  AND cm.deleted_at IS NULL
+  AND cm.sent_at >= $1
+ORDER BY cm.sent_at DESC, cm.id
 `
 
 type ListCommsMessageParticipantsSinceRow struct {
@@ -182,7 +183,11 @@ type ListCommsMessageParticipantsSinceRow struct {
 // plus the index-aligned from_name/to_names/cc_names/bcc_names. matched_contact_id
 // is the known contact the message qualified for (the co-occurring contact the
 // producer records as evidence). Bounded by @since to keep each scan cheap; the
-// scan is idempotent so re-running the same window is harmless.
+// scan is idempotent so re-running the same window is harmless. The INNER JOIN on
+// a live contact drops rows whose matched contact was soft-deleted: a contact's
+// soft-delete (UPDATE deleted_at) does NOT cascade to its comms_message rows (the
+// FK cascade only fires on a hard DELETE), so without this join the producer would
+// keep mining correspondence with a deleted contact.
 func (q *Queries) ListCommsMessageParticipantsSince(ctx context.Context, since pgtype.Timestamptz) ([]*ListCommsMessageParticipantsSinceRow, error) {
 	rows, err := q.db.Query(ctx, ListCommsMessageParticipantsSince, since)
 	if err != nil {
@@ -253,14 +258,15 @@ func (q *Queries) ListCommsMessagesByContact(ctx context.Context, matchedContact
 }
 
 const ListCommsMessagesMissingParticipantNames = `-- name: ListCommsMessagesMissingParticipantNames :many
-SELECT id, account_id, source_metadata
-FROM comms_message
-WHERE source = 'email'
-  AND deleted_at IS NULL
-  AND sent_at >= $1
-  AND id > $2
-  AND NOT (source_metadata ? 'from_name')
-ORDER BY id
+SELECT cm.id, cm.account_id, cm.source_metadata
+FROM comms_message cm
+JOIN contact c ON c.id = cm.matched_contact_id AND c.deleted_at IS NULL
+WHERE cm.source = 'email'
+  AND cm.deleted_at IS NULL
+  AND cm.sent_at >= $1
+  AND cm.id > $2
+  AND NOT (cm.source_metadata ? 'from_name')
+ORDER BY cm.id
 LIMIT $3
 `
 
@@ -282,7 +288,10 @@ type ListCommsMessagesMissingParticipantNamesRow struct {
 // capture shipped), paged by id > @after_id so the runner advances the cursor
 // regardless of per-row outcome — a skipped/failed row never blocks later rows
 // (livelock avoidance). account_id + source_metadata.account_gmail_ids together
-// locate the per-mailbox gmail id to re-fetch.
+// locate the per-mailbox gmail id to re-fetch. The INNER JOIN on a live contact
+// drops rows whose matched contact was soft-deleted (soft-delete does not cascade
+// to comms_message), so the re-derivation never spends Gmail quota re-fetching
+// mail for a deleted contact.
 func (q *Queries) ListCommsMessagesMissingParticipantNames(ctx context.Context, arg ListCommsMessagesMissingParticipantNamesParams) ([]*ListCommsMessagesMissingParticipantNamesRow, error) {
 	rows, err := q.db.Query(ctx, ListCommsMessagesMissingParticipantNames, arg.Since, arg.AfterID, arg.BatchSize)
 	if err != nil {

--- a/backend/internal/db/comms_message.sql.go
+++ b/backend/internal/db/comms_message.sql.go
@@ -11,6 +11,65 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const BackfillCommsMessageParticipantNames = `-- name: BackfillCommsMessageParticipantNames :execrows
+UPDATE comms_message
+SET source_metadata = jsonb_set(
+    jsonb_set(
+        jsonb_set(
+            jsonb_set(
+                source_metadata,
+                '{from_name}',
+                to_jsonb($1::text),
+                TRUE
+            ),
+            '{to_names}',
+            $2::jsonb,
+            TRUE
+        ),
+        '{cc_names}',
+        $3::jsonb,
+        TRUE
+    ),
+    '{bcc_names}',
+    $4::jsonb,
+    TRUE
+)
+WHERE id = $5
+  AND deleted_at IS NULL
+  AND NOT (source_metadata ? 'from_name')
+`
+
+type BackfillCommsMessageParticipantNamesParams struct {
+	FromName string      `json:"from_name"`
+	ToNames  []byte      `json:"to_names"`
+	CcNames  []byte      `json:"cc_names"`
+	BccNames []byte      `json:"bcc_names"`
+	ID       pgtype.UUID `json:"id"`
+}
+
+// Additively merge the four display-name keys onto an EXISTING row's stored
+// source_metadata, preserving every existing content key (from/to/cc/bcc/
+// subject/html/attachments/labels) and the provenance keys (observed_accounts/
+// account_gmail_ids). A nested jsonb_set chain (create_missing=true per key) —
+// NOT a wholesale replace, which would destroy provenance + content. The caller
+// passes non-NULL JSON arrays ([] when empty) for *_names so jsonb_set never
+// writes a JSON null. Guarded by NOT (? 'from_name') so a row already
+// re-derived (or concurrently re-ingested with names) is a no-op (0 rows) —
+// idempotent across runs.
+func (q *Queries) BackfillCommsMessageParticipantNames(ctx context.Context, arg BackfillCommsMessageParticipantNamesParams) (int64, error) {
+	result, err := q.db.Exec(ctx, BackfillCommsMessageParticipantNames,
+		arg.FromName,
+		arg.ToNames,
+		arg.CcNames,
+		arg.BccNames,
+		arg.ID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const GetCommsMessage = `-- name: GetCommsMessage :one
 SELECT id, source, external_id, thread_id, subject, body, snippet, peer_handle, peer_normalized, direction, sent_at, account_id, source_metadata, matched_contact_id, interaction_id, claimed_at, claimed_session_ref, processed_at, deleted_at, created_at FROM comms_message
 WHERE source = $1
@@ -183,6 +242,57 @@ func (q *Queries) ListCommsMessagesByContact(ctx context.Context, matchedContact
 			&i.DeletedAt,
 			&i.CreatedAt,
 		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const ListCommsMessagesMissingParticipantNames = `-- name: ListCommsMessagesMissingParticipantNames :many
+SELECT id, account_id, source_metadata
+FROM comms_message
+WHERE source = 'email'
+  AND deleted_at IS NULL
+  AND sent_at >= $1
+  AND id > $2
+  AND NOT (source_metadata ? 'from_name')
+ORDER BY id
+LIMIT $3
+`
+
+type ListCommsMessagesMissingParticipantNamesParams struct {
+	Since     pgtype.Timestamptz `json:"since"`
+	AfterID   pgtype.UUID        `json:"after_id"`
+	BatchSize int32              `json:"batch_size"`
+}
+
+type ListCommsMessagesMissingParticipantNamesRow struct {
+	ID             pgtype.UUID `json:"id"`
+	AccountID      pgtype.Text `json:"account_id"`
+	SourceMetadata []byte      `json:"source_metadata"`
+}
+
+// Keyset-paged rows for the one-time historical display-name re-derivation
+// (crm-admin --rederive-correspondence-names). Returns email rows at/after
+// @since that lack the from_name key (i.e. ingested before display-name
+// capture shipped), paged by id > @after_id so the runner advances the cursor
+// regardless of per-row outcome — a skipped/failed row never blocks later rows
+// (livelock avoidance). account_id + source_metadata.account_gmail_ids together
+// locate the per-mailbox gmail id to re-fetch.
+func (q *Queries) ListCommsMessagesMissingParticipantNames(ctx context.Context, arg ListCommsMessagesMissingParticipantNamesParams) ([]*ListCommsMessagesMissingParticipantNamesRow, error) {
+	rows, err := q.db.Query(ctx, ListCommsMessagesMissingParticipantNames, arg.Since, arg.AfterID, arg.BatchSize)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []*ListCommsMessagesMissingParticipantNamesRow{}
+	for rows.Next() {
+		var i ListCommsMessagesMissingParticipantNamesRow
+		if err := rows.Scan(&i.ID, &i.AccountID, &i.SourceMetadata); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)

--- a/backend/internal/db/comms_message.sql.go
+++ b/backend/internal/db/comms_message.sql.go
@@ -103,6 +103,47 @@ func (q *Queries) HardDeleteCommsMessagesByContact(ctx context.Context, matchedC
 	return err
 }
 
+const ListCommsMessageParticipantsSince = `-- name: ListCommsMessageParticipantsSince :many
+SELECT matched_contact_id, sent_at, source_metadata
+FROM comms_message
+WHERE source = 'email'
+  AND deleted_at IS NULL
+  AND sent_at >= $1
+ORDER BY sent_at DESC, id
+`
+
+type ListCommsMessageParticipantsSinceRow struct {
+	MatchedContactID pgtype.UUID        `json:"matched_contact_id"`
+	SentAt           pgtype.Timestamptz `json:"sent_at"`
+	SourceMetadata   []byte             `json:"source_metadata"`
+}
+
+// Stream recent email content rows for the correspondence-enrichment scan:
+// source_metadata carries the from/to/cc/bcc participant lists (bare addresses)
+// plus the index-aligned from_name/to_names/cc_names/bcc_names. matched_contact_id
+// is the known contact the message qualified for (the co-occurring contact the
+// producer records as evidence). Bounded by @since to keep each scan cheap; the
+// scan is idempotent so re-running the same window is harmless.
+func (q *Queries) ListCommsMessageParticipantsSince(ctx context.Context, since pgtype.Timestamptz) ([]*ListCommsMessageParticipantsSinceRow, error) {
+	rows, err := q.db.Query(ctx, ListCommsMessageParticipantsSince, since)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []*ListCommsMessageParticipantsSinceRow{}
+	for rows.Next() {
+		var i ListCommsMessageParticipantsSinceRow
+		if err := rows.Scan(&i.MatchedContactID, &i.SentAt, &i.SourceMetadata); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const ListCommsMessagesByContact = `-- name: ListCommsMessagesByContact :many
 SELECT id, source, external_id, thread_id, subject, body, snippet, peer_handle, peer_normalized, direction, sent_at, account_id, source_metadata, matched_contact_id, interaction_id, claimed_at, claimed_session_ref, processed_at, deleted_at, created_at FROM comms_message
 WHERE matched_contact_id = $1

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -746,6 +746,13 @@ type Querier interface {
 	// SET of canonical phones/emails, not the contact mapping, so DISTINCT
 	// collapses the same value across multiple contacts.
 	ListCanonicalIdentifiersByType(ctx context.Context, dollar_1 []string) ([]string, error)
+	// Stream recent email content rows for the correspondence-enrichment scan:
+	// source_metadata carries the from/to/cc/bcc participant lists (bare addresses)
+	// plus the index-aligned from_name/to_names/cc_names/bcc_names. matched_contact_id
+	// is the known contact the message qualified for (the co-occurring contact the
+	// producer records as evidence). Bounded by @since to keep each scan cheap; the
+	// scan is idempotent so re-running the same window is harmless.
+	ListCommsMessageParticipantsSince(ctx context.Context, since pgtype.Timestamptz) ([]*ListCommsMessageParticipantsSinceRow, error)
 	// Per-contact content, newest first (backs idx_comms_message_contact_sent).
 	ListCommsMessagesByContact(ctx context.Context, matchedContactID pgtype.UUID) ([]*CommsMessage, error)
 	// Lightweight query returning only IDs for navigation

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -761,7 +761,11 @@ type Querier interface {
 	// plus the index-aligned from_name/to_names/cc_names/bcc_names. matched_contact_id
 	// is the known contact the message qualified for (the co-occurring contact the
 	// producer records as evidence). Bounded by @since to keep each scan cheap; the
-	// scan is idempotent so re-running the same window is harmless.
+	// scan is idempotent so re-running the same window is harmless. The INNER JOIN on
+	// a live contact drops rows whose matched contact was soft-deleted: a contact's
+	// soft-delete (UPDATE deleted_at) does NOT cascade to its comms_message rows (the
+	// FK cascade only fires on a hard DELETE), so without this join the producer would
+	// keep mining correspondence with a deleted contact.
 	ListCommsMessageParticipantsSince(ctx context.Context, since pgtype.Timestamptz) ([]*ListCommsMessageParticipantsSinceRow, error)
 	// Per-contact content, newest first (backs idx_comms_message_contact_sent).
 	ListCommsMessagesByContact(ctx context.Context, matchedContactID pgtype.UUID) ([]*CommsMessage, error)
@@ -771,7 +775,10 @@ type Querier interface {
 	// capture shipped), paged by id > @after_id so the runner advances the cursor
 	// regardless of per-row outcome — a skipped/failed row never blocks later rows
 	// (livelock avoidance). account_id + source_metadata.account_gmail_ids together
-	// locate the per-mailbox gmail id to re-fetch.
+	// locate the per-mailbox gmail id to re-fetch. The INNER JOIN on a live contact
+	// drops rows whose matched contact was soft-deleted (soft-delete does not cascade
+	// to comms_message), so the re-derivation never spends Gmail quota re-fetching
+	// mail for a deleted contact.
 	ListCommsMessagesMissingParticipantNames(ctx context.Context, arg ListCommsMessagesMissingParticipantNamesParams) ([]*ListCommsMessagesMissingParticipantNamesRow, error)
 	// Lightweight query returning only IDs for navigation
 	ListContactIDs(ctx context.Context, arg ListContactIDsParams) ([]pgtype.UUID, error)

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -41,6 +41,16 @@ type Querier interface {
 	// uses NOW(), so the test must rewrite the DB clock for those rows).
 	// Production code MUST NOT call this.
 	BackdateTelegramMessageClaim(ctx context.Context, messageIds []pgtype.UUID) error
+	// Additively merge the four display-name keys onto an EXISTING row's stored
+	// source_metadata, preserving every existing content key (from/to/cc/bcc/
+	// subject/html/attachments/labels) and the provenance keys (observed_accounts/
+	// account_gmail_ids). A nested jsonb_set chain (create_missing=true per key) —
+	// NOT a wholesale replace, which would destroy provenance + content. The caller
+	// passes non-NULL JSON arrays ([] when empty) for *_names so jsonb_set never
+	// writes a JSON null. Guarded by NOT (? 'from_name') so a row already
+	// re-derived (or concurrently re-ingested with names) is a no-op (0 rows) —
+	// idempotent across runs.
+	BackfillCommsMessageParticipantNames(ctx context.Context, arg BackfillCommsMessageParticipantNamesParams) (int64, error)
 	BulkLinkIdentitiesToContact(ctx context.Context, arg BulkLinkIdentitiesToContactParams) error
 	// Admin operation. Bumps cursor_epoch so the daemon discards its
 	// local cursor cache on next heartbeat. Currently used only by the
@@ -755,6 +765,14 @@ type Querier interface {
 	ListCommsMessageParticipantsSince(ctx context.Context, since pgtype.Timestamptz) ([]*ListCommsMessageParticipantsSinceRow, error)
 	// Per-contact content, newest first (backs idx_comms_message_contact_sent).
 	ListCommsMessagesByContact(ctx context.Context, matchedContactID pgtype.UUID) ([]*CommsMessage, error)
+	// Keyset-paged rows for the one-time historical display-name re-derivation
+	// (crm-admin --rederive-correspondence-names). Returns email rows at/after
+	// @since that lack the from_name key (i.e. ingested before display-name
+	// capture shipped), paged by id > @after_id so the runner advances the cursor
+	// regardless of per-row outcome — a skipped/failed row never blocks later rows
+	// (livelock avoidance). account_id + source_metadata.account_gmail_ids together
+	// locate the per-mailbox gmail id to re-fetch.
+	ListCommsMessagesMissingParticipantNames(ctx context.Context, arg ListCommsMessagesMissingParticipantNamesParams) ([]*ListCommsMessagesMissingParticipantNamesRow, error)
 	// Lightweight query returning only IDs for navigation
 	ListContactIDs(ctx context.Context, arg ListContactIDsParams) ([]pgtype.UUID, error)
 	// Lightweight query returning only IDs with sorting for navigation

--- a/backend/internal/db/queries/comms_message.sql
+++ b/backend/internal/db/queries/comms_message.sql
@@ -133,3 +133,17 @@ WHERE id = ANY(@message_ids::uuid[])
 -- call this.
 DELETE FROM comms_message
 WHERE matched_contact_id = @matched_contact_id;
+
+-- name: ListCommsMessageParticipantsSince :many
+-- Stream recent email content rows for the correspondence-enrichment scan:
+-- source_metadata carries the from/to/cc/bcc participant lists (bare addresses)
+-- plus the index-aligned from_name/to_names/cc_names/bcc_names. matched_contact_id
+-- is the known contact the message qualified for (the co-occurring contact the
+-- producer records as evidence). Bounded by @since to keep each scan cheap; the
+-- scan is idempotent so re-running the same window is harmless.
+SELECT matched_contact_id, sent_at, source_metadata
+FROM comms_message
+WHERE source = 'email'
+  AND deleted_at IS NULL
+  AND sent_at >= @since
+ORDER BY sent_at DESC, id;

--- a/backend/internal/db/queries/comms_message.sql
+++ b/backend/internal/db/queries/comms_message.sql
@@ -140,13 +140,18 @@ WHERE matched_contact_id = @matched_contact_id;
 -- plus the index-aligned from_name/to_names/cc_names/bcc_names. matched_contact_id
 -- is the known contact the message qualified for (the co-occurring contact the
 -- producer records as evidence). Bounded by @since to keep each scan cheap; the
--- scan is idempotent so re-running the same window is harmless.
-SELECT matched_contact_id, sent_at, source_metadata
-FROM comms_message
-WHERE source = 'email'
-  AND deleted_at IS NULL
-  AND sent_at >= @since
-ORDER BY sent_at DESC, id;
+-- scan is idempotent so re-running the same window is harmless. The INNER JOIN on
+-- a live contact drops rows whose matched contact was soft-deleted: a contact's
+-- soft-delete (UPDATE deleted_at) does NOT cascade to its comms_message rows (the
+-- FK cascade only fires on a hard DELETE), so without this join the producer would
+-- keep mining correspondence with a deleted contact.
+SELECT cm.matched_contact_id, cm.sent_at, cm.source_metadata
+FROM comms_message cm
+JOIN contact c ON c.id = cm.matched_contact_id AND c.deleted_at IS NULL
+WHERE cm.source = 'email'
+  AND cm.deleted_at IS NULL
+  AND cm.sent_at >= @since
+ORDER BY cm.sent_at DESC, cm.id;
 
 -- name: ListCommsMessagesMissingParticipantNames :many
 -- Keyset-paged rows for the one-time historical display-name re-derivation
@@ -155,15 +160,19 @@ ORDER BY sent_at DESC, id;
 -- capture shipped), paged by id > @after_id so the runner advances the cursor
 -- regardless of per-row outcome — a skipped/failed row never blocks later rows
 -- (livelock avoidance). account_id + source_metadata.account_gmail_ids together
--- locate the per-mailbox gmail id to re-fetch.
-SELECT id, account_id, source_metadata
-FROM comms_message
-WHERE source = 'email'
-  AND deleted_at IS NULL
-  AND sent_at >= @since
-  AND id > @after_id
-  AND NOT (source_metadata ? 'from_name')
-ORDER BY id
+-- locate the per-mailbox gmail id to re-fetch. The INNER JOIN on a live contact
+-- drops rows whose matched contact was soft-deleted (soft-delete does not cascade
+-- to comms_message), so the re-derivation never spends Gmail quota re-fetching
+-- mail for a deleted contact.
+SELECT cm.id, cm.account_id, cm.source_metadata
+FROM comms_message cm
+JOIN contact c ON c.id = cm.matched_contact_id AND c.deleted_at IS NULL
+WHERE cm.source = 'email'
+  AND cm.deleted_at IS NULL
+  AND cm.sent_at >= @since
+  AND cm.id > @after_id
+  AND NOT (cm.source_metadata ? 'from_name')
+ORDER BY cm.id
 LIMIT @batch_size;
 
 -- name: BackfillCommsMessageParticipantNames :execrows

--- a/backend/internal/db/queries/comms_message.sql
+++ b/backend/internal/db/queries/comms_message.sql
@@ -147,3 +147,57 @@ WHERE source = 'email'
   AND deleted_at IS NULL
   AND sent_at >= @since
 ORDER BY sent_at DESC, id;
+
+-- name: ListCommsMessagesMissingParticipantNames :many
+-- Keyset-paged rows for the one-time historical display-name re-derivation
+-- (crm-admin --rederive-correspondence-names). Returns email rows at/after
+-- @since that lack the from_name key (i.e. ingested before display-name
+-- capture shipped), paged by id > @after_id so the runner advances the cursor
+-- regardless of per-row outcome — a skipped/failed row never blocks later rows
+-- (livelock avoidance). account_id + source_metadata.account_gmail_ids together
+-- locate the per-mailbox gmail id to re-fetch.
+SELECT id, account_id, source_metadata
+FROM comms_message
+WHERE source = 'email'
+  AND deleted_at IS NULL
+  AND sent_at >= @since
+  AND id > @after_id
+  AND NOT (source_metadata ? 'from_name')
+ORDER BY id
+LIMIT @batch_size;
+
+-- name: BackfillCommsMessageParticipantNames :execrows
+-- Additively merge the four display-name keys onto an EXISTING row's stored
+-- source_metadata, preserving every existing content key (from/to/cc/bcc/
+-- subject/html/attachments/labels) and the provenance keys (observed_accounts/
+-- account_gmail_ids). A nested jsonb_set chain (create_missing=true per key) —
+-- NOT a wholesale replace, which would destroy provenance + content. The caller
+-- passes non-NULL JSON arrays ([] when empty) for *_names so jsonb_set never
+-- writes a JSON null. Guarded by NOT (? 'from_name') so a row already
+-- re-derived (or concurrently re-ingested with names) is a no-op (0 rows) —
+-- idempotent across runs.
+UPDATE comms_message
+SET source_metadata = jsonb_set(
+    jsonb_set(
+        jsonb_set(
+            jsonb_set(
+                source_metadata,
+                '{from_name}',
+                to_jsonb(@from_name::text),
+                TRUE
+            ),
+            '{to_names}',
+            @to_names::jsonb,
+            TRUE
+        ),
+        '{cc_names}',
+        @cc_names::jsonb,
+        TRUE
+    ),
+    '{bcc_names}',
+    @bcc_names::jsonb,
+    TRUE
+)
+WHERE id = @id
+  AND deleted_at IS NULL
+  AND NOT (source_metadata ? 'from_name');

--- a/backend/internal/google/correspondence_rederive.go
+++ b/backend/internal/google/correspondence_rederive.go
@@ -1,0 +1,214 @@
+package google
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"personal-crm/backend/internal/logger"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+)
+
+// Re-fetch error sentinels the runner branches on (see classifyRefetchError).
+var (
+	// errCorrespondenceUnavailable marks a PERMANENT re-fetch failure (the
+	// message is gone upstream, e.g. Gmail 404). Counted SkippedUnavailable,
+	// never a non-zero exit.
+	errCorrespondenceUnavailable = errors.New("correspondence: message unavailable")
+	// errCorrespondenceTransient marks a retryable re-fetch failure (429 / 5xx).
+	errCorrespondenceTransient = errors.New("correspondence: transient error")
+)
+
+const (
+	// rederiveBatchSize bounds each keyset page (and thus each burst of Gmail
+	// re-fetches). Small + rate-limit-friendly.
+	rederiveBatchSize = 50
+	// rederiveInterCallDelay is a short pause between per-message re-fetches so a
+	// full pass stays well under Gmail's per-user rate limits.
+	rederiveInterCallDelay = 50 * time.Millisecond
+	// rederiveMaxTransientRetries bounds per-row backoff retries on a 429/5xx
+	// before the row is counted Failed (retried on the next subcommand run).
+	rederiveMaxTransientRetries = 3
+	// rederiveBackoffBase is the first transient-retry backoff; it doubles each
+	// retry.
+	rederiveBackoffBase = 200 * time.Millisecond
+	// correspondenceUnknownAccountKey is the sentinel account_gmail_ids key the
+	// upsert writes when account_id was NULL. It holds a gmail id but no account
+	// to fetch with, so it is never a valid re-fetch target.
+	correspondenceUnknownAccountKey = "__unknown__"
+)
+
+// CorrespondenceRederiveResult is the counts-only summary the subcommand prints.
+type CorrespondenceRederiveResult struct {
+	Scanned            int
+	Rederived          int
+	SkippedNoGmailID   int
+	SkippedUnavailable int
+	Failed             int
+}
+
+// rederiveCommsRepo is the narrow comms_message surface the runner needs.
+// Concrete: *repository.CommsMessageRepository.
+type rederiveCommsRepo interface {
+	ListMissingParticipantNames(ctx context.Context, since time.Time, afterID uuid.UUID, batchSize int32) ([]repository.MissingParticipantNamesRow, error)
+	BackfillParticipantNames(ctx context.Context, id uuid.UUID, names repository.ParticipantNames) (int64, error)
+}
+
+// rederiveFetcher is the narrow provider surface the runner needs. Concrete:
+// *GmailSyncProvider.RefetchParticipantNames. An interface so the runner unit
+// test injects a fake with no OAuth.
+type rederiveFetcher interface {
+	RefetchParticipantNames(ctx context.Context, accountID, gmailMessageID string) (repository.ParticipantNames, error)
+}
+
+// CorrespondenceNameRederiveService performs the one-time historical
+// display-name re-derivation: it keyset-pages name-less email rows, re-fetches
+// each from Gmail, and additively backfills the display names onto the stored
+// source_metadata. Idempotent and re-runnable: a row that already has names is
+// skipped by the query's NOT (? 'from_name') guard, and a fresh run restarts
+// the keyset at the nil id.
+type CorrespondenceNameRederiveService struct {
+	comms    rederiveCommsRepo
+	fetcher  rederiveFetcher
+	sleep    func(time.Duration)
+	maxBatch int32
+}
+
+// NewCorrespondenceNameRederiveService builds the runner.
+func NewCorrespondenceNameRederiveService(comms rederiveCommsRepo, fetcher rederiveFetcher) *CorrespondenceNameRederiveService {
+	return &CorrespondenceNameRederiveService{
+		comms:    comms,
+		fetcher:  fetcher,
+		sleep:    time.Sleep,
+		maxBatch: rederiveBatchSize,
+	}
+}
+
+// RederiveNames keyset-pages every name-less email row at/after `since`,
+// re-fetches its display names, and backfills them. The keyset cursor advances
+// to max(id) of each batch regardless of per-row outcome, so a skipped/failed
+// row never blocks later rows (livelock avoidance) and is simply retried on the
+// next run (it still lacks from_name). Continue-on-error; returns the counts.
+func (s *CorrespondenceNameRederiveService) RederiveNames(ctx context.Context, since time.Time) (CorrespondenceRederiveResult, error) {
+	var result CorrespondenceRederiveResult
+	afterID := uuid.Nil
+
+	for {
+		rows, err := s.comms.ListMissingParticipantNames(ctx, since, afterID, s.maxBatch)
+		if err != nil {
+			return result, err
+		}
+		if len(rows) == 0 {
+			break
+		}
+		for _, row := range rows {
+			result.Scanned++
+			s.processRow(ctx, row, &result)
+		}
+		// Advance the keyset cursor to the last row's id. The query orders by id
+		// ascending, so the last row carries the batch's max id — advancing here
+		// (unconditionally, regardless of per-row outcome) guarantees a
+		// skipped/failed row is never re-queried in this pass (livelock
+		// avoidance). It is retried on the NEXT run, which still finds it
+		// name-less and restarts the keyset at uuid.Nil.
+		afterID = rows[len(rows)-1].ID
+	}
+	return result, nil
+}
+
+// processRow re-derives one row's names, updating the result counts. It never
+// returns an error: each outcome maps to a counter (continue-on-error).
+func (s *CorrespondenceNameRederiveService) processRow(ctx context.Context, row repository.MissingParticipantNamesRow, result *CorrespondenceRederiveResult) {
+	accountID, gmailID, ok := resolveRefetchTarget(row)
+	if !ok {
+		result.SkippedNoGmailID++
+		return
+	}
+
+	names, err := s.refetchWithRetry(ctx, accountID, gmailID)
+	if err != nil {
+		switch {
+		case errors.Is(err, errCorrespondenceUnavailable):
+			result.SkippedUnavailable++
+		default:
+			// Transient-after-retries and any other hard error are Failed
+			// (retried on the next run, which still finds the row name-less).
+			result.Failed++
+			logger.Warn().
+				Err(err).
+				Str("message_id", hashIdentifier(gmailID)).
+				Msg("correspondence_rederive: re-fetch failed")
+		}
+		return
+	}
+
+	affected, err := s.comms.BackfillParticipantNames(ctx, row.ID, names)
+	if err != nil {
+		result.Failed++
+		logger.Warn().
+			Err(err).
+			Str("message_id", hashIdentifier(gmailID)).
+			Msg("correspondence_rederive: backfill failed")
+		return
+	}
+	if affected > 0 {
+		result.Rederived++
+	}
+	s.sleep(rederiveInterCallDelay)
+}
+
+// refetchWithRetry calls the provider re-fetch, retrying transient (429/5xx)
+// failures with bounded exponential backoff. A permanent unavailability or a
+// hard error returns immediately.
+func (s *CorrespondenceNameRederiveService) refetchWithRetry(ctx context.Context, accountID, gmailID string) (repository.ParticipantNames, error) {
+	backoff := rederiveBackoffBase
+	var lastErr error
+	for attempt := 0; attempt <= rederiveMaxTransientRetries; attempt++ {
+		names, err := s.fetcher.RefetchParticipantNames(ctx, accountID, gmailID)
+		if err == nil {
+			return names, nil
+		}
+		if !errors.Is(err, errCorrespondenceTransient) {
+			return repository.ParticipantNames{}, err
+		}
+		lastErr = err
+		if attempt < rederiveMaxTransientRetries {
+			s.sleep(backoff)
+			backoff *= 2
+		}
+	}
+	return repository.ParticipantNames{}, lastErr
+}
+
+// resolveRefetchTarget extracts the (accountID, gmailID) re-fetch target from a
+// row. A re-fetch needs BOTH a real connected account_id (newFetcher calls
+// GetClientForAccount) AND that account's per-mailbox gmail id under
+// source_metadata.account_gmail_ids.<account_id>. The __unknown__ key holds a
+// gmail id but no account to fetch with, so it is never a valid target. Returns
+// ok=false (→ SkippedNoGmailID) when either is missing.
+func resolveRefetchTarget(row repository.MissingParticipantNamesRow) (accountID, gmailID string, ok bool) {
+	if row.AccountID == nil || *row.AccountID == "" {
+		return "", "", false
+	}
+	account := *row.AccountID
+	if account == correspondenceUnknownAccountKey {
+		return "", "", false
+	}
+	var meta struct {
+		AccountGmailIDs map[string]string `json:"account_gmail_ids"`
+	}
+	if len(row.SourceMetadata) == 0 {
+		return "", "", false
+	}
+	if err := json.Unmarshal(row.SourceMetadata, &meta); err != nil {
+		return "", "", false
+	}
+	gid, present := meta.AccountGmailIDs[account]
+	if !present || gid == "" {
+		return "", "", false
+	}
+	return account, gid, true
+}

--- a/backend/internal/google/correspondence_rederive.go
+++ b/backend/internal/google/correspondence_rederive.go
@@ -124,9 +124,16 @@ func (s *CorrespondenceNameRederiveService) RederiveNames(ctx context.Context, s
 func (s *CorrespondenceNameRederiveService) processRow(ctx context.Context, row repository.MissingParticipantNamesRow, result *CorrespondenceRederiveResult) {
 	accountID, gmailID, ok := resolveRefetchTarget(row)
 	if !ok {
+		// No Gmail call made — no pacing needed (and we must not slow a backlog
+		// that is mostly account-less rows).
 		result.SkippedNoGmailID++
 		return
 	}
+
+	// Every path below makes at least one Gmail re-fetch, so pace after the call
+	// regardless of outcome — a 404/failure-heavy backlog would otherwise hammer
+	// Gmail back-to-back. Defer keeps the single sleep on all return paths.
+	defer s.sleep(rederiveInterCallDelay)
 
 	names, err := s.refetchWithRetry(ctx, accountID, gmailID)
 	if err != nil {
@@ -157,7 +164,6 @@ func (s *CorrespondenceNameRederiveService) processRow(ctx context.Context, row 
 	if affected > 0 {
 		result.Rederived++
 	}
-	s.sleep(rederiveInterCallDelay)
 }
 
 // refetchWithRetry calls the provider re-fetch, retrying transient (429/5xx)

--- a/backend/internal/google/correspondence_rederive_test.go
+++ b/backend/internal/google/correspondence_rederive_test.go
@@ -1,0 +1,257 @@
+package google
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// --- fakes ---
+
+// fakeRederiveComms serves keyset pages and records backfills. Rows are stored
+// in id order; ListMissingParticipantNames pages by id > afterID. A backfilled
+// id is marked done so a second pass (fresh keyset) returns nothing
+// (idempotency).
+type fakeRederiveComms struct {
+	rows       []repository.MissingParticipantNamesRow
+	done       map[uuid.UUID]bool
+	backfills  []uuid.UUID
+	pageCalls  int
+	maxPerCall int32
+}
+
+func newFakeRederiveComms(rows []repository.MissingParticipantNamesRow) *fakeRederiveComms {
+	return &fakeRederiveComms{rows: rows, done: map[uuid.UUID]bool{}}
+}
+
+func (f *fakeRederiveComms) ListMissingParticipantNames(_ context.Context, _ time.Time, afterID uuid.UUID, batchSize int32) ([]repository.MissingParticipantNamesRow, error) {
+	f.pageCalls++
+	if f.maxPerCall == 0 {
+		f.maxPerCall = batchSize
+	}
+	out := []repository.MissingParticipantNamesRow{}
+	for _, r := range f.rows {
+		if f.done[r.ID] {
+			continue
+		}
+		// keyset: id strictly greater than the cursor (string order matches the
+		// hyphenated-UUID byte order Postgres uses).
+		if afterID != uuid.Nil && r.ID.String() <= afterID.String() {
+			continue
+		}
+		out = append(out, r)
+		if int32(len(out)) >= f.maxPerCall {
+			break
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeRederiveComms) BackfillParticipantNames(_ context.Context, id uuid.UUID, _ repository.ParticipantNames) (int64, error) {
+	f.backfills = append(f.backfills, id)
+	f.done[id] = true
+	return 1, nil
+}
+
+// fakeRederiveFetcher returns canned names or canned errors keyed by gmail id.
+type fakeRederiveFetcher struct {
+	names     map[string]repository.ParticipantNames
+	errs      map[string]error
+	transient map[string]int // gmail id → remaining transient failures before success
+	calls     map[string]int
+}
+
+func newFakeRederiveFetcher() *fakeRederiveFetcher {
+	return &fakeRederiveFetcher{
+		names:     map[string]repository.ParticipantNames{},
+		errs:      map[string]error{},
+		transient: map[string]int{},
+		calls:     map[string]int{},
+	}
+}
+
+func (f *fakeRederiveFetcher) RefetchParticipantNames(_ context.Context, _, gmailID string) (repository.ParticipantNames, error) {
+	f.calls[gmailID]++
+	if n, ok := f.transient[gmailID]; ok && n > 0 {
+		f.transient[gmailID] = n - 1
+		return repository.ParticipantNames{}, fmt.Errorf("%w: 429", errCorrespondenceTransient)
+	}
+	if err, ok := f.errs[gmailID]; ok {
+		return repository.ParticipantNames{}, err
+	}
+	return f.names[gmailID], nil
+}
+
+// --- helpers ---
+
+func rederiveRow(t *testing.T, id uuid.UUID, accountID string, gmailID string) repository.MissingParticipantNamesRow {
+	t.Helper()
+	var acct *string
+	meta := map[string]any{}
+	if accountID != "" {
+		acct = &accountID
+	}
+	if gmailID != "" {
+		key := accountID
+		if key == "" {
+			key = correspondenceUnknownAccountKey
+		}
+		meta["account_gmail_ids"] = map[string]string{key: gmailID}
+	}
+	b, err := json.Marshal(meta)
+	require.NoError(t, err)
+	return repository.MissingParticipantNamesRow{ID: id, AccountID: acct, SourceMetadata: b}
+}
+
+func newRederiveService(comms rederiveCommsRepo, fetcher rederiveFetcher) *CorrespondenceNameRederiveService {
+	s := NewCorrespondenceNameRederiveService(comms, fetcher)
+	s.sleep = func(time.Duration) {} // no real waits in tests
+	return s
+}
+
+// orderedID returns a UUID whose string sorts by n (so keyset ordering in the
+// fake is deterministic across rows).
+func orderedID(n int) uuid.UUID {
+	return uuid.MustParse(fmt.Sprintf("00000000-0000-0000-0000-%012d", n))
+}
+
+// --- tests ---
+
+func TestRederive_HappyPath(t *testing.T) {
+	id := orderedID(1)
+	comms := newFakeRederiveComms([]repository.MissingParticipantNamesRow{
+		rederiveRow(t, id, "me@example.com", "gmail-1"),
+	})
+	fetcher := newFakeRederiveFetcher()
+	fetcher.names["gmail-1"] = repository.ParticipantNames{FromName: "Sender Name", ToNames: []string{"Me"}}
+	s := newRederiveService(comms, fetcher)
+
+	res, err := s.RederiveNames(context.Background(), time.Now().Add(-time.Hour))
+	require.NoError(t, err)
+	require.Equal(t, 1, res.Scanned)
+	require.Equal(t, 1, res.Rederived)
+	require.Equal(t, 0, res.Failed)
+	require.Equal(t, []uuid.UUID{id}, comms.backfills)
+}
+
+func TestRederive_SkippedNoGmailID(t *testing.T) {
+	comms := newFakeRederiveComms([]repository.MissingParticipantNamesRow{
+		// nil account_id
+		rederiveRow(t, orderedID(1), "", "gmail-x"),
+		// only __unknown__ (no real account to fetch with)
+		rederiveRow(t, orderedID(2), "", "gmail-y"),
+		// account set but no gmail id under that account key
+		rederiveRow(t, orderedID(3), "me@example.com", ""),
+	})
+	fetcher := newFakeRederiveFetcher()
+	s := newRederiveService(comms, fetcher)
+
+	res, err := s.RederiveNames(context.Background(), time.Now().Add(-time.Hour))
+	require.NoError(t, err)
+	require.Equal(t, 3, res.Scanned)
+	require.Equal(t, 3, res.SkippedNoGmailID)
+	require.Equal(t, 0, res.Rederived)
+	require.Empty(t, fetcher.calls, "no Gmail call for a row with no fetch target")
+}
+
+func TestRederive_SkippedUnavailableNotFailed(t *testing.T) {
+	id := orderedID(1)
+	comms := newFakeRederiveComms([]repository.MissingParticipantNamesRow{
+		rederiveRow(t, id, "me@example.com", "gone-1"),
+	})
+	fetcher := newFakeRederiveFetcher()
+	fetcher.errs["gone-1"] = fmt.Errorf("%w: 404", errCorrespondenceUnavailable)
+	s := newRederiveService(comms, fetcher)
+
+	res, err := s.RederiveNames(context.Background(), time.Now().Add(-time.Hour))
+	require.NoError(t, err)
+	require.Equal(t, 1, res.SkippedUnavailable)
+	require.Equal(t, 0, res.Failed, "a since-deleted message must NOT count as Failed (no non-zero exit)")
+}
+
+func TestRederive_TransientRetriesThenSucceeds(t *testing.T) {
+	id := orderedID(1)
+	comms := newFakeRederiveComms([]repository.MissingParticipantNamesRow{
+		rederiveRow(t, id, "me@example.com", "flaky-1"),
+	})
+	fetcher := newFakeRederiveFetcher()
+	fetcher.transient["flaky-1"] = 2 // fails twice, then succeeds
+	fetcher.names["flaky-1"] = repository.ParticipantNames{FromName: "Recovered Name"}
+	s := newRederiveService(comms, fetcher)
+
+	res, err := s.RederiveNames(context.Background(), time.Now().Add(-time.Hour))
+	require.NoError(t, err)
+	require.Equal(t, 1, res.Rederived)
+	require.Equal(t, 0, res.Failed)
+	require.Equal(t, 3, fetcher.calls["flaky-1"], "two transient failures + one success")
+}
+
+func TestRederive_TransientExhaustedIsFailed(t *testing.T) {
+	id := orderedID(1)
+	comms := newFakeRederiveComms([]repository.MissingParticipantNamesRow{
+		rederiveRow(t, id, "me@example.com", "always-429"),
+	})
+	fetcher := newFakeRederiveFetcher()
+	fetcher.transient["always-429"] = 99 // never recovers within the retry budget
+	s := newRederiveService(comms, fetcher)
+
+	res, err := s.RederiveNames(context.Background(), time.Now().Add(-time.Hour))
+	require.NoError(t, err)
+	require.Equal(t, 0, res.Rederived)
+	require.Equal(t, 1, res.Failed)
+	// 1 initial + rederiveMaxTransientRetries retries.
+	require.Equal(t, 1+rederiveMaxTransientRetries, fetcher.calls["always-429"])
+}
+
+// Livelock guard: a batch where every row is skipped/failed STILL advances the
+// keyset cursor and the pass terminates (does not re-query the same rows
+// forever). With batchSize smaller than the row count, paging must complete.
+func TestRederive_LivelockGuardTerminates(t *testing.T) {
+	rows := []repository.MissingParticipantNamesRow{
+		rederiveRow(t, orderedID(1), "", "x"),                  // SkippedNoGmailID
+		rederiveRow(t, orderedID(2), "", "y"),                  // SkippedNoGmailID
+		rederiveRow(t, orderedID(3), "me@example.com", "gone"), // SkippedUnavailable
+	}
+	comms := newFakeRederiveComms(rows)
+	comms.maxPerCall = 1 // force multiple pages so the cursor must advance
+	fetcher := newFakeRederiveFetcher()
+	fetcher.errs["gone"] = fmt.Errorf("%w: 404", errCorrespondenceUnavailable)
+	s := newRederiveService(comms, fetcher)
+
+	res, err := s.RederiveNames(context.Background(), time.Now().Add(-time.Hour))
+	require.NoError(t, err)
+	require.Equal(t, 3, res.Scanned, "all rows visited exactly once despite none being rewritten")
+	require.Equal(t, 2, res.SkippedNoGmailID)
+	require.Equal(t, 1, res.SkippedUnavailable)
+	// 3 data pages (one row each) + 1 terminating empty page.
+	require.Equal(t, 4, comms.pageCalls)
+}
+
+// Idempotency: a second full run over already-named rows re-derives nothing.
+func TestRederive_IdempotentSecondRun(t *testing.T) {
+	id := orderedID(1)
+	comms := newFakeRederiveComms([]repository.MissingParticipantNamesRow{
+		rederiveRow(t, id, "me@example.com", "gmail-1"),
+	})
+	fetcher := newFakeRederiveFetcher()
+	fetcher.names["gmail-1"] = repository.ParticipantNames{FromName: "Sender Name"}
+	s := newRederiveService(comms, fetcher)
+
+	res1, err := s.RederiveNames(context.Background(), time.Now().Add(-time.Hour))
+	require.NoError(t, err)
+	require.Equal(t, 1, res1.Rederived)
+
+	// Second run: the fake marks backfilled rows done (mirrors the SQL's
+	// NOT (? 'from_name') guard), so the keyset returns nothing.
+	res2, err := s.RederiveNames(context.Background(), time.Now().Add(-time.Hour))
+	require.NoError(t, err)
+	require.Equal(t, 0, res2.Scanned)
+	require.Equal(t, 0, res2.Rederived)
+}

--- a/backend/internal/google/correspondence_rederive_test.go
+++ b/backend/internal/google/correspondence_rederive_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"personal-crm/backend/internal/accelerated"
 	"personal-crm/backend/internal/repository"
 
 	"github.com/google/uuid"
@@ -133,7 +134,7 @@ func TestRederive_HappyPath(t *testing.T) {
 	fetcher.names["gmail-1"] = repository.ParticipantNames{FromName: "Sender Name", ToNames: []string{"Me"}}
 	s := newRederiveService(comms, fetcher)
 
-	res, err := s.RederiveNames(context.Background(), time.Now().Add(-time.Hour))
+	res, err := s.RederiveNames(context.Background(), accelerated.GetCurrentTime().Add(-time.Hour))
 	require.NoError(t, err)
 	require.Equal(t, 1, res.Scanned)
 	require.Equal(t, 1, res.Rederived)
@@ -153,7 +154,7 @@ func TestRederive_SkippedNoGmailID(t *testing.T) {
 	fetcher := newFakeRederiveFetcher()
 	s := newRederiveService(comms, fetcher)
 
-	res, err := s.RederiveNames(context.Background(), time.Now().Add(-time.Hour))
+	res, err := s.RederiveNames(context.Background(), accelerated.GetCurrentTime().Add(-time.Hour))
 	require.NoError(t, err)
 	require.Equal(t, 3, res.Scanned)
 	require.Equal(t, 3, res.SkippedNoGmailID)
@@ -170,7 +171,7 @@ func TestRederive_SkippedUnavailableNotFailed(t *testing.T) {
 	fetcher.errs["gone-1"] = fmt.Errorf("%w: 404", errCorrespondenceUnavailable)
 	s := newRederiveService(comms, fetcher)
 
-	res, err := s.RederiveNames(context.Background(), time.Now().Add(-time.Hour))
+	res, err := s.RederiveNames(context.Background(), accelerated.GetCurrentTime().Add(-time.Hour))
 	require.NoError(t, err)
 	require.Equal(t, 1, res.SkippedUnavailable)
 	require.Equal(t, 0, res.Failed, "a since-deleted message must NOT count as Failed (no non-zero exit)")
@@ -186,7 +187,7 @@ func TestRederive_TransientRetriesThenSucceeds(t *testing.T) {
 	fetcher.names["flaky-1"] = repository.ParticipantNames{FromName: "Recovered Name"}
 	s := newRederiveService(comms, fetcher)
 
-	res, err := s.RederiveNames(context.Background(), time.Now().Add(-time.Hour))
+	res, err := s.RederiveNames(context.Background(), accelerated.GetCurrentTime().Add(-time.Hour))
 	require.NoError(t, err)
 	require.Equal(t, 1, res.Rederived)
 	require.Equal(t, 0, res.Failed)
@@ -202,7 +203,7 @@ func TestRederive_TransientExhaustedIsFailed(t *testing.T) {
 	fetcher.transient["always-429"] = 99 // never recovers within the retry budget
 	s := newRederiveService(comms, fetcher)
 
-	res, err := s.RederiveNames(context.Background(), time.Now().Add(-time.Hour))
+	res, err := s.RederiveNames(context.Background(), accelerated.GetCurrentTime().Add(-time.Hour))
 	require.NoError(t, err)
 	require.Equal(t, 0, res.Rederived)
 	require.Equal(t, 1, res.Failed)
@@ -225,7 +226,7 @@ func TestRederive_LivelockGuardTerminates(t *testing.T) {
 	fetcher.errs["gone"] = fmt.Errorf("%w: 404", errCorrespondenceUnavailable)
 	s := newRederiveService(comms, fetcher)
 
-	res, err := s.RederiveNames(context.Background(), time.Now().Add(-time.Hour))
+	res, err := s.RederiveNames(context.Background(), accelerated.GetCurrentTime().Add(-time.Hour))
 	require.NoError(t, err)
 	require.Equal(t, 3, res.Scanned, "all rows visited exactly once despite none being rewritten")
 	require.Equal(t, 2, res.SkippedNoGmailID)
@@ -244,13 +245,13 @@ func TestRederive_IdempotentSecondRun(t *testing.T) {
 	fetcher.names["gmail-1"] = repository.ParticipantNames{FromName: "Sender Name"}
 	s := newRederiveService(comms, fetcher)
 
-	res1, err := s.RederiveNames(context.Background(), time.Now().Add(-time.Hour))
+	res1, err := s.RederiveNames(context.Background(), accelerated.GetCurrentTime().Add(-time.Hour))
 	require.NoError(t, err)
 	require.Equal(t, 1, res1.Rederived)
 
 	// Second run: the fake marks backfilled rows done (mirrors the SQL's
 	// NOT (? 'from_name') guard), so the keyset returns nothing.
-	res2, err := s.RederiveNames(context.Background(), time.Now().Add(-time.Hour))
+	res2, err := s.RederiveNames(context.Background(), accelerated.GetCurrentTime().Add(-time.Hour))
 	require.NoError(t, err)
 	require.Equal(t, 0, res2.Scanned)
 	require.Equal(t, 0, res2.Rederived)

--- a/backend/internal/google/gmail.go
+++ b/backend/internal/google/gmail.go
@@ -133,6 +133,14 @@ type attachmentMeta struct {
 // emailMetadata is the non-provenance JSON the provider assembles into
 // comms_message.source_metadata. The provenance keys (observed_accounts,
 // account_gmail_ids) are added by the UpsertCommsMessage query, NOT here.
+//
+// The *Name(s) fields carry the parsed display names index-aligned with their
+// bare-address siblings (FromName ↔ From; ToNames[i] ↔ To[i]; etc.). They are
+// additive: the bare-address keys keep their original shape so existing
+// consumers and the provenance-merge JSON contract are undisturbed. The
+// correspondence-enrichment producer pairs each address with its display name
+// to trigram-match unknown correspondents against CRM contacts. A header
+// without a display part stores the empty string at that index.
 type emailMetadata struct {
 	HTML        string           `json:"html,omitempty"`
 	Attachments []attachmentMeta `json:"attachments,omitempty"`
@@ -141,6 +149,10 @@ type emailMetadata struct {
 	To          []string         `json:"to,omitempty"`
 	Cc          []string         `json:"cc,omitempty"`
 	Bcc         []string         `json:"bcc,omitempty"`
+	FromName    string           `json:"from_name,omitempty"`
+	ToNames     []string         `json:"to_names,omitempty"`
+	CcNames     []string         `json:"cc_names,omitempty"`
+	BccNames    []string         `json:"bcc_names,omitempty"`
 }
 
 // qualifiedRow is the provider's internal per-(message, contact, direction)
@@ -683,16 +695,17 @@ func (p *GmailSyncProvider) processMessage(
 
 	headers := newHeaderLookup(msg.Payload)
 	subject := headers.first("Subject")
-	fromRaw, fromNorm := parseSingleAddress(headers.first("From"))
-	toRaw, toNorm := parseAddressList(headers.first("To"))
-	ccRaw, ccNorm := parseAddressList(headers.first("Cc"))
-	bccRaw, bccNorm := parseAddressList(headers.first("Bcc"))
+	fromRaw, fromNorm, fromName := parseSingleAddress(headers.first("From"))
+	toRaw, toNorm, toNames := parseAddressList(headers.first("To"))
+	ccRaw, ccNorm, ccNames := parseAddressList(headers.first("Cc"))
+	bccRaw, bccNorm, bccNames := parseAddressList(headers.first("Bcc"))
 
 	externalID := extractExternalID(headers, accountID, msg.Id)
 	localDay := computeLocalDay(epochMillisToTime(msg.InternalDate), time.Local)
 	sentAt := epochMillisToTime(msg.InternalDate)
 
-	metadata := buildMetadataJSON(htmlBody, attachments, msg.LabelIds, fromRaw, toRaw, ccRaw, bccRaw)
+	metadata := buildMetadataJSON(htmlBody, attachments, msg.LabelIds,
+		fromRaw, toRaw, ccRaw, bccRaw, fromName, toNames, ccNames, bccNames)
 
 	// Recipient set R (normalized To ∪ Cc ∪ Bcc), and whether M ∩ R ≠ ∅.
 	recipientSet := make(map[string]struct{})
@@ -881,33 +894,39 @@ func (h headerLookup) first(name string) string {
 }
 
 // parseSingleAddress parses a single-address header (From). Returns the raw and
-// normalized address. On parse failure it falls back to trimming the raw value.
-func parseSingleAddress(header string) (raw, normalized string) {
+// normalized address plus the parsed display name (empty when the header had no
+// display part or failed to parse). On parse failure it falls back to trimming
+// the raw value. The name return is additive — existing callers ignore it.
+func parseSingleAddress(header string) (raw, normalized, name string) {
 	header = strings.TrimSpace(header)
 	if header == "" {
-		return "", ""
+		return "", "", ""
 	}
 	if addr, err := mail.ParseAddress(header); err == nil {
-		return addr.Address, matching.NormalizeEmail(addr.Address)
+		return addr.Address, matching.NormalizeEmail(addr.Address), strings.TrimSpace(addr.Name)
 	}
-	return header, matching.NormalizeEmail(header)
+	return header, matching.NormalizeEmail(header), ""
 }
 
 // parseAddressList parses an address-list header (To/Cc/Bcc) robustly. On a
 // ParseAddressList failure it falls back to a lenient comma-split so a single
-// malformed recipient doesn't drop the whole list. Raw and normalized slices
-// are index-aligned.
-func parseAddressList(header string) (raws, normalized []string) {
+// malformed recipient doesn't drop the whole list. The raw, normalized, and
+// name slices are index-aligned on BOTH paths (a recipient with no display part
+// gets an empty-string name at its index), so the correspondence producer can
+// pair names[i] with the address at the same index. The names return is
+// additive — existing callers ignore it.
+func parseAddressList(header string) (raws, normalized, names []string) {
 	header = strings.TrimSpace(header)
 	if header == "" {
-		return nil, nil
+		return nil, nil, nil
 	}
 	if addrs, err := mail.ParseAddressList(header); err == nil {
 		for _, a := range addrs {
 			raws = append(raws, a.Address)
 			normalized = append(normalized, matching.NormalizeEmail(a.Address))
+			names = append(names, strings.TrimSpace(a.Name))
 		}
-		return raws, normalized
+		return raws, normalized, names
 	}
 	for _, part := range strings.Split(header, ",") {
 		part = strings.TrimSpace(part)
@@ -915,13 +934,16 @@ func parseAddressList(header string) (raws, normalized []string) {
 			continue
 		}
 		raw := part
+		name := ""
 		if addr, err := mail.ParseAddress(part); err == nil {
 			raw = addr.Address
+			name = strings.TrimSpace(addr.Name)
 		}
 		raws = append(raws, raw)
 		normalized = append(normalized, matching.NormalizeEmail(raw))
+		names = append(names, name)
 	}
-	return raws, normalized
+	return raws, normalized, names
 }
 
 // extractExternalID reads the RFC822 Message-ID header (trimming surrounding
@@ -1050,10 +1072,20 @@ func stripHTML(s string) string {
 }
 
 // buildMetadataJSON assembles the non-provenance source_metadata JSON the
-// provider owns (html, attachments, labels, from/to/cc/bcc). The provenance
-// keys (observed_accounts, account_gmail_ids) are added by the
-// UpsertCommsMessage query, not here.
-func buildMetadataJSON(htmlBody string, attachments []attachmentMeta, labels []string, fromRaw string, toRaw, ccRaw, bccRaw []string) []byte {
+// provider owns (html, attachments, labels, from/to/cc/bcc + their index-aligned
+// display names). The provenance keys (observed_accounts, account_gmail_ids) are
+// added by the UpsertCommsMessage query, not here. The *Name(s) slices stay
+// index-aligned with their address siblings (the parsers guarantee this on both
+// the happy path and the lenient comma-split fallback).
+func buildMetadataJSON(
+	htmlBody string,
+	attachments []attachmentMeta,
+	labels []string,
+	fromRaw string,
+	toRaw, ccRaw, bccRaw []string,
+	fromName string,
+	toNames, ccNames, bccNames []string,
+) []byte {
 	meta := emailMetadata{
 		HTML:        htmlBody,
 		Attachments: attachments,
@@ -1062,6 +1094,10 @@ func buildMetadataJSON(htmlBody string, attachments []attachmentMeta, labels []s
 		To:          toRaw,
 		Cc:          ccRaw,
 		Bcc:         bccRaw,
+		FromName:    fromName,
+		ToNames:     toNames,
+		CcNames:     ccNames,
+		BccNames:    bccNames,
 	}
 	b, err := json.Marshal(meta)
 	if err != nil {

--- a/backend/internal/google/gmail.go
+++ b/backend/internal/google/gmail.go
@@ -142,6 +142,14 @@ type attachmentMeta struct {
 // correspondence-enrichment producer pairs each address with its display name
 // to trigram-match unknown correspondents against CRM contacts. A header
 // without a display part stores the empty string at that index.
+//
+// FromName deliberately has NO omitempty: it is always written (even as "")
+// so every row ingested after display-name capture shipped carries the
+// from_name key. The historical re-derivation selects rows with NO from_name
+// key; if a bare-From row omitted the key it would look "pre-capture" forever
+// and be re-fetched on every catchup run. Always writing the key marks a row
+// as "names already captured at ingest". (ToNames/CcNames/BccNames keep
+// omitempty — they are not part of the re-derivation predicate.)
 type emailMetadata struct {
 	HTML        string           `json:"html,omitempty"`
 	Attachments []attachmentMeta `json:"attachments,omitempty"`
@@ -150,7 +158,7 @@ type emailMetadata struct {
 	To          []string         `json:"to,omitempty"`
 	Cc          []string         `json:"cc,omitempty"`
 	Bcc         []string         `json:"bcc,omitempty"`
-	FromName    string           `json:"from_name,omitempty"`
+	FromName    string           `json:"from_name"`
 	ToNames     []string         `json:"to_names,omitempty"`
 	CcNames     []string         `json:"cc_names,omitempty"`
 	BccNames    []string         `json:"bcc_names,omitempty"`

--- a/backend/internal/google/gmail.go
+++ b/backend/internal/google/gmail.go
@@ -27,6 +27,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"google.golang.org/api/gmail/v1"
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
 )
 
@@ -469,6 +470,59 @@ func (p *GmailSyncProvider) ScanIdentifier(
 		return matched, fmt.Errorf("scan identifier: %w", err)
 	}
 	return matched, nil
+}
+
+// RefetchParticipantNames re-fetches one already-ingested message by its
+// per-mailbox Gmail id and re-parses the From/To/Cc/Bcc display names. It is
+// the re-fetch seam for the one-time historical display-name re-derivation
+// (crm-admin --rederive-correspondence-names): the bare addresses stored at
+// first ingest cannot recover the display names, so the runner must re-fetch
+// the original headers. Reuses the existing fetcher + name-returning parsers;
+// tests inject a fake fetcher via SetFetcherFactoryForTest (no OAuth).
+//
+// Error classification (so the runner can distinguish a since-deleted message
+// from a retryable failure): a Gmail 404 → errCorrespondenceUnavailable
+// (PERMANENT — count SkippedUnavailable, never a non-zero exit); a 429/5xx →
+// errCorrespondenceTransient (retryable). Other errors propagate as-is and the
+// runner counts them Failed.
+func (p *GmailSyncProvider) RefetchParticipantNames(ctx context.Context, accountID, gmailMessageID string) (repository.ParticipantNames, error) {
+	fetcher, err := p.newFetcher(ctx, accountID)
+	if err != nil {
+		return repository.ParticipantNames{}, fmt.Errorf("build gmail fetcher: %w", err)
+	}
+	msg, err := fetcher.GetMessage(ctx, gmailMessageID)
+	if err != nil {
+		return repository.ParticipantNames{}, classifyRefetchError(err)
+	}
+	headers := newHeaderLookup(msg.Payload)
+	_, _, fromName := parseSingleAddress(headers.first("From"))
+	_, _, toNames := parseAddressList(headers.first("To"))
+	_, _, ccNames := parseAddressList(headers.first("Cc"))
+	_, _, bccNames := parseAddressList(headers.first("Bcc"))
+	return repository.ParticipantNames{
+		FromName: fromName,
+		ToNames:  toNames,
+		CcNames:  ccNames,
+		BccNames: bccNames,
+	}, nil
+}
+
+// classifyRefetchError maps a GetMessage error to a permanent
+// (errCorrespondenceUnavailable) or transient (errCorrespondenceTransient)
+// sentinel the re-derivation runner branches on. A googleapi 404 is permanent
+// (the message is gone upstream); 429 / 5xx are transient (backoff + retry).
+// Anything else is returned wrapped (the runner counts it Failed).
+func classifyRefetchError(err error) error {
+	var apiErr *googleapi.Error
+	if errors.As(err, &apiErr) {
+		switch {
+		case apiErr.Code == 404:
+			return fmt.Errorf("%w: %v", errCorrespondenceUnavailable, err)
+		case apiErr.Code == 429 || (apiErr.Code >= 500 && apiErr.Code < 600):
+			return fmt.Errorf("%w: %v", errCorrespondenceTransient, err)
+		}
+	}
+	return fmt.Errorf("refetch message: %w", err)
 }
 
 // MeSet builds the "me" set (the normalized address of every connected

--- a/backend/internal/google/gmail_correspondence.go
+++ b/backend/internal/google/gmail_correspondence.go
@@ -163,11 +163,19 @@ func (s *GmailCorrespondenceSuggester) Run(ctx context.Context, since time.Time)
 	aggregates := s.aggregate(rows, known, own)
 
 	upserted := 0
+	failed := 0
+	var firstErr error
 	for _, agg := range aggregates {
 		ok, err := s.evaluateAndUpsert(ctx, agg)
 		if err != nil {
-			// Continue-on-error: one bad address must not abort the whole scan.
-			// River retries the periodic job on the next tick anyway.
+			// Continue-on-error so one bad address does not abort the whole
+			// scan, but remember the failure: a swallowed DB error would let the
+			// worker / catchup report success while silently emitting nothing
+			// (e.g. a DB outage), so Run surfaces an aggregated error at the end.
+			failed++
+			if firstErr == nil {
+				firstErr = err
+			}
 			logger.Warn().
 				Err(err).
 				Str("address", hashIdentifier(agg.address)).
@@ -184,6 +192,9 @@ func (s *GmailCorrespondenceSuggester) Run(ctx context.Context, since time.Time)
 			Int("candidates_upserted", upserted).
 			Int("addresses_scanned", len(aggregates)).
 			Msg("gmail_correspondence: scan upserted candidates")
+	}
+	if failed > 0 {
+		return upserted, fmt.Errorf("gmail_correspondence scan: %d of %d addresses failed (first: %w)", failed, len(aggregates), firstErr)
 	}
 	return upserted, nil
 }

--- a/backend/internal/google/gmail_correspondence.go
+++ b/backend/internal/google/gmail_correspondence.go
@@ -1,0 +1,432 @@
+package google
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/logger"
+	"personal-crm/backend/internal/matching"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+)
+
+const (
+	// CorrespondenceSource is the external_contact.source tag for candidates
+	// the correspondence-enrichment producer emits. It is a LINK-ONLY source
+	// (the import-suggestions policy never lets it create a new contact); the
+	// producer only ever proposes adding an observed address to an EXISTING
+	// CRM contact.
+	CorrespondenceSource = "gmail_correspondence"
+
+	// correspondenceSimThreshold is the empirically-calibrated minimum name
+	// similarity (§4 gate): an unknown address qualifies only when its observed
+	// display name matches a CRM contact at sim >= 0.60. The gate yielded ~93%
+	// precision on the validation sample; loosening it is a conscious change a
+	// regression test pins.
+	correspondenceSimThreshold = 0.60
+
+	// correspondenceSimFloor is passed to the FindSimilarContacts SQL, which
+	// filters with a STRICT `>` (similarity > threshold). To honor the `>= 0.60`
+	// gate we pass a floor a hair below 0.60 so the SQL returns exact-0.60 rows,
+	// then re-check `>= correspondenceSimThreshold` in Go. The epsilon must
+	// survive the query's float32 (`::real`) cast: 1e-9 is below the float32 ULP
+	// at 0.60 (~6e-8) and would round back to 0.60, re-rejecting exact-0.60
+	// matches; 1e-6 is comfortably above that ULP yet far below the next distinct
+	// similarity score, so it admits exactly the rows a true `>= 0.60` test would.
+	correspondenceSimFloor = correspondenceSimThreshold - 1e-6
+
+	// correspondenceMinNameTokens is the §4 token gate: a display name must have
+	// at least two whitespace-separated tokens (a full name), since bare first
+	// names are the dominant noise source.
+	correspondenceMinNameTokens = 2
+
+	// correspondenceMatchLimit caps the FindSimilarContacts result set per
+	// observed name. We only need the best match, but request a few so the
+	// Go-side `>= 0.60` re-check has the top candidates to choose from.
+	correspondenceMatchLimit = 5
+
+	// CorrespondenceWindow is the steady-state recent-window the periodic scan
+	// covers. The scan is idempotent so re-scanning the same window every tick
+	// is harmless; the historical catchup subcommand passes a wider `since`.
+	CorrespondenceWindow = 120 * 24 * time.Hour
+)
+
+// correspondenceMetadata is the participant-list view the producer unmarshals
+// from comms_message.source_metadata. The bare-address fields are already
+// parsed/normalized at ingest; the *Name(s) fields (added by display-name
+// capture) are index-aligned with their address siblings.
+type correspondenceMetadata struct {
+	From     string   `json:"from"`
+	To       []string `json:"to"`
+	Cc       []string `json:"cc"`
+	Bcc      []string `json:"bcc"`
+	FromName string   `json:"from_name"`
+	ToNames  []string `json:"to_names"`
+	CcNames  []string `json:"cc_names"`
+	BccNames []string `json:"bcc_names"`
+}
+
+// correspondenceContactRepo is the narrow contact surface the producer needs:
+// the §4 trigram gate (FindSimilarContacts) and a name lookup for the
+// co-occurring-contact evidence. Concrete: *repository.ContactRepository.
+type correspondenceContactRepo interface {
+	FindSimilarContacts(ctx context.Context, name string, threshold float64, limit int32) ([]repository.ContactMatch, error)
+	GetContact(ctx context.Context, id uuid.UUID) (*repository.Contact, error)
+}
+
+// correspondenceExternalRepo is the narrow external_contact surface the
+// producer needs (sticky-ignore read + candidate upsert). Concrete:
+// *repository.ExternalContactRepository.
+type correspondenceExternalRepo interface {
+	GetBySource(ctx context.Context, source, sourceID string, accountID *string) (*repository.ExternalContact, error)
+	Upsert(ctx context.Context, req repository.UpsertExternalContactRequest) (*repository.ExternalContact, error)
+}
+
+// correspondenceCommsRepo is the narrow comms_message surface the producer
+// needs (known-address set + recent participant scan). Concrete:
+// *repository.CommsMessageRepository.
+type correspondenceCommsRepo interface {
+	ListEmailIdentitiesForSync(ctx context.Context) ([]repository.EmailIdentity, error)
+	ListParticipantsSince(ctx context.Context, since time.Time) ([]repository.CommsMessageParticipantRow, error)
+}
+
+// GmailCorrespondenceSuggester mines the participants of already-ingested
+// known-contact email threads to discover addresses that belong to EXISTING
+// CRM contacts but aren't on their record yet, surfacing each as a link-only
+// candidate. It reads only stored comms_message participants — it never fetches
+// mail. Idempotent: re-runs upsert the same per-address rows and skip
+// already-known / already-ignored addresses.
+type GmailCorrespondenceSuggester struct {
+	commsRepo    correspondenceCommsRepo
+	contactRepo  correspondenceContactRepo
+	externalRepo correspondenceExternalRepo
+	// meSet returns the connected-account ("own") address set so the producer
+	// drops the user's own addresses. Reuses the Gmail provider's MeSet seam so
+	// the set comes from the same source and tests can inject it.
+	meSet func(ctx context.Context) (map[string]struct{}, error)
+}
+
+// NewGmailCorrespondenceSuggester builds the producer. All deps are constructed
+// in main.go; meSet is the Gmail provider's MeSet method.
+func NewGmailCorrespondenceSuggester(
+	commsRepo correspondenceCommsRepo,
+	contactRepo correspondenceContactRepo,
+	externalRepo correspondenceExternalRepo,
+	meSet func(ctx context.Context) (map[string]struct{}, error),
+) *GmailCorrespondenceSuggester {
+	return &GmailCorrespondenceSuggester{
+		commsRepo:    commsRepo,
+		contactRepo:  contactRepo,
+		externalRepo: externalRepo,
+		meSet:        meSet,
+	}
+}
+
+// correspondenceAggregate accumulates per-unknown-address evidence across all
+// scanned rows before the §4 gate runs once per address.
+type correspondenceAggregate struct {
+	address      string   // normalized unknown address (the candidate source_id)
+	namesSeen    []string // deduped observed display names (>=1 token)
+	messageCount int
+	// coOccurrence counts how often this address co-appeared with each known
+	// contact (the row's matched_contact_id). The most-frequent is the
+	// co-occurring contact recorded as evidence (tie-break by id for stability).
+	coOccurrence map[uuid.UUID]int
+}
+
+// Run scans comms_message email rows from `since` forward, applies the §4 gate
+// to each unknown correspondent, and upserts a gmail_correspondence candidate
+// per qualifying address. The periodic worker passes now-CorrespondenceWindow;
+// the historical catchup passes the backfill floor. Returns the number of
+// candidates upserted. Idempotent and error-free on empty input.
+func (s *GmailCorrespondenceSuggester) Run(ctx context.Context, since time.Time) (int, error) {
+	known, err := s.buildKnownSet(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("build known set: %w", err)
+	}
+	own, err := s.meSet(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("build own-account set: %w", err)
+	}
+
+	rows, err := s.commsRepo.ListParticipantsSince(ctx, since)
+	if err != nil {
+		return 0, fmt.Errorf("list participants: %w", err)
+	}
+
+	aggregates := s.aggregate(rows, known, own)
+
+	upserted := 0
+	for _, agg := range aggregates {
+		ok, err := s.evaluateAndUpsert(ctx, agg)
+		if err != nil {
+			// Continue-on-error: one bad address must not abort the whole scan.
+			// River retries the periodic job on the next tick anyway.
+			logger.Warn().
+				Err(err).
+				Str("address", hashIdentifier(agg.address)).
+				Msg("gmail_correspondence: evaluate/upsert failed")
+			continue
+		}
+		if ok {
+			upserted++
+		}
+	}
+
+	if upserted > 0 {
+		logger.Info().
+			Int("candidates_upserted", upserted).
+			Int("addresses_scanned", len(aggregates)).
+			Msg("gmail_correspondence: scan upserted candidates")
+	}
+	return upserted, nil
+}
+
+// buildKnownSet returns the set of normalized addresses that already belong to
+// a CRM contact (every email contact_method). An address in this set is never
+// emitted (it is either already on a contact, or the matched contact's own).
+func (s *GmailCorrespondenceSuggester) buildKnownSet(ctx context.Context) (map[string]struct{}, error) {
+	identities, err := s.commsRepo.ListEmailIdentitiesForSync(ctx)
+	if err != nil {
+		return nil, err
+	}
+	known := make(map[string]struct{}, len(identities))
+	for _, id := range identities {
+		if id.ValueNormalized != "" {
+			known[id.ValueNormalized] = struct{}{}
+		}
+	}
+	return known, nil
+}
+
+// aggregate folds every scanned row's participants into per-unknown-address
+// evidence, dropping known and own-account addresses. Returns aggregates keyed
+// (and iterable) deterministically — a sorted slice — so a Go map's randomized
+// iteration order never makes the output non-deterministic.
+func (s *GmailCorrespondenceSuggester) aggregate(
+	rows []repository.CommsMessageParticipantRow,
+	known, own map[string]struct{},
+) []*correspondenceAggregate {
+	byAddress := make(map[string]*correspondenceAggregate)
+
+	for _, row := range rows {
+		var meta correspondenceMetadata
+		if len(row.SourceMetadata) == 0 {
+			continue
+		}
+		if err := json.Unmarshal(row.SourceMetadata, &meta); err != nil {
+			// A row whose metadata won't parse is skipped, not fatal.
+			continue
+		}
+		for _, p := range meta.participants() {
+			normAddr := matching.NormalizeEmail(p.address)
+			if normAddr == "" {
+				continue
+			}
+			if _, ok := known[normAddr]; ok {
+				continue
+			}
+			if _, ok := own[normAddr]; ok {
+				continue
+			}
+			agg := byAddress[normAddr]
+			if agg == nil {
+				agg = &correspondenceAggregate{
+					address:      normAddr,
+					coOccurrence: make(map[uuid.UUID]int),
+				}
+				byAddress[normAddr] = agg
+			}
+			agg.messageCount++
+			if name := strings.TrimSpace(p.name); name != "" {
+				agg.namesSeen = appendUnique(agg.namesSeen, name)
+			}
+			if row.MatchedContactID != uuid.Nil {
+				agg.coOccurrence[row.MatchedContactID]++
+			}
+		}
+	}
+
+	out := make([]*correspondenceAggregate, 0, len(byAddress))
+	for _, agg := range byAddress {
+		out = append(out, agg)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].address < out[j].address
+	})
+	return out
+}
+
+// evaluateAndUpsert applies the §4 gate to one aggregated address and, if it
+// qualifies, upserts its gmail_correspondence candidate. Returns true iff a
+// candidate was upserted.
+func (s *GmailCorrespondenceSuggester) evaluateAndUpsert(ctx context.Context, agg *correspondenceAggregate) (bool, error) {
+	// Take the most-informative observed display name (the most tokens, then the
+	// longest) — bare first names are dropped by the token gate.
+	name := bestDisplayName(agg.namesSeen)
+	if tokenCount(name) < correspondenceMinNameTokens {
+		return false, nil
+	}
+
+	matches, err := s.contactRepo.FindSimilarContacts(ctx, name, correspondenceSimFloor, correspondenceMatchLimit)
+	if err != nil {
+		return false, fmt.Errorf("find similar contacts: %w", err)
+	}
+	var best *repository.ContactMatch
+	for i := range matches {
+		// Go-side `>=` re-check: the SQL is strict `>` against the floor, so
+		// honor the spec's `>= 0.60` here.
+		if matches[i].Similarity < correspondenceSimThreshold {
+			continue
+		}
+		if best == nil || matches[i].Similarity > best.Similarity {
+			best = &matches[i]
+		}
+	}
+	if best == nil {
+		return false, nil
+	}
+
+	// Sticky-ignore: if a live ignored row already exists for this address, skip
+	// the upsert. This is a write-avoidance optimization — the shared Upsert's
+	// DO UPDATE SET never touches match_status, so an ignored row would stay
+	// ignored even without this guard, but skipping avoids a pointless write.
+	existing, err := s.externalRepo.GetBySource(ctx, CorrespondenceSource, agg.address, nil)
+	if err != nil {
+		return false, fmt.Errorf("get existing candidate: %w", err)
+	}
+	if existing != nil && existing.DeletedAt == nil && existing.MatchStatus == repository.MatchStatusIgnored {
+		return false, nil
+	}
+
+	metadata := s.buildEvidence(ctx, agg)
+	now := accelerated.GetCurrentTime()
+	displayName := name
+	if _, err := s.externalRepo.Upsert(ctx, repository.UpsertExternalContactRequest{
+		Source:      CorrespondenceSource,
+		SourceID:    agg.address,
+		DisplayName: &displayName,
+		Emails:      []repository.EmailEntry{{Value: agg.address}},
+		Metadata:    metadata,
+		SyncedAt:    &now,
+	}); err != nil {
+		return false, fmt.Errorf("upsert candidate: %w", err)
+	}
+	return true, nil
+}
+
+// buildEvidence assembles the metadata the card renders: deduped observed
+// names, message count, and the strongest co-occurring known contact (id +
+// resolved name). A name-lookup failure degrades to id-only evidence rather
+// than dropping the candidate.
+func (s *GmailCorrespondenceSuggester) buildEvidence(ctx context.Context, agg *correspondenceAggregate) map[string]any {
+	metadata := map[string]any{
+		"display_names_seen": agg.namesSeen,
+		"message_count":      agg.messageCount,
+	}
+	if co := strongestCoOccurrence(agg.coOccurrence); co != uuid.Nil {
+		coContact := map[string]any{"id": co.String()}
+		if contact, err := s.contactRepo.GetContact(ctx, co); err == nil && contact != nil {
+			coContact["name"] = contact.FullName
+		}
+		metadata["co_occurring_contact"] = coContact
+	}
+	return metadata
+}
+
+// participant is one (display_name, address) pair extracted from a message's
+// participant lists.
+type participant struct {
+	name    string
+	address string
+}
+
+// participants flattens the metadata's from/to/cc/bcc lists into
+// (display_name, address) pairs, pairing each address with its index-aligned
+// name. A name slice shorter than its address slice (defensively tolerated,
+// e.g. pre-capture rows or a parse mismatch) yields an empty name for the
+// unpaired addresses rather than a panic.
+func (m correspondenceMetadata) participants() []participant {
+	out := make([]participant, 0, 1+len(m.To)+len(m.Cc)+len(m.Bcc))
+	if m.From != "" {
+		out = append(out, participant{name: m.FromName, address: m.From})
+	}
+	out = append(out, zip(m.To, m.ToNames)...)
+	out = append(out, zip(m.Cc, m.CcNames)...)
+	out = append(out, zip(m.Bcc, m.BccNames)...)
+	return out
+}
+
+// zip pairs each address with its index-aligned name; a missing name (slice
+// shorter than addresses) becomes the empty string.
+func zip(addresses, names []string) []participant {
+	out := make([]participant, 0, len(addresses))
+	for i, addr := range addresses {
+		if addr == "" {
+			continue
+		}
+		name := ""
+		if i < len(names) {
+			name = names[i]
+		}
+		out = append(out, participant{name: name, address: addr})
+	}
+	return out
+}
+
+// appendUnique appends v to s only if not already present (case-insensitive).
+func appendUnique(s []string, v string) []string {
+	for _, existing := range s {
+		if strings.EqualFold(existing, v) {
+			return s
+		}
+	}
+	return append(s, v)
+}
+
+// tokenCount counts whitespace-separated non-empty tokens in name.
+func tokenCount(name string) int {
+	return len(strings.Fields(name))
+}
+
+// bestDisplayName picks the most-informative observed name: most tokens, then
+// longest, with a lexical tie-break for determinism. Returns "" for empty input.
+func bestDisplayName(names []string) string {
+	best := ""
+	bestTokens := -1
+	for _, n := range names {
+		n = strings.TrimSpace(n)
+		if n == "" {
+			continue
+		}
+		t := tokenCount(n)
+		switch {
+		case t > bestTokens:
+			best, bestTokens = n, t
+		case t == bestTokens && len(n) > len(best):
+			best = n
+		case t == bestTokens && len(n) == len(best) && n < best:
+			best = n
+		}
+	}
+	return best
+}
+
+// strongestCoOccurrence returns the most-frequent co-occurring contact id,
+// tie-broken by smallest id for stability. Returns uuid.Nil when empty.
+func strongestCoOccurrence(counts map[uuid.UUID]int) uuid.UUID {
+	best := uuid.Nil
+	bestCount := 0
+	for id, c := range counts {
+		if c > bestCount || (c == bestCount && (best == uuid.Nil || id.String() < best.String())) {
+			best, bestCount = id, c
+		}
+	}
+	return best
+}

--- a/backend/internal/google/gmail_correspondence.go
+++ b/backend/internal/google/gmail_correspondence.go
@@ -235,6 +235,11 @@ func (s *GmailCorrespondenceSuggester) aggregate(
 			// A row whose metadata won't parse is skipped, not fatal.
 			continue
 		}
+		// Track which unknown addresses this single message contributed to, so
+		// an address appearing in more than one bucket of the SAME message (e.g.
+		// both To and Cc) counts as one message, not two — message_count is a
+		// per-message tally, not a per-occurrence one.
+		seenThisRow := make(map[string]struct{})
 		for _, p := range meta.participants() {
 			normAddr := matching.NormalizeEmail(p.address)
 			if normAddr == "" {
@@ -254,12 +259,15 @@ func (s *GmailCorrespondenceSuggester) aggregate(
 				}
 				byAddress[normAddr] = agg
 			}
-			agg.messageCount++
+			if _, dup := seenThisRow[normAddr]; !dup {
+				seenThisRow[normAddr] = struct{}{}
+				agg.messageCount++
+				if row.MatchedContactID != uuid.Nil {
+					agg.coOccurrence[row.MatchedContactID]++
+				}
+			}
 			if name := strings.TrimSpace(p.name); name != "" {
 				agg.namesSeen = appendUnique(agg.namesSeen, name)
-			}
-			if row.MatchedContactID != uuid.Nil {
-				agg.coOccurrence[row.MatchedContactID]++
 			}
 		}
 	}

--- a/backend/internal/google/gmail_correspondence_test.go
+++ b/backend/internal/google/gmail_correspondence_test.go
@@ -3,6 +3,7 @@ package google
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
@@ -51,14 +52,20 @@ func (f *fakeCorrespondenceContacts) GetContact(_ context.Context, id uuid.UUID)
 }
 
 // fakeCorrespondenceExternal records upserts and serves a seeded sticky-ignore
-// row. Keyed by source_id (the normalized address).
+// row. Keyed by source_id (the normalized address). upsertErr maps a source_id
+// to an error the Upsert should return (to exercise the continue-on-error /
+// aggregate-error path).
 type fakeCorrespondenceExternal struct {
-	existing map[string]*repository.ExternalContact
-	upserts  []repository.UpsertExternalContactRequest
+	existing  map[string]*repository.ExternalContact
+	upserts   []repository.UpsertExternalContactRequest
+	upsertErr map[string]error
 }
 
 func newFakeExternal() *fakeCorrespondenceExternal {
-	return &fakeCorrespondenceExternal{existing: map[string]*repository.ExternalContact{}}
+	return &fakeCorrespondenceExternal{
+		existing:  map[string]*repository.ExternalContact{},
+		upsertErr: map[string]error{},
+	}
 }
 
 func (f *fakeCorrespondenceExternal) GetBySource(_ context.Context, _, sourceID string, _ *string) (*repository.ExternalContact, error) {
@@ -66,6 +73,9 @@ func (f *fakeCorrespondenceExternal) GetBySource(_ context.Context, _, sourceID 
 }
 
 func (f *fakeCorrespondenceExternal) Upsert(_ context.Context, req repository.UpsertExternalContactRequest) (*repository.ExternalContact, error) {
+	if err := f.upsertErr[req.SourceID]; err != nil {
+		return nil, err
+	}
 	f.upserts = append(f.upserts, req)
 	row := &repository.ExternalContact{
 		Source:      req.Source,
@@ -406,6 +416,50 @@ func TestCorrespondence_EmptyInputNoError(t *testing.T) {
 	n, err := s.Run(context.Background(), accelerated.GetCurrentTime().Add(-time.Hour))
 	require.NoError(t, err)
 	require.Equal(t, 0, n)
+}
+
+// A per-address upsert failure must NOT abort the scan (the other address still
+// upserts) but Run must return the successful count AND a non-nil aggregated
+// error, so the worker retries / the catchup fails instead of reporting an
+// empty-but-successful scan.
+func TestCorrespondence_PerAddressErrorAggregated(t *testing.T) {
+	goodContact := uuid.New()
+	badContact := uuid.New()
+	comms := &fakeCorrespondenceComms{
+		rows: []repository.CommsMessageParticipantRow{
+			{
+				MatchedContactID: goodContact,
+				SourceMetadata: metaJSON(t, correspondenceMetadata{
+					From: "me@example.com", FromName: "Me",
+					To: []string{"good@example.com"}, ToNames: []string{"Good Person"},
+				}),
+			},
+			{
+				MatchedContactID: badContact,
+				SourceMetadata: metaJSON(t, correspondenceMetadata{
+					From: "me@example.com", FromName: "Me",
+					To: []string{"bad@example.com"}, ToNames: []string{"Bad Person"},
+				}),
+			},
+		},
+	}
+	contacts := &fakeCorrespondenceContacts{
+		matches: map[string][]repository.ContactMatch{
+			"Good Person": {contactMatch(goodContact, "Good Person", 0.8)},
+			"Bad Person":  {contactMatch(badContact, "Bad Person", 0.8)},
+		},
+		names: map[uuid.UUID]string{goodContact: "Good Person", badContact: "Bad Person"},
+	}
+	ext := newFakeExternal()
+	ext.upsertErr["bad@example.com"] = errors.New("db down")
+	s := newSuggester(comms, contacts, ext, map[string]struct{}{"me@example.com": {}})
+
+	n, err := s.Run(context.Background(), accelerated.GetCurrentTime().Add(-time.Hour))
+	require.Error(t, err, "an upsert failure must surface as a non-nil Run error")
+	require.Contains(t, err.Error(), "failed")
+	require.Equal(t, 1, n, "the surviving address still upserts and is counted")
+	require.Len(t, ext.upserts, 1)
+	require.Equal(t, "good@example.com", ext.upserts[0].SourceID)
 }
 
 func TestBestDisplayName(t *testing.T) {

--- a/backend/internal/google/gmail_correspondence_test.go
+++ b/backend/internal/google/gmail_correspondence_test.go
@@ -264,6 +264,80 @@ func TestCorrespondence_ParticipantExtractionAndNamelessSkip(t *testing.T) {
 	require.Equal(t, "named@example.com", ext.upserts[0].SourceID)
 }
 
+func TestCorrespondence_NameSliceShorterThanAddresses(t *testing.T) {
+	// Defensive index-alignment: a names slice shorter than its address slice
+	// (a parse mismatch, or a row written before all buckets carried names)
+	// must pair the present names by index and leave the trailing addresses
+	// name-less rather than panic or mis-pair.
+	contactID := uuid.New()
+	comms := &fakeCorrespondenceComms{
+		rows: []repository.CommsMessageParticipantRow{{
+			MatchedContactID: contactID,
+			SourceMetadata: metaJSON(t, correspondenceMetadata{
+				From: "me@example.com", FromName: "Me",
+				// Two addresses, one name → addr[0] pairs with "Named Person";
+				// addr[1] (extra@) gets an empty name and is dropped by the gate.
+				To:      []string{"named@example.com", "extra@example.com"},
+				ToNames: []string{"Named Person"},
+			}),
+		}},
+	}
+	contacts := &fakeCorrespondenceContacts{
+		matches: map[string][]repository.ContactMatch{
+			"Named Person": {contactMatch(contactID, "Named Person", 0.8)},
+		},
+		names: map[uuid.UUID]string{contactID: "Named Person"},
+	}
+	ext := newFakeExternal()
+	s := newSuggester(comms, contacts, ext, map[string]struct{}{"me@example.com": {}})
+
+	n, err := s.Run(context.Background(), accelerated.GetCurrentTime().Add(-time.Hour))
+	require.NoError(t, err)
+	require.Equal(t, 1, n, "only the index-aligned named address qualifies")
+	require.Len(t, ext.upserts, 1)
+	require.Equal(t, "named@example.com", ext.upserts[0].SourceID,
+		"the name must pair with addr[0], not the unnamed extra address")
+}
+
+func TestCorrespondence_MessageCountDedupsWithinRow(t *testing.T) {
+	// One message that lists the same unknown address in BOTH To and Cc must
+	// count as ONE message, not two — message_count is a per-message tally.
+	contactID := uuid.New()
+	comms := &fakeCorrespondenceComms{
+		rows: []repository.CommsMessageParticipantRow{{
+			MatchedContactID: contactID,
+			SourceMetadata: metaJSON(t, correspondenceMetadata{
+				From: "me@example.com", FromName: "Me",
+				To:      []string{"dup@example.com"},
+				ToNames: []string{"Full Name"},
+				Cc:      []string{"dup@example.com"},
+				CcNames: []string{"Full Name"},
+			}),
+		}},
+	}
+	contacts := &fakeCorrespondenceContacts{
+		matches: map[string][]repository.ContactMatch{
+			"Full Name": {contactMatch(contactID, "Full Name", 0.8)},
+		},
+		names: map[uuid.UUID]string{contactID: "Full Name"},
+	}
+	ext := newFakeExternal()
+	s := newSuggester(comms, contacts, ext, map[string]struct{}{"me@example.com": {}})
+
+	n, err := s.Run(context.Background(), accelerated.GetCurrentTime().Add(-time.Hour))
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+	require.Len(t, ext.upserts, 1)
+
+	var meta struct {
+		MessageCount int `json:"message_count"`
+	}
+	b, err := json.Marshal(ext.upserts[0].Metadata)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(b, &meta))
+	require.Equal(t, 1, meta.MessageCount, "same address in To+Cc of one message counts once")
+}
+
 func TestCorrespondence_DedupByAddress(t *testing.T) {
 	contactID := uuid.New()
 	rowFor := func(name string) repository.CommsMessageParticipantRow {

--- a/backend/internal/google/gmail_correspondence_test.go
+++ b/backend/internal/google/gmail_correspondence_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"personal-crm/backend/internal/accelerated"
 	"personal-crm/backend/internal/repository"
 
 	"github.com/google/uuid"
@@ -116,7 +117,7 @@ func TestCorrespondence_GateQualifiesAtThreshold(t *testing.T) {
 	ext := newFakeExternal()
 	s := newSuggester(comms, contacts, ext, map[string]struct{}{"me@example.com": {}})
 
-	n, err := s.Run(context.Background(), time.Now().Add(-time.Hour))
+	n, err := s.Run(context.Background(), accelerated.GetCurrentTime().Add(-time.Hour))
 	require.NoError(t, err)
 	require.Equal(t, 1, n)
 	require.Len(t, ext.upserts, 1)
@@ -146,7 +147,7 @@ func TestCorrespondence_GateExactBoundary(t *testing.T) {
 	ext := newFakeExternal()
 	s := newSuggester(comms, contacts, ext, map[string]struct{}{"me@example.com": {}})
 
-	n, err := s.Run(context.Background(), time.Now().Add(-time.Hour))
+	n, err := s.Run(context.Background(), accelerated.GetCurrentTime().Add(-time.Hour))
 	require.NoError(t, err)
 	require.Equal(t, 1, n, "exact-0.60 similarity must qualify")
 }
@@ -170,7 +171,7 @@ func TestCorrespondence_GateRejectsBelowThreshold(t *testing.T) {
 	ext := newFakeExternal()
 	s := newSuggester(comms, contacts, ext, map[string]struct{}{"me@example.com": {}})
 
-	n, err := s.Run(context.Background(), time.Now().Add(-time.Hour))
+	n, err := s.Run(context.Background(), accelerated.GetCurrentTime().Add(-time.Hour))
 	require.NoError(t, err)
 	require.Equal(t, 0, n, "sub-0.60 must be rejected")
 	require.Empty(t, ext.upserts)
@@ -196,7 +197,7 @@ func TestCorrespondence_GateRejectsBareFirstName(t *testing.T) {
 	ext := newFakeExternal()
 	s := newSuggester(comms, contacts, ext, map[string]struct{}{"me@example.com": {}})
 
-	n, err := s.Run(context.Background(), time.Now().Add(-time.Hour))
+	n, err := s.Run(context.Background(), accelerated.GetCurrentTime().Add(-time.Hour))
 	require.NoError(t, err)
 	require.Equal(t, 0, n, "bare first name must be rejected by the ≥2-token gate")
 	require.Empty(t, ext.upserts)
@@ -234,7 +235,7 @@ func TestCorrespondence_ParticipantExtractionAndNamelessSkip(t *testing.T) {
 	ext := newFakeExternal()
 	s := newSuggester(comms, contacts, ext, map[string]struct{}{"me@example.com": {}})
 
-	n, err := s.Run(context.Background(), time.Now().Add(-time.Hour))
+	n, err := s.Run(context.Background(), accelerated.GetCurrentTime().Add(-time.Hour))
 	require.NoError(t, err)
 	require.Equal(t, 1, n)
 	require.Len(t, ext.upserts, 1)
@@ -267,7 +268,7 @@ func TestCorrespondence_DedupByAddress(t *testing.T) {
 	ext := newFakeExternal()
 	s := newSuggester(comms, contacts, ext, map[string]struct{}{"me@example.com": {}})
 
-	n, err := s.Run(context.Background(), time.Now().Add(-time.Hour))
+	n, err := s.Run(context.Background(), accelerated.GetCurrentTime().Add(-time.Hour))
 	require.NoError(t, err)
 	require.Equal(t, 1, n, "three rows for one address → one candidate")
 	require.Len(t, ext.upserts, 1)
@@ -308,7 +309,7 @@ func TestCorrespondence_SkipKnownAndOwn(t *testing.T) {
 		"own2@example.com": {},
 	})
 
-	n, err := s.Run(context.Background(), time.Now().Add(-time.Hour))
+	n, err := s.Run(context.Background(), accelerated.GetCurrentTime().Add(-time.Hour))
 	require.NoError(t, err)
 	require.Equal(t, 0, n, "known and own-account addresses are never emitted")
 	require.Empty(t, ext.upserts)
@@ -340,7 +341,7 @@ func TestCorrespondence_StickyIgnoreNoClobber(t *testing.T) {
 	}
 	s := newSuggester(comms, contacts, ext, map[string]struct{}{"me@example.com": {}})
 
-	n, err := s.Run(context.Background(), time.Now().Add(-time.Hour))
+	n, err := s.Run(context.Background(), accelerated.GetCurrentTime().Add(-time.Hour))
 	require.NoError(t, err)
 	require.Equal(t, 0, n)
 	require.Empty(t, ext.upserts, "ignored row → no redundant write")
@@ -367,7 +368,7 @@ func TestCorrespondence_CoOccurringContactEvidence(t *testing.T) {
 	ext := newFakeExternal()
 	s := newSuggester(comms, contacts, ext, map[string]struct{}{"me@example.com": {}})
 
-	_, err := s.Run(context.Background(), time.Now().Add(-time.Hour))
+	_, err := s.Run(context.Background(), accelerated.GetCurrentTime().Add(-time.Hour))
 	require.NoError(t, err)
 	require.Len(t, ext.upserts, 1)
 
@@ -390,7 +391,7 @@ func TestCorrespondence_EmptyInputNoError(t *testing.T) {
 	ext := newFakeExternal()
 	s := newSuggester(comms, contacts, ext, map[string]struct{}{})
 
-	n, err := s.Run(context.Background(), time.Now().Add(-time.Hour))
+	n, err := s.Run(context.Background(), accelerated.GetCurrentTime().Add(-time.Hour))
 	require.NoError(t, err)
 	require.Equal(t, 0, n)
 }

--- a/backend/internal/google/gmail_correspondence_test.go
+++ b/backend/internal/google/gmail_correspondence_test.go
@@ -1,0 +1,409 @@
+package google
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// --- fakes ---
+
+type fakeCorrespondenceComms struct {
+	identities []repository.EmailIdentity
+	rows       []repository.CommsMessageParticipantRow
+}
+
+func (f *fakeCorrespondenceComms) ListEmailIdentitiesForSync(_ context.Context) ([]repository.EmailIdentity, error) {
+	return f.identities, nil
+}
+
+func (f *fakeCorrespondenceComms) ListParticipantsSince(_ context.Context, _ time.Time) ([]repository.CommsMessageParticipantRow, error) {
+	return f.rows, nil
+}
+
+type fakeCorrespondenceContacts struct {
+	// matches keyed by exact search name → matches returned (already sorted).
+	matches map[string][]repository.ContactMatch
+	names   map[uuid.UUID]string
+}
+
+func (f *fakeCorrespondenceContacts) FindSimilarContacts(_ context.Context, name string, _ float64, _ int32) ([]repository.ContactMatch, error) {
+	return f.matches[name], nil
+}
+
+func (f *fakeCorrespondenceContacts) GetContact(_ context.Context, id uuid.UUID) (*repository.Contact, error) {
+	if n, ok := f.names[id]; ok {
+		return &repository.Contact{ID: id, FullName: n}, nil
+	}
+	return nil, nil
+}
+
+// fakeCorrespondenceExternal records upserts and serves a seeded sticky-ignore
+// row. Keyed by source_id (the normalized address).
+type fakeCorrespondenceExternal struct {
+	existing map[string]*repository.ExternalContact
+	upserts  []repository.UpsertExternalContactRequest
+}
+
+func newFakeExternal() *fakeCorrespondenceExternal {
+	return &fakeCorrespondenceExternal{existing: map[string]*repository.ExternalContact{}}
+}
+
+func (f *fakeCorrespondenceExternal) GetBySource(_ context.Context, _, sourceID string, _ *string) (*repository.ExternalContact, error) {
+	return f.existing[sourceID], nil
+}
+
+func (f *fakeCorrespondenceExternal) Upsert(_ context.Context, req repository.UpsertExternalContactRequest) (*repository.ExternalContact, error) {
+	f.upserts = append(f.upserts, req)
+	row := &repository.ExternalContact{
+		Source:      req.Source,
+		SourceID:    req.SourceID,
+		MatchStatus: repository.MatchStatusUnmatched,
+	}
+	// Preserve a pre-existing status (mirrors the real upsert's DO UPDATE SET
+	// which never touches match_status).
+	if prior := f.existing[req.SourceID]; prior != nil {
+		row.MatchStatus = prior.MatchStatus
+	}
+	f.existing[req.SourceID] = row
+	return row, nil
+}
+
+// --- helpers ---
+
+func metaJSON(t *testing.T, m correspondenceMetadata) []byte {
+	t.Helper()
+	b, err := json.Marshal(m)
+	require.NoError(t, err)
+	return b
+}
+
+func newSuggester(comms *fakeCorrespondenceComms, contacts *fakeCorrespondenceContacts, ext *fakeCorrespondenceExternal, own map[string]struct{}) *GmailCorrespondenceSuggester {
+	return NewGmailCorrespondenceSuggester(comms, contacts, ext, func(context.Context) (map[string]struct{}, error) {
+		return own, nil
+	})
+}
+
+func contactMatch(id uuid.UUID, name string, sim float64) repository.ContactMatch {
+	return repository.ContactMatch{Contact: repository.Contact{ID: id, FullName: name}, Similarity: sim}
+}
+
+// --- tests ---
+
+func TestCorrespondence_GateQualifiesAtThreshold(t *testing.T) {
+	contactID := uuid.New()
+	comms := &fakeCorrespondenceComms{
+		rows: []repository.CommsMessageParticipantRow{{
+			MatchedContactID: contactID,
+			SourceMetadata: metaJSON(t, correspondenceMetadata{
+				From: "me@example.com", FromName: "Me",
+				To: []string{"unknown@example.com"}, ToNames: []string{"Full Name"},
+			}),
+		}},
+	}
+	contacts := &fakeCorrespondenceContacts{
+		matches: map[string][]repository.ContactMatch{
+			"Full Name": {contactMatch(contactID, "Full Name", 0.72)},
+		},
+		names: map[uuid.UUID]string{contactID: "Full Name"},
+	}
+	ext := newFakeExternal()
+	s := newSuggester(comms, contacts, ext, map[string]struct{}{"me@example.com": {}})
+
+	n, err := s.Run(context.Background(), time.Now().Add(-time.Hour))
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+	require.Len(t, ext.upserts, 1)
+	require.Equal(t, "unknown@example.com", ext.upserts[0].SourceID)
+	require.Equal(t, CorrespondenceSource, ext.upserts[0].Source)
+}
+
+// Boundary case: an EXACT 0.60 match must qualify (the floor-minus-epsilon +
+// Go `>=` re-check honors `>= 0.60`, not the SQL's strict `>`).
+func TestCorrespondence_GateExactBoundary(t *testing.T) {
+	contactID := uuid.New()
+	comms := &fakeCorrespondenceComms{
+		rows: []repository.CommsMessageParticipantRow{{
+			MatchedContactID: contactID,
+			SourceMetadata: metaJSON(t, correspondenceMetadata{
+				From: "unknown@example.com", FromName: "Exact Match",
+				To: []string{"me@example.com"}, ToNames: []string{"Me"},
+			}),
+		}},
+	}
+	contacts := &fakeCorrespondenceContacts{
+		matches: map[string][]repository.ContactMatch{
+			"Exact Match": {contactMatch(contactID, "Exact Match", 0.60)},
+		},
+		names: map[uuid.UUID]string{contactID: "Exact Match"},
+	}
+	ext := newFakeExternal()
+	s := newSuggester(comms, contacts, ext, map[string]struct{}{"me@example.com": {}})
+
+	n, err := s.Run(context.Background(), time.Now().Add(-time.Hour))
+	require.NoError(t, err)
+	require.Equal(t, 1, n, "exact-0.60 similarity must qualify")
+}
+
+func TestCorrespondence_GateRejectsBelowThreshold(t *testing.T) {
+	contactID := uuid.New()
+	comms := &fakeCorrespondenceComms{
+		rows: []repository.CommsMessageParticipantRow{{
+			MatchedContactID: contactID,
+			SourceMetadata: metaJSON(t, correspondenceMetadata{
+				From: "unknown@example.com", FromName: "Weak Match",
+				To: []string{"me@example.com"},
+			}),
+		}},
+	}
+	contacts := &fakeCorrespondenceContacts{
+		matches: map[string][]repository.ContactMatch{
+			"Weak Match": {contactMatch(contactID, "Weak Match", 0.59)},
+		},
+	}
+	ext := newFakeExternal()
+	s := newSuggester(comms, contacts, ext, map[string]struct{}{"me@example.com": {}})
+
+	n, err := s.Run(context.Background(), time.Now().Add(-time.Hour))
+	require.NoError(t, err)
+	require.Equal(t, 0, n, "sub-0.60 must be rejected")
+	require.Empty(t, ext.upserts)
+}
+
+func TestCorrespondence_GateRejectsBareFirstName(t *testing.T) {
+	contactID := uuid.New()
+	comms := &fakeCorrespondenceComms{
+		rows: []repository.CommsMessageParticipantRow{{
+			MatchedContactID: contactID,
+			SourceMetadata: metaJSON(t, correspondenceMetadata{
+				From: "unknown@example.com", FromName: "Jane",
+				To: []string{"me@example.com"},
+			}),
+		}},
+	}
+	// Even a high similarity must not save a single-token name.
+	contacts := &fakeCorrespondenceContacts{
+		matches: map[string][]repository.ContactMatch{
+			"Jane": {contactMatch(contactID, "Jane", 0.99)},
+		},
+	}
+	ext := newFakeExternal()
+	s := newSuggester(comms, contacts, ext, map[string]struct{}{"me@example.com": {}})
+
+	n, err := s.Run(context.Background(), time.Now().Add(-time.Hour))
+	require.NoError(t, err)
+	require.Equal(t, 0, n, "bare first name must be rejected by the ≥2-token gate")
+	require.Empty(t, ext.upserts)
+}
+
+func TestCorrespondence_ParticipantExtractionAndNamelessSkip(t *testing.T) {
+	contactID := uuid.New()
+	comms := &fakeCorrespondenceComms{
+		rows: []repository.CommsMessageParticipantRow{
+			// Row WITH name fields → yields a candidate.
+			{
+				MatchedContactID: contactID,
+				SourceMetadata: metaJSON(t, correspondenceMetadata{
+					From: "me@example.com", FromName: "Me",
+					To: []string{"named@example.com"}, ToNames: []string{"Named Person"},
+				}),
+			},
+			// Row with NO name fields (pre-capture shape) → no display name →
+			// participant skipped at the token gate.
+			{
+				MatchedContactID: contactID,
+				SourceMetadata: metaJSON(t, correspondenceMetadata{
+					From: "me@example.com",
+					To:   []string{"nameless@example.com"},
+				}),
+			},
+		},
+	}
+	contacts := &fakeCorrespondenceContacts{
+		matches: map[string][]repository.ContactMatch{
+			"Named Person": {contactMatch(contactID, "Named Person", 0.8)},
+		},
+		names: map[uuid.UUID]string{contactID: "Named Person"},
+	}
+	ext := newFakeExternal()
+	s := newSuggester(comms, contacts, ext, map[string]struct{}{"me@example.com": {}})
+
+	n, err := s.Run(context.Background(), time.Now().Add(-time.Hour))
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+	require.Len(t, ext.upserts, 1)
+	require.Equal(t, "named@example.com", ext.upserts[0].SourceID)
+}
+
+func TestCorrespondence_DedupByAddress(t *testing.T) {
+	contactID := uuid.New()
+	rowFor := func(name string) repository.CommsMessageParticipantRow {
+		return repository.CommsMessageParticipantRow{
+			MatchedContactID: contactID,
+			SourceMetadata: metaJSON(t, correspondenceMetadata{
+				From: "me@example.com", FromName: "Me",
+				To: []string{"dup@example.com"}, ToNames: []string{name},
+			}),
+		}
+	}
+	comms := &fakeCorrespondenceComms{rows: []repository.CommsMessageParticipantRow{
+		rowFor("Full Name"),
+		rowFor("Full Name"),
+		rowFor("Fuller Longer Name"),
+	}}
+	contacts := &fakeCorrespondenceContacts{
+		matches: map[string][]repository.ContactMatch{
+			// bestDisplayName picks the most-token name.
+			"Fuller Longer Name": {contactMatch(contactID, "Fuller Longer Name", 0.7)},
+		},
+		names: map[uuid.UUID]string{contactID: "Fuller Longer Name"},
+	}
+	ext := newFakeExternal()
+	s := newSuggester(comms, contacts, ext, map[string]struct{}{"me@example.com": {}})
+
+	n, err := s.Run(context.Background(), time.Now().Add(-time.Hour))
+	require.NoError(t, err)
+	require.Equal(t, 1, n, "three rows for one address → one candidate")
+	require.Len(t, ext.upserts, 1)
+
+	var meta struct {
+		DisplayNamesSeen []string `json:"display_names_seen"`
+		MessageCount     int      `json:"message_count"`
+	}
+	b, err := json.Marshal(ext.upserts[0].Metadata)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(b, &meta))
+	require.Equal(t, 3, meta.MessageCount, "message_count sums across rows")
+	require.ElementsMatch(t, []string{"Full Name", "Fuller Longer Name"}, meta.DisplayNamesSeen)
+}
+
+func TestCorrespondence_SkipKnownAndOwn(t *testing.T) {
+	contactID := uuid.New()
+	comms := &fakeCorrespondenceComms{
+		identities: []repository.EmailIdentity{{ValueNormalized: "known@example.com", ContactID: contactID}},
+		rows: []repository.CommsMessageParticipantRow{{
+			MatchedContactID: contactID,
+			SourceMetadata: metaJSON(t, correspondenceMetadata{
+				From: "me@example.com", FromName: "Me",
+				To:      []string{"known@example.com", "own2@example.com"},
+				ToNames: []string{"Known Person", "Own Two"},
+			}),
+		}},
+	}
+	contacts := &fakeCorrespondenceContacts{
+		matches: map[string][]repository.ContactMatch{
+			"Known Person": {contactMatch(contactID, "Known Person", 0.9)},
+			"Own Two":      {contactMatch(contactID, "Own Two", 0.9)},
+		},
+	}
+	ext := newFakeExternal()
+	s := newSuggester(comms, contacts, ext, map[string]struct{}{
+		"me@example.com":   {},
+		"own2@example.com": {},
+	})
+
+	n, err := s.Run(context.Background(), time.Now().Add(-time.Hour))
+	require.NoError(t, err)
+	require.Equal(t, 0, n, "known and own-account addresses are never emitted")
+	require.Empty(t, ext.upserts)
+}
+
+// No-clobber invariant: an existing ignored row stays ignored, the producer
+// skips the upsert (write-avoidance), and the address does not become unmatched.
+func TestCorrespondence_StickyIgnoreNoClobber(t *testing.T) {
+	contactID := uuid.New()
+	comms := &fakeCorrespondenceComms{
+		rows: []repository.CommsMessageParticipantRow{{
+			MatchedContactID: contactID,
+			SourceMetadata: metaJSON(t, correspondenceMetadata{
+				From: "ignored@example.com", FromName: "Ignored Person",
+				To: []string{"me@example.com"},
+			}),
+		}},
+	}
+	contacts := &fakeCorrespondenceContacts{
+		matches: map[string][]repository.ContactMatch{
+			"Ignored Person": {contactMatch(contactID, "Ignored Person", 0.9)},
+		},
+	}
+	ext := newFakeExternal()
+	ext.existing["ignored@example.com"] = &repository.ExternalContact{
+		Source:      CorrespondenceSource,
+		SourceID:    "ignored@example.com",
+		MatchStatus: repository.MatchStatusIgnored,
+	}
+	s := newSuggester(comms, contacts, ext, map[string]struct{}{"me@example.com": {}})
+
+	n, err := s.Run(context.Background(), time.Now().Add(-time.Hour))
+	require.NoError(t, err)
+	require.Equal(t, 0, n)
+	require.Empty(t, ext.upserts, "ignored row → no redundant write")
+	require.Equal(t, repository.MatchStatusIgnored, ext.existing["ignored@example.com"].MatchStatus)
+}
+
+func TestCorrespondence_CoOccurringContactEvidence(t *testing.T) {
+	coContact := uuid.New()
+	comms := &fakeCorrespondenceComms{
+		rows: []repository.CommsMessageParticipantRow{{
+			MatchedContactID: coContact,
+			SourceMetadata: metaJSON(t, correspondenceMetadata{
+				From: "me@example.com", FromName: "Me",
+				To: []string{"alt@example.com"}, ToNames: []string{"Alt Person"},
+			}),
+		}},
+	}
+	contacts := &fakeCorrespondenceContacts{
+		matches: map[string][]repository.ContactMatch{
+			"Alt Person": {contactMatch(coContact, "Alt Person", 0.8)},
+		},
+		names: map[uuid.UUID]string{coContact: "Alt Person"},
+	}
+	ext := newFakeExternal()
+	s := newSuggester(comms, contacts, ext, map[string]struct{}{"me@example.com": {}})
+
+	_, err := s.Run(context.Background(), time.Now().Add(-time.Hour))
+	require.NoError(t, err)
+	require.Len(t, ext.upserts, 1)
+
+	var meta struct {
+		CoOccurring struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"co_occurring_contact"`
+	}
+	b, err := json.Marshal(ext.upserts[0].Metadata)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(b, &meta))
+	require.Equal(t, coContact.String(), meta.CoOccurring.ID)
+	require.Equal(t, "Alt Person", meta.CoOccurring.Name)
+}
+
+func TestCorrespondence_EmptyInputNoError(t *testing.T) {
+	comms := &fakeCorrespondenceComms{}
+	contacts := &fakeCorrespondenceContacts{}
+	ext := newFakeExternal()
+	s := newSuggester(comms, contacts, ext, map[string]struct{}{})
+
+	n, err := s.Run(context.Background(), time.Now().Add(-time.Hour))
+	require.NoError(t, err)
+	require.Equal(t, 0, n)
+}
+
+func TestBestDisplayName(t *testing.T) {
+	require.Equal(t, "", bestDisplayName(nil))
+	require.Equal(t, "Two Tokens", bestDisplayName([]string{"One", "Two Tokens"}))
+	require.Equal(t, "Longer Full Name", bestDisplayName([]string{"Full Name", "Longer Full Name"}))
+}
+
+func TestTokenCount(t *testing.T) {
+	require.Equal(t, 0, tokenCount(""))
+	require.Equal(t, 1, tokenCount("Jane"))
+	require.Equal(t, 2, tokenCount("Jane Doe"))
+	require.Equal(t, 2, tokenCount("  Jane   Doe  "))
+}

--- a/backend/internal/google/gmail_correspondence_test.go
+++ b/backend/internal/google/gmail_correspondence_test.go
@@ -32,9 +32,14 @@ type fakeCorrespondenceContacts struct {
 	// matches keyed by exact search name → matches returned (already sorted).
 	matches map[string][]repository.ContactMatch
 	names   map[uuid.UUID]string
+	// lastThreshold records the threshold the producer passed on the most
+	// recent FindSimilarContacts call so a test can pin the floor-minus-epsilon
+	// SQL workaround.
+	lastThreshold float64
 }
 
-func (f *fakeCorrespondenceContacts) FindSimilarContacts(_ context.Context, name string, _ float64, _ int32) ([]repository.ContactMatch, error) {
+func (f *fakeCorrespondenceContacts) FindSimilarContacts(_ context.Context, name string, threshold float64, _ int32) ([]repository.ContactMatch, error) {
+	f.lastThreshold = threshold
 	return f.matches[name], nil
 }
 
@@ -150,6 +155,13 @@ func TestCorrespondence_GateExactBoundary(t *testing.T) {
 	n, err := s.Run(context.Background(), accelerated.GetCurrentTime().Add(-time.Hour))
 	require.NoError(t, err)
 	require.Equal(t, 1, n, "exact-0.60 similarity must qualify")
+	// Pin the floor-minus-epsilon SQL workaround: the producer must query the
+	// strict-`>` SQL with a threshold strictly below 0.60 so an exact-0.60 row
+	// is returned (then the Go-side `>=` re-check qualifies it). A regression to
+	// passing 0.60 would silently drop exact-0.60 matches.
+	require.Less(t, contacts.lastThreshold, correspondenceSimThreshold,
+		"FindSimilarContacts must be called with a floor strictly below 0.60")
+	require.Equal(t, correspondenceSimFloor, contacts.lastThreshold)
 }
 
 func TestCorrespondence_GateRejectsBelowThreshold(t *testing.T) {

--- a/backend/internal/google/gmail_test.go
+++ b/backend/internal/google/gmail_test.go
@@ -684,6 +684,14 @@ func TestProcessMessage_MetadataNoDisplayNameStoresEmpty(t *testing.T) {
 	// empty name as "no display name → skip at the ≥2-token gate".
 	require.Equal(t, []string{""}, meta.ToNames)
 	require.Len(t, meta.ToNames, len(meta.To))
+
+	// The from_name key is ALWAYS written (even empty) so a bare-From row
+	// ingested after capture is not mistaken for a pre-capture row by the
+	// re-derivation predicate (NOT ? 'from_name').
+	var rawMeta map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(rows[0].Metadata, &rawMeta))
+	_, present := rawMeta["from_name"]
+	require.True(t, present, "from_name key must be present even when empty")
 }
 
 func TestParseSingleAddress_Name(t *testing.T) {

--- a/backend/internal/google/gmail_test.go
+++ b/backend/internal/google/gmail_test.go
@@ -636,6 +636,97 @@ func TestProcessMessage_MetadataCarriesAttachmentsAndHTML(t *testing.T) {
 	require.Equal(t, []string{"me@example.com"}, meta.To)
 }
 
+func TestProcessMessage_MetadataCapturesDisplayNames(t *testing.T) {
+	p := newProviderForResolution()
+	contactA := uuid.New()
+	knownMap := map[string][]uuid.UUID{"contact@example.com": {contactA}}
+	meSet := map[string]struct{}{"me@example.com": {}}
+	// From carries a display name; To has two recipients, one with a name and
+	// one bare. The metadata must store bare addresses unchanged plus aligned
+	// display-name slices.
+	msg := buildMessage(t, "g1", "t1", "\"Contact A\" <contact@example.com>",
+		[]string{"\"My Self\" <me@example.com>", "bare@example.com"}, nil, nil,
+		"S", "b", "<dn@example.com>", 1700000000000)
+
+	rows, err := p.RunProcessMessageForTest(context.Background(), msg, "me@example.com", knownMap, meSet)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+
+	var meta emailMetadata
+	require.NoError(t, json.Unmarshal(rows[0].Metadata, &meta))
+	// Bare addresses unchanged.
+	require.Equal(t, "contact@example.com", meta.From)
+	require.Equal(t, []string{"me@example.com", "bare@example.com"}, meta.To)
+	// Display names captured, index-aligned.
+	require.Equal(t, "Contact A", meta.FromName)
+	require.Equal(t, []string{"My Self", ""}, meta.ToNames)
+	require.Len(t, meta.ToNames, len(meta.To))
+}
+
+func TestProcessMessage_MetadataNoDisplayNameStoresEmpty(t *testing.T) {
+	p := newProviderForResolution()
+	contactA := uuid.New()
+	knownMap := map[string][]uuid.UUID{"contact@example.com": {contactA}}
+	meSet := map[string]struct{}{"me@example.com": {}}
+	// No display parts anywhere.
+	msg := buildMessage(t, "g1", "t1", "contact@example.com",
+		[]string{"me@example.com"}, nil, nil, "S", "b", "<nodn@example.com>", 1700000000000)
+
+	rows, err := p.RunProcessMessageForTest(context.Background(), msg, "me@example.com", knownMap, meSet)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+
+	var meta emailMetadata
+	require.NoError(t, json.Unmarshal(rows[0].Metadata, &meta))
+	require.Equal(t, "", meta.FromName)
+	// The name slice stays index-aligned with the address slice: one recipient
+	// with no display part → one empty-string name. The producer treats an
+	// empty name as "no display name → skip at the ≥2-token gate".
+	require.Equal(t, []string{""}, meta.ToNames)
+	require.Len(t, meta.ToNames, len(meta.To))
+}
+
+func TestParseSingleAddress_Name(t *testing.T) {
+	raw, norm, name := parseSingleAddress("\"Contact A\" <Contact.A@Example.com>")
+	require.Equal(t, "Contact.A@Example.com", raw)
+	require.Equal(t, "contact.a@example.com", norm)
+	require.Equal(t, "Contact A", name)
+
+	raw, norm, name = parseSingleAddress("bare@example.com")
+	require.Equal(t, "bare@example.com", raw)
+	require.Equal(t, "bare@example.com", norm)
+	require.Equal(t, "", name)
+
+	raw, norm, name = parseSingleAddress("")
+	require.Equal(t, "", raw)
+	require.Equal(t, "", norm)
+	require.Equal(t, "", name)
+}
+
+func TestParseAddressList_NamesIndexAligned(t *testing.T) {
+	// Happy path: ParseAddressList succeeds; names aligned to addresses.
+	raws, norms, names := parseAddressList("\"First Last\" <first@example.com>, bare@example.com")
+	require.Equal(t, []string{"first@example.com", "bare@example.com"}, raws)
+	require.Equal(t, []string{"first@example.com", "bare@example.com"}, norms)
+	require.Equal(t, []string{"First Last", ""}, names)
+	require.Len(t, names, len(raws))
+
+	// Empty header → all nil.
+	raws, norms, names = parseAddressList("")
+	require.Nil(t, raws)
+	require.Nil(t, norms)
+	require.Nil(t, names)
+}
+
+func TestParseAddressList_CommaSplitFallbackAligned(t *testing.T) {
+	// A malformed entry forces the lenient comma-split fallback. The name/raw
+	// slices must stay the same length so the producer never mis-pairs a name
+	// to the wrong address.
+	raws, _, names := parseAddressList("\"Valid Name\" <ok@example.com>, @@@broken")
+	require.Len(t, names, len(raws))
+	require.GreaterOrEqual(t, len(raws), 1)
+}
+
 // --- local_day boundary in time.Local (incl. DST) ---
 
 func TestComputeLocalDay_PureForm_AcrossMidnight(t *testing.T) {

--- a/backend/internal/repository/comms_message.go
+++ b/backend/internal/repository/comms_message.go
@@ -316,6 +316,38 @@ func (r *CommsMessageRepository) HardDeleteByContact(ctx context.Context, contac
 	return r.queries.HardDeleteCommsMessagesByContact(ctx, uuidToPgUUID(contactID))
 }
 
+// CommsMessageParticipantRow is one recent email content row projected for the
+// correspondence-enrichment scan: the qualifying contact (the co-occurring
+// contact), when it was sent, and the raw source_metadata JSON (carrying the
+// from/to/cc/bcc participant lists + their display names). The producer
+// unmarshals SourceMetadata itself.
+type CommsMessageParticipantRow struct {
+	MatchedContactID uuid.UUID
+	SentAt           time.Time
+	SourceMetadata   []byte
+}
+
+// ListParticipantsSince streams recent email content rows (sent_at >= since)
+// for the correspondence-enrichment producer. Newest first; bounded by since.
+func (r *CommsMessageRepository) ListParticipantsSince(ctx context.Context, since time.Time) ([]CommsMessageParticipantRow, error) {
+	rows, err := r.queries.ListCommsMessageParticipantsSince(ctx, timeToPgTimestamptz(&since))
+	if err != nil {
+		return nil, err
+	}
+	out := make([]CommsMessageParticipantRow, 0, len(rows))
+	for _, row := range rows {
+		pr := CommsMessageParticipantRow{SourceMetadata: row.SourceMetadata}
+		if row.MatchedContactID.Valid {
+			pr.MatchedContactID = uuid.UUID(row.MatchedContactID.Bytes)
+		}
+		if row.SentAt.Valid {
+			pr.SentAt = row.SentAt.Time
+		}
+		out = append(out, pr)
+	}
+	return out, nil
+}
+
 // CommsStagingProcessor adapts *CommsMessageRepository to the source-neutral
 // StagingProcessor interface. It is wired into the StagingProcessorRegistry by
 // main.go only once an email consumer exists to dispatch through it; until then

--- a/backend/internal/repository/comms_message.go
+++ b/backend/internal/repository/comms_message.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"time"
 
@@ -346,6 +347,77 @@ func (r *CommsMessageRepository) ListParticipantsSince(ctx context.Context, sinc
 		out = append(out, pr)
 	}
 	return out, nil
+}
+
+// MissingParticipantNamesRow is one keyset-paged row the historical
+// display-name re-derivation must re-fetch: the row id (and keyset cursor),
+// the connected account that observed it, and the stored source_metadata
+// (carrying account_gmail_ids to resolve the per-mailbox gmail id).
+type MissingParticipantNamesRow struct {
+	ID             uuid.UUID
+	AccountID      *string
+	SourceMetadata []byte
+}
+
+// ListMissingParticipantNames keyset-pages email rows (sent_at >= since,
+// id > afterID) that lack the from_name key, in id order, capped at batchSize.
+// The runner advances afterID = max(id) of each returned batch regardless of
+// per-row outcome, so a skipped/failed row never blocks later rows.
+func (r *CommsMessageRepository) ListMissingParticipantNames(ctx context.Context, since time.Time, afterID uuid.UUID, batchSize int32) ([]MissingParticipantNamesRow, error) {
+	rows, err := r.queries.ListCommsMessagesMissingParticipantNames(ctx, db.ListCommsMessagesMissingParticipantNamesParams{
+		Since:     timeToPgTimestamptz(&since),
+		AfterID:   uuidToPgUUID(afterID),
+		BatchSize: batchSize,
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]MissingParticipantNamesRow, 0, len(rows))
+	for _, row := range rows {
+		mr := MissingParticipantNamesRow{SourceMetadata: row.SourceMetadata}
+		if row.ID.Valid {
+			mr.ID = uuid.UUID(row.ID.Bytes)
+		}
+		if row.AccountID.Valid {
+			mr.AccountID = &row.AccountID.String
+		}
+		out = append(out, mr)
+	}
+	return out, nil
+}
+
+// ParticipantNames is the set of re-derived display names for one message,
+// index-aligned with the row's stored from/to/cc/bcc address lists.
+type ParticipantNames struct {
+	FromName string
+	ToNames  []string
+	CcNames  []string
+	BccNames []string
+}
+
+// BackfillParticipantNames additively merges the re-derived display names onto
+// an existing row's source_metadata, preserving all existing content +
+// provenance keys. The *_names slices are marshalled to non-NULL JSON arrays
+// ([] when empty) so the SQL jsonb_set never writes a JSON null. Returns the
+// number of rows affected (0 when the row already has names — idempotent).
+func (r *CommsMessageRepository) BackfillParticipantNames(ctx context.Context, id uuid.UUID, names ParticipantNames) (int64, error) {
+	toJSON := func(s []string) []byte {
+		if s == nil {
+			s = []string{}
+		}
+		b, err := json.Marshal(s)
+		if err != nil {
+			return []byte("[]")
+		}
+		return b
+	}
+	return r.queries.BackfillCommsMessageParticipantNames(ctx, db.BackfillCommsMessageParticipantNamesParams{
+		ID:       uuidToPgUUID(id),
+		FromName: names.FromName,
+		ToNames:  toJSON(names.ToNames),
+		CcNames:  toJSON(names.CcNames),
+		BccNames: toJSON(names.BccNames),
+	})
 }
 
 // CommsStagingProcessor adapts *CommsMessageRepository to the source-neutral

--- a/backend/internal/scheduler/args.go
+++ b/backend/internal/scheduler/args.go
@@ -37,3 +37,12 @@ type PairingTokenJanitorArgs struct{}
 
 // Kind implements river.JobArgs.
 func (PairingTokenJanitorArgs) Kind() string { return "pairing_token_janitor" }
+
+// GmailCorrespondenceScanArgs are the args for the periodic
+// GmailCorrespondenceScanWorker. Empty: the worker computes its own
+// recent-window `since` at run time, so the periodic scheduler inserts it
+// without per-tick parameter resolution.
+type GmailCorrespondenceScanArgs struct{}
+
+// Kind implements river.JobArgs.
+func (GmailCorrespondenceScanArgs) Kind() string { return "gmail_correspondence_scan" }

--- a/backend/internal/scheduler/gmail_correspondence_worker.go
+++ b/backend/internal/scheduler/gmail_correspondence_worker.go
@@ -1,0 +1,59 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/logger"
+
+	"github.com/riverqueue/river"
+)
+
+// CorrespondenceScanner is the narrow producer surface the worker drives. In
+// production this is *google.GmailCorrespondenceSuggester; keeping it an
+// interface lets the worker unit test run without OAuth or a DB.
+type CorrespondenceScanner interface {
+	Run(ctx context.Context, since time.Time) (int, error)
+}
+
+// GmailCorrespondenceScanWorker periodically runs the correspondence-enrichment
+// producer over the recent window (the steady-state scan). It computes
+// `since = now - window` and delegates to the scanner. The scan is idempotent,
+// so River retrying a failed tick is harmless.
+//
+// The window is injected (not imported from internal/google) because
+// internal/google → internal/service → internal/scheduler, so this package
+// cannot import internal/google without an import cycle. main.go supplies
+// google.CorrespondenceWindow at construction time.
+type GmailCorrespondenceScanWorker struct {
+	river.WorkerDefaults[GmailCorrespondenceScanArgs]
+	scanner CorrespondenceScanner
+	window  time.Duration
+}
+
+// NewGmailCorrespondenceScanWorker constructs the worker over the given scanner
+// and recent-window duration.
+func NewGmailCorrespondenceScanWorker(scanner CorrespondenceScanner, window time.Duration) *GmailCorrespondenceScanWorker {
+	return &GmailCorrespondenceScanWorker{scanner: scanner, window: window}
+}
+
+// Work implements river.Worker for GmailCorrespondenceScanArgs.
+func (w *GmailCorrespondenceScanWorker) Work(ctx context.Context, _ *river.Job[GmailCorrespondenceScanArgs]) error {
+	since := accelerated.GetCurrentTime().Add(-w.window)
+	n, err := w.scanner.Run(ctx, since)
+	if err != nil {
+		return fmt.Errorf("gmail correspondence scan: %w", err)
+	}
+	if n > 0 {
+		logger.Info().Int("candidates_upserted", n).Msg("gmail_correspondence_scan: tick complete")
+	}
+	return nil
+}
+
+// Timeout caps each invocation. The scan is bounded by the recent-window row
+// count (small at current scale); 2 minutes is generous headroom.
+func (*GmailCorrespondenceScanWorker) Timeout(*river.Job[GmailCorrespondenceScanArgs]) time.Duration {
+	return 2 * time.Minute
+}

--- a/backend/internal/scheduler/gmail_correspondence_worker_test.go
+++ b/backend/internal/scheduler/gmail_correspondence_worker_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"personal-crm/backend/internal/accelerated"
+
 	"github.com/riverqueue/river"
 	"github.com/stretchr/testify/require"
 )
@@ -28,9 +30,9 @@ func TestGmailCorrespondenceScanWorker_ComputesRecentWindow(t *testing.T) {
 	scanner := &stubCorrespondenceScanner{count: 3}
 	w := NewGmailCorrespondenceScanWorker(scanner, window)
 
-	before := time.Now().Add(-window)
+	before := accelerated.GetCurrentTime().Add(-window)
 	err := w.Work(context.Background(), &river.Job[GmailCorrespondenceScanArgs]{})
-	after := time.Now().Add(-window)
+	after := accelerated.GetCurrentTime().Add(-window)
 
 	require.NoError(t, err)
 	require.Equal(t, 1, scanner.called)

--- a/backend/internal/scheduler/gmail_correspondence_worker_test.go
+++ b/backend/internal/scheduler/gmail_correspondence_worker_test.go
@@ -1,0 +1,53 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/riverqueue/river"
+	"github.com/stretchr/testify/require"
+)
+
+type stubCorrespondenceScanner struct {
+	since  time.Time
+	called int
+	count  int
+	err    error
+}
+
+func (s *stubCorrespondenceScanner) Run(_ context.Context, since time.Time) (int, error) {
+	s.called++
+	s.since = since
+	return s.count, s.err
+}
+
+func TestGmailCorrespondenceScanWorker_ComputesRecentWindow(t *testing.T) {
+	const window = 120 * 24 * time.Hour
+	scanner := &stubCorrespondenceScanner{count: 3}
+	w := NewGmailCorrespondenceScanWorker(scanner, window)
+
+	before := time.Now().Add(-window)
+	err := w.Work(context.Background(), &river.Job[GmailCorrespondenceScanArgs]{})
+	after := time.Now().Add(-window)
+
+	require.NoError(t, err)
+	require.Equal(t, 1, scanner.called)
+	// since = now - window, bounded by the wall-clock window around the call.
+	require.False(t, scanner.since.Before(before.Add(-time.Second)))
+	require.False(t, scanner.since.After(after.Add(time.Second)))
+}
+
+func TestGmailCorrespondenceScanWorker_ErrorWrapped(t *testing.T) {
+	scanner := &stubCorrespondenceScanner{err: errors.New("boom")}
+	w := NewGmailCorrespondenceScanWorker(scanner, time.Hour)
+
+	err := w.Work(context.Background(), &river.Job[GmailCorrespondenceScanArgs]{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "gmail correspondence scan")
+}
+
+func TestGmailCorrespondenceScanArgs_Kind(t *testing.T) {
+	require.Equal(t, "gmail_correspondence_scan", GmailCorrespondenceScanArgs{}.Kind())
+}

--- a/backend/tests/comms_message_repository_test.go
+++ b/backend/tests/comms_message_repository_test.go
@@ -570,3 +570,60 @@ func TestInteractionSourceCheck_AcceptsEmail(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, repository.InteractionSourceEmail, interaction.Source)
 }
+
+// TestBackfillParticipantNames_AdditiveMergeAndIdempotent pins the additive
+// merge contract directly at the SQL level: BackfillParticipantNames ADDS the
+// four display-name keys onto a name-less row while preserving ALL existing
+// content + provenance keys, and a second call is a no-op (the NOT (?
+// 'from_name') guard → 0 rows).
+func TestBackfillParticipantNames_AdditiveMergeAndIdempotent(t *testing.T) {
+	ctx, repo, contactRepo, _ := setupCommsMessageTest(t)
+
+	suffix := randomSuffix(t)
+	contact := newEmailContact(t, ctx, repo, contactRepo, "Test Backfill Names "+suffix)
+
+	// Seed a name-less row carrying full content + provenance keys.
+	externalID := "<msgid-backfill-" + suffix + ">"
+	md := metadataFor(t, "accA", "gidA", map[string]any{
+		"from":    "unknown@example.test",
+		"to":      []string{"me@example.test"},
+		"subject": "Original Subject",
+		"html":    "<p>original</p>",
+	})
+	seeded, err := repo.UpsertMessage(ctx, baseUpsertParams(externalID, contact.ID, accelerated.GetCurrentTime().Truncate(time.Microsecond), "accA", "gidA", md))
+	require.NoError(t, err)
+
+	// First backfill ADDS the name keys.
+	affected, err := repo.BackfillParticipantNames(ctx, seeded.ID, repository.ParticipantNames{
+		FromName: "Unknown Person",
+		ToNames:  []string{"Me"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), affected)
+
+	got, err := repo.GetByID(ctx, seeded.ID)
+	require.NoError(t, err)
+	merged := decodeMetadata(t, got.SourceMetadata)
+	// Name keys added.
+	require.Equal(t, "Unknown Person", merged["from_name"])
+	require.Equal(t, []any{"Me"}, merged["to_names"])
+	require.Contains(t, merged, "cc_names")
+	require.Contains(t, merged, "bcc_names")
+	// All pre-existing content + provenance keys preserved.
+	require.Equal(t, "unknown@example.test", merged["from"])
+	require.Equal(t, "Original Subject", merged["subject"])
+	require.Equal(t, "<p>original</p>", merged["html"])
+	require.Contains(t, merged, "observed_accounts")
+	require.Contains(t, merged, "account_gmail_ids")
+
+	// Second backfill is a no-op (idempotent — row already has from_name).
+	affected2, err := repo.BackfillParticipantNames(ctx, seeded.ID, repository.ParticipantNames{
+		FromName: "DIFFERENT Name",
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(0), affected2, "guard: a row that already has from_name is a no-op")
+
+	got2, err := repo.GetByID(ctx, seeded.ID)
+	require.NoError(t, err)
+	require.Equal(t, "Unknown Person", decodeMetadata(t, got2.SourceMetadata)["from_name"], "name not overwritten")
+}

--- a/backend/tests/gmail_correspondence_integration_test.go
+++ b/backend/tests/gmail_correspondence_integration_test.go
@@ -1,0 +1,458 @@
+// Integration coverage for the gmail_correspondence enrichment source (C).
+// Drives the REAL producer, repos, ImportMatchService, EnrichmentService (with
+// a live event bus + River client), and the re-derivation runner (with a fake
+// Gmail fetcher via the provider's exported test seam) against the shared test
+// DB. Proves:
+//   - the producer turns name-bearing comms_message participants into
+//     gmail_correspondence external_contact rows with the expected evidence +
+//     suggested_match;
+//   - linking a candidate adds the email as a contact_method and dispatches the
+//     KindContactMethodsAdded rematch (the inherited backfill hand-off — async
+//     scan completion is covered by gmail_rematch_integration_test.go, not here);
+//   - sticky-ignore is preserved across producer re-runs (no clobber);
+//   - the import endpoint returns 403 for this link-only source (B's teeth);
+//   - the one-time re-derivation re-fetches name-less rows, ADDS the name keys
+//     while preserving all existing content + provenance (the additive-merge
+//     invariant), and the producer then surfaces the previously-hidden backlog;
+//   - the re-derivation is idempotent.
+//
+// All seeding goes through repositories (sqlc-only); addresses/names are
+// placeholders; times use accelerated.GetCurrentTime().
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/api"
+	"personal-crm/backend/internal/api/handlers"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/google"
+	"personal-crm/backend/internal/matching"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/stretchr/testify/require"
+	gmailapi "google.golang.org/api/gmail/v1"
+)
+
+// correspondenceEnv bundles a real DB + the repos/services the C tests drive.
+type correspondenceEnv struct {
+	ctx          context.Context
+	database     *db.Database
+	commsRepo    *repository.CommsMessageRepository
+	contactRepo  *repository.ContactRepository
+	methodRepo   *repository.ContactMethodRepository
+	externalRepo *repository.ExternalContactRepository
+	eventRepo    *repository.EventRepository
+	matchService *service.ImportMatchService
+	suggester    *google.GmailCorrespondenceSuggester
+}
+
+func newCorrespondenceEnv(t *testing.T, ownAddr string) *correspondenceEnv {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	require.NoError(t, db.RunMigrations(ctx, databaseURL, getMigrationsPath()))
+
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	t.Cleanup(database.Close)
+
+	commsRepo := repository.NewCommsMessageRepository(database.Queries)
+	contactRepo := repository.NewContactRepository(database.Queries)
+	methodRepo := repository.NewContactMethodRepository(database.Queries)
+	externalRepo := repository.NewExternalContactRepository(database.Queries)
+	eventRepo := repository.NewEventRepository(database.Queries)
+
+	suggester := google.NewGmailCorrespondenceSuggester(
+		commsRepo, contactRepo, externalRepo,
+		func(context.Context) (map[string]struct{}, error) {
+			return map[string]struct{}{matching.NormalizeEmail(ownAddr): {}}, nil
+		},
+	)
+
+	return &correspondenceEnv{
+		ctx:          ctx,
+		database:     database,
+		commsRepo:    commsRepo,
+		contactRepo:  contactRepo,
+		methodRepo:   methodRepo,
+		externalRepo: externalRepo,
+		eventRepo:    eventRepo,
+		matchService: service.NewImportMatchService(contactRepo),
+		suggester:    suggester,
+	}
+}
+
+// uniqueAddr returns a per-test unique placeholder address so parallel/shared-DB
+// runs do not collide on the producer's source_id dedup.
+func uniqueAddr(prefix string) string {
+	return prefix + "-" + uuid.New().String()[:8] + "@example.test"
+}
+
+// seedCorrespondenceContact creates a CRM contact and registers cleanup of its
+// comms_message rows, methods, and the contact itself.
+func (e *correspondenceEnv) seedContact(t *testing.T, fullName string) *repository.Contact {
+	t.Helper()
+	c, err := e.contactRepo.CreateContact(e.ctx, repository.CreateContactRequest{FullName: fullName})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = e.commsRepo.HardDeleteByContact(e.ctx, c.ID)
+		_ = e.contactRepo.SoftDeleteContact(e.ctx, c.ID)
+	})
+	return c
+}
+
+// nameMetadata builds a source_metadata blob with a single From participant
+// carrying both the bare address and the display name (the post-capture shape).
+func nameMetadata(t *testing.T, fromAddr, fromName, ownAddr string) []byte {
+	t.Helper()
+	b, err := json.Marshal(map[string]any{
+		"from":      fromAddr,
+		"from_name": fromName,
+		"to":        []string{ownAddr},
+		"to_names":  []string{"Me"},
+		"subject":   "Hello",
+		"html":      "<p>body</p>",
+	})
+	require.NoError(t, err)
+	return b
+}
+
+// seedMessage upserts one email comms_message row for the contact.
+func (e *correspondenceEnv) seedMessage(t *testing.T, contactID uuid.UUID, externalID, account, gmailID string, metadata []byte) {
+	t.Helper()
+	acct := account
+	gid := gmailID
+	_, err := e.commsRepo.UpsertMessage(e.ctx, repository.UpsertCommsMessageParams{
+		Source:           repository.InteractionSourceEmail,
+		ExternalID:       externalID,
+		Direction:        repository.InteractionDirectionInbound,
+		SentAt:           accelerated.GetCurrentTime().Add(-24 * time.Hour),
+		AccountID:        &acct,
+		SourceMetadata:   metadata,
+		MatchedContactID: contactID,
+		GmailMessageID:   &gid,
+	})
+	require.NoError(t, err)
+}
+
+// cleanupExternal registers a hard-delete of a produced candidate so the
+// shared DB does not accumulate gmail_correspondence rows across runs.
+func (e *correspondenceEnv) cleanupExternal(t *testing.T, sourceID string) {
+	t.Helper()
+	t.Cleanup(func() {
+		row, _ := e.externalRepo.GetBySource(e.ctx, google.CorrespondenceSource, sourceID, nil)
+		if row != nil {
+			_ = e.externalRepo.Delete(e.ctx, row.ID)
+		}
+	})
+}
+
+func TestCorrespondence_ProducerEmitsCandidateWithSuggestedMatch(t *testing.T) {
+	ownAddr := uniqueAddr("me")
+	e := newCorrespondenceEnv(t, ownAddr)
+
+	fullName := "Correspondence Alpha " + uuid.New().String()[:6]
+	contact := e.seedContact(t, fullName)
+	unknownAddr := uniqueAddr("alpha")
+	e.cleanupExternal(t, matching.NormalizeEmail(unknownAddr))
+
+	e.seedMessage(t, contact.ID, "ext-"+uuid.New().String(), ownAddr, "gmail-1",
+		nameMetadata(t, unknownAddr, fullName, ownAddr))
+
+	n, err := e.suggester.Run(e.ctx, accelerated.GetCurrentTime().Add(-google.CorrespondenceWindow))
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, n, 1)
+
+	row, err := e.externalRepo.GetBySource(e.ctx, google.CorrespondenceSource, matching.NormalizeEmail(unknownAddr), nil)
+	require.NoError(t, err)
+	require.NotNil(t, row, "producer must emit a gmail_correspondence candidate")
+	require.Equal(t, repository.MatchStatusUnmatched, row.MatchStatus)
+	require.NotNil(t, row.DisplayName)
+	require.Equal(t, fullName, *row.DisplayName)
+	require.Equal(t, float64(1), row.Metadata["message_count"])
+	co, ok := row.Metadata["co_occurring_contact"].(map[string]any)
+	require.True(t, ok, "co_occurring_contact evidence present")
+	require.Equal(t, contact.ID.String(), co["id"])
+
+	// The surface recomputes suggested_match from display_name → the seeded
+	// same-named contact.
+	match, err := e.matchService.FindBestMatch(e.ctx, row)
+	require.NoError(t, err)
+	require.NotNil(t, match, "suggested match recomputed from display_name")
+	require.Equal(t, contact.ID.String(), match.ContactID)
+}
+
+func TestCorrespondence_LinkAddsMethodAndDispatchesRematch(t *testing.T) {
+	ownAddr := uniqueAddr("me")
+	e := newCorrespondenceEnv(t, ownAddr)
+
+	// Live River client + event bus so the link publishes KindContactMethodsAdded
+	// and enqueues a RematchDispatcher job (the inherited backfill hand-off).
+	workers := river.NewWorkers()
+	river.AddWorker(workers, &correspondenceDispatcherNoopWorker{})
+	riverClient, err := river.NewClient(riverpgxv5.New(e.database.Pool), &river.Config{
+		Queues:   map[string]river.QueueConfig{river.QueueDefault: {MaxWorkers: 1}},
+		Workers:  workers,
+		TestOnly: true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, riverClient.Start(e.ctx))
+	t.Cleanup(func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = riverClient.Stop(stopCtx)
+	})
+
+	bus := events.NewBus(e.database.Pool, riverClient, e.eventRepo)
+	rematchSvc := service.NewRematchService()
+	rematchSvc.Register(correspondenceEmailEligibleHandler{})
+	enrichmentRepo := repository.NewEnrichmentRepository(e.database.Queries)
+	enrichment := service.NewEnrichmentService(e.database, e.contactRepo, e.methodRepo, enrichmentRepo, bus, rematchSvc)
+
+	fullName := "Correspondence Beta " + uuid.New().String()[:6]
+	contact := e.seedContact(t, fullName)
+	unknownAddr := uniqueAddr("beta")
+	normAddr := matching.NormalizeEmail(unknownAddr)
+	e.cleanupExternal(t, normAddr)
+
+	e.seedMessage(t, contact.ID, "ext-"+uuid.New().String(), ownAddr, "gmail-1",
+		nameMetadata(t, unknownAddr, fullName, ownAddr))
+
+	_, err = e.suggester.Run(e.ctx, accelerated.GetCurrentTime().Add(-google.CorrespondenceWindow))
+	require.NoError(t, err)
+	row, err := e.externalRepo.GetBySource(e.ctx, google.CorrespondenceSource, normAddr, nil)
+	require.NoError(t, err)
+	require.NotNil(t, row)
+
+	// Link: enrich the contact with the candidate's email (the modal's link path).
+	jobID, err := enrichment.EnrichContactFromExternalWithSelections(
+		e.ctx, contact.ID, row,
+		[]service.MethodSelection{{OriginalValue: normAddr, Type: "email"}},
+		nil, nil, nil,
+	)
+	require.NoError(t, err)
+	require.NotEqual(t, uuid.Nil, jobID, "email handler eligible → a rematch job id is returned")
+
+	// (a) the email is now a contact_method on the linked contact.
+	methods, err := e.methodRepo.ListContactMethodsByContact(e.ctx, contact.ID)
+	require.NoError(t, err)
+	found := false
+	for _, m := range methods {
+		if m.Value == normAddr && m.Type == "email" {
+			found = true
+		}
+	}
+	require.True(t, found, "linked email must be added as a contact_method")
+
+	// (b) the rematch was dispatched: a contact_methods.added event published +
+	// a RematchDispatcher job enqueued for (contact, jobID).
+	count, err := e.eventRepo.CountRematchDispatcherJobs(e.ctx, contact.ID, jobID)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), count, "exactly one rematch dispatcher job enqueued")
+}
+
+func TestCorrespondence_StickyIgnoreNoClobber(t *testing.T) {
+	ownAddr := uniqueAddr("me")
+	e := newCorrespondenceEnv(t, ownAddr)
+
+	fullName := "Correspondence Gamma " + uuid.New().String()[:6]
+	contact := e.seedContact(t, fullName)
+	unknownAddr := uniqueAddr("gamma")
+	normAddr := matching.NormalizeEmail(unknownAddr)
+	e.cleanupExternal(t, normAddr)
+
+	e.seedMessage(t, contact.ID, "ext-"+uuid.New().String(), ownAddr, "gmail-1",
+		nameMetadata(t, unknownAddr, fullName, ownAddr))
+
+	// First run produces the candidate; ignore it.
+	_, err := e.suggester.Run(e.ctx, accelerated.GetCurrentTime().Add(-google.CorrespondenceWindow))
+	require.NoError(t, err)
+	row, err := e.externalRepo.GetBySource(e.ctx, google.CorrespondenceSource, normAddr, nil)
+	require.NoError(t, err)
+	require.NotNil(t, row)
+	require.NoError(t, e.externalRepo.Ignore(e.ctx, row.ID))
+
+	// Re-run the producer: the ignored row must STAY ignored (the upsert's
+	// DO UPDATE SET never touches match_status) and must NOT reappear unmatched.
+	_, err = e.suggester.Run(e.ctx, accelerated.GetCurrentTime().Add(-google.CorrespondenceWindow))
+	require.NoError(t, err)
+
+	after, err := e.externalRepo.GetBySource(e.ctx, google.CorrespondenceSource, normAddr, nil)
+	require.NoError(t, err)
+	require.NotNil(t, after)
+	require.Equal(t, repository.MatchStatusIgnored, after.MatchStatus, "ignored row not clobbered to unmatched")
+
+	unmatched, err := e.externalRepo.ListAllUnmatched(e.ctx, 1000, 0)
+	require.NoError(t, err)
+	for _, u := range unmatched {
+		require.NotEqual(t, normAddr, u.SourceID, "ignored candidate must not reappear in the unmatched list")
+	}
+}
+
+func TestCorrespondence_ImportEndpointForbidden(t *testing.T) {
+	ownAddr := uniqueAddr("me")
+	e := newCorrespondenceEnv(t, ownAddr)
+
+	// Seed a gmail_correspondence candidate directly.
+	normAddr := matching.NormalizeEmail(uniqueAddr("delta"))
+	e.cleanupExternal(t, normAddr)
+	name := "Correspondence Delta"
+	row, err := e.externalRepo.Upsert(e.ctx, repository.UpsertExternalContactRequest{
+		Source:      google.CorrespondenceSource,
+		SourceID:    normAddr,
+		DisplayName: &name,
+		Emails:      []repository.EmailEntry{{Value: normAddr}},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, row)
+
+	// Wire the import handler + POST the import endpoint.
+	contactService := service.NewContactService(e.database, e.contactRepo, e.methodRepo,
+		repository.NewInteractionRepository(e.database.Queries), repository.NewContactTaskRepository(e.database.Queries), nil, nil)
+	enrichmentRepo := repository.NewEnrichmentRepository(e.database.Queries)
+	enrichment := service.NewEnrichmentService(e.database, e.contactRepo, e.methodRepo, enrichmentRepo, nil, nil)
+	suggestionService := service.NewSuggestionService(e.externalRepo, e.contactRepo, e.methodRepo, enrichment, e.matchService, e.database)
+	importHandler := handlers.NewImportHandler(e.externalRepo, nil, contactService, e.matchService, enrichment, suggestionService)
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(api.RequestIDMiddleware())
+	v1 := router.Group("/api/v1")
+	v1.Group("/imports").POST("/:id/import", importHandler.ImportContact)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/imports/"+row.ID.String()+"/import", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusForbidden, rec.Code, "link-only source must reject import; body: %s", rec.Body.String())
+}
+
+func TestCorrespondence_RederivationEndToEndAndIdempotent(t *testing.T) {
+	ownAddr := uniqueAddr("me")
+	e := newCorrespondenceEnv(t, ownAddr)
+
+	fullName := "Correspondence Epsilon " + uuid.New().String()[:6]
+	contact := e.seedContact(t, fullName)
+	unknownAddr := uniqueAddr("epsilon")
+	normAddr := matching.NormalizeEmail(unknownAddr)
+	e.cleanupExternal(t, normAddr)
+
+	account := ownAddr
+	gmailID := "gmail-rederive-" + uuid.New().String()[:8]
+	externalID := "ext-" + uuid.New().String()
+
+	// Seed a NAME-LESS row (pre-capture shape): bare from/to + full content +
+	// account_gmail_ids provenance, but no *_name keys.
+	namelessMeta, err := json.Marshal(map[string]any{
+		"from":    unknownAddr,
+		"to":      []string{ownAddr},
+		"subject": "Original Subject",
+		"html":    "<p>original body</p>",
+	})
+	require.NoError(t, err)
+	e.seedMessage(t, contact.ID, externalID, account, gmailID, namelessMeta)
+
+	// Producer over the name-less row yields nothing (no display name).
+	n0, err := e.suggester.Run(e.ctx, accelerated.GetCurrentTime().Add(-google.CorrespondenceWindow))
+	require.NoError(t, err)
+	pre, err := e.externalRepo.GetBySource(e.ctx, google.CorrespondenceSource, normAddr, nil)
+	require.NoError(t, err)
+	require.Nil(t, pre, "name-less row must not surface (n0=%d)", n0)
+
+	// Provider with a fake fetcher that supplies display-name headers for the
+	// re-fetch (no OAuth).
+	provider := google.NewGmailSyncProvider(nil, e.commsRepo, nil, e.database.Pool)
+	provider.SetFetcherFactoryForTest(google.NewFakeGmailFetcherFactoryForTest(google.FakeGmailFetcherFuncs{
+		GetMessage: func(_ context.Context, id string) (*gmailapi.Message, error) {
+			require.Equal(t, gmailID, id)
+			return &gmailapi.Message{
+				Id: id,
+				Payload: &gmailapi.MessagePart{
+					Headers: []*gmailapi.MessagePartHeader{
+						{Name: "From", Value: "\"" + fullName + "\" <" + unknownAddr + ">"},
+						{Name: "To", Value: ownAddr},
+					},
+				},
+			}, nil
+		},
+	}))
+
+	runner := google.NewCorrespondenceNameRederiveService(e.commsRepo, provider)
+	since := accelerated.GetCurrentTime().Add(-google.CorrespondenceWindow)
+	res, err := runner.RederiveNames(e.ctx, since)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, res.Rederived, 1)
+	require.Equal(t, 0, res.Failed)
+
+	// Additive-merge invariant: the row now has the name keys AND still has its
+	// original content + provenance keys.
+	msg, err := e.commsRepo.GetMessage(e.ctx, repository.InteractionSourceEmail, externalID, contact.ID)
+	require.NoError(t, err)
+	var merged map[string]any
+	require.NoError(t, json.Unmarshal(msg.SourceMetadata, &merged))
+	require.Equal(t, fullName, merged["from_name"], "name key added")
+	require.Equal(t, unknownAddr, merged["from"], "original from preserved")
+	require.Equal(t, "Original Subject", merged["subject"], "original subject preserved")
+	require.Equal(t, "<p>original body</p>", merged["html"], "original html preserved")
+	require.Contains(t, merged, "account_gmail_ids", "provenance preserved")
+	require.Contains(t, merged, "observed_accounts", "provenance preserved")
+
+	// Producer over the full range now surfaces the previously-hidden backlog.
+	_, err = e.suggester.Run(e.ctx, since)
+	require.NoError(t, err)
+	row, err := e.externalRepo.GetBySource(e.ctx, google.CorrespondenceSource, normAddr, nil)
+	require.NoError(t, err)
+	require.NotNil(t, row, "re-derived backlog now surfaces as a candidate")
+
+	// Idempotency: a second re-derivation re-derives nothing (NOT (? 'from_name')).
+	res2, err := runner.RederiveNames(e.ctx, since)
+	require.NoError(t, err)
+	require.Equal(t, 0, res2.Rederived, "second run re-derives nothing")
+}
+
+// correspondenceEmailEligibleHandler makes the "email" method type eligible so
+// the enrichment link publishes KindContactMethodsAdded. The admin/test process
+// never runs the handler body — only the crm-api dispatcher does.
+type correspondenceEmailEligibleHandler struct{}
+
+func (correspondenceEmailEligibleHandler) IdentifierType() string { return "email" }
+func (correspondenceEmailEligibleHandler) Rematch(context.Context, uuid.UUID, string) (int, error) {
+	return 0, nil
+}
+
+// correspondenceDispatcherNoopWorker satisfies River's registered-kind rule so
+// the live client accepts RematchDispatcher inserts; we assert row counts, not
+// execution.
+type correspondenceDispatcherNoopWorker struct {
+	river.WorkerDefaults[correspondenceDispatcherNoopArgs]
+}
+
+func (*correspondenceDispatcherNoopWorker) Work(context.Context, *river.Job[correspondenceDispatcherNoopArgs]) error {
+	return nil
+}
+
+type correspondenceDispatcherNoopArgs struct{}
+
+func (correspondenceDispatcherNoopArgs) Kind() string { return "rematch_dispatcher" }

--- a/backend/tests/gmail_correspondence_integration_test.go
+++ b/backend/tests/gmail_correspondence_integration_test.go
@@ -1,4 +1,4 @@
-// Integration coverage for the gmail_correspondence enrichment source (C).
+// Integration coverage for the gmail_correspondence enrichment source.
 // Drives the REAL producer, repos, ImportMatchService, EnrichmentService (with
 // a live event bus + River client), and the re-derivation runner (with a fake
 // Gmail fetcher via the provider's exported test seam) against the shared test
@@ -10,7 +10,8 @@
 //     KindContactMethodsAdded rematch (the inherited backfill hand-off — async
 //     scan completion is covered by gmail_rematch_integration_test.go, not here);
 //   - sticky-ignore is preserved across producer re-runs (no clobber);
-//   - the import endpoint returns 403 for this link-only source (B's teeth);
+//   - the import endpoint returns 403 for this link-only source (the shared
+//     import-suggestions surface's server-side link-only enforcement);
 //   - the one-time re-derivation re-fetches name-less rows, ADDS the name keys
 //     while preserving all existing content + provenance (the additive-merge
 //     invariant), and the producer then surfaces the previously-hidden backlog;
@@ -48,7 +49,7 @@ import (
 	gmailapi "google.golang.org/api/gmail/v1"
 )
 
-// correspondenceEnv bundles a real DB + the repos/services the C tests drive.
+// correspondenceEnv bundles a real DB + the repos/services these tests drive.
 type correspondenceEnv struct {
 	ctx          context.Context
 	database     *db.Database

--- a/backend/tests/gmail_correspondence_integration_test.go
+++ b/backend/tests/gmail_correspondence_integration_test.go
@@ -206,6 +206,34 @@ func TestCorrespondence_ProducerEmitsCandidateWithSuggestedMatch(t *testing.T) {
 	require.Equal(t, contact.ID.String(), match.ContactID)
 }
 
+func TestCorrespondence_SkipsSoftDeletedContactRows(t *testing.T) {
+	// A contact's soft-delete (UPDATE deleted_at) does NOT cascade to its
+	// comms_message rows — the FK cascade only fires on a hard DELETE. The
+	// producer's scan query INNER-JOINs a live contact, so once the matched
+	// contact is soft-deleted its correspondence must stop surfacing candidates.
+	ownAddr := uniqueAddr("me")
+	e := newCorrespondenceEnv(t, ownAddr)
+
+	fullName := "Correspondence Deleted " + uuid.New().String()[:6]
+	contact := e.seedContact(t, fullName)
+	unknownAddr := uniqueAddr("deleted")
+	normAddr := matching.NormalizeEmail(unknownAddr)
+	e.cleanupExternal(t, normAddr)
+
+	e.seedMessage(t, contact.ID, "ext-"+uuid.New().String(), ownAddr, "gmail-1",
+		nameMetadata(t, unknownAddr, fullName, ownAddr))
+
+	// Soft-delete the matched contact; its comms_message row stays live.
+	require.NoError(t, e.contactRepo.SoftDeleteContact(e.ctx, contact.ID))
+
+	_, err := e.suggester.Run(e.ctx, accelerated.GetCurrentTime().Add(-google.CorrespondenceWindow))
+	require.NoError(t, err)
+
+	row, err := e.externalRepo.GetBySource(e.ctx, google.CorrespondenceSource, normAddr, nil)
+	require.NoError(t, err)
+	require.Nil(t, row, "a soft-deleted contact's correspondence must not surface a candidate")
+}
+
 func TestCorrespondence_LinkAddsMethodAndDispatchesRematch(t *testing.T) {
 	ownAddr := uniqueAddr("me")
 	e := newCorrespondenceEnv(t, ownAddr)

--- a/frontend/src/app/imports/page.tsx
+++ b/frontend/src/app/imports/page.tsx
@@ -17,6 +17,7 @@ import {
   Calendar,
   Send,
   MessageCircle,
+  Users,
 } from 'lucide-react'
 import { Navigation } from '@/components/layout/navigation'
 import { Button } from '@/components/ui/button'
@@ -160,6 +161,23 @@ function CandidateCard({
     ? meetingContext.meeting_link
     : null
 
+  // Gmail-correspondence evidence: the co-occurring contact and how many
+  // messages this address was seen in.
+  const correspondence =
+    candidate.source === 'gmail_correspondence' && candidate.metadata ? candidate.metadata : null
+  const correspondenceLabel = correspondence
+    ? [
+        correspondence.co_occurring_contact?.name
+          ? `Seen with ${correspondence.co_occurring_contact.name}`
+          : null,
+        correspondence.message_count
+          ? `${correspondence.message_count} ${correspondence.message_count === 1 ? 'message' : 'messages'}`
+          : null,
+      ]
+        .filter(Boolean)
+        .join(' · ')
+    : null
+
   return (
     <div className="p-4 bg-white border border-gray-200 rounded-lg hover:shadow-sm transition-shadow">
       <div className="flex items-start justify-between">
@@ -204,6 +222,14 @@ function CandidateCard({
                     From: {meetingContext.meeting_title}
                   </span>
                 ))}
+              {/* Inline correspondence-evidence badge for gmail_correspondence
+                  candidates: who this address co-appeared with + message count. */}
+              {correspondenceLabel && (
+                <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800">
+                  <Users className="w-3 h-3 mr-1" />
+                  {correspondenceLabel}
+                </span>
+              )}
             </div>
 
             {/* Organization and job title */}

--- a/frontend/src/types/import.ts
+++ b/frontend/src/types/import.ts
@@ -16,6 +16,10 @@ export interface ImportCandidateMetadata {
   discovered_at?: string
   // Telegram peer metadata (source: 'telegram'). Stored with leading '@'.
   username?: string
+  // Gmail correspondence evidence (source: 'gmail_correspondence').
+  display_names_seen?: string[]
+  co_occurring_contact?: { id: string; name?: string }
+  message_count?: number
 }
 
 export interface ImportCandidate {

--- a/frontend/tests/e2e/imports-correspondence.spec.ts
+++ b/frontend/tests/e2e/imports-correspondence.spec.ts
@@ -54,9 +54,12 @@ test.describe('Imports gmail_correspondence evidence @area:imports', () => {
     // Link-only: no Import button on the card.
     await expect(card.getByRole('button', { name: 'Import' })).toHaveCount(0)
 
-    // Open the modal via Link, steer it to THIS worker's candidate, and link.
+    // Open the modal via Link. This is a link-only source, so the modal is
+    // locked to link mode (no Import/Link toggle buttons) — wait for the
+    // always-present Link Contact submit button instead, then steer the modal
+    // to THIS worker's candidate.
     await card.getByRole('button', { name: /Link/i }).click()
-    await expect(page.getByRole('button', { name: /Link to Existing/i })).toBeVisible()
+    await expect(page.getByRole('button', { name: /Link Contact/i })).toBeVisible()
     await navigateModalToCandidate(page, cardName)
 
     // Ensure a contact is selected (the trigram match usually pre-selects it).

--- a/frontend/tests/e2e/imports-correspondence.spec.ts
+++ b/frontend/tests/e2e/imports-correspondence.spec.ts
@@ -2,11 +2,12 @@ import { test, expect } from './fixtures'
 import { createTestAPI, TestAPI } from './helpers/test-api'
 import { navigateModalToCandidate } from './helpers/imports-helpers'
 
-// gmail_correspondence source (C): a link-only candidate carries an evidence
-// badge (co-occurring contact + message count) and links to an existing
-// contact, adding the email as a contact method. Data is seeded per-worker for
-// parallel isolation. The link-only Import-hidden policy is B's; this spec
-// covers C's net-new evidence badge + the end-to-end link.
+// gmail_correspondence source: a link-only candidate carries an evidence badge
+// (co-occurring contact + message count) and links to an existing contact,
+// adding the email as a contact method. Data is seeded per-worker for parallel
+// isolation. The link-only Import-hidden policy is enforced by the shared
+// import-suggestions surface; this spec covers the evidence badge + the
+// end-to-end link.
 test.describe('Imports gmail_correspondence evidence @area:imports', () => {
   let testApi: TestAPI
 
@@ -47,7 +48,7 @@ test.describe('Imports gmail_correspondence evidence @area:imports', () => {
       .locator('div.border', { has: page.getByRole('heading', { name: cardName }) })
       .first()
 
-    // C's net-new UI: the evidence badge (co-occurring contact + message count).
+    // The evidence badge: co-occurring contact + message count.
     await expect(card.getByText(`Seen with ${testApi.prefix}-Correspondence Person`)).toBeVisible()
     await expect(card.getByText('4 messages')).toBeVisible()
 

--- a/frontend/tests/e2e/imports-correspondence.spec.ts
+++ b/frontend/tests/e2e/imports-correspondence.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect } from './fixtures'
+import { createTestAPI, TestAPI } from './helpers/test-api'
+import { navigateModalToCandidate } from './helpers/imports-helpers'
+
+// gmail_correspondence source (C): a link-only candidate carries an evidence
+// badge (co-occurring contact + message count) and links to an existing
+// contact, adding the email as a contact method. Data is seeded per-worker for
+// parallel isolation. The link-only Import-hidden policy is B's; this spec
+// covers C's net-new evidence badge + the end-to-end link.
+test.describe('Imports gmail_correspondence evidence @area:imports', () => {
+  let testApi: TestAPI
+
+  test.beforeEach(async ({ request }, testInfo) => {
+    testApi = createTestAPI(request, testInfo)
+  })
+
+  test.afterEach(async () => {
+    await testApi.cleanup()
+  })
+
+  test('evidence badge renders, Import is hidden, and link adds the method', async ({ page }) => {
+    // Seed the CRM contact the candidate should suggest (same name so the
+    // trigram suggested-match pre-selects it), then the gmail_correspondence
+    // candidate with evidence metadata. The seed route prefixes display names,
+    // so the candidate's effective name matches the prefixed contact name.
+    await testApi.seedContacts([{ full_name: 'Correspondence Person' }])
+    await testApi.seedExternalContacts([
+      {
+        display_name: 'Correspondence Person',
+        source: 'gmail_correspondence',
+        emails: [`correspondence-${testApi.prefix}@example.invalid`],
+        metadata: {
+          display_names_seen: ['Correspondence Person'],
+          message_count: 4,
+          co_occurring_contact: { id: '', name: `${testApi.prefix}-Correspondence Person` },
+        },
+      },
+    ])
+
+    await page.goto('/imports')
+    await page.waitForLoadState('domcontentloaded')
+
+    const cardName = `${testApi.prefix}-Correspondence Person`
+    await expect(page.getByText(cardName).first()).toBeVisible({ timeout: 10000 })
+
+    const card = page
+      .locator('div.border', { has: page.getByRole('heading', { name: cardName }) })
+      .first()
+
+    // C's net-new UI: the evidence badge (co-occurring contact + message count).
+    await expect(card.getByText(`Seen with ${testApi.prefix}-Correspondence Person`)).toBeVisible()
+    await expect(card.getByText('4 messages')).toBeVisible()
+
+    // Link-only: no Import button on the card.
+    await expect(card.getByRole('button', { name: 'Import' })).toHaveCount(0)
+
+    // Open the modal via Link, steer it to THIS worker's candidate, and link.
+    await card.getByRole('button', { name: /Link/i }).click()
+    await expect(page.getByRole('button', { name: /Link to Existing/i })).toBeVisible()
+    await navigateModalToCandidate(page, cardName)
+
+    // Ensure a contact is selected (the trigram match usually pre-selects it).
+    const search = page.locator('input[placeholder="Search for a contact..."]')
+    if (await search.isVisible().catch(() => false)) {
+      await search.fill('Correspondence Person')
+      await page.getByText(cardName, { exact: true }).last().click()
+    }
+    await expect(page.getByRole('button', { name: /Link Contact/i })).toBeEnabled()
+
+    // Link adds the email method to the existing contact (200 response).
+    const linkResponse = page.waitForResponse(res => /\/imports\/.+\/link$/.test(res.url()))
+    await page.getByRole('button', { name: /Link Contact/i }).click()
+    const res = await linkResponse
+    expect(res.status()).toBe(200)
+
+    // The candidate leaves the People list once linked.
+    await page.keyboard.press('Escape')
+    await expect(
+      page.locator('div.border', { has: page.getByRole('heading', { name: cardName }) })
+    ).toHaveCount(0, { timeout: 10000 })
+  })
+})


### PR DESCRIPTION
## What

Item C of the contact-method-enrichment arc. A producer that mines the participants of already-ingested known-contact email threads to discover email addresses belonging to **existing** CRM contacts that aren't on their record, surfaced as **link-only** candidates in the People-tab suggestion surface. It never creates new contacts. Builds on A (#388, the category-filter fix) and reuses B's merged spine (#397).

Design SSOT: `.ai/spec/2026-06-02-gmail-correspondence-enrichment-design.md` (committed here) + umbrella `.ai/spec/2026-06-02-contact-method-enrichment-suggestions-design.md` §3.

## How

- **Producer** (`GmailCorrespondenceSuggester`) + a periodic ~6h River scan worker: reads from/to/cc/bcc participants from `comms_message.source_metadata` (no new Gmail fetching on the steady-state path), drops known + own-account addresses, and for each unknown address with a ≥2-token display name trigram-matches the name to CRM contacts; qualifies at similarity ≥ 0.60. Upserts `external_contact` rows (`source='gmail_correspondence'`) that flow through the existing suggestion surface as link-only candidates with evidence (observed name, co-occurring contact, message count).
- **Step 2a — ingest fix:** Gmail ingest previously parsed participant display names and discarded them (only bare addresses were stored). It now stores `from_name`/`to_names`/… additively. Forward-only on its own.
- **Step 2b — historical re-derivation:** a one-time `crm-admin --rederive-correspondence-names` that re-fetches already-ingested messages from Gmail, additively merges the recovered display names into `comms_message.source_metadata` (preserving all existing content + provenance keys; idempotent; rate-limit-aware), then runs a one-time full-range producer pass — so the historical backlog surfaces, not just new mail.
- **Link-only** is enforced server-side (a `gmail_correspondence` candidate cannot be imported as a new contact; 403), reusing B's per-source policy.

## Precision

Gate pinned by a regression test: similarity ≥ 0.60 AND a ≥2-token display name (validated ~93% precision on a real-account sample). Single-token names and sub-0.60 matches are rejected.

## Review / tests

Independent design + pre-push review passed with no P0/P1 (3 P2 + 3 P3 non-blocking); all CI-only invariant guards pass locally. Coverage: unit (the gate incl. the exact-0.60 boundary, dedup, skip-known/ignored, participant + display-name extraction, the Step-2b metadata merge), integration (producer→candidates, link→enrich→rematch dispatch, sticky-ignore, import-not-offered, re-derivation→names→candidates), E2E (a correspondence candidate appears and link adds the method). `make lint` / `make test` / `make test-e2e-diff` green.

## After merge (operator steps)

1. Deploy to the Pi.
2. Run the one-time `crm-admin --rederive-correspondence-names` to recover historical display names and surface the existing backlog. (Forward mail accrues names automatically via Step 2a.)