### PR TITLE
feat(gchat): match on-file contacts via canonical Chat user-id resolution

### DIFF
--- a/backend/internal/google/gchat.go
+++ b/backend/internal/google/gchat.go
@@ -93,6 +93,16 @@ type chatFetcher interface {
 	// normalized email via the People API. Returns "" (no error) when the person
 	// has no email or is not resolvable under the granted scope.
 	ResolvePersonEmail(ctx context.Context, userName string) (normalizedEmail string, err error)
+	// ResolveMemberID resolves a normalized email TO its canonical Chat user
+	// resource name ("users/{id}") within a space, via members.get with the email
+	// as the member alias. Unlike ResolvePersonEmail (which reads the caller's
+	// Contacts graph), this reads the space's membership graph, so it resolves a
+	// co-member even when that person is not in the user's Google Contacts.
+	// notMember is true (with no error) when the email is not a member of the
+	// space — the API returns HTTP 400 (unrecognized member) or 404 for that case;
+	// the caller treats it as a cacheable negative. Transient/auth errors
+	// propagate so the window aborts and retries.
+	ResolveMemberID(ctx context.Context, spaceName, normalizedEmail string) (canonicalUserName string, notMember bool, err error)
 }
 
 // chatServiceFetcher is the production chatFetcher backed by *chat.Service +
@@ -171,6 +181,36 @@ func (f *chatServiceFetcher) ResolvePersonEmail(ctx context.Context, userName st
 		return "", fmt.Errorf("resolve person %s: %w", hashIdentifier(userName), err)
 	}
 	return primaryNormalizedEmail(person), nil
+}
+
+// ResolveMemberID resolves a normalized email to its canonical "users/{id}"
+// within a space by calling members.get with the email as the membership alias.
+// The member resource name is space.Name + "/members/" + email — i.e. the BARE
+// email after "members/" (NOT "members/users/{email}"). The chat/v1 client
+// expands "{+name}" with reserved expansion, so the "@"/"." in the email are
+// preserved (no manual escaping). On success it returns the canonical
+// Member.Name (the alias is request-only; responses are always canonical). An
+// unrecognized member yields an HTTP 400 ("Invalid membership state, user,
+// group or request ID") — that, like a 404, means "not a member of this space",
+// so both map to notMember=true (a cacheable negative, NOT a window-aborting
+// error). Other errors (auth, quota, 5xx) propagate.
+func (f *chatServiceFetcher) ResolveMemberID(ctx context.Context, spaceName, normalizedEmail string) (string, bool, error) {
+	if spaceName == "" || normalizedEmail == "" {
+		return "", true, nil
+	}
+	name := spaceName + "/members/" + normalizedEmail
+	resp, err := f.chat.Spaces.Members.Get(name).Context(ctx).Do()
+	if err != nil {
+		var apiErr *googleapi.Error
+		if errors.As(err, &apiErr) && (apiErr.Code == 400 || apiErr.Code == 404) {
+			return "", true, nil
+		}
+		return "", false, fmt.Errorf("resolve member id for %s: %w", hashIdentifier(spaceName), err)
+	}
+	if resp == nil || resp.Member == nil {
+		return "", true, nil
+	}
+	return resp.Member.Name, false, nil
 }
 
 // primaryNormalizedEmail extracts the person's primary email (or the first

--- a/backend/internal/google/gchat.go
+++ b/backend/internal/google/gchat.go
@@ -433,7 +433,6 @@ func (p *GChatSyncProvider) Sync(
 			logger.Warn().Err(err).Str("source", GChatSourceName).Msg("gchat: membership resolution failed; skipping space")
 			continue
 		}
-		_ = fingerprint // wired into buildKnownIDIndex in the id-matching step
 		if incomplete {
 			// Budget ran out before the membership was fully paged → skip this
 			// space (don't act on a partial member list); it retries next sweep.
@@ -448,14 +447,40 @@ func (p *GChatSyncProvider) Sync(
 			continue
 		}
 
+		// Build the reverse (email→id) index: a known contact whose canonical id is
+		// a member of this space matches even when the People API can't resolve them
+		// (not-in-Contacts). This is the cursor-safety boundary — an UNKNOWN
+		// candidate deferred by the cap (blockedByCapOnDebt) HOLDS this space's
+		// cursor, and a page-budget exhaustion (blockedByBudget) is an incomplete
+		// window. Never advance over a window whose id resolution was incomplete.
+		knownIDs, blockedByBudget, blockedByCapOnDebt, err := buildKnownIDIndex(ctx, space, members, fingerprint, knownMap, meSet, idResolver, counters, &budget)
+		if err != nil {
+			logger.Warn().Err(err).Str("source", GChatSourceName).Msg("gchat: id-index resolution failed; skipping space")
+			continue
+		}
+		if blockedByBudget {
+			// Shared page budget exhausted mid-resolution → incomplete window, stop
+			// the sweep (cursor unadvanced; restarts next tick).
+			break
+		}
+		if blockedByCapOnDebt {
+			// Resolution debt: an UNKNOWN candidate could not be resolved within the
+			// per-sweep cap. HOLD this space's cursor (do NOT advance over its
+			// messages) but let other debt-free spaces continue this sweep. The debt
+			// is durable (persisted negative fingerprint vs. current member-set
+			// fingerprint), so the hold survives across sweeps until it drains.
+			counters.spacesHeldByCapOnDebt++
+			continue
+		}
+
 		isDM := space.SpaceType == gchatSpaceTypeDM
-		if len(knownMembers) == 0 && !isDM {
+		if len(knownMembers) == 0 && len(knownIDs) == 0 && !isDM {
 			counters.spacesSkippedNoKnownMember++
 			continue
 		}
 
 		cur := gcm.cursorFor(space.Name, backfillFloor)
-		newCreateCursor, proven, err := p.consumeContentWindow(ctx, fetcher, space, cur.CreateCursor, knownMembers, knownMap, meSet, resolver, accountID, counters, &budget)
+		newCreateCursor, proven, err := p.consumeContentWindow(ctx, fetcher, space, cur.CreateCursor, knownMembers, knownMap, knownIDs, meSet, resolver, accountID, counters, &budget)
 		if err != nil {
 			// A list/resolve/upsert error mid-window leaves create_cursor
 			// UNADVANCED so the whole window restarts next sweep (idempotent via
@@ -501,6 +526,10 @@ func (p *GChatSyncProvider) Sync(
 		Int("senders_unresolved", counters.sendersUnresolved).
 		Int("edits_applied", counters.editsApplied).
 		Int("deletes_applied", counters.deletesApplied).
+		Int("member_ids_resolved", counters.memberIDsResolved).
+		Int("member_resolve_deferred_cap", counters.memberResolveDeferredCap).
+		Int("member_resolve_negatives_written", counters.memberResolveNegativesWritten).
+		Int("spaces_held_by_cap_on_debt", counters.spacesHeldByCapOnDebt).
 		Msg("GChat sync completed")
 
 	return &syncpkg.SyncResult{
@@ -520,6 +549,11 @@ type sweepCounters struct {
 	sendersUnresolved          int
 	editsApplied               int
 	deletesApplied             int
+	// Reverse (email→id) resolution observability (§3.6).
+	memberIDsResolved             int // fresh members.get → id that IS a member of its space
+	memberResolveDeferredCap      int // UNKNOWN candidates deferred this sweep (cap exhausted)
+	memberResolveNegativesWritten int // fresh members.get → not-a-member negatives written
+	spacesHeldByCapOnDebt         int // spaces whose cursor was held because debt couldn't drain within the cap
 }
 
 // buildKnownMap loads the dual-source (gchat+email) known-contact map:
@@ -580,6 +614,13 @@ func (p *GChatSyncProvider) ScanIdentifier(
 	}
 
 	resolver := newCachedEmailResolver(fetcher, nil)
+	// In-scan-only reverse resolver: seeded empty and NOT persisted back to
+	// metadata (§3.4) — this avoids a read-modify-write race with the sweep on the
+	// same external_sync_state.metadata row. The resolve-cap does NOT apply to the
+	// scan (cap=nil): the scan resolves exactly ONE address per space, bounded only
+	// by the page budget. The in-scan memo dedups the address across spaces within
+	// the run, so this is at most a handful of members.get calls per rematch event.
+	idResolver := newMemberIDResolver(fetcher, nil, nil, nil)
 	counters := &sweepCounters{}
 	// The rematch scan is a one-shot historical backfill. It gets its OWN full
 	// page budget. If the budget is exhausted before every space's window is
@@ -609,16 +650,45 @@ func (p *GChatSyncProvider) ScanIdentifier(
 			return counters.matched, fmt.Errorf("resolve co-members: %w", rErr)
 		}
 		scanMembers := restrictKnownMembers(knownMembers, addrNormalized)
+
+		// Reverse id-resolution for the scanned address: resolve it to its canonical
+		// id in THIS space (members.get with the email alias) so a contact who is a
+		// member/sender but not in Google Contacts matches historical messages too.
+		// The scanned email carries through as the peer identity (same idMatch
+		// shape). A page-budget exhaustion mid-resolution fails the scan (the
+		// completeness invariant), exactly like a mid-window budget hit.
+		scanIDs := map[string]idMatch{}
+		fingerprint := memberSetFingerprint(members)
+		userName, status, sErr := idResolver.resolve(ctx, space.Name, fingerprint, addrNormalized, &budget)
+		if sErr != nil {
+			return counters.matched, fmt.Errorf("resolve scanned member id: %w", sErr)
+		}
+		if status == deferredBudgetHit {
+			return counters.matched, fmt.Errorf("rematch scan budget exhausted resolving member id: retry to finish backfill")
+		}
+		idIsMember := false
+		if status == resolvedKnownID {
+			for _, id := range members {
+				if id == userName {
+					idIsMember = true
+					break
+				}
+			}
+			if idIsMember {
+				scanIDs[userName] = idMatch{Email: addrNormalized, Contacts: contacts}
+			}
+		}
+
 		isDM := space.SpaceType == gchatSpaceTypeDM
-		if len(scanMembers) == 0 && !isDM {
-			// The target address is not a member of this space → it can still be
-			// the inbound SENDER, so we must still page messages. But to bound the
-			// scan we skip spaces where the address is neither a member nor (for a
-			// DM) the implicit peer — an inbound message from the address can only
-			// arrive in a space the address belongs to.
+		// Page the space when the address is an email-resolved member, an
+		// id-resolved member, OR a DM peer; otherwise it can still be the inbound
+		// SENDER only if it's a member, so skipping a non-member non-DM space is
+		// safe (an inbound message from the address arrives only in a space it
+		// belongs to).
+		if len(scanMembers) == 0 && !idIsMember && !isDM {
 			continue
 		}
-		_, proven, cErr := p.consumeContentWindow(ctx, fetcher, space, afterCursor, scanMembers, scanMap, meSet, resolver, accountID, counters, &budget)
+		_, proven, cErr := p.consumeContentWindow(ctx, fetcher, space, afterCursor, scanMembers, scanMap, scanIDs, meSet, resolver, accountID, counters, &budget)
 		if cErr != nil {
 			return counters.matched, fmt.Errorf("scan space: %w", cErr)
 		}
@@ -658,6 +728,7 @@ func (p *GChatSyncProvider) consumeContentWindow(
 	createCursor string,
 	knownMembers map[string][]uuid.UUID,
 	knownMap map[string][]uuid.UUID,
+	knownIDs map[string]idMatch,
 	meSet map[string]struct{},
 	resolver *cachedEmailResolver,
 	accountID string,
@@ -682,7 +753,7 @@ func (p *GChatSyncProvider) consumeContentWindow(
 			if !qualifiableContentMessage(m) {
 				continue
 			}
-			matchErr := p.qualifyAndUpsert(ctx, m, space, knownMembers, knownMap, meSet, resolver, accountID, counters)
+			matchErr := p.qualifyAndUpsert(ctx, m, space, knownMembers, knownMap, knownIDs, meSet, resolver, accountID, counters)
 			if matchErr != nil {
 				// Transient resolve/upsert error: abort the window, keep the
 				// original cursor (do NOT advance past this message).
@@ -845,14 +916,40 @@ type messageClassification struct {
 // classifyMessage resolves the sender and decides direction + fan-out WITHOUT
 // touching the DB. A resolve error propagates (so the caller aborts the window
 // and retries). An unresolved sender or a bystander yields an empty Matched set.
+//
+// knownIDs is the per-space id index (sender/member "users/{id}" → idMatch),
+// built by buildKnownIDIndex from the global positive cache + fresh members.get
+// resolutions. It lets a sender id match a CRM contact even when the People API
+// (Contacts) cannot resolve that id to an email. The match precedence is:
+//
+//   - INBOUND id-path FIRST: if the sender id is in knownIDs (never me — meSet is
+//     excluded when the index is built), the message is inbound and the PEER is
+//     the sender, so SenderEmail is set to the matched idMatch.Email (so the peer
+//     columns carry the CRM email, not the empty People-API result).
+//   - else fall through to the People-API email path: OUTBOUND (sender ∈ meSet)
+//     fans out to the UNION of email-resolved known co-members AND id-resolved
+//     known members (the peer stays "me", unchanged); email-resolved INBOUND
+//     (sender's email ∈ knownMap) is sender-only as before; otherwise bystander.
 func classifyMessage(
 	ctx context.Context,
 	m *chat.Message,
 	knownMembers map[string][]uuid.UUID,
 	knownMap map[string][]uuid.UUID,
+	knownIDs map[string]idMatch,
 	meSet map[string]struct{},
 	resolver *cachedEmailResolver,
 ) (messageClassification, error) {
+	// INBOUND id-path first: a sender id present in knownIDs is a known co-member
+	// resolved by canonical id (Contacts-independent). The peer is the sender, so
+	// carry the CRM email through SenderEmail for the peer columns.
+	if idm, ok := knownIDs[m.Sender.Name]; ok && len(idm.Contacts) > 0 {
+		return messageClassification{
+			SenderEmail: idm.Email,
+			Direction:   repository.InteractionDirectionInbound,
+			Matched:     idm.Contacts,
+		}, nil
+	}
+
 	senderEmail, err := resolver.resolve(ctx, m.Sender.Name)
 	if err != nil {
 		return messageClassification{}, fmt.Errorf("resolve sender: %w", err)
@@ -865,8 +962,9 @@ func classifyMessage(
 	switch {
 	case inSet(meSet, senderEmail):
 		c.Direction = repository.InteractionDirectionOutbound
-		// Fan out to every known co-member, EXCLUDING any self-contact.
-		c.Matched = flattenKnownMembers(knownMembers, meSet)
+		// Fan out to the UNION of email-resolved known co-members and id-resolved
+		// known members, EXCLUDING any self-contact (deduped by contact id).
+		c.Matched = flattenKnownMembersAndIDs(knownMembers, knownIDs, meSet)
 	case len(knownMap[senderEmail]) > 0:
 		c.Direction = repository.InteractionDirectionInbound
 		c.Matched = knownMap[senderEmail] // sender-only
@@ -885,12 +983,13 @@ func (p *GChatSyncProvider) qualifyAndUpsert(
 	space *chat.Space,
 	knownMembers map[string][]uuid.UUID,
 	knownMap map[string][]uuid.UUID,
+	knownIDs map[string]idMatch,
 	meSet map[string]struct{},
 	resolver *cachedEmailResolver,
 	accountID string,
 	counters *sweepCounters,
 ) error {
-	c, err := classifyMessage(ctx, m, knownMembers, knownMap, meSet, resolver)
+	c, err := classifyMessage(ctx, m, knownMembers, knownMap, knownIDs, meSet, resolver)
 	if err != nil {
 		return err
 	}
@@ -948,16 +1047,25 @@ type MessageClassificationForTest struct {
 	Unresolved  bool
 }
 
+// IDMatchForTest is an exported constructor for the unexported idMatch so
+// cross-package tests can seed RunClassifyForTest's known-id index. Production
+// code must NOT use this.
+func IDMatchForTest(email string, contacts []uuid.UUID) idMatch {
+	return idMatch{Email: email, Contacts: contacts}
+}
+
 // RunClassifyForTest drives the DB-free classifyMessage for cross-package tests,
-// using a fake-fetcher-backed resolver. Production code must NOT call this.
+// using a fake-fetcher-backed resolver. knownIDs is the reverse (email→id)
+// index (build values with IDMatchForTest). Production code must NOT call this.
 func RunClassifyForTest(
 	ctx context.Context,
 	m *chat.Message,
 	knownMembers map[string][]uuid.UUID,
 	knownMap map[string][]uuid.UUID,
+	knownIDs map[string]idMatch,
 	meSet map[string]struct{},
 	resolver *CachedEmailResolverForTest,
 ) (MessageClassificationForTest, error) {
-	c, err := classifyMessage(ctx, m, knownMembers, knownMap, meSet, resolver.inner)
+	c, err := classifyMessage(ctx, m, knownMembers, knownMap, knownIDs, meSet, resolver.inner)
 	return MessageClassificationForTest(c), err
 }

--- a/backend/internal/google/gchat.go
+++ b/backend/internal/google/gchat.go
@@ -409,6 +409,11 @@ func (p *GChatSyncProvider) Sync(
 	reapStaleCursors(gcm, spaces, accelerated.GetCurrentTime())
 
 	resolver := newCachedEmailResolver(fetcher, gcm.UserEmailCache)
+	// The reverse (email→id) resolver shares the global positive cache + per-space
+	// negatives across the whole sweep, capped at gchatMaxMemberResolvesPerSync
+	// fresh members.get calls so a cold start amortizes over many ticks.
+	resolveCap := gchatMaxMemberResolvesPerSync
+	idResolver := newMemberIDResolver(fetcher, gcm.EmailUserIDs, gcm.SpaceMemberNegatives, &resolveCap)
 	counters := &sweepCounters{}
 	backfillFloor := gchatBackfillFloor(state.Metadata)
 	// Shared list-page budget for the WHOLE sweep (membership + content + edit
@@ -482,7 +487,7 @@ func (p *GChatSyncProvider) Sync(
 		gcm.setCursor(space.Name, cur)
 	}
 
-	if err := p.persistMetadata(ctx, state, gcm, resolver); err != nil {
+	if err := p.persistMetadata(ctx, state, gcm, resolver, idResolver); err != nil {
 		return nil, fmt.Errorf("persist gchat metadata: %w", err)
 	}
 

--- a/backend/internal/google/gchat.go
+++ b/backend/internal/google/gchat.go
@@ -42,7 +42,7 @@ const (
 	// single sweep may issue across ALL spaces (the reverse email→id resolutions).
 	// 50 is comfortably under quota, amortizes a cold 67-space start over a handful
 	// of 15-min ticks, and is sized to cover a single space's debt re-resolution
-	// set in one sweep (§3.2.1). When the cap is hit, remaining UNKNOWN candidates
+	// set in one sweep. When the cap is hit, remaining UNKNOWN candidates
 	// are left unresolved THIS sweep and HOLD their space's cursor (resolution
 	// debt) until a later tick resolves them. Revisit if prod logs show persistent
 	// spacesHeldByCapOnDebt.
@@ -91,7 +91,7 @@ const (
 	// gchatMetaSpaceMemberNegatives is the PER-(space,email) negative cache
 	// (space → normalizedEmail → memberNegative): "this known email is NOT a
 	// member of this space," stamped with the space's member-set fingerprint so a
-	// negative is only honored while membership is unchanged (see §3.2.1).
+	// negative is only honored while membership is unchanged.
 	gchatMetaSpaceMemberNegatives = "space_member_negatives"
 )
 
@@ -558,7 +558,7 @@ type sweepCounters struct {
 	sendersUnresolved          int
 	editsApplied               int
 	deletesApplied             int
-	// Reverse (email→id) resolution observability (§3.6).
+	// Reverse (email→id) resolution observability.
 	memberIDsResolved             int // fresh members.get → id that IS a member of its space
 	memberResolveDeferredCap      int // UNKNOWN candidates deferred this sweep (cap exhausted)
 	memberResolveNegativesWritten int // fresh members.get → not-a-member negatives written
@@ -624,7 +624,7 @@ func (p *GChatSyncProvider) ScanIdentifier(
 
 	resolver := newCachedEmailResolver(fetcher, nil)
 	// In-scan-only reverse resolver: seeded empty and NOT persisted back to
-	// metadata (§3.4) — this avoids a read-modify-write race with the sweep on the
+	// metadata — this avoids a read-modify-write race with the sweep on the
 	// same external_sync_state.metadata row. The resolve-cap does NOT apply to the
 	// scan (cap=nil): the scan resolves exactly ONE address per space, bounded only
 	// by the page budget. The in-scan memo dedups the address across spaces within
@@ -1056,25 +1056,33 @@ type MessageClassificationForTest struct {
 	Unresolved  bool
 }
 
-// IDMatchForTest is an exported constructor for the unexported idMatch so
-// cross-package tests can seed RunClassifyForTest's known-id index. Production
-// code must NOT use this.
-func IDMatchForTest(email string, contacts []uuid.UUID) idMatch {
-	return idMatch{Email: email, Contacts: contacts}
+// KnownSenderIDForTest is an exported DTO describing one entry of the reverse
+// (id→contact) index so cross-package tests can seed RunClassifyForTest WITHOUT
+// naming the unexported idMatch type. Production code must NOT use this.
+type KnownSenderIDForTest struct {
+	UserName string // canonical "users/{id}"
+	Email    string // the CRM email carried as the peer identity
+	Contacts []uuid.UUID
 }
 
 // RunClassifyForTest drives the DB-free classifyMessage for cross-package tests,
-// using a fake-fetcher-backed resolver. knownIDs is the reverse (email→id)
-// index (build values with IDMatchForTest). Production code must NOT call this.
+// using a fake-fetcher-backed resolver. knownIDs is the reverse (id→contact)
+// index, supplied as exported DTOs and converted to the internal index here so
+// no unexported type crosses the package boundary. Production code must NOT call
+// this.
 func RunClassifyForTest(
 	ctx context.Context,
 	m *chat.Message,
 	knownMembers map[string][]uuid.UUID,
 	knownMap map[string][]uuid.UUID,
-	knownIDs map[string]idMatch,
+	knownIDs []KnownSenderIDForTest,
 	meSet map[string]struct{},
 	resolver *CachedEmailResolverForTest,
 ) (MessageClassificationForTest, error) {
-	c, err := classifyMessage(ctx, m, knownMembers, knownMap, knownIDs, meSet, resolver.inner)
+	idx := make(map[string]idMatch, len(knownIDs))
+	for _, k := range knownIDs {
+		idx[k.UserName] = idMatch{Email: k.Email, Contacts: k.Contacts}
+	}
+	c, err := classifyMessage(ctx, m, knownMembers, knownMap, idx, meSet, resolver.inner)
 	return MessageClassificationForTest(c), err
 }

--- a/backend/internal/google/gchat.go
+++ b/backend/internal/google/gchat.go
@@ -464,7 +464,7 @@ func (p *GChatSyncProvider) Sync(
 		// window. Never advance over a window whose id resolution was incomplete.
 		// meIDs (the account's own ids in this space) are excluded so a stray
 		// alias resolving to the account's own id can never enter the index.
-		knownIDs, blockedByBudget, blockedByCapOnDebt, err := buildKnownIDIndex(ctx, space, members, fingerprint, knownMap, meSet, meIDs, idResolver, counters, &budget)
+		knownIDs, spaceMeIDs, blockedByBudget, blockedByCapOnDebt, err := buildKnownIDIndex(ctx, space, members, fingerprint, knownMap, meSet, meIDs, idResolver, counters, &budget)
 		if err != nil {
 			logger.Warn().Err(err).Str("source", GChatSourceName).Msg("gchat: id-index resolution failed; skipping space")
 			continue
@@ -491,7 +491,7 @@ func (p *GChatSyncProvider) Sync(
 		}
 
 		cur := gcm.cursorFor(space.Name, backfillFloor)
-		newCreateCursor, proven, err := p.consumeContentWindow(ctx, fetcher, space, cur.CreateCursor, knownMembers, knownMap, knownIDs, meSet, resolver, accountID, counters, &budget)
+		newCreateCursor, proven, err := p.consumeContentWindow(ctx, fetcher, space, cur.CreateCursor, knownMembers, knownMap, knownIDs, spaceMeIDs, meSet, resolver, accountID, counters, &budget)
 		if err != nil {
 			// A list/resolve/upsert error mid-window leaves create_cursor
 			// UNADVANCED so the whole window restarts next sweep (idempotent via
@@ -701,7 +701,7 @@ func (p *GChatSyncProvider) ScanIdentifier(
 		if len(scanMembers) == 0 && !idIsMember && !isDM {
 			continue
 		}
-		_, proven, cErr := p.consumeContentWindow(ctx, fetcher, space, afterCursor, scanMembers, scanMap, scanIDs, meSet, resolver, accountID, counters, &budget)
+		_, proven, cErr := p.consumeContentWindow(ctx, fetcher, space, afterCursor, scanMembers, scanMap, scanIDs, meIDs, meSet, resolver, accountID, counters, &budget)
 		if cErr != nil {
 			return counters.matched, fmt.Errorf("scan space: %w", cErr)
 		}
@@ -742,6 +742,7 @@ func (p *GChatSyncProvider) consumeContentWindow(
 	knownMembers map[string][]uuid.UUID,
 	knownMap map[string][]uuid.UUID,
 	knownIDs map[string]idMatch,
+	meIDs map[string]struct{},
 	meSet map[string]struct{},
 	resolver *cachedEmailResolver,
 	accountID string,
@@ -766,7 +767,7 @@ func (p *GChatSyncProvider) consumeContentWindow(
 			if !qualifiableContentMessage(m) {
 				continue
 			}
-			matchErr := p.qualifyAndUpsert(ctx, m, space, knownMembers, knownMap, knownIDs, meSet, resolver, accountID, counters)
+			matchErr := p.qualifyAndUpsert(ctx, m, space, knownMembers, knownMap, knownIDs, meIDs, meSet, resolver, accountID, counters)
 			if matchErr != nil {
 				// Transient resolve/upsert error: abort the window, keep the
 				// original cursor (do NOT advance past this message).
@@ -949,18 +950,26 @@ func classifyMessage(
 	knownMembers map[string][]uuid.UUID,
 	knownMap map[string][]uuid.UUID,
 	knownIDs map[string]idMatch,
+	meIDs map[string]struct{},
 	meSet map[string]struct{},
 	resolver *cachedEmailResolver,
 ) (messageClassification, error) {
 	// INBOUND id-path first: a sender id present in knownIDs is a known co-member
 	// resolved by canonical id (Contacts-independent). The peer is the sender, so
-	// carry the CRM email through SenderEmail for the peer columns.
-	if idm, ok := knownIDs[m.Sender.Name]; ok && len(idm.Contacts) > 0 {
-		return messageClassification{
-			SenderEmail: idm.Email,
-			Direction:   repository.InteractionDirectionInbound,
-			Matched:     idm.Contacts,
-		}, nil
+	// carry the CRM email through SenderEmail for the peer columns. Defense-in-
+	// depth: never take the id-path for the account's own id (meIDs) — even though
+	// buildKnownIDIndex already excludes me-ids from knownIDs, this point-of-use
+	// guard makes a self-sender fall through to the email path (→ outbound), so a
+	// stray alias resolving to a me-id can never be stored as inbound from a
+	// contact.
+	if _, isMe := meIDs[m.Sender.Name]; !isMe {
+		if idm, ok := knownIDs[m.Sender.Name]; ok && len(idm.Contacts) > 0 {
+			return messageClassification{
+				SenderEmail: idm.Email,
+				Direction:   repository.InteractionDirectionInbound,
+				Matched:     idm.Contacts,
+			}, nil
+		}
 	}
 
 	senderEmail, err := resolver.resolve(ctx, m.Sender.Name)
@@ -997,12 +1006,13 @@ func (p *GChatSyncProvider) qualifyAndUpsert(
 	knownMembers map[string][]uuid.UUID,
 	knownMap map[string][]uuid.UUID,
 	knownIDs map[string]idMatch,
+	meIDs map[string]struct{},
 	meSet map[string]struct{},
 	resolver *cachedEmailResolver,
 	accountID string,
 	counters *sweepCounters,
 ) error {
-	c, err := classifyMessage(ctx, m, knownMembers, knownMap, knownIDs, meSet, resolver)
+	c, err := classifyMessage(ctx, m, knownMembers, knownMap, knownIDs, meIDs, meSet, resolver)
 	if err != nil {
 		return err
 	}
@@ -1080,6 +1090,7 @@ func RunClassifyForTest(
 	knownMembers map[string][]uuid.UUID,
 	knownMap map[string][]uuid.UUID,
 	knownIDs []KnownSenderIDForTest,
+	meIDs map[string]struct{},
 	meSet map[string]struct{},
 	resolver *CachedEmailResolverForTest,
 ) (MessageClassificationForTest, error) {
@@ -1087,6 +1098,6 @@ func RunClassifyForTest(
 	for _, k := range knownIDs {
 		idx[k.UserName] = idMatch{Email: k.Email, Contacts: k.Contacts}
 	}
-	c, err := classifyMessage(ctx, m, knownMembers, knownMap, idx, meSet, resolver.inner)
+	c, err := classifyMessage(ctx, m, knownMembers, knownMap, idx, meIDs, meSet, resolver.inner)
 	return MessageClassificationForTest(c), err
 }

--- a/backend/internal/google/gchat.go
+++ b/backend/internal/google/gchat.go
@@ -38,6 +38,16 @@ const (
 	// retries (idempotent via the upsert dedup).
 	gchatMaxWindowsPerSync = 100
 
+	// gchatMaxMemberResolvesPerSync caps the number of FRESH members.get calls a
+	// single sweep may issue across ALL spaces (the reverse email→id resolutions).
+	// 50 is comfortably under quota, amortizes a cold 67-space start over a handful
+	// of 15-min ticks, and is sized to cover a single space's debt re-resolution
+	// set in one sweep (§3.2.1). When the cap is hit, remaining UNKNOWN candidates
+	// are left unresolved THIS sweep and HOLD their space's cursor (resolution
+	// debt) until a later tick resolves them. Revisit if prod logs show persistent
+	// spacesHeldByCapOnDebt.
+	gchatMaxMemberResolvesPerSync = 50
+
 	// gchatMembershipCacheTTL bounds how long a cached space-member list (and a
 	// cached id→email resolution) stays valid before a forced refetch, even when
 	// the space's lastActiveTime never advances. Caps People/Chat API quota.
@@ -73,6 +83,16 @@ const (
 	gchatMetaSpaceMembers    = "space_members"
 	gchatMetaUserEmailCache  = "user_email_cache"
 	gchatMetaMeIdentities    = "me_identities"
+	// gchatMetaEmailUserIDs is the GLOBAL positive cache (normalizedEmail →
+	// canonical "users/{id}") from the reverse resolver: a canonical id is the
+	// same person in every space, so once an email resolves anywhere it is reused
+	// everywhere with zero further members.get calls.
+	gchatMetaEmailUserIDs = "email_user_ids"
+	// gchatMetaSpaceMemberNegatives is the PER-(space,email) negative cache
+	// (space → normalizedEmail → memberNegative): "this known email is NOT a
+	// member of this space," stamped with the space's member-set fingerprint so a
+	// negative is only honored while membership is unchanged (see §3.2.1).
+	gchatMetaSpaceMemberNegatives = "space_member_negatives"
 )
 
 // chatFetcher is the narrow Google Chat + People read surface the provider
@@ -401,13 +421,14 @@ func (p *GChatSyncProvider) Sync(
 		if budget <= 0 {
 			break
 		}
-		members, incomplete, err := p.resolveMembership(ctx, fetcher, space, gcm, &budget)
+		members, fingerprint, incomplete, err := p.resolveMembership(ctx, fetcher, space, gcm, &budget)
 		if err != nil {
 			// Transient membership error: abort THIS space (cursor unadvanced),
 			// continue with already-proven spaces. Don't fail the whole sweep.
 			logger.Warn().Err(err).Str("source", GChatSourceName).Msg("gchat: membership resolution failed; skipping space")
 			continue
 		}
+		_ = fingerprint // wired into buildKnownIDIndex in the id-matching step
 		if incomplete {
 			// Budget ran out before the membership was fully paged → skip this
 			// space (don't act on a partial member list); it retries next sweep.

--- a/backend/internal/google/gchat.go
+++ b/backend/internal/google/gchat.go
@@ -277,6 +277,12 @@ type GChatSyncProvider struct {
 	// newMeSet builds the "me" set (the normalized address of every connected
 	// account). Tests override via SetMeSetForTest.
 	newMeSet func(ctx context.Context) (map[string]struct{}, error)
+
+	// memberResolveCapOverride, when non-nil, replaces gchatMaxMemberResolvesPerSync
+	// as the per-sweep reverse-resolve cap. Tests set it via
+	// SetMemberResolveCapForTest to drive the resolve-cap deferral (debt) path
+	// deterministically. nil in production (the default constant applies).
+	memberResolveCapOverride *int
 }
 
 // Ensure GChatSyncProvider implements the sync.SyncProvider interface.
@@ -413,6 +419,9 @@ func (p *GChatSyncProvider) Sync(
 	// negatives across the whole sweep, capped at gchatMaxMemberResolvesPerSync
 	// fresh members.get calls so a cold start amortizes over many ticks.
 	resolveCap := gchatMaxMemberResolvesPerSync
+	if p.memberResolveCapOverride != nil {
+		resolveCap = *p.memberResolveCapOverride
+	}
 	idResolver := newMemberIDResolver(fetcher, gcm.EmailUserIDs, gcm.SpaceMemberNegatives, &resolveCap)
 	counters := &sweepCounters{}
 	backfillFloor := gchatBackfillFloor(state.Metadata)

--- a/backend/internal/google/gchat.go
+++ b/backend/internal/google/gchat.go
@@ -447,7 +447,7 @@ func (p *GChatSyncProvider) Sync(
 			// space (don't act on a partial member list); it retries next sweep.
 			break
 		}
-		knownMembers, err := resolveKnownMembers(ctx, members, resolver, knownMap, meSet)
+		knownMembers, meIDs, err := resolveKnownMembers(ctx, members, resolver, knownMap, meSet)
 		if err != nil {
 			// Transient resolve error while resolving co-members: abort THIS space
 			// (cursor unadvanced) so the window retries next sweep with the full
@@ -462,7 +462,9 @@ func (p *GChatSyncProvider) Sync(
 		// candidate deferred by the cap (blockedByCapOnDebt) HOLDS this space's
 		// cursor, and a page-budget exhaustion (blockedByBudget) is an incomplete
 		// window. Never advance over a window whose id resolution was incomplete.
-		knownIDs, blockedByBudget, blockedByCapOnDebt, err := buildKnownIDIndex(ctx, space, members, fingerprint, knownMap, meSet, idResolver, counters, &budget)
+		// meIDs (the account's own ids in this space) are excluded so a stray
+		// alias resolving to the account's own id can never enter the index.
+		knownIDs, blockedByBudget, blockedByCapOnDebt, err := buildKnownIDIndex(ctx, space, members, fingerprint, knownMap, meSet, meIDs, idResolver, counters, &budget)
 		if err != nil {
 			logger.Warn().Err(err).Str("source", GChatSourceName).Msg("gchat: id-index resolution failed; skipping space")
 			continue
@@ -654,7 +656,9 @@ func (p *GChatSyncProvider) ScanIdentifier(
 		}
 		// Co-member resolution uses the FULL knownMap (so a space qualifies when
 		// the target address is one of its members); row-writing uses scanMap.
-		knownMembers, rErr := resolveKnownMembers(ctx, members, resolver, knownMap, meSet)
+		// meIDs are the account's own ids in this space (used to keep a scanned
+		// alias that resolves to the account's own id out of the id-match set).
+		knownMembers, meIDs, rErr := resolveKnownMembers(ctx, members, resolver, knownMap, meSet)
 		if rErr != nil {
 			return counters.matched, fmt.Errorf("resolve co-members: %w", rErr)
 		}
@@ -676,7 +680,7 @@ func (p *GChatSyncProvider) ScanIdentifier(
 			return counters.matched, fmt.Errorf("rematch scan budget exhausted resolving member id: retry to finish backfill")
 		}
 		idIsMember := false
-		if status == resolvedKnownID {
+		if _, isMe := meIDs[userName]; status == resolvedKnownID && !isMe {
 			for _, id := range members {
 				if id == userName {
 					idIsMember = true

--- a/backend/internal/google/gchat_helpers.go
+++ b/backend/internal/google/gchat_helpers.go
@@ -3,11 +3,14 @@ package google
 import (
 	"context"
 	"encoding/json"
+	"sort"
 	"time"
 
 	chat "google.golang.org/api/chat/v1"
 
 	"github.com/google/uuid"
+
+	"personal-crm/backend/internal/accelerated"
 )
 
 // --- pagination ------------------------------------------------------
@@ -140,6 +143,27 @@ func flattenKnownMembers(knownMembers map[string][]uuid.UUID, meSet map[string]s
 	return out
 }
 
+// flattenKnownMembersAndIDs is the outbound fan-out recipient set: the UNION of
+// the email-resolved known co-members (flattenKnownMembers) and the id-resolved
+// known members (knownIDs values), deduped by contact id and self-excluded. An
+// idMatch's Email is checked against meSet defensively (the index already drops
+// meSet members, so this never fires in practice but keeps the self-exclusion
+// invariant local).
+func flattenKnownMembersAndIDs(knownMembers map[string][]uuid.UUID, knownIDs map[string]idMatch, meSet map[string]struct{}) []uuid.UUID {
+	out := flattenKnownMembers(knownMembers, meSet)
+	for _, idm := range knownIDs {
+		if inSet(meSet, idm.Email) {
+			continue
+		}
+		for _, c := range idm.Contacts {
+			if !containsUUID(out, c) {
+				out = append(out, c)
+			}
+		}
+	}
+	return out
+}
+
 // firstN returns the first n characters (runes) of s.
 func firstN(s string, n int) string {
 	if n <= 0 {
@@ -200,6 +224,148 @@ func buildContentMetadata(space *chat.Space, m *chat.Message) []byte {
 		return []byte("{}")
 	}
 	return b
+}
+
+// --- known-id index (reverse email→id matching) ----------------------
+
+// idMatch is the value of the per-space known-id index: the CRM email that
+// resolved to a canonical id, plus the contact ids that email maps to. The
+// email is carried so an id-path match populates the peer columns with the CRM
+// email (an id-path People-API resolution is "", which would otherwise write an
+// empty peer).
+type idMatch struct {
+	Email    string
+	Contacts []uuid.UUID
+}
+
+// buildKnownIDIndex builds the per-space "users/{id}" → idMatch index that lets
+// a sender/member match a CRM contact by CANONICAL ID even when the People API
+// (Contacts) cannot resolve that id to an email. It has two zero-API-call
+// sources (global positive cache + the space's member-id list) plus bounded
+// fresh members.get resolutions for the rest.
+//
+// members is the space's current "users/{id}" member set; fingerprint is its
+// member-set fingerprint (§3.2.1). knownMap is the dual-source known-contact
+// map (normalizedEmail → []contactID); meSet is the connected-account self set.
+// resolver is the reverse resolver; pageBudget is the shared page allowance.
+//
+// Returns:
+//   - knownIDs: the index. A member/sender id present here is a known contact.
+//   - blockedByBudget: a fresh resolution hit the page budget (incomplete window
+//     — the caller must NOT advance the cursor; treat like a partial page).
+//   - blockedByCapOnDebt: an UNKNOWN candidate could not be resolved because the
+//     per-sweep resolve-cap was exhausted (resolution debt — the caller holds
+//     THIS space's cursor until a later sweep drains the debt, §3.2.1).
+//
+// Candidate classification under the current fingerprint: POSITIVE (global
+// positive hit whose id ∈ members), NEGATIVE-VALID (per-space negative with a
+// matching fingerprint, within TTL), or UNKNOWN (must resolve). UNKNOWN
+// fingerprint-invalidated candidates (a negative whose fingerprint no longer
+// matches — a membership change happened) get PRIORITY access to the cap over
+// never-seen candidates, so a one-time debt drains efficiently.
+func buildKnownIDIndex(
+	ctx context.Context,
+	space *chat.Space,
+	members []string,
+	fingerprint string,
+	knownMap map[string][]uuid.UUID,
+	meSet map[string]struct{},
+	resolver *memberIDResolver,
+	counters *sweepCounters,
+	pageBudget *int,
+) (knownIDs map[string]idMatch, blockedByBudget bool, blockedByCapOnDebt bool, err error) {
+	knownIDs = map[string]idMatch{}
+
+	// The member-id set of this space, for the "id ∈ members" check.
+	memberSet := make(map[string]struct{}, len(members))
+	for _, id := range members {
+		memberSet[id] = struct{}{}
+	}
+
+	// Seed from the GLOBAL positive cache: every known email whose cached id is a
+	// member of this space matches with zero API calls. Track which emails are
+	// already matched so they are not re-resolved.
+	seeded := map[string]struct{}{}
+	for email, contacts := range knownMap {
+		if inSet(meSet, email) || len(contacts) == 0 {
+			continue
+		}
+		id, ok := resolver.cachedPositive(email)
+		if !ok {
+			continue
+		}
+		if _, isMember := memberSet[id]; isMember {
+			knownIDs[id] = idMatch{Email: email, Contacts: contacts}
+			seeded[email] = struct{}{}
+		}
+	}
+
+	// Classify the remaining candidates and order them so fingerprint-invalidated
+	// (was-NEGATIVE-now-UNKNOWN) candidates get priority access to the cap.
+	priority, normal := classifyIDCandidates(space.Name, fingerprint, knownMap, meSet, seeded, resolver)
+
+	for _, email := range append(priority, normal...) {
+		id, status, rerr := resolver.resolve(ctx, space.Name, fingerprint, email, pageBudget)
+		if rerr != nil {
+			return nil, false, false, rerr
+		}
+		switch status {
+		case resolvedKnownID:
+			if _, isMember := memberSet[id]; isMember {
+				knownIDs[id] = idMatch{Email: email, Contacts: knownMap[email]}
+				counters.memberIDsResolved++
+			}
+			// A resolved id that is NOT a member of this space is a co-member of
+			// some OTHER space (the positive is global) — not a match here, but the
+			// global positive is now populated for future spaces.
+		case notMember:
+			counters.memberResolveNegativesWritten++
+		case deferredCapHit:
+			counters.memberResolveDeferredCap++
+			blockedByCapOnDebt = true
+		case deferredBudgetHit:
+			blockedByBudget = true
+			return knownIDs, blockedByBudget, blockedByCapOnDebt, nil
+		}
+	}
+	return knownIDs, blockedByBudget, blockedByCapOnDebt, nil
+}
+
+// classifyIDCandidates partitions the not-yet-matched known emails into those
+// whose per-space negative was invalidated by a fingerprint change (priority —
+// a membership change happened, so re-resolve first) and the rest (never-seen,
+// or no negative). meSet emails and already-seeded emails are skipped. Both
+// slices are sorted for deterministic ordering across runs.
+func classifyIDCandidates(
+	spaceName, fingerprint string,
+	knownMap map[string][]uuid.UUID,
+	meSet map[string]struct{},
+	seeded map[string]struct{},
+	resolver *memberIDResolver,
+) (priority, normal []string) {
+	for email, contacts := range knownMap {
+		if inSet(meSet, email) || len(contacts) == 0 {
+			continue
+		}
+		if _, ok := seeded[email]; ok {
+			continue
+		}
+		// A within-TTL, fingerprint-matching negative is NEGATIVE-VALID → not a
+		// candidate (no debt). Anything else is UNKNOWN → a candidate.
+		if neg, ok := resolver.negativeFor(spaceName, email); ok {
+			if !memberNegativeExpired(neg, accelerated.GetCurrentTime()) && neg.MemberSetFingerprint == fingerprint {
+				continue // NEGATIVE-VALID
+			}
+			// A stale negative (fingerprint changed or expired) is UNKNOWN with
+			// PRIORITY — a membership change happened, so drain it first.
+			priority = append(priority, email)
+			continue
+		}
+		normal = append(normal, email) // never seen → UNKNOWN
+	}
+	sort.Strings(priority)
+	sort.Strings(normal)
+	return priority, normal
 }
 
 // --- test seams ------------------------------------------------------
@@ -295,10 +461,14 @@ func (r *CachedEmailResolverForTest) Resolve(ctx context.Context, userName strin
 // SweepCountersForTest is the exported view of the per-sweep counters so tests
 // can assert qualification outcomes. Production code must NOT use this.
 type SweepCountersForTest struct {
-	Processed                  int
-	Matched                    int
-	SpacesSkippedNoKnownMember int
-	SendersUnresolved          int
-	EditsApplied               int
-	DeletesApplied             int
+	Processed                     int
+	Matched                       int
+	SpacesSkippedNoKnownMember    int
+	SendersUnresolved             int
+	EditsApplied                  int
+	DeletesApplied                int
+	MemberIDsResolved             int
+	MemberResolveDeferredCap      int
+	MemberResolveNegativesWritten int
+	SpacesHeldByCapOnDebt         int
 }

--- a/backend/internal/google/gchat_helpers.go
+++ b/backend/internal/google/gchat_helpers.go
@@ -263,6 +263,11 @@ type idMatch struct {
 // fingerprint-invalidated candidates (a negative whose fingerprint no longer
 // matches — a membership change happened) get PRIORITY access to the cap over
 // never-seen candidates, so a one-time debt drains efficiently.
+// meIDs is the set of the account's OWN canonical ids within this space
+// (observed by resolveKnownMembers). Any resolved id in meIDs is dropped from
+// the index so the inbound id-path can never fire for the account itself — even
+// if a stray non-meSet alias resolves to the account's own id. This makes the
+// "knownIDs never contains a me-id" invariant enforced, not merely assumed.
 func buildKnownIDIndex(
 	ctx context.Context,
 	space *chat.Space,
@@ -270,6 +275,7 @@ func buildKnownIDIndex(
 	fingerprint string,
 	knownMap map[string][]uuid.UUID,
 	meSet map[string]struct{},
+	meIDs map[string]struct{},
 	resolver *memberIDResolver,
 	counters *sweepCounters,
 	pageBudget *int,
@@ -294,6 +300,9 @@ func buildKnownIDIndex(
 		if !ok {
 			continue
 		}
+		if _, isMe := meIDs[id]; isMe {
+			continue // the account's own id never enters the reverse index
+		}
 		if _, isMember := memberSet[id]; isMember {
 			knownIDs[id] = idMatch{Email: email, Contacts: contacts}
 			seeded[email] = struct{}{}
@@ -304,28 +313,35 @@ func buildKnownIDIndex(
 	// (was-NEGATIVE-now-UNKNOWN) candidates get priority access to the cap.
 	priority, normal := classifyIDCandidates(space.Name, fingerprint, knownMap, meSet, seeded, resolver)
 
-	for _, email := range append(priority, normal...) {
-		id, status, rerr := resolver.resolve(ctx, space.Name, fingerprint, email, pageBudget)
-		if rerr != nil {
-			return nil, false, false, rerr
-		}
-		switch status {
-		case resolvedKnownID:
-			if _, isMember := memberSet[id]; isMember {
-				knownIDs[id] = idMatch{Email: email, Contacts: knownMap[email]}
-				counters.memberIDsResolved++
+	// Resolve priority candidates first, then never-seen ones (two ranges instead
+	// of a merged slice to avoid a per-call allocation in the hot per-space path).
+	for _, group := range [2][]string{priority, normal} {
+		for _, email := range group {
+			id, status, rerr := resolver.resolve(ctx, space.Name, fingerprint, email, pageBudget)
+			if rerr != nil {
+				return nil, false, false, rerr
 			}
-			// A resolved id that is NOT a member of this space is a co-member of
-			// some OTHER space (the positive is global) — not a match here, but the
-			// global positive is now populated for future spaces.
-		case notMember:
-			counters.memberResolveNegativesWritten++
-		case deferredCapHit:
-			counters.memberResolveDeferredCap++
-			blockedByCapOnDebt = true
-		case deferredBudgetHit:
-			blockedByBudget = true
-			return knownIDs, blockedByBudget, blockedByCapOnDebt, nil
+			switch status {
+			case resolvedKnownID:
+				if _, isMe := meIDs[id]; isMe {
+					break // the account's own id never enters the reverse index
+				}
+				if _, isMember := memberSet[id]; isMember {
+					knownIDs[id] = idMatch{Email: email, Contacts: knownMap[email]}
+					counters.memberIDsResolved++
+				}
+				// A resolved id that is NOT a member of this space is a co-member of
+				// some OTHER space (the positive is global) — not a match here, but the
+				// global positive is now populated for future spaces.
+			case notMember:
+				counters.memberResolveNegativesWritten++
+			case deferredCapHit:
+				counters.memberResolveDeferredCap++
+				blockedByCapOnDebt = true
+			case deferredBudgetHit:
+				blockedByBudget = true
+				return knownIDs, blockedByBudget, blockedByCapOnDebt, nil
+			}
 		}
 	}
 	return knownIDs, blockedByBudget, blockedByCapOnDebt, nil

--- a/backend/internal/google/gchat_helpers.go
+++ b/backend/internal/google/gchat_helpers.go
@@ -384,6 +384,20 @@ func (p *GChatSyncProvider) SetMeSetForTest(meSet map[string]struct{}) {
 	}
 }
 
+// SetMemberResolveCapForTest overrides the per-sweep reverse-resolve cap so a
+// test can drive the resolve-cap deferral (resolution-debt) path
+// deterministically. Production code must NOT call this.
+func (p *GChatSyncProvider) SetMemberResolveCapForTest(cap int) {
+	p.memberResolveCapOverride = &cap
+}
+
+// MemberSetFingerprintForTest exposes the member-set fingerprint hash so a
+// cross-package integration test can pre-seed a fingerprint-stamped negative in
+// metadata. Production code must NOT call this.
+func MemberSetFingerprintForTest(members []string) string {
+	return memberSetFingerprint(members)
+}
+
 // FakeChatFetcherFuncs lets a cross-package test supply a fake chatFetcher by
 // closures, since the chatFetcher interface is unexported. Build the fetcher
 // with NewFakeChatFetcherFactoryForTest and inject via SetFetcherFactoryForTest.

--- a/backend/internal/google/gchat_helpers.go
+++ b/backend/internal/google/gchat_helpers.go
@@ -226,6 +226,11 @@ type FakeChatFetcherFuncs struct {
 	ListMembers        func(ctx context.Context, spaceName, pageToken string) ([]*chat.Membership, string, error)
 	ListMessages       func(ctx context.Context, spaceName, filter string, showDeleted bool, pageToken string) ([]*chat.Message, string, error)
 	ResolvePersonEmail func(ctx context.Context, userName string) (string, error)
+	// ResolveMemberID is optional: a fake that omits it defaults to "not a member
+	// of this space" (notMember=true, no error), so existing tests that exercise
+	// only the People-API email path compile and keep their current outcomes — the
+	// id path is purely additive.
+	ResolveMemberID func(ctx context.Context, spaceName, normalizedEmail string) (string, bool, error)
 }
 
 type fakeChatFetcher struct {
@@ -246,6 +251,15 @@ func (f *fakeChatFetcher) ListMessages(ctx context.Context, spaceName, filter st
 
 func (f *fakeChatFetcher) ResolvePersonEmail(ctx context.Context, userName string) (string, error) {
 	return f.funcs.ResolvePersonEmail(ctx, userName)
+}
+
+func (f *fakeChatFetcher) ResolveMemberID(ctx context.Context, spaceName, normalizedEmail string) (string, bool, error) {
+	if f.funcs.ResolveMemberID == nil {
+		// Default: the email is not a member of this space (the id path is purely
+		// additive, so a fake that doesn't opt in behaves as the email-only path).
+		return "", true, nil
+	}
+	return f.funcs.ResolveMemberID(ctx, spaceName, normalizedEmail)
 }
 
 // NewFakeChatFetcherFactoryForTest returns a fetcher factory (accountID-keyed,

--- a/backend/internal/google/gchat_helpers.go
+++ b/backend/internal/google/gchat_helpers.go
@@ -245,7 +245,7 @@ type idMatch struct {
 // fresh members.get resolutions for the rest.
 //
 // members is the space's current "users/{id}" member set; fingerprint is its
-// member-set fingerprint (§3.2.1). knownMap is the dual-source known-contact
+// member-set fingerprint. knownMap is the dual-source known-contact
 // map (normalizedEmail → []contactID); meSet is the connected-account self set.
 // resolver is the reverse resolver; pageBudget is the shared page allowance.
 //
@@ -255,7 +255,7 @@ type idMatch struct {
 //     — the caller must NOT advance the cursor; treat like a partial page).
 //   - blockedByCapOnDebt: an UNKNOWN candidate could not be resolved because the
 //     per-sweep resolve-cap was exhausted (resolution debt — the caller holds
-//     THIS space's cursor until a later sweep drains the debt, §3.2.1).
+//     THIS space's cursor until a later sweep drains the debt).
 //
 // Candidate classification under the current fingerprint: POSITIVE (global
 // positive hit whose id ∈ members), NEGATIVE-VALID (per-space negative with a

--- a/backend/internal/google/gchat_helpers.go
+++ b/backend/internal/google/gchat_helpers.go
@@ -263,11 +263,15 @@ type idMatch struct {
 // fingerprint-invalidated candidates (a negative whose fingerprint no longer
 // matches — a membership change happened) get PRIORITY access to the cap over
 // never-seen candidates, so a one-time debt drains efficiently.
-// meIDs is the set of the account's OWN canonical ids within this space
-// (observed by resolveKnownMembers). Any resolved id in meIDs is dropped from
-// the index so the inbound id-path can never fire for the account itself — even
-// if a stray non-meSet alias resolves to the account's own id. This makes the
-// "knownIDs never contains a me-id" invariant enforced, not merely assumed.
+// meIDs is the set of the account's OWN canonical ids within this space, seeded
+// by resolveKnownMembers (People-path) and extended here from the reverse
+// resolver's ALREADY-CACHED positives for the meSet emails (no fresh members.get,
+// no budget impact) — so a me-id already discovered in an earlier space is caught
+// even when People cannot resolve it (the not-in-Contacts me case). Any resolved
+// id in meIDs is dropped from the index so the inbound id-path can never fire for
+// the account itself, even if a stray non-meSet CRM alias resolves to the
+// account's own id. classifyMessage ALSO guards its inbound id-path with meIDs as
+// a defense-in-depth check at the point of use.
 func buildKnownIDIndex(
 	ctx context.Context,
 	space *chat.Space,
@@ -279,7 +283,7 @@ func buildKnownIDIndex(
 	resolver *memberIDResolver,
 	counters *sweepCounters,
 	pageBudget *int,
-) (knownIDs map[string]idMatch, blockedByBudget bool, blockedByCapOnDebt bool, err error) {
+) (knownIDs map[string]idMatch, meIDsOut map[string]struct{}, blockedByBudget bool, blockedByCapOnDebt bool, err error) {
 	knownIDs = map[string]idMatch{}
 
 	// The member-id set of this space, for the "id ∈ members" check.
@@ -287,6 +291,19 @@ func buildKnownIDIndex(
 	for _, id := range members {
 		memberSet[id] = struct{}{}
 	}
+
+	// Extend meIDs from the reverse resolver's already-cached positives for the
+	// meSet emails (cache-only — no fresh members.get, no budget consumption, no
+	// negative writes). This catches a me-id discovered in an earlier space.
+	for meEmail := range meSet {
+		if id, ok := resolver.cachedPositive(meEmail); ok {
+			if _, already := meIDs[id]; !already {
+				// Copy-on-write so we never mutate the caller's map.
+				meIDs = mergeMeID(meIDs, id)
+			}
+		}
+	}
+	meIDsOut = meIDs // the (possibly extended) me-id set, for the classify guard
 
 	// Seed from the GLOBAL positive cache: every known email whose cached id is a
 	// member of this space matches with zero API calls. Track which emails are
@@ -319,7 +336,7 @@ func buildKnownIDIndex(
 		for _, email := range group {
 			id, status, rerr := resolver.resolve(ctx, space.Name, fingerprint, email, pageBudget)
 			if rerr != nil {
-				return nil, false, false, rerr
+				return nil, nil, false, false, rerr
 			}
 			switch status {
 			case resolvedKnownID:
@@ -340,11 +357,22 @@ func buildKnownIDIndex(
 				blockedByCapOnDebt = true
 			case deferredBudgetHit:
 				blockedByBudget = true
-				return knownIDs, blockedByBudget, blockedByCapOnDebt, nil
+				return knownIDs, meIDsOut, blockedByBudget, blockedByCapOnDebt, nil
 			}
 		}
 	}
-	return knownIDs, blockedByBudget, blockedByCapOnDebt, nil
+	return knownIDs, meIDsOut, blockedByBudget, blockedByCapOnDebt, nil
+}
+
+// mergeMeID returns a new set that is src plus id (copy-on-write so the caller's
+// map is never mutated). src may be nil.
+func mergeMeID(src map[string]struct{}, id string) map[string]struct{} {
+	out := make(map[string]struct{}, len(src)+1)
+	for k := range src {
+		out[k] = struct{}{}
+	}
+	out[id] = struct{}{}
+	return out
 }
 
 // classifyIDCandidates partitions the not-yet-matched known emails into those

--- a/backend/internal/google/gchat_support.go
+++ b/backend/internal/google/gchat_support.go
@@ -2,8 +2,11 @@ package google
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"sort"
+	"strings"
 	"time"
 
 	"personal-crm/backend/internal/accelerated"
@@ -55,6 +58,28 @@ type cachedEmail struct {
 	ResolvedAt string `json:"resolved_at"`
 }
 
+// cachedUserID is one email→canonical-id resolution in the GLOBAL positive
+// cache (the reverse of cachedEmail). UserName is the canonical "users/{id}".
+// A canonical id is the same person in every space, so this cache is global
+// (not per-space) and reused everywhere once an email resolves anywhere.
+type cachedUserID struct {
+	UserName   string `json:"user_name"`
+	ResolvedAt string `json:"resolved_at"`
+}
+
+// memberNegative records that one known email is NOT a member of one space.
+// MemberSetFingerprint is the space's member-set fingerprint at the time the
+// negative was written: the negative is honored ONLY while within TTL AND its
+// fingerprint still matches the space's CURRENT member-set fingerprint. An
+// actual join/leave flips the fingerprint and invalidates the negative (so the
+// email is re-resolved before the cursor advances past new messages); mere
+// message activity does NOT change the fingerprint, so a hot space's negatives
+// are not churned (§3.2.1).
+type memberNegative struct {
+	ResolvedAt           string `json:"resolved_at"`
+	MemberSetFingerprint string `json:"member_set_fingerprint"`
+}
+
 // gchatMetadata is the typed view of the gchat-owned keys in
 // external_sync_state.metadata. It is read from state.Metadata at sweep start
 // and written back (read-modify-write — only the gchat keys) at sweep end.
@@ -64,17 +89,24 @@ type gchatMetadata struct {
 	SpaceMembers    map[string]spaceMembers
 	UserEmailCache  map[string]cachedEmail
 	MeIdentities    map[string]struct{}
+	// EmailUserIDs is the GLOBAL positive cache: normalizedEmail → canonical id.
+	EmailUserIDs map[string]cachedUserID
+	// SpaceMemberNegatives is the per-(space,email) negative cache:
+	// space.Name → normalizedEmail → memberNegative.
+	SpaceMemberNegatives map[string]map[string]memberNegative
 }
 
 // loadGChatMetadata decodes the gchat keys from the raw metadata map, tolerating
 // missing/malformed keys (a fresh state has none).
 func loadGChatMetadata(raw map[string]any) *gchatMetadata {
 	gcm := &gchatMetadata{
-		SpaceCursors:    map[string]spaceCursor{},
-		ArchivedCursors: map[string]archivedCursor{},
-		SpaceMembers:    map[string]spaceMembers{},
-		UserEmailCache:  map[string]cachedEmail{},
-		MeIdentities:    map[string]struct{}{},
+		SpaceCursors:         map[string]spaceCursor{},
+		ArchivedCursors:      map[string]archivedCursor{},
+		SpaceMembers:         map[string]spaceMembers{},
+		UserEmailCache:       map[string]cachedEmail{},
+		MeIdentities:         map[string]struct{}{},
+		EmailUserIDs:         map[string]cachedUserID{},
+		SpaceMemberNegatives: map[string]map[string]memberNegative{},
 	}
 	if raw == nil {
 		return gcm
@@ -83,6 +115,8 @@ func loadGChatMetadata(raw map[string]any) *gchatMetadata {
 	decodeMetaKey(raw, gchatMetaArchivedCursors, &gcm.ArchivedCursors)
 	decodeMetaKey(raw, gchatMetaSpaceMembers, &gcm.SpaceMembers)
 	decodeMetaKey(raw, gchatMetaUserEmailCache, &gcm.UserEmailCache)
+	decodeMetaKey(raw, gchatMetaEmailUserIDs, &gcm.EmailUserIDs)
+	decodeMetaKey(raw, gchatMetaSpaceMemberNegatives, &gcm.SpaceMemberNegatives)
 
 	var ids []string
 	decodeMetaKey(raw, gchatMetaMeIdentities, &ids)
@@ -91,7 +125,63 @@ func loadGChatMetadata(raw map[string]any) *gchatMetadata {
 			gcm.MeIdentities[id] = struct{}{}
 		}
 	}
+	gcm.pruneIDCaches(accelerated.GetCurrentTime())
 	return gcm
+}
+
+// pruneIDCaches drops expired global positives and expired negatives, plus any
+// negative whose space no longer has a cached membership entry. This keeps
+// space_member_negatives bounded by live (space × known-absent-email) pairs
+// within TTL across the estate. Negatives whose fingerprint no longer matches
+// the current member set are NOT pruned here (they are treated as UNKNOWN on
+// next read and overwritten when re-resolved — eager pruning is unnecessary for
+// correctness). A decode that produced nil maps (very old metadata) is tolerated.
+func (g *gchatMetadata) pruneIDCaches(now time.Time) {
+	if g.EmailUserIDs == nil {
+		g.EmailUserIDs = map[string]cachedUserID{}
+	}
+	if g.SpaceMemberNegatives == nil {
+		g.SpaceMemberNegatives = map[string]map[string]memberNegative{}
+	}
+	for email, entry := range g.EmailUserIDs {
+		if cachedUserIDExpired(entry, now) {
+			delete(g.EmailUserIDs, email)
+		}
+	}
+	for spaceName, byEmail := range g.SpaceMemberNegatives {
+		if _, hasMembership := g.SpaceMembers[spaceName]; !hasMembership {
+			delete(g.SpaceMemberNegatives, spaceName)
+			continue
+		}
+		for email, neg := range byEmail {
+			if memberNegativeExpired(neg, now) {
+				delete(byEmail, email)
+			}
+		}
+		if len(byEmail) == 0 {
+			delete(g.SpaceMemberNegatives, spaceName)
+		}
+	}
+}
+
+// cachedUserIDExpired reports whether a global positive is older than the TTL
+// (an unparseable resolved_at counts as expired).
+func cachedUserIDExpired(entry cachedUserID, now time.Time) bool {
+	resolvedAt, err := time.Parse(chatTimeLayout, entry.ResolvedAt)
+	if err != nil {
+		return true
+	}
+	return now.Sub(resolvedAt) > gchatMembershipCacheTTL
+}
+
+// memberNegativeExpired reports whether a per-space negative is older than the
+// TTL (an unparseable resolved_at counts as expired).
+func memberNegativeExpired(neg memberNegative, now time.Time) bool {
+	resolvedAt, err := time.Parse(chatTimeLayout, neg.ResolvedAt)
+	if err != nil {
+		return true
+	}
+	return now.Sub(resolvedAt) > gchatMembershipCacheTTL
 }
 
 // decodeMetaKey round-trips one metadata key through JSON into dst, ignoring
@@ -138,6 +228,8 @@ func (g *gchatMetadata) writeInto(raw map[string]any) map[string]any {
 	raw[gchatMetaArchivedCursors] = g.ArchivedCursors
 	raw[gchatMetaSpaceMembers] = g.SpaceMembers
 	raw[gchatMetaUserEmailCache] = g.UserEmailCache
+	raw[gchatMetaEmailUserIDs] = g.EmailUserIDs
+	raw[gchatMetaSpaceMemberNegatives] = g.SpaceMemberNegatives
 	ids := make([]string, 0, len(g.MeIdentities))
 	for id := range g.MeIdentities {
 		ids = append(ids, id)
@@ -231,26 +323,26 @@ func (p *GChatSyncProvider) resolveMembership(
 	space *chat.Space,
 	g *gchatMetadata,
 	budget *int,
-) (members []string, incomplete bool, err error) {
+) (members []string, fingerprint string, incomplete bool, err error) {
 	now := accelerated.GetCurrentTime()
 	cached, ok := g.SpaceMembers[space.Name]
 	if ok && !membershipNeedsRefresh(cached, space.LastActiveTime, now) {
-		return cached.Members, false, nil
+		return cached.Members, memberSetFingerprint(cached.Members), false, nil
 	}
 
 	fetched, _, incomplete, err := paginateMembers(ctx, fetcher, space.Name, budget)
 	if err != nil {
-		return nil, false, err
+		return nil, "", false, err
 	}
 	if incomplete {
-		return nil, true, nil
+		return nil, "", true, nil
 	}
 	g.SpaceMembers[space.Name] = spaceMembers{
 		Version:   space.LastActiveTime,
 		FetchedAt: now.Format(chatTimeLayout),
 		Members:   fetched,
 	}
-	return fetched, false, nil
+	return fetched, memberSetFingerprint(fetched), false, nil
 }
 
 // membershipNeedsRefresh reports whether a cached membership must be refetched:
@@ -307,6 +399,37 @@ func resolveKnownMembers(
 		}
 	}
 	return out, nil
+}
+
+// memberSetFingerprint returns a deterministic, order-independent hash of a
+// space's member-id set. It SORTs + DEDUPs the canonical "users/{id}" names and
+// returns the sha256 hex of the newline-joined result, so the same member set
+// always yields the same fingerprint regardless of ListMembers page ordering.
+// An empty set yields a fixed sentinel. The fingerprint is the §3.2.1 stability
+// signal: it changes ONLY when membership actually changes (a join/leave), never
+// on mere message activity (which advances lastActiveTime but not the set).
+func memberSetFingerprint(members []string) string {
+	if len(members) == 0 {
+		return "empty"
+	}
+	uniq := make([]string, 0, len(members))
+	seen := make(map[string]struct{}, len(members))
+	for _, m := range members {
+		if m == "" {
+			continue
+		}
+		if _, ok := seen[m]; ok {
+			continue
+		}
+		seen[m] = struct{}{}
+		uniq = append(uniq, m)
+	}
+	if len(uniq) == 0 {
+		return "empty"
+	}
+	sort.Strings(uniq)
+	sum := sha256.Sum256([]byte(strings.Join(uniq, "\n")))
+	return hex.EncodeToString(sum[:])
 }
 
 // --- cached email resolver -------------------------------------------

--- a/backend/internal/google/gchat_support.go
+++ b/backend/internal/google/gchat_support.go
@@ -74,7 +74,7 @@ type cachedUserID struct {
 // actual join/leave flips the fingerprint and invalidates the negative (so the
 // email is re-resolved before the cursor advances past new messages); mere
 // message activity does NOT change the fingerprint, so a hot space's negatives
-// are not churned (§3.2.1).
+// are not churned.
 type memberNegative struct {
 	ResolvedAt           string `json:"resolved_at"`
 	MemberSetFingerprint string `json:"member_set_fingerprint"`
@@ -405,7 +405,7 @@ func resolveKnownMembers(
 // space's member-id set. It SORTs + DEDUPs the canonical "users/{id}" names and
 // returns the sha256 hex of the newline-joined result, so the same member set
 // always yields the same fingerprint regardless of ListMembers page ordering.
-// An empty set yields a fixed sentinel. The fingerprint is the §3.2.1 stability
+// An empty set yields a fixed sentinel. The fingerprint is the
 // signal: it changes ONLY when membership actually changes (a join/leave), never
 // on mere message activity (which advances lastActiveTime but not the set).
 func memberSetFingerprint(members []string) string {
@@ -558,7 +558,7 @@ func newMemberIDResolver(
 }
 
 // resolve resolves one normalizedEmail to its canonical id within spaceName,
-// honoring/stamping caches per §3.2.1. fingerprint is the space's CURRENT
+// honoring/stamping caches. fingerprint is the space's CURRENT
 // member-set fingerprint (used both to honor a negative — only when its stamped
 // fingerprint matches — and to stamp a freshly-written negative). pageBudget is
 // the shared remaining-page allowance; a fresh members.get decrements BOTH the
@@ -601,7 +601,7 @@ func (r *memberIDResolver) resolve(
 		return "", notMember, nil
 	}
 
-	// UNKNOWN candidate — must resolve. Guard the caps in the §3.2.1 order:
+	// UNKNOWN candidate — must resolve. Guard the caps in this order:
 	// resolve-cap first (deferring an UNKNOWN candidate is resolution debt), then
 	// the shared page budget.
 	if r.cap != nil && *r.cap <= 0 {
@@ -611,15 +611,20 @@ func (r *memberIDResolver) resolve(
 		return "", deferredBudgetHit, nil
 	}
 
-	resolved, isNotMember, ferr := r.fetcher.ResolveMemberID(ctx, spaceName, normalizedEmail)
-	if ferr != nil {
-		return "", notMember, ferr
-	}
+	// Decrement BOTH budgets BEFORE the call: an issued members.get is a real API
+	// call whatever its outcome, so it must count against the per-sweep resolve cap
+	// AND the shared page budget even when it errors. Counting only on success
+	// would let a space with persistently-failing members.get (Sync logs+continues
+	// per space) re-issue calls every space and blow past both bounds.
 	if r.cap != nil {
 		*r.cap--
 	}
 	if pageBudget != nil {
 		*pageBudget--
+	}
+	resolved, isNotMember, ferr := r.fetcher.ResolveMemberID(ctx, spaceName, normalizedEmail)
+	if ferr != nil {
+		return "", notMember, ferr
 	}
 	now := accelerated.GetCurrentTime()
 	if isNotMember || resolved == "" {

--- a/backend/internal/google/gchat_support.go
+++ b/backend/internal/google/gchat_support.go
@@ -647,6 +647,22 @@ func (r *memberIDResolver) lookupNegative(spaceName, email string) (memberNegati
 	return neg, ok
 }
 
+// cachedPositive returns the cached canonical id for an email if there is a
+// within-TTL global positive (no API call). Used by buildKnownIDIndex to seed
+// the index from already-resolved emails.
+func (r *memberIDResolver) cachedPositive(email string) (string, bool) {
+	entry, ok := r.posCache[email]
+	if !ok || cachedUserIDExpired(entry, accelerated.GetCurrentTime()) {
+		return "", false
+	}
+	return entry.UserName, true
+}
+
+// negativeFor exposes the per-space negative (if any) for classification.
+func (r *memberIDResolver) negativeFor(spaceName, email string) (memberNegative, bool) {
+	return r.lookupNegative(spaceName, email)
+}
+
 // writeNegative records (or overwrites) a per-space negative stamped with the
 // current member-set fingerprint.
 func (r *memberIDResolver) writeNegative(spaceName, email, fingerprint string, now time.Time) {

--- a/backend/internal/google/gchat_support.go
+++ b/backend/internal/google/gchat_support.go
@@ -498,18 +498,197 @@ func cachedEmailExpired(entry cachedEmail) bool {
 	return accelerated.GetCurrentTime().Sub(resolvedAt) > gchatMembershipCacheTTL
 }
 
+// --- reverse resolver (email → canonical id) -------------------------
+
+// resolveStatus is the outcome of one reverse (email→id) resolution attempt.
+type resolveStatus int
+
+const (
+	// resolvedKnownID — the email resolved to a canonical "users/{id}" (the
+	// returned userName is non-empty).
+	resolvedKnownID resolveStatus = iota
+	// notMember — the email is confirmed NOT a member of the space (a cached
+	// negative was honored or freshly written).
+	notMember
+	// deferredCapHit — the per-sweep resolve-cap is exhausted; this UNKNOWN
+	// candidate was NOT resolved this sweep and remains resolution debt.
+	deferredCapHit
+	// deferredBudgetHit — the shared page budget is exhausted; the resolution
+	// could not be issued (treated like an incomplete window).
+	deferredBudgetHit
+)
+
+// memberIDResolver resolves normalizedEmail → canonical "users/{id}" within a
+// space (the reverse of cachedEmailResolver), backed by the GLOBAL positive
+// cache (email→id, reused across all spaces) and the per-(space,email) negative
+// cache (stamped with the member-set fingerprint). It holds an in-sweep memo,
+// a dirty flag, and a pointer to the shared remaining-resolve-cap counter.
+type memberIDResolver struct {
+	fetcher  chatFetcher
+	posCache map[string]cachedUserID              // global: email → cachedUserID
+	negCache map[string]map[string]memberNegative // per-space: space → email → negative
+	memo     map[string]string                    // in-sweep: email → userName ("" = negative)
+	cap      *int                                 // shared remaining resolve-cap (nil = unbounded, used by the scan)
+	dirty    bool
+}
+
+// newMemberIDResolver builds a reverse resolver over the persisted caches. A nil
+// posCache/negCache is seeded empty. capRemaining is the shared per-sweep
+// resolve-cap pointer; pass nil to leave fresh resolutions uncapped (the scan,
+// which resolves a single address per space and is bounded by the page budget).
+func newMemberIDResolver(
+	fetcher chatFetcher,
+	posCache map[string]cachedUserID,
+	negCache map[string]map[string]memberNegative,
+	capRemaining *int,
+) *memberIDResolver {
+	if posCache == nil {
+		posCache = map[string]cachedUserID{}
+	}
+	if negCache == nil {
+		negCache = map[string]map[string]memberNegative{}
+	}
+	return &memberIDResolver{
+		fetcher:  fetcher,
+		posCache: posCache,
+		negCache: negCache,
+		memo:     map[string]string{},
+		cap:      capRemaining,
+	}
+}
+
+// resolve resolves one normalizedEmail to its canonical id within spaceName,
+// honoring/stamping caches per §3.2.1. fingerprint is the space's CURRENT
+// member-set fingerprint (used both to honor a negative — only when its stamped
+// fingerprint matches — and to stamp a freshly-written negative). pageBudget is
+// the shared remaining-page allowance; a fresh members.get decrements BOTH the
+// resolve-cap and pageBudget (it is a real API call).
+//
+// Precedence: positive-cache hit → negative-cache hit (fingerprint-valid) →
+// resolve-cap exhausted → page-budget exhausted → fresh fetch.
+func (r *memberIDResolver) resolve(
+	ctx context.Context,
+	spaceName, fingerprint, normalizedEmail string,
+	pageBudget *int,
+) (userName string, status resolveStatus, err error) {
+	if normalizedEmail == "" {
+		return "", notMember, nil
+	}
+
+	// In-sweep memo: a value already resolved this sweep (positive id or ""
+	// negative) is reused without re-touching the caches or the fetcher.
+	if id, ok := r.memo[normalizedEmail]; ok {
+		if id != "" {
+			return id, resolvedKnownID, nil
+		}
+		// A memoized "" is a within-sweep negative ONLY if it is still negative for
+		// THIS space under THIS fingerprint; fall through to the negative-cache
+		// check so a per-space/per-fingerprint negative is evaluated correctly.
+	}
+
+	// Global positive cache: a canonical id is space-independent, so a within-TTL
+	// hit resolves for any space with zero API calls.
+	if entry, ok := r.posCache[normalizedEmail]; ok && !cachedUserIDExpired(entry, accelerated.GetCurrentTime()) {
+		r.memo[normalizedEmail] = entry.UserName
+		return entry.UserName, resolvedKnownID, nil
+	}
+
+	// Per-space negative cache: honored ONLY when within TTL AND its stamped
+	// fingerprint equals the space's current fingerprint (membership unchanged).
+	if neg, ok := r.lookupNegative(spaceName, normalizedEmail); ok &&
+		!memberNegativeExpired(neg, accelerated.GetCurrentTime()) &&
+		neg.MemberSetFingerprint == fingerprint {
+		return "", notMember, nil
+	}
+
+	// UNKNOWN candidate — must resolve. Guard the caps in the §3.2.1 order:
+	// resolve-cap first (deferring an UNKNOWN candidate is resolution debt), then
+	// the shared page budget.
+	if r.cap != nil && *r.cap <= 0 {
+		return "", deferredCapHit, nil
+	}
+	if pageBudget != nil && *pageBudget <= 0 {
+		return "", deferredBudgetHit, nil
+	}
+
+	resolved, isNotMember, ferr := r.fetcher.ResolveMemberID(ctx, spaceName, normalizedEmail)
+	if ferr != nil {
+		return "", notMember, ferr
+	}
+	if r.cap != nil {
+		*r.cap--
+	}
+	if pageBudget != nil {
+		*pageBudget--
+	}
+	now := accelerated.GetCurrentTime()
+	if isNotMember || resolved == "" {
+		r.writeNegative(spaceName, normalizedEmail, fingerprint, now)
+		r.memo[normalizedEmail] = ""
+		r.dirty = true
+		return "", notMember, nil
+	}
+	r.posCache[normalizedEmail] = cachedUserID{
+		UserName:   resolved,
+		ResolvedAt: now.Format(chatTimeLayout),
+	}
+	r.memo[normalizedEmail] = resolved
+	r.dirty = true
+	return resolved, resolvedKnownID, nil
+}
+
+// lookupNegative returns the per-space negative for an email, if present.
+func (r *memberIDResolver) lookupNegative(spaceName, email string) (memberNegative, bool) {
+	byEmail, ok := r.negCache[spaceName]
+	if !ok {
+		return memberNegative{}, false
+	}
+	neg, ok := byEmail[email]
+	return neg, ok
+}
+
+// writeNegative records (or overwrites) a per-space negative stamped with the
+// current member-set fingerprint.
+func (r *memberIDResolver) writeNegative(spaceName, email, fingerprint string, now time.Time) {
+	byEmail, ok := r.negCache[spaceName]
+	if !ok {
+		byEmail = map[string]memberNegative{}
+		r.negCache[spaceName] = byEmail
+	}
+	byEmail[email] = memberNegative{
+		ResolvedAt:           now.Format(chatTimeLayout),
+		MemberSetFingerprint: fingerprint,
+	}
+}
+
+// snapshotPositives / snapshotNegatives return the (possibly-grown) caches for
+// persistence (folded into metadata by persistMetadata).
+func (r *memberIDResolver) snapshotPositives() map[string]cachedUserID {
+	return r.posCache
+}
+
+func (r *memberIDResolver) snapshotNegatives() map[string]map[string]memberNegative {
+	return r.negCache
+}
+
 // --- metadata persistence --------------------------------------------
 
-// persistMetadata folds the resolver's grown email cache into the typed
-// metadata and writes the merged gchat keys back via UpdateSyncStateMetadata
-// (read-modify-write of state.Metadata — only the gchat keys change).
+// persistMetadata folds the resolvers' grown caches into the typed metadata and
+// writes the merged gchat keys back via UpdateSyncStateMetadata (read-modify-
+// write of state.Metadata — only the gchat keys change). idResolver may be nil
+// (e.g. a path that never built one) — its caches are then left as-loaded.
 func (p *GChatSyncProvider) persistMetadata(
 	ctx context.Context,
 	state *repository.SyncState,
 	g *gchatMetadata,
 	resolver *cachedEmailResolver,
+	idResolver *memberIDResolver,
 ) error {
 	g.UserEmailCache = resolver.snapshot()
+	if idResolver != nil {
+		g.EmailUserIDs = idResolver.snapshotPositives()
+		g.SpaceMemberNegatives = idResolver.snapshotNegatives()
+	}
 	merged := g.writeInto(state.Metadata)
 	_, err := p.syncRepo.UpdateSyncStateMetadata(ctx, state.ID, merged)
 	return err

--- a/backend/internal/google/gchat_support.go
+++ b/backend/internal/google/gchat_support.go
@@ -375,42 +375,57 @@ func membershipNeedsRefresh(cached spaceMembers, lastActiveTime string, now time
 // member, produce a partial outbound fan-out, and then advance the cursor past
 // rows that were never persisted. A resolved-to-no-email member ("" with no
 // error) is simply not a known co-member.
+// It ALSO returns the set of member ids that resolve to one of the connected
+// accounts' own emails (meIDs): these are the account's own canonical
+// "users/{id}" within this space, observed at zero extra API cost from the same
+// People-path resolutions. The caller uses meIDs to keep the account's own id
+// out of the reverse (id→contact) index, so a stray non-meSet alias that
+// resolves to the account's own id can never misclassify an outbound message as
+// inbound.
 func resolveKnownMembers(
 	ctx context.Context,
 	members []string,
 	resolver *cachedEmailResolver,
 	knownMap map[string][]uuid.UUID,
 	meSet map[string]struct{},
-) (map[string][]uuid.UUID, error) {
+) (known map[string][]uuid.UUID, meIDs map[string]struct{}, err error) {
 	out := make(map[string][]uuid.UUID)
+	meIDs = make(map[string]struct{})
 	for _, userName := range members {
-		email, err := resolver.resolve(ctx, userName)
-		if err != nil {
-			return nil, err
+		email, rErr := resolver.resolve(ctx, userName)
+		if rErr != nil {
+			return nil, nil, rErr
 		}
 		if email == "" {
 			continue // resolved to no email → not a known co-member
 		}
 		if inSet(meSet, email) {
-			continue // self
+			meIDs[userName] = struct{}{} // this member id is the account itself
+			continue                     // self
 		}
 		if contacts := knownMap[email]; len(contacts) > 0 {
 			out[email] = contacts
 		}
 	}
-	return out, nil
+	return out, meIDs, nil
 }
+
+// memberSetFingerprintEmpty is the empty-member-set sentinel. The "fp:" prefix
+// makes it obviously NOT a sha256 hex string (which is pure lowercase hex), so a
+// reader never mistakes the sentinel for a real hash and the two can never
+// collide.
+const memberSetFingerprintEmpty = "fp:empty"
 
 // memberSetFingerprint returns a deterministic, order-independent hash of a
 // space's member-id set. It SORTs + DEDUPs the canonical "users/{id}" names and
 // returns the sha256 hex of the newline-joined result, so the same member set
 // always yields the same fingerprint regardless of ListMembers page ordering.
-// An empty set yields a fixed sentinel. The fingerprint is the
-// signal: it changes ONLY when membership actually changes (a join/leave), never
-// on mere message activity (which advances lastActiveTime but not the set).
+// An empty set yields memberSetFingerprintEmpty. The fingerprint changes ONLY
+// when membership actually changes (a join/leave), never on mere message
+// activity (which advances lastActiveTime but not the set).
 func memberSetFingerprint(members []string) string {
 	if len(members) == 0 {
-		return "empty"
+		return memberSetFingerprintEmpty
 	}
 	uniq := make([]string, 0, len(members))
 	seen := make(map[string]struct{}, len(members))
@@ -425,7 +440,7 @@ func memberSetFingerprint(members []string) string {
 		uniq = append(uniq, m)
 	}
 	if len(uniq) == 0 {
-		return "empty"
+		return memberSetFingerprintEmpty
 	}
 	sort.Strings(uniq)
 	sum := sha256.Sum256([]byte(strings.Join(uniq, "\n")))

--- a/backend/internal/google/gchat_test.go
+++ b/backend/internal/google/gchat_test.go
@@ -330,12 +330,21 @@ func TestReapStaleCursors_ArchiveRestoreDrop(t *testing.T) {
 }
 
 func TestGChatMetadata_RoundTrip(t *testing.T) {
+	// Use a recent resolved_at so the new id caches survive the prune-on-load.
+	recent := accelerated.GetCurrentTime().Add(-time.Hour).Format(chatTimeLayout)
 	g := &gchatMetadata{
 		SpaceCursors:    map[string]spaceCursor{"spaces/A": {CreateCursor: "2026-06-04T10:00:00Z", EditCursor: "2026-06-04T09:00:00Z"}},
 		ArchivedCursors: map[string]archivedCursor{"spaces/B": {CreateCursor: "x", ArchivedAt: "2026-06-04T08:00:00Z"}},
 		SpaceMembers:    map[string]spaceMembers{"spaces/A": {Version: "v1", FetchedAt: "2026-06-04T10:00:00Z", Members: []string{"users/a"}}},
 		UserEmailCache:  map[string]cachedEmail{"users/a": {Email: "a@example.test", ResolvedAt: "2026-06-04T10:00:00Z"}},
 		MeIdentities:    map[string]struct{}{"me@example.test": {}},
+		EmailUserIDs:    map[string]cachedUserID{"a@example.test": {UserName: "users/a", ResolvedAt: recent}},
+		SpaceMemberNegatives: map[string]map[string]memberNegative{
+			// Negative under spaces/A, which has a cached membership entry, so it
+			// survives the prune-on-load (a negative for a space with no cached
+			// membership is dropped — covered by TestPruneIDCaches).
+			"spaces/A": {"absent@example.test": {ResolvedAt: recent, MemberSetFingerprint: "fp-1"}},
+		},
 	}
 	// Preserve a non-gchat key to prove read-modify-write doesn't clobber it.
 	raw := map[string]any{"backfill_since": "2026-01-01", "some_other_key": 42}
@@ -357,6 +366,68 @@ func TestGChatMetadata_RoundTrip(t *testing.T) {
 	assert.Equal(t, g.SpaceMembers, reloaded.SpaceMembers)
 	assert.Equal(t, g.UserEmailCache, reloaded.UserEmailCache)
 	assert.Equal(t, g.MeIdentities, reloaded.MeIdentities)
+	// The two new id caches survive writeInto → loadGChatMetadata.
+	assert.Equal(t, g.EmailUserIDs, reloaded.EmailUserIDs)
+	assert.Equal(t, g.SpaceMemberNegatives, reloaded.SpaceMemberNegatives)
+}
+
+func TestMemberSetFingerprint_OrderIndependentAndChangeSensitive(t *testing.T) {
+	base := []string{"users/a", "users/b", "users/c"}
+	shuffled := []string{"users/c", "users/a", "users/b"}
+	withDup := []string{"users/b", "users/a", "users/c", "users/a"}
+
+	fp := memberSetFingerprint(base)
+	assert.Equal(t, fp, memberSetFingerprint(shuffled), "fingerprint is order-independent")
+	assert.Equal(t, fp, memberSetFingerprint(withDup), "fingerprint dedups before hashing")
+
+	// Adding a member changes the fingerprint (a join is detected).
+	assert.NotEqual(t, fp, memberSetFingerprint(append([]string{"users/d"}, base...)),
+		"adding a member must change the fingerprint")
+	// Removing a member changes the fingerprint (a leave is detected).
+	assert.NotEqual(t, fp, memberSetFingerprint([]string{"users/a", "users/b"}),
+		"removing a member must change the fingerprint")
+
+	// The empty set is a stable sentinel (and not equal to any non-empty hash).
+	assert.Equal(t, "empty", memberSetFingerprint(nil))
+	assert.Equal(t, "empty", memberSetFingerprint([]string{}))
+	assert.Equal(t, "empty", memberSetFingerprint([]string{""}), "blank ids are skipped")
+}
+
+func TestPruneIDCaches_DropsExpiredAndOrphanNegatives(t *testing.T) {
+	now := accelerated.GetCurrentTime()
+	fresh := now.Add(-time.Hour).Format(chatTimeLayout)
+	expired := now.Add(-25 * time.Hour).Format(chatTimeLayout)
+
+	g := &gchatMetadata{
+		SpaceMembers: map[string]spaceMembers{
+			"spaces/live": {Members: []string{"users/a"}},
+		},
+		EmailUserIDs: map[string]cachedUserID{
+			"keep@example.test": {UserName: "users/a", ResolvedAt: fresh},
+			"drop@example.test": {UserName: "users/b", ResolvedAt: expired},
+		},
+		SpaceMemberNegatives: map[string]map[string]memberNegative{
+			"spaces/live": {
+				"absent@example.test":  {ResolvedAt: fresh, MemberSetFingerprint: "fp"},
+				"expired@example.test": {ResolvedAt: expired, MemberSetFingerprint: "fp"},
+			},
+			// Orphan: no cached membership for this space → whole entry dropped.
+			"spaces/gone": {"x@example.test": {ResolvedAt: fresh, MemberSetFingerprint: "fp"}},
+		},
+	}
+	g.pruneIDCaches(now)
+
+	// Expired global positive dropped; fresh one kept.
+	assert.Contains(t, g.EmailUserIDs, "keep@example.test")
+	assert.NotContains(t, g.EmailUserIDs, "drop@example.test")
+
+	// Live-space negatives: expired dropped, fresh kept.
+	live := g.SpaceMemberNegatives["spaces/live"]
+	assert.Contains(t, live, "absent@example.test")
+	assert.NotContains(t, live, "expired@example.test")
+
+	// Orphan space (no cached membership) dropped entirely.
+	assert.NotContains(t, g.SpaceMemberNegatives, "spaces/gone")
 }
 
 func TestGChatMetadata_CursorForSeedsBackfillFloor(t *testing.T) {

--- a/backend/internal/google/gchat_test.go
+++ b/backend/internal/google/gchat_test.go
@@ -68,7 +68,7 @@ func TestClassifyMessage_InboundSenderOnly(t *testing.T) {
 	meSet := map[string]struct{}{"me@example.test": {}}
 
 	m := humanMsg("spaces/S/messages/1", "users/alice", "2026-06-04T10:00:00Z", "hi all")
-	c, err := classifyMessage(ctx, m, knownMembers, knownMap, meSet, resolver)
+	c, err := classifyMessage(ctx, m, knownMembers, knownMap, nil, meSet, resolver)
 	require.NoError(t, err)
 	assert.Equal(t, "inbound", c.Direction)
 	// Sender-only: exactly Alice, NOT Bob/Carol.
@@ -95,7 +95,7 @@ func TestClassifyMessage_OutboundFanOut(t *testing.T) {
 	meSet := map[string]struct{}{"me@example.test": {}}
 
 	m := humanMsg("spaces/S/messages/2", "users/me", "2026-06-04T10:01:00Z", "hello")
-	c, err := classifyMessage(ctx, m, knownMembers, knownMap, meSet, resolver)
+	c, err := classifyMessage(ctx, m, knownMembers, knownMap, nil, meSet, resolver)
 	require.NoError(t, err)
 	assert.Equal(t, "outbound", c.Direction)
 	assert.ElementsMatch(t, []uuid.UUID{alice, bob}, c.Matched)
@@ -123,7 +123,7 @@ func TestClassifyMessage_OutboundExcludesSelfContact(t *testing.T) {
 	meSet := map[string]struct{}{"me@example.test": {}}
 
 	m := humanMsg("spaces/S/messages/3", "users/me", "2026-06-04T10:02:00Z", "hi")
-	c, err := classifyMessage(ctx, m, knownMembers, knownMap, meSet, resolver)
+	c, err := classifyMessage(ctx, m, knownMembers, knownMap, nil, meSet, resolver)
 	require.NoError(t, err)
 	assert.Equal(t, "outbound", c.Direction)
 	// The self-contact must NOT receive a self-attributed outreach row.
@@ -142,17 +142,147 @@ func TestClassifyMessage_BystanderAndUnresolved(t *testing.T) {
 
 	// Bystander: sender neither me nor known.
 	mBy := humanMsg("spaces/S/messages/4", "users/stranger", "2026-06-04T10:03:00Z", "hey")
-	c, err := classifyMessage(ctx, mBy, nil, knownMap, meSet, resolver)
+	c, err := classifyMessage(ctx, mBy, nil, knownMap, nil, meSet, resolver)
 	require.NoError(t, err)
 	assert.Empty(t, c.Matched)
 	assert.False(t, c.Unresolved)
 
 	// Unresolved sender: resolves to "" → flagged Unresolved, no rows.
 	mUn := humanMsg("spaces/S/messages/5", "users/ghost", "2026-06-04T10:04:00Z", "hey")
-	c, err = classifyMessage(ctx, mUn, nil, knownMap, meSet, resolver)
+	c, err = classifyMessage(ctx, mUn, nil, knownMap, nil, meSet, resolver)
 	require.NoError(t, err)
 	assert.Empty(t, c.Matched)
 	assert.True(t, c.Unresolved)
+}
+
+// TestClassifyMessage_MatchesBySenderID is the headline DB-free behavior: a
+// sender id in knownIDs matches the contact even when the People API resolves
+// the id to "" (the not-in-Google-Contacts case). The peer email is carried
+// from the idMatch (not the empty People-API result).
+func TestClassifyMessage_MatchesBySenderID(t *testing.T) {
+	ctx := context.Background()
+	dave := uuid.New()
+	// The People API returns "" for users/dave (simulating not-in-Contacts).
+	resolver := staticResolver(t, map[string]string{"users/dave": ""}, nil)
+	knownMap := map[string][]uuid.UUID{"dave@example.test": {dave}}
+	meSet := map[string]struct{}{"me@example.test": {}}
+	knownIDs := map[string]idMatch{
+		"users/dave": {Email: "dave@example.test", Contacts: []uuid.UUID{dave}},
+	}
+
+	m := humanMsg("spaces/S/messages/d", "users/dave", "2026-06-04T10:00:00Z", "hi from dave")
+	c, err := classifyMessage(ctx, m, nil, knownMap, knownIDs, meSet, resolver)
+	require.NoError(t, err)
+	assert.Equal(t, "inbound", c.Direction)
+	assert.Equal(t, []uuid.UUID{dave}, c.Matched, "the sender id matched the contact via the id path")
+	assert.Equal(t, "dave@example.test", c.SenderEmail, "the peer email is carried from the idMatch, not the empty People-API result")
+}
+
+// TestClassifyMessage_OutboundFanOutIncludesIDResolvedMembers proves an outbound
+// message fans out to the UNION of email-resolved and id-resolved known members,
+// deduped and self-excluded.
+func TestClassifyMessage_OutboundFanOutIncludesIDResolvedMembers(t *testing.T) {
+	ctx := context.Background()
+	alice := uuid.New()
+	dave := uuid.New()
+	resolver := staticResolver(t, map[string]string{"users/me": "me@example.test"}, nil)
+	knownMap := map[string][]uuid.UUID{
+		"alice@example.test": {alice},
+		"dave@example.test":  {dave},
+	}
+	// Alice is email-resolved; Dave is id-resolved (not in Contacts).
+	knownMembers := map[string][]uuid.UUID{"alice@example.test": {alice}}
+	knownIDs := map[string]idMatch{
+		"users/dave": {Email: "dave@example.test", Contacts: []uuid.UUID{dave}},
+	}
+	meSet := map[string]struct{}{"me@example.test": {}}
+
+	m := humanMsg("spaces/S/messages/o", "users/me", "2026-06-04T10:01:00Z", "team update")
+	c, err := classifyMessage(ctx, m, knownMembers, knownMap, knownIDs, meSet, resolver)
+	require.NoError(t, err)
+	assert.Equal(t, "outbound", c.Direction)
+	assert.ElementsMatch(t, []uuid.UUID{alice, dave}, c.Matched, "fan-out unions email-resolved and id-resolved members")
+}
+
+// TestClassifyMessage_OutboundFanOutDedupsContact proves the union dedups a
+// contact that is present on BOTH the email-resolved and id-resolved sides (a
+// contact reachable both via Contacts and via canonical id). The index builder
+// guarantees meSet ids are never in knownIDs, so the inbound id-path's
+// meSet-independence is safe; self-exclusion of a meSet *email* member is
+// covered directly in TestFlattenKnownMembersAndIDs_UnionDedupSelfExclude.
+func TestClassifyMessage_OutboundFanOutDedupsContact(t *testing.T) {
+	ctx := context.Background()
+	alice := uuid.New()
+	resolver := staticResolver(t, map[string]string{"users/me": "me@example.test"}, nil)
+	knownMap := map[string][]uuid.UUID{"alice@example.test": {alice}}
+	knownMembers := map[string][]uuid.UUID{"alice@example.test": {alice}}
+	// Same contact also id-resolved (must dedup to a single row).
+	knownIDs := map[string]idMatch{
+		"users/alice": {Email: "alice@example.test", Contacts: []uuid.UUID{alice}},
+	}
+	meSet := map[string]struct{}{"me@example.test": {}}
+
+	m := humanMsg("spaces/S/messages/o2", "users/me", "2026-06-04T10:02:00Z", "hi")
+	c, err := classifyMessage(ctx, m, knownMembers, knownMap, knownIDs, meSet, resolver)
+	require.NoError(t, err)
+	assert.Equal(t, "outbound", c.Direction)
+	assert.Equal(t, []uuid.UUID{alice}, c.Matched, "the shared contact appears once, not twice")
+}
+
+// TestFlattenKnownMembersAndIDs_UnionDedupSelfExclude pins the fan-out helper:
+// the union dedups across the email-resolved and id-resolved sides and drops any
+// id-resolved member whose email is in meSet (defensive self-exclusion).
+func TestFlattenKnownMembersAndIDs_UnionDedupSelfExclude(t *testing.T) {
+	alice := uuid.New()
+	dave := uuid.New()
+	meContact := uuid.New()
+	knownMembers := map[string][]uuid.UUID{"alice@example.test": {alice}}
+	knownIDs := map[string]idMatch{
+		"users/alice": {Email: "alice@example.test", Contacts: []uuid.UUID{alice}},  // dup of email side
+		"users/dave":  {Email: "dave@example.test", Contacts: []uuid.UUID{dave}},    // id-only
+		"users/me":    {Email: "me@example.test", Contacts: []uuid.UUID{meContact}}, // meSet → excluded
+	}
+	meSet := map[string]struct{}{"me@example.test": {}}
+
+	out := flattenKnownMembersAndIDs(knownMembers, knownIDs, meSet)
+	assert.ElementsMatch(t, []uuid.UUID{alice, dave}, out, "union dedups the shared contact and self-excludes the meSet id member")
+}
+
+// TestClassifyMessage_IDPathPreferredEmailFallback proves an id in knownIDs
+// matches WITHOUT calling the email resolver, while an id absent from knownIDs
+// falls through to the (still-working) email path.
+func TestClassifyMessage_IDPathPreferredEmailFallback(t *testing.T) {
+	ctx := context.Background()
+	dave := uuid.New()
+	erin := uuid.New()
+	calls := 0
+	resolver := staticResolver(t, map[string]string{
+		"users/erin": "erin@example.test", // email-resolvable
+		"users/dave": "",                  // not-in-Contacts
+	}, &calls)
+	knownMap := map[string][]uuid.UUID{
+		"dave@example.test": {dave},
+		"erin@example.test": {erin},
+	}
+	knownIDs := map[string]idMatch{
+		"users/dave": {Email: "dave@example.test", Contacts: []uuid.UUID{dave}},
+	}
+	meSet := map[string]struct{}{"me@example.test": {}}
+
+	// Dave: id path → no email resolver call.
+	mDave := humanMsg("spaces/S/messages/d", "users/dave", "2026-06-04T10:00:00Z", "x")
+	c, err := classifyMessage(ctx, mDave, nil, knownMap, knownIDs, meSet, resolver)
+	require.NoError(t, err)
+	assert.Equal(t, []uuid.UUID{dave}, c.Matched)
+	assert.Equal(t, 0, calls, "an id-path match must not call the email resolver")
+
+	// Erin: absent from knownIDs → email path still matches.
+	mErin := humanMsg("spaces/S/messages/e", "users/erin", "2026-06-04T10:01:00Z", "y")
+	c, err = classifyMessage(ctx, mErin, nil, knownMap, knownIDs, meSet, resolver)
+	require.NoError(t, err)
+	assert.Equal(t, "inbound", c.Direction)
+	assert.Equal(t, []uuid.UUID{erin}, c.Matched)
+	assert.Equal(t, 1, calls, "the absent id falls through to the email path")
 }
 
 func TestQualifiableContentMessage_FiltersBotsTombstonesNameless(t *testing.T) {
@@ -437,6 +567,185 @@ func TestMemberIDResolver_PropagatesFetcherError(t *testing.T) {
 	require.ErrorIs(t, err, wantErr, "a transient members.get error must propagate, not become a negative")
 }
 
+// TestBuildKnownIDIndex_SeedsFromPositiveCacheZeroCalls proves the index is
+// seeded from the global positive cache with ZERO members.get calls when the
+// cached id is already a member of the space, and that a fresh resolve happens
+// only for an uncached non-negative email.
+func TestBuildKnownIDIndex_SeedsFromPositiveCacheZeroCalls(t *testing.T) {
+	ctx := context.Background()
+	dave := uuid.New()
+	frank := uuid.New()
+	members := []string{"users/dave", "users/frank", "users/me"}
+	fp := memberSetFingerprint(members)
+	now := accelerated.GetCurrentTime()
+
+	calls := 0
+	// frank is resolvable fresh; dave is pre-seeded in the positive cache.
+	fetcher := fakeIDFetcher(map[string]string{"spaces/A|frank@example.test": "users/frank"}, &calls)
+	pos := map[string]cachedUserID{"dave@example.test": {UserName: "users/dave", ResolvedAt: now.Format(chatTimeLayout)}}
+	cap := 10
+	resolver := newMemberIDResolver(fetcher, pos, nil, &cap)
+
+	knownMap := map[string][]uuid.UUID{
+		"dave@example.test":  {dave},
+		"frank@example.test": {frank},
+	}
+	meSet := map[string]struct{}{"me@example.test": {}}
+	counters := &sweepCounters{}
+	budget := 10
+	idx, blockedBudget, blockedCap, err := buildKnownIDIndex(ctx, &chat.Space{Name: "spaces/A"}, members, fp, knownMap, meSet, resolver, counters, &budget)
+	require.NoError(t, err)
+	assert.False(t, blockedBudget)
+	assert.False(t, blockedCap)
+
+	// dave seeded from the positive cache (zero calls); frank resolved fresh (one).
+	assert.Equal(t, idMatch{Email: "dave@example.test", Contacts: []uuid.UUID{dave}}, idx["users/dave"])
+	assert.Equal(t, idMatch{Email: "frank@example.test", Contacts: []uuid.UUID{frank}}, idx["users/frank"])
+	assert.Equal(t, 1, calls, "only the uncached email triggered a members.get")
+}
+
+// TestBuildKnownIDIndex_DebtHoldsCursor drives the §3.2.1 debt model:
+//
+//	(a) a NEGATIVE-VALID candidate is not debt → no resolve, blockedByCapOnDebt=false;
+//	(b) an UNKNOWN candidate (fingerprint-mismatched negative) with the cap
+//	    exhausted → deferredCapHit → blockedByCapOnDebt=true (cursor held), driven
+//	    purely by the persisted-negative-vs-current-fingerprint mismatch (no flag);
+//	(c) priority — when the cap admits only N resolves, fingerprint-invalidated
+//	    candidates are resolved before never-seen ones.
+func TestBuildKnownIDIndex_DebtHoldsCursor(t *testing.T) {
+	ctx := context.Background()
+	now := accelerated.GetCurrentTime()
+	fresh := now.Format(chatTimeLayout)
+
+	t.Run("negative_valid_is_not_debt", func(t *testing.T) {
+		absent := uuid.New()
+		members := []string{"users/me"}
+		fp := memberSetFingerprint(members)
+		calls := 0
+		fetcher := fakeIDFetcher(map[string]string{}, &calls)
+		neg := map[string]map[string]memberNegative{
+			"spaces/A": {"absent@example.test": {ResolvedAt: fresh, MemberSetFingerprint: fp}},
+		}
+		cap := 0 // cap exhausted, but a NEGATIVE-VALID candidate is not debt
+		resolver := newMemberIDResolver(fetcher, nil, neg, &cap)
+		knownMap := map[string][]uuid.UUID{"absent@example.test": {absent}}
+		counters := &sweepCounters{}
+		budget := 10
+		idx, _, blockedCap, err := buildKnownIDIndex(ctx, &chat.Space{Name: "spaces/A"}, members, fp, knownMap, map[string]struct{}{"me@example.test": {}}, resolver, counters, &budget)
+		require.NoError(t, err)
+		assert.Empty(t, idx)
+		assert.False(t, blockedCap, "a NEGATIVE-VALID candidate under the current fingerprint is not debt")
+		assert.Equal(t, 0, calls, "a valid negative is honored without a fetch")
+	})
+
+	t.Run("fingerprint_mismatch_is_debt_when_cap_exhausted", func(t *testing.T) {
+		joiner := uuid.New()
+		members := []string{"users/me", "users/joiner"} // joiner just joined → fingerprint flipped
+		fpNew := memberSetFingerprint(members)
+		calls := 0
+		fetcher := fakeIDFetcher(map[string]string{"spaces/A|joiner@example.test": "users/joiner"}, &calls)
+		// Persisted negative carries the OLD fingerprint (before the join).
+		neg := map[string]map[string]memberNegative{
+			"spaces/A": {"joiner@example.test": {ResolvedAt: fresh, MemberSetFingerprint: "old-fp"}},
+		}
+		cap := 0 // cap exhausted: the now-UNKNOWN candidate cannot resolve → debt
+		resolver := newMemberIDResolver(fetcher, nil, neg, &cap)
+		knownMap := map[string][]uuid.UUID{"joiner@example.test": {joiner}}
+		counters := &sweepCounters{}
+		budget := 10
+		idx, blockedBudget, blockedCap, err := buildKnownIDIndex(ctx, &chat.Space{Name: "spaces/A"}, members, fpNew, knownMap, map[string]struct{}{"me@example.test": {}}, resolver, counters, &budget)
+		require.NoError(t, err)
+		assert.Empty(t, idx, "the candidate could not resolve this sweep")
+		assert.False(t, blockedBudget)
+		assert.True(t, blockedCap, "the fingerprint mismatch alone makes the candidate UNKNOWN; cap exhaustion holds the cursor (no transient flag)")
+		assert.Equal(t, 0, calls, "the cap-exhausted candidate is not fetched")
+	})
+
+	t.Run("priority_invalidated_before_neverseen", func(t *testing.T) {
+		invalidated := uuid.New()
+		neverSeen := uuid.New()
+		members := []string{"users/me", "users/invalidated"}
+		fpNew := memberSetFingerprint(members)
+		calls := 0
+		fetcher := fakeIDFetcher(map[string]string{
+			"spaces/A|invalidated@example.test": "users/invalidated",
+			// neverseen would resolve too, but the cap admits only ONE.
+			"spaces/A|neverseen@example.test": "users/neverseen",
+		}, &calls)
+		neg := map[string]map[string]memberNegative{
+			"spaces/A": {"invalidated@example.test": {ResolvedAt: fresh, MemberSetFingerprint: "old-fp"}},
+		}
+		cap := 1 // only ONE fresh resolve allowed → the priority candidate wins
+		resolver := newMemberIDResolver(fetcher, nil, neg, &cap)
+		knownMap := map[string][]uuid.UUID{
+			"invalidated@example.test": {invalidated},
+			"neverseen@example.test":   {neverSeen},
+		}
+		counters := &sweepCounters{}
+		budget := 10
+		idx, _, blockedCap, err := buildKnownIDIndex(ctx, &chat.Space{Name: "spaces/A"}, members, fpNew, knownMap, map[string]struct{}{"me@example.test": {}}, resolver, counters, &budget)
+		require.NoError(t, err)
+		// The invalidated (priority) candidate consumed the single cap slot and
+		// matched; the never-seen one was deferred (debt) → cursor held.
+		assert.Contains(t, idx, "users/invalidated", "the fingerprint-invalidated candidate is resolved first")
+		assert.NotContains(t, idx, "users/neverseen")
+		assert.True(t, blockedCap, "the deferred never-seen candidate is debt")
+		assert.Equal(t, 1, calls, "exactly the single capped resolve was issued")
+	})
+}
+
+// TestBuildKnownIDIndex_ActivityDoesNotReincurDebt proves the round-4 starvation
+// fix: with an UNCHANGED member set (same fingerprint), repeated index builds
+// issue ZERO members.get calls for a known-absent contact and never set
+// blockedByCapOnDebt — mere activity does not re-incur debt. Contrast: when a
+// member is actually added (fingerprint flips), the affected candidate becomes
+// UNKNOWN and is re-resolved.
+func TestBuildKnownIDIndex_ActivityDoesNotReincurDebt(t *testing.T) {
+	ctx := context.Background()
+	now := accelerated.GetCurrentTime()
+	fresh := now.Format(chatTimeLayout)
+	absent := uuid.New()
+
+	members := []string{"users/me", "users/other"}
+	fp := memberSetFingerprint(members)
+	calls := 0
+	fetcher := fakeIDFetcher(map[string]string{}, &calls) // absent never resolves
+	neg := map[string]map[string]memberNegative{
+		"spaces/A": {"absent@example.test": {ResolvedAt: fresh, MemberSetFingerprint: fp}},
+	}
+	cap := 50
+	resolver := newMemberIDResolver(fetcher, nil, neg, &cap)
+	knownMap := map[string][]uuid.UUID{"absent@example.test": {absent}}
+	meSet := map[string]struct{}{"me@example.test": {}}
+
+	// Many sweeps with the SAME member set (fingerprint stable). Each uses a fresh
+	// resolver instance (drops the in-sweep memo) reading the persisted negatives.
+	for i := 0; i < 5; i++ {
+		r := newMemberIDResolver(fetcher, resolver.snapshotPositives(), resolver.snapshotNegatives(), &cap)
+		counters := &sweepCounters{}
+		budget := 10
+		idx, blockedBudget, blockedCap, err := buildKnownIDIndex(ctx, &chat.Space{Name: "spaces/A"}, members, fp, knownMap, meSet, r, counters, &budget)
+		require.NoError(t, err)
+		assert.Empty(t, idx)
+		assert.False(t, blockedBudget)
+		assert.False(t, blockedCap, "a stable fingerprint never re-incurs debt (sweep %d)", i)
+	}
+	assert.Equal(t, 0, calls, "no members.get calls across many stable-membership sweeps")
+
+	// Now a member is actually added → fingerprint flips → the absent candidate
+	// becomes UNKNOWN and IS re-resolved (here it resolves to a real id).
+	membersAfter := []string{"users/me", "users/other", "users/absent"}
+	fpAfter := memberSetFingerprint(membersAfter)
+	fetcher2 := fakeIDFetcher(map[string]string{"spaces/A|absent@example.test": "users/absent"}, &calls)
+	r := newMemberIDResolver(fetcher2, resolver.snapshotPositives(), resolver.snapshotNegatives(), &cap)
+	counters := &sweepCounters{}
+	budget := 10
+	idx, _, _, err := buildKnownIDIndex(ctx, &chat.Space{Name: "spaces/A"}, membersAfter, fpAfter, knownMap, meSet, r, counters, &budget)
+	require.NoError(t, err)
+	assert.Contains(t, idx, "users/absent", "a real membership change re-resolves the candidate")
+	assert.Equal(t, 1, calls, "exactly one re-resolve after the membership actually changed")
+}
+
 func TestMembershipNeedsRefresh(t *testing.T) {
 	now := accelerated.GetCurrentTime()
 	fresh := now.Add(-time.Hour).Format(chatTimeLayout)
@@ -673,7 +982,7 @@ func TestConsumeContentWindow_BudgetExhaustionKeepsCursor(t *testing.T) {
 
 	newCursor, proven, err := p.consumeContentWindow(ctx, fetcher,
 		&chat.Space{Name: "spaces/B", SpaceType: "SPACE"}, floor,
-		map[string][]uuid.UUID{}, map[string][]uuid.UUID{}, map[string]struct{}{},
+		map[string][]uuid.UUID{}, map[string][]uuid.UUID{}, nil, map[string]struct{}{},
 		resolver, "acct", counters, &budget)
 	require.NoError(t, err)
 	assert.False(t, proven, "an un-finished window is NOT proven")
@@ -712,7 +1021,7 @@ func TestConsumeContentWindow_FullyPagedIsProven(t *testing.T) {
 	floor := "2026-01-01T00:00:00Z"
 	newCursor, proven, err := p.consumeContentWindow(ctx, fetcher,
 		&chat.Space{Name: "spaces/B", SpaceType: "SPACE"}, floor,
-		map[string][]uuid.UUID{}, map[string][]uuid.UUID{"someone-else@example.test": {alice}}, map[string]struct{}{},
+		map[string][]uuid.UUID{}, map[string][]uuid.UUID{"someone-else@example.test": {alice}}, nil, map[string]struct{}{},
 		resolver, "acct", counters, &budget)
 	require.NoError(t, err)
 	assert.True(t, proven, "a fully-paged window is proven")
@@ -752,7 +1061,7 @@ func TestConsumeContentWindow_CursorAdvancesByInstantNotLexical(t *testing.T) {
 	floor := "2026-01-01T00:00:00Z"
 	newCursor, proven, err := p.consumeContentWindow(ctx, fetcher,
 		&chat.Space{Name: "spaces/B", SpaceType: "SPACE"}, floor,
-		map[string][]uuid.UUID{}, map[string][]uuid.UUID{}, map[string]struct{}{},
+		map[string][]uuid.UUID{}, map[string][]uuid.UUID{}, nil, map[string]struct{}{},
 		resolver, "acct", counters, &budget)
 	require.NoError(t, err)
 	assert.True(t, proven)
@@ -906,7 +1215,7 @@ func TestConsumeContentWindow_DeepHistoryCompletesUnderRaisedBudget(t *testing.T
 		counters := &sweepCounters{}
 		newCursor, proven, err := p.consumeContentWindow(ctx, fetcher,
 			&chat.Space{Name: "spaces/B", SpaceType: "SPACE"}, floor,
-			map[string][]uuid.UUID{}, map[string][]uuid.UUID{}, map[string]struct{}{},
+			map[string][]uuid.UUID{}, map[string][]uuid.UUID{}, nil, map[string]struct{}{},
 			resolver, "acct", counters, &budget)
 		require.NoError(t, err)
 		assert.True(t, proven, "a 30-page window fully pages under the 100-page budget")
@@ -927,7 +1236,7 @@ func TestConsumeContentWindow_DeepHistoryCompletesUnderRaisedBudget(t *testing.T
 		counters := &sweepCounters{}
 		newCursor, proven, err := p.consumeContentWindow(ctx, fetcher,
 			&chat.Space{Name: "spaces/B", SpaceType: "SPACE"}, floor,
-			map[string][]uuid.UUID{}, map[string][]uuid.UUID{}, map[string]struct{}{},
+			map[string][]uuid.UUID{}, map[string][]uuid.UUID{}, nil, map[string]struct{}{},
 			resolver, "acct", counters, &budget)
 		require.NoError(t, err)
 		assert.False(t, proven, "a 30-page window cannot complete under a 24-page budget")

--- a/backend/internal/google/gchat_test.go
+++ b/backend/internal/google/gchat_test.go
@@ -563,8 +563,14 @@ func TestMemberIDResolver_PropagatesFetcherError(t *testing.T) {
 	r := newMemberIDResolver(fetcher, nil, nil, &cap)
 	fp := memberSetFingerprint([]string{"users/1"})
 
-	_, _, err := r.resolve(ctx, "spaces/A", fp, "a@example.test", nil)
+	pageBudget := 5
+	_, _, err := r.resolve(ctx, "spaces/A", fp, "a@example.test", &pageBudget)
 	require.ErrorIs(t, err, wantErr, "a transient members.get error must propagate, not become a negative")
+	// An ISSUED members.get is a real API call regardless of outcome: it consumes
+	// both budgets even on error, so a persistently-failing space cannot blow past
+	// the bounds across many spaces in one sweep.
+	assert.Equal(t, 9, cap, "an errored members.get still consumes the resolve cap")
+	assert.Equal(t, 4, pageBudget, "an errored members.get still consumes the page budget")
 }
 
 // TestBuildKnownIDIndex_SeedsFromPositiveCacheZeroCalls proves the index is

--- a/backend/internal/google/gchat_test.go
+++ b/backend/internal/google/gchat_test.go
@@ -265,6 +265,178 @@ func TestCachedEmailResolver_PositiveNegativeCachingAndTTL(t *testing.T) {
 	assert.Equal(t, 1, calls2, "expired cache entry refetched")
 }
 
+// fakeIDFetcher builds a fakeChatFetcher whose ResolveMemberID returns a fixed
+// (space,email)→id mapping and counts calls. A missing mapping entry returns
+// notMember. A space named in errSpaces returns a transient error.
+func fakeIDFetcher(mapping map[string]string, callCount *int) *fakeChatFetcher {
+	return &fakeChatFetcher{funcs: FakeChatFetcherFuncs{
+		ResolveMemberID: func(_ context.Context, spaceName, email string) (string, bool, error) {
+			if callCount != nil {
+				*callCount++
+			}
+			if id, ok := mapping[spaceName+"|"+email]; ok {
+				return id, false, nil
+			}
+			return "", true, nil
+		},
+	}}
+}
+
+func TestMemberIDResolver_GlobalPositiveReusedAcrossSpaces(t *testing.T) {
+	ctx := context.Background()
+	calls := 0
+	fetcher := fakeIDFetcher(map[string]string{
+		"spaces/A|person@example.test": "users/777",
+		"spaces/B|person@example.test": "users/777",
+	}, &calls)
+	cap := 10
+	r := newMemberIDResolver(fetcher, nil, nil, &cap)
+	fpA := memberSetFingerprint([]string{"users/777"})
+	fpB := memberSetFingerprint([]string{"users/777", "users/me"})
+
+	// First resolve in space A hits the fetcher.
+	id, status, err := r.resolve(ctx, "spaces/A", fpA, "person@example.test", nil)
+	require.NoError(t, err)
+	assert.Equal(t, resolvedKnownID, status)
+	assert.Equal(t, "users/777", id)
+	assert.Equal(t, 1, calls)
+
+	// Second resolve in space B reuses the GLOBAL positive — ZERO additional calls.
+	id, status, err = r.resolve(ctx, "spaces/B", fpB, "person@example.test", nil)
+	require.NoError(t, err)
+	assert.Equal(t, resolvedKnownID, status)
+	assert.Equal(t, "users/777", id)
+	assert.Equal(t, 1, calls, "the canonical id is space-independent; space B reuses the global positive")
+	assert.Equal(t, 9, cap, "only one fresh resolve consumed the cap")
+}
+
+func TestMemberIDResolver_NegativeIsPerSpace(t *testing.T) {
+	ctx := context.Background()
+	calls := 0
+	// person is a member of B only; absent from A.
+	fetcher := fakeIDFetcher(map[string]string{
+		"spaces/B|person@example.test": "users/888",
+	}, &calls)
+	cap := 10
+	r := newMemberIDResolver(fetcher, nil, nil, &cap)
+	fpA := memberSetFingerprint([]string{"users/me"})
+	fpB := memberSetFingerprint([]string{"users/888", "users/me"})
+
+	// A: not a member → negative for A.
+	_, status, err := r.resolve(ctx, "spaces/A", fpA, "person@example.test", nil)
+	require.NoError(t, err)
+	assert.Equal(t, notMember, status)
+	assert.Equal(t, 1, calls)
+
+	// The negative for A is re-served (within fingerprint) without a fetch.
+	_, status, err = r.resolve(ctx, "spaces/A", fpA, "person@example.test", nil)
+	require.NoError(t, err)
+	assert.Equal(t, notMember, status)
+	assert.Equal(t, 1, calls, "per-space negative re-served from cache")
+
+	// B: same email is STILL attempted (per-space negative does not block B) and
+	// resolves.
+	id, status, err := r.resolve(ctx, "spaces/B", fpB, "person@example.test", nil)
+	require.NoError(t, err)
+	assert.Equal(t, resolvedKnownID, status)
+	assert.Equal(t, "users/888", id)
+	assert.Equal(t, 2, calls, "a negative in A does not suppress a fresh resolve in B")
+}
+
+func TestMemberIDResolver_NegativeInvalidatedByFingerprintChange(t *testing.T) {
+	ctx := context.Background()
+	calls := 0
+	// Initially absent from A; after the "join" the mapping yields an id.
+	mapping := map[string]string{}
+	fetcher := &fakeChatFetcher{funcs: FakeChatFetcherFuncs{
+		ResolveMemberID: func(_ context.Context, spaceName, email string) (string, bool, error) {
+			calls++
+			if id, ok := mapping[spaceName+"|"+email]; ok {
+				return id, false, nil
+			}
+			return "", true, nil
+		},
+	}}
+	cap := 10
+	r := newMemberIDResolver(fetcher, nil, nil, &cap)
+	fpBefore := memberSetFingerprint([]string{"users/me"})
+	fpAfter := memberSetFingerprint([]string{"users/me", "users/999"})
+
+	// Sweep 1: absent → negative stamped with fpBefore.
+	_, status, err := r.resolve(ctx, "spaces/A", fpBefore, "joiner@example.test", nil)
+	require.NoError(t, err)
+	assert.Equal(t, notMember, status)
+	assert.Equal(t, 1, calls)
+
+	// Sweep 2 (new resolver instance to drop the in-sweep memo): the contact has
+	// joined → mapping yields the id AND the fingerprint flipped. The stale
+	// negative (stamped fpBefore) is NOT honored under fpAfter → re-resolved.
+	mapping["spaces/A|joiner@example.test"] = "users/999"
+	r2 := newMemberIDResolver(fetcher, r.snapshotPositives(), r.snapshotNegatives(), &cap)
+	id, status, err := r2.resolve(ctx, "spaces/A", fpAfter, "joiner@example.test", nil)
+	require.NoError(t, err)
+	assert.Equal(t, resolvedKnownID, status, "fingerprint flip invalidates the stale negative")
+	assert.Equal(t, "users/999", id)
+	assert.Equal(t, 2, calls)
+}
+
+func TestMemberIDResolver_ResolveCapDefers(t *testing.T) {
+	ctx := context.Background()
+	calls := 0
+	fetcher := fakeIDFetcher(map[string]string{
+		"spaces/A|a@example.test": "users/1",
+		"spaces/A|b@example.test": "users/2",
+	}, &calls)
+	cap := 1
+	r := newMemberIDResolver(fetcher, nil, nil, &cap)
+	fp := memberSetFingerprint([]string{"users/1", "users/2"})
+
+	// First fresh resolve consumes the cap.
+	_, status, err := r.resolve(ctx, "spaces/A", fp, "a@example.test", nil)
+	require.NoError(t, err)
+	assert.Equal(t, resolvedKnownID, status)
+	assert.Equal(t, 1, calls)
+	assert.Equal(t, 0, cap)
+
+	// Second fresh resolve is deferred (cap exhausted) — NO fetcher call.
+	_, status, err = r.resolve(ctx, "spaces/A", fp, "b@example.test", nil)
+	require.NoError(t, err)
+	assert.Equal(t, deferredCapHit, status)
+	assert.Equal(t, 1, calls, "the cap-exhausted candidate is not fetched this sweep")
+}
+
+func TestMemberIDResolver_BudgetExhaustionDefers(t *testing.T) {
+	ctx := context.Background()
+	calls := 0
+	fetcher := fakeIDFetcher(map[string]string{"spaces/A|a@example.test": "users/1"}, &calls)
+	cap := 10
+	r := newMemberIDResolver(fetcher, nil, nil, &cap)
+	fp := memberSetFingerprint([]string{"users/1"})
+
+	pageBudget := 0
+	_, status, err := r.resolve(ctx, "spaces/A", fp, "a@example.test", &pageBudget)
+	require.NoError(t, err)
+	assert.Equal(t, deferredBudgetHit, status)
+	assert.Equal(t, 0, calls, "a zero page budget defers without a fetch")
+	assert.Equal(t, 10, cap, "the resolve-cap is not consumed when the budget defers")
+}
+
+func TestMemberIDResolver_PropagatesFetcherError(t *testing.T) {
+	ctx := context.Background()
+	wantErr := errors.New("members.get transient")
+	fetcher := &fakeChatFetcher{funcs: FakeChatFetcherFuncs{
+		ResolveMemberID: func(context.Context, string, string) (string, bool, error) {
+			return "", false, wantErr
+		},
+	}}
+	cap := 10
+	r := newMemberIDResolver(fetcher, nil, nil, &cap)
+	fp := memberSetFingerprint([]string{"users/1"})
+
+	_, _, err := r.resolve(ctx, "spaces/A", fp, "a@example.test", nil)
+	require.ErrorIs(t, err, wantErr, "a transient members.get error must propagate, not become a negative")
+}
+
 func TestMembershipNeedsRefresh(t *testing.T) {
 	now := accelerated.GetCurrentTime()
 	fresh := now.Add(-time.Hour).Format(chatTimeLayout)

--- a/backend/internal/google/gchat_test.go
+++ b/backend/internal/google/gchat_test.go
@@ -319,13 +319,18 @@ func TestResolveKnownMembers_ResolvesAndExcludesSelf(t *testing.T) {
 	meSet := map[string]struct{}{"me@example.test": {}}
 
 	members := []string{"users/alice", "users/me", "users/unknown", "users/noemail"}
-	known, err := resolveKnownMembers(ctx, members, resolver, knownMap, meSet)
+	known, meIDs, err := resolveKnownMembers(ctx, members, resolver, knownMap, meSet)
 	require.NoError(t, err)
 
 	// Only Alice is a known co-member; me is excluded, unknown is not in knownMap,
 	// noemail is unresolvable.
 	require.Len(t, known, 1)
 	assert.Equal(t, []uuid.UUID{alice}, known["alice@example.test"])
+
+	// The account's own member id is reported in meIDs (so the reverse id-index
+	// can exclude it).
+	assert.Contains(t, meIDs, "users/me")
+	assert.NotContains(t, meIDs, "users/alice")
 }
 
 func TestResolveKnownMembers_PropagatesResolveError(t *testing.T) {
@@ -336,7 +341,7 @@ func TestResolveKnownMembers_PropagatesResolveError(t *testing.T) {
 	}}
 	resolver := newCachedEmailResolver(fetcher, nil)
 
-	_, err := resolveKnownMembers(ctx, []string{"users/alice"}, resolver, map[string][]uuid.UUID{}, map[string]struct{}{})
+	_, _, err := resolveKnownMembers(ctx, []string{"users/alice"}, resolver, map[string][]uuid.UUID{}, map[string]struct{}{})
 	require.ErrorIs(t, err, resolveErr, "a transient co-member resolve error must propagate, not be swallowed")
 }
 
@@ -599,7 +604,7 @@ func TestBuildKnownIDIndex_SeedsFromPositiveCacheZeroCalls(t *testing.T) {
 	meSet := map[string]struct{}{"me@example.test": {}}
 	counters := &sweepCounters{}
 	budget := 10
-	idx, blockedBudget, blockedCap, err := buildKnownIDIndex(ctx, &chat.Space{Name: "spaces/A"}, members, fp, knownMap, meSet, resolver, counters, &budget)
+	idx, blockedBudget, blockedCap, err := buildKnownIDIndex(ctx, &chat.Space{Name: "spaces/A"}, members, fp, knownMap, meSet, nil, resolver, counters, &budget)
 	require.NoError(t, err)
 	assert.False(t, blockedBudget)
 	assert.False(t, blockedCap)
@@ -608,6 +613,45 @@ func TestBuildKnownIDIndex_SeedsFromPositiveCacheZeroCalls(t *testing.T) {
 	assert.Equal(t, idMatch{Email: "dave@example.test", Contacts: []uuid.UUID{dave}}, idx["users/dave"])
 	assert.Equal(t, idMatch{Email: "frank@example.test", Contacts: []uuid.UUID{frank}}, idx["users/frank"])
 	assert.Equal(t, 1, calls, "only the uncached email triggered a members.get")
+}
+
+// TestBuildKnownIDIndex_ExcludesMeIDs proves the account's own id never enters
+// the reverse index, even when a stray non-meSet CRM email (a contact carrying
+// the user's own alternate alias) resolves to the account's own canonical id —
+// from BOTH the global-positive seed path AND the fresh-resolve path. Without
+// the meIDs guard, the account's own outbound messages would misclassify as
+// inbound from that contact.
+func TestBuildKnownIDIndex_ExcludesMeIDs(t *testing.T) {
+	ctx := context.Background()
+	strayContact := uuid.New()
+	freshStray := uuid.New()
+	members := []string{"users/me", "users/other"}
+	fp := memberSetFingerprint(members)
+	now := accelerated.GetCurrentTime()
+
+	calls := 0
+	// A second stray alias resolves fresh to users/me too.
+	fetcher := fakeIDFetcher(map[string]string{"spaces/A|stray-fresh@example.test": "users/me"}, &calls)
+	// One stray alias is pre-seeded in the global positive cache as users/me.
+	pos := map[string]cachedUserID{"stray-seeded@example.test": {UserName: "users/me", ResolvedAt: now.Format(chatTimeLayout)}}
+	cap := 10
+	resolver := newMemberIDResolver(fetcher, pos, nil, &cap)
+
+	knownMap := map[string][]uuid.UUID{
+		"stray-seeded@example.test": {strayContact}, // a contact holding the user's own alias
+		"stray-fresh@example.test":  {freshStray},
+	}
+	meSet := map[string]struct{}{"me@example.test": {}}
+	meIDs := map[string]struct{}{"users/me": {}}
+	counters := &sweepCounters{}
+	budget := 10
+	idx, _, _, err := buildKnownIDIndex(ctx, &chat.Space{Name: "spaces/A"}, members, fp, knownMap, meSet, meIDs, resolver, counters, &budget)
+	require.NoError(t, err)
+
+	// users/me must NOT be in the index from either path.
+	_, present := idx["users/me"]
+	assert.False(t, present, "the account's own id must never enter the reverse index")
+	assert.Empty(t, idx, "no contact is matched via a me-id alias")
 }
 
 // TestBuildKnownIDIndex_DebtHoldsCursor drives the resolution-debt model:
@@ -637,7 +681,7 @@ func TestBuildKnownIDIndex_DebtHoldsCursor(t *testing.T) {
 		knownMap := map[string][]uuid.UUID{"absent@example.test": {absent}}
 		counters := &sweepCounters{}
 		budget := 10
-		idx, _, blockedCap, err := buildKnownIDIndex(ctx, &chat.Space{Name: "spaces/A"}, members, fp, knownMap, map[string]struct{}{"me@example.test": {}}, resolver, counters, &budget)
+		idx, _, blockedCap, err := buildKnownIDIndex(ctx, &chat.Space{Name: "spaces/A"}, members, fp, knownMap, map[string]struct{}{"me@example.test": {}}, nil, resolver, counters, &budget)
 		require.NoError(t, err)
 		assert.Empty(t, idx)
 		assert.False(t, blockedCap, "a NEGATIVE-VALID candidate under the current fingerprint is not debt")
@@ -659,7 +703,7 @@ func TestBuildKnownIDIndex_DebtHoldsCursor(t *testing.T) {
 		knownMap := map[string][]uuid.UUID{"joiner@example.test": {joiner}}
 		counters := &sweepCounters{}
 		budget := 10
-		idx, blockedBudget, blockedCap, err := buildKnownIDIndex(ctx, &chat.Space{Name: "spaces/A"}, members, fpNew, knownMap, map[string]struct{}{"me@example.test": {}}, resolver, counters, &budget)
+		idx, blockedBudget, blockedCap, err := buildKnownIDIndex(ctx, &chat.Space{Name: "spaces/A"}, members, fpNew, knownMap, map[string]struct{}{"me@example.test": {}}, nil, resolver, counters, &budget)
 		require.NoError(t, err)
 		assert.Empty(t, idx, "the candidate could not resolve this sweep")
 		assert.False(t, blockedBudget)
@@ -689,7 +733,7 @@ func TestBuildKnownIDIndex_DebtHoldsCursor(t *testing.T) {
 		}
 		counters := &sweepCounters{}
 		budget := 10
-		idx, _, blockedCap, err := buildKnownIDIndex(ctx, &chat.Space{Name: "spaces/A"}, members, fpNew, knownMap, map[string]struct{}{"me@example.test": {}}, resolver, counters, &budget)
+		idx, _, blockedCap, err := buildKnownIDIndex(ctx, &chat.Space{Name: "spaces/A"}, members, fpNew, knownMap, map[string]struct{}{"me@example.test": {}}, nil, resolver, counters, &budget)
 		require.NoError(t, err)
 		// The invalidated (priority) candidate consumed the single cap slot and
 		// matched; the never-seen one was deferred (debt) → cursor held.
@@ -730,7 +774,7 @@ func TestBuildKnownIDIndex_ActivityDoesNotReincurDebt(t *testing.T) {
 		r := newMemberIDResolver(fetcher, resolver.snapshotPositives(), resolver.snapshotNegatives(), &cap)
 		counters := &sweepCounters{}
 		budget := 10
-		idx, blockedBudget, blockedCap, err := buildKnownIDIndex(ctx, &chat.Space{Name: "spaces/A"}, members, fp, knownMap, meSet, r, counters, &budget)
+		idx, blockedBudget, blockedCap, err := buildKnownIDIndex(ctx, &chat.Space{Name: "spaces/A"}, members, fp, knownMap, meSet, nil, r, counters, &budget)
 		require.NoError(t, err)
 		assert.Empty(t, idx)
 		assert.False(t, blockedBudget)
@@ -746,7 +790,7 @@ func TestBuildKnownIDIndex_ActivityDoesNotReincurDebt(t *testing.T) {
 	r := newMemberIDResolver(fetcher2, resolver.snapshotPositives(), resolver.snapshotNegatives(), &cap)
 	counters := &sweepCounters{}
 	budget := 10
-	idx, _, _, err := buildKnownIDIndex(ctx, &chat.Space{Name: "spaces/A"}, membersAfter, fpAfter, knownMap, meSet, r, counters, &budget)
+	idx, _, _, err := buildKnownIDIndex(ctx, &chat.Space{Name: "spaces/A"}, membersAfter, fpAfter, knownMap, meSet, nil, r, counters, &budget)
 	require.NoError(t, err)
 	assert.Contains(t, idx, "users/absent", "a real membership change re-resolves the candidate")
 	assert.Equal(t, 1, calls, "exactly one re-resolve after the membership actually changed")
@@ -875,9 +919,9 @@ func TestMemberSetFingerprint_OrderIndependentAndChangeSensitive(t *testing.T) {
 		"removing a member must change the fingerprint")
 
 	// The empty set is a stable sentinel (and not equal to any non-empty hash).
-	assert.Equal(t, "empty", memberSetFingerprint(nil))
-	assert.Equal(t, "empty", memberSetFingerprint([]string{}))
-	assert.Equal(t, "empty", memberSetFingerprint([]string{""}), "blank ids are skipped")
+	assert.Equal(t, memberSetFingerprintEmpty, memberSetFingerprint(nil))
+	assert.Equal(t, memberSetFingerprintEmpty, memberSetFingerprint([]string{}))
+	assert.Equal(t, memberSetFingerprintEmpty, memberSetFingerprint([]string{""}), "blank ids are skipped")
 }
 
 func TestPruneIDCaches_DropsExpiredAndOrphanNegatives(t *testing.T) {

--- a/backend/internal/google/gchat_test.go
+++ b/backend/internal/google/gchat_test.go
@@ -68,7 +68,7 @@ func TestClassifyMessage_InboundSenderOnly(t *testing.T) {
 	meSet := map[string]struct{}{"me@example.test": {}}
 
 	m := humanMsg("spaces/S/messages/1", "users/alice", "2026-06-04T10:00:00Z", "hi all")
-	c, err := classifyMessage(ctx, m, knownMembers, knownMap, nil, meSet, resolver)
+	c, err := classifyMessage(ctx, m, knownMembers, knownMap, nil, nil, meSet, resolver)
 	require.NoError(t, err)
 	assert.Equal(t, "inbound", c.Direction)
 	// Sender-only: exactly Alice, NOT Bob/Carol.
@@ -95,7 +95,7 @@ func TestClassifyMessage_OutboundFanOut(t *testing.T) {
 	meSet := map[string]struct{}{"me@example.test": {}}
 
 	m := humanMsg("spaces/S/messages/2", "users/me", "2026-06-04T10:01:00Z", "hello")
-	c, err := classifyMessage(ctx, m, knownMembers, knownMap, nil, meSet, resolver)
+	c, err := classifyMessage(ctx, m, knownMembers, knownMap, nil, nil, meSet, resolver)
 	require.NoError(t, err)
 	assert.Equal(t, "outbound", c.Direction)
 	assert.ElementsMatch(t, []uuid.UUID{alice, bob}, c.Matched)
@@ -123,7 +123,7 @@ func TestClassifyMessage_OutboundExcludesSelfContact(t *testing.T) {
 	meSet := map[string]struct{}{"me@example.test": {}}
 
 	m := humanMsg("spaces/S/messages/3", "users/me", "2026-06-04T10:02:00Z", "hi")
-	c, err := classifyMessage(ctx, m, knownMembers, knownMap, nil, meSet, resolver)
+	c, err := classifyMessage(ctx, m, knownMembers, knownMap, nil, nil, meSet, resolver)
 	require.NoError(t, err)
 	assert.Equal(t, "outbound", c.Direction)
 	// The self-contact must NOT receive a self-attributed outreach row.
@@ -142,14 +142,14 @@ func TestClassifyMessage_BystanderAndUnresolved(t *testing.T) {
 
 	// Bystander: sender neither me nor known.
 	mBy := humanMsg("spaces/S/messages/4", "users/stranger", "2026-06-04T10:03:00Z", "hey")
-	c, err := classifyMessage(ctx, mBy, nil, knownMap, nil, meSet, resolver)
+	c, err := classifyMessage(ctx, mBy, nil, knownMap, nil, nil, meSet, resolver)
 	require.NoError(t, err)
 	assert.Empty(t, c.Matched)
 	assert.False(t, c.Unresolved)
 
 	// Unresolved sender: resolves to "" → flagged Unresolved, no rows.
 	mUn := humanMsg("spaces/S/messages/5", "users/ghost", "2026-06-04T10:04:00Z", "hey")
-	c, err = classifyMessage(ctx, mUn, nil, knownMap, nil, meSet, resolver)
+	c, err = classifyMessage(ctx, mUn, nil, knownMap, nil, nil, meSet, resolver)
 	require.NoError(t, err)
 	assert.Empty(t, c.Matched)
 	assert.True(t, c.Unresolved)
@@ -171,11 +171,37 @@ func TestClassifyMessage_MatchesBySenderID(t *testing.T) {
 	}
 
 	m := humanMsg("spaces/S/messages/d", "users/dave", "2026-06-04T10:00:00Z", "hi from dave")
-	c, err := classifyMessage(ctx, m, nil, knownMap, knownIDs, meSet, resolver)
+	c, err := classifyMessage(ctx, m, nil, knownMap, knownIDs, nil, meSet, resolver)
 	require.NoError(t, err)
 	assert.Equal(t, "inbound", c.Direction)
 	assert.Equal(t, []uuid.UUID{dave}, c.Matched, "the sender id matched the contact via the id path")
 	assert.Equal(t, "dave@example.test", c.SenderEmail, "the peer email is carried from the idMatch, not the empty People-API result")
+}
+
+// TestClassifyMessage_InboundIDPathYieldsToMeID is the defense-in-depth guard:
+// if a stray index entry maps the account's OWN id to a contact (the anomalous
+// self-alias case), the inbound id-path must NOT fire for the account's own
+// message — meIDs makes it fall through to the email path, where the sender (me)
+// is classified outbound, not inbound from that contact.
+func TestClassifyMessage_InboundIDPathYieldsToMeID(t *testing.T) {
+	ctx := context.Background()
+	strayContact := uuid.New()
+	// The account's own id resolves to its own email via the email path.
+	resolver := staticResolver(t, map[string]string{"users/me": "me@example.test"}, nil)
+	knownMap := map[string][]uuid.UUID{"me@example.test": {strayContact}}
+	meSet := map[string]struct{}{"me@example.test": {}}
+	// A stray index entry mapping the account's own id to a contact (what the
+	// build-time meIDs exclusion normally prevents — here we assert the
+	// point-of-use guard independently).
+	knownIDs := map[string]idMatch{
+		"users/me": {Email: "me@example.test", Contacts: []uuid.UUID{strayContact}},
+	}
+	meIDs := map[string]struct{}{"users/me": {}}
+
+	m := humanMsg("spaces/S/messages/self", "users/me", "2026-06-04T10:00:00Z", "my own message")
+	c, err := classifyMessage(ctx, m, nil, knownMap, knownIDs, meIDs, meSet, resolver)
+	require.NoError(t, err)
+	assert.Equal(t, "outbound", c.Direction, "the account's own message is outbound, never inbound from a stray self-alias contact")
 }
 
 // TestClassifyMessage_OutboundFanOutIncludesIDResolvedMembers proves an outbound
@@ -198,7 +224,7 @@ func TestClassifyMessage_OutboundFanOutIncludesIDResolvedMembers(t *testing.T) {
 	meSet := map[string]struct{}{"me@example.test": {}}
 
 	m := humanMsg("spaces/S/messages/o", "users/me", "2026-06-04T10:01:00Z", "team update")
-	c, err := classifyMessage(ctx, m, knownMembers, knownMap, knownIDs, meSet, resolver)
+	c, err := classifyMessage(ctx, m, knownMembers, knownMap, knownIDs, nil, meSet, resolver)
 	require.NoError(t, err)
 	assert.Equal(t, "outbound", c.Direction)
 	assert.ElementsMatch(t, []uuid.UUID{alice, dave}, c.Matched, "fan-out unions email-resolved and id-resolved members")
@@ -223,7 +249,7 @@ func TestClassifyMessage_OutboundFanOutDedupsContact(t *testing.T) {
 	meSet := map[string]struct{}{"me@example.test": {}}
 
 	m := humanMsg("spaces/S/messages/o2", "users/me", "2026-06-04T10:02:00Z", "hi")
-	c, err := classifyMessage(ctx, m, knownMembers, knownMap, knownIDs, meSet, resolver)
+	c, err := classifyMessage(ctx, m, knownMembers, knownMap, knownIDs, nil, meSet, resolver)
 	require.NoError(t, err)
 	assert.Equal(t, "outbound", c.Direction)
 	assert.Equal(t, []uuid.UUID{alice}, c.Matched, "the shared contact appears once, not twice")
@@ -271,14 +297,14 @@ func TestClassifyMessage_IDPathPreferredEmailFallback(t *testing.T) {
 
 	// Dave: id path → no email resolver call.
 	mDave := humanMsg("spaces/S/messages/d", "users/dave", "2026-06-04T10:00:00Z", "x")
-	c, err := classifyMessage(ctx, mDave, nil, knownMap, knownIDs, meSet, resolver)
+	c, err := classifyMessage(ctx, mDave, nil, knownMap, knownIDs, nil, meSet, resolver)
 	require.NoError(t, err)
 	assert.Equal(t, []uuid.UUID{dave}, c.Matched)
 	assert.Equal(t, 0, calls, "an id-path match must not call the email resolver")
 
 	// Erin: absent from knownIDs → email path still matches.
 	mErin := humanMsg("spaces/S/messages/e", "users/erin", "2026-06-04T10:01:00Z", "y")
-	c, err = classifyMessage(ctx, mErin, nil, knownMap, knownIDs, meSet, resolver)
+	c, err = classifyMessage(ctx, mErin, nil, knownMap, knownIDs, nil, meSet, resolver)
 	require.NoError(t, err)
 	assert.Equal(t, "inbound", c.Direction)
 	assert.Equal(t, []uuid.UUID{erin}, c.Matched)
@@ -604,7 +630,7 @@ func TestBuildKnownIDIndex_SeedsFromPositiveCacheZeroCalls(t *testing.T) {
 	meSet := map[string]struct{}{"me@example.test": {}}
 	counters := &sweepCounters{}
 	budget := 10
-	idx, blockedBudget, blockedCap, err := buildKnownIDIndex(ctx, &chat.Space{Name: "spaces/A"}, members, fp, knownMap, meSet, nil, resolver, counters, &budget)
+	idx, _, blockedBudget, blockedCap, err := buildKnownIDIndex(ctx, &chat.Space{Name: "spaces/A"}, members, fp, knownMap, meSet, nil, resolver, counters, &budget)
 	require.NoError(t, err)
 	assert.False(t, blockedBudget)
 	assert.False(t, blockedCap)
@@ -645,13 +671,50 @@ func TestBuildKnownIDIndex_ExcludesMeIDs(t *testing.T) {
 	meIDs := map[string]struct{}{"users/me": {}}
 	counters := &sweepCounters{}
 	budget := 10
-	idx, _, _, err := buildKnownIDIndex(ctx, &chat.Space{Name: "spaces/A"}, members, fp, knownMap, meSet, meIDs, resolver, counters, &budget)
+	idx, _, _, _, err := buildKnownIDIndex(ctx, &chat.Space{Name: "spaces/A"}, members, fp, knownMap, meSet, meIDs, resolver, counters, &budget)
 	require.NoError(t, err)
 
 	// users/me must NOT be in the index from either path.
 	_, present := idx["users/me"]
 	assert.False(t, present, "the account's own id must never enter the reverse index")
 	assert.Empty(t, idx, "no contact is matched via a me-id alias")
+}
+
+// TestBuildKnownIDIndex_DiscoversMeIDFromCachedPositive proves meIDs is
+// authoritatively extended from the reverse resolver's already-cached positive
+// for the meSet email — even when the People-derived meIDs is EMPTY (the
+// not-in-Contacts me case). This closes the residual gap where People could not
+// identify the account's own member id. The discovery is cache-only (no fresh
+// members.get): the me-email's id was cached by an earlier space.
+func TestBuildKnownIDIndex_DiscoversMeIDFromCachedPositive(t *testing.T) {
+	ctx := context.Background()
+	strayContact := uuid.New()
+	members := []string{"users/me", "users/other"}
+	fp := memberSetFingerprint(members)
+	now := accelerated.GetCurrentTime()
+
+	calls := 0
+	fetcher := fakeIDFetcher(map[string]string{}, &calls)
+	// The account's own email is in the global positive cache as users/me (from an
+	// earlier space), AND a stray contact alias is cached as users/me too.
+	pos := map[string]cachedUserID{
+		"me@example.test":           {UserName: "users/me", ResolvedAt: now.Format(chatTimeLayout)},
+		"stray-seeded@example.test": {UserName: "users/me", ResolvedAt: now.Format(chatTimeLayout)},
+	}
+	cap := 10
+	resolver := newMemberIDResolver(fetcher, pos, nil, &cap)
+
+	knownMap := map[string][]uuid.UUID{"stray-seeded@example.test": {strayContact}}
+	meSet := map[string]struct{}{"me@example.test": {}}
+	// People-derived meIDs is EMPTY (People could not identify the me member id).
+	counters := &sweepCounters{}
+	budget := 10
+	idx, meIDsOut, _, _, err := buildKnownIDIndex(ctx, &chat.Space{Name: "spaces/A"}, members, fp, knownMap, meSet, map[string]struct{}{}, resolver, counters, &budget)
+	require.NoError(t, err)
+
+	assert.Contains(t, meIDsOut, "users/me", "the me-id is discovered from the cached positive for the me-email")
+	assert.Empty(t, idx, "the stray contact alias is excluded because it resolves to the discovered me-id")
+	assert.Equal(t, 0, calls, "the me-id discovery is cache-only — no fresh members.get")
 }
 
 // TestBuildKnownIDIndex_DebtHoldsCursor drives the resolution-debt model:
@@ -681,7 +744,7 @@ func TestBuildKnownIDIndex_DebtHoldsCursor(t *testing.T) {
 		knownMap := map[string][]uuid.UUID{"absent@example.test": {absent}}
 		counters := &sweepCounters{}
 		budget := 10
-		idx, _, blockedCap, err := buildKnownIDIndex(ctx, &chat.Space{Name: "spaces/A"}, members, fp, knownMap, map[string]struct{}{"me@example.test": {}}, nil, resolver, counters, &budget)
+		idx, _, _, blockedCap, err := buildKnownIDIndex(ctx, &chat.Space{Name: "spaces/A"}, members, fp, knownMap, map[string]struct{}{"me@example.test": {}}, nil, resolver, counters, &budget)
 		require.NoError(t, err)
 		assert.Empty(t, idx)
 		assert.False(t, blockedCap, "a NEGATIVE-VALID candidate under the current fingerprint is not debt")
@@ -703,7 +766,7 @@ func TestBuildKnownIDIndex_DebtHoldsCursor(t *testing.T) {
 		knownMap := map[string][]uuid.UUID{"joiner@example.test": {joiner}}
 		counters := &sweepCounters{}
 		budget := 10
-		idx, blockedBudget, blockedCap, err := buildKnownIDIndex(ctx, &chat.Space{Name: "spaces/A"}, members, fpNew, knownMap, map[string]struct{}{"me@example.test": {}}, nil, resolver, counters, &budget)
+		idx, _, blockedBudget, blockedCap, err := buildKnownIDIndex(ctx, &chat.Space{Name: "spaces/A"}, members, fpNew, knownMap, map[string]struct{}{"me@example.test": {}}, nil, resolver, counters, &budget)
 		require.NoError(t, err)
 		assert.Empty(t, idx, "the candidate could not resolve this sweep")
 		assert.False(t, blockedBudget)
@@ -733,7 +796,7 @@ func TestBuildKnownIDIndex_DebtHoldsCursor(t *testing.T) {
 		}
 		counters := &sweepCounters{}
 		budget := 10
-		idx, _, blockedCap, err := buildKnownIDIndex(ctx, &chat.Space{Name: "spaces/A"}, members, fpNew, knownMap, map[string]struct{}{"me@example.test": {}}, nil, resolver, counters, &budget)
+		idx, _, _, blockedCap, err := buildKnownIDIndex(ctx, &chat.Space{Name: "spaces/A"}, members, fpNew, knownMap, map[string]struct{}{"me@example.test": {}}, nil, resolver, counters, &budget)
 		require.NoError(t, err)
 		// The invalidated (priority) candidate consumed the single cap slot and
 		// matched; the never-seen one was deferred (debt) → cursor held.
@@ -774,7 +837,7 @@ func TestBuildKnownIDIndex_ActivityDoesNotReincurDebt(t *testing.T) {
 		r := newMemberIDResolver(fetcher, resolver.snapshotPositives(), resolver.snapshotNegatives(), &cap)
 		counters := &sweepCounters{}
 		budget := 10
-		idx, blockedBudget, blockedCap, err := buildKnownIDIndex(ctx, &chat.Space{Name: "spaces/A"}, members, fp, knownMap, meSet, nil, r, counters, &budget)
+		idx, _, blockedBudget, blockedCap, err := buildKnownIDIndex(ctx, &chat.Space{Name: "spaces/A"}, members, fp, knownMap, meSet, nil, r, counters, &budget)
 		require.NoError(t, err)
 		assert.Empty(t, idx)
 		assert.False(t, blockedBudget)
@@ -790,7 +853,7 @@ func TestBuildKnownIDIndex_ActivityDoesNotReincurDebt(t *testing.T) {
 	r := newMemberIDResolver(fetcher2, resolver.snapshotPositives(), resolver.snapshotNegatives(), &cap)
 	counters := &sweepCounters{}
 	budget := 10
-	idx, _, _, err := buildKnownIDIndex(ctx, &chat.Space{Name: "spaces/A"}, membersAfter, fpAfter, knownMap, meSet, nil, r, counters, &budget)
+	idx, _, _, _, err := buildKnownIDIndex(ctx, &chat.Space{Name: "spaces/A"}, membersAfter, fpAfter, knownMap, meSet, nil, r, counters, &budget)
 	require.NoError(t, err)
 	assert.Contains(t, idx, "users/absent", "a real membership change re-resolves the candidate")
 	assert.Equal(t, 1, calls, "exactly one re-resolve after the membership actually changed")
@@ -1032,7 +1095,7 @@ func TestConsumeContentWindow_BudgetExhaustionKeepsCursor(t *testing.T) {
 
 	newCursor, proven, err := p.consumeContentWindow(ctx, fetcher,
 		&chat.Space{Name: "spaces/B", SpaceType: "SPACE"}, floor,
-		map[string][]uuid.UUID{}, map[string][]uuid.UUID{}, nil, map[string]struct{}{},
+		map[string][]uuid.UUID{}, map[string][]uuid.UUID{}, nil, nil, map[string]struct{}{},
 		resolver, "acct", counters, &budget)
 	require.NoError(t, err)
 	assert.False(t, proven, "an un-finished window is NOT proven")
@@ -1071,7 +1134,7 @@ func TestConsumeContentWindow_FullyPagedIsProven(t *testing.T) {
 	floor := "2026-01-01T00:00:00Z"
 	newCursor, proven, err := p.consumeContentWindow(ctx, fetcher,
 		&chat.Space{Name: "spaces/B", SpaceType: "SPACE"}, floor,
-		map[string][]uuid.UUID{}, map[string][]uuid.UUID{"someone-else@example.test": {alice}}, nil, map[string]struct{}{},
+		map[string][]uuid.UUID{}, map[string][]uuid.UUID{"someone-else@example.test": {alice}}, nil, nil, map[string]struct{}{},
 		resolver, "acct", counters, &budget)
 	require.NoError(t, err)
 	assert.True(t, proven, "a fully-paged window is proven")
@@ -1111,7 +1174,7 @@ func TestConsumeContentWindow_CursorAdvancesByInstantNotLexical(t *testing.T) {
 	floor := "2026-01-01T00:00:00Z"
 	newCursor, proven, err := p.consumeContentWindow(ctx, fetcher,
 		&chat.Space{Name: "spaces/B", SpaceType: "SPACE"}, floor,
-		map[string][]uuid.UUID{}, map[string][]uuid.UUID{}, nil, map[string]struct{}{},
+		map[string][]uuid.UUID{}, map[string][]uuid.UUID{}, nil, nil, map[string]struct{}{},
 		resolver, "acct", counters, &budget)
 	require.NoError(t, err)
 	assert.True(t, proven)
@@ -1265,7 +1328,7 @@ func TestConsumeContentWindow_DeepHistoryCompletesUnderRaisedBudget(t *testing.T
 		counters := &sweepCounters{}
 		newCursor, proven, err := p.consumeContentWindow(ctx, fetcher,
 			&chat.Space{Name: "spaces/B", SpaceType: "SPACE"}, floor,
-			map[string][]uuid.UUID{}, map[string][]uuid.UUID{}, nil, map[string]struct{}{},
+			map[string][]uuid.UUID{}, map[string][]uuid.UUID{}, nil, nil, map[string]struct{}{},
 			resolver, "acct", counters, &budget)
 		require.NoError(t, err)
 		assert.True(t, proven, "a 30-page window fully pages under the 100-page budget")
@@ -1286,7 +1349,7 @@ func TestConsumeContentWindow_DeepHistoryCompletesUnderRaisedBudget(t *testing.T
 		counters := &sweepCounters{}
 		newCursor, proven, err := p.consumeContentWindow(ctx, fetcher,
 			&chat.Space{Name: "spaces/B", SpaceType: "SPACE"}, floor,
-			map[string][]uuid.UUID{}, map[string][]uuid.UUID{}, nil, map[string]struct{}{},
+			map[string][]uuid.UUID{}, map[string][]uuid.UUID{}, nil, nil, map[string]struct{}{},
 			resolver, "acct", counters, &budget)
 		require.NoError(t, err)
 		assert.False(t, proven, "a 30-page window cannot complete under a 24-page budget")

--- a/backend/internal/google/gchat_test.go
+++ b/backend/internal/google/gchat_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"testing"
 	"time"
 
@@ -690,6 +691,83 @@ func TestConsumeContentWindow_DeepHistoryCompletesUnderRaisedBudget(t *testing.T
 		assert.Equal(t, floor, newCursor, "cursor must NOT advance past an un-listed page")
 		assert.Equal(t, 0, budget, "the tight budget is fully drained")
 		assert.Equal(t, 24, calls, "exactly the budgeted number of pages were fetched")
+	})
+}
+
+// TestChatServiceFetcher_ResolveMemberID_RequestPath pins the actual request the
+// godoc promises: members.get with the BARE email as the member resource-name
+// segment (NOT "members/users/{email}"), parsing the canonical Member.Name from
+// the response, and mapping the unrecognized-member statuses (400/404) to
+// notMember=true. Like TestListMessages_RequestsMaxPageSize, it stands up an
+// httptest.Server and points a real *chat.Service at it (no OAuth, no live
+// Google), so it guards against the doubled-prefix mistake at the production
+// seam where the unit fakes cannot.
+func TestChatServiceFetcher_ResolveMemberID_RequestPath(t *testing.T) {
+	t.Run("success_parses_canonical_id", func(t *testing.T) {
+		ctx := context.Background()
+		var gotPath string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			w.Header().Set("Content-Type", "application/json")
+			// Membership response whose member carries the CANONICAL users/{id}
+			// (the request used the email alias; the response is always canonical).
+			_, _ = w.Write([]byte(`{"member":{"name":"users/123456789","type":"HUMAN"}}`))
+		}))
+		defer server.Close()
+
+		svc, err := chat.NewService(ctx, option.WithEndpoint(server.URL), option.WithoutAuthentication())
+		require.NoError(t, err)
+		fetcher := &chatServiceFetcher{chat: svc}
+
+		userName, notMember, err := fetcher.ResolveMemberID(ctx, "spaces/ABC", "person@example.test")
+		require.NoError(t, err)
+		assert.False(t, notMember)
+		assert.Equal(t, "users/123456789", userName)
+		// The bare email is the member segment — NOT "members/users/{email}".
+		assert.Equal(t, "/v1/spaces/ABC/members/person@example.test", gotPath,
+			"members.get must use the bare-email member resource name (reserved expansion preserves @/.)")
+	})
+
+	// A 400 (unrecognized member) and a 404 both mean "not a member of this
+	// space" — a cacheable negative, not an error.
+	for _, code := range []int{400, 404} {
+		code := code
+		t.Run("status_maps_to_notMember", func(t *testing.T) {
+			ctx := context.Background()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(code)
+				_, _ = w.Write([]byte(`{"error":{"code":` + strconv.Itoa(code) + `,"message":"Invalid membership state, user, group or request ID"}}`))
+			}))
+			defer server.Close()
+
+			svc, err := chat.NewService(ctx, option.WithEndpoint(server.URL), option.WithoutAuthentication())
+			require.NoError(t, err)
+			fetcher := &chatServiceFetcher{chat: svc}
+
+			userName, notMember, err := fetcher.ResolveMemberID(ctx, "spaces/ABC", "stranger@example.test")
+			require.NoError(t, err, "an unrecognized-member %d must be a cacheable negative, not an error", code)
+			assert.True(t, notMember)
+			assert.Empty(t, userName)
+		})
+	}
+
+	t.Run("server_error_propagates", func(t *testing.T) {
+		ctx := context.Background()
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(500)
+			_, _ = w.Write([]byte(`{"error":{"code":500,"message":"backend error"}}`))
+		}))
+		defer server.Close()
+
+		svc, err := chat.NewService(ctx, option.WithEndpoint(server.URL), option.WithoutAuthentication())
+		require.NoError(t, err)
+		fetcher := &chatServiceFetcher{chat: svc}
+
+		_, notMember, err := fetcher.ResolveMemberID(ctx, "spaces/ABC", "person@example.test")
+		require.Error(t, err, "a transient 5xx must propagate so the window aborts and retries")
+		assert.False(t, notMember)
 	})
 }
 

--- a/backend/internal/google/gchat_test.go
+++ b/backend/internal/google/gchat_test.go
@@ -610,7 +610,7 @@ func TestBuildKnownIDIndex_SeedsFromPositiveCacheZeroCalls(t *testing.T) {
 	assert.Equal(t, 1, calls, "only the uncached email triggered a members.get")
 }
 
-// TestBuildKnownIDIndex_DebtHoldsCursor drives the §3.2.1 debt model:
+// TestBuildKnownIDIndex_DebtHoldsCursor drives the resolution-debt model:
 //
 //	(a) a NEGATIVE-VALID candidate is not debt → no resolve, blockedByCapOnDebt=false;
 //	(b) an UNKNOWN candidate (fingerprint-mismatched negative) with the cap
@@ -700,7 +700,7 @@ func TestBuildKnownIDIndex_DebtHoldsCursor(t *testing.T) {
 	})
 }
 
-// TestBuildKnownIDIndex_ActivityDoesNotReincurDebt proves the round-4 starvation
+// TestBuildKnownIDIndex_ActivityDoesNotReincurDebt proves the no-starvation
 // fix: with an UNCHANGED member set (same fingerprint), repeated index builds
 // issue ZERO members.get calls for a known-absent contact and never set
 // blockedByCapOnDebt — mere activity does not re-incur debt. Contrast: when a

--- a/backend/tests/gchat_provider_integration_test.go
+++ b/backend/tests/gchat_provider_integration_test.go
@@ -1080,7 +1080,7 @@ func TestGChatProvider_GlobalPositiveCachePersistsAndReused(t *testing.T) {
 }
 
 // TestGChatProvider_DebtHeldCursorAcrossTwoSweeps proves the debt-hold survives
-// the sweep in which membership changed (the round-3 two-sweep hole). The
+// the sweep in which membership changed (the two-sweep hole). The
 // resolve-cap is forced to 0 so the post-change re-resolution CANNOT happen on
 // the change sweep. Sweep B holds the cursor; sweep C (cap restored) drains the
 // debt and matches the message from sweep B's window.
@@ -1188,7 +1188,7 @@ func TestGChatProvider_DebtHeldCursorAcrossTwoSweeps(t *testing.T) {
 	assert.NotEqual(t, cursorBefore, spaceCursorFromMetadata(t, persistedC.Metadata, spaceName), "the cursor advances after the debt drains")
 }
 
-// TestGChatProvider_HotSpaceNoStarvation proves the round-4 starvation fix: a
+// TestGChatProvider_HotSpaceNoStarvation proves the starvation fix: a
 // space with a known-absent contact (negative written) and an UNCHANGED member
 // set across many sweeps — each adding a new message from a DIFFERENT known
 // member so lastActiveTime advances (membership refetches) but the member SET is

--- a/backend/tests/gchat_provider_integration_test.go
+++ b/backend/tests/gchat_provider_integration_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"context"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
@@ -827,4 +828,505 @@ func TestGChatProvider_MultiPageWindowPersistsCursor(t *testing.T) {
 	createCursor, ok := entry["create_cursor"].(string)
 	require.True(t, ok, "create_cursor must be a string")
 	assert.Equal(t, latestCursor, createCursor, "persisted cursor must equal the latest message create_time")
+}
+
+// spaceCursorFromMetadata extracts a space's create_cursor from the persisted
+// JSONB metadata (decoded as map[string]any). Returns "" when absent.
+func spaceCursorFromMetadata(t *testing.T, metadata map[string]any, spaceName string) string {
+	t.Helper()
+	cursors, ok := metadata["space_cursors"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	entry, ok := cursors[spaceName].(map[string]any)
+	if !ok {
+		return ""
+	}
+	cur, _ := entry["create_cursor"].(string)
+	return cur
+}
+
+// TestGChatProvider_MatchesContactNotInGoogleContacts is the HEADLINE
+// REGRESSION. A contact whose EMAIL is in the CRM but whose canonical id returns
+// "" from the People-API fake (the not-in-Contacts case) is matched via the
+// reverse members.get id resolution: (a) an INBOUND message writes a row matched
+// to the contact with the CRM email as the peer; (b) an OUTBOUND message fans
+// out to the id-resolved contact; (c) the id-resolved contact is a co-member of
+// the group space; (d) the cursor advances (window proven).
+func TestGChatProvider_MatchesContactNotInGoogleContacts(t *testing.T) {
+	e := setupGChatProviderTest(t)
+	suffix := randomSuffix(t)
+
+	daveEmail := "dave-" + suffix + "@example.test"
+	dave := e.newGChatProviderContact(t, "GChat NotInContacts Dave "+suffix, string(repository.ContactMethodEmail), daveEmail)
+
+	spaceName := "spaces/NOTINCONTACTS-" + suffix
+	inboundMsg := spaceName + "/messages/in-" + suffix
+	outboundMsg := spaceName + "/messages/out-" + suffix
+	accountID := "me-" + suffix + "@example.test"
+	e.newGChatSyncState(t, accountID, true, nil)
+	base := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Second)
+
+	funcs := google.FakeChatFetcherFuncs{
+		ListSpaces: func(context.Context, string) ([]*chat.Space, string, error) {
+			return []*chat.Space{space(spaceName, "SPACE")}, "", nil
+		},
+		ListMembers: func(context.Context, string, string) ([]*chat.Membership, string, error) {
+			return []*chat.Membership{membership("users/dave"), membership("users/me")}, "", nil
+		},
+		ListMessages: func(_ context.Context, _, _ string, showDeleted bool, _ string) ([]*chat.Message, string, error) {
+			if showDeleted {
+				return nil, "", nil
+			}
+			return []*chat.Message{
+				chatMessage(inboundMsg, "users/dave", "hi from dave", base),
+				chatMessage(outboundMsg, "users/me", "team update", base.Add(time.Minute)),
+			}, "", nil
+		},
+		// People API CANNOT resolve dave (not in Contacts) → "".
+		ResolvePersonEmail: func(_ context.Context, userName string) (string, error) {
+			if userName == "users/me" {
+				return accountID, nil
+			}
+			return "", nil // users/dave → not in Contacts
+		},
+		// But members.get DOES resolve dave's email to his canonical id.
+		ResolveMemberID: func(_ context.Context, _, normalizedEmail string) (string, bool, error) {
+			if normalizedEmail == daveEmail {
+				return "users/dave", false, nil
+			}
+			return "", true, nil
+		},
+	}
+	p := e.newProvider(t, map[string]struct{}{accountID: {}}, funcs)
+	state, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &accountID)
+	require.NoError(t, err)
+
+	_, err = p.Sync(e.ctx, state, nil)
+	require.NoError(t, err)
+
+	// (a) Inbound row matched to dave via the id path, with the CRM email as peer.
+	inRow, err := e.commsRepo.GetMessage(e.ctx, repository.InteractionSourceGChat, inboundMsg, dave.ID)
+	require.NoError(t, err, "inbound message matched dave via the canonical-id path")
+	assert.Equal(t, repository.InteractionDirectionInbound, inRow.Direction)
+	require.NotNil(t, inRow.PeerNormalized)
+	assert.Equal(t, daveEmail, *inRow.PeerNormalized, "the id-path carries the CRM email as the peer, not an empty value")
+
+	// (b) Outbound fanned out to the id-resolved dave (a co-member, (c)).
+	outRow, err := e.commsRepo.GetMessage(e.ctx, repository.InteractionSourceGChat, outboundMsg, dave.ID)
+	require.NoError(t, err, "outbound fanned out to the id-resolved co-member")
+	assert.Equal(t, repository.InteractionDirectionOutbound, outRow.Direction)
+
+	// (d) The cursor advanced (window proven) AND the global positive cache + the
+	// resolved id are persisted.
+	persisted, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &accountID)
+	require.NoError(t, err)
+	assert.NotEmpty(t, spaceCursorFromMetadata(t, persisted.Metadata, spaceName), "create_cursor advanced")
+	assert.Contains(t, persisted.Metadata, "email_user_ids", "the global positive cache is persisted")
+}
+
+// TestGChatProvider_StaleNegativeClearedOnMembershipChange proves a per-space
+// negative is NOT cursor-safe across an actual membership change. Sweep 1: the
+// known email is not a member (negative written, stamped with the current
+// fingerprint), no message from them, cursor advances. Sweep 2: they joined
+// (fingerprint flips) and sent a new message after the cursor → the message
+// MATCHES (the fingerprint flip invalidated the stale negative before the cursor
+// advanced past the message).
+func TestGChatProvider_StaleNegativeClearedOnMembershipChange(t *testing.T) {
+	e := setupGChatProviderTest(t)
+	suffix := randomSuffix(t)
+
+	daveEmail := "dave-" + suffix + "@example.test"
+	dave := e.newGChatProviderContact(t, "GChat StaleNeg Dave "+suffix, string(repository.ContactMethodEmail), daveEmail)
+
+	spaceName := "spaces/STALENEG-" + suffix
+	joinMsg := spaceName + "/messages/join-" + suffix
+	accountID := "me-" + suffix + "@example.test"
+	e.newGChatSyncState(t, accountID, true, nil)
+	base := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Second)
+
+	var daveJoined bool
+	funcs := google.FakeChatFetcherFuncs{
+		ListSpaces: func(context.Context, string) ([]*chat.Space, string, error) {
+			sp := space(spaceName, "SPACE")
+			// Advance lastActiveTime on sweep 2 so the membership is refetched.
+			if daveJoined {
+				sp.LastActiveTime = chatRFC3339(accelerated.GetCurrentTime())
+			} else {
+				sp.LastActiveTime = chatRFC3339(base)
+			}
+			return []*chat.Space{sp}, "", nil
+		},
+		ListMembers: func(context.Context, string, string) ([]*chat.Membership, string, error) {
+			if daveJoined {
+				return []*chat.Membership{membership("users/dave"), membership("users/me")}, "", nil
+			}
+			return []*chat.Membership{membership("users/me")}, "", nil
+		},
+		ListMessages: func(_ context.Context, _, _ string, showDeleted bool, _ string) ([]*chat.Message, string, error) {
+			if showDeleted || !daveJoined {
+				return nil, "", nil // sweep 1: no messages
+			}
+			return []*chat.Message{chatMessage(joinMsg, "users/dave", "just joined", accelerated.GetCurrentTime().Add(-time.Minute).Truncate(time.Second))}, "", nil
+		},
+		ResolvePersonEmail: func(_ context.Context, userName string) (string, error) {
+			if userName == "users/me" {
+				return accountID, nil
+			}
+			return "", nil
+		},
+		ResolveMemberID: func(_ context.Context, _, normalizedEmail string) (string, bool, error) {
+			// dave only resolves once he has joined.
+			if daveJoined && normalizedEmail == daveEmail {
+				return "users/dave", false, nil
+			}
+			return "", true, nil
+		},
+	}
+	p := e.newProvider(t, map[string]struct{}{accountID: {}}, funcs)
+
+	// Sweep 1: dave absent → negative written, cursor advances.
+	state, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &accountID)
+	require.NoError(t, err)
+	_, err = p.Sync(e.ctx, state, nil)
+	require.NoError(t, err)
+
+	// Sweep 2: dave joined (fingerprint flips) and sent a message after the cursor.
+	daveJoined = true
+	state2, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &accountID)
+	require.NoError(t, err)
+	_, err = p.Sync(e.ctx, state2, nil)
+	require.NoError(t, err)
+
+	// The join message matched — the stale negative did NOT cause a permanent miss.
+	row, err := e.commsRepo.GetMessage(e.ctx, repository.InteractionSourceGChat, joinMsg, dave.ID)
+	require.NoError(t, err, "the message from the newly-joined contact matched (stale negative invalidated by fingerprint flip)")
+	assert.Equal(t, repository.InteractionDirectionInbound, row.Direction)
+}
+
+// TestGChatProvider_GlobalPositiveCachePersistsAndReused proves sweep 1 resolves
+// the email→id once and sweep 2 (a second space, same email) issues ZERO
+// ResolveMemberID calls (the global positive is reused from persisted metadata).
+func TestGChatProvider_GlobalPositiveCachePersistsAndReused(t *testing.T) {
+	e := setupGChatProviderTest(t)
+	suffix := randomSuffix(t)
+
+	daveEmail := "dave-" + suffix + "@example.test"
+	dave := e.newGChatProviderContact(t, "GChat GlobalPos Dave "+suffix, string(repository.ContactMethodEmail), daveEmail)
+
+	spaceA := "spaces/GPA-" + suffix
+	spaceB := "spaces/GPB-" + suffix
+	msgA := spaceA + "/messages/a-" + suffix
+	msgB := spaceB + "/messages/b-" + suffix
+	accountID := "me-" + suffix + "@example.test"
+	e.newGChatSyncState(t, accountID, true, nil)
+	base := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Second)
+
+	resolveIDCalls := 0
+	var showSpaceB bool
+	funcs := google.FakeChatFetcherFuncs{
+		ListSpaces: func(context.Context, string) ([]*chat.Space, string, error) {
+			if showSpaceB {
+				return []*chat.Space{space(spaceB, "SPACE")}, "", nil
+			}
+			return []*chat.Space{space(spaceA, "SPACE")}, "", nil
+		},
+		ListMembers: func(_ context.Context, sp, _ string) ([]*chat.Membership, string, error) {
+			return []*chat.Membership{membership("users/dave"), membership("users/me")}, "", nil
+		},
+		ListMessages: func(_ context.Context, sp, _ string, showDeleted bool, _ string) ([]*chat.Message, string, error) {
+			if showDeleted {
+				return nil, "", nil
+			}
+			if showSpaceB {
+				return []*chat.Message{chatMessage(msgB, "users/dave", "in B", base.Add(time.Minute))}, "", nil
+			}
+			return []*chat.Message{chatMessage(msgA, "users/dave", "in A", base)}, "", nil
+		},
+		ResolvePersonEmail: func(_ context.Context, userName string) (string, error) {
+			if userName == "users/me" {
+				return accountID, nil
+			}
+			return "", nil // dave not in Contacts
+		},
+		ResolveMemberID: func(_ context.Context, _, normalizedEmail string) (string, bool, error) {
+			if normalizedEmail == daveEmail {
+				resolveIDCalls++
+				return "users/dave", false, nil
+			}
+			return "", true, nil
+		},
+	}
+	p := e.newProvider(t, map[string]struct{}{accountID: {}}, funcs)
+
+	// Sweep 1 in space A: resolves dave's id once.
+	state, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &accountID)
+	require.NoError(t, err)
+	_, err = p.Sync(e.ctx, state, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, resolveIDCalls, "sweep 1 resolved the id once")
+	_, err = e.commsRepo.GetMessage(e.ctx, repository.InteractionSourceGChat, msgA, dave.ID)
+	require.NoError(t, err)
+
+	// Sweep 2 in space B (same email): the global positive is reused → ZERO calls.
+	showSpaceB = true
+	state2, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &accountID)
+	require.NoError(t, err)
+	_, err = p.Sync(e.ctx, state2, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, resolveIDCalls, "sweep 2 reused the global positive — no new ResolveMemberID call")
+	_, err = e.commsRepo.GetMessage(e.ctx, repository.InteractionSourceGChat, msgB, dave.ID)
+	require.NoError(t, err, "the same id matched in space B via the global positive")
+}
+
+// TestGChatProvider_DebtHeldCursorAcrossTwoSweeps proves the debt-hold survives
+// the sweep in which membership changed (the round-3 two-sweep hole). The
+// resolve-cap is forced to 0 so the post-change re-resolution CANNOT happen on
+// the change sweep. Sweep B holds the cursor; sweep C (cap restored) drains the
+// debt and matches the message from sweep B's window.
+func TestGChatProvider_DebtHeldCursorAcrossTwoSweeps(t *testing.T) {
+	e := setupGChatProviderTest(t)
+	suffix := randomSuffix(t)
+
+	daveEmail := "dave-" + suffix + "@example.test"
+	dave := e.newGChatProviderContact(t, "GChat Debt Dave "+suffix, string(repository.ContactMethodEmail), daveEmail)
+
+	spaceName := "spaces/DEBT-" + suffix
+	joinMsg := spaceName + "/messages/join-" + suffix
+	accountID := "me-" + suffix + "@example.test"
+	base := accelerated.GetCurrentTime().Add(-2 * time.Hour).Truncate(time.Second)
+
+	// Pre-seed: a space_members entry (dave absent) and a NEGATIVE-VALID negative
+	// for dave stamped with the absent-set fingerprint, plus a create_cursor so
+	// the message (sent after the cursor) is in-window on the change sweep.
+	absentFP := google.MemberSetFingerprintForTest([]string{"users/me"})
+	seededAt := accelerated.GetCurrentTime().Add(-time.Minute).UTC().Format(time.RFC3339Nano)
+	metadata := map[string]any{
+		"space_members": map[string]any{
+			spaceName: map[string]any{"version": chatRFC3339(base), "fetched_at": seededAt, "members": []string{"users/me"}},
+		},
+		"space_cursors": map[string]any{
+			spaceName: map[string]any{"create_cursor": chatRFC3339(base), "edit_cursor": chatRFC3339(base)},
+		},
+		"space_member_negatives": map[string]any{
+			spaceName: map[string]any{daveEmail: map[string]any{"resolved_at": seededAt, "member_set_fingerprint": absentFP}},
+		},
+	}
+	e.newGChatSyncState(t, accountID, true, metadata)
+
+	var daveJoined bool
+	funcs := google.FakeChatFetcherFuncs{
+		ListSpaces: func(context.Context, string) ([]*chat.Space, string, error) {
+			sp := space(spaceName, "SPACE")
+			if daveJoined {
+				sp.LastActiveTime = chatRFC3339(accelerated.GetCurrentTime())
+			} else {
+				sp.LastActiveTime = chatRFC3339(base)
+			}
+			return []*chat.Space{sp}, "", nil
+		},
+		ListMembers: func(context.Context, string, string) ([]*chat.Membership, string, error) {
+			if daveJoined {
+				return []*chat.Membership{membership("users/dave"), membership("users/me")}, "", nil
+			}
+			return []*chat.Membership{membership("users/me")}, "", nil
+		},
+		ListMessages: func(_ context.Context, _, _ string, showDeleted bool, _ string) ([]*chat.Message, string, error) {
+			if showDeleted || !daveJoined {
+				return nil, "", nil
+			}
+			return []*chat.Message{chatMessage(joinMsg, "users/dave", "just joined", accelerated.GetCurrentTime().Add(-30*time.Second).Truncate(time.Second))}, "", nil
+		},
+		ResolvePersonEmail: func(_ context.Context, userName string) (string, error) {
+			if userName == "users/me" {
+				return accountID, nil
+			}
+			return "", nil
+		},
+		ResolveMemberID: func(_ context.Context, _, normalizedEmail string) (string, bool, error) {
+			if daveJoined && normalizedEmail == daveEmail {
+				return "users/dave", false, nil
+			}
+			return "", true, nil
+		},
+	}
+	p := e.newProvider(t, map[string]struct{}{accountID: {}}, funcs)
+
+	cursorBefore := chatRFC3339(base)
+
+	// Sweep B: dave joined (fingerprint flips → negative UNKNOWN), but cap=0 so the
+	// re-resolution is DEFERRED → cursor HELD; the join message is NOT yet matched.
+	p.SetMemberResolveCapForTest(0)
+	daveJoined = true
+	stateB, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &accountID)
+	require.NoError(t, err)
+	_, err = p.Sync(e.ctx, stateB, nil)
+	require.NoError(t, err)
+
+	_, err = e.commsRepo.GetMessage(e.ctx, repository.InteractionSourceGChat, joinMsg, dave.ID)
+	assert.ErrorIs(t, err, db.ErrNotFound, "cap=0 defers the re-resolution; the message is not yet matched")
+
+	persistedB, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &accountID)
+	require.NoError(t, err)
+	assert.Equal(t, cursorBefore, spaceCursorFromMetadata(t, persistedB.Metadata, spaceName),
+		"the cursor is HELD on the change sweep (not advanced past the unmatched message)")
+
+	// Sweep C: cap restored → the debt drains, the held message matches, cursor
+	// advances. On a transient-flag design sweep C would see no refresh and advance
+	// past the message unmatched — this asserts the durable fingerprint debt model.
+	p.SetMemberResolveCapForTest(50)
+	stateC, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &accountID)
+	require.NoError(t, err)
+	_, err = p.Sync(e.ctx, stateC, nil)
+	require.NoError(t, err)
+
+	row, err := e.commsRepo.GetMessage(e.ctx, repository.InteractionSourceGChat, joinMsg, dave.ID)
+	require.NoError(t, err, "the held message matches once the debt drains (cap restored)")
+	assert.Equal(t, repository.InteractionDirectionInbound, row.Direction)
+	persistedC, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &accountID)
+	require.NoError(t, err)
+	assert.NotEqual(t, cursorBefore, spaceCursorFromMetadata(t, persistedC.Metadata, spaceName), "the cursor advances after the debt drains")
+}
+
+// TestGChatProvider_HotSpaceNoStarvation proves the round-4 starvation fix: a
+// space with a known-absent contact (negative written) and an UNCHANGED member
+// set across many sweeps — each adding a new message from a DIFFERENT known
+// member so lastActiveTime advances (membership refetches) but the member SET is
+// identical (fingerprint stable). The cursor advances every sweep and ZERO
+// ResolveMemberID calls fire for the absent contact after the first.
+func TestGChatProvider_HotSpaceNoStarvation(t *testing.T) {
+	e := setupGChatProviderTest(t)
+	suffix := randomSuffix(t)
+
+	absentEmail := "absent-" + suffix + "@example.test"
+	e.newGChatProviderContact(t, "GChat Hot Absent "+suffix, string(repository.ContactMethodEmail), absentEmail)
+	activeEmail := "active-" + suffix + "@example.test"
+	active := e.newGChatProviderContact(t, "GChat Hot Active "+suffix, string(repository.ContactMethodEmail), activeEmail)
+
+	spaceName := "spaces/HOT-" + suffix
+	accountID := "me-" + suffix + "@example.test"
+	e.newGChatSyncState(t, accountID, true, nil)
+
+	resolveAbsentCalls := 0
+	sweepIdx := 0
+	funcs := google.FakeChatFetcherFuncs{
+		ListSpaces: func(context.Context, string) ([]*chat.Space, string, error) {
+			sp := space(spaceName, "SPACE")
+			// lastActiveTime advances each sweep (the space is hot) → membership
+			// refetches, but the returned member SET is identical (fingerprint stable).
+			sp.LastActiveTime = chatRFC3339(accelerated.GetCurrentTime().Add(time.Duration(sweepIdx) * time.Minute))
+			return []*chat.Space{sp}, "", nil
+		},
+		ListMembers: func(context.Context, string, string) ([]*chat.Membership, string, error) {
+			// active + me are the stable member set; absent is NOT a member.
+			return []*chat.Membership{membership("users/active"), membership("users/me")}, "", nil
+		},
+		ListMessages: func(_ context.Context, _, _ string, showDeleted bool, _ string) ([]*chat.Message, string, error) {
+			if showDeleted {
+				return nil, "", nil
+			}
+			// A new message from the active member each sweep, strictly after the cursor.
+			at := accelerated.GetCurrentTime().Add(time.Duration(sweepIdx)*time.Minute - time.Hour).Truncate(time.Second)
+			return []*chat.Message{chatMessage(spaceName+"/messages/hot-"+suffix+"-"+strconv.Itoa(sweepIdx), "users/active", "ping", at)}, "", nil
+		},
+		ResolvePersonEmail: func(_ context.Context, userName string) (string, error) {
+			switch userName {
+			case "users/me":
+				return accountID, nil
+			case "users/active":
+				return activeEmail, nil
+			}
+			return "", nil
+		},
+		ResolveMemberID: func(_ context.Context, _, normalizedEmail string) (string, bool, error) {
+			if normalizedEmail == absentEmail {
+				resolveAbsentCalls++
+			}
+			return "", true, nil // absent is never a member; active resolves via the email path
+		},
+	}
+	p := e.newProvider(t, map[string]struct{}{accountID: {}}, funcs)
+
+	var lastCursor string
+	for sweepIdx = 0; sweepIdx < 4; sweepIdx++ {
+		state, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &accountID)
+		require.NoError(t, err)
+		_, err = p.Sync(e.ctx, state, nil)
+		require.NoError(t, err)
+
+		persisted, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &accountID)
+		require.NoError(t, err)
+		cur := spaceCursorFromMetadata(t, persisted.Metadata, spaceName)
+		require.NotEmpty(t, cur, "the cursor must advance every sweep (never held)")
+		if sweepIdx > 0 {
+			assert.NotEqual(t, lastCursor, cur, "the cursor advances each hot sweep — no starvation")
+		}
+		lastCursor = cur
+	}
+
+	// After the first sweep wrote the negative, NO further ResolveMemberID calls
+	// fire for the absent contact — mere activity (stable fingerprint) never
+	// re-incurs debt.
+	assert.Equal(t, 1, resolveAbsentCalls, "the absent contact is resolved once, then never re-resolved across hot sweeps")
+
+	// The active member's messages all matched.
+	rows, err := e.commsRepo.ListByContact(e.ctx, active.ID)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(rows), 4, "every hot-sweep message from the active member matched")
+}
+
+// TestGChatRematch_IDResolutionMatchesHistory extends the rematch scan: the
+// scanned email's People-API resolution is "" but ResolveMemberID yields its id,
+// so the historical message still upserts. Proves the rematch path uses the new
+// id resolution.
+func TestGChatRematch_IDResolutionMatchesHistory(t *testing.T) {
+	e := setupGChatProviderTest(t)
+	suffix := randomSuffix(t)
+
+	daveEmail := "dave-" + suffix + "@example.test"
+	dave := e.newGChatProviderContact(t, "GChat RematchID Dave "+suffix, string(repository.ContactMethodGChat), daveEmail)
+
+	spaceName := "spaces/REMATCHID-" + suffix
+	msgName := spaceName + "/messages/m-" + suffix
+	accountID := "me-" + suffix + "@example.test"
+	e.newGChatSyncState(t, accountID, true, nil)
+	sentAt := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Second)
+
+	funcs := google.FakeChatFetcherFuncs{
+		ListSpaces: func(context.Context, string) ([]*chat.Space, string, error) {
+			return []*chat.Space{space(spaceName, "SPACE")}, "", nil
+		},
+		ListMembers: func(context.Context, string, string) ([]*chat.Membership, string, error) {
+			return []*chat.Membership{membership("users/dave"), membership("users/me")}, "", nil
+		},
+		ListMessages: func(_ context.Context, _, _ string, showDeleted bool, _ string) ([]*chat.Message, string, error) {
+			if showDeleted {
+				return nil, "", nil
+			}
+			return []*chat.Message{chatMessage(msgName, "users/dave", "historical", sentAt)}, "", nil
+		},
+		ResolvePersonEmail: func(_ context.Context, userName string) (string, error) {
+			if userName == "users/me" {
+				return accountID, nil
+			}
+			return "", nil // dave not in Contacts
+		},
+		ResolveMemberID: func(_ context.Context, _, normalizedEmail string) (string, bool, error) {
+			if normalizedEmail == daveEmail {
+				return "users/dave", false, nil
+			}
+			return "", true, nil
+		},
+	}
+	p := e.newProvider(t, map[string]struct{}{accountID: {}}, funcs)
+
+	matched, err := p.ScanIdentifier(e.ctx, accountID, daveEmail, map[string][]uuid.UUID{daveEmail: {dave.ID}}, map[string]struct{}{accountID: {}}, "2026-01-01T00:00:00Z")
+	require.NoError(t, err)
+	assert.Equal(t, 1, matched, "the historical message matched via the id path even though People API returned empty")
+
+	row, err := e.commsRepo.GetMessage(e.ctx, repository.InteractionSourceGChat, msgName, dave.ID)
+	require.NoError(t, err)
+	assert.Equal(t, repository.InteractionDirectionInbound, row.Direction)
+	require.NotNil(t, row.PeerNormalized)
+	assert.Equal(t, daveEmail, *row.PeerNormalized)
 }


### PR DESCRIPTION
## Summary

Adds Contacts-independent contact matching to the merged Google Chat integration. A Chat member/sender (`users/{id}`) is now bridged to a CRM contact even when that person is **not in the user's Google Contacts** — by resolving the CRM's own on-file email to its canonical `users/{id}` and matching by id, in addition to the existing People-API path.

Backend-only: no new OAuth scope, no migration, no UI, no operator command.

Closes #337.

## Root cause

Before this change, the only member/sender → contact bridge went through `people.Get(people/{id})`. That call reads the caller's **Contacts** graph and returns 404 for anyone not in it, yielding an empty email — so the member/sender was dropped as a bystander and the CRM's own stored email for that person was never reached. In prod, roughly a third of correspondents were unmatchable even when the CRM already had their email on file, and each sweep logged a large `senders_unresolved` count.

The Chat `User`/`Membership` structs never expose an email, so a member's email cannot be read *from* the Chat API. The fix runs the lookup the other direction.

## The fix

- **Reverse resolution.** Resolve each on-file CRM email **to** its canonical `users/{id}` via `members.get` with the email as the membership alias (`spaces/{space}/members/{email}`), under the **already-granted** `chat.memberships.readonly` scope — no re-consent. This reads the space's *membership* graph (space-scoped), not the caller's address book, so it resolves a co-member who is not in Google Contacts. An unrecognized member returns HTTP 400 (or 404), which is treated as a cacheable "not a member of this space" negative; transient/auth/5xx errors propagate and abort the window. The request path (bare-email member resource name) is pinned with an httptest seam test.
- **Match by id, fall back to email.** An inbound sender id in the per-space id index matches the contact directly (carrying the CRM email as the peer identity); outbound fan-out unions email-resolved and id-resolved members (deduped, self-excluded). Senders absent from the index still fall through to the existing People-API path, so every currently-working match keeps working — the id path is purely additive.
- **Cost design.** A **global positive cache** (`email → users/{id}`) is reused across every space (a canonical id is the same person everywhere), so once an email resolves anywhere it costs zero further API calls. Fresh `members.get` resolutions are bounded by a per-sweep cap.
- **Cursor-safety (the hard part).** A per-(space, email) **negative** cache records "this known email is not a member of this space," but is stamped with the space's **member-set fingerprint** (a sha256 of the sorted-unique member id list). A negative is honored only while within TTL *and* its stamped fingerprint matches the space's current one. An actual join/leave flips the fingerprint and forces re-resolution **before** the cursor advances past the new messages (no permanent miss); mere message activity advances `lastActiveTime` but not the fingerprint, so a hot space's negatives are never re-churned (no starvation). A candidate that can't resolve within the per-sweep cap is durable **resolution debt** that holds only that space's cursor until it drains.

The mechanism (400-as-negative, Contacts-independence of the members.get email alias) was **empirically confirmed against the production Google account** before implementation.

## Changes

- `chatFetcher` seam + production `ResolveMemberID` (`members.get` email-alias; 400/404 → cacheable negative, else propagate).
- Global positive cache + per-space fingerprint-stamped negatives, persisted in `external_sync_state.metadata` (read-modify-write of the gchat keys only); pruned on load.
- Reverse `memberIDResolver` with a four-way status (resolved / not-member / cap-deferred / budget-deferred); an issued-but-errored call still consumes both budgets.
- `buildKnownIDIndex` wired into the steady-state sweep and the rematch `ScanIdentifier`; durable debt model holds the cursor; fingerprint-invalidated candidates get priority access to the cap.
- The account's own canonical ids are excluded from the reverse index (enforced, not assumed).
- New member-resolution counters in the completion log line.

## Test plan

- **Unit (DB-free, fake fetcher):** request-path pin (bare-email member name; 400/404 → notMember; 5xx → error); global-positive reuse across spaces; per-space negatives; fingerprint invalidation; cap/budget deferral (incl. errored call still consuming both budgets); order-independent + change-sensitive fingerprint; prune-on-load; id-path inbound match with empty People-API result; outbound fan-out union/dedup/self-exclude; me-id exclusion (both index paths); debt-holds-cursor and activity-does-not-re-incur-debt.
- **Integration (real DB, fake fetcher):** headline not-in-Google-Contacts match (members + inbound peer + outbound fan-out + cursor advance); stale-negative-cleared-on-membership-change; durable two-sweep debt hold (cap forced to 0 on the change sweep, drains on the next); hot-space no-starvation; global-positive persist-and-reuse; rematch id-resolution. All pre-existing gchat integration tests pass unchanged (the `ResolveMemberID` fake defaults to notMember, so the id path is additive).
- `make lint` clean; `make test` green; gchat integration suite green under the `integration_testdb` harness.

## Known limitations

- **Go-forward only.** Pre-existing on-file contacts who are not in Google Contacts pick up only **new** messages via the go-forward sweep. There is no in-PR backfill of their history — that is handled separately by the operator via a cursor reset (deliberate, plan-documented scope boundary).
- **`members.get` 200 with a nil member** is treated as a cacheable negative rather than a hard error. A genuine 200 cannot carry a matchable id with a nil member, and a negative self-heals on the next fingerprint flip; this is preferred over propagating an error that would stall a space's cursor on an unexpected/transient shape.

## Plan

`.ai/log/plan/gchat-userid-resolution-match.md` (local).