### PR TITLE
fix(e2e): fail-safe diff selection — guard spec coverage, warn on unmapped files (#474)

### DIFF
--- a/.ai/pre-push.json
+++ b/.ai/pre-push.json
@@ -7,7 +7,8 @@
     "commands": [
       { "name": "Backend lint", "command": "make lint" },
       { "name": "Frontend lint", "command": "cd frontend && bun run lint" },
-      { "name": "Repo hygiene", "command": "bash scripts/hooks/repo-hygiene-check.sh" }
+      { "name": "Repo hygiene", "command": "bash scripts/hooks/repo-hygiene-check.sh" },
+      { "name": "E2E test-map coverage", "command": "bash scripts/hooks/test-map-coverage-check.sh" }
     ]
   },
   "swift": {

--- a/.ai/rules/core.md
+++ b/.ai/rules/core.md
@@ -95,7 +95,7 @@ See [Request Flow Diagram](../guides/architecture.md#why-layered) for the full s
 | E2E test waiting for page load | Use `domcontentloaded` + `getByRole` with explicit timeout, not `networkidle` |
 | OAuth callback routes inside auth middleware | Register callback routes BEFORE `v1.Use(auth.APIKeyMiddleware)` - external providers can't include API keys |
 | String concat for OAuth redirect params | Use `url.Values{}.Encode()` for ALL redirect query params - prevents injection vulnerabilities |
-| Adding settings hooks without test-map entry | Add new hooks (e.g., use-todoist-accounts.ts) to `frontend/tests/e2e/test-map.json` with `@area:settings` |
+| Adding settings hooks (or any source) without test-map entry | Spec self-entries are now mechanically guarded — `scripts/hooks/test-map-coverage-check.sh` (pre-push LINT) fails the push if any `frontend/tests/e2e/*.spec.ts` is unmapped. An unmapped `frontend/src/`/`backend/internal/` SOURCE file is not push-blocking but produces a loud warning from `make test-e2e-diff`; add a `frontend/tests/e2e/test-map.json` entry mapping it to an `@area` to silence the warning + keep diff-selection accurate (e.g. new hooks like use-todoist-accounts.ts → `@area:settings`) |
 | Redefining helper functions in new repository files | Use existing helpers from `repository/conversions.go` (uuidToPgUUID, stringToPgText, timeToPgTimestamptz) |
 | List display and navigation use different sort defaults | Extract DEFAULT_SORT_FIELD/ORDER constants; use in useState, buildContactUrl, and detail page listContext |
 | SQL queries without ORDER BY for "unsorted" case | Always provide deterministic ordering; arbitrary DB order breaks navigation consistency |

--- a/frontend/tests/e2e/test-map.json
+++ b/frontend/tests/e2e/test-map.json
@@ -439,6 +439,10 @@
     "tags": ["@area:contacts"]
   },
   {
+    "pattern": "^frontend/tests/e2e/gchat-contact-signal\\.spec\\.ts$",
+    "tags": ["@area:contacts"]
+  },
+  {
     "pattern": "^frontend/tests/e2e/rematch-on-add-email\\.spec\\.ts$",
     "tags": ["@area:contacts", "@area:meetings"]
   },
@@ -509,5 +513,49 @@
   {
     "pattern": "^backend/migrations/032_",
     "tags": ["@area:settings"]
+  },
+  {
+    "pattern": "^backend/internal/google/gchat.*\\.go$",
+    "tags": ["@area:contacts", "@area:settings"]
+  },
+  {
+    "pattern": "^backend/internal/google/gmail.*\\.go$",
+    "tags": ["@area:imports", "@area:contacts"]
+  },
+  {
+    "pattern": "^backend/internal/google/correspondence_rederive\\.go$",
+    "tags": ["@area:imports"]
+  },
+  {
+    "pattern": "^backend/internal/db/queries/comms_message\\.sql$",
+    "tags": ["@area:imports", "@area:contacts"]
+  },
+  {
+    "pattern": "^backend/internal/repository/comms_message\\.go$",
+    "tags": ["@area:imports", "@area:contacts"]
+  },
+  {
+    "pattern": "^backend/internal/service/(email|gchat)_reconcile\\.go$",
+    "tags": ["@area:settings", "@area:contacts"]
+  },
+  {
+    "pattern": "^backend/internal/consumer/email_interaction\\.go$",
+    "tags": ["@area:contacts", "@area:overdue"]
+  },
+  {
+    "pattern": "^backend/internal/consumer/interaction_recorder\\.go$",
+    "tags": ["@area:contacts", "@area:overdue"]
+  },
+  {
+    "pattern": "^backend/internal/consumer/(aggregator_reenqueuer|comms_aggregator_reenqueuer|messages_aggregator_reenqueuer)\\.go$",
+    "tags": ["@area:imports", "@area:contacts"]
+  },
+  {
+    "pattern": "^backend/internal/messaging/aggregation/",
+    "tags": ["@area:imports", "@area:contacts"]
+  },
+  {
+    "pattern": "^backend/internal/scheduler/messaging_aggregate.*\\.go$",
+    "tags": ["@area:imports", "@area:contacts"]
   }
 ]

--- a/scripts/hooks/lib/test-map-coverage.mjs
+++ b/scripts/hooks/lib/test-map-coverage.mjs
@@ -1,0 +1,49 @@
+// test-map-coverage.mjs — the matcher behind scripts/hooks/test-map-coverage-check.sh.
+//
+// Asserts that every E2E spec file passed on argv is matched by at least one
+// `pattern` in test-map.json. The matching uses the SAME `new RegExp(pattern).test(file)`
+// construction that scripts/run-e2e-local.mjs uses, so the guard's "is this spec
+// selected?" answer is byte-identical to what the diff-selector would compute (no
+// bash/grep -E vs JS RegExp semantics drift).
+//
+// Usage:   node test-map-coverage.mjs <map-path> <spec-path...>
+// Stdout:  one unmatched spec path per line (the drift offenders).
+// Stderr:  the error message on an internal failure.
+// Exit:    0 = every spec matched; 1 = >=1 unmatched spec; 2 = internal error
+//          (fail-closed: an unreadable/unparseable map, a pattern that throws in
+//          new RegExp(), or an empty spec list all exit 2 so the guard blocks the
+//          push rather than silently passing on an empty offender list).
+import { readFileSync } from 'node:fs'
+
+function main(argv) {
+  const [mapPath, ...specPaths] = argv
+  if (!mapPath) {
+    throw new Error('usage: test-map-coverage.mjs <map-path> <spec-path...>')
+  }
+  if (specPaths.length === 0) {
+    throw new Error('no spec files provided — refusing to pass on an empty spec list')
+  }
+
+  const mapping = JSON.parse(readFileSync(mapPath, 'utf8'))
+  if (!Array.isArray(mapping)) {
+    throw new Error(`${mapPath} did not parse to a JSON array`)
+  }
+
+  // Compile every pattern up front so a bad regex fails the run (exit 2) rather
+  // than silently never matching (which would look like a drift offender, exit 1).
+  const regexes = mapping.map(rule => new RegExp(rule.pattern))
+
+  const offenders = specPaths.filter(spec => !regexes.some(re => re.test(spec)))
+
+  for (const spec of offenders) {
+    console.log(spec)
+  }
+  return offenders.length > 0 ? 1 : 0
+}
+
+try {
+  process.exit(main(process.argv.slice(2)))
+} catch (err) {
+  console.error(`test-map-coverage: ${err.message}`)
+  process.exit(2)
+}

--- a/scripts/hooks/lib/test-map-coverage.mjs
+++ b/scripts/hooks/lib/test-map-coverage.mjs
@@ -31,7 +31,16 @@ function main(argv) {
 
   // Compile every pattern up front so a bad regex fails the run (exit 2) rather
   // than silently never matching (which would look like a drift offender, exit 1).
-  const regexes = mapping.map(rule => new RegExp(rule.pattern))
+  // Validate the rule shape FIRST: a rule with no `pattern` (or a non-string one)
+  // would otherwise become `new RegExp(undefined)` — a valid match-ALL regex that
+  // marks every spec covered and fails OPEN (exit 0). Reject it so a malformed map
+  // entry fails closed (exit 2).
+  const regexes = mapping.map((rule, i) => {
+    if (typeof rule?.pattern !== 'string') {
+      throw new Error(`${mapPath}: rule[${i}] has a missing or non-string "pattern"`)
+    }
+    return new RegExp(rule.pattern)
+  })
 
   const offenders = specPaths.filter(spec => !regexes.some(re => re.test(spec)))
 

--- a/scripts/hooks/test-map-coverage-check.sh
+++ b/scripts/hooks/test-map-coverage-check.sh
@@ -26,12 +26,14 @@
 set -uo pipefail
 
 run_test_map_coverage() {
+  # Optional $1 overrides the map path. Production callers pass nothing (the guard
+  # body and the pre-push command both invoke it with no args); only the self-test
+  # passes an injected map so it can drive this real wrapper (incl. its
+  # command-substitution rc-capture below) against a malformed map. Using a function
+  # parameter rather than an env var avoids an exported-in-a-dev-shell footgun.
   local repo_root map specs offenders rc
   repo_root="$(git rev-parse --show-toplevel)"
-  # TEST_MAP_PATH lets the self-test drive this real wrapper (incl. its
-  # command-substitution rc-capture below) against an injected malformed map,
-  # so the fail-closed branch is exercised end-to-end and not just reimplemented.
-  map="${TEST_MAP_PATH:-$repo_root/frontend/tests/e2e/test-map.json}"
+  map="${1:-$repo_root/frontend/tests/e2e/test-map.json}"
 
   # Tracked top-level specs only. An untracked new spec is in-progress work and
   # shouldn't block; once committed it's caught. The glob is non-recursive so

--- a/scripts/hooks/test-map-coverage-check.sh
+++ b/scripts/hooks/test-map-coverage-check.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# test-map-coverage-check.sh — guards E2E test-map spec self-coverage in the
+# pre-push LINT phase (which runs unconditionally, NOT gated by should_skip_tests
+# — so the gate fires even on a frontend-test-only push, which is exactly when a
+# spec self-entry can drift). Converts the hand-patched core.md gotcha ("Adding
+# settings hooks without test-map entry") into a mechanical gate.
+#
+# Invariant: every tracked frontend/tests/e2e/*.spec.ts (top-level, excluding
+# helpers/) is matched by at least one `pattern` in test-map.json. A spec with no
+# matching pattern means editing that test never selects it in test-e2e-diff — a
+# uniquely bad, silent failure mode this guard makes loud.
+#
+# The actual regex matching lives in scripts/hooks/lib/test-map-coverage.mjs and
+# uses JS `new RegExp(pattern).test(file)` — the same construction run-e2e-local.mjs
+# uses — so the guard's answer is byte-identical to the diff-selector's. The module
+# distinguishes exit 0 (all matched), 1 (offenders on stdout), 2 (internal error).
+#
+# Fail-closed: this wrapper captures the module's exit code explicitly and treats
+# ANY non-zero rc as push-blocking. It never infers pass/fail from whether stdout
+# was empty (an empty stdout under rc=2 is an error, not a pass) — so a malformed
+# test-map.json, an invalid regex, a missing spec list, or a missing `node` all
+# block the push instead of silently passing.
+#
+# Sourceable: when sourced (BASH_SOURCE != $0) it only defines functions, so the
+# logic can be unit-tested with injected input (see test/test-test-map-coverage-check.sh).
+set -uo pipefail
+
+run_test_map_coverage() {
+  local repo_root map specs offenders rc
+  repo_root="$(git rev-parse --show-toplevel)"
+  map="$repo_root/frontend/tests/e2e/test-map.json"
+
+  # Tracked top-level specs only. An untracked new spec is in-progress work and
+  # shouldn't block; once committed it's caught. The glob is non-recursive so
+  # helpers/** is excluded.
+  specs="$(git -C "$repo_root" ls-files 'frontend/tests/e2e/*.spec.ts')"
+  if [ -z "$specs" ]; then
+    # The repo always has specs — an empty list means a broken invocation. Fail closed.
+    echo "test-map coverage: no e2e spec files found via git ls-files — refusing to pass" >&2
+    return 1
+  fi
+
+  # Capture stdout (offenders) and the explicit exit code. Word-splitting $specs
+  # into argv is intentional (paths have no spaces).
+  # shellcheck disable=SC2086
+  offenders="$(node "$repo_root/scripts/hooks/lib/test-map-coverage.mjs" "$map" $specs)"
+  rc=$?
+
+  case "$rc" in
+    0)
+      return 0
+      ;;
+    1)
+      echo "e2e test-map: spec file(s) not matched by any test-map.json pattern — editing them won't select them in test-e2e-diff. Add a self-entry:" >&2
+      echo "$offenders" | sed 's/^/  - /' >&2
+      return 1
+      ;;
+    *)
+      # rc=2 (internal error) or any other non-{0,1} value — the module already
+      # printed the cause to stderr. Fail closed; never treat an error as a pass.
+      echo "e2e test-map: coverage check failed to run (see error above)" >&2
+      return 1
+      ;;
+  esac
+}
+
+# Source-guard: run the gate only when executed directly, not when sourced by tests.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  run_test_map_coverage
+fi

--- a/scripts/hooks/test-map-coverage-check.sh
+++ b/scripts/hooks/test-map-coverage-check.sh
@@ -28,7 +28,10 @@ set -uo pipefail
 run_test_map_coverage() {
   local repo_root map specs offenders rc
   repo_root="$(git rev-parse --show-toplevel)"
-  map="$repo_root/frontend/tests/e2e/test-map.json"
+  # TEST_MAP_PATH lets the self-test drive this real wrapper (incl. its
+  # command-substitution rc-capture below) against an injected malformed map,
+  # so the fail-closed branch is exercised end-to-end and not just reimplemented.
+  map="${TEST_MAP_PATH:-$repo_root/frontend/tests/e2e/test-map.json}"
 
   # Tracked top-level specs only. An untracked new spec is in-progress work and
   # shouldn't block; once committed it's caught. The glob is non-recursive so

--- a/scripts/hooks/test/test-pre-push-filters.sh
+++ b/scripts/hooks/test/test-pre-push-filters.sh
@@ -112,5 +112,9 @@ echo "--- Makefile adaptive -p / CI-pin render guard ---"
 bash scripts/ci/test-parallelism-render-guard.sh || fail=1
 echo "--- repo-hygiene check guard ---"
 bash scripts/hooks/test/test-repo-hygiene-check.sh || fail=1
+echo "--- e2e test-map coverage guard ---"
+bash scripts/hooks/test/test-test-map-coverage-check.sh || fail=1
+echo "--- run-e2e-local warning behavior ---"
+bash scripts/hooks/test/test-run-e2e-warning.sh || fail=1
 
 [[ "$fail" -eq 0 ]] && { echo "ALL PASS"; exit 0; } || { echo "FAILURES"; exit 1; }

--- a/scripts/hooks/test/test-run-e2e-warning.sh
+++ b/scripts/hooks/test/test-run-e2e-warning.sh
@@ -76,14 +76,20 @@ stderr2="$(cat "$stderr2_file")"
 assert_contains "resolver falls back to origin/develop -> warns on unmapped file" "$stderr2" "backend/internal/foo.go"
 assert_contains "resolver fallback still selects mapped tag"                       "$stdout2" "@area:contacts"
 
-# --- no base ref at all (bare clone): must NOT crash, degrades to empty diff ---
+# --- no base ref at all (bare clone): must NOT crash, degrades to empty diff,
+#     AND must WARN that the base diff failed ---
 # Remove origin/develop; with no upstream and no origin/develop/origin/main, the
 # resolver returns origin/main (nonexistent) and the git diff against it must be
-# swallowed to an empty changed set rather than crashing the script.
+# swallowed to an empty changed set rather than crashing the script — but the
+# catch-block must announce the degradation on stderr (this pins that warning
+# against a silent-deletion regression).
 git -C "$tmp" update-ref -d refs/remotes/origin/develop
-stdout3="$(cd "$tmp" && E2E_PRINT_ONLY=1 node "$SCRIPT" 2>/dev/null)"; rc3=$?
+stderr3_file="$tmp/stderr3.txt"
+stdout3="$(cd "$tmp" && E2E_PRINT_ONLY=1 node "$SCRIPT" 2>"$stderr3_file")"; rc3=$?
+stderr3="$(cat "$stderr3_file")"
 assert_eq() { if [[ "$2" == "$3" ]]; then echo "ok: $1"; else echo "FAIL: $1 (expected '$2', got '$3')"; fail=1; fi; }
 assert_eq       "no base ref -> script exits 0 (no crash)" "0" "$rc3"
 assert_contains "no base ref -> still emits a grep pattern (at least @smoke)" "$stdout3" "@smoke"
+assert_contains "no base ref -> WARNS that the base diff failed" "$stderr3" "diff-selection is treating it as no changes"
 
 [[ "$fail" -eq 0 ]] && { echo "ALL PASS"; exit 0; } || { echo "FAILURES"; exit 1; }

--- a/scripts/hooks/test/test-run-e2e-warning.sh
+++ b/scripts/hooks/test/test-run-e2e-warning.sh
@@ -64,4 +64,26 @@ assert_not_contains "does NOT warn on mapped frontend/src file"      "$stderr" "
 assert_contains     "stdout grep pattern carries the mapped tag"     "$stdout" "@area:contacts"
 assert_not_contains "stdout is pure (no warning text leaked to it)"  "$stdout" "WARNING"
 
+# --- base-ref resolver fallback (NO E2E_BASE_REF) ---
+# With E2E_BASE_REF unset and no tracked upstream, the resolver falls back to the
+# first existing ref in origin/develop -> origin/main. Create an origin/develop ref
+# pointing at BASE so the resolver picks it up; the diff over BASE...HEAD then sees
+# the same controlled changes, so the warning still fires on the unmapped file.
+git -C "$tmp" update-ref refs/remotes/origin/develop "$BASE"
+stderr2_file="$tmp/stderr2.txt"
+stdout2="$(cd "$tmp" && E2E_PRINT_ONLY=1 node "$SCRIPT" 2>"$stderr2_file")"
+stderr2="$(cat "$stderr2_file")"
+assert_contains "resolver falls back to origin/develop -> warns on unmapped file" "$stderr2" "backend/internal/foo.go"
+assert_contains "resolver fallback still selects mapped tag"                       "$stdout2" "@area:contacts"
+
+# --- no base ref at all (bare clone): must NOT crash, degrades to empty diff ---
+# Remove origin/develop; with no upstream and no origin/develop/origin/main, the
+# resolver returns origin/main (nonexistent) and the git diff against it must be
+# swallowed to an empty changed set rather than crashing the script.
+git -C "$tmp" update-ref -d refs/remotes/origin/develop
+stdout3="$(cd "$tmp" && E2E_PRINT_ONLY=1 node "$SCRIPT" 2>/dev/null)"; rc3=$?
+assert_eq() { if [[ "$2" == "$3" ]]; then echo "ok: $1"; else echo "FAIL: $1 (expected '$2', got '$3')"; fail=1; fi; }
+assert_eq       "no base ref -> script exits 0 (no crash)" "0" "$rc3"
+assert_contains "no base ref -> still emits a grep pattern (at least @smoke)" "$stdout3" "@smoke"
+
 [[ "$fail" -eq 0 ]] && { echo "ALL PASS"; exit 0; } || { echo "FAILURES"; exit 1; }

--- a/scripts/hooks/test/test-run-e2e-warning.sh
+++ b/scripts/hooks/test/test-run-e2e-warning.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Unit test for the warn-on-unmatched-files behavior in scripts/run-e2e-local.mjs.
+#
+# Stands up a throwaway git repo (mktemp -d) with a minimal test-map.json, a base
+# commit, and a controlled diff (one MAPPED frontend/src file + one UNMAPPED
+# backend/internal file), then runs the real run-e2e-local.mjs with E2E_PRINT_ONLY=1
+# (so it computes selection + warning and exits WITHOUT spawning make/Playwright) and
+# E2E_BASE_REF pinned to the base commit (so the diff is deterministic, independent of
+# the live repo's git state). Asserts:
+#   - stderr lists the unmapped backend/internal file (warned)
+#   - stderr does NOT list the mapped frontend/src file (not warned)
+#   - stdout (the grep pattern) carries the mapped file's tag
+#   - stdout contains NO warning text (stdout-purity guard for the unconditional
+#     warning-under-print-only decision: the warning must live on stderr only)
+set -u
+cd "$(dirname "${BASH_SOURCE[0]}")/../../.." || exit 1   # repo root of THIS repo
+SCRIPT="$(pwd)/scripts/run-e2e-local.mjs"
+
+fail=0
+assert_contains() {
+  # assert_contains <desc> <haystack> <needle>
+  if [[ "$2" == *"$3"* ]]; then echo "ok: $1"; else echo "FAIL: $1 (missing '$3')"; fail=1; fi
+}
+assert_not_contains() {
+  # assert_not_contains <desc> <haystack> <needle>
+  if [[ "$2" != *"$3"* ]]; then echo "ok: $1"; else echo "FAIL: $1 (unexpectedly found '$3')"; fail=1; fi
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# --- seed a throwaway repo ---
+git -C "$tmp" init -q
+git -C "$tmp" config user.email test@example.com
+git -C "$tmp" config user.name "test"
+git -C "$tmp" config commit.gpgsign false
+
+mkdir -p "$tmp/frontend/tests/e2e" "$tmp/frontend/src/app/contacts" "$tmp/backend/internal"
+cat > "$tmp/frontend/tests/e2e/test-map.json" <<'JSON'
+[
+  { "pattern": "^frontend/src/app/contacts/", "tags": ["@area:contacts"] }
+]
+JSON
+# A tracked baseline file so the repo has an initial commit to diff against.
+echo "seed" > "$tmp/README.md"
+git -C "$tmp" add -A
+git -C "$tmp" commit -qm "base"
+BASE="$(git -C "$tmp" rev-parse HEAD)"
+
+# --- controlled diff on top of the base ---
+# Mapped change (frontend/src -> @area:contacts) and unmapped change (backend/internal).
+echo "export const x = 1" > "$tmp/frontend/src/app/contacts/x.ts"
+echo "package internal" > "$tmp/backend/internal/foo.go"
+git -C "$tmp" add -A
+git -C "$tmp" commit -qm "change"
+
+# --- run the real selector in print-only mode against the pinned base ---
+stderr_file="$tmp/stderr.txt"
+stdout="$(cd "$tmp" && E2E_PRINT_ONLY=1 E2E_BASE_REF="$BASE" node "$SCRIPT" 2>"$stderr_file")"
+stderr="$(cat "$stderr_file")"
+
+assert_contains     "warns on unmapped backend/internal file"        "$stderr" "backend/internal/foo.go"
+assert_not_contains "does NOT warn on mapped frontend/src file"      "$stderr" "frontend/src/app/contacts/x.ts"
+assert_contains     "stdout grep pattern carries the mapped tag"     "$stdout" "@area:contacts"
+assert_not_contains "stdout is pure (no warning text leaked to it)"  "$stdout" "WARNING"
+
+[[ "$fail" -eq 0 ]] && { echo "ALL PASS"; exit 0; } || { echo "FAILURES"; exit 1; }

--- a/scripts/hooks/test/test-test-map-coverage-check.sh
+++ b/scripts/hooks/test/test-test-map-coverage-check.sh
@@ -96,14 +96,14 @@ node "$MODULE" "$tmp/does-not-exist.json" "frontend/tests/e2e/contacts.spec.ts" 
 assert_eq "missing map file -> exit 2 (fail-closed)" "2" "$rc"
 
 # Wrapper fail-closed: drive the REAL run_test_map_coverage (sourced above) against
-# an injected map via TEST_MAP_PATH. This exercises the actual command-substitution
-# rc-capture (`offenders="$(node ...)"; rc=$?; case "$rc"`) in the guard — not a
-# reimplementation — so a future regression in that path is caught here. The guard
-# still reads the live tracked spec list via git ls-files, which all map cleanly,
-# so the verdict is driven entirely by the injected map's validity.
-TEST_MAP_PATH="$tmp/bad-json.json" run_test_map_coverage >/dev/null 2>&1; rc=$?
+# an injected map passed as its optional $1. This exercises the actual command-
+# substitution rc-capture (`offenders="$(node ...)"; rc=$?; case "$rc"`) in the guard
+# — not a reimplementation — so a future regression in that path is caught here. The
+# guard still reads the live tracked spec list via git ls-files, which all map
+# cleanly, so the verdict is driven entirely by the injected map's validity.
+run_test_map_coverage "$tmp/bad-json.json" >/dev/null 2>&1; rc=$?
 assert_eq "wrapper: malformed-JSON map -> non-zero verdict (blocks push)" "1" "$rc"
-TEST_MAP_PATH="$tmp/missing-pattern.json" run_test_map_coverage >/dev/null 2>&1; rc=$?
+run_test_map_coverage "$tmp/missing-pattern.json" >/dev/null 2>&1; rc=$?
 assert_eq "wrapper: map with patternless rule -> non-zero verdict (blocks push)" "1" "$rc"
 
 # Live-repo regression guard: after the Step-1 backfill the real guard exits 0.

--- a/scripts/hooks/test/test-test-map-coverage-check.sh
+++ b/scripts/hooks/test/test-test-map-coverage-check.sh
@@ -106,6 +106,22 @@ assert_eq "wrapper: malformed-JSON map -> non-zero verdict (blocks push)" "1" "$
 run_test_map_coverage "$tmp/missing-pattern.json" >/dev/null 2>&1; rc=$?
 assert_eq "wrapper: map with patternless rule -> non-zero verdict (blocks push)" "1" "$rc"
 
+# Wrapper offenders path (rc=1 — the case the guard EXISTS to catch): drive the
+# real wrapper against a VALID map that is the live map MINUS the gchat self-entry,
+# so the live git-ls-files spec list contains one spec the map no longer covers.
+# This exercises the wrapper's offenders branch end-to-end (not just the module),
+# proving an unmapped live spec actually blocks the push — a regression making the
+# rc=1 branch fall through to 0 would be caught here, not just by the all-pass guard.
+node -e "
+const fs=require('fs');
+const m=JSON.parse(fs.readFileSync('frontend/tests/e2e/test-map.json','utf8'));
+const dropped=m.filter(r=>r.pattern!=='^frontend/tests/e2e/gchat-contact-signal\\\\.spec\\\\.ts\$');
+if (dropped.length !== m.length-1) { console.error('fixture setup error: expected to drop exactly 1 entry'); process.exit(3); }
+fs.writeFileSync('$tmp/map-missing-gchat.json', JSON.stringify(dropped));
+"
+run_test_map_coverage "$tmp/map-missing-gchat.json" >/dev/null 2>&1; rc=$?
+assert_eq "wrapper: valid map missing a live spec entry -> rc=1 (offenders block push)" "1" "$rc"
+
 # Live-repo regression guard: after the Step-1 backfill the real guard exits 0.
 if run_test_map_coverage >/dev/null 2>&1; then
   echo "ok: live repo passes test-map coverage (all specs self-mapped)"

--- a/scripts/hooks/test/test-test-map-coverage-check.sh
+++ b/scripts/hooks/test/test-test-map-coverage-check.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Unit tests for scripts/hooks/test-map-coverage-check.sh and its matcher module
+# scripts/hooks/lib/test-map-coverage.mjs. Drives the module directly with temp
+# fixtures (a fixture test-map.json + fixture spec paths on argv) so the matching
+# semantics and the fail-closed exit codes are pinned, then confirms the live repo
+# passes the guard. No real push.
+set -u
+cd "$(dirname "${BASH_SOURCE[0]}")/../../.." || exit 1   # repo root
+source scripts/hooks/test-map-coverage-check.sh          # source-guard prevents the gate body
+
+MODULE="scripts/hooks/lib/test-map-coverage.mjs"
+
+fail=0
+assert_eq() {
+  # assert_eq <desc> <expected> <actual>
+  if [[ "$2" == "$3" ]]; then echo "ok: $1"; else echo "FAIL: $1 (expected '$2', got '$3')"; fail=1; fi
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# A representative fixture map mirroring the real conventions: single-file anchored
+# entries plus the imports glob whose JS-RegExp semantics the guard relies on.
+cat > "$tmp/map.json" <<'JSON'
+[
+  { "pattern": "^frontend/tests/e2e/contacts\\.spec\\.ts$", "tags": ["@area:contacts"] },
+  { "pattern": "^frontend/tests/e2e/imports(-[a-z]+)*\\.spec\\.ts$", "tags": ["@area:imports"] }
+]
+JSON
+
+# (a) a spec WITH a self-entry -> not an offender, exit 0.
+out="$(node "$MODULE" "$tmp/map.json" "frontend/tests/e2e/contacts.spec.ts")"; rc=$?
+assert_eq "matched spec -> exit 0" "0" "$rc"
+assert_eq "matched spec -> no offenders printed" "" "$out"
+
+# (b) a spec with NO entry -> printed as an offender, exit 1.
+out="$(node "$MODULE" "$tmp/map.json" "frontend/tests/e2e/gchat-contact-signal.spec.ts")"; rc=$?
+assert_eq "unmatched spec -> exit 1" "1" "$rc"
+assert_eq "unmatched spec -> printed as offender" "frontend/tests/e2e/gchat-contact-signal.spec.ts" "$out"
+
+# (c) imports-foo.spec.ts against the imports(-[a-z]+)* glob -> matched (pins the
+# JS-RegExp glob semantics the guard depends on; bash grep -E would differ).
+out="$(node "$MODULE" "$tmp/map.json" "frontend/tests/e2e/imports-correspondence.spec.ts")"; rc=$?
+assert_eq "imports-foo glob -> matched, exit 0" "0" "$rc"
+
+# Mixed list: one matched + one not -> only the unmatched one is an offender, exit 1.
+out="$(node "$MODULE" "$tmp/map.json" "frontend/tests/e2e/contacts.spec.ts" "frontend/tests/e2e/orphan.spec.ts")"; rc=$?
+assert_eq "mixed list -> exit 1" "1" "$rc"
+assert_eq "mixed list -> only unmatched offender printed" "frontend/tests/e2e/orphan.spec.ts" "$out"
+
+# (d) fail-closed: invalid-JSON map -> module exit 2 (NOT 1), stderr non-empty.
+echo '{ this is not json' > "$tmp/bad-json.json"
+out="$(node "$MODULE" "$tmp/bad-json.json" "frontend/tests/e2e/contacts.spec.ts" 2>/dev/null)"; rc=$?
+assert_eq "invalid-JSON map -> exit 2 (fail-closed)" "2" "$rc"
+
+# (d) fail-closed: a syntactically-bad regex pattern -> module exit 2.
+cat > "$tmp/bad-regex.json" <<'JSON'
+[
+  { "pattern": "(", "tags": ["@area:contacts"] }
+]
+JSON
+node "$MODULE" "$tmp/bad-regex.json" "frontend/tests/e2e/contacts.spec.ts" >/dev/null 2>&1; rc=$?
+assert_eq "bad regex pattern -> exit 2 (fail-closed)" "2" "$rc"
+
+# (d) fail-closed: a map that parses but is not an array -> module exit 2.
+echo '{ "pattern": "x" }' > "$tmp/not-array.json"
+node "$MODULE" "$tmp/not-array.json" "frontend/tests/e2e/contacts.spec.ts" >/dev/null 2>&1; rc=$?
+assert_eq "non-array map -> exit 2 (fail-closed)" "2" "$rc"
+
+# (e) empty spec list (no spec argv) -> module exit 2.
+node "$MODULE" "$tmp/map.json" >/dev/null 2>&1; rc=$?
+assert_eq "empty spec list -> exit 2 (fail-closed)" "2" "$rc"
+
+# Missing map file -> module exit 2.
+node "$MODULE" "$tmp/does-not-exist.json" "frontend/tests/e2e/contacts.spec.ts" >/dev/null 2>&1; rc=$?
+assert_eq "missing map file -> exit 2 (fail-closed)" "2" "$rc"
+
+# Wrapper fail-closed: the bash guard must map a non-{0,1} module rc to a non-zero
+# return (never treat an internal error as a pass). We invoke the guard's exact
+# module-call shape against the malformed map and assert the rc-branch verdict.
+# This mirrors run_test_map_coverage's `node ... ; rc=$?; case rc` logic.
+guard_verdict_for_map() {
+  # guard_verdict_for_map <map> <spec...> -> returns the verdict rc the wrapper would return
+  local map="$1"; shift
+  local rc
+  node "$MODULE" "$map" "$@" >/dev/null 2>&1; rc=$?
+  case "$rc" in
+    0) return 0 ;;
+    1) return 1 ;;
+    *) return 1 ;;  # fail-closed: any other rc blocks the push
+  esac
+}
+guard_verdict_for_map "$tmp/bad-json.json" "frontend/tests/e2e/contacts.spec.ts" >/dev/null 2>&1; rc=$?
+assert_eq "wrapper: malformed map -> non-zero verdict (blocks push)" "1" "$rc"
+guard_verdict_for_map "$tmp/map.json" "frontend/tests/e2e/contacts.spec.ts" >/dev/null 2>&1; rc=$?
+assert_eq "wrapper: clean map+matched spec -> zero verdict (passes)" "0" "$rc"
+
+# Live-repo regression guard: after the Step-1 backfill the real guard exits 0.
+if run_test_map_coverage >/dev/null 2>&1; then
+  echo "ok: live repo passes test-map coverage (all specs self-mapped)"
+else
+  echo "FAIL: live repo has an e2e spec with no test-map.json self-entry"
+  fail=1
+fi
+
+[[ "$fail" -eq 0 ]] && { echo "ALL PASS"; exit 0; } || { echo "FAILURES"; exit 1; }

--- a/scripts/hooks/test/test-test-map-coverage-check.sh
+++ b/scripts/hooks/test/test-test-map-coverage-check.sh
@@ -67,6 +67,26 @@ echo '{ "pattern": "x" }' > "$tmp/not-array.json"
 node "$MODULE" "$tmp/not-array.json" "frontend/tests/e2e/contacts.spec.ts" >/dev/null 2>&1; rc=$?
 assert_eq "non-array map -> exit 2 (fail-closed)" "2" "$rc"
 
+# (d) fail-closed: a rule with NO "pattern" key would otherwise become
+# new RegExp(undefined) — a match-ALL regex that marks every spec covered and
+# fails OPEN. It must exit 2 instead.
+cat > "$tmp/missing-pattern.json" <<'JSON'
+[
+  { "tags": ["@area:contacts"] }
+]
+JSON
+node "$MODULE" "$tmp/missing-pattern.json" "frontend/tests/e2e/contacts.spec.ts" >/dev/null 2>&1; rc=$?
+assert_eq "rule missing pattern -> exit 2 (fail-closed, no match-all)" "2" "$rc"
+
+# (d) fail-closed: a rule whose "pattern" is a non-string -> exit 2.
+cat > "$tmp/nonstring-pattern.json" <<'JSON'
+[
+  { "pattern": 123, "tags": ["@area:contacts"] }
+]
+JSON
+node "$MODULE" "$tmp/nonstring-pattern.json" "frontend/tests/e2e/contacts.spec.ts" >/dev/null 2>&1; rc=$?
+assert_eq "rule non-string pattern -> exit 2 (fail-closed)" "2" "$rc"
+
 # (e) empty spec list (no spec argv) -> module exit 2.
 node "$MODULE" "$tmp/map.json" >/dev/null 2>&1; rc=$?
 assert_eq "empty spec list -> exit 2 (fail-closed)" "2" "$rc"
@@ -75,25 +95,16 @@ assert_eq "empty spec list -> exit 2 (fail-closed)" "2" "$rc"
 node "$MODULE" "$tmp/does-not-exist.json" "frontend/tests/e2e/contacts.spec.ts" >/dev/null 2>&1; rc=$?
 assert_eq "missing map file -> exit 2 (fail-closed)" "2" "$rc"
 
-# Wrapper fail-closed: the bash guard must map a non-{0,1} module rc to a non-zero
-# return (never treat an internal error as a pass). We invoke the guard's exact
-# module-call shape against the malformed map and assert the rc-branch verdict.
-# This mirrors run_test_map_coverage's `node ... ; rc=$?; case rc` logic.
-guard_verdict_for_map() {
-  # guard_verdict_for_map <map> <spec...> -> returns the verdict rc the wrapper would return
-  local map="$1"; shift
-  local rc
-  node "$MODULE" "$map" "$@" >/dev/null 2>&1; rc=$?
-  case "$rc" in
-    0) return 0 ;;
-    1) return 1 ;;
-    *) return 1 ;;  # fail-closed: any other rc blocks the push
-  esac
-}
-guard_verdict_for_map "$tmp/bad-json.json" "frontend/tests/e2e/contacts.spec.ts" >/dev/null 2>&1; rc=$?
-assert_eq "wrapper: malformed map -> non-zero verdict (blocks push)" "1" "$rc"
-guard_verdict_for_map "$tmp/map.json" "frontend/tests/e2e/contacts.spec.ts" >/dev/null 2>&1; rc=$?
-assert_eq "wrapper: clean map+matched spec -> zero verdict (passes)" "0" "$rc"
+# Wrapper fail-closed: drive the REAL run_test_map_coverage (sourced above) against
+# an injected map via TEST_MAP_PATH. This exercises the actual command-substitution
+# rc-capture (`offenders="$(node ...)"; rc=$?; case "$rc"`) in the guard — not a
+# reimplementation — so a future regression in that path is caught here. The guard
+# still reads the live tracked spec list via git ls-files, which all map cleanly,
+# so the verdict is driven entirely by the injected map's validity.
+TEST_MAP_PATH="$tmp/bad-json.json" run_test_map_coverage >/dev/null 2>&1; rc=$?
+assert_eq "wrapper: malformed-JSON map -> non-zero verdict (blocks push)" "1" "$rc"
+TEST_MAP_PATH="$tmp/missing-pattern.json" run_test_map_coverage >/dev/null 2>&1; rc=$?
+assert_eq "wrapper: map with patternless rule -> non-zero verdict (blocks push)" "1" "$rc"
 
 # Live-repo regression guard: after the Step-1 backfill the real guard exits 0.
 if run_test_map_coverage >/dev/null 2>&1; then

--- a/scripts/run-e2e-local.mjs
+++ b/scripts/run-e2e-local.mjs
@@ -1,8 +1,13 @@
 import { readFileSync } from 'node:fs'
-import { execSync, spawnSync } from 'node:child_process'
+import { execFileSync, spawnSync } from 'node:child_process'
 import path from 'node:path'
 
-const repoRoot = execSync('git rev-parse --show-toplevel', {
+// Run git with an argv array via execFileSync (no shell), so a ref name —
+// e.g. an operator-set E2E_BASE_REF — is never shell-interpreted.
+const git = (args, opts = {}) =>
+  execFileSync('git', args, { cwd: repoRoot, encoding: 'utf8', ...opts })
+
+const repoRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], {
   encoding: 'utf8',
   stdio: ['ignore', 'pipe', 'inherit'],
 }).trim()
@@ -10,10 +15,7 @@ const mappingPath = path.join(repoRoot, 'frontend/tests/e2e/test-map.json')
 
 const refExists = ref => {
   try {
-    execSync(`git rev-parse --verify --quiet ${ref}`, {
-      cwd: repoRoot,
-      stdio: ['ignore', 'ignore', 'ignore'],
-    })
+    git(['rev-parse', '--verify', '--quiet', ref], { stdio: ['ignore', 'ignore', 'ignore'] })
     return true
   } catch {
     return false
@@ -28,9 +30,7 @@ const refExists = ref => {
 const resolveBaseRef = () => {
   if (process.env.E2E_BASE_REF) return process.env.E2E_BASE_REF
   try {
-    const upstream = execSync('git rev-parse --abbrev-ref --symbolic-full-name @{u}', {
-      encoding: 'utf8',
-      cwd: repoRoot,
+    const upstream = git(['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}'], {
       stdio: ['ignore', 'pipe', 'ignore'],
     }).trim()
     if (upstream) return upstream
@@ -41,20 +41,16 @@ const resolveBaseRef = () => {
 }
 const baseRef = resolveBaseRef()
 
-const readChangedFiles = command => {
+const readChangedFiles = args => {
   let output
   try {
-    output = execSync(command, {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-      cwd: repoRoot,
-    }).trim()
+    output = git(args, { stdio: ['ignore', 'pipe', 'ignore'] }).trim()
   } catch {
     // A `git diff` against a base ref that doesn't exist (e.g. a bare clone with
     // neither origin/develop nor origin/main, or an invalid E2E_BASE_REF) throws.
     // Degrade to an empty changed set rather than crashing the whole run — but warn,
     // since silently dropping to @smoke would under-cover real committed changes.
-    console.error(`WARNING: test-e2e-diff — "${command}" failed; diff-selection is treating it as no changes. Selection may under-cover this push (set E2E_BASE_REF to a valid ref).`)
+    console.error(`WARNING: test-e2e-diff — "git ${args.join(' ')}" failed; diff-selection is treating it as no changes. Selection may under-cover this push (set E2E_BASE_REF to a valid ref).`)
     return []
   }
 
@@ -62,9 +58,9 @@ const readChangedFiles = command => {
 }
 
 const changedFiles = new Set([
-  ...readChangedFiles(`git diff --name-only ${baseRef}...HEAD`),
-  ...readChangedFiles('git diff --name-only'),
-  ...readChangedFiles('git diff --name-only --cached'),
+  ...readChangedFiles(['diff', '--name-only', `${baseRef}...HEAD`]),
+  ...readChangedFiles(['diff', '--name-only']),
+  ...readChangedFiles(['diff', '--name-only', '--cached']),
 ])
 
 const mapping = JSON.parse(readFileSync(mappingPath, 'utf8'))

--- a/scripts/run-e2e-local.mjs
+++ b/scripts/run-e2e-local.mjs
@@ -51,9 +51,10 @@ const readChangedFiles = command => {
     }).trim()
   } catch {
     // A `git diff` against a base ref that doesn't exist (e.g. a bare clone with
-    // neither origin/develop nor origin/main) throws. Degrade to an empty changed
-    // set — selection falls back to @smoke and the warning fires on nothing —
-    // rather than crashing the whole diff-selection run.
+    // neither origin/develop nor origin/main, or an invalid E2E_BASE_REF) throws.
+    // Degrade to an empty changed set rather than crashing the whole run — but warn,
+    // since silently dropping to @smoke would under-cover real committed changes.
+    console.error(`WARNING: test-e2e-diff — "${command}" failed; diff-selection is treating it as no changes. Selection may under-cover this push (set E2E_BASE_REF to a valid ref).`)
     return []
   }
 

--- a/scripts/run-e2e-local.mjs
+++ b/scripts/run-e2e-local.mjs
@@ -7,7 +7,39 @@ const repoRoot = execSync('git rev-parse --show-toplevel', {
   stdio: ['ignore', 'pipe', 'inherit'],
 }).trim()
 const mappingPath = path.join(repoRoot, 'frontend/tests/e2e/test-map.json')
-const baseRef = process.env.E2E_BASE_REF || 'origin/main'
+
+const refExists = ref => {
+  try {
+    execSync(`git rev-parse --verify --quiet ${ref}`, {
+      cwd: repoRoot,
+      stdio: ['ignore', 'ignore', 'ignore'],
+    })
+    return true
+  } catch {
+    return false
+  }
+}
+// Resolve the diff base the SAME way scripts/hooks/pre-push does (upstream branch,
+// falling back to origin/develop) so the tag selection AND the unmatched-file
+// warning below both operate over the real push range — not origin/main, which on
+// the develop-default branch model can include already-merged-to-develop work.
+// E2E_BASE_REF still overrides for CI/explicit use. The final origin/main last-resort
+// keeps baseRef a string even on a bare clone lacking origin/develop.
+const resolveBaseRef = () => {
+  if (process.env.E2E_BASE_REF) return process.env.E2E_BASE_REF
+  try {
+    const upstream = execSync('git rev-parse --abbrev-ref --symbolic-full-name @{u}', {
+      encoding: 'utf8',
+      cwd: repoRoot,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim()
+    if (upstream) return upstream
+  } catch {
+    // no tracked upstream — fall through to the develop/main chain
+  }
+  return ['origin/develop', 'origin/main'].find(refExists) || 'origin/main'
+}
+const baseRef = resolveBaseRef()
 
 const readChangedFiles = command => {
   const output = execSync(command, {
@@ -28,16 +60,34 @@ const changedFiles = new Set([
 const mapping = JSON.parse(readFileSync(mappingPath, 'utf8'))
 
 const tags = new Set(['@smoke'])
+const matchedFiles = new Set()
 
 for (const file of changedFiles) {
   for (const rule of mapping) {
     const regex = new RegExp(rule.pattern)
     if (regex.test(file)) {
+      matchedFiles.add(file)
       for (const tag of rule.tags || []) {
         tags.add(tag)
       }
     }
   }
+}
+
+// Warn-first (non-fatal): a changed frontend/src or backend/internal file that
+// matched NO pattern contributed no E2E tags, so test-e2e-diff may under-cover it.
+// Goes to stderr so it never pollutes the stdout grep-pattern contract (the
+// E2E_PRINT_ONLY consumer reads stdout) — emitted unconditionally, including under
+// E2E_PRINT_ONLY, so an author gets the signal without spawning Playwright.
+const unmatched = [...changedFiles].filter(
+  f => !matchedFiles.has(f) && (f.startsWith('frontend/src/') || f.startsWith('backend/internal/')),
+)
+if (unmatched.length) {
+  console.error('WARNING: test-e2e-diff — changed file(s) matched no test-map.json pattern, contributing no E2E tags:')
+  for (const file of unmatched) {
+    console.error(`  - ${file}`)
+  }
+  console.error('These files may be under-covered by the diff-selected run. Add a test-map.json entry to map them to an @area, or accept this (CI runs the full suite regardless).')
 }
 
 const escapeRegex = value => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')

--- a/scripts/run-e2e-local.mjs
+++ b/scripts/run-e2e-local.mjs
@@ -42,11 +42,20 @@ const resolveBaseRef = () => {
 const baseRef = resolveBaseRef()
 
 const readChangedFiles = command => {
-  const output = execSync(command, {
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'inherit'],
-    cwd: repoRoot,
-  }).trim()
+  let output
+  try {
+    output = execSync(command, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      cwd: repoRoot,
+    }).trim()
+  } catch {
+    // A `git diff` against a base ref that doesn't exist (e.g. a bare clone with
+    // neither origin/develop nor origin/main) throws. Degrade to an empty changed
+    // set — selection falls back to @smoke and the warning fires on nothing —
+    // rather than crashing the whole diff-selection run.
+    return []
+  }
 
   return output.length ? output.split('\n').map(line => line.trim()).filter(Boolean) : []
 }


### PR DESCRIPTION
## What this does

Converts the hand-patched `core.md` "settings hooks without test-map entry" prose gotcha into a mechanical gate, and makes `make test-e2e-diff` fail-safe so unmapped code stops silently degrading the pre-push E2E gate to smoke-only. Four components:

1. **Spec self-coverage guard** — `scripts/hooks/lib/test-map-coverage.mjs` (JS `RegExp` matcher, fail-closed exit codes 0/1/2) + `scripts/hooks/test-map-coverage-check.sh` (bash wrapper), wired into the pre-push **LINT** phase. Fails the push when any tracked `frontend/tests/e2e/*.spec.ts` is matched by no `pattern` in `test-map.json` (catches the gchat-style self-entry drift mechanically). Fail-closed: a malformed/unparseable map, an invalid regex, a patternless rule, an empty spec list, or a missing `node` all block the push rather than passing on an empty offender list.
2. **Warn-on-unmapped + base-ref alignment** (`scripts/run-e2e-local.mjs`) — after tag selection, a loud non-fatal stderr warning lists changed `frontend/src/**` / `backend/internal/**` files that matched no pattern (warn-first, no escalation). The diff base ref now resolves the same way the pre-push hook does (`@{u}` upstream → `origin/develop` → `origin/main`) so selection and the warning both operate over the real push range, not `origin/main`. A failed base diff degrades to an empty changed set **with a warning** instead of crashing. `git` is invoked via `execFileSync` argv (no shell) so an operator-set `E2E_BASE_REF` is never shell-interpreted.
3. **test-map backfill** — entries for the merged gmail/gchat/`comms_message`/consumer/scheduler/reconcile surfaces plus the `gchat-contact-signal.spec.ts` self-entry, so the guard and the warning both pass clean on a current checkout.
4. **core.md gotcha** — the stale "settings hooks without test-map entry" row now notes spec self-entries are mechanically guarded and unmapped source files produce a warning.

Closes #474.

## Tests

- `scripts/hooks/test/test-test-map-coverage-check.sh` — module + guard self-test: matched/unmatched/mixed specs, the `imports(-[a-z]+)*` JS-glob semantics, all fail-closed cases (invalid JSON, bad regex, non-array, patternless rule, non-string pattern, empty spec list, missing map), the real-wrapper offenders path (rc=1 blocks push), and the live-repo regression guard.
- `scripts/hooks/test/test-run-e2e-warning.sh` — warning behavior over a throwaway repo: warns on an unmapped `backend/internal` file, not on a mapped `frontend/src` file, stdout-purity under `E2E_PRINT_ONLY`, the resolver fallback chain, and the no-base-ref non-crash + failed-diff warning.
- Both ride the already-CONCURRENT-classified `test-pre-push-filters` command (no `classify_command()` change). The P1 warning coverage and the P2 wrapper-offenders case were mutation-verified during review.

## Review

Codex converged in 2 rounds (round 1: a P1 match-all fail-open on patternless map rules + 2 P2s, all fixed; round 2 PASS). A subsequent `/review-head` adversarial pass caught a P1 (the failed-base-diff warning had no test) + 2 P2s, fixed in `12386ad` and verified. The **final** review round used `/review-head` as the review gate because both Codex accounts were usage-exhausted in that window (documented failover-ladder degradation); the fixes were independently mutation-verified by the reviewer.

## Known non-blocking items

- **`gchat.*\.go` / `gmail.*\.go` `.*` matches across `/`** — intentional per plan R3/D5. These also match `_test.go` siblings; editing a backend test selects the related E2E area — a safe **over**-selection, never an under-selection, consistent with existing entries (e.g. `^backend/internal/telegram/`).
- **Wording nit** on the unmatched-file warning's "(CI runs the full suite regardless)" — accurate for the pre-push gate context; left as-is.
- **Latent comment inaccuracy** (`test-map-coverage-check.sh`) about git pathspec / non-recursive glob semantics — `helpers/` has zero specs today, so the effect is correct and fail-safe in direction; comment-only.