### PR TITLE
fix(ui): calibrate staleness banner - settings-only, drop sync_error

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -5,7 +5,6 @@ import Link from 'next/link'
 import { CheckCircle, Clock, AlertCircle, User, Plus } from 'lucide-react'
 import { Navigation } from '@/components/layout/navigation'
 import { Button } from '@/components/ui/button'
-import { SyncStalenessBanner } from '@/components/sync-staleness-banner'
 import { ContactMethodIcon } from '@/components/contacts/contact-method-icon'
 import { useOverdueContacts } from '@/hooks/use-contacts'
 import { useCreateInteraction } from '@/hooks/use-interactions'
@@ -207,8 +206,6 @@ export default function DashboardPage() {
       <Navigation />
 
       <div className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
-        <SyncStalenessBanner />
-
         {/* Header */}
         <div className="md:flex md:items-center md:justify-between mb-8">
           <div className="flex-1 min-w-0">

--- a/frontend/src/components/__tests__/sync-staleness-banner.test.tsx
+++ b/frontend/src/components/__tests__/sync-staleness-banner.test.tsx
@@ -17,7 +17,7 @@ function createBreach(overrides: Partial<StalenessBreach> = {}): StalenessBreach
     source: 'messages',
     account_id: 'host-1',
     breach_type: 'push_stale',
-    stale_since: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
+    stale_since: '2026-06-01T00:00:00Z',
     threshold_seconds: 172800,
     details: 'no push for 3d (threshold 48h)',
     detected_at: '2026-06-04T00:00:00Z',
@@ -49,6 +49,36 @@ describe('SyncStalenessBanner', () => {
     expect(container).toBeEmptyDOMElement()
   })
 
+  it('renders nothing when all breaches are sync_error (settings already shows them)', () => {
+    mockedUseSyncStaleness.mockReturnValue({
+      data: [
+        createBreach({ id: 'b1', source: 'gcal', breach_type: 'sync_error' }),
+        createBreach({ id: 'b2', source: 'email', breach_type: 'sync_error' }),
+      ],
+      isLoading: false,
+      isError: false,
+    })
+    const { container } = render(<SyncStalenessBanner />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('excludes sync_error breaches from the list and the count', () => {
+    mockedUseSyncStaleness.mockReturnValue({
+      data: [
+        createBreach({ id: 'b1', source: 'messages' }),
+        createBreach({ id: 'b2', source: 'gcal', breach_type: 'sync_error' }),
+      ],
+      isLoading: false,
+      isError: false,
+    })
+    render(<SyncStalenessBanner />)
+
+    expect(screen.getByText('1 sync source may be stalled')).toBeInTheDocument()
+    expect(screen.getByText(/Messages/)).toBeInTheDocument()
+    expect(screen.queryByText(/Google Calendar/)).not.toBeInTheDocument()
+    expect(screen.getAllByRole('listitem')).toHaveLength(1)
+  })
+
   it('renders a singular heading and one line for a single breach', () => {
     mockedUseSyncStaleness.mockReturnValue({
       data: [createBreach()],
@@ -59,17 +89,21 @@ describe('SyncStalenessBanner', () => {
 
     expect(screen.getByRole('status')).toBeInTheDocument()
     expect(screen.getByText('1 sync source may be stalled')).toBeInTheDocument()
-    // Human source label + details string appear on the line.
+    // Human source label + the watchdog's details string appear on the line.
     expect(screen.getByText(/Messages/)).toBeInTheDocument()
     expect(screen.getByText(/no push for 3d/)).toBeInTheDocument()
-    expect(screen.getByText(/stale 3d/)).toBeInTheDocument()
   })
 
   it('renders a plural heading and one line per breach', () => {
     mockedUseSyncStaleness.mockReturnValue({
       data: [
         createBreach({ id: 'b1', source: 'messages' }),
-        createBreach({ id: 'b2', source: 'gcal', details: 'no sync for 26h (threshold 24h)' }),
+        createBreach({
+          id: 'b2',
+          source: 'gcal',
+          breach_type: 'sync_stale',
+          details: 'no successful sync for 26h (threshold 24h)',
+        }),
         createBreach({ id: 'b3', source: 'mac_host', breach_type: 'heartbeat', details: '' }),
       ],
       isLoading: false,
@@ -92,15 +126,5 @@ describe('SyncStalenessBanner', () => {
     })
     render(<SyncStalenessBanner />)
     expect(screen.getByText(/some_new_source/)).toBeInTheDocument()
-  })
-
-  it('renders a sub-minute age as <1m', () => {
-    mockedUseSyncStaleness.mockReturnValue({
-      data: [createBreach({ stale_since: new Date().toISOString(), details: '' })],
-      isLoading: false,
-      isError: false,
-    })
-    render(<SyncStalenessBanner />)
-    expect(screen.getByText(/stale <1m/)).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/sync-staleness-banner.tsx
+++ b/frontend/src/components/sync-staleness-banner.tsx
@@ -26,52 +26,37 @@ function sourceLabel(source: string): string {
   return SOURCE_LABELS[source] ?? source
 }
 
-// Relative age of a stale reference timestamp, computed client-side so the
-// banner ages without the server rewriting rows. Mirrors the coarse buckets
-// used elsewhere (formatSyncTime).
-function formatAge(staleSince: string, now: Date): string {
-  const since = new Date(staleSince)
-  if (Number.isNaN(since.getTime())) return ''
-
-  const diffMs = now.getTime() - since.getTime()
-  // Sub-minute ages (and small negative clock skew) render as "<1m" so the
-  // line reads "stale <1m" rather than an awkward "stale just now".
-  if (diffMs < 0) return '<1m'
-
-  const diffMins = Math.floor(diffMs / (1000 * 60))
-  const diffHours = Math.floor(diffMs / (1000 * 60 * 60))
-  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24))
-
-  if (diffMins < 1) return '<1m'
-  if (diffMins < 60) return `${diffMins}m`
-  if (diffHours < 24) return `${diffHours}h`
-  return `${diffDays}d`
-}
-
-function breachLine(breach: StalenessBreach, now: Date): string {
+// One banner line per breach. The watchdog refreshes details every tick
+// (server-side, accelerated-time-aware), so the line needs no client-side
+// age computation.
+function breachLine(breach: StalenessBreach): string {
   const label = sourceLabel(breach.source)
-  const age = formatAge(breach.stale_since, now)
-  const ageText = age ? ` — stale ${age}` : ''
-  const detailText = breach.details ? ` (${breach.details})` : ''
-  return `${label}${ageText}${detailText}`
+  return breach.details ? `${label} — ${breach.details}` : label
 }
 
 /**
  * SyncStalenessBanner surfaces the sync-staleness watchdog's active breaches
- * as a persistent amber banner. It is deliberately fail-quiet: it
- * renders nothing while loading, on a fetch error, or when there are no
- * breaches, so a flaky poll can never break or alarm the page. The watchdog's
- * own logs are the backend signal path; this banner is just the surface cue.
+ * on the settings page. sync_error breaches are excluded: the settings page
+ * already shows per-source provider/OAuth errors, so the banner only carries
+ * the classes nothing else surfaces (dead daemon heartbeat, silent pull
+ * staleness, push staleness). It is deliberately fail-quiet: it renders
+ * nothing while loading, on a fetch error, or when there is nothing to show,
+ * so a flaky poll can never break or alarm the page. The watchdog's own logs
+ * are the backend signal path; this banner is just the surface cue.
  */
 export function SyncStalenessBanner() {
   const { data: breaches, isError, isLoading } = useSyncStaleness()
 
-  if (isLoading || isError || !breaches || breaches.length === 0) {
+  if (isLoading || isError || !breaches) {
     return null
   }
 
-  const now = new Date()
-  const count = breaches.length
+  const visible = breaches.filter(breach => breach.breach_type !== 'sync_error')
+  if (visible.length === 0) {
+    return null
+  }
+
+  const count = visible.length
 
   return (
     <div
@@ -88,8 +73,8 @@ export function SyncStalenessBanner() {
             {count} sync {count === 1 ? 'source' : 'sources'} may be stalled
           </h3>
           <ul className="mt-2 space-y-1 text-sm text-amber-700">
-            {breaches.map(breach => (
-              <li key={breach.id}>{breachLine(breach, now)}</li>
+            {visible.map(breach => (
+              <li key={breach.id}>{breachLine(breach)}</li>
             ))}
           </ul>
         </div>

--- a/frontend/tests/e2e/test-map.json
+++ b/frontend/tests/e2e/test-map.json
@@ -175,11 +175,11 @@
   },
   {
     "pattern": "^frontend/src/hooks/use-sync-staleness\\.ts$",
-    "tags": ["@area:dashboard", "@area:settings"]
+    "tags": ["@area:settings"]
   },
   {
     "pattern": "^frontend/src/components/sync-staleness-banner\\.tsx$",
-    "tags": ["@area:dashboard", "@area:settings"]
+    "tags": ["@area:settings"]
   },
   {
     "pattern": "^frontend/src/hooks/use-mac-hosts\\.ts$",


### PR DESCRIPTION
## Why

Day-one prod triage of the staleness banner (#480 / PR #527) showed poor signal-to-noise: four of six entries duplicated OAuth/provider errors the settings page already surfaces per source, and the dashboard placement was too loud for a monitoring cue.

## What

- Banner renders **only on the settings page** (removed from dashboard).
- Banner **excludes `sync_error` breaches** — settings already owns per-source provider/OAuth error surfacing. It now carries only the classes nothing else shows: `heartbeat` (daemon dead), `sync_stale` (silent pull staleness), `push_stale`.
- Banner lines use the watchdog's server-side `details` string (refreshed every tick, accelerated-time-aware) instead of client wall-clock age computation — this also removes the known accelerated-time age-skew P2 from #527.
- `test-map.json` tags for the banner + hook updated to `@area:settings` only.

The watchdog, breach table, `GET /api/v1/sync/staleness`, and `/health` readiness are **unchanged** and still report all breach classes (the tailnet pinger keeps full fidelity).

## Testing

- Component unit tests updated: sync_error-only → renders nothing; mixed → sync_error excluded from list and count; age-rendering tests removed with the client-side age code.
- `make test-frontend` (366 passed), `make lint`, full pre-push gate green.
- Reviewed: PASS (P0=0 P1=0 P2=2 P3=1), verdict at `.ai/log/review/85c1190….md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)