### PR TITLE
fix: independent AES-GCM nonces for OAuth tokens, persist-on-refresh

### DIFF
--- a/backend/internal/crypto/encrypt.go
+++ b/backend/internal/crypto/encrypt.go
@@ -61,38 +61,6 @@ func (e *TokenEncryptor) Encrypt(plaintext string) (ciphertext, nonce []byte, er
 	return ciphertext, nonce, nil
 }
 
-// EncryptWithNonce encrypts plaintext using AES-256-GCM with a provided nonce
-// This is useful when you need to encrypt multiple values with the same nonce
-// WARNING: Using the same nonce with the same key is a security risk in GCM
-// Only use this when you're sure the nonce is unique for this key
-func (e *TokenEncryptor) EncryptWithNonce(plaintext string, nonce []byte) (ciphertext []byte, err error) {
-	if plaintext == "" {
-		return nil, errors.New("plaintext cannot be empty")
-	}
-	if len(nonce) == 0 {
-		return nil, errors.New("nonce cannot be empty")
-	}
-
-	block, err := aes.NewCipher(e.key)
-	if err != nil {
-		return nil, fmt.Errorf("create cipher: %w", err)
-	}
-
-	gcm, err := cipher.NewGCM(block)
-	if err != nil {
-		return nil, fmt.Errorf("create GCM: %w", err)
-	}
-
-	if len(nonce) != gcm.NonceSize() {
-		return nil, fmt.Errorf("invalid nonce size: expected %d, got %d", gcm.NonceSize(), len(nonce))
-	}
-
-	// Encrypt the plaintext
-	ciphertext = gcm.Seal(nil, nonce, []byte(plaintext), nil)
-
-	return ciphertext, nil
-}
-
 // Decrypt decrypts ciphertext using AES-256-GCM
 func (e *TokenEncryptor) Decrypt(ciphertext, nonce []byte) (string, error) {
 	if len(ciphertext) == 0 {

--- a/backend/internal/db/models.go
+++ b/backend/internal/db/models.go
@@ -394,6 +394,7 @@ type OauthCredential struct {
 	Scopes                []string           `json:"scopes"`
 	CreatedAt             pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt             pgtype.Timestamptz `json:"updated_at"`
+	RefreshTokenNonce     []byte             `json:"refresh_token_nonce"`
 }
 
 type PgConstraint struct {

--- a/backend/internal/db/oauth.sql.go
+++ b/backend/internal/db/oauth.sql.go
@@ -289,7 +289,8 @@ UPDATE oauth_credential SET
     refresh_token_encrypted = COALESCE($2, refresh_token_encrypted),
     refresh_token_nonce = CASE
         WHEN $2 IS NOT NULL THEN $3
-        ELSE refresh_token_nonce
+        WHEN refresh_token_encrypted IS NOT NULL THEN COALESCE(refresh_token_nonce, encryption_nonce)
+        ELSE NULL
     END,
     encryption_nonce = $4,
     expires_at = $5,
@@ -309,7 +310,12 @@ type UpdateOAuthCredentialTokensParams struct {
 
 // Update only the token data (for token refresh).
 // refresh_token_nonce tracks refresh_token_encrypted: it is only overwritten when
-// a new refresh token is supplied, otherwise the stored ciphertext and nonce stay.
+// a new refresh token is supplied. When the stored ciphertext is preserved, a
+// NULL nonce (legacy row whose refresh token was sealed with the shared
+// encryption_nonce) is captured into the dedicated column before encryption_nonce
+// rotates to the new access-token nonce — otherwise the preserved refresh token
+// would become undecryptable. SET right-hand sides read the pre-update row, so
+// the captured values are the old ones regardless of assignment order.
 func (q *Queries) UpdateOAuthCredentialTokens(ctx context.Context, arg UpdateOAuthCredentialTokensParams) (*OauthCredential, error) {
 	row := q.db.QueryRow(ctx, UpdateOAuthCredentialTokens,
 		arg.AccessTokenEncrypted,
@@ -368,7 +374,8 @@ ON CONFLICT (provider, account_id) DO UPDATE SET
     refresh_token_encrypted = COALESCE(EXCLUDED.refresh_token_encrypted, oauth_credential.refresh_token_encrypted),
     refresh_token_nonce = CASE
         WHEN EXCLUDED.refresh_token_encrypted IS NOT NULL THEN EXCLUDED.refresh_token_nonce
-        ELSE oauth_credential.refresh_token_nonce
+        WHEN oauth_credential.refresh_token_encrypted IS NOT NULL THEN COALESCE(oauth_credential.refresh_token_nonce, oauth_credential.encryption_nonce)
+        ELSE NULL
     END,
     encryption_nonce = EXCLUDED.encryption_nonce,
     token_type = EXCLUDED.token_type,
@@ -393,8 +400,12 @@ type UpsertOAuthCredentialParams struct {
 
 // Insert or update an OAuth credential.
 // refresh_token_nonce is kept in sync with refresh_token_encrypted: when a new
-// refresh token is provided both columns update together, otherwise the existing
-// ciphertext and its nonce are preserved.
+// refresh token is provided both columns update together. When the existing
+// ciphertext is preserved, a NULL nonce (legacy row whose refresh token was
+// sealed with the shared encryption_nonce) is captured into the dedicated column
+// before encryption_nonce rotates to the new access-token nonce — otherwise the
+// preserved refresh token would become undecryptable. With no ciphertext at all
+// the nonce is NULL.
 func (q *Queries) UpsertOAuthCredential(ctx context.Context, arg UpsertOAuthCredentialParams) (*OauthCredential, error) {
 	row := q.db.QueryRow(ctx, UpsertOAuthCredential,
 		arg.Provider,

--- a/backend/internal/db/oauth.sql.go
+++ b/backend/internal/db/oauth.sql.go
@@ -45,7 +45,7 @@ func (q *Queries) DeleteOAuthCredentialByProvider(ctx context.Context, provider 
 
 const GetOAuthCredential = `-- name: GetOAuthCredential :one
 
-SELECT id, provider, account_id, account_name, access_token_encrypted, refresh_token_encrypted, encryption_nonce, token_type, expires_at, scopes, created_at, updated_at FROM oauth_credential
+SELECT id, provider, account_id, account_name, access_token_encrypted, refresh_token_encrypted, encryption_nonce, token_type, expires_at, scopes, created_at, updated_at, refresh_token_nonce FROM oauth_credential
 WHERE provider = $1 AND account_id = $2
 `
 
@@ -72,12 +72,13 @@ func (q *Queries) GetOAuthCredential(ctx context.Context, arg GetOAuthCredential
 		&i.Scopes,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.RefreshTokenNonce,
 	)
 	return &i, err
 }
 
 const GetOAuthCredentialByID = `-- name: GetOAuthCredentialByID :one
-SELECT id, provider, account_id, account_name, access_token_encrypted, refresh_token_encrypted, encryption_nonce, token_type, expires_at, scopes, created_at, updated_at FROM oauth_credential
+SELECT id, provider, account_id, account_name, access_token_encrypted, refresh_token_encrypted, encryption_nonce, token_type, expires_at, scopes, created_at, updated_at, refresh_token_nonce FROM oauth_credential
 WHERE id = $1
 `
 
@@ -98,6 +99,7 @@ func (q *Queries) GetOAuthCredentialByID(ctx context.Context, id pgtype.UUID) (*
 		&i.Scopes,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.RefreshTokenNonce,
 	)
 	return &i, err
 }
@@ -145,7 +147,7 @@ func (q *Queries) GetOAuthCredentialStatus(ctx context.Context, id pgtype.UUID) 
 }
 
 const ListAllOAuthCredentials = `-- name: ListAllOAuthCredentials :many
-SELECT id, provider, account_id, account_name, access_token_encrypted, refresh_token_encrypted, encryption_nonce, token_type, expires_at, scopes, created_at, updated_at FROM oauth_credential
+SELECT id, provider, account_id, account_name, access_token_encrypted, refresh_token_encrypted, encryption_nonce, token_type, expires_at, scopes, created_at, updated_at, refresh_token_nonce FROM oauth_credential
 ORDER BY provider, created_at DESC
 `
 
@@ -172,6 +174,7 @@ func (q *Queries) ListAllOAuthCredentials(ctx context.Context) ([]*OauthCredenti
 			&i.Scopes,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.RefreshTokenNonce,
 		); err != nil {
 			return nil, err
 		}
@@ -240,7 +243,7 @@ func (q *Queries) ListOAuthCredentialStatuses(ctx context.Context, provider stri
 }
 
 const ListOAuthCredentials = `-- name: ListOAuthCredentials :many
-SELECT id, provider, account_id, account_name, access_token_encrypted, refresh_token_encrypted, encryption_nonce, token_type, expires_at, scopes, created_at, updated_at FROM oauth_credential
+SELECT id, provider, account_id, account_name, access_token_encrypted, refresh_token_encrypted, encryption_nonce, token_type, expires_at, scopes, created_at, updated_at, refresh_token_nonce FROM oauth_credential
 WHERE provider = $1
 ORDER BY created_at DESC
 `
@@ -268,6 +271,7 @@ func (q *Queries) ListOAuthCredentials(ctx context.Context, provider string) ([]
 			&i.Scopes,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.RefreshTokenNonce,
 		); err != nil {
 			return nil, err
 		}
@@ -281,31 +285,39 @@ func (q *Queries) ListOAuthCredentials(ctx context.Context, provider string) ([]
 
 const UpdateOAuthCredentialTokens = `-- name: UpdateOAuthCredentialTokens :one
 UPDATE oauth_credential SET
-    access_token_encrypted = $2,
-    refresh_token_encrypted = COALESCE($3, refresh_token_encrypted),
+    access_token_encrypted = $1,
+    refresh_token_encrypted = COALESCE($2, refresh_token_encrypted),
+    refresh_token_nonce = CASE
+        WHEN $2 IS NOT NULL THEN $3
+        ELSE refresh_token_nonce
+    END,
     encryption_nonce = $4,
     expires_at = $5,
     updated_at = NOW()
-WHERE id = $1
-RETURNING id, provider, account_id, account_name, access_token_encrypted, refresh_token_encrypted, encryption_nonce, token_type, expires_at, scopes, created_at, updated_at
+WHERE id = $6
+RETURNING id, provider, account_id, account_name, access_token_encrypted, refresh_token_encrypted, encryption_nonce, token_type, expires_at, scopes, created_at, updated_at, refresh_token_nonce
 `
 
 type UpdateOAuthCredentialTokensParams struct {
-	ID                    pgtype.UUID        `json:"id"`
 	AccessTokenEncrypted  []byte             `json:"access_token_encrypted"`
 	RefreshTokenEncrypted []byte             `json:"refresh_token_encrypted"`
+	RefreshTokenNonce     []byte             `json:"refresh_token_nonce"`
 	EncryptionNonce       []byte             `json:"encryption_nonce"`
 	ExpiresAt             pgtype.Timestamptz `json:"expires_at"`
+	ID                    pgtype.UUID        `json:"id"`
 }
 
-// Update only the token data (for token refresh)
+// Update only the token data (for token refresh).
+// refresh_token_nonce tracks refresh_token_encrypted: it is only overwritten when
+// a new refresh token is supplied, otherwise the stored ciphertext and nonce stay.
 func (q *Queries) UpdateOAuthCredentialTokens(ctx context.Context, arg UpdateOAuthCredentialTokensParams) (*OauthCredential, error) {
 	row := q.db.QueryRow(ctx, UpdateOAuthCredentialTokens,
-		arg.ID,
 		arg.AccessTokenEncrypted,
 		arg.RefreshTokenEncrypted,
+		arg.RefreshTokenNonce,
 		arg.EncryptionNonce,
 		arg.ExpiresAt,
+		arg.ID,
 	)
 	var i OauthCredential
 	err := row.Scan(
@@ -321,6 +333,7 @@ func (q *Queries) UpdateOAuthCredentialTokens(ctx context.Context, arg UpdateOAu
 		&i.Scopes,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.RefreshTokenNonce,
 	)
 	return &i, err
 }
@@ -332,21 +345,37 @@ INSERT INTO oauth_credential (
     account_name,
     access_token_encrypted,
     refresh_token_encrypted,
+    refresh_token_nonce,
     encryption_nonce,
     token_type,
     expires_at,
     scopes
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+) VALUES (
+    $1,
+    $2,
+    $3,
+    $4,
+    $5,
+    $6,
+    $7,
+    $8,
+    $9,
+    $10
+)
 ON CONFLICT (provider, account_id) DO UPDATE SET
     account_name = EXCLUDED.account_name,
     access_token_encrypted = EXCLUDED.access_token_encrypted,
     refresh_token_encrypted = COALESCE(EXCLUDED.refresh_token_encrypted, oauth_credential.refresh_token_encrypted),
+    refresh_token_nonce = CASE
+        WHEN EXCLUDED.refresh_token_encrypted IS NOT NULL THEN EXCLUDED.refresh_token_nonce
+        ELSE oauth_credential.refresh_token_nonce
+    END,
     encryption_nonce = EXCLUDED.encryption_nonce,
     token_type = EXCLUDED.token_type,
     expires_at = EXCLUDED.expires_at,
     scopes = EXCLUDED.scopes,
     updated_at = NOW()
-RETURNING id, provider, account_id, account_name, access_token_encrypted, refresh_token_encrypted, encryption_nonce, token_type, expires_at, scopes, created_at, updated_at
+RETURNING id, provider, account_id, account_name, access_token_encrypted, refresh_token_encrypted, encryption_nonce, token_type, expires_at, scopes, created_at, updated_at, refresh_token_nonce
 `
 
 type UpsertOAuthCredentialParams struct {
@@ -355,13 +384,17 @@ type UpsertOAuthCredentialParams struct {
 	AccountName           pgtype.Text        `json:"account_name"`
 	AccessTokenEncrypted  []byte             `json:"access_token_encrypted"`
 	RefreshTokenEncrypted []byte             `json:"refresh_token_encrypted"`
+	RefreshTokenNonce     []byte             `json:"refresh_token_nonce"`
 	EncryptionNonce       []byte             `json:"encryption_nonce"`
 	TokenType             pgtype.Text        `json:"token_type"`
 	ExpiresAt             pgtype.Timestamptz `json:"expires_at"`
 	Scopes                []string           `json:"scopes"`
 }
 
-// Insert or update an OAuth credential
+// Insert or update an OAuth credential.
+// refresh_token_nonce is kept in sync with refresh_token_encrypted: when a new
+// refresh token is provided both columns update together, otherwise the existing
+// ciphertext and its nonce are preserved.
 func (q *Queries) UpsertOAuthCredential(ctx context.Context, arg UpsertOAuthCredentialParams) (*OauthCredential, error) {
 	row := q.db.QueryRow(ctx, UpsertOAuthCredential,
 		arg.Provider,
@@ -369,6 +402,7 @@ func (q *Queries) UpsertOAuthCredential(ctx context.Context, arg UpsertOAuthCred
 		arg.AccountName,
 		arg.AccessTokenEncrypted,
 		arg.RefreshTokenEncrypted,
+		arg.RefreshTokenNonce,
 		arg.EncryptionNonce,
 		arg.TokenType,
 		arg.ExpiresAt,
@@ -388,6 +422,7 @@ func (q *Queries) UpsertOAuthCredential(ctx context.Context, arg UpsertOAuthCred
 		&i.Scopes,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.RefreshTokenNonce,
 	)
 	return &i, err
 }

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -1738,7 +1738,9 @@ type Querier interface {
 	// runs its own UPDATE path that also clears deleted_at).
 	UpdateMeetingNoteOnResync(ctx context.Context, arg UpdateMeetingNoteOnResyncParams) (*MeetingNote, error)
 	UpdateNote(ctx context.Context, arg UpdateNoteParams) (*Note, error)
-	// Update only the token data (for token refresh)
+	// Update only the token data (for token refresh).
+	// refresh_token_nonce tracks refresh_token_encrypted: it is only overwritten when
+	// a new refresh token is supplied, otherwise the stored ciphertext and nonce stay.
 	UpdateOAuthCredentialTokens(ctx context.Context, arg UpdateOAuthCredentialTokensParams) (*OauthCredential, error)
 	UpdateSyncStateCursor(ctx context.Context, arg UpdateSyncStateCursorParams) error
 	UpdateSyncStateEnabled(ctx context.Context, arg UpdateSyncStateEnabledParams) (*ExternalSyncState, error)
@@ -1800,7 +1802,10 @@ type Querier interface {
 	// come from the Pi ingest service identity-match path. mac_host_id is
 	// provenance — multi-host dedup is by guid, not by host.
 	UpsertMessagesMessage(ctx context.Context, arg UpsertMessagesMessageParams) (*MessagesMessage, error)
-	// Insert or update an OAuth credential
+	// Insert or update an OAuth credential.
+	// refresh_token_nonce is kept in sync with refresh_token_encrypted: when a new
+	// refresh token is provided both columns update together, otherwise the existing
+	// ciphertext and its nonce are preserved.
 	UpsertOAuthCredential(ctx context.Context, arg UpsertOAuthCredentialParams) (*OauthCredential, error)
 	// Insert with no-op on call_unique_id conflict. peer_normalized comes from
 	// the daemon (canonicalized via HandleNormalization). matched_contact_id

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -1740,7 +1740,12 @@ type Querier interface {
 	UpdateNote(ctx context.Context, arg UpdateNoteParams) (*Note, error)
 	// Update only the token data (for token refresh).
 	// refresh_token_nonce tracks refresh_token_encrypted: it is only overwritten when
-	// a new refresh token is supplied, otherwise the stored ciphertext and nonce stay.
+	// a new refresh token is supplied. When the stored ciphertext is preserved, a
+	// NULL nonce (legacy row whose refresh token was sealed with the shared
+	// encryption_nonce) is captured into the dedicated column before encryption_nonce
+	// rotates to the new access-token nonce — otherwise the preserved refresh token
+	// would become undecryptable. SET right-hand sides read the pre-update row, so
+	// the captured values are the old ones regardless of assignment order.
 	UpdateOAuthCredentialTokens(ctx context.Context, arg UpdateOAuthCredentialTokensParams) (*OauthCredential, error)
 	UpdateSyncStateCursor(ctx context.Context, arg UpdateSyncStateCursorParams) error
 	UpdateSyncStateEnabled(ctx context.Context, arg UpdateSyncStateEnabledParams) (*ExternalSyncState, error)
@@ -1804,8 +1809,12 @@ type Querier interface {
 	UpsertMessagesMessage(ctx context.Context, arg UpsertMessagesMessageParams) (*MessagesMessage, error)
 	// Insert or update an OAuth credential.
 	// refresh_token_nonce is kept in sync with refresh_token_encrypted: when a new
-	// refresh token is provided both columns update together, otherwise the existing
-	// ciphertext and its nonce are preserved.
+	// refresh token is provided both columns update together. When the existing
+	// ciphertext is preserved, a NULL nonce (legacy row whose refresh token was
+	// sealed with the shared encryption_nonce) is captured into the dedicated column
+	// before encryption_nonce rotates to the new access-token nonce — otherwise the
+	// preserved refresh token would become undecryptable. With no ciphertext at all
+	// the nonce is NULL.
 	UpsertOAuthCredential(ctx context.Context, arg UpsertOAuthCredentialParams) (*OauthCredential, error)
 	// Insert with no-op on call_unique_id conflict. peer_normalized comes from
 	// the daemon (canonicalized via HandleNormalization). matched_contact_id

--- a/backend/internal/db/queries/oauth.sql
+++ b/backend/internal/db/queries/oauth.sql
@@ -24,8 +24,12 @@ ORDER BY provider, created_at DESC;
 -- name: UpsertOAuthCredential :one
 -- Insert or update an OAuth credential.
 -- refresh_token_nonce is kept in sync with refresh_token_encrypted: when a new
--- refresh token is provided both columns update together, otherwise the existing
--- ciphertext and its nonce are preserved.
+-- refresh token is provided both columns update together. When the existing
+-- ciphertext is preserved, a NULL nonce (legacy row whose refresh token was
+-- sealed with the shared encryption_nonce) is captured into the dedicated column
+-- before encryption_nonce rotates to the new access-token nonce — otherwise the
+-- preserved refresh token would become undecryptable. With no ciphertext at all
+-- the nonce is NULL.
 INSERT INTO oauth_credential (
     provider,
     account_id,
@@ -55,7 +59,8 @@ ON CONFLICT (provider, account_id) DO UPDATE SET
     refresh_token_encrypted = COALESCE(EXCLUDED.refresh_token_encrypted, oauth_credential.refresh_token_encrypted),
     refresh_token_nonce = CASE
         WHEN EXCLUDED.refresh_token_encrypted IS NOT NULL THEN EXCLUDED.refresh_token_nonce
-        ELSE oauth_credential.refresh_token_nonce
+        WHEN oauth_credential.refresh_token_encrypted IS NOT NULL THEN COALESCE(oauth_credential.refresh_token_nonce, oauth_credential.encryption_nonce)
+        ELSE NULL
     END,
     encryption_nonce = EXCLUDED.encryption_nonce,
     token_type = EXCLUDED.token_type,
@@ -67,13 +72,19 @@ RETURNING *;
 -- name: UpdateOAuthCredentialTokens :one
 -- Update only the token data (for token refresh).
 -- refresh_token_nonce tracks refresh_token_encrypted: it is only overwritten when
--- a new refresh token is supplied, otherwise the stored ciphertext and nonce stay.
+-- a new refresh token is supplied. When the stored ciphertext is preserved, a
+-- NULL nonce (legacy row whose refresh token was sealed with the shared
+-- encryption_nonce) is captured into the dedicated column before encryption_nonce
+-- rotates to the new access-token nonce — otherwise the preserved refresh token
+-- would become undecryptable. SET right-hand sides read the pre-update row, so
+-- the captured values are the old ones regardless of assignment order.
 UPDATE oauth_credential SET
     access_token_encrypted = sqlc.arg(access_token_encrypted),
     refresh_token_encrypted = COALESCE(sqlc.arg(refresh_token_encrypted), refresh_token_encrypted),
     refresh_token_nonce = CASE
         WHEN sqlc.arg(refresh_token_encrypted) IS NOT NULL THEN sqlc.arg(refresh_token_nonce)
-        ELSE refresh_token_nonce
+        WHEN refresh_token_encrypted IS NOT NULL THEN COALESCE(refresh_token_nonce, encryption_nonce)
+        ELSE NULL
     END,
     encryption_nonce = sqlc.arg(encryption_nonce),
     expires_at = sqlc.arg(expires_at),

--- a/backend/internal/db/queries/oauth.sql
+++ b/backend/internal/db/queries/oauth.sql
@@ -22,22 +22,41 @@ SELECT * FROM oauth_credential
 ORDER BY provider, created_at DESC;
 
 -- name: UpsertOAuthCredential :one
--- Insert or update an OAuth credential
+-- Insert or update an OAuth credential.
+-- refresh_token_nonce is kept in sync with refresh_token_encrypted: when a new
+-- refresh token is provided both columns update together, otherwise the existing
+-- ciphertext and its nonce are preserved.
 INSERT INTO oauth_credential (
     provider,
     account_id,
     account_name,
     access_token_encrypted,
     refresh_token_encrypted,
+    refresh_token_nonce,
     encryption_nonce,
     token_type,
     expires_at,
     scopes
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+) VALUES (
+    sqlc.arg(provider),
+    sqlc.arg(account_id),
+    sqlc.arg(account_name),
+    sqlc.arg(access_token_encrypted),
+    sqlc.arg(refresh_token_encrypted),
+    sqlc.arg(refresh_token_nonce),
+    sqlc.arg(encryption_nonce),
+    sqlc.arg(token_type),
+    sqlc.arg(expires_at),
+    sqlc.arg(scopes)
+)
 ON CONFLICT (provider, account_id) DO UPDATE SET
     account_name = EXCLUDED.account_name,
     access_token_encrypted = EXCLUDED.access_token_encrypted,
     refresh_token_encrypted = COALESCE(EXCLUDED.refresh_token_encrypted, oauth_credential.refresh_token_encrypted),
+    refresh_token_nonce = CASE
+        WHEN EXCLUDED.refresh_token_encrypted IS NOT NULL THEN EXCLUDED.refresh_token_nonce
+        ELSE oauth_credential.refresh_token_nonce
+    END,
     encryption_nonce = EXCLUDED.encryption_nonce,
     token_type = EXCLUDED.token_type,
     expires_at = EXCLUDED.expires_at,
@@ -46,14 +65,20 @@ ON CONFLICT (provider, account_id) DO UPDATE SET
 RETURNING *;
 
 -- name: UpdateOAuthCredentialTokens :one
--- Update only the token data (for token refresh)
+-- Update only the token data (for token refresh).
+-- refresh_token_nonce tracks refresh_token_encrypted: it is only overwritten when
+-- a new refresh token is supplied, otherwise the stored ciphertext and nonce stay.
 UPDATE oauth_credential SET
-    access_token_encrypted = $2,
-    refresh_token_encrypted = COALESCE($3, refresh_token_encrypted),
-    encryption_nonce = $4,
-    expires_at = $5,
+    access_token_encrypted = sqlc.arg(access_token_encrypted),
+    refresh_token_encrypted = COALESCE(sqlc.arg(refresh_token_encrypted), refresh_token_encrypted),
+    refresh_token_nonce = CASE
+        WHEN sqlc.arg(refresh_token_encrypted) IS NOT NULL THEN sqlc.arg(refresh_token_nonce)
+        ELSE refresh_token_nonce
+    END,
+    encryption_nonce = sqlc.arg(encryption_nonce),
+    expires_at = sqlc.arg(expires_at),
     updated_at = NOW()
-WHERE id = $1
+WHERE id = sqlc.arg(id)
 RETURNING *;
 
 -- name: DeleteOAuthCredential :exec

--- a/backend/internal/google/oauth.go
+++ b/backend/internal/google/oauth.go
@@ -59,12 +59,24 @@ type OAuthServiceInterface interface {
 // Ensure OAuthService implements OAuthServiceInterface
 var _ OAuthServiceInterface = (*OAuthService)(nil)
 
+// defaultUserInfoEndpoint is Google's OpenID userinfo URL.
+const defaultUserInfoEndpoint = "https://www.googleapis.com/oauth2/v2/userinfo"
+
 // OAuthService handles Google OAuth2 authentication
 type OAuthService struct {
 	config    *oauth2.Config
 	repo      *repository.OAuthRepository
 	syncRepo  *repository.SyncRepository
 	encryptor *crypto.TokenEncryptor
+
+	// userInfoEndpoint is the URL queried for the account's email and name. It
+	// defaults to Google's endpoint and is overridable only for tests.
+	userInfoEndpoint string
+
+	// httpClient, when set, replaces the default HTTP client for token exchange,
+	// refresh, and userinfo requests. It exists only to let tests substitute an
+	// httptest server; production leaves it nil and uses oauth2's default client.
+	httpClient *http.Client
 }
 
 // UserInfo contains user information from Google
@@ -93,11 +105,40 @@ func NewOAuthService(cfg *config.Config, repo *repository.OAuthRepository, syncR
 	}
 
 	return &OAuthService{
-		config:    oauthConfig,
-		repo:      repo,
-		syncRepo:  syncRepo,
-		encryptor: encryptor,
+		config:           oauthConfig,
+		repo:             repo,
+		syncRepo:         syncRepo,
+		encryptor:        encryptor,
+		userInfoEndpoint: defaultUserInfoEndpoint,
 	}, nil
+}
+
+// SetHTTPClient sets a custom HTTP client used for token exchange, refresh, and
+// userinfo requests. It is intended for tests that substitute an httptest server.
+func (s *OAuthService) SetHTTPClient(client *http.Client) {
+	s.httpClient = client
+}
+
+// SetTokenEndpoint overrides the OAuth token endpoint. It is intended for tests
+// that point token exchange and refresh at an httptest server.
+func (s *OAuthService) SetTokenEndpoint(tokenURL string) {
+	s.config.Endpoint.TokenURL = tokenURL
+}
+
+// SetUserInfoEndpoint overrides the userinfo endpoint. It is intended for tests
+// that point the account lookup at an httptest server.
+func (s *OAuthService) SetUserInfoEndpoint(userInfoURL string) {
+	s.userInfoEndpoint = userInfoURL
+}
+
+// clientContext returns a context carrying the configured HTTP client so the
+// oauth2 library routes token exchange and refresh through it. When no custom
+// client is set it returns the original context, preserving production behavior.
+func (s *OAuthService) clientContext(ctx context.Context) context.Context {
+	if s.httpClient == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, oauth2.HTTPClient, s.httpClient)
 }
 
 // GenerateState generates a secure random state for CSRF protection
@@ -121,7 +162,7 @@ func (s *OAuthService) GetAuthURL(state string) string {
 // ExchangeCode exchanges an authorization code for tokens and stores them
 func (s *OAuthService) ExchangeCode(ctx context.Context, code string) (*repository.OAuthCredentialStatus, error) {
 	// Exchange code for token
-	token, err := s.config.Exchange(ctx, code)
+	token, err := s.config.Exchange(s.clientContext(ctx), code)
 	if err != nil {
 		return nil, fmt.Errorf("exchange code: %w", err)
 	}
@@ -159,24 +200,58 @@ func (s *OAuthService) GetClientForAccount(ctx context.Context, accountID string
 		return nil, err
 	}
 
-	// Create a token source that handles refresh
-	tokenSource := s.config.TokenSource(ctx, token)
+	// Wrap the refreshing token source so that any refresh — whether it happens
+	// now or later inside a long-running sync — is written back to the database.
+	// Without this only a construction-time refresh would be persisted, so every
+	// later refresh would be redundant and a rotated refresh token would be lost.
+	source := s.persistingTokenSource(ctx, cred.ID, token)
 
-	// Get a potentially refreshed token
-	newToken, err := tokenSource.Token()
+	return oauth2.NewClient(ctx, source), nil
+}
+
+// persistingTokenSource wraps the OAuth refreshing token source so that a token
+// changed by a refresh is persisted exactly once. oauth2.ReuseTokenSource caches
+// the token and only calls the wrapped source when the cached token is invalid,
+// so the persist callback runs only on an actual refresh.
+func (s *OAuthService) persistingTokenSource(ctx context.Context, id uuid.UUID, token *oauth2.Token) oauth2.TokenSource {
+	base := s.config.TokenSource(s.clientContext(ctx), token)
+	persisting := &persistOnRefreshSource{
+		ctx:      ctx,
+		service:  s,
+		id:       id,
+		previous: token,
+		source:   base,
+	}
+	return oauth2.ReuseTokenSource(token, persisting)
+}
+
+// persistOnRefreshSource persists a refreshed token before returning it. It is
+// only consulted by oauth2.ReuseTokenSource when the cached token is no longer
+// valid, so Token() returning a value different from the last seen token means a
+// real refresh occurred.
+type persistOnRefreshSource struct {
+	ctx      context.Context
+	service  *OAuthService
+	id       uuid.UUID
+	previous *oauth2.Token
+	source   oauth2.TokenSource
+}
+
+func (p *persistOnRefreshSource) Token() (*oauth2.Token, error) {
+	newToken, err := p.source.Token()
 	if err != nil {
 		return nil, fmt.Errorf("refresh token: %w", err)
 	}
 
-	// If token was refreshed, save the new one
-	if newToken.AccessToken != token.AccessToken {
-		if err := s.updateToken(ctx, cred.ID, newToken); err != nil {
-			// Log but don't fail - we still have a valid token
+	if newToken.AccessToken != p.previous.AccessToken {
+		if err := p.service.updateToken(p.ctx, p.id, newToken); err != nil {
+			// Log but don't fail - we still have a valid token to return.
 			logger.Warn().Err(err).Msg("failed to save refreshed token")
 		}
+		p.previous = newToken
 	}
 
-	return oauth2.NewClient(ctx, tokenSource), nil
+	return newToken, nil
 }
 
 // ListAccounts returns all connected Google accounts
@@ -245,9 +320,9 @@ func (s *OAuthService) RevokeAccount(ctx context.Context, id uuid.UUID) error {
 
 // getUserInfo fetches the user's email and name from Google
 func (s *OAuthService) getUserInfo(ctx context.Context, token *oauth2.Token) (*UserInfo, error) {
-	client := s.config.Client(ctx, token)
+	client := s.config.Client(s.clientContext(ctx), token)
 
-	resp, err := client.Get("https://www.googleapis.com/oauth2/v2/userinfo")
+	resp, err := client.Get(s.userInfoEndpoint)
 	if err != nil {
 		return nil, fmt.Errorf("fetch user info: %w", err)
 	}
@@ -277,10 +352,11 @@ func (s *OAuthService) storeToken(ctx context.Context, token *oauth2.Token, user
 		return nil, fmt.Errorf("encrypt access token: %w", err)
 	}
 
-	// Encrypt refresh token if present (reuse nonce from access token)
-	var refreshCiphertext []byte
+	// Encrypt refresh token if present, using its own nonce. Reusing the access
+	// token's nonce with the same key would leak keystream under AES-GCM.
+	var refreshCiphertext, refreshNonce []byte
 	if token.RefreshToken != "" {
-		refreshCiphertext, err = s.encryptor.EncryptWithNonce(token.RefreshToken, nonce)
+		refreshCiphertext, refreshNonce, err = s.encryptor.Encrypt(token.RefreshToken)
 		if err != nil {
 			return nil, fmt.Errorf("encrypt refresh token: %w", err)
 		}
@@ -302,6 +378,7 @@ func (s *OAuthService) storeToken(ctx context.Context, token *oauth2.Token, user
 		AccountName:           accountName,
 		AccessTokenEncrypted:  accessCiphertext,
 		RefreshTokenEncrypted: refreshCiphertext,
+		RefreshTokenNonce:     refreshNonce,
 		EncryptionNonce:       nonce,
 		TokenType:             token.TokenType,
 		ExpiresAt:             expiresAt,
@@ -317,10 +394,12 @@ func (s *OAuthService) updateToken(ctx context.Context, id uuid.UUID, token *oau
 		return fmt.Errorf("encrypt access token: %w", err)
 	}
 
-	// Encrypt refresh token if present (refresh tokens are sometimes rotated, reuse nonce from access token)
-	var refreshCiphertext []byte
+	// Encrypt refresh token if present (refresh tokens are sometimes rotated),
+	// using its own nonce. Reusing the access token's nonce with the same key
+	// would leak keystream under AES-GCM.
+	var refreshCiphertext, refreshNonce []byte
 	if token.RefreshToken != "" {
-		refreshCiphertext, err = s.encryptor.EncryptWithNonce(token.RefreshToken, nonce)
+		refreshCiphertext, refreshNonce, err = s.encryptor.Encrypt(token.RefreshToken)
 		if err != nil {
 			return fmt.Errorf("encrypt refresh token: %w", err)
 		}
@@ -334,6 +413,7 @@ func (s *OAuthService) updateToken(ctx context.Context, id uuid.UUID, token *oau
 	_, err = s.repo.UpdateTokens(ctx, id, repository.UpdateOAuthTokensRequest{
 		AccessTokenEncrypted:  accessCiphertext,
 		RefreshTokenEncrypted: refreshCiphertext,
+		RefreshTokenNonce:     refreshNonce,
 		EncryptionNonce:       nonce,
 		ExpiresAt:             expiresAt,
 	})
@@ -354,10 +434,16 @@ func (s *OAuthService) getToken(ctx context.Context, accountID string) (*oauth2.
 		return nil, nil, fmt.Errorf("decrypt access token: %w", err)
 	}
 
-	// Decrypt refresh token if present
+	// Decrypt refresh token if present. Rows written by the current code carry a
+	// dedicated refresh_token_nonce; legacy rows (NULL nonce) shared the access
+	// token's nonce, so fall back to it for backward compatibility.
 	var refreshToken string
 	if len(cred.RefreshTokenEncrypted) > 0 {
-		refreshToken, err = s.encryptor.Decrypt(cred.RefreshTokenEncrypted, cred.EncryptionNonce)
+		refreshNonce := cred.RefreshTokenNonce
+		if len(refreshNonce) == 0 {
+			refreshNonce = cred.EncryptionNonce
+		}
+		refreshToken, err = s.encryptor.Decrypt(cred.RefreshTokenEncrypted, refreshNonce)
 		if err != nil {
 			return nil, nil, fmt.Errorf("decrypt refresh token: %w", err)
 		}

--- a/backend/internal/repository/oauth.go
+++ b/backend/internal/repository/oauth.go
@@ -20,6 +20,7 @@ type OAuthCredential struct {
 	AccountName           *string    `json:"account_name,omitempty"`
 	AccessTokenEncrypted  []byte     `json:"-"` // Never expose in JSON
 	RefreshTokenEncrypted []byte     `json:"-"` // Never expose in JSON
+	RefreshTokenNonce     []byte     `json:"-"` // Never expose in JSON; NULL means legacy shared-nonce format
 	EncryptionNonce       []byte     `json:"-"` // Never expose in JSON
 	TokenType             string     `json:"token_type"`
 	ExpiresAt             *time.Time `json:"expires_at,omitempty"`
@@ -47,6 +48,7 @@ type UpsertOAuthCredentialRequest struct {
 	AccountName           *string
 	AccessTokenEncrypted  []byte
 	RefreshTokenEncrypted []byte
+	RefreshTokenNonce     []byte
 	EncryptionNonce       []byte
 	TokenType             string
 	ExpiresAt             *time.Time
@@ -57,6 +59,7 @@ type UpsertOAuthCredentialRequest struct {
 type UpdateOAuthTokensRequest struct {
 	AccessTokenEncrypted  []byte
 	RefreshTokenEncrypted []byte
+	RefreshTokenNonce     []byte
 	EncryptionNonce       []byte
 	ExpiresAt             *time.Time
 }
@@ -78,6 +81,7 @@ func convertDbOAuthCredential(dbCred *db.OauthCredential) OAuthCredential {
 		AccountID:             dbCred.AccountID,
 		AccessTokenEncrypted:  dbCred.AccessTokenEncrypted,
 		RefreshTokenEncrypted: dbCred.RefreshTokenEncrypted,
+		RefreshTokenNonce:     dbCred.RefreshTokenNonce,
 		EncryptionNonce:       dbCred.EncryptionNonce,
 		TokenType:             "Bearer",
 		Scopes:                dbCred.Scopes,
@@ -257,6 +261,7 @@ func (r *OAuthRepository) Upsert(ctx context.Context, req UpsertOAuthCredentialR
 		AccountName:           stringToPgText(req.AccountName),
 		AccessTokenEncrypted:  req.AccessTokenEncrypted,
 		RefreshTokenEncrypted: req.RefreshTokenEncrypted,
+		RefreshTokenNonce:     req.RefreshTokenNonce,
 		EncryptionNonce:       req.EncryptionNonce,
 		TokenType:             pgtype.Text{String: req.TokenType, Valid: req.TokenType != ""},
 		ExpiresAt:             timeToPgTimestamptz(req.ExpiresAt),
@@ -276,6 +281,7 @@ func (r *OAuthRepository) UpdateTokens(ctx context.Context, id uuid.UUID, req Up
 		ID:                    uuidToPgUUID(id),
 		AccessTokenEncrypted:  req.AccessTokenEncrypted,
 		RefreshTokenEncrypted: req.RefreshTokenEncrypted,
+		RefreshTokenNonce:     req.RefreshTokenNonce,
 		EncryptionNonce:       req.EncryptionNonce,
 		ExpiresAt:             timeToPgTimestamptz(req.ExpiresAt),
 	})

--- a/backend/migrations/062_oauth_refresh_token_nonce.down.sql
+++ b/backend/migrations/062_oauth_refresh_token_nonce.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oauth_credential DROP COLUMN refresh_token_nonce;

--- a/backend/migrations/062_oauth_refresh_token_nonce.up.sql
+++ b/backend/migrations/062_oauth_refresh_token_nonce.up.sql
@@ -1,0 +1,9 @@
+-- Give the refresh token its own AES-GCM nonce.
+--
+-- Previously the refresh token was encrypted with the same nonce as the access
+-- token (encryption_nonce). Reusing a nonce with the same key in AES-GCM leaks
+-- keystream and is a security risk. This column lets each field carry its own
+-- nonce. A NULL value means the row predates this change and its refresh token
+-- still uses the shared encryption_nonce (legacy format); such rows are upgraded
+-- to the new format the next time their tokens are written.
+ALTER TABLE oauth_credential ADD COLUMN refresh_token_nonce BYTEA;

--- a/backend/tests/google_oauth_token_integration_test.go
+++ b/backend/tests/google_oauth_token_integration_test.go
@@ -14,6 +14,7 @@ import (
 
 	"personal-crm/backend/internal/accelerated"
 	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/crypto"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/google"
 	"personal-crm/backend/internal/repository"
@@ -275,4 +276,107 @@ func TestGoogleOAuth_LegacyRowDecryptsAndUpgrades(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "upgraded-access-token", stored.AccessToken)
 	assert.Equal(t, "upgraded-refresh-token", stored.RefreshToken)
+}
+
+// TestGoogleOAuth_LegacyRow_RefreshlessWriteKeepsDecryptable verifies that a
+// write which preserves an existing legacy refresh ciphertext (because no new
+// refresh token is supplied) captures the legacy shared nonce into the dedicated
+// column. Without that capture such a write rotates encryption_nonce while
+// leaving refresh_token_nonce NULL, so the legacy decrypt fallback would read
+// the new access-token nonce and the preserved refresh token would become
+// permanently undecryptable.
+func TestGoogleOAuth_LegacyRow_RefreshlessWriteKeepsDecryptable(t *testing.T) {
+	t.Parallel()
+
+	svc, repo, cfg, ctx := newGoogleOAuthTestService(t)
+
+	const refreshPlain = "legacy-refresh-token-preserved"
+
+	// seedLegacyRow stores a row in the old format: refresh token sealed with the
+	// access token's nonce and refresh_token_nonce left NULL.
+	seedLegacyRow := func(t *testing.T, email string) {
+		t.Helper()
+		sharedNonce := make([]byte, 12)
+		for i := range sharedNonce {
+			sharedNonce[i] = byte(i + 7)
+		}
+		accessCipher := sealWithKey(t, cfg.External.TokenEncryptionKey, "legacy-access-token", sharedNonce)
+		refreshCipher := sealWithKey(t, cfg.External.TokenEncryptionKey, refreshPlain, sharedNonce)
+
+		_, err := repo.Upsert(ctx, repository.UpsertOAuthCredentialRequest{
+			Provider:              google.ProviderName,
+			AccountID:             email,
+			AccessTokenEncrypted:  accessCipher,
+			RefreshTokenEncrypted: refreshCipher,
+			RefreshTokenNonce:     nil, // legacy format
+			EncryptionNonce:       sharedNonce,
+			TokenType:             "Bearer",
+			Scopes:                google.Scopes,
+		})
+		require.NoError(t, err)
+
+		t.Cleanup(func() {
+			if cred, err := repo.GetByProviderAndAccount(context.Background(), google.ProviderName, email); err == nil {
+				_ = repo.Delete(context.Background(), cred.ID)
+			}
+		})
+	}
+
+	// Re-exchange where Google omits refresh_token: hits the upsert conflict
+	// branch with a NULL refresh ciphertext.
+	t.Run("UpsertConflictBranch", func(t *testing.T) {
+		email := syntheticNS(t) + "@example.test"
+		seedLegacyRow(t, email)
+
+		fake := newFakeGoogleEndpoints(t, email, "Legacy Refreshless Upsert")
+		fake.accessToken = "reexchanged-access-token"
+		fake.refreshTok = "" // omitted from the token response
+		svc.SetHTTPClient(fake.server.Client())
+		svc.SetTokenEndpoint(fake.server.URL + "/token")
+		svc.SetUserInfoEndpoint(fake.server.URL + "/userinfo")
+
+		_, err := svc.ExchangeCode(ctx, "reexchange-code")
+		require.NoError(t, err)
+
+		token, err := svc.GetTokenForAccount(ctx, email)
+		require.NoError(t, err, "preserved legacy refresh token must stay decryptable after a refreshless upsert")
+		assert.Equal(t, "reexchanged-access-token", token.AccessToken)
+		assert.Equal(t, refreshPlain, token.RefreshToken)
+
+		cred, err := repo.GetByProviderAndAccount(ctx, google.ProviderName, email)
+		require.NoError(t, err)
+		assert.NotEmpty(t, cred.RefreshTokenNonce, "legacy shared nonce must be captured into the dedicated column")
+	})
+
+	// Token refresh where the provider does not rotate the refresh token: hits
+	// UpdateOAuthCredentialTokens with a NULL refresh ciphertext.
+	t.Run("TokensUpdate", func(t *testing.T) {
+		email := syntheticNS(t) + "@example.test"
+		seedLegacyRow(t, email)
+
+		cred, err := repo.GetByProviderAndAccount(ctx, google.ProviderName, email)
+		require.NoError(t, err)
+
+		encryptor, err := crypto.NewTokenEncryptor(cfg.External.TokenEncryptionKey)
+		require.NoError(t, err)
+		newAccessCipher, newNonce, err := encryptor.Encrypt("refreshed-access-token")
+		require.NoError(t, err)
+
+		_, err = repo.UpdateTokens(ctx, cred.ID, repository.UpdateOAuthTokensRequest{
+			AccessTokenEncrypted:  newAccessCipher,
+			RefreshTokenEncrypted: nil, // refresh token not rotated
+			RefreshTokenNonce:     nil,
+			EncryptionNonce:       newNonce,
+		})
+		require.NoError(t, err)
+
+		token, err := svc.GetTokenForAccount(ctx, email)
+		require.NoError(t, err, "preserved legacy refresh token must stay decryptable after a refreshless tokens update")
+		assert.Equal(t, "refreshed-access-token", token.AccessToken)
+		assert.Equal(t, refreshPlain, token.RefreshToken)
+
+		credAfter, err := repo.GetByProviderAndAccount(ctx, google.ProviderName, email)
+		require.NoError(t, err)
+		assert.NotEmpty(t, credAfter.RefreshTokenNonce, "legacy shared nonce must be captured into the dedicated column")
+	})
 }

--- a/backend/tests/google_oauth_token_integration_test.go
+++ b/backend/tests/google_oauth_token_integration_test.go
@@ -1,0 +1,278 @@
+package tests
+
+import (
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/google"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newGoogleOAuthTestService wires a Google OAuthService against the shared test
+// DB and returns the service plus the repository so tests can inspect the stored
+// (encrypted) row directly. The HTTP client and userinfo endpoint are pointed at
+// the caller-supplied test server URL.
+func newGoogleOAuthTestService(t *testing.T) (*google.OAuthService, *repository.OAuthRepository, *config.Config, context.Context) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set")
+	}
+
+	ctx := context.Background()
+	cfg := config.TestConfig()
+	cfg.Database.URL = databaseURL
+
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	t.Cleanup(func() { database.Close() })
+
+	repo := repository.NewOAuthRepository(database.Queries)
+	svc, err := google.NewOAuthService(cfg, repo, nil)
+	require.NoError(t, err)
+
+	return svc, repo, cfg, ctx
+}
+
+// fakeGoogleEndpoints stands in for Google's token and userinfo endpoints. The
+// token handler returns whatever access/refresh tokens are currently configured,
+// so a test can rotate them between calls to exercise refresh persistence.
+type fakeGoogleEndpoints struct {
+	server      *httptest.Server
+	accessToken string
+	refreshTok  string
+	tokenCalls  int
+}
+
+func newFakeGoogleEndpoints(t *testing.T, email, name string) *fakeGoogleEndpoints {
+	t.Helper()
+	f := &fakeGoogleEndpoints{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		f.tokenCalls++
+		w.Header().Set("Content-Type", "application/json")
+		resp := map[string]any{
+			"access_token": f.accessToken,
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		}
+		if f.refreshTok != "" {
+			resp["refresh_token"] = f.refreshTok
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+	mux.HandleFunc("/userinfo", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"email": email, "name": name})
+	})
+	f.server = httptest.NewServer(mux)
+	t.Cleanup(f.server.Close)
+	return f
+}
+
+// sealWithKey encrypts plaintext with the given hex key and nonce using raw
+// AES-256-GCM. It fabricates a legacy credential row whose refresh token shares
+// the access token's nonce, exactly as the previous code stored it.
+func sealWithKey(t *testing.T, hexKey, plaintext string, nonce []byte) []byte {
+	t.Helper()
+	key, err := hex.DecodeString(hexKey)
+	require.NoError(t, err)
+	block, err := aes.NewCipher(key)
+	require.NoError(t, err)
+	gcm, err := cipher.NewGCM(block)
+	require.NoError(t, err)
+	return gcm.Seal(nil, nonce, []byte(plaintext), nil)
+}
+
+// TestGoogleOAuth_ExchangeRoundTrip verifies that a token exchanged via the fake
+// endpoint is stored encrypted and decrypts back to the same values, and that the
+// access and refresh tokens are stored under distinct nonces.
+func TestGoogleOAuth_ExchangeRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	email := syntheticNS(t) + "@example.test"
+	svc, repo, _, ctx := newGoogleOAuthTestService(t)
+	fake := newFakeGoogleEndpoints(t, email, "Round Trip")
+	fake.accessToken = "fake-access-token-rt"
+	fake.refreshTok = "fake-refresh-token-rt"
+
+	svc.SetHTTPClient(fake.server.Client())
+	svc.SetTokenEndpoint(fake.server.URL + "/token")
+	svc.SetUserInfoEndpoint(fake.server.URL + "/userinfo")
+
+	t.Cleanup(func() {
+		if cred, err := repo.GetByProviderAndAccount(context.Background(), google.ProviderName, email); err == nil {
+			_ = repo.Delete(context.Background(), cred.ID)
+		}
+	})
+
+	status, err := svc.ExchangeCode(ctx, "fake-auth-code")
+	require.NoError(t, err)
+	require.Equal(t, email, status.AccountID)
+
+	// Decrypt fidelity: the decrypted token matches what the endpoint returned.
+	token, err := svc.GetTokenForAccount(ctx, email)
+	require.NoError(t, err)
+	assert.Equal(t, "fake-access-token-rt", token.AccessToken)
+	assert.Equal(t, "fake-refresh-token-rt", token.RefreshToken)
+
+	// Regression: the two stored ciphertexts must never share a nonce.
+	cred, err := repo.GetByProviderAndAccount(ctx, google.ProviderName, email)
+	require.NoError(t, err)
+	require.NotEmpty(t, cred.RefreshTokenEncrypted)
+	require.NotEmpty(t, cred.RefreshTokenNonce, "new format must store a dedicated refresh-token nonce")
+	assert.NotEqual(t, cred.EncryptionNonce, cred.RefreshTokenNonce, "access and refresh tokens must use distinct nonces")
+}
+
+// TestGoogleOAuth_RefreshPersistsRotatedToken verifies that a refresh performed by
+// the token source persists the new access token and a rotated refresh token.
+func TestGoogleOAuth_RefreshPersistsRotatedToken(t *testing.T) {
+	t.Parallel()
+
+	email := syntheticNS(t) + "@example.test"
+	svc, repo, _, ctx := newGoogleOAuthTestService(t)
+	fake := newFakeGoogleEndpoints(t, email, "Refresh Rotate")
+	svc.SetHTTPClient(fake.server.Client())
+	svc.SetTokenEndpoint(fake.server.URL + "/token")
+	svc.SetUserInfoEndpoint(fake.server.URL + "/userinfo")
+
+	t.Cleanup(func() {
+		if cred, err := repo.GetByProviderAndAccount(context.Background(), google.ProviderName, email); err == nil {
+			_ = repo.Delete(context.Background(), cred.ID)
+		}
+	})
+
+	// Seed an already-expired credential with a refresh token so the token source
+	// is forced to refresh on first use. Encrypt through the real encryptor by way
+	// of an exchange whose returned token we then expire in the DB.
+	fake.accessToken = "stale-access-token"
+	fake.refreshTok = "original-refresh-token"
+	_, err := svc.ExchangeCode(ctx, "seed-code")
+	require.NoError(t, err)
+
+	cred, err := repo.GetByProviderAndAccount(ctx, google.ProviderName, email)
+	require.NoError(t, err)
+	expired := accelerated.GetCurrentTime().Add(-1 * time.Hour)
+	_, err = repo.UpdateTokens(ctx, cred.ID, repository.UpdateOAuthTokensRequest{
+		AccessTokenEncrypted:  cred.AccessTokenEncrypted,
+		RefreshTokenEncrypted: cred.RefreshTokenEncrypted,
+		RefreshTokenNonce:     cred.RefreshTokenNonce,
+		EncryptionNonce:       cred.EncryptionNonce,
+		ExpiresAt:             &expired,
+	})
+	require.NoError(t, err)
+
+	// Configure the endpoint to rotate both tokens on the refresh call.
+	fake.accessToken = "rotated-access-token"
+	fake.refreshTok = "rotated-refresh-token"
+	callsBefore := fake.tokenCalls
+
+	// The client refreshes lazily on its first request; the expired credential
+	// forces a refresh against the fake token endpoint.
+	client, err := svc.GetClientForAccount(ctx, email)
+	require.NoError(t, err)
+	resp, err := client.Get(fake.server.URL + "/userinfo")
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	assert.Greater(t, fake.tokenCalls, callsBefore, "a refresh should have hit the token endpoint")
+
+	// The rotated tokens must be persisted to the DB.
+	stored, err := svc.GetTokenForAccount(ctx, email)
+	require.NoError(t, err)
+	assert.Equal(t, "rotated-access-token", stored.AccessToken)
+	assert.Equal(t, "rotated-refresh-token", stored.RefreshToken)
+
+	// Persisted refresh token keeps its own nonce.
+	credAfter, err := repo.GetByProviderAndAccount(ctx, google.ProviderName, email)
+	require.NoError(t, err)
+	require.NotEmpty(t, credAfter.RefreshTokenNonce)
+	assert.NotEqual(t, credAfter.EncryptionNonce, credAfter.RefreshTokenNonce)
+}
+
+// TestGoogleOAuth_LegacyRowDecryptsAndUpgrades verifies a row stored in the old
+// shared-nonce format still decrypts, and is upgraded to the per-field nonce
+// format the next time its tokens are written.
+func TestGoogleOAuth_LegacyRowDecryptsAndUpgrades(t *testing.T) {
+	t.Parallel()
+
+	email := syntheticNS(t) + "@example.test"
+	svc, repo, cfg, ctx := newGoogleOAuthTestService(t)
+
+	t.Cleanup(func() {
+		if cred, err := repo.GetByProviderAndAccount(context.Background(), google.ProviderName, email); err == nil {
+			_ = repo.Delete(context.Background(), cred.ID)
+		}
+	})
+
+	// Build a legacy row: access and refresh tokens encrypted under the same
+	// nonce, with refresh_token_nonce left NULL.
+	const accessPlain = "legacy-access-token"
+	const refreshPlain = "legacy-refresh-token"
+	sharedNonce := make([]byte, 12)
+	for i := range sharedNonce {
+		sharedNonce[i] = byte(i + 1)
+	}
+	accessCipher := sealWithKey(t, cfg.External.TokenEncryptionKey, accessPlain, sharedNonce)
+	refreshCipher := sealWithKey(t, cfg.External.TokenEncryptionKey, refreshPlain, sharedNonce)
+
+	_, err := repo.Upsert(ctx, repository.UpsertOAuthCredentialRequest{
+		Provider:              google.ProviderName,
+		AccountID:             email,
+		AccessTokenEncrypted:  accessCipher,
+		RefreshTokenEncrypted: refreshCipher,
+		RefreshTokenNonce:     nil, // legacy format
+		EncryptionNonce:       sharedNonce,
+		TokenType:             "Bearer",
+		Scopes:                google.Scopes,
+	})
+	require.NoError(t, err)
+
+	// Legacy row decrypts correctly via the shared-nonce fallback.
+	token, err := svc.GetTokenForAccount(ctx, email)
+	require.NoError(t, err)
+	assert.Equal(t, accessPlain, token.AccessToken)
+	assert.Equal(t, refreshPlain, token.RefreshToken)
+
+	legacy, err := repo.GetByProviderAndAccount(ctx, google.ProviderName, email)
+	require.NoError(t, err)
+	require.Empty(t, legacy.RefreshTokenNonce, "fixture should start in legacy (NULL nonce) format")
+
+	// Rewriting the tokens upgrades the row to the new per-field nonce format.
+	fake := newFakeGoogleEndpoints(t, email, "Legacy Upgrade")
+	fake.accessToken = "upgraded-access-token"
+	fake.refreshTok = "upgraded-refresh-token"
+	svc.SetHTTPClient(fake.server.Client())
+	svc.SetTokenEndpoint(fake.server.URL + "/token")
+	svc.SetUserInfoEndpoint(fake.server.URL + "/userinfo")
+
+	_, err = svc.ExchangeCode(ctx, "upgrade-code")
+	require.NoError(t, err)
+
+	upgraded, err := repo.GetByProviderAndAccount(ctx, google.ProviderName, email)
+	require.NoError(t, err)
+	require.NotEmpty(t, upgraded.RefreshTokenNonce, "rewrite must populate a dedicated refresh-token nonce")
+	assert.NotEqual(t, upgraded.EncryptionNonce, upgraded.RefreshTokenNonce)
+
+	stored, err := svc.GetTokenForAccount(ctx, email)
+	require.NoError(t, err)
+	assert.Equal(t, "upgraded-access-token", stored.AccessToken)
+	assert.Equal(t, "upgraded-refresh-token", stored.RefreshToken)
+}


### PR DESCRIPTION
Fixes the three verified defects in Google OAuth token handling from the improvement audit.

**Nonce reuse (the security fix):** `storeToken` and `updateToken` encrypted the refresh token with `EncryptWithNonce`, reusing the access token's nonce — AES-256-GCM with the same key+nonce over two different plaintexts, exactly what the helper's own doc comment warns against. Both paths now encrypt each field with its own random nonce; the refresh nonce lands in a new nullable `refresh_token_nonce BYTEA` column (migration 062). Backward compatible: NULL means a legacy shared-nonce row, the decrypt path falls back to `encryption_nonce` for those, and any row rewritten by an exchange or refresh upgrades to the per-field format. The SQL keeps nonce and ciphertext in lockstep on both the upsert (including the conflict branch) and update paths. The now-unused `EncryptWithNonce` footgun helper is deleted.

**Persist-on-refresh:** `GetClientForAccount` previously persisted a refreshed token only when the construction-time `Token()` call changed it; refreshes performed later by the oauth2 token source during a long sync were never written back, so every sync paid a redundant refresh and a rotated refresh token would have been silently lost. The token source is now wrapped (`persistOnRefreshSource` under `oauth2.ReuseTokenSource`) so a mid-sync refresh persists exactly once, gated on actual change, fail-soft on persist errors.

**Test coverage:** the google package gains the instance-scoped test seam todoist already had (`SetHTTPClient`, `SetTokenEndpoint`, `SetUserInfoEndpoint`), plus three integration tests against httptest fake endpoints: exchange→store→decrypt round-trip asserting the two stored ciphertexts never share a nonce, refresh-rotation persistence, and legacy-row decrypt + upgrade-on-rewrite. All `t.Parallel()`, namespace-scoped, fake credentials only. Green under `-race -count=5 -shuffle=on`.

Reviewed via the pre-push Claude review gate: PASS, 0×P0/P1/P2, 1×P3 (benign last-writer-wins double-persist under concurrent same-account clients, non-corrupting since each write atomically pairs its own nonce with its own ciphertext). The review included a mutation check — re-introducing the shared-nonce bug makes the new regression test fail.

Closes #473
