### PR TITLE
feat(graph): SP1 contact→node person dual-write + backfill (068)

### DIFF
--- a/.ai/guides/architecture.md
+++ b/.ai/guides/architecture.md
@@ -158,7 +158,7 @@ sequenceDiagram
 | Table | Purpose | Key Relations |
 |-------|---------|---------------|
 | **Core** | | |
-| `contact` | People in CRM | Parent of most entities |
+| `contact` | People in CRM. ContactService dual-writes a `node(type='person')` at the contact's own id in the same tx on create — the `contact.id == node.id` invariant — and syncs `node.canonical_label` on rename | Parent of most entities; 1:1 person `node` (shared id) |
 | `contact_method` | Email, phone, social handles | → contact |
 | `note` | Freeform notes | → contact |
 | `tag` | Contact categorization | ↔ contact (via contact_tag) |
@@ -177,7 +177,7 @@ sequenceDiagram
 | **Event Bus** | | |
 | `event` | Append-only raw event log feeding the worker queue (spec §3.1) | (append-only; no FKs) |
 | **Graph (SP1)** | | |
-| `node` | Uniform registry every graph entity attaches to (person/entity/venue); caller-supplied id (person id == contact id); CHECK-enum `type`; `merged_into` self-FK merge alias; single `deleted_at` tombstone | self-FK (`merged_into`) |
+| `node` | Uniform registry every graph entity attaches to (person/entity/venue); caller-supplied id (person id == contact id, maintained by the ContactService dual-write + the `068_backfill_person_nodes` backfill); CHECK-enum `type`; `merged_into` self-FK merge alias; single `deleted_at` tombstone | self-FK (`merged_into`); person node shares the contact's id |
 | `entity_type` | Per-TYPE entity-subtype catalog (`resolution_config` JSONB; curated/provisional status) | (catalog; no FKs) |
 | `entity` | Structural subtype rows for organizations/places/topics/tags; per-instance `detail` JSONB; unique `(subtype, normalized_name)` | → node (PK/FK, ON DELETE CASCADE), → entity_type |
 | `venue` | Structural subtype rows for shared interaction containers (email threads, group chats, DMs, meetings, calls, sessions); unique `(source, kind, source_container_id)` | → node (PK/FK, ON DELETE CASCADE) |

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -1585,6 +1585,10 @@ type Querier interface {
 	// rows whose normalized value shares the namespace's phone prefix. Caller passes
 	// a BARE prefix; '%' is appended here.
 	SyntheticCountContactMethodsByValueNormalizedPrefix(ctx context.Context, valueNormalizedPrefix pgtype.Text) (int64, error)
+	// Contact→node dual-write test support: count contacts with an exact full_name
+	// (namespace-prefixed names are unique per test), so a rollback test asserts a
+	// failed-tx contact did not survive without paging the whole contact list.
+	SyntheticCountContactsByFullName(ctx context.Context, fullName string) (int64, error)
 	// Cleanup assertion — count surviving contact rows for the given ids.
 	SyntheticCountContactsByIds(ctx context.Context, contactIds []pgtype.UUID) (int64, error)
 	// Harness setup collision detection (D5): count external_identity rows whose

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -1769,6 +1769,10 @@ type Querier interface {
 	// tracked peer ids before the contact delete (external_identity survives contact
 	// delete via ON DELETE SET NULL and would otherwise pollute future matching).
 	SyntheticDeleteTelegramExternalIdentitiesByPeerIds(ctx context.Context, peerIds []string) (int64, error)
+	// Contact→node dual-write test support: fetch the person node a contact owns
+	// (node.id == contact.id). Returns the live (non-soft-deleted) node row so a
+	// test can assert the dual-write created it with the expected type/label.
+	SyntheticGetNodeForContact(ctx context.Context, id pgtype.UUID) (*Node, error)
 	// Todoist replay: snapshot the set of contact_task ids for a provider so the
 	// replay can diff before/after its (globally-scoped) reconcile and track the
 	// rows it created — even for cadence-bearing contacts it did not seed — so

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -1745,6 +1745,10 @@ type Querier interface {
 	// Cleanup step 5: messages_message rows whose guid is ns-prefixed.
 	// Caller passes a BARE prefix; '%' is appended here.
 	SyntheticDeleteMessagesMessageByGuidPrefix(ctx context.Context, guidPrefix pgtype.Text) (int64, error)
+	// Cleanup: the person node a seeded contact owns (node.id == contact.id), so
+	// the harness teardown removes the nodes its dual-writing SeedContact created
+	// alongside the contacts. Hard delete, keyed by the tracked contact ids.
+	SyntheticDeleteNodesByIds(ctx context.Context, nodeIds []pgtype.UUID) (int64, error)
 	// Graph identity cleanup: hard-delete nodes whose canonical_label is ns-prefixed.
 	// entity and venue cascade via their ON DELETE CASCADE FK to node, so this one
 	// delete removes a namespace's node+entity+venue rows. Caller passes a BARE

--- a/backend/internal/db/queries/test.sql
+++ b/backend/internal/db/queries/test.sql
@@ -572,6 +572,12 @@ SELECT * FROM node WHERE id = $1 AND deleted_at IS NULL;
 -- failed-tx contact did not survive without paging the whole contact list.
 SELECT COUNT(*) FROM contact WHERE full_name = $1 AND deleted_at IS NULL;
 
+-- name: SyntheticDeleteNodesByIds :execrows
+-- Cleanup: the person node a seeded contact owns (node.id == contact.id), so
+-- the harness teardown removes the nodes its dual-writing SeedContact created
+-- alongside the contacts. Hard delete, keyed by the tracked contact ids.
+DELETE FROM node WHERE id = ANY(@node_ids::uuid[]);
+
 -- name: SyntheticDeleteAssertionsForNode :execrows
 -- Assertion-store cleanup: hard-delete the assertions touching a node in EITHER
 -- position (provenance cascades). The assertion → node FK is restrict (NO

--- a/backend/internal/db/queries/test.sql
+++ b/backend/internal/db/queries/test.sql
@@ -560,6 +560,12 @@ DELETE FROM node WHERE canonical_label LIKE @label_prefix || '%';
 -- the shared test DB.
 SELECT COUNT(*) FROM assertion WHERE subject_node_id = $1;
 
+-- name: SyntheticGetNodeForContact :one
+-- Contact→node dual-write test support: fetch the person node a contact owns
+-- (node.id == contact.id). Returns the live (non-soft-deleted) node row so a
+-- test can assert the dual-write created it with the expected type/label.
+SELECT * FROM node WHERE id = $1 AND deleted_at IS NULL;
+
 -- name: SyntheticDeleteAssertionsForNode :execrows
 -- Assertion-store cleanup: hard-delete the assertions touching a node in EITHER
 -- position (provenance cascades). The assertion → node FK is restrict (NO

--- a/backend/internal/db/queries/test.sql
+++ b/backend/internal/db/queries/test.sql
@@ -566,6 +566,12 @@ SELECT COUNT(*) FROM assertion WHERE subject_node_id = $1;
 -- test can assert the dual-write created it with the expected type/label.
 SELECT * FROM node WHERE id = $1 AND deleted_at IS NULL;
 
+-- name: SyntheticCountContactsByFullName :one
+-- Contact→node dual-write test support: count contacts with an exact full_name
+-- (namespace-prefixed names are unique per test), so a rollback test asserts a
+-- failed-tx contact did not survive without paging the whole contact list.
+SELECT COUNT(*) FROM contact WHERE full_name = $1 AND deleted_at IS NULL;
+
 -- name: SyntheticDeleteAssertionsForNode :execrows
 -- Assertion-store cleanup: hard-delete the assertions touching a node in EITHER
 -- position (provenance cascades). The assertion → node FK is restrict (NO

--- a/backend/internal/db/test.sql.go
+++ b/backend/internal/db/test.sql.go
@@ -785,6 +785,20 @@ func (q *Queries) SyntheticCountContactMethodsByValueNormalizedPrefix(ctx contex
 	return count, err
 }
 
+const SyntheticCountContactsByFullName = `-- name: SyntheticCountContactsByFullName :one
+SELECT COUNT(*) FROM contact WHERE full_name = $1 AND deleted_at IS NULL
+`
+
+// Contact→node dual-write test support: count contacts with an exact full_name
+// (namespace-prefixed names are unique per test), so a rollback test asserts a
+// failed-tx contact did not survive without paging the whole contact list.
+func (q *Queries) SyntheticCountContactsByFullName(ctx context.Context, fullName string) (int64, error) {
+	row := q.db.QueryRow(ctx, SyntheticCountContactsByFullName, fullName)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const SyntheticCountContactsByIds = `-- name: SyntheticCountContactsByIds :one
 SELECT COUNT(*) FROM contact WHERE id = ANY($1::uuid[])
 `

--- a/backend/internal/db/test.sql.go
+++ b/backend/internal/db/test.sql.go
@@ -1407,6 +1407,21 @@ func (q *Queries) SyntheticDeleteMessagesMessageByGuidPrefix(ctx context.Context
 	return result.RowsAffected(), nil
 }
 
+const SyntheticDeleteNodesByIds = `-- name: SyntheticDeleteNodesByIds :execrows
+DELETE FROM node WHERE id = ANY($1::uuid[])
+`
+
+// Cleanup: the person node a seeded contact owns (node.id == contact.id), so
+// the harness teardown removes the nodes its dual-writing SeedContact created
+// alongside the contacts. Hard delete, keyed by the tracked contact ids.
+func (q *Queries) SyntheticDeleteNodesByIds(ctx context.Context, nodeIds []pgtype.UUID) (int64, error) {
+	result, err := q.db.Exec(ctx, SyntheticDeleteNodesByIds, nodeIds)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const SyntheticDeleteNodesByLabelPrefix = `-- name: SyntheticDeleteNodesByLabelPrefix :execrows
 DELETE FROM node WHERE canonical_label LIKE $1 || '%'
 `

--- a/backend/internal/db/test.sql.go
+++ b/backend/internal/db/test.sql.go
@@ -1489,6 +1489,27 @@ func (q *Queries) SyntheticDeleteTelegramExternalIdentitiesByPeerIds(ctx context
 	return result.RowsAffected(), nil
 }
 
+const SyntheticGetNodeForContact = `-- name: SyntheticGetNodeForContact :one
+SELECT id, type, canonical_label, created_at, deleted_at, merged_into FROM node WHERE id = $1 AND deleted_at IS NULL
+`
+
+// Contact→node dual-write test support: fetch the person node a contact owns
+// (node.id == contact.id). Returns the live (non-soft-deleted) node row so a
+// test can assert the dual-write created it with the expected type/label.
+func (q *Queries) SyntheticGetNodeForContact(ctx context.Context, id pgtype.UUID) (*Node, error) {
+	row := q.db.QueryRow(ctx, SyntheticGetNodeForContact, id)
+	var i Node
+	err := row.Scan(
+		&i.ID,
+		&i.Type,
+		&i.CanonicalLabel,
+		&i.CreatedAt,
+		&i.DeletedAt,
+		&i.MergedInto,
+	)
+	return &i, err
+}
+
 const SyntheticListContactTaskIdsByProvider = `-- name: SyntheticListContactTaskIdsByProvider :many
 SELECT id FROM contact_task WHERE provider = $1
 `

--- a/backend/internal/repository/node.go
+++ b/backend/internal/repository/node.go
@@ -139,7 +139,13 @@ func (r *NodeRepository) SetNodeMergedIntoTx(ctx context.Context, tx pgx.Tx, los
 }
 
 // UpdateNodeCanonicalLabel keeps the node's display label loosely synced with
-// its owning entity (e.g. a contact rename).
+// its owning entity (e.g. a contact rename). The underlying query is :exec, so a
+// missing node is a silent no-op (no rows-affected check). This is deliberate:
+// the contact→node dual-write callers (CreateContact, UpdateContact,
+// MergeContacts, enrichment) always pass a contact id whose person node exists
+// — created in the same lifecycle by the dual-write and the 068 backfill — so 0
+// rows cannot occur on those paths; and for any other caller a label sync
+// against a non-existent node is harmlessly idempotent rather than an error.
 func (r *NodeRepository) UpdateNodeCanonicalLabel(ctx context.Context, id uuid.UUID, canonicalLabel string) error {
 	return r.queries.UpdateNodeCanonicalLabel(ctx, db.UpdateNodeCanonicalLabelParams{
 		ID:             uuidToPgUUID(id),

--- a/backend/internal/repository/synthetic_support.go
+++ b/backend/internal/repository/synthetic_support.go
@@ -710,6 +710,16 @@ func (r *SyntheticSupportRepository) CountContactsByFullName(ctx context.Context
 	return r.queries.SyntheticCountContactsByFullName(ctx, fullName)
 }
 
+// DeleteNodesByIds hard-deletes the person nodes a seeded contact owns
+// (node.id == contact.id), so the harness teardown removes the nodes its
+// dual-writing SeedContact created alongside the contacts it tracks.
+func (r *SyntheticSupportRepository) DeleteNodesByIds(ctx context.Context, nodeIDs []uuid.UUID) (int64, error) {
+	if len(nodeIDs) == 0 {
+		return 0, nil
+	}
+	return r.queries.SyntheticDeleteNodesByIds(ctx, pgUUIDs(nodeIDs))
+}
+
 // DeleteAssertionsForNode hard-deletes the assertions touching a node in either
 // position (provenance cascades). The assertion → node FK is restrict, so a test
 // MUST clear its assertions before deleting its nodes — register this cleanup to

--- a/backend/internal/repository/synthetic_support.go
+++ b/backend/internal/repository/synthetic_support.go
@@ -17,6 +17,7 @@ package repository
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -24,6 +25,7 @@ import (
 	"personal-crm/backend/internal/db"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
@@ -682,6 +684,22 @@ func (r *SyntheticSupportRepository) DeletePredicatesByKeyPrefix(ctx context.Con
 // from assertion, so a node-prefix delete clears both.
 func (r *SyntheticSupportRepository) CountAssertionsForSubject(ctx context.Context, subjectNodeID uuid.UUID) (int64, error) {
 	return r.queries.SyntheticCountAssertionsForSubject(ctx, pgtype.UUID{Bytes: subjectNodeID, Valid: true})
+}
+
+// GetNodeForContact fetches the person node a contact owns (node.id ==
+// contact.id), so a contact→node dual-write test can assert the node exists
+// with the expected type and canonical_label. Returns db.ErrNotFound when no
+// live node is at the contact's id.
+func (r *SyntheticSupportRepository) GetNodeForContact(ctx context.Context, contactID uuid.UUID) (*Node, error) {
+	dbNode, err := r.queries.SyntheticGetNodeForContact(ctx, pgtype.UUID{Bytes: contactID, Valid: true})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, db.ErrNotFound
+		}
+		return nil, err
+	}
+	node := convertDbNode(dbNode)
+	return &node, nil
 }
 
 // DeleteAssertionsForNode hard-deletes the assertions touching a node in either

--- a/backend/internal/repository/synthetic_support.go
+++ b/backend/internal/repository/synthetic_support.go
@@ -702,6 +702,14 @@ func (r *SyntheticSupportRepository) GetNodeForContact(ctx context.Context, cont
 	return &node, nil
 }
 
+// CountContactsByFullName counts live contacts with an exact full_name, so a
+// contact→node dual-write rollback test can assert a failed-tx contact did not
+// survive without paging the whole contact list (namespace-prefixed names are
+// unique per test).
+func (r *SyntheticSupportRepository) CountContactsByFullName(ctx context.Context, fullName string) (int64, error) {
+	return r.queries.SyntheticCountContactsByFullName(ctx, fullName)
+}
+
 // DeleteAssertionsForNode hard-deletes the assertions touching a node in either
 // position (provenance cascades). The assertion → node FK is restrict, so a test
 // MUST clear its assertions before deleting its nodes — register this cleanup to

--- a/backend/internal/service/contact.go
+++ b/backend/internal/service/contact.go
@@ -1337,6 +1337,17 @@ func (s *ContactService) MergeContacts(ctx context.Context, req MergeContactsReq
 		return nil, fmt.Errorf("update target contact: %w", err)
 	}
 
+	// Keep the target's person node label loosely synced when the merge
+	// renames the target (node.id == contact.id), mirroring
+	// ContactService.UpdateContact. The source contact's node tombstoning is a
+	// later soft-delete-propagation concern.
+	if updateReq.FullName != targetContact.FullName {
+		nodeRepo := repository.NewNodeRepository(txQueries)
+		if err := nodeRepo.UpdateNodeCanonicalLabelTx(ctx, tx, req.TargetContactID, updateReq.FullName); err != nil {
+			return nil, fmt.Errorf("sync target person node label: %w", err)
+		}
+	}
+
 	// 9a. Forward-max merged cadence columns through
 	// CadenceUpdater.BulkApply. The merged cadence string may come from
 	// the source (when FieldSelections.Cadence == "source"), so

--- a/backend/internal/service/contact.go
+++ b/backend/internal/service/contact.go
@@ -388,13 +388,13 @@ func (s *ContactService) UpdateContact(ctx context.Context, id uuid.UUID, req re
 		return nil, uuid.Nil, err
 	}
 
-	// Keep the person node's display label loosely synced with the contact's
-	// name. Only write on an actual rename to avoid a no-op UPDATE on every
-	// profile edit.
-	if req.FullName != existingContact.FullName {
-		if err = nodeRepo.UpdateNodeCanonicalLabelTx(ctx, tx, id, req.FullName); err != nil {
-			return nil, uuid.Nil, fmt.Errorf("sync person node label: %w", err)
-		}
+	// Keep the person node's display label synced with the contact's name.
+	// UpdateContact always writes full_name in this same tx, so we sync the
+	// node to req.FullName UNCONDITIONALLY — gating on a pre-read name compare
+	// would let a stale-read non-rename update leave node and contact divergent
+	// under concurrency. A redundant no-op UPDATE on a non-rename edit is cheap.
+	if err = nodeRepo.UpdateNodeCanonicalLabelTx(ctx, tx, id, req.FullName); err != nil {
+		return nil, uuid.Nil, fmt.Errorf("sync person node label: %w", err)
 	}
 
 	if err := s.cadence.ApplyContactByOverride(ctx, tx, id, newContactBy); err != nil {
@@ -1337,15 +1337,14 @@ func (s *ContactService) MergeContacts(ctx context.Context, req MergeContactsReq
 		return nil, fmt.Errorf("update target contact: %w", err)
 	}
 
-	// Keep the target's person node label loosely synced when the merge
-	// renames the target (node.id == contact.id), mirroring
-	// ContactService.UpdateContact. The source contact's node tombstoning is a
-	// later soft-delete-propagation concern.
-	if updateReq.FullName != targetContact.FullName {
-		nodeRepo := repository.NewNodeRepository(txQueries)
-		if err := nodeRepo.UpdateNodeCanonicalLabelTx(ctx, tx, req.TargetContactID, updateReq.FullName); err != nil {
-			return nil, fmt.Errorf("sync target person node label: %w", err)
-		}
+	// Keep the target's person node label synced with the merged name
+	// (node.id == contact.id). The UpdateContact above always writes full_name
+	// in this same tx, so sync the node UNCONDITIONALLY to avoid divergence.
+	// The source contact's node tombstoning is a later soft-delete-propagation
+	// concern.
+	nodeRepo := repository.NewNodeRepository(txQueries)
+	if err := nodeRepo.UpdateNodeCanonicalLabelTx(ctx, tx, req.TargetContactID, updateReq.FullName); err != nil {
+		return nil, fmt.Errorf("sync target person node label: %w", err)
 	}
 
 	// 9a. Forward-max merged cadence columns through

--- a/backend/internal/service/contact.go
+++ b/backend/internal/service/contact.go
@@ -269,10 +269,19 @@ func (s *ContactService) CreateContact(ctx context.Context, req repository.Creat
 	txQueries := db.New(tx)
 	contactRepo := repository.NewContactRepository(txQueries)
 	contactMethodRepo := repository.NewContactMethodRepository(txQueries)
+	nodeRepo := repository.NewNodeRepository(txQueries)
 
 	contact, err = contactRepo.CreateContact(ctx, req)
 	if err != nil {
 		return nil, uuid.Nil, err
+	}
+
+	// Dual-write the person node at the contact's own id (node.id ==
+	// contact.id) inside the same tx so the node registry stays in lockstep
+	// with contact creation — both commit or both roll back. Node creation is
+	// silent graph infra (no event); assertion events are the graph's signal.
+	if _, err = nodeRepo.CreateNodeTx(ctx, tx, contact.ID, repository.NodeTypePerson, contact.FullName); err != nil {
+		return nil, uuid.Nil, fmt.Errorf("create person node: %w", err)
 	}
 
 	createdMethods, err := createContactMethods(ctx, contactMethodRepo, contact.ID, methods)
@@ -341,6 +350,7 @@ func (s *ContactService) UpdateContact(ctx context.Context, id uuid.UUID, req re
 	txQueries := db.New(tx)
 	contactRepo := repository.NewContactRepository(txQueries)
 	contactMethodRepo := repository.NewContactMethodRepository(txQueries)
+	nodeRepo := repository.NewNodeRepository(txQueries)
 
 	existingContact, err := contactRepo.GetContact(ctx, id)
 	if err != nil {
@@ -376,6 +386,15 @@ func (s *ContactService) UpdateContact(ctx context.Context, id uuid.UUID, req re
 
 	if _, err = contactRepo.UpdateContact(ctx, id, req); err != nil {
 		return nil, uuid.Nil, err
+	}
+
+	// Keep the person node's display label loosely synced with the contact's
+	// name. Only write on an actual rename to avoid a no-op UPDATE on every
+	// profile edit.
+	if req.FullName != existingContact.FullName {
+		if err = nodeRepo.UpdateNodeCanonicalLabelTx(ctx, tx, id, req.FullName); err != nil {
+			return nil, uuid.Nil, fmt.Errorf("sync person node label: %w", err)
+		}
 	}
 
 	if err := s.cadence.ApplyContactByOverride(ctx, tx, id, newContactBy); err != nil {

--- a/backend/internal/service/enrichment.go
+++ b/backend/internal/service/enrichment.go
@@ -293,7 +293,10 @@ func (s *EnrichmentService) EnrichContactFromExternalWithSelections(
 		needsUpdate = true
 	}
 
-	// Apply updates to contact if any enrichment occurred.
+	// Apply updates to contact if any enrichment occurred. Keep the person
+	// node's canonical_label loosely synced whenever enrichment renames the
+	// contact (node.id == contact.id), mirroring ContactService.UpdateContact.
+	nameChanged := updateReq.FullName != contact.FullName
 	if needsUpdate {
 		if cadencePresent {
 			if s.cadence == nil {
@@ -308,6 +311,12 @@ func (s *EnrichmentService) EnrichContactFromExternalWithSelections(
 				if _, txErr := txContactRepo.UpdateContact(ctx, crmContactID, updateReq); txErr != nil {
 					return fmt.Errorf("update contact profile: %w", txErr)
 				}
+				if nameChanged {
+					nodeRepo := repository.NewNodeRepository(txQueries)
+					if txErr := nodeRepo.UpdateNodeCanonicalLabelTx(ctx, tx, crmContactID, updateReq.FullName); txErr != nil {
+						return fmt.Errorf("sync person node label: %w", txErr)
+					}
+				}
 				return s.cadence.ApplyContactByOverride(ctx, tx, crmContactID, newContactBy)
 			})
 			if txErr != nil {
@@ -318,6 +327,11 @@ func (s *EnrichmentService) EnrichContactFromExternalWithSelections(
 			// repository's default pool connection.
 			if _, err := s.contactRepo.UpdateContact(ctx, crmContactID, updateReq); err != nil {
 				logger.Warn().Err(err).Msg("failed to update contact with enrichments")
+			} else if nameChanged {
+				nodeRepo := repository.NewNodeRepository(s.database.Queries)
+				if err := nodeRepo.UpdateNodeCanonicalLabel(ctx, crmContactID, updateReq.FullName); err != nil {
+					logger.Warn().Err(err).Msg("failed to sync person node label after enrichment rename")
+				}
 			}
 		}
 	}

--- a/backend/internal/service/enrichment.go
+++ b/backend/internal/service/enrichment.go
@@ -294,8 +294,13 @@ func (s *EnrichmentService) EnrichContactFromExternalWithSelections(
 	}
 
 	// Apply updates to contact if any enrichment occurred. Keep the person
-	// node's canonical_label loosely synced whenever enrichment renames the
-	// contact (node.id == contact.id), mirroring ContactService.UpdateContact.
+	// node's canonical_label synced whenever enrichment renames the contact
+	// (node.id == contact.id). Here nameChanged is derived from the explicit
+	// `name` argument (updateReq.FullName starts == contact.FullName and is only
+	// overwritten above when a name is supplied), NOT a race-prone pre-read — so
+	// when it is false the node already equals the contact name and no sync is
+	// needed. When true, the sync rides in the same write path (tx) as the
+	// contact update so the two can't diverge.
 	nameChanged := updateReq.FullName != contact.FullName
 	if needsUpdate {
 		if cadencePresent {

--- a/backend/internal/service/enrichment.go
+++ b/backend/internal/service/enrichment.go
@@ -133,10 +133,21 @@ func (s *EnrichmentService) EnrichContactFromExternal(
 		s.recordEnrichment(ctx, crmContactID, external, "location", location)
 	}
 
-	// Apply updates to contact if any enrichment occurred
+	// Apply updates to contact if any enrichment occurred. This path never
+	// renames (no name input — updateReq.FullName stays == contact.FullName),
+	// but UpdateContact still writes full_name, so the node label sync rides the
+	// same tx and is UNCONDITIONAL — keeping contact and node in lockstep even
+	// if the written name clobbers a concurrent rename.
 	if needsUpdate {
-		if _, err := s.contactRepo.UpdateContact(ctx, crmContactID, updateReq); err != nil {
-			logger.Warn().Err(err).Msg("failed to update contact with enrichments")
+		txErr := pgx.BeginTxFunc(ctx, s.database.Pool, pgx.TxOptions{}, func(tx pgx.Tx) error {
+			txQueries := db.New(tx)
+			if _, txErr := repository.NewContactRepository(txQueries).UpdateContact(ctx, crmContactID, updateReq); txErr != nil {
+				return fmt.Errorf("update contact profile: %w", txErr)
+			}
+			return repository.NewNodeRepository(txQueries).UpdateNodeCanonicalLabelTx(ctx, tx, crmContactID, updateReq.FullName)
+		})
+		if txErr != nil {
+			logger.Warn().Err(txErr).Msg("failed to update contact with enrichments")
 		}
 	}
 
@@ -293,63 +304,37 @@ func (s *EnrichmentService) EnrichContactFromExternalWithSelections(
 		needsUpdate = true
 	}
 
-	// Apply updates to contact if any enrichment occurred. Keep the person
-	// node's canonical_label synced whenever enrichment renames the contact
-	// (node.id == contact.id). Here nameChanged is derived from the explicit
-	// `name` argument (updateReq.FullName starts == contact.FullName and is only
-	// overwritten above when a name is supplied), NOT a race-prone pre-read — so
-	// when it is false the node already equals the contact name and no sync is
-	// needed. When true, the sync rides in the same write path (tx) as the
-	// contact update so the two can't diverge.
-	nameChanged := updateReq.FullName != contact.FullName
+	// Apply updates to contact if any enrichment occurred. UpdateContact always
+	// writes full_name, so the contact update + the person node label sync
+	// (node.id == contact.id) ALWAYS share one tx and the node is synced
+	// UNCONDITIONALLY to the written name — gating on a pre-read name compare
+	// would let a stale-read enrichment write back an old name while leaving the
+	// node on a concurrent rename's value, diverging the two.
 	if needsUpdate {
+		var newContactBy *time.Time
 		if cadencePresent {
 			if s.cadence == nil {
 				return uuid.Nil, errors.New("enrichment: cadence override requested but CadenceUpdater not wired")
 			}
-			newContactBy := deriveContactByFromCadence(contact, cadenceArg)
-			txErr := pgx.BeginTxFunc(ctx, s.database.Pool, pgx.TxOptions{}, func(tx pgx.Tx) error {
-				// Profile-only write inside the tx so the cadence string
-				// is visible to ApplyContactByOverride's downstream reads.
-				txQueries := db.New(tx)
-				txContactRepo := repository.NewContactRepository(txQueries)
-				if _, txErr := txContactRepo.UpdateContact(ctx, crmContactID, updateReq); txErr != nil {
-					return fmt.Errorf("update contact profile: %w", txErr)
-				}
-				if nameChanged {
-					nodeRepo := repository.NewNodeRepository(txQueries)
-					if txErr := nodeRepo.UpdateNodeCanonicalLabelTx(ctx, tx, crmContactID, updateReq.FullName); txErr != nil {
-						return fmt.Errorf("sync person node label: %w", txErr)
-					}
-				}
+			newContactBy = deriveContactByFromCadence(contact, cadenceArg)
+		}
+		txErr := pgx.BeginTxFunc(ctx, s.database.Pool, pgx.TxOptions{}, func(tx pgx.Tx) error {
+			// Profile-only write inside the tx so the cadence string is visible
+			// to ApplyContactByOverride's downstream reads.
+			txQueries := db.New(tx)
+			if _, txErr := repository.NewContactRepository(txQueries).UpdateContact(ctx, crmContactID, updateReq); txErr != nil {
+				return fmt.Errorf("update contact profile: %w", txErr)
+			}
+			if txErr := repository.NewNodeRepository(txQueries).UpdateNodeCanonicalLabelTx(ctx, tx, crmContactID, updateReq.FullName); txErr != nil {
+				return fmt.Errorf("sync person node label: %w", txErr)
+			}
+			if cadencePresent {
 				return s.cadence.ApplyContactByOverride(ctx, tx, crmContactID, newContactBy)
-			})
-			if txErr != nil {
-				logger.Warn().Err(txErr).Msg("failed to update contact with cadence override")
 			}
-		} else if nameChanged {
-			// A rename must keep contact.full_name and node.canonical_label in
-			// lockstep, so the two writes share one tx (atomic — never a
-			// half-applied rename).
-			txErr := pgx.BeginTxFunc(ctx, s.database.Pool, pgx.TxOptions{}, func(tx pgx.Tx) error {
-				txQueries := db.New(tx)
-				if _, txErr := repository.NewContactRepository(txQueries).UpdateContact(ctx, crmContactID, updateReq); txErr != nil {
-					return fmt.Errorf("update contact profile: %w", txErr)
-				}
-				if txErr := repository.NewNodeRepository(txQueries).UpdateNodeCanonicalLabelTx(ctx, tx, crmContactID, updateReq.FullName); txErr != nil {
-					return fmt.Errorf("sync person node label: %w", txErr)
-				}
-				return nil
-			})
-			if txErr != nil {
-				logger.Warn().Err(txErr).Msg("failed to update contact with enrichments")
-			}
-		} else {
-			// No cadence change and no rename — profile-only path is safe to run
-			// on the repository's default pool connection.
-			if _, err := s.contactRepo.UpdateContact(ctx, crmContactID, updateReq); err != nil {
-				logger.Warn().Err(err).Msg("failed to update contact with enrichments")
-			}
+			return nil
+		})
+		if txErr != nil {
+			logger.Warn().Err(txErr).Msg("failed to update contact with enrichments")
 		}
 	}
 

--- a/backend/internal/service/enrichment.go
+++ b/backend/internal/service/enrichment.go
@@ -322,16 +322,28 @@ func (s *EnrichmentService) EnrichContactFromExternalWithSelections(
 			if txErr != nil {
 				logger.Warn().Err(txErr).Msg("failed to update contact with cadence override")
 			}
+		} else if nameChanged {
+			// A rename must keep contact.full_name and node.canonical_label in
+			// lockstep, so the two writes share one tx (atomic — never a
+			// half-applied rename).
+			txErr := pgx.BeginTxFunc(ctx, s.database.Pool, pgx.TxOptions{}, func(tx pgx.Tx) error {
+				txQueries := db.New(tx)
+				if _, txErr := repository.NewContactRepository(txQueries).UpdateContact(ctx, crmContactID, updateReq); txErr != nil {
+					return fmt.Errorf("update contact profile: %w", txErr)
+				}
+				if txErr := repository.NewNodeRepository(txQueries).UpdateNodeCanonicalLabelTx(ctx, tx, crmContactID, updateReq.FullName); txErr != nil {
+					return fmt.Errorf("sync person node label: %w", txErr)
+				}
+				return nil
+			})
+			if txErr != nil {
+				logger.Warn().Err(txErr).Msg("failed to update contact with enrichments")
+			}
 		} else {
-			// No cadence change — profile-only path is safe to run on the
-			// repository's default pool connection.
+			// No cadence change and no rename — profile-only path is safe to run
+			// on the repository's default pool connection.
 			if _, err := s.contactRepo.UpdateContact(ctx, crmContactID, updateReq); err != nil {
 				logger.Warn().Err(err).Msg("failed to update contact with enrichments")
-			} else if nameChanged {
-				nodeRepo := repository.NewNodeRepository(s.database.Queries)
-				if err := nodeRepo.UpdateNodeCanonicalLabel(ctx, crmContactID, updateReq.FullName); err != nil {
-					logger.Warn().Err(err).Msg("failed to sync person node label after enrichment rename")
-				}
 			}
 		}
 	}

--- a/backend/internal/synthetic/replay/harness_cleanup.go
+++ b/backend/internal/synthetic/replay/harness_cleanup.go
@@ -239,8 +239,12 @@ func (h *Harness) cleanup(ctx context.Context) error {
 	})
 	// 13a. person node (node.id == contact.id): SeedContact dual-writes a node
 	// via the real service path, so teardown must remove it too or the shared
-	// DB leaks an orphan node per seeded contact. No FK from node→contact, so
-	// order relative to the contact delete is immaterial.
+	// DB leaks an orphan node per seeded contact. There is no FK from
+	// node→contact, so order relative to the contact delete is free. But the
+	// assertion→node FK is RESTRICT, so once a harness seeds assertions on these
+	// person nodes (PR4+), those assertions MUST be deleted before this step
+	// (register that cleanup LATER so t.Cleanup's LIFO runs it FIRST); today no
+	// harness path seeds them, so this delete stands alone.
 	step("person_node", func() error {
 		_, err := h.support.DeleteNodesByIds(ctx, c.contactIDs)
 		return err

--- a/backend/internal/synthetic/replay/harness_cleanup.go
+++ b/backend/internal/synthetic/replay/harness_cleanup.go
@@ -237,6 +237,14 @@ func (h *Harness) cleanup(ctx context.Context) error {
 		_, err := h.support.DeleteContactsByIds(ctx, c.contactIDs)
 		return err
 	})
+	// 13a. person node (node.id == contact.id): SeedContact dual-writes a node
+	// via the real service path, so teardown must remove it too or the shared
+	// DB leaks an orphan node per seeded contact. No FK from node→contact, so
+	// order relative to the contact delete is immaterial.
+	step("person_node", func() error {
+		_, err := h.support.DeleteNodesByIds(ctx, c.contactIDs)
+		return err
+	})
 	// meeting_note scoped to the seeded synthetic host, BEFORE the mac_host
 	// delete. A profile may seed orphan_needs_review meeting_note rows against
 	// this host; the mac_host FK is ON DELETE SET NULL, so deleting the host

--- a/backend/internal/synthetic/replay/harness_cleanup.go
+++ b/backend/internal/synthetic/replay/harness_cleanup.go
@@ -240,11 +240,11 @@ func (h *Harness) cleanup(ctx context.Context) error {
 	// 13a. person node (node.id == contact.id): SeedContact dual-writes a node
 	// via the real service path, so teardown must remove it too or the shared
 	// DB leaks an orphan node per seeded contact. There is no FK from
-	// node→contact, so order relative to the contact delete is free. But the
+	// node→contact, so order relative to the contact delete is free. The
 	// assertion→node FK is RESTRICT, so once a harness seeds assertions on these
-	// person nodes (PR4+), those assertions MUST be deleted before this step
-	// (register that cleanup LATER so t.Cleanup's LIFO runs it FIRST); today no
-	// harness path seeds them, so this delete stands alone.
+	// person nodes, those assertions must be deleted in an EARLIER cleanup step
+	// (added before this one in the sequence); no harness path seeds them today,
+	// so this delete stands alone.
 	step("person_node", func() error {
 		_, err := h.support.DeleteNodesByIds(ctx, c.contactIDs)
 		return err

--- a/backend/migrations/068_backfill_person_nodes.down.sql
+++ b/backend/migrations/068_backfill_person_nodes.down.sql
@@ -4,16 +4,21 @@
 -- rollback that runs after assertion data has landed must NOT orphan or FK-
 -- violate against those rows. A plain "delete all person nodes" down is
 -- DISALLOWED for exactly that reason. Instead, delete ONLY person nodes that
--- have become non-load-bearing: not merged away and referenced by NO assertion
--- (as subject or object). Any person node an assertion still points at is left
--- intact, so the down degrades gracefully when the graph has grown beyond this
--- migration's seed.
+-- have become non-load-bearing: not a merge winner still referenced by a
+-- preserved loser (the node.merged_into self-FK is restrict), and referenced by
+-- NO assertion (as subject or object). Any person node something still points
+-- at is left intact, so the down degrades gracefully when the graph has grown
+-- beyond this migration's seed.
 
 BEGIN;
 
 DELETE FROM node
 WHERE type = 'person'
   AND merged_into IS NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM node child
+    WHERE child.merged_into = node.id
+  )
   AND NOT EXISTS (
     SELECT 1 FROM assertion a
     WHERE a.subject_node_id = node.id

--- a/backend/migrations/068_backfill_person_nodes.down.sql
+++ b/backend/migrations/068_backfill_person_nodes.down.sql
@@ -14,11 +14,19 @@ BEGIN;
 
 DELETE FROM node
 WHERE type = 'person'
+  -- Skip merge LOSERS: they carry merged_into (and are tombstoned). Deleting a
+  -- merged-away node would silently drop merge history.
   AND merged_into IS NULL
+  -- Skip merge WINNERS still pointed at by a preserved loser's merged_into
+  -- self-FK (restrict): a winner has merged_into NULL and may have no assertion,
+  -- so without this guard the delete would FK-violate against the loser's
+  -- merged_into reference.
   AND NOT EXISTS (
     SELECT 1 FROM node child
     WHERE child.merged_into = node.id
   )
+  -- Skip nodes any assertion references (subject or object): the assertion→node
+  -- FK is restrict, so deleting them would FK-violate / orphan history.
   AND NOT EXISTS (
     SELECT 1 FROM assertion a
     WHERE a.subject_node_id = node.id

--- a/backend/migrations/068_backfill_person_nodes.down.sql
+++ b/backend/migrations/068_backfill_person_nodes.down.sql
@@ -1,0 +1,23 @@
+-- Guarded removal of the backfilled person nodes.
+--
+-- The assertion table already exists at this migration level (067 < 068), so a
+-- rollback that runs after assertion data has landed must NOT orphan or FK-
+-- violate against those rows. A plain "delete all person nodes" down is
+-- DISALLOWED for exactly that reason. Instead, delete ONLY person nodes that
+-- have become no load-bearing: not merged away and referenced by NO assertion
+-- (as subject or object). Any person node an assertion still points at is left
+-- intact, so the down degrades gracefully when the graph has grown beyond this
+-- migration's seed.
+
+BEGIN;
+
+DELETE FROM node
+WHERE type = 'person'
+  AND merged_into IS NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM assertion a
+    WHERE a.subject_node_id = node.id
+       OR a.object_node_id = node.id
+  );
+
+COMMIT;

--- a/backend/migrations/068_backfill_person_nodes.down.sql
+++ b/backend/migrations/068_backfill_person_nodes.down.sql
@@ -4,7 +4,7 @@
 -- rollback that runs after assertion data has landed must NOT orphan or FK-
 -- violate against those rows. A plain "delete all person nodes" down is
 -- DISALLOWED for exactly that reason. Instead, delete ONLY person nodes that
--- have become no load-bearing: not merged away and referenced by NO assertion
+-- have become non-load-bearing: not merged away and referenced by NO assertion
 -- (as subject or object). Any person node an assertion still points at is left
 -- intact, so the down degrades gracefully when the graph has grown beyond this
 -- migration's seed.

--- a/backend/migrations/068_backfill_person_nodes.up.sql
+++ b/backend/migrations/068_backfill_person_nodes.up.sql
@@ -1,0 +1,24 @@
+-- Backfill one person node per existing non-deleted contact (graph foundation).
+--
+-- The contact→node dual-write (in ContactService) covers all FUTURE contacts;
+-- this migration seeds the node registry for contacts that already exist. Each
+-- person node lives at the contact's own id (node.id == contact.id) so every
+-- assertion the write API later makes about an existing contact resolves its
+-- subject node directly.
+--
+-- Wrapped in an explicit transaction: the postgres migration driver does NOT
+-- auto-wrap a file, and this is data DML, so it self-wraps to stay all-or-
+-- nothing. Deleted contacts are intentionally skipped — their node tombstone is
+-- a later soft-delete-propagation concern, and no assertion can reference a
+-- deleted contact's node yet. ON CONFLICT (id) DO NOTHING keeps re-runs a no-op
+-- and tolerates any person node already created by the live dual-write.
+
+BEGIN;
+
+INSERT INTO node (id, type, canonical_label, created_at)
+SELECT id, 'person', full_name, created_at
+FROM contact
+WHERE deleted_at IS NULL
+ON CONFLICT (id) DO NOTHING;
+
+COMMIT;

--- a/backend/tests/contact_node_dualwrite_integration_test.go
+++ b/backend/tests/contact_node_dualwrite_integration_test.go
@@ -384,9 +384,9 @@ func TestContactNodeDualWrite_MigrationDownUp(t *testing.T) {
 	// Seed a SOFT-DELETED contact whose person node is absent (simulating a
 	// contact deleted before 068 ran). This pins the up backfill's
 	// `WHERE deleted_at IS NULL` rule: the up must NOT mint a person node for a
-	// soft-deleted contact (plan D7 — a deleted contact's node is a later
+	// soft-deleted contact — a deleted contact's node is a later
 	// soft-delete-propagation concern, and the write API rejects a deleted
-	// subject node). Drop the node the dual-write created so the contact enters
+	// subject node. Drop the node the dual-write created so the contact enters
 	// the up step node-less, exactly like a pre-068 deletion.
 	deleted, _, err := contactSvc.CreateContact(ctx, repository.CreateContactRequest{
 		FullName: "migration-deleted-person",

--- a/backend/tests/contact_node_dualwrite_integration_test.go
+++ b/backend/tests/contact_node_dualwrite_integration_test.go
@@ -323,6 +323,19 @@ func TestContactNodeDualWrite_MigrationDownUp(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	// Seed a merge winner/loser pair with NO assertions: the winner has
+	// merged_into NULL (so an assertion-only guard would select it for
+	// deletion) but is still referenced by the preserved loser via the
+	// merged_into self-FK (restrict). Deleting the winner would FK-violate, so
+	// the guarded down must skip it. (The loser carries merged_into, so it is
+	// never selected.)
+	winnerID, loserID := uuid.New(), uuid.New()
+	_, err = nodeRepo.CreateNode(ctx, winnerID, repository.NodeTypePerson, "migration-merge-winner")
+	require.NoError(t, err)
+	_, err = nodeRepo.CreateNode(ctx, loserID, repository.NodeTypePerson, "migration-merge-loser")
+	require.NoError(t, err)
+	require.NoError(t, nodeRepo.SetNodeMergedInto(ctx, loserID, winnerID))
+
 	m, err := migrate.New(fmt.Sprintf("file://%s", migrationsPath), cloneURL)
 	require.NoError(t, err)
 	t.Cleanup(func() { _, _ = m.Close() })
@@ -347,6 +360,13 @@ func TestContactNodeDualWrite_MigrationDownUp(t *testing.T) {
 	objStillThere, err := nodeRepo.GetNode(ctx, objectReferencedID)
 	require.NoError(t, err, "guarded down preserves the assertion-object person node")
 	assert.Equal(t, objectReferencedID, objStillThere.ID)
+
+	// The merge winner (live, no assertions) survives because the preserved
+	// loser still references it via merged_into, so the guarded down must not
+	// delete it (an assertion-only guard would have FK-violated here).
+	winnerStillThere, err := nodeRepo.GetNode(ctx, winnerID)
+	require.NoError(t, err, "guarded down preserves a merge winner referenced by a loser")
+	assert.Equal(t, winnerID, winnerStillThere.ID)
 
 	// Roll back up: the backfill re-seeds a person node for every NON-deleted
 	// contact at its own id. The unreferenced contact still exists (its row was

--- a/backend/tests/contact_node_dualwrite_integration_test.go
+++ b/backend/tests/contact_node_dualwrite_integration_test.go
@@ -129,6 +129,85 @@ func TestContactNodeDualWrite_Integration(t *testing.T) {
 		assert.Equal(t, contact.FullName, node.CanonicalLabel)
 	})
 
+	t.Run("enrichment rename syncs the node label", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		t.Cleanup(func() { _, _ = support.DeleteNodesByLabelPrefix(ctx, gen.Prefix()) })
+
+		contactRepo := repository.NewContactRepository(database.Queries)
+		methodRepo := repository.NewContactMethodRepository(database.Queries)
+		interactionRepo := repository.NewInteractionRepository(database.Queries)
+		taskRepo := repository.NewContactTaskRepository(database.Queries)
+		enrichmentRepo := repository.NewEnrichmentRepository(database.Queries)
+		externalRepo := repository.NewExternalContactRepository(database.Queries)
+		svc := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, taskRepo, nil, nil)
+		// nil bus/registry → enrichment skips publish.
+		enrichSvc := service.NewEnrichmentService(database, contactRepo, methodRepo, enrichmentRepo, nil, nil)
+
+		spec := gen.Contact()
+		contact, _, err := svc.CreateContact(ctx, repository.CreateContactRequest{
+			FullName: spec.FullName,
+		}, nil)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = contactRepo.HardDeleteContact(ctx, contact.ID) })
+
+		display := gen.Prefix() + "ext-display"
+		external, err := externalRepo.Upsert(ctx, repository.UpsertExternalContactRequest{
+			Source:      "google",
+			SourceID:    gen.Prefix() + "ext-src",
+			DisplayName: &display,
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = externalRepo.Delete(ctx, external.ID) })
+
+		// Enrichment-driven rename via the no-cadence pool path: the node label
+		// must follow (mirrors ContactService.UpdateContact's sync).
+		renamed := gen.Prefix() + "enriched-renamed"
+		_, err = enrichSvc.EnrichContactFromExternalWithSelections(ctx, contact.ID, external, nil, nil, nil, &renamed)
+		require.NoError(t, err)
+
+		node, err := support.GetNodeForContact(ctx, contact.ID)
+		require.NoError(t, err)
+		assert.Equal(t, renamed, node.CanonicalLabel, "enrichment rename syncs the node label")
+	})
+
+	t.Run("merge with a new name syncs the target node label", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		t.Cleanup(func() { _, _ = support.DeleteNodesByLabelPrefix(ctx, gen.Prefix()) })
+
+		contactRepo := repository.NewContactRepository(database.Queries)
+		methodRepo := repository.NewContactMethodRepository(database.Queries)
+		interactionRepo := repository.NewInteractionRepository(database.Queries)
+		taskRepo := repository.NewContactTaskRepository(database.Queries)
+		svc := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, taskRepo, nil, nil)
+		wireCadenceUpdaterForTest(t, database, svc)
+
+		monthly := "monthly"
+		target, _, err := svc.CreateContact(ctx, repository.CreateContactRequest{
+			FullName: gen.Prefix() + "merge-target", Cadence: &monthly,
+		}, nil)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = contactRepo.HardDeleteContact(ctx, target.ID) })
+		source, _, err := svc.CreateContact(ctx, repository.CreateContactRequest{
+			FullName: gen.Prefix() + "merge-source", Cadence: &monthly,
+		}, nil)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = contactRepo.HardDeleteContact(ctx, source.ID) })
+
+		newName := gen.Prefix() + "merged-renamed"
+		_, err = svc.MergeContacts(ctx, service.MergeContactsRequest{
+			SourceContactID: source.ID,
+			TargetContactID: target.ID,
+			NewName:         &newName,
+		})
+		require.NoError(t, err)
+
+		node, err := support.GetNodeForContact(ctx, target.ID)
+		require.NoError(t, err)
+		assert.Equal(t, newName, node.CanonicalLabel, "merge new_name syncs the target node label")
+	})
+
 	t.Run("tx rollback leaves no node and no contact", func(t *testing.T) {
 		t.Parallel()
 		gen, _ := migrationGenerator(t)
@@ -157,15 +236,9 @@ func TestContactNodeDualWrite_Integration(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, int64(0), count, "rolled-back tx leaves no person node")
 
-		var contactCount int
-		contacts, err := contactRepo.ListContacts(ctx, repository.ListContactsParams{Limit: 1000})
+		contactCount, err := support.CountContactsByFullName(ctx, spec.FullName)
 		require.NoError(t, err)
-		for _, c := range contacts {
-			if c.FullName == spec.FullName {
-				contactCount++
-			}
-		}
-		assert.Equal(t, 0, contactCount, "rolled-back tx leaves no contact")
+		assert.Equal(t, int64(0), contactCount, "rolled-back tx leaves no contact")
 	})
 }
 
@@ -213,8 +286,9 @@ func TestContactNodeDualWrite_MigrationDownUp(t *testing.T) {
 	_, err = nodeRepo.GetNode(ctx, unreferenced.ID)
 	require.NoError(t, err, "dual-write created the person node")
 
-	// Seed a SECOND person node that an assertion references — the guarded down
-	// must leave this one intact (deleting it would orphan the assertion).
+	// Seed a SECOND person node that an assertion references as its SUBJECT —
+	// the guarded down must leave it intact (deleting it would orphan the
+	// assertion).
 	referencedID := uuid.New()
 	_, err = nodeRepo.CreateNode(ctx, referencedID, repository.NodeTypePerson, "migration-referenced-person")
 	require.NoError(t, err)
@@ -228,6 +302,24 @@ func TestContactNodeDualWrite_MigrationDownUp(t *testing.T) {
 		Salience:       45,
 		Status:         repository.AssertionStatusAccepted,
 		PropositionKey: "migration-dualwrite-prop-1",
+	})
+	require.NoError(t, err)
+
+	// Seed a THIRD person node referenced ONLY as an assertion's OBJECT (a
+	// person→person edge). The guarded down checks both positions, so this one
+	// must also survive (covering the object_node_id arm of the down's guard).
+	objectReferencedID := uuid.New()
+	_, err = nodeRepo.CreateNode(ctx, objectReferencedID, repository.NodeTypePerson, "migration-object-referenced-person")
+	require.NoError(t, err)
+	_, err = assertionRepo.InsertAssertion(ctx, repository.InsertAssertionParams{
+		SubjectNodeID:  referencedID,
+		PredicateKey:   "parent_of",
+		ObjectNodeID:   &objectReferencedID,
+		KnowledgeFrom:  accelerated.GetCurrentTime().UTC(),
+		Confidence:     80,
+		Salience:       45,
+		Status:         repository.AssertionStatusAccepted,
+		PropositionKey: "migration-dualwrite-prop-2",
 	})
 	require.NoError(t, err)
 
@@ -249,8 +341,12 @@ func TestContactNodeDualWrite_MigrationDownUp(t *testing.T) {
 	require.ErrorIs(t, err, db.ErrNotFound, "guarded down removes the unreferenced person node")
 
 	stillThere, err := nodeRepo.GetNode(ctx, referencedID)
-	require.NoError(t, err, "guarded down preserves the assertion-referenced person node")
+	require.NoError(t, err, "guarded down preserves the assertion-subject person node")
 	assert.Equal(t, referencedID, stillThere.ID)
+
+	objStillThere, err := nodeRepo.GetNode(ctx, objectReferencedID)
+	require.NoError(t, err, "guarded down preserves the assertion-object person node")
+	assert.Equal(t, objectReferencedID, objStillThere.ID)
 
 	// Roll back up: the backfill re-seeds a person node for every NON-deleted
 	// contact at its own id. The unreferenced contact still exists (its row was

--- a/backend/tests/contact_node_dualwrite_integration_test.go
+++ b/backend/tests/contact_node_dualwrite_integration_test.go
@@ -1,0 +1,265 @@
+//go:build integration_testdb
+
+package tests
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+	"personal-crm/backend/internal/testdb"
+
+	migrate "github.com/golang-migrate/migrate/v4"
+	_ "github.com/golang-migrate/migrate/v4/source/file"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// backfillPersonNodesVersion is the golang-migrate version of the person-node
+// backfill migration (068). The down/up round-trip positions the clone here
+// before Steps(-1), so it stays robust to later migrations (069+) being added
+// above it (mirrors the assertion-store migration test's positioning).
+const backfillPersonNodesVersion = 68
+
+// Contact→node dual-write: ContactService.CreateContact writes a
+// node(type='person') at the contact's own id (node.id == contact.id) in the
+// same tx, and UpdateContact syncs node.canonical_label on rename. Each
+// sub-test is namespace-scoped (migrationGenerator) and cleans up its own
+// node by label prefix (the person node's canonical_label == full_name, which
+// is namespace-prefixed) so the shared test DB stays isolated under
+// t.Parallel().
+
+func TestContactNodeDualWrite_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	database, ctx := graphTestDB(t)
+	support := repository.NewSyntheticSupportRepository(database.Queries)
+
+	t.Run("create contact writes a person node at the same id", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		t.Cleanup(func() { _, _ = support.DeleteNodesByLabelPrefix(ctx, gen.Prefix()) })
+
+		contact, cleanup := seedMigrationContact(ctx, t, database, gen)
+		t.Cleanup(cleanup)
+
+		node, err := support.GetNodeForContact(ctx, contact.ID)
+		require.NoError(t, err, "create must dual-write a person node at the contact's id")
+		assert.Equal(t, contact.ID, node.ID, "node.id == contact.id invariant")
+		assert.Equal(t, repository.NodeTypePerson, node.Type)
+		assert.Equal(t, contact.FullName, node.CanonicalLabel, "node label seeded from full_name")
+		assert.Nil(t, node.DeletedAt)
+	})
+
+	t.Run("rename contact updates the node canonical_label", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		t.Cleanup(func() { _, _ = support.DeleteNodesByLabelPrefix(ctx, gen.Prefix()) })
+
+		// UpdateContact requires a wired cadence updater; build a service that
+		// owns the same namespace's node cleanup via the prefix above.
+		contactRepo := repository.NewContactRepository(database.Queries)
+		methodRepo := repository.NewContactMethodRepository(database.Queries)
+		interactionRepo := repository.NewInteractionRepository(database.Queries)
+		taskRepo := repository.NewContactTaskRepository(database.Queries)
+		svc := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, taskRepo, nil, nil)
+		wireCadenceUpdaterForTest(t, database, svc)
+
+		spec := gen.Contact()
+		contact, _, err := svc.CreateContact(ctx, repository.CreateContactRequest{
+			FullName: spec.FullName,
+			Cadence:  spec.Cadence,
+		}, nil)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = contactRepo.HardDeleteContact(ctx, contact.ID) })
+
+		// Rename via the profile-update path: the node label must follow.
+		renamed := gen.Prefix() + "renamed-person"
+		_, _, err = svc.UpdateContact(ctx, contact.ID, repository.UpdateContactRequest{
+			FullName: renamed,
+		}, nil, false)
+		require.NoError(t, err)
+
+		node, err := support.GetNodeForContact(ctx, contact.ID)
+		require.NoError(t, err)
+		assert.Equal(t, renamed, node.CanonicalLabel, "rename syncs node canonical_label")
+	})
+
+	t.Run("update without a rename leaves the node label untouched", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		t.Cleanup(func() { _, _ = support.DeleteNodesByLabelPrefix(ctx, gen.Prefix()) })
+
+		contactRepo := repository.NewContactRepository(database.Queries)
+		methodRepo := repository.NewContactMethodRepository(database.Queries)
+		interactionRepo := repository.NewInteractionRepository(database.Queries)
+		taskRepo := repository.NewContactTaskRepository(database.Queries)
+		svc := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, taskRepo, nil, nil)
+		wireCadenceUpdaterForTest(t, database, svc)
+
+		spec := gen.Contact()
+		contact, _, err := svc.CreateContact(ctx, repository.CreateContactRequest{
+			FullName: spec.FullName,
+			Cadence:  spec.Cadence,
+		}, nil)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = contactRepo.HardDeleteContact(ctx, contact.ID) })
+
+		// Same name, a cadence-only edit: the label must not change.
+		monthly := "monthly"
+		_, _, err = svc.UpdateContact(ctx, contact.ID, repository.UpdateContactRequest{
+			FullName: contact.FullName,
+			Cadence:  &monthly,
+		}, nil, false)
+		require.NoError(t, err)
+
+		node, err := support.GetNodeForContact(ctx, contact.ID)
+		require.NoError(t, err)
+		assert.Equal(t, contact.FullName, node.CanonicalLabel)
+	})
+
+	t.Run("tx rollback leaves no node and no contact", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		t.Cleanup(func() { _, _ = support.DeleteNodesByLabelPrefix(ctx, gen.Prefix()) })
+
+		contactRepo := repository.NewContactRepository(database.Queries)
+		methodRepo := repository.NewContactMethodRepository(database.Queries)
+		interactionRepo := repository.NewInteractionRepository(database.Queries)
+		taskRepo := repository.NewContactTaskRepository(database.Queries)
+		svc := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, taskRepo, nil, nil)
+
+		// Force a failure AFTER the contact + node inserts but inside the same
+		// tx: an invalid contact_method type violates the contact_method CHECK
+		// constraint, aborting the tx. The dual-write must roll back with it.
+		spec := gen.Contact()
+		_, _, err := svc.CreateContact(ctx, repository.CreateContactRequest{
+			FullName: spec.FullName,
+			Cadence:  spec.Cadence,
+		}, []service.ContactMethodInput{
+			{Type: "not_a_real_method_type", Value: "x"},
+		})
+		require.Error(t, err, "invalid method type must abort the create tx")
+
+		// Neither the contact nor its person node may have survived the rollback.
+		count, err := support.CountNodesByLabelPrefix(ctx, gen.Prefix())
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), count, "rolled-back tx leaves no person node")
+
+		var contactCount int
+		contacts, err := contactRepo.ListContacts(ctx, repository.ListContactsParams{Limit: 1000})
+		require.NoError(t, err)
+		for _, c := range contacts {
+			if c.FullName == spec.FullName {
+				contactCount++
+			}
+		}
+		assert.Equal(t, 0, contactCount, "rolled-back tx leaves no contact")
+	})
+}
+
+// TestContactNodeDualWrite_MigrationDownUp exercises the 068 person-node
+// backfill down + up round-trip against an isolated clone (it rolls the schema
+// down, so it cannot share the package DB). The down is the GUARDED delete: it
+// removes only unreferenced person nodes and leaves any node an assertion still
+// points at intact.
+func TestContactNodeDualWrite_MigrationDownUp(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	if os.Getenv("DATABASE_URL") == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+	// Migration-subject test: rolls the schema down, so it stays serial and uses
+	// an isolated clone (never the shared package DB).
+
+	ctx := context.Background()
+	cloneURL, drop := testdb.NewEphemeralClone(t)
+	t.Cleanup(drop)
+	migrationsPath := getMigrationsPath()
+
+	cfg := config.TestConfig()
+	cfg.Database.URL = cloneURL
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	t.Cleanup(database.Close)
+
+	contactRepo := repository.NewContactRepository(database.Queries)
+	nodeRepo := repository.NewNodeRepository(database.Queries)
+	assertionRepo := repository.NewAssertionRepository(database.Queries)
+
+	// Seed a contact via the dual-write service path so a live person node
+	// exists at the contact's id (this is what 068's down must consider). It
+	// has no assertions, so the guarded down is free to delete it.
+	contactSvc := service.NewContactService(database, contactRepo,
+		repository.NewContactMethodRepository(database.Queries),
+		repository.NewInteractionRepository(database.Queries),
+		repository.NewContactTaskRepository(database.Queries), nil, nil)
+	unreferenced, _, err := contactSvc.CreateContact(ctx, repository.CreateContactRequest{
+		FullName: "migration-unreferenced-person",
+	}, nil)
+	require.NoError(t, err)
+	_, err = nodeRepo.GetNode(ctx, unreferenced.ID)
+	require.NoError(t, err, "dual-write created the person node")
+
+	// Seed a SECOND person node that an assertion references — the guarded down
+	// must leave this one intact (deleting it would orphan the assertion).
+	referencedID := uuid.New()
+	_, err = nodeRepo.CreateNode(ctx, referencedID, repository.NodeTypePerson, "migration-referenced-person")
+	require.NoError(t, err)
+	value := "anchored"
+	_, err = assertionRepo.InsertAssertion(ctx, repository.InsertAssertionParams{
+		SubjectNodeID:  referencedID,
+		PredicateKey:   "home_address",
+		ValueText:      &value,
+		KnowledgeFrom:  accelerated.GetCurrentTime().UTC(),
+		Confidence:     80,
+		Salience:       45,
+		Status:         repository.AssertionStatusAccepted,
+		PropositionKey: "migration-dualwrite-prop-1",
+	})
+	require.NoError(t, err)
+
+	m, err := migrate.New(fmt.Sprintf("file://%s", migrationsPath), cloneURL)
+	require.NoError(t, err)
+	t.Cleanup(func() { _, _ = m.Close() })
+
+	// Position the clone at the backfill tip (068) FIRST, so Steps(-1) rolls
+	// 068 specifically — robust to later migrations (069+) landing above it.
+	if err := m.Migrate(backfillPersonNodesVersion); err != nil && !errors.Is(err, migrate.ErrNoChange) {
+		require.NoError(t, err, "position the clone at the backfill tip")
+	}
+
+	// Roll down ONE step: the 068 guarded delete. The unreferenced person node
+	// is removed; the assertion-referenced one is preserved.
+	require.NoError(t, m.Steps(-1), "roll the person-node backfill down one step")
+
+	_, err = nodeRepo.GetNode(ctx, unreferenced.ID)
+	require.ErrorIs(t, err, db.ErrNotFound, "guarded down removes the unreferenced person node")
+
+	stillThere, err := nodeRepo.GetNode(ctx, referencedID)
+	require.NoError(t, err, "guarded down preserves the assertion-referenced person node")
+	assert.Equal(t, referencedID, stillThere.ID)
+
+	// Roll back up: the backfill re-seeds a person node for every NON-deleted
+	// contact at its own id. The unreferenced contact still exists (its row was
+	// never touched by the down — only its node was), so the up restores its
+	// person node.
+	require.NoError(t, m.Steps(1), "re-apply the person-node backfill")
+
+	restored, err := nodeRepo.GetNode(ctx, unreferenced.ID)
+	require.NoError(t, err, "the up backfill restores the person node for the surviving contact")
+	assert.Equal(t, repository.NodeTypePerson, restored.Type)
+	assert.Equal(t, unreferenced.FullName, restored.CanonicalLabel)
+}

--- a/backend/tests/contact_node_dualwrite_integration_test.go
+++ b/backend/tests/contact_node_dualwrite_integration_test.go
@@ -99,7 +99,7 @@ func TestContactNodeDualWrite_Integration(t *testing.T) {
 		assert.Equal(t, renamed, node.CanonicalLabel, "rename syncs node canonical_label")
 	})
 
-	t.Run("update without a rename leaves the node label untouched", func(t *testing.T) {
+	t.Run("rename alongside a cadence edit syncs the node label", func(t *testing.T) {
 		t.Parallel()
 		gen, _ := migrationGenerator(t)
 		t.Cleanup(func() { _, _ = support.DeleteNodesByLabelPrefix(ctx, gen.Prefix()) })
@@ -119,17 +119,20 @@ func TestContactNodeDualWrite_Integration(t *testing.T) {
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = contactRepo.HardDeleteContact(ctx, contact.ID) })
 
-		// Same name, a cadence-only edit: the label must not change.
+		// A rename combined with a cadence change (the cadence-recompute branch
+		// of UpdateContact): the node label must follow the new name — this
+		// fails if the in-tx sync regresses, unlike a same-name no-op.
+		renamed := gen.Prefix() + "renamed-with-cadence"
 		monthly := "monthly"
 		_, _, err = svc.UpdateContact(ctx, contact.ID, repository.UpdateContactRequest{
-			FullName: contact.FullName,
+			FullName: renamed,
 			Cadence:  &monthly,
 		}, nil, false)
 		require.NoError(t, err)
 
 		node, err := support.GetNodeForContact(ctx, contact.ID)
 		require.NoError(t, err)
-		assert.Equal(t, contact.FullName, node.CanonicalLabel)
+		assert.Equal(t, renamed, node.CanonicalLabel, "rename+cadence edit syncs the node label")
 	})
 
 	t.Run("enrichment rename syncs the node label", func(t *testing.T) {
@@ -362,6 +365,7 @@ func TestContactNodeDualWrite_MigrationDownUp(t *testing.T) {
 	contactRepo := repository.NewContactRepository(database.Queries)
 	nodeRepo := repository.NewNodeRepository(database.Queries)
 	assertionRepo := repository.NewAssertionRepository(database.Queries)
+	support := repository.NewSyntheticSupportRepository(database.Queries)
 
 	// Seed a contact via the dual-write service path so a live person node
 	// exists at the contact's id (this is what 068's down must consider). It
@@ -376,6 +380,23 @@ func TestContactNodeDualWrite_MigrationDownUp(t *testing.T) {
 	require.NoError(t, err)
 	_, err = nodeRepo.GetNode(ctx, unreferenced.ID)
 	require.NoError(t, err, "dual-write created the person node")
+
+	// Seed a SOFT-DELETED contact whose person node is absent (simulating a
+	// contact deleted before 068 ran). This pins the up backfill's
+	// `WHERE deleted_at IS NULL` rule: the up must NOT mint a person node for a
+	// soft-deleted contact (plan D7 — a deleted contact's node is a later
+	// soft-delete-propagation concern, and the write API rejects a deleted
+	// subject node). Drop the node the dual-write created so the contact enters
+	// the up step node-less, exactly like a pre-068 deletion.
+	deleted, _, err := contactSvc.CreateContact(ctx, repository.CreateContactRequest{
+		FullName: "migration-deleted-person",
+	}, nil)
+	require.NoError(t, err)
+	require.NoError(t, contactRepo.SoftDeleteContact(ctx, deleted.ID))
+	_, err = support.DeleteNodesByIds(ctx, []uuid.UUID{deleted.ID})
+	require.NoError(t, err)
+	_, err = nodeRepo.GetNodeIncludingDeleted(ctx, deleted.ID)
+	require.ErrorIs(t, err, db.ErrNotFound, "soft-deleted contact starts the up step with no person node")
 
 	// Seed a SECOND person node that an assertion references as its SUBJECT —
 	// the guarded down must leave it intact (deleting it would orphan the
@@ -478,6 +499,12 @@ func TestContactNodeDualWrite_MigrationDownUp(t *testing.T) {
 	require.NoError(t, err, "the up backfill restores the person node for the surviving contact")
 	assert.Equal(t, repository.NodeTypePerson, restored.Type)
 	assert.Equal(t, unreferenced.FullName, restored.CanonicalLabel)
+
+	// The soft-deleted contact gets NO person node from the up backfill — this
+	// is the `WHERE deleted_at IS NULL` invariant. Dropping that clause from the
+	// up migration would mint a node here and fail this assertion.
+	_, err = nodeRepo.GetNodeIncludingDeleted(ctx, deleted.ID)
+	require.ErrorIs(t, err, db.ErrNotFound, "up backfill must skip soft-deleted contacts (WHERE deleted_at IS NULL)")
 }
 
 // TestContactNodeDualWrite_HarnessSeedCreatesNode confirms the synthetic

--- a/backend/tests/contact_node_dualwrite_integration_test.go
+++ b/backend/tests/contact_node_dualwrite_integration_test.go
@@ -220,6 +220,48 @@ func TestContactNodeDualWrite_Integration(t *testing.T) {
 		assert.Equal(t, renamed, node.CanonicalLabel, "cadence-path enrichment rename syncs the node label")
 	})
 
+	t.Run("no-name enrichment keeps the node label matching the contact", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		t.Cleanup(func() { _, _ = support.DeleteNodesByLabelPrefix(ctx, gen.Prefix()) })
+
+		contactRepo := repository.NewContactRepository(database.Queries)
+		methodRepo := repository.NewContactMethodRepository(database.Queries)
+		interactionRepo := repository.NewInteractionRepository(database.Queries)
+		taskRepo := repository.NewContactTaskRepository(database.Queries)
+		enrichmentRepo := repository.NewEnrichmentRepository(database.Queries)
+		externalRepo := repository.NewExternalContactRepository(database.Queries)
+		svc := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, taskRepo, nil, nil)
+		enrichSvc := service.NewEnrichmentService(database, contactRepo, methodRepo, enrichmentRepo, nil, nil)
+
+		spec := gen.Contact()
+		contact, _, err := svc.CreateContact(ctx, repository.CreateContactRequest{
+			FullName: spec.FullName,
+		}, nil)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = contactRepo.HardDeleteContact(ctx, contact.ID) })
+
+		// External carries a birthday the contact lacks → the legacy
+		// EnrichContactFromExternal path performs a (non-rename) UpdateContact,
+		// which now also unconditionally syncs the node label in-tx. The label
+		// must still equal the (unchanged) contact name afterward.
+		bday := accelerated.GetCurrentTime().UTC()
+		external, err := externalRepo.Upsert(ctx, repository.UpsertExternalContactRequest{
+			Source:   "google",
+			SourceID: gen.Prefix() + "ext-src-noname",
+			Birthday: &bday,
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = externalRepo.Delete(ctx, external.ID) })
+
+		_, err = enrichSvc.EnrichContactFromExternal(ctx, contact.ID, external)
+		require.NoError(t, err)
+
+		node, err := support.GetNodeForContact(ctx, contact.ID)
+		require.NoError(t, err)
+		assert.Equal(t, contact.FullName, node.CanonicalLabel, "no-name enrichment leaves the node label in sync")
+	})
+
 	t.Run("merge with a new name syncs the target node label", func(t *testing.T) {
 		t.Parallel()
 		gen, _ := migrationGenerator(t)
@@ -416,6 +458,15 @@ func TestContactNodeDualWrite_MigrationDownUp(t *testing.T) {
 	winnerStillThere, err := nodeRepo.GetNode(ctx, winnerID)
 	require.NoError(t, err, "guarded down preserves a merge winner referenced by a loser")
 	assert.Equal(t, winnerID, winnerStillThere.ID)
+
+	// The merge loser (soft-deleted, merged_into set, no assertions) also
+	// survives — the `merged_into IS NULL` guard arm skips it (deleting it would
+	// be a silent loss of merge history). Resolvable via the includes-deleted
+	// read since SetNodeMergedInto tombstones it.
+	loserStillThere, err := nodeRepo.GetNodeIncludingDeleted(ctx, loserID)
+	require.NoError(t, err, "guarded down preserves a merged-away loser node")
+	require.NotNil(t, loserStillThere.MergedInto)
+	assert.Equal(t, winnerID, *loserStillThere.MergedInto)
 
 	// Roll back up: the backfill re-seeds a person node for every NON-deleted
 	// contact at its own id. The unreferenced contact still exists (its row was

--- a/backend/tests/contact_node_dualwrite_integration_test.go
+++ b/backend/tests/contact_node_dualwrite_integration_test.go
@@ -14,7 +14,10 @@ import (
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/service"
+	"personal-crm/backend/internal/synthetic"
+	"personal-crm/backend/internal/synthetic/factory"
 	"personal-crm/backend/internal/testdb"
+	"personal-crm/backend/tests/testsupport"
 
 	migrate "github.com/golang-migrate/migrate/v4"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
@@ -169,6 +172,52 @@ func TestContactNodeDualWrite_Integration(t *testing.T) {
 		node, err := support.GetNodeForContact(ctx, contact.ID)
 		require.NoError(t, err)
 		assert.Equal(t, renamed, node.CanonicalLabel, "enrichment rename syncs the node label")
+	})
+
+	t.Run("enrichment rename with cadence syncs the node label in-tx", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		t.Cleanup(func() { _, _ = support.DeleteNodesByLabelPrefix(ctx, gen.Prefix()) })
+
+		contactRepo := repository.NewContactRepository(database.Queries)
+		methodRepo := repository.NewContactMethodRepository(database.Queries)
+		interactionRepo := repository.NewInteractionRepository(database.Queries)
+		taskRepo := repository.NewContactTaskRepository(database.Queries)
+		enrichmentRepo := repository.NewEnrichmentRepository(database.Queries)
+		externalRepo := repository.NewExternalContactRepository(database.Queries)
+		svc := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, taskRepo, nil, nil)
+		enrichSvc := service.NewEnrichmentService(database, contactRepo, methodRepo, enrichmentRepo, nil, nil)
+		// The cadence-present branch routes through CadenceUpdater and writes
+		// the node label inside the same tx — wire cadence on both services.
+		cadenceUpdater := wireCadenceUpdaterForTest(t, database, svc)
+		enrichSvc.SetCadenceUpdater(cadenceUpdater)
+
+		spec := gen.Contact()
+		contact, _, err := svc.CreateContact(ctx, repository.CreateContactRequest{
+			FullName: spec.FullName,
+		}, nil)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = contactRepo.HardDeleteContact(ctx, contact.ID) })
+
+		display := gen.Prefix() + "ext-display-cad"
+		external, err := externalRepo.Upsert(ctx, repository.UpsertExternalContactRequest{
+			Source:      "google",
+			SourceID:    gen.Prefix() + "ext-src-cad",
+			DisplayName: &display,
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = externalRepo.Delete(ctx, external.ID) })
+
+		// name + cadence → the cadence-tx branch; the node label sync rides the
+		// same tx as the contact update.
+		renamed := gen.Prefix() + "enriched-cad-renamed"
+		monthly := "monthly"
+		_, err = enrichSvc.EnrichContactFromExternalWithSelections(ctx, contact.ID, external, nil, nil, &monthly, &renamed)
+		require.NoError(t, err)
+
+		node, err := support.GetNodeForContact(ctx, contact.ID)
+		require.NoError(t, err)
+		assert.Equal(t, renamed, node.CanonicalLabel, "cadence-path enrichment rename syncs the node label")
 	})
 
 	t.Run("merge with a new name syncs the target node label", func(t *testing.T) {
@@ -378,4 +427,27 @@ func TestContactNodeDualWrite_MigrationDownUp(t *testing.T) {
 	require.NoError(t, err, "the up backfill restores the person node for the surviving contact")
 	assert.Equal(t, repository.NodeTypePerson, restored.Type)
 	assert.Equal(t, unreferenced.FullName, restored.CanonicalLabel)
+}
+
+// TestContactNodeDualWrite_HarnessSeedCreatesNode confirms the synthetic
+// harness's SeedContact — which drives the real ContactService.CreateContact —
+// implicitly dual-writes a person node, and that the harness teardown removes
+// it (the cleanup step added alongside the dual-write). SLOW-gated because the
+// harness spins up a River client.
+func TestContactNodeDualWrite_HarnessSeedCreatesNode(t *testing.T) {
+	testsupport.RequireLongTests(t)
+	database, ctx := newSyntheticDB(t)
+
+	h := synthetic.NewHarnessForNamespace(t, ctx, database, syntheticNS(t), factory.DefaultSeed)
+	support := repository.NewSyntheticSupportRepository(h.Database().Queries)
+
+	spec := h.Generator().Contact()
+	contact, err := h.SeedContact(ctx, spec)
+	require.NoError(t, err)
+
+	node, err := support.GetNodeForContact(ctx, contact.ID)
+	require.NoError(t, err, "SeedContact must dual-write a person node")
+	assert.Equal(t, contact.ID, node.ID)
+	assert.Equal(t, repository.NodeTypePerson, node.Type)
+	assert.Equal(t, contact.FullName, node.CanonicalLabel)
 }


### PR DESCRIPTION
PR5 of the SP1 Relationship Data Model delivery (Bucket A, additive backend). Establishes the `contact.id == node.id` invariant so the assertion write API (PR4) can resolve every existing contact's subject node.

## Changes

- **Migration `068_backfill_person_nodes`** (explicit `BEGIN;…COMMIT;`): UP backfills one `node(type='person', canonical_label=full_name, created_at)` per non-deleted contact at the contact's own id, `ON CONFLICT (id) DO NOTHING`. DOWN is a **guarded delete** — removes only person nodes that are not merged-away, not referenced by another node's `merged_into`, and referenced by no assertion (subject or object).
- **Dual-write**: `ContactService.CreateContact` creates the person node in its existing tx. All four `full_name` writers — `CreateContact`, `UpdateContact`, `MergeContacts`, and both `EnrichmentService` entry points — sync `node.canonical_label` **unconditionally within a single transaction**, so contact and node never diverge (even under concurrent renames).
- **Synthetic toolkit**: `SyntheticGetNodeForContact` / `SyntheticCountContactsByFullName` / `SyntheticDeleteNodesByIds` test-support reads; the replay harness teardown now deletes the dual-written person node.
- **architecture.md**: documents the `contact.id == node.id` invariant.

## Note on the 068 DOWN guard (plan divergence, intentional)

The plan's literal DOWN clause guards only against assertion references. This PR's DOWN adds a **merge-winner guard** beyond that literal clause: it also skips any person node still referenced by another node's `merged_into` self-FK. This is a correctness necessity — a merge winner has `merged_into IS NULL` and may carry no assertion, so without this guard the DOWN would FK-violate against the preserved loser's `merged_into` reference (the self-FK is restrict). The guard is documented inline in `068_backfill_person_nodes.down.sql` and pinned by a winner/loser test case. Flagging it here so the divergence from the plan's literal SQL is traceable.

## Test plan

- Integration (`contact_node_dualwrite_integration_test.go`): create writes a person node at the contact's id; rename (name-only and rename+cadence) syncs the label; enrichment rename (±cadence and no-name) syncs the label; merge `new_name` syncs the target label; tx rollback leaves no node and no contact.
- Migration down/up round-trip on an ephemeral clone: the guarded DOWN preserves assertion-subject, assertion-object, merge-winner, and merge-loser nodes while deleting the unreferenced one; the UP re-backfill restores the surviving contact's node AND **skips a soft-deleted contact** (pins the `WHERE deleted_at IS NULL` invariant — verified the test fails if the clause is dropped).
- SLOW-gated harness test: `SeedContact` (real service path) implicitly dual-writes the node.

Plan: `.ai/log/plan/sp1-relationship-data-model.md` (§1 D7, §2 PR5).