### PR TITLE
perf(ci): rolling go build cache via explicit actions/cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,14 +40,44 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.23'
-          cache-dependency-path: backend/go.sum
+          cache: false
+
+      # Rolling Go module download cache. Per-job primary key (trailing token)
+      # so the three parallel Go jobs never race to save the same key, with a
+      # shared restore-keys prefix so they still restore each other's identical
+      # module set (on subsequent runs; saves land post-job, so this warms a
+      # sibling job on a LATER run, not the others running concurrently here).
+      # go.sum-keyed: rolls only when dependencies change.
+      - name: Cache Go module download cache
+        uses: actions/cache@v4
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-${{ runner.os }}-go1.23-${{ hashFiles('backend/go.sum') }}-quality
+          restore-keys: |
+            go-mod-${{ runner.os }}-go1.23-${{ hashFiles('backend/go.sum') }}-
+            go-mod-${{ runner.os }}-go1.23-
+
+      # Rolling Go build cache. SHA-keyed so every run misses its exact key and
+      # saves a fresh entry; restore-keys brings the most recent prior build
+      # cache forward so warmth compounds across CI runs. Namespaced per job
+      # because each job has a distinct build config (arm64 cross-compile plus
+      # amd64 lint/analysis here).
+      - name: Cache Go build cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/go-build
+          key: go-build-quality-${{ runner.os }}-go1.23-${{ github.sha }}
+          restore-keys: |
+            go-build-quality-${{ runner.os }}-go1.23-
 
       # The Makefile defaults GOCACHE to a workspace-local dir via `?=`, which
-      # would bypass setup-go's restored ~/.cache/go-build for every make-driven
-      # Go build. Pin GOCACHE to setup-go's default so make-invoked builds reuse
-      # the warm cache. `go env GOCACHE` returns the default here because GOCACHE
-      # is not set in the shell env (the Makefile only exports it inside make).
-      - name: Pin GOCACHE to setup-go cache
+      # would bypass the restored ~/.cache/go-build for every make-driven Go
+      # build. Pin GOCACHE to that warm dir so make-invoked builds reuse the
+      # cache restored by the explicit actions/cache step above (setup-go's
+      # built-in cache is disabled via `cache: false`). `go env GOCACHE`
+      # returns the default ~/.cache/go-build here because GOCACHE is not set
+      # in the shell env (the Makefile only exports it inside make).
+      - name: Pin GOCACHE to the restored go-build cache
         run: echo "GOCACHE=$(go env GOCACHE)" >> "$GITHUB_ENV"
 
       - name: Download Go modules
@@ -110,12 +140,41 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.23'
-          cache-dependency-path: backend/go.sum
+          cache: false
+
+      # Rolling Go module download cache. Per-job primary key (trailing token)
+      # so the three parallel Go jobs never race to save the same key, with a
+      # shared restore-keys prefix so they still restore each other's identical
+      # module set (on subsequent runs; saves land post-job, so this warms a
+      # sibling job on a LATER run, not the others running concurrently here).
+      # go.sum-keyed: rolls only when dependencies change.
+      - name: Cache Go module download cache
+        uses: actions/cache@v4
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-${{ runner.os }}-go1.23-${{ hashFiles('backend/go.sum') }}-tests
+          restore-keys: |
+            go-mod-${{ runner.os }}-go1.23-${{ hashFiles('backend/go.sum') }}-
+            go-mod-${{ runner.os }}-go1.23-
+
+      # Rolling Go build cache. SHA-keyed so every run misses its exact key and
+      # saves a fresh entry; restore-keys brings the most recent prior build
+      # cache forward so warmth compounds across pushes. Namespaced per job
+      # because each job has a distinct build config (amd64 with the
+      # integration_testdb build tag here).
+      - name: Cache Go build cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/go-build
+          key: go-build-tests-${{ runner.os }}-go1.23-${{ github.sha }}
+          restore-keys: |
+            go-build-tests-${{ runner.os }}-go1.23-
 
       # See backend-quality: pin GOCACHE so make-invoked builds (the
-      # integration step calls `make test-integration-fast`) reuse setup-go's
-      # warm cache instead of the Makefile's workspace-local default.
-      - name: Pin GOCACHE to setup-go cache
+      # integration step calls `make test-integration-fast`) reuse the
+      # ~/.cache/go-build restored by the explicit actions/cache step above
+      # instead of the Makefile's workspace-local default.
+      - name: Pin GOCACHE to the restored go-build cache
         run: echo "GOCACHE=$(go env GOCACHE)" >> "$GITHUB_ENV"
 
       # Disposable CI Postgres: max_connections raised from the stock 100 to
@@ -377,12 +436,41 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.23'
-          cache-dependency-path: backend/go.sum
+          cache: false
+
+      # Rolling Go module download cache. Per-job primary key (trailing token)
+      # so the three parallel Go jobs never race to save the same key, with a
+      # shared restore-keys prefix so they still restore each other's identical
+      # module set (on subsequent runs; saves land post-job, so this warms a
+      # sibling job on a LATER run, not the others running concurrently here).
+      # go.sum-keyed: rolls only when dependencies change.
+      - name: Cache Go module download cache
+        uses: actions/cache@v4
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-${{ runner.os }}-go1.23-${{ hashFiles('backend/go.sum') }}-e2e
+          restore-keys: |
+            go-mod-${{ runner.os }}-go1.23-${{ hashFiles('backend/go.sum') }}-
+            go-mod-${{ runner.os }}-go1.23-
+
+      # Rolling Go build cache. SHA-keyed so every run misses its exact key and
+      # saves a fresh entry; restore-keys brings the most recent prior build
+      # cache forward so warmth compounds across pushes. Namespaced per job
+      # because each job has a distinct build config (plain amd64 `go run` here).
+      - name: Cache Go build cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/go-build
+          key: go-build-e2e-${{ runner.os }}-go1.23-${{ github.sha }}
+          restore-keys: |
+            go-build-e2e-${{ runner.os }}-go1.23-
 
       # The Playwright webServer launches the backend via `go run`; pin GOCACHE
-      # to setup-go's warm cache for consistency with the backend jobs (and to
-      # cover any future make-driven build added here).
-      - name: Pin GOCACHE to setup-go cache
+      # to the ~/.cache/go-build restored by the explicit actions/cache step
+      # above for consistency with the backend jobs (and to cover any future
+      # make-driven build added here). setup-go's built-in cache is disabled
+      # via `cache: false`.
+      - name: Pin GOCACHE to the restored go-build cache
         run: echo "GOCACHE=$(go env GOCACHE)" >> "$GITHUB_ENV"
 
       # Disposable CI Postgres: max_connections raised from the stock 100 to


### PR DESCRIPTION
## Summary

Rolling, SHA-keyed Go build cache (per-job) plus a `go.sum`-keyed module cache (per-job save key, shared restore prefix) for the three Go-building jobs in `ci.yml` (`backend-quality`, `backend-tests`, `e2e-tests`), replacing `setup-go@v5`'s built-in `go.sum`-only cache. `setup-go`'s built-in cache only SAVES on a `go.sum` change, so #431's GOCACHE warmth decays between dependency bumps instead of compounding across commits. This makes that warmth compound across CI runs in the interactive `ci.yml` workflow (the PR critical path).

This is #432 Tier 2 item 1b (rolling go-build cache). It builds on #431 (which added the GOCACHE pin steps this PR makes compounding) and #434 (the merged Postgres tuning that established the post-1a baseline).

## Design

CI-YAML-only change. For each of the three Go jobs:
- `cache: false` on the `actions/setup-go@v5` step (disables the built-in cache) and drops the now-inert `cache-dependency-path: backend/go.sum` line. `go-version: '1.23'` is preserved verbatim (the `go.mod` 1.25.0 vs CI 1.23 mismatch is pre-existing and out of scope).
- A **SHA-keyed build cache** (`~/.cache/go-build`, key `go-build-<job>-${{ runner.os }}-go1.23-${{ github.sha }}`) that always misses its exact per-run key and saves a fresh entry every run, with `restore-keys` bringing the most recent prior entry forward so warmth compounds across pushes. Namespaced per job because each job has a distinct build config (arm64 cross-compile in `backend-quality`, `integration_testdb`-tagged amd64 in `backend-tests`, plain amd64 in `e2e-tests`).
- A **`go.sum`-keyed module cache** (`~/go/pkg/mod`) that rolls only on dependency changes. The primary key carries a trailing `<job>` token (so the three parallel jobs never race to save the same key) plus a shared `restore-keys` prefix (so they still restore each other's identical module set).
- The GOCACHE pin step's `echo` command is unchanged (it still resolves to `~/.cache/go-build`, now restored by `actions/cache`); only its name and comment were refreshed.

The per-job key namespacing is what avoids "Cache already exists" parallel-save collisions across the three concurrent jobs. The build cache is content-addressed, so a cross-config restore is always safe (mismatched entries miss and recompile, never a wrong object).

**Scope clarity:** "compounds across CI runs" means the interactive `ci.yml` workflow only. The nightly/manual `backend-slow-tests.yml` still uses `setup-go`'s built-in cache and is a deliberate follow-on, not covered here.

## Measurement caveat (honest, for a rolling cache)

A rolling SHA-keyed cache cannot show its win on the first run: the first CI run on this branch restores cold (or from `main`'s prefix once `main` has run under this scheme), so it won't be faster. The compounding benefit appears on the SECOND push (a new SHA → primary-key miss → `restore-keys` fallback to the first push's own entry → warm restore). The second push is produced by amending the single commit (keeping the PR at one commit), not by adding a second commit. A workflow *re-run* reuses the same SHA and would exact-hit, so it is NOT a valid measurement substitute.

Baseline reference (post-1a): Backend Quality ~137s, Backend Tests ~106s, E2E ~181s.

Build/compile-portion timings, cold first run (SHA `eb13761`, run 27235736380) -> warm second run (SHA `a74e927`, run 27236167098). The warm run restored the cold run's build cache via the `restore-keys` prefix in every job:

- **Backend Quality** (golangci-lint compile + arm64 cross-compile + `go mod download`): ~173s -> ~12s. golangci-lint 88s -> 8s; arm64 `crm-api` cross-compile 72s -> 3s; arm64 `crm-admin` 3s -> 1s; module download 10s -> 0s.
- **Backend Tests** (unit compile + integration + `go mod download`): ~154s -> ~31s. unit-test build/run 112s -> 4s; integration 32s -> 27s; module download 10s -> 0s.

The compile-dominated steps drop ~90%+ on the warm run, which is the compounding win this change unlocks. (E2E's Go portion is a single `go run` started by Playwright's webServer and is not separately timed; it restores its build cache identically.)

## Verification

- Both CI runs fully green (cold and warm), correctness gate met.
- **No "Cache already exists" / overlap warnings in any of the three Go jobs' cache steps on either run** (the parallel-save-race gate — confirmed via the cache-step logs).
- Cache restore/save steps ran in every job: cold run saved all 6 entries under their SHA/go.sum keys; warm run restored the build cache via `restore-keys` (prior SHA) and the module cache via an exact go.sum hit, then re-saved the build cache under the new SHA.

Refs #432

