### PR TITLE
chore(hooks): skip pre-push on main promotion; base diff on develop

### DIFF
--- a/.ai/rules/core.md
+++ b/.ai/rules/core.md
@@ -53,6 +53,13 @@ See `.ai/rules/code-review.md` for details
 - Commit logical units of work, not partial changes
 - Use conventional branches (feat/, fix/, refactor/, docs/, test/, chore/)
 
+### Branch model: `develop` (default) + `main` (prod)
+
+- The default branch is `develop`. ALL PRs target `develop` (protected: requires a PR + green CI).
+- `main` is prod and is fast-forward-only from `develop` — never commit or open PRs directly against it.
+- Promote with `make promote` (`git push origin develop:main`), which triggers the self-hosted-runner prod deploy via `deploy-prod.yml`.
+- Pushes to `main` skip the local pre-push checks: the content was already reviewed + CI-gated on `develop`, and `deploy-prod.yml` re-verifies CI for the SHA before deploying.
+
 ## Layered Architecture
 
 ```
@@ -136,8 +143,8 @@ See [Request Flow Diagram](../guides/architecture.md#why-layered) for the full s
 | Holding `pgx.Tx` open across external HTTP calls in consumers | Commit DB writes first, then call external APIs (Todoist, etc.) in a post-commit closure. Blocking the tx on network I/O stalls the connection pool and risks deadlocks |
 | `river.Client.Start(ctx)` with a timeout-derived context | River silently stops fetching jobs when its fetch-loop ctx cancels. Pass the outer root context (never `context.WithTimeout(...)`). Applies to test harnesses too — use the test's base ctx, not a per-test timeout ctx |
 | Echoing API keys or other secrets in bash commands or tool descriptions | Session transcripts persist across conversations. Read secrets inline from `.env` on the target host without emitting them: `ssh host "API_KEY=\$(grep -oP '^API_KEY=\\K.*' /path/.env) curl ..."`. Never include the literal value in a command visible to the transcript. If a secret already leaked into a transcript, rotate it |
-| Integration tests fail with "Contact X should be in list" or limit-based assertions | Test DB (`personal_crm_test`) accumulates state across runs (e.g. 255 contacts). Reduced by toolkit seeding: scope assertions to your namespace (`syntheticNS(t)`) instead of asserting over the whole list/limit window — see `.ai/patterns/synthetic-seed-toolkit.md`. For any unscoped list-bounded test: `make e2e-db` is wired into `test-e2e` but NOT into `test-integration`, so run `make e2e-db` manually before `make test-integration` if it fails. Symptom: tests pass on a fresh DB and on `main`, but fail mid-session after many runs |
-| Test failures during PR rebase work | Verify against `main` first (`git checkout main && make test-integration`) — pre-existing failures (e.g. flaky LONG_TESTS-gated scheduler rescuer tests) are not regressions from your rebase. Distinguish before debugging |
+| Integration tests fail with "Contact X should be in list" or limit-based assertions | Test DB (`personal_crm_test`) accumulates state across runs (e.g. 255 contacts). Reduced by toolkit seeding: scope assertions to your namespace (`syntheticNS(t)`) instead of asserting over the whole list/limit window — see `.ai/patterns/synthetic-seed-toolkit.md`. For any unscoped list-bounded test: `make e2e-db` is wired into `test-e2e` but NOT into `test-integration`, so run `make e2e-db` manually before `make test-integration` if it fails. Symptom: tests pass on a fresh DB and on `develop`, but fail mid-session after many runs |
+| Test failures during PR rebase work | Verify against `develop` first (`git checkout develop && make test-integration`) — pre-existing failures (e.g. flaky LONG_TESTS-gated scheduler rescuer tests) are not regressions from your rebase. Distinguish before debugging |
 | Deleting tests in one commit with "Step N adds replacements" promissory note | Delete tests in the SAME commit as their replacements, or keep old tests until the new ones land and delete in a follow-up commit. A promissory deletion stranded between commits (e.g. long agent work hits auth failure mid-task) leaves the branch in a broken-tests state |
 | Two-phase updates (`UpdateContact` → `ApplyContactByOverride`) returning a stale struct | The second write bumps `updated_at` and any columns it touches, but the struct returned from the first write is NOT refreshed. Refetch via `repo.GetContact(ctx, id)` inside the same tx after the second update, before returning. Applies to any two-phase write pattern where columns in the returned struct may change |
 | Inline comments referencing `PR #N`, `Step N`, `Decision N`, `Round-N`, plan names, or "this fix" | These metadata references rot the moment the PR merges. Strip them — keep the underlying rationale (why the code behaves this way) but drop the scaffolding (which PR / step / decision it came from). The PR description is the right home for that context. Applies to `.go`, `.sql`, and any source file comments; documentation (`.md`, `README`, `CHANGELOG`) is allowed to cite PRs |

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -17,6 +17,11 @@
 # NOT gated by should_skip_tests — it runs whenever lint is enabled (matching the
 # prior always-run-lint behavior).
 #
+# A promotion push to main (git push origin develop:main / make promote) skips all
+# of these checks: every pushed ref targets refs/heads/main, whose content was
+# already reviewed + CI-green on develop, and deploy-prod.yml re-verifies CI for the
+# SHA before deploying.
+#
 # To bypass (not recommended): git push --no-verify
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -475,8 +480,22 @@ run_phases_parallel() {
   rm -f $PHASE_TMPFILES
 }
 
+# refs_all_target_main <git-stdin-block>: 0 (true) if the block is non-empty AND
+# EVERY pushed ref's remote_ref (3rd field of `<local_ref> <local_sha>
+# <remote_ref> <remote_sha>`) is refs/heads/main. Empty input -> 1 (false): an
+# empty stdin must NOT skip. A mixed push that includes any non-main remote_ref
+# -> 1 (false): only a pure promotion to main qualifies. Pure (no git/FS calls)
+# so the phase-guard test can source the hook and assert it directly.
+refs_all_target_main() {
+  local refs="$1"
+  [[ -n "$refs" ]] || return 1
+  awk 'NF{print $3}' <<<"$refs" | grep -qv '^refs/heads/main$' && return 1
+  return 0
+}
+
 # Allow tests to source this file for unit-testing the pure functions
-# (file_in_group / any_file_in_groups) without running the hook body.
+# (file_in_group / any_file_in_groups / refs_all_target_main) without running the
+# hook body.
 if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
   return 0 2>/dev/null || true
 fi
@@ -487,6 +506,19 @@ cd "$PROJECT_ROOT"
 if [[ ! -f "$CONFIG_FILE" ]]; then
   echo "Warning: No $CONFIG_FILE found, skipping pre-push checks" >&2
   exit 0
+fi
+
+# A promotion to main (git push origin develop:main / make promote) only carries
+# content already reviewed + CI-green on develop, and deploy-prod.yml re-verifies
+# CI for the SHA before deploying — so the local pre-push checks are redundant for
+# it. If EVERY pushed ref targets refs/heads/main, skip. Guard on [ -t 0 ] so a
+# manual/terminal invocation (no git stdin) never blocks on the read.
+if [ ! -t 0 ]; then
+  _pp_refs="$(cat)"
+  if refs_all_target_main "$_pp_refs"; then
+    echo "Pre-push: promotion to main -> skipping local checks (content gated on develop CI; deploy-prod.yml re-verifies CI for the SHA)." >&2
+    exit 0
+  fi
 fi
 
 # Temp files for parallel execution results

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -165,7 +165,7 @@ any_file_under_macdaemon() {
 should_skip_tests() {
   # Case 1: No pushed files trigger tests
   local remote_branch
-  remote_branch=$(git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null) || remote_branch="origin/main"
+  remote_branch=$(git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null) || remote_branch="origin/develop"
   local pushed_files
   pushed_files=$(git diff --name-only "$remote_branch"...HEAD 2>/dev/null)
 
@@ -212,7 +212,7 @@ check_swift() {
   fi
 
   local remote_branch changed
-  remote_branch=$(git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null) || remote_branch="origin/main"
+  remote_branch=$(git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null) || remote_branch="origin/develop"
   changed=$(git diff --name-only "$remote_branch"...HEAD 2>/dev/null) || changed=""
 
   if ! any_file_under_macdaemon "$changed"; then

--- a/scripts/hooks/test/test-pre-push-phases.sh
+++ b/scripts/hooks/test/test-pre-push-phases.sh
@@ -22,6 +22,32 @@ assert_eq "test-integration -> GO"                      "GO"         "$(classify
 # Unrecognized command defaults to the GO (serial, DB-owning) lane — never concurrent.
 assert_eq "unrecognized command -> GO (safe default)"   "GO"         "$(classify_command 'make some-future-db-command')"
 
+# --- refs_all_target_main: the promotion-to-main skip predicate ---
+# Git feeds pushed refs on stdin as `<local_ref> <local_sha> <remote_ref>
+# <remote_sha>`. 0 (true) only when EVERY remote_ref is refs/heads/main.
+rc_of() { "$@"; echo $?; }   # capture a predicate's exit code as a value
+assert_eq "develop:main promotion -> skip (0)"          "0" "$(rc_of refs_all_target_main 'refs/heads/develop a refs/heads/main b')"
+assert_eq "all-main multi-ref -> skip (0)"              "0" "$(rc_of refs_all_target_main $'refs/heads/a x refs/heads/main y\nrefs/heads/b x refs/heads/main y')"
+assert_eq "feature-branch push -> run checks (1)"       "1" "$(rc_of refs_all_target_main 'refs/heads/feat/x a refs/heads/feat/x b')"
+# A mixed push that includes any non-main ref must NOT skip.
+assert_eq "mixed (main + feat) -> run checks (1)"       "1" "$(rc_of refs_all_target_main $'refs/heads/develop a refs/heads/main b\nrefs/heads/feat a refs/heads/feat b')"
+# Empty stdin must NOT skip.
+assert_eq "empty stdin -> run checks (1)"               "1" "$(rc_of refs_all_target_main '')"
+
+# --- full-hook integration: piping git's stdin exercises the real skip branch ---
+# Positive: a develop:main promotion line makes the hook exit 0 WITHOUT printing
+# the "Running checks" banner (i.e. it skips before any phase runs).
+hook_out_promotion=$(printf 'refs/heads/develop %s refs/heads/main %s\n' "$(git rev-parse HEAD)" "$(git rev-parse HEAD)" | bash scripts/hooks/pre-push 2>&1)
+hook_rc_promotion=$?
+assert_eq "promotion push -> hook exits 0"              "0" "$hook_rc_promotion"
+assert_eq "promotion push -> NO 'Running checks' banner" "0" "$(grep -c 'Running checks' <<<"$hook_out_promotion")"
+assert_eq "promotion push -> emits skip message"        "1" "$(grep -c 'promotion to main' <<<"$hook_out_promotion")"
+# Negative full-hook coverage is provided by the refs_all_target_main predicate
+# assertions above (feat / mixed / empty all -> 1 = run checks): the hook calls
+# that exact predicate, so a non-promotion push enters the normal flow. We do NOT
+# pipe a feature-branch line through the full hook here — that would proceed past
+# the skip into the real (slow) phases whenever a HEAD review log happens to exist.
+
 # --- run_phase: writes rc-file + buffers log; does NOT self-background ---
 tmpd=$(mktemp -d) || { echo "FAIL: mktemp -d failed"; exit 1; }
 


### PR DESCRIPTION
Two related pre-push hook fixes for the develop/main model, plus docs.

**1. Skip pre-push checks on a promotion to main.** `make promote` (`git push origin develop:main`) now skips the local checks: main only fast-forwards to a develop tip already reviewed + CI-green on develop, and `deploy-prod.yml` re-verifies CI for the SHA before deploying — so the local checks are pure redundancy. Implemented via a pure sourceable `refs_all_target_main()` predicate + an `[ -t 0 ]`-guarded read of git's pushed-refs stdin; only an all-`refs/heads/main` push skips (feature/mixed/empty/terminal still run).

**2. Default the pre-push diff base to `origin/develop`, not `origin/main`.** With develop the default/integration branch, a branch with no resolvable upstream (every feature branch on its FIRST push) was diffing against `origin/main` — and since develop runs ahead of main by undeployed work, that pulled unrelated changes into the range and ran their tests/Swift gate. Now it diffs against the integration branch.

**3. Docs:** document the develop/main branch model in `.ai/rules/core.md`; repoint two stale "verify against main" gotchas to develop.

Reviewed: independent review-head PASS on #1 (predicate run against 17 adversarial inputs under real grep; direct-push-to-main backstopped by deploy-prod's CI gate). #2 is the info finding review-head flagged, applied. Hook phase-guard + filters tests pass; no new shellcheck findings.