### PR TITLE
chore(dev): auto-link gitignored env files into new worktrees

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Personal CRM Makefile
 
-.PHONY: help setup dev dev-seed staging-reset build crm-admin mac-daemon test test-daemon-local clean docker-up docker-down docker-reset test-cadence-ultra test-cadence-fast prod staging testing start start-local stop restart reload status dev-stop dev-restart dev-api-stop dev-api-start dev-api-restart ci-build-backend ci-build-frontend ci-build ci-test test-e2e test-e2e-local test-e2e-diff e2e-db deploy-mac promote setup-pi setup-mac-deploy dev-native postgres-native sqlc smoke-test test-deploy-scripts test-integration-fast test-integration-slow test-clean-clones worktree-test-pg-ensure test-pg-stop test-pg-teardown test-pg-reap test-pg-smoke check-cadence-sole-writer check-followup-sole-writer check-rematch-sole-dispatcher check-crm-marker-construction check-sqlc-select-lists lint-ingest-registry
+.PHONY: help setup dev dev-seed staging-reset build crm-admin mac-daemon test test-daemon-local clean docker-up docker-down docker-reset test-cadence-ultra test-cadence-fast prod staging testing start start-local stop restart reload status dev-stop dev-restart dev-api-stop dev-api-start dev-api-restart ci-build-backend ci-build-frontend ci-build ci-test test-e2e test-e2e-local test-e2e-diff e2e-db deploy-mac promote setup-pi setup-mac-deploy dev-native postgres-native sqlc smoke-test test-deploy-scripts worktree-env test-integration-fast test-integration-slow test-clean-clones worktree-test-pg-ensure test-pg-stop test-pg-teardown test-pg-reap test-pg-smoke check-cadence-sole-writer check-followup-sole-writer check-rematch-sole-dispatcher check-crm-marker-construction check-sqlc-select-lists lint-ingest-registry
 
 # Repo root (supports running make from subdirectories).
 REPO_ROOT := $(shell git rev-parse --show-toplevel)
@@ -121,6 +121,7 @@ help:
 	@echo "  dev          - Start development servers (uses Docker for PostgreSQL)"
 	@echo "  dev-seed     - Seed the dev synthetic world, then start dev servers (opt-in; dev is unchanged)"
 	@echo "  dev-native   - Start dev servers with native PostgreSQL (no Docker)"
+	@echo "  worktree-env - Symlink the main checkout's gitignored env files into this worktree"
 	@echo "  staging-reset - HARD reset + reseed STAGING with the prod-shaped synthetic world (refuses production)"
 	@echo "  build       - Build both frontend and backend"
 	@echo "  crm-admin   - Build the operator-only admin CLI (backend/crm-admin)"
@@ -275,6 +276,14 @@ staging-reset: ## HARD reset + reseed STAGING with the prod-shaped synthetic wor
 	@bash scripts/staging-reset.sh   # stops service -> sources staging env -> crm-admin --reset-and-seed --profile prod-shaped --yes -> starts service
 
 # Native PostgreSQL (for containerized development without Docker-in-Docker)
+# Symlink the main checkout's gitignored env files (.env, frontend/.env.local,
+# ...) into the current worktree. Normally automatic via the post-checkout git
+# hook on `git worktree add`; run this manually if a worktree was created before
+# the hook existed, or to re-link after rotating a secret. No-op in the main
+# checkout.
+worktree-env:
+	@WORKTREE_ENV_VERBOSE=1 bash scripts/link-worktree-env.sh
+
 postgres-native:
 	@bash scripts/start-postgres-native.sh
 

--- a/scripts/hooks/post-checkout
+++ b/scripts/hooks/post-checkout
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# post-checkout — provision a freshly-created linked worktree with the main
+# checkout's gitignored env files (.env, frontend/.env.local, ...).
+#
+# Env files are gitignored, so a new worktree (Orca workspace, VPS dev sandbox,
+# or a plain `git worktree add`) starts WITHOUT them and the dev stack can't
+# run. This rides the git post-checkout hook — which fires wherever a worktree
+# is born — so the provisioning is environment-agnostic. The actual linking
+# lives in scripts/link-worktree-env.sh; this is just the trigger + gate.
+#
+# Active automatically under the project's core.hooksPath=scripts/hooks
+# (set by scripts/install-git-hooks.sh); no per-worktree wiring needed.
+#
+# Sourceable: when sourced (BASH_SOURCE != $0) it only defines functions, so the
+# gate logic can be unit-tested (see scripts/test/test-link-worktree-env.sh).
+set -uo pipefail
+
+# worktree_env_should_provision <prev_head> <branch_flag> returns 0 only for a
+# fresh worktree/clone checkout: an all-zero prev HEAD (any hash length, SHA-1
+# or SHA-256) AND a branch checkout (flag 1). Everything else — ordinary branch
+# switches, file checkouts — is skipped so we don't re-link on every checkout.
+# Pure -> unit-testable.
+worktree_env_should_provision() {
+  local prev_head="${1:-}" branch_flag="${2:-}"
+  [[ "$prev_head" =~ ^0+$ ]] && [ "$branch_flag" = "1" ]
+}
+
+# worktree_env_post_checkout is the hook body. git passes:
+#   $1=prev HEAD  $2=new HEAD  $3=branch-checkout flag.
+# Always returns 0 — a hook must never abort the checkout it observes.
+worktree_env_post_checkout() {
+  worktree_env_should_provision "${1:-}" "${3:-}" || return 0
+  local repo_root script
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || return 0
+  script="$repo_root/scripts/link-worktree-env.sh"
+  [ -f "$script" ] && bash "$script"
+  return 0
+}
+
+# Source-guard: run the hook only when executed directly by git, not when sourced.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  worktree_env_post_checkout "$@"
+fi

--- a/scripts/hooks/test/test-pre-push-filters.sh
+++ b/scripts/hooks/test/test-pre-push-filters.sh
@@ -112,6 +112,8 @@ echo "--- Makefile adaptive -p / CI-pin render guard ---"
 bash scripts/ci/test-parallelism-render-guard.sh || fail=1
 echo "--- per-worktree test-pg resolver unit (shim-only, DB/port-free) ---"
 bash scripts/test/test-worktree-test-pg.sh || fail=1
+echo "--- worktree env-link resolver + post-checkout gate (fs/git-only) ---"
+bash scripts/test/test-link-worktree-env.sh || fail=1
 echo "--- repo-hygiene check guard ---"
 bash scripts/hooks/test/test-repo-hygiene-check.sh || fail=1
 echo "--- e2e test-map coverage guard ---"

--- a/scripts/link-worktree-env.sh
+++ b/scripts/link-worktree-env.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# link-worktree-env.sh — symlink the main checkout's gitignored env files
+# (.env, .env.local, frontend/.env.local, ...) into a linked git worktree.
+#
+# Why: env files are gitignored, so a fresh worktree (Orca workspace, VPS dev
+# sandbox, or a plain `git worktree add`) starts WITHOUT them and the dev stack
+# can't run. This links them in from the main checkout. It is environment-
+# agnostic: the post-checkout git hook calls it on worktree creation wherever a
+# worktree is born, and `make worktree-env` calls it on demand.
+#
+# Symlink (not copy) on purpose: one source of truth in the main checkout, so
+# rotating a secret there propagates and no stale copies scatter across
+# worktrees. The core script refuses to touch the main checkout's real files.
+#
+# Sourceable: when sourced (BASH_SOURCE != $0) it only defines functions, so the
+# pure logic can be unit-tested with injected input (see
+# scripts/test/test-link-worktree-env.sh). When executed it runs the gate.
+set -uo pipefail
+
+# resolve_main_root prints the absolute path of the MAIN checkout (the worktree
+# whose .git is a real directory). The main root is the parent of the common git
+# dir. Prints nothing and returns non-zero outside a git repository.
+resolve_main_root() {
+  local common
+  common="$(git rev-parse --git-common-dir 2>/dev/null)" || return 1
+  [ -n "$common" ] || return 1
+  # --git-common-dir may be relative to CWD; absolutize it, then take its parent.
+  common="$(cd "$common" 2>/dev/null && pwd)" || return 1
+  (cd "$common/.." 2>/dev/null && pwd) || return 1
+}
+
+# resolve_this_root prints the absolute path of the CURRENT worktree's root.
+resolve_this_root() {
+  git rev-parse --show-toplevel 2>/dev/null
+}
+
+# enumerate_env_files <root> prints the repo-relative paths of gitignored env
+# files in <root>. Scoped to the repo root and frontend/ (the only places env
+# files live) via glob pathspecs — this keeps the ignored-tree walk fast and,
+# crucially, never reaches into node_modules (which is ignored and may itself
+# contain stray .env files). Add a pathspec here if env files gain a new home.
+enumerate_env_files() {
+  local root="$1"
+  git -C "$root" ls-files --others --ignored --exclude-standard \
+    -- ':(glob).env*' ':(glob)frontend/.env*' 2>/dev/null
+}
+
+# link_env_file <src_root> <dest_root> <rel> links <dest_root>/<rel> ->
+# <src_root>/<rel>. Returns 0 when a link was created or refreshed, non-zero
+# when it skipped (missing source, or a real file already occupies the
+# destination — never clobber a real file). Idempotent.
+link_env_file() {
+  local src_root="$1" dest_root="$2" rel="$3"
+  local src="$src_root/$rel" dest="$dest_root/$rel"
+  [ -e "$src" ] || return 1
+  if [ -L "$dest" ]; then
+    ln -sfn "$src" "$dest"   # refresh existing symlink (idempotent)
+    return 0
+  fi
+  if [ -e "$dest" ]; then
+    echo "worktree-env: $rel exists and is not a symlink; leaving as-is" >&2
+    return 1
+  fi
+  mkdir -p "$(dirname "$dest")"
+  ln -s "$src" "$dest"
+}
+
+# run_worktree_env is the side-effecting entry point: resolve the roots, refuse
+# to run in the main checkout, then link every gitignored env file from the main
+# checkout into this worktree. Set WORKTREE_ENV_VERBOSE=1 for the no-op message.
+run_worktree_env() {
+  local main_root this_root rel linked=0
+  main_root="$(resolve_main_root)" || return 0       # not a git repo -> skip quietly
+  this_root="$(resolve_this_root)" || return 0
+  if [ "$this_root" = "$main_root" ]; then
+    [ -n "${WORKTREE_ENV_VERBOSE:-}" ] && \
+      echo "worktree-env: this is the main checkout; nothing to link" >&2
+    return 0
+  fi
+  while IFS= read -r rel; do
+    [ -n "$rel" ] || continue
+    if link_env_file "$main_root" "$this_root" "$rel"; then
+      echo "worktree-env: linked $rel" >&2
+      linked=$((linked + 1))
+    fi
+  done < <(enumerate_env_files "$main_root")
+  if [ "$linked" -eq 0 ]; then
+    echo "worktree-env: no env files to link from $main_root" >&2
+  fi
+}
+
+# Source-guard: run the gate only when executed directly, not when sourced.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  run_worktree_env
+fi

--- a/scripts/test/test-link-worktree-env.sh
+++ b/scripts/test/test-link-worktree-env.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# Tests for scripts/link-worktree-env.sh + scripts/hooks/post-checkout.
+#
+# DB-FREE + PORT-FREE + NETWORK-FREE: pure filesystem + local `git` only (temp
+# repos under mktemp). Safe for the pre-push FILTER lane; runs on any CI runner.
+#
+# Invoked from scripts/hooks/test/test-pre-push-filters.sh (like the per-worktree
+# test-pg resolver unit), not as a top-level pre-push command.
+#
+# Three layers:
+#   1. link_env_file               — pure fs link/skip/idempotency safety
+#   2. enumerate_env_files         — gitignored-env discovery in a temp repo
+#   3. worktree_env_should_provision + a real `git worktree add` end-to-end
+set -u
+cd "$(dirname "${BASH_SOURCE[0]}")/../.." || exit 1   # repo root
+REPO="$PWD"
+
+source scripts/link-worktree-env.sh   # source-guard prevents the gate body
+source scripts/hooks/post-checkout     # source-guard prevents the hook body
+
+fail=0
+ok()  { echo "ok: $1"; }
+bad() { echo "FAIL: $1"; fail=1; }
+assert_true()  { local d="$1"; shift; if "$@"; then ok "$d"; else bad "$d"; fi; }
+assert_false() { local d="$1"; shift; if "$@"; then bad "$d"; else ok "$d"; fi; }
+
+# --- portable symlink-target read (no GNU-only `readlink -f`) ----------------
+link_target() { readlink "$1"; }
+
+TMPDIRS=()
+mk_tmp() { local d; d=$(mktemp -d); TMPDIRS+=("$d"); echo "$d"; }
+cleanup() { local d; for d in "${TMPDIRS[@]:-}"; do [ -n "$d" ] && rm -rf "$d"; done; }
+trap cleanup EXIT
+
+# setup_hooked_main <dir> — build a temp "main" checkout with the REAL scripts,
+# the canonical relative core.hooksPath, an env-file .gitignore, a tracked
+# .env.example, and one commit. Caller creates any actual env files afterward.
+setup_hooked_main() {
+  local m="$1"
+  mkdir -p "$m/scripts/hooks" "$m/frontend"
+  cp "$REPO/scripts/link-worktree-env.sh" "$m/scripts/link-worktree-env.sh"
+  cp "$REPO/scripts/hooks/post-checkout"  "$m/scripts/hooks/post-checkout"
+  chmod +x "$m/scripts/link-worktree-env.sh" "$m/scripts/hooks/post-checkout"
+  printf '.env\nfrontend/.env.local\n' > "$m/.gitignore"
+  printf 'EXAMPLE=1\n' > "$m/.env.example"          # tracked, must NOT be linked
+  git -C "$m" init -q -b main
+  git -C "$m" config user.email test@example.com
+  git -C "$m" config user.name "Test"
+  git -C "$m" config commit.gpgsign false
+  git -C "$m" config core.hooksPath scripts/hooks   # the canonical relative method
+  git -C "$m" add -A
+  git -C "$m" -c commit.gpgsign=false commit -q -m init
+}
+
+# ============================================================================
+# 1. link_env_file — pure filesystem behavior
+# ============================================================================
+echo "--- link_env_file ---"
+d=$(mk_tmp); src="$d/main"; dst="$d/wt"
+mkdir -p "$src" "$dst"
+printf 'ROOT=1\n' > "$src/.env"
+
+# Happy path: creates a symlink pointing at the source.
+if link_env_file "$src" "$dst" ".env" && [ -L "$dst/.env" ] \
+   && [ "$(link_target "$dst/.env")" = "$src/.env" ]; then
+  ok "links a flat env file to the source"
+else
+  bad "links a flat env file to the source"
+fi
+
+# Idempotent: re-running refreshes the symlink, still a symlink, exit 0.
+if link_env_file "$src" "$dst" ".env" && [ -L "$dst/.env" ]; then
+  ok "re-link is idempotent (stays a symlink)"
+else
+  bad "re-link is idempotent (stays a symlink)"
+fi
+
+# Nested path: creates the parent dir and links.
+mkdir -p "$src/frontend"; printf 'FE=1\n' > "$src/frontend/.env.local"
+if link_env_file "$src" "$dst" "frontend/.env.local" \
+   && [ -L "$dst/frontend/.env.local" ]; then
+  ok "creates parent dir and links a nested env file"
+else
+  bad "creates parent dir and links a nested env file"
+fi
+
+# Missing source: no link, non-zero return.
+if link_env_file "$src" "$dst" ".env.nope"; then
+  bad "missing source should skip (non-zero)"
+elif [ -e "$dst/.env.nope" ]; then
+  bad "missing source must not create a destination"
+else
+  ok "missing source skips without creating anything"
+fi
+
+# Real file at destination: never clobbered; non-zero return. The source must
+# EXIST so we get past the missing-source check and actually reach the
+# clobber-protection guard (the case under test).
+printf 'PRESERVE=1\n' > "$dst/.env.real"
+printf 'SOURCE=1\n'   > "$src/.env.real"
+if link_env_file "$src" "$dst" ".env.real" 2>/dev/null; then
+  bad "real dest file should be skipped (non-zero)"
+else
+  if [ -f "$dst/.env.real" ] && [ ! -L "$dst/.env.real" ] \
+     && [ "$(cat "$dst/.env.real")" = "PRESERVE=1" ]; then
+    ok "never clobbers a real file at the destination"
+  else
+    bad "never clobbers a real file at the destination"
+  fi
+fi
+
+# ============================================================================
+# 2. enumerate_env_files — gitignored-env discovery
+# ============================================================================
+echo "--- enumerate_env_files ---"
+repo=$(mk_tmp)
+git -C "$repo" init -q -b main
+git -C "$repo" config user.email test@example.com
+git -C "$repo" config user.name "Test"
+printf '.env\n.env.local\nfrontend/.env.local\n' > "$repo/.gitignore"
+mkdir -p "$repo/frontend"
+printf 'EXAMPLE=1\n' > "$repo/.env.example"          # tracked template
+printf 'FE_EXAMPLE=1\n' > "$repo/frontend/.env.example"
+git -C "$repo" add -A
+git -C "$repo" -c commit.gpgsign=false commit -q -m init
+# gitignored env files, present on disk:
+printf 'ROOT=1\n' > "$repo/.env"
+printf 'LOCAL=1\n' > "$repo/.env.local"
+printf 'FE=1\n' > "$repo/frontend/.env.local"
+
+got="$(enumerate_env_files "$repo" | sort | tr '\n' ',')"
+want=".env,.env.local,frontend/.env.local,"
+if [ "$got" = "$want" ]; then
+  ok "lists exactly the gitignored env files (excludes tracked .env.example)"
+else
+  bad "enumerate_env_files: got '$got' want '$want'"
+fi
+
+# run_worktree_env must be a no-op in the MAIN checkout — never symlink over /
+# clobber the main checkout's own real env files. ($repo is a main checkout.)
+( cd "$repo" && run_worktree_env ) >/dev/null 2>&1
+if [ -f "$repo/.env" ] && [ ! -L "$repo/.env" ] \
+   && [ ! -L "$repo/.env.local" ] && [ ! -L "$repo/frontend/.env.local" ]; then
+  ok "run_worktree_env is a no-op in the main checkout (real files untouched)"
+else
+  bad "run_worktree_env must not touch files in the main checkout"
+fi
+
+# ============================================================================
+# 3. worktree_env_should_provision — gate predicate
+# ============================================================================
+echo "--- worktree_env_should_provision (gate) ---"
+zero40="0000000000000000000000000000000000000000"
+zero64="0000000000000000000000000000000000000000000000000000000000000000"
+assert_true  "fresh worktree (SHA-1 zero, branch) provisions"   worktree_env_should_provision "$zero40" "1"
+assert_true  "fresh worktree (SHA-256 zero, branch) provisions" worktree_env_should_provision "$zero64" "1"
+assert_false "ordinary branch switch does not provision"        worktree_env_should_provision "abc1234" "1"
+assert_false "file checkout (flag 0) does not provision"        worktree_env_should_provision "$zero40" "0"
+assert_false "empty args do not provision"                      worktree_env_should_provision "" ""
+
+# ============================================================================
+# 4. End-to-end: a real `git worktree add` fires the hook and links env files
+# ============================================================================
+echo "--- end-to-end: git worktree add ---"
+e2e=$(mk_tmp); main="$e2e/main"
+setup_hooked_main "$main"
+# gitignored env files in the main checkout, present on disk:
+printf 'ROOT=1\n' > "$main/.env"
+printf 'FE=1\n' > "$main/frontend/.env.local"
+
+wt="$e2e/wt"
+git -C "$main" worktree add -q "$wt" -b feature HEAD 2>/dev/null
+
+# -ef compares by inode (following symlinks), robust to macOS /private path
+# normalization in the hook's pwd-resolved main_root.
+if [ -L "$wt/.env" ] && [ "$wt/.env" -ef "$main/.env" ]; then
+  ok "worktree add linked .env to the main checkout"
+else
+  bad "worktree add linked .env to the main checkout"
+fi
+if [ -L "$wt/frontend/.env.local" ] && [ "$wt/frontend/.env.local" -ef "$main/frontend/.env.local" ]; then
+  ok "worktree add linked frontend/.env.local"
+else
+  bad "worktree add linked frontend/.env.local"
+fi
+# Tracked template is checked out normally — present, but NOT a symlink.
+if [ -e "$wt/.env.example" ] && [ ! -L "$wt/.env.example" ]; then
+  ok "tracked .env.example is a normal file, not linked"
+else
+  bad "tracked .env.example is a normal file, not linked"
+fi
+# The main checkout's real env file is untouched.
+if [ -f "$main/.env" ] && [ ! -L "$main/.env" ]; then
+  ok "main checkout's real .env is left untouched"
+else
+  bad "main checkout's real .env is left untouched"
+fi
+
+# Zero env files in main: the hook still runs cleanly and links nothing.
+empty_main="$e2e/empty-main"
+setup_hooked_main "$empty_main"        # no .env / frontend/.env.local on disk
+empty_wt="$e2e/empty-wt"
+if git -C "$empty_main" worktree add -q "$empty_wt" -b feature HEAD 2>/dev/null \
+   && [ ! -e "$empty_wt/.env" ] && [ ! -e "$empty_wt/frontend/.env.local" ]; then
+  ok "worktree add with zero env files in main: succeeds, links nothing"
+else
+  bad "worktree add with zero env files in main: should succeed and link nothing"
+fi
+
+[[ "$fail" -eq 0 ]] && { echo "ALL PASS"; exit 0; } || { echo "FAILURES"; exit 1; }


### PR DESCRIPTION
## Problem

Env files are gitignored, so a freshly-created linked git worktree — an Orca workspace, the VPS dev sandbox, or a plain `git worktree add` — starts **without** the `.env` / `.env.local` / `frontend/.env.local` / `frontend/.env.test.local` files the main checkout has. The dev stack can't run in the worktree until they're copied over by hand. (PR #535's per-worktree test Postgres is unaffected — tests self-provision env from the committed `.env.example.testing`; this gap only bites interactive dev in a worktree.)

## Solution

A git `post-checkout` hook (`scripts/hooks/post-checkout`) symlinks the main checkout's gitignored env files into a new worktree the moment it's created. It's **environment-agnostic** — it rides the hook git fires wherever a worktree is born, so it works identically under Orca, the VPS sandbox, or manual `git worktree add` (no Orca-specific or sandbox-specific wiring). `make worktree-env` is the manual fallback (re-link after a secret rotation, or provision a worktree created before the hook existed).

- **Symlinks, not copies:** one source of truth in the main checkout, so a rotated secret propagates and no stale copies scatter across worktrees.
- **Safe:** the core script refuses to run in the main checkout (never touches the canonical env files), and `link_env_file` never overwrites a real (non-symlink) destination.
- **Scoped discovery:** the `:(glob).env*` / `:(glob)frontend/.env*` pathspec only walks the repo root and `frontend/`, so it never reaches into `node_modules` and link a stray third-party `.env`.
- **Auto-activates** under the project's canonical relative `core.hooksPath=scripts/hooks` (set by `install-git-hooks.sh`) — no change to that script needed. New clones get it for free; existing machines on the older absolute-hooksPath method pick it up after a one-time `make setup`.

## Files

- `scripts/link-worktree-env.sh` — core logic (source-guarded; resolve main/this root, enumerate gitignored env files, link, orchestrate).
- `scripts/hooks/post-checkout` — the trigger; gates on a fresh worktree/clone (all-zero prev HEAD + branch checkout) so it doesn't re-link on ordinary branch switches.
- `scripts/test/test-link-worktree-env.sh` — DB/port/network-free test, chained from the pre-push FILTER lane via `test-pre-push-filters.sh` (same wiring pattern as #535's dev-tooling test — no new pre-push.json command, no lane-classifier/phase-guard churn).
- `Makefile` — `make worktree-env` target + help line + `.PHONY`.

## Testing

17 assertions, all passing: `link_env_file` link/idempotency/never-clobber-a-real-file safety, `enumerate_env_files` discovery (excludes tracked templates), the fresh-checkout gate predicate (SHA-1/SHA-256 zero prev-HEAD, branch-switch and file-checkout negatives), `run_worktree_env` main-checkout no-op, and an **end-to-end real `git worktree add`** that proves the hook fires and links (plus a zero-env-files case). Full pre-push gate (lint + backend unit/integration + frontend + E2E-diff) green.

Reviewed by Codex: no P0/P1/P2 across correctness, security, and portability; the two test-coverage nits it raised are folded in.