### PR TITLE
perf(ci): shard playwright e2e across 2 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -423,10 +423,14 @@ jobs:
         run: swift test --filter 'BundleAssemblyParityTests|BundleSwapAtomicityTests'
 
   e2e-tests:
-    name: E2E Tests
+    name: E2E Tests (shard ${{ matrix.shard }})
     runs-on: ubuntu-latest
     needs: changes
     if: ${{ needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
 
     steps:
       - name: Checkout code
@@ -443,12 +447,15 @@ jobs:
       # shared restore-keys prefix so they still restore each other's identical
       # module set (on subsequent runs; saves land post-job, so this warms a
       # sibling job on a LATER run, not the others running concurrently here).
-      # go.sum-keyed: rolls only when dependencies change.
+      # go.sum-keyed: rolls only when dependencies change. The trailing
+      # ${{ matrix.shard }} makes the two concurrent E2E shards save
+      # collision-free; the shared restore-keys prefix still lets a shard
+      # restore the other shard's most-recent entry (identical module set).
       - name: Cache Go module download cache
         uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
-          key: go-mod-${{ runner.os }}-go1.23-${{ hashFiles('backend/go.sum') }}-e2e
+          key: go-mod-${{ runner.os }}-go1.23-${{ hashFiles('backend/go.sum') }}-e2e-${{ matrix.shard }}
           restore-keys: |
             go-mod-${{ runner.os }}-go1.23-${{ hashFiles('backend/go.sum') }}-
             go-mod-${{ runner.os }}-go1.23-
@@ -457,11 +464,16 @@ jobs:
       # saves a fresh entry; restore-keys brings the most recent prior build
       # cache forward so warmth compounds across pushes. Namespaced per job
       # because each job has a distinct build config (plain amd64 `go run` here).
+      # The trailing ${{ matrix.shard }} makes the two concurrent E2E shards
+      # save collision-free (same SHA otherwise collides); the shared
+      # restore-keys prefix lets a shard restore the other shard's most-recent
+      # entry (the backend binary is identical across shards, so the cross-shard
+      # restore is content-addressed-safe and genuinely warm).
       - name: Cache Go build cache
         uses: actions/cache@v4
         with:
           path: ~/.cache/go-build
-          key: go-build-e2e-${{ runner.os }}-go1.23-${{ github.sha }}
+          key: go-build-e2e-${{ runner.os }}-go1.23-${{ github.sha }}-${{ matrix.shard }}
           restore-keys: |
             go-build-e2e-${{ runner.os }}-go1.23-
 
@@ -562,13 +574,13 @@ jobs:
           FRONTEND_URL: http://localhost:3000
           CRM_ENV: testing
           ENABLE_EXTERNAL_SYNC: true
-        run: bunx playwright test --project=chromium
+        run: bunx playwright test --project=chromium --shard=${{ matrix.shard }}/2
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
-          name: playwright-report
+          name: playwright-report-shard-${{ matrix.shard }}
           path: frontend/playwright-report/
           retention-days: 7
 
@@ -576,6 +588,27 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: playwright-traces
+          name: playwright-traces-shard-${{ matrix.shard }}
           path: frontend/test-results/
           retention-days: 7
+
+  # Stable required-check surface over the E2E shard matrix. The matrix legs
+  # report as "E2E Tests (shard 1)" / "E2E Tests (shard 2)"; this aggregator
+  # owns the bare "E2E Tests" name so any branch-protection rule pinning it
+  # stays satisfied with no admin change. needs:[e2e-tests] collapses the
+  # matrix into one result that is success only if every leg passed; always()
+  # lets it run and fail loudly when a shard failed (instead of being skipped).
+  # The changes guard mirrors the matrix trigger so the aggregator is SKIPPED
+  # (treated as satisfied by branch protection) on a docs-only PR.
+  e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    needs: [changes, e2e-tests]
+    if: ${{ always() && (needs.changes.outputs.backend == 'true' || needs.changes.outputs.frontend == 'true') }}
+    steps:
+      - name: Assert all E2E shards passed
+        env:
+          E2E_RESULT: ${{ needs.e2e-tests.result }}
+        run: |
+          echo "e2e-tests matrix result: $E2E_RESULT"
+          test "$E2E_RESULT" = "success" || { echo "FAIL: one or more E2E shards did not pass"; exit 1; }


### PR DESCRIPTION
## Summary

#432 Tier 2 item 2a — shard the Playwright E2E suite 2 ways via a GitHub Actions job matrix, roughly halving the test-EXECUTION portion of CI's critical path. Each shard is a fully independent runner (own Postgres / backend / frontend / DB); the E2E critical path becomes the SLOWER of the two concurrently-running shards.

CI-config only — no production logic, schema, UI, or Go/TS source change.

## Key changes (all in `.github/workflows/ci.yml`)

- **2-way matrix** on the `e2e-tests` job: `strategy.matrix.shard: [1, 2]`, `fail-fast: false` (so a failure in one shard doesn't cancel the other and destroy half the signal). Each leg is a separate `ubuntu-latest` runner running the whole self-contained step list (its own `docker run` Postgres, its own `go run` backend + frontend via the Playwright `webServer`). `--shard=${{ matrix.shard }}/2` partitions the spec files deterministically.
- **Per-shard Go cache-key namespacing (the load-bearing correctness fix).** The rolling Go cache primary keys (build + module, from #435) gain a trailing `-${{ matrix.shard }}` suffix so the two concurrent same-SHA shards SAVE collision-free. The `restore-keys` prefixes are left exactly as #435 had them, so each shard still restores the other shard's most-recent (content-identical) entry — cross-shard restore is content-addressed-safe, the backend binary is identical across shards.
- **`E2E Tests` aggregator job** (`needs: [changes, e2e-tests]`) that AND-gates the matrix legs (`needs.e2e-tests.result == success`), so a stable check named exactly `E2E Tests` keeps reporting and any branch-protection rule pinning it stays satisfied with no admin change. `main` currently has no branch protection, so this is belt-and-suspenders. `always()` + the `changes` guard make it run-and-fail-loudly on a real failure and SKIP (treated as satisfied) on docs-only PRs. The matrix result is passed into the assertion via `env:` rather than inlined `${{ }}` in the shell.

- **Shard-unique artifact names** (`playwright-report-shard-N` / `playwright-traces-shard-N`) to avoid the `actions/upload-artifact@v4` duplicate-name error within a single run.

## Worker count: 4 (final, documented winner)

`PLAYWRIGHT_WORKERS` stays at **4** per shard. This is a deliberate, recorded outcome — not a silent cap. The residual E2E critical path is **SETUP-bound, not test-bound**: on the baseline run the slower shard's TOTAL job wall-clock was 147s but its "Run E2E tests" STEP was only ~59s, so ~88s is fixed setup (docker Postgres start / `go run` backend build / `bun install` / Playwright browser install) plus inter-shard variance. Worker count only shrinks the ~59–66s test step, which is the MINORITY term. So 3 vs 6 were not exhaustively measured on-CI: 3 reduces parallelism (almost certainly slower) and 6 adds flake risk against the known E2E cross-worker gotchas (`navigateModalToCandidate`, strict-mode collisions) for a ceiling capped by the dominant setup term. The sharding itself captured the win; shrinking the fixed setup floor (prebuilt backend binary, warmed installs) is the deferred follow-on under #432.

## Before / after (measured on CI)

- **E2E critical path** (slower of the two concurrent shards, total job wall-clock): **147s vs the ~181s single-job baseline** (~19% / ~34s reduction, at the plan's ~145s target band). shard1 131s, shard2 147s.
- **Slower-shard "Run E2E tests" step**: 66s (shard1) / 59s (shard2).
- **Partition proof** (identity, not just count): shard1 = 78 tests, shard2 = 78 tests, intersection = 0 (DISJOINT — no double-run), union = 156 = the full `--project=chromium` set (no dropped test).
- **Per-shard isolation**: each shard ran its own `docker run --name postgres` with `max_connections=200`.
- **Cache no-collision gate PASS**: both shards saved distinct shard-suffixed Go keys (`go-build-...-<sha>-1`/`-2`, `go-mod-...-e2e-1`/`-e2e-2`) — zero "Cache already exists" save-collision warnings on either Go cache. (The shared Playwright-browser cache key is deliberately NOT shard-suffixed to avoid doubling the Chromium download; a benign cold-run "Cache already exists" there is accepted and self-healing.)

## Goal framing (honest)

"Roughly halve" applies to the test-EXECUTION portion. TOTAL E2E job wall-clock does NOT halve — each shard independently pays the full FIXED per-runner floor, which does not shard (see the setup-bound analysis above). The gate is the measured critical-path REDUCTION, met at 147s.

## Not touched

- `path-filters.yml` — a matrix does not change triggering (the `if:` gate is evaluated once, then fanned out).
- `Makefile` — `test-e2e` is the LOCAL entrypoint; CI calls `bunx playwright test` directly. Local E2E stays unsharded.

Plan: `.ai/log/plan/2026-06-09-ci-e2e-playwright-sharding.md`
Refs #432

## Final-run cache note (9ab1b14, run 27239033006 — GREEN)

The load-bearing SHA-keyed **build** cache saved collision-free on both shards (distinct `go-build-...-<sha>-1` / `-2` keys). On the final run the **module** cache was a cold miss on both shards, so both saved fresh concurrently and GitHub's cache backend logged a benign `Failed to save: Unable to reserve cache ... another job may be creating this cache` on each. This is a CONTENT-level reservation race across the concurrently-running Go jobs (the `~/go/pkg/mod` tarball is byte-identical across `-quality` / `-tests` / `-e2e-1` / `-e2e-2`), NOT a key collision between the two e2e shards (their keys differ by the `-${{ matrix.shard }}` suffix exactly as designed). Both `Post Cache` steps still concluded `success`, the run is green, and it is self-healing (one writer wins; the entry is present for the next run to restore). It is timing-dependent (the earlier baseline run had a warm restore and showed clean saves).
