### PR TITLE
feat(graph): SP1 assert() write API + events + rollover worker

### DIFF
--- a/.ai/guides/architecture.md
+++ b/.ai/guides/architecture.md
@@ -254,6 +254,7 @@ scheduler runs on top of `github.com/riverqueue/river` periodic jobs.
 | `scheduler_tick` | Every 5 min (`RunOnStart: true`) | SchedulerTickWorker enumerates due `external_sync_state` rows and enqueues one `sync_provider_account` river job per account. |
 | `sync_provider_account` | Dispatched on-demand | SyncProviderAccountWorker calls `syncService.RunAccountSync(source, accountID)` for a single account. River's lease + rescuer provides durable crash-recovery. |
 | `sync_staleness_watchdog` | Every 5 min (`RunOnStart: true`) | StalenessWatchdogWorker compares per-source freshness timestamps (`external_sync_state` last-success/error + `mac_host.source_health` last-pushed + `mac_host.last_heartbeat_at`) against config-backed `SYNC_STALENESS_*` thresholds and reconciles breaches into `sync_staleness_breach`. Registered unconditionally (independent of `ENABLE_EXTERNAL_SYNC`). Read via `GET /api/v1/sync/staleness`. |
+| `assertion_rollover` | Daily | AssertionRolloverWorker (SP1 graph) terminalizes bounded-with-pending-successor assertions whose `valid_to` has passed: rows matching `status='accepted' AND knowledge_to IS NULL AND superseded_by IS NOT NULL AND valid_to <= now` flip to `status='superseded'`, `closure_reason='superseded'`, `knowledge_to=now`, emitting `assertion.superseded` per row. Stateless catch-up sweep; never touches successor-less bounded-past facts. |
 
 Dedup is done in a repository helper
 (`EnqueueAccountSyncIfNotInFlight`) that wraps
@@ -705,6 +706,8 @@ Concrete writer → kind mapping:
 | `RematchDispatcher` | `contact_methods.added` | Serializes per-contact rematch via `contactLocks` and runs `RematchService.Run` |
 
 The InteractionRecorder invokes CadenceUpdater + FollowUpManager **inline** after `bus.PublishTx` so cadence + follow-up state apply synchronously in the caller's tx. The queued river workers for the same event become durable no-ops via `event_consumer_claim` when they eventually run. This pattern closes the queued-worker replay hole while keeping per-consumer retries available.
+
+**SP1 graph assertion events.** `AssertService` emits five `assertion.*` kinds — `assertion.proposed`, `assertion.accepted`, `assertion.superseded`, `assertion.rejected`, `assertion.provenance_added` — onto the same bus via `PublishTx`, idempotency-keyed on `<assertion_id>:<transition>` (and `<assertion_id>:provenance:<locator_hash>` for the many-per-assertion provenance kind). They have **no consumer in SP1** (`consumerJobsForKind` returns nil for them); the change-feed, embedding, `relationship_signal`-recompute, projection-cache, and review-surface consumers are SP3/SP4. A `Retract` emits `assertion.superseded` (closure_reason distinguishes it; there is no separate `assertion.retracted` kind).
 
 ### Sole-Writer Map
 

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -392,6 +392,17 @@ func run() int {
 	// Initialize services
 	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, eventBus, rematchService)
 
+	// Graph (SP1) write API — the single validated assert() write path over the
+	// node/entity/predicate/assertion store. SP1 ships the service + the daily
+	// rollover worker (registered below); no HTTP handler yet (SP3/SP4 consume it).
+	graphNodeRepo := repository.NewNodeRepository(database.Queries)
+	graphEntityRepo := repository.NewEntityRepository(database.Queries)
+	graphPredicateRepo := repository.NewPredicateRepository(database.Queries)
+	graphAssertionRepo := repository.NewAssertionRepository(database.Queries)
+	assertService := service.NewAssertService(
+		database.Pool, graphNodeRepo, graphEntityRepo, graphPredicateRepo, graphAssertionRepo, eventBus,
+	)
+
 	// Telegram message repo construction (hoisted above the
 	// InteractionRecorder wiring so the consumer can mark messages
 	// processed in the same tx as the interaction insert).
@@ -1320,6 +1331,19 @@ func run() int {
 		river.PeriodicInterval(5*time.Minute),
 		func() (river.JobArgs, *river.InsertOpts) {
 			return scheduler.StalenessWatchdogArgs{}, nil
+		},
+		&river.PeriodicJobOpts{RunOnStart: true},
+	))
+
+	// Assertion valid-time rollover — a daily catch-up sweep that terminalizes the
+	// bounded-with-pending-successor assertions whose valid_to has passed (no event
+	// fires at that future date otherwise). Stateless; RunOnStart catches up any
+	// overdue rollovers on boot.
+	river.AddWorker(riverWorkers, scheduler.NewAssertionRolloverWorker(assertService))
+	riverClient.PeriodicJobs().Add(river.NewPeriodicJob(
+		river.PeriodicInterval(24*time.Hour),
+		func() (river.JobArgs, *river.InsertOpts) {
+			return scheduler.AssertionRolloverArgs{}, nil
 		},
 		&river.PeriodicJobOpts{RunOnStart: true},
 	))

--- a/backend/internal/db/assertion.sql.go
+++ b/backend/internal/db/assertion.sql.go
@@ -627,7 +627,7 @@ const RolloverDueBoundedSuccessors = `-- name: RolloverDueBoundedSuccessors :man
 UPDATE assertion
 SET status = 'superseded',
     closure_reason = 'superseded',
-    knowledge_to = $1
+    knowledge_to = GREATEST($1::timestamptz, knowledge_from)
 WHERE status = 'accepted'
   AND knowledge_to IS NULL
   AND superseded_by IS NOT NULL
@@ -639,10 +639,13 @@ RETURNING id, subject_node_id, predicate_key, object_node_id, value_text, value_
 // The rollover job: terminalize the bounded-with-pending-successor rows whose
 // bound has been reached. Scoped TIGHT — superseded_by IS NOT NULL excludes
 // successor-less historical accepted facts (which simply aren't current). Sets
-// status='superseded', closure_reason='superseded', knowledge_to=$1; returns the
-// updated rows so the caller can emit one assertion.superseded event per row.
-func (q *Queries) RolloverDueBoundedSuccessors(ctx context.Context, knowledgeTo pgtype.Timestamptz) ([]*Assertion, error) {
-	rows, err := q.db.Query(ctx, RolloverDueBoundedSuccessors, knowledgeTo)
+// status='superseded', closure_reason='superseded'. knowledge_to is
+// GREATEST(now, knowledge_from) so a row whose knowledge_from was set in the
+// future via a KnowledgeFromOverride does not violate the assertion_knowledge_range
+// CHECK and abort the whole sweep. Returns the updated rows so the caller can emit
+// one assertion.superseded event per row.
+func (q *Queries) RolloverDueBoundedSuccessors(ctx context.Context, now pgtype.Timestamptz) ([]*Assertion, error) {
+	rows, err := q.db.Query(ctx, RolloverDueBoundedSuccessors, now)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/db/assertion.sql.go
+++ b/backend/internal/db/assertion.sql.go
@@ -295,6 +295,42 @@ func (q *Queries) GetAssertion(ctx context.Context, id pgtype.UUID) (*Assertion,
 	return &i, err
 }
 
+const GetAssertionForUpdate = `-- name: GetAssertionForUpdate :one
+SELECT id, subject_node_id, predicate_key, object_node_id, value_text, value_num, value_date, value_bool, valid_from, valid_to, knowledge_from, knowledge_to, confidence, salience, status, closure_reason, superseded_by, trust_tier, proposition_key, created_at FROM assertion WHERE id = $1 FOR UPDATE
+`
+
+// Row-locking read for the lifecycle transitions (Accept/Reject/Retract): the
+// caller locks the row FOR UPDATE so the status precondition check + the status
+// update are atomic within the tx (a concurrent Accept/Reject on the same row
+// blocks until commit, so the from-status guard cannot be raced).
+func (q *Queries) GetAssertionForUpdate(ctx context.Context, id pgtype.UUID) (*Assertion, error) {
+	row := q.db.QueryRow(ctx, GetAssertionForUpdate, id)
+	var i Assertion
+	err := row.Scan(
+		&i.ID,
+		&i.SubjectNodeID,
+		&i.PredicateKey,
+		&i.ObjectNodeID,
+		&i.ValueText,
+		&i.ValueNum,
+		&i.ValueDate,
+		&i.ValueBool,
+		&i.ValidFrom,
+		&i.ValidTo,
+		&i.KnowledgeFrom,
+		&i.KnowledgeTo,
+		&i.Confidence,
+		&i.Salience,
+		&i.Status,
+		&i.ClosureReason,
+		&i.SupersededBy,
+		&i.TrustTier,
+		&i.PropositionKey,
+		&i.CreatedAt,
+	)
+	return &i, err
+}
+
 const GetCurrentAccepted = `-- name: GetCurrentAccepted :one
 SELECT id, subject_node_id, predicate_key, object_node_id, value_text, value_num, value_date, value_bool, valid_from, valid_to, knowledge_from, knowledge_to, confidence, salience, status, closure_reason, superseded_by, trust_tier, proposition_key, created_at FROM assertion
 WHERE subject_node_id = $1

--- a/backend/internal/db/assertion_provenance.sql.go
+++ b/backend/internal/db/assertion_provenance.sql.go
@@ -40,12 +40,16 @@ func (q *Queries) ExistsCalendarEvent(ctx context.Context, id pgtype.UUID) (bool
 }
 
 const ExistsCommsMessage = `-- name: ExistsCommsMessage :one
-SELECT EXISTS(SELECT 1 FROM comms_message WHERE id = $1)
+SELECT EXISTS(SELECT 1 FROM comms_message WHERE id = $1 AND deleted_at IS NULL)
 `
 
 // Write-time existence validation: confirm a content source row exists before
 // accepting a provenance locator that references it. One tiny query per content
-// table; source_id is parsed to UUID by the caller.
+// table; source_id is parsed to UUID by the caller. The four soft-deletable
+// content tables filter deleted_at so an already-tombstoned source row does not
+// pass write-time validation (a NEW assertion may not be grounded in a dead
+// source; a source deleted AFTER the assertion degrades gracefully via the
+// preserved quote/input_hash). calendar_event/phone_call have no deleted_at.
 func (q *Queries) ExistsCommsMessage(ctx context.Context, id pgtype.UUID) (bool, error) {
 	row := q.db.QueryRow(ctx, ExistsCommsMessage, id)
 	var exists bool
@@ -54,7 +58,7 @@ func (q *Queries) ExistsCommsMessage(ctx context.Context, id pgtype.UUID) (bool,
 }
 
 const ExistsMeetingNote = `-- name: ExistsMeetingNote :one
-SELECT EXISTS(SELECT 1 FROM meeting_note WHERE id = $1)
+SELECT EXISTS(SELECT 1 FROM meeting_note WHERE id = $1 AND deleted_at IS NULL)
 `
 
 func (q *Queries) ExistsMeetingNote(ctx context.Context, id pgtype.UUID) (bool, error) {
@@ -65,7 +69,7 @@ func (q *Queries) ExistsMeetingNote(ctx context.Context, id pgtype.UUID) (bool, 
 }
 
 const ExistsMessagesMessage = `-- name: ExistsMessagesMessage :one
-SELECT EXISTS(SELECT 1 FROM messages_message WHERE id = $1)
+SELECT EXISTS(SELECT 1 FROM messages_message WHERE id = $1 AND deleted_at IS NULL)
 `
 
 func (q *Queries) ExistsMessagesMessage(ctx context.Context, id pgtype.UUID) (bool, error) {
@@ -87,7 +91,7 @@ func (q *Queries) ExistsPhoneCall(ctx context.Context, id pgtype.UUID) (bool, er
 }
 
 const ExistsTelegramMessage = `-- name: ExistsTelegramMessage :one
-SELECT EXISTS(SELECT 1 FROM telegram_message WHERE id = $1)
+SELECT EXISTS(SELECT 1 FROM telegram_message WHERE id = $1 AND deleted_at IS NULL)
 `
 
 func (q *Queries) ExistsTelegramMessage(ctx context.Context, id pgtype.UUID) (bool, error) {

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -1450,9 +1450,12 @@ type Querier interface {
 	// The rollover job: terminalize the bounded-with-pending-successor rows whose
 	// bound has been reached. Scoped TIGHT — superseded_by IS NOT NULL excludes
 	// successor-less historical accepted facts (which simply aren't current). Sets
-	// status='superseded', closure_reason='superseded', knowledge_to=$1; returns the
-	// updated rows so the caller can emit one assertion.superseded event per row.
-	RolloverDueBoundedSuccessors(ctx context.Context, knowledgeTo pgtype.Timestamptz) ([]*Assertion, error)
+	// status='superseded', closure_reason='superseded'. knowledge_to is
+	// GREATEST(now, knowledge_from) so a row whose knowledge_from was set in the
+	// future via a KnowledgeFromOverride does not violate the assertion_knowledge_range
+	// CHECK and abort the whole sweep. Returns the updated rows so the caller can emit
+	// one assertion.superseded event per row.
+	RolloverDueBoundedSuccessors(ctx context.Context, now pgtype.Timestamptz) ([]*Assertion, error)
 	// Atomically replaces api_key_hash and bumps api_key_rotated_at. Used
 	// by the rotate-key endpoint. Filters revoked hosts so a revoked host
 	// cannot be silently re-activated by a rotation.

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -455,7 +455,11 @@ type Querier interface {
 	ExistsCalendarEvent(ctx context.Context, id pgtype.UUID) (bool, error)
 	// Write-time existence validation: confirm a content source row exists before
 	// accepting a provenance locator that references it. One tiny query per content
-	// table; source_id is parsed to UUID by the caller.
+	// table; source_id is parsed to UUID by the caller. The four soft-deletable
+	// content tables filter deleted_at so an already-tombstoned source row does not
+	// pass write-time validation (a NEW assertion may not be grounded in a dead
+	// source; a source deleted AFTER the assertion degrades gracefully via the
+	// preserved quote/input_hash). calendar_event/phone_call have no deleted_at.
 	ExistsCommsMessage(ctx context.Context, id pgtype.UUID) (bool, error)
 	// Non-mutating lookup. Returns true when a claim row exists for the
 	// given (event_id, consumer). Useful for assertions in tests and for

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -635,6 +635,11 @@ type Querier interface {
 	// in GetMacHostCursorEpoch below.
 	GetActiveMacHostByIDForUpdate(ctx context.Context, id pgtype.UUID) (*MacHost, error)
 	GetAssertion(ctx context.Context, id pgtype.UUID) (*Assertion, error)
+	// Row-locking read for the lifecycle transitions (Accept/Reject/Retract): the
+	// caller locks the row FOR UPDATE so the status precondition check + the status
+	// update are atomic within the tx (a concurrent Accept/Reject on the same row
+	// blocks until commit, so the from-status guard cannot be raced).
+	GetAssertionForUpdate(ctx context.Context, id pgtype.UUID) (*Assertion, error)
 	// Look up an event by its Google Calendar ID
 	GetCalendarEventByGcalID(ctx context.Context, arg GetCalendarEventByGcalIDParams) (*CalendarEvent, error)
 	// Look up an event by its UUID

--- a/backend/internal/db/queries/assertion.sql
+++ b/backend/internal/db/queries/assertion.sql
@@ -24,6 +24,13 @@ RETURNING *;
 -- name: GetAssertion :one
 SELECT * FROM assertion WHERE id = $1;
 
+-- name: GetAssertionForUpdate :one
+-- Row-locking read for the lifecycle transitions (Accept/Reject/Retract): the
+-- caller locks the row FOR UPDATE so the status precondition check + the status
+-- update are atomic within the tx (a concurrent Accept/Reject on the same row
+-- blocks until commit, so the from-status guard cannot be raced).
+SELECT * FROM assertion WHERE id = $1 FOR UPDATE;
+
 -- name: FindLiveProposition :one
 -- The dedup lookup: the single LIVE assertion (proposed or accepted, not yet
 -- knowledge-closed) for a proposition_key. Backed by idx_assertion_live_proposition.

--- a/backend/internal/db/queries/assertion.sql
+++ b/backend/internal/db/queries/assertion.sql
@@ -111,17 +111,20 @@ WHERE id = $1;
 -- The rollover job: terminalize the bounded-with-pending-successor rows whose
 -- bound has been reached. Scoped TIGHT — superseded_by IS NOT NULL excludes
 -- successor-less historical accepted facts (which simply aren't current). Sets
--- status='superseded', closure_reason='superseded', knowledge_to=$1; returns the
--- updated rows so the caller can emit one assertion.superseded event per row.
+-- status='superseded', closure_reason='superseded'. knowledge_to is
+-- GREATEST(now, knowledge_from) so a row whose knowledge_from was set in the
+-- future via a KnowledgeFromOverride does not violate the assertion_knowledge_range
+-- CHECK and abort the whole sweep. Returns the updated rows so the caller can emit
+-- one assertion.superseded event per row.
 UPDATE assertion
 SET status = 'superseded',
     closure_reason = 'superseded',
-    knowledge_to = $1
+    knowledge_to = GREATEST(sqlc.arg(now)::timestamptz, knowledge_from)
 WHERE status = 'accepted'
   AND knowledge_to IS NULL
   AND superseded_by IS NOT NULL
   AND valid_to IS NOT NULL
-  AND valid_to <= $1
+  AND valid_to <= sqlc.arg(now)
 RETURNING *;
 
 -- name: TransitionStatus :exec

--- a/backend/internal/db/queries/assertion_provenance.sql
+++ b/backend/internal/db/queries/assertion_provenance.sql
@@ -43,17 +43,21 @@ WHERE assertion_id = $1 AND locator_hash = $2;
 -- name: ExistsCommsMessage :one
 -- Write-time existence validation: confirm a content source row exists before
 -- accepting a provenance locator that references it. One tiny query per content
--- table; source_id is parsed to UUID by the caller.
-SELECT EXISTS(SELECT 1 FROM comms_message WHERE id = $1);
+-- table; source_id is parsed to UUID by the caller. The four soft-deletable
+-- content tables filter deleted_at so an already-tombstoned source row does not
+-- pass write-time validation (a NEW assertion may not be grounded in a dead
+-- source; a source deleted AFTER the assertion degrades gracefully via the
+-- preserved quote/input_hash). calendar_event/phone_call have no deleted_at.
+SELECT EXISTS(SELECT 1 FROM comms_message WHERE id = $1 AND deleted_at IS NULL);
 
 -- name: ExistsTelegramMessage :one
-SELECT EXISTS(SELECT 1 FROM telegram_message WHERE id = $1);
+SELECT EXISTS(SELECT 1 FROM telegram_message WHERE id = $1 AND deleted_at IS NULL);
 
 -- name: ExistsMessagesMessage :one
-SELECT EXISTS(SELECT 1 FROM messages_message WHERE id = $1);
+SELECT EXISTS(SELECT 1 FROM messages_message WHERE id = $1 AND deleted_at IS NULL);
 
 -- name: ExistsMeetingNote :one
-SELECT EXISTS(SELECT 1 FROM meeting_note WHERE id = $1);
+SELECT EXISTS(SELECT 1 FROM meeting_note WHERE id = $1 AND deleted_at IS NULL);
 
 -- name: ExistsCalendarEvent :one
 SELECT EXISTS(SELECT 1 FROM calendar_event WHERE id = $1);

--- a/backend/internal/events/bus.go
+++ b/backend/internal/events/bus.go
@@ -129,6 +129,14 @@ func consumerJobsForKind(env *Envelope) ([]consumerJob, error) {
 				},
 			},
 		}}, nil
+	case KindAssertionProposed, KindAssertionAccepted, KindAssertionSuperseded,
+		KindAssertionRejected, KindAssertionProvenanceAdded:
+		// SP1 ships the assertion store + write contract only — no consumer.
+		// The events land durably in the event log for audit + (source,
+		// source_id) idempotency; a later layer routes accepted/superseded to
+		// the projection-cache worker. An explicit no-consumer case (over the
+		// fallthrough) documents the deliberate decision.
+		return nil, nil
 	}
 	return nil, nil
 }

--- a/backend/internal/events/kinds.go
+++ b/backend/internal/events/kinds.go
@@ -80,6 +80,26 @@ const (
 	// exists for audit + (source, source_id) dedup on retries.
 	KindCallReceived Kind = "call.received"
 	KindCallSent     Kind = "call.sent"
+
+	// Assertion lifecycle events — published by AssertService inside the
+	// write transaction (source="assertion"). They carry a lightweight
+	// payload (AssertionEventPayload: ids + predicate key); the full
+	// assertion row lives in the assertion table. NONE has a registered
+	// consumer in consumerJobsForKind in SP1 — publishing them is durable
+	// but unconsumed (the event-log row lands, no job is enqueued). A later
+	// layer routes accepted/superseded to a projection-cache worker.
+	//
+	// The source_id keys are one-shot per transition
+	// ('<assertion_id>:<transition>') except provenance_added, which is
+	// many-per-assertion ('<assertion_id>:provenance:<locator_hash>'). A
+	// Retract emits KindAssertionSuperseded (the closure of an accepted row
+	// with no successor is operationally a supersession); there is no
+	// separate retracted kind.
+	KindAssertionProposed        Kind = "assertion.proposed"
+	KindAssertionAccepted        Kind = "assertion.accepted"
+	KindAssertionSuperseded      Kind = "assertion.superseded"
+	KindAssertionRejected        Kind = "assertion.rejected"
+	KindAssertionProvenanceAdded Kind = "assertion.provenance_added"
 )
 
 // AllKinds enumerates every defined Kind. Used by tests to guard that
@@ -106,6 +126,11 @@ var AllKinds = []Kind{
 	KindMeetingNoteDeleted,
 	KindCallReceived,
 	KindCallSent,
+	KindAssertionProposed,
+	KindAssertionAccepted,
+	KindAssertionSuperseded,
+	KindAssertionRejected,
+	KindAssertionProvenanceAdded,
 }
 
 // Envelope is the wire/DB shape passed through Bus.Publish. Payload is
@@ -530,6 +555,20 @@ type CallPayload struct {
 	StartedAt       time.Time `json:"started_at"`         // ZDATE converted to UTC
 }
 
+// AssertionEventPayload is the shared payload for all five assertion lifecycle
+// kinds (proposed/accepted/superseded/rejected/provenance_added). It is
+// deliberately lightweight: the full bi-temporal row lives in the assertion
+// table, so consumers (none in SP1) decode this to learn WHICH assertion changed
+// and re-read the row for detail. PredicateKey lets a kind-routed projection
+// consumer filter by predicate without a DB round-trip. One struct serves all
+// five kinds — the kind is the discriminator (mirroring email.received/sent).
+type AssertionEventPayload struct {
+	Version       int       `json:"version"` // start at 1
+	AssertionID   uuid.UUID `json:"assertion_id"`
+	SubjectNodeID uuid.UUID `json:"subject_node_id"`
+	PredicateKey  string    `json:"predicate_key"`
+}
+
 // kindPayloadTypes is the canonical Kind → payload-type registry used by
 // Marshal and Unmarshal to assert type-vs-kind consistency at runtime. Add
 // a row each time a new Kind + payload struct are introduced. Keep in sync
@@ -556,6 +595,13 @@ var kindPayloadTypes = map[Kind]reflect.Type{
 	KindMeetingNoteDeleted:      reflect.TypeOf(MeetingNoteDeletedPayload{}),
 	KindCallReceived:            reflect.TypeOf(CallPayload{}),
 	KindCallSent:                reflect.TypeOf(CallPayload{}),
+	// All five assertion kinds share AssertionEventPayload (the kind is the
+	// discriminator). Multiple kinds → one payload type is supported.
+	KindAssertionProposed:        reflect.TypeOf(AssertionEventPayload{}),
+	KindAssertionAccepted:        reflect.TypeOf(AssertionEventPayload{}),
+	KindAssertionSuperseded:      reflect.TypeOf(AssertionEventPayload{}),
+	KindAssertionRejected:        reflect.TypeOf(AssertionEventPayload{}),
+	KindAssertionProvenanceAdded: reflect.TypeOf(AssertionEventPayload{}),
 }
 
 // IsKnownKind reports whether kind has a registered payload type. Used by

--- a/backend/internal/events/kinds_test.go
+++ b/backend/internal/events/kinds_test.go
@@ -597,9 +597,10 @@ func TestKindPayloadTypes_CoversAllKinds(t *testing.T) {
 // external_contact.* kinds (iCloud Contacts source), plus the two
 // meeting_note.* kinds (anarlog_sessions source), plus the two call.*
 // kinds (phone_calls source, v1.5), plus the two email.* kinds (Gmail
-// source, published by GmailSyncProvider).
+// source, published by GmailSyncProvider), plus the five assertion.*
+// lifecycle kinds (graph foundation, published by AssertService).
 func TestAllKinds_ExpectedCount(t *testing.T) {
-	require.Len(t, AllKinds, 20)
+	require.Len(t, AllKinds, 25)
 }
 
 // TestIsKnownKind_CoversAllKinds is the positive side: every Kind declared
@@ -733,6 +734,14 @@ func buildCanonicalPayload(t *testing.T, kind Kind) json.RawMessage {
 			PeerNormalized: "+15551234567", Service: "facetime_audio", Direction: "outbound",
 			Answered: nil, HasVoicemail: false, DurationSeconds: 120,
 			StartedAt: at,
+		})
+		require.NoError(t, err)
+		return raw
+	case KindAssertionProposed, KindAssertionAccepted, KindAssertionSuperseded,
+		KindAssertionRejected, KindAssertionProvenanceAdded:
+		raw, err := Marshal(kind, AssertionEventPayload{
+			Version: 1, AssertionID: uuid.New(), SubjectNodeID: uuid.New(),
+			PredicateKey: "lives_in",
 		})
 		require.NoError(t, err)
 		return raw

--- a/backend/internal/repository/assertion.go
+++ b/backend/internal/repository/assertion.go
@@ -597,7 +597,18 @@ func insertProvenance(ctx context.Context, q db.Querier, p InsertProvenanceParam
 
 // ListProvenance returns all locators for an assertion, oldest first.
 func (r *AssertionRepository) ListProvenance(ctx context.Context, assertionID uuid.UUID) ([]Provenance, error) {
-	rows, err := r.queries.ListProvenance(ctx, uuidToPgUUID(assertionID))
+	return listProvenance(ctx, r.queries, assertionID)
+}
+
+// ListProvenanceTx is the tx-bound variant of ListProvenance. The merge path uses
+// it so it sees a loser assertion's provenance written earlier in the SAME tx
+// (e.g. AssertTx then AcceptTx in one tx).
+func (r *AssertionRepository) ListProvenanceTx(ctx context.Context, tx pgx.Tx, assertionID uuid.UUID) ([]Provenance, error) {
+	return listProvenance(ctx, db.New(tx), assertionID)
+}
+
+func listProvenance(ctx context.Context, q db.Querier, assertionID uuid.UUID) ([]Provenance, error) {
+	rows, err := q.ListProvenance(ctx, uuidToPgUUID(assertionID))
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/repository/assertion.go
+++ b/backend/internal/repository/assertion.go
@@ -313,6 +313,21 @@ func (r *AssertionRepository) GetAssertionTx(ctx context.Context, tx pgx.Tx, id 
 	return getAssertion(ctx, db.New(tx), id)
 }
 
+// GetAssertionForUpdateTx reads + row-locks an assertion (SELECT … FOR UPDATE) so
+// a lifecycle transition's status-precondition check and the status update are
+// atomic within the tx. Tx-only (the lock is held until commit).
+func (r *AssertionRepository) GetAssertionForUpdateTx(ctx context.Context, tx pgx.Tx, id uuid.UUID) (*Assertion, error) {
+	row, err := db.New(tx).GetAssertionForUpdate(ctx, uuidToPgUUID(id))
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, db.ErrNotFound
+		}
+		return nil, err
+	}
+	a := convertDbAssertion(row)
+	return &a, nil
+}
+
 func getAssertion(ctx context.Context, q db.Querier, id uuid.UUID) (*Assertion, error) {
 	row, err := q.GetAssertion(ctx, uuidToPgUUID(id))
 	if err != nil {
@@ -634,20 +649,32 @@ func SourceKindRequiresExistenceCheck(sourceKind string) bool {
 // error rather than a silent false, so the caller cannot misread "no check
 // performed" as "row missing" — gate on SourceKindRequiresExistenceCheck first.
 func (r *AssertionRepository) ExistsContentRow(ctx context.Context, sourceKind string, id uuid.UUID) (bool, error) {
+	return existsContentRow(ctx, r.queries, sourceKind, id)
+}
+
+// ExistsContentRowTx is the tx-bound variant of ExistsContentRow. The write API
+// uses it so the existence check runs inside the assert tx — it sees a content row
+// created earlier in the same tx and is transactionally consistent with a
+// concurrent soft delete.
+func (r *AssertionRepository) ExistsContentRowTx(ctx context.Context, tx pgx.Tx, sourceKind string, id uuid.UUID) (bool, error) {
+	return existsContentRow(ctx, db.New(tx), sourceKind, id)
+}
+
+func existsContentRow(ctx context.Context, q db.Querier, sourceKind string, id uuid.UUID) (bool, error) {
 	pgID := uuidToPgUUID(id)
 	switch sourceKind {
 	case SourceKindCommsMessage:
-		return r.queries.ExistsCommsMessage(ctx, pgID)
+		return q.ExistsCommsMessage(ctx, pgID)
 	case SourceKindTelegramMessage:
-		return r.queries.ExistsTelegramMessage(ctx, pgID)
+		return q.ExistsTelegramMessage(ctx, pgID)
 	case SourceKindMessagesMessage:
-		return r.queries.ExistsMessagesMessage(ctx, pgID)
+		return q.ExistsMessagesMessage(ctx, pgID)
 	case SourceKindMeetingNote:
-		return r.queries.ExistsMeetingNote(ctx, pgID)
+		return q.ExistsMeetingNote(ctx, pgID)
 	case SourceKindCalendarEvent:
-		return r.queries.ExistsCalendarEvent(ctx, pgID)
+		return q.ExistsCalendarEvent(ctx, pgID)
 	case SourceKindPhoneCall:
-		return r.queries.ExistsPhoneCall(ctx, pgID)
+		return q.ExistsPhoneCall(ctx, pgID)
 	default:
 		return false, errors.New("ExistsContentRow called for a source kind with no backing-row check: " + sourceKind)
 	}

--- a/backend/internal/repository/entity.go
+++ b/backend/internal/repository/entity.go
@@ -117,7 +117,18 @@ func createEntity(ctx context.Context, q db.Querier, req CreateEntityRequest) (*
 
 // GetEntity retrieves an entity by its node id.
 func (r *EntityRepository) GetEntity(ctx context.Context, nodeID uuid.UUID) (*Entity, error) {
-	dbEntity, err := r.queries.GetEntity(ctx, uuidToPgUUID(nodeID))
+	return getEntity(ctx, r.queries, nodeID)
+}
+
+// GetEntityTx is the tx-bound variant of GetEntity. The write API resolves an
+// entity-subtype subject's subtype inside its tx so subject-type validation (e.g.
+// `within` place→place) sees in-tx state.
+func (r *EntityRepository) GetEntityTx(ctx context.Context, tx pgx.Tx, nodeID uuid.UUID) (*Entity, error) {
+	return getEntity(ctx, db.New(tx), nodeID)
+}
+
+func getEntity(ctx context.Context, q db.Querier, nodeID uuid.UUID) (*Entity, error) {
+	dbEntity, err := q.GetEntity(ctx, uuidToPgUUID(nodeID))
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, db.ErrNotFound

--- a/backend/internal/repository/node.go
+++ b/backend/internal/repository/node.go
@@ -86,7 +86,18 @@ func createNode(ctx context.Context, q db.Querier, id uuid.UUID, nodeType, canon
 
 // GetNode retrieves a live (non-soft-deleted) node by id.
 func (r *NodeRepository) GetNode(ctx context.Context, id uuid.UUID) (*Node, error) {
-	dbNode, err := r.queries.GetNode(ctx, uuidToPgUUID(id))
+	return getNode(ctx, r.queries, id)
+}
+
+// GetNodeTx is the tx-bound variant of GetNode. The write API reads the subject/
+// object node inside its tx so the existence + soft-delete check sees in-tx state
+// (e.g. a latent person node created earlier in the same tx).
+func (r *NodeRepository) GetNodeTx(ctx context.Context, tx pgx.Tx, id uuid.UUID) (*Node, error) {
+	return getNode(ctx, db.New(tx), id)
+}
+
+func getNode(ctx context.Context, q db.Querier, id uuid.UUID) (*Node, error) {
+	dbNode, err := q.GetNode(ctx, uuidToPgUUID(id))
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, db.ErrNotFound

--- a/backend/internal/scheduler/args.go
+++ b/backend/internal/scheduler/args.go
@@ -46,3 +46,12 @@ type StalenessWatchdogArgs struct{}
 
 // Kind implements river.JobArgs.
 func (StalenessWatchdogArgs) Kind() string { return "sync_staleness_watchdog" }
+
+// AssertionRolloverArgs are the args for the daily periodic
+// AssertionRolloverWorker. Stateless — the worker terminalizes the whole
+// due-bounded-successor set from current DB state each tick (a catch-up sweep),
+// so no per-tick parameters are resolved.
+type AssertionRolloverArgs struct{}
+
+// Kind implements river.JobArgs.
+func (AssertionRolloverArgs) Kind() string { return "assertion_rollover" }

--- a/backend/internal/scheduler/assertion_rollover_worker.go
+++ b/backend/internal/scheduler/assertion_rollover_worker.go
@@ -1,0 +1,58 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"personal-crm/backend/internal/logger"
+
+	"github.com/riverqueue/river"
+)
+
+// AssertionRollover is the narrow interface AssertionRolloverWorker needs. In
+// production this is *service.AssertService.
+type AssertionRollover interface {
+	RunRollover(ctx context.Context) (int, error)
+}
+
+// AssertionRolloverWorker periodically terminalizes the bounded-with-pending-
+// successor assertions whose valid_to has passed: the future-successor branch
+// bounds a prior (valid_to=future, superseded_by=successor) but leaves it accepted
+// until the date arrives, and no event fires at that future date — so this daily
+// sweep flips just those rows to superseded and emits assertion.superseded.
+//
+// Scoped TIGHT (in the SQL): it touches ONLY rows with superseded_by NOT NULL, so
+// a successor-less bounded-past historical fact is never terminalized. Stateless
+// catch-up — a row already rolled over no longer matches, so re-running after
+// downtime is safe and idempotent. Scheduled daily via the River periodic-job
+// framework (see cmd/crm-api/main.go).
+type AssertionRolloverWorker struct {
+	river.WorkerDefaults[AssertionRolloverArgs]
+	svc AssertionRollover
+}
+
+// NewAssertionRolloverWorker constructs the worker over the assert service.
+func NewAssertionRolloverWorker(svc AssertionRollover) *AssertionRolloverWorker {
+	return &AssertionRolloverWorker{svc: svc}
+}
+
+// Work implements river.Worker for AssertionRolloverArgs. Errors are wrapped and
+// returned so River retries the tick.
+func (w *AssertionRolloverWorker) Work(ctx context.Context, _ *river.Job[AssertionRolloverArgs]) error {
+	n, err := w.svc.RunRollover(ctx)
+	if err != nil {
+		return fmt.Errorf("run assertion rollover: %w", err)
+	}
+	if n > 0 {
+		logger.Info().Int("rolled_over", n).Msg("assertion rollover: terminalized bounded successors")
+	}
+	return nil
+}
+
+// Timeout caps each invocation. The sweep reads + updates a tight row set (the
+// due-bounded-successor rows) and emits one event each; 60s is generous at
+// single-user scale and prevents a pathological lock-wait from hanging a worker.
+func (*AssertionRolloverWorker) Timeout(*river.Job[AssertionRolloverArgs]) time.Duration {
+	return 60 * time.Second
+}

--- a/backend/internal/service/assert.go
+++ b/backend/internal/service/assert.go
@@ -384,6 +384,20 @@ func (s *AssertService) AssertTx(ctx context.Context, tx pgx.Tx, req AssertReque
 	// Determine the landing status (auto-apply vs always-confirm / force-confirm).
 	landingAccepted := predicate.DefaultReviewPolicy == repository.PredicateReviewAutoIfConfident && !req.ForceConfirm
 
+	// GLOBAL lock order — for a single-cardinality write that may land accepted,
+	// acquire the slot advisory lock(s) BEFORE any row read/lock (the dedup lookup
+	// below, the corroborate-upgrade row update, or writeNew's conflict probe). This
+	// keeps advisory-before-row across BOTH the match (corroborate→accept) and
+	// no-match (writeNew) paths, so a concurrent AcceptTx (which also locks advisory
+	// first) cannot deadlock against this tx. Re-acquisition deeper down is
+	// re-entrant (harmless). Multi-cardinality + proposed-landing writes take no slot
+	// lock.
+	if landingAccepted && predicate.Cardinality == repository.PredicateCardinalitySingle {
+		if err := s.acquireSlotLocks(ctx, tx, predicate, canonKey, canonSubject, canonObject); err != nil {
+			return nil, err
+		}
+	}
+
 	// Step 3: resolve proposition identity (dedup).
 	existing, err := s.assertionRepo.FindLivePropositionTx(ctx, tx, propKey)
 	if err != nil && !errors.Is(err, db.ErrNotFound) {
@@ -767,13 +781,15 @@ func (s *AssertService) writeNew(ctx context.Context, tx pgx.Tx, predicate *repo
 		effectiveFrom = req.ValidFrom.UTC()
 	}
 
-	// Single-cardinality + accepted-landing writes run the supersession check under
-	// the advisory lock. Multi or proposed-landing skip it. A past-bounded backfill
-	// (valid_to <= now) is a statement about the PAST → coexists, never supersedes.
+	// Single-cardinality + accepted-landing writes consult the slot. Multi or
+	// proposed-landing skip the slot entirely. A past-bounded backfill (valid_to <=
+	// now) is a statement about the PAST → it COEXISTS with a different-value current
+	// (never supersedes); but a SAME-value past stint still merges into the slot's
+	// same-value row (it is the same fact, just a non-contiguous interval).
 	needsConflictCheck := landingAccepted && predicate.Cardinality == repository.PredicateCardinalitySingle
 	pastBounded := req.ValidTo != nil && !req.ValidTo.UTC().After(now)
 
-	if needsConflictCheck && !pastBounded {
+	if needsConflictCheck {
 		// Acquire the advisory lock(s) BEFORE the conflict check (serializes the
 		// empty-slot race a FOR UPDATE cannot). For a symmetric-single predicate the
 		// invariant is per-participant → one lock per participant, taken in lock-key
@@ -788,32 +804,39 @@ func (s *AssertService) writeNew(ctx context.Context, tx pgx.Tx, predicate *repo
 			return nil, err
 		}
 
-		// Same-value reaffirmation: an overlapping accepted row with the SAME
-		// bucket-independent proposition signature is the SAME fact in a different
-		// bucket → widen it (no new row, no supersession).
+		// Same-value reaffirmation (runs even for a past-bounded write): overlapping
+		// accepted row(s) with the SAME bucket-independent proposition signature are
+		// the SAME fact in different buckets → widen ONE survivor over the union of all
+		// of them (no new row, no supersession). A new window can bridge several
+		// same-value stints; all merge.
 		newSignature := propositionSignature(canonKey, canonSubject, normalizedPayload(canonObject, req))
-		if widen := findSameValue(conflicts, newSignature); widen != nil {
-			return s.widenReaffirmation(ctx, tx, predicate, widen, canonKey, canonSubject, canonObject, req, effectiveFrom)
+		if same := sameValueConflicts(conflicts, newSignature); len(same) > 0 {
+			return s.widenReaffirmation(ctx, tx, predicate, same, canonKey, canonSubject, canonObject, req)
 		}
 
-		// Different-value conflict(s). Insert the new row first (insert-new-then-
-		// close-prior order under the DEFERRABLE self-FK), then close each prior.
-		inserted, recovered, err := s.insertNewAndEmit(ctx, tx, predicate, canonKey, canonSubject, canonObject, propKey, req, status, salience, knowledgeFrom, now, landingAccepted)
-		if err != nil {
-			return nil, err
-		}
-		if recovered {
-			// A concurrent writer won this slot; the loser corroborated its row.
-			// Conflict resolution against OTHER slots is the winner's job — skip it.
+		// No same-value match. A past-bounded backfill of a DIFFERENT value coexists
+		// (it is historical) — fall through to a plain insert. Otherwise this is a
+		// present/future successor: insert the new row first (insert-new-then-close-
+		// prior under the DEFERRABLE self-FK), then close each different-value prior.
+		if !pastBounded {
+			inserted, recovered, err := s.insertNewAndEmit(ctx, tx, predicate, canonKey, canonSubject, canonObject, propKey, req, status, salience, knowledgeFrom, now, landingAccepted)
+			if err != nil {
+				return nil, err
+			}
+			if recovered {
+				// A concurrent writer won this slot; the loser corroborated its row.
+				// Conflict resolution against OTHER slots is the winner's job — skip it.
+				return inserted, nil
+			}
+			if err := s.closeConflicts(ctx, tx, conflicts, inserted, effectiveFrom, now); err != nil {
+				return nil, err
+			}
 			return inserted, nil
 		}
-		if err := s.closeConflicts(ctx, tx, conflicts, inserted, effectiveFrom, now); err != nil {
-			return nil, err
-		}
-		return inserted, nil
 	}
 
-	// No conflict check (multi / proposed / past-bounded backfill) → just insert.
+	// Plain insert: multi / proposed-landing, OR a single-card past-bounded backfill
+	// of a different value (coexists, no supersession).
 	inserted, _, err := s.insertNewAndEmit(ctx, tx, predicate, canonKey, canonSubject, canonObject, propKey, req, status, salience, knowledgeFrom, now, landingAccepted)
 	return inserted, err
 }
@@ -889,15 +912,19 @@ func assertionSignature(a *repository.Assertion) string {
 	return propositionSignature(a.PredicateKey, a.SubjectNodeID, assertionNormalizedValue(a))
 }
 
-// findSameValue returns the first conflict row with the SAME bucket-independent
-// proposition signature as newSignature (a same-value reaffirmation), or nil.
-func findSameValue(conflicts []repository.Assertion, newSignature string) *repository.Assertion {
+// sameValueConflicts returns ALL conflict rows with the SAME bucket-independent
+// signature as newSignature. A new window can bridge several non-contiguous
+// same-value stints (e.g. X[2010,2015) + X[2020,∞) both overlap a new X[2012,2022));
+// every one must collapse into a single survivor, else the single-cardinality slot
+// would keep two live rows.
+func sameValueConflicts(conflicts []repository.Assertion, newSignature string) []*repository.Assertion {
+	var out []*repository.Assertion
 	for i := range conflicts {
 		if assertionSignature(&conflicts[i]) == newSignature {
-			return &conflicts[i]
+			out = append(out, &conflicts[i])
 		}
 	}
-	return nil
+	return out
 }
 
 // assertionNormalizedValue returns the normalized payload form of a stored
@@ -946,29 +973,36 @@ func (s *AssertService) acquireSlotLocks(ctx context.Context, tx pgx.Tx, predica
 	return nil
 }
 
-// widenReaffirmation extends a same-value accepted row's window to cover the new
-// evidence (lower valid_from / raise valid_to), recomputes its proposition_key
-// from the widened valid_from bucket, appends the new provenance, and emits
-// provenance_added. No new row, no supersession event. On a recomputed-key
-// collision with ANOTHER live same-value row (non-contiguous stints in different
-// buckets), it MERGES the two: provenance onto the survivor, close the other
-// superseded. The widened row is the survivor.
-func (s *AssertService) widenReaffirmation(ctx context.Context, tx pgx.Tx, predicate *repository.Predicate, existing *repository.Assertion, canonKey string, canonSubject uuid.UUID, canonObject *uuid.UUID, req *AssertRequest, effectiveFrom time.Time) (*repository.Assertion, error) {
-	// Union the windows. nil start = -inf (open), nil end = +inf (open). The new
-	// side uses the request's content bounds (effectiveFrom is the probe boundary,
-	// but the STORED widened window unions real evidence: a NULL new valid_from
-	// keeps the existing/open start).
-	widenedFrom := minStart(existing.ValidFrom, req.ValidFrom)
-	widenedTo := maxEnd(existing.ValidTo, req.ValidTo)
+// widenReaffirmation collapses one-or-more same-value accepted rows (same[0] is
+// the survivor; same[1:] are bridged stints) into a single survivor whose window
+// is the union of all of them + the new evidence, recomputes its proposition_key,
+// appends the new provenance, and emits provenance_added. No new row, no
+// supersession event for the survivor. The bridged rows + any recomputed-key
+// collider are MERGED (provenance moved, closed superseded). The widened row is
+// the survivor. A new window can bridge several non-contiguous same-value stints
+// (e.g. X[2010,2015)+X[2020,∞) under a new X[2012,2022)); all merge into one.
+func (s *AssertService) widenReaffirmation(ctx context.Context, tx pgx.Tx, predicate *repository.Predicate, same []*repository.Assertion, canonKey string, canonSubject uuid.UUID, canonObject *uuid.UUID, req *AssertRequest) (*repository.Assertion, error) {
+	survivor := same[0]
 
-	// If the existing row is bounded by a PENDING future successor (superseded_by
-	// set while still accepted, valid_to in the future), widening valid_to past that
-	// bound would un-bound it and leave TWO current rows once the successor's date
-	// passes. Re-affirming the same value must NOT clear that bound — keep the
-	// existing valid_to as the upper cap (only the backward lower-bound extension is
-	// safe). The pending successor remains the future value.
-	if existing.SupersededBy != nil {
-		widenedTo = utcPtr(existing.ValidTo)
+	// Union the survivor window with the new evidence + every bridged stint. nil
+	// start = -inf, nil end = +inf (open). Merge the bridged stints into the survivor
+	// first so the union covers them and the slot keeps exactly one live row.
+	widenedFrom := minStart(survivor.ValidFrom, req.ValidFrom)
+	widenedTo := maxEnd(survivor.ValidTo, req.ValidTo)
+	for _, other := range same[1:] {
+		widenedFrom = minStart(widenedFrom, other.ValidFrom)
+		widenedTo = maxEnd(widenedTo, other.ValidTo)
+		if err := s.mergeSameValue(ctx, tx, other, survivor); err != nil {
+			return nil, err
+		}
+	}
+
+	// If the survivor is bounded by a PENDING future successor (superseded_by set
+	// while still accepted), widening valid_to past that bound would un-bound it and
+	// leave two current rows once the successor's date passes. Keep the existing
+	// valid_to as the upper cap (only the backward lower-bound extension is safe).
+	if survivor.SupersededBy != nil {
+		widenedTo = utcPtr(survivor.ValidTo)
 	}
 
 	// Recompute the proposition_key from the widened valid_from bucket.
@@ -976,26 +1010,26 @@ func (s *AssertService) widenReaffirmation(ctx context.Context, tx pgx.Tx, predi
 	widenedReq.ValidFrom = widenedFrom
 	newKey := computePropositionKey(predicate, canonKey, canonSubject, canonObject, &widenedReq)
 
-	// Collision: another LIVE row already holds the recomputed key (a non-contiguous
-	// same-value stint in that bucket). Merge it into this survivor instead of
+	// Collision: another LIVE row (NOT in the overlap probe — e.g. a disjoint stint)
+	// already holds the recomputed key. Merge it into the survivor instead of
 	// UPDATE-ing into the unique index (which would 23505).
-	if newKey != existing.PropositionKey {
+	if newKey != survivor.PropositionKey {
 		collider, err := s.assertionRepo.FindLivePropositionTx(ctx, tx, newKey)
 		if err != nil && !errors.Is(err, db.ErrNotFound) {
 			return nil, fmt.Errorf("widen collision check: %w", err)
 		}
-		if err == nil && collider.ID != existing.ID {
-			// Union the survivor window with the collider's too, then merge.
+		if err == nil && collider.ID != survivor.ID {
 			widenedFrom = minStart(widenedFrom, collider.ValidFrom)
 			widenedTo = maxEnd(widenedTo, collider.ValidTo)
 			widenedReq.ValidFrom = widenedFrom
 			newKey = computePropositionKey(predicate, canonKey, canonSubject, canonObject, &widenedReq)
-			if err := s.mergeSameValue(ctx, tx, collider, existing); err != nil {
+			if err := s.mergeSameValue(ctx, tx, collider, survivor); err != nil {
 				return nil, err
 			}
 		}
 	}
 
+	existing := survivor
 	if err := s.assertionRepo.WidenAssertionValidityTx(ctx, tx, existing.ID, widenedFrom, widenedTo, newKey); err != nil {
 		return nil, fmt.Errorf("widen assertion validity: %w", err)
 	}
@@ -1196,35 +1230,47 @@ func (s *AssertService) resolveAcceptConflicts(ctx context.Context, tx pgx.Tx, p
 	if err != nil {
 		return nil, false, err
 	}
-	// Same-value reaffirmation at accept time: an overlapping accepted row with the
-	// SAME value is the same fact in a different bucket → WIDEN it to cover the
-	// accepting row's window and MERGE the accepting (proposed) row into it. Mirrors
-	// the writeNew widen rule (P1: Accept must widen, not supersede, a same value).
+	// Same-value reaffirmation at accept time: overlapping accepted row(s) with the
+	// SAME value are the same fact in different buckets → WIDEN one survivor over the
+	// union of all of them + the accepting row's window, MERGE the accepting
+	// (proposed) row and every bridged stint into the survivor. Mirrors the writeNew
+	// widen rule (P1: Accept must widen, not supersede, a same value; and a new
+	// window may bridge several same-value stints).
 	acceptingSignature := assertionSignature(accepting)
-	if existing := findSameValue(conflicts, acceptingSignature); existing != nil {
-		widenedFrom := minStart(existing.ValidFrom, accepting.ValidFrom)
-		widenedTo := maxEnd(existing.ValidTo, accepting.ValidTo)
-		// Do NOT clear a pending-successor bound (superseded_by set): widening the
-		// upper bound past it would leave two current rows once the successor date
-		// passes (mirrors widenReaffirmation). Only the backward lower-bound extends.
-		if existing.SupersededBy != nil {
-			widenedTo = utcPtr(existing.ValidTo)
+	if same := sameValueConflicts(conflicts, acceptingSignature); len(same) > 0 {
+		survivor := same[0]
+		widenedFrom := minStart(survivor.ValidFrom, accepting.ValidFrom)
+		widenedTo := maxEnd(survivor.ValidTo, accepting.ValidTo)
+		// Merge every bridged stint into the survivor (union windows + provenance,
+		// close them) so the single-cardinality slot keeps exactly one live row.
+		for _, other := range same[1:] {
+			widenedFrom = minStart(widenedFrom, other.ValidFrom)
+			widenedTo = maxEnd(widenedTo, other.ValidTo)
+			if err := s.mergeSameValue(ctx, tx, other, survivor); err != nil {
+				return nil, false, err
+			}
 		}
-		existing.ValidFrom = widenedFrom
-		existing.ValidTo = widenedTo
-		widenReq := &AssertRequest{ValidFrom: existing.ValidFrom}
+		// Do NOT clear a pending-successor bound (superseded_by set): widening past it
+		// would leave two current rows once the successor date passes (only the
+		// backward lower-bound extends). Mirrors widenReaffirmation.
+		if survivor.SupersededBy != nil {
+			widenedTo = utcPtr(survivor.ValidTo)
+		}
+		survivor.ValidFrom = widenedFrom
+		survivor.ValidTo = widenedTo
+		widenReq := &AssertRequest{ValidFrom: survivor.ValidFrom}
 		newKey := computePropositionKey(predicate, canonKey, canonSubject, canonObject, widenReq)
 		// MERGE/close the accepting (loser) row FIRST so it is no longer live —
 		// otherwise WidenAssertionValidity could assign the survivor a key the still-
 		// live accepting row holds and 23505 on idx_assertion_live_proposition.
-		if err := s.mergeSameValue(ctx, tx, accepting, existing); err != nil {
+		if err := s.mergeSameValue(ctx, tx, accepting, survivor); err != nil {
 			return nil, false, err
 		}
-		if err := s.assertionRepo.WidenAssertionValidityTx(ctx, tx, existing.ID, existing.ValidFrom, existing.ValidTo, newKey); err != nil {
+		if err := s.assertionRepo.WidenAssertionValidityTx(ctx, tx, survivor.ID, survivor.ValidFrom, survivor.ValidTo, newKey); err != nil {
 			return nil, false, fmt.Errorf("widen survivor at accept: %w", err)
 		}
-		existing.PropositionKey = newKey
-		return existing, true, nil
+		survivor.PropositionKey = newKey
+		return survivor, true, nil
 	}
 
 	return nil, false, s.closeConflicts(ctx, tx, conflicts, accepting, effectiveFrom, now)
@@ -1321,6 +1367,12 @@ func (s *AssertService) AssertClosureTx(ctx context.Context, tx pgx.Tx, req Clos
 		}
 		return fmt.Errorf("load current for closure: %w", err)
 	}
+	// knowledge_to >= the closed row's knowledge_from (a future KnowledgeFromOverride
+	// could otherwise push knowledge_from past now → assertion_knowledge_range CHECK).
+	knowledgeTo := now
+	if current.KnowledgeFrom.After(knowledgeTo) {
+		knowledgeTo = current.KnowledgeFrom.UTC()
+	}
 	closure := repository.ClosureReasonEnded
 	if err := s.assertionRepo.CloseAssertionTx(ctx, tx, repository.CloseAssertionParams{
 		ID:            current.ID,
@@ -1328,7 +1380,7 @@ func (s *AssertService) AssertClosureTx(ctx context.Context, tx pgx.Tx, req Clos
 		Status:        repository.AssertionStatusSuperseded,
 		ClosureReason: &closure,
 		SupersededBy:  nil,
-		KnowledgeTo:   &now,
+		KnowledgeTo:   &knowledgeTo,
 	}); err != nil {
 		return fmt.Errorf("close current on closure: %w", err)
 	}

--- a/backend/internal/service/assert.go
+++ b/backend/internal/service/assert.go
@@ -1012,6 +1012,10 @@ func (s *AssertService) mergeSameValue(ctx context.Context, tx pgx.Tx, loser, su
 		}
 	}
 	now := accelerated.GetCurrentTime().UTC()
+	knowledgeTo := now
+	if loser.KnowledgeFrom.After(knowledgeTo) {
+		knowledgeTo = loser.KnowledgeFrom.UTC()
+	}
 	closure := repository.ClosureReasonSuperseded
 	if err := s.assertionRepo.CloseAssertionTx(ctx, tx, repository.CloseAssertionParams{
 		ID:            loser.ID,
@@ -1019,7 +1023,7 @@ func (s *AssertService) mergeSameValue(ctx context.Context, tx pgx.Tx, loser, su
 		Status:        repository.AssertionStatusSuperseded,
 		ClosureReason: &closure,
 		SupersededBy:  &survivor.ID,
-		KnowledgeTo:   &now,
+		KnowledgeTo:   &knowledgeTo,
 	}); err != nil {
 		return fmt.Errorf("close merged loser: %w", err)
 	}
@@ -1043,33 +1047,52 @@ func (s *AssertService) closeConflicts(ctx context.Context, tx pgx.Tx, conflicts
 		if prior.ID == newRow.ID {
 			continue
 		}
-		// valid_range CHECK: effectiveFrom must be > prior.valid_from. A backfilled
-		// successor whose boundary precedes the prior's start is incoherent → REJECT.
-		if prior.ValidFrom != nil && !effectiveFrom.After(*prior.ValidFrom) {
-			return validationError("successor boundary %s is not after prior valid_from %s", effectiveFrom, prior.ValidFrom.UTC())
-		}
-		// A pending future successor (already bounded, valid_from in the future) that
-		// this present edit overrides is fully superseded regardless of the branch.
-		priorIsPendingFuture := prior.SupersededBy != nil && prior.ValidFrom != nil && prior.ValidFrom.After(now)
+		// A pending future successor (its valid_from is in the future → not yet
+		// current) that this present edit overrides is fully superseded regardless of
+		// the branch — it never becomes current. It is exempt from the bound-ordering
+		// guard below (it is closed at its own valid_from, not at effectiveFrom). A
+		// future-dated successor is identified by valid_from > now, NOT by carrying a
+		// superseded_by (it may be the tail of the chain with none).
+		priorIsPendingFuture := prior.ValidFrom != nil && prior.ValidFrom.After(now)
 
 		if future && !priorIsPendingFuture {
+			// Future-successor bound: the prior must START before the boundary, else
+			// bounding it to effectiveFrom would invert its range → REJECT.
+			if prior.ValidFrom != nil && !effectiveFrom.After(*prior.ValidFrom) {
+				return validationError("successor boundary %s is not after prior valid_from %s", effectiveFrom, prior.ValidFrom.UTC())
+			}
 			// Bound the still-current prior; keep it accepted (current until the date).
 			if err := s.assertionRepo.BoundPendingSuccessorTx(ctx, tx, prior.ID, effectiveFrom, newRow.ID); err != nil {
 				return fmt.Errorf("bound pending successor: %w", err)
 			}
 			continue
 		}
+
 		// Terminalize the prior (present edit, or a pending future successor a present
-		// edit cancels).
-		closure := repository.ClosureReasonSuperseded
+		// edit cancels). boundTo is effectiveFrom for a normally-overlapping prior, or
+		// the prior's own valid_from for a never-current pending-future row.
 		boundTo := closeBoundary(prior, effectiveFrom, now)
+		// Guard the valid_range CHECK for the terminalized prior too: if we stamp
+		// valid_to = effectiveFrom but the prior STARTS at/after that, the range would
+		// invert (an incoherent backfilled successor) → REJECT.
+		if !priorIsPendingFuture && prior.ValidFrom != nil && boundTo != nil && !boundTo.After(*prior.ValidFrom) {
+			return validationError("successor boundary %s is not after prior valid_from %s", boundTo.UTC(), prior.ValidFrom.UTC())
+		}
+		// knowledge_to must satisfy knowledge_to >= prior.knowledge_from. Concurrent
+		// txs capture `now` microseconds apart, so clamp to the prior's knowledge_from
+		// to keep the assertion_knowledge_range CHECK satisfied.
+		knowledgeTo := now
+		if prior.KnowledgeFrom.After(knowledgeTo) {
+			knowledgeTo = prior.KnowledgeFrom.UTC()
+		}
+		closure := repository.ClosureReasonSuperseded
 		if err := s.assertionRepo.CloseAssertionTx(ctx, tx, repository.CloseAssertionParams{
 			ID:            prior.ID,
 			ValidTo:       boundTo,
 			Status:        repository.AssertionStatusSuperseded,
 			ClosureReason: &closure,
 			SupersededBy:  &newRow.ID,
-			KnowledgeTo:   &now,
+			KnowledgeTo:   &knowledgeTo,
 		}); err != nil {
 			return fmt.Errorf("close prior on supersession: %w", err)
 		}
@@ -1082,15 +1105,14 @@ func (s *AssertService) closeConflicts(ctx context.Context, tx pgx.Tx, conflicts
 
 // closeBoundary picks the valid_to to stamp on a terminalized prior. For a present
 // successor the boundary is effectiveFrom (the new row starts where the old ends).
-// For a pending future successor being cancelled by a present edit, its valid_from
-// is already in the future — clamping valid_to to effectiveFrom (<= now) would
-// violate the valid_range CHECK (valid_to > valid_from). Such a never-current
-// pending row is closed with valid_to = its own valid_from (a zero-length future
-// window) so the CHECK holds and it never becomes current.
+// For a never-current pending future successor being cancelled by a present edit
+// (valid_from in the future), clamping valid_to to effectiveFrom (<= now < its
+// valid_from) would invert the range, and clamping to its valid_from would make a
+// zero-length window — both violate the valid_range CHECK. Such a row never became
+// current, so its EXISTING valid_to is kept unchanged (it's terminal regardless).
 func closeBoundary(prior *repository.Assertion, effectiveFrom, now time.Time) *time.Time {
-	if prior.ValidFrom != nil && prior.ValidFrom.After(now) && !effectiveFrom.After(*prior.ValidFrom) {
-		vf := prior.ValidFrom.UTC()
-		return &vf
+	if prior.ValidFrom != nil && prior.ValidFrom.After(now) {
+		return utcPtr(prior.ValidTo)
 	}
 	ef := effectiveFrom
 	return &ef

--- a/backend/internal/service/assert.go
+++ b/backend/internal/service/assert.go
@@ -456,7 +456,7 @@ func (s *AssertService) validate(ctx context.Context, tx pgx.Tx, req *AssertRequ
 	if len(req.Locators) == 0 {
 		return nil, "", uuid.Nil, nil, validationError("at least one provenance locator is required")
 	}
-	if err := s.validateLocators(ctx, predicate, req.Locators); err != nil {
+	if err := s.validateLocators(ctx, tx, predicate, req.Locators); err != nil {
 		return nil, "", uuid.Nil, nil, err
 	}
 
@@ -560,7 +560,7 @@ func validateFactValue(req *AssertRequest, predicate *repository.Predicate) erro
 // validateLocators checks each provenance locator: producer_kind set, source_kind
 // in the closed enum, content-kind rows exist, and phone_call/calendar_event do
 // not back a fact (metadata-only sources).
-func (s *AssertService) validateLocators(ctx context.Context, predicate *repository.Predicate, locators []ProvenanceLocator) error {
+func (s *AssertService) validateLocators(ctx context.Context, tx pgx.Tx, predicate *repository.Predicate, locators []ProvenanceLocator) error {
 	for i, loc := range locators {
 		if !isValidProducerKind(loc.ProducerKind) {
 			return validationError("locator[%d] producer_kind %q is not in {extractor,agent,user}", i, loc.ProducerKind)
@@ -579,7 +579,7 @@ func (s *AssertService) validateLocators(ctx context.Context, predicate *reposit
 			if parseErr != nil {
 				return validationError("locator[%d] source_id %q is not a UUID for source_kind %q", i, loc.SourceID, loc.SourceKind)
 			}
-			exists, err := s.assertionRepo.ExistsContentRow(ctx, loc.SourceKind, id)
+			exists, err := s.assertionRepo.ExistsContentRowTx(ctx, tx, loc.SourceKind, id)
 			if err != nil {
 				return fmt.Errorf("check locator[%d] source row: %w", i, err)
 			}
@@ -671,10 +671,15 @@ func (s *AssertService) corroborate(ctx context.Context, tx pgx.Tx, predicate *r
 	// a stale proposed row must not shadow the live-proposition index against an
 	// accepting writer.
 	if existing.Status == repository.AssertionStatusProposed && landingAccepted {
-		// Run the single-cardinality conflict check AT ACCEPT TIME (the prior
-		// accepted slot, if any, is superseded by this now-accepting row).
-		if err := s.supersedeConflicts(ctx, tx, predicate, existing, now); err != nil {
+		// Run the single-cardinality conflict check AT ACCEPT TIME (a same-value
+		// prior in another bucket is widened+merged; different-value priors are
+		// superseded by this now-accepting row).
+		survivor, merged, err := s.resolveAcceptConflicts(ctx, tx, predicate, existing, now)
+		if err != nil {
 			return nil, err
+		}
+		if merged {
+			return survivor, nil
 		}
 		if err := s.assertionRepo.TransitionStatusTx(ctx, tx, existing.ID, repository.AssertionStatusAccepted, nil, nil); err != nil {
 			return nil, fmt.Errorf("transition proposed→accepted: %w", err)
@@ -773,11 +778,11 @@ func (s *AssertService) writeNew(ctx context.Context, tx pgx.Tx, predicate *repo
 			return nil, err
 		}
 
-		// Same-value reaffirmation: an overlapping accepted row with the SAME value
-		// is the SAME fact in a different bucket → widen it (no new row, no
-		// supersession).
-		newNormalized := normalizedPayload(canonObject, req)
-		if widen := findSameValue(conflicts, newNormalized); widen != nil {
+		// Same-value reaffirmation: an overlapping accepted row with the SAME
+		// bucket-independent proposition signature is the SAME fact in a different
+		// bucket → widen it (no new row, no supersession).
+		newSignature := propositionSignature(canonKey, canonSubject, normalizedPayload(canonObject, req))
+		if widen := findSameValue(conflicts, newSignature); widen != nil {
 			return s.widenReaffirmation(ctx, tx, predicate, widen, canonKey, canonSubject, canonObject, req, effectiveFrom)
 		}
 
@@ -855,11 +860,30 @@ func normalizedPayload(canonObject *uuid.UUID, req *AssertRequest) string {
 	return normalizeValue(req)
 }
 
-// findSameValue returns the first conflict row whose payload equals the new
-// normalized value (a same-value reaffirmation), or nil.
-func findSameValue(conflicts []repository.Assertion, newNormalized string) *repository.Assertion {
+// propositionSignature is the bucket-INDEPENDENT proposition identity (length-
+// prefixed canonical subject + predicate + normalized value). Two assertions have
+// the SAME signature iff they represent the same fact/edge regardless of when it
+// was stated — so a same-value reaffirmation (same fact, different valid-time
+// bucket) matches while a DIFFERENT edge does not. For a symmetric edge the
+// canonical pair (subject<=object) is encoded, so partner_of(A,B) and
+// partner_of(A,C) get DISTINCT signatures even when A is the larger UUID (both
+// would store object=A, but their subjects B and C differ).
+func propositionSignature(canonKey string, canonSubject uuid.UUID, normalizedValue string) string {
+	return encodeLengthPrefixed(canonSubject.String(), canonKey, normalizedValue)
+}
+
+// assertionSignature computes the bucket-independent proposition signature of a
+// stored assertion row (canonicalized — but stored rows are ALREADY in canonical
+// form, so subject/object are taken as-is).
+func assertionSignature(a *repository.Assertion) string {
+	return propositionSignature(a.PredicateKey, a.SubjectNodeID, assertionNormalizedValue(a))
+}
+
+// findSameValue returns the first conflict row with the SAME bucket-independent
+// proposition signature as newSignature (a same-value reaffirmation), or nil.
+func findSameValue(conflicts []repository.Assertion, newSignature string) *repository.Assertion {
 	for i := range conflicts {
-		if assertionNormalizedValue(&conflicts[i]) == newNormalized {
+		if assertionSignature(&conflicts[i]) == newSignature {
 			return &conflicts[i]
 		}
 	}
@@ -927,6 +951,16 @@ func (s *AssertService) widenReaffirmation(ctx context.Context, tx pgx.Tx, predi
 	widenedFrom := minStart(existing.ValidFrom, req.ValidFrom)
 	widenedTo := maxEnd(existing.ValidTo, req.ValidTo)
 
+	// If the existing row is bounded by a PENDING future successor (superseded_by
+	// set while still accepted, valid_to in the future), widening valid_to past that
+	// bound would un-bound it and leave TWO current rows once the successor's date
+	// passes. Re-affirming the same value must NOT clear that bound — keep the
+	// existing valid_to as the upper cap (only the backward lower-bound extension is
+	// safe). The pending successor remains the future value.
+	if existing.SupersededBy != nil {
+		widenedTo = utcPtr(existing.ValidTo)
+	}
+
 	// Recompute the proposition_key from the widened valid_from bucket.
 	widenedReq := *req
 	widenedReq.ValidFrom = widenedFrom
@@ -979,9 +1013,10 @@ func (s *AssertService) widenReaffirmation(ctx context.Context, tx pgx.Tx, predi
 }
 
 // mergeSameValue collapses a colliding same-value live row (loser) into the
-// survivor: move the loser's provenance onto the survivor (ON CONFLICT no-op) and
-// close the loser superseded with superseded_by = survivor. Emits provenance_added
-// per moved locator + superseded for the loser.
+// survivor: move the loser's provenance onto the survivor (ON CONFLICT no-op),
+// fold the loser's confidence (max) + trust_tier (strongest) into the survivor,
+// and close the loser superseded with superseded_by = survivor. Emits
+// provenance_added per moved locator + superseded for the loser.
 func (s *AssertService) mergeSameValue(ctx context.Context, tx pgx.Tx, loser, survivor *repository.Assertion) error {
 	provs, err := s.assertionRepo.ListProvenance(ctx, loser.ID)
 	if err != nil {
@@ -1011,6 +1046,20 @@ func (s *AssertService) mergeSameValue(ctx context.Context, tx pgx.Tx, loser, su
 			}
 		}
 	}
+	// Fold the loser's confidence (max) + trust_tier (strongest) into the survivor —
+	// the survivor now owns the loser's provenance, so its aggregate must reflect it.
+	newConfidence := survivor.Confidence
+	if loser.Confidence > newConfidence {
+		newConfidence = loser.Confidence
+	}
+	newTrust := strongerTrustTier(survivor.TrustTier, loser.TrustTier)
+	if newConfidence != survivor.Confidence || !trustEqual(survivor.TrustTier, newTrust) {
+		if err := s.assertionRepo.UpdateAssertionConfidenceTrustTx(ctx, tx, survivor.ID, newConfidence, newTrust); err != nil {
+			return fmt.Errorf("fold loser confidence/trust into survivor: %w", err)
+		}
+		survivor.Confidence = newConfidence
+		survivor.TrustTier = newTrust
+	}
 	now := accelerated.GetCurrentTime().UTC()
 	knowledgeTo := now
 	if loser.KnowledgeFrom.After(knowledgeTo) {
@@ -1030,16 +1079,22 @@ func (s *AssertService) mergeSameValue(ctx context.Context, tx pgx.Tx, loser, su
 	return s.emitAssertionEvent(ctx, tx, events.KindAssertionSuperseded, loser, now)
 }
 
-// closeConflicts closes each different-value overlapping prior for a present/
+// closeConflicts closes each different-value overlapping prior for a present /
 // future successor (D6 step 4). The newRow is the just-inserted successor.
 //
-//   - Future successor (effectiveFrom > now): bound the CURRENT prior (valid_to =
-//     effectiveFrom, superseded_by = newRow.id) but KEEP it accepted/knowledge-open
-//     (still current until the future date). The rollover job terminalizes it
-//     later. A pending future successor among the priors is fully superseded now.
-//   - Present successor (effectiveFrom <= now): terminalize each overlapping prior
-//     (status=superseded, valid_to=effectiveFrom, superseded_by=newRow.id,
-//     knowledge_to=now), cancelling any stale pending future successor too.
+// A prior is BOUNDED (kept accepted/knowledge-open, valid_to=effectiveFrom,
+// superseded_by=newRow — the rollover job terminalizes it when the bound passes)
+// when it is genuinely CURRENT at some point strictly before the successor's
+// boundary: the successor is future (effectiveFrom > now) AND the prior starts
+// before the boundary (open start, or valid_from < effectiveFrom). This covers a
+// chained future successor: A→B(July1)→C(Aug1) bounds B to Aug1 (B is current
+// July–Aug), it does NOT terminalize B and leave a July gap.
+//
+// Otherwise the prior is TERMINALIZED (status=superseded, knowledge_to=now): a
+// present successor (effectiveFrom <= now), or a future successor that starts
+// at/before the prior's own valid_from (the prior never becomes current — a
+// present edit cancelling a pending future successor, or a future successor that
+// fully precedes another pending one).
 func (s *AssertService) closeConflicts(ctx context.Context, tx pgx.Tx, conflicts []repository.Assertion, newRow *repository.Assertion, effectiveFrom, now time.Time) error {
 	future := effectiveFrom.After(now)
 	for i := range conflicts {
@@ -1047,20 +1102,10 @@ func (s *AssertService) closeConflicts(ctx context.Context, tx pgx.Tx, conflicts
 		if prior.ID == newRow.ID {
 			continue
 		}
-		// A pending future successor (its valid_from is in the future → not yet
-		// current) that this present edit overrides is fully superseded regardless of
-		// the branch — it never becomes current. It is exempt from the bound-ordering
-		// guard below (it is closed at its own valid_from, not at effectiveFrom). A
-		// future-dated successor is identified by valid_from > now, NOT by carrying a
-		// superseded_by (it may be the tail of the chain with none).
-		priorIsPendingFuture := prior.ValidFrom != nil && prior.ValidFrom.After(now)
+		// The prior is current before the boundary iff its start precedes it.
+		startsBeforeBoundary := prior.ValidFrom == nil || effectiveFrom.After(*prior.ValidFrom)
 
-		if future && !priorIsPendingFuture {
-			// Future-successor bound: the prior must START before the boundary, else
-			// bounding it to effectiveFrom would invert its range → REJECT.
-			if prior.ValidFrom != nil && !effectiveFrom.After(*prior.ValidFrom) {
-				return validationError("successor boundary %s is not after prior valid_from %s", effectiveFrom, prior.ValidFrom.UTC())
-			}
+		if future && startsBeforeBoundary {
 			// Bound the still-current prior; keep it accepted (current until the date).
 			if err := s.assertionRepo.BoundPendingSuccessorTx(ctx, tx, prior.ID, effectiveFrom, newRow.ID); err != nil {
 				return fmt.Errorf("bound pending successor: %w", err)
@@ -1068,19 +1113,11 @@ func (s *AssertService) closeConflicts(ctx context.Context, tx pgx.Tx, conflicts
 			continue
 		}
 
-		// Terminalize the prior (present edit, or a pending future successor a present
-		// edit cancels). boundTo is effectiveFrom for a normally-overlapping prior, or
-		// the prior's own valid_from for a never-current pending-future row.
-		boundTo := closeBoundary(prior, effectiveFrom, now)
-		// Guard the valid_range CHECK for the terminalized prior too: if we stamp
-		// valid_to = effectiveFrom but the prior STARTS at/after that, the range would
-		// invert (an incoherent backfilled successor) → REJECT.
-		if !priorIsPendingFuture && prior.ValidFrom != nil && boundTo != nil && !boundTo.After(*prior.ValidFrom) {
-			return validationError("successor boundary %s is not after prior valid_from %s", boundTo.UTC(), prior.ValidFrom.UTC())
-		}
-		// knowledge_to must satisfy knowledge_to >= prior.knowledge_from. Concurrent
-		// txs capture `now` microseconds apart, so clamp to the prior's knowledge_from
-		// to keep the assertion_knowledge_range CHECK satisfied.
+		// Terminalize the prior. boundTo is effectiveFrom for a prior that is current
+		// up to the present boundary; for a never-current pending-future row (its
+		// valid_from is at/after the boundary) keep its EXISTING valid_to so the
+		// valid_range CHECK is never inverted to a zero-length/backward window.
+		boundTo := closeBoundary(prior, effectiveFrom)
 		knowledgeTo := now
 		if prior.KnowledgeFrom.After(knowledgeTo) {
 			knowledgeTo = prior.KnowledgeFrom.UTC()
@@ -1103,15 +1140,14 @@ func (s *AssertService) closeConflicts(ctx context.Context, tx pgx.Tx, conflicts
 	return nil
 }
 
-// closeBoundary picks the valid_to to stamp on a terminalized prior. For a present
-// successor the boundary is effectiveFrom (the new row starts where the old ends).
-// For a never-current pending future successor being cancelled by a present edit
-// (valid_from in the future), clamping valid_to to effectiveFrom (<= now < its
-// valid_from) would invert the range, and clamping to its valid_from would make a
-// zero-length window — both violate the valid_range CHECK. Such a row never became
-// current, so its EXISTING valid_to is kept unchanged (it's terminal regardless).
-func closeBoundary(prior *repository.Assertion, effectiveFrom, now time.Time) *time.Time {
-	if prior.ValidFrom != nil && prior.ValidFrom.After(now) {
+// closeBoundary picks the valid_to to stamp on a TERMINALIZED prior. A prior that
+// is current up to the boundary (open start, or valid_from < effectiveFrom) is
+// closed at effectiveFrom. A never-current pending-future prior (valid_from at/after
+// effectiveFrom) keeps its EXISTING valid_to: stamping effectiveFrom (which is <= its
+// valid_from) would invert the range and stamping its own valid_from would make a
+// zero-length window — both violate the valid_range CHECK. It is terminal regardless.
+func closeBoundary(prior *repository.Assertion, effectiveFrom time.Time) *time.Time {
+	if prior.ValidFrom != nil && !effectiveFrom.After(*prior.ValidFrom) {
 		return utcPtr(prior.ValidTo)
 	}
 	ef := effectiveFrom
@@ -1125,13 +1161,18 @@ func closeBoundary(prior *repository.Assertion, effectiveFrom, now time.Time) *t
 // priors (present/future branch). It does NOT re-check same-value (an accept of a
 // proposed row is a distinct proposition from any same-value accepted row, so
 // they coexist until the user reconciles; SP1 keeps accept-time minimal).
-func (s *AssertService) supersedeConflicts(ctx context.Context, tx pgx.Tx, predicate *repository.Predicate, accepting *repository.Assertion, now time.Time) error {
+// resolveAcceptConflicts returns (survivor, merged). When merged is true, the
+// accepting (proposed) row was a same-value reaffirmation of an existing accepted
+// row: it was absorbed (provenance + confidence folded onto the survivor, the
+// accepting row closed superseded), and survivor is the live row the caller should
+// return — the caller must NOT then transition the accepting row to accepted.
+func (s *AssertService) resolveAcceptConflicts(ctx context.Context, tx pgx.Tx, predicate *repository.Predicate, accepting *repository.Assertion, now time.Time) (survivor *repository.Assertion, merged bool, err error) {
 	if predicate.Cardinality != repository.PredicateCardinalitySingle {
-		return nil
+		return nil, false, nil
 	}
 	canonKey, canonSubject, canonObject := canonicalEdge(predicate, accepting.SubjectNodeID, accepting.ObjectNodeID)
 	if err := s.acquireSlotLocks(ctx, tx, predicate, canonKey, canonSubject, canonObject); err != nil {
-		return err
+		return nil, false, err
 	}
 	effectiveFrom := now
 	if accepting.ValidFrom != nil {
@@ -1139,13 +1180,33 @@ func (s *AssertService) supersedeConflicts(ctx context.Context, tx pgx.Tx, predi
 	}
 	// A past-bounded accepting row coexists (it is historical) → no supersession.
 	if accepting.ValidTo != nil && !accepting.ValidTo.UTC().After(now) {
-		return nil
+		return nil, false, nil
 	}
 	conflicts, err := s.findOverlappingAccepted(ctx, tx, predicate, canonKey, canonSubject, canonObject, effectiveFrom, accepting.ValidTo)
 	if err != nil {
-		return err
+		return nil, false, err
 	}
-	return s.closeConflicts(ctx, tx, conflicts, accepting, effectiveFrom, now)
+	// Same-value reaffirmation at accept time: an overlapping accepted row with the
+	// SAME value is the same fact in a different bucket → WIDEN it to cover the
+	// accepting row's window and MERGE the accepting (proposed) row into it. Mirrors
+	// the writeNew widen rule (P1: Accept must widen, not supersede, a same value).
+	acceptingSignature := assertionSignature(accepting)
+	if existing := findSameValue(conflicts, acceptingSignature); existing != nil {
+		existing.ValidFrom = minStart(existing.ValidFrom, accepting.ValidFrom)
+		existing.ValidTo = maxEnd(existing.ValidTo, accepting.ValidTo)
+		widenReq := &AssertRequest{ValidFrom: existing.ValidFrom}
+		newKey := computePropositionKey(predicate, canonKey, canonSubject, canonObject, widenReq)
+		if err := s.assertionRepo.WidenAssertionValidityTx(ctx, tx, existing.ID, existing.ValidFrom, existing.ValidTo, newKey); err != nil {
+			return nil, false, fmt.Errorf("widen survivor at accept: %w", err)
+		}
+		existing.PropositionKey = newKey
+		if err := s.mergeSameValue(ctx, tx, accepting, existing); err != nil {
+			return nil, false, err
+		}
+		return existing, true, nil
+	}
+
+	return nil, false, s.closeConflicts(ctx, tx, conflicts, accepting, effectiveFrom, now)
 }
 
 // insertAssertionWithRecover inserts the new assertion, recovering from the
@@ -1279,7 +1340,9 @@ func (s *AssertService) Accept(ctx context.Context, assertionID uuid.UUID, _ Acc
 // AcceptTx is the tx-bound variant of Accept.
 func (s *AssertService) AcceptTx(ctx context.Context, tx pgx.Tx, assertionID uuid.UUID) (*repository.Assertion, error) {
 	now := accelerated.GetCurrentTime().UTC()
-	assertion, err := s.assertionRepo.GetAssertionTx(ctx, tx, assertionID)
+	// Row-lock so the proposed-status check + the accept are atomic vs a concurrent
+	// Accept/Reject of the same row.
+	assertion, err := s.assertionRepo.GetAssertionForUpdateTx(ctx, tx, assertionID)
 	if err != nil {
 		return nil, err
 	}
@@ -1290,9 +1353,16 @@ func (s *AssertService) AcceptTx(ctx context.Context, tx pgx.Tx, assertionID uui
 	if err != nil {
 		return nil, fmt.Errorf("load predicate: %w", err)
 	}
-	// Single-cardinality supersession at accept time (locks + closes the prior).
-	if err := s.supersedeConflicts(ctx, tx, predicate, assertion, now); err != nil {
+	// Single-cardinality conflict resolution at accept time (locks the slot, then
+	// widens a same-value prior or supersedes different-value priors).
+	survivor, merged, err := s.resolveAcceptConflicts(ctx, tx, predicate, assertion, now)
+	if err != nil {
 		return nil, err
+	}
+	if merged {
+		// The accepting row was a same-value reaffirmation absorbed into survivor;
+		// it is already closed. Return the live survivor instead of accepting it.
+		return survivor, nil
 	}
 	if err := s.assertionRepo.TransitionStatusTx(ctx, tx, assertionID, repository.AssertionStatusAccepted, nil, nil); err != nil {
 		return nil, fmt.Errorf("transition proposed→accepted: %w", err)
@@ -1334,19 +1404,28 @@ func (s *AssertService) terminalTransition(ctx context.Context, assertionID uuid
 		}
 	}()
 	now := accelerated.GetCurrentTime().UTC()
-	assertion, err := s.assertionRepo.GetAssertionTx(ctx, tx, assertionID)
+	// Row-lock so the from-status check + the update are atomic (a concurrent
+	// Accept/Reject on the same row blocks here, so they cannot both succeed).
+	assertion, err := s.assertionRepo.GetAssertionForUpdateTx(ctx, tx, assertionID)
 	if err != nil {
 		return nil, err
 	}
 	if assertion.Status != fromStatus {
 		return nil, validationError("assertion %s is %q, expected %q for this transition", assertionID, assertion.Status, fromStatus)
 	}
+	// knowledge_to >= knowledge_from (the row's KnowledgeFromOverride may put
+	// knowledge_from in the future; clamp so the assertion_knowledge_range CHECK
+	// holds).
+	knowledgeTo := now
+	if assertion.KnowledgeFrom.After(knowledgeTo) {
+		knowledgeTo = assertion.KnowledgeFrom.UTC()
+	}
 	closure := closureReason
-	if err := s.assertionRepo.TransitionStatusTx(ctx, tx, assertionID, toStatus, &now, &closure); err != nil {
+	if err := s.assertionRepo.TransitionStatusTx(ctx, tx, assertionID, toStatus, &knowledgeTo, &closure); err != nil {
 		return nil, fmt.Errorf("terminal transition to %s: %w", toStatus, err)
 	}
 	assertion.Status = toStatus
-	assertion.KnowledgeTo = &now
+	assertion.KnowledgeTo = &knowledgeTo
 	assertion.ClosureReason = &closure
 	if err := s.emitAssertionEvent(ctx, tx, kind, assertion, now); err != nil {
 		return nil, err
@@ -1556,6 +1635,22 @@ func strongerTrust(existing *string, locators []ProvenanceLocator) *string {
 		return nil
 	}
 	return &bestTier
+}
+
+// strongerTrustTier returns the stronger of two nullable trust tiers (the higher
+// rank). Used when merging a same-value loser's trust into a survivor.
+func strongerTrustTier(a, b *string) *string {
+	rankA, rankB := 0, 0
+	if a != nil {
+		rankA = trustTierRank(*a)
+	}
+	if b != nil {
+		rankB = trustTierRank(*b)
+	}
+	if rankB > rankA {
+		return b
+	}
+	return a
 }
 
 // trustTierRank ranks a stored trust_tier token (mirrors producerRank but over the

--- a/backend/internal/service/assert.go
+++ b/backend/internal/service/assert.go
@@ -1,0 +1,1572 @@
+package service
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// ErrAssertValidation is the sentinel a write rejection wraps. The write API
+// REJECTS (returns an error) rather than silently dropping a bad assertion, so
+// callers can distinguish a validation failure (4xx-shaped) from an
+// infrastructure error.
+var ErrAssertValidation = errors.New("assert: validation failed")
+
+// validationError wraps a human-readable reason in ErrAssertValidation.
+func validationError(format string, args ...any) error {
+	return fmt.Errorf("%w: %s", ErrAssertValidation, fmt.Sprintf(format, args...))
+}
+
+// ProvenanceLocator is one corroborating source locator supplied with an assert
+// request. The write API computes its locator_hash (D5) and validates the
+// source_kind + (for content kinds) the referenced row's existence.
+type ProvenanceLocator struct {
+	SourceKind      string  // closed enum (repository.SourceKind*)
+	SourceID        string  // content-row UUID-as-text, or a stable ref for user/agent_session
+	ProducerKind    string  // extractor | agent | user
+	ProducerVersion string  // re-verifiability; "" allowed
+	Field           *string // which column/field the quote came from
+	StartOffset     *int32
+	EndOffset       *int32
+	ChunkID         *string
+	InputHash       string // extractor input hash; "" allowed
+	Quote           *string
+}
+
+// AssertRequest is the input to Assert. Exactly one of {ObjectNodeID, ValueText,
+// ValueNum, ValueDate, ValueBool} should be set per the predicate's kind (the
+// validator enforces it). ValidFrom/ValidTo are world-truth bounds from content
+// evidence (nil = open-ended); knowledge-time is always now (KnowledgeFromOverride
+// is the migration/import escape hatch).
+type AssertRequest struct {
+	SubjectNodeID uuid.UUID
+	PredicateKey  string
+
+	ObjectNodeID *uuid.UUID
+	ValueText    *string
+	ValueNum     *float64
+	ValueDate    *time.Time
+	ValueBool    *bool
+
+	ValidFrom *time.Time
+	ValidTo   *time.Time
+
+	Confidence int16
+	// Salience defaults to the predicate's default_salience when zero-and-unset;
+	// callers that want a non-default salience set SalienceOverride.
+	SalienceOverride *int16
+
+	Locators []ProvenanceLocator
+
+	// ForceConfirm routes an otherwise auto-apply predicate to 'proposed' (a
+	// human/agent wants to review it before it lands accepted).
+	ForceConfirm bool
+
+	// KnowledgeFromOverride preserves historical knowledge-time for a backfill /
+	// migration (the source row's created_at). Live producers leave it nil →
+	// knowledge_from = now. This is the ONLY caller permitted to override.
+	KnowledgeFromOverride *time.Time
+}
+
+// ClosureRequest closes a single-cardinality slot with no successor ("between
+// jobs"): the current accepted assertion for (subject, predicate) is closed
+// 'ended' and the current value becomes a gap.
+type ClosureRequest struct {
+	SubjectNodeID uuid.UUID
+	PredicateKey  string
+}
+
+// AcceptRequest carries the optional knobs for Accept. Empty is the common case.
+type AcceptRequest struct{}
+
+// RejectRequest carries the optional knobs for Reject.
+type RejectRequest struct{}
+
+// RetractRequest carries the optional knobs for Retract.
+type RetractRequest struct{}
+
+// AssertService is the single validated write path for the assertion store (D6).
+// Every producer (extractor, agent, UI, migration) asserts facts/edges through
+// it; it owns proposition identity, cardinality/supersession, the bi-temporal
+// clocks, provenance dedup, and event emission — all in one transaction.
+type AssertService struct {
+	pool          *pgxpool.Pool
+	nodeRepo      *repository.NodeRepository
+	entityRepo    *repository.EntityRepository
+	predicateRepo *repository.PredicateRepository
+	assertionRepo *repository.AssertionRepository
+	bus           busPublisher
+}
+
+// busPublisher is the narrow event-bus surface AssertService needs. *events.Bus
+// satisfies it. Nil-safe is NOT supported — the write contract requires events.
+type busPublisher interface {
+	PublishTx(ctx context.Context, tx pgx.Tx, env *events.Envelope) error
+}
+
+// NewAssertService wires the write API over the pool + graph repos + bus.
+func NewAssertService(
+	pool *pgxpool.Pool,
+	nodeRepo *repository.NodeRepository,
+	entityRepo *repository.EntityRepository,
+	predicateRepo *repository.PredicateRepository,
+	assertionRepo *repository.AssertionRepository,
+	bus busPublisher,
+) *AssertService {
+	return &AssertService{
+		pool:          pool,
+		nodeRepo:      nodeRepo,
+		entityRepo:    entityRepo,
+		predicateRepo: predicateRepo,
+		assertionRepo: assertionRepo,
+		bus:           bus,
+	}
+}
+
+// --------------------------------------------------------------------------
+// Pure helpers — deterministic encoding, proposition identity, locator hash.
+// These take no DB and are unit-tested in isolation (assert_propkey_test.go).
+// --------------------------------------------------------------------------
+
+// encodeLengthPrefixed joins components as "<len>:<value>" per field, so a
+// delimiter or NUL byte inside any component cannot forge a collision across
+// components (a plain "|"-join could: a value_text containing "|" would alias a
+// different tuple). This is the SAME encoding both proposition_key and
+// locator_hash use (D4a / D5).
+func encodeLengthPrefixed(components ...string) string {
+	var b strings.Builder
+	for _, c := range components {
+		b.WriteString(strconv.Itoa(len(c)))
+		b.WriteByte(':')
+		b.WriteString(c)
+	}
+	return b.String()
+}
+
+// canonicalEdge returns the canonical (predicateKey, subject, object) for an
+// edge, applying symmetric pair-ordering and inverse-predicate token+orientation
+// canonicalization (D4a). For a fact (no object) it returns the inputs unchanged.
+//
+//   - symmetric: store once with subject<=object in UUID byte order.
+//   - inverse pair: the canonical predicate is min(key, inverse); if the incoming
+//     predicate is NOT the canonical one, swap subject<->object and use the
+//     canonical key. So parent_of(A,B) and child_of(B,A) collapse to one row.
+//
+// object is nil for a fact predicate (returned nil). predicate is the loaded
+// catalog row for predicateKey.
+func canonicalEdge(predicate *repository.Predicate, subject uuid.UUID, object *uuid.UUID) (canonKey string, canonSubject uuid.UUID, canonObject *uuid.UUID) {
+	canonKey = predicate.Key
+	canonSubject = subject
+	canonObject = object
+
+	if object == nil {
+		return canonKey, canonSubject, canonObject
+	}
+
+	// Inverse canonicalization: rewrite to the lexicographically-smaller key's
+	// direction. min(key, inverse) is the canonical predicate. The swap uses
+	// fresh locals (NOT &canonSubject) to avoid a self-aliasing pointer.
+	if predicate.InversePredicate != nil && *predicate.InversePredicate < predicate.Key {
+		canonKey = *predicate.InversePredicate
+		newSubject := *object
+		newObject := subject
+		canonSubject = newSubject
+		canonObject = &newObject
+	}
+
+	// Symmetric ordering: store the pair subject<=object (UUID byte order). Apply
+	// AFTER inverse rewrite (a symmetric predicate has no inverse, so the two are
+	// mutually exclusive in the seed catalog, but ordering last is harmless).
+	if predicate.Symmetric && canonObject != nil {
+		if bytesGreater(canonSubject, *canonObject) {
+			newSubject := *canonObject
+			newObject := canonSubject
+			canonSubject = newSubject
+			canonObject = &newObject
+		}
+	}
+	return canonKey, canonSubject, canonObject
+}
+
+// bytesGreater reports whether a > b in UUID byte order.
+func bytesGreater(a, b uuid.UUID) bool {
+	for i := 0; i < len(a); i++ {
+		if a[i] != b[i] {
+			return a[i] > b[i]
+		}
+	}
+	return false
+}
+
+// normalizeValue returns the canonical string form of the assertion's payload
+// for the proposition key (D4a step 3): text → lower(trim()); date → ISO; num →
+// canonical float repr; bool → "t"/"f". Exactly one of the value fields is set
+// for a fact; for an edge the object UUID is used (handled by the caller).
+func normalizeValue(req *AssertRequest) string {
+	switch {
+	case req.ValueText != nil:
+		return strings.ToLower(strings.TrimSpace(*req.ValueText))
+	case req.ValueNum != nil:
+		// strconv.FormatFloat with -1 precision is the shortest round-trippable
+		// repr, deterministic for a given float64.
+		return strconv.FormatFloat(*req.ValueNum, 'g', -1, 64)
+	case req.ValueDate != nil:
+		return req.ValueDate.UTC().Format("2006-01-02")
+	case req.ValueBool != nil:
+		if *req.ValueBool {
+			return "t"
+		}
+		return "f"
+	default:
+		return ""
+	}
+}
+
+// validTimeBucket returns the valid-time component of the proposition key for a
+// predicate's proposition_bucket granularity (D4a). 'none' → no valid-time
+// component (""); otherwise validFrom is truncated to day/month/year in UTC (or
+// the literal "open" when validFrom is nil). Computed in Go (immutable,
+// timezone-pinned to UTC) — never the brittle SQL date_trunc.
+func validTimeBucket(bucket string, validFrom *time.Time) string {
+	if bucket == repository.PredicateBucketNone {
+		return ""
+	}
+	if validFrom == nil {
+		return "open"
+	}
+	u := validFrom.UTC()
+	switch bucket {
+	case repository.PredicateBucketYear:
+		return strconv.Itoa(u.Year())
+	case repository.PredicateBucketMonth:
+		return u.Format("2006-01")
+	default: // day
+		return u.Format("2006-01-02")
+	}
+}
+
+// computePropositionKey builds the deterministic dedup key (D4a) from the
+// CANONICAL (subject, predicate, object/value, valid-time-bucket). The caller
+// passes the already-canonicalized key/subject/object (from canonicalEdge) plus
+// the predicate (for the bucket granularity + edge-vs-fact discrimination) and
+// the request (for the fact value + valid_from). Length-prefixed so no component
+// can alias another.
+func computePropositionKey(predicate *repository.Predicate, canonKey string, canonSubject uuid.UUID, canonObject *uuid.UUID, req *AssertRequest) string {
+	var normalized string
+	if canonObject != nil {
+		normalized = canonObject.String()
+	} else {
+		normalized = normalizeValue(req)
+	}
+	bucket := validTimeBucket(predicate.PropositionBucket, req.ValidFrom)
+	return encodeLengthPrefixed(
+		canonSubject.String(),
+		canonKey,
+		normalized,
+		bucket,
+	)
+}
+
+// computeLocatorHash is the sha256-hex over the length-prefixed encoding of the
+// full locator identity (D5): (source_kind, source_id, field, start_offset,
+// end_offset, chunk_id, producer_kind, producer_version, input_hash). A
+// same-locator re-emit hashes identically (→ ON CONFLICT no-op); a different
+// span/version hashes differently (→ a new corroborating row).
+func computeLocatorHash(loc ProvenanceLocator) string {
+	encoded := encodeLengthPrefixed(
+		loc.SourceKind,
+		loc.SourceID,
+		strPtrOrEmpty(loc.Field),
+		int32PtrToString(loc.StartOffset),
+		int32PtrToString(loc.EndOffset),
+		strPtrOrEmpty(loc.ChunkID),
+		loc.ProducerKind,
+		loc.ProducerVersion,
+		loc.InputHash,
+	)
+	sum := sha256.Sum256([]byte(encoded))
+	return hex.EncodeToString(sum[:])
+}
+
+func strPtrOrEmpty(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+func int32PtrToString(v *int32) string {
+	if v == nil {
+		return ""
+	}
+	return strconv.FormatInt(int64(*v), 10)
+}
+
+// slotLockKey folds a single-cardinality slot identity into a deterministic int64
+// for pg_advisory_xact_lock (D6 step 4). FNV-64a is stable across the process and
+// the only requirement is that all asserts touching the SAME slot fold to the
+// SAME int64 (collisions across DIFFERENT slots merely over-serialize, never
+// corrupt). Asymmetric slot = (subject, canonical predicate); a symmetric-single
+// write takes one lock per participant, so this is called once per participant.
+func slotLockKey(predicateKey string, participant uuid.UUID) int64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(encodeLengthPrefixed(predicateKey, participant.String())))
+	// fnv.Sum64 is uint64; reinterpret the bits as int64 (pg_advisory_xact_lock
+	// takes a signed bigint — the full 64-bit space is valid).
+	return int64(h.Sum64()) //nolint:gosec // intentional bit-reinterpretation
+}
+
+// --------------------------------------------------------------------------
+// Lifecycle entry points.
+// --------------------------------------------------------------------------
+
+// Assert proposes-or-corroborates a fact/edge in its own transaction. Returns the
+// resulting assertion (the new row, or the existing one a corroboration appended
+// to / accepted). A validation failure REJECTS the write (wraps
+// ErrAssertValidation); the tx rolls back.
+func (s *AssertService) Assert(ctx context.Context, req AssertRequest) (a *repository.Assertion, err error) {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if rb := tx.Rollback(ctx); rb != nil && !errors.Is(rb, pgx.ErrTxClosed) && err == nil {
+			err = rb
+		}
+	}()
+	a, err = s.AssertTx(ctx, tx, req)
+	if err != nil {
+		return nil, err
+	}
+	if err = tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+	return a, nil
+}
+
+// AssertTx runs the 6-step write contract (D6) within the caller's tx. The caller
+// owns commit/rollback (this is how SP9's contact-create dual-emits assertions in
+// the contact tx). It NEVER commits or rolls back the tx itself.
+func (s *AssertService) AssertTx(ctx context.Context, tx pgx.Tx, req AssertRequest) (*repository.Assertion, error) {
+	// Step 1: validate against the catalog + nodes + provenance.
+	predicate, canonKey, canonSubject, canonObject, err := s.validate(ctx, tx, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	now := accelerated.GetCurrentTime().UTC()
+	knowledgeFrom := now
+	if req.KnowledgeFromOverride != nil {
+		knowledgeFrom = req.KnowledgeFromOverride.UTC()
+	}
+
+	// Step 2: compute the proposition key + per-locator hashes.
+	propKey := computePropositionKey(predicate, canonKey, canonSubject, canonObject, &req)
+
+	// Determine the landing status (auto-apply vs always-confirm / force-confirm).
+	landingAccepted := predicate.DefaultReviewPolicy == repository.PredicateReviewAutoIfConfident && !req.ForceConfirm
+
+	// Step 3: resolve proposition identity (dedup).
+	existing, err := s.assertionRepo.FindLivePropositionTx(ctx, tx, propKey)
+	if err != nil && !errors.Is(err, db.ErrNotFound) {
+		return nil, fmt.Errorf("find live proposition: %w", err)
+	}
+	if err == nil {
+		// Match → corroborate (append provenance, re-aggregate, maybe accept).
+		return s.corroborate(ctx, tx, predicate, existing, &req, landingAccepted, now)
+	}
+
+	// No match → step 4/5: cardinality/supersession + write the new row.
+	return s.writeNew(ctx, tx, predicate, canonKey, canonSubject, canonObject, propKey, &req, landingAccepted, knowledgeFrom, now)
+}
+
+// --------------------------------------------------------------------------
+// Step 1: validation (D6). Any failure REJECTS the write (never silently drops).
+// Returns the loaded predicate + the canonicalized (key, subject, object).
+// --------------------------------------------------------------------------
+
+func (s *AssertService) validate(ctx context.Context, tx pgx.Tx, req *AssertRequest) (predicate *repository.Predicate, canonKey string, canonSubject uuid.UUID, canonObject *uuid.UUID, err error) {
+	if req.SubjectNodeID == uuid.Nil {
+		return nil, "", uuid.Nil, nil, validationError("subject_node_id is required")
+	}
+
+	// Predicate exists in the catalog.
+	predicate, err = s.predicateRepo.GetPredicate(ctx, req.PredicateKey)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return nil, "", uuid.Nil, nil, validationError("unknown predicate %q", req.PredicateKey)
+		}
+		return nil, "", uuid.Nil, nil, fmt.Errorf("load predicate: %w", err)
+	}
+
+	// Subject node exists, is not soft-deleted, and its type/entity-subtype matches
+	// predicate.subject_type. The validator accepts an entity-subtype subject (e.g.
+	// `within` place→place), not only person.
+	if err := s.validateSubjectType(ctx, tx, req.SubjectNodeID, predicate); err != nil {
+		return nil, "", uuid.Nil, nil, err
+	}
+
+	// Payload shape: edge vs fact (the cross-table "object iff edge" invariant the
+	// column CHECK can't express).
+	switch predicate.Kind {
+	case repository.PredicateKindEdge:
+		if req.ObjectNodeID == nil {
+			return nil, "", uuid.Nil, nil, validationError("edge predicate %q requires object_node_id", predicate.Key)
+		}
+		if hasAnyScalar(req) {
+			return nil, "", uuid.Nil, nil, validationError("edge predicate %q must not carry a scalar value", predicate.Key)
+		}
+		// Object node exists, not soft-deleted, type matches object_type.
+		if err := s.validateObjectType(ctx, tx, *req.ObjectNodeID, predicate); err != nil {
+			return nil, "", uuid.Nil, nil, err
+		}
+	case repository.PredicateKindFact:
+		if req.ObjectNodeID != nil {
+			return nil, "", uuid.Nil, nil, validationError("fact predicate %q must not carry object_node_id", predicate.Key)
+		}
+		if err := validateFactValue(req, predicate); err != nil {
+			return nil, "", uuid.Nil, nil, err
+		}
+	default:
+		return nil, "", uuid.Nil, nil, validationError("predicate %q has unknown kind %q", predicate.Key, predicate.Kind)
+	}
+
+	// Producer + confidence + provenance.
+	if req.Confidence < 0 || req.Confidence > 100 {
+		return nil, "", uuid.Nil, nil, validationError("confidence %d out of range [0,100]", req.Confidence)
+	}
+	if len(req.Locators) == 0 {
+		return nil, "", uuid.Nil, nil, validationError("at least one provenance locator is required")
+	}
+	if err := s.validateLocators(ctx, predicate, req.Locators); err != nil {
+		return nil, "", uuid.Nil, nil, err
+	}
+
+	canonKey, canonSubject, canonObject = canonicalEdge(predicate, req.SubjectNodeID, req.ObjectNodeID)
+	return predicate, canonKey, canonSubject, canonObject, nil
+}
+
+// validateSubjectType confirms the subject node exists (live) and its type /
+// entity-subtype matches predicate.subject_type.
+func (s *AssertService) validateSubjectType(ctx context.Context, tx pgx.Tx, subjectID uuid.UUID, predicate *repository.Predicate) error {
+	node, err := s.nodeRepo.GetNodeTx(ctx, tx, subjectID)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return validationError("subject node %s does not exist or is soft-deleted", subjectID)
+		}
+		return fmt.Errorf("load subject node: %w", err)
+	}
+	return s.matchNodeType(ctx, tx, node, predicate.SubjectType, "subject")
+}
+
+// validateObjectType confirms the object node exists (live) and its type /
+// entity-subtype matches predicate.object_type.
+func (s *AssertService) validateObjectType(ctx context.Context, tx pgx.Tx, objectID uuid.UUID, predicate *repository.Predicate) error {
+	if predicate.ObjectType == nil {
+		return validationError("edge predicate %q has no object_type in the catalog", predicate.Key)
+	}
+	node, err := s.nodeRepo.GetNodeTx(ctx, tx, objectID)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return validationError("object node %s does not exist or is soft-deleted", objectID)
+		}
+		return fmt.Errorf("load object node: %w", err)
+	}
+	return s.matchNodeType(ctx, tx, node, *predicate.ObjectType, "object")
+}
+
+// matchNodeType checks a node against an expected predicate type token. The token
+// is 'person'/'venue' (a node type) OR an entity subtype (e.g. 'place', 'tag',
+// 'organization', 'topic'). For an entity node the subtype is resolved from the
+// entity row.
+func (s *AssertService) matchNodeType(ctx context.Context, tx pgx.Tx, node *repository.Node, expected, role string) error {
+	switch node.Type {
+	case repository.NodeTypePerson, repository.NodeTypeVenue:
+		if node.Type != expected {
+			return validationError("%s node type %q does not match predicate %s_type %q", role, node.Type, role, expected)
+		}
+		return nil
+	case repository.NodeTypeEntity:
+		entity, err := s.entityRepo.GetEntityTx(ctx, tx, node.ID)
+		if err != nil {
+			if errors.Is(err, db.ErrNotFound) {
+				return validationError("%s entity node %s has no entity row", role, node.ID)
+			}
+			return fmt.Errorf("load %s entity: %w", role, err)
+		}
+		if entity.Subtype != expected {
+			return validationError("%s entity subtype %q does not match predicate %s_type %q", role, entity.Subtype, role, expected)
+		}
+		return nil
+	default:
+		return validationError("%s node %s has unknown type %q", role, node.ID, node.Type)
+	}
+}
+
+// validateFactValue checks the fact payload: the value column for the predicate's
+// value_type is set, parses, and (for text) is non-empty after trim; no other
+// scalar is set.
+func validateFactValue(req *AssertRequest, predicate *repository.Predicate) error {
+	if predicate.ValueType == nil {
+		return validationError("fact predicate %q has no value_type in the catalog", predicate.Key)
+	}
+	if scalarCount(req) != 1 {
+		return validationError("fact predicate %q requires exactly one value field set", predicate.Key)
+	}
+	switch *predicate.ValueType {
+	case repository.PredicateValueTypeText:
+		if req.ValueText == nil {
+			return validationError("fact predicate %q expects value_text", predicate.Key)
+		}
+		if strings.TrimSpace(*req.ValueText) == "" {
+			return validationError("fact predicate %q value_text must be non-empty after trim", predicate.Key)
+		}
+	case repository.PredicateValueTypeNum:
+		if req.ValueNum == nil {
+			return validationError("fact predicate %q expects value_num", predicate.Key)
+		}
+	case repository.PredicateValueTypeDate:
+		if req.ValueDate == nil {
+			return validationError("fact predicate %q expects value_date", predicate.Key)
+		}
+	case repository.PredicateValueTypeBool:
+		if req.ValueBool == nil {
+			return validationError("fact predicate %q expects value_bool", predicate.Key)
+		}
+	default:
+		return validationError("fact predicate %q has unknown value_type %q", predicate.Key, *predicate.ValueType)
+	}
+	return nil
+}
+
+// validateLocators checks each provenance locator: producer_kind set, source_kind
+// in the closed enum, content-kind rows exist, and phone_call/calendar_event do
+// not back a fact (metadata-only sources).
+func (s *AssertService) validateLocators(ctx context.Context, predicate *repository.Predicate, locators []ProvenanceLocator) error {
+	for i, loc := range locators {
+		if !isValidProducerKind(loc.ProducerKind) {
+			return validationError("locator[%d] producer_kind %q is not in {extractor,agent,user}", i, loc.ProducerKind)
+		}
+		if !isValidSourceKind(loc.SourceKind) {
+			return validationError("locator[%d] source_kind %q is not in the closed enum", i, loc.SourceKind)
+		}
+		// phone_call / calendar_event are metadata sources; they may not back a fact.
+		if predicate.Kind == repository.PredicateKindFact &&
+			(loc.SourceKind == repository.SourceKindPhoneCall || loc.SourceKind == repository.SourceKindCalendarEvent) {
+			return validationError("locator[%d] source_kind %q may not back a fact assertion", i, loc.SourceKind)
+		}
+		// Content-kind rows must exist at write time.
+		if repository.SourceKindRequiresExistenceCheck(loc.SourceKind) {
+			id, parseErr := uuid.Parse(loc.SourceID)
+			if parseErr != nil {
+				return validationError("locator[%d] source_id %q is not a UUID for source_kind %q", i, loc.SourceID, loc.SourceKind)
+			}
+			exists, err := s.assertionRepo.ExistsContentRow(ctx, loc.SourceKind, id)
+			if err != nil {
+				return fmt.Errorf("check locator[%d] source row: %w", i, err)
+			}
+			if !exists {
+				return validationError("locator[%d] %s source row %s does not exist", i, loc.SourceKind, loc.SourceID)
+			}
+		} else if loc.SourceID == "" {
+			// user / agent_session / anarlog_transcript carry no row check, but a
+			// stable source_id is still required (it keys idempotent re-runs).
+			return validationError("locator[%d] source_id is required for source_kind %q", i, loc.SourceKind)
+		}
+	}
+	return nil
+}
+
+// hasAnyScalar reports whether any value_* field is set.
+func hasAnyScalar(req *AssertRequest) bool {
+	return scalarCount(req) > 0
+}
+
+// scalarCount counts how many value_* fields are set.
+func scalarCount(req *AssertRequest) int {
+	n := 0
+	if req.ValueText != nil {
+		n++
+	}
+	if req.ValueNum != nil {
+		n++
+	}
+	if req.ValueDate != nil {
+		n++
+	}
+	if req.ValueBool != nil {
+		n++
+	}
+	return n
+}
+
+func isValidProducerKind(k string) bool {
+	switch k {
+	case repository.ProducerKindExtractor, repository.ProducerKindAgent, repository.ProducerKindUser:
+		return true
+	default:
+		return false
+	}
+}
+
+func isValidSourceKind(k string) bool {
+	switch k {
+	case repository.SourceKindCommsMessage, repository.SourceKindTelegramMessage,
+		repository.SourceKindMessagesMessage, repository.SourceKindMeetingNote,
+		repository.SourceKindAnarlogTranscript, repository.SourceKindCalendarEvent,
+		repository.SourceKindPhoneCall, repository.SourceKindUser, repository.SourceKindAgentSession:
+		return true
+	default:
+		return false
+	}
+}
+
+// --------------------------------------------------------------------------
+// Step 3 match branch: corroborate an existing live proposition.
+// --------------------------------------------------------------------------
+
+// corroborate appends the incoming provenance to a matched live assertion,
+// re-aggregates confidence (max) + trust_tier, emits provenance_added per NEW
+// locator, and — if the matched row is 'proposed' and this write should land
+// accepted — runs the step-4 supersession and transitions it to accepted.
+func (s *AssertService) corroborate(ctx context.Context, tx pgx.Tx, predicate *repository.Predicate, existing *repository.Assertion, req *AssertRequest, landingAccepted bool, now time.Time) (*repository.Assertion, error) {
+	// Append provenance + emit provenance_added per genuinely-new locator.
+	if err := s.appendProvenance(ctx, tx, existing, req.Locators); err != nil {
+		return nil, err
+	}
+
+	// Re-aggregate confidence (max) + trust_tier across the (now wider) locator set.
+	newConfidence := existing.Confidence
+	if req.Confidence > newConfidence {
+		newConfidence = req.Confidence
+	}
+	newTrust := strongerTrust(existing.TrustTier, req.Locators)
+	if newConfidence != existing.Confidence || !trustEqual(existing.TrustTier, newTrust) {
+		if err := s.assertionRepo.UpdateAssertionConfidenceTrustTx(ctx, tx, existing.ID, newConfidence, newTrust); err != nil {
+			return nil, fmt.Errorf("re-aggregate confidence/trust: %w", err)
+		}
+		existing.Confidence = newConfidence
+		existing.TrustTier = newTrust
+	}
+
+	// Upgrade proposed → accepted when this corroboration is also an acceptance:
+	// a stale proposed row must not shadow the live-proposition index against an
+	// accepting writer.
+	if existing.Status == repository.AssertionStatusProposed && landingAccepted {
+		// Run the single-cardinality conflict check AT ACCEPT TIME (the prior
+		// accepted slot, if any, is superseded by this now-accepting row).
+		if err := s.supersedeConflicts(ctx, tx, predicate, existing, now); err != nil {
+			return nil, err
+		}
+		if err := s.assertionRepo.TransitionStatusTx(ctx, tx, existing.ID, repository.AssertionStatusAccepted, nil, nil); err != nil {
+			return nil, fmt.Errorf("transition proposed→accepted: %w", err)
+		}
+		existing.Status = repository.AssertionStatusAccepted
+		if err := s.emitAssertionEvent(ctx, tx, events.KindAssertionAccepted, existing, now); err != nil {
+			return nil, err
+		}
+	}
+
+	return existing, nil
+}
+
+// appendProvenance inserts each incoming locator (ON CONFLICT no-op) and emits
+// assertion.provenance_added only for a genuinely-new locator (the :execrows
+// affected count tells us), keyed by locator_hash for idempotency.
+func (s *AssertService) appendProvenance(ctx context.Context, tx pgx.Tx, assertion *repository.Assertion, locators []ProvenanceLocator) error {
+	for _, loc := range locators {
+		hash := computeLocatorHash(loc)
+		inserted, err := s.assertionRepo.InsertProvenanceTx(ctx, tx, repository.InsertProvenanceParams{
+			AssertionID:     assertion.ID,
+			LocatorHash:     hash,
+			SourceKind:      loc.SourceKind,
+			SourceID:        loc.SourceID,
+			ProducerKind:    loc.ProducerKind,
+			ProducerVersion: loc.ProducerVersion,
+			Field:           loc.Field,
+			StartOffset:     loc.StartOffset,
+			EndOffset:       loc.EndOffset,
+			ChunkID:         loc.ChunkID,
+			InputHash:       loc.InputHash,
+			Quote:           loc.Quote,
+		})
+		if err != nil {
+			return fmt.Errorf("insert provenance: %w", err)
+		}
+		if inserted {
+			if err := s.emitProvenanceAddedEvent(ctx, tx, assertion, hash); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// --------------------------------------------------------------------------
+// Steps 4-5 (no-match): cardinality/supersession + write the new row.
+// --------------------------------------------------------------------------
+
+func (s *AssertService) writeNew(ctx context.Context, tx pgx.Tx, predicate *repository.Predicate, canonKey string, canonSubject uuid.UUID, canonObject *uuid.UUID, propKey string, req *AssertRequest, landingAccepted bool, knowledgeFrom, now time.Time) (*repository.Assertion, error) {
+	status := repository.AssertionStatusProposed
+	if landingAccepted {
+		status = repository.AssertionStatusAccepted
+	}
+
+	salience := predicate.DefaultSalience
+	if req.SalienceOverride != nil {
+		salience = *req.SalienceOverride
+	}
+	if salience < 0 || salience > 100 {
+		return nil, validationError("salience %d out of range [0,100]", salience)
+	}
+
+	// effective_from = COALESCE(valid_from, now) — the overlap-probe + supersession
+	// boundary. A NULL valid_from (the common "as of now" edit) probes as
+	// [now, valid_to) and the STORED valid_from stays NULL/open.
+	effectiveFrom := now
+	if req.ValidFrom != nil {
+		effectiveFrom = req.ValidFrom.UTC()
+	}
+
+	// Degenerate-range guard: an explicit past valid_to with a now/unknown start is
+	// an incoherent "true until a past date but start unknown" assertion → REJECT.
+	if req.ValidTo != nil && !req.ValidTo.UTC().After(effectiveFrom) {
+		return nil, validationError("valid_to %s is not after effective_from %s (degenerate/empty range)", req.ValidTo.UTC(), effectiveFrom)
+	}
+
+	// Single-cardinality + accepted-landing writes run the supersession check under
+	// the advisory lock. Multi or proposed-landing skip it. A past-bounded backfill
+	// (valid_to <= now) is a statement about the PAST → coexists, never supersedes.
+	needsConflictCheck := landingAccepted && predicate.Cardinality == repository.PredicateCardinalitySingle
+	pastBounded := req.ValidTo != nil && !req.ValidTo.UTC().After(now)
+
+	if needsConflictCheck && !pastBounded {
+		// Acquire the advisory lock(s) BEFORE the conflict check (serializes the
+		// empty-slot race a FOR UPDATE cannot). For a symmetric-single predicate the
+		// invariant is per-participant → one lock per participant, taken in lock-key
+		// order to avoid deadlock.
+		if err := s.acquireSlotLocks(ctx, tx, predicate, canonKey, canonSubject, canonObject); err != nil {
+			return nil, err
+		}
+
+		// Probe the accepted rows whose valid-time overlaps the new effective window.
+		conflicts, err := s.findOverlappingAccepted(ctx, tx, predicate, canonKey, canonSubject, canonObject, effectiveFrom, req.ValidTo)
+		if err != nil {
+			return nil, err
+		}
+
+		// Same-value reaffirmation: an overlapping accepted row with the SAME value
+		// is the SAME fact in a different bucket → widen it (no new row, no
+		// supersession).
+		newNormalized := normalizedPayload(canonObject, req)
+		if widen := findSameValue(conflicts, newNormalized); widen != nil {
+			return s.widenReaffirmation(ctx, tx, predicate, widen, canonKey, canonSubject, canonObject, req, effectiveFrom)
+		}
+
+		// Different-value conflict(s). Insert the new row first (insert-new-then-
+		// close-prior order under the DEFERRABLE self-FK), then close each prior.
+		inserted, recovered, err := s.insertNewAndEmit(ctx, tx, predicate, canonKey, canonSubject, canonObject, propKey, req, status, salience, knowledgeFrom, now, landingAccepted)
+		if err != nil {
+			return nil, err
+		}
+		if recovered {
+			// A concurrent writer won this slot; the loser corroborated its row.
+			// Conflict resolution against OTHER slots is the winner's job — skip it.
+			return inserted, nil
+		}
+		if err := s.closeConflicts(ctx, tx, conflicts, inserted, effectiveFrom, now); err != nil {
+			return nil, err
+		}
+		return inserted, nil
+	}
+
+	// No conflict check (multi / proposed / past-bounded backfill) → just insert.
+	inserted, _, err := s.insertNewAndEmit(ctx, tx, predicate, canonKey, canonSubject, canonObject, propKey, req, status, salience, knowledgeFrom, now, landingAccepted)
+	return inserted, err
+}
+
+// insertNewAndEmit inserts the new assertion (with savepoint-recover), emits the
+// create-transition event, and appends provenance. The recovered bool is true
+// when a concurrent writer won the live slot and the loser corroborated instead
+// (in which case the returned assertion is the corroborated existing row).
+func (s *AssertService) insertNewAndEmit(ctx context.Context, tx pgx.Tx, predicate *repository.Predicate, canonKey string, canonSubject uuid.UUID, canonObject *uuid.UUID, propKey string, req *AssertRequest, status string, salience int16, knowledgeFrom, now time.Time, landingAccepted bool) (assertion *repository.Assertion, recovered bool, err error) {
+	inserted, err := s.insertAssertionWithRecover(ctx, tx, predicate, canonKey, canonSubject, canonObject, propKey, req, status, salience, knowledgeFrom)
+	if err != nil {
+		return nil, false, err
+	}
+	if inserted == nil {
+		// A concurrent writer won the live-proposition slot; re-read + corroborate.
+		existing, rerr := s.assertionRepo.FindLivePropositionTx(ctx, tx, propKey)
+		if rerr != nil {
+			return nil, false, fmt.Errorf("re-read after concurrent insert: %w", rerr)
+		}
+		corr, cerr := s.corroborate(ctx, tx, predicate, existing, req, landingAccepted, now)
+		return corr, true, cerr
+	}
+
+	createKind := events.KindAssertionProposed
+	if status == repository.AssertionStatusAccepted {
+		createKind = events.KindAssertionAccepted
+	}
+	if err := s.emitAssertionEvent(ctx, tx, createKind, inserted, now); err != nil {
+		return nil, false, err
+	}
+	if err := s.appendProvenance(ctx, tx, inserted, req.Locators); err != nil {
+		return nil, false, err
+	}
+	return inserted, false, nil
+}
+
+// findOverlappingAccepted runs the valid-time overlap probe (FOR UPDATE) for the
+// slot. Asymmetric → (subject, predicate); symmetric → either participant in
+// either position. effectiveFrom is the new-side lower bound (COALESCE(valid_from,
+// now)); newValidTo is the new row's valid_to (nil = open).
+func (s *AssertService) findOverlappingAccepted(ctx context.Context, tx pgx.Tx, predicate *repository.Predicate, canonKey string, canonSubject uuid.UUID, canonObject *uuid.UUID, effectiveFrom time.Time, newValidTo *time.Time) ([]repository.Assertion, error) {
+	if predicate.Symmetric && canonObject != nil {
+		return s.assertionRepo.FindAcceptedForSlotSymmetricTx(ctx, tx, canonKey, canonSubject, *canonObject, effectiveFrom, utcPtr(newValidTo))
+	}
+	return s.assertionRepo.FindAcceptedForSlotTx(ctx, tx, canonSubject, canonKey, effectiveFrom, utcPtr(newValidTo))
+}
+
+// normalizedPayload returns the normalized value form for the new request: the
+// canonical object UUID for an edge, else the normalized scalar.
+func normalizedPayload(canonObject *uuid.UUID, req *AssertRequest) string {
+	if canonObject != nil {
+		return canonObject.String()
+	}
+	return normalizeValue(req)
+}
+
+// findSameValue returns the first conflict row whose payload equals the new
+// normalized value (a same-value reaffirmation), or nil.
+func findSameValue(conflicts []repository.Assertion, newNormalized string) *repository.Assertion {
+	for i := range conflicts {
+		if assertionNormalizedValue(&conflicts[i]) == newNormalized {
+			return &conflicts[i]
+		}
+	}
+	return nil
+}
+
+// assertionNormalizedValue returns the normalized payload form of a stored
+// assertion row (mirrors normalizeValue/normalizedPayload for a persisted row).
+func assertionNormalizedValue(a *repository.Assertion) string {
+	switch {
+	case a.ObjectNodeID != nil:
+		return a.ObjectNodeID.String()
+	case a.ValueText != nil:
+		return strings.ToLower(strings.TrimSpace(*a.ValueText))
+	case a.ValueNum != nil:
+		return strconv.FormatFloat(*a.ValueNum, 'g', -1, 64)
+	case a.ValueDate != nil:
+		return a.ValueDate.UTC().Format("2006-01-02")
+	case a.ValueBool != nil:
+		if *a.ValueBool {
+			return "t"
+		}
+		return "f"
+	default:
+		return ""
+	}
+}
+
+// acquireSlotLocks takes the per-slot advisory lock(s) for a single-cardinality
+// accepted write. Asymmetric → one lock on (subject, canonical predicate).
+// Symmetric → one lock per participant (subject AND object), taken in lock-key
+// order so two concurrent writes touching the same pair acquire in the same order
+// (deadlock-safe).
+func (s *AssertService) acquireSlotLocks(ctx context.Context, tx pgx.Tx, predicate *repository.Predicate, canonKey string, canonSubject uuid.UUID, canonObject *uuid.UUID) error {
+	var keys []int64
+	if predicate.Symmetric && canonObject != nil {
+		keys = []int64{
+			slotLockKey(canonKey, canonSubject),
+			slotLockKey(canonKey, *canonObject),
+		}
+	} else {
+		keys = []int64{slotLockKey(canonKey, canonSubject)}
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+	for _, k := range keys {
+		if err := s.assertionRepo.AcquirePropositionSlotLockTx(ctx, tx, k); err != nil {
+			return fmt.Errorf("acquire slot lock: %w", err)
+		}
+	}
+	return nil
+}
+
+// widenReaffirmation extends a same-value accepted row's window to cover the new
+// evidence (lower valid_from / raise valid_to), recomputes its proposition_key
+// from the widened valid_from bucket, appends the new provenance, and emits
+// provenance_added. No new row, no supersession event. On a recomputed-key
+// collision with ANOTHER live same-value row (non-contiguous stints in different
+// buckets), it MERGES the two: provenance onto the survivor, close the other
+// superseded. The widened row is the survivor.
+func (s *AssertService) widenReaffirmation(ctx context.Context, tx pgx.Tx, predicate *repository.Predicate, existing *repository.Assertion, canonKey string, canonSubject uuid.UUID, canonObject *uuid.UUID, req *AssertRequest, effectiveFrom time.Time) (*repository.Assertion, error) {
+	// Union the windows. nil start = -inf (open), nil end = +inf (open). The new
+	// side uses the request's content bounds (effectiveFrom is the probe boundary,
+	// but the STORED widened window unions real evidence: a NULL new valid_from
+	// keeps the existing/open start).
+	widenedFrom := minStart(existing.ValidFrom, req.ValidFrom)
+	widenedTo := maxEnd(existing.ValidTo, req.ValidTo)
+
+	// Recompute the proposition_key from the widened valid_from bucket.
+	widenedReq := *req
+	widenedReq.ValidFrom = widenedFrom
+	newKey := computePropositionKey(predicate, canonKey, canonSubject, canonObject, &widenedReq)
+
+	// Collision: another LIVE row already holds the recomputed key (a non-contiguous
+	// same-value stint in that bucket). Merge it into this survivor instead of
+	// UPDATE-ing into the unique index (which would 23505).
+	if newKey != existing.PropositionKey {
+		collider, err := s.assertionRepo.FindLivePropositionTx(ctx, tx, newKey)
+		if err != nil && !errors.Is(err, db.ErrNotFound) {
+			return nil, fmt.Errorf("widen collision check: %w", err)
+		}
+		if err == nil && collider.ID != existing.ID {
+			// Union the survivor window with the collider's too, then merge.
+			widenedFrom = minStart(widenedFrom, collider.ValidFrom)
+			widenedTo = maxEnd(widenedTo, collider.ValidTo)
+			widenedReq.ValidFrom = widenedFrom
+			newKey = computePropositionKey(predicate, canonKey, canonSubject, canonObject, &widenedReq)
+			if err := s.mergeSameValue(ctx, tx, collider, existing); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if err := s.assertionRepo.WidenAssertionValidityTx(ctx, tx, existing.ID, widenedFrom, widenedTo, newKey); err != nil {
+		return nil, fmt.Errorf("widen assertion validity: %w", err)
+	}
+	existing.ValidFrom = widenedFrom
+	existing.ValidTo = widenedTo
+	existing.PropositionKey = newKey
+
+	// Append the corroborating provenance + re-aggregate confidence/trust.
+	if err := s.appendProvenance(ctx, tx, existing, req.Locators); err != nil {
+		return nil, err
+	}
+	newConfidence := existing.Confidence
+	if req.Confidence > newConfidence {
+		newConfidence = req.Confidence
+	}
+	newTrust := strongerTrust(existing.TrustTier, req.Locators)
+	if newConfidence != existing.Confidence || !trustEqual(existing.TrustTier, newTrust) {
+		if err := s.assertionRepo.UpdateAssertionConfidenceTrustTx(ctx, tx, existing.ID, newConfidence, newTrust); err != nil {
+			return nil, fmt.Errorf("re-aggregate confidence/trust on widen: %w", err)
+		}
+		existing.Confidence = newConfidence
+		existing.TrustTier = newTrust
+	}
+	return existing, nil
+}
+
+// mergeSameValue collapses a colliding same-value live row (loser) into the
+// survivor: move the loser's provenance onto the survivor (ON CONFLICT no-op) and
+// close the loser superseded with superseded_by = survivor. Emits provenance_added
+// per moved locator + superseded for the loser.
+func (s *AssertService) mergeSameValue(ctx context.Context, tx pgx.Tx, loser, survivor *repository.Assertion) error {
+	provs, err := s.assertionRepo.ListProvenance(ctx, loser.ID)
+	if err != nil {
+		return fmt.Errorf("list loser provenance: %w", err)
+	}
+	for _, p := range provs {
+		inserted, err := s.assertionRepo.InsertProvenanceTx(ctx, tx, repository.InsertProvenanceParams{
+			AssertionID:     survivor.ID,
+			LocatorHash:     p.LocatorHash,
+			SourceKind:      p.SourceKind,
+			SourceID:        p.SourceID,
+			ProducerKind:    p.ProducerKind,
+			ProducerVersion: p.ProducerVersion,
+			Field:           p.Field,
+			StartOffset:     p.StartOffset,
+			EndOffset:       p.EndOffset,
+			ChunkID:         p.ChunkID,
+			InputHash:       p.InputHash,
+			Quote:           p.Quote,
+		})
+		if err != nil {
+			return fmt.Errorf("move provenance to survivor: %w", err)
+		}
+		if inserted {
+			if err := s.emitProvenanceAddedEvent(ctx, tx, survivor, p.LocatorHash); err != nil {
+				return err
+			}
+		}
+	}
+	now := accelerated.GetCurrentTime().UTC()
+	closure := repository.ClosureReasonSuperseded
+	if err := s.assertionRepo.CloseAssertionTx(ctx, tx, repository.CloseAssertionParams{
+		ID:            loser.ID,
+		ValidTo:       loser.ValidTo,
+		Status:        repository.AssertionStatusSuperseded,
+		ClosureReason: &closure,
+		SupersededBy:  &survivor.ID,
+		KnowledgeTo:   &now,
+	}); err != nil {
+		return fmt.Errorf("close merged loser: %w", err)
+	}
+	return s.emitAssertionEvent(ctx, tx, events.KindAssertionSuperseded, loser, now)
+}
+
+// closeConflicts closes each different-value overlapping prior for a present/
+// future successor (D6 step 4). The newRow is the just-inserted successor.
+//
+//   - Future successor (effectiveFrom > now): bound the CURRENT prior (valid_to =
+//     effectiveFrom, superseded_by = newRow.id) but KEEP it accepted/knowledge-open
+//     (still current until the future date). The rollover job terminalizes it
+//     later. A pending future successor among the priors is fully superseded now.
+//   - Present successor (effectiveFrom <= now): terminalize each overlapping prior
+//     (status=superseded, valid_to=effectiveFrom, superseded_by=newRow.id,
+//     knowledge_to=now), cancelling any stale pending future successor too.
+func (s *AssertService) closeConflicts(ctx context.Context, tx pgx.Tx, conflicts []repository.Assertion, newRow *repository.Assertion, effectiveFrom, now time.Time) error {
+	future := effectiveFrom.After(now)
+	for i := range conflicts {
+		prior := &conflicts[i]
+		if prior.ID == newRow.ID {
+			continue
+		}
+		// valid_range CHECK: effectiveFrom must be > prior.valid_from. A backfilled
+		// successor whose boundary precedes the prior's start is incoherent → REJECT.
+		if prior.ValidFrom != nil && !effectiveFrom.After(*prior.ValidFrom) {
+			return validationError("successor boundary %s is not after prior valid_from %s", effectiveFrom, prior.ValidFrom.UTC())
+		}
+		// A pending future successor (already bounded, valid_from in the future) that
+		// this present edit overrides is fully superseded regardless of the branch.
+		priorIsPendingFuture := prior.SupersededBy != nil && prior.ValidFrom != nil && prior.ValidFrom.After(now)
+
+		if future && !priorIsPendingFuture {
+			// Bound the still-current prior; keep it accepted (current until the date).
+			if err := s.assertionRepo.BoundPendingSuccessorTx(ctx, tx, prior.ID, effectiveFrom, newRow.ID); err != nil {
+				return fmt.Errorf("bound pending successor: %w", err)
+			}
+			continue
+		}
+		// Terminalize the prior (present edit, or a pending future successor a present
+		// edit cancels).
+		closure := repository.ClosureReasonSuperseded
+		boundTo := closeBoundary(prior, effectiveFrom, now)
+		if err := s.assertionRepo.CloseAssertionTx(ctx, tx, repository.CloseAssertionParams{
+			ID:            prior.ID,
+			ValidTo:       boundTo,
+			Status:        repository.AssertionStatusSuperseded,
+			ClosureReason: &closure,
+			SupersededBy:  &newRow.ID,
+			KnowledgeTo:   &now,
+		}); err != nil {
+			return fmt.Errorf("close prior on supersession: %w", err)
+		}
+		if err := s.emitAssertionEvent(ctx, tx, events.KindAssertionSuperseded, prior, now); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// closeBoundary picks the valid_to to stamp on a terminalized prior. For a present
+// successor the boundary is effectiveFrom (the new row starts where the old ends).
+// For a pending future successor being cancelled by a present edit, its valid_from
+// is already in the future — clamping valid_to to effectiveFrom (<= now) would
+// violate the valid_range CHECK (valid_to > valid_from). Such a never-current
+// pending row is closed with valid_to = its own valid_from (a zero-length future
+// window) so the CHECK holds and it never becomes current.
+func closeBoundary(prior *repository.Assertion, effectiveFrom, now time.Time) *time.Time {
+	if prior.ValidFrom != nil && prior.ValidFrom.After(now) && !effectiveFrom.After(*prior.ValidFrom) {
+		vf := prior.ValidFrom.UTC()
+		return &vf
+	}
+	ef := effectiveFrom
+	return &ef
+}
+
+// supersedeConflicts runs the single-cardinality conflict resolution for an
+// already-existing row transitioning to accepted (the proposed→accepted upgrade
+// and the Accept path). It acquires the slot lock(s), probes the overlapping
+// accepted rows (excluding the accepting row), and closes the different-value
+// priors (present/future branch). It does NOT re-check same-value (an accept of a
+// proposed row is a distinct proposition from any same-value accepted row, so
+// they coexist until the user reconciles; SP1 keeps accept-time minimal).
+func (s *AssertService) supersedeConflicts(ctx context.Context, tx pgx.Tx, predicate *repository.Predicate, accepting *repository.Assertion, now time.Time) error {
+	if predicate.Cardinality != repository.PredicateCardinalitySingle {
+		return nil
+	}
+	canonKey, canonSubject, canonObject := canonicalEdge(predicate, accepting.SubjectNodeID, accepting.ObjectNodeID)
+	if err := s.acquireSlotLocks(ctx, tx, predicate, canonKey, canonSubject, canonObject); err != nil {
+		return err
+	}
+	effectiveFrom := now
+	if accepting.ValidFrom != nil {
+		effectiveFrom = accepting.ValidFrom.UTC()
+	}
+	// A past-bounded accepting row coexists (it is historical) → no supersession.
+	if accepting.ValidTo != nil && !accepting.ValidTo.UTC().After(now) {
+		return nil
+	}
+	conflicts, err := s.findOverlappingAccepted(ctx, tx, predicate, canonKey, canonSubject, canonObject, effectiveFrom, accepting.ValidTo)
+	if err != nil {
+		return err
+	}
+	return s.closeConflicts(ctx, tx, conflicts, accepting, effectiveFrom, now)
+}
+
+// insertAssertionWithRecover inserts the new assertion, recovering from the
+// identical-value concurrent-insert 23505 on idx_assertion_live_proposition via a
+// nested savepoint: on the unique violation it rolls back the savepoint (so the
+// outer tx is not aborted) and returns (nil, nil) to signal the caller to re-read
+// + corroborate. Any other error propagates.
+func (s *AssertService) insertAssertionWithRecover(ctx context.Context, tx pgx.Tx, predicate *repository.Predicate, canonKey string, canonSubject uuid.UUID, canonObject *uuid.UUID, propKey string, req *AssertRequest, status string, salience int16, knowledgeFrom time.Time) (*repository.Assertion, error) {
+	params := repository.InsertAssertionParams{
+		SubjectNodeID:  canonSubject,
+		PredicateKey:   canonKey,
+		ObjectNodeID:   canonObject,
+		KnowledgeFrom:  knowledgeFrom,
+		Confidence:     req.Confidence,
+		Salience:       salience,
+		Status:         status,
+		PropositionKey: propKey,
+		// trust_tier denorm: the strongest producer across the row's locators.
+		TrustTier: strongerTrust(nil, req.Locators),
+	}
+	// Carry the fact scalar (edge object is set via ObjectNodeID above).
+	if predicate.Kind == repository.PredicateKindFact {
+		params.ValueText = req.ValueText
+		params.ValueNum = req.ValueNum
+		params.ValueDate = req.ValueDate
+		params.ValueBool = req.ValueBool
+	}
+	// valid_from is set ONLY from content evidence (never defaulted to now).
+	params.ValidFrom = utcPtr(req.ValidFrom)
+	params.ValidTo = utcPtr(req.ValidTo)
+
+	sp, err := tx.Begin(ctx) // nested savepoint
+	if err != nil {
+		return nil, fmt.Errorf("begin savepoint: %w", err)
+	}
+	inserted, err := s.assertionRepo.InsertAssertionTx(ctx, sp, params)
+	if err != nil {
+		_ = sp.Rollback(ctx)
+		if isLivePropositionViolation(err) {
+			return nil, nil // signal: concurrent writer won; recover via re-read
+		}
+		return nil, fmt.Errorf("insert assertion: %w", err)
+	}
+	if err := sp.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit savepoint: %w", err)
+	}
+	return inserted, nil
+}
+
+// --------------------------------------------------------------------------
+// AssertClosure / Accept / Reject / Retract / EnsureLatentPerson.
+// --------------------------------------------------------------------------
+
+// AssertClosure closes a single-cardinality slot with NO successor ("between
+// jobs"): the current accepted assertion for (subject, predicate) is closed
+// 'ended' / superseded / knowledge_to=now / valid_to=now, and the current value
+// becomes a gap. Returns ErrNotFound (via the gap) if there is no current row.
+func (s *AssertService) AssertClosure(ctx context.Context, req ClosureRequest) (err error) {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if rb := tx.Rollback(ctx); rb != nil && !errors.Is(rb, pgx.ErrTxClosed) && err == nil {
+			err = rb
+		}
+	}()
+	if err = s.AssertClosureTx(ctx, tx, req); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+// AssertClosureTx is the tx-bound variant of AssertClosure.
+func (s *AssertService) AssertClosureTx(ctx context.Context, tx pgx.Tx, req ClosureRequest) error {
+	predicate, err := s.predicateRepo.GetPredicate(ctx, req.PredicateKey)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return validationError("unknown predicate %q", req.PredicateKey)
+		}
+		return fmt.Errorf("load predicate: %w", err)
+	}
+	now := accelerated.GetCurrentTime().UTC()
+	// Close the current accepted row for the slot (the subject's own slot; a
+	// closure targets the subject's predicate directly, not the canonical edge —
+	// closure is a fact/single-edge concept and the read uses subject+predicate).
+	current, err := s.assertionRepo.GetCurrentAcceptedTx(ctx, tx, req.SubjectNodeID, predicate.Key, now)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return nil // already a gap; nothing to close (idempotent)
+		}
+		return fmt.Errorf("load current for closure: %w", err)
+	}
+	closure := repository.ClosureReasonEnded
+	if err := s.assertionRepo.CloseAssertionTx(ctx, tx, repository.CloseAssertionParams{
+		ID:            current.ID,
+		ValidTo:       &now,
+		Status:        repository.AssertionStatusSuperseded,
+		ClosureReason: &closure,
+		SupersededBy:  nil,
+		KnowledgeTo:   &now,
+	}); err != nil {
+		return fmt.Errorf("close current on closure: %w", err)
+	}
+	return s.emitAssertionEvent(ctx, tx, events.KindAssertionSuperseded, current, now)
+}
+
+// Accept transitions a proposed assertion to accepted (a human/agent confirms a
+// review item). It runs the single-cardinality supersession AT ACCEPT TIME so a
+// proposed row that becomes accepted supersedes the prior accepted slot.
+func (s *AssertService) Accept(ctx context.Context, assertionID uuid.UUID, _ AcceptRequest) (a *repository.Assertion, err error) {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if rb := tx.Rollback(ctx); rb != nil && !errors.Is(rb, pgx.ErrTxClosed) && err == nil {
+			err = rb
+		}
+	}()
+	a, err = s.AcceptTx(ctx, tx, assertionID)
+	if err != nil {
+		return nil, err
+	}
+	if err = tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+	return a, nil
+}
+
+// AcceptTx is the tx-bound variant of Accept.
+func (s *AssertService) AcceptTx(ctx context.Context, tx pgx.Tx, assertionID uuid.UUID) (*repository.Assertion, error) {
+	now := accelerated.GetCurrentTime().UTC()
+	assertion, err := s.assertionRepo.GetAssertionTx(ctx, tx, assertionID)
+	if err != nil {
+		return nil, err
+	}
+	if assertion.Status != repository.AssertionStatusProposed {
+		return nil, validationError("assertion %s is %q, only a proposed assertion may be accepted", assertionID, assertion.Status)
+	}
+	predicate, err := s.predicateRepo.GetPredicate(ctx, assertion.PredicateKey)
+	if err != nil {
+		return nil, fmt.Errorf("load predicate: %w", err)
+	}
+	// Single-cardinality supersession at accept time (locks + closes the prior).
+	if err := s.supersedeConflicts(ctx, tx, predicate, assertion, now); err != nil {
+		return nil, err
+	}
+	if err := s.assertionRepo.TransitionStatusTx(ctx, tx, assertionID, repository.AssertionStatusAccepted, nil, nil); err != nil {
+		return nil, fmt.Errorf("transition proposed→accepted: %w", err)
+	}
+	assertion.Status = repository.AssertionStatusAccepted
+	if err := s.emitAssertionEvent(ctx, tx, events.KindAssertionAccepted, assertion, now); err != nil {
+		return nil, err
+	}
+	return assertion, nil
+}
+
+// Reject transitions a proposed assertion to rejected (a review item declined). It
+// never enters "current". Emits assertion.rejected.
+func (s *AssertService) Reject(ctx context.Context, assertionID uuid.UUID, _ RejectRequest) (a *repository.Assertion, err error) {
+	return s.terminalTransition(ctx, assertionID, repository.AssertionStatusProposed,
+		repository.AssertionStatusRejected, repository.ClosureReasonRejected, events.KindAssertionRejected)
+}
+
+// Retract transitions an accepted assertion to retracted (an explicit correction
+// or last-provenance-loss). A retract is the closure of an accepted row with no
+// successor — semantically a closure — so it emits assertion.superseded (NOT a
+// new kind); the row carries closure_reason='retracted' for any consumer that
+// needs to distinguish.
+func (s *AssertService) Retract(ctx context.Context, assertionID uuid.UUID, _ RetractRequest) (a *repository.Assertion, err error) {
+	return s.terminalTransition(ctx, assertionID, repository.AssertionStatusAccepted,
+		repository.AssertionStatusRetracted, repository.ClosureReasonRetracted, events.KindAssertionSuperseded)
+}
+
+// terminalTransition is the shared Reject/Retract path: require the from-status,
+// set the terminal status + knowledge_to + closure_reason, and emit the event.
+func (s *AssertService) terminalTransition(ctx context.Context, assertionID uuid.UUID, fromStatus, toStatus, closureReason string, kind events.Kind) (a *repository.Assertion, err error) {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if rb := tx.Rollback(ctx); rb != nil && !errors.Is(rb, pgx.ErrTxClosed) && err == nil {
+			err = rb
+		}
+	}()
+	now := accelerated.GetCurrentTime().UTC()
+	assertion, err := s.assertionRepo.GetAssertionTx(ctx, tx, assertionID)
+	if err != nil {
+		return nil, err
+	}
+	if assertion.Status != fromStatus {
+		return nil, validationError("assertion %s is %q, expected %q for this transition", assertionID, assertion.Status, fromStatus)
+	}
+	closure := closureReason
+	if err := s.assertionRepo.TransitionStatusTx(ctx, tx, assertionID, toStatus, &now, &closure); err != nil {
+		return nil, fmt.Errorf("terminal transition to %s: %w", toStatus, err)
+	}
+	assertion.Status = toStatus
+	assertion.KnowledgeTo = &now
+	assertion.ClosureReason = &closure
+	if err := s.emitAssertionEvent(ctx, tx, kind, assertion, now); err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+	return assertion, nil
+}
+
+// RunRollover terminalizes the bounded-with-pending-successor rows whose bound
+// has been reached (the daily rollover sweep, D6 step 4 / PR4). In one tx it flips
+// each matching row (status='accepted' AND knowledge_to IS NULL AND superseded_by
+// IS NOT NULL AND valid_to <= now) to status='superseded', closure_reason=
+// 'superseded', knowledge_to=now, and emits assertion.superseded per row. It is a
+// stateless catch-up sweep — a row already rolled over no longer matches, so
+// re-running is a no-op (and downtime catches up all overdue rollovers). A
+// successor-less bounded-past fact (superseded_by IS NULL) is NOT matched, so it
+// stays a legitimate accepted historical fact. Returns the number rolled over.
+//
+// The UPDATE...RETURNING and the per-row event publishes are in ONE tx, so a
+// publish failure rolls back the flip too — the next run re-selects and retries
+// (no stranded row). Returns the count of rows terminalized.
+func (s *AssertService) RunRollover(ctx context.Context) (rolledOver int, err error) {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer func() {
+		if rb := tx.Rollback(ctx); rb != nil && !errors.Is(rb, pgx.ErrTxClosed) && err == nil {
+			err = rb
+		}
+	}()
+	now := accelerated.GetCurrentTime().UTC()
+	rows, err := s.assertionRepo.RolloverDueBoundedSuccessorsTx(ctx, tx, now)
+	if err != nil {
+		return 0, fmt.Errorf("rollover due bounded successors: %w", err)
+	}
+	for i := range rows {
+		if err := s.emitAssertionEvent(ctx, tx, events.KindAssertionSuperseded, &rows[i], now); err != nil {
+			return 0, err
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return 0, err
+	}
+	return len(rows), nil
+}
+
+// EnsureLatentPerson returns the node id for a person referenced by an edge but
+// not yet in the CRM (a knows/introduced_by target). It mints a latent
+// person node (no contact row) and returns its id. Idempotency is the caller's
+// concern — a fresh node is created each call (latent-person dedup is deferred per
+// the spec); callers that hold a known node id should pass it directly rather than
+// minting a latent one.
+func (s *AssertService) EnsureLatentPerson(ctx context.Context, tx pgx.Tx, label string) (uuid.UUID, error) {
+	id := uuid.New()
+	if _, err := s.nodeRepo.CreateNodeTx(ctx, tx, id, repository.NodeTypePerson, label); err != nil {
+		return uuid.Nil, fmt.Errorf("create latent person node: %w", err)
+	}
+	return id, nil
+}
+
+// --------------------------------------------------------------------------
+// Event emission.
+// --------------------------------------------------------------------------
+
+// emitAssertionEvent publishes a one-shot assertion lifecycle event keyed for
+// idempotency by '<assertion_id>:<transition>'. The transition token is derived
+// from the kind (proposed/accepted/superseded/rejected). A retract emits the
+// superseded kind, so its key is '<id>:superseded' — still one-shot (an accepted
+// row is closed at most once).
+func (s *AssertService) emitAssertionEvent(ctx context.Context, tx pgx.Tx, kind events.Kind, assertion *repository.Assertion, now time.Time) error {
+	sourceID := assertion.ID.String() + ":" + transitionToken(kind)
+	return s.publishAssertionEnvelope(ctx, tx, kind, assertion, sourceID, now)
+}
+
+// emitProvenanceAddedEvent publishes a provenance_added event keyed per locator by
+// '<assertion_id>:provenance:<locator_hash>' (many-per-assertion).
+func (s *AssertService) emitProvenanceAddedEvent(ctx context.Context, tx pgx.Tx, assertion *repository.Assertion, locatorHash string) error {
+	sourceID := assertion.ID.String() + ":provenance:" + locatorHash
+	return s.publishAssertionEnvelope(ctx, tx, events.KindAssertionProvenanceAdded, assertion, sourceID, now())
+}
+
+// publishAssertionEnvelope marshals the shared payload + publishes the envelope.
+func (s *AssertService) publishAssertionEnvelope(ctx context.Context, tx pgx.Tx, kind events.Kind, assertion *repository.Assertion, sourceID string, observedAt time.Time) error {
+	payload, err := events.Marshal(kind, events.AssertionEventPayload{
+		Version:       1,
+		AssertionID:   assertion.ID,
+		SubjectNodeID: assertion.SubjectNodeID,
+		PredicateKey:  assertion.PredicateKey,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal %s payload: %w", kind, err)
+	}
+	env := &events.Envelope{
+		Source:     "assertion",
+		SourceID:   sourceID,
+		Kind:       kind,
+		Payload:    payload,
+		ObservedAt: observedAt,
+	}
+	if err := s.bus.PublishTx(ctx, tx, env); err != nil {
+		return fmt.Errorf("publish %s: %w", kind, err)
+	}
+	return nil
+}
+
+// transitionToken maps a kind to its one-shot source_id transition token.
+func transitionToken(kind events.Kind) string {
+	switch kind {
+	case events.KindAssertionProposed:
+		return "proposed"
+	case events.KindAssertionAccepted:
+		return "accepted"
+	case events.KindAssertionSuperseded:
+		return "superseded"
+	case events.KindAssertionRejected:
+		return "rejected"
+	default:
+		return string(kind)
+	}
+}
+
+func now() time.Time { return accelerated.GetCurrentTime().UTC() }
+
+// --------------------------------------------------------------------------
+// Small value helpers.
+// --------------------------------------------------------------------------
+
+// utcPtr normalizes a nullable time to UTC (nil stays nil).
+func utcPtr(t *time.Time) *time.Time {
+	if t == nil {
+		return nil
+	}
+	u := t.UTC()
+	return &u
+}
+
+// minStart returns the earlier of two valid_from bounds; nil = open (-inf), which
+// is the minimum, so a nil on either side wins.
+func minStart(a, b *time.Time) *time.Time {
+	if a == nil || b == nil {
+		return nil
+	}
+	if a.Before(*b) {
+		return utcPtr(a)
+	}
+	return utcPtr(b)
+}
+
+// maxEnd returns the later of two valid_to bounds; nil = open (+inf), which is the
+// maximum, so a nil on either side wins.
+func maxEnd(a, b *time.Time) *time.Time {
+	if a == nil || b == nil {
+		return nil
+	}
+	if a.After(*b) {
+		return utcPtr(a)
+	}
+	return utcPtr(b)
+}
+
+// producerRank ranks producer kinds for trust_tier (user strongest). The
+// trust_tier denorm is the strongest producer across an assertion's locators.
+func producerRank(producerKind string) int {
+	switch producerKind {
+	case repository.ProducerKindUser:
+		return 3
+	case repository.ProducerKindAgent:
+		return 2
+	case repository.ProducerKindExtractor:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// trustTierForProducer maps a producer kind to the trust_tier denorm token.
+func trustTierForProducer(producerKind string) string {
+	switch producerKind {
+	case repository.ProducerKindUser:
+		return "user"
+	case repository.ProducerKindAgent:
+		return "agent"
+	default:
+		return "extractor"
+	}
+}
+
+// strongerTrust returns the trust_tier denorm after folding in the incoming
+// locators: the strongest producer across the existing tier + the new locators.
+func strongerTrust(existing *string, locators []ProvenanceLocator) *string {
+	bestRank := 0
+	bestTier := ""
+	if existing != nil {
+		bestTier = *existing
+		bestRank = trustTierRank(*existing)
+	}
+	for _, loc := range locators {
+		if r := producerRank(loc.ProducerKind); r > bestRank {
+			bestRank = r
+			bestTier = trustTierForProducer(loc.ProducerKind)
+		}
+	}
+	if bestTier == "" {
+		return nil
+	}
+	return &bestTier
+}
+
+// trustTierRank ranks a stored trust_tier token (mirrors producerRank but over the
+// denorm tokens user/agent/extractor).
+func trustTierRank(tier string) int {
+	switch tier {
+	case "user":
+		return 3
+	case "agent":
+		return 2
+	case "extractor":
+		return 1
+	default:
+		return 0
+	}
+}
+
+// trustEqual compares two nullable trust tiers.
+func trustEqual(a, b *string) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}
+
+// isLivePropositionViolation reports whether err is a 23505 unique-violation on
+// the live-proposition index (the identical-value concurrent-insert race). Scoped
+// to that constraint so an UNRELATED unique violation is NOT silently treated as a
+// recoverable concurrent insert.
+func isLivePropositionViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) || pgErr.Code != pgerrcode.UniqueViolation {
+		return false
+	}
+	return pgErr.ConstraintName == "idx_assertion_live_proposition"
+}

--- a/backend/internal/service/assert.go
+++ b/backend/internal/service/assert.go
@@ -1258,7 +1258,17 @@ func (s *AssertService) resolveAcceptConflicts(ctx context.Context, tx pgx.Tx, p
 		}
 		survivor.ValidFrom = widenedFrom
 		survivor.ValidTo = widenedTo
-		widenReq := &AssertRequest{ValidFrom: survivor.ValidFrom}
+		// Carry the survivor's VALUE into the key recompute: for a fact (canonObject
+		// nil) computePropositionKey reads the request's value, so a value-less request
+		// would write an empty value component and break dedup of later same-value
+		// writes. Edges ignore the value (keyed on canonObject), so this is safe there.
+		widenReq := &AssertRequest{
+			ValidFrom: survivor.ValidFrom,
+			ValueText: survivor.ValueText,
+			ValueNum:  survivor.ValueNum,
+			ValueDate: survivor.ValueDate,
+			ValueBool: survivor.ValueBool,
+		}
 		newKey := computePropositionKey(predicate, canonKey, canonSubject, canonObject, widenReq)
 		// MERGE/close the accepting (loser) row FIRST so it is no longer live —
 		// otherwise WidenAssertionValidity could assign the survivor a key the still-

--- a/backend/internal/service/assert.go
+++ b/backend/internal/service/assert.go
@@ -460,6 +460,20 @@ func (s *AssertService) validate(ctx context.Context, tx pgx.Tx, req *AssertRequ
 		return nil, "", uuid.Nil, nil, err
 	}
 
+	// Degenerate-range guard (in validation, BEFORE the dedup lookup, so it fires
+	// even when an existing live row would otherwise corroborate): a now/unknown
+	// start (valid_from NULL → effective_from = now) combined with an explicit past
+	// valid_to is an incoherent "true until a past date but start unknown"
+	// assertion → REJECT (routed to manual review). A fully-bounded historical fact
+	// has an explicit valid_from < valid_to and passes.
+	effectiveFrom := accelerated.GetCurrentTime().UTC()
+	if req.ValidFrom != nil {
+		effectiveFrom = req.ValidFrom.UTC()
+	}
+	if req.ValidTo != nil && !req.ValidTo.UTC().After(effectiveFrom) {
+		return nil, "", uuid.Nil, nil, validationError("valid_to %s is not after effective_from %s (degenerate/empty range)", req.ValidTo.UTC(), effectiveFrom)
+	}
+
 	canonKey, canonSubject, canonObject = canonicalEdge(predicate, req.SubjectNodeID, req.ObjectNodeID)
 	return predicate, canonKey, canonSubject, canonObject, nil
 }
@@ -745,16 +759,12 @@ func (s *AssertService) writeNew(ctx context.Context, tx pgx.Tx, predicate *repo
 
 	// effective_from = COALESCE(valid_from, now) — the overlap-probe + supersession
 	// boundary. A NULL valid_from (the common "as of now" edit) probes as
-	// [now, valid_to) and the STORED valid_from stays NULL/open.
+	// [now, valid_to) and the STORED valid_from stays NULL/open. (The degenerate
+	// valid_to <= effective_from range is already rejected in validate(), before the
+	// dedup lookup, so it cannot slip through a corroboration match.)
 	effectiveFrom := now
 	if req.ValidFrom != nil {
 		effectiveFrom = req.ValidFrom.UTC()
-	}
-
-	// Degenerate-range guard: an explicit past valid_to with a now/unknown start is
-	// an incoherent "true until a past date but start unknown" assertion → REJECT.
-	if req.ValidTo != nil && !req.ValidTo.UTC().After(effectiveFrom) {
-		return nil, validationError("valid_to %s is not after effective_from %s (degenerate/empty range)", req.ValidTo.UTC(), effectiveFrom)
 	}
 
 	// Single-cardinality + accepted-landing writes run the supersession check under
@@ -1018,7 +1028,7 @@ func (s *AssertService) widenReaffirmation(ctx context.Context, tx pgx.Tx, predi
 // and close the loser superseded with superseded_by = survivor. Emits
 // provenance_added per moved locator + superseded for the loser.
 func (s *AssertService) mergeSameValue(ctx context.Context, tx pgx.Tx, loser, survivor *repository.Assertion) error {
-	provs, err := s.assertionRepo.ListProvenance(ctx, loser.ID)
+	provs, err := s.assertionRepo.ListProvenanceTx(ctx, tx, loser.ID)
 	if err != nil {
 		return fmt.Errorf("list loser provenance: %w", err)
 	}
@@ -1192,17 +1202,28 @@ func (s *AssertService) resolveAcceptConflicts(ctx context.Context, tx pgx.Tx, p
 	// the writeNew widen rule (P1: Accept must widen, not supersede, a same value).
 	acceptingSignature := assertionSignature(accepting)
 	if existing := findSameValue(conflicts, acceptingSignature); existing != nil {
-		existing.ValidFrom = minStart(existing.ValidFrom, accepting.ValidFrom)
-		existing.ValidTo = maxEnd(existing.ValidTo, accepting.ValidTo)
+		widenedFrom := minStart(existing.ValidFrom, accepting.ValidFrom)
+		widenedTo := maxEnd(existing.ValidTo, accepting.ValidTo)
+		// Do NOT clear a pending-successor bound (superseded_by set): widening the
+		// upper bound past it would leave two current rows once the successor date
+		// passes (mirrors widenReaffirmation). Only the backward lower-bound extends.
+		if existing.SupersededBy != nil {
+			widenedTo = utcPtr(existing.ValidTo)
+		}
+		existing.ValidFrom = widenedFrom
+		existing.ValidTo = widenedTo
 		widenReq := &AssertRequest{ValidFrom: existing.ValidFrom}
 		newKey := computePropositionKey(predicate, canonKey, canonSubject, canonObject, widenReq)
+		// MERGE/close the accepting (loser) row FIRST so it is no longer live —
+		// otherwise WidenAssertionValidity could assign the survivor a key the still-
+		// live accepting row holds and 23505 on idx_assertion_live_proposition.
+		if err := s.mergeSameValue(ctx, tx, accepting, existing); err != nil {
+			return nil, false, err
+		}
 		if err := s.assertionRepo.WidenAssertionValidityTx(ctx, tx, existing.ID, existing.ValidFrom, existing.ValidTo, newKey); err != nil {
 			return nil, false, fmt.Errorf("widen survivor at accept: %w", err)
 		}
 		existing.PropositionKey = newKey
-		if err := s.mergeSameValue(ctx, tx, accepting, existing); err != nil {
-			return nil, false, err
-		}
 		return existing, true, nil
 	}
 
@@ -1340,8 +1361,28 @@ func (s *AssertService) Accept(ctx context.Context, assertionID uuid.UUID, _ Acc
 // AcceptTx is the tx-bound variant of Accept.
 func (s *AssertService) AcceptTx(ctx context.Context, tx pgx.Tx, assertionID uuid.UUID) (*repository.Assertion, error) {
 	now := accelerated.GetCurrentTime().UTC()
-	// Row-lock so the proposed-status check + the accept are atomic vs a concurrent
-	// Accept/Reject of the same row.
+	// GLOBAL lock order — advisory slot lock(s) BEFORE any row lock (matches the
+	// writeNew order), so Accept cannot deadlock against a concurrent assert that
+	// holds the advisory lock and then row-locks via FindAcceptedForSlot FOR UPDATE.
+	// A plain (unlocked) read gets the predicate + canonical slot first; the
+	// authoritative status check happens after the row lock below.
+	pre, err := s.assertionRepo.GetAssertionTx(ctx, tx, assertionID)
+	if err != nil {
+		return nil, err
+	}
+	predicate, err := s.predicateRepo.GetPredicate(ctx, pre.PredicateKey)
+	if err != nil {
+		return nil, fmt.Errorf("load predicate: %w", err)
+	}
+	if predicate.Cardinality == repository.PredicateCardinalitySingle {
+		canonKey, canonSubject, canonObject := canonicalEdge(predicate, pre.SubjectNodeID, pre.ObjectNodeID)
+		if err := s.acquireSlotLocks(ctx, tx, predicate, canonKey, canonSubject, canonObject); err != nil {
+			return nil, err
+		}
+	}
+	// Now row-lock so the proposed-status check + the accept are atomic vs a
+	// concurrent Accept/Reject of the same row (re-read under the lock; a concurrent
+	// transition between the plain read and here is caught by the status check).
 	assertion, err := s.assertionRepo.GetAssertionForUpdateTx(ctx, tx, assertionID)
 	if err != nil {
 		return nil, err
@@ -1349,12 +1390,8 @@ func (s *AssertService) AcceptTx(ctx context.Context, tx pgx.Tx, assertionID uui
 	if assertion.Status != repository.AssertionStatusProposed {
 		return nil, validationError("assertion %s is %q, only a proposed assertion may be accepted", assertionID, assertion.Status)
 	}
-	predicate, err := s.predicateRepo.GetPredicate(ctx, assertion.PredicateKey)
-	if err != nil {
-		return nil, fmt.Errorf("load predicate: %w", err)
-	}
-	// Single-cardinality conflict resolution at accept time (locks the slot, then
-	// widens a same-value prior or supersedes different-value priors).
+	// Single-cardinality conflict resolution at accept time (the slot advisory lock
+	// is already held above; resolveAcceptConflicts re-acquires it re-entrantly).
 	survivor, merged, err := s.resolveAcceptConflicts(ctx, tx, predicate, assertion, now)
 	if err != nil {
 		return nil, err

--- a/backend/internal/service/assert.go
+++ b/backend/internal/service/assert.go
@@ -1526,7 +1526,7 @@ func (s *AssertService) terminalTransition(ctx context.Context, assertionID uuid
 }
 
 // RunRollover terminalizes the bounded-with-pending-successor rows whose bound
-// has been reached (the daily rollover sweep, D6 step 4 / PR4). In one tx it flips
+// has been reached (the daily rollover sweep). In one tx it flips
 // each matching row (status='accepted' AND knowledge_to IS NULL AND superseded_by
 // IS NOT NULL AND valid_to <= now) to status='superseded', closure_reason=
 // 'superseded', knowledge_to=now, and emits assertion.superseded per row. It is a

--- a/backend/internal/service/assert_propkey_test.go
+++ b/backend/internal/service/assert_propkey_test.go
@@ -1,0 +1,211 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// strPtr / boolPtr / numPtr / datePtr are tiny pointer helpers for building
+// AssertRequests in the pure-function tests.
+func strPtr(s string) *string        { return &s }
+func boolPtr(b bool) *bool           { return &b }
+func numPtr(f float64) *float64      { return &f }
+func datePtr(t time.Time) *time.Time { return &t }
+
+// edgePredicate builds a minimal edge predicate for the key/canonicalization
+// tests. symmetric + inverse are the dimensions that matter for canonicalEdge.
+func edgePredicate(key, objectType string, symmetric bool, inverse *string, bucket string) *repository.Predicate {
+	return &repository.Predicate{
+		Key:               key,
+		Kind:              repository.PredicateKindEdge,
+		SubjectType:       "person",
+		ObjectType:        &objectType,
+		Cardinality:       repository.PredicateCardinalitySingle,
+		Symmetric:         symmetric,
+		InversePredicate:  inverse,
+		PropositionBucket: bucket,
+	}
+}
+
+func factPredicate(key, valueType, bucket string) *repository.Predicate {
+	vt := valueType
+	return &repository.Predicate{
+		Key:               key,
+		Kind:              repository.PredicateKindFact,
+		SubjectType:       "person",
+		ValueType:         &vt,
+		Cardinality:       repository.PredicateCardinalitySingle,
+		PropositionBucket: bucket,
+	}
+}
+
+// TestComputePropositionKey_SymmetricPairOrdering asserts a symmetric edge keys
+// identically regardless of which way the caller orders the pair (A→B == B→A).
+func TestComputePropositionKey_SymmetricPairOrdering(t *testing.T) {
+	a := uuid.MustParse("00000000-0000-0000-0000-0000000000aa")
+	b := uuid.MustParse("00000000-0000-0000-0000-0000000000bb")
+	pred := edgePredicate("partner_of", "person", true, nil, repository.PredicateBucketNone)
+
+	keyAB := propKeyForEdge(t, pred, a, b)
+	keyBA := propKeyForEdge(t, pred, b, a)
+	assert.Equal(t, keyAB, keyBA, "symmetric edge keys identically in either order")
+}
+
+// TestComputePropositionKey_InverseCanonicalization asserts parent_of(A,B) and
+// child_of(B,A) collapse to the same key (canonical token = min(key, inverse)).
+func TestComputePropositionKey_InverseCanonicalization(t *testing.T) {
+	a := uuid.MustParse("00000000-0000-0000-0000-0000000000aa")
+	b := uuid.MustParse("00000000-0000-0000-0000-0000000000bb")
+	parentOf := edgePredicate("parent_of", "person", false, strPtr("child_of"), repository.PredicateBucketNone)
+	childOf := edgePredicate("child_of", "person", false, strPtr("parent_of"), repository.PredicateBucketNone)
+
+	// parent_of(A,B): A is the parent of B.
+	keyParent := propKeyForEdge(t, parentOf, a, b)
+	// child_of(B,A): B is the child of A — the SAME relationship.
+	keyChild := propKeyForEdge(t, childOf, b, a)
+	assert.Equal(t, keyParent, keyChild, "inverse pair collapses to one canonical key")
+
+	// Sanity: parent_of(A,B) and parent_of(B,A) are DIFFERENT relationships.
+	keyParentReversed := propKeyForEdge(t, parentOf, b, a)
+	assert.NotEqual(t, keyParent, keyParentReversed)
+}
+
+// TestComputePropositionKey_BucketGranularity asserts the valid-time bucket
+// component truncates valid_from per the predicate's proposition_bucket (UTC).
+func TestComputePropositionKey_BucketGranularity(t *testing.T) {
+	subject := uuid.MustParse("00000000-0000-0000-0000-0000000000aa")
+	jan := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	feb := time.Date(2024, 2, 20, 10, 0, 0, 0, time.UTC)
+	nextYear := time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC)
+
+	value := "nyc"
+
+	t.Run("none ignores valid_from entirely", func(t *testing.T) {
+		pred := factPredicate("how_met", "text", repository.PredicateBucketNone)
+		k1 := propKeyForFact(t, pred, subject, value, &jan)
+		k2 := propKeyForFact(t, pred, subject, value, &feb)
+		assert.Equal(t, k1, k2, "none bucket dedups regardless of valid_from")
+	})
+
+	t.Run("year buckets by calendar year", func(t *testing.T) {
+		pred := factPredicate("home_address", "text", repository.PredicateBucketYear)
+		kJan := propKeyForFact(t, pred, subject, value, &jan)
+		kFeb := propKeyForFact(t, pred, subject, value, &feb)
+		kNext := propKeyForFact(t, pred, subject, value, &nextYear)
+		assert.Equal(t, kJan, kFeb, "same year → same key")
+		assert.NotEqual(t, kJan, kNext, "different year → different key")
+	})
+
+	t.Run("month buckets by calendar month", func(t *testing.T) {
+		pred := factPredicate("home_address", "text", repository.PredicateBucketMonth)
+		kJan := propKeyForFact(t, pred, subject, value, &jan)
+		kFeb := propKeyForFact(t, pred, subject, value, &feb)
+		assert.NotEqual(t, kJan, kFeb, "different month → different key")
+	})
+
+	t.Run("day buckets by calendar day; open valid_from", func(t *testing.T) {
+		pred := factPredicate("traveling", "text", repository.PredicateBucketDay)
+		sameDayMorning := time.Date(2024, 1, 15, 1, 0, 0, 0, time.UTC)
+		sameDayEvening := time.Date(2024, 1, 15, 23, 0, 0, 0, time.UTC)
+		kMorning := propKeyForFact(t, pred, subject, value, &sameDayMorning)
+		kEvening := propKeyForFact(t, pred, subject, value, &sameDayEvening)
+		assert.Equal(t, kMorning, kEvening, "same day → same key")
+		// Open valid_from gets the literal "open" token, distinct from a dated one.
+		kOpen := propKeyForFact(t, pred, subject, value, nil)
+		assert.NotEqual(t, kMorning, kOpen)
+	})
+}
+
+// TestComputePropositionKey_TextNormalization asserts text values normalize via
+// lower(trim()) before keying.
+func TestComputePropositionKey_TextNormalization(t *testing.T) {
+	subject := uuid.MustParse("00000000-0000-0000-0000-0000000000aa")
+	pred := factPredicate("how_met", "text", repository.PredicateBucketNone)
+	k1 := propKeyForFact(t, pred, subject, "  New York  ", nil)
+	k2 := propKeyForFact(t, pred, subject, "new york", nil)
+	assert.Equal(t, k1, k2, "text normalizes via lower(trim())")
+}
+
+// TestComputePropositionKey_LengthPrefixNoAlias asserts the length-prefixed
+// encoding prevents a delimiter inside a value from aliasing a different tuple.
+func TestComputePropositionKey_LengthPrefixNoAlias(t *testing.T) {
+	subject := uuid.MustParse("00000000-0000-0000-0000-0000000000aa")
+	pred := factPredicate("how_met", "text", repository.PredicateBucketNone)
+	// "a:b" vs "a" + "b" must not collide under length-prefix encoding.
+	k1 := propKeyForFact(t, pred, subject, "a:5:b", nil)
+	k2 := propKeyForFact(t, pred, subject, "a", nil)
+	assert.NotEqual(t, k1, k2)
+}
+
+// TestComputeLocatorHash_Determinism asserts the same locator hashes identically
+// and a different span/version hashes differently.
+func TestComputeLocatorHash_Determinism(t *testing.T) {
+	base := ProvenanceLocator{
+		SourceKind:      repository.SourceKindCommsMessage,
+		SourceID:        uuid.NewString(),
+		ProducerKind:    repository.ProducerKindExtractor,
+		ProducerVersion: "v1",
+		Field:           strPtr("body"),
+		StartOffset:     i32(10),
+		EndOffset:       i32(20),
+		InputHash:       "abc",
+	}
+	h1 := computeLocatorHash(base)
+	h2 := computeLocatorHash(base)
+	require.Equal(t, h1, h2, "same locator → same hash")
+
+	// A different span.
+	span := base
+	span.StartOffset = i32(30)
+	span.EndOffset = i32(40)
+	assert.NotEqual(t, h1, computeLocatorHash(span), "different span → different hash")
+
+	// A different producer version (extractor v2 reassertion).
+	ver := base
+	ver.ProducerVersion = "v2"
+	assert.NotEqual(t, h1, computeLocatorHash(ver), "different version → different hash")
+
+	// A different source row.
+	src := base
+	src.SourceID = uuid.NewString()
+	assert.NotEqual(t, h1, computeLocatorHash(src), "different source → different hash")
+}
+
+// TestComputeLocatorHash_NilSpanFields asserts nil offset/chunk fields hash
+// stably (the encoding treats nil as empty, deterministically).
+func TestComputeLocatorHash_NilSpanFields(t *testing.T) {
+	loc := ProvenanceLocator{
+		SourceKind:   repository.SourceKindUser,
+		SourceID:     "edit:contact-1:lives_in",
+		ProducerKind: repository.ProducerKindUser,
+	}
+	assert.Equal(t, computeLocatorHash(loc), computeLocatorHash(loc))
+}
+
+// --- test plumbing ---------------------------------------------------------
+
+func i32(v int32) *int32 { return &v }
+
+// propKeyForEdge canonicalizes + keys an edge for the given subject/object.
+func propKeyForEdge(t *testing.T, pred *repository.Predicate, subject, object uuid.UUID) string {
+	t.Helper()
+	req := &AssertRequest{SubjectNodeID: subject, PredicateKey: pred.Key, ObjectNodeID: &object}
+	canonKey, canonSubject, canonObject := canonicalEdge(pred, subject, &object)
+	require.NotNil(t, canonObject)
+	return computePropositionKey(pred, canonKey, canonSubject, canonObject, req)
+}
+
+// propKeyForFact canonicalizes (no-op for facts) + keys a text fact.
+func propKeyForFact(t *testing.T, pred *repository.Predicate, subject uuid.UUID, value string, validFrom *time.Time) string {
+	t.Helper()
+	req := &AssertRequest{SubjectNodeID: subject, PredicateKey: pred.Key, ValueText: strPtr(value), ValidFrom: validFrom}
+	canonKey, canonSubject, canonObject := canonicalEdge(pred, subject, nil)
+	require.Nil(t, canonObject)
+	return computePropositionKey(pred, canonKey, canonSubject, canonObject, req)
+}

--- a/backend/internal/service/assert_test.go
+++ b/backend/internal/service/assert_test.go
@@ -1,0 +1,158 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateFactValue covers the pure fact-payload checks: the value column for
+// the predicate's value_type is set, parses, and (text) is non-empty after trim;
+// exactly one scalar; no mismatched scalar.
+func TestValidateFactValue(t *testing.T) {
+	textPred := factPredicate("how_met", repository.PredicateValueTypeText, repository.PredicateBucketNone)
+	numPred := factPredicate("score", repository.PredicateValueTypeNum, repository.PredicateBucketNone)
+	datePred := factPredicate("birthday", repository.PredicateValueTypeDate, repository.PredicateBucketNone)
+	boolPred := factPredicate("traveling", repository.PredicateValueTypeBool, repository.PredicateBucketDay)
+
+	tests := []struct {
+		name    string
+		req     *AssertRequest
+		pred    *repository.Predicate
+		wantErr bool
+	}{
+		{"text ok", &AssertRequest{ValueText: strPtr("met at a wedding")}, textPred, false},
+		{"text empty after trim", &AssertRequest{ValueText: strPtr("   ")}, textPred, true},
+		{"text wrong type for num pred", &AssertRequest{ValueText: strPtr("x")}, numPred, true},
+		{"num ok", &AssertRequest{ValueNum: numPtr(42)}, numPred, false},
+		{"num missing", &AssertRequest{ValueText: strPtr("x")}, numPred, true},
+		{"date ok", &AssertRequest{ValueDate: datePtr(time.Now())}, datePred, false},
+		{"bool ok", &AssertRequest{ValueBool: boolPtr(true)}, boolPred, false},
+		{"two scalars set", &AssertRequest{ValueText: strPtr("x"), ValueNum: numPtr(1)}, textPred, true},
+		{"no scalar set", &AssertRequest{}, textPred, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateFactValue(tc.req, tc.pred)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.ErrorIs(t, err, ErrAssertValidation)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestScalarCount counts the value_* fields set.
+func TestScalarCount(t *testing.T) {
+	assert.Equal(t, 0, scalarCount(&AssertRequest{}))
+	assert.Equal(t, 1, scalarCount(&AssertRequest{ValueText: strPtr("x")}))
+	assert.Equal(t, 1, scalarCount(&AssertRequest{ValueBool: boolPtr(false)}))
+	assert.Equal(t, 2, scalarCount(&AssertRequest{ValueText: strPtr("x"), ValueDate: datePtr(time.Now())}))
+}
+
+// TestIsValidSourceKind covers the closed enum membership.
+func TestIsValidSourceKind(t *testing.T) {
+	for _, k := range []string{
+		repository.SourceKindCommsMessage, repository.SourceKindTelegramMessage,
+		repository.SourceKindMessagesMessage, repository.SourceKindMeetingNote,
+		repository.SourceKindAnarlogTranscript, repository.SourceKindCalendarEvent,
+		repository.SourceKindPhoneCall, repository.SourceKindUser, repository.SourceKindAgentSession,
+	} {
+		assert.True(t, isValidSourceKind(k), k)
+	}
+	assert.False(t, isValidSourceKind("not_a_kind"))
+	assert.False(t, isValidSourceKind(""))
+}
+
+// TestIsValidProducerKind covers the producer-kind enum.
+func TestIsValidProducerKind(t *testing.T) {
+	assert.True(t, isValidProducerKind(repository.ProducerKindExtractor))
+	assert.True(t, isValidProducerKind(repository.ProducerKindAgent))
+	assert.True(t, isValidProducerKind(repository.ProducerKindUser))
+	assert.False(t, isValidProducerKind("robot"))
+}
+
+// TestStrongerTrust folds the strongest producer across an existing tier + new
+// locators (user > agent > extractor).
+func TestStrongerTrust(t *testing.T) {
+	extractor := []ProvenanceLocator{{ProducerKind: repository.ProducerKindExtractor}}
+	user := []ProvenanceLocator{{ProducerKind: repository.ProducerKindUser}}
+
+	// Fresh (nil existing) extractor → "extractor".
+	got := strongerTrust(nil, extractor)
+	require.NotNil(t, got)
+	assert.Equal(t, "extractor", *got)
+
+	// Existing extractor + a user locator → upgrades to "user".
+	existing := "extractor"
+	got = strongerTrust(&existing, user)
+	require.NotNil(t, got)
+	assert.Equal(t, "user", *got)
+
+	// Existing user + an extractor locator → stays "user" (never downgrades).
+	existingUser := "user"
+	got = strongerTrust(&existingUser, extractor)
+	require.NotNil(t, got)
+	assert.Equal(t, "user", *got)
+
+	// No existing, no locators → nil.
+	assert.Nil(t, strongerTrust(nil, nil))
+}
+
+// TestMinStartMaxEnd covers the window-union helpers (nil = open = -inf/+inf).
+func TestMinStartMaxEnd(t *testing.T) {
+	early := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	late := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// minStart: nil on either side → open (nil).
+	assert.Nil(t, minStart(nil, &early))
+	assert.Nil(t, minStart(&early, nil))
+	got := minStart(&early, &late)
+	require.NotNil(t, got)
+	assert.True(t, got.Equal(early), "minStart returns the earlier")
+
+	// maxEnd: nil on either side → open (nil).
+	assert.Nil(t, maxEnd(nil, &late))
+	assert.Nil(t, maxEnd(&early, nil))
+	got = maxEnd(&early, &late)
+	require.NotNil(t, got)
+	assert.True(t, got.Equal(late), "maxEnd returns the later")
+}
+
+// TestCanonicalEdge_FactUnchanged asserts a fact (nil object) passes through
+// unchanged (no canonicalization).
+func TestCanonicalEdge_FactUnchanged(t *testing.T) {
+	pred := factPredicate("how_met", repository.PredicateValueTypeText, repository.PredicateBucketNone)
+	subject := uuid.New()
+	key, subj, obj := canonicalEdge(pred, subject, nil)
+	assert.Equal(t, pred.Key, key)
+	assert.Equal(t, subject, subj)
+	assert.Nil(t, obj)
+}
+
+// TestSlotLockKey_Deterministic asserts the advisory-lock key is stable for a
+// given slot and differs across slots.
+func TestSlotLockKey_Deterministic(t *testing.T) {
+	a := uuid.New()
+	b := uuid.New()
+	assert.Equal(t, slotLockKey("lives_in", a), slotLockKey("lives_in", a))
+	assert.NotEqual(t, slotLockKey("lives_in", a), slotLockKey("lives_in", b))
+	assert.NotEqual(t, slotLockKey("lives_in", a), slotLockKey("works_at", a))
+}
+
+// TestTransitionToken maps each create/terminal kind to its one-shot source_id
+// token (retract reuses the superseded token — no :retracted).
+func TestTransitionToken(t *testing.T) {
+	assert.Equal(t, "proposed", transitionToken(events.KindAssertionProposed))
+	assert.Equal(t, "accepted", transitionToken(events.KindAssertionAccepted))
+	assert.Equal(t, "superseded", transitionToken(events.KindAssertionSuperseded))
+	assert.Equal(t, "rejected", transitionToken(events.KindAssertionRejected))
+}

--- a/backend/internal/service/assert_test.go
+++ b/backend/internal/service/assert_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"personal-crm/backend/internal/accelerated"
 	"personal-crm/backend/internal/events"
 	"personal-crm/backend/internal/repository"
 
@@ -32,7 +33,7 @@ func TestValidateFactValue(t *testing.T) {
 		{"text wrong type for num pred", &AssertRequest{ValueText: strPtr("x")}, numPred, true},
 		{"num ok", &AssertRequest{ValueNum: numPtr(42)}, numPred, false},
 		{"num missing", &AssertRequest{ValueText: strPtr("x")}, numPred, true},
-		{"date ok", &AssertRequest{ValueDate: datePtr(time.Now())}, datePred, false},
+		{"date ok", &AssertRequest{ValueDate: datePtr(accelerated.GetCurrentTime())}, datePred, false},
 		{"bool ok", &AssertRequest{ValueBool: boolPtr(true)}, boolPred, false},
 		{"two scalars set", &AssertRequest{ValueText: strPtr("x"), ValueNum: numPtr(1)}, textPred, true},
 		{"no scalar set", &AssertRequest{}, textPred, true},
@@ -55,7 +56,7 @@ func TestScalarCount(t *testing.T) {
 	assert.Equal(t, 0, scalarCount(&AssertRequest{}))
 	assert.Equal(t, 1, scalarCount(&AssertRequest{ValueText: strPtr("x")}))
 	assert.Equal(t, 1, scalarCount(&AssertRequest{ValueBool: boolPtr(false)}))
-	assert.Equal(t, 2, scalarCount(&AssertRequest{ValueText: strPtr("x"), ValueDate: datePtr(time.Now())}))
+	assert.Equal(t, 2, scalarCount(&AssertRequest{ValueText: strPtr("x"), ValueDate: datePtr(accelerated.GetCurrentTime())}))
 }
 
 // TestIsValidSourceKind covers the closed enum membership.

--- a/backend/internal/synthetic/profiles.go
+++ b/backend/internal/synthetic/profiles.go
@@ -50,6 +50,7 @@ type ProfileResult struct {
 	StrandedMessages  int
 	UnmatchedCalendar int
 	OrphanMeetingNote int
+	SeededAssertions  int
 }
 
 // ProfileParams returns the default SeedParams for a named profile (error on an
@@ -73,6 +74,7 @@ func ProfileParams(name Profile) (SeedParams, error) {
 				StrandedMessages:  1,
 				UnmatchedCalendar: 1,
 				OrphanMeetingNote: 1,
+				SeededAssertions:  2,
 			},
 		}, nil
 	case ProfileProdShaped:
@@ -87,6 +89,7 @@ func ProfileParams(name Profile) (SeedParams, error) {
 				StrandedMessages:  5,
 				UnmatchedCalendar: 7,
 				OrphanMeetingNote: 4,
+				SeededAssertions:  4,
 			},
 		}, nil
 	default:
@@ -301,6 +304,23 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 			return res, fmt.Errorf("profile %s: seed orphan meeting note %d: %w", params.Profile, i, err)
 		}
 		res.OrphanMeetingNote++
+	}
+
+	// Graph (SP1) assertions on the first catalog contact's person node
+	// (node.id == contact.id). Seeded LAST so the generator-PRNG advancement these
+	// FactAssertion calls cause does not shift the deterministic peer-id / handle
+	// sequence the earlier source replays depend on (a mid-sequence insert would
+	// collide a "stranded" peer with a seeded contact's identity). Each
+	// FactAssertion produces a distinct value + proposition_key; preference is a
+	// multi-cardinality fact so they coexist (all accepted), giving the graph
+	// surfaces content without supersession.
+	if firstCatalogContactID != uuid.Nil {
+		for i := 0; i < params.Counts.SeededAssertions; i++ {
+			if _, err := h.ReplayAssertion(ctx, firstCatalogContactID, gen.FactAssertion("preference")); err != nil {
+				return res, fmt.Errorf("profile %s: replay assertion %d: %w", params.Profile, i, err)
+			}
+			res.SeededAssertions++
+		}
 	}
 
 	return res, nil

--- a/backend/internal/synthetic/replay/assertion.go
+++ b/backend/internal/synthetic/replay/assertion.go
@@ -1,0 +1,74 @@
+package replay
+
+import (
+	"context"
+	"fmt"
+
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+	"personal-crm/backend/internal/synthetic/factory"
+
+	"github.com/google/uuid"
+)
+
+// AssertionResult is the settled outcome of an assertion replay.
+type AssertionResult struct {
+	AssertionID   uuid.UUID
+	SubjectNodeID uuid.UUID
+	PredicateKey  string
+}
+
+// assertService builds an AssertService over the harness's pool + bus + graph
+// repos. The graph repos are cheap thin wrappers, so building per-call (mirroring
+// the per-source provider construction in the other adapters) keeps the harness
+// struct lean. The bus routes the assertion kinds to no consumer, so no River job
+// is enqueued and the never-started client is fine.
+func (h *Harness) assertService() *service.AssertService {
+	return service.NewAssertService(
+		h.database.Pool,
+		repository.NewNodeRepository(h.database.Queries),
+		repository.NewEntityRepository(h.database.Queries),
+		repository.NewPredicateRepository(h.database.Queries),
+		repository.NewAssertionRepository(h.database.Queries),
+		h.bus,
+	)
+}
+
+// ReplayAssertion drives a synthetic fact assertion through the REAL
+// AssertService write path (validation, proposition identity, events) against an
+// existing subject person node. The caller seeds the subject first (e.g. via
+// SeedContact, which dual-writes the person node). The assertion's user
+// provenance carries a namespace-stable source_id so a re-run corroborates
+// (idempotent) rather than duplicating.
+//
+// Cleanup: the assertion rows ride on the subject node and are removed by the
+// harness teardown's assertion step (which deletes assertions on every seeded
+// contact node before the person-node delete, since the assertion→node FK is
+// RESTRICT).
+func (h *Harness) ReplayAssertion(ctx context.Context, subjectNodeID uuid.UUID, spec factory.AssertionSpec) (AssertionResult, error) {
+	svc := h.assertService()
+	value := spec.ValueText
+	req := service.AssertRequest{
+		SubjectNodeID: subjectNodeID,
+		PredicateKey:  spec.PredicateKey,
+		ValueText:     &value,
+		Confidence:    spec.Confidence,
+		Locators: []service.ProvenanceLocator{{
+			SourceKind:   repository.SourceKindUser,
+			SourceID:     spec.PropositionKey + ":user",
+			ProducerKind: repository.ProducerKindUser,
+		}},
+	}
+	a, err := svc.Assert(ctx, req)
+	if err != nil {
+		return AssertionResult{}, fmt.Errorf("replay assertion %s: %w", spec.PredicateKey, err)
+	}
+	// Record the source the assertion events published under so Cleanup captures
+	// the root event rows the contact-scoped read misses.
+	h.track(func(c *created) { c.addDirectSource("assertion") })
+	return AssertionResult{
+		AssertionID:   a.ID,
+		SubjectNodeID: subjectNodeID,
+		PredicateKey:  a.PredicateKey,
+	}, nil
+}

--- a/backend/internal/synthetic/replay/harness_cleanup.go
+++ b/backend/internal/synthetic/replay/harness_cleanup.go
@@ -237,14 +237,24 @@ func (h *Harness) cleanup(ctx context.Context) error {
 		_, err := h.support.DeleteContactsByIds(ctx, c.contactIDs)
 		return err
 	})
+	// 13a-pre. assertions on the seeded contact nodes: the assertion→node FK is
+	// RESTRICT, so any assertion ReplayAssertion seeded on a person node MUST be
+	// deleted BEFORE the person-node delete below. Provenance cascades from the
+	// assertion. No-op when no profile/test seeded any (DeleteAssertionsForNode is
+	// per-node; the loop is bounded by the seeded-contact count).
+	step("assertions", func() error {
+		for _, contactID := range c.contactIDs {
+			if _, err := h.support.DeleteAssertionsForNode(ctx, contactID); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 	// 13a. person node (node.id == contact.id): SeedContact dual-writes a node
 	// via the real service path, so teardown must remove it too or the shared
 	// DB leaks an orphan node per seeded contact. There is no FK from
 	// node→contact, so order relative to the contact delete is free. The
-	// assertion→node FK is RESTRICT, so once a harness seeds assertions on these
-	// person nodes, those assertions must be deleted in an EARLIER cleanup step
-	// (added before this one in the sequence); no harness path seeds them today,
-	// so this delete stands alone.
+	// assertion→node FK is RESTRICT, so the assertion step above runs first.
 	step("person_node", func() error {
 		_, err := h.support.DeleteNodesByIds(ctx, c.contactIDs)
 		return err

--- a/backend/internal/synthetic/synthetic.go
+++ b/backend/internal/synthetic/synthetic.go
@@ -79,6 +79,7 @@ type Counts struct {
 	StrandedMessages  int // stranded messages_message (iMessage) rows
 	UnmatchedCalendar int // calendar_event rows with an unmatched attendee
 	OrphanMeetingNote int // orphan_needs_review meeting_note rows
+	SeededAssertions  int // graph (SP1) fact assertions seeded on the first contact node
 }
 
 // SeedParams is the profile/volume seam consumed by the seed orchestration.

--- a/backend/tests/assert_integration_test.go
+++ b/backend/tests/assert_integration_test.go
@@ -257,7 +257,7 @@ func TestAssert_Integration(t *testing.T) {
 		assert.True(t, h.eventExists(t, ctx, supersededSourceID(prior.ID)))
 		assert.True(t, h.eventExists(t, ctx, acceptedSourceID(successor.ID)))
 
-		now := accelerated.GetCurrentTime().UTC()
+		now := accelerated.GetCurrentTime().UTC().Truncate(time.Microsecond)
 		cur, err := h.assertionRepo.GetCurrentAccepted(ctx, subject, "home_address", now)
 		require.NoError(t, err)
 		assert.Equal(t, successor.ID, cur.ID, "current is the successor")
@@ -282,7 +282,7 @@ func TestAssert_Integration(t *testing.T) {
 		assert.Equal(t, repository.ClosureReasonEnded, *closed.ClosureReason)
 		assert.Nil(t, closed.SupersededBy, "closure-only has no successor")
 
-		now := accelerated.GetCurrentTime().UTC()
+		now := accelerated.GetCurrentTime().UTC().Truncate(time.Microsecond)
 		_, err = h.assertionRepo.GetCurrentAccepted(ctx, subject, "home_address", now)
 		require.ErrorIs(t, err, db.ErrNotFound, "current is now a gap")
 	})
@@ -485,7 +485,7 @@ func TestAssert_Integration(t *testing.T) {
 		require.NotNil(t, a.ValueDate)
 		assert.Equal(t, "1990-04-21", a.ValueDate.UTC().Format("2006-01-02"))
 
-		cur, err := h.assertionRepo.GetCurrentAccepted(ctx, subject, "birthday", accelerated.GetCurrentTime().UTC())
+		cur, err := h.assertionRepo.GetCurrentAccepted(ctx, subject, "birthday", accelerated.GetCurrentTime().UTC().Truncate(time.Microsecond))
 		require.NoError(t, err)
 		require.NotNil(t, cur.ValueDate)
 		assert.Equal(t, "1990-04-21", cur.ValueDate.UTC().Format("2006-01-02"))
@@ -553,7 +553,7 @@ func TestAssert_Concurrency(t *testing.T) {
 		}
 
 		// Exactly one is current-accepted; the rest are superseded.
-		now := accelerated.GetCurrentTime().UTC()
+		now := accelerated.GetCurrentTime().UTC().Truncate(time.Microsecond)
 		cur, err := h.assertionRepo.GetCurrentAccepted(ctx, subject, "home_address", now)
 		require.NoError(t, err, "exactly one current-accepted row survives the race")
 		assert.NotNil(t, cur)
@@ -625,7 +625,7 @@ func TestAssert_ValidTime(t *testing.T) {
 		t.Parallel()
 		gen, _ := migrationGenerator(t)
 		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
-		now := accelerated.GetCurrentTime().UTC()
+		now := accelerated.GetCurrentTime().UTC().Truncate(time.Microsecond)
 
 		// NYC current (open).
 		nyc, err := h.svc.Assert(ctx, textFactReq(subject, "home_address", "NYC", gen.Prefix(), "nyc"))
@@ -665,7 +665,7 @@ func TestAssert_ValidTime(t *testing.T) {
 		// Run the rollover.
 		n, err := h.svc.RunRollover(ctx)
 		require.NoError(t, err)
-		assert.GreaterOrEqual(t, n, 1)
+		_ = n // RunRollover is a GLOBAL sweep; under t.Parallel() a concurrent test can roll this row first, so n is unreliable — the per-row state asserted below is the real check
 
 		rolled, err := h.assertionRepo.GetAssertion(ctx, nyc.ID)
 		require.NoError(t, err)
@@ -689,7 +689,7 @@ func TestAssert_ValidTime(t *testing.T) {
 		t.Parallel()
 		gen, _ := migrationGenerator(t)
 		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
-		now := accelerated.GetCurrentTime().UTC()
+		now := accelerated.GetCurrentTime().UTC().Truncate(time.Microsecond)
 
 		// A bounded-past fact (valid window entirely in the past), no successor.
 		from := now.Add(-200 * 24 * time.Hour)
@@ -716,7 +716,7 @@ func TestAssert_ValidTime(t *testing.T) {
 		t.Parallel()
 		gen, _ := migrationGenerator(t)
 		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
-		now := accelerated.GetCurrentTime().UTC()
+		now := accelerated.GetCurrentTime().UTC().Truncate(time.Microsecond)
 
 		// Current NYC, open start (a user edit → valid_from NULL).
 		nyc, err := h.svc.Assert(ctx, textFactReq(subject, "home_address", "NYC current", gen.Prefix(), "nyc"))
@@ -752,7 +752,7 @@ func TestAssert_ValidTime(t *testing.T) {
 		t.Parallel()
 		gen, _ := migrationGenerator(t)
 		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
-		now := accelerated.GetCurrentTime().UTC()
+		now := accelerated.GetCurrentTime().UTC().Truncate(time.Microsecond)
 
 		// valid_from NULL (→ effective_from = now) but an explicit PAST valid_to.
 		past := now.Add(-time.Hour)
@@ -768,7 +768,7 @@ func TestAssert_ValidTime(t *testing.T) {
 		t.Parallel()
 		gen, _ := migrationGenerator(t)
 		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
-		now := accelerated.GetCurrentTime().UTC()
+		now := accelerated.GetCurrentTime().UTC().Truncate(time.Microsecond)
 
 		// NYC current, then a FUTURE LA → NYC bounded by LA.
 		nyc, err := h.svc.Assert(ctx, textFactReq(subject, "home_address", "NYC", gen.Prefix(), "nyc"))
@@ -843,7 +843,7 @@ func TestAssert_ValidTime(t *testing.T) {
 		t.Parallel()
 		gen, _ := migrationGenerator(t)
 		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
-		now := accelerated.GetCurrentTime().UTC()
+		now := accelerated.GetCurrentTime().UTC().Truncate(time.Microsecond)
 
 		nyc, err := h.svc.Assert(ctx, textFactReq(subject, "home_address", "NYC", gen.Prefix(), "nyc"))
 		require.NoError(t, err)
@@ -887,7 +887,7 @@ func TestAssert_ValidTime(t *testing.T) {
 		t.Parallel()
 		gen, _ := migrationGenerator(t)
 		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
-		now := accelerated.GetCurrentTime().UTC()
+		now := accelerated.GetCurrentTime().UTC().Truncate(time.Microsecond)
 
 		// home_address is year-bucketed. NYC at year Y (valid_from this year).
 		thisYear := time.Date(now.Year(), 1, 15, 0, 0, 0, 0, time.UTC)
@@ -987,7 +987,7 @@ func TestAssert_ValidTime(t *testing.T) {
 		t.Parallel()
 		gen, _ := migrationGenerator(t)
 		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
-		now := accelerated.GetCurrentTime().UTC()
+		now := accelerated.GetCurrentTime().UTC().Truncate(time.Microsecond)
 
 		// NYC current with a FUTURE knowledge_from override.
 		tomorrow := now.Add(24 * time.Hour)
@@ -1016,7 +1016,7 @@ func TestAssert_ValidTime(t *testing.T) {
 		// Rollover must succeed (not abort on the CHECK) and clamp knowledge_to.
 		n, err := h.svc.RunRollover(ctx)
 		require.NoError(t, err, "rollover must not abort on a future-knowledge_from row")
-		assert.GreaterOrEqual(t, n, 1)
+		_ = n // RunRollover is a GLOBAL sweep; under t.Parallel() a concurrent test can roll this row first, so n is unreliable — the per-row state asserted below is the real check
 		rolled, err := h.assertionRepo.GetAssertion(ctx, nyc.ID)
 		require.NoError(t, err)
 		assert.Equal(t, repository.AssertionStatusSuperseded, rolled.Status)
@@ -1078,7 +1078,7 @@ func TestAssert_Lifecycle(t *testing.T) {
 		t.Parallel()
 		gen, _ := migrationGenerator(t)
 		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
-		now := accelerated.GetCurrentTime().UTC()
+		now := accelerated.GetCurrentTime().UTC().Truncate(time.Microsecond)
 
 		// Accepted NYC this year (open-ended, auto-apply), confidence 50.
 		thisYear := time.Date(now.Year(), 2, 1, 0, 0, 0, 0, time.UTC)
@@ -1130,7 +1130,7 @@ func TestAssert_Lifecycle(t *testing.T) {
 		t.Parallel()
 		gen, _ := migrationGenerator(t)
 		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
-		now := accelerated.GetCurrentTime().UTC()
+		now := accelerated.GetCurrentTime().UTC().Truncate(time.Microsecond)
 
 		tomorrow := now.Add(24 * time.Hour)
 		req := textFactReq(subject, "health_condition", "future-knowledge", gen.Prefix(), "fk")
@@ -1157,7 +1157,7 @@ func TestAssert_Lifecycle(t *testing.T) {
 		t.Parallel()
 		gen, _ := migrationGenerator(t)
 		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
-		now := accelerated.GetCurrentTime().UTC()
+		now := accelerated.GetCurrentTime().UTC().Truncate(time.Microsecond)
 
 		thisYear := time.Date(now.Year(), 2, 1, 0, 0, 0, 0, time.UTC)
 		nycReq := textFactReq(subject, "home_address", "NYC", gen.Prefix(), "nyc")
@@ -1212,7 +1212,7 @@ func TestAssert_Lifecycle(t *testing.T) {
 		t.Parallel()
 		gen, _ := migrationGenerator(t)
 		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
-		now := accelerated.GetCurrentTime().UTC()
+		now := accelerated.GetCurrentTime().UTC().Truncate(time.Microsecond)
 
 		tomorrow := now.Add(24 * time.Hour)
 		req := textFactReq(subject, "home_address", "future-k", gen.Prefix(), "fk")
@@ -1253,7 +1253,7 @@ func TestAssert_Validation(t *testing.T) {
 		t.Parallel()
 		gen, _ := migrationGenerator(t)
 		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
-		now := accelerated.GetCurrentTime().UTC()
+		now := accelerated.GetCurrentTime().UTC().Truncate(time.Microsecond)
 
 		// An open-start accepted row that the degenerate write would dedup-match.
 		first, err := h.svc.Assert(ctx, textFactReq(subject, "home_address", "same", gen.Prefix(), "d1"))

--- a/backend/tests/assert_integration_test.go
+++ b/backend/tests/assert_integration_test.go
@@ -163,10 +163,9 @@ func (h *assertHarness) eventExists(t *testing.T, ctx context.Context, sourceID 
 	return false
 }
 
-// acceptedSourceID / supersededSourceID / provenanceSourceID build the event
+// acceptedSourceID / supersededSourceID / rejectedSourceID build the event
 // source_id keys an assertion's transitions produce.
 func acceptedSourceID(id uuid.UUID) string   { return id.String() + ":accepted" }
-func proposedSourceID(id uuid.UUID) string   { return id.String() + ":proposed" }
 func supersededSourceID(id uuid.UUID) string { return id.String() + ":superseded" }
 func rejectedSourceID(id uuid.UUID) string   { return id.String() + ":rejected" }
 

--- a/backend/tests/assert_integration_test.go
+++ b/backend/tests/assert_integration_test.go
@@ -909,12 +909,13 @@ func TestAssert_ValidTime(t *testing.T) {
 		require.NotNil(t, boundedNYC.ValidTo, "NYC bounded by LA")
 		require.NotNil(t, boundedNYC.SupersededBy)
 
-		// Re-affirm NYC from a DIFFERENT (next) year bucket — a same-value
-		// reaffirmation. It must widen the lower bound but NOT clear NYC's pending
-		// upper bound (LA).
-		nextYear := time.Date(now.Year()+1, 6, 1, 0, 0, 0, 0, time.UTC)
+		// Re-affirm NYC from an EARLIER (last) year bucket — a same-value
+		// reaffirmation whose window OVERLAPS the bounded NYC (so it actually hits
+		// widenReaffirmation). It must widen NYC's lower bound backward but NOT clear
+		// NYC's pending upper bound (LA).
+		lastYear := time.Date(now.Year()-1, 6, 1, 0, 0, 0, 0, time.UTC)
 		reaffirm := textFactReq(subject, "home_address", "NYC", gen.Prefix(), "nyc2")
-		reaffirm.ValidFrom = &nextYear
+		reaffirm.ValidFrom = &lastYear
 		_, err = h.svc.Assert(ctx, reaffirm)
 		require.NoError(t, err)
 
@@ -922,6 +923,8 @@ func TestAssert_ValidTime(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, afterReaffirm.ValidTo, "NYC's pending-successor bound is preserved")
 		assert.True(t, afterReaffirm.ValidTo.Equal(*boundedNYC.ValidTo), "valid_to bound unchanged by the reaffirmation")
+		require.NotNil(t, afterReaffirm.ValidFrom)
+		assert.True(t, afterReaffirm.ValidFrom.Equal(lastYear), "lower bound widened backward to the new evidence")
 		// LA stays the pending future successor; exactly one current now (NYC).
 		curNow, err := h.assertionRepo.GetCurrentAccepted(ctx, subject, "home_address", now)
 		require.NoError(t, err)
@@ -1052,6 +1055,63 @@ func TestAssert_Lifecycle(t *testing.T) {
 		require.NotNil(t, rejected.KnowledgeTo)
 		assert.False(t, rejected.KnowledgeTo.Before(rejected.KnowledgeFrom), "knowledge_to >= knowledge_from")
 	})
+
+	// Case 23: accept-time same-value widen must NOT clear a pending-successor bound
+	// (the accept-path analogue of the P0). NYC accepted (bounded by a future LA),
+	// then a same-value force-confirm NYC proposal whose window overlaps NYC is
+	// accepted → it widens NYC backward but keeps NYC's bound to LA; exactly one
+	// current now, and LA still becomes current after its date.
+	t.Run("23 accept-time widen preserves pending-successor bound", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
+		now := accelerated.GetCurrentTime().UTC()
+
+		thisYear := time.Date(now.Year(), 2, 1, 0, 0, 0, 0, time.UTC)
+		nycReq := textFactReq(subject, "home_address", "NYC", gen.Prefix(), "nyc")
+		nycReq.ValidFrom = &thisYear
+		nyc, err := h.svc.Assert(ctx, nycReq)
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, nyc.ID)
+
+		future := now.Add(30 * 24 * time.Hour)
+		laReq := textFactReq(subject, "home_address", "LA", gen.Prefix(), "la")
+		laReq.ValidFrom = &future
+		la, err := h.svc.Assert(ctx, laReq)
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, la.ID)
+		boundedNYC, err := h.assertionRepo.GetAssertion(ctx, nyc.ID)
+		require.NoError(t, err)
+		require.NotNil(t, boundedNYC.ValidTo)
+		require.NotNil(t, boundedNYC.SupersededBy)
+
+		// A force-confirm same-value NYC proposal in last year's bucket (overlaps NYC).
+		lastYear := time.Date(now.Year()-1, 6, 1, 0, 0, 0, 0, time.UTC)
+		propReq := textFactReq(subject, "home_address", "NYC", gen.Prefix(), "nyc2")
+		propReq.ValidFrom = &lastYear
+		propReq.ForceConfirm = true
+		proposed, err := h.svc.Assert(ctx, propReq)
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, proposed.ID)
+		require.Equal(t, repository.AssertionStatusProposed, proposed.Status)
+
+		survivor, err := h.svc.Accept(ctx, proposed.ID, service.AcceptRequest{})
+		require.NoError(t, err)
+		assert.Equal(t, nyc.ID, survivor.ID, "Accept widens into NYC")
+
+		afterAccept, err := h.assertionRepo.GetAssertion(ctx, nyc.ID)
+		require.NoError(t, err)
+		require.NotNil(t, afterAccept.ValidTo, "NYC's pending-successor bound is preserved by accept-time widen")
+		assert.True(t, afterAccept.ValidTo.Equal(*boundedNYC.ValidTo), "valid_to bound unchanged")
+
+		// Exactly one current now (NYC); LA still becomes current after its date.
+		curNow, err := h.assertionRepo.GetCurrentAccepted(ctx, subject, "home_address", now)
+		require.NoError(t, err)
+		assert.Equal(t, nyc.ID, curNow.ID)
+		curFuture, err := h.assertionRepo.GetCurrentAccepted(ctx, subject, "home_address", future.Add(time.Hour))
+		require.NoError(t, err)
+		assert.Equal(t, la.ID, curFuture.ID, "LA becomes current after its date (bound intact)")
+	})
 }
 
 // TestAssert_Validation covers the DB-dependent validation rejections (the pure
@@ -1069,6 +1129,27 @@ func TestAssert_Validation(t *testing.T) {
 		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
 		_, err := h.svc.Assert(ctx, textFactReq(subject, "no_such_predicate", "x", gen.Prefix(), "u"))
 		require.ErrorIs(t, err, service.ErrAssertValidation)
+	})
+
+	t.Run("degenerate range rejected even when a live row would corroborate", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
+		now := accelerated.GetCurrentTime().UTC()
+
+		// An open-start accepted row that the degenerate write would dedup-match.
+		first, err := h.svc.Assert(ctx, textFactReq(subject, "home_address", "same", gen.Prefix(), "d1"))
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, first.ID)
+
+		// SAME value, but valid_to=yesterday with NULL valid_from → effective_from=now,
+		// valid_to <= effective_from → degenerate. It must be REJECTED in validation
+		// (before the dedup lookup), NOT silently corroborated.
+		past := now.Add(-24 * time.Hour)
+		bad := textFactReq(subject, "home_address", "same", gen.Prefix(), "d2")
+		bad.ValidTo = &past
+		_, err = h.svc.Assert(ctx, bad)
+		require.ErrorIs(t, err, service.ErrAssertValidation, "degenerate range rejected pre-dedup")
 	})
 
 	t.Run("missing subject node rejected", func(t *testing.T) {

--- a/backend/tests/assert_integration_test.go
+++ b/backend/tests/assert_integration_test.go
@@ -931,6 +931,98 @@ func TestAssert_ValidTime(t *testing.T) {
 		assert.Equal(t, nyc.ID, curNow.ID, "exactly NYC is current now")
 		_ = la
 	})
+
+	// Case 24: a reaffirmation that BRIDGES two non-contiguous same-value stints
+	// merges ALL of them into one survivor (not just the first), so the
+	// single-cardinality slot keeps exactly one live row. home_address year-bucketed.
+	t.Run("24 bridging reaffirmation merges all same-value stints", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
+
+		// Two non-contiguous past NYC stints (both bounded-past → coexist).
+		yA0 := time.Date(2010, 1, 1, 0, 0, 0, 0, time.UTC)
+		yA1 := time.Date(2015, 1, 1, 0, 0, 0, 0, time.UTC)
+		a := textFactReq(subject, "home_address", "NYC", gen.Prefix(), "a")
+		a.ValidFrom, a.ValidTo = &yA0, &yA1
+		rowA, err := h.svc.Assert(ctx, a)
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, rowA.ID)
+
+		yB0 := time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC)
+		yB1 := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+		b := textFactReq(subject, "home_address", "NYC", gen.Prefix(), "b")
+		b.ValidFrom, b.ValidTo = &yB0, &yB1
+		rowB, err := h.svc.Assert(ctx, b)
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, rowB.ID)
+		require.NotEqual(t, rowA.ID, rowB.ID, "distinct year buckets → two coexisting stints")
+
+		// A bridging NYC [2012,2019) overlaps BOTH stints → all collapse to one row.
+		yBridge0 := time.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC)
+		yBridge1 := time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC)
+		bridge := textFactReq(subject, "home_address", "NYC", gen.Prefix(), "br")
+		bridge.ValidFrom, bridge.ValidTo = &yBridge0, &yBridge1
+		survivor, err := h.svc.Assert(ctx, bridge)
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, survivor.ID)
+
+		// Exactly ONE live NYC row remains; the other stint is superseded into it.
+		live, err := h.assertionRepo.ListLiveEdgesForNode(ctx, subject, "home_address")
+		require.NoError(t, err)
+		liveCount := 0
+		for _, e := range live {
+			if e.Status == repository.AssertionStatusAccepted {
+				liveCount++
+			}
+		}
+		assert.Equal(t, 1, liveCount, "bridged same-value stints collapse to one live row")
+		assert.Equal(t, rowA.ID, survivor.ID, "survivor is the first matched stint, widened")
+	})
+
+	// Case 25: the rollover sweep does NOT abort on a bounded row whose
+	// knowledge_from was set in the future (KnowledgeFromOverride); knowledge_to is
+	// clamped via GREATEST so the assertion_knowledge_range CHECK holds.
+	t.Run("25 rollover clamps knowledge_to for future-knowledge row", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
+		now := accelerated.GetCurrentTime().UTC()
+
+		// NYC current with a FUTURE knowledge_from override.
+		tomorrow := now.Add(24 * time.Hour)
+		nycReq := textFactReq(subject, "home_address", "NYC", gen.Prefix(), "nyc")
+		nycReq.KnowledgeFromOverride = &tomorrow
+		nyc, err := h.svc.Assert(ctx, nycReq)
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, nyc.ID)
+		require.True(t, nyc.KnowledgeFrom.After(now), "knowledge_from is in the future")
+
+		// Future LA bounds NYC (pending successor).
+		future := now.Add(72 * time.Hour)
+		laReq := textFactReq(subject, "home_address", "LA", gen.Prefix(), "la")
+		laReq.ValidFrom = &future
+		la, err := h.svc.Assert(ctx, laReq)
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, la.ID)
+
+		// Re-bind NYC's valid_to into the past (simulate the bound passing).
+		past := now.Add(-time.Hour)
+		rebind, err := h.database.Pool.Begin(ctx)
+		require.NoError(t, err)
+		require.NoError(t, h.assertionRepo.BoundPendingSuccessorTx(ctx, rebind, nyc.ID, past, la.ID))
+		require.NoError(t, rebind.Commit(ctx))
+
+		// Rollover must succeed (not abort on the CHECK) and clamp knowledge_to.
+		n, err := h.svc.RunRollover(ctx)
+		require.NoError(t, err, "rollover must not abort on a future-knowledge_from row")
+		assert.GreaterOrEqual(t, n, 1)
+		rolled, err := h.assertionRepo.GetAssertion(ctx, nyc.ID)
+		require.NoError(t, err)
+		assert.Equal(t, repository.AssertionStatusSuperseded, rolled.Status)
+		require.NotNil(t, rolled.KnowledgeTo)
+		assert.False(t, rolled.KnowledgeTo.Before(rolled.KnowledgeFrom), "knowledge_to >= knowledge_from (clamped)")
+	})
 }
 
 // TestAssert_Lifecycle covers the lifecycle-transition concurrency + same-value
@@ -1111,6 +1203,32 @@ func TestAssert_Lifecycle(t *testing.T) {
 		curFuture, err := h.assertionRepo.GetCurrentAccepted(ctx, subject, "home_address", future.Add(time.Hour))
 		require.NoError(t, err)
 		assert.Equal(t, la.ID, curFuture.ID, "LA becomes current after its date (bound intact)")
+	})
+
+	// Case 26: AssertClosure on a current row whose knowledge_from is in the future
+	// (KnowledgeFromOverride) clamps knowledge_to so the closure does not violate
+	// assertion_knowledge_range.
+	t.Run("26 closure clamps knowledge_to for future-knowledge row", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
+		now := accelerated.GetCurrentTime().UTC()
+
+		tomorrow := now.Add(24 * time.Hour)
+		req := textFactReq(subject, "home_address", "future-k", gen.Prefix(), "fk")
+		req.KnowledgeFromOverride = &tomorrow
+		current, err := h.svc.Assert(ctx, req)
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, current.ID)
+		require.True(t, current.KnowledgeFrom.After(now))
+
+		// Closure today must succeed (clamped knowledge_to), not violate the CHECK.
+		require.NoError(t, h.svc.AssertClosure(ctx, service.ClosureRequest{SubjectNodeID: subject, PredicateKey: "home_address"}))
+		closed, err := h.assertionRepo.GetAssertion(ctx, current.ID)
+		require.NoError(t, err)
+		assert.Equal(t, repository.AssertionStatusSuperseded, closed.Status)
+		require.NotNil(t, closed.KnowledgeTo)
+		assert.False(t, closed.KnowledgeTo.Before(closed.KnowledgeFrom), "knowledge_to >= knowledge_from (clamped)")
 	})
 }
 

--- a/backend/tests/assert_integration_test.go
+++ b/backend/tests/assert_integration_test.go
@@ -466,6 +466,30 @@ func TestAssert_Integration(t *testing.T) {
 		assert.EqualValues(t, 1, n)
 		assert.True(t, h.eventExists(t, ctx, acceptedSourceID(a1.ID)))
 	})
+
+	// Case 11b: a date-typed fact (birthday) round-trips through the DATE column
+	// and GetCurrentAccepted returns the stored date.
+	t.Run("11b date fact round-trips", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
+
+		bday := time.Date(1990, 4, 21, 0, 0, 0, 0, time.UTC)
+		a, err := h.svc.Assert(ctx, service.AssertRequest{
+			SubjectNodeID: subject, PredicateKey: "birthday", ValueDate: &bday, Confidence: 90,
+			Locators: []service.ProvenanceLocator{userLocator(gen.Prefix(), "bday")},
+		})
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, a.ID)
+		assert.Equal(t, repository.AssertionStatusAccepted, a.Status)
+		require.NotNil(t, a.ValueDate)
+		assert.Equal(t, "1990-04-21", a.ValueDate.UTC().Format("2006-01-02"))
+
+		cur, err := h.assertionRepo.GetCurrentAccepted(ctx, subject, "birthday", accelerated.GetCurrentTime().UTC())
+		require.NoError(t, err)
+		require.NotNil(t, cur.ValueDate)
+		assert.Equal(t, "1990-04-21", cur.ValueDate.UTC().Format("2006-01-02"))
+	})
 }
 
 // ctx0 returns a fresh background context (small indirection so the harness
@@ -810,6 +834,223 @@ func TestAssert_ValidTime(t *testing.T) {
 		closedAB, err := h.assertionRepo.GetAssertion(ctx, propAB.ID)
 		require.NoError(t, err)
 		assert.Equal(t, repository.AssertionStatusSuperseded, closedAB.Status, "A-B superseded (B has one partner)")
+	})
+
+	// Case 18: a chained future successor bounds the prior pending successor (no
+	// gap). NYC current → future LA (July) bounds NYC → future SF (Aug) must BOUND
+	// LA to Aug (LA current Jul-Aug), not terminalize it leaving a July gap.
+	t.Run("18 chained future successors leave no gap", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
+		now := accelerated.GetCurrentTime().UTC()
+
+		nyc, err := h.svc.Assert(ctx, textFactReq(subject, "home_address", "NYC", gen.Prefix(), "nyc"))
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, nyc.ID)
+
+		julFrom := now.Add(30 * 24 * time.Hour)
+		laReq := textFactReq(subject, "home_address", "LA", gen.Prefix(), "la")
+		laReq.ValidFrom = &julFrom
+		la, err := h.svc.Assert(ctx, laReq)
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, la.ID)
+
+		augFrom := now.Add(60 * 24 * time.Hour)
+		sfReq := textFactReq(subject, "home_address", "SF", gen.Prefix(), "sf")
+		sfReq.ValidFrom = &augFrom
+		sf, err := h.svc.Assert(ctx, sfReq)
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, sf.ID)
+
+		// LA must be BOUNDED to Aug (still accepted, current Jul-Aug), not superseded.
+		gotLA, err := h.assertionRepo.GetAssertion(ctx, la.ID)
+		require.NoError(t, err)
+		assert.Equal(t, repository.AssertionStatusAccepted, gotLA.Status, "LA stays accepted (current Jul-Aug)")
+		require.NotNil(t, gotLA.ValidTo)
+		assert.True(t, gotLA.ValidTo.Equal(augFrom), "LA bounded to Aug")
+		require.NotNil(t, gotLA.SupersededBy)
+		assert.Equal(t, sf.ID, *gotLA.SupersededBy)
+
+		// Mid-July there IS a current value (LA), no gap.
+		midJul := now.Add(45 * 24 * time.Hour)
+		cur, err := h.assertionRepo.GetCurrentAccepted(ctx, subject, "home_address", midJul)
+		require.NoError(t, err, "no gap in July")
+		assert.Equal(t, la.ID, cur.ID)
+	})
+
+	// Case 19: re-affirming a value bounded by a pending future successor must NOT
+	// clear the bound (the P0 — widen must not resurrect the prior past the
+	// successor). NYC current → future LA bounds NYC at +30d → re-affirm NYC from a
+	// later year bucket → NYC's valid_to bound to LA is preserved.
+	t.Run("19 widen does not resurrect prior across pending successor", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
+		now := accelerated.GetCurrentTime().UTC()
+
+		// home_address is year-bucketed. NYC at year Y (valid_from this year).
+		thisYear := time.Date(now.Year(), 1, 15, 0, 0, 0, 0, time.UTC)
+		nycReq := textFactReq(subject, "home_address", "NYC", gen.Prefix(), "nyc")
+		nycReq.ValidFrom = &thisYear
+		nyc, err := h.svc.Assert(ctx, nycReq)
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, nyc.ID)
+
+		future := now.Add(30 * 24 * time.Hour)
+		laReq := textFactReq(subject, "home_address", "LA", gen.Prefix(), "la")
+		laReq.ValidFrom = &future
+		la, err := h.svc.Assert(ctx, laReq)
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, la.ID)
+
+		boundedNYC, err := h.assertionRepo.GetAssertion(ctx, nyc.ID)
+		require.NoError(t, err)
+		require.NotNil(t, boundedNYC.ValidTo, "NYC bounded by LA")
+		require.NotNil(t, boundedNYC.SupersededBy)
+
+		// Re-affirm NYC from a DIFFERENT (next) year bucket — a same-value
+		// reaffirmation. It must widen the lower bound but NOT clear NYC's pending
+		// upper bound (LA).
+		nextYear := time.Date(now.Year()+1, 6, 1, 0, 0, 0, 0, time.UTC)
+		reaffirm := textFactReq(subject, "home_address", "NYC", gen.Prefix(), "nyc2")
+		reaffirm.ValidFrom = &nextYear
+		_, err = h.svc.Assert(ctx, reaffirm)
+		require.NoError(t, err)
+
+		afterReaffirm, err := h.assertionRepo.GetAssertion(ctx, nyc.ID)
+		require.NoError(t, err)
+		require.NotNil(t, afterReaffirm.ValidTo, "NYC's pending-successor bound is preserved")
+		assert.True(t, afterReaffirm.ValidTo.Equal(*boundedNYC.ValidTo), "valid_to bound unchanged by the reaffirmation")
+		// LA stays the pending future successor; exactly one current now (NYC).
+		curNow, err := h.assertionRepo.GetCurrentAccepted(ctx, subject, "home_address", now)
+		require.NoError(t, err)
+		assert.Equal(t, nyc.ID, curNow.ID, "exactly NYC is current now")
+		_ = la
+	})
+}
+
+// TestAssert_Lifecycle covers the lifecycle-transition concurrency + same-value
+// accept-time behaviors the review surfaced.
+func TestAssert_Lifecycle(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	t.Parallel()
+	h, ctx := newAssertHarness(t, ctx0())
+
+	// Case 20: concurrent Accept + Reject of the SAME proposed row — exactly one
+	// transition wins (the row-lock makes the from-status check atomic).
+	t.Run("20 concurrent Accept and Reject race", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
+
+		prop, err := h.svc.Assert(ctx, textFactReq(subject, "health_condition", "race", gen.Prefix(), "r"))
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, prop.ID)
+		require.Equal(t, repository.AssertionStatusProposed, prop.Status)
+
+		errs := make([]error, 2)
+		runConcurrent(2, func(i int) {
+			if i == 0 {
+				_, errs[i] = h.svc.Accept(ctx, prop.ID, service.AcceptRequest{})
+			} else {
+				_, errs[i] = h.svc.Reject(ctx, prop.ID, service.RejectRequest{})
+			}
+		})
+		// Exactly one succeeds; the other fails the from-status precondition.
+		successes := 0
+		for _, e := range errs {
+			if e == nil {
+				successes++
+			} else {
+				require.ErrorIs(t, e, service.ErrAssertValidation, "the loser fails the status precondition")
+			}
+		}
+		assert.Equal(t, 1, successes, "exactly one transition wins")
+
+		// The row ends in a terminal state consistent with the winner (not both).
+		final, err := h.assertionRepo.GetAssertion(ctx, prop.ID)
+		require.NoError(t, err)
+		assert.Contains(t, []string{repository.AssertionStatusAccepted, repository.AssertionStatusRejected}, final.Status)
+	})
+
+	// Case 21: Accept of a same-value proposal in a different bucket WIDENS the
+	// existing accepted row (does not supersede it). home_address is year-bucketed +
+	// auto-apply, so use a force-confirm proposal to land it 'proposed' first.
+	t.Run("21 Accept same-value different-bucket widens", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
+		now := accelerated.GetCurrentTime().UTC()
+
+		// Accepted NYC this year (open-ended, auto-apply), confidence 50.
+		thisYear := time.Date(now.Year(), 2, 1, 0, 0, 0, 0, time.UTC)
+		nycReq := textFactReq(subject, "home_address", "NYC", gen.Prefix(), "nyc")
+		nycReq.ValidFrom = &thisYear
+		nycReq.Confidence = 50
+		accepted, err := h.svc.Assert(ctx, nycReq)
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, accepted.ID)
+		require.Equal(t, repository.AssertionStatusAccepted, accepted.Status)
+		require.EqualValues(t, 50, accepted.Confidence)
+
+		// A force-confirm same-value NYC proposal in NEXT year's bucket → proposed,
+		// confidence 95 (higher, so the merge must raise the survivor's confidence).
+		nextYear := time.Date(now.Year()+1, 3, 1, 0, 0, 0, 0, time.UTC)
+		propReq := textFactReq(subject, "home_address", "NYC", gen.Prefix(), "nyc2")
+		propReq.ValidFrom = &nextYear
+		propReq.ForceConfirm = true
+		propReq.Confidence = 95
+		proposed, err := h.svc.Assert(ctx, propReq)
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, proposed.ID)
+		require.Equal(t, repository.AssertionStatusProposed, proposed.Status)
+		require.NotEqual(t, accepted.ID, proposed.ID, "different bucket → distinct proposed row")
+
+		// Accept the proposal → it must WIDEN the existing accepted row (absorb the
+		// proposal), NOT supersede it. The accepted NYC stays accepted-live.
+		survivor, err := h.svc.Accept(ctx, proposed.ID, service.AcceptRequest{})
+		require.NoError(t, err)
+		assert.Equal(t, accepted.ID, survivor.ID, "Accept returns the widened survivor, not a superseded row")
+
+		gotAccepted, err := h.assertionRepo.GetAssertion(ctx, accepted.ID)
+		require.NoError(t, err)
+		assert.Equal(t, repository.AssertionStatusAccepted, gotAccepted.Status, "existing NYC stays accepted (widened)")
+		assert.EqualValues(t, 95, gotAccepted.Confidence, "merge folds the higher loser confidence into the survivor")
+		gotProposed, err := h.assertionRepo.GetAssertion(ctx, proposed.ID)
+		require.NoError(t, err)
+		assert.Equal(t, repository.AssertionStatusSuperseded, gotProposed.Status, "the proposal is absorbed (superseded)")
+		// Exactly one live home_address proposition for the subject.
+		live, err := h.assertionRepo.ListLiveEdgesForNode(ctx, subject, "home_address")
+		require.NoError(t, err)
+		require.Len(t, live, 1)
+		assert.Equal(t, accepted.ID, live[0].ID)
+	})
+
+	// Case 22: KnowledgeFromOverride in the future + a terminal transition clamps
+	// knowledge_to >= knowledge_from (no assertion_knowledge_range violation).
+	t.Run("22 terminal transition clamps knowledge_to for future override", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
+		now := accelerated.GetCurrentTime().UTC()
+
+		tomorrow := now.Add(24 * time.Hour)
+		req := textFactReq(subject, "health_condition", "future-knowledge", gen.Prefix(), "fk")
+		req.KnowledgeFromOverride = &tomorrow
+		prop, err := h.svc.Assert(ctx, req)
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, prop.ID)
+		require.True(t, prop.KnowledgeFrom.After(now), "knowledge_from is in the future")
+
+		// Reject today → knowledge_to must be clamped to >= knowledge_from (no CHECK
+		// violation).
+		rejected, err := h.svc.Reject(ctx, prop.ID, service.RejectRequest{})
+		require.NoError(t, err)
+		require.NotNil(t, rejected.KnowledgeTo)
+		assert.False(t, rejected.KnowledgeTo.Before(rejected.KnowledgeFrom), "knowledge_to >= knowledge_from")
 	})
 }
 

--- a/backend/tests/assert_integration_test.go
+++ b/backend/tests/assert_integration_test.go
@@ -1,0 +1,934 @@
+//go:build integration_testdb
+
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+
+	"github.com/google/uuid"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// assertNoopWorker satisfies the River Workers bundle for the test bus (the
+// assertion kinds enqueue no consumer jobs, so it is never invoked).
+type assertNoopWorker struct {
+	river.WorkerDefaults[assertNoopArgs]
+}
+
+type assertNoopArgs struct{}
+
+func (assertNoopArgs) Kind() string { return "assert_noop" }
+func (*assertNoopWorker) Work(context.Context, *river.Job[assertNoopArgs]) error {
+	return nil
+}
+
+// assertHarness bundles the service under test + the repos a test reads back.
+type assertHarness struct {
+	svc           *service.AssertService
+	assertionRepo *repository.AssertionRepository
+	nodeRepo      *repository.NodeRepository
+	entityRepo    *repository.EntityRepository
+	eventRepo     *repository.EventRepository
+	support       *repository.SyntheticSupportRepository
+	database      *db.Database
+}
+
+// newAssertHarness builds an AssertService over a never-started River client (the
+// assertion kinds route to no consumer, so InsertTx is never called).
+func newAssertHarness(t *testing.T, ctx context.Context) (*assertHarness, context.Context) {
+	t.Helper()
+	database, cfg := newSharedTestDB(t, ctx)
+
+	eventRepo := repository.NewEventRepository(database.Queries)
+	workers := river.NewWorkers()
+	river.AddWorker(workers, &assertNoopWorker{})
+	client, err := river.NewClient(riverpgxv5.New(database.Pool), &river.Config{
+		Queues:   map[string]river.QueueConfig{river.QueueDefault: {MaxWorkers: cfg.River.WorkerConcurrency}},
+		Workers:  workers,
+		TestOnly: true,
+	})
+	require.NoError(t, err)
+	bus := events.NewBus(database.Pool, client, eventRepo)
+
+	nodeRepo := repository.NewNodeRepository(database.Queries)
+	entityRepo := repository.NewEntityRepository(database.Queries)
+	predicateRepo := repository.NewPredicateRepository(database.Queries)
+	assertionRepo := repository.NewAssertionRepository(database.Queries)
+	svc := service.NewAssertService(database.Pool, nodeRepo, entityRepo, predicateRepo, assertionRepo, bus)
+
+	return &assertHarness{
+		svc:           svc,
+		assertionRepo: assertionRepo,
+		nodeRepo:      nodeRepo,
+		entityRepo:    entityRepo,
+		eventRepo:     eventRepo,
+		support:       repository.NewSyntheticSupportRepository(database.Queries),
+		database:      database,
+	}, ctx
+}
+
+// seedPerson creates a person node and registers cleanup (assertions before
+// nodes, since the assertion→node FK is restrict). The event rows an assert
+// produces are cleaned per-assertion by the test via cleanupAssertionEvents.
+func (h *assertHarness) seedPerson(t *testing.T, ctx context.Context, prefix, label string) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	_, err := h.nodeRepo.CreateNode(ctx, id, repository.NodeTypePerson, prefix+label)
+	require.NoError(t, err)
+	t.Cleanup(func() { _, _ = h.support.DeleteAssertionsForNode(ctx, id) })
+	t.Cleanup(func() { _, _ = h.support.DeleteNodesByLabelPrefix(ctx, prefix) })
+	return id
+}
+
+// seedPlace creates a place entity node (subtype='place') for lives_in/within
+// edge tests, registering the same cleanup ordering.
+func (h *assertHarness) seedPlace(t *testing.T, ctx context.Context, prefix, label string) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	_, err := h.nodeRepo.CreateNode(ctx, id, repository.NodeTypeEntity, prefix+label)
+	require.NoError(t, err)
+	_, err = h.entityRepo.CreateEntity(ctx, repository.CreateEntityRequest{
+		NodeID:         id,
+		Subtype:        repository.EntitySubtypePlace,
+		NormalizedName: prefix + label,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _, _ = h.support.DeleteAssertionsForNode(ctx, id) })
+	t.Cleanup(func() { _, _ = h.support.DeleteNodesByLabelPrefix(ctx, prefix) })
+	return id
+}
+
+// userLocator builds a user provenance locator with a stable per-test source_id
+// (no content-row existence check). srcSuffix disambiguates distinct locators.
+func userLocator(prefix, srcSuffix string) service.ProvenanceLocator {
+	return service.ProvenanceLocator{
+		SourceKind:   repository.SourceKindUser,
+		SourceID:     prefix + "edit:" + srcSuffix,
+		ProducerKind: repository.ProducerKindUser,
+	}
+}
+
+// textFactReq builds a single-text-fact AssertRequest with one user locator.
+func textFactReq(subject uuid.UUID, predicate, value, prefix, srcSuffix string) service.AssertRequest {
+	v := value
+	return service.AssertRequest{
+		SubjectNodeID: subject,
+		PredicateKey:  predicate,
+		ValueText:     &v,
+		Confidence:    80,
+		Locators:      []service.ProvenanceLocator{userLocator(prefix, srcSuffix)},
+	}
+}
+
+// edgeReq builds an edge AssertRequest with one user locator.
+func edgeReq(subject, object uuid.UUID, predicate, prefix, srcSuffix string) service.AssertRequest {
+	return service.AssertRequest{
+		SubjectNodeID: subject,
+		PredicateKey:  predicate,
+		ObjectNodeID:  &object,
+		Confidence:    80,
+		Locators:      []service.ProvenanceLocator{userLocator(prefix, srcSuffix)},
+	}
+}
+
+// cleanupAssertionEvents registers cleanup of the event rows an assertion
+// produced (source='assertion', source_id prefixed by the assertion id).
+func (h *assertHarness) cleanupAssertionEvents(t *testing.T, ctx context.Context, assertionID uuid.UUID) {
+	t.Helper()
+	t.Cleanup(func() {
+		_ = h.eventRepo.HardDeleteEventsBySourceAndSourceIDPrefix(ctx, "assertion", assertionID.String())
+	})
+}
+
+// eventExists reports whether an event row exists for (source='assertion',
+// source_id).
+func (h *assertHarness) eventExists(t *testing.T, ctx context.Context, sourceID string) bool {
+	t.Helper()
+	_, err := h.eventRepo.FindEventBySource(ctx, "assertion", sourceID)
+	if err == nil {
+		return true
+	}
+	require.ErrorIs(t, err, db.ErrNotFound)
+	return false
+}
+
+// acceptedSourceID / supersededSourceID / provenanceSourceID build the event
+// source_id keys an assertion's transitions produce.
+func acceptedSourceID(id uuid.UUID) string   { return id.String() + ":accepted" }
+func proposedSourceID(id uuid.UUID) string   { return id.String() + ":proposed" }
+func supersededSourceID(id uuid.UUID) string { return id.String() + ":superseded" }
+func rejectedSourceID(id uuid.UUID) string   { return id.String() + ":rejected" }
+
+func TestAssert_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	t.Parallel()
+	h, ctx := newAssertHarness(t, ctx0())
+
+	// Case 1: a new fact lands accepted; assertion.accepted emitted.
+	t.Run("1 new fact lands accepted with event", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
+
+		a, err := h.svc.Assert(ctx, textFactReq(subject, "home_address", "123 Main St", gen.Prefix(), "1"))
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, a.ID)
+		assert.Equal(t, repository.AssertionStatusAccepted, a.Status)
+		assert.Nil(t, a.KnowledgeTo)
+		assert.True(t, h.eventExists(t, ctx, acceptedSourceID(a.ID)), "assertion.accepted emitted")
+
+		provs, err := h.assertionRepo.ListProvenance(ctx, a.ID)
+		require.NoError(t, err)
+		require.Len(t, provs, 1)
+	})
+
+	// Case 2: corroboration from a 2nd locator → one assertion, two provenance,
+	// confidence=max, provenance_added emitted; a 3rd SAME locator → no-op.
+	t.Run("2 corroboration dedup + locator idempotency", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
+
+		req1 := textFactReq(subject, "home_address", "456 Oak Ave", gen.Prefix(), "loc1")
+		req1.Confidence = 60
+		a, err := h.svc.Assert(ctx, req1)
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, a.ID)
+
+		// Second source, SAME proposition (same value+bucket), different locator.
+		req2 := textFactReq(subject, "home_address", "456 Oak Ave", gen.Prefix(), "loc2")
+		req2.Confidence = 90
+		a2, err := h.svc.Assert(ctx, req2)
+		require.NoError(t, err)
+		assert.Equal(t, a.ID, a2.ID, "same proposition → one assertion row")
+		assert.EqualValues(t, 90, a2.Confidence, "confidence = max(existing, incoming)")
+
+		provs, err := h.assertionRepo.ListProvenance(ctx, a.ID)
+		require.NoError(t, err)
+		assert.Len(t, provs, 2, "two distinct locators")
+
+		// One assertion row total for the subject.
+		n, err := h.support.CountAssertionsForSubject(ctx, subject)
+		require.NoError(t, err)
+		assert.EqualValues(t, 1, n)
+
+		// Third corroboration with the SAME locator as req2 → no new provenance.
+		a3, err := h.svc.Assert(ctx, req2)
+		require.NoError(t, err)
+		assert.Equal(t, a.ID, a3.ID)
+		provs, err = h.assertionRepo.ListProvenance(ctx, a.ID)
+		require.NoError(t, err)
+		assert.Len(t, provs, 2, "same-locator re-emit is a no-op")
+	})
+
+	// Case 3: single-predicate successor (different value) supersedes the prior.
+	t.Run("3 present successor supersedes prior", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
+
+		prior, err := h.svc.Assert(ctx, textFactReq(subject, "home_address", "NYC addr", gen.Prefix(), "p"))
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, prior.ID)
+
+		successor, err := h.svc.Assert(ctx, textFactReq(subject, "home_address", "LA addr", gen.Prefix(), "s"))
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, successor.ID)
+		assert.NotEqual(t, prior.ID, successor.ID)
+
+		closed, err := h.assertionRepo.GetAssertion(ctx, prior.ID)
+		require.NoError(t, err)
+		assert.Equal(t, repository.AssertionStatusSuperseded, closed.Status)
+		require.NotNil(t, closed.SupersededBy)
+		assert.Equal(t, successor.ID, *closed.SupersededBy)
+		require.NotNil(t, closed.KnowledgeTo)
+		assert.True(t, h.eventExists(t, ctx, supersededSourceID(prior.ID)))
+		assert.True(t, h.eventExists(t, ctx, acceptedSourceID(successor.ID)))
+
+		now := accelerated.GetCurrentTime().UTC()
+		cur, err := h.assertionRepo.GetCurrentAccepted(ctx, subject, "home_address", now)
+		require.NoError(t, err)
+		assert.Equal(t, successor.ID, cur.ID, "current is the successor")
+	})
+
+	// Case 4: closure-only → prior closed 'ended', current becomes a gap.
+	t.Run("4 closure-only leaves a gap", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
+
+		prior, err := h.svc.Assert(ctx, textFactReq(subject, "home_address", "old addr", gen.Prefix(), "p"))
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, prior.ID)
+
+		require.NoError(t, h.svc.AssertClosure(ctx, service.ClosureRequest{SubjectNodeID: subject, PredicateKey: "home_address"}))
+
+		closed, err := h.assertionRepo.GetAssertion(ctx, prior.ID)
+		require.NoError(t, err)
+		assert.Equal(t, repository.AssertionStatusSuperseded, closed.Status)
+		require.NotNil(t, closed.ClosureReason)
+		assert.Equal(t, repository.ClosureReasonEnded, *closed.ClosureReason)
+		assert.Nil(t, closed.SupersededBy, "closure-only has no successor")
+
+		now := accelerated.GetCurrentTime().UTC()
+		_, err = h.assertionRepo.GetCurrentAccepted(ctx, subject, "home_address", now)
+		require.ErrorIs(t, err, db.ErrNotFound, "current is now a gap")
+	})
+
+	// Case 5: multi-predicate accumulation — two health conditions, both live.
+	t.Run("5 multi accumulates without supersession", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
+
+		// health_condition is always-confirm → proposed; accept both so they are live.
+		a, err := h.svc.Assert(ctx, textFactReq(subject, "health_condition", "condition A", gen.Prefix(), "a"))
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, a.ID)
+		assert.Equal(t, repository.AssertionStatusProposed, a.Status)
+
+		b, err := h.svc.Assert(ctx, textFactReq(subject, "health_condition", "condition B", gen.Prefix(), "b"))
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, b.ID)
+
+		// Both still live (proposed), no supersession on a multi predicate.
+		ga, err := h.assertionRepo.GetAssertion(ctx, a.ID)
+		require.NoError(t, err)
+		assert.Equal(t, repository.AssertionStatusProposed, ga.Status)
+		gb, err := h.assertionRepo.GetAssertion(ctx, b.ID)
+		require.NoError(t, err)
+		assert.Equal(t, repository.AssertionStatusProposed, gb.Status)
+	})
+
+	// Case 6: always-confirm single (partner_of) → proposed; Accept supersedes the
+	// prior accepted partnership at accept time.
+	t.Run("6 always-confirm proposed then Accept supersedes", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		a := h.seedPerson(t, ctx, gen.Prefix(), "A")
+		b := h.seedPerson(t, ctx, gen.Prefix(), "B")
+		c := h.seedPerson(t, ctx, gen.Prefix(), "C")
+
+		// partner_of is always-confirm → proposed. Accept A-B so it is the current
+		// accepted partnership.
+		propAB, err := h.svc.Assert(ctx, edgeReq(a, b, "partner_of", gen.Prefix(), "ab"))
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, propAB.ID)
+		assert.Equal(t, repository.AssertionStatusProposed, propAB.Status)
+		acceptedAB, err := h.svc.Accept(ctx, propAB.ID, service.AcceptRequest{})
+		require.NoError(t, err)
+		assert.Equal(t, repository.AssertionStatusAccepted, acceptedAB.Status)
+
+		// Propose A-C, then Accept it → A-B is superseded (A has one partner).
+		propAC, err := h.svc.Assert(ctx, edgeReq(a, c, "partner_of", gen.Prefix(), "ac"))
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, propAC.ID)
+		acceptedAC, err := h.svc.Accept(ctx, propAC.ID, service.AcceptRequest{})
+		require.NoError(t, err)
+		assert.Equal(t, repository.AssertionStatusAccepted, acceptedAC.Status)
+
+		closedAB, err := h.assertionRepo.GetAssertion(ctx, propAB.ID)
+		require.NoError(t, err)
+		assert.Equal(t, repository.AssertionStatusSuperseded, closedAB.Status, "A-B superseded on Accept(A-C)")
+		require.NotNil(t, closedAB.SupersededBy)
+		assert.Equal(t, propAC.ID, *closedAB.SupersededBy)
+	})
+
+	// Case 7: Reject a proposed → rejected (never current); Retract an accepted →
+	// retracted (emits superseded).
+	t.Run("7 reject and retract", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
+
+		// Reject a proposed health_condition.
+		prop, err := h.svc.Assert(ctx, textFactReq(subject, "health_condition", "to reject", gen.Prefix(), "r"))
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, prop.ID)
+		rejected, err := h.svc.Reject(ctx, prop.ID, service.RejectRequest{})
+		require.NoError(t, err)
+		assert.Equal(t, repository.AssertionStatusRejected, rejected.Status)
+		require.NotNil(t, rejected.KnowledgeTo)
+		assert.True(t, h.eventExists(t, ctx, rejectedSourceID(prop.ID)))
+
+		// Retract an accepted fact → retracted, emits the superseded kind.
+		acc, err := h.svc.Assert(ctx, textFactReq(subject, "home_address", "to retract", gen.Prefix(), "rt"))
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, acc.ID)
+		retracted, err := h.svc.Retract(ctx, acc.ID, service.RetractRequest{})
+		require.NoError(t, err)
+		assert.Equal(t, repository.AssertionStatusRetracted, retracted.Status)
+		require.NotNil(t, retracted.ClosureReason)
+		assert.Equal(t, repository.ClosureReasonRetracted, *retracted.ClosureReason)
+		assert.True(t, h.eventExists(t, ctx, supersededSourceID(acc.ID)), "retract emits the superseded kind")
+	})
+
+	// Case 8: symmetric edge (knows) A→B then B→A → one row, found for both.
+	t.Run("8 symmetric edge dedups both directions", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		a := h.seedPerson(t, ctx, gen.Prefix(), "A")
+		b := h.seedPerson(t, ctx, gen.Prefix(), "B")
+
+		ab, err := h.svc.Assert(ctx, edgeReq(a, b, "knows", gen.Prefix(), "ab"))
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, ab.ID)
+
+		ba, err := h.svc.Assert(ctx, edgeReq(b, a, "knows", gen.Prefix(), "ba"))
+		require.NoError(t, err)
+		assert.Equal(t, ab.ID, ba.ID, "A knows B and B knows A collapse to one row")
+
+		forA, err := h.assertionRepo.ListLiveEdgesForNode(ctx, a, "knows")
+		require.NoError(t, err)
+		require.Len(t, forA, 1)
+		forB, err := h.assertionRepo.ListLiveEdgesForNode(ctx, b, "knows")
+		require.NoError(t, err)
+		require.Len(t, forB, 1)
+		assert.Equal(t, forA[0].ID, forB[0].ID)
+	})
+
+	// Case 9: inverse edge parent_of(A,B) then child_of(B,A) → one canonical row.
+	t.Run("9 inverse edge dedups to one canonical row", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		a := h.seedPerson(t, ctx, gen.Prefix(), "A")
+		b := h.seedPerson(t, ctx, gen.Prefix(), "B")
+
+		// parent_of(A,B): A is parent of B.
+		parentAB, err := h.svc.Assert(ctx, edgeReq(a, b, "parent_of", gen.Prefix(), "p"))
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, parentAB.ID)
+
+		// child_of(B,A): B is child of A — the SAME relationship, canonical token.
+		childBA, err := h.svc.Assert(ctx, edgeReq(b, a, "child_of", gen.Prefix(), "c"))
+		require.NoError(t, err)
+		assert.Equal(t, parentAB.ID, childBA.ID, "inverse pair collapses to one row")
+
+		// The stored row uses the canonical predicate (child_of < parent_of).
+		row, err := h.assertionRepo.GetAssertion(ctx, parentAB.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "child_of", row.PredicateKey)
+	})
+
+	// Case 10: edge to a latent person via EnsureLatentPerson.
+	t.Run("10 edge to a latent person", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		a := h.seedPerson(t, ctx, gen.Prefix(), "A")
+
+		var latentID uuid.UUID
+		tx, err := h.database.Pool.Begin(ctx)
+		require.NoError(t, err)
+		latentID, err = h.svc.EnsureLatentPerson(ctx, tx, gen.Prefix()+"latent-person")
+		require.NoError(t, err)
+		require.NoError(t, tx.Commit(ctx))
+		t.Cleanup(func() { _, _ = h.support.DeleteAssertionsForNode(ctx, latentID) })
+
+		edge, err := h.svc.Assert(ctx, edgeReq(a, latentID, "knows", gen.Prefix(), "k"))
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, edge.ID)
+		require.NotNil(t, edge.ObjectNodeID)
+
+		forLatent, err := h.assertionRepo.ListLiveEdgesForNode(ctx, latentID, "knows")
+		require.NoError(t, err)
+		require.Len(t, forLatent, 1)
+	})
+
+	// Case 11: idempotent re-emit — replaying the same accepted write twice → one
+	// assertion, one :accepted event.
+	t.Run("11 idempotent re-emit", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
+
+		req := textFactReq(subject, "home_address", "idem addr", gen.Prefix(), "i")
+		a1, err := h.svc.Assert(ctx, req)
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, a1.ID)
+		a2, err := h.svc.Assert(ctx, req)
+		require.NoError(t, err)
+		assert.Equal(t, a1.ID, a2.ID, "replay → one assertion")
+
+		n, err := h.support.CountAssertionsForSubject(ctx, subject)
+		require.NoError(t, err)
+		assert.EqualValues(t, 1, n)
+		assert.True(t, h.eventExists(t, ctx, acceptedSourceID(a1.ID)))
+	})
+}
+
+// ctx0 returns a fresh background context (small indirection so the harness
+// constructor reads cleanly).
+func ctx0() context.Context { return context.Background() }
+
+// TestAssert_Concurrency covers the race-protection cases (savepoint-recover +
+// advisory lock). Each runs concurrent top-level Assert calls (separate txs).
+func TestAssert_Concurrency(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	t.Parallel()
+	h, ctx := newAssertHarness(t, ctx0())
+
+	// Case 12: concurrent SAME-proposition writes → one live assertion, the loser
+	// corroborates (savepoint-recover path).
+	t.Run("12 concurrent same-proposition", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
+
+		req := textFactReq(subject, "home_address", "same addr", gen.Prefix(), "same")
+		const n = 4
+		results := make([]*repository.Assertion, n)
+		errs := make([]error, n)
+		runConcurrent(n, func(i int) { results[i], errs[i] = h.svc.Assert(ctx, req) })
+
+		var firstID uuid.UUID
+		for i := 0; i < n; i++ {
+			require.NoErrorf(t, errs[i], "goroutine %d", i)
+			require.NotNil(t, results[i])
+			if firstID == uuid.Nil {
+				firstID = results[i].ID
+			}
+			assert.Equal(t, firstID, results[i].ID, "all converge on one assertion")
+		}
+		h.cleanupAssertionEvents(t, ctx, firstID)
+		cnt, err := h.support.CountAssertionsForSubject(ctx, subject)
+		require.NoError(t, err)
+		assert.EqualValues(t, 1, cnt, "exactly one assertion row")
+	})
+
+	// Case 13: concurrent DIFFERENT-value single-card writes into an empty slot →
+	// exactly one accepted-current row (the advisory lock serializes the empty slot).
+	t.Run("13 concurrent different-value empty slot", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
+
+		const n = 4
+		results := make([]*repository.Assertion, n)
+		errs := make([]error, n)
+		runConcurrent(n, func(i int) {
+			req := textFactReq(subject, "home_address", "addr-"+uuid.NewString(), gen.Prefix(), "v"+uuid.NewString())
+			results[i], errs[i] = h.svc.Assert(ctx, req)
+		})
+		for i := 0; i < n; i++ {
+			require.NoErrorf(t, errs[i], "goroutine %d", i)
+			h.cleanupAssertionEvents(t, ctx, results[i].ID)
+		}
+
+		// Exactly one is current-accepted; the rest are superseded.
+		now := accelerated.GetCurrentTime().UTC()
+		cur, err := h.assertionRepo.GetCurrentAccepted(ctx, subject, "home_address", now)
+		require.NoError(t, err, "exactly one current-accepted row survives the race")
+		assert.NotNil(t, cur)
+
+		live := 0
+		for i := 0; i < n; i++ {
+			row, err := h.assertionRepo.GetAssertion(ctx, results[i].ID)
+			require.NoError(t, err)
+			if row.Status == repository.AssertionStatusAccepted && row.KnowledgeTo == nil {
+				live++
+			}
+		}
+		assert.Equal(t, 1, live, "exactly one accepted-live row after the race")
+	})
+
+	// Case 14: concurrent Accept of two proposed single-card assertions into an
+	// empty slot → exactly one ends accepted-current (advisory lock on the Accept
+	// path).
+	t.Run("14 concurrent Accept of two proposed", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		a := h.seedPerson(t, ctx, gen.Prefix(), "A")
+		b := h.seedPerson(t, ctx, gen.Prefix(), "B")
+		c := h.seedPerson(t, ctx, gen.Prefix(), "C")
+
+		// Two proposed partnerships for A (partner_of is always-confirm → proposed).
+		propAB, err := h.svc.Assert(ctx, edgeReq(a, b, "partner_of", gen.Prefix(), "ab"))
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, propAB.ID)
+		propAC, err := h.svc.Assert(ctx, edgeReq(a, c, "partner_of", gen.Prefix(), "ac"))
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, propAC.ID)
+
+		ids := []uuid.UUID{propAB.ID, propAC.ID}
+		errs := make([]error, 2)
+		runConcurrent(2, func(i int) { _, errs[i] = h.svc.Accept(ctx, ids[i], service.AcceptRequest{}) })
+		// Both Accept calls may succeed (the second supersedes the first); what
+		// matters is exactly one of A's partnerships ends accepted-live. partner_of is
+		// symmetric (stored UUID-ordered), so A may be subject OR object — count via
+		// ListLiveEdgesForNode (both orientations), not the subject-only current read.
+		for i := 0; i < 2; i++ {
+			require.NoErrorf(t, errs[i], "accept %d", i)
+		}
+		edges, err := h.assertionRepo.ListLiveEdgesForNode(ctx, a, "partner_of")
+		require.NoError(t, err)
+		liveAccepted := 0
+		for _, e := range edges {
+			if e.Status == repository.AssertionStatusAccepted {
+				liveAccepted++
+			}
+		}
+		assert.Equal(t, 1, liveAccepted, "exactly one accepted partnership for A after the race")
+	})
+}
+
+// TestAssert_ValidTime covers the bi-temporal valid-time branches (future
+// successor + rollover, past-bounded backfill, present-edit cancellation).
+func TestAssert_ValidTime(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	t.Parallel()
+	h, ctx := newAssertHarness(t, ctx0())
+
+	// Case 15 + 15b: future-dated successor bounds the prior (still current); the
+	// rollover (after the bound passes) terminalizes it and flips GetCurrentAccepted
+	// — but does NOT terminalize a successor-less bounded-past fact.
+	t.Run("15 future successor + rollover", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
+		now := accelerated.GetCurrentTime().UTC()
+
+		// NYC current (open).
+		nyc, err := h.svc.Assert(ctx, textFactReq(subject, "home_address", "NYC", gen.Prefix(), "nyc"))
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, nyc.ID)
+
+		// LA with a FUTURE valid_from → NYC bounded (valid_to=future, superseded_by=LA)
+		// but stays accepted/current; LA accepted-but-not-yet-current.
+		future := now.Add(72 * time.Hour)
+		laReq := textFactReq(subject, "home_address", "LA", gen.Prefix(), "la")
+		laReq.ValidFrom = &future
+		la, err := h.svc.Assert(ctx, laReq)
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, la.ID)
+
+		boundedNYC, err := h.assertionRepo.GetAssertion(ctx, nyc.ID)
+		require.NoError(t, err)
+		assert.Equal(t, repository.AssertionStatusAccepted, boundedNYC.Status, "NYC stays accepted until the bound")
+		require.NotNil(t, boundedNYC.ValidTo)
+		require.NotNil(t, boundedNYC.SupersededBy)
+		assert.Equal(t, la.ID, *boundedNYC.SupersededBy)
+
+		// NYC is current now (window contains now); LA is not yet.
+		curNow, err := h.assertionRepo.GetCurrentAccepted(ctx, subject, "home_address", now)
+		require.NoError(t, err)
+		assert.Equal(t, nyc.ID, curNow.ID)
+
+		// Simulate the bound passing: re-bound NYC's valid_to into the PAST (keeping
+		// superseded_by) so the rollover's valid_to <= now predicate fires. (This
+		// avoids manipulating global accelerated-time env vars under t.Parallel().)
+		past := now.Add(-time.Hour)
+		rebindTx, err := h.database.Pool.Begin(ctx)
+		require.NoError(t, err)
+		require.NoError(t, h.assertionRepo.BoundPendingSuccessorTx(ctx, rebindTx, nyc.ID, past, la.ID))
+		require.NoError(t, rebindTx.Commit(ctx))
+
+		// Run the rollover.
+		n, err := h.svc.RunRollover(ctx)
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, n, 1)
+
+		rolled, err := h.assertionRepo.GetAssertion(ctx, nyc.ID)
+		require.NoError(t, err)
+		assert.Equal(t, repository.AssertionStatusSuperseded, rolled.Status, "rollover terminalizes NYC")
+		require.NotNil(t, rolled.ClosureReason)
+		assert.Equal(t, repository.ClosureReasonSuperseded, *rolled.ClosureReason)
+		require.NotNil(t, rolled.KnowledgeTo)
+		require.NotNil(t, rolled.SupersededBy)
+		assert.Equal(t, la.ID, *rolled.SupersededBy)
+		assert.True(t, h.eventExists(t, ctx, supersededSourceID(nyc.ID)), "rollover emits superseded for NYC")
+
+		// LA is now the current accepted (its valid_from is in the future, but
+		// GetCurrentAccepted at a time past its valid_from returns it).
+		cur, err := h.assertionRepo.GetCurrentAccepted(ctx, subject, "home_address", future.Add(time.Hour))
+		require.NoError(t, err)
+		assert.Equal(t, la.ID, cur.ID, "LA is current once its valid_from passes")
+	})
+
+	// Case 15b: a successor-less bounded-past fact is NOT terminalized by rollover.
+	t.Run("15b rollover skips successor-less bounded-past fact", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
+		now := accelerated.GetCurrentTime().UTC()
+
+		// A bounded-past fact (valid window entirely in the past), no successor.
+		from := now.Add(-200 * 24 * time.Hour)
+		to := now.Add(-100 * 24 * time.Hour)
+		boston := textFactReq(subject, "home_address", "Boston", gen.Prefix(), "bos")
+		boston.ValidFrom = &from
+		boston.ValidTo = &to
+		a, err := h.svc.Assert(ctx, boston)
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, a.ID)
+		require.Nil(t, a.SupersededBy, "no successor")
+
+		_, err = h.svc.RunRollover(ctx)
+		require.NoError(t, err)
+
+		still, err := h.assertionRepo.GetAssertion(ctx, a.ID)
+		require.NoError(t, err)
+		assert.Equal(t, repository.AssertionStatusAccepted, still.Status, "successor-less bounded-past fact stays accepted")
+	})
+
+	// Case 16 + 16b: past-bounded backfill coexists (vs both a present current AND
+	// an open-start current row) and never supersedes.
+	t.Run("16 past-bounded backfill coexists", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
+		now := accelerated.GetCurrentTime().UTC()
+
+		// Current NYC, open start (a user edit → valid_from NULL).
+		nyc, err := h.svc.Assert(ctx, textFactReq(subject, "home_address", "NYC current", gen.Prefix(), "nyc"))
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, nyc.ID)
+		require.Nil(t, nyc.ValidFrom, "open-start current row")
+
+		// Backfill a past-bounded Boston [now-200d, now-100d).
+		from := now.Add(-200 * 24 * time.Hour)
+		to := now.Add(-100 * 24 * time.Hour)
+		boston := textFactReq(subject, "home_address", "Boston past", gen.Prefix(), "bos")
+		boston.ValidFrom = &from
+		boston.ValidTo = &to
+		bos, err := h.svc.Assert(ctx, boston)
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, bos.ID)
+
+		// Boston coexists (accepted), NYC stays current.
+		gotBos, err := h.assertionRepo.GetAssertion(ctx, bos.ID)
+		require.NoError(t, err)
+		assert.Equal(t, repository.AssertionStatusAccepted, gotBos.Status, "backfill coexists")
+		gotNYC, err := h.assertionRepo.GetAssertion(ctx, nyc.ID)
+		require.NoError(t, err)
+		assert.Equal(t, repository.AssertionStatusAccepted, gotNYC.Status, "open-start current is untouched")
+		cur, err := h.assertionRepo.GetCurrentAccepted(ctx, subject, "home_address", now)
+		require.NoError(t, err)
+		assert.Equal(t, nyc.ID, cur.ID, "NYC is still current")
+	})
+
+	// Case 16 degenerate-range guard: a now/unknown-start with a past valid_to is
+	// rejected (not corrupted).
+	t.Run("16 degenerate range rejected", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
+		now := accelerated.GetCurrentTime().UTC()
+
+		// valid_from NULL (→ effective_from = now) but an explicit PAST valid_to.
+		past := now.Add(-time.Hour)
+		bad := textFactReq(subject, "home_address", "degenerate", gen.Prefix(), "deg")
+		bad.ValidTo = &past
+		_, err := h.svc.Assert(ctx, bad)
+		require.Error(t, err)
+		require.ErrorIs(t, err, service.ErrAssertValidation)
+	})
+
+	// Case 16c: a present edit cancels a pending future successor.
+	t.Run("16c present edit cancels pending future successor", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
+		now := accelerated.GetCurrentTime().UTC()
+
+		// NYC current, then a FUTURE LA → NYC bounded by LA.
+		nyc, err := h.svc.Assert(ctx, textFactReq(subject, "home_address", "NYC", gen.Prefix(), "nyc"))
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, nyc.ID)
+		future := now.Add(72 * time.Hour)
+		laReq := textFactReq(subject, "home_address", "LA", gen.Prefix(), "la")
+		laReq.ValidFrom = &future
+		la, err := h.svc.Assert(ctx, laReq)
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, la.ID)
+
+		// A present Chicago edit → BOTH NYC and the pending LA are superseded by Chicago.
+		chi, err := h.svc.Assert(ctx, textFactReq(subject, "home_address", "Chicago", gen.Prefix(), "chi"))
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, chi.ID)
+
+		gotNYC, err := h.assertionRepo.GetAssertion(ctx, nyc.ID)
+		require.NoError(t, err)
+		assert.Equal(t, repository.AssertionStatusSuperseded, gotNYC.Status, "NYC superseded by present edit")
+		require.NotNil(t, gotNYC.SupersededBy)
+		assert.Equal(t, chi.ID, *gotNYC.SupersededBy)
+
+		gotLA, err := h.assertionRepo.GetAssertion(ctx, la.ID)
+		require.NoError(t, err)
+		assert.Equal(t, repository.AssertionStatusSuperseded, gotLA.Status, "pending future LA cancelled")
+		require.NotNil(t, gotLA.SupersededBy)
+		assert.Equal(t, chi.ID, *gotLA.SupersededBy)
+
+		// Chicago is current; LA never becomes current after its date.
+		cur, err := h.assertionRepo.GetCurrentAccepted(ctx, subject, "home_address", now)
+		require.NoError(t, err)
+		assert.Equal(t, chi.ID, cur.ID)
+		_, err = h.assertionRepo.GetCurrentAccepted(ctx, subject, "home_address", future.Add(time.Hour))
+		// Either Chicago (open) remains current or LA is gone — Chicago's open window
+		// covers the future, and LA is superseded, so Chicago is current.
+		require.NoError(t, err)
+	})
+
+	// Case 17: symmetric-single conflict — partner_of(A,B) then partner_of(B,C)
+	// supersedes the A-B partnership (B can have one partner).
+	t.Run("17 symmetric-single per-participant conflict", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		a := h.seedPerson(t, ctx, gen.Prefix(), "A")
+		b := h.seedPerson(t, ctx, gen.Prefix(), "B")
+		c := h.seedPerson(t, ctx, gen.Prefix(), "C")
+
+		// partner_of is always-confirm → propose+accept A-B.
+		propAB, err := h.svc.Assert(ctx, edgeReq(a, b, "partner_of", gen.Prefix(), "ab"))
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, propAB.ID)
+		_, err = h.svc.Accept(ctx, propAB.ID, service.AcceptRequest{})
+		require.NoError(t, err)
+
+		// partner_of(B,C): B as subject. Propose+accept → A-B superseded via B.
+		propBC, err := h.svc.Assert(ctx, edgeReq(b, c, "partner_of", gen.Prefix(), "bc"))
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, propBC.ID)
+		_, err = h.svc.Accept(ctx, propBC.ID, service.AcceptRequest{})
+		require.NoError(t, err)
+
+		closedAB, err := h.assertionRepo.GetAssertion(ctx, propAB.ID)
+		require.NoError(t, err)
+		assert.Equal(t, repository.AssertionStatusSuperseded, closedAB.Status, "A-B superseded (B has one partner)")
+	})
+}
+
+// TestAssert_Validation covers the DB-dependent validation rejections (the pure
+// ones are in the service-package unit tests).
+func TestAssert_Validation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	t.Parallel()
+	h, ctx := newAssertHarness(t, ctx0())
+
+	t.Run("unknown predicate rejected", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
+		_, err := h.svc.Assert(ctx, textFactReq(subject, "no_such_predicate", "x", gen.Prefix(), "u"))
+		require.ErrorIs(t, err, service.ErrAssertValidation)
+	})
+
+	t.Run("missing subject node rejected", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		_, err := h.svc.Assert(ctx, textFactReq(uuid.New(), "home_address", "x", gen.Prefix(), "m"))
+		require.ErrorIs(t, err, service.ErrAssertValidation)
+	})
+
+	t.Run("missing provenance rejected", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
+		req := textFactReq(subject, "home_address", "x", gen.Prefix(), "p")
+		req.Locators = nil
+		_, err := h.svc.Assert(ctx, req)
+		require.ErrorIs(t, err, service.ErrAssertValidation)
+	})
+
+	t.Run("out-of-range confidence rejected", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
+		req := textFactReq(subject, "home_address", "x", gen.Prefix(), "c")
+		req.Confidence = 101
+		_, err := h.svc.Assert(ctx, req)
+		require.ErrorIs(t, err, service.ErrAssertValidation)
+	})
+
+	t.Run("fact value type mismatch rejected", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
+		// birthday expects a date; supply text.
+		_, err := h.svc.Assert(ctx, textFactReq(subject, "birthday", "not a date", gen.Prefix(), "b"))
+		require.ErrorIs(t, err, service.ErrAssertValidation)
+	})
+
+	t.Run("edge to wrong object type rejected", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		a := h.seedPerson(t, ctx, gen.Prefix(), "A")
+		place := h.seedPlace(t, ctx, gen.Prefix(), "place")
+		// partner_of expects a person object; supply a place node.
+		_, err := h.svc.Assert(ctx, edgeReq(a, place, "partner_of", gen.Prefix(), "x"))
+		require.ErrorIs(t, err, service.ErrAssertValidation)
+	})
+
+	t.Run("phone_call/calendar_event may not back a fact", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
+		req := textFactReq(subject, "home_address", "x", gen.Prefix(), "pc")
+		req.Locators = []service.ProvenanceLocator{{
+			SourceKind:   repository.SourceKindPhoneCall,
+			SourceID:     uuid.NewString(),
+			ProducerKind: repository.ProducerKindExtractor,
+		}}
+		_, err := h.svc.Assert(ctx, req)
+		require.ErrorIs(t, err, service.ErrAssertValidation)
+	})
+
+	t.Run("nonexistent content source row rejected", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
+		req := textFactReq(subject, "home_address", "x", gen.Prefix(), "src")
+		req.Locators = []service.ProvenanceLocator{{
+			SourceKind:   repository.SourceKindCommsMessage,
+			SourceID:     uuid.NewString(), // no such comms_message row
+			ProducerKind: repository.ProducerKindExtractor,
+		}}
+		_, err := h.svc.Assert(ctx, req)
+		require.ErrorIs(t, err, service.ErrAssertValidation)
+	})
+
+	t.Run("entity-subtype subject accepted (within place->place)", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		child := h.seedPlace(t, ctx, gen.Prefix(), "brooklyn")
+		parent := h.seedPlace(t, ctx, gen.Prefix(), "nyc")
+		// within: place subject → place object. The validator must accept an
+		// entity-subtype subject, not only person.
+		a, err := h.svc.Assert(ctx, edgeReq(child, parent, "within", gen.Prefix(), "w"))
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, a.ID)
+		assert.Equal(t, repository.AssertionStatusAccepted, a.Status)
+	})
+}
+
+// runConcurrent runs fn(0..n-1) in n goroutines and waits for all.
+func runConcurrent(n int, fn func(i int)) {
+	done := make(chan struct{}, n)
+	for i := 0; i < n; i++ {
+		go func(idx int) {
+			defer func() { done <- struct{}{} }()
+			fn(idx)
+		}(i)
+	}
+	for i := 0; i < n; i++ {
+		<-done
+	}
+}

--- a/backend/tests/assert_integration_test.go
+++ b/backend/tests/assert_integration_test.go
@@ -1203,6 +1203,17 @@ func TestAssert_Lifecycle(t *testing.T) {
 		curFuture, err := h.assertionRepo.GetCurrentAccepted(ctx, subject, "home_address", future.Add(time.Hour))
 		require.NoError(t, err)
 		assert.Equal(t, la.ID, curFuture.ID, "LA becomes current after its date (bound intact)")
+
+		// The accept-time widen must recompute the survivor's proposition_key WITH the
+		// fact value (a value-less recompute writes an empty value component, so a
+		// later same-value write would not dedup against the survivor and could create
+		// a duplicate live proposition under concurrency). A subsequent same-value NYC
+		// write in the survivor's (widened) bucket must DEDUP cleanly to the survivor.
+		redoReq := textFactReq(subject, "home_address", "NYC", gen.Prefix(), "nyc3")
+		redoReq.ValidFrom = &lastYear
+		redupe, err := h.svc.Assert(ctx, redoReq)
+		require.NoError(t, err)
+		assert.Equal(t, nyc.ID, redupe.ID, "later same-value write dedups to the widened survivor")
 	})
 
 	// Case 26: AssertClosure on a current row whose knowledge_from is in the future

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -84,6 +84,8 @@ func TestSyntheticProfile_DevCoversCatalog(t *testing.T) {
 	require.Equal(t, params.Counts.StrandedMessages, res.StrandedMessages)
 	require.Equal(t, params.Counts.UnmatchedCalendar, res.UnmatchedCalendar)
 	require.Equal(t, params.Counts.OrphanMeetingNote, res.OrphanMeetingNote)
+	require.Equal(t, params.Counts.SeededAssertions, res.SeededAssertions)
+	require.Equal(t, 2, res.SeededAssertions, "dev profile seeds graph assertions")
 
 	remaining, err := h.ContactsRemaining(ctx)
 	require.NoError(t, err)


### PR DESCRIPTION
PR4 of the SP1 Relationship Data Model delivery (Bucket A, additive backend-only). The load-bearing write path.

Adds `AssertService` (`backend/internal/service/assert.go`) — the single uniform `assert()` write contract for all producers (extractor/agent/UI): catalog validation, proposition-identity dedup (length-prefixed `proposition_key` + `locator_hash`), the bi-temporal cardinality/supersession state machine (present/future/closure/past-bounded/same-value-reaffirmation branches, symmetric per-participant advisory locking, savepoint-recover on the live-proposition unique), and the full lifecycle (`Assert`/`AssertClosure`/`Accept`/`Reject`/`Retract`/`EnsureLatentPerson`). Emits 5 `assertion.*` events on the bus (idempotency-keyed; no SP1 consumer). Adds the daily `AssertionRolloverWorker` that terminalizes bounded-with-pending-successor rows when their `valid_to` passes. Folds in the #541 follow-up (provenance `Exists*` checks now filter `deleted_at IS NULL`). No new migration; no HTTP routes (consumers are SP3/SP4).

Reviewed by the local Codex reviewer (3 rounds — fixed 1 P0 + ~14 P1 on the valid-time/supersession edges) and a fresh-context `/review-head` (PASS, P0=0 P1=0). The full 17-case valid-time integration matrix passes (`#15`/`#15b`/`#16`/`#16b`/`#16c`/`#17`/`#18` + the knowledge_to-clamp cases).

Depends on PR3 (assertion store, #541) + PR5 (person-node backfill, #543), both merged. architecture.md updated with the rollover job + the 5 event kinds.