### PR TITLE
feat(gchat): provider + dual-source rematch + bounded edit/delete (#337)

### DIFF
--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -724,9 +724,10 @@ func run() int {
 	// GChat provider + enabled-state lister, hoisted to function scope so the
 	// LATE depth-0 gchatEngine block (below, OUTSIDE the EnableExternalSync block)
 	// can register the gchat rematch handlers. The provider is constructed but
-	// INTENTIONALLY NOT registered into providerRegistry (PR 2 is inert — the
-	// scheduler never runs it; enablement is PR 3). Both stay nil unless Google
-	// OAuth is configured AND external sync is enabled.
+	// INTENTIONALLY NOT registered into providerRegistry: the scheduler must
+	// never run it until an enablement/boot-reconciliation path creates an
+	// enabled external_sync_state(source='gchat') row (not wired here). Both stay
+	// nil unless Google OAuth is configured AND external sync is enabled.
 	var gchatProvider *google.GChatSyncProvider
 	var gchatSyncStates google.GChatSyncStateLister
 
@@ -865,11 +866,12 @@ func run() int {
 				logger.Warn().Msg("Gmail provider NOT registered: event-bus interaction mode=off (pubBus nil)")
 			}
 
-			// GChat provider (PR 2): constructed but NOT registered into
-			// providerRegistry — the scheduler must never run it (INERT). It is
-			// store-only + event-free, so unlike Gmail it does NOT gate on pubBus.
-			// gchatSyncStates = syncRepo is the enabled-state lister the gchat
-			// rematch handlers gate on (registered in the late depth-0 block).
+			// GChat provider: constructed but NOT registered into
+			// providerRegistry — the scheduler must never run it until enablement
+			// exists (INERT). It is store-only + event-free, so unlike Gmail it
+			// does NOT gate on pubBus. gchatSyncStates = syncRepo is the
+			// enabled-state lister the gchat rematch handlers gate on (registered
+			// in the late depth-0 block).
 			gchatProvider = google.NewGChatSyncProvider(
 				googleOAuthService,
 				commsMessageRepo,
@@ -1099,14 +1101,14 @@ func run() int {
 		gchatEnqueuer,
 	)
 
-	// GChat rematch handlers (PR 2): registered when the provider was constructed
+	// GChat rematch handlers: registered when the provider was constructed
 	// (Google OAuth configured) AND external sync is enabled. They are provably
-	// inert until PR 3 enables a gchat sync state — each gates FIRST on
+	// inert until an enabled gchat sync state exists — each gates FIRST on
 	// ListEnabledSyncStates filtered to source='gchat' and returns (0, nil) when
-	// that set is empty (PR 2 enables zero gchat states). The email handler
-	// co-registers under "email" alongside Gmail/Calendar; its gchat-scoped gate
-	// means it no-ops while the others do their real work. The provider itself is
-	// NOT registered into providerRegistry (the scheduler never runs it).
+	// that set is empty. The email handler co-registers under "email" alongside
+	// Gmail/Calendar; its gchat-scoped gate means it no-ops while the others do
+	// their real work. The provider itself is NOT registered into
+	// providerRegistry (the scheduler never runs it).
 	if gchatProvider != nil && gchatSyncStates != nil {
 		rematchService.Register(google.NewGChatHandleRematchHandler(gchatProvider, gchatSyncStates, commsMessageRepo, gchatEngine))
 		rematchService.Register(google.NewGChatEmailRematchHandler(gchatProvider, gchatSyncStates, commsMessageRepo, gchatEngine))

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -721,6 +721,15 @@ func run() int {
 	var todoistOAuthService *todoist.OAuthService
 	var externalContactRepo *repository.ExternalContactRepository
 
+	// GChat provider + enabled-state lister, hoisted to function scope so the
+	// LATE depth-0 gchatEngine block (below, OUTSIDE the EnableExternalSync block)
+	// can register the gchat rematch handlers. The provider is constructed but
+	// INTENTIONALLY NOT registered into providerRegistry (PR 2 is inert — the
+	// scheduler never runs it; enablement is PR 3). Both stay nil unless Google
+	// OAuth is configured AND external sync is enabled.
+	var gchatProvider *google.GChatSyncProvider
+	var gchatSyncStates google.GChatSyncStateLister
+
 	if cfg.Features.EnableExternalSync {
 		syncRepo := repository.NewSyncRepositoryWithPool(database.Queries, database.Pool)
 		identityRepo := repository.NewIdentityRepository(database.Queries)
@@ -855,6 +864,19 @@ func run() int {
 			} else {
 				logger.Warn().Msg("Gmail provider NOT registered: event-bus interaction mode=off (pubBus nil)")
 			}
+
+			// GChat provider (PR 2): constructed but NOT registered into
+			// providerRegistry — the scheduler must never run it (INERT). It is
+			// store-only + event-free, so unlike Gmail it does NOT gate on pubBus.
+			// gchatSyncStates = syncRepo is the enabled-state lister the gchat
+			// rematch handlers gate on (registered in the late depth-0 block).
+			gchatProvider = google.NewGChatSyncProvider(
+				googleOAuthService,
+				commsMessageRepo,
+				syncRepo,
+			)
+			gchatSyncStates = syncRepo
+			logger.Info().Msg("GChat sync provider constructed (inert: not registered into provider registry)")
 		}
 
 		// Register Todoist Cadence provider if OAuth is configured
@@ -1076,6 +1098,21 @@ func run() int {
 		database.Pool,
 		gchatEnqueuer,
 	)
+
+	// GChat rematch handlers (PR 2): registered when the provider was constructed
+	// (Google OAuth configured) AND external sync is enabled. They are provably
+	// inert until PR 3 enables a gchat sync state — each gates FIRST on
+	// ListEnabledSyncStates filtered to source='gchat' and returns (0, nil) when
+	// that set is empty (PR 2 enables zero gchat states). The email handler
+	// co-registers under "email" alongside Gmail/Calendar; its gchat-scoped gate
+	// means it no-ops while the others do their real work. The provider itself is
+	// NOT registered into providerRegistry (the scheduler never runs it).
+	if gchatProvider != nil && gchatSyncStates != nil {
+		rematchService.Register(google.NewGChatHandleRematchHandler(gchatProvider, gchatSyncStates, commsMessageRepo, gchatEngine))
+		rematchService.Register(google.NewGChatEmailRematchHandler(gchatProvider, gchatSyncStates, commsMessageRepo, gchatEngine))
+		logger.Info().Msg("GChat rematch handlers registered (inert until a gchat sync state is enabled)")
+	}
+
 	gchatReenqueuer := consumer.NewCommsAggregatorReenqueuer(
 		gchatEngine,
 		riverClient,

--- a/backend/internal/db/comms_message.sql.go
+++ b/backend/internal/db/comms_message.sql.go
@@ -11,6 +11,104 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const ApplyCommsMessageEditByExternalID = `-- name: ApplyCommsMessageEditByExternalID :execrows
+
+UPDATE comms_message
+SET body = $1,
+    snippet = $2,
+    source_metadata = jsonb_set(
+        jsonb_set(
+            jsonb_set(
+                source_metadata,
+                '{previous_bodies}',
+                (
+                    SELECT COALESCE(jsonb_agg(prior_body), '[]'::jsonb)
+                    FROM (
+                        SELECT prior_body
+                        FROM jsonb_array_elements(
+                            CASE
+                                WHEN comms_message.body IS NULL THEN
+                                    COALESCE(source_metadata->'previous_bodies', '[]'::jsonb)
+                                ELSE
+                                    to_jsonb(ARRAY[comms_message.body])
+                                        || COALESCE(source_metadata->'previous_bodies', '[]'::jsonb)
+                            END
+                        ) AS prior_body
+                        LIMIT 3
+                    ) AS capped
+                ),
+                TRUE
+            ),
+            '{edited_at}',
+            to_jsonb($3::text),
+            TRUE
+        ),
+        '{last_update_time}',
+        to_jsonb($4::text),
+        TRUE
+    )
+WHERE source = $5
+  AND external_id = $6
+  AND deleted_at IS NULL
+  AND COALESCE(
+        NULLIF(source_metadata->>'last_update_time', '')::timestamptz,
+        '-infinity'::timestamptz
+      ) < ($4::text)::timestamptz
+`
+
+type ApplyCommsMessageEditByExternalIDParams struct {
+	Body           pgtype.Text `json:"body"`
+	Snippet        pgtype.Text `json:"snippet"`
+	EditedAt       string      `json:"edited_at"`
+	LastUpdateTime string      `json:"last_update_time"`
+	Source         string      `json:"source"`
+	ExternalID     string      `json:"external_id"`
+}
+
+// =====================================================================
+// GChat edit/delete reconciliation queries. Scoped by (source,
+// external_id) so they hit ALL fanned-out rows for one upstream message
+// (a message qualifying N contacts has N rows sharing external_id). All
+// scope deleted_at IS NULL.
+// =====================================================================
+// Apply an upstream message edit to every stored row for (source, external_id).
+// Updates body + snippet, pushes the row's prior body onto
+// source_metadata.previous_bodies[] (newest-first, capped at the last 3), and
+// records the edit's last_update_time + edited_at. processed_at, interaction_id,
+// and deleted_at are deliberately left untouched: the aggregation engine skips
+// rows with processed_at set, so a content edit never reprocesses the derived
+// interaction.
+//
+// RECENCY + IDEMPOTENCY GUARD: the WHERE clause compares the stored
+// last_update_time against @last_update_time as a TIMESTAMPTZ, not as a string.
+// RFC-3339 is NOT lexicographically ordered when fractional-second precision
+// varies (e.g. "...10:00:00Z" sorts after "...10:00:00.001Z" yet is earlier),
+// so a string compare would silently reject a legitimate newer edit. Casting
+// both sides to timestamptz compares real instants regardless of precision or
+// offset. NULLIF(...,”)::timestamptz handles never-edited rows (absent/empty
+// key -> NULL -> '-infinity' floor, so the first edit always passes). Because
+// only the first writer advances last_update_time, two connected accounts
+// observing the same edit in concurrent sweeps each attempt the UPDATE but only
+// one pushes previous_bodies[] — the second's predicate is false (0 rows).
+//
+// previous_bodies[] cap: prepend the row's CURRENT body (the soon-to-be-prior
+// value), then keep the first 3 elements (newest-first). A NULL current body is
+// not pushed (nothing to preserve).
+func (q *Queries) ApplyCommsMessageEditByExternalID(ctx context.Context, arg ApplyCommsMessageEditByExternalIDParams) (int64, error) {
+	result, err := q.db.Exec(ctx, ApplyCommsMessageEditByExternalID,
+		arg.Body,
+		arg.Snippet,
+		arg.EditedAt,
+		arg.LastUpdateTime,
+		arg.Source,
+		arg.ExternalID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const BackdateCommsMessageClaim = `-- name: BackdateCommsMessageClaim :exec
 UPDATE comms_message
 SET claimed_at = NOW() - INTERVAL '10 minutes'
@@ -259,6 +357,53 @@ func (q *Queries) GetCommsMessageByReplyTarget(ctx context.Context, arg GetComms
 		arg.ThreadID,
 		arg.ReplyTargetID,
 	)
+	var i CommsMessage
+	err := row.Scan(
+		&i.ID,
+		&i.Source,
+		&i.ExternalID,
+		&i.ThreadID,
+		&i.Subject,
+		&i.Body,
+		&i.Snippet,
+		&i.PeerHandle,
+		&i.PeerNormalized,
+		&i.Direction,
+		&i.SentAt,
+		&i.AccountID,
+		&i.SourceMetadata,
+		&i.MatchedContactID,
+		&i.InteractionID,
+		&i.ClaimedAt,
+		&i.ClaimedSessionRef,
+		&i.ProcessedAt,
+		&i.DeletedAt,
+		&i.CreatedAt,
+	)
+	return &i, err
+}
+
+const GetCommsMessageLatestByExternalID = `-- name: GetCommsMessageLatestByExternalID :one
+SELECT id, source, external_id, thread_id, subject, body, snippet, peer_handle, peer_normalized, direction, sent_at, account_id, source_metadata, matched_contact_id, interaction_id, claimed_at, claimed_session_ref, processed_at, deleted_at, created_at FROM comms_message
+WHERE source = $1
+  AND external_id = $2
+  AND deleted_at IS NULL
+ORDER BY sent_at DESC, id
+LIMIT 1
+`
+
+type GetCommsMessageLatestByExternalIDParams struct {
+	Source     string `json:"source"`
+	ExternalID string `json:"external_id"`
+}
+
+// Read one stored row for (source, external_id), newest first, to supply the
+// current body for the provider's bodyDiffers no-op-avoidance pre-check. Fanned-
+// out rows share content, so any one row suffices. Used ONLY for body
+// comparison — NEVER for a Go-side timestamp/recency comparison (recency is the
+// SQL ::timestamptz guard in ApplyCommsMessageEditByExternalID).
+func (q *Queries) GetCommsMessageLatestByExternalID(ctx context.Context, arg GetCommsMessageLatestByExternalIDParams) (*CommsMessage, error) {
+	row := q.db.QueryRow(ctx, GetCommsMessageLatestByExternalID, arg.Source, arg.ExternalID)
 	var i CommsMessage
 	err := row.Scan(
 		&i.ID,
@@ -699,6 +844,32 @@ WHERE id = $1
 func (q *Queries) SoftDeleteCommsMessageByID(ctx context.Context, id pgtype.UUID) error {
 	_, err := q.db.Exec(ctx, SoftDeleteCommsMessageByID, id)
 	return err
+}
+
+const SoftDeleteCommsMessagesByExternalID = `-- name: SoftDeleteCommsMessagesByExternalID :execrows
+UPDATE comms_message
+SET deleted_at = $1
+WHERE source = $2
+  AND external_id = $3
+  AND deleted_at IS NULL
+`
+
+type SoftDeleteCommsMessagesByExternalIDParams struct {
+	Now        pgtype.Timestamptz `json:"now"`
+	Source     string             `json:"source"`
+	ExternalID string             `json:"external_id"`
+}
+
+// Soft-delete every stored row for (source, external_id) — the production chat
+// delete path. Scoped by (source, external_id) so all fanned-out contacts'
+// rows drop out of future aggregation. Idempotent: an already-deleted message
+// affects 0 rows.
+func (q *Queries) SoftDeleteCommsMessagesByExternalID(ctx context.Context, arg SoftDeleteCommsMessagesByExternalIDParams) (int64, error) {
+	result, err := q.db.Exec(ctx, SoftDeleteCommsMessagesByExternalID, arg.Now, arg.Source, arg.ExternalID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const UpsertCommsMessage = `-- name: UpsertCommsMessage :one

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -33,6 +33,36 @@ type Querier interface {
 	// records interactions directly for past events (see rematch plan Design
 	// Decision 6) so the scheduler race is avoided at the source.
 	AppendMatchedContact(ctx context.Context, arg AppendMatchedContactParams) error
+	// =====================================================================
+	// GChat edit/delete reconciliation queries. Scoped by (source,
+	// external_id) so they hit ALL fanned-out rows for one upstream message
+	// (a message qualifying N contacts has N rows sharing external_id). All
+	// scope deleted_at IS NULL.
+	// =====================================================================
+	// Apply an upstream message edit to every stored row for (source, external_id).
+	// Updates body + snippet, pushes the row's prior body onto
+	// source_metadata.previous_bodies[] (newest-first, capped at the last 3), and
+	// records the edit's last_update_time + edited_at. processed_at, interaction_id,
+	// and deleted_at are deliberately left untouched: the aggregation engine skips
+	// rows with processed_at set, so a content edit never reprocesses the derived
+	// interaction.
+	//
+	// RECENCY + IDEMPOTENCY GUARD: the WHERE clause compares the stored
+	// last_update_time against @last_update_time as a TIMESTAMPTZ, not as a string.
+	// RFC-3339 is NOT lexicographically ordered when fractional-second precision
+	// varies (e.g. "...10:00:00Z" sorts after "...10:00:00.001Z" yet is earlier),
+	// so a string compare would silently reject a legitimate newer edit. Casting
+	// both sides to timestamptz compares real instants regardless of precision or
+	// offset. NULLIF(...,'')::timestamptz handles never-edited rows (absent/empty
+	// key -> NULL -> '-infinity' floor, so the first edit always passes). Because
+	// only the first writer advances last_update_time, two connected accounts
+	// observing the same edit in concurrent sweeps each attempt the UPDATE but only
+	// one pushes previous_bodies[] — the second's predicate is false (0 rows).
+	//
+	// previous_bodies[] cap: prepend the row's CURRENT body (the soon-to-be-prior
+	// value), then keep the first 3 elements (newest-first). A NULL current body is
+	// not pushed (nothing to preserve).
+	ApplyCommsMessageEditByExternalID(ctx context.Context, arg ApplyCommsMessageEditByExternalIDParams) (int64, error)
 	// Test-only helper: ages the claim past the 5-minute TTL so a fresh
 	// aggregate pass can re-claim a stale claim. Mirror of
 	// BackdateMessagesMessageClaim. Production code MUST NOT call this.
@@ -507,6 +537,12 @@ type Querier interface {
 	// Intentionally does NOT filter processed_at — a reply can target an
 	// already-processed message (the whole point of bridging).
 	GetCommsMessageByReplyTarget(ctx context.Context, arg GetCommsMessageByReplyTargetParams) (*CommsMessage, error)
+	// Read one stored row for (source, external_id), newest first, to supply the
+	// current body for the provider's bodyDiffers no-op-avoidance pre-check. Fanned-
+	// out rows share content, so any one row suffices. Used ONLY for body
+	// comparison — NEVER for a Go-side timestamp/recency comparison (recency is the
+	// SQL ::timestamptz guard in ApplyCommsMessageEditByExternalID).
+	GetCommsMessageLatestByExternalID(ctx context.Context, arg GetCommsMessageLatestByExternalIDParams) (*CommsMessage, error)
 	// Contact queries
 	GetContact(ctx context.Context, id pgtype.UUID) (*Contact, error)
 	// Get a single note for a contact by category (e.g., 'notepad')
@@ -1226,6 +1262,11 @@ type Querier interface {
 	// the upstream delete a chat provider would observe. Used by the delete-no-op
 	// aggregation test. There is no production chat delete path yet.
 	SoftDeleteCommsMessageByID(ctx context.Context, id pgtype.UUID) error
+	// Soft-delete every stored row for (source, external_id) — the production chat
+	// delete path. Scoped by (source, external_id) so all fanned-out contacts'
+	// rows drop out of future aggregation. Idempotent: an already-deleted message
+	// affects 0 rows.
+	SoftDeleteCommsMessagesByExternalID(ctx context.Context, arg SoftDeleteCommsMessagesByExternalIDParams) (int64, error)
 	SoftDeleteContact(ctx context.Context, id pgtype.UUID) error
 	// Tombstones a live row. Defensive WHERE deleted_at IS NULL keeps the
 	// statement idempotent against a concurrent delete. crm_contact_id,

--- a/backend/internal/db/queries/comms_message.sql
+++ b/backend/internal/db/queries/comms_message.sql
@@ -349,3 +349,100 @@ UPDATE comms_message
 SET deleted_at = NOW()
 WHERE id = @id
   AND deleted_at IS NULL;
+
+-- =====================================================================
+-- GChat edit/delete reconciliation queries. Scoped by (source,
+-- external_id) so they hit ALL fanned-out rows for one upstream message
+-- (a message qualifying N contacts has N rows sharing external_id). All
+-- scope deleted_at IS NULL.
+-- =====================================================================
+
+-- name: ApplyCommsMessageEditByExternalID :execrows
+-- Apply an upstream message edit to every stored row for (source, external_id).
+-- Updates body + snippet, pushes the row's prior body onto
+-- source_metadata.previous_bodies[] (newest-first, capped at the last 3), and
+-- records the edit's last_update_time + edited_at. processed_at, interaction_id,
+-- and deleted_at are deliberately left untouched: the aggregation engine skips
+-- rows with processed_at set, so a content edit never reprocesses the derived
+-- interaction.
+--
+-- RECENCY + IDEMPOTENCY GUARD: the WHERE clause compares the stored
+-- last_update_time against @last_update_time as a TIMESTAMPTZ, not as a string.
+-- RFC-3339 is NOT lexicographically ordered when fractional-second precision
+-- varies (e.g. "...10:00:00Z" sorts after "...10:00:00.001Z" yet is earlier),
+-- so a string compare would silently reject a legitimate newer edit. Casting
+-- both sides to timestamptz compares real instants regardless of precision or
+-- offset. NULLIF(...,'')::timestamptz handles never-edited rows (absent/empty
+-- key -> NULL -> '-infinity' floor, so the first edit always passes). Because
+-- only the first writer advances last_update_time, two connected accounts
+-- observing the same edit in concurrent sweeps each attempt the UPDATE but only
+-- one pushes previous_bodies[] — the second's predicate is false (0 rows).
+--
+-- previous_bodies[] cap: prepend the row's CURRENT body (the soon-to-be-prior
+-- value), then keep the first 3 elements (newest-first). A NULL current body is
+-- not pushed (nothing to preserve).
+UPDATE comms_message
+SET body = @body,
+    snippet = @snippet,
+    source_metadata = jsonb_set(
+        jsonb_set(
+            jsonb_set(
+                source_metadata,
+                '{previous_bodies}',
+                (
+                    SELECT COALESCE(jsonb_agg(prior_body), '[]'::jsonb)
+                    FROM (
+                        SELECT prior_body
+                        FROM jsonb_array_elements(
+                            CASE
+                                WHEN comms_message.body IS NULL THEN
+                                    COALESCE(source_metadata->'previous_bodies', '[]'::jsonb)
+                                ELSE
+                                    to_jsonb(ARRAY[comms_message.body])
+                                        || COALESCE(source_metadata->'previous_bodies', '[]'::jsonb)
+                            END
+                        ) AS prior_body
+                        LIMIT 3
+                    ) AS capped
+                ),
+                TRUE
+            ),
+            '{edited_at}',
+            to_jsonb(@edited_at::text),
+            TRUE
+        ),
+        '{last_update_time}',
+        to_jsonb(@last_update_time::text),
+        TRUE
+    )
+WHERE source = @source
+  AND external_id = @external_id
+  AND deleted_at IS NULL
+  AND COALESCE(
+        NULLIF(source_metadata->>'last_update_time', '')::timestamptz,
+        '-infinity'::timestamptz
+      ) < (@last_update_time::text)::timestamptz;
+
+-- name: SoftDeleteCommsMessagesByExternalID :execrows
+-- Soft-delete every stored row for (source, external_id) — the production chat
+-- delete path. Scoped by (source, external_id) so all fanned-out contacts'
+-- rows drop out of future aggregation. Idempotent: an already-deleted message
+-- affects 0 rows.
+UPDATE comms_message
+SET deleted_at = @now
+WHERE source = @source
+  AND external_id = @external_id
+  AND deleted_at IS NULL;
+
+-- name: GetCommsMessageLatestByExternalID :one
+-- Read one stored row for (source, external_id), newest first, to supply the
+-- current body for the provider's bodyDiffers no-op-avoidance pre-check. Fanned-
+-- out rows share content, so any one row suffices. Used ONLY for body
+-- comparison — NEVER for a Go-side timestamp/recency comparison (recency is the
+-- SQL ::timestamptz guard in ApplyCommsMessageEditByExternalID).
+SELECT * FROM comms_message
+WHERE source = @source
+  AND external_id = @external_id
+  AND deleted_at IS NULL
+ORDER BY sent_at DESC, id
+LIMIT 1;

--- a/backend/internal/google/gchat.go
+++ b/backend/internal/google/gchat.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/google/uuid"
 	chat "google.golang.org/api/chat/v1"
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
 	people "google.golang.org/api/people/v1"
 )
@@ -144,6 +145,15 @@ func (f *chatServiceFetcher) ResolvePersonEmail(ctx context.Context, userName st
 		PersonFields("emailAddresses").
 		Context(ctx).Do()
 	if err != nil {
+		// A 404 means the person is not in the user's address book (or not
+		// resolvable under contacts.readonly) — that is a normal unresolved
+		// sender/member, NOT a failure. Return "" so the caller treats it as a
+		// bystander and the resolver caches a negative. Only transient/other
+		// errors (auth, quota, 5xx) propagate so the window aborts and retries.
+		var apiErr *googleapi.Error
+		if errors.As(err, &apiErr) && apiErr.Code == 404 {
+			return "", nil
+		}
 		return "", fmt.Errorf("resolve person %s: %w", hashIdentifier(userName), err)
 	}
 	return primaryNormalizedEmail(person), nil
@@ -327,21 +337,32 @@ func (p *GChatSyncProvider) Sync(
 	resolver := newCachedEmailResolver(fetcher, gcm.UserEmailCache)
 	counters := &sweepCounters{}
 	backfillFloor := gchatBackfillFloor(state.Metadata)
-	windowsUsed := 0
+	// Shared list-page budget for the WHOLE sweep (membership + content + edit
+	// passes across all spaces), decremented as pages are consumed. Once it hits
+	// zero the sweep stops advancing cursors; un-advanced spaces restart next
+	// tick (crash-safe).
+	budget := gchatMaxWindowsPerSync
 
 	for _, space := range spaces {
-		if windowsUsed >= gchatMaxWindowsPerSync {
+		if budget <= 0 {
 			break
 		}
 		members, fetchedPages, err := p.resolveMembership(ctx, fetcher, space, gcm)
-		windowsUsed += fetchedPages
+		budget -= fetchedPages
 		if err != nil {
 			// Transient membership error: abort THIS space (cursor unadvanced),
 			// continue with already-proven spaces. Don't fail the whole sweep.
 			logger.Warn().Err(err).Str("source", GChatSourceName).Msg("gchat: membership resolution failed; skipping space")
 			continue
 		}
-		knownMembers := resolveKnownMembers(ctx, members, resolver, knownMap, meSet)
+		knownMembers, err := resolveKnownMembers(ctx, members, resolver, knownMap, meSet)
+		if err != nil {
+			// Transient resolve error while resolving co-members: abort THIS space
+			// (cursor unadvanced) so the window retries next sweep with the full
+			// membership. Never advance the cursor on a partial fan-out.
+			logger.Warn().Err(err).Str("source", GChatSourceName).Msg("gchat: co-member resolution failed; skipping space")
+			continue
+		}
 
 		isDM := space.SpaceType == gchatSpaceTypeDM
 		if len(knownMembers) == 0 && !isDM {
@@ -350,8 +371,7 @@ func (p *GChatSyncProvider) Sync(
 		}
 
 		cur := gcm.cursorFor(space.Name, backfillFloor)
-		newCreateCursor, pages, err := p.consumeContentWindow(ctx, fetcher, space, cur.CreateCursor, knownMembers, knownMap, meSet, resolver, accountID, counters)
-		windowsUsed += pages
+		newCreateCursor, proven, err := p.consumeContentWindow(ctx, fetcher, space, cur.CreateCursor, knownMembers, knownMap, meSet, resolver, accountID, counters, &budget)
 		if err != nil {
 			// A list/resolve/upsert error mid-window leaves create_cursor
 			// UNADVANCED so the whole window restarts next sweep (idempotent via
@@ -359,19 +379,26 @@ func (p *GChatSyncProvider) Sync(
 			logger.Warn().Err(err).Str("source", GChatSourceName).Msg("gchat: content window aborted; cursor unadvanced")
 			continue
 		}
+		if !proven {
+			// Budget ran out before the window was fully paged → keep the original
+			// cursor (do NOT advance over an un-listed page) and stop the sweep.
+			break
+		}
 		cur.CreateCursor = newCreateCursor
 
 		// Bounded edit/delete reconciliation: re-list create_time within the
-		// trailing lookback with ShowDeleted, applying edits/deletes. A failure
-		// here does NOT roll back the content cursor we just proved (the edit
-		// pass is best-effort recovery, idempotent via the SQL guards), but the
-		// edit_cursor stays unadvanced so the window retries next sweep.
-		newEditCursor, editPages, editErr := p.reconcileEditsDeletes(ctx, fetcher, space, cur, backfillFloor, counters)
-		windowsUsed += editPages
-		if editErr != nil {
-			logger.Warn().Err(editErr).Str("source", GChatSourceName).Msg("gchat: edit/delete pass aborted; edit cursor unadvanced")
-		} else {
-			cur.EditCursor = newEditCursor
+		// trailing lookback with ShowDeleted, applying edits/deletes. Skip it when
+		// the shared budget is already exhausted (the content cursor we just
+		// proved is still persisted below). A failure here does NOT roll back the
+		// content cursor (the edit pass is best-effort, idempotent via the SQL
+		// guards), but edit_cursor stays unadvanced so the window retries.
+		if budget > 0 {
+			newEditCursor, editProven, editErr := p.reconcileEditsDeletes(ctx, fetcher, space, cur, backfillFloor, counters, &budget)
+			if editErr != nil {
+				logger.Warn().Err(editErr).Str("source", GChatSourceName).Msg("gchat: edit/delete pass aborted; edit cursor unadvanced")
+			} else if editProven {
+				cur.EditCursor = newEditCursor
+			}
 		}
 		gcm.setCursor(space.Name, cur)
 	}
@@ -470,14 +497,26 @@ func (p *GChatSyncProvider) ScanIdentifier(
 
 	resolver := newCachedEmailResolver(fetcher, nil)
 	counters := &sweepCounters{}
+	// The rematch scan is a one-shot historical backfill, not a steady-state
+	// tick, so it gets its OWN full page budget (the steady-state sweep budget
+	// does not apply). The cursor is not persisted here — re-running is
+	// idempotent via the upsert dedup — so partial-window proven-ness is moot.
+	budget := gchatMaxWindowsPerSync
 	for _, space := range spaces {
-		members, _, mErr := paginateMembers(ctx, fetcher, space.Name)
+		if budget <= 0 {
+			break
+		}
+		members, memberPages, mErr := paginateMembers(ctx, fetcher, space.Name)
+		budget -= memberPages
 		if mErr != nil {
 			return counters.matched, fmt.Errorf("list members: %w", mErr)
 		}
 		// Co-member resolution uses the FULL knownMap (so a space qualifies when
 		// the target address is one of its members); row-writing uses scanMap.
-		knownMembers := resolveKnownMembers(ctx, members, resolver, knownMap, meSet)
+		knownMembers, rErr := resolveKnownMembers(ctx, members, resolver, knownMap, meSet)
+		if rErr != nil {
+			return counters.matched, fmt.Errorf("resolve co-members: %w", rErr)
+		}
 		scanMembers := restrictKnownMembers(knownMembers, addrNormalized)
 		isDM := space.SpaceType == gchatSpaceTypeDM
 		if len(scanMembers) == 0 && !isDM {
@@ -488,7 +527,7 @@ func (p *GChatSyncProvider) ScanIdentifier(
 			// arrive in a space the address belongs to.
 			continue
 		}
-		if _, _, cErr := p.consumeContentWindow(ctx, fetcher, space, afterCursor, scanMembers, scanMap, meSet, resolver, accountID, counters); cErr != nil {
+		if _, _, cErr := p.consumeContentWindow(ctx, fetcher, space, afterCursor, scanMembers, scanMap, meSet, resolver, accountID, counters, &budget); cErr != nil {
 			return counters.matched, fmt.Errorf("scan space: %w", cErr)
 		}
 	}
@@ -506,9 +545,15 @@ func restrictKnownMembers(knownMembers map[string][]uuid.UUID, addr string) map[
 }
 
 // consumeContentWindow pages a space's messages with create_time > cursor,
-// upserts qualifying rows, and returns the new create_cursor (the max createTime
-// successfully processed) plus the number of list pages consumed. On any error
-// it returns the ORIGINAL cursor so the window restarts next sweep.
+// upserts qualifying rows, and returns the new create_cursor. proven is true
+// ONLY when the window was fully paged (next == "") — that is the only case the
+// caller may advance the cursor. When the SHARED sweep budget runs out mid-
+// window (more pages remain), it returns proven=false + the ORIGINAL cursor so
+// the whole window restarts next sweep (advancing maxCreate would risk skipping
+// an un-listed later page whose first message shares maxCreate's timestamp,
+// since the next sweep filters create_time > cursor). On any error it likewise
+// returns the original cursor. budget is the shared remaining-page allowance,
+// decremented per list page.
 func (p *GChatSyncProvider) consumeContentWindow(
 	ctx context.Context,
 	fetcher chatFetcher,
@@ -520,16 +565,22 @@ func (p *GChatSyncProvider) consumeContentWindow(
 	resolver *cachedEmailResolver,
 	accountID string,
 	counters *sweepCounters,
-) (newCursor string, pages int, err error) {
+	budget *int,
+) (newCursor string, proven bool, err error) {
 	filter := fmt.Sprintf(`create_time > "%s"`, createCursor)
 	maxCreate := createCursor
 	pageToken := ""
 	for {
+		if *budget <= 0 {
+			// Shared sweep budget exhausted before this window was fully paged →
+			// unproven, keep the original cursor.
+			return createCursor, false, nil
+		}
 		msgs, next, listErr := fetcher.ListMessages(ctx, space.Name, filter, false, pageToken)
 		if listErr != nil {
-			return createCursor, pages, fmt.Errorf("list messages: %w", listErr)
+			return createCursor, false, fmt.Errorf("list messages: %w", listErr)
 		}
-		pages++
+		*budget--
 		for _, m := range msgs {
 			if !qualifiableContentMessage(m) {
 				continue
@@ -538,7 +589,7 @@ func (p *GChatSyncProvider) consumeContentWindow(
 			if matchErr != nil {
 				// Transient resolve/upsert error: abort the window, keep the
 				// original cursor (do NOT advance past this message).
-				return createCursor, pages, matchErr
+				return createCursor, false, matchErr
 			}
 			if m.CreateTime > maxCreate {
 				maxCreate = m.CreateTime
@@ -546,16 +597,11 @@ func (p *GChatSyncProvider) consumeContentWindow(
 			counters.processed++
 		}
 		if next == "" {
-			break
+			// Fully paged → the window is proven, advance to maxCreate.
+			return maxCreate, true, nil
 		}
 		pageToken = next
-		if pages >= gchatMaxWindowsPerSync {
-			// Window budget exhausted mid-space: commit what we proved. maxCreate
-			// only reflects fully-upserted messages, so this is safe.
-			break
-		}
 	}
-	return maxCreate, pages, nil
 }
 
 // qualifiableContentMessage reports whether a content-pass message should be
@@ -582,10 +628,13 @@ func qualifiableContentMessage(m *chat.Message) bool {
 //     edit, whose SQL ::timestamptz guard authoritatively decides recency +
 //     idempotency (there is NO Go-side timestamp comparison).
 //
-// Returns the new edit_cursor (the max createTime seen) and the pages consumed.
-// On a list error it returns the ORIGINAL edit cursor so the window retries.
-// Edits/deletes of messages created before the lookback are an accepted
-// lost-update (the API offers no update_time/delete_time filter).
+// proven is true ONLY when the lookback window was fully paged (next == "") —
+// the only case the caller may advance edit_cursor. On a list error or shared-
+// budget exhaustion mid-window it returns the ORIGINAL edit cursor + proven=
+// false so the window retries next sweep. budget is the shared remaining-page
+// allowance, decremented per list page. Edits/deletes of messages created
+// before the lookback are an accepted lost-update (the API offers no
+// update_time/delete_time filter).
 func (p *GChatSyncProvider) reconcileEditsDeletes(
 	ctx context.Context,
 	fetcher chatFetcher,
@@ -593,37 +642,37 @@ func (p *GChatSyncProvider) reconcileEditsDeletes(
 	cur spaceCursor,
 	backfillFloor string,
 	counters *sweepCounters,
-) (newEditCursor string, pages int, err error) {
+	budget *int,
+) (newEditCursor string, proven bool, err error) {
 	floor := editLookbackFloor(cur.CreateCursor, backfillFloor)
 	filter := fmt.Sprintf(`create_time > "%s"`, floor)
 	maxCreate := cur.EditCursor
 	pageToken := ""
 	for {
+		if *budget <= 0 {
+			return cur.EditCursor, false, nil
+		}
 		msgs, next, listErr := fetcher.ListMessages(ctx, space.Name, filter, true, pageToken)
 		if listErr != nil {
-			return cur.EditCursor, pages, fmt.Errorf("list messages (show_deleted): %w", listErr)
+			return cur.EditCursor, false, fmt.Errorf("list messages (show_deleted): %w", listErr)
 		}
-		pages++
+		*budget--
 		for _, m := range msgs {
 			if m == nil || m.Name == "" {
 				continue
 			}
 			if applyErr := p.applyEditOrDelete(ctx, m, counters); applyErr != nil {
-				return cur.EditCursor, pages, applyErr
+				return cur.EditCursor, false, applyErr
 			}
 			if m.CreateTime > maxCreate {
 				maxCreate = m.CreateTime
 			}
 		}
 		if next == "" {
-			break
+			return maxCreate, true, nil
 		}
 		pageToken = next
-		if pages >= gchatMaxWindowsPerSync {
-			break
-		}
 	}
-	return maxCreate, pages, nil
 }
 
 // applyEditOrDelete applies one re-listed message's edit or delete to the stored

--- a/backend/internal/google/gchat.go
+++ b/backend/internal/google/gchat.go
@@ -414,19 +414,95 @@ type sweepCounters struct {
 // buildKnownMap loads the dual-source (gchat+email) known-contact map:
 // normalized address → []contactID.
 func (p *GChatSyncProvider) buildKnownMap(ctx context.Context) (map[string][]uuid.UUID, error) {
-	identities, err := p.commsRepo.ListGChatIdentitiesForSync(ctx)
+	return buildKnownMapFromIdentities(ctx, p.commsRepo)
+}
+
+// buildKnownMapFromIdentities builds the dual-source known-contact map
+// (normalized address → []contactID) from ListGChatIdentitiesForSync. Shared by
+// the steady-state sweep and the rematch handlers. The same (address, contact)
+// can appear under both a gchat and an email source_type row, so it dedups.
+func buildKnownMapFromIdentities(ctx context.Context, commsRepo *repository.CommsMessageRepository) (map[string][]uuid.UUID, error) {
+	identities, err := commsRepo.ListGChatIdentitiesForSync(ctx)
 	if err != nil {
 		return nil, err
 	}
 	knownMap := make(map[string][]uuid.UUID)
 	for _, id := range identities {
-		// Defensive dedup: the same (address, contact) can appear under both a
-		// gchat and an email source_type row.
 		if !containsUUID(knownMap[id.ValueNormalized], id.ContactID) {
 			knownMap[id.ValueNormalized] = append(knownMap[id.ValueNormalized], id.ContactID)
 		}
 	}
 	return knownMap, nil
+}
+
+// ScanIdentifier runs a one-shot, address-scoped historical scan for one
+// connected account: it iterates the account's spaces and upserts only the rows
+// that involve addrNormalized (inbound FROM the address, or outbound TO a space
+// where the address is a known co-member). knownMap is the FULL map (so
+// co-member/direction resolution matches the steady-state sweep); scanMap
+// restricts which rows actually get written to the just-added address. Re-running
+// is idempotent (the upsert dedup), so a River retry that re-scans an
+// already-succeeded account produces no duplicate rows. Returns the number of
+// rows upserted.
+func (p *GChatSyncProvider) ScanIdentifier(
+	ctx context.Context,
+	accountID, addrNormalized string,
+	knownMap map[string][]uuid.UUID,
+	meSet map[string]struct{},
+	afterCursor string,
+) (matched int, err error) {
+	contacts := knownMap[addrNormalized]
+	if len(contacts) == 0 {
+		// The address maps to no live contact (already removed, or never linked)
+		// → nothing to scan.
+		return 0, nil
+	}
+	scanMap := map[string][]uuid.UUID{addrNormalized: contacts}
+
+	fetcher, err := p.newFetcher(ctx, accountID)
+	if err != nil {
+		return 0, fmt.Errorf("build chat fetcher: %w", err)
+	}
+	spaces, err := paginateSpaces(ctx, fetcher)
+	if err != nil {
+		return 0, fmt.Errorf("list spaces: %w", err)
+	}
+
+	resolver := newCachedEmailResolver(fetcher, nil)
+	counters := &sweepCounters{}
+	for _, space := range spaces {
+		members, _, mErr := paginateMembers(ctx, fetcher, space.Name)
+		if mErr != nil {
+			return counters.matched, fmt.Errorf("list members: %w", mErr)
+		}
+		// Co-member resolution uses the FULL knownMap (so a space qualifies when
+		// the target address is one of its members); row-writing uses scanMap.
+		knownMembers := resolveKnownMembers(ctx, members, resolver, knownMap, meSet)
+		scanMembers := restrictKnownMembers(knownMembers, addrNormalized)
+		isDM := space.SpaceType == gchatSpaceTypeDM
+		if len(scanMembers) == 0 && !isDM {
+			// The target address is not a member of this space → it can still be
+			// the inbound SENDER, so we must still page messages. But to bound the
+			// scan we skip spaces where the address is neither a member nor (for a
+			// DM) the implicit peer — an inbound message from the address can only
+			// arrive in a space the address belongs to.
+			continue
+		}
+		if _, _, cErr := p.consumeContentWindow(ctx, fetcher, space, afterCursor, scanMembers, scanMap, meSet, resolver, accountID, counters); cErr != nil {
+			return counters.matched, fmt.Errorf("scan space: %w", cErr)
+		}
+	}
+	return counters.matched, nil
+}
+
+// restrictKnownMembers narrows a resolved known-member map to a single address
+// (for the rematch fan-out, so an outbound message only writes the just-added
+// contact's row, not every co-member's).
+func restrictKnownMembers(knownMembers map[string][]uuid.UUID, addr string) map[string][]uuid.UUID {
+	if contacts, ok := knownMembers[addr]; ok {
+		return map[string][]uuid.UUID{addr: contacts}
+	}
+	return map[string][]uuid.UUID{}
 }
 
 // consumeContentWindow pages a space's messages with create_time > cursor,

--- a/backend/internal/google/gchat.go
+++ b/backend/internal/google/gchat.go
@@ -608,9 +608,9 @@ func (p *GChatSyncProvider) consumeContentWindow(
 				// original cursor (do NOT advance past this message).
 				return createCursor, false, matchErr
 			}
-			if m.CreateTime > maxCreate {
-				maxCreate = m.CreateTime
-			}
+			// Advance by INSTANT comparison, not lexical order, so varying
+			// fractional-second precision can't under-advance the cursor.
+			maxCreate = laterChatTime(maxCreate, m.CreateTime)
 			counters.processed++
 		}
 		if next == "" {
@@ -681,9 +681,9 @@ func (p *GChatSyncProvider) reconcileEditsDeletes(
 			if applyErr := p.applyEditOrDelete(ctx, m, counters); applyErr != nil {
 				return cur.EditCursor, false, applyErr
 			}
-			if m.CreateTime > maxCreate {
-				maxCreate = m.CreateTime
-			}
+			// Advance by INSTANT comparison, not lexical order (same fractional-
+			// second precision pitfall as the content pass).
+			maxCreate = laterChatTime(maxCreate, m.CreateTime)
 		}
 		if next == "" {
 			return maxCreate, true, nil

--- a/backend/internal/google/gchat.go
+++ b/backend/internal/google/gchat.go
@@ -347,13 +347,17 @@ func (p *GChatSyncProvider) Sync(
 		if budget <= 0 {
 			break
 		}
-		members, fetchedPages, err := p.resolveMembership(ctx, fetcher, space, gcm)
-		budget -= fetchedPages
+		members, incomplete, err := p.resolveMembership(ctx, fetcher, space, gcm, &budget)
 		if err != nil {
 			// Transient membership error: abort THIS space (cursor unadvanced),
 			// continue with already-proven spaces. Don't fail the whole sweep.
 			logger.Warn().Err(err).Str("source", GChatSourceName).Msg("gchat: membership resolution failed; skipping space")
 			continue
+		}
+		if incomplete {
+			// Budget ran out before the membership was fully paged → skip this
+			// space (don't act on a partial member list); it retries next sweep.
+			break
 		}
 		knownMembers, err := resolveKnownMembers(ctx, members, resolver, knownMap, meSet)
 		if err != nil {
@@ -497,19 +501,26 @@ func (p *GChatSyncProvider) ScanIdentifier(
 
 	resolver := newCachedEmailResolver(fetcher, nil)
 	counters := &sweepCounters{}
-	// The rematch scan is a one-shot historical backfill, not a steady-state
-	// tick, so it gets its OWN full page budget (the steady-state sweep budget
-	// does not apply). The cursor is not persisted here — re-running is
-	// idempotent via the upsert dedup — so partial-window proven-ness is moot.
+	// The rematch scan is a one-shot historical backfill. It gets its OWN full
+	// page budget. If the budget is exhausted before every space's window is
+	// fully paged, the scan is INCOMPLETE — we fail the job (return an error) so
+	// River retries the WHOLE scan, which is idempotent via the upsert dedup.
+	// Silently returning success on a partial scan would strand the rest of the
+	// address's history forever (the rematch is a one-shot trigger, not a cursor-
+	// advancing sweep that would pick up the remainder next tick).
 	budget := gchatMaxWindowsPerSync
 	for _, space := range spaces {
 		if budget <= 0 {
-			break
+			return counters.matched, fmt.Errorf("rematch scan budget exhausted before completing: retry to finish backfill")
 		}
-		members, memberPages, mErr := paginateMembers(ctx, fetcher, space.Name)
-		budget -= memberPages
+		members, _, memberIncomplete, mErr := paginateMembers(ctx, fetcher, space.Name, &budget)
 		if mErr != nil {
 			return counters.matched, fmt.Errorf("list members: %w", mErr)
+		}
+		if memberIncomplete {
+			// Budget ran out mid-membership → the scan is incomplete; fail so
+			// River retries the whole (idempotent) backfill.
+			return counters.matched, fmt.Errorf("rematch scan budget exhausted paging membership: retry to finish backfill")
 		}
 		// Co-member resolution uses the FULL knownMap (so a space qualifies when
 		// the target address is one of its members); row-writing uses scanMap.
@@ -527,8 +538,14 @@ func (p *GChatSyncProvider) ScanIdentifier(
 			// arrive in a space the address belongs to.
 			continue
 		}
-		if _, _, cErr := p.consumeContentWindow(ctx, fetcher, space, afterCursor, scanMembers, scanMap, meSet, resolver, accountID, counters, &budget); cErr != nil {
+		_, proven, cErr := p.consumeContentWindow(ctx, fetcher, space, afterCursor, scanMembers, scanMap, meSet, resolver, accountID, counters, &budget)
+		if cErr != nil {
 			return counters.matched, fmt.Errorf("scan space: %w", cErr)
+		}
+		if !proven {
+			// Budget ran out mid-window → the scan is incomplete; fail so River
+			// retries the whole (idempotent) backfill rather than dropping history.
+			return counters.matched, fmt.Errorf("rematch scan budget exhausted mid-window: retry to finish backfill")
 		}
 	}
 	return counters.matched, nil

--- a/backend/internal/google/gchat.go
+++ b/backend/internal/google/gchat.go
@@ -1,0 +1,603 @@
+package google
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/logger"
+	"personal-crm/backend/internal/matching"
+	"personal-crm/backend/internal/repository"
+	syncpkg "personal-crm/backend/internal/sync"
+
+	"github.com/google/uuid"
+	chat "google.golang.org/api/chat/v1"
+	"google.golang.org/api/option"
+	people "google.golang.org/api/people/v1"
+)
+
+const (
+	// GChatDefaultInterval is the default sync interval for Google Chat (every
+	// 15 minutes), matching the Gmail/Calendar tick.
+	GChatDefaultInterval = 15 * time.Minute
+
+	// gchatMaxWindowsPerSync bounds one sweep's total list-page iterations
+	// (content + edit/delete passes) across all spaces, mirroring Gmail's
+	// catch-up bound. Once exhausted the sweep returns; un-advanced space
+	// cursors restart next tick (crash-safe).
+	gchatMaxWindowsPerSync = 24
+
+	// gchatMembershipCacheTTL bounds how long a cached space-member list (and a
+	// cached id→email resolution) stays valid before a forced refetch, even when
+	// the space's lastActiveTime never advances. Caps People/Chat API quota.
+	gchatMembershipCacheTTL = 24 * time.Hour
+
+	// gchatArchivedCursorGrace is how long an archived (disappeared) space's
+	// cursor is retained for restore-on-rediscovery before it is dropped.
+	gchatArchivedCursorGrace = 30 * 24 * time.Hour
+
+	// gchatSnippetMaxLen caps the stored snippet length.
+	gchatSnippetMaxLen = 200
+
+	// Chat API enum values used in qualification.
+	gchatUserTypeHuman         = "HUMAN"
+	gchatSpaceTypeDM           = "DIRECT_MESSAGE"
+	gchatMembershipStateJoined = "JOINED"
+
+	// gchatUserNamePrefix is the prefix on a Chat user resource name
+	// ("users/{id}") and the People person resource name ("people/{id}").
+	gchatUserNamePrefix   = "users/"
+	gchatPersonNamePrefix = "people/"
+
+	// Metadata keys persisted into external_sync_state.metadata. Read-modify-write
+	// only the gchat keys (never replace the blob wholesale).
+	gchatMetaSpaceCursors    = "space_cursors"
+	gchatMetaArchivedCursors = "archived_space_cursors"
+	gchatMetaSpaceMembers    = "space_members"
+	gchatMetaUserEmailCache  = "user_email_cache"
+	gchatMetaMeIdentities    = "me_identities"
+)
+
+// chatFetcher is the narrow Google Chat + People read surface the provider
+// needs. The production implementation (chatServiceFetcher) wraps *chat.Service
+// + *people.Service; tests inject a fake returning canned pages so unit and
+// integration tests never touch HTTP or OAuth. The *chat.Space / *chat.Message
+// / *chat.Membership library structs stay in the signatures so tests exercise
+// the real field-mapping code.
+type chatFetcher interface {
+	// ListSpaces returns one page of the user's spaces (all space types).
+	ListSpaces(ctx context.Context, pageToken string) (spaces []*chat.Space, nextPageToken string, err error)
+	// ListMembers returns one page of a space's memberships.
+	ListMembers(ctx context.Context, spaceName, pageToken string) (members []*chat.Membership, nextPageToken string, err error)
+	// ListMessages returns one page of a space's messages matching filter,
+	// ordered by create_time ASC. showDeleted includes tombstoned messages.
+	ListMessages(ctx context.Context, spaceName, filter string, showDeleted bool, pageToken string) (msgs []*chat.Message, nextPageToken string, err error)
+	// ResolvePersonEmail resolves a Chat user resource name ("users/{id}") to a
+	// normalized email via the People API. Returns "" (no error) when the person
+	// has no email or is not resolvable under the granted scope.
+	ResolvePersonEmail(ctx context.Context, userName string) (normalizedEmail string, err error)
+}
+
+// chatServiceFetcher is the production chatFetcher backed by *chat.Service +
+// *people.Service, both built from the same per-account OAuth client.
+type chatServiceFetcher struct {
+	chat   *chat.Service
+	people *people.Service
+}
+
+func (f *chatServiceFetcher) ListSpaces(ctx context.Context, pageToken string) ([]*chat.Space, string, error) {
+	call := f.chat.Spaces.List()
+	if pageToken != "" {
+		call = call.PageToken(pageToken)
+	}
+	resp, err := call.Context(ctx).Do()
+	if err != nil {
+		return nil, "", fmt.Errorf("list spaces: %w", err)
+	}
+	return resp.Spaces, resp.NextPageToken, nil
+}
+
+func (f *chatServiceFetcher) ListMembers(ctx context.Context, spaceName, pageToken string) ([]*chat.Membership, string, error) {
+	call := f.chat.Spaces.Members.List(spaceName)
+	if pageToken != "" {
+		call = call.PageToken(pageToken)
+	}
+	resp, err := call.Context(ctx).Do()
+	if err != nil {
+		return nil, "", fmt.Errorf("list members for %s: %w", hashIdentifier(spaceName), err)
+	}
+	return resp.Memberships, resp.NextPageToken, nil
+}
+
+func (f *chatServiceFetcher) ListMessages(ctx context.Context, spaceName, filter string, showDeleted bool, pageToken string) ([]*chat.Message, string, error) {
+	call := f.chat.Spaces.Messages.List(spaceName).
+		Filter(filter).
+		ShowDeleted(showDeleted).
+		OrderBy("create_time ASC")
+	if pageToken != "" {
+		call = call.PageToken(pageToken)
+	}
+	resp, err := call.Context(ctx).Do()
+	if err != nil {
+		return nil, "", fmt.Errorf("list messages for %s: %w", hashIdentifier(spaceName), err)
+	}
+	return resp.Messages, resp.NextPageToken, nil
+}
+
+func (f *chatServiceFetcher) ResolvePersonEmail(ctx context.Context, userName string) (string, error) {
+	numericID := strings.TrimPrefix(userName, gchatUserNamePrefix)
+	if numericID == "" || numericID == userName {
+		// Not a "users/{id}" form — nothing to resolve.
+		return "", nil
+	}
+	person, err := f.people.People.Get(gchatPersonNamePrefix + numericID).
+		PersonFields("emailAddresses").
+		Context(ctx).Do()
+	if err != nil {
+		return "", fmt.Errorf("resolve person %s: %w", hashIdentifier(userName), err)
+	}
+	return primaryNormalizedEmail(person), nil
+}
+
+// primaryNormalizedEmail extracts the person's primary email (or the first
+// email when none is flagged primary), normalized. Returns "" when the person
+// carries no email.
+func primaryNormalizedEmail(person *people.Person) string {
+	if person == nil || len(person.EmailAddresses) == 0 {
+		return ""
+	}
+	first := ""
+	for _, e := range person.EmailAddresses {
+		if e == nil || strings.TrimSpace(e.Value) == "" {
+			continue
+		}
+		if first == "" {
+			first = e.Value
+		}
+		if e.Metadata != nil && e.Metadata.Primary {
+			return matching.NormalizeEmail(e.Value)
+		}
+	}
+	return matching.NormalizeEmail(first)
+}
+
+// GChatSyncProvider implements sync.SyncProvider for Google Chat. It is
+// store-only and event-free: each qualifying message is upserted into
+// comms_message(source='gchat') and the shared aggregation engine (wired
+// separately) derives interactions on its own pass. Unlike Gmail there is NO
+// event bus and NO pgxpool — the provider never publishes events and never
+// opens a tx spanning network I/O. The provider owns its rich per-space cursor
+// / membership / email-cache state, which it persists into
+// external_sync_state.metadata via syncRepo (the framework round-trips only
+// SyncResult.NewCursor, which GChat leaves empty).
+type GChatSyncProvider struct {
+	oauthService *OAuthService
+	commsRepo    *repository.CommsMessageRepository
+	syncRepo     *repository.SyncRepository
+
+	// newFetcher builds the per-account chatFetcher, encapsulating the OAuth call
+	// (GetClientForAccount + chat/people NewService). Tests override via
+	// SetFetcherFactoryForTest so a fake fetcher is injected with no OAuth state.
+	newFetcher func(ctx context.Context, accountID string) (chatFetcher, error)
+
+	// newMeSet builds the "me" set (the normalized address of every connected
+	// account). Tests override via SetMeSetForTest.
+	newMeSet func(ctx context.Context) (map[string]struct{}, error)
+}
+
+// Ensure GChatSyncProvider implements the sync.SyncProvider interface.
+var _ syncpkg.SyncProvider = (*GChatSyncProvider)(nil)
+
+// NewGChatSyncProvider builds the Google Chat provider. It takes syncRepo (not a
+// bus/pool) because GChat persists its per-space state into
+// external_sync_state.metadata itself.
+func NewGChatSyncProvider(
+	oauthService *OAuthService,
+	commsRepo *repository.CommsMessageRepository,
+	syncRepo *repository.SyncRepository,
+) *GChatSyncProvider {
+	p := &GChatSyncProvider{
+		oauthService: oauthService,
+		commsRepo:    commsRepo,
+		syncRepo:     syncRepo,
+	}
+	p.newFetcher = func(ctx context.Context, accountID string) (chatFetcher, error) {
+		client, err := oauthService.GetClientForAccount(ctx, accountID)
+		if err != nil {
+			return nil, fmt.Errorf("get OAuth client: %w", err)
+		}
+		chatSvc, err := chat.NewService(ctx, option.WithHTTPClient(client))
+		if err != nil {
+			return nil, fmt.Errorf("create Chat service: %w", err)
+		}
+		peopleSvc, err := people.NewService(ctx, option.WithHTTPClient(client))
+		if err != nil {
+			return nil, fmt.Errorf("create People service: %w", err)
+		}
+		return &chatServiceFetcher{chat: chatSvc, people: peopleSvc}, nil
+	}
+	p.newMeSet = func(ctx context.Context) (map[string]struct{}, error) {
+		accounts, err := oauthService.ListAccounts(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("list accounts: %w", err)
+		}
+		meSet := make(map[string]struct{}, len(accounts))
+		for _, a := range accounts {
+			normalized := matching.NormalizeEmail(a.AccountID)
+			if normalized != "" {
+				meSet[normalized] = struct{}{}
+			}
+		}
+		return meSet, nil
+	}
+	return p
+}
+
+// Config returns the provider's configuration.
+func (p *GChatSyncProvider) Config() syncpkg.SourceConfig {
+	return syncpkg.SourceConfig{
+		Name:                 GChatSourceName,
+		DisplayName:          "Google Chat",
+		Strategy:             repository.SyncStrategyContactDriven,
+		SupportsMultiAccount: true,
+		SupportsDiscovery:    false,
+		DefaultInterval:      GChatDefaultInterval,
+	}
+}
+
+// ValidateCredentials checks the Google credentials are valid for the account.
+func (p *GChatSyncProvider) ValidateCredentials(ctx context.Context, accountID *string) error {
+	if accountID == nil {
+		accounts, err := p.oauthService.ListAccounts(ctx)
+		if err != nil {
+			return fmt.Errorf("list accounts: %w", err)
+		}
+		if len(accounts) == 0 {
+			return fmt.Errorf("no Google accounts connected")
+		}
+		return nil
+	}
+	if _, err := p.oauthService.GetClientForAccount(ctx, *accountID); err != nil {
+		return fmt.Errorf("get OAuth client for account: %w", err)
+	}
+	return nil
+}
+
+// MeSet builds the "me" set through the provider's seam (tests override it via
+// SetMeSetForTest). Exposed so the rematch handlers can reuse it without real
+// OAuth.
+func (p *GChatSyncProvider) MeSet(ctx context.Context) (map[string]struct{}, error) {
+	return p.newMeSet(ctx)
+}
+
+// Sync performs one Google Chat sweep for one account. The framework's contacts
+// slice is ignored; the provider loads its own dual-source known-contact map.
+func (p *GChatSyncProvider) Sync(
+	ctx context.Context,
+	state *repository.SyncState,
+	_ []repository.Contact,
+) (*syncpkg.SyncResult, error) {
+	if state.AccountID == nil {
+		return nil, fmt.Errorf("account ID required for GChat sync")
+	}
+	accountID := *state.AccountID
+
+	logger.Info().
+		Str("source", GChatSourceName).
+		Str("account", accountID).
+		Msg("starting GChat sync")
+
+	gcm := loadGChatMetadata(state.Metadata)
+	knownMap, err := p.buildKnownMap(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("build known map: %w", err)
+	}
+
+	meSet, err := p.newMeSet(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("build me-set: %w", err)
+	}
+	for addr := range gcm.MeIdentities {
+		meSet[addr] = struct{}{}
+	}
+
+	fetcher, err := p.newFetcher(ctx, accountID)
+	if err != nil {
+		return nil, fmt.Errorf("build chat fetcher: %w", err)
+	}
+
+	spaces, err := paginateSpaces(ctx, fetcher)
+	if err != nil {
+		// An auth/quota error on the sweep's first call aborts the whole sweep
+		// (cursors unchanged) → service exponential backoff retries next tick.
+		return nil, fmt.Errorf("list spaces: %w", err)
+	}
+	reapStaleCursors(gcm, spaces, accelerated.GetCurrentTime())
+
+	resolver := newCachedEmailResolver(fetcher, gcm.UserEmailCache)
+	counters := &sweepCounters{}
+	backfillFloor := gchatBackfillFloor(state.Metadata)
+	windowsUsed := 0
+
+	for _, space := range spaces {
+		if windowsUsed >= gchatMaxWindowsPerSync {
+			break
+		}
+		members, fetchedPages, err := p.resolveMembership(ctx, fetcher, space, gcm)
+		windowsUsed += fetchedPages
+		if err != nil {
+			// Transient membership error: abort THIS space (cursor unadvanced),
+			// continue with already-proven spaces. Don't fail the whole sweep.
+			logger.Warn().Err(err).Str("source", GChatSourceName).Msg("gchat: membership resolution failed; skipping space")
+			continue
+		}
+		knownMembers := resolveKnownMembers(ctx, members, resolver, knownMap, meSet)
+
+		isDM := space.SpaceType == gchatSpaceTypeDM
+		if len(knownMembers) == 0 && !isDM {
+			counters.spacesSkippedNoKnownMember++
+			continue
+		}
+
+		cur := gcm.cursorFor(space.Name, backfillFloor)
+		newCreateCursor, pages, err := p.consumeContentWindow(ctx, fetcher, space, cur.CreateCursor, knownMembers, knownMap, meSet, resolver, accountID, counters)
+		windowsUsed += pages
+		if err != nil {
+			// A list/resolve/upsert error mid-window leaves create_cursor
+			// UNADVANCED so the whole window restarts next sweep (idempotent via
+			// the upsert dedup). Never advance past an unpersisted message.
+			logger.Warn().Err(err).Str("source", GChatSourceName).Msg("gchat: content window aborted; cursor unadvanced")
+			continue
+		}
+		cur.CreateCursor = newCreateCursor
+		gcm.setCursor(space.Name, cur)
+	}
+
+	if err := p.persistMetadata(ctx, state, gcm, resolver); err != nil {
+		return nil, fmt.Errorf("persist gchat metadata: %w", err)
+	}
+
+	logger.Info().
+		Str("source", GChatSourceName).
+		Str("account", accountID).
+		Int("processed", counters.processed).
+		Int("matched", counters.matched).
+		Int("spaces", len(spaces)).
+		Int("spaces_skipped_no_known_member", counters.spacesSkippedNoKnownMember).
+		Int("senders_unresolved", counters.sendersUnresolved).
+		Msg("GChat sync completed")
+
+	return &syncpkg.SyncResult{
+		ItemsProcessed: counters.processed,
+		ItemsMatched:   counters.matched,
+		NewCursor:      "",
+	}, nil
+}
+
+// sweepCounters accumulates per-sweep counts surfaced via the standard
+// SyncResult item counts (processed/matched → sync_log) and the structured
+// completion log line (the gchat-specific counters).
+type sweepCounters struct {
+	processed                  int
+	matched                    int
+	spacesSkippedNoKnownMember int
+	sendersUnresolved          int
+}
+
+// buildKnownMap loads the dual-source (gchat+email) known-contact map:
+// normalized address → []contactID.
+func (p *GChatSyncProvider) buildKnownMap(ctx context.Context) (map[string][]uuid.UUID, error) {
+	identities, err := p.commsRepo.ListGChatIdentitiesForSync(ctx)
+	if err != nil {
+		return nil, err
+	}
+	knownMap := make(map[string][]uuid.UUID)
+	for _, id := range identities {
+		// Defensive dedup: the same (address, contact) can appear under both a
+		// gchat and an email source_type row.
+		if !containsUUID(knownMap[id.ValueNormalized], id.ContactID) {
+			knownMap[id.ValueNormalized] = append(knownMap[id.ValueNormalized], id.ContactID)
+		}
+	}
+	return knownMap, nil
+}
+
+// consumeContentWindow pages a space's messages with create_time > cursor,
+// upserts qualifying rows, and returns the new create_cursor (the max createTime
+// successfully processed) plus the number of list pages consumed. On any error
+// it returns the ORIGINAL cursor so the window restarts next sweep.
+func (p *GChatSyncProvider) consumeContentWindow(
+	ctx context.Context,
+	fetcher chatFetcher,
+	space *chat.Space,
+	createCursor string,
+	knownMembers map[string][]uuid.UUID,
+	knownMap map[string][]uuid.UUID,
+	meSet map[string]struct{},
+	resolver *cachedEmailResolver,
+	accountID string,
+	counters *sweepCounters,
+) (newCursor string, pages int, err error) {
+	filter := fmt.Sprintf(`create_time > "%s"`, createCursor)
+	maxCreate := createCursor
+	pageToken := ""
+	for {
+		msgs, next, listErr := fetcher.ListMessages(ctx, space.Name, filter, false, pageToken)
+		if listErr != nil {
+			return createCursor, pages, fmt.Errorf("list messages: %w", listErr)
+		}
+		pages++
+		for _, m := range msgs {
+			if !qualifiableContentMessage(m) {
+				continue
+			}
+			matchErr := p.qualifyAndUpsert(ctx, m, space, knownMembers, knownMap, meSet, resolver, accountID, counters)
+			if matchErr != nil {
+				// Transient resolve/upsert error: abort the window, keep the
+				// original cursor (do NOT advance past this message).
+				return createCursor, pages, matchErr
+			}
+			if m.CreateTime > maxCreate {
+				maxCreate = m.CreateTime
+			}
+			counters.processed++
+		}
+		if next == "" {
+			break
+		}
+		pageToken = next
+		if pages >= gchatMaxWindowsPerSync {
+			// Window budget exhausted mid-space: commit what we proved. maxCreate
+			// only reflects fully-upserted messages, so this is safe.
+			break
+		}
+	}
+	return maxCreate, pages, nil
+}
+
+// qualifiableContentMessage reports whether a content-pass message should be
+// considered for upsert: human sender, not a tombstone, with a resource name.
+func qualifiableContentMessage(m *chat.Message) bool {
+	if m == nil || m.Name == "" {
+		return false
+	}
+	if m.DeletionMetadata != nil {
+		return false
+	}
+	if m.Sender == nil || m.Sender.Type != gchatUserTypeHuman {
+		return false
+	}
+	return true
+}
+
+// messageClassification is the pure (DB-free) result of qualifying one message:
+// its direction and the set of matched contact ids (one row will be upserted per
+// contact). matched is empty for a bystander/unresolved sender.
+type messageClassification struct {
+	SenderEmail string
+	Direction   string
+	Matched     []uuid.UUID
+	Unresolved  bool // sender resolved to no email (counts senders_unresolved)
+}
+
+// classifyMessage resolves the sender and decides direction + fan-out WITHOUT
+// touching the DB. A resolve error propagates (so the caller aborts the window
+// and retries). An unresolved sender or a bystander yields an empty Matched set.
+func classifyMessage(
+	ctx context.Context,
+	m *chat.Message,
+	knownMembers map[string][]uuid.UUID,
+	knownMap map[string][]uuid.UUID,
+	meSet map[string]struct{},
+	resolver *cachedEmailResolver,
+) (messageClassification, error) {
+	senderEmail, err := resolver.resolve(ctx, m.Sender.Name)
+	if err != nil {
+		return messageClassification{}, fmt.Errorf("resolve sender: %w", err)
+	}
+	if senderEmail == "" {
+		return messageClassification{Unresolved: true}, nil
+	}
+
+	c := messageClassification{SenderEmail: senderEmail}
+	switch {
+	case inSet(meSet, senderEmail):
+		c.Direction = repository.InteractionDirectionOutbound
+		// Fan out to every known co-member, EXCLUDING any self-contact.
+		c.Matched = flattenKnownMembers(knownMembers, meSet)
+	case len(knownMap[senderEmail]) > 0:
+		c.Direction = repository.InteractionDirectionInbound
+		c.Matched = knownMap[senderEmail] // sender-only
+	default:
+		// Sender neither me nor known → bystander, no row.
+	}
+	return c, nil
+}
+
+// qualifyAndUpsert classifies one message and upserts a row per matched contact.
+// A resolve/upsert error is returned (aborts the window); a bystander/unresolved
+// sender produces no row (and is not an error).
+func (p *GChatSyncProvider) qualifyAndUpsert(
+	ctx context.Context,
+	m *chat.Message,
+	space *chat.Space,
+	knownMembers map[string][]uuid.UUID,
+	knownMap map[string][]uuid.UUID,
+	meSet map[string]struct{},
+	resolver *cachedEmailResolver,
+	accountID string,
+	counters *sweepCounters,
+) error {
+	c, err := classifyMessage(ctx, m, knownMembers, knownMap, meSet, resolver)
+	if err != nil {
+		return err
+	}
+	if c.Unresolved {
+		counters.sendersUnresolved++
+		return nil
+	}
+	if len(c.Matched) == 0 {
+		return nil // bystander
+	}
+
+	sentAt, perr := parseChatTime(m.CreateTime)
+	if perr != nil {
+		// A message with no parseable create time can never succeed — skip it
+		// (deterministic, not transient) rather than abort the window forever.
+		logger.Warn().Str("source", GChatSourceName).Str("message", hashIdentifier(m.Name)).Msg("gchat: unparseable create time; skipping message")
+		return nil
+	}
+
+	body := m.Text
+	snippet := firstN(body, gchatSnippetMaxLen)
+	metadata := buildContentMetadata(space, m)
+	threadID := space.Name
+
+	for _, contactID := range c.Matched {
+		_, err := p.commsRepo.UpsertMessage(ctx, repository.UpsertCommsMessageParams{
+			Source:           GChatSourceName,
+			ExternalID:       m.Name,
+			ThreadID:         &threadID,
+			Body:             &body,
+			Snippet:          &snippet,
+			PeerHandle:       &c.SenderEmail,
+			PeerNormalized:   &c.SenderEmail,
+			Direction:        c.Direction,
+			SentAt:           sentAt,
+			AccountID:        &accountID,
+			SourceMetadata:   metadata,
+			MatchedContactID: contactID,
+			GmailMessageID:   nil,
+		})
+		if err != nil {
+			return fmt.Errorf("upsert comms_message: %w", err)
+		}
+		counters.matched++
+	}
+	return nil
+}
+
+// MessageClassificationForTest is the exported view of classifyMessage's result
+// so cross-package tests can assert direction + fan-out without a DB.
+type MessageClassificationForTest struct {
+	SenderEmail string
+	Direction   string
+	Matched     []uuid.UUID
+	Unresolved  bool
+}
+
+// RunClassifyForTest drives the DB-free classifyMessage for cross-package tests,
+// using a fake-fetcher-backed resolver. Production code must NOT call this.
+func RunClassifyForTest(
+	ctx context.Context,
+	m *chat.Message,
+	knownMembers map[string][]uuid.UUID,
+	knownMap map[string][]uuid.UUID,
+	meSet map[string]struct{},
+	resolver *CachedEmailResolverForTest,
+) (MessageClassificationForTest, error) {
+	c, err := classifyMessage(ctx, m, knownMembers, knownMap, meSet, resolver.inner)
+	return MessageClassificationForTest(c), err
+}

--- a/backend/internal/google/gchat.go
+++ b/backend/internal/google/gchat.go
@@ -2,11 +2,13 @@ package google
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/logger"
 	"personal-crm/backend/internal/matching"
 	"personal-crm/backend/internal/repository"
@@ -33,6 +35,12 @@ const (
 	// cached id→email resolution) stays valid before a forced refetch, even when
 	// the space's lastActiveTime never advances. Caps People/Chat API quota.
 	gchatMembershipCacheTTL = 24 * time.Hour
+
+	// gchatEditLookbackWindow is how far before a space's create_cursor the
+	// edit/delete re-list reaches. Edits/deletes of messages CREATED within this
+	// trailing window are synced; older ones are an accepted lost-update (the
+	// Chat API filters only by create_time, never by update_time/delete_time).
+	gchatEditLookbackWindow = 7 * 24 * time.Hour
 
 	// gchatArchivedCursorGrace is how long an archived (disappeared) space's
 	// cursor is retained for restore-on-rediscovery before it is dropped.
@@ -352,6 +360,19 @@ func (p *GChatSyncProvider) Sync(
 			continue
 		}
 		cur.CreateCursor = newCreateCursor
+
+		// Bounded edit/delete reconciliation: re-list create_time within the
+		// trailing lookback with ShowDeleted, applying edits/deletes. A failure
+		// here does NOT roll back the content cursor we just proved (the edit
+		// pass is best-effort recovery, idempotent via the SQL guards), but the
+		// edit_cursor stays unadvanced so the window retries next sweep.
+		newEditCursor, editPages, editErr := p.reconcileEditsDeletes(ctx, fetcher, space, cur, backfillFloor, counters)
+		windowsUsed += editPages
+		if editErr != nil {
+			logger.Warn().Err(editErr).Str("source", GChatSourceName).Msg("gchat: edit/delete pass aborted; edit cursor unadvanced")
+		} else {
+			cur.EditCursor = newEditCursor
+		}
 		gcm.setCursor(space.Name, cur)
 	}
 
@@ -367,6 +388,8 @@ func (p *GChatSyncProvider) Sync(
 		Int("spaces", len(spaces)).
 		Int("spaces_skipped_no_known_member", counters.spacesSkippedNoKnownMember).
 		Int("senders_unresolved", counters.sendersUnresolved).
+		Int("edits_applied", counters.editsApplied).
+		Int("deletes_applied", counters.deletesApplied).
 		Msg("GChat sync completed")
 
 	return &syncpkg.SyncResult{
@@ -384,6 +407,8 @@ type sweepCounters struct {
 	matched                    int
 	spacesSkippedNoKnownMember int
 	sendersUnresolved          int
+	editsApplied               int
+	deletesApplied             int
 }
 
 // buildKnownMap loads the dual-source (gchat+email) known-contact map:
@@ -470,6 +495,119 @@ func qualifiableContentMessage(m *chat.Message) bool {
 		return false
 	}
 	return true
+}
+
+// reconcileEditsDeletes runs the bounded edit/delete pass for one space: re-list
+// create_time within the trailing lookback (max(create_cursor−7d, backfill
+// floor)) with ShowDeleted=true, and for each returned message:
+//   - DeletionMetadata != nil → soft-delete every stored row for the resource
+//     name (the row drops out of future aggregation);
+//   - LastUpdateTime set AND the body differs from the stored row → apply the
+//     edit, whose SQL ::timestamptz guard authoritatively decides recency +
+//     idempotency (there is NO Go-side timestamp comparison).
+//
+// Returns the new edit_cursor (the max createTime seen) and the pages consumed.
+// On a list error it returns the ORIGINAL edit cursor so the window retries.
+// Edits/deletes of messages created before the lookback are an accepted
+// lost-update (the API offers no update_time/delete_time filter).
+func (p *GChatSyncProvider) reconcileEditsDeletes(
+	ctx context.Context,
+	fetcher chatFetcher,
+	space *chat.Space,
+	cur spaceCursor,
+	backfillFloor string,
+	counters *sweepCounters,
+) (newEditCursor string, pages int, err error) {
+	floor := editLookbackFloor(cur.CreateCursor, backfillFloor)
+	filter := fmt.Sprintf(`create_time > "%s"`, floor)
+	maxCreate := cur.EditCursor
+	pageToken := ""
+	for {
+		msgs, next, listErr := fetcher.ListMessages(ctx, space.Name, filter, true, pageToken)
+		if listErr != nil {
+			return cur.EditCursor, pages, fmt.Errorf("list messages (show_deleted): %w", listErr)
+		}
+		pages++
+		for _, m := range msgs {
+			if m == nil || m.Name == "" {
+				continue
+			}
+			if applyErr := p.applyEditOrDelete(ctx, m, counters); applyErr != nil {
+				return cur.EditCursor, pages, applyErr
+			}
+			if m.CreateTime > maxCreate {
+				maxCreate = m.CreateTime
+			}
+		}
+		if next == "" {
+			break
+		}
+		pageToken = next
+		if pages >= gchatMaxWindowsPerSync {
+			break
+		}
+	}
+	return maxCreate, pages, nil
+}
+
+// applyEditOrDelete applies one re-listed message's edit or delete to the stored
+// rows. A tombstone soft-deletes all fanned-out rows; an edit (non-empty
+// LastUpdateTime + a body that differs from the stored row) is handed to the
+// SQL ::timestamptz guard. The Go pre-filter is BODY-ONLY — it never compares
+// timestamps (recency is decided in SQL).
+func (p *GChatSyncProvider) applyEditOrDelete(ctx context.Context, m *chat.Message, counters *sweepCounters) error {
+	if m.DeletionMetadata != nil {
+		n, err := p.commsRepo.SoftDeleteByExternalID(ctx, GChatSourceName, m.Name, accelerated.GetCurrentTime())
+		if err != nil {
+			return fmt.Errorf("soft-delete by external id: %w", err)
+		}
+		counters.deletesApplied += int(n)
+		return nil
+	}
+	if m.LastUpdateTime == "" {
+		return nil // never edited
+	}
+
+	// Body-only no-op-avoidance pre-check: only round-trip the edit UPDATE when
+	// the stored body actually differs. The stored row is fetched solely for its
+	// body; its last_update_time is NEVER string-compared here.
+	stored, err := p.commsRepo.GetLatestByExternalID(ctx, GChatSourceName, m.Name)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return nil // nothing stored for this message → nothing to edit
+		}
+		return fmt.Errorf("get latest by external id: %w", err)
+	}
+	if stored.Body != nil && *stored.Body == m.Text {
+		return nil // body unchanged → skip the round-trip
+	}
+
+	body := m.Text
+	snippet := firstN(body, gchatSnippetMaxLen)
+	editedAt := accelerated.GetCurrentTime().UTC().Format(chatTimeLayout)
+	n, err := p.commsRepo.ApplyEditByExternalID(ctx, GChatSourceName, m.Name, &body, &snippet, editedAt, m.LastUpdateTime)
+	if err != nil {
+		return fmt.Errorf("apply edit by external id: %w", err)
+	}
+	// n == 0 means a concurrent sweep already applied this edit OR the stored
+	// last_update_time is already >= this one — not an error.
+	counters.editsApplied += int(n)
+	return nil
+}
+
+// editLookbackFloor returns max(createCursor − gchatEditLookbackWindow,
+// backfillFloor) as an RFC-3339 string. An unparseable createCursor falls back
+// to the backfill floor (the safe wider scan).
+func editLookbackFloor(createCursor, backfillFloor string) string {
+	created, err := parseChatTime(createCursor)
+	if err != nil {
+		return backfillFloor
+	}
+	lookback := created.Add(-gchatEditLookbackWindow).UTC().Format(chatTimeLayout)
+	if after, ok := chatTimeAfter(backfillFloor, lookback); ok && after {
+		return backfillFloor
+	}
+	return lookback
 }
 
 // messageClassification is the pure (DB-free) result of qualifying one message:

--- a/backend/internal/google/gchat_helpers.go
+++ b/backend/internal/google/gchat_helpers.go
@@ -1,0 +1,270 @@
+package google
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	chat "google.golang.org/api/chat/v1"
+
+	"github.com/google/uuid"
+)
+
+// --- pagination ------------------------------------------------------
+
+// paginateSpaces drains all pages of the user's spaces.
+func paginateSpaces(ctx context.Context, fetcher chatFetcher) ([]*chat.Space, error) {
+	var all []*chat.Space
+	pageToken := ""
+	for {
+		page, next, err := fetcher.ListSpaces(ctx, pageToken)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, page...)
+		if next == "" {
+			return all, nil
+		}
+		pageToken = next
+	}
+}
+
+// paginateMembers drains all pages of a space's JOINED human members, returning
+// their "users/{id}" resource names and the number of pages fetched.
+func paginateMembers(ctx context.Context, fetcher chatFetcher, spaceName string) ([]string, int, error) {
+	var names []string
+	pageToken := ""
+	pages := 0
+	for {
+		page, next, err := fetcher.ListMembers(ctx, spaceName, pageToken)
+		if err != nil {
+			return nil, pages, err
+		}
+		pages++
+		for _, m := range page {
+			if m == nil || m.Member == nil {
+				continue
+			}
+			if m.State != "" && m.State != gchatMembershipStateJoined {
+				continue
+			}
+			if m.Member.Type != gchatUserTypeHuman {
+				continue
+			}
+			if m.Member.Name != "" {
+				names = append(names, m.Member.Name)
+			}
+		}
+		if next == "" {
+			return names, pages, nil
+		}
+		pageToken = next
+	}
+}
+
+// --- time helpers ----------------------------------------------------
+
+// parseChatTime parses a Chat RFC-3339 timestamp into a time.Time.
+func parseChatTime(s string) (time.Time, error) {
+	return time.Parse(chatTimeLayout, s)
+}
+
+// chatTimeAfter reports whether a is strictly after b as instants. ok is false
+// when either side is unparseable (the caller decides the fallback).
+func chatTimeAfter(a, b string) (after, ok bool) {
+	ta, errA := time.Parse(chatTimeLayout, a)
+	if errA != nil {
+		return false, false
+	}
+	tb, errB := time.Parse(chatTimeLayout, b)
+	if errB != nil {
+		return false, false
+	}
+	return ta.After(tb), true
+}
+
+// --- set + slice helpers ---------------------------------------------
+
+// inSet reports membership in a set of normalized addresses.
+func inSet(set map[string]struct{}, v string) bool {
+	_, ok := set[v]
+	return ok
+}
+
+// containsUUID reports whether id is already in the slice.
+func containsUUID(ids []uuid.UUID, id uuid.UUID) bool {
+	for _, x := range ids {
+		if x == id {
+			return true
+		}
+	}
+	return false
+}
+
+// flattenKnownMembers collects the deduped contact ids across all known
+// co-members, excluding any address in meSet (self never receives an
+// outreach row). Deterministic ordering is not required (the caller upserts
+// per-contact and the dedup unique makes order irrelevant).
+func flattenKnownMembers(knownMembers map[string][]uuid.UUID, meSet map[string]struct{}) []uuid.UUID {
+	var out []uuid.UUID
+	for addr, contacts := range knownMembers {
+		if inSet(meSet, addr) {
+			continue
+		}
+		for _, c := range contacts {
+			if !containsUUID(out, c) {
+				out = append(out, c)
+			}
+		}
+	}
+	return out
+}
+
+// firstN returns the first n characters (runes) of s.
+func firstN(s string, n int) string {
+	if n <= 0 {
+		return ""
+	}
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n])
+}
+
+// --- content metadata ------------------------------------------------
+
+// gchatAttachmentMeta is the metadata-only descriptor for one Chat attachment.
+// No content is ever fetched.
+type gchatAttachmentMeta struct {
+	Name        string `json:"name,omitempty"`
+	ContentName string `json:"content_name,omitempty"`
+	ContentType string `json:"content_type,omitempty"`
+	Source      string `json:"source,omitempty"`
+}
+
+// gchatContentMetadata is the non-provenance JSON the provider assembles into
+// comms_message.source_metadata. The provenance keys (observed_accounts,
+// account_gmail_ids) are added by the UpsertCommsMessage query, not here.
+type gchatContentMetadata struct {
+	SpaceType      string                `json:"space_type,omitempty"`
+	ThreadName     string                `json:"thread_name,omitempty"`
+	LastUpdateTime string                `json:"last_update_time,omitempty"`
+	Attachments    []gchatAttachmentMeta `json:"attachments,omitempty"`
+}
+
+// buildContentMetadata assembles the source_metadata blob for a content-pass
+// message. Marshalling never fails for these fields; on the impossible error we
+// fall back to an empty object so the upsert's ::jsonb cast stays valid.
+func buildContentMetadata(space *chat.Space, m *chat.Message) []byte {
+	meta := gchatContentMetadata{
+		SpaceType:      space.SpaceType,
+		LastUpdateTime: m.LastUpdateTime,
+	}
+	if m.Thread != nil {
+		meta.ThreadName = m.Thread.Name
+	}
+	for _, a := range m.Attachment {
+		if a == nil {
+			continue
+		}
+		meta.Attachments = append(meta.Attachments, gchatAttachmentMeta{
+			Name:        a.Name,
+			ContentName: a.ContentName,
+			ContentType: a.ContentType,
+			Source:      a.Source,
+		})
+	}
+	b, err := json.Marshal(meta)
+	if err != nil {
+		return []byte("{}")
+	}
+	return b
+}
+
+// --- test seams ------------------------------------------------------
+
+// SetFetcherFactoryForTest overrides the per-account fetcher factory so tests
+// inject a fake chatFetcher with no OAuth/token state.
+func (p *GChatSyncProvider) SetFetcherFactoryForTest(factory func(ctx context.Context, accountID string) (chatFetcher, error)) {
+	p.newFetcher = factory
+}
+
+// SetMeSetForTest overrides the me-set factory so tests inject the connected-
+// account address set with no OAuth state.
+func (p *GChatSyncProvider) SetMeSetForTest(meSet map[string]struct{}) {
+	p.newMeSet = func(context.Context) (map[string]struct{}, error) {
+		return meSet, nil
+	}
+}
+
+// FakeChatFetcherFuncs lets a cross-package test supply a fake chatFetcher by
+// closures, since the chatFetcher interface is unexported. Build the fetcher
+// with NewFakeChatFetcherFactoryForTest and inject via SetFetcherFactoryForTest.
+type FakeChatFetcherFuncs struct {
+	ListSpaces         func(ctx context.Context, pageToken string) ([]*chat.Space, string, error)
+	ListMembers        func(ctx context.Context, spaceName, pageToken string) ([]*chat.Membership, string, error)
+	ListMessages       func(ctx context.Context, spaceName, filter string, showDeleted bool, pageToken string) ([]*chat.Message, string, error)
+	ResolvePersonEmail func(ctx context.Context, userName string) (string, error)
+}
+
+type fakeChatFetcher struct {
+	funcs FakeChatFetcherFuncs
+}
+
+func (f *fakeChatFetcher) ListSpaces(ctx context.Context, pageToken string) ([]*chat.Space, string, error) {
+	return f.funcs.ListSpaces(ctx, pageToken)
+}
+
+func (f *fakeChatFetcher) ListMembers(ctx context.Context, spaceName, pageToken string) ([]*chat.Membership, string, error) {
+	return f.funcs.ListMembers(ctx, spaceName, pageToken)
+}
+
+func (f *fakeChatFetcher) ListMessages(ctx context.Context, spaceName, filter string, showDeleted bool, pageToken string) ([]*chat.Message, string, error) {
+	return f.funcs.ListMessages(ctx, spaceName, filter, showDeleted, pageToken)
+}
+
+func (f *fakeChatFetcher) ResolvePersonEmail(ctx context.Context, userName string) (string, error) {
+	return f.funcs.ResolvePersonEmail(ctx, userName)
+}
+
+// NewFakeChatFetcherFactoryForTest returns a fetcher factory (accountID-keyed,
+// the SetFetcherFactoryForTest shape) yielding one closure-backed fake fetcher,
+// with NO OAuth/token state. Production code must NOT call this.
+func NewFakeChatFetcherFactoryForTest(funcs FakeChatFetcherFuncs) func(ctx context.Context, accountID string) (chatFetcher, error) {
+	fetcher := &fakeChatFetcher{funcs: funcs}
+	return func(context.Context, string) (chatFetcher, error) {
+		return fetcher, nil
+	}
+}
+
+// CachedEmailResolverForTest wraps the unexported cachedEmailResolver so a
+// cross-package test can build one for RunQualifyForTest without reaching the
+// unexported type. Production code must NOT use this.
+type CachedEmailResolverForTest struct {
+	inner *cachedEmailResolver
+}
+
+// NewCachedEmailResolverForTest builds a resolver over a fake fetcher (the same
+// FakeChatFetcherFuncs shape) with an empty cache. Production code must NOT call
+// this.
+func NewCachedEmailResolverForTest(funcs FakeChatFetcherFuncs) *CachedEmailResolverForTest {
+	return &CachedEmailResolverForTest{inner: newCachedEmailResolver(&fakeChatFetcher{funcs: funcs}, nil)}
+}
+
+// Resolve exposes the unexported resolver's resolve for cross-package tests
+// (id→email caching + TTL coverage). Production code must NOT call this.
+func (r *CachedEmailResolverForTest) Resolve(ctx context.Context, userName string) (string, error) {
+	return r.inner.resolve(ctx, userName)
+}
+
+// SweepCountersForTest is the exported view of the per-sweep counters so tests
+// can assert qualification outcomes. Production code must NOT use this.
+type SweepCountersForTest struct {
+	Processed                  int
+	Matched                    int
+	SpacesSkippedNoKnownMember int
+	SendersUnresolved          int
+	EditsApplied               int
+	DeletesApplied             int
+}

--- a/backend/internal/google/gchat_helpers.go
+++ b/backend/internal/google/gchat_helpers.go
@@ -89,6 +89,20 @@ func chatTimeAfter(a, b string) (after, ok bool) {
 	return ta.After(tb), true
 }
 
+// laterChatTime returns the chronologically-later of current and candidate,
+// compared as INSTANTS (not lexicographically). It keeps current when candidate
+// is not strictly after it OR when either side is unparseable. This is the
+// cursor-advance primitive: a raw string > comparison is wrong because RFC-3339
+// is not lexically ordered across varying fractional-second precision (e.g.
+// "...:00.001Z" is chronologically newer than "...:00Z" but sorts smaller),
+// which would under-advance the cursor and re-list already-ingested messages.
+func laterChatTime(current, candidate string) string {
+	if after, ok := chatTimeAfter(candidate, current); ok && after {
+		return candidate
+	}
+	return current
+}
+
 // --- set + slice helpers ---------------------------------------------
 
 // inSet reports membership in a set of normalized addresses.

--- a/backend/internal/google/gchat_helpers.go
+++ b/backend/internal/google/gchat_helpers.go
@@ -30,16 +30,22 @@ func paginateSpaces(ctx context.Context, fetcher chatFetcher) ([]*chat.Space, er
 }
 
 // paginateMembers drains all pages of a space's JOINED human members, returning
-// their "users/{id}" resource names and the number of pages fetched.
-func paginateMembers(ctx context.Context, fetcher chatFetcher, spaceName string) ([]string, int, error) {
-	var names []string
+// their "users/{id}" resource names and the number of pages fetched. budget is
+// the shared remaining-page allowance, decremented per list page; if it runs out
+// before the membership is fully paged, incomplete is true and the (partial)
+// names MUST NOT be used or cached — a partial member list would produce a wrong
+// fan-out. The caller skips the space and retries it next sweep.
+func paginateMembers(ctx context.Context, fetcher chatFetcher, spaceName string, budget *int) (names []string, pages int, incomplete bool, err error) {
 	pageToken := ""
-	pages := 0
 	for {
-		page, next, err := fetcher.ListMembers(ctx, spaceName, pageToken)
-		if err != nil {
-			return nil, pages, err
+		if *budget <= 0 {
+			return names, pages, true, nil
 		}
+		page, next, listErr := fetcher.ListMembers(ctx, spaceName, pageToken)
+		if listErr != nil {
+			return nil, pages, false, listErr
+		}
+		*budget--
 		pages++
 		for _, m := range page {
 			if m == nil || m.Member == nil {
@@ -56,7 +62,7 @@ func paginateMembers(ctx context.Context, fetcher chatFetcher, spaceName string)
 			}
 		}
 		if next == "" {
-			return names, pages, nil
+			return names, pages, false, nil
 		}
 		pageToken = next
 	}

--- a/backend/internal/google/gchat_rematch.go
+++ b/backend/internal/google/gchat_rematch.go
@@ -27,8 +27,8 @@ type GChatSyncStateLister interface {
 // runs a one-shot identifier-scoped historical GChat scan for the newly-added
 // address across the connected accounts whose GChat sync is ENABLED, upserting
 // comms_message(source='gchat') rows (NO events — the aggregation engine derives
-// interactions on its own pass). It is provably a no-op until PR 3 enables a
-// gchat sync state, because it gates FIRST on ListEnabledSyncStates filtered to
+// interactions on its own pass). It is provably a no-op until an enabled gchat
+// sync state exists, because it gates FIRST on ListEnabledSyncStates filtered to
 // source='gchat' and returns (0, nil) when that set is empty.
 type gchatRematchBase struct {
 	provider  *GChatSyncProvider
@@ -47,7 +47,7 @@ func (b *gchatRematchBase) rematch(ctx context.Context, contactID uuid.UUID, val
 
 	// Gate on the enabled GChat sync states FIRST so the no-op path does zero
 	// work (no identity-map build, no me-set, no fetcher). This is what makes the
-	// handlers inert until a gchat sync state is enabled (PR 3).
+	// handlers inert until a gchat sync state is enabled.
 	states, err := b.states.ListEnabledSyncStates(ctx)
 	if err != nil {
 		return 0, err

--- a/backend/internal/google/gchat_rematch.go
+++ b/backend/internal/google/gchat_rematch.go
@@ -1,0 +1,146 @@
+package google
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"personal-crm/backend/internal/matching"
+	"personal-crm/backend/internal/messaging/aggregation"
+	"personal-crm/backend/internal/repository"
+)
+
+// GChatSyncStateLister is the narrow seam the GChat rematch handlers use to find
+// the accounts whose GChat sync is enabled. Production satisfies it with
+// *repository.SyncRepository; tests satisfy it with a fake lister. Mirrors the
+// emailSyncStateLister convention so main.go can pass the block-scoped syncRepo
+// through a hoisted interface var.
+type GChatSyncStateLister interface {
+	ListEnabledSyncStates(ctx context.Context) ([]repository.SyncState, error)
+}
+
+// gchatRematchBase holds the shared dependencies + the inert-by-construction
+// gate that both GChat rematch handlers run. On a contact_methods.added event it
+// runs a one-shot identifier-scoped historical GChat scan for the newly-added
+// address across the connected accounts whose GChat sync is ENABLED, upserting
+// comms_message(source='gchat') rows (NO events — the aggregation engine derives
+// interactions on its own pass). It is provably a no-op until PR 3 enables a
+// gchat sync state, because it gates FIRST on ListEnabledSyncStates filtered to
+// source='gchat' and returns (0, nil) when that set is empty.
+type gchatRematchBase struct {
+	provider  *GChatSyncProvider
+	states    GChatSyncStateLister
+	commsRepo *repository.CommsMessageRepository
+	engine    *aggregation.Engine
+}
+
+// rematch runs the gate-then-scan-then-aggregate flow for one normalized
+// address. It is shared by both handlers (which differ only in IdentifierType).
+func (b *gchatRematchBase) rematch(ctx context.Context, contactID uuid.UUID, valueNormalized string) (int, error) {
+	addr := matching.NormalizeEmail(valueNormalized)
+	if addr == "" {
+		return 0, nil
+	}
+
+	// Gate on the enabled GChat sync states FIRST so the no-op path does zero
+	// work (no identity-map build, no me-set, no fetcher). This is what makes the
+	// handlers inert until a gchat sync state is enabled (PR 3).
+	states, err := b.states.ListEnabledSyncStates(ctx)
+	if err != nil {
+		return 0, err
+	}
+	var gchatStates []repository.SyncState
+	for _, st := range states {
+		if st.Source == GChatSourceName && st.AccountID != nil && strings.TrimSpace(*st.AccountID) != "" {
+			gchatStates = append(gchatStates, st)
+		}
+	}
+	if len(gchatStates) == 0 {
+		return 0, nil
+	}
+
+	// Build the FULL dual-source known-contact map once (so co-member/direction
+	// resolution matches the steady-state sweep — the just-added pair is already
+	// committed and included), and the me-set once through the provider seam.
+	knownMap, err := buildKnownMapFromIdentities(ctx, b.commsRepo)
+	if err != nil {
+		return 0, err
+	}
+	meSet, err := b.provider.MeSet(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	matched := 0
+	var scanErrs []error
+	for _, st := range gchatStates {
+		afterCursor := gchatBackfillFloor(st.Metadata)
+		n, scanErr := b.provider.ScanIdentifier(ctx, *st.AccountID, addr, knownMap, meSet, afterCursor)
+		matched += n
+		if scanErr != nil {
+			// The account id is the operator's OWN connected account, kept raw for
+			// triage; the rematched contact address is third-party PII and is NOT
+			// included here.
+			scanErrs = append(scanErrs, fmt.Errorf("account %s: %w", *st.AccountID, scanErr))
+		}
+	}
+	if len(scanErrs) > 0 {
+		// ANY enabled-account scan failed → fail the job so River retries the
+		// whole set (re-running is idempotent via the upsert dedup).
+		return matched, errors.Join(scanErrs...)
+	}
+
+	// Drive aggregation once for the contact so the just-upserted rows derive
+	// interactions in this rematch pass (rather than waiting for the next sweep).
+	if matched > 0 {
+		if aggErr := b.engine.AggregateForContactBatch(ctx, contactID); aggErr != nil {
+			return matched, fmt.Errorf("aggregate for contact: %w", aggErr)
+		}
+	}
+	return matched, nil
+}
+
+// GChatHandleRematchHandler implements service.RematchHandler for the "gchat"
+// identifier type.
+type GChatHandleRematchHandler struct {
+	base gchatRematchBase
+}
+
+// NewGChatHandleRematchHandler constructs the gchat-handle rematch handler.
+func NewGChatHandleRematchHandler(p *GChatSyncProvider, states GChatSyncStateLister, comms *repository.CommsMessageRepository, engine *aggregation.Engine) *GChatHandleRematchHandler {
+	return &GChatHandleRematchHandler{base: gchatRematchBase{provider: p, states: states, commsRepo: comms, engine: engine}}
+}
+
+// IdentifierType returns the contact_method type this handler binds to.
+func (h *GChatHandleRematchHandler) IdentifierType() string { return "gchat" }
+
+// Rematch runs the gated historical GChat scan for the newly-added gchat handle.
+func (h *GChatHandleRematchHandler) Rematch(ctx context.Context, contactID uuid.UUID, valueNormalized string) (int, error) {
+	return h.base.rematch(ctx, contactID, valueNormalized)
+}
+
+// GChatEmailRematchHandler implements service.RematchHandler for the "email"
+// identifier type. It co-registers alongside the Gmail and Calendar email
+// handlers; its gate is gchat-scoped, so it no-ops while the other email
+// handlers do their real work.
+type GChatEmailRematchHandler struct {
+	base gchatRematchBase
+}
+
+// NewGChatEmailRematchHandler constructs the gchat-email rematch handler.
+func NewGChatEmailRematchHandler(p *GChatSyncProvider, states GChatSyncStateLister, comms *repository.CommsMessageRepository, engine *aggregation.Engine) *GChatEmailRematchHandler {
+	return &GChatEmailRematchHandler{base: gchatRematchBase{provider: p, states: states, commsRepo: comms, engine: engine}}
+}
+
+// IdentifierType returns the contact_method type this handler binds to.
+func (h *GChatEmailRematchHandler) IdentifierType() string { return "email" }
+
+// Rematch runs the gated historical GChat scan for the newly-added email
+// address (GChat sender addresses ARE emails, so an email method is a valid
+// gchat identity).
+func (h *GChatEmailRematchHandler) Rematch(ctx context.Context, contactID uuid.UUID, valueNormalized string) (int, error) {
+	return h.base.rematch(ctx, contactID, valueNormalized)
+}

--- a/backend/internal/google/gchat_rematch_test.go
+++ b/backend/internal/google/gchat_rematch_test.go
@@ -1,0 +1,108 @@
+package google
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	chat "google.golang.org/api/chat/v1"
+)
+
+// fakeStateLister satisfies GChatSyncStateLister with a canned state list.
+type fakeStateLister struct {
+	states []repository.SyncState
+	err    error
+}
+
+func (f *fakeStateLister) ListEnabledSyncStates(context.Context) ([]repository.SyncState, error) {
+	return f.states, f.err
+}
+
+// noopFetcherProvider builds a provider whose fetcher factory FAILS the test if
+// it is ever called — proving the no-op gate does zero fetcher work.
+func noopFetcherProvider(t *testing.T) *GChatSyncProvider {
+	t.Helper()
+	p := &GChatSyncProvider{}
+	p.SetFetcherFactoryForTest(func(context.Context, string) (chatFetcher, error) {
+		t.Fatal("fetcher must not be built when no gchat state is enabled")
+		return nil, nil
+	})
+	p.SetMeSetForTest(map[string]struct{}{})
+	return p
+}
+
+func TestGChatHandleRematch_NoOpWhenNoEnabledState(t *testing.T) {
+	ctx := context.Background()
+	p := noopFetcherProvider(t)
+
+	// (a) zero states at all.
+	h := NewGChatHandleRematchHandler(p, &fakeStateLister{states: nil}, nil, nil)
+	n, err := h.Rematch(ctx, uuid.New(), "alice@example.test")
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+
+	// (b) an ENABLED state, but for a DIFFERENT source (email) — the gchat gate
+	// still finds zero gchat states.
+	acct := "me@example.test"
+	h2 := NewGChatHandleRematchHandler(p, &fakeStateLister{states: []repository.SyncState{
+		{Source: GmailSourceName, AccountID: &acct, Enabled: true},
+	}}, nil, nil)
+	n, err = h2.Rematch(ctx, uuid.New(), "alice@example.test")
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+}
+
+func TestGChatEmailRematch_NoOpWhenNoEnabledState(t *testing.T) {
+	ctx := context.Background()
+	p := noopFetcherProvider(t)
+
+	h := NewGChatEmailRematchHandler(p, &fakeStateLister{states: nil}, nil, nil)
+	n, err := h.Rematch(ctx, uuid.New(), "alice@example.test")
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+}
+
+func TestGChatRematch_IdentifierTypes(t *testing.T) {
+	handle := NewGChatHandleRematchHandler(nil, nil, nil, nil)
+	email := NewGChatEmailRematchHandler(nil, nil, nil, nil)
+	assert.Equal(t, "gchat", handle.IdentifierType())
+	assert.Equal(t, "email", email.IdentifierType())
+}
+
+func TestGChatRematch_EmptyAddressNoOps(t *testing.T) {
+	ctx := context.Background()
+	p := noopFetcherProvider(t)
+
+	// An empty/whitespace address normalizes to "" and short-circuits BEFORE the
+	// state gate, so a lister that would ERROR is never consulted (err stays nil).
+	h := NewGChatHandleRematchHandler(p, &fakeStateLister{err: errors.New("lister must not be called for an empty address")}, nil, nil)
+	n, err := h.Rematch(ctx, uuid.New(), "   ")
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+}
+
+// TestRestrictKnownMembers covers the rematch fan-out narrowing helper.
+func TestRestrictKnownMembers(t *testing.T) {
+	a := uuid.New()
+	b := uuid.New()
+	known := map[string][]uuid.UUID{
+		"alice@example.test": {a},
+		"bob@example.test":   {b},
+	}
+	got := restrictKnownMembers(known, "alice@example.test")
+	assert.Equal(t, map[string][]uuid.UUID{"alice@example.test": {a}}, got)
+
+	// Address not present → empty (non-nil) map.
+	got = restrictKnownMembers(known, "carol@example.test")
+	assert.Empty(t, got)
+	assert.NotNil(t, got)
+}
+
+// sanity: the fake fetcher funcs type is usable here (compile guard so the
+// cross-package seam stays exercised by this package's tests too).
+var _ = FakeChatFetcherFuncs{ListSpaces: func(context.Context, string) ([]*chat.Space, string, error) { return nil, "", nil }}

--- a/backend/internal/google/gchat_support.go
+++ b/backend/internal/google/gchat_support.go
@@ -266,18 +266,28 @@ func membershipNeedsRefresh(cached spaceMembers, lastActiveTime string, now time
 // normalized-address → []contactID entries they match, EXCLUDING any member
 // that resolves to one of the connected accounts' own emails (self is never a
 // co-member to fan out to). The map is keyed by normalized address.
+//
+// A resolver ERROR is propagated (NOT swallowed): a transient People API failure
+// for a co-member must abort the space's window so the cursor stays unadvanced
+// and the whole window retries next sweep. Swallowing it would silently drop the
+// member, produce a partial outbound fan-out, and then advance the cursor past
+// rows that were never persisted. A resolved-to-no-email member ("" with no
+// error) is simply not a known co-member.
 func resolveKnownMembers(
 	ctx context.Context,
 	members []string,
 	resolver *cachedEmailResolver,
 	knownMap map[string][]uuid.UUID,
 	meSet map[string]struct{},
-) map[string][]uuid.UUID {
+) (map[string][]uuid.UUID, error) {
 	out := make(map[string][]uuid.UUID)
 	for _, userName := range members {
 		email, err := resolver.resolve(ctx, userName)
-		if err != nil || email == "" {
-			continue // unresolved member → not a known co-member
+		if err != nil {
+			return nil, err
+		}
+		if email == "" {
+			continue // resolved to no email → not a known co-member
 		}
 		if inSet(meSet, email) {
 			continue // self
@@ -286,7 +296,7 @@ func resolveKnownMembers(
 			out[email] = contacts
 		}
 	}
-	return out
+	return out, nil
 }
 
 // --- cached email resolver -------------------------------------------

--- a/backend/internal/google/gchat_support.go
+++ b/backend/internal/google/gchat_support.go
@@ -1,0 +1,373 @@
+package google
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/logger"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/sync"
+
+	"github.com/google/uuid"
+	chat "google.golang.org/api/chat/v1"
+)
+
+// chatTimeLayout is the RFC-3339 form the Chat API returns for createTime /
+// lastActiveTime (always with fractional seconds + Z). time.RFC3339Nano parses
+// it (and the zero-fractional form) without losing precision.
+const chatTimeLayout = time.RFC3339Nano
+
+// --- metadata model --------------------------------------------------
+
+// spaceCursor is one space's create/edit watermarks (RFC-3339 strings, the
+// native Chat createTime form, compared as instants in SQL / via parseChatTime).
+type spaceCursor struct {
+	CreateCursor string `json:"create_cursor"`
+	EditCursor   string `json:"edit_cursor"`
+}
+
+// archivedCursor is a disappeared space's cursor held for restore-on-rediscovery.
+type archivedCursor struct {
+	CreateCursor string `json:"create_cursor"`
+	EditCursor   string `json:"edit_cursor"`
+	ArchivedAt   string `json:"archived_at"`
+}
+
+// spaceMembers is the cached membership of one space. version is the cached
+// lastActiveTime (drives the activity-based refresh); fetchedAt drives the
+// age-based refresh (the safety net for quiet spaces whose lastActiveTime never
+// advances). members holds "users/{id}" resource names only.
+type spaceMembers struct {
+	Version   string   `json:"version"`
+	FetchedAt string   `json:"fetched_at"`
+	Members   []string `json:"members"`
+}
+
+// cachedEmail is one id→email resolution (positive or negative). Email == ""
+// is an explicit cached negative (id resolves to no email under the granted
+// scope) — REQUIRED so a large space of non-contacts does not re-issue
+// people.get every sweep.
+type cachedEmail struct {
+	Email      string `json:"email"`
+	ResolvedAt string `json:"resolved_at"`
+}
+
+// gchatMetadata is the typed view of the gchat-owned keys in
+// external_sync_state.metadata. It is read from state.Metadata at sweep start
+// and written back (read-modify-write — only the gchat keys) at sweep end.
+type gchatMetadata struct {
+	SpaceCursors    map[string]spaceCursor
+	ArchivedCursors map[string]archivedCursor
+	SpaceMembers    map[string]spaceMembers
+	UserEmailCache  map[string]cachedEmail
+	MeIdentities    map[string]struct{}
+}
+
+// loadGChatMetadata decodes the gchat keys from the raw metadata map, tolerating
+// missing/malformed keys (a fresh state has none).
+func loadGChatMetadata(raw map[string]any) *gchatMetadata {
+	gcm := &gchatMetadata{
+		SpaceCursors:    map[string]spaceCursor{},
+		ArchivedCursors: map[string]archivedCursor{},
+		SpaceMembers:    map[string]spaceMembers{},
+		UserEmailCache:  map[string]cachedEmail{},
+		MeIdentities:    map[string]struct{}{},
+	}
+	if raw == nil {
+		return gcm
+	}
+	decodeMetaKey(raw, gchatMetaSpaceCursors, &gcm.SpaceCursors)
+	decodeMetaKey(raw, gchatMetaArchivedCursors, &gcm.ArchivedCursors)
+	decodeMetaKey(raw, gchatMetaSpaceMembers, &gcm.SpaceMembers)
+	decodeMetaKey(raw, gchatMetaUserEmailCache, &gcm.UserEmailCache)
+
+	var ids []string
+	decodeMetaKey(raw, gchatMetaMeIdentities, &ids)
+	for _, id := range ids {
+		if id != "" {
+			gcm.MeIdentities[id] = struct{}{}
+		}
+	}
+	return gcm
+}
+
+// decodeMetaKey round-trips one metadata key through JSON into dst, ignoring
+// absent/malformed values (the gchat keys are best-effort caches).
+func decodeMetaKey(raw map[string]any, key string, dst any) {
+	v, ok := raw[key]
+	if !ok {
+		return
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return
+	}
+	_ = json.Unmarshal(b, dst)
+}
+
+// cursorFor returns the cursor for a space, seeding both watermarks to the
+// backfill floor on first sight.
+func (g *gchatMetadata) cursorFor(spaceName, backfillFloor string) spaceCursor {
+	if cur, ok := g.SpaceCursors[spaceName]; ok {
+		if cur.CreateCursor == "" {
+			cur.CreateCursor = backfillFloor
+		}
+		if cur.EditCursor == "" {
+			cur.EditCursor = backfillFloor
+		}
+		return cur
+	}
+	return spaceCursor{CreateCursor: backfillFloor, EditCursor: backfillFloor}
+}
+
+func (g *gchatMetadata) setCursor(spaceName string, cur spaceCursor) {
+	g.SpaceCursors[spaceName] = cur
+}
+
+// writeInto merges the gchat keys back into the raw metadata map (read-modify-
+// write: never replaces the whole blob; non-gchat keys are preserved by the
+// caller passing the existing map).
+func (g *gchatMetadata) writeInto(raw map[string]any) map[string]any {
+	if raw == nil {
+		raw = map[string]any{}
+	}
+	raw[gchatMetaSpaceCursors] = g.SpaceCursors
+	raw[gchatMetaArchivedCursors] = g.ArchivedCursors
+	raw[gchatMetaSpaceMembers] = g.SpaceMembers
+	raw[gchatMetaUserEmailCache] = g.UserEmailCache
+	ids := make([]string, 0, len(g.MeIdentities))
+	for id := range g.MeIdentities {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	raw[gchatMetaMeIdentities] = ids
+	return raw
+}
+
+// gchatBackfillFloor returns the per-state onboarding floor as an RFC-3339
+// timestamp string (start-of-day UTC), reusing the email backfill_since key so
+// the two Google sources share one onboarding knob.
+func gchatBackfillFloor(metadata map[string]any) string {
+	epoch := sync.EmailBackfillFloorEpoch(metadata)
+	return time.Unix(epoch, 0).UTC().Format(chatTimeLayout)
+}
+
+// --- stale-cursor reaper + restore -----------------------------------
+
+// reapStaleCursors reconciles space_cursors against the authoritative live
+// spaces.list: cursors for vanished spaces move to archived_space_cursors (30d
+// grace), reappeared spaces restore their archived cursor, and over-grace
+// archived entries are dropped. Logs counts only (never resource names).
+func reapStaleCursors(g *gchatMetadata, spaces []*chat.Space, now time.Time) {
+	live := make(map[string]struct{}, len(spaces))
+	for _, s := range spaces {
+		if s != nil && s.Name != "" {
+			live[s.Name] = struct{}{}
+		}
+	}
+
+	archivedCount := 0
+	for name, cur := range g.SpaceCursors {
+		if _, ok := live[name]; !ok {
+			g.ArchivedCursors[name] = archivedCursor{
+				CreateCursor: cur.CreateCursor,
+				EditCursor:   cur.EditCursor,
+				ArchivedAt:   now.Format(chatTimeLayout),
+			}
+			delete(g.SpaceCursors, name)
+			archivedCount++
+		}
+	}
+
+	restoredCount := 0
+	for name := range live {
+		if arch, ok := g.ArchivedCursors[name]; ok {
+			g.SpaceCursors[name] = spaceCursor{
+				CreateCursor: arch.CreateCursor,
+				EditCursor:   arch.EditCursor,
+			}
+			delete(g.ArchivedCursors, name)
+			restoredCount++
+		}
+	}
+
+	droppedCount := 0
+	for name, arch := range g.ArchivedCursors {
+		archivedAt, err := time.Parse(chatTimeLayout, arch.ArchivedAt)
+		if err != nil || now.Sub(archivedAt) > gchatArchivedCursorGrace {
+			delete(g.ArchivedCursors, name)
+			droppedCount++
+		}
+	}
+
+	if archivedCount > 0 || restoredCount > 0 || droppedCount > 0 {
+		logger.Info().
+			Str("source", GChatSourceName).
+			Int("archived", archivedCount).
+			Int("restored", restoredCount).
+			Int("dropped", droppedCount).
+			Msg("gchat: reconciled stale space cursors")
+	}
+}
+
+// --- membership resolution + cache -----------------------------------
+
+// resolveMembership returns the "users/{id}" member set for a space, using the
+// cached list unless the activity-based (lastActiveTime advanced) or age-based
+// (fetched_at older than TTL) trigger fires. Returns the number of ListMembers
+// pages fetched (0 on a cache hit) for the sweep window budget.
+func (p *GChatSyncProvider) resolveMembership(
+	ctx context.Context,
+	fetcher chatFetcher,
+	space *chat.Space,
+	g *gchatMetadata,
+) (members []string, pages int, err error) {
+	now := accelerated.GetCurrentTime()
+	cached, ok := g.SpaceMembers[space.Name]
+	if ok && !membershipNeedsRefresh(cached, space.LastActiveTime, now) {
+		return cached.Members, 0, nil
+	}
+
+	fetched, pages, err := paginateMembers(ctx, fetcher, space.Name)
+	if err != nil {
+		return nil, pages, err
+	}
+	g.SpaceMembers[space.Name] = spaceMembers{
+		Version:   space.LastActiveTime,
+		FetchedAt: now.Format(chatTimeLayout),
+		Members:   fetched,
+	}
+	return fetched, pages, nil
+}
+
+// membershipNeedsRefresh reports whether a cached membership must be refetched:
+// the space's lastActiveTime advanced past the cached version, OR the cache is
+// older than the TTL (the quiet-space safety net).
+func membershipNeedsRefresh(cached spaceMembers, lastActiveTime string, now time.Time) bool {
+	if lastActiveTime != "" && lastActiveTime != cached.Version {
+		if newer, ok := chatTimeAfter(lastActiveTime, cached.Version); ok && newer {
+			return true
+		}
+		if cached.Version == "" {
+			return true
+		}
+	}
+	fetchedAt, err := time.Parse(chatTimeLayout, cached.FetchedAt)
+	if err != nil {
+		return true // unparseable/absent fetched_at → refetch
+	}
+	return now.Sub(fetchedAt) > gchatMembershipCacheTTL
+}
+
+// resolveKnownMembers maps a space's "users/{id}" members to the
+// normalized-address → []contactID entries they match, EXCLUDING any member
+// that resolves to one of the connected accounts' own emails (self is never a
+// co-member to fan out to). The map is keyed by normalized address.
+func resolveKnownMembers(
+	ctx context.Context,
+	members []string,
+	resolver *cachedEmailResolver,
+	knownMap map[string][]uuid.UUID,
+	meSet map[string]struct{},
+) map[string][]uuid.UUID {
+	out := make(map[string][]uuid.UUID)
+	for _, userName := range members {
+		email, err := resolver.resolve(ctx, userName)
+		if err != nil || email == "" {
+			continue // unresolved member → not a known co-member
+		}
+		if inSet(meSet, email) {
+			continue // self
+		}
+		if contacts := knownMap[email]; len(contacts) > 0 {
+			out[email] = contacts
+		}
+	}
+	return out
+}
+
+// --- cached email resolver -------------------------------------------
+
+// cachedEmailResolver resolves "users/{id}" → normalized email, backed by the
+// persisted metadata cache (positive AND negative entries, 24h TTL) plus an
+// in-sweep memo. New/refreshed resolutions are accumulated in dirty so the
+// provider can fold them back into metadata after the sweep.
+type cachedEmailResolver struct {
+	fetcher chatFetcher
+	cache   map[string]cachedEmail
+	memo    map[string]string // userName → email (in-sweep, includes "" negatives)
+	dirty   bool
+}
+
+func newCachedEmailResolver(fetcher chatFetcher, cache map[string]cachedEmail) *cachedEmailResolver {
+	if cache == nil {
+		cache = map[string]cachedEmail{}
+	}
+	return &cachedEmailResolver{
+		fetcher: fetcher,
+		cache:   cache,
+		memo:    map[string]string{},
+	}
+}
+
+// resolve returns the normalized email for a "users/{id}" name ("" for an
+// unresolved/no-email sender). A people.get error propagates (so the caller can
+// abort the window and retry), but a resolved-to-no-email result is a cached
+// negative, not an error.
+func (r *cachedEmailResolver) resolve(ctx context.Context, userName string) (string, error) {
+	if userName == "" {
+		return "", nil
+	}
+	if email, ok := r.memo[userName]; ok {
+		return email, nil
+	}
+	if entry, ok := r.cache[userName]; ok && !cachedEmailExpired(entry) {
+		r.memo[userName] = entry.Email
+		return entry.Email, nil
+	}
+
+	email, err := r.fetcher.ResolvePersonEmail(ctx, userName)
+	if err != nil {
+		return "", err
+	}
+	r.memo[userName] = email
+	r.cache[userName] = cachedEmail{
+		Email:      email,
+		ResolvedAt: accelerated.GetCurrentTime().Format(chatTimeLayout),
+	}
+	r.dirty = true
+	return email, nil
+}
+
+// snapshot returns the (possibly-grown) cache for persistence.
+func (r *cachedEmailResolver) snapshot() map[string]cachedEmail {
+	return r.cache
+}
+
+func cachedEmailExpired(entry cachedEmail) bool {
+	resolvedAt, err := time.Parse(chatTimeLayout, entry.ResolvedAt)
+	if err != nil {
+		return true
+	}
+	return accelerated.GetCurrentTime().Sub(resolvedAt) > gchatMembershipCacheTTL
+}
+
+// --- metadata persistence --------------------------------------------
+
+// persistMetadata folds the resolver's grown email cache into the typed
+// metadata and writes the merged gchat keys back via UpdateSyncStateMetadata
+// (read-modify-write of state.Metadata — only the gchat keys change).
+func (p *GChatSyncProvider) persistMetadata(
+	ctx context.Context,
+	state *repository.SyncState,
+	g *gchatMetadata,
+	resolver *cachedEmailResolver,
+) error {
+	g.UserEmailCache = resolver.snapshot()
+	merged := g.writeInto(state.Metadata)
+	_, err := p.syncRepo.UpdateSyncStateMetadata(ctx, state.ID, merged)
+	return err
+}

--- a/backend/internal/google/gchat_support.go
+++ b/backend/internal/google/gchat_support.go
@@ -219,28 +219,38 @@ func reapStaleCursors(g *gchatMetadata, spaces []*chat.Space, now time.Time) {
 // cached list unless the activity-based (lastActiveTime advanced) or age-based
 // (fetched_at older than TTL) trigger fires. Returns the number of ListMembers
 // pages fetched (0 on a cache hit) for the sweep window budget.
+// resolveMembership returns the cached members on a cache hit (incomplete=false,
+// no budget consumed). On a miss/refresh it pages membership against the shared
+// budget; if the budget runs out before the membership is fully paged it returns
+// incomplete=true and does NOT cache the partial list — the caller skips the
+// space and retries it next sweep (a partial member list would break the
+// fan-out).
 func (p *GChatSyncProvider) resolveMembership(
 	ctx context.Context,
 	fetcher chatFetcher,
 	space *chat.Space,
 	g *gchatMetadata,
-) (members []string, pages int, err error) {
+	budget *int,
+) (members []string, incomplete bool, err error) {
 	now := accelerated.GetCurrentTime()
 	cached, ok := g.SpaceMembers[space.Name]
 	if ok && !membershipNeedsRefresh(cached, space.LastActiveTime, now) {
-		return cached.Members, 0, nil
+		return cached.Members, false, nil
 	}
 
-	fetched, pages, err := paginateMembers(ctx, fetcher, space.Name)
+	fetched, _, incomplete, err := paginateMembers(ctx, fetcher, space.Name, budget)
 	if err != nil {
-		return nil, pages, err
+		return nil, false, err
+	}
+	if incomplete {
+		return nil, true, nil
 	}
 	g.SpaceMembers[space.Name] = spaceMembers{
 		Version:   space.LastActiveTime,
 		FetchedAt: now.Format(chatTimeLayout),
 		Members:   fetched,
 	}
-	return fetched, pages, nil
+	return fetched, false, nil
 }
 
 // membershipNeedsRefresh reports whether a cached membership must be refetched:

--- a/backend/internal/google/gchat_test.go
+++ b/backend/internal/google/gchat_test.go
@@ -386,6 +386,23 @@ func TestFirstN(t *testing.T) {
 	assert.Equal(t, "héll", firstN("héllo", 4))
 }
 
+func TestEditLookbackFloor(t *testing.T) {
+	backfill := "2026-01-01T00:00:00Z"
+
+	// createCursor − 7d is AFTER the backfill floor → use the lookback.
+	got := editLookbackFloor("2026-06-04T00:00:00Z", backfill)
+	want := "2026-05-28T00:00:00Z" // 7 days before
+	assert.Equal(t, want, got)
+
+	// createCursor − 7d is BEFORE the backfill floor → clamp to backfill.
+	got = editLookbackFloor("2026-01-03T00:00:00Z", backfill)
+	assert.Equal(t, backfill, got)
+
+	// Unparseable createCursor → fall back to backfill (the safe wider scan).
+	got = editLookbackFloor("not-a-time", backfill)
+	assert.Equal(t, backfill, got)
+}
+
 func TestBuildContentMetadata(t *testing.T) {
 	space := &chat.Space{Name: "spaces/A", SpaceType: "SPACE"}
 	m := &chat.Message{

--- a/backend/internal/google/gchat_test.go
+++ b/backend/internal/google/gchat_test.go
@@ -3,6 +3,7 @@ package google
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
@@ -183,12 +184,25 @@ func TestResolveKnownMembers_ResolvesAndExcludesSelf(t *testing.T) {
 	meSet := map[string]struct{}{"me@example.test": {}}
 
 	members := []string{"users/alice", "users/me", "users/unknown", "users/noemail"}
-	known := resolveKnownMembers(ctx, members, resolver, knownMap, meSet)
+	known, err := resolveKnownMembers(ctx, members, resolver, knownMap, meSet)
+	require.NoError(t, err)
 
 	// Only Alice is a known co-member; me is excluded, unknown is not in knownMap,
 	// noemail is unresolvable.
 	require.Len(t, known, 1)
 	assert.Equal(t, []uuid.UUID{alice}, known["alice@example.test"])
+}
+
+func TestResolveKnownMembers_PropagatesResolveError(t *testing.T) {
+	ctx := context.Background()
+	resolveErr := errors.New("people api transient")
+	fetcher := &fakeChatFetcher{funcs: FakeChatFetcherFuncs{
+		ResolvePersonEmail: func(context.Context, string) (string, error) { return "", resolveErr },
+	}}
+	resolver := newCachedEmailResolver(fetcher, nil)
+
+	_, err := resolveKnownMembers(ctx, []string{"users/alice"}, resolver, map[string][]uuid.UUID{}, map[string]struct{}{})
+	require.ErrorIs(t, err, resolveErr, "a transient co-member resolve error must propagate, not be swallowed")
 }
 
 func TestCachedEmailResolver_PositiveNegativeCachingAndTTL(t *testing.T) {
@@ -384,6 +398,77 @@ func TestFirstN(t *testing.T) {
 	assert.Equal(t, "abc", firstN("abc", 10))
 	// Rune-safe: a multi-byte rune is not split mid-byte.
 	assert.Equal(t, "héll", firstN("héllo", 4))
+}
+
+// TestConsumeContentWindow_BudgetExhaustionKeepsCursor proves that when the
+// shared budget runs out before a multi-page window is fully paged, the window
+// returns proven=false and the ORIGINAL cursor (so the caller does NOT advance
+// past an un-listed page).
+func TestConsumeContentWindow_BudgetExhaustionKeepsCursor(t *testing.T) {
+	ctx := context.Background()
+
+	// A fetcher that always reports another page (never returns next == "").
+	pageCalls := 0
+	fetcher := &fakeChatFetcher{funcs: FakeChatFetcherFuncs{
+		ListMessages: func(_ context.Context, _, _ string, showDeleted bool, _ string) ([]*chat.Message, string, error) {
+			pageCalls++
+			// No qualifying messages; always another page.
+			return nil, "next-token", nil
+		},
+		ResolvePersonEmail: func(context.Context, string) (string, error) { return "", nil },
+	}}
+	resolver := newCachedEmailResolver(fetcher, nil)
+	p := &GChatSyncProvider{}
+	counters := &sweepCounters{}
+	budget := 3
+	floor := "2026-01-01T00:00:00Z"
+
+	newCursor, proven, err := p.consumeContentWindow(ctx, fetcher,
+		&chat.Space{Name: "spaces/B", SpaceType: "SPACE"}, floor,
+		map[string][]uuid.UUID{}, map[string][]uuid.UUID{}, map[string]struct{}{},
+		resolver, "acct", counters, &budget)
+	require.NoError(t, err)
+	assert.False(t, proven, "an un-finished window is NOT proven")
+	assert.Equal(t, floor, newCursor, "cursor must NOT advance past an un-listed page")
+	assert.Equal(t, 0, budget, "budget fully consumed")
+	assert.Equal(t, 3, pageCalls, "exactly the budgeted number of pages were fetched")
+}
+
+// TestConsumeContentWindow_FullyPagedIsProven proves a window that pages to
+// completion (next == "") returns proven=true and advances to maxCreate.
+func TestConsumeContentWindow_FullyPagedIsProven(t *testing.T) {
+	ctx := context.Background()
+	alice := uuid.New()
+	msgTime := "2026-06-04T10:00:00Z"
+	fetcher := &fakeChatFetcher{funcs: FakeChatFetcherFuncs{
+		ListMessages: func(_ context.Context, _, _ string, _ bool, token string) ([]*chat.Message, string, error) {
+			if token == "" {
+				return []*chat.Message{humanMsg("spaces/B/messages/1", "users/alice", msgTime, "hi")}, "", nil
+			}
+			return nil, "", nil
+		},
+		ResolvePersonEmail: func(_ context.Context, u string) (string, error) {
+			if u == "users/alice" {
+				return "alice@example.test", nil
+			}
+			return "", nil
+		},
+	}}
+	resolver := newCachedEmailResolver(fetcher, nil)
+	p := &GChatSyncProvider{commsRepo: nil}
+	// Inbound from a known sender → classifyMessage returns Matched; but upsert
+	// needs commsRepo. To keep this DB-free, use a bystander (unknown) sender so
+	// no upsert happens but the page still advances maxCreate.
+	counters := &sweepCounters{}
+	budget := 10
+	floor := "2026-01-01T00:00:00Z"
+	newCursor, proven, err := p.consumeContentWindow(ctx, fetcher,
+		&chat.Space{Name: "spaces/B", SpaceType: "SPACE"}, floor,
+		map[string][]uuid.UUID{}, map[string][]uuid.UUID{"someone-else@example.test": {alice}}, map[string]struct{}{},
+		resolver, "acct", counters, &budget)
+	require.NoError(t, err)
+	assert.True(t, proven, "a fully-paged window is proven")
+	assert.Equal(t, msgTime, newCursor, "cursor advances to the max createTime seen")
 }
 
 func TestEditLookbackFloor(t *testing.T) {

--- a/backend/internal/google/gchat_test.go
+++ b/backend/internal/google/gchat_test.go
@@ -471,6 +471,70 @@ func TestConsumeContentWindow_FullyPagedIsProven(t *testing.T) {
 	assert.Equal(t, msgTime, newCursor, "cursor advances to the max createTime seen")
 }
 
+// TestConsumeContentWindow_CursorAdvancesByInstantNotLexical proves the cursor
+// advances to the chronologically-latest createTime even when an EARLIER-listed
+// message has a HIGHER fractional-second precision than a same-second
+// later-listed message. "...00.001Z" is chronologically newer than "...00Z" but
+// sorts lexically SMALLER (the '.' byte < the 'Z' byte); a raw string compare
+// would leave the cursor at "...00Z" and re-list the ".001Z" message every
+// sweep. The cursor must end at "...00.001Z".
+func TestConsumeContentWindow_CursorAdvancesByInstantNotLexical(t *testing.T) {
+	ctx := context.Background()
+	fracMsg := "2026-06-04T10:00:00.001Z" // chronologically LATER, lexically SMALLER
+	zMsg := "2026-06-04T10:00:00Z"        // chronologically EARLIER, lexically LARGER
+	fetcher := &fakeChatFetcher{funcs: FakeChatFetcherFuncs{
+		ListMessages: func(_ context.Context, _, _ string, _ bool, token string) ([]*chat.Message, string, error) {
+			if token == "" {
+				// The ".001Z" message is listed FIRST; the same-second "Z" message
+				// SECOND. A lexical max would wrongly pick "Z" (the later string).
+				return []*chat.Message{
+					humanMsg("spaces/B/messages/frac", "users/x", fracMsg, "a"),
+					humanMsg("spaces/B/messages/z", "users/x", zMsg, "b"),
+				}, "", nil
+			}
+			return nil, "", nil
+		},
+		// Bystander sender → no upsert (DB-free), but createTime still advances.
+		ResolvePersonEmail: func(context.Context, string) (string, error) { return "stranger@example.test", nil },
+	}}
+	resolver := newCachedEmailResolver(fetcher, nil)
+	p := &GChatSyncProvider{commsRepo: nil}
+	counters := &sweepCounters{}
+	budget := 10
+	floor := "2026-01-01T00:00:00Z"
+	newCursor, proven, err := p.consumeContentWindow(ctx, fetcher,
+		&chat.Space{Name: "spaces/B", SpaceType: "SPACE"}, floor,
+		map[string][]uuid.UUID{}, map[string][]uuid.UUID{}, map[string]struct{}{},
+		resolver, "acct", counters, &budget)
+	require.NoError(t, err)
+	assert.True(t, proven)
+	assert.Equal(t, fracMsg, newCursor,
+		"cursor must advance to the chronologically-latest createTime, not the lexically-largest")
+}
+
+// TestLaterChatTime pins the instant-comparison cursor primitive directly.
+func TestLaterChatTime(t *testing.T) {
+	// Fractional-second: ".001Z" is chronologically later than "Z" despite
+	// sorting lexically smaller.
+	assert.Equal(t, "2026-06-04T10:00:00.001Z",
+		laterChatTime("2026-06-04T10:00:00Z", "2026-06-04T10:00:00.001Z"))
+	// Reverse order of args → same chronological winner.
+	assert.Equal(t, "2026-06-04T10:00:00.001Z",
+		laterChatTime("2026-06-04T10:00:00.001Z", "2026-06-04T10:00:00Z"))
+	// Strictly later candidate wins.
+	assert.Equal(t, "2026-06-04T11:00:00Z",
+		laterChatTime("2026-06-04T10:00:00Z", "2026-06-04T11:00:00Z"))
+	// Earlier candidate is ignored (keep current).
+	assert.Equal(t, "2026-06-04T11:00:00Z",
+		laterChatTime("2026-06-04T11:00:00Z", "2026-06-04T10:00:00Z"))
+	// Unparseable candidate → keep current (fallback).
+	assert.Equal(t, "2026-06-04T10:00:00Z",
+		laterChatTime("2026-06-04T10:00:00Z", "not-a-time"))
+	// Unparseable current → keep current (we can't prove candidate is later).
+	assert.Equal(t, "bad-current",
+		laterChatTime("bad-current", "2026-06-04T10:00:00Z"))
+}
+
 // TestPaginateMembers_BudgetIncomplete proves membership pagination stops and
 // signals incomplete=true when the shared budget runs out before the member
 // list is fully paged (so the caller does not act on a partial list).

--- a/backend/internal/google/gchat_test.go
+++ b/backend/internal/google/gchat_test.go
@@ -471,6 +471,45 @@ func TestConsumeContentWindow_FullyPagedIsProven(t *testing.T) {
 	assert.Equal(t, msgTime, newCursor, "cursor advances to the max createTime seen")
 }
 
+// TestPaginateMembers_BudgetIncomplete proves membership pagination stops and
+// signals incomplete=true when the shared budget runs out before the member
+// list is fully paged (so the caller does not act on a partial list).
+func TestPaginateMembers_BudgetIncomplete(t *testing.T) {
+	ctx := context.Background()
+	fetcher := &fakeChatFetcher{funcs: FakeChatFetcherFuncs{
+		ListMembers: func(_ context.Context, _, _ string) ([]*chat.Membership, string, error) {
+			// Always another page → never completes on its own.
+			return []*chat.Membership{membershipForTest("users/x")}, "more", nil
+		},
+	}}
+	budget := 2
+	names, pages, incomplete, err := paginateMembers(ctx, fetcher, "spaces/M", &budget)
+	require.NoError(t, err)
+	assert.True(t, incomplete, "budget exhausted before full paging → incomplete")
+	assert.Equal(t, 2, pages, "exactly the budgeted pages were fetched")
+	assert.Equal(t, 0, budget)
+	assert.Len(t, names, 2, "collected the members from the budgeted pages")
+
+	// A membership that completes within budget is NOT incomplete.
+	fetcher2 := &fakeChatFetcher{funcs: FakeChatFetcherFuncs{
+		ListMembers: func(_ context.Context, _, token string) ([]*chat.Membership, string, error) {
+			if token == "" {
+				return []*chat.Membership{membershipForTest("users/a"), membershipForTest("users/b")}, "", nil
+			}
+			return nil, "", nil
+		},
+	}}
+	budget2 := 10
+	names2, _, incomplete2, err := paginateMembers(ctx, fetcher2, "spaces/M2", &budget2)
+	require.NoError(t, err)
+	assert.False(t, incomplete2)
+	assert.ElementsMatch(t, []string{"users/a", "users/b"}, names2)
+}
+
+func membershipForTest(userName string) *chat.Membership {
+	return &chat.Membership{State: "JOINED", Member: &chat.User{Name: userName, Type: "HUMAN"}}
+}
+
 func TestEditLookbackFloor(t *testing.T) {
 	backfill := "2026-01-01T00:00:00Z"
 

--- a/backend/internal/google/gchat_test.go
+++ b/backend/internal/google/gchat_test.go
@@ -1,0 +1,406 @@
+package google
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	chat "google.golang.org/api/chat/v1"
+	people "google.golang.org/api/people/v1"
+)
+
+// staticResolver builds a resolver whose fake ResolvePersonEmail returns a
+// fixed mapping (and counts calls), with no caching from a prior cache.
+func staticResolver(t *testing.T, mapping map[string]string, callCount *int) *cachedEmailResolver {
+	t.Helper()
+	fetcher := &fakeChatFetcher{funcs: FakeChatFetcherFuncs{
+		ResolvePersonEmail: func(_ context.Context, userName string) (string, error) {
+			if callCount != nil {
+				*callCount++
+			}
+			return mapping[userName], nil
+		},
+	}}
+	return newCachedEmailResolver(fetcher, nil)
+}
+
+func humanMsg(name, senderName, createTime, text string) *chat.Message {
+	return &chat.Message{
+		Name:       name,
+		Sender:     &chat.User{Name: senderName, Type: gchatUserTypeHuman},
+		CreateTime: createTime,
+		Text:       text,
+	}
+}
+
+func TestClassifyMessage_InboundSenderOnly(t *testing.T) {
+	ctx := context.Background()
+	alice := uuid.New()
+	bob := uuid.New()
+	carol := uuid.New()
+	resolver := staticResolver(t, map[string]string{
+		"users/alice": "alice@example.test",
+		"users/bob":   "bob@example.test",
+		"users/carol": "carol@example.test",
+	}, nil)
+	knownMap := map[string][]uuid.UUID{
+		"alice@example.test": {alice},
+		"bob@example.test":   {bob},
+		"carol@example.test": {carol},
+	}
+	knownMembers := map[string][]uuid.UUID{
+		"alice@example.test": {alice},
+		"bob@example.test":   {bob},
+		"carol@example.test": {carol},
+	}
+	meSet := map[string]struct{}{"me@example.test": {}}
+
+	m := humanMsg("spaces/S/messages/1", "users/alice", "2026-06-04T10:00:00Z", "hi all")
+	c, err := classifyMessage(ctx, m, knownMembers, knownMap, meSet, resolver)
+	require.NoError(t, err)
+	assert.Equal(t, "inbound", c.Direction)
+	// Sender-only: exactly Alice, NOT Bob/Carol.
+	assert.Equal(t, []uuid.UUID{alice}, c.Matched)
+}
+
+func TestClassifyMessage_OutboundFanOut(t *testing.T) {
+	ctx := context.Background()
+	alice := uuid.New()
+	bob := uuid.New()
+	resolver := staticResolver(t, map[string]string{
+		"users/me":    "me@example.test",
+		"users/alice": "alice@example.test",
+		"users/bob":   "bob@example.test",
+	}, nil)
+	knownMap := map[string][]uuid.UUID{
+		"alice@example.test": {alice},
+		"bob@example.test":   {bob},
+	}
+	knownMembers := map[string][]uuid.UUID{
+		"alice@example.test": {alice},
+		"bob@example.test":   {bob},
+	}
+	meSet := map[string]struct{}{"me@example.test": {}}
+
+	m := humanMsg("spaces/S/messages/2", "users/me", "2026-06-04T10:01:00Z", "hello")
+	c, err := classifyMessage(ctx, m, knownMembers, knownMap, meSet, resolver)
+	require.NoError(t, err)
+	assert.Equal(t, "outbound", c.Direction)
+	assert.ElementsMatch(t, []uuid.UUID{alice, bob}, c.Matched)
+}
+
+func TestClassifyMessage_OutboundExcludesSelfContact(t *testing.T) {
+	ctx := context.Background()
+	alice := uuid.New()
+	selfContact := uuid.New()
+	resolver := staticResolver(t, map[string]string{
+		"users/me":    "me@example.test",
+		"users/alice": "alice@example.test",
+		"users/self":  "me@example.test", // a co-member resolving to my own email
+	}, nil)
+	knownMap := map[string][]uuid.UUID{
+		"alice@example.test": {alice},
+		"me@example.test":    {selfContact}, // the user's own email is also a CRM contact
+	}
+	// knownMembers built via resolveKnownMembers excludes self; simulate that the
+	// classify fan-out also excludes any address in meSet defensively.
+	knownMembers := map[string][]uuid.UUID{
+		"alice@example.test": {alice},
+		"me@example.test":    {selfContact},
+	}
+	meSet := map[string]struct{}{"me@example.test": {}}
+
+	m := humanMsg("spaces/S/messages/3", "users/me", "2026-06-04T10:02:00Z", "hi")
+	c, err := classifyMessage(ctx, m, knownMembers, knownMap, meSet, resolver)
+	require.NoError(t, err)
+	assert.Equal(t, "outbound", c.Direction)
+	// The self-contact must NOT receive a self-attributed outreach row.
+	assert.Equal(t, []uuid.UUID{alice}, c.Matched)
+}
+
+func TestClassifyMessage_BystanderAndUnresolved(t *testing.T) {
+	ctx := context.Background()
+	alice := uuid.New()
+	resolver := staticResolver(t, map[string]string{
+		"users/stranger": "stranger@example.test", // resolvable but unknown
+		"users/ghost":    "",                      // unresolvable → no email
+	}, nil)
+	knownMap := map[string][]uuid.UUID{"alice@example.test": {alice}}
+	meSet := map[string]struct{}{"me@example.test": {}}
+
+	// Bystander: sender neither me nor known.
+	mBy := humanMsg("spaces/S/messages/4", "users/stranger", "2026-06-04T10:03:00Z", "hey")
+	c, err := classifyMessage(ctx, mBy, nil, knownMap, meSet, resolver)
+	require.NoError(t, err)
+	assert.Empty(t, c.Matched)
+	assert.False(t, c.Unresolved)
+
+	// Unresolved sender: resolves to "" → flagged Unresolved, no rows.
+	mUn := humanMsg("spaces/S/messages/5", "users/ghost", "2026-06-04T10:04:00Z", "hey")
+	c, err = classifyMessage(ctx, mUn, nil, knownMap, meSet, resolver)
+	require.NoError(t, err)
+	assert.Empty(t, c.Matched)
+	assert.True(t, c.Unresolved)
+}
+
+func TestQualifiableContentMessage_FiltersBotsTombstonesNameless(t *testing.T) {
+	// Human content message qualifies.
+	assert.True(t, qualifiableContentMessage(humanMsg("spaces/S/messages/6", "users/a", "2026-06-04T10:00:00Z", "x")))
+
+	// Bot sender filtered.
+	bot := &chat.Message{Name: "spaces/S/messages/7", Sender: &chat.User{Name: "users/bot", Type: "BOT"}, CreateTime: "2026-06-04T10:00:00Z"}
+	assert.False(t, qualifiableContentMessage(bot))
+
+	// Tombstone filtered.
+	tomb := &chat.Message{Name: "spaces/S/messages/8", Sender: &chat.User{Name: "users/a", Type: gchatUserTypeHuman}, DeletionMetadata: &chat.DeletionMetadata{}}
+	assert.False(t, qualifiableContentMessage(tomb))
+
+	// Nameless filtered.
+	nameless := &chat.Message{Sender: &chat.User{Name: "users/a", Type: gchatUserTypeHuman}}
+	assert.False(t, qualifiableContentMessage(nameless))
+
+	// Nil sender filtered.
+	noSender := &chat.Message{Name: "spaces/S/messages/9"}
+	assert.False(t, qualifiableContentMessage(noSender))
+}
+
+func TestResolveKnownMembers_ResolvesAndExcludesSelf(t *testing.T) {
+	ctx := context.Background()
+	alice := uuid.New()
+	resolver := staticResolver(t, map[string]string{
+		"users/alice":   "alice@example.test",
+		"users/me":      "me@example.test",
+		"users/unknown": "unknown@example.test",
+		"users/noemail": "",
+	}, nil)
+	knownMap := map[string][]uuid.UUID{"alice@example.test": {alice}}
+	meSet := map[string]struct{}{"me@example.test": {}}
+
+	members := []string{"users/alice", "users/me", "users/unknown", "users/noemail"}
+	known := resolveKnownMembers(ctx, members, resolver, knownMap, meSet)
+
+	// Only Alice is a known co-member; me is excluded, unknown is not in knownMap,
+	// noemail is unresolvable.
+	require.Len(t, known, 1)
+	assert.Equal(t, []uuid.UUID{alice}, known["alice@example.test"])
+}
+
+func TestCachedEmailResolver_PositiveNegativeCachingAndTTL(t *testing.T) {
+	ctx := context.Background()
+	calls := 0
+	resolver := staticResolver(t, map[string]string{
+		"users/alice": "alice@example.test",
+		"users/ghost": "", // negative
+	}, &calls)
+
+	// First resolve hits the fetcher.
+	email, err := resolver.resolve(ctx, "users/alice")
+	require.NoError(t, err)
+	assert.Equal(t, "alice@example.test", email)
+	assert.Equal(t, 1, calls)
+
+	// In-sweep memo: second resolve does NOT hit the fetcher.
+	email, err = resolver.resolve(ctx, "users/alice")
+	require.NoError(t, err)
+	assert.Equal(t, "alice@example.test", email)
+	assert.Equal(t, 1, calls)
+
+	// Negative result is cached too (one fetcher call, then memoized).
+	email, err = resolver.resolve(ctx, "users/ghost")
+	require.NoError(t, err)
+	assert.Equal(t, "", email)
+	assert.Equal(t, 2, calls)
+	email, err = resolver.resolve(ctx, "users/ghost")
+	require.NoError(t, err)
+	assert.Equal(t, "", email)
+	assert.Equal(t, 2, calls, "negative result re-served from cache, not re-fetched")
+
+	// Cross-sweep: a persisted cache entry within TTL is reused (no fetch).
+	now := accelerated.GetCurrentTime()
+	persisted := map[string]cachedEmail{
+		"users/bob": {Email: "bob@example.test", ResolvedAt: now.Add(-time.Hour).Format(chatTimeLayout)},
+	}
+	calls2 := 0
+	fresh := &cachedEmailResolver{
+		fetcher: &fakeChatFetcher{funcs: FakeChatFetcherFuncs{ResolvePersonEmail: func(context.Context, string) (string, error) { calls2++; return "SHOULD-NOT-CALL", nil }}},
+		cache:   persisted,
+		memo:    map[string]string{},
+	}
+	email, err = fresh.resolve(ctx, "users/bob")
+	require.NoError(t, err)
+	assert.Equal(t, "bob@example.test", email)
+	assert.Equal(t, 0, calls2, "within-TTL cache entry reused")
+
+	// Expired cache entry (older than TTL) is refetched.
+	persisted["users/bob"] = cachedEmail{Email: "stale@example.test", ResolvedAt: now.Add(-25 * time.Hour).Format(chatTimeLayout)}
+	delete(fresh.memo, "users/bob")
+	email, err = fresh.resolve(ctx, "users/bob")
+	require.NoError(t, err)
+	assert.Equal(t, "SHOULD-NOT-CALL", email) // refetched value
+	assert.Equal(t, 1, calls2, "expired cache entry refetched")
+}
+
+func TestMembershipNeedsRefresh(t *testing.T) {
+	now := accelerated.GetCurrentTime()
+	fresh := now.Add(-time.Hour).Format(chatTimeLayout)
+	old := now.Add(-25 * time.Hour).Format(chatTimeLayout)
+
+	// Within TTL, lastActiveTime unchanged → reuse.
+	cached := spaceMembers{Version: "2026-06-04T09:00:00Z", FetchedAt: fresh, Members: []string{"users/a"}}
+	assert.False(t, membershipNeedsRefresh(cached, "2026-06-04T09:00:00Z", now))
+
+	// lastActiveTime advanced → refetch.
+	assert.True(t, membershipNeedsRefresh(cached, "2026-06-04T11:00:00Z", now))
+
+	// Age exceeds TTL even though lastActiveTime unchanged → refetch (quiet-space
+	// safety net).
+	cachedOld := spaceMembers{Version: "2026-06-04T09:00:00Z", FetchedAt: old, Members: []string{"users/a"}}
+	assert.True(t, membershipNeedsRefresh(cachedOld, "2026-06-04T09:00:00Z", now))
+
+	// Missing/unparseable fetched_at → refetch.
+	cachedNoFetched := spaceMembers{Version: "2026-06-04T09:00:00Z", FetchedAt: "", Members: []string{"users/a"}}
+	assert.True(t, membershipNeedsRefresh(cachedNoFetched, "2026-06-04T09:00:00Z", now))
+}
+
+func TestReapStaleCursors_ArchiveRestoreDrop(t *testing.T) {
+	now := accelerated.GetCurrentTime()
+	g := &gchatMetadata{
+		SpaceCursors: map[string]spaceCursor{
+			"spaces/live":     {CreateCursor: "2026-06-04T10:00:00Z", EditCursor: "2026-06-04T09:00:00Z"},
+			"spaces/vanished": {CreateCursor: "2026-06-03T10:00:00Z", EditCursor: "2026-06-03T09:00:00Z"},
+		},
+		ArchivedCursors: map[string]archivedCursor{
+			"spaces/reappears": {CreateCursor: "2026-06-01T10:00:00Z", EditCursor: "2026-06-01T09:00:00Z", ArchivedAt: now.Add(-time.Hour).Format(chatTimeLayout)},
+			"spaces/expired":   {CreateCursor: "2026-05-01T10:00:00Z", ArchivedAt: now.Add(-40 * 24 * time.Hour).Format(chatTimeLayout)},
+		},
+		SpaceMembers:   map[string]spaceMembers{},
+		UserEmailCache: map[string]cachedEmail{},
+		MeIdentities:   map[string]struct{}{},
+	}
+	spaces := []*chat.Space{
+		{Name: "spaces/live"},
+		{Name: "spaces/reappears"},
+	}
+	reapStaleCursors(g, spaces, now)
+
+	// vanished → archived.
+	_, liveOK := g.SpaceCursors["spaces/live"]
+	assert.True(t, liveOK)
+	_, vanishedActive := g.SpaceCursors["spaces/vanished"]
+	assert.False(t, vanishedActive)
+	arch, ok := g.ArchivedCursors["spaces/vanished"]
+	require.True(t, ok)
+	assert.Equal(t, "2026-06-03T10:00:00Z", arch.CreateCursor)
+
+	// reappears → restored at its archived cursor value.
+	restored, ok := g.SpaceCursors["spaces/reappears"]
+	require.True(t, ok)
+	assert.Equal(t, "2026-06-01T10:00:00Z", restored.CreateCursor)
+	_, stillArchived := g.ArchivedCursors["spaces/reappears"]
+	assert.False(t, stillArchived)
+
+	// expired (>30d) → dropped.
+	_, expiredOK := g.ArchivedCursors["spaces/expired"]
+	assert.False(t, expiredOK)
+}
+
+func TestGChatMetadata_RoundTrip(t *testing.T) {
+	g := &gchatMetadata{
+		SpaceCursors:    map[string]spaceCursor{"spaces/A": {CreateCursor: "2026-06-04T10:00:00Z", EditCursor: "2026-06-04T09:00:00Z"}},
+		ArchivedCursors: map[string]archivedCursor{"spaces/B": {CreateCursor: "x", ArchivedAt: "2026-06-04T08:00:00Z"}},
+		SpaceMembers:    map[string]spaceMembers{"spaces/A": {Version: "v1", FetchedAt: "2026-06-04T10:00:00Z", Members: []string{"users/a"}}},
+		UserEmailCache:  map[string]cachedEmail{"users/a": {Email: "a@example.test", ResolvedAt: "2026-06-04T10:00:00Z"}},
+		MeIdentities:    map[string]struct{}{"me@example.test": {}},
+	}
+	// Preserve a non-gchat key to prove read-modify-write doesn't clobber it.
+	raw := map[string]any{"backfill_since": "2026-01-01", "some_other_key": 42}
+	merged := g.writeInto(raw)
+
+	// Round-trip through JSON (the persistence boundary).
+	b, err := json.Marshal(merged)
+	require.NoError(t, err)
+	var back map[string]any
+	require.NoError(t, json.Unmarshal(b, &back))
+
+	// Non-gchat keys preserved.
+	assert.Equal(t, "2026-01-01", back["backfill_since"])
+	assert.EqualValues(t, 42, back["some_other_key"])
+
+	reloaded := loadGChatMetadata(back)
+	assert.Equal(t, g.SpaceCursors, reloaded.SpaceCursors)
+	assert.Equal(t, g.ArchivedCursors, reloaded.ArchivedCursors)
+	assert.Equal(t, g.SpaceMembers, reloaded.SpaceMembers)
+	assert.Equal(t, g.UserEmailCache, reloaded.UserEmailCache)
+	assert.Equal(t, g.MeIdentities, reloaded.MeIdentities)
+}
+
+func TestGChatMetadata_CursorForSeedsBackfillFloor(t *testing.T) {
+	g := loadGChatMetadata(nil)
+	floor := "2026-01-01T00:00:00Z"
+	cur := g.cursorFor("spaces/new", floor)
+	assert.Equal(t, floor, cur.CreateCursor)
+	assert.Equal(t, floor, cur.EditCursor)
+}
+
+func TestPrimaryNormalizedEmail(t *testing.T) {
+	// Primary flagged → that one.
+	p := &people.Person{EmailAddresses: []*people.EmailAddress{
+		{Value: "secondary@Example.test"},
+		{Value: "Primary@Example.test", Metadata: &people.FieldMetadata{Primary: true}},
+	}}
+	assert.Equal(t, "primary@example.test", primaryNormalizedEmail(p))
+
+	// No primary → first non-empty.
+	p2 := &people.Person{EmailAddresses: []*people.EmailAddress{{Value: "First@Example.test"}}}
+	assert.Equal(t, "first@example.test", primaryNormalizedEmail(p2))
+
+	// No emails → "".
+	assert.Equal(t, "", primaryNormalizedEmail(&people.Person{}))
+	assert.Equal(t, "", primaryNormalizedEmail(nil))
+}
+
+func TestFlattenKnownMembers_DedupAndSelfExclusion(t *testing.T) {
+	a := uuid.New()
+	b := uuid.New()
+	known := map[string][]uuid.UUID{
+		"a@example.test":  {a},
+		"b@example.test":  {b, a}, // a shared across two addresses
+		"me@example.test": {uuid.New()},
+	}
+	meSet := map[string]struct{}{"me@example.test": {}}
+	out := flattenKnownMembers(known, meSet)
+	assert.ElementsMatch(t, []uuid.UUID{a, b}, out)
+}
+
+func TestFirstN(t *testing.T) {
+	assert.Equal(t, "", firstN("anything", 0))
+	assert.Equal(t, "ab", firstN("abcdef", 2))
+	assert.Equal(t, "abc", firstN("abc", 10))
+	// Rune-safe: a multi-byte rune is not split mid-byte.
+	assert.Equal(t, "héll", firstN("héllo", 4))
+}
+
+func TestBuildContentMetadata(t *testing.T) {
+	space := &chat.Space{Name: "spaces/A", SpaceType: "SPACE"}
+	m := &chat.Message{
+		Name:           "spaces/A/messages/1",
+		LastUpdateTime: "2026-06-04T10:00:00Z",
+		Thread:         &chat.Thread{Name: "spaces/A/threads/t1"},
+		Attachment:     []*chat.Attachment{{Name: "att1", ContentName: "file.pdf", ContentType: "application/pdf", Source: "DRIVE_FILE"}},
+	}
+	raw := buildContentMetadata(space, m)
+	var meta map[string]any
+	require.NoError(t, json.Unmarshal(raw, &meta))
+	assert.Equal(t, "SPACE", meta["space_type"])
+	assert.Equal(t, "spaces/A/threads/t1", meta["thread_name"])
+	assert.Equal(t, "2026-06-04T10:00:00Z", meta["last_update_time"])
+	atts, ok := meta["attachments"].([]any)
+	require.True(t, ok)
+	require.Len(t, atts, 1)
+}

--- a/backend/internal/google/oauth.go
+++ b/backend/internal/google/oauth.go
@@ -18,11 +18,19 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/calendar/v3"
+	chat "google.golang.org/api/chat/v1"
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/people/v1"
 )
 
-// Scopes defines the OAuth scopes requested for Google APIs
+// Scopes defines the OAuth scopes requested for Google APIs.
+//
+// The three chat.*.readonly scopes back the Google Chat sync provider:
+// chat.spaces.readonly lists the user's spaces, chat.messages.readonly lists
+// messages, and chat.memberships.readonly is REQUIRED for spaces.members.list
+// under User authentication (the membership-resolution path). Adding scopes
+// forces a one-time re-consent for already-connected accounts; existing
+// Gmail/Calendar tokens keep working with their previously-granted scopes.
 var Scopes = []string{
 	"openid",
 	"email",
@@ -30,6 +38,9 @@ var Scopes = []string{
 	gmail.GmailReadonlyScope,
 	calendar.CalendarReadonlyScope,
 	people.ContactsReadonlyScope,
+	chat.ChatSpacesReadonlyScope,
+	chat.ChatMessagesReadonlyScope,
+	chat.ChatMembershipsReadonlyScope,
 }
 
 // ProviderName is the identifier for Google OAuth credentials

--- a/backend/internal/google/oauth_test.go
+++ b/backend/internal/google/oauth_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 	"google.golang.org/api/calendar/v3"
+	chat "google.golang.org/api/chat/v1"
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/people/v1"
 )
@@ -26,14 +27,20 @@ func TestScopes(t *testing.T) {
 	assert.Contains(t, Scopes, calendar.CalendarReadonlyScope, "Calendar readonly scope is required")
 	assert.Contains(t, Scopes, people.ContactsReadonlyScope, "Contacts readonly scope is required")
 
-	// Verify we have exactly 6 scopes (no more, no less)
-	assert.Len(t, Scopes, 6, "Should have exactly 6 scopes")
+	// Verify all three Google Chat readonly scopes are present (the membership
+	// scope is required for spaces.members.list under User authentication).
+	assert.Contains(t, Scopes, chat.ChatSpacesReadonlyScope, "Chat spaces readonly scope is required")
+	assert.Contains(t, Scopes, chat.ChatMessagesReadonlyScope, "Chat messages readonly scope is required")
+	assert.Contains(t, Scopes, chat.ChatMembershipsReadonlyScope, "Chat memberships readonly scope is required")
+
+	// Verify we have exactly 9 scopes (no more, no less)
+	assert.Len(t, Scopes, 9, "Should have exactly 9 scopes")
 }
 
 // TestScopes_Order verifies the scopes are in the expected order
 // OpenID scopes should come first, then API scopes
 func TestScopes_Order(t *testing.T) {
-	require.Len(t, Scopes, 6, "Expected 6 scopes")
+	require.Len(t, Scopes, 9, "Expected 9 scopes")
 
 	// OpenID scopes should be first
 	assert.Equal(t, "openid", Scopes[0], "openid should be first")
@@ -44,6 +51,9 @@ func TestScopes_Order(t *testing.T) {
 	assert.Equal(t, gmail.GmailReadonlyScope, Scopes[3])
 	assert.Equal(t, calendar.CalendarReadonlyScope, Scopes[4])
 	assert.Equal(t, people.ContactsReadonlyScope, Scopes[5])
+	assert.Equal(t, chat.ChatSpacesReadonlyScope, Scopes[6])
+	assert.Equal(t, chat.ChatMessagesReadonlyScope, Scopes[7])
+	assert.Equal(t, chat.ChatMembershipsReadonlyScope, Scopes[8])
 }
 
 // TestGetAuthURL_IncludesConsentPrompt verifies that the auth URL includes prompt=consent
@@ -131,7 +141,7 @@ func TestGetAuthURL_ScopeFormatting(t *testing.T) {
 
 	// Split by space and verify we have all scopes
 	scopeParts := strings.Fields(decodedScopes)
-	assert.GreaterOrEqual(t, len(scopeParts), 6, "Should have at least 6 scopes in the URL")
+	assert.GreaterOrEqual(t, len(scopeParts), 9, "Should have at least 9 scopes in the URL")
 }
 
 // TestGenerateState verifies that state generation produces unique, secure values
@@ -186,11 +196,14 @@ func TestOAuthService_ConfigConstruction(t *testing.T) {
 	}
 
 	// Verify the service's config has all required scopes
-	assert.Len(t, service.config.Scopes, 6, "Config should have 6 scopes")
+	assert.Len(t, service.config.Scopes, 9, "Config should have 9 scopes")
 	assert.Contains(t, service.config.Scopes, "openid")
 	assert.Contains(t, service.config.Scopes, "email")
 	assert.Contains(t, service.config.Scopes, "profile")
 	assert.Contains(t, service.config.Scopes, gmail.GmailReadonlyScope)
 	assert.Contains(t, service.config.Scopes, calendar.CalendarReadonlyScope)
 	assert.Contains(t, service.config.Scopes, people.ContactsReadonlyScope)
+	assert.Contains(t, service.config.Scopes, chat.ChatSpacesReadonlyScope)
+	assert.Contains(t, service.config.Scopes, chat.ChatMessagesReadonlyScope)
+	assert.Contains(t, service.config.Scopes, chat.ChatMembershipsReadonlyScope)
 }

--- a/backend/internal/repository/comms_message.go
+++ b/backend/internal/repository/comms_message.go
@@ -655,6 +655,58 @@ func (r *CommsMessageRepository) SoftDeleteByID(ctx context.Context, id uuid.UUI
 	return r.queries.SoftDeleteCommsMessageByID(ctx, uuidToPgUUID(id))
 }
 
+// ApplyEditByExternalID applies an upstream edit to every stored row for
+// (source, external_id): updates body + snippet, pushes the prior body onto
+// source_metadata.previous_bodies[] (capped at the last 3), and records
+// last_update_time + edited_at. The SQL ::timestamptz recency guard decides
+// whether the edit is newer than the stored row, so this is idempotent under
+// concurrent same-edit observation. body/snippet are pointers (nil → SQL NULL);
+// editedAt and lastUpdateTime are RFC-3339 strings (lastUpdateTime is the
+// message's LastUpdateTime, cast ::timestamptz in the query). Returns the
+// number of rows updated (0 when the stored last_update_time is already >= the
+// new one). Production code MUST NOT compare lastUpdateTime in Go.
+func (r *CommsMessageRepository) ApplyEditByExternalID(ctx context.Context, source, externalID string, body, snippet *string, editedAt, lastUpdateTime string) (int64, error) {
+	return r.queries.ApplyCommsMessageEditByExternalID(ctx, db.ApplyCommsMessageEditByExternalIDParams{
+		Source:         source,
+		ExternalID:     externalID,
+		Body:           stringToPgText(body),
+		Snippet:        stringToPgText(snippet),
+		EditedAt:       editedAt,
+		LastUpdateTime: lastUpdateTime,
+	})
+}
+
+// SoftDeleteByExternalID soft-deletes every stored row for (source,
+// external_id) — the production chat delete path. Idempotent: an already-deleted
+// message affects 0 rows. Returns the number of rows soft-deleted.
+func (r *CommsMessageRepository) SoftDeleteByExternalID(ctx context.Context, source, externalID string, now time.Time) (int64, error) {
+	return r.queries.SoftDeleteCommsMessagesByExternalID(ctx, db.SoftDeleteCommsMessagesByExternalIDParams{
+		Source:     source,
+		ExternalID: externalID,
+		Now:        timeToPgTimestamptz(&now),
+	})
+}
+
+// GetLatestByExternalID reads one stored row for (source, external_id), newest
+// first, to supply the current body for the provider's bodyDiffers
+// no-op-avoidance pre-check. Returns db.ErrNotFound on miss. The returned row's
+// last_update_time MUST NOT be string-compared in Go to decide recency — that
+// decision belongs to the SQL ::timestamptz guard in ApplyEditByExternalID.
+func (r *CommsMessageRepository) GetLatestByExternalID(ctx context.Context, source, externalID string) (*CommsMessage, error) {
+	dbMsg, err := r.queries.GetCommsMessageLatestByExternalID(ctx, db.GetCommsMessageLatestByExternalIDParams{
+		Source:     source,
+		ExternalID: externalID,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, db.ErrNotFound
+		}
+		return nil, err
+	}
+	msg := convertDbCommsMessage(dbMsg)
+	return &msg, nil
+}
+
 // CommsSourceContactLister adapts *CommsMessageRepository to the source-neutral
 // scheduler.UnprocessedContactLister interface, pinning a source. The sweeper's
 // interface is single-source (ListUnprocessedContactIDs(ctx)) but comms_message

--- a/backend/tests/comms_message_repository_test.go
+++ b/backend/tests/comms_message_repository_test.go
@@ -571,6 +571,215 @@ func TestInteractionSourceCheck_AcceptsEmail(t *testing.T) {
 	assert.Equal(t, repository.InteractionSourceEmail, interaction.Source)
 }
 
+// gchatUpsertParams builds an upsert input for a gchat row (the source the
+// edit/delete reconciliation queries serve in production). external_id is the
+// Chat message resource name; thread_id is the space resource name.
+func gchatUpsertParams(externalID string, contactID uuid.UUID, sentAt time.Time, body string) repository.UpsertCommsMessageParams {
+	return repository.UpsertCommsMessageParams{
+		Source:           repository.InteractionSourceGChat,
+		ExternalID:       externalID,
+		ThreadID:         strPtr("spaces/AAAA-" + externalID),
+		Body:             strPtr(body),
+		Snippet:          strPtr(body),
+		PeerHandle:       strPtr("peer@example.test"),
+		PeerNormalized:   strPtr("peer@example.test"),
+		Direction:        repository.InteractionDirectionInbound,
+		SentAt:           sentAt,
+		AccountID:        strPtr("accA"),
+		MatchedContactID: contactID,
+	}
+}
+
+// previousBodies extracts source_metadata.previous_bodies as a []string.
+func previousBodies(t *testing.T, raw []byte) []string {
+	t.Helper()
+	m := decodeMetadata(t, raw)
+	arr, ok := m["previous_bodies"].([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(arr))
+	for _, v := range arr {
+		out = append(out, v.(string))
+	}
+	return out
+}
+
+// TestApplyEditByExternalID_PreviousBodiesCapAndRecencyGuard pins the edit
+// query's two SQL-level contracts: (1) previous_bodies[] holds the last 3 prior
+// bodies newest-first across repeated edits; (2) the ::timestamptz recency guard
+// rejects a stale (or equal) last_update_time so concurrent same-edit
+// observation pushes previous_bodies[] exactly once. body/snippet/edited_at/
+// last_update_time are updated; processed_at/interaction_id/deleted_at untouched.
+func TestApplyEditByExternalID_PreviousBodiesCapAndRecencyGuard(t *testing.T) {
+	ctx, repo, contactRepo, _ := setupCommsMessageTest(t)
+
+	suffix := randomSuffix(t)
+	contact := newEmailContact(t, ctx, repo, contactRepo, "Test GChat Edit "+suffix)
+
+	sentAt := accelerated.GetCurrentTime().Truncate(time.Microsecond)
+	externalID := "spaces/AAAA/messages/edit-" + suffix
+	seeded, err := repo.UpsertMessage(ctx, gchatUpsertParams(externalID, contact.ID, sentAt, "body v0"))
+	require.NoError(t, err)
+
+	src := repository.InteractionSourceGChat
+
+	// Edit 1 (prior body "body v0") at t1.
+	n, err := repo.ApplyEditByExternalID(ctx, src, externalID, strPtr("body v1"), strPtr("snip v1"), "2026-06-04T10:00:00Z", "2026-06-04T10:00:01Z")
+	require.NoError(t, err)
+	require.Equal(t, int64(1), n)
+
+	// Edit 2 (prior body "body v1") at t2.
+	n, err = repo.ApplyEditByExternalID(ctx, src, externalID, strPtr("body v2"), strPtr("snip v2"), "2026-06-04T10:00:02Z", "2026-06-04T10:00:02Z")
+	require.NoError(t, err)
+	require.Equal(t, int64(1), n)
+
+	// Edit 3 (prior body "body v2") at t3.
+	n, err = repo.ApplyEditByExternalID(ctx, src, externalID, strPtr("body v3"), strPtr("snip v3"), "2026-06-04T10:00:03Z", "2026-06-04T10:00:03Z")
+	require.NoError(t, err)
+	require.Equal(t, int64(1), n)
+
+	// Edit 4 (prior body "body v3") at t4 — should drop "body v0" from the cap.
+	n, err = repo.ApplyEditByExternalID(ctx, src, externalID, strPtr("body v4"), strPtr("snip v4"), "2026-06-04T10:00:04Z", "2026-06-04T10:00:04Z")
+	require.NoError(t, err)
+	require.Equal(t, int64(1), n)
+
+	got, err := repo.GetMessage(ctx, src, externalID, contact.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.Body)
+	assert.Equal(t, "body v4", *got.Body)
+	require.NotNil(t, got.Snippet)
+	assert.Equal(t, "snip v4", *got.Snippet)
+	// Newest-first, exactly the last 3 prior bodies (v0 dropped).
+	assert.Equal(t, []string{"body v3", "body v2", "body v1"}, previousBodies(t, got.SourceMetadata))
+	md := decodeMetadata(t, got.SourceMetadata)
+	assert.Equal(t, "2026-06-04T10:00:04Z", md["last_update_time"])
+	assert.Equal(t, "2026-06-04T10:00:04Z", md["edited_at"])
+	// Content-derived fields untouched by the edit path.
+	assert.Nil(t, got.ProcessedAt)
+	assert.Nil(t, got.InteractionID)
+	assert.Nil(t, got.DeletedAt)
+	assert.Equal(t, seeded.ID, got.ID)
+
+	// Recency guard: re-applying the SAME edit (equal last_update_time) is a
+	// no-op — 0 rows, previous_bodies unchanged (not double-pushed).
+	n, err = repo.ApplyEditByExternalID(ctx, src, externalID, strPtr("body v4 dup"), strPtr("snip dup"), "2026-06-04T10:00:99Z", "2026-06-04T10:00:04Z")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n, "equal last_update_time must not re-apply")
+
+	// Stale guard: an OLDER last_update_time is rejected too.
+	n, err = repo.ApplyEditByExternalID(ctx, src, externalID, strPtr("stale body"), strPtr("stale"), "2026-06-04T09:00:00Z", "2026-06-04T10:00:00Z")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n, "older last_update_time must be rejected")
+
+	got2, err := repo.GetMessage(ctx, src, externalID, contact.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got2.Body)
+	assert.Equal(t, "body v4", *got2.Body, "no-op edits left body unchanged")
+	assert.Equal(t, []string{"body v3", "body v2", "body v1"}, previousBodies(t, got2.SourceMetadata), "previous_bodies not double-pushed")
+}
+
+// TestApplyEditByExternalID_FractionalSecondOrdering proves the ::timestamptz
+// guard orders by real instant, not lexical RFC-3339: a higher-fractional-
+// precision newer edit applies, and a genuinely-older edit that sorts lexically
+// LATER is rejected. The "...10:00:00Z" vs "...10:00:00.001Z" pair is the exact
+// case a string compare would invert (the 'Z' byte sorts after '.').
+func TestApplyEditByExternalID_FractionalSecondOrdering(t *testing.T) {
+	ctx, repo, contactRepo, _ := setupCommsMessageTest(t)
+
+	suffix := randomSuffix(t)
+	contact := newEmailContact(t, ctx, repo, contactRepo, "Test GChat Frac "+suffix)
+	src := repository.InteractionSourceGChat
+	sentAt := accelerated.GetCurrentTime().Truncate(time.Microsecond)
+
+	externalID := "spaces/AAAA/messages/frac-" + suffix
+	_, err := repo.UpsertMessage(ctx, gchatUpsertParams(externalID, contact.ID, sentAt, "frac v0"))
+	require.NoError(t, err)
+
+	// Seed last_update_time = "...10:00:00.001Z".
+	n, err := repo.ApplyEditByExternalID(ctx, src, externalID, strPtr("frac v1"), strPtr("frac v1"), "2026-06-04T10:00:00Z", "2026-06-04T10:00:00.001Z")
+	require.NoError(t, err)
+	require.Equal(t, int64(1), n)
+
+	// Genuinely OLDER ("...10:00:00Z") but sorts lexically LATER than the stored
+	// "...10:00:00.001Z" → must be REJECTED by the timestamptz guard.
+	n, err = repo.ApplyEditByExternalID(ctx, src, externalID, strPtr("frac older"), strPtr("frac older"), "2026-06-04T10:00:00Z", "2026-06-04T10:00:00Z")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n, "lexically-later but chronologically-earlier edit must be rejected")
+
+	got, err := repo.GetMessage(ctx, src, externalID, contact.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.Body)
+	assert.Equal(t, "frac v1", *got.Body)
+
+	// Genuinely NEWER ("...10:00:00.002Z") → applies.
+	n, err = repo.ApplyEditByExternalID(ctx, src, externalID, strPtr("frac v2"), strPtr("frac v2"), "2026-06-04T10:00:01Z", "2026-06-04T10:00:00.002Z")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n)
+	got, err = repo.GetMessage(ctx, src, externalID, contact.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.Body)
+	assert.Equal(t, "frac v2", *got.Body)
+}
+
+// TestSoftDeleteByExternalID_AllFannedRows proves the production delete path
+// soft-deletes EVERY fanned-out row for (source, external_id) and is idempotent.
+func TestSoftDeleteByExternalID_AllFannedRows(t *testing.T) {
+	ctx, repo, contactRepo, _ := setupCommsMessageTest(t)
+
+	suffix := randomSuffix(t)
+	contactA := newEmailContact(t, ctx, repo, contactRepo, "Test GChat DelA "+suffix)
+	contactB := newEmailContact(t, ctx, repo, contactRepo, "Test GChat DelB "+suffix)
+	src := repository.InteractionSourceGChat
+	sentAt := accelerated.GetCurrentTime().Truncate(time.Microsecond)
+
+	externalID := "spaces/AAAA/messages/del-" + suffix
+	_, err := repo.UpsertMessage(ctx, gchatUpsertParams(externalID, contactA.ID, sentAt, "del body"))
+	require.NoError(t, err)
+	_, err = repo.UpsertMessage(ctx, gchatUpsertParams(externalID, contactB.ID, sentAt, "del body"))
+	require.NoError(t, err)
+
+	now := accelerated.GetCurrentTime().Truncate(time.Microsecond)
+	n, err := repo.SoftDeleteByExternalID(ctx, src, externalID, now)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), n, "both fanned-out rows soft-deleted")
+
+	// Both rows now invisible to the deleted_at-filtered GetMessage.
+	_, err = repo.GetMessage(ctx, src, externalID, contactA.ID)
+	assert.True(t, errors.Is(err, db.ErrNotFound))
+	_, err = repo.GetMessage(ctx, src, externalID, contactB.ID)
+	assert.True(t, errors.Is(err, db.ErrNotFound))
+
+	// Idempotent: re-deleting affects 0 rows.
+	n, err = repo.SoftDeleteByExternalID(ctx, src, externalID, now)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n)
+}
+
+// TestGetLatestByExternalID_NewestFirstAndNotFound pins the body-pre-check read:
+// it returns the newest row by (sent_at DESC, id) and ErrNotFound on miss.
+func TestGetLatestByExternalID_NewestFirstAndNotFound(t *testing.T) {
+	ctx, repo, contactRepo, _ := setupCommsMessageTest(t)
+
+	suffix := randomSuffix(t)
+	contact := newEmailContact(t, ctx, repo, contactRepo, "Test GChat Latest "+suffix)
+	src := repository.InteractionSourceGChat
+
+	externalID := "spaces/AAAA/messages/latest-" + suffix
+	sentAt := accelerated.GetCurrentTime().Truncate(time.Microsecond)
+	_, err := repo.UpsertMessage(ctx, gchatUpsertParams(externalID, contact.ID, sentAt, "latest body"))
+	require.NoError(t, err)
+
+	got, err := repo.GetLatestByExternalID(ctx, src, externalID)
+	require.NoError(t, err)
+	require.NotNil(t, got.Body)
+	assert.Equal(t, "latest body", *got.Body)
+	assert.Equal(t, externalID, got.ExternalID)
+
+	_, err = repo.GetLatestByExternalID(ctx, src, "spaces/AAAA/messages/missing-"+suffix)
+	assert.True(t, errors.Is(err, db.ErrNotFound))
+}
+
 // TestBackfillParticipantNames_AdditiveMergeAndIdempotent pins the additive
 // merge contract directly at the SQL level: BackfillParticipantNames ADDS the
 // four display-name keys onto a name-less row while preserving ALL existing

--- a/backend/tests/gchat_provider_integration_test.go
+++ b/backend/tests/gchat_provider_integration_test.go
@@ -1,0 +1,741 @@
+package tests
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/google"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	chat "google.golang.org/api/chat/v1"
+)
+
+// gchatProviderEnv bundles the repos a GChat provider integration test needs.
+type gchatProviderEnv struct {
+	ctx         context.Context
+	database    *db.Database
+	commsRepo   *repository.CommsMessageRepository
+	contactRepo *repository.ContactRepository
+	methodRepo  *repository.ContactMethodRepository
+	syncRepo    *repository.SyncRepository
+}
+
+func setupGChatProviderTest(t *testing.T) *gchatProviderEnv {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set")
+	}
+	ctx := context.Background()
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	t.Cleanup(database.Close)
+
+	return &gchatProviderEnv{
+		ctx:         ctx,
+		database:    database,
+		commsRepo:   repository.NewCommsMessageRepository(database.Queries),
+		contactRepo: repository.NewContactRepository(database.Queries),
+		methodRepo:  repository.NewContactMethodRepository(database.Queries),
+		syncRepo:    repository.NewSyncRepositoryWithPool(database.Queries, database.Pool),
+	}
+}
+
+// newGChatProviderContact creates a contact with a contact_method of the given
+// type+value (so it appears in the dual-source known map), registering cleanup
+// that hard-deletes its comms rows and soft-deletes the contact.
+func (e *gchatProviderEnv) newGChatProviderContact(t *testing.T, name, methodType, methodValue string) *repository.Contact {
+	t.Helper()
+	contact, err := e.contactRepo.CreateContact(e.ctx, repository.CreateContactRequest{FullName: name})
+	require.NoError(t, err)
+	_, err = e.methodRepo.CreateContactMethod(e.ctx, repository.CreateContactMethodRequest{
+		ContactID: contact.ID,
+		Type:      methodType,
+		Value:     methodValue,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = e.commsRepo.HardDeleteByContact(e.ctx, contact.ID)
+		_ = e.contactRepo.SoftDeleteContact(e.ctx, contact.ID)
+	})
+	return contact
+}
+
+// newGChatSyncState creates an external_sync_state(source='gchat') row for an
+// account, registering cleanup. enabled controls the rematch gate.
+func (e *gchatProviderEnv) newGChatSyncState(t *testing.T, accountID string, enabled bool, metadata map[string]any) *repository.SyncState {
+	t.Helper()
+	st, err := e.syncRepo.CreateSyncState(e.ctx, repository.CreateSyncStateRequest{
+		Source:    repository.InteractionSourceGChat,
+		AccountID: &accountID,
+		Enabled:   enabled,
+		Metadata:  metadata,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = e.syncRepo.DeleteSyncState(e.ctx, st.ID) })
+	return st
+}
+
+// newProvider builds a GChatSyncProvider wired to the test repos with a fake
+// fetcher (no OAuth/HTTP) and an injected me-set.
+func (e *gchatProviderEnv) newProvider(t *testing.T, meSet map[string]struct{}, funcs google.FakeChatFetcherFuncs) *google.GChatSyncProvider {
+	t.Helper()
+	p := google.NewGChatSyncProvider(nil, e.commsRepo, e.syncRepo)
+	p.SetFetcherFactoryForTest(google.NewFakeChatFetcherFactoryForTest(funcs))
+	p.SetMeSetForTest(meSet)
+	return p
+}
+
+// chatRFC3339 formats a time as the Chat API RFC-3339 form.
+func chatRFC3339(ts time.Time) string {
+	return ts.UTC().Format(time.RFC3339Nano)
+}
+
+func space(name, spaceType string) *chat.Space {
+	return &chat.Space{Name: name, SpaceType: spaceType, LastActiveTime: chatRFC3339(accelerated.GetCurrentTime())}
+}
+
+func membership(userName string) *chat.Membership {
+	return &chat.Membership{State: "JOINED", Member: &chat.User{Name: userName, Type: "HUMAN"}}
+}
+
+func chatMessage(name, senderUser, text string, createTime time.Time) *chat.Message {
+	return &chat.Message{
+		Name:       name,
+		Sender:     &chat.User{Name: senderUser, Type: "HUMAN"},
+		Text:       text,
+		CreateTime: chatRFC3339(createTime),
+	}
+}
+
+// TestGChatProvider_FullSweep_InboundWritesRowNoEvents proves a sweep upserts a
+// gchat row for a known inbound sender, writes NO events itself, and persists
+// per-space metadata. The row is content-only until the engine aggregates.
+func TestGChatProvider_FullSweep_InboundWritesRowNoEvents(t *testing.T) {
+	e := setupGChatProviderTest(t)
+	suffix := randomSuffix(t)
+
+	aliceEmail := "alice-" + suffix + "@example.test"
+	alice := e.newGChatProviderContact(t, "GChat Sweep Alice "+suffix, string(repository.ContactMethodEmail), aliceEmail)
+
+	spaceName := "spaces/SWEEP-" + suffix
+	msgName := spaceName + "/messages/m1-" + suffix
+	accountID := "me-" + suffix + "@example.test"
+	st := e.newGChatSyncState(t, accountID, true, nil)
+	sentAt := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Second)
+
+	funcs := google.FakeChatFetcherFuncs{
+		ListSpaces: func(context.Context, string) ([]*chat.Space, string, error) {
+			return []*chat.Space{space(spaceName, "SPACE")}, "", nil
+		},
+		ListMembers: func(_ context.Context, sp, _ string) ([]*chat.Membership, string, error) {
+			return []*chat.Membership{membership("users/alice"), membership("users/me")}, "", nil
+		},
+		ListMessages: func(_ context.Context, sp, filter string, showDeleted bool, _ string) ([]*chat.Message, string, error) {
+			if showDeleted {
+				return nil, "", nil // edit/delete pass: nothing
+			}
+			return []*chat.Message{chatMessage(msgName, "users/alice", "hi there", sentAt)}, "", nil
+		},
+		ResolvePersonEmail: func(_ context.Context, userName string) (string, error) {
+			switch userName {
+			case "users/alice":
+				return aliceEmail, nil
+			case "users/me":
+				return accountID, nil
+			}
+			return "", nil
+		},
+	}
+	p := e.newProvider(t, map[string]struct{}{accountID: {}}, funcs)
+
+	// Re-fetch the state so Metadata is hydrated as the framework would.
+	state, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &accountID)
+	require.NoError(t, err)
+
+	result, err := p.Sync(e.ctx, state, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.ItemsProcessed)
+	assert.Equal(t, 1, result.ItemsMatched)
+	assert.Empty(t, result.NewCursor, "gchat keeps the per-space cursor in metadata, not NewCursor")
+
+	// The row exists, inbound, with the sender as peer.
+	row, err := e.commsRepo.GetMessage(e.ctx, repository.InteractionSourceGChat, msgName, alice.ID)
+	require.NoError(t, err)
+	assert.Equal(t, repository.InteractionDirectionInbound, row.Direction)
+	require.NotNil(t, row.Body)
+	assert.Equal(t, "hi there", *row.Body)
+	require.NotNil(t, row.PeerNormalized)
+	assert.Equal(t, aliceEmail, *row.PeerNormalized)
+	// The provider does NOT mark rows processed (the engine does that later).
+	assert.Nil(t, row.ProcessedAt)
+
+	// Metadata now carries the per-space cursor + membership + email cache.
+	persisted, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &accountID)
+	require.NoError(t, err)
+	require.NotNil(t, persisted.Metadata)
+	assert.Contains(t, persisted.Metadata, "space_cursors")
+	assert.Contains(t, persisted.Metadata, "space_members")
+	assert.Contains(t, persisted.Metadata, "user_email_cache")
+	_ = st
+}
+
+// TestGChatProvider_OutboundFanOutAndBystander proves an outbound message
+// (sender ∈ meSet) fans out to every known co-member (one row each, same
+// external_id), while a bystander sender produces no row.
+func TestGChatProvider_OutboundFanOutAndBystander(t *testing.T) {
+	e := setupGChatProviderTest(t)
+	suffix := randomSuffix(t)
+
+	aliceEmail := "alice-" + suffix + "@example.test"
+	bobEmail := "bob-" + suffix + "@example.test"
+	alice := e.newGChatProviderContact(t, "GChat Fan Alice "+suffix, string(repository.ContactMethodGChat), aliceEmail)
+	bob := e.newGChatProviderContact(t, "GChat Fan Bob "+suffix, string(repository.ContactMethodEmail), bobEmail)
+
+	spaceName := "spaces/FAN-" + suffix
+	outboundMsg := spaceName + "/messages/out-" + suffix
+	bystanderMsg := spaceName + "/messages/by-" + suffix
+	accountID := "me-" + suffix + "@example.test"
+	e.newGChatSyncState(t, accountID, true, nil)
+	base := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Second)
+
+	funcs := google.FakeChatFetcherFuncs{
+		ListSpaces: func(context.Context, string) ([]*chat.Space, string, error) {
+			return []*chat.Space{space(spaceName, "SPACE")}, "", nil
+		},
+		ListMembers: func(context.Context, string, string) ([]*chat.Membership, string, error) {
+			return []*chat.Membership{membership("users/me"), membership("users/alice"), membership("users/bob")}, "", nil
+		},
+		ListMessages: func(_ context.Context, _, _ string, showDeleted bool, _ string) ([]*chat.Message, string, error) {
+			if showDeleted {
+				return nil, "", nil
+			}
+			return []*chat.Message{
+				chatMessage(outboundMsg, "users/me", "team update", base),
+				chatMessage(bystanderMsg, "users/stranger", "who am i", base.Add(time.Minute)),
+			}, "", nil
+		},
+		ResolvePersonEmail: func(_ context.Context, userName string) (string, error) {
+			switch userName {
+			case "users/me":
+				return accountID, nil
+			case "users/alice":
+				return aliceEmail, nil
+			case "users/bob":
+				return bobEmail, nil
+			case "users/stranger":
+				return "stranger-" + suffix + "@example.test", nil
+			}
+			return "", nil
+		},
+	}
+	p := e.newProvider(t, map[string]struct{}{accountID: {}}, funcs)
+	state, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &accountID)
+	require.NoError(t, err)
+
+	_, err = p.Sync(e.ctx, state, nil)
+	require.NoError(t, err)
+
+	// Outbound fanned out to BOTH Alice and Bob (same external_id, two rows).
+	rowA, err := e.commsRepo.GetMessage(e.ctx, repository.InteractionSourceGChat, outboundMsg, alice.ID)
+	require.NoError(t, err)
+	assert.Equal(t, repository.InteractionDirectionOutbound, rowA.Direction)
+	rowB, err := e.commsRepo.GetMessage(e.ctx, repository.InteractionSourceGChat, outboundMsg, bob.ID)
+	require.NoError(t, err)
+	assert.Equal(t, repository.InteractionDirectionOutbound, rowB.Direction)
+	assert.NotEqual(t, rowA.ID, rowB.ID, "per-contact rows are distinct")
+
+	// Bystander produced NO row for any known contact.
+	_, err = e.commsRepo.GetMessage(e.ctx, repository.InteractionSourceGChat, bystanderMsg, alice.ID)
+	assert.ErrorIs(t, err, db.ErrNotFound)
+}
+
+// TestGChatProvider_CrossAccountDedup proves the same message observed under two
+// accounts produces ONE row per matched contact with observed_accounts merged.
+func TestGChatProvider_CrossAccountDedup(t *testing.T) {
+	e := setupGChatProviderTest(t)
+	suffix := randomSuffix(t)
+
+	aliceEmail := "alice-" + suffix + "@example.test"
+	alice := e.newGChatProviderContact(t, "GChat XAcct Alice "+suffix, string(repository.ContactMethodEmail), aliceEmail)
+
+	spaceName := "spaces/XACCT-" + suffix
+	msgName := spaceName + "/messages/m-" + suffix
+	acctA := "acctA-" + suffix + "@example.test"
+	acctB := "acctB-" + suffix + "@example.test"
+	sentAt := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Second)
+
+	mkFuncs := func(myAccount string) google.FakeChatFetcherFuncs {
+		return google.FakeChatFetcherFuncs{
+			ListSpaces: func(context.Context, string) ([]*chat.Space, string, error) {
+				return []*chat.Space{space(spaceName, "SPACE")}, "", nil
+			},
+			ListMembers: func(context.Context, string, string) ([]*chat.Membership, string, error) {
+				return []*chat.Membership{membership("users/alice"), membership("users/me")}, "", nil
+			},
+			ListMessages: func(_ context.Context, _, _ string, showDeleted bool, _ string) ([]*chat.Message, string, error) {
+				if showDeleted {
+					return nil, "", nil
+				}
+				return []*chat.Message{chatMessage(msgName, "users/alice", "shared", sentAt)}, "", nil
+			},
+			ResolvePersonEmail: func(_ context.Context, userName string) (string, error) {
+				if userName == "users/alice" {
+					return aliceEmail, nil
+				}
+				if userName == "users/me" {
+					return myAccount, nil
+				}
+				return "", nil
+			},
+		}
+	}
+
+	// Account A sweep.
+	stA := e.newGChatSyncState(t, acctA, true, nil)
+	pA := e.newProvider(t, map[string]struct{}{acctA: {}}, mkFuncs(acctA))
+	stateA, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &acctA)
+	require.NoError(t, err)
+	_, err = pA.Sync(e.ctx, stateA, nil)
+	require.NoError(t, err)
+
+	// Account B sweep observes the SAME message.
+	e.newGChatSyncState(t, acctB, true, nil)
+	pB := e.newProvider(t, map[string]struct{}{acctB: {}}, mkFuncs(acctB))
+	stateB, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &acctB)
+	require.NoError(t, err)
+	_, err = pB.Sync(e.ctx, stateB, nil)
+	require.NoError(t, err)
+
+	// Still ONE row for Alice; observed_accounts is the union of both accounts.
+	row, err := e.commsRepo.GetMessage(e.ctx, repository.InteractionSourceGChat, msgName, alice.ID)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{acctA, acctB}, observedAccounts(t, row.SourceMetadata))
+	_ = stA
+}
+
+// TestGChatProvider_EditReconciliation proves a body edit observed in the
+// ShowDeleted re-list updates the stored body + last_update_time while leaving
+// processed_at untouched (so the engine does not reprocess).
+func TestGChatProvider_EditReconciliation(t *testing.T) {
+	e := setupGChatProviderTest(t)
+	suffix := randomSuffix(t)
+
+	aliceEmail := "alice-" + suffix + "@example.test"
+	alice := e.newGChatProviderContact(t, "GChat EditRecon Alice "+suffix, string(repository.ContactMethodEmail), aliceEmail)
+
+	spaceName := "spaces/EDITRECON-" + suffix
+	msgName := spaceName + "/messages/m-" + suffix
+	accountID := "me-" + suffix + "@example.test"
+	e.newGChatSyncState(t, accountID, true, nil)
+	sentAt := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Second)
+	editTime := accelerated.GetCurrentTime().Add(-30 * time.Minute)
+
+	var serveEdit bool
+	funcs := google.FakeChatFetcherFuncs{
+		ListSpaces: func(context.Context, string) ([]*chat.Space, string, error) {
+			return []*chat.Space{space(spaceName, "SPACE")}, "", nil
+		},
+		ListMembers: func(context.Context, string, string) ([]*chat.Membership, string, error) {
+			return []*chat.Membership{membership("users/alice"), membership("users/me")}, "", nil
+		},
+		ListMessages: func(_ context.Context, _, _ string, showDeleted bool, _ string) ([]*chat.Message, string, error) {
+			if showDeleted {
+				if !serveEdit {
+					return nil, "", nil
+				}
+				edited := chatMessage(msgName, "users/alice", "EDITED body", sentAt)
+				edited.LastUpdateTime = chatRFC3339(editTime)
+				return []*chat.Message{edited}, "", nil
+			}
+			if serveEdit {
+				return nil, "", nil // already past the create cursor on the second sweep
+			}
+			return []*chat.Message{chatMessage(msgName, "users/alice", "original body", sentAt)}, "", nil
+		},
+		ResolvePersonEmail: func(_ context.Context, userName string) (string, error) {
+			if userName == "users/alice" {
+				return aliceEmail, nil
+			}
+			if userName == "users/me" {
+				return accountID, nil
+			}
+			return "", nil
+		},
+	}
+	p := e.newProvider(t, map[string]struct{}{accountID: {}}, funcs)
+
+	// Sweep 1: ingest the original.
+	state, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &accountID)
+	require.NoError(t, err)
+	_, err = p.Sync(e.ctx, state, nil)
+	require.NoError(t, err)
+	row, err := e.commsRepo.GetMessage(e.ctx, repository.InteractionSourceGChat, msgName, alice.ID)
+	require.NoError(t, err)
+	require.NotNil(t, row.Body)
+	require.Equal(t, "original body", *row.Body)
+
+	// Simulate the engine having processed the row (mark it processed via a
+	// real interaction) so we can prove the edit does NOT clear processed_at.
+	ref := "gchat:" + spaceName + ":proc-" + suffix
+	interactionRepo := repository.NewInteractionRepository(e.database.Queries)
+	interaction, err := interactionRepo.CreateInteraction(e.ctx, repository.CreateInteractionRequest{
+		ContactID: alice.ID, Source: repository.InteractionSourceGChat, SourceRef: &ref,
+		OccurredAt: sentAt, Direction: repository.InteractionDirectionInbound,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = interactionRepo.HardDeleteInteractionsBySourceRefPrefix(e.ctx, repository.InteractionSourceGChat, "gchat:"+spaceName+":%")
+	})
+	require.NoError(t, e.commsRepo.MarkMessagesProcessed(e.ctx, []uuid.UUID{row.ID}, interaction.ID))
+
+	// Sweep 2: serve the edit through the ShowDeleted re-list.
+	serveEdit = true
+	state2, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &accountID)
+	require.NoError(t, err)
+	_, err = p.Sync(e.ctx, state2, nil)
+	require.NoError(t, err)
+
+	edited, err := e.commsRepo.GetMessage(e.ctx, repository.InteractionSourceGChat, msgName, alice.ID)
+	require.NoError(t, err)
+	require.NotNil(t, edited.Body)
+	assert.Equal(t, "EDITED body", *edited.Body, "edit applied to stored body")
+	assert.Equal(t, []string{"original body"}, previousBodies(t, edited.SourceMetadata))
+	require.NotNil(t, edited.ProcessedAt, "edit must NOT clear processed_at")
+	require.NotNil(t, edited.InteractionID)
+	assert.Equal(t, interaction.ID, *edited.InteractionID)
+}
+
+// TestGChatProvider_EditFractionalOrdering drives the FULL provider edit path
+// (not just the SQL wrapper): a stored row at "...:00.001Z" then an observed
+// edit with LastUpdateTime "...:00Z" (genuinely OLDER despite sorting lexically
+// LATER) must NOT apply; the reverse (genuinely newer) must apply. Proves the
+// provider's body-only pre-filter does not invert fractional ordering.
+func TestGChatProvider_EditFractionalOrdering(t *testing.T) {
+	e := setupGChatProviderTest(t)
+	suffix := randomSuffix(t)
+
+	aliceEmail := "alice-" + suffix + "@example.test"
+	alice := e.newGChatProviderContact(t, "GChat Frac Alice "+suffix, string(repository.ContactMethodEmail), aliceEmail)
+
+	spaceName := "spaces/FRAC-" + suffix
+	msgName := spaceName + "/messages/m-" + suffix
+	accountID := "me-" + suffix + "@example.test"
+	e.newGChatSyncState(t, accountID, true, nil)
+	sentAt := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Second)
+
+	// Seed a row whose stored last_update_time is "...:00.001Z" (newer fractional)
+	// by applying an edit through the repository directly.
+	_, err := e.commsRepo.UpsertMessage(e.ctx, repository.UpsertCommsMessageParams{
+		Source: repository.InteractionSourceGChat, ExternalID: msgName,
+		ThreadID: &spaceName, Body: strPtr("seed body"), Snippet: strPtr("seed body"),
+		PeerHandle: &aliceEmail, PeerNormalized: &aliceEmail,
+		Direction: repository.InteractionDirectionInbound, SentAt: sentAt,
+		AccountID: &accountID, MatchedContactID: alice.ID,
+	})
+	require.NoError(t, err)
+	n, err := e.commsRepo.ApplyEditByExternalID(e.ctx, repository.InteractionSourceGChat, msgName, strPtr("fractional-newer"), strPtr("fractional-newer"), "2026-06-04T10:00:00Z", "2026-06-04T10:00:00.001Z")
+	require.NoError(t, err)
+	require.Equal(t, int64(1), n)
+
+	// Observe an OLDER edit ("...:00Z") via the provider's ShowDeleted re-list.
+	// It sorts lexically AFTER the stored ".001Z" but is chronologically earlier,
+	// so the SQL ::timestamptz guard must reject it.
+	olderEdit := chatMessage(msgName, "users/alice", "should-not-apply", sentAt)
+	olderEdit.LastUpdateTime = "2026-06-04T10:00:00Z"
+	funcs := google.FakeChatFetcherFuncs{
+		ListSpaces: func(context.Context, string) ([]*chat.Space, string, error) {
+			return []*chat.Space{space(spaceName, "SPACE")}, "", nil
+		},
+		ListMembers: func(context.Context, string, string) ([]*chat.Membership, string, error) {
+			return []*chat.Membership{membership("users/alice"), membership("users/me")}, "", nil
+		},
+		ListMessages: func(_ context.Context, _, _ string, showDeleted bool, _ string) ([]*chat.Message, string, error) {
+			if showDeleted {
+				return []*chat.Message{olderEdit}, "", nil
+			}
+			return nil, "", nil // content pass: nothing new
+		},
+		ResolvePersonEmail: func(_ context.Context, userName string) (string, error) {
+			if userName == "users/alice" {
+				return aliceEmail, nil
+			}
+			if userName == "users/me" {
+				return accountID, nil
+			}
+			return "", nil
+		},
+	}
+	p := e.newProvider(t, map[string]struct{}{accountID: {}}, funcs)
+	state, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &accountID)
+	require.NoError(t, err)
+	_, err = p.Sync(e.ctx, state, nil)
+	require.NoError(t, err)
+
+	row, err := e.commsRepo.GetMessage(e.ctx, repository.InteractionSourceGChat, msgName, alice.ID)
+	require.NoError(t, err)
+	require.NotNil(t, row.Body)
+	assert.Equal(t, "fractional-newer", *row.Body, "chronologically-older edit (lexically later) must be rejected")
+}
+
+// TestGChatProvider_DeleteReconciliation proves a tombstone in the ShowDeleted
+// re-list soft-deletes all fanned-out rows for the message.
+func TestGChatProvider_DeleteReconciliation(t *testing.T) {
+	e := setupGChatProviderTest(t)
+	suffix := randomSuffix(t)
+
+	aliceEmail := "alice-" + suffix + "@example.test"
+	alice := e.newGChatProviderContact(t, "GChat DelRecon Alice "+suffix, string(repository.ContactMethodEmail), aliceEmail)
+
+	spaceName := "spaces/DELRECON-" + suffix
+	msgName := spaceName + "/messages/m-" + suffix
+	accountID := "me-" + suffix + "@example.test"
+	e.newGChatSyncState(t, accountID, true, nil)
+	sentAt := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Second)
+
+	var serveDelete bool
+	funcs := google.FakeChatFetcherFuncs{
+		ListSpaces: func(context.Context, string) ([]*chat.Space, string, error) {
+			return []*chat.Space{space(spaceName, "SPACE")}, "", nil
+		},
+		ListMembers: func(context.Context, string, string) ([]*chat.Membership, string, error) {
+			return []*chat.Membership{membership("users/alice"), membership("users/me")}, "", nil
+		},
+		ListMessages: func(_ context.Context, _, _ string, showDeleted bool, _ string) ([]*chat.Message, string, error) {
+			if showDeleted {
+				if !serveDelete {
+					return nil, "", nil
+				}
+				tomb := &chat.Message{Name: msgName, CreateTime: chatRFC3339(sentAt), DeletionMetadata: &chat.DeletionMetadata{DeletionType: "CREATOR"}}
+				return []*chat.Message{tomb}, "", nil
+			}
+			if serveDelete {
+				return nil, "", nil
+			}
+			return []*chat.Message{chatMessage(msgName, "users/alice", "to be deleted", sentAt)}, "", nil
+		},
+		ResolvePersonEmail: func(_ context.Context, userName string) (string, error) {
+			if userName == "users/alice" {
+				return aliceEmail, nil
+			}
+			if userName == "users/me" {
+				return accountID, nil
+			}
+			return "", nil
+		},
+	}
+	p := e.newProvider(t, map[string]struct{}{accountID: {}}, funcs)
+
+	state, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &accountID)
+	require.NoError(t, err)
+	_, err = p.Sync(e.ctx, state, nil)
+	require.NoError(t, err)
+	_, err = e.commsRepo.GetMessage(e.ctx, repository.InteractionSourceGChat, msgName, alice.ID)
+	require.NoError(t, err, "row exists after sweep 1")
+
+	serveDelete = true
+	state2, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &accountID)
+	require.NoError(t, err)
+	_, err = p.Sync(e.ctx, state2, nil)
+	require.NoError(t, err)
+
+	_, err = e.commsRepo.GetMessage(e.ctx, repository.InteractionSourceGChat, msgName, alice.ID)
+	assert.ErrorIs(t, err, db.ErrNotFound, "row soft-deleted after the tombstone re-list")
+}
+
+// TestGChatProvider_MetadataReusedAcrossSweeps proves the second sweep reuses
+// the persisted membership + email cache (no fetcher refetch within TTL) and
+// advances the create cursor so already-ingested messages are not re-listed.
+func TestGChatProvider_MetadataReusedAcrossSweeps(t *testing.T) {
+	e := setupGChatProviderTest(t)
+	suffix := randomSuffix(t)
+
+	aliceEmail := "alice-" + suffix + "@example.test"
+	e.newGChatProviderContact(t, "GChat MetaReuse Alice "+suffix, string(repository.ContactMethodEmail), aliceEmail)
+
+	spaceName := "spaces/METAREUSE-" + suffix
+	accountID := "me-" + suffix + "@example.test"
+	e.newGChatSyncState(t, accountID, true, nil)
+	sentAt := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Second)
+
+	memberCalls := 0
+	resolveCalls := 0
+	// Stable LastActiveTime across both sweeps so the activity-based membership
+	// refresh does NOT fire — this test isolates the within-TTL reuse path.
+	stableActive := chatRFC3339(accelerated.GetCurrentTime().Add(-2 * time.Hour))
+	funcs := google.FakeChatFetcherFuncs{
+		ListSpaces: func(context.Context, string) ([]*chat.Space, string, error) {
+			sp := space(spaceName, "SPACE")
+			sp.LastActiveTime = stableActive
+			return []*chat.Space{sp}, "", nil
+		},
+		ListMembers: func(context.Context, string, string) ([]*chat.Membership, string, error) {
+			memberCalls++
+			return []*chat.Membership{membership("users/alice"), membership("users/me")}, "", nil
+		},
+		ListMessages: func(_ context.Context, _, filter string, showDeleted bool, _ string) ([]*chat.Message, string, error) {
+			if showDeleted {
+				return nil, "", nil
+			}
+			return []*chat.Message{chatMessage(spaceName+"/messages/m-"+suffix, "users/alice", "hi", sentAt)}, "", nil
+		},
+		ResolvePersonEmail: func(_ context.Context, userName string) (string, error) {
+			resolveCalls++
+			if userName == "users/alice" {
+				return aliceEmail, nil
+			}
+			if userName == "users/me" {
+				return accountID, nil
+			}
+			return "", nil
+		},
+	}
+	p := e.newProvider(t, map[string]struct{}{accountID: {}}, funcs)
+
+	state, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &accountID)
+	require.NoError(t, err)
+	_, err = p.Sync(e.ctx, state, nil)
+	require.NoError(t, err)
+	membersAfter1 := memberCalls
+	resolvesAfter1 := resolveCalls
+	require.GreaterOrEqual(t, membersAfter1, 1)
+	require.GreaterOrEqual(t, resolvesAfter1, 1)
+
+	// Second sweep: membership + resolutions reused from persisted metadata
+	// within the 24h TTL → no new ListMembers / ResolvePersonEmail calls.
+	state2, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &accountID)
+	require.NoError(t, err)
+	_, err = p.Sync(e.ctx, state2, nil)
+	require.NoError(t, err)
+	assert.Equal(t, membersAfter1, memberCalls, "membership reused from metadata (no refetch within TTL)")
+	assert.Equal(t, resolvesAfter1, resolveCalls, "email resolutions reused from metadata (no refetch within TTL)")
+}
+
+// TestGChatRematch_ScansWhenEnabled proves the enabled gchat rematch handler
+// scans the address across the enabled account and upserts a row.
+func TestGChatRematch_ScansWhenEnabled(t *testing.T) {
+	e := setupGChatProviderTest(t)
+	suffix := randomSuffix(t)
+
+	aliceEmail := "alice-" + suffix + "@example.test"
+	alice := e.newGChatProviderContact(t, "GChat Rematch Alice "+suffix, string(repository.ContactMethodGChat), aliceEmail)
+
+	spaceName := "spaces/REMATCH-" + suffix
+	msgName := spaceName + "/messages/m-" + suffix
+	accountID := "me-" + suffix + "@example.test"
+	e.newGChatSyncState(t, accountID, true, nil)
+	sentAt := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Second)
+
+	funcs := google.FakeChatFetcherFuncs{
+		ListSpaces: func(context.Context, string) ([]*chat.Space, string, error) {
+			return []*chat.Space{space(spaceName, "SPACE")}, "", nil
+		},
+		ListMembers: func(context.Context, string, string) ([]*chat.Membership, string, error) {
+			return []*chat.Membership{membership("users/alice"), membership("users/me")}, "", nil
+		},
+		ListMessages: func(_ context.Context, _, _ string, showDeleted bool, _ string) ([]*chat.Message, string, error) {
+			if showDeleted {
+				return nil, "", nil
+			}
+			return []*chat.Message{chatMessage(msgName, "users/alice", "historical", sentAt)}, "", nil
+		},
+		ResolvePersonEmail: func(_ context.Context, userName string) (string, error) {
+			if userName == "users/alice" {
+				return aliceEmail, nil
+			}
+			if userName == "users/me" {
+				return accountID, nil
+			}
+			return "", nil
+		},
+	}
+	p := e.newProvider(t, map[string]struct{}{accountID: {}}, funcs)
+
+	matched, err := p.ScanIdentifier(e.ctx, accountID, aliceEmail, map[string][]uuid.UUID{aliceEmail: {alice.ID}}, map[string]struct{}{accountID: {}}, "2026-01-01T00:00:00Z")
+	require.NoError(t, err)
+	assert.Equal(t, 1, matched, "the historical message was upserted for the rematched address")
+
+	row, err := e.commsRepo.GetMessage(e.ctx, repository.InteractionSourceGChat, msgName, alice.ID)
+	require.NoError(t, err)
+	assert.Equal(t, repository.InteractionDirectionInbound, row.Direction)
+}
+
+// TestGChatRematchHandler_ScansAndAggregates drives the FULL rematch handler
+// (gate → scan → AggregateForContactBatch) against the wired engine harness: an
+// enabled gchat state + a fake fetcher → adding the address upserts a row AND
+// the engine derives an interaction in the same rematch pass.
+func TestGChatRematchHandler_ScansAndAggregates(t *testing.T) {
+	env := setupGChatEngineTest(t) // wired engine + recorder
+	suffix := randomSuffix(t)
+
+	methodRepo := repository.NewContactMethodRepository(env.database.Queries)
+	syncRepo := repository.NewSyncRepositoryWithPool(env.database.Queries, env.database.Pool)
+
+	aliceEmail := "alice-" + suffix + "@example.test"
+	alice := env.newGChatContact(t, "GChat RematchHandler Alice "+suffix)
+	_, err := methodRepo.CreateContactMethod(env.ctx, repository.CreateContactMethodRequest{
+		ContactID: alice.ID, Type: string(repository.ContactMethodGChat), Value: aliceEmail,
+	})
+	require.NoError(t, err)
+
+	spaceName := "spaces/REMATCHH-" + suffix
+	msgName := spaceName + "/messages/m-" + suffix
+	accountID := "me-" + suffix + "@example.test"
+	st, err := syncRepo.CreateSyncState(env.ctx, repository.CreateSyncStateRequest{
+		Source: repository.InteractionSourceGChat, AccountID: &accountID, Enabled: true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = syncRepo.DeleteSyncState(env.ctx, st.ID) })
+	sentAt := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Second)
+
+	funcs := google.FakeChatFetcherFuncs{
+		ListSpaces: func(context.Context, string) ([]*chat.Space, string, error) {
+			return []*chat.Space{space(spaceName, "SPACE")}, "", nil
+		},
+		ListMembers: func(context.Context, string, string) ([]*chat.Membership, string, error) {
+			return []*chat.Membership{membership("users/alice"), membership("users/me")}, "", nil
+		},
+		ListMessages: func(_ context.Context, _, _ string, showDeleted bool, _ string) ([]*chat.Message, string, error) {
+			if showDeleted {
+				return nil, "", nil
+			}
+			return []*chat.Message{chatMessage(msgName, "users/alice", "historical", sentAt)}, "", nil
+		},
+		ResolvePersonEmail: func(_ context.Context, userName string) (string, error) {
+			if userName == "users/alice" {
+				return aliceEmail, nil
+			}
+			if userName == "users/me" {
+				return accountID, nil
+			}
+			return "", nil
+		},
+	}
+	provider := google.NewGChatSyncProvider(nil, env.commsRepo, syncRepo)
+	provider.SetFetcherFactoryForTest(google.NewFakeChatFetcherFactoryForTest(funcs))
+	provider.SetMeSetForTest(map[string]struct{}{accountID: {}})
+
+	handler := google.NewGChatHandleRematchHandler(provider, syncRepo, env.commsRepo, env.engine)
+	matched, err := handler.Rematch(env.ctx, alice.ID, aliceEmail)
+	require.NoError(t, err)
+	assert.Equal(t, 1, matched)
+
+	// The row was upserted and AggregateForContactBatch derived an interaction.
+	interactions := waitForInteractionCountExact(t, env.ctx, env.interactionRepo, alice.ID, 1, defaultInteractionWaitTimeout)
+	require.Len(t, interactions, 1)
+	assert.Equal(t, repository.InteractionSourceGChat, interactions[0].Source)
+	assert.Equal(t, repository.InteractionDirectionInbound, interactions[0].Direction)
+}


### PR DESCRIPTION
## Summary

PR 2 of 3 for the Google Chat integration (#337). Lands the `GChatSyncProvider`, the two dual-source rematch handlers, bounded edit/delete reconciliation, and per-sweep observability, plus the OAuth chat scopes and the `chat/v1` dependency. Builds on PR 1's `comms_message(source='gchat')` aggregation substrate (merged at 395a45f).

**This PR is LIVE-but-INERT in production.** The provider is constructed but **NOT registered** into the scheduler/provider registry, and there is **no enablement / boot-reconciliation** path that creates an enabled `external_sync_state(source='gchat')` row — those are PR 3. The provider therefore never runs even though its code ships. The two rematch handlers ARE registered but are provably no-ops: each gates first on `ListEnabledSyncStates` filtered to `source='gchat'` and returns `(0, nil)` when that set is empty (PR 2 enables zero gchat states), exactly mirroring the `GmailRematchHandler` gate.

## Key changes

- **OAuth scopes**: append three Google Chat readonly scopes via the exported `chat/v1` constants — `chat.spaces.readonly`, `chat.messages.readonly`, and `chat.memberships.readonly` (the last is required for `spaces.members.list` under User authentication). `chat/v1` is a sub-package of the already-required `google.golang.org/api` module, so no module version bump. **Adding scopes forces a one-time re-consent for already-connected accounts to pick up GChat; existing Gmail/Calendar tokens keep working with their previously-granted scopes** (the reconnect-indicator UI is PR 3).
- **`GChatSyncProvider`** (`gchat.go` + support/helpers): a `chatFetcher` interface over `chat/v1` + `people/v1` with a fake-injecting test seam; the per-account sweep (spaces.list across all space types, membership cache with activity + age refresh triggers, stale-cursor reaper with restore-on-rediscovery, per-message qualification with inbound sender-only / outbound fan-out / bystander semantics and self-contact exclusion); a cached `users/{id}`→email resolver (People API) with positive **and** negative 24h caching; and read-modify-write of the rich per-space cursor / membership / email-cache state into `external_sync_state.metadata`. Event-free and bus-free — the shared aggregation engine derives interactions on its own pass.
- **Bounded edit/delete reconciliation**: a second per-space list pass over `create_time` within the trailing 7-day lookback with `ShowDeleted=true`. `updateTime` is not server-filterable, so edits/deletes of messages *created* within the lookback are synced; older ones are a documented, symmetric accepted lost-update. Deletes soft-delete all fanned-out rows; edits are applied via a new SQL query whose `::timestamptz` recency guard decides recency + idempotency (no Go-side timestamp comparison) and caps `previous_bodies[]` at the last 3.
- **Dual-source rematch handlers**: `GChatHandleRematchHandler` (type `gchat`) and `GChatEmailRematchHandler` (type `email`, co-registers alongside Gmail/Calendar). On an enabled gchat state they run an address-scoped historical scan across the enabled accounts, then drive `AggregateForContactBatch` once. A budget-exhausted scan fails the job so River retries the idempotent backfill.
- **Observability**: gchat-specific counters (`spaces_skipped_no_known_member`, `senders_unresolved`, `edits_applied`, `deletes_applied`) as structured zerolog fields on the completion log line; `processed`/`matched` flow into `sync_log` via the standard `SyncResult` item counts. There is no `metrics` package — this is the repo's actual observability surface.
- **Cross-account dedup**: Chat message resource names are cross-account-stable, so `external_id = message.Name` directly (no synthesized key); provenance merges `observed_accounts[]` by set-union.
- **3 new sqlc queries** on `comms_message` (edit-by-external-id with the timestamptz guard + last-3 cap, soft-delete-by-external-id, get-latest-by-external-id) + repository wrappers.

## Partial-failure posture

A `ListMessages` / membership-resolve / People-API / upsert error anywhere inside a space's window aborts that space's window and leaves its cursor **unadvanced** (the window restarts next sweep; re-ingest is idempotent via the upsert dedup). Cursors advance **only** after a window is fully paged. A shared per-sweep list-page budget bounds the whole sweep across the membership / content / edit passes; budget exhaustion mid-window keeps the original cursor.

## Test plan

- Unit (`gchat_test.go`, `gchat_rematch_test.go`): classification (inbound/outbound/bystander/bot/DM/self-exclusion), positive+negative resolver caching + TTL, stale-cursor reaper, membership refresh triggers, metadata round-trip, the shared-budget proven/unadvanced contract, membership-budget incompleteness, and the rematch no-op gate (proven to do zero fetcher work).
- Repository/SQL (`comms_message_repository_test.go`): the edit query's `previous_bodies` last-3 cap, the `::timestamptz` recency/idempotency guard (including fractional-second ordering), soft-delete across all fanned-out rows, get-latest.
- Integration (`gchat_provider_integration_test.go`): full sweep upserts rows + writes no events + persists metadata; outbound fan-out + bystander; cross-account provenance merge; edit reconciliation (body + `previous_bodies` updated, `processed_at` retained); fractional-second edit ordering through the full provider path; delete reconciliation; membership + email cache reused within TTL across sweeps; and the rematch handler's gate→scan→`AggregateForContactBatch` path deriving an interaction when a gchat state is enabled.
- No new GChat E2E specs (the provider is inert — no UI, no enabled state, no live sweep); the diff-selected regression E2E guards the new `email`-typed rematch handler's no-op against the existing rematch/settings flows.
- Local gate green: `make sqlc` (no drift), both build forms, `make lint`, `make test-unit`, `make test-integration`.

## Out of scope (PR 3)

Provider registration into the scheduler, enablement / boot-reconciliation that creates an enabled gchat sync state, the reconnect-required settings indicator, the status endpoint, and env-var burst/reply overrides.

Refs #337.