### PR TITLE
test(api): parallelize river-heavy tests/api ingest + sync_service funcs

### DIFF
--- a/backend/tests/api/ingest_raw_message_e2e_test.go
+++ b/backend/tests/api/ingest_raw_message_e2e_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 	"time"
 
@@ -14,7 +13,6 @@ import (
 	"personal-crm/backend/internal/api"
 	"personal-crm/backend/internal/api/handlers"
 	"personal-crm/backend/internal/auth"
-	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/consumer"
 	"personal-crm/backend/internal/consumer/consumerjobs"
 	"personal-crm/backend/internal/db"
@@ -49,22 +47,17 @@ import (
 // without it we could ship a path that stages rows but never turns
 // them into interactions.
 func TestIngestRawMessage_E2E_StagesAggregatesAndCreatesInteraction(t *testing.T) {
-	databaseURL := os.Getenv("DATABASE_URL")
-	if databaseURL == "" {
-		t.Skip("DATABASE_URL not set, skipping integration test")
-	}
+	t.Parallel()
 
 	ctx := context.Background()
-	cfg := config.TestConfig()
-	cfg.Database.URL = databaseURL
+	// Bucket B: this is the one func that genuinely WORKS jobs (real
+	// aggregator + recorder, polls for the worked result) AND asserts
+	// DB-wide (CountInteractionsByIDContactAndSource) + pairs the singleton
+	// mac_host — so it runs on a per-test clone. The clone helper sets
+	// WorkerConcurrency=2 (>=1), so the old `<= 0` guard is moot.
+	database, cfg := newIsolatedRiverTestDB(t, ctx)
 	cfg.External.APIKey = macHostTestKey
 	cfg.Features.EnableEventBusIngest = true
-	if cfg.River.WorkerConcurrency <= 0 {
-		cfg.River.WorkerConcurrency = 4
-	}
-
-	database, err := db.NewDatabase(ctx, cfg.Database)
-	require.NoError(t, err)
 
 	// Repos
 	hostRepo := repository.NewMacHostRepository(database.Queries)
@@ -224,7 +217,9 @@ func TestIngestRawMessage_E2E_StagesAggregatesAndCreatesInteraction(t *testing.T
 			"followup_manager",
 		})
 		_, _ = database.Queries.DeleteEventsBySource(cleanCtx, "messages")
-		database.Close()
+		// database.Close() is owned by the clone helper's t.Cleanup. The
+		// riverClient.Stop above runs first (registered later, LIFO) so the
+		// Elector resigns against a still-live pool.
 	})
 
 	// POST the raw_message event.

--- a/backend/tests/api/ingest_raw_message_e2e_test.go
+++ b/backend/tests/api/ingest_raw_message_e2e_test.go
@@ -50,10 +50,10 @@ func TestIngestRawMessage_E2E_StagesAggregatesAndCreatesInteraction(t *testing.T
 	t.Parallel()
 
 	ctx := context.Background()
-	// Bucket B: this is the one func that genuinely WORKS jobs (real
-	// aggregator + recorder, polls for the worked result) AND asserts
-	// DB-wide (CountInteractionsByIDContactAndSource) + pairs the singleton
-	// mac_host — so it runs on a per-test clone. The clone helper sets
+	// This func genuinely works jobs (real aggregator + recorder, polls for
+	// the worked result) AND asserts DB-wide
+	// (CountInteractionsByIDContactAndSource) + pairs the singleton mac_host,
+	// so it runs on an isolated per-test clone. The clone helper sets
 	// WorkerConcurrency=2 (>=1), so the old `<= 0` guard is moot.
 	database, cfg := newIsolatedRiverTestDB(t, ctx)
 	cfg.External.APIKey = macHostTestKey
@@ -140,7 +140,8 @@ func TestIngestRawMessage_E2E_StagesAggregatesAndCreatesInteraction(t *testing.T
 	ingestService := service.NewIngestService(database, bus, identityService, messagesRepo, riverClient, nil, hostRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	ingestHandler := handlers.NewIngestHandler(ingestService)
 
-	gin.SetMode(gin.TestMode)
+	// gin mode is set once for the package in gin_test.go's init(); calling
+	// gin.SetMode here would race the global with parallel route registration.
 	router := gin.New()
 	router.Use(api.RequestIDMiddleware())
 	router.Use(api.LoggingMiddleware())

--- a/backend/tests/api/ingest_raw_message_test.go
+++ b/backend/tests/api/ingest_raw_message_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 	"time"
 
@@ -14,7 +13,6 @@ import (
 	"personal-crm/backend/internal/api"
 	"personal-crm/backend/internal/api/handlers"
 	"personal-crm/backend/internal/auth"
-	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/consumer/consumerjobs"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/events"
@@ -54,19 +52,13 @@ type ingestRawTestEnv struct {
 func setupRawIngestEnv(t *testing.T) *ingestRawTestEnv {
 	t.Helper()
 
-	databaseURL := os.Getenv("DATABASE_URL")
-	if databaseURL == "" {
-		t.Skip("DATABASE_URL not set, skipping integration test")
-	}
-
 	ctx := context.Background()
-	cfg := config.TestConfig()
-	cfg.Database.URL = databaseURL
+	// This file asserts DB-wide over river_job (CountRiverJobsByKind) AND
+	// pairs the singleton mac_host with a DB-wide DeleteAllMacHosts teardown
+	// — both collide on the shared package DB, so it runs on a per-test clone.
+	database, cfg := newIsolatedRiverTestDB(t, ctx)
 	cfg.External.APIKey = macHostTestKey
 	cfg.Features.EnableEventBusIngest = true
-
-	database, err := db.NewDatabase(ctx, cfg.Database)
-	require.NoError(t, err)
 
 	hostRepo := repository.NewMacHostRepository(database.Queries)
 	pairingRepo := repository.NewMacHostPairingTokenRepository(database.Queries)
@@ -104,12 +96,11 @@ func setupRawIngestEnv(t *testing.T) *ingestRawTestEnv {
 		TestOnly: true,
 	})
 	require.NoError(t, err)
-	require.NoError(t, riverClient.Start(ctx))
-	t.Cleanup(func() {
-		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		_ = riverClient.Stop(stopCtx)
-	})
+	// The client is wired into the Bus/IngestService for InsertTx only;
+	// these tests enqueue and count river_job rows synchronously and never
+	// WORK jobs (workers are no-ops). InsertTx needs only PoolIsSet(), not a
+	// running client, so the client is deliberately never Started — avoiding
+	// the leadership-Elector teardown cost a per-test clone would multiply.
 
 	eventRepo := repository.NewEventRepository(database.Queries)
 	eventBus := events.NewBus(database.Pool, riverClient, eventRepo)
@@ -219,7 +210,7 @@ func setupRawIngestEnv(t *testing.T) *ingestRawTestEnv {
 			"messaging_aggregate_sweeper",
 		})
 		_, _ = database.Queries.DeleteEventsBySource(cleanCtx, "messages")
-		database.Close()
+		// database.Close() is owned by the clone helper's t.Cleanup.
 	})
 
 	return env
@@ -336,6 +327,7 @@ func (a adminRiverInserter) Insert(ctx context.Context, args river.JobArgs, opts
 // produces a staging row with matched_contact_id and one River job.
 func TestIngestRawMessage_HappyPath_StagesRowAndEnqueuesJob(t *testing.T) {
 	env := setupRawIngestEnv(t)
+	t.Parallel()
 	guid := "test-guid-" + uuid.NewString()
 	ev := buildRawMessageEvent(t, events.KindRawMessageReceived, env.pairedHostID,
 		guid, "chat-1", "+15551234567")
@@ -363,6 +355,7 @@ func TestIngestRawMessage_HappyPath_StagesRowAndEnqueuesJob(t *testing.T) {
 // the same guid returns duplicate=1 and produces no new staging row.
 func TestIngestRawMessage_Duplicate_DetectedAndSkipped(t *testing.T) {
 	env := setupRawIngestEnv(t)
+	t.Parallel()
 	guid := "test-guid-" + uuid.NewString()
 	ev := buildRawMessageEvent(t, events.KindRawMessageReceived, env.pairedHostID,
 		guid, "chat-1", "+15551234567")
@@ -392,6 +385,7 @@ func TestIngestRawMessage_Duplicate_DetectedAndSkipped(t *testing.T) {
 // produces NO aggregator River job for this row.
 func TestIngestRawMessage_UnmatchedPeer_StagedWithoutContactNoJob(t *testing.T) {
 	env := setupRawIngestEnv(t)
+	t.Parallel()
 	guid := "test-guid-" + uuid.NewString()
 	ev := buildRawMessageEvent(t, events.KindRawMessageReceived, env.pairedHostID,
 		guid, "chat-x", "+15559999999") // not in contact_method
@@ -413,6 +407,7 @@ func TestIngestRawMessage_UnmatchedPeer_StagedWithoutContactNoJob(t *testing.T) 
 // X-Mac-Host-ID) are REJECTED per-event with HOST_ONLY_REQUIRES_HOST_AUTH.
 func TestIngestRawMessage_GlobalKeyPath_RejectedWithCode(t *testing.T) {
 	env := setupRawIngestEnv(t)
+	t.Parallel()
 	guid := "test-guid-" + uuid.NewString()
 	ev := buildRawMessageEvent(t, events.KindRawMessageReceived, uuid.New(),
 		guid, "chat-1", "+15551234567")
@@ -432,6 +427,7 @@ func TestIngestRawMessage_GlobalKeyPath_RejectedWithCode(t *testing.T) {
 // UNSUPPORTED_HOST_AUTH_KIND.
 func TestIngestRawMessage_HostAuthForeignKind_Rejected(t *testing.T) {
 	env := setupRawIngestEnv(t)
+	t.Parallel()
 	now := accelerated.GetCurrentTime()
 	payload, err := events.Marshal(events.KindCalendarAttended, events.CalendarAttendedPayload{
 		Version:    1,
@@ -463,6 +459,7 @@ func TestIngestRawMessage_HostAuthForeignKind_Rejected(t *testing.T) {
 // is REJECTED with PAYLOAD_INVARIANT.
 func TestIngestRawMessage_PayloadHostMismatch_Rejected(t *testing.T) {
 	env := setupRawIngestEnv(t)
+	t.Parallel()
 	guid := "test-guid-" + uuid.NewString()
 	otherHost := uuid.New()
 	ev := buildRawMessageEvent(t, events.KindRawMessageReceived, otherHost,
@@ -484,6 +481,7 @@ func TestIngestRawMessage_PayloadHostMismatch_Rejected(t *testing.T) {
 // MISSING_FIELD.
 func TestIngestRawMessage_MissingSourceID_Rejected(t *testing.T) {
 	env := setupRawIngestEnv(t)
+	t.Parallel()
 	ev := buildRawMessageEvent(t, events.KindRawMessageReceived, env.pairedHostID,
 		"guid-some", "chat-1", "+15551234567")
 	ev["source_id"] = ""
@@ -502,6 +500,7 @@ func TestIngestRawMessage_MissingSourceID_Rejected(t *testing.T) {
 // with an out-of-set message_type is REJECTED at the handler.
 func TestIngestRawMessage_InvalidMessageType_Rejected(t *testing.T) {
 	env := setupRawIngestEnv(t)
+	t.Parallel()
 	guid := "test-guid-" + uuid.NewString()
 	now := accelerated.GetCurrentTime()
 	p := events.RawMessageReceivedPayload{
@@ -538,6 +537,7 @@ func TestIngestRawMessage_InvalidMessageType_Rejected(t *testing.T) {
 // exactly ONE aggregator River job (per-batch dedup).
 func TestIngestRawMessage_BatchDedupesAggregatorJobs(t *testing.T) {
 	env := setupRawIngestEnv(t)
+	t.Parallel()
 	mkEv := func() map[string]any {
 		return buildRawMessageEvent(t, events.KindRawMessageReceived, env.pairedHostID,
 			"test-guid-"+uuid.NewString(), "chat-1", "+15551234567")
@@ -557,6 +557,7 @@ func TestIngestRawMessage_BatchDedupesAggregatorJobs(t *testing.T) {
 // added that matches it.
 func TestIngestRawMessage_AdminRematch_MatchesAfterContactAdded(t *testing.T) {
 	env := setupRawIngestEnv(t)
+	t.Parallel()
 	guid := "test-guid-" + uuid.NewString()
 	// Step 1 — POST a raw_message with an unknown peer.
 	ev := buildRawMessageEvent(t, events.KindRawMessageReceived, env.pairedHostID,

--- a/backend/tests/api/ingest_raw_message_test.go
+++ b/backend/tests/api/ingest_raw_message_test.go
@@ -127,7 +127,8 @@ func setupRawIngestEnv(t *testing.T) *ingestRawTestEnv {
 	)
 	ingestHandler := handlers.NewIngestHandler(ingestService)
 
-	gin.SetMode(gin.TestMode)
+	// gin mode is set once for the package in gin_test.go's init(); calling
+	// gin.SetMode here would race the global with parallel route registration.
 	router := gin.New()
 	router.Use(api.RequestIDMiddleware())
 	router.Use(api.LoggingMiddleware())

--- a/backend/tests/api/ingest_test.go
+++ b/backend/tests/api/ingest_test.go
@@ -79,6 +79,14 @@ func setupIngestTestRouter(t *testing.T, enableIngest bool) *ingestTestSetup {
 	cfg := config.TestConfig()
 	cfg.Database.URL = databaseURL
 	cfg.Database.MigrationsPath = getMigrationsPath()
+	// This setup opens a fresh pool per test call against the shared package
+	// DB; with all 18 funcs now parallel, lower MaxConns so the concurrent
+	// pool count stays bounded. WorkerConcurrency drops to 1 (the client is
+	// never started, so concurrency is irrelevant) to keep Validate()'s
+	// MaxConns >= WorkerConcurrency+3 holding (1+3 <= 4).
+	cfg.Database.MaxConns = 4
+	cfg.Database.MinConns = 1
+	cfg.River.WorkerConcurrency = 1
 	cfg.External.APIKey = ingestTestAPIKey
 	cfg.Features.EnableEventBusIngest = enableIngest
 
@@ -103,14 +111,12 @@ func setupIngestTestRouter(t *testing.T, enableIngest bool) *ingestTestSetup {
 		TestOnly: true,
 	})
 	require.NoError(t, err)
-	startCtx, startCancel := context.WithTimeout(ctx, 10*time.Second)
-	defer startCancel()
-	require.NoError(t, client.Start(startCtx))
-	t.Cleanup(func() {
-		stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer stopCancel()
-		_ = client.Stop(stopCtx)
-	})
+	// The client is wired into the Bus/IngestService for InsertTx (which
+	// needs only PoolIsSet(), not a running client). These tests enqueue
+	// and count rows synchronously — they never WORK jobs (the registered
+	// workers are no-ops). Starting the client would spin up the leadership
+	// Elector whose teardown burns ~5s resigning against a closing pool, so
+	// we deliberately never Start it.
 
 	eventRepo := repository.NewEventRepository(database.Queries)
 	busFactory := func(repo events.EventRepository) *events.Bus {
@@ -207,6 +213,7 @@ func TestIngest_ValidBatch(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	setup := setupIngestTestRouter(t, true)
 
 	source := uniqueIngestSource("valid-batch")
@@ -238,6 +245,7 @@ func TestIngest_AuthFailure_MissingKey(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	setup := setupIngestTestRouter(t, true)
 	batch := handlers.IngestBatchRequest{
 		Events: []handlers.IngestEventRequest{
@@ -253,6 +261,7 @@ func TestIngest_AuthFailure_InvalidKey(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	setup := setupIngestTestRouter(t, true)
 	batch := handlers.IngestBatchRequest{
 		Events: []handlers.IngestEventRequest{
@@ -268,6 +277,7 @@ func TestIngest_MalformedJSON(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	setup := setupIngestTestRouter(t, true)
 	w := postIngest(t, setup.router, setup.apiKey, []byte("{not json"))
 	require.Equal(t, http.StatusBadRequest, w.Code)
@@ -281,6 +291,7 @@ func TestIngest_MissingFields(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	setup := setupIngestTestRouter(t, true)
 
 	source := uniqueIngestSource("missing-fields")
@@ -352,6 +363,7 @@ func TestIngest_NullPayload(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	setup := setupIngestTestRouter(t, true)
 	source := uniqueIngestSource("null-payload")
 	nullEv := fmt.Sprintf(`{"source":%q,"source_id":%q,"kind":%q,"payload":null,"observed_at":"2026-04-10T12:00:00Z"}`,
@@ -381,6 +393,7 @@ func TestIngest_UnknownKind(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	setup := setupIngestTestRouter(t, true)
 	source := uniqueIngestSource("unknown-kind")
 
@@ -407,6 +420,7 @@ func TestIngest_PayloadStructurallyInvalid(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	setup := setupIngestTestRouter(t, true)
 	source := uniqueIngestSource("payload-invalid")
 
@@ -438,6 +452,7 @@ func TestIngest_BatchTooLarge(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	setup := setupIngestTestRouter(t, true)
 
 	// 501 events, each tiny. The batch-size check runs pre-validation so
@@ -457,6 +472,7 @@ func TestIngest_EmptyBatch(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	setup := setupIngestTestRouter(t, true)
 
 	// binding:"required" on Events []IngestEventRequest flags nil/missing.
@@ -471,6 +487,7 @@ func TestIngest_DuplicateInBatch(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	setup := setupIngestTestRouter(t, true)
 
 	source := uniqueIngestSource("dup-in-batch")
@@ -498,6 +515,7 @@ func TestIngest_DuplicateAcrossBatches(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	setup := setupIngestTestRouter(t, true)
 
 	source := uniqueIngestSource("dup-across")
@@ -537,6 +555,7 @@ func TestIngest_NullSourceID_NotDeduped(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	setup := setupIngestTestRouter(t, true)
 
 	source := uniqueIngestSource("null-sid")
@@ -569,6 +588,7 @@ func TestIngest_GateDisabled_Returns404(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	setup := setupIngestTestRouter(t, false)
 	batch := handlers.IngestBatchRequest{
 		Events: []handlers.IngestEventRequest{
@@ -586,6 +606,7 @@ func TestIngest_GateDisabled_NoKey_StillReturns404(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	setup := setupIngestTestRouter(t, false)
 	body := []byte(`{"events":[]}`)
 	w := postIngest(t, setup.router, "", body)
@@ -599,6 +620,7 @@ func TestIngest_MixedBatch(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	setup := setupIngestTestRouter(t, true)
 
 	source := uniqueIngestSource("mixed")
@@ -644,6 +666,7 @@ func TestIngest_BodyTooLarge_Returns413(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	setup := setupIngestTestRouter(t, true)
 
 	// Build a body > 8 MiB: an events array containing a single event with
@@ -693,6 +716,7 @@ func TestIngest_MidTxRollback_RollsBack_And_Returns500(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	setup := setupIngestTestRouter(t, true)
 
 	// Wire a new handler over a failing repo, mounted on a fresh router

--- a/backend/tests/api/ingest_test.go
+++ b/backend/tests/api/ingest_test.go
@@ -132,7 +132,8 @@ func setupIngestTestRouter(t *testing.T, enableIngest bool) *ingestTestSetup {
 	ingestService := service.NewIngestService(database, eventBus, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	ingestHandler := handlers.NewIngestHandler(ingestService)
 
-	gin.SetMode(gin.TestMode)
+	// gin mode is set once for the package in gin_test.go's init(); calling
+	// gin.SetMode here would race the global with parallel route registration.
 	router := gin.New()
 	router.Use(api.RequestIDMiddleware())
 	router.Use(api.LoggingMiddleware())
@@ -728,7 +729,8 @@ func TestIngest_MidTxRollback_RollsBack_And_Returns500(t *testing.T) {
 
 	cfg := config.TestConfig()
 	cfg.External.APIKey = setup.apiKey
-	gin.SetMode(gin.TestMode)
+	// gin mode is set once for the package in gin_test.go's init(); calling
+	// gin.SetMode here would race the global with parallel route registration.
 	router := gin.New()
 	router.Use(api.RequestIDMiddleware())
 	router.Use(api.LoggingMiddleware())

--- a/backend/tests/api/phone_call_ingest_integration_test.go
+++ b/backend/tests/api/phone_call_ingest_integration_test.go
@@ -223,7 +223,8 @@ func setupPhoneCallIngestEnv(t *testing.T) *phoneCallIngestEnv {
 	)
 	ingestHandler := handlers.NewIngestHandler(ingestService)
 
-	gin.SetMode(gin.TestMode)
+	// gin mode is set once for the package in gin_test.go's init(); calling
+	// gin.SetMode here would race the global with parallel route registration.
 	router := gin.New()
 	router.Use(api.RequestIDMiddleware())
 	router.Use(api.LoggingMiddleware())

--- a/backend/tests/api/phone_call_ingest_integration_test.go
+++ b/backend/tests/api/phone_call_ingest_integration_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 	"time"
 
@@ -15,7 +14,6 @@ import (
 	"personal-crm/backend/internal/api"
 	"personal-crm/backend/internal/api/handlers"
 	"personal-crm/backend/internal/auth"
-	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/consumer"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/events"
@@ -113,19 +111,13 @@ func (f *failingPhoneCallWriter) MarkProcessedTx(ctx context.Context, tx pgx.Tx,
 func setupPhoneCallIngestEnv(t *testing.T) *phoneCallIngestEnv {
 	t.Helper()
 
-	databaseURL := os.Getenv("DATABASE_URL")
-	if databaseURL == "" {
-		t.Skip("DATABASE_URL not set, skipping integration test")
-	}
-
 	ctx := context.Background()
-	cfg := config.TestConfig()
-	cfg.Database.URL = databaseURL
+	// Records interactions INLINE (no async worker), but pairs the singleton
+	// mac_host with a DB-wide DeleteAllMacHosts teardown that collides on the
+	// shared package DB, so it runs on a per-test clone.
+	database, cfg := newIsolatedRiverTestDB(t, ctx)
 	cfg.External.APIKey = macHostTestKey
 	cfg.Features.EnableEventBusIngest = true
-
-	database, err := db.NewDatabase(ctx, cfg.Database)
-	require.NoError(t, err)
 
 	hostRepo := repository.NewMacHostRepository(database.Queries)
 	pairingRepo := repository.NewMacHostPairingTokenRepository(database.Queries)
@@ -162,12 +154,11 @@ func setupPhoneCallIngestEnv(t *testing.T) *phoneCallIngestEnv {
 		TestOnly: true,
 	})
 	require.NoError(t, err)
-	require.NoError(t, riverClient.Start(ctx))
-	t.Cleanup(func() {
-		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		_ = riverClient.Stop(stopCtx)
-	})
+	// The client is wired for InsertTx / FollowUpManager only; handleCall
+	// records interactions INLINE (publish → inline CadenceUpdater /
+	// FollowUpManager HandleEvent), so no job is ever worked. InsertTx needs
+	// only PoolIsSet(), not a running client, so it is deliberately never
+	// Started — avoiding the leadership-Elector teardown cost.
 
 	eventBus := events.NewBus(database.Pool, riverClient, eventRepo)
 	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, eventBus, nil)
@@ -309,7 +300,7 @@ func setupPhoneCallIngestEnv(t *testing.T) *phoneCallIngestEnv {
 		_ = contactRepo.HardDeleteContact(cleanCtx, env.seededContact)
 		_, _ = database.Queries.DeleteAllMacHosts(cleanCtx)
 		_, _ = database.Queries.DeleteAllPairingTokens(cleanCtx)
-		database.Close()
+		// database.Close() is owned by the clone helper's t.Cleanup.
 	})
 
 	return env
@@ -401,6 +392,7 @@ func TestIngestCall_Inbound_RecordsInteractionAndBumpsLastContacted(t *testing.T
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	env := setupPhoneCallIngestEnv(t)
 	ctx := context.Background()
 
@@ -469,6 +461,7 @@ func TestIngestCall_Outbound_BumpsLastOutreachAt(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	env := setupPhoneCallIngestEnv(t)
 	ctx := context.Background()
 
@@ -523,6 +516,7 @@ func TestIngestCall_MissedInboundNoVoicemail_NoInteractionWritten(t *testing.T) 
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	env := setupPhoneCallIngestEnv(t)
 	ctx := context.Background()
 
@@ -560,6 +554,7 @@ func TestIngestCall_UpsertFailure_RollsBackBatch(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	env := setupPhoneCallIngestEnv(t)
 	ctx := context.Background()
 	env.failWriter.failOnUpsert = errors.New("injected upsert failure")
@@ -589,6 +584,7 @@ func TestIngestCall_MarkProcessedFailure_RollsBackBatch(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	env := setupPhoneCallIngestEnv(t)
 	ctx := context.Background()
 	env.failWriter.failOnMarkProcess = errors.New("injected mark-processed failure")
@@ -621,6 +617,7 @@ func TestIngestCall_VersionTooHigh_Rejected(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	env := setupPhoneCallIngestEnv(t)
 
 	callID := env.sourcePrefix + "vhigh"

--- a/backend/tests/api/river_isolated_testdb_fallback_test.go
+++ b/backend/tests/api/river_isolated_testdb_fallback_test.go
@@ -1,0 +1,18 @@
+//go:build !integration_testdb
+
+package api
+
+import (
+	"context"
+	"testing"
+
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+)
+
+func newIsolatedRiverTestDB(t *testing.T, ctx context.Context) (*db.Database, *config.Config) {
+	t.Helper()
+	_ = ctx
+	t.Skip("integration_testdb build tag required for isolated River database tests")
+	return nil, nil
+}

--- a/backend/tests/api/river_isolated_testdb_test.go
+++ b/backend/tests/api/river_isolated_testdb_test.go
@@ -1,0 +1,45 @@
+//go:build integration_testdb
+
+package api
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/testdb"
+
+	"github.com/stretchr/testify/require"
+)
+
+// newIsolatedRiverTestDB opens a per-test clone for tests/api tests that start
+// (or build a DB-wide-counting) River client. Sharing the package clone lets
+// TestOnly clients steal each other's jobs from river_job and makes DB-wide
+// river_job counts collide, so River-draining tests must isolate the whole DB.
+// Mirrors backend/tests/river_isolated_testdb_test.go (package tests); the two
+// are intentionally identical except for package + this comment.
+func newIsolatedRiverTestDB(t *testing.T, ctx context.Context) (*db.Database, *config.Config) {
+	t.Helper()
+
+	if os.Getenv("DATABASE_URL") == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	cloneURL, drop := testdb.NewEphemeralClone(t)
+	t.Cleanup(drop)
+
+	cfg := config.TestConfig()
+	cfg.Database.URL = cloneURL
+	cfg.Database.MigrationsPath = getMigrationsPath()
+	cfg.Database.MaxConns = 6
+	cfg.Database.MinConns = 1
+	cfg.River.WorkerConcurrency = 2
+
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	t.Cleanup(func() { database.Close() })
+
+	return database, cfg
+}

--- a/backend/tests/api/river_isolated_testdb_test.go
+++ b/backend/tests/api/river_isolated_testdb_test.go
@@ -18,8 +18,7 @@ import (
 // (or build a DB-wide-counting) River client. Sharing the package clone lets
 // TestOnly clients steal each other's jobs from river_job and makes DB-wide
 // river_job counts collide, so River-draining tests must isolate the whole DB.
-// Mirrors backend/tests/river_isolated_testdb_test.go (package tests); the two
-// are intentionally identical except for package + this comment.
+// The package tests equivalent lives in backend/tests/river_isolated_testdb_test.go.
 func newIsolatedRiverTestDB(t *testing.T, ctx context.Context) (*db.Database, *config.Config) {
 	t.Helper()
 

--- a/backend/tests/unit/sync_service_test.go
+++ b/backend/tests/unit/sync_service_test.go
@@ -63,6 +63,7 @@ func TestSyncService_TriggerSync_UsesEnqueuerWhenSet(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping db-backed service test in short mode")
 	}
+	t.Parallel()
 	database, ctx := newServiceSuiteDB(t)
 
 	syncRepo := repository.NewSyncRepositoryWithPool(database.Queries, database.Pool)
@@ -159,6 +160,7 @@ func TestSyncService_TriggerSync_DedupedIsNoError(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping db-backed service test in short mode")
 	}
+	t.Parallel()
 	database, ctx := newServiceSuiteDB(t)
 
 	syncRepo := repository.NewSyncRepositoryWithPool(database.Queries, database.Pool)
@@ -268,6 +270,7 @@ func TestSyncService_TriggerSync_NoLongerReadsSyncingStatus(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping db-backed service test in short mode")
 	}
+	t.Parallel()
 	database, ctx := newServiceSuiteDB(t)
 
 	syncRepo := repository.NewSyncRepositoryWithPool(database.Queries, database.Pool)


### PR DESCRIPTION
Part of #428 (the `tests/api` portion; PR #440 shipped the top-level `backend/tests` portion). This does NOT close #428 — the `tests/api` flip audit (#429) and other portions may remain.

## What this does

Applies PR #440's per-test ephemeral-clone machinery to the `tests/api` package's river-heavy ingest files plus the three river funcs of `tests/unit/sync_service_test.go`, with a profiler-informed refinement: not every "river-heavy" func actually works River jobs, and the ones that don't neither need `client.Start()` nor a full isolated clone.

- Drops the never-needed River `Start()` from the enqueue-only `tests/api` ingest setups (`setupIngestTestRouter`, `setupRawIngestEnv`, `setupPhoneCallIngestEnv`). These funcs only `Insert`/`InsertTx` and count rows synchronously — they never WORK jobs (no-op workers, zero `waitFor`/`Eventually`), and `InsertTx` needs only `PoolIsSet()`, not a running client. Starting the client spun up the leadership Elector whose teardown burned ~5s resigning against a closing pool (the profiler root cause). The one func that genuinely works jobs (`ingest_raw_message_e2e_test.go` — real aggregator + recorder, polls) keeps `Start(ctx)`.
- Isolates the DB-wide-river-count / singleton-mac_host funcs via per-test clones. The two `raw_message` files (DB-wide `CountRiverJobsByKind`) and `phone_call_ingest` + the e2e file (singleton `mac_host` + DB-wide `DeleteAllMacHosts` teardown) move to a new `tests/api` isolated-River clone helper (tagged/fallback pair, mirroring the existing `shared_testdb` split). The other funcs flip on the shared package DB — their reads are already namespace-scoped (`uniqueIngestSource`/`CountBySource`, `args->>'source'`) and they don't touch the singleton.
- Flips 35 funcs to `t.Parallel()` (18 `ingest_test` + 10 `ingest_raw_message` + 6 `phone_call` + 1 e2e), plus the 3 enqueue-only `sync_service` funcs.
- Removes a redundant per-setup `gin.SetMode(gin.TestMode)` that surfaced as a data race under parallelism: `gin_test.go`'s package `init()` already sets `TestMode` once before any test runs, and the per-setup calls wrote the gin global concurrently with parallel route registration (`gin.IsDebugging` reads the same global in `debugPrintRoute`).

## Honest framing of the win

Local fast-suite drops ~4-5s, MOST of it the `Start()`-drop (a profiler fix that removes the ~5s leadership-Elector teardown — it would land identically as a standalone one-line change), NOT the parallelization. The `t.Parallel()` flip's incremental contribution is overlap of the remaining funcs once the 5s floor is gone, capped where `tests/api` crosses under the `tests`-package floor (~12s). CI is unaffected: it runs pinned `-p4 -parallel4` and is build-bound (established by #431); this PR changes no build inputs and no CI `-p`.

## Validation

- `go build ./...` clean; `go vet` clean on both tag paths (no-tag unit build + `integration_testdb`).
- Collision-detector gate: `-tags integration_testdb -race -count=10 -shuffle=on -p 9 -parallel 9` on the `tests/api` river cohort and the 3 `sync_service` funcs — all `--- PASS` (non-empty DSN, no false-green self-skip), 0 data races. The DB-wide `countRiverJobs(kind)` assertions pass under `-count=10` only because isolation works.
- Full-package `-count=2 -race` (including the serial `mac_host` cohort) — both packages `ok`, 0 races.
- `make test-integration-fast` — all 8 packages `ok`.
- Peak connections sampled at 24 (well under the ~187 usable ceiling); `make test-clean-clones` — 0 leaked clones.

## Not touched

The `mac_host_*` auth/pairing singleton cluster (`setupMacHostEnv` / `setupMeetingNoteIngestEnv`) stays serial — separate deferred redesign. No production Go, schema, frontend, `ci.yml`, `Makefile`, or `scripts/`.