### PR TITLE
fix(infra): A0 cutover hardening (gate widths, runbook corrections)

### DIFF
--- a/infra/cutover-runbook.md
+++ b/infra/cutover-runbook.md
@@ -80,8 +80,11 @@ ssh "$PI_HOST" 'sudo systemctl stop personalcrm-backend personalcrm-frontend'
 ssh "$PI_HOST" 'cd /srv/personalcrm/infra && docker compose stop postgres'   # old DB stays on its pristine volume = rollback anchor
 
 # 2. permanent crm home change (deferred from Phase 1; crm now has no live procs).
-#    Bounce linger so the user manager (user@995) restarts with HOME=/var/lib/personalcrm.
-ssh "$PI_HOST" 'sudo loginctl disable-linger crm'
+#    Bounce linger so the user manager restarts with HOME=/var/lib/personalcrm.
+#    IMPORTANT: disable-linger stops user@<uid> ASYNCHRONOUSLY; usermod refuses
+#    while ANY crm process (incl. a still-dying user manager) exists. Stop it
+#    explicitly and WAIT for it dead before usermod, or usermod aborts mid-flip.
+ssh "$PI_HOST" 'sudo loginctl disable-linger crm; sudo systemctl stop "user@$(id -u crm).service"; for i in $(seq 1 30); do systemctl is-active --quiet "user@$(id -u crm).service" || break; sleep 1; done'
 ssh "$PI_HOST" 'sudo usermod -d /var/lib/personalcrm crm && getent passwd crm'
 ssh "$PI_HOST" 'sudo loginctl enable-linger crm'; sleep 2
 
@@ -92,7 +95,7 @@ ssh "$PI_HOST" "cd /tmp && until sudo -n -u crm HOME=/var/lib/personalcrm XDG_RU
 cat /tmp/crm-cutover.dump | crm_podman exec -i crm-postgres pg_restore -U crm_user -d personal_crm --no-owner --clean --if-exists
 
 crm_ctl start personalcrm-backend.service personalcrm-frontend.service
-ssh "$PI_HOST" 'sudo systemctl reload caddy'   # pick up the X-API-Key injection
+ssh "$PI_HOST" 'sudo systemctl restart caddy'   # RESTART (not reload): reload runs in the existing process and won't pick up the newly-wired CRM_API_KEY EnvironmentFile; only restart re-reads it. Sub-second.
 
 # 4. confirm cgroup-v2 delegation actually bit (proven in VM; confirm on Pi)
 crm_ctl show personalcrm-backend.service -p MemoryMax --value   # expect 536870912
@@ -115,8 +118,11 @@ The old Docker Postgres volume is untouched, so rollback is lossless:
 
 ```bash
 crm_ctl stop personalcrm-frontend.service personalcrm-backend.service personalcrm-database.service
-ssh "$PI_HOST" 'cd /srv/personalcrm/infra && docker compose start postgres'
-ssh "$PI_HOST" 'sudo cp '"$(pwd)"'/infra/caddy/Caddyfile.orig /etc/caddy/Caddyfile && sudo systemctl reload caddy'  # restore pre-injection Caddyfile
+# up -d, NOT start: the old Docker container is removed if the Pi rebooted (the
+# disabled-but-active database oneshot runs `compose down` on shutdown); the named
+# volume survives, so `up -d` recreates the container on the pristine pre-cutover data.
+ssh "$PI_HOST" 'cd /srv/personalcrm/infra && docker compose up -d postgres'
+ssh "$PI_HOST" 'sudo cp /etc/caddy/Caddyfile.orig /etc/caddy/Caddyfile && sudo systemctl restart caddy'  # restore pre-injection Caddyfile
 ssh "$PI_HOST" 'sudo systemctl start personalcrm-backend personalcrm-frontend'
 ```
 

--- a/infra/quadlet/personalcrm-backend.container
+++ b/infra/quadlet/personalcrm-backend.container
@@ -39,7 +39,7 @@ TimeoutStopSec=30s
 # Boot/restart health gate (distroless image has no curl, so gate host-side against
 # the published port). Restores parity with the old native ExecStartPost curl gate:
 # the unit isn't "active" until /health (incl. DB) returns 200; else Restart=always.
-ExecStartPost=/bin/bash -c 'for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do curl -sf http://127.0.0.1:8080/health >/dev/null && exit 0; sleep 1; done; exit 1'
+ExecStartPost=/bin/bash -c 'for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40; do curl -sf http://127.0.0.1:8080/health >/dev/null && exit 0; sleep 1; done; exit 1'
 # Resource ceilings carried over from the systemd unit (need cgroup-v2
 # controller delegation for the crm user slice -- verified in rehearsal).
 MemoryMax=512M

--- a/infra/quadlet/personalcrm-frontend.container
+++ b/infra/quadlet/personalcrm-frontend.container
@@ -30,7 +30,7 @@ MemoryMax=512M
 CPUQuota=150%
 # Boot/restart health gate, host-side against the published port (parity with the
 # old native unit). Not "active" until the Next server answers; else Restart=always.
-ExecStartPost=/bin/bash -c 'for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do curl -sf http://127.0.0.1:3001 >/dev/null && exit 0; sleep 1; done; exit 1'
+ExecStartPost=/bin/bash -c 'for n in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25; do curl -sf http://127.0.0.1:3001 >/dev/null && exit 0; sleep 1; done; exit 1'
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
Follow-up to #443, capturing fixes from the live A0 cutover (the stack is now in prod + reboot-tested):

- **Health gate widths** 20s→40s (backend) / 15s→25s (frontend) so a cold-start (migrations + DB warmup) passes the first `systemctl start` on reboot — verified by a reboot test (NRestarts=0). Already live on the Pi; this syncs the repo.
- **Runbook `reload`→`restart caddy`** — reload runs in the existing process and won't load the newly-wired `CRM_API_KEY` EnvironmentFile; only restart re-reads it.
- **Runbook `usermod` timing** — stop `user@<uid>` + bounded wait before `usermod -d` (`disable-linger` is async; usermod refuses while the dying user manager still has a process — this aborted the first flip attempt).
- **Runbook rollback** uses `docker compose up -d postgres` (not `start`) — the old container is removed on reboot via the disabled oneshot's `compose down`; the named volume survives, so `up -d` recreates on the pristine data. Plus a Pi-side `Caddyfile.orig` path fix.

Doc + unit-file only; reviewed (Codex rate-limited → Claude review PASS).