### PR TITLE
feat(settings): add Gmail sync-now UI trigger

### DIFF
--- a/frontend/src/components/settings/google-accounts-section.tsx
+++ b/frontend/src/components/settings/google-accounts-section.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react'
 import { useSearchParams } from 'next/navigation'
 import { Mail, Plus, Trash2, CheckCircle, AlertCircle, Info, RefreshCcw } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { SyncBadge, PermissionBadge } from '@/components/settings/sync-badge'
+import { SyncBadge } from '@/components/settings/sync-badge'
 import { useGoogleAccounts, useRevokeGoogleAccount } from '@/hooks/use-google-accounts'
 import {
   useSyncStates,
@@ -73,6 +73,28 @@ export function GoogleAccountsSection() {
         message: errorMessage.includes('authentication')
           ? 'Authentication failed. Please reconnect your account.'
           : `Failed to start contacts sync: ${errorMessage}`,
+      })
+    } finally {
+      setSyncingAccount(null)
+    }
+  }
+
+  const handleSyncEmail = async (accountId: string) => {
+    setSyncingAccount(`email-${accountId}`)
+    try {
+      await triggerSyncMutation.mutateAsync({ source: 'email', accountId })
+      setNotification({
+        type: 'success',
+        message: 'Gmail sync started!',
+      })
+    } catch (error) {
+      console.error('Gmail sync error:', error)
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+      setNotification({
+        type: 'error',
+        message: errorMessage.includes('authentication')
+          ? 'Authentication failed. Please reconnect your account.'
+          : `Failed to start Gmail sync: ${errorMessage}`,
       })
     } finally {
       setSyncingAccount(null)
@@ -284,9 +306,14 @@ export function GoogleAccountsSection() {
                   Permissions & Sync
                 </p>
                 <div className="flex flex-wrap gap-2">
-                  {/* Gmail - simple badge (no sync) */}
+                  {/* Gmail - sync badge */}
                   {account.scopes?.includes('https://www.googleapis.com/auth/gmail.readonly') && (
-                    <PermissionBadge label="Gmail (read)" />
+                    <SyncBadge
+                      label="Gmail"
+                      syncState={getSyncStateForAccount(syncStates, 'email', account.account_id)}
+                      onSync={() => handleSyncEmail(account.account_id)}
+                      loading={syncingAccount === `email-${account.account_id}`}
+                    />
                   )}
                   {/* Calendar - sync badge */}
                   {account.scopes?.includes(

--- a/frontend/tests/e2e/settings.spec.ts
+++ b/frontend/tests/e2e/settings.spec.ts
@@ -20,6 +20,32 @@ test.describe('Settings Page @area:settings', () => {
     expect(hasConnectButton || hasConfigMessage).toBe(true)
   })
 
+  test('should display Google Accounts section with optional Gmail sync badge', async ({
+    page,
+  }) => {
+    await page.goto('/settings', { waitUntil: 'networkidle' })
+    await page.reload({ waitUntil: 'networkidle' })
+
+    // Google Accounts section heading should always render
+    await expect(page.getByRole('heading', { name: 'Google Accounts', exact: true })).toBeVisible()
+
+    // The Gmail sync badge only appears when an account with the gmail.readonly
+    // scope is connected (depends on backend GOOGLE_* env vars + a real account).
+    // If present, its refresh button must be accessible and not permanently disabled.
+    const gmailBadge = page.locator('div').filter({ hasText: /^Gmail/ })
+    const hasGmailBadge = await gmailBadge
+      .first()
+      .isVisible()
+      .catch(() => false)
+
+    if (hasGmailBadge) {
+      const refreshButton = gmailBadge.first().getByRole('button')
+      await expect(refreshButton).toBeVisible()
+      // Button may be transiently disabled while syncing, but not absent/hidden.
+      await expect(refreshButton).toBeEnabled({ timeout: 5000 })
+    }
+  })
+
   test('should display settings page with export and import sections', async ({ page }) => {
     await page.goto('/settings')
 


### PR DESCRIPTION
## What

Adds a manual "Sync now" trigger for the Gmail email sync on the settings page, mirroring the existing Google Calendar and Contacts triggers.

## How

The sync pipeline is already source-agnostic, so this is a single-file UI change plus a test:
- `frontend/src/components/settings/google-accounts-section.tsx`: a `handleSyncEmail(accountId)` handler mirroring the Calendar/Contacts handlers, and the static Gmail `PermissionBadge` replaced with a `SyncBadge` wired to `source: 'email'` (label "Gmail"). Reuses the existing `POST /api/v1/sync/:source/trigger` endpoint, the `useTriggerSync` mutation, `getSyncStateForAccount`, and `useSyncStates` polling — no backend / api-client / query-key changes.
- `frontend/tests/e2e/settings.spec.ts`: one defensive `@area:settings` case.

Per-account trigger (independent per connected account); in-flight dedup via the existing River unique-args constraint; a manual trigger runs one bounded windowed catch-up. The source string is `'email'` throughout (only the human label is "Gmail").

## Tests

`make test-frontend` (335), `make lint`, and `make test-e2e-diff` (incl. the new settings case) green. UI-bearing — awaiting human review.