### PR TITLE
feat(gchat): registration + enablement + settings reconnect UI (#337)

### DIFF
--- a/.ai/patterns/sync.md
+++ b/.ai/patterns/sync.md
@@ -6,6 +6,7 @@
 |----------|-------------|----------|------|
 | Google Contacts | `gcontacts` | `contact_driven` | `backend/internal/google/contacts.go` |
 | Google Calendar | `gcal` | `contact_driven` | `backend/internal/google/calendar.go` |
+| Google Chat | `gchat` | `contact_driven` | `backend/internal/google/gchat.go` |
 | Todoist | `todoist` | `fetch_all` | `backend/internal/todoist/provider.go` |
 | Messages | `messages` | `push` | `backend/internal/messages/provider.go` |
 | iCloud Contacts | `icloud_contacts` | `push` | `backend/internal/icloudcontacts/provider.go` |
@@ -16,6 +17,17 @@ The poll-strategy providers register themselves in
 **push** providers register through one helper,
 `push.RegisterPushProviders(providerRegistry)`
 (`backend/internal/push/push.go`), which main.go calls once.
+
+**Google Chat is registered but enablement-gated.** `gchat` registers
+unconditionally whenever Google OAuth is configured (it is store-only +
+event-free, so unlike Gmail it does NOT gate on the event bus), but it stays
+inert until `SyncService.ReconcileGChatSyncStates`
+(`backend/internal/service/gchat_reconcile.go`) creates an enabled
+`external_sync_state(source='gchat')` row. That reconciliation only enables an
+account whose stored requested-scope list contains ALL THREE chat scopes
+(`chat.spaces.readonly`, `chat.messages.readonly`, `chat.memberships.readonly`),
+so the feature does no work until the operator re-consents — see
+`.ai/spec/2026-06-04-gchat-integration-design.md` §7.
 
 **Not every push source has a provider stub.** The `anarlog_humans` and
 `anarlog_sessions` push sources are accepted by the ingest pipeline but

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -866,19 +866,22 @@ func run() int {
 				logger.Warn().Msg("Gmail provider NOT registered: event-bus interaction mode=off (pubBus nil)")
 			}
 
-			// GChat provider: constructed but NOT registered into
-			// providerRegistry — the scheduler must never run it until enablement
-			// exists (INERT). It is store-only + event-free, so unlike Gmail it
-			// does NOT gate on pubBus. gchatSyncStates = syncRepo is the
-			// enabled-state lister the gchat rematch handlers gate on (registered
-			// in the late depth-0 block).
+			// GChat provider: registered into providerRegistry so the scheduler
+			// can run it — this is the go-live switch (PR 3). It stays inert
+			// until enablement reconciliation creates an enabled gchat sync state
+			// (no state → ListDueSyncStates filters enabled=TRUE → nothing to
+			// dispatch). It is store-only + event-free, so unlike Gmail it does
+			// NOT gate on pubBus. gchatSyncStates = syncRepo is the enabled-state
+			// lister the gchat rematch handlers gate on (registered in the late
+			// depth-0 block).
 			gchatProvider = google.NewGChatSyncProvider(
 				googleOAuthService,
 				commsMessageRepo,
 				syncRepo,
 			)
 			gchatSyncStates = syncRepo
-			logger.Info().Msg("GChat sync provider constructed (inert: not registered into provider registry)")
+			providerRegistry.Register(gchatProvider)
+			logger.Info().Msg("GChat sync provider registered (inert until a gchat sync state is enabled)")
 		}
 
 		// Register Todoist Cadence provider if OAuth is configured
@@ -944,6 +947,31 @@ func run() int {
 				// Non-fatal: the scheduler simply has nothing to do for email
 				// until states exist; the next connect or next boot retries.
 				logger.Warn().Err(err).Msg("boot email sync reconciliation failed (non-fatal)")
+			}
+		}
+
+		// GChat enablement reconciliation (Chat go-live). Guarded ONLY by
+		// googleOAuthService != nil — NOT pubBus: GChat is store-only + event-free,
+		// so its registration + reconciliation are independent of the event-bus
+		// interaction mode (gating on pubBus would wrongly disable GChat in
+		// off-mode). The provider is registered above whenever Google OAuth is
+		// configured; here we wire the account lister + OAuth-connect hook, then
+		// run the idempotent, chat-scope-gated boot reconciliation BEFORE
+		// riverClient.Start so the RunOnStart tick already sees any freshly-enabled
+		// gchat states. No state is created until a connected account carries the
+		// chat scopes (re-consent), keeping the feature inert until the operator
+		// completes the Chat App config + re-consent.
+		if googleOAuthService != nil {
+			syncService.SetGChatAccountLister(googleOAuthService)
+			if oauthHandler != nil {
+				oauthHandler.SetGChatStateReconciler(func(ctx context.Context) error {
+					return syncService.ReconcileGChatSyncStates(ctx)
+				})
+			}
+			if err := syncService.ReconcileGChatSyncStates(ctx); err != nil {
+				// Non-fatal: the scheduler simply has nothing to do for gchat
+				// until states exist; the next connect or next boot retries.
+				logger.Warn().Err(err).Msg("boot gchat sync reconciliation failed (non-fatal)")
 			}
 		}
 

--- a/backend/internal/api/handlers/oauth.go
+++ b/backend/internal/api/handlers/oauth.go
@@ -35,6 +35,13 @@ type OAuthHandler struct {
 	// SyncService.ReconcileEmailSyncStates, keeping the handler decoupled from
 	// the service package (no import cycle).
 	emailStateReconciler func(context.Context) error
+	// gchatStateReconciler mirrors emailStateReconciler for Google Chat: when
+	// set, it is invoked after a successful Google connect so a newly re-consented
+	// account gets its gchat sync state without waiting for a reboot. Nil-default
+	// (no-Google builds). Wired in main.go as a closure over
+	// SyncService.ReconcileGChatSyncStates. The reconciliation itself gates on
+	// the chat scopes, so a connect without those scopes is a no-op.
+	gchatStateReconciler func(context.Context) error
 }
 
 // NewOAuthHandler creates a new OAuth handler
@@ -61,6 +68,13 @@ func (h *OAuthHandler) SetTodoistOAuth(todoistOAuth todoist.OAuthServiceInterfac
 // Nil-default; only populated in cutover mode (see main.go).
 func (h *OAuthHandler) SetEmailStateReconciler(reconcile func(context.Context) error) {
 	h.emailStateReconciler = reconcile
+}
+
+// SetGChatStateReconciler wires the callback invoked after a successful Google
+// connect to reconcile GChat sync states for the newly-connected account.
+// Nil-default; only populated when Google OAuth is configured (see main.go).
+func (h *OAuthHandler) SetGChatStateReconciler(reconcile func(context.Context) error) {
+	h.gchatStateReconciler = reconcile
 }
 
 // HasTodoistOAuth returns true if Todoist OAuth is configured
@@ -205,6 +219,17 @@ func (h *OAuthHandler) GoogleCallback(c *gin.Context) {
 	if h.emailStateReconciler != nil {
 		if err := h.emailStateReconciler(c.Request.Context()); err != nil {
 			logger.Warn().Err(err).Msg("email sync reconciliation after Google connect failed (non-fatal)")
+		}
+	}
+
+	// Reconcile GChat sync states so a newly re-consented account (one that now
+	// carries the chat scopes) gets its sweep enabled without waiting for a
+	// reboot. Idempotent and scope-gated, so a connect without the chat scopes
+	// is a no-op. Non-fatal: the account is connected regardless; boot / the
+	// next connect retries.
+	if h.gchatStateReconciler != nil {
+		if err := h.gchatStateReconciler(c.Request.Context()); err != nil {
+			logger.Warn().Err(err).Msg("gchat sync reconciliation after Google connect failed (non-fatal)")
 		}
 	}
 

--- a/backend/internal/api/handlers/oauth_test.go
+++ b/backend/internal/api/handlers/oauth_test.go
@@ -185,6 +185,73 @@ func TestGoogleCallback(t *testing.T) {
 		assert.Contains(t, location, "/settings?auth=success")
 		assert.Contains(t, location, "provider=google")
 	})
+
+	t.Run("invokes email and gchat reconcilers on valid exchange", func(t *testing.T) {
+		mock := &MockOAuthService{
+			ExchangeCodeFunc: func(ctx context.Context, code string) (*repository.OAuthCredentialStatus, error) {
+				return &repository.OAuthCredentialStatus{
+					ID:        uuid.New(),
+					Provider:  "google",
+					AccountID: "test@example.com",
+				}, nil
+			},
+		}
+		handler := NewOAuthHandler(mock, "http://localhost:3000")
+
+		emailCalled, gchatCalled := false, false
+		handler.SetEmailStateReconciler(func(context.Context) error {
+			emailCalled = true
+			return nil
+		})
+		handler.SetGChatStateReconciler(func(context.Context) error {
+			gchatCalled = true
+			return nil
+		})
+
+		state := "valid-state-789"
+		handler.storeState(state)
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest("GET", "/auth/google/callback?code=authcode&state="+state, nil)
+
+		handler.GoogleCallback(c)
+
+		assert.Equal(t, http.StatusFound, w.Code)
+		assert.Contains(t, w.Header().Get("Location"), "/settings?auth=success")
+		assert.True(t, emailCalled, "email reconciler must be invoked after a successful connect")
+		assert.True(t, gchatCalled, "gchat reconciler must be invoked after a successful connect")
+	})
+
+	t.Run("gchat reconciler error is non-fatal (still redirects success)", func(t *testing.T) {
+		mock := &MockOAuthService{
+			ExchangeCodeFunc: func(ctx context.Context, code string) (*repository.OAuthCredentialStatus, error) {
+				return &repository.OAuthCredentialStatus{
+					ID:        uuid.New(),
+					Provider:  "google",
+					AccountID: "test@example.com",
+				}, nil
+			},
+		}
+		handler := NewOAuthHandler(mock, "http://localhost:3000")
+		handler.SetGChatStateReconciler(func(context.Context) error {
+			return errors.New("reconcile boom")
+		})
+
+		state := "valid-state-abc"
+		handler.storeState(state)
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest("GET", "/auth/google/callback?code=authcode&state="+state, nil)
+
+		handler.GoogleCallback(c)
+
+		// A reconciler error must NOT fail the connect — the account is connected
+		// regardless; boot / the next connect retries.
+		assert.Equal(t, http.StatusFound, w.Code)
+		assert.Contains(t, w.Header().Get("Location"), "/settings?auth=success")
+	})
 }
 
 func TestListGoogleAccounts(t *testing.T) {

--- a/backend/internal/service/gchat_reconcile.go
+++ b/backend/internal/service/gchat_reconcile.go
@@ -19,15 +19,27 @@ const (
 	// dependency direction).
 	gchatSyncSource = "gchat"
 
-	// gchatSpacesReadonlyScope is the OAuth scope a connected Google account must
-	// carry before GChat sync is enabled for it. spaces.list — the provider's
-	// very first call — needs it; gating on this single scope is the minimal
-	// honest enablement check (the provider degrades cleanly per-call on any
-	// missing scope). Defined as a literal so the service layer does not import
-	// the chat API client just to name a scope string. MUST match
-	// chat.ChatSpacesReadonlyScope.
-	gchatSpacesReadonlyScope = "https://www.googleapis.com/auth/chat.spaces.readonly"
+	// The GChat sweep authenticates against three Chat scopes: spaces.list needs
+	// chat.spaces.readonly, messages.list needs chat.messages.readonly, and
+	// spaces.members.list needs chat.memberships.readonly under User auth. The
+	// enablement gate requires ALL THREE in the stored requested-scope list — a
+	// partial grant (e.g. spaces-only) would let the sweep start but fail mid-run
+	// on the first messages/members call, so we do not enable until the account
+	// has fully re-consented. Defined as literals so the service layer does not
+	// import the chat API client just to name scope strings; each MUST match the
+	// corresponding chat.Chat*ReadonlyScope constant.
+	gchatSpacesReadonlyScope      = "https://www.googleapis.com/auth/chat.spaces.readonly"
+	gchatMessagesReadonlyScope    = "https://www.googleapis.com/auth/chat.messages.readonly"
+	gchatMembershipsReadonlyScope = "https://www.googleapis.com/auth/chat.memberships.readonly"
 )
+
+// gchatRequiredScopes is the full set of Chat scopes an account must carry in
+// its stored requested-scope list before GChat sync is enabled for it.
+var gchatRequiredScopes = []string{
+	gchatSpacesReadonlyScope,
+	gchatMessagesReadonlyScope,
+	gchatMembershipsReadonlyScope,
+}
 
 // SetGChatAccountLister wires the Google account lister used by
 // ReconcileGChatSyncStates. Nil-default: when unset (tests / no-Google builds)
@@ -48,12 +60,14 @@ func (s *SyncService) SetGChatAccountLister(lister GoogleAccountLister) {
 //
 // The chat-scope gate is the one behavioral departure from
 // ReconcileEmailSyncStates (which creates a state regardless and only warns on a
-// missing scope). For GChat the scope is the ENABLEMENT gate: an account that
-// has not re-consented to the chat scopes gets NO state and NO sweep, which is
-// what keeps the feature inert until the user re-consents (spec §7). The stored
-// scope list is the requested-scope proxy for "re-consented since the chat
-// scopes were added"; the provider's clean 403-degrade on spaces.list backstops
-// a proxy-positive-but-not-truly-granted account.
+// missing scope). For GChat the full chat-scope set is the ENABLEMENT gate: an
+// account that has not re-consented to ALL THREE chat scopes gets NO state and
+// NO sweep, which is what keeps the feature inert until the user re-consents
+// (spec §7). Requiring the full set (not just spaces.list's scope) avoids
+// enabling an account whose sweep would start but fail mid-run on the first
+// messages/members call. The stored scope list is the requested-scope proxy for
+// "re-consented since the chat scopes were added"; the provider's clean
+// 403-degrade backstops a proxy-positive-but-not-truly-granted account.
 //
 // Idempotency contract (run on every boot AND on every OAuth connect):
 //   - create-if-absent ONLY. For each scoped account it probes
@@ -93,15 +107,15 @@ func (s *SyncService) ReconcileGChatSyncStates(ctx context.Context) error {
 			continue
 		}
 
-		// Scope gate FIRST: an account missing chat.spaces.readonly is not
-		// enabled (no state created). This is the enablement gate — unlike the
-		// email reconciliation, which creates regardless and only warns. The
+		// Scope gate FIRST: an account missing ANY of the three chat scopes is
+		// not enabled (no state created). This is the enablement gate — unlike
+		// the email reconciliation, which creates regardless and only warns. The
 		// account id is the user's own connected mailbox address (operational
 		// provenance, already in oauth_credential), not third-party PII.
-		if !accountHasChatScope(account) {
+		if !accountHasChatScopes(account) {
 			logger.Info().
 				Str("account", accountID).
-				Msg("gchat sync: account missing chat scopes; not enabling until reconnected")
+				Msg("gchat sync: account missing one or more chat scopes; not enabling until reconnected")
 			continue
 		}
 
@@ -143,13 +157,19 @@ func (s *SyncService) ReconcileGChatSyncStates(ctx context.Context) error {
 	return nil
 }
 
-// accountHasChatScope reports whether a connected Google account's stored scope
-// list contains chat.spaces.readonly — the enablement gate for GChat sync.
-func accountHasChatScope(account repository.OAuthCredentialStatus) bool {
+// accountHasChatScopes reports whether a connected Google account's stored scope
+// list contains ALL THREE chat scopes — the enablement gate for GChat sync. A
+// partial grant returns false: the sweep needs every scope (spaces.list,
+// messages.list, members.list), so enabling on a subset would only fail mid-run.
+func accountHasChatScopes(account repository.OAuthCredentialStatus) bool {
+	have := make(map[string]struct{}, len(account.Scopes))
 	for _, scope := range account.Scopes {
-		if scope == gchatSpacesReadonlyScope {
-			return true
+		have[scope] = struct{}{}
+	}
+	for _, required := range gchatRequiredScopes {
+		if _, ok := have[required]; !ok {
+			return false
 		}
 	}
-	return false
+	return true
 }

--- a/backend/internal/service/gchat_reconcile.go
+++ b/backend/internal/service/gchat_reconcile.go
@@ -1,0 +1,155 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/logger"
+	"personal-crm/backend/internal/repository"
+	syncpkg "personal-crm/backend/internal/sync"
+)
+
+const (
+	// gchatSyncSource is the external_sync_state.source value for Google Chat
+	// sync. It matches google.GChatSourceName and comms_message.source /
+	// interaction.source value 'gchat'. Duplicated as a local literal so the
+	// service layer does not import the google package (which would invert the
+	// dependency direction).
+	gchatSyncSource = "gchat"
+
+	// gchatSpacesReadonlyScope is the OAuth scope a connected Google account must
+	// carry before GChat sync is enabled for it. spaces.list — the provider's
+	// very first call — needs it; gating on this single scope is the minimal
+	// honest enablement check (the provider degrades cleanly per-call on any
+	// missing scope). Defined as a literal so the service layer does not import
+	// the chat API client just to name a scope string. MUST match
+	// chat.ChatSpacesReadonlyScope.
+	gchatSpacesReadonlyScope = "https://www.googleapis.com/auth/chat.spaces.readonly"
+)
+
+// SetGChatAccountLister wires the Google account lister used by
+// ReconcileGChatSyncStates. Nil-default: when unset (tests / no-Google builds)
+// ReconcileGChatSyncStates is a no-op. Reuses the same GoogleAccountLister
+// interface as the email reconciliation (both are satisfied by
+// *google.OAuthService); a dedicated field keeps gchat enablement independently
+// nil-gated from email wiring. Safe to call once at boot; not safe to call
+// concurrently with an in-flight ReconcileGChatSyncStates.
+func (s *SyncService) SetGChatAccountLister(lister GoogleAccountLister) {
+	s.gchatAccountLister = lister
+}
+
+// ReconcileGChatSyncStates ensures one enabled GChat sync state exists per
+// connected Google credential THAT HAS THE CHAT SCOPES GRANTED. It is the
+// headless enablement routine that flips the (store-only, event-free) Google
+// Chat feature on: nothing creates a gchat state automatically, so without this
+// no state is ever created and the scheduler runs no sweep.
+//
+// The chat-scope gate is the one behavioral departure from
+// ReconcileEmailSyncStates (which creates a state regardless and only warns on a
+// missing scope). For GChat the scope is the ENABLEMENT gate: an account that
+// has not re-consented to the chat scopes gets NO state and NO sweep, which is
+// what keeps the feature inert until the user re-consents (spec §7). The stored
+// scope list is the requested-scope proxy for "re-consented since the chat
+// scopes were added"; the provider's clean 403-degrade on spaces.list backstops
+// a proxy-positive-but-not-truly-granted account.
+//
+// Idempotency contract (run on every boot AND on every OAuth connect):
+//   - create-if-absent ONLY. For each scoped account it probes
+//     GetSyncStateBySource("gchat", &accountID); on db.ErrNotFound it creates a
+//     per-account state (enabled=true, strategy=contact_driven,
+//     metadata={"backfill_since": sync.EmailBackfillSinceDefault}, empty cursor,
+//     NULL next_sync_at → immediately due on the next tick). The empty
+//     space_cursors map is materialized by the provider on its first sweep, so
+//     it is not seeded here.
+//   - a found state is left COMPLETELY untouched: no re-enable, no metadata
+//     rewrite, no cursor reset. Re-running must never duplicate states, reset
+//     cursors/backfill on already-enabled accounts, or re-enable an account the
+//     user manually disabled.
+//
+// A no-op when no account lister is wired (nil-default) or no Google accounts
+// are connected. A per-account create error is returned (callers log it WARN and
+// do not block boot); a benign concurrent-create unique violation is treated as
+// "already exists, skip" rather than a failure.
+func (s *SyncService) ReconcileGChatSyncStates(ctx context.Context) error {
+	if s.gchatAccountLister == nil {
+		logger.Debug().Msg("gchat sync reconciliation: no account lister wired; skipping")
+		return nil
+	}
+
+	accounts, err := s.gchatAccountLister.ListAccounts(ctx)
+	if err != nil {
+		return fmt.Errorf("list google accounts: %w", err)
+	}
+
+	for _, account := range accounts {
+		accountID := account.AccountID
+		if accountID == "" {
+			// A credential with no account id cannot be probed per-account
+			// (GetSyncStateBySource COALESCE-matches account_id) and would
+			// produce a stray (gchat, NULL) row the provider rejects. Skip it.
+			logger.Warn().Msg("gchat sync reconciliation: skipping google credential with empty account id")
+			continue
+		}
+
+		// Scope gate FIRST: an account missing chat.spaces.readonly is not
+		// enabled (no state created). This is the enablement gate — unlike the
+		// email reconciliation, which creates regardless and only warns. The
+		// account id is the user's own connected mailbox address (operational
+		// provenance, already in oauth_credential), not third-party PII.
+		if !accountHasChatScope(account) {
+			logger.Info().
+				Str("account", accountID).
+				Msg("gchat sync: account missing chat scopes; not enabling until reconnected")
+			continue
+		}
+
+		acctID := accountID
+		_, getErr := s.syncRepo.GetSyncStateBySource(ctx, gchatSyncSource, &acctID)
+		if getErr == nil {
+			// Found: leave it completely untouched (idempotency contract).
+			continue
+		}
+		if !errors.Is(getErr, db.ErrNotFound) {
+			return fmt.Errorf("probe gchat sync state for account: %w", getErr)
+		}
+
+		// Absent: create the per-account enabled state.
+		if _, createErr := s.syncRepo.CreateSyncState(ctx, repository.CreateSyncStateRequest{
+			Source:    gchatSyncSource,
+			AccountID: &acctID,
+			Enabled:   true,
+			Strategy:  repository.SyncStrategyContactDriven,
+			Metadata:  map[string]any{"backfill_since": syncpkg.EmailBackfillSinceDefault},
+			// NextSyncAt left nil → NULL → immediately due on the next tick.
+		}); createErr != nil {
+			if isUniqueViolation(createErr) {
+				// Benign concurrent create (another connect/boot raced us).
+				// The row now exists and is untouched, which is the desired
+				// end state — skip rather than fail the whole reconciliation.
+				logger.Debug().Msg("gchat sync reconciliation: state already created concurrently; skipping")
+				continue
+			}
+			return fmt.Errorf("create gchat sync state for account: %w", createErr)
+		}
+
+		logger.Info().
+			Str("source", gchatSyncSource).
+			Str("account", accountID).
+			Msg("gchat sync reconciliation: created enabled gchat sync state")
+	}
+
+	return nil
+}
+
+// accountHasChatScope reports whether a connected Google account's stored scope
+// list contains chat.spaces.readonly — the enablement gate for GChat sync.
+func accountHasChatScope(account repository.OAuthCredentialStatus) bool {
+	for _, scope := range account.Scopes {
+		if scope == gchatSpacesReadonlyScope {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/service/sync.go
+++ b/backend/internal/service/sync.go
@@ -38,6 +38,11 @@ type SyncService struct {
 	// only). When nil (tests / no-Google builds / off-mode)
 	// ReconcileEmailSyncStates is a no-op. See email_reconcile.go.
 	emailAccountLister GoogleAccountLister
+	// gchatAccountLister is set at boot by SetGChatAccountLister. When nil
+	// (tests / no-Google builds) ReconcileGChatSyncStates is a no-op. A
+	// dedicated field (vs. reusing emailAccountLister) keeps gchat enablement
+	// independently nil-gated. See gchat_reconcile.go.
+	gchatAccountLister GoogleAccountLister
 }
 
 // NewSyncService creates a new sync service

--- a/backend/tests/gchat_enablement_reconcile_test.go
+++ b/backend/tests/gchat_enablement_reconcile_test.go
@@ -1,0 +1,327 @@
+// Integration coverage for SyncService.ReconcileGChatSyncStates (GChat
+// integration PR 3 — the GO-LIVE enablement reconciliation). These tests drive
+// the REAL service method against a REAL external_sync_state table via the
+// repository (no raw SQL), with a stub GoogleAccountLister (no OAuth). They
+// prove the chat-scope enablement gate + the idempotency contract that makes
+// the store-only / event-free feature safe to run on every boot AND every OAuth
+// connect:
+//   - one enabled (gchat, account) state created per SCOPED Google credential;
+//   - an account missing the chat scope gets NO state (the enablement gate —
+//     the one behavioral departure from the email reconciliation);
+//   - re-running creates no duplicates and resets no cursor/metadata;
+//   - a user-disabled state is never re-enabled;
+//   - a re-consent (scope appears on a second pass) opens the gate;
+//   - the per-account shape invariant holds (no (gchat, NULL) row is produced);
+//   - empty account list / nil lister are no-ops;
+//   - the OAuth-connect reconciler closure is idempotent on re-connect;
+//   - the status data path (GetSyncStatus) surfaces the gchat state (DD-5).
+//
+// Account ids are synthetic placeholders (NO real PII). All assertions go
+// through the SyncRepository; timestamps are accelerated.GetCurrentTime()-safe.
+// The reconcileEnv + reconcileStubLister + uniqueAccount helpers are shared with
+// gmail_enablement_reconcile_test.go (same package).
+package tests
+
+import (
+	"testing"
+
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/stretchr/testify/require"
+)
+
+const gchatSpacesReadonlyScopeForTest = "https://www.googleapis.com/auth/chat.spaces.readonly"
+
+func (e *reconcileEnv) getGChatState(t *testing.T, accountID string) *repository.SyncState {
+	t.Helper()
+	acct := accountID
+	st, err := e.syncRepo.GetSyncStateBySource(e.ctx, "gchat", &acct)
+	require.NoError(t, err)
+	return st
+}
+
+// countGChatStatesForAccount counts live (gchat, account) rows via the
+// repository's ListSyncStates (no raw SQL).
+func (e *reconcileEnv) countGChatStatesForAccount(t *testing.T, accountID string) int {
+	t.Helper()
+	states, err := e.syncRepo.ListSyncStates(e.ctx)
+	require.NoError(t, err)
+	n := 0
+	for _, st := range states {
+		if st.Source == "gchat" && st.AccountID != nil && *st.AccountID == accountID {
+			n++
+		}
+	}
+	return n
+}
+
+// --- creates one state per SCOPED credential; unscoped gets none ------------
+
+func TestReconcileGChat_CreatesStatePerScopedCredential(t *testing.T) {
+	e := newReconcileEnv(t)
+	scoped1 := uniqueAccount("gchat-scoped1")
+	scoped2 := uniqueAccount("gchat-scoped2")
+	unscoped := uniqueAccount("gchat-unscoped")
+	for _, acct := range []string{scoped1, scoped2, unscoped} {
+		e.cleanupAccount(t, acct)
+	}
+
+	lister := &reconcileStubLister{accounts: []repository.OAuthCredentialStatus{
+		credWithScope(scoped1, gchatSpacesReadonlyScopeForTest),
+		credWithScope(scoped2, gchatSpacesReadonlyScopeForTest),
+		// Unscoped: connected but never re-consented to the chat scopes.
+		credWithScope(unscoped, "openid", "email", "profile"),
+	}}
+	e.service.SetGChatAccountLister(lister)
+
+	require.NoError(t, e.service.ReconcileGChatSyncStates(e.ctx))
+
+	// Both scoped accounts get an enabled state with the expected shape.
+	for _, acct := range []string{scoped1, scoped2} {
+		st := e.getGChatState(t, acct)
+		require.Equal(t, "gchat", st.Source)
+		require.NotNil(t, st.AccountID, "per-account shape: account_id must be set")
+		require.Equal(t, acct, *st.AccountID)
+		require.True(t, st.Enabled, "scoped account is enabled")
+		require.Equal(t, repository.SyncStrategyContactDriven, st.Strategy)
+		require.Equal(t, repository.SyncStatusIdle, st.Status)
+		require.Nil(t, st.SyncCursor, "cursor starts empty")
+		require.Nil(t, st.NextSyncAt, "next_sync_at NULL → immediately due on first tick")
+		require.Equal(t, "2026-01-01", st.Metadata["backfill_since"])
+	}
+
+	// The UNSCOPED account has NO gchat state — the enablement gate.
+	unscopedAcct := unscoped
+	_, err := e.syncRepo.GetSyncStateBySource(e.ctx, "gchat", &unscopedAcct)
+	require.ErrorIs(t, err, db.ErrNotFound, "unscoped account must NOT get a gchat state (enablement gate)")
+}
+
+// --- scope gate is the CREATE gate, not warn-and-create ---------------------
+
+func TestReconcileGChat_ScopeGate_NoStateForUnscopedAccount(t *testing.T) {
+	e := newReconcileEnv(t)
+	acct := uniqueAccount("gchat-gate")
+	e.cleanupAccount(t, acct)
+
+	lister := &reconcileStubLister{accounts: []repository.OAuthCredentialStatus{
+		credWithScope(acct, "openid", "email", "profile", gmailReadonlyScopeForTest),
+	}}
+	e.service.SetGChatAccountLister(lister)
+
+	// Reconciliation succeeds (nil) but creates NO state for the unscoped
+	// account — contrast with email, which creates + warns.
+	require.NoError(t, e.service.ReconcileGChatSyncStates(e.ctx))
+
+	acctID := acct
+	_, err := e.syncRepo.GetSyncStateBySource(e.ctx, "gchat", &acctID)
+	require.ErrorIs(t, err, db.ErrNotFound, "scope gate: unscoped account gets no state")
+	require.Equal(t, 0, e.countGChatStatesForAccount(t, acct))
+}
+
+// --- idempotent re-run: no duplicates, no cursor/metadata reset -------------
+
+func TestReconcileGChat_IdempotentRerun_NoDuplicatesNoReset(t *testing.T) {
+	e := newReconcileEnv(t)
+	acct := uniqueAccount("gchat-idem")
+	e.cleanupAccount(t, acct)
+
+	lister := &reconcileStubLister{accounts: []repository.OAuthCredentialStatus{
+		credWithScope(acct, gchatSpacesReadonlyScopeForTest),
+	}}
+	e.service.SetGChatAccountLister(lister)
+
+	// First run creates the state.
+	require.NoError(t, e.service.ReconcileGChatSyncStates(e.ctx))
+	created := e.getGChatState(t, acct)
+
+	// Simulate steady-state progress: advance metadata as a sweep would
+	// (per-space cursors + a different backfill floor).
+	advanced := map[string]any{
+		"backfill_since": "2026-03-15",
+		"space_cursors":  map[string]any{"spaces/AAA": "token-123"},
+		"extra":          "keep-me",
+	}
+	_, err := e.syncRepo.UpdateSyncStateMetadata(e.ctx, created.ID, advanced)
+	require.NoError(t, err)
+
+	// Re-run reconciliation.
+	require.NoError(t, e.service.ReconcileGChatSyncStates(e.ctx))
+
+	// Still exactly one (gchat, account) state, metadata intact.
+	after := e.getGChatState(t, acct)
+	require.Equal(t, created.ID, after.ID, "no duplicate state; same row")
+	require.Equal(t, "2026-03-15", after.Metadata["backfill_since"], "backfill NOT reset")
+	require.Equal(t, "keep-me", after.Metadata["extra"], "existing metadata preserved")
+	require.Contains(t, after.Metadata, "space_cursors", "space_cursors NOT reset")
+	cursors, ok := after.Metadata["space_cursors"].(map[string]any)
+	require.True(t, ok, "space_cursors preserved as a map")
+	require.Equal(t, "token-123", cursors["spaces/AAA"], "per-space cursor preserved")
+
+	require.Equal(t, 1, e.countGChatStatesForAccount(t, acct))
+}
+
+// --- respects a user-disabled state (never re-enabled) ----------------------
+
+func TestReconcileGChat_RespectsUserDisabled(t *testing.T) {
+	e := newReconcileEnv(t)
+	acct := uniqueAccount("gchat-disabled")
+	e.cleanupAccount(t, acct)
+
+	lister := &reconcileStubLister{accounts: []repository.OAuthCredentialStatus{
+		credWithScope(acct, gchatSpacesReadonlyScopeForTest),
+	}}
+	e.service.SetGChatAccountLister(lister)
+
+	require.NoError(t, e.service.ReconcileGChatSyncStates(e.ctx))
+	created := e.getGChatState(t, acct)
+
+	// User disables the account via the existing enable/disable path.
+	_, err := e.syncRepo.UpdateSyncStateEnabled(e.ctx, created.ID, false)
+	require.NoError(t, err)
+
+	// Re-run reconciliation — must NOT re-enable (create-if-absent only).
+	require.NoError(t, e.service.ReconcileGChatSyncStates(e.ctx))
+
+	after := e.getGChatState(t, acct)
+	require.Equal(t, created.ID, after.ID)
+	require.False(t, after.Enabled, "user-disabled state must stay disabled (never re-enabled)")
+}
+
+// --- re-consent transition: the gate opens when the scope appears -----------
+
+func TestReconcileGChat_ReConsentTransition_GateOpens(t *testing.T) {
+	e := newReconcileEnv(t)
+	acct := uniqueAccount("gchat-reconsent")
+	e.cleanupAccount(t, acct)
+
+	// Start unscoped: no state created.
+	unscopedLister := &reconcileStubLister{accounts: []repository.OAuthCredentialStatus{
+		credWithScope(acct, "openid", "email", "profile"),
+	}}
+	e.service.SetGChatAccountLister(unscopedLister)
+	require.NoError(t, e.service.ReconcileGChatSyncStates(e.ctx))
+	require.Equal(t, 0, e.countGChatStatesForAccount(t, acct), "no state before re-consent")
+
+	// Simulate re-consent: the same account now carries the chat scope.
+	scopedLister := &reconcileStubLister{accounts: []repository.OAuthCredentialStatus{
+		credWithScope(acct, "openid", "email", "profile", gchatSpacesReadonlyScopeForTest),
+	}}
+	e.service.SetGChatAccountLister(scopedLister)
+	require.NoError(t, e.service.ReconcileGChatSyncStates(e.ctx))
+
+	st := e.getGChatState(t, acct)
+	require.True(t, st.Enabled, "state created + enabled after re-consent")
+	require.Equal(t, 1, e.countGChatStatesForAccount(t, acct))
+}
+
+// --- per-account shape invariant: no (gchat, NULL) row ever produced --------
+
+func TestReconcileGChat_PerAccountShape_NoNullAccountRow(t *testing.T) {
+	e := newReconcileEnv(t)
+	acct := uniqueAccount("gchat-shape")
+	e.cleanupAccount(t, acct)
+
+	lister := &reconcileStubLister{accounts: []repository.OAuthCredentialStatus{
+		credWithScope(acct, gchatSpacesReadonlyScopeForTest),
+		// An empty-account-id credential must be skipped, not turned into a
+		// (gchat, NULL) row the provider rejects.
+		credWithScope("", gchatSpacesReadonlyScopeForTest),
+	}}
+	e.service.SetGChatAccountLister(lister)
+
+	require.NoError(t, e.service.ReconcileGChatSyncStates(e.ctx))
+
+	// The per-account row exists with a non-NULL account_id.
+	st := e.getGChatState(t, acct)
+	require.NotNil(t, st.AccountID)
+	require.Equal(t, acct, *st.AccountID)
+
+	// No (gchat, NULL) orphan row exists.
+	_, err := e.syncRepo.GetSyncStateBySource(e.ctx, "gchat", nil)
+	require.ErrorIs(t, err, db.ErrNotFound, "reconciliation must never create a (gchat, NULL) row")
+}
+
+// --- empty account list is a no-op ------------------------------------------
+
+func TestReconcileGChat_EmptyAccountList_NoOp(t *testing.T) {
+	e := newReconcileEnv(t)
+	lister := &reconcileStubLister{accounts: nil}
+	e.service.SetGChatAccountLister(lister)
+
+	require.NoError(t, e.service.ReconcileGChatSyncStates(e.ctx))
+	require.Equal(t, 1, lister.calls, "lister was consulted")
+}
+
+// --- nil lister is a no-op (does not even consult a lister) ------------------
+
+func TestReconcileGChat_NilLister_NoOp(t *testing.T) {
+	e := newReconcileEnv(t)
+	// No SetGChatAccountLister call → nil lister.
+	require.NoError(t, e.service.ReconcileGChatSyncStates(e.ctx))
+}
+
+// --- OAuth-connect reconciler closure is idempotent on re-connect -----------
+
+func TestReconcileGChat_ConnectPath_IdempotentOnReconnect(t *testing.T) {
+	e := newReconcileEnv(t)
+	scoped := uniqueAccount("gchat-connect")
+	unscoped := uniqueAccount("gchat-connect-unscoped")
+	e.cleanupAccount(t, scoped)
+	e.cleanupAccount(t, unscoped)
+
+	lister := &reconcileStubLister{accounts: []repository.OAuthCredentialStatus{
+		credWithScope(scoped, gchatSpacesReadonlyScopeForTest),
+		credWithScope(unscoped, "openid", "email", "profile"),
+	}}
+	e.service.SetGChatAccountLister(lister)
+
+	// The OAuth-connect hook (main.go) is exactly this closure shape.
+	reconcile := func() error {
+		return e.service.ReconcileGChatSyncStates(e.ctx)
+	}
+
+	// First connect creates the scoped state; the unscoped one gets nothing.
+	require.NoError(t, reconcile())
+	first := e.getGChatState(t, scoped)
+	require.Equal(t, 0, e.countGChatStatesForAccount(t, unscoped), "unscoped connect creates no state")
+
+	// Second connect of the same accounts is a no-op (no duplicate, untouched).
+	require.NoError(t, reconcile())
+	second := e.getGChatState(t, scoped)
+	require.Equal(t, first.ID, second.ID)
+	require.Equal(t, 1, e.countGChatStatesForAccount(t, scoped))
+}
+
+// --- status data path surfaces the gchat state (DD-5 verification) ----------
+
+func TestReconcileGChat_StatusSurfacesGChatState(t *testing.T) {
+	e := newReconcileEnv(t)
+	acct := uniqueAccount("gchat-status")
+	e.cleanupAccount(t, acct)
+
+	lister := &reconcileStubLister{accounts: []repository.OAuthCredentialStatus{
+		credWithScope(acct, gchatSpacesReadonlyScopeForTest),
+	}}
+	e.service.SetGChatAccountLister(lister)
+	require.NoError(t, e.service.ReconcileGChatSyncStates(e.ctx))
+
+	// GetSyncStatus is the data path behind GET /api/v1/sync/status. The gchat
+	// state must surface there with the generic SyncState shape (no new fields)
+	// once reconciliation enables it — this is what "mirror Gmail's status
+	// shape" means (DD-5): GChat surfaces through the identical generic row.
+	states, err := e.service.GetSyncStatus(e.ctx)
+	require.NoError(t, err)
+
+	var found *repository.SyncState
+	for i := range states {
+		st := states[i]
+		if st.Source == "gchat" && st.AccountID != nil && *st.AccountID == acct {
+			found = &states[i]
+			break
+		}
+	}
+	require.NotNil(t, found, "gchat state must surface via GetSyncStatus (the /sync/status data path)")
+	require.True(t, found.Enabled)
+	require.Equal(t, "2026-01-01", found.Metadata["backfill_since"])
+}

--- a/backend/tests/gchat_enablement_reconcile_test.go
+++ b/backend/tests/gchat_enablement_reconcile_test.go
@@ -31,7 +31,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const gchatSpacesReadonlyScopeForTest = "https://www.googleapis.com/auth/chat.spaces.readonly"
+// The full chat-scope set the enablement gate requires (all three). A partial
+// grant (any subset) must NOT enable the account.
+const (
+	gchatSpacesReadonlyScopeForTest      = "https://www.googleapis.com/auth/chat.spaces.readonly"
+	gchatMessagesReadonlyScopeForTest    = "https://www.googleapis.com/auth/chat.messages.readonly"
+	gchatMembershipsReadonlyScopeForTest = "https://www.googleapis.com/auth/chat.memberships.readonly"
+)
+
+// allChatScopesForTest returns the full chat-scope set a credential needs to be
+// enabled by ReconcileGChatSyncStates, optionally prefixed with extra scopes.
+func allChatScopesForTest(extra ...string) []string {
+	return append(extra,
+		gchatSpacesReadonlyScopeForTest,
+		gchatMessagesReadonlyScopeForTest,
+		gchatMembershipsReadonlyScopeForTest,
+	)
+}
+
+// chatScopedCred builds a credential carrying the full chat-scope set (the
+// enablement-positive case).
+func chatScopedCred(accountID string) repository.OAuthCredentialStatus {
+	return credWithScope(accountID, allChatScopesForTest()...)
+}
 
 func (e *reconcileEnv) getGChatState(t *testing.T, accountID string) *repository.SyncState {
 	t.Helper()
@@ -68,8 +90,8 @@ func TestReconcileGChat_CreatesStatePerScopedCredential(t *testing.T) {
 	}
 
 	lister := &reconcileStubLister{accounts: []repository.OAuthCredentialStatus{
-		credWithScope(scoped1, gchatSpacesReadonlyScopeForTest),
-		credWithScope(scoped2, gchatSpacesReadonlyScopeForTest),
+		chatScopedCred(scoped1),
+		chatScopedCred(scoped2),
 		// Unscoped: connected but never re-consented to the chat scopes.
 		credWithScope(unscoped, "openid", "email", "profile"),
 	}}
@@ -119,6 +141,40 @@ func TestReconcileGChat_ScopeGate_NoStateForUnscopedAccount(t *testing.T) {
 	require.Equal(t, 0, e.countGChatStatesForAccount(t, acct))
 }
 
+// --- scope gate requires the FULL chat-scope set (partial grants rejected) ---
+
+func TestReconcileGChat_ScopeGate_PartialChatScopesNotEnabled(t *testing.T) {
+	e := newReconcileEnv(t)
+
+	// Each subset is missing at least one required scope, so none must enable.
+	partials := map[string][]string{
+		"spaces-only":      {gchatSpacesReadonlyScopeForTest},
+		"messages-only":    {gchatMessagesReadonlyScopeForTest},
+		"memberships-only": {gchatMembershipsReadonlyScopeForTest},
+		"spaces+messages":  {gchatSpacesReadonlyScopeForTest, gchatMessagesReadonlyScopeForTest},
+		"missing-spaces":   {gchatMessagesReadonlyScopeForTest, gchatMembershipsReadonlyScopeForTest},
+	}
+
+	for name, scopes := range partials {
+		t.Run(name, func(t *testing.T) {
+			acct := uniqueAccount("gchat-partial-" + name)
+			e.cleanupAccount(t, acct)
+
+			lister := &reconcileStubLister{accounts: []repository.OAuthCredentialStatus{
+				credWithScope(acct, append([]string{"openid", "email"}, scopes...)...),
+			}}
+			e.service.SetGChatAccountLister(lister)
+
+			require.NoError(t, e.service.ReconcileGChatSyncStates(e.ctx))
+
+			acctID := acct
+			_, err := e.syncRepo.GetSyncStateBySource(e.ctx, "gchat", &acctID)
+			require.ErrorIs(t, err, db.ErrNotFound, "partial chat-scope grant must NOT enable gchat sync")
+			require.Equal(t, 0, e.countGChatStatesForAccount(t, acct))
+		})
+	}
+}
+
 // --- idempotent re-run: no duplicates, no cursor/metadata reset -------------
 
 func TestReconcileGChat_IdempotentRerun_NoDuplicatesNoReset(t *testing.T) {
@@ -127,7 +183,7 @@ func TestReconcileGChat_IdempotentRerun_NoDuplicatesNoReset(t *testing.T) {
 	e.cleanupAccount(t, acct)
 
 	lister := &reconcileStubLister{accounts: []repository.OAuthCredentialStatus{
-		credWithScope(acct, gchatSpacesReadonlyScopeForTest),
+		chatScopedCred(acct),
 	}}
 	e.service.SetGChatAccountLister(lister)
 
@@ -169,7 +225,7 @@ func TestReconcileGChat_RespectsUserDisabled(t *testing.T) {
 	e.cleanupAccount(t, acct)
 
 	lister := &reconcileStubLister{accounts: []repository.OAuthCredentialStatus{
-		credWithScope(acct, gchatSpacesReadonlyScopeForTest),
+		chatScopedCred(acct),
 	}}
 	e.service.SetGChatAccountLister(lister)
 
@@ -203,15 +259,24 @@ func TestReconcileGChat_ReConsentTransition_GateOpens(t *testing.T) {
 	require.NoError(t, e.service.ReconcileGChatSyncStates(e.ctx))
 	require.Equal(t, 0, e.countGChatStatesForAccount(t, acct), "no state before re-consent")
 
-	// Simulate re-consent: the same account now carries the chat scope.
-	scopedLister := &reconcileStubLister{accounts: []repository.OAuthCredentialStatus{
+	// A PARTIAL grant (only spaces.readonly, missing messages/memberships) must
+	// NOT open the gate — enabling on a subset would only fail mid-sweep.
+	partialLister := &reconcileStubLister{accounts: []repository.OAuthCredentialStatus{
 		credWithScope(acct, "openid", "email", "profile", gchatSpacesReadonlyScopeForTest),
+	}}
+	e.service.SetGChatAccountLister(partialLister)
+	require.NoError(t, e.service.ReconcileGChatSyncStates(e.ctx))
+	require.Equal(t, 0, e.countGChatStatesForAccount(t, acct), "partial chat-scope grant must not enable")
+
+	// Simulate full re-consent: the same account now carries ALL THREE chat scopes.
+	scopedLister := &reconcileStubLister{accounts: []repository.OAuthCredentialStatus{
+		credWithScope(acct, allChatScopesForTest("openid", "email", "profile")...),
 	}}
 	e.service.SetGChatAccountLister(scopedLister)
 	require.NoError(t, e.service.ReconcileGChatSyncStates(e.ctx))
 
 	st := e.getGChatState(t, acct)
-	require.True(t, st.Enabled, "state created + enabled after re-consent")
+	require.True(t, st.Enabled, "state created + enabled after full re-consent")
 	require.Equal(t, 1, e.countGChatStatesForAccount(t, acct))
 }
 
@@ -223,10 +288,10 @@ func TestReconcileGChat_PerAccountShape_NoNullAccountRow(t *testing.T) {
 	e.cleanupAccount(t, acct)
 
 	lister := &reconcileStubLister{accounts: []repository.OAuthCredentialStatus{
-		credWithScope(acct, gchatSpacesReadonlyScopeForTest),
-		// An empty-account-id credential must be skipped, not turned into a
-		// (gchat, NULL) row the provider rejects.
-		credWithScope("", gchatSpacesReadonlyScopeForTest),
+		chatScopedCred(acct),
+		// An empty-account-id credential (even fully chat-scoped) must be
+		// skipped, not turned into a (gchat, NULL) row the provider rejects.
+		chatScopedCred(""),
 	}}
 	e.service.SetGChatAccountLister(lister)
 
@@ -271,7 +336,7 @@ func TestReconcileGChat_ConnectPath_IdempotentOnReconnect(t *testing.T) {
 	e.cleanupAccount(t, unscoped)
 
 	lister := &reconcileStubLister{accounts: []repository.OAuthCredentialStatus{
-		credWithScope(scoped, gchatSpacesReadonlyScopeForTest),
+		chatScopedCred(scoped),
 		credWithScope(unscoped, "openid", "email", "profile"),
 	}}
 	e.service.SetGChatAccountLister(lister)
@@ -301,7 +366,7 @@ func TestReconcileGChat_StatusSurfacesGChatState(t *testing.T) {
 	e.cleanupAccount(t, acct)
 
 	lister := &reconcileStubLister{accounts: []repository.OAuthCredentialStatus{
-		credWithScope(acct, gchatSpacesReadonlyScopeForTest),
+		chatScopedCred(acct),
 	}}
 	e.service.SetGChatAccountLister(lister)
 	require.NoError(t, e.service.ReconcileGChatSyncStates(e.ctx))

--- a/backend/tests/gchat_golive_integration_test.go
+++ b/backend/tests/gchat_golive_integration_test.go
@@ -129,7 +129,7 @@ func TestGChatGoLive_RegisteredProvider_SchedulerSweep_ProducesInteractionsAndCa
 	// reconciliation would: chat-scope-gated, enabled, contact_driven,
 	// backfill_since, NO cursor (the provider materializes space_cursors).
 	stateLister := &reconcileStubLister{accounts: []repository.OAuthCredentialStatus{
-		credWithScope(account, gchatSpacesReadonlyScopeForTest),
+		chatScopedCred(account),
 	}}
 	reconcileSvc := service.NewSyncService(syncRepo, contactRepo, registry)
 	reconcileSvc.SetGChatAccountLister(stateLister)

--- a/backend/tests/gchat_golive_integration_test.go
+++ b/backend/tests/gchat_golive_integration_test.go
@@ -1,0 +1,218 @@
+// Go-live acceptance for the GChat integration (PR 3, spec §8 Phase 3). This is
+// the end-to-end proof that flipping the feature on actually works: a
+// GChatSyncProvider registered in a real ProviderRegistry, an enabled
+// (gchat, account) external_sync_state created exactly as the boot
+// reconciliation creates it (chat-scope-gated), and the sweep driven through the
+// SyncService.RunAccountSync worker entry point (NOT a direct provider.Sync
+// call) so the registered-provider + state-fetch + metadata-cursor-write path is
+// exercised. The REAL GChat aggregation engine + InteractionRecorder +
+// CadenceUpdater are wired (via the shared gchat engine harness) so derived
+// interactions + cadence are asserted, not just stored content rows.
+//
+// It proves: provider registered → scheduler-driven sweep → comms_message rows →
+// aggregation → interactions (with a "GChat …(N messages)" description) →
+// cadence (last_contacted for inbound, last_outreach_at for outbound), no
+// contact created for an unknown participant, and the per-space cursor advanced
+// in metadata so a second sweep is incremental.
+//
+// Unlike Gmail, GChat is event-free: the provider only writes content rows, and
+// the aggregation engine (driven here via AggregateForContactBatch — the path
+// the sweeper/reenqueuer drive) derives the interactions. The tick-enumeration /
+// ListDueAccounts → enqueue chain is covered by the scheduler's own tests. The
+// fetcher + me-set are injected fakes (NEVER the live Chat API); addresses are
+// placeholders (NO PII).
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/google"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+	syncpkg "personal-crm/backend/internal/sync"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	chat "google.golang.org/api/chat/v1"
+)
+
+// TestGChatGoLive_RegisteredProvider_SchedulerSweep_ProducesInteractionsAndCadence
+// is the PR-3 go-live acceptance test.
+func TestGChatGoLive_RegisteredProvider_SchedulerSweep_ProducesInteractionsAndCadence(t *testing.T) {
+	e := setupGChatEngineTest(t) // engine + live bus + recorder + cadence + repos
+	suffix := randomSuffix(t)
+
+	contactRepo := e.contactRepo
+	contactRepo.SetPool(e.database.Pool)
+	methodRepo := repository.NewContactMethodRepository(e.database.Queries)
+	syncRepo := repository.NewSyncRepositoryWithPool(e.database.Queries, e.database.Pool)
+	identityRepo := repository.NewIdentityRepository(e.database.Queries)
+
+	account := "me-" + suffix + "@example.test"
+
+	// Known contact + email method (appears in the provider's dual-source known
+	// map). A cadence makes the contact_by recompute observable.
+	cadence := "weekly"
+	contact, err := contactRepo.CreateContact(e.ctx, repository.CreateContactRequest{
+		FullName: "GChat GoLive " + suffix,
+		Cadence:  &cadence,
+	})
+	require.NoError(t, err)
+	peerEmail := "peer-" + suffix + "@example.test"
+	_, err = methodRepo.CreateContactMethod(e.ctx, repository.CreateContactMethodRequest{
+		ContactID: contact.ID,
+		Type:      string(repository.ContactMethodEmail),
+		Value:     peerEmail,
+		IsPrimary: true,
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = e.commsRepo.HardDeleteByContact(e.ctx, contact.ID)
+		_ = e.interactionRepo.HardDeleteInteractionsBySourceRefPrefix(e.ctx, repository.InteractionSourceGChat, "gchat:%")
+		_ = contactRepo.SoftDeleteContact(e.ctx, contact.ID)
+		_ = syncRepo.DeleteSyncStatesByAccountID(e.ctx, account)
+	})
+
+	spaceName := "spaces/GOLIVE-" + suffix
+	inMsg := spaceName + "/messages/in-" + suffix
+	outMsg := spaceName + "/messages/out-" + suffix
+	bystanderMsg := spaceName + "/messages/by-" + suffix
+	base := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Second)
+	// Unknown participant the sweep must NOT turn into a contact.
+	stranger := "stranger-" + suffix + "@example.test"
+
+	funcs := google.FakeChatFetcherFuncs{
+		ListSpaces: func(context.Context, string) ([]*chat.Space, string, error) {
+			return []*chat.Space{space(spaceName, "SPACE")}, "", nil
+		},
+		ListMembers: func(context.Context, string, string) ([]*chat.Membership, string, error) {
+			return []*chat.Membership{membership("users/peer"), membership("users/me"), membership("users/stranger")}, "", nil
+		},
+		ListMessages: func(_ context.Context, _, _ string, showDeleted bool, _ string) ([]*chat.Message, string, error) {
+			if showDeleted {
+				return nil, "", nil // edit/delete pass: nothing
+			}
+			return []*chat.Message{
+				chatMessage(inMsg, "users/peer", "hey there", base),
+				chatMessage(outMsg, "users/me", "replying", base.Add(30*time.Minute)),
+				// A message between "me" and an unknown address: a bystander to
+				// the known contact, must not create a contact.
+				chatMessage(bystanderMsg, "users/stranger", "who am i", base.Add(45*time.Minute)),
+			}, "", nil
+		},
+		ResolvePersonEmail: func(_ context.Context, userName string) (string, error) {
+			switch userName {
+			case "users/peer":
+				return peerEmail, nil
+			case "users/me":
+				return account, nil
+			case "users/stranger":
+				return stranger, nil
+			}
+			return "", nil
+		},
+	}
+
+	provider := google.NewGChatSyncProvider(nil, e.commsRepo, syncRepo)
+	provider.SetFetcherFactoryForTest(google.NewFakeChatFetcherFactoryForTest(funcs))
+	provider.SetMeSetForTest(map[string]struct{}{account: {}})
+
+	registry := syncpkg.NewProviderRegistry()
+	registry.Register(provider)
+
+	// Create the enabled (gchat, account) state exactly as the boot
+	// reconciliation would: chat-scope-gated, enabled, contact_driven,
+	// backfill_since, NO cursor (the provider materializes space_cursors).
+	stateLister := &reconcileStubLister{accounts: []repository.OAuthCredentialStatus{
+		credWithScope(account, gchatSpacesReadonlyScopeForTest),
+	}}
+	reconcileSvc := service.NewSyncService(syncRepo, contactRepo, registry)
+	reconcileSvc.SetGChatAccountLister(stateLister)
+	require.NoError(t, reconcileSvc.ReconcileGChatSyncStates(e.ctx))
+
+	// Sanity: the reconciliation created the enabled state the sweep fetches,
+	// with an empty per-space cursor map (not yet materialized).
+	acct := account
+	created, err := syncRepo.GetSyncStateBySource(e.ctx, "gchat", &acct)
+	require.NoError(t, err)
+	require.True(t, created.Enabled)
+	require.NotContains(t, created.Metadata, "space_cursors", "no per-space cursor before the first sweep")
+
+	// Drive the sweep through the worker entry point: RunAccountSync fetches
+	// fresh state from the registry-backed provider, runs Sync, and persists the
+	// advanced per-space cursor into metadata.
+	sweepSvc := service.NewSyncService(syncRepo, contactRepo, registry)
+	require.NoError(t, sweepSvc.RunAccountSync(e.ctx, "gchat", &acct))
+
+	// Content rows exist for both qualifying directions (inbound + outbound),
+	// none for the unknown bystander.
+	inRow, err := e.commsRepo.GetMessage(e.ctx, repository.InteractionSourceGChat, inMsg, contact.ID)
+	require.NoError(t, err)
+	assert.Equal(t, repository.InteractionDirectionInbound, inRow.Direction)
+	outRow, err := e.commsRepo.GetMessage(e.ctx, repository.InteractionSourceGChat, outMsg, contact.ID)
+	require.NoError(t, err)
+	assert.Equal(t, repository.InteractionDirectionOutbound, outRow.Direction)
+
+	// Aggregate the contact's unprocessed gchat chats — the path the
+	// sweeper/reenqueuer drive (discovers the space itself, no hard-coding).
+	require.NoError(t, e.engine.AggregateForContactBatch(e.ctx, contact.ID))
+
+	// The recorder derives interactions asynchronously after the publish. An
+	// inbound-then-outbound ordering produces two same-direction interactions
+	// (one inbound, one outbound — the inbound precedes the outbound, so the
+	// 48h reply bridge that would promote an OUTBOUND to mutual does not apply;
+	// that promotion path is covered by the engine's own bridge test).
+	interactions := waitForInteractionCountExact(t, e.ctx, e.interactionRepo, contact.ID, 2, defaultInteractionWaitTimeout)
+	require.Len(t, interactions, 2)
+	dirs := map[string]bool{}
+	for _, in := range interactions {
+		assert.Equal(t, repository.InteractionSourceGChat, in.Source)
+		require.NotNil(t, in.Description, "every gchat interaction carries a description")
+		assert.Contains(t, *in.Description, "GChat", "description is a GChat …(N messages) summary")
+		assert.Contains(t, *in.Description, "message", "description reports the aggregated message count")
+		dirs[in.Direction] = true
+	}
+	assert.True(t, dirs[repository.InteractionDirectionInbound], "an inbound gchat interaction was derived")
+	assert.True(t, dirs[repository.InteractionDirectionOutbound], "an outbound gchat interaction was derived")
+
+	// Cadence: the inbound bumps last_contacted; the outbound bumps
+	// last_outreach_at.
+	c := waitForBothGChatCadence(t, e.ctx, contactRepo, contact.ID)
+	require.NotNil(t, c.LastContacted, "inbound bumps last_contacted")
+	require.NotNil(t, c.LastOutreachAt, "outbound bumps last_outreach_at")
+
+	// Match-only: the unknown participant never produced a contact_method.
+	unknownMatches, err := identityRepo.FindContactMethodsByValue(e.ctx, []string{"email"}, stranger)
+	require.NoError(t, err)
+	require.Empty(t, unknownMatches, "unknown participant must not create a contact")
+
+	// Per-space cursor advanced off empty → a second RunAccountSync is incremental.
+	after, err := syncRepo.GetSyncStateBySource(e.ctx, "gchat", &acct)
+	require.NoError(t, err)
+	require.Contains(t, after.Metadata, "space_cursors", "per-space cursor materialized after the sweep")
+	cursors, ok := after.Metadata["space_cursors"].(map[string]any)
+	require.True(t, ok, "space_cursors is a map")
+	require.Contains(t, cursors, spaceName, "the swept space has an advanced cursor")
+}
+
+// waitForBothGChatCadence polls until both last_contacted and last_outreach_at
+// are set on the contact.
+func waitForBothGChatCadence(t *testing.T, ctx context.Context, contactRepo *repository.ContactRepository, contactID uuid.UUID) *repository.Contact {
+	t.Helper()
+	deadline := accelerated.GetCurrentTime().Add(defaultInteractionWaitTimeout)
+	for accelerated.GetCurrentTime().Before(deadline) {
+		c, err := contactRepo.GetContact(ctx, contactID)
+		require.NoError(t, err)
+		if c.LastContacted != nil && c.LastOutreachAt != nil {
+			return c
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for last_contacted + last_outreach_at on contact %s", contactID)
+	return nil
+}

--- a/frontend/src/components/settings/__tests__/google-accounts-section.test.tsx
+++ b/frontend/src/components/settings/__tests__/google-accounts-section.test.tsx
@@ -2,18 +2,33 @@ import { describe, expect, it } from 'vitest'
 
 import { accountHasChatScopes } from '../google-accounts-section'
 
-const CHAT_SCOPE = 'https://www.googleapis.com/auth/chat.spaces.readonly'
+const SPACES_SCOPE = 'https://www.googleapis.com/auth/chat.spaces.readonly'
+const MESSAGES_SCOPE = 'https://www.googleapis.com/auth/chat.messages.readonly'
+const MEMBERSHIPS_SCOPE = 'https://www.googleapis.com/auth/chat.memberships.readonly'
+const ALL_CHAT_SCOPES = [SPACES_SCOPE, MESSAGES_SCOPE, MEMBERSHIPS_SCOPE]
 
 describe('accountHasChatScopes', () => {
-  it('returns true when the account carries chat.spaces.readonly', () => {
+  it('returns true when the account carries ALL THREE chat scopes', () => {
     expect(
       accountHasChatScopes({
-        scopes: ['openid', 'email', CHAT_SCOPE],
+        scopes: ['openid', 'email', ...ALL_CHAT_SCOPES],
       })
     ).toBe(true)
   })
 
-  it('returns false when the chat scope is absent (badge hidden, hint shown)', () => {
+  it('returns false for a partial grant — only spaces.readonly', () => {
+    expect(accountHasChatScopes({ scopes: ['openid', 'email', SPACES_SCOPE] })).toBe(false)
+  })
+
+  it('returns false for a partial grant — only messages.readonly', () => {
+    expect(accountHasChatScopes({ scopes: ['openid', 'email', MESSAGES_SCOPE] })).toBe(false)
+  })
+
+  it('returns false for a partial grant — missing memberships.readonly', () => {
+    expect(accountHasChatScopes({ scopes: ['openid', SPACES_SCOPE, MESSAGES_SCOPE] })).toBe(false)
+  })
+
+  it('returns false when no chat scopes are present (badge hidden, hint shown)', () => {
     expect(
       accountHasChatScopes({
         scopes: ['openid', 'email', 'https://www.googleapis.com/auth/gmail.readonly'],

--- a/frontend/src/components/settings/__tests__/google-accounts-section.test.tsx
+++ b/frontend/src/components/settings/__tests__/google-accounts-section.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import { accountHasChatScopes } from '../google-accounts-section'
+
+const CHAT_SCOPE = 'https://www.googleapis.com/auth/chat.spaces.readonly'
+
+describe('accountHasChatScopes', () => {
+  it('returns true when the account carries chat.spaces.readonly', () => {
+    expect(
+      accountHasChatScopes({
+        scopes: ['openid', 'email', CHAT_SCOPE],
+      })
+    ).toBe(true)
+  })
+
+  it('returns false when the chat scope is absent (badge hidden, hint shown)', () => {
+    expect(
+      accountHasChatScopes({
+        scopes: ['openid', 'email', 'https://www.googleapis.com/auth/gmail.readonly'],
+      })
+    ).toBe(false)
+  })
+
+  it('returns false when scopes is undefined', () => {
+    expect(accountHasChatScopes({ scopes: undefined })).toBe(false)
+  })
+
+  it('returns false when scopes is empty', () => {
+    expect(accountHasChatScopes({ scopes: [] })).toBe(false)
+  })
+})

--- a/frontend/src/components/settings/google-accounts-section.tsx
+++ b/frontend/src/components/settings/google-accounts-section.tsx
@@ -23,20 +23,28 @@ import {
 import { useTriggerSync } from '@/hooks/use-imports'
 import { startGoogleOAuthFlow, GoogleAccount } from '@/lib/oauth-api'
 
-// GCHAT_SPACES_READONLY_SCOPE gates the Google Chat sync badge. It mirrors the
-// backend enablement gate (service.gchatSpacesReadonlyScope /
-// chat.ChatSpacesReadonlyScope): an account only shows the Chat badge once it
-// has re-consented with this scope. Like the other Google badges, this is the
+// GCHAT_REQUIRED_SCOPES gates the Google Chat sync badge. It mirrors the backend
+// enablement gate (service.gchatRequiredScopes): the sweep needs all three Chat
+// scopes (spaces.list, messages.list, members.list), so the badge only shows
+// once the account has re-consented with ALL of them — a partial grant shows the
+// reconnect hint instead. Like the other Google badges, this is the
 // requested-scope proxy (the stored scope list), not a true-grant check.
-const GCHAT_SPACES_READONLY_SCOPE = 'https://www.googleapis.com/auth/chat.spaces.readonly'
+const GCHAT_REQUIRED_SCOPES = [
+  'https://www.googleapis.com/auth/chat.spaces.readonly',
+  'https://www.googleapis.com/auth/chat.messages.readonly',
+  'https://www.googleapis.com/auth/chat.memberships.readonly',
+]
 
 /**
- * accountHasChatScopes reports whether a connected Google account carries the
- * chat.spaces.readonly scope — the gate for the Google Chat sync badge.
- * Exported as a pure function so it can be unit-tested without rendering.
+ * accountHasChatScopes reports whether a connected Google account carries ALL
+ * THREE chat scopes — the gate for the Google Chat sync badge. A partial grant
+ * returns false (the reconnect hint is shown instead). Exported as a pure
+ * function so it can be unit-tested without rendering.
  */
 export function accountHasChatScopes(account: Pick<GoogleAccount, 'scopes'>): boolean {
-  return account.scopes?.includes(GCHAT_SPACES_READONLY_SCOPE) ?? false
+  const scopes = account.scopes
+  if (!scopes) return false
+  return GCHAT_REQUIRED_SCOPES.every(required => scopes.includes(required))
 }
 
 function formatDate(dateString: string): string {

--- a/frontend/src/components/settings/google-accounts-section.tsx
+++ b/frontend/src/components/settings/google-accounts-section.tsx
@@ -2,7 +2,16 @@
 
 import { useEffect, useState } from 'react'
 import { useSearchParams } from 'next/navigation'
-import { Mail, Plus, Trash2, CheckCircle, AlertCircle, Info, RefreshCcw } from 'lucide-react'
+import {
+  Mail,
+  MessageSquare,
+  Plus,
+  Trash2,
+  CheckCircle,
+  AlertCircle,
+  Info,
+  RefreshCcw,
+} from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { SyncBadge } from '@/components/settings/sync-badge'
 import { useGoogleAccounts, useRevokeGoogleAccount } from '@/hooks/use-google-accounts'
@@ -13,6 +22,22 @@ import {
 } from '@/hooks/use-sync-states'
 import { useTriggerSync } from '@/hooks/use-imports'
 import { startGoogleOAuthFlow, GoogleAccount } from '@/lib/oauth-api'
+
+// GCHAT_SPACES_READONLY_SCOPE gates the Google Chat sync badge. It mirrors the
+// backend enablement gate (service.gchatSpacesReadonlyScope /
+// chat.ChatSpacesReadonlyScope): an account only shows the Chat badge once it
+// has re-consented with this scope. Like the other Google badges, this is the
+// requested-scope proxy (the stored scope list), not a true-grant check.
+const GCHAT_SPACES_READONLY_SCOPE = 'https://www.googleapis.com/auth/chat.spaces.readonly'
+
+/**
+ * accountHasChatScopes reports whether a connected Google account carries the
+ * chat.spaces.readonly scope — the gate for the Google Chat sync badge.
+ * Exported as a pure function so it can be unit-tested without rendering.
+ */
+export function accountHasChatScopes(account: Pick<GoogleAccount, 'scopes'>): boolean {
+  return account.scopes?.includes(GCHAT_SPACES_READONLY_SCOPE) ?? false
+}
 
 function formatDate(dateString: string): string {
   return new Date(dateString).toLocaleDateString(undefined, {
@@ -95,6 +120,28 @@ export function GoogleAccountsSection() {
         message: errorMessage.includes('authentication')
           ? 'Authentication failed. Please reconnect your account.'
           : `Failed to start Gmail sync: ${errorMessage}`,
+      })
+    } finally {
+      setSyncingAccount(null)
+    }
+  }
+
+  const handleSyncGChat = async (accountId: string) => {
+    setSyncingAccount(`gchat-${accountId}`)
+    try {
+      await triggerSyncMutation.mutateAsync({ source: 'gchat', accountId })
+      setNotification({
+        type: 'success',
+        message: 'Google Chat sync started!',
+      })
+    } catch (error) {
+      console.error('Google Chat sync error:', error)
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+      setNotification({
+        type: 'error',
+        message: errorMessage.includes('authentication')
+          ? 'Authentication failed. Please reconnect your account.'
+          : `Failed to start Google Chat sync: ${errorMessage}`,
       })
     } finally {
       setSyncingAccount(null)
@@ -340,6 +387,26 @@ export function GoogleAccountsSection() {
                       onSync={() => handleSyncContacts(account.account_id)}
                       loading={syncingAccount === `gcontacts-${account.account_id}`}
                     />
+                  )}
+                  {/* Google Chat - sync badge (scoped) or reconnect hint (unscoped) */}
+                  {accountHasChatScopes(account) ? (
+                    <SyncBadge
+                      label="Chat"
+                      syncState={getSyncStateForAccount(syncStates, 'gchat', account.account_id)}
+                      onSync={() => handleSyncGChat(account.account_id)}
+                      loading={syncingAccount === `gchat-${account.account_id}`}
+                    />
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={handleConnectGoogle}
+                      disabled={isConnecting}
+                      title="Reconnect this account to grant Google Chat access"
+                      className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-medium bg-amber-50 border border-amber-300 text-amber-700 hover:bg-amber-100 disabled:opacity-50"
+                    >
+                      <MessageSquare className="w-3 h-3" />
+                      Chat — reconnect required
+                    </button>
                   )}
                 </div>
               </div>

--- a/frontend/tests/e2e/gchat-contact-signal.spec.ts
+++ b/frontend/tests/e2e/gchat-contact-signal.spec.ts
@@ -1,0 +1,106 @@
+import { test, expect } from '@playwright/test'
+import { createTestAPI, TestAPI } from './helpers/test-api'
+
+// Realistic E2E scope for the GChat contact surface (PR 3, Q2-A). The contact
+// detail page renders no per-interaction timeline (it shows only direction
+// signals), and the public interactions POST API only creates source='manual'
+// interactions — so a gchat-source line item cannot be seeded through the UI or
+// public API. We therefore assert:
+//   - the direction-signal behavior on the detail page (mirroring
+//     contact-direction.spec.ts), which is what a gchat-derived interaction
+//     bumps; and
+//   - the interactions-API response SHAPE that a real gchat interaction surfaces
+//     through (description + direction + source), using a description of the
+//     "GChat … (N messages)" form to mirror what the integration path produces.
+// The full enable→sweep→aggregate→cadence chain (where the real gchat
+// interaction is produced) lives in the backend Phase-3 integration test.
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080'
+const API_KEY = process.env.NEXT_PUBLIC_API_KEY || 'test-api-key-for-ci'
+const API_HEADERS = {
+  'X-API-Key': API_KEY,
+  'Content-Type': 'application/json',
+}
+
+test.describe('GChat Contact Signals @area:contacts', () => {
+  let testApi: TestAPI
+
+  test.beforeEach(async ({ request }, testInfo) => {
+    testApi = createTestAPI(request, testInfo)
+  })
+
+  test.afterEach(async () => {
+    await testApi.cleanup()
+  })
+
+  test('contact detail page shows direction signals after a mutual interaction', async ({
+    page,
+    request,
+  }) => {
+    const { ids } = await testApi.seedContacts([
+      { full_name: 'GChat Signal Test', cadence: 'monthly' },
+    ])
+    const contactId = ids[0]
+
+    // A gchat mutual exchange bumps both direction signals; record an
+    // equivalent interaction via the public API (which is manual-source) to
+    // exercise the same detail-page rendering path.
+    const pastDate = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString()
+    await request.post(`${API_BASE_URL}/api/v1/contacts/${contactId}/interactions`, {
+      headers: API_HEADERS,
+      data: { occurred_at: pastDate, direction: 'mutual' },
+    })
+
+    await page.goto(`/contacts/${contactId}`)
+    await page.waitForLoadState('domcontentloaded')
+
+    await expect(page.getByRole('heading', { name: 'GChat Signal Test' })).toBeVisible({
+      timeout: 15000,
+    })
+
+    await expect(page.getByText('Last outreach:')).toBeVisible({ timeout: 5000 })
+    await expect(page.getByText('Last response:')).toBeVisible()
+  })
+
+  test('interactions API surfaces description + direction + source (gchat description shape)', async ({
+    request,
+  }) => {
+    const { ids } = await testApi.seedContacts([{ full_name: 'GChat Interaction Shape Test' }])
+    const contactId = ids[0]
+
+    // The "GChat <label> (<n> messages)" description is what the aggregation
+    // engine writes for a real gchat interaction. The public interactions API
+    // is manual-source, so we assert the response SHAPE that carries that
+    // description form end-to-end (description + direction), not a rendered
+    // line item (infeasible — the detail page has no interaction timeline).
+    const gchatDescription = 'GChat exchange (3 messages)'
+    const pastDate = new Date(Date.now() - 60 * 60 * 1000).toISOString()
+    const createResp = await request.post(
+      `${API_BASE_URL}/api/v1/contacts/${contactId}/interactions`,
+      {
+        headers: API_HEADERS,
+        data: { occurred_at: pastDate, direction: 'inbound', description: gchatDescription },
+      }
+    )
+    expect(createResp.ok()).toBeTruthy()
+    const createBody = await createResp.json()
+    expect(createBody.data.direction).toBe('inbound')
+    expect(createBody.data.description).toBe(gchatDescription)
+
+    const listResp = await request.get(
+      `${API_BASE_URL}/api/v1/contacts/${contactId}/interactions`,
+      { headers: API_HEADERS }
+    )
+    expect(listResp.ok()).toBeTruthy()
+    const listBody = await listResp.json()
+    expect(listBody.data.length).toBeGreaterThan(0)
+
+    const row = listBody.data[0]
+    expect(row).toHaveProperty('description')
+    expect(row).toHaveProperty('direction')
+    expect(row).toHaveProperty('source')
+    expect(row.description).toContain('GChat')
+    expect(row.description).toContain('messages')
+    expect(row.direction).toBe('inbound')
+  })
+})

--- a/frontend/tests/e2e/settings.spec.ts
+++ b/frontend/tests/e2e/settings.spec.ts
@@ -46,6 +46,42 @@ test.describe('Settings Page @area:settings', () => {
     }
   })
 
+  test('should display optional Google Chat sync badge or reconnect hint', async ({ page }) => {
+    await page.goto('/settings', { waitUntil: 'networkidle' })
+    await page.reload({ waitUntil: 'networkidle' })
+
+    await expect(page.getByRole('heading', { name: 'Google Accounts', exact: true })).toBeVisible()
+
+    // Per connected Google account, the Chat surface is conditional: a "Chat"
+    // SyncBadge when the account carries chat.spaces.readonly, OR a
+    // "Chat — reconnect required" hint when it does not. Both depend on backend
+    // GOOGLE_* env vars + a real connected account, so this is a
+    // conditional-presence test (like the Gmail-badge test above).
+    const chatBadge = page.locator('div').filter({ hasText: /^Chat/ })
+    const hasChatBadge = await chatBadge
+      .first()
+      .isVisible()
+      .catch(() => false)
+
+    if (hasChatBadge) {
+      const refreshButton = chatBadge.first().getByRole('button')
+      await expect(refreshButton).toBeVisible()
+      await expect(refreshButton).toBeEnabled({ timeout: 5000 })
+    } else {
+      // No scoped account: if any Google account is connected, the reconnect
+      // hint may be present. Its visibility is account-dependent, so only assert
+      // it is clickable WHEN present (never required).
+      const reconnectHint = page.getByRole('button', { name: /Chat — reconnect required/ })
+      const hasHint = await reconnectHint
+        .first()
+        .isVisible()
+        .catch(() => false)
+      if (hasHint) {
+        await expect(reconnectHint.first()).toBeEnabled({ timeout: 5000 })
+      }
+    }
+  })
+
   test('should display settings page with export and import sections', async ({ page }) => {
     await page.goto('/settings')
 


### PR DESCRIPTION
PR 3 of 3 — the **GO-LIVE** PR for the Google Chat integration (#337). PR 1 (`395a45f`, comms substrate) and PR 2 (`6eda648`, provider + dual-source rematch + bounded edit/delete) landed every moving part but left the provider inert. This PR flips the feature on.

## What this PR does

- **Registers `GChatSyncProvider`** into the scheduler's provider registry — the actual go-live switch. NOT pubBus-gated: GChat is store-only + event-free (unlike Gmail), so registration runs whenever Google OAuth is configured.
- **Enablement reconciliation** (`SyncService.ReconcileGChatSyncStates`): scope-gated, idempotent, create-if-absent per Google credential that carries `chat.spaces.readonly`. Seeds `metadata.backfill_since`; the provider materializes the empty `space_cursors` map on its first sweep. Runs at boot (before river start) AND on OAuth-connect (via `OAuthHandler.SetGChatStateReconciler`), mirroring the Gmail reconciliation — with one departure: the chat-scope check is the **enablement gate** (no state created for an unscoped account), not a warn-and-create.
- **Settings UI**: a `Chat` `SyncBadge` per account carrying the chat scope (triggers a sweep via the existing trigger-sync hook), and an amber "Chat — reconnect required" hint (reusing the existing connect flow) when the scope is absent. Reuses `useGoogleAccounts`/`useSyncStates` — no new hook.
- **Status endpoint**: no new code. The gchat state surfaces through the existing generic `SyncState` shape on `GET /sync/status` once reconciliation enables it (verified by integration assertion).

## Inert until the operator acts — four-gate safety proof

Merge and deploy do **no** real GChat work until the operator completes the GCP Chat App config + OAuth re-consent. Four independent gates each keep every path inert:

1. **No state until reconciliation finds a chat-scoped account.** Pre-consent credentials don't carry `chat.spaces.readonly` in their stored scope list, so reconciliation creates zero rows.
2. **`ListDueSyncStates` filters `enabled = TRUE`** — a disabled/absent state is never due.
3. **`ListDueAccounts` dispatches only to registered providers** — registration is the switch, but it does nothing until gate 1 produces an enabled state.
4. **Clean 403-degrade** — if a state is somehow enabled without a real grant, the provider's first `spaces.list` call fails into `sync_log` with backoff (no panic, no corruption, cursors unadvanced).

Merge ≠ deploy ≠ activation — three separate user-controlled steps. The scope gate is the requested-scope proxy (consistent with every existing Google badge); capturing true granted scopes is noted as out-of-scope follow-up.

## Test plan

- `ReconcileGChatSyncStates`: scope-gate (unscoped account gets no state), idempotent re-run (no duplicates / no cursor-or-backfill reset), respects user-disabled, re-consent transition opens the gate, per-account shape (no NULL-account row), empty/nil lister no-op, connect-path idempotency, status-surfaces-state.
- OAuth-connect handler: gchat reconciler is invoked on a successful exchange; a reconciler error is non-fatal.
- Go-live integration: registered provider → `RunAccountSync` sweep → comms rows → `AggregateForContactBatch` → interactions with "GChat … (N messages)" descriptions → cadence (`last_contacted`/`last_outreach_at`) → no contact for an unknown participant → per-space cursor advanced. Fake `chat.Service` fetcher — never the live API.
- Frontend: `accountHasChatScopes` gate unit test; E2E conditional-presence for the settings badge/hint (`@area:settings`) + contact direction-signal and interactions-API shape (`@area:contacts`).

Closes the 3-PR series for #337.