### PR TITLE
fix(gchat): never freeze message processing on id-resolution debt

### DIFF
--- a/backend/internal/google/gchat.go
+++ b/backend/internal/google/gchat.go
@@ -731,15 +731,17 @@ func restrictKnownMembers(knownMembers map[string][]uuid.UUID, addr string) map[
 }
 
 // consumeContentWindow pages a space's messages with create_time > cursor,
-// upserts qualifying rows, and returns the new create_cursor. proven is true
-// ONLY when the window was fully paged (next == "") — that is the only case the
-// caller may advance the cursor. When the SHARED sweep budget runs out mid-
-// window (more pages remain), it returns proven=false + the ORIGINAL cursor so
-// the whole window restarts next sweep (advancing maxCreate would risk skipping
-// an un-listed later page whose first message shares maxCreate's timestamp,
-// since the next sweep filters create_time > cursor). On any error it likewise
-// returns the original cursor. budget is the shared remaining-page allowance,
-// decremented per list page.
+// upserts qualifying rows, and returns the new create_cursor advanced to the
+// latest create_time across ALL listed messages (qualifiable or not — a
+// non-qualifiable message is still definitively examined, so the window need not
+// be re-paged for it). proven is true ONLY when the window was fully paged
+// (next == "") — that is the only case the caller may advance the cursor. When
+// the SHARED sweep budget runs out mid-window (more pages remain), it returns
+// proven=false + the ORIGINAL cursor so the whole window restarts next sweep
+// (advancing maxCreate would risk skipping an un-listed later page whose first
+// message shares maxCreate's timestamp, since the next sweep filters
+// create_time > cursor). On any error it likewise returns the original cursor.
+// budget is the shared remaining-page allowance, decremented per list page.
 func (p *GChatSyncProvider) consumeContentWindow(
 	ctx context.Context,
 	fetcher chatFetcher,
@@ -770,19 +772,29 @@ func (p *GChatSyncProvider) consumeContentWindow(
 		}
 		*budget--
 		for _, m := range msgs {
-			if !qualifiableContentMessage(m) {
+			if m == nil {
 				continue
 			}
-			matchErr := p.qualifyAndUpsert(ctx, m, space, knownMembers, knownMap, knownIDs, meIDs, meSet, resolver, accountID, counters)
-			if matchErr != nil {
-				// Transient resolve/upsert error: abort the window, keep the
-				// original cursor (do NOT advance past this message).
-				return createCursor, false, matchErr
+			if qualifiableContentMessage(m) {
+				matchErr := p.qualifyAndUpsert(ctx, m, space, knownMembers, knownMap, knownIDs, meIDs, meSet, resolver, accountID, counters)
+				if matchErr != nil {
+					// Transient resolve/upsert error: abort the window, keep the
+					// original cursor (do NOT advance past this message).
+					return createCursor, false, matchErr
+				}
+				counters.processed++
 			}
-			// Advance by INSTANT comparison, not lexical order, so varying
-			// fractional-second precision can't under-advance the cursor.
+			// Advance the watermark over EVERY listed message, qualifiable or not.
+			// A non-qualifiable message (bot/app sender, tombstone) has still been
+			// definitively examined and will never produce a row, so advancing past
+			// it on a proven window is safe and prevents a no-known-member or
+			// bot-only space from re-paging the same unmatched window every sweep
+			// (which would otherwise hold the cursor and consume shared page budget,
+			// reintroducing starvation). Advance by INSTANT comparison, not lexical
+			// order, so varying fractional-second precision can't under-advance the
+			// cursor. The edit/delete pass keeps its own trailing-lookback cursor, so
+			// advancing here loses no edit/delete coverage.
 			maxCreate = laterChatTime(maxCreate, m.CreateTime)
-			counters.processed++
 		}
 		if next == "" {
 			// Fully paged → the window is proven, advance to maxCreate.

--- a/backend/internal/google/gchat.go
+++ b/backend/internal/google/gchat.go
@@ -40,12 +40,14 @@ const (
 
 	// gchatMaxMemberResolvesPerSync caps the number of FRESH members.get calls a
 	// single sweep may issue across ALL spaces (the reverse email→id resolutions).
-	// 50 is comfortably under quota, amortizes a cold 67-space start over a handful
-	// of 15-min ticks, and is sized to cover a single space's debt re-resolution
-	// set in one sweep. When the cap is hit, remaining UNKNOWN candidates
-	// are left unresolved THIS sweep and HOLD their space's cursor (resolution
-	// debt) until a later tick resolves them. Revisit if prod logs show persistent
-	// spacesHeldByCapOnDebt.
+	// 50 is comfortably under quota and amortizes a cold start over a handful of
+	// 15-min ticks. The cap bounds a BEST-EFFORT background warm-up: when it is
+	// hit, remaining UNKNOWN candidates are left unresolved THIS sweep (resolution
+	// debt) and resolve on a later tick — but this NEVER holds a space's cursor.
+	// Every space still pages its content window and advances its cursor using the
+	// matches already known. A deferred candidate's earlier messages are recovered
+	// by the rematch/backfill path or a manual cursor reset (go-forward by design).
+	// Tracked by spacesWarmupDeferred (observability only).
 	gchatMaxMemberResolvesPerSync = 50
 
 	// gchatMembershipCacheTTL bounds how long a cached space-member list (and a
@@ -458,12 +460,14 @@ func (p *GChatSyncProvider) Sync(
 
 		// Build the reverse (email→id) index: a known contact whose canonical id is
 		// a member of this space matches even when the People API can't resolve them
-		// (not-in-Contacts). This is the cursor-safety boundary — an UNKNOWN
-		// candidate deferred by the cap (blockedByCapOnDebt) HOLDS this space's
-		// cursor, and a page-budget exhaustion (blockedByBudget) is an incomplete
-		// window. Never advance over a window whose id resolution was incomplete.
-		// meIDs (the account's own ids in this space) are excluded so a stray
-		// alias resolving to the account's own id can never enter the index.
+		// (not-in-Contacts). id-resolution is a BEST-EFFORT background warm-up: it
+		// NEVER gates cursor advancement. A page-budget exhaustion (blockedByBudget)
+		// IS an incomplete window (a real API call could not be issued), so it still
+		// stops the sweep. But an UNKNOWN candidate deferred by the per-sweep resolve
+		// cap (blockedByCapOnDebt) does NOT hold the cursor — the space still pages
+		// its content with the members already known. meIDs (the account's own ids in
+		// this space) are excluded so a stray alias resolving to the account's own id
+		// can never enter the index.
 		knownIDs, spaceMeIDs, blockedByBudget, blockedByCapOnDebt, err := buildKnownIDIndex(ctx, space, members, fingerprint, knownMap, meSet, meIDs, idResolver, counters, &budget)
 		if err != nil {
 			logger.Warn().Err(err).Str("source", GChatSourceName).Msg("gchat: id-index resolution failed; skipping space")
@@ -475,21 +479,25 @@ func (p *GChatSyncProvider) Sync(
 			break
 		}
 		if blockedByCapOnDebt {
-			// Resolution debt: an UNKNOWN candidate could not be resolved within the
-			// per-sweep cap. HOLD this space's cursor (do NOT advance over its
-			// messages) but let other debt-free spaces continue this sweep. The debt
-			// is durable (persisted negative fingerprint vs. current member-set
-			// fingerprint), so the hold survives across sweeps until it drains.
-			counters.spacesHeldByCapOnDebt++
-			continue
+			// Id-resolution warm-up is incomplete for this space (the per-sweep
+			// resolve cap deferred an UNKNOWN candidate). This is NOT a reason to hold
+			// the cursor: process the content window with the matches already known
+			// (People-path co-members, inbound senders via knownMap, and
+			// globally-cached positives) and advance. The deferred candidate resolves
+			// on a later sweep; its earlier messages are recovered by the
+			// rematch/backfill path or a manual cursor reset (go-forward by design).
+			// This counter is observability only — it no longer changes any cursor
+			// outcome.
+			counters.spacesWarmupDeferred++
 		}
 
-		isDM := space.SpaceType == gchatSpaceTypeDM
-		if len(knownMembers) == 0 && len(knownIDs) == 0 && !isDM {
-			counters.spacesSkippedNoKnownMember++
-			continue
-		}
-
+		// Every non-incomplete space pages its content window. We deliberately do NOT
+		// skip a space with no currently-known member: classifyMessage matches an
+		// INBOUND sender via knownMap (the email-sender path) INDEPENDENT of current
+		// membership, so a former member who left the space still has matchable
+		// inbound history. consumeContentWindow advances the cursor on a proven
+		// (fully-paged) window or stops the sweep with the cursor unadvanced when the
+		// shared page budget runs out mid-window — unchanged semantics.
 		cur := gcm.cursorFor(space.Name, backfillFloor)
 		newCreateCursor, proven, err := p.consumeContentWindow(ctx, fetcher, space, cur.CreateCursor, knownMembers, knownMap, knownIDs, spaceMeIDs, meSet, resolver, accountID, counters, &budget)
 		if err != nil {
@@ -533,14 +541,13 @@ func (p *GChatSyncProvider) Sync(
 		Int("processed", counters.processed).
 		Int("matched", counters.matched).
 		Int("spaces", len(spaces)).
-		Int("spaces_skipped_no_known_member", counters.spacesSkippedNoKnownMember).
 		Int("senders_unresolved", counters.sendersUnresolved).
 		Int("edits_applied", counters.editsApplied).
 		Int("deletes_applied", counters.deletesApplied).
 		Int("member_ids_resolved", counters.memberIDsResolved).
 		Int("member_resolve_deferred_cap", counters.memberResolveDeferredCap).
 		Int("member_resolve_negatives_written", counters.memberResolveNegativesWritten).
-		Int("spaces_held_by_cap_on_debt", counters.spacesHeldByCapOnDebt).
+		Int("spaces_warmup_deferred", counters.spacesWarmupDeferred).
 		Msg("GChat sync completed")
 
 	return &syncpkg.SyncResult{
@@ -554,17 +561,16 @@ func (p *GChatSyncProvider) Sync(
 // SyncResult item counts (processed/matched → sync_log) and the structured
 // completion log line (the gchat-specific counters).
 type sweepCounters struct {
-	processed                  int
-	matched                    int
-	spacesSkippedNoKnownMember int
-	sendersUnresolved          int
-	editsApplied               int
-	deletesApplied             int
+	processed         int
+	matched           int
+	sendersUnresolved int
+	editsApplied      int
+	deletesApplied    int
 	// Reverse (email→id) resolution observability.
 	memberIDsResolved             int // fresh members.get → id that IS a member of its space
 	memberResolveDeferredCap      int // UNKNOWN candidates deferred this sweep (cap exhausted)
 	memberResolveNegativesWritten int // fresh members.get → not-a-member negatives written
-	spacesHeldByCapOnDebt         int // spaces whose cursor was held because debt couldn't drain within the cap
+	spacesWarmupDeferred          int // spaces whose id-resolution warm-up was deferred by the cap (NON-blocking; the cursor still advances)
 }
 
 // buildKnownMap loads the dual-source (gchat+email) known-contact map:

--- a/backend/internal/google/gchat_helpers.go
+++ b/backend/internal/google/gchat_helpers.go
@@ -254,8 +254,10 @@ type idMatch struct {
 //   - blockedByBudget: a fresh resolution hit the page budget (incomplete window
 //     — the caller must NOT advance the cursor; treat like a partial page).
 //   - blockedByCapOnDebt: an UNKNOWN candidate could not be resolved because the
-//     per-sweep resolve-cap was exhausted (resolution debt — the caller holds
-//     THIS space's cursor until a later sweep drains the debt).
+//     per-sweep resolve-cap was exhausted (resolution debt). This is purely
+//     informational now — it drives the spacesWarmupDeferred observability counter
+//     and NEVER holds the cursor (id-resolution is a best-effort background
+//     warm-up; the caller pages content and advances regardless).
 //
 // Candidate classification under the current fingerprint: POSITIVE (global
 // positive hit whose id ∈ members), NEGATIVE-VALID (per-space negative with a
@@ -272,6 +274,20 @@ type idMatch struct {
 // the account itself, even if a stray non-meSet CRM alias resolves to the
 // account's own id. classifyMessage ALSO guards its inbound id-path with meIDs as
 // a defense-in-depth check at the point of use.
+//
+// Cost bound (lossless): a fresh members.get can only ADD a NEW index entry for a
+// member id that is not ALREADY definitively covered by an id-keyed signal — i.e.
+// a member id that is neither a me-id nor already in the global positive cache.
+// Call that set U_id = members \ (meIDs ∪ positive-cached ids). When U_id is
+// empty, every fresh resolution is a guaranteed not-a-member, so the candidate
+// loop is skipped entirely. Otherwise the loop early-exits once every DISTINCT id
+// in U_id has been attached (a SET, not a count — two known addresses can resolve
+// to the SAME canonical id, so counting raw resolutions would terminate early and
+// drop a still-unmatched member id). U_id deliberately keys ONLY on me-id +
+// positive-cache, NEVER on People-resolution: a member id People resolves to a
+// non-known email can still be a valid CRM contact reachable via a DIFFERENT known
+// gchat/email address (dual-source identity, ListGChatIdentitiesForSync), so it
+// MUST remain a candidate.
 func buildKnownIDIndex(
 	ctx context.Context,
 	space *chat.Space,
@@ -305,6 +321,16 @@ func buildKnownIDIndex(
 	}
 	meIDsOut = meIDs // the (possibly extended) me-id set, for the classify guard
 
+	// coveredIDs is the set of member ids already definitively covered by an
+	// id-keyed signal: a me-id, or an id already in the global positive cache.
+	// These are the ONLY ids a fresh members.get can never newly attach, so
+	// U_id = members \ coveredIDs are the only ids worth resolving for. Seed it from
+	// meIDs and grow it with every positive-cache hit in the seed pass below.
+	coveredIDs := make(map[string]struct{}, len(meIDs))
+	for id := range meIDs {
+		coveredIDs[id] = struct{}{}
+	}
+
 	// Seed from the GLOBAL positive cache: every known email whose cached id is a
 	// member of this space matches with zero API calls. Track which emails are
 	// already matched so they are not re-resolved.
@@ -317,23 +343,52 @@ func buildKnownIDIndex(
 		if !ok {
 			continue
 		}
+		// The cached id is definitively covered whether or not it is a member of THIS
+		// space (it can only be excluded from U_id by being a member, but tracking it
+		// here keeps coveredIDs the exact "id-keyed covered" set).
+		coveredIDs[id] = struct{}{}
 		if _, isMe := meIDs[id]; isMe {
 			continue // the account's own id never enters the reverse index
 		}
 		if _, isMember := memberSet[id]; isMember {
-			knownIDs[id] = idMatch{Email: email, Contacts: contacts}
+			knownIDs[id] = mergeIDMatch(knownIDs[id], email, contacts)
 			seeded[email] = struct{}{}
 		}
+	}
+
+	// U_id: the distinct member ids NOT yet covered by an id-keyed signal. These
+	// are the only ids a fresh resolution could newly attach to a known email.
+	uncovered := make(map[string]struct{}, len(members))
+	for _, id := range members {
+		if _, covered := coveredIDs[id]; !covered {
+			uncovered[id] = struct{}{}
+		}
+	}
+	// Lossless skip: no member id any known email could newly match → every fresh
+	// resolution is a guaranteed not-a-member. Skip the candidate loop entirely
+	// (the zero-API-call positive seed above still applied).
+	if len(uncovered) == 0 {
+		return knownIDs, meIDsOut, blockedByBudget, blockedByCapOnDebt, nil
 	}
 
 	// Classify the remaining candidates and order them so fingerprint-invalidated
 	// (was-NEGATIVE-now-UNKNOWN) candidates get priority access to the cap.
 	priority, normal := classifyIDCandidates(space.Name, fingerprint, knownMap, meSet, seeded, resolver)
 
+	// matchedUncovered tracks the DISTINCT ids in U_id actually attached. Once it
+	// equals U_id, no fresh resolution can add a new member-id entry, so the loop
+	// early-exits (every remaining candidate is a guaranteed not-a-member). A SET,
+	// not a count: dual-source identities can resolve two known addresses to one id.
+	matchedUncovered := make(map[string]struct{}, len(uncovered))
+
 	// Resolve priority candidates first, then never-seen ones (two ranges instead
 	// of a merged slice to avoid a per-call allocation in the hot per-space path).
 	for _, group := range [2][]string{priority, normal} {
 		for _, email := range group {
+			if len(matchedUncovered) == len(uncovered) {
+				// Every uncovered member id is attached → nothing left to resolve.
+				return knownIDs, meIDsOut, blockedByBudget, blockedByCapOnDebt, nil
+			}
 			id, status, rerr := resolver.resolve(ctx, space.Name, fingerprint, email, pageBudget)
 			if rerr != nil {
 				return nil, nil, false, false, rerr
@@ -344,8 +399,11 @@ func buildKnownIDIndex(
 					break // the account's own id never enters the reverse index
 				}
 				if _, isMember := memberSet[id]; isMember {
-					knownIDs[id] = idMatch{Email: email, Contacts: knownMap[email]}
+					knownIDs[id] = mergeIDMatch(knownIDs[id], email, knownMap[email])
 					counters.memberIDsResolved++
+					if _, isUncovered := uncovered[id]; isUncovered {
+						matchedUncovered[id] = struct{}{}
+					}
 				}
 				// A resolved id that is NOT a member of this space is a co-member of
 				// some OTHER space (the positive is global) — not a match here, but the
@@ -362,6 +420,25 @@ func buildKnownIDIndex(
 		}
 	}
 	return knownIDs, meIDsOut, blockedByBudget, blockedByCapOnDebt, nil
+}
+
+// mergeIDMatch folds an additional (email, contacts) seed for one canonical id
+// into the existing index entry, UNIONing the contact ids so all contacts that
+// share a canonical id via the positive-cache / resolve paths are matched (rather
+// than the second writer silently overwriting the first). The Email is kept as
+// the first writer's (the peer identity is any of the equivalent known addresses;
+// they all map to the same person). A nil/zero prev starts a fresh entry.
+func mergeIDMatch(prev idMatch, email string, contacts []uuid.UUID) idMatch {
+	if prev.Email == "" && len(prev.Contacts) == 0 {
+		return idMatch{Email: email, Contacts: append([]uuid.UUID(nil), contacts...)}
+	}
+	out := idMatch{Email: prev.Email, Contacts: prev.Contacts}
+	for _, c := range contacts {
+		if !containsUUID(out.Contacts, c) {
+			out.Contacts = append(out.Contacts, c)
+		}
+	}
+	return out
 }
 
 // mergeMeID returns a new set that is src plus id (copy-on-write so the caller's
@@ -433,13 +510,6 @@ func (p *GChatSyncProvider) SetMeSetForTest(meSet map[string]struct{}) {
 // deterministically. Production code must NOT call this.
 func (p *GChatSyncProvider) SetMemberResolveCapForTest(cap int) {
 	p.memberResolveCapOverride = &cap
-}
-
-// MemberSetFingerprintForTest exposes the member-set fingerprint hash so a
-// cross-package integration test can pre-seed a fingerprint-stamped negative in
-// metadata. Production code must NOT call this.
-func MemberSetFingerprintForTest(members []string) string {
-	return memberSetFingerprint(members)
 }
 
 // FakeChatFetcherFuncs lets a cross-package test supply a fake chatFetcher by
@@ -521,12 +591,11 @@ func (r *CachedEmailResolverForTest) Resolve(ctx context.Context, userName strin
 type SweepCountersForTest struct {
 	Processed                     int
 	Matched                       int
-	SpacesSkippedNoKnownMember    int
 	SendersUnresolved             int
 	EditsApplied                  int
 	DeletesApplied                int
 	MemberIDsResolved             int
 	MemberResolveDeferredCap      int
 	MemberResolveNegativesWritten int
-	SpacesHeldByCapOnDebt         int
+	SpacesWarmupDeferred          int
 }

--- a/backend/internal/google/gchat_helpers.go
+++ b/backend/internal/google/gchat_helpers.go
@@ -343,9 +343,10 @@ func buildKnownIDIndex(
 		if !ok {
 			continue
 		}
-		// The cached id is definitively covered whether or not it is a member of THIS
-		// space (it can only be excluded from U_id by being a member, but tracking it
-		// here keeps coveredIDs the exact "id-keyed covered" set).
+		// The cached id is added to coveredIDs whether or not it is a member of THIS
+		// space; if it is a member, it is thereby excluded from U_id. A non-member
+		// cached id cannot affect U_id (U_id ranges over members), but tracking it
+		// here keeps coveredIDs the exact "id-keyed covered" set.
 		coveredIDs[id] = struct{}{}
 		if _, isMe := meIDs[id]; isMe {
 			continue // the account's own id never enters the reverse index
@@ -387,6 +388,14 @@ func buildKnownIDIndex(
 		for _, email := range group {
 			if len(matchedUncovered) == len(uncovered) {
 				// Every uncovered member id is attached → nothing left to resolve.
+				// Accepted limitation (matches origin/main's last-writer behavior, and
+				// strictly better than it): when the LAST uncovered id is shared by two
+				// DISTINCT contact records reachable via two known addresses, the first
+				// address to resolve completes the set and this exit returns before the
+				// second same-id alias resolves — so only the first contact is attached.
+				// Multi-contact-per-canonical-id fan-out is explicitly out of scope for
+				// this hotfix (a single contact carrying both a gchat and an email value
+				// produces ONE UUID, which mergeIDMatch dedups harmlessly).
 				return knownIDs, meIDsOut, blockedByBudget, blockedByCapOnDebt, nil
 			}
 			id, status, rerr := resolver.resolve(ctx, space.Name, fingerprint, email, pageBudget)
@@ -427,7 +436,9 @@ func buildKnownIDIndex(
 // share a canonical id via the positive-cache / resolve paths are matched (rather
 // than the second writer silently overwriting the first). The Email is kept as
 // the first writer's (the peer identity is any of the equivalent known addresses;
-// they all map to the same person). A nil/zero prev starts a fresh entry.
+// they all map to the same person). The first writer is deterministic: the
+// positive-cache seed pass runs before the resolve loop, and candidates within the
+// loop are resolved in sorted order. A nil/zero prev starts a fresh entry.
 func mergeIDMatch(prev idMatch, email string, contacts []uuid.UUID) idMatch {
 	if prev.Email == "" && len(prev.Contacts) == 0 {
 		return idMatch{Email: email, Contacts: append([]uuid.UUID(nil), contacts...)}

--- a/backend/internal/google/gchat_test.go
+++ b/backend/internal/google/gchat_test.go
@@ -717,15 +717,19 @@ func TestBuildKnownIDIndex_DiscoversMeIDFromCachedPositive(t *testing.T) {
 	assert.Equal(t, 0, calls, "the me-id discovery is cache-only — no fresh members.get")
 }
 
-// TestBuildKnownIDIndex_DebtHoldsCursor drives the resolution-debt model:
+// TestBuildKnownIDIndex_DeferredCapReturnsDebtFlagOnly drives the resolution-debt
+// classification. blockedByCapOnDebt is now PURELY informational (it drives the
+// spacesWarmupDeferred counter and no longer implies any cursor outcome — that is
+// a Sync-level concern, proven in the integration tests). The subtests assert the
+// resolver/index classification only:
 //
 //	(a) a NEGATIVE-VALID candidate is not debt → no resolve, blockedByCapOnDebt=false;
 //	(b) an UNKNOWN candidate (fingerprint-mismatched negative) with the cap
-//	    exhausted → deferredCapHit → blockedByCapOnDebt=true (cursor held), driven
-//	    purely by the persisted-negative-vs-current-fingerprint mismatch (no flag);
+//	    exhausted → deferredCapHit → blockedByCapOnDebt=true, driven purely by the
+//	    persisted-negative-vs-current-fingerprint mismatch (no transient flag);
 //	(c) priority — when the cap admits only N resolves, fingerprint-invalidated
 //	    candidates are resolved before never-seen ones.
-func TestBuildKnownIDIndex_DebtHoldsCursor(t *testing.T) {
+func TestBuildKnownIDIndex_DeferredCapReturnsDebtFlagOnly(t *testing.T) {
 	ctx := context.Background()
 	now := accelerated.GetCurrentTime()
 	fresh := now.Format(chatTimeLayout)
@@ -857,6 +861,170 @@ func TestBuildKnownIDIndex_ActivityDoesNotReincurDebt(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, idx, "users/absent", "a real membership change re-resolves the candidate")
 	assert.Equal(t, 1, calls, "exactly one re-resolve after the membership actually changed")
+}
+
+// TestBuildKnownIDIndex_SkipsResolutionWhenAllMembersCovered proves the lossless
+// skip: when every member id is already covered by an id-keyed signal (a me-id or
+// already in the global positive cache), the candidate-resolution loop is skipped
+// entirely — ZERO members.get calls and ZERO negatives written — because no fresh
+// resolution could ever newly attach to a known email. The index is seeded only
+// from the positive cache. Keyed strictly on id signals (never People-resolution).
+func TestBuildKnownIDIndex_SkipsResolutionWhenAllMembersCovered(t *testing.T) {
+	ctx := context.Background()
+	dave := uuid.New()
+	otherContact := uuid.New()
+	members := []string{"users/dave", "users/other", "users/me"}
+	fp := memberSetFingerprint(members)
+	now := accelerated.GetCurrentTime()
+
+	calls := 0
+	// The fetcher would resolve BOTH known emails if asked — but it must NOT be
+	// asked, because every member id is already covered.
+	fetcher := fakeIDFetcher(map[string]string{
+		"spaces/A|dave@example.test":  "users/dave",
+		"spaces/A|other@example.test": "users/other",
+	}, &calls)
+	// dave + other are already in the global positive cache; users/me is a me-id.
+	pos := map[string]cachedUserID{
+		"dave@example.test":  {UserName: "users/dave", ResolvedAt: now.Format(chatTimeLayout)},
+		"other@example.test": {UserName: "users/other", ResolvedAt: now.Format(chatTimeLayout)},
+	}
+	cap := 10
+	resolver := newMemberIDResolver(fetcher, pos, nil, &cap)
+
+	knownMap := map[string][]uuid.UUID{
+		"dave@example.test":  {dave},
+		"other@example.test": {otherContact},
+	}
+	meSet := map[string]struct{}{"me@example.test": {}}
+	meIDs := map[string]struct{}{"users/me": {}}
+	counters := &sweepCounters{}
+	budget := 10
+	idx, _, blockedBudget, blockedCap, err := buildKnownIDIndex(ctx, &chat.Space{Name: "spaces/A"}, members, fp, knownMap, meSet, meIDs, resolver, counters, &budget)
+	require.NoError(t, err)
+	assert.False(t, blockedBudget)
+	assert.False(t, blockedCap, "no uncovered member id remains → no debt")
+
+	// Both contacts seeded from the positive cache.
+	assert.Equal(t, idMatch{Email: "dave@example.test", Contacts: []uuid.UUID{dave}}, idx["users/dave"])
+	assert.Equal(t, idMatch{Email: "other@example.test", Contacts: []uuid.UUID{otherContact}}, idx["users/other"])
+	assert.Equal(t, 0, calls, "every member id is covered (me-id or positive-cached) → zero members.get calls")
+	assert.Equal(t, 0, counters.memberResolveNegativesWritten, "no negatives written when the loop is skipped")
+	assert.Equal(t, 10, cap, "the resolve cap is untouched")
+}
+
+// TestBuildKnownIDIndex_StopsAfterAllUncoveredMemberIDsMatched proves the
+// SET-based early-exit. U_id contains TWO distinct uncovered member ids, and a
+// DUAL-SOURCE alias maps TWO known addresses to the SAME canonical id. A scalar
+// "count of successful resolutions" would terminate after the alias double-counts
+// (count reaches 2 while only ONE distinct uncovered id is attached), dropping the
+// second distinct member id. The set-based test continues until BOTH distinct
+// uncovered ids are attached, then STOPS (no further members.get).
+func TestBuildKnownIDIndex_StopsAfterAllUncoveredMemberIDsMatched(t *testing.T) {
+	ctx := context.Background()
+	dave := uuid.New()
+	daveAlt := uuid.New()
+	frank := uuid.New()
+	bystander := uuid.New()
+	// Two distinct uncovered member ids: users/dave and users/frank.
+	members := []string{"users/dave", "users/frank", "users/me"}
+	fp := memberSetFingerprint(members)
+
+	calls := 0
+	// Dual-source alias: dave@ and dave-alt@ BOTH resolve to users/dave (same
+	// canonical id reachable from two known addresses). frank@ resolves to
+	// users/frank. zzz-bystander@ resolves to a non-member id and sorts LAST, so it
+	// is the candidate the early-exit must skip once both uncovered ids are matched.
+	// Emails are sorted in classifyIDCandidates, so the resolution order is
+	// deterministic: dave-alt@, dave@, frank@, zzz-bystander@.
+	fetcher := fakeIDFetcher(map[string]string{
+		"spaces/A|dave@example.test":          "users/dave",
+		"spaces/A|dave-alt@example.test":      "users/dave",
+		"spaces/A|frank@example.test":         "users/frank",
+		"spaces/A|zzz-bystander@example.test": "users/elsewhere",
+	}, &calls)
+	cap := 10
+	resolver := newMemberIDResolver(fetcher, nil, nil, &cap)
+
+	knownMap := map[string][]uuid.UUID{
+		"dave@example.test":          {dave},
+		"dave-alt@example.test":      {daveAlt},
+		"frank@example.test":         {frank},
+		"zzz-bystander@example.test": {bystander},
+	}
+	meSet := map[string]struct{}{"me@example.test": {}}
+	// users/me is the account's own member id (covered via meIDs, as
+	// resolveKnownMembers would populate in the real sweep) → not part of U_id.
+	meIDs := map[string]struct{}{"users/me": {}}
+	counters := &sweepCounters{}
+	budget := 10
+	idx, _, blockedBudget, blockedCap, err := buildKnownIDIndex(ctx, &chat.Space{Name: "spaces/A"}, members, fp, knownMap, meSet, meIDs, resolver, counters, &budget)
+	require.NoError(t, err)
+	assert.False(t, blockedBudget)
+	assert.False(t, blockedCap)
+
+	// (b) BOTH distinct uncovered member ids are attached.
+	require.Contains(t, idx, "users/dave", "the first uncovered member id is attached")
+	require.Contains(t, idx, "users/frank", "the second distinct uncovered member id is attached (a scalar count would have stopped before reaching it)")
+	// The dual-source alias unioned both contacts onto the shared id.
+	assert.ElementsMatch(t, []uuid.UUID{dave, daveAlt}, idx["users/dave"].Contacts, "both contacts sharing the canonical id are unioned, not last-writer-wins")
+
+	// (c) Once both uncovered ids matched, the loop STOPPED before zzz-bystander@.
+	// Resolution order: dave-alt@ (→users/dave), dave@ (→users/dave, unioned),
+	// frank@ (→users/frank, second distinct id matched), then the early-exit fires
+	// and zzz-bystander@ is NOT resolved → exactly THREE members.get calls.
+	// Critically, the early-exit did NOT fire after only the dave aliases (a scalar
+	// count==2 bug) — users/frank is present AND zzz-bystander@ was skipped only
+	// AFTER frank, proving the SET semantics.
+	assert.Equal(t, 3, calls, "the loop resolves until both distinct uncovered ids match, then stops before the trailing bystander candidate")
+}
+
+// TestBuildKnownIDIndex_DualSourceIdentityNotLost is the losslessness boundary.
+// A member id (users/dave) whose People-API resolution is a NON-known email
+// (looks like a bystander) is STILL matched, because a DIFFERENT known address
+// resolves (members.get) to that SAME canonical id. The optimization keys U_id on
+// id signals (me-id + positive cache) ONLY, never on People-resolution, so the
+// dual-source identity is never skipped/early-exited out. Built on the
+// ListGChatIdentitiesForSync dual-source shape: one contact with both a gchat and
+// an email value that differ.
+func TestBuildKnownIDIndex_DualSourceIdentityNotLost(t *testing.T) {
+	ctx := context.Background()
+	dave := uuid.New()
+	// users/dave is a member; People would resolve it to dave-people@ (a NON-known
+	// address — not in knownMap). But the contact is reachable via TWO known
+	// addresses (a gchat handle and an email), and the email resolves via
+	// members.get to users/dave.
+	members := []string{"users/dave", "users/me"}
+	fp := memberSetFingerprint(members)
+
+	calls := 0
+	// Only the known email resolves to users/dave; the gchat-handle alias is a
+	// no-member alias here (it would match in a different space). The point: U_id
+	// includes users/dave (People-resolved-to-non-known), so it IS resolved.
+	fetcher := fakeIDFetcher(map[string]string{
+		"spaces/A|dave-email@example.test": "users/dave",
+	}, &calls)
+	cap := 10
+	resolver := newMemberIDResolver(fetcher, nil, nil, &cap)
+
+	// Dual-source: the SAME contact carries both a gchat value and an email value.
+	knownMap := map[string][]uuid.UUID{
+		"dave-gchat@example.test": {dave},
+		"dave-email@example.test": {dave},
+	}
+	meSet := map[string]struct{}{"me@example.test": {}}
+	counters := &sweepCounters{}
+	budget := 10
+	idx, _, blockedBudget, blockedCap, err := buildKnownIDIndex(ctx, &chat.Space{Name: "spaces/A"}, members, fp, knownMap, meSet, nil, resolver, counters, &budget)
+	require.NoError(t, err)
+	assert.False(t, blockedBudget)
+	assert.False(t, blockedCap)
+
+	// users/dave IS in the index — the optimization did NOT skip it on the basis
+	// that People resolves it to a non-known email. The contact matches.
+	require.Contains(t, idx, "users/dave", "a dual-source identity is matched via the alternate known address")
+	assert.Equal(t, []uuid.UUID{dave}, idx["users/dave"].Contacts)
+	assert.GreaterOrEqual(t, calls, 1, "the alternate known address WAS resolved (U_id keys on id signals, not People-resolution)")
 }
 
 func TestMembershipNeedsRefresh(t *testing.T) {

--- a/backend/internal/google/gchat_test.go
+++ b/backend/internal/google/gchat_test.go
@@ -774,7 +774,7 @@ func TestBuildKnownIDIndex_DeferredCapReturnsDebtFlagOnly(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, idx, "the candidate could not resolve this sweep")
 		assert.False(t, blockedBudget)
-		assert.True(t, blockedCap, "the fingerprint mismatch alone makes the candidate UNKNOWN; cap exhaustion holds the cursor (no transient flag)")
+		assert.True(t, blockedCap, "the fingerprint mismatch alone makes the candidate UNKNOWN; cap exhaustion sets the debt flag (informational, no transient flag)")
 		assert.Equal(t, 0, calls, "the cap-exhausted candidate is not fetched")
 	})
 
@@ -803,7 +803,7 @@ func TestBuildKnownIDIndex_DeferredCapReturnsDebtFlagOnly(t *testing.T) {
 		idx, _, _, blockedCap, err := buildKnownIDIndex(ctx, &chat.Space{Name: "spaces/A"}, members, fpNew, knownMap, map[string]struct{}{"me@example.test": {}}, nil, resolver, counters, &budget)
 		require.NoError(t, err)
 		// The invalidated (priority) candidate consumed the single cap slot and
-		// matched; the never-seen one was deferred (debt) → cursor held.
+		// matched; the never-seen one was deferred (debt flag set, informational).
 		assert.Contains(t, idx, "users/invalidated", "the fingerprint-invalidated candidate is resolved first")
 		assert.NotContains(t, idx, "users/neverseen")
 		assert.True(t, blockedCap, "the deferred never-seen candidate is debt")

--- a/backend/internal/google/gchat_test.go
+++ b/backend/internal/google/gchat_test.go
@@ -1309,6 +1309,54 @@ func TestConsumeContentWindow_FullyPagedIsProven(t *testing.T) {
 	assert.Equal(t, msgTime, newCursor, "cursor advances to the max createTime seen")
 }
 
+// TestConsumeContentWindow_NonQualifiableOnlyWindowStillAdvances proves a
+// fully-paged window whose messages are ALL non-qualifiable (bot/app senders,
+// tombstones) STILL advances the cursor to the latest create_time. Without this,
+// a no-known-member or bot-only space would re-page the same unmatched window
+// every sweep, holding its cursor and consuming the shared page budget —
+// reintroducing the starvation this hotfix removed.
+func TestConsumeContentWindow_NonQualifiableOnlyWindowStillAdvances(t *testing.T) {
+	ctx := context.Background()
+	earlier := "2026-06-04T10:00:00Z"
+	latest := "2026-06-04T11:00:00Z"
+	// A bot message (non-HUMAN sender) and a tombstone — both non-qualifiable.
+	botMsg := &chat.Message{
+		Name:       "spaces/B/messages/bot",
+		Sender:     &chat.User{Name: "users/bot", Type: "BOT"},
+		CreateTime: earlier,
+		Text:       "automated notice",
+	}
+	tombstone := &chat.Message{
+		Name:             "spaces/B/messages/gone",
+		Sender:           &chat.User{Name: "users/x", Type: gchatUserTypeHuman},
+		CreateTime:       latest,
+		DeletionMetadata: &chat.DeletionMetadata{},
+	}
+	fetcher := &fakeChatFetcher{funcs: FakeChatFetcherFuncs{
+		ListMessages: func(_ context.Context, _, _ string, _ bool, token string) ([]*chat.Message, string, error) {
+			if token == "" {
+				return []*chat.Message{botMsg, tombstone}, "", nil
+			}
+			return nil, "", nil
+		},
+		ResolvePersonEmail: func(context.Context, string) (string, error) { return "", nil },
+	}}
+	resolver := newCachedEmailResolver(fetcher, nil)
+	// nil commsRepo is safe: no qualifiable message means no upsert is attempted.
+	p := &GChatSyncProvider{commsRepo: nil}
+	counters := &sweepCounters{}
+	budget := 10
+	floor := "2026-01-01T00:00:00Z"
+	newCursor, proven, err := p.consumeContentWindow(ctx, fetcher,
+		&chat.Space{Name: "spaces/B", SpaceType: "SPACE"}, floor,
+		map[string][]uuid.UUID{}, map[string][]uuid.UUID{}, nil, nil, map[string]struct{}{},
+		resolver, "acct", counters, &budget)
+	require.NoError(t, err)
+	assert.True(t, proven, "a fully-paged window is proven even with no qualifiable messages")
+	assert.Equal(t, latest, newCursor, "the cursor advances over non-qualifiable messages to the latest create_time")
+	assert.Equal(t, 0, counters.processed, "no qualifiable message was processed/upserted")
+}
+
 // TestConsumeContentWindow_CursorAdvancesByInstantNotLexical proves the cursor
 // advances to the chronologically-latest createTime even when an EARLIER-listed
 // message has a HIGHER fractional-second precision than a same-second

--- a/backend/tests/gchat_provider_integration_test.go
+++ b/backend/tests/gchat_provider_integration_test.go
@@ -1082,10 +1082,11 @@ func TestGChatProvider_GlobalPositiveCachePersistsAndReused(t *testing.T) {
 // TestGChatProvider_ColdStartProcessesAndAdvancesDespiteResolveDebt is the
 // HEADLINE REGRESSION for the incident. Multiple spaces, the resolve-cap forced to
 // 0 so id-resolution is DEFERRED for every space. Each space has a message from a
-// People-RESOLVABLE known member (the pre-#411 working path). Asserts: every
-// space's message is processed AND matched (no freeze), every space's cursor
-// advances, and the result counts are non-zero — the exact prod failure
-// (processed=0 with all spaces held) turned into a passing assertion.
+// member the People API CAN resolve (the email-path match, which does not depend
+// on id-resolution). Asserts: every space's message is processed AND matched (no
+// freeze), every space's cursor advances, and the result counts are non-zero — the
+// exact prod failure (processed=0 with all spaces held) turned into a passing
+// assertion.
 func TestGChatProvider_ColdStartProcessesAndAdvancesDespiteResolveDebt(t *testing.T) {
 	e := setupGChatProviderTest(t)
 	suffix := randomSuffix(t)

--- a/backend/tests/gchat_provider_integration_test.go
+++ b/backend/tests/gchat_provider_integration_test.go
@@ -1079,46 +1079,122 @@ func TestGChatProvider_GlobalPositiveCachePersistsAndReused(t *testing.T) {
 	require.NoError(t, err, "the same id matched in space B via the global positive")
 }
 
-// TestGChatProvider_DebtHeldCursorAcrossTwoSweeps proves the debt-hold survives
-// the sweep in which membership changed (the two-sweep hole). The
-// resolve-cap is forced to 0 so the post-change re-resolution CANNOT happen on
-// the change sweep. Sweep B holds the cursor; sweep C (cap restored) drains the
-// debt and matches the message from sweep B's window.
-func TestGChatProvider_DebtHeldCursorAcrossTwoSweeps(t *testing.T) {
+// TestGChatProvider_ColdStartProcessesAndAdvancesDespiteResolveDebt is the
+// HEADLINE REGRESSION for the incident. Multiple spaces, the resolve-cap forced to
+// 0 so id-resolution is DEFERRED for every space. Each space has a message from a
+// People-RESOLVABLE known member (the pre-#411 working path). Asserts: every
+// space's message is processed AND matched (no freeze), every space's cursor
+// advances, and the result counts are non-zero — the exact prod failure
+// (processed=0 with all spaces held) turned into a passing assertion.
+func TestGChatProvider_ColdStartProcessesAndAdvancesDespiteResolveDebt(t *testing.T) {
 	e := setupGChatProviderTest(t)
 	suffix := randomSuffix(t)
 
+	aliceEmail := "alice-" + suffix + "@example.test"
+	alice := e.newGChatProviderContact(t, "GChat ColdStart Alice "+suffix, string(repository.ContactMethodEmail), aliceEmail)
+	// A second known contact whose id is NOT in Contacts (would need members.get) —
+	// deferred by cap=0, but must NOT hold any cursor.
 	daveEmail := "dave-" + suffix + "@example.test"
-	dave := e.newGChatProviderContact(t, "GChat Debt Dave "+suffix, string(repository.ContactMethodEmail), daveEmail)
+	e.newGChatProviderContact(t, "GChat ColdStart Dave "+suffix, string(repository.ContactMethodEmail), daveEmail)
 
-	spaceName := "spaces/DEBT-" + suffix
-	joinMsg := spaceName + "/messages/join-" + suffix
+	spaceA := "spaces/COLDA-" + suffix
+	spaceB := "spaces/COLDB-" + suffix
+	msgA := spaceA + "/messages/a-" + suffix
+	msgB := spaceB + "/messages/b-" + suffix
 	accountID := "me-" + suffix + "@example.test"
-	base := accelerated.GetCurrentTime().Add(-2 * time.Hour).Truncate(time.Second)
+	e.newGChatSyncState(t, accountID, true, nil)
+	base := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Second)
 
-	// Pre-seed: a space_members entry (dave absent) and a NEGATIVE-VALID negative
-	// for dave stamped with the absent-set fingerprint, plus a create_cursor so
-	// the message (sent after the cursor) is in-window on the change sweep.
-	absentFP := google.MemberSetFingerprintForTest([]string{"users/me"})
-	seededAt := accelerated.GetCurrentTime().Add(-time.Minute).UTC().Format(time.RFC3339Nano)
-	metadata := map[string]any{
-		"space_members": map[string]any{
-			spaceName: map[string]any{"version": chatRFC3339(base), "fetched_at": seededAt, "members": []string{"users/me"}},
+	funcs := google.FakeChatFetcherFuncs{
+		ListSpaces: func(context.Context, string) ([]*chat.Space, string, error) {
+			return []*chat.Space{space(spaceA, "SPACE"), space(spaceB, "SPACE")}, "", nil
 		},
-		"space_cursors": map[string]any{
-			spaceName: map[string]any{"create_cursor": chatRFC3339(base), "edit_cursor": chatRFC3339(base)},
+		ListMembers: func(_ context.Context, spaceName, _ string) ([]*chat.Membership, string, error) {
+			// Both spaces include alice (People-resolvable), dave (needs members.get),
+			// and me.
+			return []*chat.Membership{membership("users/alice"), membership("users/dave"), membership("users/me")}, "", nil
 		},
-		"space_member_negatives": map[string]any{
-			spaceName: map[string]any{daveEmail: map[string]any{"resolved_at": seededAt, "member_set_fingerprint": absentFP}},
+		ListMessages: func(_ context.Context, spaceName, _ string, showDeleted bool, _ string) ([]*chat.Message, string, error) {
+			if showDeleted {
+				return nil, "", nil
+			}
+			switch spaceName {
+			case spaceA:
+				return []*chat.Message{chatMessage(msgA, "users/alice", "hi from A", base)}, "", nil
+			case spaceB:
+				return []*chat.Message{chatMessage(msgB, "users/alice", "hi from B", base.Add(time.Minute))}, "", nil
+			}
+			return nil, "", nil
+		},
+		ResolvePersonEmail: func(_ context.Context, userName string) (string, error) {
+			switch userName {
+			case "users/me":
+				return accountID, nil
+			case "users/alice":
+				return aliceEmail, nil
+			}
+			return "", nil // users/dave is NOT in Contacts (id path would be needed)
+		},
+		// dave WOULD resolve via members.get, but cap=0 defers it every space.
+		ResolveMemberID: func(_ context.Context, _, normalizedEmail string) (string, bool, error) {
+			if normalizedEmail == daveEmail {
+				return "users/dave", false, nil
+			}
+			return "", true, nil
 		},
 	}
-	e.newGChatSyncState(t, accountID, true, metadata)
+	p := e.newProvider(t, map[string]struct{}{accountID: {}}, funcs)
+	// Cap=0: id-resolution is deferred for EVERY space (the prod stampede).
+	p.SetMemberResolveCapForTest(0)
 
-	var daveJoined bool
+	state, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &accountID)
+	require.NoError(t, err)
+	result, err := p.Sync(e.ctx, state, nil)
+	require.NoError(t, err)
+
+	// (a) EVERY space's message processed AND matched despite the resolve debt.
+	assert.Positive(t, result.ItemsProcessed, "messages are processed even with the resolve cap at 0 (no freeze)")
+	assert.Positive(t, result.ItemsMatched, "messages are matched via the People path even with the resolve cap at 0")
+	rowA, err := e.commsRepo.GetMessage(e.ctx, repository.InteractionSourceGChat, msgA, alice.ID)
+	require.NoError(t, err, "space A's message matched the People-resolvable member despite deferred id-resolution")
+	assert.Equal(t, repository.InteractionDirectionInbound, rowA.Direction)
+	_, err = e.commsRepo.GetMessage(e.ctx, repository.InteractionSourceGChat, msgB, alice.ID)
+	require.NoError(t, err, "space B's message matched too — the cap deferral on space A did NOT freeze space B")
+
+	// (b) BOTH spaces' cursors advanced (no space held by the resolve debt).
+	persisted, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &accountID)
+	require.NoError(t, err)
+	assert.NotEmpty(t, spaceCursorFromMetadata(t, persisted.Metadata, spaceA), "space A's cursor advanced")
+	assert.NotEmpty(t, spaceCursorFromMetadata(t, persisted.Metadata, spaceB), "space B's cursor advanced")
+}
+
+// TestGChatProvider_DeferredIDContactMatchesOnLaterSweep proves the go-forward
+// backfill semantics. Sweep 1 (cap=0): a not-in-Contacts contact's id is NOT
+// resolved, so their message is NOT matched — BUT the space cursor STILL advances
+// and a People-resolvable co-member's message DOES match. Sweep 2 (cap raised): a
+// NEW message from the now-resolvable contact, sent after the cursor, matches.
+func TestGChatProvider_DeferredIDContactMatchesOnLaterSweep(t *testing.T) {
+	e := setupGChatProviderTest(t)
+	suffix := randomSuffix(t)
+
+	aliceEmail := "alice-" + suffix + "@example.test"
+	alice := e.newGChatProviderContact(t, "GChat Deferred Alice "+suffix, string(repository.ContactMethodEmail), aliceEmail)
+	daveEmail := "dave-" + suffix + "@example.test"
+	dave := e.newGChatProviderContact(t, "GChat Deferred Dave "+suffix, string(repository.ContactMethodEmail), daveEmail)
+
+	spaceName := "spaces/DEFER-" + suffix
+	aliceMsg := spaceName + "/messages/alice-" + suffix
+	daveMsg1 := spaceName + "/messages/dave1-" + suffix
+	daveMsg2 := spaceName + "/messages/dave2-" + suffix
+	accountID := "me-" + suffix + "@example.test"
+	e.newGChatSyncState(t, accountID, true, nil)
+	base := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Second)
+
+	var sweep2 bool
 	funcs := google.FakeChatFetcherFuncs{
 		ListSpaces: func(context.Context, string) ([]*chat.Space, string, error) {
 			sp := space(spaceName, "SPACE")
-			if daveJoined {
+			if sweep2 {
 				sp.LastActiveTime = chatRFC3339(accelerated.GetCurrentTime())
 			} else {
 				sp.LastActiveTime = chatRFC3339(base)
@@ -1126,25 +1202,33 @@ func TestGChatProvider_DebtHeldCursorAcrossTwoSweeps(t *testing.T) {
 			return []*chat.Space{sp}, "", nil
 		},
 		ListMembers: func(context.Context, string, string) ([]*chat.Membership, string, error) {
-			if daveJoined {
-				return []*chat.Membership{membership("users/dave"), membership("users/me")}, "", nil
-			}
-			return []*chat.Membership{membership("users/me")}, "", nil
+			return []*chat.Membership{membership("users/alice"), membership("users/dave"), membership("users/me")}, "", nil
 		},
 		ListMessages: func(_ context.Context, _, _ string, showDeleted bool, _ string) ([]*chat.Message, string, error) {
-			if showDeleted || !daveJoined {
+			if showDeleted {
 				return nil, "", nil
 			}
-			return []*chat.Message{chatMessage(joinMsg, "users/dave", "just joined", accelerated.GetCurrentTime().Add(-30*time.Second).Truncate(time.Second))}, "", nil
+			if sweep2 {
+				// A NEW message from dave, sent after sweep-1's cursor.
+				return []*chat.Message{chatMessage(daveMsg2, "users/dave", "dave after warm-up", accelerated.GetCurrentTime().Add(-time.Minute).Truncate(time.Second))}, "", nil
+			}
+			// Sweep 1: alice (People-resolvable) and dave (id deferred by cap=0).
+			return []*chat.Message{
+				chatMessage(aliceMsg, "users/alice", "alice hi", base),
+				chatMessage(daveMsg1, "users/dave", "dave before warm-up", base.Add(time.Minute)),
+			}, "", nil
 		},
 		ResolvePersonEmail: func(_ context.Context, userName string) (string, error) {
-			if userName == "users/me" {
+			switch userName {
+			case "users/me":
 				return accountID, nil
+			case "users/alice":
+				return aliceEmail, nil
 			}
-			return "", nil
+			return "", nil // dave not in Contacts
 		},
 		ResolveMemberID: func(_ context.Context, _, normalizedEmail string) (string, bool, error) {
-			if daveJoined && normalizedEmail == daveEmail {
+			if normalizedEmail == daveEmail {
 				return "users/dave", false, nil
 			}
 			return "", true, nil
@@ -1152,40 +1236,299 @@ func TestGChatProvider_DebtHeldCursorAcrossTwoSweeps(t *testing.T) {
 	}
 	p := e.newProvider(t, map[string]struct{}{accountID: {}}, funcs)
 
-	cursorBefore := chatRFC3339(base)
-
-	// Sweep B: dave joined (fingerprint flips → negative UNKNOWN), but cap=0 so the
-	// re-resolution is DEFERRED → cursor HELD; the join message is NOT yet matched.
+	// Sweep 1: cap=0 → dave's id is deferred.
 	p.SetMemberResolveCapForTest(0)
-	daveJoined = true
-	stateB, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &accountID)
+	state1, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &accountID)
 	require.NoError(t, err)
-	_, err = p.Sync(e.ctx, stateB, nil)
+	_, err = p.Sync(e.ctx, state1, nil)
 	require.NoError(t, err)
 
-	_, err = e.commsRepo.GetMessage(e.ctx, repository.InteractionSourceGChat, joinMsg, dave.ID)
-	assert.ErrorIs(t, err, db.ErrNotFound, "cap=0 defers the re-resolution; the message is not yet matched")
-
-	persistedB, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &accountID)
+	// alice matched (People path); dave NOT matched (id deferred); cursor advanced.
+	_, err = e.commsRepo.GetMessage(e.ctx, repository.InteractionSourceGChat, aliceMsg, alice.ID)
+	require.NoError(t, err, "the People-resolvable co-member matched on sweep 1")
+	_, err = e.commsRepo.GetMessage(e.ctx, repository.InteractionSourceGChat, daveMsg1, dave.ID)
+	assert.ErrorIs(t, err, db.ErrNotFound, "dave's sweep-1 message is NOT matched (id deferred by cap=0) — go-forward gap")
+	persisted1, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &accountID)
 	require.NoError(t, err)
-	assert.Equal(t, cursorBefore, spaceCursorFromMetadata(t, persistedB.Metadata, spaceName),
-		"the cursor is HELD on the change sweep (not advanced past the unmatched message)")
+	cursor1 := spaceCursorFromMetadata(t, persisted1.Metadata, spaceName)
+	require.NotEmpty(t, cursor1, "the cursor ADVANCED on sweep 1 despite the deferred id (no freeze)")
 
-	// Sweep C: cap restored → the debt drains, the held message matches, cursor
-	// advances. On a transient-flag design sweep C would see no refresh and advance
-	// past the message unmatched — this asserts the durable fingerprint debt model.
+	// Sweep 2: cap raised → dave's id resolves; a new message from him matches.
+	sweep2 = true
 	p.SetMemberResolveCapForTest(50)
-	stateC, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &accountID)
+	state2, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &accountID)
 	require.NoError(t, err)
-	_, err = p.Sync(e.ctx, stateC, nil)
+	_, err = p.Sync(e.ctx, state2, nil)
 	require.NoError(t, err)
 
-	row, err := e.commsRepo.GetMessage(e.ctx, repository.InteractionSourceGChat, joinMsg, dave.ID)
-	require.NoError(t, err, "the held message matches once the debt drains (cap restored)")
+	row, err := e.commsRepo.GetMessage(e.ctx, repository.InteractionSourceGChat, daveMsg2, dave.ID)
+	require.NoError(t, err, "dave's NEW message matches once his id warms up (go-forward)")
 	assert.Equal(t, repository.InteractionDirectionInbound, row.Direction)
-	persistedC, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &accountID)
+}
+
+// TestGChatProvider_NoCurrentMemberSpaceStillPagesAndAdvances proves the
+// freeze + former-member correctness fix. A space whose CURRENT membership has NO
+// known CRM contact (the contact LEFT) but whose history contains an INBOUND
+// message from a known contact (sender email ∈ knownMap, matched via the People
+// email-sender path INDEPENDENT of current membership). Asserts the space pages
+// content, the former-member's message MATCHES, and the cursor ADVANCES. A second
+// space whose only known participant is a DEFERRED not-in-Contacts contact (cap=0,
+// no known inbound sender) STILL advances its cursor (window pages to zero
+// matchable rows and proven advances it).
+func TestGChatProvider_NoCurrentMemberSpaceStillPagesAndAdvances(t *testing.T) {
+	e := setupGChatProviderTest(t)
+	suffix := randomSuffix(t)
+
+	// Former member: a known contact who LEFT the space but has inbound history.
+	formerEmail := "former-" + suffix + "@example.test"
+	former := e.newGChatProviderContact(t, "GChat Former "+suffix, string(repository.ContactMethodEmail), formerEmail)
+	// Deferred contact for the second space (id never resolves under cap=0).
+	deferredEmail := "deferred-" + suffix + "@example.test"
+	deferred := e.newGChatProviderContact(t, "GChat DeferredOnly "+suffix, string(repository.ContactMethodEmail), deferredEmail)
+
+	formerSpace := "spaces/FORMER-" + suffix
+	formerMsg := formerSpace + "/messages/former-" + suffix
+	deferredSpace := "spaces/DEFERREDONLY-" + suffix
+	accountID := "me-" + suffix + "@example.test"
+	e.newGChatSyncState(t, accountID, true, nil)
+	base := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Second)
+
+	funcs := google.FakeChatFetcherFuncs{
+		ListSpaces: func(context.Context, string) ([]*chat.Space, string, error) {
+			return []*chat.Space{space(formerSpace, "SPACE"), space(deferredSpace, "SPACE")}, "", nil
+		},
+		ListMembers: func(_ context.Context, spaceName, _ string) ([]*chat.Membership, string, error) {
+			// Neither space currently has a known CRM contact as a member: the former
+			// space has only "me"; the deferred space has "me" + a member whose id
+			// would only resolve via members.get (deferred by cap=0).
+			if spaceName == deferredSpace {
+				return []*chat.Membership{membership("users/deferred"), membership("users/me")}, "", nil
+			}
+			return []*chat.Membership{membership("users/me")}, "", nil
+		},
+		ListMessages: func(_ context.Context, spaceName, _ string, showDeleted bool, _ string) ([]*chat.Message, string, error) {
+			if showDeleted {
+				return nil, "", nil
+			}
+			if spaceName == formerSpace {
+				// An INBOUND message from the former member (still in history).
+				return []*chat.Message{chatMessage(formerMsg, "users/former", "i left but said this", base)}, "", nil
+			}
+			return nil, "", nil // deferred space: no matchable rows this sweep
+		},
+		// The former member's SENDER id resolves to their email via People (the
+		// email-sender path, independent of current membership). deferred + me too.
+		ResolvePersonEmail: func(_ context.Context, userName string) (string, error) {
+			switch userName {
+			case "users/me":
+				return accountID, nil
+			case "users/former":
+				return formerEmail, nil
+			}
+			return "", nil // users/deferred not in Contacts
+		},
+		ResolveMemberID: func(_ context.Context, _, normalizedEmail string) (string, bool, error) {
+			if normalizedEmail == deferredEmail {
+				return "users/deferred", false, nil
+			}
+			return "", true, nil
+		},
+	}
+	p := e.newProvider(t, map[string]struct{}{accountID: {}}, funcs)
+	// cap=0 so the deferred space's only known participant is never id-resolved.
+	p.SetMemberResolveCapForTest(0)
+
+	state, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &accountID)
 	require.NoError(t, err)
-	assert.NotEqual(t, cursorBefore, spaceCursorFromMetadata(t, persistedC.Metadata, spaceName), "the cursor advances after the debt drains")
+	result, err := p.Sync(e.ctx, state, nil)
+	require.NoError(t, err)
+
+	// (a) The former member's inbound message is matched (a watermark-skip shortcut
+	// would have dropped it). (c) ItemsMatched > 0 for this space.
+	row, err := e.commsRepo.GetMessage(e.ctx, repository.InteractionSourceGChat, formerMsg, former.ID)
+	require.NoError(t, err, "the former member's inbound message matched via the email-sender path despite no current membership")
+	assert.Equal(t, repository.InteractionDirectionInbound, row.Direction)
+	assert.Positive(t, result.ItemsMatched, "the former-member match counts")
+
+	// (b) Both spaces' cursors advanced (no freeze on the no-current-member spaces).
+	persisted, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &accountID)
+	require.NoError(t, err)
+	assert.NotEmpty(t, spaceCursorFromMetadata(t, persisted.Metadata, formerSpace), "the former-member space's cursor advanced")
+	assert.NotEmpty(t, spaceCursorFromMetadata(t, persisted.Metadata, deferredSpace), "the deferred-only space's cursor advanced (window paged to zero matchable rows)")
+
+	// The deferred contact has no row this sweep (go-forward), but caused no freeze.
+	rows, err := e.commsRepo.ListByContact(e.ctx, deferred.ID)
+	require.NoError(t, err)
+	assert.Empty(t, rows, "the deferred contact is not matched this sweep (go-forward), but did not hold any cursor")
+}
+
+// TestGChatProvider_ColdStartFrontSpaceDoesNotStarveLaterSpaces proves the budget
+// amortization. Several spaces in stable ListSpaces order; the FRONT one has a
+// multi-page history that pages fully (proven, cursor advances) within budget,
+// leaving budget for later spaces. Asserts the front space advances AND a later
+// space is also processed in the same sweep (forward progress, no starvation).
+func TestGChatProvider_ColdStartFrontSpaceDoesNotStarveLaterSpaces(t *testing.T) {
+	e := setupGChatProviderTest(t)
+	suffix := randomSuffix(t)
+
+	aliceEmail := "alice-" + suffix + "@example.test"
+	alice := e.newGChatProviderContact(t, "GChat Starve Alice "+suffix, string(repository.ContactMethodEmail), aliceEmail)
+
+	frontSpace := "spaces/FRONT-" + suffix
+	laterSpace := "spaces/LATER-" + suffix
+	laterMsg := laterSpace + "/messages/later-" + suffix
+	accountID := "me-" + suffix + "@example.test"
+	e.newGChatSyncState(t, accountID, true, nil)
+	base := accelerated.GetCurrentTime().Add(-3 * time.Hour).Truncate(time.Second)
+
+	funcs := google.FakeChatFetcherFuncs{
+		ListSpaces: func(context.Context, string) ([]*chat.Space, string, error) {
+			// Stable order: the front space first, the later space second.
+			return []*chat.Space{space(frontSpace, "SPACE"), space(laterSpace, "SPACE")}, "", nil
+		},
+		ListMembers: func(context.Context, string, string) ([]*chat.Membership, string, error) {
+			return []*chat.Membership{membership("users/alice"), membership("users/me")}, "", nil
+		},
+		ListMessages: func(_ context.Context, spaceName, _ string, showDeleted bool, token string) ([]*chat.Message, string, error) {
+			if showDeleted {
+				return nil, "", nil
+			}
+			if spaceName == frontSpace {
+				// A multi-page history for the front space (three pages).
+				switch token {
+				case "":
+					return []*chat.Message{chatMessage(frontSpace+"/messages/f1-"+suffix, "users/alice", "f1", base)}, "fp2", nil
+				case "fp2":
+					return []*chat.Message{chatMessage(frontSpace+"/messages/f2-"+suffix, "users/alice", "f2", base.Add(time.Minute))}, "fp3", nil
+				case "fp3":
+					return []*chat.Message{chatMessage(frontSpace+"/messages/f3-"+suffix, "users/alice", "f3", base.Add(2*time.Minute))}, "", nil
+				}
+				return nil, "", nil
+			}
+			// The later space: a single page.
+			return []*chat.Message{chatMessage(laterMsg, "users/alice", "later", base.Add(time.Hour))}, "", nil
+		},
+		ResolvePersonEmail: func(_ context.Context, userName string) (string, error) {
+			switch userName {
+			case "users/me":
+				return accountID, nil
+			case "users/alice":
+				return aliceEmail, nil
+			}
+			return "", nil
+		},
+	}
+	p := e.newProvider(t, map[string]struct{}{accountID: {}}, funcs)
+
+	state, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &accountID)
+	require.NoError(t, err)
+	_, err = p.Sync(e.ctx, state, nil)
+	require.NoError(t, err)
+
+	// The front space paged fully and advanced; the later space was ALSO processed
+	// in the same sweep — the front space's multi-page window did not starve it.
+	persisted, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &accountID)
+	require.NoError(t, err)
+	assert.NotEmpty(t, spaceCursorFromMetadata(t, persisted.Metadata, frontSpace), "the front space advanced (fully paged)")
+	assert.NotEmpty(t, spaceCursorFromMetadata(t, persisted.Metadata, laterSpace), "the later space was reached in the same sweep — no starvation")
+	_, err = e.commsRepo.GetMessage(e.ctx, repository.InteractionSourceGChat, laterMsg, alice.ID)
+	require.NoError(t, err, "the later space's message was processed despite the front space's multi-page history")
+}
+
+// TestGChatProvider_NoDoubleProcessOnReResolve proves idempotency: a message
+// processed on sweep 1 via the People path is re-listed on sweep 2 (cursor reset)
+// and now ALSO id-resolves the sender — but the upsert dedup yields exactly ONE
+// row per contact, no duplicate. Guards the "process with partial index now,
+// fuller later" safety claim.
+func TestGChatProvider_NoDoubleProcessOnReResolve(t *testing.T) {
+	e := setupGChatProviderTest(t)
+	suffix := randomSuffix(t)
+
+	daveEmail := "dave-" + suffix + "@example.test"
+	dave := e.newGChatProviderContact(t, "GChat NoDouble Dave "+suffix, string(repository.ContactMethodEmail), daveEmail)
+
+	spaceName := "spaces/NODOUBLE-" + suffix
+	msgName := spaceName + "/messages/m-" + suffix
+	accountID := "me-" + suffix + "@example.test"
+	base := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Second)
+
+	var davePeopleResolvable = true
+	funcs := google.FakeChatFetcherFuncs{
+		ListSpaces: func(context.Context, string) ([]*chat.Space, string, error) {
+			return []*chat.Space{space(spaceName, "SPACE")}, "", nil
+		},
+		ListMembers: func(context.Context, string, string) ([]*chat.Membership, string, error) {
+			return []*chat.Membership{membership("users/dave"), membership("users/me")}, "", nil
+		},
+		ListMessages: func(_ context.Context, _, _ string, showDeleted bool, _ string) ([]*chat.Message, string, error) {
+			if showDeleted {
+				return nil, "", nil
+			}
+			// The SAME message is returned on both sweeps (sweep 2 re-lists it via the
+			// reset cursor below).
+			return []*chat.Message{chatMessage(msgName, "users/dave", "hello", base)}, "", nil
+		},
+		ResolvePersonEmail: func(_ context.Context, userName string) (string, error) {
+			if userName == "users/me" {
+				return accountID, nil
+			}
+			if userName == "users/dave" && davePeopleResolvable {
+				return daveEmail, nil // sweep 1: matched via the People path
+			}
+			return "", nil
+		},
+		ResolveMemberID: func(_ context.Context, _, normalizedEmail string) (string, bool, error) {
+			// On sweep 2 dave is matched via the id path instead.
+			if normalizedEmail == daveEmail {
+				return "users/dave", false, nil
+			}
+			return "", true, nil
+		},
+	}
+	// Seed an empty cursor so sweep 1 lists the message; sweep 2 resets the cursor
+	// to re-list the same message (overlap), now also id-resolving the sender.
+	e.newGChatSyncState(t, accountID, true, nil)
+	p := e.newProvider(t, map[string]struct{}{accountID: {}}, funcs)
+
+	// Sweep 1: matched via the People path.
+	state1, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &accountID)
+	require.NoError(t, err)
+	_, err = p.Sync(e.ctx, state1, nil)
+	require.NoError(t, err)
+
+	// Reset the space cursor (simulating a manual cursor reset / overlap) and flip
+	// dave to People-UNresolvable so sweep 2 matches him via the id path instead.
+	// Read-modify-write only the cursor so the other persisted keys (membership,
+	// positive cache) are preserved, then re-list the same message.
+	davePeopleResolvable = false
+	state1b, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &accountID)
+	require.NoError(t, err)
+	resetMeta := state1b.Metadata
+	if resetMeta == nil {
+		resetMeta = map[string]any{}
+	}
+	resetMeta["space_cursors"] = map[string]any{
+		spaceName: map[string]any{"create_cursor": chatRFC3339(base.Add(-time.Hour)), "edit_cursor": chatRFC3339(base.Add(-time.Hour))},
+	}
+	_, err = e.syncRepo.UpdateSyncStateMetadata(e.ctx, state1b.ID, resetMeta)
+	require.NoError(t, err)
+
+	// Sweep 2: the same message is re-listed and id-resolves the sender.
+	state2, err := e.syncRepo.GetSyncStateBySource(e.ctx, repository.InteractionSourceGChat, &accountID)
+	require.NoError(t, err)
+	_, err = p.Sync(e.ctx, state2, nil)
+	require.NoError(t, err)
+
+	// Exactly ONE row for the message+contact (upsert dedup; no duplicate).
+	rows, err := e.commsRepo.ListByContact(e.ctx, dave.ID)
+	require.NoError(t, err)
+	count := 0
+	for _, r := range rows {
+		if r.ExternalID == msgName {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "re-processing the same message (People path then id path) upserts ONE row, not a duplicate")
 }
 
 // TestGChatProvider_HotSpaceNoStarvation proves the starvation fix: a


### PR DESCRIPTION
## Hotfix: Google Chat cold-start freeze

This is a **production hotfix** for a cold-start freeze introduced by the merged canonical Chat user-id resolution work (#411, issue #337).

### The incident

On a real account, #411's id-resolution warm-up turned a best-effort enrichment into a hard gate on **all** message processing. Two compounding behaviors in the steady-state sweep:

1. **Cursor-hold on resolve debt.** When the per-sweep `members.get` resolve cap was exhausted, any space with an unresolved id candidate hit `blockedByCapOnDebt → continue`, which skipped `consumeContentWindow` entirely — holding the space's cursor and processing no messages.
2. **Membership-based content skip.** A space whose current membership had no currently-known CRM contact was skipped before paging content.

At real scale (many spaces × hundreds of known CRM emails), the first space's candidates drained the global cap, so every later space deferred immediately and **all** spaces held. The global positive cache stayed empty, message processing was frozen, and the warm-up would have taken days to thaw — delivering nothing in the interim. This regressed even the pre-#411 People-path matching that previously worked.

### The fix — decouple message processing from id-resolution warm-up

Id-resolution becomes a best-effort background warm-up that **never** gates cursor advancement or content processing:

- **Remove the cursor-hold-on-debt.** `blockedByCapOnDebt` is now a non-blocking observability counter (`spacesWarmupDeferred`); the space falls through and pages its content window, matching with the members already known (People-path co-members, inbound senders via `knownMap`, and globally-cached positive ids) and advancing its cursor.
- **Remove the membership-based content skip.** Every non-incomplete space pages content. This also restores a correctness gap: a former member who left a space still has matchable inbound history via the unchanged email-sender path (`classifyMessage` matches `knownMap[senderEmail]` independent of current membership).
- **Lossless `U_id` early-exit in `buildKnownIDIndex`.** A fresh `members.get` can only newly attach an id that is not already covered. `U_id = members \ (me-ids ∪ globally-cached positive ids)`. When `U_id` is empty, the candidate loop is skipped entirely; otherwise it early-exits once every **distinct** uncovered id is attached (a SET, not a scalar count, so two known addresses resolving to one canonical id can't terminate early). `U_id` keys **only** on me-ids + the positive cache, never on People-resolution, so a dual-source identity reachable via an alternate known address is never skipped.
- **`mergeIDMatch`** unions contacts when one canonical id is seeded from multiple known emails (replacing last-writer-wins).

What is **preserved** (unchanged): page-budget / incomplete-window semantics (`blockedByBudget → break`, membership `incomplete → break`, content `!proven → break`), the dedup/fingerprint/negative-cache model, me-id self-exclusion, the idempotent upsert, and the rematch (`ScanIdentifier`) backfill path.

### Authorized relaxed invariant

The one relaxed invariant (explicitly authorized): a space's cursor may advance while some of its CRM-contact members are still unresolved. This is **go-forward by design** — a newly-resolved contact's earlier messages are recovered by the existing contact-method-add rematch path or a manual space-cursor reset. The fix turns a multi-day freeze into a bounded, transparent background warm-up (`member_ids_resolved` climbs and `spaces_warmup_deferred` shrinks across sweeps).

### Test plan

- **Unit (`gchat_test.go`, fake fetcher, DB-free):** lossless `U_id` skip when all members covered; SET-based early-exit with a dual-source shared-id alias (proves it isn't a scalar count); dual-source-identity-not-lost boundary (early-exit keys on id signals, not People-resolution); repurposed deferred-cap-returns-debt-flag-only (the flag is informational, not a cursor outcome).
- **Integration (`gchat_provider_integration_test.go`, real test DB, fake fetcher):** cold-start processes + advances despite resolve debt (cap=0, the headline regression: `processed>0`, `matched>0`, all cursors advance — no freeze); deferred-id contact matches on a later sweep (go-forward backfill); no-current-member space still pages + advances + matches a former member's inbound message; front space doesn't starve later spaces (budget amortization); no double-process on re-resolve (idempotency). The old `DebtHeldCursorAcrossTwoSweeps` (whose premise was the removed cursor-hold) is deleted in the same commit as its replacements.
- **Regression guards retained unchanged:** `MatchesContactNotInGoogleContacts`, `StaleNegativeClearedOnMembershipChange`, `HotSpaceNoStarvation`, `GlobalPositiveCachePersistsAndReused`, the full-sweep / edit / delete / multi-page tests.

No schema, OAuth scope, sqlc, or frontend change.

### Known limitations (out of scope for this hotfix)

- **Multi-contact-per-canonical-id fan-out.** When two **distinct** CRM contact records map (via two different known addresses) to the same Google user id, and that id is the last remaining uncovered id, the early-exit attaches only the first-resolving contact. This is strictly better than the prior unconditional last-writer-wins behavior and is documented at the call site; a single contact carrying both a gchat and an email value produces one UUID and dedups harmlessly. Fan-out across duplicate contact records is a separate follow-up.
- **Single pathologically-deep space.** A space whose unprocessed window cannot be fully paged within one whole page-budget allowance is a pre-existing limitation mitigated by #410's larger page size; this PR neither changes nor worsens it.

Plan doc: `.ai/log/plan/gchat-coldstart-no-freeze.md` (gitignored — local scratch).

Refs #411, #337.
