### PR TITLE
fix(gmail): advance backfill cursor only over scanned windows

### DIFF
--- a/backend/cmd/crm-admin/main.go
+++ b/backend/cmd/crm-admin/main.go
@@ -44,6 +44,11 @@
 //	                              Google OAuth credentials; built lazily so
 //	                              other subcommands work on Google-less hosts.
 //
+//	--reset-gmail-backfill-cursors
+//	                              Rewind enabled Gmail sync cursors to each
+//	                              row's backfill floor, mark them due, and
+//	                              clear error state. Prints counts only.
+//
 //	--mint-pairing-token          Mint a single-use pairing token for
 //	                              `crm-mac install --pair`. Optional
 //	                              --hostname-label is operator-side
@@ -121,8 +126,8 @@ type hostRevoker interface {
 }
 
 // rematchRunner is the narrow interface --messages-rematch-stranded
-// needs. Defined for symmetry with the new flags so all four
-// subcommands can be exercised by test doubles.
+// needs. Defined for symmetry with the other flags so subcommands can be
+// exercised by test doubles.
 type rematchRunner interface {
 	RematchStranded(ctx context.Context) (*messages.RematchStrandedResult, error)
 }
@@ -149,6 +154,13 @@ type correspondenceScanner interface {
 	Run(ctx context.Context, since time.Time) (int, error)
 }
 
+// gmailBackfillCursorResetter is the narrow interface
+// --reset-gmail-backfill-cursors needs. Production wires this to
+// *service.EmailBackfillCursorResetService.ResetGmailBackfillCursors.
+type gmailBackfillCursorResetter interface {
+	ResetGmailBackfillCursors(ctx context.Context) (service.EmailBackfillCursorResetResult, error)
+}
+
 // adminDeps groups the per-subcommand dependencies. Tests inject
 // fakes for each interface; the production wiring builds a single
 // MacHostService and a small adapter for rematch.
@@ -164,6 +176,7 @@ type adminDeps struct {
 	// subcommand on a Google-less host. Nil for all other subcommands.
 	rederive       rederiveRunner
 	correspondence correspondenceScanner
+	gmailReset     gmailBackfillCursorResetter
 	stdout         io.Writer
 	stderr         io.Writer
 }
@@ -174,6 +187,7 @@ type runOptions struct {
 	rematchStranded        bool
 	reconcileAddressBook   bool
 	rederiveCorrespondence bool
+	resetGmailBackfill     bool
 	mintPairingToken       bool
 	hostnameLabel          string
 	listHosts              bool
@@ -238,6 +252,9 @@ func validateSubcommand(opts runOptions) error {
 	if opts.rederiveCorrespondence {
 		active++
 	}
+	if opts.resetGmailBackfill {
+		active++
+	}
 	if opts.mintPairingToken {
 		active++
 	}
@@ -252,11 +269,11 @@ func validateSubcommand(opts runOptions) error {
 	}
 	if active == 0 {
 		return errors.New("no subcommand specified; pass exactly one of " +
-			"--messages-rematch-stranded, --reconcile-address-book-methods, --rederive-correspondence-names, --mint-pairing-token, --list-hosts, --revoke-host <uuid>, --rotate-host-key <uuid>")
+			"--messages-rematch-stranded, --reconcile-address-book-methods, --rederive-correspondence-names, --reset-gmail-backfill-cursors, --mint-pairing-token, --list-hosts, --revoke-host <uuid>, --rotate-host-key <uuid>")
 	}
 	if active > 1 {
 		return errors.New("subcommand flags are mutually exclusive; pass exactly one of " +
-			"--messages-rematch-stranded, --reconcile-address-book-methods, --rederive-correspondence-names, --mint-pairing-token, --list-hosts, --revoke-host <uuid>, --rotate-host-key <uuid>")
+			"--messages-rematch-stranded, --reconcile-address-book-methods, --rederive-correspondence-names, --reset-gmail-backfill-cursors, --mint-pairing-token, --list-hosts, --revoke-host <uuid>, --rotate-host-key <uuid>")
 	}
 	return nil
 }
@@ -278,6 +295,9 @@ func parseArgs(args []string) (runOptions, error) {
 			"then run a full-range gmail_correspondence producer pass so the historical "+
 			"backlog surfaces as link candidates. Continue-on-error; exits non-zero iff "+
 			"any row failed. Idempotent — safe to re-run. Requires Google OAuth creds.")
+	fs.BoolVar(&opts.resetGmailBackfill, "reset-gmail-backfill-cursors", false,
+		"Rewind enabled Gmail sync cursors to each row's backfill floor, mark them due, "+
+			"and clear error state. Prints counts only.")
 	fs.BoolVar(&opts.mintPairingToken, "mint-pairing-token", false,
 		"Mint a single-use pairing token for `crm-mac install --pair`.")
 	fs.StringVar(&opts.hostnameLabel, "hostname-label", "",
@@ -319,6 +339,8 @@ func run(ctx context.Context, opts runOptions, deps adminDeps) error {
 		return runReconcileAddressBookMethods(ctx, deps)
 	case opts.rederiveCorrespondence:
 		return runRederiveCorrespondenceNames(ctx, deps)
+	case opts.resetGmailBackfill:
+		return runResetGmailBackfillCursors(ctx, deps)
 	}
 	return errors.New("unreachable")
 }
@@ -460,6 +482,20 @@ func runReconcileAddressBookMethods(ctx context.Context, deps adminDeps) error {
 	return nil
 }
 
+func runResetGmailBackfillCursors(ctx context.Context, deps adminDeps) error {
+	res, err := deps.gmailReset.ResetGmailBackfillCursors(ctx)
+	if err != nil {
+		return fmt.Errorf("reset gmail backfill cursors: %w", err)
+	}
+	if _, err := fmt.Fprintf(deps.stdout, "reset-gmail-backfill-cursors summary:\n"+
+		"  scanned: %d\n"+
+		"  reset:   %d\n",
+		res.Scanned, res.Reset); err != nil {
+		return fmt.Errorf("write summary: %w", err)
+	}
+	return nil
+}
+
 // correspondenceBackfillFloor is the lower bound for the one-time
 // re-derivation + full-range producer pass. It matches the Gmail onboarding
 // backfill floor (the earliest mail the integration ever ingested), so the
@@ -588,11 +624,12 @@ func buildProductionDeps(ctx context.Context, cfg *config.Config, database *db.D
 	)
 
 	deps := adminDeps{
-		tokens:    hostService,
-		hosts:     hostService,
-		revoker:   hostService,
-		rematch:   rematch,
-		reconcile: addressBookReconcile,
+		tokens:     hostService,
+		hosts:      hostService,
+		revoker:    hostService,
+		rematch:    rematch,
+		reconcile:  addressBookReconcile,
+		gmailReset: service.NewEmailBackfillCursorResetService(syncRepo),
 	}
 
 	// LAZY: build the correspondence re-derivation stack ONLY for

--- a/backend/cmd/crm-admin/main_test.go
+++ b/backend/cmd/crm-admin/main_test.go
@@ -79,6 +79,20 @@ func (f *fakeRematchRunner) RematchStranded(_ context.Context) (*messages.Rematc
 	return f.result, nil
 }
 
+type fakeGmailBackfillResetter struct {
+	result service.EmailBackfillCursorResetResult
+	err    error
+	calls  int
+}
+
+func (f *fakeGmailBackfillResetter) ResetGmailBackfillCursors(_ context.Context) (service.EmailBackfillCursorResetResult, error) {
+	f.calls++
+	if f.err != nil {
+		return service.EmailBackfillCursorResetResult{}, f.err
+	}
+	return f.result, nil
+}
+
 func newTestDeps() (adminDeps, *bytes.Buffer, *fakeTokenMinter, *fakeHostLister, *fakeHostRevoker, *fakeRematchRunner) {
 	stdout := &bytes.Buffer{}
 	tokens := &fakeTokenMinter{
@@ -88,13 +102,15 @@ func newTestDeps() (adminDeps, *bytes.Buffer, *fakeTokenMinter, *fakeHostLister,
 	hosts := &fakeHostLister{}
 	revoker := &fakeHostRevoker{}
 	rematch := &fakeRematchRunner{result: &messages.RematchStrandedResult{}}
+	gmailReset := &fakeGmailBackfillResetter{}
 	return adminDeps{
-		tokens:  tokens,
-		hosts:   hosts,
-		revoker: revoker,
-		rematch: rematch,
-		stdout:  stdout,
-		stderr:  &bytes.Buffer{},
+		tokens:     tokens,
+		hosts:      hosts,
+		revoker:    revoker,
+		rematch:    rematch,
+		gmailReset: gmailReset,
+		stdout:     stdout,
+		stderr:     &bytes.Buffer{},
 	}, stdout, tokens, hosts, revoker, rematch
 }
 
@@ -367,6 +383,46 @@ func TestRunRematchStrandedDelegates(t *testing.T) {
 	}
 }
 
+func TestRunResetGmailBackfillCursorsCountsOnly(t *testing.T) {
+	deps, stdout, _, _, _, _ := newTestDeps()
+	reset := &fakeGmailBackfillResetter{
+		result: service.EmailBackfillCursorResetResult{Scanned: 3, Reset: 2},
+	}
+	deps.gmailReset = reset
+
+	err := run(context.Background(), runOptions{resetGmailBackfill: true}, deps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if reset.calls != 1 {
+		t.Fatalf("expected 1 reset call, got %d", reset.calls)
+	}
+	out := stdout.String()
+	for _, want := range []string{"reset-gmail-backfill-cursors summary:", "scanned: 3", "reset:   2"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q: %s", want, out)
+		}
+	}
+	for _, forbidden := range []string{"account_id", "sync_cursor", "example.com"} {
+		if strings.Contains(out, forbidden) {
+			t.Fatalf("output must be counts-only; found %q in %s", forbidden, out)
+		}
+	}
+}
+
+func TestRunResetGmailBackfillCursorsError(t *testing.T) {
+	deps, _, _, _, _, _ := newTestDeps()
+	deps.gmailReset = &fakeGmailBackfillResetter{err: errors.New("db down")}
+
+	err := run(context.Background(), runOptions{resetGmailBackfill: true}, deps)
+	if err == nil {
+		t.Fatal("expected reset error")
+	}
+	if !strings.Contains(err.Error(), "reset gmail backfill cursors") {
+		t.Fatalf("expected wrapped reset error, got %v", err)
+	}
+}
+
 type fakeReconcileRunner struct {
 	result service.ReconcileAllResult
 	err    error
@@ -442,6 +498,17 @@ func TestRunReconcileMutualExclusion(t *testing.T) {
 	}
 }
 
+func TestRunResetGmailBackfillMutualExclusion(t *testing.T) {
+	deps, _, _, _, _, _ := newTestDeps()
+	err := run(context.Background(), runOptions{
+		resetGmailBackfill: true,
+		rematchStranded:    true,
+	}, deps)
+	if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("expected mutual-exclusion error, got %v", err)
+	}
+}
+
 func TestParseArgsAllFlags(t *testing.T) {
 	cases := []struct {
 		name     string
@@ -511,6 +578,15 @@ func TestParseArgsAllFlags(t *testing.T) {
 			func(t *testing.T, o runOptions) {
 				if !o.rederiveCorrespondence {
 					t.Fatal("rederive-correspondence-names flag not set")
+				}
+			},
+		},
+		{
+			"reset-gmail-backfill-cursors",
+			[]string{"--reset-gmail-backfill-cursors"},
+			func(t *testing.T, o runOptions) {
+				if !o.resetGmailBackfill {
+					t.Fatal("reset-gmail-backfill-cursors flag not set")
 				}
 			},
 		},

--- a/backend/internal/db/external_sync.sql.go
+++ b/backend/internal/db/external_sync.sql.go
@@ -541,6 +541,50 @@ func (q *Queries) ListEnabledSyncStates(ctx context.Context) ([]*ExternalSyncSta
 	return items, nil
 }
 
+const ListEnabledSyncStatesBySource = `-- name: ListEnabledSyncStatesBySource :many
+SELECT id, source, account_id, enabled, status, strategy, last_sync_at, last_successful_sync_at, next_sync_at, sync_cursor, error_message, error_count, metadata, created_at, updated_at FROM external_sync_state
+WHERE source = $1
+  AND enabled = TRUE
+  AND status != 'disabled'
+ORDER BY account_id
+`
+
+func (q *Queries) ListEnabledSyncStatesBySource(ctx context.Context, source string) ([]*ExternalSyncState, error) {
+	rows, err := q.db.Query(ctx, ListEnabledSyncStatesBySource, source)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []*ExternalSyncState{}
+	for rows.Next() {
+		var i ExternalSyncState
+		if err := rows.Scan(
+			&i.ID,
+			&i.Source,
+			&i.AccountID,
+			&i.Enabled,
+			&i.Status,
+			&i.Strategy,
+			&i.LastSyncAt,
+			&i.LastSuccessfulSyncAt,
+			&i.NextSyncAt,
+			&i.SyncCursor,
+			&i.ErrorMessage,
+			&i.ErrorCount,
+			&i.Metadata,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const ListRecentSyncLogs = `-- name: ListRecentSyncLogs :many
 SELECT id, sync_state_id, source, account_id, started_at, completed_at, status, items_processed, items_matched, items_created, error_message, metadata, created_at FROM external_sync_log
 ORDER BY started_at DESC
@@ -667,6 +711,47 @@ func (q *Queries) ListSyncStates(ctx context.Context) ([]*ExternalSyncState, err
 		return nil, err
 	}
 	return items, nil
+}
+
+const ResetSyncStateBackfillCursor = `-- name: ResetSyncStateBackfillCursor :one
+UPDATE external_sync_state
+SET sync_cursor = $1,
+    next_sync_at = $2,
+    status = 'idle',
+    error_message = NULL,
+    error_count = 0,
+    updated_at = NOW()
+WHERE id = $3
+RETURNING id, source, account_id, enabled, status, strategy, last_sync_at, last_successful_sync_at, next_sync_at, sync_cursor, error_message, error_count, metadata, created_at, updated_at
+`
+
+type ResetSyncStateBackfillCursorParams struct {
+	SyncCursor pgtype.Text        `json:"sync_cursor"`
+	NextSyncAt pgtype.Timestamptz `json:"next_sync_at"`
+	ID         pgtype.UUID        `json:"id"`
+}
+
+func (q *Queries) ResetSyncStateBackfillCursor(ctx context.Context, arg ResetSyncStateBackfillCursorParams) (*ExternalSyncState, error) {
+	row := q.db.QueryRow(ctx, ResetSyncStateBackfillCursor, arg.SyncCursor, arg.NextSyncAt, arg.ID)
+	var i ExternalSyncState
+	err := row.Scan(
+		&i.ID,
+		&i.Source,
+		&i.AccountID,
+		&i.Enabled,
+		&i.Status,
+		&i.Strategy,
+		&i.LastSyncAt,
+		&i.LastSuccessfulSyncAt,
+		&i.NextSyncAt,
+		&i.SyncCursor,
+		&i.ErrorMessage,
+		&i.ErrorCount,
+		&i.Metadata,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return &i, err
 }
 
 const UpdateMacHostSyncCursor = `-- name: UpdateMacHostSyncCursor :one

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -824,6 +824,7 @@ type Querier interface {
 	// lowercased by the contact_method trigger. Ordered deterministically.
 	ListEmailIdentitiesForSync(ctx context.Context) ([]*ListEmailIdentitiesForSyncRow, error)
 	ListEnabledSyncStates(ctx context.Context) ([]*ExternalSyncState, error)
+	ListEnabledSyncStatesBySource(ctx context.Context, source string) ([]*ExternalSyncState, error)
 	ListEnrichmentsBySource(ctx context.Context, arg ListEnrichmentsBySourceParams) ([]*ContactEnrichment, error)
 	// List events by Google account within a date range
 	ListEventsByAccountAndDateRange(ctx context.Context, arg ListEventsByAccountAndDateRangeParams) ([]*CalendarEvent, error)
@@ -1054,6 +1055,7 @@ type Querier interface {
 	// Replace source contact ID with target contact ID in calendar event matched_contact_ids array
 	// Uses array_replace for efficient in-place replacement
 	ReplaceContactInCalendarEvents(ctx context.Context, arg ReplaceContactInCalendarEventsParams) error
+	ResetSyncStateBackfillCursor(ctx context.Context, arg ResetSyncStateBackfillCursorParams) (*ExternalSyncState, error)
 	ResetTelegramChatConfigBackfill(ctx context.Context, telegramChatID int64) error
 	// Sets linked_kind, linked_id, linkage_state='linked',
 	// conflict_candidates=NULL on a row currently in linkage_state =

--- a/backend/internal/db/queries/external_sync.sql
+++ b/backend/internal/db/queries/external_sync.sql
@@ -17,6 +17,13 @@ SELECT * FROM external_sync_state
 WHERE enabled = TRUE AND status != 'disabled'
 ORDER BY source, account_id;
 
+-- name: ListEnabledSyncStatesBySource :many
+SELECT * FROM external_sync_state
+WHERE source = @source
+  AND enabled = TRUE
+  AND status != 'disabled'
+ORDER BY account_id;
+
 -- name: ListDueSyncStates :many
 -- The 'syncing' status value stays in the CHECK constraint for
 -- down-migration safety but is no longer written by any code path.
@@ -114,6 +121,17 @@ UPDATE external_sync_state
 SET sync_cursor = $2,
     updated_at = NOW()
 WHERE id = $1;
+
+-- name: ResetSyncStateBackfillCursor :one
+UPDATE external_sync_state
+SET sync_cursor = @sync_cursor,
+    next_sync_at = @next_sync_at,
+    status = 'idle',
+    error_message = NULL,
+    error_count = 0,
+    updated_at = NOW()
+WHERE id = @id
+RETURNING *;
 
 -- name: UpdateSyncStateMetadata :one
 UPDATE external_sync_state

--- a/backend/internal/google/gmail.go
+++ b/backend/internal/google/gmail.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"personal-crm/backend/internal/accelerated"
 	"personal-crm/backend/internal/events"
 	"personal-crm/backend/internal/logger"
 	"personal-crm/backend/internal/matching"
@@ -54,11 +55,23 @@ const (
 	// gmailChunkByteCap caps the URL-encoded length of a single chunk query at
 	// ~6 KB, well under the practical ~8 KB GET-URL limit (spec §3.1/§7).
 	gmailChunkByteCap = 6000
-	// gmailDefaultBackfillSince is the onboarding floor used when an account
-	// has no cursor and no metadata override (spec §3.2/§7).
-	gmailDefaultBackfillSince = "2026-01-01"
 	// gmailUserID is Gmail's special-value alias for the authenticated account.
 	gmailUserID = "me"
+	// gmailWindowSpan bounds each proven cursor window. Catch-up scans several
+	// windows per run, but the cursor only moves after a whole window is listed,
+	// paged, fetched, and filtered successfully.
+	gmailWindowSpan = 7 * 24 * time.Hour
+	// gmailMaxWindowsPerSync lets a rewound account catch up promptly while
+	// keeping one run bounded against unexpectedly large mailboxes or Gmail
+	// rate limits.
+	gmailMaxWindowsPerSync = 24
+	// gmailSearchSafetyLag leaves recent Gmail index churn out of the proven
+	// window. A later run picks it up once the index has had time to settle.
+	gmailSearchSafetyLag = 10 * time.Minute
+	// gmailSearchBoundaryOverlap compensates for Gmail search date operators
+	// behaving coarser than internalDate. The query is deliberately broad and
+	// the provider applies the exact internalDate window in Go.
+	gmailSearchBoundaryOverlap = 48 * time.Hour
 )
 
 // emailSafeTermRegex matches an address that is safe to embed verbatim in a
@@ -118,7 +131,7 @@ func (f *gmailServiceFetcher) GetMessage(ctx context.Context, id string) (*gmail
 		// id is a per-mailbox Gmail message id (third-party identifier); hash it
 		// so the error (which flows into River logs) carries no raw third-party
 		// reference while staying correlatable.
-		return nil, fmt.Errorf("get message %s: %w", hashIdentifier(id), err)
+		return nil, fmt.Errorf("get message %s: %w", hashGmailMessageID(id), err)
 	}
 	return msg, nil
 }
@@ -335,53 +348,189 @@ func (p *GmailSyncProvider) Sync(
 		return nil, fmt.Errorf("build gmail fetcher: %w", err)
 	}
 
-	// Resolve the after: floor. An empty cursor means onboarding — fall back to
-	// backfill_since (default 2026-01-01) converted to epoch seconds.
 	priorCursor := ""
 	if state.SyncCursor != nil {
 		priorCursor = *state.SyncCursor
 	}
-	priorCursorSecs, afterEpoch := resolveAfterFloor(priorCursor, state.Metadata)
+	cursorState := parseGmailCursor(priorCursor, state.Metadata)
+	safeHorizon := accelerated.GetCurrentTime().UTC().Add(-gmailSearchSafetyLag).Unix()
+	if safeHorizon <= cursorState.CompletedThrough {
+		logger.Info().
+			Str("source", GmailSourceName).
+			Str("account", accountID).
+			Int64("completed_through", cursorState.CompletedThrough).
+			Int64("safe_horizon", safeHorizon).
+			Msg("Gmail sync has no closed window to scan")
+		return &sync.SyncResult{NewCursor: priorCursor}, nil
+	}
 
 	addresses := make([]string, 0, len(knownMap))
 	for addr := range knownMap {
 		addresses = append(addresses, addr)
 	}
-	chunks := buildORChunks(addresses, afterEpoch)
 
-	processed, matched, maxInternalDateSecs, fetchedAny, err := p.scanChunks(ctx, fetcher, chunks, accountID, knownMap, meSet)
-	if err != nil {
-		// Hard failure: abort the sweep, return the prior cursor unchanged so
-		// the whole after:<prior> window re-runs next tick.
-		return p.failResult(priorCursor), fmt.Errorf("scan chunks: %w", err)
+	result := &sync.SyncResult{}
+	windowsScanned := 0
+	fetchedMessages := make(map[string]*gmail.Message)
+	for windowsScanned < gmailMaxWindowsPerSync && cursorState.CompletedThrough < safeHorizon {
+		windowEnd := cursorState.CompletedThrough + int64(gmailWindowSpan/time.Second)
+		if windowEnd > safeHorizon {
+			windowEnd = safeHorizon
+		}
+		if windowEnd <= cursorState.CompletedThrough {
+			break
+		}
+
+		window := gmailScanWindow{
+			StartEpoch:          cursorState.CompletedThrough,
+			EndEpoch:            windowEnd,
+			PriorBoundaryHashes: cursorState.BoundaryHashes,
+		}
+		chunks := buildWindowORChunks(addresses, window.StartEpoch, window.EndEpoch)
+
+		scanned, err := p.scanWindowChunks(ctx, fetcher, chunks, accountID, knownMap, meSet, window, fetchedMessages)
+		if err != nil {
+			// Hard failure: abort the sweep, return the stored cursor unchanged
+			// so no unproven window is skipped on the next tick.
+			return p.failResult(priorCursor), fmt.Errorf("scan window: %w", err)
+		}
+
+		result.ItemsProcessed += scanned.Processed
+		result.ItemsMatched += scanned.Matched
+		cursorState.CompletedThrough = windowEnd
+		cursorState.BoundaryHashes = hashesToSet(scanned.BoundaryHashes)
+		windowsScanned++
 	}
 
-	result := &sync.SyncResult{
-		ItemsProcessed: processed,
-		ItemsMatched:   matched,
+	if windowsScanned == 0 {
+		result.NewCursor = priorCursor
+	} else {
+		result.NewCursor = encodeGmailCursor(cursorState)
 	}
-	result.NewCursor = computeNewCursor(fetchedAny, maxInternalDateSecs, priorCursorSecs, priorCursor, afterEpoch)
 
 	logger.Info().
 		Str("source", GmailSourceName).
 		Str("account", accountID).
 		Int("processed", result.ItemsProcessed).
 		Int("matched", result.ItemsMatched).
-		Str("cursor", result.NewCursor).
+		Int("windows_scanned", windowsScanned).
+		Int64("completed_through", cursorState.CompletedThrough).
+		Int("boundary_count", len(cursorState.BoundaryHashes)).
 		Msg("Gmail sync completed")
 
 	return result, nil
 }
 
-// scanChunks runs the fetch → per-call `seen` cross-chunk dedup → GetMessage →
-// processMessage → persistRow inner loop for one account against the given
-// chunk queries. It owns NEITHER cursor math NOR external_sync_state NOR
-// failResult — it returns the RAW error to the caller, which applies its own
-// failure semantics (Sync wraps it with failResult + cursor; ScanIdentifier
-// returns it directly).
+type gmailCursorState struct {
+	CompletedThrough int64
+	BoundaryHashes   map[string]struct{}
+}
+
+type gmailCursorJSON struct {
+	Version          int      `json:"v"`
+	CompletedThrough int64    `json:"completed_through"`
+	BoundaryHashes   []string `json:"boundary_hashes"`
+}
+
+type gmailScanWindow struct {
+	StartEpoch          int64
+	EndEpoch            int64
+	PriorBoundaryHashes map[string]struct{}
+}
+
+type gmailWindowScanResult struct {
+	Processed      int
+	Matched        int
+	BoundaryHashes []string
+}
+
+// scanWindowChunks runs one closed cursor window. Gmail's search operators are
+// intentionally broad; each fetched message is filtered by internalDate seconds
+// before processing so coarse search-boundary behavior cannot skip mail inside
+// the proven window.
+func (p *GmailSyncProvider) scanWindowChunks(
+	ctx context.Context,
+	fetcher gmailFetcher,
+	chunks []string,
+	accountID string,
+	knownMap map[string][]uuid.UUID,
+	meSet map[string]struct{},
+	window gmailScanWindow,
+	fetchedMessages map[string]*gmail.Message,
+) (gmailWindowScanResult, error) {
+	var result gmailWindowScanResult
+	seen := make(map[string]struct{})
+	boundaryHashes := make(map[string]struct{})
+	if fetchedMessages == nil {
+		fetchedMessages = make(map[string]*gmail.Message)
+	}
+
+	for _, query := range chunks {
+		pageToken := ""
+		for {
+			refs, next, listErr := fetcher.ListMessageIDs(ctx, query, pageToken)
+			if listErr != nil {
+				return result, fmt.Errorf("list message ids: %w", listErr)
+			}
+			for _, ref := range refs {
+				idHash := hashGmailMessageID(ref.ID)
+				if _, dup := seen[idHash]; dup {
+					continue
+				}
+				seen[idHash] = struct{}{}
+
+				if _, replay := window.PriorBoundaryHashes[idHash]; replay {
+					continue
+				}
+
+				msg, fetched := fetchedMessages[idHash]
+				if !fetched {
+					var getErr error
+					msg, getErr = fetcher.GetMessage(ctx, ref.ID)
+					if getErr != nil {
+						return result, fmt.Errorf("get message %s: %w", idHash, getErr)
+					}
+					fetchedMessages[idHash] = msg
+				}
+
+				msgEpoch := msg.InternalDate / 1000
+				if msgEpoch < window.StartEpoch || msgEpoch > window.EndEpoch {
+					continue
+				}
+				if msgEpoch == window.EndEpoch {
+					boundaryHashes[idHash] = struct{}{}
+				}
+
+				rows, procErr := p.processMessage(ctx, msg, accountID, knownMap, meSet)
+				if procErr != nil {
+					return result, fmt.Errorf("process message %s: %w", idHash, procErr)
+				}
+				result.Processed++
+
+				for _, row := range rows {
+					if perr := p.persistRow(ctx, row); perr != nil {
+						return result, fmt.Errorf("persist row for message %s: %w", idHash, perr)
+					}
+					result.Matched++
+				}
+			}
+			pageToken = next
+			if pageToken == "" {
+				break
+			}
+		}
+	}
+
+	result.BoundaryHashes = setToSortedHashes(boundaryHashes)
+	return result, nil
+}
+
+// scanChunks runs ScanIdentifier's fetch → per-call `seen` cross-chunk dedup →
+// GetMessage → processMessage → persistRow inner loop for one account against
+// the given chunk queries. It does not read or write steady-state cursors.
 //
 // The `seen` set is created fresh INSIDE this call — a per-account, per-sweep
-// invariant (spec §3.1). Callers MUST NOT hoist it: a `seen` shared across
+// invariant. Callers MUST NOT hoist it: a `seen` shared across
 // accounts would skip the same Message-ID in account B and defeat the
 // cross-account provenance merge.
 func (p *GmailSyncProvider) scanChunks(
@@ -391,43 +540,36 @@ func (p *GmailSyncProvider) scanChunks(
 	accountID string,
 	knownMap map[string][]uuid.UUID,
 	meSet map[string]struct{},
-) (processed, matched int, maxInternalDateSecs int64, fetchedAny bool, err error) {
+) (processed, matched int, err error) {
 	seen := make(map[string]struct{})
 	for _, query := range chunks {
 		pageToken := ""
 		for {
 			refs, next, listErr := fetcher.ListMessageIDs(ctx, query, pageToken)
 			if listErr != nil {
-				return processed, matched, maxInternalDateSecs, fetchedAny, fmt.Errorf("list message ids: %w", listErr)
+				return processed, matched, fmt.Errorf("list message ids: %w", listErr)
 			}
 			for _, ref := range refs {
 				if _, dup := seen[ref.ID]; dup {
 					continue // cross-chunk dedup: body already fetched this sweep
 				}
 				seen[ref.ID] = struct{}{}
-				fetchedAny = true
 
 				msg, getErr := fetcher.GetMessage(ctx, ref.ID)
 				if getErr != nil {
 					// ref.ID is a per-mailbox Gmail message id (third-party);
 					// hash it so the error in River logs carries no raw id.
-					return processed, matched, maxInternalDateSecs, fetchedAny, fmt.Errorf("get message %s: %w", hashIdentifier(ref.ID), getErr)
+					return processed, matched, fmt.Errorf("get message %s: %w", hashGmailMessageID(ref.ID), getErr)
 				}
 				rows, procErr := p.processMessage(ctx, msg, accountID, knownMap, meSet)
 				if procErr != nil {
-					return processed, matched, maxInternalDateSecs, fetchedAny, fmt.Errorf("process message %s: %w", hashIdentifier(ref.ID), procErr)
+					return processed, matched, fmt.Errorf("process message %s: %w", hashGmailMessageID(ref.ID), procErr)
 				}
 				processed++
 
-				// Processed (even if zero qualifying rows) contributes its
-				// internalDate to the cursor advance.
-				if secs := msg.InternalDate / 1000; secs > maxInternalDateSecs {
-					maxInternalDateSecs = secs
-				}
-
 				for _, row := range rows {
 					if perr := p.persistRow(ctx, row); perr != nil {
-						return processed, matched, maxInternalDateSecs, fetchedAny, fmt.Errorf("persist row for message %s: %w", hashIdentifier(ref.ID), perr)
+						return processed, matched, fmt.Errorf("persist row for message %s: %w", hashGmailMessageID(ref.ID), perr)
 					}
 					matched++
 				}
@@ -438,7 +580,7 @@ func (p *GmailSyncProvider) scanChunks(
 			}
 		}
 	}
-	return processed, matched, maxInternalDateSecs, fetchedAny, nil
+	return processed, matched, nil
 }
 
 // ScanIdentifier runs a one-shot, identifier-scoped historical Gmail scan for a
@@ -473,7 +615,7 @@ func (p *GmailSyncProvider) ScanIdentifier(
 	}
 
 	// scanChunks creates its own per-account `seen` set; no cursor math here.
-	_, matched, _, _, err = p.scanChunks(ctx, fetcher, chunks, accountID, knownMap, meSet)
+	_, matched, err = p.scanChunks(ctx, fetcher, chunks, accountID, knownMap, meSet)
 	if err != nil {
 		return matched, fmt.Errorf("scan identifier: %w", err)
 	}
@@ -625,53 +767,71 @@ func (p *GmailSyncProvider) persistRow(ctx context.Context, row qualifiedRow) (e
 	return nil
 }
 
-// resolveAfterFloor derives the after:<epoch> floor and the prior cursor in
-// epoch seconds. On an empty/unparseable cursor (onboarding) the floor is
-// backfill_since (default 2026-01-01), and priorCursorSecs is 0. On a numeric
-// cursor the floor is that value and priorCursorSecs mirrors it.
-func resolveAfterFloor(cursor string, metadata map[string]any) (priorCursorSecs, afterEpoch int64) {
-	if secs, err := strconv.ParseInt(strings.TrimSpace(cursor), 10, 64); err == nil && secs > 0 {
-		return secs, secs
+// parseGmailCursor accepts the legacy numeric cursor and the v2 JSON cursor.
+// Empty or invalid cursors fall back to the configured backfill floor.
+func parseGmailCursor(cursor string, metadata map[string]any) gmailCursorState {
+	cursor = strings.TrimSpace(cursor)
+	if cursor == "" {
+		return gmailCursorState{CompletedThrough: backfillSinceEpoch(metadata), BoundaryHashes: map[string]struct{}{}}
 	}
-	return 0, backfillSinceEpoch(metadata)
-}
 
-// backfillSinceEpoch reads metadata["backfill_since"] (a YYYY-MM-DD string,
-// default 2026-01-01) and converts it to epoch seconds in UTC.
-func backfillSinceEpoch(metadata map[string]any) int64 {
-	since := gmailDefaultBackfillSince
-	if metadata != nil {
-		if v, ok := metadata["backfill_since"].(string); ok && strings.TrimSpace(v) != "" {
-			since = strings.TrimSpace(v)
+	if secs, err := strconv.ParseInt(cursor, 10, 64); err == nil && secs > 0 {
+		return gmailCursorState{CompletedThrough: secs, BoundaryHashes: map[string]struct{}{}}
+	}
+
+	var encoded gmailCursorJSON
+	if err := json.Unmarshal([]byte(cursor), &encoded); err == nil &&
+		encoded.Version == 2 &&
+		encoded.CompletedThrough > 0 {
+		return gmailCursorState{
+			CompletedThrough: encoded.CompletedThrough,
+			BoundaryHashes:   hashesToSet(encoded.BoundaryHashes),
 		}
 	}
-	t, err := time.Parse("2006-01-02", since)
+
+	return gmailCursorState{CompletedThrough: backfillSinceEpoch(metadata), BoundaryHashes: map[string]struct{}{}}
+}
+
+func encodeGmailCursor(state gmailCursorState) string {
+	encoded := gmailCursorJSON{
+		Version:          2,
+		CompletedThrough: state.CompletedThrough,
+		BoundaryHashes:   setToSortedHashes(state.BoundaryHashes),
+	}
+	b, err := json.Marshal(encoded)
 	if err != nil {
-		t, _ = time.Parse("2006-01-02", gmailDefaultBackfillSince)
+		return strconv.FormatInt(state.CompletedThrough, 10)
 	}
-	return t.Unix()
+	return string(b)
 }
 
-// computeNewCursor implements the cursor-write contract. It NEVER returns
-// an empty string (an empty NewCursor would NULL-clear the stored cursor and
-// trigger a full re-backfill):
-//   - ≥1 message fetched: advance to max(maxInternalDateSecs, priorCursorSecs),
-//     monotonic so an out-of-order older message can't pull the floor back.
-//   - zero messages fetched: re-write the prior cursor verbatim (idempotent
-//     no-advance); on an empty prior cursor, write the backfill_since epoch so
-//     the next sweep doesn't re-scan from the dawn of time.
-func computeNewCursor(fetchedAny bool, maxInternalDateSecs, priorCursorSecs int64, priorCursor string, afterEpoch int64) string {
-	if fetchedAny {
-		advanced := maxInternalDateSecs
-		if priorCursorSecs > advanced {
-			advanced = priorCursorSecs
+func hashesToSet(hashes []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(hashes))
+	for _, h := range hashes {
+		h = strings.TrimSpace(h)
+		if h == "" {
+			continue
 		}
-		return strconv.FormatInt(advanced, 10)
+		out[h] = struct{}{}
 	}
-	if strings.TrimSpace(priorCursor) != "" {
-		return priorCursor
+	return out
+}
+
+func setToSortedHashes(set map[string]struct{}) []string {
+	if len(set) == 0 {
+		return []string{}
 	}
-	return strconv.FormatInt(afterEpoch, 10)
+	out := make([]string, 0, len(set))
+	for h := range set {
+		out = append(out, h)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// backfillSinceEpoch reads the shared email backfill floor from sync metadata.
+func backfillSinceEpoch(metadata map[string]any) int64 {
+	return sync.EmailBackfillFloorEpoch(metadata)
 }
 
 // sanitizeAddresses filters the address list to terms safe to embed in a Gmail
@@ -702,13 +862,25 @@ func sanitizeAddresses(addresses []string) []string {
 // participant-dimension coverage invariant). Addresses are sorted for
 // deterministic chunk contents. Returns no chunks for an empty address list.
 func buildORChunks(addresses []string, afterEpoch int64) []string {
+	prefix := fmt.Sprintf("%s after:%d", gmailCategoryFilter, afterEpoch)
+	return buildORChunksWithPrefix(addresses, prefix)
+}
+
+// buildWindowORChunks builds Sync's closed-window queries. The Gmail search
+// bounds are intentionally wider than the proven internalDate window; exact
+// inclusion/exclusion happens after GetMessage using internalDate seconds.
+func buildWindowORChunks(addresses []string, startEpoch, endEpoch int64) []string {
+	queryAfter, queryBefore := gmailSearchQueryBounds(startEpoch, endEpoch)
+	prefix := fmt.Sprintf("%s after:%d before:%d", gmailCategoryFilter, queryAfter, queryBefore)
+	return buildORChunksWithPrefix(addresses, prefix)
+}
+
+func buildORChunksWithPrefix(addresses []string, prefix string) []string {
 	safe := sanitizeAddresses(addresses)
 	if len(safe) == 0 {
 		return nil
 	}
 	sort.Strings(safe)
-
-	prefix := fmt.Sprintf("%s after:%d", gmailCategoryFilter, afterEpoch)
 
 	var chunks []string
 	var groups []string
@@ -730,6 +902,15 @@ func buildORChunks(addresses []string, afterEpoch int64) []string {
 	}
 	flush()
 	return chunks
+}
+
+func gmailSearchQueryBounds(startEpoch, endEpoch int64) (afterEpoch, beforeEpoch int64) {
+	afterEpoch = time.Unix(startEpoch, 0).UTC().Add(-gmailSearchBoundaryOverlap).Unix()
+	if afterEpoch < 0 {
+		afterEpoch = 0
+	}
+	beforeEpoch = time.Unix(endEpoch, 0).UTC().Add(gmailSearchBoundaryOverlap).Unix()
+	return afterEpoch, beforeEpoch
 }
 
 // encodedLen returns the URL-encoded byte length of a query — the dimension the
@@ -1189,6 +1370,18 @@ func hashIdentifier(v string) string {
 		return ""
 	}
 	sum := sha256.Sum256([]byte(strings.ToLower(v)))
+	return "sha256:" + hex.EncodeToString(sum[:])[:12]
+}
+
+// hashGmailMessageID hashes a per-mailbox Gmail message id as an exact opaque
+// identifier. Unlike email-address hashing, it is case-sensitive because the id
+// itself is the identity key used by boundary replay suppression.
+func hashGmailMessageID(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(v))
 	return "sha256:" + hex.EncodeToString(sum[:])[:12]
 }
 

--- a/backend/internal/google/gmail_test.go
+++ b/backend/internal/google/gmail_test.go
@@ -776,38 +776,148 @@ func TestComputeLocalDay_ReadsGlobalTimeLocal(t *testing.T) {
 
 // --- cursor helpers ---
 
-func TestComputeNewCursor_FetchedAdvancesMonotonic(t *testing.T) {
-	// max(maxInternalDate, prior) — never below prior.
-	require.Equal(t, "200", computeNewCursor(true, 200, 100, "100", 50))
-	require.Equal(t, "100", computeNewCursor(true, 80, 100, "100", 50), "out-of-order older message must not pull floor back")
+func TestParseGmailCursor_NumericCursor(t *testing.T) {
+	got := parseGmailCursor("1700000000", nil)
+	require.Equal(t, int64(1700000000), got.CompletedThrough)
+	require.Empty(t, got.BoundaryHashes)
 }
 
-func TestComputeNewCursor_ZeroFetched_PreservesPriorCursor(t *testing.T) {
-	require.Equal(t, "12345", computeNewCursor(false, 0, 12345, "12345", 50))
-}
-
-func TestComputeNewCursor_ZeroFetched_EmptyPrior_WritesBackfillEpoch(t *testing.T) {
-	require.Equal(t, "1735689600", computeNewCursor(false, 0, 0, "", 1735689600))
-}
-
-func TestResolveAfterFloor_NumericCursor(t *testing.T) {
-	prior, after := resolveAfterFloor("1700000000", nil)
-	require.Equal(t, int64(1700000000), prior)
-	require.Equal(t, int64(1700000000), after)
-}
-
-func TestResolveAfterFloor_EmptyCursor_UsesBackfillSince(t *testing.T) {
+func TestParseGmailCursor_EmptyCursor_UsesBackfillSince(t *testing.T) {
 	expected := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC).Unix()
-	prior, after := resolveAfterFloor("", nil)
-	require.Equal(t, int64(0), prior)
-	require.Equal(t, expected, after)
+	got := parseGmailCursor("", nil)
+	require.Equal(t, expected, got.CompletedThrough)
+	require.Empty(t, got.BoundaryHashes)
 }
 
-func TestResolveAfterFloor_EmptyCursor_MetadataOverride(t *testing.T) {
+func TestParseGmailCursor_EmptyCursor_MetadataOverride(t *testing.T) {
 	expected := time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC).Unix()
-	prior, after := resolveAfterFloor("", map[string]any{"backfill_since": "2026-03-15"})
-	require.Equal(t, int64(0), prior)
-	require.Equal(t, expected, after)
+	got := parseGmailCursor("", map[string]any{"backfill_since": "2026-03-15"})
+	require.Equal(t, expected, got.CompletedThrough)
+	require.Empty(t, got.BoundaryHashes)
+}
+
+func TestParseGmailCursor_JSONCursor(t *testing.T) {
+	got := parseGmailCursor(`{"v":2,"completed_through":1700000000,"boundary_hashes":["h2","h1","h1"]}`, nil)
+	require.Equal(t, int64(1700000000), got.CompletedThrough)
+	require.Contains(t, got.BoundaryHashes, "h1")
+	require.Contains(t, got.BoundaryHashes, "h2")
+	require.Len(t, got.BoundaryHashes, 2)
+}
+
+func TestEncodeGmailCursor_SortsBoundaryHashesAndUsesArray(t *testing.T) {
+	encoded := encodeGmailCursor(gmailCursorState{
+		CompletedThrough: 1700000000,
+		BoundaryHashes:   map[string]struct{}{"h2": {}, "h1": {}},
+	})
+	require.JSONEq(t, `{"v":2,"completed_through":1700000000,"boundary_hashes":["h1","h2"]}`, encoded)
+
+	encoded = encodeGmailCursor(gmailCursorState{CompletedThrough: 1700000000})
+	require.JSONEq(t, `{"v":2,"completed_through":1700000000,"boundary_hashes":[]}`, encoded)
+}
+
+func TestBuildWindowORChunks_AddsBroadAfterBeforeBounds(t *testing.T) {
+	start := time.Date(2026, 3, 10, 12, 0, 0, 0, time.UTC).Unix()
+	end := time.Date(2026, 3, 17, 12, 0, 0, 0, time.UTC).Unix()
+	chunks := buildWindowORChunks([]string{"b@example.com", "a@example.com"}, start, end)
+	require.Len(t, chunks, 1)
+	q := chunks[0]
+	queryAfter, queryBefore := gmailSearchQueryBounds(start, end)
+	require.True(t, strings.HasPrefix(q, fmt.Sprintf("%s after:%d before:%d (", gmailCategoryFilter, queryAfter, queryBefore)), "got %q", q)
+	require.Less(t, strings.Index(q, "a@example.com"), strings.Index(q, "b@example.com"))
+	require.LessOrEqual(t, len(url.QueryEscape(q)), gmailChunkByteCap)
+}
+
+func TestScanWindowChunks_FiltersByInternalDateAndStoresBoundaryHashes(t *testing.T) {
+	p := newProviderForResolution()
+	f := newFakeFetcher()
+	start := int64(1000)
+	end := int64(1100)
+	query := "q"
+	f.listPages[query] = [][]gmailMessageRef{
+		{{ID: "older"}, {ID: "inside"}},
+		{{ID: "boundary"}, {ID: "future"}},
+	}
+	f.messages["older"] = &gmail.Message{Id: "older", InternalDate: (start - 1) * 1000}
+	f.messages["inside"] = &gmail.Message{Id: "inside", InternalDate: (start + 10) * 1000}
+	f.messages["boundary"] = &gmail.Message{Id: "boundary", InternalDate: end * 1000}
+	f.messages["future"] = &gmail.Message{Id: "future", InternalDate: (end + 1) * 1000}
+
+	res, err := p.scanWindowChunks(context.Background(), f, []string{query}, "account@example.com", nil, nil, gmailScanWindow{
+		StartEpoch:          start,
+		EndEpoch:            end,
+		PriorBoundaryHashes: map[string]struct{}{},
+	}, map[string]*gmail.Message{})
+	require.NoError(t, err)
+	require.Equal(t, 2, res.Processed)
+	require.Equal(t, 0, res.Matched)
+	require.Equal(t, []string{hashGmailMessageID("boundary")}, res.BoundaryHashes)
+	require.Equal(t, 1, f.getCalls["older"], "out-of-window messages still need internalDate inspection")
+	require.Equal(t, 1, f.getCalls["future"])
+}
+
+func TestScanWindowChunks_PriorBoundarySkipsReplayAllowsNewSameSecond(t *testing.T) {
+	p := newProviderForResolution()
+	f := newFakeFetcher()
+	start := int64(1000)
+	end := int64(1100)
+	query := "q"
+	f.listPages[query] = [][]gmailMessageRef{{{ID: "replayed"}, {ID: "late-indexed"}}}
+	f.messages["replayed"] = &gmail.Message{Id: "replayed", InternalDate: start * 1000}
+	f.messages["late-indexed"] = &gmail.Message{Id: "late-indexed", InternalDate: start*1000 + 999}
+
+	res, err := p.scanWindowChunks(context.Background(), f, []string{query}, "account@example.com", nil, nil, gmailScanWindow{
+		StartEpoch: start,
+		EndEpoch:   end,
+		PriorBoundaryHashes: map[string]struct{}{
+			hashGmailMessageID("replayed"): {},
+		},
+	}, map[string]*gmail.Message{})
+	require.NoError(t, err)
+	require.Equal(t, 1, res.Processed)
+	require.Equal(t, 0, f.getCalls["replayed"], "known boundary id is skipped by identity hash before refetch")
+	require.Equal(t, 1, f.getCalls["late-indexed"], "new id at the same boundary second is still eligible")
+}
+
+func TestScanWindowChunks_ReusesFetchedMessageAcrossOverlappingWindows(t *testing.T) {
+	p := newProviderForResolution()
+	f := newFakeFetcher()
+	firstQuery := "w1"
+	secondQuery := "w2"
+	f.listPages[firstQuery] = [][]gmailMessageRef{{{ID: "overlap"}}}
+	f.listPages[secondQuery] = [][]gmailMessageRef{{{ID: "overlap"}}}
+	f.messages["overlap"] = &gmail.Message{Id: "overlap", InternalDate: 1150 * 1000}
+
+	fetchedMessages := map[string]*gmail.Message{}
+	first, err := p.scanWindowChunks(context.Background(), f, []string{firstQuery}, "account@example.com", nil, nil, gmailScanWindow{
+		StartEpoch:          1000,
+		EndEpoch:            1100,
+		PriorBoundaryHashes: map[string]struct{}{},
+	}, fetchedMessages)
+	require.NoError(t, err)
+	require.Equal(t, 0, first.Processed, "neighboring overlap fetch is outside the exact first window")
+	require.Equal(t, 1, f.getCalls["overlap"])
+
+	second, err := p.scanWindowChunks(context.Background(), f, []string{secondQuery}, "account@example.com", nil, nil, gmailScanWindow{
+		StartEpoch:          1100,
+		EndEpoch:            1200,
+		PriorBoundaryHashes: map[string]struct{}{},
+	}, fetchedMessages)
+	require.NoError(t, err)
+	require.Equal(t, 1, second.Processed, "cached body is still processed in its exact window")
+	require.Equal(t, 1, f.getCalls["overlap"], "overlap body is fetched once across the run")
+}
+
+func TestScanWindowChunks_ListFailureReturnsError(t *testing.T) {
+	p := newProviderForResolution()
+	f := newFakeFetcher()
+	f.listErr = fmt.Errorf("forced list error")
+
+	_, err := p.scanWindowChunks(context.Background(), f, []string{"q"}, "account@example.com", nil, nil, gmailScanWindow{
+		StartEpoch:          1000,
+		EndEpoch:            1100,
+		PriorBoundaryHashes: map[string]struct{}{},
+	}, map[string]*gmail.Message{})
+	require.Error(t, err)
 }
 
 // --- cross-chunk seen dedup ---

--- a/backend/internal/repository/sync.go
+++ b/backend/internal/repository/sync.go
@@ -311,6 +311,21 @@ func (r *SyncRepository) ListEnabledSyncStates(ctx context.Context) ([]SyncState
 	return states, nil
 }
 
+// ListEnabledSyncStatesBySource retrieves enabled sync states for one source.
+func (r *SyncRepository) ListEnabledSyncStatesBySource(ctx context.Context, source string) ([]SyncState, error) {
+	dbStates, err := r.queries.ListEnabledSyncStatesBySource(ctx, source)
+	if err != nil {
+		return nil, err
+	}
+
+	states := make([]SyncState, len(dbStates))
+	for i, dbState := range dbStates {
+		states[i] = convertDbSyncState(dbState)
+	}
+
+	return states, nil
+}
+
 // ListDueSyncStates retrieves sync states that are due for syncing
 func (r *SyncRepository) ListDueSyncStates(ctx context.Context, now time.Time) ([]SyncState, error) {
 	dbStates, err := r.queries.ListDueSyncStates(ctx, pgtype.Timestamptz{Time: now, Valid: true})
@@ -389,6 +404,27 @@ func (r *SyncRepository) UpdateSyncStateSuccess(ctx context.Context, id uuid.UUI
 		ID:         uuidToPgUUID(id),
 		NextSyncAt: pgtype.Timestamptz{Time: nextSyncAt, Valid: true},
 		SyncCursor: stringToPgText(cursor),
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, db.ErrNotFound
+		}
+		return nil, err
+	}
+
+	state := convertDbSyncState(dbState)
+	return &state, nil
+}
+
+// ResetSyncStateBackfillCursor rewinds a sync state's cursor and marks it due.
+func (r *SyncRepository) ResetSyncStateBackfillCursor(ctx context.Context, id uuid.UUID, cursor string, nextSyncAt time.Time) (*SyncState, error) {
+	dbState, err := r.queries.ResetSyncStateBackfillCursor(ctx, db.ResetSyncStateBackfillCursorParams{
+		ID:         uuidToPgUUID(id),
+		SyncCursor: pgtype.Text{String: cursor, Valid: true},
+		NextSyncAt: pgtype.Timestamptz{
+			Time:  nextSyncAt,
+			Valid: true,
+		},
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/backend/internal/service/email_backfill_reset.go
+++ b/backend/internal/service/email_backfill_reset.go
@@ -1,0 +1,55 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/repository"
+	syncpkg "personal-crm/backend/internal/sync"
+)
+
+// EmailBackfillCursorResetResult is the counts-only outcome for the operator
+// reset. It intentionally carries no account identifiers or cursor values.
+type EmailBackfillCursorResetResult struct {
+	Scanned int
+	Reset   int
+}
+
+// EmailBackfillCursorResetService rewinds enabled Gmail sync cursors so the
+// corrected provider can re-scan from each account's backfill floor.
+type EmailBackfillCursorResetService struct {
+	syncRepo *repository.SyncRepository
+}
+
+func NewEmailBackfillCursorResetService(syncRepo *repository.SyncRepository) *EmailBackfillCursorResetService {
+	return &EmailBackfillCursorResetService{syncRepo: syncRepo}
+}
+
+func (s *EmailBackfillCursorResetService) ResetGmailBackfillCursors(ctx context.Context) (EmailBackfillCursorResetResult, error) {
+	if s.syncRepo == nil {
+		return EmailBackfillCursorResetResult{}, fmt.Errorf("sync repository is required")
+	}
+
+	states, err := s.syncRepo.ListEnabledSyncStatesBySource(ctx, emailSyncSource)
+	if err != nil {
+		return EmailBackfillCursorResetResult{}, fmt.Errorf("list enabled email sync states: %w", err)
+	}
+
+	now := accelerated.GetCurrentTime()
+	result := EmailBackfillCursorResetResult{Scanned: len(states)}
+	for _, st := range states {
+		cursor := strconv.FormatInt(emailBackfillFloorEpoch(st.Metadata), 10)
+		if _, err := s.syncRepo.ResetSyncStateBackfillCursor(ctx, st.ID, cursor, now); err != nil {
+			return result, fmt.Errorf("reset email sync cursor: %w", err)
+		}
+		result.Reset++
+	}
+
+	return result, nil
+}
+
+func emailBackfillFloorEpoch(metadata map[string]any) int64 {
+	return syncpkg.EmailBackfillFloorEpoch(metadata)
+}

--- a/backend/internal/service/email_reconcile.go
+++ b/backend/internal/service/email_reconcile.go
@@ -8,6 +8,7 @@ import (
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/logger"
 	"personal-crm/backend/internal/repository"
+	syncpkg "personal-crm/backend/internal/sync"
 )
 
 const (
@@ -17,13 +18,6 @@ const (
 	// literal so the service layer does not import the google package (which
 	// would invert the dependency direction).
 	emailSyncSource = "email"
-
-	// emailBackfillSince is the onboarding floor written into a newly-created
-	// email sync state's metadata. It must match the value the Gmail provider
-	// reads from metadata["backfill_since"] (google.gmailDefaultBackfillSince);
-	// even an absent/empty value defaults to the same date inside the provider,
-	// so this is belt-and-suspenders alignment, not a hard coupling.
-	emailBackfillSince = "2026-01-01"
 
 	// gmailReadonlyScope is the OAuth scope a connected Google account needs for
 	// the email sweep to authenticate against Gmail. Defined as a literal so the
@@ -59,7 +53,7 @@ func (s *SyncService) SetEmailAccountLister(lister GoogleAccountLister) {
 //   - create-if-absent ONLY. For each account it probes
 //     GetSyncStateBySource("email", &accountID); on db.ErrNotFound it creates a
 //     per-account state (enabled=true, strategy=contact_driven,
-//     metadata={"backfill_since": emailBackfillSince}, empty cursor, NULL
+//     metadata={"backfill_since": sync.EmailBackfillSinceDefault}, empty cursor, NULL
 //     next_sync_at → immediately due on the next tick).
 //   - a found state is left COMPLETELY untouched: no re-enable, no metadata
 //     rewrite, no cursor reset. Re-running must never duplicate states, reset
@@ -114,7 +108,7 @@ func (s *SyncService) ReconcileEmailSyncStates(ctx context.Context) error {
 			AccountID: &acctID,
 			Enabled:   true,
 			Strategy:  repository.SyncStrategyContactDriven,
-			Metadata:  map[string]any{"backfill_since": emailBackfillSince},
+			Metadata:  map[string]any{"backfill_since": syncpkg.EmailBackfillSinceDefault},
 			// NextSyncAt left nil → NULL → immediately due on the next tick.
 		}); createErr != nil {
 			if isUniqueViolation(createErr) {

--- a/backend/internal/sync/email_backfill.go
+++ b/backend/internal/sync/email_backfill.go
@@ -1,0 +1,31 @@
+package sync
+
+import (
+	"strings"
+	"time"
+)
+
+const (
+	// EmailBackfillSinceDefault is the onboarding floor written into new email
+	// sync state metadata and used when metadata has no valid override.
+	EmailBackfillSinceDefault = "2026-01-01"
+
+	emailBackfillSinceMetadataKey = "backfill_since"
+	emailBackfillDateLayout       = "2006-01-02"
+)
+
+// EmailBackfillFloorEpoch reads metadata["backfill_since"] as YYYY-MM-DD and
+// returns its UTC epoch seconds, falling back to EmailBackfillSinceDefault.
+func EmailBackfillFloorEpoch(metadata map[string]any) int64 {
+	since := EmailBackfillSinceDefault
+	if metadata != nil {
+		if v, ok := metadata[emailBackfillSinceMetadataKey].(string); ok && strings.TrimSpace(v) != "" {
+			since = strings.TrimSpace(v)
+		}
+	}
+	t, err := time.Parse(emailBackfillDateLayout, since)
+	if err != nil {
+		t, _ = time.Parse(emailBackfillDateLayout, EmailBackfillSinceDefault)
+	}
+	return t.Unix()
+}

--- a/backend/tests/gmail_enablement_reconcile_test.go
+++ b/backend/tests/gmail_enablement_reconcile_test.go
@@ -20,7 +20,9 @@ package tests
 import (
 	"context"
 	"os"
+	"strconv"
 	"testing"
+	"time"
 
 	"personal-crm/backend/internal/accelerated"
 	"personal-crm/backend/internal/db"
@@ -186,6 +188,101 @@ func TestReconcileEmail_IdempotentRerun_NoDuplicatesNoReset(t *testing.T) {
 
 	// Assert exactly one row for this account across all sync states.
 	require.Equal(t, 1, e.countEmailStatesForAccount(t, acct))
+}
+
+// --- operator reset: enabled email cursors only -----------------------------
+
+func TestResetGmailBackfillCursors_ResetsOnlyEnabledEmailStates(t *testing.T) {
+	e := newReconcileEnv(t)
+	enabledAcct := uniqueAccount("reset-enabled")
+	defaultAcct := uniqueAccount("reset-default")
+	disabledAcct := uniqueAccount("reset-disabled")
+	otherAcct := uniqueAccount("reset-other")
+	for _, acct := range []string{enabledAcct, defaultAcct, disabledAcct, otherAcct} {
+		e.cleanupAccount(t, acct)
+	}
+
+	enabled, err := e.syncRepo.CreateSyncState(e.ctx, repository.CreateSyncStateRequest{
+		Source:    "email",
+		AccountID: &enabledAcct,
+		Enabled:   true,
+		Strategy:  repository.SyncStrategyContactDriven,
+		Metadata:  map[string]any{"backfill_since": "2026-03-15", "extra": "keep-me"},
+	})
+	require.NoError(t, err)
+	oldCursor := "9999999999"
+	_, err = e.syncRepo.UpdateSyncStateSuccess(e.ctx, enabled.ID, accelerated.GetCurrentTime().Add(24*time.Hour), &oldCursor)
+	require.NoError(t, err)
+	errMsg := "previous failure"
+	_, err = e.syncRepo.UpdateSyncStateStatus(e.ctx, enabled.ID, repository.SyncStatusError, &errMsg)
+	require.NoError(t, err)
+
+	defaultMeta, err := e.syncRepo.CreateSyncState(e.ctx, repository.CreateSyncStateRequest{
+		Source:    "email",
+		AccountID: &defaultAcct,
+		Enabled:   true,
+		Strategy:  repository.SyncStrategyContactDriven,
+	})
+	require.NoError(t, err)
+	_, err = e.syncRepo.UpdateSyncStateSuccess(e.ctx, defaultMeta.ID, accelerated.GetCurrentTime().Add(24*time.Hour), &oldCursor)
+	require.NoError(t, err)
+
+	disabled, err := e.syncRepo.CreateSyncState(e.ctx, repository.CreateSyncStateRequest{
+		Source:    "email",
+		AccountID: &disabledAcct,
+		Enabled:   false,
+		Status:    repository.SyncStatusDisabled,
+		Strategy:  repository.SyncStrategyContactDriven,
+		Metadata:  map[string]any{"backfill_since": "2026-04-01"},
+	})
+	require.NoError(t, err)
+
+	other, err := e.syncRepo.CreateSyncState(e.ctx, repository.CreateSyncStateRequest{
+		Source:    "calendar",
+		AccountID: &otherAcct,
+		Enabled:   true,
+		Strategy:  repository.SyncStrategyFetchAll,
+	})
+	require.NoError(t, err)
+	otherNext := accelerated.GetCurrentTime().Add(48 * time.Hour)
+	_, err = e.syncRepo.UpdateSyncStateSuccess(e.ctx, other.ID, otherNext, &oldCursor)
+	require.NoError(t, err)
+
+	resetSvc := service.NewEmailBackfillCursorResetService(e.syncRepo)
+	before := accelerated.GetCurrentTime()
+	res, err := resetSvc.ResetGmailBackfillCursors(e.ctx)
+	after := accelerated.GetCurrentTime()
+	require.NoError(t, err)
+	require.Equal(t, service.EmailBackfillCursorResetResult{Scanned: 2, Reset: 2}, res)
+
+	enabledAfter := e.getEmailState(t, enabledAcct)
+	require.NotNil(t, enabledAfter.SyncCursor)
+	require.Equal(t, strconv.FormatInt(time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC).Unix(), 10), *enabledAfter.SyncCursor)
+	require.Equal(t, repository.SyncStatusIdle, enabledAfter.Status)
+	require.Nil(t, enabledAfter.ErrorMessage)
+	require.Equal(t, int32(0), enabledAfter.ErrorCount)
+	require.NotNil(t, enabledAfter.NextSyncAt)
+	require.False(t, enabledAfter.NextSyncAt.Before(before))
+	require.False(t, enabledAfter.NextSyncAt.After(after))
+	require.Equal(t, "2026-03-15", enabledAfter.Metadata["backfill_since"])
+	require.Equal(t, "keep-me", enabledAfter.Metadata["extra"])
+
+	defaultAfter := e.getEmailState(t, defaultAcct)
+	require.NotNil(t, defaultAfter.SyncCursor)
+	require.Equal(t, strconv.FormatInt(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC).Unix(), 10), *defaultAfter.SyncCursor)
+
+	disabledAfter, err := e.syncRepo.GetSyncState(e.ctx, disabled.ID)
+	require.NoError(t, err)
+	require.False(t, disabledAfter.Enabled)
+	require.Equal(t, repository.SyncStatusDisabled, disabledAfter.Status)
+	require.Nil(t, disabledAfter.SyncCursor)
+
+	otherAfter, err := e.syncRepo.GetSyncState(e.ctx, other.ID)
+	require.NoError(t, err)
+	require.NotNil(t, otherAfter.SyncCursor)
+	require.Equal(t, oldCursor, *otherAfter.SyncCursor)
+	require.NotNil(t, otherAfter.NextSyncAt)
+	require.WithinDuration(t, otherNext, *otherAfter.NextSyncAt, time.Millisecond)
 }
 
 // --- respects a user-disabled state (never re-enabled) ----------------------

--- a/backend/tests/gmail_golive_integration_test.go
+++ b/backend/tests/gmail_golive_integration_test.go
@@ -111,7 +111,7 @@ func TestGmailGoLive_RegisteredProvider_SchedulerSweep_ProducesInteractionsAndCa
 		_ = syncRepo.DeleteSyncStatesByAccountID(ctx, account)
 	})
 
-	sentAt := localNoonAnchor()
+	sentAt := gmailPastNoonAnchor()
 	inbound := gmailMsg("glv-in", "thr-in", addr, []string{account}, nil, nil, "In", "hi", "<"+inExt+">", sentAt.UnixMilli())
 	outbound := gmailMsg("glv-out", "thr-out", account, []string{addr}, nil, nil, "Out", "yo", "<"+outExt+">", sentAt.Add(time.Hour).UnixMilli())
 	// Message between "me" and an unknown address only — a bystander to the

--- a/backend/tests/gmail_golive_integration_test.go
+++ b/backend/tests/gmail_golive_integration_test.go
@@ -142,6 +142,18 @@ func TestGmailGoLive_RegisteredProvider_SchedulerSweep_ProducesInteractionsAndCa
 	require.True(t, created.Enabled)
 	require.Nil(t, created.SyncCursor, "cursor empty before first sweep")
 
+	// Anchor the backfill floor a few days behind the fixture so one sweep's
+	// catch-up always reaches it, independent of the calendar date the suite
+	// runs on. With the default 2026-01-01 floor, the fixed per-run window cap
+	// would eventually stop covering "yesterday" as wall-clock advances.
+	md := created.Metadata
+	if md == nil {
+		md = map[string]any{}
+	}
+	md["backfill_since"] = sentAt.Add(-72 * time.Hour).Format("2006-01-02")
+	_, err = syncRepo.UpdateSyncStateMetadata(ctx, created.ID, md)
+	require.NoError(t, err)
+
 	// Drive the sweep through the worker entry point: RunAccountSync fetches
 	// fresh state from the registry-backed provider, runs Sync, and writes the
 	// advanced cursor via UpdateSyncStateSuccess.

--- a/backend/tests/gmail_provider_integration_test.go
+++ b/backend/tests/gmail_provider_integration_test.go
@@ -10,8 +10,8 @@
 //   - cursor-overlap idempotency (no duplicate rows / events / provenance growth);
 //   - publish-before-mutate (a failing PublishTx leaves no content row);
 //   - nomsgid fallback persistence;
-//   - cursor edge cases (all-bystander advances; zero-fetched preserves; hard
-//     failure leaves cursor unchanged);
+//   - cursor edge cases (all-bystander and empty windows advance; hard failure
+//     leaves cursor unchanged);
 //   - nil-account guard;
 //   - cross-account set-union provenance merge through the provider/upsert path.
 //
@@ -24,13 +24,16 @@ package tests
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
+	"personal-crm/backend/internal/accelerated"
 	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/events"
@@ -163,6 +166,9 @@ func (s *fakeMessageStore) fetcherFuncs() google.FakeGmailFetcherFuncs {
 			}
 			refs := make([]google.GmailMessageRefForTest, 0, len(s.messages))
 			for _, m := range s.messages {
+				if !fakeMessageMatchesQuery(m, query) {
+					continue
+				}
 				refs = append(refs, google.GmailMessageRefForTest{ID: m.Id, ThreadID: m.ThreadId})
 			}
 			return refs, "", nil
@@ -180,6 +186,28 @@ func (s *fakeMessageStore) fetcherFuncs() google.FakeGmailFetcherFuncs {
 			return nil, fmt.Errorf("message %s not found", id)
 		},
 	}
+}
+
+func fakeMessageMatchesQuery(msg *gmailapi.Message, query string) bool {
+	secs := msg.InternalDate / 1000
+	if after, ok := fakeQueryEpoch(query, "after:"); ok && secs < after {
+		return false
+	}
+	if before, ok := fakeQueryEpoch(query, "before:"); ok && secs > before {
+		return false
+	}
+	return true
+}
+
+func fakeQueryEpoch(query, prefix string) (int64, bool) {
+	for _, part := range strings.Fields(query) {
+		if !strings.HasPrefix(part, prefix) {
+			continue
+		}
+		v, err := strconv.ParseInt(strings.TrimPrefix(part, prefix), 10, 64)
+		return v, err == nil
+	}
+	return 0, false
 }
 
 // inject wires the store as the provider's fetcher + sets the me-set.
@@ -230,11 +258,36 @@ func (failingBus) PublishTx(_ context.Context, _ pgx.Tx, _ *events.Envelope) err
 }
 
 func syncState(accountID, cursor string) *repository.SyncState {
-	st := &repository.SyncState{Source: "email", AccountID: &accountID}
+	st := &repository.SyncState{
+		Source:    "email",
+		AccountID: &accountID,
+		Metadata:  map[string]any{"backfill_since": "2023-11-01"},
+	}
 	if cursor != "" {
 		st.SyncCursor = &cursor
 	}
 	return st
+}
+
+type gmailCursorForTest struct {
+	Version          int      `json:"v"`
+	CompletedThrough int64    `json:"completed_through"`
+	BoundaryHashes   []string `json:"boundary_hashes"`
+}
+
+func decodeGmailCursor(t *testing.T, cursor string) gmailCursorForTest {
+	t.Helper()
+	var decoded gmailCursorForTest
+	require.NoError(t, json.Unmarshal([]byte(cursor), &decoded))
+	require.Equal(t, 2, decoded.Version)
+	return decoded
+}
+
+func expectCursorAtLeast(t *testing.T, cursor string, minEpoch int64) gmailCursorForTest {
+	t.Helper()
+	decoded := decodeGmailCursor(t, cursor)
+	require.GreaterOrEqual(t, decoded.CompletedThrough, minEpoch)
+	return decoded
 }
 
 // --- full sweep → content rows + events ---
@@ -261,7 +314,7 @@ func TestGmailProvider_FullSweep_ContentAndEvents(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 2, result.ItemsProcessed)
 	require.Equal(t, 2, result.ItemsMatched)
-	require.Equal(t, "1700000200", result.NewCursor) // max internalDate (epoch secs)
+	expectCursorAtLeast(t, result.NewCursor, 1700000200)
 
 	aRows, err := e.commsRepo.ListByContact(e.ctx, contactA.ID)
 	require.NoError(t, err)
@@ -453,14 +506,14 @@ func TestGmailProvider_AllBystanderSweepAdvancesCursor(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, result.ItemsProcessed)
 	require.Equal(t, 0, result.ItemsMatched)
-	require.Equal(t, "1700000800", result.NewCursor, "processed-but-not-persisted message still advances the cursor")
+	expectCursorAtLeast(t, result.NewCursor, 1700000800)
 
 	aRows, err := e.commsRepo.ListByContact(e.ctx, contactA.ID)
 	require.NoError(t, err)
 	require.Empty(t, aRows)
 }
 
-func TestGmailProvider_ZeroFetchedPreservesCursor(t *testing.T) {
+func TestGmailProvider_ZeroFetchedAdvancesCompletedWindows(t *testing.T) {
 	e := newGmailProviderEnv(t)
 	suffix := uuid.NewString()[:8]
 	me := "me-" + suffix + "@example.com"
@@ -469,17 +522,103 @@ func TestGmailProvider_ZeroFetchedPreservesCursor(t *testing.T) {
 
 	e.inject(newFakeMessageStore(nil), map[string]struct{}{me: {}})
 
-	// With a prior cursor, the same value is re-written verbatim.
-	result, err := e.provider.Sync(e.ctx, syncState(me, "1699999999"), nil)
+	// Empty but fully scanned windows are proven complete and advance.
+	priorEpoch := int64(1699999999)
+	result, err := e.provider.Sync(e.ctx, syncState(me, fmt.Sprintf("%d", priorEpoch)), nil)
 	require.NoError(t, err)
-	require.Equal(t, "1699999999", result.NewCursor)
+	decoded := decodeGmailCursor(t, result.NewCursor)
+	require.Greater(t, decoded.CompletedThrough, priorEpoch)
 
-	// With an empty prior cursor (onboarding, nothing fetched), the
-	// backfill_since epoch is written (never empty → no NULL-clear).
+	// With an empty prior cursor, the metadata backfill floor is upgraded into
+	// the v2 cursor and advanced through completed empty windows.
 	result, err = e.provider.Sync(e.ctx, syncState(me, ""), nil)
 	require.NoError(t, err)
-	expectedBackfill := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC).Unix()
-	require.Equal(t, fmt.Sprintf("%d", expectedBackfill), result.NewCursor)
+	expectedBackfill := time.Date(2023, 11, 1, 0, 0, 0, 0, time.UTC).Unix()
+	decoded = decodeGmailCursor(t, result.NewCursor)
+	require.Greater(t, decoded.CompletedThrough, expectedBackfill)
+}
+
+func TestGmailProvider_CatchUpScansSuccessiveWindowsInOneRun(t *testing.T) {
+	e := newGmailProviderEnv(t)
+	suffix := uuid.NewString()[:8]
+	me := "me-" + suffix + "@example.com"
+	addrA := "a-" + suffix + "@example.com"
+	contactA := e.newEmailContactWithMethod(t, "Contact A "+suffix, addrA)
+
+	start := accelerated.GetCurrentTime().UTC().Add(-28 * 24 * time.Hour).Truncate(time.Second).Unix()
+	msgEpochs := []int64{
+		start + int64((1 * time.Hour).Seconds()),
+		start + int64((8 * 24 * time.Hour).Seconds()),
+		start + int64((15 * 24 * time.Hour).Seconds()),
+	}
+	var messages []*gmailapi.Message
+	for i, epoch := range msgEpochs {
+		ext := fmt.Sprintf("catchup-%d-%s@example.com", i, suffix)
+		e.cleanupEvents(t, ext)
+		messages = append(messages, gmailMsg(
+			fmt.Sprintf("g-catchup-%d", i),
+			"thr",
+			addrA,
+			[]string{me},
+			nil,
+			nil,
+			"S",
+			"body",
+			"<"+ext+">",
+			epoch*1000,
+		))
+	}
+
+	tooNewExt := "catchup-new-" + suffix + "@example.com"
+	e.cleanupEvents(t, tooNewExt)
+	tooNewEpoch := accelerated.GetCurrentTime().UTC().Add(-1 * time.Minute).Unix()
+	messages = append(messages, gmailMsg("g-catchup-new", "thr", addrA, []string{me}, nil, nil, "S", "body", "<"+tooNewExt+">", tooNewEpoch*1000))
+
+	e.inject(newFakeMessageStore(messages), map[string]struct{}{me: {}})
+
+	beforeSafe := accelerated.GetCurrentTime().UTC().Add(-10 * time.Minute).Unix()
+	result, err := e.provider.Sync(e.ctx, syncState(me, fmt.Sprintf("%d", start)), nil)
+	afterSafe := accelerated.GetCurrentTime().UTC().Add(-10 * time.Minute).Unix()
+	require.NoError(t, err)
+	require.Equal(t, 3, result.ItemsProcessed)
+	require.Equal(t, 3, result.ItemsMatched)
+	cursor := decodeGmailCursor(t, result.NewCursor)
+	require.GreaterOrEqual(t, cursor.CompletedThrough, beforeSafe)
+	require.LessOrEqual(t, cursor.CompletedThrough, afterSafe)
+
+	rows, err := e.commsRepo.ListByContact(e.ctx, contactA.ID)
+	require.NoError(t, err)
+	require.Len(t, rows, 3, "all eligible messages below the final cursor are inserted")
+	for _, row := range rows {
+		require.NotEqual(t, tooNewExt, row.ExternalID, "message inside the safety lag must not be ingested yet")
+	}
+}
+
+func TestGmailProvider_BoundaryOverlapSkipsOnlySeenMessageIDs(t *testing.T) {
+	e := newGmailProviderEnv(t)
+	suffix := uuid.NewString()[:8]
+	me := "me-" + suffix + "@example.com"
+	addrA := "a-" + suffix + "@example.com"
+	contactA := e.newEmailContactWithMethod(t, "Contact A "+suffix, addrA)
+
+	start := accelerated.GetCurrentTime().UTC().Add(-21 * 24 * time.Hour).Truncate(time.Second).Unix()
+	boundaryEpoch := start + int64((7 * 24 * time.Hour).Seconds())
+	ext := "boundary-" + suffix + "@example.com"
+	e.cleanupEvents(t, ext)
+	msg := gmailMsg("g-boundary-"+suffix, "thr", addrA, []string{me}, nil, nil, "S", "body", "<"+ext+">", boundaryEpoch*1000)
+	store := newFakeMessageStore([]*gmailapi.Message{msg})
+	e.inject(store, map[string]struct{}{me: {}})
+
+	result, err := e.provider.Sync(e.ctx, syncState(me, fmt.Sprintf("%d", start)), nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, result.ItemsProcessed)
+	require.Equal(t, 1, result.ItemsMatched)
+	require.Equal(t, 1, store.getCalls[msg.Id], "boundary replay should be skipped by Gmail message id hash")
+
+	rows, err := e.commsRepo.ListByContact(e.ctx, contactA.ID)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, ext, rows[0].ExternalID)
 }
 
 func TestGmailProvider_HardFailureLeavesCursorUnchanged(t *testing.T) {
@@ -508,7 +647,7 @@ func TestGmailProvider_HardFailureLeavesCursorUnchanged(t *testing.T) {
 	delete(store.forcedGetErr, "g-hf")
 	result, err = e.provider.Sync(e.ctx, syncState(me, priorCursor), nil)
 	require.NoError(t, err)
-	require.Equal(t, "1700000900", result.NewCursor)
+	expectCursorAtLeast(t, result.NewCursor, 1700000900)
 }
 
 // --- nil-account guard ---
@@ -570,11 +709,10 @@ func TestGmailProvider_CrossAccountProvenanceMerge(t *testing.T) {
 
 // TestGmailProvider_Onboarding_EmptyCursor_BackfillSince drives the full
 // onboarding seam through Sync end-to-end: a nil SyncCursor + a backfill_since
-// metadata override must (a) floor the scan query at the override epoch, (b)
+// metadata override must (a) start the proven window at the override epoch, (b)
 // persist a qualifying message dated after the floor, (c) advance the cursor to
-// the message's internalDate seconds, and (d) be idempotent on a second sweep
-// with the returned cursor. Complements (does not duplicate) the resolveAfterFloor
-// / computeNewCursor helper unit tests, which exercise the functions in isolation.
+// a completed window, and (d) be idempotent on a second sweep with the returned
+// cursor.
 func TestGmailProvider_Onboarding_EmptyCursor_BackfillSince(t *testing.T) {
 	e := newGmailProviderEnv(t)
 	suffix := uuid.NewString()[:8]
@@ -624,13 +762,14 @@ func TestGmailProvider_Onboarding_EmptyCursor_BackfillSince(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, result.ItemsProcessed)
 	require.Equal(t, 1, result.ItemsMatched)
-	require.Equal(t, fmt.Sprintf("%d", msgEpochSecs), result.NewCursor, "cursor advances to the message internalDate seconds")
+	expectCursorAtLeast(t, result.NewCursor, msgEpochSecs)
 
-	// Query floored at the override epoch, not the default 2026-01-01.
+	// The first query is widened around the override floor; exact inclusion is
+	// enforced with internalDate after fetching.
 	require.NotEmpty(t, capturedQueries)
-	for _, q := range capturedQueries {
-		require.Contains(t, q, fmt.Sprintf("after:%d", overrideEpoch), "scan floors at the backfill_since override")
-	}
+	firstAfter, ok := fakeQueryEpoch(capturedQueries[0], "after:")
+	require.True(t, ok, "first query should include after:")
+	require.Equal(t, overrideEpoch-int64((48*time.Hour)/time.Second), firstAfter)
 
 	// Content row + event persisted.
 	rows, err := e.commsRepo.ListByContact(e.ctx, contactA.ID)

--- a/backend/tests/gmail_rematch_integration_test.go
+++ b/backend/tests/gmail_rematch_integration_test.go
@@ -28,7 +28,7 @@
 // freshly-created contact's rows — never a global state count.
 //
 // Addresses are placeholders; timestamps are accelerated.GetCurrentTime()-safe
-// (the localNoonAnchor helper from the email suite); all assertions go through
+// (the Gmail past-noon helper); all assertions go through
 // repositories (no raw SQL).
 package tests
 
@@ -292,7 +292,7 @@ func TestGmailRematch_NewAddressScan_DerivesInteractions(t *testing.T) {
 	e.cleanupEvents(t, inExt)
 	e.cleanupEvents(t, outExt)
 
-	sentAt := localNoonAnchor()
+	sentAt := gmailPastNoonAnchor()
 	inbound := gmailMsg("g-in", "thr-in", addrA, []string{me}, nil, nil, "In", "hi", "<"+inExt+">", sentAt.UnixMilli())
 	outbound := gmailMsg("g-out", "thr-out", me, []string{addrA}, nil, nil, "Out", "yo", "<"+outExt+">", sentAt.Add(time.Hour).UnixMilli())
 	e.inject(newRecordingMessageStore([]*gmailapi.Message{inbound, outbound}), map[string]struct{}{me: {}})
@@ -338,7 +338,7 @@ func TestGmailRematch_MatchOnly_NoContactCreated(t *testing.T) {
 
 	e.cleanupEvents(t, "mo-"+suffix+"@example.com")
 	// Message between "me" and an UNKNOWN address only (A is not a participant).
-	msg := gmailMsg("g-mo", "thr", unknown, []string{me}, nil, nil, "S", "body", "<mo-"+suffix+"@example.com>", localNoonAnchor().UnixMilli())
+	msg := gmailMsg("g-mo", "thr", unknown, []string{me}, nil, nil, "S", "body", "<mo-"+suffix+"@example.com>", gmailPastNoonAnchor().UnixMilli())
 	e.inject(newRecordingMessageStore([]*gmailapi.Message{msg}), map[string]struct{}{me: {}})
 
 	// Rematch for A's address, but the message has no A participant → no rows.
@@ -368,7 +368,7 @@ func TestGmailRematch_FanOut_SharedAddress(t *testing.T) {
 
 	ext := "fan-" + suffix + "@example.com"
 	e.cleanupEvents(t, ext)
-	msg := gmailMsg("g-fan", "thr", shared, []string{me}, nil, nil, "S", "body", "<"+ext+">", localNoonAnchor().UnixMilli())
+	msg := gmailMsg("g-fan", "thr", shared, []string{me}, nil, nil, "S", "body", "<"+ext+">", gmailPastNoonAnchor().UnixMilli())
 	e.inject(newRecordingMessageStore([]*gmailapi.Message{msg}), map[string]struct{}{me: {}})
 
 	matched, err := e.handler.Rematch(e.ctx, c1.ID, shared)
@@ -410,7 +410,7 @@ func TestGmailRematch_MultipleAccounts_PerAccountSeen(t *testing.T) {
 	// The SAME Message-ID observed in both mailboxes: same gmail message id so
 	// the fetcher's per-id counter measures cross-account scanning. Both
 	// accounts share the me-set so cross-account provenance detection fires.
-	sentAt := localNoonAnchor()
+	sentAt := gmailPastNoonAnchor()
 	msg := gmailMsg("g-shared", "thr", addrA, []string{accountX, accountY}, nil, nil, "S", "body", "<"+ext+">", sentAt.UnixMilli())
 	store := newRecordingMessageStore([]*gmailapi.Message{msg})
 	e.inject(store, map[string]struct{}{accountX: {}, accountY: {}})
@@ -455,7 +455,7 @@ func TestGmailRematch_NoCursorSideEffects(t *testing.T) {
 
 	ext := "nocur-" + suffix + "@example.com"
 	e.cleanupEvents(t, ext)
-	msg := gmailMsg("g-nocur", "thr", addrA, []string{account}, nil, nil, "S", "body", "<"+ext+">", localNoonAnchor().UnixMilli())
+	msg := gmailMsg("g-nocur", "thr", addrA, []string{account}, nil, nil, "S", "body", "<"+ext+">", gmailPastNoonAnchor().UnixMilli())
 	e.inject(newRecordingMessageStore([]*gmailapi.Message{msg}), map[string]struct{}{account: {}})
 
 	matched, err := e.handler.Rematch(e.ctx, contactA.ID, addrA)
@@ -482,7 +482,7 @@ func TestGmailRematch_BackfillFloorAndQueryShape(t *testing.T) {
 
 	ext := "shape-" + suffix + "@example.com"
 	e.cleanupEvents(t, ext)
-	msg := gmailMsg("g-shape", "thr", addrA, []string{account}, nil, nil, "S", "body", "<"+ext+">", localNoonAnchor().UnixMilli())
+	msg := gmailMsg("g-shape", "thr", addrA, []string{account}, nil, nil, "S", "body", "<"+ext+">", gmailPastNoonAnchor().UnixMilli())
 	store := newRecordingMessageStore([]*gmailapi.Message{msg})
 	e.inject(store, map[string]struct{}{account: {}})
 
@@ -523,7 +523,7 @@ func TestGmailRematch_NoEnabledState_NoOp(t *testing.T) {
 
 		// A fetcher that WOULD return a qualifying message if it were ever
 		// consulted — the gate must prevent that.
-		msg := gmailMsg("g-gate-a", "thr", addrA, []string{me}, nil, nil, "S", "body", "<gate-a-"+suffix+"@example.com>", localNoonAnchor().UnixMilli())
+		msg := gmailMsg("g-gate-a", "thr", addrA, []string{me}, nil, nil, "S", "body", "<gate-a-"+suffix+"@example.com>", gmailPastNoonAnchor().UnixMilli())
 		store := newRecordingMessageStore([]*gmailapi.Message{msg})
 		e.inject(store, map[string]struct{}{me: {}})
 
@@ -565,7 +565,7 @@ func TestGmailRematch_NoEnabledState_NoOp(t *testing.T) {
 		_, err = e.syncRepo.UpdateSyncStateEnabled(e.ctx, created.ID, false)
 		require.NoError(t, err)
 
-		msg := gmailMsg("g-gate-d", "thr", addrA, []string{me}, nil, nil, "S", "body", "<gate-d-"+suffix+"@example.com>", localNoonAnchor().UnixMilli())
+		msg := gmailMsg("g-gate-d", "thr", addrA, []string{me}, nil, nil, "S", "body", "<gate-d-"+suffix+"@example.com>", gmailPastNoonAnchor().UnixMilli())
 		store := newRecordingMessageStore([]*gmailapi.Message{msg})
 		e.inject(store, map[string]struct{}{me: {}})
 
@@ -598,7 +598,7 @@ func TestGmailRematch_PartialFailure_ReturnsError(t *testing.T) {
 
 	ext := "pf-" + suffix + "@example.com"
 	e.cleanupEvents(t, ext)
-	msg := gmailMsg("g-pf", "thr", addrA, []string{accountY}, nil, nil, "S", "body", "<"+ext+">", localNoonAnchor().UnixMilli())
+	msg := gmailMsg("g-pf", "thr", addrA, []string{accountY}, nil, nil, "S", "body", "<"+ext+">", gmailPastNoonAnchor().UnixMilli())
 
 	// Account-keyed fetcher factory: account X always fails its list call;
 	// account Y returns the qualifying message and records its query.
@@ -648,7 +648,7 @@ func TestGmailRematch_PerAccountBackfillSince(t *testing.T) {
 		contactA := e.newContactWithEmail(t, "Contact A "+suffix, addrA)
 		ext := "bf-" + suffix + "@example.com"
 		e.cleanupEvents(t, ext)
-		msg := gmailMsg("g-bf", "thr", addrA, []string{account}, nil, nil, "S", "body", "<"+ext+">", localNoonAnchor().UnixMilli())
+		msg := gmailMsg("g-bf", "thr", addrA, []string{account}, nil, nil, "S", "body", "<"+ext+">", gmailPastNoonAnchor().UnixMilli())
 		store := newRecordingMessageStore([]*gmailapi.Message{msg})
 		e.inject(store, map[string]struct{}{account: {}})
 
@@ -685,7 +685,7 @@ func TestGmailRematch_PerAccountBackfillSince(t *testing.T) {
 		contactA := e.newContactWithEmail(t, "Contact A "+suffix, addrA)
 		ext := "bfd-" + suffix + "@example.com"
 		e.cleanupEvents(t, ext)
-		msg := gmailMsg("g-bfd", "thr", addrA, []string{account}, nil, nil, "S", "body", "<"+ext+">", localNoonAnchor().UnixMilli())
+		msg := gmailMsg("g-bfd", "thr", addrA, []string{account}, nil, nil, "S", "body", "<"+ext+">", gmailPastNoonAnchor().UnixMilli())
 		store := newRecordingMessageStore([]*gmailapi.Message{msg})
 		e.inject(store, map[string]struct{}{account: {}})
 

--- a/backend/tests/gmail_time_helpers_test.go
+++ b/backend/tests/gmail_time_helpers_test.go
@@ -1,0 +1,9 @@
+package tests
+
+import "time"
+
+// gmailPastNoonAnchor keeps Gmail test messages on one local day while placing
+// them well outside the provider's recent-message safety lag.
+func gmailPastNoonAnchor() time.Time {
+	return localNoonAnchor().Add(-24 * time.Hour)
+}


### PR DESCRIPTION
## The bug (P0)

The Gmail backfill advanced its per-account cursor to the **newest message timestamp it happened to fetch**, treating that as proof the scan was complete. It wasn't: after a sparse sweep the cursor jumped forward and **permanently stranded all older known-contact mail** below the `after:` bound. Production had ingested only 32 messages for a far larger known-contact corpus across Jan–Jun, then trickled ~1/sweep with boundary replay. This under-fed the entire email integration (and is why the correspondence-discovery feature had almost no input).

## The fix

- **Bounded closed-window scans** (`after:start before:end`): the cursor advances only to `window_end`, and only after every address-chunk and page in that window is fully scanned — never from the max fetched timestamp. A chunk/page failure preserves the prior cursor.
- **Versioned JSON cursor** (`completed_through` + boundary message-ID hashes), with back-compat parsing of the legacy numeric cursor. Boundary hashes end same-second replay without hiding genuinely-new boundary mail.
- **Safety lag** keeps `window_end` behind Gmail's search-index horizon; a **capped multi-window catch-up loop** so a multi-month rewind isn't glacial.
- **Run-level fetched-message cache** (keyed by message-ID hash, checked before the body fetch) so the ±48h boundary overlap — needed for Gmail's coarse date granularity — never double-fetches a message.
- **Recovery command** `crm-admin --reset-gmail-backfill-cursors`: rewinds enabled email cursors to the shared backfill floor and marks them due, so the corrected windowed sync re-scans. Safe because the `comms_message` upsert is content-immutable on conflict (already-ingested rows no-op; stranded rows insert, picking up display names via ingest-time capture). Counts-only output.

Gmail History API (a more robust steady-state primitive) is deliberately deferred — tracked in #399.

## Operator runbook (after merge + deploy)

1. Deploy to the Pi.
2. Run `crm-admin --reset-gmail-backfill-cursors` once → rewinds the email cursors to the Jan-1 floor.
3. The corrected windowed backfill walks Jan→now over subsequent syncs and ingests the real mail volume.
4. (If any pre-display-name-capture rows remain) `crm-admin --rederive-correspondence-names`; then the correspondence producer surfaces candidates.

## Review / tests

Independent review passed with no P0/P1 (1 P2 + 1 P3 non-blocking: a latent post-2026-06-18 test date-coupling; a theoretical empty-ID hash collision). Coverage: unit tests for the window/cursor-advance invariant ("cursor never advances past unscanned mail"), boundary dedup, fetch-once-across-overlapping-windows, cursor parsing (empty / legacy-numeric / v2 JSON), and chunk/page-failure-preserves-cursor; an integration test proving no message is stranded across windows; and admin-reset tests (enabled-email-only scoping, metadata preserved, accelerated due-time, counts-only/no-PII). `make lint` / `make test` (unit + integration) green.