### PR TITLE
docs: flesh out test-parallelization spec (i) + split cross-run/E2E

### DIFF
--- a/.ai/spec/2026-06-07-test-parallelization-design.md
+++ b/.ai/spec/2026-06-07-test-parallelization-design.md
@@ -1,51 +1,95 @@
-# Test Suite Parallelization — Design (Placeholder)
+# Backend Test Parallelization — Design
 
-**Date:** 2026-06-07
-**Status:** Placeholder skeleton — direction sketched during the synthetic-seed (D) brainstorm; not yet a full design. Gated on D.
+**Date:** 2026-06-07 (fleshed out 2026-06-08)
+**Status:** Design ready for planning.
 **Author:** spengrah (brainstormed with Claude)
 **Tracking:** gh issue #413
-**Prerequisite:** `2026-06-07-synthetic-seed-generator-design.md` (D) — the synthetic seed toolkit + its suite migration.
+**Prerequisite (met):** `2026-06-07-synthetic-seed-generator-design.md` (D) — synthetic seed toolkit + suite migration, all merged.
 
 ## Scope
 
-Parallelize the backend integration (and E2E) test suite to cut wall-clock time, building on the synthetic seed toolkit (D). Successor to the determinism→speed arc (#360 / #361 / #362), which achieved determinism + a long-pole package split; parallelism is the next speed lever.
+This is **sub-project (i)** of the broader test-parallelization effort: parallelize the backend Go integration suite by enabling within-run `t.Parallel()` in the long-pole `backend/tests` package, and make concurrent worktree-agent test runs safe by removing the single-shared-template contention point.
 
-This is a **placeholder** — it captures the direction discovered while scoping D so it isn't lost. Flesh out into a full design (its own brainstorm) when the project starts.
+Explicitly split out:
 
-## Why this is now possible (the D enabler)
+- **(ii) E2E parallelization** — deferred until after #380 Track A (which thins brittle E2E and grows the Go/API suite this project parallelizes). Its own spec later. Tracked: #425.
+- **Cross-run / parallel-implementation isolation beyond the Go template enabler** — connection/instance ceilings + E2E per-worktree ports/DB/process isolation — moved to `2026-06-08-parallel-implementation-isolation-design.md` (placeholder) + #424.
+- **CI matrix sharding** — dropped from scope (see Decisions).
 
-The blocker to parallelism today is the **shared mutable test DB + global-state assertions** — tests assert against totals ("contact X is in the list," "count = N"), so they collide when run concurrently (the whole pollution-gotcha cluster: accumulated state, trigram collisions, list-bounded assertions, the E2E cross-worker import/link candidate problem). D removes that root cause: deterministic, idempotent, fast, **namespaced** fixtures, built to support both isolation modes below.
+## Background: what already exists (and reframes this work)
 
-## Direction (sketched, from the D brainstorm)
+The original placeholder for this spec assumed "one shared mutable test DB + global-state assertions block all parallelism." Three merged efforts have since moved that line, so the remaining work is narrower and lower-risk than the placeholder implied:
 
-Two models, likely both, chosen per test class:
+- **#360** — per-package template-clone isolation (`backend/internal/testdb`). Each `go test` package process gets a fresh, migrated, data-empty clone (`CREATE DATABASE … TEMPLATE personal_crm_test_template`), with `DATABASE_URL` rewritten to it. `go test` runs packages in parallel processes, so **cross-package isolation + parallelism already exist today**.
+- **#362** — split the monolithic suite into sub-packages (`tests`, `tests/api`, `tests/river`, `tests/scheduler`, `tests/unit`, plus `internal/google`, `internal/todoist`), parallelizing across processes. Pre-push dropped ~76s → ~60s.
+- **D (synthetic toolkit)** — namespace-scoped fixtures + scoped assertions, and `testdb.NewEphemeralClone(t)` (a per-test fresh clone). The placeholder's "DB/schema-per-worker provisioning" open thread is effectively already built — it is clone-per-test on the existing template.
 
-1. **Scoped-shared-DB** — namespaced fixtures + *scoped* assertions (query/filter by the namespace marker, not totals) → safe within-package `t.Parallel()` on one DB. Fits lightweight unit/integration tests. Requires D's suite migration to have converted assertions to scoped form.
-2. **DB/schema-per-worker** — D's fast deterministic seed makes N isolated seeded DBs/schemas cheap → true isolation, zero cross-talk. The right fit for **heavy replay / River-draining tests** (which interleave badly on a shared DB) and for **CI sharding**.
+**What's left:** the `backend/tests` package is the remaining long pole — ~80 files / ~432 test functions running **serially** within its single package clone. The dominant unused lever is within-package `t.Parallel()`.
 
-D is being built **parallelization-ready**: its isolation primitive supports both prefix-scoping and full per-DB/schema seeding, so this project is a cheap successor rather than a rework.
+## Decisions (from the brainstorm)
 
-## Open threads (flesh out when this project starts)
+1. **Rollout = audit-then-flip.** Classify all fast-suite files first, scope the gaps, then enable `t.Parallel()` in one coordinated change. Highest confidence, clearest done-criteria, lowest residual flake risk.
+2. **Leave River/heavy tests serial** (do not parallelize them now). They are `RequireLongTests`-gated, so they already skip the fast suite (pre-push + PR CI) — parallelizing them buys nothing for the inner loop / PR gate and adds ephemeral-clone complexity. `NewEphemeralClone(t)` + `t.Parallel()` is the recorded future lever if the full/slow suite ever becomes the bottleneck.
+3. **Fold the Go cross-run enabler (template-by-content-hash) into this spec.** Small change to `testdb`; makes concurrent worktree agents on divergent-migration branches robust. Independent of the `t.Parallel()` rollout.
+4. **Drop CI matrix sharding.** `t.Parallel()` already parallelizes `backend/tests` across one runner's cores (`make test-integration-fast` is a single `go test` invocation, bounded by GOMAXPROCS). A matrix only adds value by adding total cores across runners, at real config cost (Postgres service + template build per shard, result aggregation). Revisit only if a single runner proves insufficient after the flip.
 
-- [ ] Model choice per test class (lightweight → scoped-shared-DB; heavy replay/River → DB-per-worker).
-- [ ] DB/schema-per-worker provisioning mechanism (template-DB clone, schema-per-worker `search_path`, or containerized DB-per-shard).
-- [ ] River-in-parallel handling (queue/DB isolation per worker).
-- [ ] `t.Parallel()` rollout + the assertion-scoping it requires (rides on D's suite migration).
-- [ ] CI sharding config (Go test shards across runners; Playwright shard alignment).
-- [ ] Resource ceiling (Postgres connection limits / DB instances per box; CI runner sizing).
-- [ ] Retire the remaining shared-DB parallelism gotchas (E2E cross-worker candidate collisions, etc.) — overlaps D's gotcha-retirement set.
+## Component 1 — Within-run parallelism (the audit + flip)
 
-## Relationship to #380 (QA pyramid rebalance)
+### The audit taxonomy
 
-#380 (agentic UX QA + behavior SSOT, `2026-05-31-agentic-ux-qa-and-behavior-ssot-design.md`) reshapes the exact surface this project parallelizes — coordinate the two:
+Classify every fast-suite test in `backend/tests` (and confirm the other integration packages are already safe or trivially convertible) into four buckets:
 
-- **#380 Track A relaxes/rewrites the brittle Playwright assertions** (~70% are UI-regression brittle) and moves correctness to **API-level / Go tests** (new handler tests for rematch, sync, calendar, todoist, search), thinning E2E to ~8 data-asserting flows. So **this project's parallelization target is mostly the Go integration/API suite Track A *grows*, not the brittle E2E assertions Track A *thins*.**
-- **Sequencing:** do the E2E-scoping work **after** Track A's relaxation, so we don't scope assertions #380 is about to delete. The Go/API DB-per-worker parallelization is the durable, independent win and can proceed alongside.
-- **Build Track A's new tests parallelization-ready:** the API-level handler tests Track A adds should be D-backed + scoped from the start, so they don't need re-isolation later.
-- **Shared convention (D + this + #380):** deterministic seeded scenarios (D) + scoped / data-asserted assertions (here + Track A) that cite **SSOT behavior IDs** (#380 Piece 1). One philosophy, three consumers.
+| Bucket | Definition | Action |
+|---|---|---|
+| **scoped-safe** | No River client; data already scoped by `syntheticNS(t)` / unique ids | Add `t.Parallel()` as-is |
+| **needs-scoping** | Safe in principle but asserts on global state (totals, "X in list", unscoped counts) or reuses fixed identifiers | Scope fixtures + convert assertions to scoped form, then `t.Parallel()` |
+| **River/heavy** | Starts a River client or drains the queue | Stay serial (Decision 2). Cannot share the package clone's `river_job` table under concurrency — `TestOnly:true` disables leader election, so concurrent clients steal each other's jobs |
+| **inherently-serial** | Touches a process-global (env vars, package-level singletons, the accelerated-time global, fixed ports) | Stay serial; no `t.Parallel()` |
 
-## Dependencies
+The audit output is a checked-in classification table (file → bucket → action) that defines done.
 
-- **Gated on D** (the synthetic seed toolkit + the migration of the existing integration suite onto its factories).
-- Successor to the determinism→speed arc (#360 / #361 / #362).
-- Coordinated with **#380** (above).
+### The flip
+
+Go schedules non-parallel tests first, then runs all `t.Parallel()` tests concurrently — so mixed packages are correct. Add `t.Parallel()` to the scoped-safe + (newly-scoped) needs-scoping buckets. Serial / River / global tests are simply not marked parallel. Because the River/heavy bucket is `RequireLongTests`-gated, the flip delivers parallelism across exactly the set the fast suite runs.
+
+## Component 2 — Cross-run Go enabler (template-by-content-hash)
+
+**Problem:** there is one shared `personal_crm_test_template`. Concurrent agents in different worktrees on **divergent-migration** branches compute different template content-hashes and contend over that single template — each drop+rebuilds it, and the racing loser's clone creation fails loudly with `"template marker mismatch before clone"` (safe, not corruption, but mutually flaky).
+
+**Change:** name the template by its content hash — `personal_crm_test_template_<hash-prefix>` — so each migration-set keeps its own template and they never contend.
+
+Touches `backend/internal/testdb`:
+
+- Derive the template name from `templateHashFromInputs` (use a 32-hex prefix of the sha256; `personal_crm_test_template_` is 27 chars, within Postgres's 63-char identifier limit).
+- Extend `dbNamePattern` to allow `template_[0-9a-f]+`.
+- The drop-on-mismatch logic in `ensureTemplate` becomes unnecessary (distinct hash = distinct DB name = no contention).
+- Add a **template reaper** — distinct migration-sets now leave templates behind; extend `make test-clean-clones` (or add a sibling `test-clean-templates`) to sweep stale `…_template_*`.
+
+**Bonus:** also removes the template rebuild a single developer eats when switching branches across migration sets (previously-built sets are cached by name).
+
+Independent of Component 1 — can land in parallel.
+
+## Resource tuning
+
+With N concurrent tests each opening a pool (+ harness DBs) against Postgres `max_connections ≈ 100`: bound within-package `-parallel`, keep per-test pool `MaxConns` small in `TestConfig`, and ensure every harness `database.Close()` runs in `t.Cleanup`. Choose `-parallel` so `parallel × pool_max` stays comfortably under the ceiling on both a dev box and `ubuntu-latest`. (The cross-agent connection ceiling — many agents at once — is out of scope here; see #424.)
+
+## Success criteria
+
+- **Phase 0 baseline:** measure the fast-suite wall-clock and the `backend/tests`-package time specifically.
+- **Target:** a meaningful reduction on `backend/tests` (core-bounded — realistically ~2–4× on a 4-core runner), validated **flake-free under `-race`, `-count=10`, and `-shuffle=on`**.
+- **Done:** every file classified + actioned per the audit table; fast + full suites green; template-by-hash + reaper landed.
+
+## Sequencing (phases)
+
+1. **Measure + audit** → baseline numbers + the classification table.
+2. **Scope** the needs-scoping bucket → namespaced fixtures + scoped assertions.
+3. **Flip** → `t.Parallel()` on scoped-safe + needs-scoping; verify under `-race` / `-count` / `-shuffle`.
+4. **Template-by-hash + reaper** → the cross-run Go enabler (parallelizable with phases 1–3).
+5. **Tune** → `-parallel` + pool sizing; re-measure against the target.
+
+## Relationships
+
+- **Successor to the determinism→speed arc** (#360 isolation / #361 flake fix / #362 sub-package split).
+- **Builds on D** (synthetic seed toolkit; the namespace primitive + `NewEphemeralClone`).
+- **Coordinated with #380** (QA pyramid rebalance): #380 Track A relaxes brittle Playwright assertions and grows the Go/API suite — so build Track A's new handler tests D-backed + scoped from the start, and do (ii) E2E parallelization after Track A. The Go within-run parallelization here is the durable, independent win that does not wait on #380.
+- **(ii) E2E parallelization** → #425. **Cross-run / parallel-implementation isolation (things 2/3)** → #424 + `2026-06-08-parallel-implementation-isolation-design.md`.

--- a/.ai/spec/2026-06-08-parallel-implementation-isolation-design.md
+++ b/.ai/spec/2026-06-08-parallel-implementation-isolation-design.md
@@ -1,0 +1,45 @@
+# Parallel-Implementation Isolation — Design (Placeholder)
+
+**Date:** 2026-06-08
+**Status:** Placeholder skeleton — direction captured during the test-parallelization (i) brainstorm; not yet a full design.
+**Author:** spengrah (brainstormed with Claude)
+**Tracking:** gh issue #424
+**Related:** `2026-06-07-test-parallelization-design.md` (sub-project i — the within-run sibling; ships the Go template-by-hash enabler this spec assumes), `2026-06-07-deploy-and-staging-overview-design.md`, `2026-05-31-agentic-ux-qa-and-behavior-ssot-design.md` (#380), gh issue #425 (sub-project ii — E2E parallelization).
+
+## Problem
+
+Running **multiple concurrent implementations** — e.g. several Claude agents, each on its own git worktree, often coordinated by a dynamic workflow — each wanting to run the test suite without colliding on shared state. This is the **cross-run** axis (N concurrent test runs not colliding), distinct from sub-project (i)'s **within-run** axis (one run using many cores).
+
+## What already works (no build needed)
+
+- **Go integration tests, same-migration branches:** `testdb.SetupPackage` (#360) mints a uniquely-named random clone per `go test` package process and rewrites that process's `DATABASE_URL` to it. Two worktree agents running `make test-integration-fast` already get independent databases per package — provided both branches share the same migration set.
+- **Go integration tests, divergent-migration branches:** handled by sub-project (i)'s **template-by-content-hash** change (each migration-set keeps its own template; agents never contend). That enabler ships in #413, so this spec assumes it.
+
+## Gaps this spec covers
+
+### Thing 2 — one Postgres instance = shared ceilings
+
+All clones live in the single `crm-postgres` instance (`max_connections ≈ 100`; each process opens pools + River clients; template/clone CREATE/DROP is serialized by an advisory lock on the shared maintenance DB). N agents × parallel-packages × pool-size can approach the connection ceiling, and clone-mint throughput is capped by the lock.
+
+Open threads:
+
+- [ ] Per-agent connection budgeting (pool sizing × expected concurrent agents vs `max_connections`).
+- [ ] Whether to raise `max_connections` / add a pooler (pgbouncer) for the test instance, or cap concurrent agents.
+- [ ] Clone-mint throughput under many concurrent agents (advisory-lock serialization).
+- [ ] Per-agent Postgres instance (a container per worktree) vs one shared instance with many clones — tradeoffs.
+
+### Thing 3 — E2E / `make dev` is not isolated at all
+
+E2E runs a real backend (:8080) + frontend (:3000) against a shared DB on fixed ports with a live process. Concurrent agents collide on ports, the DB, and the server process.
+
+Open threads:
+
+- [ ] Per-worktree port allocation (backend / frontend / DB) and process management.
+- [ ] Per-worktree E2E database (extend the clone idea to the running app's DB, or a per-worktree compose project).
+- [ ] Relationship to the **deploy/staging** design (per-environment isolation is the same shape) and to **(ii) E2E parallelization** (#425, which addresses within-run E2E concurrency after #380) — decide whether thing 3 folds into one of those rather than standing alone.
+
+## Dependencies / sequencing
+
+- The Go enabler (thing 1) ships in sub-project (i) (#413); this spec assumes it.
+- Thing 3 likely sequences with or folds into (ii) E2E parallelization (#425, post-#380) and/or the deploy/staging work — resolve when this is picked up.
+- Lower priority than (i); flesh out into a full design when parallel-implementation workflows become a routine need.


### PR DESCRIPTION
Flesh out the backend test-parallelization design spec (sub-project (i)) from its placeholder into a planning-ready design, and split the broader cross-run / E2E isolation concerns into a separate placeholder spec.

## What changed

- `.ai/spec/2026-06-07-test-parallelization-design.md` — promoted from placeholder to full design for **sub-project (i)**: within-run `t.Parallel()` rollout in the long-pole `backend/tests` package via an **audit-then-flip** (classify every fast-suite file → scoped-safe / needs-scoping / River-heavy / inherently-serial → scope the gaps → flip in one coordinated change), plus the **template-by-content-hash** cross-run enabler in `backend/internal/testdb` (+ a template reaper). Records the #360/#362/D reframing that narrowed the scope, the decision to keep River/heavy tests serial, and the decision to drop CI matrix sharding.
- `.ai/spec/2026-06-08-parallel-implementation-isolation-design.md` — new placeholder skeleton for the **cross-run** isolation gaps (Postgres connection/instance ceilings; E2E per-worktree ports/DB/process isolation). Tracking #424.

## Split out (not in this spec)

- Sub-project (ii) E2E parallelization → #425 (after #380 Track A).
- Cross-run isolation beyond the Go template enabler → #424 + the 2026-06-08 placeholder spec.
- CI matrix sharding → dropped from scope.

Docs-only. Implementation of sub-project (i) follows in subsequent PRs (Component 2 template-by-hash first, then Component 1 audit→flip).

Tracking: #413.
