### PR TITLE
perf: Tier 3 local loop — adaptive -p/-parallel + pre-push phase parallelism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,27 @@ GOCACHE ?= $(REPO_ROOT)/.gocache
 export GOCACHE
 
 TEST_DATABASE_URL ?= postgres://crm_user:crm_password@localhost:5432/personal_crm_test?sslmode=disable
+
+# Adaptive LOCAL -p/-parallel for the integration recipes. The formula lives
+# ONLY in scripts/test-parallelism.sh; the Makefile just calls it. Lazy `=` +
+# `$(eval ...)` memo so the script runs at most ONCE per `make`, and ONLY when
+# an integration recipe expands $(TEST_P) — never on `make help`/`make build`.
+# TEST_DATABASE_URL/PER_BINARY_CONN_EST are passed explicitly because $(shell)
+# does NOT inherit Make variables as env vars automatically.
+ADAPTIVE_P = $(eval ADAPTIVE_P := $(shell TEST_DATABASE_URL='$(TEST_DATABASE_URL)' PER_BINARY_CONN_EST='$(PER_BINARY_CONN_EST)' bash scripts/test-parallelism.sh))$(ADAPTIVE_P)
+
+# CI pins the historical 4/4 (the CI Postgres + go-build concurrency are tuned
+# for it; raising it there is out of scope). Gate on GITHUB_ACTIONS (GHA sets it
+# "true" in every job), NOT bare CI (a local tool could export CI). The CI
+# branch is a `:=` constant — no probe runs in CI.
+ifeq ($(GITHUB_ACTIONS),true)
+  TEST_P := 4
+  TEST_PARALLEL := 4
+else
+  TEST_P = $(ADAPTIVE_P)
+  TEST_PARALLEL = $(ADAPTIVE_P)
+endif
+
 E2E_DATABASE_NAME ?= personal_crm_test
 E2E_DATABASE_URL ?= postgres://crm_user:crm_password@localhost:5432/$(E2E_DATABASE_NAME)?sslmode=disable
 E2E_FRONTEND_PORT ?= 3000
@@ -336,15 +357,15 @@ test-unit:
 
 test-integration-fast:
 	@echo "Running backend integration tests (default set)..."
-	@cd backend && DATABASE_URL="$(TEST_DATABASE_URL)" go test -tags integration_testdb -count=1 -parallel 4 -p 4 ./tests/... ./internal/todoist/... ./internal/google/... ./internal/testdb/... $(GOTEST_VERBOSE)
+	@cd backend && DATABASE_URL="$(TEST_DATABASE_URL)" go test -tags integration_testdb -count=1 -parallel $(TEST_PARALLEL) -p $(TEST_P) ./tests/... ./internal/todoist/... ./internal/google/... ./internal/testdb/... $(GOTEST_VERBOSE)
 
 test-integration:
 	@echo "Running backend integration tests..."
-	@cd backend && DATABASE_URL="$(TEST_DATABASE_URL)" LONG_TESTS=1 go test -tags integration_testdb -count=1 -parallel 4 -p 4 ./tests/... ./internal/todoist/... ./internal/google/... ./internal/testdb/... $(GOTEST_VERBOSE)
+	@cd backend && DATABASE_URL="$(TEST_DATABASE_URL)" LONG_TESTS=1 go test -tags integration_testdb -count=1 -parallel $(TEST_PARALLEL) -p $(TEST_P) ./tests/... ./internal/todoist/... ./internal/google/... ./internal/testdb/... $(GOTEST_VERBOSE)
 
 test-integration-slow:
 	@echo "Running backend slow integration tests..."
-	@cd backend && DATABASE_URL="$(TEST_DATABASE_URL)" LONG_TESTS=1 go test -tags integration_testdb -count=1 -parallel 4 -p 4 ./tests/... ./internal/todoist/... ./internal/google/... ./internal/testdb/... $(GOTEST_VERBOSE) -run '$(BACKEND_SLOW_TESTS_REGEX)'
+	@cd backend && DATABASE_URL="$(TEST_DATABASE_URL)" LONG_TESTS=1 go test -tags integration_testdb -count=1 -parallel $(TEST_PARALLEL) -p $(TEST_P) ./tests/... ./internal/todoist/... ./internal/google/... ./internal/testdb/... $(GOTEST_VERBOSE) -run '$(BACKEND_SLOW_TESTS_REGEX)'
 
 # Sweep leaked clone databases (personal_crm_test_clone_*) AND stale
 # per-migration-set template databases (personal_crm_test_template_<hash>).

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -2,6 +2,12 @@ services:
   postgres:
     image: pgvector/pgvector:pg16
     container_name: crm-postgres
+    # Local test/dev Postgres ceiling raised to match CI (#434). max_connections
+    # is a server-config bump only — the postgres_data volume (real dev data) is
+    # untouched and durability stays ON locally (unlike CI's disposable PG).
+    # First `docker compose up -d` after this change recreates the container; the
+    # named volume persists, so no data loss.
+    command: ["postgres", "-c", "max_connections=200"]
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-personal_crm}
       POSTGRES_USER: ${POSTGRES_USER:-crm_user}

--- a/scripts/ci/test-parallelism-render-guard.sh
+++ b/scripts/ci/test-parallelism-render-guard.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Guards the L2 adaptive -p/-parallel render in the Makefile against drift.
+# Pure `make -n` string assertions — no running Postgres required (PG_MAXCONNS
+# is read from the env by scripts/test-parallelism.sh, so the guard forces the
+# ceiling deterministically). Wired into the local pre-push FILTER phase.
+#
+# Asserts:
+#   1. CI pin: GITHUB_ACTIONS=true renders -parallel 4 -p 4 byte-identical.
+#   2. stock-100 safety: a forced PG_MAXCONNS=100 renders -parallel 4 -p 4.
+#   3. 200 ceiling: the render's -p equals what scripts/test-parallelism.sh
+#      emits on THIS machine for PG_MAXCONNS=200 (no independent re-derivation),
+#      and -parallel == -p.
+#   4. laziness: `make help` never invokes the probe; `make -n test-integration`
+#      invokes it exactly once (instrumented via a fake psql on PATH).
+set -u
+cd "$(dirname "${BASH_SOURCE[0]}")/../.." || exit 1   # repo root
+
+fail=0
+note() { echo "$1"; }
+ok()   { echo "ok: $1"; }
+bad()  { echo "FAIL: $1"; fail=1; }
+
+render_pp() {
+  # render_pp <target>: echo the "-parallel N -p M" substring from `make -n`.
+  # GITHUB_ACTIONS / PG_MAXCONNS are taken from the caller's environment (set via
+  # `export` in a subshell), since a `VAR=x func` prefix does NOT pass to a shell
+  # function's invoked commands the way it does for an external command.
+  make -n "$1" 2>/dev/null | grep -oE '\-parallel [0-9]+ -p [0-9]+' | head -1
+}
+
+# --- 1. CI pin byte-identical ---
+ci_render=$( export GITHUB_ACTIONS=true; render_pp test-integration-fast )
+[[ "$ci_render" == "-parallel 4 -p 4" ]] \
+  && ok "CI pin test-integration-fast renders '-parallel 4 -p 4'" \
+  || bad "CI pin render was '$ci_render', expected '-parallel 4 -p 4'"
+
+ci_render_long=$( export GITHUB_ACTIONS=true; render_pp test-integration )
+[[ "$ci_render_long" == "-parallel 4 -p 4" ]] \
+  && ok "CI pin test-integration renders '-parallel 4 -p 4'" \
+  || bad "CI pin (long) render was '$ci_render_long', expected '-parallel 4 -p 4'"
+
+# --- 2. stock-100 safety (forced ceiling, GITHUB_ACTIONS cleared) ---
+stock_render=$( unset GITHUB_ACTIONS; export PG_MAXCONNS=100; render_pp test-integration )
+[[ "$stock_render" == "-parallel 4 -p 4" ]] \
+  && ok "local stock-100 renders '-parallel 4 -p 4'" \
+  || bad "local stock-100 render was '$stock_render', expected '-parallel 4 -p 4'"
+
+# --- 3. 200 ceiling: render -p equals the single script's output ---
+script_p=$(PG_MAXCONNS=200 bash scripts/test-parallelism.sh 2>/dev/null)
+hi_render=$( unset GITHUB_ACTIONS; export PG_MAXCONNS=200; render_pp test-integration )
+expected="-parallel ${script_p} -p ${script_p}"
+[[ "$hi_render" == "$expected" ]] \
+  && ok "local 200 render '$hi_render' matches script output ($script_p)" \
+  || bad "local 200 render was '$hi_render', expected '$expected'"
+
+# -parallel must always equal -p (single-probe memo).
+hi_par=$(echo "$hi_render" | grep -oE '\-parallel [0-9]+' | grep -oE '[0-9]+')
+hi_p=$(echo "$hi_render" | grep -oE '\-p [0-9]+' | grep -oE '[0-9]+')
+[[ -n "$hi_par" && "$hi_par" == "$hi_p" ]] \
+  && ok "-parallel ($hi_par) == -p ($hi_p)" \
+  || bad "-parallel ($hi_par) != -p ($hi_p)"
+
+# --- 4. laziness/once (instrumented fake psql + counter file) ---
+tmpd=$(mktemp -d)
+ctr="$tmpd/count"
+: > "$ctr"
+cat > "$tmpd/psql" <<EOF
+#!/bin/bash
+echo x >> "$ctr"
+echo 200
+EOF
+chmod +x "$tmpd/psql"
+
+# make help must NOT invoke the probe.
+PATH="$tmpd:$PATH" GITHUB_ACTIONS='' TEST_DATABASE_URL='postgres://fake/db' make -n help >/dev/null 2>&1
+help_n=$(wc -l < "$ctr" | tr -d ' ')
+[[ "$help_n" -eq 0 ]] \
+  && ok "make help invokes the probe 0 times (lazy)" \
+  || bad "make help invoked the probe $help_n times (should be 0)"
+
+# make -n test-integration must invoke it exactly once (memoized).
+: > "$ctr"
+PATH="$tmpd:$PATH" GITHUB_ACTIONS='' TEST_DATABASE_URL='postgres://fake/db' make -n test-integration >/dev/null 2>&1
+int_n=$(wc -l < "$ctr" | tr -d ' ')
+[[ "$int_n" -eq 1 ]] \
+  && ok "make -n test-integration invokes the probe exactly once (memoized)" \
+  || bad "make -n test-integration invoked the probe $int_n times (should be 1)"
+
+rm -rf "$tmpd"
+
+[[ "$fail" -eq 0 ]] && { echo "ALL PASS (parallelism render guard)"; exit 0; } || { echo "FAILURES (parallelism render guard)"; exit 1; }

--- a/scripts/ci/test-parallelism-render-guard.sh
+++ b/scripts/ci/test-parallelism-render-guard.sh
@@ -61,7 +61,7 @@ hi_p=$(echo "$hi_render" | grep -oE '\-p [0-9]+' | grep -oE '[0-9]+')
   || bad "-parallel ($hi_par) != -p ($hi_p)"
 
 # --- 4. laziness/once (instrumented fake psql + counter file) ---
-tmpd=$(mktemp -d)
+tmpd=$(mktemp -d) || { echo "FAIL: mktemp -d failed"; exit 1; }
 ctr="$tmpd/count"
 : > "$ctr"
 cat > "$tmpd/psql" <<EOF

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -1,8 +1,21 @@
 #!/bin/bash
-# Unified pre-push hook: lint, swift (mac-daemon), test (parallel execution)
+# Unified pre-push hook: review-log + swift gate (precede), then a PARALLEL block.
 #
-# Reads configuration from .ai/pre-push.json
-# Runs enabled checks; blocks push if any required check fails
+# Reads configuration from .ai/pre-push.json. Runs enabled checks; blocks push
+# if any required check fails.
+#
+# Execution model (L3): review-log and the Swift gate run first (cheap / path-
+# gated fast-fail). Then four independent phases run CONCURRENTLY — LINT,
+# GO (test-unit && test-integration, the DB-owning long pole), FRONTEND, and
+# FILTER (pre-push filter unit tests) — each buffered to its own log. Once all
+# four pass, E2E runs EXCLUSIVELY and last, because make test-e2e-diff DROPs the
+# personal_crm_test database (the Go base/clone source) and binds ports
+# 3000/8080 — it must never overlap the Go integration lane.
+#
+# LINT is no longer a hard fast-fail gate BEFORE tests: it runs concurrent with
+# the Go pole and feeds the unified aggregate. Unlike the test phases, LINT is
+# NOT gated by should_skip_tests — it runs whenever lint is enabled (matching the
+# prior always-run-lint behavior).
 #
 # To bypass (not recommended): git push --no-verify
 
@@ -52,44 +65,35 @@ check_review_log() {
   echo "  [review] OK Claude review of ${head_sha:0:12}" >&2
 }
 
-# Run lint commands
-run_lint() {
-  local enabled=$(jq -r '.lint.enabled // false' "$CONFIG_FILE")
-  if [[ "$enabled" != "true" ]]; then
-    echo "SKIP" > "$LINT_RESULT"
-    return
-  fi
-
-  local count=$(jq '.lint.commands | length' "$CONFIG_FILE")
-  if [[ "$count" -eq 0 ]]; then
-    echo "SKIP" > "$LINT_RESULT"
-    return
-  fi
-
+# Run the lint commands and RETURN a real exit code (non-zero on a required
+# failure). Unlike the old run_lint, this does NOT write a result file and does
+# NOT swallow output: stdout/stderr flow through so the LINT phase log captures
+# diagnostics, and the non-zero return becomes the phase rc. Invoked as the LINT
+# phase command string (eval'd in run_phase's subshell, which inherits this
+# function). Caller checks .lint.enabled / command count before launching.
+run_lint_inner() {
+  local count
+  count=$(jq '.lint.commands | length' "$CONFIG_FILE")
   local failed=0
   for i in $(seq 0 $((count - 1))); do
-    local name=$(jq -r ".lint.commands[$i].name" "$CONFIG_FILE")
-    local cmd=$(jq -r ".lint.commands[$i].command" "$CONFIG_FILE")
-    local optional=$(jq -r ".lint.commands[$i].optional // false" "$CONFIG_FILE")
+    local name cmd optional
+    name=$(jq -r ".lint.commands[$i].name" "$CONFIG_FILE")
+    cmd=$(jq -r ".lint.commands[$i].command" "$CONFIG_FILE")
+    optional=$(jq -r ".lint.commands[$i].optional // false" "$CONFIG_FILE")
 
-    echo "  [lint] -> $name" >&2
-    if eval "$cmd" >/dev/null 2>&1; then
-      echo "  [lint] OK $name" >&2
+    echo "  [lint] -> $name"
+    if ( eval "$cmd" ); then
+      echo "  [lint] OK $name"
     else
       if [[ "$optional" == "true" ]]; then
-        echo "  [lint] WARN $name (optional)" >&2
+        echo "  [lint] WARN $name (optional)"
       else
-        echo "  [lint] FAIL $name" >&2
+        echo "  [lint] FAIL $name"
         failed=1
       fi
     fi
   done
-
-  if [[ "$failed" -eq 1 ]]; then
-    echo "FAIL" > "$LINT_RESULT"
-  else
-    echo "PASS" > "$LINT_RESULT"
-  fi
+  return $failed
 }
 
 # file_in_group <file> <group>: true (0) if <file> matches any glob under the
@@ -229,53 +233,240 @@ check_swift() {
   fi
 }
 
-# Run test commands
-run_tests() {
-  cd "$PROJECT_ROOT"  # Ensure correct directory in background
-  local enabled=$(jq -r '.test.enabled // false' "$CONFIG_FILE")
-  if [[ "$enabled" != "true" ]]; then
-    echo "SKIP" > "$TEST_RESULT"
-    return
-  fi
+# run_phase <log> <rcfile> <shell-command-string>
+# Runs the command string FOREGROUND in an isolating subshell, buffering all
+# output to <log> and writing the exit code to <rcfile>. The subshell isolates
+# any `cd` (e.g. "cd frontend && bun run lint") so it can never leak into a
+# sibling phase or the parent. The caller backgrounds it with a single `&`; the
+# helper does NOT self-background (double-backgrounding would orphan the rc-file
+# from `wait`). The rc-file is the single source of truth for pass/fail — the
+# aggregate never trusts `wait`'s multiplexed status.
+run_phase() {
+  local log="$1" rc="$2" cmd="$3"
+  # `set +e` inside the subshell so a failing command does NOT abort before the
+  # rc-file is written (the parent hook runs under `set -e`, which the subshell
+  # would otherwise inherit). The rc-file is the single source of truth.
+  ( set +e; eval "$cmd" >"$log" 2>&1; echo $? >"$rc" )
+}
 
-  # Check if we can skip tests
-  if should_skip_tests; then
+# classify_command <command-string>: echo the lane for a .test.commands[] entry.
+#   E2E        — matches "test-e2e"           (DROPs the DB + binds ports: EXCLUSIVE, last)
+#   CONCURRENT — matches "test-frontend" OR "test-pre-push-filters"
+#                (the only commands KNOWN to be DB-free AND port-free)
+#   GO         — matches "test-unit" OR "test-integration" (DB-owning serial lane)
+#   GO (default) — anything UNRECOGNIZED falls to the GO serial lane.
+# Contract: a new known-safe (DB-free, port-free) command MUST be added to the
+# CONCURRENT allowlist explicitly. Anything not on the allowlist is treated as
+# DB-owning and serialized — NEVER silently run concurrently (no DB collision).
+classify_command() {
+  local cmd="$1"
+  case "$cmd" in
+    *test-e2e*)                              echo "E2E" ;;
+    *test-frontend*|*test-pre-push-filters*) echo "CONCURRENT" ;;
+    *test-unit*|*test-integration*)          echo "GO" ;;
+    *)                                       echo "GO" ;;
+  esac
+}
+
+# Build the GO lane's command list from the GO-classified .test.commands[],
+# preserving each entry's `optional` flag and fast-fail-on-required semantics.
+# A compound `a && b` cannot express per-command optionality, so GO runs each
+# command sequentially: optional ones tolerate failure (`|| true`, logged WARN);
+# required ones fast-fail the lane (`|| return $?`). For today's two required GO
+# commands this reduces to `make test-unit && make test-integration`.
+run_go_lane() {
+  # $@ alternates: cmd optional cmd optional ...
+  local cmd optional
+  while [[ $# -ge 2 ]]; do
+    cmd="$1"; optional="$2"; shift 2
+    echo "  [test] -> GO: $cmd"
+    if [[ "$optional" == "true" ]]; then
+      ( eval "$cmd" ) || echo "  [test] WARN GO command failed (optional): $cmd"
+    else
+      ( eval "$cmd" ) || return $?
+    fi
+  done
+  return 0
+}
+
+# Print a phase's buffered log under a labeled banner.
+print_phase_log() {
+  local name="$1" log="$2"
+  echo "" >&2
+  echo "=== [phase] $name ===" >&2
+  [[ -f "$log" ]] && cat "$log" >&2
+}
+
+# run_phases_parallel: the L3 orchestrator. Replaces the old sequential
+# run_lint; <lint-gate>; run_tests flow. Launches LINT (if enabled) + GO +
+# FRONTEND + FILTER concurrently (the test phases only when tests are active),
+# waits, aggregates rc-files, then runs E2E EXCLUSIVELY last (only if all prior
+# phases passed and tests are active). Writes PASS/FAIL/SKIP to TEST_RESULT and
+# PASS/FAIL/SKIP to LINT_RESULT (for the Results summary). save_test_marker on a
+# full test pass.
+run_phases_parallel() {
+  cd "$PROJECT_ROOT"
+
+  # ---- Compute gating ONCE up front ----
+  local lint_enabled
+  lint_enabled=$(jq -r '.lint.enabled // false' "$CONFIG_FILE")
+  [[ "$lint_enabled" == "true" ]] && [[ "$(jq '.lint.commands | length' "$CONFIG_FILE")" -gt 0 ]] || lint_enabled="false"
+
+  local test_enabled
+  test_enabled=$(jq -r '.test.enabled // false' "$CONFIG_FILE")
+  local test_count
+  test_count=$(jq '.test.commands | length' "$CONFIG_FILE")
+
+  # tests_active = test.enabled AND commands present AND NOT should_skip_tests.
+  # (Mirrors the old run_tests: SKIP when disabled/empty; PASS-without-running
+  # when should_skip_tests.)
+  local tests_active="true"
+  if [[ "$test_enabled" != "true" ]] || [[ "$test_count" -eq 0 ]]; then
+    tests_active="false"
+    echo "SKIP" > "$TEST_RESULT"
+  elif should_skip_tests; then
+    tests_active="false"
     echo "  [test] OK Skipped (no trigger files changed since last pass)" >&2
     echo "PASS" > "$TEST_RESULT"
-    return
   fi
 
-  local count=$(jq '.test.commands | length' "$CONFIG_FILE")
-  if [[ "$count" -eq 0 ]]; then
-    echo "SKIP" > "$TEST_RESULT"
-    return
+  # ---- Buffered phase logs / rc-files ----
+  local LINT_LOG GO_LOG FE_LOG FILTER_LOG E2E_LOG
+  local LINT_RC GO_RC FE_RC FILTER_RC E2E_RC
+  LINT_LOG=$(mktemp); GO_LOG=$(mktemp); FE_LOG=$(mktemp); FILTER_LOG=$(mktemp); E2E_LOG=$(mktemp)
+  LINT_RC=$(mktemp); GO_RC=$(mktemp); FE_RC=$(mktemp); FILTER_RC=$(mktemp); E2E_RC=$(mktemp)
+  PHASE_TMPFILES="$LINT_LOG $GO_LOG $FE_LOG $FILTER_LOG $E2E_LOG $LINT_RC $GO_RC $FE_RC $FILTER_RC $E2E_RC"
+
+  # ---- Classify the test commands into lanes ----
+  local go_args=() fe_cmds=() filter_cmds=() e2e_cmds=()
+  if [[ "$tests_active" == "true" ]]; then
+    local i name cmd optional lane
+    for i in $(seq 0 $((test_count - 1))); do
+      name=$(jq -r ".test.commands[$i].name" "$CONFIG_FILE")
+      cmd=$(jq -r ".test.commands[$i].command" "$CONFIG_FILE")
+      optional=$(jq -r ".test.commands[$i].optional // false" "$CONFIG_FILE")
+      lane=$(classify_command "$cmd")
+      case "$lane" in
+        E2E)        e2e_cmds+=("$cmd") ;;
+        CONCURRENT)
+          if [[ "$cmd" == *test-frontend* ]]; then fe_cmds+=("$cmd"); else filter_cmds+=("$cmd"); fi ;;
+        GO)         go_args+=("$cmd" "$optional") ;;
+      esac
+    done
   fi
 
-  local failed=0
-  for i in $(seq 0 $((count - 1))); do
-    local name=$(jq -r ".test.commands[$i].name" "$CONFIG_FILE")
-    local cmd=$(jq -r ".test.commands[$i].command" "$CONFIG_FILE")
-    local optional=$(jq -r ".test.commands[$i].optional // false" "$CONFIG_FILE")
+  # ---- Launch concurrent phases (set +e fence: a non-zero background child
+  #      must never abort the parent before rc-files are read) ----
+  local launched_rcs=() launched_names=() launched_logs=()
+  set +e
 
-    echo "  [test] -> $name" >&2
-    if eval "$cmd" >/dev/null 2>&1; then
-      echo "  [test] OK $name" >&2
+  if [[ "$lint_enabled" == "true" ]]; then
+    echo "  [test] -> LINT (running, logs buffered)" >&2
+    run_phase "$LINT_LOG" "$LINT_RC" "run_lint_inner" &
+    launched_rcs+=("$LINT_RC"); launched_names+=("LINT"); launched_logs+=("$LINT_LOG")
+  fi
+
+  if [[ "$tests_active" == "true" ]]; then
+    if [[ ${#go_args[@]} -gt 0 ]]; then
+      echo "  [test] -> GO (unit+integration, running, logs buffered)" >&2
+      # Pass the alternating cmd/optional list to run_go_lane via a quoted call.
+      run_phase "$GO_LOG" "$GO_RC" "run_go_lane $(printf '%q ' "${go_args[@]}")" &
+      launched_rcs+=("$GO_RC"); launched_names+=("GO"); launched_logs+=("$GO_LOG")
+    fi
+    if [[ ${#fe_cmds[@]} -gt 0 ]]; then
+      echo "  [test] -> FRONTEND (running, logs buffered)" >&2
+      run_phase "$FE_LOG" "$FE_RC" "${fe_cmds[0]}" &
+      launched_rcs+=("$FE_RC"); launched_names+=("FRONTEND"); launched_logs+=("$FE_LOG")
+    fi
+    if [[ ${#filter_cmds[@]} -gt 0 ]]; then
+      echo "  [test] -> FILTER (running, logs buffered)" >&2
+      run_phase "$FILTER_LOG" "$FILTER_RC" "${filter_cmds[0]}" &
+      launched_rcs+=("$FILTER_RC"); launched_names+=("FILTER"); launched_logs+=("$FILTER_LOG")
+    fi
+  fi
+
+  wait
+  set -e
+
+  # ---- Aggregate the launched phases' rc-files ----
+  local failed=0 lint_failed=0 idx
+  for idx in "${!launched_rcs[@]}"; do
+    local rcfile="${launched_rcs[$idx]}" pname="${launched_names[$idx]}" plog="${launched_logs[$idx]}"
+    local rcval
+    rcval=$(cat "$rcfile" 2>/dev/null || echo 1)   # missing rc => failure
+    [[ "$rcval" =~ ^[0-9]+$ ]] || rcval=1
+    if [[ "$rcval" -ne 0 ]]; then
+      failed=1
+      [[ "$pname" == "LINT" ]] && lint_failed=1
+      echo "  [test] FAIL $pname" >&2
+      print_phase_log "$pname" "$plog"
     else
-      if [[ "$optional" == "true" ]]; then
-        echo "  [test] WARN $name (optional)" >&2
-      else
-        echo "  [test] FAIL $name" >&2
-        failed=1
-      fi
+      echo "  [test] OK $pname" >&2
     fi
   done
 
-  if [[ "$failed" -eq 1 ]]; then
-    echo "FAIL" > "$TEST_RESULT"
-  else
-    save_test_marker
-    echo "PASS" > "$TEST_RESULT"
+  # ---- E2E: exclusive, last, only if all prior passed AND tests are active ----
+  if [[ "$tests_active" == "true" ]] && [[ ${#e2e_cmds[@]} -gt 0 ]]; then
+    if [[ "$failed" -eq 0 ]]; then
+      echo "  [test] -> E2E (exclusive, running, logs buffered)" >&2
+      set +e
+      run_phase "$E2E_LOG" "$E2E_RC" "${e2e_cmds[0]}"
+      set -e
+      local e2e_rc
+      e2e_rc=$(cat "$E2E_RC" 2>/dev/null || echo 1)
+      [[ "$e2e_rc" =~ ^[0-9]+$ ]] || e2e_rc=1
+      if [[ "$e2e_rc" -ne 0 ]]; then
+        failed=1
+        echo "  [test] FAIL E2E" >&2
+        print_phase_log "E2E" "$E2E_LOG"
+      else
+        echo "  [test] OK E2E" >&2
+      fi
+    else
+      echo "  [test] SKIP E2E (a prior phase failed)" >&2
+    fi
   fi
+
+  # ---- Lint result line (for the Results summary) ----
+  if [[ "$lint_enabled" != "true" ]]; then
+    echo "SKIP" > "$LINT_RESULT"
+  elif [[ "$lint_failed" -eq 1 ]]; then
+    echo "FAIL" > "$LINT_RESULT"
+  else
+    echo "PASS" > "$LINT_RESULT"
+  fi
+
+  # ---- Test result + marker ----
+  if [[ "$tests_active" == "true" ]]; then
+    if [[ "$failed" -eq 1 ]]; then
+      # Distinguish a lint-only failure from a real test failure for TEST_RESULT.
+      local test_only_failed=0 jdx
+      for jdx in "${!launched_rcs[@]}"; do
+        [[ "${launched_names[$jdx]}" == "LINT" ]] && continue
+        local rv; rv=$(cat "${launched_rcs[$jdx]}" 2>/dev/null || echo 1)
+        [[ "$rv" =~ ^[0-9]+$ ]] || rv=1
+        [[ "$rv" -ne 0 ]] && test_only_failed=1
+      done
+      local e2erv; e2erv=$(cat "$E2E_RC" 2>/dev/null || echo 0)
+      [[ "$e2erv" =~ ^[0-9]+$ ]] || e2erv=1
+      [[ "$e2erv" -ne 0 ]] && test_only_failed=1
+      if [[ "$test_only_failed" -eq 1 ]]; then
+        echo "FAIL" > "$TEST_RESULT"
+      else
+        # Only lint failed; tests all passed. Tests pass, lint gates separately.
+        save_test_marker
+        echo "PASS" > "$TEST_RESULT"
+      fi
+    else
+      save_test_marker
+      echo "PASS" > "$TEST_RESULT"
+    fi
+  fi
+  # (When tests_active=false, TEST_RESULT was already written above: SKIP if
+  #  disabled/empty, PASS if should_skip_tests.)
+
+  # shellcheck disable=SC2086  # PHASE_TMPFILES is a space-separated path list.
+  rm -f $PHASE_TMPFILES
 }
 
 # Allow tests to source this file for unit-testing the pure functions
@@ -303,23 +494,13 @@ echo "==============================================================" >&2
 
 check_review_log
 
-# Run lint first (fast, fail early)
-run_lint
-LINT_STATUS=$(cat "$LINT_RESULT")
-
-if [[ "$LINT_STATUS" == "FAIL" ]]; then
-  echo ""
-  echo "=============================================================="
-  echo "FAILED: Linting failed. Fix issues before pushing."
-  echo "=============================================================="
-  exit 1
-fi
-
-# Swift gate (path-filtered, fast-fail before the heavy Go/frontend suite)
+# Swift gate (path-filtered, fast-fail before the heavy parallel block)
 check_swift
 
-# Run tests
-run_tests
+# L3: LINT + GO + FRONTEND + FILTER run concurrently; E2E runs exclusively last.
+# Lint is one of the aggregated phases (no longer a separate fast-fail gate).
+run_phases_parallel
+LINT_STATUS=$(cat "$LINT_RESULT")
 TEST_STATUS=$(cat "$TEST_RESULT")
 
 echo "" >&2
@@ -329,7 +510,13 @@ echo "  Lint:   $LINT_STATUS" >&2
 echo "  Tests:  $TEST_STATUS" >&2
 echo "==============================================================" >&2
 
-# Determine exit (lint already checked above)
+if [[ "$LINT_STATUS" == "FAIL" ]]; then
+  echo "" >&2
+  echo "FAILED: Linting failed. Fix issues before pushing." >&2
+  echo "" >&2
+  exit 1
+fi
+
 if [[ "$TEST_STATUS" == "FAIL" ]]; then
   echo "" >&2
   echo "FAILED: Tests failed. Fix issues before pushing." >&2

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -268,20 +268,23 @@ classify_command() {
   esac
 }
 
-# Build the GO lane's command list from the GO-classified .test.commands[],
+# run_lane <cmd optional cmd optional ...>: run a lane's commands sequentially,
 # preserving each entry's `optional` flag and fast-fail-on-required semantics.
-# A compound `a && b` cannot express per-command optionality, so GO runs each
-# command sequentially: optional ones tolerate failure (`|| true`, logged WARN);
-# required ones fast-fail the lane (`|| return $?`). For today's two required GO
-# commands this reduces to `make test-unit && make test-integration`.
-run_go_lane() {
+# A compound `a && b` cannot express per-command optionality, so the lane runs
+# each command in order: optional ones tolerate failure (logged WARN, rc stays
+# 0); required ones fast-fail the lane (`|| return $?`). Used by ALL lanes (GO,
+# FRONTEND, FILTER, E2E) so every .test.commands[] entry in a lane runs and its
+# `optional` flag is honored — matching the prior hook, which ran every command.
+# For today's two required GO commands this reduces to
+# `make test-unit && make test-integration`.
+run_lane() {
   # $@ alternates: cmd optional cmd optional ...
   local cmd optional
   while [[ $# -ge 2 ]]; do
     cmd="$1"; optional="$2"; shift 2
-    echo "  [test] -> GO: $cmd"
+    echo "  -> $cmd"
     if [[ "$optional" == "true" ]]; then
-      ( eval "$cmd" ) || echo "  [test] WARN GO command failed (optional): $cmd"
+      ( eval "$cmd" ) || echo "  WARN command failed (optional): $cmd"
     else
       ( eval "$cmd" ) || return $?
     fi
@@ -337,8 +340,11 @@ run_phases_parallel() {
   LINT_RC=$(mktemp); GO_RC=$(mktemp); FE_RC=$(mktemp); FILTER_RC=$(mktemp); E2E_RC=$(mktemp)
   PHASE_TMPFILES="$LINT_LOG $GO_LOG $FE_LOG $FILTER_LOG $E2E_LOG $LINT_RC $GO_RC $FE_RC $FILTER_RC $E2E_RC"
 
-  # ---- Classify the test commands into lanes ----
-  local go_args=() fe_cmds=() filter_cmds=() e2e_cmds=()
+  # ---- Classify the test commands into lanes (each lane is an alternating
+  #      cmd/optional list so EVERY command runs and its optional flag is
+  #      honored — matching the prior hook). The FRONTEND/FILTER split is by
+  #      command substring; both are concurrent. ----
+  local go_args=() fe_args=() filter_args=() e2e_args=()
   if [[ "$tests_active" == "true" ]]; then
     local i name cmd optional lane
     for i in $(seq 0 $((test_count - 1))); do
@@ -347,9 +353,9 @@ run_phases_parallel() {
       optional=$(jq -r ".test.commands[$i].optional // false" "$CONFIG_FILE")
       lane=$(classify_command "$cmd")
       case "$lane" in
-        E2E)        e2e_cmds+=("$cmd") ;;
+        E2E)        e2e_args+=("$cmd" "$optional") ;;
         CONCURRENT)
-          if [[ "$cmd" == *test-frontend* ]]; then fe_cmds+=("$cmd"); else filter_cmds+=("$cmd"); fi ;;
+          if [[ "$cmd" == *test-frontend* ]]; then fe_args+=("$cmd" "$optional"); else filter_args+=("$cmd" "$optional"); fi ;;
         GO)         go_args+=("$cmd" "$optional") ;;
       esac
     done
@@ -369,18 +375,18 @@ run_phases_parallel() {
   if [[ "$tests_active" == "true" ]]; then
     if [[ ${#go_args[@]} -gt 0 ]]; then
       echo "  [test] -> GO (unit+integration, running, logs buffered)" >&2
-      # Pass the alternating cmd/optional list to run_go_lane via a quoted call.
-      run_phase "$GO_LOG" "$GO_RC" "run_go_lane $(printf '%q ' "${go_args[@]}")" &
+      # Pass the alternating cmd/optional list to run_lane via a quoted call.
+      run_phase "$GO_LOG" "$GO_RC" "run_lane $(printf '%q ' "${go_args[@]}")" &
       launched_rcs+=("$GO_RC"); launched_names+=("GO"); launched_logs+=("$GO_LOG")
     fi
-    if [[ ${#fe_cmds[@]} -gt 0 ]]; then
+    if [[ ${#fe_args[@]} -gt 0 ]]; then
       echo "  [test] -> FRONTEND (running, logs buffered)" >&2
-      run_phase "$FE_LOG" "$FE_RC" "${fe_cmds[0]}" &
+      run_phase "$FE_LOG" "$FE_RC" "run_lane $(printf '%q ' "${fe_args[@]}")" &
       launched_rcs+=("$FE_RC"); launched_names+=("FRONTEND"); launched_logs+=("$FE_LOG")
     fi
-    if [[ ${#filter_cmds[@]} -gt 0 ]]; then
+    if [[ ${#filter_args[@]} -gt 0 ]]; then
       echo "  [test] -> FILTER (running, logs buffered)" >&2
-      run_phase "$FILTER_LOG" "$FILTER_RC" "${filter_cmds[0]}" &
+      run_phase "$FILTER_LOG" "$FILTER_RC" "run_lane $(printf '%q ' "${filter_args[@]}")" &
       launched_rcs+=("$FILTER_RC"); launched_names+=("FILTER"); launched_logs+=("$FILTER_LOG")
     fi
   fi
@@ -406,11 +412,11 @@ run_phases_parallel() {
   done
 
   # ---- E2E: exclusive, last, only if all prior passed AND tests are active ----
-  if [[ "$tests_active" == "true" ]] && [[ ${#e2e_cmds[@]} -gt 0 ]]; then
+  if [[ "$tests_active" == "true" ]] && [[ ${#e2e_args[@]} -gt 0 ]]; then
     if [[ "$failed" -eq 0 ]]; then
       echo "  [test] -> E2E (exclusive, running, logs buffered)" >&2
       set +e
-      run_phase "$E2E_LOG" "$E2E_RC" "${e2e_cmds[0]}"
+      run_phase "$E2E_LOG" "$E2E_RC" "run_lane $(printf '%q ' "${e2e_args[@]}")"
       set -e
       local e2e_rc
       e2e_rc=$(cat "$E2E_RC" 2>/dev/null || echo 1)

--- a/scripts/hooks/test/test-pre-push-filters.sh
+++ b/scripts/hooks/test/test-pre-push-filters.sh
@@ -103,4 +103,12 @@ assert_true  "any_file_under_macdaemon mixed -> fires" \
 assert_grep_count 1 'any_file_in_groups "$pushed_files" backend frontend' scripts/hooks/pre-push
 assert_grep_count 1 'any_file_in_groups "$files_since_test" backend frontend' scripts/hooks/pre-push
 
+# --- Chain the sibling guard suites so the FILTER phase covers them all in one
+# command (the pre-push classifier routes this single test-pre-push-filters
+# command to the CONCURRENT lane). ---
+echo "--- pre-push phase classifier / failure-propagation guard ---"
+bash scripts/hooks/test/test-pre-push-phases.sh || fail=1
+echo "--- Makefile adaptive -p / CI-pin render guard ---"
+bash scripts/ci/test-parallelism-render-guard.sh || fail=1
+
 [[ "$fail" -eq 0 ]] && { echo "ALL PASS"; exit 0; } || { echo "FAILURES"; exit 1; }

--- a/scripts/hooks/test/test-pre-push-phases.sh
+++ b/scripts/hooks/test/test-pre-push-phases.sh
@@ -23,7 +23,7 @@ assert_eq "test-integration -> GO"                      "GO"         "$(classify
 assert_eq "unrecognized command -> GO (safe default)"   "GO"         "$(classify_command 'make some-future-db-command')"
 
 # --- run_phase: writes rc-file + buffers log; does NOT self-background ---
-tmpd=$(mktemp -d)
+tmpd=$(mktemp -d) || { echo "FAIL: mktemp -d failed"; exit 1; }
 
 run_phase "$tmpd/ok.log" "$tmpd/ok.rc" "true"
 assert_eq "run_phase success rc == 0"                   "0"          "$(cat "$tmpd/ok.rc")"
@@ -74,18 +74,23 @@ assert_eq "a failing background phase -> aggregate 1"   "1" "$(aggregate_rcs "$t
 # A MISSING rc-file -> treated as failure (1).
 assert_eq "missing rc-file -> aggregate 1"              "1" "$(aggregate_rcs "$tmpd/nonexistent.rc")"
 
-# --- optional GO command failing does NOT fail its phase ---
-# run_go_lane takes alternating cmd/optional args. An optional failure is
-# tolerated (rc 0); a required failure fast-fails (non-zero rc).
-run_phase "$tmpd/goopt.log" "$tmpd/goopt.rc" "run_go_lane $(printf '%q ' 'false' 'true' 'true' 'false')"
-assert_eq "optional GO command failing -> GO rc stays 0" "0" "$(cat "$tmpd/goopt.rc")"
+# --- run_lane: optional command failing does NOT fail its phase ---
+# run_lane (used by ALL lanes) takes alternating cmd/optional args. An optional
+# failure is tolerated (rc 0); a required failure fast-fails (non-zero rc).
+run_phase "$tmpd/goopt.log" "$tmpd/goopt.rc" "run_lane $(printf '%q ' 'false' 'true' 'true' 'false')"
+assert_eq "optional command failing -> lane rc stays 0" "0" "$(cat "$tmpd/goopt.rc")"
 
-run_phase "$tmpd/goreq.log" "$tmpd/goreq.rc" "run_go_lane $(printf '%q ' 'false' 'false')"
-assert_eq "required GO command failing -> GO rc != 0"   "1" "$([[ "$(cat "$tmpd/goreq.rc")" -ne 0 ]] && echo 1 || echo 0)"
+run_phase "$tmpd/goreq.log" "$tmpd/goreq.rc" "run_lane $(printf '%q ' 'false' 'false')"
+assert_eq "required command failing -> lane rc != 0"    "1" "$([[ "$(cat "$tmpd/goreq.rc")" -ne 0 ]] && echo 1 || echo 0)"
 
-# Two required GO commands, both pass -> rc 0 (today's shape).
-run_phase "$tmpd/gook.log" "$tmpd/gook.rc" "run_go_lane $(printf '%q ' 'true' 'false' 'true' 'false')"
-assert_eq "two required GO commands passing -> GO rc 0" "0" "$(cat "$tmpd/gook.rc")"
+# Two required commands, both pass -> rc 0 (today's GO shape).
+run_phase "$tmpd/gook.log" "$tmpd/gook.rc" "run_lane $(printf '%q ' 'true' 'false' 'true' 'false')"
+assert_eq "two required commands passing -> lane rc 0"  "0" "$(cat "$tmpd/gook.rc")"
+
+# A lane with multiple required commands runs ALL of them (not just the first):
+# the second command's failure must fail the lane even though the first passed.
+run_phase "$tmpd/multi.log" "$tmpd/multi.rc" "run_lane $(printf '%q ' 'true' 'false' 'false' 'false')"
+assert_eq "lane runs every command (2nd failure fails lane)" "1" "$([[ "$(cat "$tmpd/multi.rc")" -ne 0 ]] && echo 1 || echo 0)"
 
 rm -rf "$tmpd"
 

--- a/scripts/hooks/test/test-pre-push-phases.sh
+++ b/scripts/hooks/test/test-pre-push-phases.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Unit tests for the L3 phase classifier + rc-file failure propagation in
+# scripts/hooks/pre-push. Sources the hook (source-guard prevents the body from
+# running) and asserts the pure functions directly. No real push, no real tests.
+set -u
+cd "$(dirname "${BASH_SOURCE[0]}")/../../.." || exit 1   # repo root
+source scripts/hooks/pre-push                            # source-guard prevents hook body
+
+fail=0
+assert_eq() {
+  # assert_eq <desc> <expected> <actual>
+  if [[ "$2" == "$3" ]]; then echo "ok: $1"; else echo "FAIL: $1 (expected '$2', got '$3')"; fail=1; fi
+}
+
+# --- classify_command: lane assignment ---
+assert_eq "test-e2e-diff -> E2E (exclusive)"             "E2E"        "$(classify_command 'make test-e2e-diff')"
+assert_eq "test-e2e -> E2E"                              "E2E"        "$(classify_command 'make test-e2e')"
+assert_eq "test-frontend -> CONCURRENT"                 "CONCURRENT" "$(classify_command 'make test-frontend')"
+assert_eq "test-pre-push-filters -> CONCURRENT"         "CONCURRENT" "$(classify_command 'bash scripts/hooks/test/test-pre-push-filters.sh')"
+assert_eq "test-unit -> GO"                             "GO"         "$(classify_command 'make test-unit')"
+assert_eq "test-integration -> GO"                      "GO"         "$(classify_command 'make test-integration')"
+# Unrecognized command defaults to the GO (serial, DB-owning) lane — never concurrent.
+assert_eq "unrecognized command -> GO (safe default)"   "GO"         "$(classify_command 'make some-future-db-command')"
+
+# --- run_phase: writes rc-file + buffers log; does NOT self-background ---
+tmpd=$(mktemp -d)
+
+run_phase "$tmpd/ok.log" "$tmpd/ok.rc" "true"
+assert_eq "run_phase success rc == 0"                   "0"          "$(cat "$tmpd/ok.rc")"
+
+# Use a child process (not a bare `exit`, which would terminate the subshell
+# before the rc is written). Real phase commands are always make/bash/external
+# invocations that return an exit code rather than exiting the phase subshell.
+run_phase "$tmpd/bad.log" "$tmpd/bad.rc" "bash -c 'exit 7'"
+assert_eq "run_phase failure rc preserved (7)"          "7"          "$(cat "$tmpd/bad.rc")"
+
+run_phase "$tmpd/echo.log" "$tmpd/echo.rc" "echo hello-from-phase"
+assert_eq "run_phase buffers stdout to the log"         "hello-from-phase" "$(cat "$tmpd/echo.log")"
+
+# `cd` inside a phase must NOT leak into the parent (isolating subshell).
+cwd_before=$(pwd)
+run_phase "$tmpd/cd.log" "$tmpd/cd.rc" "cd /tmp"
+assert_eq "run_phase cd does not leak into parent cwd"  "$cwd_before" "$(pwd)"
+
+# --- rc-file aggregation under REAL set -e: a failing background phase fails ---
+# Replicate the orchestrator's aggregation loop under `set -e` (the source-guard
+# bypasses the hook's own `set -e`, so the harness enables it to exercise the
+# real condition).
+aggregate_rcs() {
+  local rcs=("$@") failed=0 rcfile rcval
+  set +e
+  for rcfile in "${rcs[@]}"; do
+    rcval=$(cat "$rcfile" 2>/dev/null || echo 1)
+    [[ "$rcval" =~ ^[0-9]+$ ]] || rcval=1
+    [[ "$rcval" -ne 0 ]] && failed=1
+  done
+  set -e
+  echo "$failed"
+}
+
+# All-pass background phases via run_phase + & + wait (the real launch shape).
+set -e
+run_phase "$tmpd/p1.log" "$tmpd/p1.rc" "true" &
+run_phase "$tmpd/p2.log" "$tmpd/p2.rc" "true" &
+wait
+assert_eq "all-pass background phases -> aggregate 0"   "0" "$(aggregate_rcs "$tmpd/p1.rc" "$tmpd/p2.rc")"
+
+# A failing required background phase -> aggregate FAIL (1).
+run_phase "$tmpd/f1.log" "$tmpd/f1.rc" "true" &
+run_phase "$tmpd/f2.log" "$tmpd/f2.rc" "exit 3" &
+wait
+assert_eq "a failing background phase -> aggregate 1"   "1" "$(aggregate_rcs "$tmpd/f1.rc" "$tmpd/f2.rc")"
+
+# A MISSING rc-file -> treated as failure (1).
+assert_eq "missing rc-file -> aggregate 1"              "1" "$(aggregate_rcs "$tmpd/nonexistent.rc")"
+
+# --- optional GO command failing does NOT fail its phase ---
+# run_go_lane takes alternating cmd/optional args. An optional failure is
+# tolerated (rc 0); a required failure fast-fails (non-zero rc).
+run_phase "$tmpd/goopt.log" "$tmpd/goopt.rc" "run_go_lane $(printf '%q ' 'false' 'true' 'true' 'false')"
+assert_eq "optional GO command failing -> GO rc stays 0" "0" "$(cat "$tmpd/goopt.rc")"
+
+run_phase "$tmpd/goreq.log" "$tmpd/goreq.rc" "run_go_lane $(printf '%q ' 'false' 'false')"
+assert_eq "required GO command failing -> GO rc != 0"   "1" "$([[ "$(cat "$tmpd/goreq.rc")" -ne 0 ]] && echo 1 || echo 0)"
+
+# Two required GO commands, both pass -> rc 0 (today's shape).
+run_phase "$tmpd/gook.log" "$tmpd/gook.rc" "run_go_lane $(printf '%q ' 'true' 'false' 'true' 'false')"
+assert_eq "two required GO commands passing -> GO rc 0" "0" "$(cat "$tmpd/gook.rc")"
+
+rm -rf "$tmpd"
+
+[[ "$fail" -eq 0 ]] && { echo "ALL PASS (pre-push phases)"; exit 0; } || { echo "FAILURES (pre-push phases)"; exit 1; }

--- a/scripts/test-parallelism.sh
+++ b/scripts/test-parallelism.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Emits the adaptive -p / -parallel value for LOCAL integration tests.
+#
+# This is the SINGLE source of truth for the adaptive parallelism formula.
+# Both the Makefile integration recipes and the pre-push guard test call THIS
+# script — there is no second formula to drift from.
+#
+# Ceiling resolution (in order):
+#   1. $PG_MAXCONNS if set (the guard test forces this for deterministic renders)
+#   2. the LIVE max_connections of the test target, probed via psql
+#      ($TEST_DATABASE_URL first, then `docker exec crm-postgres`)
+#   3. fall back to 100 (pessimistic stock Postgres) on any probe failure
+#
+# The probe targets the EXACT test DSN first, but ONLY if a DSN is actually
+# present — never `psql ""`, which could hit a default/socket Postgres.
+#
+# Formula: -p = min(cores-2, (ceiling - 13) / est), floored at 4.
+#   - 13 = superuser_reserved_connections(3) + safety margin(10)
+#   - est = per-test-binary connection estimate (default 20), locked by an
+#     empirical pg_stat_activity peak measurement (see the PR body).
+set -euo pipefail
+
+# Validate a value is a positive integer; else echo the fallback.
+posint() { case "$1" in (''|*[!0-9]*|0) echo "$2" ;; (*) echo "$1" ;; esac; }
+
+pg="${PG_MAXCONNS:-}"
+if [ -z "$pg" ]; then
+  # `|| true` on EACH assignment: under `set -euo pipefail` a failing
+  # psql/docker in a command substitution returns non-zero (pipefail propagates
+  # it) and would abort the script before the next fallback. `|| true`
+  # neutralizes that, so a missing/unreachable Postgres or absent docker falls
+  # through to the 100 fallback.
+  if [ -n "${TEST_DATABASE_URL:-}" ]; then
+    pg=$( psql "$TEST_DATABASE_URL" -tAc 'SHOW max_connections;' 2>/dev/null | tr -dc '0-9' | head -c 6 ) || true
+  fi
+  if [ -z "${pg:-}" ]; then
+    pg=$( docker exec crm-postgres psql -U crm_user -d postgres -tAc 'SHOW max_connections;' 2>/dev/null | tr -dc '0-9' | head -c 6 ) || true
+  fi
+fi
+
+pg=$( posint "${pg:-}" 100 )                       # any garbage/empty/zero => 100
+est=$( posint "${PER_BINARY_CONN_EST:-20}" 20 )    # clamp est — locked by measurement
+ncore=$( getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4 )
+ncore=$( posint "$ncore" 4 )                       # clamp core count (no div/garbage)
+
+usable=$(( pg - 13 ))                              # - superuser_reserved(3) - margin(10)
+budget=$(( usable / est )); [ "$budget" -lt 4 ] && budget=4
+np=$(( ncore - 2 )); [ "$np" -lt 4 ] && np=4
+[ "$np" -lt "$budget" ] && echo "$np" || echo "$budget"


### PR DESCRIPTION
Tier 3 local developer-loop speedups (PR 4 of the test-suite wall-clock effort, #432). Two levers, **LOCAL-ONLY** — CI behavior is byte-unchanged.

## L2 — adaptive `-p`/`-parallel` (`Makefile` + `scripts/test-parallelism.sh` + compose)

The three integration recipes hardcoded `-parallel 4 -p 4`. On a multi-core dev box this under-utilizes CPU during the LONG integration run (the pre-push long pole), but naively scaling `-p` risks exhausting the local Postgres connection ceiling.

**Single source of truth.** The adaptive formula lives only in `scripts/test-parallelism.sh`; both the Makefile recipes and the guard test call that one script (no second formula to drift from). Formula: `-p = min(cores-2, (ceiling − 13) / est)`, floored at 4, with `est` defaulting to 20. The ceiling is the **live** `max_connections`, probed in order: `psql $TEST_DATABASE_URL` → `docker exec crm-postgres` → fall back to a pessimistic 100 on any failure. So the value self-adjusts: a stock-100 box (or native Postgres, or an un-recreated container) degrades cleanly to `-p 4` (today's unchanged baseline, no exhaustion); a recreated 200-ceiling box gets real headroom.

**Measured connection budget.** Ran `make test-integration` (LONG) at the adaptive `-p 9` against the 200 ceiling while sampling `SELECT count(*) FROM pg_stat_activity` at 1s. **Peak = 29 connections** — far under the ~131 (70% of 187 usable) acceptance gate, so `est=20` is comfortably conservative and is shipped as the default. The real bottleneck was never connections; raising the ceiling simply removes them as a constraint.

**Local 200-ceiling raise.** `infra/docker-compose.yml` gains `command: ["postgres", "-c", "max_connections=200"]` to match CI (#434). This is a **server-config bump only** — the `postgres_data` volume (real dev data) is untouched and **durability stays ON locally** (unlike CI's disposable Postgres, which also disables fsync). **Recreate-once UX:** the first `docker compose up -d` after merge recreates the `crm-postgres` container; the named volume persists, so no data loss. Verified: post-recreate `SHOW max_connections` → 200 with all dev data intact.

**CI byte-pinned.** `ifeq ($(GITHUB_ACTIONS),true)` pins CI to a `:=` constant `4/4` (the CI Postgres + go-build concurrency are tuned for it; re-tuning is out of scope). Gating on `GITHUB_ACTIONS` (not bare `CI`) reliably distinguishes CI from a local tool that exports `CI`. The local branch uses recursive `=` + an `$(eval ...)` memo so the probe runs at most once per `make` and ONLY when an integration recipe expands `$(TEST_P)` — never on `make help`/`make build` (instrumented and asserted).

## L3 — pre-push phase parallelism (`scripts/hooks/pre-push`)

The hook ran every phase sequentially around the LONG integration pole. Lint, frontend tests, and the filter unit tests touch neither the test DB nor ports 3000/8080 — they can overlap the Go long pole for free.

`run_phases_parallel()` replaces the old `run_lint; <gate>; run_tests` sequence: it launches **LINT + GO (`test-unit && test-integration`) + FRONTEND + FILTER concurrently**, waits, aggregates, then runs **E2E exclusively and last**. E2E is exclusive because `make test-e2e-diff` DROPs `personal_crm_test` (the Go base/clone source) and binds ports 3000/8080 — it must never overlap the Go integration lane.

- **rc-file failure propagation.** Each phase buffers output to its own log and writes its exit code to an rc-file under a `set +e` fence, so a failing background phase can never abort the parent before its rc/log are recorded — the rc-file is the single source of truth (`wait`'s multiplexed status is never trusted). `run_phase` isolates each phase in a subshell (a `cd` can't leak across lanes) and disables `set -e` inside so a failing command still writes its rc.
- **Classifier.** `.test.commands[]` route by an explicit allowlist: `test-e2e` → exclusive; `test-frontend` / `test-pre-push-filters` → concurrent; `test-unit` / `test-integration` → GO; **anything UNRECOGNIZED → GO** (the safe serial DB-owning lane, never silently concurrent). A future DB- or port-owning command lands in GO (slower but correct), never racing the e2e drop.
- **Lint un-gated.** Lint is now an aggregated phase that runs whenever lint is enabled (NOT gated by `should_skip_tests`), preserving lint-always-runs. A lint failure no longer short-circuits the Go pole (accepted: overlapping independent work is the point). `should_skip_tests`, `save_test_marker`, `check_swift`, `check_review_log`, the source-guard, and all `file_in_group`/path-filter gating are preserved unchanged.

## Measured local pre-push wall-clock

- **L2 (integration suite, warm, same 200 ceiling):** `-p 4` = 75.4s, `-p 9` = 72.8s — **~3%**, modest as expected (the LONG suite is part serial / part compile-bound, so more `-p` only speeds the parallelizable portion). The durable value is the live-ceiling budget formula, not the raw speedup.
- **L3 (phase overlap):** LINT (~4.3s warm) + FRONTEND (~2.3s) + FILTER (<1s) ≈ **~7s warm removed from the critical path** by hiding behind the GO pole; larger on a cold-lint run where golangci-lint takes tens of seconds. The critical path becomes `max(GO, lint, frontend, filter) + e2e` instead of `lint + unit + integration + frontend + filter + e2e`.

Verified a full live pre-push run (all four phases concurrent, e2e ran AFTER the Go lane — no `personal_crm_test` drop mid-integration) and a deliberate-break run (a broken phase blocks the push, buffered failure log printed legibly under its banner), then reverted the break.

## CI behavior is byte-unchanged

The Makefile pins CI to `-parallel 4 -p 4` via `GITHUB_ACTIONS`; the pre-push hook never runs in CI. **No CI timing claim is made** — this is a local change. Guard test asserts the CI render is byte-identical.

## Known minor (non-blocking)

Surfaced by review for human awareness; deliberately NOT fixed here (would change the reviewed SHA):
- P2: the FILTER lane chains 3 guard suites under one phase name.
- P2: `run_lane` silently drops an odd trailing arg (cannot occur with current callers — args are always cmd/optional pairs).
- P3: a `check_swift` comment is now stale after the restructure.
- P3: no log breadcrumb when the ceiling probe falls back to the default.

## Test plan

- `scripts/ci/test-parallelism-render-guard.sh` — `make -n` string assertions (no running Postgres): CI pin `4/4` byte-identical; forced `PG_MAXCONNS=100` → `4/4`; `PG_MAXCONNS=200` → `-p` equal to the script's own output, `-parallel == -p`; instrumented fake-`psql` proves `make help` probes 0× and `make -n test-integration` probes exactly 1×.
- `scripts/hooks/test/test-pre-push-phases.sh` — classifier lane routing (e2e→exclusive, frontend/filter→concurrent, unit/integration→GO, unrecognized→GO); `run_phase` rc-file + buffered-log + no-cd-leak; rc aggregation under real `set -e` (failing phase ⇒ FAIL, missing rc ⇒ FAIL); `run_lane` optional-tolerance + required-fast-fail + runs-every-command.
- Both chained from the existing `test-pre-push-filters.sh` so they run in the FILTER phase every push.

Plan: `.ai/log/plan/2026-06-09-tier3-local-loop-speedups.md`. Closes nothing; part of #432.
