### PR TITLE
docs(infra): install jq+curl in runner runbook, not just verify

### DIFF
--- a/infra/runner-installation-runbook.md
+++ b/infra/runner-installation-runbook.md
@@ -42,10 +42,11 @@ Rationale: `--system` (no aging, low uid), `--shell /usr/sbin/nologin` (no inter
 
 The runner agent registers against the repo with the `pi` label (matching `runs-on: [self-hosted, pi]` in `deploy-prod.yml`) and runs as a **system** systemd service under `gha-runner`.
 
-**Prerequisites** — the deploy workflow's CI/image gates use `curl` + `jq` (NOT `gh`), so both must be present on the runner host. Verify (install via the distro package manager if missing):
+**Prerequisites** — the deploy workflow's CI/image gates pipe `curl | jq` (NOT `gh`), so both must be present on the runner host. The very first go-live failed on a missing `jq`, so install them explicitly rather than only verifying:
 
 ```bash
-ssh "$PI_HOST" 'command -v curl jq'   # both must resolve; install with: sudo apt-get install -y curl jq
+ssh "$PI_HOST" 'sudo apt-get update && sudo apt-get install -y jq curl'
+ssh "$PI_HOST" 'command -v jq curl'   # confirm both resolve after install
 ```
 
 **Install + register** — download the arm64 runner, install its OS dependencies, register, then install + start the service:


### PR DESCRIPTION
## What

Changes the runner-installation runbook's Phase 2 prerequisite step from verify-only to an explicit install of `jq` + `curl`.

## Why

The deploy automation's CI/image gates in `deploy-prod.yml` pipe `curl | jq`. The very first prod go-live failed because the self-hosted GitHub Actions runner lacked `jq` — it was fixed by manually installing it on the live runner. The runbook only *verified* the prereqs (`command -v curl jq`) and never *installed* them, so a future runner rebuild would repeat the miss.

## Change

Docs-only edit to `infra/runner-installation-runbook.md`:
- Prereq now runs `ssh "$PI_HOST" 'sudo apt-get update && sudo apt-get install -y jq curl'` (matching the doc's existing `$PI_HOST` command style).
- Keeps a `command -v jq curl` confirmation after the install so the operator still sees them present.
- Adds a one-line rationale noting the gates depend on jq+curl and that the first go-live failed on a missing jq.

The live runner is already fine; this is a procedure fix to prevent recurrence. No code, secrets, or PII.