### PR TITLE
fix(infra): don't inject X-API-Key onto Mac-daemon requests at Caddy edge

### DIFF
--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -5,11 +5,25 @@
 # both upstreams are the loopback ports the rootless containers publish.
 #
 # NEW in A0: inject X-API-Key on /api/* from the edge env (CRM_API_KEY), since
-# the frontend image is built key-less. This replaces whatever (empty) X-API-Key
-# the browser sends. Set CRM_API_KEY in Caddy's systemd environment, e.g.:
+# the frontend image is built key-less. This replaces the (empty) X-API-Key the
+# browser sends. Set CRM_API_KEY in Caddy's systemd environment, e.g.:
 #   systemctl edit caddy  ->  [Service]\nEnvironmentFile=/etc/caddy/crm.env
 # where /etc/caddy/crm.env holds CRM_API_KEY=<the prod API key> (root-owned, 0600).
+#
+# IMPORTANT: the Mac daemon authenticates host requests with X-Mac-Host-ID (NOT
+# X-API-Key). The backend rejects requests that carry BOTH (400 AMBIGUOUS_AUTH),
+# so we must NOT inject X-API-Key onto daemon requests — only onto browser
+# requests (which carry no X-Mac-Host-ID).
 :80 {
+	# Daemon requests (have X-Mac-Host-ID): proxy through untouched, no key injection.
+	@daemon {
+		path /api/*
+		header X-Mac-Host-ID *
+	}
+	handle @daemon {
+		reverse_proxy localhost:8080
+	}
+	# Browser API requests: inject the key (frontend image is key-less).
 	handle /api/* {
 		reverse_proxy localhost:8080 {
 			header_up X-API-Key {env.CRM_API_KEY}


### PR DESCRIPTION
Post-cutover hotfix (already live on the Pi; this syncs the repo + protects staging reuse).

The A0 Caddy edge injected `X-API-Key` on all `/api/*`. The Mac daemon authenticates host requests with `X-Mac-Host-ID` (not X-API-Key), so post-cutover its requests arrived with both headers → backend `400 AMBIGUOUS_AUTH` → stale daemon connection.

Fix: a `@daemon` matcher (`path /api/*` + `header X-Mac-Host-ID *`) routes daemon requests through untouched; only browser `/api/*` gets the key injected.

Verified live: `crm-mac doctor` → pi_reachability PASS; browser edge /api still 200. Reviewed (no auth bypass — forged X-Mac-Host-ID still hits the backend's independent Bearer pair-key check; header_up replaces not appends). Claude review PASS.