### PR TITLE
feat(crm-admin): add --migrate and --migrate-check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -357,15 +357,15 @@ test-unit:
 
 test-integration-fast:
 	@echo "Running backend integration tests (default set)..."
-	@cd backend && DATABASE_URL="$(TEST_DATABASE_URL)" go test -tags integration_testdb -count=1 -parallel $(TEST_PARALLEL) -p $(TEST_P) ./tests/... ./internal/todoist/... ./internal/google/... ./internal/testdb/... $(GOTEST_VERBOSE)
+	@cd backend && DATABASE_URL="$(TEST_DATABASE_URL)" go test -tags integration_testdb -count=1 -parallel $(TEST_PARALLEL) -p $(TEST_P) ./tests/... ./internal/todoist/... ./internal/google/... ./internal/testdb/... ./cmd/crm-admin/... $(GOTEST_VERBOSE)
 
 test-integration:
 	@echo "Running backend integration tests..."
-	@cd backend && DATABASE_URL="$(TEST_DATABASE_URL)" LONG_TESTS=1 go test -tags integration_testdb -count=1 -parallel $(TEST_PARALLEL) -p $(TEST_P) ./tests/... ./internal/todoist/... ./internal/google/... ./internal/testdb/... $(GOTEST_VERBOSE)
+	@cd backend && DATABASE_URL="$(TEST_DATABASE_URL)" LONG_TESTS=1 go test -tags integration_testdb -count=1 -parallel $(TEST_PARALLEL) -p $(TEST_P) ./tests/... ./internal/todoist/... ./internal/google/... ./internal/testdb/... ./cmd/crm-admin/... $(GOTEST_VERBOSE)
 
 test-integration-slow:
 	@echo "Running backend slow integration tests..."
-	@cd backend && DATABASE_URL="$(TEST_DATABASE_URL)" LONG_TESTS=1 go test -tags integration_testdb -count=1 -parallel $(TEST_PARALLEL) -p $(TEST_P) ./tests/... ./internal/todoist/... ./internal/google/... ./internal/testdb/... $(GOTEST_VERBOSE) -run '$(BACKEND_SLOW_TESTS_REGEX)'
+	@cd backend && DATABASE_URL="$(TEST_DATABASE_URL)" LONG_TESTS=1 go test -tags integration_testdb -count=1 -parallel $(TEST_PARALLEL) -p $(TEST_P) ./tests/... ./internal/todoist/... ./internal/google/... ./internal/testdb/... ./cmd/crm-admin/... $(GOTEST_VERBOSE) -run '$(BACKEND_SLOW_TESTS_REGEX)'
 
 # Sweep leaked clone databases (personal_crm_test_clone_*) AND stale
 # per-migration-set template databases (personal_crm_test_template_<hash>).

--- a/backend/cmd/crm-admin/main.go
+++ b/backend/cmd/crm-admin/main.go
@@ -91,6 +91,22 @@
 //	                                `make staging-reset`). Requires --yes. The
 //	                                stable namespace makes the reseed reproducible.
 //
+//	--migrate                     Apply pending application + River migrations
+//	                              idempotently (the exact call crm-api boot
+//	                              makes). Exit 0 on success, 1 on error. The
+//	                              deploy script runs this from the NEW image,
+//	                              after a snapshot, before swapping the running
+//	                              container.
+//
+//	--migrate-check               Report whether migrations are pending WITHOUT
+//	                              mutating the DB. THREE distinct exit codes:
+//	                              0 = up-to-date, 2 = pending (app and/or River),
+//	                              1 = operational error (cannot connect, dirty DB,
+//	                              version read failed). The deploy script branches
+//	                              on exit 2 to snapshot-then-migrate; exit 1 aborts
+//	                              before touching anything. Prints a counts-only
+//	                              summary (no PII).
+//
 // The seed/reset subcommands inherit the process env (CRM_ENV / TIME_BASE /
 // TIME_ACCELERATION / DATABASE_URL / MIGRATIONS_PATH) — on the Pi via
 // `set -a; . /srv/personalcrm/.env; set +a` — so the seeded world's cadence /
@@ -241,10 +257,33 @@ type runOptions struct {
 	seedNamespace string
 	prngSeed      uint64
 	seedYes       bool
+	// Migration subcommands. migrate ← --migrate (idempotent apply);
+	// migrateCheck ← --migrate-check (report pending, non-mutating, distinct
+	// exit codes). Both run PRE-DB (they need only cfg.Database URL +
+	// MigrationsPath, not buildProductionDeps).
+	migrate      bool
+	migrateCheck bool
 }
+
+// exitErr carries an explicit process exit code so a subcommand can drive a
+// distinct exit status (e.g. --migrate-check's exit 2 = pending). main() maps it
+// via errors.As; every other error keeps the existing exit-1 (log.Fatalf)
+// behavior. run()/runMain keep returning error so the dispatch + exit-code
+// contract stay unit-testable without spawning a subprocess.
+type exitErr struct {
+	code int
+	msg  string
+}
+
+func (e exitErr) Error() string { return e.msg }
 
 func main() {
 	if err := runMain(os.Args[1:]); err != nil {
+		var ee exitErr
+		if errors.As(err, &ee) {
+			fmt.Fprintln(os.Stderr, "crm-admin:", ee.msg)
+			os.Exit(ee.code)
+		}
 		log.Fatalf("crm-admin: %v", err)
 	}
 }
@@ -269,6 +308,18 @@ func runMain(args []string) error {
 		return fmt.Errorf("load config: %w", err)
 	}
 	ctx := context.Background()
+
+	// Migration subcommands run PRE-DB: they need only the database URL +
+	// migrations path, NOT the full buildProductionDeps service stack (no River
+	// client, no Google, no MacHostService). Dispatching here keeps them runnable
+	// on a host that lacks Google creds etc., and avoids opening the application
+	// pool just to check/apply migrations. Mirrors the seed gate short-circuit.
+	if opts.migrate {
+		return runMigrate(ctx, cfg.Database.URL, cfg.Database.MigrationsPath, os.Stdout)
+	}
+	if opts.migrateCheck {
+		return runMigrateCheck(ctx, cfg.Database.URL, cfg.Database.MigrationsPath, os.Stdout)
+	}
 
 	// The seed/reset entrypoints invoke shippable fake-fetcher scaffolding and
 	// (for reset) destroy data, so BOTH gates run PRE-DB AND PRE-MIGRATION — a
@@ -347,6 +398,12 @@ func validateSubcommand(opts runOptions) error {
 	if opts.resetAndSeed {
 		active++
 	}
+	if opts.migrate {
+		active++
+	}
+	if opts.migrateCheck {
+		active++
+	}
 	if active == 0 {
 		return errors.New("no subcommand specified; pass exactly one of " +
 			subcommandList)
@@ -362,7 +419,8 @@ func validateSubcommand(opts runOptions) error {
 // no-subcommand and mutual-exclusion usage errors.
 const subcommandList = "--messages-rematch-stranded, --reconcile-address-book-methods, " +
 	"--rederive-correspondence-names, --reset-gmail-backfill-cursors, --mint-pairing-token, " +
-	"--list-hosts, --revoke-host <uuid>, --rotate-host-key <uuid>, --seed, --reset-and-seed"
+	"--list-hosts, --revoke-host <uuid>, --rotate-host-key <uuid>, --seed, --reset-and-seed, " +
+	"--migrate, --migrate-check"
 
 // parseArgs uses a private FlagSet so tests can drive the parser
 // without polluting flag's global state.
@@ -417,10 +475,81 @@ func parseArgs(args []string) (runOptions, error) {
 	fs.BoolVar(&opts.seedYes, "yes", false,
 		"Confirm a seed/reset against this DB. MANDATORY for --seed and --reset-and-seed (or set "+
 			"CRM_SEED_RESET_CONFIRM=1). Asserts the operator stopped the crm-api service first.")
+	fs.BoolVar(&opts.migrate, "migrate", false,
+		"Apply pending application + River migrations (idempotent; the same call crm-api boot makes). "+
+			"Exit 0 on success, 1 on error. Used by the deploy script before swapping the running image.")
+	fs.BoolVar(&opts.migrateCheck, "migrate-check", false,
+		"Report whether migrations are pending WITHOUT mutating the DB. Exit 0 = up-to-date, "+
+			"2 = pending (app and/or River), 1 = operational error (cannot connect / dirty DB / read failed). "+
+			"The deploy script branches on exit 2 to snapshot-then-migrate.")
 	if err := fs.Parse(args); err != nil {
 		return runOptions{}, err
 	}
 	return opts, nil
+}
+
+// migrateExitPending is the exit code --migrate-check returns when app and/or
+// River migrations are pending. It is the contract deploy-artifact.sh branches
+// on (exit 2 ⇒ snapshot-then-migrate); distinct from operational errors (exit 1)
+// so the deploy script never confuses "pending" with "abort".
+const migrateExitPending = 2
+
+// migrationStatusFn is the read-only migration-status reporter --migrate-check
+// depends on. Production passes db.MigrationStatus; tests pass a stub so the
+// exit-code mapping is unit-testable without a real database.
+type migrationStatusFn func(ctx context.Context, databaseURL, migrationsPath string) (appPending, riverPending bool, err error)
+
+// runMigrate applies pending application + River migrations idempotently (the
+// same call crm-api boot makes). Returns nil on success (exit 0) or a plain
+// error (exit 1). db.RunMigrations swallows ErrNoChange, so re-running on an
+// up-to-date DB is a clean no-op.
+func runMigrate(ctx context.Context, databaseURL, migrationsPath string, stdout io.Writer) error {
+	if err := db.RunMigrations(ctx, databaseURL, migrationsPath); err != nil {
+		return fmt.Errorf("run migrations: %w", err)
+	}
+	if _, err := fmt.Fprintln(stdout, "migrations applied (or already up-to-date)"); err != nil {
+		return fmt.Errorf("write migrate summary: %w", err)
+	}
+	return nil
+}
+
+// runMigrateCheck reports whether migrations are pending WITHOUT mutating the
+// DB. It returns:
+//   - nil (exit 0) when up-to-date,
+//   - exitErr{code:2} (exit 2) when app and/or River migrations are pending,
+//   - a plain error (exit 1) on any operational failure (cannot connect, dirty
+//     DB, version read failed).
+//
+// The status reporter is injected so the exit-code mapping is unit-testable;
+// production passes db.MigrationStatus.
+func runMigrateCheck(ctx context.Context, databaseURL, migrationsPath string, stdout io.Writer) error {
+	return runMigrateCheckWith(ctx, databaseURL, migrationsPath, stdout, db.MigrationStatus)
+}
+
+// runMigrateCheckWith is the injectable core of runMigrateCheck. It prints a
+// counts-only summary (no PII) and maps the boolean status to the exit-code
+// contract.
+func runMigrateCheckWith(ctx context.Context, databaseURL, migrationsPath string, stdout io.Writer, status migrationStatusFn) error {
+	appPending, riverPending, err := status(ctx, databaseURL, migrationsPath)
+	if err != nil {
+		return fmt.Errorf("migration check: %w", err)
+	}
+
+	appCount, riverCount := 0, 0
+	if appPending {
+		appCount = 1
+	}
+	if riverPending {
+		riverCount = 1
+	}
+	if _, werr := fmt.Fprintf(stdout, "migrate-check: app_pending=%d river_pending=%d\n", appCount, riverCount); werr != nil {
+		return fmt.Errorf("write migrate-check summary: %w", werr)
+	}
+
+	if appPending || riverPending {
+		return exitErr{code: migrateExitPending, msg: "migrations pending"}
+	}
+	return nil
 }
 
 // run dispatches to exactly one subcommand. Validates flag selection
@@ -452,6 +581,13 @@ func run(ctx context.Context, opts runOptions, deps adminDeps) error {
 		return runSeed(ctx, opts, deps)
 	case opts.resetAndSeed:
 		return runResetAndSeed(ctx, opts, deps)
+	case opts.migrate, opts.migrateCheck:
+		// Migration subcommands are dispatched PRE-DB in runMain (they need
+		// only the database URL + migrations path, not deps), so they never
+		// reach this DB-backed dispatcher. Guard against a future caller that
+		// drives run() directly with these set rather than falling through to
+		// the misleading "unreachable".
+		return errors.New("migration subcommands are dispatched pre-DB in runMain, not run()")
 	}
 	return errors.New("unreachable")
 }

--- a/backend/cmd/crm-admin/main_test.go
+++ b/backend/cmd/crm-admin/main_test.go
@@ -663,6 +663,30 @@ func TestParseArgsAllFlags(t *testing.T) {
 				}
 			},
 		},
+		{
+			"migrate",
+			[]string{"--migrate"},
+			func(t *testing.T, o runOptions) {
+				if !o.migrate {
+					t.Fatal("--migrate not set")
+				}
+				if o.migrateCheck {
+					t.Fatal("--migrate-check should not be set")
+				}
+			},
+		},
+		{
+			"migrate-check",
+			[]string{"--migrate-check"},
+			func(t *testing.T, o runOptions) {
+				if !o.migrateCheck {
+					t.Fatal("--migrate-check not set")
+				}
+				if o.migrate {
+					t.Fatal("--migrate should not be set")
+				}
+			},
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -961,5 +985,135 @@ func TestRunSeedMutualExclusion(t *testing.T) {
 	err := run(context.Background(), runOptions{doSeed: true, resetAndSeed: true, seedYes: true}, deps)
 	if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
 		t.Fatalf("expected mutual-exclusion error, got %v", err)
+	}
+}
+
+// --- --migrate / --migrate-check tests ---
+
+// TestValidateSubcommandMigrateSole confirms each migration flag is a valid sole
+// subcommand.
+func TestValidateSubcommandMigrateSole(t *testing.T) {
+	if err := validateSubcommand(runOptions{migrate: true}); err != nil {
+		t.Fatalf("--migrate alone should validate, got %v", err)
+	}
+	if err := validateSubcommand(runOptions{migrateCheck: true}); err != nil {
+		t.Fatalf("--migrate-check alone should validate, got %v", err)
+	}
+}
+
+// TestValidateSubcommandMigrateMutualExclusion confirms the migration flags are
+// mutually exclusive with each other and with other subcommands.
+func TestValidateSubcommandMigrateMutualExclusion(t *testing.T) {
+	cases := []struct {
+		name string
+		opts runOptions
+	}{
+		{"migrate+migrate-check", runOptions{migrate: true, migrateCheck: true}},
+		{"migrate+list-hosts", runOptions{migrate: true, listHosts: true}},
+		{"migrate-check+seed", runOptions{migrateCheck: true, doSeed: true}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := validateSubcommand(c.opts)
+			if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+				t.Fatalf("expected mutual-exclusion error, got %v", err)
+			}
+		})
+	}
+}
+
+// TestRunMigrateThroughDispatcherGuards confirms run() refuses the migration
+// subcommands (they are dispatched pre-DB in runMain, never through run()).
+func TestRunMigrateThroughDispatcherGuards(t *testing.T) {
+	deps, _, _, _, _, _ := newTestDeps()
+	for _, opts := range []runOptions{{migrate: true}, {migrateCheck: true}} {
+		err := run(context.Background(), opts, deps)
+		if err == nil || !strings.Contains(err.Error(), "dispatched pre-DB") {
+			t.Fatalf("expected pre-DB dispatch guard error, got %v", err)
+		}
+	}
+}
+
+// TestRunMigrateCheckUpToDate: no migrations pending → nil (exit 0) + summary.
+func TestRunMigrateCheckUpToDate(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	status := func(_ context.Context, _, _ string) (bool, bool, error) {
+		return false, false, nil
+	}
+	err := runMigrateCheckWith(context.Background(), "url", "path", stdout, status)
+	if err != nil {
+		t.Fatalf("expected nil (up-to-date), got %v", err)
+	}
+	if got := stdout.String(); !strings.Contains(got, "app_pending=0 river_pending=0") {
+		t.Fatalf("unexpected summary: %q", got)
+	}
+}
+
+// TestRunMigrateCheckPendingExit2: app and/or River pending → exitErr{code:2}.
+func TestRunMigrateCheckPendingExit2(t *testing.T) {
+	cases := []struct {
+		name           string
+		app, river     bool
+		wantAppSummary string
+	}{
+		{"app only", true, false, "app_pending=1 river_pending=0"},
+		{"river only", false, true, "app_pending=0 river_pending=1"},
+		{"both", true, true, "app_pending=1 river_pending=1"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			stdout := &bytes.Buffer{}
+			status := func(_ context.Context, _, _ string) (bool, bool, error) {
+				return c.app, c.river, nil
+			}
+			err := runMigrateCheckWith(context.Background(), "url", "path", stdout, status)
+			var ee exitErr
+			if !errors.As(err, &ee) {
+				t.Fatalf("expected exitErr, got %v", err)
+			}
+			if ee.code != migrateExitPending {
+				t.Fatalf("expected exit code %d, got %d", migrateExitPending, ee.code)
+			}
+			if got := stdout.String(); !strings.Contains(got, c.wantAppSummary) {
+				t.Fatalf("unexpected summary: %q", got)
+			}
+		})
+	}
+}
+
+// TestRunMigrateCheckErrorExit1: an operational error from the status reporter
+// surfaces as a plain error (→ exit 1), NOT an exitErr{code:2}.
+func TestRunMigrateCheckErrorExit1(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	status := func(_ context.Context, _, _ string) (bool, bool, error) {
+		return false, false, errors.New("dirty migration state")
+	}
+	err := runMigrateCheckWith(context.Background(), "url", "path", stdout, status)
+	if err == nil {
+		t.Fatal("expected an operational error")
+	}
+	var ee exitErr
+	if errors.As(err, &ee) {
+		t.Fatalf("operational error must NOT be an exitErr (would map to exit 2), got code %d", ee.code)
+	}
+	if !strings.Contains(err.Error(), "dirty migration state") {
+		t.Fatalf("expected wrapped status error, got %v", err)
+	}
+}
+
+// TestExitErrMapping confirms main()'s errors.As mapping contract: an
+// exitErr propagates its code, while a plain error does not match. (main() itself
+// calls os.Exit, so we assert the classification run() relies on rather than
+// spawning a subprocess.)
+func TestExitErrMapping(t *testing.T) {
+	var ee exitErr
+	if !errors.As(exitErr{code: migrateExitPending, msg: "migrations pending"}, &ee) {
+		t.Fatal("exitErr should match errors.As(exitErr)")
+	}
+	if ee.code != migrateExitPending {
+		t.Fatalf("expected propagated code %d, got %d", migrateExitPending, ee.code)
+	}
+	if errors.As(errors.New("plain"), &ee) {
+		t.Fatal("a plain error must NOT match errors.As(exitErr) — it keeps exit-1 behavior")
 	}
 }

--- a/backend/cmd/crm-admin/migrate_integration_test.go
+++ b/backend/cmd/crm-admin/migrate_integration_test.go
@@ -14,6 +14,8 @@ package main
 import (
 	"bytes"
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -24,7 +26,12 @@ import (
 	"personal-crm/backend/internal/testdb"
 
 	migrate "github.com/golang-migrate/migrate/v4"
+	migratepg "github.com/golang-migrate/migrate/v4/database/postgres"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
+	"github.com/jackc/pgx/v5/pgxpool"
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/riverqueue/river/rivermigrate"
 	"github.com/stretchr/testify/require"
 )
 
@@ -112,6 +119,43 @@ func TestMigrateAppliesThenCheckClean(t *testing.T) {
 	require.Contains(t, out.String(), "app_pending=0 river_pending=0")
 }
 
+// TestMigrateCheckRiverPendingExit2 drives the real runMigrateCheck end-to-end
+// against a clone whose River schema is one migration behind (app fully applied),
+// asserting River-pending maps to exit 2.
+func TestMigrateCheckRiverPendingExit2(t *testing.T) {
+	ctx := context.Background()
+	cloneURL, migrationsPath := newMigrateClone(t)
+	require.NoError(t, db.RunMigrations(ctx, cloneURL, migrationsPath))
+
+	rollRiverDownOne(t, ctx, cloneURL)
+
+	var out bytes.Buffer
+	err := runMigrateCheck(ctx, cloneURL, migrationsPath, &out)
+	var ee exitErr
+	require.ErrorAs(t, err, &ee, "River-pending DB must return an exitErr")
+	require.Equal(t, migrateExitPending, ee.code, "River-pending DB must map to exit 2")
+	require.Contains(t, out.String(), "river_pending=1")
+	require.Contains(t, out.String(), "app_pending=0")
+}
+
+// TestMigrateCheckDirtyExit1 drives the real runMigrateCheck end-to-end against a
+// clone forced into a dirty golang-migrate state, asserting the operational-error
+// mapping to exit 1 (a plain error, NOT an exitErr{code:2}).
+func TestMigrateCheckDirtyExit1(t *testing.T) {
+	ctx := context.Background()
+	cloneURL, migrationsPath := newMigrateClone(t)
+	require.NoError(t, db.RunMigrations(ctx, cloneURL, migrationsPath))
+
+	forceAppMigrationDirty(t, ctx, cloneURL, migrationsPath)
+
+	var out bytes.Buffer
+	err := runMigrateCheck(ctx, cloneURL, migrationsPath, &out)
+	require.Error(t, err, "a dirty DB must surface as an operational error")
+	require.ErrorIs(t, err, db.ErrDirtyMigration, "dirty error must wrap ErrDirtyMigration")
+	var ee exitErr
+	require.False(t, errors.As(err, &ee), "a dirty DB must map to exit 1, NOT exitErr{code:2}")
+}
+
 // rollAppDownOne rolls the golang-migrate app schema down by exactly one
 // migration (no raw SQL — uses the migrate library).
 func rollAppDownOne(t *testing.T, databaseURL, migrationsPath string) {
@@ -122,4 +166,51 @@ func rollAppDownOne(t *testing.T, databaseURL, migrationsPath string) {
 	srcErr, dbErr := m.Close()
 	require.NoError(t, srcErr)
 	require.NoError(t, dbErr)
+}
+
+// rollRiverDownOne rolls River's migration schema down by exactly one version
+// using River's own migrator (no raw SQL).
+func rollRiverDownOne(t *testing.T, ctx context.Context, databaseURL string) {
+	t.Helper()
+	poolCfg, err := pgxpool.ParseConfig(databaseURL)
+	require.NoError(t, err)
+	poolCfg.MaxConns = 2
+	pool, err := pgxpool.NewWithConfig(ctx, poolCfg)
+	require.NoError(t, err)
+	defer pool.Close()
+
+	migrator, err := rivermigrate.New(riverpgxv5.New(pool), nil)
+	require.NoError(t, err)
+	res, err := migrator.Migrate(ctx, rivermigrate.DirectionDown, &rivermigrate.MigrateOpts{MaxSteps: 1})
+	require.NoError(t, err)
+	require.Len(t, res.Versions, 1, "expected exactly one River migration rolled down")
+}
+
+// forceAppMigrationDirty marks the golang-migrate schema_migrations row dirty at
+// the current applied version via the postgres database driver's SetVersion — a
+// library call (no raw SQL). Uses the pgx stdlib sql driver to open the *sql.DB
+// the migrate postgres driver wraps.
+func forceAppMigrationDirty(t *testing.T, ctx context.Context, databaseURL, migrationsPath string) {
+	t.Helper()
+	sqlDB, err := sql.Open("pgx", databaseURL)
+	require.NoError(t, err)
+	defer func() { _ = sqlDB.Close() }()
+	require.NoError(t, sqlDB.PingContext(ctx))
+
+	driver, err := migratepg.WithInstance(sqlDB, &migratepg.Config{})
+	require.NoError(t, err)
+
+	current, dirty, err := driver.Version()
+	require.NoError(t, err)
+	require.False(t, dirty, "clone should start clean")
+	require.NotEqual(t, -1, current, "clone should have an applied app version")
+	require.NoError(t, driver.SetVersion(current, true))
+
+	// Sanity: a fresh migrate instance now reads dirty=true.
+	verify, err := migrate.New(fmt.Sprintf("file://%s", migrationsPath), databaseURL)
+	require.NoError(t, err)
+	defer func() { _, _ = verify.Close() }()
+	_, gotDirty, verr := verify.Version()
+	require.NoError(t, verr)
+	require.True(t, gotDirty, "expected the forced dirty marker to be visible")
 }

--- a/backend/cmd/crm-admin/migrate_integration_test.go
+++ b/backend/cmd/crm-admin/migrate_integration_test.go
@@ -1,0 +1,125 @@
+//go:build integration_testdb
+
+// End-to-end exit-code contract for crm-admin --migrate / --migrate-check,
+// driving the REAL runMigrate / runMigrateCheck (which call db.MigrationStatus /
+// db.RunMigrations) against a real golang-migrate + River clone. This proves the
+// 0/1/2 exit-code contract deploy-artifact.sh depends on end-to-end, not just the
+// boolean MigrationStatus or the stubbed exit-code mapping in main_test.go.
+//
+// These mutate the schema (roll migrations down to manufacture a pending state),
+// so each uses an ISOLATED per-test clone via testdb.NewEphemeralClone — never
+// the shared package DB. Migration-subject tests stay serial (no t.Parallel()).
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/testdb"
+
+	migrate "github.com/golang-migrate/migrate/v4"
+	_ "github.com/golang-migrate/migrate/v4/source/file"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMain clones a per-package template database (testdb.SetupPackage) and
+// rewrites DATABASE_URL to the clone before running this package's tagged tests.
+// Excluded from the no-tag unit build, so main_test.go's DB-free unit tests are
+// unaffected.
+func TestMain(m *testing.M) {
+	os.Exit(testdb.SetupPackage(m, testdb.WithMigrationsPath(migrationsPathForTest())))
+}
+
+// migrationsPathForTest resolves the migrations dir relative to this test file
+// (cmd/crm-admin → ../../migrations), honoring an absolute MIGRATIONS_PATH
+// override like the other integration packages.
+func migrationsPathForTest() string {
+	if path := os.Getenv("MIGRATIONS_PATH"); path != "" && filepath.IsAbs(path) {
+		return path
+	}
+	_, filename, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(filename), "..", "..", "migrations")
+}
+
+// newMigrateClone returns a fresh fully-migrated isolated clone URL + migrations
+// path. The testdb template already applied all migrations, so --migrate-check
+// starts up-to-date.
+func newMigrateClone(t *testing.T) (cloneURL, migrationsPath string) {
+	t.Helper()
+	if os.Getenv("DATABASE_URL") == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+	cloneURL, drop := testdb.NewEphemeralClone(t)
+	t.Cleanup(drop)
+	return cloneURL, migrationsPathForTest()
+}
+
+// TestMigrateCheckExitContract drives the real runMigrateCheck end-to-end and
+// asserts the 0 / 2 exit-code contract against a real DB.
+func TestMigrateCheckExitContract(t *testing.T) {
+	ctx := context.Background()
+	cloneURL, migrationsPath := newMigrateClone(t)
+
+	// Call before any read (CI bare-Postgres gotcha; here a no-op backstop).
+	require.NoError(t, db.RunMigrations(ctx, cloneURL, migrationsPath))
+
+	// Up-to-date → nil (exit 0).
+	var out bytes.Buffer
+	err := runMigrateCheck(ctx, cloneURL, migrationsPath, &out)
+	require.NoError(t, err, "fully-migrated clone must report exit 0")
+	require.Contains(t, out.String(), "app_pending=0 river_pending=0")
+
+	// Roll the app schema down one step → pending → exitErr{code:2}.
+	rollAppDownOne(t, cloneURL, migrationsPath)
+
+	out.Reset()
+	err = runMigrateCheck(ctx, cloneURL, migrationsPath, &out)
+	var ee exitErr
+	require.ErrorAs(t, err, &ee, "pending DB must return an exitErr")
+	require.Equal(t, migrateExitPending, ee.code, "pending DB must map to exit 2")
+	require.Contains(t, out.String(), "app_pending=1")
+}
+
+// TestMigrateAppliesThenCheckClean drives the real runMigrate end-to-end: after a
+// real --migrate the DB is up-to-date, so --migrate-check returns exit 0. Also
+// confirms --migrate is idempotent (a second apply is a clean no-op).
+func TestMigrateAppliesThenCheckClean(t *testing.T) {
+	ctx := context.Background()
+	cloneURL, migrationsPath := newMigrateClone(t)
+
+	// Roll the app schema down one step so --migrate has real work to do.
+	require.NoError(t, db.RunMigrations(ctx, cloneURL, migrationsPath))
+	rollAppDownOne(t, cloneURL, migrationsPath)
+
+	// --migrate applies the pending migration (exit 0) and prints its summary.
+	var out bytes.Buffer
+	require.NoError(t, runMigrate(ctx, cloneURL, migrationsPath, &out))
+	require.Contains(t, out.String(), "migrations applied")
+
+	// --migrate is idempotent: a second apply is a clean no-op.
+	out.Reset()
+	require.NoError(t, runMigrate(ctx, cloneURL, migrationsPath, &out))
+
+	// --migrate-check now reports up-to-date (exit 0).
+	out.Reset()
+	require.NoError(t, runMigrateCheck(ctx, cloneURL, migrationsPath, &out))
+	require.Contains(t, out.String(), "app_pending=0 river_pending=0")
+}
+
+// rollAppDownOne rolls the golang-migrate app schema down by exactly one
+// migration (no raw SQL — uses the migrate library).
+func rollAppDownOne(t *testing.T, databaseURL, migrationsPath string) {
+	t.Helper()
+	m, err := migrate.New(fmt.Sprintf("file://%s", migrationsPath), databaseURL)
+	require.NoError(t, err)
+	require.NoError(t, m.Steps(-1), "roll app schema down one step")
+	srcErr, dbErr := m.Close()
+	require.NoError(t, srcErr)
+	require.NoError(t, dbErr)
+}

--- a/backend/internal/db/migration_status.go
+++ b/backend/internal/db/migration_status.go
@@ -1,0 +1,162 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/golang-migrate/migrate/v4"
+	"github.com/golang-migrate/migrate/v4/source"
+	_ "github.com/golang-migrate/migrate/v4/source/file"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/riverqueue/river/rivermigrate"
+)
+
+// ErrDirtyMigration reports that golang-migrate's schema_migrations row is
+// marked dirty (a prior migration failed mid-apply). This needs manual
+// intervention — callers must NOT treat it as "pending" and must NOT apply
+// migrations over a dirty DB. MigrationStatus returns it wrapped so callers
+// can detect it with errors.Is.
+var ErrDirtyMigration = errors.New("dirty migration state, manual intervention required")
+
+// MigrationStatus reports whether application (golang-migrate) and/or River
+// migrations are pending WITHOUT mutating the database. It is the read-only
+// counterpart of RunMigrations: --migrate-check calls it to decide whether a
+// deploy needs a snapshot-then-migrate (pending) or can skip straight to the
+// image swap (up-to-date).
+//
+// It NEVER applies a migration. App pending is detected by comparing the
+// current applied version (golang-migrate m.Version()) against the highest
+// version available in the migrations source; River pending is detected via a
+// rivermigrate DryRun, which is guaranteed not to write.
+//
+// A dirty golang-migrate state is surfaced as an error wrapping
+// ErrDirtyMigration (NOT "pending"), so the caller can abort and require manual
+// intervention rather than snapshot-and-migrate over a half-applied schema.
+func MigrationStatus(ctx context.Context, databaseURL string, migrationsPath string) (appPending bool, riverPending bool, err error) {
+	appPending, err = appMigrationsPending(databaseURL, migrationsPath)
+	if err != nil {
+		return false, false, err
+	}
+
+	riverPending, err = riverMigrationsPending(ctx, databaseURL)
+	if err != nil {
+		return false, false, err
+	}
+
+	return appPending, riverPending, nil
+}
+
+// appMigrationsPending reports whether any golang-migrate application migration
+// is unapplied. It reads the current applied version and compares it against the
+// highest version present in the migrations source; it never calls Up/Steps.
+//
+// Fresh DB (ErrNilVersion) counts as pending iff the source has any migration.
+// A dirty state returns an error wrapping ErrDirtyMigration.
+func appMigrationsPending(databaseURL string, migrationsPath string) (bool, error) {
+	sourceURL := fmt.Sprintf("file://%s", migrationsPath)
+
+	highest, hasAny, err := highestSourceVersion(sourceURL)
+	if err != nil {
+		return false, fmt.Errorf("read highest source migration version: %w", err)
+	}
+
+	m, err := migrate.New(sourceURL, databaseURL)
+	if err != nil {
+		return false, fmt.Errorf("create migration instance: %w", err)
+	}
+	defer func() {
+		// Closing reports source/db errors; they are non-fatal to the read we
+		// already completed, so log-and-ignore via the package logger would add
+		// noise here. We intentionally discard them.
+		_, _ = m.Close()
+	}()
+
+	current, dirty, err := m.Version()
+	if err != nil {
+		if errors.Is(err, migrate.ErrNilVersion) {
+			// Fresh DB: pending iff the source defines any migration at all.
+			return hasAny, nil
+		}
+		return false, fmt.Errorf("read current migration version: %w", err)
+	}
+	if dirty {
+		return false, fmt.Errorf("%w (current version %d)", ErrDirtyMigration, current)
+	}
+
+	// hasAny is implied when current is set (the applied version came from the
+	// source), but guard anyway: with no source migrations nothing can pend.
+	if !hasAny {
+		return false, nil
+	}
+	return current < highest, nil
+}
+
+// highestSourceVersion opens the migrations source read-only and walks it to
+// find the highest available version. hasAny is false when the source defines no
+// migrations at all. The source driver is read-only (it never touches the DB).
+func highestSourceVersion(sourceURL string) (highest uint, hasAny bool, err error) {
+	src, err := source.Open(sourceURL)
+	if err != nil {
+		return 0, false, fmt.Errorf("open migrations source: %w", err)
+	}
+	defer func() { _ = src.Close() }()
+
+	version, err := src.First()
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// No migrations in the source.
+			return 0, false, nil
+		}
+		return 0, false, fmt.Errorf("read first source version: %w", err)
+	}
+
+	highest = version
+	for {
+		next, err := src.Next(version)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				break
+			}
+			return 0, false, fmt.Errorf("read next source version after %d: %w", version, err)
+		}
+		version = next
+		if version > highest {
+			highest = version
+		}
+	}
+	return highest, true, nil
+}
+
+// riverMigrationsPending reports whether River has any unapplied migration. It
+// runs a DryRun up-migration (guaranteed non-mutating: rivermigrate's
+// versionsInsert/versionsDelete early-return when DryRun is set) and inspects the
+// versions that WOULD apply — a non-empty set means pending.
+//
+// Unlike runRiverMigrations, the read does NOT take the migration advisory lock:
+// a DryRun never writes, so it needs no serialization against concurrent writers,
+// and skipping the lock avoids blocking the check behind an in-progress migrate.
+func riverMigrationsPending(ctx context.Context, databaseURL string) (bool, error) {
+	poolCfg, err := pgxpool.ParseConfig(databaseURL)
+	if err != nil {
+		return false, fmt.Errorf("parse DATABASE_URL for river migration check: %w", err)
+	}
+	poolCfg.MaxConns = 2
+	pool, err := pgxpool.NewWithConfig(ctx, poolCfg)
+	if err != nil {
+		return false, fmt.Errorf("open pool for river migration check: %w", err)
+	}
+	defer pool.Close()
+
+	migrator, err := rivermigrate.New(riverpgxv5.New(pool), nil)
+	if err != nil {
+		return false, fmt.Errorf("create river migrator: %w", err)
+	}
+	res, err := migrator.Migrate(ctx, rivermigrate.DirectionUp, &rivermigrate.MigrateOpts{DryRun: true})
+	if err != nil {
+		return false, fmt.Errorf("river migration dry-run: %w", err)
+	}
+	return len(res.Versions) > 0, nil
+}

--- a/backend/internal/db/migration_status.go
+++ b/backend/internal/db/migration_status.go
@@ -114,10 +114,17 @@ func appMigrationsPending(ctx context.Context, databaseURL string, migrationsPat
 
 // migrationsTableExists reports whether golang-migrate's schema_migrations
 // tracking table is present, via a read-only to_regclass catalog lookup on a
-// short-lived connection. This is the established migration-infrastructure SQL
-// exception (mirroring the advisory-lock reads in migration.go): a parameterized,
-// non-mutating system-catalog read with no sqlc representation. It exists so the
-// fresh-DB path stays strictly non-mutating (see appMigrationsPending).
+// short-lived connection.
+//
+// Raw-SQL exception: this is the same migration-infrastructure carve-out
+// core.md blesses for the advisory-lock SELECTs already in migration.go
+// (runRiverMigrations) — a single static, non-mutating, system-catalog read. It
+// has no sqlc representation by construction: schema_migrations is
+// golang-migrate's OWN internal bookkeeping table, not part of the application
+// schema sqlc generates from, and golang-migrate exposes no API to test the
+// table's existence (its version reads go through Open, which CREATEs the table).
+// The read exists precisely so the fresh-DB path can short-circuit BEFORE
+// migrate.New and stay strictly non-mutating (see appMigrationsPending).
 func migrationsTableExists(ctx context.Context, databaseURL string) (bool, error) {
 	poolCfg, err := pgxpool.ParseConfig(databaseURL)
 	if err != nil {

--- a/backend/internal/db/migration_status.go
+++ b/backend/internal/db/migration_status.go
@@ -36,7 +36,7 @@ var ErrDirtyMigration = errors.New("dirty migration state, manual intervention r
 // ErrDirtyMigration (NOT "pending"), so the caller can abort and require manual
 // intervention rather than snapshot-and-migrate over a half-applied schema.
 func MigrationStatus(ctx context.Context, databaseURL string, migrationsPath string) (appPending bool, riverPending bool, err error) {
-	appPending, err = appMigrationsPending(databaseURL, migrationsPath)
+	appPending, err = appMigrationsPending(ctx, databaseURL, migrationsPath)
 	if err != nil {
 		return false, false, err
 	}
@@ -53,14 +53,31 @@ func MigrationStatus(ctx context.Context, databaseURL string, migrationsPath str
 // is unapplied. It reads the current applied version and compares it against the
 // highest version present in the migrations source; it never calls Up/Steps.
 //
-// Fresh DB (ErrNilVersion) counts as pending iff the source has any migration.
-// A dirty state returns an error wrapping ErrDirtyMigration.
-func appMigrationsPending(databaseURL string, migrationsPath string) (bool, error) {
+// Fresh DB (no schema_migrations table yet) counts as pending iff the source has
+// any migration. A dirty state returns an error wrapping ErrDirtyMigration.
+//
+// Strictly non-mutating: golang-migrate's Postgres driver CREATEs the
+// schema_migrations table on migrate.New (its ensureVersionTable runs at Open),
+// which would mutate a fresh DB just by reading. So we first detect a fresh DB
+// via a read-only catalog check and short-circuit BEFORE opening migrate.New —
+// preserving the "report pending WITHOUT mutating" contract on the fresh path.
+func appMigrationsPending(ctx context.Context, databaseURL string, migrationsPath string) (bool, error) {
 	sourceURL := fmt.Sprintf("file://%s", migrationsPath)
 
 	highest, hasAny, err := highestSourceVersion(sourceURL)
 	if err != nil {
 		return false, fmt.Errorf("read highest source migration version: %w", err)
+	}
+
+	// Fresh-DB short-circuit: if the version-tracking table does not exist yet,
+	// the DB has never been migrated. Detect this read-only (no migrate.New, which
+	// would create the table) and report pending iff the source has any migration.
+	tracked, err := migrationsTableExists(ctx, databaseURL)
+	if err != nil {
+		return false, fmt.Errorf("check migrations table exists: %w", err)
+	}
+	if !tracked {
+		return hasAny, nil
 	}
 
 	m, err := migrate.New(sourceURL, databaseURL)
@@ -77,7 +94,8 @@ func appMigrationsPending(databaseURL string, migrationsPath string) (bool, erro
 	current, dirty, err := m.Version()
 	if err != nil {
 		if errors.Is(err, migrate.ErrNilVersion) {
-			// Fresh DB: pending iff the source defines any migration at all.
+			// schema_migrations exists but holds no row (e.g. a prior failed
+			// bootstrap): pending iff the source defines any migration.
 			return hasAny, nil
 		}
 		return false, fmt.Errorf("read current migration version: %w", err)
@@ -92,6 +110,31 @@ func appMigrationsPending(databaseURL string, migrationsPath string) (bool, erro
 		return false, nil
 	}
 	return current < highest, nil
+}
+
+// migrationsTableExists reports whether golang-migrate's schema_migrations
+// tracking table is present, via a read-only to_regclass catalog lookup on a
+// short-lived connection. This is the established migration-infrastructure SQL
+// exception (mirroring the advisory-lock reads in migration.go): a parameterized,
+// non-mutating system-catalog read with no sqlc representation. It exists so the
+// fresh-DB path stays strictly non-mutating (see appMigrationsPending).
+func migrationsTableExists(ctx context.Context, databaseURL string) (bool, error) {
+	poolCfg, err := pgxpool.ParseConfig(databaseURL)
+	if err != nil {
+		return false, fmt.Errorf("parse DATABASE_URL for migrations-table check: %w", err)
+	}
+	poolCfg.MaxConns = 1
+	pool, err := pgxpool.NewWithConfig(ctx, poolCfg)
+	if err != nil {
+		return false, fmt.Errorf("open pool for migrations-table check: %w", err)
+	}
+	defer pool.Close()
+
+	var regclass *string
+	if err := pool.QueryRow(ctx, "SELECT to_regclass('public.schema_migrations')::text").Scan(&regclass); err != nil {
+		return false, fmt.Errorf("read schema_migrations regclass: %w", err)
+	}
+	return regclass != nil, nil
 }
 
 // highestSourceVersion opens the migrations source read-only and walks it to

--- a/backend/tests/migration_status_integration_test.go
+++ b/backend/tests/migration_status_integration_test.go
@@ -178,9 +178,13 @@ func dropAllTables(t *testing.T, databaseURL, migrationsPath string) {
 }
 
 // schemaMigrationsTableExists reports whether golang-migrate's schema_migrations
-// table is present, via a read-only to_regclass catalog lookup (no raw DDL). Used
-// to assert the fresh-DB non-mutating contract in
-// TestMigrationStatus_FreshDBNonMutating.
+// table is present, via a read-only to_regclass catalog lookup. Used to assert
+// the fresh-DB non-mutating contract in TestMigrationStatus_FreshDBNonMutating.
+//
+// Raw-SQL exception (test-only): the same migration-infrastructure carve-out
+// migrationsTableExists uses in production — a static, non-mutating system-catalog
+// read of golang-migrate's own bookkeeping table, which has no sqlc representation
+// and no library existence-check API.
 func schemaMigrationsTableExists(t *testing.T, ctx context.Context, databaseURL string) bool {
 	t.Helper()
 	pool, err := pgxpool.New(ctx, databaseURL)

--- a/backend/tests/migration_status_integration_test.go
+++ b/backend/tests/migration_status_integration_test.go
@@ -1,0 +1,191 @@
+//go:build integration_testdb
+
+package tests
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"testing"
+
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/testdb"
+
+	migrate "github.com/golang-migrate/migrate/v4"
+	migratepg "github.com/golang-migrate/migrate/v4/database/postgres"
+	_ "github.com/golang-migrate/migrate/v4/source/file"
+	"github.com/jackc/pgx/v5/pgxpool"
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/riverqueue/river/rivermigrate"
+	"github.com/stretchr/testify/require"
+)
+
+// These exercise db.MigrationStatus and the crm-admin --migrate / --migrate-check
+// exit-code contract against REAL golang-migrate + River, NOT a unit stub. They
+// mutate the schema (roll migrations down to manufacture a pending/dirty state),
+// so each uses an ISOLATED per-test clone via testdb.NewEphemeralClone — never
+// the shared package DB, whose schema a half-rewound migration would corrupt for
+// sibling tests. Migration-subject tests stay serial (no t.Parallel()).
+
+// newMigrationStatusClone returns a fresh, fully-migrated isolated clone URL plus
+// the migrations path. The testdb template already applied all app + River
+// migrations into the clone, so MigrationStatus starts up-to-date.
+func newMigrationStatusClone(t *testing.T) (cloneURL, migrationsPath string) {
+	t.Helper()
+	if os.Getenv("DATABASE_URL") == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+	cloneURL, drop := testdb.NewEphemeralClone(t)
+	t.Cleanup(drop)
+	return cloneURL, getMigrationsPath()
+}
+
+func TestMigrationStatus_UpToDate(t *testing.T) {
+	ctx := context.Background()
+	cloneURL, migrationsPath := newMigrationStatusClone(t)
+
+	// The clone is template-migrated; RunMigrations is a no-op backstop and must
+	// stay clean per the CI bare-Postgres gotcha (call it before any read).
+	require.NoError(t, db.RunMigrations(ctx, cloneURL, migrationsPath))
+
+	appPending, riverPending, err := db.MigrationStatus(ctx, cloneURL, migrationsPath)
+	require.NoError(t, err)
+	require.False(t, appPending, "fully-migrated clone must report no app migrations pending")
+	require.False(t, riverPending, "fully-migrated clone must report no River migrations pending")
+}
+
+func TestMigrationStatus_AppPending(t *testing.T) {
+	ctx := context.Background()
+	cloneURL, migrationsPath := newMigrationStatusClone(t)
+	require.NoError(t, db.RunMigrations(ctx, cloneURL, migrationsPath))
+
+	// Roll the app schema down by exactly one migration, so the latest app
+	// migration is unapplied. This proves the golang-migrate version-comparison
+	// path against real migrations (not a stub).
+	m, err := migrate.New(fmt.Sprintf("file://%s", migrationsPath), cloneURL)
+	require.NoError(t, err)
+	require.NoError(t, m.Steps(-1), "roll app schema down one step")
+	srcErr, dbErr := m.Close()
+	require.NoError(t, srcErr)
+	require.NoError(t, dbErr)
+
+	appPending, riverPending, err := db.MigrationStatus(ctx, cloneURL, migrationsPath)
+	require.NoError(t, err)
+	require.True(t, appPending, "after rolling down one app migration, app should be pending")
+	require.False(t, riverPending, "River was not touched, so it should report up-to-date")
+
+	// Re-applying restores up-to-date — confirms the down/up symmetry holds and
+	// MigrationStatus flips back to false.
+	require.NoError(t, db.RunMigrations(ctx, cloneURL, migrationsPath))
+	appPending, _, err = db.MigrationStatus(ctx, cloneURL, migrationsPath)
+	require.NoError(t, err)
+	require.False(t, appPending, "after re-applying, app should be up-to-date again")
+}
+
+func TestMigrationStatus_RiverPending(t *testing.T) {
+	ctx := context.Background()
+	cloneURL, migrationsPath := newMigrationStatusClone(t)
+	require.NoError(t, db.RunMigrations(ctx, cloneURL, migrationsPath))
+
+	// Roll River's schema down by one migration via its own migrator, leaving the
+	// app schema fully applied. This proves the rivermigrate DryRun read detects a
+	// DB missing River's latest version.
+	rollRiverDownOne(t, ctx, cloneURL)
+
+	appPending, riverPending, err := db.MigrationStatus(ctx, cloneURL, migrationsPath)
+	require.NoError(t, err)
+	require.False(t, appPending, "app schema was not touched, so it should be up-to-date")
+	require.True(t, riverPending, "after rolling River down one migration, River should be pending")
+
+	// Re-applying River migrations restores up-to-date.
+	require.NoError(t, db.RunMigrations(ctx, cloneURL, migrationsPath))
+	_, riverPending, err = db.MigrationStatus(ctx, cloneURL, migrationsPath)
+	require.NoError(t, err)
+	require.False(t, riverPending, "after re-applying River migrations, River should be up-to-date")
+}
+
+func TestMigrationStatus_DirtyIsOperationalError(t *testing.T) {
+	ctx := context.Background()
+	cloneURL, migrationsPath := newMigrationStatusClone(t)
+	require.NoError(t, db.RunMigrations(ctx, cloneURL, migrationsPath))
+
+	// Force the golang-migrate schema_migrations row into a dirty state via the
+	// database driver's SetVersion (a library call, not raw SQL). A dirty DB must
+	// be surfaced as an operational error (→ exit 1), NEVER as "pending" (exit 2).
+	forceAppMigrationDirty(t, ctx, cloneURL)
+
+	appPending, riverPending, err := db.MigrationStatus(ctx, cloneURL, migrationsPath)
+	require.Error(t, err, "a dirty DB must surface as an operational error")
+	require.ErrorIs(t, err, db.ErrDirtyMigration, "dirty error must wrap ErrDirtyMigration")
+	require.False(t, appPending)
+	require.False(t, riverPending)
+}
+
+func TestMigrate_Idempotent(t *testing.T) {
+	ctx := context.Background()
+	cloneURL, migrationsPath := newMigrationStatusClone(t)
+
+	// First apply (clone is already template-migrated, so this is the no-op
+	// backstop path), then a second apply must also be a clean no-op.
+	require.NoError(t, db.RunMigrations(ctx, cloneURL, migrationsPath))
+	require.NoError(t, db.RunMigrations(ctx, cloneURL, migrationsPath), "re-running --migrate must be a clean no-op")
+
+	appPending, riverPending, err := db.MigrationStatus(ctx, cloneURL, migrationsPath)
+	require.NoError(t, err)
+	require.False(t, appPending)
+	require.False(t, riverPending)
+}
+
+// rollRiverDownOne rolls River's migration schema down by exactly one version
+// using River's own migrator (no raw SQL).
+func rollRiverDownOne(t *testing.T, ctx context.Context, databaseURL string) {
+	t.Helper()
+	poolCfg, err := pgxpool.ParseConfig(databaseURL)
+	require.NoError(t, err)
+	poolCfg.MaxConns = 2
+	pool, err := pgxpool.NewWithConfig(ctx, poolCfg)
+	require.NoError(t, err)
+	defer pool.Close()
+
+	migrator, err := rivermigrate.New(riverpgxv5.New(pool), nil)
+	require.NoError(t, err)
+	res, err := migrator.Migrate(ctx, rivermigrate.DirectionDown, &rivermigrate.MigrateOpts{MaxSteps: 1})
+	require.NoError(t, err)
+	require.Len(t, res.Versions, 1, "expected exactly one River migration rolled down")
+}
+
+// forceAppMigrationDirty marks the golang-migrate schema_migrations row dirty at
+// the current applied version via the postgres database driver's SetVersion — a
+// library call (no raw SQL). Uses the pgx stdlib sql driver to open the *sql.DB
+// the migrate postgres driver wraps.
+func forceAppMigrationDirty(t *testing.T, ctx context.Context, databaseURL string) {
+	t.Helper()
+	sqlDB, err := sql.Open("pgx", databaseURL)
+	require.NoError(t, err)
+	defer func() { _ = sqlDB.Close() }()
+	require.NoError(t, sqlDB.PingContext(ctx))
+
+	driver, err := migratepg.WithInstance(sqlDB, &migratepg.Config{})
+	require.NoError(t, err)
+
+	current, dirty, err := driver.Version()
+	require.NoError(t, err)
+	require.False(t, dirty, "clone should start clean")
+	require.NotEqual(t, -1, current, "clone should have an applied app version")
+
+	// SetVersion(version, dirty=true) writes the dirty marker the migrate library
+	// itself uses to signal a failed mid-apply state.
+	require.NoError(t, driver.SetVersion(current, true))
+
+	// Sanity: a fresh migrate instance now reads dirty=true. Version() reads the
+	// marker straight from the driver, so it returns (version, true, nil) — the
+	// ErrDirty sentinel is only produced by Up/Steps, not Version.
+	verify, err := migrate.New(fmt.Sprintf("file://%s", getMigrationsPath()), databaseURL)
+	require.NoError(t, err)
+	defer func() { _, _ = verify.Close() }()
+	_, gotDirty, verr := verify.Version()
+	require.NoError(t, verr, "Version() should read the dirty marker without an error")
+	require.True(t, gotDirty, "expected the forced dirty marker to be visible")
+}

--- a/backend/tests/migration_status_integration_test.go
+++ b/backend/tests/migration_status_integration_test.go
@@ -138,6 +138,59 @@ func TestMigrate_Idempotent(t *testing.T) {
 	require.False(t, riverPending)
 }
 
+// TestMigrationStatus_FreshDBNonMutating proves MigrationStatus is strictly
+// non-mutating on a fresh (never-migrated) DB: it reports pending WITHOUT
+// creating golang-migrate's schema_migrations tracking table. golang-migrate's
+// Postgres driver creates that table at migrate.New time, so a naive read would
+// mutate a fresh DB — the read-only to_regclass short-circuit must prevent it.
+func TestMigrationStatus_FreshDBNonMutating(t *testing.T) {
+	ctx := context.Background()
+	cloneURL, migrationsPath := newMigrationStatusClone(t)
+	require.NoError(t, db.RunMigrations(ctx, cloneURL, migrationsPath))
+
+	// Drop ALL tables (app + River + schema_migrations) via the migrate library
+	// to manufacture a genuinely fresh DB — no raw SQL.
+	dropAllTables(t, cloneURL, migrationsPath)
+	require.False(t, schemaMigrationsTableExists(t, ctx, cloneURL),
+		"precondition: schema_migrations must be absent on the fresh DB")
+
+	appPending, riverPending, err := db.MigrationStatus(ctx, cloneURL, migrationsPath)
+	require.NoError(t, err)
+	require.True(t, appPending, "a fresh DB with source migrations must report app pending")
+	require.True(t, riverPending, "a fresh DB must report River pending")
+
+	// The load-bearing assertion: the status read must NOT have re-created the
+	// tracking table.
+	require.False(t, schemaMigrationsTableExists(t, ctx, cloneURL),
+		"MigrationStatus must not create schema_migrations on a fresh DB (non-mutating contract)")
+}
+
+// dropAllTables drops every table (app + River + schema_migrations) via the
+// migrate library's Drop, manufacturing a genuinely fresh DB without raw SQL.
+func dropAllTables(t *testing.T, databaseURL, migrationsPath string) {
+	t.Helper()
+	m, err := migrate.New(fmt.Sprintf("file://%s", migrationsPath), databaseURL)
+	require.NoError(t, err)
+	require.NoError(t, m.Drop(), "drop all tables to manufacture a fresh DB")
+	srcErr, dbErr := m.Close()
+	require.NoError(t, srcErr)
+	require.NoError(t, dbErr)
+}
+
+// schemaMigrationsTableExists reports whether golang-migrate's schema_migrations
+// table is present, via a read-only to_regclass catalog lookup (no raw DDL). Used
+// to assert the fresh-DB non-mutating contract in
+// TestMigrationStatus_FreshDBNonMutating.
+func schemaMigrationsTableExists(t *testing.T, ctx context.Context, databaseURL string) bool {
+	t.Helper()
+	pool, err := pgxpool.New(ctx, databaseURL)
+	require.NoError(t, err)
+	defer pool.Close()
+	var regclass *string
+	require.NoError(t, pool.QueryRow(ctx, "SELECT to_regclass('public.schema_migrations')::text").Scan(&regclass))
+	return regclass != nil
+}
+
 // rollRiverDownOne rolls River's migration schema down by exactly one version
 // using River's own migrator (no raw SQL).
 func rollRiverDownOne(t *testing.T, ctx context.Context, databaseURL string) {


### PR DESCRIPTION
## Summary

Adds two mutually-exclusive `crm-admin` subcommands the deploy script (PR3) drives from the **new** image before swapping the running container, plus a testable `db.MigrationStatus` helper. crm-api boot is unchanged (`db.RunMigrations` stays a no-op backstop).

- **`--migrate`** — applies pending application + River migrations idempotently (reuses `db.RunMigrations`, the exact crm-api boot call). Exit 0 on success, 1 on error.
- **`--migrate-check`** — reports whether migrations are pending **without mutating** the DB, with three distinct exit codes the deploy script branches on.

## Exit-code contract (`--migrate-check`)

- **0** — up-to-date (no app or River migrations pending)
- **2** — pending (app and/or River) → deploy script snapshots-then-migrates
- **1** — operational error (cannot connect, dirty DB, version read failed) → deploy script aborts before touching anything

Implemented with a typed `exitErr{code,msg}` mapped in `main()` via `errors.As`; `run()` keeps returning `error` for testability. The migrate subcommands dispatch **pre-DB** in `runMain` (they need only the database URL + migrations path, not `buildProductionDeps`), so they run on Google-less hosts without opening the application pool.

## Non-mutating detection (`db.MigrationStatus`)

- **App** — golang-migrate `m.Version()` vs the highest version walked from the read-only migrations source. Never calls `Up`/`Steps`. A dirty state surfaces as `ErrDirtyMigration` (→ exit 1, never "pending"). A fresh DB short-circuits via a read-only `to_regclass` catalog check **before** `migrate.New`, because golang-migrate's Postgres driver creates `schema_migrations` at construction — so a naive read would mutate a never-migrated DB. (This was a latent bug in the plan's own design, caught during implementation.)
- **River** — `rivermigrate` `DryRun:true` (guaranteed non-mutating); non-empty returned versions means pending.

The single read-only `to_regclass` SELECT is the same migration-infrastructure raw-SQL carve-out core.md already blesses for `migration.go`'s advisory-lock reads (golang-migrate's `schema_migrations` is its own bookkeeping table — no sqlc representation, no library existence-check API).

## Tests

- **Unit** (`backend/cmd/crm-admin/main_test.go`) — `parseArgs`/`validateSubcommand` recognition + mutual exclusion; exit-code mapping (0/2/1) via an injectable status reporter; `exitErr` `errors.As` classification.
- **Integration** on **isolated per-test clones** (`testdb.NewEphemeralClone`, migration-subject serial) against real golang-migrate + River: up-to-date, app-pending (roll-down to N-1), river-pending (River roll-down), dirty → exit 1, fresh-DB non-mutating (drop all tables, assert `schema_migrations` stays absent), `--migrate` idempotence, and the **end-to-end 0/1/2 exit-code contract** through the real `runMigrateCheck`.
- Wired `./cmd/crm-admin/...` into the integration Makefile targets so the new tagged tests run in CI (`test-integration-fast`) and locally.

## Test plan

- `make test-integration-fast` (CI set) and `make test-unit` both green locally.
- Lint clean.
- Local Codex review converged to PASS (3 rounds); `/review-head` PASS.

## Review findings (accepted, non-blocking)

The `/review-head` pass returned 0 P0 / 0 P1 / 4 P3. All four are accepted as-is with no code change:

1. Near-zero-probability stdout-write edge that could mask exit 2 as exit 1 (deploy stdout is a captured `podman run --rm` pipe; exit 1 aborts-safe).
2. Latent `public.schema_migrations` schema assumption (no non-public `search_path` override exists anywhere today).
3. Stray-positional-arg tolerance (`parseArgs` ignores extra positionals — pre-existing binary-wide pattern).
4. River-pending fresh-DB test does not assert `river_migration` stays absent (verified from river v0.34.0 source that the dry-run cannot create it — a test-symmetry nit, not a code bug).

## Links

- Plan: `.ai/log/plan/2026-06-11-deploy-automation-phaseA-bucketA.md` §3 (PR2)
