### PR TITLE
feat(mac-deploy): reconcile-mac-daemon.sh + mocked tests + gate

### DIFF
--- a/.ai/pre-push.json
+++ b/.ai/pre-push.json
@@ -17,6 +17,7 @@
     "enabled": true,
     "commands": [
       { "name": "Pre-push filter unit tests", "command": "bash scripts/hooks/test/test-pre-push-filters.sh" },
+      { "name": "Deploy script tests", "command": "make test-deploy-scripts" },
       { "name": "Unit tests", "command": "make test-unit" },
       { "name": "Integration tests", "command": "make test-integration" },
       { "name": "Frontend tests", "command": "make test-frontend" },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,13 @@ jobs:
         working-directory: backend
         run: go test -short ./...
 
+      - name: Run deploy-script shell tests
+        # Pure-bash mocked suites (PATH-shadow stubs for git/gh/podman/plutil/
+        # crm-mac/curl/launchctl) — no DB, no podman, no network, no macOS-only
+        # binary reached outside a stub — so they run on the standard Ubuntu
+        # runner. Gated by the same backend path-filter (scripts/**, Makefile).
+        run: make test-deploy-scripts
+
       - name: Wait for PostgreSQL
         run: |
           timeout 30 bash -c 'until pg_isready -h localhost -p 5432; do sleep 1; done'

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Personal CRM Makefile
 
-.PHONY: help setup dev dev-seed staging-reset build crm-admin mac-daemon test test-daemon-local clean docker-up docker-down docker-reset test-cadence-ultra test-cadence-fast prod staging testing start start-local stop restart reload status dev-stop dev-restart dev-api-stop dev-api-start dev-api-restart ci-build-backend ci-build-frontend ci-build ci-test test-e2e test-e2e-local test-e2e-diff e2e-db deploy-mac promote setup-pi dev-native postgres-native sqlc smoke-test test-integration-fast test-integration-slow test-clean-clones check-cadence-sole-writer check-followup-sole-writer check-rematch-sole-dispatcher check-crm-marker-construction check-sqlc-select-lists lint-ingest-registry
+.PHONY: help setup dev dev-seed staging-reset build crm-admin mac-daemon test test-daemon-local clean docker-up docker-down docker-reset test-cadence-ultra test-cadence-fast prod staging testing start start-local stop restart reload status dev-stop dev-restart dev-api-stop dev-api-start dev-api-restart ci-build-backend ci-build-frontend ci-build ci-test test-e2e test-e2e-local test-e2e-diff e2e-db deploy-mac promote setup-pi dev-native postgres-native sqlc smoke-test test-deploy-scripts test-integration-fast test-integration-slow test-clean-clones check-cadence-sole-writer check-followup-sole-writer check-rematch-sole-dispatcher check-crm-marker-construction check-sqlc-select-lists lint-ingest-registry
 
 # Repo root (supports running make from subdirectories).
 REPO_ROOT := $(shell git rev-parse --show-toplevel)
@@ -86,6 +86,7 @@ help:
 	@echo "  test-e2e-local        - Run Playwright E2E tests (honors PLAYWRIGHT_GREP)"
 	@echo "  test-e2e-diff         - Run diff-selected E2E tests (core + impacted)"
 	@echo "  test-api              - Run API endpoint tests"
+	@echo "  test-deploy-scripts   - Run the mocked deploy-script shell suites"
 	@echo "  smoke-test            - Full system verification (restart + test)"
 	@echo ""
 	@echo "Docker:"
@@ -390,6 +391,13 @@ test-frontend:
 test-api:
 	@echo "Running API tests..."
 	@cd backend && go test ./tests/... -v
+
+# Mocked shell suites for the deploy orchestrators (Pi + Mac). Pure bash with
+# PATH-shadow stubs (no podman/Mac/network), so they run on any CI runner.
+test-deploy-scripts:
+	@echo "Running deploy-script shell tests..."
+	@bash scripts/deploy-artifact.test.sh
+	@bash scripts/reconcile-mac-daemon.test.sh
 
 smoke-test:
 	@echo "Running full system smoke test..."

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -256,8 +256,9 @@ run_phase() {
 
 # classify_command <command-string>: echo the lane for a .test.commands[] entry.
 #   E2E        — matches "test-e2e"           (DROPs the DB + binds ports: EXCLUSIVE, last)
-#   CONCURRENT — matches "test-frontend" OR "test-pre-push-filters"
-#                (the only commands KNOWN to be DB-free AND port-free)
+#   CONCURRENT — matches "test-frontend" OR "test-pre-push-filters" OR
+#                "test-deploy-scripts" (commands KNOWN to be DB-free AND port-free:
+#                the deploy-script suites are pure bash with PATH-shadow stubs)
 #   GO         — matches "test-unit" OR "test-integration" (DB-owning serial lane)
 #   GO (default) — anything UNRECOGNIZED falls to the GO serial lane.
 # Contract: a new known-safe (DB-free, port-free) command MUST be added to the
@@ -266,10 +267,10 @@ run_phase() {
 classify_command() {
   local cmd="$1"
   case "$cmd" in
-    *test-e2e*)                              echo "E2E" ;;
-    *test-frontend*|*test-pre-push-filters*) echo "CONCURRENT" ;;
-    *test-unit*|*test-integration*)          echo "GO" ;;
-    *)                                       echo "GO" ;;
+    *test-e2e*)                                                    echo "E2E" ;;
+    *test-frontend*|*test-pre-push-filters*|*test-deploy-scripts*) echo "CONCURRENT" ;;
+    *test-unit*|*test-integration*)                                echo "GO" ;;
+    *)                                                             echo "GO" ;;
   esac
 }
 

--- a/scripts/hooks/test/test-pre-push-phases.sh
+++ b/scripts/hooks/test/test-pre-push-phases.sh
@@ -17,6 +17,7 @@ assert_eq "test-e2e-diff -> E2E (exclusive)"             "E2E"        "$(classif
 assert_eq "test-e2e -> E2E"                              "E2E"        "$(classify_command 'make test-e2e')"
 assert_eq "test-frontend -> CONCURRENT"                 "CONCURRENT" "$(classify_command 'make test-frontend')"
 assert_eq "test-pre-push-filters -> CONCURRENT"         "CONCURRENT" "$(classify_command 'bash scripts/hooks/test/test-pre-push-filters.sh')"
+assert_eq "test-deploy-scripts -> CONCURRENT"           "CONCURRENT" "$(classify_command 'make test-deploy-scripts')"
 assert_eq "test-unit -> GO"                             "GO"         "$(classify_command 'make test-unit')"
 assert_eq "test-integration -> GO"                      "GO"         "$(classify_command 'make test-integration')"
 # Unrecognized command defaults to the GO (serial, DB-owning) lane — never concurrent.

--- a/scripts/reconcile-mac-daemon.sh
+++ b/scripts/reconcile-mac-daemon.sh
@@ -143,13 +143,21 @@ acquire_lock() {
     else
         # Owner file missing/unparseable: fall back to the dir mtime TTL.
         local mtime
-        mtime="$(get_mtime "$LOCK_DIR" 2>/dev/null || echo 0)"
-        age=$(( now - mtime ))
-        if [ "$age" -lt "$LOCK_STALE_SECS" ]; then
-            log "lock held (no owner file, age ${age}s); exiting"
-            return 1
+        mtime="$(get_mtime "$LOCK_DIR")"
+        if [[ "$mtime" =~ ^[0-9]+$ ]]; then
+            age=$(( now - mtime ))
+            if [ "$age" -lt "$LOCK_STALE_SECS" ]; then
+                log "lock held (no owner file, age ${age}s); exiting"
+                return 1
+            fi
+            log "lock owner file missing and dir age ${age}s >= ${LOCK_STALE_SECS}s; reclaiming stale lock"
+        else
+            # mtime unparseable (no usable stat output) -> cannot compute age.
+            # Safe direction is to RECLAIM (never wedge forever on a lock whose
+            # age we can't read); the re-mkdir race still guards against stealing
+            # a live winner's lock.
+            log "lock owner file missing and dir mtime unreadable; reclaiming stale lock"
         fi
-        log "lock owner file missing and dir age ${age}s >= ${LOCK_STALE_SECS}s; reclaiming stale lock"
     fi
 
     # Reclaim ONCE. A real run racing in between -> the re-mkdir fails -> exit 0.
@@ -164,8 +172,22 @@ acquire_lock() {
 }
 
 # get_mtime <path>: epoch mtime, portable across BSD (macOS) and GNU stat.
+# Echoes a bare integer epoch on success, or NOTHING (empty) if neither form
+# yields a numeric value. BSD `stat -f %m` and GNU `stat -c %Y` are mutually
+# exclusive in SYNTAX but NOT in exit code: GNU stat treats `-f %m DIR` as
+# `--file-system` over files `%m`+DIR and, for an existing DIR, prints a
+# MULTI-LINE filesystem block (first line `  File: ...`) and exits 0 — so the
+# `||` fallback never fires and the garbage would flow into arithmetic and crash
+# under `set -u` (`File: unbound variable`). Guard by validating each form's
+# output is a single integer before accepting it; emit nothing otherwise so the
+# caller can treat it as "unparseable -> safe path".
 get_mtime() {
-    stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null
+    local out
+    out="$(stat -f %m "$1" 2>/dev/null)"
+    if [[ "$out" =~ ^[0-9]+$ ]]; then echo "$out"; return 0; fi
+    out="$(stat -c %Y "$1" 2>/dev/null)"
+    if [[ "$out" =~ ^[0-9]+$ ]]; then echo "$out"; return 0; fi
+    return 0  # nothing parseable -> empty output, caller handles
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/reconcile-mac-daemon.sh
+++ b/scripts/reconcile-mac-daemon.sh
@@ -1,0 +1,417 @@
+#!/bin/bash
+# PersonalCRM Mac daemon reconcile-to-origin/main orchestrator.
+#
+# The Mac analog of deploy-artifact.sh (the Pi deploy primitive). Runs as the
+# LOGGED-IN USER (userland; NO sudo). Invoked by BOTH the runner workflow
+# (deploy-mac.yml) and the launchd timer, so the two paths can never diverge.
+#
+# Flow (every step idempotent + fail-closed):
+#   lock (mkdir + stale recovery) -> fetch origin/main -> CI gate (gh) ->
+#   refresh installed tooling -> relevance gate (CRMBuildSHA vs target) ->
+#   build+install via deploy-mac-daemon.sh in a throwaway worktree ->
+#   health gate (crm-mac doctor, parsed by CONTENT) -> notify.
+#
+# Exit codes:
+#   0  success, no-op, or soft-skip (transient: try again next tick).
+#   1  genuine CI-fail / build-fail / health-fail (runner job shows red;
+#      failure ntfy fires).
+#
+# Notifications: sourced from $DEPLOY_ENV_FILE if present (degrade-open --
+# absent file => no ntfy, never PII or secrets in bodies).
+#
+# Success-ntfy shape (DOCUMENTED SPEC DEVIATION): a successful real upgrade
+# emits ONE combined informational push "Mac deploy OK -- Contacts re-approval
+# needed". The spec lists two distinct success pushes (a plain "Mac deploy OK"
+# AND the Contacts notice), but Contacts re-prompts after EVERY rebuild (a TCC
+# quirk the script cannot observe surviving), so the plain "Mac deploy OK" would
+# only ever be correct in a state the script cannot detect. Emitting one combined
+# push avoids redundant double-notification on every deploy.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration (env-overridable for tests; $HOME-relative defaults).
+# Mirror deploy-mac-daemon.sh's "$HOME/Library/Application Support/crm-mac/..."
+# style (double-quoted, unbraced $HOME, literal space in "Application Support").
+# ---------------------------------------------------------------------------
+DEPLOY_ROOT="${CRM_MAC_DEPLOY_ROOT:-$HOME/Library/Application Support/crm-mac-deploy}"
+CLONE_DIR="${CRM_MAC_CLONE_DIR:-$DEPLOY_ROOT/repo}"
+WORKTREE_DIR="${CRM_MAC_WORKTREE_DIR:-$DEPLOY_ROOT/worktree}"          # throwaway
+DEPLOY_ENV_FILE="${CRM_MAC_DEPLOY_ENV_FILE:-$DEPLOY_ROOT/deploy.env}"  # chmod 600, uncommitted
+INSTALL_BUNDLE="${CRM_MAC_INSTALL_BUNDLE:-$HOME/Library/Application Support/crm-mac/crm-mac.app}"
+LOCK_DIR="${CRM_MAC_LOCK_DIR:-$DEPLOY_ROOT/reconcile.lock}"            # mkdir-based lock
+LOCK_STALE_SECS="${CRM_MAC_LOCK_STALE_SECS:-3600}"                     # lock TTL (env-overridable for tests)
+# Where the refreshed (self-updating) orchestrator + delegate live. setup-mac-deploy.sh
+# installs the stable path; reconcile self-refreshes it BEFORE the relevance gate.
+INSTALL_BIN_DIR="${CRM_MAC_INSTALL_BIN_DIR:-$DEPLOY_ROOT/bin}"
+# Recorded committed-template hash, written by setup-mac-deploy.sh; reconcile
+# compares it to origin/main's template to detect drift (notify-only).
+INSTALLED_TEMPLATE_HASH_FILE="${CRM_MAC_INSTALLED_TEMPLATE_HASH_FILE:-$DEPLOY_ROOT/.installed-template-hash}"
+TIMER_TEMPLATE_PATH="${CRM_MAC_TIMER_TEMPLATE_PATH:-infra/mac-deploy/xyz.spengrah.crm-mac-deploy.plist.template}"
+# Default to the INSTALLED bundle's binary, NOT a bare `crm-mac` on PATH -- the
+# health gate must verify the app we just upgraded, and `crm-mac` is not
+# guaranteed to be on the runner/timer PATH. Derived from INSTALL_BUNDLE so the
+# two never drift; tests override it with a stub.
+CRM_MAC_BIN="${CRM_MAC_BIN:-$INSTALL_BUNDLE/Contents/MacOS/crm-mac}"
+# Bounded retry budget for the gh CI-conclusion query.
+GH_API_RETRIES="${CRM_MAC_GH_API_RETRIES:-3}"
+
+log() { echo "[reconcile] $*" >&2; }
+
+# ---------------------------------------------------------------------------
+# deploy.env: source if present (degrade-open). Defines CRM_MAC_CODESIGN_IDENTITY
+# (passed to the delegated build), NTFY_URL, NTFY_TOPIC. set -u safety: an ABSENT
+# deploy.env means these are never set, so normalize to "" right after the source
+# so any later bare reference does not abort the script (unbound variable).
+# ---------------------------------------------------------------------------
+if [ -f "$DEPLOY_ENV_FILE" ]; then
+    # shellcheck source=/dev/null
+    source "$DEPLOY_ENV_FILE"
+fi
+CRM_MAC_CODESIGN_IDENTITY="${CRM_MAC_CODESIGN_IDENTITY:-}"
+NTFY_URL="${NTFY_URL:-}"
+NTFY_TOPIC="${NTFY_TOPIC:-}"
+
+NTFY_ENABLED=false
+if [ -n "$NTFY_URL" ] && [ -n "$NTFY_TOPIC" ]; then
+    NTFY_ENABLED=true
+fi
+
+# ntfy <title> <priority> <tags> <body>. Never logs the topic/URL. A failing POST
+# is logged but never changes the deploy outcome (degrade-open).
+ntfy() {
+    local title="$1" priority="$2" tags="$3" body="$4"
+    if [ "$NTFY_ENABLED" != true ]; then
+        return 0
+    fi
+    if ! curl -fsS \
+        -H "Title: $title" -H "Priority: $priority" -H "Tags: $tags" \
+        -d "$body" "$NTFY_URL/$NTFY_TOPIC" >/dev/null 2>&1; then
+        echo "warning: ntfy POST failed (deploy outcome unchanged)" >&2
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Lock + worktree cleanup trap. Gated ENTIRELY on lock_created=1 so a concurrent
+# LOSER (which never acquired the lock and never created the worktree) does NOT
+# tear down the live winner's lock OR mid-build worktree.
+# ---------------------------------------------------------------------------
+lock_created=0
+
+# Invoked indirectly via `trap`.
+# shellcheck disable=SC2329
+cleanup() {
+    if [ "$lock_created" -eq 1 ]; then
+        git -C "$CLONE_DIR" worktree remove --force "$WORKTREE_DIR" 2>/dev/null || true
+        rm -rf "$LOCK_DIR" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT INT TERM HUP
+
+# acquire_lock: atomic mkdir; on contention, recover a stale lock via a two-factor
+# (PID-liveness AND age) rule. Returns 0 if we hold the lock (sets lock_created=1),
+# 1 if a live concurrent run holds it (caller should exit 0).
+acquire_lock() {
+    if mkdir "$LOCK_DIR" 2>/dev/null; then
+        echo "$$ $(date +%s)" > "$LOCK_DIR/owner"
+        lock_created=1
+        return 0
+    fi
+
+    # Lock already held -- check for a STALE lock before deferring.
+    local owner pid ts now age
+    owner="$(cat "$LOCK_DIR/owner" 2>/dev/null || true)"
+    pid="$(printf '%s\n' "$owner" | awk '{print $1}')"
+    ts="$(printf '%s\n' "$owner" | awk '{print $2}')"
+    now="$(date +%s)"
+
+    if [ -n "$pid" ] && [ -n "$ts" ] && [[ "$pid" =~ ^[0-9]+$ ]] && [[ "$ts" =~ ^[0-9]+$ ]]; then
+        age=$(( now - ts ))
+        if kill -0 "$pid" 2>/dev/null; then
+            # PID alive.
+            if [ "$age" -lt "$LOCK_STALE_SECS" ]; then
+                log "lock held by PID $pid (age ${age}s); exiting"
+                return 1
+            fi
+            # PID alive but older than the TTL: no legitimate reconcile runs that
+            # long, so this is almost certainly a REUSED PID. Reclaim once.
+            log "lock PID $pid alive but age ${age}s >= ${LOCK_STALE_SECS}s (likely reused PID); reclaiming"
+        else
+            # PID dead -> stale regardless of age. Reclaim once.
+            log "lock owner PID $pid is dead; reclaiming stale lock"
+        fi
+    else
+        # Owner file missing/unparseable: fall back to the dir mtime TTL.
+        local mtime
+        mtime="$(get_mtime "$LOCK_DIR" 2>/dev/null || echo 0)"
+        age=$(( now - mtime ))
+        if [ "$age" -lt "$LOCK_STALE_SECS" ]; then
+            log "lock held (no owner file, age ${age}s); exiting"
+            return 1
+        fi
+        log "lock owner file missing and dir age ${age}s >= ${LOCK_STALE_SECS}s; reclaiming stale lock"
+    fi
+
+    # Reclaim ONCE. A real run racing in between -> the re-mkdir fails -> exit 0.
+    rm -rf "$LOCK_DIR"
+    if mkdir "$LOCK_DIR" 2>/dev/null; then
+        echo "$$ $(date +%s)" > "$LOCK_DIR/owner"
+        lock_created=1
+        return 0
+    fi
+    log "lost the race to reclaim the stale lock; exiting"
+    return 1
+}
+
+# get_mtime <path>: epoch mtime, portable across BSD (macOS) and GNU stat.
+get_mtime() {
+    stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# empty-identity abort: a missing CRM_MAC_CODESIGN_IDENTITY can never sign a
+# build. ALWAYS a loud, non-silent abort -- via ntfy when ntfy is configured,
+# else via a red exit + stderr log (the "notify when notify-config is in the
+# same missing file" contradiction: loud via red-exit+log, not ntfy).
+# ---------------------------------------------------------------------------
+abort_empty_identity() {
+    if [ "$NTFY_ENABLED" = true ]; then
+        # deploy.env exists (NTFY configured) but the identity is empty: a
+        # half-filled scaffold. Notify, then exit non-zero (loud).
+        ntfy "Mac deploy: deploy.env not configured" "max" "warning" \
+            "codesign identity empty -- fill CRM_MAC_CODESIGN_IDENTITY in deploy.env"
+        log "CRM_MAC_CODESIGN_IDENTITY empty (deploy.env present); aborting"
+    else
+        # deploy.env wholly absent: ntfy is ALSO unconfigured, so NO push is
+        # possible. Log loudly + exit non-zero so the runner job shows red.
+        log "CRM_MAC_CODESIGN_IDENTITY empty and deploy.env/ntfy unconfigured; aborting (no ntfy possible)"
+    fi
+    exit 1
+}
+
+# ---------------------------------------------------------------------------
+# refresh_tooling: copy the orchestrator + delegate from the clone's origin/main
+# tree to their installed stable paths, effective NEXT run. Runs on EVERY
+# non-skip path (including a daemon no-op) so a machinery fix is never stranded.
+# Atomic same-dir rename over an OPEN file: the running shell keeps the OLD inode
+# and executes to completion; new content takes effect next invocation.
+# ---------------------------------------------------------------------------
+refresh_tooling() {
+    local script dest tmp
+    mkdir -p "$INSTALL_BIN_DIR"
+    for script in reconcile-mac-daemon.sh deploy-mac-daemon.sh; do
+        dest="$INSTALL_BIN_DIR/$script"
+        tmp="$dest.tmp.$$"
+        if git -C "$CLONE_DIR" show "origin/main:scripts/$script" > "$tmp" 2>/dev/null; then
+            # Preserve the executable bit: `git show > tmp` writes 0644; a bare mv
+            # would brick the next invocation with "permission denied".
+            chmod 0755 "$tmp"
+            mv -f "$tmp" "$dest"
+        else
+            rm -f "$tmp" 2>/dev/null || true
+            log "warning: could not refresh $script from origin/main"
+        fi
+    done
+
+    check_timer_template_drift
+}
+
+# check_timer_template_drift: best-effort notify-only. Compare origin/main's timer
+# template to the hash recorded at setup time. Differ -> informational ntfy + do
+# NOT auto-reload launchd (out of scope). Ambiguous (no recorded hash) -> silent.
+check_timer_template_drift() {
+    local committed stored
+    committed="$(git -C "$CLONE_DIR" show "origin/main:$TIMER_TEMPLATE_PATH" 2>/dev/null | hash_stdin || true)"
+    if [ -z "$committed" ]; then
+        return 0  # template not present at origin/main -> nothing to compare
+    fi
+    if [ ! -f "$INSTALLED_TEMPLATE_HASH_FILE" ]; then
+        return 0  # ambiguous (no recorded hash) -> skip silently, do not spam
+    fi
+    stored="$(cat "$INSTALLED_TEMPLATE_HASH_FILE" 2>/dev/null || true)"
+    if [ -n "$stored" ] && [ "$committed" != "$stored" ]; then
+        ntfy "Mac deploy: timer template changed" "default" "information_source" \
+            "re-run \`make setup-mac-deploy\` to update the launchd timer"
+        log "timer template drift detected (committed != recorded); notified, not reloading launchd"
+    fi
+}
+
+# hash_stdin: stable content hash of stdin (shasum is present on macOS + Ubuntu).
+hash_stdin() {
+    shasum -a 256 | awk '{print $1}'
+}
+
+# ---------------------------------------------------------------------------
+# Steps.
+# ---------------------------------------------------------------------------
+
+# Step 1: lock.
+if ! acquire_lock; then
+    exit 0
+fi
+
+# Step 2: fetch -- advance the origin/main REMOTE-TRACKING ref (not just
+# FETCH_HEAD), via an EXPLICIT refspec so rev-parse origin/main is never stale.
+# Fetch failure -> soft-skip (transient; try again next tick).
+if ! git -C "$CLONE_DIR" fetch --quiet origin main:refs/remotes/origin/main 2>/dev/null; then
+    log "git fetch failed; soft-skip (try again next tick)"
+    exit 0
+fi
+TARGET_SHA="$(git -C "$CLONE_DIR" rev-parse origin/main 2>/dev/null || true)"
+if [ -z "$TARGET_SHA" ]; then
+    log "could not resolve origin/main after fetch; soft-skip"
+    exit 0
+fi
+
+# Step 3: CI gate. Query ci.yml's conclusion for TARGET_SHA via the user's gh
+# auth. Derive REPO with gh (BSD-sed-safe; no hand-rolled regex), anchored to the
+# clone's remote URL (reconcile's CWD has no checkout). The status=completed
+# filter is load-bearing: an in-progress re-run on the main push must never read
+# as success; for a SHA promoted from CI-green develop, the already-completed
+# develop run is returned.
+ci_gate() {
+    # Prints the resolved CI-gate class on stdout (one of):
+    #   __resolved__ <conclusion>   the gh query succeeded; <conclusion> is the
+    #                               run conclusion or "missing" (zero completed runs)
+    #   ghfailure                   persistent/structural (unauthed, empty REPO,
+    #                               401/403/404) -> surfaced, not silent
+    #   softskip                    auth OK but transport error -> try next tick
+    if ! gh auth status >/dev/null 2>&1; then
+        echo "ghfailure"
+        return 0
+    fi
+
+    local origin_url repo
+    origin_url="$(git -C "$CLONE_DIR" remote get-url origin 2>/dev/null || true)"
+    repo="$(gh repo view "$origin_url" --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)"
+    if [ -z "$repo" ]; then
+        # Structural: cannot resolve owner/name -> surfaced, not silent.
+        echo "ghfailure"
+        return 0
+    fi
+
+    local query="repos/$repo/actions/workflows/ci.yml/runs?head_sha=$TARGET_SHA&status=completed&per_page=1"
+    local attempt conclusion
+    for (( attempt = 1; attempt <= GH_API_RETRIES; attempt++ )); do
+        # The happy path: gh resolves + the jq fallback emits the conclusion (or
+        # "missing"). A stub can echo the conclusion and exit 0.
+        if conclusion="$(gh api "$query" \
+                --jq '.workflow_runs[0].conclusion // "missing"' 2>/dev/null)"; then
+            echo "__resolved__ ${conclusion:-missing}"
+            return 0
+        fi
+        # gh api returned non-zero. Classify structural (4xx) vs transient (5xx)
+        # by probing the HTTP status line via -i. 401/403/404 = structural.
+        local status_code
+        status_code="$(gh api -i "$query" 2>/dev/null | awk 'NR==1{print $2; exit}')"
+        case "$status_code" in
+            401|403|404)
+                echo "ghfailure"  # token lacks scope / repo|workflow not found
+                return 0 ;;
+        esac
+        sleep 1
+    done
+
+    # Auth OK but the query kept failing as a transport error -> transient.
+    echo "softskip"
+    return 0
+}
+
+ci_result="$(ci_gate)"
+case "$ci_result" in
+    __resolved__*)
+        conclusion="${ci_result#__resolved__ }"
+        case "$conclusion" in
+            success)
+                log "CI conclusion success for $TARGET_SHA; proceeding"
+                ;;
+            failure|cancelled|timed_out|action_required)
+                ntfy "Mac deploy FAILED" "max" "rotating_light" \
+                    "CI conclusion '$conclusion' for $TARGET_SHA; not deploying"
+                log "CI conclusion '$conclusion' for $TARGET_SHA; fail-closed"
+                exit 1
+                ;;
+            missing|*)
+                # Zero completed runs (CI still in-progress or not found). Never a
+                # deploy failure -- try again next tick.
+                log "CI not completed for $TARGET_SHA (conclusion='$conclusion'); soft-skip"
+                exit 0
+                ;;
+        esac
+        ;;
+    ghfailure)
+        # Persistent/structural gh failure (unauthed, or auth OK but
+        # misconfigured). SURFACED via a low-priority informational ntfy, NOT a
+        # silent forever-skip. Not a deploy failure -- nothing to roll back.
+        ntfy "Mac deploy: CI gate could not be queried" "low" "warning" \
+            "check \`gh auth status\` and Actions read access"
+        log "CI gate could not be queried (gh auth/structural failure); informational notice + exit 0"
+        exit 0
+        ;;
+    softskip|*)
+        log "CI gate transient query failure; soft-skip (try again next tick)"
+        exit 0
+        ;;
+esac
+
+# Step 4: refresh installed tooling BEFORE the relevance gate (so machinery fixes
+# are never stranded by a daemon no-op).
+refresh_tooling
+
+# Step 5: relevance gate. Read the INSTALLED bundle's CRMBuildSHA; skip the
+# upgrade only if mac-daemon/ is unchanged between it and the target.
+installed_sha="$(plutil -extract CRMBuildSHA raw "$INSTALL_BUNDLE/Contents/Info.plist" 2>/dev/null || true)"
+if [ -n "$installed_sha" ] \
+   && git -C "$CLONE_DIR" diff --quiet "$installed_sha" "$TARGET_SHA" -- mac-daemon/ 2>/dev/null; then
+    log "no mac-daemon changes since $installed_sha; no-op"
+    exit 0  # no-op, no ntfy
+fi
+# Missing/unparseable stamp, or an unknown installed SHA (git diff errors) ->
+# treat as "must deploy" (bootstrap path / self-correcting downgrade).
+
+# Empty identity is only reachable here (we are about to build). Loud abort.
+if [ -z "$CRM_MAC_CODESIGN_IDENTITY" ]; then
+    abort_empty_identity
+fi
+
+# Step 6: upgrade -- checkout TARGET_SHA into the throwaway worktree, delegate the
+# single build+install to deploy-mac-daemon.sh (which runs `make mac-daemon`,
+# stamping CRMBuildSHA=$(git rev-parse HEAD)=TARGET_SHA from inside the worktree).
+git -C "$CLONE_DIR" worktree remove --force "$WORKTREE_DIR" 2>/dev/null || true
+git -C "$CLONE_DIR" worktree add --detach "$WORKTREE_DIR" "$TARGET_SHA"
+
+if ! CRM_MAC_CODESIGN_IDENTITY="$CRM_MAC_CODESIGN_IDENTITY" \
+        "$WORKTREE_DIR/scripts/deploy-mac-daemon.sh"; then
+    ntfy "Mac deploy FAILED" "max" "rotating_light" \
+        "build/install failed for $TARGET_SHA; prior bundle retained (restore via \`crm-mac install --upgrade\` from a known-good build)"
+    log "deploy-mac-daemon.sh failed for $TARGET_SHA; fail-closed"
+    exit 1
+fi
+
+# Step 7: health gate -- crm-mac doctor, parsed by CONTENT (NOT exit code: the
+# exit code equals the FAIL count, so an informational pi_reachability blip would
+# false-fail). Capture output FIRST (|| true) so pipefail does not abort us.
+doctor_out="$("$CRM_MAC_BIN" doctor 2>/dev/null || true)"
+if printf '%s\n' "$doctor_out" \
+     | grep -E '^(PASS|FAIL)[[:space:]]+agent_service:' \
+     | grep -q 'registered (enabled)'; then
+    health_ok=true
+else
+    health_ok=false
+fi
+
+if [ "$health_ok" != true ]; then
+    ntfy "Mac deploy FAILED" "max" "rotating_light" \
+        "health gate failed for $TARGET_SHA (agent_service not registered); prior bundle retained (restore via \`crm-mac install --upgrade\` from a known-good build)"
+    log "health gate failed for $TARGET_SHA; fail-closed"
+    exit 1
+fi
+
+# Step 8: Contacts-pending check -- informational only (iCloud Contacts grant is
+# reset every rebuild; a TCC quirk). Not a health failure.
+# Step 9: notify -- one combined informational success push (see header note).
+ntfy "Mac deploy OK -- Contacts re-approval needed" "default" "white_check_mark" \
+    "deployed $TARGET_SHA; click Allow for Contacts when next at the Mac"
+log "deploy OK for $TARGET_SHA (Contacts re-approval pending)"
+
+exit 0

--- a/scripts/reconcile-mac-daemon.sh
+++ b/scripts/reconcile-mac-daemon.sh
@@ -220,14 +220,19 @@ refresh_tooling() {
 # template to the hash recorded at setup time. Differ -> informational ntfy + do
 # NOT auto-reload launchd (out of scope). Ambiguous (no recorded hash) -> silent.
 check_timer_template_drift() {
-    local committed stored
-    committed="$(git -C "$CLONE_DIR" show "origin/main:$TIMER_TEMPLATE_PATH" 2>/dev/null | hash_stdin || true)"
-    if [ -z "$committed" ]; then
+    local template_content committed stored
+    # Capture the committed template SEPARATELY from hashing: piping a failed
+    # `git show` straight into shasum would hash the EMPTY string (a non-empty
+    # digest), defeating the "template absent" guard. The template does not exist
+    # at origin/main until PR3 lands it, so this guard must hold.
+    template_content="$(git -C "$CLONE_DIR" show "origin/main:$TIMER_TEMPLATE_PATH" 2>/dev/null || true)"
+    if [ -z "$template_content" ]; then
         return 0  # template not present at origin/main -> nothing to compare
     fi
     if [ ! -f "$INSTALLED_TEMPLATE_HASH_FILE" ]; then
         return 0  # ambiguous (no recorded hash) -> skip silently, do not spam
     fi
+    committed="$(printf '%s' "$template_content" | hash_stdin)"
     stored="$(cat "$INSTALLED_TEMPLATE_HASH_FILE" 2>/dev/null || true)"
     if [ -n "$stored" ] && [ "$committed" != "$stored" ]; then
         ntfy "Mac deploy: timer template changed" "default" "information_source" \
@@ -392,9 +397,16 @@ fi
 # exit code equals the FAIL count, so an informational pi_reachability blip would
 # false-fail). Capture output FIRST (|| true) so pipefail does not abort us.
 doctor_out="$("$CRM_MAC_BIN" doctor 2>/dev/null || true)"
-if printf '%s\n' "$doctor_out" \
-     | grep -E '^(PASS|FAIL)[[:space:]]+agent_service:' \
-     | grep -q 'registered (enabled)'; then
+# Extract the agent_service line into a variable, THEN match -- do NOT chain
+# `grep -E ... | grep -q ...`: under pipefail, grep -q matching and exiting early
+# can SIGPIPE the upstream grep, surfacing a non-zero pipeline status that would
+# FALSE-FAIL a genuinely-healthy deploy (the exact fail-closed-when-healthy bug
+# this content-parse gate exists to avoid).
+agent_line="$(printf '%s\n' "$doctor_out" \
+    | grep -E '^(PASS|FAIL)[[:space:]]+agent_service:' || true)"
+# Pipeline-free content match (a bash glob, not a piped grep -q) so there is no
+# second pipeline whose status pipefail could surface.
+if [[ "$agent_line" == *"registered (enabled)"* ]]; then
     health_ok=true
 else
     health_ok=false

--- a/scripts/reconcile-mac-daemon.test.sh
+++ b/scripts/reconcile-mac-daemon.test.sh
@@ -84,7 +84,12 @@ case "\$1" in
     ref="\$2"
     case "\$ref" in
       *scripts/*) echo "#!/bin/bash"; echo "# refreshed \$ref"; exit 0 ;;
-      *)          printf '%s' "\${STUB_TEMPLATE_CONTENT:-}"; exit "\${STUB_TEMPLATE_SHOW_RC:-0}" ;;
+      *)
+        # Template ref. STUB_TEMPLATE_ABSENT=1 models a ref that does not exist
+        # at origin/main yet (the real case until PR3 lands the template): git
+        # show emits NOTHING and exits non-zero.
+        if [ "\${STUB_TEMPLATE_ABSENT:-0}" = "1" ]; then exit 128; fi
+        printf '%s' "\${STUB_TEMPLATE_CONTENT:-}"; exit "\${STUB_TEMPLATE_SHOW_RC:-0}" ;;
     esac ;;
   worktree)  exit 0 ;;
   *)         exit 0 ;;
@@ -458,6 +463,22 @@ test_timer_drift_ambiguous_silent() {
     unset DEPLOY_ENV_FILE_OVERRIDE
 }
 
+test_timer_drift_template_absent_no_notice() {
+    echo "test: timer template absent at origin/main (pre-PR3) -> no spurious notice"
+    make_sandbox
+    write_deploy_env "CRM_MAC_CODESIGN_IDENTITY=My Cert" "NTFY_URL=https://ntfy.example" "NTFY_TOPIC=tok"
+    # A stored hash EXISTS but the committed template does NOT (git show fails).
+    # Guards against hashing empty stdin to a non-empty digest and firing a false
+    # drift notice every run before PR3 lands the template.
+    echo "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef" > "$TEMPLATE_HASH_FILE"
+    STUB_CI_CONCLUSION=success STUB_INSTALLED_SHA="$INSTALLED_SHA" STUB_DIFF_RC=0 \
+        STUB_TEMPLATE_ABSENT=1 run_reconcile
+    if [ "$RC" -eq 0 ]; then ok; else fail "absent template must not crash, got $RC ($OUT)"; fi
+    if log_lacks "Title: Mac deploy: timer template changed"; then ok; else fail "absent template must NOT fire a drift notice"; fi
+    cleanup_sandbox
+    unset DEPLOY_ENV_FILE_OVERRIDE
+}
+
 test_health_fail_max_ntfy() {
     echo "test: max-priority ntfy on health failure"
     make_sandbox
@@ -654,6 +675,7 @@ main() {
     test_timer_drift_notifies
     test_timer_drift_unchanged_no_notice
     test_timer_drift_ambiguous_silent
+    test_timer_drift_template_absent_no_notice
     test_health_fail_max_ntfy
     test_health_gate_parses_by_content
     test_contacts_pending_ntfy_on_success

--- a/scripts/reconcile-mac-daemon.test.sh
+++ b/scripts/reconcile-mac-daemon.test.sh
@@ -1,0 +1,679 @@
+#!/usr/bin/env bash
+# Tests for reconcile-mac-daemon.sh (the Mac deploy reconcile orchestrator).
+#
+# These run anywhere (no Mac, no real build, no network). PATH is shadowed with
+# stub `git`/`gh`/`plutil`/`crm-mac`/`curl`/`launchctl` and a stub
+# `deploy-mac-daemon.sh` that records its argv to a per-test call log. Each test
+# drives a scenario via env vars (CI conclusion, gh exit code, diff result,
+# doctor output, lock state) and asserts on the recorded calls + the script exit
+# code. The real-tool path is the Bucket-B supervised dry-run, not this suite --
+# every macOS-only binary (plutil/launchctl) is reached ONLY through a stub so
+# the suite is green on the Ubuntu CI backend runner too.
+#
+# Asserts the load-bearing correctness points from plan §3.2:
+#   - relevance gate: no-op when mac-daemon/ unchanged; deploy when changed.
+#   - CI gate: fail-closed on failure; soft-skip on missing; gh auth/structural
+#     failure -> informational notice (not silent); transient -> soft-skip.
+#   - fetch advances origin/main (not just FETCH_HEAD).
+#   - empty codesign identity: loud abort (ntfy when configured, else red exit).
+#   - tooling refresh runs even on a no-op + preserves the executable bit.
+#   - timer-template drift -> informational notice; unchanged -> none; ambiguous
+#     -> silent.
+#   - health gate parses the agent_service line by CONTENT, not exit code.
+#   - Contacts-pending informational ntfy on success.
+#   - mkdir lock: live holder defers; stale (dead PID / TTL) reclaims; loser does
+#     not tear down the winner's worktree.
+#   - path-with-spaces deploy path.
+#   - worktree cleanup on success + on a mid-run failure.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/reconcile-mac-daemon.sh"
+TARGET_SHA="abcdef0123456789abcdef0123456789abcdef01"
+INSTALLED_SHA="1111111111111111111111111111111111111111"
+
+PASS=0
+FAIL=0
+fail() { echo "  FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+ok()   { PASS=$((PASS + 1)); }
+
+# ---------------------------------------------------------------------------
+# Test sandbox: a fresh tmp dir per scenario with a stub bin/, a clone dir, a
+# fake installed bundle, and a call log. Sets globals SANDBOX, CALL_LOG,
+# DEPLOY_ROOT, CLONE_DIR, INSTALL_BUNDLE, INSTALL_BIN_DIR.
+# ---------------------------------------------------------------------------
+make_sandbox() {
+    # Optional arg $1 = a deploy-root suffix so a test can force a path WITH a
+    # space (the real default lives under "Application Support").
+    SANDBOX="$(mktemp -d)"
+    CALL_LOG="$SANDBOX/calls.log"
+    : > "$CALL_LOG"
+    mkdir -p "$SANDBOX/bin"
+
+    local root_name="${1:-deploy}"
+    DEPLOY_ROOT="$SANDBOX/$root_name"
+    CLONE_DIR="$DEPLOY_ROOT/repo"
+    WORKTREE_DIR="$DEPLOY_ROOT/worktree"
+    INSTALL_BUNDLE="$DEPLOY_ROOT/installed/crm-mac.app"
+    INSTALL_BIN_DIR="$DEPLOY_ROOT/bin"
+    LOCK_DIR="$DEPLOY_ROOT/reconcile.lock"
+    TEMPLATE_HASH_FILE="$DEPLOY_ROOT/.installed-template-hash"
+    mkdir -p "$CLONE_DIR" "$INSTALL_BUNDLE/Contents" "$DEPLOY_ROOT/installed"
+
+    # --- stub: git ---------------------------------------------------------
+    # Branches on the subcommand. Records every invocation.
+    #   fetch            -> exit ${STUB_FETCH_RC:-0}
+    #   rev-parse origin/main -> echo the fetched SHA (STUB_TARGET_SHA)
+    #   remote get-url   -> echo a fixed origin URL
+    #   diff --quiet     -> exit ${STUB_DIFF_RC:-1}  (default 1 = "changed")
+    #   show origin/main:scripts/<f> -> emit fake script body (records refresh)
+    #   show origin/main:<template>  -> emit ${STUB_TEMPLATE_CONTENT}
+    #   worktree         -> exit 0 (records add/remove)
+    cat > "$SANDBOX/bin/git" <<EOF
+#!/usr/bin/env bash
+echo "git \$*" >> "$CALL_LOG"
+# Drop a leading "-C <dir>" so we can match on the subcommand.
+if [ "\$1" = "-C" ]; then shift 2; fi
+case "\$1" in
+  fetch)     exit "\${STUB_FETCH_RC:-0}" ;;
+  rev-parse) echo "\${STUB_TARGET_SHA:-$TARGET_SHA}"; exit 0 ;;
+  remote)    echo "https://github.com/spengrah/PersonalCRM.git"; exit 0 ;;
+  diff)      exit "\${STUB_DIFF_RC:-1}" ;;
+  show)
+    ref="\$2"
+    case "\$ref" in
+      *scripts/*) echo "#!/bin/bash"; echo "# refreshed \$ref"; exit 0 ;;
+      *)          printf '%s' "\${STUB_TEMPLATE_CONTENT:-}"; exit "\${STUB_TEMPLATE_SHOW_RC:-0}" ;;
+    esac ;;
+  worktree)  exit 0 ;;
+  *)         exit 0 ;;
+esac
+EOF
+
+    # --- stub: gh ----------------------------------------------------------
+    # auth status -> exit ${STUB_GH_AUTH_RC:-0}
+    # repo view   -> echo ${STUB_REPO:-spengrah/PersonalCRM} (empty models a
+    #                structural resolution failure)
+    # api ... --jq -> echo ${STUB_CI_CONCLUSION:-success}; exit ${STUB_GH_API_RC:-0}
+    # api -i ...   -> emit a fake HTTP status line ${STUB_GH_HTTP_STATUS:-200}
+    cat > "$SANDBOX/bin/gh" <<EOF
+#!/usr/bin/env bash
+echo "gh \$*" >> "$CALL_LOG"
+case "\$1" in
+  auth)  exit "\${STUB_GH_AUTH_RC:-0}" ;;
+  repo)  printf '%s' "\${STUB_REPO-spengrah/PersonalCRM}"; exit 0 ;;
+  api)
+    if [ "\$2" = "-i" ]; then
+      echo "HTTP/2 \${STUB_GH_HTTP_STATUS:-200}"
+      exit 0
+    fi
+    echo "\${STUB_CI_CONCLUSION:-success}"
+    exit "\${STUB_GH_API_RC:-0}" ;;
+  *) exit 0 ;;
+esac
+EOF
+
+    # --- stub: plutil ------------------------------------------------------
+    # -extract CRMBuildSHA raw <plist> -> echo ${STUB_INSTALLED_SHA}; or exit 1
+    # to model a missing key (bootstrap path).
+    cat > "$SANDBOX/bin/plutil" <<EOF
+#!/usr/bin/env bash
+echo "plutil \$*" >> "$CALL_LOG"
+if [ "\$1" = "-extract" ] && [ "\$2" = "CRMBuildSHA" ]; then
+  if [ "\${STUB_INSTALLED_SHA_MISSING:-0}" = "1" ]; then exit 1; fi
+  echo "\${STUB_INSTALLED_SHA:-$INSTALLED_SHA}"
+  exit 0
+fi
+exit 0
+EOF
+
+    # --- stub: crm-mac (doctor) -------------------------------------------
+    # Emits ${STUB_DOCTOR_OUTPUT} and exits the FAIL-count (faithfully models the
+    # real exit-code-equals-FAIL-count behavior).
+    cat > "$SANDBOX/bin/crm-mac" <<EOF
+#!/usr/bin/env bash
+echo "crm-mac \$*" >> "$CALL_LOG"
+out="\${STUB_DOCTOR_OUTPUT:-PASS  agent_service: registered (enabled)}"
+printf '%s\n' "\$out"
+# exit code = number of FAIL lines.
+fails=\$(printf '%s\n' "\$out" | grep -cE '^FAIL' || true)
+exit "\$fails"
+EOF
+
+    # --- stub: deploy-mac-daemon.sh (the build+install delegate) ----------
+    # Placed at BOTH the worktree path the script invokes and recorded here. The
+    # real script invokes "\$WORKTREE_DIR/scripts/deploy-mac-daemon.sh"; the git
+    # `worktree add` is stubbed (no real checkout), so we pre-create that path.
+    mkdir -p "$WORKTREE_DIR/scripts"
+    cat > "$WORKTREE_DIR/scripts/deploy-mac-daemon.sh" <<EOF
+#!/usr/bin/env bash
+echo "deploy-mac-daemon.sh identity=\${CRM_MAC_CODESIGN_IDENTITY:-<unset>}" >> "$CALL_LOG"
+exit "\${STUB_BUILD_RC:-0}"
+EOF
+    chmod +x "$WORKTREE_DIR/scripts/deploy-mac-daemon.sh"
+
+    # --- stub: curl (ntfy) -------------------------------------------------
+    cat > "$SANDBOX/bin/curl" <<EOF
+#!/usr/bin/env bash
+echo "curl \$*" >> "$CALL_LOG"
+exit 0
+EOF
+
+    # --- stub: launchctl (must never reach a real one on Ubuntu CI) -------
+    cat > "$SANDBOX/bin/launchctl" <<EOF
+#!/usr/bin/env bash
+echo "launchctl \$*" >> "$CALL_LOG"
+exit 0
+EOF
+
+    # --- stub: sleep (no-op so retry loops run instantly) -----------------
+    cat > "$SANDBOX/bin/sleep" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+    chmod +x "$SANDBOX"/bin/*
+}
+
+cleanup_sandbox() { [ -n "${SANDBOX:-}" ] && rm -rf "$SANDBOX"; }
+
+# run_reconcile : run reconcile-mac-daemon.sh in the sandbox; sets RC + OUT.
+# Honors any STUB_* env the caller exported. The script's stable-bin refresh
+# target ($INSTALL_BIN_DIR) is inside the sandbox so the refresh never touches
+# the running repo script.
+run_reconcile() {
+    OUT="$(
+        PATH="$SANDBOX/bin:$PATH" \
+        CRM_MAC_DEPLOY_ROOT="$DEPLOY_ROOT" \
+        CRM_MAC_CLONE_DIR="$CLONE_DIR" \
+        CRM_MAC_WORKTREE_DIR="$WORKTREE_DIR" \
+        CRM_MAC_DEPLOY_ENV_FILE="${DEPLOY_ENV_FILE_OVERRIDE:-$DEPLOY_ROOT/missing-deploy.env}" \
+        CRM_MAC_INSTALL_BUNDLE="$INSTALL_BUNDLE" \
+        CRM_MAC_INSTALL_BIN_DIR="$INSTALL_BIN_DIR" \
+        CRM_MAC_LOCK_DIR="$LOCK_DIR" \
+        CRM_MAC_INSTALLED_TEMPLATE_HASH_FILE="$TEMPLATE_HASH_FILE" \
+        CRM_MAC_BIN="$SANDBOX/bin/crm-mac" \
+        CRM_MAC_LOCK_STALE_SECS="${LOCK_STALE_SECS_OVERRIDE:-3600}" \
+        CRM_MAC_GH_API_RETRIES="${GH_API_RETRIES_OVERRIDE:-2}" \
+        bash "$SCRIPT" 2>&1
+    )"
+    RC=$?
+}
+
+# Write a deploy.env into the sandbox + point the override at it. Each arg is a
+# KEY=value pair; the value is double-quoted in the written file (mirroring a real
+# env file) so values containing spaces (e.g. a codesign identity "My Cert") are
+# sourced as a single value, not word-split.
+write_deploy_env() {
+    DEPLOY_ENV_FILE_OVERRIDE="$DEPLOY_ROOT/deploy.env"
+    : > "$DEPLOY_ENV_FILE_OVERRIDE"
+    local pair key val
+    for pair in "$@"; do
+        key="${pair%%=*}"
+        val="${pair#*=}"
+        printf '%s="%s"\n' "$key" "$val" >> "$DEPLOY_ENV_FILE_OVERRIDE"
+    done
+}
+
+# assert helpers operating on $CALL_LOG / $OUT.
+log_has()   { grep -qF -- "$1" "$CALL_LOG"; }
+log_lacks() { ! grep -qF -- "$1" "$CALL_LOG"; }
+out_has()   { printf '%s' "$OUT" | grep -qF -- "$1"; }
+# count ntfy POSTs (curl invocations). grep -c prints 0 and exits 1 on no match,
+# so swallow the exit without a second echo (which would print "0\n0").
+ntfy_count() { grep -cE '^curl ' "$CALL_LOG" || true; }
+
+# ===========================================================================
+# Tests
+# ===========================================================================
+
+test_noop_when_unchanged() {
+    echo "test: no-op when mac-daemon/ unchanged vs the bundle-reported SHA"
+    make_sandbox
+    write_deploy_env "CRM_MAC_CODESIGN_IDENTITY=My Cert" "NTFY_URL=https://ntfy.example" "NTFY_TOPIC=tok"
+    STUB_CI_CONCLUSION=success STUB_INSTALLED_SHA="$INSTALLED_SHA" STUB_DIFF_RC=0 run_reconcile
+    if [ "$RC" -eq 0 ]; then ok; else fail "no-op should exit 0, got $RC ($OUT)"; fi
+    if log_lacks "deploy-mac-daemon.sh identity="; then ok; else fail "no-op must NOT build"; fi
+    # No ntfy POST on a no-op.
+    if [ "$(ntfy_count)" -eq 0 ]; then ok; else fail "no-op must not POST ntfy"; fi
+    cleanup_sandbox
+    unset DEPLOY_ENV_FILE_OVERRIDE
+}
+
+test_deploys_when_changed() {
+    echo "test: deploys when mac-daemon/ changed"
+    make_sandbox
+    write_deploy_env "CRM_MAC_CODESIGN_IDENTITY=My Cert" "NTFY_URL=https://ntfy.example" "NTFY_TOPIC=tok"
+    STUB_CI_CONCLUSION=success STUB_INSTALLED_SHA="$INSTALLED_SHA" STUB_DIFF_RC=1 run_reconcile
+    if [ "$RC" -eq 0 ]; then ok; else fail "deploy happy path should exit 0, got $RC ($OUT)"; fi
+    if log_has "deploy-mac-daemon.sh identity=My Cert"; then ok; else fail "build must run WITH the codesign identity"; fi
+    if log_has "worktree add --detach"; then ok; else fail "worktree must be added at the target SHA"; fi
+    cleanup_sandbox
+    unset DEPLOY_ENV_FILE_OVERRIDE
+}
+
+test_fail_closed_on_ci_failure() {
+    echo "test: fail-closed on CI failure"
+    make_sandbox
+    write_deploy_env "CRM_MAC_CODESIGN_IDENTITY=My Cert" "NTFY_URL=https://ntfy.example" "NTFY_TOPIC=tok"
+    STUB_CI_CONCLUSION=failure run_reconcile
+    if [ "$RC" -eq 1 ]; then ok; else fail "CI failure should exit 1, got $RC"; fi
+    if log_has "Title: Mac deploy FAILED"; then ok; else fail "CI failure must ntfy 'Mac deploy FAILED'"; fi
+    if log_has "Priority: max"; then ok; else fail "CI failure ntfy must be max priority"; fi
+    if log_lacks "deploy-mac-daemon.sh identity="; then ok; else fail "CI failure must NOT build"; fi
+    cleanup_sandbox
+    unset DEPLOY_ENV_FILE_OVERRIDE
+}
+
+test_soft_skip_on_ci_missing() {
+    echo "test: soft-skip on CI missing (in-progress / not found)"
+    make_sandbox
+    write_deploy_env "CRM_MAC_CODESIGN_IDENTITY=My Cert" "NTFY_URL=https://ntfy.example" "NTFY_TOPIC=tok"
+    STUB_CI_CONCLUSION=missing run_reconcile
+    if [ "$RC" -eq 0 ]; then ok; else fail "CI missing should soft-skip exit 0, got $RC"; fi
+    if [ "$(ntfy_count)" -eq 0 ]; then ok; else fail "CI missing must not POST ntfy"; fi
+    if log_lacks "deploy-mac-daemon.sh identity="; then ok; else fail "CI missing must NOT build"; fi
+    cleanup_sandbox
+    unset DEPLOY_ENV_FILE_OVERRIDE
+}
+
+test_transient_gh_failure_soft_skips() {
+    echo "test: transient gh api failure -> soft-skip (no ntfy)"
+    make_sandbox
+    write_deploy_env "CRM_MAC_CODESIGN_IDENTITY=My Cert" "NTFY_URL=https://ntfy.example" "NTFY_TOPIC=tok"
+    # auth OK, api exits non-zero, HTTP status 503 (transient/transport) across retries.
+    STUB_GH_AUTH_RC=0 STUB_GH_API_RC=1 STUB_GH_HTTP_STATUS=503 run_reconcile
+    if [ "$RC" -eq 0 ]; then ok; else fail "transient gh failure should soft-skip exit 0, got $RC"; fi
+    if [ "$(ntfy_count)" -eq 0 ]; then ok; else fail "transient gh failure must NOT ntfy"; fi
+    if log_lacks "deploy-mac-daemon.sh identity="; then ok; else fail "transient gh failure must NOT build"; fi
+    cleanup_sandbox
+    unset DEPLOY_ENV_FILE_OVERRIDE
+}
+
+test_unauthed_gh_informational_notice() {
+    echo "test: unauthed gh -> informational notice (not silent)"
+    make_sandbox
+    write_deploy_env "CRM_MAC_CODESIGN_IDENTITY=My Cert" "NTFY_URL=https://ntfy.example" "NTFY_TOPIC=tok"
+    STUB_GH_AUTH_RC=1 run_reconcile
+    if [ "$RC" -eq 0 ]; then ok; else fail "unauthed gh should exit 0, got $RC"; fi
+    if log_has "Title: Mac deploy: CI gate could not be queried"; then ok; else fail "unauthed gh must fire the informational CI-gate notice"; fi
+    if log_has "Priority: low"; then ok; else fail "CI-gate notice must be low priority"; fi
+    if log_lacks "Title: Mac deploy FAILED"; then ok; else fail "unauthed gh must NOT fire a FAILED ntfy"; fi
+    if log_lacks "deploy-mac-daemon.sh identity="; then ok; else fail "unauthed gh must NOT build"; fi
+    cleanup_sandbox
+    unset DEPLOY_ENV_FILE_OVERRIDE
+}
+
+test_structural_gh_failure_informational() {
+    echo "test: structural gh failures (empty REPO / 404 / 403) -> informational notice"
+    # Sub-case 1: empty REPO (gh repo view yields nothing).
+    make_sandbox
+    write_deploy_env "CRM_MAC_CODESIGN_IDENTITY=My Cert" "NTFY_URL=https://ntfy.example" "NTFY_TOPIC=tok"
+    STUB_GH_AUTH_RC=0 STUB_REPO="" run_reconcile
+    if [ "$RC" -eq 0 ] && log_has "Title: Mac deploy: CI gate could not be queried" && log_lacks "deploy-mac-daemon.sh identity="; then ok
+    else fail "empty REPO must give the informational notice + no build (rc=$RC)"; fi
+    cleanup_sandbox
+    unset DEPLOY_ENV_FILE_OVERRIDE
+
+    # Sub-case 2: 404 (repo/workflow not found).
+    make_sandbox
+    write_deploy_env "CRM_MAC_CODESIGN_IDENTITY=My Cert" "NTFY_URL=https://ntfy.example" "NTFY_TOPIC=tok"
+    STUB_GH_AUTH_RC=0 STUB_GH_API_RC=1 STUB_GH_HTTP_STATUS=404 run_reconcile
+    if [ "$RC" -eq 0 ] && log_has "Title: Mac deploy: CI gate could not be queried" && log_lacks "deploy-mac-daemon.sh identity="; then ok
+    else fail "404 must give the informational notice + no build (rc=$RC)"; fi
+    cleanup_sandbox
+    unset DEPLOY_ENV_FILE_OVERRIDE
+
+    # Sub-case 3: 403 (token lacks scope).
+    make_sandbox
+    write_deploy_env "CRM_MAC_CODESIGN_IDENTITY=My Cert" "NTFY_URL=https://ntfy.example" "NTFY_TOPIC=tok"
+    STUB_GH_AUTH_RC=0 STUB_GH_API_RC=1 STUB_GH_HTTP_STATUS=403 run_reconcile
+    if [ "$RC" -eq 0 ] && log_has "Title: Mac deploy: CI gate could not be queried" && log_lacks "deploy-mac-daemon.sh identity="; then ok
+    else fail "403 must give the informational notice + no build (rc=$RC)"; fi
+    cleanup_sandbox
+    unset DEPLOY_ENV_FILE_OVERRIDE
+}
+
+test_soft_skip_on_fetch_failure() {
+    echo "test: soft-skip on git fetch failure"
+    make_sandbox
+    write_deploy_env "CRM_MAC_CODESIGN_IDENTITY=My Cert" "NTFY_URL=https://ntfy.example" "NTFY_TOPIC=tok"
+    STUB_FETCH_RC=1 run_reconcile
+    if [ "$RC" -eq 0 ]; then ok; else fail "fetch failure should soft-skip exit 0, got $RC"; fi
+    if [ "$(ntfy_count)" -eq 0 ]; then ok; else fail "fetch failure must not ntfy"; fi
+    if log_lacks "gh api"; then ok; else fail "fetch failure must abort before the CI gate"; fi
+    cleanup_sandbox
+    unset DEPLOY_ENV_FILE_OVERRIDE
+}
+
+test_fetch_advances_tracking_ref() {
+    echo "test: fetch advances origin/main tracking ref, target from rev-parse origin/main"
+    make_sandbox
+    write_deploy_env "CRM_MAC_CODESIGN_IDENTITY=My Cert" "NTFY_URL=https://ntfy.example" "NTFY_TOPIC=tok"
+    local new_sha="cafebabecafebabecafebabecafebabecafebabe"
+    # The fetch must use the explicit refspec form (updates refs/remotes/origin/main).
+    STUB_CI_CONCLUSION=success STUB_TARGET_SHA="$new_sha" STUB_DIFF_RC=1 run_reconcile
+    if log_has "fetch --quiet origin main:refs/remotes/origin/main"; then ok
+    else fail "fetch must use the explicit origin/main refspec (not FETCH_HEAD-only)"; fi
+    if log_has "rev-parse origin/main"; then ok; else fail "target SHA must come from rev-parse origin/main"; fi
+    # The new SHA must flow into the build (worktree add at the new SHA).
+    if grep -F 'worktree add' "$CALL_LOG" | grep -qF "$new_sha"; then ok
+    else fail "deploy must target the NEW SHA the fetch advanced to"; fi
+    cleanup_sandbox
+    unset DEPLOY_ENV_FILE_OVERRIDE
+}
+
+test_empty_identity_with_ntfy_fires() {
+    echo "test: empty identity WITH ntfy configured -> ntfy fired (no unbound-var crash)"
+    make_sandbox
+    write_deploy_env "CRM_MAC_CODESIGN_IDENTITY=" "NTFY_URL=https://ntfy.example" "NTFY_TOPIC=tok"
+    STUB_CI_CONCLUSION=success STUB_INSTALLED_SHA="$INSTALLED_SHA" STUB_DIFF_RC=1 run_reconcile
+    # Must reach the upgrade decision, find the identity empty, ntfy, and NOT crash.
+    if log_has "Title: Mac deploy: deploy.env not configured"; then ok; else fail "empty identity must ntfy the deploy.env-not-configured notice"; fi
+    if out_has "unbound variable"; then fail "empty identity must NOT crash with an unbound variable"; else ok; fi
+    if log_lacks "deploy-mac-daemon.sh identity="; then ok; else fail "empty identity must NOT build"; fi
+    if [ "$RC" -ne 0 ]; then ok; else fail "empty identity must exit non-zero, got $RC"; fi
+    cleanup_sandbox
+    unset DEPLOY_ENV_FILE_OVERRIDE
+}
+
+test_empty_identity_absent_env_red_exit() {
+    echo "test: wholly absent deploy.env -> red exit + stderr, NO ntfy attempted"
+    make_sandbox
+    # No deploy.env at all -> NTFY disabled. Identity is therefore empty too.
+    STUB_CI_CONCLUSION=success STUB_INSTALLED_SHA="$INSTALLED_SHA" STUB_DIFF_RC=1 run_reconcile
+    if [ "$RC" -ne 0 ]; then ok; else fail "absent deploy.env empty-identity must exit non-zero, got $RC"; fi
+    if [ "$(ntfy_count)" -eq 0 ]; then ok; else fail "absent deploy.env: no ntfy POST possible (config in the missing file)"; fi
+    if out_has "CRM_MAC_CODESIGN_IDENTITY empty"; then ok; else fail "absent deploy.env must log a clear stderr message"; fi
+    if log_lacks "deploy-mac-daemon.sh identity="; then ok; else fail "empty identity must NOT build"; fi
+    cleanup_sandbox
+}
+
+test_tooling_refresh_on_noop() {
+    echo "test: tooling refresh happens even on a daemon no-op"
+    make_sandbox
+    write_deploy_env "CRM_MAC_CODESIGN_IDENTITY=My Cert" "NTFY_URL=https://ntfy.example" "NTFY_TOPIC=tok"
+    STUB_CI_CONCLUSION=success STUB_INSTALLED_SHA="$INSTALLED_SHA" STUB_DIFF_RC=0 run_reconcile
+    if [ "$RC" -eq 0 ]; then ok; else fail "no-op should exit 0, got $RC"; fi
+    # The refresh reads both scripts from origin/main BEFORE the relevance gate.
+    if log_has "show origin/main:scripts/reconcile-mac-daemon.sh"; then ok; else fail "refresh must read reconcile-mac-daemon.sh from origin/main"; fi
+    if log_has "show origin/main:scripts/deploy-mac-daemon.sh"; then ok; else fail "refresh must read deploy-mac-daemon.sh from origin/main"; fi
+    # The refreshed files land at the stable bin dir.
+    if [ -f "$INSTALL_BIN_DIR/reconcile-mac-daemon.sh" ]; then ok; else fail "refreshed reconcile script must be installed to the stable bin dir"; fi
+    cleanup_sandbox
+    unset DEPLOY_ENV_FILE_OVERRIDE
+}
+
+test_tooling_refresh_preserves_exec_bit() {
+    echo "test: tooling refresh preserves the executable bit (0755)"
+    make_sandbox
+    write_deploy_env "CRM_MAC_CODESIGN_IDENTITY=My Cert" "NTFY_URL=https://ntfy.example" "NTFY_TOPIC=tok"
+    STUB_CI_CONCLUSION=success STUB_INSTALLED_SHA="$INSTALLED_SHA" STUB_DIFF_RC=0 run_reconcile
+    for f in reconcile-mac-daemon.sh deploy-mac-daemon.sh; do
+        if [ -x "$INSTALL_BIN_DIR/$f" ]; then ok; else fail "$f must be executable after refresh"; fi
+    done
+    cleanup_sandbox
+    unset DEPLOY_ENV_FILE_OVERRIDE
+}
+
+test_timer_drift_notifies() {
+    echo "test: timer-template drift -> informational notice (changed)"
+    make_sandbox
+    write_deploy_env "CRM_MAC_CODESIGN_IDENTITY=My Cert" "NTFY_URL=https://ntfy.example" "NTFY_TOPIC=tok"
+    # Record a stored hash that differs from the committed template's hash.
+    echo "0000000000000000000000000000000000000000000000000000000000000000" > "$TEMPLATE_HASH_FILE"
+    STUB_CI_CONCLUSION=success STUB_INSTALLED_SHA="$INSTALLED_SHA" STUB_DIFF_RC=0 \
+        STUB_TEMPLATE_CONTENT="new template body" run_reconcile
+    if log_has "Title: Mac deploy: timer template changed"; then ok; else fail "drift must fire the timer-template-changed notice"; fi
+    if log_lacks "launchctl"; then ok; else fail "drift must NOT auto-reload launchd"; fi
+    cleanup_sandbox
+    unset DEPLOY_ENV_FILE_OVERRIDE
+}
+
+test_timer_drift_unchanged_no_notice() {
+    echo "test: timer template unchanged -> no notice"
+    make_sandbox
+    write_deploy_env "CRM_MAC_CODESIGN_IDENTITY=My Cert" "NTFY_URL=https://ntfy.example" "NTFY_TOPIC=tok"
+    # Compute the committed template's real hash and store it -> equal -> no notice.
+    local content="stable template body"
+    printf '%s' "$content" | shasum -a 256 | awk '{print $1}' > "$TEMPLATE_HASH_FILE"
+    STUB_CI_CONCLUSION=success STUB_INSTALLED_SHA="$INSTALLED_SHA" STUB_DIFF_RC=0 \
+        STUB_TEMPLATE_CONTENT="$content" run_reconcile
+    if log_lacks "Title: Mac deploy: timer template changed"; then ok; else fail "unchanged template must NOT notify"; fi
+    cleanup_sandbox
+    unset DEPLOY_ENV_FILE_OVERRIDE
+}
+
+test_timer_drift_ambiguous_silent() {
+    echo "test: timer-drift ambiguous (no recorded hash) -> silent, no crash"
+    make_sandbox
+    write_deploy_env "CRM_MAC_CODESIGN_IDENTITY=My Cert" "NTFY_URL=https://ntfy.example" "NTFY_TOPIC=tok"
+    # No TEMPLATE_HASH_FILE written.
+    STUB_CI_CONCLUSION=success STUB_INSTALLED_SHA="$INSTALLED_SHA" STUB_DIFF_RC=0 \
+        STUB_TEMPLATE_CONTENT="some body" run_reconcile
+    if [ "$RC" -eq 0 ]; then ok; else fail "ambiguous drift must not crash, got $RC ($OUT)"; fi
+    if log_lacks "Title: Mac deploy: timer template changed"; then ok; else fail "ambiguous drift must NOT spam a notice"; fi
+    cleanup_sandbox
+    unset DEPLOY_ENV_FILE_OVERRIDE
+}
+
+test_health_fail_max_ntfy() {
+    echo "test: max-priority ntfy on health failure"
+    make_sandbox
+    write_deploy_env "CRM_MAC_CODESIGN_IDENTITY=My Cert" "NTFY_URL=https://ntfy.example" "NTFY_TOPIC=tok"
+    STUB_CI_CONCLUSION=success STUB_INSTALLED_SHA="$INSTALLED_SHA" STUB_DIFF_RC=1 \
+        STUB_DOCTOR_OUTPUT="FAIL  agent_service: not registered" run_reconcile
+    if [ "$RC" -eq 1 ]; then ok; else fail "health failure should exit 1, got $RC"; fi
+    if log_has "Title: Mac deploy FAILED"; then ok; else fail "health failure must ntfy 'Mac deploy FAILED'"; fi
+    if log_has "Priority: max"; then ok; else fail "health failure ntfy must be max priority"; fi
+    cleanup_sandbox
+    unset DEPLOY_ENV_FILE_OVERRIDE
+}
+
+test_health_gate_parses_by_content() {
+    echo "test: health gate parses by content, not exit code"
+    make_sandbox
+    write_deploy_env "CRM_MAC_CODESIGN_IDENTITY=My Cert" "NTFY_URL=https://ntfy.example" "NTFY_TOPIC=tok"
+    # agent_service PASSES but an unrelated pi_reachability FAILS -> doctor exits
+    # non-zero. The deploy must still be declared HEALTHY (parse by content).
+    local doctor="PASS  agent_service: registered (enabled)
+FAIL  pi_reachability: 401 from Pi"
+    STUB_CI_CONCLUSION=success STUB_INSTALLED_SHA="$INSTALLED_SHA" STUB_DIFF_RC=1 \
+        STUB_DOCTOR_OUTPUT="$doctor" run_reconcile
+    if [ "$RC" -eq 0 ]; then ok; else fail "an unrelated FAIL must NOT false-fail the gate, got $RC ($OUT)"; fi
+    if log_lacks "Title: Mac deploy FAILED"; then ok; else fail "a healthy agent_service must NOT fire a FAILED ntfy"; fi
+    if log_has "Title: Mac deploy OK"; then ok; else fail "a healthy agent_service must report success"; fi
+    cleanup_sandbox
+    unset DEPLOY_ENV_FILE_OVERRIDE
+}
+
+test_contacts_pending_ntfy_on_success() {
+    echo "test: informational Contacts-pending ntfy on success"
+    make_sandbox
+    write_deploy_env "CRM_MAC_CODESIGN_IDENTITY=My Cert" "NTFY_URL=https://ntfy.example" "NTFY_TOPIC=tok"
+    STUB_CI_CONCLUSION=success STUB_INSTALLED_SHA="$INSTALLED_SHA" STUB_DIFF_RC=1 run_reconcile
+    if [ "$RC" -eq 0 ]; then ok; else fail "success should exit 0, got $RC"; fi
+    if log_has "Title: Mac deploy OK -- Contacts re-approval needed"; then ok; else fail "success must fire the combined Contacts re-approval notice"; fi
+    cleanup_sandbox
+    unset DEPLOY_ENV_FILE_OVERRIDE
+}
+
+test_build_failure_fail_closed() {
+    echo "test: build (deploy-mac-daemon.sh) failure -> fail-closed"
+    make_sandbox
+    write_deploy_env "CRM_MAC_CODESIGN_IDENTITY=My Cert" "NTFY_URL=https://ntfy.example" "NTFY_TOPIC=tok"
+    STUB_CI_CONCLUSION=success STUB_INSTALLED_SHA="$INSTALLED_SHA" STUB_DIFF_RC=1 STUB_BUILD_RC=1 run_reconcile
+    if [ "$RC" -eq 1 ]; then ok; else fail "build failure should exit 1, got $RC"; fi
+    if log_has "Title: Mac deploy FAILED"; then ok; else fail "build failure must ntfy 'Mac deploy FAILED'"; fi
+    cleanup_sandbox
+    unset DEPLOY_ENV_FILE_OVERRIDE
+}
+
+test_lock_live_holder_defers() {
+    echo "test: mkdir lock prevents concurrent runs (LIVE holder)"
+    make_sandbox
+    write_deploy_env "CRM_MAC_CODESIGN_IDENTITY=My Cert" "NTFY_URL=https://ntfy.example" "NTFY_TOPIC=tok"
+    # Pre-create the lock with an owner naming a LIVE PID ($$ of this test) + a
+    # fresh timestamp.
+    mkdir -p "$LOCK_DIR"
+    echo "$$ $(date +%s)" > "$LOCK_DIR/owner"
+    STUB_CI_CONCLUSION=success run_reconcile
+    if [ "$RC" -eq 0 ]; then ok; else fail "live-holder lock should exit 0, got $RC"; fi
+    if log_lacks "fetch --quiet origin"; then ok; else fail "live-holder lock must NOT fetch/build"; fi
+    if log_lacks "deploy-mac-daemon.sh identity="; then ok; else fail "live-holder lock must NOT build"; fi
+    # The loser's trap must NOT remove the lock it did not create.
+    if [ -d "$LOCK_DIR" ]; then ok; else fail "loser must NOT remove the winner's lock dir"; fi
+    cleanup_sandbox
+    unset DEPLOY_ENV_FILE_OVERRIDE
+}
+
+test_lock_loser_does_not_touch_worktree() {
+    echo "test: loser does NOT remove the winner's worktree"
+    make_sandbox
+    write_deploy_env "CRM_MAC_CODESIGN_IDENTITY=My Cert" "NTFY_URL=https://ntfy.example" "NTFY_TOPIC=tok"
+    mkdir -p "$LOCK_DIR"
+    echo "$$ $(date +%s)" > "$LOCK_DIR/owner"
+    STUB_CI_CONCLUSION=success run_reconcile
+    # The loser's cleanup trap must fire NO git worktree remove.
+    if log_lacks "worktree remove"; then ok; else fail "loser must NOT tear down the winner's worktree"; fi
+    cleanup_sandbox
+    unset DEPLOY_ENV_FILE_OVERRIDE
+}
+
+test_stale_lock_dead_pid_reclaims() {
+    echo "test: stale-lock recovery (dead PID)"
+    make_sandbox
+    write_deploy_env "CRM_MAC_CODESIGN_IDENTITY=My Cert" "NTFY_URL=https://ntfy.example" "NTFY_TOPIC=tok"
+    # Owner names a PID guaranteed dead (a very high, unlikely PID) + fresh ts.
+    mkdir -p "$LOCK_DIR"
+    echo "999999 $(date +%s)" > "$LOCK_DIR/owner"
+    STUB_CI_CONCLUSION=success STUB_INSTALLED_SHA="$INSTALLED_SHA" STUB_DIFF_RC=1 run_reconcile
+    if [ "$RC" -eq 0 ]; then ok; else fail "dead-PID lock should be reclaimed -> exit 0, got $RC ($OUT)"; fi
+    if log_has "fetch --quiet origin"; then ok; else fail "after reclaim, reconcile must proceed to fetch"; fi
+    if log_has "deploy-mac-daemon.sh identity="; then ok; else fail "after reclaim, reconcile must build"; fi
+    # On exit, the reclaimed lock is released (this invocation created it).
+    if [ ! -d "$LOCK_DIR" ]; then ok; else fail "reclaiming invocation must release the lock on exit"; fi
+    cleanup_sandbox
+    unset DEPLOY_ENV_FILE_OVERRIDE
+}
+
+test_stale_lock_ttl_no_owner_file() {
+    echo "test: stale-lock TTL fallback (missing owner file)"
+    make_sandbox
+    write_deploy_env "CRM_MAC_CODESIGN_IDENTITY=My Cert" "NTFY_URL=https://ntfy.example" "NTFY_TOPIC=tok"
+    # Lock dir exists but NO owner file. LOCK_STALE_SECS=0 forces the age>=TTL path.
+    mkdir -p "$LOCK_DIR"
+    LOCK_STALE_SECS_OVERRIDE=0 STUB_CI_CONCLUSION=success STUB_INSTALLED_SHA="$INSTALLED_SHA" STUB_DIFF_RC=1 run_reconcile
+    if [ "$RC" -eq 0 ]; then ok; else fail "missing-owner TTL-stale lock should be reclaimed -> exit 0, got $RC ($OUT)"; fi
+    if log_has "fetch --quiet origin"; then ok; else fail "after TTL reclaim, reconcile must proceed"; fi
+    cleanup_sandbox
+    unset DEPLOY_ENV_FILE_OVERRIDE
+}
+
+test_lock_released_on_signal() {
+    echo "test: lock + worktree cleanup trap is registered for INT TERM HUP, not EXIT alone"
+    # Structural assertion: the script registers the trap for INT TERM HUP EXIT.
+    if grep -qE 'trap cleanup EXIT INT TERM HUP' "$SCRIPT"; then ok
+    else fail "cleanup trap must cover INT TERM HUP (not EXIT alone)"; fi
+}
+
+test_path_with_spaces() {
+    echo "test: deploy path with a SPACE in the deploy root"
+    make_sandbox "deploy root with spaces"
+    write_deploy_env "CRM_MAC_CODESIGN_IDENTITY=My Cert" "NTFY_URL=https://ntfy.example" "NTFY_TOPIC=tok"
+    STUB_CI_CONCLUSION=success STUB_INSTALLED_SHA="$INSTALLED_SHA" STUB_DIFF_RC=1 run_reconcile
+    if [ "$RC" -eq 0 ]; then ok; else fail "space-bearing path deploy should exit 0, got $RC ($OUT)"; fi
+    if log_has "deploy-mac-daemon.sh identity=My Cert"; then ok; else fail "build must run from the space-bearing path"; fi
+    if log_has "worktree add --detach"; then ok; else fail "worktree add must succeed under a space-bearing path"; fi
+    if [ -f "$INSTALL_BIN_DIR/reconcile-mac-daemon.sh" ]; then ok; else fail "tooling refresh must work under a space-bearing path"; fi
+    cleanup_sandbox
+    unset DEPLOY_ENV_FILE_OVERRIDE
+}
+
+test_worktree_cleanup_on_success() {
+    echo "test: worktree removed on the success path"
+    make_sandbox
+    write_deploy_env "CRM_MAC_CODESIGN_IDENTITY=My Cert" "NTFY_URL=https://ntfy.example" "NTFY_TOPIC=tok"
+    STUB_CI_CONCLUSION=success STUB_INSTALLED_SHA="$INSTALLED_SHA" STUB_DIFF_RC=1 run_reconcile
+    # The cleanup trap (lock_created=1 on a real run) removes the worktree on exit.
+    if log_has "worktree remove"; then ok; else fail "success path must clean up the worktree (trap)"; fi
+    cleanup_sandbox
+    unset DEPLOY_ENV_FILE_OVERRIDE
+}
+
+test_worktree_cleanup_on_failure() {
+    echo "test: worktree removed on a mid-run (build) failure"
+    make_sandbox
+    write_deploy_env "CRM_MAC_CODESIGN_IDENTITY=My Cert" "NTFY_URL=https://ntfy.example" "NTFY_TOPIC=tok"
+    STUB_CI_CONCLUSION=success STUB_INSTALLED_SHA="$INSTALLED_SHA" STUB_DIFF_RC=1 STUB_BUILD_RC=1 run_reconcile
+    if [ "$RC" -eq 1 ]; then ok; else fail "build failure should exit 1, got $RC"; fi
+    if log_has "worktree remove"; then ok; else fail "failure path must clean up the worktree (trap)"; fi
+    cleanup_sandbox
+    unset DEPLOY_ENV_FILE_OVERRIDE
+}
+
+test_bootstrap_missing_stamp_deploys() {
+    echo "test: missing CRMBuildSHA stamp -> must deploy (bootstrap path)"
+    make_sandbox
+    write_deploy_env "CRM_MAC_CODESIGN_IDENTITY=My Cert" "NTFY_URL=https://ntfy.example" "NTFY_TOPIC=tok"
+    # plutil -extract exits 1 (no stamp). The relevance gate must fall through to
+    # the upgrade regardless of the diff result.
+    STUB_CI_CONCLUSION=success STUB_INSTALLED_SHA_MISSING=1 STUB_DIFF_RC=0 run_reconcile
+    if [ "$RC" -eq 0 ]; then ok; else fail "bootstrap (no stamp) should deploy + exit 0, got $RC ($OUT)"; fi
+    if log_has "deploy-mac-daemon.sh identity="; then ok; else fail "missing stamp must force a deploy (no short-circuit)"; fi
+    cleanup_sandbox
+    unset DEPLOY_ENV_FILE_OVERRIDE
+}
+
+test_ntfy_degrade_open() {
+    echo "test: ntfy absent deploy.env -> a forced fail path logs but POSTs no ntfy"
+    make_sandbox
+    # No deploy.env -> NTFY disabled. Force a CI failure (would normally ntfy).
+    STUB_CI_CONCLUSION=failure run_reconcile
+    if [ "$RC" -eq 1 ]; then ok; else fail "CI failure should still exit 1 with ntfy disabled, got $RC"; fi
+    if [ "$(ntfy_count)" -eq 0 ]; then ok; else fail "no ntfy POST may be attempted when deploy.env is absent"; fi
+    cleanup_sandbox
+}
+
+# ---------------------------------------------------------------------------
+main() {
+    test_noop_when_unchanged
+    test_deploys_when_changed
+    test_fail_closed_on_ci_failure
+    test_soft_skip_on_ci_missing
+    test_transient_gh_failure_soft_skips
+    test_unauthed_gh_informational_notice
+    test_structural_gh_failure_informational
+    test_soft_skip_on_fetch_failure
+    test_fetch_advances_tracking_ref
+    test_empty_identity_with_ntfy_fires
+    test_empty_identity_absent_env_red_exit
+    test_tooling_refresh_on_noop
+    test_tooling_refresh_preserves_exec_bit
+    test_timer_drift_notifies
+    test_timer_drift_unchanged_no_notice
+    test_timer_drift_ambiguous_silent
+    test_health_fail_max_ntfy
+    test_health_gate_parses_by_content
+    test_contacts_pending_ntfy_on_success
+    test_build_failure_fail_closed
+    test_lock_live_holder_defers
+    test_lock_loser_does_not_touch_worktree
+    test_stale_lock_dead_pid_reclaims
+    test_stale_lock_ttl_no_owner_file
+    test_lock_released_on_signal
+    test_path_with_spaces
+    test_worktree_cleanup_on_success
+    test_worktree_cleanup_on_failure
+    test_bootstrap_missing_stamp_deploys
+    test_ntfy_degrade_open
+
+    echo ""
+    echo "===================="
+    echo "PASS=$PASS FAIL=$FAIL"
+    echo "===================="
+    [ "$FAIL" -eq 0 ]
+}
+
+main "$@"

--- a/scripts/reconcile-mac-daemon.test.sh
+++ b/scripts/reconcile-mac-daemon.test.sh
@@ -172,6 +172,33 @@ echo "launchctl \$*" >> "$CALL_LOG"
 exit 0
 EOF
 
+    # --- stub: stat (lock-dir mtime) --------------------------------------
+    # The lock-mtime path calls `stat -f %m DIR` (BSD) then `stat -c %Y DIR`
+    # (GNU). Stub it so the missing-owner TTL branch is HERMETIC -- never
+    # dependent on the host's real stat (which differs BSD vs GNU and leaked the
+    # GNU `-f`=--file-system "  File: ..." block into arithmetic on Linux CI).
+    #   default                 -> emit ${STUB_STAT_MTIME:-1000} for -f %m / -c %Y
+    #   STUB_STAT_GARBAGE=1      -> model GNU `stat -f %m DIR` (=--file-system):
+    #                              a multi-line block whose first line is "  File:"
+    #                              and exit 0, so the script must validate + not crash
+    cat > "$SANDBOX/bin/stat" <<EOF
+#!/usr/bin/env bash
+echo "stat \$*" >> "$CALL_LOG"
+if [ "\${STUB_STAT_GARBAGE:-0}" = "1" ]; then
+  # GNU \`stat -f %m DIR\` prints a filesystem block (NOT a number) and exits 0.
+  if [ "\$1" = "-f" ]; then
+    printf '  File: "%s"\n    ID: 0 Namelen: 255 Type: apfs\n' "\${@: -1}"
+    exit 0
+  fi
+  # GNU \`-c %Y\` would still work, but model the worst case: also non-numeric.
+  echo "garbage"
+  exit 0
+fi
+# Hermetic numeric mtime for both BSD (-f %m) and GNU (-c %Y) forms.
+echo "\${STUB_STAT_MTIME:-1000}"
+exit 0
+EOF
+
     # --- stub: sleep (no-op so retry loops run instantly) -----------------
     cat > "$SANDBOX/bin/sleep" <<'EOF'
 #!/usr/bin/env bash
@@ -583,11 +610,31 @@ test_stale_lock_ttl_no_owner_file() {
     echo "test: stale-lock TTL fallback (missing owner file)"
     make_sandbox
     write_deploy_env "CRM_MAC_CODESIGN_IDENTITY=My Cert" "NTFY_URL=https://ntfy.example" "NTFY_TOPIC=tok"
-    # Lock dir exists but NO owner file. LOCK_STALE_SECS=0 forces the age>=TTL path.
+    # Lock dir exists but NO owner file. The `stat` stub returns a fixed numeric
+    # mtime (1000); LOCK_STALE_SECS=0 forces the age>=TTL reclaim path. Hermetic:
+    # never touches the host's real stat (BSD vs GNU output differs).
     mkdir -p "$LOCK_DIR"
     LOCK_STALE_SECS_OVERRIDE=0 STUB_CI_CONCLUSION=success STUB_INSTALLED_SHA="$INSTALLED_SHA" STUB_DIFF_RC=1 run_reconcile
     if [ "$RC" -eq 0 ]; then ok; else fail "missing-owner TTL-stale lock should be reclaimed -> exit 0, got $RC ($OUT)"; fi
     if log_has "fetch --quiet origin"; then ok; else fail "after TTL reclaim, reconcile must proceed"; fi
+    cleanup_sandbox
+    unset DEPLOY_ENV_FILE_OVERRIDE
+}
+
+test_stale_lock_garbage_stat_does_not_crash() {
+    echo "test: missing owner + non-numeric stat output -> safe reclaim, NO crash"
+    make_sandbox
+    write_deploy_env "CRM_MAC_CODESIGN_IDENTITY=My Cert" "NTFY_URL=https://ntfy.example" "NTFY_TOPIC=tok"
+    # Lock dir exists, NO owner file, and `stat -f %m` emits a non-numeric
+    # filesystem block (the GNU `stat -f`=--file-system "  File: ..." output that
+    # crashed Linux CI: `File: unbound variable` under set -u). The mtime must be
+    # rejected as unparseable and the lock RECLAIMED, never an arithmetic crash.
+    mkdir -p "$LOCK_DIR"
+    STUB_STAT_GARBAGE=1 STUB_CI_CONCLUSION=success STUB_INSTALLED_SHA="$INSTALLED_SHA" STUB_DIFF_RC=1 run_reconcile
+    if [ "$RC" -eq 0 ]; then ok; else fail "garbage stat output must reclaim safely -> exit 0, got $RC ($OUT)"; fi
+    if out_has "unbound variable"; then fail "garbage stat output must NOT crash with an unbound variable"; else ok; fi
+    if out_has "arithmetic"; then fail "garbage stat output must NOT hit an arithmetic error"; else ok; fi
+    if log_has "fetch --quiet origin"; then ok; else fail "after safe reclaim, reconcile must proceed"; fi
     cleanup_sandbox
     unset DEPLOY_ENV_FILE_OVERRIDE
 }
@@ -684,6 +731,7 @@ main() {
     test_lock_loser_does_not_touch_worktree
     test_stale_lock_dead_pid_reclaims
     test_stale_lock_ttl_no_owner_file
+    test_stale_lock_garbage_stat_does_not_crash
     test_lock_released_on_signal
     test_path_with_spaces
     test_worktree_cleanup_on_success


### PR DESCRIPTION
PR2 of 4 in the Mac deploy-automation Bucket A plan (`.ai/spec/2026-06-12-mac-deploy-automation-design.md`). Adds the load-bearing reconcile orchestrator that the self-hosted Mac runner and the launchd timer both invoke.

## What this adds
- **`scripts/reconcile-mac-daemon.sh`** — idempotent, fail-closed reconcile-to-`origin/main` orchestrator: mkdir-based atomic lock with two-factor stale recovery (no `flock` on macOS); explicit-refspec `git fetch`; CI gate querying the ci.yml conclusion for the target SHA via the user's `gh` auth, with an auth/structural-vs-transient split (in-progress/not-found soft-skip exit 0, genuinely-failed conclusion fails closed with ntfy); tooling self-refresh from the clone *before* the relevance gate; `CRMBuildSHA` relevance gate (reads the installed bundle `Info.plist`, `git diff --quiet <installedSHA> <targetSHA> -- mac-daemon/` to skip no-ops); worktree-isolated build delegated to `scripts/deploy-mac-daemon.sh`; health gate that parses `crm-mac doctor`'s `agent_service` line by content (not exit code); outcome-keyed ntfy.
- **`scripts/reconcile-mac-daemon.test.sh`** — 84-assertion mocked suite stubbing `git`/`gh`/`plutil`/`crm-mac`/`curl`/`launchctl`, covering soft-skip, fail-closed, no-op relevance skip, build path, and health-gate pass/fail.
- **`make test-deploy-scripts`** gate wiring both shell suites into the pre-push hook (`.ai/pre-push.json`, classified CONCURRENT, with a phase-guard assertion) and CI's `backend-tests` job.

No production Swift/Go change. `deploy-mac.yml`, `setup-mac-deploy.sh`, the timer template, and the runbook are intentionally deferred to PR3/PR4.

## Review
Codex was usage-limited (`ALL_EXHAUSTED`) this window, so Phase 3 used the Claude self-review fallback (which caught and fixed 2 real bugs: a health-gate SIGPIPE false-fail and a timer-drift empty-string-hash guard), and the gate was a fresh-context `/review-head` pass. Both **PASS** (0×P0, 0×P1). The review-head pass empirically ran the suites + shellcheck + standalone branch probes (CI-conclusion classifier, gh auth-vs-transient split, relevance fall-through, health-gate parse, lock release on soft-skip) and found no fail-open or false-alarm paths.

Accepted non-blocking findings: (P2) the two worktree-cleanup tests assert presence of `worktree remove` and so can't distinguish the trap's cleanup from the unconditional pre-add remove — cleanup is correct, the test is just weaker than claimed; (P2) `make mac-daemon` swallows a `git rev-parse` failure into a fail-safe empty stamp; (P3) minor. One documented plan deviation (§3.1): a single combined `Mac deploy OK -- Contacts re-approval needed` success ntfy instead of two pushes, noted in the script header.
