### PR TITLE
refactor(tests): Element 5 PR-A — migration exemplar + shared helper

### DIFF
--- a/backend/tests/messages_message_repository_test.go
+++ b/backend/tests/messages_message_repository_test.go
@@ -2,8 +2,6 @@ package tests
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/hex"
 	"errors"
 	"os"
 	"testing"
@@ -13,28 +11,28 @@ import (
 	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/synthetic/factory"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// randomSuffix returns a 12-char hex string for per-test isolation.
-// Required because the test DB is shared across runs; the gotcha table
-// warns that fixed identifiers cause cross-run pollution.
-func randomSuffix(t *testing.T) string {
-	t.Helper()
-	b := make([]byte, 6)
-	_, err := rand.Read(b)
-	require.NoError(t, err)
-	return hex.EncodeToString(b)
-}
-
-// setupMessagesMessageTest provisions a per-test mac_host row + repo
-// pair. Cleanup hard-deletes scoped by mac_host_id (upsert does not
-// clear deleted_at on conflict, so soft-delete would resurrect rows
-// across runs per the gotcha table).
-func setupMessagesMessageTest(t *testing.T) (context.Context, *repository.MessagesMessageRepository, *repository.ContactRepository, uuid.UUID, func()) {
+// setupMessagesMessageTest provisions a per-test, namespace-isolated fixture set
+// for the messages_message repo tests via the LIGHTWEIGHT synthetic path (a
+// factory.Generator, no replay harness / River client — so the file stays in the
+// fast PR gate). It returns the generator (its namespace prefix scopes every
+// string identifier the sub-tests construct), the repos, the mac_host FK target,
+// and a cleanup.
+//
+// The mac_host is seeded pre-revoked so the singleton index idx_mac_host_singleton
+// (which only constrains rows WHERE api_key_revoked_at IS NULL) never collides with
+// a parallel tests/api package holding the live singleton slot. The tests here only
+// need a valid mac_host UUID as an FK target; they don't exercise auth or pairing
+// state. Its hostname/hash are namespace-prefixed (no random suffix), and cleanup
+// hard-deletes the messages_message rows scoped by mac_host_id — upsert does not
+// clear deleted_at on conflict, so a soft delete would resurrect rows across runs.
+func setupMessagesMessageTest(t *testing.T) (context.Context, *factory.Generator, *db.Database, *repository.MessagesMessageRepository, uuid.UUID, func()) {
 	t.Helper()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -50,45 +48,38 @@ func setupMessagesMessageTest(t *testing.T) (context.Context, *repository.Messag
 	database, err := db.NewDatabase(ctx, cfg.Database)
 	require.NoError(t, err)
 
-	repo := repository.NewMessagesMessageRepository(database.Queries)
-	contactRepo := repository.NewContactRepository(database.Queries)
+	gen, _ := migrationGenerator(t)
 
-	// Per-test mac_host so HardDeleteByMacHost scopes our cleanup. We
-	// seed a pre-revoked host so the singleton index
-	// idx_mac_host_singleton (which only constrains rows WHERE
-	// api_key_revoked_at IS NULL) never collides with a parallel
-	// tests/api package that holds the live singleton slot. The tests
-	// here only need a valid mac_host UUID as an FK target; they don't
-	// exercise auth or pairing state.
+	repo := repository.NewMessagesMessageRepository(database.Queries)
+
 	macHostRepo := repository.NewMacHostRepository(database.Queries)
-	suffix := randomSuffix(t)
+	prefix := gen.Prefix()
 	host, err := macHostRepo.SeedRevokedHostForTest(ctx,
-		"test-host-"+suffix, "test-version", 1, "test-hash-"+suffix)
+		prefix+"host", "test-version", 1, prefix+"hash")
 	require.NoError(t, err)
 
 	cleanup := func() {
 		_ = repo.HardDeleteByMacHost(ctx, host.ID)
 		database.Close()
 	}
-	return ctx, repo, contactRepo, host.ID, cleanup
+	return ctx, gen, database, repo, host.ID, cleanup
 }
 
 func TestMessagesMessageRepository_UpsertAndGet(t *testing.T) {
-	ctx, repo, contactRepo, hostID, cleanup := setupMessagesMessageTest(t)
+	ctx, gen, database, repo, hostID, cleanup := setupMessagesMessageTest(t)
 	defer cleanup()
 
-	suffix := randomSuffix(t)
-	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: "Test Upsert " + suffix})
-	require.NoError(t, err)
-	defer func() { _ = contactRepo.SoftDeleteContact(ctx, contact.ID) }()
+	contact, contactCleanup := seedMigrationContact(ctx, t, database, gen)
+	defer contactCleanup()
 
+	prefix := gen.Prefix()
 	sentAt := accelerated.GetCurrentTime().Truncate(time.Microsecond)
 	text := "hello messages"
-	guid := "guid-upsert-" + suffix
+	guid := prefix + "guid-upsert"
 
 	msg, err := repo.UpsertMessage(ctx, repository.UpsertMessagesMessageParams{
 		Guid:             guid,
-		ChatGuid:         "chat-" + suffix,
+		ChatGuid:         prefix + "chat",
 		PeerHandle:       "+15551234567",
 		Text:             &text,
 		MessageType:      "text",
@@ -110,20 +101,19 @@ func TestMessagesMessageRepository_UpsertAndGet(t *testing.T) {
 }
 
 func TestMessagesMessageRepository_UpsertConflictIsNoOp(t *testing.T) {
-	ctx, repo, contactRepo, hostID, cleanup := setupMessagesMessageTest(t)
+	ctx, gen, database, repo, hostID, cleanup := setupMessagesMessageTest(t)
 	defer cleanup()
 
-	suffix := randomSuffix(t)
-	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: "Test NoOp " + suffix})
-	require.NoError(t, err)
-	defer func() { _ = contactRepo.SoftDeleteContact(ctx, contact.ID) }()
+	contact, contactCleanup := seedMigrationContact(ctx, t, database, gen)
+	defer contactCleanup()
 
+	prefix := gen.Prefix()
 	sentAt := accelerated.GetCurrentTime().Truncate(time.Microsecond)
 	originalText := "original"
-	guid := "guid-conflict-" + suffix
+	guid := prefix + "guid-conflict"
 
 	first, err := repo.UpsertMessage(ctx, repository.UpsertMessagesMessageParams{
-		Guid: guid, ChatGuid: "chat-" + suffix, PeerHandle: "h",
+		Guid: guid, ChatGuid: prefix + "chat", PeerHandle: "h",
 		Text: &originalText, MessageType: "text", SentAt: sentAt,
 		MatchedContactID: &contact.ID, MacHostID: &hostID,
 	})
@@ -132,7 +122,7 @@ func TestMessagesMessageRepository_UpsertConflictIsNoOp(t *testing.T) {
 	// Second upsert with different text — no-op on conflict.
 	newText := "second push"
 	second, err := repo.UpsertMessage(ctx, repository.UpsertMessagesMessageParams{
-		Guid: guid, ChatGuid: "chat-" + suffix, PeerHandle: "h",
+		Guid: guid, ChatGuid: prefix + "chat", PeerHandle: "h",
 		Text: &newText, MessageType: "text", SentAt: sentAt,
 		MatchedContactID: &contact.ID, MacHostID: &hostID,
 	})
@@ -144,31 +134,25 @@ func TestMessagesMessageRepository_UpsertConflictIsNoOp(t *testing.T) {
 }
 
 func TestMessagesMessageRepository_ListUnprocessedByContact_ExcludesProcessed(t *testing.T) {
-	ctx, repo, contactRepo, hostID, cleanup := setupMessagesMessageTest(t)
+	ctx, gen, database, repo, hostID, cleanup := setupMessagesMessageTest(t)
 	defer cleanup()
 
-	databaseURL := os.Getenv("DATABASE_URL")
-	cfg := config.TestConfig()
-	cfg.Database.URL = databaseURL
-	database, err := db.NewDatabase(ctx, cfg.Database)
-	require.NoError(t, err)
-	defer database.Close()
 	interactionRepo := repository.NewInteractionRepository(database.Queries)
 
-	suffix := randomSuffix(t)
-	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: "Test Excl Proc " + suffix})
-	require.NoError(t, err)
+	contact, contactCleanup := seedMigrationContact(ctx, t, database, gen)
+	prefix := gen.Prefix()
+	ref := prefix + "msgs-excl-proc"
 	defer func() {
-		// Hard-delete the interaction we'll insert so it doesn't trip
-		// the migration test's data-loss guard (see
+		// Hard-delete the interaction we'll insert so it doesn't trip the
+		// migration test's data-loss guard (see
 		// interaction_source_messages_check_test.go for the same pattern).
-		_ = interactionRepo.HardDeleteInteractionsBySourceRefPrefix(ctx, repository.InteractionSourceMessages, "msgs-excl-proc-%")
-		_ = contactRepo.SoftDeleteContact(ctx, contact.ID)
+		_ = interactionRepo.HardDeleteInteractionsBySourceRefPrefix(ctx, repository.InteractionSourceMessages, ref+"%")
+		contactCleanup()
 	}()
 
 	sentAt := accelerated.GetCurrentTime().Truncate(time.Microsecond)
 	msg, err := repo.UpsertMessage(ctx, repository.UpsertMessagesMessageParams{
-		Guid: "guid-proc-" + suffix, ChatGuid: "chat-" + suffix, PeerHandle: "h",
+		Guid: prefix + "guid-proc", ChatGuid: prefix + "chat", PeerHandle: "h",
 		MessageType: "text", SentAt: sentAt,
 		MatchedContactID: &contact.ID, MacHostID: &hostID,
 	})
@@ -179,9 +163,8 @@ func TestMessagesMessageRepository_ListUnprocessedByContact_ExcludesProcessed(t 
 	require.NoError(t, err)
 	require.Len(t, list, 1)
 
-	// Create a real interaction so the staging row's interaction_id FK
-	// constraint is satisfied when MarkMessagesProcessed sets it.
-	ref := "msgs-excl-proc-" + suffix
+	// Create a real interaction so the staging row's interaction_id FK constraint
+	// is satisfied when MarkMessagesProcessed sets it.
 	interaction, err := interactionRepo.CreateInteraction(ctx, repository.CreateInteractionRequest{
 		ContactID:  contact.ID,
 		Source:     repository.InteractionSourceMessages,
@@ -191,8 +174,8 @@ func TestMessagesMessageRepository_ListUnprocessedByContact_ExcludesProcessed(t 
 	})
 	require.NoError(t, err)
 
-	// Mark processed (non-tx variant; no session scope needed for
-	// processed-row filter testing).
+	// Mark processed (non-tx variant; no session scope needed for processed-row
+	// filter testing).
 	require.NoError(t, repo.MarkMessagesProcessed(ctx, []uuid.UUID{msg.ID}, interaction.ID))
 
 	// Processed row → excluded from the unprocessed-by-contact list.
@@ -201,7 +184,7 @@ func TestMessagesMessageRepository_ListUnprocessedByContact_ExcludesProcessed(t 
 	assert.Empty(t, list, "processed row must be excluded from unprocessed list")
 
 	// Verify the row state on disk.
-	got, err := repo.GetMessage(ctx, "guid-proc-"+suffix)
+	got, err := repo.GetMessage(ctx, prefix+"guid-proc")
 	require.NoError(t, err)
 	require.NotNil(t, got.ProcessedAt)
 	require.NotNil(t, got.InteractionID)
@@ -209,17 +192,16 @@ func TestMessagesMessageRepository_ListUnprocessedByContact_ExcludesProcessed(t 
 }
 
 func TestMessagesMessageRepository_ListUnprocessedByContact_ExcludesActiveClaim(t *testing.T) {
-	ctx, repo, contactRepo, hostID, cleanup := setupMessagesMessageTest(t)
+	ctx, gen, database, repo, hostID, cleanup := setupMessagesMessageTest(t)
 	defer cleanup()
 
-	suffix := randomSuffix(t)
-	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: "Test Excl Claim " + suffix})
-	require.NoError(t, err)
-	defer func() { _ = contactRepo.SoftDeleteContact(ctx, contact.ID) }()
+	contact, contactCleanup := seedMigrationContact(ctx, t, database, gen)
+	defer contactCleanup()
 
+	prefix := gen.Prefix()
 	sentAt := accelerated.GetCurrentTime().Truncate(time.Microsecond)
 	msg, err := repo.UpsertMessage(ctx, repository.UpsertMessagesMessageParams{
-		Guid: "guid-claim-" + suffix, ChatGuid: "chat-" + suffix, PeerHandle: "h",
+		Guid: prefix + "guid-claim", ChatGuid: prefix + "chat", PeerHandle: "h",
 		MessageType: "text", SentAt: sentAt,
 		MatchedContactID: &contact.ID, MacHostID: &hostID,
 	})
@@ -237,17 +219,16 @@ func TestMessagesMessageRepository_ListUnprocessedByContact_ExcludesActiveClaim(
 }
 
 func TestMessagesMessageRepository_ListUnprocessedByContact_IncludesStaleClaim(t *testing.T) {
-	ctx, repo, contactRepo, hostID, cleanup := setupMessagesMessageTest(t)
+	ctx, gen, database, repo, hostID, cleanup := setupMessagesMessageTest(t)
 	defer cleanup()
 
-	suffix := randomSuffix(t)
-	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: "Test Stale " + suffix})
-	require.NoError(t, err)
-	defer func() { _ = contactRepo.SoftDeleteContact(ctx, contact.ID) }()
+	contact, contactCleanup := seedMigrationContact(ctx, t, database, gen)
+	defer contactCleanup()
 
+	prefix := gen.Prefix()
 	sentAt := accelerated.GetCurrentTime().Truncate(time.Microsecond)
 	msg, err := repo.UpsertMessage(ctx, repository.UpsertMessagesMessageParams{
-		Guid: "guid-stale-" + suffix, ChatGuid: "chat-" + suffix, PeerHandle: "h",
+		Guid: prefix + "guid-stale", ChatGuid: prefix + "chat", PeerHandle: "h",
 		MessageType: "text", SentAt: sentAt,
 		MatchedContactID: &contact.ID, MacHostID: &hostID,
 	})
@@ -268,22 +249,21 @@ func TestMessagesMessageRepository_ListUnprocessedByContact_IncludesStaleClaim(t
 }
 
 func TestMessagesMessageRepository_ClaimMessages_PartialClaim(t *testing.T) {
-	ctx, repo, contactRepo, hostID, cleanup := setupMessagesMessageTest(t)
+	ctx, gen, database, repo, hostID, cleanup := setupMessagesMessageTest(t)
 	defer cleanup()
 
-	suffix := randomSuffix(t)
-	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: "Test Partial " + suffix})
-	require.NoError(t, err)
-	defer func() { _ = contactRepo.SoftDeleteContact(ctx, contact.ID) }()
+	contact, contactCleanup := seedMigrationContact(ctx, t, database, gen)
+	defer contactCleanup()
 
+	prefix := gen.Prefix()
 	sentAt := accelerated.GetCurrentTime().Truncate(time.Microsecond)
 	m1, err := repo.UpsertMessage(ctx, repository.UpsertMessagesMessageParams{
-		Guid: "guid-p1-" + suffix, ChatGuid: "chat-" + suffix, PeerHandle: "h",
+		Guid: prefix + "guid-p1", ChatGuid: prefix + "chat", PeerHandle: "h",
 		MessageType: "text", SentAt: sentAt, MatchedContactID: &contact.ID, MacHostID: &hostID,
 	})
 	require.NoError(t, err)
 	m2, err := repo.UpsertMessage(ctx, repository.UpsertMessagesMessageParams{
-		Guid: "guid-p2-" + suffix, ChatGuid: "chat-" + suffix, PeerHandle: "h",
+		Guid: prefix + "guid-p2", ChatGuid: prefix + "chat", PeerHandle: "h",
 		MessageType: "text", SentAt: sentAt.Add(time.Second), MatchedContactID: &contact.ID, MacHostID: &hostID,
 	})
 	require.NoError(t, err)
@@ -299,31 +279,22 @@ func TestMessagesMessageRepository_ClaimMessages_PartialClaim(t *testing.T) {
 }
 
 func TestMessagesMessageRepository_ClearStaleClaimTx(t *testing.T) {
-	ctx, repo, contactRepo, hostID, cleanup := setupMessagesMessageTest(t)
+	ctx, gen, database, repo, hostID, cleanup := setupMessagesMessageTest(t)
 	defer cleanup()
 
-	suffix := randomSuffix(t)
-	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: "Test Clear " + suffix})
-	require.NoError(t, err)
-	defer func() { _ = contactRepo.SoftDeleteContact(ctx, contact.ID) }()
+	contact, contactCleanup := seedMigrationContact(ctx, t, database, gen)
+	defer contactCleanup()
 
+	prefix := gen.Prefix()
 	sentAt := accelerated.GetCurrentTime().Truncate(time.Microsecond)
 	msg, err := repo.UpsertMessage(ctx, repository.UpsertMessagesMessageParams{
-		Guid: "guid-clear-" + suffix, ChatGuid: "chat-" + suffix, PeerHandle: "h",
+		Guid: prefix + "guid-clear", ChatGuid: prefix + "chat", PeerHandle: "h",
 		MessageType: "text", SentAt: sentAt, MatchedContactID: &contact.ID, MacHostID: &hostID,
 	})
 	require.NoError(t, err)
 
 	_, err = repo.ClaimMessages(ctx, []uuid.UUID{msg.ID}, "stale-ref")
 	require.NoError(t, err)
-
-	// Re-open a fresh DB connection / tx via the same pool.
-	databaseURL := os.Getenv("DATABASE_URL")
-	cfg := config.TestConfig()
-	cfg.Database.URL = databaseURL
-	database, err := db.NewDatabase(ctx, cfg.Database)
-	require.NoError(t, err)
-	defer database.Close()
 
 	tx, err := database.Pool.Begin(ctx)
 	require.NoError(t, err)
@@ -333,7 +304,7 @@ func TestMessagesMessageRepository_ClearStaleClaimTx(t *testing.T) {
 	require.NoError(t, tx.Commit(ctx))
 
 	// Row should now be unclaimed.
-	got, err := repo.GetMessage(ctx, "guid-clear-"+suffix)
+	got, err := repo.GetMessage(ctx, prefix+"guid-clear")
 	require.NoError(t, err)
 	assert.Nil(t, got.ClaimedAt)
 	assert.Nil(t, got.ClaimedSessionRef)
@@ -346,17 +317,17 @@ func TestMessagesMessageRepository_ClearStaleClaimTx(t *testing.T) {
 	err = repo.ClearStaleClaimTx(ctx, tx2, []uuid.UUID{msg.ID}, "stale-ref") // doesn't match
 	require.NoError(t, err)
 	require.NoError(t, tx2.Commit(ctx))
-	got2, err := repo.GetMessage(ctx, "guid-clear-"+suffix)
+	got2, err := repo.GetMessage(ctx, prefix+"guid-clear")
 	require.NoError(t, err)
 	require.NotNil(t, got2.ClaimedSessionRef)
 	assert.Equal(t, "other-ref", *got2.ClaimedSessionRef, "wrong expected ref does not clear")
 }
 
 func TestMessagesMessageRepository_GetMessage_NotFound(t *testing.T) {
-	ctx, repo, _, _, cleanup := setupMessagesMessageTest(t)
+	ctx, gen, _, repo, _, cleanup := setupMessagesMessageTest(t)
 	defer cleanup()
 
-	_, err := repo.GetMessage(ctx, "non-existent-guid-"+randomSuffix(t))
+	_, err := repo.GetMessage(ctx, gen.Prefix()+"non-existent-guid")
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, db.ErrNotFound), "expected ErrNotFound, got %v", err)
 }

--- a/backend/tests/synthetic_migration_helpers_test.go
+++ b/backend/tests/synthetic_migration_helpers_test.go
@@ -1,0 +1,109 @@
+package tests
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"testing"
+
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+	"personal-crm/backend/internal/synthetic/factory"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Shared migration helpers for the Element 5 suite migration onto the synthetic
+// toolkit. These provide the LIGHTWEIGHT (no-harness, no-River) isolation
+// primitives that Transform-F/lite repo tests adopt: a namespaced factory
+// generator plus a nil-bus contact seed with a scoped cleanup closure. Transform-R
+// tests use the full synthetic.NewHarnessForNamespace + h.SeedContact directly —
+// the harness already is the heavy primitive, so there is no helper for that path.
+
+// migrationGenerator returns a factory.Generator scoped to a unique per-test
+// namespace plus the namespace token. It is the LIGHTWEIGHT isolation primitive:
+// the generator imports only accelerated (no DB, no River client), so a fast repo
+// test gets namespace-disjoint identifiers without paying the harness's cost.
+//
+// Use this for Transform-F/lite tests that keep their own DB setup and only need
+// namespaced fixtures. Transform-R tests use synthetic.NewHarnessForNamespace
+// instead.
+//
+// Phone-band caveat: the lightweight path SKIPS the harness's resolveNamespace
+// numeric-band collision check. It is SAFE for namespaced name + string
+// identifiers (guids/handles/emails), which never cross-match DB-wide. It is NOT
+// automatically safe for a fixture that seeds a PHONE identifier matched DB-wide:
+// such a test must either use the full harness (which collision-checks the phone
+// area band) or assert only on rows it created by exact id, never relying on a
+// DB-wide phone lookup.
+func migrationGenerator(t *testing.T) (*factory.Generator, string) {
+	t.Helper()
+	ns := syntheticNS(t)
+	return factory.NewGenerator(factory.DefaultSeed, ns), ns
+}
+
+// seedMigrationContact writes a factory ContactSpec through a nil-bus
+// ContactService.CreateContact — the sanctioned multi-method write path — and
+// returns the persisted contact plus a scoped HardDeleteContact cleanup closure.
+//
+// The nil bus is deliberate: ContactService.CreateContact guards its event
+// publish with `s.bus != nil`, so a service built with a nil bus writes the
+// contact + all its methods in ONE tx with NO River client and NO event publish.
+// That is exactly the lightweight (no-harness) seed path.
+//
+// The returned cleanup covers the CONTACT only — not FK-child rows on other
+// tables. A repo test that writes rows keyed by a different FK (e.g.
+// messages_message keyed by mac_host_id) keeps its OWN scoped cleanup for those
+// rows and composes it alongside this closure.
+func seedMigrationContact(
+	ctx context.Context,
+	t *testing.T,
+	database *db.Database,
+	gen *factory.Generator,
+	opts ...factory.ContactOption,
+) (*repository.Contact, func()) {
+	t.Helper()
+
+	contactRepo := repository.NewContactRepository(database.Queries)
+	methodRepo := repository.NewContactMethodRepository(database.Queries)
+	interactionRepo := repository.NewInteractionRepository(database.Queries)
+	taskRepo := repository.NewContactTaskRepository(database.Queries)
+
+	// nil bus + nil rematchRegistry → CreateContact writes contact+methods in one
+	// tx with no event publish, no River client (the lightweight seed path).
+	contactSvc := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, taskRepo, nil, nil)
+
+	spec := gen.Contact(opts...)
+	methods := make([]service.ContactMethodInput, 0, len(spec.Methods))
+	for _, m := range spec.Methods {
+		methods = append(methods, service.ContactMethodInput{Type: m.Type, Value: m.Value, IsPrimary: m.IsPrimary})
+	}
+
+	contact, _, err := contactSvc.CreateContact(ctx, repository.CreateContactRequest{
+		FullName:      spec.FullName,
+		Cadence:       spec.Cadence,
+		LastContacted: spec.LastContacted,
+		Birthday:      spec.Birthday,
+		Location:      spec.Location,
+		HowMet:        spec.HowMet,
+	}, methods)
+	require.NoError(t, err)
+
+	cleanup := func() { _ = contactRepo.HardDeleteContact(ctx, contact.ID) }
+	return contact, cleanup
+}
+
+// LEGACY — staged removal.
+//
+// randomSuffix returns a 12-char hex string for per-test isolation. It is
+// superseded by the namespace token from migrationGenerator and is centralized
+// here only so the still-unmigrated callers compile; it is deleted once the last
+// caller migrates off it. Do NOT add new callers — use migrationGenerator.
+func randomSuffix(t *testing.T) string {
+	t.Helper()
+	b := make([]byte, 6)
+	_, err := rand.Read(b)
+	require.NoError(t, err)
+	return hex.EncodeToString(b)
+}

--- a/backend/tests/synthetic_migration_helpers_test.go
+++ b/backend/tests/synthetic_migration_helpers_test.go
@@ -14,12 +14,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Shared migration helpers for the Element 5 suite migration onto the synthetic
-// toolkit. These provide the LIGHTWEIGHT (no-harness, no-River) isolation
-// primitives that Transform-F/lite repo tests adopt: a namespaced factory
-// generator plus a nil-bus contact seed with a scoped cleanup closure. Transform-R
-// tests use the full synthetic.NewHarnessForNamespace + h.SeedContact directly —
-// the harness already is the heavy primitive, so there is no helper for that path.
+// Shared helpers for migrating the integration suite onto the synthetic toolkit.
+// These provide the LIGHTWEIGHT (no-harness, no-River) isolation primitives that
+// Transform-F/lite repo tests adopt: a namespaced factory generator plus a
+// nil-bus contact seed with a scoped cleanup closure. Transform-R tests use the
+// full synthetic.NewHarnessForNamespace + h.SeedContact directly — the harness
+// already is the heavy primitive, so there is no helper for that path.
 
 // migrationGenerator returns a factory.Generator scoped to a unique per-test
 // namespace plus the namespace token. It is the LIGHTWEIGHT isolation primitive:

--- a/backend/tests/synthetic_migration_transform_r_reference_test.go
+++ b/backend/tests/synthetic_migration_transform_r_reference_test.go
@@ -10,12 +10,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// This file is the canonical TRANSFORM-R reference for the Element 5 suite
-// migration: the FULL replay-harness pattern, as opposed to the lightweight
-// Transform-F/lite path the messages_message exemplar models. A Transform-R test
-// seeds a contact via the factory, drives a real source through a Replay* adapter
-// (which settles the graph + auto-cleans on teardown), and asserts the settled
-// domain graph at/above the harness surface.
+// This file is the canonical TRANSFORM-R reference for the suite migration onto
+// the synthetic toolkit: the FULL replay-harness pattern, as opposed to the
+// lightweight Transform-F/lite path the messages_message exemplar models. A
+// Transform-R test seeds a contact via the factory, drives a real source through
+// a Replay* adapter (which settles the graph + auto-cleans on teardown), and
+// asserts the settled domain graph at/above the harness surface.
 //
 // It is River-draining and therefore SLOW-gated: RequireLongTests skips it in the
 // fast PR gate, and the TestSynthetic name prefix routes it onto the nightly slow

--- a/backend/tests/synthetic_migration_transform_r_reference_test.go
+++ b/backend/tests/synthetic_migration_transform_r_reference_test.go
@@ -1,0 +1,54 @@
+package tests
+
+import (
+	"testing"
+
+	"personal-crm/backend/internal/synthetic"
+	"personal-crm/backend/internal/synthetic/factory"
+	"personal-crm/backend/tests/testsupport"
+
+	"github.com/stretchr/testify/require"
+)
+
+// This file is the canonical TRANSFORM-R reference for the Element 5 suite
+// migration: the FULL replay-harness pattern, as opposed to the lightweight
+// Transform-F/lite path the messages_message exemplar models. A Transform-R test
+// seeds a contact via the factory, drives a real source through a Replay* adapter
+// (which settles the graph + auto-cleans on teardown), and asserts the settled
+// domain graph at/above the harness surface.
+//
+// It is River-draining and therefore SLOW-gated: RequireLongTests skips it in the
+// fast PR gate, and the TestSynthetic name prefix routes it onto the nightly slow
+// suite (BACKEND_SLOW_TESTS_REGEX). Do NOT route a fast repo test through this
+// pattern — that would drop it from the PR gate (a coverage regression).
+
+// TestSyntheticReplay_GCalDerivesLastContacted drives a past calendar event the
+// account attended together with a seeded contact through the REAL
+// CalendarSyncProvider via ReplayGCal, and asserts the settled graph derives the
+// contact's last_contacted from the attended (mutual) interaction. The seeded
+// contact starts with no last_contacted; after settle it is non-nil and lands at
+// the event's occurred_at (~1h before the anchor).
+func TestSyntheticReplay_GCalDerivesLastContacted(t *testing.T) {
+	testsupport.RequireLongTests(t)
+	database, ctx := newSyntheticDB(t)
+
+	h := synthetic.NewHarnessForNamespace(t, ctx, database, syntheticNS(t), factory.DefaultSeed)
+	gen := h.Generator()
+
+	spec := gen.Contact(factory.WithEmail())
+	contact, err := h.SeedContact(ctx, spec)
+	require.NoError(t, err)
+	require.Nil(t, contact.LastContacted, "seeded contact has no last_contacted before the replay")
+
+	res, err := h.ReplayGCal(ctx, contact.ID, gen.GCalEvent(spec, factory.MatchSeeded))
+	require.NoError(t, err)
+	require.True(t, res.Matched)
+
+	// The attended event is recorded as a gcal interaction for the contact.
+	requireInteractionSource(t, ctx, h, contact.ID, "gcal")
+
+	// And the mutual attended interaction derives the contact's last_contacted.
+	updated, err := h.ContactRepo().GetContact(ctx, contact.ID)
+	require.NoError(t, err)
+	require.NotNil(t, updated.LastContacted, "the attended interaction must derive last_contacted")
+}


### PR DESCRIPTION
**PR-A of the Element 5 suite migration (the foundation PR).** Establishes the two canonical conversion templates and the shared helper that the parallel cluster PRs (B/C1/C2/D) replicate.

## What this lands
- **Exemplar (Transform F-lite, fast path):** `backend/tests/messages_message_repository_test.go` converted onto the toolkit's namespace-isolated factories via the lightweight nil-bus `ContactService.CreateContact` seed path — kept in the **fast** PR gate (`make test-integration-fast`), behavior byte-identical (same 8 tests/assertions).
- **Shared helper** (`backend/tests/synthetic_migration_helpers_test.go`): `migrationGenerator` (namespace-isolated factory identifiers) + `seedMigrationContact` (nil-bus seed + scoped `HardDeleteContact` cleanup). This is the pattern the cluster PRs copy.
- **Transform-R reference** (`synthetic_migration_transform_r_reference_test.go`): one small LONG-gated `ReplayGCal` test as the heavy-path template.
- **`randomSuffix` staged-legacy relocation:** moved verbatim (with a deprecation note) into the shared helper; the exemplar no longer depends on it; its 11 remaining callers still compile. The helper is deleted in the final PR-E once its last caller is migrated.

## Review
Codex is unavailable this window (account outage). Reviewed via a fresh-context `/review-head` (PASS, P0=0 P1=0) with elevated scrutiny since the helper/pattern propagate ~25×: verified the nil-bus path is safe (`CreateContact` guards its bus call with `s.bus != nil`), namespace isolation is real, cleanup is orphan-free in all orderings, behavior is byte-identical, and coverage is preserved (exemplar runs in the fast gate; Transform-R skips fast / passes under `LONG_TESTS`).