### PR TITLE
perf(ci): raise test Postgres max_connections + disable durability

### DIFF
--- a/.ai/spec/2026-06-08-parallel-implementation-isolation-design.md
+++ b/.ai/spec/2026-06-08-parallel-implementation-isolation-design.md
@@ -3,7 +3,7 @@
 **Date:** 2026-06-08
 **Status:** Placeholder skeleton — direction captured during the test-parallelization (i) brainstorm; not yet a full design.
 **Author:** spengrah (brainstormed with Claude)
-**Tracking:** gh issue #424
+**Tracking:** gh issue #433 (re-scoped from #424, which is now the within-run connection-ceiling fix)
 **Related:** `2026-06-07-test-parallelization-design.md` (sub-project i — the within-run sibling; ships the Go template-by-hash enabler this spec assumes), `2026-06-07-deploy-and-staging-overview-design.md`, `2026-05-31-agentic-ux-qa-and-behavior-ssot-design.md` (#380), gh issue #425 (sub-project ii — E2E parallelization).
 
 ## Problem

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,22 +102,6 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.backend == 'true' }}
 
-    services:
-      postgres:
-        image: pgvector/pgvector:pg16
-        env:
-          POSTGRES_DB: personal_crm_test
-          POSTGRES_USER: crm_user_test
-          POSTGRES_PASSWORD: test_password
-          POSTGRES_HOST_AUTH_METHOD: trust
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -134,6 +118,29 @@ jobs:
       - name: Pin GOCACHE to setup-go cache
         run: echo "GOCACHE=$(go env GOCACHE)" >> "$GITHUB_ENV"
 
+      # Disposable CI Postgres: max_connections raised to 200 (#424 connection
+      # ceiling — see PR body for the budget) and durability disabled (fsync /
+      # synchronous_commit / full_page_writes off) for wall-clock; data is
+      # thrown away at job end. services: can't pass server args, so we run it
+      # explicitly. See the connection-budget note in the PR description.
+      - name: Start PostgreSQL
+        run: |
+          docker run -d --name postgres \
+            -e POSTGRES_DB=personal_crm_test \
+            -e POSTGRES_USER=crm_user_test \
+            -e POSTGRES_PASSWORD=test_password \
+            -e POSTGRES_HOST_AUTH_METHOD=trust \
+            -p 5432:5432 \
+            --health-cmd pg_isready \
+            --health-interval 10s \
+            --health-timeout 5s \
+            --health-retries 5 \
+            pgvector/pgvector:pg16 \
+            -c max_connections=200 \
+            -c fsync=off \
+            -c synchronous_commit=off \
+            -c full_page_writes=off
+
       - name: Download Go modules
         working-directory: backend
         run: go mod download
@@ -145,6 +152,27 @@ jobs:
       - name: Wait for PostgreSQL
         run: |
           timeout 30 bash -c 'until pg_isready -h localhost -p 5432; do sleep 1; done'
+
+      - name: Verify Postgres config applied
+        env:
+          # PGPASSWORD covers the e2e password-auth path; harmless for the
+          # backend-tests trust path. Values are the existing non-secret CI
+          # test credentials already present in this workflow.
+          PGHOST: localhost
+          PGPORT: "5432"
+          PGUSER: crm_user_test
+          PGDATABASE: personal_crm_test
+          PGPASSWORD: test_password
+        run: |
+          got=$(psql -tAc 'SHOW max_connections;')
+          echo "max_connections=$got"
+          test "$got" = "200" || { echo "FAIL: max_connections is $got, expected 200"; exit 1; }
+          for kv in "fsync:off" "synchronous_commit:off" "full_page_writes:off"; do
+            name=${kv%%:*}; want=${kv##*:}
+            val=$(psql -tAc "SHOW $name;")
+            echo "$name=$val"
+            test "$val" = "$want" || { echo "FAIL: $name is $val, expected $want"; exit 1; }
+          done
 
       - name: Run integration tests
         env:
@@ -340,21 +368,6 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true' }}
 
-    services:
-      postgres:
-        image: pgvector/pgvector:pg16
-        env:
-          POSTGRES_DB: personal_crm
-          POSTGRES_USER: crm_user
-          POSTGRES_PASSWORD: crm_password
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -370,6 +383,28 @@ jobs:
       # cover any future make-driven build added here).
       - name: Pin GOCACHE to setup-go cache
         run: echo "GOCACHE=$(go env GOCACHE)" >> "$GITHUB_ENV"
+
+      # Disposable CI Postgres: max_connections raised to 200 (#424 connection
+      # ceiling — see PR body for the budget) and durability disabled (fsync /
+      # synchronous_commit / full_page_writes off) for wall-clock; data is
+      # thrown away at job end. services: can't pass server args, so we run it
+      # explicitly. See the connection-budget note in the PR description.
+      - name: Start PostgreSQL
+        run: |
+          docker run -d --name postgres \
+            -e POSTGRES_DB=personal_crm \
+            -e POSTGRES_USER=crm_user \
+            -e POSTGRES_PASSWORD=crm_password \
+            -p 5432:5432 \
+            --health-cmd pg_isready \
+            --health-interval 10s \
+            --health-timeout 5s \
+            --health-retries 5 \
+            pgvector/pgvector:pg16 \
+            -c max_connections=200 \
+            -c fsync=off \
+            -c synchronous_commit=off \
+            -c full_page_writes=off
 
       - name: Download Go modules
         working-directory: backend
@@ -398,6 +433,27 @@ jobs:
       - name: Wait for PostgreSQL
         run: |
           timeout 30 bash -c 'until pg_isready -h localhost -p 5432; do sleep 1; done'
+
+      - name: Verify Postgres config applied
+        env:
+          # PGPASSWORD covers the e2e password-auth path; harmless for the
+          # backend-tests trust path. Values are the existing non-secret CI
+          # test credentials already present in this workflow.
+          PGHOST: localhost
+          PGPORT: "5432"
+          PGUSER: crm_user
+          PGDATABASE: personal_crm
+          PGPASSWORD: crm_password
+        run: |
+          got=$(psql -tAc 'SHOW max_connections;')
+          echo "max_connections=$got"
+          test "$got" = "200" || { echo "FAIL: max_connections is $got, expected 200"; exit 1; }
+          for kv in "fsync:off" "synchronous_commit:off" "full_page_writes:off"; do
+            name=${kv%%:*}; want=${kv##*:}
+            val=$(psql -tAc "SHOW $name;")
+            echo "$name=$val"
+            test "$val" = "$want" || { echo "FAIL: $name is $val, expected $want"; exit 1; }
+          done
 
       - name: Run E2E tests
         working-directory: frontend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,11 +118,12 @@ jobs:
       - name: Pin GOCACHE to setup-go cache
         run: echo "GOCACHE=$(go env GOCACHE)" >> "$GITHUB_ENV"
 
-      # Disposable CI Postgres: max_connections raised to 200 (#424 connection
-      # ceiling — see PR body for the budget) and durability disabled (fsync /
-      # synchronous_commit / full_page_writes off) for wall-clock; data is
-      # thrown away at job end. services: can't pass server args, so we run it
-      # explicitly. See the connection-budget note in the PR description.
+      # Disposable CI Postgres: max_connections raised from the stock 100 to
+      # 200 (#424) to clear the measured ~92-conn peak with headroom for the
+      # #428/#429 per-test-clone scaling; durability disabled (fsync /
+      # synchronous_commit / full_page_writes off) for wall-clock since the
+      # data is thrown away at job end. services: can't pass server args
+      # (the -c flags below sit after the image name), so we run it explicitly.
       - name: Start PostgreSQL
         run: |
           docker run -d --name postgres \
@@ -155,8 +156,8 @@ jobs:
 
       - name: Verify Postgres config applied
         env:
-          # PGPASSWORD covers the e2e password-auth path; harmless for the
-          # backend-tests trust path. Values are the existing non-secret CI
+          # PGPASSWORD set for parity with the e2e job; harmless under the
+          # trust auth this job uses. Values are the existing non-secret CI
           # test credentials already present in this workflow.
           PGHOST: localhost
           PGPORT: "5432"
@@ -384,11 +385,12 @@ jobs:
       - name: Pin GOCACHE to setup-go cache
         run: echo "GOCACHE=$(go env GOCACHE)" >> "$GITHUB_ENV"
 
-      # Disposable CI Postgres: max_connections raised to 200 (#424 connection
-      # ceiling — see PR body for the budget) and durability disabled (fsync /
-      # synchronous_commit / full_page_writes off) for wall-clock; data is
-      # thrown away at job end. services: can't pass server args, so we run it
-      # explicitly. See the connection-budget note in the PR description.
+      # Disposable CI Postgres: max_connections raised from the stock 100 to
+      # 200 (#424) to clear the measured ~92-conn peak with headroom for the
+      # #428/#429 per-test-clone scaling; durability disabled (fsync /
+      # synchronous_commit / full_page_writes off) for wall-clock since the
+      # data is thrown away at job end. services: can't pass server args
+      # (the -c flags below sit after the image name), so we run it explicitly.
       - name: Start PostgreSQL
         run: |
           docker run -d --name postgres \


### PR DESCRIPTION
Closes #424.

## What

Replace the GitHub Actions managed `services: postgres` containers in the **backend-tests** and **e2e-tests** jobs of `ci.yml` with explicit `docker run` steps, so we can pass server args after the image name (which `services:` cannot express). On both disposable CI Postgres instances we now set `-c max_connections=200 -c fsync=off -c synchronous_commit=off -c full_page_writes=off`, and add a "Verify Postgres config applied" step that asserts every param actually took effect over the same TCP + auth path the tests use, failing the job loudly if any silently did not apply.

## Connection budget (the #424 ceiling fix)

The budget rule (from #424): `concurrent_test_DBs × per-test_pool_MaxConns + maintenance/overhead < max_connections`. The backend-tests job runs `make test-integration-fast` at `-p 4 × -parallel 4`; per-test pools are 15 conns in `tests/api` + `internal/todoist`, 8 in most of `tests/`, 6 in river-isolated, plus a per-process migrator pool (2), transient testdb admin conns (1 each), and ~3 River internals per live client. The **measured** pressure in #424 is ~92 conns at the current shape against the stock `max_connections = 100` (~97 usable after `superuser_reserved_connections = 3`). Raising to 200 (~197 usable) roughly doubles real headroom and clears today's ~92 with margin. The durable artifact is the *rule* (and the ~92/97 datapoint), not the literal 200 — it is a round, conventional CI value chosen for headroom, not a tuned exact number. This is NOT a proof that any arbitrary future concurrency increase is safe: #428 (river-core ephemeral clones), #429 (tests/api flip), and the Tier-3 adaptive-`-parallel` work (#432) must each re-check the budget rule against their new shape and raise the ceiling further if needed.

Durability flags are disabled because both CI Postgres instances are created fresh per job and thrown away at job end, so `fsync` / `synchronous_commit` / `full_page_writes` buy nothing and only cost fsync stalls on every migration/seed/commit. They affect crash durability only, never query results or transaction visibility, so this is transparent to the suite on a disposable DB.

## Why Approach A (explicit `docker run`), not B

`max_connections` is postmaster-context (`PGC_POSTMASTER`) — it requires a full server **restart**; `ALTER SYSTEM SET max_connections = 200` + `pg_reload_conf()` is insufficient. The two real options were (A) replace the `services:` container with an explicit `docker run ... -c ...` that sets all four params at postmaster startup, or (B) keep `services:` and `docker restart` it after `ALTER SYSTEM`. We chose **A**: one mechanism (all four params set identically at startup, no restart moving-part), no fight with the Actions runner's service-harness lifecycle (B's mid-job `docker restart` races that harness and is a known flakiness source), the existing "Wait for PostgreSQL" `pg_isready` loop is exactly the readiness gate A needs, and verifiability is built in via the new Verify step. There is no `services.<id>.command` key in GitHub Actions workflow syntax (that is a docker-compose-only key), so A and B were the only two viable options.

## Local dev Postgres is out of scope

`crm-postgres` holds real dev data and is untouched. #424's local opt-in path is documentation-only and intentionally deferred: a dev who hits the connection wall locally raises `DB_MAX_CONNS` (already an env knob in `config.Load`) or runs a separate disposable test instance — no code/Makefile change needed in this PR.

## Test plan

- The in-CI "Verify Postgres config applied" step is the primary correctness gate (present in both jobs): it fails the job if `max_connections != 200` or any durability flag is not `off`, asserted over `-h localhost -p 5432` as the test user (the real TCP/auth surface, not the in-container socket).
- Suite-green on both jobs proves the `docker run` swap is behaviorally transparent (same DB name/user/password/port, same readiness gate; backend keeps `POSTGRES_HOST_AUTH_METHOD=trust`, e2e keeps password auth — not crossed).
- Local pre-push (lint + Go/frontend/E2E suites against untouched local `crm-postgres`) passed.

## Timing (before / after)

Baseline (post-#431 `main`): Backend Tests 121s, E2E Tests 198s. After (this branch's green CI run): Backend Tests 106s (~12% faster), E2E Tests 181s (~9% faster). Both Postgres-backed jobs executed and their "Verify Postgres config applied" steps confirmed `max_connections=200` and `fsync` / `synchronous_commit` / `full_page_writes` all `off`.

## Links

- Plan: `.ai/log/plan/2026-06-09-ci-postgres-tuning-and-connection-ceiling.md`
- Umbrella: #432 (test-suite wall-clock, Tier 2 item 1a)

