### PR TITLE
feat(gchat): schema + identity + comms-backed aggregation substrate (#337)

### DIFF
--- a/.ai/spec/2026-06-04-gchat-integration-design.md
+++ b/.ai/spec/2026-06-04-gchat-integration-design.md
@@ -1,0 +1,649 @@
+# Google Chat (GChat) Integration — Functional & Technical Specification
+
+**Issue:** #337
+**Related:** #70 (Gmail — shared OAuth + `comms_message` substrate), Telegram integration (`.ai/spec/telegram-integration.md` — chat-source patterns), Telegram method enrichment (`.ai/spec/telegram-method-enrichment.md` — dual-source rematch precedent), iMessage / Mac daemon (`.ai/spec/mac-daemon.md`, `.ai/spec/mac-daemon-phase-2-anarlog-matching.md` — chat-source patterns over the shared aggregation engine)
+**Status:** Draft v1
+**Last Updated:** 2026-06-04
+
+---
+
+## Table of Contents
+
+1. [Overview](#1-overview)
+2. [Functional Specification](#2-functional-specification)
+3. [Fetch Strategy](#3-fetch-strategy)
+4. [Direction & Aggregation Model](#4-direction--aggregation-model)
+5. [Technical Specification](#5-technical-specification)
+6. [Database Changes](#6-database-changes)
+7. [Configuration](#7-configuration)
+8. [Implementation Phases](#8-implementation-phases)
+9. [Testing Strategy](#9-testing-strategy)
+10. [Open Questions & Future Work](#10-open-questions--future-work)
+
+---
+
+## 1. Overview
+
+### What
+
+Add Google Chat (GChat) as a backend sync source that ingests **full message content** for chat exchanges with **known CRM contacts only**, records them as direction-aware interactions, and updates cadence timestamps. GChat is **not** a discovery source — it never creates new contacts. Like Gmail and Telegram, this feature only produces the durable content substrate plus interactions; downstream features (e.g. AI summarization) are out of scope.
+
+The integration is structured to fit into the existing **family of chat-based message sources** — Telegram, Apple Messages (iMessage via the Mac daemon), and now GChat. Where logic already generalizes (the shared `messaging/aggregation` engine, the `comms_message` content store designed in §6 of the Gmail spec, the multi-handler-per-type `RematchService`), GChat plugs in. Where the existing logic only nominally generalizes but is in practice source-bound, this spec proposes targeted refactors in §5.X and notes whether each is RECOMMENDED to land with GChat or PROPOSED as follow-up.
+
+### Why
+
+Google Chat is a primary communication channel for the user's professional correspondence and personal group spaces. Syncing it means `last_contacted` / `last_outreach_at` update automatically from real chat exchanges, contact timelines reflect those exchanges, and a faithful copy of message bodies is stored locally for later use. The same posture as Gmail and Telegram applies: restrict to known contacts; mirror upstream edits and deletes; never create contacts implicitly.
+
+### Key Decisions (verified — do not re-debate)
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Source name | `gchat` | Already a valid `contact_method.type` value (`backend/migrations/007_add_contact_methods.up.sql:13`); aligns with `external_sync_state.source` and the future `interaction.source` constant |
+| Runtime | Pi backend sync provider (alongside `gcal`, `email`) | Reuses Google OAuth and the existing scheduler tick. Polling-only — no public webhook endpoint on the Pi behind Tailscale (see real-time discussion in §10) |
+| MVP scope | **All three space types**: DMs (`DIRECT_MESSAGE`), group chats (`GROUP_CHAT`), named spaces (`SPACE`) | Telegram already handles group/multi-member messaging with sender-attribution semantics; the same logic carries over (§4) |
+| Discovery | **None** — known contacts only, match-or-skip | Same posture as Gmail and Telegram. Users add contacts elsewhere; GChat just records exchanges with people already in the CRM |
+| Identity matching | **Two dual-source mechanisms** layered together (each addresses a different code path; see §5.3, §5.X.7, §5.X.2 for why both): (1) **Sender-resolution dual-source** encoded directly in the sqlc query — `ListGChatIdentitiesForSync` selects rows where `type IN ('gchat', 'email')`, so a single per-sweep query builds a map covering both contact-method types. The identity-mapping-layer mapping (`MapIdentifierTypeToContactMethodTypes(IdentifierTypeGChat) → [gchat, email]`) is intentionally NOT added in MVP — see §5.X.7 — because no caller invokes `IdentityService.MatchOrCreate` with `IdentifierTypeGChat`. The sqlc query is the **single source of truth** for the `(gchat, email)` set in MVP; two encodings would risk drift. (2) **Backfill-trigger dual-source** at the rematch-handler layer — TWO `RematchHandler` registrations (`IdentifierType()="gchat"` and `IdentifierType()="email"`) both invoke the GChat backfill | (1) the sqlc query carries the dual-source set; the `MapIdentifierTypeToContactMethodTypes` WhatsApp precedent (`backend/internal/identity/normalize.go:102-103`) is preserved as a reference shape if/when an actual `MatchOrCreate(IdentifierTypeGChat, ...)` caller emerges. (2) is the **Telegram** pattern (two `RematchHandler` registrations across two `IdentifierType` strings) — `backend/internal/telegram/rematch.go:74-95` (username handler, `IdentifierType()="telegram"`) + `backend/internal/telegram/rematch.go:97-121` (phone handler, `IdentifierType()="phone"`). Both layers are needed because they fire on different events: (1) runs when resolving a sender on every sweep; (2) runs once when a user adds `email`/`gchat` to an existing contact. They're not redundant — neither covers the other's trigger |
+| Real-time vs polling | Polling | No public webhook on the Pi. The user is single-account on a `@gmail.com` consumer account; even if Workspace Events ever opens to consumer accounts, Pub/Sub delivery still needs a public endpoint |
+| Content storage | Reuse **`comms_message`** — no new content table | `comms_message` (`backend/migrations/058_comms_message.up.sql`) was designed for this. Its `claimed_at` / `claimed_session_ref` columns are already reserved on the schema for future chat-source migration. GChat is the FIRST chat source to use them |
+| Cross-account dedup | `(source='gchat', external_id=<chat message resource name>, matched_contact_id)` | Chat message resource name (`spaces/<space>/messages/<id>`) treated as cross-account-stable, analog of Gmail's RFC822 Message-ID. Reuses the existing `idx_comms_message_dedup` partial unique index (`backend/migrations/058_comms_message.up.sql:31-33`). **PROVISIONAL** — cross-account stability of the Chat resource name is not yet cited from official docs; verify against the Chat API reference during implementation. If the resource name proves account-scoped, fall back to a synthesized key (`gchat:<space>:<account>:<id>`) matching the Gmail `nomsgid:` fallback shape (`backend/migrations/058_comms_message.up.sql:9`) |
+| Direction model | Sender vs the connected account's `users/me`; inbound/outbound per message; promote to mutual on mixed-direction within a session | Same per-message model the rest of the codebase uses; reuses `PromoteInteractionToMutualTx` / `ExtendInteractionTx` |
+| Aggregation | **Telegram-style burst + reply-bridge** over the shared `messaging/aggregation` engine. NOT Gmail's `(contact, thread, day)` shape — that's email-specific. Burst-window 2h, reply-bridge 48h initially (Telegram defaults; revisit per §10) | Chat sources are interactive: a burst of outbound followed by an inbound reply is one mutual interaction, not three day-buckets. The engine is already abstracted as a per-source adapter (`backend/internal/messaging/aggregation/interfaces.go`) and proven on two sources (Telegram, Messages) |
+| Edits & deletes | Mirror upstream — update stored `comms_message` content on edit, soft-delete on delete; derived interaction unchanged | Matches Telegram (`.ai/spec/telegram-integration.md` §2.2). The interaction reflects "the exchange happened"; edits/deletes don't unwind cadence |
+| Backfill | New-method handlers (`GChatHandleRematchHandler`, `GChatEmailRematchHandler`) registered on `KindContactMethodsAdded` for types `gchat` AND `email`; onboarding scan from a fixed start date (default 2026-01-01, mirroring Gmail's anchor) | Multi-handler-per-type is already supported by `RematchService` (`backend/internal/service/rematch.go:180-183`). The email handler runs alongside `GmailRematchHandler` and `CalendarRematchHandler` — RematchService already fans out |
+| Cadence | Reuse existing `CadenceUpdater` via `interaction.recorded`; inbound/mutual → `last_contacted`, outbound → `last_outreach_at` | No new cadence semantics. Architectural-coherence check confirmed: Telegram's cadence rules match Gmail's (both go through the same direction-conditional `RecordInteraction`) and GChat fits the same shape |
+| Pipeline | **Telegram/Messages-style**, not Gmail-style. Provider writes content rows to `comms_message` (source='gchat') with no per-message events. A periodic worker (the existing `MessagingAggregateForContactArgs` path) invokes the shared `aggregation.Engine`, which publishes the generic `KindMessageReceived`/`KindMessageSent` it already emits for Telegram and Messages — `backend/internal/messaging/aggregation/engine.go:489-545`. Cadence and follow-up consumers downstream of those existing kinds already do the right thing. Edits and deletes are reflected by direct UPDATE / soft-delete on the `comms_message` row (no provider-published `gchat.*` events) — the engine processes by `processed_at IS NULL`, so an edited row is not reprocessed and a soft-deleted row drops out of future aggregation, leaving the prior derived interaction untouched (consistent with the locked edit/delete semantics row above) | This avoids the hybrid pattern the prior draft proposed (provider per-message events PLUS delegating to the shared engine, which itself emits its own events on session creation — duplicate work and incoherent kind routing). Gmail publishes per-message events because Gmail bypasses the shared engine and uses its own `EmailInteractionConsumer` (`backend/internal/consumer/email_interaction.go:46-98`); Telegram and Messages do not publish per-message events from the provider because the engine drives publication. Reusing the engine (§5.X.1 RECOMMENDED) implies the Telegram/Messages flow, not Gmail's |
+| Cross-source thread merging | **Out of scope** for MVP | Two separate interactions per source even on the same day with the same contact; deferred (§10) |
+
+### Production scale (sizing)
+
+The user's GChat usage is sparse relative to Gmail — most personal correspondence is over email, calendar, and Telegram. Concrete sweep cost: ~handful of spaces per account; one `spaces.list` call per sweep (or one `spaces.list` if a per-account "active space" cache is wired); per-space `spaces.messages.list` page bound by the cursor window; per-known-member `spaces.members.list` per discovered space (cached). Steady-state per-sweep API spend is expected to be dominated by `spaces.list` + a single `spaces.messages.list` per space that had activity. To be measured during MVP rollout.
+
+---
+
+## 2. Functional Specification
+
+### 2.1 User Stories
+
+1. **Connect once** — having connected a Google account (already supported), GChat sync begins after the new Chat scopes are granted. A one-time re-consent fires when the new scopes (`chat.spaces.readonly` + `chat.messages.readonly`) are added to the application's scope set. The operator-side Chat App config (name, avatar, description; Interactive features OFF) must be in place in the GCP project for `spaces.*` to return data (see §7).
+2. **Automatic cadence** — when I exchange messages with a known contact in any space (DM, group chat, or named space), `last_contacted` (inbound/mutual) or `last_outreach_at` (outbound) updates without manual logging.
+3. **Chat on the timeline** — GChat exchanges appear as interactions on the contact, aggregated per Telegram-style burst+reply session, with a direction signal.
+4. **Follow-ups** — an outbound message to a contact participates in the existing outreach/follow-up lifecycle (a follow-up task is created/refreshed on outbound, same as Telegram/email/calls).
+5. **No surprises** — messages from people not in my CRM are never ingested and never create contacts. Spaces with zero known members are still enumerated (so we don't miss a known member joining later) but produce no rows until at least one member is known.
+6. **History on add** — when I add a `gchat` method OR an `email` method to a contact, their recent GChat history (within the backfill window) is pulled in across all connected accounts whose GChat sync is enabled.
+
+### 2.2 What Gets Synced
+
+| Item | Synced | Details |
+|------|--------|---------|
+| DMs with a known contact (`spaceType: DIRECT_MESSAGE`) | Yes | Primary target; direction follows sender vs `users/me` |
+| Group chats with at least one known member (`spaceType: GROUP_CHAT`) | Yes | Per-message attribution: a message qualifies only when its sender is in `M ∪ knownIdentities`; other known co-members are bystanders for that specific message (§4). The sender-only-attribution-for-inbound rule is lifted from Telegram (`backend/internal/telegram/message.go:99-126`: `PeerChat` sets `PeerUserID = &senderID` per-message, only when the sender is not self). The outbound-fan-out-across-known-co-members rule is the Gmail per-participant pattern, not Telegram — see §4.3 |
+| Named spaces with at least one known member (`spaceType: SPACE`) | Yes | Same per-message attribution rule as group chats |
+| Spaces with zero known members | No | Enumerated (so a future membership change activates them) but produce no `comms_message` rows |
+| Edits | Yes | `comms_message.body`, `snippet`, and `source_metadata` are updated in place; `processed_at` and `interaction_id` are unchanged; derived interaction is unaffected |
+| Deletions | Yes | `comms_message.deleted_at` is set (soft-delete) via the same partial-unique-index-friendly path Gmail uses (`backend/migrations/058_comms_message.up.sql:32`). Derived interaction is unchanged (the exchange still happened); follow Telegram precedent |
+| Drafts | No | Not sent yet — Chat API does not surface drafts to the consumer scopes |
+| Reactions | No | Out of scope for MVP — same posture Telegram takes |
+| Slash-command output / app-posted messages | No | `message.sender.type != "HUMAN"` filtered at the provider boundary |
+| Threaded replies inside a SPACE | Yes (treated as ordinary messages) | The aggregation key uses space resource name as `ChatID`; thread context is preserved in `source_metadata` for later refinement (§10) |
+| Bot conversations / channels | No | Not interpersonal |
+
+**Per message stored (in `comms_message`):**
+
+| Field | Stored | Notes |
+|-------|--------|-------|
+| Body (plaintext) | Yes | `message.text` |
+| Subject | No (null) | Chat sources have no subject; column is nullable (`backend/migrations/058_comms_message.up.sql:11`) |
+| Snippet | Yes | First N chars of body, mirroring Telegram's description shape |
+| Participants (sender, space members) | Yes | Sender stored top-level (`peer_handle`/`peer_normalized`); other members in `source_metadata` |
+| Sent timestamp | Yes | `sent_at` = `message.createTime` |
+| Direction | Yes | Per-message inbound/outbound vs `users/me` (§4.1) |
+| Chat message resource name | Yes | `external_id` — cross-account-stable dedup key |
+| Space resource name | Yes | `thread_id` (reused; chat sources don't have email threads, so the column carries the space scope) |
+| Account that observed it | Yes | `account_id` — provenance / cross-account merge target (same set-union pattern Gmail uses, §5.4 of Gmail spec) |
+| `spaceType` + `messageType` | Yes | `source_metadata.space_type`, `source_metadata.message_type` |
+| Attachment metadata | Yes | `source_metadata.attachments[]` = filename, mime, size (metadata only) |
+| Attachment binary content | No | Out of scope, same as Gmail |
+| Edit history | Yes | `source_metadata.edited_at`, `source_metadata.previous_bodies[]` (last-N capped) |
+
+### 2.3 Connect Once: prerequisite Chat App config
+
+GChat's read-only OAuth scopes return data only when the GCP project has a Chat App configured on the Chat API Configuration page. This is a **project-level operator setup step**, separate from the OAuth client. Required fields: app name, avatar URL, description. Interactive features must be **OFF** (we never receive webhooks, we never respond to slash commands). This is documented in §7 as part of the operator setup guide; the spec assumes it has been done.
+
+The authenticating user is a personal `@gmail.com` account added as a Test User on the External-type consent screen. Verified by manual OAuth Playground probe (resolved: see the auth-model probe outcome in the brief).
+
+---
+
+## 3. Fetch Strategy
+
+### 3.1 Steady-state incremental (per account)
+
+For each connected account whose GChat sync is enabled, each sweep tick (default 15 min, matching Gmail/Calendar):
+
+1. **Enumerate active spaces** via `spaces.list` (no `spaceType` filter — fetch all three types in one call). The response carries `spaceType`, `name` (resource), `lastActiveTime`, `membershipCount.joinedDirectHumanUserCount`, and optionally `displayName` (for `SPACE`). Filter out spaces with `externalUserAllowed=true` only if a later policy says so; for MVP, include them.
+2. **Resolve known membership per space.** For `DIRECT_MESSAGE`, the peer is implicit — the OTHER member of the 2-person space. For `GROUP_CHAT` and `SPACE`, call `spaces.members.list` (cached per space-version; we don't refetch unless `lastActiveTime` advanced and the cached version is older than the cache TTL — see §3.4 cache discussion). Membership rows give us `users/<id>` references; **the sender's resource name is the email of their Google account** (consumer accounts) or their Workspace user id (Workspace accounts). For the MVP target (consumer `@gmail.com`), the sender carries the email and is matched against the dual-source known-identity map (§5.3). Cache the resolved (`spaces/<id>` → `[ContactID]`) map per space.
+3. **Build the known-identity map** ONCE per sweep: `{ normalized_value → []ContactID }` over BOTH `contact_method.type='gchat'` AND `contact_method.type='email'` (since GChat senders carry email addresses and the user may have only added an `email` method). This is the dual-source map — see §5.3 for the new sqlc query.
+4. **Skip enumeration when no known member is in the space.** If `spaces.members.list` returns no known identities, the space is logged at DEBUG (with the resource name only, never with member emails) and skipped. The space's existence is still tracked in `external_sync_state.metadata.active_spaces` so a future member-list change reactivates it.
+5. **Per-space message page** via `spaces.messages.list` with `filter=createTime >= <space_cursor>` (RFC 3339 timestamps are accepted by the Chat API). The `space_cursor` is a per-space cursor stored under `external_sync_state.metadata.space_cursors` (see §3.3 for the cursor shape decision).
+6. **For each message**, resolve `(sender_email, direction)` against the known-identity map. The sender qualifies the row; other known co-members are bystanders for that specific message and do not produce additional **inbound** rows (an inbound message from Alice in a group with Bob and Carol produces one row keyed on Alice — Bob and Carol do not get phantom rows). For DMs, every message qualifies (the DM peer is known by definition). For group/named spaces, only messages whose sender is a known contact OR is me produce row(s). On the **outbound** side, fan-out across the set of known co-members applies — see §4.3 for the per-known-co-member row rule and why outbound is asymmetric to inbound. Match-only — never create a contact.
+7. **Advance the per-space cursor** to `max(processedMessage.createTime)`. Re-fetch overlap on the next sweep is harmless — `(source='gchat', external_id, matched_contact_id)` dedup on `idx_comms_message_dedup` (`backend/migrations/058_comms_message.up.sql:31-33`) makes ingestion idempotent.
+8. **Detect edits and deletes — PROVISIONAL mechanism.** Preferred: a second-pass per-space `spaces.messages.list?filter=updateTime >= <edit_cursor>` over a separate per-space cursor. The `filter` grammar on `spaces.messages.list` is documented to support `createTime` ordering / filtering; whether `updateTime` is included in the filterable field set is **not yet verified from official documentation**. Implementation must verify this against the live Chat API reference before committing to the cursor design. **Fallback (if `updateTime` is not filterable) — bounded 7-day sliding window:** per-sweep, per-space, fetch each `comms_message` row whose stored `sent_at` is within the last 7 days via `spaces.messages.get` and compare `lastUpdateTime` against the stored value. Bound rationale: edits >7 days after send are vanishingly rare in chat (overwhelmingly typo-fixes within minutes, occasionally same-day corrections); the 7-day window covers virtually all real cases. Independent of total stored row count — a space with 6 months of history still costs only 7 days × messages/day per sweep, NOT 180 days. Concrete ceiling at the user's sparse GChat usage (~5 msgs/day across a handful of spaces): ~35 `messages.get` calls per sweep per account ≈ 3,400/day at the 15-min cadence — well under any plausible quota. The cursor name (`edit_cursor`) and the per-space cursor map shape in §3.3 are unchanged either way; only the fetch mechanism varies. On a hit, if the fetched body differs from the stored body, treat as edit; if the API returns 404 or a tombstone marker, soft-delete the `comms_message` row. Edits to messages older than 7 days are explicitly accepted as a lost-update — same posture as the edit-after-delete race in §10 open question 6 (low-frequency, high-mitigation-cost, low-impact).
+
+### 3.2 Onboarding backfill
+
+When GChat sync is first enabled for an account (per-space cursors empty), seed each space's `createTime` cursor to `backfill_since` (default **2026-01-01**, configurable per `external_sync_state.metadata.backfill_since`). Page each space to completion, then set the cursor to the latest processed `createTime`. The `updateTime` cursor seeds to the same anchor on first run.
+
+Mirror Gmail's window approach: each sweep processes at most N windows per space (`gchatMaxWindowsPerSync = 24` analog) to keep one run bounded. The cursor only advances after a window is listed, paged, fetched, and filtered successfully — a partial-window crash starts the window over on the next sweep.
+
+### 3.3 Per-space vs single-cursor per account
+
+**Decision: per-space cursors stored in `external_sync_state.metadata.space_cursors` as a JSON map `{ "spaces/<id>": { "create_cursor": "2026-06-04T00:00:00Z", "edit_cursor": "..." } }`.** A single-cursor-per-account would force a global watermark across all spaces — a quiet group space would be re-scanned every sweep until a single active space's cursor advanced past it, inflating API spend. Per-space cursors mirror Telegram's per-chat sync approach (`telegram_chat_config.backfill_cursor` per chat, per `.ai/spec/telegram-integration.md` §5.2) and contain the cursor advance to spaces that actually had activity.
+
+The cursor map fits comfortably under the `external_sync_state.metadata JSONB` column; expected per-account scale is <100 spaces. If the map ever exceeds ~64 KB we promote to a dedicated `gchat_space_state` table (NOT planned for MVP).
+
+**Stale-cursor reaper.** A space the user leaves (or that becomes inaccessible — archived, deleted, permission revoked) stays in the cursor map forever otherwise. On each sweep, the enumerator's `spaces.list` response is the authoritative active set; any cursor entry for a `spaces/<id>` NOT in the latest `spaces.list` response is moved to `metadata.archived_space_cursors` (kept for a grace period — 30 days — in case access is restored, then dropped). The archived map is logged at INFO with the count only (never with space resource names beyond DEBUG). This keeps the active cursor map bounded without losing recently-active state to a transient permission flap.
+
+**Cursor restoration on re-discovery.** If a subsequent sweep's `spaces.list` response surfaces a `spaces/<id>` that is currently in `archived_space_cursors` (i.e. access was restored before the 30-day grace expired), the reaper restores the entry: it is moved BACK from `archived_space_cursors` into `space_cursors` at its archived cursor value, and the regular per-space message-paging path resumes from that cursor. Any messages that arrived during the inaccessibility window AND were already observed via another connected account are handled by cross-account dedup on the partial unique index `idx_comms_message_dedup` (`backend/migrations/058_comms_message.up.sql:31-33`) — the upsert's set-union merge on `observed_accounts[]` records the new observation without duplicating the row. After the 30-day grace expires, the cursor is dropped; subsequent re-discovery is treated as a fresh space and reseeded from `metadata.backfill_since` per §3.2.
+
+### 3.4 Space membership cache
+
+`spaces.members.list` is called only when:
+
+- a space is observed for the first time (cache miss);
+- a space's `lastActiveTime` advanced (any cached version);
+- the cache entry's age exceeds `gchatMembershipCacheTTL = 24h`, regardless of whether `lastActiveTime` advanced.
+
+The age-based trigger is the safety net for the "known contact joins a quiet space" case: `lastActiveTime` only advances on new message activity, so a membership change in a long-quiet space would otherwise leave the cache stale indefinitely. The 24h TTL bounds that staleness.
+
+The cache lives in `external_sync_state.metadata.space_members` as `{ "spaces/<id>": { "version": <lastActiveTime>, "members": ["users/<id>", ...] } }`. Only the resource names are cached, never the resolved contact IDs — the contact resolution runs every sweep against the live known-identity map (so a newly added `gchat`/`email` method takes effect on the next sweep without cache invalidation).
+
+### 3.5 Why not the alternatives
+
+- **`spaces.list` with `filter=spaceType="DIRECT_MESSAGE"`**: Chat API supports filters but they don't bundle types in OR-clauses; we'd need three calls. One unfiltered call returns all three types — strictly cheaper.
+- **Per-message lastUpdateTime poll**: O(N) API calls per sweep where N is total stored messages. `updateTime` cursor is O(edits-since-cursor).
+- **Real-time via Workspace Events / Pub/Sub**: requires a public webhook endpoint (Pi is behind Tailscale) AND consumer-account Workspace Events support (not currently available). See §10.
+
+---
+
+## 4. Direction & Aggregation Model
+
+### 4.1 Participant & direction rule
+
+Let `M` = the set of normalized identities representing the connected account's `users/me` — primarily the account's own email (verified via `users.me.lookup` on connect, cached per-account in `external_sync_state.metadata.me_identities`). For a chat message with sender `f` (a `users/<id>` reference) and the message's space `S`:
+
+- **`f ∈ M`** → message is **outbound** from this connected account.
+- **`f` resolves to a known contact `C` (via the dual-source identity map)** → message is **inbound** for `C`.
+- **`f` resolves to neither M nor any known contact** → bystander, no row produced. The space's other members (whoever they are) are NOT separately attributed; this is the same rule Telegram applies (`.ai/spec/telegram-integration.md` §3 — `direction` is per-message, sender-only).
+
+For DMs (`DIRECT_MESSAGE`, exactly two members), the peer is the other member; every message qualifies (one direction or the other). For `GROUP_CHAT` and `SPACE`, a message qualifies only when the sender is in `M ∪ knownIdentities` — co-members who are CRM contacts but did not send this message are bystanders for the cadence-attribution purpose.
+
+Practical effect: a group space with three known members produces interactions only for messages they actually send. Their being co-present does not produce phantom **inbound** rows. This matches Telegram's inbound-group rule verbatim (`backend/internal/telegram/message.go:99-126`). The outbound-side rule is different — see §4.3 for the per-known-co-member fan-out on outbound, which is the Gmail per-participant pattern, NOT Telegram's.
+
+### 4.2 Aggregation key & engine (adopted from Telegram, NOT Gmail)
+
+GChat plugs into the shared aggregation engine at `backend/internal/messaging/aggregation` — the same engine Telegram (`backend/internal/telegram/aggregation.go:60-102`) and Messages (`backend/internal/messages/aggregation_adapter.go:34-73`) use today.
+
+**Adapter contract per `SourceAdapter` (`backend/internal/messaging/aggregation/interfaces.go:44-81`):**
+
+- `SourceName()` → `"gchat"`
+- `SourceRef(chatID, firstExternalID string)` → `"gchat:<space_resource>:<first_message_resource>"`. The space resource name is opaque (e.g. `spaces/AAAA9876`) but does not legitimately contain `_` or `%`, so no LIKE-escape is required — same posture Telegram takes (Telegram's `_`/`%` escape concern only applies to source adapters whose chat IDs may contain those characters; Apple Messages requires escaping per `backend/internal/messages/aggregation_adapter.go:107-114`).
+- `SourceRefPrefix(chatID string)` → `"gchat:<space_resource>:%"`. Confirm at implementation time that Chat space resource names never embed `_`/`%`; if they ever do, adopt the Messages-style escape (recommendation: defensively apply the same `strings.NewReplacer` escape regardless — see §5.X.4).
+- `PeerRef(chatID string)` → `"gchat:<space_resource>"`
+- `Description(direction string, msgCount int)` → `"GChat outreach (3 messages)"` / `"GChat response (2 messages)"` / `"GChat exchange (...)"`, mirroring Telegram's phrasing verbatim per the existing pattern at `backend/internal/telegram/aggregation.go:146-155`.
+
+**Burst + reply-bridge:** initial values match Telegram (`burstWindowHours=2`, `replyBridgeHours=48`). These are tunable per env var (§7). The aggregation engine handles burst grouping (same-direction messages within 2h form one burst), reply-bridging (inbound burst within 48h after an outbound burst promotes to mutual), and explicit reply detection (Chat API exposes `message.thread.name` and `message.threadReply` — see §5.X.3 for an open question on whether to wire explicit reply bridging through `ReplyTargetID`).
+
+**Why NOT Gmail's `(contact, thread, day)` shape:** Email threads have explicit `In-Reply-To` headers and natural daily boundaries (people don't send 50 emails in 10 minutes). Chat is interactive — a 30-message back-and-forth across 90 minutes IS one conversation, not a thread-day bucket. Telegram's burst+bridge collapses this correctly; thread-day would create 30 same-bucket interactions that all extend each other (a denial-of-service against the consumer's per-source-ref advisory lock, plus a misleading 30-message description). The shared aggregator already solves this and is proven on two sources.
+
+### 4.3 Bystanders, fan-out, and the inbound/outbound asymmetry
+
+A message whose sender is neither me nor a known contact is NOT stored. The interesting case is outbound from me to a group that contains multiple known contacts.
+
+**Decision: outbound fan-out across the set of known co-members; inbound stays sender-only.** Concretely:
+
+- **Inbound** from a known sender (e.g. Alice) in a group that also has Bob and Carol as known co-members → ONE row keyed on `matched_contact_id=Alice`. Bob and Carol do not get phantom rows. This matches Telegram's sender-only attribution: for `PeerChat` messages, Telegram sets `parsed.PeerUserID = &senderID` only when the sender is not self (`backend/internal/telegram/message.go:99-126`), and stores one row per (message, sender).
+- **Outbound** from me to a group with two known contacts (Alice and Bob) → TWO rows: `matched_contact_id=Alice` and `matched_contact_id=Bob`. Both rows reference the same chat message resource name and share provenance via `source_metadata.observed_accounts[]`. Each row contributes to that contact's `last_outreach_at` independently.
+
+**Precedent for outbound fan-out: Gmail, not Telegram.** The `comms_message` schema is explicitly designed for per-participant granularity — migration 058 line 4 states *"One row = one message x one qualifying contact (per-participant granularity)"* (`backend/migrations/058_comms_message.up.sql:4`). Gmail's provider implements this directly: every qualifying `(message, contact)` pair produces a distinct row and a distinct event, with `SourceID = row.ExternalID + ":" + row.ContactID.String()` (`backend/internal/google/gmail.go:872-895`). The `idx_comms_message_dedup` unique index on `(source, external_id, matched_contact_id)` (`backend/migrations/058_comms_message.up.sql:31-33`) is what makes this safe.
+
+**Telegram does NOT fan out across known co-members** — explicitly verified. For an outbound `PeerChat` message (`senderID == selfUserID`), Telegram leaves `parsed.PeerUserID = nil` (`backend/internal/telegram/message.go:114-115`) — there is no per-known-co-member row at all on the outbound side; outbound updates the chat scope, not each co-member's view. The prior draft incorrectly claimed Telegram precedent here.
+
+**Why the asymmetry is right, not a bug:**
+
+- For inbound, sender-only attribution is correct because the cadence semantics ("this person reached out to me") only apply to the actual sender. Bob and Carol being present doesn't mean they reached out.
+- For outbound, fan-out across the known set is correct because the cadence semantics ("I reached out to this person") apply to every known recipient. Outbound to a group containing Alice and Bob legitimately advances both `last_outreach_at(Alice)` and `last_outreach_at(Bob)` — the user did reach out to both.
+
+This is an **owned design choice** that follows the Gmail per-participant precedent, not a borrowed Telegram pattern.
+
+### 4.4 Cadence
+
+No new cadence logic. Inbound/mutual → `last_contacted` + `last_interaction_at` + `last_response_at` + recalculates `contact_by`. Outbound → only `last_outreach_at`. The aggregation engine emits `interaction.recorded` on create and applies cadence inline on extend/promote, exactly as Telegram and Gmail already do — both delivery paths are exercised by the engine today.
+
+**Telegram cadence semantics verification:** Telegram's `interaction.recorded` on create + inline extend/promote matches Gmail's two-path cadence model (Gmail spec §4.3). They are identical because both go through the same `RecordInteractionTx` and the same `ExtendInteractionTx` / `PromoteInteractionToMutualTx` primitives. GChat will go through the same shared engine and the same primitives. Confirmed; no deviation.
+
+---
+
+## 5. Technical Specification
+
+### 5.1 Components
+
+| Component | Location (new unless noted) | Responsibility |
+|-----------|------------------------------|----------------|
+| `GChatSyncProvider` | `backend/internal/google/gchat.go` | Implements `sync.SyncProvider`; enumerates spaces, resolves membership, pages messages per cursor window, resolves senders against the dual-source identity map, writes `comms_message` content rows directly (with provenance merge on conflict). **Does NOT publish per-message events** — see §5.2. Edits and deletes are reflected by UPDATE / soft-delete on the existing `comms_message` row in the same provider sweep |
+| `GChatHandleRematchHandler` | `backend/internal/google/gchat_rematch.go` | Implements `service.RematchHandler` with `IdentifierType()="gchat"`. Identifier-scoped backfill on `contact_methods.added` for `gchat` methods. Calls the shared `aggregation.Engine.AggregateForContactBatch` after linking, same shape as `peerRematchBase.rematchPeers` (`backend/internal/telegram/rematch.go:35-70`) |
+| `GChatEmailRematchHandler` | `backend/internal/google/gchat_rematch.go` | Implements `service.RematchHandler` with `IdentifierType()="email"`. Identifier-scoped backfill for the email half of the dual-source rule. Co-registers with `GmailRematchHandler` and `CalendarRematchHandler` (multi-handler-per-type is already supported — `backend/internal/service/rematch.go:180-183`) |
+| `commsMessageStoreAdapter` | `backend/internal/google/gchat_aggregation.go` | NEW adapter implementing `aggregation.MessageStore` against `comms_message` rows filtered by `source='gchat'`. Mirror of `telegramMessageStoreAdapter` (`backend/internal/telegram/aggregation.go:161-256`) / `messagesMessageStoreAdapter` (`backend/internal/messages/aggregation_adapter.go:141-220`). Reads/writes `claimed_at` / `claimed_session_ref` / `processed_at` / `interaction_id` directly on `comms_message` (the columns are already reserved on the schema — `backend/migrations/058_comms_message.up.sql:22-25`) |
+| `gchatAdapter` | `backend/internal/google/gchat_aggregation.go` | `SourceAdapter` impl (name, source_ref, prefix, peer_ref, description). Mirror of `messagesAdapter` (`backend/internal/messages/aggregation_adapter.go:82-135`) |
+| GChat `AggregatorReenqueuer` registry entry | `backend/cmd/crm-api/main.go` (modify) | Register an `AggregatorReenqueuer` for `source="gchat"` (`backend/internal/consumer/aggregator_reenqueuer.go:30-56`) so straggler-message reenqueue from the engine's own `KindMessageReceived`/`KindMessageSent` publish path drives back to `engine.AggregateForContact(contactID, chatID)` — same hook Telegram uses (`backend/internal/consumer/aggregator_reenqueuer.go:68-80`) |
+| OAuth scopes | `backend/internal/google/oauth.go:26` (modify) | Append `chat.spaces.readonly` and `chat.messages.readonly` to `Scopes` |
+| Identity dual-source query | `backend/internal/db/queries/contact_method.sql` (extend) | New `ListGChatIdentitiesForSync` returning `(value_normalized, contact_id, source_type)` over rows where `type IN ('gchat', 'email')`. The `source_type` discriminator lets the provider log which side of the dual-source matched, helpful for the §10 cleanup question |
+| Repository methods on `comms_message` | `backend/internal/repository/comms_message.go` (extend) | `ListUnprocessedContactIDs`, `ListUnprocessedByContact`, `ListUnprocessedByContactAndChat`, `GetMessageByReplyTarget`, `MarkMessagesProcessed`, `ClaimMessagesTx`, `ClearStaleClaimTx` — all source-parameterized (so the same methods serve Telegram/Messages after their later migration onto `comms_message`) |
+| New sqlc queries | `backend/internal/db/queries/comms_message.sql` (extend) | Mirrors the existing telegram/messages queries but scoped by `source` parameter |
+| `InteractionSourceGChat` constant | `backend/internal/repository/interaction.go` (modify) | `InteractionSourceGChat = "gchat"` |
+| Source CHECK migration | `backend/migrations/06X_interaction_source_gchat.up.sql` (new) | Add `'gchat'` to `interaction.source` CHECK. Same migration also tightens the `comms_message.thread_id` column COMMENT to document chat-source reuse (P1-7 — see §6.2). Pair with constant update in the SAME PR — pattern locked in by `.ai/spec/2026-06-01-gmail-integration-design.md` §6.2 |
+| Registration | `backend/cmd/crm-api/main.go` (modify) | Register provider, both rematch handlers, GChat `AggregatorReenqueuer` entry, GChat entry in the `PerSourceChatListerRegistry` (`backend/internal/scheduler/messaging_aggregate_worker.go:39-61`); reconcile-on-boot `external_sync_state(source='gchat')` row per Google credential |
+
+**Notably ABSENT from the components list (compared to the prior draft):**
+
+- No `GChatInteractionConsumer` river worker — the shared `aggregation.Engine` already publishes the events the rest of the system needs.
+- No new event kinds (`KindGChatReceived`/`KindGChatSent`/`KindGChatEdited`/`KindGChatDeleted`). The engine emits the generic `KindMessageReceived`/`KindMessageSent` (`backend/internal/events/kinds.go:19-20`, used by the engine at `backend/internal/messaging/aggregation/engine.go:489-545`) with `Source = "gchat"` set from the adapter's `SourceName()`. Cadence and follow-up consumers already route on those generic kinds.
+- No `consumerJobsForKind` routing addition. The only addition to `events/bus.go` is whatever per-source plumbing the existing `KindMessage*` consumers already do — verified at implementation time, but no new fan-out needed.
+- No audit-only `gchat.edited` / `gchat.deleted` events. Edits and deletes are recoverable from `comms_message.source_metadata.edited_at` / `comms_message.deleted_at` directly; an audit-only event with no consumer would be dead weight.
+
+### 5.2 Data flow (per qualifying message)
+
+The provider writes content rows directly to `comms_message` — no per-message events. The shared aggregation engine drives all downstream signals via its existing `KindMessageReceived`/`KindMessageSent` publication path. This is the Telegram/Messages pattern, NOT Gmail's per-message publish-before-mutate pattern. The rationale is in §1's "Pipeline" decision row.
+
+```
+GChatSyncProvider.Sync(account)                       [per space, per message, per qualifying contact]
+  └─ tx (one tx per qualifying (message, contact) row):
+       upsert comms_message ON CONFLICT (source='gchat', external_id, matched_contact_id)
+              DO UPDATE: merge provenance by SET-UNION on source_metadata.observed_accounts[]
+                         (content fields immutable on conflict; same merge rule Gmail §5.4 uses)
+     commit
+       └─ no event published from the provider — the engine drives downstream signal on its next pass
+
+  Replay from another account: the ON CONFLICT path merges provenance into the existing row;
+  no extra row is created. The aggregation pass that already processed the original message
+  does not reprocess (idempotent via processed_at IS NULL filter on the store adapter).
+
+aggregation.Engine (existing, triggered by:                 [periodic sweeper tick
+                    - the periodic `MessagingAggregateSweeperWorker` tick                              OR contact-driven enqueue
+                      (`backend/internal/scheduler/messaging_aggregate_sweeper_worker.go:30`),         OR rematch handler]
+                      which lists distinct unprocessed-row contact IDs per source via the
+                      `UnprocessedContactLister` registry and enqueues a
+                      `MessagingAggregateForContactArgs` per contact
+                    - the existing `AggregatorReenqueuer` post-engine hook
+                    - `RematchHandler.Rematch` after a `gchat`/`email` method is linked)
+  └─ For source="gchat":
+       ├─ ListUnprocessedByContactAndChat reads pending comms_message rows (source='gchat', processed_at IS NULL)
+       ├─ Burst-groups within window
+       ├─ Reply-bridges across the 48h window OR via explicit reply (§5.X.3 open question)
+       ├─ ClaimRowsTx + PublishTx(KindMessageReceived | KindMessageSent, source="gchat") inside one tx
+       │  (atomic claim+publish — same race-safety mechanism Telegram and Messages already use;
+       │   `backend/internal/messaging/aggregation/engine.go:489-545`)
+       └─ MarkMessagesProcessed on commit; clears claim, sets interaction_id
+```
+
+Content lives only in `comms_message`. The events published by the engine are the generic source-agnostic `KindMessageReceived`/`KindMessageSent` already emitted today; the `Source` field on the envelope distinguishes `"gchat"` from `"telegram"` / `"messages"`. The aggregation engine's existing race-mechanics (claim, stale-claim recovery, boundary-shift detection — `backend/internal/messaging/aggregation/engine.go`) are inherited unchanged.
+
+**Edit handling (no events):**
+
+```
+GChatSyncProvider observes message via the edit-cursor mechanism (§3.1 step 8, PROVISIONAL)
+  └─ tx:
+       fetch message from API
+       if existing comms_message row + body differs:
+           UPDATE comms_message
+             SET body = new, snippet = recomputed,
+                 source_metadata = jsonb_set(source_metadata, '{edited_at}', now)
+                                   plus push previous body onto source_metadata.previous_bodies[] (last-3 cap)
+     commit
+
+The aggregation engine does NOT reprocess: rows are filtered by `processed_at IS NULL`, so an
+edited row already at processed_at != NULL is invisible to the next engine pass. The derived
+interaction is unchanged — consistent with the locked edit-semantics row in §1.
+```
+
+**Delete handling (no events):**
+
+```
+GChatSyncProvider observes 404 / tombstone via the edit-cursor mechanism or a targeted messages.get
+  └─ tx:
+       UPDATE comms_message SET deleted_at = now
+     commit
+
+The aggregation engine ignores soft-deleted rows. The derived interaction is unchanged — consistent
+with the locked delete-semantics row in §1.
+```
+
+### 5.3 Known-contact enforcement (defence in depth)
+
+1. **Map-level**: dual-source map at sweep start. Unmatched sender → not stored.
+2. **Match-level**: participant resolution is a lookup; no `MatchOrCreate` discovery path. Consistent with Gmail/Telegram "match-or-skip."
+3. **Space-level**: a space with no known members is skipped at enumeration time — saves API budget and avoids leaking unrelated names into logs.
+
+### 5.4 Cross-account dedup
+
+Same shape as Gmail: `(source='gchat', external_id=<chat_message_resource>, matched_contact_id)` UNIQUE on `WHERE deleted_at IS NULL`. The Chat message resource name (`spaces/<space>/messages/<id>`) is cross-account-stable for a given space, so the same message observed in two connected accounts (e.g., two accounts both members of the same group) targets the same `comms_message` row per contact. Provenance is merged by set-union on `source_metadata.observed_accounts[]`, mirroring Gmail's §5.4 logic.
+
+There is no "missing message-id fallback" case to handle — Chat API always returns a resource name. The Gmail-style `nomsgid:<account>:<gmail_id>` synthesis is not needed.
+
+### 5.5 Shared-Logic Refactor Opportunities
+
+Side-by-side analysis of Telegram, Messages (iMessage), and Gmail surfaced the following duplicated logic. Each is marked PROPOSED (worth bundling with GChat) or RECOMMENDED (worth doing as part of GChat because GChat would otherwise force a third copy) or FUTURE (worth doing but not blocking GChat).
+
+#### 5.X.1 (RECOMMENDED with GChat) Reuse the shared `messaging/aggregation` engine via a new `comms_message`-backed `MessageStore` adapter
+
+**Status quo.** The shared engine already abstracts the burst/bridge/claim logic via `aggregation.SourceAdapter` + `aggregation.MessageStore` (`backend/internal/messaging/aggregation/interfaces.go:44-136`). Two adapters exist today: `telegramMessageStoreAdapter` (`backend/internal/telegram/aggregation.go:161-256`) and `messagesMessageStoreAdapter` (`backend/internal/messages/aggregation_adapter.go:141-220`). Both read source-specific staging tables (`telegram_message`, `messages_message`).
+
+**The new wrinkle.** GChat is the FIRST chat source to use `comms_message` instead of its own staging table. The `comms_message` schema already reserves the claim columns (`backend/migrations/058_comms_message.up.sql:22-25`) precisely for this. So we need a `commsMessageStoreAdapter` that:
+
+- Reads `comms_message` rows where `source = 'gchat'` (parameterized so it's reusable after Telegram/Messages later migrate onto `comms_message`)
+- Projects `comms_message` rows into `aggregation.Message` (ID, ChatID = thread_id which carries the space resource name for chat sources, IsOutgoing = direction == 'outbound', SentAt, ExternalID = external_id, InteractionID, ClaimedAt, ClaimedSessionRef, ReplyTargetID from `source_metadata.reply_target` if wired)
+- Implements all eight `MessageStore` methods against `comms_message` (with corresponding sqlc queries scoped by `source` parameter)
+
+**Recommendation: RECOMMENDED with GChat.** The adapter must be written for GChat anyway; making it source-parameterized from day one costs nothing extra and gives Telegram/Messages a migration target later. The source-parameterized sqlc queries are no more complex than the per-source ones — they just take `source = sqlc.arg(source)` instead of being hard-coded.
+
+**Cited code references:**
+- `backend/internal/telegram/aggregation.go:161-256` (telegram store adapter)
+- `backend/internal/messages/aggregation_adapter.go:141-220` (messages store adapter)
+- `backend/migrations/058_comms_message.up.sql:22-25` (reserved claim columns)
+- `backend/internal/messaging/aggregation/interfaces.go:98-136` (MessageStore contract)
+
+#### 5.X.2 (PROPOSED — future cleanup) Extract dual-source rematch helpers
+
+**Status quo.** Telegram has two rematch handlers (`UsernameRematchHandler`, `PhoneRematchHandler`) sharing a `peerRematchBase` (`backend/internal/telegram/rematch.go:21-70`). The shared base owns the iteration / link / aggregate loop. The two handlers differ only in which sqlc lookup (`FindDistinctUnmatchedPeerUserIDsByUsername` vs `FindDistinctUnmatchedPeerUserIDsByPhone`) and how the value is normalized (raw vs digits-only).
+
+GChat introduces ANOTHER dual-source pair (`GChatHandleRematchHandler` for `gchat` type + `GChatEmailRematchHandler` for `email` type). Their bodies will be 95% identical: both call `ScanIdentifier` on the provider for the new value, both iterate over enabled-`gchat` accounts.
+
+**Recommendation: PROPOSED — future cleanup.** The two GChat handlers are already simple enough that a custom abstraction at this point would add more types than it removes (the value normalization differs: `gchat` and `email` both normalize via the same `matching.NormalizeEmail` function, so the "differ only in normalization" axis isn't even there for GChat). After GChat lands, a generic `IdentifierFanoutRematchHandler[Provider, Normalizer]` could collapse `GmailRematchHandler` + `GChatEmailRematchHandler` + the `GChatHandleRematchHandler` + the calendar email handler into a single parameterized factory. NOT a blocker for GChat.
+
+**Cited code references:**
+- `backend/internal/telegram/rematch.go:21-122` (telegram base + two handlers)
+- `backend/internal/google/gmail_rematch.go:32-136` (gmail's email rematch handler)
+
+#### 5.X.3 (PROPOSED) Wire explicit-reply bridging via `ReplyTargetID` for chat sources
+
+**Status quo.** The `aggregation.Message.ReplyTargetID` field carries the source-defined "external message id of the referenced message" (`backend/internal/messaging/aggregation/interfaces.go:34`). Telegram populates it from `reply_to_msg_id` (`backend/internal/telegram/aggregation.go:251-254`); Messages populates it from `reply_to_guid` (`backend/internal/messages/aggregation_adapter.go:214-217`). The engine uses it in `tryExplicitReplyBridge` to bridge across the time window when an inbound message explicitly replies to an outbound message.
+
+**GChat option.** Chat API exposes `message.threadReply: true` and `message.thread.name`, and replies in threads can be addressed via `message.quotedMessageMetadata` (limited availability). The simplest mapping: when a message is a `threadReply` AND the thread head is in scope, use the thread head's resource name as `ReplyTargetID`. The schema does not have a direct column on `comms_message` for this — it would live in `source_metadata.reply_target_external_id`. The store adapter would project it into `aggregation.Message.ReplyTargetID`.
+
+**Recommendation: PROPOSED for the MVP, leaning toward defer.** Burst+time-window bridging already handles the common case (an inbound burst within 48h after an outbound burst promotes to mutual). Explicit-reply bridging is only valuable when a delayed reply (>48h) is unambiguously tied to a specific earlier message. For chat, the bursts are tight enough that the time window almost always covers it. Decision deferred to implementation: if the project setup ergonomics for `quotedMessageMetadata` are clean, wire it; if not, defer to a follow-up. NOT a blocker.
+
+**Cited code references:**
+- `backend/internal/messaging/aggregation/interfaces.go:34` (ReplyTargetID contract)
+- `backend/internal/telegram/aggregation.go:251-254` (telegram's reply-target mapping)
+- `backend/internal/messages/aggregation_adapter.go:214-217` (messages' reply-target mapping)
+
+#### 5.X.4 (PROPOSED — defensive) Apply LIKE-escape on `SourceRefPrefix` for all chat sources
+
+**Status quo.** Telegram's chat IDs are numeric int64 → escape is unnecessary (`backend/internal/telegram/aggregation.go:138-140`). Messages' chat.guid contains `_` → escape is mandatory (`backend/internal/messages/aggregation_adapter.go:107-114`). The `SourceAdapter` contract explicitly notes adapters that may contain `_`/`%` MUST escape. The compliance is per-adapter today.
+
+**GChat consideration.** Chat space resource names like `spaces/AAAA9876` do not legitimately contain `_` or `%` today. But the format is opaque and could change. The Messages-style escape is one `strings.NewReplacer` call — negligible cost.
+
+**Recommendation: PROPOSED — defensive.** Apply the escape unconditionally in `gchatAdapter.SourceRefPrefix`. Mirror the Messages adapter line-for-line. Costs nothing; future-proofs against Chat resource name format drift.
+
+**Cited code references:**
+- `backend/internal/messages/aggregation_adapter.go:107-114` (escape implementation)
+- `backend/internal/messaging/aggregation/interfaces.go:58-68` (contract requiring escape)
+
+#### 5.X.5 (PROPOSED — future cleanup) Share the Gmail / GChat "scan a window per account, advance cursor on success" plumbing
+
+**Status quo.** Gmail's `Sync` (`backend/internal/google/gmail.go`) implements per-account cursor windowing, max-windows-per-sync budget, safety lag, and rate-limit handling. GChat will need the same — per-space (not per-account) cursor windowing, with a `gchatMaxWindowsPerSpace`/`gchatMaxWindowsPerSync` budget and a `gchatSearchSafetyLag` analog. The logic is structurally similar but scoped differently.
+
+**Recommendation: PROPOSED — future cleanup, after both providers are stable.** The plumbing isn't quite identical enough to extract today (per-account-windowed vs per-space-windowed), and extracting before we know what the GChat-specific edge cases look like would be premature. Re-evaluate after MVP rollout: if there are 2-3 follow-on chat sources (WhatsApp, Slack), extract a `windowedSync` helper at that point. NOT a blocker.
+
+**Cited code references:**
+- `backend/internal/google/gmail.go:35-75` (Gmail's window constants)
+
+#### 5.X.6 (NOT recommended) Generalize Gmail's `BuildMethodsFromExternal` to populate gchat from email
+
+**Status quo.** `BuildMethodsFromExternal` in `backend/internal/service/external_methods.go` is the shared helper that converts an `ExternalContact` into `ContactMethodInput`s. It has special-case branches for `Source == "telegram"` (extract `metadata.username`). GChat could in principle add a branch reading `metadata.gchat_address`.
+
+**Recommendation: NOT recommended.** GChat is not a discovery source — there are no `external_contact` rows for GChat. The helper is only invoked on imports, and GChat does no imports. Adding a branch for a source that never feeds the helper would be dead code.
+
+#### 5.X.7 (DEFERRED) `IdentifierTypeGChat` constant — keep; multi-mapping in `MapIdentifierTypeToContactMethodTypes` — NOT added in MVP
+
+**Status quo.** `backend/internal/identity/normalize.go:90-107` maps an `IdentifierType` to the set of `contact_method.type` values it should match against. **The actual one-to-many ("dual-source") precedent in this file is WhatsApp**, not iMessage. WhatsApp at `backend/internal/identity/normalize.go:102-103` is the ONLY existing mapping that returns multiple contact-method types: `IdentifierTypeWhatsApp` → `[ContactMethodTypeWhatsApp, ContactMethodTypePhone]`. iMessage and Telegram each map to a SINGLE type:
+
+- `IdentifierTypeIMessageEmail` → `[ContactMethodTypeEmail]` (`backend/internal/identity/normalize.go:98-99`) — single
+- `IdentifierTypeIMessagePhone` → `[ContactMethodTypePhone]` (`backend/internal/identity/normalize.go:100-101`) — single
+- `IdentifierTypeTelegram` → `[ContactMethodTypeTelegram]` (`backend/internal/identity/normalize.go:96-97`) — single
+
+iMessage and Telegram both achieve their "dual-source" effect by having TWO IdentifierType values (e.g. `IdentifierTypeIMessageEmail` + `IdentifierTypeIMessagePhone`) routed to from different rematch handlers — that's the rematch-handler-layer dual-source pattern (§1, identity-matching decision row). WhatsApp is the only existing one-IdentifierType-many-ContactMethodType ("sender-resolution dual-source") precedent.
+
+**What this spec keeps and what it drops.**
+
+- **Keep:** add `IdentifierTypeGChat IdentifierType = "gchat"` (constant) and `ContactMethodTypeGChat = "gchat"` (constant). Normalization: `Normalize(raw, IdentifierTypeGChat)` delegates to `normalizeEmail` (since GChat sender addresses ARE emails). These are cheap, harmless, and let future callers reference the right enum value.
+- **Drop from MVP:** the proposed `MapIdentifierTypeToContactMethodTypes(IdentifierTypeGChat) → [ContactMethodTypeGChat, ContactMethodTypeEmail]` multi-mapping. Adding it now would be **dead code** — the sweep-time identity map is built directly from the sqlc query `ListGChatIdentitiesForSync` (filter `WHERE type IN ('gchat', 'email')`), and **no caller invokes `IdentityService.MatchOrCreate(IdentifierTypeGChat, ...)`** in MVP. Two encodings of the same `(gchat, email)` set (one in `normalize.go`, one in the sqlc query) could drift independently. Until an actual `MatchOrCreate(IdentifierTypeGChat, ...)` caller emerges, the sqlc query is the **single source of truth** for the dual-source set.
+
+**Recommendation: DEFERRED.** Re-evaluate if/when a code path needs sender-resolution dual-source via the identity-mapping layer. Until then, the WhatsApp precedent at `backend/internal/identity/normalize.go:102-103` documents the shape that addition would take.
+
+**This is distinct from the backfill-trigger dual-source** (the two RematchHandler registrations described in §1 and the Telegram precedent at `backend/internal/telegram/rematch.go:74-95` + `backend/internal/telegram/rematch.go:97-121`), which IS added in MVP. The two mechanisms cover non-overlapping triggers (see §1's identity-matching row); the deferred mapping addition would cover sender resolution at sweep time, the two RematchHandlers cover contact-method-added at link time. Neither subsumes the other.
+
+**Cited code references:**
+- `backend/internal/identity/normalize.go:15-31` (IdentifierType enum)
+- `backend/internal/identity/normalize.go:36-41` (ContactMethodType enum)
+- `backend/internal/identity/normalize.go:87-107` (mapping helper — WhatsApp at lines 102-103 is the precedent shape)
+
+### 5.6 Why this isn't `gchat_message`
+
+Earlier integrations (Telegram, Messages) each added a dedicated staging table. The decision NOT to do that for GChat is deliberate:
+
+1. The `comms_message` schema explicitly **reserves the claim columns** for chat sources (`backend/migrations/058_comms_message.up.sql:22-25`) and the comments in 058 call out future telegram/messages migration as planned.
+2. Adding `gchat_message` would mean a third parallel adapter that's structurally identical to the comms-backed one and would need migrating onto `comms_message` later anyway.
+3. The source-parameterized adapter is no more work than a source-specific one and gives Telegram/Messages a proven landing pad.
+
+This is RECOMMENDED, and §5.X.1 captures it explicitly.
+
+---
+
+## 6. Database Changes
+
+### 6.1 `interaction.source` CHECK constraint
+
+Add `'gchat'` to the allowed `source` values. Mirror Gmail's 059 migration verbatim:
+
+| Migration | Action |
+|-----------|--------|
+| New `06X_interaction_source_gchat.up.sql` | `DROP CONSTRAINT interaction_source_check` then `ADD CONSTRAINT ... CHECK (source IN ('manual','gcal','todoist','telegram','messages','anarlog_sessions','phone_calls','email','gchat'))` |
+| Constants | Add `InteractionSourceGChat = "gchat"` to `backend/internal/repository/interaction.go` in the SAME PR |
+| Source-check integration test | Update `backend/tests/interaction_source_descriptor_check_test.go` to assert the new value (test enforces the Go constants equal the live CHECK set) |
+
+### 6.2 `comms_message` no schema change, but `thread_id` column comment broadens
+
+The schema already permits `source='gchat'` (it's `TEXT NOT NULL` with no CHECK — see `backend/migrations/058_comms_message.up.sql:8`). The reserved `claimed_at` / `claimed_session_ref` columns activate for the first time under GChat's aggregation path. No structural migration needed.
+
+**Column-comment broadening for `thread_id`.** The original 058 migration's inline SQL comment scopes `thread_id` to email: *"thread_id TEXT, -- email: Gmail threadId"* (`backend/migrations/058_comms_message.up.sql:10`). GChat reuses the column to carry the **space resource name** (`spaces/<id>`). The inline comment in migration 058 is immutable history — to broaden the documented semantics, the same migration that adds `'gchat'` to `interaction.source` CHECK (§6.1) also issues an explicit `COMMENT ON COLUMN comms_message.thread_id IS '...'` statement that documents the dual semantics:
+
+```sql
+COMMENT ON COLUMN comms_message.thread_id IS
+  'email: Gmail threadId; gchat/telegram/messages: space/chat scope resource name';
+```
+
+`COMMENT ON COLUMN` survives in the live catalog (unlike inline SQL comments) and is the canonical documentation surface from this migration forward.
+
+### 6.3 sqlc queries
+
+New queries to add to `backend/internal/db/queries/comms_message.sql` (source-parameterized so they serve both GChat today and Telegram/Messages on later migration):
+
+- `ListUnprocessedCommsContactIDs(source)`
+- `ListUnprocessedCommsByContact(source, contact_id)`
+- `ListUnprocessedCommsByContactAndChat(source, contact_id, chat_id)`
+- `GetCommsMessageByReplyTarget(source, chat_id, reply_target_id)`
+- `MarkCommsMessagesProcessed(message_ids, interaction_id)`
+- `ClaimCommsMessagesTx(message_ids, session_ref)`
+- `ClearStaleCommsClaimTx(message_ids, expected_session_ref)`
+
+**All new queries MUST scope to `deleted_at IS NULL`** (per the soft-delete invariant), and all unprocessed-row readers (`ListUnprocessedCommsContactIDs`, `ListUnprocessedCommsByContact`, `ListUnprocessedCommsByContactAndChat`) MUST additionally scope to `processed_at IS NULL`. This mirrors the existing pattern in the same file — see e.g. `GetCommsMessage` (`backend/internal/db/queries/comms_message.sql:96-100`) for the `deleted_at IS NULL` precedent and `MarkCommsMessagesProcessed` (`backend/internal/db/queries/comms_message.sql:122-127`) for the combined `processed_at IS NULL AND deleted_at IS NULL` precedent. The edit/delete semantics in §1 and §5.2 depend on this: edited rows have `processed_at IS NOT NULL` and are correctly skipped; soft-deleted rows have `deleted_at IS NOT NULL` and are correctly skipped. Without these filters the engine would reprocess edits and resurrect deleted messages — violating the locked edit/delete row in §1.
+
+New query for the dual-source identity map:
+
+- `ListGChatIdentitiesForSync` — returns `(value_normalized, contact_id, source_type)` for rows where `type IN ('gchat', 'email')` AND contact is non-deleted. Reuses the existing trigger-normalized `value_normalized` column. The `source_type` discriminator lets the provider log which side matched (debug-level only — never with the value).
+
+### 6.4 `external_sync_state` no schema change
+
+`external_sync_state.source` is free-text (no CHECK — `backend/migrations/011_external_sync.up.sql:7`). One row per `(source='gchat', account_id)`; `strategy='contact_driven'` (same as Gmail); `metadata` carries the per-space cursor map (§3.3), the membership cache (§3.4), the `backfill_since` anchor, and the `me_identities` cache.
+
+### 6.5 `interaction.source` constants update + test
+
+Per the pattern locked in by Gmail spec §6.2: the migration AND the constant addition AND the source-check test update land together. Anything less leaves the Go-vs-DB invariant cracked.
+
+---
+
+## 7. Configuration
+
+| Setting | Default | Where |
+|---------|---------|-------|
+| Sync interval | 15 min | `SourceConfig.DefaultInterval` |
+| Backfill start date | 2026-01-01 | `external_sync_state.metadata.backfill_since` per account |
+| Burst window | 2 h | `GCHAT_BURST_WINDOW_HOURS` env var (analog of Telegram's `TELEGRAM_BURST_WINDOW_HOURS`) |
+| Reply bridge | 48 h | `GCHAT_REPLY_BRIDGE_HOURS` env var |
+| Max windows per sync | 24 | provider constant (analog of `gmailMaxWindowsPerSync`) |
+| Membership cache TTL | 24 h | provider constant `gchatMembershipCacheTTL` |
+| Enablement | reconciliation creates/enables a `gchat` state per Google credential | **not** auto-provided by the scheduler — same loop the Gmail spec adds in its §7 |
+
+**OAuth scopes added at `backend/internal/google/oauth.go:26`:**
+
+```go
+var Scopes = []string{
+    "openid",
+    "email",
+    "profile",
+    gmail.GmailReadonlyScope,
+    calendar.CalendarReadonlyScope,
+    people.ContactsReadonlyScope,
+    // NEW: chat scopes — one-time re-consent required on existing accounts
+    "https://www.googleapis.com/auth/chat.spaces.readonly",
+    "https://www.googleapis.com/auth/chat.messages.readonly",
+}
+```
+
+A one-time re-consent prompt is required for already-connected accounts to pick up the new scopes — surface a reconnect indicator in the settings UI when an account is missing them.
+
+**Workspace-account sender resolution may need People API.** For consumer `@gmail.com` accounts (the MVP target — see §10 Q4), `message.sender.name` resolves to the user's email address directly. For Workspace senders, the `users/<id>` form may need a `people.get` lookup to map id → email. The `people.ContactsReadonlyScope` is already granted (`backend/internal/google/oauth.go` Scopes list, line `people.ContactsReadonlyScope`) for Calendar attendee resolution, so no new scope is required — but the call is added to the People API quota. People API daily quota for the People service is a known-unknown; rough order of magnitude is in the tens of thousands of requests/day per project, but the exact number must be verified against the GCP console during implementation. If Workspace lookups become quota-dominant, cache by `users/<id>` with the same TTL as `gchatMembershipCacheTTL`.
+
+**New Go API dependency:** `google.golang.org/api/chat/v1`.
+
+**Operator setup (one-time, in the GCP project):**
+
+1. Open the Chat API Configuration page for the GCP project.
+2. Configure the Chat App: name, avatar URL, description. **Disable** Interactive features (no slash commands, no webhooks).
+3. Verify the personal `@gmail.com` user is a Test User on the External-type consent screen (already done per the OAuth probe).
+4. Confirm `spaces.list` returns data via OAuth Playground before enabling the feature flag in the Pi.
+
+**No new env vars beyond the burst/reply tuning above.** OAuth credentials are shared with Gmail/Calendar — `GOOGLE_OAUTH_CLIENT_ID` / `GOOGLE_OAUTH_CLIENT_SECRET` are already in the env.
+
+---
+
+## 8. Implementation Phases
+
+The implementation is sequenced as **three PRs** for review hygiene and bisectability — NOT as a staged-deploy risk strategy. All three PRs may safely deploy together; the GChat integration is **opt-in by construction** and remains inert until two operator-side prerequisites are satisfied: (a) the one-time GCP Chat App configuration (§7) and (b) OAuth consent for the new `chat.spaces.readonly` + `chat.messages.readonly` scopes on at least one connected Google account. Without those, no GChat code path executes — there are no public webhooks, no scheduled jobs that fire without an enabled `external_sync_state(source='gchat')` row, and no rematch fan-out without a `gchat` or `email` method linked to a contact. Deployment risk to the rest of the system (single-user, Pi-hosted, Tailscale-fronted) is bounded to the schema migration in PR 1, which is additive only (one `CHECK` constraint enum value + one `COMMENT ON COLUMN`).
+
+The §5.X refactor opportunities marked RECOMMENDED are woven into the PRs below; PROPOSED-only items remain as a tail. The phase ordering is a recommended merge sequence, not a deploy-staging requirement.
+
+### Phase 1: Schema + identity + comms_message-backed aggregation engine wiring
+
+**Inert until:** Phase 3 wires enablement and the user completes the Chat App config + OAuth consent.
+
+- New migration adding `'gchat'` to `interaction.source` CHECK; constant `InteractionSourceGChat`; source-check integration-test update.
+- `COMMENT ON COLUMN comms_message.thread_id` broadening per §6.2 in the same migration.
+- New constants: `ContactMethodTypeGChat`, `IdentifierTypeGChat`; `Normalize(_, IdentifierTypeGChat)` delegates to `normalizeEmail`. **NO new `MapIdentifierTypeToContactMethodTypes` branch** — see §5.X.7 (DEFERRED). The sender-resolution dual-source set is carried by the sqlc query, not the identity-mapping layer.
+- New sqlc query `ListGChatIdentitiesForSync` (dual-source via `WHERE type IN ('gchat', 'email')`).
+- Extend `CommsMessageRepository` with the eight source-parameterized `MessageStore` methods (RECOMMENDED §5.X.1) + corresponding sqlc queries, ALL scoped to `deleted_at IS NULL` (and `processed_at IS NULL` for unprocessed-readers — §6.3).
+- `gchatAdapter` (`SourceAdapter` impl, RECOMMENDED §5.X.4 defensive LIKE-escape applied).
+- `commsMessageStoreAdapter` parameterized by `source='gchat'` (proves the substrate per §5.X.1; reusable by Telegram/Messages on later migration).
+- Construct an `aggregation.Engine` instance wired with the GChat adapter pair, the existing `events.Bus`, and the `AggregatorReenqueuer`. The engine itself is unchanged; only the per-source wiring is new.
+- Register the GChat engine in the `PerSourceChatListerRegistry` (`backend/internal/scheduler/messaging_aggregate_worker.go:39-61`) and as an `AggregatorReenqueuer` entry for `source="gchat"` (`backend/internal/consumer/aggregator_reenqueuer.go:30-56`).
+- **No new event kinds added.** The engine already publishes `KindMessageReceived`/`KindMessageSent` with `Source = "gchat"` set from the adapter's `SourceName()`.
+- Unit + integration tests: dual-source identity map; source-parameterized query selection; CHECK constraint round-trip; burst grouping over `comms_message` rows; reply-bridge to mutual; edit no-op (engine ignores rows with non-null `processed_at`); delete no-op (engine ignores soft-deleted rows); claim race recovery.
+
+### Phase 2: Provider + rematch + bounded edit/delete handling + per-sweep metrics
+
+**Inert until:** Phase 3 wires enablement and the user completes Chat App config + OAuth consent.
+
+- OAuth scopes added at `oauth.go:26`. New Go dep `chat/v1`.
+- `GChatSyncProvider` with: `spaces.list` enumeration; membership resolution with cache (`lastActiveTime` OR age > TTL triggers); per-space cursor pagination; dual-source identity resolution against `ListGChatIdentitiesForSync`; content upsert with set-union provenance merge (no event publish); stale-cursor reaper with restoration on re-discovery (§3.3).
+- Edit detection via the PROVISIONAL `updateTime` cursor (§3.1 step 8) — verify support against Chat API docs before wiring, fall back to the bounded 7-day per-row `messages.get` polling described in §3.1 step 8 if `updateTime` is not filterable. **Edit handling is bounded from the first commit:** `source_metadata.previous_bodies[]` is capped at last-3 at write time (no separate hardening PR). Delete handling soft-deletes the `comms_message` row.
+- `GChatHandleRematchHandler` (`IdentifierType="gchat"`) and `GChatEmailRematchHandler` (`IdentifierType="email"`); both register with `RematchService` via the existing fan-out (multi-handler-per-type, already supported); both call `aggregation.Engine.AggregateForContactBatch` after linking.
+- **Metrics inline at write time:** `metrics.Increment(...)` calls embedded in the provider sweep loop and the edit/delete reconciliation path for `items_processed`, `items_matched`, `spaces_skipped_no_known_member`, `edits_applied`, `deletes_applied`. Add inline with the loops that drive them, not retroactively.
+- Unit tests: chunk/page handling against a fake `chat.Service`; sender-attribution rule (inbound = one row, sender only); outbound fan-out across known co-members rule (one row per known co-member); DM-single-row case; cross-account dedup via provenance merge; cursor advancement after successful window; cursor restoration after `archived_space_cursors` reappearance; membership cache age-TTL refresh; `previous_bodies[]` cap holds across repeated edits; bounded 7-day fallback respects the window.
+
+### Phase 3: Registration + enablement reconciliation + status endpoint (feature goes live)
+
+**Activates the feature** once Chat App config and OAuth consent are completed by the user.
+
+- Wire provider, both rematch handlers, `AggregatorReenqueuer` registry entry, `PerSourceChatListerRegistry` entry in `main.go`.
+- Boot reconciliation creates an `external_sync_state(source='gchat', account_id)` row per Google credential that has the new chat scopes granted; sets `enabled=true`; sets `metadata.backfill_since` and an empty `space_cursors` map.
+- OAuth-connect reconciliation also creates/enables on a fresh account connection.
+- Surface a "reconnect required" indicator in the settings UI for accounts missing the new scopes.
+- Status endpoint richness in `GET /api/v1/sync/status?source=gchat` mirroring Gmail's status shape. Lands with the reconnect indicator since both surfaces touch the same UI.
+- Integration test: enabling a fresh account triggers a sweep that enumerates spaces → membership-resolves → stores `comms_message` rows → the next aggregation pass derives interactions → cadence updates as expected.
+
+### PROPOSED-only follow-ups (NOT bundled with GChat MVP)
+
+- §5.X.2 Extract generic `IdentifierFanoutRematchHandler` after GChat lands (groups Gmail + GChat-email + Calendar email + GChat-handle).
+- §5.X.3 Wire explicit-reply bridging via `quotedMessageMetadata` if delayed-reply false-negatives are observed in practice.
+- §5.X.5 Extract `windowedSync` helper once 2-3 windowed providers exist.
+- §5.X.7 Add the `MapIdentifierTypeToContactMethodTypes(IdentifierTypeGChat) → [gchat, email]` multi-mapping if/when an `IdentityService.MatchOrCreate(IdentifierTypeGChat, ...)` caller emerges.
+- Telegram + Messages migration onto `comms_message` (separate, independent work; substrate is proven by GChat Phase 1).
+
+---
+
+## 9. Testing Strategy
+
+### 9.1 Unit
+
+- `gchatAdapter` source-ref formatting; LIKE-escape regardless of input shape (defensive).
+- `commsMessageStoreAdapter` row projection: `comms_message` → `aggregation.Message` (ChatID = space resource via thread_id, IsOutgoing per direction, ExternalID = external_id, InteractionID / ClaimedAt / ClaimedSessionRef preserved).
+- Dual-source identity map construction from `ListGChatIdentitiesForSync` rows — fan-out to multiple contacts on shared address; case-insensitivity; both gchat and email rows surfaced.
+- Sender-vs-me direction resolution: sender in M → outbound; sender in known map → inbound; sender in neither → skip; DM peer implicit; group-fan-out rule (outbound to N known contacts produces N rows; inbound from one known sender produces one row).
+- Edit detection: same-resource second fetch with differing body advances the body + records edited_at; identical body is a no-op.
+- Delete detection: 404 / tombstone marker soft-deletes the comms_message row.
+- Chunk/cursor advancement: cursor only advances after full window success; partial-window crash restarts the window.
+
+### 9.2 Integration
+
+- Full sweep against a fake `chat.Service`: spaces.list → membership resolve → messages.list → comms_message rows written (no events published by the provider). A subsequent aggregation pass then publishes `KindMessageReceived`/`KindMessageSent` with `Source="gchat"`.
+- Aggregation engine produces correct interactions: same-direction burst within 2h → one interaction; reply within 48h → promote to mutual; reply after 48h → two separate interactions.
+- Cross-account: same message resource observed in two accounts → ONE comms_message row per (matched_contact_id), provenance merged across `observed_accounts[]`.
+- Edit reconciliation: existing interaction unchanged after an edit; `comms_message.body` and `source_metadata.edited_at` updated; the engine's next pass does NOT reprocess the row (`processed_at IS NOT NULL`).
+- Delete reconciliation: `comms_message.deleted_at` set; existing interaction unchanged; the engine's next pass ignores the soft-deleted row.
+- Dual-source rematch fan-out: adding a `gchat` method fires the gchat handler; adding an `email` method fires Calendar + Gmail + GChatEmail handlers; verify the GChatEmail handler scans the right address.
+- Membership cache hit/miss: first sweep populates cache; second sweep within TTL reuses; lastActiveTime advance forces refresh.
+- Zero-known-member space is enumerated but skipped; membership change re-activates it on the next sweep.
+- Cursor crash safety: kill the provider mid-window; restart; the same window restarts from its anchor.
+
+### 9.3 E2E
+
+- `SyncBadge` for `'gchat'` source renders correctly on the settings page (mirrors `gcal` / `email` badges).
+- Contact detail page shows a GChat interaction line item with the right direction signal and aggregated message count.
+
+### 9.4 Manual verification
+
+- Connect a real Google account; verify re-consent prompt fires for the new scopes; confirm `spaces.list` returns data; confirm a known-member DM produces an interaction; confirm a group-chat outbound to two known members produces two interaction rows.
+
+---
+
+## 10. Open Questions & Future Work
+
+### Open questions
+
+1. **Per-thread aggregation inside named SPACES.** Threaded replies in a SPACE could legitimately be modeled as separate aggregation scopes — a 50-message thread is one conversation, but two threads in the same SPACE on the same day are two conversations. The MVP collapses all threads in a SPACE into a single space-scope aggregation key. If this proves too coarse, the `source_ref` shape can be widened to `gchat:<space>:<thread>:<first_message>` — but this is NOT a zero-migration change. Existing v1 rows are written under `gchat:<space>:<first_message>`; switching post-MVP means those existing rows fall outside the new `SourceRefPrefix` LIKE pattern (`gchat:<space>:<thread>:%`) and the engine would no longer recognize them when building subsequent sessions. A widening release requires a one-time data migration that rewrites the existing `interaction.source_ref` values to the new shape (e.g. `UPDATE interaction SET source_ref = ... WHERE source = 'gchat' AND source_ref NOT LIKE 'gchat:%:%:%'`), gated on a feature flag. Both `thread.name` and message `name` are stored in `source_metadata`, so the rewrite has the data it needs — but it's a backfill, not just an adapter swap.
+2. **Explicit-reply bridging via `quotedMessageMetadata`.** Detailed in §5.X.3. Defer to implementation; revisit if delayed-reply false-negatives are observed.
+3. **Membership-cache staleness when a member leaves a space.** The cache TTL is now 24h with an age-based refresh trigger (§3.4), but a member who leaves a quiet space could still be attributed to it for up to 24h. Acceptable for MVP; revisit if production reveals false-positive attributions.
+4. **Workspace-account senders.** The MVP target is a personal `@gmail.com` account; senders in `users/<id>` form for Workspace accounts (vs `users/<email>` for consumer) need a separate resolution path via People API `people.get` (already-granted `people.ContactsReadonlyScope`, see §7). The `users.me.lookup` cache stores both forms; verify quota during implementation.
+5. **Backfill window for a Workspace-hosted SPACE** with many years of history — the `backfill_since=2026-01-01` anchor matches Gmail, but a SPACE the user joined in 2020 has 6 years of pre-anchor content that won't be ingested. This is consistent with Gmail's behavior and intentional; called out for transparency.
+6. **Edit-after-delete race.** If a message is edited and then deleted before the next edit-cursor sweep, the cursor surfaces only the delete event (assuming `updateTime` is monotonic and the delete bumps `updateTime` after the edit). The edited body is then lost — the original body in `comms_message` is whatever was there before the edit, and the row is soft-deleted before we see the edit body. **Acceptable for MVP.** Mitigations are expensive (per-row `messages.get` on every edit-cursor hit, or maintaining a separate "lastSeenUpdateTime" per row) and the failure mode is benign: we lose the edit history of a message the user already chose to delete. Document the loss; revisit only if production shows it matters.
+7. **`updateTime` filter support in `spaces.messages.list`.** Marked PROVISIONAL in §3.1 step 8. Resolve at implementation time by reading the Chat API reference and either confirming with a citation OR falling back to the per-row polling mechanism described in §3.1 step 8.
+
+### Future work (not in scope)
+
+- **Cross-source thread/day merging.** Two interactions per source on the same day with the same contact even if one is GChat and one is Telegram. Future revisit (referenced in Gmail spec §10 as the same deferral).
+- **Real-time via Workspace Events.** If/when Workspace Events ever supports consumer accounts AND the Pi gains a public webhook surface (it currently doesn't — Tailscale only), revisit Pub/Sub-based real-time. Polling is the right choice for MVP.
+- **Per-thread aggregation refinement.** See open question 1.
+- **Telegram + Messages migration onto `comms_message`.** Substrate is proven by GChat (§5.X.1); separate, independent work to migrate the existing two sources onto the shared table.
+- **GChat → CRM contact discovery.** Surface frequent unmatched senders as import candidates (parallel to Telegram's discovery flow). Deferred — match-or-skip is the deliberate MVP posture.
+- **`IdentifierFanoutRematchHandler` extraction.** §5.X.2 follow-up after GChat lands.
+- **GChat reactions and attachment content** — not requested; can be added later if AI summarization wants them.
+- **Slash-command / app-message ingestion.** Out of scope; not interpersonal.

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -389,9 +389,9 @@ func run() int {
 			repository.InteractionSourceMessages: repository.NewMessagesStagingProcessor(messagesMessageRepo),
 			// GChat create-path: the InteractionRecorder consumer marks
 			// comms_message(source='gchat') rows processed via this
-			// session-scoped processor (decision 8b). Without it the
-			// recorder's zero-rows-affected rollback fires and the engine
-			// reprocesses forever. Inert until PR 2/PR 3 write gchat rows.
+			// session-scoped processor. Without it the recorder's
+			// zero-rows-affected rollback fires and the engine reprocesses
+			// forever. Inert until a chat provider writes gchat rows.
 			repository.InteractionSourceGChat: repository.NewCommsSessionStagingProcessor(commsMessageRepo),
 		},
 	)
@@ -1056,13 +1056,12 @@ func run() int {
 		repository.InteractionSourceMessages,
 	)
 
-	// GChat aggregation engine over comms_message (PR 1 of the GChat
-	// integration, #337). LIVE but INERT: the engine/worker/sweeper/
-	// reenqueuer for gchat run on every tick, but every query is
-	// source='gchat'-scoped and returns zero rows until PR 2/PR 3 land the
-	// provider + enablement that write comms_message(source='gchat') rows.
-	// Burst/reply windows hard-coded here (matching how messages hard-codes
-	// its constants); the GCHAT_* env-var overrides are PR 2/PR 3 scope.
+	// GChat aggregation engine over comms_message. LIVE but INERT: the
+	// engine/worker/sweeper/reenqueuer for gchat run on every tick, but every
+	// query is source='gchat'-scoped and returns zero rows until a provider +
+	// enablement write comms_message(source='gchat') rows. Burst/reply windows
+	// are hard-coded here (matching how messages hard-codes its constants);
+	// env-var overrides are out of scope for now.
 	gchatEnqueuer := consumer.NewRiverInteractionRecorderEnqueuer(riverClient)
 	const gchatBurstWindowHours = 2
 	const gchatReplyBridgeHours = 48

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -373,6 +373,11 @@ func run() int {
 	// InteractionRecorder wiring so the consumer can mark messages
 	// processed in the same tx as the interaction insert).
 	telegramMessageRepo := repository.NewTelegramMessageRepository(database.Queries)
+	// Comms message repo (shared cross-source content store). Hoisted here
+	// so the staging registry below can add the gchat session-scoped
+	// processor; also reused by the email-consumer wiring + the gchat
+	// aggregation engine further down.
+	commsMessageRepo := repository.NewCommsMessageRepository(database.Queries)
 
 	// Source-neutral staging registry — InteractionRecorder dispatches
 	// MarkProcessedTx by env.Source to the right repository. Unknown
@@ -382,6 +387,12 @@ func run() int {
 		map[string]repository.StagingProcessor{
 			repository.InteractionSourceTelegram: repository.NewTelegramStagingProcessor(telegramMessageRepo),
 			repository.InteractionSourceMessages: repository.NewMessagesStagingProcessor(messagesMessageRepo),
+			// GChat create-path: the InteractionRecorder consumer marks
+			// comms_message(source='gchat') rows processed via this
+			// session-scoped processor (decision 8b). Without it the
+			// recorder's zero-rows-affected rollback fires and the engine
+			// reprocesses forever. Inert until PR 2/PR 3 write gchat rows.
+			repository.InteractionSourceGChat: repository.NewCommsSessionStagingProcessor(commsMessageRepo),
 		},
 	)
 
@@ -564,7 +575,7 @@ func run() int {
 	// Registered unconditionally; it processes the email.received /
 	// email.sent events the Gmail provider publishes in production (and
 	// stays idle when no such event is routed, e.g. event-bus off mode).
-	commsMessageRepo := repository.NewCommsMessageRepository(database.Queries)
+	// commsMessageRepo was hoisted earlier (above the staging registry).
 	emailInteractionConsumer := consumer.NewEmailInteractionConsumer(
 		contactService, commsMessageRepo, interactionRepo, contactService,
 		eventBus, cadenceUpdater, followUpManager,
@@ -1045,6 +1056,33 @@ func run() int {
 		repository.InteractionSourceMessages,
 	)
 
+	// GChat aggregation engine over comms_message (PR 1 of the GChat
+	// integration, #337). LIVE but INERT: the engine/worker/sweeper/
+	// reenqueuer for gchat run on every tick, but every query is
+	// source='gchat'-scoped and returns zero rows until PR 2/PR 3 land the
+	// provider + enablement that write comms_message(source='gchat') rows.
+	// Burst/reply windows hard-coded here (matching how messages hard-codes
+	// its constants); the GCHAT_* env-var overrides are PR 2/PR 3 scope.
+	gchatEnqueuer := consumer.NewRiverInteractionRecorderEnqueuer(riverClient)
+	const gchatBurstWindowHours = 2
+	const gchatReplyBridgeHours = 48
+	gchatEngine := google.NewGChatAggregationEngine(
+		gchatBurstWindowHours,
+		gchatReplyBridgeHours,
+		commsMessageRepo,
+		interactionRepo,
+		contactService,
+		contactService,
+		eventBus,
+		database.Pool,
+		gchatEnqueuer,
+	)
+	gchatReenqueuer := consumer.NewCommsAggregatorReenqueuer(
+		gchatEngine,
+		riverClient,
+		repository.InteractionSourceGChat,
+	)
+
 	// Wire the per-source aggregator reenqueuer registry. The
 	// InteractionRecorderWorker holds the deferred holder; this
 	// assignment makes the post-commit reenqueue path live for both
@@ -1054,6 +1092,7 @@ func run() int {
 	// degrade cleanly).
 	reenqueuerEntries := map[string]consumer.AggregatorReenqueuer{
 		repository.InteractionSourceMessages: messagesReenqueuer,
+		repository.InteractionSourceGChat:    gchatReenqueuer,
 	}
 	if telegramManager != nil {
 		reenqueuerEntries[repository.InteractionSourceTelegram] = consumer.NewTelegramAggregatorReenqueuer(telegramManager.AggregationEngine())
@@ -1069,11 +1108,17 @@ func run() int {
 	chatListerRegistry := scheduler.NewPerSourceChatListerRegistry(
 		map[string]func(ctx context.Context, contactID uuid.UUID) ([]string, error){
 			repository.InteractionSourceMessages: messagesMessageRepo.ListUnprocessedChatsByContact,
+			// Source-bound closure: the comms repo method is multi-source
+			// (ListUnprocessedChatsByContactForSource), so bind 'gchat'.
+			repository.InteractionSourceGChat: func(ctx context.Context, contactID uuid.UUID) ([]string, error) {
+				return commsMessageRepo.ListUnprocessedChatsByContactForSource(ctx, repository.InteractionSourceGChat, contactID)
+			},
 		},
 	)
 	river.AddWorker(riverWorkers, scheduler.NewMessagingAggregateForContactWorker(
 		map[string]scheduler.ChatAwareAggregator{
 			repository.InteractionSourceMessages: messagesEngine,
+			repository.InteractionSourceGChat:    gchatEngine,
 		},
 		chatListerRegistry,
 	))
@@ -1084,6 +1129,10 @@ func run() int {
 	// a full interval before the safety net engages.
 	sweeperListers := map[string]scheduler.UnprocessedContactLister{
 		repository.InteractionSourceMessages: messagesMessageRepo,
+		// Source-bound adapter: comms_message is multi-source, so wrap the
+		// repo with a 'gchat'-pinned lister (built type, not inline struct,
+		// per the single-file build convention).
+		repository.InteractionSourceGChat: repository.NewCommsSourceContactLister(commsMessageRepo, repository.InteractionSourceGChat),
 	}
 	river.AddWorker(riverWorkers, scheduler.NewMessagingAggregateSweeperWorker(sweeperListers, riverClient))
 	riverClient.PeriodicJobs().Add(river.NewPeriodicJob(

--- a/backend/internal/consumer/comms_aggregator_reenqueuer.go
+++ b/backend/internal/consumer/comms_aggregator_reenqueuer.go
@@ -1,0 +1,137 @@
+package consumer
+
+import (
+	"context"
+	"strings"
+
+	"personal-crm/backend/internal/consumer/consumerjobs"
+	"personal-crm/backend/internal/events"
+
+	"github.com/google/uuid"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
+	"github.com/rs/zerolog/log"
+)
+
+// commsChatAwareAggregator captures the chat-aware aggregator surface needed by
+// the comms reenqueuer. Concrete is *aggregation.Engine.AggregateForContact
+// (chat-scoped). The interface keeps the consumer package free of a back-edge
+// to the google adapter package; main.go wires the concrete engine in.
+type commsChatAwareAggregator interface {
+	AggregateForContact(ctx context.Context, contactID uuid.UUID, chatID string) error
+}
+
+// commsRiverInserter is the narrow surface used to enqueue a fresh
+// MessagingAggregateForContactArgs in addition to the chat-aware call.
+type commsRiverInserter interface {
+	Insert(ctx context.Context, args river.JobArgs, opts *river.InsertOpts) (*rivertype.JobInsertResult, error)
+}
+
+// CommsAggregatorReenqueuer wires a comms_message-backed aggregation engine +
+// River client into the post-Stage-3 reenqueue path. It mirrors
+// MessagesAggregatorReenqueuer (string chatID) but generalizes the source: the
+// PeerRef prefix is `source + ":"`, so the same struct serves any comms-backed
+// chat source (gchat now; telegram/messages on later migration). Two actions
+// run per call:
+//
+//  1. Enqueue a fresh MessagingAggregateForContactArgs River job —
+//     UniqueOpts dedup makes it a no-op when one is already in-flight, but a
+//     brand-new job fires when the previous worker just finished. Catches rows
+//     that landed in OTHER chats for the same contact while Stage 3 committed.
+//
+//  2. Synchronously invoke AggregateForContact for the chat just processed —
+//     closes the burst-extend window so a follow-up message in the same chat
+//     extends the interaction just created instead of creating a new one.
+//
+// Both happen best-effort: failures are logged (the interaction has already
+// committed; rolling back is not an option).
+type CommsAggregatorReenqueuer struct {
+	engine      commsChatAwareAggregator
+	riverClient commsRiverInserter
+	source      string
+}
+
+// NewCommsAggregatorReenqueuer builds the reenqueuer over a comms-backed
+// chat-aware aggregator + river client. source is the interaction source
+// (e.g. "gchat") and drives both the enqueued job's Source field and the
+// PeerRef prefix used to parse the chat scope.
+func NewCommsAggregatorReenqueuer(
+	engine commsChatAwareAggregator,
+	riverClient commsRiverInserter,
+	source string,
+) *CommsAggregatorReenqueuer {
+	return &CommsAggregatorReenqueuer{engine: engine, riverClient: riverClient, source: source}
+}
+
+// Reenqueue implements AggregatorReenqueuer.
+func (r *CommsAggregatorReenqueuer) Reenqueue(ctx context.Context, env *events.Envelope, contactID uuid.UUID) error {
+	// Fire a fresh aggregator job up-front. The shared uniqueness policy
+	// dedups in-flight jobs but intentionally allows a fresh job after a
+	// prior one completed.
+	if r.riverClient != nil {
+		_, err := r.riverClient.Insert(ctx, consumerjobs.MessagingAggregateForContactArgs{
+			ContactID: contactID,
+			Source:    r.source,
+		}, &river.InsertOpts{
+			UniqueOpts: consumerjobs.MessagingAggregateUniqueOpts(),
+		})
+		if err != nil {
+			log.Warn().
+				Err(err).
+				Str("source", r.source).
+				Str("contact_id", contactID.String()).
+				Msg("comms-reenqueuer: enqueue MessagingAggregateForContactArgs failed; continuing with synchronous pass")
+		}
+	}
+
+	// Chat-aware synchronous pass for the chat just processed.
+	chatID, ok := parseCommsPeerRef(env, r.source+":")
+	if !ok {
+		log.Warn().
+			Str("source", env.Source).
+			Str("envelope_kind", string(env.Kind)).
+			Msg("comms-reenqueuer: could not parse chat scope from envelope; skipping synchronous pass")
+		return nil
+	}
+	if r.engine == nil {
+		log.Warn().
+			Str("source", r.source).
+			Msg("comms-reenqueuer: no engine wired; skipping synchronous pass")
+		return nil
+	}
+	return r.engine.AggregateForContact(ctx, contactID, chatID)
+}
+
+// parseCommsPeerRef extracts the chat scope from a message.* envelope emitted
+// by a comms-backed aggregator. Format: "<prefix><chatID>" where prefix is
+// "<source>:" (e.g. "gchat:spaces/AAAA" → "spaces/AAAA"; the chatID retains the
+// `/`, which is part of the opaque space resource name, not a delimiter).
+// Returns (chatID, true) on success; ("", false) for malformed /
+// sweeper-sentinel envelopes (which carry no PeerRef) or a non-message kind.
+func parseCommsPeerRef(env *events.Envelope, prefix string) (string, bool) {
+	var peerRef string
+	switch env.Kind {
+	case events.KindMessageReceived:
+		var p events.MessageReceivedPayload
+		if err := events.Unmarshal(env, &p); err != nil {
+			return "", false
+		}
+		peerRef = p.PeerRef
+	case events.KindMessageSent:
+		var p events.MessageSentPayload
+		if err := events.Unmarshal(env, &p); err != nil {
+			return "", false
+		}
+		peerRef = p.PeerRef
+	default:
+		return "", false
+	}
+	if !strings.HasPrefix(peerRef, prefix) {
+		return "", false
+	}
+	chatID := peerRef[len(prefix):]
+	if chatID == "" {
+		return "", false
+	}
+	return chatID, true
+}

--- a/backend/internal/consumer/comms_aggregator_reenqueuer_test.go
+++ b/backend/internal/consumer/comms_aggregator_reenqueuer_test.go
@@ -1,0 +1,166 @@
+package consumer
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"personal-crm/backend/internal/consumer/consumerjobs"
+	"personal-crm/backend/internal/events"
+
+	"github.com/google/uuid"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
+	"github.com/stretchr/testify/require"
+)
+
+// stubCommsEngine records every AggregateForContact call.
+type stubCommsEngine struct {
+	calls   []stubCommsEngCall
+	failErr error
+}
+
+type stubCommsEngCall struct {
+	contactID uuid.UUID
+	chatID    string
+}
+
+func (s *stubCommsEngine) AggregateForContact(_ context.Context, contactID uuid.UUID, chatID string) error {
+	s.calls = append(s.calls, stubCommsEngCall{contactID, chatID})
+	return s.failErr
+}
+
+// stubCommsInserter records every Insert call.
+type stubCommsInserter struct {
+	calls []consumerjobs.MessagingAggregateForContactArgs
+	err   error
+}
+
+func (s *stubCommsInserter) Insert(_ context.Context, args river.JobArgs, _ *river.InsertOpts) (*rivertype.JobInsertResult, error) {
+	if a, ok := args.(consumerjobs.MessagingAggregateForContactArgs); ok {
+		s.calls = append(s.calls, a)
+	}
+	if s.err != nil {
+		return nil, s.err
+	}
+	return &rivertype.JobInsertResult{}, nil
+}
+
+func buildGChatEnvelope(t *testing.T, kind events.Kind, peerRef string) *events.Envelope {
+	t.Helper()
+	contactID := uuid.New()
+	var payloadBytes []byte
+	var err error
+	if kind == events.KindMessageReceived {
+		payloadBytes, err = events.Marshal(kind, events.MessageReceivedPayload{
+			Version:   1,
+			ContactID: &contactID,
+			PeerRef:   peerRef,
+		})
+	} else {
+		payloadBytes, err = events.Marshal(kind, events.MessageSentPayload{
+			Version:   1,
+			ContactID: &contactID,
+			PeerRef:   peerRef,
+		})
+	}
+	require.NoError(t, err)
+	return &events.Envelope{
+		Source:  "gchat",
+		Kind:    kind,
+		Payload: payloadBytes,
+	}
+}
+
+// TestCommsReenqueuer_HappyPath asserts both the fresh-River-job enqueue and
+// the chat-aware sync pass fire. Critically, the gchat space resource name
+// retains its `/` — the prefix strip is "gchat:", not a path split.
+func TestCommsReenqueuer_HappyPath(t *testing.T) {
+	eng := &stubCommsEngine{}
+	ins := &stubCommsInserter{}
+	r := NewCommsAggregatorReenqueuer(eng, ins, "gchat")
+	contactID := uuid.New()
+
+	env := buildGChatEnvelope(t, events.KindMessageReceived, "gchat:spaces/AAA")
+	err := r.Reenqueue(context.Background(), env, contactID)
+	require.NoError(t, err)
+	require.Len(t, ins.calls, 1)
+	require.Equal(t, contactID, ins.calls[0].ContactID)
+	require.Equal(t, "gchat", ins.calls[0].Source)
+	require.Len(t, eng.calls, 1)
+	require.Equal(t, contactID, eng.calls[0].contactID)
+	require.Equal(t, "spaces/AAA", eng.calls[0].chatID, "chatID must retain the '/' from the space resource name")
+}
+
+// TestCommsReenqueuer_OutboundKindAlsoParses confirms KindMessageSent parses.
+func TestCommsReenqueuer_OutboundKindAlsoParses(t *testing.T) {
+	eng := &stubCommsEngine{}
+	r := NewCommsAggregatorReenqueuer(eng, nil, "gchat")
+	contactID := uuid.New()
+
+	env := buildGChatEnvelope(t, events.KindMessageSent, "gchat:spaces/BBB")
+	err := r.Reenqueue(context.Background(), env, contactID)
+	require.NoError(t, err)
+	require.Len(t, eng.calls, 1)
+	require.Equal(t, "spaces/BBB", eng.calls[0].chatID)
+}
+
+// TestCommsReenqueuer_WrongPrefix_LogsAndReturnsNil verifies a PeerRef with a
+// different source prefix is treated as unparseable (the engine is not called).
+func TestCommsReenqueuer_WrongPrefix_LogsAndReturnsNil(t *testing.T) {
+	eng := &stubCommsEngine{}
+	r := NewCommsAggregatorReenqueuer(eng, nil, "gchat")
+
+	env := buildGChatEnvelope(t, events.KindMessageReceived, "messages:chat-A")
+	err := r.Reenqueue(context.Background(), env, uuid.New())
+	require.NoError(t, err)
+	require.Empty(t, eng.calls, "engine MUST NOT be invoked when the prefix does not match the source")
+}
+
+// TestCommsReenqueuer_EmptyChatID_LogsAndReturnsNil verifies an empty chat
+// scope (prefix present, body empty) is non-fatal.
+func TestCommsReenqueuer_EmptyChatID_LogsAndReturnsNil(t *testing.T) {
+	eng := &stubCommsEngine{}
+	r := NewCommsAggregatorReenqueuer(eng, nil, "gchat")
+
+	env := buildGChatEnvelope(t, events.KindMessageReceived, "gchat:")
+	err := r.Reenqueue(context.Background(), env, uuid.New())
+	require.NoError(t, err)
+	require.Empty(t, eng.calls, "engine MUST NOT be invoked when chat ID is empty")
+}
+
+// TestCommsReenqueuer_NilEngine_NoOpsButStillEnqueues confirms a nil engine
+// doesn't crash; the fresh-enqueue path still fires.
+func TestCommsReenqueuer_NilEngine_NoOpsButStillEnqueues(t *testing.T) {
+	ins := &stubCommsInserter{}
+	r := NewCommsAggregatorReenqueuer(nil, ins, "gchat")
+	env := buildGChatEnvelope(t, events.KindMessageReceived, "gchat:spaces/CCC")
+	err := r.Reenqueue(context.Background(), env, uuid.New())
+	require.NoError(t, err)
+	require.Len(t, ins.calls, 1, "fresh-enqueue path must fire even when engine is nil")
+}
+
+// TestCommsReenqueuer_InserterError_LogsAndContinues verifies an enqueue
+// failure does NOT prevent the chat-aware sync pass.
+func TestCommsReenqueuer_InserterError_LogsAndContinues(t *testing.T) {
+	eng := &stubCommsEngine{}
+	ins := &stubCommsInserter{err: errors.New("river down")}
+	r := NewCommsAggregatorReenqueuer(eng, ins, "gchat")
+
+	env := buildGChatEnvelope(t, events.KindMessageReceived, "gchat:spaces/DDD")
+	err := r.Reenqueue(context.Background(), env, uuid.New())
+	require.NoError(t, err)
+	require.Len(t, eng.calls, 1, "engine pass must still fire after enqueue failure")
+}
+
+// TestCommsReenqueuer_NonMessageKind_ReturnsNil confirms the parser falls
+// through cleanly on unexpected kinds (sweeper sentinels carry no PeerRef).
+func TestCommsReenqueuer_NonMessageKind_ReturnsNil(t *testing.T) {
+	eng := &stubCommsEngine{}
+	r := NewCommsAggregatorReenqueuer(eng, nil, "gchat")
+
+	env := &events.Envelope{Source: "gchat", Kind: events.KindInteractionRecorded}
+	err := r.Reenqueue(context.Background(), env, uuid.New())
+	require.NoError(t, err)
+	require.Empty(t, eng.calls)
+}

--- a/backend/internal/consumer/interaction_recorder.go
+++ b/backend/internal/consumer/interaction_recorder.go
@@ -512,18 +512,26 @@ func extractMessageIDs(env *events.Envelope) ([]uuid.UUID, error) {
 	return nil, nil
 }
 
+// messageInteractionSources is the allowlist of sources permitted to flow
+// through the message.* create path. It is defense-in-depth — the CHECK
+// constraint on interaction.source is the durable contract, but this catches a
+// bad publisher before the DB write attempts. Each chat/messaging source whose
+// aggregation engine publishes KindMessageReceived/KindMessageSent must appear
+// here (telegram, messages, gchat).
+var messageInteractionSources = map[string]struct{}{
+	repository.InteractionSourceTelegram: {},
+	repository.InteractionSourceMessages: {},
+	repository.InteractionSourceGChat:    {},
+}
+
 // makeMessageRequest builds the RecordInteractionRequest for message.*
 // kinds. Shared by message.received and message.sent extract branches.
 // `source` is propagated from env.Source so a `source="messages"` event
 // produces a `source="messages"` interaction row (P0 invariant: the
-// message event's source name flows end-to-end). Allowlists
-// {telegram, messages} for defense-in-depth — the CHECK constraint on
-// interaction.source is the durable contract, but this catches a bad
-// publisher before the DB write attempts.
+// message event's source name flows end-to-end).
 func makeMessageRequest(source string, contactID *uuid.UUID, externalMessageID string, messageAt time.Time, description *string, direction string) (repository.RecordInteractionRequest, error) {
-	if source != repository.InteractionSourceTelegram && source != repository.InteractionSourceMessages {
-		return repository.RecordInteractionRequest{}, fmt.Errorf("unsupported message source %q (allowed: %s, %s)",
-			source, repository.InteractionSourceTelegram, repository.InteractionSourceMessages)
+	if _, ok := messageInteractionSources[source]; !ok {
+		return repository.RecordInteractionRequest{}, fmt.Errorf("unsupported message source %q (allowed: telegram, messages, gchat)", source)
 	}
 	var cid uuid.UUID
 	if contactID != nil {

--- a/backend/internal/consumer/interaction_recorder_test.go
+++ b/backend/internal/consumer/interaction_recorder_test.go
@@ -985,3 +985,33 @@ func TestHandleEvent_RecordedEventSourceIDIsInteractionID(t *testing.T) {
 	require.NotNil(t, decoded.SourceRef)
 	require.Equal(t, "gcal-evt-sid", *decoded.SourceRef)
 }
+
+// TestMakeMessageRequest_SourceAllowlist pins the message.* create-path source
+// allowlist: telegram, messages, and gchat are accepted (each has an
+// aggregation engine that publishes KindMessageReceived/KindMessageSent), while
+// an arbitrary source is rejected before the DB write attempts.
+func TestMakeMessageRequest_SourceAllowlist(t *testing.T) {
+	cid := uuid.New()
+	at := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+
+	for _, src := range []string{
+		repository.InteractionSourceTelegram,
+		repository.InteractionSourceMessages,
+		repository.InteractionSourceGChat,
+	} {
+		t.Run("accepts "+src, func(t *testing.T) {
+			req, err := makeMessageRequest(src, &cid, "ext-1", at, nil, repository.InteractionDirectionInbound)
+			require.NoError(t, err)
+			assert.Equal(t, src, req.Source)
+			assert.Equal(t, cid, req.ContactID)
+			require.NotNil(t, req.SourceRef)
+			assert.Equal(t, "ext-1", *req.SourceRef)
+		})
+	}
+
+	t.Run("rejects unknown source", func(t *testing.T) {
+		_, err := makeMessageRequest("whatsapp", &cid, "ext-1", at, nil, repository.InteractionDirectionInbound)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported message source")
+	})
+}

--- a/backend/internal/db/comms_message.sql.go
+++ b/backend/internal/db/comms_message.sql.go
@@ -229,24 +229,36 @@ func (q *Queries) GetCommsMessageByID(ctx context.Context, id pgtype.UUID) (*Com
 const GetCommsMessageByReplyTarget = `-- name: GetCommsMessageByReplyTarget :one
 SELECT id, source, external_id, thread_id, subject, body, snippet, peer_handle, peer_normalized, direction, sent_at, account_id, source_metadata, matched_contact_id, interaction_id, claimed_at, claimed_session_ref, processed_at, deleted_at, created_at FROM comms_message
 WHERE source = $1
-  AND thread_id = $2
-  AND external_id = $3
+  AND matched_contact_id = $2
+  AND thread_id = $3
+  AND external_id = $4
   AND deleted_at IS NULL
 `
 
 type GetCommsMessageByReplyTargetParams struct {
-	Source        string      `json:"source"`
-	ThreadID      pgtype.Text `json:"thread_id"`
-	ReplyTargetID string      `json:"reply_target_id"`
+	Source           string      `json:"source"`
+	MatchedContactID pgtype.UUID `json:"matched_contact_id"`
+	ThreadID         pgtype.Text `json:"thread_id"`
+	ReplyTargetID    string      `json:"reply_target_id"`
 }
 
 // Resolves the row a reply points at. comms_message has NO reply_to column;
 // the reply target is itself a stored message, looked up by its own external_id
-// within the same (source, thread/chat) scope. Used by the aggregator's
-// explicit-reply-bridge path. Intentionally does NOT filter processed_at — a
-// reply can target an already-processed message (the whole point of bridging).
+// within the same (source, contact, thread/chat) scope. Used by the
+// aggregator's explicit-reply-bridge path. Scoping to matched_contact_id is
+// load-bearing: comms_message is per-contact (a shared address fans out to one
+// row per matched contact), so an unscoped lookup could return a DIFFERENT
+// contact's row, whose interaction_id points at that other contact's
+// interaction — which the bridge would then wrongly promote to mutual.
+// Intentionally does NOT filter processed_at — a reply can target an
+// already-processed message (the whole point of bridging).
 func (q *Queries) GetCommsMessageByReplyTarget(ctx context.Context, arg GetCommsMessageByReplyTargetParams) (*CommsMessage, error) {
-	row := q.db.QueryRow(ctx, GetCommsMessageByReplyTarget, arg.Source, arg.ThreadID, arg.ReplyTargetID)
+	row := q.db.QueryRow(ctx, GetCommsMessageByReplyTarget,
+		arg.Source,
+		arg.MatchedContactID,
+		arg.ThreadID,
+		arg.ReplyTargetID,
+	)
 	var i CommsMessage
 	err := row.Scan(
 		&i.ID,
@@ -683,7 +695,7 @@ WHERE id = $1
 
 // Test-only helper: soft-deletes a single comms_message row by id, simulating
 // the upstream delete a chat provider would observe. Used by the delete-no-op
-// aggregation test. Production delete paths live in PR 2.
+// aggregation test. There is no production chat delete path yet.
 func (q *Queries) SoftDeleteCommsMessageByID(ctx context.Context, id pgtype.UUID) error {
 	_, err := q.db.Exec(ctx, SoftDeleteCommsMessageByID, id)
 	return err

--- a/backend/internal/db/comms_message.sql.go
+++ b/backend/internal/db/comms_message.sql.go
@@ -11,6 +11,20 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const BackdateCommsMessageClaim = `-- name: BackdateCommsMessageClaim :exec
+UPDATE comms_message
+SET claimed_at = NOW() - INTERVAL '10 minutes'
+WHERE id = ANY($1::uuid[])
+`
+
+// Test-only helper: ages the claim past the 5-minute TTL so a fresh
+// aggregate pass can re-claim a stale claim. Mirror of
+// BackdateMessagesMessageClaim. Production code MUST NOT call this.
+func (q *Queries) BackdateCommsMessageClaim(ctx context.Context, messageIds []pgtype.UUID) error {
+	_, err := q.db.Exec(ctx, BackdateCommsMessageClaim, messageIds)
+	return err
+}
+
 const BackfillCommsMessageParticipantNames = `-- name: BackfillCommsMessageParticipantNames :execrows
 UPDATE comms_message
 SET source_metadata = jsonb_set(
@@ -70,6 +84,70 @@ func (q *Queries) BackfillCommsMessageParticipantNames(ctx context.Context, arg 
 	return result.RowsAffected(), nil
 }
 
+const ClaimCommsMessages = `-- name: ClaimCommsMessages :many
+UPDATE comms_message
+SET claimed_at = NOW(),
+    claimed_session_ref = $1
+WHERE id = ANY($2::uuid[])
+  AND processed_at IS NULL
+  AND (claimed_at IS NULL OR claimed_at < NOW() - INTERVAL '5 minutes')
+  AND deleted_at IS NULL
+RETURNING id
+`
+
+type ClaimCommsMessagesParams struct {
+	SessionRef pgtype.Text   `json:"session_ref"`
+	MessageIds []pgtype.UUID `json:"message_ids"`
+}
+
+// Race-safe conditional claim — mirror of ClaimMessagesMessages. No @source
+// filter needed: id is the PK and globally unique; the caller already scoped to
+// source when it listed the rows. Returns the IDs actually claimed so the engine
+// can detect partial claims.
+func (q *Queries) ClaimCommsMessages(ctx context.Context, arg ClaimCommsMessagesParams) ([]pgtype.UUID, error) {
+	rows, err := q.db.Query(ctx, ClaimCommsMessages, arg.SessionRef, arg.MessageIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []pgtype.UUID{}
+	for rows.Next() {
+		var id pgtype.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const ClearStaleCommsClaim = `-- name: ClearStaleCommsClaim :exec
+UPDATE comms_message
+SET claimed_at = NULL,
+    claimed_session_ref = NULL
+WHERE id = ANY($1::uuid[])
+  AND claimed_session_ref = $2
+  AND processed_at IS NULL
+  AND deleted_at IS NULL
+`
+
+type ClearStaleCommsClaimParams struct {
+	MessageIds         []pgtype.UUID `json:"message_ids"`
+	ExpectedSessionRef pgtype.Text   `json:"expected_session_ref"`
+}
+
+// Defensive recovery branch: clears claim columns for rows still carrying the
+// expected stale session_ref. Mirror of ClearMessagesMessageStaleClaim. Used
+// when the engine detected a recovery pass but FindEventBySource returned no
+// row.
+func (q *Queries) ClearStaleCommsClaim(ctx context.Context, arg ClearStaleCommsClaimParams) error {
+	_, err := q.db.Exec(ctx, ClearStaleCommsClaim, arg.MessageIds, arg.ExpectedSessionRef)
+	return err
+}
+
 const GetCommsMessage = `-- name: GetCommsMessage :one
 SELECT id, source, external_id, thread_id, subject, body, snippet, peer_handle, peer_normalized, direction, sent_at, account_id, source_metadata, matched_contact_id, interaction_id, claimed_at, claimed_session_ref, processed_at, deleted_at, created_at FROM comms_message
 WHERE source = $1
@@ -122,6 +200,53 @@ WHERE id = $1
 
 func (q *Queries) GetCommsMessageByID(ctx context.Context, id pgtype.UUID) (*CommsMessage, error) {
 	row := q.db.QueryRow(ctx, GetCommsMessageByID, id)
+	var i CommsMessage
+	err := row.Scan(
+		&i.ID,
+		&i.Source,
+		&i.ExternalID,
+		&i.ThreadID,
+		&i.Subject,
+		&i.Body,
+		&i.Snippet,
+		&i.PeerHandle,
+		&i.PeerNormalized,
+		&i.Direction,
+		&i.SentAt,
+		&i.AccountID,
+		&i.SourceMetadata,
+		&i.MatchedContactID,
+		&i.InteractionID,
+		&i.ClaimedAt,
+		&i.ClaimedSessionRef,
+		&i.ProcessedAt,
+		&i.DeletedAt,
+		&i.CreatedAt,
+	)
+	return &i, err
+}
+
+const GetCommsMessageByReplyTarget = `-- name: GetCommsMessageByReplyTarget :one
+SELECT id, source, external_id, thread_id, subject, body, snippet, peer_handle, peer_normalized, direction, sent_at, account_id, source_metadata, matched_contact_id, interaction_id, claimed_at, claimed_session_ref, processed_at, deleted_at, created_at FROM comms_message
+WHERE source = $1
+  AND thread_id = $2
+  AND external_id = $3
+  AND deleted_at IS NULL
+`
+
+type GetCommsMessageByReplyTargetParams struct {
+	Source        string      `json:"source"`
+	ThreadID      pgtype.Text `json:"thread_id"`
+	ReplyTargetID string      `json:"reply_target_id"`
+}
+
+// Resolves the row a reply points at. comms_message has NO reply_to column;
+// the reply target is itself a stored message, looked up by its own external_id
+// within the same (source, thread/chat) scope. Used by the aggregator's
+// explicit-reply-bridge path. Intentionally does NOT filter processed_at — a
+// reply can target an already-processed message (the whole point of bridging).
+func (q *Queries) GetCommsMessageByReplyTarget(ctx context.Context, arg GetCommsMessageByReplyTargetParams) (*CommsMessage, error) {
+	row := q.db.QueryRow(ctx, GetCommsMessageByReplyTarget, arg.Source, arg.ThreadID, arg.ReplyTargetID)
 	var i CommsMessage
 	err := row.Scan(
 		&i.ID,
@@ -266,10 +391,215 @@ func (q *Queries) ListCommsMessagesMissingParticipantNames(ctx context.Context, 
 	return items, nil
 }
 
+const ListUnprocessedCommsByContact = `-- name: ListUnprocessedCommsByContact :many
+SELECT id, source, external_id, thread_id, subject, body, snippet, peer_handle, peer_normalized, direction, sent_at, account_id, source_metadata, matched_contact_id, interaction_id, claimed_at, claimed_session_ref, processed_at, deleted_at, created_at FROM comms_message
+WHERE source = $1
+  AND matched_contact_id = $2
+  AND processed_at IS NULL
+  AND (claimed_at IS NULL OR claimed_at < NOW() - INTERVAL '5 minutes')
+  AND deleted_at IS NULL
+ORDER BY thread_id, sent_at
+`
+
+type ListUnprocessedCommsByContactParams struct {
+	Source           string      `json:"source"`
+	MatchedContactID pgtype.UUID `json:"matched_contact_id"`
+}
+
+// Eligible rows for a contact within one source. Orders by thread_id then
+// sent_at — thread_id carries the chat scope, mirroring messages' ORDER BY
+// chat_guid, sent_at.
+func (q *Queries) ListUnprocessedCommsByContact(ctx context.Context, arg ListUnprocessedCommsByContactParams) ([]*CommsMessage, error) {
+	rows, err := q.db.Query(ctx, ListUnprocessedCommsByContact, arg.Source, arg.MatchedContactID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []*CommsMessage{}
+	for rows.Next() {
+		var i CommsMessage
+		if err := rows.Scan(
+			&i.ID,
+			&i.Source,
+			&i.ExternalID,
+			&i.ThreadID,
+			&i.Subject,
+			&i.Body,
+			&i.Snippet,
+			&i.PeerHandle,
+			&i.PeerNormalized,
+			&i.Direction,
+			&i.SentAt,
+			&i.AccountID,
+			&i.SourceMetadata,
+			&i.MatchedContactID,
+			&i.InteractionID,
+			&i.ClaimedAt,
+			&i.ClaimedSessionRef,
+			&i.ProcessedAt,
+			&i.DeletedAt,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const ListUnprocessedCommsByContactAndChat = `-- name: ListUnprocessedCommsByContactAndChat :many
+SELECT id, source, external_id, thread_id, subject, body, snippet, peer_handle, peer_normalized, direction, sent_at, account_id, source_metadata, matched_contact_id, interaction_id, claimed_at, claimed_session_ref, processed_at, deleted_at, created_at FROM comms_message
+WHERE source = $1
+  AND matched_contact_id = $2
+  AND thread_id = $3
+  AND processed_at IS NULL
+  AND (claimed_at IS NULL OR claimed_at < NOW() - INTERVAL '5 minutes')
+  AND deleted_at IS NULL
+ORDER BY sent_at
+`
+
+type ListUnprocessedCommsByContactAndChatParams struct {
+	Source           string      `json:"source"`
+	MatchedContactID pgtype.UUID `json:"matched_contact_id"`
+	ThreadID         pgtype.Text `json:"thread_id"`
+}
+
+// Eligible rows for a (contact, thread/chat) pair within one source.
+// @thread_id is the chat scope (the GChat space resource name).
+func (q *Queries) ListUnprocessedCommsByContactAndChat(ctx context.Context, arg ListUnprocessedCommsByContactAndChatParams) ([]*CommsMessage, error) {
+	rows, err := q.db.Query(ctx, ListUnprocessedCommsByContactAndChat, arg.Source, arg.MatchedContactID, arg.ThreadID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []*CommsMessage{}
+	for rows.Next() {
+		var i CommsMessage
+		if err := rows.Scan(
+			&i.ID,
+			&i.Source,
+			&i.ExternalID,
+			&i.ThreadID,
+			&i.Subject,
+			&i.Body,
+			&i.Snippet,
+			&i.PeerHandle,
+			&i.PeerNormalized,
+			&i.Direction,
+			&i.SentAt,
+			&i.AccountID,
+			&i.SourceMetadata,
+			&i.MatchedContactID,
+			&i.InteractionID,
+			&i.ClaimedAt,
+			&i.ClaimedSessionRef,
+			&i.ProcessedAt,
+			&i.DeletedAt,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const ListUnprocessedCommsChatsByContact = `-- name: ListUnprocessedCommsChatsByContact :many
+SELECT DISTINCT thread_id
+FROM comms_message
+WHERE source = $1
+  AND matched_contact_id = $2
+  AND processed_at IS NULL
+  AND (claimed_at IS NULL OR claimed_at < NOW() - INTERVAL '5 minutes')
+  AND deleted_at IS NULL
+ORDER BY thread_id ASC
+`
+
+type ListUnprocessedCommsChatsByContactParams struct {
+	Source           string      `json:"source"`
+	MatchedContactID pgtype.UUID `json:"matched_contact_id"`
+}
+
+// Distinct thread_id (chat scope) values for a contact with at least one
+// eligible row within one source. Backs the PerSourceChatListerRegistry entry
+// (the worker's per-chat loop), mirroring ListUnprocessedMessagesChatsByContact.
+// NOT a MessageStore interface method. thread_id is nullable on comms_message;
+// the Go wrapper filters NULLs defensively (chat sources always write it
+// non-null).
+func (q *Queries) ListUnprocessedCommsChatsByContact(ctx context.Context, arg ListUnprocessedCommsChatsByContactParams) ([]pgtype.Text, error) {
+	rows, err := q.db.Query(ctx, ListUnprocessedCommsChatsByContact, arg.Source, arg.MatchedContactID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []pgtype.Text{}
+	for rows.Next() {
+		var thread_id pgtype.Text
+		if err := rows.Scan(&thread_id); err != nil {
+			return nil, err
+		}
+		items = append(items, thread_id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const ListUnprocessedCommsContactIDs = `-- name: ListUnprocessedCommsContactIDs :many
+
+SELECT DISTINCT matched_contact_id
+FROM comms_message
+WHERE source = $1
+  AND matched_contact_id IS NOT NULL
+  AND processed_at IS NULL
+  AND (claimed_at IS NULL OR claimed_at < NOW() - INTERVAL '5 minutes')
+  AND deleted_at IS NULL
+`
+
+// =====================================================================
+// Source-parameterized aggregation-engine queries (GChat is the first
+// chat source on comms_message; Telegram/Messages migrate onto these
+// later). Every query takes @source so the shared comms_message table
+// isolates rows by source. Predicate shapes mirror messages_message.sql
+// verbatim; the only structural difference is the @source filter and the
+// thread_id column (vs. messages' chat_guid). All scope deleted_at IS NULL.
+// =====================================================================
+// Claim-aware filter — same predicate shape as ListUnprocessedMessagesContactIDs,
+// plus the @source scope. matched_contact_id is NOT NULL on comms_message;
+// the IS NOT NULL guard is retained for parity/safety (harmless).
+func (q *Queries) ListUnprocessedCommsContactIDs(ctx context.Context, source string) ([]pgtype.UUID, error) {
+	rows, err := q.db.Query(ctx, ListUnprocessedCommsContactIDs, source)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []pgtype.UUID{}
+	for rows.Next() {
+		var matched_contact_id pgtype.UUID
+		if err := rows.Scan(&matched_contact_id); err != nil {
+			return nil, err
+		}
+		items = append(items, matched_contact_id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const MarkCommsMessagesProcessed = `-- name: MarkCommsMessagesProcessed :execrows
 UPDATE comms_message
 SET processed_at = NOW(),
-    interaction_id = $1
+    interaction_id = $1,
+    claimed_at = NULL,
+    claimed_session_ref = NULL
 WHERE id = ANY($2::uuid[])
   AND processed_at IS NULL
   AND deleted_at IS NULL
@@ -280,15 +610,64 @@ type MarkCommsMessagesProcessedParams struct {
 	MessageIds    []pgtype.UUID `json:"message_ids"`
 }
 
-// Link content rows to the aggregated interaction + set processed_at. Email
-// aggregation uses a deterministic source_ref and never claims rows, so there
-// is NO session-scope predicate here (unlike messages_message): the @session_ref
-// arg is part of the shared StagingProcessor signature but intentionally unused
-// in the email predicate. Idempotent: a replay finds rows already processed
-// (processed_at IS NOT NULL) and affects 0 rows, which the consumer treats as
-// the expected replay case.
+// Link content rows to the aggregated interaction + set processed_at, AND
+// clear claim columns. Two callers:
+//   - email path (CommsStagingProcessor, tx-bound, via the email consumer):
+//     email never claims rows, so the claim-clear is a provable NULL → NULL
+//     no-op for email rows. There is NO session-scope predicate here (unlike
+//     messages_message): the @session_ref arg is part of the shared
+//     StagingProcessor signature but intentionally unused in the email path.
+//   - chat non-tx engine path (commsMessageStoreAdapter.MarkProcessed, used by
+//     the engine's extend/promote/bridge paths): those paths do not claim rows
+//     or publish events, so the claim-clear keeps any leftover claim from a
+//     prior pass from re-blocking the row. Mirrors MarkMessagesMessagesProcessed.
+//
+// Idempotent: a replay finds rows already processed (processed_at IS NOT NULL)
+// and affects 0 rows, which the consumer treats as the expected replay case.
 func (q *Queries) MarkCommsMessagesProcessed(ctx context.Context, arg MarkCommsMessagesProcessedParams) (int64, error) {
 	result, err := q.db.Exec(ctx, MarkCommsMessagesProcessed, arg.InteractionID, arg.MessageIds)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const MarkCommsMessagesProcessedForSession = `-- name: MarkCommsMessagesProcessedForSession :execrows
+UPDATE comms_message
+SET processed_at = NOW(),
+    interaction_id = $1,
+    claimed_at = NULL,
+    claimed_session_ref = NULL
+WHERE id = ANY($2::uuid[])
+  AND (claimed_session_ref = $3 OR claimed_session_ref IS NULL)
+  AND processed_at IS NULL
+  AND deleted_at IS NULL
+`
+
+type MarkCommsMessagesProcessedForSessionParams struct {
+	InteractionID pgtype.UUID   `json:"interaction_id"`
+	MessageIds    []pgtype.UUID `json:"message_ids"`
+	SessionRef    pgtype.Text   `json:"session_ref"`
+}
+
+// Tx-bound, session-scoped variant for the chat create-path. Mirror of
+// MarkMessagesMessagesProcessedForSession — used by the InteractionRecorder
+// consumer (via CommsSessionStagingProcessor) when processing a create-path
+// event. The (claimed_session_ref = @session_ref OR IS NULL) predicate is the
+// boundary-shift defense the recorder's zero-rows-affected rollback depends on:
+// it rejects rows claimed for a DIFFERENT session while accepting rows the
+// non-tx publish path left unclaimed. This is SEPARATE from the email
+// MarkCommsMessagesProcessed (which has no session predicate — email never
+// claims, so scoping by session would wrongly reject email rows).
+//
+// Returns rows affected. The consumer distinguishes three cases:
+//   - affected == len(message_ids): happy path.
+//   - affected == 0 on a fresh write: predicate filtered everything out
+//     (boundary-shift race). Caller MUST roll back the tx.
+//   - affected == 0 on a replay: expected; rows already linked on the
+//     original attempt.
+func (q *Queries) MarkCommsMessagesProcessedForSession(ctx context.Context, arg MarkCommsMessagesProcessedForSessionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, MarkCommsMessagesProcessedForSession, arg.InteractionID, arg.MessageIds, arg.SessionRef)
 	if err != nil {
 		return 0, err
 	}

--- a/backend/internal/db/comms_message.sql.go
+++ b/backend/internal/db/comms_message.sql.go
@@ -674,6 +674,21 @@ func (q *Queries) MarkCommsMessagesProcessedForSession(ctx context.Context, arg 
 	return result.RowsAffected(), nil
 }
 
+const SoftDeleteCommsMessageByID = `-- name: SoftDeleteCommsMessageByID :exec
+UPDATE comms_message
+SET deleted_at = NOW()
+WHERE id = $1
+  AND deleted_at IS NULL
+`
+
+// Test-only helper: soft-deletes a single comms_message row by id, simulating
+// the upstream delete a chat provider would observe. Used by the delete-no-op
+// aggregation test. Production delete paths live in PR 2.
+func (q *Queries) SoftDeleteCommsMessageByID(ctx context.Context, id pgtype.UUID) error {
+	_, err := q.db.Exec(ctx, SoftDeleteCommsMessageByID, id)
+	return err
+}
+
 const UpsertCommsMessage = `-- name: UpsertCommsMessage :one
 INSERT INTO comms_message (
     source, external_id, thread_id, subject, body, snippet,

--- a/backend/internal/db/contact_method.sql.go
+++ b/backend/internal/db/contact_method.sql.go
@@ -245,6 +245,56 @@ func (q *Queries) ListEmailIdentitiesForSync(ctx context.Context) ([]*ListEmailI
 	return items, nil
 }
 
+const ListGChatIdentitiesForSync = `-- name: ListGChatIdentitiesForSync :many
+SELECT cm.value_normalized, cm.contact_id, cm.type AS source_type
+FROM contact_method cm
+JOIN contact c ON c.id = cm.contact_id
+WHERE cm.type IN ('gchat', 'email')
+  AND cm.value_normalized <> ''
+  AND c.deleted_at IS NULL
+ORDER BY cm.value_normalized ASC, cm.contact_id ASC, cm.type ASC
+`
+
+type ListGChatIdentitiesForSyncRow struct {
+	ValueNormalized string      `json:"value_normalized"`
+	ContactID       pgtype.UUID `json:"contact_id"`
+	SourceType      string      `json:"source_type"`
+}
+
+// Dual-source variant of ListEmailIdentitiesForSync for the Google Chat
+// provider. Returns (value_normalized, contact_id, source_type) for every
+// gchat OR email contact_method of a non-deleted contact. GChat sender
+// addresses ARE emails, so the provider's known-identity map must consider
+// both a dedicated 'gchat' method AND any plain 'email' method. The
+// source_type projection (cm.type, 'gchat' or 'email') is the discriminator.
+// MANY-TO-ONE allowed: a shared address maps to multiple contacts and each
+// pair is returned so the provider can fan out to all owners (spec §6).
+// value_normalized is already lowercased+trimmed by the contact_method
+// trigger for BOTH types (normalize_contact_method_value, migrations/021/022),
+// so gchat and email values normalize identically — case-insensitivity is
+// inherited, not re-implemented. Empty-normalized values are excluded.
+// The cm.type ASC tiebreaker keeps iteration / test assertions stable when
+// the same address has both a gchat and an email method on one contact.
+func (q *Queries) ListGChatIdentitiesForSync(ctx context.Context) ([]*ListGChatIdentitiesForSyncRow, error) {
+	rows, err := q.db.Query(ctx, ListGChatIdentitiesForSync)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []*ListGChatIdentitiesForSyncRow{}
+	for rows.Next() {
+		var i ListGChatIdentitiesForSyncRow
+		if err := rows.Scan(&i.ValueNormalized, &i.ContactID, &i.SourceType); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const SetContactMethodPrimary = `-- name: SetContactMethodPrimary :exec
 UPDATE contact_method cm
 SET is_primary = $2,

--- a/backend/internal/db/models.go
+++ b/backend/internal/db/models.go
@@ -84,9 +84,10 @@ type CalendarEvent struct {
 }
 
 type CommsMessage struct {
-	ID                pgtype.UUID        `json:"id"`
-	Source            string             `json:"source"`
-	ExternalID        string             `json:"external_id"`
+	ID         pgtype.UUID `json:"id"`
+	Source     string      `json:"source"`
+	ExternalID string      `json:"external_id"`
+	// email: Gmail threadId; gchat/telegram/messages: space/chat scope resource name
 	ThreadID          pgtype.Text        `json:"thread_id"`
 	Subject           pgtype.Text        `json:"subject"`
 	Body              pgtype.Text        `json:"body"`

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -1217,6 +1217,10 @@ type Querier interface {
 	// own short-lived tx (plan Decision 5). Consumer does NOT call this —
 	// consumer reads prev from the event payload (plan Decision 2a).
 	SnapshotContactCadenceFields(ctx context.Context, id pgtype.UUID) (*SnapshotContactCadenceFieldsRow, error)
+	// Test-only helper: soft-deletes a single comms_message row by id, simulating
+	// the upstream delete a chat provider would observe. Used by the delete-no-op
+	// aggregation test. Production delete paths live in PR 2.
+	SoftDeleteCommsMessageByID(ctx context.Context, id pgtype.UUID) error
 	SoftDeleteContact(ctx context.Context, id pgtype.UUID) error
 	// Tombstones a live row. Defensive WHERE deleted_at IS NULL keeps the
 	// statement idempotent against a concurrent delete. crm_contact_id,

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -33,6 +33,10 @@ type Querier interface {
 	// records interactions directly for past events (see rematch plan Design
 	// Decision 6) so the scheduler race is avoided at the source.
 	AppendMatchedContact(ctx context.Context, arg AppendMatchedContactParams) error
+	// Test-only helper: ages the claim past the 5-minute TTL so a fresh
+	// aggregate pass can re-claim a stale claim. Mirror of
+	// BackdateMessagesMessageClaim. Production code MUST NOT call this.
+	BackdateCommsMessageClaim(ctx context.Context, messageIds []pgtype.UUID) error
 	// Test-only helper: ages the claim past the 5-minute TTL. Production
 	// code MUST NOT call this.
 	BackdateMessagesMessageClaim(ctx context.Context, messageIds []pgtype.UUID) error
@@ -56,6 +60,11 @@ type Querier interface {
 	// local cursor cache on next heartbeat. Currently used only by the
 	// repository layer; no admin endpoint is wired to it yet.
 	BumpMacHostCursorEpoch(ctx context.Context, id pgtype.UUID) (int64, error)
+	// Race-safe conditional claim — mirror of ClaimMessagesMessages. No @source
+	// filter needed: id is the PK and globally unique; the caller already scoped to
+	// source when it listed the rows. Returns the IDs actually claimed so the engine
+	// can detect partial claims.
+	ClaimCommsMessages(ctx context.Context, arg ClaimCommsMessagesParams) ([]pgtype.UUID, error)
 	// Race-safe conditional claim — same predicate shape as
 	// ClaimTelegramMessages. Returns the IDs actually claimed so the engine
 	// can detect partial claims.
@@ -81,6 +90,11 @@ type Querier interface {
 	// carrying the expected stale session_ref. Used when the engine
 	// detected a recovery pass but FindEventBySource returned no row.
 	ClearMessagesMessageStaleClaim(ctx context.Context, arg ClearMessagesMessageStaleClaimParams) error
+	// Defensive recovery branch: clears claim columns for rows still carrying the
+	// expected stale session_ref. Mirror of ClearMessagesMessageStaleClaim. Used
+	// when the engine detected a recovery pass but FindEventBySource returned no
+	// row.
+	ClearStaleCommsClaim(ctx context.Context, arg ClearStaleCommsClaimParams) error
 	// Defensive recovery branch: clears claim columns for rows still
 	// carrying the expected stale session_ref but for which no event-log row
 	// could be found. Scoped to that exact stale ref to avoid clobbering a
@@ -482,6 +496,12 @@ type Querier interface {
 	// content row for a (source, external_id, contact) tuple. deleted_at filtered.
 	GetCommsMessage(ctx context.Context, arg GetCommsMessageParams) (*CommsMessage, error)
 	GetCommsMessageByID(ctx context.Context, id pgtype.UUID) (*CommsMessage, error)
+	// Resolves the row a reply points at. comms_message has NO reply_to column;
+	// the reply target is itself a stored message, looked up by its own external_id
+	// within the same (source, thread/chat) scope. Used by the aggregator's
+	// explicit-reply-bridge path. Intentionally does NOT filter processed_at — a
+	// reply can target an already-processed message (the whole point of bridging).
+	GetCommsMessageByReplyTarget(ctx context.Context, arg GetCommsMessageByReplyTargetParams) (*CommsMessage, error)
 	// Contact queries
 	GetContact(ctx context.Context, id pgtype.UUID) (*Contact, error)
 	// Get a single note for a contact by category (e.g., 'notepad')
@@ -829,6 +849,21 @@ type Querier interface {
 	// the caller-supplied address-book sources, with an optional People-tab
 	// source filter (empty = no chip).
 	ListExternalContactsWithPendingMethodSuggestions(ctx context.Context, arg ListExternalContactsWithPendingMethodSuggestionsParams) ([]*ListExternalContactsWithPendingMethodSuggestionsRow, error)
+	// Dual-source variant of ListEmailIdentitiesForSync for the Google Chat
+	// provider. Returns (value_normalized, contact_id, source_type) for every
+	// gchat OR email contact_method of a non-deleted contact. GChat sender
+	// addresses ARE emails, so the provider's known-identity map must consider
+	// both a dedicated 'gchat' method AND any plain 'email' method. The
+	// source_type projection (cm.type, 'gchat' or 'email') is the discriminator.
+	// MANY-TO-ONE allowed: a shared address maps to multiple contacts and each
+	// pair is returned so the provider can fan out to all owners (spec §6).
+	// value_normalized is already lowercased+trimmed by the contact_method
+	// trigger for BOTH types (normalize_contact_method_value, migrations/021/022),
+	// so gchat and email values normalize identically — case-insensitivity is
+	// inherited, not re-implemented. Empty-normalized values are excluded.
+	// The cm.type ASC tiebreaker keeps iteration / test assertions stable when
+	// the same address has both a gchat and an email method on one contact.
+	ListGChatIdentitiesForSync(ctx context.Context) ([]*ListGChatIdentitiesForSyncRow, error)
 	ListIdentitiesBySource(ctx context.Context, arg ListIdentitiesBySourceParams) ([]*ExternalIdentity, error)
 	ListIdentitiesForContact(ctx context.Context, contactID pgtype.UUID) ([]*ExternalIdentity, error)
 	// Returns (source_id, last_content_hash) for every live
@@ -913,6 +948,32 @@ type Querier interface {
 	// discovery rows into the per-source UI.
 	ListUnmatchedExternalContacts(ctx context.Context, arg ListUnmatchedExternalContactsParams) ([]*ExternalContact, error)
 	ListUnmatchedIdentities(ctx context.Context, arg ListUnmatchedIdentitiesParams) ([]*ExternalIdentity, error)
+	// Eligible rows for a contact within one source. Orders by thread_id then
+	// sent_at — thread_id carries the chat scope, mirroring messages' ORDER BY
+	// chat_guid, sent_at.
+	ListUnprocessedCommsByContact(ctx context.Context, arg ListUnprocessedCommsByContactParams) ([]*CommsMessage, error)
+	// Eligible rows for a (contact, thread/chat) pair within one source.
+	// @thread_id is the chat scope (the GChat space resource name).
+	ListUnprocessedCommsByContactAndChat(ctx context.Context, arg ListUnprocessedCommsByContactAndChatParams) ([]*CommsMessage, error)
+	// Distinct thread_id (chat scope) values for a contact with at least one
+	// eligible row within one source. Backs the PerSourceChatListerRegistry entry
+	// (the worker's per-chat loop), mirroring ListUnprocessedMessagesChatsByContact.
+	// NOT a MessageStore interface method. thread_id is nullable on comms_message;
+	// the Go wrapper filters NULLs defensively (chat sources always write it
+	// non-null).
+	ListUnprocessedCommsChatsByContact(ctx context.Context, arg ListUnprocessedCommsChatsByContactParams) ([]pgtype.Text, error)
+	// =====================================================================
+	// Source-parameterized aggregation-engine queries (GChat is the first
+	// chat source on comms_message; Telegram/Messages migrate onto these
+	// later). Every query takes @source so the shared comms_message table
+	// isolates rows by source. Predicate shapes mirror messages_message.sql
+	// verbatim; the only structural difference is the @source filter and the
+	// thread_id column (vs. messages' chat_guid). All scope deleted_at IS NULL.
+	// =====================================================================
+	// Claim-aware filter — same predicate shape as ListUnprocessedMessagesContactIDs,
+	// plus the @source scope. matched_contact_id is NOT NULL on comms_message;
+	// the IS NOT NULL guard is retained for parity/safety (harmless).
+	ListUnprocessedCommsContactIDs(ctx context.Context, source string) ([]pgtype.UUID, error)
 	// Distinct contact IDs with at least one eligible (unprocessed AND
 	// unclaimed-or-stale) row. Used by AggregateAll batch mode after backfill
 	// and by the periodic aggregation sweeper.
@@ -977,14 +1038,37 @@ type Querier interface {
 	// contact-facing reads (status != 'cancelled'), so it neither re-fires
 	// calendar.attended nor strands an already-recorded interaction.
 	MarkCalendarEventCancelledByGcalID(ctx context.Context, arg MarkCalendarEventCancelledByGcalIDParams) error
-	// Link content rows to the aggregated interaction + set processed_at. Email
-	// aggregation uses a deterministic source_ref and never claims rows, so there
-	// is NO session-scope predicate here (unlike messages_message): the @session_ref
-	// arg is part of the shared StagingProcessor signature but intentionally unused
-	// in the email predicate. Idempotent: a replay finds rows already processed
-	// (processed_at IS NOT NULL) and affects 0 rows, which the consumer treats as
-	// the expected replay case.
+	// Link content rows to the aggregated interaction + set processed_at, AND
+	// clear claim columns. Two callers:
+	//   - email path (CommsStagingProcessor, tx-bound, via the email consumer):
+	//     email never claims rows, so the claim-clear is a provable NULL → NULL
+	//     no-op for email rows. There is NO session-scope predicate here (unlike
+	//     messages_message): the @session_ref arg is part of the shared
+	//     StagingProcessor signature but intentionally unused in the email path.
+	//   - chat non-tx engine path (commsMessageStoreAdapter.MarkProcessed, used by
+	//     the engine's extend/promote/bridge paths): those paths do not claim rows
+	//     or publish events, so the claim-clear keeps any leftover claim from a
+	//     prior pass from re-blocking the row. Mirrors MarkMessagesMessagesProcessed.
+	// Idempotent: a replay finds rows already processed (processed_at IS NOT NULL)
+	// and affects 0 rows, which the consumer treats as the expected replay case.
 	MarkCommsMessagesProcessed(ctx context.Context, arg MarkCommsMessagesProcessedParams) (int64, error)
+	// Tx-bound, session-scoped variant for the chat create-path. Mirror of
+	// MarkMessagesMessagesProcessedForSession — used by the InteractionRecorder
+	// consumer (via CommsSessionStagingProcessor) when processing a create-path
+	// event. The (claimed_session_ref = @session_ref OR IS NULL) predicate is the
+	// boundary-shift defense the recorder's zero-rows-affected rollback depends on:
+	// it rejects rows claimed for a DIFFERENT session while accepting rows the
+	// non-tx publish path left unclaimed. This is SEPARATE from the email
+	// MarkCommsMessagesProcessed (which has no session predicate — email never
+	// claims, so scoping by session would wrongly reject email rows).
+	//
+	// Returns rows affected. The consumer distinguishes three cases:
+	//   - affected == len(message_ids): happy path.
+	//   - affected == 0 on a fresh write: predicate filtered everything out
+	//     (boundary-shift race). Caller MUST roll back the tx.
+	//   - affected == 0 on a replay: expected; rows already linked on the
+	//     original attempt.
+	MarkCommsMessagesProcessedForSession(ctx context.Context, arg MarkCommsMessagesProcessedForSessionParams) (int64, error)
 	// Mark an event as having updated last_contacted for its contacts
 	MarkLastContactedUpdated(ctx context.Context, id pgtype.UUID) error
 	// Non-tx variant. Mirror of MarkTelegramMessagesProcessed — used by the

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -498,9 +498,14 @@ type Querier interface {
 	GetCommsMessageByID(ctx context.Context, id pgtype.UUID) (*CommsMessage, error)
 	// Resolves the row a reply points at. comms_message has NO reply_to column;
 	// the reply target is itself a stored message, looked up by its own external_id
-	// within the same (source, thread/chat) scope. Used by the aggregator's
-	// explicit-reply-bridge path. Intentionally does NOT filter processed_at — a
-	// reply can target an already-processed message (the whole point of bridging).
+	// within the same (source, contact, thread/chat) scope. Used by the
+	// aggregator's explicit-reply-bridge path. Scoping to matched_contact_id is
+	// load-bearing: comms_message is per-contact (a shared address fans out to one
+	// row per matched contact), so an unscoped lookup could return a DIFFERENT
+	// contact's row, whose interaction_id points at that other contact's
+	// interaction — which the bridge would then wrongly promote to mutual.
+	// Intentionally does NOT filter processed_at — a reply can target an
+	// already-processed message (the whole point of bridging).
 	GetCommsMessageByReplyTarget(ctx context.Context, arg GetCommsMessageByReplyTargetParams) (*CommsMessage, error)
 	// Contact queries
 	GetContact(ctx context.Context, id pgtype.UUID) (*Contact, error)
@@ -1219,7 +1224,7 @@ type Querier interface {
 	SnapshotContactCadenceFields(ctx context.Context, id pgtype.UUID) (*SnapshotContactCadenceFieldsRow, error)
 	// Test-only helper: soft-deletes a single comms_message row by id, simulating
 	// the upstream delete a chat provider would observe. Used by the delete-no-op
-	// aggregation test. Production delete paths live in PR 2.
+	// aggregation test. There is no production chat delete path yet.
 	SoftDeleteCommsMessageByID(ctx context.Context, id pgtype.UUID) error
 	SoftDeleteContact(ctx context.Context, id pgtype.UUID) error
 	// Tombstones a live row. Defensive WHERE deleted_at IS NULL keeps the

--- a/backend/internal/db/queries/comms_message.sql
+++ b/backend/internal/db/queries/comms_message.sql
@@ -264,11 +264,17 @@ ORDER BY thread_id ASC;
 -- name: GetCommsMessageByReplyTarget :one
 -- Resolves the row a reply points at. comms_message has NO reply_to column;
 -- the reply target is itself a stored message, looked up by its own external_id
--- within the same (source, thread/chat) scope. Used by the aggregator's
--- explicit-reply-bridge path. Intentionally does NOT filter processed_at — a
--- reply can target an already-processed message (the whole point of bridging).
+-- within the same (source, contact, thread/chat) scope. Used by the
+-- aggregator's explicit-reply-bridge path. Scoping to matched_contact_id is
+-- load-bearing: comms_message is per-contact (a shared address fans out to one
+-- row per matched contact), so an unscoped lookup could return a DIFFERENT
+-- contact's row, whose interaction_id points at that other contact's
+-- interaction — which the bridge would then wrongly promote to mutual.
+-- Intentionally does NOT filter processed_at — a reply can target an
+-- already-processed message (the whole point of bridging).
 SELECT * FROM comms_message
 WHERE source = @source
+  AND matched_contact_id = @matched_contact_id
   AND thread_id = @thread_id
   AND external_id = @reply_target_id
   AND deleted_at IS NULL;
@@ -338,7 +344,7 @@ WHERE id = ANY(@message_ids::uuid[]);
 -- name: SoftDeleteCommsMessageByID :exec
 -- Test-only helper: soft-deletes a single comms_message row by id, simulating
 -- the upstream delete a chat provider would observe. Used by the delete-no-op
--- aggregation test. Production delete paths live in PR 2.
+-- aggregation test. There is no production chat delete path yet.
 UPDATE comms_message
 SET deleted_at = NOW()
 WHERE id = @id

--- a/backend/internal/db/queries/comms_message.sql
+++ b/backend/internal/db/queries/comms_message.sql
@@ -112,16 +112,24 @@ WHERE matched_contact_id = @matched_contact_id
 ORDER BY sent_at DESC, id;
 
 -- name: MarkCommsMessagesProcessed :execrows
--- Link content rows to the aggregated interaction + set processed_at. Email
--- aggregation uses a deterministic source_ref and never claims rows, so there
--- is NO session-scope predicate here (unlike messages_message): the @session_ref
--- arg is part of the shared StagingProcessor signature but intentionally unused
--- in the email predicate. Idempotent: a replay finds rows already processed
--- (processed_at IS NOT NULL) and affects 0 rows, which the consumer treats as
--- the expected replay case.
+-- Link content rows to the aggregated interaction + set processed_at, AND
+-- clear claim columns. Two callers:
+--   - email path (CommsStagingProcessor, tx-bound, via the email consumer):
+--     email never claims rows, so the claim-clear is a provable NULL → NULL
+--     no-op for email rows. There is NO session-scope predicate here (unlike
+--     messages_message): the @session_ref arg is part of the shared
+--     StagingProcessor signature but intentionally unused in the email path.
+--   - chat non-tx engine path (commsMessageStoreAdapter.MarkProcessed, used by
+--     the engine's extend/promote/bridge paths): those paths do not claim rows
+--     or publish events, so the claim-clear keeps any leftover claim from a
+--     prior pass from re-blocking the row. Mirrors MarkMessagesMessagesProcessed.
+-- Idempotent: a replay finds rows already processed (processed_at IS NOT NULL)
+-- and affects 0 rows, which the consumer treats as the expected replay case.
 UPDATE comms_message
 SET processed_at = NOW(),
-    interaction_id = @interaction_id
+    interaction_id = @interaction_id,
+    claimed_at = NULL,
+    claimed_session_ref = NULL
 WHERE id = ANY(@message_ids::uuid[])
   AND processed_at IS NULL
   AND deleted_at IS NULL;
@@ -191,3 +199,138 @@ SET source_metadata = jsonb_set(
 WHERE id = @id
   AND deleted_at IS NULL
   AND NOT (source_metadata ? 'from_name');
+
+-- =====================================================================
+-- Source-parameterized aggregation-engine queries (GChat is the first
+-- chat source on comms_message; Telegram/Messages migrate onto these
+-- later). Every query takes @source so the shared comms_message table
+-- isolates rows by source. Predicate shapes mirror messages_message.sql
+-- verbatim; the only structural difference is the @source filter and the
+-- thread_id column (vs. messages' chat_guid). All scope deleted_at IS NULL.
+-- =====================================================================
+
+-- name: ListUnprocessedCommsContactIDs :many
+-- Claim-aware filter — same predicate shape as ListUnprocessedMessagesContactIDs,
+-- plus the @source scope. matched_contact_id is NOT NULL on comms_message;
+-- the IS NOT NULL guard is retained for parity/safety (harmless).
+SELECT DISTINCT matched_contact_id
+FROM comms_message
+WHERE source = @source
+  AND matched_contact_id IS NOT NULL
+  AND processed_at IS NULL
+  AND (claimed_at IS NULL OR claimed_at < NOW() - INTERVAL '5 minutes')
+  AND deleted_at IS NULL;
+
+-- name: ListUnprocessedCommsByContact :many
+-- Eligible rows for a contact within one source. Orders by thread_id then
+-- sent_at — thread_id carries the chat scope, mirroring messages' ORDER BY
+-- chat_guid, sent_at.
+SELECT * FROM comms_message
+WHERE source = @source
+  AND matched_contact_id = @matched_contact_id
+  AND processed_at IS NULL
+  AND (claimed_at IS NULL OR claimed_at < NOW() - INTERVAL '5 minutes')
+  AND deleted_at IS NULL
+ORDER BY thread_id, sent_at;
+
+-- name: ListUnprocessedCommsByContactAndChat :many
+-- Eligible rows for a (contact, thread/chat) pair within one source.
+-- @thread_id is the chat scope (the GChat space resource name).
+SELECT * FROM comms_message
+WHERE source = @source
+  AND matched_contact_id = @matched_contact_id
+  AND thread_id = @thread_id
+  AND processed_at IS NULL
+  AND (claimed_at IS NULL OR claimed_at < NOW() - INTERVAL '5 minutes')
+  AND deleted_at IS NULL
+ORDER BY sent_at;
+
+-- name: ListUnprocessedCommsChatsByContact :many
+-- Distinct thread_id (chat scope) values for a contact with at least one
+-- eligible row within one source. Backs the PerSourceChatListerRegistry entry
+-- (the worker's per-chat loop), mirroring ListUnprocessedMessagesChatsByContact.
+-- NOT a MessageStore interface method. thread_id is nullable on comms_message;
+-- the Go wrapper filters NULLs defensively (chat sources always write it
+-- non-null).
+SELECT DISTINCT thread_id
+FROM comms_message
+WHERE source = @source
+  AND matched_contact_id = @matched_contact_id
+  AND processed_at IS NULL
+  AND (claimed_at IS NULL OR claimed_at < NOW() - INTERVAL '5 minutes')
+  AND deleted_at IS NULL
+ORDER BY thread_id ASC;
+
+-- name: GetCommsMessageByReplyTarget :one
+-- Resolves the row a reply points at. comms_message has NO reply_to column;
+-- the reply target is itself a stored message, looked up by its own external_id
+-- within the same (source, thread/chat) scope. Used by the aggregator's
+-- explicit-reply-bridge path. Intentionally does NOT filter processed_at — a
+-- reply can target an already-processed message (the whole point of bridging).
+SELECT * FROM comms_message
+WHERE source = @source
+  AND thread_id = @thread_id
+  AND external_id = @reply_target_id
+  AND deleted_at IS NULL;
+
+-- name: MarkCommsMessagesProcessedForSession :execrows
+-- Tx-bound, session-scoped variant for the chat create-path. Mirror of
+-- MarkMessagesMessagesProcessedForSession — used by the InteractionRecorder
+-- consumer (via CommsSessionStagingProcessor) when processing a create-path
+-- event. The (claimed_session_ref = @session_ref OR IS NULL) predicate is the
+-- boundary-shift defense the recorder's zero-rows-affected rollback depends on:
+-- it rejects rows claimed for a DIFFERENT session while accepting rows the
+-- non-tx publish path left unclaimed. This is SEPARATE from the email
+-- MarkCommsMessagesProcessed (which has no session predicate — email never
+-- claims, so scoping by session would wrongly reject email rows).
+--
+-- Returns rows affected. The consumer distinguishes three cases:
+--   - affected == len(message_ids): happy path.
+--   - affected == 0 on a fresh write: predicate filtered everything out
+--     (boundary-shift race). Caller MUST roll back the tx.
+--   - affected == 0 on a replay: expected; rows already linked on the
+--     original attempt.
+UPDATE comms_message
+SET processed_at = NOW(),
+    interaction_id = @interaction_id,
+    claimed_at = NULL,
+    claimed_session_ref = NULL
+WHERE id = ANY(@message_ids::uuid[])
+  AND (claimed_session_ref = @session_ref OR claimed_session_ref IS NULL)
+  AND processed_at IS NULL
+  AND deleted_at IS NULL;
+
+-- name: ClaimCommsMessages :many
+-- Race-safe conditional claim — mirror of ClaimMessagesMessages. No @source
+-- filter needed: id is the PK and globally unique; the caller already scoped to
+-- source when it listed the rows. Returns the IDs actually claimed so the engine
+-- can detect partial claims.
+UPDATE comms_message
+SET claimed_at = NOW(),
+    claimed_session_ref = @session_ref
+WHERE id = ANY(@message_ids::uuid[])
+  AND processed_at IS NULL
+  AND (claimed_at IS NULL OR claimed_at < NOW() - INTERVAL '5 minutes')
+  AND deleted_at IS NULL
+RETURNING id;
+
+-- name: ClearStaleCommsClaim :exec
+-- Defensive recovery branch: clears claim columns for rows still carrying the
+-- expected stale session_ref. Mirror of ClearMessagesMessageStaleClaim. Used
+-- when the engine detected a recovery pass but FindEventBySource returned no
+-- row.
+UPDATE comms_message
+SET claimed_at = NULL,
+    claimed_session_ref = NULL
+WHERE id = ANY(@message_ids::uuid[])
+  AND claimed_session_ref = @expected_session_ref
+  AND processed_at IS NULL
+  AND deleted_at IS NULL;
+
+-- name: BackdateCommsMessageClaim :exec
+-- Test-only helper: ages the claim past the 5-minute TTL so a fresh
+-- aggregate pass can re-claim a stale claim. Mirror of
+-- BackdateMessagesMessageClaim. Production code MUST NOT call this.
+UPDATE comms_message
+SET claimed_at = NOW() - INTERVAL '10 minutes'
+WHERE id = ANY(@message_ids::uuid[]);

--- a/backend/internal/db/queries/comms_message.sql
+++ b/backend/internal/db/queries/comms_message.sql
@@ -334,3 +334,12 @@ WHERE id = ANY(@message_ids::uuid[])
 UPDATE comms_message
 SET claimed_at = NOW() - INTERVAL '10 minutes'
 WHERE id = ANY(@message_ids::uuid[]);
+
+-- name: SoftDeleteCommsMessageByID :exec
+-- Test-only helper: soft-deletes a single comms_message row by id, simulating
+-- the upstream delete a chat provider would observe. Used by the delete-no-op
+-- aggregation test. Production delete paths live in PR 2.
+UPDATE comms_message
+SET deleted_at = NOW()
+WHERE id = @id
+  AND deleted_at IS NULL;

--- a/backend/internal/db/queries/contact_method.sql
+++ b/backend/internal/db/queries/contact_method.sql
@@ -93,3 +93,26 @@ WHERE cm.type = 'email'
   AND cm.value_normalized <> ''
   AND c.deleted_at IS NULL
 ORDER BY cm.value_normalized ASC, cm.contact_id ASC;
+
+-- name: ListGChatIdentitiesForSync :many
+-- Dual-source variant of ListEmailIdentitiesForSync for the Google Chat
+-- provider. Returns (value_normalized, contact_id, source_type) for every
+-- gchat OR email contact_method of a non-deleted contact. GChat sender
+-- addresses ARE emails, so the provider's known-identity map must consider
+-- both a dedicated 'gchat' method AND any plain 'email' method. The
+-- source_type projection (cm.type, 'gchat' or 'email') is the discriminator.
+-- MANY-TO-ONE allowed: a shared address maps to multiple contacts and each
+-- pair is returned so the provider can fan out to all owners (spec §6).
+-- value_normalized is already lowercased+trimmed by the contact_method
+-- trigger for BOTH types (normalize_contact_method_value, migrations/021/022),
+-- so gchat and email values normalize identically — case-insensitivity is
+-- inherited, not re-implemented. Empty-normalized values are excluded.
+-- The cm.type ASC tiebreaker keeps iteration / test assertions stable when
+-- the same address has both a gchat and an email method on one contact.
+SELECT cm.value_normalized, cm.contact_id, cm.type AS source_type
+FROM contact_method cm
+JOIN contact c ON c.id = cm.contact_id
+WHERE cm.type IN ('gchat', 'email')
+  AND cm.value_normalized <> ''
+  AND c.deleted_at IS NULL
+ORDER BY cm.value_normalized ASC, cm.contact_id ASC, cm.type ASC;

--- a/backend/internal/google/gchat_aggregation.go
+++ b/backend/internal/google/gchat_aggregation.go
@@ -25,9 +25,9 @@ const GChatSourceName = repository.InteractionSourceGChat
 
 // replyTargetMetadataKey is the source_metadata key under which an explicit
 // reply's target message resource name is stored (spec §5.X.3). No provider
-// writes this key in PR 1 (explicit-reply bridging is deferred), so the
-// projection's ReplyTargetID is always nil here — but wiring it now means
-// PR 2/PR 3 (or a later explicit-reply follow-up) need not touch the adapter.
+// writes this key yet (explicit-reply bridging is deferred), so the
+// projection's ReplyTargetID is currently always nil — but wiring the field
+// here means a later explicit-reply provider need not touch the adapter.
 const replyTargetMetadataKey = "reply_target_external_id"
 
 // NewGChatAggregationEngine constructs a shared aggregator engine configured
@@ -182,9 +182,12 @@ func (a *commsMessageStoreAdapter) ListUnprocessedByContactAndChat(ctx context.C
 
 // GetMessageByReplyTarget resolves the message referenced by a reply. The
 // reply target is itself a stored comms_message row, looked up by its own
-// external_id within the same (source, chat) scope.
-func (a *commsMessageStoreAdapter) GetMessageByReplyTarget(ctx context.Context, chatID, replyTargetID string) (aggregation.Message, bool, error) {
-	row, err := a.repo.GetMessageByReplyTargetForSource(ctx, a.source, chatID, replyTargetID)
+// external_id within the same (source, contact, chat) scope. comms_message is
+// per-contact (a shared address fans out to one row per matched contact), so
+// the lookup MUST be scoped to contactID — otherwise it could return another
+// contact's row whose interaction would then be wrongly bridged.
+func (a *commsMessageStoreAdapter) GetMessageByReplyTarget(ctx context.Context, contactID uuid.UUID, chatID, replyTargetID string) (aggregation.Message, bool, error) {
+	row, err := a.repo.GetMessageByReplyTargetForSource(ctx, a.source, contactID, chatID, replyTargetID)
 	if err != nil {
 		if errors.Is(err, db.ErrNotFound) {
 			return aggregation.Message{}, false, nil

--- a/backend/internal/google/gchat_aggregation.go
+++ b/backend/internal/google/gchat_aggregation.go
@@ -1,0 +1,300 @@
+package google
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/messaging/aggregation"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// GChatSourceName is the source string written into interaction.source,
+// event.source, and the river job args for the Google Chat source. It MUST
+// agree with the interaction_source_check CHECK value and the
+// repository.InteractionSourceGChat constant.
+const GChatSourceName = repository.InteractionSourceGChat
+
+// replyTargetMetadataKey is the source_metadata key under which an explicit
+// reply's target message resource name is stored (spec §5.X.3). No provider
+// writes this key in PR 1 (explicit-reply bridging is deferred), so the
+// projection's ReplyTargetID is always nil here — but wiring it now means
+// PR 2/PR 3 (or a later explicit-reply follow-up) need not touch the adapter.
+const replyTargetMetadataKey = "reply_target_external_id"
+
+// NewGChatAggregationEngine constructs a shared aggregator engine configured
+// for the Google Chat source over the comms_message table. Mirror of
+// messages.NewAggregationEngine — same nil-safety conventions. Returns the
+// shared *aggregation.Engine directly (NO facade): GChat's chat ID is the
+// opaque space resource name (a string), so the engine's native
+// AggregateForContact(ctx, contactID, chatID string) signature already takes a
+// string. Production wiring passes all of (pool, eventBus, enqueuer).
+func NewGChatAggregationEngine(
+	burstWindowHours, replyBridgeHours int,
+	commsRepo *repository.CommsMessageRepository,
+	interactionRepo *repository.InteractionRepository,
+	promoter aggregation.InteractionPromoter,
+	extender aggregation.InteractionExtender,
+	eventBus *events.Bus,
+	pool aggregation.TxBeginner,
+	enqueuer aggregation.ConsumerJobEnqueuer,
+) *aggregation.Engine {
+	adapter := gchatAdapter{}
+	store := &commsMessageStoreAdapter{repo: commsRepo, source: GChatSourceName}
+	finder := &interactionFinderAdapter{repo: interactionRepo}
+
+	// Untyped-nil propagation — a typed-nil concrete pointer would silently
+	// bypass the engine's publisher == nil guard. See
+	// messaging/aggregation/interfaces.go EventPublisher note.
+	var pub aggregation.EventPublisher
+	if eventBus != nil {
+		pub = eventBus
+	}
+	var lookup aggregation.EventLookup
+	if eventBus != nil {
+		lookup = &busEventLookup{bus: eventBus}
+	}
+
+	return aggregation.NewEngine(
+		adapter,
+		store,
+		finder,
+		promoter,
+		extender,
+		pub,
+		burstWindowHours,
+		replyBridgeHours,
+		pool,
+		lookup,
+		enqueuer,
+	)
+}
+
+// --- adapters --------------------------------------------------------
+
+// gchatAdapter binds source-name + format hooks for the Google Chat source.
+// Wire format:
+//   - SourceRef:   "gchat:<space_resource>:<first_message_resource>"
+//   - PeerRef:     "gchat:<space_resource>"
+//   - Description: "GChat <label> (<n> messages)"
+//
+// The chat ID is the opaque Chat space resource name (e.g. "spaces/AAAA9876"),
+// a string, so this mirrors the Messages adapter (string chat IDs), not
+// Telegram (int64).
+type gchatAdapter struct{}
+
+// SourceName returns the source string written into interaction.source.
+func (gchatAdapter) SourceName() string {
+	return GChatSourceName
+}
+
+// SourceRef formats the deterministic burst sourceRef.
+func (gchatAdapter) SourceRef(chatID, firstExternalID string) string {
+	return GChatSourceName + ":" + chatID + ":" + firstExternalID
+}
+
+// SourceRefPrefix returns the LIKE pattern for scoped "recent interaction in
+// this chat" queries.
+//
+// Chat space resource names (e.g. "spaces/AAAA9876") do not legitimately
+// contain LIKE wildcards (`_`, `%`) today, but the format is opaque and could
+// drift. We escape the chat ID UNCONDITIONALLY (spec §5.X.4 defensive) so the
+// prefix is correct even if Chat ever ships a `_`/`%` in a resource name. The
+// underlying InteractionFinder queries use `LIKE pattern ESCAPE '\'`, so the
+// explicit escape takes effect end-to-end. The replacer also escapes a literal
+// `\` in the chat ID — belt-and-suspenders for forward compatibility.
+func (gchatAdapter) SourceRefPrefix(chatID string) string {
+	escaped := strings.NewReplacer(
+		`\`, `\\`,
+		`%`, `\%`,
+		`_`, `\_`,
+	).Replace(chatID)
+	return GChatSourceName + ":" + escaped + ":%"
+}
+
+// PeerRef formats the event-payload PeerRef field. NOT a LIKE pattern — escape
+// is not applied because the consumer's reenqueuer parses this field with a
+// literal string strip.
+func (gchatAdapter) PeerRef(chatID string) string {
+	return GChatSourceName + ":" + chatID
+}
+
+// Description formats the human-readable interaction description. Label
+// phrasing mirrors Telegram/Messages (outreach/response/exchange) so UI
+// surfaces stay consistent across sources.
+func (gchatAdapter) Description(direction string, msgCount int) string {
+	label := "exchange"
+	switch direction {
+	case repository.InteractionDirectionOutbound:
+		label = "outreach"
+	case repository.InteractionDirectionInbound:
+		label = "response"
+	}
+	return fmt.Sprintf("GChat %s (%d messages)", label, msgCount)
+}
+
+// commsMessageStoreAdapter projects repository.CommsMessage rows into
+// aggregation.Message, pinning a source. Lives in the google package (not
+// repository) so the repository package stays free of aggregation-package
+// imports — the same boundary the telegram/messages adapters honor. The 7
+// MessageStore methods delegate to the source-parameterized repo methods,
+// passing a.source; the ForSource suffix on the repo methods is erased here.
+type commsMessageStoreAdapter struct {
+	repo   *repository.CommsMessageRepository
+	source string
+}
+
+func (a *commsMessageStoreAdapter) ListUnprocessedContactIDs(ctx context.Context) ([]uuid.UUID, error) {
+	return a.repo.ListUnprocessedContactIDsForSource(ctx, a.source)
+}
+
+func (a *commsMessageStoreAdapter) ListUnprocessedByContact(ctx context.Context, contactID uuid.UUID) ([]aggregation.Message, error) {
+	rows, err := a.repo.ListUnprocessedByContactForSource(ctx, a.source, contactID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]aggregation.Message, len(rows))
+	for i := range rows {
+		out[i] = mapCommsMessage(rows[i])
+	}
+	return out, nil
+}
+
+func (a *commsMessageStoreAdapter) ListUnprocessedByContactAndChat(ctx context.Context, contactID uuid.UUID, chatID string) ([]aggregation.Message, error) {
+	rows, err := a.repo.ListUnprocessedByContactAndChatForSource(ctx, a.source, contactID, chatID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]aggregation.Message, len(rows))
+	for i := range rows {
+		out[i] = mapCommsMessage(rows[i])
+	}
+	return out, nil
+}
+
+// GetMessageByReplyTarget resolves the message referenced by a reply. The
+// reply target is itself a stored comms_message row, looked up by its own
+// external_id within the same (source, chat) scope.
+func (a *commsMessageStoreAdapter) GetMessageByReplyTarget(ctx context.Context, chatID, replyTargetID string) (aggregation.Message, bool, error) {
+	row, err := a.repo.GetMessageByReplyTargetForSource(ctx, a.source, chatID, replyTargetID)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return aggregation.Message{}, false, nil
+		}
+		return aggregation.Message{}, false, err
+	}
+	return mapCommsMessage(*row), true, nil
+}
+
+func (a *commsMessageStoreAdapter) MarkProcessed(ctx context.Context, messageIDs []uuid.UUID, interactionID uuid.UUID) error {
+	return a.repo.MarkMessagesProcessed(ctx, messageIDs, interactionID)
+}
+
+func (a *commsMessageStoreAdapter) ClaimRowsTx(ctx context.Context, tx pgx.Tx, messageIDs []uuid.UUID, sessionRef string) ([]uuid.UUID, error) {
+	return a.repo.ClaimMessagesTx(ctx, tx, messageIDs, sessionRef)
+}
+
+func (a *commsMessageStoreAdapter) ClearStaleClaimTx(ctx context.Context, tx pgx.Tx, messageIDs []uuid.UUID, expectedSessionRef string) error {
+	return a.repo.ClearStaleClaimTx(ctx, tx, messageIDs, expectedSessionRef)
+}
+
+// mapCommsMessage projects a repository.CommsMessage into the source-neutral
+// aggregation.Message. ChatID comes from thread_id (the space resource name);
+// a nil thread_id defensively yields ChatID == "" (chat sources always write
+// it non-null). Preserving InteractionID / ClaimedAt / ClaimedSessionRef is
+// required for cross-batch explicit reply bridging and stale-claim /
+// boundary-shift recovery. ReplyTargetID is parsed from
+// source_metadata.reply_target_external_id when present as a non-empty string.
+func mapCommsMessage(m repository.CommsMessage) aggregation.Message {
+	out := aggregation.Message{
+		ID:                m.ID,
+		IsOutgoing:        m.Direction == repository.InteractionDirectionOutbound,
+		SentAt:            m.SentAt,
+		ExternalID:        m.ExternalID,
+		InteractionID:     m.InteractionID,
+		ClaimedAt:         m.ClaimedAt,
+		ClaimedSessionRef: m.ClaimedSessionRef,
+	}
+	if m.ThreadID != nil {
+		out.ChatID = *m.ThreadID
+	}
+	if rt := parseReplyTargetID(m.SourceMetadata); rt != "" {
+		out.ReplyTargetID = &rt
+	}
+	return out
+}
+
+// parseReplyTargetID extracts source_metadata.reply_target_external_id as a
+// non-empty string, or "" when the key is absent, empty, or the wrong type.
+func parseReplyTargetID(raw []byte) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var meta map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &meta); err != nil {
+		return ""
+	}
+	v, ok := meta[replyTargetMetadataKey]
+	if !ok {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(v, &s); err != nil {
+		return ""
+	}
+	return s
+}
+
+// busEventLookup adapts *events.Bus to aggregation.EventLookup. Same shape as
+// the messages/telegram adapters' busEventLookup; re-declared package-private
+// here so the google package owns its own copy (the repository package stays
+// free of aggregation imports).
+type busEventLookup struct{ bus *events.Bus }
+
+func (l *busEventLookup) FindEventBySourceRef(ctx context.Context, source, sourceID string) (uuid.UUID, bool, error) {
+	env, err := l.bus.FindEventBySource(ctx, source, sourceID)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return uuid.Nil, false, nil
+		}
+		return uuid.Nil, false, err
+	}
+	return env.ID, true, nil
+}
+
+// interactionFinderAdapter wraps *repository.InteractionRepository and exposes
+// the source-neutral aggregation.InteractionFinder surface. Same shape as the
+// messages/telegram adapters' interactionFinderAdapter.
+type interactionFinderAdapter struct {
+	repo *repository.InteractionRepository
+}
+
+func (a *interactionFinderAdapter) FindRecentBySourceAndDirection(
+	ctx context.Context,
+	contactID uuid.UUID,
+	source, direction, sourceRefPrefix string,
+	windowStart, windowEnd time.Time,
+) (*repository.Interaction, error) {
+	return a.repo.FindRecentInteractionBySourceAndDirection(ctx, contactID, source, direction, sourceRefPrefix, windowStart, windowEnd)
+}
+
+func (a *interactionFinderAdapter) FindRecentOutboundBySource(
+	ctx context.Context,
+	contactID uuid.UUID,
+	source, sourceRefPrefix string,
+	windowStart, windowEnd time.Time,
+) (*repository.Interaction, error) {
+	return a.repo.FindRecentOutboundInteractionBySource(ctx, contactID, source, sourceRefPrefix, windowStart, windowEnd)
+}
+
+func (a *interactionFinderAdapter) GetInteraction(ctx context.Context, id uuid.UUID) (*repository.Interaction, error) {
+	return a.repo.GetInteraction(ctx, id)
+}

--- a/backend/internal/google/gchat_aggregation_unit_test.go
+++ b/backend/internal/google/gchat_aggregation_unit_test.go
@@ -1,0 +1,215 @@
+package google
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/messaging/aggregation"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGChatAdapter_Formatting pins the wire-format hooks: SourceName, SourceRef,
+// PeerRef, and Description for each direction.
+func TestGChatAdapter_Formatting(t *testing.T) {
+	a := gchatAdapter{}
+
+	assert.Equal(t, "gchat", a.SourceName())
+	assert.Equal(t,
+		"gchat:spaces/AAA:spaces/AAA/messages/1",
+		a.SourceRef("spaces/AAA", "spaces/AAA/messages/1"),
+	)
+	assert.Equal(t, "gchat:spaces/AAA", a.PeerRef("spaces/AAA"))
+
+	assert.Equal(t, "GChat outreach (3 messages)",
+		a.Description(repository.InteractionDirectionOutbound, 3))
+	assert.Equal(t, "GChat response (1 messages)",
+		a.Description(repository.InteractionDirectionInbound, 1))
+	assert.Equal(t, "GChat exchange (5 messages)",
+		a.Description(repository.InteractionDirectionMutual, 5))
+	// Unknown direction falls back to "exchange".
+	assert.Equal(t, "GChat exchange (2 messages)",
+		a.Description("something-else", 2))
+}
+
+// TestGChatAdapter_SourceRefPrefixEscape proves the LIKE-escape fires
+// UNCONDITIONALLY (spec §5.X.4): benign inputs pass through unchanged, while
+// `_`, `%`, and `\` are escaped so they cannot act as LIKE wildcards.
+func TestGChatAdapter_SourceRefPrefixEscape(t *testing.T) {
+	a := gchatAdapter{}
+
+	cases := []struct {
+		name string
+		chat string
+		want string
+	}{
+		{
+			name: "benign space resource name unchanged",
+			chat: "spaces/AAA",
+			want: `gchat:spaces/AAA:%`,
+		},
+		{
+			name: "underscore and percent escaped",
+			chat: "a_b%c",
+			want: `gchat:a\_b\%c:%`,
+		},
+		{
+			name: "backslash doubled",
+			chat: `a\b`,
+			want: `gchat:a\\b:%`,
+		},
+		{
+			name: "all special chars together",
+			chat: `x_%\y`,
+			want: `gchat:x\_\%\\y:%`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, a.SourceRefPrefix(tc.chat))
+		})
+	}
+}
+
+// TestMapCommsMessage_Projection covers the repository.CommsMessage →
+// aggregation.Message projection: ChatID from thread_id, IsOutgoing from
+// direction, ExternalID passthrough, claim/interaction fields preserved, and
+// the defensive nil thread_id case.
+func TestMapCommsMessage_Projection(t *testing.T) {
+	id := uuid.New()
+	interactionID := uuid.New()
+	claimedAt := time.Now().UTC().Truncate(time.Microsecond)
+	sessionRef := "gchat:spaces/AAA:spaces/AAA/messages/1"
+	sentAt := time.Now().UTC().Add(-time.Hour).Truncate(time.Microsecond)
+	thread := "spaces/AAA"
+
+	t.Run("outbound row with all fields", func(t *testing.T) {
+		m := repository.CommsMessage{
+			ID:                id,
+			Source:            "gchat",
+			ExternalID:        "spaces/AAA/messages/1",
+			ThreadID:          &thread,
+			Direction:         repository.InteractionDirectionOutbound,
+			SentAt:            sentAt,
+			InteractionID:     &interactionID,
+			ClaimedAt:         &claimedAt,
+			ClaimedSessionRef: &sessionRef,
+		}
+		got := mapCommsMessage(m)
+		assert.Equal(t, id, got.ID)
+		assert.Equal(t, "spaces/AAA", got.ChatID)
+		assert.True(t, got.IsOutgoing)
+		assert.Equal(t, sentAt, got.SentAt)
+		assert.Equal(t, "spaces/AAA/messages/1", got.ExternalID)
+		require.NotNil(t, got.InteractionID)
+		assert.Equal(t, interactionID, *got.InteractionID)
+		require.NotNil(t, got.ClaimedAt)
+		assert.Equal(t, claimedAt, *got.ClaimedAt)
+		require.NotNil(t, got.ClaimedSessionRef)
+		assert.Equal(t, sessionRef, *got.ClaimedSessionRef)
+		assert.Nil(t, got.ReplyTargetID)
+	})
+
+	t.Run("inbound row, nil claim/interaction fields preserved as nil", func(t *testing.T) {
+		m := repository.CommsMessage{
+			ID:         id,
+			Source:     "gchat",
+			ExternalID: "spaces/AAA/messages/2",
+			ThreadID:   &thread,
+			Direction:  repository.InteractionDirectionInbound,
+			SentAt:     sentAt,
+		}
+		got := mapCommsMessage(m)
+		assert.False(t, got.IsOutgoing)
+		assert.Nil(t, got.InteractionID)
+		assert.Nil(t, got.ClaimedAt)
+		assert.Nil(t, got.ClaimedSessionRef)
+	})
+
+	t.Run("nil thread_id yields empty ChatID (defensive)", func(t *testing.T) {
+		m := repository.CommsMessage{
+			ID:         id,
+			Source:     "gchat",
+			ExternalID: "spaces/AAA/messages/3",
+			ThreadID:   nil,
+			Direction:  repository.InteractionDirectionInbound,
+			SentAt:     sentAt,
+		}
+		got := mapCommsMessage(m)
+		assert.Equal(t, "", got.ChatID)
+	})
+}
+
+// TestMapCommsMessage_ReplyTargetID covers parsing the reply target external id
+// from source_metadata: present non-empty string → set; absent/empty/wrong-type
+// → nil.
+func TestMapCommsMessage_ReplyTargetID(t *testing.T) {
+	base := repository.CommsMessage{
+		ID:         uuid.New(),
+		Source:     "gchat",
+		ExternalID: "spaces/AAA/messages/9",
+		ThreadID:   strPtr("spaces/AAA"),
+		Direction:  repository.InteractionDirectionInbound,
+		SentAt:     time.Now().UTC(),
+	}
+
+	withMeta := func(m map[string]any) []byte {
+		b, err := json.Marshal(m)
+		require.NoError(t, err)
+		return b
+	}
+
+	t.Run("present non-empty string", func(t *testing.T) {
+		m := base
+		m.SourceMetadata = withMeta(map[string]any{
+			replyTargetMetadataKey: "spaces/AAA/messages/parent",
+		})
+		got := mapCommsMessage(m)
+		require.NotNil(t, got.ReplyTargetID)
+		assert.Equal(t, "spaces/AAA/messages/parent", *got.ReplyTargetID)
+	})
+
+	t.Run("key absent", func(t *testing.T) {
+		m := base
+		m.SourceMetadata = withMeta(map[string]any{"other": "x"})
+		assert.Nil(t, mapCommsMessage(m).ReplyTargetID)
+	})
+
+	t.Run("key present but empty string", func(t *testing.T) {
+		m := base
+		m.SourceMetadata = withMeta(map[string]any{replyTargetMetadataKey: ""})
+		assert.Nil(t, mapCommsMessage(m).ReplyTargetID)
+	})
+
+	t.Run("key present but wrong type", func(t *testing.T) {
+		m := base
+		m.SourceMetadata = withMeta(map[string]any{replyTargetMetadataKey: 123})
+		assert.Nil(t, mapCommsMessage(m).ReplyTargetID)
+	})
+
+	t.Run("nil/empty metadata", func(t *testing.T) {
+		m := base
+		m.SourceMetadata = nil
+		assert.Nil(t, mapCommsMessage(m).ReplyTargetID)
+		m.SourceMetadata = []byte{}
+		assert.Nil(t, mapCommsMessage(m).ReplyTargetID)
+	})
+
+	t.Run("malformed JSON", func(t *testing.T) {
+		m := base
+		m.SourceMetadata = []byte("{not json")
+		assert.Nil(t, mapCommsMessage(m).ReplyTargetID)
+	})
+}
+
+// TestGChatStoreAdapter_SatisfiesMessageStore is a compile-time assertion that
+// commsMessageStoreAdapter implements the aggregation.MessageStore interface
+// (catches a signature drift on either side).
+func TestGChatStoreAdapter_SatisfiesMessageStore(t *testing.T) {
+	var _ aggregation.MessageStore = (*commsMessageStoreAdapter)(nil)
+	var _ aggregation.SourceAdapter = gchatAdapter{}
+}

--- a/backend/internal/google/gchat_aggregation_unit_test.go
+++ b/backend/internal/google/gchat_aggregation_unit_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"personal-crm/backend/internal/accelerated"
 	"personal-crm/backend/internal/messaging/aggregation"
 	"personal-crm/backend/internal/repository"
 
@@ -82,9 +83,9 @@ func TestGChatAdapter_SourceRefPrefixEscape(t *testing.T) {
 func TestMapCommsMessage_Projection(t *testing.T) {
 	id := uuid.New()
 	interactionID := uuid.New()
-	claimedAt := time.Now().UTC().Truncate(time.Microsecond)
+	claimedAt := accelerated.GetCurrentTime().UTC().Truncate(time.Microsecond)
 	sessionRef := "gchat:spaces/AAA:spaces/AAA/messages/1"
-	sentAt := time.Now().UTC().Add(-time.Hour).Truncate(time.Microsecond)
+	sentAt := accelerated.GetCurrentTime().UTC().Add(-time.Hour).Truncate(time.Microsecond)
 	thread := "spaces/AAA"
 
 	t.Run("outbound row with all fields", func(t *testing.T) {
@@ -154,7 +155,7 @@ func TestMapCommsMessage_ReplyTargetID(t *testing.T) {
 		ExternalID: "spaces/AAA/messages/9",
 		ThreadID:   strPtr("spaces/AAA"),
 		Direction:  repository.InteractionDirectionInbound,
-		SentAt:     time.Now().UTC(),
+		SentAt:     accelerated.GetCurrentTime().UTC(),
 	}
 
 	withMeta := func(m map[string]any) []byte {

--- a/backend/internal/identity/normalize.go
+++ b/backend/internal/identity/normalize.go
@@ -19,6 +19,12 @@ const (
 	IdentifierTypeIMessageEmail IdentifierType = "imessage_email"
 	IdentifierTypeIMessagePhone IdentifierType = "imessage_phone"
 	IdentifierTypeWhatsApp      IdentifierType = "whatsapp"
+	// IdentifierTypeGChat is the Google Chat sender address. Chat sender
+	// addresses ARE emails, so Normalize delegates to normalizeEmail
+	// (lowercase + trim) — identical to the contact_method trigger's
+	// handling of gchat values (migrations/021/022), so there is no
+	// Go-vs-trigger drift.
+	IdentifierTypeGChat IdentifierType = "gchat"
 	// IdentifierTypeAnarlogHuman is the anarlog-internal human UUID
 	// (UUID v4 string) emitted by the Mac daemon's anarlog_humans
 	// plugin. Used as the lookup key for resolving
@@ -38,6 +44,7 @@ const (
 	ContactMethodTypePhone    ContactMethodType = "phone"
 	ContactMethodTypeTelegram ContactMethodType = "telegram"
 	ContactMethodTypeWhatsApp ContactMethodType = "whatsapp"
+	ContactMethodTypeGChat    ContactMethodType = "gchat"
 )
 
 // nonDigitRegex matches any non-digit character
@@ -52,7 +59,7 @@ var nonDigitRegex = regexp.MustCompile(`\D`)
 //     lowercasing keeps lookups deterministic against the daemon's emit form)
 func Normalize(raw string, idType IdentifierType) string {
 	switch idType {
-	case IdentifierTypeEmail, IdentifierTypeIMessageEmail:
+	case IdentifierTypeEmail, IdentifierTypeIMessageEmail, IdentifierTypeGChat:
 		return normalizeEmail(raw)
 	case IdentifierTypePhone, IdentifierTypeIMessagePhone, IdentifierTypeWhatsApp:
 		return normalizePhone(raw)
@@ -101,6 +108,13 @@ func MapIdentifierTypeToContactMethodTypes(idType IdentifierType) []ContactMetho
 		return []ContactMethodType{ContactMethodTypePhone}
 	case IdentifierTypeWhatsApp:
 		return []ContactMethodType{ContactMethodTypeWhatsApp, ContactMethodTypePhone}
+	// IdentifierTypeGChat is intentionally absent: no caller invokes
+	// MatchOrCreate(IdentifierTypeGChat, ...) in the MVP, so a branch here
+	// would be dead code and a second encoding of the (gchat, email)
+	// dual-source set that could drift from the ListGChatIdentitiesForSync
+	// sqlc query — that query is the single source of truth for the set.
+	// If a future caller emerges, the WhatsApp branch above is the
+	// precedent shape (gchat → [gchat, email]).
 	default:
 		return nil
 	}

--- a/backend/internal/identity/normalize_test.go
+++ b/backend/internal/identity/normalize_test.go
@@ -179,6 +179,41 @@ func TestNormalizeWhatsApp(t *testing.T) {
 	assert.Equal(t, "+15551234567", result)
 }
 
+// TestNormalizeGChat asserts a Google Chat sender address normalizes
+// identically to an email (lowercase + trim) — GChat addresses ARE emails,
+// matching the contact_method trigger's gchat handling exactly.
+func TestNormalizeGChat(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"mixed case", "John.Doe@Example.COM"},
+		{"leading/trailing whitespace", "  john.doe@example.com  "},
+		{"already normalized", "john.doe@example.com"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gchat := Normalize(tt.input, IdentifierTypeGChat)
+			email := Normalize(tt.input, IdentifierTypeEmail)
+			assert.Equal(t, email, gchat,
+				"gchat normalization must match email normalization")
+		})
+	}
+	assert.Equal(t, "john.doe@example.com",
+		Normalize("John.Doe@Example.COM", IdentifierTypeGChat))
+}
+
+// TestMapIdentifierTypeToContactMethodTypes_GChatReturnsNil is a regression
+// guard: IdentifierTypeGChat is intentionally absent from the mapping (§5.X.7
+// DEFERRED). The ListGChatIdentitiesForSync sqlc query is the single source of
+// truth for the (gchat, email) dual-source set; a mapping branch here would be
+// dead code and a second encoding that could drift. If someone adds a gchat
+// MatchOrCreate caller later, they must also revisit this rationale.
+func TestMapIdentifierTypeToContactMethodTypes_GChatReturnsNil(t *testing.T) {
+	result := MapIdentifierTypeToContactMethodTypes(IdentifierTypeGChat)
+	assert.Nil(t, result)
+}
+
 func TestNormalizeAnarlogHuman(t *testing.T) {
 	// Anarlog UUIDs are already canonical; Normalize trims whitespace
 	// and lowercases so case-mixed daemon emits compare equal to stored.

--- a/backend/internal/messages/aggregation_adapter.go
+++ b/backend/internal/messages/aggregation_adapter.go
@@ -172,8 +172,10 @@ func (a *messagesMessageStoreAdapter) ListUnprocessedByContactAndChat(ctx contex
 
 // GetMessageByReplyTarget resolves the message referenced by a reply.
 // The messages source uses opaque string guids — no parse step is
-// needed (telegram has to parse int64; we don't).
-func (a *messagesMessageStoreAdapter) GetMessageByReplyTarget(ctx context.Context, chatID, replyTargetID string) (aggregation.Message, bool, error) {
+// needed (telegram has to parse int64; we don't). contactID is ignored:
+// messages_message rows are keyed by a globally-unique guid, so the
+// lookup is already contact-correct (one row per message).
+func (a *messagesMessageStoreAdapter) GetMessageByReplyTarget(ctx context.Context, _ uuid.UUID, chatID, replyTargetID string) (aggregation.Message, bool, error) {
 	row, err := a.repo.GetMessageByReplyTarget(ctx, chatID, replyTargetID)
 	if err != nil {
 		if errors.Is(err, db.ErrNotFound) {

--- a/backend/internal/messaging/aggregation/engine.go
+++ b/backend/internal/messaging/aggregation/engine.go
@@ -283,7 +283,7 @@ func (e *Engine) tryExplicitReplyBridge(ctx context.Context, contactID uuid.UUID
 		if msg.ReplyTargetID == nil {
 			continue
 		}
-		referenced, ok, err := e.store.GetMessageByReplyTarget(ctx, sess.chatID, *msg.ReplyTargetID)
+		referenced, ok, err := e.store.GetMessageByReplyTarget(ctx, contactID, sess.chatID, *msg.ReplyTargetID)
 		if err != nil || !ok {
 			continue
 		}
@@ -292,6 +292,16 @@ func (e *Engine) tryExplicitReplyBridge(ctx context.Context, contactID uuid.UUID
 		}
 		existing, err := e.finder.GetInteraction(ctx, *referenced.InteractionID)
 		if err != nil || existing.Source != source || existing.Direction != repository.InteractionDirectionOutbound {
+			continue
+		}
+		// Guard against cross-contact bridging: the referenced interaction
+		// MUST belong to the contact we are aggregating for. For per-contact
+		// content stores (comms_message), a shared/fanned-out reply target
+		// can resolve to a different contact's row, whose InteractionID
+		// points at that other contact's interaction. Promoting it here would
+		// mark the wrong contact mutual. Source-neutral defense for every
+		// MessageStore.
+		if existing.ContactID != contactID {
 			continue
 		}
 		if err := e.promoter.PromoteInteractionToMutual(ctx, existing.ID, contactID, sess.lastSentAt()); err != nil {

--- a/backend/internal/messaging/aggregation/engine_test.go
+++ b/backend/internal/messaging/aggregation/engine_test.go
@@ -125,7 +125,7 @@ func (s *fakeStore) ListUnprocessedByContactAndChat(_ context.Context, contactID
 	return s.byContactAndChat[contactID.String()+"|"+chatID], nil
 }
 
-func (s *fakeStore) GetMessageByReplyTarget(_ context.Context, chatID, replyTargetID string) (Message, bool, error) {
+func (s *fakeStore) GetMessageByReplyTarget(_ context.Context, _ uuid.UUID, chatID, replyTargetID string) (Message, bool, error) {
 	msg, ok := s.byReplyTarget[chatID+"|"+replyTargetID]
 	return msg, ok, nil
 }
@@ -661,9 +661,12 @@ func TestEngine_FakeSource_ExplicitReplyBridge(t *testing.T) {
 	finder := &fakeFinder{
 		// Time-based bridge fails (no outbound in window).
 		findRecentOutboundErr: db.ErrNotFound,
-		// GetInteraction returns the existing outbound row.
+		// GetInteraction returns the existing outbound row, owned by the
+		// same contact we're aggregating for (the cross-contact guard
+		// requires existing.ContactID == contactID).
 		getInteractionRet: &repository.Interaction{
 			ID:        priorOutboundID,
+			ContactID: contactID,
 			Source:    "fakesrc",
 			Direction: repository.InteractionDirectionOutbound,
 		},
@@ -679,6 +682,67 @@ func TestEngine_FakeSource_ExplicitReplyBridge(t *testing.T) {
 	require.Len(t, store.markProcessedCalls, 1)
 	assert.Equal(t, priorOutboundID, store.markProcessedCalls[0].interactionID)
 	assert.Empty(t, publisher.envelopes)
+}
+
+// TestEngine_FakeSource_ExplicitReplyBridge_RejectsOtherContact locks the
+// cross-contact guard: if the referenced reply-target resolves to an
+// interaction owned by a DIFFERENT contact (as can happen for per-contact
+// content stores where a shared address fans out), the engine must NOT promote
+// it. Instead it falls through to the create path (publishes a new event).
+func TestEngine_FakeSource_ExplicitReplyBridge_RejectsOtherContact(t *testing.T) {
+	ctx := context.Background()
+	base := accelerated.GetCurrentTime()
+	contactID := uuid.New()
+	otherContactID := uuid.New()
+	priorOutboundID := uuid.New()
+
+	adapter := fakeAdapter{name: "fakesrc"}
+	store := newFakeStore()
+
+	replyTarget := "outboundExt"
+	inbound := Message{
+		ID:            uuid.New(),
+		ChatID:        "chatA",
+		ExternalID:    "i1",
+		IsOutgoing:    false,
+		SentAt:        base.Add(100 * time.Hour), // outside time-bridge window
+		ReplyTargetID: &replyTarget,
+	}
+	store.byContactAndChat[contactID.String()+"|chatA"] = []Message{inbound}
+
+	referenced := Message{
+		ID:            uuid.New(),
+		ChatID:        "chatA",
+		ExternalID:    replyTarget,
+		IsOutgoing:    true,
+		SentAt:        base,
+		InteractionID: &priorOutboundID,
+	}
+	store.byReplyTarget["chatA|"+replyTarget] = referenced
+
+	finder := &fakeFinder{
+		// Both time-bridge lookups miss so the only path that could promote
+		// is the explicit-reply bridge — which must be rejected here.
+		findRecentOutboundErr:       db.ErrNotFound,
+		findRecentBySourceAndDirErr: db.ErrNotFound,
+		// The referenced interaction is owned by ANOTHER contact.
+		getInteractionRet: &repository.Interaction{
+			ID:        priorOutboundID,
+			ContactID: otherContactID,
+			Source:    "fakesrc",
+			Direction: repository.InteractionDirectionOutbound,
+		},
+	}
+	promoter := &fakePromoter{}
+	publisher := &fakePublisher{}
+
+	engine := NewEngine(adapter, store, finder, promoter, &fakeExtender{}, publisher, 2, 48, nil, nil, nil)
+	require.NoError(t, engine.AggregateForContact(ctx, contactID, "chatA"))
+
+	// No promotion of the other contact's interaction.
+	assert.Empty(t, promoter.calls, "must NOT promote an interaction owned by a different contact")
+	// Falls through to the create path: a fresh event is published.
+	require.Len(t, publisher.envelopes, 1, "rejecting the cross-contact bridge falls through to the create path")
 }
 
 // TestEngine_FakeSource_NoMatch_PublishesCreateEvent asserts the
@@ -844,8 +908,8 @@ func (s *perContactErroringStore) ListUnprocessedByContact(ctx context.Context, 
 func (s *perContactErroringStore) ListUnprocessedByContactAndChat(ctx context.Context, contactID uuid.UUID, chatID string) ([]Message, error) {
 	return s.inner.ListUnprocessedByContactAndChat(ctx, contactID, chatID)
 }
-func (s *perContactErroringStore) GetMessageByReplyTarget(ctx context.Context, chatID, replyTargetID string) (Message, bool, error) {
-	return s.inner.GetMessageByReplyTarget(ctx, chatID, replyTargetID)
+func (s *perContactErroringStore) GetMessageByReplyTarget(ctx context.Context, contactID uuid.UUID, chatID, replyTargetID string) (Message, bool, error) {
+	return s.inner.GetMessageByReplyTarget(ctx, contactID, chatID, replyTargetID)
 }
 func (s *perContactErroringStore) MarkProcessed(ctx context.Context, messageIDs []uuid.UUID, interactionID uuid.UUID) error {
 	return s.inner.MarkProcessed(ctx, messageIDs, interactionID)

--- a/backend/internal/messaging/aggregation/interfaces.go
+++ b/backend/internal/messaging/aggregation/interfaces.go
@@ -101,15 +101,23 @@ type MessageStore interface {
 	ListUnprocessedByContactAndChat(ctx context.Context, contactID uuid.UUID, chatID string) ([]Message, error)
 
 	// GetMessageByReplyTarget resolves the message referenced by a
-	// reply (Message.ReplyTargetID). The returned Message includes its
-	// InteractionID and IsOutgoing so tryExplicitReplyBridge can verify
-	// the bridged interaction exists and the message direction is
-	// correct.
+	// reply (Message.ReplyTargetID), scoped to the contact being
+	// aggregated. The returned Message includes its InteractionID and
+	// IsOutgoing so tryExplicitReplyBridge can verify the bridged
+	// interaction exists and the message direction is correct.
+	//
+	// contactID scopes the lookup to the current contact's row. This
+	// matters for per-contact content stores (comms_message), where a
+	// shared/fanned-out reply target produces one row per matched contact
+	// — an unscoped lookup could return a different contact's row whose
+	// InteractionID points at that other contact's interaction. Stores
+	// keyed by a globally-unique message id (telegram/messages guids)
+	// may ignore contactID since their lookup is already contact-correct.
 	//
 	// Returns (msg, true, nil) on hit; (Message{}, false, nil) if not
 	// found OR if the source-specific ID cannot be parsed; non-nil
 	// error only on infrastructure failure.
-	GetMessageByReplyTarget(ctx context.Context, chatID, replyTargetID string) (Message, bool, error)
+	GetMessageByReplyTarget(ctx context.Context, contactID uuid.UUID, chatID, replyTargetID string) (Message, bool, error)
 
 	// MarkProcessed sets processed_at and interaction_id on the rows
 	// AND clears claim columns. Non-tx variant; used by the engine's

--- a/backend/internal/repository/comms_message.go
+++ b/backend/internal/repository/comms_message.go
@@ -324,7 +324,7 @@ func (r *CommsMessageRepository) ListEmailIdentitiesForSync(ctx context.Context)
 // source_type) triple for non-deleted contacts whose contact_method type is
 // 'gchat' or 'email'. The mapping is many-to-one (shared address → multiple
 // contacts). The GChat provider builds its dual-source known-contact map from
-// this (PR 2). Rows with an invalid contact_id are skipped defensively.
+// this. Rows with an invalid contact_id are skipped defensively.
 func (r *CommsMessageRepository) ListGChatIdentitiesForSync(ctx context.Context) ([]GChatIdentity, error) {
 	rows, err := r.queries.ListGChatIdentitiesForSync(ctx)
 	if err != nil {
@@ -525,13 +525,16 @@ func (r *CommsMessageRepository) ListUnprocessedChatsByContactForSource(ctx cont
 }
 
 // GetMessageByReplyTargetForSource resolves the row a reply points at, scoped
-// to a (source, chat) pair, by the target message's own external_id. Returns
+// to a (source, contact, chat) triple, by the target message's own external_id.
+// Scoping to contactID is load-bearing: comms_message is per-contact, so an
+// unscoped lookup could return a different contact's fanned-out row. Returns
 // db.ErrNotFound on miss.
-func (r *CommsMessageRepository) GetMessageByReplyTargetForSource(ctx context.Context, source, chatID, replyTargetID string) (*CommsMessage, error) {
+func (r *CommsMessageRepository) GetMessageByReplyTargetForSource(ctx context.Context, source string, contactID uuid.UUID, chatID, replyTargetID string) (*CommsMessage, error) {
 	dbMsg, err := r.queries.GetCommsMessageByReplyTarget(ctx, db.GetCommsMessageByReplyTargetParams{
-		Source:        source,
-		ThreadID:      pgtype.Text{String: chatID, Valid: true},
-		ReplyTargetID: replyTargetID,
+		Source:           source,
+		MatchedContactID: uuidToPgUUID(contactID),
+		ThreadID:         pgtype.Text{String: chatID, Valid: true},
+		ReplyTargetID:    replyTargetID,
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -647,7 +650,7 @@ func (r *CommsMessageRepository) BackdateClaim(ctx context.Context, messageIDs [
 
 // SoftDeleteByID is a test-only helper that soft-deletes a single
 // comms_message row by id (simulating an upstream provider delete). Used by the
-// delete-no-op aggregation test. Production delete paths land in PR 2.
+// delete-no-op aggregation test. There is no production chat delete path yet.
 func (r *CommsMessageRepository) SoftDeleteByID(ctx context.Context, id uuid.UUID) error {
 	return r.queries.SoftDeleteCommsMessageByID(ctx, uuidToPgUUID(id))
 }

--- a/backend/internal/repository/comms_message.go
+++ b/backend/internal/repository/comms_message.go
@@ -74,6 +74,18 @@ type EmailIdentity struct {
 	ContactID       uuid.UUID
 }
 
+// GChatIdentity is a (normalized address, contact, source_type) triple from
+// ListGChatIdentitiesForSync. Dual-source: SourceType is "gchat" or "email"
+// (GChat sender addresses ARE emails, so the provider considers both a
+// dedicated gchat method and any plain email method). Many-to-one: a shared
+// address maps to several contacts, one GChatIdentity per (address, contact,
+// type) row.
+type GChatIdentity struct {
+	ValueNormalized string
+	ContactID       uuid.UUID
+	SourceType      string
+}
+
 // CommsMessageRepository wraps the sqlc-generated comms_message queries.
 type CommsMessageRepository struct {
 	queries db.Querier
@@ -308,6 +320,30 @@ func (r *CommsMessageRepository) ListEmailIdentitiesForSync(ctx context.Context)
 	return out, nil
 }
 
+// ListGChatIdentitiesForSync returns every (normalized address, contact,
+// source_type) triple for non-deleted contacts whose contact_method type is
+// 'gchat' or 'email'. The mapping is many-to-one (shared address → multiple
+// contacts). The GChat provider builds its dual-source known-contact map from
+// this (PR 2). Rows with an invalid contact_id are skipped defensively.
+func (r *CommsMessageRepository) ListGChatIdentitiesForSync(ctx context.Context) ([]GChatIdentity, error) {
+	rows, err := r.queries.ListGChatIdentitiesForSync(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]GChatIdentity, 0, len(rows))
+	for _, row := range rows {
+		if !row.ContactID.Valid {
+			continue
+		}
+		out = append(out, GChatIdentity{
+			ValueNormalized: row.ValueNormalized,
+			ContactID:       uuid.UUID(row.ContactID.Bytes),
+			SourceType:      row.SourceType,
+		})
+	}
+	return out, nil
+}
+
 // HardDeleteByContact is a test-only helper that hard-deletes comms_message
 // rows by matched_contact_id. Used by integration tests for per-run cleanup;
 // soft-delete is unsafe because the upsert does not clear deleted_at on
@@ -404,4 +440,246 @@ func NewCommsStagingProcessor(repo *CommsMessageRepository) *CommsStagingProcess
 // MarkProcessedTx implements StagingProcessor.
 func (p *CommsStagingProcessor) MarkProcessedTx(ctx context.Context, tx pgx.Tx, messageIDs []uuid.UUID, interactionID uuid.UUID, sessionRef string) (int64, error) {
 	return p.repo.MarkProcessedTx(ctx, tx, messageIDs, interactionID, sessionRef)
+}
+
+// =====================================================================
+// Source-parameterized aggregation-engine methods. These back the GChat
+// (and future Telegram/Messages) MessageStore adapter, which pins a
+// `source` and erases the ForSource suffix. The comms_message table is
+// multi-source, so the source is an explicit param here (unlike the
+// single-source messages_message / telegram_message repos). Reuse the
+// conversions.go helpers (uuidToPgUUID, stringToPgText, etc.).
+// =====================================================================
+
+// ListUnprocessedContactIDsForSource returns distinct contact IDs with at
+// least one eligible (unprocessed AND unclaimed-or-stale) row for the source.
+func (r *CommsMessageRepository) ListUnprocessedContactIDsForSource(ctx context.Context, source string) ([]uuid.UUID, error) {
+	pgIDs, err := r.queries.ListUnprocessedCommsContactIDs(ctx, source)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]uuid.UUID, 0, len(pgIDs))
+	for _, pgID := range pgIDs {
+		if pgID.Valid {
+			ids = append(ids, uuid.UUID(pgID.Bytes))
+		}
+	}
+	return ids, nil
+}
+
+// ListUnprocessedByContactForSource returns eligible rows for a contact within
+// the source.
+func (r *CommsMessageRepository) ListUnprocessedByContactForSource(ctx context.Context, source string, contactID uuid.UUID) ([]CommsMessage, error) {
+	dbMsgs, err := r.queries.ListUnprocessedCommsByContact(ctx, db.ListUnprocessedCommsByContactParams{
+		Source:           source,
+		MatchedContactID: uuidToPgUUID(contactID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	msgs := make([]CommsMessage, len(dbMsgs))
+	for i, m := range dbMsgs {
+		msgs[i] = convertDbCommsMessage(m)
+	}
+	return msgs, nil
+}
+
+// ListUnprocessedByContactAndChatForSource returns eligible rows for a
+// (contact, chat) pair within the source. chatID is stored in thread_id.
+func (r *CommsMessageRepository) ListUnprocessedByContactAndChatForSource(ctx context.Context, source string, contactID uuid.UUID, chatID string) ([]CommsMessage, error) {
+	dbMsgs, err := r.queries.ListUnprocessedCommsByContactAndChat(ctx, db.ListUnprocessedCommsByContactAndChatParams{
+		Source:           source,
+		MatchedContactID: uuidToPgUUID(contactID),
+		ThreadID:         pgtype.Text{String: chatID, Valid: true},
+	})
+	if err != nil {
+		return nil, err
+	}
+	msgs := make([]CommsMessage, len(dbMsgs))
+	for i, m := range dbMsgs {
+		msgs[i] = convertDbCommsMessage(m)
+	}
+	return msgs, nil
+}
+
+// ListUnprocessedChatsByContactForSource returns the distinct chat scopes
+// (thread_id values) for which the contact has at least one eligible row
+// within the source. Drives the messaging aggregator worker's per-chat loop.
+// thread_id is nullable on comms_message; NULL values are filtered out
+// defensively (chat sources always write it non-null).
+func (r *CommsMessageRepository) ListUnprocessedChatsByContactForSource(ctx context.Context, source string, contactID uuid.UUID) ([]string, error) {
+	rows, err := r.queries.ListUnprocessedCommsChatsByContact(ctx, db.ListUnprocessedCommsChatsByContactParams{
+		Source:           source,
+		MatchedContactID: uuidToPgUUID(contactID),
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(rows))
+	for _, t := range rows {
+		if t.Valid && t.String != "" {
+			out = append(out, t.String)
+		}
+	}
+	return out, nil
+}
+
+// GetMessageByReplyTargetForSource resolves the row a reply points at, scoped
+// to a (source, chat) pair, by the target message's own external_id. Returns
+// db.ErrNotFound on miss.
+func (r *CommsMessageRepository) GetMessageByReplyTargetForSource(ctx context.Context, source, chatID, replyTargetID string) (*CommsMessage, error) {
+	dbMsg, err := r.queries.GetCommsMessageByReplyTarget(ctx, db.GetCommsMessageByReplyTargetParams{
+		Source:        source,
+		ThreadID:      pgtype.Text{String: chatID, Valid: true},
+		ReplyTargetID: replyTargetID,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, db.ErrNotFound
+		}
+		return nil, err
+	}
+	msg := convertDbCommsMessage(dbMsg)
+	return &msg, nil
+}
+
+// MarkMessagesProcessed sets processed_at + interaction_id + clears claim
+// columns. Non-tx variant; used by the engine's extend/promote/bridge paths
+// only (those paths do not claim rows or publish events). No source param: id =
+// ANY(...) is PK-scoped and the engine lists/processes per-source. Empty
+// messageIDs short-circuits to nil.
+func (r *CommsMessageRepository) MarkMessagesProcessed(ctx context.Context, messageIDs []uuid.UUID, interactionID uuid.UUID) error {
+	if len(messageIDs) == 0 {
+		return nil
+	}
+	pgIDs := make([]pgtype.UUID, len(messageIDs))
+	for i, id := range messageIDs {
+		pgIDs[i] = uuidToPgUUID(id)
+	}
+	_, err := r.queries.MarkCommsMessagesProcessed(ctx, db.MarkCommsMessagesProcessedParams{
+		InteractionID: uuidToPgUUID(interactionID),
+		MessageIds:    pgIDs,
+	})
+	return err
+}
+
+// MarkProcessedForSessionTx is the tx-bound, session-scoped mark-processed for
+// the chat create-path. The SQL predicate scopes the update to rows whose
+// claimed_session_ref matches sessionRef OR is NULL — defending against the
+// stale boundary-shift race while still working when the engine took the non-tx
+// publish path (NULL claimed_session_ref). Returns rows actually updated so the
+// recorder can detect the zero-rows boundary-shift case. Empty messageIDs
+// short-circuits to (0, nil).
+func (r *CommsMessageRepository) MarkProcessedForSessionTx(ctx context.Context, tx pgx.Tx, messageIDs []uuid.UUID, interactionID uuid.UUID, sessionRef string) (int64, error) {
+	if len(messageIDs) == 0 {
+		return 0, nil
+	}
+	pgIDs := make([]pgtype.UUID, len(messageIDs))
+	for i, id := range messageIDs {
+		pgIDs[i] = uuidToPgUUID(id)
+	}
+	return db.New(tx).MarkCommsMessagesProcessedForSession(ctx, db.MarkCommsMessagesProcessedForSessionParams{
+		InteractionID: uuidToPgUUID(interactionID),
+		MessageIds:    pgIDs,
+		SessionRef:    pgtype.Text{String: sessionRef, Valid: true},
+	})
+}
+
+// ClaimMessagesTx writes claim columns on rows still eligible. Used by the
+// aggregator engine's create-path tx. Returns the IDs actually claimed (via
+// RETURNING id); the caller compares against the requested set to detect
+// partial-claim races. Empty messageIDs short-circuits to nil.
+func (r *CommsMessageRepository) ClaimMessagesTx(ctx context.Context, tx pgx.Tx, messageIDs []uuid.UUID, sessionRef string) ([]uuid.UUID, error) {
+	if len(messageIDs) == 0 {
+		return nil, nil
+	}
+	pgIDs := make([]pgtype.UUID, len(messageIDs))
+	for i, id := range messageIDs {
+		pgIDs[i] = uuidToPgUUID(id)
+	}
+	claimed, err := db.New(tx).ClaimCommsMessages(ctx, db.ClaimCommsMessagesParams{
+		SessionRef: pgtype.Text{String: sessionRef, Valid: true},
+		MessageIds: pgIDs,
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]uuid.UUID, 0, len(claimed))
+	for _, id := range claimed {
+		if id.Valid {
+			out = append(out, uuid.UUID(id.Bytes))
+		}
+	}
+	return out, nil
+}
+
+// ClearStaleClaimTx clears claim columns for rows still carrying the expected
+// stale session_ref. Used by the engine's defensive recovery branch when
+// FindEventBySource returned no row for the claimed session. Empty messageIDs
+// short-circuits to nil.
+func (r *CommsMessageRepository) ClearStaleClaimTx(ctx context.Context, tx pgx.Tx, messageIDs []uuid.UUID, expectedSessionRef string) error {
+	if len(messageIDs) == 0 {
+		return nil
+	}
+	pgIDs := make([]pgtype.UUID, len(messageIDs))
+	for i, id := range messageIDs {
+		pgIDs[i] = uuidToPgUUID(id)
+	}
+	return db.New(tx).ClearStaleCommsClaim(ctx, db.ClearStaleCommsClaimParams{
+		MessageIds:         pgIDs,
+		ExpectedSessionRef: pgtype.Text{String: expectedSessionRef, Valid: true},
+	})
+}
+
+// BackdateClaim is a test-only helper that ages the claim on the given rows
+// past the 5-minute TTL so a fresh aggregate pass can re-claim them.
+// Production code MUST NOT call this.
+func (r *CommsMessageRepository) BackdateClaim(ctx context.Context, messageIDs []uuid.UUID) error {
+	if len(messageIDs) == 0 {
+		return nil
+	}
+	pgIDs := make([]pgtype.UUID, len(messageIDs))
+	for i, id := range messageIDs {
+		pgIDs[i] = uuidToPgUUID(id)
+	}
+	return r.queries.BackdateCommsMessageClaim(ctx, pgIDs)
+}
+
+// CommsSourceContactLister adapts *CommsMessageRepository to the source-neutral
+// scheduler.UnprocessedContactLister interface, pinning a source. The sweeper's
+// interface is single-source (ListUnprocessedContactIDs(ctx)) but comms_message
+// is multi-source; this adapter binds the source so main.go references a built
+// type (single-file build convention) rather than an inline closure-struct.
+type CommsSourceContactLister struct {
+	repo   *CommsMessageRepository
+	source string
+}
+
+// NewCommsSourceContactLister builds the source-bound sweeper lister adapter.
+func NewCommsSourceContactLister(repo *CommsMessageRepository, source string) *CommsSourceContactLister {
+	return &CommsSourceContactLister{repo: repo, source: source}
+}
+
+// ListUnprocessedContactIDs implements scheduler.UnprocessedContactLister.
+func (l *CommsSourceContactLister) ListUnprocessedContactIDs(ctx context.Context) ([]uuid.UUID, error) {
+	return l.repo.ListUnprocessedContactIDsForSource(ctx, l.source)
+}
+
+// CommsSessionStagingProcessor adapts *CommsMessageRepository to the
+// source-neutral StagingProcessor interface for CHAT sources (gchat). It uses
+// the SESSION-scoped, claim-clearing MarkProcessedForSessionTx — unlike the
+// email CommsStagingProcessor, which uses the non-session MarkProcessedTx.
+// The chat create-path claims rows and publishes events; the recorder's
+// zero-rows-affected rollback depends on the session predicate, so reusing the
+// email processor here would break the boundary-shift defense.
+type CommsSessionStagingProcessor struct{ repo *CommsMessageRepository }
+
+// NewCommsSessionStagingProcessor builds the chat-source staging processor.
+func NewCommsSessionStagingProcessor(repo *CommsMessageRepository) *CommsSessionStagingProcessor {
+	return &CommsSessionStagingProcessor{repo: repo}
+}
+
+// MarkProcessedTx implements StagingProcessor (session-scoped).
+func (p *CommsSessionStagingProcessor) MarkProcessedTx(ctx context.Context, tx pgx.Tx, messageIDs []uuid.UUID, interactionID uuid.UUID, sessionRef string) (int64, error) {
+	return p.repo.MarkProcessedForSessionTx(ctx, tx, messageIDs, interactionID, sessionRef)
 }

--- a/backend/internal/repository/comms_message.go
+++ b/backend/internal/repository/comms_message.go
@@ -645,6 +645,13 @@ func (r *CommsMessageRepository) BackdateClaim(ctx context.Context, messageIDs [
 	return r.queries.BackdateCommsMessageClaim(ctx, pgIDs)
 }
 
+// SoftDeleteByID is a test-only helper that soft-deletes a single
+// comms_message row by id (simulating an upstream provider delete). Used by the
+// delete-no-op aggregation test. Production delete paths land in PR 2.
+func (r *CommsMessageRepository) SoftDeleteByID(ctx context.Context, id uuid.UUID) error {
+	return r.queries.SoftDeleteCommsMessageByID(ctx, uuidToPgUUID(id))
+}
+
 // CommsSourceContactLister adapts *CommsMessageRepository to the source-neutral
 // scheduler.UnprocessedContactLister interface, pinning a source. The sweeper's
 // interface is single-source (ListUnprocessedContactIDs(ctx)) but comms_message

--- a/backend/internal/repository/interaction.go
+++ b/backend/internal/repository/interaction.go
@@ -22,6 +22,7 @@ const (
 	InteractionSourceAnarlogSessions = "anarlog_sessions"
 	InteractionSourcePhoneCalls      = "phone_calls"
 	InteractionSourceEmail           = "email"
+	InteractionSourceGChat           = "gchat"
 )
 
 // Interaction direction constants

--- a/backend/internal/telegram/aggregation.go
+++ b/backend/internal/telegram/aggregation.go
@@ -199,7 +199,10 @@ func (a *telegramMessageStoreAdapter) ListUnprocessedByContactAndChat(ctx contex
 	return out, nil
 }
 
-func (a *telegramMessageStoreAdapter) GetMessageByReplyTarget(ctx context.Context, chatID, replyTargetID string) (aggregation.Message, bool, error) {
+// GetMessageByReplyTarget ignores contactID: telegram_message rows are keyed
+// by a globally-unique (chat_id, message_id), so the lookup is already
+// contact-correct (one row per message, not per matched contact).
+func (a *telegramMessageStoreAdapter) GetMessageByReplyTarget(ctx context.Context, _ uuid.UUID, chatID, replyTargetID string) (aggregation.Message, bool, error) {
 	parsedChat, err := strconv.ParseInt(chatID, 10, 64)
 	if err != nil {
 		log.Warn().Err(err).Str("chat_id", chatID).Msg("telegram: reply-target chat_id is not int64-parseable; treating as not-found")

--- a/backend/migrations/061_interaction_source_gchat.down.sql
+++ b/backend/migrations/061_interaction_source_gchat.down.sql
@@ -1,0 +1,15 @@
+-- Down migration is destructive if rows exist. Refuse to revert the CHECK if
+-- any gchat-source interactions remain — the constraint would fail anyway;
+-- raise early for a clear error.
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM interaction WHERE source = 'gchat') THEN
+        RAISE EXCEPTION 'cannot revert interaction.source check: % rows still use gchat',
+            (SELECT count(*) FROM interaction WHERE source = 'gchat');
+    END IF;
+END $$;
+ALTER TABLE interaction DROP CONSTRAINT interaction_source_check;
+ALTER TABLE interaction ADD CONSTRAINT interaction_source_check
+    CHECK (source IN ('manual', 'gcal', 'todoist', 'telegram', 'messages', 'anarlog_sessions', 'phone_calls', 'email'));
+
+COMMENT ON COLUMN comms_message.thread_id IS 'email: Gmail threadId';

--- a/backend/migrations/061_interaction_source_gchat.up.sql
+++ b/backend/migrations/061_interaction_source_gchat.up.sql
@@ -1,0 +1,13 @@
+-- 061_interaction_source_gchat.up.sql
+-- Add 'gchat' to interaction.source. See spec §6.1 (NOT migration-only: also
+-- adds InteractionSourceGChat constant + updates the source-check test).
+-- Also broadens the comms_message.thread_id column comment to document that
+-- chat sources reuse it as the space/chat scope resource name (spec §6.2).
+-- Existing set (after 059_interaction_source_email): manual, gcal, todoist,
+-- telegram, messages, anarlog_sessions, phone_calls, email.
+ALTER TABLE interaction DROP CONSTRAINT interaction_source_check;
+ALTER TABLE interaction ADD CONSTRAINT interaction_source_check
+    CHECK (source IN ('manual', 'gcal', 'todoist', 'telegram', 'messages', 'anarlog_sessions', 'phone_calls', 'email', 'gchat'));
+
+COMMENT ON COLUMN comms_message.thread_id IS
+    'email: Gmail threadId; gchat/telegram/messages: space/chat scope resource name';

--- a/backend/tests/comms_gchat_engine_test.go
+++ b/backend/tests/comms_gchat_engine_test.go
@@ -1,0 +1,433 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/consumer"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/google"
+	"personal-crm/backend/internal/messaging/aggregation"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+
+	"github.com/google/uuid"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// gchatTestEnv bundles everything a GChat engine integration test needs.
+type gchatTestEnv struct {
+	ctx             context.Context
+	database        *db.Database
+	commsRepo       *repository.CommsMessageRepository
+	interactionRepo *repository.InteractionRepository
+	contactRepo     *repository.ContactRepository
+	engine          *aggregation.Engine
+}
+
+// setupGChatEngineTest wires the FULL create-path harness: a live river client
+// with the InteractionRecorder worker, a StagingProcessorRegistry containing
+// the gchat session-scoped processor (decision 8b), and a GChat aggregation
+// engine constructed with database.Pool as TxBeginner so the create path takes
+// the ClaimRowsTx + PublishTx branch (NOT the non-tx fallback). This is the
+// regression guard for the gchat StagingProcessor registry seam: without the
+// gchat entry the recorder's zero-rows-affected rollback fires and no
+// interaction is ever recorded.
+func setupGChatEngineTest(t *testing.T) *gchatTestEnv {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set")
+	}
+
+	ctx := context.Background()
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	t.Cleanup(database.Close)
+
+	commsRepo := repository.NewCommsMessageRepository(database.Queries)
+	interactionRepo := repository.NewInteractionRepository(database.Queries)
+	contactRepo := repository.NewContactRepository(database.Queries)
+	contactMethodRepo := repository.NewContactMethodRepository(database.Queries)
+	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
+	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, nil, nil)
+
+	bus := setupGChatEventBus(t, ctx, database, contactService, commsRepo)
+
+	engine := google.NewGChatAggregationEngine(
+		2, 48, // burst window 2h, reply bridge 48h
+		commsRepo, interactionRepo,
+		contactService, contactService,
+		bus,
+		database.Pool, // TxBeginner: create path takes ClaimRowsTx + PublishTx
+		consumer.NewRiverInteractionRecorderEnqueuer(nil), // enqueuer unused in these tests
+	)
+
+	return &gchatTestEnv{
+		ctx:             ctx,
+		database:        database,
+		commsRepo:       commsRepo,
+		interactionRepo: interactionRepo,
+		contactRepo:     contactRepo,
+		engine:          engine,
+	}
+}
+
+// setupGChatEventBus mirrors setupTestEventBus but registers the gchat
+// session-scoped StagingProcessor so the InteractionRecorder consumer can mark
+// comms_message(source='gchat') rows processed in the create-path tx.
+func setupGChatEventBus(
+	t *testing.T,
+	ctx context.Context,
+	database *db.Database,
+	contactService *service.ContactService,
+	commsRepo *repository.CommsMessageRepository,
+) *events.Bus {
+	t.Helper()
+
+	eventRepo := repository.NewEventRepository(database.Queries)
+	cfg := config.TestConfig()
+	if cfg.River.WorkerConcurrency <= 0 {
+		cfg.River.WorkerConcurrency = 4
+	}
+
+	workers := river.NewWorkers()
+	shim := &deferredRecorderWorker{}
+	river.AddWorker(workers, shim)
+	river.AddWorker(workers, &cadenceUpdaterNoopWorker{})
+	river.AddWorker(workers, &followUpManagerNoopWorker{})
+	river.AddWorker(workers, &emailInteractionNoopWorker{})
+
+	client, err := river.NewClient(riverpgxv5.New(database.Pool), &river.Config{
+		Queues: map[string]river.QueueConfig{
+			river.QueueDefault: {MaxWorkers: cfg.River.WorkerConcurrency},
+		},
+		Workers:  workers,
+		TestOnly: true,
+	})
+	require.NoError(t, err)
+
+	bus := events.NewBus(database.Pool, client, eventRepo)
+	contactRepo := repository.NewContactRepository(database.Queries)
+	contactRepo.SetPool(database.Pool)
+	claimRepo := repository.NewEventConsumerClaimRepository(database.Queries)
+	cadenceUpdater := consumer.NewCadenceUpdater(
+		claimRepo, contactRepo, database.Queries,
+		consumer.CadenceModeCutover,
+		false,
+	)
+	contactService.SetCadenceUpdater(cadenceUpdater)
+	// The gchat session-scoped processor is the load-bearing decision-8b entry.
+	stagingRegistry := repository.NewStagingProcessorRegistry(map[string]repository.StagingProcessor{
+		repository.InteractionSourceGChat: repository.NewCommsSessionStagingProcessor(commsRepo),
+	})
+	recorder := consumer.NewInteractionRecorder(contactService, stagingRegistry, bus, cadenceUpdater, nil, repository.NewCalendarEventRepository(database.Queries))
+	shim.real = consumer.NewInteractionRecorderWorker(bus, database.Pool, recorder, nil)
+
+	require.NoError(t, client.Start(ctx))
+	t.Cleanup(func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer stopCancel()
+		_ = client.Stop(stopCtx)
+	})
+
+	return bus
+}
+
+// newGChatContact creates a contact and registers hard-delete cleanup for its
+// comms_message rows + interactions, then soft-deletes the contact.
+func (e *gchatTestEnv) newGChatContact(t *testing.T, name string) *repository.Contact {
+	t.Helper()
+	contact, err := e.contactRepo.CreateContact(e.ctx, repository.CreateContactRequest{FullName: name})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = e.commsRepo.HardDeleteByContact(e.ctx, contact.ID)
+		_ = e.interactionRepo.HardDeleteInteractionsBySourceRefPrefix(e.ctx, repository.InteractionSourceGChat, "gchat:%")
+		_ = e.contactRepo.SoftDeleteContact(e.ctx, contact.ID)
+	})
+	return contact
+}
+
+// seedGChatRow inserts one comms_message(source='gchat') row.
+func (e *gchatTestEnv) seedGChatRow(t *testing.T, contactID uuid.UUID, space, externalID, direction string, sentAt time.Time) *repository.CommsMessage {
+	t.Helper()
+	return upsertGChatRow(t, e.ctx, e.commsRepo, contactID, space, externalID, direction, sentAt)
+}
+
+// waitForGChatRowsProcessed polls each row via GetByID until all carry
+// processed_at + the expected interaction_id (or fails on timeout). Routes
+// through the repository (no raw SQL), satisfying the test-determinism rule.
+func waitForGChatRowsProcessed(t *testing.T, e *gchatTestEnv, ids []uuid.UUID, interactionID uuid.UUID) {
+	t.Helper()
+	deadline := accelerated.GetCurrentTime().Add(defaultInteractionWaitTimeout)
+	for accelerated.GetCurrentTime().Before(deadline) {
+		all := true
+		for _, id := range ids {
+			row, err := e.commsRepo.GetByID(e.ctx, id)
+			require.NoError(t, err)
+			if row.ProcessedAt == nil || row.InteractionID == nil || *row.InteractionID != interactionID {
+				all = false
+				break
+			}
+		}
+		if all {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d gchat rows to be processed + linked to interaction %s", len(ids), interactionID)
+}
+
+// softDeleteCommsRow soft-deletes a comms row via the repository helper.
+func softDeleteCommsRow(e *gchatTestEnv, id uuid.UUID) error {
+	return e.commsRepo.SoftDeleteByID(e.ctx, id)
+}
+
+// TestGChatEngine_BurstCreatePath validates the full create-path wiring
+// (decision 8b): 3 same-direction gchat rows within 2h for one contact+space
+// produce ONE interaction with the burst description, and all 3 rows get
+// processed_at + interaction_id set. This test FAILS OUTRIGHT if the gchat
+// StagingProcessor entry is missing (recorder's zero-rows rollback fires).
+func TestGChatEngine_BurstCreatePath(t *testing.T) {
+	e := setupGChatEngineTest(t)
+	suffix := randomSuffix(t)
+
+	contact := e.newGChatContact(t, "GChat Burst "+suffix)
+	space := "spaces/BURST-" + suffix
+	base := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Microsecond)
+
+	r1 := e.seedGChatRow(t, contact.ID, space, "gchat-burst1-"+suffix, repository.InteractionDirectionOutbound, base)
+	r2 := e.seedGChatRow(t, contact.ID, space, "gchat-burst2-"+suffix, repository.InteractionDirectionOutbound, base.Add(10*time.Minute))
+	r3 := e.seedGChatRow(t, contact.ID, space, "gchat-burst3-"+suffix, repository.InteractionDirectionOutbound, base.Add(30*time.Minute))
+
+	require.NoError(t, e.engine.AggregateForContact(e.ctx, contact.ID, space))
+
+	// Async: the recorder writes the interaction after the publish.
+	interactions := waitForInteractionCountExact(t, e.ctx, e.interactionRepo, contact.ID, 1, defaultInteractionWaitTimeout)
+	require.Len(t, interactions, 1)
+	assert.Equal(t, repository.InteractionSourceGChat, interactions[0].Source)
+	assert.Equal(t, repository.InteractionDirectionOutbound, interactions[0].Direction)
+	require.NotNil(t, interactions[0].Description)
+	assert.Equal(t, "GChat outreach (3 messages)", *interactions[0].Description)
+
+	// All 3 rows marked processed + linked (proves the StagingProcessor seam).
+	waitForGChatRowsProcessed(t, e, []uuid.UUID{r1.ID, r2.ID, r3.ID}, interactions[0].ID)
+}
+
+// TestGChatEngine_ReplyBridgeToMutual seeds an outbound burst then an inbound
+// row within 48h; the outbound interaction is promoted to mutual (time-window
+// bridge). A second case: inbound after 48h stays a separate interaction.
+func TestGChatEngine_ReplyBridgeToMutual(t *testing.T) {
+	e := setupGChatEngineTest(t)
+	suffix := randomSuffix(t)
+
+	t.Run("inbound within 48h promotes to mutual", func(t *testing.T) {
+		contact := e.newGChatContact(t, "GChat Bridge "+suffix)
+		space := "spaces/BRIDGE-" + suffix
+		base := accelerated.GetCurrentTime().Add(-2 * time.Hour).Truncate(time.Microsecond)
+
+		e.seedGChatRow(t, contact.ID, space, "gchat-br-out1-"+suffix, repository.InteractionDirectionOutbound, base)
+		e.seedGChatRow(t, contact.ID, space, "gchat-br-out2-"+suffix, repository.InteractionDirectionOutbound, base.Add(5*time.Minute))
+		e.seedGChatRow(t, contact.ID, space, "gchat-br-in1-"+suffix, repository.InteractionDirectionInbound, base.Add(1*time.Hour))
+
+		require.NoError(t, e.engine.AggregateForContact(e.ctx, contact.ID, space))
+
+		rows := waitForInteractionDirection(t, e.ctx, e.interactionRepo, contact.ID, repository.InteractionDirectionMutual, defaultInteractionWaitTimeout)
+		// Exactly one interaction, promoted to mutual.
+		require.Len(t, rows, 1)
+		assert.Equal(t, repository.InteractionDirectionMutual, rows[0].Direction)
+	})
+}
+
+// TestGChatEngine_EditNoOp proves the processed_at IS NULL filter protects an
+// edited row: after a row is aggregated (processed_at set), updating its body
+// (simulating an edit) WITHOUT clearing processed_at does not create a new
+// interaction on re-aggregate.
+func TestGChatEngine_EditNoOp(t *testing.T) {
+	e := setupGChatEngineTest(t)
+	suffix := randomSuffix(t)
+
+	contact := e.newGChatContact(t, "GChat Edit "+suffix)
+	space := "spaces/EDIT-" + suffix
+	base := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Microsecond)
+
+	row := e.seedGChatRow(t, contact.ID, space, "gchat-edit1-"+suffix, repository.InteractionDirectionInbound, base)
+	require.NoError(t, e.engine.AggregateForContact(e.ctx, contact.ID, space))
+	interactions := waitForInteractionCountExact(t, e.ctx, e.interactionRepo, contact.ID, 1, defaultInteractionWaitTimeout)
+	require.Len(t, interactions, 1)
+
+	// Confirm the row is now processed.
+	waitForGChatRowsProcessed(t, e, []uuid.UUID{row.ID}, interactions[0].ID)
+
+	// Re-aggregate: the processed row is invisible → still exactly one interaction.
+	require.NoError(t, e.engine.AggregateForContact(e.ctx, contact.ID, space))
+	time.Sleep(500 * time.Millisecond) // settle any (unexpected) async write
+	count, err := e.interactionRepo.CountContactInteractions(e.ctx, contact.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count, "edited (already-processed) row must not create a second interaction")
+}
+
+// TestGChatEngine_DeleteNoOp proves the deleted_at IS NULL filter drops a
+// soft-deleted row: an unprocessed row that is soft-deleted before aggregation
+// produces no interaction.
+func TestGChatEngine_DeleteNoOp(t *testing.T) {
+	e := setupGChatEngineTest(t)
+	suffix := randomSuffix(t)
+
+	contact := e.newGChatContact(t, "GChat Delete "+suffix)
+	space := "spaces/DELETE-" + suffix
+	base := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Microsecond)
+
+	row := e.seedGChatRow(t, contact.ID, space, "gchat-del1-"+suffix, repository.InteractionDirectionInbound, base)
+	// Soft-delete the row before aggregation.
+	require.NoError(t, softDeleteCommsRow(e, row.ID))
+
+	require.NoError(t, e.engine.AggregateForContact(e.ctx, contact.ID, space))
+	time.Sleep(500 * time.Millisecond)
+	count, err := e.interactionRepo.CountContactInteractions(e.ctx, contact.ID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count, "soft-deleted row must not produce an interaction")
+}
+
+// TestGChatEngine_ClaimRaceRecovery claims a row for a session, backdates the
+// claim past the 5-min TTL, then a fresh aggregate pass re-claims and processes
+// it. Also verifies ClearStaleClaimTx clears a matching-ref claim and leaves a
+// different-ref claim untouched.
+func TestGChatEngine_ClaimRaceRecovery(t *testing.T) {
+	e := setupGChatEngineTest(t)
+	suffix := randomSuffix(t)
+
+	contact := e.newGChatContact(t, "GChat Claim "+suffix)
+	space := "spaces/CLAIM-" + suffix
+	base := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Microsecond)
+
+	row := e.seedGChatRow(t, contact.ID, space, "gchat-claim1-"+suffix, repository.InteractionDirectionInbound, base)
+
+	// Claim the row for a stale session, then backdate the claim past TTL.
+	tx, err := e.database.Pool.Begin(e.ctx)
+	require.NoError(t, err)
+	claimed, err := e.commsRepo.ClaimMessagesTx(e.ctx, tx, []uuid.UUID{row.ID}, "gchat:"+space+":stale")
+	require.NoError(t, err)
+	require.Equal(t, []uuid.UUID{row.ID}, claimed)
+	require.NoError(t, tx.Commit(e.ctx))
+	require.NoError(t, e.commsRepo.BackdateClaim(e.ctx, []uuid.UUID{row.ID}))
+
+	// A fresh aggregate pass re-claims the stale row and processes it.
+	require.NoError(t, e.engine.AggregateForContact(e.ctx, contact.ID, space))
+	interactions := waitForInteractionCountExact(t, e.ctx, e.interactionRepo, contact.ID, 1, defaultInteractionWaitTimeout)
+	require.Len(t, interactions, 1)
+	waitForGChatRowsProcessed(t, e, []uuid.UUID{row.ID}, interactions[0].ID)
+}
+
+// TestGChatEngine_ClearStaleClaimTx is a focused repo-level check of the
+// stale-claim clearing predicate: a matching expected-ref claim is cleared; a
+// different-ref claim is left untouched.
+func TestGChatEngine_ClearStaleClaimTx(t *testing.T) {
+	e := setupGChatEngineTest(t)
+	suffix := randomSuffix(t)
+
+	contact := e.newGChatContact(t, "GChat ClearClaim "+suffix)
+	space := "spaces/CLEAR-" + suffix
+	base := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Microsecond)
+
+	row := e.seedGChatRow(t, contact.ID, space, "gchat-clear1-"+suffix, repository.InteractionDirectionInbound, base)
+	ref := "gchat:" + space + ":ref"
+
+	tx, err := e.database.Pool.Begin(e.ctx)
+	require.NoError(t, err)
+	_, err = e.commsRepo.ClaimMessagesTx(e.ctx, tx, []uuid.UUID{row.ID}, ref)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit(e.ctx))
+
+	// Clearing with a DIFFERENT expected ref leaves the claim intact.
+	tx2, err := e.database.Pool.Begin(e.ctx)
+	require.NoError(t, err)
+	require.NoError(t, e.commsRepo.ClearStaleClaimTx(e.ctx, tx2, []uuid.UUID{row.ID}, "gchat:"+space+":OTHER"))
+	require.NoError(t, tx2.Commit(e.ctx))
+	got, err := e.commsRepo.GetByID(e.ctx, row.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.ClaimedSessionRef, "different-ref clear must NOT clear the claim")
+
+	// Clearing with the MATCHING ref clears it.
+	tx3, err := e.database.Pool.Begin(e.ctx)
+	require.NoError(t, err)
+	require.NoError(t, e.commsRepo.ClearStaleClaimTx(e.ctx, tx3, []uuid.UUID{row.ID}, ref))
+	require.NoError(t, tx3.Commit(e.ctx))
+	got, err = e.commsRepo.GetByID(e.ctx, row.ID)
+	require.NoError(t, err)
+	assert.Nil(t, got.ClaimedSessionRef, "matching-ref clear must clear the claim")
+	assert.Nil(t, got.ClaimedAt)
+}
+
+// TestGChatEngine_MarkProcessedForSessionBoundaryShift is the direct repo-level
+// guard for decision 8b's session predicate: a row claimed for a MATCHING
+// session ref is marked processed; a DIFFERENT session ref is rejected (zero
+// rows affected — the recorder's rollback trigger).
+func TestGChatEngine_MarkProcessedForSessionBoundaryShift(t *testing.T) {
+	e := setupGChatEngineTest(t)
+	suffix := randomSuffix(t)
+
+	contact := e.newGChatContact(t, "GChat Session "+suffix)
+	space := "spaces/SESSION-" + suffix
+	base := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Microsecond)
+	row := e.seedGChatRow(t, contact.ID, space, "gchat-session1-"+suffix, repository.InteractionDirectionInbound, base)
+
+	sessionRef := "gchat:" + space + ":session"
+	// comms_message.interaction_id is a real FK — create an actual interaction
+	// row so MarkProcessedForSessionTx can link to it without a 23503.
+	ref := sessionRef
+	interaction, err := e.interactionRepo.CreateInteraction(e.ctx, repository.CreateInteractionRequest{
+		ContactID:  contact.ID,
+		Source:     repository.InteractionSourceGChat,
+		SourceRef:  &ref,
+		OccurredAt: base,
+		Direction:  repository.InteractionDirectionInbound,
+	})
+	require.NoError(t, err)
+	interactionID := interaction.ID
+
+	// Claim the row for sessionRef.
+	tx, err := e.database.Pool.Begin(e.ctx)
+	require.NoError(t, err)
+	claimed, err := e.commsRepo.ClaimMessagesTx(e.ctx, tx, []uuid.UUID{row.ID}, sessionRef)
+	require.NoError(t, err)
+	require.Equal(t, []uuid.UUID{row.ID}, claimed)
+	require.NoError(t, tx.Commit(e.ctx))
+
+	// A different session ref must NOT mark it processed (boundary-shift reject).
+	tx2, err := e.database.Pool.Begin(e.ctx)
+	require.NoError(t, err)
+	affected, err := e.commsRepo.MarkProcessedForSessionTx(e.ctx, tx2, []uuid.UUID{row.ID}, interactionID, "gchat:"+space+":OTHER")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), affected, "wrong session ref must affect zero rows")
+	require.NoError(t, tx2.Rollback(e.ctx))
+
+	// The matching session ref marks it processed + clears the claim.
+	tx3, err := e.database.Pool.Begin(e.ctx)
+	require.NoError(t, err)
+	affected, err = e.commsRepo.MarkProcessedForSessionTx(e.ctx, tx3, []uuid.UUID{row.ID}, interactionID, sessionRef)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), affected, "matching session ref must mark the row processed")
+	require.NoError(t, tx3.Commit(e.ctx))
+
+	updated, err := e.commsRepo.GetByID(e.ctx, row.ID)
+	require.NoError(t, err)
+	require.NotNil(t, updated.ProcessedAt)
+	require.NotNil(t, updated.InteractionID)
+	assert.Equal(t, interactionID, *updated.InteractionID)
+	assert.Nil(t, updated.ClaimedAt)
+	assert.Nil(t, updated.ClaimedSessionRef)
+}

--- a/backend/tests/comms_gchat_engine_test.go
+++ b/backend/tests/comms_gchat_engine_test.go
@@ -250,6 +250,33 @@ func TestGChatEngine_ReplyBridgeToMutual(t *testing.T) {
 		require.Len(t, rows, 1)
 		assert.Equal(t, repository.InteractionDirectionMutual, rows[0].Direction)
 	})
+
+	t.Run("inbound after 48h stays two separate interactions", func(t *testing.T) {
+		contact := e.newGChatContact(t, "GChat NoBridge "+suffix)
+		space := "spaces/NOBRIDGE-" + suffix
+		// Outbound burst far in the past; inbound > 48h later, outside the
+		// time-window bridge (48h), so the outbound is NOT promoted.
+		base := accelerated.GetCurrentTime().Add(-100 * time.Hour).Truncate(time.Microsecond)
+
+		e.seedGChatRow(t, contact.ID, space, "gchat-nb-out1-"+suffix, repository.InteractionDirectionOutbound, base)
+		e.seedGChatRow(t, contact.ID, space, "gchat-nb-out2-"+suffix, repository.InteractionDirectionOutbound, base.Add(5*time.Minute))
+		e.seedGChatRow(t, contact.ID, space, "gchat-nb-in1-"+suffix, repository.InteractionDirectionInbound, base.Add(60*time.Hour))
+
+		require.NoError(t, e.engine.AggregateForContact(e.ctx, contact.ID, space))
+
+		// Two separate interactions: one outbound (the burst) + one inbound
+		// (the late reply). Neither is mutual.
+		rows := waitForInteractionCountExact(t, e.ctx, e.interactionRepo, contact.ID, 2, defaultInteractionWaitTimeout)
+		require.Len(t, rows, 2)
+		dirs := map[string]int{}
+		for _, r := range rows {
+			assert.NotEqual(t, repository.InteractionDirectionMutual, r.Direction,
+				"a reply outside the 48h window must NOT promote to mutual")
+			dirs[r.Direction]++
+		}
+		assert.Equal(t, 1, dirs[repository.InteractionDirectionOutbound], "one outbound interaction")
+		assert.Equal(t, 1, dirs[repository.InteractionDirectionInbound], "one inbound interaction")
+	})
 }
 
 // TestGChatEngine_EditNoOp proves the processed_at IS NULL filter protects an

--- a/backend/tests/comms_gchat_engine_test.go
+++ b/backend/tests/comms_gchat_engine_test.go
@@ -35,9 +35,9 @@ type gchatTestEnv struct {
 
 // setupGChatEngineTest wires the FULL create-path harness: a live river client
 // with the InteractionRecorder worker, a StagingProcessorRegistry containing
-// the gchat session-scoped processor (decision 8b), and a GChat aggregation
-// engine constructed with database.Pool as TxBeginner so the create path takes
-// the ClaimRowsTx + PublishTx branch (NOT the non-tx fallback). This is the
+// the gchat session-scoped processor, and a GChat aggregation engine
+// constructed with database.Pool as TxBeginner so the create path takes the
+// ClaimRowsTx + PublishTx branch (NOT the non-tx fallback). This is the
 // regression guard for the gchat StagingProcessor registry seam: without the
 // gchat entry the recorder's zero-rows-affected rollback fires and no
 // interaction is ever recorded.
@@ -196,11 +196,11 @@ func softDeleteCommsRow(e *gchatTestEnv, id uuid.UUID) error {
 	return e.commsRepo.SoftDeleteByID(e.ctx, id)
 }
 
-// TestGChatEngine_BurstCreatePath validates the full create-path wiring
-// (decision 8b): 3 same-direction gchat rows within 2h for one contact+space
-// produce ONE interaction with the burst description, and all 3 rows get
-// processed_at + interaction_id set. This test FAILS OUTRIGHT if the gchat
-// StagingProcessor entry is missing (recorder's zero-rows rollback fires).
+// TestGChatEngine_BurstCreatePath validates the full create-path wiring:
+// 3 same-direction gchat rows within 2h for one contact+space produce ONE
+// interaction with the burst description, and all 3 rows get processed_at +
+// interaction_id set. This test FAILS OUTRIGHT if the gchat StagingProcessor
+// entry is missing (recorder's zero-rows rollback fires).
 func TestGChatEngine_BurstCreatePath(t *testing.T) {
 	e := setupGChatEngineTest(t)
 	suffix := randomSuffix(t)
@@ -373,8 +373,8 @@ func TestGChatEngine_ClearStaleClaimTx(t *testing.T) {
 }
 
 // TestGChatEngine_MarkProcessedForSessionBoundaryShift is the direct repo-level
-// guard for decision 8b's session predicate: a row claimed for a MATCHING
-// session ref is marked processed; a DIFFERENT session ref is rejected (zero
+// guard for the session-scoped mark-processed predicate: a row claimed for a
+// MATCHING session ref is marked processed; a DIFFERENT session ref is rejected (zero
 // rows affected — the recorder's rollback trigger).
 func TestGChatEngine_MarkProcessedForSessionBoundaryShift(t *testing.T) {
 	e := setupGChatEngineTest(t)

--- a/backend/tests/comms_gchat_identity_test.go
+++ b/backend/tests/comms_gchat_identity_test.go
@@ -1,0 +1,116 @@
+package tests
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedContactWithMethod creates a contact + one contact_method of the given
+// type, registering cleanup (hard-delete comms rows, delete methods,
+// soft-delete contact). Returns the contact.
+func seedContactWithMethod(t *testing.T, ctx context.Context, commsRepo *repository.CommsMessageRepository, contactRepo *repository.ContactRepository, methodRepo *repository.ContactMethodRepository, name, methodType, value string) *repository.Contact {
+	t.Helper()
+	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: name})
+	require.NoError(t, err)
+	_, err = methodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
+		ContactID: contact.ID,
+		Type:      methodType,
+		Value:     value,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = commsRepo.HardDeleteByContact(ctx, contact.ID)
+		_ = methodRepo.DeleteContactMethodsByContact(ctx, contact.ID)
+		_ = contactRepo.SoftDeleteContact(ctx, contact.ID)
+	})
+	return contact
+}
+
+// TestListGChatIdentitiesForSync_DualSource verifies the dual-source identity
+// map: gchat AND email methods are both returned with the correct source_type
+// discriminator; a contact with BOTH method types yields two rows; a shared
+// address fans out to multiple contacts; soft-deleted contacts and
+// empty-normalized values are excluded; values are already lowercased.
+func TestListGChatIdentitiesForSync_DualSource(t *testing.T) {
+	ctx, commsRepo, contactRepo, methodRepo := setupCommsMessageTest(t)
+	suffix := randomSuffix(t)
+
+	// Unique per-suffix addresses so this sub-test's pool is isolated on the
+	// shared DB. value_normalized lowercases, so seed with mixed case to also
+	// prove case-insensitivity is inherited from the trigger.
+	gchatOnlyAddr := "GChatOnly-" + suffix + "@Example.com"
+	emailOnlyAddr := "EmailOnly-" + suffix + "@Example.com"
+	bothAddr := "Both-" + suffix + "@Example.com"
+	sharedAddr := "Shared-" + suffix + "@Example.com"
+
+	gchatOnly := seedContactWithMethod(t, ctx, commsRepo, contactRepo, methodRepo,
+		"GChat Only "+suffix, "gchat", gchatOnlyAddr)
+	emailOnly := seedContactWithMethod(t, ctx, commsRepo, contactRepo, methodRepo,
+		"Email Only "+suffix, "email", emailOnlyAddr)
+
+	// Contact with BOTH a gchat and an email method (same address).
+	both, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: "Both Methods " + suffix})
+	require.NoError(t, err)
+	_, err = methodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{ContactID: both.ID, Type: "gchat", Value: bothAddr})
+	require.NoError(t, err)
+	_, err = methodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{ContactID: both.ID, Type: "email", Value: bothAddr})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = commsRepo.HardDeleteByContact(ctx, both.ID)
+		_ = methodRepo.DeleteContactMethodsByContact(ctx, both.ID)
+		_ = contactRepo.SoftDeleteContact(ctx, both.ID)
+	})
+
+	// Two contacts sharing the SAME gchat address (fan-out).
+	shareA := seedContactWithMethod(t, ctx, commsRepo, contactRepo, methodRepo,
+		"Share A "+suffix, "gchat", sharedAddr)
+	shareB := seedContactWithMethod(t, ctx, commsRepo, contactRepo, methodRepo,
+		"Share B "+suffix, "gchat", sharedAddr)
+
+	// A soft-deleted contact with a gchat method MUST be excluded.
+	deleted := seedContactWithMethod(t, ctx, commsRepo, contactRepo, methodRepo,
+		"Deleted "+suffix, "gchat", "Deleted-"+suffix+"@Example.com")
+	require.NoError(t, contactRepo.SoftDeleteContact(ctx, deleted.ID))
+
+	rows, err := commsRepo.ListGChatIdentitiesForSync(ctx)
+	require.NoError(t, err)
+
+	// Index rows by (normalized address, contact, source_type) for assertions.
+	type key struct {
+		addr    string
+		contact uuid.UUID
+		st      string
+	}
+	got := make(map[key]bool)
+	for _, r := range rows {
+		got[key{r.ValueNormalized, r.ContactID, r.SourceType}] = true
+		// All addresses must be already-lowercased by the trigger.
+		assert.Equal(t, strings.ToLower(r.ValueNormalized), r.ValueNormalized,
+			"value_normalized must already be lowercased")
+	}
+
+	assert.True(t, got[key{strings.ToLower(gchatOnlyAddr), gchatOnly.ID, "gchat"}],
+		"gchat-only contact's gchat row missing")
+	assert.True(t, got[key{strings.ToLower(emailOnlyAddr), emailOnly.ID, "email"}],
+		"email-only contact's email row missing")
+	// Both-methods contact yields one gchat row AND one email row.
+	assert.True(t, got[key{strings.ToLower(bothAddr), both.ID, "gchat"}],
+		"both-methods contact's gchat row missing")
+	assert.True(t, got[key{strings.ToLower(bothAddr), both.ID, "email"}],
+		"both-methods contact's email row missing")
+	// Shared address fans out to both contacts.
+	assert.True(t, got[key{strings.ToLower(sharedAddr), shareA.ID, "gchat"}],
+		"shared-address fan-out to contact A missing")
+	assert.True(t, got[key{strings.ToLower(sharedAddr), shareB.ID, "gchat"}],
+		"shared-address fan-out to contact B missing")
+	// Soft-deleted contact excluded.
+	assert.False(t, got[key{strings.ToLower("Deleted-" + suffix + "@Example.com"), deleted.ID, "gchat"}],
+		"soft-deleted contact must be excluded")
+}

--- a/backend/tests/comms_gchat_query_test.go
+++ b/backend/tests/comms_gchat_query_test.go
@@ -1,0 +1,115 @@
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// upsertGChatRow seeds one comms_message(source='gchat') row for a contact in a
+// space. Direction defaults to inbound. Returns the persisted row.
+func upsertGChatRow(t *testing.T, ctx context.Context, commsRepo *repository.CommsMessageRepository, contactID uuid.UUID, space, externalID, direction string, sentAt time.Time) *repository.CommsMessage {
+	t.Helper()
+	thread := space
+	body := "gchat body"
+	msg, err := commsRepo.UpsertMessage(ctx, repository.UpsertCommsMessageParams{
+		Source:           repository.InteractionSourceGChat,
+		ExternalID:       externalID,
+		ThreadID:         &thread,
+		Body:             &body,
+		Direction:        direction,
+		SentAt:           sentAt,
+		MatchedContactID: contactID,
+	})
+	require.NoError(t, err)
+	return msg
+}
+
+// TestCommsSourceParameterizedQueries_IsolateSources proves the @source filter
+// isolates rows on the shared comms_message table: gchat-source readers see
+// only gchat rows (email rows are invisible) and vice-versa.
+func TestCommsSourceParameterizedQueries_IsolateSources(t *testing.T) {
+	ctx, commsRepo, contactRepo, _ := setupCommsMessageTest(t)
+	suffix := randomSuffix(t)
+
+	contact := newEmailContact(t, ctx, commsRepo, contactRepo, "Source Isolation "+suffix)
+	base := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Microsecond)
+
+	// One gchat row + one email row for the SAME contact.
+	gchatRow := upsertGChatRow(t, ctx, commsRepo, contact.ID,
+		"spaces/ISO-"+suffix, "gchat-iso-"+suffix, repository.InteractionDirectionInbound, base)
+
+	emailThread := "thread-iso-" + suffix
+	emailBody := "email body"
+	_, err := commsRepo.UpsertMessage(ctx, repository.UpsertCommsMessageParams{
+		Source:           repository.InteractionSourceEmail,
+		ExternalID:       "email-iso-" + suffix,
+		ThreadID:         &emailThread,
+		Body:             &emailBody,
+		Direction:        repository.InteractionDirectionInbound,
+		SentAt:           base,
+		MatchedContactID: contact.ID,
+	})
+	require.NoError(t, err)
+
+	// gchat readers see only the gchat row.
+	gchatRows, err := commsRepo.ListUnprocessedByContactForSource(ctx, repository.InteractionSourceGChat, contact.ID)
+	require.NoError(t, err)
+	require.Len(t, gchatRows, 1, "gchat reader must see exactly the one gchat row")
+	assert.Equal(t, gchatRow.ID, gchatRows[0].ID)
+
+	// email readers see only the email row.
+	emailRows, err := commsRepo.ListUnprocessedByContactForSource(ctx, repository.InteractionSourceEmail, contact.ID)
+	require.NoError(t, err)
+	require.Len(t, emailRows, 1, "email reader must see exactly the one email row")
+	assert.NotEqual(t, gchatRow.ID, emailRows[0].ID)
+
+	// Contact-ID listers are likewise source-scoped.
+	gchatContacts, err := commsRepo.ListUnprocessedContactIDsForSource(ctx, repository.InteractionSourceGChat)
+	require.NoError(t, err)
+	assert.Contains(t, gchatContacts, contact.ID)
+
+	// Chat-lister returns the space for the gchat source only.
+	chats, err := commsRepo.ListUnprocessedChatsByContactForSource(ctx, repository.InteractionSourceGChat, contact.ID)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"spaces/ISO-" + suffix}, chats)
+}
+
+// TestGetMessageByReplyTargetForSource verifies the reply-target getter:
+// resolves a row by its own external_id within the (source, space) scope,
+// returns db.ErrNotFound for a missing target, and is space-scoped (a target
+// in a different space is not found).
+func TestGetMessageByReplyTargetForSource(t *testing.T) {
+	ctx, commsRepo, contactRepo, _ := setupCommsMessageTest(t)
+	suffix := randomSuffix(t)
+
+	contact := newEmailContact(t, ctx, commsRepo, contactRepo, "Reply Target "+suffix)
+	base := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Microsecond)
+
+	spaceA := "spaces/RTA-" + suffix
+	spaceB := "spaces/RTB-" + suffix
+	extID1 := "gchat-rt1-" + suffix
+	row1 := upsertGChatRow(t, ctx, commsRepo, contact.ID, spaceA, extID1, repository.InteractionDirectionInbound, base)
+	_ = upsertGChatRow(t, ctx, commsRepo, contact.ID, spaceA, "gchat-rt2-"+suffix, repository.InteractionDirectionInbound, base.Add(time.Minute))
+
+	// Hit: row1 resolved by its external_id within spaceA.
+	got, err := commsRepo.GetMessageByReplyTargetForSource(ctx, repository.InteractionSourceGChat, spaceA, extID1)
+	require.NoError(t, err)
+	assert.Equal(t, row1.ID, got.ID)
+
+	// Miss: non-existent target.
+	_, err = commsRepo.GetMessageByReplyTargetForSource(ctx, repository.InteractionSourceGChat, spaceA, "no-such-id-"+suffix)
+	assert.ErrorIs(t, err, db.ErrNotFound)
+
+	// Space-scoped: the same external_id looked up in a DIFFERENT space is not found.
+	_, err = commsRepo.GetMessageByReplyTargetForSource(ctx, repository.InteractionSourceGChat, spaceB, extID1)
+	assert.ErrorIs(t, err, db.ErrNotFound)
+}

--- a/backend/tests/comms_gchat_query_test.go
+++ b/backend/tests/comms_gchat_query_test.go
@@ -84,11 +84,13 @@ func TestCommsSourceParameterizedQueries_IsolateSources(t *testing.T) {
 }
 
 // TestGetMessageByReplyTargetForSource verifies the reply-target getter:
-// resolves a row by its own external_id within the (source, space) scope,
-// returns db.ErrNotFound for a missing target, and is space-scoped (a target
-// in a different space is not found).
+// resolves a row by its own external_id within the (source, contact, space)
+// scope, returns db.ErrNotFound for a missing target, is space-scoped (a target
+// in a different space is not found), and is CONTACT-scoped — the same address
+// fanned out to two contacts must resolve to the querying contact's own row,
+// never the other contact's.
 func TestGetMessageByReplyTargetForSource(t *testing.T) {
-	ctx, commsRepo, contactRepo, _ := setupCommsMessageTest(t)
+	ctx, commsRepo, contactRepo, methodRepo := setupCommsMessageTest(t)
 	suffix := randomSuffix(t)
 
 	contact := newEmailContact(t, ctx, commsRepo, contactRepo, "Reply Target "+suffix)
@@ -100,16 +102,34 @@ func TestGetMessageByReplyTargetForSource(t *testing.T) {
 	row1 := upsertGChatRow(t, ctx, commsRepo, contact.ID, spaceA, extID1, repository.InteractionDirectionInbound, base)
 	_ = upsertGChatRow(t, ctx, commsRepo, contact.ID, spaceA, "gchat-rt2-"+suffix, repository.InteractionDirectionInbound, base.Add(time.Minute))
 
-	// Hit: row1 resolved by its external_id within spaceA.
-	got, err := commsRepo.GetMessageByReplyTargetForSource(ctx, repository.InteractionSourceGChat, spaceA, extID1)
+	// Hit: row1 resolved by its external_id within spaceA for this contact.
+	got, err := commsRepo.GetMessageByReplyTargetForSource(ctx, repository.InteractionSourceGChat, contact.ID, spaceA, extID1)
 	require.NoError(t, err)
 	assert.Equal(t, row1.ID, got.ID)
 
 	// Miss: non-existent target.
-	_, err = commsRepo.GetMessageByReplyTargetForSource(ctx, repository.InteractionSourceGChat, spaceA, "no-such-id-"+suffix)
+	_, err = commsRepo.GetMessageByReplyTargetForSource(ctx, repository.InteractionSourceGChat, contact.ID, spaceA, "no-such-id-"+suffix)
 	assert.ErrorIs(t, err, db.ErrNotFound)
 
 	// Space-scoped: the same external_id looked up in a DIFFERENT space is not found.
-	_, err = commsRepo.GetMessageByReplyTargetForSource(ctx, repository.InteractionSourceGChat, spaceB, extID1)
+	_, err = commsRepo.GetMessageByReplyTargetForSource(ctx, repository.InteractionSourceGChat, contact.ID, spaceB, extID1)
 	assert.ErrorIs(t, err, db.ErrNotFound)
+
+	// Contact-scoped (fanout defense): a SECOND contact with the SAME address
+	// gets its own fanned-out row for the SAME (space, external_id). Each
+	// contact's lookup must return its OWN row, never the other's. An unscoped
+	// query would non-deterministically return one of the two and could
+	// cross-link interactions.
+	_ = methodRepo // contact_method not needed; fanout is modeled directly via per-contact rows
+	other := newEmailContact(t, ctx, commsRepo, contactRepo, "Reply Target Other "+suffix)
+	otherRow := upsertGChatRow(t, ctx, commsRepo, other.ID, spaceA, extID1, repository.InteractionDirectionInbound, base)
+
+	gotSelf, err := commsRepo.GetMessageByReplyTargetForSource(ctx, repository.InteractionSourceGChat, contact.ID, spaceA, extID1)
+	require.NoError(t, err)
+	assert.Equal(t, row1.ID, gotSelf.ID, "contact's lookup must return its own row")
+
+	gotOther, err := commsRepo.GetMessageByReplyTargetForSource(ctx, repository.InteractionSourceGChat, other.ID, spaceA, extID1)
+	require.NoError(t, err)
+	assert.Equal(t, otherRow.ID, gotOther.ID, "other contact's lookup must return the other contact's row")
+	assert.NotEqual(t, row1.ID, otherRow.ID, "the two contacts' fanned-out rows are distinct")
 }

--- a/backend/tests/interaction_source_descriptor_check_test.go
+++ b/backend/tests/interaction_source_descriptor_check_test.go
@@ -84,7 +84,7 @@ func TestInteractionSourceCheck_AgreesWithDescriptorAndConstants(t *testing.T) {
 		liveSet[m[1]] = struct{}{}
 	}
 
-	// --- Assert live set == all 8 InteractionSource* constants (both
+	// --- Assert live set == all 9 InteractionSource* constants (both
 	// directions). ---
 	allConstants := []string{
 		repository.InteractionSourceManual,
@@ -95,6 +95,7 @@ func TestInteractionSourceCheck_AgreesWithDescriptorAndConstants(t *testing.T) {
 		repository.InteractionSourceAnarlogSessions,
 		repository.InteractionSourcePhoneCalls,
 		repository.InteractionSourceEmail,
+		repository.InteractionSourceGChat,
 	}
 	constantSet := make(map[string]struct{}, len(allConstants))
 	for _, c := range allConstants {

--- a/backend/tests/interaction_source_gchat_check_test.go
+++ b/backend/tests/interaction_source_gchat_check_test.go
@@ -1,0 +1,65 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInteraction_SourceCheckAcceptsGchat locks in the migration-061 CHECK
+// extension: an interaction with source="gchat" inserts successfully. The
+// migration lifts interaction_source_check from the 8-value email set to also
+// include 'gchat'. The upper-boundary regression (a non-listed source is
+// rejected) is already guarded by TestInteraction_SourceCheckRejectsWhatsapp.
+func TestInteraction_SourceCheckAcceptsGchat(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	defer database.Close()
+
+	interactionRepo := repository.NewInteractionRepository(database.Queries)
+	contactRepo := repository.NewContactRepository(database.Queries)
+
+	suffix := randomSuffix(t)
+	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
+		FullName: "Test GChat Source CHECK " + suffix,
+	})
+	require.NoError(t, err)
+	// Hard-delete any gchat-source rows before closing the DB handle. The
+	// down migration in 061 refuses to drop interaction_source_check while
+	// any row uses source='gchat' (data-loss guard), and the guard counts
+	// rows regardless of deleted_at — so a soft-delete is insufficient.
+	defer func() {
+		_ = interactionRepo.HardDeleteInteractionsBySourceRefPrefix(ctx, repository.InteractionSourceGChat, "gchat-test-%")
+		_ = contactRepo.SoftDeleteContact(ctx, contact.ID)
+	}()
+
+	ref := "gchat-test-" + suffix
+	interaction, err := interactionRepo.CreateInteraction(ctx, repository.CreateInteractionRequest{
+		ContactID:  contact.ID,
+		Source:     repository.InteractionSourceGChat,
+		SourceRef:  &ref,
+		OccurredAt: accelerated.GetCurrentTime().Truncate(time.Microsecond),
+		Direction:  repository.InteractionDirectionInbound,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, repository.InteractionSourceGChat, interaction.Source)
+}


### PR DESCRIPTION
PR 1 of 3 for the Google Chat integration (#337). Backend-only and **INERT by construction**: no `GChatSyncProvider`, no OAuth chat scopes, no enablement row, and no production path writes a `comms_message` row with `source='gchat'`. The engine/worker/sweeper/reenqueuer for `gchat` are wired live in `main.go` but every query is `source='gchat'`-scoped and returns zero rows until PR 2 (provider + OAuth + edit/delete) and PR 3 (registration + enablement + status endpoint + UI) land. The only production-visible change is the additive migration (one CHECK enum value + one `COMMENT ON COLUMN`).

## Scope

- **Migration 061** — adds `'gchat'` to the `interaction.source` CHECK; broadens the `comms_message.thread_id` COMMENT to document chat-source reuse. Additive and reversible (down migration carries the standard data-loss guard).
- **Source constant + identity** — `InteractionSourceGChat`; `IdentifierTypeGChat`/`ContactMethodTypeGChat` (normalize delegates to email, matching the contact_method trigger); the multi-mapping branch is intentionally omitted (the sqlc query below is the single source of truth for the dual-source set).
- **Dual-source identity sync** — `ListGChatIdentitiesForSync` returns `(value_normalized, contact_id, source_type)` over `type IN ('gchat','email')` so a later provider can build a dual-source known-contact map.
- **Source-parameterized `comms_message` substrate** — the `MessageStore`-backing queries (unprocessed listers, claim, session-scoped + non-session mark-processed, reply-target getter) all take a `source` arg; `gchat` is the first source to activate the reserved `claimed_at`/`claimed_session_ref` columns. The reply-target lookup is scoped to `matched_contact_id` (per-contact rows fan out on shared addresses).
- **Aggregation adapters + engine** — `gchatAdapter` + `commsMessageStoreAdapter` + finder/lookup adapters + `NewGChatAggregationEngine` (mirrors the Messages string-chatID adapter pair); plus `CommsAggregatorReenqueuer`.
- **`main.go` wiring** — constructs the engine and registers `gchat` in the staging registry, reenqueuer registry, per-source chat-lister registry, the chat-aware worker engines map, and the sweeper listers map.

## Notable fixes surfaced during implementation

- The InteractionRecorder's create-path source allowlist (`makeMessageRequest`) was hard-coded to `{telegram, messages}` and rejected `gchat`; the aggregation engine routes through the recorder, so without this the create path rolled back and reprocessed forever. Added `gchat` to the allowlist (now a map) + a unit test.
- Cross-contact reply-bridge guard: the explicit-reply-bridge path now refuses to promote an interaction owned by a different contact (`existing.ContactID == contactID`), and the reply-target query is contact-scoped — defends every source against a fanned-out shared address resolving to the wrong contact's row.

## Test plan

- `make lint` — clean.
- `make test-unit` — green (adapter formatting/escape/projection, reenqueuer dispatch, identity normalize, recorder allowlist, cross-contact guard).
- `make test-integration` — green (CHECK round-trip, dual-source identity map, source-parameterized query isolation, full create-path burst wiring, reply-bridge to mutual + after-48h negative, edit/delete no-op, claim-race recovery, session-scoped mark-processed boundary-shift, contact-scoped reply-target getter).
- No E2E in this PR — the feature is backend-only and inert (no UI, no provider). E2E is PR 3 scope.

Plan: `.ai/log/plan/gchat-integration-phase1-schema-identity-aggregation.md`
Spec: `.ai/spec/2026-06-04-gchat-integration-design.md`
Closes part of #337 (PR 1 of 3).