### PR TITLE
fix(deploy): stamp frontend version vars in build-images.yml

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -65,7 +65,14 @@ jobs:
           NEXT_PUBLIC_API_KEY: ''
           NEXT_PUBLIC_API_URL: ''
           NEXT_TELEMETRY_DISABLED: '1'
+          # Version stamp, mirroring the backend ldflags stamp above so Settings →
+          # System Information shows the build date + commit instead of "(dev)".
+          # NEXT_PUBLIC_* are inlined at build time, so they must be set HERE.
+          # Full 40-char SHA: the UI validates /^[0-9a-f]{40}$/ before linking it.
+          NEXT_PUBLIC_COMMIT_HASH: ${{ github.sha }}
+          NEXT_PUBLIC_GITHUB_REPO: ${{ github.repository }}
         run: |
+          export NEXT_PUBLIC_BUILD_VERSION=$(date -u +"%Y.%-m.%-d")
           bun install --frozen-lockfile
           bun run build
 


### PR DESCRIPTION
## Problem

Settings → System Information shows **`Personal CRM (dev)`** in production instead of the build date + commit.

## Root cause

The version string in `frontend/src/app/settings/page.tsx` is built from three `NEXT_PUBLIC_*` vars (`BUILD_VERSION`, `COMMIT_HASH`, `GITHUB_REPO`). Next.js inlines `NEXT_PUBLIC_*` at `bun run build` time, so whatever is set when the image is built is frozen into the bundle. When `BUILD_VERSION` is empty the component falls through to the `else` branch and renders literally `Personal CRM (dev)`.

The image deployed to prod is built by `.github/workflows/build-images.yml`. Its frontend build step set the API-key/URL/telemetry vars but **never set the three version vars**, so every frontend image baked "(dev)". The backend got its `-ldflags` stamp in the same workflow — which is why `/health` reports the right version but the UI doesn't. `ci.yml` sets these correctly, but that job only *verifies* a build; it doesn't produce the deployed image.

This is a regression from the GHCR-image deploy cutover: the old native deploy built the frontend with these vars set, and `build-images.yml` didn't carry them over.

## Fix

Set `NEXT_PUBLIC_COMMIT_HASH` / `NEXT_PUBLIC_GITHUB_REPO` / `NEXT_PUBLIC_BUILD_VERSION` in the `build-images.yml` frontend build step, mirroring `ci.yml` and the backend stamp in the same workflow. Used `date -u` for the version date to match the backend's UTC `BUILD_TIME` stamp.

The E2E build job in `ci.yml` *deliberately* omits these so `settings.spec.ts` can assert "(dev)" — that's intentional and untouched.

## Verification

This only affects newly built images. After merge to `develop`, `build-images.yml` rebuilds the frontend `:<sha>` with the stamp; the System Information panel will read e.g. `Personal CRM 2026.6.12 (08a5ceb)` with the commit linking to GitHub. `make promote` then deploys it to prod.

## Review notes

Adversarial review (`/review-head`) passed: 0×P0, 0×P1, 1×P2 (no regression-guard test/lint — pre-existing duplication between the two workflows; recurrence risk noted), 2×P3 (comment regex `/i` flag, `date -u` vs ci.yml's local-TZ `date` — no functional impact on UTC runners). None blocking.