### PR TITLE
feat(mac-deploy): stamp CRMBuildSHA + land mac-deploy spec

### DIFF
--- a/.ai/spec/2026-06-12-mac-deploy-automation-design.md
+++ b/.ai/spec/2026-06-12-mac-deploy-automation-design.md
@@ -1,0 +1,156 @@
+# Mac Deploy Automation (self-hosted runner) — Design
+
+**Date:** 2026-06-12
+**Status:** Design firmed up — ready for implementation planning. Revised 2026-06-12 after a Codex content review (4 critical / 7 major / 5 minor findings folded in; see "Review corrections applied").
+**Author:** spengrah (brainstormed with Claude, content-reviewed with Codex)
+**Parent:** `2026-06-07-deploy-automation-design.md` (Phase A — Pi prod deploy; landed + live)
+**Relationship:** Extends the Phase A self-hosted-runner pattern to the Mac. The same `make promote` (`git push origin develop:main`) that deploys the backend to the Pi now also deploys the mac-daemon to the Mac, where relevant.
+
+## Scope
+
+Promoting `develop` to `main` auto-deploys the mac-daemon (`crm-mac`) to the Mac via a **self-hosted GitHub Actions runner**, gated on green CI, the same way Phase A deploys the backend to the Pi. Because a Mac is a personal laptop that is frequently asleep, powered off, or logged out — unlike the always-on Pi — a **launchd reconcile timer** is added as a long-offline safety net so the Mac eventually converges to `main` whenever it is next logged in. Promotes that do not touch `mac-daemon/` cause no Mac rebuild ("where relevant").
+
+This is almost entirely **ops/scripts wiring**: one idempotent reconcile script, one new CI workflow, one launchd timer, one setup script, one runbook. **No Swift or Go application-code changes** — the daemon's `install --upgrade` / `doctor` / SMAppService lifecycle is reused as-is. The one non-script change is a **build-script tweak** to stamp the built git SHA into the bundle `Info.plist` (needed for drift-proof relevance detection — see below).
+
+## Hard constraints that shape everything
+
+- **Codesign / TCC.** Full Disk Access (the daemon's read of `~/Library/Messages/chat.db`, the Messages source) survives rebuilds **only** because the codesign designated requirement is anchored to a stable local self-signed Code Signing cert whose private key lives **only in the Mac's login Keychain**. This forces "build + sign on the Mac, as the user," and rules out a CI-built artifact (CI can't reproduce that designated requirement without exporting the signing key — rejected, see Out of scope).
+- **Contacts re-prompts on every rebuild.** Per the daemon README and `deploy-mac-daemon.sh`, the **iCloud Contacts** grant does **not** survive a rebuild — TCC's Contacts subsystem re-evaluates on CDHash change regardless of the designated requirement, so the system Contacts dialog fires after **every** deploy. Messages/FDA is unaffected. This is an accepted, notified manual step, not a blocker (see "Failure & permission handling"). It is the reason an automated Mac deploy is "unattended for Messages, one-click-for-Contacts," never "fully unattended."
+- **gui-domain only.** The daemon runs as a per-user SMAppService LaunchAgent in the gui domain. Everything that manages it (codesign against the login Keychain, `launchctl bootstrap gui/$(id -u)`, SMAppService register) **must run as the logged-in user, in their login session.** Consequence: the deploy runs **only while the user is logged in** (screen-locked is fine if the login Keychain stays unlocked); it does **not** run while logged out or sitting at the pre-login screen after a reboot.
+
+## What already exists (so this design does not rebuild it)
+
+- **`scripts/deploy-mac-daemon.sh`** — builds (`make mac-daemon`), runs `crm-mac install --upgrade`, performs the SMAppService re-register-from-installed-binary workaround, and verifies the registered program path. Refuses first install (pairing is interactive). This is the build+install+verify primitive the reconcile orchestrator delegates to — reconcile does **not** build separately (it would double-build).
+- **`crm-mac` lifecycle** — `install --upgrade` (backs up the prior bundle, atomic-renames the new one in, re-registers via SMAppService), `doctor` (line-oriented health: `PASS agent_service: registered (enabled)` etc.), `status`. No daemon code change needed.
+- **`__INSTALL_PREFIX__` placeholder pattern** — the daemon's embedded LaunchAgent plist ships with a placeholder substituted at install time. The reconcile timer's plist reuses this to keep absolute paths (and the username) out of git.
+- **Phase A Pi deploy** — `deploy-prod.yml` (push:`main` → self-hosted `pi` runner → CI-conclusion gate → `deploy-artifact.sh`). The Mac deploy is a **separate** workflow (see Triggers), not a job added to that file.
+
+## Decisions locked
+
+### Architecture: three triggers, one idempotent core
+
+```
+push to main ──► deploy-mac.yml ──► deploy-mac job (runs-on: [self-hosted, mac]) ─┐
+                                                                                  ├─► reconcile-mac-daemon.sh
+launchd timer (StartCalendarInterval + RunAtLoad; runs on login + ~6h catch-up) ─┘        (the idempotent core)
+                                                                                                   │
+                  git fetch → CI gate → refresh tooling → relevance gate → upgrade → health → ntfy
+```
+
+- The **runner** handles "logged in when the push lands" (picks the job up in seconds) and "asleep/offline <24h then logs back in" (GitHub keeps the job queued up to ~24h; the runner agent drains the surviving pending run on reconnect).
+- The **timer** closes the ">24h offline, GitHub expired the queued job" gap, and the "was logged out / powered off" gap. It runs on login (`RunAtLoad`) and on a calendar catch-up.
+- Both invoke the **same** `reconcile-mac-daemon.sh`, so the two paths can never diverge — the Mac analog of Phase A's "one idempotent `deploy-artifact.sh`; the workflow merely invokes it."
+
+### Reconcile-to-`main`, not per-SHA
+
+Unlike the Pi (which deploys the exact `$GITHUB_SHA`), the Mac reconcile always converges to **current `origin/main` HEAD**. Consequences:
+
+- Several mac-touching promotes that piled up while offline collapse to **one real upgrade + no-ops** (a later/superseding run sees "already at `main`"). This holds whether GitHub supersedes the older pending run (default concurrency behavior) or stacks them — either way they converge to latest.
+- The runner job and the timer share one code path with no SHA threading.
+- The Mac is not latency-critical, so converge-to-latest is the right semantics. `main` is always CI-green by construction (it fast-forwards only from CI-gated `develop`), and reconcile still verifies the target SHA's CI before building (fail-closed).
+
+### The reconcile orchestrator (`scripts/reconcile-mac-daemon.sh`)
+
+The Mac analog of `deploy-artifact.sh`. Every step is idempotent and fail-closed:
+
+1. **Lock** — an atomic `mkdir`-based lock (macOS has **no `flock` binary**; `mkdir`/`shlock`/`lockf` are the portable options) so the runner-trigger and timer-trigger cannot race; if the lock is held, exit 0.
+2. **Fetch** — `git -C "$CLONE_DIR" fetch --quiet origin main`; target SHA = `origin/main` HEAD.
+3. **CI gate** — query `ci.yml`'s conclusion for the target SHA via `gh api`, using the **user's existing `gh` auth** (both the runner and the timer run as the user, so one auth mechanism serves both; pinned in setup). Outcomes: `success` → proceed; `failure`/`cancelled` → fail-closed with a failure ntfy; **in-progress / not-found → soft-skip (exit 0, no failure ntfy)** — the next timer tick or promote retries. (A "CI not done yet" result is never treated as a deploy failure.)
+4. **Refresh tooling** — atomically swap the installed orchestrator + delegated deploy scripts (and detect timer-plist/template changes) from the clone, effective next run. This runs **before** the relevance gate so fixes to the *deploy machinery itself* are never stranded by a daemon no-op. The relevance gate governs only whether to rebuild the **daemon**. A changed timer-plist template is surfaced via ntfy ("re-run `make setup-mac-deploy`") rather than auto-reloading launchd mid-run.
+5. **Relevance gate** ("where relevant") — read the **actually-installed** SHA from the installed bundle's `Info.plist` (`plutil -extract`/`defaults read` of the `CRMBuildSHA` key the build stamps in), then `git diff --quiet <installedSHA> <targetSHA> -- mac-daemon/`. Unchanged → **no-op, exit 0.** Reading the SHA from the bundle (not an external file) means a manual restore/downgrade/ad-hoc install **self-corrects** — an older installed bundle reports its older SHA and the diff re-fires. Missing/unparseable `CRMBuildSHA` (first automated deploy, or a dirty manual build) → treat as "must deploy."
+6. **Upgrade** — check out the target SHA into a **throwaway `git worktree`** (so the running orchestrator's own file is never rewritten under itself), then delegate to that worktree's `scripts/deploy-mac-daemon.sh` (single build → `install --upgrade` → SMAppService re-register-from-installed → registered-path verify). Reused so the hard-won SMAppService workaround lives in one place; reconcile does not pre-build.
+7. **Health gate** — run `crm-mac doctor` and parse the `agent_service` line **by content** for `registered (enabled)`. Do **not** use doctor's exit code (it equals the count of FAIL lines, so an informational `pi_reachability` FAIL from a Tailscale blip would false-fail). `launchctl print` stays a narrow registered-path guard only, never the primary health contract.
+8. **Contacts-pending check** — surface whether the Contacts grant needs re-approval (expected after every rebuild) as an **informational** outcome, not a health failure (Messages/registration is the success contract).
+9. **Stamp-by-build + notify** — the build already stamped `CRMBuildSHA` into the installed bundle (step 6), so success needs no separate stamp write. ntfy per outcome (see Notifications). **No notification on no-ops.**
+10. **Exit codes** — 0 on success, no-op, and soft-skip; non-zero only on a genuine deploy/health failure (so the runner job shows red and the failure ntfy fires).
+
+### The two triggers
+
+- **`deploy-mac.yml`** (a **separate** workflow, not a job in `deploy-prod.yml` — a Mac job there would inherit the workflow-level `concurrency: deploy-pi` and a 24h-queued Mac run could stall/supersede Pi deploys). `on: push: [main]`, `runs-on: [self-hosted, mac]`, its **own** `concurrency: deploy-mac` with `cancel-in-progress: false` (a new promote queues behind a running deploy; reconcile-to-`main` makes the queued run converge to latest), `environment: production`. **No `actions/checkout`** — it is a thin trigger that invokes the local reconcile orchestrator, which does its own fetch. **No `sudo`** — the entire Mac deploy is userland.
+- **launchd reconcile timer** — a per-user LaunchAgent (`xyz.spengrah.crm-mac-reconcile`) using **`StartCalendarInterval`** (the variant Apple documents as catching up a missed fire after wake) plus **`RunAtLoad`** (fires on login, covering reboot/power-off → next login). `StartInterval` is **not** used — contrary to a common assumption it does not coalesce sleep-missed fires. Realistic cadence: "on login + a periodic (~6h) catch-up while logged in," **not** "on every wake." Runs in the user's login session.
+
+### Source & isolation
+
+- **Dedicated canonical clone** at a fixed `$HOME`-relative path (`"${HOME}/Library/Application Support/crm-mac-deploy/repo"`), never the developer's `~/Workspaces/PersonalCRM` tree. Builds happen in a throwaway worktree at the target SHA, so the dev tree's branch/dirty state is irrelevant and untouched.
+- **`deploy.env`** alongside the clone (`chmod 600`, **not committed**) — codesign identity name + ntfy topic/URL. Same handling as the Pi's `ntfy.env`.
+- **No external stamp file** — the installed SHA is read back from the bundle's `Info.plist` (drift-proof, per the relevance gate).
+- **Git + GitHub auth** reuse the user's existing user-level git credential helper and `gh` auth (the runner and timer both run as the user, who already pushes from this Mac).
+
+### Paths & PII
+
+The project's no-PII-in-repo rule applies: **no absolute `/Users/<name>/…` paths in git.**
+
+- Committed scripts express all paths as **`$HOME`-relative** (`"${HOME}/Library/Application Support/crm-mac-deploy/…"`), matching the already-committed `deploy-mac-daemon.sh` (`"$HOME/Library/Application Support/crm-mac/crm-mac.app"`).
+- The launchd timer plist is the one place needing a literal absolute path (launchd does not expand `$HOME`/`~` in `ProgramArguments`). The **committed template** carries a `__INSTALL_PREFIX__`-style placeholder; `setup-mac-deploy.sh` substitutes the real absolute path at install time into the on-disk plist (never committed).
+- Anything genuinely machine-specific goes in the uncommitted `deploy.env`.
+
+### Failure & permission handling (alert-only)
+
+Unlike the Pi, the Mac upgrade has **no irreversible / data-loss step** (no DB migration), and `install --upgrade` already backs up the prior bundle. So the Pi's restore-first auto-rollback machinery is not justified. On a failed health gate: fire a **max-priority ntfy** with the one-command manual-restore hint and leave the backed-up prior bundle in place. (Auto-restore can be bolted on later — the backup already exists.)
+
+**Contacts (accepted manual step).** Every deploy resets the iCloud Contacts grant. Messages/FDA keeps working; the deploy is declared healthy on Messages/registration. Reconcile fires a **distinct, informational** ntfy — "Mac deployed; Contacts re-approval needed, click Allow when next at the Mac" — and Contacts ingestion resumes on the user's next Allow (the daemon auto-fires the system dialog on its next iCloud tick; no menu hunting). Contacts data lags until then; acceptable because iCloud-contact changes are low-frequency.
+
+### Notifications
+
+**ntfy**, reusing the Pi's channel convention, topic/URL from `deploy.env` (never committed). Titled pushes:
+- low-priority `Mac deploy OK` (on a real upgrade only),
+- informational `Mac deploy OK — Contacts re-approval needed` (the accepted manual step),
+- max-priority `Mac deploy FAILED` (carries the manual-restore hint).
+No push on no-ops or soft-skips.
+
+### Runner security posture (contrast with the Pi)
+
+The Mac runner is deliberately **simpler** than the Pi's locked-down posture, because the constraints invert:
+
+- **Runs as the logged-in user, in the user's login session** — required so codesign reaches the login-Keychain signing key and SMAppService can manage the gui-domain agent. A dedicated system user (the Pi's `gha-runner` model) cannot do either. The **default `svc.sh` install is not sufficient** (it is not a proven `~/Library/LaunchAgents` GUI-session install); the runbook installs a **custom user LaunchAgent that invokes the runner's `runsvc.sh`** and validates, from an actual job, both `launchctl print gui/$(id -u)` and a real SMAppService operation.
+- **No sudoers entry, no root.** Install path is under `~/Library`, launchd is the gui domain, the signing key is the user's. The runner's entire capability is "run build + install as you," which you can already do by hand.
+- **Trust boundary:** a self-hosted runner in your user session runs whatever the workflow says, as you — acceptable for a **private, single-author**, PR-gated repo; noted as a conscious choice. (Phase A keeps the repo public-runner-safe: PRs cannot reach self-hosted runners.)
+- **Codesign key ACL** must be pre-authorized for non-interactive use (`security set-key-partition-list` / the identity's key ACL allowing `codesign` without a prompt). Caveat: this does **not** unlock a *locked* Keychain — validate after reboot and after screen-lock. Builds run while logged in (login Keychain stays unlocked across a screen-lock by default).
+
+## One-time setup
+
+Mostly operational (Bucket B). Prereqs already true: the daemon is **already paired/installed** (the runner only ever does *upgrades*; first install stays manual via pairing), Xcode present, `jq`/`curl` present (install if missing), `gh` already authed as the user.
+
+1. **Register the Mac as a GH self-hosted runner**, labels `self-hosted, mac`, installed as a **custom user LaunchAgent invoking `runsvc.sh`** (not the default `svc.sh` LaunchDaemon), running in the user login session. Validate gui-domain + SMAppService access from a test job.
+2. **`make setup-mac-deploy`** (scriptable parts): create the dedicated clone; install the reconcile orchestrator to a stable path; scaffold `deploy.env` (codesign identity + ntfy); render + load the timer LaunchAgent from its template (placeholder substituted; `StartCalendarInterval` + `RunAtLoad`).
+3. **Pre-authorize the codesign signing key** for non-interactive use; validate post-reboot and post-screen-lock.
+4. **Supervised dry-run** validating against the real tools — the Phase A go-live lesson: mocked tests don't catch real-tool behavior. Specifically exercise reboot-before-login, login (`RunAtLoad` fire), and screen-locked cases.
+
+## Repo artifacts vs ops wiring
+
+- **Bucket A (committed; built via plan-and-ship):**
+  - `scripts/reconcile-mac-daemon.sh` + `scripts/reconcile-mac-daemon.test.sh`
+  - **`.github/workflows/deploy-mac.yml`** (new, separate workflow)
+  - `scripts/setup-mac-deploy.sh` + `make setup-mac-deploy`
+  - committed timer LaunchAgent **template** (placeholder; `StartCalendarInterval` + `RunAtLoad`)
+  - `infra/mac-runner-installation-runbook.md`
+  - **build-script tweak** to stamp `CRMBuildSHA` (the built git SHA) into the bundle `Info.plist` at assembly time (`mac-daemon/Scripts/assemble_bundle.sh` / the `mac-daemon` Make target) — the only non-script change; **no Swift/Go app code.**
+  - minor `scripts/deploy-mac-daemon.sh` tweaks for clean reuse (if needed)
+- **Bucket B (operational; coordinator performs on the Mac):** register the runner as a user LaunchAgent (runsvc.sh) and validate gui/SMAppService from a job; run `make setup-mac-deploy`; create `deploy.env`; pre-authorize the codesign key; load the timer; perform the supervised dry-run across login/lock/reboot cases; confirm the daemon is paired.
+
+## Testing
+
+- **`reconcile-mac-daemon.test.sh`** — mocks `git` / `gh` / `crm-mac` / `plutil` / ntfy and asserts: no-op when `mac-daemon/` is unchanged vs the bundle-reported SHA; deploys when it changed; **fail-closed** on CI `failure`; **soft-skip (exit 0, no failure ntfy)** on CI in-progress/not-found; tooling refresh happens even on a daemon no-op; max-priority ntfy on health failure; informational Contacts-pending ntfy on success; the `mkdir` lock prevents concurrent runs; no ntfy on no-ops. Mirrors `deploy-artifact.test.sh`.
+- **Mandatory supervised real dry-run** in the runbook — the Phase A go-live surfaced two real bugs a fully-mocked suite passed. Validate the real path, including login/lock/reboot, before going live.
+- Pre-push already gates the Swift suite when the range touches `mac-daemon/**`. The `CRMBuildSHA` stamp touches the bundle-assembly path, which the integration test gate (`BundleAssemblyParityTests`) covers — confirm it still passes.
+
+## Out of scope / deferred
+
+- **CI-built signed artifact (no local build).** Rejected: CI can't sign with the local self-signed cert's designated requirement, so a CI-signed bundle resets **FDA** grants every deploy and the daemon goes blind to Messages until re-granted by hand. (FDA is the differentiator here, not Contacts — Contacts already re-prompts under the accepted local-cert path.) The only ways to make CI-signing viable — export the signing key into CI secrets (a secret-exposure downgrade the user declined) or buy an Apple Developer ID — aren't worth it for a personal box. Build-and-sign-on-the-Mac stays.
+- **Auto-restore on failed upgrade.** Deferred (alert-only chosen); cheap to add later since the prior bundle is already backed up.
+- **Apple Developer ID to make Contacts persist.** Out of scope (paid; the user declined). It would remove the Contacts re-approval step entirely.
+- **Auto-reloading the timer LaunchAgent when its template changes.** Reconcile notifies and defers to `make setup-mac-deploy` rather than bootout/bootstrap-ing launchd mid-run.
+- **`crm-mac status`/`doctor` reporting the running SHA.** A nicety; reconcile reads `CRMBuildSHA` from the installed `Info.plist` directly, so the daemon needs no change.
+
+## Review corrections applied (Codex content pass, 2026-06-12)
+
+- **Critical:** `StartInterval`→`StartCalendarInterval` + `RunAtLoad` (no on-wake coalescing for `StartInterval`); separate `deploy-mac.yml` (avoid inheriting `deploy-prod.yml`'s workflow concurrency); read installed SHA from the bundle `Info.plist` instead of a drift-prone external stamp file; Contacts re-prompt is an accepted, notified manual step, not "fully unattended."
+- **Major:** `mkdir` lock (no `flock` on macOS); pin CI-gate auth to the user's `gh` for both triggers; parse `doctor`'s `agent_service` line by content (its exit code = FAIL count); install the runner as a custom user LaunchAgent via `runsvc.sh` and validate gui/SMAppService from a job; logged-out/pre-login does not run (state + test); refresh deploy tooling before the relevance gate so machinery fixes aren't stranded.
+- **Minor:** drop reconcile's redundant pre-build (delegate the single build to `deploy-mac-daemon.sh`); `set-key-partition-list` doesn't unlock a locked Keychain (validate post-reboot/lock); FDA (not Contacts) is the CI-signing differentiator; keep `launchctl print` as a narrow path-guard, not the health contract; CI-not-yet-complete is a soft-skip, not a failure.
+
+## Risks / notes
+
+- **Runner session model** remains the highest-uncertainty setup step — the `runsvc.sh`-as-user-LaunchAgent mechanism must be validated from a real job (gui-domain + SMAppService), not assumed from the default `svc.sh` path.
+- **Login Keychain availability** — codesign needs it unlocked; it stays unlocked while logged in (a screen-lock doesn't relock it by default). Pre-authorizing the key ACL removes the per-binary prompt but does not unlock a locked Keychain.
+- **Orchestrator self-update** — installed to a stable path, atomically swapped from the worktree each run (effective next run), built in a throwaway worktree so the running file is never rewritten mid-run.
+- **First automated deploy bootstraps the stamp** — the currently-installed (manually built) bundle has no `CRMBuildSHA`, so the first reconcile treats it as "must deploy" and stamps it; subsequent runs diff cleanly.

--- a/Makefile
+++ b/Makefile
@@ -333,7 +333,7 @@ crm-admin:
 mac-daemon:
 	@echo "Building crm-mac (release)..."
 	@cd mac-daemon && swift build -c release
-	@bash mac-daemon/Scripts/assemble_bundle.sh \
+	@CRM_BUILD_SHA="$$(git rev-parse HEAD)" bash mac-daemon/Scripts/assemble_bundle.sh \
 		mac-daemon/.build/release/crm-mac \
 		mac-daemon/.build/release/crm-mac.app \
 		mac-daemon/Sources/crm-mac/Info.plist

--- a/mac-daemon/Scripts/assemble_bundle.sh
+++ b/mac-daemon/Scripts/assemble_bundle.sh
@@ -22,6 +22,15 @@
 #       development rebuilds (Contacts grants still re-prompt — TCC
 #       Contacts subsystem binds to CDHash regardless of DR).
 #
+#   CRM_BUILD_SHA=<git-sha>
+#       If non-empty, stamp the assembled bundle's Contents/Info.plist
+#       with a CRMBuildSHA key carrying this value, BEFORE the codesign
+#       pass (so the key is sealed). `make mac-daemon` sets this to
+#       `git rev-parse HEAD`; the mac-deploy reconcile flow reads the
+#       key back from the installed bundle to decide whether a rebuild
+#       is needed. When unset, no key is written (the byte-identity
+#       parity test relies on this to stay deterministic).
+#
 # Output: a fully-assembled, codesigned crm-mac.app bundle at
 # <bundle_path> with:
 #
@@ -113,6 +122,17 @@ chmod +x "${BUNDLE_PATH}/Contents/MacOS/crm-mac"
 # Copy Info.plist verbatim from the source tree. This is byte-identical
 # to the source file by construction (cp(1) preserves bytes).
 cp "${INFO_PLIST_SOURCE}" "${BUNDLE_PATH}/Contents/Info.plist"
+
+# Optionally stamp the build's git SHA into Contents/Info.plist. Inserted
+# here, BEFORE the codesign pass below, so the key is under the seal. Uses
+# `plutil -replace` (inserts if absent, replaces if present — idempotent;
+# unlike `-insert`, which errors on an existing key). When CRM_BUILD_SHA is
+# unset/empty the plist is left byte-identical to the source so the
+# byte-identity parity test stays deterministic.
+if [ -n "${CRM_BUILD_SHA:-}" ]; then
+    plutil -replace CRMBuildSHA -string "${CRM_BUILD_SHA}" \
+        "${BUNDLE_PATH}/Contents/Info.plist"
+fi
 
 # Write the LaunchAgents plist. The binary path contains the
 # __INSTALL_PREFIX__ placeholder; the Swift installer substitutes the

--- a/mac-daemon/Tests/CRMMacSystemTests/BundleAssemblyParityTests.swift
+++ b/mac-daemon/Tests/CRMMacSystemTests/BundleAssemblyParityTests.swift
@@ -108,7 +108,163 @@ final class BundleAssemblyParityTests: XCTestCase {
         }
     }
 
+    // MARK: - CRMBuildSHA stamp coverage
+
+    // These two methods live INSIDE BundleAssemblyParityTests on purpose:
+    // CI's mac-daemon integration step runs
+    // `swift test --filter 'BundleAssemblyParityTests|BundleSwapAtomicityTests'`,
+    // so a separate test class would silently not run. Keeping them here
+    // means CI picks them up with no ci.yml filter change.
+
+    /// (a) Build-path stamp: `assemble_bundle.sh` writes CRMBuildSHA into
+    /// Contents/Info.plist when CRM_BUILD_SHA is set, and the key survives
+    /// under the codesign seal (it is inserted before the codesign pass).
+    func testShellAssembleStampsCRMBuildSHAUnderCodesignSeal() throws {
+        let workDir = try makeTempWorkDir()
+        defer { try? FileManager.default.removeItem(at: workDir) }
+
+        let machoSource = workDir.appendingPathComponent("crm-mac")
+        try FileManager.default.copyItem(
+            at: URL(fileURLWithPath: "/bin/echo"),
+            to: machoSource)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: machoSource.path)
+
+        let infoPlistURL = sourceInfoPlistURL()
+        let scriptURL = assembleScriptURL()
+        let bundle = workDir.appendingPathComponent("stamped-bundle.app")
+
+        let fixtureSHA = "deadbeef00000000000000000000000000000000"
+        try runShellAssemble(
+            scriptURL: scriptURL,
+            machoSource: machoSource,
+            bundlePath: bundle,
+            infoPlistSource: infoPlistURL,
+            extraEnv: ["CRM_BUILD_SHA": fixtureSHA])
+
+        // The stamped key is present and equals the fixture SHA.
+        let infoPlist = bundle.appendingPathComponent("Contents/Info.plist")
+        let extracted = try runCommand(
+            "/usr/bin/plutil",
+            ["-extract", "CRMBuildSHA", "raw", infoPlist.path])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        XCTAssertEqual(
+            extracted, fixtureSHA,
+            "assemble_bundle.sh did not stamp CRMBuildSHA into Contents/Info.plist")
+
+        // The key is under the codesign seal: a strict/deep verify still
+        // passes (the stamp was inserted before the codesign pass).
+        _ = try runCommand(
+            "/usr/bin/codesign",
+            ["--verify", "--strict", "--deep", bundle.path])
+    }
+
+    /// (b) Install-path carry-through: the `loadInfoPlistContent()`
+    /// transform `install --upgrade` uses (serialize Bundle.main's dict to
+    /// XML, feed to BundleAssembler) is key-preserving — a CRMBuildSHA in
+    /// the build-bundle dict survives into the assembled (installed) bundle
+    /// with NO Swift change. A unit test cannot mutate Bundle.main, but it
+    /// CAN drive the IDENTICAL PropertyListSerialization + BundleAssembler
+    /// the production path uses.
+    func testStampedInfoPlistSurvivesSerializeAndAssemble() throws {
+        let workDir = try makeTempWorkDir()
+        defer { try? FileManager.default.removeItem(at: workDir) }
+
+        let machoSource = workDir.appendingPathComponent("crm-mac")
+        try FileManager.default.copyItem(
+            at: URL(fileURLWithPath: "/bin/echo"),
+            to: machoSource)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: machoSource.path)
+
+        // 1. Parse the real source Info.plist into a dict and add
+        //    CRMBuildSHA, mirroring a build-stamped bundle's dict as
+        //    Bundle.main.infoDictionary would surface it.
+        let fixtureSHA = "feedface00000000000000000000000000000000"
+        let sourceBytes = try Data(contentsOf: sourceInfoPlistURL())
+        guard var dict = try PropertyListSerialization.propertyList(
+            from: sourceBytes, options: [], format: nil) as? [String: Any] else {
+            XCTFail("source Info.plist did not parse into a [String: Any] dict")
+            return
+        }
+        dict["CRMBuildSHA"] = fixtureSHA
+
+        // 2. Re-serialize via the IDENTICAL call loadInfoPlistContent() makes.
+        let serialized = try PropertyListSerialization.data(
+            fromPropertyList: dict, format: .xml, options: 0)
+
+        // 3. Feed those bytes to the real BundleAssembler (the same Swift
+        //    assembler `install --upgrade` uses). Force ad-hoc signing for
+        //    determinism, matching the byte-identity test above.
+        let buildHome = ProcessInfo.processInfo.environment["HOME"]
+            ?? "/Users/runner"
+        let launchAgentContent = Self.renderShellEquivalentLaunchAgent(
+            buildHome: buildHome)
+        let assembledBundle = workDir.appendingPathComponent("assembled-bundle.app")
+        let fs = ProductionFilesystemAdapter()
+        let exec = ProductionExecutableAdapter(signingIdentity: nil)
+        let assembler = BundleAssembler(filesystem: fs, executable: exec)
+        try assembler.assemble(BundleAssemblerInput(
+            machoSourcePath: machoSource.path,
+            bundlePath: assembledBundle.path,
+            launchAgentPlistContent: launchAgentContent,
+            infoPlistContent: serialized,
+            codesignIdentifier: Daemon.label))
+
+        // 4. The assembled (installed-equivalent) bundle STILL carries the
+        //    stamp — proving the serialize→assemble round-trip is
+        //    key-preserving, which is what carries a build-time stamp into
+        //    the installed bundle.
+        let infoPlist = assembledBundle.appendingPathComponent("Contents/Info.plist")
+        let extracted = try runCommand(
+            "/usr/bin/plutil",
+            ["-extract", "CRMBuildSHA", "raw", infoPlist.path])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        XCTAssertEqual(
+            extracted, fixtureSHA,
+            "CRMBuildSHA did not survive the serialize→assemble round-trip")
+    }
+
     // MARK: - helpers
+
+    private func sourceInfoPlistURL() -> URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // CRMMacSystemTests/
+            .deletingLastPathComponent()  // Tests/
+            .deletingLastPathComponent()  // mac-daemon/
+            .appendingPathComponent("Sources/crm-mac/Info.plist")
+    }
+
+    private func assembleScriptURL() -> URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Scripts/assemble_bundle.sh")
+    }
+
+    /// Run an executable and return stdout, failing the test on non-zero exit.
+    @discardableResult
+    private func runCommand(_ launchPath: String, _ args: [String]) throws -> String {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: launchPath)
+        proc.arguments = args
+        let outPipe = Pipe(), errPipe = Pipe()
+        proc.standardOutput = outPipe
+        proc.standardError = errPipe
+        try proc.run()
+        let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
+        let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+        proc.waitUntilExit()
+        let out = String(data: outData, encoding: .utf8) ?? ""
+        if proc.terminationStatus != 0 {
+            let err = String(data: errData, encoding: .utf8) ?? ""
+            XCTFail("\(launchPath) \(args.joined(separator: " ")) exit \(proc.terminationStatus): \(err)")
+        }
+        return out
+    }
 
     private static func renderShellEquivalentLaunchAgent(buildHome: String) -> String {
         // Mirrors the heredoc in Scripts/assemble_bundle.sh exactly.
@@ -163,7 +319,8 @@ final class BundleAssemblyParityTests: XCTestCase {
         scriptURL: URL,
         machoSource: URL,
         bundlePath: URL,
-        infoPlistSource: URL
+        infoPlistSource: URL,
+        extraEnv: [String: String] = [:]
     ) throws {
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: "/bin/bash")
@@ -175,9 +332,18 @@ final class BundleAssemblyParityTests: XCTestCase {
         ]
         // Strip CRM_MAC_CODESIGN_IDENTITY from the child env so the shell
         // script signs ad-hoc regardless of the developer's exported shell
-        // env — matches the Swift adapter pinning above.
+        // env — matches the Swift adapter pinning above. Also strip
+        // CRM_BUILD_SHA: assemble_bundle.sh stamps Contents/Info.plist when
+        // it is set, but the Swift path is fed the raw source-plist bytes
+        // (unstamped) — a developer with CRM_BUILD_SHA exported would
+        // otherwise break the byte-identity assertion on Info.plist. Tests
+        // that DO want a stamp pass it back in explicitly via `extraEnv`.
         var env = ProcessInfo.processInfo.environment
         env.removeValue(forKey: "CRM_MAC_CODESIGN_IDENTITY")
+        env.removeValue(forKey: "CRM_BUILD_SHA")
+        for (key, value) in extraEnv {
+            env[key] = value
+        }
         proc.environment = env
         let outPipe = Pipe(), errPipe = Pipe()
         proc.standardOutput = outPipe

--- a/scripts/deploy-mac-daemon.sh
+++ b/scripts/deploy-mac-daemon.sh
@@ -3,6 +3,16 @@
 #
 # Usage: ./scripts/deploy-mac-daemon.sh
 #
+# Reuse contract: the mac-deploy reconcile orchestrator
+# (scripts/reconcile-mac-daemon.sh) invokes this script in place from a
+# throwaway worktree checked out at the target SHA, i.e.
+# "$WORKTREE/scripts/deploy-mac-daemon.sh". PROJECT_DIR is derived from
+# ${BASH_SOURCE[0]} below, so it resolves to that worktree root — exactly
+# the target-SHA tree `make mac-daemon` must build from. Keep that
+# BASH_SOURCE-relative resolution and the `make mac-daemon` delegation
+# intact so the single build/install primitive stays shared between the
+# local-dev and reconcile paths.
+#
 # Required env:
 #   CRM_MAC_CODESIGN_IDENTITY=<identity>
 #       Local self-signed Code Signing certificate to sign with.


### PR DESCRIPTION
## Summary

PR1 of 4 in the **Mac deploy-automation Bucket A** plan (`.ai/log/plan/2026-06-12-mac-deploy-automation-bucketA.md`). This is the foundational PR: it lands the design spec and stamps the git SHA the rest of the chain's relevance gate depends on. PRs 2–4 (reconcile script + mocked tests, `deploy-mac.yml` + setup script + timer template, runbook) build on this and target `develop` after it merges.

This PR makes the **installed** crm-mac.app bundle carry the git SHA it was built from, via `CRMBuildSHA` in `Contents/Info.plist`, so a future reconcile orchestrator can read that key back and skip a rebuild when `mac-daemon/` is unchanged. It achieves this with **no Swift production-code change** — the stamp flows through the existing `loadInfoPlistContent()` / `PropertyListSerialization` path on `install --upgrade`.

## Changes

- **Spec doc** — `.ai/spec/2026-06-12-mac-deploy-automation-design.md` landed verbatim from the `docs/mac-deploy-automation-spec` branch (no content edits), so the rest of the plan is reviewable against an on-`develop` spec.
- **Build-time stamp** — `mac-daemon/Scripts/assemble_bundle.sh` gains an optional `CRM_BUILD_SHA` env input. When set, it writes `CRMBuildSHA` into the assembled bundle's `Contents/Info.plist` via `plutil -replace` (idempotent: insert-if-absent / replace-if-present), inserted **before** the codesign pass so the key is sealed. When unset, the plist is left byte-identical to the source (keeps the existing byte-identity parity test deterministic).
- **Makefile** — the `mac-daemon` target now passes `CRM_BUILD_SHA="$(git rev-parse HEAD)"` to the assembly script.
- **Tests** — two new methods inside `BundleAssemblyParityTests` (the CI-filter-matched, `CRM_MAC_INTEGRATION_TESTS`-gated class, so no `ci.yml` filter change is needed):
  - `testShellAssembleStampsCRMBuildSHAUnderCodesignSeal` — proves the build path writes `CRMBuildSHA` and the key survives under a strict/deep codesign verify (the build-path link).
  - `testStampedInfoPlistSurvivesSerializeAndAssemble` — drives the IDENTICAL `PropertyListSerialization.data(fromPropertyList:format:.xml:)` + real `BundleAssembler` transform that `install --upgrade` uses, proving the stamp survives serialize→assemble into the installed bundle (the install-path carry-through link — the actually-load-bearing claim). `Bundle.main` is intentionally not mutated; the test exercises the real serialization + assembler the production path runs.
  - `runShellAssemble` now also scrubs `CRM_BUILD_SHA` from the child env so a developer with it exported can't perturb the byte-identity comparison; tests that DO want a stamp pass it back via `extraEnv`.
- **Reuse-contract comment** — `scripts/deploy-mac-daemon.sh` gains a header note documenting that the reconcile orchestrator (PR2) invokes it in place from a throwaway worktree, and that its `BASH_SOURCE`-relative `PROJECT_DIR` resolution + `make mac-daemon` delegation must stay intact. No behavior change.

No production Swift change. `mac-daemon/Sources/crm-mac/Info.plist` is intentionally **not** touched — the SHA is per-build, stamped at assembly time onto the bundle copy, never into the static source plist.

## Accepted non-blocking review findings (P2, intentional)

Recorded from the `/review-head` verdict (0×P0, 0×P1, 2×P2, 3×P3 — all non-blocking; verdict keyed to `7cc6dd4`):

- **(P2a)** The `CRMBuildSHA` stamp tests live behind the CI/integration filter (`CRM_MAC_INTEGRATION_TESTS`), so they only run in CI's dedicated mac-daemon integration step, not under a default `swift test`. This is intentional — these tests shell out to `bash` + `codesign` + `plutil` and write to a tmp dir, which is exactly why the existing parity/seal tests are env-gated too. Placing them inside `BundleAssemblyParityTests` means CI's `--filter 'BundleAssemblyParityTests|BundleSwapAtomicityTests'` picks them up with no `ci.yml` change.
- **(P2b)** `make mac-daemon` swallows a `git rev-parse` failure into an empty-but-fail-safe stamp. If `git rev-parse HEAD` were to fail, `CRM_BUILD_SHA` ends up empty and the bundle is left unstamped. This is fail-safe by design: the reconcile relevance gate treats a missing `CRMBuildSHA` as "must deploy" (an extra rebuild, never a skipped one), so an empty stamp degrades safely rather than silently mis-gating.

Both are intentional and acceptable; not fixed in this PR.

## Test plan

- `cd mac-daemon && swift build -c release` — green.
- `cd mac-daemon && CRM_MAC_INTEGRATION_TESTS=1 swift test --filter BundleAssemblyParityTests` — 3/3 pass (byte-identity + build-path stamp + install-path carry-through).
- `CI=true make test-daemon-local` — 975 tests, 10 skipped (integration-gated), 0 failures.
- Pre-push hook green: Claude review OK, Swift gate OK, Lint/Go/Frontend/Filter/E2E PASS.

**Post-deploy real-tool confirmation (Bucket B, runbook PR4):** after a supervised deploy, `plutil -extract CRMBuildSHA raw "$INSTALL_BUNDLE/Contents/Info.plist"` must return the deployed SHA. That is the empirical acceptance of the one link no unit test covers (`Bundle.main.infoDictionary` resolving from the build-dir bundle's `Contents/Info.plist`); the relevance gate fails safe on a missing stamp regardless.

## Links

- Plan: `.ai/log/plan/2026-06-12-mac-deploy-automation-bucketA.md` (PR1 section)
- Spec: `.ai/spec/2026-06-12-mac-deploy-automation-design.md` (landed by this PR)