### PR TITLE
fix: hide unresolved telegram imports

### DIFF
--- a/backend/internal/api/handlers/import.go
+++ b/backend/internal/api/handlers/import.go
@@ -176,15 +176,21 @@ func (h *ImportHandler) ListImportCandidates(c *gin.Context) {
 
 	// Check for source filter
 	source := c.Query("source")
+	includeUnresolvedTelegram := includeUnresolvedTelegramParam(c)
 
 	// Build the confidence-sorted candidate list via the shared service
 	// helper (the single sort implementation, also used by the suggestions
 	// surface). We fetch all candidates up to MaxCandidatesForSorting
 	// because confidence scores are computed in-memory and can't be sorted
 	// at the DB level.
-	sorted, err := h.suggestionSvc.BuildSortedCandidates(ctx, source, MaxCandidatesForSorting)
+	sorted, err := h.suggestionSvc.BuildSortedCandidates(ctx, source, MaxCandidatesForSorting, includeUnresolvedTelegram)
 	if err != nil {
 		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to list candidates", err.Error())
+		return
+	}
+	hiddenCount, err := h.externalRepo.CountHiddenUnresolvedTelegram(ctx, source)
+	if err != nil {
+		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to count hidden candidates", err.Error())
 		return
 	}
 
@@ -214,6 +220,7 @@ func (h *ImportHandler) ListImportCandidates(c *gin.Context) {
 	}
 
 	api.SendSuccess(c, http.StatusOK, paginatedCandidates, &api.Meta{
+		HiddenUnresolvedTelegramCount: hiddenCount,
 		Pagination: &api.PaginationMeta{
 			Page:  page,
 			Limit: limit,

--- a/backend/internal/api/handlers/import_suggestions.go
+++ b/backend/internal/api/handlers/import_suggestions.go
@@ -42,6 +42,10 @@ func NewSuggestionHandler(suggestionSvc *service.SuggestionService) *SuggestionH
 	return &SuggestionHandler{suggestionSvc: suggestionSvc}
 }
 
+func includeUnresolvedTelegramParam(c *gin.Context) bool {
+	return c.Query("include_unresolved_telegram") == "true"
+}
+
 // MethodSuggestionResponse is the method-kind queue entry. Methods are the
 // pending (type, normalized-value) pairs displayable for confirmation.
 type MethodSuggestionResponse struct {
@@ -104,9 +108,10 @@ func (h *SuggestionHandler) ListSuggestions(c *gin.Context) {
 	}
 
 	list, err := h.suggestionSvc.ListSuggestions(ctx, service.SuggestionListParams{
-		Source: c.Query("source"),
-		Page:   page,
-		Limit:  limit,
+		Source:                    c.Query("source"),
+		Page:                      page,
+		Limit:                     limit,
+		IncludeUnresolvedTelegram: includeUnresolvedTelegramParam(c),
 	}, MaxCandidatesForSorting)
 	if err != nil {
 		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to list suggestions", err.Error())
@@ -133,6 +138,7 @@ func (h *SuggestionHandler) ListSuggestions(c *gin.Context) {
 	}
 
 	api.SendSuccess(c, http.StatusOK, items, &api.Meta{
+		HiddenUnresolvedTelegramCount: list.HiddenUnresolvedTelegramCount,
 		Pagination: &api.PaginationMeta{
 			Page:  list.Page,
 			Limit: list.Limit,

--- a/backend/internal/api/response.go
+++ b/backend/internal/api/response.go
@@ -23,7 +23,8 @@ type APIError struct {
 
 // Meta represents metadata for responses (pagination, etc.)
 type Meta struct {
-	Pagination *PaginationMeta `json:"pagination,omitempty"`
+	Pagination                    *PaginationMeta `json:"pagination,omitempty"`
+	HiddenUnresolvedTelegramCount int64           `json:"hidden_unresolved_telegram_count,omitempty"`
 }
 
 // PaginationMeta represents pagination metadata

--- a/backend/internal/db/external_contact.sql.go
+++ b/backend/internal/db/external_contact.sql.go
@@ -17,10 +17,44 @@ WHERE match_status = 'unmatched'
   AND source != 'anarlog_title'
   AND duplicate_of_id IS NULL
   AND deleted_at IS NULL
+  AND (
+    $1::bool
+    OR NOT (
+      source = 'telegram'
+      AND NULLIF(BTRIM(COALESCE(display_name, '')), '') IS NULL
+      AND NULLIF(BTRIM(COALESCE(first_name, '')), '') IS NULL
+      AND NULLIF(BTRIM(COALESCE(last_name, '')), '') IS NULL
+      AND NULLIF(BTRIM(COALESCE(metadata->>'username', '')), '') IS NULL
+      AND COALESCE(jsonb_array_length(emails), 0) = 0
+      AND COALESCE(jsonb_array_length(phones), 0) = 0
+    )
+  )
 `
 
-func (q *Queries) CountAllUnmatchedExternalContacts(ctx context.Context) (int64, error) {
-	row := q.db.QueryRow(ctx, CountAllUnmatchedExternalContacts)
+func (q *Queries) CountAllUnmatchedExternalContacts(ctx context.Context, includeUnresolvedTelegram bool) (int64, error) {
+	row := q.db.QueryRow(ctx, CountAllUnmatchedExternalContacts, includeUnresolvedTelegram)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const CountHiddenUnresolvedTelegramContacts = `-- name: CountHiddenUnresolvedTelegramContacts :one
+SELECT COUNT(*) FROM external_contact
+WHERE source = 'telegram'
+  AND ($1::text = '' OR source = $1::text)
+  AND match_status = 'unmatched'
+  AND duplicate_of_id IS NULL
+  AND deleted_at IS NULL
+  AND NULLIF(BTRIM(COALESCE(display_name, '')), '') IS NULL
+  AND NULLIF(BTRIM(COALESCE(first_name, '')), '') IS NULL
+  AND NULLIF(BTRIM(COALESCE(last_name, '')), '') IS NULL
+  AND NULLIF(BTRIM(COALESCE(metadata->>'username', '')), '') IS NULL
+  AND COALESCE(jsonb_array_length(emails), 0) = 0
+  AND COALESCE(jsonb_array_length(phones), 0) = 0
+`
+
+func (q *Queries) CountHiddenUnresolvedTelegramContacts(ctx context.Context, sourceFilter string) (int64, error) {
+	row := q.db.QueryRow(ctx, CountHiddenUnresolvedTelegramContacts, sourceFilter)
 	var count int64
 	err := row.Scan(&count)
 	return count, err
@@ -33,13 +67,30 @@ WHERE source = $1
   AND match_status = 'unmatched'
   AND duplicate_of_id IS NULL
   AND deleted_at IS NULL
+  AND (
+    $2::bool
+    OR NOT (
+      source = 'telegram'
+      AND NULLIF(BTRIM(COALESCE(display_name, '')), '') IS NULL
+      AND NULLIF(BTRIM(COALESCE(first_name, '')), '') IS NULL
+      AND NULLIF(BTRIM(COALESCE(last_name, '')), '') IS NULL
+      AND NULLIF(BTRIM(COALESCE(metadata->>'username', '')), '') IS NULL
+      AND COALESCE(jsonb_array_length(emails), 0) = 0
+      AND COALESCE(jsonb_array_length(phones), 0) = 0
+    )
+  )
 `
+
+type CountUnmatchedExternalContactsParams struct {
+	Source                    string `json:"source"`
+	IncludeUnresolvedTelegram bool   `json:"include_unresolved_telegram"`
+}
 
 // Per-source count; mirrors ListUnmatched's anarlog_title exclusion
 // so list+count cardinality stays consistent regardless of caller-
 // supplied source.
-func (q *Queries) CountUnmatchedExternalContacts(ctx context.Context, source string) (int64, error) {
-	row := q.db.QueryRow(ctx, CountUnmatchedExternalContacts, source)
+func (q *Queries) CountUnmatchedExternalContacts(ctx context.Context, arg CountUnmatchedExternalContactsParams) (int64, error) {
+	row := q.db.QueryRow(ctx, CountUnmatchedExternalContacts, arg.Source, arg.IncludeUnresolvedTelegram)
 	var count int64
 	err := row.Scan(&count)
 	return count, err
@@ -617,17 +668,30 @@ WHERE match_status = 'unmatched'
   AND source != 'anarlog_title'
   AND duplicate_of_id IS NULL
   AND deleted_at IS NULL
+  AND (
+    $1::bool
+    OR NOT (
+      source = 'telegram'
+      AND NULLIF(BTRIM(COALESCE(display_name, '')), '') IS NULL
+      AND NULLIF(BTRIM(COALESCE(first_name, '')), '') IS NULL
+      AND NULLIF(BTRIM(COALESCE(last_name, '')), '') IS NULL
+      AND NULLIF(BTRIM(COALESCE(metadata->>'username', '')), '') IS NULL
+      AND COALESCE(jsonb_array_length(emails), 0) = 0
+      AND COALESCE(jsonb_array_length(phones), 0) = 0
+    )
+  )
 ORDER BY source, display_name
-LIMIT $1 OFFSET $2
+LIMIT $3 OFFSET $2
 `
 
 type ListAllUnmatchedExternalContactsParams struct {
-	Limit  int32 `json:"limit"`
-	Offset int32 `json:"offset"`
+	IncludeUnresolvedTelegram bool  `json:"include_unresolved_telegram"`
+	PageOffset                int32 `json:"page_offset"`
+	PageLimit                 int32 `json:"page_limit"`
 }
 
 func (q *Queries) ListAllUnmatchedExternalContacts(ctx context.Context, arg ListAllUnmatchedExternalContactsParams) ([]*ExternalContact, error) {
-	rows, err := q.db.Query(ctx, ListAllUnmatchedExternalContacts, arg.Limit, arg.Offset)
+	rows, err := q.db.Query(ctx, ListAllUnmatchedExternalContacts, arg.IncludeUnresolvedTelegram, arg.PageOffset, arg.PageLimit)
 	if err != nil {
 		return nil, err
 	}
@@ -1184,14 +1248,27 @@ WHERE source = $1
   AND match_status = 'unmatched'
   AND duplicate_of_id IS NULL
   AND deleted_at IS NULL
+  AND (
+    $2::bool
+    OR NOT (
+      source = 'telegram'
+      AND NULLIF(BTRIM(COALESCE(display_name, '')), '') IS NULL
+      AND NULLIF(BTRIM(COALESCE(first_name, '')), '') IS NULL
+      AND NULLIF(BTRIM(COALESCE(last_name, '')), '') IS NULL
+      AND NULLIF(BTRIM(COALESCE(metadata->>'username', '')), '') IS NULL
+      AND COALESCE(jsonb_array_length(emails), 0) = 0
+      AND COALESCE(jsonb_array_length(phones), 0) = 0
+    )
+  )
 ORDER BY display_name
-LIMIT $2 OFFSET $3
+LIMIT $4 OFFSET $3
 `
 
 type ListUnmatchedExternalContactsParams struct {
-	Source string `json:"source"`
-	Limit  int32  `json:"limit"`
-	Offset int32  `json:"offset"`
+	Source                    string `json:"source"`
+	IncludeUnresolvedTelegram bool   `json:"include_unresolved_telegram"`
+	PageOffset                int32  `json:"page_offset"`
+	PageLimit                 int32  `json:"page_limit"`
 }
 
 // Per-source query; anarlog_title rows are intentionally NOT exposed
@@ -1201,7 +1278,12 @@ type ListUnmatchedExternalContactsParams struct {
 // injection), this query returns empty rather than leaking weak
 // discovery rows into the per-source UI.
 func (q *Queries) ListUnmatchedExternalContacts(ctx context.Context, arg ListUnmatchedExternalContactsParams) ([]*ExternalContact, error) {
-	rows, err := q.db.Query(ctx, ListUnmatchedExternalContacts, arg.Source, arg.Limit, arg.Offset)
+	rows, err := q.db.Query(ctx, ListUnmatchedExternalContacts,
+		arg.Source,
+		arg.IncludeUnresolvedTelegram,
+		arg.PageOffset,
+		arg.PageLimit,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -106,7 +106,7 @@ type Querier interface {
 	// FOR UPDATE retained below re-takes the held lock; the load-bearing
 	// serialization is the prior LockContactForDateRecompute statement).
 	ComputeContactDatesAfterDelete(ctx context.Context, arg ComputeContactDatesAfterDeleteParams) (*ComputeContactDatesAfterDeleteRow, error)
-	CountAllUnmatchedExternalContacts(ctx context.Context) (int64, error)
+	CountAllUnmatchedExternalContacts(ctx context.Context, includeUnresolvedTelegram bool) (int64, error)
 	CountContactInteractions(ctx context.Context, contactID pgtype.UUID) (int64, error)
 	CountContactNotes(ctx context.Context, contactID pgtype.UUID) (int64, error)
 	CountContactTasksByProvider(ctx context.Context, arg CountContactTasksByProviderParams) (int64, error)
@@ -126,6 +126,7 @@ type Querier interface {
 	//   - duplicate_of_id IS NULL: excludes merge-dupe rows that the import
 	//     UI doesn't surface.
 	CountExternalContactsByHostAndSource(ctx context.Context, hostID pgtype.UUID) ([]*CountExternalContactsByHostAndSourceRow, error)
+	CountHiddenUnresolvedTelegramContacts(ctx context.Context, sourceFilter string) (int64, error)
 	CountIdentitiesBySource(ctx context.Context, source string) (int64, error)
 	// Counts river_job rows that represent an in-flight SyncProviderAccountJob
 	// for the given (source, account_id). Used by
@@ -189,7 +190,7 @@ type Querier interface {
 	// Per-source count; mirrors ListUnmatched's anarlog_title exclusion
 	// so list+count cardinality stays consistent regardless of caller-
 	// supplied source.
-	CountUnmatchedExternalContacts(ctx context.Context, source string) (int64, error)
+	CountUnmatchedExternalContacts(ctx context.Context, arg CountUnmatchedExternalContactsParams) (int64, error)
 	CountUnmatchedIdentities(ctx context.Context) (int64, error)
 	// Counts messages about to be linked for a given peer. Read BEFORE
 	// OnPeerLinked so the matched-count reporting observes the pre-link state.

--- a/backend/internal/db/queries/external_contact.sql
+++ b/backend/internal/db/queries/external_contact.sql
@@ -148,13 +148,25 @@ LIMIT $3 OFFSET $4;
 -- injection), this query returns empty rather than leaking weak
 -- discovery rows into the per-source UI.
 SELECT * FROM external_contact
-WHERE source = $1
+WHERE source = sqlc.arg('source')
   AND source != 'anarlog_title'
   AND match_status = 'unmatched'
   AND duplicate_of_id IS NULL
   AND deleted_at IS NULL
+  AND (
+    sqlc.arg('include_unresolved_telegram')::bool
+    OR NOT (
+      source = 'telegram'
+      AND NULLIF(BTRIM(COALESCE(display_name, '')), '') IS NULL
+      AND NULLIF(BTRIM(COALESCE(first_name, '')), '') IS NULL
+      AND NULLIF(BTRIM(COALESCE(last_name, '')), '') IS NULL
+      AND NULLIF(BTRIM(COALESCE(metadata->>'username', '')), '') IS NULL
+      AND COALESCE(jsonb_array_length(emails), 0) = 0
+      AND COALESCE(jsonb_array_length(phones), 0) = 0
+    )
+  )
 ORDER BY display_name
-LIMIT $2 OFFSET $3;
+LIMIT sqlc.arg('page_limit') OFFSET sqlc.arg('page_offset');
 
 -- name: ListAllUnmatchedExternalContacts :many
 SELECT * FROM external_contact
@@ -162,26 +174,76 @@ WHERE match_status = 'unmatched'
   AND source != 'anarlog_title'
   AND duplicate_of_id IS NULL
   AND deleted_at IS NULL
+  AND (
+    sqlc.arg('include_unresolved_telegram')::bool
+    OR NOT (
+      source = 'telegram'
+      AND NULLIF(BTRIM(COALESCE(display_name, '')), '') IS NULL
+      AND NULLIF(BTRIM(COALESCE(first_name, '')), '') IS NULL
+      AND NULLIF(BTRIM(COALESCE(last_name, '')), '') IS NULL
+      AND NULLIF(BTRIM(COALESCE(metadata->>'username', '')), '') IS NULL
+      AND COALESCE(jsonb_array_length(emails), 0) = 0
+      AND COALESCE(jsonb_array_length(phones), 0) = 0
+    )
+  )
 ORDER BY source, display_name
-LIMIT $1 OFFSET $2;
+LIMIT sqlc.arg('page_limit') OFFSET sqlc.arg('page_offset');
 
 -- name: CountUnmatchedExternalContacts :one
 -- Per-source count; mirrors ListUnmatched's anarlog_title exclusion
 -- so list+count cardinality stays consistent regardless of caller-
 -- supplied source.
 SELECT COUNT(*) FROM external_contact
-WHERE source = $1
+WHERE source = sqlc.arg('source')
   AND source != 'anarlog_title'
   AND match_status = 'unmatched'
   AND duplicate_of_id IS NULL
-  AND deleted_at IS NULL;
+  AND deleted_at IS NULL
+  AND (
+    sqlc.arg('include_unresolved_telegram')::bool
+    OR NOT (
+      source = 'telegram'
+      AND NULLIF(BTRIM(COALESCE(display_name, '')), '') IS NULL
+      AND NULLIF(BTRIM(COALESCE(first_name, '')), '') IS NULL
+      AND NULLIF(BTRIM(COALESCE(last_name, '')), '') IS NULL
+      AND NULLIF(BTRIM(COALESCE(metadata->>'username', '')), '') IS NULL
+      AND COALESCE(jsonb_array_length(emails), 0) = 0
+      AND COALESCE(jsonb_array_length(phones), 0) = 0
+    )
+  );
 
 -- name: CountAllUnmatchedExternalContacts :one
 SELECT COUNT(*) FROM external_contact
 WHERE match_status = 'unmatched'
   AND source != 'anarlog_title'
   AND duplicate_of_id IS NULL
-  AND deleted_at IS NULL;
+  AND deleted_at IS NULL
+  AND (
+    sqlc.arg('include_unresolved_telegram')::bool
+    OR NOT (
+      source = 'telegram'
+      AND NULLIF(BTRIM(COALESCE(display_name, '')), '') IS NULL
+      AND NULLIF(BTRIM(COALESCE(first_name, '')), '') IS NULL
+      AND NULLIF(BTRIM(COALESCE(last_name, '')), '') IS NULL
+      AND NULLIF(BTRIM(COALESCE(metadata->>'username', '')), '') IS NULL
+      AND COALESCE(jsonb_array_length(emails), 0) = 0
+      AND COALESCE(jsonb_array_length(phones), 0) = 0
+    )
+  );
+
+-- name: CountHiddenUnresolvedTelegramContacts :one
+SELECT COUNT(*) FROM external_contact
+WHERE source = 'telegram'
+  AND (sqlc.arg('source_filter')::text = '' OR source = sqlc.arg('source_filter')::text)
+  AND match_status = 'unmatched'
+  AND duplicate_of_id IS NULL
+  AND deleted_at IS NULL
+  AND NULLIF(BTRIM(COALESCE(display_name, '')), '') IS NULL
+  AND NULLIF(BTRIM(COALESCE(first_name, '')), '') IS NULL
+  AND NULLIF(BTRIM(COALESCE(last_name, '')), '') IS NULL
+  AND NULLIF(BTRIM(COALESCE(metadata->>'username', '')), '') IS NULL
+  AND COALESCE(jsonb_array_length(emails), 0) = 0
+  AND COALESCE(jsonb_array_length(phones), 0) = 0;
 
 -- name: UpdateExternalContactMatch :one
 -- Filter `deleted_at IS NULL` so a tombstoned row cannot have its

--- a/backend/internal/repository/external_contact.go
+++ b/backend/internal/repository/external_contact.go
@@ -571,12 +571,13 @@ func (r *ExternalContactRepository) UpsertTelegramDiscoveryCandidate(
 	return convertDbExternalContact(dbContact)
 }
 
-// ListUnmatched returns unmatched external contacts for a source
-func (r *ExternalContactRepository) ListUnmatched(ctx context.Context, source string, limit, offset int32) ([]ExternalContact, error) {
+// ListUnmatched returns unmatched external contacts for a source.
+func (r *ExternalContactRepository) ListUnmatched(ctx context.Context, source string, limit, offset int32, includeUnresolvedTelegram bool) ([]ExternalContact, error) {
 	dbContacts, err := r.queries.ListUnmatchedExternalContacts(ctx, db.ListUnmatchedExternalContactsParams{
-		Source: source,
-		Limit:  limit,
-		Offset: offset,
+		Source:                    source,
+		IncludeUnresolvedTelegram: includeUnresolvedTelegram,
+		PageLimit:                 limit,
+		PageOffset:                offset,
 	})
 	if err != nil {
 		return nil, err
@@ -593,11 +594,12 @@ func (r *ExternalContactRepository) ListUnmatched(ctx context.Context, source st
 	return contacts, nil
 }
 
-// ListAllUnmatched returns all unmatched external contacts across sources
-func (r *ExternalContactRepository) ListAllUnmatched(ctx context.Context, limit, offset int32) ([]ExternalContact, error) {
+// ListAllUnmatched returns all unmatched external contacts across sources.
+func (r *ExternalContactRepository) ListAllUnmatched(ctx context.Context, limit, offset int32, includeUnresolvedTelegram bool) ([]ExternalContact, error) {
 	dbContacts, err := r.queries.ListAllUnmatchedExternalContacts(ctx, db.ListAllUnmatchedExternalContactsParams{
-		Limit:  limit,
-		Offset: offset,
+		IncludeUnresolvedTelegram: includeUnresolvedTelegram,
+		PageLimit:                 limit,
+		PageOffset:                offset,
 	})
 	if err != nil {
 		return nil, err
@@ -614,14 +616,24 @@ func (r *ExternalContactRepository) ListAllUnmatched(ctx context.Context, limit,
 	return contacts, nil
 }
 
-// CountUnmatched returns the count of unmatched contacts for a source
-func (r *ExternalContactRepository) CountUnmatched(ctx context.Context, source string) (int64, error) {
-	return r.queries.CountUnmatchedExternalContacts(ctx, source)
+// CountUnmatched returns the count of unmatched contacts for a source.
+func (r *ExternalContactRepository) CountUnmatched(ctx context.Context, source string, includeUnresolvedTelegram bool) (int64, error) {
+	return r.queries.CountUnmatchedExternalContacts(ctx, db.CountUnmatchedExternalContactsParams{
+		Source:                    source,
+		IncludeUnresolvedTelegram: includeUnresolvedTelegram,
+	})
 }
 
-// CountAllUnmatched returns the count of all unmatched contacts
-func (r *ExternalContactRepository) CountAllUnmatched(ctx context.Context) (int64, error) {
-	return r.queries.CountAllUnmatchedExternalContacts(ctx)
+// CountAllUnmatched returns the count of all unmatched contacts.
+func (r *ExternalContactRepository) CountAllUnmatched(ctx context.Context, includeUnresolvedTelegram bool) (int64, error) {
+	return r.queries.CountAllUnmatchedExternalContacts(ctx, includeUnresolvedTelegram)
+}
+
+// CountHiddenUnresolvedTelegram returns the number of unresolved Telegram
+// candidates hidden by default for the given source filter. Empty source
+// means all sources; non-Telegram sources naturally return zero.
+func (r *ExternalContactRepository) CountHiddenUnresolvedTelegram(ctx context.Context, source string) (int64, error) {
+	return r.queries.CountHiddenUnresolvedTelegramContacts(ctx, source)
 }
 
 // UpdateMatch updates the CRM contact ID and match status. Returns

--- a/backend/internal/service/import_suggestions.go
+++ b/backend/internal/service/import_suggestions.go
@@ -84,21 +84,23 @@ type MethodSuggestionItem struct {
 // BOTH the method group and the candidate group; Page/Limit paginate the
 // candidate group only (the method group rides above the fold on page 1).
 type SuggestionListParams struct {
-	Source string
-	Page   int
-	Limit  int
+	Source                    string
+	Page                      int
+	Limit                     int
+	IncludeUnresolvedTelegram bool
 }
 
 // SuggestionList is the composed read-model: the method-suggestion group
 // (page 1 only) plus the page's slice of confidence-ranked candidates, with
 // candidate-group pagination meta.
 type SuggestionList struct {
-	Methods        []MethodSuggestionItem
-	Candidates     []CandidateWithMatch
-	CandidateTotal int
-	Page           int
-	Limit          int
-	Pages          int
+	Methods                       []MethodSuggestionItem
+	Candidates                    []CandidateWithMatch
+	CandidateTotal                int
+	HiddenUnresolvedTelegramCount int64
+	Page                          int
+	Limit                         int
+	Pages                         int
 }
 
 // ResolveResult is the outcome of confirming pending methods. Applied is
@@ -122,8 +124,9 @@ type DismissResult struct {
 // matching the rest of the service package's composition style.
 type suggestionExternalRepo interface {
 	GetByID(ctx context.Context, id uuid.UUID) (*repository.ExternalContact, error)
-	ListUnmatched(ctx context.Context, source string, limit, offset int32) ([]repository.ExternalContact, error)
-	ListAllUnmatched(ctx context.Context, limit, offset int32) ([]repository.ExternalContact, error)
+	ListUnmatched(ctx context.Context, source string, limit, offset int32, includeUnresolvedTelegram bool) ([]repository.ExternalContact, error)
+	ListAllUnmatched(ctx context.Context, limit, offset int32, includeUnresolvedTelegram bool) ([]repository.ExternalContact, error)
+	CountHiddenUnresolvedTelegram(ctx context.Context, source string) (int64, error)
 	ListPendingMethodSuggestionRows(ctx context.Context, sourceFilter string) ([]repository.PendingMethodSuggestionRow, error)
 	ResolveReconcileTarget(ctx context.Context, id uuid.UUID) (*repository.ReconcileTarget, error)
 	GetForUpdateTx(ctx context.Context, tx pgx.Tx, id uuid.UUID) (*repository.ExternalContact, error)
@@ -199,13 +202,13 @@ func NewSuggestionService(
 // match, and sorts by confidence descending, then alphabetically by display
 // name (empty names last). This is the SINGLE sort implementation shared by
 // the existing /imports/candidates handler and the suggestions surface.
-func (s *SuggestionService) BuildSortedCandidates(ctx context.Context, source string, maxCandidates int32) ([]CandidateWithMatch, error) {
+func (s *SuggestionService) BuildSortedCandidates(ctx context.Context, source string, maxCandidates int32, includeUnresolvedTelegram bool) ([]CandidateWithMatch, error) {
 	var contacts []repository.ExternalContact
 	var err error
 	if source != "" {
-		contacts, err = s.externalRepo.ListUnmatched(ctx, source, maxCandidates, 0)
+		contacts, err = s.externalRepo.ListUnmatched(ctx, source, maxCandidates, 0, includeUnresolvedTelegram)
 	} else {
-		contacts, err = s.externalRepo.ListAllUnmatched(ctx, maxCandidates, 0)
+		contacts, err = s.externalRepo.ListAllUnmatched(ctx, maxCandidates, 0, includeUnresolvedTelegram)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("list unmatched candidates: %w", err)
@@ -291,9 +294,13 @@ func (s *SuggestionService) ListSuggestions(ctx context.Context, params Suggesti
 	}
 
 	// Candidate group: shared sorted build, then paginate.
-	candidates, err := s.BuildSortedCandidates(ctx, params.Source, maxCandidates)
+	candidates, err := s.BuildSortedCandidates(ctx, params.Source, maxCandidates, params.IncludeUnresolvedTelegram)
 	if err != nil {
 		return SuggestionList{}, err
+	}
+	hiddenCount, err := s.externalRepo.CountHiddenUnresolvedTelegram(ctx, params.Source)
+	if err != nil {
+		return SuggestionList{}, fmt.Errorf("count hidden unresolved telegram candidates: %w", err)
 	}
 	total := len(candidates)
 	offset := (page - 1) * limit
@@ -320,12 +327,13 @@ func (s *SuggestionService) ListSuggestions(ctx context.Context, params Suggesti
 	}
 
 	return SuggestionList{
-		Methods:        methods,
-		Candidates:     pageCandidates,
-		CandidateTotal: total,
-		Page:           page,
-		Limit:          limit,
-		Pages:          pages,
+		Methods:                       methods,
+		Candidates:                    pageCandidates,
+		CandidateTotal:                total,
+		HiddenUnresolvedTelegramCount: hiddenCount,
+		Page:                          page,
+		Limit:                         limit,
+		Pages:                         pages,
 	}, nil
 }
 

--- a/backend/tests/api/meeting_note_ingest_test.go
+++ b/backend/tests/api/meeting_note_ingest_test.go
@@ -2229,7 +2229,7 @@ func TestMeetingNote_TitleMatch_CountQueryExcludesAnarlogTitle(t *testing.T) {
 	// depth `source != 'anarlog_title'` filter zeroes out every row
 	// regardless of what other tests in the shared DB are doing. True
 	// invariant assertion, resistant to parallel test pollution.
-	srcCount, err := env.externalRepo.CountUnmatched(ctx, "anarlog_title")
+	srcCount, err := env.externalRepo.CountUnmatched(ctx, "anarlog_title", false)
 	require.NoError(t, err)
 	require.Equal(t, int64(0), srcCount,
 		"CountUnmatched(anarlog_title) MUST be 0 — filter excludes all rows")
@@ -2241,7 +2241,7 @@ func TestMeetingNote_TitleMatch_CountQueryExcludesAnarlogTitle(t *testing.T) {
 		"the raw row exists in external_contact (sanity check)")
 
 	// Per-source list MUST be empty (filter excludes all anarlog_title rows).
-	imports, err := env.externalRepo.ListUnmatched(ctx, "anarlog_title", 100, 0)
+	imports, err := env.externalRepo.ListUnmatched(ctx, "anarlog_title", 100, 0, false)
 	require.NoError(t, err)
 	require.Empty(t, imports,
 		"ListUnmatched(anarlog_title) MUST be empty — filter excludes all rows")
@@ -2252,7 +2252,7 @@ func TestMeetingNote_TitleMatch_CountQueryExcludesAnarlogTitle(t *testing.T) {
 	sid, err := uuid.Parse(sessionUUID)
 	require.NoError(t, err)
 	wroteSourceID := computeTestAnarlogTitleSourceID(strings.ToLower(tokenJ), sid)
-	allImports, err := env.externalRepo.ListAllUnmatched(ctx, 1000, 0)
+	allImports, err := env.externalRepo.ListAllUnmatched(ctx, 1000, 0, false)
 	require.NoError(t, err)
 	for _, row := range allImports {
 		require.NotEqual(t, "anarlog_title", row.Source,
@@ -2260,7 +2260,7 @@ func TestMeetingNote_TitleMatch_CountQueryExcludesAnarlogTitle(t *testing.T) {
 		require.NotEqual(t, wroteSourceID, row.SourceID,
 			"ListAllUnmatched MUST NOT include our specific anarlog_title row")
 	}
-	allCount, err := env.externalRepo.CountAllUnmatched(ctx)
+	allCount, err := env.externalRepo.CountAllUnmatched(ctx, false)
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, allCount, int64(0))
 	require.LessOrEqual(t, allCount, int64(len(allImports))+50,

--- a/backend/tests/external_contact_soft_delete_sweep_test.go
+++ b/backend/tests/external_contact_soft_delete_sweep_test.go
@@ -196,7 +196,7 @@ func TestExternalContactSweep_ListUnmatched_FiltersTombstone(t *testing.T) {
 		_ = database.Queries.TestDeleteExternalContactsBySourceIDPrefix(cleanCtx, prefix)
 	})
 
-	listed, err := repo.ListUnmatched(ctx, "gcontacts", 1000, 0)
+	listed, err := repo.ListUnmatched(ctx, "gcontacts", 1000, 0, false)
 	require.NoError(t, err)
 	foundLive := false
 	for _, r := range listed {
@@ -243,7 +243,7 @@ func TestExternalContactSweep_ListAllUnmatched_FiltersTombstone(t *testing.T) {
 		_ = database.Queries.TestDeleteExternalContactsBySourceIDPrefix(cleanCtx, prefix)
 	})
 
-	listed, err := repo.ListAllUnmatched(ctx, 1000, 0)
+	listed, err := repo.ListAllUnmatched(ctx, 1000, 0, false)
 	require.NoError(t, err)
 	foundLive := false
 	for _, r := range listed {
@@ -296,9 +296,87 @@ func TestExternalContactSweep_CountUnmatched_ExcludesTombstone(t *testing.T) {
 		_ = database.Queries.TestDeleteExternalContactsBySourceIDPrefix(cleanCtx, prefix)
 	})
 
-	count, err := repo.CountUnmatched(ctx, source)
+	count, err := repo.CountUnmatched(ctx, source, false)
 	require.NoError(t, err)
 	require.Equal(t, int64(2), count, "tombstoned row must not be counted")
+}
+
+func TestExternalContactUnmatched_HidesUnresolvedTelegramByDefault(t *testing.T) {
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+	ctx := context.Background()
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	t.Cleanup(func() { database.Close() })
+
+	repo := repository.NewExternalContactRepository(database.Queries)
+	prefix := "tg-hidden-" + uuid.NewString()[:8] + "-"
+	syncedAt := accelerated.GetCurrentTime()
+	t.Cleanup(func() {
+		cleanCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_ = database.Queries.TestDeleteExternalContactsBySourceIDPrefix(cleanCtx, prefix)
+	})
+
+	hidden, err := repo.Upsert(ctx, repository.UpsertExternalContactRequest{
+		Source:   "telegram",
+		SourceID: prefix + "hidden",
+		SyncedAt: &syncedAt,
+	})
+	require.NoError(t, err)
+	withUsername, err := repo.Upsert(ctx, repository.UpsertExternalContactRequest{
+		Source:   "telegram",
+		SourceID: prefix + "username",
+		Metadata: map[string]any{"username": "@visible"},
+		SyncedAt: &syncedAt,
+	})
+	require.NoError(t, err)
+	displayName := "Visible Telegram"
+	withName, err := repo.Upsert(ctx, repository.UpsertExternalContactRequest{
+		Source:      "telegram",
+		SourceID:    prefix + "name",
+		DisplayName: &displayName,
+		SyncedAt:    &syncedAt,
+	})
+	require.NoError(t, err)
+	withEmail, err := repo.Upsert(ctx, repository.UpsertExternalContactRequest{
+		Source:   "telegram",
+		SourceID: prefix + "email",
+		Emails:   []repository.EmailEntry{{Value: prefix + "visible@example.invalid"}},
+		SyncedAt: &syncedAt,
+	})
+	require.NoError(t, err)
+
+	defaultRows, err := repo.ListUnmatched(ctx, "telegram", 1000, 0, false)
+	require.NoError(t, err)
+	defaultIDs := externalIDs(defaultRows)
+	require.NotContains(t, defaultIDs, hidden.ID)
+	require.Contains(t, defaultIDs, withUsername.ID)
+	require.Contains(t, defaultIDs, withName.ID)
+	require.Contains(t, defaultIDs, withEmail.ID)
+
+	includedRows, err := repo.ListUnmatched(ctx, "telegram", 1000, 0, true)
+	require.NoError(t, err)
+	require.Contains(t, externalIDs(includedRows), hidden.ID)
+
+	hiddenCount, err := repo.CountHiddenUnresolvedTelegram(ctx, "telegram")
+	require.NoError(t, err)
+	require.Equal(t, int64(1), hiddenCount)
+	hiddenCountAll, err := repo.CountHiddenUnresolvedTelegram(ctx, "")
+	require.NoError(t, err)
+	require.Equal(t, int64(1), hiddenCountAll)
+	hiddenCountOther, err := repo.CountHiddenUnresolvedTelegram(ctx, "gcontacts")
+	require.NoError(t, err)
+	require.Equal(t, int64(0), hiddenCountOther)
+
+	hiddenAfterList, err := repo.GetByID(ctx, hidden.ID)
+	require.NoError(t, err)
+	require.NotNil(t, hiddenAfterList)
+	require.Equal(t, repository.MatchStatusUnmatched, hiddenAfterList.MatchStatus)
 }
 
 func TestExternalContactSweep_FindByNormalizedEmail_FiltersTombstone(t *testing.T) {
@@ -362,6 +440,14 @@ func TestExternalContactSweep_ListForCRMContact_FiltersTombstone(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, results, 1, "tombstoned external_contact must not surface in ListForCRMContact")
 	require.Equal(t, live.ID, results[0].ID)
+}
+
+func externalIDs(rows []repository.ExternalContact) map[uuid.UUID]bool {
+	out := make(map[uuid.UUID]bool, len(rows))
+	for _, row := range rows {
+		out[row.ID] = true
+	}
+	return out
 }
 
 func TestExternalContactSweep_RoundTrip_ReviveAfterSoftDelete(t *testing.T) {

--- a/frontend/src/app/imports/__tests__/page.test.tsx
+++ b/frontend/src/app/imports/__tests__/page.test.tsx
@@ -35,6 +35,19 @@ vi.mock('@/hooks/use-interactions-queue', () => ({
   useResolveNameCandidate: vi.fn(),
 }))
 
+vi.mock('@/lib/imports-api', () => ({
+  importsApi: {
+    getSuggestions: vi.fn().mockResolvedValue({
+      items: [],
+      total: 0,
+      page: 1,
+      limit: 20,
+      pages: 0,
+      hidden_unresolved_telegram_count: 0,
+    }),
+  },
+}))
+
 vi.mock('@/components/layout/navigation', () => ({
   Navigation: () => <div>Navigation</div>,
 }))
@@ -96,13 +109,20 @@ function mockInteractionsQueueDefaults() {
  * existing assertions on candidate rendering keep working. */
 function setListData(
   candidates: any[],
-  meta: { total?: number; page?: number; limit?: number; pages?: number } = {}
+  meta: {
+    total?: number
+    page?: number
+    limit?: number
+    pages?: number
+    hidden_unresolved_telegram_count?: number
+  } = {}
 ) {
   const m = {
     total: meta.total ?? candidates.length,
     page: meta.page ?? 1,
     limit: meta.limit ?? 20,
     pages: meta.pages ?? 1,
+    hidden_unresolved_telegram_count: meta.hidden_unresolved_telegram_count ?? 0,
   }
   vi.mocked(useSuggestions).mockReturnValue({
     data: {
@@ -245,6 +265,32 @@ describe('ImportsPage - Suggested Matches', () => {
     render(<ImportsPage />, { wrapper: createWrapper() })
 
     expect(screen.getByRole('button', { name: 'Link (select)' })).toBeInTheDocument()
+  })
+
+  it('toggles unresolved Telegram visibility for the suggestions query', async () => {
+    const user = userEvent.setup()
+    setListData([], {
+      total: 0,
+      page: 1,
+      limit: 20,
+      pages: 0,
+      hidden_unresolved_telegram_count: 6,
+    })
+
+    render(<ImportsPage />, { wrapper: createWrapper() })
+
+    const toggle = screen.getByRole('switch', {
+      name: 'Show unresolved (6)',
+    })
+    expect(toggle).toHaveAttribute('aria-checked', 'false')
+
+    await user.click(toggle)
+
+    expect(useSuggestions).toHaveBeenLastCalledWith({
+      page: 1,
+      limit: 20,
+      include_unresolved_telegram: true,
+    })
   })
 
   it('displays candidates with matches before those without', () => {

--- a/frontend/src/app/imports/page.tsx
+++ b/frontend/src/app/imports/page.tsx
@@ -2,6 +2,7 @@
 
 import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
+import { useQueryClient } from '@tanstack/react-query'
 import {
   RefreshCw,
   Mail,
@@ -39,8 +40,10 @@ import {
   useResolveNameCandidate,
 } from '@/hooks/use-interactions-queue'
 import { useGoogleAccounts } from '@/hooks/use-google-accounts'
-import { getCandidateDisplayName } from '@/lib/candidate-display'
+import { getCandidateDisplayName, isUnresolvedTelegramCandidate } from '@/lib/candidate-display'
 import { sourceAllowsImport } from '@/lib/candidate-actions'
+import { importsApi } from '@/lib/imports-api'
+import { importKeys } from '@/lib/query-invalidation'
 import type {
   ImportCandidate,
   SuggestionItem,
@@ -151,6 +154,7 @@ function CandidateCard({
   ignoreLoading: boolean
 }) {
   const displayName = getCandidateDisplayName(candidate)
+  const unresolvedTelegram = isUnresolvedTelegramCandidate(candidate)
 
   // Get meeting context for calendar attendees
   const meetingContext =
@@ -228,6 +232,12 @@ function CandidateCard({
                 <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800">
                   <Users className="w-3 h-3 mr-1" />
                   {correspondenceLabel}
+                </span>
+              )}
+              {unresolvedTelegram && (
+                <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800">
+                  <MessageCircle className="w-3 h-3 mr-1" />
+                  Unresolved Telegram peer
                 </span>
               )}
             </div>
@@ -358,6 +368,7 @@ function ImportsPageFallback() {
 function ImportsPageInner() {
   const router = useRouter()
   const searchParams = useSearchParams()
+  const queryClient = useQueryClient()
   const tabParam = searchParams.get('tab')
   const sessionParam = searchParams.get('session')
   const activeTab = normalizeTab(tabParam)
@@ -473,6 +484,7 @@ function ImportsPageInner() {
       candidates: candidateItems,
       initialIndex: index,
       initialMode: mode,
+      includeUnresolvedTelegram: Boolean(params.include_unresolved_telegram),
     })
   }
 
@@ -622,6 +634,31 @@ function ImportsPageInner() {
     }))
   }
 
+  const handleUnresolvedTelegramToggle = () => {
+    setParams(prev => ({
+      ...prev,
+      page: 1,
+      include_unresolved_telegram: !prev.include_unresolved_telegram || undefined,
+    }))
+  }
+
+  useEffect(() => {
+    if (activeTab !== 'people') return
+    if (isLoading || error) return
+    if (params.include_unresolved_telegram) return
+    if ((data?.hidden_unresolved_telegram_count ?? 0) === 0) return
+
+    const nextParams: SuggestionsListParams = {
+      ...params,
+      include_unresolved_telegram: true,
+    }
+    queryClient.prefetchQuery({
+      queryKey: importKeys.suggestions(nextParams),
+      queryFn: () => importsApi.getSuggestions(nextParams),
+      staleTime: 1000 * 60 * 2,
+    })
+  }, [activeTab, data?.hidden_unresolved_telegram_count, error, isLoading, params, queryClient])
+
   // --- Interactions tab: conflict / orphan resolution ---
 
   const handlePickCandidate = async (
@@ -745,7 +782,7 @@ function ImportsPageInner() {
         ) : (
           <>
             {/* Source filter (People tab only) */}
-            <div className="mb-6 flex items-center gap-2">
+            <div className="mb-6 flex flex-wrap items-center gap-2">
               <span className="text-sm text-gray-500">Filter:</span>
               {SOURCE_FILTERS.map(filter => (
                 <button
@@ -760,6 +797,36 @@ function ImportsPageInner() {
                   {filter.label}
                 </button>
               ))}
+              {((data?.hidden_unresolved_telegram_count ?? 0) > 0 ||
+                params.include_unresolved_telegram) && (
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={Boolean(params.include_unresolved_telegram)}
+                  onClick={handleUnresolvedTelegramToggle}
+                  className="mt-2 inline-flex items-center gap-2 text-sm text-gray-600 hover:text-gray-900 sm:mt-0 sm:ml-auto"
+                >
+                  <span
+                    className={`relative inline-flex h-5 w-9 flex-shrink-0 rounded-full transition-colors ${
+                      params.include_unresolved_telegram ? 'bg-blue-600' : 'bg-gray-300'
+                    }`}
+                  >
+                    <span
+                      className={`inline-block h-4 w-4 translate-y-0.5 rounded-full bg-white shadow-sm transition-transform ${
+                        params.include_unresolved_telegram
+                          ? 'translate-x-[18px]'
+                          : 'translate-x-0.5'
+                      }`}
+                    />
+                  </span>
+                  <span>
+                    Show unresolved
+                    {(data?.hidden_unresolved_telegram_count ?? 0) > 0
+                      ? ` (${data?.hidden_unresolved_telegram_count})`
+                      : ''}
+                  </span>
+                </button>
+              )}
             </div>
 
             {/* Error state */}

--- a/frontend/src/components/imports/suggestion-modal.tsx
+++ b/frontend/src/components/imports/suggestion-modal.tsx
@@ -16,7 +16,7 @@ import {
   useImportCandidates,
 } from '@/hooks/use-imports'
 import { detectMethodConflicts, areNamesSimilar } from '@/lib/method-conflict-detection'
-import { getCandidateDisplayName } from '@/lib/candidate-display'
+import { getCandidateDisplayName, isUnresolvedTelegramCandidate } from '@/lib/candidate-display'
 import { getSourceDisplay } from '@/lib/source-display'
 import { sourceAllowsImport } from '@/lib/candidate-actions'
 import type {
@@ -60,6 +60,7 @@ export type SuggestionModalItem =
       candidates: ImportCandidate[]
       initialIndex: number
       initialMode?: 'import' | 'link'
+      includeUnresolvedTelegram?: boolean
     }
   | { kind: 'method'; suggestion: MethodSuggestion }
 
@@ -88,6 +89,7 @@ export function SuggestionModal({ item, onClose, onSuccess, onError }: Suggestio
       candidates={item.candidates}
       initialIndex={item.initialIndex}
       initialMode={item.initialMode}
+      includeUnresolvedTelegram={item.includeUnresolvedTelegram}
       onClose={onClose}
       onSuccess={onSuccess}
       onError={onError}
@@ -102,6 +104,8 @@ interface ContactCandidateResolverProps {
   initialIndex: number
   /** Initial mode - 'import' or 'link' */
   initialMode?: 'import' | 'link'
+  /** Whether unresolved Telegram rows are visible in modal navigation */
+  includeUnresolvedTelegram?: boolean
   /** Callback when modal is closed */
   onClose: () => void
   /** Callback when an action completes successfully */
@@ -123,6 +127,7 @@ function ContactCandidateResolver({
   candidates: initialCandidates,
   initialIndex,
   initialMode = 'import',
+  includeUnresolvedTelegram = false,
   onClose,
   onSuccess,
   onError,
@@ -147,7 +152,11 @@ function ContactCandidateResolver({
 
   // Fetch all candidates for the modal (not limited by page pagination)
   // Note: We need to pass page: 1 explicitly to ensure consistent query params
-  const { data: allCandidatesData, isSuccess } = useImportCandidates({ page: 1, limit: 1000 })
+  const { data: allCandidatesData, isSuccess } = useImportCandidates({
+    page: 1,
+    limit: 1000,
+    include_unresolved_telegram: includeUnresolvedTelegram,
+  })
   // Use fetched data once query succeeds, otherwise fall back to initialCandidates
   const candidates =
     isSuccess && allCandidatesData?.candidates?.length
@@ -156,6 +165,7 @@ function ContactCandidateResolver({
 
   const candidate = candidates[currentIndex]
   const displayName = candidate ? getCandidateDisplayName(candidate) : ''
+  const unresolvedTelegram = candidate ? isUnresolvedTelegramCandidate(candidate) : false
   const sourceInfo = candidate ? getSourceDisplay(candidate.source) : null
   // Link-only sources (e.g. gmail_correspondence) cannot create a new
   // contact. Derived from the source via the shared policy mirror — NOT a
@@ -441,6 +451,10 @@ function ContactCandidateResolver({
     // Validate name
     if (!editedName.trim()) {
       onError('Contact name cannot be empty. Please enter a valid name.')
+      return
+    }
+    if (unresolvedTelegram && editedName.trim() === displayName) {
+      onError('Enter a name before importing this unresolved Telegram peer.')
       return
     }
     const selectedMethods = buildSelectedMethods()

--- a/frontend/src/hooks/use-suggestions.ts
+++ b/frontend/src/hooks/use-suggestions.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from '@tanstack/react-query'
+import { keepPreviousData, useMutation, useQuery } from '@tanstack/react-query'
 import { importsApi } from '@/lib/imports-api'
 import { importKeys, invalidateFor } from '@/lib/query-invalidation'
 import { useRegisterRematchJob } from '@/components/providers/rematch-jobs-provider'
@@ -14,6 +14,7 @@ export function useSuggestions(params: SuggestionsListParams = {}) {
   return useQuery({
     queryKey: importKeys.suggestions(params),
     queryFn: () => importsApi.getSuggestions(params),
+    placeholderData: keepPreviousData,
     staleTime: 1000 * 60 * 2, // 2 minutes
   })
 }

--- a/frontend/src/lib/__tests__/imports-api.test.ts
+++ b/frontend/src/lib/__tests__/imports-api.test.ts
@@ -36,6 +36,7 @@ describe('importsApi', () => {
               limit: 20,
               pages: 1,
             },
+            hidden_unresolved_telegram_count: 6,
           },
         }),
       })
@@ -47,6 +48,7 @@ describe('importsApi', () => {
       expect(result.page).toBe(1)
       expect(result.limit).toBe(20)
       expect(result.pages).toBe(1)
+      expect(result.hidden_unresolved_telegram_count).toBe(6)
 
       const fetchCall = (global.fetch as any).mock.calls[0]
       expect(fetchCall[0]).toContain('/api/v1/imports/candidates')
@@ -89,6 +91,23 @@ describe('importsApi', () => {
       expect(fetchCall[0]).toContain('source=gcontacts')
     })
 
+    it('passes unresolved Telegram visibility when enabled', async () => {
+      ;(global.fetch as any).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          success: true,
+          data: [],
+          meta: { pagination: { total: 0, page: 1, limit: 20, pages: 0 } },
+        }),
+      })
+
+      await importsApi.getCandidates({ include_unresolved_telegram: true })
+
+      const fetchCall = (global.fetch as any).mock.calls[0]
+      expect(fetchCall[0]).toContain('include_unresolved_telegram=true')
+    })
+
     it('handles empty response gracefully', async () => {
       ;(global.fetch as any).mockResolvedValueOnce({
         ok: true,
@@ -103,6 +122,7 @@ describe('importsApi', () => {
       expect(result.page).toBe(1)
       expect(result.limit).toBe(20)
       expect(result.pages).toBe(0)
+      expect(result.hidden_unresolved_telegram_count).toBe(0)
     })
 
     it('throws ApiError on HTTP 404', async () => {

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -27,6 +27,7 @@ interface ApiResponse<T = unknown> {
       limit: number
       pages: number
     }
+    hidden_unresolved_telegram_count?: number
   }
 }
 

--- a/frontend/src/lib/candidate-display.ts
+++ b/frontend/src/lib/candidate-display.ts
@@ -15,3 +15,15 @@ export function getCandidateDisplayName(candidate: ImportCandidate): string {
   }
   return 'Unknown'
 }
+
+export function isUnresolvedTelegramCandidate(candidate: ImportCandidate): boolean {
+  return (
+    candidate.source === 'telegram' &&
+    !candidate.display_name?.trim() &&
+    !candidate.first_name?.trim() &&
+    !candidate.last_name?.trim() &&
+    !candidate.metadata?.username?.trim() &&
+    candidate.emails.length === 0 &&
+    candidate.phones.length === 0
+  )
+}

--- a/frontend/src/lib/imports-api.ts
+++ b/frontend/src/lib/imports-api.ts
@@ -31,6 +31,7 @@ export const importsApi = {
       page: params.page || 1,
       limit: params.limit || 20,
       ...(params.source && { source: params.source }),
+      ...(params.include_unresolved_telegram && { include_unresolved_telegram: true }),
     }
 
     const response = await apiClient.getWithMeta<ImportCandidate[]>(
@@ -44,6 +45,7 @@ export const importsApi = {
       page: response.meta?.pagination?.page || 1,
       limit: response.meta?.pagination?.limit || 20,
       pages: response.meta?.pagination?.pages || 0,
+      hidden_unresolved_telegram_count: response.meta?.hidden_unresolved_telegram_count || 0,
     }
   },
 
@@ -60,6 +62,7 @@ export const importsApi = {
       page: params.page || 1,
       limit: params.limit || 20,
       ...(params.source && { source: params.source }),
+      ...(params.include_unresolved_telegram && { include_unresolved_telegram: true }),
     }
 
     const response = await apiClient.getWithMeta<SuggestionItem[]>(
@@ -73,6 +76,7 @@ export const importsApi = {
       page: response.meta?.pagination?.page || 1,
       limit: response.meta?.pagination?.limit || 20,
       pages: response.meta?.pagination?.pages || 0,
+      hidden_unresolved_telegram_count: response.meta?.hidden_unresolved_telegram_count || 0,
     }
   },
 

--- a/frontend/src/types/import.ts
+++ b/frontend/src/types/import.ts
@@ -42,6 +42,7 @@ export interface ImportCandidatesListParams {
   page?: number
   limit?: number
   source?: string
+  include_unresolved_telegram?: boolean
 }
 
 export interface ImportCandidatesListResponse {
@@ -50,6 +51,7 @@ export interface ImportCandidatesListResponse {
   page: number
   limit: number
   pages: number
+  hidden_unresolved_telegram_count: number
 }
 
 // ---------------------------------------------------------------------------
@@ -89,6 +91,7 @@ export interface SuggestionsListParams {
   page?: number
   limit?: number
   source?: string
+  include_unresolved_telegram?: boolean
 }
 
 export interface SuggestionsListResponse {
@@ -99,6 +102,7 @@ export interface SuggestionsListResponse {
   page: number
   limit: number
   pages: number
+  hidden_unresolved_telegram_count: number
 }
 
 /** Request body for POST /imports/suggestions/:id/methods/resolve. */


### PR DESCRIPTION
## Summary
- Hide unresolved Telegram import candidates by default on import candidate and suggestions endpoints
- Add hidden unresolved count metadata and a People-tab switch to reveal them
- Keep previous suggestions visible during toggle refetch and prefetch the unresolved-visible variant for lower first-toggle latency

## Tests
- make test-frontend
- pre-push hook: backend lint, frontend lint, unit tests, integration tests, frontend tests, diff-selected E2E tests