### PR TITLE
perf(tests): within-run t.Parallel() flip of backend/tests (#413)

### DIFF
--- a/.ai/spec/2026-06-08-test-parallelization-audit.md
+++ b/.ai/spec/2026-06-08-test-parallelization-audit.md
@@ -8,12 +8,18 @@ All **80** top-level `backend/tests` files are classified — zero duplicates, z
 
 | Bucket | Distinct files | Action |
 |--------|---------------|--------|
-| scoped-safe | 28 | flip the top-level funcs (some need a `gin.SetMode` hoist first — see D3.5) |
-| needs-scoping | 13 | scope assertions/fixtures, then flip |
+| scoped-safe | 27 | flip the top-level funcs (some need a `gin.SetMode` hoist first — see D3.5) |
+| needs-scoping | 14 | scope assertions/fixtures, then flip |
 | river-heavy | 30 | stay serial (live `river.NewClient(TestOnly:true)` shares the package clone's `river_job`) |
 | inherently-serial | 4 | stay serial (process globals / fixed-id singletons / shared on-disk fixtures) |
 | mixed | 5 | flip per-func (scoped-safe + scoped funcs) and leave the river/serial funcs serial |
 | **Total** | **80** | |
+
+**Reclassifications found during the `-count=10`/`-shuffle` validation (the audit's static read missed these):**
+- `telegram_discovery_upsert_test.go` — audit said scoped-safe, but its funcs share fixed source_ids (`tg-discovery-upsert-<name>`) and a prefix-wide setup cleanup, plus a fixed peer `99001`/chat `9900` in the batch func. Moved to **needs-scoping**: per-test-unique source_id prefix (`syntheticNS`) + `uniqueTestIDs`-derived peer/chat. So scoped-safe drops to 27, needs-scoping rises to 14.
+- `gmail_enablement_reconcile_test.go`'s `TestResetGmailBackfillCursors_ResetsOnlyEnabledEmailStates` — `ResetGmailBackfillCursors` scans/mutates ALL enabled email states DB-wide and asserts an exact Scanned/Reset count. **That one func stays SERIAL** (inherently global); the file's other 9 funcs flip.
+- Two `ListContacts(limit 100)` membership checks (`cadence_filter`, `interaction_direction` `TestFollowupFilter`) overflowed the page once the shared DB accumulated >100 contacts under `-count=10`; raised the limit so own-ID membership stays in-window.
+- `contact_task` `TestContactTask_CountByProvider` used a DB-wide `DeleteContactTasksByProvider("todoist")` cleanup that deleted parallel tests' tasks; scoped to delete only its own task IDs.
 
 Notes on the count:
 - 4 of the 28 scoped-safe and 1 of the 5 mixed entries are helper/zero-func files (`gmail_time_helpers_test.go`, `synthetic_migration_helpers_test.go`, `testmain_integration_test.go`, `test_event_bus_harness_test.go`) — no `TestXxx` to flip; listed for completeness.
@@ -126,11 +132,13 @@ Each builds a live `river.NewClient(TestOnly:true)` and/or drains `river_job` on
 
 _Measured on a 12-core dev box (GOMAXPROCS=12), Postgres `max_connections=100`, with a freshly-cleaned test DB. CI timing is reported separately from the CI run logs._
 
-| Metric | Before (`main`) | After (flip, tuned) |
-|--------|-----------------|---------------------|
-| (a) `make test-integration-fast` wall-clock | ~29s | _TBD_ |
-| (b) `go test ./tests/` package wall-clock | ~20s (17.8s internal) | _TBD_ |
+| Metric | Before (`main`) | After (flip, tuned) | Ratio |
+|--------|-----------------|---------------------|-------|
+| (a) `make test-integration-fast` wall-clock | ~29s | ~26s | ~1.12× |
+| (b) `go test ./tests/ -parallel 4` package wall-clock | ~20s (17.0s internal) | ~17s (16.0s internal) | ~1.18× |
 
-At baseline the fast-suite wall-clock (~29s) is set by `tests/api` (27.5s internal, deferred to #429), which runs concurrently above the `tests` package this PR speeds up. So the flip's win shows up most directly in metric (b), and only partially in (a) until `tests/api` is also parallelized.
+At baseline the fast-suite wall-clock (~29s) is set by `tests/api` (~24-27s internal, deferred to #429), which runs concurrently above the `tests` package this PR speeds up. So the flip's win shows up most directly in metric (b), and only partially in (a) until `tests/api` is also parallelized.
 
-Amdahl note: the whole-package (b) speedup is bounded by the serial River floor (~23 non-long-gated river-heavy files + 4 inherently-serial + the mixed files' serial funcs). The larger speedup applies to the parallelizable subset; the residual is the deferred per-test-River-isolation effort (#428), not a regression.
+Amdahl note: the whole-package (b) speedup is bounded by the serial River floor (~23 non-long-gated river-heavy files + 4 inherently-serial + the mixed files' serial funcs). Go runs the serial cohort to completion BEFORE the parallel cohort, so the River floor is paid in full first; the modest ~1.18× whole-package ratio is the correct, expected outcome (the parallelizable subset alone is much faster). The residual is the deferred per-test-River-isolation effort (#428), not a regression. There is no fixed-multiplier gate — the honest measured number ships as-is.
+
+**Flake validation (all on the flipped set, river-heavy serial funcs run alongside):** `-race -parallel 4` PASS (no data races); `-parallel 4 -count=10` PASS; `-shuffle=on -parallel 4` PASS; combined `-race -shuffle=on -parallel 4 -count=5` PASS. Exception: the 5 `TestIntegration_CreateWorker_*` funcs in `followup_create_worker_integration_test.go` (river-heavy, SERIAL, untouched by this PR) fail under `-count>=2` because they use fixed `external_task_id` literals (`real-123`, etc.) that collide on the global `unique_external_task_id` on the 2nd iteration. This reproduces identically in isolation and on `main` — a pre-existing `-count` limitation of the serial river suite, orthogonal to the flip; tracked with the River parallelization effort (#428). The `-count` gates above `-skip 'TestIntegration_CreateWorker'` for that reason; the normal `-count=1` fast + LONG_TESTS suites run it and pass.

--- a/.ai/spec/2026-06-08-test-parallelization-audit.md
+++ b/.ai/spec/2026-06-08-test-parallelization-audit.md
@@ -1,0 +1,136 @@
+# `backend/tests` `t.Parallel()` Audit — Classification Table
+
+Companion to `.ai/spec/2026-06-07-test-parallelization-design.md` (Component 1 — within-run parallelism). This is the per-file classification of every `backend/tests` top-level file into one of five buckets, with the concrete action taken in the flip PR (#413). It is the done-definition for the flip: every file is classified + actioned exactly as recorded here.
+
+## Authoritative counts
+
+All **80** top-level `backend/tests` files are classified — zero duplicates, zero gaps.
+
+| Bucket | Distinct files | Action |
+|--------|---------------|--------|
+| scoped-safe | 28 | flip the top-level funcs (some need a `gin.SetMode` hoist first — see D3.5) |
+| needs-scoping | 13 | scope assertions/fixtures, then flip |
+| river-heavy | 30 | stay serial (live `river.NewClient(TestOnly:true)` shares the package clone's `river_job`) |
+| inherently-serial | 4 | stay serial (process globals / fixed-id singletons / shared on-disk fixtures) |
+| mixed | 5 | flip per-func (scoped-safe + scoped funcs) and leave the river/serial funcs serial |
+| **Total** | **80** | |
+
+Notes on the count:
+- 4 of the 28 scoped-safe and 1 of the 5 mixed entries are helper/zero-func files (`gmail_time_helpers_test.go`, `synthetic_migration_helpers_test.go`, `testmain_integration_test.go`, `test_event_bus_harness_test.go`) — no `TestXxx` to flip; listed for completeness.
+- **River-heavy = 30 distinct files.** An earlier working pass double-listed `gmail_golive_integration_test.go` (identical river-heavy/serial classification both times); it is one file.
+- **7 files are `RequireLongTests`-gated** (the `synthetic_*` provider/replay/profile/seed/golden set) and skip the fast suite entirely. Leaving them serial has zero effect on fast-suite / pre-push wall-clock.
+- **Scoping work before flip = 15 actions:** the 13 pure needs-scoping files + the needs-scoping sub-work in the 2 mixed files `identity_integration_test.go` and `integration_test.go`.
+
+## Key planning findings
+
+- **The parallelization win comes entirely from the non-long-gated scoped-safe + needs-scoping files.** The 7 long-gated files skip the fast suite; the 30 river-heavy + 4 inherently-serial files stay serial.
+- **~23 non-long-gated river-heavy files still run in the fast suite and stay serial.** These (`address_book_reconcile`, `calendar_decline_cutover`, `comms_gchat_engine`, `consumer_interaction_recorder`, `email_interaction`, `followup_apply_interaction`, `followup_create_worker`, `followup_manager_cutover`, `gchat_golive`, `gmail_correspondence`, `gmail_golive`, `gmail_provider`, `gmail_rematch`, `rematch_dispatcher_unique_opts`, `rematch_event_dedup`, `rematch_integration`, `river_integration`, `suggestion_service`, `sync_repo_enqueue`, `synthetic_reset`, the three `telegram_aggregation*` files, plus the river-heavy funcs of `event_bus`/`gchat_provider`/`synthetic_golden`) carry ~90+ test funcs and dominate fast-suite serial time. They cannot be sped up without per-test River-client isolation — out of scope for this flip (the recorded future lever; tracked as #428).
+- **Go scheduling semantics for mixed packages:** within one package, all non-`t.Parallel()` funcs run to completion (sequentially) FIRST, and only then does the `t.Parallel()` cohort run concurrently. So the serial River funcs gate the parallel cohort rather than overlapping it. This is the Amdahl floor — the serial fraction is paid in full before any parallel speedup.
+- **Helper/zero-func files:** `gmail_time_helpers_test.go`, `synthetic_migration_helpers_test.go`, `testmain_integration_test.go` (TestMain only), `test_event_bus_harness_test.go` (the shared River harness every river-heavy file depends on) have zero `TestXxx` — nothing to flip.
+- **Inherently-serial conversion opportunities (out of scope here):** `telegram_state_storage` (fixed consts 99999/88888) and `unit_test.go`'s `gin.SetMode` global could in principle be reworked, but `telegram_session` (id=1 singleton) is genuinely unconvertible. Left serial.
+
+## Subpackage confirmation / deferral
+
+This audit covers ONLY the top-level `backend/tests` package (one Go package, one `TestMain` clone). The fast suite (`make test-integration-fast`) also compiles and runs these sibling packages — their handling:
+
+- **CONFIRMED serial — `tests/river` (2 funcs), `tests/scheduler` (1 func):** river-heavy by construction (live River clients). Stay serial; no parallelism benefit. This matches the design spec's "already safe" outcome for the no-benefit case.
+- **DEFERRED — `tests/api` (~241 funcs) and `tests/unit` (64 funcs):** NOT covered by this audit. `tests/api` is a large, genuinely parallelizable opportunity, but flipping it correctly needs the SAME per-file audit (handler tests, shared `gin` mode, DB-backed vs `httptest`, fixed-id fixtures). That audit does not exist yet. Tracked as a follow-up (#429). This PR does not assert these are "safe or trivially convertible."
+- **DEFERRED — `internal/google`, `internal/todoist`:** mock-based, mostly no DB, low parallelism yield. NOT audited; NOT claimed safe.
+
+## Needs-scoping actions (do these before flipping the file)
+
+Each action matches the existing toolkit/namespace pattern already used in the file (`syntheticNS(t)` / `migrationGenerator(t).Prefix()` / `gen.Prefix()`); a local per-test `uuid` suffix where the file does not import the toolkit. No raw SQL — a fixture that genuinely needs a new query gets a test-only sqlc query + repository wrapper.
+
+1. **`cadence_filter_integration_test.go`** — Scope the `CountContacts_HasCadence` sub-test's `totalHas`/`totalNo` (currently unscoped DB-wide `CountContacts("has_cadence","")>0`) to count only this test's own `syntheticNS`-prefixed rows (or restate as a before/after delta). List/ID sub-tests already ID-scoped.
+2. **`contact_by_integration_test.go`** — Suffix all FIXED `full_name` fixtures (`Test Weekly Contact`, `Overdue Contact`, `Very Overdue Contact`) with a per-test suffix. File does NOT import the toolkit → add a local `uuid`-suffix mechanism. Per-id membership/index asserts already safe.
+3. **`contact_task_integration_test.go`** — Suffix the FIXED `ExternalTaskID` literals (`12345`,`11111`,`33333`,`44444`,`55555`,`action-task-1`, …) with the per-test ns so `GetContactTaskByExternalID` + the `(provider, external_task_id)` unique/upsert keys don't collide. FK contacts already scoped; `CountByProvider` `GreaterOrEqual` is invariant-safe.
+4. **`contact_task_service_test.go`** — Replace fixed Todoist sync-state `AccountID "test-account-123"` + fixed contact name `Test Contact for Service` with per-test unique values, and update the `DeleteSyncStatesByAccountID` pre-clean to target the unique AccountID. `SetTodoistClientFactory` is per-instance → does NOT force serial.
+5. **`external_contact_soft_delete_sweep_test.go`** — Rescope the two `CountHiddenUnresolvedTelegram(...) == 1` asserts in `TestExternalContactUnmatched_HidesUnresolvedTelegramByDefault` (DB-wide `COUNT(*) WHERE source='telegram'`, no prefix filter) to count only this test's prefixed rows, or assert a delta. All other funcs already `syntheticNS`-scoped.
+6. **`gchat_enablement_reconcile_test.go`** — `TestReconcileGChat_PerAccountShape_NoNullAccountRow` asserts `GetSyncStateBySource('gchat', nil) == ErrNotFound` (DB-wide "no `(gchat, NULL)` row anywhere"). **Decision: keep that one func serial** as an invariant guard; flip the other 9 `uniqueAccount`-scoped funcs.
+7. **`interaction_direction_test.go`** — Give `TestFollowupFilter`'s two contacts namespaced `full_name`s (it scans the whole table via `has_followup`/`no_followup` with fixed names → fuzzy-collision risk); suffix `TestCompletedCadenceTask_CanBeReplacedByNewOne`'s fixed `ExternalTaskID` literals (`original-cadence-task`/`replacement-cadence-task`) with the per-test ns. Other 6 funcs already `contact.ID`-scoped.
+8. **`interaction_source_descriptor_check_test.go`** — Narrow `TestInteractionSourceCheck_AcceptsPhoneCalls`'s deferred `HardDeleteInteractionsBySourceRefPrefix` from fixed `phone-calls-test-%` to `phone-calls-test-<syntheticNS>%`. The descriptor-agreement func is read-only.
+9. **`interaction_source_gchat_check_test.go`** — Narrow the deferred `HardDeleteInteractionsBySourceRefPrefix(GChat, …)` from fixed `gchat-test-%` to `gchat-test-<syntheticNS>%`.
+10. **`interaction_source_messages_check_test.go`** — Narrow `TestInteraction_SourceCheckAcceptsMessages`'s deferred cleanup from fixed `messages-test-%` to `messages-test-<syntheticNS>%`. `RejectsWhatsapp` already scoped.
+11. **`search_integration_test.go`** — Give each created contact/note a unique suffix (`syntheticNS(t)`) so the FTS query term is unique, replacing FIXED `full_name`s (`Alice Johnson`,`Bob Smith`,`Michael Johnson`,`Sarah Michael`) and search terms (`Michael`,`golang`,`Pagination`). Convert global-shape asserts to asserts over only the test's own rows queried with its unique term.
+12. **`telegram_chat_config_test.go`** — Replace package-level fixed `testChatID1/2/3` (70001-70003) with per-test unique chat IDs; make each func's cleanup target only its own IDs; convert global-list asserts to scoped lookups.
+13. **`telegram_message_test.go`** — Replace fixed message IDs (90001-90005) and fixed chat IDs (12345, -100555, 77777) with per-test unique ids; rework `cleanupTelegramMessages` to delete only the test's own ids/chat range; change `TestTelegramMessage_ListUnprocessed` to assert on its own scoped chat.
+
+Mixed-file scoping (the needs-scoping sub-work in 2 mixed files):
+
+14. **`identity_integration_test.go`** — `TestIdentityRepository_Integration`: replace fixed identifiers + fixed source `test_source` with per-test uuid-suffixed values; the upsert accumulates `message_count = old + EXCLUDED`, so the exact `message_count == 6` assert and the `ListUnmatched idx1<idx2` ordering assert must be scoped. `TestIdentityService_Integration`: replace fixed emails/phone and fixed `test_discovery`/`test_cache` sources. `NormalizationPolicy` already collision-free.
+15. **`integration_test.go`** — `TestContactRepository_Integration` (`ListContacts`: scope membership to own-IDs); `TestSyncRepository_Integration` (suffix fixed `Source` strings; own-IDs; `ListRecentSyncLogs len>=2` → scope to own sources); `TestOAuthRepository_Integration` (suffix provider/account; `Count == 2` → scope to suffixed provider; membership → own-IDs). `TestContactMethodRepository_Integration` + `TestFindSimilarContactsBatch_Integration` already own-scoped.
+
+## Per-file classification
+
+Format: `file` — **bucket** (func count; river; long-gated) — action.
+
+### scoped-safe (28 files)
+
+- `cadence_test.go` — scoped-safe (5; no; no) — flip all. Pure in-process cadence-package unit tests; no DB/River/globals.
+- `calendar_decline_removal_integration_test.go` — scoped-safe (11; no; no) — flip all. `newDeclineTestEnv` runs declines synchronously in-tx (no River); per-test contact keyed by `uuid` + `gen.Prefix()` accountID; concurrent-recompute func locks only its own contact.
+- `calendar_event_integration_test.go` — scoped-safe (2; no; no) — flip both. No River; namespaced seeds + per-test `event-`+uuid gcal IDs; own-row assertions. (Carries 2 inline `DatabaseConfig` literals → conn fields lowered in the tune commit.)
+- `comms_gchat_identity_test.go` — scoped-safe (1; no; no) — flip. `setupCommsMessageTest` repos only; `gen.Prefix()` suffixes; membership-only assertions over own rows.
+- `comms_gchat_query_test.go` — scoped-safe (2; no; no) — flip both. `migrationGenerator(t).Prefix()` on every contact/space/external_id; scoped `Len`/`Contains` membership.
+- `comms_message_repository_test.go` — scoped-safe (12; no; no) — flip all. `gen.Prefix()` namespace; own-row assertions; the one DB-wide `ListEmailIdentitiesForSync` is filtered to own emails before `ElementsMatch`.
+- `consumer_cadence_updater_cutover_integration_test.go` — scoped-safe (9; no; no) — flip all. `consumer.NewCadenceUpdater` directly (no River client); own-contact assertions; fresh `uuid` event ids.
+- `gmail_enablement_reconcile_test.go` — scoped-safe (9; no; no) — flip all. `newEventBusTestDB` (plain DB ctor, NO River); `uniqueAccount()` per account; per-account state reads.
+- `gmail_time_helpers_test.go` — scoped-safe (0; no; no) — no-op. Helper only.
+- `ingest_registry_guard_static_test.go` — scoped-safe (2; no; no) — flip both. Static guard test; `t.TempDir()` fixtures, no DB/River.
+- `interaction_integration_test.go` — scoped-safe (4; no; no) — flip all. Nil-bus ContactService (no River); contact-scoped `CountContactInteractions`. (Carries an inline `DatabaseConfig` literal → conn fields lowered in the tune commit.)
+- `interaction_repository_source_filter_test.go` — scoped-safe (1; no; no) — flip. `migrationGenerator` + per-test stripe+seed source_refs; own-prefix cleanup + assertions.
+- `jsonb_gin_index_test.go` — scoped-safe (5; no; no) — flip all. Per-test `uuid` prefix on every source_id/gcal_event_id; every DB-wide result narrowed by prefix before `Len`.
+- `link_contact_curated_status_integration_test.go` — scoped-safe (6; no; no) — **hoist `gin.SetMode` to TestMain (D3.5), then flip all 6.** Nil-bus handler; `abSuffix(t)=syntheticNS(t)`; own-row `MatchStatus` assertions.
+- `messages_message_repository_test.go` — scoped-safe (9; no; no) — flip all. `migrationGenerator` + nil-bus seed; `gen.Prefix()` guids; per-contact assertions.
+- `phone_call_repository_test.go` — scoped-safe (5; no; no) — flip all. Same lightweight pattern; namespaced ids; per-contact assertions.
+- `sole_writer_static_test.go` — scoped-safe (3; no; no) — flip all. Pure go/ast + file-read static guards; read-only.
+- `sqlc_select_list_static_test.go` — scoped-safe (4; no; no) — flip all. Pure source-SQL lint; read-only + inline string fixtures.
+- `synthetic_factory_test.go` — scoped-safe (8; no; no) — flip all. Pure factory unit tests; read-only `fixedAnchor`.
+- `synthetic_migration_helpers_test.go` — scoped-safe (0; no; no) — no-op. Helpers only.
+- `telegram_discovery_upsert_test.go` — scoped-safe (9; no; no) — flip all. Per-test unique source_id; own-row `GetBySource` assertions; namespaced FK contacts.
+- `telegram_import_suggestion_test.go` — scoped-safe (1; no; no) — **hoist `gin.SetMode` to TestMain (D3.5), then flip.** `wireCadenceUpdaterForTest` (no River); `uniqueSuffix()` names; own-ext.ID assertions.
+- `telegram_matcher_enrichment_test.go` — scoped-safe (7; no; no) — flip all. PeerMatcher/Identity/Enrichment only (no River); `uniqueTestIDs` namespace; even the concurrent-23505 func races within one test on its own contact.
+- `telegram_message_all_fields_test.go` — scoped-safe (1; no; no) — flip. Namespaced FK contact; pre-purge + own-row read; no other test uses chat 920001.
+- `telegram_message_claim_test.go` — scoped-safe (7; no; no) — flip all. `gen.PeerBandStart()` disjoint chatID + scoped `HardDeleteByChatIDRange`; own-row reads.
+- `telegram_sparse_entity_enrichment_test.go` — scoped-safe (7; no; no) — flip all. `uniqueTestIDs(t,ns)` unique int64 ids; scoped cleanup; per-test handler (no package global); no River.
+- `template_isolation_integration_test.go` — scoped-safe (1; no; no) — flip. `testdb.NewEphemeralClone(t)` isolated clone; sentinel asserted only by unique ID.
+- `testmain_integration_test.go` — scoped-safe (0; no; no) — no test funcs (TestMain only). **Receives the `gin.SetMode` hoist (D3.5).**
+
+### needs-scoping (13 files)
+
+(See "Needs-scoping actions" above for the per-file action. All are river=False, long-gated=False.)
+
+- `cadence_filter_integration_test.go` (1) · `contact_by_integration_test.go` (5) · `contact_task_integration_test.go` (5) · `contact_task_service_test.go` (2) · `external_contact_soft_delete_sweep_test.go` (12) · `gchat_enablement_reconcile_test.go` (10; 1 func kept serial) · `interaction_direction_test.go` (8) · `interaction_source_descriptor_check_test.go` (2) · `interaction_source_gchat_check_test.go` (1) · `interaction_source_messages_check_test.go` (2) · `search_integration_test.go` (2) · `telegram_chat_config_test.go` (7) · `telegram_message_test.go` (7).
+
+### mixed (5 files)
+
+- `event_bus_integration_test.go` — mixed (10; river=True; no) — flip the 5 `TestEventRepository_*` (`newEventBusTestDB`, no River, `uniqueSourceID(uuid)`-scoped); leave the 5 `TestBus_*` serial (`newEventBusTestBus` Start()s a River client).
+- `gchat_provider_integration_test.go` — mixed (18; river=True; no) — flip the 17 `setupGChatProviderTest` funcs (scoped-safe, namespaced); leave `TestGChatRematchHandler_ScansAndAggregates` serial (`setupGChatEngineTest` → live River client).
+- `identity_integration_test.go` — mixed (3; river=False; no) — scope `TestIdentityRepository_Integration` + `TestIdentityService_Integration` (action 14), then flip all 3 (`NormalizationPolicy` already safe via tx-rollback + uuid suffixes).
+- `integration_test.go` — mixed (6; river=False; no) — keep `TestRunMigrations_Integration` + `TestMigration020_UnifyEmailDedup` serial (schema/trigger mutation on the shared DB); scope `TestContactRepository_Integration` + `TestSyncRepository_Integration` + `TestOAuthRepository_Integration` (action 15), then flip those 3 + the already-safe `TestContactMethodRepository_Integration` + `TestFindSimilarContactsBatch_Integration`. (Carries an inline `DatabaseConfig` literal → conn fields lowered in the tune commit.)
+- `synthetic_golden_scenario_integration_test.go` — mixed (2; river=True; long-gated=True) — both funcs stay serial (one River via `NewHarnessForNamespace`; one process-global `-update` flag + shared on-disk golden). No flip.
+
+### river-heavy (30 files) — all stay serial
+
+`address_book_reconcile_integration_test.go` (15) · `calendar_decline_cutover_integration_test.go` (2) · `comms_gchat_engine_test.go` (6) · `consumer_interaction_recorder_integration_test.go` (7) · `email_interaction_integration_test.go` (10) · `followup_apply_interaction_integration_test.go` (3) · `followup_create_worker_integration_test.go` (5) · `followup_manager_cutover_integration_test.go` (8) · `gchat_golive_integration_test.go` (1) · `gmail_correspondence_integration_test.go` (3) · `gmail_golive_integration_test.go` (1) · `gmail_provider_integration_test.go` (13) · `gmail_rematch_integration_test.go` (9) · `rematch_dispatcher_unique_opts_test.go` (1) · `rematch_event_dedup_test.go` (1) · `rematch_integration_test.go` (13) · `river_integration_test.go` (4) · `suggestion_service_integration_test.go` (13) · `sync_repo_enqueue_test.go` (6) · `telegram_aggregation_explicit_reply_bridge_test.go` (1) · `telegram_aggregation_inbound_coalesce_test.go` (1) · `telegram_aggregation_test.go` (9) · `test_event_bus_harness_test.go` (0; shared River harness, no funcs) · **long-gated:** `synthetic_gcal_provider_integration_test.go` (6) · `synthetic_migration_transform_r_reference_test.go` (1) · `synthetic_profile_integration_test.go` (5) · `synthetic_replay_integration_test.go` (5) · `synthetic_reset_integration_test.go` (2; build-tag/Short, not long) · `synthetic_seed_all_integration_test.go` (3) · `synthetic_telegram_provider_integration_test.go` (7).
+
+Each builds a live `river.NewClient(TestOnly:true)` and/or drains `river_job` on the shared package clone; concurrent clients would steal each other's jobs. Per-test River isolation is the future lever (#428), out of scope here.
+
+### inherently-serial (4 files) — all stay serial
+
+- `crm_marker_construction_static_test.go` (3) — writes a shared on-disk probe into `backend/internal/todoist` and shells out to a tree-wide guard script (shared filesystem state).
+- `telegram_session_test.go` (5) — `telegram_session` is a hard singleton (every query `WHERE id = 1`); no identifier to namespace.
+- `telegram_state_storage_test.go` (5) — package-level fixed consts `testUserID=99999`/`testChannelID=88888` shared across funcs; convertible in principle but not in scope.
+- `unit_test.go` (5) — every func calls `gin.SetMode(gin.TestMode)` (process-global write); stays serial in this PR (the `gin.SetMode` hoist that unblocks the two DB-backed handler files does not flip `unit_test.go` here).
+
+## Baseline / after timings
+
+_Measured on a 12-core dev box (GOMAXPROCS=12), Postgres `max_connections=100`, with a freshly-cleaned test DB. CI timing is reported separately from the CI run logs._
+
+| Metric | Before (`main`) | After (flip, tuned) |
+|--------|-----------------|---------------------|
+| (a) `make test-integration-fast` wall-clock | ~29s | _TBD_ |
+| (b) `go test ./tests/` package wall-clock | ~20s (17.8s internal) | _TBD_ |
+
+At baseline the fast-suite wall-clock (~29s) is set by `tests/api` (27.5s internal, deferred to #429), which runs concurrently above the `tests` package this PR speeds up. So the flip's win shows up most directly in metric (b), and only partially in (a) until `tests/api` is also parallelized.
+
+Amdahl note: the whole-package (b) speedup is bounded by the serial River floor (~23 non-long-gated river-heavy files + 4 inherently-serial + the mixed files' serial funcs). The larger speedup applies to the parallelizable subset; the residual is the deferred per-test-River-isolation effort (#428), not a regression.

--- a/.ai/spec/2026-06-08-test-parallelization-audit.md
+++ b/.ai/spec/2026-06-08-test-parallelization-audit.md
@@ -70,7 +70,9 @@ Mixed-file scoping (the needs-scoping sub-work in 2 mixed files):
 
 Format: `file` — **bucket** (func count; river; long-gated) — action.
 
-### scoped-safe (28 files)
+### scoped-safe (27 files)
+
+(One file originally listed here as scoped-safe — `telegram_discovery_upsert_test.go` — was reclassified to **needs-scoping** during validation; see the reclassification note near the top. Its entry below is retained for the audit trail with the corrected action.)
 
 - `cadence_test.go` — scoped-safe (5; no; no) — flip all. Pure in-process cadence-package unit tests; no DB/River/globals.
 - `calendar_decline_removal_integration_test.go` — scoped-safe (11; no; no) — flip all. `newDeclineTestEnv` runs declines synchronously in-tx (no River); per-test contact keyed by `uuid` + `gen.Prefix()` accountID; concurrent-recompute func locks only its own contact.
@@ -79,7 +81,7 @@ Format: `file` — **bucket** (func count; river; long-gated) — action.
 - `comms_gchat_query_test.go` — scoped-safe (2; no; no) — flip both. `migrationGenerator(t).Prefix()` on every contact/space/external_id; scoped `Len`/`Contains` membership.
 - `comms_message_repository_test.go` — scoped-safe (12; no; no) — flip all. `gen.Prefix()` namespace; own-row assertions; the one DB-wide `ListEmailIdentitiesForSync` is filtered to own emails before `ElementsMatch`.
 - `consumer_cadence_updater_cutover_integration_test.go` — scoped-safe (9; no; no) — flip all. `consumer.NewCadenceUpdater` directly (no River client); own-contact assertions; fresh `uuid` event ids.
-- `gmail_enablement_reconcile_test.go` — scoped-safe (9; no; no) — flip all. `newEventBusTestDB` (plain DB ctor, NO River); `uniqueAccount()` per account; per-account state reads.
+- `gmail_enablement_reconcile_test.go` — scoped-safe (10; no; no) — flip 9; `newEventBusTestDB` (plain DB ctor, NO River); `uniqueAccount()` per account; per-account state reads. **Exception: `TestResetGmailBackfillCursors_ResetsOnlyEnabledEmailStates` stays SERIAL** (DB-wide scan + exact Scanned/Reset count — see the reclassification note above).
 - `gmail_time_helpers_test.go` — scoped-safe (0; no; no) — no-op. Helper only.
 - `ingest_registry_guard_static_test.go` — scoped-safe (2; no; no) — flip both. Static guard test; `t.TempDir()` fixtures, no DB/River.
 - `interaction_integration_test.go` — scoped-safe (4; no; no) — flip all. Nil-bus ContactService (no River); contact-scoped `CountContactInteractions`. (Carries an inline `DatabaseConfig` literal → conn fields lowered in the tune commit.)
@@ -92,7 +94,7 @@ Format: `file` — **bucket** (func count; river; long-gated) — action.
 - `sqlc_select_list_static_test.go` — scoped-safe (4; no; no) — flip all. Pure source-SQL lint; read-only + inline string fixtures.
 - `synthetic_factory_test.go` — scoped-safe (8; no; no) — flip all. Pure factory unit tests; read-only `fixedAnchor`.
 - `synthetic_migration_helpers_test.go` — scoped-safe (0; no; no) — no-op. Helpers only.
-- `telegram_discovery_upsert_test.go` — scoped-safe (9; no; no) — flip all. Per-test unique source_id; own-row `GetBySource` assertions; namespaced FK contacts.
+- `telegram_discovery_upsert_test.go` — **needs-scoping** (10; no; no) — RECLASSIFIED. Was assumed scoped-safe, but funcs share fixed source_ids + a prefix-wide setup cleanup, plus a fixed peer/chat in the batch func. Scoped via a per-test source_id prefix (`syntheticNS`) + `uniqueTestIDs` peer/chat, then flip all.
 - `telegram_import_suggestion_test.go` — scoped-safe (1; no; no) — **hoist `gin.SetMode` to TestMain (D3.5), then flip.** `wireCadenceUpdaterForTest` (no River); `uniqueSuffix()` names; own-ext.ID assertions.
 - `telegram_matcher_enrichment_test.go` — scoped-safe (7; no; no) — flip all. PeerMatcher/Identity/Enrichment only (no River); `uniqueTestIDs` namespace; even the concurrent-23505 func races within one test on its own contact.
 - `telegram_message_all_fields_test.go` — scoped-safe (1; no; no) — flip. Namespaced FK contact; pre-purge + own-row read; no other test uses chat 920001.
@@ -101,7 +103,9 @@ Format: `file` — **bucket** (func count; river; long-gated) — action.
 - `template_isolation_integration_test.go` — scoped-safe (1; no; no) — flip. `testdb.NewEphemeralClone(t)` isolated clone; sentinel asserted only by unique ID.
 - `testmain_integration_test.go` — scoped-safe (0; no; no) — no test funcs (TestMain only). **Receives the `gin.SetMode` hoist (D3.5).**
 
-### needs-scoping (13 files)
+### needs-scoping (14 files)
+
+(Plus `telegram_discovery_upsert_test.go`, reclassified from scoped-safe — listed in the scoped-safe section above with its corrected action.)
 
 (See "Needs-scoping actions" above for the per-file action. All are river=False, long-gated=False.)
 

--- a/.ai/spec/2026-06-08-test-parallelization-audit.md
+++ b/.ai/spec/2026-06-08-test-parallelization-audit.md
@@ -22,7 +22,7 @@ All **80** top-level `backend/tests` files are classified — zero duplicates, z
 - `contact_task` `TestContactTask_CountByProvider` used a DB-wide `DeleteContactTasksByProvider("todoist")` cleanup that deleted parallel tests' tasks; scoped to delete only its own task IDs.
 
 Notes on the count:
-- 4 of the 28 scoped-safe and 1 of the 5 mixed entries are helper/zero-func files (`gmail_time_helpers_test.go`, `synthetic_migration_helpers_test.go`, `testmain_integration_test.go`, `test_event_bus_harness_test.go`) — no `TestXxx` to flip; listed for completeness.
+- 3 of the 27 scoped-safe entries are helper/zero-func files (`gmail_time_helpers_test.go`, `synthetic_migration_helpers_test.go`, `testmain_integration_test.go`) — no `TestXxx` to flip; listed for completeness. (`test_event_bus_harness_test.go` is also a zero-func helper but is classified under river-heavy, since it builds the live River clients every river-heavy file depends on.)
 - **River-heavy = 30 distinct files.** An earlier working pass double-listed `gmail_golive_integration_test.go` (identical river-heavy/serial classification both times); it is one file.
 - **7 files are `RequireLongTests`-gated** (the `synthetic_*` provider/replay/profile/seed/golden set) and skip the fast suite entirely. Leaving them serial has zero effect on fast-suite / pre-push wall-clock.
 - **Scoping work before flip = 15 actions:** the 13 pure needs-scoping files + the needs-scoping sub-work in the 2 mixed files `identity_integration_test.go` and `integration_test.go`.

--- a/Makefile
+++ b/Makefile
@@ -330,15 +330,15 @@ test-unit:
 
 test-integration-fast:
 	@echo "Running backend integration tests (default set)..."
-	@cd backend && DATABASE_URL="$(TEST_DATABASE_URL)" go test -tags integration_testdb -count=1 ./tests/... ./internal/todoist/... ./internal/google/... ./internal/testdb/... -v
+	@cd backend && DATABASE_URL="$(TEST_DATABASE_URL)" go test -tags integration_testdb -count=1 -parallel 4 -p 4 ./tests/... ./internal/todoist/... ./internal/google/... ./internal/testdb/... -v
 
 test-integration:
 	@echo "Running backend integration tests..."
-	@cd backend && DATABASE_URL="$(TEST_DATABASE_URL)" LONG_TESTS=1 go test -tags integration_testdb -count=1 ./tests/... ./internal/todoist/... ./internal/google/... ./internal/testdb/... -v
+	@cd backend && DATABASE_URL="$(TEST_DATABASE_URL)" LONG_TESTS=1 go test -tags integration_testdb -count=1 -parallel 4 -p 4 ./tests/... ./internal/todoist/... ./internal/google/... ./internal/testdb/... -v
 
 test-integration-slow:
 	@echo "Running backend slow integration tests..."
-	@cd backend && DATABASE_URL="$(TEST_DATABASE_URL)" LONG_TESTS=1 go test -tags integration_testdb -count=1 ./tests/... ./internal/todoist/... ./internal/google/... ./internal/testdb/... -v -run '$(BACKEND_SLOW_TESTS_REGEX)'
+	@cd backend && DATABASE_URL="$(TEST_DATABASE_URL)" LONG_TESTS=1 go test -tags integration_testdb -count=1 -parallel 4 -p 4 ./tests/... ./internal/todoist/... ./internal/google/... ./internal/testdb/... -v -run '$(BACKEND_SLOW_TESTS_REGEX)'
 
 # Sweep leaked clone databases (personal_crm_test_clone_*) AND stale
 # per-migration-set template databases (personal_crm_test_template_<hash>).

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -654,11 +654,16 @@ func contains(slice []string, item string) bool {
 func TestConfig() *Config {
 	return &Config{
 		Database: DatabaseConfig{
-			URL:               "postgres://test:test@localhost:5432/test?sslmode=disable",
-			MigrationsPath:    "../../migrations",
-			HealthTimeout:     DefaultHealthCheckTimeout,
-			MaxConns:          DefaultDBMaxConns,
-			MinConns:          DefaultDBMinConns,
+			URL:            "postgres://test:test@localhost:5432/test?sslmode=disable",
+			MigrationsPath: "../../migrations",
+			HealthTimeout:  DefaultHealthCheckTimeout,
+			// Lowered for parallel integration tests: concurrent per-test pools
+			// must not exhaust Postgres max_connections. MaxConns=8 is the floor
+			// that still satisfies Validate()'s MaxConns >= WorkerConcurrency+3
+			// after WorkerConcurrency drops to 4 below. Production Load() keeps
+			// the DefaultDB* values.
+			MaxConns:          8,
+			MinConns:          1,
 			MaxConnIdleTime:   DefaultDBMaxConnIdleTime,
 			MaxConnLifetime:   DefaultDBMaxConnLifetime,
 			HealthCheckPeriod: DefaultDBHealthCheckPeriod,
@@ -718,7 +723,10 @@ func TestConfig() *Config {
 			GroupMaxMembers:      10,
 		},
 		River: RiverConfig{
-			WorkerConcurrency: DefaultRiverWorkerConcurrency,
+			// Lowered alongside Database.MaxConns above so Validate()'s
+			// MaxConns >= WorkerConcurrency+3 holds (4+3 <= 8). The River test
+			// harnesses cap MaxWorkers at this value; 4 is plenty for tests.
+			WorkerConcurrency: 4,
 			JobTimeout:        DefaultRiverJobTimeout,
 		},
 		EventBus: EventBusConfig{

--- a/backend/tests/cadence_filter_integration_test.go
+++ b/backend/tests/cadence_filter_integration_test.go
@@ -25,6 +25,7 @@ func TestCadenceFilter_Integration(t *testing.T) {
 		t.Skip("DATABASE_URL not set, skipping integration test")
 	}
 
+	t.Parallel()
 	// Migrations are applied once by TestMain.
 	ctx := context.Background()
 	cfg := config.TestConfig()
@@ -49,7 +50,7 @@ func TestCadenceFilter_Integration(t *testing.T) {
 
 	t.Run("ListContacts_NoCadenceFilter", func(t *testing.T) {
 		results, err := repo.ListContacts(ctx, repository.ListContactsParams{
-			Limit:         100,
+			Limit:         100000,
 			Offset:        0,
 			CadenceFilter: "",
 		})
@@ -71,7 +72,7 @@ func TestCadenceFilter_Integration(t *testing.T) {
 
 	t.Run("ListContacts_HasCadence", func(t *testing.T) {
 		results, err := repo.ListContacts(ctx, repository.ListContactsParams{
-			Limit:         100,
+			Limit:         100000,
 			Offset:        0,
 			CadenceFilter: "has_cadence",
 		})
@@ -92,7 +93,7 @@ func TestCadenceFilter_Integration(t *testing.T) {
 
 	t.Run("ListContacts_NoCadence", func(t *testing.T) {
 		results, err := repo.ListContacts(ctx, repository.ListContactsParams{
-			Limit:         100,
+			Limit:         100000,
 			Offset:        0,
 			CadenceFilter: "no_cadence",
 		})
@@ -113,7 +114,7 @@ func TestCadenceFilter_Integration(t *testing.T) {
 
 	t.Run("ListContactsSorted_HasCadence", func(t *testing.T) {
 		results, err := repo.ListContacts(ctx, repository.ListContactsParams{
-			Limit:         100,
+			Limit:         100000,
 			Offset:        0,
 			Sort:          "name",
 			Order:         "asc",

--- a/backend/tests/cadence_filter_integration_test.go
+++ b/backend/tests/cadence_filter_integration_test.go
@@ -135,14 +135,20 @@ func TestCadenceFilter_Integration(t *testing.T) {
 	})
 
 	t.Run("CountContacts_HasCadence", func(t *testing.T) {
+		// CountContacts is a DB-wide COUNT(*), so it sees other parallel tests'
+		// rows. We only assert it is >= 1 for each partition: this test's own
+		// withCadence/withoutCadence rows guarantee at least one in each, and
+		// concurrent tests can only ADD rows, never drop the count below our
+		// contribution. (A stricter "== N" over the whole table would be
+		// shared-DB-unsafe under t.Parallel().)
 		totalHas, err := repo.CountContacts(ctx, "has_cadence", "")
 		require.NoError(t, err)
 
 		totalNo, err := repo.CountContacts(ctx, "no_cadence", "")
 		require.NoError(t, err)
 
-		assert.Greater(t, totalHas, int64(0), "should have at least one contact with cadence")
-		assert.Greater(t, totalNo, int64(0), "should have at least one contact without cadence")
+		assert.GreaterOrEqual(t, totalHas, int64(1), "this test's own cadence contact guarantees >= 1")
+		assert.GreaterOrEqual(t, totalNo, int64(1), "this test's own no-cadence contact guarantees >= 1")
 	})
 
 	t.Run("ListContactIDs_HasCadence", func(t *testing.T) {

--- a/backend/tests/cadence_test.go
+++ b/backend/tests/cadence_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestParseCadence(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input    string
 		expected cadence.CadenceType
@@ -40,6 +41,7 @@ func TestParseCadence(t *testing.T) {
 }
 
 func TestCalculateNextDueDate(t *testing.T) {
+	t.Parallel()
 	baseDate := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
 
 	tests := []struct {
@@ -112,6 +114,7 @@ func TestCalculateNextDueDate(t *testing.T) {
 }
 
 func TestIsOverdue(t *testing.T) {
+	t.Parallel()
 	now := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC) // Jan 15, 2024
 
 	tests := []struct {
@@ -160,6 +163,7 @@ func TestIsOverdue(t *testing.T) {
 }
 
 func TestGetOverdueDays(t *testing.T) {
+	t.Parallel()
 	now := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC) // Jan 15, 2024
 
 	tests := []struct {
@@ -201,6 +205,7 @@ func TestGetOverdueDays(t *testing.T) {
 }
 
 func TestGetDaysUntilDue(t *testing.T) {
+	t.Parallel()
 	now := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC) // Jan 15, 2024
 
 	tests := []struct {

--- a/backend/tests/calendar_decline_removal_integration_test.go
+++ b/backend/tests/calendar_decline_removal_integration_test.go
@@ -158,6 +158,7 @@ func TestIntegration_CalendarDecline_SoftDeletesAndRecomputes(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	e := newDeclineTestEnv(t, ctx)
 
@@ -192,6 +193,7 @@ func TestIntegration_CalendarDecline_NullOutWithCadenceFallback(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	e := newDeclineTestEnv(t, ctx)
 
@@ -223,6 +225,7 @@ func TestIntegration_CalendarDecline_NoCadence_ContactByStaysNil(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	e := newDeclineTestEnv(t, ctx)
 
@@ -246,6 +249,7 @@ func TestIntegration_CalendarDecline_PerDirectionRollback(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	e := newDeclineTestEnv(t, ctx)
 
@@ -301,6 +305,7 @@ func TestIntegration_CalendarDecline_PreservesCreationValue(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	e := newDeclineTestEnv(t, ctx)
 
@@ -339,6 +344,7 @@ func TestIntegration_CalendarDecline_PreservesContactByOverride(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	e := newDeclineTestEnv(t, ctx)
 
@@ -372,6 +378,7 @@ func TestIntegration_CalendarDecline_RollsBackContactByWhenNoOverride(t *testing
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	e := newDeclineTestEnv(t, ctx)
 
@@ -406,6 +413,7 @@ func TestIntegration_CalendarDecline_ContactByForwardWriterParity(t *testing.T) 
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	e := newDeclineTestEnv(t, ctx)
 
@@ -434,6 +442,7 @@ func TestIntegration_CalendarDecline_ReplayIsNoOp(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	e := newDeclineTestEnv(t, ctx)
 
@@ -458,6 +467,7 @@ func TestIntegration_AttendedAfterDelete_SkipsInsert(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	e := newDeclineTestEnv(t, ctx)
 	contact := e.newContact(t, nil, nil)
@@ -486,6 +496,7 @@ func TestIntegration_AttendedAfterDelete_LockSerialization(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	e := newDeclineTestEnv(t, ctx)
 	contact := e.newContact(t, nil, nil)
@@ -543,6 +554,7 @@ func TestIntegration_CalendarDecline_RecomputeSeesConcurrentInteraction(t *testi
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	e := newDeclineTestEnv(t, ctx)
 
@@ -626,6 +638,7 @@ func TestIntegration_DeclineSourceID_CoexistsWithAttended(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	e := newDeclineTestEnv(t, ctx)
 

--- a/backend/tests/calendar_event_integration_test.go
+++ b/backend/tests/calendar_event_integration_test.go
@@ -31,8 +31,8 @@ func TestCalendarEventUpsertResetsLastContactedUpdated(t *testing.T) {
 	// Migrations are applied once by TestMain.
 	dbConfig := config.DatabaseConfig{
 		URL:               databaseURL,
-		MaxConns:          config.DefaultDBMaxConns,
-		MinConns:          config.DefaultDBMinConns,
+		MaxConns:          8, // mirrors the lowered TestConfig() ceiling for parallel tests
+		MinConns:          1,
 		MaxConnIdleTime:   config.DefaultDBMaxConnIdleTime,
 		MaxConnLifetime:   config.DefaultDBMaxConnLifetime,
 		HealthCheckPeriod: config.DefaultDBHealthCheckPeriod,
@@ -181,8 +181,8 @@ func TestUpdateContactLastContactedIfLater_OnlyUpdatesWhenLater(t *testing.T) {
 	// Migrations are applied once by TestMain.
 	dbConfig := config.DatabaseConfig{
 		URL:               databaseURL,
-		MaxConns:          config.DefaultDBMaxConns,
-		MinConns:          config.DefaultDBMinConns,
+		MaxConns:          8, // mirrors the lowered TestConfig() ceiling for parallel tests
+		MinConns:          1,
 		MaxConnIdleTime:   config.DefaultDBMaxConnIdleTime,
 		MaxConnLifetime:   config.DefaultDBMaxConnLifetime,
 		HealthCheckPeriod: config.DefaultDBHealthCheckPeriod,

--- a/backend/tests/calendar_event_integration_test.go
+++ b/backend/tests/calendar_event_integration_test.go
@@ -26,6 +26,7 @@ func TestCalendarEventUpsertResetsLastContactedUpdated(t *testing.T) {
 		t.Skip("DATABASE_URL not set, skipping integration test")
 	}
 
+	t.Parallel()
 	ctx := context.Background()
 
 	// Migrations are applied once by TestMain.
@@ -176,6 +177,7 @@ func TestUpdateContactLastContactedIfLater_OnlyUpdatesWhenLater(t *testing.T) {
 		t.Skip("DATABASE_URL not set, skipping integration test")
 	}
 
+	t.Parallel()
 	ctx := context.Background()
 
 	// Migrations are applied once by TestMain.

--- a/backend/tests/comms_gchat_identity_test.go
+++ b/backend/tests/comms_gchat_identity_test.go
@@ -39,6 +39,7 @@ func seedContactWithMethod(t *testing.T, ctx context.Context, commsRepo *reposit
 // address fans out to multiple contacts; soft-deleted contacts and
 // empty-normalized values are excluded; values are already lowercased.
 func TestListGChatIdentitiesForSync_DualSource(t *testing.T) {
+	t.Parallel()
 	ctx, commsRepo, contactRepo, methodRepo := setupCommsMessageTest(t)
 	gen, _ := migrationGenerator(t)
 	suffix := gen.Prefix()

--- a/backend/tests/comms_gchat_query_test.go
+++ b/backend/tests/comms_gchat_query_test.go
@@ -37,6 +37,7 @@ func upsertGChatRow(t *testing.T, ctx context.Context, commsRepo *repository.Com
 // isolates rows on the shared comms_message table: gchat-source readers see
 // only gchat rows (email rows are invisible) and vice-versa.
 func TestCommsSourceParameterizedQueries_IsolateSources(t *testing.T) {
+	t.Parallel()
 	ctx, commsRepo, contactRepo, _ := setupCommsMessageTest(t)
 	gen, _ := migrationGenerator(t)
 	suffix := gen.Prefix()
@@ -91,6 +92,7 @@ func TestCommsSourceParameterizedQueries_IsolateSources(t *testing.T) {
 // fanned out to two contacts must resolve to the querying contact's own row,
 // never the other contact's.
 func TestGetMessageByReplyTargetForSource(t *testing.T) {
+	t.Parallel()
 	ctx, commsRepo, contactRepo, methodRepo := setupCommsMessageTest(t)
 	gen, _ := migrationGenerator(t)
 	suffix := gen.Prefix()

--- a/backend/tests/comms_message_repository_test.go
+++ b/backend/tests/comms_message_repository_test.go
@@ -143,6 +143,7 @@ func metadataFor(t *testing.T, accountID, gmailID string, extra map[string]any) 
 }
 
 func TestCommsMessageRepository_UpsertAndGet(t *testing.T) {
+	t.Parallel()
 	ctx, repo, contactRepo, _ := setupCommsMessageTest(t)
 
 	gen, _ := migrationGenerator(t)
@@ -183,6 +184,7 @@ func TestCommsMessageRepository_UpsertAndGet(t *testing.T) {
 // keys). The repository must not depend on the caller pre-seeding
 // observed_accounts[] / account_gmail_ids.
 func TestCommsMessageRepository_UpsertSynthesizesProvenanceOnInsert(t *testing.T) {
+	t.Parallel()
 	ctx, repo, contactRepo, _ := setupCommsMessageTest(t)
 
 	gen, _ := migrationGenerator(t)
@@ -227,6 +229,7 @@ func TestCommsMessageRepository_UpsertSynthesizesProvenanceOnInsert(t *testing.T
 }
 
 func TestCommsMessageRepository_GetMessage_NotFound(t *testing.T) {
+	t.Parallel()
 	ctx, repo, contactRepo, _ := setupCommsMessageTest(t)
 
 	gen, _ := migrationGenerator(t)
@@ -239,6 +242,7 @@ func TestCommsMessageRepository_GetMessage_NotFound(t *testing.T) {
 }
 
 func TestCommsMessageRepository_UpsertIdempotentSameAccount(t *testing.T) {
+	t.Parallel()
 	ctx, repo, contactRepo, _ := setupCommsMessageTest(t)
 
 	gen, _ := migrationGenerator(t)
@@ -264,6 +268,7 @@ func TestCommsMessageRepository_UpsertIdempotentSameAccount(t *testing.T) {
 }
 
 func TestCommsMessageRepository_CrossAccountProvenanceMerge(t *testing.T) {
+	t.Parallel()
 	ctx, repo, contactRepo, _ := setupCommsMessageTest(t)
 
 	gen, _ := migrationGenerator(t)
@@ -303,6 +308,7 @@ func TestCommsMessageRepository_CrossAccountProvenanceMerge(t *testing.T) {
 }
 
 func TestCommsMessageRepository_SameAccountReplayAfterMerge(t *testing.T) {
+	t.Parallel()
 	ctx, repo, contactRepo, _ := setupCommsMessageTest(t)
 
 	gen, _ := migrationGenerator(t)
@@ -329,6 +335,7 @@ func TestCommsMessageRepository_SameAccountReplayAfterMerge(t *testing.T) {
 }
 
 func TestCommsMessageRepository_ContentImmutableOnConflict(t *testing.T) {
+	t.Parallel()
 	ctx, repo, contactRepo, _ := setupCommsMessageTest(t)
 
 	gen, _ := migrationGenerator(t)
@@ -359,6 +366,7 @@ func TestCommsMessageRepository_ContentImmutableOnConflict(t *testing.T) {
 }
 
 func TestCommsMessageRepository_PerParticipantRowsDistinct(t *testing.T) {
+	t.Parallel()
 	ctx, repo, contactRepo, _ := setupCommsMessageTest(t)
 
 	gen, _ := migrationGenerator(t)
@@ -387,6 +395,7 @@ func TestCommsMessageRepository_PerParticipantRowsDistinct(t *testing.T) {
 }
 
 func TestCommsMessageRepository_MarkProcessedTx(t *testing.T) {
+	t.Parallel()
 	ctx, repo, contactRepo, _ := setupCommsMessageTest(t)
 
 	databaseURL := os.Getenv("DATABASE_URL")
@@ -454,6 +463,7 @@ func TestCommsMessageRepository_MarkProcessedTx(t *testing.T) {
 }
 
 func TestCommsMessageRepository_ListByContactNewestFirst(t *testing.T) {
+	t.Parallel()
 	ctx, repo, contactRepo, _ := setupCommsMessageTest(t)
 
 	gen, _ := migrationGenerator(t)
@@ -481,6 +491,7 @@ func TestCommsMessageRepository_ListByContactNewestFirst(t *testing.T) {
 }
 
 func TestCommsMessageRepository_ListEmailIdentitiesForSync(t *testing.T) {
+	t.Parallel()
 	ctx, repo, contactRepo, methodRepo := setupCommsMessageTest(t)
 
 	gen, _ := migrationGenerator(t)
@@ -550,6 +561,7 @@ func TestInteractionSourceCheck_AcceptsEmail(t *testing.T) {
 	if databaseURL == "" {
 		t.Skip("DATABASE_URL not set")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	cfg := config.TestConfig()
 	cfg.Database.URL = databaseURL
@@ -624,6 +636,7 @@ func previousBodies(t *testing.T, raw []byte) []string {
 // observation pushes previous_bodies[] exactly once. body/snippet/edited_at/
 // last_update_time are updated; processed_at/interaction_id/deleted_at untouched.
 func TestApplyEditByExternalID_PreviousBodiesCapAndRecencyGuard(t *testing.T) {
+	t.Parallel()
 	ctx, repo, contactRepo, _ := setupCommsMessageTest(t)
 
 	gen, _ := migrationGenerator(t)
@@ -698,6 +711,7 @@ func TestApplyEditByExternalID_PreviousBodiesCapAndRecencyGuard(t *testing.T) {
 // LATER is rejected. The "...10:00:00Z" vs "...10:00:00.001Z" pair is the exact
 // case a string compare would invert (the 'Z' byte sorts after '.').
 func TestApplyEditByExternalID_FractionalSecondOrdering(t *testing.T) {
+	t.Parallel()
 	ctx, repo, contactRepo, _ := setupCommsMessageTest(t)
 
 	gen, _ := migrationGenerator(t)
@@ -739,6 +753,7 @@ func TestApplyEditByExternalID_FractionalSecondOrdering(t *testing.T) {
 // TestSoftDeleteByExternalID_AllFannedRows proves the production delete path
 // soft-deletes EVERY fanned-out row for (source, external_id) and is idempotent.
 func TestSoftDeleteByExternalID_AllFannedRows(t *testing.T) {
+	t.Parallel()
 	ctx, repo, contactRepo, _ := setupCommsMessageTest(t)
 
 	gen, _ := migrationGenerator(t)
@@ -774,6 +789,7 @@ func TestSoftDeleteByExternalID_AllFannedRows(t *testing.T) {
 // TestGetLatestByExternalID_NewestFirstAndNotFound pins the body-pre-check read:
 // it returns the newest row by (sent_at DESC, id) and ErrNotFound on miss.
 func TestGetLatestByExternalID_NewestFirstAndNotFound(t *testing.T) {
+	t.Parallel()
 	ctx, repo, contactRepo, _ := setupCommsMessageTest(t)
 
 	gen, _ := migrationGenerator(t)
@@ -802,6 +818,7 @@ func TestGetLatestByExternalID_NewestFirstAndNotFound(t *testing.T) {
 // content + provenance keys, and a second call is a no-op (the NOT (?
 // 'from_name') guard → 0 rows).
 func TestBackfillParticipantNames_AdditiveMergeAndIdempotent(t *testing.T) {
+	t.Parallel()
 	ctx, repo, contactRepo, _ := setupCommsMessageTest(t)
 
 	gen, _ := migrationGenerator(t)

--- a/backend/tests/consumer_cadence_updater_cutover_integration_test.go
+++ b/backend/tests/consumer_cadence_updater_cutover_integration_test.go
@@ -74,6 +74,7 @@ func TestIntegration_CadenceUpdater_ApplyInteraction_Outbound_LiveDB(t *testing.
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	database, cleanup := newCadenceUpdaterTestDB(t)
 	defer cleanup()
 	ctx := context.Background()
@@ -114,6 +115,7 @@ func TestIntegration_CadenceUpdater_ApplyInteraction_Mutual_ForwardOnly(t *testi
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	database, cleanup := newCadenceUpdaterTestDB(t)
 	defer cleanup()
 	ctx := context.Background()
@@ -150,6 +152,7 @@ func TestIntegration_CadenceUpdater_ApplyInteraction_Manual_UnconditionalBackdat
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	database, cleanup := newCadenceUpdaterTestDB(t)
 	defer cleanup()
 	ctx := context.Background()
@@ -189,6 +192,7 @@ func TestIntegration_CadenceUpdater_BulkApply_DoesNotBumpLastInteractionAt(t *te
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	database, cleanup := newCadenceUpdaterTestDB(t)
 	defer cleanup()
 	ctx := context.Background()
@@ -242,6 +246,7 @@ func TestIntegration_CadenceUpdater_BulkApply_ForwardMaxOnMerge(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	database, cleanup := newCadenceUpdaterTestDB(t)
 	defer cleanup()
 	ctx := context.Background()
@@ -283,6 +288,7 @@ func TestIntegration_CadenceUpdater_ApplyContactByOverride_ClearAndBackdate(t *t
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	database, cleanup := newCadenceUpdaterTestDB(t)
 	defer cleanup()
 	ctx := context.Background()
@@ -328,6 +334,7 @@ func TestIntegration_CadenceUpdater_HandleEvent_DuplicateClaim_NoOp(t *testing.T
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	database, cleanup := newCadenceUpdaterTestDB(t)
 	defer cleanup()
 	ctx := context.Background()
@@ -410,6 +417,7 @@ func TestIntegration_CadenceUpdater_ModeOff_NoWrite(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	database, cleanup := newCadenceUpdaterTestDB(t)
 	defer cleanup()
 	ctx := context.Background()
@@ -445,6 +453,7 @@ func TestIntegration_CadenceUpdater_ContactBy_DerivedFromCadence(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	database, cleanup := newCadenceUpdaterTestDB(t)
 	defer cleanup()
 	ctx := context.Background()

--- a/backend/tests/contact_by_integration_test.go
+++ b/backend/tests/contact_by_integration_test.go
@@ -513,7 +513,7 @@ func TestContactBy_ListOverdueContacts(t *testing.T) {
 	t.Run("returns only overdue contacts", func(t *testing.T) {
 		today := cadence.Today(accelerated.GetCurrentTime())
 
-		overdueContacts, err := contactRepo.ListOverdueContacts(ctx, today, 100)
+		overdueContacts, err := contactRepo.ListOverdueContacts(ctx, today, 100000)
 		require.NoError(t, err)
 
 		// Find our test contacts in the results
@@ -547,7 +547,7 @@ func TestContactBy_ListOverdueContacts(t *testing.T) {
 		defer func() { _ = contactRepo.HardDeleteContact(ctx, veryOverdueContact.ID) }()
 
 		today := cadence.Today(accelerated.GetCurrentTime())
-		overdueContacts, err := contactRepo.ListOverdueContacts(ctx, today, 100)
+		overdueContacts, err := contactRepo.ListOverdueContacts(ctx, today, 100000)
 		require.NoError(t, err)
 
 		// Find positions of our test contacts

--- a/backend/tests/contact_by_integration_test.go
+++ b/backend/tests/contact_by_integration_test.go
@@ -20,9 +20,19 @@ import (
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/service"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// contactByName suffixes a fixed full_name with a per-test-run unique token so
+// parallel copies don't collide under the shared DB's trigram matching. This
+// file does not import the synthetic toolkit, so the local uuid suffix is the
+// lightweight isolation primitive. Assertions key on contact.ID, so the exact
+// name is irrelevant — only its uniqueness matters.
+func contactByName(base string) string {
+	return base + " " + uuid.NewString()[:8]
+}
 
 // TestContactBy_CreateWithCadence verifies that contact_by is correctly set when creating a contact with cadence.
 func TestContactBy_CreateWithCadence(t *testing.T) {
@@ -51,7 +61,7 @@ func TestContactBy_CreateWithCadence(t *testing.T) {
 	t.Run("weekly cadence sets contact_by to created_at + 7 days", func(t *testing.T) {
 		weeklyStr := "weekly"
 		contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-			FullName: "Test Weekly Contact",
+			FullName: contactByName("Test Weekly Contact"),
 			Cadence:  &weeklyStr,
 		})
 		require.NoError(t, err)
@@ -69,7 +79,7 @@ func TestContactBy_CreateWithCadence(t *testing.T) {
 	t.Run("monthly cadence sets contact_by to created_at + 30 days", func(t *testing.T) {
 		monthlyStr := "monthly"
 		contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-			FullName: "Test Monthly Contact",
+			FullName: contactByName("Test Monthly Contact"),
 			Cadence:  &monthlyStr,
 		})
 		require.NoError(t, err)
@@ -85,7 +95,7 @@ func TestContactBy_CreateWithCadence(t *testing.T) {
 
 	t.Run("no cadence leaves contact_by nil", func(t *testing.T) {
 		contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-			FullName: "Test No Cadence Contact",
+			FullName: contactByName("Test No Cadence Contact"),
 			Cadence:  nil,
 		})
 		require.NoError(t, err)
@@ -98,7 +108,7 @@ func TestContactBy_CreateWithCadence(t *testing.T) {
 		weeklyStr := "weekly"
 		lastContacted := time.Date(2024, 1, 15, 10, 30, 0, 0, time.Local)
 		contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-			FullName:      "Test With LastContacted",
+			FullName:      contactByName("Test With LastContacted"),
 			Cadence:       &weeklyStr,
 			LastContacted: &lastContacted,
 		})
@@ -141,7 +151,7 @@ func TestContactBy_UpdateLastContacted(t *testing.T) {
 	t.Run("updating last_contacted recalculates contact_by", func(t *testing.T) {
 		weeklyStr := "weekly"
 		contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-			FullName: "Test Update LastContacted",
+			FullName: contactByName("Test Update LastContacted"),
 			Cadence:  &weeklyStr,
 		})
 		require.NoError(t, err)
@@ -169,7 +179,7 @@ func TestContactBy_UpdateLastContacted(t *testing.T) {
 
 	t.Run("updating last_contacted without cadence keeps contact_by nil", func(t *testing.T) {
 		contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-			FullName: "Test Update LastContacted No Cadence",
+			FullName: contactByName("Test Update LastContacted No Cadence"),
 			Cadence:  nil,
 		})
 		require.NoError(t, err)
@@ -218,7 +228,7 @@ func TestContactBy_UpdateContactLastContactedIfLater(t *testing.T) {
 		initialContactBy := cadence.CalculateContactBy(initialDate, cadence.CadenceWeekly)
 
 		contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-			FullName:      "Test IfLater Update",
+			FullName:      contactByName("Test IfLater Update"),
 			Cadence:       &weeklyStr,
 			LastContacted: &initialDate,
 		})
@@ -248,7 +258,7 @@ func TestContactBy_UpdateContactLastContactedIfLater(t *testing.T) {
 		initialDate := time.Date(2024, 1, 15, 12, 0, 0, 0, time.Local)
 
 		contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-			FullName:      "Test IfLater No Update",
+			FullName:      contactByName("Test IfLater No Update"),
 			Cadence:       &weeklyStr,
 			LastContacted: &initialDate,
 		})
@@ -274,7 +284,7 @@ func TestContactBy_UpdateContactLastContactedIfLater(t *testing.T) {
 
 	t.Run("handles contact without cadence (sets contact_by to NULL)", func(t *testing.T) {
 		contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-			FullName: "Test IfLater No Cadence",
+			FullName: contactByName("Test IfLater No Cadence"),
 			Cadence:  nil,
 		})
 		require.NoError(t, err)
@@ -340,7 +350,7 @@ func TestContactBy_CadenceStateTransitions(t *testing.T) {
 
 		// Step 1: Create contact WITH cadence
 		contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-			FullName: "Test Cadence State Transitions",
+			FullName: contactByName("Test Cadence State Transitions"),
 			Cadence:  &weeklyStr,
 		})
 		require.NoError(t, err)
@@ -391,7 +401,7 @@ func TestContactBy_CadenceStateTransitions(t *testing.T) {
 
 		// Create contact WITHOUT cadence
 		contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-			FullName: "Test No Cadence To Set",
+			FullName: contactByName("Test No Cadence To Set"),
 			Cadence:  nil,
 		})
 		require.NoError(t, err)
@@ -416,7 +426,7 @@ func TestContactBy_CadenceStateTransitions(t *testing.T) {
 		// Create with weekly cadence + a fixed last_contacted so the
 		// service-layer contact_by recompute has a stable base.
 		contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-			FullName:      "Test Change Cadence Type",
+			FullName:      contactByName("Test Change Cadence Type"),
 			Cadence:       &weeklyStr,
 			LastContacted: &lastContacted,
 		})
@@ -470,7 +480,7 @@ func TestContactBy_ListOverdueContacts(t *testing.T) {
 	// Contact that is overdue (contact_by in the past)
 	pastDate := time.Date(2024, 1, 1, 12, 0, 0, 0, time.Local)
 	overdueContact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-		FullName:      "Overdue Contact",
+		FullName:      contactByName("Overdue Contact"),
 		Cadence:       &weeklyStr,
 		LastContacted: &pastDate, // contact_by will be 2024-01-08
 	})
@@ -480,7 +490,7 @@ func TestContactBy_ListOverdueContacts(t *testing.T) {
 	// Contact that is not overdue (contact_by in the future)
 	futureDate := accelerated.GetCurrentTime().AddDate(0, 0, 7)
 	notOverdueContact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-		FullName:      "Not Overdue Contact",
+		FullName:      contactByName("Not Overdue Contact"),
 		Cadence:       &weeklyStr,
 		LastContacted: &futureDate, // contact_by will be in the future
 	})
@@ -489,7 +499,7 @@ func TestContactBy_ListOverdueContacts(t *testing.T) {
 
 	// Contact without cadence (no contact_by)
 	noCadenceContact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-		FullName: "No Cadence Contact",
+		FullName: contactByName("No Cadence Contact"),
 		Cadence:  nil,
 	})
 	require.NoError(t, err)
@@ -524,7 +534,7 @@ func TestContactBy_ListOverdueContacts(t *testing.T) {
 		// Create another overdue contact with an even older contact_by
 		veryOldDate := time.Date(2023, 6, 1, 12, 0, 0, 0, time.Local)
 		veryOverdueContact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-			FullName:      "Very Overdue Contact",
+			FullName:      contactByName("Very Overdue Contact"),
 			Cadence:       &weeklyStr,
 			LastContacted: &veryOldDate, // contact_by will be 2023-06-08
 		})

--- a/backend/tests/contact_by_integration_test.go
+++ b/backend/tests/contact_by_integration_test.go
@@ -45,6 +45,7 @@ func TestContactBy_CreateWithCadence(t *testing.T) {
 		t.Skip("DATABASE_URL not set, skipping integration test")
 	}
 
+	t.Parallel()
 	ctx := context.Background()
 	cfg := config.TestConfig()
 	cfg.Database.URL = databaseURL
@@ -136,6 +137,7 @@ func TestContactBy_UpdateLastContacted(t *testing.T) {
 		t.Skip("DATABASE_URL not set, skipping integration test")
 	}
 
+	t.Parallel()
 	ctx := context.Background()
 	cfg := config.TestConfig()
 	cfg.Database.URL = databaseURL
@@ -210,6 +212,7 @@ func TestContactBy_UpdateContactLastContactedIfLater(t *testing.T) {
 		t.Skip("DATABASE_URL not set, skipping integration test")
 	}
 
+	t.Parallel()
 	ctx := context.Background()
 	cfg := config.TestConfig()
 	cfg.Database.URL = databaseURL
@@ -327,6 +330,7 @@ func TestContactBy_CadenceStateTransitions(t *testing.T) {
 		t.Skip("DATABASE_URL not set, skipping integration test")
 	}
 
+	t.Parallel()
 	ctx := context.Background()
 	cfg := config.TestConfig()
 	cfg.Database.URL = databaseURL
@@ -462,6 +466,7 @@ func TestContactBy_ListOverdueContacts(t *testing.T) {
 		t.Skip("DATABASE_URL not set, skipping integration test")
 	}
 
+	t.Parallel()
 	ctx := context.Background()
 	cfg := config.TestConfig()
 	cfg.Database.URL = databaseURL

--- a/backend/tests/contact_task_integration_test.go
+++ b/backend/tests/contact_task_integration_test.go
@@ -44,7 +44,12 @@ func TestContactTask_CRUD(t *testing.T) {
 
 	contactRepo := repository.NewContactRepository(database.Queries)
 	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
-	gen, _ := migrationGenerator(t)
+	gen, ns := migrationGenerator(t)
+
+	// tid suffixes a fixed external-task-id literal with the per-test namespace
+	// so the (provider, external_task_id) unique/upsert keys don't collide
+	// across parallel clones.
+	tid := func(s string) string { return s + "-" + ns }
 
 	// Seed a test contact via the synthetic factory (FK target for the tasks).
 	contact, contactCleanup := seedMigrationContact(ctx, t, database, gen, factory.WithCadence("weekly"))
@@ -57,7 +62,7 @@ func TestContactTask_CRUD(t *testing.T) {
 			Provider:       "todoist",
 			Kind:           contacttask.KindReachOut,
 			Lifecycle:      contacttask.LifecycleCadenceDue,
-			ExternalTaskID: "12345",
+			ExternalTaskID: tid("12345"),
 			State:          "managed",
 			Metadata:       map[string]any{"test_key": "test_value"},
 		})
@@ -65,7 +70,7 @@ func TestContactTask_CRUD(t *testing.T) {
 		assert.Equal(t, contact.ID, task.ContactID)
 		assert.Equal(t, "todoist", task.Provider)
 		assert.Equal(t, contacttask.KindReachOut, task.Kind)
-		assert.Equal(t, "12345", task.ExternalTaskID)
+		assert.Equal(t, tid("12345"), task.ExternalTaskID)
 		assert.Equal(t, repository.ContactTaskStateManaged, task.State)
 
 		// Retrieve by ID
@@ -80,7 +85,7 @@ func TestContactTask_CRUD(t *testing.T) {
 		assert.Equal(t, task.ID, retrieved2.ID)
 
 		// Retrieve by external ID
-		retrieved3, err := contactTaskRepo.GetContactTaskByExternalID(ctx, "todoist", "12345")
+		retrieved3, err := contactTaskRepo.GetContactTaskByExternalID(ctx, "todoist", tid("12345"))
 		require.NoError(t, err)
 		assert.Equal(t, task.ID, retrieved3.ID)
 
@@ -96,11 +101,11 @@ func TestContactTask_CRUD(t *testing.T) {
 			Provider:       "todoist",
 			Kind:           contacttask.KindReachOut,
 			Lifecycle:      contacttask.LifecycleCadenceDue,
-			ExternalTaskID: "11111",
+			ExternalTaskID: tid("11111"),
 			State:          string(repository.ContactTaskStateManaged),
 		})
 		require.NoError(t, err)
-		assert.Equal(t, "11111", task1.ExternalTaskID)
+		assert.Equal(t, tid("11111"), task1.ExternalTaskID)
 		assert.Equal(t, repository.ContactTaskStateManaged, task1.State)
 
 		// Upsert again with same external_task_id (should update state)
@@ -109,12 +114,12 @@ func TestContactTask_CRUD(t *testing.T) {
 			Provider:       "todoist",
 			Kind:           contacttask.KindReachOut,
 			Lifecycle:      contacttask.LifecycleCadenceDue,
-			ExternalTaskID: "11111", // Same external ID
+			ExternalTaskID: tid("11111"), // Same external ID
 			State:          string(repository.ContactTaskStateUnmanaged),
 		})
 		require.NoError(t, err)
 		assert.Equal(t, task1.ID, task2.ID)                                // Same ID (upsert matched)
-		assert.Equal(t, "11111", task2.ExternalTaskID)                     // Same external ID (it's the key)
+		assert.Equal(t, tid("11111"), task2.ExternalTaskID)                // Same external ID (it's the key)
 		assert.Equal(t, repository.ContactTaskStateUnmanaged, task2.State) // State was updated
 
 		// Clean up
@@ -129,7 +134,7 @@ func TestContactTask_CRUD(t *testing.T) {
 			Provider:       "todoist",
 			Kind:           contacttask.KindReachOut,
 			Lifecycle:      contacttask.LifecycleCadenceDue,
-			ExternalTaskID: "33333",
+			ExternalTaskID: tid("33333"),
 		})
 		require.NoError(t, err)
 		assert.Equal(t, repository.ContactTaskStateManaged, task.State)
@@ -151,7 +156,7 @@ func TestContactTask_CRUD(t *testing.T) {
 			Provider:       "todoist",
 			Kind:           contacttask.KindReachOut,
 			Lifecycle:      contacttask.LifecycleCadenceDue,
-			ExternalTaskID: "44444",
+			ExternalTaskID: tid("44444"),
 		})
 		require.NoError(t, err)
 
@@ -178,7 +183,7 @@ func TestContactTask_CRUD(t *testing.T) {
 			Provider:       "todoist",
 			Kind:           contacttask.KindReachOut,
 			Lifecycle:      contacttask.LifecycleCadenceDue,
-			ExternalTaskID: "55555",
+			ExternalTaskID: tid("55555"),
 		})
 		require.NoError(t, err)
 
@@ -210,7 +215,7 @@ func TestContactTask_CRUD(t *testing.T) {
 			Provider:       "todoist",
 			Kind:           contacttask.KindReachOut,
 			Lifecycle:      contacttask.LifecycleCadenceDue,
-			ExternalTaskID: "66666",
+			ExternalTaskID: tid("66666"),
 		})
 		require.NoError(t, err)
 
@@ -233,7 +238,7 @@ func TestContactTask_CRUD(t *testing.T) {
 			Provider:       "todoist",
 			Kind:           contacttask.KindReachOut,
 			Lifecycle:      contacttask.LifecycleCadenceDue,
-			ExternalTaskID: "77777",
+			ExternalTaskID: tid("77777"),
 		})
 		require.NoError(t, err)
 
@@ -253,7 +258,7 @@ func TestContactTask_CRUD(t *testing.T) {
 			Provider:       "todoist",
 			Kind:           contacttask.KindReachOut,
 			Lifecycle:      contacttask.LifecycleCadenceDue,
-			ExternalTaskID: "88888",
+			ExternalTaskID: tid("88888"),
 		})
 		require.NoError(t, err)
 
@@ -263,7 +268,7 @@ func TestContactTask_CRUD(t *testing.T) {
 			Provider:       "todoist",
 			Kind:           contacttask.KindReachOut,
 			Lifecycle:      contacttask.LifecycleCadenceDue,
-			ExternalTaskID: "99999",
+			ExternalTaskID: tid("99999"),
 		})
 		assert.Error(t, err) // Should fail due to unique constraint
 
@@ -359,7 +364,8 @@ func TestContactTask_SyncedDeadlineMetadata(t *testing.T) {
 	defer database.Close()
 
 	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
-	gen, _ := migrationGenerator(t)
+	gen, ns := migrationGenerator(t)
+	tid := func(s string) string { return s + "-" + ns }
 
 	// Seed a test contact via the synthetic factory (FK target for the tasks).
 	contact, contactCleanup := seedMigrationContact(ctx, t, database, gen, factory.WithCadence("weekly"))
@@ -372,7 +378,7 @@ func TestContactTask_SyncedDeadlineMetadata(t *testing.T) {
 			Provider:       "todoist",
 			Kind:           contacttask.KindReachOut,
 			Lifecycle:      contacttask.LifecycleCadenceDue,
-			ExternalTaskID: "temp-uuid-123",
+			ExternalTaskID: tid("temp-uuid-123"),
 			State:          "managed",
 			Metadata: map[string]any{
 				"pending_temp_id": "temp-uuid-123",
@@ -411,7 +417,7 @@ func TestContactTask_SyncedDeadlineMetadata(t *testing.T) {
 			Provider:       "todoist",
 			Kind:           contacttask.KindReachOut,
 			Lifecycle:      contacttask.LifecycleCadenceDue,
-			ExternalTaskID: "12345678",
+			ExternalTaskID: tid("12345678"),
 			State:          "managed",
 			Metadata:       map[string]any{}, // No synced_deadline
 		})
@@ -456,7 +462,8 @@ func TestContactTask_ActionTasks(t *testing.T) {
 	defer database.Close()
 
 	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
-	gen, _ := migrationGenerator(t)
+	gen, ns := migrationGenerator(t)
+	tid := func(s string) string { return s + "-" + ns }
 
 	// Seed a test contact via the synthetic factory (FK target for the tasks).
 	contact, contactCleanup := seedMigrationContact(ctx, t, database, gen)
@@ -469,7 +476,7 @@ func TestContactTask_ActionTasks(t *testing.T) {
 			Provider:       "todoist",
 			Kind:           contacttask.KindAction,
 			Lifecycle:      contacttask.LifecycleManual,
-			ExternalTaskID: "action-task-1",
+			ExternalTaskID: tid("action-task-1"),
 			State:          "managed",
 			Metadata: map[string]any{
 				"content":  "Follow up about surgery",
@@ -485,7 +492,7 @@ func TestContactTask_ActionTasks(t *testing.T) {
 			Provider:       "todoist",
 			Kind:           contacttask.KindAction,
 			Lifecycle:      contacttask.LifecycleManual,
-			ExternalTaskID: "action-task-2",
+			ExternalTaskID: tid("action-task-2"),
 			State:          "managed",
 			Metadata: map[string]any{
 				"content":  "Send contract",
@@ -502,7 +509,7 @@ func TestContactTask_ActionTasks(t *testing.T) {
 			Provider:       "todoist",
 			Kind:           contacttask.KindAction,
 			Lifecycle:      contacttask.LifecycleManual,
-			ExternalTaskID: "action-task-3",
+			ExternalTaskID: tid("action-task-3"),
 			State:          "managed",
 			Metadata: map[string]any{
 				"content": "No due date task",
@@ -526,7 +533,7 @@ func TestContactTask_ActionTasks(t *testing.T) {
 			Provider:       "todoist",
 			Kind:           contacttask.KindAction,
 			Lifecycle:      contacttask.LifecycleManual,
-			ExternalTaskID: "action-managed",
+			ExternalTaskID: tid("action-managed"),
 			State:          "managed",
 		})
 		require.NoError(t, err)
@@ -536,7 +543,7 @@ func TestContactTask_ActionTasks(t *testing.T) {
 			Provider:       "todoist",
 			Kind:           contacttask.KindAction,
 			Lifecycle:      contacttask.LifecycleManual,
-			ExternalTaskID: "action-completed",
+			ExternalTaskID: tid("action-completed"),
 			State:          "completed",
 		})
 		require.NoError(t, err)
@@ -546,7 +553,7 @@ func TestContactTask_ActionTasks(t *testing.T) {
 			Provider:       "todoist",
 			Kind:           contacttask.KindReachOut,
 			Lifecycle:      contacttask.LifecycleCadenceDue,
-			ExternalTaskID: "cadence-managed",
+			ExternalTaskID: tid("cadence-managed"),
 			State:          "managed",
 		})
 		require.NoError(t, err)
@@ -567,7 +574,7 @@ func TestContactTask_ActionTasks(t *testing.T) {
 		completedTasks, err := contactTaskRepo.ListContactTasksFiltered(ctx, contact.ID, &completed, nil, nil)
 		require.NoError(t, err)
 		assert.Len(t, completedTasks, 1)
-		assert.Equal(t, "action-completed", completedTasks[0].ExternalTaskID)
+		assert.Equal(t, tid("action-completed"), completedTasks[0].ExternalTaskID)
 
 		// Filter by kind=action
 		action := "action"
@@ -579,7 +586,7 @@ func TestContactTask_ActionTasks(t *testing.T) {
 		actionManagedTasks, err := contactTaskRepo.ListContactTasksFiltered(ctx, contact.ID, &managed, &action, nil)
 		require.NoError(t, err)
 		assert.Len(t, actionManagedTasks, 1)
-		assert.Equal(t, "action-managed", actionManagedTasks[0].ExternalTaskID)
+		assert.Equal(t, tid("action-managed"), actionManagedTasks[0].ExternalTaskID)
 
 		// Clean up
 		err = contactTaskRepo.DeleteContactTask(ctx, actionManaged.ID)
@@ -597,7 +604,7 @@ func TestContactTask_ActionTasks(t *testing.T) {
 			Provider:       "todoist",
 			Kind:           contacttask.KindAction,
 			Lifecycle:      contacttask.LifecycleManual,
-			ExternalTaskID: "task-to-complete",
+			ExternalTaskID: tid("task-to-complete"),
 			State:          "managed",
 		})
 		require.NoError(t, err)
@@ -625,7 +632,7 @@ func TestContactTask_ActionTasks(t *testing.T) {
 			Provider:       "todoist",
 			Kind:           contacttask.KindAction,
 			Lifecycle:      contacttask.LifecycleManual,
-			ExternalTaskID: "action-with-metadata",
+			ExternalTaskID: tid("action-with-metadata"),
 			State:          "managed",
 			Metadata: map[string]any{
 				"content":    "Follow up about surgery",

--- a/backend/tests/contact_task_integration_test.go
+++ b/backend/tests/contact_task_integration_test.go
@@ -32,6 +32,7 @@ func TestContactTask_CRUD(t *testing.T) {
 		t.Skip("DATABASE_URL not set, skipping integration test")
 	}
 
+	t.Parallel()
 	ctx := context.Background()
 	cfg := config.TestConfig()
 	cfg.Database.URL = databaseURL
@@ -289,6 +290,7 @@ func TestContactTask_CountByProvider(t *testing.T) {
 		t.Skip("DATABASE_URL not set, skipping integration test")
 	}
 
+	t.Parallel()
 	ctx := context.Background()
 	cfg := config.TestConfig()
 	cfg.Database.URL = databaseURL
@@ -310,13 +312,16 @@ func TestContactTask_CountByProvider(t *testing.T) {
 		contacts = append(contacts, c.ID)
 	}
 
-	// Create tasks for each contact
+	// Create tasks for each contact. Track the IDs so cleanup deletes only this
+	// test's own rows — a DB-wide DeleteContactTasksByProvider("todoist") would
+	// nuke parallel tests' tasks.
+	var taskIDs []uuid.UUID
 	for i, contactID := range contacts {
 		state := "managed"
 		if i == 2 {
 			state = "unmanaged"
 		}
-		_, err := contactTaskRepo.CreateContactTask(ctx, repository.CreateContactTaskRequest{
+		task, err := contactTaskRepo.CreateContactTask(ctx, repository.CreateContactTaskRequest{
 			ContactID:      contactID,
 			Provider:       "todoist",
 			Kind:           contacttask.KindReachOut,
@@ -325,12 +330,16 @@ func TestContactTask_CountByProvider(t *testing.T) {
 			State:          state,
 		})
 		require.NoError(t, err)
+		taskIDs = append(taskIDs, task.ID)
 	}
 	defer func() {
-		_ = contactTaskRepo.DeleteContactTasksByProvider(ctx, "todoist")
+		for _, id := range taskIDs {
+			_ = contactTaskRepo.DeleteContactTask(ctx, id)
+		}
 	}()
 
-	// Count managed tasks
+	// Count managed tasks (GreaterOrEqual is shared-DB-safe: this test's own
+	// rows guarantee the minimum, parallel tests can only add more).
 	managedCount, err := contactTaskRepo.CountContactTasksByProvider(ctx, "todoist", "managed")
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, managedCount, int64(2))
@@ -353,6 +362,7 @@ func TestContactTask_SyncedDeadlineMetadata(t *testing.T) {
 		t.Skip("DATABASE_URL not set, skipping integration test")
 	}
 
+	t.Parallel()
 	ctx := context.Background()
 	cfg := config.TestConfig()
 	cfg.Database.URL = databaseURL
@@ -451,6 +461,7 @@ func TestContactTask_ActionTasks(t *testing.T) {
 		t.Skip("DATABASE_URL not set, skipping integration test")
 	}
 
+	t.Parallel()
 	ctx := context.Background()
 	cfg := config.TestConfig()
 	cfg.Database.URL = databaseURL
@@ -682,6 +693,7 @@ func TestContactTask_Migration046_CheckConstraints(t *testing.T) {
 		t.Skip("DATABASE_URL not set, skipping integration test")
 	}
 
+	t.Parallel()
 	ctx := context.Background()
 	cfg := config.TestConfig()
 	cfg.Database.URL = databaseURL
@@ -805,6 +817,7 @@ func TestContactTask_Migration046_PartialUniqueIndexes(t *testing.T) {
 		t.Skip("DATABASE_URL not set, skipping integration test")
 	}
 
+	t.Parallel()
 	ctx := context.Background()
 	cfg := config.TestConfig()
 	cfg.Database.URL = databaseURL

--- a/backend/tests/contact_task_service_test.go
+++ b/backend/tests/contact_task_service_test.go
@@ -85,18 +85,24 @@ func setupServiceTest(t *testing.T) (*service.ContactTaskService, *repository.Co
 	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
 	syncRepo := repository.NewSyncRepository(database.Queries)
 
+	// Per-test unique identifiers so parallel copies don't share the contact
+	// name (surfaced in the task link) or the sync-state AccountID (its pre-clean
+	// + create would otherwise clobber another run's sync state).
+	suffix := uuid.New().String()[:8]
+	accountID := "test-account-" + suffix
+
 	// Create a test contact
 	now := accelerated.GetCurrentTime()
 	cadence := "weekly"
 	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-		FullName:      "Test Contact for Service",
+		FullName:      "Test Contact for Service " + suffix,
 		Cadence:       &cadence,
 		LastContacted: &now,
 	})
 	require.NoError(t, err)
 
-	// Clean up any existing test sync state
-	_ = syncRepo.DeleteSyncStatesByAccountID(ctx, "test-account-123")
+	// Clean up any existing test sync state for this unique account
+	_ = syncRepo.DeleteSyncStatesByAccountID(ctx, accountID)
 
 	// Create sync state with Todoist settings (simulates configured Todoist)
 	metadata := map[string]any{
@@ -108,7 +114,7 @@ func setupServiceTest(t *testing.T) (*service.ContactTaskService, *repository.Co
 	}
 	syncState, err := syncRepo.CreateSyncState(ctx, repository.CreateSyncStateRequest{
 		Source:    todoist.SourceName,
-		AccountID: strPtr("test-account-123"),
+		AccountID: strPtr(accountID),
 		Metadata:  metadata,
 	})
 	require.NoError(t, err)
@@ -157,7 +163,7 @@ func TestContactTaskService_CreateManualTask_Integration(t *testing.T) {
 		// Verify QuickAdd was called with contact link prefix
 		require.Len(t, mock.quickAddCalls, 1)
 		quickAddText := mock.quickAddCalls[0].Text
-		assert.Contains(t, quickAddText, "[Test Contact for Service]")
+		assert.Contains(t, quickAddText, "["+contact.FullName+"]")
 		assert.Contains(t, quickAddText, "https://example.com/contacts/"+contact.ID.String())
 		assert.Contains(t, quickAddText, "Follow up on proposal")
 	})

--- a/backend/tests/contact_task_service_test.go
+++ b/backend/tests/contact_task_service_test.go
@@ -141,6 +141,7 @@ func TestContactTaskService_CreateManualTask_Integration(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 
+	t.Parallel()
 	svc, contact, cleanup := setupServiceTest(t)
 	defer cleanup()
 
@@ -428,6 +429,7 @@ func TestContactTaskService_CRMMarkerFormat(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 
+	t.Parallel()
 	svc, contact, cleanup := setupServiceTest(t)
 	defer cleanup()
 

--- a/backend/tests/event_bus_integration_test.go
+++ b/backend/tests/event_bus_integration_test.go
@@ -116,6 +116,7 @@ func TestEventRepository_InsertAndFetch_Integration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	database, _ := newEventBusTestDB(t, ctx)
 	repo := repository.NewEventRepository(database.Queries)
@@ -155,6 +156,7 @@ func TestEventRepository_DuplicateSourceID_ReturnsErrDuplicate_Integration(t *te
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	database, _ := newEventBusTestDB(t, ctx)
 	repo := repository.NewEventRepository(database.Queries)
@@ -204,6 +206,7 @@ func TestEventRepository_NullSourceID_AllowsMultipleInserts_Integration(t *testi
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	database, _ := newEventBusTestDB(t, ctx)
 	repo := repository.NewEventRepository(database.Queries)
@@ -240,6 +243,7 @@ func TestEventRepository_GetEvent_NotFound_ReturnsErrNotFound_Integration(t *tes
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	database, _ := newEventBusTestDB(t, ctx)
 	repo := repository.NewEventRepository(database.Queries)
@@ -252,6 +256,7 @@ func TestEventRepository_FindEventBySource_NotFound_ReturnsErrNotFound_Integrati
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	database, _ := newEventBusTestDB(t, ctx)
 	repo := repository.NewEventRepository(database.Queries)

--- a/backend/tests/external_contact_soft_delete_sweep_test.go
+++ b/backend/tests/external_contact_soft_delete_sweep_test.go
@@ -322,6 +322,17 @@ func TestExternalContactUnmatched_HidesUnresolvedTelegramByDefault(t *testing.T)
 		_ = database.Queries.TestDeleteExternalContactsBySourceIDPrefix(cleanCtx, prefix)
 	})
 
+	// CountHiddenUnresolvedTelegram is a DB-wide COUNT with no prefix filter, so
+	// under t.Parallel() it sees other tests' rows. Capture baselines before
+	// seeding and assert the DELTA this test contributes (exactly one hidden
+	// unresolved telegram row), not an absolute count.
+	baseTelegram, err := repo.CountHiddenUnresolvedTelegram(ctx, "telegram")
+	require.NoError(t, err)
+	baseAll, err := repo.CountHiddenUnresolvedTelegram(ctx, "")
+	require.NoError(t, err)
+	baseGcontacts, err := repo.CountHiddenUnresolvedTelegram(ctx, "gcontacts")
+	require.NoError(t, err)
+
 	hidden, err := repo.Upsert(ctx, repository.UpsertExternalContactRequest{
 		Source:   "telegram",
 		SourceID: prefix + "hidden",
@@ -365,13 +376,13 @@ func TestExternalContactUnmatched_HidesUnresolvedTelegramByDefault(t *testing.T)
 
 	hiddenCount, err := repo.CountHiddenUnresolvedTelegram(ctx, "telegram")
 	require.NoError(t, err)
-	require.Equal(t, int64(1), hiddenCount)
+	require.Equal(t, int64(1), hiddenCount-baseTelegram, "this test adds exactly one hidden unresolved telegram row")
 	hiddenCountAll, err := repo.CountHiddenUnresolvedTelegram(ctx, "")
 	require.NoError(t, err)
-	require.Equal(t, int64(1), hiddenCountAll)
+	require.Equal(t, int64(1), hiddenCountAll-baseAll, "same row counts under the unfiltered source")
 	hiddenCountOther, err := repo.CountHiddenUnresolvedTelegram(ctx, "gcontacts")
 	require.NoError(t, err)
-	require.Equal(t, int64(0), hiddenCountOther)
+	require.Equal(t, int64(0), hiddenCountOther-baseGcontacts, "this test adds no gcontacts hidden rows")
 
 	hiddenAfterList, err := repo.GetByID(ctx, hidden.ID)
 	require.NoError(t, err)

--- a/backend/tests/external_contact_soft_delete_sweep_test.go
+++ b/backend/tests/external_contact_soft_delete_sweep_test.go
@@ -200,7 +200,7 @@ func TestExternalContactSweep_ListUnmatched_FiltersTombstone(t *testing.T) {
 		_ = database.Queries.TestDeleteExternalContactsBySourceIDPrefix(cleanCtx, prefix)
 	})
 
-	listed, err := repo.ListUnmatched(ctx, "gcontacts", 1000, 0, false)
+	listed, err := repo.ListUnmatched(ctx, "gcontacts", 100000, 0, false)
 	require.NoError(t, err)
 	foundLive := false
 	for _, r := range listed {
@@ -248,7 +248,7 @@ func TestExternalContactSweep_ListAllUnmatched_FiltersTombstone(t *testing.T) {
 		_ = database.Queries.TestDeleteExternalContactsBySourceIDPrefix(cleanCtx, prefix)
 	})
 
-	listed, err := repo.ListAllUnmatched(ctx, 1000, 0, false)
+	listed, err := repo.ListAllUnmatched(ctx, 100000, 0, false)
 	require.NoError(t, err)
 	foundLive := false
 	for _, r := range listed {

--- a/backend/tests/external_contact_soft_delete_sweep_test.go
+++ b/backend/tests/external_contact_soft_delete_sweep_test.go
@@ -114,6 +114,7 @@ func seedExtSweepFixtures(t *testing.T) *extSweepFixtures {
 }
 
 func TestExternalContactSweep_GetByID_LiveRowReturned(t *testing.T) {
+	t.Parallel()
 	fx := seedExtSweepFixtures(t)
 	row, err := fx.repo.GetByID(context.Background(), fx.live.ID)
 	require.NoError(t, err)
@@ -122,6 +123,7 @@ func TestExternalContactSweep_GetByID_LiveRowReturned(t *testing.T) {
 }
 
 func TestExternalContactSweep_GetByID_TombstonedRowAbsent(t *testing.T) {
+	t.Parallel()
 	fx := seedExtSweepFixtures(t)
 	row, err := fx.repo.GetByID(context.Background(), fx.tombstoned.ID)
 	require.NoError(t, err)
@@ -129,6 +131,7 @@ func TestExternalContactSweep_GetByID_TombstonedRowAbsent(t *testing.T) {
 }
 
 func TestExternalContactSweep_GetBySource_TombstoneAware(t *testing.T) {
+	t.Parallel()
 	fx := seedExtSweepFixtures(t)
 	// Live row reachable.
 	live, err := fx.repo.GetBySource(context.Background(), fx.live.Source, fx.live.SourceID, nil)
@@ -145,6 +148,7 @@ func TestExternalContactSweep_GetBySource_TombstoneAware(t *testing.T) {
 }
 
 func TestExternalContactSweep_FindBySourceAndSourceID_FiltersTombstone(t *testing.T) {
+	t.Parallel()
 	fx := seedExtSweepFixtures(t)
 	// Use the tombstoned row's source_id; FindBySourceAndSourceID is
 	// the rematch query and must NEVER return a tombstoned candidate.
@@ -157,6 +161,7 @@ func TestExternalContactSweep_FindBySourceAndSourceID_FiltersTombstone(t *testin
 }
 
 func TestExternalContactSweep_ListUnmatched_FiltersTombstone(t *testing.T) {
+	t.Parallel()
 	// Re-seed but with both rows unmatched so the predicate fires.
 	databaseURL := os.Getenv("DATABASE_URL")
 	if databaseURL == "" {
@@ -214,6 +219,7 @@ func TestExternalContactSweep_ListAllUnmatched_FiltersTombstone(t *testing.T) {
 	if databaseURL == "" {
 		t.Skip("DATABASE_URL not set, skipping integration test")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	cfg := config.TestConfig()
 	cfg.Database.URL = databaseURL
@@ -261,6 +267,7 @@ func TestExternalContactSweep_CountUnmatched_ExcludesTombstone(t *testing.T) {
 	if databaseURL == "" {
 		t.Skip("DATABASE_URL not set, skipping integration test")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	cfg := config.TestConfig()
 	cfg.Database.URL = databaseURL
@@ -306,6 +313,7 @@ func TestExternalContactUnmatched_HidesUnresolvedTelegramByDefault(t *testing.T)
 	if databaseURL == "" {
 		t.Skip("DATABASE_URL not set, skipping integration test")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	cfg := config.TestConfig()
 	cfg.Database.URL = databaseURL
@@ -391,6 +399,7 @@ func TestExternalContactUnmatched_HidesUnresolvedTelegramByDefault(t *testing.T)
 }
 
 func TestExternalContactSweep_FindByNormalizedEmail_FiltersTombstone(t *testing.T) {
+	t.Parallel()
 	fx := seedExtSweepFixtures(t)
 	// The seed planted the same email on both rows. The matched (live)
 	// row's email is at index 0.
@@ -408,6 +417,7 @@ func TestExternalContactSweep_ListForCRMContact_FiltersTombstone(t *testing.T) {
 	if databaseURL == "" {
 		t.Skip("DATABASE_URL not set, skipping integration test")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	cfg := config.TestConfig()
 	cfg.Database.URL = databaseURL
@@ -466,6 +476,7 @@ func TestExternalContactSweep_RoundTrip_ReviveAfterSoftDelete(t *testing.T) {
 	if databaseURL == "" {
 		t.Skip("DATABASE_URL not set, skipping integration test")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	cfg := config.TestConfig()
 	cfg.Database.URL = databaseURL
@@ -522,6 +533,7 @@ func TestExternalContactSweep_GetByID_AccountIDNullSemantics(t *testing.T) {
 	if databaseURL == "" {
 		t.Skip("DATABASE_URL not set, skipping integration test")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	cfg := config.TestConfig()
 	cfg.Database.URL = databaseURL

--- a/backend/tests/external_contact_soft_delete_sweep_test.go
+++ b/backend/tests/external_contact_soft_delete_sweep_test.go
@@ -308,12 +308,17 @@ func TestExternalContactSweep_CountUnmatched_ExcludesTombstone(t *testing.T) {
 	require.Equal(t, int64(2), count, "tombstoned row must not be counted")
 }
 
+// NOTE: this func stays SERIAL. CountHiddenUnresolvedTelegram is a DB-wide
+// COUNT(*) over source='telegram' with no prefix parameter, so it cannot be
+// scoped to this test's rows. The before/after delta is racy under t.Parallel()
+// because a concurrent telegram test can create/remove a matching hidden
+// unresolved row between the baseline and final reads. The other 11 funcs in
+// this file are prefix-scoped and flip.
 func TestExternalContactUnmatched_HidesUnresolvedTelegramByDefault(t *testing.T) {
 	databaseURL := os.Getenv("DATABASE_URL")
 	if databaseURL == "" {
 		t.Skip("DATABASE_URL not set, skipping integration test")
 	}
-	t.Parallel()
 	ctx := context.Background()
 	cfg := config.TestConfig()
 	cfg.Database.URL = databaseURL

--- a/backend/tests/gchat_enablement_reconcile_test.go
+++ b/backend/tests/gchat_enablement_reconcile_test.go
@@ -81,6 +81,7 @@ func (e *reconcileEnv) countGChatStatesForAccount(t *testing.T, accountID string
 // --- creates one state per SCOPED credential; unscoped gets none ------------
 
 func TestReconcileGChat_CreatesStatePerScopedCredential(t *testing.T) {
+	t.Parallel()
 	e := newReconcileEnv(t)
 	scoped1 := uniqueAccount("gchat-scoped1")
 	scoped2 := uniqueAccount("gchat-scoped2")
@@ -122,6 +123,7 @@ func TestReconcileGChat_CreatesStatePerScopedCredential(t *testing.T) {
 // --- scope gate is the CREATE gate, not warn-and-create ---------------------
 
 func TestReconcileGChat_ScopeGate_NoStateForUnscopedAccount(t *testing.T) {
+	t.Parallel()
 	e := newReconcileEnv(t)
 	acct := uniqueAccount("gchat-gate")
 	e.cleanupAccount(t, acct)
@@ -144,6 +146,7 @@ func TestReconcileGChat_ScopeGate_NoStateForUnscopedAccount(t *testing.T) {
 // --- scope gate requires the FULL chat-scope set (partial grants rejected) ---
 
 func TestReconcileGChat_ScopeGate_PartialChatScopesNotEnabled(t *testing.T) {
+	t.Parallel()
 	e := newReconcileEnv(t)
 
 	// Each subset is missing at least one required scope, so none must enable.
@@ -178,6 +181,7 @@ func TestReconcileGChat_ScopeGate_PartialChatScopesNotEnabled(t *testing.T) {
 // --- idempotent re-run: no duplicates, no cursor/metadata reset -------------
 
 func TestReconcileGChat_IdempotentRerun_NoDuplicatesNoReset(t *testing.T) {
+	t.Parallel()
 	e := newReconcileEnv(t)
 	acct := uniqueAccount("gchat-idem")
 	e.cleanupAccount(t, acct)
@@ -220,6 +224,7 @@ func TestReconcileGChat_IdempotentRerun_NoDuplicatesNoReset(t *testing.T) {
 // --- respects a user-disabled state (never re-enabled) ----------------------
 
 func TestReconcileGChat_RespectsUserDisabled(t *testing.T) {
+	t.Parallel()
 	e := newReconcileEnv(t)
 	acct := uniqueAccount("gchat-disabled")
 	e.cleanupAccount(t, acct)
@@ -247,6 +252,7 @@ func TestReconcileGChat_RespectsUserDisabled(t *testing.T) {
 // --- re-consent transition: the gate opens when the scope appears -----------
 
 func TestReconcileGChat_ReConsentTransition_GateOpens(t *testing.T) {
+	t.Parallel()
 	e := newReconcileEnv(t)
 	acct := uniqueAccount("gchat-reconsent")
 	e.cleanupAccount(t, acct)
@@ -310,6 +316,7 @@ func TestReconcileGChat_PerAccountShape_NoNullAccountRow(t *testing.T) {
 // --- empty account list is a no-op ------------------------------------------
 
 func TestReconcileGChat_EmptyAccountList_NoOp(t *testing.T) {
+	t.Parallel()
 	e := newReconcileEnv(t)
 	lister := &reconcileStubLister{accounts: nil}
 	e.service.SetGChatAccountLister(lister)
@@ -321,6 +328,7 @@ func TestReconcileGChat_EmptyAccountList_NoOp(t *testing.T) {
 // --- nil lister is a no-op (does not even consult a lister) ------------------
 
 func TestReconcileGChat_NilLister_NoOp(t *testing.T) {
+	t.Parallel()
 	e := newReconcileEnv(t)
 	// No SetGChatAccountLister call → nil lister.
 	require.NoError(t, e.service.ReconcileGChatSyncStates(e.ctx))
@@ -329,6 +337,7 @@ func TestReconcileGChat_NilLister_NoOp(t *testing.T) {
 // --- OAuth-connect reconciler closure is idempotent on re-connect -----------
 
 func TestReconcileGChat_ConnectPath_IdempotentOnReconnect(t *testing.T) {
+	t.Parallel()
 	e := newReconcileEnv(t)
 	scoped := uniqueAccount("gchat-connect")
 	unscoped := uniqueAccount("gchat-connect-unscoped")
@@ -361,6 +370,7 @@ func TestReconcileGChat_ConnectPath_IdempotentOnReconnect(t *testing.T) {
 // --- status data path surfaces the gchat state (DD-5 verification) ----------
 
 func TestReconcileGChat_StatusSurfacesGChatState(t *testing.T) {
+	t.Parallel()
 	e := newReconcileEnv(t)
 	acct := uniqueAccount("gchat-status")
 	e.cleanupAccount(t, acct)

--- a/backend/tests/gchat_provider_integration_test.go
+++ b/backend/tests/gchat_provider_integration_test.go
@@ -139,6 +139,7 @@ func chatMessage(name, senderUser, text string, createTime time.Time) *chat.Mess
 // gchat row for a known inbound sender, writes NO events itself, and persists
 // per-space metadata. The row is content-only until the engine aggregates.
 func TestGChatProvider_FullSweep_InboundWritesRowNoEvents(t *testing.T) {
+	t.Parallel()
 	e := setupGChatProviderTest(t)
 	prefix := e.gen.Prefix()
 
@@ -210,6 +211,7 @@ func TestGChatProvider_FullSweep_InboundWritesRowNoEvents(t *testing.T) {
 // (sender ∈ meSet) fans out to every known co-member (one row each, same
 // external_id), while a bystander sender produces no row.
 func TestGChatProvider_OutboundFanOutAndBystander(t *testing.T) {
+	t.Parallel()
 	e := setupGChatProviderTest(t)
 	prefix := e.gen.Prefix()
 
@@ -277,6 +279,7 @@ func TestGChatProvider_OutboundFanOutAndBystander(t *testing.T) {
 // TestGChatProvider_CrossAccountDedup proves the same message observed under two
 // accounts produces ONE row per matched contact with observed_accounts merged.
 func TestGChatProvider_CrossAccountDedup(t *testing.T) {
+	t.Parallel()
 	e := setupGChatProviderTest(t)
 	prefix := e.gen.Prefix()
 
@@ -341,6 +344,7 @@ func TestGChatProvider_CrossAccountDedup(t *testing.T) {
 // ShowDeleted re-list updates the stored body + last_update_time while leaving
 // processed_at untouched (so the engine does not reprocess).
 func TestGChatProvider_EditReconciliation(t *testing.T) {
+	t.Parallel()
 	e := setupGChatProviderTest(t)
 	prefix := e.gen.Prefix()
 
@@ -434,6 +438,7 @@ func TestGChatProvider_EditReconciliation(t *testing.T) {
 // LATER) must NOT apply; the reverse (genuinely newer) must apply. Proves the
 // provider's body-only pre-filter does not invert fractional ordering.
 func TestGChatProvider_EditFractionalOrdering(t *testing.T) {
+	t.Parallel()
 	e := setupGChatProviderTest(t)
 	prefix := e.gen.Prefix()
 
@@ -502,6 +507,7 @@ func TestGChatProvider_EditFractionalOrdering(t *testing.T) {
 // TestGChatProvider_DeleteReconciliation proves a tombstone in the ShowDeleted
 // re-list soft-deletes all fanned-out rows for the message.
 func TestGChatProvider_DeleteReconciliation(t *testing.T) {
+	t.Parallel()
 	e := setupGChatProviderTest(t)
 	prefix := e.gen.Prefix()
 
@@ -567,6 +573,7 @@ func TestGChatProvider_DeleteReconciliation(t *testing.T) {
 // the persisted membership + email cache (no fetcher refetch within TTL) and
 // advances the create cursor so already-ingested messages are not re-listed.
 func TestGChatProvider_MetadataReusedAcrossSweeps(t *testing.T) {
+	t.Parallel()
 	e := setupGChatProviderTest(t)
 	prefix := e.gen.Prefix()
 
@@ -633,6 +640,7 @@ func TestGChatProvider_MetadataReusedAcrossSweeps(t *testing.T) {
 // TestGChatRematch_ScansWhenEnabled proves the enabled gchat rematch handler
 // scans the address across the enabled account and upserts a row.
 func TestGChatRematch_ScansWhenEnabled(t *testing.T) {
+	t.Parallel()
 	e := setupGChatProviderTest(t)
 	prefix := e.gen.Prefix()
 
@@ -755,6 +763,7 @@ func TestGChatRematchHandler_ScansAndAggregates(t *testing.T) {
 // package — its job is the persistence path (window → setCursor → persistMetadata
 // → DB), not the budget boundary.
 func TestGChatProvider_MultiPageWindowPersistsCursor(t *testing.T) {
+	t.Parallel()
 	e := setupGChatProviderTest(t)
 	prefix := e.gen.Prefix()
 
@@ -859,6 +868,7 @@ func spaceCursorFromMetadata(t *testing.T, metadata map[string]any, spaceName st
 // out to the id-resolved contact; (c) the id-resolved contact is a co-member of
 // the group space; (d) the cursor advances (window proven).
 func TestGChatProvider_MatchesContactNotInGoogleContacts(t *testing.T) {
+	t.Parallel()
 	e := setupGChatProviderTest(t)
 	prefix := e.gen.Prefix()
 
@@ -937,6 +947,7 @@ func TestGChatProvider_MatchesContactNotInGoogleContacts(t *testing.T) {
 // MATCHES (the fingerprint flip invalidated the stale negative before the cursor
 // advanced past the message).
 func TestGChatProvider_StaleNegativeClearedOnMembershipChange(t *testing.T) {
+	t.Parallel()
 	e := setupGChatProviderTest(t)
 	prefix := e.gen.Prefix()
 
@@ -1011,6 +1022,7 @@ func TestGChatProvider_StaleNegativeClearedOnMembershipChange(t *testing.T) {
 // the email→id once and sweep 2 (a second space, same email) issues ZERO
 // ResolveMemberID calls (the global positive is reused from persisted metadata).
 func TestGChatProvider_GlobalPositiveCachePersistsAndReused(t *testing.T) {
+	t.Parallel()
 	e := setupGChatProviderTest(t)
 	prefix := e.gen.Prefix()
 
@@ -1090,6 +1102,7 @@ func TestGChatProvider_GlobalPositiveCachePersistsAndReused(t *testing.T) {
 // exact prod failure (processed=0 with all spaces held) turned into a passing
 // assertion.
 func TestGChatProvider_ColdStartProcessesAndAdvancesDespiteResolveDebt(t *testing.T) {
+	t.Parallel()
 	e := setupGChatProviderTest(t)
 	prefix := e.gen.Prefix()
 
@@ -1175,6 +1188,7 @@ func TestGChatProvider_ColdStartProcessesAndAdvancesDespiteResolveDebt(t *testin
 // and a People-resolvable co-member's message DOES match. Sweep 2 (cap raised): a
 // NEW message from the now-resolvable contact, sent after the cursor, matches.
 func TestGChatProvider_DeferredIDContactMatchesOnLaterSweep(t *testing.T) {
+	t.Parallel()
 	e := setupGChatProviderTest(t)
 	prefix := e.gen.Prefix()
 
@@ -1275,6 +1289,7 @@ func TestGChatProvider_DeferredIDContactMatchesOnLaterSweep(t *testing.T) {
 // no known inbound sender) STILL advances its cursor (window pages to zero
 // matchable rows and proven advances it).
 func TestGChatProvider_NoCurrentMemberSpaceStillPagesAndAdvances(t *testing.T) {
+	t.Parallel()
 	e := setupGChatProviderTest(t)
 	prefix := e.gen.Prefix()
 
@@ -1365,6 +1380,7 @@ func TestGChatProvider_NoCurrentMemberSpaceStillPagesAndAdvances(t *testing.T) {
 // leaving budget for later spaces. Asserts the front space advances AND a later
 // space is also processed in the same sweep (forward progress, no starvation).
 func TestGChatProvider_ColdStartFrontSpaceDoesNotStarveLaterSpaces(t *testing.T) {
+	t.Parallel()
 	e := setupGChatProviderTest(t)
 	prefix := e.gen.Prefix()
 
@@ -1437,6 +1453,7 @@ func TestGChatProvider_ColdStartFrontSpaceDoesNotStarveLaterSpaces(t *testing.T)
 // row per contact, no duplicate. Guards the "process with partial index now,
 // fuller later" safety claim.
 func TestGChatProvider_NoDoubleProcessOnReResolve(t *testing.T) {
+	t.Parallel()
 	e := setupGChatProviderTest(t)
 	prefix := e.gen.Prefix()
 
@@ -1533,6 +1550,7 @@ func TestGChatProvider_NoDoubleProcessOnReResolve(t *testing.T) {
 // identical (fingerprint stable). The cursor advances every sweep and ZERO
 // ResolveMemberID calls fire for the absent contact after the first.
 func TestGChatProvider_HotSpaceNoStarvation(t *testing.T) {
+	t.Parallel()
 	e := setupGChatProviderTest(t)
 	prefix := e.gen.Prefix()
 
@@ -1616,6 +1634,7 @@ func TestGChatProvider_HotSpaceNoStarvation(t *testing.T) {
 // so the historical message still upserts. Proves the rematch path uses the new
 // id resolution.
 func TestGChatRematch_IDResolutionMatchesHistory(t *testing.T) {
+	t.Parallel()
 	e := setupGChatProviderTest(t)
 	prefix := e.gen.Prefix()
 

--- a/backend/tests/gmail_enablement_reconcile_test.go
+++ b/backend/tests/gmail_enablement_reconcile_test.go
@@ -119,6 +119,7 @@ func credWithScope(accountID string, scopes ...string) repository.OAuthCredentia
 // --- creates-one-state-per-credential ---------------------------------------
 
 func TestReconcileEmail_CreatesStatePerCredential(t *testing.T) {
+	t.Parallel()
 	e := newReconcileEnv(t)
 	a1 := uniqueAccount("acct1")
 	a2 := uniqueAccount("acct2")
@@ -153,6 +154,7 @@ func TestReconcileEmail_CreatesStatePerCredential(t *testing.T) {
 // --- idempotent re-run: no duplicates, no cursor/metadata reset -------------
 
 func TestReconcileEmail_IdempotentRerun_NoDuplicatesNoReset(t *testing.T) {
+	t.Parallel()
 	e := newReconcileEnv(t)
 	acct := uniqueAccount("idem")
 	e.cleanupAccount(t, acct)
@@ -192,6 +194,11 @@ func TestReconcileEmail_IdempotentRerun_NoDuplicatesNoReset(t *testing.T) {
 
 // --- operator reset: enabled email cursors only -----------------------------
 
+// NOTE: this test stays SERIAL. ResetGmailBackfillCursors scans and mutates
+// ALL enabled email sync states DB-wide and the test asserts an exact
+// Scanned/Reset count, so a concurrent test's enabled email state would be
+// swept into the count (and could be deleted mid-reset). Inherently global —
+// not parallelizable without a per-account scoping parameter on the service.
 func TestResetGmailBackfillCursors_ResetsOnlyEnabledEmailStates(t *testing.T) {
 	e := newReconcileEnv(t)
 	enabledAcct := uniqueAccount("reset-enabled")
@@ -288,6 +295,7 @@ func TestResetGmailBackfillCursors_ResetsOnlyEnabledEmailStates(t *testing.T) {
 // --- respects a user-disabled state (never re-enabled) ----------------------
 
 func TestReconcileEmail_RespectsUserDisabled(t *testing.T) {
+	t.Parallel()
 	e := newReconcileEnv(t)
 	acct := uniqueAccount("disabled")
 	e.cleanupAccount(t, acct)
@@ -315,6 +323,7 @@ func TestReconcileEmail_RespectsUserDisabled(t *testing.T) {
 // --- scope warning on the CREATE branch (no existing state) -----------------
 
 func TestReconcileEmail_ScopeWarn_OnCreateBranch(t *testing.T) {
+	t.Parallel()
 	e := newReconcileEnv(t)
 	acct := uniqueAccount("noscope-create")
 	e.cleanupAccount(t, acct)
@@ -337,6 +346,7 @@ func TestReconcileEmail_ScopeWarn_OnCreateBranch(t *testing.T) {
 // --- scope warning on the FOUND branch (state pre-exists) -------------------
 
 func TestReconcileEmail_ScopeWarn_OnFoundBranch(t *testing.T) {
+	t.Parallel()
 	e := newReconcileEnv(t)
 	acct := uniqueAccount("noscope-found")
 	e.cleanupAccount(t, acct)
@@ -369,6 +379,7 @@ func TestReconcileEmail_ScopeWarn_OnFoundBranch(t *testing.T) {
 // --- per-account shape invariant: no (email, NULL) row ever produced --------
 
 func TestReconcileEmail_PerAccountShape_NoNullAccountRow(t *testing.T) {
+	t.Parallel()
 	e := newReconcileEnv(t)
 	acct := uniqueAccount("shape")
 	e.cleanupAccount(t, acct)
@@ -394,6 +405,7 @@ func TestReconcileEmail_PerAccountShape_NoNullAccountRow(t *testing.T) {
 // --- empty account list is a no-op ------------------------------------------
 
 func TestReconcileEmail_EmptyAccountList_NoOp(t *testing.T) {
+	t.Parallel()
 	e := newReconcileEnv(t)
 	lister := &reconcileStubLister{accounts: nil}
 	e.service.SetEmailAccountLister(lister)
@@ -405,6 +417,7 @@ func TestReconcileEmail_EmptyAccountList_NoOp(t *testing.T) {
 // --- nil lister is a no-op (does not even consult a lister) ------------------
 
 func TestReconcileEmail_NilLister_NoOp(t *testing.T) {
+	t.Parallel()
 	e := newReconcileEnv(t)
 	// No SetEmailAccountLister call → nil lister.
 	require.NoError(t, e.service.ReconcileEmailSyncStates(e.ctx))
@@ -413,6 +426,7 @@ func TestReconcileEmail_NilLister_NoOp(t *testing.T) {
 // --- OAuth-connect reconciler closure is idempotent on re-connect -----------
 
 func TestReconcileEmail_ConnectPath_IdempotentOnReconnect(t *testing.T) {
+	t.Parallel()
 	e := newReconcileEnv(t)
 	acct := uniqueAccount("connect")
 	e.cleanupAccount(t, acct)

--- a/backend/tests/identity_integration_test.go
+++ b/backend/tests/identity_integration_test.go
@@ -28,6 +28,7 @@ func TestIdentityRepository_Integration(t *testing.T) {
 		t.Skip("DATABASE_URL not set, skipping integration test")
 	}
 
+	t.Parallel()
 	ctx := context.Background()
 
 	// Migrations are applied once by TestMain.
@@ -306,6 +307,7 @@ func TestIdentityService_Integration(t *testing.T) {
 		t.Skip("DATABASE_URL not set, skipping integration test")
 	}
 
+	t.Parallel()
 	ctx := context.Background()
 
 	// Migrations are applied once by TestMain.
@@ -560,6 +562,7 @@ func TestIdentityService_NormalizationPolicy_Integration(t *testing.T) {
 		t.Skip("DATABASE_URL not set, skipping integration test")
 	}
 
+	t.Parallel()
 	ctx := context.Background()
 
 	// Migrations are applied once by TestMain.

--- a/backend/tests/identity_integration_test.go
+++ b/backend/tests/identity_integration_test.go
@@ -185,8 +185,9 @@ func TestIdentityRepository_Integration(t *testing.T) {
 		require.NoError(t, err)
 		defer func() { _ = repo.Delete(ctx, ident2.ID) }()
 
-		// List unmatched
-		unmatched, err := repo.ListUnmatched(ctx, 100, 0)
+		// List unmatched. A high limit keeps both rows in the window even as the
+		// shared DB accumulates unmatched identities across runs.
+		unmatched, err := repo.ListUnmatched(ctx, 100000, 0)
 		require.NoError(t, err)
 
 		// Should contain our test identities, sorted by message_count desc.

--- a/backend/tests/identity_integration_test.go
+++ b/backend/tests/identity_integration_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 
@@ -41,16 +42,23 @@ func TestIdentityRepository_Integration(t *testing.T) {
 
 	repo := repository.NewIdentityRepository(database.Queries)
 
+	// Per-test-run unique suffix so the (identifier, type, source)-keyed
+	// accumulating upserts don't collide with a parallel copy and corrupt the
+	// exact message_count / ordering assertions below.
+	ns := uuid.NewString()[:8]
+	src := "test_source_" + ns
+
 	t.Run("UpsertAndGetIdentity", func(t *testing.T) {
-		rawIdentifier := "TEST.USER@EXAMPLE.COM"
+		identifier := "test.user." + ns + "@example.com"
+		rawIdentifier := "TEST.USER." + ns + "@EXAMPLE.COM"
 		displayName := "Test User"
 
 		// Create an identity
 		ident, err := repo.Upsert(ctx, repository.UpsertIdentityRequest{
-			Identifier:     "test.user@example.com",
+			Identifier:     identifier,
 			IdentifierType: identity.IdentifierTypeEmail,
 			RawIdentifier:  &rawIdentifier,
-			Source:         "test_source",
+			Source:         src,
 			MatchType:      repository.MatchTypeUnmatched,
 			DisplayName:    &displayName,
 			MessageCount:   1,
@@ -59,9 +67,9 @@ func TestIdentityRepository_Integration(t *testing.T) {
 		require.NotNil(t, ident)
 
 		// Verify fields
-		assert.Equal(t, "test.user@example.com", ident.Identifier)
+		assert.Equal(t, identifier, ident.Identifier)
 		assert.Equal(t, identity.IdentifierTypeEmail, ident.IdentifierType)
-		assert.Equal(t, "test_source", ident.Source)
+		assert.Equal(t, src, ident.Source)
 		assert.Equal(t, repository.MatchTypeUnmatched, ident.MatchType)
 		assert.Equal(t, "Test User", *ident.DisplayName)
 		assert.Equal(t, int32(1), ident.MessageCount)
@@ -74,7 +82,7 @@ func TestIdentityRepository_Integration(t *testing.T) {
 		assert.Equal(t, ident.Identifier, found.Identifier)
 
 		// Get by identifier
-		found, err = repo.GetByIdentifier(ctx, identity.IdentifierTypeEmail, "test.user@example.com", "test_source")
+		found, err = repo.GetByIdentifier(ctx, identity.IdentifierTypeEmail, identifier, src)
 		require.NoError(t, err)
 		assert.Equal(t, ident.ID, found.ID)
 
@@ -84,11 +92,12 @@ func TestIdentityRepository_Integration(t *testing.T) {
 	})
 
 	t.Run("UpsertIncrementsMessageCount", func(t *testing.T) {
+		identifier := "increment.test." + ns + "@example.com"
 		// Create identity
 		ident, err := repo.Upsert(ctx, repository.UpsertIdentityRequest{
-			Identifier:     "increment.test@example.com",
+			Identifier:     identifier,
 			IdentifierType: identity.IdentifierTypeEmail,
-			Source:         "test_source",
+			Source:         src,
 			MatchType:      repository.MatchTypeUnmatched,
 			MessageCount:   1,
 		})
@@ -97,9 +106,9 @@ func TestIdentityRepository_Integration(t *testing.T) {
 
 		// Upsert again - should increment
 		ident, err = repo.Upsert(ctx, repository.UpsertIdentityRequest{
-			Identifier:     "increment.test@example.com",
+			Identifier:     identifier,
 			IdentifierType: identity.IdentifierTypeEmail,
-			Source:         "test_source",
+			Source:         src,
 			MatchType:      repository.MatchTypeUnmatched,
 			MessageCount:   5,
 		})
@@ -122,9 +131,9 @@ func TestIdentityRepository_Integration(t *testing.T) {
 
 		// Create an unmatched identity
 		ident, err := repo.Upsert(ctx, repository.UpsertIdentityRequest{
-			Identifier:     "link.test@example.com",
+			Identifier:     "link.test." + ns + "@example.com",
 			IdentifierType: identity.IdentifierTypeEmail,
-			Source:         "test_source",
+			Source:         src,
 			MatchType:      repository.MatchTypeUnmatched,
 			MessageCount:   1,
 		})
@@ -156,9 +165,9 @@ func TestIdentityRepository_Integration(t *testing.T) {
 	t.Run("ListUnmatched", func(t *testing.T) {
 		// Create some unmatched identities
 		ident1, err := repo.Upsert(ctx, repository.UpsertIdentityRequest{
-			Identifier:     "unmatched1@example.com",
+			Identifier:     "unmatched1." + ns + "@example.com",
 			IdentifierType: identity.IdentifierTypeEmail,
-			Source:         "test_source",
+			Source:         src,
 			MatchType:      repository.MatchTypeUnmatched,
 			MessageCount:   10,
 		})
@@ -166,9 +175,9 @@ func TestIdentityRepository_Integration(t *testing.T) {
 		defer func() { _ = repo.Delete(ctx, ident1.ID) }()
 
 		ident2, err := repo.Upsert(ctx, repository.UpsertIdentityRequest{
-			Identifier:     "unmatched2@example.com",
+			Identifier:     "unmatched2." + ns + "@example.com",
 			IdentifierType: identity.IdentifierTypeEmail,
-			Source:         "test_source",
+			Source:         src,
 			MatchType:      repository.MatchTypeUnmatched,
 			MessageCount:   5,
 		})
@@ -179,7 +188,9 @@ func TestIdentityRepository_Integration(t *testing.T) {
 		unmatched, err := repo.ListUnmatched(ctx, 100, 0)
 		require.NoError(t, err)
 
-		// Should contain our test identities, sorted by message_count desc
+		// Should contain our test identities, sorted by message_count desc.
+		// The relative ordering (idx1 < idx2) holds even with other parallel
+		// tests' rows interspersed, since ident1 (10 msgs) outranks ident2 (5).
 		found1, found2 := false, false
 		var idx1, idx2 int
 		for i, u := range unmatched {
@@ -211,11 +222,13 @@ func TestIdentityRepository_Integration(t *testing.T) {
 		require.NoError(t, err)
 		defer func() { _ = contactRepo.HardDeleteContact(ctx, contact.ID) }()
 
-		// Create identities linked to contact
+		// Create identities linked to contact. The email is namespaced and the
+		// phone's source is namespaced so the (identifier, type, source) upsert
+		// keys are unique to this test run.
 		ident1, err := repo.Upsert(ctx, repository.UpsertIdentityRequest{
-			Identifier:     "contact.ident1@example.com",
+			Identifier:     "contact.ident1." + ns + "@example.com",
 			IdentifierType: identity.IdentifierTypeEmail,
-			Source:         "gmail",
+			Source:         "gmail_" + ns,
 			ContactID:      &contact.ID,
 			MatchType:      repository.MatchTypeExact,
 			MessageCount:   1,
@@ -226,7 +239,7 @@ func TestIdentityRepository_Integration(t *testing.T) {
 		ident2, err := repo.Upsert(ctx, repository.UpsertIdentityRequest{
 			Identifier:     "+15551234567",
 			IdentifierType: identity.IdentifierTypePhone,
-			Source:         "imessage",
+			Source:         "imessage_" + ns,
 			ContactID:      &contact.ID,
 			MatchType:      repository.MatchTypeExact,
 			MessageCount:   1,
@@ -234,7 +247,7 @@ func TestIdentityRepository_Integration(t *testing.T) {
 		require.NoError(t, err)
 		defer func() { _ = repo.Delete(ctx, ident2.ID) }()
 
-		// List for contact
+		// List for contact (scoped to this run's unique contact)
 		identities, err := repo.ListForContact(ctx, contact.ID)
 		require.NoError(t, err)
 		assert.Len(t, identities, 2)
@@ -251,9 +264,9 @@ func TestIdentityRepository_Integration(t *testing.T) {
 
 		// Create unmatched identities
 		ident1, err := repo.Upsert(ctx, repository.UpsertIdentityRequest{
-			Identifier:     "bulk1@example.com",
+			Identifier:     "bulk1." + ns + "@example.com",
 			IdentifierType: identity.IdentifierTypeEmail,
-			Source:         "test_source",
+			Source:         src,
 			MatchType:      repository.MatchTypeUnmatched,
 			MessageCount:   1,
 		})
@@ -261,9 +274,9 @@ func TestIdentityRepository_Integration(t *testing.T) {
 		defer func() { _ = repo.Delete(ctx, ident1.ID) }()
 
 		ident2, err := repo.Upsert(ctx, repository.UpsertIdentityRequest{
-			Identifier:     "bulk2@example.com",
+			Identifier:     "bulk2." + ns + "@example.com",
 			IdentifierType: identity.IdentifierTypeEmail,
-			Source:         "test_source",
+			Source:         src,
 			MatchType:      repository.MatchTypeUnmatched,
 			MessageCount:   1,
 		})
@@ -310,11 +323,16 @@ func TestIdentityService_Integration(t *testing.T) {
 	methodRepo := repository.NewContactMethodRepository(database.Queries)
 	identityService := service.NewIdentityService(identityRepo)
 
+	// Per-test-run unique suffix so the matched emails/phones and the discovery/
+	// cache sources don't collide with a parallel copy (the cached-match path is
+	// order/state-sensitive).
+	ns := uuid.NewString()[:8]
+
 	t.Run("MatchOrCreate_DiscoveryMode_NoMatch", func(t *testing.T) {
 		result, err := identityService.MatchOrCreate(ctx, service.MatchRequest{
-			RawIdentifier: "UNKNOWN@Example.COM",
+			RawIdentifier: "UNKNOWN." + ns + "@Example.COM",
 			Type:          identity.IdentifierTypeEmail,
-			Source:        "test_discovery",
+			Source:        "test_discovery_" + ns,
 		})
 		require.NoError(t, err)
 		require.NotNil(t, result)
@@ -325,7 +343,7 @@ func TestIdentityService_Integration(t *testing.T) {
 		assert.False(t, result.Cached)
 
 		// Verify normalized
-		assert.Equal(t, "unknown@example.com", result.Identity.Identifier)
+		assert.Equal(t, "unknown."+ns+"@example.com", result.Identity.Identifier)
 
 		// Clean up
 		err = identityRepo.Delete(ctx, result.Identity.ID)
@@ -344,7 +362,7 @@ func TestIdentityService_Integration(t *testing.T) {
 		_, err = methodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
 			ContactID: contact.ID,
 			Type:      string(repository.ContactMethodEmail),
-			Value:     "discovery.match@example.com",
+			Value:     "discovery.match." + ns + "@example.com",
 			IsPrimary: true,
 		})
 		require.NoError(t, err)
@@ -352,9 +370,9 @@ func TestIdentityService_Integration(t *testing.T) {
 
 		// Try to match via identity service
 		result, err := identityService.MatchOrCreate(ctx, service.MatchRequest{
-			RawIdentifier: "DISCOVERY.MATCH@EXAMPLE.COM",
+			RawIdentifier: "DISCOVERY.MATCH." + ns + "@EXAMPLE.COM",
 			Type:          identity.IdentifierTypeEmail,
-			Source:        "test_discovery",
+			Source:        "test_discovery_" + ns,
 		})
 		require.NoError(t, err)
 		require.NotNil(t, result)
@@ -382,7 +400,7 @@ func TestIdentityService_Integration(t *testing.T) {
 		_, err = methodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
 			ContactID: contact.ID,
 			Type:      string(repository.ContactMethodEmail),
-			Value:     "cache.test@example.com",
+			Value:     "cache.test." + ns + "@example.com",
 			IsPrimary: true,
 		})
 		require.NoError(t, err)
@@ -390,9 +408,9 @@ func TestIdentityService_Integration(t *testing.T) {
 
 		// First match - should search and cache
 		result1, err := identityService.MatchOrCreate(ctx, service.MatchRequest{
-			RawIdentifier: "cache.test@example.com",
+			RawIdentifier: "cache.test." + ns + "@example.com",
 			Type:          identity.IdentifierTypeEmail,
-			Source:        "test_cache",
+			Source:        "test_cache_" + ns,
 		})
 		require.NoError(t, err)
 		assert.False(t, result1.Cached)
@@ -401,9 +419,9 @@ func TestIdentityService_Integration(t *testing.T) {
 
 		// Second match - should use cache
 		result2, err := identityService.MatchOrCreate(ctx, service.MatchRequest{
-			RawIdentifier: "cache.test@example.com",
+			RawIdentifier: "cache.test." + ns + "@example.com",
 			Type:          identity.IdentifierTypeEmail,
-			Source:        "test_cache",
+			Source:        "test_cache_" + ns,
 		})
 		require.NoError(t, err)
 		assert.True(t, result2.Cached)
@@ -420,9 +438,9 @@ func TestIdentityService_Integration(t *testing.T) {
 
 		// Use contact-driven mode with KnownContactID
 		result, err := identityService.MatchOrCreate(ctx, service.MatchRequest{
-			RawIdentifier:  "CONTACT.DRIVEN@EXAMPLE.COM",
+			RawIdentifier:  "CONTACT.DRIVEN." + ns + "@EXAMPLE.COM",
 			Type:           identity.IdentifierTypeEmail,
-			Source:         "gmail",
+			Source:         "gmail_" + ns,
 			KnownContactID: &contact.ID,
 		})
 		require.NoError(t, err)
@@ -435,7 +453,7 @@ func TestIdentityService_Integration(t *testing.T) {
 		assert.False(t, result.Cached)
 
 		// Verify normalized
-		assert.Equal(t, "contact.driven@example.com", result.Identity.Identifier)
+		assert.Equal(t, "contact.driven."+ns+"@example.com", result.Identity.Identifier)
 
 		// Clean up
 		err = identityRepo.Delete(ctx, result.Identity.ID)
@@ -443,36 +461,46 @@ func TestIdentityService_Integration(t *testing.T) {
 	})
 
 	t.Run("MatchOrCreate_PhoneNormalization", func(t *testing.T) {
-		// Create a contact with phone
+		// Per-test-unique 10-digit phone so a parallel copy's contact (with the
+		// same normalized phone) can't be matched by mistake. Derive a 7-digit
+		// subscriber+exchange from the namespace hash; the 4 format variants all
+		// normalize to the same +1<area><number>.
+		phoneBase, _ := uniqueTestIDs(t, ns) // >= 9_000_000_000
+		sub := phoneBase % 10_000_000        // 7 digits: NXX-XXXX
+		area := 200 + int(phoneBase%700)     // valid-ish NANP area code [200, 899]
+		exch := sub / 10_000                 // 3 digits
+		line := sub % 10_000                 // 4 digits
+
+		// Add contact method with the canonical normalized phone.
+		canonical := fmt.Sprintf("+1%03d%03d%04d", area, exch, line)
 		contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-			FullName: "Phone Match Test",
+			FullName: "Phone Match Test " + ns,
 		})
 		require.NoError(t, err)
 		defer func() { _ = contactRepo.HardDeleteContact(ctx, contact.ID) }()
 
-		// Add contact method with normalized phone
 		_, err = methodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
 			ContactID: contact.ID,
 			Type:      "phone",
-			Value:     "+15551234567",
+			Value:     canonical,
 			IsPrimary: true,
 		})
 		require.NoError(t, err)
 		defer func() { _ = methodRepo.DeleteContactMethodsByContact(ctx, contact.ID) }()
 
-		// Try to match with different phone formats
+		// Try to match with different phone formats — all equivalent to canonical.
 		testCases := []string{
-			"(555) 123-4567",
-			"+1 555 123 4567",
-			"555.123.4567",
-			"1-555-123-4567",
+			fmt.Sprintf("(%03d) %03d-%04d", area, exch, line),
+			fmt.Sprintf("+1 %03d %03d %04d", area, exch, line),
+			fmt.Sprintf("%03d.%03d.%04d", area, exch, line),
+			fmt.Sprintf("1-%03d-%03d-%04d", area, exch, line),
 		}
 
-		for _, phoneFormat := range testCases {
+		for i, phoneFormat := range testCases {
 			result, err := identityService.MatchOrCreate(ctx, service.MatchRequest{
 				RawIdentifier: phoneFormat,
 				Type:          identity.IdentifierTypePhone,
-				Source:        "test_phone_" + phoneFormat[:3],
+				Source:        fmt.Sprintf("test_phone_%s_%d", ns, i),
 			})
 			require.NoError(t, err, "failed for format: %s", phoneFormat)
 
@@ -495,9 +523,9 @@ func TestIdentityService_Integration(t *testing.T) {
 
 		// Create unmatched identity
 		result, err := identityService.MatchOrCreate(ctx, service.MatchRequest{
-			RawIdentifier: "manual.link@example.com",
+			RawIdentifier: "manual.link." + ns + "@example.com",
 			Type:          identity.IdentifierTypeEmail,
-			Source:        "test_manual",
+			Source:        "test_manual_" + ns,
 		})
 		require.NoError(t, err)
 		assert.Nil(t, result.ContactID)

--- a/backend/tests/ingest_registry_guard_static_test.go
+++ b/backend/tests/ingest_registry_guard_static_test.go
@@ -40,6 +40,7 @@ func ingestRegistryGuardPath(t *testing.T) string {
 // TestIngestRegistryGuard_PassesOnRealTree confirms the guard exits zero on
 // the actual ingest.go — a false positive here would block every push.
 func TestIngestRegistryGuard_PassesOnRealTree(t *testing.T) {
+	t.Parallel()
 	guard := ingestRegistryGuardPath(t)
 	if out, runErr := exec.Command(guard).CombinedOutput(); runErr != nil {
 		t.Fatalf("guard unexpectedly failed on the real tree: %v\n%s", runErr, out)
@@ -53,6 +54,7 @@ func TestIngestRegistryGuard_PassesOnRealTree(t *testing.T) {
 // kind reference lives OUTSIDE the IngestBatch body must pass — that proves
 // the guard is scoped to the body, not the whole file.
 func TestIngestRegistryGuard_CatchesViolations(t *testing.T) {
+	t.Parallel()
 	guard := ingestRegistryGuardPath(t)
 
 	cases := []struct {

--- a/backend/tests/integration_test.go
+++ b/backend/tests/integration_test.go
@@ -184,6 +184,7 @@ func TestContactRepository_Integration(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
+	t.Parallel()
 	// Check if DATABASE_URL is set for integration testing
 	databaseURL := os.Getenv("DATABASE_URL")
 	if databaseURL == "" {
@@ -300,6 +301,7 @@ func TestContactMethodRepository_Integration(t *testing.T) {
 		t.Skip("DATABASE_URL not set, skipping integration test")
 	}
 
+	t.Parallel()
 	ctx := context.Background()
 	cfg := config.TestConfig()
 	if databaseURL != "" {
@@ -387,6 +389,7 @@ func TestSyncRepository_Integration(t *testing.T) {
 		t.Skip("DATABASE_URL not set, skipping integration test")
 	}
 
+	t.Parallel()
 	ctx := context.Background()
 
 	// Migrations are applied once by TestMain.
@@ -747,6 +750,7 @@ func TestOAuthRepository_Integration(t *testing.T) {
 		t.Skip("DATABASE_URL not set, skipping integration test")
 	}
 
+	t.Parallel()
 	ctx := context.Background()
 
 	// Migrations are applied once by TestMain.
@@ -1101,6 +1105,7 @@ func TestFindSimilarContactsBatch_Integration(t *testing.T) {
 		t.Skip("DATABASE_URL not set, skipping integration test")
 	}
 
+	t.Parallel()
 	ctx := context.Background()
 
 	// Migrations are applied once by TestMain.

--- a/backend/tests/integration_test.go
+++ b/backend/tests/integration_test.go
@@ -240,37 +240,42 @@ func TestContactRepository_Integration(t *testing.T) {
 	})
 
 	t.Run("ListContacts", func(t *testing.T) {
-		// Create test contacts with unique emails to avoid conflicts
+		// Namespaced names so the FullName assertions don't collide with a
+		// parallel copy. Membership keys on contact.ID, which is always scoped.
+		ns := uuid.New().String()[:8]
+		name1 := "Integration List Test User 1 " + ns
+		name2 := "Integration List Test User 2 " + ns
 		contact1, err := repo.CreateContact(ctx, repository.CreateContactRequest{
-			FullName: "Integration List Test User 1",
+			FullName: name1,
 		})
 		require.NoError(t, err)
 		require.NotNil(t, contact1)
 
 		contact2, err := repo.CreateContact(ctx, repository.CreateContactRequest{
-			FullName: "Integration List Test User 2",
+			FullName: name2,
 		})
 		require.NoError(t, err)
 		require.NotNil(t, contact2)
 
-		// List contacts
+		// List contacts. A high limit keeps both rows in the window even as the
+		// shared test DB accumulates state across runs.
 		contacts, err := repo.ListContacts(ctx, repository.ListContactsParams{
-			Limit:  100,
+			Limit:  100000,
 			Offset: 0,
 		})
 		require.NoError(t, err)
 
-		// Verify our test contacts are in the list
+		// Verify our test contacts are in the list (membership by ID)
 		foundContact1 := false
 		foundContact2 := false
 		for _, c := range contacts {
 			if c.ID == contact1.ID {
 				foundContact1 = true
-				assert.Equal(t, "Integration List Test User 1", c.FullName)
+				assert.Equal(t, name1, c.FullName)
 			}
 			if c.ID == contact2.ID {
 				foundContact2 = true
-				assert.Equal(t, "Integration List Test User 2", c.FullName)
+				assert.Equal(t, name2, c.FullName)
 			}
 		}
 		assert.True(t, foundContact1, "Contact 1 should be in the list")
@@ -396,11 +401,17 @@ func TestSyncRepository_Integration(t *testing.T) {
 
 	repo := repository.NewSyncRepository(database.Queries)
 
+	// Per-test-run unique suffix so the (source, account_id) unique constraint
+	// and the account-scoped delete don't collide with a parallel copy.
+	ns := uuid.New().String()[:8]
+
 	t.Run("CreateAndGetSyncState", func(t *testing.T) {
 		// Create a sync state
+		source := "test_provider_" + ns
+		account := "test." + ns + "@example.com"
 		req := repository.CreateSyncStateRequest{
-			Source:    "test_provider",
-			AccountID: stringPtr("test@example.com"),
+			Source:    source,
+			AccountID: stringPtr(account),
 			Strategy:  repository.SyncStrategyContactDriven,
 			Enabled:   true,
 		}
@@ -410,8 +421,8 @@ func TestSyncRepository_Integration(t *testing.T) {
 		require.NotNil(t, createdState)
 
 		// Verify the created state
-		assert.Equal(t, "test_provider", createdState.Source)
-		assert.Equal(t, "test@example.com", *createdState.AccountID)
+		assert.Equal(t, source, createdState.Source)
+		assert.Equal(t, account, *createdState.AccountID)
 		assert.Equal(t, repository.SyncStatusIdle, createdState.Status)
 		assert.Equal(t, repository.SyncStrategyContactDriven, createdState.Strategy)
 		assert.True(t, createdState.Enabled)
@@ -432,9 +443,11 @@ func TestSyncRepository_Integration(t *testing.T) {
 
 	t.Run("GetSyncStateBySource", func(t *testing.T) {
 		// Create a sync state
+		gmailSource := "gmail_" + ns
+		account := "user." + ns + "@gmail.com"
 		req := repository.CreateSyncStateRequest{
-			Source:    "gmail",
-			AccountID: stringPtr("user@gmail.com"),
+			Source:    gmailSource,
+			AccountID: stringPtr(account),
 			Strategy:  repository.SyncStrategyFetchAll,
 		}
 
@@ -443,29 +456,28 @@ func TestSyncRepository_Integration(t *testing.T) {
 		defer func() { _ = repo.DeleteSyncState(ctx, createdState.ID) }()
 
 		// Get by source and account
-		accountID := "user@gmail.com"
-		foundState, err := repo.GetSyncStateBySource(ctx, "gmail", &accountID)
+		foundState, err := repo.GetSyncStateBySource(ctx, gmailSource, &account)
 		require.NoError(t, err)
 		require.NotNil(t, foundState)
 		assert.Equal(t, createdState.ID, foundState.ID)
 
 		// Try with wrong account - should not find
-		wrongAccount := "other@gmail.com"
-		_, err = repo.GetSyncStateBySource(ctx, "gmail", &wrongAccount)
+		wrongAccount := "other." + ns + "@gmail.com"
+		_, err = repo.GetSyncStateBySource(ctx, gmailSource, &wrongAccount)
 		assert.Error(t, err)
 	})
 
 	t.Run("ListSyncStates", func(t *testing.T) {
 		// Create multiple sync states
 		state1, err := repo.CreateSyncState(ctx, repository.CreateSyncStateRequest{
-			Source:   "provider1",
+			Source:   "provider1_" + ns,
 			Strategy: repository.SyncStrategyContactDriven,
 		})
 		require.NoError(t, err)
 		defer func() { _ = repo.DeleteSyncState(ctx, state1.ID) }()
 
 		state2, err := repo.CreateSyncState(ctx, repository.CreateSyncStateRequest{
-			Source:   "provider2",
+			Source:   "provider2_" + ns,
 			Strategy: repository.SyncStrategyFetchAll,
 		})
 		require.NoError(t, err)
@@ -491,7 +503,7 @@ func TestSyncRepository_Integration(t *testing.T) {
 
 	t.Run("UpdateSyncStateStatus", func(t *testing.T) {
 		state, err := repo.CreateSyncState(ctx, repository.CreateSyncStateRequest{
-			Source:   "status_test",
+			Source:   "status_test_" + ns,
 			Strategy: repository.SyncStrategyContactDriven,
 		})
 		require.NoError(t, err)
@@ -514,7 +526,7 @@ func TestSyncRepository_Integration(t *testing.T) {
 
 	t.Run("UpdateSyncStateEnabled", func(t *testing.T) {
 		state, err := repo.CreateSyncState(ctx, repository.CreateSyncStateRequest{
-			Source:   "enable_test",
+			Source:   "enable_test_" + ns,
 			Strategy: repository.SyncStrategyContactDriven,
 			Enabled:  true,
 		})
@@ -538,7 +550,7 @@ func TestSyncRepository_Integration(t *testing.T) {
 	t.Run("SyncLogLifecycle", func(t *testing.T) {
 		// Create a sync state first
 		state, err := repo.CreateSyncState(ctx, repository.CreateSyncStateRequest{
-			Source:   "log_test",
+			Source:   "log_test_" + ns,
 			Strategy: repository.SyncStrategyContactDriven,
 		})
 		require.NoError(t, err)
@@ -573,7 +585,7 @@ func TestSyncRepository_Integration(t *testing.T) {
 
 	t.Run("SyncLogWithError", func(t *testing.T) {
 		state, err := repo.CreateSyncState(ctx, repository.CreateSyncStateRequest{
-			Source:   "log_error_test",
+			Source:   "log_error_test_" + ns,
 			Strategy: repository.SyncStrategyContactDriven,
 		})
 		require.NoError(t, err)
@@ -601,7 +613,7 @@ func TestSyncRepository_Integration(t *testing.T) {
 
 	t.Run("CountSyncLogs", func(t *testing.T) {
 		state, err := repo.CreateSyncState(ctx, repository.CreateSyncStateRequest{
-			Source:   "count_test",
+			Source:   "count_test_" + ns,
 			Strategy: repository.SyncStrategyContactDriven,
 		})
 		require.NoError(t, err)
@@ -627,7 +639,7 @@ func TestSyncRepository_Integration(t *testing.T) {
 
 	t.Run("ListRecentSyncLogs", func(t *testing.T) {
 		state, err := repo.CreateSyncState(ctx, repository.CreateSyncStateRequest{
-			Source:   "recent_test",
+			Source:   "recent_test_" + ns,
 			Strategy: repository.SyncStrategyContactDriven,
 		})
 		require.NoError(t, err)
@@ -653,13 +665,14 @@ func TestSyncRepository_Integration(t *testing.T) {
 	})
 
 	t.Run("DeleteSyncStatesByAccountID", func(t *testing.T) {
-		// Create sync states for different accounts
-		account1 := "account1@example.com"
-		account2 := "account2@example.com"
+		// Per-test-unique accounts so the account-scoped delete only touches this
+		// test's rows, not a parallel copy's.
+		account1 := "account1." + ns + "@example.com"
+		account2 := "account2." + ns + "@example.com"
 
 		// Create multiple sync states for account1
 		state1a, err := repo.CreateSyncState(ctx, repository.CreateSyncStateRequest{
-			Source:    "gcontacts",
+			Source:    "gcontacts_" + ns,
 			AccountID: &account1,
 			Strategy:  repository.SyncStrategyFetchAll,
 			Enabled:   true,
@@ -667,7 +680,7 @@ func TestSyncRepository_Integration(t *testing.T) {
 		require.NoError(t, err)
 
 		state1b, err := repo.CreateSyncState(ctx, repository.CreateSyncStateRequest{
-			Source:    "gcal",
+			Source:    "gcal_" + ns,
 			AccountID: &account1,
 			Strategy:  repository.SyncStrategyFetchAll,
 			Enabled:   true,
@@ -676,7 +689,7 @@ func TestSyncRepository_Integration(t *testing.T) {
 
 		// Create a sync state for account2 (should NOT be deleted)
 		state2, err := repo.CreateSyncState(ctx, repository.CreateSyncStateRequest{
-			Source:    "gcontacts",
+			Source:    "gcontacts2_" + ns,
 			AccountID: &account2,
 			Strategy:  repository.SyncStrategyFetchAll,
 			Enabled:   true,
@@ -686,7 +699,7 @@ func TestSyncRepository_Integration(t *testing.T) {
 
 		// Create a sync state with NULL account_id (e.g., iMessage - should NOT be deleted)
 		stateNull, err := repo.CreateSyncState(ctx, repository.CreateSyncStateRequest{
-			Source:    "imessage",
+			Source:    "imessage_" + ns,
 			AccountID: nil, // NULL account_id
 			Strategy:  repository.SyncStrategyContactDriven,
 			Enabled:   true,
@@ -748,13 +761,19 @@ func TestOAuthRepository_Integration(t *testing.T) {
 
 	repo := repository.NewOAuthRepository(database.Queries)
 
+	// Per-test-run unique suffix so the (provider, account_id) upsert key, the
+	// provider-scoped Count, and DeleteByProvider don't collide with a parallel
+	// copy.
+	ns := uuid.New().String()[:8]
+
 	t.Run("UpsertAndGetCredential", func(t *testing.T) {
 		// Create a credential
+		account := "test-upsert." + ns + "@example.com"
 		accountName := "Test User"
 		expiresAt := timeNow().Add(1 * time.Hour)
 		req := repository.UpsertOAuthCredentialRequest{
 			Provider:              "google",
-			AccountID:             "test-upsert@example.com",
+			AccountID:             account,
 			AccountName:           &accountName,
 			AccessTokenEncrypted:  []byte("encrypted-access-token"),
 			RefreshTokenEncrypted: []byte("encrypted-refresh-token"),
@@ -771,13 +790,13 @@ func TestOAuthRepository_Integration(t *testing.T) {
 
 		// Verify the created credential
 		assert.Equal(t, "google", cred.Provider)
-		assert.Equal(t, "test-upsert@example.com", cred.AccountID)
+		assert.Equal(t, account, cred.AccountID)
 		assert.Equal(t, "Test User", *cred.AccountName)
 		assert.Equal(t, []byte("encrypted-access-token"), cred.AccessTokenEncrypted)
 		assert.NotEqual(t, uuid.Nil, cred.ID)
 
 		// Get by provider and account
-		found, err := repo.GetByProviderAndAccount(ctx, "google", "test-upsert@example.com")
+		found, err := repo.GetByProviderAndAccount(ctx, "google", account)
 		require.NoError(t, err)
 		require.NotNil(t, found)
 		assert.Equal(t, cred.ID, found.ID)
@@ -794,7 +813,7 @@ func TestOAuthRepository_Integration(t *testing.T) {
 		// Create initial credential
 		req := repository.UpsertOAuthCredentialRequest{
 			Provider:             "google",
-			AccountID:            "test-update@example.com",
+			AccountID:            "test-update." + ns + "@example.com",
 			AccessTokenEncrypted: []byte("initial-token"),
 			EncryptionNonce:      []byte("12-byte-nonce"),
 			TokenType:            "Bearer",
@@ -819,7 +838,7 @@ func TestOAuthRepository_Integration(t *testing.T) {
 		// Create multiple credentials
 		cred1, err := repo.Upsert(ctx, repository.UpsertOAuthCredentialRequest{
 			Provider:             "google",
-			AccountID:            "list-test1@example.com",
+			AccountID:            "list-test1." + ns + "@example.com",
 			AccessTokenEncrypted: []byte("token1"),
 			EncryptionNonce:      []byte("12-byte-nonce"),
 			TokenType:            "Bearer",
@@ -830,7 +849,7 @@ func TestOAuthRepository_Integration(t *testing.T) {
 
 		cred2, err := repo.Upsert(ctx, repository.UpsertOAuthCredentialRequest{
 			Provider:             "google",
-			AccountID:            "list-test2@example.com",
+			AccountID:            "list-test2." + ns + "@example.com",
 			AccessTokenEncrypted: []byte("token2"),
 			EncryptionNonce:      []byte("12-byte-nonce"),
 			TokenType:            "Bearer",
@@ -842,7 +861,7 @@ func TestOAuthRepository_Integration(t *testing.T) {
 		// Create one for a different provider
 		cred3, err := repo.Upsert(ctx, repository.UpsertOAuthCredentialRequest{
 			Provider:             "microsoft",
-			AccountID:            "list-test@outlook.com",
+			AccountID:            "list-test." + ns + "@outlook.com",
 			AccessTokenEncrypted: []byte("token3"),
 			EncryptionNonce:      []byte("12-byte-nonce"),
 			TokenType:            "Bearer",
@@ -871,10 +890,11 @@ func TestOAuthRepository_Integration(t *testing.T) {
 	})
 
 	t.Run("ListStatusesByProvider", func(t *testing.T) {
+		statusAccount := "status-test." + ns + "@example.com"
 		accountName := "Status Test User"
 		cred, err := repo.Upsert(ctx, repository.UpsertOAuthCredentialRequest{
 			Provider:             "google",
-			AccountID:            "status-test@example.com",
+			AccountID:            statusAccount,
 			AccountName:          &accountName,
 			AccessTokenEncrypted: []byte("encrypted-token"),
 			EncryptionNonce:      []byte("12-byte-nonce"),
@@ -895,16 +915,17 @@ func TestOAuthRepository_Integration(t *testing.T) {
 			}
 		}
 		require.NotNil(t, foundStatus, "Should find status for created credential")
-		assert.Equal(t, "status-test@example.com", foundStatus.AccountID)
+		assert.Equal(t, statusAccount, foundStatus.AccountID)
 		assert.Equal(t, "Status Test User", *foundStatus.AccountName)
 		assert.Len(t, foundStatus.Scopes, 2)
 	})
 
 	t.Run("GetStatus", func(t *testing.T) {
+		getStatusAccount := "get-status." + ns + "@example.com"
 		accountName := "Get Status User"
 		cred, err := repo.Upsert(ctx, repository.UpsertOAuthCredentialRequest{
 			Provider:             "google",
-			AccountID:            "get-status@example.com",
+			AccountID:            getStatusAccount,
 			AccountName:          &accountName,
 			AccessTokenEncrypted: []byte("token"),
 			EncryptionNonce:      []byte("12-byte-nonce"),
@@ -919,14 +940,14 @@ func TestOAuthRepository_Integration(t *testing.T) {
 		require.NotNil(t, status)
 
 		assert.Equal(t, cred.ID, status.ID)
-		assert.Equal(t, "get-status@example.com", status.AccountID)
+		assert.Equal(t, getStatusAccount, status.AccountID)
 		assert.Equal(t, "Get Status User", *status.AccountName)
 	})
 
 	t.Run("UpdateTokens", func(t *testing.T) {
 		cred, err := repo.Upsert(ctx, repository.UpsertOAuthCredentialRequest{
 			Provider:             "google",
-			AccountID:            "token-update@example.com",
+			AccountID:            "token-update." + ns + "@example.com",
 			AccessTokenEncrypted: []byte("old-token"),
 			EncryptionNonce:      []byte("old-nonce-123"),
 			TokenType:            "Bearer",
@@ -954,7 +975,7 @@ func TestOAuthRepository_Integration(t *testing.T) {
 	t.Run("Delete", func(t *testing.T) {
 		cred, err := repo.Upsert(ctx, repository.UpsertOAuthCredentialRequest{
 			Provider:             "google",
-			AccountID:            "delete-test@example.com",
+			AccountID:            "delete-test." + ns + "@example.com",
 			AccessTokenEncrypted: []byte("token"),
 			EncryptionNonce:      []byte("12-byte-nonce"),
 			TokenType:            "Bearer",
@@ -971,10 +992,12 @@ func TestOAuthRepository_Integration(t *testing.T) {
 	})
 
 	t.Run("DeleteByProvider", func(t *testing.T) {
-		// Create credentials for a test provider
+		// Use a per-test-unique provider so DeleteByProvider only removes this
+		// test's rows, not a parallel copy's.
+		deleteProvider := "test_provider_" + ns
 		cred1, err := repo.Upsert(ctx, repository.UpsertOAuthCredentialRequest{
-			Provider:             "test_provider",
-			AccountID:            "delete-by-provider1@example.com",
+			Provider:             deleteProvider,
+			AccountID:            "delete-by-provider1." + ns + "@example.com",
 			AccessTokenEncrypted: []byte("token1"),
 			EncryptionNonce:      []byte("12-byte-nonce"),
 			TokenType:            "Bearer",
@@ -983,8 +1006,8 @@ func TestOAuthRepository_Integration(t *testing.T) {
 		require.NoError(t, err)
 
 		cred2, err := repo.Upsert(ctx, repository.UpsertOAuthCredentialRequest{
-			Provider:             "test_provider",
-			AccountID:            "delete-by-provider2@example.com",
+			Provider:             deleteProvider,
+			AccountID:            "delete-by-provider2." + ns + "@example.com",
 			AccessTokenEncrypted: []byte("token2"),
 			EncryptionNonce:      []byte("12-byte-nonce"),
 			TokenType:            "Bearer",
@@ -993,7 +1016,7 @@ func TestOAuthRepository_Integration(t *testing.T) {
 		require.NoError(t, err)
 
 		// Delete all credentials for the provider
-		err = repo.DeleteByProvider(ctx, "test_provider")
+		err = repo.DeleteByProvider(ctx, deleteProvider)
 		require.NoError(t, err)
 
 		// Both should be gone
@@ -1005,10 +1028,12 @@ func TestOAuthRepository_Integration(t *testing.T) {
 	})
 
 	t.Run("Count", func(t *testing.T) {
-		// Create credentials for counting
+		// Per-test-unique provider so the exact Count == 2 is over this test's
+		// own rows only.
+		countProvider := "count_test_provider_" + ns
 		cred1, err := repo.Upsert(ctx, repository.UpsertOAuthCredentialRequest{
-			Provider:             "count_test_provider",
-			AccountID:            "count1@example.com",
+			Provider:             countProvider,
+			AccountID:            "count1." + ns + "@example.com",
 			AccessTokenEncrypted: []byte("token1"),
 			EncryptionNonce:      []byte("12-byte-nonce"),
 			TokenType:            "Bearer",
@@ -1018,8 +1043,8 @@ func TestOAuthRepository_Integration(t *testing.T) {
 		defer func() { _ = repo.Delete(ctx, cred1.ID) }()
 
 		cred2, err := repo.Upsert(ctx, repository.UpsertOAuthCredentialRequest{
-			Provider:             "count_test_provider",
-			AccountID:            "count2@example.com",
+			Provider:             countProvider,
+			AccountID:            "count2." + ns + "@example.com",
 			AccessTokenEncrypted: []byte("token2"),
 			EncryptionNonce:      []byte("12-byte-nonce"),
 			TokenType:            "Bearer",
@@ -1028,7 +1053,7 @@ func TestOAuthRepository_Integration(t *testing.T) {
 		require.NoError(t, err)
 		defer func() { _ = repo.Delete(ctx, cred2.ID) }()
 
-		count, err := repo.Count(ctx, "count_test_provider")
+		count, err := repo.Count(ctx, countProvider)
 		require.NoError(t, err)
 		assert.Equal(t, int64(2), count)
 	})

--- a/backend/tests/integration_test.go
+++ b/backend/tests/integration_test.go
@@ -1082,8 +1082,8 @@ func TestFindSimilarContactsBatch_Integration(t *testing.T) {
 	// Create database connection
 	dbConfig := config.DatabaseConfig{
 		URL:               databaseURL,
-		MaxConns:          config.DefaultDBMaxConns,
-		MinConns:          config.DefaultDBMinConns,
+		MaxConns:          8, // mirrors the lowered TestConfig() ceiling for parallel tests
+		MinConns:          1,
 		MaxConnIdleTime:   config.DefaultDBMaxConnIdleTime,
 		MaxConnLifetime:   config.DefaultDBMaxConnLifetime,
 		HealthCheckPeriod: config.DefaultDBHealthCheckPeriod,

--- a/backend/tests/integration_test.go
+++ b/backend/tests/integration_test.go
@@ -648,7 +648,8 @@ func TestSyncRepository_Integration(t *testing.T) {
 		require.NoError(t, err)
 		defer func() { _ = repo.DeleteSyncState(ctx, state.ID) }()
 
-		// Create a few logs
+		// Create a few logs, tracking their IDs.
+		myLogIDs := map[uuid.UUID]bool{}
 		for i := 0; i < 2; i++ {
 			log, err := repo.CreateSyncLog(ctx, state)
 			require.NoError(t, err)
@@ -659,12 +660,21 @@ func TestSyncRepository_Integration(t *testing.T) {
 				ItemsCreated:   1,
 			})
 			require.NoError(t, err)
+			myLogIDs[log.ID] = true
 		}
 
-		// Get recent logs across all sources
-		logs, err := repo.ListRecentSyncLogs(ctx, 10)
+		// Get recent logs across all sources. Scope the assertion to this test's
+		// own logs (a high limit keeps them in the window despite shared-DB
+		// accumulation) — the global len is shared with parallel tests.
+		logs, err := repo.ListRecentSyncLogs(ctx, 100000)
 		require.NoError(t, err)
-		assert.GreaterOrEqual(t, len(logs), 2)
+		found := 0
+		for _, l := range logs {
+			if myLogIDs[l.ID] {
+				found++
+			}
+		}
+		assert.Equal(t, 2, found, "both of this test's recent logs should be returned")
 	})
 
 	t.Run("DeleteSyncStatesByAccountID", func(t *testing.T) {

--- a/backend/tests/interaction_direction_test.go
+++ b/backend/tests/interaction_direction_test.go
@@ -28,8 +28,8 @@ func setupDirectionTestDeps(t *testing.T) (*service.ContactService, *repository.
 	ctx := context.Background()
 	dbConfig := config.DatabaseConfig{
 		URL:               databaseURL,
-		MaxConns:          config.DefaultDBMaxConns,
-		MinConns:          config.DefaultDBMinConns,
+		MaxConns:          8, // mirrors the lowered TestConfig() ceiling for parallel tests
+		MinConns:          1,
 		MaxConnIdleTime:   config.DefaultDBMaxConnIdleTime,
 		MaxConnLifetime:   config.DefaultDBMaxConnLifetime,
 		HealthCheckPeriod: config.DefaultDBHealthCheckPeriod,

--- a/backend/tests/interaction_direction_test.go
+++ b/backend/tests/interaction_direction_test.go
@@ -52,6 +52,7 @@ func setupDirectionTestDeps(t *testing.T) (*service.ContactService, *repository.
 }
 
 func TestRecordInteraction_DirectionOutbound(t *testing.T) {
+	t.Parallel()
 	contactService, contactRepo, _, cleanup := setupDirectionTestDeps(t)
 	defer cleanup()
 	ctx := context.Background()
@@ -96,6 +97,7 @@ func TestRecordInteraction_DirectionOutbound(t *testing.T) {
 }
 
 func TestRecordInteraction_DirectionMutual(t *testing.T) {
+	t.Parallel()
 	contactService, contactRepo, _, cleanup := setupDirectionTestDeps(t)
 	defer cleanup()
 	ctx := context.Background()
@@ -138,6 +140,7 @@ func TestRecordInteraction_DirectionMutual(t *testing.T) {
 }
 
 func TestRecordInteraction_DirectionInbound(t *testing.T) {
+	t.Parallel()
 	contactService, contactRepo, _, cleanup := setupDirectionTestDeps(t)
 	defer cleanup()
 	ctx := context.Background()
@@ -177,6 +180,7 @@ func TestRecordInteraction_DirectionInbound(t *testing.T) {
 }
 
 func TestRecordInteraction_EmptyDirectionDefaultsMutual(t *testing.T) {
+	t.Parallel()
 	contactService, contactRepo, _, cleanup := setupDirectionTestDeps(t)
 	defer cleanup()
 	ctx := context.Background()
@@ -200,6 +204,7 @@ func TestRecordInteraction_EmptyDirectionDefaultsMutual(t *testing.T) {
 }
 
 func TestRecordInteraction_ForwardOnlyGuard_ContactByNotRegressed(t *testing.T) {
+	t.Parallel()
 	contactService, contactRepo, _, cleanup := setupDirectionTestDeps(t)
 	defer cleanup()
 	ctx := context.Background()
@@ -253,6 +258,7 @@ func TestRecordInteraction_ForwardOnlyGuard_ContactByNotRegressed(t *testing.T) 
 }
 
 func TestHasPendingFollowUp(t *testing.T) {
+	t.Parallel()
 	contactService, contactRepo, contactTaskRepo, cleanup := setupDirectionTestDeps(t)
 	defer cleanup()
 	ctx := context.Background()
@@ -294,6 +300,7 @@ func TestHasPendingFollowUp(t *testing.T) {
 }
 
 func TestFollowupFilter(t *testing.T) {
+	t.Parallel()
 	_, contactRepo, contactTaskRepo, cleanup := setupDirectionTestDeps(t)
 	defer cleanup()
 	ctx := context.Background()
@@ -326,7 +333,7 @@ func TestFollowupFilter(t *testing.T) {
 
 	// Filter: has_followup
 	contactsWithFollowup, err := contactRepo.ListContacts(ctx, repository.ListContactsParams{
-		Limit:          100,
+		Limit:          100000,
 		FollowupFilter: "has_followup",
 	})
 	require.NoError(t, err)
@@ -345,7 +352,7 @@ func TestFollowupFilter(t *testing.T) {
 
 	// Filter: no_followup
 	contactsWithout, err := contactRepo.ListContacts(ctx, repository.ListContactsParams{
-		Limit:          100,
+		Limit:          100000,
 		FollowupFilter: "no_followup",
 	})
 	require.NoError(t, err)
@@ -364,6 +371,7 @@ func TestFollowupFilter(t *testing.T) {
 }
 
 func TestCompletedCadenceTask_CanBeReplacedByNewOne(t *testing.T) {
+	t.Parallel()
 	_, contactRepo, contactTaskRepo, cleanup := setupDirectionTestDeps(t)
 	defer cleanup()
 	ctx := context.Background()

--- a/backend/tests/interaction_direction_test.go
+++ b/backend/tests/interaction_direction_test.go
@@ -298,14 +298,18 @@ func TestFollowupFilter(t *testing.T) {
 	defer cleanup()
 	ctx := context.Background()
 
-	// Create two contacts
+	// Namespaced names: this test scans the whole table via the has_followup /
+	// no_followup filters, so fixed names risk fuzzy-trigram collision with a
+	// parallel copy. Assertions key on contact.ID, so the name only needs to be
+	// unique.
+	ns := syntheticNS(t)
 	contactWithFollowup, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-		FullName: "Has Followup Filter Test",
+		FullName: "Has Followup Filter Test " + ns,
 	})
 	require.NoError(t, err)
 
 	contactWithoutFollowup, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-		FullName: "No Followup Filter Test",
+		FullName: "No Followup Filter Test " + ns,
 	})
 	require.NoError(t, err)
 
@@ -364,9 +368,12 @@ func TestCompletedCadenceTask_CanBeReplacedByNewOne(t *testing.T) {
 	defer cleanup()
 	ctx := context.Background()
 
+	// Per-test namespace so the fixed external_task_id literals below don't
+	// collide on the (provider, external_task_id) key across parallel clones.
+	ns := syntheticNS(t)
 	cadence := "monthly"
 	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
-		FullName: "Cadence Replacement Test",
+		FullName: "Cadence Replacement Test " + ns,
 		Cadence:  &cadence,
 	})
 	require.NoError(t, err)
@@ -377,7 +384,7 @@ func TestCompletedCadenceTask_CanBeReplacedByNewOne(t *testing.T) {
 		Provider:       "todoist",
 		Kind:           contacttask.KindReachOut,
 		Lifecycle:      contacttask.LifecycleCadenceDue,
-		ExternalTaskID: "original-cadence-task",
+		ExternalTaskID: "original-cadence-task-" + ns,
 		State:          "managed",
 	})
 	require.NoError(t, err)
@@ -400,12 +407,12 @@ func TestCompletedCadenceTask_CanBeReplacedByNewOne(t *testing.T) {
 		Provider:       "todoist",
 		Kind:           contacttask.KindReachOut,
 		Lifecycle:      contacttask.LifecycleCadenceDue,
-		ExternalTaskID: "replacement-cadence-task",
+		ExternalTaskID: "replacement-cadence-task-" + ns,
 		State:          "managed",
 	})
 	require.NoError(t, err)
 	assert.Equal(t, repository.ContactTaskStateManaged, newTask.State)
-	assert.Equal(t, "replacement-cadence-task", newTask.ExternalTaskID)
+	assert.Equal(t, "replacement-cadence-task-"+ns, newTask.ExternalTaskID)
 
 	// Verify: GetContactTaskByContact now returns the new managed task
 	current, err := contactTaskRepo.GetContactTaskByContactCadenceDue(ctx, contact.ID, "todoist")

--- a/backend/tests/interaction_integration_test.go
+++ b/backend/tests/interaction_integration_test.go
@@ -65,6 +65,7 @@ func TestRecordInteraction_SourceRefDedup(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
+	t.Parallel()
 	contactService, interactionRepo, contactRepo, cleanup := setupInteractionTestDeps(t)
 	defer cleanup()
 
@@ -124,6 +125,7 @@ func TestRecordInteraction_ForwardOnlyLastContacted(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
+	t.Parallel()
 	contactService, _, contactRepo, cleanup := setupInteractionTestDeps(t)
 	defer cleanup()
 
@@ -172,6 +174,7 @@ func TestRecordInteraction_ManualAlwaysUpdates(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
+	t.Parallel()
 	contactService, _, contactRepo, cleanup := setupInteractionTestDeps(t)
 	defer cleanup()
 
@@ -201,6 +204,7 @@ func TestRecordInteraction_NonExistentContact(t *testing.T) {
 		t.Skip("Skipping integration test in short mode")
 	}
 
+	t.Parallel()
 	contactService, _, _, cleanup := setupInteractionTestDeps(t)
 	defer cleanup()
 

--- a/backend/tests/interaction_integration_test.go
+++ b/backend/tests/interaction_integration_test.go
@@ -29,8 +29,8 @@ func setupInteractionTestDeps(t *testing.T) (*service.ContactService, *repositor
 	ctx := context.Background()
 	dbConfig := config.DatabaseConfig{
 		URL:               databaseURL,
-		MaxConns:          config.DefaultDBMaxConns,
-		MinConns:          config.DefaultDBMinConns,
+		MaxConns:          8, // mirrors the lowered TestConfig() ceiling for parallel tests
+		MinConns:          1,
 		MaxConnIdleTime:   config.DefaultDBMaxConnIdleTime,
 		MaxConnLifetime:   config.DefaultDBMaxConnLifetime,
 		HealthCheckPeriod: config.DefaultDBHealthCheckPeriod,

--- a/backend/tests/interaction_repository_source_filter_test.go
+++ b/backend/tests/interaction_repository_source_filter_test.go
@@ -33,6 +33,7 @@ func TestInteractionRepository_FindRecentInteractionBySourceAndDirection_SourceF
 		t.Skip("DATABASE_URL not set")
 	}
 
+	t.Parallel()
 	ctx := context.Background()
 	cfg := config.TestConfig()
 	cfg.Database.URL = databaseURL

--- a/backend/tests/interaction_source_descriptor_check_test.go
+++ b/backend/tests/interaction_source_descriptor_check_test.go
@@ -155,7 +155,7 @@ func TestInteractionSourceCheck_AcceptsPhoneCalls(t *testing.T) {
 	})
 	require.NoError(t, err)
 	defer func() {
-		_ = interactionRepo.HardDeleteInteractionsBySourceRefPrefix(ctx, repository.InteractionSourcePhoneCalls, "phone-calls-test-%")
+		_ = interactionRepo.HardDeleteInteractionsBySourceRefPrefix(ctx, repository.InteractionSourcePhoneCalls, "phone-calls-test-"+suffix+"%")
 		_ = contactRepo.SoftDeleteContact(ctx, contact.ID)
 	}()
 

--- a/backend/tests/interaction_source_descriptor_check_test.go
+++ b/backend/tests/interaction_source_descriptor_check_test.go
@@ -54,6 +54,7 @@ func TestInteractionSourceCheck_AgreesWithDescriptorAndConstants(t *testing.T) {
 	if databaseURL == "" {
 		t.Skip("DATABASE_URL not set")
 	}
+	t.Parallel()
 	ctx := context.Background()
 
 	// CI runs against a bare PostgreSQL — run migrations before opening
@@ -139,6 +140,7 @@ func TestInteractionSourceCheck_AcceptsPhoneCalls(t *testing.T) {
 	if databaseURL == "" {
 		t.Skip("DATABASE_URL not set")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	cfg := config.TestConfig()
 	cfg.Database.URL = databaseURL

--- a/backend/tests/interaction_source_gchat_check_test.go
+++ b/backend/tests/interaction_source_gchat_check_test.go
@@ -48,7 +48,7 @@ func TestInteraction_SourceCheckAcceptsGchat(t *testing.T) {
 	// any row uses source='gchat' (data-loss guard), and the guard counts
 	// rows regardless of deleted_at — so a soft-delete is insufficient.
 	defer func() {
-		_ = interactionRepo.HardDeleteInteractionsBySourceRefPrefix(ctx, repository.InteractionSourceGChat, "gchat-test-%")
+		_ = interactionRepo.HardDeleteInteractionsBySourceRefPrefix(ctx, repository.InteractionSourceGChat, "gchat-test-"+suffix+"%")
 		_ = contactRepo.SoftDeleteContact(ctx, contact.ID)
 	}()
 

--- a/backend/tests/interaction_source_gchat_check_test.go
+++ b/backend/tests/interaction_source_gchat_check_test.go
@@ -28,6 +28,7 @@ func TestInteraction_SourceCheckAcceptsGchat(t *testing.T) {
 	if databaseURL == "" {
 		t.Skip("DATABASE_URL not set")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	cfg := config.TestConfig()
 	cfg.Database.URL = databaseURL

--- a/backend/tests/interaction_source_messages_check_test.go
+++ b/backend/tests/interaction_source_messages_check_test.go
@@ -51,7 +51,7 @@ func TestInteraction_SourceCheckAcceptsMessages(t *testing.T) {
 	// the shared CI DB. Soft-delete is not enough — the guard counts
 	// rows regardless of deleted_at.
 	defer func() {
-		_ = interactionRepo.HardDeleteInteractionsBySourceRefPrefix(ctx, repository.InteractionSourceMessages, "messages-test-%")
+		_ = interactionRepo.HardDeleteInteractionsBySourceRefPrefix(ctx, repository.InteractionSourceMessages, "messages-test-"+suffix+"%")
 		_ = contactRepo.SoftDeleteContact(ctx, contact.ID)
 	}()
 

--- a/backend/tests/interaction_source_messages_check_test.go
+++ b/backend/tests/interaction_source_messages_check_test.go
@@ -28,6 +28,7 @@ func TestInteraction_SourceCheckAcceptsMessages(t *testing.T) {
 	if databaseURL == "" {
 		t.Skip("DATABASE_URL not set")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	cfg := config.TestConfig()
 	cfg.Database.URL = databaseURL
@@ -79,6 +80,7 @@ func TestInteraction_SourceCheckRejectsWhatsapp(t *testing.T) {
 	if databaseURL == "" {
 		t.Skip("DATABASE_URL not set")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	cfg := config.TestConfig()
 	cfg.Database.URL = databaseURL

--- a/backend/tests/jsonb_gin_index_test.go
+++ b/backend/tests/jsonb_gin_index_test.go
@@ -96,6 +96,7 @@ func (e *jsonbGINEnv) gcalIDFor(label string) string {
 // to seq scan) — this test catches a future migration that accidentally
 // drops or renames the index.
 func TestJSONBGINIndexes_Exist(t *testing.T) {
+	t.Parallel()
 	env := setupJSONBGINEnv(t)
 
 	for _, name := range []string{
@@ -113,6 +114,7 @@ func TestJSONBGINIndexes_Exist(t *testing.T) {
 // every JSONB shape that exists in prod plus the defensive shapes that
 // don't (NULL JSONB column, non-array JSONB).
 func TestFindExternalContactsByNormalizedEmail_Behavior(t *testing.T) {
+	t.Parallel()
 	env := setupJSONBGINEnv(t)
 
 	t.Run("Case01_MixedCaseStored_LowercaseQuery_Matches", func(t *testing.T) {
@@ -270,6 +272,7 @@ func TestFindExternalContactsByNormalizedEmail_Behavior(t *testing.T) {
 // TestFindEventsByAttendeeEmailUnmatchedForContact_Behavior covers cases
 // 11–16 plus a case-insensitivity guard (Case11B) for the calendar query.
 func TestFindEventsByAttendeeEmailUnmatchedForContact_Behavior(t *testing.T) {
+	t.Parallel()
 	env := setupJSONBGINEnv(t)
 	now := accelerated.GetCurrentTime().UTC()
 
@@ -407,6 +410,7 @@ func TestFindEventsByAttendeeEmailUnmatchedForContact_Behavior(t *testing.T) {
 // lookup parameter. Excludes shapes (NULL, non-array) on which the legacy
 // form raises or where parity is trivially satisfied.
 func TestParity_NewVsLegacyForms_ExternalContact(t *testing.T) {
+	t.Parallel()
 	env := setupJSONBGINEnv(t)
 
 	target := fmt.Sprintf("parity_target_%s@x.invalid", env.suffix)
@@ -443,6 +447,7 @@ func TestParity_NewVsLegacyForms_ExternalContact(t *testing.T) {
 // TestParity_NewVsLegacyForms_CalendarEvent (case 18) — same shape parity
 // check for the calendar_event query.
 func TestParity_NewVsLegacyForms_CalendarEvent(t *testing.T) {
+	t.Parallel()
 	env := setupJSONBGINEnv(t)
 	now := accelerated.GetCurrentTime().UTC()
 	target := fmt.Sprintf("parity_evt_%s@x.invalid", env.suffix)

--- a/backend/tests/link_contact_curated_status_integration_test.go
+++ b/backend/tests/link_contact_curated_status_integration_test.go
@@ -147,6 +147,7 @@ func (env *linkCuratedEnv) seedUnmatchedExternal(t *testing.T, ctx context.Conte
 
 // Curated link with selected methods → match_status='imported'.
 func TestLinkContact_CuratedWithSelections_LandsImported(t *testing.T) {
+	t.Parallel()
 	env := setupLinkCuratedEnv(t)
 	ctx := context.Background()
 	contact, external := env.seedUnmatchedExternal(t, ctx)
@@ -165,6 +166,7 @@ func TestLinkContact_CuratedWithSelections_LandsImported(t *testing.T) {
 
 // Curated link via cadence (no method selections) → imported.
 func TestLinkContact_CuratedWithCadence_LandsImported(t *testing.T) {
+	t.Parallel()
 	env := setupLinkCuratedEnv(t)
 	ctx := context.Background()
 	contact, external := env.seedUnmatchedExternal(t, ctx)
@@ -183,6 +185,7 @@ func TestLinkContact_CuratedWithCadence_LandsImported(t *testing.T) {
 
 // Bare link (no curation signal) → match_status='matched'.
 func TestLinkContact_Bare_LandsMatched(t *testing.T) {
+	t.Parallel()
 	env := setupLinkCuratedEnv(t)
 	ctx := context.Background()
 	contact, external := env.seedUnmatchedExternal(t, ctx)
@@ -202,6 +205,7 @@ func TestLinkContact_Bare_LandsMatched(t *testing.T) {
 // methods_curated discriminator, this was indistinguishable from a bare
 // link and wrongly classified as 'matched'.
 func TestLinkContact_MethodsCuratedDeselectAll_LandsImported(t *testing.T) {
+	t.Parallel()
 	env := setupLinkCuratedEnv(t)
 	ctx := context.Background()
 	contact, external := env.seedUnmatchedExternal(t, ctx)
@@ -221,6 +225,7 @@ func TestLinkContact_MethodsCuratedDeselectAll_LandsImported(t *testing.T) {
 // Link-only import guard: a gmail_correspondence external row cannot be
 // imported as a new contact → 403, and the row stays unmatched.
 func TestImportContact_LinkOnlySource_Forbidden(t *testing.T) {
+	t.Parallel()
 	env := setupLinkCuratedEnv(t)
 	ctx := context.Background()
 	external := env.seedUnmatchedExternalSource(t, ctx, "gmail_correspondence")
@@ -236,6 +241,7 @@ func TestImportContact_LinkOnlySource_Forbidden(t *testing.T) {
 // Control: a non-link-only source (gcontacts) still imports successfully,
 // proving the guard is scoped to link-only sources only.
 func TestImportContact_OrdinarySource_Imports(t *testing.T) {
+	t.Parallel()
 	env := setupLinkCuratedEnv(t)
 	ctx := context.Background()
 	external := env.seedUnmatchedExternalSource(t, ctx, "gcontacts")

--- a/backend/tests/link_contact_curated_status_integration_test.go
+++ b/backend/tests/link_contact_curated_status_integration_test.go
@@ -37,7 +37,7 @@ func setupLinkCuratedEnv(t *testing.T) *linkCuratedEnv {
 	if databaseURL == "" {
 		t.Skip("DATABASE_URL not set")
 	}
-	gin.SetMode(gin.TestMode)
+	// gin.SetMode is hoisted to TestMain so parallel tests don't race on it.
 
 	cfg := config.TestConfig()
 	cfg.Database.URL = databaseURL

--- a/backend/tests/messages_message_repository_test.go
+++ b/backend/tests/messages_message_repository_test.go
@@ -66,6 +66,7 @@ func setupMessagesMessageTest(t *testing.T) (context.Context, *factory.Generator
 }
 
 func TestMessagesMessageRepository_UpsertAndGet(t *testing.T) {
+	t.Parallel()
 	ctx, gen, database, repo, hostID, cleanup := setupMessagesMessageTest(t)
 	defer cleanup()
 
@@ -101,6 +102,7 @@ func TestMessagesMessageRepository_UpsertAndGet(t *testing.T) {
 }
 
 func TestMessagesMessageRepository_UpsertConflictIsNoOp(t *testing.T) {
+	t.Parallel()
 	ctx, gen, database, repo, hostID, cleanup := setupMessagesMessageTest(t)
 	defer cleanup()
 
@@ -134,6 +136,7 @@ func TestMessagesMessageRepository_UpsertConflictIsNoOp(t *testing.T) {
 }
 
 func TestMessagesMessageRepository_ListUnprocessedByContact_ExcludesProcessed(t *testing.T) {
+	t.Parallel()
 	ctx, gen, database, repo, hostID, cleanup := setupMessagesMessageTest(t)
 	defer cleanup()
 
@@ -192,6 +195,7 @@ func TestMessagesMessageRepository_ListUnprocessedByContact_ExcludesProcessed(t 
 }
 
 func TestMessagesMessageRepository_ListUnprocessedByContact_ExcludesActiveClaim(t *testing.T) {
+	t.Parallel()
 	ctx, gen, database, repo, hostID, cleanup := setupMessagesMessageTest(t)
 	defer cleanup()
 
@@ -219,6 +223,7 @@ func TestMessagesMessageRepository_ListUnprocessedByContact_ExcludesActiveClaim(
 }
 
 func TestMessagesMessageRepository_ListUnprocessedByContact_IncludesStaleClaim(t *testing.T) {
+	t.Parallel()
 	ctx, gen, database, repo, hostID, cleanup := setupMessagesMessageTest(t)
 	defer cleanup()
 
@@ -249,6 +254,7 @@ func TestMessagesMessageRepository_ListUnprocessedByContact_IncludesStaleClaim(t
 }
 
 func TestMessagesMessageRepository_ClaimMessages_PartialClaim(t *testing.T) {
+	t.Parallel()
 	ctx, gen, database, repo, hostID, cleanup := setupMessagesMessageTest(t)
 	defer cleanup()
 
@@ -279,6 +285,7 @@ func TestMessagesMessageRepository_ClaimMessages_PartialClaim(t *testing.T) {
 }
 
 func TestMessagesMessageRepository_ClearStaleClaimTx(t *testing.T) {
+	t.Parallel()
 	ctx, gen, database, repo, hostID, cleanup := setupMessagesMessageTest(t)
 	defer cleanup()
 
@@ -324,6 +331,7 @@ func TestMessagesMessageRepository_ClearStaleClaimTx(t *testing.T) {
 }
 
 func TestMessagesMessageRepository_GetMessage_NotFound(t *testing.T) {
+	t.Parallel()
 	ctx, gen, _, repo, _, cleanup := setupMessagesMessageTest(t)
 	defer cleanup()
 

--- a/backend/tests/phone_call_repository_test.go
+++ b/backend/tests/phone_call_repository_test.go
@@ -81,6 +81,7 @@ func setupPhoneCallTest(t *testing.T) (phoneCallTestEnv, func()) {
 }
 
 func TestPhoneCallRepository_UpsertAndGet(t *testing.T) {
+	t.Parallel()
 	env, cleanup := setupPhoneCallTest(t)
 	defer cleanup()
 
@@ -138,6 +139,7 @@ func TestPhoneCallRepository_UpsertAndGet(t *testing.T) {
 }
 
 func TestPhoneCallRepository_GetByUniqueID_NotFound(t *testing.T) {
+	t.Parallel()
 	env, cleanup := setupPhoneCallTest(t)
 	defer cleanup()
 
@@ -147,6 +149,7 @@ func TestPhoneCallRepository_GetByUniqueID_NotFound(t *testing.T) {
 }
 
 func TestPhoneCallRepository_MarkProcessed_WithInteraction(t *testing.T) {
+	t.Parallel()
 	env, cleanup := setupPhoneCallTest(t)
 	defer cleanup()
 
@@ -196,6 +199,7 @@ func TestPhoneCallRepository_MarkProcessed_WithInteraction(t *testing.T) {
 }
 
 func TestPhoneCallRepository_MarkProcessed_NoInteraction(t *testing.T) {
+	t.Parallel()
 	env, cleanup := setupPhoneCallTest(t)
 	defer cleanup()
 
@@ -228,6 +232,7 @@ func TestPhoneCallRepository_MarkProcessed_NoInteraction(t *testing.T) {
 }
 
 func TestPhoneCallRepository_HardDeleteByMacHost(t *testing.T) {
+	t.Parallel()
 	env, cleanup := setupPhoneCallTest(t)
 	defer cleanup()
 

--- a/backend/tests/search_integration_test.go
+++ b/backend/tests/search_integration_test.go
@@ -234,7 +234,7 @@ func TestContactSearch_Integration(t *testing.T) {
 
 		// Test offset
 		page2, err := repo.SearchContacts(ctx, repository.SearchContactsParams{
-			Query:  "Pagination",
+			Query:  pageTerm,
 			Limit:  2,
 			Offset: 2,
 		})

--- a/backend/tests/search_integration_test.go
+++ b/backend/tests/search_integration_test.go
@@ -46,6 +46,7 @@ func TestContactSearch_Integration(t *testing.T) {
 		t.Skip("DATABASE_URL not set, skipping integration test")
 	}
 
+	t.Parallel()
 	ctx := context.Background()
 	cfg := config.TestConfig()
 	cfg.Database.URL = databaseURL
@@ -334,6 +335,7 @@ func TestNoteSearch_Integration(t *testing.T) {
 		t.Skip("DATABASE_URL not set, skipping integration test")
 	}
 
+	t.Parallel()
 	ctx := context.Background()
 	cfg := config.TestConfig()
 	cfg.Database.URL = databaseURL

--- a/backend/tests/search_integration_test.go
+++ b/backend/tests/search_integration_test.go
@@ -59,18 +59,23 @@ func TestContactSearch_Integration(t *testing.T) {
 	repo := repository.NewContactRepository(database.Queries)
 	methodRepo := repository.NewContactMethodRepository(database.Queries)
 
+	// Per-test namespace token so FTS query terms are unique to this test and
+	// only match its own rows (the shared DB holds other tests' contacts/notes).
+	ns := syntheticNS(t)
+
 	t.Run("ExactNameMatch", func(t *testing.T) {
 		// Create test contact
+		name := "Alice Johnson " + ns
 		contact, err := repo.CreateContact(ctx, repository.CreateContactRequest{
-			FullName: "Alice Johnson",
+			FullName: name,
 		})
 		require.NoError(t, err)
 		defer func() { _ = repo.HardDeleteContact(ctx, contact.ID) }()
-		addContactMethod(t, ctx, methodRepo, contact.ID, string(repository.ContactMethodEmail), "alice.johnson@example.com", true)
+		addContactMethod(t, ctx, methodRepo, contact.ID, string(repository.ContactMethodEmail), "alice.johnson."+ns+"@example.com", true)
 
 		// Search for exact name
 		results, err := repo.SearchContacts(ctx, repository.SearchContactsParams{
-			Query:  "Alice Johnson",
+			Query:  name,
 			Limit:  10,
 			Offset: 0,
 		})
@@ -79,30 +84,33 @@ func TestContactSearch_Integration(t *testing.T) {
 		// Should find the contact
 		assert.GreaterOrEqual(t, len(results), 1)
 
-		// Verify Alice Johnson is in the results
+		// Verify the contact is in the results
 		found := false
 		for _, c := range results {
 			if c.ID == contact.ID {
 				found = true
-				assert.Equal(t, "Alice Johnson", c.FullName)
+				assert.Equal(t, name, c.FullName)
 				break
 			}
 		}
-		assert.True(t, found, "Alice Johnson should be found in search results")
+		assert.True(t, found, "the seeded contact should be found in search results")
 	})
 
 	t.Run("PartialNameMatch", func(t *testing.T) {
-		// Create test contact
+		// Create test contact. The surname embeds the namespace token so the
+		// single-word search matches only this test's contact.
+		surname := "Smith" + ns
+		name := "Bob " + surname
 		contact, err := repo.CreateContact(ctx, repository.CreateContactRequest{
-			FullName: "Bob Smith",
+			FullName: name,
 		})
 		require.NoError(t, err)
 		defer func() { _ = repo.HardDeleteContact(ctx, contact.ID) }()
-		addContactMethod(t, ctx, methodRepo, contact.ID, string(repository.ContactMethodEmail), "bob.smith@example.com", true)
+		addContactMethod(t, ctx, methodRepo, contact.ID, string(repository.ContactMethodEmail), "bob.smith."+ns+"@example.com", true)
 
 		// Search for partial name (single word)
 		results, err := repo.SearchContacts(ctx, repository.SearchContactsParams{
-			Query:  "Smith",
+			Query:  surname,
 			Limit:  10,
 			Offset: 0,
 		})
@@ -113,25 +121,26 @@ func TestContactSearch_Integration(t *testing.T) {
 		for _, c := range results {
 			if c.ID == contact.ID {
 				found = true
-				assert.Equal(t, "Bob Smith", c.FullName)
+				assert.Equal(t, name, c.FullName)
 				break
 			}
 		}
-		assert.True(t, found, "Bob Smith should be found when searching for 'Smith'")
+		assert.True(t, found, "the seeded contact should be found when searching the unique surname")
 	})
 
 	t.Run("EmailSearch", func(t *testing.T) {
 		// Create test contact
+		firstName := "Carol" + ns
 		contact, err := repo.CreateContact(ctx, repository.CreateContactRequest{
-			FullName: "Carol Davis",
+			FullName: firstName + " Davis",
 		})
 		require.NoError(t, err)
 		defer func() { _ = repo.HardDeleteContact(ctx, contact.ID) }()
-		addContactMethod(t, ctx, methodRepo, contact.ID, string(repository.ContactMethodEmail), "carol.davis@example.com", true)
+		addContactMethod(t, ctx, methodRepo, contact.ID, string(repository.ContactMethodEmail), "carol.davis."+ns+"@example.com", true)
 
 		// Search by name (FTS tokenizes email addresses specially, so search by name)
 		results, err := repo.SearchContacts(ctx, repository.SearchContactsParams{
-			Query:  "Carol",
+			Query:  firstName,
 			Limit:  10,
 			Offset: 0,
 		})
@@ -150,14 +159,15 @@ func TestContactSearch_Integration(t *testing.T) {
 
 	t.Run("MethodValueSearch", func(t *testing.T) {
 		contact, err := repo.CreateContact(ctx, repository.CreateContactRequest{
-			FullName: "Method Search Contact",
+			FullName: "Method Search Contact " + ns,
 		})
 		require.NoError(t, err)
 		defer func() { _ = repo.HardDeleteContact(ctx, contact.ID) }()
-		addContactMethod(t, ctx, methodRepo, contact.ID, string(repository.ContactMethodTelegram), "handle123", true)
+		handle := "handle" + ns
+		addContactMethod(t, ctx, methodRepo, contact.ID, string(repository.ContactMethodTelegram), handle, true)
 
 		results, err := repo.SearchContacts(ctx, repository.SearchContactsParams{
-			Query:  "handle123",
+			Query:  handle,
 			Limit:  10,
 			Offset: 0,
 		})
@@ -200,19 +210,21 @@ func TestContactSearch_Integration(t *testing.T) {
 	})
 
 	t.Run("Pagination", func(t *testing.T) {
-		// Create multiple test contacts with same pattern
+		// Create multiple test contacts with same pattern. The unique token in
+		// the name makes the search term match only this test's contacts.
+		pageTerm := "Pagination" + ns
 		for i := 0; i < 5; i++ {
 			contact, err := repo.CreateContact(ctx, repository.CreateContactRequest{
-				FullName: "Pagination Test User",
+				FullName: pageTerm + " Test User",
 			})
 			require.NoError(t, err)
 			defer func(id uuid.UUID) { _ = repo.HardDeleteContact(ctx, id) }(contact.ID)
-			addContactMethod(t, ctx, methodRepo, contact.ID, string(repository.ContactMethodEmail), "pagination.test."+string(rune('a'+i))+"@example.com", true)
+			addContactMethod(t, ctx, methodRepo, contact.ID, string(repository.ContactMethodEmail), "pagination.test."+ns+"."+string(rune('a'+i))+"@example.com", true)
 		}
 
 		// Test limit
 		page1, err := repo.SearchContacts(ctx, repository.SearchContactsParams{
-			Query:  "Pagination",
+			Query:  pageTerm,
 			Limit:  2,
 			Offset: 0,
 		})
@@ -234,31 +246,33 @@ func TestContactSearch_Integration(t *testing.T) {
 	})
 
 	t.Run("RelevanceRanking", func(t *testing.T) {
-		// Create contacts with different relevance (both have "Michael" in name)
+		// Both names share a unique token so the search matches only this test's
+		// two contacts — the >= 2 shape assertion is then over our own rows.
+		token := "Michael" + ns
 		contact1, err := repo.CreateContact(ctx, repository.CreateContactRequest{
-			FullName: "Michael Johnson",
+			FullName: token + " Johnson",
 		})
 		require.NoError(t, err)
 		defer func() { _ = repo.HardDeleteContact(ctx, contact1.ID) }()
-		addContactMethod(t, ctx, methodRepo, contact1.ID, string(repository.ContactMethodEmail), "michael.j@example.com", true)
+		addContactMethod(t, ctx, methodRepo, contact1.ID, string(repository.ContactMethodEmail), "michael.j."+ns+"@example.com", true)
 
 		contact2, err := repo.CreateContact(ctx, repository.CreateContactRequest{
-			FullName: "Sarah Michael",
+			FullName: "Sarah " + token,
 		})
 		require.NoError(t, err)
 		defer func() { _ = repo.HardDeleteContact(ctx, contact2.ID) }()
-		addContactMethod(t, ctx, methodRepo, contact2.ID, string(repository.ContactMethodEmail), "sarah.m@example.com", true)
+		addContactMethod(t, ctx, methodRepo, contact2.ID, string(repository.ContactMethodEmail), "sarah.m."+ns+"@example.com", true)
 
-		// Search for "Michael"
+		// Search for the unique token
 		results, err := repo.SearchContacts(ctx, repository.SearchContactsParams{
-			Query:  "Michael",
+			Query:  token,
 			Limit:  10,
 			Offset: 0,
 		})
 		require.NoError(t, err)
 
-		// Should find both contacts (both have "Michael" in full_name)
-		assert.GreaterOrEqual(t, len(results), 2, "Should find at least 2 contacts with 'Michael' in name")
+		// Should find both contacts (both share the token in full_name)
+		assert.GreaterOrEqual(t, len(results), 2, "Should find at least 2 contacts with the token in name")
 
 		// Verify both are in results (order may vary based on other data)
 		foundContact1 := false
@@ -271,21 +285,23 @@ func TestContactSearch_Integration(t *testing.T) {
 				foundContact2 = true
 			}
 		}
-		assert.True(t, foundContact1, "Contact 1 (Michael Johnson) should be in results")
-		assert.True(t, foundContact2, "Contact 2 (Sarah Michael) should be in results")
+		assert.True(t, foundContact1, "Contact 1 should be in results")
+		assert.True(t, foundContact2, "Contact 2 should be in results")
 	})
 
 	t.Run("CaseInsensitive", func(t *testing.T) {
-		// Create test contact
+		// Create test contact. The unique ns suffix scopes the search to this
+		// test's contact; the "david" word is varied in case to prove FTS is
+		// case-insensitive (the ns token is appended unchanged each time).
 		contact, err := repo.CreateContact(ctx, repository.CreateContactRequest{
-			FullName: "David Miller",
+			FullName: "david" + ns + " Miller",
 		})
 		require.NoError(t, err)
 		defer func() { _ = repo.HardDeleteContact(ctx, contact.ID) }()
-		addContactMethod(t, ctx, methodRepo, contact.ID, string(repository.ContactMethodEmail), "david.miller@example.com", true)
+		addContactMethod(t, ctx, methodRepo, contact.ID, string(repository.ContactMethodEmail), "david.miller."+ns+"@example.com", true)
 
-		// Search with different cases
-		testCases := []string{"david", "DAVID", "David", "dAvId"}
+		// Search with different cases of the word, all carrying the ns suffix.
+		testCases := []string{"david" + ns, "DAVID" + ns, "David" + ns, "dAvId" + ns}
 		for _, query := range testCases {
 			results, err := repo.SearchContacts(ctx, repository.SearchContactsParams{
 				Query:  query,
@@ -332,27 +348,31 @@ func TestNoteSearch_Integration(t *testing.T) {
 	repo := repository.NewContactRepository(queries)
 	methodRepo := repository.NewContactMethodRepository(queries)
 
+	// Per-test namespace token so FTS query terms match only this test's notes.
+	ns := syntheticNS(t)
+
 	t.Run("BasicNoteSearch", func(t *testing.T) {
 		// Create a test contact
 		contact, err := repo.CreateContact(ctx, repository.CreateContactRequest{
-			FullName: "Note Test Contact",
+			FullName: "Note Test Contact " + ns,
 		})
 		require.NoError(t, err)
 		defer func() { _ = repo.HardDeleteContact(ctx, contact.ID) }()
-		addContactMethod(t, ctx, methodRepo, contact.ID, string(repository.ContactMethodEmail), "note.test@example.com", true)
+		addContactMethod(t, ctx, methodRepo, contact.ID, string(repository.ContactMethodEmail), "note.test."+ns+"@example.com", true)
 
-		// Create a test note
+		// Create a test note. The ns token makes the two-word phrase unique.
+		term := "machine" + ns
 		note, err := queries.CreateNote(ctx, db.CreateNoteParams{
 			ContactID: pgtype.UUID{Bytes: contact.ID, Valid: true},
-			Body:      "This is a test note about machine learning and artificial intelligence",
+			Body:      "This is a test note about " + term + " learning and artificial intelligence",
 			Category:  pgtype.Text{String: "technical", Valid: true},
 		})
 		require.NoError(t, err)
 		defer func() { _ = queries.DeleteNote(ctx, note.ID) }()
 
-		// Search for "machine learning"
+		// Search for the unique two-word phrase
 		results, err := queries.SearchNotes(ctx, db.SearchNotesParams{
-			PlaintoTsquery: "machine learning",
+			PlaintoTsquery: term + " learning",
 			Limit:          10,
 			Offset:         0,
 		})
@@ -363,26 +383,29 @@ func TestNoteSearch_Integration(t *testing.T) {
 		for _, n := range results {
 			if n.ID.Bytes == note.ID.Bytes {
 				found = true
-				assert.Contains(t, n.Body, "machine learning")
+				assert.Contains(t, n.Body, term)
 				break
 			}
 		}
-		assert.True(t, found, "Note should be found when searching for 'machine learning'")
+		assert.True(t, found, "Note should be found when searching for the unique phrase")
 	})
 
 	t.Run("NoteRelevanceRanking", func(t *testing.T) {
 		// Create contact for test notes
 		contact, err := repo.CreateContact(ctx, repository.CreateContactRequest{
-			FullName: "Ranking Test Contact",
+			FullName: "Ranking Test Contact " + ns,
 		})
 		require.NoError(t, err)
 		defer func() { _ = repo.HardDeleteContact(ctx, contact.ID) }()
-		addContactMethod(t, ctx, methodRepo, contact.ID, string(repository.ContactMethodEmail), "ranking.test@example.com", true)
+		addContactMethod(t, ctx, methodRepo, contact.ID, string(repository.ContactMethodEmail), "ranking.test."+ns+"@example.com", true)
 
-		// Create notes with different relevance
+		// Unique term so only this test's two notes match; note1 carries 3
+		// occurrences (higher rank) vs note2's 1. Searching the term means the
+		// "ranks first" assertion is over our own result set only.
+		term := "golang" + ns
 		note1, err := queries.CreateNote(ctx, db.CreateNoteParams{
 			ContactID: pgtype.UUID{Bytes: contact.ID, Valid: true},
-			Body:      "golang golang golang programming language", // High relevance
+			Body:      term + " " + term + " " + term + " programming language", // High relevance
 			Category:  pgtype.Text{String: "technical", Valid: true},
 		})
 		require.NoError(t, err)
@@ -390,15 +413,15 @@ func TestNoteSearch_Integration(t *testing.T) {
 
 		note2, err := queries.CreateNote(ctx, db.CreateNoteParams{
 			ContactID: pgtype.UUID{Bytes: contact.ID, Valid: true},
-			Body:      "python programming with some golang mention", // Medium relevance
+			Body:      "python programming with some " + term + " mention", // Medium relevance
 			Category:  pgtype.Text{String: "technical", Valid: true},
 		})
 		require.NoError(t, err)
 		defer func() { _ = queries.DeleteNote(ctx, note2.ID) }()
 
-		// Search for "golang"
+		// Search for the unique term
 		results, err := queries.SearchNotes(ctx, db.SearchNotesParams{
-			PlaintoTsquery: "golang",
+			PlaintoTsquery: term,
 			Limit:          10,
 			Offset:         0,
 		})
@@ -436,17 +459,18 @@ func TestNoteSearch_Integration(t *testing.T) {
 	t.Run("NoteSearchPagination", func(t *testing.T) {
 		// Create contact for test notes
 		contact, err := repo.CreateContact(ctx, repository.CreateContactRequest{
-			FullName: "Note Pagination Test",
+			FullName: "Note Pagination Test " + ns,
 		})
 		require.NoError(t, err)
 		defer func() { _ = repo.HardDeleteContact(ctx, contact.ID) }()
-		addContactMethod(t, ctx, methodRepo, contact.ID, string(repository.ContactMethodEmail), "note.pagination@example.com", true)
+		addContactMethod(t, ctx, methodRepo, contact.ID, string(repository.ContactMethodEmail), "note.pagination."+ns+"@example.com", true)
 
-		// Create multiple notes with same keyword
+		// Create multiple notes with the same unique keyword
+		term := "pagination" + ns
 		for i := 0; i < 5; i++ {
 			note, err := queries.CreateNote(ctx, db.CreateNoteParams{
 				ContactID: pgtype.UUID{Bytes: contact.ID, Valid: true},
-				Body:      "Testing pagination functionality with unique content number " + string(rune('0'+i)),
+				Body:      "Testing " + term + " functionality with unique content number " + string(rune('0'+i)),
 				Category:  pgtype.Text{String: "test", Valid: true},
 			})
 			require.NoError(t, err)
@@ -455,7 +479,7 @@ func TestNoteSearch_Integration(t *testing.T) {
 
 		// Test limit
 		page1, err := queries.SearchNotes(ctx, db.SearchNotesParams{
-			PlaintoTsquery: "pagination",
+			PlaintoTsquery: term,
 			Limit:          2,
 			Offset:         0,
 		})
@@ -464,7 +488,7 @@ func TestNoteSearch_Integration(t *testing.T) {
 
 		// Test offset
 		page2, err := queries.SearchNotes(ctx, db.SearchNotesParams{
-			PlaintoTsquery: "pagination",
+			PlaintoTsquery: term,
 			Limit:          2,
 			Offset:         2,
 		})
@@ -479,16 +503,18 @@ func TestNoteSearch_Integration(t *testing.T) {
 	t.Run("NoteSearchCreatedAtSecondarySort", func(t *testing.T) {
 		// Create contact for test notes
 		contact, err := repo.CreateContact(ctx, repository.CreateContactRequest{
-			FullName: "Sort Test Contact",
+			FullName: "Sort Test Contact " + ns,
 		})
 		require.NoError(t, err)
 		defer func() { _ = repo.HardDeleteContact(ctx, contact.ID) }()
-		addContactMethod(t, ctx, methodRepo, contact.ID, string(repository.ContactMethodEmail), "sort.test@example.com", true)
+		addContactMethod(t, ctx, methodRepo, contact.ID, string(repository.ContactMethodEmail), "sort.test."+ns+"@example.com", true)
 
-		// Create notes with same relevance (same keyword count)
+		// Create notes with same relevance (same keyword count); the unique
+		// term keeps the result set to this test's two notes.
+		term := "sorting" + ns
 		note1, err := queries.CreateNote(ctx, db.CreateNoteParams{
 			ContactID: pgtype.UUID{Bytes: contact.ID, Valid: true},
-			Body:      "sorting test first",
+			Body:      term + " test first",
 			Category:  pgtype.Text{String: "test", Valid: true},
 		})
 		require.NoError(t, err)
@@ -496,15 +522,15 @@ func TestNoteSearch_Integration(t *testing.T) {
 
 		note2, err := queries.CreateNote(ctx, db.CreateNoteParams{
 			ContactID: pgtype.UUID{Bytes: contact.ID, Valid: true},
-			Body:      "sorting test second",
+			Body:      term + " test second",
 			Category:  pgtype.Text{String: "test", Valid: true},
 		})
 		require.NoError(t, err)
 		defer func() { _ = queries.DeleteNote(ctx, note2.ID) }()
 
-		// Search for "sorting"
+		// Search for the unique term
 		results, err := queries.SearchNotes(ctx, db.SearchNotesParams{
-			PlaintoTsquery: "sorting",
+			PlaintoTsquery: term,
 			Limit:          10,
 			Offset:         0,
 		})

--- a/backend/tests/sole_writer_static_test.go
+++ b/backend/tests/sole_writer_static_test.go
@@ -134,6 +134,7 @@ var allowedCallSites = map[string]string{
 // cadence-writing symbol lives in the allowedCallSites map. Generated
 // sqlc files and test files are skipped.
 func TestCadenceSoleWriter_OnlyAllowedFilesCallCadenceSQL(t *testing.T) {
+	t.Parallel()
 	moduleRoot, err := backendModuleRoot()
 	if err != nil {
 		t.Fatalf("locate backend module root: %v", err)
@@ -302,6 +303,7 @@ func sqlcQuerierIdent(name string) bool {
 // cadence column. A regression that adds e.g. `last_contacted = $X` to
 // UpdateContact would trip here, independent of the call-site guard.
 func TestUpdateContactSQL_DoesNotTouchCadenceColumns(t *testing.T) {
+	t.Parallel()
 	moduleRoot, err := backendModuleRoot()
 	if err != nil {
 		t.Fatalf("locate backend module root: %v", err)
@@ -356,6 +358,7 @@ func TestUpdateContactSQL_DoesNotTouchCadenceColumns(t *testing.T) {
 // asserts a violation is reported. Without this, a future loosening
 // of the check (e.g., all-files-allowed) could silently pass.
 func TestCadenceSoleWriter_NegativeGuardCatchesNewWrite(t *testing.T) {
+	t.Parallel()
 	src := `package poc
 
 type querier struct{}

--- a/backend/tests/sqlc_select_list_static_test.go
+++ b/backend/tests/sqlc_select_list_static_test.go
@@ -84,6 +84,7 @@ var (
 // queries unless allowlisted. Runs DB-free (pure file parsing) so it executes
 // under make test-unit and -short.
 func TestNoDuplicatedFullRowSelectLists(t *testing.T) {
+	t.Parallel()
 	moduleRoot, err := backendModuleRoot()
 	if err != nil {
 		t.Fatalf("locate backend module root: %v", err)
@@ -411,6 +412,7 @@ func itoa(n int) string {
 // the detector is live (not a no-op). A second case proves SELECT * is NOT
 // flagged.
 func TestSelectListDetector_FlagsSyntheticDuplicate(t *testing.T) {
+	t.Parallel()
 	const dupSrc = `-- name: GetWidgetA :one
 SELECT alpha, beta, gamma FROM widget WHERE id = $1;
 
@@ -447,6 +449,7 @@ SELECT * FROM widget WHERE name = $1;
 // bare-column projection must fingerprint identically — a false-negative hole
 // that existed when the analyzer matched the first SELECT in the block.
 func TestSelectListDetector_ReachesOuterSelectOfCTE(t *testing.T) {
+	t.Parallel()
 	const cteDupSrc = `-- name: WithQueryA :many
 WITH names AS (
   SELECT unnest($1::text[]) as nm
@@ -482,6 +485,7 @@ SELECT alpha, beta, gamma FROM widget WHERE name = $2;
 // and single-occurrence narrow projections (a lone explicit projection is
 // fine; only 2+ identical ones are the smell).
 func TestSelectListDetector_SkipsNonFullRowShapes(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name string
 		src  string

--- a/backend/tests/synthetic_factory_test.go
+++ b/backend/tests/synthetic_factory_test.go
@@ -22,6 +22,7 @@ import (
 var fixedAnchor = time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
 
 func TestSyntheticFactory_StrongDeterminism_NonTimestampOutput(t *testing.T) {
+	t.Parallel()
 	g1 := factory.NewGeneratorAt(factory.DefaultSeed, "ns", fixedAnchor)
 	g2 := factory.NewGeneratorAt(factory.DefaultSeed, "ns", fixedAnchor)
 
@@ -34,6 +35,7 @@ func TestSyntheticFactory_StrongDeterminism_NonTimestampOutput(t *testing.T) {
 }
 
 func TestSyntheticFactory_AnchorRelativeTimestamps(t *testing.T) {
+	t.Parallel()
 	anchorA := fixedAnchor
 	anchorB := fixedAnchor.Add(100 * time.Hour)
 
@@ -55,6 +57,7 @@ func TestSyntheticFactory_AnchorRelativeTimestamps(t *testing.T) {
 }
 
 func TestSyntheticFactory_NamespaceStringPrefixesDisjoint(t *testing.T) {
+	t.Parallel()
 	gA := factory.NewGeneratorAt(factory.DefaultSeed, "alpha", fixedAnchor)
 	gB := factory.NewGeneratorAt(factory.DefaultSeed, "beta", fixedAnchor)
 
@@ -69,6 +72,7 @@ func TestSyntheticFactory_NamespaceStringPrefixesDisjoint(t *testing.T) {
 }
 
 func TestSyntheticFactory_TelegramPeerSubBlocksDisjoint(t *testing.T) {
+	t.Parallel()
 	gA := factory.NewGeneratorAt(factory.DefaultSeed, "alpha", fixedAnchor)
 	gB := factory.NewGeneratorAt(factory.DefaultSeed, "beta", fixedAnchor)
 
@@ -88,6 +92,7 @@ func TestSyntheticFactory_TelegramPeerSubBlocksDisjoint(t *testing.T) {
 }
 
 func TestSyntheticFactory_PhoneSubBlocksDisjoint(t *testing.T) {
+	t.Parallel()
 	gA := factory.NewGeneratorAt(factory.DefaultSeed, "alpha", fixedAnchor)
 	gB := factory.NewGeneratorAt(factory.DefaultSeed, "beta", fixedAnchor)
 
@@ -118,6 +123,7 @@ func TestSyntheticFactory_PhoneSubBlocksDisjoint(t *testing.T) {
 }
 
 func TestSyntheticNamespaceValidation(t *testing.T) {
+	t.Parallel()
 	// Safe tokens (lowercase alnum + hyphen) are accepted; cleanup deletes by
 	// LIKE 'synth-<ns>-%', so anything with a LIKE metacharacter is rejected.
 	for _, ns := range []string{"alpha", "qa-1", "h1234567890", "r0a1b2c3", "seedall"} {
@@ -129,6 +135,7 @@ func TestSyntheticNamespaceValidation(t *testing.T) {
 }
 
 func TestSyntheticFactory_EdgeCaseOptions(t *testing.T) {
+	t.Parallel()
 	g := factory.NewGeneratorAt(factory.DefaultSeed, "edge", fixedAnchor)
 
 	// 1900 birthday sentinel.
@@ -148,6 +155,7 @@ func TestSyntheticFactory_EdgeCaseOptions(t *testing.T) {
 }
 
 func TestSyntheticFactory_MatchIntentAddressesDistinctIdentifiers(t *testing.T) {
+	t.Parallel()
 	g := factory.NewGeneratorAt(factory.DefaultSeed, "intent", fixedAnchor)
 	target := g.Contact(factory.WithEmail())
 

--- a/backend/tests/telegram_chat_config_test.go
+++ b/backend/tests/telegram_chat_config_test.go
@@ -13,16 +13,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const testChatID1 int64 = 70001
-const testChatID2 int64 = 70002
-const testChatID3 int64 = 70003
-
-func cleanupTelegramChatConfigs(t *testing.T, queries db.Querier) {
+// chatConfigIDs returns three per-test-unique telegram chat IDs and registers a
+// cleanup that deletes exactly those rows. Per-test IDs (vs the old fixed
+// 70001-70003 package consts shared by every func) let the funcs run under
+// t.Parallel() without clobbering each other's rows.
+func chatConfigIDs(t *testing.T, queries db.Querier) (id1, id2, id3 int64) {
 	t.Helper()
-	ctx := context.Background()
-	_ = queries.DeleteTelegramChatConfig(ctx, testChatID1)
-	_ = queries.DeleteTelegramChatConfig(ctx, testChatID2)
-	_ = queries.DeleteTelegramChatConfig(ctx, testChatID3)
+	_, ns := migrationGenerator(t)
+	base, _ := uniqueTestIDs(t, ns)
+	id1, id2, id3 = base, base+1, base+2
+	clean := func() {
+		ctx := context.Background()
+		_ = queries.DeleteTelegramChatConfig(ctx, id1)
+		_ = queries.DeleteTelegramChatConfig(ctx, id2)
+		_ = queries.DeleteTelegramChatConfig(ctx, id3)
+	}
+	clean()
+	t.Cleanup(clean)
+	return id1, id2, id3
 }
 
 func TestChatConfig_UpsertAndList(t *testing.T) {
@@ -47,13 +55,12 @@ func TestChatConfig_UpsertAndList(t *testing.T) {
 
 	repo := repository.NewTelegramChatConfigRepository(database.Queries)
 
-	cleanupTelegramChatConfigs(t, database.Queries)
-	t.Cleanup(func() { cleanupTelegramChatConfigs(t, database.Queries) })
+	chatID1, _, _ := chatConfigIDs(t, database.Queries)
 
 	title := "Test Group"
 	mc := int32(5)
 	_, err = repo.UpsertConfig(ctx, repository.UpsertTelegramChatConfigParams{
-		TelegramChatID: testChatID1,
+		TelegramChatID: chatID1,
 		ChatTitle:      &title,
 		ChatType:       "group",
 		MemberCount:    &mc,
@@ -61,6 +68,7 @@ func TestChatConfig_UpsertAndList(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	// This test's own row guarantees ListConfigs returns >= 1.
 	cfgs, err := repo.ListConfigs(ctx)
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, len(cfgs), 1)
@@ -88,19 +96,18 @@ func TestChatConfig_UpdateStatus(t *testing.T) {
 
 	repo := repository.NewTelegramChatConfigRepository(database.Queries)
 
-	cleanupTelegramChatConfigs(t, database.Queries)
-	t.Cleanup(func() { cleanupTelegramChatConfigs(t, database.Queries) })
+	chatID1, _, _ := chatConfigIDs(t, database.Queries)
 
 	title := "Status Test"
 	_, err = repo.UpsertConfig(ctx, repository.UpsertTelegramChatConfigParams{
-		TelegramChatID: testChatID1,
+		TelegramChatID: chatID1,
 		ChatTitle:      &title,
 		ChatType:       "group",
 		Status:         "auto",
 	})
 	require.NoError(t, err)
 
-	updated, err := repo.UpdateStatus(ctx, testChatID1, "ignored")
+	updated, err := repo.UpdateStatus(ctx, chatID1, "ignored")
 	require.NoError(t, err)
 	assert.Equal(t, "ignored", updated.Status)
 }
@@ -127,31 +134,30 @@ func TestChatConfig_BackfillCursorAndComplete(t *testing.T) {
 
 	repo := repository.NewTelegramChatConfigRepository(database.Queries)
 
-	cleanupTelegramChatConfigs(t, database.Queries)
-	t.Cleanup(func() { cleanupTelegramChatConfigs(t, database.Queries) })
+	_, chatID2, _ := chatConfigIDs(t, database.Queries)
 
 	_, err = repo.UpsertConfig(ctx, repository.UpsertTelegramChatConfigParams{
-		TelegramChatID: testChatID2,
+		TelegramChatID: chatID2,
 		ChatType:       "private",
 		Status:         "auto",
 	})
 	require.NoError(t, err)
 
 	// Update cursor
-	err = repo.UpdateBackfillCursor(ctx, testChatID2, 500)
+	err = repo.UpdateBackfillCursor(ctx, chatID2, 500)
 	require.NoError(t, err)
 
-	got, err := repo.GetConfig(ctx, testChatID2)
+	got, err := repo.GetConfig(ctx, chatID2)
 	require.NoError(t, err)
 	require.NotNil(t, got.BackfillCursor)
 	assert.Equal(t, int32(500), *got.BackfillCursor)
 	assert.False(t, got.BackfillComplete)
 
 	// Mark complete
-	err = repo.UpdateBackfillComplete(ctx, testChatID2)
+	err = repo.UpdateBackfillComplete(ctx, chatID2)
 	require.NoError(t, err)
 
-	got, err = repo.GetConfig(ctx, testChatID2)
+	got, err = repo.GetConfig(ctx, chatID2)
 	require.NoError(t, err)
 	assert.True(t, got.BackfillComplete)
 	assert.Nil(t, got.BackfillCursor) // cleared on complete
@@ -179,25 +185,24 @@ func TestChatConfig_ResetBackfill(t *testing.T) {
 
 	repo := repository.NewTelegramChatConfigRepository(database.Queries)
 
-	cleanupTelegramChatConfigs(t, database.Queries)
-	t.Cleanup(func() { cleanupTelegramChatConfigs(t, database.Queries) })
+	_, _, chatID3 := chatConfigIDs(t, database.Queries)
 
 	_, err = repo.UpsertConfig(ctx, repository.UpsertTelegramChatConfigParams{
-		TelegramChatID: testChatID3,
+		TelegramChatID: chatID3,
 		ChatType:       "group",
 		Status:         "auto",
 	})
 	require.NoError(t, err)
 
 	// Complete it
-	err = repo.UpdateBackfillComplete(ctx, testChatID3)
+	err = repo.UpdateBackfillComplete(ctx, chatID3)
 	require.NoError(t, err)
 
 	// Reset
-	err = repo.ResetBackfill(ctx, testChatID3)
+	err = repo.ResetBackfill(ctx, chatID3)
 	require.NoError(t, err)
 
-	got, err := repo.GetConfig(ctx, testChatID3)
+	got, err := repo.GetConfig(ctx, chatID3)
 	require.NoError(t, err)
 	assert.False(t, got.BackfillComplete)
 	assert.Nil(t, got.BackfillCursor)
@@ -225,38 +230,41 @@ func TestChatConfig_ListForBackfill(t *testing.T) {
 
 	repo := repository.NewTelegramChatConfigRepository(database.Queries)
 
-	cleanupTelegramChatConfigs(t, database.Queries)
-	t.Cleanup(func() { cleanupTelegramChatConfigs(t, database.Queries) })
+	chatID1, chatID2, _ := chatConfigIDs(t, database.Queries)
 
 	// Create one incomplete and one complete
 	_, err = repo.UpsertConfig(ctx, repository.UpsertTelegramChatConfigParams{
-		TelegramChatID: testChatID1,
+		TelegramChatID: chatID1,
 		ChatType:       "private",
 		Status:         "auto",
 	})
 	require.NoError(t, err)
 
 	_, err = repo.UpsertConfig(ctx, repository.UpsertTelegramChatConfigParams{
-		TelegramChatID: testChatID2,
+		TelegramChatID: chatID2,
 		ChatType:       "private",
 		Status:         "auto",
 	})
 	require.NoError(t, err)
-	err = repo.UpdateBackfillComplete(ctx, testChatID2)
+	err = repo.UpdateBackfillComplete(ctx, chatID2)
 	require.NoError(t, err)
 
-	// Only the incomplete one should appear
+	// Only the incomplete one should appear. ListForBackfill returns only
+	// incomplete chats, so the BackfillComplete=false check holds for every
+	// returned row (including other parallel tests'); membership is scoped to
+	// this test's own incomplete chat.
 	chats, err := repo.ListForBackfill(ctx)
 	require.NoError(t, err)
 
 	found := false
 	for _, c := range chats {
-		if c.TelegramChatID == testChatID1 {
+		if c.TelegramChatID == chatID1 {
 			found = true
 		}
 		assert.False(t, c.BackfillComplete)
+		assert.NotEqual(t, chatID2, c.TelegramChatID, "completed chat must not appear")
 	}
-	assert.True(t, found, "testChatID1 should be in backfill list")
+	assert.True(t, found, "this test's incomplete chat should be in backfill list")
 }
 
 func TestChatConfig_UpdateMemberCount(t *testing.T) {
@@ -281,22 +289,21 @@ func TestChatConfig_UpdateMemberCount(t *testing.T) {
 
 	repo := repository.NewTelegramChatConfigRepository(database.Queries)
 
-	cleanupTelegramChatConfigs(t, database.Queries)
-	t.Cleanup(func() { cleanupTelegramChatConfigs(t, database.Queries) })
+	chatID1, _, _ := chatConfigIDs(t, database.Queries)
 
 	mc := int32(5)
 	_, err = repo.UpsertConfig(ctx, repository.UpsertTelegramChatConfigParams{
-		TelegramChatID: testChatID1,
+		TelegramChatID: chatID1,
 		ChatType:       "group",
 		MemberCount:    &mc,
 		Status:         "auto",
 	})
 	require.NoError(t, err)
 
-	err = repo.UpdateMemberCount(ctx, testChatID1, 25)
+	err = repo.UpdateMemberCount(ctx, chatID1, 25)
 	require.NoError(t, err)
 
-	got, err := repo.GetConfig(ctx, testChatID1)
+	got, err := repo.GetConfig(ctx, chatID1)
 	require.NoError(t, err)
 	require.NotNil(t, got.MemberCount)
 	assert.Equal(t, int32(25), *got.MemberCount)
@@ -324,29 +331,28 @@ func TestChatConfig_BackfillResume(t *testing.T) {
 
 	repo := repository.NewTelegramChatConfigRepository(database.Queries)
 
-	cleanupTelegramChatConfigs(t, database.Queries)
-	t.Cleanup(func() { cleanupTelegramChatConfigs(t, database.Queries) })
+	chatID1, chatID2, _ := chatConfigIDs(t, database.Queries)
 
 	// Chat 1: has cursor (interrupted mid-backfill)
 	_, err = repo.UpsertConfig(ctx, repository.UpsertTelegramChatConfigParams{
-		TelegramChatID: testChatID1,
+		TelegramChatID: chatID1,
 		ChatType:       "private",
 		Status:         "auto",
 	})
 	require.NoError(t, err)
-	err = repo.UpdateBackfillCursor(ctx, testChatID1, 750)
+	err = repo.UpdateBackfillCursor(ctx, chatID1, 750)
 	require.NoError(t, err)
 
 	// Chat 2: reset (retroactive backfill)
 	_, err = repo.UpsertConfig(ctx, repository.UpsertTelegramChatConfigParams{
-		TelegramChatID: testChatID2,
+		TelegramChatID: chatID2,
 		ChatType:       "group",
 		Status:         "tracked",
 	})
 	require.NoError(t, err)
-	err = repo.UpdateBackfillComplete(ctx, testChatID2)
+	err = repo.UpdateBackfillComplete(ctx, chatID2)
 	require.NoError(t, err)
-	err = repo.ResetBackfill(ctx, testChatID2)
+	err = repo.ResetBackfill(ctx, chatID2)
 	require.NoError(t, err)
 
 	// Both should appear in ListForBackfill
@@ -355,12 +361,12 @@ func TestChatConfig_BackfillResume(t *testing.T) {
 
 	var foundChat1, foundChat2 bool
 	for _, c := range chats {
-		if c.TelegramChatID == testChatID1 {
+		if c.TelegramChatID == chatID1 {
 			foundChat1 = true
 			require.NotNil(t, c.BackfillCursor)
 			assert.Equal(t, int32(750), *c.BackfillCursor, "cursor should be preserved")
 		}
-		if c.TelegramChatID == testChatID2 {
+		if c.TelegramChatID == chatID2 {
 			foundChat2 = true
 			assert.Nil(t, c.BackfillCursor, "cursor should be nil after reset")
 			assert.False(t, c.BackfillComplete)

--- a/backend/tests/telegram_chat_config_test.go
+++ b/backend/tests/telegram_chat_config_test.go
@@ -52,7 +52,9 @@ func TestChatConfig_UpsertAndList(t *testing.T) {
 
 	database, err := db.NewDatabase(ctx, cfg.Database)
 	require.NoError(t, err)
-	defer database.Close()
+	// Close via t.Cleanup (LIFO) so it runs AFTER chatConfigIDs' row-delete
+	// cleanup — a defer would close the pool first and the deletes would no-op.
+	t.Cleanup(func() { database.Close() })
 
 	repo := repository.NewTelegramChatConfigRepository(database.Queries)
 
@@ -102,7 +104,9 @@ func TestChatConfig_UpdateStatus(t *testing.T) {
 
 	database, err := db.NewDatabase(ctx, cfg.Database)
 	require.NoError(t, err)
-	defer database.Close()
+	// Close via t.Cleanup (LIFO) so it runs AFTER chatConfigIDs' row-delete
+	// cleanup — a defer would close the pool first and the deletes would no-op.
+	t.Cleanup(func() { database.Close() })
 
 	repo := repository.NewTelegramChatConfigRepository(database.Queries)
 
@@ -141,7 +145,9 @@ func TestChatConfig_BackfillCursorAndComplete(t *testing.T) {
 
 	database, err := db.NewDatabase(ctx, cfg.Database)
 	require.NoError(t, err)
-	defer database.Close()
+	// Close via t.Cleanup (LIFO) so it runs AFTER chatConfigIDs' row-delete
+	// cleanup — a defer would close the pool first and the deletes would no-op.
+	t.Cleanup(func() { database.Close() })
 
 	repo := repository.NewTelegramChatConfigRepository(database.Queries)
 
@@ -193,7 +199,9 @@ func TestChatConfig_ResetBackfill(t *testing.T) {
 
 	database, err := db.NewDatabase(ctx, cfg.Database)
 	require.NoError(t, err)
-	defer database.Close()
+	// Close via t.Cleanup (LIFO) so it runs AFTER chatConfigIDs' row-delete
+	// cleanup — a defer would close the pool first and the deletes would no-op.
+	t.Cleanup(func() { database.Close() })
 
 	repo := repository.NewTelegramChatConfigRepository(database.Queries)
 
@@ -239,7 +247,9 @@ func TestChatConfig_ListForBackfill(t *testing.T) {
 
 	database, err := db.NewDatabase(ctx, cfg.Database)
 	require.NoError(t, err)
-	defer database.Close()
+	// Close via t.Cleanup (LIFO) so it runs AFTER chatConfigIDs' row-delete
+	// cleanup — a defer would close the pool first and the deletes would no-op.
+	t.Cleanup(func() { database.Close() })
 
 	repo := repository.NewTelegramChatConfigRepository(database.Queries)
 
@@ -299,7 +309,9 @@ func TestChatConfig_UpdateMemberCount(t *testing.T) {
 
 	database, err := db.NewDatabase(ctx, cfg.Database)
 	require.NoError(t, err)
-	defer database.Close()
+	// Close via t.Cleanup (LIFO) so it runs AFTER chatConfigIDs' row-delete
+	// cleanup — a defer would close the pool first and the deletes would no-op.
+	t.Cleanup(func() { database.Close() })
 
 	repo := repository.NewTelegramChatConfigRepository(database.Queries)
 
@@ -342,7 +354,9 @@ func TestChatConfig_BackfillResume(t *testing.T) {
 
 	database, err := db.NewDatabase(ctx, cfg.Database)
 	require.NoError(t, err)
-	defer database.Close()
+	// Close via t.Cleanup (LIFO) so it runs AFTER chatConfigIDs' row-delete
+	// cleanup — a defer would close the pool first and the deletes would no-op.
+	t.Cleanup(func() { database.Close() })
 
 	repo := repository.NewTelegramChatConfigRepository(database.Queries)
 

--- a/backend/tests/telegram_chat_config_test.go
+++ b/backend/tests/telegram_chat_config_test.go
@@ -43,6 +43,7 @@ func TestChatConfig_UpsertAndList(t *testing.T) {
 		t.Skip("DATABASE_URL not set")
 	}
 
+	t.Parallel()
 	// Migrations are applied once by TestMain.
 
 	ctx := context.Background()
@@ -84,6 +85,7 @@ func TestChatConfig_UpdateStatus(t *testing.T) {
 		t.Skip("DATABASE_URL not set")
 	}
 
+	t.Parallel()
 	// Migrations are applied once by TestMain.
 
 	ctx := context.Background()
@@ -122,6 +124,7 @@ func TestChatConfig_BackfillCursorAndComplete(t *testing.T) {
 		t.Skip("DATABASE_URL not set")
 	}
 
+	t.Parallel()
 	// Migrations are applied once by TestMain.
 
 	ctx := context.Background()
@@ -173,6 +176,7 @@ func TestChatConfig_ResetBackfill(t *testing.T) {
 		t.Skip("DATABASE_URL not set")
 	}
 
+	t.Parallel()
 	// Migrations are applied once by TestMain.
 
 	ctx := context.Background()
@@ -218,6 +222,7 @@ func TestChatConfig_ListForBackfill(t *testing.T) {
 		t.Skip("DATABASE_URL not set")
 	}
 
+	t.Parallel()
 	// Migrations are applied once by TestMain.
 
 	ctx := context.Background()
@@ -277,6 +282,7 @@ func TestChatConfig_UpdateMemberCount(t *testing.T) {
 		t.Skip("DATABASE_URL not set")
 	}
 
+	t.Parallel()
 	// Migrations are applied once by TestMain.
 
 	ctx := context.Background()
@@ -319,6 +325,7 @@ func TestChatConfig_BackfillResume(t *testing.T) {
 		t.Skip("DATABASE_URL not set")
 	}
 
+	t.Parallel()
 	// Migrations are applied once by TestMain.
 
 	ctx := context.Background()

--- a/backend/tests/telegram_chat_config_test.go
+++ b/backend/tests/telegram_chat_config_test.go
@@ -69,10 +69,18 @@ func TestChatConfig_UpsertAndList(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// This test's own row guarantees ListConfigs returns >= 1.
+	// Scope the ListConfigs assertion to this test's own chat ID (a DB-wide len
+	// check is shared with parallel tests).
 	cfgs, err := repo.ListConfigs(ctx)
 	require.NoError(t, err)
-	assert.GreaterOrEqual(t, len(cfgs), 1)
+	found := false
+	for _, c := range cfgs {
+		if c.TelegramChatID == chatID1 {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "this test's chat config should be in ListConfigs")
 }
 
 func TestChatConfig_UpdateStatus(t *testing.T) {

--- a/backend/tests/telegram_discovery_upsert_test.go
+++ b/backend/tests/telegram_discovery_upsert_test.go
@@ -19,10 +19,15 @@ import (
 )
 
 // setupDiscoveryUpsertTest spins up a real DB-backed ExternalContactRepository
-// and returns a cleanup function that hard-deletes the rows seeded by the test.
+// and returns a per-test-unique source_id prefix plus a cleanup function that
+// hard-deletes only this test's rows (scoped to that prefix). The per-test
+// prefix is what makes these funcs safe under t.Parallel() — two parallel
+// copies would otherwise share fixed "tg-discovery-upsert-<name>" source_ids
+// and the prefix-wide cleanup would delete each other's rows mid-test.
 func setupDiscoveryUpsertTest(t *testing.T) (
 	*repository.ExternalContactRepository,
 	*db.Database,
+	string,
 	func(),
 ) {
 	t.Helper()
@@ -44,28 +49,29 @@ func setupDiscoveryUpsertTest(t *testing.T) (
 
 	repo := repository.NewExternalContactRepository(database.Queries)
 
+	prefix := "tg-discovery-upsert-" + syntheticNS(t) + "-"
 	cleanup := func() {
-		// Narrow cleanup: only touch rows this test file creates. All test
-		// source_ids are prefixed with "tg-discovery-upsert-". Use the sqlc
-		// query (also used by the /test/cleanup handler) rather than raw SQL.
+		// Narrow cleanup: only this test's per-run prefix. Use the sqlc query
+		// (also used by the /test/cleanup handler) rather than raw SQL.
 		_, _ = database.Queries.DeleteExternalContactsBySourceIDPrefix(
 			context.Background(),
-			pgtype.Text{String: "tg-discovery-upsert-", Valid: true},
+			pgtype.Text{String: prefix, Valid: true},
 		)
 		database.Close()
 	}
-	return repo, database, cleanup
+	return repo, database, prefix, cleanup
 }
 
 func TestUpsertTelegramDiscoveryCandidate_InsertsNewRow(t *testing.T) {
-	repo, _, cleanup := setupDiscoveryUpsertTest(t)
+	t.Parallel()
+	repo, _, prefix, cleanup := setupDiscoveryUpsertTest(t)
 	defer cleanup()
 
 	ctx := context.Background()
 	now := accelerated.GetCurrentTime()
 
 	got, err := repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
-		SourceID:    "tg-discovery-upsert-insert",
+		SourceID:    prefix + "insert",
 		DisplayName: strPtr("Dale Dobeck"),
 		FirstName:   strPtr("Dale"),
 		LastName:    strPtr("Dobeck"),
@@ -76,7 +82,7 @@ func TestUpsertTelegramDiscoveryCandidate_InsertsNewRow(t *testing.T) {
 	require.NotNil(t, got)
 
 	assert.Equal(t, "telegram", got.Source)
-	assert.Equal(t, "tg-discovery-upsert-insert", got.SourceID)
+	assert.Equal(t, prefix+"insert", got.SourceID)
 	require.NotNil(t, got.DisplayName)
 	assert.Equal(t, "Dale Dobeck", *got.DisplayName)
 	require.NotNil(t, got.FirstName)
@@ -90,7 +96,8 @@ func TestUpsertTelegramDiscoveryCandidate_InsertsNewRow(t *testing.T) {
 }
 
 func TestUpsertTelegramDiscoveryCandidate_PreservesFirstNameWhenNil(t *testing.T) {
-	repo, _, cleanup := setupDiscoveryUpsertTest(t)
+	t.Parallel()
+	repo, _, prefix, cleanup := setupDiscoveryUpsertTest(t)
 	defer cleanup()
 
 	ctx := context.Background()
@@ -98,7 +105,7 @@ func TestUpsertTelegramDiscoveryCandidate_PreservesFirstNameWhenNil(t *testing.T
 
 	// Seed with names populated.
 	_, err := repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
-		SourceID:  "tg-discovery-upsert-preserve",
+		SourceID:  prefix + "preserve",
 		FirstName: strPtr("Dale"),
 		LastName:  strPtr("Dobeck"),
 		SyncedAt:  &now,
@@ -107,7 +114,7 @@ func TestUpsertTelegramDiscoveryCandidate_PreservesFirstNameWhenNil(t *testing.T
 
 	// Re-upsert with nil names — should preserve existing.
 	got, err := repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
-		SourceID: "tg-discovery-upsert-preserve",
+		SourceID: prefix + "preserve",
 		SyncedAt: &now,
 	})
 	require.NoError(t, err)
@@ -118,21 +125,22 @@ func TestUpsertTelegramDiscoveryCandidate_PreservesFirstNameWhenNil(t *testing.T
 }
 
 func TestUpsertTelegramDiscoveryCandidate_OverwritesFirstNameWhenNewValueProvided(t *testing.T) {
-	repo, _, cleanup := setupDiscoveryUpsertTest(t)
+	t.Parallel()
+	repo, _, prefix, cleanup := setupDiscoveryUpsertTest(t)
 	defer cleanup()
 
 	ctx := context.Background()
 	now := accelerated.GetCurrentTime()
 
 	_, err := repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
-		SourceID:  "tg-discovery-upsert-overwrite",
+		SourceID:  prefix + "overwrite",
 		FirstName: strPtr("Dale"),
 		SyncedAt:  &now,
 	})
 	require.NoError(t, err)
 
 	got, err := repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
-		SourceID:  "tg-discovery-upsert-overwrite",
+		SourceID:  prefix + "overwrite",
 		FirstName: strPtr("Daniel"),
 		SyncedAt:  &now,
 	})
@@ -142,7 +150,8 @@ func TestUpsertTelegramDiscoveryCandidate_OverwritesFirstNameWhenNewValueProvide
 }
 
 func TestUpsertTelegramDiscoveryCandidate_MergesMetadata_PreservesExistingKey(t *testing.T) {
-	repo, _, cleanup := setupDiscoveryUpsertTest(t)
+	t.Parallel()
+	repo, _, prefix, cleanup := setupDiscoveryUpsertTest(t)
 	defer cleanup()
 
 	ctx := context.Background()
@@ -150,7 +159,7 @@ func TestUpsertTelegramDiscoveryCandidate_MergesMetadata_PreservesExistingKey(t 
 
 	// Seed with a username key.
 	_, err := repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
-		SourceID: "tg-discovery-upsert-merge-keep",
+		SourceID: prefix + "merge-keep",
 		Metadata: map[string]any{"username": "@dale", "message_count": 5},
 		SyncedAt: &now,
 	})
@@ -158,7 +167,7 @@ func TestUpsertTelegramDiscoveryCandidate_MergesMetadata_PreservesExistingKey(t 
 
 	// Re-upsert with only message_count — username must be retained.
 	got, err := repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
-		SourceID: "tg-discovery-upsert-merge-keep",
+		SourceID: prefix + "merge-keep",
 		Metadata: map[string]any{"message_count": 10},
 		SyncedAt: &now,
 	})
@@ -168,21 +177,22 @@ func TestUpsertTelegramDiscoveryCandidate_MergesMetadata_PreservesExistingKey(t 
 }
 
 func TestUpsertTelegramDiscoveryCandidate_MergesMetadata_IncomingWinsForDuplicate(t *testing.T) {
-	repo, _, cleanup := setupDiscoveryUpsertTest(t)
+	t.Parallel()
+	repo, _, prefix, cleanup := setupDiscoveryUpsertTest(t)
 	defer cleanup()
 
 	ctx := context.Background()
 	now := accelerated.GetCurrentTime()
 
 	_, err := repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
-		SourceID: "tg-discovery-upsert-merge-new",
+		SourceID: prefix + "merge-new",
 		Metadata: map[string]any{"username": "@old"},
 		SyncedAt: &now,
 	})
 	require.NoError(t, err)
 
 	got, err := repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
-		SourceID: "tg-discovery-upsert-merge-new",
+		SourceID: prefix + "merge-new",
 		Metadata: map[string]any{"username": "@new"},
 		SyncedAt: &now,
 	})
@@ -191,21 +201,22 @@ func TestUpsertTelegramDiscoveryCandidate_MergesMetadata_IncomingWinsForDuplicat
 }
 
 func TestUpsertTelegramDiscoveryCandidate_SyncedAtAlwaysUpdates(t *testing.T) {
-	repo, _, cleanup := setupDiscoveryUpsertTest(t)
+	t.Parallel()
+	repo, _, prefix, cleanup := setupDiscoveryUpsertTest(t)
 	defer cleanup()
 
 	ctx := context.Background()
 
 	start := accelerated.GetCurrentTime()
 	_, err := repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
-		SourceID: "tg-discovery-upsert-syncedat",
+		SourceID: prefix + "syncedat",
 		SyncedAt: &start,
 	})
 	require.NoError(t, err)
 
 	later := start.Add(1 * time.Hour)
 	got, err := repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
-		SourceID: "tg-discovery-upsert-syncedat",
+		SourceID: prefix + "syncedat",
 		SyncedAt: &later,
 	})
 	require.NoError(t, err)
@@ -217,7 +228,8 @@ func TestUpsertTelegramDiscoveryCandidate_SyncedAtAlwaysUpdates(t *testing.T) {
 // proves the dedicated DO UPDATE SET only touches the 6 columns it manages —
 // anything seeded via the shared Upsert (emails, phones, etc.) is untouched.
 func TestUpsertTelegramDiscoveryCandidate_DoesNotClearEmailsSetBySharedUpsert(t *testing.T) {
-	repo, _, cleanup := setupDiscoveryUpsertTest(t)
+	t.Parallel()
+	repo, _, prefix, cleanup := setupDiscoveryUpsertTest(t)
 	defer cleanup()
 
 	ctx := context.Background()
@@ -226,7 +238,7 @@ func TestUpsertTelegramDiscoveryCandidate_DoesNotClearEmailsSetBySharedUpsert(t 
 	// Seed via the shared Upsert so emails are populated.
 	_, err := repo.Upsert(ctx, repository.UpsertExternalContactRequest{
 		Source:   "telegram",
-		SourceID: "tg-discovery-upsert-emails",
+		SourceID: prefix + "emails",
 		Emails:   []repository.EmailEntry{{Value: "a@x", Type: "personal", Primary: true}},
 		SyncedAt: &now,
 	})
@@ -234,14 +246,14 @@ func TestUpsertTelegramDiscoveryCandidate_DoesNotClearEmailsSetBySharedUpsert(t 
 
 	// Call the dedicated upsert with only names.
 	_, err = repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
-		SourceID:  "tg-discovery-upsert-emails",
+		SourceID:  prefix + "emails",
 		FirstName: strPtr("Dale"),
 		Metadata:  map[string]any{"username": "@dale"},
 		SyncedAt:  &now,
 	})
 	require.NoError(t, err)
 
-	got, err := repo.GetBySource(ctx, "telegram", "tg-discovery-upsert-emails", nil)
+	got, err := repo.GetBySource(ctx, "telegram", prefix+"emails", nil)
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	require.Len(t, got.Emails, 1)
@@ -249,7 +261,8 @@ func TestUpsertTelegramDiscoveryCandidate_DoesNotClearEmailsSetBySharedUpsert(t 
 }
 
 func TestUpsertTelegramDiscoveryCandidate_DoesNotTouchMatchStatus(t *testing.T) {
-	repo, database, cleanup := setupDiscoveryUpsertTest(t)
+	t.Parallel()
+	repo, database, prefix, cleanup := setupDiscoveryUpsertTest(t)
 	defer cleanup()
 
 	ctx := context.Background()
@@ -263,7 +276,7 @@ func TestUpsertTelegramDiscoveryCandidate_DoesNotTouchMatchStatus(t *testing.T) 
 	defer contactCleanup()
 
 	row, err := repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
-		SourceID: "tg-discovery-upsert-match",
+		SourceID: prefix + "match",
 		SyncedAt: &now,
 	})
 	require.NoError(t, err)
@@ -272,13 +285,13 @@ func TestUpsertTelegramDiscoveryCandidate_DoesNotTouchMatchStatus(t *testing.T) 
 	require.NoError(t, err)
 
 	_, err = repo.UpsertTelegramDiscoveryCandidate(ctx, repository.UpsertTelegramDiscoveryCandidateRequest{
-		SourceID:  "tg-discovery-upsert-match",
+		SourceID:  prefix + "match",
 		FirstName: strPtr("Dale"),
 		SyncedAt:  &now,
 	})
 	require.NoError(t, err)
 
-	got, err := repo.GetBySource(ctx, "telegram", "tg-discovery-upsert-match", nil)
+	got, err := repo.GetBySource(ctx, "telegram", prefix+"match", nil)
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	assert.Equal(t, repository.MatchStatusMatched, got.MatchStatus, "dedicated upsert must not reset match_status")
@@ -290,7 +303,8 @@ func TestUpsertTelegramDiscoveryCandidate_DoesNotTouchMatchStatus(t *testing.T) 
 // upsert retains its "authoritative overwrite" semantics for Google flows —
 // this plan only adds a parallel path, it does not change the shared one.
 func TestUpsertExternalContact_SharedUpsertStillOverwrites(t *testing.T) {
-	repo, _, cleanup := setupDiscoveryUpsertTest(t)
+	t.Parallel()
+	repo, _, prefix, cleanup := setupDiscoveryUpsertTest(t)
 	defer cleanup()
 
 	ctx := context.Background()
@@ -298,7 +312,7 @@ func TestUpsertExternalContact_SharedUpsertStillOverwrites(t *testing.T) {
 
 	_, err := repo.Upsert(ctx, repository.UpsertExternalContactRequest{
 		Source:    "gcontacts",
-		SourceID:  "tg-discovery-upsert-shared-overwrite",
+		SourceID:  prefix + "shared-overwrite",
 		FirstName: strPtr("Alice"),
 		SyncedAt:  &now,
 	})
@@ -306,7 +320,7 @@ func TestUpsertExternalContact_SharedUpsertStillOverwrites(t *testing.T) {
 
 	got, err := repo.Upsert(ctx, repository.UpsertExternalContactRequest{
 		Source:   "gcontacts",
-		SourceID: "tg-discovery-upsert-shared-overwrite",
+		SourceID: prefix + "shared-overwrite",
 		// FirstName intentionally nil — shared upsert should clear it.
 		SyncedAt: &now,
 	})
@@ -329,6 +343,7 @@ func TestUpdateDiscoveryCandidates_BatchPath_BlankStringsDoNotClobberStoredData(
 	if databaseURL == "" {
 		t.Skip("DATABASE_URL not set")
 	}
+	t.Parallel()
 	// Migrations are applied once by TestMain.
 
 	ctx := context.Background()
@@ -339,8 +354,12 @@ func TestUpdateDiscoveryCandidates_BatchPath_BlankStringsDoNotClobberStoredData(
 	require.NoError(t, err)
 	defer database.Close()
 
-	const testPeerID int64 = 99001
-	const testChatID int64 = 9900
+	// Per-test-unique peer/chat IDs. The external_contact / external_identity
+	// source_id is derived from the peer_user_id, so two parallel copies sharing
+	// a fixed 99001 would collide on the row and on the peer-scoped cleanup.
+	_, ns := migrationGenerator(t)
+	testPeerID, peerStr := uniqueTestIDs(t, ns)
+	testChatID := testPeerID + 1
 	username := "daledobeck"
 	empty := ""
 	firstName := "Dale"
@@ -360,12 +379,12 @@ func TestUpdateDiscoveryCandidates_BatchPath_BlankStringsDoNotClobberStoredData(
 		)
 		_, _ = database.Queries.DeleteExternalContactsBySourceIDPrefix(
 			ctx,
-			pgtype.Text{String: "99001", Valid: true},
+			pgtype.Text{String: peerStr, Valid: true},
 		)
 		// External_identity row created by MatchOrCreate — also keyed by source_id.
 		_, _ = database.Queries.DeleteExternalIdentitiesBySourceID(
 			ctx,
-			pgtype.Text{String: "99001", Valid: true},
+			pgtype.Text{String: peerStr, Valid: true},
 		)
 	})
 
@@ -409,7 +428,7 @@ func TestUpdateDiscoveryCandidates_BatchPath_BlankStringsDoNotClobberStoredData(
 	require.NoError(t, matcher.MatchAllUnmatched(ctx))
 	require.NoError(t, matcher.UpdateDiscoveryCandidates(ctx))
 
-	got, err := externalRepo.GetBySource(ctx, "telegram", "99001", nil)
+	got, err := externalRepo.GetBySource(ctx, "telegram", peerStr, nil)
 	require.NoError(t, err)
 	require.NotNil(t, got, "discovery should have inserted an external_contact row")
 	require.NotNil(t, got.FirstName)
@@ -422,7 +441,7 @@ func TestUpdateDiscoveryCandidates_BatchPath_BlankStringsDoNotClobberStoredData(
 	// even when future aggregation picks the blank-string row.
 	require.NoError(t, matcher.UpdateDiscoveryCandidates(ctx))
 
-	got, err = externalRepo.GetBySource(ctx, "telegram", "99001", nil)
+	got, err = externalRepo.GetBySource(ctx, "telegram", peerStr, nil)
 	require.NoError(t, err)
 	require.NotNil(t, got.FirstName)
 	assert.Equal(t, "Dale", *got.FirstName, "re-running discovery must not clobber stored names")

--- a/backend/tests/telegram_discovery_upsert_test.go
+++ b/backend/tests/telegram_discovery_upsert_test.go
@@ -352,7 +352,9 @@ func TestUpdateDiscoveryCandidates_BatchPath_BlankStringsDoNotClobberStoredData(
 
 	database, err := db.NewDatabase(ctx, cfg.Database)
 	require.NoError(t, err)
-	defer database.Close()
+	// Close via t.Cleanup (LIFO) so it runs AFTER the row-delete t.Cleanup below
+	// — a defer would close the pool first and the deletes would no-op.
+	t.Cleanup(func() { database.Close() })
 
 	// Per-test-unique peer/chat IDs. The external_contact / external_identity
 	// source_id is derived from the peer_user_id, so two parallel copies sharing

--- a/backend/tests/telegram_import_suggestion_test.go
+++ b/backend/tests/telegram_import_suggestion_test.go
@@ -73,7 +73,7 @@ func setupTelegramImportSuggestionTest(t *testing.T) (
 	suggestionService := service.NewSuggestionService(externalRepo, contactRepo, contactMethodRepo, enrichmentService, matchService, database)
 	importHandler := handlers.NewImportHandler(externalRepo, nil, contactService, matchService, enrichmentService, suggestionService)
 
-	gin.SetMode(gin.TestMode)
+	// gin.SetMode is hoisted to TestMain so parallel tests don't race on it.
 	router := gin.New()
 	router.Use(api.RequestIDMiddleware())
 	router.Use(api.CORSMiddleware(config.CORSConfig{AllowAll: true}))

--- a/backend/tests/telegram_import_suggestion_test.go
+++ b/backend/tests/telegram_import_suggestion_test.go
@@ -168,6 +168,7 @@ func seedContactWithCleanup(t *testing.T, repo *repository.ContactRepository, fu
 // Each sub-test uses unique full_names to avoid pg_trgm returning multiple
 // equal-score matches (which would trip the collision-gap rule).
 func TestTelegramImportSuggestion_Integration(t *testing.T) {
+	t.Parallel()
 	router, externalRepo, contactRepo, cleanup := setupTelegramImportSuggestionTest(t)
 	defer cleanup()
 

--- a/backend/tests/telegram_matcher_enrichment_test.go
+++ b/backend/tests/telegram_matcher_enrichment_test.go
@@ -120,6 +120,7 @@ func registerCleanupBySource(t *testing.T, env *matcherEnrichTestEnv, ctx contex
 }
 
 func TestMatcherEnrichment_AboveThreshold_UsernameMatch(t *testing.T) {
+	t.Parallel()
 	env := setupMatcherEnrichmentTest(t)
 	ctx := context.Background()
 	gen, ns := migrationGenerator(t)
@@ -186,6 +187,7 @@ func TestMatcherEnrichment_AboveThreshold_UsernameMatch(t *testing.T) {
 }
 
 func TestMatcherEnrichment_BelowThreshold_NoExternalContact(t *testing.T) {
+	t.Parallel()
 	env := setupMatcherEnrichmentTest(t)
 	ctx := context.Background()
 	gen, ns := migrationGenerator(t)
@@ -231,6 +233,7 @@ func TestMatcherEnrichment_BelowThreshold_NoExternalContact(t *testing.T) {
 }
 
 func TestMatcherEnrichment_PhoneMatchWithUsername(t *testing.T) {
+	t.Parallel()
 	env := setupMatcherEnrichmentTest(t)
 	ctx := context.Background()
 	gen, ns := migrationGenerator(t)
@@ -265,6 +268,7 @@ func TestMatcherEnrichment_PhoneMatchWithUsername(t *testing.T) {
 }
 
 func TestMatcherEnrichment_PhoneMatchWithoutUsername(t *testing.T) {
+	t.Parallel()
 	env := setupMatcherEnrichmentTest(t)
 	ctx := context.Background()
 	gen, ns := migrationGenerator(t)
@@ -292,6 +296,7 @@ func TestMatcherEnrichment_PhoneMatchWithoutUsername(t *testing.T) {
 }
 
 func TestMatcherEnrichment_Idempotency(t *testing.T) {
+	t.Parallel()
 	env := setupMatcherEnrichmentTest(t)
 	ctx := context.Background()
 	gen, ns := migrationGenerator(t)
@@ -333,6 +338,7 @@ func TestMatcherEnrichment_Idempotency(t *testing.T) {
 // no duplicate row. Higher concurrency is used to make 23505 path coverage
 // deterministic in practice; a single sequential run cannot trigger it.
 func TestMatcherEnrichment_ConcurrentMatch_TreatsUniqueViolationAsSuccess(t *testing.T) {
+	t.Parallel()
 	env := setupMatcherEnrichmentTest(t)
 	ctx := context.Background()
 	gen, ns := migrationGenerator(t)
@@ -391,6 +397,7 @@ func TestMatcherEnrichment_ConcurrentMatch_TreatsUniqueViolationAsSuccess(t *tes
 // markExternalContactMatched early-returns in this case, so enrichment must
 // run from MatchPeer regardless of stored match status.
 func TestMatcherEnrichment_AlreadyMatchedExternalContact_RepairsMissingMethod(t *testing.T) {
+	t.Parallel()
 	env := setupMatcherEnrichmentTest(t)
 	ctx := context.Background()
 	gen, ns := migrationGenerator(t)
@@ -451,6 +458,7 @@ func TestMatcherEnrichment_EnricherErrorDoesNotBreakMatch(t *testing.T) {
 	if databaseURL == "" {
 		t.Skip("DATABASE_URL not set")
 	}
+	t.Parallel()
 	// Migrations are applied once by TestMain.
 
 	cfg := config.TestConfig()

--- a/backend/tests/telegram_message_all_fields_test.go
+++ b/backend/tests/telegram_message_all_fields_test.go
@@ -40,6 +40,7 @@ func TestTelegramMessage_AllFieldsPopulatedOnRead(t *testing.T) {
 		t.Skip("DATABASE_URL not set")
 	}
 
+	t.Parallel()
 	// Migrations are applied once by TestMain.
 
 	ctx := context.Background()

--- a/backend/tests/telegram_message_claim_test.go
+++ b/backend/tests/telegram_message_claim_test.go
@@ -56,6 +56,7 @@ func telegramClaimSetup(t *testing.T) (context.Context, *factory.Generator, *rep
 }
 
 func TestTelegramMessageRepository_ClaimMessages_SetsClaimColumns(t *testing.T) {
+	t.Parallel()
 	ctx, _, repo, _, contact, chatID, cleanup := telegramClaimSetup(t)
 	defer cleanup()
 
@@ -88,6 +89,7 @@ func TestTelegramMessageRepository_ClaimMessages_SetsClaimColumns(t *testing.T) 
 }
 
 func TestTelegramMessageRepository_ListUnprocessedByContact_ExcludesActiveClaim(t *testing.T) {
+	t.Parallel()
 	ctx, _, repo, _, contact, chatID, cleanup := telegramClaimSetup(t)
 	defer cleanup()
 
@@ -118,6 +120,7 @@ func TestTelegramMessageRepository_ListUnprocessedByContact_ExcludesActiveClaim(
 }
 
 func TestTelegramMessageRepository_ListUnprocessedByContact_IncludesStaleClaim(t *testing.T) {
+	t.Parallel()
 	ctx, _, repo, _, contact, chatID, cleanup := telegramClaimSetup(t)
 	defer cleanup()
 
@@ -147,6 +150,7 @@ func TestTelegramMessageRepository_ListUnprocessedByContact_IncludesStaleClaim(t
 }
 
 func TestTelegramMessageRepository_ClaimMessages_PartialClaim(t *testing.T) {
+	t.Parallel()
 	ctx, _, repo, _, contact, chatID, cleanup := telegramClaimSetup(t)
 	defer cleanup()
 
@@ -178,6 +182,7 @@ func TestTelegramMessageRepository_ClaimMessages_PartialClaim(t *testing.T) {
 // MarkProcessedTx returns 0 rows affected when the predicate filters
 // out everything.
 func TestTelegramMessageRepository_MarkProcessedTx_RejectsOtherSession(t *testing.T) {
+	t.Parallel()
 	ctx, _, repo, _, contact, chatID, cleanup := telegramClaimSetup(t)
 	defer cleanup()
 
@@ -223,6 +228,7 @@ func TestTelegramMessageRepository_MarkProcessedTx_RejectsOtherSession(t *testin
 // confirms the consumer can process rows it claimed for its own
 // session.
 func TestTelegramMessageRepository_MarkProcessedTx_AcceptsOwnSession(t *testing.T) {
+	t.Parallel()
 	ctx, gen, repo, _, contact, chatID, cleanup := telegramClaimSetup(t)
 	defer cleanup()
 
@@ -276,6 +282,7 @@ func TestTelegramMessageRepository_MarkProcessedTx_AcceptsOwnSession(t *testing.
 // claimed (engine took the non-tx publish path / test mode) is still
 // markable by the consumer.
 func TestTelegramMessageRepository_MarkProcessedTx_AcceptsNullClaim(t *testing.T) {
+	t.Parallel()
 	ctx, gen, repo, _, contact, chatID, cleanup := telegramClaimSetup(t)
 	defer cleanup()
 

--- a/backend/tests/telegram_message_test.go
+++ b/backend/tests/telegram_message_test.go
@@ -41,6 +41,7 @@ func TestTelegramMessage_UpsertAndGet(t *testing.T) {
 		t.Skip("DATABASE_URL not set")
 	}
 
+	t.Parallel()
 	// Migrations are applied once by TestMain.
 
 	ctx := context.Background()
@@ -100,6 +101,7 @@ func TestTelegramMessage_UpsertIdempotent(t *testing.T) {
 		t.Skip("DATABASE_URL not set")
 	}
 
+	t.Parallel()
 	// Migrations are applied once by TestMain.
 
 	ctx := context.Background()
@@ -154,6 +156,7 @@ func TestTelegramMessage_UpsertEdit(t *testing.T) {
 		t.Skip("DATABASE_URL not set")
 	}
 
+	t.Parallel()
 	// Migrations are applied once by TestMain.
 
 	ctx := context.Background()
@@ -210,6 +213,7 @@ func TestTelegramMessage_SoftDelete(t *testing.T) {
 		t.Skip("DATABASE_URL not set")
 	}
 
+	t.Parallel()
 	// Migrations are applied once by TestMain.
 
 	ctx := context.Background()
@@ -257,6 +261,7 @@ func TestTelegramMessage_SoftDeleteChannel(t *testing.T) {
 		t.Skip("DATABASE_URL not set")
 	}
 
+	t.Parallel()
 	// Migrations are applied once by TestMain.
 
 	ctx := context.Background()
@@ -308,6 +313,7 @@ func TestTelegramMessage_ListUnprocessed(t *testing.T) {
 		t.Skip("DATABASE_URL not set")
 	}
 
+	t.Parallel()
 	// Migrations are applied once by TestMain.
 
 	ctx := context.Background()

--- a/backend/tests/telegram_message_test.go
+++ b/backend/tests/telegram_message_test.go
@@ -227,12 +227,16 @@ func TestTelegramMessage_SoftDelete(t *testing.T) {
 	repo := repository.NewTelegramMessageRepository(database.Queries)
 
 	chatID := telegramTestChat(t, repo)
+	// SoftDeleteMessages is DB-wide by message_id (no chat filter), so use a
+	// per-test-unique message ID derived from the unique chat base — otherwise a
+	// parallel copy's row with the same fixed message ID would be soft-deleted.
+	msgID := int32(chatID % 2_000_000_000)
 
 	sentAt := accelerated.GetCurrentTime().Truncate(time.Microsecond)
 	text := "To be deleted"
 
 	_, err = repo.UpsertMessage(ctx, repository.UpsertTelegramMessageParams{
-		TelegramMessageID: 90004,
+		TelegramMessageID: msgID,
 		TelegramChatID:    chatID,
 		ChatType:          "private",
 		MessageText:       &text,
@@ -243,11 +247,11 @@ func TestTelegramMessage_SoftDelete(t *testing.T) {
 	require.NoError(t, err)
 
 	// Soft delete
-	err = repo.SoftDeleteMessages(ctx, []int32{90004})
+	err = repo.SoftDeleteMessages(ctx, []int32{msgID})
 	require.NoError(t, err)
 
 	// Verify deleted — GetMessage filters deleted_at IS NULL, so should return not found
-	_, err = repo.GetMessage(ctx, chatID, 90004)
+	_, err = repo.GetMessage(ctx, chatID, msgID)
 	assert.Error(t, err)
 }
 

--- a/backend/tests/telegram_message_test.go
+++ b/backend/tests/telegram_message_test.go
@@ -15,10 +15,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func cleanupTelegramMessages(t *testing.T, queries db.Querier) {
+// telegramTestChat returns a per-test-unique telegram chat ID and registers a
+// chat-range cleanup that deletes only this test's own rows. Per-test chat IDs
+// (vs the old fixed 12345/-100555/77777 shared across funcs) let the funcs run
+// under t.Parallel() without their shared message-ID cleanup deleting each
+// other's rows. The message IDs themselves stay as small literals — they are
+// unique per (chat_id, message_id), and the chat_id is now unique per test.
+func telegramTestChat(t *testing.T, repo *repository.TelegramMessageRepository) int64 {
 	t.Helper()
-	ctx := context.Background()
-	_, _ = queries.DeleteTelegramMessagesByMessageIDs(ctx, []int32{90001, 90002, 90003, 90004, 90005})
+	_, ns := migrationGenerator(t)
+	base, _ := uniqueTestIDs(t, ns)
+	clean := func() { _ = repo.HardDeleteByChatIDRange(context.Background(), base, base) }
+	clean()
+	t.Cleanup(clean)
+	return base
 }
 
 func TestTelegramMessage_UpsertAndGet(t *testing.T) {
@@ -43,8 +53,7 @@ func TestTelegramMessage_UpsertAndGet(t *testing.T) {
 
 	repo := repository.NewTelegramMessageRepository(database.Queries)
 
-	cleanupTelegramMessages(t, database.Queries)
-	t.Cleanup(func() { cleanupTelegramMessages(t, database.Queries) })
+	chatID := telegramTestChat(t, repo)
 
 	sentAt := accelerated.GetCurrentTime().Truncate(time.Microsecond)
 	text := "Hello, world!"
@@ -53,7 +62,7 @@ func TestTelegramMessage_UpsertAndGet(t *testing.T) {
 
 	msg, err := repo.UpsertMessage(ctx, repository.UpsertTelegramMessageParams{
 		TelegramMessageID: 90001,
-		TelegramChatID:    12345,
+		TelegramChatID:    chatID,
 		ChatType:          "private",
 		MessageText:       &text,
 		MessageType:       "text",
@@ -65,7 +74,7 @@ func TestTelegramMessage_UpsertAndGet(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, int32(90001), msg.TelegramMessageID)
-	assert.Equal(t, int64(12345), msg.TelegramChatID)
+	assert.Equal(t, chatID, msg.TelegramChatID)
 	assert.Equal(t, "private", msg.ChatType)
 	assert.Equal(t, &text, msg.MessageText)
 	assert.Equal(t, "text", msg.MessageType)
@@ -75,7 +84,7 @@ func TestTelegramMessage_UpsertAndGet(t *testing.T) {
 	assert.Equal(t, &firstName, msg.PeerFirstName)
 
 	// Get it back
-	got, err := repo.GetMessage(ctx, 12345, 90001)
+	got, err := repo.GetMessage(ctx, chatID, 90001)
 	require.NoError(t, err)
 	assert.Equal(t, msg.ID, got.ID)
 	assert.Equal(t, &text, got.MessageText)
@@ -103,15 +112,14 @@ func TestTelegramMessage_UpsertIdempotent(t *testing.T) {
 
 	repo := repository.NewTelegramMessageRepository(database.Queries)
 
-	cleanupTelegramMessages(t, database.Queries)
-	t.Cleanup(func() { cleanupTelegramMessages(t, database.Queries) })
+	chatID := telegramTestChat(t, repo)
 
 	sentAt := accelerated.GetCurrentTime().Truncate(time.Microsecond)
 	text1 := "First version"
 
 	msg1, err := repo.UpsertMessage(ctx, repository.UpsertTelegramMessageParams{
 		TelegramMessageID: 90002,
-		TelegramChatID:    12345,
+		TelegramChatID:    chatID,
 		ChatType:          "private",
 		MessageText:       &text1,
 		MessageType:       "text",
@@ -124,7 +132,7 @@ func TestTelegramMessage_UpsertIdempotent(t *testing.T) {
 	text2 := "Updated version"
 	msg2, err := repo.UpsertMessage(ctx, repository.UpsertTelegramMessageParams{
 		TelegramMessageID: 90002,
-		TelegramChatID:    12345,
+		TelegramChatID:    chatID,
 		ChatType:          "private",
 		MessageText:       &text2,
 		MessageType:       "text",
@@ -158,15 +166,14 @@ func TestTelegramMessage_UpsertEdit(t *testing.T) {
 
 	repo := repository.NewTelegramMessageRepository(database.Queries)
 
-	cleanupTelegramMessages(t, database.Queries)
-	t.Cleanup(func() { cleanupTelegramMessages(t, database.Queries) })
+	chatID := telegramTestChat(t, repo)
 
 	sentAt := accelerated.GetCurrentTime().Truncate(time.Microsecond)
 	text := "Original"
 
 	_, err = repo.UpsertMessage(ctx, repository.UpsertTelegramMessageParams{
 		TelegramMessageID: 90003,
-		TelegramChatID:    12345,
+		TelegramChatID:    chatID,
 		ChatType:          "private",
 		MessageText:       &text,
 		MessageType:       "text",
@@ -180,7 +187,7 @@ func TestTelegramMessage_UpsertEdit(t *testing.T) {
 	editedAt := accelerated.GetCurrentTime().Add(time.Minute).Truncate(time.Microsecond)
 	msg, err := repo.UpsertMessage(ctx, repository.UpsertTelegramMessageParams{
 		TelegramMessageID: 90003,
-		TelegramChatID:    12345,
+		TelegramChatID:    chatID,
 		ChatType:          "private",
 		MessageText:       &editedText,
 		MessageType:       "text",
@@ -215,15 +222,14 @@ func TestTelegramMessage_SoftDelete(t *testing.T) {
 
 	repo := repository.NewTelegramMessageRepository(database.Queries)
 
-	cleanupTelegramMessages(t, database.Queries)
-	t.Cleanup(func() { cleanupTelegramMessages(t, database.Queries) })
+	chatID := telegramTestChat(t, repo)
 
 	sentAt := accelerated.GetCurrentTime().Truncate(time.Microsecond)
 	text := "To be deleted"
 
 	_, err = repo.UpsertMessage(ctx, repository.UpsertTelegramMessageParams{
 		TelegramMessageID: 90004,
-		TelegramChatID:    12345,
+		TelegramChatID:    chatID,
 		ChatType:          "private",
 		MessageText:       &text,
 		MessageType:       "text",
@@ -237,7 +243,7 @@ func TestTelegramMessage_SoftDelete(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify deleted — GetMessage filters deleted_at IS NULL, so should return not found
-	_, err = repo.GetMessage(ctx, 12345, 90004)
+	_, err = repo.GetMessage(ctx, chatID, 90004)
 	assert.Error(t, err)
 }
 
@@ -263,15 +269,19 @@ func TestTelegramMessage_SoftDeleteChannel(t *testing.T) {
 
 	repo := repository.NewTelegramMessageRepository(database.Queries)
 
-	cleanupTelegramMessages(t, database.Queries)
-	t.Cleanup(func() { cleanupTelegramMessages(t, database.Queries) })
+	// Channels use a negative chat ID. telegramTestChat registers cleanup on the
+	// positive base range; this test stores under the negated id, so register a
+	// matching negative-range cleanup too.
+	base := telegramTestChat(t, repo)
+	chatID := -base
+	t.Cleanup(func() { _ = repo.HardDeleteByChatIDRange(context.Background(), chatID, chatID) })
 
 	sentAt := accelerated.GetCurrentTime().Truncate(time.Microsecond)
 	text := "Channel message"
 
 	_, err = repo.UpsertMessage(ctx, repository.UpsertTelegramMessageParams{
 		TelegramMessageID: 90005,
-		TelegramChatID:    -100555,
+		TelegramChatID:    chatID,
 		ChatType:          "group",
 		MessageText:       &text,
 		MessageType:       "text",
@@ -281,10 +291,10 @@ func TestTelegramMessage_SoftDeleteChannel(t *testing.T) {
 	require.NoError(t, err)
 
 	// Soft delete with chat_id filter
-	err = repo.SoftDeleteChannelMessages(ctx, -100555, []int32{90005})
+	err = repo.SoftDeleteChannelMessages(ctx, chatID, []int32{90005})
 	require.NoError(t, err)
 
-	_, err = repo.GetMessage(ctx, -100555, 90005)
+	_, err = repo.GetMessage(ctx, chatID, 90005)
 	assert.Error(t, err)
 }
 
@@ -310,15 +320,14 @@ func TestTelegramMessage_ListUnprocessed(t *testing.T) {
 
 	repo := repository.NewTelegramMessageRepository(database.Queries)
 
-	cleanupTelegramMessages(t, database.Queries)
-	t.Cleanup(func() { cleanupTelegramMessages(t, database.Queries) })
+	chatID := telegramTestChat(t, repo)
 
 	sentAt := accelerated.GetCurrentTime().Truncate(time.Microsecond)
 	text := "Unprocessed msg"
 
 	_, err = repo.UpsertMessage(ctx, repository.UpsertTelegramMessageParams{
 		TelegramMessageID: 90001,
-		TelegramChatID:    77777,
+		TelegramChatID:    chatID,
 		ChatType:          "private",
 		MessageText:       &text,
 		MessageType:       "text",
@@ -327,7 +336,8 @@ func TestTelegramMessage_ListUnprocessed(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	msgs, err := repo.ListUnprocessedByChat(ctx, 77777)
+	// Scoped to this test's own unique chat, so >= 1 holds deterministically.
+	msgs, err := repo.ListUnprocessedByChat(ctx, chatID)
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, len(msgs), 1)
 }

--- a/backend/tests/telegram_message_test.go
+++ b/backend/tests/telegram_message_test.go
@@ -50,7 +50,9 @@ func TestTelegramMessage_UpsertAndGet(t *testing.T) {
 
 	database, err := db.NewDatabase(ctx, cfg.Database)
 	require.NoError(t, err)
-	defer database.Close()
+	// Close via t.Cleanup (LIFO) so it runs AFTER telegramTestChat's row-delete
+	// cleanup — a defer would close the pool first and the deletes would no-op.
+	t.Cleanup(func() { database.Close() })
 
 	repo := repository.NewTelegramMessageRepository(database.Queries)
 
@@ -110,7 +112,9 @@ func TestTelegramMessage_UpsertIdempotent(t *testing.T) {
 
 	database, err := db.NewDatabase(ctx, cfg.Database)
 	require.NoError(t, err)
-	defer database.Close()
+	// Close via t.Cleanup (LIFO) so it runs AFTER telegramTestChat's row-delete
+	// cleanup — a defer would close the pool first and the deletes would no-op.
+	t.Cleanup(func() { database.Close() })
 
 	repo := repository.NewTelegramMessageRepository(database.Queries)
 
@@ -165,7 +169,9 @@ func TestTelegramMessage_UpsertEdit(t *testing.T) {
 
 	database, err := db.NewDatabase(ctx, cfg.Database)
 	require.NoError(t, err)
-	defer database.Close()
+	// Close via t.Cleanup (LIFO) so it runs AFTER telegramTestChat's row-delete
+	// cleanup — a defer would close the pool first and the deletes would no-op.
+	t.Cleanup(func() { database.Close() })
 
 	repo := repository.NewTelegramMessageRepository(database.Queries)
 
@@ -222,7 +228,9 @@ func TestTelegramMessage_SoftDelete(t *testing.T) {
 
 	database, err := db.NewDatabase(ctx, cfg.Database)
 	require.NoError(t, err)
-	defer database.Close()
+	// Close via t.Cleanup (LIFO) so it runs AFTER telegramTestChat's row-delete
+	// cleanup — a defer would close the pool first and the deletes would no-op.
+	t.Cleanup(func() { database.Close() })
 
 	repo := repository.NewTelegramMessageRepository(database.Queries)
 
@@ -274,7 +282,9 @@ func TestTelegramMessage_SoftDeleteChannel(t *testing.T) {
 
 	database, err := db.NewDatabase(ctx, cfg.Database)
 	require.NoError(t, err)
-	defer database.Close()
+	// Close via t.Cleanup (LIFO) so it runs AFTER telegramTestChat's row-delete
+	// cleanup — a defer would close the pool first and the deletes would no-op.
+	t.Cleanup(func() { database.Close() })
 
 	repo := repository.NewTelegramMessageRepository(database.Queries)
 
@@ -326,7 +336,9 @@ func TestTelegramMessage_ListUnprocessed(t *testing.T) {
 
 	database, err := db.NewDatabase(ctx, cfg.Database)
 	require.NoError(t, err)
-	defer database.Close()
+	// Close via t.Cleanup (LIFO) so it runs AFTER telegramTestChat's row-delete
+	// cleanup — a defer would close the pool first and the deletes would no-op.
+	t.Cleanup(func() { database.Close() })
 
 	repo := repository.NewTelegramMessageRepository(database.Queries)
 

--- a/backend/tests/telegram_sparse_entity_enrichment_test.go
+++ b/backend/tests/telegram_sparse_entity_enrichment_test.go
@@ -135,6 +135,7 @@ func makePrivateMessage(peerUserID int64, msgID int, sentAt time.Time, text stri
 }
 
 func TestSparseEntityEnrichment_HandleNewMessage_FillsFromHistory(t *testing.T) {
+	t.Parallel()
 	env := setupSparseEnrichTest(t)
 	ctx := context.Background()
 	_, ns := migrationGenerator(t)
@@ -175,6 +176,7 @@ func TestSparseEntityEnrichment_HandleNewMessage_FillsFromHistory(t *testing.T) 
 }
 
 func TestSparseEntityEnrichment_HandleNewMessage_NoHistoryStaysSparse(t *testing.T) {
+	t.Parallel()
 	env := setupSparseEnrichTest(t)
 	ctx := context.Background()
 	_, ns := migrationGenerator(t)
@@ -196,6 +198,7 @@ func TestSparseEntityEnrichment_HandleNewMessage_NoHistoryStaysSparse(t *testing
 }
 
 func TestSparseEntityEnrichment_HandleEditMessage_FillsFromHistory(t *testing.T) {
+	t.Parallel()
 	env := setupSparseEnrichTest(t)
 	ctx := context.Background()
 	_, ns := migrationGenerator(t)
@@ -234,6 +237,7 @@ func TestSparseEntityEnrichment_HandleEditMessage_FillsFromHistory(t *testing.T)
 }
 
 func TestSparseEntityEnrichment_AuthoritativeEmptyRespectsRemoval(t *testing.T) {
+	t.Parallel()
 	env := setupSparseEnrichTest(t)
 	ctx := context.Background()
 	_, ns := migrationGenerator(t)
@@ -274,6 +278,7 @@ func TestSparseEntityEnrichment_AuthoritativeEmptyRespectsRemoval(t *testing.T) 
 }
 
 func TestSparseEntityEnrichment_StraightRenameCurrentNonBlankWins(t *testing.T) {
+	t.Parallel()
 	env := setupSparseEnrichTest(t)
 	ctx := context.Background()
 	_, ns := migrationGenerator(t)
@@ -317,6 +322,7 @@ func TestSparseEntityEnrichment_StraightRenameCurrentNonBlankWins(t *testing.T) 
 }
 
 func TestSparseEntityEnrichment_UntrackedGroupSkipsBeforeEnrichment(t *testing.T) {
+	t.Parallel()
 	env := setupSparseEnrichTest(t)
 	ctx := context.Background()
 	_, ns := migrationGenerator(t)
@@ -367,6 +373,7 @@ func TestSparseEntityEnrichment_UntrackedGroupSkipsBeforeEnrichment(t *testing.T
 // GetPeerEntityByUserID prefers the most recent authoritative row over any
 // older non-blank value.
 func TestSparseEntityEnrichment_AuthoritativeRemovalSticksAcrossSparseUpdates(t *testing.T) {
+	t.Parallel()
 	env := setupSparseEnrichTest(t)
 	ctx := context.Background()
 	_, ns := migrationGenerator(t)
@@ -416,6 +423,7 @@ func TestSparseEntityEnrichment_AuthoritativeRemovalSticksAcrossSparseUpdates(t 
 // data, the enriched username/first_name flows through MatchPeer →
 // UpdateDiscoveryCandidatesForPeer and lands on the external_contact row.
 func TestSparseEntityEnrichment_EnrichedFieldsFlowToDiscoveryCandidate(t *testing.T) {
+	t.Parallel()
 	env := setupSparseEnrichTest(t)
 	ctx := context.Background()
 	_, ns := migrationGenerator(t)

--- a/backend/tests/template_isolation_integration_test.go
+++ b/backend/tests/template_isolation_integration_test.go
@@ -28,6 +28,7 @@ func TestTemplateIsolation(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	if os.Getenv("DATABASE_URL") == "" {
 		t.Skip("DATABASE_URL not set, skipping integration test")
 	}

--- a/backend/tests/testmain_integration_test.go
+++ b/backend/tests/testmain_integration_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/gin-gonic/gin"
+
 	"personal-crm/backend/internal/testdb"
 )
 
@@ -19,5 +21,9 @@ import (
 // the no-tag unit build it is excluded, this package has no TestMain, and the
 // DB-backed tests self-skip on unset DATABASE_URL / testing.Short().
 func TestMain(m *testing.M) {
+	// Set gin's mode once, before any test runs, so DB-backed handler tests
+	// (link_contact_curated_status, telegram_import_suggestion) can run under
+	// t.Parallel() without racing on gin's package-global mode under -race.
+	gin.SetMode(gin.TestMode)
 	os.Exit(testdb.SetupPackage(m, testdb.WithMigrationsPath(getMigrationsPath())))
 }


### PR DESCRIPTION
PR2 of the test-parallelization effort (#413, Component 1): the within-run `t.Parallel()` flip of the `backend/tests` integration package, plus the resource tune and the needs-scoping fixture work that precedes the flip. Test-only except `config.go` (the `TestConfig()` constructor) and `Makefile`.

## What changed (4 logical commits + 2 Codex-review rounds)

1. **Tune (lands first, behaviorally inert while serial):** `TestConfig()` `MaxConns` 15→8, `MinConns` 2→1, `River.WorkerConcurrency` 10→4 (keeps `Validate()`'s `MaxConns >= WorkerConcurrency+3`); the same `MaxConns=8`/`MinConns=1` on the 5 inline `DatabaseConfig` literals in the parallelizable files; `-parallel 4 -p 4` on `test-integration{,-fast,-slow}`. Production `Load()` defaults are unchanged. This bounds the concurrent connection envelope (~92 conns worst-case) under Postgres `max_connections=100` on both dev and CI.
2. **Scope:** 15 needs-scoping fixtures given per-test-unique identifiers (`syntheticNS` / `migrationGenerator` namespace, `uuid` suffix, or per-test chat/account IDs); DB-wide count/ordering/membership assertions converted to scoped, delta, or high-limit forms. `gin.SetMode(gin.TestMode)` hoisted into `TestMain` so the two DB-backed handler tests flip race-free. No raw SQL — all scoping uses existing toolkit helpers.
3. **Flip:** `t.Parallel()` added to ~232 funcs (27 scoped-safe files, 14 needs-scoping files minus the `gchat` `NoNullAccountRow` invariant guard, and the mixed files' parallel funcs: 5 `TestEventRepository_*`, 19 gchat-provider, identity's 3, integration's 5). The 30 river-heavy + 4 inherently-serial files and the mixed files' river/serial funcs stay serial.
4. **Codex-review rounds:** closed the remaining shared-DB scoping gaps the static audit missed (per-test source_id prefix in `telegram_discovery_upsert`, two funcs reverted to serial for DB-wide global operations, several limit-window membership checks widened, and a real page-2 search-term bug).

## Honest measured result (Amdahl-bounded)

This is a measure-and-report change, not a fixed-multiplier one. The spec's headline "~2-4×" applies to the **parallelizable subset**, not the whole package.

| Metric | Before (`main`) | After (flip, tuned) | Ratio |
|--------|-----------------|---------------------|-------|
| `go test ./tests/ -parallel 4` | ~20s (17.0s internal) | ~17s (16.0s internal) | ~1.18× |
| `make test-integration-fast` | ~29s | ~26s | ~1.12× |

The modest whole-package ratio is the **serial River floor**: Go runs the serial cohort (the ~23 non-long-gated river-heavy files + 4 inherently-serial + the mixed files' serial funcs) to completion *before* the parallel cohort, so that floor is paid in full first. The fast-suite long pole is now `tests/api` (~24-27s internal), which runs concurrently above `tests` and is **deferred to #429**. Speeding up the river-heavy core needs per-test River-client isolation, **deferred to #428**. Both deferrals are intentional and out of scope here.

## Validation

Flake-free under the full battery on the flipped set:
- `-race -parallel 4` — PASS (no data races; covers the `gin.SetMode` hoist + shared helpers)
- `-parallel 4 -count=10` — PASS
- `-shuffle=on -parallel 4` — PASS
- combined `-race -shuffle=on -parallel 4 -count=5` — PASS

Full `make test-integration-fast` + `make test-integration` (LONG_TESTS) + `make test-unit` + lint all green. Connection peak stays well under the ~97-conn usable ceiling.

### Pre-existing `-count` fragility (not introduced by this PR)

Under `-count>=2`, the 5 `TestIntegration_CreateWorker_*` funcs in `followup_create_worker_integration_test.go` (a river-heavy SERIAL file this PR does not touch) fail on a `unique_external_task_id` collision — they use fixed `external_task_id` literals (`real-123`, etc.) that collide on the 2nd iteration. This reproduces identically in isolation and on `main` (the file is byte-identical to `main`), so it is a pre-existing limitation of the serial river suite, orthogonal to the flip. The `-count` gates above `-skip` it for that reason; the normal `-count=1` fast + LONG_TESTS suites run it and pass. It belongs with the River parallelization effort (#428).

## Known non-blockers (from the review verdict — intentionally not fixed to preserve the reviewed SHA)

- **[P2]** `gmail` `TestReconcileEmail_PerAccountShape_NoNullAccountRow` is parallelized while its `gchat` twin is serial — an asymmetry. Safe today (no parallel-eligible test creates the offending `(email, '')` row; river-heavy email creators are serial-gated), but the safety rests on a non-local invariant.
- **[P2]** `HidesUnresolvedTelegramByDefault` (now correctly serial) still carries the delta-baseline scaffolding from the scope commit; it's dead weight under serial execution and one inline comment still references `t.Parallel()`.
- **[P3]** Minor audit-doc func-count drift (table integers lag a few files).
- **[P3]** The plan's "audit `config_test.go` for numeric assertions" step was a verified no-op (the relevant assertions read from `Load()`, not `TestConfig()`), so it produced no diff — correct outcome, but invisible.

## Links

- Tracking: #413 (Component 1)
- Deferred: #428 (river-heavy core parallelization), #429 (`tests/api` / `tests/unit` audit + flip)
- Plan: `.ai/log/plan/2026-06-08-test-parallelization-component1-flip.md`
- Audit (checked in): `.ai/spec/2026-06-08-test-parallelization-audit.md`

### Codex-bot CI finding — FIXED in 55163ab

- **[P2 → FIXED] `telegramTestChat` cleanup ran against a closed pool.** The Codex bot's inline comment on this PR (`backend/tests/telegram_message_test.go`) flagged that callers registered `defer database.Close()` before the per-test row cleanups (registered via `t.Cleanup`). Since Go runs body `defer`s before `t.Cleanup`, the pool was closed when the row deletes fired → they silently no-opped and telegram rows leaked until clone teardown. Fixed at all 14 affected call sites (6 `telegramTestChat` callers in `telegram_message_test.go`, 7 `chatConfigIDs` callers in `telegram_chat_config_test.go`, the 1 inline-`t.Cleanup` discovery batch func in `telegram_discovery_upsert_test.go`) by registering the pool close via `t.Cleanup(func(){ database.Close() })` before the row-cleanup registration, so LIFO runs Close last — after the deletes, pool still open. The `setupDiscoveryUpsertTest` path already closed inside its cleanup closure (delete then close) and is unchanged. Verified with a leak probe that fails under the old `defer` ordering and passes under the fix; affected tests green under `-race -count=5 -shuffle=on -parallel 4`; local Codex re-review PASS (P0=0 P1=0 P2=0 P3=0).
