### PR TITLE
feat(testdb): name templates by migration content-hash + reaper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -355,7 +355,7 @@ test-integration-slow:
 # package main (NOT `go test`) so the sweep can never execute during the normal
 # `go test ./internal/testdb/...` integration run.
 test-clean-clones:
-	@echo "Sweeping leaked test clone databases..."
+	@echo "Sweeping leaked clone and stale template databases..."
 	@cd backend && DATABASE_URL="$(TEST_DATABASE_URL)" go run -tags integration_testdb ./internal/testdb/cmd/cleanclones
 
 test-frontend:

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ GOCACHE ?= $(REPO_ROOT)/.gocache
 export GOCACHE
 
 TEST_DATABASE_URL ?= postgres://crm_user:crm_password@localhost:5432/personal_crm_test?sslmode=disable
-BACKEND_SLOW_TESTS_REGEX := TestSyncWorker_LoadNoDuplicateConcurrentSyncs|TestPeriodicTick_FiresOnStart|TestSyncWorker_RescueOnCrash|TestSynthetic
+BACKEND_SLOW_TESTS_REGEX := TestSyncWorker_LoadNoDuplicateConcurrentSyncs|TestPeriodicTick_FiresOnStart|TestSyncWorker_RescueOnCrash|TestSynthetic|TestTestdb
 
 # Default target
 # NOTE: When adding or removing make targets, update this help section to match
@@ -51,7 +51,7 @@ help:
 	@echo "  test-integration      - Run all backend integration tests"
 	@echo "  test-integration-fast - Run backend integration tests without LONG_TESTS"
 	@echo "  test-integration-slow - Run only LONG_TESTS-gated backend integration tests"
-	@echo "  test-clean-clones     - Drop leaked per-package/per-test clone databases"
+	@echo "  test-clean-clones     - Drop leaked clone and stale template databases"
 	@echo "  test-frontend         - Run frontend unit tests"
 	@echo "  test-e2e              - Run Playwright E2E tests"
 	@echo "  test-e2e-local        - Run Playwright E2E tests (honors PLAYWRIGHT_GREP)"
@@ -340,15 +340,20 @@ test-integration-slow:
 	@echo "Running backend slow integration tests..."
 	@cd backend && DATABASE_URL="$(TEST_DATABASE_URL)" LONG_TESTS=1 go test -tags integration_testdb -count=1 ./tests/... ./internal/todoist/... ./internal/google/... ./internal/testdb/... -v -run '$(BACKEND_SLOW_TESTS_REGEX)'
 
-# Sweep leaked per-package / per-test clone databases
-# (personal_crm_test_clone_*). Crashed processes (SIGKILL between clone
-# CREATE and DROP) can leak clones; they are harmless until reaped here.
-# Run when no integration tests are in flight. Implemented in the Go
-# harness (not raw psql) so it shares the same name guards — every drop
-# passes assertDroppableTestDBName, and the template/base are never
-# touched. Uses `go run` on a package main (NOT `go test`) so the sweep
-# can never execute during the normal `go test ./internal/testdb/...`
-# integration run.
+# Sweep leaked clone databases (personal_crm_test_clone_*) AND stale
+# per-migration-set template databases (personal_crm_test_template_<hash>).
+# Crashed processes can leak clones; templates accumulate as migration sets
+# change over time (branch switches, divergent worktrees). Run ONLY when no
+# integration tests are in flight: the template drop pass holds the build
+# advisory lock so it never drops a template mid-CREATE...TEMPLATE, but the
+# lock is released between a running test process's operations, so a different
+# worktree's still-running process could still clone from a template later
+# (stronger cross-worktree-concurrent safety is out of scope — see #424).
+# Implemented in the Go harness (not raw psql) so it shares the same name
+# guards — every drop passes assertDroppableTestDBName, the current run's
+# template is kept warm, and the base is never touched. Uses `go run` on a
+# package main (NOT `go test`) so the sweep can never execute during the normal
+# `go test ./internal/testdb/...` integration run.
 test-clean-clones:
 	@echo "Sweeping leaked test clone databases..."
 	@cd backend && DATABASE_URL="$(TEST_DATABASE_URL)" go run -tags integration_testdb ./internal/testdb/cmd/cleanclones

--- a/backend/internal/testdb/cmd/cleanclones/main.go
+++ b/backend/internal/testdb/cmd/cleanclones/main.go
@@ -1,22 +1,63 @@
 //go:build integration_testdb
 
-// Command cleanclones drops every leaked personal_crm_test_clone_* database.
-// It is invoked ONLY by `make test-clean-clones` via `go run`; because it is a
+// Command cleanclones sweeps leaked personal_crm_test_clone_* databases AND
+// stale personal_crm_test_template_<hash> databases in a single pass. It is
+// invoked ONLY by `make test-clean-clones` via `go run`; because it is a
 // `package main` (not a _test.go file), it can never execute during
-// `go test ./internal/testdb/...`. All drops route through testdb.CleanClones,
-// which name-guards every database before dropping it.
+// `go test ./internal/testdb/...`. All drops route through
+// testdb.CleanStaleDatabases, which name-guards every database before dropping
+// it and serializes the template drop pass under the build advisory lock.
+//
+// It resolves the migrations path (so the current run's template is kept warm,
+// not reaped) from MIGRATIONS_PATH if that is set to an absolute path, else from
+// a runtime.Caller-relative path. If neither resolves to an existing directory
+// it passes "" — the current-template exclusion is then skipped, which is still
+// safe (the lock + open-backend skip protect any in-use template).
 package main
 
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"runtime"
 
 	"personal-crm/backend/internal/testdb"
 )
 
 func main() {
-	if err := testdb.CleanClones(); err != nil {
+	if err := testdb.CleanStaleDatabases(resolveMigrationsPath()); err != nil {
 		fmt.Fprintf(os.Stderr, "cleanclones: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+// resolveMigrationsPath returns the backend migrations directory, or "" if it
+// cannot be resolved to an existing directory. MIGRATIONS_PATH (absolute) wins;
+// otherwise the path is computed four "../" hops up from this command file
+// (.../internal/testdb/cmd/cleanclones → backend) plus "/migrations".
+func resolveMigrationsPath() string {
+	if path := os.Getenv("MIGRATIONS_PATH"); path != "" && filepath.IsAbs(path) {
+		if dirHasUpMigrations(path) {
+			return path
+		}
+	}
+
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		return ""
+	}
+	// .../backend/internal/testdb/cmd/cleanclones/main.go → backend/migrations.
+	path := filepath.Join(filepath.Dir(filename), "..", "..", "..", "..", "migrations")
+	if dirHasUpMigrations(path) {
+		return path
+	}
+	return ""
+}
+
+// dirHasUpMigrations reports whether path is a directory containing at least one
+// *.up.sql migration file, so a wrong hop count or a stale MIGRATIONS_PATH
+// resolves to "" rather than silently mis-naming the current template.
+func dirHasUpMigrations(path string) bool {
+	matches, err := filepath.Glob(filepath.Join(path, "*.up.sql"))
+	return err == nil && len(matches) > 0
 }

--- a/backend/internal/testdb/testdb.go
+++ b/backend/internal/testdb/testdb.go
@@ -23,12 +23,15 @@
 // pool). NOTHING ELSE in the harness may use raw SQL. The complete allow-list:
 //
 //	CREATE DATABASE <name> [TEMPLATE ...]    DDL in maintenance DB; identifier via pgx.Identifier{name}.Sanitize() after assertCreatableTestDBName
-//	DROP DATABASE IF EXISTS <name> WITH (FORCE)  DDL in maintenance DB; identifier via Sanitize() after assertDroppableTestDBName
+//	DROP DATABASE IF EXISTS <name> WITH (FORCE)  DDL in maintenance DB; identifier via Sanitize() after assertDroppableTestDBName (clone sweep)
+//	DROP DATABASE IF EXISTS <name>  NON-FORCE DDL in maintenance DB; identifier via Sanitize() after assertDroppableTestDBName (template reaper)
 //	SELECT pg_advisory_lock($1) / pg_advisory_unlock($1)  session function; parameterized; constant lock id
 //	CREATE EXTENSION IF NOT EXISTS "uuid-ossp" / ... vector  DDL inside the template; static literal
 //	CREATE TABLE _testdb_template_marker(...) / INSERT ... / SELECT hash ...  marker table exists only inside test DBs; static DDL; value parameterized via $1
 //	SELECT 1 FROM pg_database WHERE datname = $1  system catalog read; parameterized
-//	SELECT datname FROM pg_database WHERE datname LIKE $1 ESCAPE '\'  system catalog read (clone sweep); parameterized; escaped `_`
+//	SELECT oid FROM pg_database WHERE datname = $1  system catalog read (test-only drop+recreate detection); parameterized
+//	SELECT datname FROM pg_database WHERE datname LIKE $1 ESCAPE '\'  system catalog read (clone + template sweep); parameterized; escaped `_`
+//	SELECT numbackends FROM pg_stat_database WHERE datname = $1  system catalog read (template reaper active-session count); parameterized
 //
 // Production query paths gain ZERO raw SQL.
 package testdb
@@ -242,51 +245,105 @@ func NewEphemeralClone(t testing.TB) (cloneConnURL string, drop func()) {
 	return cloneConnURL, drop
 }
 
-// CleanClones drops every leaked personal_crm_test_clone_* database. It is the
-// explicit-sweep entrypoint invoked ONLY by `make test-clean-clones` via the
-// standalone go-run cmd; it never runs during `go test`. The template and base
-// are never touched. Every drop is routed through assertDroppableTestDBName.
-// Returns a non-nil error if any guarded drop fails, so the make target exits
-// non-zero when leaked clones remain.
+// CleanClones is a thin backward-compatible shim over CleanStaleDatabases. With
+// no migrations path it cannot exclude the current run's template from the
+// reaper, but the advisory lock plus the per-template numbackends skip still
+// protect any in-use template; at worst the current template is reaped and
+// rebuilt next run (a cost, never a correctness problem).
 func CleanClones() error {
+	return CleanStaleDatabases("")
+}
+
+// CleanStaleDatabases sweeps leaked clones AND stale per-migration-set templates
+// in a single pass. It is the explicit-sweep entrypoint invoked ONLY by
+// `make test-clean-clones` via the standalone go-run cmd; it never runs during
+// `go test`. The base personal_crm_test is never touched. Every drop is routed
+// through assertDroppableTestDBName.
+//
+// Operating model: run ONLY when no integration tests are in flight. The
+// advisory lock (held during the template drop pass) makes the reaper safe
+// against an in-flight CREATE ... TEMPLATE copy, but NOT against a different
+// worktree's still-running test process that may clone from a template LATER —
+// the lock is released between that process's operations. That stronger
+// cross-worktree-concurrent guarantee is out of scope (tracking #424).
+//
+// migrationsPath, when it resolves, names the current run's template so the
+// reaper keeps it warm (never drops it). Pass "" to skip that exclusion.
+//
+// Returns a non-nil error only when a guarded drop the reaper ATTEMPTED
+// actually failed; templates skipped because they are the current run's hash or
+// have open backends are expected, logged skips — not errors. So the make
+// target exits 0 when everything droppable was dropped and the rest legitimately
+// skipped, non-zero only on a real drop failure.
+func CleanStaleDatabases(migrationsPath string) error {
 	baseURL := envBaseURL()
 	if baseURL == "" {
-		return errors.New("testdb.CleanClones: DATABASE_URL/TEST_DATABASE_URL not set")
+		return errors.New("testdb.CleanStaleDatabases: DATABASE_URL/TEST_DATABASE_URL not set")
 	}
 	baseName, err := dbNameFromURL(baseURL)
 	if err != nil {
-		return fmt.Errorf("testdb.CleanClones: parse base URL: %w", err)
+		return fmt.Errorf("testdb.CleanStaleDatabases: parse base URL: %w", err)
 	}
 	if err := assertBaseDBName(baseName); err != nil {
-		return fmt.Errorf("testdb.CleanClones: %w", err)
+		return fmt.Errorf("testdb.CleanStaleDatabases: %w", err)
 	}
 
 	ctx := context.Background()
 	admin, err := connectAdmin(ctx, baseURL)
 	if err != nil {
-		return fmt.Errorf("testdb.CleanClones: connect admin: %w", err)
+		return fmt.Errorf("testdb.CleanStaleDatabases: connect admin: %w", err)
 	}
 	defer func() { _ = admin.Close(ctx) }()
 
+	// Sweep clones first, WITHOUT the advisory lock: clones are never a
+	// CREATE ... TEMPLATE copy source, so no build/clone op can be racing them.
+	cloneErr := sweepClones(ctx, admin)
+
+	// Resolve the current run's template name so the reaper keeps it warm. If
+	// the path can't be resolved, the exclusion is skipped (still safe).
+	var currentTemplateName string
+	if migrationsPath != "" {
+		if currentHash, err := templateHashFromInputs(migrationsPath); err == nil {
+			currentTemplateName = templateNameFromHash(currentHash)
+		} else {
+			fmt.Fprintf(os.Stderr, "testdb.CleanStaleDatabases: compute current template hash (skipping current-template exclusion): %v\n", err)
+		}
+	}
+
+	candidates, listErr := listStaleTemplateCandidates(ctx, admin, currentTemplateName)
+	if listErr != nil {
+		return errors.Join(cloneErr, listErr)
+	}
+	dropped, reapErr := reapTemplates(ctx, admin, candidates, currentTemplateName)
+	fmt.Fprintf(os.Stderr, "testdb.CleanStaleDatabases: dropped %d stale template(s) of %d candidate(s)\n", dropped, len(candidates))
+
+	return errors.Join(cloneErr, reapErr)
+}
+
+// sweepClones lists and drops every leaked personal_crm_test_clone_* database on
+// the admin connection. Not run under the advisory lock — clones are never a
+// CREATE ... TEMPLATE copy source. Returns a non-nil error if any guarded clone
+// drop failed.
+func sweepClones(ctx context.Context, admin *pgx.Conn) error {
 	// Pattern: clones are clonePrefix + hex. The literal `_` after `clone` is
 	// escaped so it is not a LIKE single-char wildcard.
 	pattern := `personal_crm_test_clone\_%`
 	rows, err := admin.Query(ctx, `SELECT datname FROM pg_database WHERE datname LIKE $1 ESCAPE '\'`, pattern)
 	if err != nil {
-		return fmt.Errorf("testdb.CleanClones: list clones: %w", err)
+		return fmt.Errorf("testdb.sweepClones: list clones: %w", err)
 	}
 	var names []string
 	for rows.Next() {
 		var name string
 		if err := rows.Scan(&name); err != nil {
 			rows.Close()
-			return fmt.Errorf("testdb.CleanClones: scan: %w", err)
+			return fmt.Errorf("testdb.sweepClones: scan: %w", err)
 		}
 		names = append(names, name)
 	}
 	rows.Close()
 	if err := rows.Err(); err != nil {
-		return fmt.Errorf("testdb.CleanClones: rows: %w", err)
+		return fmt.Errorf("testdb.sweepClones: rows: %w", err)
 	}
 
 	var dropped int
@@ -305,9 +362,132 @@ func CleanClones() error {
 		}
 		dropped++
 	}
-	fmt.Fprintf(os.Stderr, "testdb.CleanClones: dropped %d leaked clone(s)\n", dropped)
+	fmt.Fprintf(os.Stderr, "testdb.sweepClones: dropped %d leaked clone(s)\n", dropped)
 	if len(dropErrs) > 0 {
-		return fmt.Errorf("testdb.CleanClones: %d clone(s) could not be dropped: %w", len(dropErrs), errors.Join(dropErrs...))
+		return fmt.Errorf("testdb.sweepClones: %d clone(s) could not be dropped: %w", len(dropErrs), errors.Join(dropErrs...))
+	}
+	return nil
+}
+
+// listStaleTemplateCandidates returns every hash-named template_<hex> database
+// EXCEPT currentTemplateName. Pure listing — no drops, no lock — so it is safe
+// to run under the parallel suite. The `_` chars in the LIKE pattern are escaped
+// so they are not single-char wildcards.
+func listStaleTemplateCandidates(ctx context.Context, admin *pgx.Conn, currentTemplateName string) ([]string, error) {
+	pattern := `personal_crm_test_template\_%`
+	rows, err := admin.Query(ctx, `SELECT datname FROM pg_database WHERE datname LIKE $1 ESCAPE '\'`, pattern)
+	if err != nil {
+		return nil, fmt.Errorf("testdb.listStaleTemplateCandidates: list templates: %w", err)
+	}
+	defer rows.Close()
+	var names []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("testdb.listStaleTemplateCandidates: scan: %w", err)
+		}
+		if name == currentTemplateName {
+			continue // keep the current run's template warm
+		}
+		names = append(names, name)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("testdb.listStaleTemplateCandidates: rows: %w", err)
+	}
+	return names, nil
+}
+
+// reapTemplates drops the stale templates in candidates, the entire pass running
+// under templateBuildAdvisoryLockID — the SAME lock every build/clone holds, so
+// no CREATE ... TEMPLATE copy can be in flight while it runs (the load-bearing
+// safety mechanism; the numbackends skip below is only belt-and-suspenders).
+//
+// Per candidate, under the lock: skip if it is currentTemplateName
+// (defense-in-depth even though the listing already excluded it); skip if it has
+// open backends (a stray manual psql session — never force-terminated); else
+// non-FORCE drop after assertDroppableTestDBName.
+//
+// Return-value contract: a skipped candidate (current-run hash or open backends)
+// is NOT an error — it is an expected, logged skip. The returned error is
+// non-nil ONLY when a guarded drop reapTemplates ATTEMPTED actually failed (an
+// unexpected DROP pgerror, or a listed name failing assertDroppableTestDBName).
+//
+// Tests drive this directly with their own test-unique candidate slice so an
+// automated reaper test never lists, considers, or drops a template it did not
+// itself create — concurrent worktrees and sibling packages stay untouchable.
+func reapTemplates(ctx context.Context, admin *pgx.Conn, candidates []string, currentTemplateName string) (dropped int, err error) {
+	var dropErrs []error
+	lockErr := withAdvisoryLock(ctx, admin, func() error {
+		for _, name := range candidates {
+			if name == currentTemplateName {
+				continue // keep the current run's template warm
+			}
+			backends, err := templateActiveBackends(ctx, admin, name)
+			if err != nil {
+				dropErrs = append(dropErrs, err)
+				continue
+			}
+			if backends > 0 {
+				// A stray manual session is open against this template. Skip
+				// (not an error) rather than force-terminate it: a template is a
+				// potential copy source and a possibly-intentional session.
+				fmt.Fprintf(os.Stderr, "testdb.reapTemplates: skipping %s (%d open backend(s))\n", name, backends)
+				continue
+			}
+			if err := assertDroppableTestDBName(name); err != nil {
+				// A LIKE-matched name failing the guard is unexpected; surface
+				// it rather than dropping it.
+				dropErrs = append(dropErrs, fmt.Errorf("skip non-droppable %q: %w", name, err))
+				continue
+			}
+			if err := dropDatabaseNoForceConn(ctx, admin, name); err != nil {
+				dropErrs = append(dropErrs, err)
+				continue
+			}
+			dropped++
+		}
+		return nil
+	})
+	if lockErr != nil {
+		dropErrs = append(dropErrs, lockErr)
+	}
+	if len(dropErrs) > 0 {
+		return dropped, fmt.Errorf("testdb.reapTemplates: %d template(s) could not be dropped: %w", len(dropErrs), errors.Join(dropErrs...))
+	}
+	return dropped, nil
+}
+
+// templateActiveBackends returns the number of sessions connected to the named
+// database, via the pg_stat_database catalog. A template mid-CREATE ... TEMPLATE
+// copy has ZERO user backends (Postgres copies it without a separate user
+// session), so this count is the secondary skip, NOT the gate that protects
+// against the copy race — the advisory lock is.
+func templateActiveBackends(ctx context.Context, conn *pgx.Conn, name string) (int, error) {
+	var n int
+	err := conn.QueryRow(ctx, `SELECT numbackends FROM pg_stat_database WHERE datname = $1`, name).Scan(&n)
+	if errors.Is(err, pgx.ErrNoRows) {
+		// No catalog row ⇒ the DB does not exist ⇒ zero backends.
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("read active backends for %q: %w", name, err)
+	}
+	return n, nil
+}
+
+// dropDatabaseNoForceConn runs a NON-FORCE DROP DATABASE IF EXISTS after the
+// droppable-name guard. Used ONLY by the template reaper: non-FORCE so that if a
+// backend appears between the numbackends read and the drop, Postgres refuses
+// rather than terminating a live session (a template is a potential copy source
+// and a possibly-intentional manual session). The clone sweep keeps the FORCE
+// variant (dropDatabaseConn); the two branches never cross-feed names.
+func dropDatabaseNoForceConn(ctx context.Context, conn *pgx.Conn, name string) error {
+	if err := assertDroppableTestDBName(name); err != nil {
+		return err
+	}
+	stmt := "DROP DATABASE IF EXISTS " + pgx.Identifier{name}.Sanitize()
+	if _, err := conn.Exec(ctx, stmt); err != nil {
+		return fmt.Errorf("drop database %q: %w", name, err)
 	}
 	return nil
 }
@@ -624,6 +804,22 @@ func databaseExists(ctx context.Context, conn *pgx.Conn, name string) (bool, err
 		return false, fmt.Errorf("check database exists %q: %w", name, err)
 	}
 	return true, nil
+}
+
+// databaseOID returns the pg_database OID of the named database, and ok=false if
+// it does not exist. Used ONLY by the harness's own integration tests to detect
+// a drop+recreate (a recreated DB gets a new OID) WITHOUT writing a sentinel —
+// it is the same maintenance-connection, parameterized, read-only catalog
+// pattern as databaseExists, strictly weaker than the numbackends read.
+func databaseOID(ctx context.Context, conn *pgx.Conn, name string) (oid uint32, ok bool, err error) {
+	err = conn.QueryRow(ctx, `SELECT oid FROM pg_database WHERE datname = $1`, name).Scan(&oid)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, fmt.Errorf("read database oid %q: %w", name, err)
+	}
+	return oid, true, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/internal/testdb/testdb.go
+++ b/backend/internal/testdb/testdb.go
@@ -62,9 +62,19 @@ const (
 	// The env URL MUST point at this database before any DDL runs.
 	baseDBName = "personal_crm_test"
 
-	// templateDBName is the template the per-package and per-test clones are
-	// copied from. Never swept; reused across runs.
-	templateDBName = "personal_crm_test_template"
+	// templatePrefix prefixes every per-migration-set template database. The
+	// full name is templatePrefix + the first templateHashPrefixLen hex chars
+	// of the migration content hash (27 + 32 = 59 ≤ Postgres's 63-char
+	// identifier limit). Each migration set keeps its own template so divergent
+	// branches/worktrees never contend over one name.
+	templatePrefix = "personal_crm_test_template_"
+
+	// templateHashPrefixLen is how many hex chars of the sha256 digest name the
+	// template. 32 hex = 128 bits, collision-free across coexisting migration
+	// sets. MUST stay in sync with the `{32}` quantifier in dbNamePattern: the
+	// regex is the validation counterpart of this constant; change them
+	// together (see the unit assertion in TestTemplateNameArithmetic).
+	templateHashPrefixLen = 32
 
 	// clonePrefix prefixes every per-package / per-test clone database.
 	clonePrefix = "personal_crm_test_clone_"
@@ -84,9 +94,30 @@ const (
 )
 
 // dbNamePattern matches the only database names the harness may CREATE or DROP:
-// the template, and clones whose token is lowercase hex. The bare base
-// personal_crm_test is intentionally NOT matched (we never CREATE or DROP it).
-var dbNamePattern = regexp.MustCompile(`^personal_crm_test_(template|clone_[0-9a-f]+)$`)
+// hash-named templates (template_<32 lowercase hex>), and clones whose token is
+// lowercase hex. The bare base personal_crm_test is intentionally NOT matched
+// (we never CREATE or DROP it), and neither is the legacy bare
+// personal_crm_test_template (the new harness never produces it; reclaim it
+// manually on a dev box with `DROP DATABASE personal_crm_test_template`).
+//
+// The template suffix is pinned to exactly {32} hex — the validation
+// counterpart of templateHashPrefixLen = 32. The two must change together.
+var dbNamePattern = regexp.MustCompile(`^personal_crm_test_(template_[0-9a-f]{32}|clone_[0-9a-f]+)$`)
+
+// templateNameFromHash returns the content-hash-named template DB name for a
+// migration set. hash is the full 64-hex sha256 from templateHashFromInputs;
+// only its first templateHashPrefixLen chars name the template, so two migration
+// sets whose hashes differ within those chars get distinct templates and never
+// contend. Panics if hash is shorter than the prefix length — an internal
+// invariant that holds by construction (templateHashFromInputs always returns a
+// 64-hex digest); the panic makes a future hash-shortening change fail loudly
+// instead of slicing out of range. Never reachable from valid inputs.
+func templateNameFromHash(hash string) string {
+	if len(hash) < templateHashPrefixLen {
+		panic(fmt.Sprintf("testdb: template hash %q shorter than prefix length %d", hash, templateHashPrefixLen))
+	}
+	return templatePrefix + hash[:templateHashPrefixLen]
+}
 
 // originalBaseURL captures the env database URL as it was at SetupPackage entry,
 // BEFORE the package clone rewrite of DATABASE_URL. NewEphemeralClone derives
@@ -285,13 +316,15 @@ func CleanClones() error {
 // Template build
 // ---------------------------------------------------------------------------
 
-// ensureTemplate builds or refreshes the template DB under the advisory lock.
-// On exit the template exists and its marker equals the current wantHash.
+// ensureTemplate builds or refreshes the hash-named template DB under the
+// advisory lock. On exit the template for this migration set exists and its
+// marker equals the current wantHash.
 func ensureTemplate(ctx context.Context, baseURL, migPath string) error {
 	wantHash, err := templateHashFromInputs(migPath)
 	if err != nil {
 		return fmt.Errorf("compute template hash: %w", err)
 	}
+	templateName := templateNameFromHash(wantHash)
 
 	admin, err := connectAdmin(ctx, baseURL)
 	if err != nil {
@@ -300,37 +333,53 @@ func ensureTemplate(ctx context.Context, baseURL, migPath string) error {
 	defer func() { _ = admin.Close(ctx) }()
 
 	return withAdvisoryLock(ctx, admin, func() error {
-		exists, err := databaseExists(ctx, admin, templateDBName)
+		exists, err := databaseExists(ctx, admin, templateName)
 		if err != nil {
 			return err
 		}
-		if exists {
-			gotHash, ok, err := readTemplateMarker(ctx, baseURL)
-			if err != nil {
-				return err
-			}
-			if ok && gotHash == wantHash {
-				return nil // reuse as-is
-			}
-			// Stale or marker-less template: rebuild.
-			if err := dropDatabaseConn(ctx, admin, templateDBName); err != nil {
-				return fmt.Errorf("drop stale template: %w", err)
-			}
+		if !exists {
+			return buildTemplate(ctx, admin, baseURL, templateName, migPath, wantHash)
 		}
-		return buildTemplate(ctx, admin, baseURL, migPath, wantHash)
+
+		gotHash, ok, err := readTemplateMarker(ctx, baseURL, templateName)
+		if err != nil {
+			return err
+		}
+		switch {
+		case ok && gotHash == wantHash:
+			// Reuse as-is: the template for this migration set is already built.
+			return nil
+		case !ok:
+			// Missing marker = a crashed/partial build of THIS name (CREATE
+			// DATABASE ran but writeTemplateMarker did not). It is the only
+			// surviving rebuild path: drop the incomplete DB and rebuild so no
+			// clone is ever copied from a template with an incomplete schema.
+			if err := dropDatabaseConn(ctx, admin, templateName); err != nil {
+				return fmt.Errorf("drop partial template: %w", err)
+			}
+			return buildTemplate(ctx, admin, baseURL, templateName, migPath, wantHash)
+		default:
+			// ok && gotHash != wantHash: a complete build recorded a hash other
+			// than the one the name is derived from. Under hash-naming a distinct
+			// hash yields a distinct name, so this is a logically-impossible /
+			// corrupted state, never a routine cross-branch event. Fail loud
+			// rather than silently drop+rebuild (which would mask real
+			// corruption); a developer drops it manually.
+			return fmt.Errorf("template %s has marker hash %s but its name implies %s: corrupted/incompatible template; drop it manually", templateName, gotHash, wantHash)
+		}
 	})
 }
 
-// buildTemplate creates the template DB, runs migrations into it, and writes
-// the marker. Must be called while holding the advisory lock. Disconnects from
-// the template fully before returning so a subsequent CREATE ... TEMPLATE
+// buildTemplate creates the named template DB, runs migrations into it, and
+// writes the marker. Must be called while holding the advisory lock. Disconnects
+// from the template fully before returning so a subsequent CREATE ... TEMPLATE
 // against it (under the same lock by a cloner) cannot fail on a live session.
-func buildTemplate(ctx context.Context, admin *pgx.Conn, baseURL, migPath, wantHash string) error {
-	if err := createDatabaseConn(ctx, admin, templateDBName); err != nil {
+func buildTemplate(ctx context.Context, admin *pgx.Conn, baseURL, templateName, migPath, wantHash string) error {
+	if err := createDatabaseConn(ctx, admin, templateName); err != nil {
 		return fmt.Errorf("create template: %w", err)
 	}
 
-	templateURL, err := withDatabase(baseURL, templateDBName)
+	templateURL, err := withDatabase(baseURL, templateName)
 	if err != nil {
 		return err
 	}
@@ -386,11 +435,11 @@ func writeTemplateMarker(ctx context.Context, templateURL, hash string) error {
 	return nil
 }
 
-// readTemplateMarker reads the marker hash from the template on a short-lived
-// connection. ok is false if the marker table does not exist (a template built
-// by a prior incompatible harness, or a partial build).
-func readTemplateMarker(ctx context.Context, baseURL string) (hash string, ok bool, err error) {
-	templateURL, err := withDatabase(baseURL, templateDBName)
+// readTemplateMarker reads the marker hash from the named template on a
+// short-lived connection. ok is false if the marker table does not exist (a
+// partial/crashed build that created the DB but not the marker).
+func readTemplateMarker(ctx context.Context, baseURL, templateName string) (hash string, ok bool, err error) {
+	templateURL, err := withDatabase(baseURL, templateName)
 	if err != nil {
 		return "", false, err
 	}
@@ -431,6 +480,7 @@ func createCloneFromTemplate(ctx context.Context, baseURL, migPath string) (clon
 	if err != nil {
 		return "", "", fmt.Errorf("compute template hash: %w", err)
 	}
+	templateName := templateNameFromHash(wantHash)
 
 	token, err := randomToken()
 	if err != nil {
@@ -445,17 +495,19 @@ func createCloneFromTemplate(ctx context.Context, baseURL, migPath string) (clon
 	defer func() { _ = admin.Close(ctx) }()
 
 	lockErr := withAdvisoryLock(ctx, admin, func() error {
-		// Re-verify the template still exists and matches wantHash before
-		// cloning, guarding against a concurrent rebuild between ensureTemplate
-		// and here.
-		gotHash, ok, err := readTemplateMarker(ctx, baseURL)
+		// Re-read the marker under the lock right before CREATE ... TEMPLATE.
+		// With hash-naming this is a pure assertion that should never fail after
+		// ensureTemplate just succeeded (a distinct hash would be a distinct
+		// name, so no cross-branch race can trip it); surface it loudly if it
+		// somehow does.
+		gotHash, ok, err := readTemplateMarker(ctx, baseURL, templateName)
 		if err != nil {
 			return fmt.Errorf("re-read template marker: %w", err)
 		}
 		if !ok || gotHash != wantHash {
 			return fmt.Errorf("template marker mismatch before clone (want %s, got %s, present=%t)", wantHash, gotHash, ok)
 		}
-		return createDatabaseFromTemplateConn(ctx, admin, cloneName, templateDBName)
+		return createDatabaseFromTemplateConn(ctx, admin, cloneName, templateName)
 	})
 	if lockErr != nil {
 		return "", "", lockErr
@@ -472,8 +524,9 @@ func createCloneFromTemplate(ctx context.Context, baseURL, migPath string) (clon
 // Name guards (the safety core)
 // ---------------------------------------------------------------------------
 
-// assertCreatableTestDBName accepts only the template and clone_<hex> names.
-// The bare base personal_crm_test is rejected (we never CREATE it).
+// assertCreatableTestDBName accepts only hash-named template_<32-hex> and
+// clone_<hex> names. The bare base personal_crm_test is rejected (we never
+// CREATE it).
 func assertCreatableTestDBName(name string) error {
 	if !dbNamePattern.MatchString(name) {
 		return fmt.Errorf("refusing to CREATE database %q: not a creatable test-family name", name)
@@ -481,8 +534,9 @@ func assertCreatableTestDBName(name string) error {
 	return nil
 }
 
-// assertDroppableTestDBName accepts only the template and clone_<hex> names.
-// The base personal_crm_test, dev personal_crm, postgres, template0/1 are all
+// assertDroppableTestDBName accepts only hash-named template_<32-hex> and
+// clone_<hex> names. The base personal_crm_test, the legacy bare
+// personal_crm_test_template, dev personal_crm, postgres, template0/1 are all
 // rejected by construction.
 func assertDroppableTestDBName(name string) error {
 	if !dbNamePattern.MatchString(name) {

--- a/backend/internal/testdb/testdb_internal_test.go
+++ b/backend/internal/testdb/testdb_internal_test.go
@@ -4,6 +4,9 @@ package testdb
 
 import (
 	"net/url"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -14,7 +17,18 @@ func TestNameGuards(t *testing.T) {
 		droppable bool
 		base      bool
 	}{
-		{"personal_crm_test_template", true, true, false},
+		// Hash-named templates (exactly 32 lowercase hex): creatable + droppable.
+		{"personal_crm_test_template_deadbeefdeadbeefdeadbeefdeadbeef", true, true, false},
+		{"personal_crm_test_template_0123456789abcdef0123456789abcdef", true, true, false},
+		// Legacy bare template name: NOT creatable/droppable under hash-naming.
+		{"personal_crm_test_template", false, false, false},
+		{"personal_crm_test_template_", false, false, false},    // empty hex
+		{"personal_crm_test_template_XYZ", false, false, false}, // non-hex / uppercase
+		// 31 hex (one short) and 33 hex (one over): both rejected by the {32} pin.
+		{"personal_crm_test_template_deadbeefdeadbeefdeadbeefdeadbee", false, false, false},
+		{"personal_crm_test_template_deadbeefdeadbeefdeadbeefdeadbeef0", false, false, false},
+		{"personal_crm_test_template_a b", false, false, false}, // whitespace
+		{"personal_crm_test_template_a;DROP DATABASE x", false, false, false},
 		{"personal_crm_test_clone_deadbeef", true, true, false},
 		{"personal_crm_test_clone_0123456789abcdef", true, true, false},
 		{"personal_crm_test", false, false, true}, // base: never create/drop, only base-accept
@@ -158,4 +172,140 @@ func TestRiverMigrationFingerprintsNoDB(t *testing.T) {
 			t.Errorf("unexpected non-positive River migration version: %d", fp.version)
 		}
 	}
+}
+
+const hex64 = "deadbeefdeadbeefdeadbeefdeadbeefcafebabecafebabecafebabecafebabe"
+
+// TestTemplateNameArithmetic pins the identifier-length math and ties the regex
+// {32} quantifier to templateHashPrefixLen: the produced name is the prefix plus
+// exactly the first 32 hex chars, is 59 chars (≤ Postgres's 63-char limit), and
+// matches dbNamePattern. A one-sided change to either the constant or the regex
+// breaks this.
+func TestTemplateNameArithmetic(t *testing.T) {
+	if templateHashPrefixLen != 32 {
+		t.Fatalf("templateHashPrefixLen = %d, want 32 (dbNamePattern pins {32})", templateHashPrefixLen)
+	}
+
+	name := templateNameFromHash(hex64)
+	wantName := templatePrefix + hex64[:32]
+	if name != wantName {
+		t.Errorf("templateNameFromHash: got %q, want %q", name, wantName)
+	}
+
+	const wantLen = 59 // len("personal_crm_test_template_") == 27, + 32 == 59
+	if got := len(name); got != wantLen {
+		t.Errorf("template name length: got %d, want %d", got, wantLen)
+	}
+	if len(templatePrefix)+templateHashPrefixLen != wantLen {
+		t.Errorf("len(templatePrefix)+templateHashPrefixLen = %d, want %d", len(templatePrefix)+templateHashPrefixLen, wantLen)
+	}
+	if wantLen > 63 {
+		t.Errorf("template name length %d exceeds Postgres identifier limit 63", wantLen)
+	}
+
+	// The produced name must be accepted by the create/drop guard — this is the
+	// assertion that couples the regex {32} to templateHashPrefixLen.
+	if !dbNamePattern.MatchString(name) {
+		t.Errorf("templateNameFromHash(%q) = %q does not match dbNamePattern", hex64, name)
+	}
+}
+
+// TestTemplateNameFromHashTruncationAndPanic documents that only the first 32
+// hex chars name the template (so two hashes differing only past char 32 map to
+// the SAME name — infeasible at 128 bits, but the explicit semantics), that
+// differing within the first 32 yields different names, and that a too-short
+// hash panics (the internal invariant guard).
+func TestTemplateNameFromHashTruncationAndPanic(t *testing.T) {
+	// Differ within the first 32 chars ⇒ different names.
+	a := templateNameFromHash("0000000000000000000000000000000a" + strings.Repeat("f", 32))
+	b := templateNameFromHash("0000000000000000000000000000000b" + strings.Repeat("f", 32))
+	if a == b {
+		t.Errorf("hashes differing within first 32 chars produced the same name: %q", a)
+	}
+
+	// Share the first 32 chars, differ only past char 32 ⇒ same name.
+	shared := strings.Repeat("a", 32)
+	c := templateNameFromHash(shared + strings.Repeat("0", 32))
+	d := templateNameFromHash(shared + strings.Repeat("1", 32))
+	if c != d {
+		t.Errorf("hashes sharing first 32 chars produced different names: %q vs %q", c, d)
+	}
+
+	// A hash shorter than the prefix length must panic (internal invariant).
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("templateNameFromHash with short hash did not panic")
+			}
+		}()
+		_ = templateNameFromHash(strings.Repeat("a", templateHashPrefixLen-1))
+	}()
+}
+
+// TestTemplateNameFromInputHashMatchesGuard derives a name from the real
+// migration-input hash and asserts it passes the create/drop guard — proving the
+// full pipeline (templateHashFromInputs → templateNameFromHash → dbNamePattern)
+// agrees end to end without a database.
+func TestTemplateNameFromInputHashMatchesGuard(t *testing.T) {
+	migPath := testMigrationsPath(t)
+	hash, err := templateHashFromInputs(migPath)
+	if err != nil {
+		t.Fatalf("templateHashFromInputs: %v", err)
+	}
+	name := templateNameFromHash(hash)
+	if err := assertCreatableTestDBName(name); err != nil {
+		t.Errorf("derived template name %q not creatable: %v", name, err)
+	}
+	if err := assertDroppableTestDBName(name); err != nil {
+		t.Errorf("derived template name %q not droppable: %v", name, err)
+	}
+}
+
+// TestCleanclonesMigrationsPathArithmetic pins the four-".."-hop arithmetic the
+// cmd/cleanclones command uses: the path resolved relative to a file at
+// internal/testdb/<x>/<y>/ must reach backend/migrations and contain *.up.sql.
+// A wrong hop count fails here instead of silently mis-naming the current
+// template at runtime. (This test lives at internal/testdb/, ONE level below the
+// command's internal/testdb/cmd/cleanclones/, so it uses two ".." hops to reach
+// the same backend/migrations target — the relative depth, not the literal hop
+// count, is what's pinned; the command's own four hops are asserted reachable by
+// resolving from this file's known location.)
+func TestCleanclonesMigrationsPathArithmetic(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed")
+	}
+	// This file is at backend/internal/testdb/testdb_internal_test.go.
+	// backend/migrations is two hops up (testdb → internal → backend) + migrations.
+	fromHere := filepath.Join(filepath.Dir(thisFile), "..", "..", "migrations")
+	assertDirHasUpMigrations(t, fromHere)
+
+	// The command file is two levels deeper (cmd/cleanclones), so its own
+	// resolution adds two more hops (four total). Simulate that target by
+	// descending two synthetic levels from this file's dir and climbing four.
+	cmdDir := filepath.Join(filepath.Dir(thisFile), "cmd", "cleanclones")
+	fromCmd := filepath.Join(cmdDir, "..", "..", "..", "..", "migrations")
+	assertDirHasUpMigrations(t, fromCmd)
+}
+
+func assertDirHasUpMigrations(t *testing.T, dir string) {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(dir, "*.up.sql"))
+	if err != nil {
+		t.Fatalf("glob %q: %v", dir, err)
+	}
+	if len(matches) == 0 {
+		t.Errorf("migrations dir %q resolved to no *.up.sql files (wrong hop count?)", dir)
+	}
+}
+
+// testMigrationsPath resolves backend/migrations from this test file's location
+// (two hops up from internal/testdb/).
+func testMigrationsPath(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed")
+	}
+	return filepath.Join(filepath.Dir(thisFile), "..", "..", "migrations")
 }

--- a/backend/internal/testdb/testdb_reaper_integration_test.go
+++ b/backend/internal/testdb/testdb_reaper_integration_test.go
@@ -1,0 +1,554 @@
+//go:build integration_testdb
+
+package testdb
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"personal-crm/backend/tests/testsupport"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// These DB-backed tests exercise the hash-named template + reaper machinery
+// directly against personal_crm_test. They never call SetupPackage (no clone /
+// DATABASE_URL rewrite is wanted); they connect admin and operate on synthetic,
+// test-unique templates so concurrent worktrees and sibling packages stay
+// untouchable.
+//
+// Heavy cases that run a full migration build (TestTestdbTemplateReuseSameSet,
+// TestTestdbDistinctSetsNoContention, TestTestdbMissingMarkerRebuilds) are gated
+// by testsupport.RequireLongTests and named TestTestdb* so the slow suite's
+// -run '...|TestTestdb' allow-list runs them. The cheap reaper/skip cases stay
+// un-gated and run in the fast suite; per the "Critical" design seam they call
+// reapTemplates with their OWN synthetic candidate slice only — never the global
+// CleanStaleDatabases sweep — so they are safe under the parallel suite.
+
+// requireDB skips the test unless a base DB is configured (and not short mode),
+// and returns the base URL plus an admin connection bound to t.Cleanup.
+func requireDB(t *testing.T) (baseURL string, admin *pgx.Conn) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("skipping DB-backed testdb test in short mode")
+	}
+	baseURL = envBaseURL()
+	if baseURL == "" {
+		t.Skip("skipping DB-backed testdb test; DATABASE_URL/TEST_DATABASE_URL not set")
+	}
+	baseName, err := dbNameFromURL(baseURL)
+	if err != nil {
+		t.Fatalf("dbNameFromURL: %v", err)
+	}
+	if err := assertBaseDBName(baseName); err != nil {
+		t.Fatalf("base DB guard: %v", err)
+	}
+	ctx := context.Background()
+	admin, err = connectAdmin(ctx, baseURL)
+	if err != nil {
+		t.Fatalf("connect admin: %v", err)
+	}
+	t.Cleanup(func() { _ = admin.Close(context.Background()) })
+	return baseURL, admin
+}
+
+// uniqueToken returns 16 lowercase-hex chars unique per call, used to make each
+// test's synthetic template name unique-per-run (so a deterministically-named
+// synthetic DB never collides with the same test on a -shuffle/-count iteration
+// or a concurrent worktree).
+func uniqueToken(t *testing.T) string {
+	t.Helper()
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	return hex.EncodeToString(b[:])
+}
+
+// syntheticMigDir writes a minimal valid golang-migrate migration set into a
+// fresh t.TempDir, with a table name unique to this test run. Its content hash
+// (and therefore its derived template name) is unique-per-run AND
+// deterministic-within-the-run.
+func syntheticMigDir(t *testing.T) (migPath, hash, templateName string) {
+	t.Helper()
+	dir := t.TempDir()
+	tbl := "synthetic_" + uniqueToken(t)
+	up := "CREATE TABLE " + tbl + " (id int);\n"
+	down := "DROP TABLE " + tbl + ";\n"
+	if err := os.WriteFile(filepath.Join(dir, "001_"+tbl+".up.sql"), []byte(up), 0o600); err != nil {
+		t.Fatalf("write up: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "001_"+tbl+".down.sql"), []byte(down), 0o600); err != nil {
+		t.Fatalf("write down: %v", err)
+	}
+	hash, err := templateHashFromInputs(dir)
+	if err != nil {
+		t.Fatalf("templateHashFromInputs: %v", err)
+	}
+	return dir, hash, templateNameFromHash(hash)
+}
+
+// createSyntheticTemplate creates an empty hash-named template DB and writes the
+// given marker hash into it (no migration run). It registers a name-guarded,
+// non-FORCE drop in t.Cleanup. The drop is registered FIRST so that, by LIFO
+// ordering, any later-registered connection-close cleanup runs BEFORE the drop
+// (a non-FORCE drop refuses while a session is open).
+func createSyntheticTemplate(t *testing.T, ctx context.Context, admin *pgx.Conn, baseURL, templateName, markerHash string) {
+	t.Helper()
+	if err := createDatabaseConn(ctx, admin, templateName); err != nil {
+		t.Fatalf("create synthetic template %q: %v", templateName, err)
+	}
+	t.Cleanup(func() {
+		if err := dropDatabaseNoForceConn(context.Background(), admin, templateName); err != nil {
+			t.Logf("cleanup drop %q (non-fatal): %v", templateName, err)
+		}
+	})
+	if markerHash != "" {
+		templateURL, err := withDatabase(baseURL, templateName)
+		if err != nil {
+			t.Fatalf("template url: %v", err)
+		}
+		if err := writeTemplateMarker(ctx, templateURL, markerHash); err != nil {
+			t.Fatalf("write synthetic marker: %v", err)
+		}
+	}
+}
+
+func mustOID(t *testing.T, ctx context.Context, admin *pgx.Conn, name string) uint32 {
+	t.Helper()
+	oid, ok, err := databaseOID(ctx, admin, name)
+	if err != nil {
+		t.Fatalf("databaseOID(%q): %v", name, err)
+	}
+	if !ok {
+		t.Fatalf("expected database %q to exist", name)
+	}
+	return oid
+}
+
+// TestTestdbTemplateReuseSameSet [heavy]: building a template for a migration
+// set, then calling ensureTemplate again for the SAME set, reuses it — the
+// template name is unchanged, the OID is unchanged (no drop+rebuild), and the
+// marker still equals the set's hash.
+func TestTestdbTemplateReuseSameSet(t *testing.T) {
+	testsupport.RequireLongTests(t)
+	baseURL, admin := requireDB(t)
+	ctx := context.Background()
+
+	migPath, wantHash, templateName := syntheticMigDir(t)
+	// Drop the synthetic template at the end regardless of which path built it.
+	t.Cleanup(func() {
+		if err := dropDatabaseNoForceConn(context.Background(), admin, templateName); err != nil {
+			t.Logf("cleanup drop %q (non-fatal): %v", templateName, err)
+		}
+	})
+
+	if err := ensureTemplate(ctx, baseURL, migPath); err != nil {
+		t.Fatalf("first ensureTemplate: %v", err)
+	}
+	firstOID := mustOID(t, ctx, admin, templateName)
+
+	if err := ensureTemplate(ctx, baseURL, migPath); err != nil {
+		t.Fatalf("second ensureTemplate: %v", err)
+	}
+	secondOID := mustOID(t, ctx, admin, templateName)
+	if firstOID != secondOID {
+		t.Errorf("template was rebuilt on reuse: OID %d → %d", firstOID, secondOID)
+	}
+
+	gotHash, ok, err := readTemplateMarker(ctx, baseURL, templateName)
+	if err != nil {
+		t.Fatalf("readTemplateMarker: %v", err)
+	}
+	if !ok || gotHash != wantHash {
+		t.Errorf("marker after reuse: got (%q, present=%t), want %q", gotHash, ok, wantHash)
+	}
+}
+
+// TestTestdbDistinctSetsNoContention [heavy]: two distinct migration sets build
+// two distinct templates that coexist; building the second leaves the first's
+// OID and marker untouched. The core anti-contention proof.
+func TestTestdbDistinctSetsNoContention(t *testing.T) {
+	testsupport.RequireLongTests(t)
+	baseURL, admin := requireDB(t)
+	ctx := context.Background()
+
+	migA, hashA, nameA := syntheticMigDir(t)
+	migB, hashB, nameB := syntheticMigDir(t)
+	if nameA == nameB {
+		t.Fatalf("synthetic sets collided on a template name: %q", nameA)
+	}
+	for _, n := range []string{nameA, nameB} {
+		n := n
+		t.Cleanup(func() {
+			if err := dropDatabaseNoForceConn(context.Background(), admin, n); err != nil {
+				t.Logf("cleanup drop %q (non-fatal): %v", n, err)
+			}
+		})
+	}
+
+	if err := ensureTemplate(ctx, baseURL, migA); err != nil {
+		t.Fatalf("ensureTemplate A: %v", err)
+	}
+	oidA := mustOID(t, ctx, admin, nameA)
+
+	if err := ensureTemplate(ctx, baseURL, migB); err != nil {
+		t.Fatalf("ensureTemplate B: %v", err)
+	}
+
+	// Both templates exist concurrently.
+	for _, n := range []string{nameA, nameB} {
+		exists, err := databaseExists(ctx, admin, n)
+		if err != nil {
+			t.Fatalf("databaseExists(%q): %v", n, err)
+		}
+		if !exists {
+			t.Errorf("expected template %q to exist", n)
+		}
+	}
+
+	// Building B did not disturb A.
+	if got := mustOID(t, ctx, admin, nameA); got != oidA {
+		t.Errorf("building set B rebuilt template A: OID %d → %d", oidA, got)
+	}
+	if gotHash, ok, err := readTemplateMarker(ctx, baseURL, nameA); err != nil {
+		t.Fatalf("readTemplateMarker A: %v", err)
+	} else if !ok || gotHash != hashA {
+		t.Errorf("template A marker disturbed: got (%q, present=%t), want %q", gotHash, ok, hashA)
+	}
+	if gotHash, ok, err := readTemplateMarker(ctx, baseURL, nameB); err != nil {
+		t.Fatalf("readTemplateMarker B: %v", err)
+	} else if !ok || gotHash != hashB {
+		t.Errorf("template B marker wrong: got (%q, present=%t), want %q", gotHash, ok, hashB)
+	}
+}
+
+// TestTestdbMissingMarkerRebuilds [heavy]: a template DB that exists but has NO
+// marker (a crashed/partial build) is dropped and rebuilt by ensureTemplate, and
+// the rebuilt template's marker equals the set's hash. Pins D3's surviving
+// recovery branch.
+func TestTestdbMissingMarkerRebuilds(t *testing.T) {
+	testsupport.RequireLongTests(t)
+	baseURL, admin := requireDB(t)
+	ctx := context.Background()
+
+	migPath, wantHash, templateName := syntheticMigDir(t)
+	// Create the matching-named template WITHOUT a marker (empty DB).
+	createSyntheticTemplate(t, ctx, admin, baseURL, templateName, "")
+	partialOID := mustOID(t, ctx, admin, templateName)
+
+	if err := ensureTemplate(ctx, baseURL, migPath); err != nil {
+		t.Fatalf("ensureTemplate: %v", err)
+	}
+	rebuiltOID := mustOID(t, ctx, admin, templateName)
+	if rebuiltOID == partialOID {
+		t.Errorf("partial template was not rebuilt: OID unchanged (%d)", partialOID)
+	}
+	gotHash, ok, err := readTemplateMarker(ctx, baseURL, templateName)
+	if err != nil {
+		t.Fatalf("readTemplateMarker: %v", err)
+	}
+	if !ok || gotHash != wantHash {
+		t.Errorf("marker after rebuild: got (%q, present=%t), want %q", gotHash, ok, wantHash)
+	}
+}
+
+// TestTestdbWrongMarkerFailsLoud [cheap]: a template DB whose marker hash differs
+// from the hash its name implies makes ensureTemplate FAIL LOUD without silently
+// dropping and rebuilding (OID unchanged). Pins the D3 removal. No migration run
+// happens (the wrong-marker branch errors before building).
+func TestTestdbWrongMarkerFailsLoud(t *testing.T) {
+	baseURL, admin := requireDB(t)
+	ctx := context.Background()
+
+	migPath, _, templateName := syntheticMigDir(t)
+	// Write a marker whose hash differs from the synthetic set's hash.
+	wrongHash := strings.Repeat("0", 64)
+	createSyntheticTemplate(t, ctx, admin, baseURL, templateName, wrongHash)
+	beforeOID := mustOID(t, ctx, admin, templateName)
+
+	err := ensureTemplate(ctx, baseURL, migPath)
+	if err == nil {
+		t.Fatal("expected ensureTemplate to fail loud on a present-but-wrong marker")
+	}
+	if !strings.Contains(err.Error(), "corrupted/incompatible template") {
+		t.Errorf("error %q does not mention corrupted/incompatible template", err)
+	}
+	// No silent drop+rebuild.
+	afterOID := mustOID(t, ctx, admin, templateName)
+	if afterOID != beforeOID {
+		t.Errorf("wrong-marker template was silently rebuilt: OID %d → %d", beforeOID, afterOID)
+	}
+}
+
+// TestTestdbReaperSweepsStaleTemplate [cheap]: reapTemplates, handed a synthetic
+// stale template's name as its candidate slice, drops it. Uses the scoped seam
+// (NOT the global CleanStaleDatabases sweep), so it can never touch a template it
+// did not create.
+func TestTestdbReaperSweepsStaleTemplate(t *testing.T) {
+	baseURL, admin := requireDB(t)
+	ctx := context.Background()
+
+	_, hash, templateName := syntheticMigDir(t)
+	createSyntheticTemplate(t, ctx, admin, baseURL, templateName, hash)
+
+	dropped, err := reapTemplates(ctx, admin, []string{templateName}, "")
+	if err != nil {
+		t.Fatalf("reapTemplates: %v", err)
+	}
+	if dropped != 1 {
+		t.Errorf("dropped = %d, want 1", dropped)
+	}
+	exists, err := databaseExists(ctx, admin, templateName)
+	if err != nil {
+		t.Fatalf("databaseExists: %v", err)
+	}
+	if exists {
+		t.Errorf("stale template %q still exists after reap", templateName)
+	}
+}
+
+// TestTestdbReaperBlocksOnAdvisoryLock [load-bearing]: the reaper cannot drop a
+// template while a build/clone critical section holds the advisory lock. Hold
+// the lock on a dedicated admin conn, run reapTemplates in a goroutine, assert it
+// BLOCKS (the synthetic template still exists) while the lock is held, then
+// release and assert it proceeds and drops. This proves the round-1 clone-copy
+// race is closed by serialization, not by a connection count.
+func TestTestdbReaperBlocksOnAdvisoryLock(t *testing.T) {
+	baseURL, admin := requireDB(t)
+	ctx := context.Background()
+
+	_, hash, templateName := syntheticMigDir(t)
+	createSyntheticTemplate(t, ctx, admin, baseURL, templateName, hash)
+
+	// Three distinct connections: `holder` holds the lock, `reaperConn` runs the
+	// blocked reapTemplates in a goroutine, and `admin` stays free for the main
+	// goroutine's databaseExists checks. A single *pgx.Conn is NOT safe for
+	// concurrent use, so the reaper must not share `admin`.
+	holder, err := connectAdmin(ctx, baseURL)
+	if err != nil {
+		t.Fatalf("connect lock holder: %v", err)
+	}
+	defer func() { _ = holder.Close(context.Background()) }()
+
+	reaperConn, err := connectAdmin(ctx, baseURL)
+	if err != nil {
+		t.Fatalf("connect reaper conn: %v", err)
+	}
+	defer func() { _ = reaperConn.Close(context.Background()) }()
+
+	if _, err := holder.Exec(ctx, "SELECT pg_advisory_lock($1)", templateBuildAdvisoryLockID); err != nil {
+		t.Fatalf("acquire lock on holder: %v", err)
+	}
+	lockReleased := false
+	releaseLock := func() {
+		if lockReleased {
+			return
+		}
+		lockReleased = true
+		if _, err := holder.Exec(context.Background(), "SELECT pg_advisory_unlock($1)", templateBuildAdvisoryLockID); err != nil {
+			t.Logf("release lock (non-fatal): %v", err)
+		}
+	}
+	defer releaseLock()
+
+	var wg sync.WaitGroup
+	var reapErr error
+	done := make(chan struct{})
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, reapErr = reapTemplates(ctx, reaperConn, []string{templateName}, "")
+		close(done)
+	}()
+
+	// While the lock is held, the reaper must block: the synthetic template
+	// stays present. Give the goroutine time to reach the lock acquire.
+	select {
+	case <-done:
+		t.Fatal("reapTemplates returned while the advisory lock was held; it must block")
+	case <-time.After(500 * time.Millisecond):
+	}
+	exists, err := databaseExists(ctx, admin, templateName)
+	if err != nil {
+		t.Fatalf("databaseExists while blocked: %v", err)
+	}
+	if !exists {
+		t.Fatal("synthetic template dropped while the advisory lock was held")
+	}
+
+	// Release the lock; the reaper should now proceed and drop.
+	releaseLock()
+	wg.Wait()
+	if reapErr != nil {
+		t.Fatalf("reapTemplates after lock release: %v", reapErr)
+	}
+	exists, err = databaseExists(ctx, admin, templateName)
+	if err != nil {
+		t.Fatalf("databaseExists after release: %v", err)
+	}
+	if exists {
+		t.Errorf("synthetic template %q still exists after the reaper proceeded", templateName)
+	}
+}
+
+// TestTestdbReaperSkipsOpenSession [cheap]: a synthetic template with a live
+// session (numbackends >= 1) is skipped — not dropped, not terminated — and
+// reapTemplates returns nil (a skip is not an error). After the session closes a
+// re-run drops it.
+func TestTestdbReaperSkipsOpenSession(t *testing.T) {
+	baseURL, admin := requireDB(t)
+	ctx := context.Background()
+
+	_, hash, templateName := syntheticMigDir(t)
+	// Register the synthetic-template drop FIRST so it runs LAST (LIFO); the
+	// session-close cleanup registered next runs BEFORE the drop, so the
+	// non-FORCE cleanup drop never refuses on an open session.
+	createSyntheticTemplate(t, ctx, admin, baseURL, templateName, hash)
+
+	templateURL, err := withDatabase(baseURL, templateName)
+	if err != nil {
+		t.Fatalf("template url: %v", err)
+	}
+	sess, err := pgx.Connect(ctx, templateURL)
+	if err != nil {
+		t.Fatalf("open session on template: %v", err)
+	}
+	sessClosed := false
+	closeSess := func() {
+		if sessClosed {
+			return
+		}
+		sessClosed = true
+		_ = sess.Close(context.Background())
+	}
+	t.Cleanup(closeSess)
+
+	dropped, err := reapTemplates(ctx, admin, []string{templateName}, "")
+	if err != nil {
+		t.Fatalf("reapTemplates with open session returned error (a skip must not error): %v", err)
+	}
+	if dropped != 0 {
+		t.Errorf("dropped = %d, want 0 (open session must be skipped)", dropped)
+	}
+	exists, err := databaseExists(ctx, admin, templateName)
+	if err != nil {
+		t.Fatalf("databaseExists: %v", err)
+	}
+	if !exists {
+		t.Fatal("synthetic template with an open session was dropped")
+	}
+
+	// Close the session and re-run: now it drops, still returning nil.
+	closeSess()
+	// pg_stat_database can lag a beat after a close; retry briefly.
+	var dropped2 int
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		dropped2, err = reapTemplates(ctx, admin, []string{templateName}, "")
+		if err != nil {
+			t.Fatalf("reapTemplates after close: %v", err)
+		}
+		if dropped2 == 1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("template not dropped after session close within deadline (dropped=%d)", dropped2)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	exists, err = databaseExists(ctx, admin, templateName)
+	if err != nil {
+		t.Fatalf("databaseExists after close: %v", err)
+	}
+	if exists {
+		t.Errorf("template not dropped after session closed")
+	}
+}
+
+// TestTestdbReaperKeepsCurrentTemplate [cheap]: passing a candidate as the
+// currentTemplateName excludes it from the drop set — the current-hash exclusion
+// independent of the connection check.
+func TestTestdbReaperKeepsCurrentTemplate(t *testing.T) {
+	baseURL, admin := requireDB(t)
+	ctx := context.Background()
+
+	_, hash, templateName := syntheticMigDir(t)
+	createSyntheticTemplate(t, ctx, admin, baseURL, templateName, hash)
+
+	dropped, err := reapTemplates(ctx, admin, []string{templateName}, templateName)
+	if err != nil {
+		t.Fatalf("reapTemplates: %v", err)
+	}
+	if dropped != 0 {
+		t.Errorf("dropped = %d, want 0 (current template must be kept)", dropped)
+	}
+	exists, err := databaseExists(ctx, admin, templateName)
+	if err != nil {
+		t.Fatalf("databaseExists: %v", err)
+	}
+	if !exists {
+		t.Errorf("current template %q was dropped", templateName)
+	}
+}
+
+// TestTestdbListStaleTemplateCandidates [lists only, never drops]: the global
+// LIKE-listing + current-hash exclusion, asserted with SUBSET semantics (the
+// shared instance may hold other worktrees' templates). Drops nothing, so it is
+// safe under the parallel suite.
+func TestTestdbListStaleTemplateCandidates(t *testing.T) {
+	baseURL, admin := requireDB(t)
+	ctx := context.Background()
+
+	_, hashA, nameA := syntheticMigDir(t)
+	_, hashB, nameB := syntheticMigDir(t)
+	createSyntheticTemplate(t, ctx, admin, baseURL, nameA, hashA)
+	createSyntheticTemplate(t, ctx, admin, baseURL, nameB, hashB)
+
+	// A non-matching name (a clone-shaped DB) must never appear in the template
+	// candidate list. Create + clean it up.
+	cloneName := clonePrefix + uniqueToken(t)
+	if err := createDatabaseConn(ctx, admin, cloneName); err != nil {
+		t.Fatalf("create decoy clone: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := dropDatabaseConn(context.Background(), admin, cloneName); err != nil {
+			t.Logf("cleanup decoy clone %q (non-fatal): %v", cloneName, err)
+		}
+	})
+
+	// Exclude nameA as the current template; nameB should remain a candidate.
+	candidates, err := listStaleTemplateCandidates(ctx, admin, nameA)
+	if err != nil {
+		t.Fatalf("listStaleTemplateCandidates: %v", err)
+	}
+	set := make(map[string]bool, len(candidates))
+	for _, c := range candidates {
+		set[c] = true
+	}
+	if set[nameA] {
+		t.Errorf("current template %q should be excluded from candidates", nameA)
+	}
+	if !set[nameB] {
+		t.Errorf("seeded template %q should be a candidate", nameB)
+	}
+	if set[cloneName] {
+		t.Errorf("clone-shaped name %q must not appear in template candidates", cloneName)
+	}
+}
+
+// errorsJoinNil is a tiny guard documenting that errors.Join over only-nils is
+// nil — relied on by CleanStaleDatabases when nothing needs dropping.
+func TestErrorsJoinNilIsNil(t *testing.T) {
+	if errors.Join(nil, nil) != nil {
+		t.Error("errors.Join(nil, nil) should be nil")
+	}
+}

--- a/backend/internal/testdb/testdb_reaper_integration_test.go
+++ b/backend/internal/testdb/testdb_reaper_integration_test.go
@@ -449,10 +449,12 @@ func TestTestdbReaperSkipsOpenSession(t *testing.T) {
 
 	// Close the session and re-run: now it drops, still returning nil.
 	closeSess()
-	// pg_stat_database can lag a beat after a close; retry briefly.
+	// pg_stat_database can lag a beat after a close; retry a bounded number of
+	// attempts. A fixed attempt count (not wall-clock arithmetic) keeps this
+	// free of time.Now() per core rule #1 / plan D9.
+	const maxAttempts = 30 // ~3s total at 100ms between attempts
 	var dropped2 int
-	deadline := time.Now().Add(3 * time.Second)
-	for {
+	for attempt := 0; attempt < maxAttempts; attempt++ {
 		dropped2, err = reapTemplates(ctx, admin, []string{templateName}, "")
 		if err != nil {
 			t.Fatalf("reapTemplates after close: %v", err)
@@ -460,10 +462,10 @@ func TestTestdbReaperSkipsOpenSession(t *testing.T) {
 		if dropped2 == 1 {
 			break
 		}
-		if time.Now().After(deadline) {
-			t.Fatalf("template not dropped after session close within deadline (dropped=%d)", dropped2)
-		}
 		time.Sleep(100 * time.Millisecond)
+	}
+	if dropped2 != 1 {
+		t.Fatalf("template not dropped after session close within %d attempts (dropped=%d)", maxAttempts, dropped2)
 	}
 	exists, err = databaseExists(ctx, admin, templateName)
 	if err != nil {


### PR DESCRIPTION
## What

PR1 of 2 for the test-suite parallelization effort (#413), Component 2 only — the `testdb` harness change. Component 1 (the `t.Parallel()` audit → flip) follows in PR2 and is explicitly out of scope here.

Today the build-tagged `integration_testdb` harness gives every `go test` package a fresh clone from a single fixed-name template `personal_crm_test_template`. Two concurrent worktree agents on branches with divergent migrations compute different content-hashes but target that one name, so they fight over it — each drop+rebuilds it to its own hash and invalidates the other's clone (a safe-but-mutually-flaky contention). A single developer eats the same cost benignly: every branch-switch across migration sets forces a full template rebuild. This PR names the template by its migration content-hash so each migration set keeps its own template and they never contend, and adds a reaper so the now-multiple templates don't accumulate without bound.

## Changes

- **Hash-named templates** `personal_crm_test_template_<32-hex>`, derived from the existing `templateHashFromInputs` sha256 (27 + 32 = 59 ≤ Postgres's 63-char identifier limit; 32 hex = 128 bits, collision-free across coexisting migration sets). The derived `templateName` is threaded through `ensureTemplate`/`buildTemplate`/`readTemplateMarker`/`createCloneFromTemplate`. `dbNamePattern` is tightened to `^personal_crm_test_(template_[0-9a-f]{32}|clone_[0-9a-f]+)$` — pinned to exactly `{32}` (the validation counterpart of `templateHashPrefixLen`, coupled by a unit assertion) and the bare legacy `template` alternative dropped.
- **Marker-branch split (D3):** `ensureTemplate`'s existing-template path now branches three ways instead of two — reuse on a matching marker; drop+rebuild only on a missing marker (the surviving crash/partial-build recovery); fail loud on a present-but-wrong marker (a logically-impossible state under hash-naming) instead of silently dropping+rebuilding, so real corruption surfaces rather than being masked. The clone-time re-verify guard is kept and simplified to a pure should-never-fail assertion.
- **Template reaper:** the explicit sweep (`make test-clean-clones`) now reaps stale templates as well as leaked clones, in a single pass. `CleanClones()` becomes a thin shim over a new `CleanStaleDatabases(migrationsPath)`. The template drop pass runs inside `templateBuildAdvisoryLockID` — the same lock every build/clone holds — so no `CREATE … TEMPLATE` copy can be in flight while it drops; that advisory-lock serialization is the load-bearing safety mechanism (a per-template `numbackends` skip is only belt-and-suspenders for a stray manual session, and templates use a NON-FORCE drop so Postgres refuses rather than terminating a live session). The current run's template is excluded from the sweep (kept warm) when the migrations path resolves; `cmd/cleanclones` resolves it via `MIGRATIONS_PATH` or a four-hop `runtime.Caller` path. `listStaleTemplateCandidates` and `reapTemplates` are split so tests drive the reaper with their own injected candidate slice and never run the destructive global sweep under the parallel suite.
- **Raw SQL:** no new raw SQL outside the harness's pre-existing, documented maintenance/admin-connection allow-list. The package doc comment is extended to enumerate the additions (a NON-FORCE `DROP DATABASE`, the `template_%` `LIKE` listing, the `numbackends` read, and a test-only `oid` read used to detect drop+recreate without a sentinel write).

## Operating model and scope

The reaper is safe against an in-flight clone *copy* (advisory-lock serialization). It is NOT claimed safe to run concurrently with a *different worktree's* still-running test process on a divergent migration set (the lock is released between that process's individual operations). The operating model is therefore "run `make test-clean-clones` when no integration tests are in flight" — the same precondition the existing clone reaper already documents. The stronger cross-worktree-concurrent guarantee is deferred to #424.

## Tests

- Extended `TestNameGuards`: accept `template_<32-hex>`, reject the bare legacy name, empty/non-hex/31-or-33-hex/whitespace/injection.
- Pure unit tests (no DB): name arithmetic (length 59 ≤ 63, regex `{32}` coupled to `templateHashPrefixLen`, truncation semantics, the short-hash panic guard) and the `cmd/cleanclones` four-hop migrations-path resolution.
- New tagged `testdb_reaper_integration_test.go` driving the harness directly (no `SetupPackage` clone): reuse (same set ⇒ same name ⇒ no rebuild, OID-stable), distinct-sets-no-contention (two templates coexist, building one doesn't disturb the other), missing-marker rebuild, wrong-marker fail-loud (no silent rebuild), and the reaper paths. Each reaper case drives `reapTemplates` with its OWN test-unique synthetic candidate slice (never the global sweep), so it's safe under the parallel suite; the load-bearing case holds the advisory lock on a dedicated connection and proves the reaper BLOCKS while a build/clone critical section holds it, then drops once released.
- Heavy cases that run a full migration build are gated by `RequireLongTests` and named `TestTestdb*`; `|TestTestdb` is appended to `BACKEND_SLOW_TESTS_REGEX` so the slow suite (and the `backend-slow-tests` CI workflow, which runs `test-integration-slow`) runs them. No edit to the slow-workflow file itself is needed.

Verification: `go build ./cmd/crm-api` clean (prod build excludes the tagged harness), `make lint` 0 issues, `make test-integration-fast` and full `make test-integration` (LONG_TESTS) green across all packages, determinism shake-out `LONG_TESTS=1 go test -tags integration_testdb -race -count=5 -shuffle=on -run TestTestdb ./internal/testdb/...` clean, `staticcheck -tags integration_testdb` clean, and an end-to-end `make test-clean-clones` correctly reaped a leaked synthetic template while keeping the live one and the legacy bare name untouched.

## Known non-blockers

Surfaced from review for human awareness; intentionally not fixed in this PR.

- `CleanClones()` is now a no-internal-caller shim over `CleanStaleDatabases("")`, kept for backward-compat / any external callers of the exported API. Candidate for follow-up removal if confirmed unused.
- No explicit test asserts the bare legacy `personal_crm_test_template` name is excluded from the reaper's `LIKE` listing. It is double-protected at runtime: the tightened `dbNamePattern` rejects it from both the create/drop guard and the `{32}`-anchored sweep, so the reaper cannot list or drop it.

## Operational note

A dev box that predates this PR may hold one leftover bare `personal_crm_test_template` database. Under the new scheme it is inert (never a clone source) and the name guard refuses to drop it, so the reaper leaves it alone. One-time manual reclaim if you want the space back: `DROP DATABASE personal_crm_test_template`. CI's Postgres is ephemeral, so it never has a legacy template and is unaffected.

Closes part of #413 (Component 2). PR2 (Component 1: `t.Parallel()` audit → flip) follows.
