### PR TITLE
feat(river): dead-letter visibility — ErrorHandler, slog bridge, CLI

### DIFF
--- a/.ai/spec/event-bus-foundation.md
+++ b/.ai/spec/event-bus-foundation.md
@@ -437,7 +437,7 @@ Redesigned with **three guarantees**:
 
 3. **Atomic finalize.** On step 2 success, the worker updates `state='active'`, `external_task_id=<from response>` in a single `UPDATE` — no race window. Uniqueness on `(contact_id, kind, idempotency_key)` survives the state transition because the index is partial on `deleted_at IS NULL`, not on `state`.
 
-On repeated failure after `MaxAttempts=10` exponential backoff, state stays `pending_remote_create`; an admin alert log fires; the task is still visible in the CRM (just not in Todoist).
+On repeated failure after `MaxAttempts=10` exponential backoff, state stays `pending_remote_create`; an admin alert log fires; the task is still visible in the CRM (just not in Todoist). (The "admin alert log fires" promise is implemented generically by the client-level River `ErrorHandler` added in #459 — it logs every worker-returned error/panic that exhausts attempts at ERROR with `discarded=true`, covering this kind without a per-worker log call. Note: a job discarded by River's JobRescuer after a hard crash bypasses the ErrorHandler, so this covers worker-error/panic discards, not every path to `discarded`.)
 
 **Interaction with response/completion flow:** `FindPendingFollowUp` (`contact_task.sql:137`) is updated to match `state IN ('pending_remote_create', 'active')` so that a response arriving while step 2 is in flight correctly cancels the pending row. `CompleteFollowUp` is extended to:
 - If matched row has `state='active'` with `external_task_id` → close remote + set `state='completed'` (existing path).
@@ -1090,7 +1090,7 @@ PR 9a / PR 9b can run in parallel with PR 10 (independent consumers).
 ### Open for reviewer input
 
 1. **Event retention.** No retention policy in this spec. How long do we keep `event` rows? A year? Indefinite? (Single-user Pi — storage is not urgent.) Suggest: indefinite for now; add retention job when volume justifies.
-2. **Observability.** River ships a Pro dashboard and there's a community OSS view. Do we want to set up a `/admin/river` view now, or defer? (Defer to a follow-up PR; logs + `SELECT FROM river_job` suffices for MVP.)
+2. **Observability.** River ships a Pro dashboard and there's a community OSS view. Do we want to set up a `/admin/river` view now, or defer? (Defer to a follow-up PR; logs + `SELECT FROM river_job` suffices for MVP.) (#459 shipped the logs+CLI level: the River `ErrorHandler` + slog→zerolog bridge route all River internals and job discards/panics into the structured zerolog stream, `crm-admin --list-jobs` / `--retry-job` give a CLI over `river_job`, and a 90d discarded-job retention preserves the forensic trail. A dashboard remains deferred.)
 3. **Multiple consumer workers for the same kind.** Current design: one worker per kind per consumer. If throughput ever matters, scale via `river.Workers.ConcurrencyLimit`. Not an issue at single-user scale.
 4. **Event schema governance.** When we add an event kind or bump payload version, what's the review process? Suggest: treat events like API contracts — new kinds require a spec entry; version bumps require a migration note.
 

--- a/backend/cmd/crm-admin/jobs_integration_test.go
+++ b/backend/cmd/crm-admin/jobs_integration_test.go
@@ -1,0 +1,187 @@
+//go:build integration_testdb
+
+// End-to-end coverage for crm-admin --list-jobs / --retry-job, driving the REAL
+// run() dispatch against a real River client + isolated DB clone. Proves the
+// list output, --job-limit → JobListParams.First propagation, --job-state
+// filtering, and the post-retry river_job state — none of which the unit fakes
+// (opaque JobListParams) can see.
+//
+// Each test starts a River client against an ISOLATED per-test clone via
+// testdb.NewEphemeralClone (River-draining tests must own a private river_job,
+// or clients steal each other's jobs). t.Parallel() on the clone.
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/testdb"
+
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/stretchr/testify/require"
+)
+
+// jobsTestFailArgs is a test-only worker type whose worker always fails, so a
+// MaxAttempts=1 job lands directly in `discarded` on its single attempt.
+type jobsTestFailArgs struct{}
+
+func (jobsTestFailArgs) Kind() string { return "test_admin_jobs_fail" }
+
+type jobsTestFailWorker struct {
+	river.WorkerDefaults[jobsTestFailArgs]
+}
+
+func (*jobsTestFailWorker) Work(_ context.Context, _ *river.Job[jobsTestFailArgs]) error {
+	return errors.New("deliberate test failure")
+}
+
+// newJobsTestDB opens an isolated clone + db.Database for a River-draining admin
+// test. Mirrors newIsolatedRiverTestDB in backend/tests (test helpers don't
+// cross package boundaries in this repo).
+func newJobsTestDB(t *testing.T, ctx context.Context) (*db.Database, *config.Config) {
+	t.Helper()
+	cloneURL, drop := testdb.NewEphemeralClone(t)
+	t.Cleanup(drop)
+
+	cfg := config.TestConfig()
+	cfg.Database.URL = cloneURL
+	cfg.Database.MigrationsPath = migrationsPathForTest()
+	cfg.Database.MaxConns = 6
+	cfg.Database.MinConns = 1
+	cfg.River.WorkerConcurrency = 2
+
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	t.Cleanup(func() { database.Close() })
+	return database, cfg
+}
+
+// waitForJobState polls river_job for the given id until its state equals want
+// or the ctx deadline fires. Real wall-clock per the polling-wait rule; reads
+// through the test-only sqlc query, not raw SQL.
+func waitForJobState(t *testing.T, ctx context.Context, queries *db.Queries, id int64, want db.RiverJobState) {
+	t.Helper()
+	waitCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	tick := time.NewTicker(50 * time.Millisecond)
+	defer tick.Stop()
+	var last db.RiverJobState
+	for {
+		state, err := queries.GetRiverJobStateByID(ctx, id)
+		if err == nil {
+			last = state
+			if state == want {
+				return
+			}
+		}
+		select {
+		case <-waitCtx.Done():
+			t.Fatalf("timed out waiting for river_job id=%d state=%q (last %q, err=%v)", id, want, last, err)
+		case <-tick.C:
+		}
+	}
+}
+
+func TestListAndRetryJobs_Integration(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	if os.Getenv("DATABASE_URL") == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	ctx := context.Background()
+	database, cfg := newJobsTestDB(t, ctx)
+
+	workers := river.NewWorkers()
+	river.AddWorker(workers, &jobsTestFailWorker{})
+
+	client, err := river.NewClient(riverpgxv5.New(database.Pool), &river.Config{
+		Queues: map[string]river.QueueConfig{
+			river.QueueDefault: {MaxWorkers: cfg.River.WorkerConcurrency},
+		},
+		Workers: workers,
+	})
+	require.NoError(t, err)
+	require.NoError(t, client.Start(ctx))
+	clientStopped := false
+	stopClient := func() {
+		if clientStopped {
+			return
+		}
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer stopCancel()
+		_ = client.Stop(stopCtx)
+		clientStopped = true
+	}
+	t.Cleanup(stopClient)
+
+	// Drive TWO single-attempt jobs to `discarded` (MaxAttempts=1 → one failure
+	// discards immediately).
+	jobIDs := make([]int64, 0, 2)
+	for i := 0; i < 2; i++ {
+		res, ierr := client.Insert(ctx, jobsTestFailArgs{}, &river.InsertOpts{MaxAttempts: 1})
+		require.NoError(t, ierr)
+		jobIDs = append(jobIDs, res.Job.ID)
+	}
+	for _, id := range jobIDs {
+		waitForJobState(t, ctx, database.Queries, id, db.RiverJobStateDiscarded)
+	}
+
+	// Stop the client so it no longer competes for the jobs we list/retry.
+	stopClient()
+
+	out := &bytes.Buffer{}
+	deps := adminDeps{jobs: client, stdout: out, stderr: &bytes.Buffer{}}
+
+	// (1) --list-jobs (default discarded,retryable) shows BOTH discarded rows.
+	require.NoError(t, run(ctx, runOptions{listJobs: true, jobState: "discarded,retryable", jobLimit: 100}, deps))
+	listed := out.String()
+	for _, id := range jobIDs {
+		require.Contains(t, listed, "id="+strconv.FormatInt(id, 10))
+	}
+	require.Contains(t, listed, "kind=test_admin_jobs_fail")
+	require.Contains(t, listed, "state=discarded")
+	require.Contains(t, listed, "attempt=1/1")
+	require.Contains(t, listed, "deliberate test failure")
+
+	// (2) --list-jobs --job-limit 1 returns exactly one row + the limit-reached
+	// note (proves --job-limit → JobListParams.First end-to-end).
+	out.Reset()
+	require.NoError(t, run(ctx, runOptions{listJobs: true, jobState: "discarded", jobLimit: 1}, deps))
+	limited := out.String()
+	require.Equal(t, 1, strings.Count(limited, "id="), "exactly one job row expected")
+	require.Contains(t, limited, "note: limit reached (1 rows shown)")
+
+	// (3) --list-jobs --job-state retryable filters the discarded jobs out.
+	out.Reset()
+	require.NoError(t, run(ctx, runOptions{listJobs: true, jobState: "retryable", jobLimit: 100}, deps))
+	require.Contains(t, out.String(), "no jobs found (states=retryable)")
+
+	// (4) --retry-job <id> makes the first job available again.
+	retryID := jobIDs[0]
+	out.Reset()
+	require.NoError(t, run(ctx, runOptions{retryJobID: retryID}, deps))
+	require.Contains(t, out.String(), "id="+strconv.FormatInt(retryID, 10))
+	require.Contains(t, out.String(), "retried job")
+	// The row is now re-workable (River bumps max_attempts on an exhausted job).
+	state, serr := database.Queries.GetRiverJobStateByID(ctx, retryID)
+	require.NoError(t, serr)
+	require.Equal(t, db.RiverJobStateAvailable, state, "retried job should be available")
+
+	// (5) --retry-job <unknown> → friendly not-found error mentioning the id.
+	out.Reset()
+	err = run(ctx, runOptions{retryJobID: 999999999}, deps)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "999999999")
+}

--- a/backend/cmd/crm-admin/main.go
+++ b/backend/cmd/crm-admin/main.go
@@ -107,6 +107,22 @@
 //	                              before touching anything. Prints a counts-only
 //	                              summary (no PII).
 //
+//	--list-jobs                   List River jobs (one key=value row per job) for
+//	      [--job-state S]         dead-letter inspection. --job-state is a
+//	      [--job-limit N]         comma-separated state filter (default
+//	                              "discarded,retryable"; each token validated
+//	                              against River's job states). --job-limit caps the
+//	                              row count (default 100; 1..10000). Newest job
+//	                              first. SAFE with crm-api running (read-only).
+//
+//	--retry-job <id>              Make a single River job available to run again
+//	                              (by numeric id from --list-jobs). On an exhausted
+//	                              job River bumps max_attempts so it can run once
+//	                              more. SAFE with crm-api running: the live worker
+//	                              pool picks the job up — that is the intended flow.
+//	                              Consumers are idempotent, so retrying an
+//	                              already-side-effected job re-runs into a no-op.
+//
 // The seed/reset subcommands inherit the process env (CRM_ENV / TIME_BASE /
 // TIME_ACCELERATION / DATABASE_URL / MIGRATIONS_PATH) — on the Pi via
 // `set -a; . /srv/personalcrm/.env; set +a` — so the seeded world's cadence /
@@ -216,6 +232,15 @@ type seedRunner interface {
 	ResetAndSeed(ctx context.Context, params synthetic.SeedParams) (synthetic.ProfileResult, error)
 }
 
+// riverJobAdmin is the narrow interface --list-jobs / --retry-job need.
+// *river.Client[pgx.Tx] satisfies it structurally, so the existing insert-only
+// admin client serves both calls (JobList / JobRetry go straight through the
+// driver — neither needs Start() nor registered workers).
+type riverJobAdmin interface {
+	JobList(ctx context.Context, params *river.JobListParams) (*river.JobListResult, error)
+	JobRetry(ctx context.Context, id int64) (*rivertype.JobRow, error)
+}
+
 // adminDeps groups the per-subcommand dependencies. Tests inject
 // fakes for each interface; the production wiring builds a single
 // MacHostService and a small adapter for rematch.
@@ -232,8 +257,12 @@ type adminDeps struct {
 	rederive   rederiveRunner
 	gmailReset gmailBackfillCursorResetter
 	seed       seedRunner
-	stdout     io.Writer
-	stderr     io.Writer
+	// jobs serves --list-jobs / --retry-job. Wired to the insert-only river
+	// client in buildProductionDeps (JobList/JobRetry go through the driver,
+	// no worker pool needed).
+	jobs   riverJobAdmin
+	stdout io.Writer
+	stderr io.Writer
 }
 
 // runOptions captures parsed flags. Exposed as a struct so tests can
@@ -264,6 +293,14 @@ type runOptions struct {
 	// MigrationsPath, not buildProductionDeps).
 	migrate      bool
 	migrateCheck bool
+	// River dead-letter subcommands. listJobs ← --list-jobs (the bool
+	// subcommand selector); jobState / jobLimit are auxiliary filters used only
+	// by --list-jobs. retryJobID ← --retry-job (0 = unset; non-zero selects the
+	// retry subcommand).
+	listJobs   bool
+	jobState   string
+	jobLimit   int
+	retryJobID int64
 }
 
 // exitErr carries an explicit process exit code so a subcommand can drive a
@@ -405,6 +442,12 @@ func validateSubcommand(opts runOptions) error {
 	if opts.migrateCheck {
 		active++
 	}
+	if opts.listJobs {
+		active++
+	}
+	if opts.retryJobID != 0 {
+		active++
+	}
 	if active == 0 {
 		return errors.New("no subcommand specified; pass exactly one of " +
 			subcommandList)
@@ -421,7 +464,7 @@ func validateSubcommand(opts runOptions) error {
 const subcommandList = "--messages-rematch-stranded, --reconcile-address-book-methods, " +
 	"--rederive-correspondence-names, --reset-gmail-backfill-cursors, --mint-pairing-token, " +
 	"--list-hosts, --revoke-host <uuid>, --rotate-host-key <uuid>, --seed, --reset-and-seed, " +
-	"--migrate, --migrate-check"
+	"--migrate, --migrate-check, --list-jobs, --retry-job <id>"
 
 // parseArgs uses a private FlagSet so tests can drive the parser
 // without polluting flag's global state.
@@ -483,6 +526,17 @@ func parseArgs(args []string) (runOptions, error) {
 		"Report whether migrations are pending WITHOUT mutating the DB. Exit 0 = up-to-date, "+
 			"2 = pending (app and/or River), 1 = operational error (cannot connect / dirty DB / read failed). "+
 			"The deploy script branches on exit 2 to snapshot-then-migrate.")
+	fs.BoolVar(&opts.listJobs, "list-jobs", false,
+		"List River jobs (one key=value row per job) for dead-letter inspection. Use with "+
+			"--job-state / --job-limit. Read-only; safe with crm-api running.")
+	fs.StringVar(&opts.jobState, "job-state", "discarded,retryable",
+		"Comma-separated River job states to filter --list-jobs (default discarded,retryable). "+
+			"Each token is validated against River's job states.")
+	fs.IntVar(&opts.jobLimit, "job-limit", 100,
+		"Max rows for --list-jobs (default 100; 1..10000). Newest job first.")
+	fs.Int64Var(&opts.retryJobID, "retry-job", 0,
+		"Make a single River job (by numeric id from --list-jobs) available to run again. "+
+			"On an exhausted job River bumps max_attempts. Safe with crm-api running.")
 	if err := fs.Parse(args); err != nil {
 		return runOptions{}, err
 	}
@@ -582,6 +636,10 @@ func run(ctx context.Context, opts runOptions, deps adminDeps) error {
 		return runSeed(ctx, opts, deps)
 	case opts.resetAndSeed:
 		return runResetAndSeed(ctx, opts, deps)
+	case opts.listJobs:
+		return runListJobs(ctx, opts, deps)
+	case opts.retryJobID != 0:
+		return runRetryJob(ctx, opts, deps)
 	case opts.migrate, opts.migrateCheck:
 		// Migration subcommands are dispatched PRE-DB in runMain (they need
 		// only the database URL + migrations path, not deps), so they never
@@ -861,6 +919,138 @@ func runResetGmailBackfillCursors(ctx context.Context, deps adminDeps) error {
 	return nil
 }
 
+// jobListMaxLimit is the upper bound River's JobListParams.First enforces (it
+// panics outside 1..10000). We validate --job-limit against it BEFORE calling
+// First so the operator gets a friendly usage error instead of a panic.
+const jobListMaxLimit = 10_000
+
+// parseJobStates splits a comma-separated state filter into rivertype.JobState
+// values, validating each token against River's known states. Whitespace around
+// tokens is trimmed; an empty filter is rejected. An unknown token returns a
+// usage error listing the valid states.
+func parseJobStates(filter string) ([]rivertype.JobState, error) {
+	valid := rivertype.JobStates()
+	validSet := make(map[string]rivertype.JobState, len(valid))
+	for _, s := range valid {
+		validSet[string(s)] = s
+	}
+	var states []rivertype.JobState
+	for _, tok := range strings.Split(filter, ",") {
+		tok = strings.TrimSpace(tok)
+		if tok == "" {
+			continue
+		}
+		st, ok := validSet[tok]
+		if !ok {
+			validNames := make([]string, len(valid))
+			for i, s := range valid {
+				validNames[i] = string(s)
+			}
+			return nil, fmt.Errorf("--job-state: unknown state %q (valid: %s)", tok, strings.Join(validNames, ", "))
+		}
+		states = append(states, st)
+	}
+	if len(states) == 0 {
+		return nil, errors.New("--job-state: at least one state required")
+	}
+	return states, nil
+}
+
+// runListJobs lists River jobs (one key=value row per job) for dead-letter
+// inspection. Read-only; safe with crm-api running. Newest job first on the
+// never-null, deterministic id key (finalized_at is NULL for retryable rows, so
+// it can't sort the mixed default view).
+func runListJobs(ctx context.Context, opts runOptions, deps adminDeps) error {
+	states, err := parseJobStates(opts.jobState)
+	if err != nil {
+		return err
+	}
+	if opts.jobLimit < 1 || opts.jobLimit > jobListMaxLimit {
+		return fmt.Errorf("--job-limit must be between 1 and %d (got %d)", jobListMaxLimit, opts.jobLimit)
+	}
+
+	params := river.NewJobListParams().
+		States(states...).
+		First(opts.jobLimit).
+		OrderBy(river.JobListOrderByID, river.SortOrderDesc)
+
+	res, err := deps.jobs.JobList(ctx, params)
+	if err != nil {
+		return fmt.Errorf("list jobs: %w", err)
+	}
+
+	if len(res.Jobs) == 0 {
+		if _, err := fmt.Fprintf(deps.stdout, "no jobs found (states=%s)\n", opts.jobState); err != nil {
+			return fmt.Errorf("write empty list: %w", err)
+		}
+		return nil
+	}
+
+	for _, job := range res.Jobs {
+		if err := writeJobRow(deps.stdout, job); err != nil {
+			return err
+		}
+	}
+
+	// A full page may mean older rows exist beyond the limit.
+	if len(res.Jobs) == opts.jobLimit {
+		if _, err := fmt.Fprintf(deps.stdout,
+			"note: limit reached (%d rows shown); older rows may exist — raise --job-limit\n",
+			opts.jobLimit); err != nil {
+			return fmt.Errorf("write limit note: %w", err)
+		}
+	}
+	return nil
+}
+
+// writeJobRow prints a single River job as a key=value row (runListHosts style).
+// last_error is the Error of the most recent attempt (empty if none), printed
+// with %q so a multi-line worker error stays on one line. args is the raw
+// EncodedArgs (compact JSON). finalized_at is "none" when nil.
+func writeJobRow(w io.Writer, job *rivertype.JobRow) error {
+	lastError := ""
+	if n := len(job.Errors); n > 0 {
+		lastError = job.Errors[n-1].Error
+	}
+	finalizedAt := "none"
+	if job.FinalizedAt != nil {
+		finalizedAt = job.FinalizedAt.UTC().Format(time.RFC3339)
+	}
+	args := string(job.EncodedArgs)
+	if args == "" {
+		args = "{}"
+	}
+	if _, err := fmt.Fprintf(w,
+		"id=%d kind=%s state=%s attempt=%d/%d queue=%s created_at=%s finalized_at=%s last_error=%q args=%s\n",
+		job.ID, job.Kind, job.State, job.Attempt, job.MaxAttempts, job.Queue,
+		job.CreatedAt.UTC().Format(time.RFC3339), finalizedAt, lastError, args); err != nil {
+		return fmt.Errorf("write job row: %w", err)
+	}
+	return nil
+}
+
+// runRetryJob makes a single River job available to run again (by numeric id).
+// On an exhausted job River bumps max_attempts so it can run once more. Safe
+// with crm-api running — the live worker pool picks it up.
+func runRetryJob(ctx context.Context, opts runOptions, deps adminDeps) error {
+	if opts.retryJobID < 1 {
+		return fmt.Errorf("--retry-job must be a positive job id (got %d)", opts.retryJobID)
+	}
+	job, err := deps.jobs.JobRetry(ctx, opts.retryJobID)
+	if err != nil {
+		if errors.Is(err, rivertype.ErrNotFound) {
+			return fmt.Errorf("no job with id %d (already cleaned by retention?)", opts.retryJobID)
+		}
+		return fmt.Errorf("retry job %d: %w", opts.retryJobID, err)
+	}
+	if _, err := fmt.Fprintf(deps.stdout,
+		"retried job id=%d kind=%s state=%s scheduled_at=%s\n",
+		job.ID, job.Kind, job.State, job.ScheduledAt.UTC().Format(time.RFC3339)); err != nil {
+		return fmt.Errorf("write retry summary: %w", err)
+	}
+	return nil
+}
+
 // correspondenceBackfillFloor is the lower bound for the one-time display-name
 // re-derivation. It matches the Gmail onboarding backfill floor (the earliest
 // mail the integration ever ingested), so the catchup covers the entire stored
@@ -993,6 +1183,9 @@ func buildProductionDeps(ctx context.Context, cfg *config.Config, database *db.D
 			database: database,
 			support:  repository.NewSyntheticSupportRepository(database.Queries),
 		},
+		// --list-jobs / --retry-job: the insert-only river client also satisfies
+		// JobList / JobRetry (both go through the driver, no worker pool needed).
+		jobs: riverClient,
 	}
 
 	// LAZY: build the correspondence re-derivation stack ONLY for

--- a/backend/cmd/crm-admin/main_test.go
+++ b/backend/cmd/crm-admin/main_test.go
@@ -20,6 +20,8 @@ import (
 	"personal-crm/backend/internal/synthetic"
 
 	"github.com/google/uuid"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
 )
 
 type fakeTokenMinter struct {
@@ -1115,5 +1117,319 @@ func TestExitErrMapping(t *testing.T) {
 	}
 	if errors.As(errors.New("plain"), &ee) {
 		t.Fatal("a plain error must NOT match errors.As(exitErr) — it keeps exit-1 behavior")
+	}
+}
+
+// --- --list-jobs / --retry-job dispatch tests ---
+
+// fakeRiverJobAdmin records the JobList params it received and returns canned
+// jobs/errors, so list/retry dispatch + output formatting can be asserted
+// without a real River client. The opaque JobListParams can't be introspected,
+// so --job-state / --job-limit propagation is exercised by the integration
+// test; here we assert behavior and output.
+type fakeRiverJobAdmin struct {
+	listResult *river.JobListResult
+	listErr    error
+	listCalls  int
+
+	retryResult *rivertype.JobRow
+	retryErr    error
+	retryID     int64
+	retryCalls  int
+}
+
+func (f *fakeRiverJobAdmin) JobList(_ context.Context, _ *river.JobListParams) (*river.JobListResult, error) {
+	f.listCalls++
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.listResult, nil
+}
+
+func (f *fakeRiverJobAdmin) JobRetry(_ context.Context, id int64) (*rivertype.JobRow, error) {
+	f.retryCalls++
+	f.retryID = id
+	if f.retryErr != nil {
+		return nil, f.retryErr
+	}
+	return f.retryResult, nil
+}
+
+func depsWithJobs(jobs riverJobAdmin) (adminDeps, *bytes.Buffer) {
+	stdout := &bytes.Buffer{}
+	return adminDeps{jobs: jobs, stdout: stdout, stderr: &bytes.Buffer{}}, stdout
+}
+
+func TestParseArgsListAndRetryFlags(t *testing.T) {
+	t.Run("list-jobs with state + limit", func(t *testing.T) {
+		opts, err := parseArgs([]string{"--list-jobs", "--job-state", "discarded", "--job-limit", "5"})
+		if err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if !opts.listJobs {
+			t.Fatal("--list-jobs not set")
+		}
+		if opts.jobState != "discarded" {
+			t.Fatalf("expected job-state discarded, got %q", opts.jobState)
+		}
+		if opts.jobLimit != 5 {
+			t.Fatalf("expected job-limit 5, got %d", opts.jobLimit)
+		}
+	})
+
+	t.Run("list-jobs defaults", func(t *testing.T) {
+		opts, err := parseArgs([]string{"--list-jobs"})
+		if err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if opts.jobState != "discarded,retryable" {
+			t.Fatalf("expected default state filter, got %q", opts.jobState)
+		}
+		if opts.jobLimit != 100 {
+			t.Fatalf("expected default limit 100, got %d", opts.jobLimit)
+		}
+	})
+
+	t.Run("retry-job id", func(t *testing.T) {
+		opts, err := parseArgs([]string{"--retry-job", "412"})
+		if err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if opts.retryJobID != 412 {
+			t.Fatalf("expected retry id 412, got %d", opts.retryJobID)
+		}
+	})
+}
+
+func TestListAndRetryMutualExclusion(t *testing.T) {
+	// Both selected → mutual-exclusion error.
+	if err := validateSubcommand(runOptions{listJobs: true, retryJobID: 7}); err == nil {
+		t.Fatal("expected mutual-exclusion error for --list-jobs + --retry-job")
+	}
+	// --retry-job 0 = unset, so only --list-jobs is active.
+	if err := validateSubcommand(runOptions{listJobs: true, retryJobID: 0}); err != nil {
+		t.Fatalf("--list-jobs alone should be valid, got %v", err)
+	}
+	// --retry-job alone is valid.
+	if err := validateSubcommand(runOptions{retryJobID: 7}); err != nil {
+		t.Fatalf("--retry-job alone should be valid, got %v", err)
+	}
+	// Neither → no-subcommand error.
+	if err := validateSubcommand(runOptions{}); err == nil {
+		t.Fatal("expected no-subcommand error")
+	}
+}
+
+func TestRunListJobsHappy(t *testing.T) {
+	finalized := time.Date(2026, 6, 12, 3, 4, 5, 0, time.UTC)
+	created := time.Date(2026, 6, 12, 1, 2, 3, 0, time.UTC)
+	jobs := &fakeRiverJobAdmin{
+		listResult: &river.JobListResult{
+			Jobs: []*rivertype.JobRow{
+				{
+					ID:          412,
+					Kind:        "todoist_followup_create",
+					State:       rivertype.JobStateDiscarded,
+					Attempt:     10,
+					MaxAttempts: 10,
+					Queue:       "default",
+					CreatedAt:   created,
+					FinalizedAt: &finalized,
+					EncodedArgs: []byte(`{"contact_task_id":"00000000-0000-0000-0000-000000000001"}`),
+					Errors: []rivertype.AttemptError{
+						{Attempt: 9, Error: "first failure"},
+						{Attempt: 10, Error: "POST /tasks: 503\nsecond line"},
+					},
+				},
+				{
+					ID:          413,
+					Kind:        "interaction_recorder",
+					State:       rivertype.JobStateRetryable,
+					Attempt:     1,
+					MaxAttempts: 5,
+					Queue:       "default",
+					CreatedAt:   created,
+					FinalizedAt: nil,
+					EncodedArgs: []byte(`{"event_id":"00000000-0000-0000-0000-000000000002"}`),
+				},
+			},
+		},
+	}
+	deps, stdout := depsWithJobs(jobs)
+	err := run(context.Background(), runOptions{listJobs: true, jobState: "discarded,retryable", jobLimit: 100}, deps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if jobs.listCalls != 1 {
+		t.Fatalf("expected 1 JobList call, got %d", jobs.listCalls)
+	}
+	out := stdout.String()
+	// Row 1: discarded, exhausted, finalized, multi-line last error quoted.
+	if !strings.Contains(out, "id=412 kind=todoist_followup_create state=discarded attempt=10/10") {
+		t.Fatalf("missing discarded row prefix: %q", out)
+	}
+	if !strings.Contains(out, "finalized_at=2026-06-12T03:04:05Z") {
+		t.Fatalf("missing finalized_at: %q", out)
+	}
+	// %q keeps the multi-line error on one line as an escaped string.
+	if !strings.Contains(out, `last_error="POST /tasks: 503\nsecond line"`) {
+		t.Fatalf("expected quoted multi-line last_error, got %q", out)
+	}
+	if !strings.Contains(out, `args={"contact_task_id":"00000000-0000-0000-0000-000000000001"}`) {
+		t.Fatalf("missing args JSON: %q", out)
+	}
+	// Row 2: retryable, no finalized_at.
+	if !strings.Contains(out, "id=413 kind=interaction_recorder state=retryable attempt=1/5") {
+		t.Fatalf("missing retryable row prefix: %q", out)
+	}
+	if !strings.Contains(out, "finalized_at=none") {
+		t.Fatalf("expected finalized_at=none for retryable row: %q", out)
+	}
+	// last_error empty for the row with no Errors.
+	if !strings.Contains(out, `last_error=""`) {
+		t.Fatalf("expected empty last_error for no-error row: %q", out)
+	}
+}
+
+func TestRunListJobsEmpty(t *testing.T) {
+	jobs := &fakeRiverJobAdmin{listResult: &river.JobListResult{Jobs: nil}}
+	deps, stdout := depsWithJobs(jobs)
+	err := run(context.Background(), runOptions{listJobs: true, jobState: "discarded,retryable", jobLimit: 100}, deps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "no jobs found (states=discarded,retryable)") {
+		t.Fatalf("expected empty-result message, got %q", stdout.String())
+	}
+}
+
+func TestRunListJobsLimitReachedNote(t *testing.T) {
+	// Fake returns exactly limit rows → limit-reached note fires.
+	rows := make([]*rivertype.JobRow, 2)
+	for i := range rows {
+		rows[i] = &rivertype.JobRow{
+			ID: int64(500 + i), Kind: "interaction_recorder", State: rivertype.JobStateDiscarded,
+			Attempt: 3, MaxAttempts: 3, Queue: "default",
+			CreatedAt: time.Date(2026, 6, 12, 0, 0, 0, 0, time.UTC),
+		}
+	}
+	jobs := &fakeRiverJobAdmin{listResult: &river.JobListResult{Jobs: rows}}
+	deps, stdout := depsWithJobs(jobs)
+	err := run(context.Background(), runOptions{listJobs: true, jobState: "discarded", jobLimit: 2}, deps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "note: limit reached (2 rows shown)") {
+		t.Fatalf("expected limit-reached note, got %q", stdout.String())
+	}
+}
+
+func TestRunListJobsInvalidState(t *testing.T) {
+	jobs := &fakeRiverJobAdmin{}
+	deps, _ := depsWithJobs(jobs)
+	err := run(context.Background(), runOptions{listJobs: true, jobState: "bogus", jobLimit: 100}, deps)
+	if err == nil {
+		t.Fatal("expected unknown-state error")
+	}
+	if !strings.Contains(err.Error(), "unknown state") || !strings.Contains(err.Error(), "discarded") {
+		t.Fatalf("expected error naming valid states, got %v", err)
+	}
+	if jobs.listCalls != 0 {
+		t.Fatalf("JobList must not be called on invalid state; got %d", jobs.listCalls)
+	}
+}
+
+func TestRunListJobsInvalidLimit(t *testing.T) {
+	for _, lim := range []int{0, 10001} {
+		jobs := &fakeRiverJobAdmin{}
+		deps, _ := depsWithJobs(jobs)
+		err := run(context.Background(), runOptions{listJobs: true, jobState: "discarded", jobLimit: lim}, deps)
+		if err == nil {
+			t.Fatalf("expected limit error for --job-limit %d", lim)
+		}
+		if !strings.Contains(err.Error(), "--job-limit must be between 1 and 10000") {
+			t.Fatalf("expected limit-range error, got %v", err)
+		}
+		if jobs.listCalls != 0 {
+			t.Fatalf("JobList must not be called on invalid limit; got %d", jobs.listCalls)
+		}
+	}
+}
+
+func TestRunListJobsError(t *testing.T) {
+	jobs := &fakeRiverJobAdmin{listErr: errors.New("db unreachable")}
+	deps, _ := depsWithJobs(jobs)
+	err := run(context.Background(), runOptions{listJobs: true, jobState: "discarded", jobLimit: 100}, deps)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "list jobs") {
+		t.Fatalf("expected wrapped error, got %v", err)
+	}
+}
+
+func TestRunRetryJobHappy(t *testing.T) {
+	scheduled := time.Date(2026, 6, 12, 5, 0, 0, 0, time.UTC)
+	jobs := &fakeRiverJobAdmin{
+		retryResult: &rivertype.JobRow{
+			ID: 412, Kind: "todoist_followup_create", State: rivertype.JobStateAvailable,
+			ScheduledAt: scheduled,
+		},
+	}
+	deps, stdout := depsWithJobs(jobs)
+	err := run(context.Background(), runOptions{retryJobID: 412}, deps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if jobs.retryCalls != 1 || jobs.retryID != 412 {
+		t.Fatalf("expected 1 JobRetry(412) call, got calls=%d id=%d", jobs.retryCalls, jobs.retryID)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "retried job id=412 kind=todoist_followup_create state=available") {
+		t.Fatalf("missing retry confirmation: %q", out)
+	}
+	if !strings.Contains(out, "scheduled_at=2026-06-12T05:00:00Z") {
+		t.Fatalf("missing scheduled_at: %q", out)
+	}
+}
+
+func TestRunRetryJobNotFound(t *testing.T) {
+	jobs := &fakeRiverJobAdmin{retryErr: rivertype.ErrNotFound}
+	deps, _ := depsWithJobs(jobs)
+	err := run(context.Background(), runOptions{retryJobID: 999999999}, deps)
+	if err == nil {
+		t.Fatal("expected not-found error")
+	}
+	if !strings.Contains(err.Error(), "no job with id 999999999") {
+		t.Fatalf("expected friendly not-found error naming the id, got %v", err)
+	}
+}
+
+func TestRunRetryJobInvalidID(t *testing.T) {
+	jobs := &fakeRiverJobAdmin{}
+	deps, _ := depsWithJobs(jobs)
+	// A negative id counts as active in validateSubcommand but is rejected by
+	// the runner before calling JobRetry.
+	err := run(context.Background(), runOptions{retryJobID: -1}, deps)
+	if err == nil {
+		t.Fatal("expected invalid-id error")
+	}
+	if !strings.Contains(err.Error(), "--retry-job must be a positive job id") {
+		t.Fatalf("expected positive-id error, got %v", err)
+	}
+	if jobs.retryCalls != 0 {
+		t.Fatalf("JobRetry must not be called on invalid id; got %d", jobs.retryCalls)
+	}
+}
+
+func TestRunRetryJobError(t *testing.T) {
+	jobs := &fakeRiverJobAdmin{retryErr: errors.New("connection reset")}
+	deps, _ := depsWithJobs(jobs)
+	err := run(context.Background(), runOptions{retryJobID: 412}, deps)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "retry job 412") {
+		t.Fatalf("expected wrapped error, got %v", err)
 	}
 }

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -69,9 +69,9 @@ import (
 
 // riverDiscardedJobRetention is how long River keeps discarded job rows before
 // JobCleaner prunes them. River's 7-day default would destroy the forensic
-// trail that `crm-admin --list-jobs` (and #483's /health discarded-job counts)
-// rely on. Single-user row counts are trivial, so we keep discarded jobs for
-// 90 days. Not exposed via config — no caller needs to vary it.
+// trail that `crm-admin --list-jobs` (and any health-check counts over
+// river_job) rely on. Single-user row counts are trivial, so we keep discarded
+// jobs for 90 days. Not exposed via config — no caller needs to vary it.
 const riverDiscardedJobRetention = 90 * 24 * time.Hour
 
 // noopJobArgs is the args type for the placeholder worker below. It is
@@ -311,7 +311,7 @@ func run() int {
 			river.QueueDefault: {MaxWorkers: cfg.River.WorkerConcurrency},
 		},
 		Workers: riverWorkers,
-		// Dead-letter visibility (#459): the ErrorHandler logs every errored
+		// Dead-letter visibility: the ErrorHandler logs every errored
 		// attempt + panic (ERROR on final-attempt discard, WARN otherwise);
 		// Logger routes River's own internal logs into the zerolog stream
 		// instead of a default slog TextHandler on stdout; the retention raise

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -67,6 +67,13 @@ import (
 	_ "personal-crm/backend/docs" // Import generated docs
 )
 
+// riverDiscardedJobRetention is how long River keeps discarded job rows before
+// JobCleaner prunes them. River's 7-day default would destroy the forensic
+// trail that `crm-admin --list-jobs` (and #483's /health discarded-job counts)
+// rely on. Single-user row counts are trivial, so we keep discarded jobs for
+// 90 days. Not exposed via config — no caller needs to vary it.
+const riverDiscardedJobRetention = 90 * 24 * time.Hour
+
 // noopJobArgs is the args type for the placeholder worker below. It is
 // never enqueued in production; its sole purpose is to satisfy river's
 // "must have at least one registered worker" invariant when external
@@ -304,6 +311,14 @@ func run() int {
 			river.QueueDefault: {MaxWorkers: cfg.River.WorkerConcurrency},
 		},
 		Workers: riverWorkers,
+		// Dead-letter visibility (#459): the ErrorHandler logs every errored
+		// attempt + panic (ERROR on final-attempt discard, WARN otherwise);
+		// Logger routes River's own internal logs into the zerolog stream
+		// instead of a default slog TextHandler on stdout; the retention raise
+		// keeps discarded rows queryable for forensics.
+		ErrorHandler:                events.NewRiverErrorHandler(logger.Get()),
+		Logger:                      logger.NewSlogLogger(logger.Get()),
+		DiscardedJobRetentionPeriod: riverDiscardedJobRetention,
 	})
 	if err != nil {
 		logger.Fatal().Err(err).Msg("failed to build river client")

--- a/backend/internal/events/river_error_handler.go
+++ b/backend/internal/events/river_error_handler.go
@@ -1,0 +1,81 @@
+package events
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
+	"github.com/rs/zerolog"
+)
+
+// RiverErrorHandler is a client-level River ErrorHandler that logs every errored
+// attempt and panic into the app's zerolog stream. It is a pure observer: both
+// methods always return nil, so River's configured retry schedule is untouched.
+//
+// A single client-level handler covers every job kind, including the event-bus
+// spec §3.4.3 promise that "an admin alert log fires" when a
+// todoist_followup_create job exhausts its attempts — no per-worker log calls
+// are needed.
+type RiverErrorHandler struct {
+	zl *zerolog.Logger
+}
+
+// NewRiverErrorHandler builds a RiverErrorHandler over the given logger. main.go
+// passes logger.Get(); the logger is initialized at boot before the River client
+// is constructed.
+func NewRiverErrorHandler(zl *zerolog.Logger) *RiverErrorHandler {
+	return &RiverErrorHandler{zl: zl}
+}
+
+// HandleError logs an errored job attempt. The attempt that just failed is the
+// final one (the job will be discarded) iff Attempt >= MaxAttempts — the exact
+// predicate River applies after this handler returns. Discards log at ERROR;
+// retryable failures log at WARN. Always returns nil (pure observer).
+func (h *RiverErrorHandler) HandleError(_ context.Context, job *rivertype.JobRow, err error) *river.ErrorHandlerResult {
+	discarded := job.Attempt >= job.MaxAttempts
+	level := zerolog.WarnLevel
+	msg := "river job errored; will retry"
+	if discarded {
+		level = zerolog.ErrorLevel
+		msg = "river job discarded after final attempt"
+	}
+	h.baseEvent(level, job, discarded).Err(err).Msg(msg)
+	return nil
+}
+
+// HandlePanic logs a panicking job attempt. A panic always logs at ERROR
+// regardless of remaining retry budget — a panic is a code bug, and a panicking
+// worker usually panics on every attempt, so deferring the signal would only
+// delay it. The discarded field still distinguishes a final-attempt panic.
+// Always returns nil (pure observer).
+func (h *RiverErrorHandler) HandlePanic(_ context.Context, job *rivertype.JobRow, panicVal any, trace string) *river.ErrorHandlerResult {
+	discarded := job.Attempt >= job.MaxAttempts
+	h.baseEvent(zerolog.ErrorLevel, job, discarded).
+		Str("panic", fmt.Sprintf("%v", panicVal)).
+		Str("trace", trace).
+		Msg("river job panicked")
+	return nil
+}
+
+// baseEvent builds a zerolog event with the fields common to both error and
+// panic logs. The caller appends its own fields (error / panic+trace) and the
+// message.
+func (h *RiverErrorHandler) baseEvent(level zerolog.Level, job *rivertype.JobRow, discarded bool) *zerolog.Event {
+	event := h.zl.WithLevel(level).
+		Int64("job_id", job.ID).
+		Str("kind", job.Kind).
+		Str("queue", job.Queue).
+		Int("attempt", job.Attempt).
+		Int("max_attempts", job.MaxAttempts).
+		Bool("discarded", discarded)
+	// EncodedArgs is always valid JSON for River-inserted rows; guard the
+	// defensive empty case so the log record can't be corrupted by RawJSON on
+	// an empty slice.
+	if len(job.EncodedArgs) == 0 {
+		event.Str("args", "")
+	} else {
+		event.RawJSON("args", job.EncodedArgs)
+	}
+	return event
+}

--- a/backend/internal/events/river_error_handler_test.go
+++ b/backend/internal/events/river_error_handler_test.go
@@ -1,0 +1,174 @@
+package events
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/riverqueue/river/rivertype"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newBufferHandler builds a RiverErrorHandler writing JSON into the returned
+// buffer at debug level (so every record is emitted). Parallel-safe: no global
+// mutation.
+func newBufferHandler() (*RiverErrorHandler, *bytes.Buffer) {
+	buf := &bytes.Buffer{}
+	zl := zerolog.New(buf).Level(zerolog.DebugLevel).With().Timestamp().Logger()
+	return NewRiverErrorHandler(&zl), buf
+}
+
+func decodeRecord(t *testing.T, buf *bytes.Buffer) map[string]any {
+	t.Helper()
+	require.NotEmpty(t, buf.Bytes(), "expected a log line")
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &m))
+	return m
+}
+
+func TestHandleError_RetryableLogsWarn(t *testing.T) {
+	t.Parallel()
+	h, buf := newBufferHandler()
+	job := &rivertype.JobRow{
+		ID:          101,
+		Kind:        "interaction_recorder",
+		Queue:       "default",
+		Attempt:     3,
+		MaxAttempts: 5,
+		EncodedArgs: []byte(`{"event_id":"00000000-0000-0000-0000-000000000001"}`),
+	}
+	res := h.HandleError(context.Background(), job, errors.New("transient db error"))
+	assert.Nil(t, res, "handler must always return nil (pure observer)")
+
+	m := decodeRecord(t, buf)
+	assert.Equal(t, "warn", m["level"])
+	assert.Equal(t, false, m["discarded"])
+	assert.Equal(t, float64(101), m["job_id"])
+	assert.Equal(t, "interaction_recorder", m["kind"])
+	assert.Equal(t, "default", m["queue"])
+	assert.Equal(t, float64(3), m["attempt"])
+	assert.Equal(t, float64(5), m["max_attempts"])
+	assert.Equal(t, "transient db error", m["error"])
+	assert.Equal(t, "river job errored; will retry", m["message"])
+	// args round-trips as the raw JSON object.
+	args, ok := m["args"].(map[string]any)
+	require.True(t, ok, "args should be a JSON object")
+	assert.Equal(t, "00000000-0000-0000-0000-000000000001", args["event_id"])
+}
+
+func TestHandleError_FinalAttemptLogsErrorDiscarded(t *testing.T) {
+	t.Parallel()
+	h, buf := newBufferHandler()
+	job := &rivertype.JobRow{
+		ID:          102,
+		Kind:        "cadence_updater",
+		Queue:       "default",
+		Attempt:     5,
+		MaxAttempts: 5,
+		EncodedArgs: []byte(`{"contact_id":"00000000-0000-0000-0000-000000000002"}`),
+	}
+	res := h.HandleError(context.Background(), job, errors.New("permanent failure"))
+	assert.Nil(t, res)
+
+	m := decodeRecord(t, buf)
+	assert.Equal(t, "error", m["level"])
+	assert.Equal(t, true, m["discarded"])
+	assert.Equal(t, "river job discarded after final attempt", m["message"])
+	assert.Equal(t, "permanent failure", m["error"])
+}
+
+// TestHandleError_TodoistFollowupExhaustion pins the event-bus spec §3.4.3 case:
+// a todoist_followup_create job exhausting MaxAttempts=10 logs at ERROR with
+// discarded=true — the generic implementation of the spec's "admin alert log
+// fires" promise.
+func TestHandleError_TodoistFollowupExhaustion(t *testing.T) {
+	t.Parallel()
+	h, buf := newBufferHandler()
+	job := &rivertype.JobRow{
+		ID:          103,
+		Kind:        "todoist_followup_create",
+		Queue:       "default",
+		Attempt:     10,
+		MaxAttempts: 10,
+		EncodedArgs: []byte(`{"contact_task_id":"00000000-0000-0000-0000-000000000003"}`),
+	}
+	res := h.HandleError(context.Background(), job, errors.New("POST /tasks: 503"))
+	assert.Nil(t, res)
+
+	m := decodeRecord(t, buf)
+	assert.Equal(t, "error", m["level"])
+	assert.Equal(t, true, m["discarded"])
+	assert.Equal(t, "todoist_followup_create", m["kind"])
+	assert.Equal(t, float64(10), m["attempt"])
+	assert.Equal(t, float64(10), m["max_attempts"])
+}
+
+func TestHandlePanic_NonFinalLogsErrorWithTrace(t *testing.T) {
+	t.Parallel()
+	h, buf := newBufferHandler()
+	job := &rivertype.JobRow{
+		ID:          104,
+		Kind:        "interaction_recorder",
+		Queue:       "default",
+		Attempt:     1,
+		MaxAttempts: 3,
+		EncodedArgs: []byte(`{"event_id":"00000000-0000-0000-0000-000000000004"}`),
+	}
+	res := h.HandlePanic(context.Background(), job, "nil map write", "goroutine 1 [running]:\nmain.work()")
+	assert.Nil(t, res)
+
+	m := decodeRecord(t, buf)
+	// A panic always logs ERROR, even on a non-final attempt.
+	assert.Equal(t, "error", m["level"])
+	assert.Equal(t, false, m["discarded"])
+	assert.Equal(t, "nil map write", m["panic"])
+	assert.Contains(t, m["trace"], "goroutine 1")
+	assert.Equal(t, "river job panicked", m["message"])
+}
+
+// TestHandlePanic_FinalAttemptStaysDistinguishable pins that a final-attempt
+// panic still carries discarded=true even though panics always log ERROR.
+func TestHandlePanic_FinalAttemptStaysDistinguishable(t *testing.T) {
+	t.Parallel()
+	h, buf := newBufferHandler()
+	job := &rivertype.JobRow{
+		ID:          105,
+		Kind:        "cadence_updater",
+		Queue:       "default",
+		Attempt:     3,
+		MaxAttempts: 3,
+		EncodedArgs: []byte(`{"contact_id":"00000000-0000-0000-0000-000000000005"}`),
+	}
+	res := h.HandlePanic(context.Background(), job, "index out of range", "trace")
+	assert.Nil(t, res)
+
+	m := decodeRecord(t, buf)
+	assert.Equal(t, "error", m["level"])
+	assert.Equal(t, true, m["discarded"])
+}
+
+// TestHandleError_EmptyArgsStaysValidJSON pins the D1 guard: an empty
+// EncodedArgs slice produces args="" rather than corrupting the record.
+func TestHandleError_EmptyArgsStaysValidJSON(t *testing.T) {
+	t.Parallel()
+	h, buf := newBufferHandler()
+	job := &rivertype.JobRow{
+		ID:          106,
+		Kind:        "some_kind",
+		Queue:       "default",
+		Attempt:     1,
+		MaxAttempts: 3,
+		EncodedArgs: nil,
+	}
+	res := h.HandleError(context.Background(), job, errors.New("boom"))
+	assert.Nil(t, res)
+
+	// The record must still be valid JSON.
+	m := decodeRecord(t, buf)
+	assert.Equal(t, "", m["args"])
+	assert.Equal(t, "warn", m["level"])
+}

--- a/backend/internal/events/river_error_handler_test.go
+++ b/backend/internal/events/river_error_handler_test.go
@@ -151,7 +151,7 @@ func TestHandlePanic_FinalAttemptStaysDistinguishable(t *testing.T) {
 	assert.Equal(t, true, m["discarded"])
 }
 
-// TestHandleError_EmptyArgsStaysValidJSON pins the D1 guard: an empty
+// TestHandleError_EmptyArgsStaysValidJSON pins the empty-args guard: an empty
 // EncodedArgs slice produces args="" rather than corrupting the record.
 func TestHandleError_EmptyArgsStaysValidJSON(t *testing.T) {
 	t.Parallel()

--- a/backend/internal/logger/slog_bridge.go
+++ b/backend/internal/logger/slog_bridge.go
@@ -1,0 +1,175 @@
+package logger
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/rs/zerolog"
+)
+
+// NewSlogLogger returns a *slog.Logger that writes through the given zerolog
+// logger, so a dependency that only speaks slog (e.g. River) joins the app's
+// structured zerolog stream instead of writing to its own default handler.
+//
+// Known cosmetic limitation: the app logger is built with .Caller(), so lines
+// emitted through this bridge report THIS file's source location as `caller`
+// rather than the original call site. The message text identifies the source
+// (e.g. River's own messages), so caller-skip plumbing isn't worth it.
+func NewSlogLogger(zl *zerolog.Logger) *slog.Logger {
+	return slog.New(&slogZerologHandler{zl: zl})
+}
+
+// slogZerologHandler implements slog.Handler by forwarding records to a zerolog
+// logger. Group prefixes are flattened into dotted keys (group.key), which is
+// adequate because the bridged dependencies barely use groups.
+type slogZerologHandler struct {
+	zl     *zerolog.Logger
+	groups []string
+}
+
+// Enabled reports whether a record at the given slog level would be emitted by
+// the underlying zerolog logger. This filters a dependency's debug chatter at
+// the app's configured level before any record is allocated.
+func (h *slogZerologHandler) Enabled(_ context.Context, level slog.Level) bool {
+	return slogToZerologLevel(level) >= h.zl.GetLevel()
+}
+
+// Handle forwards a single record to zerolog at the mapped level. It is safe to
+// call even when Enabled returned false: WithLevel produces a disabled event
+// below the logger's level, so nothing is written.
+func (h *slogZerologHandler) Handle(_ context.Context, record slog.Record) error {
+	event := h.zl.WithLevel(slogToZerologLevel(record.Level))
+	if event == nil {
+		return nil
+	}
+	record.Attrs(func(attr slog.Attr) bool {
+		appendAttr(event, h.groups, attr)
+		return true
+	})
+	// Timestamp comes from the zerolog logger's own Timestamp() hook; we do not
+	// duplicate record.Time (microsecond skew is irrelevant here).
+	event.Msg(record.Message)
+	return nil
+}
+
+// WithAttrs returns a handler that pre-binds the given attrs into a child
+// zerolog logger, qualifying their keys with the current group prefix (the
+// slog.Handler contract requires attrs added after WithGroup to be scoped by
+// it).
+func (h *slogZerologHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	if len(attrs) == 0 {
+		return h
+	}
+	ctx := h.zl.With()
+	for _, attr := range attrs {
+		ctx = appendAttrToContext(ctx, h.groups, attr)
+	}
+	child := ctx.Logger()
+	return &slogZerologHandler{zl: &child, groups: h.groups}
+}
+
+// WithGroup returns a handler that qualifies subsequent keys with the given
+// group name. Per the slog contract, an empty name returns the receiver
+// unchanged.
+func (h *slogZerologHandler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+	groups := make([]string, len(h.groups)+1)
+	copy(groups, h.groups)
+	groups[len(h.groups)] = name
+	return &slogZerologHandler{zl: h.zl, groups: groups}
+}
+
+// slogToZerologLevel maps an slog level band onto a zerolog level. slog levels
+// are coarser bands (Debug/Info/Warn/Error at multiples of 4), so anything
+// below Info is Debug, below Warn is Info, below Error is Warn, else Error.
+func slogToZerologLevel(level slog.Level) zerolog.Level {
+	switch {
+	case level < slog.LevelInfo:
+		return zerolog.DebugLevel
+	case level < slog.LevelWarn:
+		return zerolog.InfoLevel
+	case level < slog.LevelError:
+		return zerolog.WarnLevel
+	default:
+		return zerolog.ErrorLevel
+	}
+}
+
+// qualifyKey joins the active group prefix onto an attr key as group.subgroup.key.
+func qualifyKey(groups []string, key string) string {
+	if len(groups) == 0 {
+		return key
+	}
+	out := ""
+	for _, g := range groups {
+		out += g + "."
+	}
+	return out + key
+}
+
+// appendAttr writes a single resolved attr onto a zerolog event, honoring the
+// group prefix. Empty attrs (zero key and value) are elided per the slog
+// contract.
+func appendAttr(event *zerolog.Event, groups []string, attr slog.Attr) {
+	attr.Value = attr.Value.Resolve()
+	if attr.Equal(slog.Attr{}) {
+		return
+	}
+	key := qualifyKey(groups, attr.Key)
+	switch attr.Value.Kind() {
+	case slog.KindString:
+		event.Str(key, attr.Value.String())
+	case slog.KindInt64:
+		event.Int64(key, attr.Value.Int64())
+	case slog.KindUint64:
+		event.Uint64(key, attr.Value.Uint64())
+	case slog.KindFloat64:
+		event.Float64(key, attr.Value.Float64())
+	case slog.KindBool:
+		event.Bool(key, attr.Value.Bool())
+	case slog.KindDuration:
+		event.Dur(key, attr.Value.Duration())
+	case slog.KindTime:
+		event.Time(key, attr.Value.Time())
+	default:
+		if err, ok := attr.Value.Any().(error); ok {
+			event.AnErr(key, err)
+			return
+		}
+		event.Interface(key, attr.Value.Any())
+	}
+}
+
+// appendAttrToContext binds a single resolved attr into a zerolog child-logger
+// context (used by WithAttrs), honoring the group prefix. Mirrors appendAttr's
+// kind switch.
+func appendAttrToContext(ctx zerolog.Context, groups []string, attr slog.Attr) zerolog.Context {
+	attr.Value = attr.Value.Resolve()
+	if attr.Equal(slog.Attr{}) {
+		return ctx
+	}
+	key := qualifyKey(groups, attr.Key)
+	switch attr.Value.Kind() {
+	case slog.KindString:
+		return ctx.Str(key, attr.Value.String())
+	case slog.KindInt64:
+		return ctx.Int64(key, attr.Value.Int64())
+	case slog.KindUint64:
+		return ctx.Uint64(key, attr.Value.Uint64())
+	case slog.KindFloat64:
+		return ctx.Float64(key, attr.Value.Float64())
+	case slog.KindBool:
+		return ctx.Bool(key, attr.Value.Bool())
+	case slog.KindDuration:
+		return ctx.Dur(key, attr.Value.Duration())
+	case slog.KindTime:
+		return ctx.Time(key, attr.Value.Time())
+	default:
+		if err, ok := attr.Value.Any().(error); ok {
+			return ctx.AnErr(key, err)
+		}
+		return ctx.Interface(key, attr.Value.Any())
+	}
+}

--- a/backend/internal/logger/slog_bridge_test.go
+++ b/backend/internal/logger/slog_bridge_test.go
@@ -1,0 +1,186 @@
+package logger
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newBufferSlog builds a slog.Logger bridged to a zerolog logger writing JSON
+// into the returned buffer, at the given zerolog level. Parallel-safe: no
+// global mutation, each test owns its own buffer + logger.
+func newBufferSlog(level zerolog.Level) (*slog.Logger, *bytes.Buffer) {
+	buf := &bytes.Buffer{}
+	zl := zerolog.New(buf).Level(level).With().Timestamp().Logger()
+	return NewSlogLogger(&zl), buf
+}
+
+// decode parses the single JSON log line in the buffer into a map.
+func decode(t *testing.T, buf *bytes.Buffer) map[string]any {
+	t.Helper()
+	require.NotEmpty(t, buf.Bytes(), "expected a log line")
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &m))
+	return m
+}
+
+func TestSlogToZerologLevel(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   slog.Level
+		want zerolog.Level
+	}{
+		{"debug band", slog.LevelDebug, zerolog.DebugLevel},
+		{"below info still debug", slog.LevelInfo - 1, zerolog.DebugLevel},
+		{"info band", slog.LevelInfo, zerolog.InfoLevel},
+		{"below warn is info", slog.LevelWarn - 1, zerolog.InfoLevel},
+		{"warn band", slog.LevelWarn, zerolog.WarnLevel},
+		{"below error is warn", slog.LevelError - 1, zerolog.WarnLevel},
+		{"error band", slog.LevelError, zerolog.ErrorLevel},
+		{"above error is error", slog.LevelError + 4, zerolog.ErrorLevel},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, c.want, slogToZerologLevel(c.in))
+		})
+	}
+}
+
+func TestSlogBridgeLevelRoundTrip(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		log      func(l *slog.Logger)
+		wantZLvl string
+	}{
+		{"debug", func(l *slog.Logger) { l.Debug("m") }, "debug"},
+		{"info", func(l *slog.Logger) { l.Info("m") }, "info"},
+		{"warn", func(l *slog.Logger) { l.Warn("m") }, "warn"},
+		{"error", func(l *slog.Logger) { l.Error("m") }, "error"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			l, buf := newBufferSlog(zerolog.DebugLevel)
+			c.log(l)
+			m := decode(t, buf)
+			assert.Equal(t, c.wantZLvl, m["level"])
+			assert.Equal(t, "m", m["message"])
+		})
+	}
+}
+
+func TestSlogBridgeAttrKinds(t *testing.T) {
+	t.Parallel()
+	l, buf := newBufferSlog(zerolog.DebugLevel)
+	l.Info("structured",
+		slog.String("s", "hello"),
+		slog.Int("n", 42),
+		slog.Bool("flag", true),
+		slog.Duration("d", 1500*time.Millisecond),
+		slog.Any("err", errors.New("boom")),
+	)
+	m := decode(t, buf)
+	assert.Equal(t, "hello", m["s"])
+	assert.Equal(t, float64(42), m["n"])
+	assert.Equal(t, true, m["flag"])
+	// zerolog Dur defaults to milliseconds.
+	assert.Equal(t, float64(1500), m["d"])
+	assert.Equal(t, "boom", m["err"])
+}
+
+func TestSlogBridgeWithAttrsPersist(t *testing.T) {
+	t.Parallel()
+	l, buf := newBufferSlog(zerolog.DebugLevel)
+	child := l.With(slog.String("component", "river"))
+
+	child.Info("first")
+	m := decode(t, buf)
+	assert.Equal(t, "river", m["component"])
+
+	// The bound attr persists across calls.
+	buf.Reset()
+	child.Warn("second")
+	m = decode(t, buf)
+	assert.Equal(t, "river", m["component"])
+	assert.Equal(t, "warn", m["level"])
+}
+
+func TestSlogBridgeWithGroupDottedKeys(t *testing.T) {
+	t.Parallel()
+	l, buf := newBufferSlog(zerolog.DebugLevel)
+	l.WithGroup("river").Info("grouped", slog.String("queue", "default"))
+	m := decode(t, buf)
+	assert.Equal(t, "default", m["river.queue"])
+	_, bare := m["queue"]
+	assert.False(t, bare, "key should be group-qualified, not bare")
+}
+
+func TestSlogBridgeWithGroupThenWithAttrs(t *testing.T) {
+	t.Parallel()
+	// The contract: attrs bound after WithGroup carry the group prefix.
+	l, buf := newBufferSlog(zerolog.DebugLevel)
+	l.WithGroup("river").With(slog.Int("attempt", 3)).Info("m")
+	m := decode(t, buf)
+	assert.Equal(t, float64(3), m["river.attempt"])
+}
+
+func TestSlogBridgeWithEmptyGroupIsNoOp(t *testing.T) {
+	t.Parallel()
+	l, buf := newBufferSlog(zerolog.DebugLevel)
+	l.WithGroup("").Info("m", slog.String("k", "v"))
+	m := decode(t, buf)
+	// No group prefix applied.
+	assert.Equal(t, "v", m["k"])
+}
+
+func TestSlogBridgeEnabledFiltering(t *testing.T) {
+	t.Parallel()
+	// Debug record against an info-level logger emits nothing.
+	l, buf := newBufferSlog(zerolog.InfoLevel)
+	l.Debug("should be filtered", slog.String("k", "v"))
+	assert.Empty(t, buf.Bytes(), "debug below info level must not be written")
+
+	// Info passes.
+	l.Info("should pass")
+	assert.NotEmpty(t, buf.Bytes())
+}
+
+// resolvable exercises the LogValuer resolution path.
+type resolvable struct{ inner string }
+
+func (r resolvable) LogValue() slog.Value { return slog.StringValue(r.inner) }
+
+func TestSlogBridgeLogValuerResolves(t *testing.T) {
+	t.Parallel()
+	l, buf := newBufferSlog(zerolog.DebugLevel)
+	l.Info("m", slog.Any("v", resolvable{inner: "resolved"}))
+	m := decode(t, buf)
+	assert.Equal(t, "resolved", m["v"])
+}
+
+func TestSlogBridgeUint64AndFloatAndTime(t *testing.T) {
+	t.Parallel()
+	l, buf := newBufferSlog(zerolog.DebugLevel)
+	ts := time.Date(2026, 6, 12, 1, 2, 3, 0, time.UTC)
+	l.Info("m",
+		slog.Uint64("u", 18446744073709551615),
+		slog.Float64("f", 3.5),
+		slog.Time("t", ts),
+	)
+	m := decode(t, buf)
+	// Large uint64 round-trips via JSON number.
+	assert.Equal(t, float64(18446744073709551615), m["u"])
+	assert.Equal(t, 3.5, m["f"])
+	// zerolog default time format is RFC3339.
+	assert.Equal(t, ts.Format(time.RFC3339), m["t"])
+}

--- a/backend/tests/river_integration_test.go
+++ b/backend/tests/river_integration_test.go
@@ -1,17 +1,25 @@
 package tests
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
 	"os"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"personal-crm/backend/internal/accelerated"
 	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
 
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/riverqueue/river/rivertype"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
 
@@ -217,4 +225,126 @@ func TestRiverClient_BootsWithNoopWorkerOnly(t *testing.T) {
 	stopCtx, stopCancel := context.WithTimeout(ctx, 10*time.Second)
 	defer stopCancel()
 	require.NoError(t, client.Stop(stopCtx))
+}
+
+// alwaysFailJobArgs is a test-only worker type whose worker always returns an
+// error, so it exhausts its attempts and lands in `discarded`.
+type alwaysFailJobArgs struct{}
+
+func (alwaysFailJobArgs) Kind() string { return "test_always_fail" }
+
+type alwaysFailWorker struct {
+	river.WorkerDefaults[alwaysFailJobArgs]
+}
+
+func (*alwaysFailWorker) Work(_ context.Context, _ *river.Job[alwaysFailJobArgs]) error {
+	return errors.New("deliberate test failure")
+}
+
+// errorHandlerFastRetry puts every retry 200ms out so a two-attempt job reaches
+// `discarded` in a few seconds. The accelerated clock is used per the repo's
+// no-time.Now rule.
+type errorHandlerFastRetry struct{}
+
+func (errorHandlerFastRetry) NextRetry(_ *rivertype.JobRow) time.Time {
+	return accelerated.GetCurrentTime().Add(200 * time.Millisecond)
+}
+
+// TestRiverErrorHandler_DiscardLogging_Integration pins the ErrorHandler's
+// discard predicate against the REAL River executor: an always-failing job with
+// MaxAttempts=2 must produce exactly one WARN (attempt 1, discarded=false) and
+// one ERROR (attempt 2, discarded=true). This is the upgrade-time safety net for
+// the handler's duplication of River's `Attempt >= MaxAttempts` comparison — a
+// future River bump that changes the discard semantics fails here instead of
+// silently mislabeling.
+func TestRiverErrorHandler_DiscardLogging_Integration(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	database, cfg := newIsolatedRiverTestDB(t, ctx)
+
+	// Thread-safe buffer: River invokes the ErrorHandler on its own goroutines.
+	buf := &bytes.Buffer{}
+	zl := zerolog.New(zerolog.SyncWriter(buf)).Level(zerolog.DebugLevel).With().Timestamp().Logger()
+
+	workers := river.NewWorkers()
+	river.AddWorker(workers, &alwaysFailWorker{})
+
+	client, err := river.NewClient(riverpgxv5.New(database.Pool), &river.Config{
+		Queues: map[string]river.QueueConfig{
+			river.QueueDefault: {MaxWorkers: cfg.River.WorkerConcurrency},
+		},
+		Workers:      workers,
+		ErrorHandler: events.NewRiverErrorHandler(&zl),
+		RetryPolicy:  errorHandlerFastRetry{},
+		// NOT TestOnly: we need the scheduler loop so the retryable attempt 1
+		// becomes available and gets worked a second time to reach `discarded`.
+	})
+	require.NoError(t, err)
+
+	// Start with the test's BASE ctx (never a timeout-derived ctx — River
+	// silently stops fetching when its fetch-loop ctx cancels).
+	require.NoError(t, client.Start(ctx))
+	t.Cleanup(func() {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer stopCancel()
+		_ = client.Stop(stopCtx)
+	})
+
+	insertRes, err := client.Insert(ctx, alwaysFailJobArgs{}, &river.InsertOpts{MaxAttempts: 2})
+	require.NoError(t, err)
+	jobID := insertRes.Job.ID
+
+	// Poll until the job lands in `discarded` (both attempts exhausted). Generous
+	// deadline: ~200ms retry backoff + scheduler interval.
+	waitCtx, waitCancel := context.WithTimeout(ctx, 15*time.Second)
+	defer waitCancel()
+	tick := time.NewTicker(50 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		state, qerr := database.Queries.GetRiverJobStateByID(ctx, jobID)
+		if qerr == nil && state == db.RiverJobStateDiscarded {
+			break
+		}
+		select {
+		case <-waitCtx.Done():
+			t.Fatalf("timed out waiting for job %d to reach discarded", jobID)
+		case <-tick.C:
+		}
+	}
+
+	// Parse the buffered JSON log lines, filtering to records carrying our
+	// job_id (Logger is unset here, so only the ErrorHandler writes).
+	var warnRec, errorRec map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var m map[string]any
+		require.NoError(t, json.Unmarshal([]byte(line), &m))
+		if id, ok := m["job_id"].(float64); !ok || int64(id) != jobID {
+			continue
+		}
+		switch m["level"] {
+		case "warn":
+			warnRec = m
+		case "error":
+			errorRec = m
+		}
+	}
+
+	require.NotNil(t, warnRec, "expected a WARN record for the non-final attempt")
+	require.Equal(t, false, warnRec["discarded"])
+	require.Equal(t, float64(1), warnRec["attempt"])
+	require.Equal(t, "test_always_fail", warnRec["kind"])
+	require.Contains(t, warnRec["error"], "deliberate test failure")
+	require.NotNil(t, warnRec["args"], "args field must be present")
+
+	require.NotNil(t, errorRec, "expected an ERROR record for the final (discard) attempt")
+	require.Equal(t, true, errorRec["discarded"])
+	require.Equal(t, float64(2), errorRec["attempt"])
+	require.Equal(t, float64(2), errorRec["max_attempts"])
 }

--- a/frontend/tests/e2e/test-map.json
+++ b/frontend/tests/e2e/test-map.json
@@ -557,5 +557,13 @@
   {
     "pattern": "^backend/internal/scheduler/messaging_aggregate.*\\.go$",
     "tags": ["@area:imports", "@area:contacts"]
+  },
+  {
+    "pattern": "^backend/internal/events/river_error_handler\\.go$",
+    "tags": ["@smoke"]
+  },
+  {
+    "pattern": "^backend/internal/logger/slog_bridge\\.go$",
+    "tags": ["@smoke"]
   }
 ]

--- a/scripts/hooks/test/test-run-e2e-warning.sh
+++ b/scripts/hooks/test/test-run-e2e-warning.sh
@@ -13,6 +13,14 @@
 #   - stdout contains NO warning text (stdout-purity guard for the unconditional
 #     warning-under-print-only decision: the warning must live on stderr only)
 set -u
+# Sanitize hook-inherited git env BEFORE any git command. git exports GIT_DIR to
+# hooks (absolute in linked worktrees), which silently redirects every
+# `git -C "$tmp" ...` below at the REAL repo with work-tree=$tmp: `add -A` wipes
+# the real index down to the temp fixture files, `commit` strands fixture commits
+# on the pushed branch, and `update-ref -d` deletes the real origin/develop
+# tracking ref. Unsetting here restores cwd-based discovery, so the throwaway
+# repo is genuinely isolated (and the node child below inherits the clean env).
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE
 cd "$(dirname "${BASH_SOURCE[0]}")/../../.." || exit 1   # repo root of THIS repo
 SCRIPT="$(pwd)/scripts/run-e2e-local.mjs"
 


### PR DESCRIPTION
## Summary

Closes #459 (element 2 of the prod-observability train, tracker #509). Plan: `.ai/log/plan/459-river-deadletter-visibility.md`.

- **River ErrorHandler** (`backend/internal/events/river_error_handler.go`): client-level observer logging every errored job attempt and panic into the zerolog stream — ERROR with `discarded=true` on the final attempt (`Attempt >= MaxAttempts`, River's own discard predicate), WARN otherwise; panics always ERROR with `panic`+`trace`. Always returns nil (retry behavior untouched). Implements the event-bus spec §3.4.3 "admin alert log fires" promise generically for every kind, including `todoist_followup_create` exhaustion — no per-worker log calls.
- **slog→zerolog bridge** (`backend/internal/logger/slog_bridge.go`): `NewSlogLogger` wraps zerolog in an `slog.Handler`, so River's internal logs (start/stop, leadership, job-errored lines, rescuer/cleaner activity) join the structured stream in `podman logs crm-backend` instead of a default slog TextHandler on stdout. Level bands map slog→zerolog; groups flatten to dotted keys; `Enabled` gates at the app's configured level.
- **crm-admin subcommands**: `--list-jobs` (one `key=value` row per job; `--job-state` comma-filter validated against River's states, `--job-limit` 1..10000, newest first; empty-result + limit-reached messages) and `--retry-job <id>` (River `JobRetry`; friendly not-found for retention-cleaned ids). Both go through the existing insert-only river client (`JobList`/`JobRetry` hit the driver; no worker pool, no raw SQL) and are safe with crm-api running.
- **crm-api wiring**: `ErrorHandler` + `Logger` + `DiscardedJobRetentionPeriod` (90d, hardcoded const — River's 7-day default destroyed the forensic trail) on the existing `river.Config` literal. No new types in main.go (single-file build convention preserved).
- **Spec annotations**: §3.4.3 (promise implemented, with the JobRescuer-bypass caveat explicitly NOT over-claimed) and §8 Q2 (logs+CLI observability level shipped; dashboard still deferred). Two `@smoke` test-map entries for the new backend files.
- **Hook fix** (`scripts/hooks/test/test-run-e2e-warning.sh`): unset hook-exported `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE` before the temp-repo fixture commands. git exports an absolute `GIT_DIR` to hooks for linked-worktree pushes, which redirected the test's `git -C "$tmp"` fixture ops at the real repo (work-tree=$tmp): it wiped the index to the fixture files, stranded fixture commits on the pushed branch, and deleted the `origin/develop` tracking ref — discovered when this branch's first push corrupted its own worktree. Verified by running the suite with the hook's absolute `GIT_DIR` exported. (Residual: the hook resolves `PROJECT_ROOT` through its symlink to the main worktree, so worktree pushes verify the main checkout — follow-up issue filed.)

## Test plan

- Unit: bridge level-mapping/attr-kinds/`WithAttrs`/`WithGroup`/`Enabled`/LogValuer (buffer-backed, parallel); handler WARN-vs-ERROR/discard predicate/panic fields/empty-args guard/nil-result incl. the named spec-§3.4.3 Todoist-exhaustion case; crm-admin parse/mutual-exclusion/output-format/error paths via fakes.
- Integration (clone-isolated, `t.Parallel()`, base-ctx `Start`): `TestRiverErrorHandler_DiscardLogging_Integration` pins the discard predicate against the real executor (1 WARN + 1 ERROR for a MaxAttempts=2 always-failing job); `TestListAndRetryJobs_Integration` drives `run()` against a real River client — list output, `--job-limit`→`First` propagation, state filtering, post-retry `available` state, not-found error.
- Gate: `make lint` (0 issues), `make test` (unit + integration + frontend, all green), `make test-e2e-diff` (3 `@smoke` specs passed — boots crm-api through the new `river.Config` wiring).

## Post-deploy notes (manual)

After promotion: `podman logs crm-backend` shows River internals as structured zerolog JSON; a transient consumer failure surfaces as WARN with `discarded=false`; `crm-admin --list-jobs` runs via the documented `podman run --entrypoint` pattern and reports `no jobs found` or the real backlog.
