### PR TITLE
fix(gchat): page messages at API max + raise sweep budget (#337)

### DIFF
--- a/backend/internal/google/gchat.go
+++ b/backend/internal/google/gchat.go
@@ -26,11 +26,17 @@ const (
 	// 15 minutes), matching the Gmail/Calendar tick.
 	GChatDefaultInterval = 15 * time.Minute
 
-	// gchatMaxWindowsPerSync bounds one sweep's total list-page iterations
-	// (content + edit/delete passes) across all spaces, mirroring Gmail's
-	// catch-up bound. Once exhausted the sweep returns; un-advanced space
-	// cursors restart next tick (crash-safe).
-	gchatMaxWindowsPerSync = 24
+	// gchatMaxWindowsPerSync bounds the total list-page iterations a single
+	// sweep or scan may consume (membership + content + edit/delete passes
+	// across all spaces). It is the shared page budget for BOTH the steady-state
+	// sweep (Sync) AND the one-shot rematch scan (ScanIdentifier). Because
+	// ListMessages now requests up to 1000 messages per page, a realistically
+	// sized space pages in one or very few calls, so 100 gives generous headroom
+	// for accounts with many (or deep) spaces without one sweep/scan starving the
+	// rest. Once exhausted the sweep returns and un-advanced space cursors restart
+	// next tick (crash-safe); the rematch scan instead fails its River job and
+	// retries (idempotent via the upsert dedup).
+	gchatMaxWindowsPerSync = 100
 
 	// gchatMembershipCacheTTL bounds how long a cached space-member list (and a
 	// cached id→email resolution) stays valid before a forced refetch, even when
@@ -121,10 +127,18 @@ func (f *chatServiceFetcher) ListMembers(ctx context.Context, spaceName, pageTok
 }
 
 func (f *chatServiceFetcher) ListMessages(ctx context.Context, spaceName, filter string, showDeleted bool, pageToken string) ([]*chat.Message, string, error) {
+	// PageSize(1000) requests the documented Chat API maximum (default is 25,
+	// max is 1000, values >1000 are clamped by the API). This collapses a
+	// deep-history space's content pass from ~one page per 25 messages to one or
+	// very few pages, so its window completes within the shared sweep budget and
+	// its cursor advances. Both the content pass (showDeleted=false) and the
+	// edit/delete pass (showDeleted=true) route through this method, so both
+	// inherit the larger page size.
 	call := f.chat.Spaces.Messages.List(spaceName).
 		Filter(filter).
 		ShowDeleted(showDeleted).
-		OrderBy("create_time ASC")
+		OrderBy("create_time ASC").
+		PageSize(1000)
 	if pageToken != "" {
 		call = call.PageToken(pageToken)
 	}

--- a/backend/internal/google/gchat_test.go
+++ b/backend/internal/google/gchat_test.go
@@ -614,17 +614,17 @@ func TestBuildContentMetadata(t *testing.T) {
 	require.Len(t, atts, 1)
 }
 
-// TestConsumeContentWindow_DeepHistoryCompletesUnderRaisedBudget proves the
-// budget-raise half of the fix: a window that needs more pages than the OLD
-// budget (24) but fewer than the NEW budget (gchatMaxWindowsPerSync = 100)
-// strands its cursor under the old budget yet fully pages and advances under
-// the shipped constant.
+// TestConsumeContentWindow_DeepHistoryCompletesUnderRaisedBudget exercises the
+// budget boundary: a window that needs 30 pages strands its cursor under a tight
+// 24-page budget but fully pages and advances under gchatMaxWindowsPerSync (100).
+// This is the property that lets a deep-history space complete its backfill in a
+// single sweep.
 //
 // NOTE: the fake fetcher here ignores page size entirely — it returns a fixed
 // number of pages regardless of the requested page size. So this test validates
-// ONLY that a window needing >24 but <=100 pages completes under the shipped
-// constant. It does NOT and cannot prove production now requests larger pages;
-// the .PageSize(1000) request is pinned separately by
+// ONLY that a window needing >24 but <=100 pages completes under
+// gchatMaxWindowsPerSync. It does NOT and cannot prove the production list call
+// requests larger pages; the PageSize(1000) request is pinned separately by
 // TestListMessages_RequestsMaxPageSize.
 func TestConsumeContentWindow_DeepHistoryCompletesUnderRaisedBudget(t *testing.T) {
 	ctx := context.Background()
@@ -651,10 +651,10 @@ func TestConsumeContentWindow_DeepHistoryCompletesUnderRaisedBudget(t *testing.T
 	}
 	p := &GChatSyncProvider{}
 
-	// Sub-case A — passes under the SHIPPED constant (100): the 30-page window
-	// fully pages, proven=true, cursor advances to the latest createTime, and the
+	// Sub-case A — under gchatMaxWindowsPerSync (100) the 30-page window fully
+	// pages, proven=true, the cursor advances to the latest createTime, and the
 	// budget is decremented by exactly the pages consumed.
-	t.Run("completes_under_shipped_budget", func(t *testing.T) {
+	t.Run("completes_under_full_budget", func(t *testing.T) {
 		calls := 0
 		fetcher := newFetcher(&calls)
 		resolver := newCachedEmailResolver(fetcher, nil)
@@ -671,30 +671,30 @@ func TestConsumeContentWindow_DeepHistoryCompletesUnderRaisedBudget(t *testing.T
 		assert.Equal(t, gchatMaxWindowsPerSync-totalPages, budget, "budget decremented by exactly the pages consumed")
 	})
 
-	// Sub-case B — strands under the OLD budget (24, set as a local literal, NOT
-	// by mutating the constant): the same 30-page window cannot complete, returns
-	// proven=false + the original cursor, with the budget fully drained and
-	// exactly 24 pages fetched. This is the regression the fix removes.
-	t.Run("strands_under_old_budget", func(t *testing.T) {
+	// Sub-case B — under a tight 24-page budget (a local literal) the same 30-page
+	// window cannot complete: it returns proven=false + the original cursor, with
+	// the budget fully drained and exactly 24 pages fetched. This is the stranding
+	// behavior the raised budget avoids for realistically sized spaces.
+	t.Run("strands_under_tight_budget", func(t *testing.T) {
 		calls := 0
 		fetcher := newFetcher(&calls)
 		resolver := newCachedEmailResolver(fetcher, nil)
-		budget := 24 // pre-fix value, a local literal
+		budget := 24 // a tight budget smaller than the window's page count
 		counters := &sweepCounters{}
 		newCursor, proven, err := p.consumeContentWindow(ctx, fetcher,
 			&chat.Space{Name: "spaces/B", SpaceType: "SPACE"}, floor,
 			map[string][]uuid.UUID{}, map[string][]uuid.UUID{}, map[string]struct{}{},
 			resolver, "acct", counters, &budget)
 		require.NoError(t, err)
-		assert.False(t, proven, "a 30-page window cannot complete under the old 24-page budget")
+		assert.False(t, proven, "a 30-page window cannot complete under a 24-page budget")
 		assert.Equal(t, floor, newCursor, "cursor must NOT advance past an un-listed page")
-		assert.Equal(t, 0, budget, "old budget fully drained")
-		assert.Equal(t, 24, calls, "exactly the old-budget number of pages were fetched")
+		assert.Equal(t, 0, budget, "the tight budget is fully drained")
+		assert.Equal(t, 24, calls, "exactly the budgeted number of pages were fetched")
 	})
 }
 
-// TestListMessages_RequestsMaxPageSize pins the .PageSize(1000) half of the fix
-// at the production seam. The chatFetcher interface does not carry a page size
+// TestListMessages_RequestsMaxPageSize pins the PageSize(1000) request at the
+// production seam. The chatFetcher interface does not carry a page size
 // (it is set on the *chat.Service call builder, whose urlParams_ is unexported
 // and unreadable from a test), so we stand up an httptest.Server, point a real
 // *chat.Service at it via WithoutAuthentication (no OAuth, no live Google), and

--- a/backend/internal/google/gchat_test.go
+++ b/backend/internal/google/gchat_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -13,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	chat "google.golang.org/api/chat/v1"
+	"google.golang.org/api/option"
 	people "google.golang.org/api/people/v1"
 )
 
@@ -608,4 +612,130 @@ func TestBuildContentMetadata(t *testing.T) {
 	atts, ok := meta["attachments"].([]any)
 	require.True(t, ok)
 	require.Len(t, atts, 1)
+}
+
+// TestConsumeContentWindow_DeepHistoryCompletesUnderRaisedBudget proves the
+// budget-raise half of the fix: a window that needs more pages than the OLD
+// budget (24) but fewer than the NEW budget (gchatMaxWindowsPerSync = 100)
+// strands its cursor under the old budget yet fully pages and advances under
+// the shipped constant.
+//
+// NOTE: the fake fetcher here ignores page size entirely — it returns a fixed
+// number of pages regardless of the requested page size. So this test validates
+// ONLY that a window needing >24 but <=100 pages completes under the shipped
+// constant. It does NOT and cannot prove production now requests larger pages;
+// the .PageSize(1000) request is pinned separately by
+// TestListMessages_RequestsMaxPageSize.
+func TestConsumeContentWindow_DeepHistoryCompletesUnderRaisedBudget(t *testing.T) {
+	ctx := context.Background()
+	floor := "2026-01-01T00:00:00Z"
+	// The window needs exactly 30 pages to fully list: pages 1..29 each report
+	// another page (a bystander/unknown sender so no upsert and no commsRepo is
+	// needed), and page 30 returns next == "" with the latest message.
+	const totalPages = 30
+	latest := "2026-02-15T08:30:00Z"
+
+	newFetcher := func(callCount *int) *fakeChatFetcher {
+		return &fakeChatFetcher{funcs: FakeChatFetcherFuncs{
+			ListMessages: func(_ context.Context, _, _ string, _ bool, token string) ([]*chat.Message, string, error) {
+				*callCount++
+				if *callCount < totalPages {
+					// Bystander sender → no upsert; still a non-final page.
+					return []*chat.Message{humanMsg("spaces/B/messages/x", "users/stranger", "2026-02-01T00:00:00Z", "x")}, "next", nil
+				}
+				// Final page carries the latest createTime, no more pages.
+				return []*chat.Message{humanMsg("spaces/B/messages/last", "users/stranger", latest, "last")}, "", nil
+			},
+			ResolvePersonEmail: func(context.Context, string) (string, error) { return "stranger@example.test", nil },
+		}}
+	}
+	p := &GChatSyncProvider{}
+
+	// Sub-case A — passes under the SHIPPED constant (100): the 30-page window
+	// fully pages, proven=true, cursor advances to the latest createTime, and the
+	// budget is decremented by exactly the pages consumed.
+	t.Run("completes_under_shipped_budget", func(t *testing.T) {
+		calls := 0
+		fetcher := newFetcher(&calls)
+		resolver := newCachedEmailResolver(fetcher, nil)
+		budget := gchatMaxWindowsPerSync
+		counters := &sweepCounters{}
+		newCursor, proven, err := p.consumeContentWindow(ctx, fetcher,
+			&chat.Space{Name: "spaces/B", SpaceType: "SPACE"}, floor,
+			map[string][]uuid.UUID{}, map[string][]uuid.UUID{}, map[string]struct{}{},
+			resolver, "acct", counters, &budget)
+		require.NoError(t, err)
+		assert.True(t, proven, "a 30-page window fully pages under the 100-page budget")
+		assert.Equal(t, latest, newCursor, "cursor advances to the latest createTime")
+		assert.Equal(t, totalPages, calls, "exactly the 30 pages were fetched")
+		assert.Equal(t, gchatMaxWindowsPerSync-totalPages, budget, "budget decremented by exactly the pages consumed")
+	})
+
+	// Sub-case B — strands under the OLD budget (24, set as a local literal, NOT
+	// by mutating the constant): the same 30-page window cannot complete, returns
+	// proven=false + the original cursor, with the budget fully drained and
+	// exactly 24 pages fetched. This is the regression the fix removes.
+	t.Run("strands_under_old_budget", func(t *testing.T) {
+		calls := 0
+		fetcher := newFetcher(&calls)
+		resolver := newCachedEmailResolver(fetcher, nil)
+		budget := 24 // pre-fix value, a local literal
+		counters := &sweepCounters{}
+		newCursor, proven, err := p.consumeContentWindow(ctx, fetcher,
+			&chat.Space{Name: "spaces/B", SpaceType: "SPACE"}, floor,
+			map[string][]uuid.UUID{}, map[string][]uuid.UUID{}, map[string]struct{}{},
+			resolver, "acct", counters, &budget)
+		require.NoError(t, err)
+		assert.False(t, proven, "a 30-page window cannot complete under the old 24-page budget")
+		assert.Equal(t, floor, newCursor, "cursor must NOT advance past an un-listed page")
+		assert.Equal(t, 0, budget, "old budget fully drained")
+		assert.Equal(t, 24, calls, "exactly the old-budget number of pages were fetched")
+	})
+}
+
+// TestListMessages_RequestsMaxPageSize pins the .PageSize(1000) half of the fix
+// at the production seam. The chatFetcher interface does not carry a page size
+// (it is set on the *chat.Service call builder, whose urlParams_ is unexported
+// and unreadable from a test), so we stand up an httptest.Server, point a real
+// *chat.Service at it via WithoutAuthentication (no OAuth, no live Google), and
+// assert the recorded request's pageSize query parameter is 1000. We run it for
+// both showDeleted paths to make the "covers both passes" guarantee explicit —
+// the content pass (false) and the edit/delete pass (true) both route through
+// chatServiceFetcher.ListMessages.
+func TestListMessages_RequestsMaxPageSize(t *testing.T) {
+	for _, showDeleted := range []bool{false, true} {
+		showDeleted := showDeleted
+		name := "contentPass"
+		if showDeleted {
+			name = "editDeletePass"
+		}
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			var gotQuery url.Values
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotQuery = r.URL.Query()
+				w.Header().Set("Content-Type", "application/json")
+				// {} decodes to an empty ListMessagesResponse (no messages, no
+				// next page token), so ListMessages returns cleanly.
+				_, _ = w.Write([]byte("{}"))
+			}))
+			defer server.Close()
+
+			svc, err := chat.NewService(ctx,
+				option.WithEndpoint(server.URL),
+				option.WithoutAuthentication())
+			require.NoError(t, err)
+			fetcher := &chatServiceFetcher{chat: svc}
+
+			msgs, next, err := fetcher.ListMessages(ctx, "spaces/B", `create_time > "2026-01-01T00:00:00Z"`, showDeleted, "")
+			require.NoError(t, err)
+			assert.Empty(t, msgs)
+			assert.Empty(t, next)
+
+			require.NotNil(t, gotQuery, "the server handler must have recorded a request")
+			assert.Equal(t, "1000", gotQuery.Get("pageSize"), "ListMessages must request the documented Chat API max page size")
+			// Bonus: documents that the create_time ASC ordering is preserved.
+			assert.Equal(t, "create_time ASC", gotQuery.Get("orderBy"))
+		})
+	}
 }

--- a/backend/tests/gchat_provider_integration_test.go
+++ b/backend/tests/gchat_provider_integration_test.go
@@ -739,3 +739,92 @@ func TestGChatRematchHandler_ScansAndAggregates(t *testing.T) {
 	assert.Equal(t, repository.InteractionSourceGChat, interactions[0].Source)
 	assert.Equal(t, repository.InteractionDirectionInbound, interactions[0].Direction)
 }
+
+// TestGChatProvider_MultiPageWindowPersistsCursor proves the end-to-end cursor
+// persistence wiring: a multi-page content window (paged via pageToken, ending
+// in next == "") fully pages within budget, advances its create_cursor to the
+// latest message's create_time, and that value is persisted to the JSONB
+// metadata column. This complements the DB-free budget test in the google
+// package — its job is the persistence path (window → setCursor → persistMetadata
+// → DB), not the budget boundary.
+func TestGChatProvider_MultiPageWindowPersistsCursor(t *testing.T) {
+	e := setupGChatProviderTest(t)
+	suffix := randomSuffix(t)
+
+	aliceEmail := "alice-" + suffix + "@example.test"
+	alice := e.newGChatProviderContact(t, "GChat Paged Alice "+suffix, string(repository.ContactMethodEmail), aliceEmail)
+
+	spaceName := "spaces/PAGED-" + suffix
+	accountID := "me-" + suffix + "@example.test"
+	e.newGChatSyncState(t, accountID, true, nil)
+
+	// Three content pages, oldest-first; the newest message (on the final page)
+	// sets the cursor the sweep must persist. Truncate to seconds so the RFC-3339
+	// string round-trips exactly through the cursor comparison.
+	base := accelerated.GetCurrentTime().Add(-3 * time.Hour).Truncate(time.Second)
+	msg1At := base
+	msg2At := base.Add(time.Hour)
+	latestAt := base.Add(2 * time.Hour)
+	latestCursor := chatRFC3339(latestAt)
+
+	funcs := google.FakeChatFetcherFuncs{
+		ListSpaces: func(context.Context, string) ([]*chat.Space, string, error) {
+			return []*chat.Space{space(spaceName, "SPACE")}, "", nil
+		},
+		ListMembers: func(context.Context, string, string) ([]*chat.Membership, string, error) {
+			return []*chat.Membership{membership("users/alice"), membership("users/me")}, "", nil
+		},
+		ListMessages: func(_ context.Context, _, _ string, showDeleted bool, token string) ([]*chat.Message, string, error) {
+			if showDeleted {
+				return nil, "", nil // edit/delete pass: nothing
+			}
+			// Content pass paged via pageToken: page 1 → "p2", page 2 → "p3",
+			// page 3 → "" (fully paged). The newest message is on the final page.
+			switch token {
+			case "":
+				return []*chat.Message{chatMessage(spaceName+"/messages/m1-"+suffix, "users/alice", "first", msg1At)}, "p2", nil
+			case "p2":
+				return []*chat.Message{chatMessage(spaceName+"/messages/m2-"+suffix, "users/alice", "second", msg2At)}, "p3", nil
+			case "p3":
+				return []*chat.Message{chatMessage(spaceName+"/messages/m3-"+suffix, "users/alice", "third", latestAt)}, "", nil
+			}
+			return nil, "", nil
+		},
+		ResolvePersonEmail: func(_ context.Context, userName string) (string, error) {
+			switch userName {
+			case "users/alice":
+				return aliceEmail, nil
+			case "users/me":
+				return accountID, nil
+			}
+			return "", nil
+		},
+	}
+	p := e.newProvider(t, map[string]struct{}{accountID: {}}, funcs)
+
+	state, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &accountID)
+	require.NoError(t, err)
+	result, err := p.Sync(e.ctx, state, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 3, result.ItemsProcessed, "all three pages' messages processed")
+
+	// A row exists for the newest message (proving the window paged to the end).
+	_, err = e.commsRepo.GetMessage(e.ctx, repository.InteractionSourceGChat, spaceName+"/messages/m3-"+suffix, alice.ID)
+	require.NoError(t, err)
+
+	// The persisted create_cursor equals the latest message's create_time. The
+	// JSONB metadata decodes into map[string]any, so space_cursors is a nested
+	// map[string]any keyed by space name, each entry itself a map[string]any with
+	// a "create_cursor" string (the spaceCursor JSON tags). Type-assert through
+	// that generic shape with require so a mismatch fails loudly.
+	persisted, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &accountID)
+	require.NoError(t, err)
+	require.NotNil(t, persisted.Metadata)
+	spaceCursors, ok := persisted.Metadata["space_cursors"].(map[string]any)
+	require.True(t, ok, "space_cursors must decode as a map[string]any")
+	entry, ok := spaceCursors[spaceName].(map[string]any)
+	require.True(t, ok, "this space's cursor entry must be present and a map[string]any")
+	createCursor, ok := entry["create_cursor"].(string)
+	require.True(t, ok, "create_cursor must be a string")
+	assert.Equal(t, latestCursor, createCursor, "persisted cursor must equal the latest message create_time")
+}


### PR DESCRIPTION
## Problem

Follow-up to the merged 3-PR Google Chat integration (#337). A Google Chat space with several hundred messages of history never finished its backfill and re-scanned every sweep, burning API quota.

Two constants interacted badly:

- `chatServiceFetcher.ListMessages` requested no page size, so `spaces.messages.list` defaulted to at most 25 messages per page. A deep-history space needed many content pages.
- A single shared per-sweep page budget (`gchatMaxWindowsPerSync = 24`) was decremented across the membership, content, and edit/delete passes for all spaces. `consumeContentWindow` advances a space's `create_cursor` only when its window is fully paged (`proven=true`). When the shared budget was exhausted before a space's content window finished, it returned `proven=false` and the original cursor, so the cursor never advanced or persisted.

Result: every 15-minute sweep re-seeded from the `backfill_since` anchor and re-paged the same oldest-first messages. The cursor never advanced and the backfill effectively never completed. Rows were still correct (idempotent upsert dedup) — this was a completeness + quota bug, not data corruption.

## Fix

- Set `PageSize(1000)` on `ListMessages` (the documented Chat API max; default 25, values >1000 clamped by the API). This serves both the content pass and the edit/delete pass (both route through the same method), so a realistically sized space pages in one or very few calls and its window completes within budget.
- Raise `gchatMaxWindowsPerSync` 24 → 100 as headroom for accounts with many or deep spaces. This budget is also shared by the `ScanIdentifier` rematch scan path, so the bump helps both.

Preserved invariants (unchanged): `OrderBy("create_time ASC")` and the advance-cursor-only-when-fully-paged (`proven`) semantics in `consumeContentWindow` / `reconcileEditsDeletes`.

No migration. A space whose cursor is currently stranded at the anchor self-heals on the first post-deploy sweep — it re-seeds from the anchor anyway and now fully pages, advances, and persists.

## Out of scope (future hardening)

- Partial-window cursor advancement under budget pressure.
- Per-pass / per-space budget split instead of one shared counter.

## Tests

- DB-free budget regression (`internal/google/gchat_test.go`): a 30-page window strands its cursor under a tight 24-page budget but fully pages and advances under `gchatMaxWindowsPerSync` (100).
- httptest page-size assertion (`internal/google/gchat_test.go`): a real `*chat.Service` pointed at an `httptest.Server` (no OAuth, no live Google) confirms `ListMessages` requests `pageSize=1000` on both the content and edit/delete passes.
- Integration cursor-persistence (`tests/gchat_provider_integration_test.go`): a multi-page content window runs through `p.Sync` and the advanced `create_cursor` (latest message create_time) is asserted in the persisted JSONB metadata.

All synthetic data; no live API.

## Test plan

- `go build ./cmd/crm-api`
- `make lint`
- `make test-integration-fast` (covers `./internal/google/...` + `./tests/`; note `make test-unit` excludes the google package)

Refs #337.