### PR TITLE
Handle placeholder birthdays and calendar day labels

### DIFF
--- a/frontend/src/app/birthdays/page.tsx
+++ b/frontend/src/app/birthdays/page.tsx
@@ -4,7 +4,7 @@ import { Calendar, Cake, Gift, Users } from 'lucide-react'
 import { Navigation } from '@/components/layout/navigation'
 import { useContacts } from '@/hooks/use-contacts'
 import { useAcceleratedTime } from '@/hooks/use-accelerated-time'
-import { parseDateOnly } from '@/lib/utils'
+import { isPlaceholderBirthday, parseDateOnly } from '@/lib/utils'
 import type { Contact } from '@/types/contact'
 
 // Birthday data with calculated fields
@@ -13,34 +13,44 @@ interface BirthdayInfo {
   birthday: Date
   dayOfWeek: string
   monthDay: string
-  ageThisYear: number
+  ageThisYear?: number
   daysUntil: number
   isPastThisYear: boolean
   isNextYear?: boolean
 }
 
 // Calculate age turning this year
-function calculateAgeThisYear(birthday: Date, currentTime: Date): number {
-  const currentYear = currentTime.getFullYear()
+function calculateAgeThisYear(birthday: Date, year: number): number {
+  return year - birthday.getFullYear()
+}
 
-  // Age they turn this calendar year
-  return currentYear - birthday.getFullYear()
+function startOfLocalDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate())
+}
+
+function birthdayInYear(birthday: Date, year: number): Date {
+  return new Date(year, birthday.getMonth(), birthday.getDate())
+}
+
+function getNextBirthday(birthday: Date, currentTime: Date): Date {
+  const currentDay = startOfLocalDay(currentTime)
+  const currentYear = currentDay.getFullYear()
+  const birthdayThisYear = birthdayInYear(birthday, currentYear)
+
+  if (birthdayThisYear < currentDay) {
+    return birthdayInYear(birthday, currentYear + 1)
+  }
+
+  return birthdayThisYear
 }
 
 // Calculate days until next birthday
 function calculateDaysUntilBirthday(birthday: Date, currentTime: Date): number {
-  const currentYear = currentTime.getFullYear()
-
-  // Birthday this year
-  let nextBirthday = new Date(currentYear, birthday.getMonth(), birthday.getDate())
-
-  // If birthday already passed this year, calculate for next year
-  if (nextBirthday < currentTime) {
-    nextBirthday = new Date(currentYear + 1, birthday.getMonth(), birthday.getDate())
-  }
+  const currentDay = startOfLocalDay(currentTime)
+  const nextBirthday = getNextBirthday(birthday, currentTime)
 
   // Calculate difference in days
-  const diffTime = nextBirthday.getTime() - currentTime.getTime()
+  const diffTime = nextBirthday.getTime() - currentDay.getTime()
   return Math.ceil(diffTime / (1000 * 60 * 60 * 24))
 }
 
@@ -70,9 +80,10 @@ function getNextYearEarlyBirthdays(contacts: Contact[], currentTime: Date): Birt
       if (birthdayMonth > 3) return null
 
       const nextYear = currentTime.getFullYear() + 1
-      const nextYearBirthday = new Date(nextYear, birthday.getMonth(), birthday.getDate())
+      const currentDay = startOfLocalDay(currentTime)
+      const nextYearBirthday = birthdayInYear(birthday, nextYear)
       const daysUntil = Math.ceil(
-        (nextYearBirthday.getTime() - currentTime.getTime()) / (1000 * 60 * 60 * 24)
+        (nextYearBirthday.getTime() - currentDay.getTime()) / (1000 * 60 * 60 * 24)
       )
 
       return {
@@ -80,7 +91,9 @@ function getNextYearEarlyBirthdays(contacts: Contact[], currentTime: Date): Birt
         birthday: nextYearBirthday,
         dayOfWeek: nextYearBirthday.toLocaleDateString('en-US', { weekday: 'long' }),
         monthDay: nextYearBirthday.toLocaleDateString('en-US', { month: 'long', day: 'numeric' }),
-        ageThisYear: nextYear - birthday.getFullYear(),
+        ageThisYear: isPlaceholderBirthday(contact.birthday)
+          ? undefined
+          : calculateAgeThisYear(birthday, nextYear),
         daysUntil,
         isPastThisYear: false,
         isNextYear: true,
@@ -91,10 +104,10 @@ function getNextYearEarlyBirthdays(contacts: Contact[], currentTime: Date): Birt
 
 // Check if birthday already passed this year
 function isBirthdayPastThisYear(birthday: Date, currentTime: Date): boolean {
-  const currentYear = currentTime.getFullYear()
-  const birthdayThisYear = new Date(currentYear, birthday.getMonth(), birthday.getDate())
+  const currentDay = startOfLocalDay(currentTime)
+  const birthdayThisYear = birthdayInYear(birthday, currentDay.getFullYear())
 
-  return birthdayThisYear < currentTime
+  return birthdayThisYear < currentDay
 }
 
 // Process contacts to extract birthday information
@@ -106,13 +119,17 @@ function processBirthdayContacts(contacts: Contact[], currentTime: Date): Birthd
       if (!birthday) return null
 
       const daysUntil = calculateDaysUntilBirthday(birthday, currentTime)
+      const nextBirthday = getNextBirthday(birthday, currentTime)
+      const hasPlaceholderYear = isPlaceholderBirthday(contact.birthday)
 
       return {
         contact,
-        birthday,
-        dayOfWeek: birthday.toLocaleDateString('en-US', { weekday: 'long' }),
-        monthDay: birthday.toLocaleDateString('en-US', { month: 'long', day: 'numeric' }),
-        ageThisYear: calculateAgeThisYear(birthday, currentTime),
+        birthday: nextBirthday,
+        dayOfWeek: nextBirthday.toLocaleDateString('en-US', { weekday: 'long' }),
+        monthDay: nextBirthday.toLocaleDateString('en-US', { month: 'long', day: 'numeric' }),
+        ageThisYear: hasPlaceholderYear
+          ? undefined
+          : calculateAgeThisYear(birthday, currentTime.getFullYear()),
         daysUntil,
         isPastThisYear: isBirthdayPastThisYear(birthday, currentTime),
       }
@@ -140,6 +157,7 @@ function BirthdayCard({ birthdayInfo }: { birthdayInfo: BirthdayInfo }) {
 
   return (
     <div
+      data-testid="birthday-card"
       className={`
       bg-white rounded-lg shadow-sm border p-4 hover:shadow-md transition-shadow
       ${isToday ? 'border-pink-300 bg-pink-50' : ''}
@@ -178,12 +196,14 @@ function BirthdayCard({ birthdayInfo }: { birthdayInfo: BirthdayInfo }) {
         </div>
 
         <div className="text-right">
-          <p className="text-lg font-semibold text-gray-900">
-            {isPastDue ? `Turned ${ageThisYear}` : `Turning ${ageThisYear}`}
-            {isGiftPlanningTime && (
-              <span className="text-xs text-purple-600 ml-1">(next year)</span>
-            )}
-          </p>
+          {ageThisYear !== undefined && (
+            <p className="text-lg font-semibold text-gray-900">
+              {isPastDue ? `Turned ${ageThisYear}` : `Turning ${ageThisYear}`}
+              {isGiftPlanningTime && (
+                <span className="text-xs text-purple-600 ml-1">(next year)</span>
+              )}
+            </p>
+          )}
           <p
             className={`text-sm ${
               isToday

--- a/frontend/src/app/contacts/[id]/page.tsx
+++ b/frontend/src/app/contacts/[id]/page.tsx
@@ -16,7 +16,7 @@ import { useContactNote, useSaveContactNote } from '@/hooks/use-contact-note'
 import { useContactTasks } from '@/hooks/use-contact-tasks'
 import { useKeyboardNavigation } from '@/hooks/use-keyboard-navigation'
 import { ContactNavigationBar } from '@/components/contacts/contact-navigation-bar'
-import { formatDateOnly, formatRelativeTime } from '@/lib/utils'
+import { formatBirthday, formatRelativeTime } from '@/lib/utils'
 import {
   Edit,
   Trash2,
@@ -470,7 +470,7 @@ export default function ContactDetailPage() {
                   <dd className="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2">
                     <div className="flex items-center">
                       <Calendar className="w-4 h-4 mr-2 text-gray-400" />
-                      {formatDateOnly(contact.birthday)}
+                      {formatBirthday(contact.birthday)}
                     </div>
                   </dd>
                 </div>

--- a/frontend/src/app/contacts/page.tsx
+++ b/frontend/src/app/contacts/page.tsx
@@ -23,7 +23,7 @@ import { Button } from '@/components/ui/button'
 import { Pagination } from '@/components/ui/pagination'
 import { Navigation } from '@/components/layout/navigation'
 import { FORM_CONTROL_WITH_ICON, FORM_SELECT_BASE } from '@/lib/form-classes'
-import { formatDateOnly, formatCadence } from '@/lib/utils'
+import { formatDateOnly, formatCadence, formatBirthday } from '@/lib/utils'
 import type { Contact, ContactListParams } from '@/types/contact'
 
 type SortField =
@@ -273,7 +273,7 @@ function ContactsTable({
               </td>
               <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-500">
                 {contact.birthday
-                  ? formatDateOnly(contact.birthday, {
+                  ? formatBirthday(contact.birthday, {
                       year: '2-digit',
                       month: 'numeric',
                       day: 'numeric',

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -15,6 +15,7 @@ import {
   getContactMethodLabel,
   getPrimaryAndSecondaryMethods,
 } from '@/lib/contact-methods'
+import { getLocalCalendarDayDifference } from '@/lib/utils'
 import type { ContactMethod, OverdueContact } from '@/types/contact'
 import { clsx } from 'clsx'
 
@@ -57,14 +58,14 @@ function OverdueContactCard({ contact }: { contact: OverdueContact }) {
   const formatLastContacted = (lastContacted?: string) => {
     if (!lastContacted) return 'Never contacted'
     const date = new Date(lastContacted)
-    const now = currentTime // Use accelerated time instead of new Date()
-    const diffTime = now.getTime() - date.getTime()
-    const diffDays = Math.ceil(Math.abs(diffTime) / (1000 * 60 * 60 * 24))
+    if (Number.isNaN(date.getTime())) return ''
 
-    // Handle future dates (data anomaly from time acceleration)
-    if (diffTime < 0) {
-      if (diffDays === 1) return 'in 1 day'
-      return `in ${diffDays} days`
+    const diffDays = getLocalCalendarDayDifference(date, currentTime)
+
+    if (diffDays < 0) {
+      const futureDays = Math.abs(diffDays)
+      if (futureDays === 1) return 'in 1 day'
+      return `in ${futureDays} days`
     }
 
     if (diffDays === 0) return 'Today'

--- a/frontend/src/lib/__tests__/utils.test.ts
+++ b/frontend/src/lib/__tests__/utils.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from 'vitest'
-import { parseDateOnly, formatDateOnly, formatCadence } from '../utils'
+import {
+  parseDateOnly,
+  formatDateOnly,
+  formatBirthday,
+  isPlaceholderBirthday,
+  PLACEHOLDER_BIRTHDAY_YEAR,
+  formatCadence,
+  getLocalCalendarDayDifference,
+  formatRelativeTime,
+} from '../utils'
 
 describe('parseDateOnly', () => {
   it('parses YYYY-MM-DD format correctly', () => {
@@ -77,6 +86,95 @@ describe('formatDateOnly', () => {
   it('handles empty string input', () => {
     const result = formatDateOnly('')
     expect(result).toBe('')
+  })
+})
+
+describe('isPlaceholderBirthday', () => {
+  it('detects the sentinel placeholder birthday year', () => {
+    expect(isPlaceholderBirthday(`${PLACEHOLDER_BIRTHDAY_YEAR}-01-15`)).toBe(true)
+    expect(isPlaceholderBirthday(`${PLACEHOLDER_BIRTHDAY_YEAR}-01-15T00:00:00Z`)).toBe(true)
+  })
+
+  it('does not treat real birthday years or invalid dates as placeholders', () => {
+    expect(isPlaceholderBirthday('1990-01-15')).toBe(false)
+    expect(isPlaceholderBirthday('invalid-date')).toBe(false)
+    expect(isPlaceholderBirthday(null)).toBe(false)
+  })
+})
+
+describe('formatBirthday', () => {
+  it('omits the year for placeholder-year birthdays', () => {
+    const result = formatBirthday(`${PLACEHOLDER_BIRTHDAY_YEAR}-01-15`)
+
+    expect(result).toMatch(/Jan/)
+    expect(result).toMatch(/15/)
+    expect(result).not.toMatch(String(PLACEHOLDER_BIRTHDAY_YEAR))
+  })
+
+  it('omits the year from custom date options for placeholder-year birthdays', () => {
+    const result = formatBirthday(`${PLACEHOLDER_BIRTHDAY_YEAR}-01-15`, {
+      year: '2-digit',
+      month: 'numeric',
+      day: 'numeric',
+    })
+
+    expect(result).toMatch(/^1\/15$/)
+  })
+
+  it('preserves the requested year format for real birthday years', () => {
+    const result = formatBirthday('1990-01-15', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    })
+
+    expect(result).toMatch(/January/)
+    expect(result).toMatch(/15/)
+    expect(result).toMatch(/1990/)
+  })
+})
+
+describe('getLocalCalendarDayDifference', () => {
+  it('returns 0 for timestamps on the same local calendar day', () => {
+    const date = new Date(2026, 5, 4, 0, 5)
+    const referenceDate = new Date(2026, 5, 4, 23, 55)
+
+    expect(getLocalCalendarDayDifference(date, referenceDate)).toBe(0)
+  })
+
+  it('returns 1 for yesterday even when less than 24 hours elapsed', () => {
+    const date = new Date(2026, 5, 3, 23, 55)
+    const referenceDate = new Date(2026, 5, 4, 0, 5)
+
+    expect(getLocalCalendarDayDifference(date, referenceDate)).toBe(1)
+  })
+
+  it('returns negative days for future calendar dates', () => {
+    const date = new Date(2026, 5, 6, 0, 5)
+    const referenceDate = new Date(2026, 5, 4, 23, 55)
+
+    expect(getLocalCalendarDayDifference(date, referenceDate)).toBe(-2)
+  })
+
+  it('counts calendar days across daylight saving time changes', () => {
+    const date = new Date(2026, 2, 7, 12)
+    const referenceDate = new Date(2026, 2, 9, 12)
+
+    expect(getLocalCalendarDayDifference(date, referenceDate)).toBe(2)
+  })
+})
+
+describe('formatRelativeTime', () => {
+  it('returns today for timestamps earlier on the same calendar day', () => {
+    expect(
+      formatRelativeTime(new Date(2026, 5, 4, 0, 5).toISOString(), new Date(2026, 5, 4, 23, 55))
+    ).toBe('today')
+  })
+
+  it('returns yesterday for timestamps on the previous calendar day', () => {
+    expect(
+      formatRelativeTime(new Date(2026, 5, 3, 23, 55).toISOString(), new Date(2026, 5, 4, 0, 5))
+    ).toBe('yesterday')
   })
 })
 

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -36,6 +36,46 @@ export function formatDateOnly(
   return date.toLocaleDateString(undefined, options)
 }
 
+const MS_PER_DAY = 1000 * 60 * 60 * 24
+
+export function getLocalCalendarDayDifference(date: Date, referenceDate: Date): number {
+  const dateDay = Date.UTC(date.getFullYear(), date.getMonth(), date.getDate())
+  const referenceDay = Date.UTC(
+    referenceDate.getFullYear(),
+    referenceDate.getMonth(),
+    referenceDate.getDate()
+  )
+
+  return Math.round((referenceDay - dateDay) / MS_PER_DAY)
+}
+
+// Imported year-less birthdays use this sentinel year until the data model can represent them explicitly.
+export const PLACEHOLDER_BIRTHDAY_YEAR = 1900
+
+export function isPlaceholderBirthday(dateString: string | undefined | null): boolean {
+  const date = parseDateOnly(dateString)
+  return date?.getFullYear() === PLACEHOLDER_BIRTHDAY_YEAR
+}
+
+export function formatBirthday(
+  dateString: string | undefined | null,
+  options: Intl.DateTimeFormatOptions = { year: 'numeric', month: 'short', day: 'numeric' }
+): string {
+  if (!isPlaceholderBirthday(dateString)) {
+    return formatDateOnly(dateString, options)
+  }
+
+  const monthDayOptions = { ...options }
+  delete monthDayOptions.year
+
+  if (!monthDayOptions.month && !monthDayOptions.day) {
+    monthDayOptions.month = 'short'
+    monthDayOptions.day = 'numeric'
+  }
+
+  return formatDateOnly(dateString, monthDayOptions)
+}
+
 /**
  * Format a cadence value for display.
  *
@@ -48,14 +88,15 @@ export function formatDateOnly(
  * @param dateString - ISO timestamp string
  * @returns Relative time string, or empty string if invalid
  */
-export function formatRelativeTime(dateString: string | undefined | null): string {
+export function formatRelativeTime(
+  dateString: string | undefined | null,
+  referenceDate: Date = new Date()
+): string {
   if (!dateString) return ''
   const date = new Date(dateString)
   if (isNaN(date.getTime())) return ''
 
-  const now = new Date()
-  const diffMs = now.getTime() - date.getTime()
-  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24))
+  const diffDays = getLocalCalendarDayDifference(date, referenceDate)
 
   if (diffDays < 0) return 'in the future'
   if (diffDays === 0) return 'today'

--- a/frontend/tests/e2e/birthdays.spec.ts
+++ b/frontend/tests/e2e/birthdays.spec.ts
@@ -1,0 +1,107 @@
+import { test, expect } from '@playwright/test'
+import type { APIRequestContext } from '@playwright/test'
+import { createTestAPI, TestAPI } from './helpers/test-api'
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080'
+const API_KEY = process.env.NEXT_PUBLIC_API_KEY || 'test-api-key-for-ci'
+const API_HEADERS = {
+  'X-API-Key': API_KEY,
+  'Content-Type': 'application/json',
+}
+
+async function getCurrentBirthdayDate(request: APIRequestContext): Promise<string> {
+  const response = await request.get(`${API_BASE_URL}/api/v1/system/time`, {
+    headers: API_HEADERS,
+  })
+  expect(response.ok()).toBeTruthy()
+
+  const body = await response.json()
+  const systemTime = body.data as { current_time: string; is_accelerated: boolean }
+  const currentTime = systemTime.is_accelerated ? new Date(systemTime.current_time) : new Date()
+  const month = String(currentTime.getMonth() + 1).padStart(2, '0')
+  const day = String(currentTime.getDate()).padStart(2, '0')
+
+  return `1900-${month}-${day}`
+}
+
+async function createContactWithBirthday(
+  request: APIRequestContext,
+  testApi: TestAPI,
+  input: { fullName: string; birthday: string }
+): Promise<string> {
+  const response = await request.post(`${API_BASE_URL}/api/v1/contacts`, {
+    headers: API_HEADERS,
+    data: {
+      full_name: `${testApi.prefix}-${input.fullName}`,
+      birthday: input.birthday,
+    },
+  })
+  expect(response.ok()).toBeTruthy()
+
+  const body = await response.json()
+  return (body.data as { id: string }).id
+}
+
+test.describe('Birthdays - Placeholder Years @area:birthdays', () => {
+  let testApi: TestAPI
+
+  test.beforeEach(async ({ request }, testInfo) => {
+    testApi = createTestAPI(request, testInfo)
+  })
+
+  test.afterEach(async () => {
+    await testApi.cleanup()
+  })
+
+  test('shows placeholder-year birthdays without age and keeps today at the top', async ({
+    page,
+    request,
+  }) => {
+    const birthday = await getCurrentBirthdayDate(request)
+    const birthdayDate = new Date(`${birthday}T12:00:00`)
+    const expectedListDate = `${birthdayDate.getMonth() + 1}/${birthdayDate.getDate()}`
+    const expectedDetailDate = birthdayDate.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+    })
+    const expectedBirthdayPageDate = birthdayDate.toLocaleDateString('en-US', {
+      month: 'long',
+      day: 'numeric',
+    })
+
+    const contactId = await createContactWithBirthday(request, testApi, {
+      fullName: 'Placeholder Birthday Contact',
+      birthday,
+    })
+    const fullName = `${testApi.prefix}-Placeholder Birthday Contact`
+
+    await page.goto('/contacts')
+    await page.waitForLoadState('domcontentloaded')
+    await page.getByPlaceholder('Search contacts...').fill(fullName)
+    await page.getByPlaceholder('Search contacts...').press('Enter')
+    const row = page.locator('tr', { has: page.getByText(fullName) })
+    await expect(row).toBeVisible({ timeout: 15000 })
+    await expect(row).toContainText(expectedListDate)
+    await expect(row).not.toContainText('/00')
+    await expect(row).not.toContainText('1900')
+
+    await page.goto(`/contacts/${contactId}`)
+    await page.waitForLoadState('domcontentloaded')
+    await expect(page.getByRole('heading', { name: fullName })).toBeVisible({ timeout: 15000 })
+    await expect(page.getByText(expectedDetailDate, { exact: true })).toBeVisible()
+    await expect(page.getByText('1900')).not.toBeVisible()
+
+    await page.goto('/birthdays')
+    await page.waitForLoadState('domcontentloaded')
+    const todaySection = page.locator('section', {
+      has: page.getByRole('heading', { name: /Today's Birthdays/ }),
+    })
+    await expect(todaySection).toBeVisible({ timeout: 15000 })
+
+    const card = todaySection.getByTestId('birthday-card').filter({ hasText: fullName })
+    await expect(card).toBeVisible()
+    await expect(card).toContainText(expectedBirthdayPageDate)
+    await expect(card).toContainText('Today!')
+    await expect(card).not.toContainText(/Turning|Turned/)
+  })
+})

--- a/frontend/tests/e2e/test-map.json
+++ b/frontend/tests/e2e/test-map.json
@@ -11,6 +11,7 @@
       "@area:overdue",
       "@area:settings",
       "@area:navigation",
+      "@area:birthdays",
       "@area:error-boundary"
     ]
   },
@@ -26,6 +27,7 @@
       "@area:overdue",
       "@area:settings",
       "@area:navigation",
+      "@area:birthdays",
       "@area:error-boundary"
     ]
   },
@@ -36,6 +38,10 @@
   {
     "pattern": "^frontend/tests/e2e/contacts\\.spec\\.ts$",
     "tags": ["@area:contacts", "@area:overdue"]
+  },
+  {
+    "pattern": "^frontend/tests/e2e/birthdays\\.spec\\.ts$",
+    "tags": ["@area:birthdays"]
   },
   {
     "pattern": "^frontend/tests/e2e/contact-navigation\\.spec\\.ts$",
@@ -80,6 +86,10 @@
   {
     "pattern": "^frontend/src/app/contacts/",
     "tags": ["@area:contacts", "@area:contact-navigation", "@area:contact-merge", "@area:overdue"]
+  },
+  {
+    "pattern": "^frontend/src/app/birthdays/",
+    "tags": ["@area:birthdays"]
   },
   {
     "pattern": "^frontend/src/app/imports/",
@@ -189,6 +199,10 @@
       "@area:navigation",
       "@area:error-boundary"
     ]
+  },
+  {
+    "pattern": "^frontend/src/lib/utils\\.ts$",
+    "tags": ["@area:contacts", "@area:birthdays"]
   },
   {
     "pattern": "^frontend/src/lib/contacts-api\\.ts$",


### PR DESCRIPTION
## Summary

- handle `1900-MM-DD` placeholder birthdays as month/day-only birthdays in the UI
- suppress age text for placeholder-year birthdays while preserving real-year birthday behavior
- fix calendar-day comparisons so today's birthdays and same-day relative labels do not drift after midnight

## Root Cause

Imported year-less birthdays are currently represented with the sentinel year `1900`, but the UI treated that as a real birth year. The birthdays page also compared generated birthday dates to the full current timestamp, so a birthday at local midnight could be considered past later the same day.

## Validation

- `bun test src/lib/__tests__/utils.test.ts`
- `make test-frontend`
- `bun run lint` with existing warnings only
- `make test-e2e-diff`
- pre-push hook: lint PASS, tests PASS

Closes #400 