### PR TITLE
test(synthetic): Element 5 — migrate integration suite onto synthetic toolkit

### DIFF
--- a/backend/tests/address_book_reconcile_integration_test.go
+++ b/backend/tests/address_book_reconcile_integration_test.go
@@ -93,11 +93,13 @@ func (h stubRematchHandler) Rematch(_ context.Context, _ uuid.UUID, _ string) (i
 	return 0, nil
 }
 
-// abSuffix returns a short randomized suffix so per-subtest names /
+// abSuffix returns a per-call namespace token so per-subtest names /
 // addresses don't collide across runs in the shared DB (trigram
-// cross-talk guard).
-func abSuffix() string {
-	return uuid.New().String()[:8]
+// cross-talk guard). It draws from the synthetic toolkit's syntheticNS
+// helper so isolation tokens come from one shared primitive.
+func abSuffix(t *testing.T) string {
+	t.Helper()
+	return syntheticNS(t)
 }
 
 // seedLinkedExternal creates a CRM contact + an external_contact row in
@@ -112,7 +114,7 @@ func seedLinkedExternal(
 	emails []string,
 ) (*repository.Contact, *repository.ExternalContact) {
 	t.Helper()
-	sfx := abSuffix()
+	sfx := abSuffix(t)
 	contact, err := env.contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: "AB Reconcile " + sfx})
 	require.NoError(t, err)
 
@@ -160,7 +162,7 @@ func contactHasMethod(t *testing.T, ctx context.Context, env *abReconcileEnv, co
 func TestABReconcile_Matched_AutoPropagates(t *testing.T) {
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
-	email := "matched-" + abSuffix() + "@example.com"
+	email := "matched-" + abSuffix(t) + "@example.com"
 	contact, external := seedLinkedExternal(t, ctx, env, "gcontacts", repository.MatchStatusMatched, []string{email})
 
 	require.False(t, contactHasMethod(t, ctx, env, contact.ID, email), "precondition: contact has no method yet")
@@ -184,7 +186,7 @@ func TestABReconcile_Matched_AutoPropagates(t *testing.T) {
 func TestABReconcile_Imported_RecordsSuggestion(t *testing.T) {
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
-	email := "imported-" + abSuffix() + "@example.com"
+	email := "imported-" + abSuffix(t) + "@example.com"
 	contact, external := seedLinkedExternal(t, ctx, env, "gcontacts", repository.MatchStatusImported, []string{email})
 
 	res, err := env.reconcile.ReconcileLinkedExternalContactMethods(ctx, repository.ReconcileTarget{
@@ -210,7 +212,7 @@ func TestABReconcile_Imported_RecordsSuggestion(t *testing.T) {
 func TestABReconcile_Ignored_Skips(t *testing.T) {
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
-	email := "ignored-" + abSuffix() + "@example.com"
+	email := "ignored-" + abSuffix(t) + "@example.com"
 	contact, external := seedLinkedExternal(t, ctx, env, "gcontacts", repository.MatchStatusIgnored, []string{email})
 
 	// ResolveAndReconcile must resolve to a skip (ok=false) for ignored.
@@ -231,7 +233,7 @@ func TestABReconcile_Ignored_Skips(t *testing.T) {
 func TestABReconcile_SoftDeletedContact_MatchedSkips(t *testing.T) {
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
-	email := "softdel-matched-" + abSuffix() + "@example.com"
+	email := "softdel-matched-" + abSuffix(t) + "@example.com"
 	contact, external := seedLinkedExternal(t, ctx, env, "gcontacts", repository.MatchStatusMatched, []string{email})
 
 	require.NoError(t, env.contactRepo.SoftDeleteContact(ctx, contact.ID))
@@ -243,7 +245,7 @@ func TestABReconcile_SoftDeletedContact_MatchedSkips(t *testing.T) {
 func TestABReconcile_SoftDeletedContact_ImportedSkips(t *testing.T) {
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
-	email := "softdel-imported-" + abSuffix() + "@example.com"
+	email := "softdel-imported-" + abSuffix(t) + "@example.com"
 	contact, external := seedLinkedExternal(t, ctx, env, "gcontacts", repository.MatchStatusImported, []string{email})
 
 	require.NoError(t, env.contactRepo.SoftDeleteContact(ctx, contact.ID))
@@ -266,7 +268,7 @@ func TestABReconcile_SoftDeletedContact_ImportedSkips(t *testing.T) {
 func TestABReconcile_Dedup_ExistingMethodNotResuggested(t *testing.T) {
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
-	email := "dedup-" + abSuffix() + "@example.com"
+	email := "dedup-" + abSuffix(t) + "@example.com"
 	contact, external := seedLinkedExternal(t, ctx, env, "gcontacts", repository.MatchStatusImported, []string{email})
 
 	// Contact already has the method.
@@ -295,7 +297,7 @@ func TestABReconcile_Dedup_ExistingMethodNotResuggested(t *testing.T) {
 func TestABReconcile_PhoneNormalization_Equivalence(t *testing.T) {
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
-	sfx := abSuffix()
+	sfx := abSuffix(t)
 	contact, err := env.contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: "AB Phone " + sfx})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = env.contactRepo.HardDeleteContact(ctx, contact.ID) })
@@ -337,7 +339,7 @@ func TestABReconcile_PhoneNormalization_Equivalence(t *testing.T) {
 func TestABReconcile_DismissedMethod_NotResuggested(t *testing.T) {
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
-	email := "dismissed-" + abSuffix() + "@example.com"
+	email := "dismissed-" + abSuffix(t) + "@example.com"
 	contact, external := seedLinkedExternal(t, ctx, env, "gcontacts", repository.MatchStatusImported, []string{email})
 
 	// Pre-seed the dismissed set (normalized value).
@@ -364,7 +366,7 @@ func TestABReconcile_DismissedMethod_NotResuggested(t *testing.T) {
 func TestABReconcile_EmptySet_ClearsPendingToNull(t *testing.T) {
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
-	email := "clear-" + abSuffix() + "@example.com"
+	email := "clear-" + abSuffix(t) + "@example.com"
 	contact, external := seedLinkedExternal(t, ctx, env, "gcontacts", repository.MatchStatusImported, []string{email})
 
 	// First reconcile records the suggestion.
@@ -406,7 +408,7 @@ func TestABReconcile_EmptySet_ClearsPendingToNull(t *testing.T) {
 func TestABReconcile_ProducerUpsertPreservesSuggestionColumns(t *testing.T) {
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
-	email := "survive-" + abSuffix() + "@example.com"
+	email := "survive-" + abSuffix(t) + "@example.com"
 	contact, external := seedLinkedExternal(t, ctx, env, "gcontacts", repository.MatchStatusImported, []string{email})
 
 	// Write a pending suggestion + a dismissal.
@@ -448,7 +450,7 @@ func TestABReconcile_ProducerUpsertPreservesSuggestionColumns(t *testing.T) {
 func TestABReconcile_Idempotent(t *testing.T) {
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
-	email := "idem-" + abSuffix() + "@example.com"
+	email := "idem-" + abSuffix(t) + "@example.com"
 	contact, external := seedLinkedExternal(t, ctx, env, "gcontacts", repository.MatchStatusMatched, []string{email})
 
 	require.NoError(t, env.reconcile.ResolveAndReconcile(ctx, external.ID))
@@ -475,7 +477,7 @@ func seedDupOfCanonical(
 	uniqueEmail string,
 ) (canonContact *repository.Contact, dupExternal *repository.ExternalContact) {
 	t.Helper()
-	sfx := abSuffix()
+	sfx := abSuffix(t)
 
 	canonContact, err := env.contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: "AB Canon " + sfx})
 	require.NoError(t, err)
@@ -524,7 +526,7 @@ func seedDupOfCanonical(
 func TestABReconcile_DupOfMatchedCanonical_AutoPropagates(t *testing.T) {
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
-	uniqueEmail := "dupmatched-" + abSuffix() + "@example.com"
+	uniqueEmail := "dupmatched-" + abSuffix(t) + "@example.com"
 	canon, dup := seedDupOfCanonical(t, ctx, env, repository.MatchStatusMatched, repository.MatchStatusMatched, uniqueEmail)
 
 	require.NoError(t, env.reconcile.ResolveAndReconcile(ctx, dup.ID))
@@ -538,7 +540,7 @@ func TestABReconcile_DupOfMatchedCanonical_AutoPropagates(t *testing.T) {
 func TestABReconcile_DupOfImportedCanonical_Suggests(t *testing.T) {
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
-	uniqueEmail := "dupimported-" + abSuffix() + "@example.com"
+	uniqueEmail := "dupimported-" + abSuffix(t) + "@example.com"
 	canon, dup := seedDupOfCanonical(t, ctx, env, repository.MatchStatusImported, repository.MatchStatusMatched, uniqueEmail)
 
 	require.NoError(t, env.reconcile.ResolveAndReconcile(ctx, dup.ID))
@@ -556,7 +558,7 @@ func TestABReconcile_DupOfImportedCanonical_Suggests(t *testing.T) {
 func TestABReconcile_IgnoredDupOfMatchedCanonical_Skips(t *testing.T) {
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
-	uniqueEmail := "dupignored-" + abSuffix() + "@example.com"
+	uniqueEmail := "dupignored-" + abSuffix(t) + "@example.com"
 	canon, dup := seedDupOfCanonical(t, ctx, env, repository.MatchStatusMatched, repository.MatchStatusIgnored, uniqueEmail)
 
 	require.NoError(t, env.reconcile.ResolveAndReconcile(ctx, dup.ID))
@@ -574,10 +576,10 @@ func TestABReconcile_Catchup_MixedSet(t *testing.T) {
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
 
-	matchedEmail := "catchup-matched-" + abSuffix() + "@example.com"
+	matchedEmail := "catchup-matched-" + abSuffix(t) + "@example.com"
 	matchedContact, _ := seedLinkedExternal(t, ctx, env, "gcontacts", repository.MatchStatusMatched, []string{matchedEmail})
 
-	importedEmail := "catchup-imported-" + abSuffix() + "@example.com"
+	importedEmail := "catchup-imported-" + abSuffix(t) + "@example.com"
 	_, importedExternal := seedLinkedExternal(t, ctx, env, "icloud_contacts", repository.MatchStatusImported, []string{importedEmail})
 
 	res, err := env.reconcile.ReconcileAllAddressBookMethods(ctx)

--- a/backend/tests/cadence_filter_integration_test.go
+++ b/backend/tests/cadence_filter_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/synthetic/factory"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -36,21 +37,15 @@ func TestCadenceFilter_Integration(t *testing.T) {
 	defer database.Close()
 
 	repo := repository.NewContactRepository(database.Queries)
+	gen, _ := migrationGenerator(t)
 
-	// Create test contacts: one with cadence, one without
-	weekly := "weekly"
-	withCadence, err := repo.CreateContact(ctx, repository.CreateContactRequest{
-		FullName: "CadenceFilter With",
-		Cadence:  &weekly,
-	})
-	require.NoError(t, err)
-	defer func() { _ = repo.HardDeleteContact(ctx, withCadence.ID) }()
+	// Seed test contacts via the synthetic factory: one with cadence, one
+	// without. Both are referenced by ID only, so namespaced names are fine.
+	withCadence, withCleanup := seedMigrationContact(ctx, t, database, gen, factory.WithCadence("weekly"))
+	defer withCleanup()
 
-	withoutCadence, err := repo.CreateContact(ctx, repository.CreateContactRequest{
-		FullName: "CadenceFilter Without",
-	})
-	require.NoError(t, err)
-	defer func() { _ = repo.HardDeleteContact(ctx, withoutCadence.ID) }()
+	withoutCadence, withoutCleanup := seedMigrationContact(ctx, t, database, gen)
+	defer withoutCleanup()
 
 	t.Run("ListContacts_NoCadenceFilter", func(t *testing.T) {
 		results, err := repo.ListContacts(ctx, repository.ListContactsParams{

--- a/backend/tests/calendar_decline_cutover_integration_test.go
+++ b/backend/tests/calendar_decline_cutover_integration_test.go
@@ -27,6 +27,7 @@ import (
 	"personal-crm/backend/internal/events"
 	"personal-crm/backend/internal/google"
 	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/synthetic/factory"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -43,6 +44,7 @@ import (
 type declineCutoverEnv struct {
 	ctx             context.Context
 	database        *db.Database
+	gen             *factory.Generator
 	provider        *google.CalendarSyncProvider
 	bus             *events.Bus
 	contactRepo     *repository.ContactRepository
@@ -102,12 +104,14 @@ func newDeclineCutoverEnv(t *testing.T, ctx context.Context) *declineCutoverEnv 
 
 	provider := google.NewCalendarSyncProvider(nil, calendarRepo, contactRepo, nil, nil, bus, database.Pool)
 
-	accountID := "decline-cutover-" + uuid.NewString()
+	gen, _ := migrationGenerator(t)
+	accountID := gen.Prefix() + "decline-cutover"
 	t.Cleanup(func() { _ = calendarRepo.DeleteEventsByAccount(ctx, accountID) })
 
 	return &declineCutoverEnv{
 		ctx:             ctx,
 		database:        database,
+		gen:             gen,
 		provider:        provider,
 		bus:             bus,
 		contactRepo:     contactRepo,
@@ -141,7 +145,7 @@ func (w *deferredDeclineWorker) Timeout(j *river.Job[consumerjobs.CalendarDeclin
 func (e *declineCutoverEnv) newContact(t *testing.T, cadenceStr *string) repository.Contact {
 	t.Helper()
 	contact, err := e.contactRepo.CreateContact(e.ctx, repository.CreateContactRequest{
-		FullName: "decline-cutover-" + uuid.NewString()[:8],
+		FullName: e.gen.Contact(factory.WithNoMethods()).FullName,
 		Cadence:  cadenceStr,
 	})
 	require.NoError(t, err)

--- a/backend/tests/calendar_decline_removal_integration_test.go
+++ b/backend/tests/calendar_decline_removal_integration_test.go
@@ -27,6 +27,7 @@ import (
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/events"
 	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/synthetic/factory"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -39,6 +40,7 @@ import (
 type declineTestEnv struct {
 	ctx             context.Context
 	database        *db.Database
+	gen             *factory.Generator
 	contactRepo     *repository.ContactRepository
 	interactionRepo *repository.InteractionRepository
 	calendarRepo    *repository.CalendarEventRepository
@@ -73,9 +75,11 @@ func newDeclineTestEnv(t *testing.T, ctx context.Context) *declineTestEnv {
 	)
 	declineHandler := consumer.NewCalendarDeclineHandler(interactionRepo, contactRepo)
 
+	gen, _ := migrationGenerator(t)
 	return &declineTestEnv{
 		ctx:             ctx,
 		database:        database,
+		gen:             gen,
 		contactRepo:     contactRepo,
 		interactionRepo: interactionRepo,
 		calendarRepo:    calendarRepo,
@@ -87,7 +91,7 @@ func newDeclineTestEnv(t *testing.T, ctx context.Context) *declineTestEnv {
 func (e *declineTestEnv) newContact(t *testing.T, cadenceStr *string, lastContacted *time.Time) repository.Contact {
 	t.Helper()
 	contact, err := e.contactRepo.CreateContact(e.ctx, repository.CreateContactRequest{
-		FullName:      "decline-removal-" + uuid.NewString()[:8],
+		FullName:      e.gen.Contact(factory.WithNoMethods()).FullName,
 		Cadence:       cadenceStr,
 		LastContacted: lastContacted,
 	})
@@ -486,7 +490,7 @@ func TestIntegration_AttendedAfterDelete_LockSerialization(t *testing.T) {
 	e := newDeclineTestEnv(t, ctx)
 	contact := e.newContact(t, nil, nil)
 
-	accountID := "decline-lock-" + uuid.NewString()
+	accountID := e.gen.Prefix() + "decline-lock"
 	stored := e.seedCalendarEvent(t, accountID, contact.ID)
 
 	// Open attended tx A and acquire the FOR SHARE lock (do NOT commit yet).

--- a/backend/tests/calendar_event_integration_test.go
+++ b/backend/tests/calendar_event_integration_test.go
@@ -41,22 +41,16 @@ func TestCalendarEventUpsertResetsLastContactedUpdated(t *testing.T) {
 	require.NoError(t, err)
 	defer database.Close()
 
-	contactRepo := repository.NewContactRepository(database.Queries)
+	gen, _ := migrationGenerator(t)
 	calendarRepo := repository.NewCalendarEventRepository(database.Queries)
 
-	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-		FullName: "Calendar Event Match Reset",
-	})
-	require.NoError(t, err)
-	defer func() { _ = contactRepo.HardDeleteContact(ctx, contact.ID) }()
+	contact, contactCleanup := seedMigrationContact(ctx, t, database, gen)
+	defer contactCleanup()
 
-	contactTwo, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-		FullName: "Calendar Event Match Reset Two",
-	})
-	require.NoError(t, err)
-	defer func() { _ = contactRepo.HardDeleteContact(ctx, contactTwo.ID) }()
+	contactTwo, contactTwoCleanup := seedMigrationContact(ctx, t, database, gen)
+	defer contactTwoCleanup()
 
-	accountID := "calendar-reset@example.com"
+	accountID := gen.Prefix() + "calendar-reset@example.com"
 	defer func() { _ = calendarRepo.DeleteEventsByAccount(ctx, accountID) }()
 
 	now := accelerated.GetCurrentTime()
@@ -197,13 +191,11 @@ func TestUpdateContactLastContactedIfLater_OnlyUpdatesWhenLater(t *testing.T) {
 	require.NoError(t, err)
 	defer database.Close()
 
+	gen, _ := migrationGenerator(t)
 	contactRepo := repository.NewContactRepository(database.Queries)
 
-	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-		FullName: "Last Contacted Clamp",
-	})
-	require.NoError(t, err)
-	defer func() { _ = contactRepo.HardDeleteContact(ctx, contact.ID) }()
+	contact, contactCleanup := seedMigrationContact(ctx, t, database, gen)
+	defer contactCleanup()
 
 	initial := accelerated.GetCurrentTime().Add(-2 * time.Hour)
 	later := initial.Add(2 * time.Hour)

--- a/backend/tests/comms_gchat_engine_test.go
+++ b/backend/tests/comms_gchat_engine_test.go
@@ -203,7 +203,8 @@ func softDeleteCommsRow(e *gchatTestEnv, id uuid.UUID) error {
 // entry is missing (recorder's zero-rows rollback fires).
 func TestGChatEngine_BurstCreatePath(t *testing.T) {
 	e := setupGChatEngineTest(t)
-	suffix := randomSuffix(t)
+	gen, _ := migrationGenerator(t)
+	suffix := gen.Prefix()
 
 	contact := e.newGChatContact(t, "GChat Burst "+suffix)
 	space := "spaces/BURST-" + suffix
@@ -232,7 +233,8 @@ func TestGChatEngine_BurstCreatePath(t *testing.T) {
 // bridge). A second case: inbound after 48h stays a separate interaction.
 func TestGChatEngine_ReplyBridgeToMutual(t *testing.T) {
 	e := setupGChatEngineTest(t)
-	suffix := randomSuffix(t)
+	gen, _ := migrationGenerator(t)
+	suffix := gen.Prefix()
 
 	t.Run("inbound within 48h promotes to mutual", func(t *testing.T) {
 		contact := e.newGChatContact(t, "GChat Bridge "+suffix)
@@ -285,7 +287,8 @@ func TestGChatEngine_ReplyBridgeToMutual(t *testing.T) {
 // interaction on re-aggregate.
 func TestGChatEngine_EditNoOp(t *testing.T) {
 	e := setupGChatEngineTest(t)
-	suffix := randomSuffix(t)
+	gen, _ := migrationGenerator(t)
+	suffix := gen.Prefix()
 
 	contact := e.newGChatContact(t, "GChat Edit "+suffix)
 	space := "spaces/EDIT-" + suffix
@@ -312,7 +315,8 @@ func TestGChatEngine_EditNoOp(t *testing.T) {
 // produces no interaction.
 func TestGChatEngine_DeleteNoOp(t *testing.T) {
 	e := setupGChatEngineTest(t)
-	suffix := randomSuffix(t)
+	gen, _ := migrationGenerator(t)
+	suffix := gen.Prefix()
 
 	contact := e.newGChatContact(t, "GChat Delete "+suffix)
 	space := "spaces/DELETE-" + suffix
@@ -335,7 +339,8 @@ func TestGChatEngine_DeleteNoOp(t *testing.T) {
 // different-ref claim untouched.
 func TestGChatEngine_ClaimRaceRecovery(t *testing.T) {
 	e := setupGChatEngineTest(t)
-	suffix := randomSuffix(t)
+	gen, _ := migrationGenerator(t)
+	suffix := gen.Prefix()
 
 	contact := e.newGChatContact(t, "GChat Claim "+suffix)
 	space := "spaces/CLAIM-" + suffix
@@ -364,7 +369,8 @@ func TestGChatEngine_ClaimRaceRecovery(t *testing.T) {
 // different-ref claim is left untouched.
 func TestGChatEngine_ClearStaleClaimTx(t *testing.T) {
 	e := setupGChatEngineTest(t)
-	suffix := randomSuffix(t)
+	gen, _ := migrationGenerator(t)
+	suffix := gen.Prefix()
 
 	contact := e.newGChatContact(t, "GChat ClearClaim "+suffix)
 	space := "spaces/CLEAR-" + suffix
@@ -405,7 +411,8 @@ func TestGChatEngine_ClearStaleClaimTx(t *testing.T) {
 // rows affected — the recorder's rollback trigger).
 func TestGChatEngine_MarkProcessedForSessionBoundaryShift(t *testing.T) {
 	e := setupGChatEngineTest(t)
-	suffix := randomSuffix(t)
+	gen, _ := migrationGenerator(t)
+	suffix := gen.Prefix()
 
 	contact := e.newGChatContact(t, "GChat Session "+suffix)
 	space := "spaces/SESSION-" + suffix

--- a/backend/tests/comms_gchat_identity_test.go
+++ b/backend/tests/comms_gchat_identity_test.go
@@ -40,7 +40,8 @@ func seedContactWithMethod(t *testing.T, ctx context.Context, commsRepo *reposit
 // empty-normalized values are excluded; values are already lowercased.
 func TestListGChatIdentitiesForSync_DualSource(t *testing.T) {
 	ctx, commsRepo, contactRepo, methodRepo := setupCommsMessageTest(t)
-	suffix := randomSuffix(t)
+	gen, _ := migrationGenerator(t)
+	suffix := gen.Prefix()
 
 	// Unique per-suffix addresses so this sub-test's pool is isolated on the
 	// shared DB. value_normalized lowercases, so seed with mixed case to also

--- a/backend/tests/comms_gchat_query_test.go
+++ b/backend/tests/comms_gchat_query_test.go
@@ -38,7 +38,8 @@ func upsertGChatRow(t *testing.T, ctx context.Context, commsRepo *repository.Com
 // only gchat rows (email rows are invisible) and vice-versa.
 func TestCommsSourceParameterizedQueries_IsolateSources(t *testing.T) {
 	ctx, commsRepo, contactRepo, _ := setupCommsMessageTest(t)
-	suffix := randomSuffix(t)
+	gen, _ := migrationGenerator(t)
+	suffix := gen.Prefix()
 
 	contact := newEmailContact(t, ctx, commsRepo, contactRepo, "Source Isolation "+suffix)
 	base := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Microsecond)
@@ -91,7 +92,8 @@ func TestCommsSourceParameterizedQueries_IsolateSources(t *testing.T) {
 // never the other contact's.
 func TestGetMessageByReplyTargetForSource(t *testing.T) {
 	ctx, commsRepo, contactRepo, methodRepo := setupCommsMessageTest(t)
-	suffix := randomSuffix(t)
+	gen, _ := migrationGenerator(t)
+	suffix := gen.Prefix()
 
 	contact := newEmailContact(t, ctx, commsRepo, contactRepo, "Reply Target "+suffix)
 	base := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Microsecond)

--- a/backend/tests/comms_message_repository_test.go
+++ b/backend/tests/comms_message_repository_test.go
@@ -145,7 +145,8 @@ func metadataFor(t *testing.T, accountID, gmailID string, extra map[string]any) 
 func TestCommsMessageRepository_UpsertAndGet(t *testing.T) {
 	ctx, repo, contactRepo, _ := setupCommsMessageTest(t)
 
-	suffix := randomSuffix(t)
+	gen, _ := migrationGenerator(t)
+	suffix := gen.Prefix()
 	contact := newEmailContact(t, ctx, repo, contactRepo, "Test Comms Upsert "+suffix)
 
 	sentAt := accelerated.GetCurrentTime().Truncate(time.Microsecond)
@@ -184,7 +185,8 @@ func TestCommsMessageRepository_UpsertAndGet(t *testing.T) {
 func TestCommsMessageRepository_UpsertSynthesizesProvenanceOnInsert(t *testing.T) {
 	ctx, repo, contactRepo, _ := setupCommsMessageTest(t)
 
-	suffix := randomSuffix(t)
+	gen, _ := migrationGenerator(t)
+	suffix := gen.Prefix()
 	contact := newEmailContact(t, ctx, repo, contactRepo, "Test Comms Synth "+suffix)
 	sentAt := accelerated.GetCurrentTime().Truncate(time.Microsecond)
 
@@ -227,7 +229,8 @@ func TestCommsMessageRepository_UpsertSynthesizesProvenanceOnInsert(t *testing.T
 func TestCommsMessageRepository_GetMessage_NotFound(t *testing.T) {
 	ctx, repo, contactRepo, _ := setupCommsMessageTest(t)
 
-	suffix := randomSuffix(t)
+	gen, _ := migrationGenerator(t)
+	suffix := gen.Prefix()
 	contact := newEmailContact(t, ctx, repo, contactRepo, "Test Comms NotFound "+suffix)
 
 	_, err := repo.GetMessage(ctx, repository.InteractionSourceEmail, "<missing-"+suffix+">", contact.ID)
@@ -238,7 +241,8 @@ func TestCommsMessageRepository_GetMessage_NotFound(t *testing.T) {
 func TestCommsMessageRepository_UpsertIdempotentSameAccount(t *testing.T) {
 	ctx, repo, contactRepo, _ := setupCommsMessageTest(t)
 
-	suffix := randomSuffix(t)
+	gen, _ := migrationGenerator(t)
+	suffix := gen.Prefix()
 	contact := newEmailContact(t, ctx, repo, contactRepo, "Test Comms Idem "+suffix)
 
 	sentAt := accelerated.GetCurrentTime().Truncate(time.Microsecond)
@@ -262,7 +266,8 @@ func TestCommsMessageRepository_UpsertIdempotentSameAccount(t *testing.T) {
 func TestCommsMessageRepository_CrossAccountProvenanceMerge(t *testing.T) {
 	ctx, repo, contactRepo, _ := setupCommsMessageTest(t)
 
-	suffix := randomSuffix(t)
+	gen, _ := migrationGenerator(t)
+	suffix := gen.Prefix()
 	contact := newEmailContact(t, ctx, repo, contactRepo, "Test Comms XAcct "+suffix)
 
 	sentAt := accelerated.GetCurrentTime().Truncate(time.Microsecond)
@@ -300,7 +305,8 @@ func TestCommsMessageRepository_CrossAccountProvenanceMerge(t *testing.T) {
 func TestCommsMessageRepository_SameAccountReplayAfterMerge(t *testing.T) {
 	ctx, repo, contactRepo, _ := setupCommsMessageTest(t)
 
-	suffix := randomSuffix(t)
+	gen, _ := migrationGenerator(t)
+	suffix := gen.Prefix()
 	contact := newEmailContact(t, ctx, repo, contactRepo, "Test Comms ReplayMerge "+suffix)
 
 	sentAt := accelerated.GetCurrentTime().Truncate(time.Microsecond)
@@ -325,7 +331,8 @@ func TestCommsMessageRepository_SameAccountReplayAfterMerge(t *testing.T) {
 func TestCommsMessageRepository_ContentImmutableOnConflict(t *testing.T) {
 	ctx, repo, contactRepo, _ := setupCommsMessageTest(t)
 
-	suffix := randomSuffix(t)
+	gen, _ := migrationGenerator(t)
+	suffix := gen.Prefix()
 	contact := newEmailContact(t, ctx, repo, contactRepo, "Test Comms Immutable "+suffix)
 
 	sentAt := accelerated.GetCurrentTime().Truncate(time.Microsecond)
@@ -354,7 +361,8 @@ func TestCommsMessageRepository_ContentImmutableOnConflict(t *testing.T) {
 func TestCommsMessageRepository_PerParticipantRowsDistinct(t *testing.T) {
 	ctx, repo, contactRepo, _ := setupCommsMessageTest(t)
 
-	suffix := randomSuffix(t)
+	gen, _ := migrationGenerator(t)
+	suffix := gen.Prefix()
 	contactA := newEmailContact(t, ctx, repo, contactRepo, "Test Comms PartA "+suffix)
 	contactB := newEmailContact(t, ctx, repo, contactRepo, "Test Comms PartB "+suffix)
 
@@ -391,7 +399,8 @@ func TestCommsMessageRepository_MarkProcessedTx(t *testing.T) {
 	t.Cleanup(database.Close)
 	interactionRepo := repository.NewInteractionRepository(database.Queries)
 
-	suffix := randomSuffix(t)
+	gen, _ := migrationGenerator(t)
+	suffix := gen.Prefix()
 	contact := newEmailContact(t, ctx, repo, contactRepo, "Test Comms MarkProc "+suffix)
 	t.Cleanup(func() {
 		_ = interactionRepo.HardDeleteInteractionsBySourceRefPrefix(ctx, repository.InteractionSourceEmail, "email-markproc-%")
@@ -447,7 +456,8 @@ func TestCommsMessageRepository_MarkProcessedTx(t *testing.T) {
 func TestCommsMessageRepository_ListByContactNewestFirst(t *testing.T) {
 	ctx, repo, contactRepo, _ := setupCommsMessageTest(t)
 
-	suffix := randomSuffix(t)
+	gen, _ := migrationGenerator(t)
+	suffix := gen.Prefix()
 	contact := newEmailContact(t, ctx, repo, contactRepo, "Test Comms List "+suffix)
 
 	now := accelerated.GetCurrentTime().Truncate(time.Microsecond)
@@ -473,7 +483,8 @@ func TestCommsMessageRepository_ListByContactNewestFirst(t *testing.T) {
 func TestCommsMessageRepository_ListEmailIdentitiesForSync(t *testing.T) {
 	ctx, repo, contactRepo, methodRepo := setupCommsMessageTest(t)
 
-	suffix := randomSuffix(t)
+	gen, _ := migrationGenerator(t)
+	suffix := gen.Prefix()
 	sharedEmail := "shared-" + suffix + "@example.test"
 	uniqueEmail := "unique-" + suffix + "@example.test"
 	deletedEmail := "deleted-" + suffix + "@example.test"
@@ -549,7 +560,8 @@ func TestInteractionSourceCheck_AcceptsEmail(t *testing.T) {
 	interactionRepo := repository.NewInteractionRepository(database.Queries)
 	contactRepo := repository.NewContactRepository(database.Queries)
 
-	suffix := randomSuffix(t)
+	gen, _ := migrationGenerator(t)
+	suffix := gen.Prefix()
 	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
 		FullName: "Test Email Source CHECK " + suffix,
 	})
@@ -614,7 +626,8 @@ func previousBodies(t *testing.T, raw []byte) []string {
 func TestApplyEditByExternalID_PreviousBodiesCapAndRecencyGuard(t *testing.T) {
 	ctx, repo, contactRepo, _ := setupCommsMessageTest(t)
 
-	suffix := randomSuffix(t)
+	gen, _ := migrationGenerator(t)
+	suffix := gen.Prefix()
 	contact := newEmailContact(t, ctx, repo, contactRepo, "Test GChat Edit "+suffix)
 
 	sentAt := accelerated.GetCurrentTime().Truncate(time.Microsecond)
@@ -687,7 +700,8 @@ func TestApplyEditByExternalID_PreviousBodiesCapAndRecencyGuard(t *testing.T) {
 func TestApplyEditByExternalID_FractionalSecondOrdering(t *testing.T) {
 	ctx, repo, contactRepo, _ := setupCommsMessageTest(t)
 
-	suffix := randomSuffix(t)
+	gen, _ := migrationGenerator(t)
+	suffix := gen.Prefix()
 	contact := newEmailContact(t, ctx, repo, contactRepo, "Test GChat Frac "+suffix)
 	src := repository.InteractionSourceGChat
 	sentAt := accelerated.GetCurrentTime().Truncate(time.Microsecond)
@@ -727,7 +741,8 @@ func TestApplyEditByExternalID_FractionalSecondOrdering(t *testing.T) {
 func TestSoftDeleteByExternalID_AllFannedRows(t *testing.T) {
 	ctx, repo, contactRepo, _ := setupCommsMessageTest(t)
 
-	suffix := randomSuffix(t)
+	gen, _ := migrationGenerator(t)
+	suffix := gen.Prefix()
 	contactA := newEmailContact(t, ctx, repo, contactRepo, "Test GChat DelA "+suffix)
 	contactB := newEmailContact(t, ctx, repo, contactRepo, "Test GChat DelB "+suffix)
 	src := repository.InteractionSourceGChat
@@ -761,7 +776,8 @@ func TestSoftDeleteByExternalID_AllFannedRows(t *testing.T) {
 func TestGetLatestByExternalID_NewestFirstAndNotFound(t *testing.T) {
 	ctx, repo, contactRepo, _ := setupCommsMessageTest(t)
 
-	suffix := randomSuffix(t)
+	gen, _ := migrationGenerator(t)
+	suffix := gen.Prefix()
 	contact := newEmailContact(t, ctx, repo, contactRepo, "Test GChat Latest "+suffix)
 	src := repository.InteractionSourceGChat
 
@@ -788,7 +804,8 @@ func TestGetLatestByExternalID_NewestFirstAndNotFound(t *testing.T) {
 func TestBackfillParticipantNames_AdditiveMergeAndIdempotent(t *testing.T) {
 	ctx, repo, contactRepo, _ := setupCommsMessageTest(t)
 
-	suffix := randomSuffix(t)
+	gen, _ := migrationGenerator(t)
+	suffix := gen.Prefix()
 	contact := newEmailContact(t, ctx, repo, contactRepo, "Test Backfill Names "+suffix)
 
 	// Seed a name-less row carrying full content + provenance keys.

--- a/backend/tests/consumer_cadence_updater_cutover_integration_test.go
+++ b/backend/tests/consumer_cadence_updater_cutover_integration_test.go
@@ -79,9 +79,10 @@ func TestIntegration_CadenceUpdater_ApplyInteraction_Outbound_LiveDB(t *testing.
 	ctx := context.Background()
 	cad := "monthly"
 	initial := time.Date(2026, 3, 1, 10, 0, 0, 0, time.UTC)
+	gen, _ := migrationGenerator(t)
 	contactRepo := repository.NewContactRepository(database.Queries)
 	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-		FullName: "Cadence Outbound Apply", Cadence: &cad, LastContacted: &initial,
+		FullName: gen.Prefix() + "Cadence Outbound Apply", Cadence: &cad, LastContacted: &initial,
 	})
 	require.NoError(t, err)
 	defer func() { _ = contactRepo.HardDeleteContact(ctx, contact.ID) }()
@@ -118,9 +119,10 @@ func TestIntegration_CadenceUpdater_ApplyInteraction_Mutual_ForwardOnly(t *testi
 	ctx := context.Background()
 	cad := "weekly"
 	newer := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+	gen, _ := migrationGenerator(t)
 	contactRepo := repository.NewContactRepository(database.Queries)
 	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-		FullName: "Cadence Forward Only", Cadence: &cad, LastContacted: &newer,
+		FullName: gen.Prefix() + "Cadence Forward Only", Cadence: &cad, LastContacted: &newer,
 	})
 	require.NoError(t, err)
 	defer func() { _ = contactRepo.HardDeleteContact(ctx, contact.ID) }()
@@ -153,9 +155,10 @@ func TestIntegration_CadenceUpdater_ApplyInteraction_Manual_UnconditionalBackdat
 	ctx := context.Background()
 	cad := "weekly"
 	newer := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+	gen, _ := migrationGenerator(t)
 	contactRepo := repository.NewContactRepository(database.Queries)
 	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-		FullName: "Cadence Manual Backdate", Cadence: &cad, LastContacted: &newer,
+		FullName: gen.Prefix() + "Cadence Manual Backdate", Cadence: &cad, LastContacted: &newer,
 	})
 	require.NoError(t, err)
 	defer func() { _ = contactRepo.HardDeleteContact(ctx, contact.ID) }()
@@ -194,9 +197,10 @@ func TestIntegration_CadenceUpdater_BulkApply_DoesNotBumpLastInteractionAt(t *te
 	// Seed a pre-merge last_interaction_at on the target so we can
 	// assert the merge leaves it alone. We seed via a mutual
 	// ApplyInteraction (the legitimate path for this column).
+	gen, _ := migrationGenerator(t)
 	contactRepo := repository.NewContactRepository(database.Queries)
 	target, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-		FullName: "Merge LastInteractionAt Guard", LastContacted: &targetLast,
+		FullName: gen.Prefix() + "Merge LastInteractionAt Guard", LastContacted: &targetLast,
 	})
 	require.NoError(t, err)
 	defer func() { _ = contactRepo.HardDeleteContact(ctx, target.ID) }()
@@ -243,9 +247,10 @@ func TestIntegration_CadenceUpdater_BulkApply_ForwardMaxOnMerge(t *testing.T) {
 	ctx := context.Background()
 
 	targetLast := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+	gen, _ := migrationGenerator(t)
 	contactRepo := repository.NewContactRepository(database.Queries)
 	target, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-		FullName: "Merge Target", LastContacted: &targetLast,
+		FullName: gen.Prefix() + "Merge Target", LastContacted: &targetLast,
 	})
 	require.NoError(t, err)
 	defer func() { _ = contactRepo.HardDeleteContact(ctx, target.ID) }()
@@ -282,9 +287,10 @@ func TestIntegration_CadenceUpdater_ApplyContactByOverride_ClearAndBackdate(t *t
 	defer cleanup()
 	ctx := context.Background()
 	cad := "weekly"
+	gen, _ := migrationGenerator(t)
 	contactRepo := repository.NewContactRepository(database.Queries)
 	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-		FullName: "Cadence Override", Cadence: &cad,
+		FullName: gen.Prefix() + "Cadence Override", Cadence: &cad,
 	})
 	require.NoError(t, err)
 	defer func() { _ = contactRepo.HardDeleteContact(ctx, contact.ID) }()
@@ -327,9 +333,10 @@ func TestIntegration_CadenceUpdater_HandleEvent_DuplicateClaim_NoOp(t *testing.T
 	ctx := context.Background()
 	cad := "weekly"
 	initialLast := time.Date(2026, 3, 1, 10, 0, 0, 0, time.UTC)
+	gen, _ := migrationGenerator(t)
 	contactRepo := repository.NewContactRepository(database.Queries)
 	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-		FullName: "Duplicate Claim", Cadence: &cad, LastContacted: &initialLast,
+		FullName: gen.Prefix() + "Duplicate Claim", Cadence: &cad, LastContacted: &initialLast,
 	})
 	require.NoError(t, err)
 	defer func() { _ = contactRepo.HardDeleteContact(ctx, contact.ID) }()
@@ -408,9 +415,10 @@ func TestIntegration_CadenceUpdater_ModeOff_NoWrite(t *testing.T) {
 	ctx := context.Background()
 	cad := "weekly"
 	initialLast := time.Date(2026, 3, 1, 10, 0, 0, 0, time.UTC)
+	gen, _ := migrationGenerator(t)
 	contactRepo := repository.NewContactRepository(database.Queries)
 	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-		FullName: "Cadence Mode Off", Cadence: &cad, LastContacted: &initialLast,
+		FullName: gen.Prefix() + "Cadence Mode Off", Cadence: &cad, LastContacted: &initialLast,
 	})
 	require.NoError(t, err)
 	defer func() { _ = contactRepo.HardDeleteContact(ctx, contact.ID) }()
@@ -442,9 +450,10 @@ func TestIntegration_CadenceUpdater_ContactBy_DerivedFromCadence(t *testing.T) {
 	ctx := context.Background()
 	cad := "monthly"
 	initialLast := time.Date(2026, 3, 1, 10, 0, 0, 0, time.UTC)
+	gen, _ := migrationGenerator(t)
 	contactRepo := repository.NewContactRepository(database.Queries)
 	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-		FullName: "Cadence Contact By", Cadence: &cad, LastContacted: &initialLast,
+		FullName: gen.Prefix() + "Cadence Contact By", Cadence: &cad, LastContacted: &initialLast,
 	})
 	require.NoError(t, err)
 	defer func() { _ = contactRepo.HardDeleteContact(ctx, contact.ID) }()

--- a/backend/tests/consumer_interaction_recorder_integration_test.go
+++ b/backend/tests/consumer_interaction_recorder_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"personal-crm/backend/internal/events"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/service"
+	"personal-crm/backend/internal/synthetic/factory"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -29,6 +30,7 @@ import (
 type consumerTestEnv struct {
 	ctx             context.Context
 	database        *db.Database
+	gen             *factory.Generator
 	cfg             *config.Config
 	bus             *events.Bus
 	contactRepo     *repository.ContactRepository
@@ -185,9 +187,11 @@ func newConsumerTestEnv(t *testing.T, ctx context.Context) *consumerTestEnv {
 
 	manualHandler := service.NewManualInteractionHandler(database.Pool, bus, recorder)
 
+	gen, _ := migrationGenerator(t)
 	return &consumerTestEnv{
 		ctx:             ctx,
 		database:        database,
+		gen:             gen,
 		cfg:             cfg,
 		bus:             bus,
 		contactRepo:     contactRepo,
@@ -228,7 +232,7 @@ func (e *consumerTestEnv) seedCalendarEvent(t *testing.T, contactID uuid.UUID) u
 func (e *consumerTestEnv) newContact(t *testing.T, name string) uuid.UUID {
 	t.Helper()
 	contact, err := e.contactRepo.CreateContact(e.ctx, repository.CreateContactRequest{
-		FullName: name + "-" + uuid.NewString()[:8],
+		FullName: name + "-" + e.gen.Prefix(),
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = e.contactRepo.HardDeleteContact(e.ctx, contact.ID) })

--- a/backend/tests/contact_task_integration_test.go
+++ b/backend/tests/contact_task_integration_test.go
@@ -10,11 +10,11 @@ import (
 	"strings"
 	"testing"
 
-	"personal-crm/backend/internal/accelerated"
 	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/contacttask"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/synthetic/factory"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -44,19 +44,11 @@ func TestContactTask_CRUD(t *testing.T) {
 
 	contactRepo := repository.NewContactRepository(database.Queries)
 	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
+	gen, _ := migrationGenerator(t)
 
-	// Create a test contact
-	now := accelerated.GetCurrentTime()
-	cadence := "weekly"
-	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-		FullName:      "Test Contact for Tasks",
-		Cadence:       &cadence,
-		LastContacted: &now,
-	})
-	require.NoError(t, err)
-	defer func() {
-		_ = contactRepo.HardDeleteContact(ctx, contact.ID)
-	}()
+	// Seed a test contact via the synthetic factory (FK target for the tasks).
+	contact, contactCleanup := seedMigrationContact(ctx, t, database, gen, factory.WithCadence("weekly"))
+	defer contactCleanup()
 
 	t.Run("create and retrieve contact task", func(t *testing.T) {
 		// Create task
@@ -204,7 +196,7 @@ func TestContactTask_CRUD(t *testing.T) {
 		}
 		require.NotNil(t, found, "Task should be in list")
 		assert.Equal(t, contact.FullName, found.FullName)
-		assert.Equal(t, cadence, *found.Cadence)
+		assert.Equal(t, "weekly", *found.Cadence)
 
 		// Clean up
 		err = contactTaskRepo.DeleteContactTask(ctx, task.ID)
@@ -232,11 +224,8 @@ func TestContactTask_CRUD(t *testing.T) {
 	})
 
 	t.Run("cascade delete when contact is deleted", func(t *testing.T) {
-		// Create a new contact
-		tempContact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-			FullName: "Temp Contact for Cascade Test",
-		})
-		require.NoError(t, err)
+		// Seed a fresh contact whose hard-delete must cascade to its task.
+		tempContact, _ := seedMigrationContact(ctx, t, database, gen)
 
 		// Create a task for this contact
 		task, err := contactTaskRepo.CreateContactTask(ctx, repository.CreateContactTaskRequest{
@@ -305,27 +294,16 @@ func TestContactTask_CountByProvider(t *testing.T) {
 	}
 	defer database.Close()
 
-	contactRepo := repository.NewContactRepository(database.Queries)
 	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
+	gen, _ := migrationGenerator(t)
 
-	// Create test contacts
+	// Seed test contacts via the synthetic factory (FK targets only).
 	var contacts []uuid.UUID
 	for i := 0; i < 3; i++ {
-		now := accelerated.GetCurrentTime()
-		cadence := "weekly"
-		c, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-			FullName:      "Test Contact " + uuid.New().String()[:8],
-			Cadence:       &cadence,
-			LastContacted: &now,
-		})
-		require.NoError(t, err)
+		c, cleanup := seedMigrationContact(ctx, t, database, gen, factory.WithCadence("weekly"))
+		defer cleanup()
 		contacts = append(contacts, c.ID)
 	}
-	defer func() {
-		for _, id := range contacts {
-			_ = contactRepo.HardDeleteContact(ctx, id)
-		}
-	}()
 
 	// Create tasks for each contact
 	for i, contactID := range contacts {
@@ -380,21 +358,12 @@ func TestContactTask_SyncedDeadlineMetadata(t *testing.T) {
 	}
 	defer database.Close()
 
-	contactRepo := repository.NewContactRepository(database.Queries)
 	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
+	gen, _ := migrationGenerator(t)
 
-	// Create a test contact
-	now := accelerated.GetCurrentTime()
-	cadence := "weekly"
-	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-		FullName:      "Test Contact for SyncedDeadline",
-		Cadence:       &cadence,
-		LastContacted: &now,
-	})
-	require.NoError(t, err)
-	defer func() {
-		_ = contactRepo.HardDeleteContact(ctx, contact.ID)
-	}()
+	// Seed a test contact via the synthetic factory (FK target for the tasks).
+	contact, contactCleanup := seedMigrationContact(ctx, t, database, gen, factory.WithCadence("weekly"))
+	defer contactCleanup()
 
 	t.Run("create task with synced_deadline metadata", func(t *testing.T) {
 		// Create task with synced_deadline in metadata (simulating what reconciliation does)
@@ -486,19 +455,12 @@ func TestContactTask_ActionTasks(t *testing.T) {
 	}
 	defer database.Close()
 
-	contactRepo := repository.NewContactRepository(database.Queries)
 	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
+	gen, _ := migrationGenerator(t)
 
-	// Create a test contact
-	now := accelerated.GetCurrentTime()
-	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-		FullName:      "Test Contact for Action Tasks",
-		LastContacted: &now,
-	})
-	require.NoError(t, err)
-	defer func() {
-		_ = contactRepo.HardDeleteContact(ctx, contact.ID)
-	}()
+	// Seed a test contact via the synthetic factory (FK target for the tasks).
+	contact, contactCleanup := seedMigrationContact(ctx, t, database, gen)
+	defer contactCleanup()
 
 	t.Run("multiple action tasks per contact allowed", func(t *testing.T) {
 		// Create first action task
@@ -722,18 +684,11 @@ func TestContactTask_Migration046_CheckConstraints(t *testing.T) {
 	}
 	defer database.Close()
 
-	contactRepo := repository.NewContactRepository(database.Queries)
 	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
+	gen, ns := migrationGenerator(t)
 
-	now := accelerated.GetCurrentTime()
-	cadence := "weekly"
-	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-		FullName:      "Migration046 CHECK Constraints",
-		Cadence:       &cadence,
-		LastContacted: &now,
-	})
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = contactRepo.HardDeleteContact(ctx, contact.ID) })
+	contact, contactCleanup := seedMigrationContact(ctx, t, database, gen, factory.WithCadence("weekly"))
+	t.Cleanup(contactCleanup)
 
 	// Composite CHECK rejects every invalid (kind, lifecycle) pair.
 	// Only kind=reach_out participates in all three lifecycles; every
@@ -759,7 +714,7 @@ func TestContactTask_Migration046_CheckConstraints(t *testing.T) {
 				Provider:       "todoist",
 				Kind:           c.kind,
 				Lifecycle:      c.lifecycle,
-				ExternalTaskID: "check-pair-" + c.name + "-" + uuid.New().String()[:8],
+				ExternalTaskID: "check-pair-" + c.name + "-" + ns,
 				State:          "managed",
 			})
 			require.Error(t, err, "(%s, %s) MUST be rejected by composite CHECK", c.kind, c.lifecycle)
@@ -775,7 +730,7 @@ func TestContactTask_Migration046_CheckConstraints(t *testing.T) {
 			Provider:       "todoist",
 			Kind:           "bogus_kind",
 			Lifecycle:      "manual",
-			ExternalTaskID: "check-bogus-kind-" + uuid.New().String()[:8],
+			ExternalTaskID: "check-bogus-kind-" + ns,
 			State:          "managed",
 		})
 		require.Error(t, err)
@@ -795,7 +750,7 @@ func TestContactTask_Migration046_CheckConstraints(t *testing.T) {
 			Provider:       "todoist",
 			Kind:           "reach_out",
 			Lifecycle:      "bogus_lifecycle",
-			ExternalTaskID: "check-bogus-lc-" + uuid.New().String()[:8],
+			ExternalTaskID: "check-bogus-lc-" + ns,
 			State:          "managed",
 		})
 		require.Error(t, err)
@@ -815,7 +770,7 @@ func TestContactTask_Migration046_CheckConstraints(t *testing.T) {
 				Provider:       "todoist",
 				Kind:           legacyKind,
 				Lifecycle:      "manual",
-				ExternalTaskID: "check-legacy-" + legacyKind + "-" + uuid.New().String()[:8],
+				ExternalTaskID: "check-legacy-" + legacyKind + "-" + ns,
 				State:          "managed",
 			})
 			require.Error(t, err, "legacy kind=%q MUST be rejected post-046", legacyKind)
@@ -852,27 +807,19 @@ func TestContactTask_Migration046_PartialUniqueIndexes(t *testing.T) {
 	}
 	defer database.Close()
 
-	contactRepo := repository.NewContactRepository(database.Queries)
 	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
-
-	now := accelerated.GetCurrentTime()
-	cadence := "weekly"
+	gen, ns := migrationGenerator(t)
 
 	t.Run("cadence_due_unique_per_contact_provider", func(t *testing.T) {
-		contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-			FullName:      "Migration046 Cadence Unique " + uuid.New().String()[:8],
-			Cadence:       &cadence,
-			LastContacted: &now,
-		})
-		require.NoError(t, err)
-		t.Cleanup(func() { _ = contactRepo.HardDeleteContact(ctx, contact.ID) })
+		contact, contactCleanup := seedMigrationContact(ctx, t, database, gen, factory.WithCadence("weekly"))
+		t.Cleanup(contactCleanup)
 
-		_, err = contactTaskRepo.CreateContactTask(ctx, repository.CreateContactTaskRequest{
+		_, err := contactTaskRepo.CreateContactTask(ctx, repository.CreateContactTaskRequest{
 			ContactID:      contact.ID,
 			Provider:       "todoist",
 			Kind:           contacttask.KindReachOut,
 			Lifecycle:      contacttask.LifecycleCadenceDue,
-			ExternalTaskID: "cadence-1-" + uuid.New().String()[:8],
+			ExternalTaskID: "cadence-1-" + ns,
 			State:          "managed",
 		})
 		require.NoError(t, err)
@@ -883,27 +830,22 @@ func TestContactTask_Migration046_PartialUniqueIndexes(t *testing.T) {
 			Provider:       "todoist",
 			Kind:           contacttask.KindReachOut,
 			Lifecycle:      contacttask.LifecycleCadenceDue,
-			ExternalTaskID: "cadence-2-" + uuid.New().String()[:8],
+			ExternalTaskID: "cadence-2-" + ns,
 			State:          "managed",
 		})
 		require.Error(t, err, "second cadence_due row for same (contact, provider) must violate unique index")
 	})
 
 	t.Run("followup_loop_live_unique_per_contact_provider", func(t *testing.T) {
-		contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-			FullName:      "Migration046 FollowUp Unique " + uuid.New().String()[:8],
-			Cadence:       &cadence,
-			LastContacted: &now,
-		})
-		require.NoError(t, err)
-		t.Cleanup(func() { _ = contactRepo.HardDeleteContact(ctx, contact.ID) })
+		contact, contactCleanup := seedMigrationContact(ctx, t, database, gen, factory.WithCadence("weekly"))
+		t.Cleanup(contactCleanup)
 
-		_, err = contactTaskRepo.CreateContactTask(ctx, repository.CreateContactTaskRequest{
+		_, err := contactTaskRepo.CreateContactTask(ctx, repository.CreateContactTaskRequest{
 			ContactID:      contact.ID,
 			Provider:       "todoist",
 			Kind:           contacttask.KindReachOut,
 			Lifecycle:      contacttask.LifecycleFollowUpLoop,
-			ExternalTaskID: "followup-1-" + uuid.New().String()[:8],
+			ExternalTaskID: "followup-1-" + ns,
 			State:          "managed",
 		})
 		require.NoError(t, err)
@@ -914,7 +856,7 @@ func TestContactTask_Migration046_PartialUniqueIndexes(t *testing.T) {
 			Provider:       "todoist",
 			Kind:           contacttask.KindReachOut,
 			Lifecycle:      contacttask.LifecycleFollowUpLoop,
-			ExternalTaskID: "followup-2-" + uuid.New().String()[:8],
+			ExternalTaskID: "followup-2-" + ns,
 			State:          "managed",
 		})
 		require.Error(t, err, "second live followup_loop row for same (contact, provider) must violate unique index")
@@ -923,20 +865,15 @@ func TestContactTask_Migration046_PartialUniqueIndexes(t *testing.T) {
 	t.Run("manual_lifecycle_has_no_uniqueness", func(t *testing.T) {
 		// Two reach_out manual tasks for the same contact/provider are
 		// fine — manual lifecycle is intentionally unconstrained.
-		contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-			FullName:      "Migration046 Manual NoUnique " + uuid.New().String()[:8],
-			Cadence:       &cadence,
-			LastContacted: &now,
-		})
-		require.NoError(t, err)
-		t.Cleanup(func() { _ = contactRepo.HardDeleteContact(ctx, contact.ID) })
+		contact, contactCleanup := seedMigrationContact(ctx, t, database, gen, factory.WithCadence("weekly"))
+		t.Cleanup(contactCleanup)
 
-		_, err = contactTaskRepo.CreateContactTask(ctx, repository.CreateContactTaskRequest{
+		_, err := contactTaskRepo.CreateContactTask(ctx, repository.CreateContactTaskRequest{
 			ContactID:      contact.ID,
 			Provider:       "todoist",
 			Kind:           contacttask.KindReachOut,
 			Lifecycle:      contacttask.LifecycleManual,
-			ExternalTaskID: "manual-1-" + uuid.New().String()[:8],
+			ExternalTaskID: "manual-1-" + ns,
 			State:          "managed",
 		})
 		require.NoError(t, err)
@@ -946,7 +883,7 @@ func TestContactTask_Migration046_PartialUniqueIndexes(t *testing.T) {
 			Provider:       "todoist",
 			Kind:           contacttask.KindReachOut,
 			Lifecycle:      contacttask.LifecycleManual,
-			ExternalTaskID: "manual-2-" + uuid.New().String()[:8],
+			ExternalTaskID: "manual-2-" + ns,
 			State:          "managed",
 		})
 		require.NoError(t, err, "manual lifecycle has no uniqueness — both inserts must succeed")

--- a/backend/tests/email_interaction_integration_test.go
+++ b/backend/tests/email_interaction_integration_test.go
@@ -22,6 +22,7 @@ import (
 	"personal-crm/backend/internal/events"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/service"
+	"personal-crm/backend/internal/synthetic/factory"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -33,6 +34,7 @@ import (
 type emailEnv struct {
 	ctx             context.Context
 	database        *db.Database
+	gen             *factory.Generator
 	bus             *events.Bus
 	emailConsumer   *consumer.EmailInteractionConsumer
 	contactRepo     *repository.ContactRepository
@@ -61,9 +63,12 @@ func newEmailEnv(t *testing.T, ctx context.Context) *emailEnv {
 
 	bus, emailConsumer := setupTestEventBusForEmail(t, ctx, database, contactService)
 
+	gen, _ := migrationGenerator(t)
+
 	return &emailEnv{
 		ctx:             ctx,
 		database:        database,
+		gen:             gen,
 		bus:             bus,
 		emailConsumer:   emailConsumer,
 		contactRepo:     contactRepo,
@@ -73,21 +78,19 @@ func newEmailEnv(t *testing.T, ctx context.Context) *emailEnv {
 	}
 }
 
-// newEmailTestContact creates a contact (with a weekly cadence so contact_by
-// rolls) and registers cleanup that hard-deletes its comms_message + email
-// interaction rows then soft-deletes the contact.
-func (e *emailEnv) newEmailTestContact(t *testing.T, name string) *repository.Contact {
+// newEmailTestContact seeds a namespaced contact (no methods — the consumer
+// matches on the contact id carried in the payload, never on an identifier) with
+// a weekly cadence so contact_by rolls, and registers cleanup that hard-deletes
+// its comms_message + email interaction rows before the contact (FK-child rows
+// must go first).
+func (e *emailEnv) newEmailTestContact(t *testing.T) *repository.Contact {
 	t.Helper()
-	cadence := "weekly"
-	contact, err := e.contactRepo.CreateContact(e.ctx, repository.CreateContactRequest{
-		FullName: name,
-		Cadence:  &cadence,
-	})
-	require.NoError(t, err)
+	contact, contactCleanup := seedMigrationContact(e.ctx, t, e.database, e.gen,
+		factory.WithNoMethods(), factory.WithCadence("weekly"))
 	t.Cleanup(func() {
 		_ = e.commsRepo.HardDeleteByContact(e.ctx, contact.ID)
 		_ = e.interactionRepo.HardDeleteInteractionsBySourceRefPrefix(e.ctx, repository.InteractionSourceEmail, contact.ID.String()+":%")
-		_ = e.contactRepo.SoftDeleteContact(e.ctx, contact.ID)
+		contactCleanup()
 	})
 	return contact
 }
@@ -188,7 +191,7 @@ func (e *emailEnv) waitForCommsProcessed(t *testing.T, externalID string, contac
 func TestEmailIntegration_CreateInbound_AppliesCadence(t *testing.T) {
 	ctx := context.Background()
 	e := newEmailEnv(t, ctx)
-	contact := e.newEmailTestContact(t, "Email Inbound A")
+	contact := e.newEmailTestContact(t)
 
 	sentAt := localNoonAnchor()
 	e.seedCommsMessage(t, contact.ID, "<a-1@example.test>", "thr-A", repository.InteractionDirectionInbound, sentAt)
@@ -213,7 +216,7 @@ func TestEmailIntegration_CreateInbound_AppliesCadence(t *testing.T) {
 func TestEmailIntegration_CreateOutbound_AppliesOutreachCadence(t *testing.T) {
 	ctx := context.Background()
 	e := newEmailEnv(t, ctx)
-	contact := e.newEmailTestContact(t, "Email Outbound B")
+	contact := e.newEmailTestContact(t)
 
 	sentAt := localNoonAnchor()
 	e.seedCommsMessage(t, contact.ID, "<b-1@example.test>", "thr-B", repository.InteractionDirectionOutbound, sentAt)
@@ -235,7 +238,7 @@ func TestEmailIntegration_CreateOutbound_AppliesOutreachCadence(t *testing.T) {
 func TestEmailIntegration_SameThreadDay_Extends(t *testing.T) {
 	ctx := context.Background()
 	e := newEmailEnv(t, ctx)
-	contact := e.newEmailTestContact(t, "Email Extend C")
+	contact := e.newEmailTestContact(t)
 
 	t1 := localNoonAnchor()
 	t2 := t1.Add(2 * time.Hour)
@@ -274,7 +277,7 @@ func TestEmailIntegration_SameThreadDay_Extends(t *testing.T) {
 func TestEmailIntegration_NextDay_NewInteraction(t *testing.T) {
 	ctx := context.Background()
 	e := newEmailEnv(t, ctx)
-	contact := e.newEmailTestContact(t, "Email NextDay D")
+	contact := e.newEmailTestContact(t)
 
 	dayD := localNoonAnchor()
 	dayD1 := dayD.Add(24 * time.Hour)
@@ -298,7 +301,7 @@ func TestEmailIntegration_NextDay_NewInteraction(t *testing.T) {
 func TestEmailIntegration_MixedDirection_PromotesToMutual(t *testing.T) {
 	ctx := context.Background()
 	e := newEmailEnv(t, ctx)
-	contact := e.newEmailTestContact(t, "Email Mutual E")
+	contact := e.newEmailTestContact(t)
 
 	t1 := localNoonAnchor()
 	t2 := t1.Add(time.Hour)
@@ -328,7 +331,7 @@ func TestEmailIntegration_MixedDirection_PromotesToMutual(t *testing.T) {
 func TestEmailIntegration_OutOfOrderBackfill_NoBackwardMove(t *testing.T) {
 	ctx := context.Background()
 	e := newEmailEnv(t, ctx)
-	contact := e.newEmailTestContact(t, "Email Backfill F")
+	contact := e.newEmailTestContact(t)
 
 	t1 := localNoonAnchor()
 	t2 := t1.Add(3 * time.Hour)
@@ -363,7 +366,7 @@ func TestEmailIntegration_OutOfOrderBackfill_NoBackwardMove(t *testing.T) {
 func TestEmailIntegration_ReDelivery_Idempotent(t *testing.T) {
 	ctx := context.Background()
 	e := newEmailEnv(t, ctx)
-	contact := e.newEmailTestContact(t, "Email Idempotent G")
+	contact := e.newEmailTestContact(t)
 
 	sentAt := localNoonAnchor()
 	e.seedCommsMessage(t, contact.ID, "<g-1@example.test>", "thr-G", repository.InteractionDirectionInbound, sentAt)
@@ -390,7 +393,7 @@ func TestEmailIntegration_ReDelivery_Idempotent(t *testing.T) {
 func TestEmailIntegration_CrossAccountSameMessageID_OneInteraction(t *testing.T) {
 	ctx := context.Background()
 	e := newEmailEnv(t, ctx)
-	contact := e.newEmailTestContact(t, "Email CrossAcct H")
+	contact := e.newEmailTestContact(t)
 
 	sentAt := localNoonAnchor()
 	e.seedCommsMessage(t, contact.ID, "<h-shared@example.test>", "thr-H", repository.InteractionDirectionInbound, sentAt)
@@ -411,7 +414,7 @@ func TestEmailIntegration_CrossAccountSameMessageID_OneInteraction(t *testing.T)
 func TestEmailIntegration_MatchOnly_NoContactCreation(t *testing.T) {
 	ctx := context.Background()
 	e := newEmailEnv(t, ctx)
-	contact := e.newEmailTestContact(t, "Email MatchOnly I")
+	contact := e.newEmailTestContact(t)
 
 	before := e.countContacts(t)
 
@@ -429,7 +432,7 @@ func TestEmailIntegration_MatchOnly_NoContactCreation(t *testing.T) {
 func TestEmailIntegration_Concurrent_NoBackwardMove(t *testing.T) {
 	ctx := context.Background()
 	e := newEmailEnv(t, ctx)
-	contact := e.newEmailTestContact(t, "Email Concurrent J")
+	contact := e.newEmailTestContact(t)
 
 	t1 := localNoonAnchor()
 	t2 := t1.Add(2 * time.Hour)

--- a/backend/tests/external_contact_soft_delete_sweep_test.go
+++ b/backend/tests/external_contact_soft_delete_sweep_test.go
@@ -3,7 +3,6 @@ package tests
 import (
 	"context"
 	"os"
-	"strings"
 	"testing"
 	"time"
 
@@ -50,7 +49,7 @@ func seedExtSweepFixtures(t *testing.T) *extSweepFixtures {
 	contactRepo.SetPool(database.Pool)
 
 	// Unique prefix per test run so concurrent tests don't collide.
-	prefix := "sweep-" + uuid.NewString()[:8] + "-"
+	prefix := "sweep-" + syntheticNS(t) + "-"
 
 	// Seed a CRM contact the live external_contact row links to. The
 	// ListForCRMContact assertion needs this association.
@@ -171,7 +170,7 @@ func TestExternalContactSweep_ListUnmatched_FiltersTombstone(t *testing.T) {
 	t.Cleanup(func() { database.Close() })
 
 	repo := repository.NewExternalContactRepository(database.Queries)
-	prefix := "sweep-unm-" + uuid.NewString()[:8] + "-"
+	prefix := "sweep-unm-" + syntheticNS(t) + "-"
 	syncedAt := accelerated.GetCurrentTime()
 
 	live, err := repo.Upsert(ctx, repository.UpsertExternalContactRequest{
@@ -223,7 +222,7 @@ func TestExternalContactSweep_ListAllUnmatched_FiltersTombstone(t *testing.T) {
 	t.Cleanup(func() { database.Close() })
 
 	repo := repository.NewExternalContactRepository(database.Queries)
-	prefix := "sweep-allunm-" + uuid.NewString()[:8] + "-"
+	prefix := "sweep-allunm-" + syntheticNS(t) + "-"
 	syncedAt := accelerated.GetCurrentTime()
 	live, err := repo.Upsert(ctx, repository.UpsertExternalContactRequest{
 		Source: "gcontacts", SourceID: prefix + "live", SyncedAt: &syncedAt,
@@ -270,9 +269,10 @@ func TestExternalContactSweep_CountUnmatched_ExcludesTombstone(t *testing.T) {
 	t.Cleanup(func() { database.Close() })
 
 	repo := repository.NewExternalContactRepository(database.Queries)
-	// Use a unique source per-run so counts are bounded.
-	source := "sweep-src-" + strings.ReplaceAll(uuid.NewString()[:8], "-", "")
-	prefix := "sweep-cnt-" + uuid.NewString()[:8] + "-"
+	// Use a unique source per-run so counts are bounded. The namespace token
+	// is alphanumeric, so it needs no hyphen stripping.
+	source := "sweep-src-" + syntheticNS(t)
+	prefix := "sweep-cnt-" + syntheticNS(t) + "-"
 	syncedAt := accelerated.GetCurrentTime()
 	_, err = repo.Upsert(ctx, repository.UpsertExternalContactRequest{
 		Source: source, SourceID: prefix + "live-a", SyncedAt: &syncedAt,
@@ -314,7 +314,7 @@ func TestExternalContactUnmatched_HidesUnresolvedTelegramByDefault(t *testing.T)
 	t.Cleanup(func() { database.Close() })
 
 	repo := repository.NewExternalContactRepository(database.Queries)
-	prefix := "tg-hidden-" + uuid.NewString()[:8] + "-"
+	prefix := "tg-hidden-" + syntheticNS(t) + "-"
 	syncedAt := accelerated.GetCurrentTime()
 	t.Cleanup(func() {
 		cleanCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -407,7 +407,7 @@ func TestExternalContactSweep_ListForCRMContact_FiltersTombstone(t *testing.T) {
 	repo := repository.NewExternalContactRepository(database.Queries)
 	contactRepo := repository.NewContactRepository(database.Queries)
 	contactRepo.SetPool(database.Pool)
-	prefix := "sweep-crm-" + uuid.NewString()[:8] + "-"
+	prefix := "sweep-crm-" + syntheticNS(t) + "-"
 	syncedAt := accelerated.GetCurrentTime()
 
 	crm, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: "Sweep CRM " + prefix})
@@ -465,7 +465,7 @@ func TestExternalContactSweep_RoundTrip_ReviveAfterSoftDelete(t *testing.T) {
 	repo := repository.NewExternalContactRepository(database.Queries)
 	contactRepo := repository.NewContactRepository(database.Queries)
 	contactRepo.SetPool(database.Pool)
-	prefix := "sweep-rt-" + uuid.NewString()[:8] + "-"
+	prefix := "sweep-rt-" + syntheticNS(t) + "-"
 	syncedAt := accelerated.GetCurrentTime()
 
 	crm, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: "RT " + prefix})
@@ -519,7 +519,7 @@ func TestExternalContactSweep_GetByID_AccountIDNullSemantics(t *testing.T) {
 	t.Cleanup(func() { database.Close() })
 
 	repo := repository.NewExternalContactRepository(database.Queries)
-	prefix := "sweep-acct-" + uuid.NewString()[:8] + "-"
+	prefix := "sweep-acct-" + syntheticNS(t) + "-"
 	syncedAt := accelerated.GetCurrentTime()
 
 	// account_id = NULL (icloud_contacts shape).

--- a/backend/tests/followup_apply_interaction_integration_test.go
+++ b/backend/tests/followup_apply_interaction_integration_test.go
@@ -21,9 +21,9 @@ import (
 	"personal-crm/backend/internal/consumer"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/synthetic/factory"
 	"personal-crm/backend/internal/todoist"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
@@ -36,6 +36,7 @@ import (
 // ErrTodoistUnconfigured.
 type applyInteractionEnv struct {
 	database    *db.Database
+	gen         *factory.Generator
 	contactRepo *repository.ContactRepository
 	taskRepo    *repository.ContactTaskRepository
 	riverClient *river.Client[pgx.Tx]
@@ -90,8 +91,10 @@ func newApplyInteractionEnv(t *testing.T, settingsErr error) (*applyInteractionE
 		watchdog,
 	)
 
+	gen, _ := migrationGenerator(t)
 	env := &applyInteractionEnv{
 		database:    database,
+		gen:         gen,
 		contactRepo: contactRepo,
 		taskRepo:    taskRepo,
 		riverClient: riverClient,
@@ -106,8 +109,7 @@ func newApplyInteractionEnv(t *testing.T, settingsErr error) (*applyInteractionE
 func (e *applyInteractionEnv) seedContact(t *testing.T, cadence string) *repository.Contact {
 	t.Helper()
 	ctx := context.Background()
-	name := "ApplyInt-" + uuid.NewString()[:8]
-	req := repository.CreateContactRequest{FullName: name}
+	req := repository.CreateContactRequest{FullName: e.gen.Contact(factory.WithNoMethods()).FullName}
 	if cadence != "" {
 		req.Cadence = &cadence
 	}

--- a/backend/tests/followup_create_worker_integration_test.go
+++ b/backend/tests/followup_create_worker_integration_test.go
@@ -31,6 +31,7 @@ import (
 	"personal-crm/backend/internal/contacttask"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/synthetic/factory"
 	"personal-crm/backend/internal/todoist"
 
 	"github.com/google/uuid"
@@ -90,6 +91,7 @@ func (m *createWorkerMockTodoist) Sync(_ context.Context, _ string, _ []string, 
 
 type createWorkerEnv struct {
 	database    *db.Database
+	gen         *factory.Generator
 	contactRepo *repository.ContactRepository
 	taskRepo    *repository.ContactTaskRepository
 	riverClient *river.Client[pgx.Tx]
@@ -132,8 +134,10 @@ func newCreateWorkerEnv(t *testing.T) (*createWorkerEnv, func()) {
 		riverClient,
 		database.Pool,
 	)
+	gen, _ := migrationGenerator(t)
 	env := &createWorkerEnv{
 		database:    database,
+		gen:         gen,
 		contactRepo: contactRepo,
 		taskRepo:    taskRepo,
 		riverClient: riverClient,
@@ -149,8 +153,7 @@ func newCreateWorkerEnv(t *testing.T) (*createWorkerEnv, func()) {
 func (e *createWorkerEnv) seedPendingTask(t *testing.T) *repository.ContactTask {
 	t.Helper()
 	ctx := context.Background()
-	name := "CreateWorker-" + uuid.NewString()[:8]
-	contact, err := e.contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: name})
+	contact, err := e.contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: e.gen.Contact(factory.WithNoMethods()).FullName})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = e.contactRepo.HardDeleteContact(ctx, contact.ID) })
 

--- a/backend/tests/followup_manager_cutover_integration_test.go
+++ b/backend/tests/followup_manager_cutover_integration_test.go
@@ -41,6 +41,7 @@ import (
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/events"
 	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/synthetic/factory"
 	"personal-crm/backend/internal/todoist"
 
 	"github.com/google/uuid"
@@ -82,6 +83,7 @@ func newFollowUpIntegrationDB(t *testing.T) (*db.Database, func()) {
 // up and HTTP out to a nonexistent Todoist.
 type followUpIntegrationEnv struct {
 	database    *db.Database
+	gen         *factory.Generator
 	contactRepo *repository.ContactRepository
 	taskRepo    *repository.ContactTaskRepository
 	interRepo   *repository.InteractionRepository
@@ -175,8 +177,10 @@ func newFollowUpIntegrationEnv(t *testing.T) (*followUpIntegrationEnv, func()) {
 		decisions = append(decisions, d)
 	})
 
+	gen, _ := migrationGenerator(t)
 	env := &followUpIntegrationEnv{
 		database:    database,
+		gen:         gen,
 		contactRepo: contactRepo,
 		taskRepo:    taskRepo,
 		interRepo:   interRepo,
@@ -266,8 +270,7 @@ func (*followUpIntegrationNoopClient) Sync(context.Context, string, []string, []
 func (e *followUpIntegrationEnv) seedContact(t *testing.T, cadenceStr string) *repository.Contact {
 	t.Helper()
 	ctx := context.Background()
-	name := "FollowUpCutover-" + uuid.NewString()[:8]
-	req := repository.CreateContactRequest{FullName: name}
+	req := repository.CreateContactRequest{FullName: e.gen.Contact(factory.WithNoMethods()).FullName}
 	if cadenceStr != "" {
 		req.Cadence = &cadenceStr
 	}

--- a/backend/tests/gchat_golive_integration_test.go
+++ b/backend/tests/gchat_golive_integration_test.go
@@ -33,6 +33,7 @@ import (
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/service"
 	syncpkg "personal-crm/backend/internal/sync"
+	"personal-crm/backend/internal/synthetic/factory"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -44,7 +45,8 @@ import (
 // is the PR-3 go-live acceptance test.
 func TestGChatGoLive_RegisteredProvider_SchedulerSweep_ProducesInteractionsAndCadence(t *testing.T) {
 	e := setupGChatEngineTest(t) // engine + live bus + recorder + cadence + repos
-	suffix := randomSuffix(t)
+	gen, _ := migrationGenerator(t)
+	prefix := gen.Prefix()
 
 	contactRepo := e.contactRepo
 	contactRepo.SetPool(e.database.Pool)
@@ -52,39 +54,35 @@ func TestGChatGoLive_RegisteredProvider_SchedulerSweep_ProducesInteractionsAndCa
 	syncRepo := repository.NewSyncRepositoryWithPool(e.database.Queries, e.database.Pool)
 	identityRepo := repository.NewIdentityRepository(e.database.Queries)
 
-	account := "me-" + suffix + "@example.test"
+	account := prefix + "me@synthetic.example"
 
 	// Known contact + email method (appears in the provider's dual-source known
-	// map). A cadence makes the contact_by recompute observable.
-	cadence := "weekly"
-	contact, err := contactRepo.CreateContact(e.ctx, repository.CreateContactRequest{
-		FullName: "GChat GoLive " + suffix,
-		Cadence:  &cadence,
-	})
-	require.NoError(t, err)
-	peerEmail := "peer-" + suffix + "@example.test"
-	_, err = methodRepo.CreateContactMethod(e.ctx, repository.CreateContactMethodRequest{
-		ContactID: contact.ID,
-		Type:      string(repository.ContactMethodEmail),
-		Value:     peerEmail,
-		IsPrimary: true,
-	})
+	// map). A cadence makes the contact_by recompute observable. Seeded via the
+	// nil-bus ContactService (single-tx contact+method write, no River client).
+	contactSvc := service.NewContactService(e.database, contactRepo, methodRepo,
+		e.interactionRepo, repository.NewContactTaskRepository(e.database.Queries), nil, nil)
+	spec := gen.Contact(factory.WithEmail(), factory.WithCadence("weekly"))
+	peerEmail := spec.Email
+	contact, _, err := contactSvc.CreateContact(e.ctx, repository.CreateContactRequest{
+		FullName: spec.FullName,
+		Cadence:  spec.Cadence,
+	}, []service.ContactMethodInput{{Type: string(repository.ContactMethodEmail), Value: peerEmail, IsPrimary: true}})
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
 		_ = e.commsRepo.HardDeleteByContact(e.ctx, contact.ID)
 		_ = e.interactionRepo.HardDeleteInteractionsBySourceRefPrefix(e.ctx, repository.InteractionSourceGChat, "gchat:%")
-		_ = contactRepo.SoftDeleteContact(e.ctx, contact.ID)
 		_ = syncRepo.DeleteSyncStatesByAccountID(e.ctx, account)
+		_ = contactRepo.HardDeleteContact(e.ctx, contact.ID)
 	})
 
-	spaceName := "spaces/GOLIVE-" + suffix
-	inMsg := spaceName + "/messages/in-" + suffix
-	outMsg := spaceName + "/messages/out-" + suffix
-	bystanderMsg := spaceName + "/messages/by-" + suffix
+	spaceName := "spaces/GOLIVE-" + prefix
+	inMsg := spaceName + "/messages/in-" + prefix
+	outMsg := spaceName + "/messages/out-" + prefix
+	bystanderMsg := spaceName + "/messages/by-" + prefix
 	base := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Second)
 	// Unknown participant the sweep must NOT turn into a contact.
-	stranger := "stranger-" + suffix + "@example.test"
+	stranger := prefix + "stranger@synthetic.example"
 
 	funcs := google.FakeChatFetcherFuncs{
 		ListSpaces: func(context.Context, string) ([]*chat.Space, string, error) {

--- a/backend/tests/gchat_provider_integration_test.go
+++ b/backend/tests/gchat_provider_integration_test.go
@@ -12,6 +12,8 @@ import (
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/google"
 	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+	"personal-crm/backend/internal/synthetic/factory"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -21,12 +23,13 @@ import (
 
 // gchatProviderEnv bundles the repos a GChat provider integration test needs.
 type gchatProviderEnv struct {
-	ctx         context.Context
-	database    *db.Database
-	commsRepo   *repository.CommsMessageRepository
-	contactRepo *repository.ContactRepository
-	methodRepo  *repository.ContactMethodRepository
-	syncRepo    *repository.SyncRepository
+	ctx            context.Context
+	database       *db.Database
+	gen            *factory.Generator
+	commsRepo      *repository.CommsMessageRepository
+	contactRepo    *repository.ContactRepository
+	contactService *service.ContactService
+	syncRepo       *repository.SyncRepository
 }
 
 func setupGChatProviderTest(t *testing.T) *gchatProviderEnv {
@@ -45,34 +48,44 @@ func setupGChatProviderTest(t *testing.T) *gchatProviderEnv {
 	require.NoError(t, err)
 	t.Cleanup(database.Close)
 
+	contactRepo := repository.NewContactRepository(database.Queries)
+	methodRepo := repository.NewContactMethodRepository(database.Queries)
+	interactionRepo := repository.NewInteractionRepository(database.Queries)
+	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
+	// nil bus + nil rematch: a single-tx multi-method seed write, no River client.
+	contactService := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, contactTaskRepo, nil, nil)
+
+	gen, _ := migrationGenerator(t)
+
 	return &gchatProviderEnv{
-		ctx:         ctx,
-		database:    database,
-		commsRepo:   repository.NewCommsMessageRepository(database.Queries),
-		contactRepo: repository.NewContactRepository(database.Queries),
-		methodRepo:  repository.NewContactMethodRepository(database.Queries),
-		syncRepo:    repository.NewSyncRepositoryWithPool(database.Queries, database.Pool),
+		ctx:            ctx,
+		database:       database,
+		gen:            gen,
+		commsRepo:      repository.NewCommsMessageRepository(database.Queries),
+		contactRepo:    contactRepo,
+		contactService: contactService,
+		syncRepo:       repository.NewSyncRepositoryWithPool(database.Queries, database.Pool),
 	}
 }
 
-// newGChatProviderContact creates a contact with a contact_method of the given
-// type+value (so it appears in the dual-source known map), registering cleanup
-// that hard-deletes its comms rows and soft-deletes the contact.
-func (e *gchatProviderEnv) newGChatProviderContact(t *testing.T, name, methodType, methodValue string) *repository.Contact {
+// newGChatProviderContact seeds a namespaced contact with one contact_method of
+// the given type whose value is a factory-namespaced email (so it appears in the
+// dual-source known map), and returns it plus that value (the match key). The
+// method type varies per test (email vs gchat); the value is always an
+// email-shaped address the provider resolves a chat user to.
+func (e *gchatProviderEnv) newGChatProviderContact(t *testing.T, methodType string) (*repository.Contact, string) {
 	t.Helper()
-	contact, err := e.contactRepo.CreateContact(e.ctx, repository.CreateContactRequest{FullName: name})
-	require.NoError(t, err)
-	_, err = e.methodRepo.CreateContactMethod(e.ctx, repository.CreateContactMethodRequest{
-		ContactID: contact.ID,
-		Type:      methodType,
-		Value:     methodValue,
-	})
+	spec := e.gen.Contact(factory.WithEmail())
+	value := spec.Email
+	contact, _, err := e.contactService.CreateContact(e.ctx, repository.CreateContactRequest{
+		FullName: spec.FullName,
+	}, []service.ContactMethodInput{{Type: methodType, Value: value}})
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		_ = e.commsRepo.HardDeleteByContact(e.ctx, contact.ID)
-		_ = e.contactRepo.SoftDeleteContact(e.ctx, contact.ID)
+		_ = e.contactRepo.HardDeleteContact(e.ctx, contact.ID)
 	})
-	return contact
+	return contact, value
 }
 
 // newGChatSyncState creates an external_sync_state(source='gchat') row for an
@@ -127,14 +140,13 @@ func chatMessage(name, senderUser, text string, createTime time.Time) *chat.Mess
 // per-space metadata. The row is content-only until the engine aggregates.
 func TestGChatProvider_FullSweep_InboundWritesRowNoEvents(t *testing.T) {
 	e := setupGChatProviderTest(t)
-	suffix := randomSuffix(t)
+	prefix := e.gen.Prefix()
 
-	aliceEmail := "alice-" + suffix + "@example.test"
-	alice := e.newGChatProviderContact(t, "GChat Sweep Alice "+suffix, string(repository.ContactMethodEmail), aliceEmail)
+	alice, aliceEmail := e.newGChatProviderContact(t, string(repository.ContactMethodEmail))
 
-	spaceName := "spaces/SWEEP-" + suffix
-	msgName := spaceName + "/messages/m1-" + suffix
-	accountID := "me-" + suffix + "@example.test"
+	spaceName := "spaces/SWEEP-" + prefix
+	msgName := spaceName + "/messages/m1-" + prefix
+	accountID := prefix + "me@synthetic.example"
 	st := e.newGChatSyncState(t, accountID, true, nil)
 	sentAt := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Second)
 
@@ -199,17 +211,15 @@ func TestGChatProvider_FullSweep_InboundWritesRowNoEvents(t *testing.T) {
 // external_id), while a bystander sender produces no row.
 func TestGChatProvider_OutboundFanOutAndBystander(t *testing.T) {
 	e := setupGChatProviderTest(t)
-	suffix := randomSuffix(t)
+	prefix := e.gen.Prefix()
 
-	aliceEmail := "alice-" + suffix + "@example.test"
-	bobEmail := "bob-" + suffix + "@example.test"
-	alice := e.newGChatProviderContact(t, "GChat Fan Alice "+suffix, string(repository.ContactMethodGChat), aliceEmail)
-	bob := e.newGChatProviderContact(t, "GChat Fan Bob "+suffix, string(repository.ContactMethodEmail), bobEmail)
+	alice, aliceEmail := e.newGChatProviderContact(t, string(repository.ContactMethodGChat))
+	bob, bobEmail := e.newGChatProviderContact(t, string(repository.ContactMethodEmail))
 
-	spaceName := "spaces/FAN-" + suffix
-	outboundMsg := spaceName + "/messages/out-" + suffix
-	bystanderMsg := spaceName + "/messages/by-" + suffix
-	accountID := "me-" + suffix + "@example.test"
+	spaceName := "spaces/FAN-" + prefix
+	outboundMsg := spaceName + "/messages/out-" + prefix
+	bystanderMsg := spaceName + "/messages/by-" + prefix
+	accountID := prefix + "me@synthetic.example"
 	e.newGChatSyncState(t, accountID, true, nil)
 	base := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Second)
 
@@ -238,7 +248,7 @@ func TestGChatProvider_OutboundFanOutAndBystander(t *testing.T) {
 			case "users/bob":
 				return bobEmail, nil
 			case "users/stranger":
-				return "stranger-" + suffix + "@example.test", nil
+				return "stranger-" + prefix + "@synthetic.example", nil
 			}
 			return "", nil
 		},
@@ -268,15 +278,14 @@ func TestGChatProvider_OutboundFanOutAndBystander(t *testing.T) {
 // accounts produces ONE row per matched contact with observed_accounts merged.
 func TestGChatProvider_CrossAccountDedup(t *testing.T) {
 	e := setupGChatProviderTest(t)
-	suffix := randomSuffix(t)
+	prefix := e.gen.Prefix()
 
-	aliceEmail := "alice-" + suffix + "@example.test"
-	alice := e.newGChatProviderContact(t, "GChat XAcct Alice "+suffix, string(repository.ContactMethodEmail), aliceEmail)
+	alice, aliceEmail := e.newGChatProviderContact(t, string(repository.ContactMethodEmail))
 
-	spaceName := "spaces/XACCT-" + suffix
-	msgName := spaceName + "/messages/m-" + suffix
-	acctA := "acctA-" + suffix + "@example.test"
-	acctB := "acctB-" + suffix + "@example.test"
+	spaceName := "spaces/XACCT-" + prefix
+	msgName := spaceName + "/messages/m-" + prefix
+	acctA := "acctA-" + prefix + "@synthetic.example"
+	acctB := "acctB-" + prefix + "@synthetic.example"
 	sentAt := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Second)
 
 	mkFuncs := func(myAccount string) google.FakeChatFetcherFuncs {
@@ -333,14 +342,13 @@ func TestGChatProvider_CrossAccountDedup(t *testing.T) {
 // processed_at untouched (so the engine does not reprocess).
 func TestGChatProvider_EditReconciliation(t *testing.T) {
 	e := setupGChatProviderTest(t)
-	suffix := randomSuffix(t)
+	prefix := e.gen.Prefix()
 
-	aliceEmail := "alice-" + suffix + "@example.test"
-	alice := e.newGChatProviderContact(t, "GChat EditRecon Alice "+suffix, string(repository.ContactMethodEmail), aliceEmail)
+	alice, aliceEmail := e.newGChatProviderContact(t, string(repository.ContactMethodEmail))
 
-	spaceName := "spaces/EDITRECON-" + suffix
-	msgName := spaceName + "/messages/m-" + suffix
-	accountID := "me-" + suffix + "@example.test"
+	spaceName := "spaces/EDITRECON-" + prefix
+	msgName := spaceName + "/messages/m-" + prefix
+	accountID := prefix + "me@synthetic.example"
 	e.newGChatSyncState(t, accountID, true, nil)
 	sentAt := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Second)
 	editTime := accelerated.GetCurrentTime().Add(-30 * time.Minute)
@@ -391,7 +399,7 @@ func TestGChatProvider_EditReconciliation(t *testing.T) {
 
 	// Simulate the engine having processed the row (mark it processed via a
 	// real interaction) so we can prove the edit does NOT clear processed_at.
-	ref := "gchat:" + spaceName + ":proc-" + suffix
+	ref := "gchat:" + spaceName + ":proc-" + prefix
 	interactionRepo := repository.NewInteractionRepository(e.database.Queries)
 	interaction, err := interactionRepo.CreateInteraction(e.ctx, repository.CreateInteractionRequest{
 		ContactID: alice.ID, Source: repository.InteractionSourceGChat, SourceRef: &ref,
@@ -427,14 +435,13 @@ func TestGChatProvider_EditReconciliation(t *testing.T) {
 // provider's body-only pre-filter does not invert fractional ordering.
 func TestGChatProvider_EditFractionalOrdering(t *testing.T) {
 	e := setupGChatProviderTest(t)
-	suffix := randomSuffix(t)
+	prefix := e.gen.Prefix()
 
-	aliceEmail := "alice-" + suffix + "@example.test"
-	alice := e.newGChatProviderContact(t, "GChat Frac Alice "+suffix, string(repository.ContactMethodEmail), aliceEmail)
+	alice, aliceEmail := e.newGChatProviderContact(t, string(repository.ContactMethodEmail))
 
-	spaceName := "spaces/FRAC-" + suffix
-	msgName := spaceName + "/messages/m-" + suffix
-	accountID := "me-" + suffix + "@example.test"
+	spaceName := "spaces/FRAC-" + prefix
+	msgName := spaceName + "/messages/m-" + prefix
+	accountID := prefix + "me@synthetic.example"
 	e.newGChatSyncState(t, accountID, true, nil)
 	sentAt := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Second)
 
@@ -496,14 +503,13 @@ func TestGChatProvider_EditFractionalOrdering(t *testing.T) {
 // re-list soft-deletes all fanned-out rows for the message.
 func TestGChatProvider_DeleteReconciliation(t *testing.T) {
 	e := setupGChatProviderTest(t)
-	suffix := randomSuffix(t)
+	prefix := e.gen.Prefix()
 
-	aliceEmail := "alice-" + suffix + "@example.test"
-	alice := e.newGChatProviderContact(t, "GChat DelRecon Alice "+suffix, string(repository.ContactMethodEmail), aliceEmail)
+	alice, aliceEmail := e.newGChatProviderContact(t, string(repository.ContactMethodEmail))
 
-	spaceName := "spaces/DELRECON-" + suffix
-	msgName := spaceName + "/messages/m-" + suffix
-	accountID := "me-" + suffix + "@example.test"
+	spaceName := "spaces/DELRECON-" + prefix
+	msgName := spaceName + "/messages/m-" + prefix
+	accountID := prefix + "me@synthetic.example"
 	e.newGChatSyncState(t, accountID, true, nil)
 	sentAt := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Second)
 
@@ -562,13 +568,12 @@ func TestGChatProvider_DeleteReconciliation(t *testing.T) {
 // advances the create cursor so already-ingested messages are not re-listed.
 func TestGChatProvider_MetadataReusedAcrossSweeps(t *testing.T) {
 	e := setupGChatProviderTest(t)
-	suffix := randomSuffix(t)
+	prefix := e.gen.Prefix()
 
-	aliceEmail := "alice-" + suffix + "@example.test"
-	e.newGChatProviderContact(t, "GChat MetaReuse Alice "+suffix, string(repository.ContactMethodEmail), aliceEmail)
+	_, aliceEmail := e.newGChatProviderContact(t, string(repository.ContactMethodEmail))
 
-	spaceName := "spaces/METAREUSE-" + suffix
-	accountID := "me-" + suffix + "@example.test"
+	spaceName := "spaces/METAREUSE-" + prefix
+	accountID := prefix + "me@synthetic.example"
 	e.newGChatSyncState(t, accountID, true, nil)
 	sentAt := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Second)
 
@@ -591,7 +596,7 @@ func TestGChatProvider_MetadataReusedAcrossSweeps(t *testing.T) {
 			if showDeleted {
 				return nil, "", nil
 			}
-			return []*chat.Message{chatMessage(spaceName+"/messages/m-"+suffix, "users/alice", "hi", sentAt)}, "", nil
+			return []*chat.Message{chatMessage(spaceName+"/messages/m-"+prefix, "users/alice", "hi", sentAt)}, "", nil
 		},
 		ResolvePersonEmail: func(_ context.Context, userName string) (string, error) {
 			resolveCalls++
@@ -629,14 +634,13 @@ func TestGChatProvider_MetadataReusedAcrossSweeps(t *testing.T) {
 // scans the address across the enabled account and upserts a row.
 func TestGChatRematch_ScansWhenEnabled(t *testing.T) {
 	e := setupGChatProviderTest(t)
-	suffix := randomSuffix(t)
+	prefix := e.gen.Prefix()
 
-	aliceEmail := "alice-" + suffix + "@example.test"
-	alice := e.newGChatProviderContact(t, "GChat Rematch Alice "+suffix, string(repository.ContactMethodGChat), aliceEmail)
+	alice, aliceEmail := e.newGChatProviderContact(t, string(repository.ContactMethodGChat))
 
-	spaceName := "spaces/REMATCH-" + suffix
-	msgName := spaceName + "/messages/m-" + suffix
-	accountID := "me-" + suffix + "@example.test"
+	spaceName := "spaces/REMATCH-" + prefix
+	msgName := spaceName + "/messages/m-" + prefix
+	accountID := prefix + "me@synthetic.example"
 	e.newGChatSyncState(t, accountID, true, nil)
 	sentAt := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Second)
 
@@ -680,21 +684,23 @@ func TestGChatRematch_ScansWhenEnabled(t *testing.T) {
 // the engine derives an interaction in the same rematch pass.
 func TestGChatRematchHandler_ScansAndAggregates(t *testing.T) {
 	env := setupGChatEngineTest(t) // wired engine + recorder
-	suffix := randomSuffix(t)
+	gen, _ := migrationGenerator(t)
+	prefix := gen.Prefix()
 
 	methodRepo := repository.NewContactMethodRepository(env.database.Queries)
 	syncRepo := repository.NewSyncRepositoryWithPool(env.database.Queries, env.database.Pool)
 
-	aliceEmail := "alice-" + suffix + "@example.test"
-	alice := env.newGChatContact(t, "GChat RematchHandler Alice "+suffix)
+	spec := gen.Contact(factory.WithEmail())
+	aliceEmail := spec.Email
+	alice := env.newGChatContact(t, spec.FullName)
 	_, err := methodRepo.CreateContactMethod(env.ctx, repository.CreateContactMethodRequest{
 		ContactID: alice.ID, Type: string(repository.ContactMethodGChat), Value: aliceEmail,
 	})
 	require.NoError(t, err)
 
-	spaceName := "spaces/REMATCHH-" + suffix
-	msgName := spaceName + "/messages/m-" + suffix
-	accountID := "me-" + suffix + "@example.test"
+	spaceName := "spaces/REMATCHH-" + prefix
+	msgName := spaceName + "/messages/m-" + prefix
+	accountID := prefix + "me@synthetic.example"
 	st, err := syncRepo.CreateSyncState(env.ctx, repository.CreateSyncStateRequest{
 		Source: repository.InteractionSourceGChat, AccountID: &accountID, Enabled: true,
 	})
@@ -750,13 +756,12 @@ func TestGChatRematchHandler_ScansAndAggregates(t *testing.T) {
 // → DB), not the budget boundary.
 func TestGChatProvider_MultiPageWindowPersistsCursor(t *testing.T) {
 	e := setupGChatProviderTest(t)
-	suffix := randomSuffix(t)
+	prefix := e.gen.Prefix()
 
-	aliceEmail := "alice-" + suffix + "@example.test"
-	alice := e.newGChatProviderContact(t, "GChat Paged Alice "+suffix, string(repository.ContactMethodEmail), aliceEmail)
+	alice, aliceEmail := e.newGChatProviderContact(t, string(repository.ContactMethodEmail))
 
-	spaceName := "spaces/PAGED-" + suffix
-	accountID := "me-" + suffix + "@example.test"
+	spaceName := "spaces/PAGED-" + prefix
+	accountID := prefix + "me@synthetic.example"
 	e.newGChatSyncState(t, accountID, true, nil)
 
 	// Three content pages, oldest-first; the newest message (on the final page)
@@ -783,11 +788,11 @@ func TestGChatProvider_MultiPageWindowPersistsCursor(t *testing.T) {
 			// page 3 → "" (fully paged). The newest message is on the final page.
 			switch token {
 			case "":
-				return []*chat.Message{chatMessage(spaceName+"/messages/m1-"+suffix, "users/alice", "first", msg1At)}, "p2", nil
+				return []*chat.Message{chatMessage(spaceName+"/messages/m1-"+prefix, "users/alice", "first", msg1At)}, "p2", nil
 			case "p2":
-				return []*chat.Message{chatMessage(spaceName+"/messages/m2-"+suffix, "users/alice", "second", msg2At)}, "p3", nil
+				return []*chat.Message{chatMessage(spaceName+"/messages/m2-"+prefix, "users/alice", "second", msg2At)}, "p3", nil
 			case "p3":
-				return []*chat.Message{chatMessage(spaceName+"/messages/m3-"+suffix, "users/alice", "third", latestAt)}, "", nil
+				return []*chat.Message{chatMessage(spaceName+"/messages/m3-"+prefix, "users/alice", "third", latestAt)}, "", nil
 			}
 			return nil, "", nil
 		},
@@ -810,7 +815,7 @@ func TestGChatProvider_MultiPageWindowPersistsCursor(t *testing.T) {
 	assert.Equal(t, 3, result.ItemsProcessed, "all three pages' messages processed")
 
 	// A row exists for the newest message (proving the window paged to the end).
-	_, err = e.commsRepo.GetMessage(e.ctx, repository.InteractionSourceGChat, spaceName+"/messages/m3-"+suffix, alice.ID)
+	_, err = e.commsRepo.GetMessage(e.ctx, repository.InteractionSourceGChat, spaceName+"/messages/m3-"+prefix, alice.ID)
 	require.NoError(t, err)
 
 	// The persisted create_cursor equals the latest message's create_time. The
@@ -855,15 +860,14 @@ func spaceCursorFromMetadata(t *testing.T, metadata map[string]any, spaceName st
 // the group space; (d) the cursor advances (window proven).
 func TestGChatProvider_MatchesContactNotInGoogleContacts(t *testing.T) {
 	e := setupGChatProviderTest(t)
-	suffix := randomSuffix(t)
+	prefix := e.gen.Prefix()
 
-	daveEmail := "dave-" + suffix + "@example.test"
-	dave := e.newGChatProviderContact(t, "GChat NotInContacts Dave "+suffix, string(repository.ContactMethodEmail), daveEmail)
+	dave, daveEmail := e.newGChatProviderContact(t, string(repository.ContactMethodEmail))
 
-	spaceName := "spaces/NOTINCONTACTS-" + suffix
-	inboundMsg := spaceName + "/messages/in-" + suffix
-	outboundMsg := spaceName + "/messages/out-" + suffix
-	accountID := "me-" + suffix + "@example.test"
+	spaceName := "spaces/NOTINCONTACTS-" + prefix
+	inboundMsg := spaceName + "/messages/in-" + prefix
+	outboundMsg := spaceName + "/messages/out-" + prefix
+	accountID := prefix + "me@synthetic.example"
 	e.newGChatSyncState(t, accountID, true, nil)
 	base := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Second)
 
@@ -934,14 +938,13 @@ func TestGChatProvider_MatchesContactNotInGoogleContacts(t *testing.T) {
 // advanced past the message).
 func TestGChatProvider_StaleNegativeClearedOnMembershipChange(t *testing.T) {
 	e := setupGChatProviderTest(t)
-	suffix := randomSuffix(t)
+	prefix := e.gen.Prefix()
 
-	daveEmail := "dave-" + suffix + "@example.test"
-	dave := e.newGChatProviderContact(t, "GChat StaleNeg Dave "+suffix, string(repository.ContactMethodEmail), daveEmail)
+	dave, daveEmail := e.newGChatProviderContact(t, string(repository.ContactMethodEmail))
 
-	spaceName := "spaces/STALENEG-" + suffix
-	joinMsg := spaceName + "/messages/join-" + suffix
-	accountID := "me-" + suffix + "@example.test"
+	spaceName := "spaces/STALENEG-" + prefix
+	joinMsg := spaceName + "/messages/join-" + prefix
+	accountID := prefix + "me@synthetic.example"
 	e.newGChatSyncState(t, accountID, true, nil)
 	base := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Second)
 
@@ -1009,16 +1012,15 @@ func TestGChatProvider_StaleNegativeClearedOnMembershipChange(t *testing.T) {
 // ResolveMemberID calls (the global positive is reused from persisted metadata).
 func TestGChatProvider_GlobalPositiveCachePersistsAndReused(t *testing.T) {
 	e := setupGChatProviderTest(t)
-	suffix := randomSuffix(t)
+	prefix := e.gen.Prefix()
 
-	daveEmail := "dave-" + suffix + "@example.test"
-	dave := e.newGChatProviderContact(t, "GChat GlobalPos Dave "+suffix, string(repository.ContactMethodEmail), daveEmail)
+	dave, daveEmail := e.newGChatProviderContact(t, string(repository.ContactMethodEmail))
 
-	spaceA := "spaces/GPA-" + suffix
-	spaceB := "spaces/GPB-" + suffix
-	msgA := spaceA + "/messages/a-" + suffix
-	msgB := spaceB + "/messages/b-" + suffix
-	accountID := "me-" + suffix + "@example.test"
+	spaceA := "spaces/GPA-" + prefix
+	spaceB := "spaces/GPB-" + prefix
+	msgA := spaceA + "/messages/a-" + prefix
+	msgB := spaceB + "/messages/b-" + prefix
+	accountID := prefix + "me@synthetic.example"
 	e.newGChatSyncState(t, accountID, true, nil)
 	base := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Second)
 
@@ -1089,20 +1091,18 @@ func TestGChatProvider_GlobalPositiveCachePersistsAndReused(t *testing.T) {
 // assertion.
 func TestGChatProvider_ColdStartProcessesAndAdvancesDespiteResolveDebt(t *testing.T) {
 	e := setupGChatProviderTest(t)
-	suffix := randomSuffix(t)
+	prefix := e.gen.Prefix()
 
-	aliceEmail := "alice-" + suffix + "@example.test"
-	alice := e.newGChatProviderContact(t, "GChat ColdStart Alice "+suffix, string(repository.ContactMethodEmail), aliceEmail)
+	alice, aliceEmail := e.newGChatProviderContact(t, string(repository.ContactMethodEmail))
 	// A second known contact whose id is NOT in Contacts (would need members.get) —
 	// deferred by cap=0, but must NOT hold any cursor.
-	daveEmail := "dave-" + suffix + "@example.test"
-	e.newGChatProviderContact(t, "GChat ColdStart Dave "+suffix, string(repository.ContactMethodEmail), daveEmail)
+	_, daveEmail := e.newGChatProviderContact(t, string(repository.ContactMethodEmail))
 
-	spaceA := "spaces/COLDA-" + suffix
-	spaceB := "spaces/COLDB-" + suffix
-	msgA := spaceA + "/messages/a-" + suffix
-	msgB := spaceB + "/messages/b-" + suffix
-	accountID := "me-" + suffix + "@example.test"
+	spaceA := "spaces/COLDA-" + prefix
+	spaceB := "spaces/COLDB-" + prefix
+	msgA := spaceA + "/messages/a-" + prefix
+	msgB := spaceB + "/messages/b-" + prefix
+	accountID := prefix + "me@synthetic.example"
 	e.newGChatSyncState(t, accountID, true, nil)
 	base := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Second)
 
@@ -1176,18 +1176,16 @@ func TestGChatProvider_ColdStartProcessesAndAdvancesDespiteResolveDebt(t *testin
 // NEW message from the now-resolvable contact, sent after the cursor, matches.
 func TestGChatProvider_DeferredIDContactMatchesOnLaterSweep(t *testing.T) {
 	e := setupGChatProviderTest(t)
-	suffix := randomSuffix(t)
+	prefix := e.gen.Prefix()
 
-	aliceEmail := "alice-" + suffix + "@example.test"
-	alice := e.newGChatProviderContact(t, "GChat Deferred Alice "+suffix, string(repository.ContactMethodEmail), aliceEmail)
-	daveEmail := "dave-" + suffix + "@example.test"
-	dave := e.newGChatProviderContact(t, "GChat Deferred Dave "+suffix, string(repository.ContactMethodEmail), daveEmail)
+	alice, aliceEmail := e.newGChatProviderContact(t, string(repository.ContactMethodEmail))
+	dave, daveEmail := e.newGChatProviderContact(t, string(repository.ContactMethodEmail))
 
-	spaceName := "spaces/DEFER-" + suffix
-	aliceMsg := spaceName + "/messages/alice-" + suffix
-	daveMsg1 := spaceName + "/messages/dave1-" + suffix
-	daveMsg2 := spaceName + "/messages/dave2-" + suffix
-	accountID := "me-" + suffix + "@example.test"
+	spaceName := "spaces/DEFER-" + prefix
+	aliceMsg := spaceName + "/messages/alice-" + prefix
+	daveMsg1 := spaceName + "/messages/dave1-" + prefix
+	daveMsg2 := spaceName + "/messages/dave2-" + prefix
+	accountID := prefix + "me@synthetic.example"
 	e.newGChatSyncState(t, accountID, true, nil)
 	base := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Second)
 
@@ -1278,19 +1276,17 @@ func TestGChatProvider_DeferredIDContactMatchesOnLaterSweep(t *testing.T) {
 // matchable rows and proven advances it).
 func TestGChatProvider_NoCurrentMemberSpaceStillPagesAndAdvances(t *testing.T) {
 	e := setupGChatProviderTest(t)
-	suffix := randomSuffix(t)
+	prefix := e.gen.Prefix()
 
 	// Former member: a known contact who LEFT the space but has inbound history.
-	formerEmail := "former-" + suffix + "@example.test"
-	former := e.newGChatProviderContact(t, "GChat Former "+suffix, string(repository.ContactMethodEmail), formerEmail)
+	former, formerEmail := e.newGChatProviderContact(t, string(repository.ContactMethodEmail))
 	// Deferred contact for the second space (id never resolves under cap=0).
-	deferredEmail := "deferred-" + suffix + "@example.test"
-	deferred := e.newGChatProviderContact(t, "GChat DeferredOnly "+suffix, string(repository.ContactMethodEmail), deferredEmail)
+	deferred, deferredEmail := e.newGChatProviderContact(t, string(repository.ContactMethodEmail))
 
-	formerSpace := "spaces/FORMER-" + suffix
-	formerMsg := formerSpace + "/messages/former-" + suffix
-	deferredSpace := "spaces/DEFERREDONLY-" + suffix
-	accountID := "me-" + suffix + "@example.test"
+	formerSpace := "spaces/FORMER-" + prefix
+	formerMsg := formerSpace + "/messages/former-" + prefix
+	deferredSpace := "spaces/DEFERREDONLY-" + prefix
+	accountID := prefix + "me@synthetic.example"
 	e.newGChatSyncState(t, accountID, true, nil)
 	base := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Second)
 
@@ -1370,15 +1366,14 @@ func TestGChatProvider_NoCurrentMemberSpaceStillPagesAndAdvances(t *testing.T) {
 // space is also processed in the same sweep (forward progress, no starvation).
 func TestGChatProvider_ColdStartFrontSpaceDoesNotStarveLaterSpaces(t *testing.T) {
 	e := setupGChatProviderTest(t)
-	suffix := randomSuffix(t)
+	prefix := e.gen.Prefix()
 
-	aliceEmail := "alice-" + suffix + "@example.test"
-	alice := e.newGChatProviderContact(t, "GChat Starve Alice "+suffix, string(repository.ContactMethodEmail), aliceEmail)
+	alice, aliceEmail := e.newGChatProviderContact(t, string(repository.ContactMethodEmail))
 
-	frontSpace := "spaces/FRONT-" + suffix
-	laterSpace := "spaces/LATER-" + suffix
-	laterMsg := laterSpace + "/messages/later-" + suffix
-	accountID := "me-" + suffix + "@example.test"
+	frontSpace := "spaces/FRONT-" + prefix
+	laterSpace := "spaces/LATER-" + prefix
+	laterMsg := laterSpace + "/messages/later-" + prefix
+	accountID := prefix + "me@synthetic.example"
 	e.newGChatSyncState(t, accountID, true, nil)
 	base := accelerated.GetCurrentTime().Add(-3 * time.Hour).Truncate(time.Second)
 
@@ -1398,11 +1393,11 @@ func TestGChatProvider_ColdStartFrontSpaceDoesNotStarveLaterSpaces(t *testing.T)
 				// A multi-page history for the front space (three pages).
 				switch token {
 				case "":
-					return []*chat.Message{chatMessage(frontSpace+"/messages/f1-"+suffix, "users/alice", "f1", base)}, "fp2", nil
+					return []*chat.Message{chatMessage(frontSpace+"/messages/f1-"+prefix, "users/alice", "f1", base)}, "fp2", nil
 				case "fp2":
-					return []*chat.Message{chatMessage(frontSpace+"/messages/f2-"+suffix, "users/alice", "f2", base.Add(time.Minute))}, "fp3", nil
+					return []*chat.Message{chatMessage(frontSpace+"/messages/f2-"+prefix, "users/alice", "f2", base.Add(time.Minute))}, "fp3", nil
 				case "fp3":
-					return []*chat.Message{chatMessage(frontSpace+"/messages/f3-"+suffix, "users/alice", "f3", base.Add(2*time.Minute))}, "", nil
+					return []*chat.Message{chatMessage(frontSpace+"/messages/f3-"+prefix, "users/alice", "f3", base.Add(2*time.Minute))}, "", nil
 				}
 				return nil, "", nil
 			}
@@ -1443,14 +1438,13 @@ func TestGChatProvider_ColdStartFrontSpaceDoesNotStarveLaterSpaces(t *testing.T)
 // fuller later" safety claim.
 func TestGChatProvider_NoDoubleProcessOnReResolve(t *testing.T) {
 	e := setupGChatProviderTest(t)
-	suffix := randomSuffix(t)
+	prefix := e.gen.Prefix()
 
-	daveEmail := "dave-" + suffix + "@example.test"
-	dave := e.newGChatProviderContact(t, "GChat NoDouble Dave "+suffix, string(repository.ContactMethodEmail), daveEmail)
+	dave, daveEmail := e.newGChatProviderContact(t, string(repository.ContactMethodEmail))
 
-	spaceName := "spaces/NODOUBLE-" + suffix
-	msgName := spaceName + "/messages/m-" + suffix
-	accountID := "me-" + suffix + "@example.test"
+	spaceName := "spaces/NODOUBLE-" + prefix
+	msgName := spaceName + "/messages/m-" + prefix
+	accountID := prefix + "me@synthetic.example"
 	base := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Second)
 
 	var davePeopleResolvable = true
@@ -1540,15 +1534,13 @@ func TestGChatProvider_NoDoubleProcessOnReResolve(t *testing.T) {
 // ResolveMemberID calls fire for the absent contact after the first.
 func TestGChatProvider_HotSpaceNoStarvation(t *testing.T) {
 	e := setupGChatProviderTest(t)
-	suffix := randomSuffix(t)
+	prefix := e.gen.Prefix()
 
-	absentEmail := "absent-" + suffix + "@example.test"
-	e.newGChatProviderContact(t, "GChat Hot Absent "+suffix, string(repository.ContactMethodEmail), absentEmail)
-	activeEmail := "active-" + suffix + "@example.test"
-	active := e.newGChatProviderContact(t, "GChat Hot Active "+suffix, string(repository.ContactMethodEmail), activeEmail)
+	_, absentEmail := e.newGChatProviderContact(t, string(repository.ContactMethodEmail))
+	active, activeEmail := e.newGChatProviderContact(t, string(repository.ContactMethodEmail))
 
-	spaceName := "spaces/HOT-" + suffix
-	accountID := "me-" + suffix + "@example.test"
+	spaceName := "spaces/HOT-" + prefix
+	accountID := prefix + "me@synthetic.example"
 	e.newGChatSyncState(t, accountID, true, nil)
 
 	resolveAbsentCalls := 0
@@ -1571,7 +1563,7 @@ func TestGChatProvider_HotSpaceNoStarvation(t *testing.T) {
 			}
 			// A new message from the active member each sweep, strictly after the cursor.
 			at := accelerated.GetCurrentTime().Add(time.Duration(sweepIdx)*time.Minute - time.Hour).Truncate(time.Second)
-			return []*chat.Message{chatMessage(spaceName+"/messages/hot-"+suffix+"-"+strconv.Itoa(sweepIdx), "users/active", "ping", at)}, "", nil
+			return []*chat.Message{chatMessage(spaceName+"/messages/hot-"+prefix+"-"+strconv.Itoa(sweepIdx), "users/active", "ping", at)}, "", nil
 		},
 		ResolvePersonEmail: func(_ context.Context, userName string) (string, error) {
 			switch userName {
@@ -1625,14 +1617,13 @@ func TestGChatProvider_HotSpaceNoStarvation(t *testing.T) {
 // id resolution.
 func TestGChatRematch_IDResolutionMatchesHistory(t *testing.T) {
 	e := setupGChatProviderTest(t)
-	suffix := randomSuffix(t)
+	prefix := e.gen.Prefix()
 
-	daveEmail := "dave-" + suffix + "@example.test"
-	dave := e.newGChatProviderContact(t, "GChat RematchID Dave "+suffix, string(repository.ContactMethodGChat), daveEmail)
+	dave, daveEmail := e.newGChatProviderContact(t, string(repository.ContactMethodGChat))
 
-	spaceName := "spaces/REMATCHID-" + suffix
-	msgName := spaceName + "/messages/m-" + suffix
-	accountID := "me-" + suffix + "@example.test"
+	spaceName := "spaces/REMATCHID-" + prefix
+	msgName := spaceName + "/messages/m-" + prefix
+	accountID := prefix + "me@synthetic.example"
 	e.newGChatSyncState(t, accountID, true, nil)
 	sentAt := accelerated.GetCurrentTime().Add(-time.Hour).Truncate(time.Second)
 

--- a/backend/tests/gmail_correspondence_integration_test.go
+++ b/backend/tests/gmail_correspondence_integration_test.go
@@ -33,6 +33,7 @@ import (
 	"personal-crm/backend/internal/matching"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/service"
+	"personal-crm/backend/internal/synthetic/factory"
 
 	"github.com/google/uuid"
 	"github.com/riverqueue/river"
@@ -43,15 +44,17 @@ import (
 
 // discoveryEnv bundles a real provider + bus + repos for the discovery tests.
 type discoveryEnv struct {
-	ctx          context.Context
-	database     *db.Database
-	provider     *google.GmailSyncProvider
-	commsRepo    *repository.CommsMessageRepository
-	contactRepo  *repository.ContactRepository
-	methodRepo   *repository.ContactMethodRepository
-	externalRepo *repository.ExternalContactRepository
-	eventRepo    *repository.EventRepository
-	matchService *service.ImportMatchService
+	ctx            context.Context
+	database       *db.Database
+	gen            *factory.Generator
+	provider       *google.GmailSyncProvider
+	commsRepo      *repository.CommsMessageRepository
+	contactRepo    *repository.ContactRepository
+	methodRepo     *repository.ContactMethodRepository
+	contactService *service.ContactService
+	externalRepo   *repository.ExternalContactRepository
+	eventRepo      *repository.EventRepository
+	matchService   *service.ImportMatchService
 }
 
 func newDiscoveryEnv(t *testing.T) *discoveryEnv {
@@ -88,49 +91,57 @@ func newDiscoveryEnv(t *testing.T) *discoveryEnv {
 
 	provider := google.NewGmailSyncProvider(nil, commsRepo, bus, database.Pool)
 
+	gen, _ := migrationGenerator(t)
+
 	return &discoveryEnv{
-		ctx:          ctx,
-		database:     database,
-		provider:     provider,
-		commsRepo:    commsRepo,
-		contactRepo:  contactRepo,
-		methodRepo:   methodRepo,
-		externalRepo: externalRepo,
-		eventRepo:    eventRepo,
-		matchService: service.NewImportMatchService(contactRepo),
+		ctx:            ctx,
+		database:       database,
+		gen:            gen,
+		provider:       provider,
+		commsRepo:      commsRepo,
+		contactRepo:    contactRepo,
+		methodRepo:     methodRepo,
+		contactService: contactService,
+		externalRepo:   externalRepo,
+		eventRepo:      eventRepo,
+		matchService:   service.NewImportMatchService(contactRepo),
 	}
 }
 
-// seedContactWithMethod creates a CRM contact with one email method (so it is a
-// KNOWN contact in the sync's knownMap) and registers cleanup.
-func (e *discoveryEnv) seedContactWithMethod(t *testing.T, name, email string) *repository.Contact {
+// newKnownContact seeds a namespaced contact carrying one email method (so it is
+// a KNOWN contact in the sync's knownMap) and returns it plus that email.
+func (e *discoveryEnv) newKnownContact(t *testing.T) (*repository.Contact, string) {
 	t.Helper()
-	contact, err := e.contactRepo.CreateContact(e.ctx, repository.CreateContactRequest{FullName: name})
-	require.NoError(t, err)
-	_, err = e.methodRepo.CreateContactMethod(e.ctx, repository.CreateContactMethodRequest{
-		ContactID: contact.ID,
-		Type:      "email",
-		Value:     email,
-		IsPrimary: true,
-	})
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = e.commsRepo.HardDeleteByContact(e.ctx, contact.ID)
-		_ = e.contactRepo.SoftDeleteContact(e.ctx, contact.ID)
-	})
-	return contact
+	spec := e.gen.Contact(factory.WithEmail())
+	return e.seedSpec(t, spec), spec.Email
 }
 
-// seedContactNoMethod creates a CRM contact with NO email method (so it is only
-// trigram-matchable by name, never in the known-address set) and registers
-// cleanup.
+// seedContactNoMethod seeds a CRM contact with NO email method (so it is only
+// trigram-matchable by the given name, never in the known-address set). The name
+// is caller-supplied because the discovery tests cross-reference it against a
+// message's Cc display name.
 func (e *discoveryEnv) seedContactNoMethod(t *testing.T, name string) *repository.Contact {
 	t.Helper()
-	contact, err := e.contactRepo.CreateContact(e.ctx, repository.CreateContactRequest{FullName: name})
+	return e.seedSpec(t, factory.ContactSpec{FullName: name})
+}
+
+// seedSpec writes a factory ContactSpec through the env's nil-bus
+// ContactService.CreateContact (single-tx multi-method write, no River client)
+// and registers content-then-contact cleanup.
+func (e *discoveryEnv) seedSpec(t *testing.T, spec factory.ContactSpec) *repository.Contact {
+	t.Helper()
+	methods := make([]service.ContactMethodInput, 0, len(spec.Methods))
+	for _, m := range spec.Methods {
+		methods = append(methods, service.ContactMethodInput{Type: m.Type, Value: m.Value, IsPrimary: m.IsPrimary})
+	}
+	contact, _, err := e.contactService.CreateContact(e.ctx, repository.CreateContactRequest{
+		FullName: spec.FullName,
+		Cadence:  spec.Cadence,
+	}, methods)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		_ = e.commsRepo.HardDeleteByContact(e.ctx, contact.ID)
-		_ = e.contactRepo.SoftDeleteContact(e.ctx, contact.ID)
+		_ = e.contactRepo.HardDeleteContact(e.ctx, contact.ID)
 	})
 	return contact
 }
@@ -175,27 +186,26 @@ func discoverySyncState(accountID string) *repository.SyncState {
 func TestDiscovery_RunsBetweenFetchAndStorage(t *testing.T) {
 	e := newDiscoveryEnv(t)
 	e.wireDiscoverer()
-	suffix := uuid.NewString()[:8]
+	prefix := e.gen.Prefix()
 
-	me := "me-" + suffix + "@example.com"
-	addrA := "a-" + suffix + "@example.com"          // KNOWN contact A (has method)
-	other := "peer-other-" + suffix + "@example.com" // non-own, non-contact recipient
-	patAddr := "peer-pat-" + suffix + "@example.com" // unknown Cc → candidate
+	me := prefix + "me@synthetic.example"
+	other := prefix + "peer-other@synthetic.example" // non-own, non-contact recipient
+	patAddr := prefix + "peer-pat@synthetic.example" // unknown Cc → candidate
 	patNorm := matching.NormalizeEmail(patAddr)
-	patName := "Pat Carter " + suffix
+	patName := prefix + "Pat Carter"
 
-	contactA := e.seedContactWithMethod(t, "Known Alpha "+suffix, addrA)
+	contactA, addrA := e.newKnownContact(t)       // KNOWN contact A (has method)
 	contactB := e.seedContactNoMethod(t, patName) // trigram-matched by name only
 	e.cleanupExternal(t, patNorm)
-	e.cleanupEvents(t, "disc-"+suffix)
+	e.cleanupEvents(t, prefix+"disc")
 
 	// From=A (known), To=other (non-own non-contact), Cc=Pat (unknown, ≥2-token
 	// name matching contact B). The storage gate drops this: for A, inbound needs
 	// own-account ∈ recipients (false — only `other`+Pat are recipients);
 	// outbound needs sender==own (false — sender is A). So zero qualifiedRows.
-	msg := gmailMsg("g-disc-"+suffix, "thr-"+suffix, "Known Alpha <"+addrA+">",
+	msg := gmailMsg("g-disc-"+prefix, "thr-"+prefix, "Known Alpha <"+addrA+">",
 		[]string{other}, []string{patName + " <" + patAddr + ">"}, nil,
-		"Subj", "body", "<disc-"+suffix+"@example.com>", 1700000100000)
+		"Subj", "body", "<"+prefix+"disc@synthetic.example>", 1700000100000)
 	e.provider.SetFetcherFactoryForTest(google.NewFakeGmailFetcherFactoryForTest(newFakeMessageStore([]*gmailapi.Message{msg}).fetcherFuncs()))
 	e.provider.SetMeSetForTest(map[string]struct{}{me: {}})
 
@@ -233,23 +243,22 @@ func TestDiscovery_RunsBetweenFetchAndStorage(t *testing.T) {
 func TestDiscovery_LinkAddsMethodAndDispatchesRematch(t *testing.T) {
 	e := newDiscoveryEnv(t)
 	e.wireDiscoverer()
-	suffix := uuid.NewString()[:8]
+	prefix := e.gen.Prefix()
 
-	me := "me-" + suffix + "@example.com"
-	addrA := "a-" + suffix + "@example.com"
-	other := "peer-other-" + suffix + "@example.com"
-	patAddr := "peer-pat-" + suffix + "@example.com"
+	me := prefix + "me@synthetic.example"
+	other := prefix + "peer-other@synthetic.example"
+	patAddr := prefix + "peer-pat@synthetic.example"
 	patNorm := matching.NormalizeEmail(patAddr)
-	patName := "Pat Linker " + suffix
+	patName := prefix + "Pat Linker"
 
-	_ = e.seedContactWithMethod(t, "Known Beta "+suffix, addrA)
+	_, addrA := e.newKnownContact(t)
 	contactB := e.seedContactNoMethod(t, patName)
 	e.cleanupExternal(t, patNorm)
-	e.cleanupEvents(t, "disclink-"+suffix)
+	e.cleanupEvents(t, prefix+"disclink")
 
-	msg := gmailMsg("g-disclink-"+suffix, "thr-"+suffix, "Known Beta <"+addrA+">",
+	msg := gmailMsg("g-disclink-"+prefix, "thr-"+prefix, "Known Beta <"+addrA+">",
 		[]string{other}, []string{patName + " <" + patAddr + ">"}, nil,
-		"Subj", "body", "<disclink-"+suffix+"@example.com>", 1700000100000)
+		"Subj", "body", "<"+prefix+"disclink@synthetic.example>", 1700000100000)
 	e.provider.SetFetcherFactoryForTest(google.NewFakeGmailFetcherFactoryForTest(newFakeMessageStore([]*gmailapi.Message{msg}).fetcherFuncs()))
 	e.provider.SetMeSetForTest(map[string]struct{}{me: {}})
 
@@ -314,20 +323,19 @@ func TestDiscovery_LinkAddsMethodAndDispatchesRematch(t *testing.T) {
 // qualifying address.
 func TestDiscovery_ErrorNonFatalToSync(t *testing.T) {
 	e := newDiscoveryEnv(t)
-	suffix := uuid.NewString()[:8]
+	prefix := e.gen.Prefix()
 
-	me := "me-" + suffix + "@example.com"
-	addrA := "a-" + suffix + "@example.com"
-	other := "peer-other-" + suffix + "@example.com"
-	patAddr := "peer-pat-" + suffix + "@example.com"
+	me := prefix + "me@synthetic.example"
+	other := prefix + "peer-other@synthetic.example"
+	patAddr := prefix + "peer-pat@synthetic.example"
 	patNorm := matching.NormalizeEmail(patAddr)
-	patName := "Pat Failer " + suffix
+	patName := prefix + "Pat Failer"
 
-	contactA := e.seedContactWithMethod(t, "Known Gamma "+suffix, addrA)
+	contactA, addrA := e.newKnownContact(t)
 	_ = e.seedContactNoMethod(t, patName)
 	e.cleanupExternal(t, patNorm)
-	e.cleanupEvents(t, "discfail-"+suffix)
-	e.cleanupEvents(t, "discstore-"+suffix)
+	e.cleanupEvents(t, prefix+"discfail")
+	e.cleanupEvents(t, prefix+"discstore")
 
 	// Discoverer whose external Upsert errors for the qualifying Cc address.
 	failExt := &failingUpsertExternal{
@@ -337,15 +345,15 @@ func TestDiscovery_ErrorNonFatalToSync(t *testing.T) {
 	e.provider.SetCorrespondenceDiscoverer(google.NewCorrespondenceDiscoverer(e.contactRepo, failExt))
 
 	// Message 1: the discovery-triggering multi-party message (storage gate misses).
-	discMsg := gmailMsg("g-discfail-"+suffix, "thr-f-"+suffix, "Known Gamma <"+addrA+">",
+	discMsg := gmailMsg("g-discfail-"+prefix, "thr-f-"+prefix, "Known Gamma <"+addrA+">",
 		[]string{other}, []string{patName + " <" + patAddr + ">"}, nil,
-		"Subj", "body", "<discfail-"+suffix+"@example.com>", 1700000100000)
+		"Subj", "body", "<"+prefix+"discfail@synthetic.example>", 1700000100000)
 	// Message 2: a clean you↔contact message that DOES pass the storage gate
 	// (inbound: A → me), so we can assert ingest is not stranded by the
 	// discovery failure.
-	storeMsg := gmailMsg("g-discstore-"+suffix, "thr-s-"+suffix, "Known Gamma <"+addrA+">",
+	storeMsg := gmailMsg("g-discstore-"+prefix, "thr-s-"+prefix, "Known Gamma <"+addrA+">",
 		[]string{me}, nil, nil,
-		"Stored", "stored body", "<discstore-"+suffix+"@example.com>", 1700000200000)
+		"Stored", "stored body", "<"+prefix+"discstore@synthetic.example>", 1700000200000)
 
 	e.provider.SetFetcherFactoryForTest(google.NewFakeGmailFetcherFactoryForTest(
 		newFakeMessageStore([]*gmailapi.Message{discMsg, storeMsg}).fetcherFuncs()))

--- a/backend/tests/gmail_golive_integration_test.go
+++ b/backend/tests/gmail_golive_integration_test.go
@@ -30,6 +30,7 @@ import (
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/service"
 	syncpkg "personal-crm/backend/internal/sync"
+	"personal-crm/backend/internal/synthetic/factory"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -67,8 +68,9 @@ func TestGmailGoLive_RegisteredProvider_SchedulerSweep_ProducesInteractionsAndCa
 	// are observable.
 	bus, _ := setupTestEventBusForEmail(t, ctx, database, contactService)
 
-	suffix := uuid.NewString()[:8]
-	account := "me-" + suffix + "@example.com"
+	gen, _ := migrationGenerator(t)
+	prefix := gen.Prefix()
+	account := prefix + "me@synthetic.example"
 
 	// Build + register the Gmail provider in a real registry, exactly as
 	// main.go does (cutover). Inject a fake fetcher + me-set so no OAuth is
@@ -77,38 +79,32 @@ func TestGmailGoLive_RegisteredProvider_SchedulerSweep_ProducesInteractionsAndCa
 	provider := google.NewGmailSyncProvider(nil, commsRepo, bus, database.Pool)
 
 	// Known contact + email method. The provider loads its own known-contact
-	// map from contact_method rows via ListEmailIdentitiesForSync.
-	cadence := "weekly"
-	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-		FullName: "GoLive Contact " + suffix,
-		Cadence:  &cadence,
-	})
+	// map from contact_method rows via ListEmailIdentitiesForSync. Seeded via the
+	// nil-bus ContactService (single-tx contact+method write, no River client).
+	spec := gen.Contact(factory.WithEmail(), factory.WithCadence("weekly"))
+	contact, _, err := contactService.CreateContact(ctx, repository.CreateContactRequest{
+		FullName: spec.FullName,
+		Cadence:  spec.Cadence,
+	}, []service.ContactMethodInput{{Type: "email", Value: spec.Email, IsPrimary: true}})
 	require.NoError(t, err)
-	addr := "peer-" + suffix + "@example.com"
-	_, err = methodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
-		ContactID: contact.ID,
-		Type:      "email",
-		Value:     addr,
-		IsPrimary: true,
-	})
-	require.NoError(t, err)
+	addr := spec.Email
 
 	// Unknown participant the sweep must NOT turn into a contact.
-	unknown := "stranger-" + suffix + "@example.com"
+	unknown := prefix + "stranger@synthetic.example"
 
 	// External IDs are stored UNBRACKETED (the provider strips the RFC822
 	// Message-ID's surrounding <>), so query/assert with the unbracketed form
 	// and pass the bracketed form into the message header.
-	inExt := "golive-in-" + suffix + "@example.com"
-	outExt := "golive-out-" + suffix + "@example.com"
-	unkExt := "golive-unk-" + suffix + "@example.com"
+	inExt := prefix + "golive-in@synthetic.example"
+	outExt := prefix + "golive-out@synthetic.example"
+	unkExt := prefix + "golive-unk@synthetic.example"
 
 	t.Cleanup(func() {
 		_ = commsRepo.HardDeleteByContact(ctx, contact.ID)
 		_ = interactionRepo.HardDeleteInteractionsBySourceRefPrefix(ctx, repository.InteractionSourceEmail, contact.ID.String()+":%")
-		_ = contactRepo.SoftDeleteContact(ctx, contact.ID)
-		_ = eventRepo.HardDeleteEventsBySourceAndSourceIDPrefix(ctx, "email", "golive-")
+		_ = eventRepo.HardDeleteEventsBySourceAndSourceIDPrefix(ctx, "email", prefix+"golive-")
 		_ = syncRepo.DeleteSyncStatesByAccountID(ctx, account)
+		_ = contactRepo.HardDeleteContact(ctx, contact.ID)
 	})
 
 	sentAt := gmailPastNoonAnchor()

--- a/backend/tests/gmail_provider_integration_test.go
+++ b/backend/tests/gmail_provider_integration_test.go
@@ -40,8 +40,8 @@ import (
 	"personal-crm/backend/internal/google"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/service"
+	"personal-crm/backend/internal/synthetic/factory"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/require"
 	gmailapi "google.golang.org/api/gmail/v1"
@@ -49,15 +49,16 @@ import (
 
 // gmailProviderEnv bundles a real provider + bus + repos for the sweep tests.
 type gmailProviderEnv struct {
-	ctx          context.Context
-	database     *db.Database
-	provider     *google.GmailSyncProvider
-	bus          *events.Bus
-	commsRepo    *repository.CommsMessageRepository
-	contactRepo  *repository.ContactRepository
-	methodRepo   *repository.ContactMethodRepository
-	identityRepo *repository.IdentityRepository
-	eventRepo    *repository.EventRepository
+	ctx            context.Context
+	database       *db.Database
+	gen            *factory.Generator
+	provider       *google.GmailSyncProvider
+	bus            *events.Bus
+	commsRepo      *repository.CommsMessageRepository
+	contactRepo    *repository.ContactRepository
+	contactService *service.ContactService
+	identityRepo   *repository.IdentityRepository
+	eventRepo      *repository.EventRepository
 }
 
 func newGmailProviderEnv(t *testing.T) *gmailProviderEnv {
@@ -86,6 +87,7 @@ func newGmailProviderEnv(t *testing.T) *gmailProviderEnv {
 	interactionRepo := repository.NewInteractionRepository(database.Queries)
 	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
 	eventRepo := repository.NewEventRepository(database.Queries)
+	// nil bus + nil rematch: a single-tx multi-method seed write, no River client.
 	contactService := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, contactTaskRepo, nil, nil)
 
 	// Live bus via the shared harness. email.* kinds enqueue an
@@ -96,35 +98,50 @@ func newGmailProviderEnv(t *testing.T) *gmailProviderEnv {
 
 	provider := google.NewGmailSyncProvider(nil, commsRepo, bus, database.Pool)
 
+	gen, _ := migrationGenerator(t)
+
 	return &gmailProviderEnv{
-		ctx:          ctx,
-		database:     database,
-		provider:     provider,
-		bus:          bus,
-		commsRepo:    commsRepo,
-		contactRepo:  contactRepo,
-		methodRepo:   methodRepo,
-		identityRepo: identityRepo,
-		eventRepo:    eventRepo,
+		ctx:            ctx,
+		database:       database,
+		gen:            gen,
+		provider:       provider,
+		bus:            bus,
+		commsRepo:      commsRepo,
+		contactRepo:    contactRepo,
+		contactService: contactService,
+		identityRepo:   identityRepo,
+		eventRepo:      eventRepo,
 	}
 }
 
-// newEmailContactWithMethod creates a contact with one email method and
-// registers cleanup (hard-delete content + soft-delete contact).
-func (e *gmailProviderEnv) newEmailContactWithMethod(t *testing.T, name, email string) *repository.Contact {
+// newEmailContact seeds a namespaced contact carrying one email method and
+// returns it plus that email (the value the sweep matches a fetched message's
+// participants against). Cleanup hard-deletes the contact's content rows before
+// the contact itself (FK-child rows must go first).
+func (e *gmailProviderEnv) newEmailContact(t *testing.T) (*repository.Contact, string) {
 	t.Helper()
-	contact, err := e.contactRepo.CreateContact(e.ctx, repository.CreateContactRequest{FullName: name})
-	require.NoError(t, err)
-	_, err = e.methodRepo.CreateContactMethod(e.ctx, repository.CreateContactMethodRequest{
-		ContactID: contact.ID,
-		Type:      "email",
-		Value:     email,
-		IsPrimary: true,
-	})
+	spec := e.gen.Contact(factory.WithEmail())
+	contact := e.seedSpec(t, spec)
+	return contact, spec.Email
+}
+
+// seedSpec writes a factory ContactSpec through the env's nil-bus
+// ContactService.CreateContact (the sanctioned single-tx multi-method write
+// path) and registers content-then-contact cleanup.
+func (e *gmailProviderEnv) seedSpec(t *testing.T, spec factory.ContactSpec) *repository.Contact {
+	t.Helper()
+	methods := make([]service.ContactMethodInput, 0, len(spec.Methods))
+	for _, m := range spec.Methods {
+		methods = append(methods, service.ContactMethodInput{Type: m.Type, Value: m.Value, IsPrimary: m.IsPrimary})
+	}
+	contact, _, err := e.contactService.CreateContact(e.ctx, repository.CreateContactRequest{
+		FullName: spec.FullName,
+		Cadence:  spec.Cadence,
+	}, methods)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		_ = e.commsRepo.HardDeleteByContact(e.ctx, contact.ID)
-		_ = e.contactRepo.SoftDeleteContact(e.ctx, contact.ID)
+		_ = e.contactRepo.HardDeleteContact(e.ctx, contact.ID)
 	})
 	return contact
 }
@@ -294,17 +311,17 @@ func expectCursorAtLeast(t *testing.T, cursor string, minEpoch int64) gmailCurso
 
 func TestGmailProvider_FullSweep_ContentAndEvents(t *testing.T) {
 	e := newGmailProviderEnv(t)
-	suffix := uuid.NewString()[:8]
-	me := "me-" + suffix + "@example.com"
-	addrA := "a-" + suffix + "@example.com"
-	addrB := "b-" + suffix + "@example.com"
-	contactA := e.newEmailContactWithMethod(t, "Contact A "+suffix, addrA)
-	contactB := e.newEmailContactWithMethod(t, "Contact B "+suffix, addrB)
+	prefix := e.gen.Prefix()
+	me := prefix + "me@synthetic.example"
+	contactA, addrA := e.newEmailContact(t)
+	contactB, addrB := e.newEmailContact(t)
 
-	inMsgID := "<in-" + suffix + "@example.com>"
-	outMsgID := "<out-" + suffix + "@example.com>"
-	e.cleanupEvents(t, "in-"+suffix+"@example.com")
-	e.cleanupEvents(t, "out-"+suffix+"@example.com")
+	inExt := prefix + "in@synthetic.example"
+	outExt := prefix + "out@synthetic.example"
+	inMsgID := "<" + inExt + ">"
+	outMsgID := "<" + outExt + ">"
+	e.cleanupEvents(t, inExt)
+	e.cleanupEvents(t, outExt)
 
 	inbound := gmailMsg("g-in", "thr-in", addrA, []string{me}, nil, nil, "Inbound subj", "hello from A", inMsgID, 1700000100000)
 	outbound := gmailMsg("g-out", "thr-out", me, []string{addrB}, nil, nil, "Outbound subj", "hi to B", outMsgID, 1700000200000)
@@ -320,7 +337,7 @@ func TestGmailProvider_FullSweep_ContentAndEvents(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, aRows, 1)
 	require.Equal(t, "inbound", aRows[0].Direction)
-	require.Equal(t, "in-"+suffix+"@example.com", aRows[0].ExternalID)
+	require.Equal(t, inExt, aRows[0].ExternalID)
 	require.Equal(t, "thr-in", *aRows[0].ThreadID)
 	require.Equal(t, "Inbound subj", *aRows[0].Subject)
 	require.Equal(t, "hello from A", *aRows[0].Body)
@@ -333,7 +350,7 @@ func TestGmailProvider_FullSweep_ContentAndEvents(t *testing.T) {
 	require.Equal(t, "outbound", bRows[0].Direction)
 	require.Equal(t, addrB, *bRows[0].PeerNormalized)
 
-	inEnv, err := e.eventRepo.FindEventBySource(e.ctx, "email", "in-"+suffix+"@example.com:"+contactA.ID.String())
+	inEnv, err := e.eventRepo.FindEventBySource(e.ctx, "email", inExt+":"+contactA.ID.String())
 	require.NoError(t, err)
 	require.Equal(t, events.KindEmailReceived, inEnv.Kind)
 	var inPayload events.EmailEventPayload
@@ -342,7 +359,7 @@ func TestGmailProvider_FullSweep_ContentAndEvents(t *testing.T) {
 	require.Equal(t, "inbound", inPayload.Direction)
 	require.Equal(t, "thr-in", inPayload.ThreadID)
 
-	outEnv, err := e.eventRepo.FindEventBySource(e.ctx, "email", "out-"+suffix+"@example.com:"+contactB.ID.String())
+	outEnv, err := e.eventRepo.FindEventBySource(e.ctx, "email", outExt+":"+contactB.ID.String())
 	require.NoError(t, err)
 	require.Equal(t, events.KindEmailSent, outEnv.Kind)
 }
@@ -351,8 +368,8 @@ func TestGmailProvider_FullSweep_ContentAndEvents(t *testing.T) {
 
 func TestGmailProvider_CrossChunkSeenDedup(t *testing.T) {
 	e := newGmailProviderEnv(t)
-	suffix := uuid.NewString()[:8]
-	me := "me-" + suffix + "@example.com"
+	prefix := e.gen.Prefix()
+	me := prefix + "me@synthetic.example"
 
 	// Many known contacts force the provider to build MORE THAN ONE OR-chunk;
 	// the query-agnostic fake returns the single spanning message for every
@@ -360,13 +377,13 @@ func TestGmailProvider_CrossChunkSeenDedup(t *testing.T) {
 	const n = 250
 	var addrs []string
 	for i := 0; i < n; i++ {
-		addr := fmt.Sprintf("c%03d-%s@example.com", i, suffix)
+		_, addr := e.newEmailContact(t)
 		addrs = append(addrs, addr)
-		e.newEmailContactWithMethod(t, fmt.Sprintf("Contact %03d %s", i, suffix), addr)
 	}
 
-	msgID := "<span-" + suffix + "@example.com>"
-	e.cleanupEvents(t, "span-"+suffix+"@example.com")
+	spanExt := prefix + "span@synthetic.example"
+	msgID := "<" + spanExt + ">"
+	e.cleanupEvents(t, spanExt)
 	// Inbound from the first known contact to me.
 	msg := gmailMsg("g-span", "thr", addrs[0], []string{me}, nil, nil, "S", "body", msgID, 1700000300000)
 
@@ -386,14 +403,13 @@ func TestGmailProvider_CrossChunkSeenDedup(t *testing.T) {
 
 func TestGmailProvider_MatchOnly_NoContactCreated(t *testing.T) {
 	e := newGmailProviderEnv(t)
-	suffix := uuid.NewString()[:8]
-	me := "me-" + suffix + "@example.com"
-	addrA := "a-" + suffix + "@example.com"
-	unknown := "unknown-" + suffix + "@example.com"
-	contactA := e.newEmailContactWithMethod(t, "Contact A "+suffix, addrA)
+	prefix := e.gen.Prefix()
+	me := prefix + "me@synthetic.example"
+	unknown := prefix + "unknown@synthetic.example"
+	contactA, addrA := e.newEmailContact(t)
 
-	e.cleanupEvents(t, "mo-"+suffix+"@example.com")
-	msg := gmailMsg("g-mo", "thr", addrA, []string{me, unknown}, nil, nil, "S", "body", "<mo-"+suffix+"@example.com>", 1700000400000)
+	e.cleanupEvents(t, prefix+"mo@synthetic.example")
+	msg := gmailMsg("g-mo", "thr", addrA, []string{me, unknown}, nil, nil, "S", "body", "<"+prefix+"mo@synthetic.example>", 1700000400000)
 	e.inject(newFakeMessageStore([]*gmailapi.Message{msg}), map[string]struct{}{me: {}})
 
 	_, err := e.provider.Sync(e.ctx, syncState(me, ""), nil)
@@ -414,13 +430,13 @@ func TestGmailProvider_MatchOnly_NoContactCreated(t *testing.T) {
 
 func TestGmailProvider_CursorOverlapIdempotent(t *testing.T) {
 	e := newGmailProviderEnv(t)
-	suffix := uuid.NewString()[:8]
-	me := "me-" + suffix + "@example.com"
-	addrA := "a-" + suffix + "@example.com"
-	contactA := e.newEmailContactWithMethod(t, "Contact A "+suffix, addrA)
+	prefix := e.gen.Prefix()
+	me := prefix + "me@synthetic.example"
+	contactA, addrA := e.newEmailContact(t)
 
-	e.cleanupEvents(t, "idem-"+suffix+"@example.com")
-	msg := gmailMsg("g-idem", "thr", addrA, []string{me}, nil, nil, "S", "body", "<idem-"+suffix+"@example.com>", 1700000500000)
+	idemExt := prefix + "idem@synthetic.example"
+	e.cleanupEvents(t, idemExt)
+	msg := gmailMsg("g-idem", "thr", addrA, []string{me}, nil, nil, "S", "body", "<"+idemExt+">", 1700000500000)
 	e.inject(newFakeMessageStore([]*gmailapi.Message{msg}), map[string]struct{}{me: {}})
 
 	_, err := e.provider.Sync(e.ctx, syncState(me, ""), nil)
@@ -432,7 +448,7 @@ func TestGmailProvider_CursorOverlapIdempotent(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, aRows, 1, "second sweep must not add a duplicate content row")
 
-	got, err := e.commsRepo.GetMessage(e.ctx, "email", "idem-"+suffix+"@example.com", contactA.ID)
+	got, err := e.commsRepo.GetMessage(e.ctx, "email", idemExt, contactA.ID)
 	require.NoError(t, err)
 	require.Equal(t, []string{me}, observedAccounts(t, got.SourceMetadata))
 }
@@ -441,13 +457,12 @@ func TestGmailProvider_CursorOverlapIdempotent(t *testing.T) {
 
 func TestGmailProvider_PublishBeforeMutate_RollsBack(t *testing.T) {
 	e := newGmailProviderEnv(t)
-	suffix := uuid.NewString()[:8]
-	me := "me-" + suffix + "@example.com"
-	addrA := "a-" + suffix + "@example.com"
-	contactA := e.newEmailContactWithMethod(t, "Contact A "+suffix, addrA)
+	prefix := e.gen.Prefix()
+	me := prefix + "me@synthetic.example"
+	contactA, addrA := e.newEmailContact(t)
 
-	e.cleanupEvents(t, "pbm-"+suffix+"@example.com")
-	msg := gmailMsg("g-pbm", "thr", addrA, []string{me}, nil, nil, "S", "body", "<pbm-"+suffix+"@example.com>", 1700000600000)
+	e.cleanupEvents(t, prefix+"pbm@synthetic.example")
+	msg := gmailMsg("g-pbm", "thr", addrA, []string{me}, nil, nil, "S", "body", "<"+prefix+"pbm@synthetic.example>", 1700000600000)
 	e.inject(newFakeMessageStore([]*gmailapi.Message{msg}), map[string]struct{}{me: {}})
 
 	e.provider.SetBusForTest(failingBus{})
@@ -463,12 +478,11 @@ func TestGmailProvider_PublishBeforeMutate_RollsBack(t *testing.T) {
 
 func TestGmailProvider_NomsgidFallback(t *testing.T) {
 	e := newGmailProviderEnv(t)
-	suffix := uuid.NewString()[:8]
-	me := "me-" + suffix + "@example.com"
-	addrA := "a-" + suffix + "@example.com"
-	contactA := e.newEmailContactWithMethod(t, "Contact A "+suffix, addrA)
+	prefix := e.gen.Prefix()
+	me := prefix + "me@synthetic.example"
+	contactA, addrA := e.newEmailContact(t)
 
-	gmailID := "g-nomsgid-" + suffix
+	gmailID := "g-nomsgid-" + prefix
 	expectedExternal := "nomsgid:" + me + ":" + gmailID
 	e.cleanupEvents(t, expectedExternal)
 	msg := gmailMsg(gmailID, "thr", addrA, []string{me}, nil, nil, "S", "body", "", 1700000700000)
@@ -491,15 +505,14 @@ func TestGmailProvider_NomsgidFallback(t *testing.T) {
 
 func TestGmailProvider_AllBystanderSweepAdvancesCursor(t *testing.T) {
 	e := newGmailProviderEnv(t)
-	suffix := uuid.NewString()[:8]
-	me := "me-" + suffix + "@example.com"
-	addrA := "a-" + suffix + "@example.com"
-	contactA := e.newEmailContactWithMethod(t, "Contact A "+suffix, addrA)
+	prefix := e.gen.Prefix()
+	me := prefix + "me@synthetic.example"
+	contactA, addrA := e.newEmailContact(t)
 
-	e.cleanupEvents(t, "by-"+suffix+"@example.com")
+	e.cleanupEvents(t, prefix+"by@synthetic.example")
 	// A is only co-Cc'd by a third party; thread not to/from me → bystander.
-	msg := gmailMsg("g-by", "thr", "third-"+suffix+"@example.com",
-		[]string{"other-" + suffix + "@example.com"}, []string{addrA}, nil, "S", "body", "<by-"+suffix+"@example.com>", 1700000800000)
+	msg := gmailMsg("g-by", "thr", prefix+"third@synthetic.example",
+		[]string{prefix + "other@synthetic.example"}, []string{addrA}, nil, "S", "body", "<"+prefix+"by@synthetic.example>", 1700000800000)
 	e.inject(newFakeMessageStore([]*gmailapi.Message{msg}), map[string]struct{}{me: {}})
 
 	result, err := e.provider.Sync(e.ctx, syncState(me, ""), nil)
@@ -515,10 +528,9 @@ func TestGmailProvider_AllBystanderSweepAdvancesCursor(t *testing.T) {
 
 func TestGmailProvider_ZeroFetchedAdvancesCompletedWindows(t *testing.T) {
 	e := newGmailProviderEnv(t)
-	suffix := uuid.NewString()[:8]
-	me := "me-" + suffix + "@example.com"
-	addrA := "a-" + suffix + "@example.com"
-	_ = e.newEmailContactWithMethod(t, "Contact A "+suffix, addrA)
+	prefix := e.gen.Prefix()
+	me := prefix + "me@synthetic.example"
+	_, _ = e.newEmailContact(t)
 
 	e.inject(newFakeMessageStore(nil), map[string]struct{}{me: {}})
 
@@ -540,10 +552,9 @@ func TestGmailProvider_ZeroFetchedAdvancesCompletedWindows(t *testing.T) {
 
 func TestGmailProvider_CatchUpScansSuccessiveWindowsInOneRun(t *testing.T) {
 	e := newGmailProviderEnv(t)
-	suffix := uuid.NewString()[:8]
-	me := "me-" + suffix + "@example.com"
-	addrA := "a-" + suffix + "@example.com"
-	contactA := e.newEmailContactWithMethod(t, "Contact A "+suffix, addrA)
+	prefix := e.gen.Prefix()
+	me := prefix + "me@synthetic.example"
+	contactA, addrA := e.newEmailContact(t)
 
 	start := accelerated.GetCurrentTime().UTC().Add(-28 * 24 * time.Hour).Truncate(time.Second).Unix()
 	msgEpochs := []int64{
@@ -553,7 +564,7 @@ func TestGmailProvider_CatchUpScansSuccessiveWindowsInOneRun(t *testing.T) {
 	}
 	var messages []*gmailapi.Message
 	for i, epoch := range msgEpochs {
-		ext := fmt.Sprintf("catchup-%d-%s@example.com", i, suffix)
+		ext := fmt.Sprintf("%scatchup-%d@synthetic.example", prefix, i)
 		e.cleanupEvents(t, ext)
 		messages = append(messages, gmailMsg(
 			fmt.Sprintf("g-catchup-%d", i),
@@ -569,7 +580,7 @@ func TestGmailProvider_CatchUpScansSuccessiveWindowsInOneRun(t *testing.T) {
 		))
 	}
 
-	tooNewExt := "catchup-new-" + suffix + "@example.com"
+	tooNewExt := prefix + "catchup-new@synthetic.example"
 	e.cleanupEvents(t, tooNewExt)
 	tooNewEpoch := accelerated.GetCurrentTime().UTC().Add(-1 * time.Minute).Unix()
 	messages = append(messages, gmailMsg("g-catchup-new", "thr", addrA, []string{me}, nil, nil, "S", "body", "<"+tooNewExt+">", tooNewEpoch*1000))
@@ -596,16 +607,15 @@ func TestGmailProvider_CatchUpScansSuccessiveWindowsInOneRun(t *testing.T) {
 
 func TestGmailProvider_BoundaryOverlapSkipsOnlySeenMessageIDs(t *testing.T) {
 	e := newGmailProviderEnv(t)
-	suffix := uuid.NewString()[:8]
-	me := "me-" + suffix + "@example.com"
-	addrA := "a-" + suffix + "@example.com"
-	contactA := e.newEmailContactWithMethod(t, "Contact A "+suffix, addrA)
+	prefix := e.gen.Prefix()
+	me := prefix + "me@synthetic.example"
+	contactA, addrA := e.newEmailContact(t)
 
 	start := accelerated.GetCurrentTime().UTC().Add(-21 * 24 * time.Hour).Truncate(time.Second).Unix()
 	boundaryEpoch := start + int64((7 * 24 * time.Hour).Seconds())
-	ext := "boundary-" + suffix + "@example.com"
+	ext := prefix + "boundary@synthetic.example"
 	e.cleanupEvents(t, ext)
-	msg := gmailMsg("g-boundary-"+suffix, "thr", addrA, []string{me}, nil, nil, "S", "body", "<"+ext+">", boundaryEpoch*1000)
+	msg := gmailMsg("g-boundary-"+prefix, "thr", addrA, []string{me}, nil, nil, "S", "body", "<"+ext+">", boundaryEpoch*1000)
 	store := newFakeMessageStore([]*gmailapi.Message{msg})
 	e.inject(store, map[string]struct{}{me: {}})
 
@@ -623,13 +633,12 @@ func TestGmailProvider_BoundaryOverlapSkipsOnlySeenMessageIDs(t *testing.T) {
 
 func TestGmailProvider_HardFailureLeavesCursorUnchanged(t *testing.T) {
 	e := newGmailProviderEnv(t)
-	suffix := uuid.NewString()[:8]
-	me := "me-" + suffix + "@example.com"
-	addrA := "a-" + suffix + "@example.com"
-	contactA := e.newEmailContactWithMethod(t, "Contact A "+suffix, addrA)
+	prefix := e.gen.Prefix()
+	me := prefix + "me@synthetic.example"
+	contactA, addrA := e.newEmailContact(t)
 
-	e.cleanupEvents(t, "hf-"+suffix+"@example.com")
-	msg := gmailMsg("g-hf", "thr", addrA, []string{me}, nil, nil, "S", "body", "<hf-"+suffix+"@example.com>", 1700000900000)
+	e.cleanupEvents(t, prefix+"hf@synthetic.example")
+	msg := gmailMsg("g-hf", "thr", addrA, []string{me}, nil, nil, "S", "body", "<"+prefix+"hf@synthetic.example>", 1700000900000)
 	store := newFakeMessageStore([]*gmailapi.Message{msg})
 	store.forcedGetErr["g-hf"] = struct{}{}
 	e.inject(store, map[string]struct{}{me: {}})
@@ -664,20 +673,20 @@ func TestGmailProvider_NilAccount_Errors(t *testing.T) {
 
 func TestGmailProvider_CrossAccountProvenanceMerge(t *testing.T) {
 	e := newGmailProviderEnv(t)
-	suffix := uuid.NewString()[:8]
-	accountX := "x-" + suffix + "@example.com"
-	accountY := "y-" + suffix + "@example.com"
-	addrA := "a-" + suffix + "@example.com"
-	contactA := e.newEmailContactWithMethod(t, "Contact A "+suffix, addrA)
+	prefix := e.gen.Prefix()
+	accountX := prefix + "x@synthetic.example"
+	accountY := prefix + "y@synthetic.example"
+	contactA, addrA := e.newEmailContact(t)
 
-	e.cleanupEvents(t, "xacct-"+suffix+"@example.com")
-	msgID := "<xacct-" + suffix + "@example.com>"
+	xacctExt := prefix + "xacct@synthetic.example"
+	e.cleanupEvents(t, xacctExt)
+	msgID := "<" + xacctExt + ">"
 
 	// Same RFC822 Message-ID observed in both mailboxes, with a different
 	// per-mailbox gmail id each sweep. Both accounts share the same "me" set so
 	// cross-account detection works.
-	gmailX := "gmail-x-" + suffix
-	gmailY := "gmail-y-" + suffix
+	gmailX := "gmail-x-" + prefix
+	gmailY := "gmail-y-" + prefix
 	msgX := gmailMsg(gmailX, "thr", addrA, []string{accountX}, nil, nil, "S", "body", msgID, 1700001000000)
 	msgY := gmailMsg(gmailY, "thr", addrA, []string{accountY}, nil, nil, "S", "body", msgID, 1700001000000)
 	meSet := map[string]struct{}{accountX: {}, accountY: {}}
@@ -697,7 +706,7 @@ func TestGmailProvider_CrossAccountProvenanceMerge(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
 
-	got, err := e.commsRepo.GetMessage(e.ctx, "email", "xacct-"+suffix+"@example.com", contactA.ID)
+	got, err := e.commsRepo.GetMessage(e.ctx, "email", xacctExt, contactA.ID)
 	require.NoError(t, err)
 	require.ElementsMatch(t, []string{accountX, accountY}, observedAccounts(t, got.SourceMetadata))
 	gmailIDs := accountGmailIDs(t, got.SourceMetadata)
@@ -715,12 +724,11 @@ func TestGmailProvider_CrossAccountProvenanceMerge(t *testing.T) {
 // cursor.
 func TestGmailProvider_Onboarding_EmptyCursor_BackfillSince(t *testing.T) {
 	e := newGmailProviderEnv(t)
-	suffix := uuid.NewString()[:8]
-	me := "me-" + suffix + "@example.com"
-	addrA := "a-" + suffix + "@example.com"
-	contactA := e.newEmailContactWithMethod(t, "Contact A "+suffix, addrA)
+	prefix := e.gen.Prefix()
+	me := prefix + "me@synthetic.example"
+	contactA, addrA := e.newEmailContact(t)
 
-	ext := "onb-" + suffix + "@example.com"
+	ext := prefix + "onb@synthetic.example"
 	e.cleanupEvents(t, ext)
 
 	// backfill_since override floors the scan at 2026-03-01.

--- a/backend/tests/gmail_rematch_integration_test.go
+++ b/backend/tests/gmail_rematch_integration_test.go
@@ -48,6 +48,7 @@ import (
 	"personal-crm/backend/internal/google"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/service"
+	"personal-crm/backend/internal/synthetic/factory"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -62,13 +63,14 @@ var _ service.RematchHandler = (*google.GmailRematchHandler)(nil)
 type gmailRematchEnv struct {
 	ctx             context.Context
 	database        *db.Database
+	gen             *factory.Generator
 	provider        *google.GmailSyncProvider
 	handler         *google.GmailRematchHandler
 	accountIDs      []string
 	bus             *events.Bus
 	commsRepo       *repository.CommsMessageRepository
 	contactRepo     *repository.ContactRepository
-	methodRepo      *repository.ContactMethodRepository
+	contactService  *service.ContactService
 	interactionRepo *repository.InteractionRepository
 	identityRepo    *repository.IdentityRepository
 	eventRepo       *repository.EventRepository
@@ -114,16 +116,19 @@ func newGmailRematchEnv(t *testing.T, accountIDs []string) *gmailRematchEnv {
 	provider := google.NewGmailSyncProvider(nil, commsRepo, bus, database.Pool)
 	handler := google.NewGmailRematchHandler(provider, syncRepo, commsRepo)
 
+	gen, _ := migrationGenerator(t)
+
 	env := &gmailRematchEnv{
 		ctx:             ctx,
 		database:        database,
+		gen:             gen,
 		provider:        provider,
 		handler:         handler,
 		accountIDs:      accountIDs,
 		bus:             bus,
 		commsRepo:       commsRepo,
 		contactRepo:     contactRepo,
-		methodRepo:      methodRepo,
+		contactService:  contactService,
 		interactionRepo: interactionRepo,
 		identityRepo:    identityRepo,
 		eventRepo:       eventRepo,
@@ -158,25 +163,30 @@ func (e *gmailRematchEnv) seedEnabledEmailState(t *testing.T, accountID, backfil
 	})
 }
 
-func (e *gmailRematchEnv) newContactWithEmail(t *testing.T, name, email string) *repository.Contact {
+// newContact seeds a namespaced contact (weekly cadence) carrying one factory
+// email method and returns it plus that email (the rematch match key).
+func (e *gmailRematchEnv) newContact(t *testing.T) (*repository.Contact, string) {
+	t.Helper()
+	spec := e.gen.Contact(factory.WithEmail(), factory.WithCadence("weekly"))
+	return e.seedContactWithEmail(t, spec.FullName, spec.Email), spec.Email
+}
+
+// seedContactWithEmail seeds a contact with the given full name + a single email
+// method through the nil-bus ContactService (single-tx write, no River client),
+// registering content/interaction-then-contact cleanup. The email is explicit so
+// the fan-out test can seed two contacts that share one address.
+func (e *gmailRematchEnv) seedContactWithEmail(t *testing.T, name, email string) *repository.Contact {
 	t.Helper()
 	cadence := "weekly"
-	contact, err := e.contactRepo.CreateContact(e.ctx, repository.CreateContactRequest{
+	contact, _, err := e.contactService.CreateContact(e.ctx, repository.CreateContactRequest{
 		FullName: name,
 		Cadence:  &cadence,
-	})
-	require.NoError(t, err)
-	_, err = e.methodRepo.CreateContactMethod(e.ctx, repository.CreateContactMethodRequest{
-		ContactID: contact.ID,
-		Type:      "email",
-		Value:     email,
-		IsPrimary: true,
-	})
+	}, []service.ContactMethodInput{{Type: "email", Value: email, IsPrimary: true}})
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		_ = e.commsRepo.HardDeleteByContact(e.ctx, contact.ID)
 		_ = e.interactionRepo.HardDeleteInteractionsBySourceRefPrefix(e.ctx, repository.InteractionSourceEmail, contact.ID.String()+":%")
-		_ = e.contactRepo.SoftDeleteContact(e.ctx, contact.ID)
+		_ = e.contactRepo.HardDeleteContact(e.ctx, contact.ID)
 	})
 	return contact
 }
@@ -282,13 +292,12 @@ func (e *gmailRematchEnv) waitForLastContacted(t *testing.T, contactID uuid.UUID
 
 func TestGmailRematch_NewAddressScan_DerivesInteractions(t *testing.T) {
 	e := newGmailRematchEnv(t, []string{"acct-" + uuid.NewString()[:8] + "@example.com"})
-	suffix := uuid.NewString()[:8]
+	prefix := e.gen.Prefix()
 	me := e.accountIDs[0]
-	addrA := "a-" + suffix + "@example.com"
-	contactA := e.newContactWithEmail(t, "Contact A "+suffix, addrA)
+	contactA, addrA := e.newContact(t)
 
-	inExt := "in-" + suffix + "@example.com"
-	outExt := "out-" + suffix + "@example.com"
+	inExt := prefix + "in@synthetic.example"
+	outExt := prefix + "out@synthetic.example"
 	e.cleanupEvents(t, inExt)
 	e.cleanupEvents(t, outExt)
 
@@ -330,15 +339,14 @@ func TestGmailRematch_NewAddressScan_DerivesInteractions(t *testing.T) {
 
 func TestGmailRematch_MatchOnly_NoContactCreated(t *testing.T) {
 	e := newGmailRematchEnv(t, []string{"acct-" + uuid.NewString()[:8] + "@example.com"})
-	suffix := uuid.NewString()[:8]
+	prefix := e.gen.Prefix()
 	me := e.accountIDs[0]
-	addrA := "a-" + suffix + "@example.com"
-	unknown := "unknown-" + suffix + "@example.com"
-	contactA := e.newContactWithEmail(t, "Contact A "+suffix, addrA)
+	unknown := prefix + "unknown@synthetic.example"
+	contactA, addrA := e.newContact(t)
 
-	e.cleanupEvents(t, "mo-"+suffix+"@example.com")
+	e.cleanupEvents(t, prefix+"mo@synthetic.example")
 	// Message between "me" and an UNKNOWN address only (A is not a participant).
-	msg := gmailMsg("g-mo", "thr", unknown, []string{me}, nil, nil, "S", "body", "<mo-"+suffix+"@example.com>", gmailPastNoonAnchor().UnixMilli())
+	msg := gmailMsg("g-mo", "thr", unknown, []string{me}, nil, nil, "S", "body", "<"+prefix+"mo@synthetic.example>", gmailPastNoonAnchor().UnixMilli())
 	e.inject(newRecordingMessageStore([]*gmailapi.Message{msg}), map[string]struct{}{me: {}})
 
 	// Rematch for A's address, but the message has no A participant → no rows.
@@ -360,13 +368,13 @@ func TestGmailRematch_MatchOnly_NoContactCreated(t *testing.T) {
 
 func TestGmailRematch_FanOut_SharedAddress(t *testing.T) {
 	e := newGmailRematchEnv(t, []string{"acct-" + uuid.NewString()[:8] + "@example.com"})
-	suffix := uuid.NewString()[:8]
+	prefix := e.gen.Prefix()
 	me := e.accountIDs[0]
-	shared := "shared-" + suffix + "@example.com"
-	c1 := e.newContactWithEmail(t, "Contact One "+suffix, shared)
-	c2 := e.newContactWithEmail(t, "Contact Two "+suffix, shared)
+	shared := prefix + "shared@synthetic.example"
+	c1 := e.seedContactWithEmail(t, prefix+"Contact One", shared)
+	c2 := e.seedContactWithEmail(t, prefix+"Contact Two", shared)
 
-	ext := "fan-" + suffix + "@example.com"
+	ext := prefix + "fan@synthetic.example"
 	e.cleanupEvents(t, ext)
 	msg := gmailMsg("g-fan", "thr", shared, []string{me}, nil, nil, "S", "body", "<"+ext+">", gmailPastNoonAnchor().UnixMilli())
 	e.inject(newRecordingMessageStore([]*gmailapi.Message{msg}), map[string]struct{}{me: {}})
@@ -398,14 +406,13 @@ func TestGmailRematch_FanOut_SharedAddress(t *testing.T) {
 // --- Scenario 4: across multiple accounts (per-account `seen` not hoisted) --
 
 func TestGmailRematch_MultipleAccounts_PerAccountSeen(t *testing.T) {
-	suffix := uuid.NewString()[:8]
-	accountX := "x-" + suffix + "@example.com"
-	accountY := "y-" + suffix + "@example.com"
+	accountX := "x-" + uuid.NewString()[:8] + "@example.com"
+	accountY := "y-" + uuid.NewString()[:8] + "@example.com"
 	e := newGmailRematchEnv(t, []string{accountX, accountY})
-	addrA := "a-" + suffix + "@example.com"
-	contactA := e.newContactWithEmail(t, "Contact A "+suffix, addrA)
+	prefix := e.gen.Prefix()
+	contactA, addrA := e.newContact(t)
 
-	ext := "xacct-" + suffix + "@example.com"
+	ext := prefix + "xacct@synthetic.example"
 	e.cleanupEvents(t, ext)
 	// The SAME Message-ID observed in both mailboxes: same gmail message id so
 	// the fetcher's per-id counter measures cross-account scanning. Both
@@ -449,11 +456,10 @@ func TestGmailRematch_MultipleAccounts_PerAccountSeen(t *testing.T) {
 func TestGmailRematch_NoCursorSideEffects(t *testing.T) {
 	account := "acct-" + uuid.NewString()[:8] + "@example.com"
 	e := newGmailRematchEnv(t, []string{account})
-	suffix := uuid.NewString()[:8]
-	addrA := "a-" + suffix + "@example.com"
-	contactA := e.newContactWithEmail(t, "Contact A "+suffix, addrA)
+	prefix := e.gen.Prefix()
+	contactA, addrA := e.newContact(t)
 
-	ext := "nocur-" + suffix + "@example.com"
+	ext := prefix + "nocur@synthetic.example"
 	e.cleanupEvents(t, ext)
 	msg := gmailMsg("g-nocur", "thr", addrA, []string{account}, nil, nil, "S", "body", "<"+ext+">", gmailPastNoonAnchor().UnixMilli())
 	e.inject(newRecordingMessageStore([]*gmailapi.Message{msg}), map[string]struct{}{account: {}})
@@ -476,11 +482,10 @@ func TestGmailRematch_NoCursorSideEffects(t *testing.T) {
 func TestGmailRematch_BackfillFloorAndQueryShape(t *testing.T) {
 	account := "acct-" + uuid.NewString()[:8] + "@example.com"
 	e := newGmailRematchEnv(t, []string{account})
-	suffix := uuid.NewString()[:8]
-	addrA := "a-" + suffix + "@example.com"
-	contactA := e.newContactWithEmail(t, "Contact A "+suffix, addrA)
+	prefix := e.gen.Prefix()
+	contactA, addrA := e.newContact(t)
 
-	ext := "shape-" + suffix + "@example.com"
+	ext := prefix + "shape@synthetic.example"
 	e.cleanupEvents(t, ext)
 	msg := gmailMsg("g-shape", "thr", addrA, []string{account}, nil, nil, "S", "body", "<"+ext+">", gmailPastNoonAnchor().UnixMilli())
 	store := newRecordingMessageStore([]*gmailapi.Message{msg})
@@ -516,14 +521,13 @@ func TestGmailRematch_NoEnabledState_NoOp(t *testing.T) {
 	t.Run("no_state_at_all", func(t *testing.T) {
 		// Seed NO email state for this env (nil account list).
 		e := newGmailRematchEnv(t, nil)
-		suffix := uuid.NewString()[:8]
-		me := "acct-" + suffix + "@example.com"
-		addrA := "a-" + suffix + "@example.com"
-		contactA := e.newContactWithEmail(t, "Contact A "+suffix, addrA)
+		prefix := e.gen.Prefix()
+		me := prefix + "me@synthetic.example"
+		contactA, addrA := e.newContact(t)
 
 		// A fetcher that WOULD return a qualifying message if it were ever
 		// consulted — the gate must prevent that.
-		msg := gmailMsg("g-gate-a", "thr", addrA, []string{me}, nil, nil, "S", "body", "<gate-a-"+suffix+"@example.com>", gmailPastNoonAnchor().UnixMilli())
+		msg := gmailMsg("g-gate-a", "thr", addrA, []string{me}, nil, nil, "S", "body", "<"+prefix+"gate-a@synthetic.example>", gmailPastNoonAnchor().UnixMilli())
 		store := newRecordingMessageStore([]*gmailapi.Message{msg})
 		e.inject(store, map[string]struct{}{me: {}})
 
@@ -542,10 +546,9 @@ func TestGmailRematch_NoEnabledState_NoOp(t *testing.T) {
 		// Seed an email state for this account, then DISABLE it via the
 		// enable/disable path. ListEnabledSyncStates filters status='disabled'.
 		e := newGmailRematchEnv(t, nil)
-		suffix := uuid.NewString()[:8]
-		me := "acct-" + suffix + "@example.com"
-		addrA := "a-" + suffix + "@example.com"
-		contactA := e.newContactWithEmail(t, "Contact A "+suffix, addrA)
+		prefix := e.gen.Prefix()
+		me := "acct-" + uuid.NewString()[:8] + "@example.com"
+		contactA, addrA := e.newContact(t)
 
 		acct := me
 		created, err := e.syncRepo.CreateSyncState(e.ctx, repository.CreateSyncStateRequest{
@@ -565,7 +568,7 @@ func TestGmailRematch_NoEnabledState_NoOp(t *testing.T) {
 		_, err = e.syncRepo.UpdateSyncStateEnabled(e.ctx, created.ID, false)
 		require.NoError(t, err)
 
-		msg := gmailMsg("g-gate-d", "thr", addrA, []string{me}, nil, nil, "S", "body", "<gate-d-"+suffix+"@example.com>", gmailPastNoonAnchor().UnixMilli())
+		msg := gmailMsg("g-gate-d", "thr", addrA, []string{me}, nil, nil, "S", "body", "<"+prefix+"gate-d@synthetic.example>", gmailPastNoonAnchor().UnixMilli())
 		store := newRecordingMessageStore([]*gmailapi.Message{msg})
 		e.inject(store, map[string]struct{}{me: {}})
 
@@ -589,14 +592,13 @@ func TestGmailRematch_NoEnabledState_NoOp(t *testing.T) {
 // failing OWN-mailbox account id RAW (operator triage) and must NOT contain the
 // third-party contact address being rematched.
 func TestGmailRematch_PartialFailure_ReturnsError(t *testing.T) {
-	suffix := uuid.NewString()[:8]
-	accountX := "x-" + suffix + "@example.com"
-	accountY := "y-" + suffix + "@example.com"
+	accountX := "x-" + uuid.NewString()[:8] + "@example.com"
+	accountY := "y-" + uuid.NewString()[:8] + "@example.com"
 	e := newGmailRematchEnv(t, []string{accountX, accountY})
-	addrA := "a-" + suffix + "@example.com"
-	contactA := e.newContactWithEmail(t, "Contact A "+suffix, addrA)
+	prefix := e.gen.Prefix()
+	contactA, addrA := e.newContact(t)
 
-	ext := "pf-" + suffix + "@example.com"
+	ext := prefix + "pf@synthetic.example"
 	e.cleanupEvents(t, ext)
 	msg := gmailMsg("g-pf", "thr", addrA, []string{accountY}, nil, nil, "S", "body", "<"+ext+">", gmailPastNoonAnchor().UnixMilli())
 
@@ -640,13 +642,12 @@ func TestGmailRematch_PerAccountBackfillSince(t *testing.T) {
 	t.Run("explicit_backfill_since", func(t *testing.T) {
 		// Seed NO default state; create one with an explicit non-default floor.
 		e := newGmailRematchEnv(t, nil)
-		suffix := uuid.NewString()[:8]
-		account := "acct-" + suffix + "@example.com"
+		prefix := e.gen.Prefix()
+		account := "acct-" + uuid.NewString()[:8] + "@example.com"
 		e.seedEnabledEmailState(t, account, "2026-03-15")
 
-		addrA := "a-" + suffix + "@example.com"
-		contactA := e.newContactWithEmail(t, "Contact A "+suffix, addrA)
-		ext := "bf-" + suffix + "@example.com"
+		contactA, addrA := e.newContact(t)
+		ext := prefix + "bf@synthetic.example"
 		e.cleanupEvents(t, ext)
 		msg := gmailMsg("g-bf", "thr", addrA, []string{account}, nil, nil, "S", "body", "<"+ext+">", gmailPastNoonAnchor().UnixMilli())
 		store := newRecordingMessageStore([]*gmailapi.Message{msg})
@@ -668,8 +669,8 @@ func TestGmailRematch_PerAccountBackfillSince(t *testing.T) {
 		// An enabled state with empty metadata falls back to 2026-01-01 through
 		// the new per-state wiring (proves backfillSinceEpoch's default path).
 		e := newGmailRematchEnv(t, nil)
-		suffix := uuid.NewString()[:8]
-		account := "acct-" + suffix + "@example.com"
+		prefix := e.gen.Prefix()
+		account := "acct-" + uuid.NewString()[:8] + "@example.com"
 		acct := account
 		_, err := e.syncRepo.CreateSyncState(e.ctx, repository.CreateSyncStateRequest{
 			Source:    "email",
@@ -681,9 +682,8 @@ func TestGmailRematch_PerAccountBackfillSince(t *testing.T) {
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = e.syncRepo.DeleteSyncStatesByAccountID(e.ctx, acct) })
 
-		addrA := "a-" + suffix + "@example.com"
-		contactA := e.newContactWithEmail(t, "Contact A "+suffix, addrA)
-		ext := "bfd-" + suffix + "@example.com"
+		contactA, addrA := e.newContact(t)
+		ext := prefix + "bfd@synthetic.example"
 		e.cleanupEvents(t, ext)
 		msg := gmailMsg("g-bfd", "thr", addrA, []string{account}, nil, nil, "S", "body", "<"+ext+">", gmailPastNoonAnchor().UnixMilli())
 		store := newRecordingMessageStore([]*gmailapi.Message{msg})

--- a/backend/tests/interaction_repository_source_filter_test.go
+++ b/backend/tests/interaction_repository_source_filter_test.go
@@ -41,7 +41,7 @@ func TestInteractionRepository_FindRecentInteractionBySourceAndDirection_SourceF
 	require.NoError(t, err)
 	t.Cleanup(func() { database.Close() })
 
-	contactRepo := repository.NewContactRepository(database.Queries)
+	gen, _ := migrationGenerator(t)
 	interactionRepo := repository.NewInteractionRepository(database.Queries)
 
 	// testStripe=3 carves out a per-test subspace of chat IDs and source_ref
@@ -67,11 +67,11 @@ func TestInteractionRepository_FindRecentInteractionBySourceAndDirection_SourceF
 		_ = interactionRepo.HardDeleteInteractionsBySourceRefPrefix(ctx, repository.InteractionSourceGCal, gcalCleanupPrefix)
 	})
 
-	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-		FullName: fmt.Sprintf("source-filter-test-%d", seed),
-	})
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = contactRepo.SoftDeleteContact(ctx, contact.ID) })
+	// The contact is an FK target referenced by ID only; the source_ref
+	// stripe scheme above carries this test's isolation, so the seed just
+	// needs a valid contact.
+	contact, contactCleanup := seedMigrationContact(ctx, t, database, gen)
+	t.Cleanup(contactCleanup)
 
 	t0 := accelerated.GetCurrentTime().Add(-2 * time.Hour).Truncate(time.Microsecond)
 	windowStart := t0.Add(-1 * time.Hour)

--- a/backend/tests/interaction_source_descriptor_check_test.go
+++ b/backend/tests/interaction_source_descriptor_check_test.go
@@ -149,7 +149,7 @@ func TestInteractionSourceCheck_AcceptsPhoneCalls(t *testing.T) {
 	interactionRepo := repository.NewInteractionRepository(database.Queries)
 	contactRepo := repository.NewContactRepository(database.Queries)
 
-	suffix := randomSuffix(t)
+	suffix := syntheticNS(t)
 	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
 		FullName: "Test PhoneCalls Source CHECK " + suffix,
 	})

--- a/backend/tests/interaction_source_gchat_check_test.go
+++ b/backend/tests/interaction_source_gchat_check_test.go
@@ -38,7 +38,7 @@ func TestInteraction_SourceCheckAcceptsGchat(t *testing.T) {
 	interactionRepo := repository.NewInteractionRepository(database.Queries)
 	contactRepo := repository.NewContactRepository(database.Queries)
 
-	suffix := randomSuffix(t)
+	suffix := syntheticNS(t)
 	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
 		FullName: "Test GChat Source CHECK " + suffix,
 	})

--- a/backend/tests/interaction_source_messages_check_test.go
+++ b/backend/tests/interaction_source_messages_check_test.go
@@ -38,7 +38,7 @@ func TestInteraction_SourceCheckAcceptsMessages(t *testing.T) {
 	interactionRepo := repository.NewInteractionRepository(database.Queries)
 	contactRepo := repository.NewContactRepository(database.Queries)
 
-	suffix := randomSuffix(t)
+	suffix := syntheticNS(t)
 	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
 		FullName: "Test Source CHECK " + suffix,
 	})
@@ -89,7 +89,7 @@ func TestInteraction_SourceCheckRejectsWhatsapp(t *testing.T) {
 	interactionRepo := repository.NewInteractionRepository(database.Queries)
 	contactRepo := repository.NewContactRepository(database.Queries)
 
-	suffix := randomSuffix(t)
+	suffix := syntheticNS(t)
 	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
 		FullName: "Test Whatsapp Reject " + suffix,
 	})

--- a/backend/tests/link_contact_curated_status_integration_test.go
+++ b/backend/tests/link_contact_curated_status_integration_test.go
@@ -112,7 +112,7 @@ func (env *linkCuratedEnv) callImport(t *testing.T, externalID string, body *han
 // arbitrary source (used to exercise the link-only import guard).
 func (env *linkCuratedEnv) seedUnmatchedExternalSource(t *testing.T, ctx context.Context, source string) *repository.ExternalContact {
 	t.Helper()
-	sfx := abSuffix()
+	sfx := abSuffix(t)
 	display := "Link Only Ext " + sfx
 	external, err := env.externalRepo.Upsert(ctx, repository.UpsertExternalContactRequest{
 		Source:      source,
@@ -127,7 +127,7 @@ func (env *linkCuratedEnv) seedUnmatchedExternalSource(t *testing.T, ctx context
 
 func (env *linkCuratedEnv) seedUnmatchedExternal(t *testing.T, ctx context.Context) (*repository.Contact, *repository.ExternalContact) {
 	t.Helper()
-	sfx := abSuffix()
+	sfx := abSuffix(t)
 	contact, err := env.contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: "Link Curated " + sfx})
 	require.NoError(t, err)
 	display := "Link Curated Ext " + sfx

--- a/backend/tests/phone_call_repository_test.go
+++ b/backend/tests/phone_call_repository_test.go
@@ -11,27 +11,34 @@ import (
 	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/synthetic/factory"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// phoneCallTestEnv bundles the per-test repos and host ID. The
+// phoneCallTestEnv bundles the per-test repos, generator, and host ID. The
 // InteractionRepository is included for tests that need to create
-// interactions for FK references.
+// interactions for FK references. gen scopes every string identifier the
+// sub-tests construct to a unique per-test namespace, and seeds contacts via
+// seedMigrationContact.
 type phoneCallTestEnv struct {
 	ctx             context.Context
+	database        *db.Database
+	gen             *factory.Generator
 	repo            *repository.PhoneCallRepository
-	contactRepo     *repository.ContactRepository
 	interactionRepo *repository.InteractionRepository
 	hostID          uuid.UUID
 }
 
-// setupPhoneCallTest provisions a per-test mac_host row + repo bundle.
-// Cleanup hard-deletes scoped by mac_host_id. Matches the pattern from
-// setupMessagesMessageTest — same parallel-runner singleton-slot
-// constraint applies.
+// setupPhoneCallTest provisions a per-test mac_host row + repo bundle via the
+// lightweight synthetic path (a factory.Generator, no replay harness / River
+// client — so the file stays in the fast PR gate). The mac_host is seeded
+// pre-revoked and namespace-prefixed so the singleton index never collides with
+// a parallel tests/api package, mirroring setupMessagesMessageTest. Cleanup
+// hard-deletes scoped by mac_host_id (upsert does not clear deleted_at on
+// conflict, so a soft delete would resurrect rows across runs).
 func setupPhoneCallTest(t *testing.T) (phoneCallTestEnv, func()) {
 	t.Helper()
 	if testing.Short() {
@@ -48,14 +55,15 @@ func setupPhoneCallTest(t *testing.T) (phoneCallTestEnv, func()) {
 	database, err := db.NewDatabase(ctx, cfg.Database)
 	require.NoError(t, err)
 
+	gen, _ := migrationGenerator(t)
+
 	repo := repository.NewPhoneCallRepository(database.Queries)
-	contactRepo := repository.NewContactRepository(database.Queries)
 	interactionRepo := repository.NewInteractionRepository(database.Queries)
 
 	macHostRepo := repository.NewMacHostRepository(database.Queries)
-	suffix := randomSuffix(t)
+	prefix := gen.Prefix()
 	host, err := macHostRepo.SeedRevokedHostForTest(ctx,
-		"test-pc-host-"+suffix, "test-version", 1, "test-hash-"+suffix)
+		prefix+"pc-host", "test-version", 1, prefix+"pc-hash")
 	require.NoError(t, err)
 
 	cleanup := func() {
@@ -64,8 +72,9 @@ func setupPhoneCallTest(t *testing.T) (phoneCallTestEnv, func()) {
 	}
 	return phoneCallTestEnv{
 		ctx:             ctx,
+		database:        database,
+		gen:             gen,
 		repo:            repo,
-		contactRepo:     contactRepo,
 		interactionRepo: interactionRepo,
 		hostID:          host.ID,
 	}, cleanup
@@ -75,14 +84,13 @@ func TestPhoneCallRepository_UpsertAndGet(t *testing.T) {
 	env, cleanup := setupPhoneCallTest(t)
 	defer cleanup()
 
-	suffix := randomSuffix(t)
-	contact, err := env.contactRepo.CreateContact(env.ctx, repository.CreateContactRequest{FullName: "Test PC Upsert " + suffix})
-	require.NoError(t, err)
-	defer func() { _ = env.contactRepo.SoftDeleteContact(env.ctx, contact.ID) }()
+	contact, contactCleanup := seedMigrationContact(env.ctx, t, env.database, env.gen)
+	defer contactCleanup()
 
+	prefix := env.gen.Prefix()
 	startedAt := accelerated.GetCurrentTime().Truncate(time.Microsecond)
 	answered := true
-	uniqueID := "call-" + suffix
+	uniqueID := prefix + "call"
 
 	call, err := env.repo.UpsertCall(env.ctx, repository.UpsertPhoneCallParams{
 		CallUniqueID:     uniqueID,
@@ -133,7 +141,7 @@ func TestPhoneCallRepository_GetByUniqueID_NotFound(t *testing.T) {
 	env, cleanup := setupPhoneCallTest(t)
 	defer cleanup()
 
-	_, err := env.repo.GetCallByUniqueID(env.ctx, "nonexistent-call-"+randomSuffix(t))
+	_, err := env.repo.GetCallByUniqueID(env.ctx, env.gen.Prefix()+"nonexistent-call")
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, db.ErrNotFound))
 }
@@ -142,14 +150,13 @@ func TestPhoneCallRepository_MarkProcessed_WithInteraction(t *testing.T) {
 	env, cleanup := setupPhoneCallTest(t)
 	defer cleanup()
 
-	suffix := randomSuffix(t)
-	contact, err := env.contactRepo.CreateContact(env.ctx, repository.CreateContactRequest{FullName: "Test PC Processed " + suffix})
-	require.NoError(t, err)
-	defer func() { _ = env.contactRepo.SoftDeleteContact(env.ctx, contact.ID) }()
+	contact, contactCleanup := seedMigrationContact(env.ctx, t, env.database, env.gen)
+	defer contactCleanup()
 
-	ref := "call-mp-" + suffix
+	prefix := env.gen.Prefix()
+	ref := prefix + "call-mp"
 	defer func() {
-		_ = env.interactionRepo.HardDeleteInteractionsBySourceRefPrefix(env.ctx, "phone_calls", "call-mp-%")
+		_ = env.interactionRepo.HardDeleteInteractionsBySourceRefPrefix(env.ctx, "phone_calls", ref+"%")
 	}()
 	interaction, err := env.interactionRepo.CreateInteraction(env.ctx, repository.CreateInteractionRequest{
 		ContactID:  contact.ID,
@@ -192,10 +199,9 @@ func TestPhoneCallRepository_MarkProcessed_NoInteraction(t *testing.T) {
 	env, cleanup := setupPhoneCallTest(t)
 	defer cleanup()
 
-	suffix := randomSuffix(t)
 	answered := false
 	call, err := env.repo.UpsertCall(env.ctx, repository.UpsertPhoneCallParams{
-		CallUniqueID:    "call-noix-" + suffix,
+		CallUniqueID:    env.gen.Prefix() + "call-noix",
 		PeerHandle:      "+15551234567",
 		PeerNormalized:  "+15551234567",
 		Service:         repository.PhoneCallServiceVoice,
@@ -225,10 +231,10 @@ func TestPhoneCallRepository_HardDeleteByMacHost(t *testing.T) {
 	env, cleanup := setupPhoneCallTest(t)
 	defer cleanup()
 
-	suffix := randomSuffix(t)
+	uniqueID := env.gen.Prefix() + "call-del"
 	answered := true
 	_, err := env.repo.UpsertCall(env.ctx, repository.UpsertPhoneCallParams{
-		CallUniqueID:    "call-del-" + suffix,
+		CallUniqueID:    uniqueID,
 		PeerHandle:      "+15551234567",
 		PeerNormalized:  "+15551234567",
 		Service:         repository.PhoneCallServiceVoice,
@@ -243,6 +249,6 @@ func TestPhoneCallRepository_HardDeleteByMacHost(t *testing.T) {
 	err = env.repo.HardDeleteByMacHost(env.ctx, env.hostID)
 	require.NoError(t, err)
 
-	_, err = env.repo.GetCallByUniqueID(env.ctx, "call-del-"+suffix)
+	_, err = env.repo.GetCallByUniqueID(env.ctx, uniqueID)
 	assert.True(t, errors.Is(err, db.ErrNotFound))
 }

--- a/backend/tests/rematch_integration_test.go
+++ b/backend/tests/rematch_integration_test.go
@@ -15,6 +15,7 @@ import (
 	"personal-crm/backend/internal/google"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/service"
+	"personal-crm/backend/internal/synthetic/factory"
 	tgpkg "personal-crm/backend/internal/telegram"
 
 	"github.com/google/uuid"
@@ -33,6 +34,7 @@ import (
 type rematchTestEnv struct {
 	ctx               context.Context
 	database          *db.Database
+	gen               *factory.Generator
 	contactRepo       *repository.ContactRepository
 	contactMethodRepo *repository.ContactMethodRepository
 	calendarRepo      *repository.CalendarEventRepository
@@ -97,9 +99,12 @@ func setupRematchEnv(t *testing.T) *rematchTestEnv {
 
 	rematchSvc.Register(google.NewCalendarRematchHandler(calendarRepo, externalRepo, bus))
 
+	gen, _ := migrationGenerator(t)
+
 	return &rematchTestEnv{
 		ctx:               ctx,
 		database:          database,
+		gen:               gen,
 		contactRepo:       contactRepo,
 		contactMethodRepo: contactMethodRepo,
 		calendarRepo:      calendarRepo,
@@ -110,6 +115,17 @@ func setupRematchEnv(t *testing.T) *rematchTestEnv {
 		rematchSvc:        rematchSvc,
 		bus:               bus,
 	}
+}
+
+// newContact seeds a namespaced, method-less contact through the lightweight
+// migration helper (nil-bus single-tx write) and registers its scoped cleanup.
+// Rematch is driven by an explicit attendee email/handle, so the contact needs
+// no method of its own — only a namespace-isolated identity.
+func (env *rematchTestEnv) newContact(t *testing.T) *repository.Contact {
+	t.Helper()
+	contact, cleanup := seedMigrationContact(env.ctx, t, env.database, env.gen, factory.WithNoMethods())
+	t.Cleanup(cleanup)
+	return contact
 }
 
 // waitForJob polls the rematch service until the job is in a terminal state.
@@ -156,11 +172,7 @@ func seedCalendarEventWithAttendee(t *testing.T, env *rematchTestEnv, accountID,
 func TestRematch_CalendarPastEvent_RecordsInteraction(t *testing.T) {
 	env := setupRematchEnv(t)
 
-	contact, err := env.contactRepo.CreateContact(env.ctx, repository.CreateContactRequest{
-		FullName: "Rematch Past Event " + uuid.NewString()[:8],
-	})
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = env.contactRepo.HardDeleteContact(env.ctx, contact.ID) })
+	contact := env.newContact(t)
 
 	accountID := "rematch-past-" + uuid.NewString()
 	email := "alice@example.com"
@@ -200,11 +212,7 @@ func TestRematch_CalendarPastEvent_RecordsInteraction(t *testing.T) {
 func TestRematch_CalendarFutureEvent_NoInteraction(t *testing.T) {
 	env := setupRematchEnv(t)
 
-	contact, err := env.contactRepo.CreateContact(env.ctx, repository.CreateContactRequest{
-		FullName: "Rematch Future Event " + uuid.NewString()[:8],
-	})
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = env.contactRepo.HardDeleteContact(env.ctx, contact.ID) })
+	contact := env.newContact(t)
 
 	accountID := "rematch-future-" + uuid.NewString()
 	email := "bob@example.com"
@@ -236,11 +244,7 @@ func TestRematch_CalendarFutureEvent_NoInteraction(t *testing.T) {
 func TestRematch_CalendarCaseInsensitiveEmailMatch(t *testing.T) {
 	env := setupRematchEnv(t)
 
-	contact, err := env.contactRepo.CreateContact(env.ctx, repository.CreateContactRequest{
-		FullName: "Rematch Case " + uuid.NewString()[:8],
-	})
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = env.contactRepo.HardDeleteContact(env.ctx, contact.ID) })
+	contact := env.newContact(t)
 
 	accountID := "rematch-case-" + uuid.NewString()
 	t.Cleanup(func() { _ = env.calendarRepo.DeleteEventsByAccount(env.ctx, accountID) })
@@ -265,11 +269,7 @@ func TestRematch_CalendarCaseInsensitiveEmailMatch(t *testing.T) {
 func TestRematch_CalendarIdempotent(t *testing.T) {
 	env := setupRematchEnv(t)
 
-	contact, err := env.contactRepo.CreateContact(env.ctx, repository.CreateContactRequest{
-		FullName: "Rematch Idempotent " + uuid.NewString()[:8],
-	})
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = env.contactRepo.HardDeleteContact(env.ctx, contact.ID) })
+	contact := env.newContact(t)
 
 	accountID := "rematch-idem-" + uuid.NewString()
 	email := "carol@example.com"
@@ -323,13 +323,9 @@ func TestRematch_CalendarIdempotent(t *testing.T) {
 func TestRematch_CalendarMarksGcalAttendeeExternalContactMatched(t *testing.T) {
 	env := setupRematchEnv(t)
 
-	contact, err := env.contactRepo.CreateContact(env.ctx, repository.CreateContactRequest{
-		FullName: "Rematch External " + uuid.NewString()[:8],
-	})
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = env.contactRepo.HardDeleteContact(env.ctx, contact.ID) })
+	contact := env.newContact(t)
 
-	email := "dan-" + uuid.NewString()[:8] + "@example.com"
+	email := env.gen.Prefix() + "dan@synthetic.example"
 	displayName := "Dan Test"
 
 	// Seed a gcal_attendee external_contact with this email as its source_id.
@@ -389,11 +385,7 @@ func TestRematch_TelegramUsernameMatch(t *testing.T) {
 	)
 	env.rematchSvc.Register(tgpkg.NewUsernameRematchHandler(messageRepo, peerMatcher, aggregationEngine))
 
-	contact, err := env.contactRepo.CreateContact(env.ctx, repository.CreateContactRequest{
-		FullName: "Rematch TG Username " + uuid.NewString()[:8],
-	})
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = env.contactRepo.HardDeleteContact(env.ctx, contact.ID) })
+	contact := env.newContact(t)
 
 	suffix := uuid.NewString()[:8]
 	chatID := int64(900100)
@@ -410,7 +402,7 @@ func TestRematch_TelegramUsernameMatch(t *testing.T) {
 	now := accelerated.GetCurrentTime()
 	text := "Hello"
 	for i := range 3 {
-		_, err = messageRepo.UpsertMessage(env.ctx, repository.UpsertTelegramMessageParams{
+		_, err := messageRepo.UpsertMessage(env.ctx, repository.UpsertTelegramMessageParams{
 			TelegramMessageID: int32(90100 + i),
 			TelegramChatID:    chatID,
 			ChatType:          "private",
@@ -473,7 +465,7 @@ func TestRematch_Publisher_NoHandler_ReturnsNilJobID(t *testing.T) {
 	// for "phone" in the base env.
 	phone := "+15551212"
 	_, jobID, err := env.contactSvc.CreateContact(env.ctx, repository.CreateContactRequest{
-		FullName: "No Handler " + uuid.NewString()[:8],
+		FullName: env.gen.Prefix() + "No Handler",
 	}, []service.ContactMethodInput{
 		{Type: "phone", Value: phone, IsPrimary: true},
 	})
@@ -483,7 +475,7 @@ func TestRematch_Publisher_NoHandler_ReturnsNilJobID(t *testing.T) {
 	// RescanRematch on a contact whose only methods are unhandled
 	// should also return uuid.Nil.
 	contact, err := env.contactRepo.CreateContact(env.ctx, repository.CreateContactRequest{
-		FullName: "Rescan No Handler " + uuid.NewString()[:8],
+		FullName: env.gen.Prefix() + "Rescan No Handler",
 	})
 	require.NoError(t, err)
 	_, err = env.contactMethodRepo.CreateContactMethod(env.ctx, repository.CreateContactMethodRequest{
@@ -526,11 +518,7 @@ func TestRematch_TelegramPhoneMatch(t *testing.T) {
 	env := setupRematchEnv(t)
 	messageRepo := registerTelegramHandlers(t, env)
 
-	contact, err := env.contactRepo.CreateContact(env.ctx, repository.CreateContactRequest{
-		FullName: "Rematch TG Phone " + uuid.NewString()[:8],
-	})
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = env.contactRepo.HardDeleteContact(env.ctx, contact.ID) })
+	contact := env.newContact(t)
 
 	chatID := int64(900200)
 	peerUserID := int64(800200)
@@ -548,7 +536,7 @@ func TestRematch_TelegramPhoneMatch(t *testing.T) {
 
 	now := accelerated.GetCurrentTime()
 	text := "Hi"
-	_, err = messageRepo.UpsertMessage(env.ctx, repository.UpsertTelegramMessageParams{
+	_, err := messageRepo.UpsertMessage(env.ctx, repository.UpsertTelegramMessageParams{
 		TelegramMessageID: 90200,
 		TelegramChatID:    chatID,
 		ChatType:          "private",
@@ -580,11 +568,7 @@ func TestRematch_TelegramPhoneMatch(t *testing.T) {
 func TestRematch_ConcurrentJobs_PerContactMutex(t *testing.T) {
 	env := setupRematchEnv(t)
 
-	contact, err := env.contactRepo.CreateContact(env.ctx, repository.CreateContactRequest{
-		FullName: "Rematch Concurrent " + uuid.NewString()[:8],
-	})
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = env.contactRepo.HardDeleteContact(env.ctx, contact.ID) })
+	contact := env.newContact(t)
 
 	accountID := "rematch-concurrent-" + uuid.NewString()
 	email1 := "conc1@example.com"
@@ -622,16 +606,12 @@ func TestRematch_ConcurrentJobs_PerContactMutex(t *testing.T) {
 func TestRematch_RescanContact_RunsForAllMethods(t *testing.T) {
 	env := setupRematchEnv(t)
 
-	contact, err := env.contactRepo.CreateContact(env.ctx, repository.CreateContactRequest{
-		FullName: "Rematch Rescan " + uuid.NewString()[:8],
-	})
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = env.contactRepo.HardDeleteContact(env.ctx, contact.ID) })
+	contact := env.newContact(t)
 
 	// Create the method directly on the repo so the create path doesn't
 	// trigger a rematch job we don't care about.
 	email := "rescan@example.com"
-	_, err = env.contactMethodRepo.CreateContactMethod(env.ctx, repository.CreateContactMethodRequest{
+	_, err := env.contactMethodRepo.CreateContactMethod(env.ctx, repository.CreateContactMethodRequest{
 		ContactID: contact.ID,
 		Type:      "email",
 		Value:     email,
@@ -695,11 +675,7 @@ func TestRematch_TelegramRematchPlusPostImportHook_NoDuplicateInteraction(t *tes
 	)
 	env.rematchSvc.Register(tgpkg.NewUsernameRematchHandler(messageRepo, peerMatcher, aggregationEngine))
 
-	contact, err := env.contactRepo.CreateContact(env.ctx, repository.CreateContactRequest{
-		FullName: "Rematch TG Combined " + uuid.NewString()[:8],
-	})
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = env.contactRepo.HardDeleteContact(env.ctx, contact.ID) })
+	contact := env.newContact(t)
 
 	suffix := uuid.NewString()[:8]
 	chatID := int64(900300)
@@ -723,7 +699,7 @@ func TestRematch_TelegramRematchPlusPostImportHook_NoDuplicateInteraction(t *tes
 	now := accelerated.GetCurrentTime().Truncate(time.Microsecond)
 	text := "ping"
 	for i := range 3 {
-		_, err = messageRepo.UpsertMessage(env.ctx, repository.UpsertTelegramMessageParams{
+		_, err := messageRepo.UpsertMessage(env.ctx, repository.UpsertTelegramMessageParams{
 			TelegramMessageID: int32(90300 + i),
 			TelegramChatID:    chatID,
 			ChatType:          "private",
@@ -775,14 +751,10 @@ func TestRematch_ContactServiceUpdateContact_FiresForNewMethodOnly(t *testing.T)
 	env := setupRematchEnv(t)
 
 	existingEmail := "existing@example.com"
-	contact, err := env.contactRepo.CreateContact(env.ctx, repository.CreateContactRequest{
-		FullName: "Rematch Diff " + uuid.NewString()[:8],
-	})
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = env.contactRepo.HardDeleteContact(env.ctx, contact.ID) })
+	contact := env.newContact(t)
 
 	// Seed an existing email method outside the service so no rematch fires.
-	_, err = env.contactMethodRepo.CreateContactMethod(env.ctx, repository.CreateContactMethodRequest{
+	_, err := env.contactMethodRepo.CreateContactMethod(env.ctx, repository.CreateContactMethodRequest{
 		ContactID: contact.ID, Type: "email", Value: existingEmail, IsPrimary: true,
 	})
 	require.NoError(t, err)

--- a/backend/tests/suggestion_service_integration_test.go
+++ b/backend/tests/suggestion_service_integration_test.go
@@ -56,7 +56,7 @@ func TestSuggestions_List_SurfacesLinkedRowWithName(t *testing.T) {
 	ctx := context.Background()
 	svc := newSuggestionService(env)
 
-	email := "list-" + abSuffix() + "@example.com"
+	email := "list-" + abSuffix(t) + "@example.com"
 	contact, external := seedImportedWithPending(t, ctx, env, []string{email})
 
 	list, err := svc.ListSuggestions(ctx, service.SuggestionListParams{Page: 1, Limit: 20}, 10000)
@@ -82,7 +82,7 @@ func TestSuggestions_List_DropsSoftDeletedContact(t *testing.T) {
 	ctx := context.Background()
 	svc := newSuggestionService(env)
 
-	email := "softdel-" + abSuffix() + "@example.com"
+	email := "softdel-" + abSuffix(t) + "@example.com"
 	contact, external := seedImportedWithPending(t, ctx, env, []string{email})
 	require.NoError(t, env.contactRepo.SoftDeleteContact(ctx, contact.ID))
 
@@ -100,7 +100,7 @@ func TestSuggestions_List_SourceScopeExcludesNonAddressBook(t *testing.T) {
 
 	// Seed a telegram row with pending JSONB directly (non-address-book
 	// source); it must NOT appear in the suggestions list (source guard).
-	sfx := abSuffix()
+	sfx := abSuffix(t)
 	contact, err := env.contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: "Tg Suggestion " + sfx})
 	require.NoError(t, err)
 	display := "Tg External " + sfx
@@ -134,7 +134,7 @@ func TestSuggestions_Resolve_AddsMethodAndClearsPending(t *testing.T) {
 	ctx := context.Background()
 	svc := newSuggestionService(env)
 
-	email := "resolve-" + abSuffix() + "@example.com"
+	email := "resolve-" + abSuffix(t) + "@example.com"
 	contact, external := seedImportedWithPending(t, ctx, env, []string{email})
 
 	require.False(t, contactHasMethod(t, ctx, env, contact.ID, email), "precondition: method not yet on contact")
@@ -164,7 +164,7 @@ func TestSuggestions_Resolve_Idempotent(t *testing.T) {
 	ctx := context.Background()
 	svc := newSuggestionService(env)
 
-	email := "resolve-idem-" + abSuffix() + "@example.com"
+	email := "resolve-idem-" + abSuffix(t) + "@example.com"
 	_, external := seedImportedWithPending(t, ctx, env, []string{email})
 
 	first, err := svc.ResolveMethodSuggestions(ctx, external.ID, []repository.PendingMethodSuggestion{
@@ -186,7 +186,7 @@ func TestSuggestions_Resolve_AlreadyOnContact_NotReAdded(t *testing.T) {
 	ctx := context.Background()
 	svc := newSuggestionService(env)
 
-	email := "resolve-present-" + abSuffix() + "@example.com"
+	email := "resolve-present-" + abSuffix(t) + "@example.com"
 	contact, external := seedImportedWithPending(t, ctx, env, []string{email})
 
 	// Add the method via another path so it's already present.
@@ -213,7 +213,7 @@ func TestSuggestions_Resolve_UnknownMethodIsNoOp(t *testing.T) {
 	ctx := context.Background()
 	svc := newSuggestionService(env)
 
-	email := "resolve-unknown-" + abSuffix() + "@example.com"
+	email := "resolve-unknown-" + abSuffix(t) + "@example.com"
 	_, external := seedImportedWithPending(t, ctx, env, []string{email})
 
 	// A (type,value) never in this row's pending → silent no-op, not 400.
@@ -234,7 +234,7 @@ func TestSuggestions_Resolve_MalformedMethod400(t *testing.T) {
 	ctx := context.Background()
 	svc := newSuggestionService(env)
 
-	email := "resolve-malformed-" + abSuffix() + "@example.com"
+	email := "resolve-malformed-" + abSuffix(t) + "@example.com"
 	_, external := seedImportedWithPending(t, ctx, env, []string{email})
 
 	_, err := svc.ResolveMethodSuggestions(ctx, external.ID, []repository.PendingMethodSuggestion{
@@ -248,8 +248,8 @@ func TestSuggestions_Dismiss_RecordsStickyAndDropsPending(t *testing.T) {
 	ctx := context.Background()
 	svc := newSuggestionService(env)
 
-	emailX := "dismiss-x-" + abSuffix() + "@example.com"
-	emailY := "dismiss-y-" + abSuffix() + "@example.com"
+	emailX := "dismiss-x-" + abSuffix(t) + "@example.com"
+	emailY := "dismiss-y-" + abSuffix(t) + "@example.com"
 	contact, external := seedImportedWithPending(t, ctx, env, []string{emailX, emailY})
 
 	res, err := svc.DismissMethodSuggestions(ctx, external.ID, []repository.PendingMethodSuggestion{
@@ -284,7 +284,7 @@ func TestSuggestions_Dismiss_Idempotent(t *testing.T) {
 	ctx := context.Background()
 	svc := newSuggestionService(env)
 
-	email := "dismiss-idem-" + abSuffix() + "@example.com"
+	email := "dismiss-idem-" + abSuffix(t) + "@example.com"
 	_, external := seedImportedWithPending(t, ctx, env, []string{email})
 
 	first, err := svc.DismissMethodSuggestions(ctx, external.ID, []repository.PendingMethodSuggestion{
@@ -305,7 +305,7 @@ func TestSuggestions_Dismiss_AlreadyOnContact_NotStickyDismissed(t *testing.T) {
 	ctx := context.Background()
 	svc := newSuggestionService(env)
 
-	email := "dismiss-present-" + abSuffix() + "@example.com"
+	email := "dismiss-present-" + abSuffix(t) + "@example.com"
 	contact, external := seedImportedWithPending(t, ctx, env, []string{email})
 
 	// Add the method to the contact via another path.
@@ -333,7 +333,7 @@ func TestSuggestions_Resolve_ContactGone(t *testing.T) {
 	ctx := context.Background()
 	svc := newSuggestionService(env)
 
-	email := "gone-" + abSuffix() + "@example.com"
+	email := "gone-" + abSuffix(t) + "@example.com"
 	contact, external := seedImportedWithPending(t, ctx, env, []string{email})
 	require.NoError(t, env.contactRepo.SoftDeleteContact(ctx, contact.ID))
 
@@ -347,13 +347,13 @@ func TestSuggestions_DuplicateOfCanonical_ResolvesToCanonicalContact(t *testing.
 	svc := newSuggestionService(env)
 
 	// Canonical: a linked imported gcontacts row.
-	canonEmail := "canon-" + abSuffix() + "@example.com"
+	canonEmail := "canon-" + abSuffix(t) + "@example.com"
 	canonContact, canon := seedLinkedExternal(t, ctx, env, "gcontacts", repository.MatchStatusImported, []string{canonEmail})
 
 	// Duplicate: an icloud row with its OWN crm_contact_id nil, pointing at
 	// the canonical via duplicate_of_id, carrying its own pending method.
-	dupEmail := "dup-" + abSuffix() + "@example.com"
-	sfx := abSuffix()
+	dupEmail := "dup-" + abSuffix(t) + "@example.com"
+	sfx := abSuffix(t)
 	dupDisplay := "Dup External " + sfx
 	dup, err := env.externalRepo.Upsert(ctx, repository.UpsertExternalContactRequest{
 		Source:      "icloud_contacts",

--- a/backend/tests/synthetic_migration_helpers_test.go
+++ b/backend/tests/synthetic_migration_helpers_test.go
@@ -2,8 +2,6 @@ package tests
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/hex"
 	"testing"
 
 	"personal-crm/backend/internal/db"
@@ -92,18 +90,4 @@ func seedMigrationContact(
 
 	cleanup := func() { _ = contactRepo.HardDeleteContact(ctx, contact.ID) }
 	return contact, cleanup
-}
-
-// LEGACY — staged removal.
-//
-// randomSuffix returns a 12-char hex string for per-test isolation. It is
-// superseded by the namespace token from migrationGenerator and is centralized
-// here only so the still-unmigrated callers compile; it is deleted once the last
-// caller migrates off it. Do NOT add new callers — use migrationGenerator.
-func randomSuffix(t *testing.T) string {
-	t.Helper()
-	b := make([]byte, 6)
-	_, err := rand.Read(b)
-	require.NoError(t, err)
-	return hex.EncodeToString(b)
 }

--- a/backend/tests/telegram_aggregation_explicit_reply_bridge_test.go
+++ b/backend/tests/telegram_aggregation_explicit_reply_bridge_test.go
@@ -38,7 +38,7 @@ import (
 // Stripe-based IDs (testStripe=2) keep this disjoint from the
 // inbound-coalesce (=1) and source-filter (=3) tests.
 func TestAggregation_IncrementalExplicitReplyBridge_CrossBatch(t *testing.T) {
-	messageRepo, interactionRepo, contactRepo, _, engine, database := setupAggregationTest(t)
+	messageRepo, interactionRepo, _, _, engine, database := setupAggregationTest(t)
 	ctx := context.Background()
 	eventRepo := repository.NewEventRepository(database.Queries)
 
@@ -62,8 +62,9 @@ func TestAggregation_IncrementalExplicitReplyBridge_CrossBatch(t *testing.T) {
 		_ = eventRepo.HardDeleteEventsBySourceAndSourceIDPrefix(ctx, repository.InteractionSourceTelegram, sourceRefPrefix)
 	})
 
-	contact := createTestContact(t, contactRepo, fmt.Sprintf("Explicit Reply Bridge %d", seed))
-	t.Cleanup(func() { _ = contactRepo.SoftDeleteContact(ctx, contact.ID) })
+	gen, _ := migrationGenerator(t)
+	contact, contactCleanup := seedMigrationContact(ctx, t, database, gen)
+	t.Cleanup(contactCleanup)
 
 	// 90h gap > 48h reply-bridge window — time-based bridging will NOT
 	// fire. Only the cross-batch explicit reply-bridge can promote.

--- a/backend/tests/telegram_aggregation_inbound_coalesce_test.go
+++ b/backend/tests/telegram_aggregation_inbound_coalesce_test.go
@@ -29,7 +29,7 @@ import (
 // Cleanup uses the new sqlc-backed HardDelete helpers per core.md rule
 // 2 (no raw SQL in Go).
 func TestAggregation_IncrementalInboundCoalesce(t *testing.T) {
-	messageRepo, interactionRepo, contactRepo, _, engine, database := setupAggregationTest(t)
+	messageRepo, interactionRepo, _, _, engine, database := setupAggregationTest(t)
 	ctx := context.Background()
 	eventRepo := repository.NewEventRepository(database.Queries)
 
@@ -55,8 +55,9 @@ func TestAggregation_IncrementalInboundCoalesce(t *testing.T) {
 		_ = eventRepo.HardDeleteEventsBySourceAndSourceIDPrefix(ctx, repository.InteractionSourceTelegram, sourceRefPrefix)
 	})
 
-	contact := createTestContact(t, contactRepo, fmt.Sprintf("Inbound Coalesce %d", seed))
-	t.Cleanup(func() { _ = contactRepo.SoftDeleteContact(ctx, contact.ID) })
+	gen, _ := migrationGenerator(t)
+	contact, contactCleanup := seedMigrationContact(ctx, t, database, gen)
+	t.Cleanup(contactCleanup)
 
 	t0 := accelerated.GetCurrentTime().Add(-2 * time.Hour).Truncate(time.Microsecond)
 

--- a/backend/tests/telegram_aggregation_test.go
+++ b/backend/tests/telegram_aggregation_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -19,22 +20,34 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// aggregationTestChatIDs is the fixed set of chat IDs used by the burst /
+// bridge / chat-scoped / incremental sub-tests. The cleanup scopes its
+// per-prefix interaction + event deletes to these.
+var aggregationTestChatIDs = []int64{100, 101, 102, 201, 202, 301, 302, 303}
+
+// aggregationTestMessageIDs is the fixed set of telegram_message IDs the
+// sub-tests upsert.
+var aggregationTestMessageIDs = []int32{80001, 80002, 80003, 80011, 80012, 80013, 80021, 80022, 80031, 80032, 80041, 80042, 80051, 80052, 80061, 80062}
+
 // cleanupAggregationMessages hard-deletes test messages, interactions,
-// AND the published event rows from prior runs. Post-PR-6 the aggregation
-// engine publishes events via bus.PublishTx which dedupes on (source,
-// source_id); leftover event rows from a previous run would cause the
-// next publish to no-op and the consumer to never fire. Hard-delete the
-// event rows keyed on the test's chat IDs too.
+// AND the published event rows from prior runs. The aggregation engine
+// publishes events via bus.PublishTx which dedupes on (source, source_id);
+// leftover event rows from a previous run would cause the next publish to
+// no-op and the consumer to never fire. Hard-delete the event rows keyed on
+// the test's chat IDs too. All deletes go through sqlc-backed repository
+// wrappers (no raw SQL in Go, including tests).
 func cleanupAggregationMessages(t *testing.T, database *db.Database) {
 	t.Helper()
 	ctx := context.Background()
-	// Hard delete test messages (unique message IDs for this test suite)
-	_, _ = database.Pool.Exec(ctx, "DELETE FROM telegram_message WHERE telegram_message_id IN (80001, 80002, 80003, 80011, 80012, 80013, 80021, 80022, 80031, 80032, 80041, 80042, 80051, 80052, 80061, 80062)")
-	// Hard delete interactions with source_ref matching test chat IDs
-	_, _ = database.Pool.Exec(ctx, "DELETE FROM interaction WHERE source_ref LIKE 'tg:100:%' OR source_ref LIKE 'tg:101:%' OR source_ref LIKE 'tg:102:%' OR source_ref LIKE 'tg:201:%' OR source_ref LIKE 'tg:202:%' OR source_ref LIKE 'tg:301:%' OR source_ref LIKE 'tg:302:%' OR source_ref LIKE 'tg:303:%'")
-	// Hard delete event rows keyed on the same test chat IDs so a re-run
-	// doesn't collide with the previous run's published events.
-	_, _ = database.Pool.Exec(ctx, "DELETE FROM event WHERE source = 'telegram' AND (source_id LIKE 'tg:100:%' OR source_id LIKE 'tg:101:%' OR source_id LIKE 'tg:102:%' OR source_id LIKE 'tg:201:%' OR source_id LIKE 'tg:202:%' OR source_id LIKE 'tg:301:%' OR source_id LIKE 'tg:302:%' OR source_id LIKE 'tg:303:%')")
+	interactionRepo := repository.NewInteractionRepository(database.Queries)
+	eventRepo := repository.NewEventRepository(database.Queries)
+
+	_, _ = database.Queries.DeleteTelegramMessagesByMessageIDs(ctx, aggregationTestMessageIDs)
+	for _, chatID := range aggregationTestChatIDs {
+		prefix := fmt.Sprintf("tg:%d:", chatID)
+		_ = interactionRepo.HardDeleteInteractionsBySourceRefPrefix(ctx, repository.InteractionSourceTelegram, prefix+"%")
+		_ = eventRepo.HardDeleteEventsBySourceAndSourceIDPrefix(ctx, repository.InteractionSourceTelegram, prefix+"%")
+	}
 }
 
 func setupAggregationTest(t *testing.T) (
@@ -93,15 +106,6 @@ func setupAggregationTest(t *testing.T) (
 	return messageRepo, interactionRepo, contactRepo, contactService, engine, database
 }
 
-func createTestContact(t *testing.T, contactRepo *repository.ContactRepository, name string) *repository.Contact {
-	t.Helper()
-	contact, err := contactRepo.CreateContact(context.Background(), repository.CreateContactRequest{
-		FullName: name,
-	})
-	require.NoError(t, err)
-	return contact
-}
-
 // createTestContactWithCadence creates a contact with a cadence + baseline
 // last_contacted so Extend/Promote tests can assert cadence column
 // transitions against a deterministic starting state.
@@ -140,13 +144,12 @@ func insertTestMessage(t *testing.T, repo *repository.TelegramMessageRepository,
 }
 
 func TestAggregation_BatchOutboundBurst(t *testing.T) {
-	messageRepo, interactionRepo, contactRepo, _, engine, _ := setupAggregationTest(t)
+	messageRepo, interactionRepo, _, _, engine, database := setupAggregationTest(t)
 	ctx := context.Background()
 
-	contact := createTestContact(t, contactRepo, "Aggregation Test 1")
-	t.Cleanup(func() {
-		_ = contactRepo.SoftDeleteContact(ctx, contact.ID)
-	})
+	gen, _ := migrationGenerator(t)
+	contact, contactCleanup := seedMigrationContact(ctx, t, database, gen)
+	t.Cleanup(contactCleanup)
 
 	base := accelerated.GetCurrentTime().Add(-1 * time.Hour).Truncate(time.Microsecond)
 
@@ -166,13 +169,12 @@ func TestAggregation_BatchOutboundBurst(t *testing.T) {
 }
 
 func TestAggregation_BatchMutualBridge(t *testing.T) {
-	messageRepo, interactionRepo, contactRepo, _, engine, _ := setupAggregationTest(t)
+	messageRepo, interactionRepo, _, _, engine, database := setupAggregationTest(t)
 	ctx := context.Background()
 
-	contact := createTestContact(t, contactRepo, "Aggregation Test 2")
-	t.Cleanup(func() {
-		_ = contactRepo.SoftDeleteContact(ctx, contact.ID)
-	})
+	gen, _ := migrationGenerator(t)
+	contact, contactCleanup := seedMigrationContact(ctx, t, database, gen)
+	t.Cleanup(contactCleanup)
 
 	base := accelerated.GetCurrentTime().Add(-2 * time.Hour).Truncate(time.Microsecond)
 
@@ -192,13 +194,12 @@ func TestAggregation_BatchNoChurnFollowUp(t *testing.T) {
 	// Batch mode should NOT create an outbound interaction first and then promote —
 	// it should directly create mutual. This test verifies by checking that exactly
 	// one interaction is created (not an outbound followed by a mutual update).
-	messageRepo, interactionRepo, contactRepo, _, engine, _ := setupAggregationTest(t)
+	messageRepo, interactionRepo, _, _, engine, database := setupAggregationTest(t)
 	ctx := context.Background()
 
-	contact := createTestContact(t, contactRepo, "Aggregation Test No Churn")
-	t.Cleanup(func() {
-		_ = contactRepo.SoftDeleteContact(ctx, contact.ID)
-	})
+	gen, _ := migrationGenerator(t)
+	contact, contactCleanup := seedMigrationContact(ctx, t, database, gen)
+	t.Cleanup(contactCleanup)
 
 	base := accelerated.GetCurrentTime().Add(-3 * time.Hour).Truncate(time.Microsecond)
 	insertTestMessage(t, messageRepo, 80021, 102, true, base, &contact.ID, 70003)
@@ -212,13 +213,12 @@ func TestAggregation_BatchNoChurnFollowUp(t *testing.T) {
 }
 
 func TestAggregation_ChatScoped(t *testing.T) {
-	messageRepo, interactionRepo, contactRepo, _, engine, database := setupAggregationTest(t)
+	messageRepo, interactionRepo, _, _, engine, database := setupAggregationTest(t)
 	ctx := context.Background()
 
-	contact := createTestContact(t, contactRepo, "Aggregation Chat Scoped")
-	t.Cleanup(func() {
-		_ = contactRepo.SoftDeleteContact(ctx, contact.ID)
-	})
+	gen, _ := migrationGenerator(t)
+	contact, contactCleanup := seedMigrationContact(ctx, t, database, gen)
+	t.Cleanup(contactCleanup)
 
 	base := accelerated.GetCurrentTime().Add(-1 * time.Hour).Truncate(time.Microsecond)
 
@@ -360,13 +360,12 @@ func TestAggregation_IncrementalReplyBridge(t *testing.T) {
 }
 
 func TestAggregation_IncrementalExplicitReplyBridge(t *testing.T) {
-	messageRepo, interactionRepo, contactRepo, _, engine, database := setupAggregationTest(t)
+	messageRepo, interactionRepo, _, _, engine, database := setupAggregationTest(t)
 	ctx := context.Background()
 
-	contact := createTestContact(t, contactRepo, "Aggregation Explicit Reply Bridge")
-	t.Cleanup(func() {
-		_ = contactRepo.SoftDeleteContact(ctx, contact.ID)
-	})
+	gen, _ := migrationGenerator(t)
+	contact, contactCleanup := seedMigrationContact(ctx, t, database, gen)
+	t.Cleanup(contactCleanup)
 
 	// Use timestamps >48h apart to prove explicit reply bridges regardless of time
 	outboundTime := accelerated.GetCurrentTime().Add(-72 * time.Hour).Truncate(time.Microsecond)
@@ -419,9 +418,9 @@ func TestAggregation_IncrementalExplicitReplyBridge(t *testing.T) {
 	require.Len(t, interactions, 1)
 	assert.Equal(t, "mutual", interactions[0].Direction)
 
-	// Clean up test-specific data
-	_, _ = database.Pool.Exec(ctx, "DELETE FROM telegram_message WHERE telegram_message_id IN (80061, 80062)")
-	_, _ = database.Pool.Exec(ctx, "DELETE FROM interaction WHERE source_ref LIKE 'tg:303:%'")
+	// Clean up test-specific data via sqlc-backed wrappers (no raw SQL in Go).
+	_, _ = database.Queries.DeleteTelegramMessagesByMessageIDs(ctx, []int32{80061, 80062})
+	_ = interactionRepo.HardDeleteInteractionsBySourceRefPrefix(ctx, repository.InteractionSourceTelegram, "tg:303:%")
 }
 
 // TestListDistinctUnmatchedPeers_PrefersPopulatedNameRow locks in the

--- a/backend/tests/telegram_discovery_upsert_test.go
+++ b/backend/tests/telegram_discovery_upsert_test.go
@@ -256,20 +256,11 @@ func TestUpsertTelegramDiscoveryCandidate_DoesNotTouchMatchStatus(t *testing.T) 
 	now := accelerated.GetCurrentTime()
 
 	// Create a real CRM contact so the FK (external_contact.crm_contact_id ->
-	// contact.id) is satisfiable. Use a unique name so it doesn't collide with
-	// other tests and cleans up cleanly.
-	contactRepo := repository.NewContactRepository(database.Queries)
-	crmContact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-		FullName:      "tg-discovery-upsert-match-contact",
-		LastContacted: &now,
-	})
-	require.NoError(t, err)
-	defer func() {
-		_, _ = database.Queries.DeleteContactsByNamePrefix(
-			ctx,
-			pgtype.Text{String: "tg-discovery-upsert-match-contact", Valid: true},
-		)
-	}()
+	// contact.id) is satisfiable. The namespaced factory contact never
+	// collides with other tests and cleans up via its scoped closure.
+	gen, _ := migrationGenerator(t)
+	crmContact, contactCleanup := seedMigrationContact(ctx, t, database, gen)
+	defer contactCleanup()
 
 	row, err := repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
 		SourceID: "tg-discovery-upsert-match",

--- a/backend/tests/telegram_matcher_enrichment_test.go
+++ b/backend/tests/telegram_matcher_enrichment_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"context"
 	"errors"
+	"hash/fnv"
 	"os"
 	"strconv"
 	"sync"
@@ -13,6 +14,7 @@ import (
 	"personal-crm/backend/internal/identity"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/service"
+	"personal-crm/backend/internal/synthetic/factory"
 	tgpkg "personal-crm/backend/internal/telegram"
 
 	"github.com/google/uuid"
@@ -80,59 +82,52 @@ func setupMatcherEnrichmentTest(t *testing.T) *matcherEnrichTestEnv {
 	}
 }
 
-// uniqueTestIDs returns a peer user ID and matching string ID derived from a
-// fresh UUID. Each test invocation gets unique values so cross-test or
-// cross-run pollution in the shared test DB cannot affect results.
+// uniqueTestIDs returns a peer user ID and matching string ID derived from
+// the per-test synthetic namespace token. Each test invocation has a unique
+// namespace, so cross-test or cross-run pollution in the shared test DB
+// cannot affect results.
 //
 // The integer is offset by 9_000_000_000 to keep it well above any
-// hand-picked low test IDs elsewhere in the suite. The string form is the
-// decimal representation of that int — digit-only, safe for phone-shaped values.
-func uniqueTestIDs(t *testing.T) (int64, string) {
+// hand-picked low test IDs elsewhere in the suite (and below the factory's
+// trillion-range telegram band, so the digit layout — and the phone built
+// from peerIDStr[:7] — stays the same as before). The string form is the
+// decimal representation of that int — digit-only, safe for phone-shaped
+// values.
+func uniqueTestIDs(t *testing.T, ns string) (int64, string) {
 	t.Helper()
-	suffix := uuid.New().String()[:8]
-	var n int64
-	for _, c := range suffix {
-		n <<= 4
-		switch {
-		case c >= '0' && c <= '9':
-			n |= int64(c - '0')
-		case c >= 'a' && c <= 'f':
-			n |= int64(c-'a') + 10
-		}
-	}
+	// Hash the namespace token into the low 32 bits, mirroring the prior
+	// hex-of-uuid layout so the derived phone keeps its digit shape.
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(ns))
+	n := int64(h.Sum64() & 0xFFFFFFFF)
 	id := int64(9_000_000_000) + n
 	return id, strconv.FormatInt(id, 10)
-}
-
-func newTestContact(t *testing.T, ctx context.Context, contactRepo *repository.ContactRepository, name string) *repository.Contact {
-	t.Helper()
-	c, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: name})
-	require.NoError(t, err)
-	return c
 }
 
 // registerCleanupBySource removes any external_contact, external_identity, and
 // contact rows tied to the given peer ID string after the test runs. Hard
 // deletes — keeps the shared DB free of orphans. Order matters: identity and
 // external_contact rows clear first so the contact's FK references drop before
-// the contact itself is deleted.
-func registerCleanupBySource(t *testing.T, env *matcherEnrichTestEnv, ctx context.Context, contactID uuid.UUID, peerIDStr string) {
+// the contact itself is deleted, so the seeded-contact cleanup closure runs
+// last inside this single t.Cleanup.
+func registerCleanupBySource(t *testing.T, env *matcherEnrichTestEnv, ctx context.Context, contactCleanup func(), peerIDStr string) {
 	t.Helper()
 	t.Cleanup(func() {
 		_, _ = env.database.Queries.DeleteExternalContactsBySourceIDPrefix(ctx, pgtype.Text{String: peerIDStr, Valid: true})
 		_, _ = env.database.Queries.DeleteExternalIdentitiesBySourceID(ctx, pgtype.Text{String: peerIDStr, Valid: true})
-		_ = env.contactRepo.HardDeleteContact(ctx, contactID)
+		contactCleanup()
 	})
 }
 
 func TestMatcherEnrichment_AboveThreshold_UsernameMatch(t *testing.T) {
 	env := setupMatcherEnrichmentTest(t)
 	ctx := context.Background()
-	peerUserID, peerIDStr := uniqueTestIDs(t)
+	gen, ns := migrationGenerator(t)
+	peerUserID, peerIDStr := uniqueTestIDs(t, ns)
 	username := "AboveUser" + peerIDStr
 
-	contact := newTestContact(t, ctx, env.contactRepo, "Above Thresh "+peerIDStr)
-	registerCleanupBySource(t, env, ctx, contact.ID, peerIDStr)
+	contact, contactCleanup := seedMigrationContact(ctx, t, env.database, gen, factory.WithNoMethods())
+	registerCleanupBySource(t, env, ctx, contactCleanup, peerIDStr)
 
 	// Pre-link the username via cached identity (mimics #272 name match path).
 	_, err := env.identitySvc.MatchOrCreate(ctx, service.MatchRequest{
@@ -193,11 +188,12 @@ func TestMatcherEnrichment_AboveThreshold_UsernameMatch(t *testing.T) {
 func TestMatcherEnrichment_BelowThreshold_NoExternalContact(t *testing.T) {
 	env := setupMatcherEnrichmentTest(t)
 	ctx := context.Background()
-	peerUserID, peerIDStr := uniqueTestIDs(t)
+	gen, ns := migrationGenerator(t)
+	peerUserID, peerIDStr := uniqueTestIDs(t, ns)
 	username := "BelowUser" + peerIDStr
 
-	contact := newTestContact(t, ctx, env.contactRepo, "Below Thresh "+peerIDStr)
-	registerCleanupBySource(t, env, ctx, contact.ID, peerIDStr)
+	contact, contactCleanup := seedMigrationContact(ctx, t, env.database, gen, factory.WithNoMethods())
+	registerCleanupBySource(t, env, ctx, contactCleanup, peerIDStr)
 
 	// Pre-link the username; do NOT seed an external_contact row.
 	_, err := env.identitySvc.MatchOrCreate(ctx, service.MatchRequest{
@@ -237,19 +233,20 @@ func TestMatcherEnrichment_BelowThreshold_NoExternalContact(t *testing.T) {
 func TestMatcherEnrichment_PhoneMatchWithUsername(t *testing.T) {
 	env := setupMatcherEnrichmentTest(t)
 	ctx := context.Background()
-	peerUserID, peerIDStr := uniqueTestIDs(t)
+	gen, ns := migrationGenerator(t)
+	peerUserID, peerIDStr := uniqueTestIDs(t, ns)
 	username := "PhoneMatched" + peerIDStr
 	// Build a unique 11-digit phone number from peerUserID's last 8 digits.
 	phone := "+1555" + peerIDStr[:7]
 
-	contact := newTestContact(t, ctx, env.contactRepo, "Phone Match "+peerIDStr)
+	contact, contactCleanup := seedMigrationContact(ctx, t, env.database, gen, factory.WithNoMethods())
 	_, err := env.methodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
 		ContactID: contact.ID,
 		Type:      "phone",
 		Value:     phone,
 	})
 	require.NoError(t, err)
-	registerCleanupBySource(t, env, ctx, contact.ID, peerIDStr)
+	registerCleanupBySource(t, env, ctx, contactCleanup, peerIDStr)
 
 	result, err := env.matcher.MatchPeer(ctx, peerUserID, &username, nil, nil, &phone)
 	require.NoError(t, err)
@@ -270,17 +267,18 @@ func TestMatcherEnrichment_PhoneMatchWithUsername(t *testing.T) {
 func TestMatcherEnrichment_PhoneMatchWithoutUsername(t *testing.T) {
 	env := setupMatcherEnrichmentTest(t)
 	ctx := context.Background()
-	peerUserID, peerIDStr := uniqueTestIDs(t)
+	gen, ns := migrationGenerator(t)
+	peerUserID, peerIDStr := uniqueTestIDs(t, ns)
 	phone := "+1555" + peerIDStr[:7]
 
-	contact := newTestContact(t, ctx, env.contactRepo, "Phone Only "+peerIDStr)
+	contact, contactCleanup := seedMigrationContact(ctx, t, env.database, gen, factory.WithNoMethods())
 	_, err := env.methodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
 		ContactID: contact.ID,
 		Type:      "phone",
 		Value:     phone,
 	})
 	require.NoError(t, err)
-	registerCleanupBySource(t, env, ctx, contact.ID, peerIDStr)
+	registerCleanupBySource(t, env, ctx, contactCleanup, peerIDStr)
 
 	result, err := env.matcher.MatchPeer(ctx, peerUserID, nil, nil, nil, &phone)
 	require.NoError(t, err)
@@ -296,11 +294,12 @@ func TestMatcherEnrichment_PhoneMatchWithoutUsername(t *testing.T) {
 func TestMatcherEnrichment_Idempotency(t *testing.T) {
 	env := setupMatcherEnrichmentTest(t)
 	ctx := context.Background()
-	peerUserID, peerIDStr := uniqueTestIDs(t)
+	gen, ns := migrationGenerator(t)
+	peerUserID, peerIDStr := uniqueTestIDs(t, ns)
 	username := "IdemUser" + peerIDStr
 
-	contact := newTestContact(t, ctx, env.contactRepo, "Idem "+peerIDStr)
-	registerCleanupBySource(t, env, ctx, contact.ID, peerIDStr)
+	contact, contactCleanup := seedMigrationContact(ctx, t, env.database, gen, factory.WithNoMethods())
+	registerCleanupBySource(t, env, ctx, contactCleanup, peerIDStr)
 
 	_, err := env.identitySvc.MatchOrCreate(ctx, service.MatchRequest{
 		RawIdentifier:  username,
@@ -336,11 +335,12 @@ func TestMatcherEnrichment_Idempotency(t *testing.T) {
 func TestMatcherEnrichment_ConcurrentMatch_TreatsUniqueViolationAsSuccess(t *testing.T) {
 	env := setupMatcherEnrichmentTest(t)
 	ctx := context.Background()
-	peerUserID, peerIDStr := uniqueTestIDs(t)
+	gen, ns := migrationGenerator(t)
+	peerUserID, peerIDStr := uniqueTestIDs(t, ns)
 	username := "RaceUser" + peerIDStr
 
-	contact := newTestContact(t, ctx, env.contactRepo, "Race "+peerIDStr)
-	registerCleanupBySource(t, env, ctx, contact.ID, peerIDStr)
+	contact, contactCleanup := seedMigrationContact(ctx, t, env.database, gen, factory.WithNoMethods())
+	registerCleanupBySource(t, env, ctx, contactCleanup, peerIDStr)
 
 	_, err := env.identitySvc.MatchOrCreate(ctx, service.MatchRequest{
 		RawIdentifier:  username,
@@ -393,11 +393,12 @@ func TestMatcherEnrichment_ConcurrentMatch_TreatsUniqueViolationAsSuccess(t *tes
 func TestMatcherEnrichment_AlreadyMatchedExternalContact_RepairsMissingMethod(t *testing.T) {
 	env := setupMatcherEnrichmentTest(t)
 	ctx := context.Background()
-	peerUserID, peerIDStr := uniqueTestIDs(t)
+	gen, ns := migrationGenerator(t)
+	peerUserID, peerIDStr := uniqueTestIDs(t, ns)
 	username := "RepairUser" + peerIDStr
 
-	contact := newTestContact(t, ctx, env.contactRepo, "Repair "+peerIDStr)
-	registerCleanupBySource(t, env, ctx, contact.ID, peerIDStr)
+	contact, contactCleanup := seedMigrationContact(ctx, t, env.database, gen, factory.WithNoMethods())
+	registerCleanupBySource(t, env, ctx, contactCleanup, peerIDStr)
 
 	// Pre-link the username so the matcher resolves to this contact via cache.
 	_, err := env.identitySvc.MatchOrCreate(ctx, service.MatchRequest{
@@ -410,7 +411,7 @@ func TestMatcherEnrichment_AlreadyMatchedExternalContact_RepairsMissingMethod(t 
 	require.NoError(t, err)
 
 	// Pre-seed external_contact already in 'matched' status pointing at the contact —
-	// this is the exact prod state of Jack Laing's row. No telegram contact_method.
+	// the exact prod state the original bug repaired. No telegram contact_method.
 	displayName := "Repair External " + peerIDStr
 	external, err := env.externalRepo.Upsert(ctx, repository.UpsertExternalContactRequest{
 		Source:      "telegram",
@@ -459,10 +460,10 @@ func TestMatcherEnrichment_EnricherErrorDoesNotBreakMatch(t *testing.T) {
 	t.Cleanup(database.Close)
 
 	ctx := context.Background()
-	peerUserID, peerIDStr := uniqueTestIDs(t)
+	gen, ns := migrationGenerator(t)
+	peerUserID, peerIDStr := uniqueTestIDs(t, ns)
 	username := "FaultyUser" + peerIDStr
 
-	contactRepo := repository.NewContactRepository(database.Queries)
 	methodRepo := repository.NewContactMethodRepository(database.Queries)
 	externalRepo := repository.NewExternalContactRepository(database.Queries)
 	identityRepo := repository.NewIdentityRepository(database.Queries)
@@ -471,10 +472,10 @@ func TestMatcherEnrichment_EnricherErrorDoesNotBreakMatch(t *testing.T) {
 
 	matcher := tgpkg.NewPeerMatcher(identitySvc, messageRepo, externalRepo, failingEnricher{}, 100)
 
-	contact := newTestContact(t, ctx, contactRepo, "Faulty Enricher "+peerIDStr)
+	contact, contactCleanup := seedMigrationContact(ctx, t, database, gen, factory.WithNoMethods())
 	t.Cleanup(func() {
 		_, _ = database.Queries.DeleteExternalIdentitiesBySourceID(ctx, pgtype.Text{String: peerIDStr, Valid: true})
-		_ = contactRepo.HardDeleteContact(ctx, contact.ID)
+		contactCleanup()
 	})
 
 	_, err = identitySvc.MatchOrCreate(ctx, service.MatchRequest{

--- a/backend/tests/telegram_message_all_fields_test.go
+++ b/backend/tests/telegram_message_all_fields_test.go
@@ -50,15 +50,12 @@ func TestTelegramMessage_AllFieldsPopulatedOnRead(t *testing.T) {
 	require.NoError(t, err)
 	defer database.Close()
 
-	contactRepo := repository.NewContactRepository(database.Queries)
 	interactionRepo := repository.NewInteractionRepository(database.Queries)
 
 	// A real contact + interaction so matched_contact_id / interaction_id FKs
 	// resolve. The interaction is hung off the contact.
-	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-		FullName: "All Fields Probe Contact",
-	})
-	require.NoError(t, err)
+	gen, _ := migrationGenerator(t)
+	contact, contactCleanup := seedMigrationContact(ctx, t, database, gen)
 
 	occurredAt := accelerated.GetCurrentTime().Truncate(time.Microsecond)
 	direction := "inbound"
@@ -95,7 +92,7 @@ func TestTelegramMessage_AllFieldsPopulatedOnRead(t *testing.T) {
 		// independent of FK rules).
 		purgeRow()
 		_ = interactionRepo.SoftDeleteInteraction(ctx, interaction.ID)
-		_ = contactRepo.SoftDeleteContact(ctx, contact.ID)
+		contactCleanup()
 	})
 
 	// A non-zero time distinct from createdAt's default, used for every

--- a/backend/tests/telegram_message_claim_test.go
+++ b/backend/tests/telegram_message_claim_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"context"
-	"encoding/hex"
 	"os"
 	"testing"
 	"time"
@@ -11,27 +10,18 @@ import (
 	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/synthetic/factory"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// chatIDFromSuffix maps a random hex suffix to a deterministic int64
-// chat ID. Uses the first 4 bytes (8 hex chars) of the suffix to
-// produce a 0-4G range so HardDeleteByChatIDRange cleans up only this
-// test's rows even across parallel runs.
-func chatIDFromSuffix(suffix string) int64 {
-	raw, err := hex.DecodeString(suffix)
-	if err != nil || len(raw) < 4 {
-		return 1_000_000_000 // fallback; unlikely to collide for one test
-	}
-	return int64(uint32(raw[0])<<24 | uint32(raw[1])<<16 | uint32(raw[2])<<8 | uint32(raw[3]))
-}
-
-// telegramClaimSetup gives us a fresh test contact and a chat-ID range
-// scoped to the test so HardDeleteByChatIDRange cleans up only our rows.
-func telegramClaimSetup(t *testing.T) (context.Context, *repository.TelegramMessageRepository, *repository.ContactRepository, *repository.Contact, int64, func()) {
+// telegramClaimSetup gives us a fresh namespaced test contact and a
+// namespace-disjoint chat-ID range so HardDeleteByChatIDRange cleans up
+// only our rows. The chat ID is drawn from the generator's collision-free
+// telegram peer band, which is deterministically distinct per namespace.
+func telegramClaimSetup(t *testing.T) (context.Context, *factory.Generator, *repository.TelegramMessageRepository, *repository.ContactRepository, *repository.Contact, int64, func()) {
 	t.Helper()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -49,28 +39,24 @@ func telegramClaimSetup(t *testing.T) (context.Context, *repository.TelegramMess
 	repo := repository.NewTelegramMessageRepository(database.Queries)
 	contactRepo := repository.NewContactRepository(database.Queries)
 
-	suffix := randomSuffix(t)
-	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-		FullName: "Test Claim " + suffix,
-	})
-	require.NoError(t, err)
+	gen, _ := migrationGenerator(t)
+	contact, contactCleanup := seedMigrationContact(ctx, t, database, gen)
 
-	// Per-test chat_id (large randomized value so we don't collide
-	// with other tests in the shared DB). The hex suffix is converted
-	// to int64 via the low 4 bytes — enough entropy for parallel test
-	// isolation. The chatID is used as the cleanup range [chatID, chatID].
-	chatID := chatIDFromSuffix(suffix)
+	// Per-test chat_id drawn from this namespace's telegram peer band —
+	// deterministically disjoint from any other namespace's rows. The
+	// chatID is used as the cleanup range [chatID, chatID].
+	chatID := gen.PeerBandStart()
 
 	cleanup := func() {
 		_ = repo.HardDeleteByChatIDRange(ctx, chatID, chatID)
-		_ = contactRepo.SoftDeleteContact(ctx, contact.ID)
+		contactCleanup()
 		database.Close()
 	}
-	return ctx, repo, contactRepo, contact, chatID, cleanup
+	return ctx, gen, repo, contactRepo, contact, chatID, cleanup
 }
 
 func TestTelegramMessageRepository_ClaimMessages_SetsClaimColumns(t *testing.T) {
-	ctx, repo, _, contact, chatID, cleanup := telegramClaimSetup(t)
+	ctx, _, repo, _, contact, chatID, cleanup := telegramClaimSetup(t)
 	defer cleanup()
 
 	sentAt := accelerated.GetCurrentTime().Truncate(time.Microsecond)
@@ -102,7 +88,7 @@ func TestTelegramMessageRepository_ClaimMessages_SetsClaimColumns(t *testing.T) 
 }
 
 func TestTelegramMessageRepository_ListUnprocessedByContact_ExcludesActiveClaim(t *testing.T) {
-	ctx, repo, _, contact, chatID, cleanup := telegramClaimSetup(t)
+	ctx, _, repo, _, contact, chatID, cleanup := telegramClaimSetup(t)
 	defer cleanup()
 
 	sentAt := accelerated.GetCurrentTime().Truncate(time.Microsecond)
@@ -132,7 +118,7 @@ func TestTelegramMessageRepository_ListUnprocessedByContact_ExcludesActiveClaim(
 }
 
 func TestTelegramMessageRepository_ListUnprocessedByContact_IncludesStaleClaim(t *testing.T) {
-	ctx, repo, _, contact, chatID, cleanup := telegramClaimSetup(t)
+	ctx, _, repo, _, contact, chatID, cleanup := telegramClaimSetup(t)
 	defer cleanup()
 
 	sentAt := accelerated.GetCurrentTime().Truncate(time.Microsecond)
@@ -161,7 +147,7 @@ func TestTelegramMessageRepository_ListUnprocessedByContact_IncludesStaleClaim(t
 }
 
 func TestTelegramMessageRepository_ClaimMessages_PartialClaim(t *testing.T) {
-	ctx, repo, _, contact, chatID, cleanup := telegramClaimSetup(t)
+	ctx, _, repo, _, contact, chatID, cleanup := telegramClaimSetup(t)
 	defer cleanup()
 
 	sentAt := accelerated.GetCurrentTime().Truncate(time.Microsecond)
@@ -192,7 +178,7 @@ func TestTelegramMessageRepository_ClaimMessages_PartialClaim(t *testing.T) {
 // MarkProcessedTx returns 0 rows affected when the predicate filters
 // out everything.
 func TestTelegramMessageRepository_MarkProcessedTx_RejectsOtherSession(t *testing.T) {
-	ctx, repo, _, contact, chatID, cleanup := telegramClaimSetup(t)
+	ctx, _, repo, _, contact, chatID, cleanup := telegramClaimSetup(t)
 	defer cleanup()
 
 	databaseURL := os.Getenv("DATABASE_URL")
@@ -237,7 +223,7 @@ func TestTelegramMessageRepository_MarkProcessedTx_RejectsOtherSession(t *testin
 // confirms the consumer can process rows it claimed for its own
 // session.
 func TestTelegramMessageRepository_MarkProcessedTx_AcceptsOwnSession(t *testing.T) {
-	ctx, repo, _, contact, chatID, cleanup := telegramClaimSetup(t)
+	ctx, gen, repo, _, contact, chatID, cleanup := telegramClaimSetup(t)
 	defer cleanup()
 
 	databaseURL := os.Getenv("DATABASE_URL")
@@ -249,8 +235,7 @@ func TestTelegramMessageRepository_MarkProcessedTx_AcceptsOwnSession(t *testing.
 
 	// Create a real interaction so the FK constraint is satisfied.
 	interactionRepo := repository.NewInteractionRepository(database.Queries)
-	suffix := randomSuffix(t)
-	ref := "tg:own:" + suffix
+	ref := "tg:own:" + gen.Prefix()
 	interaction, err := interactionRepo.CreateInteraction(ctx, repository.CreateInteractionRequest{
 		ContactID: contact.ID, Source: repository.InteractionSourceTelegram,
 		SourceRef: &ref, OccurredAt: accelerated.GetCurrentTime().Truncate(time.Microsecond),
@@ -266,7 +251,7 @@ func TestTelegramMessageRepository_MarkProcessedTx_AcceptsOwnSession(t *testing.
 	require.NoError(t, err)
 	require.NoError(t, repo.UpdateMessageContact(ctx, *msg.PeerUserID, contact.ID))
 
-	sessionRef := "tg:own-session:" + suffix
+	sessionRef := "tg:own-session:" + gen.Prefix()
 	_, err = repo.ClaimMessages(ctx, []uuid.UUID{msg.ID}, sessionRef)
 	require.NoError(t, err)
 
@@ -291,7 +276,7 @@ func TestTelegramMessageRepository_MarkProcessedTx_AcceptsOwnSession(t *testing.
 // claimed (engine took the non-tx publish path / test mode) is still
 // markable by the consumer.
 func TestTelegramMessageRepository_MarkProcessedTx_AcceptsNullClaim(t *testing.T) {
-	ctx, repo, _, contact, chatID, cleanup := telegramClaimSetup(t)
+	ctx, gen, repo, _, contact, chatID, cleanup := telegramClaimSetup(t)
 	defer cleanup()
 
 	databaseURL := os.Getenv("DATABASE_URL")
@@ -302,8 +287,7 @@ func TestTelegramMessageRepository_MarkProcessedTx_AcceptsNullClaim(t *testing.T
 	defer database.Close()
 
 	interactionRepo := repository.NewInteractionRepository(database.Queries)
-	suffix := randomSuffix(t)
-	ref := "tg:null-claim:" + suffix
+	ref := "tg:null-claim:" + gen.Prefix()
 	interaction, err := interactionRepo.CreateInteraction(ctx, repository.CreateInteractionRequest{
 		ContactID: contact.ID, Source: repository.InteractionSourceTelegram,
 		SourceRef: &ref, OccurredAt: accelerated.GetCurrentTime().Truncate(time.Microsecond),

--- a/backend/tests/telegram_sparse_entity_enrichment_test.go
+++ b/backend/tests/telegram_sparse_entity_enrichment_test.go
@@ -115,11 +115,12 @@ func cleanupExternalBySource(t *testing.T, env *sparseEnrichEnv, peerIDStr strin
 
 // cleanupSparseEnrichTestData hard-deletes any telegram_message rows for the
 // given chat_id and the chat_config row for that chat. Scoped narrowly to a
-// single test's chat_id to avoid touching unrelated data.
+// single test's chat_id to avoid touching unrelated data. Deletes go through
+// the sqlc-backed repository wrapper (no raw SQL in Go, including tests).
 func cleanupSparseEnrichTestData(t *testing.T, env *sparseEnrichEnv, chatID int64) {
 	t.Helper()
 	ctx := context.Background()
-	_, _ = env.database.Pool.Exec(ctx, "DELETE FROM telegram_message WHERE telegram_chat_id = $1", chatID)
+	_ = env.messageRepo.HardDeleteByChatIDRange(ctx, chatID, chatID)
 	_ = env.chatConfigRepo.DeleteConfig(ctx, chatID)
 }
 
@@ -136,7 +137,8 @@ func makePrivateMessage(peerUserID int64, msgID int, sentAt time.Time, text stri
 func TestSparseEntityEnrichment_HandleNewMessage_FillsFromHistory(t *testing.T) {
 	env := setupSparseEnrichTest(t)
 	ctx := context.Background()
-	peerUserID, peerIDStr := uniqueTestIDs(t)
+	_, ns := migrationGenerator(t)
+	peerUserID, peerIDStr := uniqueTestIDs(t, ns)
 	chatID := peerUserID
 	t.Cleanup(func() { cleanupSparseEnrichTestData(t, env, chatID) })
 
@@ -175,7 +177,8 @@ func TestSparseEntityEnrichment_HandleNewMessage_FillsFromHistory(t *testing.T) 
 func TestSparseEntityEnrichment_HandleNewMessage_NoHistoryStaysSparse(t *testing.T) {
 	env := setupSparseEnrichTest(t)
 	ctx := context.Background()
-	peerUserID, _ := uniqueTestIDs(t)
+	_, ns := migrationGenerator(t)
+	peerUserID, _ := uniqueTestIDs(t, ns)
 	chatID := peerUserID
 	t.Cleanup(func() { cleanupSparseEnrichTestData(t, env, chatID) })
 
@@ -195,7 +198,8 @@ func TestSparseEntityEnrichment_HandleNewMessage_NoHistoryStaysSparse(t *testing
 func TestSparseEntityEnrichment_HandleEditMessage_FillsFromHistory(t *testing.T) {
 	env := setupSparseEnrichTest(t)
 	ctx := context.Background()
-	peerUserID, peerIDStr := uniqueTestIDs(t)
+	_, ns := migrationGenerator(t)
+	peerUserID, peerIDStr := uniqueTestIDs(t, ns)
 	chatID := peerUserID
 	t.Cleanup(func() { cleanupSparseEnrichTestData(t, env, chatID) })
 
@@ -232,7 +236,8 @@ func TestSparseEntityEnrichment_HandleEditMessage_FillsFromHistory(t *testing.T)
 func TestSparseEntityEnrichment_AuthoritativeEmptyRespectsRemoval(t *testing.T) {
 	env := setupSparseEnrichTest(t)
 	ctx := context.Background()
-	peerUserID, peerIDStr := uniqueTestIDs(t)
+	_, ns := migrationGenerator(t)
+	peerUserID, peerIDStr := uniqueTestIDs(t, ns)
 	chatID := peerUserID
 	t.Cleanup(func() { cleanupSparseEnrichTestData(t, env, chatID) })
 
@@ -271,7 +276,8 @@ func TestSparseEntityEnrichment_AuthoritativeEmptyRespectsRemoval(t *testing.T) 
 func TestSparseEntityEnrichment_StraightRenameCurrentNonBlankWins(t *testing.T) {
 	env := setupSparseEnrichTest(t)
 	ctx := context.Background()
-	peerUserID, peerIDStr := uniqueTestIDs(t)
+	_, ns := migrationGenerator(t)
+	peerUserID, peerIDStr := uniqueTestIDs(t, ns)
 	chatID := peerUserID
 	t.Cleanup(func() { cleanupSparseEnrichTestData(t, env, chatID) })
 
@@ -313,7 +319,8 @@ func TestSparseEntityEnrichment_StraightRenameCurrentNonBlankWins(t *testing.T) 
 func TestSparseEntityEnrichment_UntrackedGroupSkipsBeforeEnrichment(t *testing.T) {
 	env := setupSparseEnrichTest(t)
 	ctx := context.Background()
-	peerUserID, peerIDStr := uniqueTestIDs(t)
+	_, ns := migrationGenerator(t)
+	peerUserID, peerIDStr := uniqueTestIDs(t, ns)
 	groupChatID := peerUserID + 1 // distinct from peer id
 	t.Cleanup(func() { cleanupSparseEnrichTestData(t, env, groupChatID) })
 
@@ -362,7 +369,8 @@ func TestSparseEntityEnrichment_UntrackedGroupSkipsBeforeEnrichment(t *testing.T
 func TestSparseEntityEnrichment_AuthoritativeRemovalSticksAcrossSparseUpdates(t *testing.T) {
 	env := setupSparseEnrichTest(t)
 	ctx := context.Background()
-	peerUserID, peerIDStr := uniqueTestIDs(t)
+	_, ns := migrationGenerator(t)
+	peerUserID, peerIDStr := uniqueTestIDs(t, ns)
 	chatID := peerUserID
 	t.Cleanup(func() { cleanupSparseEnrichTestData(t, env, chatID) })
 
@@ -410,7 +418,8 @@ func TestSparseEntityEnrichment_AuthoritativeRemovalSticksAcrossSparseUpdates(t 
 func TestSparseEntityEnrichment_EnrichedFieldsFlowToDiscoveryCandidate(t *testing.T) {
 	env := setupSparseEnrichTest(t)
 	ctx := context.Background()
-	peerUserID, peerIDStr := uniqueTestIDs(t)
+	_, ns := migrationGenerator(t)
+	peerUserID, peerIDStr := uniqueTestIDs(t, ns)
 	chatID := peerUserID
 	t.Cleanup(func() {
 		cleanupSparseEnrichTestData(t, env, chatID)


### PR DESCRIPTION
**Element 5 of the synthetic seed generator: the suite-wide migration.** Consolidated single PR (4 cluster conversions + the staged-legacy `randomSuffix` removal), built in parallel via a worktree-isolated workflow and each cluster independently reviewed before consolidation.

## What this does
Migrates the existing `backend/tests` integration suite off hand-rolled fixtures + per-test `randomSuffix`/`uuid[:8]` isolation onto the synthetic toolkit's namespaced factories (`migrationGenerator` + `seedMigrationContact`, the lightweight nil-bus seed path from PR-A #419), behavior-preserving (no assertion changes). It also removes raw-SQL test setup/cleanup where it stood in for the toolkit.

By cluster:
- **Telegram** (8 files): factory fixtures + namespace tokens; also replaces 5 raw `pool.Exec` DELETEs with existing sqlc wrappers. 5 files justified-skipped (no contact fixture, or `telegram_import_suggestion` whose contact names are subject-under-test for pg_trgm fuzzy matching).
- **Providers** (8 files): gmail/gchat provider/correspondence/golive/rematch + email_interaction. The Category-B below-surface seams (provider envs, durable event-log assertions, cursor-advance, publish-before-mutate, the consumer-in-isolation `UpsertMessage` seam) are preserved unchanged. Skipped the 4 no-contact-fixture files.
- **Consumers** (13 files): followup/cadence/decline consumers + calendar_event + the messaging repo tests; consumer/mode wiring preserved; `phone_call` cleanup narrowed from DB-wide to namespace-scoped.
- **Core** (7 files): identity/search/contact_task/event_bus/etc.; `integration_test.go` migration-subject tests left untouched (raw SQL there is the subject under test).
- **Cleanup**: the 3 `interaction_source_*_check` guards move from `randomSuffix` to `syntheticNS`, and the staged-legacy `randomSuffix` helper is deleted (zero remaining references).

## Review & verification
Each cluster was adversarially reviewed in parallel (all PASS, P0=0/P1=0). The consolidated branch was verified together: `go build`/`vet` clean, `make lint` 0 issues, and the **full `make test-integration` suite on a clean DB PASSED** — the all-clusters-together gate. Codex remained usage-exhausted this window, so reviews used the `/review-head` substitute (verdicts in `.ai/log/review/`). Builds on PR-A #419 (exemplar + shared helper).

Note: `rematch_integration.go` retains 11 pre-existing raw-SQL sites that predate and are out of scope for this contact-fixture migration (untouched, not introduced here).