### PR TITLE
perf: speed up test suites

### DIFF
--- a/.github/workflows/backend-slow-tests.yml
+++ b/.github/workflows/backend-slow-tests.yml
@@ -36,6 +36,12 @@ jobs:
           go-version: '1.23'
           cache-dependency-path: backend/go.sum
 
+      # The integration target runs via make, which defaults GOCACHE to a
+      # workspace-local dir; pin it to setup-go's warm cache so the build is
+      # incremental. See .github/workflows/ci.yml for the full rationale.
+      - name: Pin GOCACHE to setup-go cache
+        run: echo "GOCACHE=$(go env GOCACHE)" >> "$GITHUB_ENV"
+
       - name: Download Go modules
         working-directory: backend
         run: go mod download

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,14 @@ jobs:
           go-version: '1.23'
           cache-dependency-path: backend/go.sum
 
+      # The Makefile defaults GOCACHE to a workspace-local dir via `?=`, which
+      # would bypass setup-go's restored ~/.cache/go-build for every make-driven
+      # Go build. Pin GOCACHE to setup-go's default so make-invoked builds reuse
+      # the warm cache. `go env GOCACHE` returns the default here because GOCACHE
+      # is not set in the shell env (the Makefile only exports it inside make).
+      - name: Pin GOCACHE to setup-go cache
+        run: echo "GOCACHE=$(go env GOCACHE)" >> "$GITHUB_ENV"
+
       - name: Download Go modules
         working-directory: backend
         run: go mod download
@@ -120,13 +128,19 @@ jobs:
           go-version: '1.23'
           cache-dependency-path: backend/go.sum
 
+      # See backend-quality: pin GOCACHE so make-invoked builds (the
+      # integration step calls `make test-integration-fast`) reuse setup-go's
+      # warm cache instead of the Makefile's workspace-local default.
+      - name: Pin GOCACHE to setup-go cache
+        run: echo "GOCACHE=$(go env GOCACHE)" >> "$GITHUB_ENV"
+
       - name: Download Go modules
         working-directory: backend
         run: go mod download
 
       - name: Run unit tests
         working-directory: backend
-        run: go test -short -v ./...
+        run: go test -short ./...
 
       - name: Wait for PostgreSQL
         run: |
@@ -138,6 +152,7 @@ jobs:
           NODE_ENV: test
           SESSION_SECRET: test-session-secret-for-ci
           API_KEY: test-api-key-for-ci
+          GOTEST_VERBOSE: ""
         run: make test-integration-fast
 
   frontend-tests:
@@ -349,6 +364,12 @@ jobs:
         with:
           go-version: '1.23'
           cache-dependency-path: backend/go.sum
+
+      # The Playwright webServer launches the backend via `go run`; pin GOCACHE
+      # to setup-go's warm cache for consistency with the backend jobs (and to
+      # cover any future make-driven build added here).
+      - name: Pin GOCACHE to setup-go cache
+        run: echo "GOCACHE=$(go env GOCACHE)" >> "$GITHUB_ENV"
 
       - name: Download Go modules
         working-directory: backend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,27 +26,11 @@ jobs:
       - name: Check path-filters parity
         run: bash scripts/ci/path-filters-parity-guard.sh
 
-  backend-tests:
-    name: Backend Tests
+  backend-quality:
+    name: Backend Quality
     runs-on: ubuntu-latest
     needs: changes
     if: ${{ needs.changes.outputs.backend == 'true' }}
-
-    services:
-      postgres:
-        image: pgvector/pgvector:pg16
-        env:
-          POSTGRES_DB: personal_crm_test
-          POSTGRES_USER: crm_user_test
-          POSTGRES_PASSWORD: test_password
-          POSTGRES_HOST_AUTH_METHOD: trust
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
 
     steps:
       - name: Checkout code
@@ -87,10 +71,6 @@ jobs:
       - name: Check ingest-registry descriptor invariant
         run: ./scripts/check-ingest-registry.sh
 
-      - name: Run unit tests
-        working-directory: backend
-        run: go test -short -v ./...
-
       - name: Cross-compile for ARM64
         working-directory: backend
         env:
@@ -107,6 +87,46 @@ jobs:
         # compile error in its single-file main.go (e.g. a new --seed subcommand
         # type not defined there) would otherwise ship uncaught. This guards it.
         run: go build -o bin/crm-admin-arm64 cmd/crm-admin/main.go
+
+  backend-tests:
+    name: Backend Tests
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.backend == 'true' }}
+
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_DB: personal_crm_test
+          POSTGRES_USER: crm_user_test
+          POSTGRES_PASSWORD: test_password
+          POSTGRES_HOST_AUTH_METHOD: trust
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+          cache-dependency-path: backend/go.sum
+
+      - name: Download Go modules
+        working-directory: backend
+        run: go mod download
+
+      - name: Run unit tests
+        working-directory: backend
+        run: go test -short -v ./...
 
       - name: Wait for PostgreSQL
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,7 @@ backend/bin/
 backend/crm-api
 backend/crm-admin
 backend/main
+backend/*.test
 backend/*.exe
 backend/*.exe~
 backend/*.dll

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ GOCACHE ?= $(REPO_ROOT)/.gocache
 export GOCACHE
 
 TEST_DATABASE_URL ?= postgres://crm_user:crm_password@localhost:5432/personal_crm_test?sslmode=disable
+E2E_DATABASE_NAME ?= personal_crm_test
+E2E_DATABASE_URL ?= postgres://crm_user:crm_password@localhost:5432/$(E2E_DATABASE_NAME)?sslmode=disable
+E2E_FRONTEND_PORT ?= 3000
+E2E_BACKEND_PORT ?= 8080
 BACKEND_SLOW_TESTS_REGEX := TestSyncWorker_LoadNoDuplicateConcurrentSyncs|TestPeriodicTick_FiresOnStart|TestSyncWorker_RescueOnCrash|TestSynthetic|TestTestdb
 
 # Default target
@@ -217,20 +221,18 @@ dev-native: postgres-native
 
 test-e2e: e2e-db
 	@echo "Cleaning up any conflicting processes..."
-	@-pkill -f "playwright" 2>/dev/null || true
-	@-pkill -f "next.*dev" 2>/dev/null || true
-	@-lsof -ti:3000 | xargs -r kill -9 2>/dev/null || true
-	@-lsof -ti:8080 | xargs -r kill -9 2>/dev/null || true
+	@-lsof -ti:$(E2E_FRONTEND_PORT) | xargs -r kill -9 2>/dev/null || true
+	@-lsof -ti:$(E2E_BACKEND_PORT) | xargs -r kill -9 2>/dev/null || true
 	@sleep 1
 	@echo "Running Playwright E2E tests..."
 	@ENV_FILE=$${ENV_FILE:-$(REPO_ROOT)/.env.example.testing}; \
 	if [ ! -f "$$ENV_FILE" ]; then echo "❌ ENV file not found: $$ENV_FILE"; exit 1; fi; \
 	set -a; . "$$ENV_FILE"; set +a; \
-	export DATABASE_URL="postgres://crm_user:crm_password@localhost:5432/personal_crm_test?sslmode=disable"; \
+	export DATABASE_URL="$(E2E_DATABASE_URL)"; \
 	if [ -f "$(REPO_ROOT)/frontend/.env.local" ]; then mv "$(REPO_ROOT)/frontend/.env.local" "$(REPO_ROOT)/frontend/.env.local.bak"; fi; \
 	echo "NEXT_PUBLIC_API_KEY=$$API_KEY" > "$(REPO_ROOT)/frontend/.env.local"; \
-	echo "NEXT_PUBLIC_API_URL=http://localhost:8080" >> "$(REPO_ROOT)/frontend/.env.local"; \
-	cd "$(REPO_ROOT)/frontend" && DATABASE_URL="$$DATABASE_URL" API_KEY=$$API_KEY NEXT_PUBLIC_API_KEY=$$API_KEY NEXT_PUBLIC_API_URL=http://localhost:8080 ./node_modules/.bin/playwright test --project=chromium; \
+	echo "NEXT_PUBLIC_API_URL=http://localhost:$(E2E_BACKEND_PORT)" >> "$(REPO_ROOT)/frontend/.env.local"; \
+	cd "$(REPO_ROOT)/frontend" && DATABASE_URL="$$DATABASE_URL" API_KEY=$$API_KEY NEXT_PUBLIC_API_KEY=$$API_KEY NEXT_PUBLIC_API_URL=http://localhost:$(E2E_BACKEND_PORT) E2E_FRONTEND_PORT="$(E2E_FRONTEND_PORT)" E2E_BACKEND_PORT="$(E2E_BACKEND_PORT)" ./node_modules/.bin/playwright test --project=chromium; \
 	EXIT_CODE=$$?; \
 	rm -f "$(REPO_ROOT)/frontend/.env.local"; \
 	if [ -f "$(REPO_ROOT)/frontend/.env.local.bak" ]; then mv "$(REPO_ROOT)/frontend/.env.local.bak" "$(REPO_ROOT)/frontend/.env.local"; fi; \
@@ -238,22 +240,20 @@ test-e2e: e2e-db
 
 test-e2e-local: e2e-db
 	@echo "Cleaning up any conflicting processes..."
-	@-pkill -f "playwright" 2>/dev/null || true
-	@-pkill -f "next.*dev" 2>/dev/null || true
-	@-lsof -ti:3000 | xargs -r kill -9 2>/dev/null || true
-	@-lsof -ti:8080 | xargs -r kill -9 2>/dev/null || true
+	@-lsof -ti:$(E2E_FRONTEND_PORT) | xargs -r kill -9 2>/dev/null || true
+	@-lsof -ti:$(E2E_BACKEND_PORT) | xargs -r kill -9 2>/dev/null || true
 	@sleep 1
 	@echo "Running Playwright E2E tests (local selection)..."
 	@ENV_FILE=$${ENV_FILE:-$(REPO_ROOT)/.env.example.testing}; \
 	if [ ! -f "$$ENV_FILE" ]; then echo "❌ ENV file not found: $$ENV_FILE"; exit 1; fi; \
 	set -a; . "$$ENV_FILE"; set +a; \
-	export DATABASE_URL="postgres://crm_user:crm_password@localhost:5432/personal_crm_test?sslmode=disable"; \
+	export DATABASE_URL="$(E2E_DATABASE_URL)"; \
 	if [ -f "$(REPO_ROOT)/frontend/.env.local" ]; then mv "$(REPO_ROOT)/frontend/.env.local" "$(REPO_ROOT)/frontend/.env.local.bak"; fi; \
 	echo "NEXT_PUBLIC_API_KEY=$$API_KEY" > "$(REPO_ROOT)/frontend/.env.local"; \
-	echo "NEXT_PUBLIC_API_URL=http://localhost:8080" >> "$(REPO_ROOT)/frontend/.env.local"; \
+	echo "NEXT_PUBLIC_API_URL=http://localhost:$(E2E_BACKEND_PORT)" >> "$(REPO_ROOT)/frontend/.env.local"; \
 	GREP_ARGS=""; \
 	if [ -n "$$PLAYWRIGHT_GREP" ]; then GREP_ARGS="--grep $$PLAYWRIGHT_GREP"; fi; \
-	cd "$(REPO_ROOT)/frontend" && DATABASE_URL="$$DATABASE_URL" API_KEY=$$API_KEY NEXT_PUBLIC_API_KEY=$$API_KEY NEXT_PUBLIC_API_URL=http://localhost:8080 ./node_modules/.bin/playwright test --project=chromium $$GREP_ARGS; \
+	cd "$(REPO_ROOT)/frontend" && DATABASE_URL="$$DATABASE_URL" API_KEY=$$API_KEY NEXT_PUBLIC_API_KEY=$$API_KEY NEXT_PUBLIC_API_URL=http://localhost:$(E2E_BACKEND_PORT) E2E_FRONTEND_PORT="$(E2E_FRONTEND_PORT)" E2E_BACKEND_PORT="$(E2E_BACKEND_PORT)" ./node_modules/.bin/playwright test --project=chromium $$GREP_ARGS; \
 	EXIT_CODE=$$?; \
 	rm -f "$(REPO_ROOT)/frontend/.env.local"; \
 	if [ -f "$(REPO_ROOT)/frontend/.env.local.bak" ]; then mv "$(REPO_ROOT)/frontend/.env.local.bak" "$(REPO_ROOT)/frontend/.env.local"; fi; \
@@ -264,20 +264,22 @@ test-e2e-diff: e2e-db
 
 e2e-db:
 	@bash "$(REPO_ROOT)/scripts/ensure-postgres-for-tests.sh"
-	@echo "Setting up isolated E2E test database..."
+	@echo "Setting up isolated E2E test database ($(E2E_DATABASE_NAME))..."
+	@case "$(E2E_DATABASE_NAME)" in (*[!A-Za-z0-9_]*|'') echo "Invalid E2E_DATABASE_NAME: $(E2E_DATABASE_NAME)" >&2; exit 1;; esac
+	@case "$(E2E_DATABASE_NAME)" in (personal_crm_test|personal_crm_test_[A-Za-z0-9_]*) ;; (*) echo "Invalid E2E_DATABASE_NAME: $(E2E_DATABASE_NAME) (must be personal_crm_test or personal_crm_test_<suffix>)" >&2; exit 1;; esac
 	@if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then \
-		docker exec crm-postgres psql -U crm_user -d postgres -c "DROP DATABASE IF EXISTS personal_crm_test;" 2>/dev/null || true; \
-		docker exec crm-postgres psql -U crm_user -d postgres -c "CREATE DATABASE personal_crm_test;" 2>/dev/null; \
-		docker exec crm-postgres psql -U crm_user -d personal_crm_test -c "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\"; CREATE EXTENSION IF NOT EXISTS vector;" 2>/dev/null; \
+		docker exec crm-postgres psql -U crm_user -d postgres -c "DROP DATABASE IF EXISTS \"$(E2E_DATABASE_NAME)\";" 2>/dev/null || true; \
+		docker exec crm-postgres psql -U crm_user -d postgres -c "CREATE DATABASE \"$(E2E_DATABASE_NAME)\";" 2>/dev/null; \
+		docker exec crm-postgres psql -U crm_user -d "$(E2E_DATABASE_NAME)" -c "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\"; CREATE EXTENSION IF NOT EXISTS vector;" 2>/dev/null; \
 	else \
 		if ! sudo -u postgres psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='crm_user';" | grep -q 1; then \
 			echo "crm_user role missing; run scripts/start-postgres-native.sh first" >&2; \
 			exit 1; \
 		fi; \
-		sudo -u postgres psql -c "DROP DATABASE IF EXISTS personal_crm_test;" 2>/dev/null || true; \
-		sudo -u postgres psql -c "CREATE DATABASE personal_crm_test OWNER crm_user;" 2>/dev/null; \
-		sudo -u postgres psql -d personal_crm_test -c "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\"; CREATE EXTENSION IF NOT EXISTS vector;" 2>/dev/null; \
-		sudo -u postgres psql -d personal_crm_test -c "GRANT ALL ON SCHEMA public TO crm_user;" 2>/dev/null; \
+		sudo -u postgres psql -c "DROP DATABASE IF EXISTS \"$(E2E_DATABASE_NAME)\";" 2>/dev/null || true; \
+		sudo -u postgres psql -c "CREATE DATABASE \"$(E2E_DATABASE_NAME)\" OWNER crm_user;" 2>/dev/null; \
+		sudo -u postgres psql -d "$(E2E_DATABASE_NAME)" -c "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\"; CREATE EXTENSION IF NOT EXISTS vector;" 2>/dev/null; \
+		sudo -u postgres psql -d "$(E2E_DATABASE_NAME)" -c "GRANT ALL ON SCHEMA public TO crm_user;" 2>/dev/null; \
 	fi
 	@echo "✓ E2E test database ready"
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ E2E_FRONTEND_PORT ?= 3000
 E2E_BACKEND_PORT ?= 8080
 BACKEND_SLOW_TESTS_REGEX := TestSyncWorker_LoadNoDuplicateConcurrentSyncs|TestPeriodicTick_FiresOnStart|TestSyncWorker_RescueOnCrash|TestSynthetic|TestTestdb
 
+# Verbosity for `go test`. Defaults to -v for local readability; CI overrides
+# to empty (GOTEST_VERBOSE=) to cut ~23k log lines. Failures still print.
+GOTEST_VERBOSE ?= -v
+
 # Default target
 # NOTE: When adding or removing make targets, update this help section to match
 help:
@@ -328,19 +332,19 @@ test: test-unit test-integration test-frontend
 
 test-unit:
 	@echo "Running backend unit tests..."
-	@cd backend && go test ./tests/... ./internal/matching/... ./internal/events/... ./internal/service/... ./internal/contacttask/... -v -short
+	@cd backend && go test ./tests/... ./internal/matching/... ./internal/events/... ./internal/service/... ./internal/contacttask/... $(GOTEST_VERBOSE) -short
 
 test-integration-fast:
 	@echo "Running backend integration tests (default set)..."
-	@cd backend && DATABASE_URL="$(TEST_DATABASE_URL)" go test -tags integration_testdb -count=1 -parallel 4 -p 4 ./tests/... ./internal/todoist/... ./internal/google/... ./internal/testdb/... -v
+	@cd backend && DATABASE_URL="$(TEST_DATABASE_URL)" go test -tags integration_testdb -count=1 -parallel 4 -p 4 ./tests/... ./internal/todoist/... ./internal/google/... ./internal/testdb/... $(GOTEST_VERBOSE)
 
 test-integration:
 	@echo "Running backend integration tests..."
-	@cd backend && DATABASE_URL="$(TEST_DATABASE_URL)" LONG_TESTS=1 go test -tags integration_testdb -count=1 -parallel 4 -p 4 ./tests/... ./internal/todoist/... ./internal/google/... ./internal/testdb/... -v
+	@cd backend && DATABASE_URL="$(TEST_DATABASE_URL)" LONG_TESTS=1 go test -tags integration_testdb -count=1 -parallel 4 -p 4 ./tests/... ./internal/todoist/... ./internal/google/... ./internal/testdb/... $(GOTEST_VERBOSE)
 
 test-integration-slow:
 	@echo "Running backend slow integration tests..."
-	@cd backend && DATABASE_URL="$(TEST_DATABASE_URL)" LONG_TESTS=1 go test -tags integration_testdb -count=1 -parallel 4 -p 4 ./tests/... ./internal/todoist/... ./internal/google/... ./internal/testdb/... -v -run '$(BACKEND_SLOW_TESTS_REGEX)'
+	@cd backend && DATABASE_URL="$(TEST_DATABASE_URL)" LONG_TESTS=1 go test -tags integration_testdb -count=1 -parallel 4 -p 4 ./tests/... ./internal/todoist/... ./internal/google/... ./internal/testdb/... $(GOTEST_VERBOSE) -run '$(BACKEND_SLOW_TESTS_REGEX)'
 
 # Sweep leaked clone databases (personal_crm_test_clone_*) AND stale
 # per-migration-set template databases (personal_crm_test_template_<hash>).

--- a/backend/tests/address_book_reconcile_integration_test.go
+++ b/backend/tests/address_book_reconcile_integration_test.go
@@ -6,10 +6,13 @@ import (
 	"testing"
 
 	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/service"
 
 	"github.com/google/uuid"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -27,11 +30,10 @@ type abReconcileEnv struct {
 	matchSvc     *service.ImportMatchService
 }
 
-// setupABReconcileEnv wires a real reconcile service with a live event
-// bus + rematch service (a stub email/phone handler makes those method
-// types eligible so the matched-branch auto-propagate publishes
-// contact_methods.added). Each test gets its own ephemeral clone so the live
-// River client can use TestOnly without sharing river_job across tests.
+// setupABReconcileEnv wires a real reconcile service with an enqueue-capable
+// event bus + rematch service. The River client is not started: these tests
+// assert that contact_methods.added enqueues rematch_dispatcher jobs, not that
+// the worker drains them.
 func setupABReconcileEnv(t *testing.T) *abReconcileEnv {
 	t.Helper()
 	if testing.Short() {
@@ -39,21 +41,17 @@ func setupABReconcileEnv(t *testing.T) *abReconcileEnv {
 	}
 
 	ctx := context.Background()
-	database, _ := newIsolatedRiverTestDB(t, ctx)
+	database, _ := newSharedTestDB(t, ctx)
 
 	contactRepo := repository.NewContactRepository(database.Queries)
 	methodRepo := repository.NewContactMethodRepository(database.Queries)
 	externalRepo := repository.NewExternalContactRepository(database.Queries)
 	enrichmentRepo := repository.NewEnrichmentRepository(database.Queries)
 	eventRepo := repository.NewEventRepository(database.Queries)
-	interactionRepo := repository.NewInteractionRepository(database.Queries)
-	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
-
-	contactService := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, contactTaskRepo, nil, nil)
 	rematchSvc := service.NewRematchService()
 	rematchSvc.Register(stubRematchHandler{idType: "email"})
 	rematchSvc.Register(stubRematchHandler{idType: "phone"})
-	bus := setupTestEventBusWithRematch(t, ctx, database, contactService, rematchSvc)
+	bus := setupRematchEnqueueOnlyBus(t, database)
 
 	enrichmentSvc := service.NewEnrichmentService(database, contactRepo, methodRepo, enrichmentRepo, bus, rematchSvc)
 	reconcile := service.NewAddressBookReconcileService(enrichmentSvc, contactRepo, methodRepo, externalRepo)
@@ -69,6 +67,24 @@ func setupABReconcileEnv(t *testing.T) *abReconcileEnv {
 		enrich:       enrichmentSvc,
 		matchSvc:     matchSvc,
 	}
+}
+
+func setupRematchEnqueueOnlyBus(t *testing.T, database *db.Database) *events.Bus {
+	t.Helper()
+
+	workers := river.NewWorkers()
+	river.AddWorker(workers, &deferredRematchWorker{})
+
+	client, err := river.NewClient(riverpgxv5.New(database.Pool), &river.Config{
+		Queues: map[string]river.QueueConfig{
+			river.QueueDefault: {MaxWorkers: 1},
+		},
+		Workers:  workers,
+		TestOnly: true,
+	})
+	require.NoError(t, err)
+
+	return events.NewBus(database.Pool, client, repository.NewEventRepository(database.Queries))
 }
 
 // stubRematchHandler is a type-only rematch handler so EligibleMethods
@@ -578,7 +594,6 @@ func TestABReconcile_IgnoredDupOfMatchedCanonical_Skips(t *testing.T) {
 // --- catchup: mixed set, summary counts + idempotent re-run -------------
 
 func TestABReconcile_Catchup_MixedSet(t *testing.T) {
-	t.Parallel()
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
 

--- a/backend/tests/address_book_reconcile_integration_test.go
+++ b/backend/tests/address_book_reconcile_integration_test.go
@@ -2,11 +2,9 @@ package tests
 
 import (
 	"context"
-	"os"
 	"strings"
 	"testing"
 
-	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/service"
@@ -32,23 +30,16 @@ type abReconcileEnv struct {
 // setupABReconcileEnv wires a real reconcile service with a live event
 // bus + rematch service (a stub email/phone handler makes those method
 // types eligible so the matched-branch auto-propagate publishes
-// contact_methods.added). Migrations are applied by TestMain via the
-// template clone.
+// contact_methods.added). Each test gets its own ephemeral clone so the live
+// River client can use TestOnly without sharing river_job across tests.
 func setupABReconcileEnv(t *testing.T) *abReconcileEnv {
 	t.Helper()
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
-	databaseURL := os.Getenv("DATABASE_URL")
-	if databaseURL == "" {
-		t.Skip("DATABASE_URL not set")
-	}
 
-	cfg := config.TestConfig()
-	cfg.Database.URL = databaseURL
-	database, err := db.NewDatabase(context.Background(), cfg.Database)
-	require.NoError(t, err)
-	t.Cleanup(database.Close)
+	ctx := context.Background()
+	database, _ := newIsolatedRiverTestDB(t, ctx)
 
 	contactRepo := repository.NewContactRepository(database.Queries)
 	methodRepo := repository.NewContactMethodRepository(database.Queries)
@@ -62,7 +53,7 @@ func setupABReconcileEnv(t *testing.T) *abReconcileEnv {
 	rematchSvc := service.NewRematchService()
 	rematchSvc.Register(stubRematchHandler{idType: "email"})
 	rematchSvc.Register(stubRematchHandler{idType: "phone"})
-	bus := setupTestEventBusWithRematch(t, context.Background(), database, contactService, rematchSvc)
+	bus := setupTestEventBusWithRematch(t, ctx, database, contactService, rematchSvc)
 
 	enrichmentSvc := service.NewEnrichmentService(database, contactRepo, methodRepo, enrichmentRepo, bus, rematchSvc)
 	reconcile := service.NewAddressBookReconcileService(enrichmentSvc, contactRepo, methodRepo, externalRepo)
@@ -160,6 +151,7 @@ func contactHasMethod(t *testing.T, ctx context.Context, env *abReconcileEnv, co
 // --- matched -> auto-propagate (+ rematch event) ------------------------
 
 func TestABReconcile_Matched_AutoPropagates(t *testing.T) {
+	t.Parallel()
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
 	email := "matched-" + abSuffix(t) + "@example.com"
@@ -184,6 +176,7 @@ func TestABReconcile_Matched_AutoPropagates(t *testing.T) {
 // --- imported -> suggestion recorded, no method added -------------------
 
 func TestABReconcile_Imported_RecordsSuggestion(t *testing.T) {
+	t.Parallel()
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
 	email := "imported-" + abSuffix(t) + "@example.com"
@@ -210,6 +203,7 @@ func TestABReconcile_Imported_RecordsSuggestion(t *testing.T) {
 // --- ignored -> skip entirely ------------------------------------------
 
 func TestABReconcile_Ignored_Skips(t *testing.T) {
+	t.Parallel()
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
 	email := "ignored-" + abSuffix(t) + "@example.com"
@@ -231,6 +225,7 @@ func TestABReconcile_Ignored_Skips(t *testing.T) {
 // (matched) or record suggestions for a dead contact (imported).
 
 func TestABReconcile_SoftDeletedContact_MatchedSkips(t *testing.T) {
+	t.Parallel()
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
 	email := "softdel-matched-" + abSuffix(t) + "@example.com"
@@ -243,6 +238,7 @@ func TestABReconcile_SoftDeletedContact_MatchedSkips(t *testing.T) {
 }
 
 func TestABReconcile_SoftDeletedContact_ImportedSkips(t *testing.T) {
+	t.Parallel()
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
 	email := "softdel-imported-" + abSuffix(t) + "@example.com"
@@ -266,6 +262,7 @@ func TestABReconcile_SoftDeletedContact_ImportedSkips(t *testing.T) {
 // --- dedup: method already on contact is neither re-added nor suggested -
 
 func TestABReconcile_Dedup_ExistingMethodNotResuggested(t *testing.T) {
+	t.Parallel()
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
 	email := "dedup-" + abSuffix(t) + "@example.com"
@@ -295,6 +292,7 @@ func TestABReconcile_Dedup_ExistingMethodNotResuggested(t *testing.T) {
 // --- phone normalization equivalence ------------------------------------
 
 func TestABReconcile_PhoneNormalization_Equivalence(t *testing.T) {
+	t.Parallel()
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
 	sfx := abSuffix(t)
@@ -337,6 +335,7 @@ func TestABReconcile_PhoneNormalization_Equivalence(t *testing.T) {
 // --- dismissed-method skip ---------------------------------------------
 
 func TestABReconcile_DismissedMethod_NotResuggested(t *testing.T) {
+	t.Parallel()
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
 	email := "dismissed-" + abSuffix(t) + "@example.com"
@@ -364,6 +363,7 @@ func TestABReconcile_DismissedMethod_NotResuggested(t *testing.T) {
 // --- empty-set clears pending_method_suggestions to NULL ----------------
 
 func TestABReconcile_EmptySet_ClearsPendingToNull(t *testing.T) {
+	t.Parallel()
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
 	email := "clear-" + abSuffix(t) + "@example.com"
@@ -406,6 +406,7 @@ func TestABReconcile_EmptySet_ClearsPendingToNull(t *testing.T) {
 // wholesale UpsertExternalContact (which replaces metadata). ------------
 
 func TestABReconcile_ProducerUpsertPreservesSuggestionColumns(t *testing.T) {
+	t.Parallel()
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
 	email := "survive-" + abSuffix(t) + "@example.com"
@@ -448,6 +449,7 @@ func TestABReconcile_ProducerUpsertPreservesSuggestionColumns(t *testing.T) {
 // --- idempotency: second run adds nothing, suggestion stable ------------
 
 func TestABReconcile_Idempotent(t *testing.T) {
+	t.Parallel()
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
 	email := "idem-" + abSuffix(t) + "@example.com"
@@ -524,6 +526,7 @@ func seedDupOfCanonical(
 // --- dup of matched canonical -> auto-propagates to canonical contact ---
 
 func TestABReconcile_DupOfMatchedCanonical_AutoPropagates(t *testing.T) {
+	t.Parallel()
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
 	uniqueEmail := "dupmatched-" + abSuffix(t) + "@example.com"
@@ -538,6 +541,7 @@ func TestABReconcile_DupOfMatchedCanonical_AutoPropagates(t *testing.T) {
 // --- dup (stale matched) of IMPORTED canonical -> suggestion, not auto --
 
 func TestABReconcile_DupOfImportedCanonical_Suggests(t *testing.T) {
+	t.Parallel()
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
 	uniqueEmail := "dupimported-" + abSuffix(t) + "@example.com"
@@ -556,6 +560,7 @@ func TestABReconcile_DupOfImportedCanonical_Suggests(t *testing.T) {
 // --- ignored dup of matched canonical -> skipped entirely ---------------
 
 func TestABReconcile_IgnoredDupOfMatchedCanonical_Skips(t *testing.T) {
+	t.Parallel()
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
 	uniqueEmail := "dupignored-" + abSuffix(t) + "@example.com"
@@ -573,6 +578,7 @@ func TestABReconcile_IgnoredDupOfMatchedCanonical_Skips(t *testing.T) {
 // --- catchup: mixed set, summary counts + idempotent re-run -------------
 
 func TestABReconcile_Catchup_MixedSet(t *testing.T) {
+	t.Parallel()
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
 

--- a/backend/tests/api/gin_test.go
+++ b/backend/tests/api/gin_test.go
@@ -1,0 +1,7 @@
+package api
+
+import "github.com/gin-gonic/gin"
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}

--- a/backend/tests/api/mac_host_auth_test.go
+++ b/backend/tests/api/mac_host_auth_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestMacHost_Auth_WrongAuthOnDaemonRoute(t *testing.T) {
-	t.Parallel()
 
 	env := setupMacHostEnv(t)
 
@@ -26,7 +25,6 @@ func TestMacHost_Auth_WrongAuthOnDaemonRoute(t *testing.T) {
 }
 
 func TestMacHost_Auth_AmbiguousAuth_400(t *testing.T) {
-	t.Parallel()
 
 	env := setupMacHostEnv(t)
 
@@ -49,7 +47,6 @@ func TestMacHost_Auth_AmbiguousAuth_400(t *testing.T) {
 }
 
 func TestMacHost_Auth_AdminRouteHostAuth_401(t *testing.T) {
-	t.Parallel()
 
 	env := setupMacHostEnv(t)
 
@@ -69,7 +66,6 @@ func TestMacHost_Auth_AdminRouteHostAuth_401(t *testing.T) {
 }
 
 func TestMacHost_Auth_IDParamMismatch_403(t *testing.T) {
-	t.Parallel()
 
 	env := setupMacHostEnv(t)
 
@@ -91,7 +87,6 @@ func TestMacHost_Auth_IDParamMismatch_403(t *testing.T) {
 }
 
 func TestMacHost_Auth_MinProtocolVersion_412(t *testing.T) {
-	t.Parallel()
 
 	env := setupMacHostEnv(t)
 

--- a/backend/tests/api/mac_host_auth_test.go
+++ b/backend/tests/api/mac_host_auth_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestMacHost_Auth_WrongAuthOnDaemonRoute(t *testing.T) {
+	t.Parallel()
+
 	env := setupMacHostEnv(t)
 
 	// Daemon route with global API key (no X-Mac-Host-ID) → 401.
@@ -24,6 +26,8 @@ func TestMacHost_Auth_WrongAuthOnDaemonRoute(t *testing.T) {
 }
 
 func TestMacHost_Auth_AmbiguousAuth_400(t *testing.T) {
+	t.Parallel()
+
 	env := setupMacHostEnv(t)
 
 	// Pair a host so we have a valid id/key for the daemon side.
@@ -45,6 +49,8 @@ func TestMacHost_Auth_AmbiguousAuth_400(t *testing.T) {
 }
 
 func TestMacHost_Auth_AdminRouteHostAuth_401(t *testing.T) {
+	t.Parallel()
+
 	env := setupMacHostEnv(t)
 
 	// Pair a host.
@@ -63,6 +69,8 @@ func TestMacHost_Auth_AdminRouteHostAuth_401(t *testing.T) {
 }
 
 func TestMacHost_Auth_IDParamMismatch_403(t *testing.T) {
+	t.Parallel()
+
 	env := setupMacHostEnv(t)
 
 	plain, _, err := env.macService.CreatePairingToken(context.Background())
@@ -83,6 +91,8 @@ func TestMacHost_Auth_IDParamMismatch_403(t *testing.T) {
 }
 
 func TestMacHost_Auth_MinProtocolVersion_412(t *testing.T) {
+	t.Parallel()
+
 	env := setupMacHostEnv(t)
 
 	plain, _, err := env.macService.CreatePairingToken(context.Background())

--- a/backend/tests/api/mac_host_janitor_test.go
+++ b/backend/tests/api/mac_host_janitor_test.go
@@ -5,12 +5,10 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
 	"personal-crm/backend/internal/accelerated"
-	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/scheduler"
@@ -24,23 +22,15 @@ func TestPairingTokenJanitor_DeletesExpired(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
-	databaseURL := os.Getenv("DATABASE_URL")
-	if databaseURL == "" {
-		t.Skip("DATABASE_URL not set")
-	}
+	t.Parallel()
 
 	ctx := context.Background()
-	cfg := config.TestConfig()
-	cfg.Database.URL = databaseURL
-
-	database, err := db.NewDatabase(ctx, cfg.Database)
-	require.NoError(t, err)
-	t.Cleanup(database.Close)
+	database, _ := newAPIIsolatedTestDB(t, ctx)
 
 	tokenRepo := repository.NewMacHostPairingTokenRepository(database.Queries)
 
 	// Clean any pre-existing rows so the test asserts on a known state.
-	_, err = database.Queries.DeleteAllPairingTokens(ctx)
+	_, err := database.Queries.DeleteAllPairingTokens(ctx)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		// best-effort cleanup

--- a/backend/tests/api/mac_host_janitor_test.go
+++ b/backend/tests/api/mac_host_janitor_test.go
@@ -22,10 +22,9 @@ func TestPairingTokenJanitor_DeletesExpired(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
-	t.Parallel()
 
 	ctx := context.Background()
-	database, _ := newAPIIsolatedTestDB(t, ctx)
+	database, _ := newAPISharedTestDB(t, ctx)
 
 	tokenRepo := repository.NewMacHostPairingTokenRepository(database.Queries)
 

--- a/backend/tests/api/mac_host_pairing_test.go
+++ b/backend/tests/api/mac_host_pairing_test.go
@@ -31,9 +31,9 @@ import (
 const macHostTestKey = "test-mac-host-admin-key"
 
 // macHostTestEnv bundles the wired stack for mac_host integration tests.
-// Each TestXxx builds its own env so the singleton mac_host index isn't
-// shared across subtests (the test DB is shared, so we still hard-delete
-// rows in cleanup).
+// Each TestXxx builds its own env. Mac host tests run serially because the
+// mac_host table intentionally has singleton semantics and cleanup hard-deletes
+// those shared rows from the package clone.
 type macHostTestEnv struct {
 	router     *gin.Engine
 	apiKey     string
@@ -50,7 +50,7 @@ func setupMacHostEnv(t *testing.T) *macHostTestEnv {
 
 	ctx := context.Background()
 
-	database, cfg := newAPIIsolatedTestDB(t, ctx)
+	database, cfg := newAPISharedTestDB(t, ctx)
 	cfg.External.APIKey = macHostTestKey
 
 	hostRepo := repository.NewMacHostRepository(database.Queries)
@@ -179,7 +179,6 @@ func parseConflict(t *testing.T, w *httptest.ResponseRecorder) cursorConflictBod
 }
 
 func TestMacHost_FullPairingFlow(t *testing.T) {
-	t.Parallel()
 
 	env := setupMacHostEnv(t)
 
@@ -330,7 +329,6 @@ func TestMacHost_FullPairingFlow(t *testing.T) {
 }
 
 func TestMacHost_PairingToken_Unknown(t *testing.T) {
-	t.Parallel()
 
 	env := setupMacHostEnv(t)
 
@@ -344,7 +342,6 @@ func TestMacHost_PairingToken_Unknown(t *testing.T) {
 }
 
 func TestMacHost_Pair_MissingHostname_400(t *testing.T) {
-	t.Parallel()
 
 	env := setupMacHostEnv(t)
 
@@ -363,7 +360,6 @@ func TestMacHost_Pair_MissingHostname_400(t *testing.T) {
 }
 
 func TestMacHost_Pair_MissingToken_400(t *testing.T) {
-	t.Parallel()
 
 	env := setupMacHostEnv(t)
 
@@ -377,7 +373,6 @@ func TestMacHost_Pair_MissingToken_400(t *testing.T) {
 }
 
 func TestMacHost_Singleton_SecondPairBlocked(t *testing.T) {
-	t.Parallel()
 
 	env := setupMacHostEnv(t)
 
@@ -405,7 +400,6 @@ func TestMacHost_Singleton_SecondPairBlocked(t *testing.T) {
 }
 
 func TestMacHost_CursorFirstWriteRace(t *testing.T) {
-	t.Parallel()
 
 	env := setupMacHostEnv(t)
 

--- a/backend/tests/api/mac_host_pairing_test.go
+++ b/backend/tests/api/mac_host_pairing_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -17,7 +16,6 @@ import (
 	"personal-crm/backend/internal/api"
 	"personal-crm/backend/internal/api/handlers"
 	"personal-crm/backend/internal/auth"
-	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/service"
@@ -50,19 +48,10 @@ type macHostTestEnv struct {
 func setupMacHostEnv(t *testing.T) *macHostTestEnv {
 	t.Helper()
 
-	databaseURL := os.Getenv("DATABASE_URL")
-	if databaseURL == "" {
-		t.Skip("DATABASE_URL not set, skipping integration test")
-	}
-
 	ctx := context.Background()
 
-	cfg := config.TestConfig()
-	cfg.Database.URL = databaseURL
+	database, cfg := newAPIIsolatedTestDB(t, ctx)
 	cfg.External.APIKey = macHostTestKey
-
-	database, err := db.NewDatabase(ctx, cfg.Database)
-	require.NoError(t, err)
 
 	hostRepo := repository.NewMacHostRepository(database.Queries)
 	tokenRepo := repository.NewMacHostPairingTokenRepository(database.Queries)
@@ -76,7 +65,6 @@ func setupMacHostEnv(t *testing.T) *macHostTestEnv {
 	limiter := auth.NewPairingIPRateLimiter()
 	macHandler := handlers.NewMacHostHandler(macService, limiter)
 
-	gin.SetMode(gin.TestMode)
 	router := gin.New()
 	router.Use(api.RequestIDMiddleware())
 	router.Use(api.LoggingMiddleware())
@@ -127,7 +115,6 @@ func setupMacHostEnv(t *testing.T) *macHostTestEnv {
 		}
 		_, _ = database.Queries.DeleteAllMacHosts(cleanCtx)
 		_, _ = database.Queries.DeleteAllPairingTokens(cleanCtx)
-		database.Close()
 	})
 
 	return env
@@ -192,6 +179,8 @@ func parseConflict(t *testing.T, w *httptest.ResponseRecorder) cursorConflictBod
 }
 
 func TestMacHost_FullPairingFlow(t *testing.T) {
+	t.Parallel()
+
 	env := setupMacHostEnv(t)
 
 	// 1. Admin requests a pairing token.
@@ -341,6 +330,8 @@ func TestMacHost_FullPairingFlow(t *testing.T) {
 }
 
 func TestMacHost_PairingToken_Unknown(t *testing.T) {
+	t.Parallel()
+
 	env := setupMacHostEnv(t)
 
 	w := macHTTP(t, env, http.MethodPost, "/api/v1/host", nil, map[string]any{
@@ -353,6 +344,8 @@ func TestMacHost_PairingToken_Unknown(t *testing.T) {
 }
 
 func TestMacHost_Pair_MissingHostname_400(t *testing.T) {
+	t.Parallel()
+
 	env := setupMacHostEnv(t)
 
 	// Mint a real token via the service so we know the only validation
@@ -370,6 +363,8 @@ func TestMacHost_Pair_MissingHostname_400(t *testing.T) {
 }
 
 func TestMacHost_Pair_MissingToken_400(t *testing.T) {
+	t.Parallel()
+
 	env := setupMacHostEnv(t)
 
 	w := macHTTP(t, env, http.MethodPost, "/api/v1/host", nil, map[string]any{
@@ -382,6 +377,8 @@ func TestMacHost_Pair_MissingToken_400(t *testing.T) {
 }
 
 func TestMacHost_Singleton_SecondPairBlocked(t *testing.T) {
+	t.Parallel()
+
 	env := setupMacHostEnv(t)
 
 	// First pair.
@@ -408,6 +405,8 @@ func TestMacHost_Singleton_SecondPairBlocked(t *testing.T) {
 }
 
 func TestMacHost_CursorFirstWriteRace(t *testing.T) {
+	t.Parallel()
+
 	env := setupMacHostEnv(t)
 
 	// Pair a host directly via the service to bypass HTTP.

--- a/backend/tests/api/mac_host_rotate_key_test.go
+++ b/backend/tests/api/mac_host_rotate_key_test.go
@@ -78,6 +78,8 @@ func hostAuthHeaders(hostID uuid.UUID, apiKey string) map[string]string {
 }
 
 func TestMacHostRotateKey_HappyPath(t *testing.T) {
+	t.Parallel()
+
 	env := setupMacHostEnv(t)
 	hostID, oldKey := pairFreshHost(t, env, "rotate-happy")
 	token := mintRotateToken(t, env)
@@ -128,6 +130,8 @@ func TestMacHostRotateKey_HappyPath(t *testing.T) {
 }
 
 func TestMacHostRotateKey_TokenAlreadyUsed(t *testing.T) {
+	t.Parallel()
+
 	env := setupMacHostEnv(t)
 	hostID, oldKey := pairFreshHost(t, env, "rotate-reuse")
 	token := mintRotateToken(t, env)
@@ -160,6 +164,8 @@ func TestMacHostRotateKey_TokenAlreadyUsed(t *testing.T) {
 }
 
 func TestMacHostRotateKey_InvalidPairingToken(t *testing.T) {
+	t.Parallel()
+
 	env := setupMacHostEnv(t)
 	hostID, oldKey := pairFreshHost(t, env, "rotate-invalid")
 
@@ -177,6 +183,8 @@ func TestMacHostRotateKey_InvalidPairingToken(t *testing.T) {
 }
 
 func TestMacHostRotateKey_TokenExpired(t *testing.T) {
+	t.Parallel()
+
 	env := setupMacHostEnv(t)
 	hostID, oldKey := pairFreshHost(t, env, "rotate-expired")
 
@@ -204,6 +212,8 @@ func TestMacHostRotateKey_TokenExpired(t *testing.T) {
 }
 
 func TestMacHostRotateKey_HostNotFound_MiddlewareCatches(t *testing.T) {
+	t.Parallel()
+
 	env := setupMacHostEnv(t)
 	hostID, oldKey := pairFreshHost(t, env, "rotate-not-found")
 	token := mintRotateToken(t, env)
@@ -229,6 +239,8 @@ func TestMacHostRotateKey_HostNotFound_MiddlewareCatches(t *testing.T) {
 }
 
 func TestMacHostRotateKey_RevokedHostRotation(t *testing.T) {
+	t.Parallel()
+
 	env := setupMacHostEnv(t)
 	hostID, oldKey := pairFreshHost(t, env, "rotate-revoked")
 
@@ -245,6 +257,8 @@ func TestMacHostRotateKey_RevokedHostRotation(t *testing.T) {
 }
 
 func TestMacHostRotateKey_WrongCurrentKey(t *testing.T) {
+	t.Parallel()
+
 	env := setupMacHostEnv(t)
 	hostID, _ := pairFreshHost(t, env, "rotate-wrong-key")
 	token := mintRotateToken(t, env)
@@ -285,6 +299,8 @@ func callRotateAPIKeyDirect(
 }
 
 func TestMacHostRotateKey_ConcurrentRotation_DifferentTokens(t *testing.T) {
+	t.Parallel()
+
 	env := setupMacHostEnv(t)
 	hostID, _ := pairFreshHost(t, env, "rotate-concurrent-diff")
 	tokenA := mintRotateToken(t, env)
@@ -351,6 +367,8 @@ func TestMacHostRotateKey_ConcurrentRotation_DifferentTokens(t *testing.T) {
 }
 
 func TestMacHostRotateKey_ConcurrentRotation_SameToken(t *testing.T) {
+	t.Parallel()
+
 	env := setupMacHostEnv(t)
 	hostID, _ := pairFreshHost(t, env, "rotate-concurrent-same")
 	token := mintRotateToken(t, env)
@@ -407,6 +425,8 @@ func TestMacHostRotateKey_ConcurrentRotation_SameToken(t *testing.T) {
 }
 
 func TestMacHostRotateKey_OldKeyImmediatelyInvalid(t *testing.T) {
+	t.Parallel()
+
 	env := setupMacHostEnv(t)
 	hostID, oldKey := pairFreshHost(t, env, "rotate-old-invalid")
 	token := mintRotateToken(t, env)

--- a/backend/tests/api/mac_host_rotate_key_test.go
+++ b/backend/tests/api/mac_host_rotate_key_test.go
@@ -78,7 +78,6 @@ func hostAuthHeaders(hostID uuid.UUID, apiKey string) map[string]string {
 }
 
 func TestMacHostRotateKey_HappyPath(t *testing.T) {
-	t.Parallel()
 
 	env := setupMacHostEnv(t)
 	hostID, oldKey := pairFreshHost(t, env, "rotate-happy")
@@ -130,7 +129,6 @@ func TestMacHostRotateKey_HappyPath(t *testing.T) {
 }
 
 func TestMacHostRotateKey_TokenAlreadyUsed(t *testing.T) {
-	t.Parallel()
 
 	env := setupMacHostEnv(t)
 	hostID, oldKey := pairFreshHost(t, env, "rotate-reuse")
@@ -164,7 +162,6 @@ func TestMacHostRotateKey_TokenAlreadyUsed(t *testing.T) {
 }
 
 func TestMacHostRotateKey_InvalidPairingToken(t *testing.T) {
-	t.Parallel()
 
 	env := setupMacHostEnv(t)
 	hostID, oldKey := pairFreshHost(t, env, "rotate-invalid")
@@ -183,7 +180,6 @@ func TestMacHostRotateKey_InvalidPairingToken(t *testing.T) {
 }
 
 func TestMacHostRotateKey_TokenExpired(t *testing.T) {
-	t.Parallel()
 
 	env := setupMacHostEnv(t)
 	hostID, oldKey := pairFreshHost(t, env, "rotate-expired")
@@ -212,7 +208,6 @@ func TestMacHostRotateKey_TokenExpired(t *testing.T) {
 }
 
 func TestMacHostRotateKey_HostNotFound_MiddlewareCatches(t *testing.T) {
-	t.Parallel()
 
 	env := setupMacHostEnv(t)
 	hostID, oldKey := pairFreshHost(t, env, "rotate-not-found")
@@ -239,7 +234,6 @@ func TestMacHostRotateKey_HostNotFound_MiddlewareCatches(t *testing.T) {
 }
 
 func TestMacHostRotateKey_RevokedHostRotation(t *testing.T) {
-	t.Parallel()
 
 	env := setupMacHostEnv(t)
 	hostID, oldKey := pairFreshHost(t, env, "rotate-revoked")
@@ -257,7 +251,6 @@ func TestMacHostRotateKey_RevokedHostRotation(t *testing.T) {
 }
 
 func TestMacHostRotateKey_WrongCurrentKey(t *testing.T) {
-	t.Parallel()
 
 	env := setupMacHostEnv(t)
 	hostID, _ := pairFreshHost(t, env, "rotate-wrong-key")
@@ -299,7 +292,6 @@ func callRotateAPIKeyDirect(
 }
 
 func TestMacHostRotateKey_ConcurrentRotation_DifferentTokens(t *testing.T) {
-	t.Parallel()
 
 	env := setupMacHostEnv(t)
 	hostID, _ := pairFreshHost(t, env, "rotate-concurrent-diff")
@@ -367,7 +359,6 @@ func TestMacHostRotateKey_ConcurrentRotation_DifferentTokens(t *testing.T) {
 }
 
 func TestMacHostRotateKey_ConcurrentRotation_SameToken(t *testing.T) {
-	t.Parallel()
 
 	env := setupMacHostEnv(t)
 	hostID, _ := pairFreshHost(t, env, "rotate-concurrent-same")
@@ -425,7 +416,6 @@ func TestMacHostRotateKey_ConcurrentRotation_SameToken(t *testing.T) {
 }
 
 func TestMacHostRotateKey_OldKeyImmediatelyInvalid(t *testing.T) {
-	t.Parallel()
 
 	env := setupMacHostEnv(t)
 	hostID, oldKey := pairFreshHost(t, env, "rotate-old-invalid")

--- a/backend/tests/api/mac_host_scheduler_test.go
+++ b/backend/tests/api/mac_host_scheduler_test.go
@@ -50,6 +50,8 @@ func TestSyncService_ListDueAccounts_ExcludesPushStrategy(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
+
 	databaseURL := os.Getenv("DATABASE_URL")
 	if databaseURL == "" {
 		t.Skip("DATABASE_URL not set")

--- a/backend/tests/api/mac_host_source_counts_test.go
+++ b/backend/tests/api/mac_host_source_counts_test.go
@@ -17,6 +17,8 @@ import (
 // Tombstoned + merge-dupe rows are excluded; rows belonging to a
 // different host are excluded.
 func TestMacHost_GetSourceCounts_HappyPath(t *testing.T) {
+	t.Parallel()
+
 	env := setupMacHostEnv(t)
 	ctx := context.Background()
 
@@ -98,6 +100,8 @@ func TestMacHost_GetSourceCounts_HappyPath(t *testing.T) {
 // pre-check: an unknown host id returns 404 (not 200 with empty
 // counts).
 func TestMacHost_GetSourceCounts_UnknownHost_404(t *testing.T) {
+	t.Parallel()
+
 	env := setupMacHostEnv(t)
 	missing := uuid.New().String()
 	headers := map[string]string{"X-API-Key": env.apiKey}
@@ -109,6 +113,8 @@ func TestMacHost_GetSourceCounts_UnknownHost_404(t *testing.T) {
 // with no external_contact rows returns 200 with counts={} rather than
 // 404 or 500.
 func TestMacHost_GetSourceCounts_NoRowsReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
 	env := setupMacHostEnv(t)
 	ctx := context.Background()
 	host, err := env.hostRepo.SeedRevokedHostForTest(ctx,
@@ -130,6 +136,8 @@ func TestMacHost_GetSourceCounts_NoRowsReturnsEmpty(t *testing.T) {
 // TestMacHost_GetSourceCounts_Unauthenticated_401 covers the admin-auth
 // path: without the global API key, the request is rejected.
 func TestMacHost_GetSourceCounts_Unauthenticated_401(t *testing.T) {
+	t.Parallel()
+
 	env := setupMacHostEnv(t)
 	ctx := context.Background()
 	host, err := env.hostRepo.SeedRevokedHostForTest(ctx,
@@ -143,6 +151,8 @@ func TestMacHost_GetSourceCounts_Unauthenticated_401(t *testing.T) {
 // TestMacHost_GetSourceCounts_BadID_400 confirms the handler rejects a
 // non-UUID path param at validation before touching the service.
 func TestMacHost_GetSourceCounts_BadID_400(t *testing.T) {
+	t.Parallel()
+
 	env := setupMacHostEnv(t)
 	headers := map[string]string{"X-API-Key": env.apiKey}
 	w := macHTTP(t, env, http.MethodGet, "/api/v1/host/not-a-uuid/source-counts", headers, nil)

--- a/backend/tests/api/mac_host_source_counts_test.go
+++ b/backend/tests/api/mac_host_source_counts_test.go
@@ -17,7 +17,6 @@ import (
 // Tombstoned + merge-dupe rows are excluded; rows belonging to a
 // different host are excluded.
 func TestMacHost_GetSourceCounts_HappyPath(t *testing.T) {
-	t.Parallel()
 
 	env := setupMacHostEnv(t)
 	ctx := context.Background()
@@ -100,7 +99,6 @@ func TestMacHost_GetSourceCounts_HappyPath(t *testing.T) {
 // pre-check: an unknown host id returns 404 (not 200 with empty
 // counts).
 func TestMacHost_GetSourceCounts_UnknownHost_404(t *testing.T) {
-	t.Parallel()
 
 	env := setupMacHostEnv(t)
 	missing := uuid.New().String()
@@ -113,7 +111,6 @@ func TestMacHost_GetSourceCounts_UnknownHost_404(t *testing.T) {
 // with no external_contact rows returns 200 with counts={} rather than
 // 404 or 500.
 func TestMacHost_GetSourceCounts_NoRowsReturnsEmpty(t *testing.T) {
-	t.Parallel()
 
 	env := setupMacHostEnv(t)
 	ctx := context.Background()
@@ -136,7 +133,6 @@ func TestMacHost_GetSourceCounts_NoRowsReturnsEmpty(t *testing.T) {
 // TestMacHost_GetSourceCounts_Unauthenticated_401 covers the admin-auth
 // path: without the global API key, the request is rejected.
 func TestMacHost_GetSourceCounts_Unauthenticated_401(t *testing.T) {
-	t.Parallel()
 
 	env := setupMacHostEnv(t)
 	ctx := context.Background()
@@ -151,7 +147,6 @@ func TestMacHost_GetSourceCounts_Unauthenticated_401(t *testing.T) {
 // TestMacHost_GetSourceCounts_BadID_400 confirms the handler rejects a
 // non-UUID path param at validation before touching the service.
 func TestMacHost_GetSourceCounts_BadID_400(t *testing.T) {
-	t.Parallel()
 
 	env := setupMacHostEnv(t)
 	headers := map[string]string{"X-API-Key": env.apiKey}

--- a/backend/tests/api/shared_testdb_fallback_test.go
+++ b/backend/tests/api/shared_testdb_fallback_test.go
@@ -10,10 +10,9 @@ import (
 	"personal-crm/backend/internal/db"
 )
 
-func newAPIIsolatedTestDB(t *testing.T, ctx context.Context) (*db.Database, *config.Config) {
+func newAPISharedTestDB(t *testing.T, ctx context.Context) (*db.Database, *config.Config) {
 	t.Helper()
-
 	_ = ctx
-	t.Skip("integration_testdb build tag required for isolated API database tests")
+	t.Skip("integration_testdb build tag required for shared API database tests")
 	return nil, nil
 }

--- a/backend/tests/api/shared_testdb_test.go
+++ b/backend/tests/api/shared_testdb_test.go
@@ -9,27 +9,21 @@ import (
 
 	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/db"
-	"personal-crm/backend/internal/testdb"
 
 	"github.com/stretchr/testify/require"
 )
 
-func newAPIIsolatedTestDB(t *testing.T, ctx context.Context) (*db.Database, *config.Config) {
+func newAPISharedTestDB(t *testing.T, ctx context.Context) (*db.Database, *config.Config) {
 	t.Helper()
 
-	if os.Getenv("DATABASE_URL") == "" {
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
 		t.Skip("DATABASE_URL not set, skipping integration test")
 	}
 
-	cloneURL, drop := testdb.NewEphemeralClone(t)
-	t.Cleanup(drop)
-
 	cfg := config.TestConfig()
-	cfg.Database.URL = cloneURL
+	cfg.Database.URL = databaseURL
 	cfg.Database.MigrationsPath = getMigrationsPath()
-	cfg.Database.MaxConns = 6
-	cfg.Database.MinConns = 1
-	cfg.River.WorkerConcurrency = 2
 
 	database, err := db.NewDatabase(ctx, cfg.Database)
 	require.NoError(t, err)

--- a/backend/tests/api/testdb_helpers_fallback_test.go
+++ b/backend/tests/api/testdb_helpers_fallback_test.go
@@ -1,0 +1,19 @@
+//go:build !integration_testdb
+
+package api
+
+import (
+	"context"
+	"testing"
+
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+)
+
+func newAPIIsolatedTestDB(t *testing.T, ctx context.Context) (*db.Database, *config.Config) {
+	t.Helper()
+
+	_ = ctx
+	t.Skip("integration_testdb build tag required for isolated API database tests")
+	return nil, nil
+}

--- a/backend/tests/api/testdb_helpers_test.go
+++ b/backend/tests/api/testdb_helpers_test.go
@@ -1,0 +1,39 @@
+//go:build integration_testdb
+
+package api
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/testdb"
+
+	"github.com/stretchr/testify/require"
+)
+
+func newAPIIsolatedTestDB(t *testing.T, ctx context.Context) (*db.Database, *config.Config) {
+	t.Helper()
+
+	if os.Getenv("DATABASE_URL") == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	cloneURL, drop := testdb.NewEphemeralClone(t)
+	t.Cleanup(drop)
+
+	cfg := config.TestConfig()
+	cfg.Database.URL = cloneURL
+	cfg.Database.MigrationsPath = getMigrationsPath()
+	cfg.Database.MaxConns = 6
+	cfg.Database.MinConns = 1
+	cfg.River.WorkerConcurrency = 2
+
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	t.Cleanup(func() { database.Close() })
+
+	return database, cfg
+}

--- a/backend/tests/comms_gchat_engine_test.go
+++ b/backend/tests/comms_gchat_engine_test.go
@@ -2,12 +2,10 @@ package tests
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
 	"personal-crm/backend/internal/accelerated"
-	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/consumer"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/events"
@@ -46,17 +44,9 @@ func setupGChatEngineTest(t *testing.T) *gchatTestEnv {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
-	databaseURL := os.Getenv("DATABASE_URL")
-	if databaseURL == "" {
-		t.Skip("DATABASE_URL not set")
-	}
 
 	ctx := context.Background()
-	cfg := config.TestConfig()
-	cfg.Database.URL = databaseURL
-	database, err := db.NewDatabase(ctx, cfg.Database)
-	require.NoError(t, err)
-	t.Cleanup(database.Close)
+	database, _ := newIsolatedRiverTestDB(t, ctx)
 
 	commsRepo := repository.NewCommsMessageRepository(database.Queries)
 	interactionRepo := repository.NewInteractionRepository(database.Queries)
@@ -99,10 +89,7 @@ func setupGChatEventBus(
 	t.Helper()
 
 	eventRepo := repository.NewEventRepository(database.Queries)
-	cfg := config.TestConfig()
-	if cfg.River.WorkerConcurrency <= 0 {
-		cfg.River.WorkerConcurrency = 4
-	}
+	workerConcurrency := 2
 
 	workers := river.NewWorkers()
 	shim := &deferredRecorderWorker{}
@@ -113,7 +100,7 @@ func setupGChatEventBus(
 
 	client, err := river.NewClient(riverpgxv5.New(database.Pool), &river.Config{
 		Queues: map[string]river.QueueConfig{
-			river.QueueDefault: {MaxWorkers: cfg.River.WorkerConcurrency},
+			river.QueueDefault: {MaxWorkers: workerConcurrency},
 		},
 		Workers:  workers,
 		TestOnly: true,
@@ -202,6 +189,7 @@ func softDeleteCommsRow(e *gchatTestEnv, id uuid.UUID) error {
 // interaction_id set. This test FAILS OUTRIGHT if the gchat StagingProcessor
 // entry is missing (recorder's zero-rows rollback fires).
 func TestGChatEngine_BurstCreatePath(t *testing.T) {
+	t.Parallel()
 	e := setupGChatEngineTest(t)
 	gen, _ := migrationGenerator(t)
 	suffix := gen.Prefix()
@@ -232,6 +220,7 @@ func TestGChatEngine_BurstCreatePath(t *testing.T) {
 // row within 48h; the outbound interaction is promoted to mutual (time-window
 // bridge). A second case: inbound after 48h stays a separate interaction.
 func TestGChatEngine_ReplyBridgeToMutual(t *testing.T) {
+	t.Parallel()
 	e := setupGChatEngineTest(t)
 	gen, _ := migrationGenerator(t)
 	suffix := gen.Prefix()
@@ -286,6 +275,7 @@ func TestGChatEngine_ReplyBridgeToMutual(t *testing.T) {
 // (simulating an edit) WITHOUT clearing processed_at does not create a new
 // interaction on re-aggregate.
 func TestGChatEngine_EditNoOp(t *testing.T) {
+	t.Parallel()
 	e := setupGChatEngineTest(t)
 	gen, _ := migrationGenerator(t)
 	suffix := gen.Prefix()
@@ -314,6 +304,7 @@ func TestGChatEngine_EditNoOp(t *testing.T) {
 // soft-deleted row: an unprocessed row that is soft-deleted before aggregation
 // produces no interaction.
 func TestGChatEngine_DeleteNoOp(t *testing.T) {
+	t.Parallel()
 	e := setupGChatEngineTest(t)
 	gen, _ := migrationGenerator(t)
 	suffix := gen.Prefix()
@@ -338,6 +329,7 @@ func TestGChatEngine_DeleteNoOp(t *testing.T) {
 // it. Also verifies ClearStaleClaimTx clears a matching-ref claim and leaves a
 // different-ref claim untouched.
 func TestGChatEngine_ClaimRaceRecovery(t *testing.T) {
+	t.Parallel()
 	e := setupGChatEngineTest(t)
 	gen, _ := migrationGenerator(t)
 	suffix := gen.Prefix()
@@ -368,6 +360,7 @@ func TestGChatEngine_ClaimRaceRecovery(t *testing.T) {
 // stale-claim clearing predicate: a matching expected-ref claim is cleared; a
 // different-ref claim is left untouched.
 func TestGChatEngine_ClearStaleClaimTx(t *testing.T) {
+	t.Parallel()
 	e := setupGChatEngineTest(t)
 	gen, _ := migrationGenerator(t)
 	suffix := gen.Prefix()
@@ -410,6 +403,7 @@ func TestGChatEngine_ClearStaleClaimTx(t *testing.T) {
 // MATCHING session ref is marked processed; a DIFFERENT session ref is rejected (zero
 // rows affected — the recorder's rollback trigger).
 func TestGChatEngine_MarkProcessedForSessionBoundaryShift(t *testing.T) {
+	t.Parallel()
 	e := setupGChatEngineTest(t)
 	gen, _ := migrationGenerator(t)
 	suffix := gen.Prefix()

--- a/backend/tests/consumer_interaction_recorder_integration_test.go
+++ b/backend/tests/consumer_interaction_recorder_integration_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
@@ -152,11 +151,6 @@ func (*lateFollowUpManagerWorker) Work(_ context.Context, _ *river.Job[followUpM
 func newConsumerTestEnv(t *testing.T, ctx context.Context) *consumerTestEnv {
 	t.Helper()
 
-	databaseURL := os.Getenv("DATABASE_URL")
-	if databaseURL == "" {
-		t.Skip("DATABASE_URL not set, skipping integration test")
-	}
-
 	database, cfg := newEventBusTestDB(t, ctx)
 
 	contactRepo := repository.NewContactRepository(database.Queries)
@@ -281,6 +275,7 @@ func TestIntegration_CalendarAttended_CutoverWritesInteraction(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	env := newConsumerTestEnv(t, ctx)
 
@@ -334,6 +329,7 @@ func TestIntegration_CalendarAttended_TitlePreservedInInteraction(t *testing.T) 
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	env := newConsumerTestEnv(t, ctx)
 
@@ -372,6 +368,7 @@ func TestIntegration_CalendarAttended_Replay(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	env := newConsumerTestEnv(t, ctx)
 
@@ -424,6 +421,7 @@ func TestIntegration_ManualHandler_SingleTxFlow(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	env := newConsumerTestEnv(t, ctx)
 
@@ -465,6 +463,7 @@ func TestIntegration_ManualHandler_DedupWithinWindow(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	env := newConsumerTestEnv(t, ctx)
 
@@ -494,6 +493,7 @@ func TestIntegration_ManualHandler_DifferentDirectionsDoNotDedup(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	env := newConsumerTestEnv(t, ctx)
 
@@ -518,6 +518,7 @@ func TestIntegration_MissingContact_ConsumerReturnsNotFound(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	env := newConsumerTestEnv(t, ctx)
 

--- a/backend/tests/consumer_interaction_recorder_integration_test.go
+++ b/backend/tests/consumer_interaction_recorder_integration_test.go
@@ -7,6 +7,7 @@ import (
 
 	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/consumer"
+	"personal-crm/backend/internal/consumer/consumerjobs"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/events"
 	"personal-crm/backend/internal/repository"
@@ -40,10 +41,9 @@ type consumerTestEnv struct {
 	manualHandler   *service.ManualInteractionHandler
 }
 
-// newConsumerTestBus builds a river client with both the noop worker and
-// the real InteractionRecorderWorker registered. TestOnly=true means the
-// dispatcher never picks jobs up; tests manually invoke HandleEvent via
-// env.runHandleEvent.
+// newConsumerTestBus builds a non-started river client with the consumer job
+// kinds registered. The tests manually invoke HandleEvent via env.runHandleEvent;
+// the client only needs to validate/enqueue downstream jobs in PublishTx.
 func newConsumerTestBus(
 	t *testing.T,
 	ctx context.Context,
@@ -77,74 +77,49 @@ func newConsumerTestBus(
 		recorderRef: recorderRef,
 	})
 	// consumerJobsForKind enqueues cadence_updater and followup_manager
-	// jobs for interaction.recorded events. Register placeholder workers
-	// so river accepts those kinds at Start; TestOnly=true means they
-	// never run.
+	// jobs for interaction.recorded events. Register no-op workers with
+	// the real arg types so river accepts those kinds; the client is not
+	// started, so they never run.
 	river.AddWorker(workers, &lateCadenceUpdaterWorker{})
 	river.AddWorker(workers, &lateFollowUpManagerWorker{})
-
-	startCtx, startCancel := context.WithTimeout(ctx, 10*time.Second)
-	defer startCancel()
-	require.NoError(t, client.Start(startCtx))
-
-	t.Cleanup(func() {
-		stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer stopCancel()
-		_ = client.Stop(stopCtx)
-	})
 
 	return bus
 }
 
-// lateRecorderWorker is a thin shim that lets us register a worker before
-// the concrete recorder is available. Since TestOnly=true, this worker
-// never actually runs — it exists only so river's AddWorker validates the
-// job kind at Start time.
+// lateRecorderWorker is a thin shim that lets us register the job kind before
+// the concrete recorder is available. The client is not started in these tests,
+// so this worker exists only for InsertTx kind validation.
 type lateRecorderWorker struct {
-	river.WorkerDefaults[interactionRecorderJobArgsPlaceholder]
+	river.WorkerDefaults[consumerjobs.InteractionRecorderJobArgs]
 	bus         *events.Bus
 	pool        any
 	recorderRef **consumer.InteractionRecorder
 }
 
-// interactionRecorderJobArgsPlaceholder mirrors the real job args kind so
-// river can route to lateRecorderWorker.
-type interactionRecorderJobArgsPlaceholder struct{}
-
-func (interactionRecorderJobArgsPlaceholder) Kind() string { return "interaction_recorder" }
-
-func (w *lateRecorderWorker) Work(_ context.Context, _ *river.Job[interactionRecorderJobArgsPlaceholder]) error {
-	// TestOnly=true means this never runs. Kept as a no-op.
+func (w *lateRecorderWorker) Work(_ context.Context, _ *river.Job[consumerjobs.InteractionRecorderJobArgs]) error {
+	// The client is not started, so this never runs. Kept as a no-op.
 	return nil
 }
 
-// lateCadenceUpdaterWorker is the cadence_updater placeholder. TestOnly
-// means it never runs; registering it just lets river accept the kind
-// when the test bus enqueues jobs via PublishTx.
+// lateCadenceUpdaterWorker is the cadence_updater no-op. The client is
+// not started; registering it just lets river accept the kind when the test bus
+// enqueues jobs via PublishTx.
 type lateCadenceUpdaterWorker struct {
-	river.WorkerDefaults[cadenceUpdaterJobArgsPlaceholder]
+	river.WorkerDefaults[consumerjobs.CadenceUpdaterJobArgs]
 }
 
-type cadenceUpdaterJobArgsPlaceholder struct{}
-
-func (cadenceUpdaterJobArgsPlaceholder) Kind() string { return "cadence_updater" }
-
-func (*lateCadenceUpdaterWorker) Work(_ context.Context, _ *river.Job[cadenceUpdaterJobArgsPlaceholder]) error {
+func (*lateCadenceUpdaterWorker) Work(_ context.Context, _ *river.Job[consumerjobs.CadenceUpdaterJobArgs]) error {
 	return nil
 }
 
-// lateFollowUpManagerWorker is the followup_manager placeholder.
-// TestOnly means it never runs; registering it just lets river accept
-// the kind when the test bus enqueues jobs via PublishTx.
+// lateFollowUpManagerWorker is the followup_manager no-op. The client is
+// not started; registering it just lets river accept the kind when the test bus
+// enqueues jobs via PublishTx.
 type lateFollowUpManagerWorker struct {
-	river.WorkerDefaults[followUpManagerJobArgsPlaceholder]
+	river.WorkerDefaults[consumerjobs.FollowUpManagerJobArgs]
 }
 
-type followUpManagerJobArgsPlaceholder struct{}
-
-func (followUpManagerJobArgsPlaceholder) Kind() string { return "followup_manager" }
-
-func (*lateFollowUpManagerWorker) Work(_ context.Context, _ *river.Job[followUpManagerJobArgsPlaceholder]) error {
+func (*lateFollowUpManagerWorker) Work(_ context.Context, _ *river.Job[consumerjobs.FollowUpManagerJobArgs]) error {
 	return nil
 }
 

--- a/backend/tests/event_bus_integration_test.go
+++ b/backend/tests/event_bus_integration_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"os"
 	"testing"
 	"time"
 
@@ -35,27 +34,12 @@ func (*eventBusNoopWorker) Work(_ context.Context, _ *river.Job[eventBusNoopArgs
 	return nil
 }
 
-// newEventBusTestDB runs migrations (including 036) and opens a DB. Mirrors
-// the PR 1 river integration test pattern.
+// newEventBusTestDB opens an isolated per-test DB because this file also starts
+// live River clients. Repository-only tests pay the same setup cost so the
+// shared helper can stay simple and the whole file can run under t.Parallel().
 func newEventBusTestDB(t *testing.T, ctx context.Context) (*db.Database, *config.Config) {
 	t.Helper()
-
-	databaseURL := os.Getenv("DATABASE_URL")
-	if databaseURL == "" {
-		t.Skip("DATABASE_URL not set, skipping integration test")
-	}
-
-	cfg := config.TestConfig()
-	cfg.Database.URL = databaseURL
-	cfg.Database.MigrationsPath = getMigrationsPath()
-
-	// Migrations are applied once by TestMain.
-
-	database, err := db.NewDatabase(ctx, cfg.Database)
-	require.NoError(t, err)
-	t.Cleanup(func() { database.Close() })
-
-	return database, cfg
+	return newIsolatedRiverTestDB(t, ctx)
 }
 
 // newEventBusTestBus builds a full Bus with a real river client registered
@@ -269,6 +253,7 @@ func TestBus_PublishTx_Succeeds_Integration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	database, cfg := newEventBusTestDB(t, ctx)
 	bus := newEventBusTestBus(t, ctx, database, cfg)
@@ -300,6 +285,7 @@ func TestBus_PublishTx_DuplicateSourceID_IsNoOp_Integration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	database, cfg := newEventBusTestDB(t, ctx)
 	bus := newEventBusTestBus(t, ctx, database, cfg)
@@ -345,6 +331,7 @@ func TestBus_Publish_OpensOwnTransaction_AndCommits_Integration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	database, cfg := newEventBusTestDB(t, ctx)
 	bus := newEventBusTestBus(t, ctx, database, cfg)
@@ -372,6 +359,7 @@ func TestBus_PublishTx_ValidationError_NoRowPersisted_Integration(t *testing.T) 
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	database, cfg := newEventBusTestDB(t, ctx)
 	bus := newEventBusTestBus(t, ctx, database, cfg)
@@ -401,6 +389,7 @@ func TestBus_PublishTx_PreGeneratedID_IsRespected_Integration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	ctx := context.Background()
 	database, cfg := newEventBusTestDB(t, ctx)
 	bus := newEventBusTestBus(t, ctx, database, cfg)

--- a/backend/tests/event_bus_integration_test.go
+++ b/backend/tests/event_bus_integration_test.go
@@ -34,17 +34,17 @@ func (*eventBusNoopWorker) Work(_ context.Context, _ *river.Job[eventBusNoopArgs
 	return nil
 }
 
-// newEventBusTestDB opens an isolated per-test DB because this file also starts
-// live River clients. Repository-only tests pay the same setup cost so the
-// shared helper can stay simple and the whole file can run under t.Parallel().
+// newEventBusTestDB opens the package-clone DB. These tests publish only
+// interaction.manual events, which do not route to async consumer jobs, so they
+// do not need a live River fetch loop or a per-test database clone.
 func newEventBusTestDB(t *testing.T, ctx context.Context) (*db.Database, *config.Config) {
 	t.Helper()
-	return newIsolatedRiverTestDB(t, ctx)
+	return newSharedTestDB(t, ctx)
 }
 
-// newEventBusTestBus builds a full Bus with a real river client registered
-// against the shared test DB. TestOnly skips leader election / periodic
-// loops. Client is stopped in t.Cleanup.
+// newEventBusTestBus builds a Bus with a River client that is never started.
+// InsertTx does not need a fetch loop, and these tests use event kinds whose
+// routing table returns no jobs.
 func newEventBusTestBus(t *testing.T, ctx context.Context, database *db.Database, cfg *config.Config) *events.Bus {
 	t.Helper()
 	eventRepo := repository.NewEventRepository(database.Queries)
@@ -60,16 +60,6 @@ func newEventBusTestBus(t *testing.T, ctx context.Context, database *db.Database
 		TestOnly: true,
 	})
 	require.NoError(t, err)
-
-	startCtx, startCancel := context.WithTimeout(ctx, 10*time.Second)
-	defer startCancel()
-	require.NoError(t, client.Start(startCtx))
-
-	t.Cleanup(func() {
-		stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer stopCancel()
-		_ = client.Stop(stopCtx)
-	})
 
 	return events.NewBus(database.Pool, client, eventRepo)
 }

--- a/backend/tests/gchat_golive_integration_test.go
+++ b/backend/tests/gchat_golive_integration_test.go
@@ -44,6 +44,7 @@ import (
 // TestGChatGoLive_RegisteredProvider_SchedulerSweep_ProducesInteractionsAndCadence
 // is the PR-3 go-live acceptance test.
 func TestGChatGoLive_RegisteredProvider_SchedulerSweep_ProducesInteractionsAndCadence(t *testing.T) {
+	t.Parallel()
 	e := setupGChatEngineTest(t) // engine + live bus + recorder + cadence + repos
 	gen, _ := migrationGenerator(t)
 	prefix := gen.Prefix()

--- a/backend/tests/gchat_provider_integration_test.go
+++ b/backend/tests/gchat_provider_integration_test.go
@@ -691,6 +691,7 @@ func TestGChatRematch_ScansWhenEnabled(t *testing.T) {
 // enabled gchat state + a fake fetcher → adding the address upserts a row AND
 // the engine derives an interaction in the same rematch pass.
 func TestGChatRematchHandler_ScansAndAggregates(t *testing.T) {
+	t.Parallel()
 	env := setupGChatEngineTest(t) // wired engine + recorder
 	gen, _ := migrationGenerator(t)
 	prefix := gen.Prefix()

--- a/backend/tests/river_isolated_testdb_fallback_test.go
+++ b/backend/tests/river_isolated_testdb_fallback_test.go
@@ -1,0 +1,21 @@
+//go:build !integration_testdb
+
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+)
+
+// newIsolatedRiverTestDB is the no-tag fallback used by short unit builds.
+// Integration targets compile the tagged helper that creates an ephemeral clone.
+func newIsolatedRiverTestDB(t *testing.T, ctx context.Context) (*db.Database, *config.Config) {
+	t.Helper()
+
+	_ = ctx
+	t.Skip("integration_testdb build tag required for isolated River database tests")
+	return nil, nil
+}

--- a/backend/tests/river_isolated_testdb_test.go
+++ b/backend/tests/river_isolated_testdb_test.go
@@ -1,0 +1,42 @@
+//go:build integration_testdb
+
+package tests
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/testdb"
+
+	"github.com/stretchr/testify/require"
+)
+
+// newIsolatedRiverTestDB opens a per-test clone for tests that start a River
+// client. Sharing the package clone lets TestOnly clients steal each other's
+// jobs from river_job, so River-draining tests must isolate the whole DB.
+func newIsolatedRiverTestDB(t *testing.T, ctx context.Context) (*db.Database, *config.Config) {
+	t.Helper()
+
+	if os.Getenv("DATABASE_URL") == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	cloneURL, drop := testdb.NewEphemeralClone(t)
+	t.Cleanup(drop)
+
+	cfg := config.TestConfig()
+	cfg.Database.URL = cloneURL
+	cfg.Database.MigrationsPath = getMigrationsPath()
+	cfg.Database.MaxConns = 6
+	cfg.Database.MinConns = 1
+	cfg.River.WorkerConcurrency = 2
+
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	t.Cleanup(func() { database.Close() })
+
+	return database, cfg
+}

--- a/backend/tests/shared_testdb_fallback_test.go
+++ b/backend/tests/shared_testdb_fallback_test.go
@@ -1,0 +1,18 @@
+//go:build !integration_testdb
+
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+)
+
+func newSharedTestDB(t *testing.T, ctx context.Context) (*db.Database, *config.Config) {
+	t.Helper()
+	_ = ctx
+	t.Skip("integration_testdb build tag required for shared integration database tests")
+	return nil, nil
+}

--- a/backend/tests/shared_testdb_test.go
+++ b/backend/tests/shared_testdb_test.go
@@ -1,0 +1,33 @@
+//go:build integration_testdb
+
+package tests
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+
+	"github.com/stretchr/testify/require"
+)
+
+func newSharedTestDB(t *testing.T, ctx context.Context) (*db.Database, *config.Config) {
+	t.Helper()
+
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+	cfg.Database.MigrationsPath = getMigrationsPath()
+
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	t.Cleanup(func() { database.Close() })
+
+	return database, cfg
+}

--- a/backend/tests/suggestion_service_integration_test.go
+++ b/backend/tests/suggestion_service_integration_test.go
@@ -52,6 +52,7 @@ func seedImportedWithPending(
 }
 
 func TestSuggestions_List_SurfacesLinkedRowWithName(t *testing.T) {
+	t.Parallel()
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
 	svc := newSuggestionService(env)
@@ -78,6 +79,7 @@ func TestSuggestions_List_SurfacesLinkedRowWithName(t *testing.T) {
 }
 
 func TestSuggestions_List_DropsSoftDeletedContact(t *testing.T) {
+	t.Parallel()
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
 	svc := newSuggestionService(env)
@@ -94,6 +96,7 @@ func TestSuggestions_List_DropsSoftDeletedContact(t *testing.T) {
 }
 
 func TestSuggestions_List_SourceScopeExcludesNonAddressBook(t *testing.T) {
+	t.Parallel()
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
 	svc := newSuggestionService(env)
@@ -130,6 +133,7 @@ func TestSuggestions_List_SourceScopeExcludesNonAddressBook(t *testing.T) {
 }
 
 func TestSuggestions_Resolve_AddsMethodAndClearsPending(t *testing.T) {
+	t.Parallel()
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
 	svc := newSuggestionService(env)
@@ -160,6 +164,7 @@ func TestSuggestions_Resolve_AddsMethodAndClearsPending(t *testing.T) {
 }
 
 func TestSuggestions_Resolve_Idempotent(t *testing.T) {
+	t.Parallel()
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
 	svc := newSuggestionService(env)
@@ -182,6 +187,7 @@ func TestSuggestions_Resolve_Idempotent(t *testing.T) {
 }
 
 func TestSuggestions_Resolve_AlreadyOnContact_NotReAdded(t *testing.T) {
+	t.Parallel()
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
 	svc := newSuggestionService(env)
@@ -209,6 +215,7 @@ func TestSuggestions_Resolve_AlreadyOnContact_NotReAdded(t *testing.T) {
 }
 
 func TestSuggestions_Resolve_UnknownMethodIsNoOp(t *testing.T) {
+	t.Parallel()
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
 	svc := newSuggestionService(env)
@@ -230,6 +237,7 @@ func TestSuggestions_Resolve_UnknownMethodIsNoOp(t *testing.T) {
 }
 
 func TestSuggestions_Resolve_MalformedMethod400(t *testing.T) {
+	t.Parallel()
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
 	svc := newSuggestionService(env)
@@ -244,6 +252,7 @@ func TestSuggestions_Resolve_MalformedMethod400(t *testing.T) {
 }
 
 func TestSuggestions_Dismiss_RecordsStickyAndDropsPending(t *testing.T) {
+	t.Parallel()
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
 	svc := newSuggestionService(env)
@@ -280,6 +289,7 @@ func TestSuggestions_Dismiss_RecordsStickyAndDropsPending(t *testing.T) {
 }
 
 func TestSuggestions_Dismiss_Idempotent(t *testing.T) {
+	t.Parallel()
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
 	svc := newSuggestionService(env)
@@ -301,6 +311,7 @@ func TestSuggestions_Dismiss_Idempotent(t *testing.T) {
 }
 
 func TestSuggestions_Dismiss_AlreadyOnContact_NotStickyDismissed(t *testing.T) {
+	t.Parallel()
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
 	svc := newSuggestionService(env)
@@ -329,6 +340,7 @@ func TestSuggestions_Dismiss_AlreadyOnContact_NotStickyDismissed(t *testing.T) {
 }
 
 func TestSuggestions_Resolve_ContactGone(t *testing.T) {
+	t.Parallel()
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
 	svc := newSuggestionService(env)
@@ -342,6 +354,7 @@ func TestSuggestions_Resolve_ContactGone(t *testing.T) {
 }
 
 func TestSuggestions_DuplicateOfCanonical_ResolvesToCanonicalContact(t *testing.T) {
+	t.Parallel()
 	env := setupABReconcileEnv(t)
 	ctx := context.Background()
 	svc := newSuggestionService(env)

--- a/backend/tests/unit/cadence_test.go
+++ b/backend/tests/unit/cadence_test.go
@@ -12,6 +12,8 @@ import (
 
 // TestParseCadence tests parsing of cadence strings
 func TestParseCadence(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		input    string
 		expected cadence.CadenceType
@@ -44,6 +46,8 @@ func TestParseCadence(t *testing.T) {
 
 // TestCalculateNextDueDate tests calculation of next due dates
 func TestCalculateNextDueDate(t *testing.T) {
+	t.Parallel()
+
 	baseDate := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
 
 	tests := []struct {
@@ -138,6 +142,8 @@ func TestCalculateNextDueDate(t *testing.T) {
 
 // TestIsOverdue tests overdue detection
 func TestIsOverdue(t *testing.T) {
+	t.Parallel()
+
 	now := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC) // Jan 15, 2024
 
 	tests := []struct {
@@ -208,6 +214,8 @@ func TestIsOverdue(t *testing.T) {
 
 // TestGetOverdueDays tests overdue days calculation
 func TestGetOverdueDays(t *testing.T) {
+	t.Parallel()
+
 	now := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC) // Jan 15, 2024
 
 	tests := []struct {
@@ -257,6 +265,8 @@ func TestGetOverdueDays(t *testing.T) {
 
 // TestGetDaysUntilDue tests days until due calculation
 func TestGetDaysUntilDue(t *testing.T) {
+	t.Parallel()
+
 	now := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC) // Jan 15, 2024
 
 	tests := []struct {
@@ -500,6 +510,8 @@ func TestGetOverdueDaysWithConfig(t *testing.T) {
 
 // TestBiweeklyCadenceComprehensive tests biweekly cadence across all functions
 func TestBiweeklyCadenceComprehensive(t *testing.T) {
+	t.Parallel()
+
 	now := time.Date(2024, 1, 22, 12, 0, 0, 0, time.UTC)
 	lastContact := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC) // 21 days ago
 	created := time.Date(2023, 12, 1, 12, 0, 0, 0, time.UTC)

--- a/backend/tests/unit/date_test.go
+++ b/backend/tests/unit/date_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestDateOnly(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name  string
 		input time.Time
@@ -46,6 +48,8 @@ func TestDateOnly(t *testing.T) {
 }
 
 func TestToday(t *testing.T) {
+	t.Parallel()
+
 	now := time.Date(2024, 6, 15, 16, 45, 30, 0, time.UTC)
 	today := cadence.Today(now)
 
@@ -57,6 +61,8 @@ func TestToday(t *testing.T) {
 }
 
 func TestCadenceDays(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		cadence      cadence.CadenceType
 		expectedDays int
@@ -80,6 +86,8 @@ func TestCadenceDays(t *testing.T) {
 }
 
 func TestCalculateContactBy(t *testing.T) {
+	t.Parallel()
+
 	base := time.Date(2024, 1, 15, 10, 30, 0, 0, time.Local)
 
 	tests := []struct {
@@ -118,6 +126,8 @@ func TestCalculateContactBy(t *testing.T) {
 }
 
 func TestIsContactByOverdue(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name      string
 		contactBy time.Time
@@ -153,6 +163,8 @@ func TestIsContactByOverdue(t *testing.T) {
 }
 
 func TestGetContactByOverdueDays(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name         string
 		contactBy    time.Time

--- a/backend/tests/unit/gin_test.go
+++ b/backend/tests/unit/gin_test.go
@@ -1,0 +1,7 @@
+package unit
+
+import "github.com/gin-gonic/gin"
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}

--- a/backend/tests/unit/import_handler_test.go
+++ b/backend/tests/unit/import_handler_test.go
@@ -14,6 +14,8 @@ import (
 // using integration tests with real database connections.
 
 func TestSelectedMethodInput_TypeValues(t *testing.T) {
+	t.Parallel()
+
 	// Verify all valid type values that the handler accepts
 	// These match the validation tag: oneof=email phone telegram signal discord twitter gchat whatsapp
 	validTypes := []string{
@@ -40,6 +42,8 @@ func TestSelectedMethodInput_TypeValues(t *testing.T) {
 }
 
 func TestLinkRequest_Structure(t *testing.T) {
+	t.Parallel()
+
 	t.Run("RequiredCRMContactID", func(t *testing.T) {
 		// LinkRequest requires crm_contact_id
 		req := handlers.LinkRequest{
@@ -73,6 +77,8 @@ func TestLinkRequest_Structure(t *testing.T) {
 }
 
 func TestImportRequest_Structure(t *testing.T) {
+	t.Parallel()
+
 	t.Run("EmptyRequestIsValid", func(t *testing.T) {
 		// Empty ImportRequest is valid for backward compatibility
 		req := handlers.ImportRequest{}
@@ -91,6 +97,8 @@ func TestImportRequest_Structure(t *testing.T) {
 }
 
 func TestConflictResolutionValues(t *testing.T) {
+	t.Parallel()
+
 	// Verify valid conflict resolution values
 	validResolutions := []string{"use_crm", "use_external"}
 
@@ -108,6 +116,8 @@ func TestConflictResolutionValues(t *testing.T) {
 }
 
 func TestMethodSelectionConversion(t *testing.T) {
+	t.Parallel()
+
 	// Verify that handler SelectedMethodInput can be converted to service MethodSelection
 	handlerInput := handlers.SelectedMethodInput{
 		OriginalValue: "test@example.com",

--- a/backend/tests/unit/sync_handler_test.go
+++ b/backend/tests/unit/sync_handler_test.go
@@ -95,8 +95,6 @@ func (m *mockSyncService) GetAvailableProviders() []psync.SourceConfig {
 }
 
 func setupSyncHandlerTestRouter(mockService *mockSyncService) *gin.Engine {
-	gin.SetMode(gin.TestMode)
-
 	// Create handler with mock service
 	handler := handlers.NewSyncHandler(mockService)
 
@@ -115,6 +113,7 @@ func setupSyncHandlerTestRouter(mockService *mockSyncService) *gin.Engine {
 // TestTriggerSync_Returns202Immediately verifies that the TriggerSync handler
 // returns 202 Accepted immediately without waiting for the sync to complete.
 func TestTriggerSync_Returns202Immediately(t *testing.T) {
+	t.Parallel()
 	mockService := newMockSyncService()
 	// Simulate a slow sync operation
 	mockService.triggerSyncDelay = 5 * time.Second
@@ -158,6 +157,7 @@ func TestTriggerSync_Returns202Immediately(t *testing.T) {
 // TestTriggerSync_BackgroundSyncRuns verifies that the sync actually runs
 // in the background after the handler returns.
 func TestTriggerSync_BackgroundSyncRuns(t *testing.T) {
+	t.Parallel()
 	mockService := newMockSyncService()
 	mockService.triggerSyncDelay = 100 * time.Millisecond
 
@@ -183,6 +183,7 @@ func TestTriggerSync_BackgroundSyncRuns(t *testing.T) {
 
 // TestTriggerSync_RequiresSource verifies validation of source parameter.
 func TestTriggerSync_RequiresSource(t *testing.T) {
+	t.Parallel()
 	mockService := newMockSyncService()
 	router := setupSyncHandlerTestRouter(mockService)
 

--- a/backend/tests/unit/sync_test.go
+++ b/backend/tests/unit/sync_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestBackoffCalculation(t *testing.T) {
+	t.Parallel()
+
 	backoffIntervals := []time.Duration{
 		1 * time.Minute,
 		5 * time.Minute,
@@ -44,6 +46,8 @@ func TestBackoffCalculation(t *testing.T) {
 }
 
 func TestProviderRegistry(t *testing.T) {
+	t.Parallel()
+
 	t.Run("register and get provider", func(t *testing.T) {
 		registry := psync.NewProviderRegistry()
 
@@ -139,6 +143,8 @@ func TestProviderRegistry(t *testing.T) {
 }
 
 func TestSyncStatus(t *testing.T) {
+	t.Parallel()
+
 	t.Run("sync status constants", func(t *testing.T) {
 		assert.Equal(t, repository.SyncStatus("idle"), repository.SyncStatusIdle)
 		assert.Equal(t, repository.SyncStatus("error"), repository.SyncStatusError)
@@ -147,6 +153,8 @@ func TestSyncStatus(t *testing.T) {
 }
 
 func TestSyncStrategy(t *testing.T) {
+	t.Parallel()
+
 	t.Run("sync strategy constants", func(t *testing.T) {
 		assert.Equal(t, repository.SyncStrategy("contact_driven"), repository.SyncStrategyContactDriven)
 		assert.Equal(t, repository.SyncStrategy("fetch_all"), repository.SyncStrategyFetchAll)
@@ -155,6 +163,8 @@ func TestSyncStrategy(t *testing.T) {
 }
 
 func TestSourceConfig(t *testing.T) {
+	t.Parallel()
+
 	t.Run("source config fields", func(t *testing.T) {
 		config := psync.SourceConfig{
 			Name:                 "gmail",
@@ -175,6 +185,8 @@ func TestSourceConfig(t *testing.T) {
 }
 
 func TestSyncResult(t *testing.T) {
+	t.Parallel()
+
 	t.Run("sync result fields", func(t *testing.T) {
 		result := psync.SyncResult{
 			ItemsProcessed: 100,

--- a/backend/tests/unit/todoist_test.go
+++ b/backend/tests/unit/todoist_test.go
@@ -13,6 +13,8 @@ import (
 // used when checking if Todoist deadline differs from CRM contact_by.
 // This ensures timezone differences don't cause incorrect comparisons.
 func TestTodoistDeadlineDateComparison(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name            string
 		todoistDate     string // Todoist deadline date string (YYYY-MM-DD)
@@ -79,6 +81,8 @@ func TestTodoistDeadlineDateComparison(t *testing.T) {
 // TestTodoistDeadlineDateComparisonOldVsNew compares the old (buggy) comparison
 // with the new (fixed) comparison to demonstrate the difference.
 func TestTodoistDeadlineDateComparisonOldVsNew(t *testing.T) {
+	t.Parallel()
+
 	// Simulate a scenario where old code would give wrong result
 	// due to timezone conversion
 
@@ -104,6 +108,8 @@ func TestTodoistDeadlineDateComparisonOldVsNew(t *testing.T) {
 // TestSyncedDeadlineComparison tests the synced_deadline comparison logic
 // used to detect when contact_by has changed and the Todoist task needs updating.
 func TestSyncedDeadlineComparison(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name           string
 		syncedDeadline string // stored in metadata (YYYY-MM-DD)
@@ -154,6 +160,8 @@ func TestSyncedDeadlineComparison(t *testing.T) {
 // TestIsPendingTempIDLogic tests the logic for detecting if a task's
 // external ID is still a pending temp ID (not yet resolved to real Todoist ID).
 func TestIsPendingTempIDLogic(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name           string
 		externalTaskID string
@@ -230,6 +238,8 @@ func TestIsPendingTempIDLogic(t *testing.T) {
 // TestReconciliationCommandGeneration tests the logic for determining which commands
 // should be generated during reconciliation based on task state and deadline drift.
 func TestReconciliationCommandGeneration(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name             string
 		externalTaskID   string
@@ -341,6 +351,8 @@ func TestReconciliationCommandGeneration(t *testing.T) {
 // This ensures the reconciliation correctly identifies stale tasks even when
 // contact_by hasn't changed (same cadence period).
 func TestWasContactedSinceSyncLogic(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name                string
 		lastContacted       *time.Time
@@ -419,6 +431,8 @@ func TestWasContactedSinceSyncLogic(t *testing.T) {
 // including the new non-Todoist contact detection. This covers the bug fix for
 // GH #235 where calendar-synced contacts didn't auto-complete Todoist tasks.
 func TestReconciliationWithNonTodoistContact(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name             string
 		externalTaskID   string
@@ -563,6 +577,8 @@ func TestReconciliationWithNonTodoistContact(t *testing.T) {
 // TestBackfillSyncedLastContacted verifies that legacy tasks without synced_last_contacted
 // get it backfilled, enabling detection of non-Todoist contacts on subsequent sync cycles.
 func TestBackfillSyncedLastContacted(t *testing.T) {
+	t.Parallel()
+
 	// Simulate two sync cycles:
 	// Cycle 1: Legacy task has synced_deadline but no synced_last_contacted
 	//   → Backfill happens: synced_last_contacted = current last_contacted
@@ -607,6 +623,8 @@ func TestBackfillSyncedLastContacted(t *testing.T) {
 // and contact_task.lifecycle and in CRM marker JSON; changing them would
 // orphan existing rows and pre-migration markers.
 func TestKindLifecycleConstants(t *testing.T) {
+	t.Parallel()
+
 	assert.Equal(t, "reach_out", contacttask.KindReachOut)
 	assert.Equal(t, "send", contacttask.KindSend)
 	assert.Equal(t, "reminder", contacttask.KindReminder)
@@ -619,6 +637,8 @@ func TestKindLifecycleConstants(t *testing.T) {
 
 // TestActionTaskStateTransitions tests the expected state transitions for action tasks
 func TestActionTaskStateTransitions(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name           string
 		initialState   string
@@ -699,6 +719,8 @@ func TestActionTaskStateTransitions(t *testing.T) {
 
 // TestActionTaskMetadataSchema tests the expected metadata structure for action tasks
 func TestActionTaskMetadataSchema(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name         string
 		metadata     map[string]any
@@ -762,6 +784,8 @@ func TestActionTaskMetadataSchema(t *testing.T) {
 
 // TestActionTaskVsCadenceTaskBehavior documents the key behavioral differences
 func TestActionTaskVsCadenceTaskBehavior(t *testing.T) {
+	t.Parallel()
+
 	t.Run("cadence tasks create new task on completion", func(t *testing.T) {
 		// Cadence tasks: completion -> update last_contacted -> calculate new contact_by -> create next task
 		// This is the existing behavior verified by other tests

--- a/backend/tests/unit/validation_test.go
+++ b/backend/tests/unit/validation_test.go
@@ -19,6 +19,8 @@ func init() {
 
 // TestContactValidation_FullName tests FullName validation
 func TestContactValidation_FullName(t *testing.T) {
+	t.Parallel()
+
 	type Contact struct {
 		FullName string `validate:"required,min=1,max=255"`
 	}
@@ -52,6 +54,8 @@ func TestContactValidation_FullName(t *testing.T) {
 
 // TestContactMethodValidation_Type tests method type validation
 func TestContactMethodValidation_Type(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name      string
 		method    handlers.ContactMethodRequest
@@ -78,6 +82,8 @@ func TestContactMethodValidation_Type(t *testing.T) {
 
 // TestContactMethodValidation_Value tests method value validation
 func TestContactMethodValidation_Value(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name      string
 		method    handlers.ContactMethodRequest
@@ -104,6 +110,8 @@ func TestContactMethodValidation_Value(t *testing.T) {
 
 // TestContactValidation_Location tests Location validation
 func TestContactValidation_Location(t *testing.T) {
+	t.Parallel()
+
 	type Contact struct {
 		Location *string `validate:"omitempty,max=255"`
 	}
@@ -135,6 +143,8 @@ func TestContactValidation_Location(t *testing.T) {
 
 // TestContactValidation_HowMet tests HowMet validation
 func TestContactValidation_HowMet(t *testing.T) {
+	t.Parallel()
+
 	type Contact struct {
 		HowMet *string `validate:"omitempty,max=500"`
 	}
@@ -166,6 +176,8 @@ func TestContactValidation_HowMet(t *testing.T) {
 
 // TestContactValidation_Cadence tests Cadence validation
 func TestContactValidation_Cadence(t *testing.T) {
+	t.Parallel()
+
 	type Contact struct {
 		Cadence *string `validate:"omitempty,oneof=weekly biweekly monthly quarterly biannual annual"`
 	}
@@ -203,6 +215,8 @@ func TestContactValidation_Cadence(t *testing.T) {
 
 // TestContactValidation_Notes tests Notes validation
 func TestContactValidation_Notes(t *testing.T) {
+	t.Parallel()
+
 	type Contact struct {
 		Notes *string `validate:"omitempty,max=2000"`
 	}
@@ -237,6 +251,8 @@ func TestContactValidation_Notes(t *testing.T) {
 
 // TestContactValidation_ProfilePhoto tests ProfilePhoto URL validation
 func TestContactValidation_ProfilePhoto(t *testing.T) {
+	t.Parallel()
+
 	type Contact struct {
 		ProfilePhoto *string `validate:"omitempty,url,max=500"`
 	}
@@ -271,6 +287,8 @@ func TestContactValidation_ProfilePhoto(t *testing.T) {
 
 // TestQueryValidation_Page tests Page validation
 func TestQueryValidation_Page(t *testing.T) {
+	t.Parallel()
+
 	type Query struct {
 		Page int `validate:"omitempty,min=1"`
 	}
@@ -302,6 +320,8 @@ func TestQueryValidation_Page(t *testing.T) {
 
 // TestQueryValidation_Limit tests Limit validation
 func TestQueryValidation_Limit(t *testing.T) {
+	t.Parallel()
+
 	type Query struct {
 		Limit int `validate:"omitempty,min=1,max=1000"`
 	}
@@ -335,6 +355,8 @@ func TestQueryValidation_Limit(t *testing.T) {
 
 // TestQueryValidation_Search tests Search validation
 func TestQueryValidation_Search(t *testing.T) {
+	t.Parallel()
+
 	type Query struct {
 		Search string `validate:"omitempty,max=255"`
 	}
@@ -366,6 +388,8 @@ func TestQueryValidation_Search(t *testing.T) {
 
 // TestQueryValidation_Sort tests Sort field validation
 func TestQueryValidation_Sort(t *testing.T) {
+	t.Parallel()
+
 	type Query struct {
 		Sort string `validate:"omitempty,oneof=name location birthday last_contacted last_response_at contact_by cadence"`
 	}
@@ -403,6 +427,8 @@ func TestQueryValidation_Sort(t *testing.T) {
 
 // TestQueryValidation_Order tests Order validation
 func TestQueryValidation_Order(t *testing.T) {
+	t.Parallel()
+
 	type Query struct {
 		Order string `validate:"omitempty,oneof=asc desc"`
 	}
@@ -435,6 +461,8 @@ func TestQueryValidation_Order(t *testing.T) {
 
 // TestComplexValidation_MultipleFields tests validation with multiple fields
 func TestComplexValidation_MultipleFields(t *testing.T) {
+	t.Parallel()
+
 	type Contact struct {
 		FullName     string  `validate:"required,min=1,max=255"`
 		Cadence      *string `validate:"omitempty,oneof=weekly biweekly monthly quarterly biannual annual"`

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,6 +1,11 @@
 import { defineConfig, devices } from '@playwright/test'
 import os from 'os'
 
+const frontendPort = process.env.E2E_FRONTEND_PORT || '3000'
+const backendPort = process.env.E2E_BACKEND_PORT || '8080'
+const frontendURL = `http://localhost:${frontendPort}`
+const backendURL = `http://localhost:${backendPort}`
+
 export default defineConfig({
   testDir: './tests/e2e',
   fullyParallel: true,
@@ -26,7 +31,7 @@ export default defineConfig({
   })(),
   reporter: [['html', { open: 'never' }], ['list']],
   use: {
-    baseURL: 'http://localhost:3000',
+    baseURL: frontendURL,
     trace: process.env.CI ? 'on-first-retry' : 'off',
     screenshot: 'only-on-failure',
     video: 'off',
@@ -53,19 +58,24 @@ export default defineConfig({
   webServer: [
     {
       command: 'bun run dev -- --hostname 127.0.0.1',
-      url: 'http://localhost:3000',
+      url: frontendURL,
       reuseExistingServer: !process.env.CI,
       timeout: 120000,
       stdout: 'pipe',
       env: {
         ...process.env,
         NODE_ENV: 'development',
-        PORT: '3000',
+        PORT: frontendPort,
+        NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL || backendURL,
+        NEXT_PUBLIC_API_KEY:
+          process.env.NEXT_PUBLIC_API_KEY ||
+          process.env.API_KEY ||
+          'dev-api-key-change-in-production',
       },
     },
     {
       command: 'cd ../backend && go run cmd/crm-api/main.go',
-      url: 'http://localhost:8080/health',
+      url: `${backendURL}/health`,
       reuseExistingServer: !process.env.CI,
       timeout: 120000,
       stdout: 'pipe',
@@ -76,6 +86,8 @@ export default defineConfig({
           process.env.DATABASE_URL ||
           'postgres://crm_user:crm_password@localhost:5432/personal_crm_test?sslmode=disable',
         API_KEY: process.env.API_KEY || 'dev-api-key-change-in-production',
+        PORT: backendPort,
+        FRONTEND_URL: frontendURL,
         MIGRATIONS_PATH: 'migrations',
         CRM_ENV: 'testing',
         ENABLE_EXTERNAL_SYNC: 'true',


### PR DESCRIPTION
## Tier 1: fix the build-bound CI bottleneck

### The reframing

PR #431's earlier within-run `t.Parallel()` work (and the related #430/#428) moved CI wall-clock by ~nil. A wall-clock analysis showed why: **the Backend Tests job is build-bound, not test-bound.** In the ~137s integration step, ~109s is a cold-cache Go build and only ~50s is actual test execution. Parallelizing tests can't help a job dominated by rebuilding the tree from scratch.

Tier 1 fixes the build/cache and job structure instead.

### What landed

**(a) Job split + serial mac_host shared-DB helpers** (validated prior WIP) — The monolithic Backend Tests job is split into **Backend Quality** (lint, invariant guards, ARM64 cross-compile) and **Backend Tests** (unit + integration), which now run in parallel. mac_host API tests are reverted to serial execution against a shared package-clone DB (`newAPISharedTestDB`): mac_host tables are effectively singleton, so per-test `t.Parallel()` + per-test isolated River clones were both unnecessary and a source of cross-test interference. The event-bus and address-book-reconcile suites likewise drop their per-test isolated River clones in favor of the shared DB with a non-started River client (they only need `InsertTx`/`PublishTx`, not a live fetch loop). Consumer-test placeholder workers are replaced with the real `consumerjobs` arg types. The orphaned `newAPIIsolatedTestDB` helper (its `!integration_testdb` fallback already deleted) is removed.

**(b) C1 — GOCACHE warm-cache pin (the big win)** — The Makefile defaults `GOCACHE ?= $(REPO_ROOT)/.gocache` and exports it, so every `make`-invoked Go build in CI ignored `setup-go`'s restored `~/.cache/go-build` and rebuilt cold. A `Pin GOCACHE to setup-go cache` step (`echo "GOCACHE=$(go env GOCACHE)" >> "$GITHUB_ENV"`) is added after each `setup-go` in every Go-building job — Backend Quality, Backend Tests, E2E, and the nightly slow-tests workflow — so `make`-driven builds reuse the warm cache. `go env GOCACHE` returns the default at that point because GOCACHE isn't yet in the shell env (the Makefile only exports it inside `make`), and the Makefile's `?=` then respects the pre-set value. The Makefile default is untouched, so local dev is unaffected.

**(c) C8 — drop `-v` in CI** — `go test` verbosity is now controllable via `GOTEST_VERBOSE ?= -v` (local default keeps `-v`); CI overrides it to empty on the integration step and drops `-v` from the unit step, cutting ~23k log lines. Failures still print.

**(d) C4 — deferred to #432** — Merging the separate unit and integration steps into one `go test -tags integration_testdb ./...` (with `DATABASE_URL` set) was rejected: it breaks `internal/config.TestConfig_Validate_MissingDatabaseURL`, which expects `DATABASE_URL` to be absent and is only exercised today by the no-DB unit step. That changes what runs, so correctness wins over the ~29s. C1 already makes the second build incremental, capturing most of the benefit.

### Expected impact

Backend Tests job ~328s → ~150s. **This CI run is the measurement** — the GOCACHE/job-split win is unmeasurable locally (correctness was verified locally; timing is CI-only). Once it lands, E2E (~200s) becomes the critical path, addressed by Tier 2 in #432.

### Cross-refs

- Tier 2 / Tier 3 follow-ups → #432
- `tests/api` parallelization phase → #429
- Tracking → #413, #424

### Review note

The local Codex CLI was unavailable during implementation (both accounts spent — one usage-limited, one with a revoked refresh token), so the pre-push review gate was Claude `/review-head`, which PASSed (P0=0, P1=0).

### Known non-blockers (from review-head, P2/P3 — fast-follow candidates)

- `nowSuffix()` in `mac_host_scheduler_test.go` uses a clock-based suffix rather than uuid/namespace isolation. No live collision (sole caller, nanosecond resolution); future-proofing nit.
- A no-op `_ = database.Queries.DeleteSyncState` leftover.
- A few stray blank lines.
