### PR TITLE
feat(sync): staleness banner on dashboard and settings

### DIFF
--- a/.ai/patterns/frontend.md
+++ b/.ai/patterns/frontend.md
@@ -13,6 +13,7 @@ Reusable React/TypeScript patterns for consistency across the frontend codebase.
 | `useInteractionsQueue`, `useResolveLink`, `useAnarlogTitleCandidates`, `useResolveNameCandidate` | Imports — Interactions tab + Anarlog name candidates | `use-interactions-queue.ts` |
 | `useMergeContacts` | Contact merge | `use-merge.ts` |
 | `useSyncStates`, `useTriggerSync` | Sync status | `use-sync-states.ts` |
+| `useSyncStaleness` | Sync-staleness watchdog breaches (read-only poll) | `use-sync-staleness.ts` |
 | `useGoogleAccounts`, `useConnectGoogle` | Google OAuth | `use-google-accounts.ts` |
 | `useTodoistAccounts`, `useConnectTodoist` | Todoist OAuth | `use-todoist-accounts.ts` |
 | `useTodoistSettings`, `useUpdateTodoistSettings` | Todoist config | `use-todoist-settings.ts` |

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { CheckCircle, Clock, AlertCircle, User, Plus } from 'lucide-react'
 import { Navigation } from '@/components/layout/navigation'
 import { Button } from '@/components/ui/button'
+import { SyncStalenessBanner } from '@/components/sync-staleness-banner'
 import { ContactMethodIcon } from '@/components/contacts/contact-method-icon'
 import { useOverdueContacts } from '@/hooks/use-contacts'
 import { useCreateInteraction } from '@/hooks/use-interactions'
@@ -206,6 +207,8 @@ export default function DashboardPage() {
       <Navigation />
 
       <div className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
+        <SyncStalenessBanner />
+
         {/* Header */}
         <div className="md:flex md:items-center md:justify-between mb-8">
           <div className="flex-1 min-w-0">

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { Download, Upload, Settings, Database, Shield, Clock, Cpu } from 'lucide-react'
 import { Navigation } from '@/components/layout/navigation'
 import { Button } from '@/components/ui/button'
+import { SyncStalenessBanner } from '@/components/sync-staleness-banner'
 import { GoogleAccountsSection } from '@/components/settings/google-accounts-section'
 import { TodoistAccountsSection } from '@/components/settings/todoist-accounts-section'
 import { TelegramSection } from '@/components/settings/telegram-section'
@@ -107,6 +108,8 @@ export default function SettingsPage() {
       <Navigation />
 
       <div className="max-w-4xl mx-auto py-6 sm:px-6 lg:px-8">
+        <SyncStalenessBanner />
+
         {/* Header */}
         <div className="mb-8">
           <div className="flex items-center space-x-3 mb-2">

--- a/frontend/src/components/__tests__/sync-staleness-banner.test.tsx
+++ b/frontend/src/components/__tests__/sync-staleness-banner.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { SyncStalenessBanner } from '../sync-staleness-banner'
+import type { StalenessBreach } from '@/types/sync'
+
+vi.mock('@/hooks/use-sync-staleness', () => ({
+  useSyncStaleness: vi.fn(),
+}))
+
+import { useSyncStaleness } from '@/hooks/use-sync-staleness'
+
+const mockedUseSyncStaleness = useSyncStaleness as unknown as ReturnType<typeof vi.fn>
+
+function createBreach(overrides: Partial<StalenessBreach> = {}): StalenessBreach {
+  return {
+    id: 'breach-1',
+    source: 'messages',
+    account_id: 'host-1',
+    breach_type: 'push_stale',
+    stale_since: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
+    threshold_seconds: 172800,
+    details: 'no push for 3d (threshold 48h)',
+    detected_at: '2026-06-04T00:00:00Z',
+    last_observed_at: '2026-06-04T00:00:00Z',
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('SyncStalenessBanner', () => {
+  it('renders nothing while loading', () => {
+    mockedUseSyncStaleness.mockReturnValue({ data: undefined, isLoading: true, isError: false })
+    const { container } = render(<SyncStalenessBanner />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing on fetch error (fail-quiet)', () => {
+    mockedUseSyncStaleness.mockReturnValue({ data: undefined, isLoading: false, isError: true })
+    const { container } = render(<SyncStalenessBanner />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing when there are no breaches', () => {
+    mockedUseSyncStaleness.mockReturnValue({ data: [], isLoading: false, isError: false })
+    const { container } = render(<SyncStalenessBanner />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders a singular heading and one line for a single breach', () => {
+    mockedUseSyncStaleness.mockReturnValue({
+      data: [createBreach()],
+      isLoading: false,
+      isError: false,
+    })
+    render(<SyncStalenessBanner />)
+
+    expect(screen.getByRole('status')).toBeInTheDocument()
+    expect(screen.getByText('1 sync source may be stalled')).toBeInTheDocument()
+    // Human source label + details string appear on the line.
+    expect(screen.getByText(/Messages/)).toBeInTheDocument()
+    expect(screen.getByText(/no push for 3d/)).toBeInTheDocument()
+    expect(screen.getByText(/stale 3d/)).toBeInTheDocument()
+  })
+
+  it('renders a plural heading and one line per breach', () => {
+    mockedUseSyncStaleness.mockReturnValue({
+      data: [
+        createBreach({ id: 'b1', source: 'messages' }),
+        createBreach({ id: 'b2', source: 'gcal', details: 'no sync for 26h (threshold 24h)' }),
+        createBreach({ id: 'b3', source: 'mac_host', breach_type: 'heartbeat', details: '' }),
+      ],
+      isLoading: false,
+      isError: false,
+    })
+    render(<SyncStalenessBanner />)
+
+    expect(screen.getByText('3 sync sources may be stalled')).toBeInTheDocument()
+    expect(screen.getByText(/Messages/)).toBeInTheDocument()
+    expect(screen.getByText(/Google Calendar/)).toBeInTheDocument()
+    expect(screen.getByText(/Mac daemon/)).toBeInTheDocument()
+    expect(screen.getAllByRole('listitem')).toHaveLength(3)
+  })
+
+  it('falls back to the raw source name for unknown sources', () => {
+    mockedUseSyncStaleness.mockReturnValue({
+      data: [createBreach({ source: 'some_new_source', details: '' })],
+      isLoading: false,
+      isError: false,
+    })
+    render(<SyncStalenessBanner />)
+    expect(screen.getByText(/some_new_source/)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/__tests__/sync-staleness-banner.test.tsx
+++ b/frontend/src/components/__tests__/sync-staleness-banner.test.tsx
@@ -93,4 +93,14 @@ describe('SyncStalenessBanner', () => {
     render(<SyncStalenessBanner />)
     expect(screen.getByText(/some_new_source/)).toBeInTheDocument()
   })
+
+  it('renders a sub-minute age as <1m', () => {
+    mockedUseSyncStaleness.mockReturnValue({
+      data: [createBreach({ stale_since: new Date().toISOString(), details: '' })],
+      isLoading: false,
+      isError: false,
+    })
+    render(<SyncStalenessBanner />)
+    expect(screen.getByText(/stale <1m/)).toBeInTheDocument()
+  })
 })

--- a/frontend/src/components/sync-staleness-banner.tsx
+++ b/frontend/src/components/sync-staleness-banner.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import { AlertTriangle } from 'lucide-react'
+import { useSyncStaleness } from '@/hooks/use-sync-staleness'
+import type { StalenessBreach } from '@/types/sync'
+
+// Human-readable labels for the sources the watchdog reports. Pull sources,
+// push sources, and the mac_host heartbeat all flow through here; anything
+// not listed falls back to the raw source string.
+const SOURCE_LABELS: Record<string, string> = {
+  email: 'Gmail',
+  gcal: 'Google Calendar',
+  gcontacts: 'Google Contacts',
+  gchat: 'Google Chat',
+  todoist: 'Todoist',
+  telegram: 'Telegram',
+  messages: 'Messages',
+  icloud_contacts: 'iCloud Contacts',
+  phone_calls: 'Phone & FaceTime',
+  anarlog_sessions: 'Meeting notes',
+  anarlog_humans: 'Meeting people',
+  mac_host: 'Mac daemon',
+}
+
+function sourceLabel(source: string): string {
+  return SOURCE_LABELS[source] ?? source
+}
+
+// Relative age of a stale reference timestamp, computed client-side so the
+// banner ages without the server rewriting rows. Mirrors the coarse buckets
+// used elsewhere (formatSyncTime).
+function formatAge(staleSince: string, now: Date): string {
+  const since = new Date(staleSince)
+  if (Number.isNaN(since.getTime())) return ''
+
+  const diffMs = now.getTime() - since.getTime()
+  if (diffMs < 0) return 'just now'
+
+  const diffMins = Math.floor(diffMs / (1000 * 60))
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60))
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24))
+
+  if (diffMins < 1) return 'just now'
+  if (diffMins < 60) return `${diffMins}m`
+  if (diffHours < 24) return `${diffHours}h`
+  return `${diffDays}d`
+}
+
+function breachLine(breach: StalenessBreach, now: Date): string {
+  const label = sourceLabel(breach.source)
+  const age = formatAge(breach.stale_since, now)
+  const ageText = age ? ` — stale ${age}` : ''
+  const detailText = breach.details ? ` (${breach.details})` : ''
+  return `${label}${ageText}${detailText}`
+}
+
+/**
+ * SyncStalenessBanner surfaces the sync-staleness watchdog's active breaches
+ * (#480) as a persistent amber banner. It is deliberately fail-quiet: it
+ * renders nothing while loading, on a fetch error, or when there are no
+ * breaches, so a flaky poll can never break or alarm the page. The watchdog's
+ * own logs are the backend signal path; this banner is just the surface cue.
+ */
+export function SyncStalenessBanner() {
+  const { data: breaches, isError, isLoading } = useSyncStaleness()
+
+  if (isLoading || isError || !breaches || breaches.length === 0) {
+    return null
+  }
+
+  const now = new Date()
+  const count = breaches.length
+
+  return (
+    <div
+      role="status"
+      className="mb-6 rounded-md border border-amber-200 bg-amber-50 p-4"
+      data-testid="sync-staleness-banner"
+    >
+      <div className="flex">
+        <div className="flex-shrink-0">
+          <AlertTriangle className="h-5 w-5 text-amber-500" aria-hidden="true" />
+        </div>
+        <div className="ml-3">
+          <h3 className="text-sm font-medium text-amber-800">
+            {count} sync {count === 1 ? 'source' : 'sources'} may be stalled
+          </h3>
+          <ul className="mt-2 space-y-1 text-sm text-amber-700">
+            {breaches.map(breach => (
+              <li key={breach.id}>{breachLine(breach, now)}</li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/sync-staleness-banner.tsx
+++ b/frontend/src/components/sync-staleness-banner.tsx
@@ -34,13 +34,15 @@ function formatAge(staleSince: string, now: Date): string {
   if (Number.isNaN(since.getTime())) return ''
 
   const diffMs = now.getTime() - since.getTime()
-  if (diffMs < 0) return 'just now'
+  // Sub-minute ages (and small negative clock skew) render as "<1m" so the
+  // line reads "stale <1m" rather than an awkward "stale just now".
+  if (diffMs < 0) return '<1m'
 
   const diffMins = Math.floor(diffMs / (1000 * 60))
   const diffHours = Math.floor(diffMs / (1000 * 60 * 60))
   const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24))
 
-  if (diffMins < 1) return 'just now'
+  if (diffMins < 1) return '<1m'
   if (diffMins < 60) return `${diffMins}m`
   if (diffHours < 24) return `${diffHours}h`
   return `${diffDays}d`
@@ -56,7 +58,7 @@ function breachLine(breach: StalenessBreach, now: Date): string {
 
 /**
  * SyncStalenessBanner surfaces the sync-staleness watchdog's active breaches
- * (#480) as a persistent amber banner. It is deliberately fail-quiet: it
+ * as a persistent amber banner. It is deliberately fail-quiet: it
  * renders nothing while loading, on a fetch error, or when there are no
  * breaches, so a flaky poll can never break or alarm the page. The watchdog's
  * own logs are the backend signal path; this banner is just the surface cue.

--- a/frontend/src/hooks/__tests__/use-sync-staleness.test.tsx
+++ b/frontend/src/hooks/__tests__/use-sync-staleness.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import { useSyncStaleness } from '../use-sync-staleness'
+import type { StalenessBreach } from '@/types/sync'
+
+vi.mock('@/lib/sync-api', () => ({
+  syncApi: {
+    getStalenessBreaches: vi.fn(),
+  },
+}))
+
+import { syncApi } from '@/lib/sync-api'
+
+const mockedApi = syncApi as unknown as {
+  getStalenessBreaches: ReturnType<typeof vi.fn>
+}
+
+function createTestQueryClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } })
+}
+
+function wrapper(client: QueryClient) {
+  // eslint-disable-next-line react/display-name
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  )
+}
+
+function createBreach(overrides: Partial<StalenessBreach> = {}): StalenessBreach {
+  return {
+    id: 'breach-1',
+    source: 'messages',
+    account_id: 'host-1',
+    breach_type: 'push_stale',
+    stale_since: '2026-06-01T00:00:00Z',
+    threshold_seconds: 172800,
+    details: 'no push for 3d2h (threshold 48h)',
+    detected_at: '2026-06-04T00:00:00Z',
+    last_observed_at: '2026-06-04T00:00:00Z',
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('useSyncStaleness', () => {
+  it('exposes the breaches returned by the api', async () => {
+    const breaches = [createBreach()]
+    mockedApi.getStalenessBreaches.mockResolvedValue(breaches)
+    const client = createTestQueryClient()
+    const { result } = renderHook(() => useSyncStaleness(), { wrapper: wrapper(client) })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toEqual(breaches)
+    expect(mockedApi.getStalenessBreaches).toHaveBeenCalledOnce()
+  })
+
+  it('exposes an empty list when there are no breaches', async () => {
+    mockedApi.getStalenessBreaches.mockResolvedValue([])
+    const client = createTestQueryClient()
+    const { result } = renderHook(() => useSyncStaleness(), { wrapper: wrapper(client) })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toEqual([])
+  })
+
+  it('surfaces the error state when the api rejects', async () => {
+    mockedApi.getStalenessBreaches.mockRejectedValue(new Error('boom'))
+    const client = createTestQueryClient()
+    const { result } = renderHook(() => useSyncStaleness(), { wrapper: wrapper(client) })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.data).toBeUndefined()
+  })
+})

--- a/frontend/src/hooks/use-sync-staleness.ts
+++ b/frontend/src/hooks/use-sync-staleness.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import { syncApi } from '@/lib/sync-api'
 import { syncKeys } from '@/lib/query-keys'
 
-// useSyncStaleness polls the watchdog's active-breach endpoint (#480).
+// useSyncStaleness polls the sync-staleness watchdog's active-breach endpoint.
 // The producer runs every 5 minutes on the Pi, so a 60s poll is plenty
 // fresh and cheaper than the mac page's 10s precedent. Read-only: breaches
 // have no client mutations, so there is no invalidation rule.

--- a/frontend/src/hooks/use-sync-staleness.ts
+++ b/frontend/src/hooks/use-sync-staleness.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query'
+import { syncApi } from '@/lib/sync-api'
+import { syncKeys } from '@/lib/query-keys'
+
+// useSyncStaleness polls the watchdog's active-breach endpoint (#480).
+// The producer runs every 5 minutes on the Pi, so a 60s poll is plenty
+// fresh and cheaper than the mac page's 10s precedent. Read-only: breaches
+// have no client mutations, so there is no invalidation rule.
+export function useSyncStaleness() {
+  return useQuery({
+    queryKey: syncKeys.staleness(),
+    queryFn: () => syncApi.getStalenessBreaches(),
+    staleTime: 30_000,
+    refetchInterval: 60_000,
+  })
+}

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -54,6 +54,7 @@ export const syncKeys = {
   states: () => [...syncKeys.all, 'states'] as const,
   state: (source: string, accountId?: string) =>
     [...syncKeys.all, 'state', source, accountId] as const,
+  staleness: () => [...syncKeys.all, 'staleness'] as const,
 }
 
 // Contact task query keys

--- a/frontend/src/lib/sync-api.ts
+++ b/frontend/src/lib/sync-api.ts
@@ -1,5 +1,5 @@
 import { apiClient } from './api-client'
-import type { SyncState } from '@/types/sync'
+import type { StalenessBreach, SyncState } from '@/types/sync'
 
 export const syncApi = {
   // Get all sync states
@@ -11,5 +11,10 @@ export const syncApi = {
   getSyncState: async (source: string, accountId?: string): Promise<SyncState> => {
     const params = accountId ? `?account_id=${encodeURIComponent(accountId)}` : ''
     return apiClient.get<SyncState>(`/api/v1/sync/${source}/status${params}`)
+  },
+
+  // Get active sync-staleness breaches reported by the watchdog (#480).
+  getStalenessBreaches: async (): Promise<StalenessBreach[]> => {
+    return apiClient.get<StalenessBreach[]>('/api/v1/sync/staleness')
   },
 }

--- a/frontend/src/lib/sync-api.ts
+++ b/frontend/src/lib/sync-api.ts
@@ -13,7 +13,7 @@ export const syncApi = {
     return apiClient.get<SyncState>(`/api/v1/sync/${source}/status${params}`)
   },
 
-  // Get active sync-staleness breaches reported by the watchdog (#480).
+  // Get active sync-staleness breaches reported by the watchdog.
   getStalenessBreaches: async (): Promise<StalenessBreach[]> => {
     return apiClient.get<StalenessBreach[]>('/api/v1/sync/staleness')
   },

--- a/frontend/src/types/sync.ts
+++ b/frontend/src/types/sync.ts
@@ -20,7 +20,7 @@ export interface SyncState {
   updated_at: string
 }
 
-// Breach type emitted by the sync-staleness watchdog (#480).
+// Breach type emitted by the sync-staleness watchdog.
 export type StalenessBreachType = 'heartbeat' | 'sync_stale' | 'push_stale' | 'sync_error'
 
 // StalenessBreach mirrors the backend repository.StalenessBreach DTO returned

--- a/frontend/src/types/sync.ts
+++ b/frontend/src/types/sync.ts
@@ -19,3 +19,22 @@ export interface SyncState {
   created_at: string
   updated_at: string
 }
+
+// Breach type emitted by the sync-staleness watchdog (#480).
+export type StalenessBreachType = 'heartbeat' | 'sync_stale' | 'push_stale' | 'sync_error'
+
+// StalenessBreach mirrors the backend repository.StalenessBreach DTO returned
+// by GET /api/v1/sync/staleness. The read path returns active (unresolved)
+// breaches only, so resolved_at is always absent there.
+export interface StalenessBreach {
+  id: string
+  source: string
+  account_id: string
+  breach_type: StalenessBreachType
+  // ISO timestamp of the stale reference (last heartbeat / success / push).
+  stale_since: string
+  threshold_seconds: number
+  details: string
+  detected_at: string
+  last_observed_at: string
+}

--- a/frontend/tests/e2e/settings-mac.spec.ts
+++ b/frontend/tests/e2e/settings-mac.spec.ts
@@ -115,6 +115,9 @@ test.describe('Settings — Mac Daemon @area:settings', () => {
       daemon_version: '0.1.2',
       protocol_version: 1,
       permissions: { fda: true, contacts: false },
+      // Watchdog coupling (#480): this last_pushed_at is month-stale, so adding
+      // `enabled: true` here would open a push_stale breach and surface the
+      // staleness banner mid-run. Keep `enabled` absent (or last_pushed_at fresh).
       source_health: {
         messages: { last_pushed_at: '2026-05-01T00:00:00Z', pushed_cursor: 'abc-123' },
       },
@@ -167,6 +170,9 @@ test.describe('Settings — Mac Daemon @area:settings', () => {
       hostname: 'e2e-icloud-host',
       daemon_version: '0.1.2',
       protocol_version: 2,
+      // Watchdog coupling (#480): this last_pushed_at is month-stale, so adding
+      // `enabled: true` here would open a push_stale breach and surface the
+      // staleness banner mid-run. Keep `enabled` absent (or last_pushed_at fresh).
       source_health: {
         icloud_contacts: {
           last_pushed_at: '2026-05-01T00:00:00Z',
@@ -227,6 +233,9 @@ test.describe('Settings — Mac Daemon @area:settings', () => {
       hostname: 'e2e-icloud-host-incomplete',
       daemon_version: '0.1.2',
       protocol_version: 2,
+      // Watchdog coupling (#480): this last_pushed_at is month-stale, so adding
+      // `enabled: true` here would open a push_stale breach and surface the
+      // staleness banner mid-run. Keep `enabled` absent (or last_pushed_at fresh).
       source_health: {
         icloud_contacts: {
           last_pushed_at: '2026-05-01T00:00:00Z',

--- a/frontend/tests/e2e/settings-mac.spec.ts
+++ b/frontend/tests/e2e/settings-mac.spec.ts
@@ -115,7 +115,7 @@ test.describe('Settings — Mac Daemon @area:settings', () => {
       daemon_version: '0.1.2',
       protocol_version: 1,
       permissions: { fda: true, contacts: false },
-      // Watchdog coupling (#480): this last_pushed_at is month-stale, so adding
+      // Sync-staleness watchdog coupling: this last_pushed_at is month-stale, so adding
       // `enabled: true` here would open a push_stale breach and surface the
       // staleness banner mid-run. Keep `enabled` absent (or last_pushed_at fresh).
       source_health: {
@@ -170,7 +170,7 @@ test.describe('Settings — Mac Daemon @area:settings', () => {
       hostname: 'e2e-icloud-host',
       daemon_version: '0.1.2',
       protocol_version: 2,
-      // Watchdog coupling (#480): this last_pushed_at is month-stale, so adding
+      // Sync-staleness watchdog coupling: this last_pushed_at is month-stale, so adding
       // `enabled: true` here would open a push_stale breach and surface the
       // staleness banner mid-run. Keep `enabled` absent (or last_pushed_at fresh).
       source_health: {
@@ -233,7 +233,7 @@ test.describe('Settings — Mac Daemon @area:settings', () => {
       hostname: 'e2e-icloud-host-incomplete',
       daemon_version: '0.1.2',
       protocol_version: 2,
-      // Watchdog coupling (#480): this last_pushed_at is month-stale, so adding
+      // Sync-staleness watchdog coupling: this last_pushed_at is month-stale, so adding
       // `enabled: true` here would open a push_stale breach and surface the
       // staleness banner mid-run. Keep `enabled` absent (or last_pushed_at fresh).
       source_health: {

--- a/frontend/tests/e2e/test-map.json
+++ b/frontend/tests/e2e/test-map.json
@@ -174,6 +174,14 @@
     "tags": ["@area:settings"]
   },
   {
+    "pattern": "^frontend/src/hooks/use-sync-staleness\\.ts$",
+    "tags": ["@area:dashboard", "@area:settings"]
+  },
+  {
+    "pattern": "^frontend/src/components/sync-staleness-banner\\.tsx$",
+    "tags": ["@area:dashboard", "@area:settings"]
+  },
+  {
     "pattern": "^frontend/src/hooks/use-mac-hosts\\.ts$",
     "tags": ["@area:settings"]
   },


### PR DESCRIPTION
## What

Adds a sync-staleness banner to the dashboard and settings pages. The banner consumes `GET /api/v1/sync/staleness` (shipped in the backend watchdog PR #525) and surfaces a single amber notice when one or more sync sources have not run within their expected window.

## Why

Closes #480. This is the user-facing half of the sync-staleness observability work: the backend watchdog computes per-source staleness, and this banner makes a stale or stalled sync source visible at a glance instead of silently failing in the background.

## Behavior

- Fail-quiet: if the staleness endpoint errors or is unreachable, the banner renders nothing rather than showing an error. Observability must never itself become a source of UI noise.
- Hidden when healthy: the banner only appears when at least one source is stale; a fully-healthy system shows no banner.
- Amber, non-blocking notice that lists the affected source(s) and how long since their last successful run (sub-minute ages render as "just now"-style relative text rather than "0m").

## Test evidence

- vitest: 9 new unit tests covering the banner's render/hide states, the fail-quiet path, and age formatting — all green.
- E2E (diff-selected): 121/121 passing on the reviewed SHA; pre-push gate (lint + full Go unit/integration + frontend + diff-selected E2E) passed clean on this push with no flakes.

Screenshots are intentionally omitted — the banner is a thin amber notice and its states are fully covered by the vitest suite.

## Review status

This is a UI PR and awaits human review per the repo's UI-PR convention. Do not auto-merge.