### PR TITLE
fix(hooks): isolate worktree-env test git ops from hook GIT_DIR

### DIFF
--- a/scripts/test/test-link-worktree-env.sh
+++ b/scripts/test/test-link-worktree-env.sh
@@ -15,6 +15,15 @@ set -u
 cd "$(dirname "${BASH_SOURCE[0]}")/../.." || exit 1   # repo root
 REPO="$PWD"
 
+# Sanitize hook-inherited git env BEFORE any git command. git exports GIT_DIR to
+# hooks (absolute in linked worktrees), which silently redirects every
+# `git -C "$tmp" ...` below at the REAL repo with work-tree=$tmp: `add -A` wipes
+# the real index down to the temp fixture files, `commit -m init` strands fixture
+# commits on the pushed branch, and `worktree add` mutates the real repo — which
+# corrupts a worktree push (test-map coverage then sees zero specs). Unsetting
+# here restores cwd/-C-based discovery so the throwaway repos are isolated.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE
+
 source scripts/link-worktree-env.sh   # source-guard prevents the gate body
 source scripts/hooks/post-checkout     # source-guard prevents the hook body
 


### PR DESCRIPTION
The #539 worktree-env link-utility test (`scripts/test/test-link-worktree-env.sh`, invoked by `scripts/hooks/test/test-pre-push-filters.sh` in the pre-push TEST phase) ran `git -C "$tmp" init/add -A/commit -m init` and `git -C "$main" worktree add` WITHOUT sanitizing the hook-exported `GIT_DIR`.

git exports an absolute `GIT_DIR` into hooks (in linked worktrees), so during a worktree push those fixture ops silently operated on the REAL repo with work-tree=`$tmp`: `add -A` wiped the real index down to the fixture files, `commit -m init` stranded `init` commits (author `Test <test@example.com>`) on the pushed branch, and `worktree add` mutated the real repo — corrupting state so the hook's later `git ls-files` saw zero specs ("no e2e spec files found — refusing to pass") and rejected the push.

Fix: `unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE` before the script's git commands, restoring cwd/-C-based discovery so the throwaway repos are isolated. This mirrors the already-merged fix for the sibling `test-run-e2e-warning.sh` (commit 9aeafe5), which this newer test never received.

Verified by running the test with the hook's absolute `GIT_DIR` exported: it passes and leaves HEAD + index untouched (without the fix, the same invocation hijacks the branch).