### PR TITLE
perf(ci): serve e2e frontend as prod build (experiment)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -521,6 +521,25 @@ jobs:
         working-directory: frontend
         run: bun install
 
+      # Rolling Next.js webpack build cache (`frontend/.next/cache`, tens of MB).
+      # SHA-keyed so every run misses its exact key and saves a fresh entry;
+      # restore-keys brings the most recent prior cache forward so an
+      # incremental `next build` compounds warmth across pushes. bun.lock-pinned
+      # prefix rolls on a deps change; the looser runner.os fallback still
+      # restores something warm-ish on a deps bump. The trailing
+      # ${{ matrix.shard }} makes the two concurrent shards save collision-free;
+      # the shared restore-keys prefix omits the shard suffix so a shard
+      # restores the most-recent entry from EITHER shard (both build the
+      # identical app, so the webpack cache is content-addressed-safe to share).
+      - name: Cache Next.js build cache
+        uses: actions/cache@v4
+        with:
+          path: frontend/.next/cache
+          key: next-build-${{ runner.os }}-${{ hashFiles('frontend/bun.lock') }}-${{ github.sha }}-${{ matrix.shard }}
+          restore-keys: |
+            next-build-${{ runner.os }}-${{ hashFiles('frontend/bun.lock') }}-
+            next-build-${{ runner.os }}-
+
       - name: Cache Playwright browsers
         uses: actions/cache@v4
         id: playwright-cache
@@ -556,6 +575,28 @@ jobs:
             echo "$name=$val"
             test "$val" = "$want" || { echo "FAIL: $name is $val, expected $want"; exit 1; }
           done
+
+      # Build the frontend as a production standalone artifact ahead of the
+      # timed test run, so Playwright's webServer just boots `server.js` instead
+      # of paying next dev's on-demand route compilation during the suite. Kept
+      # as its own visible step (not folded into the webServer command) so the
+      # build duration is measurable in the step timings. The standalone server
+      # bundles neither `.next/static` nor `public`, so we copy both alongside
+      # `server.js`, mirroring scripts/deploy.sh. NEXT_PUBLIC_* are inlined at
+      # build time, so the values the suite needs are set HERE. We deliberately
+      # OMIT NEXT_PUBLIC_BUILD_VERSION/COMMIT_HASH/GITHUB_REPO: the settings spec
+      # asserts the Version field reads "Personal CRM (dev)", which only holds
+      # when NEXT_PUBLIC_BUILD_VERSION is unset.
+      - name: Build frontend (prod)
+        working-directory: frontend
+        env:
+          CI: true
+          NEXT_PUBLIC_API_KEY: test-api-key-for-ci
+          NEXT_PUBLIC_API_URL: http://localhost:8080
+        run: |
+          bun run build
+          cp -r .next/static .next/standalone/.next/static
+          cp -r public .next/standalone/public
 
       - name: Run E2E tests
         working-directory: frontend

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -6,6 +6,19 @@ const backendPort = process.env.E2E_BACKEND_PORT || '8080'
 const frontendURL = `http://localhost:${frontendPort}`
 const backendURL = `http://localhost:${backendPort}`
 
+// CI serves a production standalone build (built ahead of time in the e2e job,
+// with `.next/static` + `public` copied alongside `server.js` the way deploy
+// does) to remove next dev's on-demand route compilation from the timed run.
+// Locally (CI unset) we keep `next dev` for fast iteration and no build cost.
+// Value-based check (the string 'true') so a local `CI=0`/`CI=false` does not
+// select the prod path. `next start` is deliberately NOT used: it is disclaimed
+// under `output: 'standalone'`, so we run the standalone server directly.
+const isCI = process.env.CI === 'true'
+const frontendCommand = isCI
+  ? 'node .next/standalone/server.js'
+  : 'bun run dev -- --hostname 127.0.0.1'
+const frontendNodeEnv = isCI ? 'production' : 'development'
+
 export default defineConfig({
   testDir: './tests/e2e',
   fullyParallel: true,
@@ -57,15 +70,16 @@ export default defineConfig({
   /* Run your local dev server before starting the tests */
   webServer: [
     {
-      command: 'bun run dev -- --hostname 127.0.0.1',
+      command: frontendCommand,
       url: frontendURL,
       reuseExistingServer: !process.env.CI,
       timeout: 120000,
       stdout: 'pipe',
       env: {
         ...process.env,
-        NODE_ENV: 'development',
+        NODE_ENV: frontendNodeEnv,
         PORT: frontendPort,
+        HOSTNAME: '127.0.0.1',
         NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL || backendURL,
         NEXT_PUBLIC_API_KEY:
           process.env.NEXT_PUBLIC_API_KEY ||


### PR DESCRIPTION
## What & why

**#432 Tier 2 item 2b — E2E frontend prod-build EXPERIMENT.** This is **measurement-gated**: it may be **adopted (merged)** or **closed without merge**, and a documented "skip" is a fully valid outcome. References #432 (no `Closes`).

CI-only switch of the Playwright E2E frontend webServer from `next dev` to a production standalone build (`node .next/standalone/server.js`), gated on `process.env.CI === 'true'`. Local `make test-e2e*` stays on `next dev` (no behavior change, no local build cost). The hypothesis: serving a prebuilt prod artifact removes `next dev`'s on-demand route compilation from the timed test run, at the cost of a new per-shard `next build` step.

## Changes (2 files only)

- `frontend/playwright.config.ts` — `webServer[0]` command branches on `process.env.CI === 'true'`: CI runs `node .next/standalone/server.js` (`NODE_ENV=production`), local stays on `bun run dev` (`NODE_ENV=development`). Adds `HOSTNAME: 127.0.0.1`. `reuseExistingServer`, timeout, ports, existing `NEXT_PUBLIC_*` env, and the backend `webServer[1]` unchanged.
- `.github/workflows/ci.yml` (`e2e-tests` job) — adds a rolling, shard-namespaced `actions/cache@v4` for `frontend/.next/cache` (SHA-keyed + `bun.lock`/`runner.os` restore-keys, mirroring the existing Go/Playwright cache pattern), and a visible `Build frontend (prod)` step (`bun run build` then copies `.next/static` + `public` into `.next/standalone`, mirroring `scripts/deploy.sh`). Build env sets only `NEXT_PUBLIC_API_KEY`/`NEXT_PUBLIC_API_URL`/`CI` and **hard-omits** `NEXT_PUBLIC_BUILD_VERSION`/`COMMIT_HASH`/`GITHUB_REPO` (the settings spec asserts the Version field reads `Personal CRM (dev)`, which requires `NEXT_PUBLIC_BUILD_VERSION` unset).

`next start` is deliberately NOT used — it is disclaimed under `output: 'standalone'`; we serve the standalone artifact directly, the same model deploy runs.

## The binary decision rule (pre-committed, plan §5)

- `W` = the **warm** run's E2E critical path = **max(shard1, shard2) total job wall-clock**.
- `B_eval` = a live recent `main` e2e slower-shard wall-clock (fallback historical `147s`). `T = B_eval − 15`.
- **ADOPT iff `W < T`** (strict net improvement > 15s). **Otherwise SKIP** — close the PR, document the negative result. No reinterpretation.

Cold run only proves correctness (suite green, standalone serves, no 401s, settings spec still reads `Personal CRM (dev)`); only the **warm** run gates.

## Measurement (run 27241497924, SHA 6226235; warm = same-SHA rerun)

| run | cache | shard | build (s) | test step (s) | job wall-clock (s) |
|-----|-------|-------|-----------|---------------|--------------------|
| cold | miss | 1 | 35 | 34 | 155 |
| cold | miss | 2 | 36 | 32 | 133 |
| warm | hit  | 1 | 24 | 31 | 118 |
| warm | hit  | 2 | 24 | 27 | **119** |

- Cache: cold = "Cache not found" both shards, each saved its own per-shard key (`…-1` / `…-2`, collision-free). Warm = exact-primary-key **Cache hit** on both shards (true warm restore of the intended lineage, not a loose `restore-keys` fallback). No collision / save-failure warnings.
- All four shard legs + the `E2E Tests` aggregator: **GREEN**. No 401 wall; settings spec passed (Version omission held).

## Decision

- `W` = warm slower shard = **119s** (shard 2).
- `B_live` = base `main` run 27239343613 @ 838c75e, slower shard = **154s**. → `B_eval = 154`, `T = 154 − 15 = 139`.
- `W < T` → **119 < 139** → **ADOPT**. Net improvement `B_eval − W = 35s`.
- Also clears the conservative historical fallback (`B=147`, `T=132`): `119 < 132`, net 28s.

**Recommendation: ADOPT.** Final adopt/close call is the coordinator's.

## Test plan

- The E2E suite IS the functional test — GREEN on both shards, cold + warm, under the prod build.
- Local non-regression: `make test-e2e-diff` (CI unset) still spawns `next dev`, not the standalone server.
- Verified locally before push: prod build succeeds, asset-copy produces the correct standalone layout, the standalone server boots (~108ms) and serves HTTP 200.

Plan: `.ai/log/plan/2026-06-09-ci-e2e-frontend-prod-build-experiment.md`