### PR TITLE
feat(todoist): CRM_ENV production guard at SyncClient chokepoint

### DIFF
--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -453,6 +453,29 @@ func run() int {
 	// the sole writer.
 	contactService.SetCadenceUpdater(cadenceUpdater)
 
+	// Todoist client factory, built once with the running CRM_ENV so the
+	// outbound-write guard (Spec C) applies at every production write site.
+	// Non-prod instances holding real OAuth tokens (a restored prod DB, a
+	// partial env copy) refuse Todoist writes; see todoist.ErrNonProdWriteRefused.
+	todoistClientFactory := todoist.NewClientFactory(cfg.Runtime.CRMEnvironment)
+	if config.IsProductionCRMEnv(cfg.Runtime.CRMEnvironment) {
+		// Logged at Warn so it survives prod's LOG_LEVEL=warn threshold — this
+		// is the operator-facing signal that writes are live. Expected on every
+		// prod boot; the stable "event" field lets alerting route it as
+		// informational.
+		logger.Warn().
+			Str("event", "todoist_writes_enabled").
+			Str("crm_env", cfg.Runtime.CRMEnvironment).
+			Bool("todoist_writes_enabled", true).
+			Msg("Todoist outbound writes ENABLED (production CRM_ENV)")
+	} else {
+		logger.Info().
+			Str("event", "todoist_writes_enabled").
+			Str("crm_env", cfg.Runtime.CRMEnvironment).
+			Bool("todoist_writes_enabled", false).
+			Msg("Todoist outbound writes refused (non-production CRM_ENV)")
+	}
+
 	// FollowUpManager consumer — the sole writer of
 	// contact_task.kind='follow_up' lifecycle post-cutover. Constructed
 	// BEFORE the InteractionRecorder because the recorder takes it as a
@@ -474,7 +497,7 @@ func run() int {
 		riverClient,
 		database.Pool,
 		followUpSettings,
-		todoist.DefaultClientFactory,
+		todoistClientFactory,
 		cfg.CORS.FrontendURL,
 		cfg.Watchdog,
 	)
@@ -661,13 +684,13 @@ func run() int {
 	// retryable failure for river to back off.
 	river.AddWorker(riverWorkers, consumer.NewFollowUpManagerWorker(eventBus, database.Pool, followUpManager))
 	river.AddWorker(riverWorkers, consumer.NewTodoistFollowUpCreateJobWorker(
-		followUpMode, contactTaskRepo, followUpSettings, todoist.DefaultClientFactory, riverClient, database.Pool,
+		followUpMode, contactTaskRepo, followUpSettings, todoistClientFactory, riverClient, database.Pool,
 	))
 	river.AddWorker(riverWorkers, consumer.NewTodoistFollowUpCloseJobWorker(
-		followUpMode, contactTaskRepo, followUpSettings, todoist.DefaultClientFactory,
+		followUpMode, contactTaskRepo, followUpSettings, todoistClientFactory,
 	))
 	river.AddWorker(riverWorkers, consumer.NewTodoistFollowUpRefreshJobWorker(
-		followUpMode, contactTaskRepo, followUpSettings, todoist.DefaultClientFactory,
+		followUpMode, contactTaskRepo, followUpSettings, todoistClientFactory,
 	))
 
 	switch cfg.EventBus.FollowUpMode {
@@ -918,7 +941,7 @@ func run() int {
 				eventBus,
 				cadenceUpdater,
 				database.Pool,
-				todoist.DefaultClientFactory,
+				todoistClientFactory,
 			)
 			providerRegistry.Register(todoistProvider)
 			logger.Info().Msg("Todoist Cadence sync provider registered")

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -814,6 +814,25 @@ func (c *Config) IsDevelopment() bool {
 	return c.Logger.Environment == "development"
 }
 
+// IsProductionCRMEnv reports whether a CRM_ENV value is a production alias,
+// matching the convention used by cadence.GetCadenceConfig and
+// synthetic.SeedAllowed. Empty maps to production because config defaults an
+// unset CRM_ENV to "production" at load; treating "" as prod keeps this
+// consistent with cadence's switch and avoids a non-prod refusal on a
+// misconfigured-empty value that the rest of the system already treats as prod.
+//
+// This is distinct from Config.IsProduction(), which keys off NODE_ENV
+// (Logger.Environment), not CRM_ENV. Use this predicate for CRM_ENV-gated
+// behavior such as the Todoist outbound-write guard.
+func IsProductionCRMEnv(env string) bool {
+	switch env {
+	case "production", "prod", "":
+		return true
+	default:
+		return false
+	}
+}
+
 // GetBindAddress returns the server bind address in format "host:port"
 func (c *Config) GetBindAddress() string {
 	return fmt.Sprintf("%s:%d", c.Server.Host, c.Server.Port)

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -1401,3 +1401,26 @@ func TestConfig_Health_ZeroDisablesValidatesCleanly(t *testing.T) {
 		t.Errorf("expected zero-disables health config to validate cleanly, got: %v", err)
 	}
 }
+
+func TestIsProductionCRMEnv(t *testing.T) {
+	tests := []struct {
+		env  string
+		want bool
+	}{
+		{"production", true},
+		{"prod", true},
+		{"", true}, // unset CRM_ENV defaults to production at load
+		{"staging", false},
+		{"test", false},
+		{"testing", false},
+		{"accelerated", false},
+		{"development", false}, // not a valid CRM_ENV, treated non-prod
+	}
+	for _, tt := range tests {
+		t.Run(tt.env, func(t *testing.T) {
+			if got := IsProductionCRMEnv(tt.env); got != tt.want {
+				t.Errorf("IsProductionCRMEnv(%q) = %v, want %v", tt.env, got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/internal/service/contact_task.go
+++ b/backend/internal/service/contact_task.go
@@ -57,7 +57,7 @@ func NewContactTaskService(
 		syncRepo:          syncRepo,
 		oauthService:      oauthService,
 		frontendURL:       cfg.CORS.FrontendURL,
-		todoistClientFunc: todoist.DefaultClientFactory,
+		todoistClientFunc: todoist.NewClientFactory(cfg.Runtime.CRMEnvironment),
 	}
 }
 

--- a/backend/internal/service/contact_task_wiring_test.go
+++ b/backend/internal/service/contact_task_wiring_test.go
@@ -2,13 +2,28 @@ package service
 
 import (
 	"context"
+	"net/http"
+	"sync/atomic"
 	"testing"
 
 	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/todoist"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// countingRoundTripper records how many HTTP requests reach it. Injecting it
+// turns a "factory regressed to the prod-default client" bug into a non-zero
+// call count instead of a real outbound Todoist request.
+type countingRoundTripper struct {
+	calls atomic.Int32
+}
+
+func (rt *countingRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	rt.calls.Add(1)
+	return nil, http.ErrServerClosed // never reached when the guard refuses
+}
 
 // TestNewContactTaskService_WiresEnvAwareFactory verifies the production
 // constructor wires the CRM_ENV-aware Todoist factory: a staging cfg must
@@ -30,9 +45,18 @@ func TestNewContactTaskService_WiresEnvAwareFactory(t *testing.T) {
 	require.NotNil(t, svc.todoistClientFunc, "factory should be wired")
 
 	client := svc.todoistClientFunc("any-token")
-	_, err := client.QuickAdd(context.Background(), "x", "")
+
+	// Inject a recording transport so a regression that produced a writing
+	// client surfaces as a non-zero call count, never a real Todoist request.
+	rt := &countingRoundTripper{}
+	sc, ok := client.(*todoist.SyncClient)
+	require.True(t, ok, "factory should return *todoist.SyncClient")
+	sc.SetHTTPClient(&http.Client{Transport: rt})
+
+	_, err := sc.QuickAdd(context.Background(), "x", "")
 	require.ErrorIs(t, err, todoist.ErrNonProdWriteRefused,
 		"staging cfg must produce a write-refusing client")
+	assert.Equal(t, int32(0), rt.calls.Load(), "no HTTP request should be issued")
 	// Positive (production-writes) direction is covered by
 	// todoist.TestNewClientFactory_EnvWiring to avoid issuing unmocked external HTTP.
 }

--- a/backend/internal/service/contact_task_wiring_test.go
+++ b/backend/internal/service/contact_task_wiring_test.go
@@ -1,0 +1,38 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/todoist"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewContactTaskService_WiresEnvAwareFactory verifies the production
+// constructor wires the CRM_ENV-aware Todoist factory: a staging cfg must
+// produce a client that refuses outbound writes. This catches a regression
+// where NewContactTaskService kept the bare DefaultClientFactory (prod default)
+// and silently wrote from a non-prod instance.
+//
+// nil repos/oauth are safe: the guard returns before any OAuth lookup or HTTP,
+// so the test never dereferences them. Being in package service lets the test
+// read the unexported todoistClientFunc field directly.
+func TestNewContactTaskService_WiresEnvAwareFactory(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		Runtime: config.RuntimeConfig{CRMEnvironment: "staging"},
+	}
+
+	svc := NewContactTaskService(nil, nil, nil, nil, cfg)
+	require.NotNil(t, svc.todoistClientFunc, "factory should be wired")
+
+	client := svc.todoistClientFunc("any-token")
+	_, err := client.QuickAdd(context.Background(), "x", "")
+	require.ErrorIs(t, err, todoist.ErrNonProdWriteRefused,
+		"staging cfg must produce a write-refusing client")
+	// Positive (production-writes) direction is covered by
+	// todoist.TestNewClientFactory_EnvWiring to avoid issuing unmocked external HTTP.
+}

--- a/backend/internal/todoist/sync.go
+++ b/backend/internal/todoist/sync.go
@@ -3,6 +3,7 @@ package todoist
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/logger"
 
 	"github.com/google/uuid"
@@ -18,6 +20,16 @@ import (
 // Todoist API v1 endpoints (v9 deprecated Feb 2026)
 var SyncEndpoint = "https://api.todoist.com/api/v1/sync"
 var QuickAddEndpoint = "https://api.todoist.com/api/v1/tasks/quick"
+
+// ErrNonProdWriteRefused is returned by SyncClient.Sync (when commands are
+// present) and SyncClient.QuickAdd when CRM_ENV is not a production alias.
+// Outbound Todoist writes are structurally refused outside production as
+// defense-in-depth (Spec C): a non-prod instance holding real OAuth tokens
+// (a restored prod DB, or a partial env copy that left CRM_ENV at a non-prod
+// value) must never mutate the operator's real Todoist account. NB: a verbatim
+// full prod-.env clone carrying CRM_ENV=production is intentionally NOT
+// defended by this guard — only the partial-copy / restored-DB cases are.
+var ErrNonProdWriteRefused = errors.New("todoist: outbound write refused — CRM_ENV is not production")
 
 // Client interface for Todoist operations (enables testing with mocks)
 type Client interface {
@@ -28,22 +40,48 @@ type Client interface {
 // ClientFactory creates Todoist clients
 type ClientFactory func(accessToken string) Client
 
-// DefaultClientFactory creates real SyncClient instances
+// DefaultClientFactory creates real SyncClient instances with production write
+// behavior. Reserved for read-only handler fetches and tests; production write
+// paths must build their client via NewClientFactory(cfg.Runtime.CRMEnvironment)
+// so the CRM_ENV guard applies.
 func DefaultClientFactory(accessToken string) Client {
 	return NewSyncClient(accessToken)
+}
+
+// NewClientFactory returns a ClientFactory that builds clients carrying the
+// given CRM_ENV value, so the outbound-write guard fires on non-prod instances.
+// This is the construction path production write sites must use.
+func NewClientFactory(env string) ClientFactory {
+	return func(accessToken string) Client {
+		return NewSyncClientForEnv(accessToken, env)
+	}
 }
 
 // SyncClient handles Todoist Sync API operations
 type SyncClient struct {
 	httpClient  *http.Client
 	accessToken string
+	// env is the CRM_ENV value this client was built with. Outbound writes
+	// (Sync with commands, QuickAdd) are refused unless env is a production
+	// alias — see ErrNonProdWriteRefused.
+	env string
 }
 
-// NewSyncClient creates a new Todoist Sync API client
+// NewSyncClient creates a new Todoist Sync API client with production write
+// behavior (env="production"). Back-compat constructor for read-only handler
+// fetches and direct test callers; production write paths should use
+// NewClientFactory instead.
 func NewSyncClient(accessToken string) *SyncClient {
+	return NewSyncClientForEnv(accessToken, "production")
+}
+
+// NewSyncClientForEnv creates a Todoist Sync API client that refuses outbound
+// writes unless env is a production alias (see config.IsProductionCRMEnv).
+func NewSyncClientForEnv(accessToken, env string) *SyncClient {
 	return &SyncClient{
 		httpClient:  &http.Client{Timeout: 30 * time.Second},
 		accessToken: accessToken,
+		env:         env,
 	}
 }
 
@@ -164,6 +202,20 @@ type CommandError struct {
 
 // Sync performs a sync operation with the Todoist Sync API
 func (c *SyncClient) Sync(ctx context.Context, syncToken string, resourceTypes []string, commands []SyncCommand) (*SyncResponse, error) {
+	// CRM_ENV write guard: a sync carrying commands mutates the operator's
+	// real Todoist account. Refuse outside production before any HTTP is
+	// issued. Read-only syncs (no commands) are always allowed so non-prod
+	// instances can still fetch state for reconciliation comparison.
+	if len(commands) > 0 && !config.IsProductionCRMEnv(c.env) {
+		logger.Warn().
+			Str("provider", "todoist").
+			Str("operation", "sync").
+			Str("crm_env", c.env).
+			Int("command_count", len(commands)).
+			Msg("Todoist outbound write refused: CRM_ENV is not production")
+		return nil, ErrNonProdWriteRefused
+	}
+
 	// Build request body as form data (Todoist uses x-www-form-urlencoded)
 	data := url.Values{}
 	data.Set("sync_token", syncToken)
@@ -419,6 +471,17 @@ type QuickAddTask struct {
 // QuickAdd creates a task using Todoist's Quick Add API with natural language parsing.
 // The text parameter supports dates ("tomorrow", "next tuesday"), #project, @label, and p1-p4 priority.
 func (c *SyncClient) QuickAdd(ctx context.Context, text string, note string) (*QuickAddTask, error) {
+	// CRM_ENV write guard: QuickAdd always creates a task in the operator's
+	// real Todoist account. Refuse outside production before any HTTP.
+	if !config.IsProductionCRMEnv(c.env) {
+		logger.Warn().
+			Str("provider", "todoist").
+			Str("operation", "quick_add").
+			Str("crm_env", c.env).
+			Msg("Todoist outbound write refused: CRM_ENV is not production")
+		return nil, ErrNonProdWriteRefused
+	}
+
 	// Build request body as JSON (v1 API)
 	requestBody := map[string]string{
 		"text": text,

--- a/backend/internal/todoist/sync_test.go
+++ b/backend/internal/todoist/sync_test.go
@@ -143,10 +143,18 @@ func TestNewClientFactory_EnvWiring(t *testing.T) {
 
 	t.Run("staging refuses", func(t *testing.T) {
 		t.Parallel()
+		rt := &recordingRoundTripper{}
 		client := NewClientFactory("staging")("test-token")
-		task, err := client.QuickAdd(context.Background(), "x", "")
+		// Inject a recording transport so a factory regression to the
+		// prod-default client surfaces as a non-zero call count instead of a
+		// real outbound Todoist request.
+		sc, ok := client.(*SyncClient)
+		require.True(t, ok, "factory should return *SyncClient")
+		sc.SetHTTPClient(&http.Client{Transport: rt})
+		task, err := sc.QuickAdd(context.Background(), "x", "")
 		require.ErrorIs(t, err, ErrNonProdWriteRefused)
 		assert.Nil(t, task)
+		assert.Equal(t, int32(0), rt.calls.Load(), "no HTTP request should be issued")
 	})
 
 	t.Run("production writes", func(t *testing.T) {

--- a/backend/internal/todoist/sync_test.go
+++ b/backend/internal/todoist/sync_test.go
@@ -1,0 +1,179 @@
+package todoist
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingRoundTripper records how many HTTP requests reach it and returns a
+// canned response. It lets the guard tests detect whether a real outbound
+// request was issued without hitting the global endpoint vars or the network,
+// so they stay parallel-safe.
+type recordingRoundTripper struct {
+	calls atomic.Int32
+	body  string
+}
+
+func (rt *recordingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.calls.Add(1)
+	body := rt.body
+	if body == "" {
+		body = "{}"
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewBufferString(body)),
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
+// newRecordingClient builds a SyncClient for the given env whose transport
+// records calls instead of hitting the network.
+func newRecordingClient(env, respBody string) (*SyncClient, *recordingRoundTripper) {
+	rt := &recordingRoundTripper{body: respBody}
+	c := NewSyncClientForEnv("test-token", env)
+	c.SetHTTPClient(&http.Client{Transport: rt})
+	return c, rt
+}
+
+// nonProdEnvs are the CRM_ENV values that must refuse outbound writes.
+var nonProdEnvs = []string{"staging", "test", "testing", "accelerated"}
+
+// Test #1: QuickAdd under non-prod envs refuses and never issues HTTP.
+func TestQuickAdd_NonProd_Refuses(t *testing.T) {
+	t.Parallel()
+	for _, env := range nonProdEnvs {
+		env := env
+		t.Run(env, func(t *testing.T) {
+			t.Parallel()
+			c, rt := newRecordingClient(env, "")
+			task, err := c.QuickAdd(context.Background(), "do a thing", "")
+			require.ErrorIs(t, err, ErrNonProdWriteRefused)
+			assert.Nil(t, task)
+			assert.Equal(t, int32(0), rt.calls.Load(), "no HTTP request should be issued")
+		})
+	}
+}
+
+// Test #2: Sync with commands under non-prod envs refuses and never issues HTTP.
+func TestSync_WithCommands_NonProd_Refuses(t *testing.T) {
+	t.Parallel()
+	for _, env := range nonProdEnvs {
+		env := env
+		t.Run(env, func(t *testing.T) {
+			t.Parallel()
+			c, rt := newRecordingClient(env, "")
+			cmds := []SyncCommand{NewItemCloseCommand("task-123")}
+			resp, err := c.Sync(context.Background(), "*", []string{"items"}, cmds)
+			require.ErrorIs(t, err, ErrNonProdWriteRefused)
+			assert.Nil(t, resp)
+			assert.Equal(t, int32(0), rt.calls.Load(), "no HTTP request should be issued")
+		})
+	}
+}
+
+// Test #3: Sync with empty commands (read-only) under non-prod is allowed and
+// does issue HTTP — guards against over-blocking reads.
+func TestSync_ReadOnly_NonProd_Allowed(t *testing.T) {
+	t.Parallel()
+	c, rt := newRecordingClient("staging", `{"sync_token":"abc","full_sync":true}`)
+	resp, err := c.Sync(context.Background(), "*", []string{"items"}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "abc", resp.SyncToken)
+	assert.Equal(t, int32(1), rt.calls.Load(), "read-only sync should issue one request")
+}
+
+// Test #4: QuickAdd under production issues the request and decodes the response.
+func TestQuickAdd_Production_Writes(t *testing.T) {
+	t.Parallel()
+	c, rt := newRecordingClient("production", `{"id":"6abc","content":"do a thing"}`)
+	task, err := c.QuickAdd(context.Background(), "do a thing", "")
+	require.NoError(t, err)
+	require.NotNil(t, task)
+	assert.Equal(t, "6abc", task.ID)
+	assert.Equal(t, int32(1), rt.calls.Load())
+}
+
+// Test #5/#6/#7: Sync with commands under prod aliases (production, prod, "")
+// issues the request and decodes the response.
+func TestSync_WithCommands_ProdAliases_Write(t *testing.T) {
+	t.Parallel()
+	for _, env := range []string{"production", "prod", ""} {
+		env := env
+		t.Run("env="+env, func(t *testing.T) {
+			t.Parallel()
+			c, rt := newRecordingClient(env, `{"sync_token":"xyz"}`)
+			cmds := []SyncCommand{NewItemCloseCommand("task-123")}
+			resp, err := c.Sync(context.Background(), "*", []string{"items"}, cmds)
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			assert.Equal(t, "xyz", resp.SyncToken)
+			assert.Equal(t, int32(1), rt.calls.Load())
+		})
+	}
+}
+
+// Test #8: NewSyncClient produces a production-env client (back-compat): a
+// Sync-with-commands call issues the request.
+func TestNewSyncClient_BackCompat_Writes(t *testing.T) {
+	t.Parallel()
+	rt := &recordingRoundTripper{body: `{"sync_token":"ok"}`}
+	c := NewSyncClient("test-token")
+	c.SetHTTPClient(&http.Client{Transport: rt})
+	cmds := []SyncCommand{NewItemCloseCommand("task-123")}
+	resp, err := c.Sync(context.Background(), "*", []string{"items"}, cmds)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, int32(1), rt.calls.Load())
+}
+
+// Test #9: NewClientFactory wires the env through — staging refuses, production writes.
+func TestNewClientFactory_EnvWiring(t *testing.T) {
+	t.Parallel()
+
+	t.Run("staging refuses", func(t *testing.T) {
+		t.Parallel()
+		client := NewClientFactory("staging")("test-token")
+		task, err := client.QuickAdd(context.Background(), "x", "")
+		require.ErrorIs(t, err, ErrNonProdWriteRefused)
+		assert.Nil(t, task)
+	})
+
+	t.Run("production writes", func(t *testing.T) {
+		t.Parallel()
+		rt := &recordingRoundTripper{body: `{"id":"6abc"}`}
+		client := NewClientFactory("production")("test-token")
+		// The factory returns a Client; the concrete type is *SyncClient.
+		sc, ok := client.(*SyncClient)
+		require.True(t, ok, "factory should return *SyncClient")
+		sc.SetHTTPClient(&http.Client{Transport: rt})
+		task, err := sc.QuickAdd(context.Background(), "x", "")
+		require.NoError(t, err)
+		require.NotNil(t, task)
+		assert.Equal(t, int32(1), rt.calls.Load())
+	})
+}
+
+// Test #10: the refused error satisfies errors.Is and returns a nil result.
+func TestRefusedError_Surface(t *testing.T) {
+	t.Parallel()
+	c, _ := newRecordingClient("staging", "")
+
+	task, err := c.QuickAdd(context.Background(), "x", "")
+	assert.True(t, errors.Is(err, ErrNonProdWriteRefused))
+	assert.Nil(t, task)
+
+	resp, err := c.Sync(context.Background(), "*", []string{"items"}, []SyncCommand{NewItemCloseCommand("t")})
+	assert.True(t, errors.Is(err, ErrNonProdWriteRefused))
+	assert.Nil(t, resp)
+}


### PR DESCRIPTION
## Summary

Adds a defense-in-depth guard (issue #478, Spec C) so a non-production CRM instance holding real Todoist OAuth tokens — e.g. after a prod DB restore or a partial `.env` copy — can never mutate the operator's real Todoist account.

The guard lives at the single concrete `SyncClient` chokepoint, covering all ~6 outbound write paths (cadence provider, river follow-up workers, FollowUpManager, manual-task endpoint) with one check:

- **`Sync` with commands** (item_add/update/close/delete) and **`QuickAdd`** return `ErrNonProdWriteRefused` and warn-log when `CRM_ENV` is not a production alias, **before any HTTP is issued**.
- **Read-only syncs** (`commands` empty) are always allowed — non-prod instances can still fetch Todoist state for reconciliation.

## Changes

- **`config.IsProductionCRMEnv(env string) bool`** — shared predicate (`production`/`prod`/`""` → true), matching the `cadence.GetCadenceConfig` convention. Distinct from `Config.IsProduction()`, which keys off `NODE_ENV`.
- **`todoist.SyncClient`** — new `env` field; `ErrNonProdWriteRefused` sentinel; `NewSyncClientForEnv` + `NewClientFactory(env)`. `NewSyncClient` stays prod-default for back-compat (read-only handler fetches, integration tests).
- **`main.go`** — builds the env-aware factory once from `cfg.Runtime.CRMEnvironment`, passes it to all 5 construction sites (zero `DefaultClientFactory` remain). Adds a startup log recording `todoist_writes_enabled` — at `Warn` for prod (survives `LOG_LEVEL=warn`), `Info` for non-prod.
- **`service.NewContactTaskService`** — wires the env-aware factory at the manual-task construction site.

## Threat-model note (explicit de-scope)

A `CRM_ENV`-keyed guard cannot distinguish real prod from a non-prod host running a *verbatim full clone* of the prod `.env` (which carries `CRM_ENV=production`). That case is intentionally NOT defended here — only the partial-copy / restored-DB cases are (the operationally likely hazard, where the instance's own `.env` sets a non-prod `CRM_ENV`). The startup `Warn` is the operator-facing signal for the full-clone case. A follow-up against Spec C's open thread is needed for an out-of-band discriminator (e.g. a deploy-injected `DEPLOY_TARGET`).

Empty `CRM_ENV` maps to production deliberately (config defaults unset → `production`; matches cadence). This does not weaken the real defense: the documented hazard sets `CRM_ENV` to an explicit non-prod value, which is refused regardless.

## Test plan

- `config`: table test for `IsProductionCRMEnv`.
- `todoist/sync_test.go`: per-method guard tests #1–#10 — non-prod refuses (no HTTP issued), read-only allowed, prod aliases write, `NewSyncClient` back-compat, factory env wiring, `errors.Is` surface. Uses a recording `RoundTripper` so refusal tests can never issue a real request.
- `service`: same-package wiring test asserting a staging `cfg` produces a write-refusing client (recording transport asserts zero HTTP).
- Backend build, lint, unit + integration suites green. No schema / sqlc / frontend / API-route changes.

Plan: `.ai/log/plan/478-todoist-crm-env-production-guard.md`
Closes #478