### PR TITLE
fix(deploy): resolve rollback digest via image inspect, not container

### DIFF
--- a/scripts/deploy-artifact.sh
+++ b/scripts/deploy-artifact.sh
@@ -101,15 +101,18 @@ read_image_tag() {
 # If it pins :latest (or anything else mutable) -> resolve the RUNNING image
 # digest of <container> -> repo@sha256:<digest> (immutable).
 rollback_ref_for() {
-    local repo="$1" container="$2" unit="$3" image tag digest
+    local repo="$1" container="$2" unit="$3" image tag digest image_id
     image="$(read_image_tag "$unit")"
     tag="${image##*:}"
     if [[ "$tag" =~ ^[0-9a-f]{40}$ ]]; then
         echo "$repo:$tag"
         return 0
     fi
-    # Mutable tag (:latest etc.) -> pin the currently-running digest.
-    digest="$(crm_podman inspect "$container" --format '{{index .RepoDigests 0}}')"
+    # Mutable tag (:latest etc.) -> pin the currently-running digest. RepoDigests is
+    # an IMAGE field, not a container field: resolve the container's image id, then
+    # read RepoDigests from the image.
+    image_id="$(crm_podman inspect "$container" --format '{{.Image}}')"
+    digest="$(crm_podman image inspect "$image_id" --format '{{index .RepoDigests 0}}')"
     if [ -z "$digest" ]; then
         echo "error: could not resolve running digest for $container" >&2
         return 1

--- a/scripts/deploy-artifact.test.sh
+++ b/scripts/deploy-artifact.test.sh
@@ -84,7 +84,11 @@ EOF
 echo "podman \$*" >> "$CALL_LOG"
 case "\$1" in
   inspect)
-    # podman inspect <container> --format '{{index .RepoDigests 0}}'
+    # container inspect: \`podman inspect <container> --format '{{.Image}}'\` -> image id
+    echo "\${STUB_IMAGE_ID:-c91da029deadbeefc91da029deadbeefc91da029deadbeefc91da029deadbeef}"
+    exit 0 ;;
+  image)
+    # image inspect: \`podman image inspect <id> --format '{{index .RepoDigests 0}}'\` -> repo digest
     echo "\${STUB_INSPECT_DIGEST:-ghcr.io/spengrah/personalcrm-backend@sha256:c91da029deadbeefc91da029deadbeefc91da029deadbeefc91da029deadbeef}"
     exit 0 ;;
   pull)
@@ -270,9 +274,10 @@ test_rollback_ref_latest_digest() {
     STUB_MIGRATE_CHECK_RC=0 STUB_HEALTH_OK=0 \
       STUB_INSPECT_DIGEST="ghcr.io/spengrah/personalcrm-backend@sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef" \
       run_deploy "$VALID_SHA"
-    # :latest must drive `podman inspect ... RepoDigests`.
-    if log_has "podman inspect crm-backend"; then ok; else fail ":latest must resolve via podman inspect crm-backend"; fi
-    if log_has "podman inspect crm-frontend"; then ok; else fail ":latest must resolve via podman inspect crm-frontend"; fi
+    # :latest must resolve each container's image id, then read RepoDigests from the IMAGE.
+    if log_has "podman inspect crm-backend"; then ok; else fail ":latest must inspect crm-backend for its image id"; fi
+    if log_has "podman inspect crm-frontend"; then ok; else fail ":latest must inspect crm-frontend for its image id"; fi
+    if log_has "podman image inspect"; then ok; else fail ":latest must resolve the digest via podman image inspect"; fi
     # Rollback re-pin should write the @sha256 digest ref.
     if grep -q 'Image=ghcr.io/spengrah/personalcrm-backend@sha256:deadbeef' "$BACKEND_UNIT"; then ok
     else fail "backend unit should be re-pinned to the resolved @sha256 digest"; fi


### PR DESCRIPTION
Fixes the root cause of the first live prod-deploy failure (go-live).

`deploy-artifact.sh`'s `rollback_ref_for()` resolved the `:latest`-anchor digest via `podman inspect <CONTAINER> --format '{{index .RepoDigests 0}}'`, but `RepoDigests` is an **image** field, not a container field — podman errors `can't evaluate field RepoDigests in type interface {}`. It only triggers on the first-ever deploy (the `:latest`→digest anchor path). The deploy aborted there, **before touching prod** (fail-safe). The test harness mocked podman and returned a digest for any `inspect`, so it never caught this (test-validates-the-bug, like the earlier health-gate P0).

**Fix:** resolve the container's image id (`podman inspect <container> --format '{{.Image}}'`), then read `RepoDigests` from the IMAGE (`podman image inspect <id> --format '{{index .RepoDigests 0}}'`).

Verified two ways: (1) ran the corrected commands against **real podman on the Pi** → returns `ghcr.io/spengrah/personalcrm-backend@sha256:…`; (2) review-head reconstructed the old code and confirmed the **new test now FAILS against it** (78/82) with the exact production symptom — so the test is faithful, not re-mocked. Fixed code: shellcheck clean, harness 82/82.