### PR TITLE
feat(deploy): deploy-artifact.sh + restore-db.sh + backup-db --local + ntfy

### DIFF
--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -6,11 +6,18 @@
 # system user, so this stops the *user* systemd services and copies the Podman
 # named volume (`personalcrm-db`) rather than the old Docker volume.
 #
-# Usage: ./scripts/backup-db.sh [--no-restart]
+# Usage: ./scripts/backup-db.sh [--no-restart] [--local]
 #   --no-restart  Stop services for backup but don't restart (e.g., before a deploy)
+#   --local       Run on the Pi as root (no ssh). The crm-user podman/systemctl
+#                 helpers run via `sudo -u crm ...` locally instead of over ssh.
+#                 Used by deploy-artifact.sh for the pre-migrate snapshot.
 #
 # Stops the writers + postgres for a clean copy, then restarts them. Backup is
 # stored alongside the volume data as _data.bak-YYYYMMDD-HHMMSS.
+#
+# Default (ssh) mode is unchanged: all progress goes to stdout. In --local mode
+# all progress goes to stderr and the ONLY stdout line is BACKUP_PATH=<path>, so
+# a caller (deploy-artifact.sh) can capture the snapshot location cleanly.
 
 set -e
 
@@ -19,32 +26,69 @@ TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 
 # Parse arguments
 NO_RESTART=false
+LOCAL=false
 for arg in "$@"; do
     case $arg in
         --no-restart) NO_RESTART=true ;;
+        --local) LOCAL=true ;;
     esac
 done
 
-echo "=== PersonalCRM Database Backup (Podman) ==="
-echo "Target: $PI_HOST"
-echo ""
+CRM_HOME=/var/lib/personalcrm
 
-# Verify Pi is reachable
-echo "Checking connectivity to $PI_HOST..."
-if ! ssh -q -o ConnectTimeout=5 "$PI_HOST" exit; then
-    echo "Error: Cannot connect to $PI_HOST"
-    exit 1
+# log: progress messages. ssh mode → stdout (unchanged behavior); local mode →
+# stderr (so stdout carries only the captured BACKUP_PATH line).
+if [ "$LOCAL" = true ]; then
+    log() { echo "$@" >&2; }
+else
+    log() { echo "$@"; }
 fi
 
-# Resolve the crm user context for rootless systemctl --user / podman.
-# `cd /tmp` + explicit HOME: interactive `sudo -u crm` inherits the SSH user's
-# CWD/HOME, which crm can't access (rootless podman then fails to chdir). The
-# Quadlet services themselves run under systemd and are unaffected.
-CRM_UID=$(ssh "$PI_HOST" "id -u crm")
-CRM_HOME=/var/lib/personalcrm
-USERENV="HOME=$CRM_HOME XDG_RUNTIME_DIR=/run/user/$CRM_UID DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$CRM_UID/bus"
-crm_ctl()    { ssh "$PI_HOST" "cd /tmp && sudo -n -u crm $USERENV systemctl --user $*"; }
-crm_podman() { ssh "$PI_HOST" "cd /tmp && sudo -n -u crm HOME=$CRM_HOME XDG_RUNTIME_DIR=/run/user/$CRM_UID podman $*"; }
+if [ "$LOCAL" = true ]; then
+    # On-Pi mode: no ssh. Resolve the crm uid locally and wrap podman/systemctl
+    # in `sudo -u crm` so they hit the rootless crm-user store, never root's.
+    # The `cd /tmp` mirrors the ssh form: an interactive `sudo -u crm` inherits
+    # the caller's CWD, which crm can't access (rootless podman fails to chdir).
+    CRM_UID=$(id -u crm)
+    USERENV="HOME=$CRM_HOME XDG_RUNTIME_DIR=/run/user/$CRM_UID DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$CRM_UID/bus"
+    # USERENV is deliberately unquoted: it must word-split into separate KEY=val
+    # arguments for env-style `sudo -u crm KEY=val KEY=val ...`.
+    # shellcheck disable=SC2086
+    crm_ctl()    { cd /tmp && sudo -u crm $USERENV systemctl --user "$@"; }
+    crm_podman() { cd /tmp && sudo -u crm HOME=$CRM_HOME XDG_RUNTIME_DIR=/run/user/"$CRM_UID" podman "$@"; }
+    root_cp()    { sudo cp -a "$1" "$2"; }
+    root_du()    { sudo du -sh "$1" | cut -f1; }
+
+    log "=== PersonalCRM Database Backup (Podman, local) ==="
+else
+    log "=== PersonalCRM Database Backup (Podman) ==="
+    log "Target: $PI_HOST"
+    log ""
+
+    # Verify Pi is reachable
+    log "Checking connectivity to $PI_HOST..."
+    if ! ssh -q -o ConnectTimeout=5 "$PI_HOST" exit; then
+        echo "Error: Cannot connect to $PI_HOST"
+        exit 1
+    fi
+
+    # Resolve the crm user context for rootless systemctl --user / podman.
+    # `cd /tmp` + explicit HOME: interactive `sudo -u crm` inherits the SSH user's
+    # CWD/HOME, which crm can't access (rootless podman then fails to chdir). The
+    # Quadlet services themselves run under systemd and are unaffected.
+    CRM_UID=$(ssh "$PI_HOST" "id -u crm")
+    USERENV="HOME=$CRM_HOME XDG_RUNTIME_DIR=/run/user/$CRM_UID DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$CRM_UID/bus"
+    # Vars below deliberately expand client-side (resolved here, then sent over
+    # ssh as a literal remote command). SC2029 is the intended behavior.
+    # shellcheck disable=SC2029
+    crm_ctl()    { ssh "$PI_HOST" "cd /tmp && sudo -n -u crm $USERENV systemctl --user $*"; }
+    # shellcheck disable=SC2029
+    crm_podman() { ssh "$PI_HOST" "cd /tmp && sudo -n -u crm HOME=$CRM_HOME XDG_RUNTIME_DIR=/run/user/$CRM_UID podman $*"; }
+    # shellcheck disable=SC2029
+    root_cp()    { ssh "$PI_HOST" "sudo cp -a '$1' '$2'"; }
+    # shellcheck disable=SC2029
+    root_du()    { ssh "$PI_HOST" "sudo du -sh '$1' | cut -f1"; }
+fi
 
 # Safety net: if we error out (set -e) after stopping services, don't leave prod
 # down silently -- try to restart, and print an explicit manual-recovery command.
@@ -56,7 +100,11 @@ on_exit() {
         echo "⚠️  ERROR (exit $rc) with services stopped — attempting restart..." >&2
         if ! crm_ctl start personalcrm-database.service personalcrm-backend.service personalcrm-frontend.service; then
             echo "   AUTO-RESTART FAILED. Restart manually:" >&2
-            echo "   ssh $PI_HOST \"cd /tmp && sudo -n -u crm $USERENV systemctl --user start personalcrm-database.service personalcrm-backend.service personalcrm-frontend.service\"" >&2
+            if [ "$LOCAL" = true ]; then
+                echo "   sudo -u crm $USERENV systemctl --user start personalcrm-database.service personalcrm-backend.service personalcrm-frontend.service" >&2
+            else
+                echo "   ssh $PI_HOST \"cd /tmp && sudo -n -u crm $USERENV systemctl --user start personalcrm-database.service personalcrm-backend.service personalcrm-frontend.service\"" >&2
+            fi
         fi
     fi
 }
@@ -65,48 +113,58 @@ trap on_exit EXIT
 # Locate the Podman named volume mountpoint (.../volumes/personalcrm-db/_data).
 VOLUME_PATH=$(crm_podman volume inspect personalcrm-db --format '{{.Mountpoint}}')
 BACKUP_PATH="${VOLUME_PATH}.bak-${TIMESTAMP}"
-echo "Volume: $VOLUME_PATH"
-echo "Backup: $BACKUP_PATH"
-echo ""
+log "Volume: $VOLUME_PATH"
+log "Backup: $BACKUP_PATH"
+[ "$LOCAL" = true ] || log ""
 
 # Stop the writers, then postgres, to guarantee a consistent on-disk copy.
-echo "Stopping app services (backend, frontend)..."
+log "Stopping app services (backend, frontend)..."
 crm_ctl stop personalcrm-backend.service personalcrm-frontend.service
 SERVICES_STOPPED=true
 
-echo "Stopping postgres..."
+log "Stopping postgres..."
 crm_ctl stop personalcrm-database.service
 
 # Copy the volume (owned by a mapped subuid; root can read it).
-echo "Copying data volume (this may take a moment)..."
-ssh "$PI_HOST" "sudo cp -a '$VOLUME_PATH' '$BACKUP_PATH'"
+log "Copying data volume (this may take a moment)..."
+root_cp "$VOLUME_PATH" "$BACKUP_PATH"
 
-BACKUP_SIZE=$(ssh "$PI_HOST" "sudo du -sh '$BACKUP_PATH' | cut -f1")
-echo "Backup created: $BACKUP_PATH ($BACKUP_SIZE)"
+BACKUP_SIZE=$(root_du "$BACKUP_PATH")
+log "Backup created: $BACKUP_PATH ($BACKUP_SIZE)"
 
 if [ "$NO_RESTART" = true ]; then
-    echo ""
-    echo "⚠️  --no-restart specified. Services are stopped."
-    echo "   Restart manually with:"
-    echo "   ssh $PI_HOST \"sudo -n -u crm $USERENV systemctl --user start personalcrm-database.service personalcrm-backend.service personalcrm-frontend.service\""
+    log ""
+    log "⚠️  --no-restart specified. Services are stopped."
+    log "   Restart manually with:"
+    if [ "$LOCAL" = true ]; then
+        log "   sudo -u crm $USERENV systemctl --user start personalcrm-database.service personalcrm-backend.service personalcrm-frontend.service"
+    else
+        log "   ssh $PI_HOST \"sudo -n -u crm $USERENV systemctl --user start personalcrm-database.service personalcrm-backend.service personalcrm-frontend.service\""
+    fi
 else
-    echo "Restarting postgres..."
+    log "Restarting postgres..."
     crm_ctl start personalcrm-database.service
 
-    echo "Waiting for postgres to accept connections..."
+    log "Waiting for postgres to accept connections..."
     for i in $(seq 1 15); do
         if crm_podman exec crm-postgres pg_isready -U crm_user >/dev/null 2>&1; then
             break
         fi
         if [ "$i" -eq 15 ]; then
-            echo "Warning: postgres not ready after 15s, starting app anyway"
+            log "Warning: postgres not ready after 15s, starting app anyway"
         fi
         sleep 1
     done
 
-    echo "Restarting backend and frontend..."
+    log "Restarting backend and frontend..."
     crm_ctl start personalcrm-backend.service personalcrm-frontend.service
     SERVICES_STOPPED=false
-    echo ""
-    echo "✅ Backup complete. Services restarted."
+    log ""
+    log "✅ Backup complete. Services restarted."
+fi
+
+# In --local mode, emit the snapshot path on stdout (the ONLY stdout line) so a
+# caller can capture it. In ssh mode the path is already in the human log above.
+if [ "$LOCAL" = true ]; then
+    echo "BACKUP_PATH=$BACKUP_PATH"
 fi

--- a/scripts/deploy-artifact.sh
+++ b/scripts/deploy-artifact.sh
@@ -1,0 +1,424 @@
+#!/bin/bash
+# PersonalCRM artifact deploy (rootless Podman Quadlet edition).
+#
+# Promotes a single, already-built GHCR image (tagged :<sha>) to prod. Runs ON
+# THE PI AS ROOT (via one sudoers entry), but EVERY podman/systemctl op against
+# the crm runtime runs as the crm user (rootless store), never root's. The only
+# genuine-root ops live inside backup-db.sh / restore-db.sh (the cold volume cp).
+#
+# Flow:
+#   validate SHA -> read rollback anchor from the live units -> pull :<sha> ->
+#   migrate-check via the NEW image:
+#     exit 0 (up-to-date): swap Image=, restart app, health-gate (no DB touched).
+#     exit 2 (pending):    stop app -> snapshot -> start DB -> migrate -> swap ->
+#                          start app -> health-gate. ANY failure after migrate
+#                          succeeds routes to ROLLBACK-WITH-RESTORE.
+#     exit 1/other:        abort before touching anything.
+#
+# Usage: deploy-artifact.sh <40-hex-sha>
+#
+# Notifications: sourced from /etc/personalcrm/ntfy.env if present (degrade-open
+# -- absent file => skip ntfy and continue, so the script stays env-agnostic for
+# staging). Bodies carry only the SHA + a fixed reason; NEVER PII or secrets.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration (overridable by env for tests / staging; defaults are prod).
+# ---------------------------------------------------------------------------
+CRM_USER="${CRM_USER:-crm}"
+CRM_HOME="${CRM_HOME:-/var/lib/personalcrm}"
+QUADLET_DIR="${QUADLET_DIR:-$CRM_HOME/.config/containers/systemd}"
+BACKEND_UNIT="${BACKEND_UNIT:-$QUADLET_DIR/personalcrm-backend.container}"
+FRONTEND_UNIT="${FRONTEND_UNIT:-$QUADLET_DIR/personalcrm-frontend.container}"
+BACKEND_REPO="${BACKEND_REPO:-ghcr.io/spengrah/personalcrm-backend}"
+FRONTEND_REPO="${FRONTEND_REPO:-ghcr.io/spengrah/personalcrm-frontend}"
+ENV_FILE="${DEPLOY_ENV_FILE:-/srv/personalcrm/.env}"
+PODMAN_NETWORK="${PODMAN_NETWORK:-crm}"
+MIGRATIONS_PATH="${DEPLOY_MIGRATIONS_PATH:-/migrations}"
+BACKUP_SCRIPT="${BACKUP_SCRIPT:-/usr/local/sbin/backup-db.sh}"
+RESTORE_SCRIPT="${RESTORE_SCRIPT:-/usr/local/sbin/restore-db.sh}"
+NTFY_ENV_FILE="${NTFY_ENV_FILE:-/etc/personalcrm/ntfy.env}"
+HEALTH_RETRIES="${HEALTH_RETRIES:-40}"
+
+# ---------------------------------------------------------------------------
+# crm-user helpers: ALL podman/systemctl run rootless as the crm user.
+# ---------------------------------------------------------------------------
+CRM_UID="$(id -u "$CRM_USER")"
+XDG="/run/user/$CRM_UID"
+
+# crm_podman / crm_ctl: rootless ops against the crm-user store. cd /tmp because
+# an interactive `sudo -u crm` inherits root's CWD, which crm can't chdir into.
+crm_podman() { ( cd /tmp && sudo -u "$CRM_USER" HOME="$CRM_HOME" XDG_RUNTIME_DIR="$XDG" podman "$@" ); }
+crm_ctl()    { sudo -u "$CRM_USER" HOME="$CRM_HOME" XDG_RUNTIME_DIR="$XDG" DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG/bus" systemctl --user "$@"; }
+
+# ---------------------------------------------------------------------------
+# ntfy: source the env file if present (degrade-open). Two vars: NTFY_URL +
+# NTFY_TOPIC. Absent file => ntfy disabled, deploy continues.
+# ---------------------------------------------------------------------------
+NTFY_ENABLED=false
+if [ -f "$NTFY_ENV_FILE" ]; then
+    # shellcheck source=/dev/null
+    source "$NTFY_ENV_FILE"
+    if [ -n "${NTFY_URL:-}" ] && [ -n "${NTFY_TOPIC:-}" ]; then
+        NTFY_ENABLED=true
+    fi
+fi
+
+# ntfy <title> <priority> <tags> <body>. Never logs the topic/URL. A failing POST
+# is logged but never changes the deploy outcome.
+ntfy() {
+    local title="$1" priority="$2" tags="$3" body="$4"
+    if [ "$NTFY_ENABLED" != true ]; then
+        return 0
+    fi
+    if ! curl -fsS \
+        -H "Title: $title" -H "Priority: $priority" -H "Tags: $tags" \
+        -d "$body" "$NTFY_URL/$NTFY_TOPIC" >/dev/null 2>&1; then
+        echo "warning: ntfy POST failed (deploy outcome unchanged)" >&2
+    fi
+}
+
+log() { echo "[deploy] $*" >&2; }
+
+# ---------------------------------------------------------------------------
+# Pure-ish helpers (unit-tested via PATH stubs).
+# ---------------------------------------------------------------------------
+
+# valid_sha: 0 iff arg is exactly 40 lowercase hex chars.
+valid_sha() { [[ "$1" =~ ^[0-9a-f]{40}$ ]]; }
+
+# read_image_tag <unit>: echoes the value of the Image= line (e.g.
+# "ghcr.io/.../personalcrm-backend:latest"). Empty if not found.
+read_image_tag() {
+    sed -n 's/^Image=//p' "$1" | head -1
+}
+
+# rollback_ref_for <repo> <container> <unit>: resolve the immutable rollback ref.
+# If the unit pins :<40-hex-sha> -> repo:<that-sha> (deterministic).
+# If it pins :latest (or anything else mutable) -> resolve the RUNNING image
+# digest of <container> -> repo@sha256:<digest> (immutable).
+rollback_ref_for() {
+    local repo="$1" container="$2" unit="$3" image tag digest
+    image="$(read_image_tag "$unit")"
+    tag="${image##*:}"
+    if [[ "$tag" =~ ^[0-9a-f]{40}$ ]]; then
+        echo "$repo:$tag"
+        return 0
+    fi
+    # Mutable tag (:latest etc.) -> pin the currently-running digest.
+    digest="$(crm_podman inspect "$container" --format '{{index .RepoDigests 0}}')"
+    if [ -z "$digest" ]; then
+        echo "error: could not resolve running digest for $container" >&2
+        return 1
+    fi
+    # digest is "<repo>@sha256:<hex>"; use it verbatim (already an immutable ref).
+    echo "$digest"
+}
+
+# pin_image <unit> <ref>: rewrite the Image= line (as the crm user, to preserve
+# ownership) then RE-READ and assert it took. Aborts non-zero if the rewrite
+# did not land (a silent no-op sed must never ship the wrong image).
+pin_image() {
+    local unit="$1" ref="$2" got
+    sudo -u "$CRM_USER" sed -i "s|^Image=.*|Image=$ref|" "$unit"
+    got="$(read_image_tag "$unit")"
+    if [ "$got" != "$ref" ]; then
+        echo "error: Image= rewrite of $unit did not take (got '$got', want '$ref')" >&2
+        return 1
+    fi
+}
+
+# run_migrate_admin runs crm-admin from the NEW image. The image ENTRYPOINT is
+# crm-api, so --entrypoint is REQUIRED to run crm-admin instead. The mandatory
+# -e MIGRATIONS_PATH overrides any stale host .env path (same guard as the unit).
+run_migrate_admin() {
+    local subcmd="$1"  # --migrate-check | --migrate
+    crm_podman run --rm \
+        --network "$PODMAN_NETWORK" \
+        --env-file "$ENV_FILE" \
+        -e "MIGRATIONS_PATH=$MIGRATIONS_PATH" \
+        --entrypoint /usr/local/bin/crm-admin \
+        "$BACKEND_REPO:$SHA" "$subcmd"
+}
+
+# ---------------------------------------------------------------------------
+# Health gate: reads-only. All three must pass within the retry budget.
+# ---------------------------------------------------------------------------
+health_gate() {
+    local i ok=false
+    # 1. backend /health reports the DB healthy (bounded retry ~HEALTH_RETRIES s).
+    for ((i = 1; i <= HEALTH_RETRIES; i++)); do
+        if curl -sf http://127.0.0.1:8080/health 2>/dev/null | grep -q '"database":"healthy"'; then
+            ok=true
+            break
+        fi
+        sleep 1
+    done
+    if [ "$ok" != true ]; then
+        log "health-gate: backend /health did not report database healthy"
+        return 1
+    fi
+    # 2. frontend answers.
+    if ! curl -sf http://127.0.0.1:3001 >/dev/null 2>&1; then
+        log "health-gate: frontend did not answer on 3001"
+        return 1
+    fi
+    # 3. one authenticated read through Caddy. Plain curl: Caddy injects X-API-Key.
+    #    MUST NOT send X-Mac-Host-ID (that bypasses injection -> 401).
+    local code
+    code="$(curl -s -o /dev/null -w '%{http_code}' http://localhost:80/api/v1/contacts 2>/dev/null || true)"
+    if [ "$code" != "200" ]; then
+        log "health-gate: authenticated read through Caddy returned $code (want 200)"
+        return 1
+    fi
+    return 0
+}
+
+# post_migrate_swap: steps e-g of the pending path. Returns non-zero on the FIRST
+# failing step (image swap/assert, daemon-reload, app start, or health gate) so
+# the caller routes to ROLLBACK-WITH-RESTORE. Explicit && short-circuiting (not a
+# `set -e` subshell) so a failure is never swallowed by the if/! context.
+post_migrate_swap() {
+    # e. SWAP image, daemon-reload, assert (pin_image asserts the rewrite took).
+    pin_image "$BACKEND_UNIT" "$BACKEND_REPO:$SHA" \
+        && pin_image "$FRONTEND_UNIT" "$FRONTEND_REPO:$SHA" \
+        && crm_ctl daemon-reload \
+        && crm_ctl start personalcrm-backend.service personalcrm-frontend.service \
+        && health_gate
+}
+
+# ---------------------------------------------------------------------------
+# Rollback. ROLLBACK-WITH-RESTORE restores the DB UNCONDITIONALLY (app stopped)
+# BEFORE re-pinning the OLD image. A restore OR re-pin failure is max-priority
+# "ROLLBACK FAILED" with the app left STOPPED and the snapshot retained.
+# ---------------------------------------------------------------------------
+rollback_with_restore() {
+    local reason="$1"
+    # Re-entry guard: this function always exits non-zero, which re-fires the EXIT
+    # trap. Mark in-progress so the trap doesn't recursively re-invoke us.
+    ROLLBACK_IN_PROGRESS=1
+    log "ROLLBACK-WITH-RESTORE: $reason"
+
+    # 1. Ensure the app is down. With it stopped, restoring the volume can never
+    #    boot the wrong code against the restored DB.
+    crm_ctl stop personalcrm-backend.service personalcrm-frontend.service || true
+
+    # 2. RESTORE FIRST (unconditional). --no-app-start: DB restored + up, app NOT
+    #    started. This undoes the forward migration regardless of image state.
+    if ! "$RESTORE_SCRIPT" --local --no-app-start "$SNAPSHOT"; then
+        ntfy "ROLLBACK FAILED — prod degraded" "urgent" "rotating_light" \
+            "$SHA deploy failed AND restore/rollback failed; manual intervention required"
+        log "ROLLBACK FAILED: restore-db.sh failed; app left STOPPED, snapshot retained"
+        exit 1
+    fi
+
+    # 3. RE-PIN the OLD image on both units, then assert.
+    if ! pin_image "$BACKEND_UNIT" "$BACKEND_ROLLBACK_REF" \
+       || ! pin_image "$FRONTEND_UNIT" "$FRONTEND_ROLLBACK_REF" \
+       || ! crm_ctl daemon-reload; then
+        ntfy "ROLLBACK FAILED — prod degraded" "urgent" "rotating_light" \
+            "$SHA DB restored, image re-pin failed, app left STOPPED; manual intervention required"
+        log "ROLLBACK FAILED: DB restored but image re-pin failed; app left STOPPED"
+        exit 1
+    fi
+
+    # 4. Start the app on the OLD image + restored OLD DB.
+    crm_ctl start personalcrm-backend.service personalcrm-frontend.service || true
+    health_gate || log "rolled-back stack health-gate did not pass (best-effort)"
+
+    ROLLED_BACK=true
+    ntfy "Rolled back" "high" "warning" \
+        "$SHA $reason; rolled back to $(short_ref "$BACKEND_ROLLBACK_REF")"
+    exit 1
+}
+
+# prune_prior_snapshot <keep>: after a successful deploy, delete every other
+# *.bak-* alongside the volume EXCEPT <keep> (the new recovery point). Never runs
+# on a failure path -- the snapshot is only pruned once a newer one is retained.
+prune_prior_snapshot() {
+    local keep="$1" volume_path d
+    volume_path="$(crm_podman volume inspect personalcrm-db --format '{{.Mountpoint}}' 2>/dev/null || true)"
+    if [ -z "$volume_path" ]; then
+        return 0
+    fi
+    while IFS= read -r d; do
+        [ -n "$d" ] || continue
+        if [ "$d" != "$keep" ]; then
+            sudo rm -rf "$d" || log "warning: could not prune old snapshot $d"
+        fi
+    done < <(sudo bash -c "ls -d ${volume_path}.bak-* 2>/dev/null" || true)
+}
+
+# short_ref: truncate a digest ref's hex to the first 12 chars for ntfy
+# readability. A plain :<sha> ref is returned unchanged.
+short_ref() {
+    local ref="$1"
+    if [[ "$ref" == *@sha256:* ]]; then
+        local prefix="${ref%@sha256:*}" hex="${ref##*@sha256:}"
+        echo "$prefix@sha256:${hex:0:12}"
+    else
+        echo "$ref"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# EXIT trap: the post-migrate backstop. If we migrated but never reached a clean
+# success, run ROLLBACK-WITH-RESTORE for an UNANTICIPATED failure in that region.
+# Otherwise (services merely stopped mid-flight) best-effort restart.
+# ---------------------------------------------------------------------------
+MIGRATED=0
+SNAPSHOT=""
+DONE=0
+ROLLED_BACK=false
+APP_STOPPED=0
+ROLLBACK_IN_PROGRESS=0
+
+# Invoked indirectly via `trap on_exit EXIT`.
+# shellcheck disable=SC2329
+on_exit() {
+    local rc=$?
+    if [ "$rc" -eq 0 ] || [ "$DONE" -eq 1 ]; then
+        return
+    fi
+    if [ "$ROLLBACK_IN_PROGRESS" -eq 1 ]; then
+        # A rollback already ran (it exits non-zero, re-firing this trap). Don't
+        # recurse -- its own ntfy/exit already reported the outcome.
+        return
+    fi
+    if [ "$MIGRATED" -eq 1 ] && [ "$ROLLED_BACK" != true ]; then
+        # Unanticipated failure after a successful migrate -> restore.
+        rollback_with_restore "unexpected failure after migrate"
+    elif [ "$APP_STOPPED" -eq 1 ]; then
+        log "error (exit $rc) with app stopped pre-migrate; attempting restart"
+        crm_ctl start personalcrm-database.service personalcrm-backend.service personalcrm-frontend.service || true
+    fi
+}
+trap on_exit EXIT
+
+# ---------------------------------------------------------------------------
+# Main.
+# ---------------------------------------------------------------------------
+SHA="${1:-}"
+
+# Validate the SHA arg.
+if ! valid_sha "$SHA"; then
+    ntfy "Deploy aborted" "high" "warning" "bad SHA argument; no changes applied"
+    echo "error: expected a 40-hex SHA, got '${SHA}'" >&2
+    DONE=1
+    exit 2
+fi
+
+# ROLLBACK ANCHOR: read BEFORE any rewrite, so a rollback can re-pin the exact
+# image prod was running (a :<sha> tag verbatim, or a resolved digest for :latest).
+log "resolving rollback anchors from live units"
+BACKEND_ROLLBACK_REF="$(rollback_ref_for "$BACKEND_REPO" crm-backend "$BACKEND_UNIT")"
+FRONTEND_ROLLBACK_REF="$(rollback_ref_for "$FRONTEND_REPO" crm-frontend "$FRONTEND_UNIT")"
+log "backend rollback ref: $(short_ref "$BACKEND_ROLLBACK_REF")"
+log "frontend rollback ref: $(short_ref "$FRONTEND_ROLLBACK_REF")"
+
+# Pull both :<sha> images (fail fast, no DB touched).
+log "pulling $BACKEND_REPO:$SHA and $FRONTEND_REPO:$SHA"
+if ! crm_podman pull "$BACKEND_REPO:$SHA" || ! crm_podman pull "$FRONTEND_REPO:$SHA"; then
+    ntfy "Deploy aborted" "high" "warning" "$SHA image missing/pull failed; no changes applied"
+    log "image pull failed; aborting before touching the DB"
+    DONE=1
+    exit 1
+fi
+
+# MIGRATE-CHECK via the NEW image. Branch on its exit code.
+log "running migrate-check via the new image"
+set +e
+run_migrate_admin --migrate-check
+CHECK_RC=$?
+set -e
+log "migrate-check exit code: $CHECK_RC"
+
+case "$CHECK_RC" in
+    0)
+        # UP-TO-DATE: no DB work, zero DB downtime.
+        log "up-to-date: swapping image and restarting app (DB untouched)"
+        pin_image "$BACKEND_UNIT" "$BACKEND_REPO:$SHA"
+        pin_image "$FRONTEND_UNIT" "$FRONTEND_REPO:$SHA"
+        crm_ctl daemon-reload
+        crm_ctl restart personalcrm-backend.service personalcrm-frontend.service
+        if health_gate; then
+            ntfy "Deploy OK" "default" "white_check_mark" "Deployed $SHA (migrated=no)"
+            log "deploy OK (migrated=no)"
+            DONE=1
+            exit 0
+        fi
+        # Health failed: re-pin rollback, restart. No DB was touched -> no restore.
+        log "health-gate failed on up-to-date path; rolling back image (no DB restore needed)"
+        pin_image "$BACKEND_UNIT" "$BACKEND_ROLLBACK_REF"
+        pin_image "$FRONTEND_UNIT" "$FRONTEND_ROLLBACK_REF"
+        crm_ctl daemon-reload
+        crm_ctl restart personalcrm-backend.service personalcrm-frontend.service
+        ntfy "Rolled back" "high" "warning" \
+            "$SHA health-gate failed; rolled back to $(short_ref "$BACKEND_ROLLBACK_REF")"
+        DONE=1
+        exit 1
+        ;;
+    2)
+        # PENDING: stop -> snapshot -> start DB -> migrate -> swap -> start -> gate.
+        log "pending migrations: stop app, snapshot, migrate"
+        crm_ctl stop personalcrm-backend.service personalcrm-frontend.service
+        APP_STOPPED=1
+
+        # b. Snapshot (stops DB, cp -a volume, leaves DB stopped). Capture the path.
+        log "taking pre-migrate snapshot via backup-db.sh"
+        SNAPSHOT="$("$BACKUP_SCRIPT" --local --no-restart | sed -n 's/^BACKUP_PATH=//p')"
+        if [ -z "$SNAPSHOT" ]; then
+            ntfy "Deploy aborted" "high" "warning" "$SHA snapshot failed; no migration applied"
+            log "snapshot failed; aborting (DB not migrated)"
+            DONE=1
+            exit 1
+        fi
+        log "snapshot: $SNAPSHOT"
+
+        # c. Start postgres only; the migrate container connects over the network.
+        log "starting postgres for the migration"
+        crm_ctl start personalcrm-database.service
+        for ((i = 1; i <= 30; i++)); do
+            if crm_podman exec crm-postgres pg_isready -U crm_user >/dev/null 2>&1; then
+                break
+            fi
+            sleep 1
+        done
+
+        # d. MIGRATE via the NEW image.
+        log "applying migrations via the new image"
+        if ! run_migrate_admin --migrate; then
+            rollback_with_restore "migrate failed — restored"
+        fi
+        MIGRATED=1
+
+        # e-g: post-migrate region. ANY failure -> ROLLBACK-WITH-RESTORE.
+        #      post_migrate_swap returns non-zero on the first failing step. We
+        #      can't use a `set -e` subshell here: bash disables `set -e` inside a
+        #      subshell that is the operand of `!`/`if`, so a failing step would
+        #      be silently swallowed. Explicit `&&` short-circuiting is immune.
+        if ! post_migrate_swap; then
+            rollback_with_restore "rolled back"
+        fi
+
+        # Success: retain this snapshot as the recovery point; prune the PRIOR one.
+        log "deploy OK (migrated=yes); retaining snapshot, pruning prior"
+        prune_prior_snapshot "$SNAPSHOT"
+        ntfy "Deploy OK" "default" "white_check_mark" "Deployed $SHA (migrated=yes)"
+        DONE=1
+        exit 0
+        ;;
+    1)
+        ntfy "Deploy aborted" "high" "warning" "$SHA migrate-check error; no changes applied"
+        log "migrate-check operational error (exit 1); aborting before touching anything"
+        DONE=1
+        exit 1
+        ;;
+    *)
+        ntfy "Deploy aborted" "high" "warning" "$SHA migrate-check returned $CHECK_RC; no changes applied"
+        log "migrate-check returned unexpected $CHECK_RC; aborting before touching anything"
+        DONE=1
+        exit 1
+        ;;
+esac

--- a/scripts/deploy-artifact.sh
+++ b/scripts/deploy-artifact.sh
@@ -148,17 +148,20 @@ run_migrate_admin() {
 # Health gate: reads-only. All three must pass within the retry budget.
 # ---------------------------------------------------------------------------
 health_gate() {
-    local i ok=false
-    # 1. backend /health reports the DB healthy (bounded retry ~HEALTH_RETRIES s).
+    local i ok=false body
+    # 1. backend /health reports overall healthy (bounded retry ~HEALTH_RETRIES s).
+    #    The handler returns HTTP 503 (so `curl -sf` non-zeroes) AND top-level
+    #    "status":"degraded" when the DB is unhealthy; 200 + "status":"healthy"
+    #    only when the DB component is healthy. Gate on the top-level status (the
+    #    DB status is nested under components.database, not a flat key).
     for ((i = 1; i <= HEALTH_RETRIES; i++)); do
-        if curl -sf http://127.0.0.1:8080/health 2>/dev/null | grep -q '"database":"healthy"'; then
-            ok=true
-            break
-        fi
+        body="$(curl -sf http://127.0.0.1:8080/health 2>/dev/null)" \
+            && printf '%s' "$body" | grep -qE '"status":[[:space:]]*"healthy"' \
+            && { ok=true; break; }
         sleep 1
     done
     if [ "$ok" != true ]; then
-        log "health-gate: backend /health did not report database healthy"
+        log "health-gate: backend /health did not report overall status healthy"
         return 1
     fi
     # 2. frontend answers.
@@ -238,15 +241,19 @@ rollback_with_restore() {
 # prune_prior_snapshot <keep>: after a successful deploy, delete every other
 # *.bak-* alongside the volume EXCEPT <keep> (the new recovery point). Never runs
 # on a failure path -- the snapshot is only pruned once a newer one is retained.
+# Compares BASENAMES, not full paths: <keep> comes from backup-db.sh while the
+# glob is re-derived from a separate `volume inspect`, so any path-formatting
+# difference (trailing slash, symlink resolution) must not delete the keep dir.
 prune_prior_snapshot() {
-    local keep="$1" volume_path d
+    local keep="$1" keep_base volume_path d
+    keep_base="$(basename "$keep")"
     volume_path="$(crm_podman volume inspect personalcrm-db --format '{{.Mountpoint}}' 2>/dev/null || true)"
     if [ -z "$volume_path" ]; then
         return 0
     fi
     while IFS= read -r d; do
         [ -n "$d" ] || continue
-        if [ "$d" != "$keep" ]; then
+        if [ "$(basename "$d")" != "$keep_base" ]; then
             sudo rm -rf "$d" || log "warning: could not prune old snapshot $d"
         fi
     done < <(sudo bash -c "ls -d ${volume_path}.bak-* 2>/dev/null" || true)
@@ -372,8 +379,10 @@ case "$CHECK_RC" in
     2)
         # PENDING: stop -> snapshot -> start DB -> migrate -> swap -> start -> gate.
         log "pending migrations: stop app, snapshot, migrate"
-        crm_ctl stop personalcrm-backend.service personalcrm-frontend.service
+        # Set APP_STOPPED BEFORE the stop: if the stop itself errors under set -e,
+        # the EXIT trap must still know the app may be down and attempt a restart.
         APP_STOPPED=1
+        crm_ctl stop personalcrm-backend.service personalcrm-frontend.service
 
         # b. Snapshot (stops DB, cp -a volume, leaves DB stopped). Capture the
         #    path. Run with set -e OFF so a non-zero backup exit routes to the
@@ -387,7 +396,8 @@ case "$CHECK_RC" in
         if [ "$BACKUP_RC" -ne 0 ] || [ -z "$SNAPSHOT" ]; then
             ntfy "Deploy aborted" "high" "warning" "$SHA snapshot failed; no migration applied"
             log "snapshot failed (rc=$BACKUP_RC); aborting (DB not migrated)"
-            DONE=1
+            # Do NOT set DONE: the app is stopped and not migrated, so let the EXIT
+            # trap's APP_STOPPED branch restart the stack on the OLD image.
             exit 1
         fi
         log "snapshot: $SNAPSHOT"
@@ -395,12 +405,24 @@ case "$CHECK_RC" in
         # c. Start postgres only; the migrate container connects over the network.
         log "starting postgres for the migration"
         crm_ctl start personalcrm-database.service
+        PG_READY=false
         for ((i = 1; i <= 30; i++)); do
             if crm_podman exec crm-postgres pg_isready -U crm_user >/dev/null 2>&1; then
+                PG_READY=true
                 break
             fi
             sleep 1
         done
+        # If postgres never came up, this is a "DB didn't start" abort, NOT a
+        # destructive restore: the DB has not been migrated and the snapshot
+        # exists, so just abort before --migrate. The EXIT trap restarts the app.
+        if [ "$PG_READY" != true ]; then
+            ntfy "Deploy aborted" "high" "warning" "$SHA postgres did not start; no migration applied"
+            log "postgres did not become ready; aborting before migrate (snapshot: $SNAPSHOT)"
+            # Do NOT set DONE: the app+DB are stopped and not migrated, so let the
+            # EXIT trap's APP_STOPPED branch restart the stack on the OLD image.
+            exit 1
+        fi
 
         # d. MIGRATE via the NEW image.
         log "applying migrations via the new image"

--- a/scripts/deploy-artifact.sh
+++ b/scripts/deploy-artifact.sh
@@ -43,9 +43,11 @@ HEALTH_RETRIES="${HEALTH_RETRIES:-40}"
 
 # ---------------------------------------------------------------------------
 # crm-user helpers: ALL podman/systemctl run rootless as the crm user.
+# CRM_UID/XDG are resolved in main() AFTER SHA validation (so a bad arg is
+# rejected with the documented exit 2 even on a host without the crm user).
 # ---------------------------------------------------------------------------
-CRM_UID="$(id -u "$CRM_USER")"
-XDG="/run/user/$CRM_UID"
+CRM_UID=""
+XDG=""
 
 # crm_podman / crm_ctl: rootless ops against the crm-user store. cd /tmp because
 # an interactive `sudo -u crm` inherits root's CWD, which crm can't chdir into.
@@ -301,13 +303,18 @@ trap on_exit EXIT
 # ---------------------------------------------------------------------------
 SHA="${1:-}"
 
-# Validate the SHA arg.
+# Validate the SHA arg FIRST (before resolving the crm uid, so a bad arg is
+# rejected with exit 2 even on a host that lacks the crm user).
 if ! valid_sha "$SHA"; then
     ntfy "Deploy aborted" "high" "warning" "bad SHA argument; no changes applied"
     echo "error: expected a 40-hex SHA, got '${SHA}'" >&2
     DONE=1
     exit 2
 fi
+
+# Resolve the crm uid now that the arg is valid.
+CRM_UID="$(id -u "$CRM_USER")"
+XDG="/run/user/$CRM_UID"
 
 # ROLLBACK ANCHOR: read BEFORE any rewrite, so a rollback can re-pin the exact
 # image prod was running (a :<sha> tag verbatim, or a resolved digest for :latest).
@@ -354,6 +361,9 @@ case "$CHECK_RC" in
         pin_image "$FRONTEND_UNIT" "$FRONTEND_ROLLBACK_REF"
         crm_ctl daemon-reload
         crm_ctl restart personalcrm-backend.service personalcrm-frontend.service
+        # Health-gate the rolled-back stack (best-effort) so we don't report a
+        # clean rollback while prod is still unhealthy on the OLD image too.
+        health_gate || log "rolled-back stack health-gate did not pass (best-effort)"
         ntfy "Rolled back" "high" "warning" \
             "$SHA health-gate failed; rolled back to $(short_ref "$BACKEND_ROLLBACK_REF")"
         DONE=1
@@ -365,12 +375,18 @@ case "$CHECK_RC" in
         crm_ctl stop personalcrm-backend.service personalcrm-frontend.service
         APP_STOPPED=1
 
-        # b. Snapshot (stops DB, cp -a volume, leaves DB stopped). Capture the path.
+        # b. Snapshot (stops DB, cp -a volume, leaves DB stopped). Capture the
+        #    path. Run with set -e OFF so a non-zero backup exit routes to the
+        #    explicit abort branch (with ntfy) instead of the bare EXIT trap.
         log "taking pre-migrate snapshot via backup-db.sh"
-        SNAPSHOT="$("$BACKUP_SCRIPT" --local --no-restart | sed -n 's/^BACKUP_PATH=//p')"
-        if [ -z "$SNAPSHOT" ]; then
+        set +e
+        SNAPSHOT_OUT="$("$BACKUP_SCRIPT" --local --no-restart)"
+        BACKUP_RC=$?
+        set -e
+        SNAPSHOT="$(printf '%s\n' "$SNAPSHOT_OUT" | sed -n 's/^BACKUP_PATH=//p')"
+        if [ "$BACKUP_RC" -ne 0 ] || [ -z "$SNAPSHOT" ]; then
             ntfy "Deploy aborted" "high" "warning" "$SHA snapshot failed; no migration applied"
-            log "snapshot failed; aborting (DB not migrated)"
+            log "snapshot failed (rc=$BACKUP_RC); aborting (DB not migrated)"
             DONE=1
             exit 1
         fi

--- a/scripts/deploy-artifact.test.sh
+++ b/scripts/deploy-artifact.test.sh
@@ -1,0 +1,524 @@
+#!/usr/bin/env bash
+# Tests for deploy-artifact.sh (and the restore/backup interplay it drives).
+#
+# These run anywhere (no Pi, no podman, no root). PATH is shadowed with stub
+# `sudo`/`id`/`podman`/`systemctl`/`curl` and stub backup/restore scripts that
+# record their argv to a per-test call log. Each test drives a scenario via env
+# vars (migrate-check exit code, inspect digest, health outcome, failure
+# injection points) and asserts on the recorded calls + script exit code.
+#
+# Asserts the load-bearing correctness points from the plan §4:
+#   - SHA validation (40-hex only).
+#   - rollback-ref extraction from :<sha> AND :latest (digest resolution).
+#   - the generated migrate command line (--entrypoint, --network, --env-file,
+#     -e MIGRATIONS_PATH, NEW :sha, trailing --migrate-check/--migrate; never
+#     `podman exec`).
+#   - rootless `sudo -u crm` env on EVERY podman/systemctl call.
+#   - exit-code branching (0 / 2 / 1 / other) and which branches touch the DB.
+#   - ROLLBACK-WITH-RESTORE ordering: restore FIRST (unconditional), then re-pin.
+#   - post-migrate swap-failure -> ROLLBACK-WITH-RESTORE (not the bare trap).
+#   - re-pin failure -> "ROLLBACK FAILED" + app left STOPPED + snapshot retained.
+#   - ntfy outcomes + degrade-open when the ntfy env file is absent.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/deploy-artifact.sh"
+TESTDATA="$REPO_ROOT/scripts/testdata"
+VALID_SHA="abcdef0123456789abcdef0123456789abcdef01"
+NEW_SHA="$VALID_SHA"
+
+PASS=0
+FAIL=0
+fail() { echo "  FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+ok()   { PASS=$((PASS + 1)); }
+
+# ---------------------------------------------------------------------------
+# Test sandbox: a fresh tmp dir per scenario with stub bin/, fixture units, and
+# a call log. Returns nothing; sets globals SANDBOX, CALL_LOG, BACKEND_UNIT,
+# FRONTEND_UNIT for the caller.
+# ---------------------------------------------------------------------------
+make_sandbox() {
+    SANDBOX="$(mktemp -d)"
+    CALL_LOG="$SANDBOX/calls.log"
+    : > "$CALL_LOG"
+    mkdir -p "$SANDBOX/bin" "$SANDBOX/units"
+    cp "$TESTDATA/backend-${1:-latest}.container" "$SANDBOX/units/backend.container"
+    cp "$TESTDATA/frontend-${2:-latest}.container" "$SANDBOX/units/frontend.container"
+    BACKEND_UNIT="$SANDBOX/units/backend.container"
+    FRONTEND_UNIT="$SANDBOX/units/frontend.container"
+
+    # --- stub: id (resolve crm uid without a real account) ---
+    cat > "$SANDBOX/bin/id" <<'EOF'
+#!/usr/bin/env bash
+# id -u crm  -> a fixed fake uid; everything else -> real id.
+if [ "$1" = "-u" ] && [ "$2" = "crm" ]; then echo 4242; exit 0; fi
+exec /usr/bin/id "$@"
+EOF
+
+    # --- stub: sudo (record the rootless prefix, then exec the inner cmd) ---
+    # We record the FULL `sudo ...` argv so tests can assert `-u crm` + env, then
+    # strip `-u <user>` and any leading KEY=val env assignments and exec the rest
+    # (which resolves to our other PATH stubs: podman/systemctl/sed/etc.).
+    cat > "$SANDBOX/bin/sudo" <<EOF
+#!/usr/bin/env bash
+echo "sudo \$*" >> "$CALL_LOG"
+shift_user=0
+args=("\$@")
+out=()
+i=0
+while [ \$i -lt \${#args[@]} ]; do
+    a="\${args[\$i]}"
+    if [ "\$a" = "-u" ]; then i=\$((i + 2)); continue; fi
+    if [ "\$a" = "-n" ]; then i=\$((i + 1)); continue; fi
+    if [[ "\$a" == *=* ]] && [ \${#out[@]} -eq 0 ]; then i=\$((i + 1)); continue; fi
+    out+=("\$a")
+    i=\$((i + 1))
+done
+exec "\${out[@]}"
+EOF
+
+    # --- stub: podman ---
+    cat > "$SANDBOX/bin/podman" <<EOF
+#!/usr/bin/env bash
+echo "podman \$*" >> "$CALL_LOG"
+case "\$1" in
+  inspect)
+    # podman inspect <container> --format '{{index .RepoDigests 0}}'
+    echo "\${STUB_INSPECT_DIGEST:-ghcr.io/spengrah/personalcrm-backend@sha256:c91da029deadbeefc91da029deadbeefc91da029deadbeefc91da029deadbeef}"
+    exit 0 ;;
+  pull)
+    exit "\${STUB_PULL_RC:-0}" ;;
+  volume)
+    echo "$SANDBOX/volume/_data"
+    exit 0 ;;
+  exec)
+    # pg_isready
+    exit 0 ;;
+  run)
+    # crm-admin via --entrypoint. Last arg is the subcommand.
+    sub="\${@: -1}"
+    if [ "\$sub" = "--migrate-check" ]; then exit "\${STUB_MIGRATE_CHECK_RC:-0}"; fi
+    if [ "\$sub" = "--migrate" ]; then exit "\${STUB_MIGRATE_RC:-0}"; fi
+    exit 0 ;;
+esac
+exit 0
+EOF
+
+    # --- stub: systemctl ---
+    # Failure injection:
+    #   STUB_SYSTEMCTL_FAIL=<verb>  fail when this verb appears (e.g. daemon-reload).
+    #   STUB_APP_START_FAIL=1       fail ONLY the app start (backend/frontend),
+    #                               never the database start. Used to simulate a
+    #                               post-migrate swap failure without breaking the
+    #                               pre-migrate DB start.
+    cat > "$SANDBOX/bin/systemctl" <<EOF
+#!/usr/bin/env bash
+echo "systemctl \$*" >> "$CALL_LOG"
+joined="\$*"
+if [ -n "\${STUB_SYSTEMCTL_FAIL:-}" ]; then
+  for a in "\$@"; do
+    if [ "\$a" = "\$STUB_SYSTEMCTL_FAIL" ]; then exit 1; fi
+  done
+fi
+if [ "\${STUB_APP_START_FAIL:-0}" = "1" ] \
+   && [[ "\$joined" == *"start"* ]] \
+   && [[ "\$joined" == *"personalcrm-backend.service"* ]]; then
+  exit 1
+fi
+exit 0
+EOF
+
+    # --- stub: curl (health gate + ntfy) ---
+    cat > "$SANDBOX/bin/curl" <<EOF
+#!/usr/bin/env bash
+echo "curl \$*" >> "$CALL_LOG"
+url="\${@: -1}"
+case "\$url" in
+  *contacts*) echo -n "\${STUB_CADDY_CODE:-200}"; exit 0 ;;
+  *8080/health*) [ "\${STUB_HEALTH_OK:-1}" = "1" ] && { echo '{"database":"healthy"}'; exit 0; }; exit 1 ;;
+  *3001*) exit "\${STUB_FRONTEND_RC:-0}" ;;
+  *) exit 0 ;;  # ntfy posts
+esac
+EOF
+
+    # --- stub: sed (record + real edit so pin_image assertions work) ---
+    # We want the REAL sed behavior (in-place Image= rewrite) plus a call record.
+    # The script targets GNU sed (`-i` takes no arg, as on the Pi). On a BSD sed
+    # host (macOS) `-i` needs an empty-string arg, so translate the first bare
+    # `-i` to `-i ''` when the real sed is BSD. Prefer gsed if present.
+    cat > "$SANDBOX/bin/sed" <<EOF
+#!/usr/bin/env bash
+echo "sed \$*" >> "$CALL_LOG"
+real="\$(command -v gsed || echo /usr/bin/sed)"
+if [ "\$real" != "\$(command -v gsed 2>/dev/null)" ] && /usr/bin/sed --version >/dev/null 2>&1; then
+    real=/usr/bin/sed  # GNU
+fi
+if "\$real" --version >/dev/null 2>&1; then
+    exec "\$real" "\$@"          # GNU: -i takes no arg
+else
+    # BSD sed: insert '' after a bare -i.
+    args=()
+    for a in "\$@"; do
+        args+=("\$a")
+        if [ "\$a" = "-i" ]; then args+=(""); fi
+    done
+    exec /usr/bin/sed "\${args[@]}"
+fi
+EOF
+
+    # --- stub: backup-db.sh ---
+    cat > "$SANDBOX/bin/backup-db.sh" <<EOF
+#!/usr/bin/env bash
+echo "backup-db.sh \$*" >> "$CALL_LOG"
+if [ "\${STUB_BACKUP_RC:-0}" != "0" ]; then exit "\${STUB_BACKUP_RC}"; fi
+echo "BACKUP_PATH=$SANDBOX/volume/_data.bak-20260611-000000"
+exit 0
+EOF
+
+    # --- stub: restore-db.sh ---
+    cat > "$SANDBOX/bin/restore-db.sh" <<EOF
+#!/usr/bin/env bash
+echo "restore-db.sh \$*" >> "$CALL_LOG"
+exit "\${STUB_RESTORE_RC:-0}"
+EOF
+
+    chmod +x "$SANDBOX"/bin/*
+    mkdir -p "$SANDBOX/volume"
+    : > "$SANDBOX/volume/_data" 2>/dev/null || mkdir -p "$SANDBOX/volume/_data"
+}
+
+cleanup_sandbox() { [ -n "${SANDBOX:-}" ] && rm -rf "$SANDBOX"; }
+
+# run_deploy <sha> : run deploy-artifact.sh in the sandbox; sets RC + OUT.
+run_deploy() {
+    OUT="$(
+        PATH="$SANDBOX/bin:$PATH" \
+        CRM_USER=crm \
+        CRM_HOME="$SANDBOX/home" \
+        BACKEND_UNIT="$BACKEND_UNIT" \
+        FRONTEND_UNIT="$FRONTEND_UNIT" \
+        DEPLOY_ENV_FILE="$SANDBOX/env" \
+        BACKUP_SCRIPT="$SANDBOX/bin/backup-db.sh" \
+        RESTORE_SCRIPT="$SANDBOX/bin/restore-db.sh" \
+        NTFY_ENV_FILE="${NTFY_ENV_FILE_OVERRIDE:-$SANDBOX/missing-ntfy.env}" \
+        HEALTH_RETRIES=2 \
+        bash "$SCRIPT" "$1" 2>&1
+    )"
+    RC=$?
+}
+
+# assert helpers operating on $CALL_LOG / $OUT.
+log_has()    { grep -qF -- "$1" "$CALL_LOG"; }
+log_lacks()  { ! grep -qF -- "$1" "$CALL_LOG"; }
+# line index (1-based) of the first call line matching a fixed string.
+log_idx()    { grep -nF -- "$1" "$CALL_LOG" | head -1 | cut -d: -f1; }
+
+# ===========================================================================
+# Tests
+# ===========================================================================
+
+test_sha_validation() {
+    echo "test: SHA validation"
+    for bad in "" "xyz" "abc123" "ABCDEF0123456789ABCDEF0123456789ABCDEF01" \
+               "abcdef0123456789abcdef0123456789abcdef0" \
+               "abcdef0123456789abcdef0123456789abcdef012"; do
+        make_sandbox
+        run_deploy "$bad"
+        if [ "$RC" -ne 2 ]; then fail "bad SHA '$bad' should exit 2, got $RC"; else ok; fi
+        # No DB / image op may run on a bad arg.
+        if log_has "podman pull"; then fail "bad SHA '$bad' pulled an image"; else ok; fi
+        cleanup_sandbox
+    done
+
+    make_sandbox
+    STUB_MIGRATE_CHECK_RC=0 run_deploy "$VALID_SHA"
+    if [ "$RC" -ne 0 ]; then fail "valid SHA up-to-date should exit 0, got $RC ($OUT)"; else ok; fi
+    cleanup_sandbox
+}
+
+test_rollback_ref_sha_fixture() {
+    echo "test: rollback ref from :<sha> fixture (deterministic, no inspect)"
+    make_sandbox sha sha
+    STUB_MIGRATE_CHECK_RC=0 STUB_HEALTH_OK=0 run_deploy "$VALID_SHA"
+    # Health fails -> up-to-date rollback re-pins the :<sha> anchors (no inspect).
+    if log_has "podman inspect"; then fail ":<sha> fixture must NOT call podman inspect"; else ok; fi
+    if grep -q 'Image=ghcr.io/spengrah/personalcrm-backend:1111111111111111111111111111111111111111' "$BACKEND_UNIT"; then ok
+    else fail "backend unit should be re-pinned to the :<sha> rollback anchor"; fi
+    cleanup_sandbox
+}
+
+test_rollback_ref_latest_digest() {
+    echo "test: rollback ref from :latest fixture (digest resolution)"
+    make_sandbox latest latest
+    STUB_MIGRATE_CHECK_RC=0 STUB_HEALTH_OK=0 \
+      STUB_INSPECT_DIGEST="ghcr.io/spengrah/personalcrm-backend@sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef" \
+      run_deploy "$VALID_SHA"
+    # :latest must drive `podman inspect ... RepoDigests`.
+    if log_has "podman inspect crm-backend"; then ok; else fail ":latest must resolve via podman inspect crm-backend"; fi
+    if log_has "podman inspect crm-frontend"; then ok; else fail ":latest must resolve via podman inspect crm-frontend"; fi
+    # Rollback re-pin should write the @sha256 digest ref.
+    if grep -q 'Image=ghcr.io/spengrah/personalcrm-backend@sha256:deadbeef' "$BACKEND_UNIT"; then ok
+    else fail "backend unit should be re-pinned to the resolved @sha256 digest"; fi
+    cleanup_sandbox
+}
+
+test_migrate_command_line() {
+    echo "test: generated migrate-check / migrate command line"
+    make_sandbox
+    STUB_MIGRATE_CHECK_RC=2 run_deploy "$VALID_SHA"
+    # The migrate-check run line.
+    local mc
+    mc="$(grep -F 'podman run' "$CALL_LOG" | grep -F -- '--migrate-check' | head -1)"
+    [ -n "$mc" ] || { fail "no 'podman run ... --migrate-check' recorded"; }
+    for needle in "--entrypoint /usr/local/bin/crm-admin" "--network crm" \
+                  "--env-file" "-e MIGRATIONS_PATH=/migrations" \
+                  "ghcr.io/spengrah/personalcrm-backend:$NEW_SHA" "--migrate-check"; do
+        if [[ "$mc" == *"$needle"* ]]; then ok; else fail "migrate-check line missing '$needle': $mc"; fi
+    done
+    # NEVER `podman exec` for crm-admin.
+    if grep -F 'podman exec' "$CALL_LOG" | grep -q 'crm-admin'; then fail "crm-admin must NOT run via podman exec"; else ok; fi
+    # The --migrate (apply) line on the pending path.
+    local mg
+    mg="$(grep -F 'podman run' "$CALL_LOG" | grep -F -- '--migrate' | grep -vF -- '--migrate-check' | head -1)"
+    [ -n "$mg" ] || fail "no 'podman run ... --migrate' recorded on pending path"
+    if [[ "$mg" == *"--entrypoint /usr/local/bin/crm-admin"* ]]; then ok; else fail "--migrate line missing --entrypoint: $mg"; fi
+    cleanup_sandbox
+}
+
+test_rootless_env_on_every_call() {
+    echo "test: rootless sudo -u crm env on every podman/systemctl call"
+    make_sandbox
+    STUB_MIGRATE_CHECK_RC=0 run_deploy "$VALID_SHA"
+    # Every recorded podman/systemctl call must have come through a `sudo -u crm`
+    # line carrying HOME + XDG_RUNTIME_DIR. We assert there is at least one such
+    # sudo line and NO bare `podman`/`systemctl` invocation outside the stub log
+    # was made without it. Check the sudo lines carry the env.
+    local bad=0 line
+    while IFS= read -r line; do
+        case "$line" in
+            "sudo "*podman*|"sudo "*systemctl*)
+                [[ "$line" == *"-u crm"* ]] || { bad=1; echo "    no -u crm: $line" >&2; }
+                [[ "$line" == *"HOME=$SANDBOX/home"* ]] || { bad=1; echo "    no HOME: $line" >&2; }
+                [[ "$line" == *"XDG_RUNTIME_DIR=/run/user/4242"* ]] || { bad=1; echo "    no XDG: $line" >&2; }
+                ;;
+        esac
+    done < "$CALL_LOG"
+    if [ "$bad" -eq 0 ]; then ok; else fail "some podman/systemctl calls lacked the rootless env"; fi
+    # systemctl must also carry DBUS for the --user bus.
+    if grep -E '^sudo .*systemctl' "$CALL_LOG" | grep -q 'DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/4242/bus'; then ok
+    else fail "systemctl calls missing DBUS_SESSION_BUS_ADDRESS"; fi
+    cleanup_sandbox
+}
+
+test_exit0_uptodate_no_db() {
+    echo "test: exit 0 (up-to-date) touches no DB, swaps image, restarts app"
+    make_sandbox
+    STUB_MIGRATE_CHECK_RC=0 run_deploy "$VALID_SHA"
+    if [ "$RC" -eq 0 ]; then ok; else fail "up-to-date should exit 0, got $RC ($OUT)"; fi
+    if log_lacks "backup-db.sh"; then ok; else fail "up-to-date must NOT snapshot the DB"; fi
+    if log_lacks "podman run"; then fail "expected a migrate-check podman run"; else ok; fi
+    if grep -F 'podman run' "$CALL_LOG" | grep -q -- '--migrate$'; then fail "up-to-date must NOT --migrate"; else ok; fi
+    if log_lacks "stop personalcrm-database.service"; then ok; else fail "up-to-date must NOT stop the DB"; fi
+    if grep -q "Image=ghcr.io/spengrah/personalcrm-backend:$NEW_SHA" "$BACKEND_UNIT"; then ok; else fail "image not swapped to :sha"; fi
+    if log_has "restart personalcrm-backend.service"; then ok; else fail "expected app restart"; fi
+    cleanup_sandbox
+}
+
+test_exit1_abort_no_touch() {
+    echo "test: exit 1 (migrate-check error) aborts before touching anything"
+    make_sandbox
+    STUB_MIGRATE_CHECK_RC=1 run_deploy "$VALID_SHA"
+    if [ "$RC" -eq 1 ]; then ok; else fail "check-error should exit 1, got $RC"; fi
+    if log_lacks "backup-db.sh"; then ok; else fail "error path must NOT snapshot"; fi
+    if grep -F 'podman run' "$CALL_LOG" | grep -q -- '--migrate$'; then fail "error path must NOT migrate"; else ok; fi
+    if log_lacks "stop personalcrm"; then ok; else fail "error path must NOT stop services"; fi
+    # Image= untouched.
+    if grep -q 'Image=ghcr.io/spengrah/personalcrm-backend:latest' "$BACKEND_UNIT"; then ok; else fail "error path must NOT rewrite Image="; fi
+    cleanup_sandbox
+}
+
+test_exit_other_abort() {
+    echo "test: exit 7 (unexpected) aborts before touching anything"
+    make_sandbox
+    STUB_MIGRATE_CHECK_RC=7 run_deploy "$VALID_SHA"
+    if [ "$RC" -eq 1 ]; then ok; else fail "unexpected check rc should abort exit 1, got $RC"; fi
+    if log_lacks "backup-db.sh"; then ok; else fail "unexpected rc must NOT snapshot"; fi
+    cleanup_sandbox
+}
+
+test_pending_happy_path() {
+    echo "test: exit 2 (pending) snapshot -> migrate -> swap -> health OK"
+    make_sandbox
+    STUB_MIGRATE_CHECK_RC=2 run_deploy "$VALID_SHA"
+    if [ "$RC" -eq 0 ]; then ok; else fail "pending happy path should exit 0, got $RC ($OUT)"; fi
+    # Ordering: stop app -> backup -> start DB -> migrate -> swap -> start app.
+    local i_stop i_backup i_startdb i_migrate
+    i_stop="$(log_idx 'stop personalcrm-backend.service personalcrm-frontend.service')"
+    i_backup="$(log_idx 'backup-db.sh --local --no-restart')"
+    i_startdb="$(log_idx 'start personalcrm-database.service')"
+    i_migrate="$(grep -nF 'podman run' "$CALL_LOG" | grep -F -- '--migrate' | grep -vF -- '--migrate-check' | head -1 | cut -d: -f1)"
+    if [ -n "$i_stop" ] && [ -n "$i_backup" ] && [ "$i_stop" -lt "$i_backup" ]; then ok; else fail "app stop must precede backup"; fi
+    if [ -n "$i_backup" ] && [ -n "$i_startdb" ] && [ "$i_backup" -lt "$i_startdb" ]; then ok; else fail "backup must precede DB start"; fi
+    if [ -n "$i_startdb" ] && [ -n "$i_migrate" ] && [ "$i_startdb" -lt "$i_migrate" ]; then ok; else fail "DB start must precede migrate"; fi
+    if grep -q "Image=ghcr.io/spengrah/personalcrm-backend:$NEW_SHA" "$BACKEND_UNIT"; then ok; else fail "image not swapped after migrate"; fi
+    cleanup_sandbox
+}
+
+test_migrate_failure_restores() {
+    echo "test: --migrate FAILS -> ROLLBACK-WITH-RESTORE (restore first)"
+    make_sandbox
+    STUB_MIGRATE_CHECK_RC=2 STUB_MIGRATE_RC=1 run_deploy "$VALID_SHA"
+    if [ "$RC" -eq 1 ]; then ok; else fail "migrate failure should exit 1, got $RC"; fi
+    if log_has "restore-db.sh --local --no-app-start"; then ok; else fail "migrate failure must restore"; fi
+    cleanup_sandbox
+}
+
+test_post_migrate_swap_failure_restores() {
+    echo "test: post-migrate SWAP (start) FAILS -> ROLLBACK-WITH-RESTORE"
+    make_sandbox
+    # migrate-check pending, migrate OK, but the post-migrate app `start` fails
+    # (DB start in step c must still succeed, else we never reach the migrate).
+    STUB_MIGRATE_CHECK_RC=2 STUB_MIGRATE_RC=0 STUB_APP_START_FAIL=1 run_deploy "$VALID_SHA"
+    if [ "$RC" -eq 1 ]; then ok; else fail "post-migrate swap failure should exit 1, got $RC"; fi
+    # restore MUST run (DB was forward-migrated; swap failed).
+    if log_has "restore-db.sh --local --no-app-start"; then ok; else fail "post-migrate failure must restore the DB"; fi
+    cleanup_sandbox
+}
+
+test_rollback_restore_ordering() {
+    echo "test: ROLLBACK-WITH-RESTORE runs restore BEFORE re-pin (unconditional)"
+    make_sandbox
+    # Health fails after a successful migrate -> rollback. Assert order:
+    #   stop app (rollback) -> restore-db.sh -> re-pin Image= (sed on units) -> start app
+    STUB_MIGRATE_CHECK_RC=2 STUB_MIGRATE_RC=0 STUB_HEALTH_OK=0 run_deploy "$VALID_SHA"
+    if [ "$RC" -eq 1 ]; then ok; else fail "health fail after migrate should exit 1, got $RC"; fi
+    local i_restore i_repin i_startapp
+    i_restore="$(log_idx 'restore-db.sh --local --no-app-start')"
+    # The re-pin sed that writes the rollback ref (digest) -- the LAST sed writing the unit.
+    i_repin="$(grep -nF 'sed -i' "$CALL_LOG" | grep -F 'personalcrm-backend@sha256' | head -1 | cut -d: -f1)"
+    i_startapp="$(grep -nF 'start personalcrm-backend.service personalcrm-frontend.service' "$CALL_LOG" | tail -1 | cut -d: -f1)"
+    if [ -n "$i_restore" ]; then ok; else fail "restore must run in rollback"; fi
+    if [ -n "$i_restore" ] && [ -n "$i_repin" ] && [ "$i_restore" -lt "$i_repin" ]; then ok; else fail "restore must precede re-pin (got restore=$i_restore repin=$i_repin)"; fi
+    if [ -n "$i_repin" ] && [ -n "$i_startapp" ] && [ "$i_repin" -lt "$i_startapp" ]; then ok; else fail "re-pin must precede app start"; fi
+    cleanup_sandbox
+}
+
+test_restore_failure_is_rollback_failed() {
+    echo "test: restore FAILS in rollback -> ROLLBACK FAILED, app left stopped"
+    make_sandbox
+    STUB_MIGRATE_CHECK_RC=2 STUB_MIGRATE_RC=0 STUB_HEALTH_OK=0 STUB_RESTORE_RC=1 run_deploy "$VALID_SHA"
+    if [ "$RC" -eq 1 ]; then ok; else fail "restore failure should exit 1, got $RC"; fi
+    # After a restore failure, the app must NOT be (re)started.
+    local i_restore i_startapp
+    i_restore="$(log_idx 'restore-db.sh --local --no-app-start')"
+    i_startapp="$(grep -nF 'start personalcrm-backend.service personalcrm-frontend.service' "$CALL_LOG" | awk -F: -v r="$i_restore" '$1 > r {print $1; exit}')"
+    if [ -z "$i_startapp" ]; then ok; else fail "app must stay STOPPED after restore failure (started at $i_startapp)"; fi
+    cleanup_sandbox
+}
+
+test_repin_failure_is_rollback_failed() {
+    echo "test: re-pin FAILS after restore -> ROLLBACK FAILED, app left stopped"
+    make_sandbox
+    # Restore succeeds, but make the re-pin daemon-reload fail.
+    STUB_MIGRATE_CHECK_RC=2 STUB_MIGRATE_RC=0 STUB_HEALTH_OK=0 STUB_SYSTEMCTL_FAIL=daemon-reload run_deploy "$VALID_SHA"
+    if [ "$RC" -eq 1 ]; then ok; else fail "re-pin failure should exit 1, got $RC"; fi
+    if log_has "restore-db.sh --local --no-app-start"; then ok; else fail "restore must have run before re-pin"; fi
+    # App must NOT be started after a failed re-pin.
+    local i_restore i_startapp
+    i_restore="$(log_idx 'restore-db.sh --local --no-app-start')"
+    i_startapp="$(grep -nF 'start personalcrm-backend.service personalcrm-frontend.service' "$CALL_LOG" | awk -F: -v r="$i_restore" '$1 > r {print $1; exit}')"
+    if [ -z "$i_startapp" ]; then ok; else fail "app must stay STOPPED after re-pin failure"; fi
+    cleanup_sandbox
+}
+
+test_ntfy_degrade_open() {
+    echo "test: ntfy absent env file -> skip + still deploy (degrade-open)"
+    make_sandbox
+    # NTFY_ENV_FILE points at a missing file by default; confirm a clean deploy.
+    STUB_MIGRATE_CHECK_RC=0 run_deploy "$VALID_SHA"
+    if [ "$RC" -eq 0 ]; then ok; else fail "degrade-open deploy should exit 0, got $RC"; fi
+    # No ntfy POST should have been attempted (no curl to an ntfy URL).
+    if grep -F 'curl' "$CALL_LOG" | grep -qi 'ntfy'; then fail "ntfy posted despite absent env file"; else ok; fi
+    cleanup_sandbox
+}
+
+test_ntfy_present_outcomes() {
+    echo "test: ntfy present -> correct Title/Priority/Tags per outcome"
+    make_sandbox
+    printf 'NTFY_URL=https://ntfy.example\nNTFY_TOPIC=tok\n' > "$SANDBOX/ntfy.env"
+    NTFY_ENV_FILE_OVERRIDE="$SANDBOX/ntfy.env" STUB_MIGRATE_CHECK_RC=0 run_deploy "$VALID_SHA"
+    # Deploy OK: Title 'Deploy OK', Tags white_check_mark.
+    if grep -F 'curl' "$CALL_LOG" | grep -q 'Title: Deploy OK'; then ok; else fail "missing 'Deploy OK' ntfy title"; fi
+    if grep -F 'curl' "$CALL_LOG" | grep -q 'Tags: white_check_mark'; then ok; else fail "missing white_check_mark tag"; fi
+    cleanup_sandbox
+
+    make_sandbox
+    printf 'NTFY_URL=https://ntfy.example\nNTFY_TOPIC=tok\n' > "$SANDBOX/ntfy.env"
+    NTFY_ENV_FILE_OVERRIDE="$SANDBOX/ntfy.env" STUB_MIGRATE_CHECK_RC=2 STUB_MIGRATE_RC=0 STUB_HEALTH_OK=0 STUB_RESTORE_RC=1 run_deploy "$VALID_SHA"
+    if grep -F 'curl' "$CALL_LOG" | grep -q 'Title: ROLLBACK FAILED'; then ok; else fail "missing ROLLBACK FAILED ntfy title"; fi
+    if grep -F 'curl' "$CALL_LOG" | grep -q 'Priority: urgent'; then ok; else fail "ROLLBACK FAILED must be urgent priority"; fi
+    cleanup_sandbox
+}
+
+test_ntfy_post_failure_does_not_change_outcome() {
+    echo "test: present-but-failing ntfy curl does not change deploy outcome"
+    make_sandbox
+    printf 'NTFY_URL=https://ntfy.invalid\nNTFY_TOPIC=tok\n' > "$SANDBOX/ntfy.env"
+    # Make curl to the ntfy host fail; the deploy itself is up-to-date + healthy.
+    cat > "$SANDBOX/bin/curl" <<EOF
+#!/usr/bin/env bash
+echo "curl \$*" >> "$CALL_LOG"
+url="\${@: -1}"
+case "\$url" in
+  *contacts*) echo -n 200; exit 0 ;;
+  *8080/health*) echo '{"database":"healthy"}'; exit 0 ;;
+  *3001*) exit 0 ;;
+  *ntfy.invalid*) exit 7 ;;
+  *) exit 0 ;;
+esac
+EOF
+    chmod +x "$SANDBOX/bin/curl"
+    NTFY_ENV_FILE_OVERRIDE="$SANDBOX/ntfy.env" STUB_MIGRATE_CHECK_RC=0 run_deploy "$VALID_SHA"
+    if [ "$RC" -eq 0 ]; then ok; else fail "failing ntfy POST must not change exit 0, got $RC"; fi
+    cleanup_sandbox
+}
+
+test_snapshot_retained_on_failure() {
+    echo "test: snapshot is never pruned on a failure path"
+    make_sandbox
+    STUB_MIGRATE_CHECK_RC=2 STUB_MIGRATE_RC=0 STUB_HEALTH_OK=0 run_deploy "$VALID_SHA"
+    # The prune helper deletes via `rm -rf ...bak-...`; on a rollback it must NOT run.
+    if grep -F 'sudo rm -rf' "$CALL_LOG" | grep -q '_data.bak-'; then fail "snapshot pruned on a failure path"; else ok; fi
+    cleanup_sandbox
+}
+
+# ---------------------------------------------------------------------------
+main() {
+    test_sha_validation
+    test_rollback_ref_sha_fixture
+    test_rollback_ref_latest_digest
+    test_migrate_command_line
+    test_rootless_env_on_every_call
+    test_exit0_uptodate_no_db
+    test_exit1_abort_no_touch
+    test_exit_other_abort
+    test_pending_happy_path
+    test_migrate_failure_restores
+    test_post_migrate_swap_failure_restores
+    test_rollback_restore_ordering
+    test_restore_failure_is_rollback_failed
+    test_repin_failure_is_rollback_failed
+    test_ntfy_degrade_open
+    test_ntfy_present_outcomes
+    test_ntfy_post_failure_does_not_change_outcome
+    test_snapshot_retained_on_failure
+
+    echo ""
+    echo "===================="
+    echo "PASS=$PASS FAIL=$FAIL"
+    echo "===================="
+    [ "$FAIL" -eq 0 ]
+}
+
+main "$@"

--- a/scripts/deploy-artifact.test.sh
+++ b/scripts/deploy-artifact.test.sh
@@ -290,10 +290,8 @@ test_rootless_env_on_every_call() {
     echo "test: rootless sudo -u crm env on every podman/systemctl call"
     make_sandbox
     STUB_MIGRATE_CHECK_RC=0 run_deploy "$VALID_SHA"
-    # Every recorded podman/systemctl call must have come through a `sudo -u crm`
-    # line carrying HOME + XDG_RUNTIME_DIR. We assert there is at least one such
-    # sudo line and NO bare `podman`/`systemctl` invocation outside the stub log
-    # was made without it. Check the sudo lines carry the env.
+    # Every recorded sudo-wrapped podman/systemctl line must carry the rootless
+    # env (-u crm, HOME, XDG).
     local bad=0 line
     while IFS= read -r line; do
         case "$line" in
@@ -304,10 +302,24 @@ test_rootless_env_on_every_call() {
                 ;;
         esac
     done < "$CALL_LOG"
-    if [ "$bad" -eq 0 ]; then ok; else fail "some podman/systemctl calls lacked the rootless env"; fi
+    if [ "$bad" -eq 0 ]; then ok; else fail "some sudo podman/systemctl calls lacked the rootless env"; fi
     # systemctl must also carry DBUS for the --user bus.
     if grep -E '^sudo .*systemctl' "$CALL_LOG" | grep -q 'DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/4242/bus'; then ok
     else fail "systemctl calls missing DBUS_SESSION_BUS_ADDRESS"; fi
+
+    # Stronger: NO bare podman/systemctl may run outside a sudo wrapper. The sudo
+    # stub records `sudo ...X...` then execs the X stub which records `X ...`, so
+    # each genuine call yields exactly one of each. If any X ran without sudo, the
+    # bare count would exceed the sudo-wrapped count.
+    local n_podman n_sudo_podman n_systemctl n_sudo_systemctl
+    n_podman=$(grep -cE '^podman ' "$CALL_LOG" || true)
+    n_sudo_podman=$(grep -cE '^sudo .* podman ' "$CALL_LOG" || true)
+    n_systemctl=$(grep -cE '^systemctl ' "$CALL_LOG" || true)
+    n_sudo_systemctl=$(grep -cE '^sudo .* systemctl ' "$CALL_LOG" || true)
+    if [ "$n_podman" -ge 1 ] && [ "$n_podman" -eq "$n_sudo_podman" ]; then ok
+    else fail "bare podman calls ($n_podman) != sudo-wrapped ($n_sudo_podman)"; fi
+    if [ "$n_systemctl" -ge 1 ] && [ "$n_systemctl" -eq "$n_sudo_systemctl" ]; then ok
+    else fail "bare systemctl calls ($n_systemctl) != sudo-wrapped ($n_sudo_systemctl)"; fi
     cleanup_sandbox
 }
 
@@ -362,6 +374,31 @@ test_pending_happy_path() {
     if [ -n "$i_backup" ] && [ -n "$i_startdb" ] && [ "$i_backup" -lt "$i_startdb" ]; then ok; else fail "backup must precede DB start"; fi
     if [ -n "$i_startdb" ] && [ -n "$i_migrate" ] && [ "$i_startdb" -lt "$i_migrate" ]; then ok; else fail "DB start must precede migrate"; fi
     if grep -q "Image=ghcr.io/spengrah/personalcrm-backend:$NEW_SHA" "$BACKEND_UNIT"; then ok; else fail "image not swapped after migrate"; fi
+    cleanup_sandbox
+}
+
+test_backup_failure_aborts_with_ntfy() {
+    echo "test: snapshot/backup non-zero exit -> abort + ntfy (no migrate)"
+    make_sandbox
+    printf 'NTFY_URL=https://ntfy.example\nNTFY_TOPIC=tok\n' > "$SANDBOX/ntfy.env"
+    NTFY_ENV_FILE_OVERRIDE="$SANDBOX/ntfy.env" STUB_MIGRATE_CHECK_RC=2 STUB_BACKUP_RC=1 run_deploy "$VALID_SHA"
+    if [ "$RC" -eq 1 ]; then ok; else fail "backup failure should exit 1, got $RC"; fi
+    # Must NOT have migrated (backup failed first).
+    if grep -F 'podman run' "$CALL_LOG" | grep -q -- '--migrate$'; then fail "must NOT migrate after backup failure"; else ok; fi
+    # Must have sent a 'Deploy aborted' ntfy (not silently restart via the trap).
+    if grep -F 'curl' "$CALL_LOG" | grep -q 'Title: Deploy aborted'; then ok; else fail "backup failure must ntfy 'Deploy aborted'"; fi
+    cleanup_sandbox
+}
+
+test_restore_pg_not_ready_is_rollback_failed() {
+    echo "test: restore pg_isready never ready -> restore FAILS -> ROLLBACK FAILED"
+    make_sandbox
+    # restore-db.sh returns non-zero (simulating pg never ready) during rollback.
+    printf 'NTFY_URL=https://ntfy.example\nNTFY_TOPIC=tok\n' > "$SANDBOX/ntfy.env"
+    NTFY_ENV_FILE_OVERRIDE="$SANDBOX/ntfy.env" \
+      STUB_MIGRATE_CHECK_RC=2 STUB_MIGRATE_RC=0 STUB_HEALTH_OK=0 STUB_RESTORE_RC=1 run_deploy "$VALID_SHA"
+    if [ "$RC" -eq 1 ]; then ok; else fail "restore failure should exit 1, got $RC"; fi
+    if grep -F 'curl' "$CALL_LOG" | grep -q 'Title: ROLLBACK FAILED'; then ok; else fail "restore failure must ntfy ROLLBACK FAILED"; fi
     cleanup_sandbox
 }
 
@@ -504,6 +541,8 @@ main() {
     test_exit1_abort_no_touch
     test_exit_other_abort
     test_pending_happy_path
+    test_backup_failure_aborts_with_ntfy
+    test_restore_pg_not_ready_is_rollback_failed
     test_migrate_failure_restores
     test_post_migrate_swap_failure_restores
     test_rollback_restore_ordering

--- a/scripts/deploy-artifact.test.sh
+++ b/scripts/deploy-artifact.test.sh
@@ -93,8 +93,8 @@ case "\$1" in
     echo "$SANDBOX/volume/_data"
     exit 0 ;;
   exec)
-    # pg_isready
-    exit 0 ;;
+    # pg_isready -- STUB_PG_NOT_READY=1 simulates postgres never becoming ready.
+    exit "\${STUB_PG_NOT_READY:-0}" ;;
   run)
     # crm-admin via --entrypoint. Last arg is the subcommand.
     sub="\${@: -1}"
@@ -130,13 +130,23 @@ exit 0
 EOF
 
     # --- stub: curl (health gate + ntfy) ---
+    # The health stub emits the REAL /health payload shape (top-level "status"
+    # plus nested components.database.status) so the matcher is tested against
+    # what the server actually returns. Unhealthy => exit non-zero, modelling the
+    # handler's HTTP 503 + `curl -sf`'s -f flag (which non-zeroes on >=400).
     cat > "$SANDBOX/bin/curl" <<EOF
 #!/usr/bin/env bash
 echo "curl \$*" >> "$CALL_LOG"
 url="\${@: -1}"
 case "\$url" in
   *contacts*) echo -n "\${STUB_CADDY_CODE:-200}"; exit 0 ;;
-  *8080/health*) [ "\${STUB_HEALTH_OK:-1}" = "1" ] && { echo '{"database":"healthy"}'; exit 0; }; exit 1 ;;
+  *8080/health*)
+    if [ "\${STUB_HEALTH_OK:-1}" = "1" ]; then
+      echo '{"status":"healthy","timestamp":"t","version":{"version":"dev"},"components":{"database":{"status":"healthy","response_time":"1ms"}}}'
+      exit 0
+    fi
+    # Unhealthy: handler returns 503; with -sf curl writes nothing and non-zeroes.
+    exit 22 ;;
   *3001*) exit "\${STUB_FRONTEND_RC:-0}" ;;
   *) exit 0 ;;  # ntfy posts
 esac
@@ -181,6 +191,12 @@ EOF
 #!/usr/bin/env bash
 echo "restore-db.sh \$*" >> "$CALL_LOG"
 exit "\${STUB_RESTORE_RC:-0}"
+EOF
+
+    # --- stub: sleep (no-op so readiness/health retry loops run instantly) ---
+    cat > "$SANDBOX/bin/sleep" <<'EOF'
+#!/usr/bin/env bash
+exit 0
 EOF
 
     chmod +x "$SANDBOX"/bin/*
@@ -323,6 +339,24 @@ test_rootless_env_on_every_call() {
     cleanup_sandbox
 }
 
+test_health_gate_matches_real_payload() {
+    echo "test: health-gate matches the REAL /health payload shape"
+    # Healthy real payload (top-level status + nested components.database.status)
+    # must PASS -> up-to-date deploy exits 0. If the matcher were wrong (e.g. the
+    # old flat "database":"healthy" grep), this would fail because the stub now
+    # emits the shape the server actually returns.
+    make_sandbox
+    STUB_MIGRATE_CHECK_RC=0 STUB_HEALTH_OK=1 run_deploy "$VALID_SHA"
+    if [ "$RC" -eq 0 ]; then ok; else fail "healthy real payload should pass deploy (exit 0), got $RC ($OUT)"; fi
+    cleanup_sandbox
+
+    # Unhealthy (HTTP 503 -> curl -sf non-zero) must FAIL the gate -> rollback.
+    make_sandbox
+    STUB_MIGRATE_CHECK_RC=0 STUB_HEALTH_OK=0 run_deploy "$VALID_SHA"
+    if [ "$RC" -eq 1 ]; then ok; else fail "unhealthy /health should fail the gate -> rollback (exit 1), got $RC"; fi
+    cleanup_sandbox
+}
+
 test_exit0_uptodate_no_db() {
     echo "test: exit 0 (up-to-date) touches no DB, swaps image, restarts app"
     make_sandbox
@@ -374,6 +408,19 @@ test_pending_happy_path() {
     if [ -n "$i_backup" ] && [ -n "$i_startdb" ] && [ "$i_backup" -lt "$i_startdb" ]; then ok; else fail "backup must precede DB start"; fi
     if [ -n "$i_startdb" ] && [ -n "$i_migrate" ] && [ "$i_startdb" -lt "$i_migrate" ]; then ok; else fail "DB start must precede migrate"; fi
     if grep -q "Image=ghcr.io/spengrah/personalcrm-backend:$NEW_SHA" "$BACKEND_UNIT"; then ok; else fail "image not swapped after migrate"; fi
+    cleanup_sandbox
+}
+
+test_pg_not_ready_aborts_before_migrate() {
+    echo "test: postgres never ready -> abort BEFORE migrate (no restore path)"
+    make_sandbox
+    printf 'NTFY_URL=https://ntfy.example\nNTFY_TOPIC=tok\n' > "$SANDBOX/ntfy.env"
+    NTFY_ENV_FILE_OVERRIDE="$SANDBOX/ntfy.env" STUB_MIGRATE_CHECK_RC=2 STUB_PG_NOT_READY=1 run_deploy "$VALID_SHA"
+    if [ "$RC" -eq 1 ]; then ok; else fail "pg-not-ready should exit 1, got $RC"; fi
+    # Must NOT migrate (postgres never came up) and must NOT take the restore path.
+    if grep -F 'podman run' "$CALL_LOG" | grep -q -- '--migrate$'; then fail "must NOT migrate when pg not ready"; else ok; fi
+    if log_lacks "restore-db.sh"; then ok; else fail "pg-not-ready is NOT a restore path"; fi
+    if grep -F 'curl' "$CALL_LOG" | grep -q 'Title: Deploy aborted'; then ok; else fail "pg-not-ready must ntfy 'Deploy aborted'"; fi
     cleanup_sandbox
 }
 
@@ -509,7 +556,7 @@ echo "curl \$*" >> "$CALL_LOG"
 url="\${@: -1}"
 case "\$url" in
   *contacts*) echo -n 200; exit 0 ;;
-  *8080/health*) echo '{"database":"healthy"}'; exit 0 ;;
+  *8080/health*) echo '{"status":"healthy","components":{"database":{"status":"healthy"}}}'; exit 0 ;;
   *3001*) exit 0 ;;
   *ntfy.invalid*) exit 7 ;;
   *) exit 0 ;;
@@ -537,10 +584,12 @@ main() {
     test_rollback_ref_latest_digest
     test_migrate_command_line
     test_rootless_env_on_every_call
+    test_health_gate_matches_real_payload
     test_exit0_uptodate_no_db
     test_exit1_abort_no_touch
     test_exit_other_abort
     test_pending_happy_path
+    test_pg_not_ready_aborts_before_migrate
     test_backup_failure_aborts_with_ntfy
     test_restore_pg_not_ready_is_rollback_failed
     test_migrate_failure_restores

--- a/scripts/restore-db.sh
+++ b/scripts/restore-db.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+# PersonalCRM Database Restore Script (rootless Podman edition).
+# Replaces the live PostgreSQL data volume with a previously-taken physical
+# snapshot (a `_data.bak-*` directory produced by backup-db.sh).
+#
+# Mirror of backup-db.sh: same rootless crm-user helpers, same ssh/local split.
+# The cold copy requires postgres stopped, so this stops the writers + postgres,
+# swaps the volume contents, then brings postgres (and optionally the app) back.
+#
+# Usage: ./scripts/restore-db.sh [--local] [--no-app-start] [<snapshot-path>]
+#   --local         Run on the Pi as root (no ssh). crm-user podman/systemctl
+#                   helpers run via `sudo -u crm ...` locally instead of over ssh.
+#   --no-app-start  Restore the volume and bring Postgres up to pg_isready, but
+#                   do NOT start backend/frontend. Used by deploy-artifact.sh's
+#                   rollback path so it can re-pin the OLD Image= itself, then
+#                   start the app on the OLD code against the restored OLD DB.
+#   <snapshot-path> The exact `_data.bak-*` path to restore. If omitted, the
+#                   newest `*.bak-*` alongside the live volume is used.
+#
+# The snapshot is NEVER deleted (it is the recovery point). The displaced live
+# `_data` is moved aside (not removed) until the copy succeeds, then cleaned up.
+
+set -e
+
+PI_HOST="${PI_HOST:-raspberry-pi}"
+
+# Parse arguments
+LOCAL=false
+NO_APP_START=false
+SNAPSHOT_ARG=""
+for arg in "$@"; do
+    case $arg in
+        --local) LOCAL=true ;;
+        --no-app-start) NO_APP_START=true ;;
+        --*) echo "Unknown flag: $arg" >&2; exit 2 ;;
+        *) SNAPSHOT_ARG="$arg" ;;
+    esac
+done
+
+CRM_HOME=/var/lib/personalcrm
+
+# log: progress messages. ssh mode → stdout; local mode → stderr (so stdout stays
+# clean for any future machine-readable output and matches backup-db.sh's split).
+if [ "$LOCAL" = true ]; then
+    log() { echo "$@" >&2; }
+else
+    log() { echo "$@"; }
+fi
+
+if [ "$LOCAL" = true ]; then
+    # On-Pi mode: no ssh. Resolve the crm uid locally and wrap podman/systemctl
+    # in `sudo -u crm` so they hit the rootless crm-user store, never root's.
+    CRM_UID=$(id -u crm)
+    USERENV="HOME=$CRM_HOME XDG_RUNTIME_DIR=/run/user/$CRM_UID DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$CRM_UID/bus"
+    # USERENV is deliberately unquoted: it must word-split into separate KEY=val
+    # arguments for env-style `sudo -u crm KEY=val KEY=val ...`.
+    # shellcheck disable=SC2086
+    crm_ctl()    { cd /tmp && sudo -u crm $USERENV systemctl --user "$@"; }
+    crm_podman() { cd /tmp && sudo -u crm HOME=$CRM_HOME XDG_RUNTIME_DIR=/run/user/"$CRM_UID" podman "$@"; }
+    root_mv()    { sudo mv "$1" "$2"; }
+    root_cp()    { sudo cp -a "$1" "$2"; }
+    root_rm()    { sudo rm -rf "$1"; }
+    root_exists(){ sudo test -e "$1"; }
+
+    log "=== PersonalCRM Database Restore (Podman, local) ==="
+else
+    log "=== PersonalCRM Database Restore (Podman) ==="
+    log "Target: $PI_HOST"
+    log ""
+
+    # Verify Pi is reachable
+    log "Checking connectivity to $PI_HOST..."
+    if ! ssh -q -o ConnectTimeout=5 "$PI_HOST" exit; then
+        echo "Error: Cannot connect to $PI_HOST"
+        exit 1
+    fi
+
+    CRM_UID=$(ssh "$PI_HOST" "id -u crm")
+    USERENV="HOME=$CRM_HOME XDG_RUNTIME_DIR=/run/user/$CRM_UID DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$CRM_UID/bus"
+    # Vars below deliberately expand client-side (resolved here, then sent over
+    # ssh as a literal remote command). SC2029 is the intended behavior.
+    # shellcheck disable=SC2029
+    crm_ctl()    { ssh "$PI_HOST" "cd /tmp && sudo -n -u crm $USERENV systemctl --user $*"; }
+    # shellcheck disable=SC2029
+    crm_podman() { ssh "$PI_HOST" "cd /tmp && sudo -n -u crm HOME=$CRM_HOME XDG_RUNTIME_DIR=/run/user/$CRM_UID podman $*"; }
+    # shellcheck disable=SC2029
+    root_mv()    { ssh "$PI_HOST" "sudo mv '$1' '$2'"; }
+    # shellcheck disable=SC2029
+    root_cp()    { ssh "$PI_HOST" "sudo cp -a '$1' '$2'"; }
+    # shellcheck disable=SC2029
+    root_rm()    { ssh "$PI_HOST" "sudo rm -rf '$1'"; }
+    # shellcheck disable=SC2029
+    root_exists(){ ssh "$PI_HOST" "sudo test -e '$1'"; }
+fi
+
+# Safety net: if we error out (set -e) after stopping services, don't leave prod
+# down silently. Best-effort: bring the DB back so a manual recovery can proceed.
+# We do NOT auto-restart the app here -- mid-restore the app image may be wrong
+# (the caller, deploy-artifact.sh, owns the app re-pin + start decision).
+SERVICES_STOPPED=false
+on_exit() {
+    local rc=$?
+    if [ "$rc" -ne 0 ] && [ "$SERVICES_STOPPED" = true ]; then
+        echo "" >&2
+        echo "⚠️  ERROR (exit $rc) during restore with services stopped." >&2
+        echo "   The snapshot is preserved. Inspect and recover manually." >&2
+        echo "   Bring the database back with:" >&2
+        if [ "$LOCAL" = true ]; then
+            echo "   sudo -u crm $USERENV systemctl --user start personalcrm-database.service" >&2
+        else
+            echo "   ssh $PI_HOST \"sudo -n -u crm $USERENV systemctl --user start personalcrm-database.service\"" >&2
+        fi
+    fi
+}
+trap on_exit EXIT
+
+# Locate the Podman named volume mountpoint (.../volumes/personalcrm-db/_data).
+VOLUME_PATH=$(crm_podman volume inspect personalcrm-db --format '{{.Mountpoint}}')
+log "Volume: $VOLUME_PATH"
+
+# Resolve the snapshot to restore.
+if [ -n "$SNAPSHOT_ARG" ]; then
+    SNAPSHOT_PATH="$SNAPSHOT_ARG"
+else
+    # Newest *.bak-* alongside the volume. ls -d sorts the timestamped suffix
+    # lexically, which is chronological for YYYYMMDD-HHMMSS.
+    if [ "$LOCAL" = true ]; then
+        SNAPSHOT_PATH=$(sudo bash -c "ls -d ${VOLUME_PATH}.bak-* 2>/dev/null | sort | tail -1" || true)
+    else
+        # shellcheck disable=SC2029
+        SNAPSHOT_PATH=$(ssh "$PI_HOST" "sudo bash -c 'ls -d ${VOLUME_PATH}.bak-* 2>/dev/null | sort | tail -1'" || true)
+    fi
+fi
+
+# REQUIRE the snapshot exists -- NEVER restore from nothing.
+if [ -z "$SNAPSHOT_PATH" ]; then
+    echo "Error: no snapshot specified and no ${VOLUME_PATH}.bak-* found" >&2
+    exit 1
+fi
+if ! root_exists "$SNAPSHOT_PATH"; then
+    echo "Error: snapshot does not exist: $SNAPSHOT_PATH" >&2
+    exit 1
+fi
+log "Snapshot: $SNAPSHOT_PATH"
+
+# Stop the writers, then postgres, before touching the volume on disk.
+log "Stopping app services (backend, frontend)..."
+crm_ctl stop personalcrm-backend.service personalcrm-frontend.service
+SERVICES_STOPPED=true
+
+log "Stopping postgres..."
+crm_ctl stop personalcrm-database.service
+
+# Replace the live _data with the snapshot. mv the live dir aside (do NOT rm) so
+# it survives until the cp -a verifiably succeeds; clean it up only on success.
+DISPLACED="${VOLUME_PATH}.restore-old-$(date +%Y%m%d-%H%M%S)"
+log "Moving live data aside: $DISPLACED"
+root_mv "$VOLUME_PATH" "$DISPLACED"
+
+log "Copying snapshot into place (this may take a moment)..."
+root_cp "$SNAPSHOT_PATH" "$VOLUME_PATH"
+
+# Bring postgres back and wait for it to accept connections.
+log "Starting postgres..."
+crm_ctl start personalcrm-database.service
+
+log "Waiting for postgres to accept connections..."
+for i in $(seq 1 15); do
+    if crm_podman exec crm-postgres pg_isready -U crm_user >/dev/null 2>&1; then
+        break
+    fi
+    if [ "$i" -eq 15 ]; then
+        log "Warning: postgres not ready after 15s"
+    fi
+    sleep 1
+done
+
+# The copy succeeded and postgres is back -- clean up the displaced live dir.
+# (The SNAPSHOT is never touched; it remains the recovery point.)
+log "Cleaning up displaced data: $DISPLACED"
+root_rm "$DISPLACED"
+
+if [ "$NO_APP_START" = true ]; then
+    SERVICES_STOPPED=false
+    log ""
+    log "✅ Restore complete. Postgres is up; app NOT started (--no-app-start)."
+    log "   The caller is responsible for pinning the image and starting the app."
+else
+    log "Starting backend and frontend..."
+    crm_ctl start personalcrm-backend.service personalcrm-frontend.service
+    SERVICES_STOPPED=false
+    log ""
+    log "✅ Restore complete. Services restarted on the currently-pinned image."
+fi

--- a/scripts/restore-db.sh
+++ b/scripts/restore-db.sh
@@ -165,15 +165,22 @@ log "Starting postgres..."
 crm_ctl start personalcrm-database.service
 
 log "Waiting for postgres to accept connections..."
-for i in $(seq 1 15); do
+PG_READY=false
+for _ in $(seq 1 15); do
     if crm_podman exec crm-postgres pg_isready -U crm_user >/dev/null 2>&1; then
+        PG_READY=true
         break
-    fi
-    if [ "$i" -eq 15 ]; then
-        log "Warning: postgres not ready after 15s"
     fi
     sleep 1
 done
+# A restore that cannot bring Postgres ready is a FAILED restore -- the caller
+# (deploy-artifact.sh) must treat this as ROLLBACK FAILED, not a clean recovery.
+# The displaced live dir is intentionally retained (not cleaned up) for forensics.
+if [ "$PG_READY" != true ]; then
+    echo "Error: postgres did not accept connections after 15s; restore failed" >&2
+    echo "   Displaced live data retained at: $DISPLACED" >&2
+    exit 1
+fi
 
 # The copy succeeded and postgres is back -- clean up the displaced live dir.
 # (The SNAPSHOT is never touched; it remains the recovery point.)

--- a/scripts/testdata/backend-latest.container
+++ b/scripts/testdata/backend-latest.container
@@ -1,0 +1,15 @@
+[Unit]
+Description=PersonalCRM Backend API Server (Podman, rootless)
+After=personalcrm-database.service
+Requires=personalcrm-database.service
+
+[Container]
+ContainerName=crm-backend
+Image=ghcr.io/spengrah/personalcrm-backend:latest
+Network=crm.network
+EnvironmentFile=/srv/personalcrm/.env
+Environment=MIGRATIONS_PATH=/migrations
+PublishPort=127.0.0.1:8080:8080
+
+[Install]
+WantedBy=default.target

--- a/scripts/testdata/backend-sha.container
+++ b/scripts/testdata/backend-sha.container
@@ -1,0 +1,15 @@
+[Unit]
+Description=PersonalCRM Backend API Server (Podman, rootless)
+After=personalcrm-database.service
+Requires=personalcrm-database.service
+
+[Container]
+ContainerName=crm-backend
+Image=ghcr.io/spengrah/personalcrm-backend:1111111111111111111111111111111111111111
+Network=crm.network
+EnvironmentFile=/srv/personalcrm/.env
+Environment=MIGRATIONS_PATH=/migrations
+PublishPort=127.0.0.1:8080:8080
+
+[Install]
+WantedBy=default.target

--- a/scripts/testdata/frontend-latest.container
+++ b/scripts/testdata/frontend-latest.container
@@ -1,0 +1,11 @@
+[Unit]
+Description=PersonalCRM Frontend (Podman, rootless)
+After=personalcrm-backend.service
+
+[Container]
+ContainerName=crm-frontend
+Image=ghcr.io/spengrah/personalcrm-frontend:latest
+PublishPort=127.0.0.1:3001:3001
+
+[Install]
+WantedBy=default.target

--- a/scripts/testdata/frontend-sha.container
+++ b/scripts/testdata/frontend-sha.container
@@ -1,0 +1,11 @@
+[Unit]
+Description=PersonalCRM Frontend (Podman, rootless)
+After=personalcrm-backend.service
+
+[Container]
+ContainerName=crm-frontend
+Image=ghcr.io/spengrah/personalcrm-frontend:2222222222222222222222222222222222222222
+PublishPort=127.0.0.1:3001:3001
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
PR3 of the Phase A deploy-automation plan (`.ai/log/plan/2026-06-11-deploy-automation-phaseA-bucketA.md` §4). Adds the on-Pi artifact-deploy orchestration for the rootless Podman Quadlet runtime, plus its snapshot/restore dependencies and ntfy notifications. Depends on PR2 (`crm-admin --migrate`/`--migrate-check`, merged).

## What this does

`scripts/deploy-artifact.sh` promotes an already-built GHCR `:<sha>` image to prod. It runs as root via one sudoers entry, but routes EVERY podman/systemctl op through the `crm` user (rootless store) — the only genuine-root ops are the `cp -a` volume copy inside backup/restore. Flow:

- **Rollback anchor** is read from each live unit's `Image=` BEFORE any rewrite. A real `:<40-hex-sha>` is used verbatim; the mutable `:latest` (current first-deploy state) is resolved to the running image digest via `podman inspect … RepoDigests` and pinned as an immutable `@sha256:<digest>` ref.
- Pulls both `:<sha>` images (fail-fast, no DB touched), then runs `crm-admin --migrate-check` **from the NEW image** via `podman run --rm --network crm --env-file --entrypoint /usr/local/bin/crm-admin <repo>:<sha> --migrate-check` (the image ENTRYPOINT is crm-api, so `--entrypoint` is required; NOT `podman exec`, which would run the OLD image).
- **Branches on the migrate-check exit code:**
  - `0` (up-to-date): swap `Image=`→`:sha`, daemon-reload + assert, restart app, health-gate — **no DB touched**. On health fail: re-pin the rollback ref + restart (no restore needed).
  - `2` (pending): stop app → `backup-db.sh --local --no-restart` snapshot → start postgres + wait `pg_isready` → `--migrate` via the NEW image → swap `Image=`→`:sha` (sed as the crm user, daemon-reload, RE-READ + assert) → start app → health-gate. **Any failure after `--migrate` succeeds** routes to ROLLBACK-WITH-RESTORE (never the bare `set -e` trap; an EXIT-trap backstop covers unanticipated failures in that region).
  - `1`/other: abort before touching anything.
- **ROLLBACK-WITH-RESTORE** stops the app, then restores the DB **unconditionally first** (`restore-db.sh --local --no-app-start`, safe because the app is stopped) BEFORE re-pinning the OLD image and starting it. A restore OR re-pin failure is a max-priority "ROLLBACK FAILED" with the app left STOPPED and the snapshot retained.
- **Health-gate is reads-only:** backend `/health` overall status healthy (retry budget), frontend 200, and one authenticated read through Caddy (`curl localhost:80/api/v1/contacts` == 200, plain curl so Caddy injects `X-API-Key`; never `X-Mac-Host-ID`).

`scripts/restore-db.sh` mirrors `backup-db.sh` (rootless helpers, `--local`/ssh split) with `--no-app-start`. It requires the snapshot to exist, moves the live `_data` aside (never `rm`) before `cp -a`, treats a `pg_isready` timeout as a failed restore, and never deletes the snapshot on a failed restore.

`scripts/backup-db.sh` gains an **additive** `--local` (on-Pi, no-ssh) mode so deploy-artifact.sh can co-install and call it; the default ssh mode is byte-behaviorally unchanged (the dev backup path is in use). `--local` emits the snapshot path as the only stdout line for capture.

**ntfy** is sourced from `/etc/personalcrm/ntfy.env` if present (degrade-open: absent file ⇒ skip + continue, so the script stays env-agnostic for staging; prod always has it, runbook-enforced in PR7). Per-outcome titled/prioritized/tagged pushes; bodies carry only the SHA + a fixed reason — never PII, never the topic/key.

## Review-head caught a P0 (fixed)

The health-gate originally matched the substring `"database":"healthy"`, which the real `/health` payload **never emits** — `backend/internal/health/health.go` returns top-level `{"status":"healthy",…,"components":{"database":{"status":"healthy"}}}` (HTTP 503, not 200, when the DB is unhealthy). The old matcher would have failed the gate on EVERY migrating deploy and run ROLLBACK-WITH-RESTORE after a *successful* migrate — a guaranteed destructive restore. Now gates on the top-level `"status":"healthy"` (confirmed against health.go; `curl -sf` already non-zeroes on the 503). The test curl stub was emitting a fabricated flat payload that masked the bug; it now emits the **real nested shape**, with a dedicated health-gate test that fails if the matcher is wrong (verified against the old matcher).

## Tests

`scripts/deploy-artifact.test.sh` is a PATH-stub harness (shadows `sudo`/`id`/`podman`/`systemctl`/`curl`/`sed`/`sleep` + the backup/restore scripts on PATH, recording argv) with fixture units under `scripts/testdata/` (one `:<sha>`, one `:latest`). 81 assertions covering: SHA validation, tag/digest extraction (both fixtures), the generated migrate command line (`--entrypoint`, `--network crm`, `--env-file`, `-e MIGRATIONS_PATH`, NEW `:sha`, trailing subcommand; never `podman exec`), the rootless `sudo -u crm` env on every call (bare-vs-sudo count parity), exit-code branching (0/2/1/other) and which branches touch the DB, the health-gate against the real payload (healthy passes, 503 rolls back), pg-not-ready and backup-failure aborts, post-migrate swap-failure → restore, rollback ordering (restore FIRST, unconditional), restore-failure and re-pin-failure → ROLLBACK FAILED with the app left stopped, snapshot retention on failure, and ntfy outcomes incl. degrade-open.

- All three scripts + the harness: `shellcheck` clean + `bash -n` clean.
- `bash scripts/deploy-artifact.test.sh`: 81/81 pass.
- Codex review converged to PASS (P0=0 P1=0 P2=0 P3=0); two `/review-head` rounds, the second a clean re-verify of the round-1 fixes.

The full on-Pi deploy + induced-failure rollback (incl. the first-deploy `:latest`→digest anchor) can only be exercised on the Pi; that's the coordinator's bucket-B drill, documented in the PR7 runbook.

Note: path-filters will likely skip the backend/frontend CI job bodies (scripts-only change) — expected, not a failure.