### PR TITLE
fix(infra): drop dead DB Quadlet healthcheck (no podman timer)

### DIFF
--- a/infra/quadlet/personalcrm-database.container
+++ b/infra/quadlet/personalcrm-database.container
@@ -23,11 +23,12 @@ Exec=postgres -c max_connections=200
 # Published to loopback only for host-side tooling (psql, backups). The backend
 # connects over the crm network via the `crm-postgres` DNS name, not this port.
 PublishPort=127.0.0.1:5432:5432
-HealthCmd=pg_isready -U crm_user -d personal_crm
-HealthInterval=5s
-HealthTimeout=5s
-HealthRetries=5
-HealthStartPeriod=10s
+# No HealthCmd on purpose: this rootless podman-static runtime runs with
+# cgroupManager=cgroupfs + eventLogger=file, so podman never creates the
+# transient systemd timer that executes a container healthcheck. A declared
+# HealthCmd would therefore never run -- the container would report "(starting)"
+# forever despite a perfectly healthy DB. Liveness is covered by Restart=always
+# (below) and the deploy health-gate, which probes the backend API over the DB.
 
 [Service]
 Restart=always


### PR DESCRIPTION
## What

Remove the 5 `Health*` directives from `infra/quadlet/personalcrm-database.container` and replace them with a comment explaining why there is no healthcheck.

## Why

The rootless **podman-static 5.8.2** prod runtime runs with `cgroupManager=cgroupfs` + `eventLogger=file`, so podman never creates the per-container transient systemd timer that executes a container healthcheck. The declared `pg_isready` `HealthCmd` therefore **never ran** — `State.Health` was `{"Status":"starting","Log":null}` (not one execution) — and `crm-postgres` reported `(starting)` forever despite a perfectly healthy DB (a manual `podman healthcheck run` returns rc=0 / `accepting connections`; the backend serves; the deploy health-gate is green). The directives were dead config producing a misleading status.

## Safety

Nothing in the prod path depends on the container's `State.Health`: `scripts/deploy-artifact.sh` independently polls `pg_isready` gated on the unit being *active*, and the backend Quadlet's `Requires=`/`After=` gate on systemd active state — not on podman health. Liveness stays covered by `Restart=always` and the deploy health-gate (which probes the backend `/health`, exercising the DB). `/review-head` PASS, zero findings.

## Live Pi already matched

The live Pi Quadlet was edited to remove the same 5 lines and `daemon-reload`ed (backup at `*.healthbak`). No DB restart was forced — `daemon-reload` doesn't restart the running container, so there was zero downtime; the clean `Up` (no annotation) lands on the next DB container recreation. This PR keeps the repo source-of-truth in sync so a future `install-systemd.sh` re-render can't reintroduce the dead healthcheck.