### PR TITLE
feat(mac-deploy): deploy-mac.yml + setup script + timer template

### DIFF
--- a/.github/workflows/deploy-mac.yml
+++ b/.github/workflows/deploy-mac.yml
@@ -1,0 +1,46 @@
+name: Deploy Mac Daemon
+
+# Promotion-triggered Mac daemon deploy. Fires ONLY on push to main (the
+# coordinator fast-forwards main to a reviewed develop SHA). It sits INERT on
+# develop and on every PR — no develop or pull_request trigger — so fork code
+# never reaches the self-hosted Mac runner.
+#
+# A separate workflow from deploy-prod.yml (NOT a job there) on purpose: a Mac
+# job in deploy-prod.yml would inherit its `concurrency: deploy-pi` group, so a
+# queued/slow Mac run could stall or supersede a Pi deploy. This workflow gets
+# its OWN concurrency group instead.
+#
+# A thin trigger: it invokes the locally-installed reconcile orchestrator, which
+# does its own fetch + CI gate + relevance gate. No checkout, no marketplace
+# actions (nothing to SHA-pin), no sudo — the entire Mac deploy is userland, run
+# as the logged-in user. The reconcile script queries CI via the USER's `gh`
+# auth, not the workflow GITHUB_TOKEN, so this workflow needs no `actions: read`.
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: deploy-mac             # its OWN group — never shares deploy-pi
+  cancel-in-progress: false     # a new promote queues behind a running deploy;
+                                # reconcile-to-main makes the queued run converge to latest
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: [self-hosted, mac]
+    environment: production       # the production Environment enforces the main-only rule
+    steps:
+      - name: Reconcile mac-daemon to origin/main
+        # The installed reconcile path contains a space ("Application Support").
+        # In a YAML `run:` the outer quotes are YAML string syntax and are
+        # STRIPPED before the shell sees the command — a single-line
+        # `run: "$HOME/.../reconcile-mac-daemon.sh"` would leave the shell an
+        # unquoted, space-bearing path that it word-splits ("no such file"). The
+        # `run: |` block scalar below preserves the literal shell quotes so the
+        # shell receives a properly-quoted path. The path is the stable install
+        # location written by `make setup-mac-deploy` (scripts/setup-mac-deploy.sh).
+        run: |
+          "$HOME/Library/Application Support/crm-mac-deploy/bin/reconcile-mac-daemon.sh"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Personal CRM Makefile
 
-.PHONY: help setup dev dev-seed staging-reset build crm-admin mac-daemon test test-daemon-local clean docker-up docker-down docker-reset test-cadence-ultra test-cadence-fast prod staging testing start start-local stop restart reload status dev-stop dev-restart dev-api-stop dev-api-start dev-api-restart ci-build-backend ci-build-frontend ci-build ci-test test-e2e test-e2e-local test-e2e-diff e2e-db deploy-mac promote setup-pi dev-native postgres-native sqlc smoke-test test-deploy-scripts test-integration-fast test-integration-slow test-clean-clones check-cadence-sole-writer check-followup-sole-writer check-rematch-sole-dispatcher check-crm-marker-construction check-sqlc-select-lists lint-ingest-registry
+.PHONY: help setup dev dev-seed staging-reset build crm-admin mac-daemon test test-daemon-local clean docker-up docker-down docker-reset test-cadence-ultra test-cadence-fast prod staging testing start start-local stop restart reload status dev-stop dev-restart dev-api-stop dev-api-start dev-api-restart ci-build-backend ci-build-frontend ci-build ci-test test-e2e test-e2e-local test-e2e-diff e2e-db deploy-mac promote setup-pi setup-mac-deploy dev-native postgres-native sqlc smoke-test test-deploy-scripts test-integration-fast test-integration-slow test-clean-clones check-cadence-sole-writer check-followup-sole-writer check-rematch-sole-dispatcher check-crm-marker-construction check-sqlc-select-lists lint-ingest-registry
 
 # Repo root (supports running make from subdirectories).
 REPO_ROOT := $(shell git rev-parse --show-toplevel)
@@ -107,9 +107,10 @@ help:
 	@echo "  test-cadence-fast  - Test all cadences in hours (staging env)"
 	@echo ""
 	@echo "Deployment:"
-	@echo "  setup-pi   - One-time Pi setup (create user, directories)"
-	@echo "  promote    - Fast-forward main to develop (triggers prod deploy)"
-	@echo "  deploy-mac - Build and install the Mac daemon (requires CRM_MAC_CODESIGN_IDENTITY)"
+	@echo "  setup-pi         - One-time Pi setup (create user, directories)"
+	@echo "  setup-mac-deploy - One-time Mac deploy setup (clone + reconcile + timer)"
+	@echo "  promote          - Fast-forward main to develop (triggers prod deploy)"
+	@echo "  deploy-mac       - Build and install the Mac daemon (requires CRM_MAC_CODESIGN_IDENTITY)"
 
 # Setup development environment (installs all dev dependencies)
 # Run this first when setting up a new development environment
@@ -401,11 +402,18 @@ test-api:
 	@cd backend && go test ./tests/... -v
 
 # Mocked shell suites for the deploy orchestrators (Pi + Mac). Pure bash with
-# PATH-shadow stubs (no podman/Mac/network), so they run on any CI runner.
+# PATH-shadow stubs (no podman/Mac/network), so they run on any CI runner. The
+# committed timer template is validated for XML/plist well-formedness with a
+# cross-platform python3 plistlib parse (the __INSTALL_PREFIX__ placeholder lives
+# inside <string> values, so it parses fine); plutil is macOS-only and not used here.
 test-deploy-scripts:
 	@echo "Running deploy-script shell tests..."
 	@bash scripts/deploy-artifact.test.sh
 	@bash scripts/reconcile-mac-daemon.test.sh
+	@bash scripts/setup-mac-deploy.test.sh
+	@echo "Validating the committed timer template (plistlib parse)..."
+	@python3 -c "import plistlib,sys; plistlib.loads(open(sys.argv[1],'rb').read()); print('  timer template OK')" \
+		infra/mac-deploy/xyz.spengrah.crm-mac-deploy.plist.template
 
 smoke-test:
 	@echo "Running full system smoke test..."
@@ -731,3 +739,9 @@ promote:
 
 setup-pi:
 	@./scripts/setup-pi.sh
+
+# One-time Mac deploy setup (dedicated clone, reconcile install, timer LaunchAgent).
+# Operational wiring (runner registration, deploy.env values, codesign key
+# pre-auth) is the runbook's job — see infra/mac-runner-installation-runbook.md.
+setup-mac-deploy:
+	@./scripts/setup-mac-deploy.sh

--- a/infra/mac-deploy/xyz.spengrah.crm-mac-deploy.plist.template
+++ b/infra/mac-deploy/xyz.spengrah.crm-mac-deploy.plist.template
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  crm-mac-deploy reconcile timer (LaunchAgent template).
+
+  __INSTALL_PREFIX__ is substituted by scripts/setup-mac-deploy.sh to the
+  absolute deploy root ($CRM_MAC_DEPLOY_ROOT, default
+  "$HOME/Library/Application Support/crm-mac-deploy"). The RENDERED plist is
+  written to ~/Library/LaunchAgents and is NEVER committed (it carries the
+  absolute, username-bearing path). Only this placeholder template is committed.
+
+  This is a one-shot TIMER (not a persistent daemon): no KeepAlive. It uses
+  StartCalendarInterval + RunAtLoad — NOT StartInterval — because
+  StartCalendarInterval coalesces a sleep-missed fire (launchd catches it up
+  after wake) whereas StartInterval silently drops missed fires; RunAtLoad fires
+  once on login. Four daily entries give a ~6h "longer than hourly" cadence plus
+  the login fire. The invoked script does its own fetch + CI gate + relevance
+  gate, so an extra fire is a cheap no-op.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>xyz.spengrah.crm-mac-deploy</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__INSTALL_PREFIX__/bin/reconcile-mac-daemon.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StartCalendarInterval</key>
+    <array>
+        <dict><key>Hour</key><integer>3</integer><key>Minute</key><integer>0</integer></dict>
+        <dict><key>Hour</key><integer>9</integer><key>Minute</key><integer>0</integer></dict>
+        <dict><key>Hour</key><integer>15</integer><key>Minute</key><integer>0</integer></dict>
+        <dict><key>Hour</key><integer>21</integer><key>Minute</key><integer>0</integer></dict>
+    </array>
+    <key>ProcessType</key>
+    <string>Background</string>
+    <key>StandardOutPath</key>
+    <string>__INSTALL_PREFIX__/reconcile-stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>__INSTALL_PREFIX__/reconcile-stderr.log</string>
+</dict>
+</plist>

--- a/scripts/setup-mac-deploy.sh
+++ b/scripts/setup-mac-deploy.sh
@@ -71,7 +71,12 @@ mkdir -p "$DEPLOY_ROOT" "$INSTALL_BIN_DIR"
 # ---------------------------------------------------------------------------
 if [ -d "$CLONE_DIR/.git" ]; then
     log "clone exists at $CLONE_DIR; fetching origin"
-    git -C "$CLONE_DIR" fetch --quiet origin
+    # Soft-skip a failed fetch: the remaining steps (install, render, hash, load)
+    # all operate on the already-present local clone, so an offline re-run (e.g.
+    # "re-run to load the timer after filling deploy.env") must still complete
+    # them rather than aborting under `set -e` on a transient network blip.
+    git -C "$CLONE_DIR" fetch --quiet origin \
+        || log "warning: fetch failed (offline?); continuing with the existing clone"
 else
     if [ -z "$ORIGIN_URL" ]; then
         log "ERROR: could not determine the origin URL to clone from."

--- a/scripts/setup-mac-deploy.sh
+++ b/scripts/setup-mac-deploy.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# PersonalCRM Mac deploy setup (one-time, idempotent).
+#
+# Sets up the SCRIPTABLE parts of the Mac deploy path (Bucket A). The
+# operational wiring — registering the [self-hosted, mac] runner, filling in
+# deploy.env, pre-authorizing the codesign key — is the runbook's job (Bucket B)
+# and is performed separately.
+#
+# Runs LOCALLY on the Mac, as the logged-in user (NO sudo; the whole Mac deploy
+# is userland). Re-running is safe (idempotent): it never re-clones an existing
+# clone, never overwrites an existing deploy.env, and bootout-then-bootstraps the
+# timer.
+#
+# This script:
+#   - creates the deploy-root skeleton ($DEPLOY_ROOT + bin/);
+#   - clones (or fetches) a DEDICATED repo clone the reconcile orchestrator
+#     fetches/builds from (kept separate from your dev tree);
+#   - installs reconcile-mac-daemon.sh + deploy-mac-daemon.sh to the stable bin
+#     path the workflow + timer invoke (reconcile self-refreshes them in place);
+#   - scaffolds deploy.env (chmod 600, uncommitted) if absent;
+#   - renders the timer LaunchAgent from the committed template (substituting
+#     __INSTALL_PREFIX__) and records the template's content hash for reconcile's
+#     drift detection;
+#   - loads the timer ONLY once deploy.env is fully configured (the RunAtLoad
+#     timer fires immediately on bootstrap, so loading it before a real codesign
+#     identity + ntfy config is set would run a deploy that can't sign and can't
+#     notify — see the deferred-load guard below).
+#
+# After running this (with deploy.env still a scaffold) you must:
+#   1. Fill in deploy.env (CRM_MAC_CODESIGN_IDENTITY, NTFY_URL, NTFY_TOPIC).
+#   2. Pre-authorize the codesign signing key for non-interactive codesign.
+#   3. Re-run `make setup-mac-deploy` to LOAD the timer.
+# See infra/mac-runner-installation-runbook.md for the full Bucket-B procedure.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration. Defaults MUST match scripts/reconcile-mac-daemon.sh's defaults
+# (DEPLOY_ROOT, the stable bin path, deploy.env, the template-hash file) so the
+# two never drift. Env-overridable so the mocked test can sandbox them.
+# ---------------------------------------------------------------------------
+DEPLOY_ROOT="${CRM_MAC_DEPLOY_ROOT:-$HOME/Library/Application Support/crm-mac-deploy}"
+CLONE_DIR="${CRM_MAC_CLONE_DIR:-$DEPLOY_ROOT/repo}"
+INSTALL_BIN_DIR="${CRM_MAC_INSTALL_BIN_DIR:-$DEPLOY_ROOT/bin}"
+DEPLOY_ENV_FILE="${CRM_MAC_DEPLOY_ENV_FILE:-$DEPLOY_ROOT/deploy.env}"
+INSTALLED_TEMPLATE_HASH_FILE="${CRM_MAC_INSTALLED_TEMPLATE_HASH_FILE:-$DEPLOY_ROOT/.installed-template-hash}"
+# The committed timer template, relative to origin/main (matches reconcile's
+# TIMER_TEMPLATE_PATH default so the drift compare lines up).
+TIMER_TEMPLATE_PATH="${CRM_MAC_TIMER_TEMPLATE_PATH:-infra/mac-deploy/xyz.spengrah.crm-mac-deploy.plist.template}"
+# The rendered (on-disk) LaunchAgent plist. NEVER committed.
+LAUNCH_AGENT_LABEL="${CRM_MAC_LAUNCH_AGENT_LABEL:-xyz.spengrah.crm-mac-deploy}"
+LAUNCH_AGENT_DIR="${CRM_MAC_LAUNCH_AGENT_DIR:-$HOME/Library/LaunchAgents}"
+RENDERED_PLIST="${CRM_MAC_RENDERED_PLIST:-$LAUNCH_AGENT_DIR/$LAUNCH_AGENT_LABEL.plist}"
+# Origin URL for the dedicated clone. Defaults to this dev tree's origin so a
+# bare `make setup-mac-deploy` Just Works; overridable for tests / re-homing.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+ORIGIN_URL="${CRM_MAC_ORIGIN_URL:-$(git -C "$PROJECT_DIR" remote get-url origin 2>/dev/null || true)}"
+
+log() { echo "[setup-mac-deploy] $*"; }
+
+# ---------------------------------------------------------------------------
+# Step 0: create the directory skeleton FIRST. A clean first run has no
+# $DEPLOY_ROOT; without this, the clone + install below fail "no such file or
+# directory". `mkdir -p` is idempotent.
+# ---------------------------------------------------------------------------
+mkdir -p "$DEPLOY_ROOT" "$INSTALL_BIN_DIR"
+
+# ---------------------------------------------------------------------------
+# Step 1: create (or fetch) the dedicated clone.
+# ---------------------------------------------------------------------------
+if [ -d "$CLONE_DIR/.git" ]; then
+    log "clone exists at $CLONE_DIR; fetching origin"
+    git -C "$CLONE_DIR" fetch --quiet origin
+else
+    if [ -z "$ORIGIN_URL" ]; then
+        log "ERROR: could not determine the origin URL to clone from."
+        log "Set CRM_MAC_ORIGIN_URL or run from a checkout with an 'origin' remote."
+        exit 1
+    fi
+    log "cloning $ORIGIN_URL -> $CLONE_DIR"
+    git clone --quiet "$ORIGIN_URL" "$CLONE_DIR"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 2: install the reconcile orchestrator + delegated deploy-mac-daemon.sh to
+# the stable bin path. The workflow + timer invoke this stable path; reconcile's
+# tooling-refresh updates them in place on subsequent runs. install(1) sets the
+# mode + does the copy in one step.
+# ---------------------------------------------------------------------------
+for script in reconcile-mac-daemon.sh deploy-mac-daemon.sh; do
+    install -m 0755 "$CLONE_DIR/scripts/$script" "$INSTALL_BIN_DIR/$script"
+    log "installed $script -> $INSTALL_BIN_DIR/$script"
+done
+
+# ---------------------------------------------------------------------------
+# Step 3: scaffold deploy.env (chmod 600) if absent. NEVER overwrite an existing
+# one (it carries the real codesign identity + ntfy config the user filled in).
+# Lives OUTSIDE the repo tree, so it needs no .gitignore entry.
+# ---------------------------------------------------------------------------
+if [ -f "$DEPLOY_ENV_FILE" ]; then
+    log "deploy.env exists at $DEPLOY_ENV_FILE; leaving it untouched"
+else
+    cat > "$DEPLOY_ENV_FILE" <<'EOF'
+# crm-mac-deploy configuration (chmod 600; NEVER commit this file).
+# Fill in all three before re-running `make setup-mac-deploy` to load the timer.
+
+# Local self-signed Code Signing certificate name (a stable identity keeps the
+# designated requirement constant across rebuilds so FDA grants survive). Set to
+# "-" to force ad-hoc signing.
+CRM_MAC_CODESIGN_IDENTITY=
+
+# ntfy base URL + topic for deploy notifications (the deploy's only failure
+# signal). Both must be set for notifications to fire.
+NTFY_URL=
+NTFY_TOPIC=
+EOF
+    chmod 600 "$DEPLOY_ENV_FILE"
+    log "scaffolded deploy.env at $DEPLOY_ENV_FILE (chmod 600) — fill it in"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 4: render the timer LaunchAgent from the committed template, substituting
+# __INSTALL_PREFIX__ -> the absolute $DEPLOY_ROOT. Record the committed
+# template's content hash so reconcile's drift detection can compare. The
+# rendered plist is NEVER committed (it carries the absolute, username-bearing
+# path).
+# ---------------------------------------------------------------------------
+TEMPLATE_FILE="$CLONE_DIR/$TIMER_TEMPLATE_PATH"
+if [ ! -f "$TEMPLATE_FILE" ]; then
+    log "ERROR: timer template not found at $TEMPLATE_FILE"
+    exit 1
+fi
+
+mkdir -p "$LAUNCH_AGENT_DIR"
+# Substitute __INSTALL_PREFIX__ -> $DEPLOY_ROOT (only ever inside <string>
+# values). Use a control char (0x01) as the sed delimiter: a filesystem path can
+# legitimately contain '/' or '|', but never an embedded control char, so this
+# can never collide with the replacement text.
+DELIM="$(printf '\001')"
+sed "s${DELIM}__INSTALL_PREFIX__${DELIM}${DEPLOY_ROOT}${DELIM}g" \
+    "$TEMPLATE_FILE" > "$RENDERED_PLIST"
+log "rendered timer plist -> $RENDERED_PLIST"
+
+# Validate the rendered plist (macOS only; plutil is absent on other hosts).
+if command -v plutil >/dev/null 2>&1; then
+    plutil -lint "$RENDERED_PLIST" >/dev/null
+    log "plutil -lint OK"
+fi
+
+# Record the committed template's content hash, hashed over EXACTLY the bytes
+# reconcile reads (`git show origin/main:<template>`), so the two hashes match.
+template_bytes="$(git -C "$CLONE_DIR" show "origin/main:$TIMER_TEMPLATE_PATH" 2>/dev/null || true)"
+if [ -n "$template_bytes" ]; then
+    printf '%s' "$template_bytes" | shasum -a 256 | awk '{print $1}' > "$INSTALLED_TEMPLATE_HASH_FILE"
+    log "recorded template hash -> $INSTALLED_TEMPLATE_HASH_FILE"
+else
+    # The template is not at origin/main yet (e.g. first setup before PR3 merges,
+    # or a clone not yet fetched to the SHA that has it). Skip the hash record;
+    # reconcile's drift check treats a missing hash as "ambiguous -> silent".
+    log "WARNING: timer template not found at origin/main; skipping hash record"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 5: load the timer ONLY IF deploy.env is FULLY configured. The RunAtLoad
+# timer fires reconcile IMMEDIATELY on bootstrap; loading it before deploy.env
+# carries a real codesign identity AND ntfy config would (a) run a deploy with an
+# empty identity (a failed/ad-hoc build that resets FDA), and/or (b) run blind
+# with no notification — the deploy's only failure signal. Require ALL THREE.
+# ---------------------------------------------------------------------------
+deploy_env_value() {
+    # Read a KEY's value from deploy.env without sourcing it into this shell.
+    # Strips surrounding quotes; returns the last assignment if duplicated.
+    local key="$1" line
+    line="$(grep -E "^${key}=" "$DEPLOY_ENV_FILE" 2>/dev/null | tail -n1 || true)"
+    line="${line#"${key}"=}"
+    line="${line%\"}"
+    line="${line#\"}"
+    printf '%s' "$line"
+}
+
+identity="$(deploy_env_value CRM_MAC_CODESIGN_IDENTITY)"
+ntfy_url="$(deploy_env_value NTFY_URL)"
+ntfy_topic="$(deploy_env_value NTFY_TOPIC)"
+
+timer_loaded=false
+if [ -n "$identity" ] && [ -n "$ntfy_url" ] && [ -n "$ntfy_topic" ]; then
+    if ! command -v launchctl >/dev/null 2>&1; then
+        log "WARNING: launchctl not found; cannot load the timer (not on macOS?)."
+    else
+        local_uid="$(id -u)"
+        domain="gui/$local_uid"
+        # A non-login (no gui domain) context cannot bootstrap a LaunchAgent.
+        # Detect + warn rather than silently no-op.
+        if ! launchctl print "$domain" >/dev/null 2>&1; then
+            log "WARNING: no gui domain for $domain — run this in your login session to load the timer."
+        else
+            # bootout-then-bootstrap = idempotent reload.
+            launchctl bootout "$domain" "$RENDERED_PLIST" 2>/dev/null || true
+            launchctl bootstrap "$domain" "$RENDERED_PLIST"
+            timer_loaded=true
+            log "timer loaded (launchctl bootstrap $domain)"
+        fi
+    fi
+else
+    log "timer rendered but NOT loaded — fill in deploy.env (identity + ntfy)"
+    log "then re-run \`make setup-mac-deploy\`."
+fi
+
+# ---------------------------------------------------------------------------
+# Step 6: validate + report.
+# ---------------------------------------------------------------------------
+echo ""
+log "=== setup summary ==="
+log "clone:          $CLONE_DIR"
+log "reconcile bin:  $INSTALL_BIN_DIR/reconcile-mac-daemon.sh"
+log "deploy.env:     $DEPLOY_ENV_FILE"
+log "timer plist:    $RENDERED_PLIST"
+if [ "$timer_loaded" = true ]; then
+    log "timer:          LOADED"
+else
+    log "timer:          rendered, NOT loaded (deploy.env incomplete or non-login context)"
+fi
+
+# The CI gate depends on the user's `gh` auth; warn if it is not authed.
+if command -v gh >/dev/null 2>&1; then
+    if gh auth status >/dev/null 2>&1; then
+        log "gh auth:        OK"
+    else
+        log "gh auth:        NOT authed — run \`gh auth login\` (the CI gate needs it)."
+    fi
+else
+    log "gh auth:        gh not installed — install it (the CI gate needs it)."
+fi
+
+echo ""
+log "Next (Bucket B — see infra/mac-runner-installation-runbook.md):"
+log "  - register the [self-hosted, mac] runner;"
+log "  - fill in deploy.env (identity + ntfy) if still a scaffold;"
+log "  - pre-authorize the codesign signing key;"
+log "  - re-run \`make setup-mac-deploy\` to load the timer."

--- a/scripts/setup-mac-deploy.test.sh
+++ b/scripts/setup-mac-deploy.test.sh
@@ -88,8 +88,16 @@ fi
 if [ "\$1" = "-C" ]; then
   dir="\$2"; shift 2
   case "\$1" in
-    fetch)  exit 0 ;;
-    show)   cat "\$payload/$TIMER_TEMPLATE_PATH" ;;
+    fetch)  exit "\${STUB_FETCH_RC:-0}" ;;
+    show)
+      # Ref-aware: the production hash path MUST read the remote-tracking ref
+      # \`origin/main:<template>\` (the same ref reconcile's drift check reads).
+      # Honor ONLY that ref so a wrong-ref regression (e.g. HEAD:/bare main:)
+      # makes \`git show\` fail -> empty hash -> the hash test reds the suite.
+      case "\$2" in
+        origin/main:*) cat "\$payload/$TIMER_TEMPLATE_PATH" ;;
+        *)             exit 1 ;;
+      esac ;;
     remote) echo "https://github.com/spengrah/PersonalCRM.git" ;;
     *)      exit 0 ;;
   esac
@@ -290,6 +298,22 @@ test_timer_not_loaded_when_partial() {
     cleanup_sandbox
 }
 
+test_timer_not_loaded_when_identity_empty() {
+    echo "test: timer NOT bootstrapped when identity is empty but ntfy IS set"
+    make_sandbox
+    seed_existing_clone
+    # The inverse of the partial case: ntfy fully set, identity EMPTY. This is
+    # the safety-critical sub-rule of the all-three guard -- an empty
+    # CRM_MAC_CODESIGN_IDENTITY must never let the RunAtLoad timer bootstrap (it
+    # would immediately fire a deploy that ad-hoc-signs and resets FDA). Without
+    # this case, dropping the identity check from the guard slips through green.
+    write_deploy_env "CRM_MAC_CODESIGN_IDENTITY=" "NTFY_URL=https://ntfy.example" "NTFY_TOPIC=tok"
+    run_setup
+    if [ "$RC" -eq 0 ]; then ok; else fail "identity-empty run should exit 0, got $RC ($OUT)"; fi
+    if log_lacks "launchctl bootstrap"; then ok; else fail "empty identity must NOT bootstrap (even with ntfy set)"; fi
+    cleanup_sandbox
+}
+
 test_timer_loaded_when_fully_configured() {
     echo "test: timer IS bootstrapped once all three vars are set"
     make_sandbox
@@ -315,6 +339,21 @@ test_timer_not_loaded_in_non_gui_context() {
     cleanup_sandbox
 }
 
+test_offline_rerun_still_completes_local_steps() {
+    echo "test: offline re-run (fetch fails) still installs + renders + loads from the existing clone"
+    make_sandbox
+    seed_existing_clone
+    write_deploy_env "CRM_MAC_CODESIGN_IDENTITY=My Cert" "NTFY_URL=https://ntfy.example" "NTFY_TOPIC=tok"
+    # Fetch fails (offline), but the script must soft-skip and complete the
+    # local-only steps rather than aborting under set -e.
+    STUB_FETCH_RC=1 run_setup
+    if [ "$RC" -eq 0 ]; then ok; else fail "offline re-run should still exit 0, got $RC ($OUT)"; fi
+    if [ -x "$INSTALL_BIN_DIR/reconcile-mac-daemon.sh" ]; then ok; else fail "offline re-run must still install the reconcile script"; fi
+    if [ -f "$RENDERED_PLIST" ]; then ok; else fail "offline re-run must still render the timer plist"; fi
+    if log_has "launchctl bootstrap"; then ok; else fail "offline re-run with a full deploy.env must still load the timer"; fi
+    cleanup_sandbox
+}
+
 # ---------------------------------------------------------------------------
 main() {
     test_fresh_first_run_creates_skeleton
@@ -325,8 +364,10 @@ main() {
     test_records_template_hash
     test_timer_not_loaded_when_scaffold_empty
     test_timer_not_loaded_when_partial
+    test_timer_not_loaded_when_identity_empty
     test_timer_loaded_when_fully_configured
     test_timer_not_loaded_in_non_gui_context
+    test_offline_rerun_still_completes_local_steps
 
     echo ""
     echo "===================="

--- a/scripts/setup-mac-deploy.test.sh
+++ b/scripts/setup-mac-deploy.test.sh
@@ -186,6 +186,24 @@ run_setup() {
 log_has()   { grep -qF -- "$1" "$CALL_LOG"; }
 log_lacks() { ! grep -qF -- "$1" "$CALL_LOG"; }
 
+# get_mode <path>: octal file mode, portable across BSD (macOS) and GNU (Linux)
+# stat. Echoes the bare octal mode (e.g. 600) on success, or NOTHING (empty) if
+# neither form yields octal. Mirrors reconcile's get_mtime portability fix: BSD
+# `stat -f %Lp FILE` and GNU `stat -c %a FILE` are mutually exclusive in SYNTAX
+# but NOT in exit code — GNU treats `stat -f %Lp FILE` as `--file-system %Lp`
+# over FILE, printing a MULTI-LINE filesystem block ("  File: ...") and exiting
+# 0, so a bare `stat -f ... || stat -c ...` never reaches the GNU fallback and
+# the garbage block flows into the comparison. Guard by VALIDATING each form's
+# output is octal before accepting it; never trust the exit code.
+get_mode() {
+    local out
+    out="$(stat -f '%Lp' "$1" 2>/dev/null)"
+    if [[ "$out" =~ ^[0-7]{3,4}$ ]]; then echo "$out"; return 0; fi
+    out="$(stat -c '%a' "$1" 2>/dev/null)"
+    if [[ "$out" =~ ^[0-7]{3,4}$ ]]; then echo "$out"; return 0; fi
+    return 0  # nothing octal -> empty output, caller handles
+}
+
 # ===========================================================================
 # Tests
 # ===========================================================================
@@ -237,11 +255,43 @@ test_scaffolds_deploy_env_when_absent() {
     if grep -q '^CRM_MAC_CODESIGN_IDENTITY=' "$DEPLOY_ENV_FILE"; then ok; else fail "scaffold must include CRM_MAC_CODESIGN_IDENTITY"; fi
     if grep -q '^NTFY_URL=' "$DEPLOY_ENV_FILE"; then ok; else fail "scaffold must include NTFY_URL"; fi
     if grep -q '^NTFY_TOPIC=' "$DEPLOY_ENV_FILE"; then ok; else fail "scaffold must include NTFY_TOPIC"; fi
-    # chmod 600 = only-owner perms. Check the mode digits portably.
+    # chmod 600 = only-owner perms. Read the mode via the portable get_mode
+    # helper (a bare `stat -f || stat -c` mis-reads on Linux — see get_mode).
     local mode
-    mode="$(stat -f '%Lp' "$DEPLOY_ENV_FILE" 2>/dev/null || stat -c '%a' "$DEPLOY_ENV_FILE" 2>/dev/null)"
-    if [ "$mode" = "600" ]; then ok; else fail "scaffolded deploy.env must be chmod 600, got $mode"; fi
+    mode="$(get_mode "$DEPLOY_ENV_FILE")"
+    if [ "$mode" = "600" ]; then ok; else fail "scaffolded deploy.env must be chmod 600, got '$mode'"; fi
     cleanup_sandbox
+}
+
+test_get_mode_portable_against_gnu_stat() {
+    echo "test: get_mode rejects GNU \`stat -f\`=--file-system garbage, yields octal (portable-by-construction)"
+    # Prove the fallback + garbage-rejection WITHOUT needing a Linux host: shadow
+    # `stat` with a stub modeling GNU behavior — `stat -f %Lp FILE` prints a
+    # multi-line "--file-system" block and exits 0 (the exact trap that failed
+    # CI), while `stat -c %a FILE` prints the octal mode. get_mode must reject the
+    # block (not octal) and accept the GNU fallback.
+    local tmp stub_bin
+    tmp="$(mktemp -d)"
+    stub_bin="$tmp/bin"
+    mkdir -p "$stub_bin"
+    cat > "$stub_bin/stat" <<'EOF'
+#!/usr/bin/env bash
+# GNU stat: `-f` is --file-system (block + exit 0); `-c %a` is the octal mode.
+if [ "$1" = "-f" ]; then
+  printf '  File: "%s"\n    ID: 0 Namelen: 255 Type: ext2/ext3\n' "${@: -1}"
+  exit 0
+fi
+if [ "$1" = "-c" ]; then
+  echo "600"   # the GNU octal-mode form
+  exit 0
+fi
+exit 1
+EOF
+    chmod +x "$stub_bin/stat"
+    local got
+    got="$(PATH="$stub_bin:$PATH" bash -c "$(declare -f get_mode); get_mode /any/file")"
+    if [ "$got" = "600" ]; then ok; else fail "get_mode must yield octal under GNU stat, got '$got'"; fi
+    rm -rf "$tmp"
 }
 
 test_renders_placeholder_substituted() {
@@ -360,6 +410,7 @@ main() {
     test_rerun_does_not_reclone
     test_does_not_overwrite_deploy_env
     test_scaffolds_deploy_env_when_absent
+    test_get_mode_portable_against_gnu_stat
     test_renders_placeholder_substituted
     test_records_template_hash
     test_timer_not_loaded_when_scaffold_empty

--- a/scripts/setup-mac-deploy.test.sh
+++ b/scripts/setup-mac-deploy.test.sh
@@ -1,0 +1,338 @@
+#!/usr/bin/env bash
+# Tests for setup-mac-deploy.sh (the one-time Mac deploy setup).
+#
+# These run anywhere (no Mac, no network). PATH is shadowed with stub
+# `git`/`gh`/`launchctl`/`plutil`/`id` and the real `sed`/`shasum`/`install`/
+# `cat` are used (they exist on the Ubuntu CI runner). Each test drives a
+# scenario via env vars + a sandbox deploy-root and asserts on the recorded
+# calls + on-disk state. The real-tool path (a true launchctl bootstrap) is the
+# Bucket-B supervised dry-run, not this suite — every macOS-only binary
+# (plutil/launchctl) is reached ONLY through a stub so the suite is green on
+# Ubuntu CI too.
+#
+# Asserts the load-bearing correctness points from plan §4.5:
+#   - re-run does NOT re-clone (fetch instead) and does NOT overwrite deploy.env.
+#   - the timer plist is rendered with __INSTALL_PREFIX__ substituted.
+#   - the committed template's content hash is recorded.
+#   - the timer is NOT bootstrapped on an empty OR partially-filled deploy.env,
+#     and IS bootstrapped only once all three vars are set.
+#   - a clean first run (no $DEPLOY_ROOT) creates the skeleton before clone/install.
+#   - the script invokes `plutil -lint` on the rendered plist (behavioral).
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/setup-mac-deploy.sh"
+TIMER_TEMPLATE_PATH="infra/mac-deploy/xyz.spengrah.crm-mac-deploy.plist.template"
+# A real copy of the committed template, fed to the git-clone stub so render +
+# hash operate on the same bytes the production clone would carry.
+REAL_TEMPLATE="$REPO_ROOT/$TIMER_TEMPLATE_PATH"
+
+PASS=0
+FAIL=0
+fail() { echo "  FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+ok()   { PASS=$((PASS + 1)); }
+
+# ---------------------------------------------------------------------------
+# Test sandbox: a fresh tmp dir per scenario with a stub bin/, a fake clone
+# source, a LaunchAgents dir, and a call log. Sets globals SANDBOX, CALL_LOG,
+# DEPLOY_ROOT, CLONE_DIR, LAUNCH_AGENT_DIR, RENDERED_PLIST, TEMPLATE_HASH_FILE.
+#
+# Optional arg $1 = "fresh" to leave $DEPLOY_ROOT NON-EXISTENT (clean first run);
+# default pre-creates it.
+# ---------------------------------------------------------------------------
+make_sandbox() {
+    SANDBOX="$(mktemp -d)"
+    CALL_LOG="$SANDBOX/calls.log"
+    : > "$CALL_LOG"
+    mkdir -p "$SANDBOX/bin"
+
+    DEPLOY_ROOT="$SANDBOX/deploy"
+    CLONE_DIR="$DEPLOY_ROOT/repo"
+    INSTALL_BIN_DIR="$DEPLOY_ROOT/bin"
+    DEPLOY_ENV_FILE="$DEPLOY_ROOT/deploy.env"
+    TEMPLATE_HASH_FILE="$DEPLOY_ROOT/.installed-template-hash"
+    LAUNCH_AGENT_DIR="$SANDBOX/LaunchAgents"
+    RENDERED_PLIST="$LAUNCH_AGENT_DIR/xyz.spengrah.crm-mac-deploy.plist"
+
+    # The "clone payload" the git-clone stub materializes: a scripts/ dir with
+    # the two deploy scripts + the committed timer template. We model `git clone`
+    # by copying this payload into $CLONE_DIR/.git + the tracked files.
+    CLONE_PAYLOAD="$SANDBOX/clone-payload"
+    mkdir -p "$CLONE_PAYLOAD/scripts" "$CLONE_PAYLOAD/$(dirname "$TIMER_TEMPLATE_PATH")"
+    printf '#!/bin/bash\n# stub reconcile\n' > "$CLONE_PAYLOAD/scripts/reconcile-mac-daemon.sh"
+    printf '#!/bin/bash\n# stub delegate\n'  > "$CLONE_PAYLOAD/scripts/deploy-mac-daemon.sh"
+    cp "$REAL_TEMPLATE" "$CLONE_PAYLOAD/$TIMER_TEMPLATE_PATH"
+
+    if [ "${1:-pre}" != "fresh" ]; then
+        mkdir -p "$DEPLOY_ROOT" "$INSTALL_BIN_DIR"
+    fi
+    mkdir -p "$LAUNCH_AGENT_DIR"
+
+    # --- stub: git ---------------------------------------------------------
+    #   clone <url> <dir>     -> materialize the payload into <dir> (+ .git).
+    #   -C <dir> fetch ...    -> record + exit 0 (no re-clone).
+    #   -C <dir> show ref     -> emit the committed template bytes (for the hash).
+    #   -C <dir> remote ...   -> echo a fixed origin URL.
+    cat > "$SANDBOX/bin/git" <<EOF
+#!/usr/bin/env bash
+echo "git \$*" >> "$CALL_LOG"
+payload="$CLONE_PAYLOAD"
+if [ "\$1" = "clone" ]; then
+  # last arg is the dest dir.
+  dest="\${@: -1}"
+  mkdir -p "\$dest/.git"
+  cp -R "\$payload/." "\$dest/"
+  exit 0
+fi
+if [ "\$1" = "-C" ]; then
+  dir="\$2"; shift 2
+  case "\$1" in
+    fetch)  exit 0 ;;
+    show)   cat "\$payload/$TIMER_TEMPLATE_PATH" ;;
+    remote) echo "https://github.com/spengrah/PersonalCRM.git" ;;
+    *)      exit 0 ;;
+  esac
+  exit 0
+fi
+case "\$1" in
+  remote) echo "https://github.com/spengrah/PersonalCRM.git" ;;
+esac
+exit 0
+EOF
+
+    # --- stub: plutil (macOS-only; record the lint call) -------------------
+    cat > "$SANDBOX/bin/plutil" <<EOF
+#!/usr/bin/env bash
+echo "plutil \$*" >> "$CALL_LOG"
+exit 0
+EOF
+
+    # --- stub: launchctl (must never reach a real one on Ubuntu CI) -------
+    #   print gui/<uid>   -> exit ${STUB_LAUNCHCTL_PRINT_RC:-0} (gui domain check)
+    #   bootout/bootstrap -> record + exit 0
+    cat > "$SANDBOX/bin/launchctl" <<EOF
+#!/usr/bin/env bash
+echo "launchctl \$*" >> "$CALL_LOG"
+if [ "\$1" = "print" ]; then exit "\${STUB_LAUNCHCTL_PRINT_RC:-0}"; fi
+exit 0
+EOF
+
+    # --- stub: gh (auth status) -------------------------------------------
+    cat > "$SANDBOX/bin/gh" <<EOF
+#!/usr/bin/env bash
+echo "gh \$*" >> "$CALL_LOG"
+exit "\${STUB_GH_AUTH_RC:-0}"
+EOF
+
+    # --- stub: id (stable uid without depending on the host) --------------
+    cat > "$SANDBOX/bin/id" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = "-u" ]; then echo 4242; exit 0; fi
+exec /usr/bin/id "$@"
+EOF
+
+    chmod +x "$SANDBOX"/bin/*
+}
+
+cleanup_sandbox() { [ -n "${SANDBOX:-}" ] && rm -rf "$SANDBOX"; }
+
+# seed_existing_clone : materialize an EXISTING clone (the fetch path). Mirrors
+# what `git clone` would have left behind: a .git dir + the tracked scripts/
+# template, so `install` + the template render find their inputs.
+seed_existing_clone() {
+    mkdir -p "$CLONE_DIR/.git"
+    cp -R "$CLONE_PAYLOAD/." "$CLONE_DIR/"
+}
+
+# Write a deploy.env into the sandbox. Each arg is a KEY=value pair.
+write_deploy_env() {
+    : > "$DEPLOY_ENV_FILE"
+    local pair key val
+    for pair in "$@"; do
+        key="${pair%%=*}"
+        val="${pair#*=}"
+        printf '%s="%s"\n' "$key" "$val" >> "$DEPLOY_ENV_FILE"
+    done
+}
+
+# run_setup : run setup-mac-deploy.sh in the sandbox; sets RC + OUT. Honors any
+# STUB_* env the caller exported.
+run_setup() {
+    OUT="$(
+        PATH="$SANDBOX/bin:$PATH" \
+        CRM_MAC_DEPLOY_ROOT="$DEPLOY_ROOT" \
+        CRM_MAC_CLONE_DIR="$CLONE_DIR" \
+        CRM_MAC_INSTALL_BIN_DIR="$INSTALL_BIN_DIR" \
+        CRM_MAC_DEPLOY_ENV_FILE="$DEPLOY_ENV_FILE" \
+        CRM_MAC_INSTALLED_TEMPLATE_HASH_FILE="$TEMPLATE_HASH_FILE" \
+        CRM_MAC_TIMER_TEMPLATE_PATH="$TIMER_TEMPLATE_PATH" \
+        CRM_MAC_LAUNCH_AGENT_DIR="$LAUNCH_AGENT_DIR" \
+        CRM_MAC_RENDERED_PLIST="$RENDERED_PLIST" \
+        CRM_MAC_ORIGIN_URL="https://github.com/spengrah/PersonalCRM.git" \
+        bash "$SCRIPT" 2>&1
+    )"
+    RC=$?
+}
+
+log_has()   { grep -qF -- "$1" "$CALL_LOG"; }
+log_lacks() { ! grep -qF -- "$1" "$CALL_LOG"; }
+
+# ===========================================================================
+# Tests
+# ===========================================================================
+
+test_fresh_first_run_creates_skeleton() {
+    echo "test: clean first run (no \$DEPLOY_ROOT) creates skeleton + clones + renders"
+    make_sandbox fresh
+    if [ -d "$DEPLOY_ROOT" ]; then fail "DEPLOY_ROOT must NOT pre-exist for this case"; else ok; fi
+    run_setup
+    if [ "$RC" -eq 0 ]; then ok; else fail "fresh first run should exit 0, got $RC ($OUT)"; fi
+    if [ -d "$INSTALL_BIN_DIR" ]; then ok; else fail "bin dir must be created"; fi
+    if log_has "git clone"; then ok; else fail "fresh run must clone (no existing .git)"; fi
+    if [ -x "$INSTALL_BIN_DIR/reconcile-mac-daemon.sh" ]; then ok; else fail "reconcile script must be installed executable"; fi
+    if [ -x "$INSTALL_BIN_DIR/deploy-mac-daemon.sh" ]; then ok; else fail "delegate must be installed executable"; fi
+    if [ -f "$RENDERED_PLIST" ]; then ok; else fail "timer plist must be rendered"; fi
+    cleanup_sandbox
+}
+
+test_rerun_does_not_reclone() {
+    echo "test: re-run does NOT re-clone (fetches the existing clone instead)"
+    make_sandbox
+    # Pre-create an existing clone (a .git dir) so the script takes the fetch path.
+    seed_existing_clone
+    run_setup
+    if [ "$RC" -eq 0 ]; then ok; else fail "re-run should exit 0, got $RC ($OUT)"; fi
+    if log_lacks "git clone"; then ok; else fail "existing clone must NOT be re-cloned"; fi
+    if log_has "fetch --quiet origin"; then ok; else fail "existing clone must be fetched"; fi
+    cleanup_sandbox
+}
+
+test_does_not_overwrite_deploy_env() {
+    echo "test: re-run does NOT overwrite an existing deploy.env"
+    make_sandbox
+    seed_existing_clone
+    write_deploy_env "CRM_MAC_CODESIGN_IDENTITY=My Cert" "NTFY_URL=https://ntfy.example" "NTFY_TOPIC=tok"
+    local before
+    before="$(cat "$DEPLOY_ENV_FILE")"
+    run_setup
+    if [ "$(cat "$DEPLOY_ENV_FILE")" = "$before" ]; then ok; else fail "existing deploy.env must be left untouched"; fi
+    cleanup_sandbox
+}
+
+test_scaffolds_deploy_env_when_absent() {
+    echo "test: scaffolds deploy.env (chmod 600) when absent, with all three keys"
+    make_sandbox
+    seed_existing_clone
+    run_setup
+    if [ -f "$DEPLOY_ENV_FILE" ]; then ok; else fail "deploy.env must be scaffolded"; fi
+    if grep -q '^CRM_MAC_CODESIGN_IDENTITY=' "$DEPLOY_ENV_FILE"; then ok; else fail "scaffold must include CRM_MAC_CODESIGN_IDENTITY"; fi
+    if grep -q '^NTFY_URL=' "$DEPLOY_ENV_FILE"; then ok; else fail "scaffold must include NTFY_URL"; fi
+    if grep -q '^NTFY_TOPIC=' "$DEPLOY_ENV_FILE"; then ok; else fail "scaffold must include NTFY_TOPIC"; fi
+    # chmod 600 = only-owner perms. Check the mode digits portably.
+    local mode
+    mode="$(stat -f '%Lp' "$DEPLOY_ENV_FILE" 2>/dev/null || stat -c '%a' "$DEPLOY_ENV_FILE" 2>/dev/null)"
+    if [ "$mode" = "600" ]; then ok; else fail "scaffolded deploy.env must be chmod 600, got $mode"; fi
+    cleanup_sandbox
+}
+
+test_renders_placeholder_substituted() {
+    echo "test: rendered plist substitutes __INSTALL_PREFIX__ -> the deploy root"
+    make_sandbox
+    seed_existing_clone
+    run_setup
+    if [ -f "$RENDERED_PLIST" ]; then ok; else fail "plist must be rendered"; fi
+    if ! grep -qF '__INSTALL_PREFIX__' "$RENDERED_PLIST"; then ok; else fail "rendered plist must NOT still contain the placeholder"; fi
+    if grep -qF "$DEPLOY_ROOT/bin/reconcile-mac-daemon.sh" "$RENDERED_PLIST"; then ok; else fail "rendered plist must point ProgramArguments at the installed reconcile path"; fi
+    # The script lints the rendered plist via plutil (behavioral assertion).
+    if log_has "plutil -lint"; then ok; else fail "script must invoke plutil -lint on the rendered plist"; fi
+    cleanup_sandbox
+}
+
+test_records_template_hash() {
+    echo "test: records the committed template content hash for drift detection"
+    make_sandbox
+    seed_existing_clone
+    run_setup
+    if [ -f "$TEMPLATE_HASH_FILE" ]; then ok; else fail "template hash file must be written"; fi
+    # The recorded hash must equal shasum over the SAME bytes reconcile reads:
+    # `git show origin/main:<template>` captured in $(...) (which strips trailing
+    # newlines) then `printf '%s'`. Both setup AND reconcile hash this way, so the
+    # expectation must mirror the $(...)-strip + printf '%s' too, not a raw `cat`.
+    local expected actual template_bytes
+    template_bytes="$(cat "$REAL_TEMPLATE")"
+    expected="$(printf '%s' "$template_bytes" | shasum -a 256 | awk '{print $1}')"
+    actual="$(cat "$TEMPLATE_HASH_FILE")"
+    if [ "$actual" = "$expected" ]; then ok; else fail "recorded hash must match the committed template's hash"; fi
+    cleanup_sandbox
+}
+
+test_timer_not_loaded_when_scaffold_empty() {
+    echo "test: timer NOT bootstrapped when deploy.env is an empty scaffold"
+    make_sandbox
+    seed_existing_clone
+    # No deploy.env -> the script scaffolds an EMPTY one -> must not bootstrap.
+    run_setup
+    if [ "$RC" -eq 0 ]; then ok; else fail "empty scaffold run should exit 0, got $RC ($OUT)"; fi
+    if log_lacks "launchctl bootstrap"; then ok; else fail "empty scaffold must NOT bootstrap the timer"; fi
+    cleanup_sandbox
+}
+
+test_timer_not_loaded_when_partial() {
+    echo "test: timer NOT bootstrapped when deploy.env is only partially filled"
+    make_sandbox
+    seed_existing_clone
+    # Identity set but ntfy empty -> still must NOT bootstrap (all-three rule).
+    write_deploy_env "CRM_MAC_CODESIGN_IDENTITY=My Cert" "NTFY_URL=" "NTFY_TOPIC="
+    run_setup
+    if [ "$RC" -eq 0 ]; then ok; else fail "partial run should exit 0, got $RC ($OUT)"; fi
+    if log_lacks "launchctl bootstrap"; then ok; else fail "partial deploy.env must NOT bootstrap (needs all three vars)"; fi
+    cleanup_sandbox
+}
+
+test_timer_loaded_when_fully_configured() {
+    echo "test: timer IS bootstrapped once all three vars are set"
+    make_sandbox
+    seed_existing_clone
+    write_deploy_env "CRM_MAC_CODESIGN_IDENTITY=My Cert" "NTFY_URL=https://ntfy.example" "NTFY_TOPIC=tok"
+    run_setup
+    if [ "$RC" -eq 0 ]; then ok; else fail "fully-configured run should exit 0, got $RC ($OUT)"; fi
+    if log_has "launchctl bootstrap"; then ok; else fail "fully-configured deploy.env must bootstrap the timer"; fi
+    # bootout-then-bootstrap = idempotent reload.
+    if log_has "launchctl bootout"; then ok; else fail "load must bootout before bootstrap (idempotent reload)"; fi
+    cleanup_sandbox
+}
+
+test_timer_not_loaded_in_non_gui_context() {
+    echo "test: non-login (no gui domain) context warns instead of bootstrapping"
+    make_sandbox
+    seed_existing_clone
+    write_deploy_env "CRM_MAC_CODESIGN_IDENTITY=My Cert" "NTFY_URL=https://ntfy.example" "NTFY_TOPIC=tok"
+    # launchctl print gui/<uid> fails -> no gui domain -> must NOT bootstrap.
+    STUB_LAUNCHCTL_PRINT_RC=1 run_setup
+    if [ "$RC" -eq 0 ]; then ok; else fail "non-gui context should still exit 0, got $RC ($OUT)"; fi
+    if log_lacks "launchctl bootstrap"; then ok; else fail "non-gui context must NOT bootstrap"; fi
+    cleanup_sandbox
+}
+
+# ---------------------------------------------------------------------------
+main() {
+    test_fresh_first_run_creates_skeleton
+    test_rerun_does_not_reclone
+    test_does_not_overwrite_deploy_env
+    test_scaffolds_deploy_env_when_absent
+    test_renders_placeholder_substituted
+    test_records_template_hash
+    test_timer_not_loaded_when_scaffold_empty
+    test_timer_not_loaded_when_partial
+    test_timer_loaded_when_fully_configured
+    test_timer_not_loaded_in_non_gui_context
+
+    echo ""
+    echo "===================="
+    echo "PASS=$PASS FAIL=$FAIL"
+    echo "===================="
+    [ "$FAIL" -eq 0 ]
+}
+
+main "$@"


### PR DESCRIPTION
PR3 of 4 in the Mac deploy-automation Bucket A plan (`.ai/spec/2026-06-12-mac-deploy-automation-design.md`). Wires the `make promote` → push-to-`main` trigger to the Mac and provides the one-time setup tooling.

## What this adds
- **`.github/workflows/deploy-mac.yml`** — a NEW, separate workflow (deliberately not a job in `deploy-prod.yml`, to avoid inheriting the Pi workflow's `concurrency`). Triggers `push: main` only (inert on `develop`/PRs), `runs-on: [self-hosted, mac]`, its own `deploy-mac` concurrency group, `environment: production`, `permissions: contents: read`, no `uses:` actions. The job is a thin trigger that invokes `scripts/reconcile-mac-daemon.sh` from the runner's pre-existing installed clone (no checkout).
- **`scripts/setup-mac-deploy.sh`** + **`make setup-mac-deploy`** — one-time idempotent setup: creates the dedicated clone under `$HOME/Library/Application Support/crm-mac-deploy/repo`, installs the reconcile + delegate scripts to a stable bin path, scaffolds a chmod-600 `deploy.env` (preserved on re-run, never clobbered), renders the timer plist with `__INSTALL_PREFIX__` substitution + records its content hash, and guards the `RunAtLoad` timer load until codesign identity + ntfy are all configured (so the timer can't fire an FDA-resetting deploy before the box is ready). Offline re-runs still complete the local install/render/load steps.
- **`infra/mac-deploy/xyz.spengrah.crm-mac-deploy.plist.template`** — the timer LaunchAgent template: `StartCalendarInterval` (6h cadence) + `RunAtLoad`, no `StartInterval`, no `KeepAlive`.
- **`scripts/setup-mac-deploy.test.sh`** (37 cases) + a cross-platform plistlib template-validity check, wired into `make test-deploy-scripts`.

No production Swift/Go change. The runner-installation runbook (PR4) is the last remaining Bucket A piece.

## Review
Codex was usage-limited (`ALL_EXHAUSTED`) this window, so Phase 3 used the Claude self-review fallback and the gate was a fresh-context `/review-head`. Round 1 FAILed on a real 1×P1 — the deferred-load guard's codesign-identity sub-rule had zero test coverage (mutation-proven: dropping the identity check kept the suite green), so an empty `CRM_MAC_CODESIGN_IDENTITY` could have let the `RunAtLoad` timer deploy an ad-hoc-signed build that resets Full Disk Access. Fixed by adding the identity-empty/ntfy-set no-load test (plus 2 P2s: soft-skipping the re-run `git fetch` for offline re-runs, and making the test `git show` stub ref-aware). Round 2 **PASS** (0×P0, 0×P1), with every fix mutation-proven firsthand by the reviewer. Residual 2×P2 / 2×P3 are non-blocking.

The Linux-CI portability class of bug from PR2 (BSD vs GNU `stat`) was specifically audited here and the new tests are hermetic.
