### PR TITLE
feat(graph): venue model on interaction (SP1 PR6, migration 069)

### DIFF
--- a/.ai/guides/architecture.md
+++ b/.ai/guides/architecture.md
@@ -187,7 +187,7 @@ sequenceDiagram
 | **Observability** | | |
 | `sync_staleness_breach` | Open/resolved sync-staleness breaches recorded by the watchdog (partial unique index on open rows; no `updated_at`/`deleted_at`) | (system-derived; no FKs) |
 | **Future/Unused** | | |
-| `interaction` | Interaction logging (not yet used); nullable `venue_id` links each interaction to the shared-container venue node it happened in (set by the live recorders + the `069` backfill; never a dedup/cadence-partition dimension) | → contact; → node (`venue_id`, restrict) |
+| `interaction` | Interaction logging (the recorder pipeline's core row); nullable `venue_id` links each interaction to the shared-container venue node it happened in (set by the live recorders + the `069` backfill; never a dedup/cadence-partition dimension) | → contact; → node (`venue_id`, restrict) |
 | `connection` | Contact-to-contact relationships | → contact × 2 |
 | `note_embedding` | Vector embeddings (future AI) | → note |
 | `contact_summary` | AI summaries (future) | → contact |

--- a/.ai/guides/architecture.md
+++ b/.ai/guides/architecture.md
@@ -180,14 +180,14 @@ sequenceDiagram
 | `node` | Uniform registry every graph entity attaches to (person/entity/venue); caller-supplied id (person id == contact id, maintained by the ContactService dual-write + the `068_backfill_person_nodes` backfill); CHECK-enum `type`; `merged_into` self-FK merge alias; single `deleted_at` tombstone | self-FK (`merged_into`); person node shares the contact's id |
 | `entity_type` | Per-TYPE entity-subtype catalog (`resolution_config` JSONB; curated/provisional status) | (catalog; no FKs) |
 | `entity` | Structural subtype rows for organizations/places/topics/tags; per-instance `detail` JSONB; unique `(subtype, normalized_name)` | → node (PK/FK, ON DELETE CASCADE), → entity_type |
-| `venue` | Structural subtype rows for shared interaction containers (email threads, group chats, DMs, meetings, calls, sessions); unique `(source, kind, source_container_id)` | → node (PK/FK, ON DELETE CASCADE) |
+| `venue` | Structural subtype rows for shared interaction containers (email threads, group chats, DMs, meetings, calls, sessions); unique `(source, kind, source_container_id)`; the venue node id is a deterministic `uuid_generate_v5` of `(source, kind, container)` so the live `ResolveVenueForInteraction` helper and the `069_interaction_venue` backfill converge on one node per container; referenced by `interaction.venue_id` | → node (PK/FK, ON DELETE CASCADE) |
 | `predicate` | Catalog of edge/fact types (subject/object/value typing, cardinality, symmetry, inverse pairing, temporal profile, review policy, valid-time dedup bucket); curated-core rows seeded, provisional minted at runtime; nullable `embedding vector(1536)` | self-FK (`inverse_predicate`) |
 | `assertion` | Bi-temporal fact/edge row (valid-time + knowledge-time clocks); exactly-one-payload CHECK; write-API-computed `proposition_key` with a plain partial-unique live index; DEFERRABLE `superseded_by` self-FK; status state machine (proposed→accepted\|rejected, accepted→superseded\|retracted) | → node (subject + object, restrict), → predicate (restrict), self-FK (`superseded_by`, DEFERRABLE) |
 | `assertion_provenance` | Corroborating source locators for an assertion; PK `(assertion_id, locator_hash)`; closed `source_kind` enum; polymorphic no-FK `source_id`; `(source_kind, source_id)` reverse-lookup index | → assertion (ON DELETE CASCADE); `source_id` polymorphic (no FK) |
 | **Observability** | | |
 | `sync_staleness_breach` | Open/resolved sync-staleness breaches recorded by the watchdog (partial unique index on open rows; no `updated_at`/`deleted_at`) | (system-derived; no FKs) |
 | **Future/Unused** | | |
-| `interaction` | Interaction logging (not yet used) | → contact |
+| `interaction` | Interaction logging (not yet used); nullable `venue_id` links each interaction to the shared-container venue node it happened in (set by the live recorders + the `069` backfill; never a dedup/cadence-partition dimension) | → contact; → node (`venue_id`, restrict) |
 | `connection` | Contact-to-contact relationships | → contact × 2 |
 | `note_embedding` | Vector embeddings (future AI) | → note |
 | `contact_summary` | AI summaries (future) | → contact |

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -430,6 +430,22 @@ func run() int {
 		},
 	)
 
+	// Venue resolution — populates interaction.venue_id (the shared-container
+	// node an interaction happened in). The registry routes message.* sources
+	// to per-source container readers and resolves gcal via the calendar 3-tuple;
+	// the venue repo also serves the email + phone + anarlog recorders directly.
+	// Wired into each recorder via its SetVenueResolver setter below.
+	venueRepo := repository.NewVenueRepository(database.Queries)
+	venueResolver := repository.NewVenueResolverRegistry(
+		venueRepo,
+		map[string]repository.VenueContainerReader{
+			repository.InteractionSourceTelegram: repository.NewTelegramVenueContainerReader(),
+			repository.InteractionSourceMessages: repository.NewMessagesVenueContainerReader(),
+			repository.InteractionSourceGChat:    repository.NewGChatVenueContainerReader(),
+		},
+		calendarRepoForIngest,
+	)
+
 	// Aggregator reenqueuer holder. The Telegram entry needs the
 	// Telegram aggregation engine, which is constructed later (inside
 	// the cfg.Features.EnableTelegramSync branch). The worker is
@@ -538,6 +554,9 @@ func run() int {
 		// false interaction.
 		calendarRepoForIngest,
 	)
+	// Populate interaction.venue_id for message.* (telegram/messages/gchat) and
+	// gcal interactions this recorder writes.
+	interactionRecorder.SetVenueResolver(venueResolver)
 
 	// IngestService — hoisted here so the call.* inline handler can
 	// reuse contactService.RecordInteractionTx, cadenceUpdater,
@@ -578,6 +597,9 @@ func run() int {
 		titleDiscoveryWriter,
 		phoneCallRepoForIngest, // phone_call linkage candidates for meeting_note Step 1
 	)
+	// Populate interaction.venue_id for phone_calls + anarlog_sessions
+	// interactions the ingest inline handlers write.
+	ingestService.SetVenueResolver(venueResolver)
 	ingestHandler := handlers.NewIngestHandler(ingestService)
 
 	// User-driven conflict-resolution surface for meeting_note rows.
@@ -599,6 +621,8 @@ func run() int {
 		contactService,
 		contactRepo,
 	)
+	// Populate venue_id on the resolve-link interaction path.
+	meetingNoteService.SetVenueResolver(venueResolver)
 	meetingNoteHandler := handlers.NewMeetingNoteHandler(meetingNoteService)
 
 	// Register the consumer worker. The worker is registered UNCONDITIONALLY —
@@ -637,6 +661,9 @@ func run() int {
 		contactService, commsMessageRepo, interactionRepo, contactService,
 		eventBus, cadenceUpdater, followUpManager,
 	)
+	// Populate interaction.venue_id with the email-thread venue on the create
+	// branch. The venue repo resolves directly (email carries thread_id).
+	emailInteractionConsumer.SetVenueResolver(venueRepo)
 	river.AddWorker(riverWorkers, consumer.NewEmailInteractionConsumerWorker(eventBus, database.Pool, emailInteractionConsumer))
 
 	// Interaction-mode wiring gate. Cutover is the normal operating

--- a/backend/internal/consumer/email_interaction.go
+++ b/backend/internal/consumer/email_interaction.go
@@ -211,8 +211,9 @@ func (c *EmailInteractionConsumer) HandleEvent(ctx context.Context, tx pgx.Tx, e
 			Direction:   p.Direction,
 		}
 		// Resolve the email-thread venue from the content row's thread_id, set
-		// atomically with the insert. Best-effort: an empty thread or resolution
-		// error leaves venue_id NULL rather than failing the interaction.
+		// atomically with the insert. An empty/absent thread leaves venue_id NULL
+		// (no shared container); a real DB error during resolution propagates and
+		// rolls back the interaction (the recorder retries).
 		if c.venue != nil && commsMsg.ThreadID != nil && *commsMsg.ThreadID != "" {
 			venueID, venueErr := c.venue.ResolveVenueForInteraction(
 				ctx, tx, repository.InteractionSourceEmail, repository.VenueKindEmailThread, *commsMsg.ThreadID, "")

--- a/backend/internal/consumer/email_interaction.go
+++ b/backend/internal/consumer/email_interaction.go
@@ -43,6 +43,15 @@ type emailAggregator interface {
 	ExtendInteractionTx(ctx context.Context, tx pgx.Tx, interactionID, contactID uuid.UUID, direction string, occurredAt time.Time, description *string) (func(context.Context), error)
 }
 
+// emailVenueResolver resolves the email-thread venue for a freshly-created email
+// interaction from the thread container key. Best-effort: an empty thread or a
+// resolution error leaves venue_id NULL. Satisfied by
+// *repository.VenueRepository.ResolveVenueForInteraction. Optional (nil in tests
+// that don't assert on venues).
+type emailVenueResolver interface {
+	ResolveVenueForInteraction(ctx context.Context, tx pgx.Tx, source, kind, containerKey, title string) (uuid.UUID, error)
+}
+
 // EmailInteractionConsumer is the event-bus consumer for email.received /
 // email.sent. It derives a per-(contact, thread, local-calendar-day)
 // aggregated interaction from the lightweight email event + its
@@ -71,6 +80,7 @@ type EmailInteractionConsumer struct {
 	bus          eventBusTx
 	cadence      cadenceDispatcher
 	followUp     followUpDispatcher
+	venue        emailVenueResolver
 }
 
 // NewEmailInteractionConsumer builds the consumer with narrow interfaces so
@@ -95,6 +105,13 @@ func NewEmailInteractionConsumer(
 		cadence:      cadence,
 		followUp:     followUp,
 	}
+}
+
+// SetVenueResolver wires the resolver that populates interaction.venue_id with
+// the email-thread venue on the create branch. Optional: when unset the consumer
+// records email interactions with a NULL venue_id.
+func (c *EmailInteractionConsumer) SetVenueResolver(v emailVenueResolver) {
+	c.venue = v
 }
 
 // HandleEvent processes an email.received / email.sent envelope inside the
@@ -192,6 +209,17 @@ func (c *EmailInteractionConsumer) HandleEvent(ctx context.Context, tx pgx.Tx, e
 			OccurredAt:  p.SentAt,
 			Description: p.Subject,
 			Direction:   p.Direction,
+		}
+		// Resolve the email-thread venue from the content row's thread_id, set
+		// atomically with the insert. Best-effort: an empty thread or resolution
+		// error leaves venue_id NULL rather than failing the interaction.
+		if c.venue != nil && commsMsg.ThreadID != nil && *commsMsg.ThreadID != "" {
+			venueID, venueErr := c.venue.ResolveVenueForInteraction(
+				ctx, tx, repository.InteractionSourceEmail, repository.VenueKindEmailThread, *commsMsg.ThreadID, "")
+			if venueErr != nil {
+				return nil, fmt.Errorf("resolve email venue: %w", venueErr)
+			}
+			req.VenueID = &venueID
 		}
 		res, recordErr := c.writer.RecordInteractionTx(ctx, tx, true, req)
 		if recordErr != nil {

--- a/backend/internal/consumer/interaction_recorder.go
+++ b/backend/internal/consumer/interaction_recorder.go
@@ -111,6 +111,23 @@ type calendarEventLocker interface {
 	LockExistsByIDTx(ctx context.Context, tx pgx.Tx, id uuid.UUID) (bool, error)
 }
 
+// venueResolver is the narrow dependency the recorder uses to resolve the
+// shared-container venue node an interaction happened in, so it can set
+// interaction.venue_id atomically with the insert. Both methods are
+// best-effort: a nil return (no resolvable container) records the interaction
+// with a NULL venue_id rather than failing. Satisfied by
+// *repository.VenueResolverRegistry (message.*) + the calendar-event 3-tuple
+// read (gcal). Nil in tests that don't assert on venues — the recorder skips
+// resolution when it's nil.
+type venueResolver interface {
+	// ResolveMessageVenueTx resolves the venue for a telegram/messages/gchat
+	// interaction from its staging-row ids.
+	ResolveMessageVenueTx(ctx context.Context, tx pgx.Tx, source string, messageIDs []uuid.UUID) (*uuid.UUID, error)
+	// ResolveGCalVenueTx resolves the meeting venue for a gcal interaction from
+	// the internal calendar_event id carried in the interaction's source_ref.
+	ResolveGCalVenueTx(ctx context.Context, tx pgx.Tx, calendarEventID uuid.UUID) (*uuid.UUID, error)
+}
+
 // followUpDispatcher is the subset of *FollowUpManager the recorder
 // needs for the inline-apply path. Returns a post-commit closure (non-
 // nil on the refresh branch) that the recorder folds into its own
@@ -138,6 +155,7 @@ type InteractionRecorder struct {
 	cadence      cadenceDispatcher
 	followUp     followUpDispatcher
 	calendarLock calendarEventLocker
+	venue        venueResolver
 }
 
 // NewInteractionRecorder builds the consumer. staging may be nil for
@@ -168,6 +186,15 @@ func NewInteractionRecorder(
 		followUp:     followUp,
 		calendarLock: calendarLock,
 	}
+}
+
+// SetVenueResolver wires the venue resolver used to populate interaction.venue_id
+// for message.* and gcal interactions. Optional: when unset the recorder records
+// interactions with a NULL venue_id (tests that don't assert on venues leave it
+// nil). Production wiring sets it after construction, mirroring the other
+// optional-dependency setters on this package's consumers.
+func (r *InteractionRecorder) SetVenueResolver(v venueResolver) {
+	r.venue = v
 }
 
 // HandleEvent is the per-event entry point. The caller must own tx; this
@@ -228,6 +255,20 @@ func (r *InteractionRecorder) HandleEvent(ctx context.Context, tx pgx.Tx, env *e
 			// Skip the insert; no interaction, nil postCommit.
 			return nil, nil, nil
 		}
+	}
+
+	// Resolve the shared-container venue so it's set atomically with the insert.
+	// Best-effort: a resolution failure that isn't a real DB error leaves
+	// venue_id NULL (manual/todoist and unresolvable containers) — never fail
+	// the interaction over a missing venue. Runs before the dedup-or-insert so a
+	// fresh insert carries venue_id; a dedup hit ignores it (the row already has
+	// its venue).
+	if r.venue != nil {
+		venueID, venueErr := r.resolveVenue(ctx, tx, env, &req)
+		if venueErr != nil {
+			return nil, nil, fmt.Errorf("resolve venue: %w", venueErr)
+		}
+		req.VenueID = venueID
 	}
 
 	// Delegate to ContactService.RecordInteractionTx — single source of
@@ -359,6 +400,37 @@ func (r *InteractionRecorder) HandleEvent(ctx context.Context, tx pgx.Tx, env *e
 	}
 
 	return res.Interaction, postCommit, nil
+}
+
+// resolveVenue resolves the shared-container venue node id for the interaction
+// being recorded. message.received/sent (telegram/messages/gchat) resolve from
+// the staging-row ids in the payload; calendar.attended (gcal) resolves from the
+// internal calendar_event id carried in source_ref. Other kinds (task.*,
+// interaction.manual) have no shared container → nil. Returns nil (not an error)
+// whenever the container can't be resolved so the recorder records with a NULL
+// venue_id.
+func (r *InteractionRecorder) resolveVenue(ctx context.Context, tx pgx.Tx, env *events.Envelope, req *repository.RecordInteractionRequest) (*uuid.UUID, error) {
+	switch env.Kind {
+	case events.KindMessageReceived, events.KindMessageSent:
+		msgIDs, err := extractMessageIDs(env)
+		if err != nil {
+			return nil, err
+		}
+		return r.venue.ResolveMessageVenueTx(ctx, tx, env.Source, msgIDs)
+	case events.KindCalendarAttended:
+		if req.SourceRef == nil {
+			return nil, nil
+		}
+		eventID, parseErr := uuid.Parse(*req.SourceRef)
+		if parseErr != nil {
+			// source_ref isn't a calendar_event UUID — already errored above
+			// for the lock path when calendarLock is set; here just skip venue.
+			return nil, nil
+		}
+		return r.venue.ResolveGCalVenueTx(ctx, tx, eventID)
+	default:
+		return nil, nil
+	}
 }
 
 // extractRequest dispatches on env.Kind to build a RecordInteractionRequest

--- a/backend/internal/db/comms_message.sql.go
+++ b/backend/internal/db/comms_message.sql.go
@@ -386,7 +386,7 @@ func (q *Queries) GetCommsMessageByReplyTarget(ctx context.Context, arg GetComms
 const GetCommsMessageContainer = `-- name: GetCommsMessageContainer :one
 SELECT source, thread_id
 FROM comms_message
-WHERE id = $1
+WHERE id = $1 AND deleted_at IS NULL
 `
 
 type GetCommsMessageContainerRow struct {

--- a/backend/internal/db/comms_message.sql.go
+++ b/backend/internal/db/comms_message.sql.go
@@ -895,6 +895,64 @@ func (q *Queries) SoftDeleteCommsMessagesByExternalID(ctx context.Context, arg S
 	return result.RowsAffected(), nil
 }
 
+const TestInsertCommsMessageLinked = `-- name: TestInsertCommsMessageLinked :one
+INSERT INTO comms_message (
+    source, external_id, thread_id, direction, sent_at, matched_contact_id, interaction_id
+) VALUES (
+    $1, $2, $3, $4, $5, $6, $7
+)
+RETURNING id, source, external_id, thread_id, subject, body, snippet, peer_handle, peer_normalized, direction, sent_at, account_id, source_metadata, matched_contact_id, interaction_id, claimed_at, claimed_session_ref, processed_at, deleted_at, created_at
+`
+
+type TestInsertCommsMessageLinkedParams struct {
+	Source           string             `json:"source"`
+	ExternalID       string             `json:"external_id"`
+	ThreadID         pgtype.Text        `json:"thread_id"`
+	Direction        string             `json:"direction"`
+	SentAt           pgtype.Timestamptz `json:"sent_at"`
+	MatchedContactID pgtype.UUID        `json:"matched_contact_id"`
+	InteractionID    pgtype.UUID        `json:"interaction_id"`
+}
+
+// Test-only: inserts a comms_message already linked to an interaction. Used by
+// the venue backfill test to seed an email/gchat thread container row.
+// Production code MUST NOT call this.
+func (q *Queries) TestInsertCommsMessageLinked(ctx context.Context, arg TestInsertCommsMessageLinkedParams) (*CommsMessage, error) {
+	row := q.db.QueryRow(ctx, TestInsertCommsMessageLinked,
+		arg.Source,
+		arg.ExternalID,
+		arg.ThreadID,
+		arg.Direction,
+		arg.SentAt,
+		arg.MatchedContactID,
+		arg.InteractionID,
+	)
+	var i CommsMessage
+	err := row.Scan(
+		&i.ID,
+		&i.Source,
+		&i.ExternalID,
+		&i.ThreadID,
+		&i.Subject,
+		&i.Body,
+		&i.Snippet,
+		&i.PeerHandle,
+		&i.PeerNormalized,
+		&i.Direction,
+		&i.SentAt,
+		&i.AccountID,
+		&i.SourceMetadata,
+		&i.MatchedContactID,
+		&i.InteractionID,
+		&i.ClaimedAt,
+		&i.ClaimedSessionRef,
+		&i.ProcessedAt,
+		&i.DeletedAt,
+		&i.CreatedAt,
+	)
+	return &i, err
+}
+
 const UpsertCommsMessage = `-- name: UpsertCommsMessage :one
 INSERT INTO comms_message (
     source, external_id, thread_id, subject, body, snippet,

--- a/backend/internal/db/comms_message.sql.go
+++ b/backend/internal/db/comms_message.sql.go
@@ -383,6 +383,29 @@ func (q *Queries) GetCommsMessageByReplyTarget(ctx context.Context, arg GetComms
 	return &i, err
 }
 
+const GetCommsMessageContainer = `-- name: GetCommsMessageContainer :one
+SELECT source, thread_id
+FROM comms_message
+WHERE id = $1
+`
+
+type GetCommsMessageContainerRow struct {
+	Source   string      `json:"source"`
+	ThreadID pgtype.Text `json:"thread_id"`
+}
+
+// Returns the venue-container key (source + thread_id) for a staging row by its
+// UUID. Used by the live interaction recorder to resolve the gchat venue (email
+// resolves its venue from the EmailInteractionConsumer's comms row directly).
+// The thread is consistent across all messages in one aggregated session, so
+// reading the first id is sufficient.
+func (q *Queries) GetCommsMessageContainer(ctx context.Context, id pgtype.UUID) (*GetCommsMessageContainerRow, error) {
+	row := q.db.QueryRow(ctx, GetCommsMessageContainer, id)
+	var i GetCommsMessageContainerRow
+	err := row.Scan(&i.Source, &i.ThreadID)
+	return &i, err
+}
+
 const GetCommsMessageLatestByExternalID = `-- name: GetCommsMessageLatestByExternalID :one
 SELECT id, source, external_id, thread_id, subject, body, snippet, peer_handle, peer_normalized, direction, sent_at, account_id, source_metadata, matched_contact_id, interaction_id, claimed_at, claimed_session_ref, processed_at, deleted_at, created_at FROM comms_message
 WHERE source = $1

--- a/backend/internal/db/interaction.sql.go
+++ b/backend/internal/db/interaction.sql.go
@@ -43,9 +43,17 @@ func (q *Queries) CountContactInteractions(ctx context.Context, contactID pgtype
 }
 
 const CreateInteraction = `-- name: CreateInteraction :one
-INSERT INTO interaction (contact_id, source, source_ref, occurred_at, description, direction)
-VALUES ($1, $2, $3, $4, $5, COALESCE($6, 'mutual'))
-RETURNING id, contact_id, source, source_ref, occurred_at, description, created_at, deleted_at, direction
+INSERT INTO interaction (contact_id, source, source_ref, occurred_at, description, direction, venue_id)
+VALUES (
+    $1,
+    $2,
+    $3,
+    $4,
+    $5,
+    COALESCE($6, 'mutual'),
+    $7
+)
+RETURNING id, contact_id, source, source_ref, occurred_at, description, created_at, deleted_at, direction, venue_id
 `
 
 type CreateInteractionParams struct {
@@ -55,6 +63,7 @@ type CreateInteractionParams struct {
 	OccurredAt  pgtype.Timestamptz `json:"occurred_at"`
 	Description pgtype.Text        `json:"description"`
 	Direction   interface{}        `json:"direction"`
+	VenueID     pgtype.UUID        `json:"venue_id"`
 }
 
 func (q *Queries) CreateInteraction(ctx context.Context, arg CreateInteractionParams) (*Interaction, error) {
@@ -65,6 +74,7 @@ func (q *Queries) CreateInteraction(ctx context.Context, arg CreateInteractionPa
 		arg.OccurredAt,
 		arg.Description,
 		arg.Direction,
+		arg.VenueID,
 	)
 	var i Interaction
 	err := row.Scan(
@@ -77,12 +87,13 @@ func (q *Queries) CreateInteraction(ctx context.Context, arg CreateInteractionPa
 		&i.CreatedAt,
 		&i.DeletedAt,
 		&i.Direction,
+		&i.VenueID,
 	)
 	return &i, err
 }
 
 const FindInteractionBySourceRef = `-- name: FindInteractionBySourceRef :one
-SELECT id, contact_id, source, source_ref, occurred_at, description, created_at, deleted_at, direction FROM interaction
+SELECT id, contact_id, source, source_ref, occurred_at, description, created_at, deleted_at, direction, venue_id FROM interaction
 WHERE contact_id = $1 AND source = $2 AND source_ref = $3 AND deleted_at IS NULL
 LIMIT 1
 `
@@ -107,12 +118,13 @@ func (q *Queries) FindInteractionBySourceRef(ctx context.Context, arg FindIntera
 		&i.CreatedAt,
 		&i.DeletedAt,
 		&i.Direction,
+		&i.VenueID,
 	)
 	return &i, err
 }
 
 const FindInteractionInWindow = `-- name: FindInteractionInWindow :one
-SELECT id, contact_id, source, source_ref, occurred_at, description, created_at, deleted_at, direction FROM interaction
+SELECT id, contact_id, source, source_ref, occurred_at, description, created_at, deleted_at, direction, venue_id FROM interaction
 WHERE contact_id = $1
   AND source = $2
   AND direction = $3
@@ -153,12 +165,13 @@ func (q *Queries) FindInteractionInWindow(ctx context.Context, arg FindInteracti
 		&i.CreatedAt,
 		&i.DeletedAt,
 		&i.Direction,
+		&i.VenueID,
 	)
 	return &i, err
 }
 
 const FindRecentInteractionBySourceAndDirection = `-- name: FindRecentInteractionBySourceAndDirection :one
-SELECT id, contact_id, source, source_ref, occurred_at, description, created_at, deleted_at, direction FROM interaction
+SELECT id, contact_id, source, source_ref, occurred_at, description, created_at, deleted_at, direction, venue_id FROM interaction
 WHERE contact_id = $1
   AND source = $2
   AND direction = $3
@@ -216,12 +229,13 @@ func (q *Queries) FindRecentInteractionBySourceAndDirection(ctx context.Context,
 		&i.CreatedAt,
 		&i.DeletedAt,
 		&i.Direction,
+		&i.VenueID,
 	)
 	return &i, err
 }
 
 const FindRecentOutboundInteractionBySource = `-- name: FindRecentOutboundInteractionBySource :one
-SELECT id, contact_id, source, source_ref, occurred_at, description, created_at, deleted_at, direction FROM interaction
+SELECT id, contact_id, source, source_ref, occurred_at, description, created_at, deleted_at, direction, venue_id FROM interaction
 WHERE contact_id = $1
   AND source = $2
   AND direction = 'outbound'
@@ -266,12 +280,13 @@ func (q *Queries) FindRecentOutboundInteractionBySource(ctx context.Context, arg
 		&i.CreatedAt,
 		&i.DeletedAt,
 		&i.Direction,
+		&i.VenueID,
 	)
 	return &i, err
 }
 
 const FindRecentOutboundTelegramInteraction = `-- name: FindRecentOutboundTelegramInteraction :one
-SELECT id, contact_id, source, source_ref, occurred_at, description, created_at, deleted_at, direction FROM interaction
+SELECT id, contact_id, source, source_ref, occurred_at, description, created_at, deleted_at, direction, venue_id FROM interaction
 WHERE contact_id = $1
   AND source = 'telegram'
   AND direction = 'outbound'
@@ -310,12 +325,13 @@ func (q *Queries) FindRecentOutboundTelegramInteraction(ctx context.Context, arg
 		&i.CreatedAt,
 		&i.DeletedAt,
 		&i.Direction,
+		&i.VenueID,
 	)
 	return &i, err
 }
 
 const FindRecentTelegramInteraction = `-- name: FindRecentTelegramInteraction :one
-SELECT id, contact_id, source, source_ref, occurred_at, description, created_at, deleted_at, direction FROM interaction
+SELECT id, contact_id, source, source_ref, occurred_at, description, created_at, deleted_at, direction, venue_id FROM interaction
 WHERE contact_id = $1
   AND source = 'telegram'
   AND direction = $2
@@ -356,13 +372,14 @@ func (q *Queries) FindRecentTelegramInteraction(ctx context.Context, arg FindRec
 		&i.CreatedAt,
 		&i.DeletedAt,
 		&i.Direction,
+		&i.VenueID,
 	)
 	return &i, err
 }
 
 const GetInteraction = `-- name: GetInteraction :one
 
-SELECT id, contact_id, source, source_ref, occurred_at, description, created_at, deleted_at, direction FROM interaction WHERE id = $1 AND deleted_at IS NULL
+SELECT id, contact_id, source, source_ref, occurred_at, description, created_at, deleted_at, direction, venue_id FROM interaction WHERE id = $1 AND deleted_at IS NULL
 `
 
 // Interaction queries
@@ -379,6 +396,7 @@ func (q *Queries) GetInteraction(ctx context.Context, id pgtype.UUID) (*Interact
 		&i.CreatedAt,
 		&i.DeletedAt,
 		&i.Direction,
+		&i.VenueID,
 	)
 	return &i, err
 }
@@ -432,7 +450,7 @@ func (q *Queries) HasResponseAfter(ctx context.Context, arg HasResponseAfterPara
 }
 
 const ListContactInteractions = `-- name: ListContactInteractions :many
-SELECT id, contact_id, source, source_ref, occurred_at, description, created_at, deleted_at, direction FROM interaction
+SELECT id, contact_id, source, source_ref, occurred_at, description, created_at, deleted_at, direction, venue_id FROM interaction
 WHERE contact_id = $1 AND deleted_at IS NULL
 ORDER BY occurred_at DESC
 LIMIT $2 OFFSET $3
@@ -463,6 +481,7 @@ func (q *Queries) ListContactInteractions(ctx context.Context, arg ListContactIn
 			&i.CreatedAt,
 			&i.DeletedAt,
 			&i.Direction,
+			&i.VenueID,
 		); err != nil {
 			return nil, err
 		}
@@ -475,7 +494,7 @@ func (q *Queries) ListContactInteractions(ctx context.Context, arg ListContactIn
 }
 
 const ListSessionAttributedInteractions = `-- name: ListSessionAttributedInteractions :many
-SELECT id, contact_id, source, source_ref, occurred_at, description, created_at, deleted_at, direction FROM interaction
+SELECT id, contact_id, source, source_ref, occurred_at, description, created_at, deleted_at, direction, venue_id FROM interaction
 WHERE source = 'anarlog_sessions'
   AND source_ref LIKE $1
   AND deleted_at IS NULL
@@ -506,6 +525,7 @@ func (q *Queries) ListSessionAttributedInteractions(ctx context.Context, sourceR
 			&i.CreatedAt,
 			&i.DeletedAt,
 			&i.Direction,
+			&i.VenueID,
 		); err != nil {
 			return nil, err
 		}
@@ -533,7 +553,7 @@ SET direction = $1,
     occurred_at = $2
 WHERE id = $3
   AND deleted_at IS NULL
-RETURNING id, contact_id, source, source_ref, occurred_at, description, created_at, deleted_at, direction
+RETURNING id, contact_id, source, source_ref, occurred_at, description, created_at, deleted_at, direction, venue_id
 `
 
 type UpdateInteractionDirectionParams struct {
@@ -556,6 +576,7 @@ func (q *Queries) UpdateInteractionDirection(ctx context.Context, arg UpdateInte
 		&i.CreatedAt,
 		&i.DeletedAt,
 		&i.Direction,
+		&i.VenueID,
 	)
 	return &i, err
 }
@@ -566,7 +587,7 @@ SET occurred_at = $1,
     description = $2
 WHERE id = $3
   AND deleted_at IS NULL
-RETURNING id, contact_id, source, source_ref, occurred_at, description, created_at, deleted_at, direction
+RETURNING id, contact_id, source, source_ref, occurred_at, description, created_at, deleted_at, direction, venue_id
 `
 
 type UpdateInteractionTimestampParams struct {
@@ -589,6 +610,7 @@ func (q *Queries) UpdateInteractionTimestamp(ctx context.Context, arg UpdateInte
 		&i.CreatedAt,
 		&i.DeletedAt,
 		&i.Direction,
+		&i.VenueID,
 	)
 	return &i, err
 }

--- a/backend/internal/db/interaction.sql.go
+++ b/backend/internal/db/interaction.sql.go
@@ -665,3 +665,23 @@ func (q *Queries) UpdateInteractionTimestamp(ctx context.Context, arg UpdateInte
 	)
 	return &i, err
 }
+
+const UpdateInteractionVenue = `-- name: UpdateInteractionVenue :exec
+UPDATE interaction
+SET venue_id = $1
+WHERE id = $2
+  AND deleted_at IS NULL
+`
+
+type UpdateInteractionVenueParams struct {
+	VenueID pgtype.UUID `json:"venue_id"`
+	ID      pgtype.UUID `json:"id"`
+}
+
+// Sets venue_id on an existing interaction. Used by the anarlog re-sync path so
+// a retained interaction whose session was re-linked (e.g. session -> gcal event)
+// moves to the correct venue node. Does not touch cadence columns.
+func (q *Queries) UpdateInteractionVenue(ctx context.Context, arg UpdateInteractionVenueParams) error {
+	_, err := q.db.Exec(ctx, UpdateInteractionVenue, arg.VenueID, arg.ID)
+	return err
+}

--- a/backend/internal/db/interaction.sql.go
+++ b/backend/internal/db/interaction.sql.go
@@ -547,6 +547,57 @@ func (q *Queries) SoftDeleteInteraction(ctx context.Context, id pgtype.UUID) err
 	return err
 }
 
+const TestInsertInteraction = `-- name: TestInsertInteraction :one
+INSERT INTO interaction (id, contact_id, source, source_ref, occurred_at, direction)
+VALUES (
+    $1,
+    $2,
+    $3,
+    $4,
+    $5,
+    $6
+)
+RETURNING id, contact_id, source, source_ref, occurred_at, description, created_at, deleted_at, direction, venue_id
+`
+
+type TestInsertInteractionParams struct {
+	ID         pgtype.UUID        `json:"id"`
+	ContactID  pgtype.UUID        `json:"contact_id"`
+	Source     string             `json:"source"`
+	SourceRef  pgtype.Text        `json:"source_ref"`
+	OccurredAt pgtype.Timestamptz `json:"occurred_at"`
+	Direction  string             `json:"direction"`
+}
+
+// Test-only: inserts an interaction with a caller-supplied id, source, and
+// source_ref and a NULL venue_id, bypassing the recorder. Used by the venue
+// backfill migration test to stand up pre-existing (venue-less) interactions
+// that the 069 backfill then populates. Production code MUST NOT call this.
+func (q *Queries) TestInsertInteraction(ctx context.Context, arg TestInsertInteractionParams) (*Interaction, error) {
+	row := q.db.QueryRow(ctx, TestInsertInteraction,
+		arg.ID,
+		arg.ContactID,
+		arg.Source,
+		arg.SourceRef,
+		arg.OccurredAt,
+		arg.Direction,
+	)
+	var i Interaction
+	err := row.Scan(
+		&i.ID,
+		&i.ContactID,
+		&i.Source,
+		&i.SourceRef,
+		&i.OccurredAt,
+		&i.Description,
+		&i.CreatedAt,
+		&i.DeletedAt,
+		&i.Direction,
+		&i.VenueID,
+	)
+	return &i, err
+}
+
 const UpdateInteractionDirection = `-- name: UpdateInteractionDirection :one
 UPDATE interaction
 SET direction = $1,

--- a/backend/internal/db/messages_message.sql.go
+++ b/backend/internal/db/messages_message.sql.go
@@ -163,6 +163,28 @@ func (q *Queries) GetMessagesMessageByReplyTarget(ctx context.Context, arg GetMe
 	return &i, err
 }
 
+const GetMessagesMessageContainer = `-- name: GetMessagesMessageContainer :one
+SELECT chat_guid, is_group_chat
+FROM messages_message
+WHERE id = $1
+`
+
+type GetMessagesMessageContainerRow struct {
+	ChatGuid    string `json:"chat_guid"`
+	IsGroupChat bool   `json:"is_group_chat"`
+}
+
+// Returns the venue-container key (chat_guid + group flag) for a staging row by
+// its UUID. Used by the live interaction recorder to resolve the messages
+// venue. The container is consistent across all messages in one aggregated
+// session, so reading the first id is sufficient.
+func (q *Queries) GetMessagesMessageContainer(ctx context.Context, id pgtype.UUID) (*GetMessagesMessageContainerRow, error) {
+	row := q.db.QueryRow(ctx, GetMessagesMessageContainer, id)
+	var i GetMessagesMessageContainerRow
+	err := row.Scan(&i.ChatGuid, &i.IsGroupChat)
+	return &i, err
+}
+
 const HardDeleteMessagesMessagesByMacHost = `-- name: HardDeleteMessagesMessagesByMacHost :exec
 DELETE FROM messages_message
 WHERE mac_host_id = $1

--- a/backend/internal/db/messages_message.sql.go
+++ b/backend/internal/db/messages_message.sql.go
@@ -166,7 +166,7 @@ func (q *Queries) GetMessagesMessageByReplyTarget(ctx context.Context, arg GetMe
 const GetMessagesMessageContainer = `-- name: GetMessagesMessageContainer :one
 SELECT chat_guid, is_group_chat
 FROM messages_message
-WHERE id = $1
+WHERE id = $1 AND deleted_at IS NULL
 `
 
 type GetMessagesMessageContainerRow struct {

--- a/backend/internal/db/messages_message.sql.go
+++ b/backend/internal/db/messages_message.sql.go
@@ -486,6 +486,63 @@ func (q *Queries) MarkMessagesMessagesProcessedForSession(ctx context.Context, a
 	return result.RowsAffected(), nil
 }
 
+const TestInsertMessagesMessageLinked = `-- name: TestInsertMessagesMessageLinked :one
+INSERT INTO messages_message (
+    guid, chat_guid, peer_handle, sent_at, is_outgoing, is_group_chat, interaction_id
+) VALUES (
+    $1, $2, $3, $4, $5, $6, $7
+)
+RETURNING id, guid, chat_guid, peer_handle, peer_normalized, text, message_type, sent_at, is_outgoing, is_group_chat, reply_to_guid, matched_contact_id, interaction_id, mac_host_id, processed_at, claimed_at, claimed_session_ref, deleted_at, created_at
+`
+
+type TestInsertMessagesMessageLinkedParams struct {
+	Guid          string             `json:"guid"`
+	ChatGuid      string             `json:"chat_guid"`
+	PeerHandle    string             `json:"peer_handle"`
+	SentAt        pgtype.Timestamptz `json:"sent_at"`
+	IsOutgoing    bool               `json:"is_outgoing"`
+	IsGroupChat   bool               `json:"is_group_chat"`
+	InteractionID pgtype.UUID        `json:"interaction_id"`
+}
+
+// Test-only: inserts a messages_message already linked to an interaction. Used
+// by the venue backfill test to seed an iMessage chat container row. Production
+// code MUST NOT call this.
+func (q *Queries) TestInsertMessagesMessageLinked(ctx context.Context, arg TestInsertMessagesMessageLinkedParams) (*MessagesMessage, error) {
+	row := q.db.QueryRow(ctx, TestInsertMessagesMessageLinked,
+		arg.Guid,
+		arg.ChatGuid,
+		arg.PeerHandle,
+		arg.SentAt,
+		arg.IsOutgoing,
+		arg.IsGroupChat,
+		arg.InteractionID,
+	)
+	var i MessagesMessage
+	err := row.Scan(
+		&i.ID,
+		&i.Guid,
+		&i.ChatGuid,
+		&i.PeerHandle,
+		&i.PeerNormalized,
+		&i.Text,
+		&i.MessageType,
+		&i.SentAt,
+		&i.IsOutgoing,
+		&i.IsGroupChat,
+		&i.ReplyToGuid,
+		&i.MatchedContactID,
+		&i.InteractionID,
+		&i.MacHostID,
+		&i.ProcessedAt,
+		&i.ClaimedAt,
+		&i.ClaimedSessionRef,
+		&i.DeletedAt,
+		&i.CreatedAt,
+	)
+	return &i, err
+}
+
 const UpdateMatchedContactForStrandedMessage = `-- name: UpdateMatchedContactForStrandedMessage :exec
 UPDATE messages_message
 SET matched_contact_id = $1,

--- a/backend/internal/db/models.go
+++ b/backend/internal/db/models.go
@@ -346,6 +346,7 @@ type Interaction struct {
 	CreatedAt   pgtype.Timestamptz `json:"created_at"`
 	DeletedAt   pgtype.Timestamptz `json:"deleted_at"`
 	Direction   string             `json:"direction"`
+	VenueID     pgtype.UUID        `json:"venue_id"`
 }
 
 type MacHost struct {

--- a/backend/internal/db/node.sql.go
+++ b/backend/internal/db/node.sql.go
@@ -100,6 +100,33 @@ func (q *Queries) SoftDeleteNode(ctx context.Context, id pgtype.UUID) error {
 	return err
 }
 
+const TestCountOrphanVenueNodes = `-- name: TestCountOrphanVenueNodes :one
+SELECT COUNT(*) FROM node nd
+WHERE nd.type = 'venue'
+  AND NOT EXISTS (SELECT 1 FROM interaction i WHERE i.venue_id = nd.id)
+`
+
+// Test-only: counts venue-type nodes that no live interaction references via
+// venue_id. Used by the venue backfill test to assert the no-orphan-node guard.
+func (q *Queries) TestCountOrphanVenueNodes(ctx context.Context) (int64, error) {
+	row := q.db.QueryRow(ctx, TestCountOrphanVenueNodes)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const TestCountVenueNodes = `-- name: TestCountVenueNodes :one
+SELECT COUNT(*) FROM node WHERE type = 'venue'
+`
+
+// Test-only: counts venue-type nodes. Used by the venue backfill test.
+func (q *Queries) TestCountVenueNodes(ctx context.Context) (int64, error) {
+	row := q.db.QueryRow(ctx, TestCountVenueNodes)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const UpdateNodeCanonicalLabel = `-- name: UpdateNodeCanonicalLabel :exec
 UPDATE node SET canonical_label = $2 WHERE id = $1
 `

--- a/backend/internal/db/phone_call.sql.go
+++ b/backend/internal/db/phone_call.sql.go
@@ -171,6 +171,65 @@ func (q *Queries) MarkPhoneCallProcessed(ctx context.Context, arg MarkPhoneCallP
 	return err
 }
 
+const TestInsertPhoneCallLinked = `-- name: TestInsertPhoneCallLinked :one
+INSERT INTO phone_call (
+    call_unique_id, peer_handle, peer_normalized, service, direction,
+    duration_seconds, started_at, matched_contact_id, interaction_id
+) VALUES (
+    $1, $2, $3, $4, $5,
+    $6, $7, $8, $9
+)
+RETURNING id, call_unique_id, peer_handle, peer_normalized, service, direction, answered, has_voicemail, duration_seconds, started_at, matched_contact_id, interaction_id, mac_host_id, processed_at, created_at
+`
+
+type TestInsertPhoneCallLinkedParams struct {
+	CallUniqueID     string             `json:"call_unique_id"`
+	PeerHandle       string             `json:"peer_handle"`
+	PeerNormalized   string             `json:"peer_normalized"`
+	Service          string             `json:"service"`
+	Direction        string             `json:"direction"`
+	DurationSeconds  int32              `json:"duration_seconds"`
+	StartedAt        pgtype.Timestamptz `json:"started_at"`
+	MatchedContactID pgtype.UUID        `json:"matched_contact_id"`
+	InteractionID    pgtype.UUID        `json:"interaction_id"`
+}
+
+// Test-only: inserts a phone_call already linked to an interaction. Used by the
+// venue backfill test to seed a phone container row. Production code MUST NOT
+// call this (the live path sets interaction_id via MarkPhoneCallProcessed).
+func (q *Queries) TestInsertPhoneCallLinked(ctx context.Context, arg TestInsertPhoneCallLinkedParams) (*PhoneCall, error) {
+	row := q.db.QueryRow(ctx, TestInsertPhoneCallLinked,
+		arg.CallUniqueID,
+		arg.PeerHandle,
+		arg.PeerNormalized,
+		arg.Service,
+		arg.Direction,
+		arg.DurationSeconds,
+		arg.StartedAt,
+		arg.MatchedContactID,
+		arg.InteractionID,
+	)
+	var i PhoneCall
+	err := row.Scan(
+		&i.ID,
+		&i.CallUniqueID,
+		&i.PeerHandle,
+		&i.PeerNormalized,
+		&i.Service,
+		&i.Direction,
+		&i.Answered,
+		&i.HasVoicemail,
+		&i.DurationSeconds,
+		&i.StartedAt,
+		&i.MatchedContactID,
+		&i.InteractionID,
+		&i.MacHostID,
+		&i.ProcessedAt,
+		&i.CreatedAt,
+	)
+	return &i, err
+}
+
 const UpsertPhoneCall = `-- name: UpsertPhoneCall :one
 INSERT INTO phone_call (
     call_unique_id, peer_handle, peer_normalized,

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -681,6 +681,12 @@ type Querier interface {
 	// Intentionally does NOT filter processed_at — a reply can target an
 	// already-processed message (the whole point of bridging).
 	GetCommsMessageByReplyTarget(ctx context.Context, arg GetCommsMessageByReplyTargetParams) (*CommsMessage, error)
+	// Returns the venue-container key (source + thread_id) for a staging row by its
+	// UUID. Used by the live interaction recorder to resolve the gchat venue (email
+	// resolves its venue from the EmailInteractionConsumer's comms row directly).
+	// The thread is consistent across all messages in one aggregated session, so
+	// reading the first id is sufficient.
+	GetCommsMessageContainer(ctx context.Context, id pgtype.UUID) (*GetCommsMessageContainerRow, error)
 	// Read one stored row for (source, external_id), newest first, to supply the
 	// current body for the provider's bodyDiffers no-op-avoidance pre-check. Fanned-
 	// out rows share content, so any one row suffices. Used ONLY for body
@@ -794,6 +800,11 @@ type Querier interface {
 	// explicit-reply-bridge path. chat_guid is included for scoping
 	// selectivity.
 	GetMessagesMessageByReplyTarget(ctx context.Context, arg GetMessagesMessageByReplyTargetParams) (*MessagesMessage, error)
+	// Returns the venue-container key (chat_guid + group flag) for a staging row by
+	// its UUID. Used by the live interaction recorder to resolve the messages
+	// venue. The container is consistent across all messages in one aggregated
+	// session, so reading the first id is sufficient.
+	GetMessagesMessageContainer(ctx context.Context, id pgtype.UUID) (*GetMessagesMessageContainerRow, error)
 	GetNode(ctx context.Context, id pgtype.UUID) (*Node, error)
 	GetNodeIncludingDeleted(ctx context.Context, id pgtype.UUID) (*Node, error)
 	// Note queries
@@ -855,6 +866,11 @@ type Querier interface {
 	// all-fields-populated test can read back a row whose deleted_at is set.
 	// Production code MUST NOT call this (it would return soft-deleted rows).
 	GetTelegramMessageByIDForTest(ctx context.Context, id pgtype.UUID) (*TelegramMessage, error)
+	// Returns the venue-container key (chat id + type + title) for a staging row by
+	// its UUID. Used by the live interaction recorder to resolve the telegram
+	// venue. The container is consistent across all messages in one aggregated
+	// session, so reading the first id is sufficient.
+	GetTelegramMessageContainer(ctx context.Context, id pgtype.UUID) (*GetTelegramMessageContainerRow, error)
 	GetTelegramSession(ctx context.Context) (*TelegramSession, error)
 	GetTelegramUpdateState(ctx context.Context, userID int64) (*TelegramUpdateState, error)
 	// Probe used by the dispatch loop's revive-bypass: when a duplicate

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -1852,6 +1852,11 @@ type Querier interface {
 	// list by the test before it reaches here; format() with %I quotes the
 	// identifier so it can never be an injection vector.
 	TestCountAllRows(ctx context.Context, tableName string) (int64, error)
+	// Test-only: counts venue-type nodes that no live interaction references via
+	// venue_id. Used by the venue backfill test to assert the no-orphan-node guard.
+	TestCountOrphanVenueNodes(ctx context.Context) (int64, error)
+	// Test-only: counts venue-type nodes. Used by the venue backfill test.
+	TestCountVenueNodes(ctx context.Context) (int64, error)
 	// TEST ONLY. Hard-deletes calendar_event rows whose gcal_event_id starts
 	// with the given prefix. Used by t.Cleanup to remove fixtures.
 	TestDeleteCalendarEventsByGcalEventIDPrefix(ctx context.Context, prefix string) error

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -2055,6 +2055,10 @@ type Querier interface {
 	UpdateInteractionDirection(ctx context.Context, arg UpdateInteractionDirectionParams) (*Interaction, error)
 	// Extend an existing interaction's occurred_at and description (incremental coalescing)
 	UpdateInteractionTimestamp(ctx context.Context, arg UpdateInteractionTimestampParams) (*Interaction, error)
+	// Sets venue_id on an existing interaction. Used by the anarlog re-sync path so
+	// a retained interaction whose session was re-linked (e.g. session -> gcal event)
+	// moves to the correct venue node. Does not touch cadence columns.
+	UpdateInteractionVenue(ctx context.Context, arg UpdateInteractionVenueParams) error
 	UpdateMacHostHeartbeat(ctx context.Context, arg UpdateMacHostHeartbeatParams) (*MacHost, error)
 	// CAS-style update: only updates when sync_cursor matches base_cursor.
 	// Zero rows returned means another writer slipped in between the

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -1900,6 +1900,11 @@ type Querier interface {
 	// Reset test only: a marker row in external_sync_state (a sync-cursor table the
 	// reset wipes so staging cannot re-sync real data).
 	TestInsertExternalSyncStateMarker(ctx context.Context) error
+	// Test-only: inserts an interaction with a caller-supplied id, source, and
+	// source_ref and a NULL venue_id, bypassing the recorder. Used by the venue
+	// backfill migration test to stand up pre-existing (venue-less) interactions
+	// that the 069 backfill then populates. Production code MUST NOT call this.
+	TestInsertInteraction(ctx context.Context, arg TestInsertInteractionParams) (*Interaction, error)
 	// Reset/additive-seed test only: plant ONE queued (non-finalized) river_job so a
 	// test can assert the additive --seed preflight REFUSES while --reset-and-seed
 	// PROCEEDS (it wipes river_job). Minimal valid row: River requires kind, queue,

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -32,6 +32,15 @@ type Querier interface {
 	// under-serializes (a correctness cost). Mirrors the per-account
 	// sync-enqueue lock in external_sync.sql.
 	AcquireSourceRefAggregateLock(ctx context.Context, lockKey string) error
+	// Takes a transaction-scoped advisory lock keyed on a venue container so two
+	// live recorders resolving the SAME (source, kind, container) serialize on
+	// creation — exactly one node+venue pair is created and no orphan node leaks.
+	// hashtextextended folds the container string into the bigint advisory-lock key
+	// space; a rare hash collision only over-serializes two unrelated containers (a
+	// perf cost), never under-serializes (a correctness cost). Mirrors the
+	// per-source_ref aggregation lock in interaction.sql. The lock auto-releases on
+	// commit/rollback.
+	AcquireVenueContainerLock(ctx context.Context, lockKey string) error
 	AddContactTag(ctx context.Context, arg AddContactTagParams) error
 	// Atomically appends a contact to an event's matched_contact_ids iff it isn't
 	// already present. Does NOT reset last_contacted_updated — the rematch handler
@@ -322,6 +331,13 @@ type Querier interface {
 	// node's tombstone. So the live reads join node and filter node.deleted_at IS
 	// NULL; a venue whose node has been merged/soft-deleted drops from these reads.
 	CreateVenue(ctx context.Context, arg CreateVenueParams) (*Venue, error)
+	// Creates the node + venue pair for a container in one statement with a
+	// caller-supplied deterministic node id (uuid_generate_v5 of the container,
+	// matching the migration backfill). Both inserts are ON CONFLICT DO NOTHING so a
+	// concurrent winner or a re-run is a no-op without orphaning a node. Returns the
+	// venue node id on a fresh create; returns no row when the venue already existed
+	// (caller falls back to FindVenueByContainer under the advisory lock).
+	CreateVenueNode(ctx context.Context, arg CreateVenueNodeParams) (pgtype.UUID, error)
 	// Remove duplicate contact IDs that may result from merge
 	// Uses subquery with DISTINCT to rebuild the array without duplicates
 	DeduplicateCalendarEventContacts(ctx context.Context, targetContactID pgtype.UUID) error

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -1887,6 +1887,10 @@ type Querier interface {
 	// TEST ONLY. See TestInsertExternalContactRawEmails. Same rationale for
 	// calendar_event.attendees.
 	TestInsertCalendarEventRawAttendees(ctx context.Context, arg TestInsertCalendarEventRawAttendeesParams) (*CalendarEvent, error)
+	// Test-only: inserts a comms_message already linked to an interaction. Used by
+	// the venue backfill test to seed an email/gchat thread container row.
+	// Production code MUST NOT call this.
+	TestInsertCommsMessageLinked(ctx context.Context, arg TestInsertCommsMessageLinkedParams) (*CommsMessage, error)
 	// TEST ONLY. Fixture queries used by jsonb_gin_index_test.go to construct
 	// edge-case JSONB shapes (non-array, NULL, missing keys) that production
 	// code paths cannot create, plus permanent regression-guard queries that
@@ -1905,6 +1909,10 @@ type Querier interface {
 	// backfill migration test to stand up pre-existing (venue-less) interactions
 	// that the 069 backfill then populates. Production code MUST NOT call this.
 	TestInsertInteraction(ctx context.Context, arg TestInsertInteractionParams) (*Interaction, error)
+	// Test-only: inserts a messages_message already linked to an interaction. Used
+	// by the venue backfill test to seed an iMessage chat container row. Production
+	// code MUST NOT call this.
+	TestInsertMessagesMessageLinked(ctx context.Context, arg TestInsertMessagesMessageLinkedParams) (*MessagesMessage, error)
 	// Reset/additive-seed test only: plant ONE queued (non-finalized) river_job so a
 	// test can assert the additive --seed preflight REFUSES while --reset-and-seed
 	// PROCEEDS (it wipes river_job). Minimal valid row: River requires kind, queue,
@@ -1915,6 +1923,10 @@ type Querier interface {
 	// The token columns are bytea (encrypted-at-rest); dummy bytes are fine for a
 	// marker that is never decrypted.
 	TestInsertOAuthCredentialMarker(ctx context.Context) error
+	// Test-only: inserts a phone_call already linked to an interaction. Used by the
+	// venue backfill test to seed a phone container row. Production code MUST NOT
+	// call this (the live path sets interaction_id via MarkPhoneCallProcessed).
+	TestInsertPhoneCallLinked(ctx context.Context, arg TestInsertPhoneCallLinkedParams) (*PhoneCall, error)
 	// /health river-component integration test only: plant one river_job with an
 	// explicit kind, state, scheduled_at, and (nullable) finalized_at so the
 	// discarded-count / oldest-due / latest-completed-by-kind queries can be

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -1737,6 +1737,10 @@ type Querier interface {
 	// Settle Gate A (Mac-contact unknown-sender): the external_contact row for the
 	// entity id exists with match_status='unmatched'.
 	SyntheticCountUnmatchedExternalContactBySourceId(ctx context.Context, sourceID string) (int64, error)
+	// Cleanup assertion — count surviving venue nodes among the given ids (scoped to
+	// THIS run's tracked venue node ids, so it is immune to parallel tests creating
+	// their own venue nodes on the shared DB, unlike a global venue-node count).
+	SyntheticCountVenueNodesByIds(ctx context.Context, nodeIds []pgtype.UUID) (int64, error)
 	// Assertion-store cleanup: hard-delete the assertions touching a node in EITHER
 	// position (provenance cascades). The assertion → node FK is restrict (NO
 	// ACTION), so a test MUST clear its assertions before deleting its nodes; this
@@ -1821,6 +1825,14 @@ type Querier interface {
 	// tracked peer ids before the contact delete (external_identity survives contact
 	// delete via ON DELETE SET NULL and would otherwise pollute future matching).
 	SyntheticDeleteTelegramExternalIdentitiesByPeerIds(ctx context.Context, peerIds []string) (int64, error)
+	// Cleanup: hard-delete the venue nodes the real recorders minted on the replay
+	// path (interaction.venue_id → node), keyed by the tracked venue node ids. The
+	// venue subtype row cascades via its ON DELETE CASCADE FK to node. Guarded by
+	// type='venue' (defense-in-depth: never touch a person/entity node) AND by
+	// NOT EXISTS any interaction still referencing it — so a venue shared with an
+	// interaction this run did not clean up (e.g. a group container another
+	// namespace also used) is left intact rather than raising the restrict FK.
+	SyntheticDeleteVenueNodesByIds(ctx context.Context, nodeIds []pgtype.UUID) (int64, error)
 	// Contact→node dual-write test support: fetch the person node a contact owns
 	// (node.id == contact.id). Returns the live (non-soft-deleted) node row so a
 	// test can assert the dual-write created it with the expected type/label.

--- a/backend/internal/db/queries/comms_message.sql
+++ b/backend/internal/db/queries/comms_message.sql
@@ -123,7 +123,7 @@ RETURNING *;
 -- reading the first id is sufficient.
 SELECT source, thread_id
 FROM comms_message
-WHERE id = $1;
+WHERE id = $1 AND deleted_at IS NULL;
 
 -- name: ListCommsMessagesByContact :many
 -- Per-contact content, newest first (backs idx_comms_message_contact_sent).

--- a/backend/internal/db/queries/comms_message.sql
+++ b/backend/internal/db/queries/comms_message.sql
@@ -104,6 +104,17 @@ SELECT * FROM comms_message
 WHERE id = @id
   AND deleted_at IS NULL;
 
+-- name: TestInsertCommsMessageLinked :one
+-- Test-only: inserts a comms_message already linked to an interaction. Used by
+-- the venue backfill test to seed an email/gchat thread container row.
+-- Production code MUST NOT call this.
+INSERT INTO comms_message (
+    source, external_id, thread_id, direction, sent_at, matched_contact_id, interaction_id
+) VALUES (
+    @source, @external_id, @thread_id, @direction, @sent_at, @matched_contact_id, @interaction_id
+)
+RETURNING *;
+
 -- name: GetCommsMessageContainer :one
 -- Returns the venue-container key (source + thread_id) for a staging row by its
 -- UUID. Used by the live interaction recorder to resolve the gchat venue (email

--- a/backend/internal/db/queries/comms_message.sql
+++ b/backend/internal/db/queries/comms_message.sql
@@ -104,6 +104,16 @@ SELECT * FROM comms_message
 WHERE id = @id
   AND deleted_at IS NULL;
 
+-- name: GetCommsMessageContainer :one
+-- Returns the venue-container key (source + thread_id) for a staging row by its
+-- UUID. Used by the live interaction recorder to resolve the gchat venue (email
+-- resolves its venue from the EmailInteractionConsumer's comms row directly).
+-- The thread is consistent across all messages in one aggregated session, so
+-- reading the first id is sufficient.
+SELECT source, thread_id
+FROM comms_message
+WHERE id = $1;
+
 -- name: ListCommsMessagesByContact :many
 -- Per-contact content, newest first (backs idx_comms_message_contact_sent).
 SELECT * FROM comms_message

--- a/backend/internal/db/queries/interaction.sql
+++ b/backend/internal/db/queries/interaction.sql
@@ -10,8 +10,16 @@ ORDER BY occurred_at DESC
 LIMIT $2 OFFSET $3;
 
 -- name: CreateInteraction :one
-INSERT INTO interaction (contact_id, source, source_ref, occurred_at, description, direction)
-VALUES ($1, $2, $3, $4, $5, COALESCE(sqlc.narg('direction'), 'mutual'))
+INSERT INTO interaction (contact_id, source, source_ref, occurred_at, description, direction, venue_id)
+VALUES (
+    sqlc.arg('contact_id'),
+    sqlc.arg('source'),
+    sqlc.narg('source_ref'),
+    sqlc.arg('occurred_at'),
+    sqlc.narg('description'),
+    COALESCE(sqlc.narg('direction'), 'mutual'),
+    sqlc.narg('venue_id')
+)
 RETURNING *;
 
 -- name: UpdateInteractionDirection :one

--- a/backend/internal/db/queries/interaction.sql
+++ b/backend/internal/db/queries/interaction.sql
@@ -144,6 +144,15 @@ DELETE FROM interaction
 WHERE source = sqlc.arg(source)
   AND source_ref LIKE sqlc.arg(source_ref_prefix);
 
+-- name: UpdateInteractionVenue :exec
+-- Sets venue_id on an existing interaction. Used by the anarlog re-sync path so
+-- a retained interaction whose session was re-linked (e.g. session -> gcal event)
+-- moves to the correct venue node. Does not touch cadence columns.
+UPDATE interaction
+SET venue_id = sqlc.narg('venue_id')
+WHERE id = sqlc.arg('id')
+  AND deleted_at IS NULL;
+
 -- name: UpdateInteractionTimestamp :one
 -- Extend an existing interaction's occurred_at and description (incremental coalescing)
 UPDATE interaction

--- a/backend/internal/db/queries/interaction.sql
+++ b/backend/internal/db/queries/interaction.sql
@@ -179,6 +179,22 @@ WHERE source = 'anarlog_sessions'
   AND deleted_at IS NULL
 ORDER BY source_ref;
 
+-- name: TestInsertInteraction :one
+-- Test-only: inserts an interaction with a caller-supplied id, source, and
+-- source_ref and a NULL venue_id, bypassing the recorder. Used by the venue
+-- backfill migration test to stand up pre-existing (venue-less) interactions
+-- that the 069 backfill then populates. Production code MUST NOT call this.
+INSERT INTO interaction (id, contact_id, source, source_ref, occurred_at, direction)
+VALUES (
+    sqlc.arg('id'),
+    sqlc.arg('contact_id'),
+    sqlc.arg('source'),
+    sqlc.narg('source_ref'),
+    sqlc.arg('occurred_at'),
+    sqlc.arg('direction')
+)
+RETURNING *;
+
 -- name: AcquireSourceRefAggregateLock :exec
 -- Takes a transaction-scoped advisory lock keyed on an interaction
 -- aggregation source_ref. Used by the email-interaction consumer to

--- a/backend/internal/db/queries/messages_message.sql
+++ b/backend/internal/db/queries/messages_message.sql
@@ -27,6 +27,15 @@ SELECT * FROM messages_message
 WHERE guid = @guid
   AND deleted_at IS NULL;
 
+-- name: GetMessagesMessageContainer :one
+-- Returns the venue-container key (chat_guid + group flag) for a staging row by
+-- its UUID. Used by the live interaction recorder to resolve the messages
+-- venue. The container is consistent across all messages in one aggregated
+-- session, so reading the first id is sufficient.
+SELECT chat_guid, is_group_chat
+FROM messages_message
+WHERE id = $1;
+
 -- name: GetMessagesMessageByReplyTarget :one
 -- Source-neutral analog of GetTelegramMessage for the aggregator's
 -- explicit-reply-bridge path. chat_guid is included for scoping

--- a/backend/internal/db/queries/messages_message.sql
+++ b/backend/internal/db/queries/messages_message.sql
@@ -45,7 +45,7 @@ RETURNING *;
 -- session, so reading the first id is sufficient.
 SELECT chat_guid, is_group_chat
 FROM messages_message
-WHERE id = $1;
+WHERE id = $1 AND deleted_at IS NULL;
 
 -- name: GetMessagesMessageByReplyTarget :one
 -- Source-neutral analog of GetTelegramMessage for the aggregator's

--- a/backend/internal/db/queries/messages_message.sql
+++ b/backend/internal/db/queries/messages_message.sql
@@ -27,6 +27,17 @@ SELECT * FROM messages_message
 WHERE guid = @guid
   AND deleted_at IS NULL;
 
+-- name: TestInsertMessagesMessageLinked :one
+-- Test-only: inserts a messages_message already linked to an interaction. Used
+-- by the venue backfill test to seed an iMessage chat container row. Production
+-- code MUST NOT call this.
+INSERT INTO messages_message (
+    guid, chat_guid, peer_handle, sent_at, is_outgoing, is_group_chat, interaction_id
+) VALUES (
+    @guid, @chat_guid, @peer_handle, @sent_at, @is_outgoing, @is_group_chat, @interaction_id
+)
+RETURNING *;
+
 -- name: GetMessagesMessageContainer :one
 -- Returns the venue-container key (chat_guid + group flag) for a staging row by
 -- its UUID. Used by the live interaction recorder to resolve the messages

--- a/backend/internal/db/queries/node.sql
+++ b/backend/internal/db/queries/node.sql
@@ -21,3 +21,14 @@ UPDATE node SET merged_into = $2, deleted_at = NOW() WHERE id = $1;
 
 -- name: UpdateNodeCanonicalLabel :exec
 UPDATE node SET canonical_label = $2 WHERE id = $1;
+
+-- name: TestCountVenueNodes :one
+-- Test-only: counts venue-type nodes. Used by the venue backfill test.
+SELECT COUNT(*) FROM node WHERE type = 'venue';
+
+-- name: TestCountOrphanVenueNodes :one
+-- Test-only: counts venue-type nodes that no live interaction references via
+-- venue_id. Used by the venue backfill test to assert the no-orphan-node guard.
+SELECT COUNT(*) FROM node nd
+WHERE nd.type = 'venue'
+  AND NOT EXISTS (SELECT 1 FROM interaction i WHERE i.venue_id = nd.id);

--- a/backend/internal/db/queries/phone_call.sql
+++ b/backend/internal/db/queries/phone_call.sql
@@ -35,6 +35,19 @@ ON CONFLICT (call_unique_id) DO UPDATE SET
     call_unique_id = EXCLUDED.call_unique_id
 RETURNING *;
 
+-- name: TestInsertPhoneCallLinked :one
+-- Test-only: inserts a phone_call already linked to an interaction. Used by the
+-- venue backfill test to seed a phone container row. Production code MUST NOT
+-- call this (the live path sets interaction_id via MarkPhoneCallProcessed).
+INSERT INTO phone_call (
+    call_unique_id, peer_handle, peer_normalized, service, direction,
+    duration_seconds, started_at, matched_contact_id, interaction_id
+) VALUES (
+    @call_unique_id, @peer_handle, @peer_normalized, @service, @direction,
+    @duration_seconds, @started_at, @matched_contact_id, @interaction_id
+)
+RETURNING *;
+
 -- name: GetPhoneCallByUniqueID :one
 -- Lookup by call_unique_id. Returns ErrNoRows on miss.
 SELECT * FROM phone_call

--- a/backend/internal/db/queries/telegram_message.sql
+++ b/backend/internal/db/queries/telegram_message.sql
@@ -48,7 +48,7 @@ WHERE telegram_chat_id = @telegram_chat_id
 -- session, so reading the first id is sufficient.
 SELECT telegram_chat_id, chat_type, chat_title
 FROM telegram_message
-WHERE id = $1;
+WHERE id = $1 AND deleted_at IS NULL;
 
 -- name: ListTelegramMessagesByChatUnprocessed :many
 SELECT * FROM telegram_message

--- a/backend/internal/db/queries/telegram_message.sql
+++ b/backend/internal/db/queries/telegram_message.sql
@@ -41,6 +41,15 @@ WHERE telegram_chat_id = @telegram_chat_id
   AND telegram_message_id = @telegram_message_id
   AND deleted_at IS NULL;
 
+-- name: GetTelegramMessageContainer :one
+-- Returns the venue-container key (chat id + type + title) for a staging row by
+-- its UUID. Used by the live interaction recorder to resolve the telegram
+-- venue. The container is consistent across all messages in one aggregated
+-- session, so reading the first id is sufficient.
+SELECT telegram_chat_id, chat_type, chat_title
+FROM telegram_message
+WHERE id = $1;
+
 -- name: ListTelegramMessagesByChatUnprocessed :many
 SELECT * FROM telegram_message
 WHERE telegram_chat_id = @telegram_chat_id

--- a/backend/internal/db/queries/test.sql
+++ b/backend/internal/db/queries/test.sql
@@ -578,6 +578,25 @@ SELECT COUNT(*) FROM contact WHERE full_name = $1 AND deleted_at IS NULL;
 -- alongside the contacts. Hard delete, keyed by the tracked contact ids.
 DELETE FROM node WHERE id = ANY(@node_ids::uuid[]);
 
+-- name: SyntheticDeleteVenueNodesByIds :execrows
+-- Cleanup: hard-delete the venue nodes the real recorders minted on the replay
+-- path (interaction.venue_id → node), keyed by the tracked venue node ids. The
+-- venue subtype row cascades via its ON DELETE CASCADE FK to node. Guarded by
+-- type='venue' (defense-in-depth: never touch a person/entity node) AND by
+-- NOT EXISTS any interaction still referencing it — so a venue shared with an
+-- interaction this run did not clean up (e.g. a group container another
+-- namespace also used) is left intact rather than raising the restrict FK.
+DELETE FROM node
+WHERE id = ANY(@node_ids::uuid[])
+  AND type = 'venue'
+  AND NOT EXISTS (SELECT 1 FROM interaction i WHERE i.venue_id = node.id);
+
+-- name: SyntheticCountVenueNodesByIds :one
+-- Cleanup assertion — count surviving venue nodes among the given ids (scoped to
+-- THIS run's tracked venue node ids, so it is immune to parallel tests creating
+-- their own venue nodes on the shared DB, unlike a global venue-node count).
+SELECT COUNT(*) FROM node WHERE id = ANY(@node_ids::uuid[]) AND type = 'venue';
+
 -- name: SyntheticDeleteAssertionsForNode :execrows
 -- Assertion-store cleanup: hard-delete the assertions touching a node in EITHER
 -- position (provenance cascades). The assertion → node FK is restrict (NO

--- a/backend/internal/db/queries/venue.sql
+++ b/backend/internal/db/queries/venue.sql
@@ -31,3 +31,33 @@ VALUES ($1, $2, $3, $4, $5)
 ON CONFLICT (source, kind, source_container_id)
 DO UPDATE SET title = EXCLUDED.title
 RETURNING *;
+
+-- name: AcquireVenueContainerLock :exec
+-- Takes a transaction-scoped advisory lock keyed on a venue container so two
+-- live recorders resolving the SAME (source, kind, container) serialize on
+-- creation — exactly one node+venue pair is created and no orphan node leaks.
+-- hashtextextended folds the container string into the bigint advisory-lock key
+-- space; a rare hash collision only over-serializes two unrelated containers (a
+-- perf cost), never under-serializes (a correctness cost). Mirrors the
+-- per-source_ref aggregation lock in interaction.sql. The lock auto-releases on
+-- commit/rollback.
+SELECT pg_advisory_xact_lock(hashtextextended(sqlc.arg('lock_key')::text, 0));
+
+-- name: CreateVenueNode :one
+-- Creates the node + venue pair for a container in one statement with a
+-- caller-supplied deterministic node id (uuid_generate_v5 of the container,
+-- matching the migration backfill). Both inserts are ON CONFLICT DO NOTHING so a
+-- concurrent winner or a re-run is a no-op without orphaning a node. Returns the
+-- venue node id on a fresh create; returns no row when the venue already existed
+-- (caller falls back to FindVenueByContainer under the advisory lock).
+WITH ins_node AS (
+    INSERT INTO node (id, type, canonical_label)
+    VALUES (sqlc.arg('node_id'), 'venue', sqlc.arg('canonical_label'))
+    ON CONFLICT (id) DO NOTHING
+    RETURNING id
+)
+INSERT INTO venue (node_id, kind, source, source_container_id, title)
+SELECT sqlc.arg('node_id'), sqlc.arg('kind'), sqlc.arg('source'),
+       sqlc.arg('source_container_id'), sqlc.narg('title')
+ON CONFLICT (source, kind, source_container_id) DO NOTHING
+RETURNING node_id;

--- a/backend/internal/db/telegram_message.sql.go
+++ b/backend/internal/db/telegram_message.sql.go
@@ -436,7 +436,7 @@ func (q *Queries) GetTelegramMessageByIDForTest(ctx context.Context, id pgtype.U
 const GetTelegramMessageContainer = `-- name: GetTelegramMessageContainer :one
 SELECT telegram_chat_id, chat_type, chat_title
 FROM telegram_message
-WHERE id = $1
+WHERE id = $1 AND deleted_at IS NULL
 `
 
 type GetTelegramMessageContainerRow struct {

--- a/backend/internal/db/telegram_message.sql.go
+++ b/backend/internal/db/telegram_message.sql.go
@@ -433,6 +433,29 @@ func (q *Queries) GetTelegramMessageByIDForTest(ctx context.Context, id pgtype.U
 	return &i, err
 }
 
+const GetTelegramMessageContainer = `-- name: GetTelegramMessageContainer :one
+SELECT telegram_chat_id, chat_type, chat_title
+FROM telegram_message
+WHERE id = $1
+`
+
+type GetTelegramMessageContainerRow struct {
+	TelegramChatID int64       `json:"telegram_chat_id"`
+	ChatType       string      `json:"chat_type"`
+	ChatTitle      pgtype.Text `json:"chat_title"`
+}
+
+// Returns the venue-container key (chat id + type + title) for a staging row by
+// its UUID. Used by the live interaction recorder to resolve the telegram
+// venue. The container is consistent across all messages in one aggregated
+// session, so reading the first id is sufficient.
+func (q *Queries) GetTelegramMessageContainer(ctx context.Context, id pgtype.UUID) (*GetTelegramMessageContainerRow, error) {
+	row := q.db.QueryRow(ctx, GetTelegramMessageContainer, id)
+	var i GetTelegramMessageContainerRow
+	err := row.Scan(&i.TelegramChatID, &i.ChatType, &i.ChatTitle)
+	return &i, err
+}
+
 const HardDeleteTelegramMessagesByChatIDRange = `-- name: HardDeleteTelegramMessagesByChatIDRange :exec
 
 DELETE FROM telegram_message

--- a/backend/internal/db/test.sql.go
+++ b/backend/internal/db/test.sql.go
@@ -1201,6 +1201,20 @@ func (q *Queries) SyntheticCountUnmatchedExternalContactBySourceId(ctx context.C
 	return count, err
 }
 
+const SyntheticCountVenueNodesByIds = `-- name: SyntheticCountVenueNodesByIds :one
+SELECT COUNT(*) FROM node WHERE id = ANY($1::uuid[]) AND type = 'venue'
+`
+
+// Cleanup assertion — count surviving venue nodes among the given ids (scoped to
+// THIS run's tracked venue node ids, so it is immune to parallel tests creating
+// their own venue nodes on the shared DB, unlike a global venue-node count).
+func (q *Queries) SyntheticCountVenueNodesByIds(ctx context.Context, nodeIds []pgtype.UUID) (int64, error) {
+	row := q.db.QueryRow(ctx, SyntheticCountVenueNodesByIds, nodeIds)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const SyntheticDeleteAssertionsForNode = `-- name: SyntheticDeleteAssertionsForNode :execrows
 DELETE FROM assertion WHERE subject_node_id = $1 OR object_node_id = $1
 `
@@ -1512,6 +1526,28 @@ WHERE source = 'telegram' AND source_id = ANY($1::text[])
 // delete via ON DELETE SET NULL and would otherwise pollute future matching).
 func (q *Queries) SyntheticDeleteTelegramExternalIdentitiesByPeerIds(ctx context.Context, peerIds []string) (int64, error) {
 	result, err := q.db.Exec(ctx, SyntheticDeleteTelegramExternalIdentitiesByPeerIds, peerIds)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const SyntheticDeleteVenueNodesByIds = `-- name: SyntheticDeleteVenueNodesByIds :execrows
+DELETE FROM node
+WHERE id = ANY($1::uuid[])
+  AND type = 'venue'
+  AND NOT EXISTS (SELECT 1 FROM interaction i WHERE i.venue_id = node.id)
+`
+
+// Cleanup: hard-delete the venue nodes the real recorders minted on the replay
+// path (interaction.venue_id → node), keyed by the tracked venue node ids. The
+// venue subtype row cascades via its ON DELETE CASCADE FK to node. Guarded by
+// type='venue' (defense-in-depth: never touch a person/entity node) AND by
+// NOT EXISTS any interaction still referencing it — so a venue shared with an
+// interaction this run did not clean up (e.g. a group container another
+// namespace also used) is left intact rather than raising the restrict FK.
+func (q *Queries) SyntheticDeleteVenueNodesByIds(ctx context.Context, nodeIds []pgtype.UUID) (int64, error) {
+	result, err := q.db.Exec(ctx, SyntheticDeleteVenueNodesByIds, nodeIds)
 	if err != nil {
 		return 0, err
 	}

--- a/backend/internal/db/venue.sql.go
+++ b/backend/internal/db/venue.sql.go
@@ -11,6 +11,23 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const AcquireVenueContainerLock = `-- name: AcquireVenueContainerLock :exec
+SELECT pg_advisory_xact_lock(hashtextextended($1::text, 0))
+`
+
+// Takes a transaction-scoped advisory lock keyed on a venue container so two
+// live recorders resolving the SAME (source, kind, container) serialize on
+// creation — exactly one node+venue pair is created and no orphan node leaks.
+// hashtextextended folds the container string into the bigint advisory-lock key
+// space; a rare hash collision only over-serializes two unrelated containers (a
+// perf cost), never under-serializes (a correctness cost). Mirrors the
+// per-source_ref aggregation lock in interaction.sql. The lock auto-releases on
+// commit/rollback.
+func (q *Queries) AcquireVenueContainerLock(ctx context.Context, lockKey string) error {
+	_, err := q.db.Exec(ctx, AcquireVenueContainerLock, lockKey)
+	return err
+}
+
 const CreateVenue = `-- name: CreateVenue :one
 
 INSERT INTO venue (node_id, kind, source, source_container_id, title)
@@ -48,6 +65,49 @@ func (q *Queries) CreateVenue(ctx context.Context, arg CreateVenueParams) (*Venu
 		&i.Title,
 	)
 	return &i, err
+}
+
+const CreateVenueNode = `-- name: CreateVenueNode :one
+WITH ins_node AS (
+    INSERT INTO node (id, type, canonical_label)
+    VALUES ($1, 'venue', $6)
+    ON CONFLICT (id) DO NOTHING
+    RETURNING id
+)
+INSERT INTO venue (node_id, kind, source, source_container_id, title)
+SELECT $1, $2, $3,
+       $4, $5
+ON CONFLICT (source, kind, source_container_id) DO NOTHING
+RETURNING node_id
+`
+
+type CreateVenueNodeParams struct {
+	NodeID            pgtype.UUID `json:"node_id"`
+	Kind              string      `json:"kind"`
+	Source            string      `json:"source"`
+	SourceContainerID string      `json:"source_container_id"`
+	Title             pgtype.Text `json:"title"`
+	CanonicalLabel    string      `json:"canonical_label"`
+}
+
+// Creates the node + venue pair for a container in one statement with a
+// caller-supplied deterministic node id (uuid_generate_v5 of the container,
+// matching the migration backfill). Both inserts are ON CONFLICT DO NOTHING so a
+// concurrent winner or a re-run is a no-op without orphaning a node. Returns the
+// venue node id on a fresh create; returns no row when the venue already existed
+// (caller falls back to FindVenueByContainer under the advisory lock).
+func (q *Queries) CreateVenueNode(ctx context.Context, arg CreateVenueNodeParams) (pgtype.UUID, error) {
+	row := q.db.QueryRow(ctx, CreateVenueNode,
+		arg.NodeID,
+		arg.Kind,
+		arg.Source,
+		arg.SourceContainerID,
+		arg.Title,
+		arg.CanonicalLabel,
+	)
+	var node_id pgtype.UUID
+	err := row.Scan(&node_id)
+	return node_id, err
 }
 
 const FindVenueByContainer = `-- name: FindVenueByContainer :one

--- a/backend/internal/repository/interaction.go
+++ b/backend/internal/repository/interaction.go
@@ -446,6 +446,16 @@ func (r *InteractionRepository) TestInsertInteraction(ctx context.Context, id, c
 	return &interaction, nil
 }
 
+// UpdateInteractionVenueTx sets venue_id on an existing interaction inside the
+// caller's tx. Used by the anarlog re-sync path so a retained interaction whose
+// session was re-linked moves to the correct venue node. nil venueID clears it.
+func (r *InteractionRepository) UpdateInteractionVenueTx(ctx context.Context, tx pgx.Tx, id uuid.UUID, venueID *uuid.UUID) error {
+	return db.New(tx).UpdateInteractionVenue(ctx, db.UpdateInteractionVenueParams{
+		ID:      uuidToPgUUID(id),
+		VenueID: uuidPtrToPgUUID(venueID),
+	})
+}
+
 // CreateInteractionTx creates a new interaction inside the caller's tx.
 // Used by the InteractionRecorder consumer so the insert commits atomically
 // with the interaction.recorded event row (spec §3.4.1).

--- a/backend/internal/repository/interaction.go
+++ b/backend/internal/repository/interaction.go
@@ -426,6 +426,26 @@ func (r *InteractionRepository) UpdateInteractionTimestamp(ctx context.Context, 
 	return &interaction, nil
 }
 
+// TestInsertInteraction inserts an interaction with a caller-supplied id and a
+// NULL venue_id, bypassing the recorder. Test-only — used by the venue backfill
+// migration test to stand up pre-existing venue-less interactions. Production
+// code MUST NOT call this.
+func (r *InteractionRepository) TestInsertInteraction(ctx context.Context, id, contactID uuid.UUID, source string, sourceRef *string, occurredAt time.Time, direction string) (*Interaction, error) {
+	dbInteraction, err := r.queries.TestInsertInteraction(ctx, db.TestInsertInteractionParams{
+		ID:         uuidToPgUUID(id),
+		ContactID:  uuidToPgUUID(contactID),
+		Source:     source,
+		SourceRef:  stringToPgText(sourceRef),
+		OccurredAt: pgtype.Timestamptz{Time: occurredAt, Valid: true},
+		Direction:  direction,
+	})
+	if err != nil {
+		return nil, err
+	}
+	interaction := convertDbInteraction(dbInteraction)
+	return &interaction, nil
+}
+
 // CreateInteractionTx creates a new interaction inside the caller's tx.
 // Used by the InteractionRecorder consumer so the insert commits atomically
 // with the interaction.recorded event row (spec §3.4.1).

--- a/backend/internal/repository/interaction.go
+++ b/backend/internal/repository/interaction.go
@@ -40,6 +40,11 @@ type RecordInteractionRequest struct {
 	OccurredAt  time.Time
 	Description *string
 	Direction   string // "outbound", "inbound", "mutual" — defaults to "mutual" if empty
+	// VenueID is the shared-container venue node this interaction happened in
+	// (resolved by the recorder from the source's container key). Nil for
+	// manual/todoist and any source whose container can't be resolved — never
+	// fail the recorder over a missing venue.
+	VenueID *uuid.UUID
 }
 
 // ApplyInteractionRequest is the direct-invoke input for
@@ -100,17 +105,21 @@ func NewInteractionRepository(queries db.Querier) *InteractionRepository {
 
 // Interaction represents an interaction with a contact
 type Interaction struct {
-	ID          uuid.UUID `json:"id"`
-	ContactID   uuid.UUID `json:"contact_id"`
-	Source      string    `json:"source"`
-	SourceRef   *string   `json:"source_ref,omitempty"`
-	OccurredAt  time.Time `json:"occurred_at"`
-	Description *string   `json:"description,omitempty"`
-	Direction   string    `json:"direction"`
-	CreatedAt   time.Time `json:"created_at"`
+	ID          uuid.UUID  `json:"id"`
+	ContactID   uuid.UUID  `json:"contact_id"`
+	Source      string     `json:"source"`
+	SourceRef   *string    `json:"source_ref,omitempty"`
+	OccurredAt  time.Time  `json:"occurred_at"`
+	Description *string    `json:"description,omitempty"`
+	Direction   string     `json:"direction"`
+	CreatedAt   time.Time  `json:"created_at"`
+	VenueID     *uuid.UUID `json:"venue_id,omitempty"`
 }
 
-// CreateInteractionRequest represents the request to create an interaction
+// CreateInteractionRequest represents the request to create an interaction.
+//
+// Field layout MUST stay identical to RecordInteractionRequest — the service
+// constructs it via the direct type conversion CreateInteractionRequest(req).
 type CreateInteractionRequest struct {
 	ContactID   uuid.UUID
 	Source      string
@@ -118,6 +127,7 @@ type CreateInteractionRequest struct {
 	OccurredAt  time.Time
 	Description *string
 	Direction   string
+	VenueID     *uuid.UUID
 }
 
 func convertDbInteraction(dbInteraction *db.Interaction) Interaction {
@@ -143,6 +153,10 @@ func convertDbInteraction(dbInteraction *db.Interaction) Interaction {
 	}
 	if dbInteraction.Description.Valid {
 		interaction.Description = &dbInteraction.Description.String
+	}
+	if dbInteraction.VenueID.Valid {
+		v := uuid.UUID(dbInteraction.VenueID.Bytes)
+		interaction.VenueID = &v
 	}
 
 	return interaction
@@ -195,6 +209,7 @@ func (r *InteractionRepository) CreateInteraction(ctx context.Context, req Creat
 		OccurredAt:  pgtype.Timestamptz{Time: req.OccurredAt, Valid: true},
 		Description: stringToPgText(req.Description),
 		Direction:   stringToPgText(&req.Direction),
+		VenueID:     uuidPtrToPgUUID(req.VenueID),
 	})
 	if err != nil {
 		return nil, err
@@ -422,6 +437,7 @@ func (r *InteractionRepository) CreateInteractionTx(ctx context.Context, tx pgx.
 		OccurredAt:  pgtype.Timestamptz{Time: req.OccurredAt, Valid: true},
 		Description: stringToPgText(req.Description),
 		Direction:   stringToPgText(&req.Direction),
+		VenueID:     uuidPtrToPgUUID(req.VenueID),
 	})
 	if err != nil {
 		return nil, err

--- a/backend/internal/repository/node.go
+++ b/backend/internal/repository/node.go
@@ -149,6 +149,17 @@ func (r *NodeRepository) SetNodeMergedIntoTx(ctx context.Context, tx pgx.Tx, los
 	})
 }
 
+// TestCountVenueNodes counts venue-type nodes. Test-only.
+func (r *NodeRepository) TestCountVenueNodes(ctx context.Context) (int64, error) {
+	return r.queries.TestCountVenueNodes(ctx)
+}
+
+// TestCountOrphanVenueNodes counts venue-type nodes no live interaction
+// references via venue_id. Test-only.
+func (r *NodeRepository) TestCountOrphanVenueNodes(ctx context.Context) (int64, error) {
+	return r.queries.TestCountOrphanVenueNodes(ctx)
+}
+
 // UpdateNodeCanonicalLabel keeps the node's display label loosely synced with
 // its owning entity (e.g. a contact rename). The underlying query is :exec, so a
 // missing node is a silent no-op (no rows-affected check). This is deliberate:

--- a/backend/internal/repository/synthetic_support.go
+++ b/backend/internal/repository/synthetic_support.go
@@ -720,6 +720,27 @@ func (r *SyntheticSupportRepository) DeleteNodesByIds(ctx context.Context, nodeI
 	return r.queries.SyntheticDeleteNodesByIds(ctx, pgUUIDs(nodeIDs))
 }
 
+// DeleteVenueNodesByIds hard-deletes the venue nodes the real recorders minted
+// on the replay path (interaction.venue_id), keyed by the tracked venue node
+// ids. Guarded by type='venue' + no remaining interaction reference, so it never
+// touches a person/entity node and never trips the interaction→venue restrict FK
+// for a venue still referenced by an un-cleaned interaction.
+func (r *SyntheticSupportRepository) DeleteVenueNodesByIds(ctx context.Context, nodeIDs []uuid.UUID) (int64, error) {
+	if len(nodeIDs) == 0 {
+		return 0, nil
+	}
+	return r.queries.SyntheticDeleteVenueNodesByIds(ctx, pgUUIDs(nodeIDs))
+}
+
+// CountVenueNodesByIds counts surviving venue nodes among the given ids (cleanup
+// assertion, scoped to the run's tracked ids so it is parallel-test-safe).
+func (r *SyntheticSupportRepository) CountVenueNodesByIds(ctx context.Context, nodeIDs []uuid.UUID) (int64, error) {
+	if len(nodeIDs) == 0 {
+		return 0, nil
+	}
+	return r.queries.SyntheticCountVenueNodesByIds(ctx, pgUUIDs(nodeIDs))
+}
+
 // DeleteAssertionsForNode hard-deletes the assertions touching a node in either
 // position (provenance cascades). The assertion → node FK is restrict, so a test
 // MUST clear its assertions before deleting its nodes — register this cleanup to

--- a/backend/internal/repository/venue.go
+++ b/backend/internal/repository/venue.go
@@ -3,6 +3,8 @@ package repository
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strconv"
 
 	"personal-crm/backend/internal/db"
 
@@ -19,6 +21,33 @@ const (
 	VenueKindCall        = "call"
 	VenueKindSession     = "session"
 )
+
+// venueNodeNamespace is the fixed UUID namespace the venue node id is derived
+// from. The venue node id is uuid_generate_v5(namespace, <length-prefixed
+// source|kind|container>), computed identically here (uuid.NewSHA1 == UUID v5)
+// and in the 069 migration backfill so the live recorders and the backfill
+// converge on ONE venue node per real container. Changing this value would
+// orphan every existing venue node — it is frozen.
+var venueNodeNamespace = uuid.MustParse("a4f7c0e2-1b3d-4c6a-9e8f-2d5b7a1c0e94")
+
+// venueContainerName builds the length-prefixed (source, kind, container)
+// encoding used as both the uuid_generate_v5 name and the advisory-lock key.
+// Length-prefixing each component (<len>:<value>) means a delimiter or NUL byte
+// inside a container id cannot forge a collision across components. MUST stay
+// byte-identical to the migration's encoding.
+func venueContainerName(source, kind, container string) string {
+	return lengthPrefix(source) + "|" + lengthPrefix(kind) + "|" + lengthPrefix(container)
+}
+
+func lengthPrefix(s string) string {
+	return strconv.Itoa(len(s)) + ":" + s
+}
+
+// VenueNodeID returns the deterministic venue node id for a container. Exported
+// so tests can assert the live helper and the migration agree.
+func VenueNodeID(source, kind, container string) uuid.UUID {
+	return uuid.NewSHA1(venueNodeNamespace, []byte(venueContainerName(source, kind, container)))
+}
 
 // Venue is the structural subtype row for a shared-container node. NodeID is
 // both PK and the FK alias of node.id.
@@ -145,4 +174,80 @@ func upsertVenue(ctx context.Context, q db.Querier, req CreateVenueRequest) (*Ve
 	}
 	venue := convertDbVenue(dbVenue)
 	return &venue, nil
+}
+
+// ResolveVenueForInteraction returns the venue node id for a real container,
+// creating the node+venue pair on first sight. Called by the live interaction
+// recorders inside the recording tx so the venue_id is set atomically with the
+// interaction insert.
+//
+// No-orphan-node creation under concurrency: the venue node id is deterministic
+// (VenueNodeID), so the node + venue inserts are both ON CONFLICT DO NOTHING and
+// a concurrent same-container writer can never leak an orphan node. The helper
+// still reads first (fast path, no lock) and, only on a miss, takes a
+// per-container advisory lock before the create — so two recorders that race on
+// a brand-new container serialize on creation and exactly one pair is written.
+// The deterministic id keeps this in lockstep with the 069 migration backfill.
+func (r *VenueRepository) ResolveVenueForInteraction(
+	ctx context.Context, tx pgx.Tx, source, kind, containerKey, title string,
+) (uuid.UUID, error) {
+	q := db.New(tx)
+
+	// Fast path: the venue already exists for this container.
+	if existing, err := q.FindVenueByContainer(ctx, db.FindVenueByContainerParams{
+		Source:            source,
+		Kind:              kind,
+		SourceContainerID: containerKey,
+	}); err == nil {
+		return uuid.UUID(existing.NodeID.Bytes), nil
+	} else if !errors.Is(err, pgx.ErrNoRows) {
+		return uuid.Nil, fmt.Errorf("find venue by container: %w", err)
+	}
+
+	// Miss: serialize concurrent creation of THIS container on an advisory lock
+	// so exactly one node+venue pair is created (the lock auto-releases on
+	// commit/rollback).
+	if err := q.AcquireVenueContainerLock(ctx, venueContainerName(source, kind, containerKey)); err != nil {
+		return uuid.Nil, fmt.Errorf("acquire venue container lock: %w", err)
+	}
+
+	// Re-check under the lock: a racing writer may have created it between our
+	// read and the lock.
+	if existing, err := q.FindVenueByContainer(ctx, db.FindVenueByContainerParams{
+		Source:            source,
+		Kind:              kind,
+		SourceContainerID: containerKey,
+	}); err == nil {
+		return uuid.UUID(existing.NodeID.Bytes), nil
+	} else if !errors.Is(err, pgx.ErrNoRows) {
+		return uuid.Nil, fmt.Errorf("re-check venue by container: %w", err)
+	}
+
+	// Still absent: create the node+venue pair with the deterministic id. Both
+	// inserts are ON CONFLICT DO NOTHING; the deterministic id is what makes the
+	// node insert safe (no orphan) even if a writer slipped in.
+	nodeID := VenueNodeID(source, kind, containerKey)
+	if _, err := q.CreateVenueNode(ctx, db.CreateVenueNodeParams{
+		NodeID:            uuidToPgUUID(nodeID),
+		Kind:              kind,
+		Source:            source,
+		SourceContainerID: containerKey,
+		Title:             stringToPgText(nilIfEmpty(title)),
+		// Node canonical_label is kept empty for venue nodes (the human label
+		// lives on venue.title); this matches the 069 migration backfill so a
+		// venue created live and one created by the backfill are identical.
+		CanonicalLabel: "",
+	}); err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return uuid.Nil, fmt.Errorf("create venue node: %w", err)
+	}
+	return nodeID, nil
+}
+
+// nilIfEmpty maps an empty string to a nil *string (SQL NULL title) and a
+// non-empty string to its pointer.
+func nilIfEmpty(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
 }

--- a/backend/internal/repository/venue_resolver.go
+++ b/backend/internal/repository/venue_resolver.go
@@ -1,0 +1,223 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"strconv"
+
+	"personal-crm/backend/internal/db"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// VenueContainer is the per-source container identity a recorder resolves an
+// interaction's venue from. Kind + ContainerID map to the venue
+// (source, kind, source_container_id) unique; Title is the human label.
+type VenueContainer struct {
+	Kind        string
+	ContainerID string
+	Title       string
+}
+
+// VenueContainerReader resolves a message.* staging row's container key from a
+// staging row id, inside the caller's tx. One implementation per chat source
+// (telegram, messages, gchat). The recorder has the staging row ids in hand
+// (the same MessageIDs it marks processed), so the container is one read away.
+type VenueContainerReader interface {
+	ContainerForMessageTx(ctx context.Context, tx pgx.Tx, messageID uuid.UUID) (VenueContainer, error)
+}
+
+// gcalEventTupleReader reads the (gcal_event_id, gcal_calendar_id,
+// google_account_id) 3-tuple + title off a calendar_event by its internal id,
+// inside the caller's tx. Satisfied by *CalendarEventRepository.GetByIDTx.
+type gcalEventTupleReader interface {
+	GetByIDTx(ctx context.Context, tx pgx.Tx, id uuid.UUID) (*CalendarEvent, error)
+}
+
+// VenueResolverRegistry routes a recorder's container lookup to the right
+// per-source resolution path, then resolves the venue node id (creating it on
+// first sight). For message.* it dispatches by source to a per-source reader;
+// for gcal it reads the calendar_event 3-tuple. Mirrors
+// StagingProcessorRegistry's one-entry-per-source shape.
+//
+// Resolution is best-effort wrt the interaction insert: an unknown source, an
+// empty id list, or a missing/empty container yields a nil id + nil error so
+// the recorder records the interaction with a NULL venue_id rather than
+// failing. The interaction row is the durable contract; the venue link is an
+// enrichment.
+type VenueResolverRegistry struct {
+	venues   *VenueRepository
+	readers  map[string]VenueContainerReader
+	calendar gcalEventTupleReader
+}
+
+// NewVenueResolverRegistry builds the registry from a source → reader map, the
+// venue repository used to create/find the venue node, and the calendar-event
+// reader used for the gcal 3-tuple. calendar may be nil in tests that don't
+// exercise gcal.
+func NewVenueResolverRegistry(venues *VenueRepository, readers map[string]VenueContainerReader, calendar gcalEventTupleReader) *VenueResolverRegistry {
+	return &VenueResolverRegistry{venues: venues, readers: readers, calendar: calendar}
+}
+
+// ResolveMessageVenueTx resolves the venue node id for a message.* interaction
+// from its staging row ids. Returns (nil, nil) — record with NULL venue_id —
+// for an unknown source, an empty id list, or an unresolvable container; only a
+// real DB error propagates.
+func (r *VenueResolverRegistry) ResolveMessageVenueTx(
+	ctx context.Context, tx pgx.Tx, source string, messageIDs []uuid.UUID,
+) (*uuid.UUID, error) {
+	if len(messageIDs) == 0 {
+		return nil, nil
+	}
+	reader, ok := r.readers[source]
+	if !ok {
+		return nil, nil
+	}
+	container, err := reader.ContainerForMessageTx(ctx, tx, messageIDs[0])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			// Staging row gone (hard-deleted in a test, or a race) — record
+			// without a venue rather than fail the interaction.
+			return nil, nil
+		}
+		return nil, err
+	}
+	if container.ContainerID == "" {
+		return nil, nil
+	}
+	nodeID, err := r.venues.ResolveVenueForInteraction(ctx, tx, source, container.Kind, container.ContainerID, container.Title)
+	if err != nil {
+		return nil, err
+	}
+	return &nodeID, nil
+}
+
+// ResolveVenueForInteractionTx resolves (creating on first sight) the venue node
+// id for a container the caller already has in hand — phone calls and anarlog
+// sessions, which carry their container key directly. Passthrough to the venue
+// repository so service-layer recorders depend on this one registry rather than
+// the repo + the registry separately.
+func (r *VenueResolverRegistry) ResolveVenueForInteractionTx(
+	ctx context.Context, tx pgx.Tx, source, kind, containerKey, title string,
+) (uuid.UUID, error) {
+	return r.venues.ResolveVenueForInteraction(ctx, tx, source, kind, containerKey, title)
+}
+
+// ResolveGCalVenueTx resolves the meeting venue for a gcal interaction from the
+// internal calendar_event id (the interaction's source_ref). Returns (nil, nil)
+// — record with NULL venue_id — when the calendar row is gone or the reader is
+// unwired; only a real DB error propagates.
+func (r *VenueResolverRegistry) ResolveGCalVenueTx(ctx context.Context, tx pgx.Tx, calendarEventID uuid.UUID) (*uuid.UUID, error) {
+	if r.calendar == nil {
+		return nil, nil
+	}
+	event, err := r.calendar.GetByIDTx(ctx, tx, calendarEventID)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) || errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	container := GCalVenueContainerID(event.GcalEventID, event.GcalCalendarID, event.GoogleAccountID)
+	var title string
+	if event.Title != nil {
+		title = *event.Title
+	}
+	nodeID, err := r.venues.ResolveVenueForInteraction(ctx, tx, InteractionSourceGCal, VenueKindMeeting, container, title)
+	if err != nil {
+		return nil, err
+	}
+	return &nodeID, nil
+}
+
+// GCalVenueContainerID builds the gcal venue container key — the length-prefixed
+// (gcal_event_id, gcal_calendar_id, google_account_id) 3-tuple. The 3-tuple is
+// calendar_event's real uniqueness; length-prefixing prevents a delimiter in any
+// component from aliasing a different tuple. MUST stay byte-identical to the 069
+// migration's gcal container expression.
+func GCalVenueContainerID(gcalEventID, gcalCalendarID, googleAccountID string) string {
+	return lengthPrefix(gcalEventID) + "|" + lengthPrefix(gcalCalendarID) + "|" + lengthPrefix(googleAccountID)
+}
+
+// --- per-source readers ---
+
+// TelegramVenueContainerReader reads the telegram chat container off a staging
+// row. chat_type 'private' is a DM; group/supergroup are group chats.
+type TelegramVenueContainerReader struct{}
+
+// NewTelegramVenueContainerReader builds the reader.
+func NewTelegramVenueContainerReader() *TelegramVenueContainerReader {
+	return &TelegramVenueContainerReader{}
+}
+
+// ContainerForMessageTx implements VenueContainerReader for telegram.
+func (r *TelegramVenueContainerReader) ContainerForMessageTx(ctx context.Context, tx pgx.Tx, messageID uuid.UUID) (VenueContainer, error) {
+	row, err := db.New(tx).GetTelegramMessageContainer(ctx, uuidToPgUUID(messageID))
+	if err != nil {
+		return VenueContainer{}, err
+	}
+	kind := VenueKindGroupChat
+	if row.ChatType == "private" {
+		kind = VenueKindDM
+	}
+	var title string
+	if row.ChatTitle.Valid {
+		title = row.ChatTitle.String
+	}
+	return VenueContainer{
+		Kind:        kind,
+		ContainerID: strconv.FormatInt(row.TelegramChatID, 10),
+		Title:       title,
+	}, nil
+}
+
+// MessagesVenueContainerReader reads the iMessage chat container off a staging
+// row. is_group_chat decides group_chat vs dm.
+type MessagesVenueContainerReader struct{}
+
+// NewMessagesVenueContainerReader builds the reader.
+func NewMessagesVenueContainerReader() *MessagesVenueContainerReader {
+	return &MessagesVenueContainerReader{}
+}
+
+// ContainerForMessageTx implements VenueContainerReader for messages.
+func (r *MessagesVenueContainerReader) ContainerForMessageTx(ctx context.Context, tx pgx.Tx, messageID uuid.UUID) (VenueContainer, error) {
+	row, err := db.New(tx).GetMessagesMessageContainer(ctx, uuidToPgUUID(messageID))
+	if err != nil {
+		return VenueContainer{}, err
+	}
+	kind := VenueKindDM
+	if row.IsGroupChat {
+		kind = VenueKindGroupChat
+	}
+	return VenueContainer{
+		Kind:        kind,
+		ContainerID: row.ChatGuid,
+	}, nil
+}
+
+// GChatVenueContainerReader reads the Google Chat space/thread container off a
+// comms_message staging row.
+type GChatVenueContainerReader struct{}
+
+// NewGChatVenueContainerReader builds the reader.
+func NewGChatVenueContainerReader() *GChatVenueContainerReader {
+	return &GChatVenueContainerReader{}
+}
+
+// ContainerForMessageTx implements VenueContainerReader for gchat.
+func (r *GChatVenueContainerReader) ContainerForMessageTx(ctx context.Context, tx pgx.Tx, messageID uuid.UUID) (VenueContainer, error) {
+	row, err := db.New(tx).GetCommsMessageContainer(ctx, uuidToPgUUID(messageID))
+	if err != nil {
+		return VenueContainer{}, err
+	}
+	var containerID string
+	if row.ThreadID.Valid {
+		containerID = row.ThreadID.String
+	}
+	return VenueContainer{
+		Kind:        VenueKindGroupChat,
+		ContainerID: containerID,
+	}, nil
+}

--- a/backend/internal/service/ingest.go
+++ b/backend/internal/service/ingest.go
@@ -2215,8 +2215,8 @@ func (s *IngestService) handleMeetingNoteRecorded(
 		// interactions belong to the same session): reuse the linked gcal meeting
 		// venue when this note links to an event, else mint a session venue. Used
 		// for BOTH retained interactions (whose linkage may have changed on this
-		// re-sync) and newly-added ones. Best-effort — a resolution error leaves
-		// venue_id NULL.
+		// re-sync) and newly-added ones. An unwired resolver / unresolvable linked
+		// event leaves venue_id NULL; a real DB error rejects the event below.
 		sessionVenueID, venueErr := resolveAnarlogSessionVenue(ctx, tx, s.venue, sessionID, finalLinkedKind, finalLinkedID)
 		if venueErr != nil {
 			return nil, nil, &IngestPerEventRejection{

--- a/backend/internal/service/ingest.go
+++ b/backend/internal/service/ingest.go
@@ -2217,11 +2217,23 @@ func (s *IngestService) handleMeetingNoteRecorded(
 		// for BOTH retained interactions (whose linkage may have changed on this
 		// re-sync) and newly-added ones. An unwired resolver / unresolvable linked
 		// event leaves venue_id NULL; a real DB error rejects the event below.
-		sessionVenueID, venueErr := resolveAnarlogSessionVenue(ctx, tx, s.venue, sessionID, finalLinkedKind, finalLinkedID)
-		if venueErr != nil {
-			return nil, nil, &IngestPerEventRejection{
-				Code:    ingestRejectInteractionWriteFailed,
-				Message: fmt.Sprintf("resolve session venue: %s", venueErr.Error()),
+		//
+		// GATED on len(desiredByRef) > 0: both the in-both update loop and the
+		// to-add loop iterate desiredByRef, so when there are NO desired
+		// interactions (e.g. decideLinkage returned an orphan-needs-review /
+		// conflict-pending state with no walk-ins) nothing would consume the venue
+		// — and resolveAnarlogSessionVenue CREATES a node, so resolving it here
+		// would mint an unreferenced venue node onto the DB. Only resolve when an
+		// interaction will actually carry the venue_id.
+		var sessionVenueID *uuid.UUID
+		if len(desiredByRef) > 0 {
+			var venueErr error
+			sessionVenueID, venueErr = resolveAnarlogSessionVenue(ctx, tx, s.venue, sessionID, finalLinkedKind, finalLinkedID)
+			if venueErr != nil {
+				return nil, nil, &IngestPerEventRejection{
+					Code:    ingestRejectInteractionWriteFailed,
+					Message: fmt.Sprintf("resolve session venue: %s", venueErr.Error()),
+				}
 			}
 		}
 		// to_drop = existing \ desired

--- a/backend/internal/service/ingest.go
+++ b/backend/internal/service/ingest.go
@@ -334,6 +334,28 @@ type IngestService struct {
 	// wired post-construction via SetAddressBookReconciler so the big
 	// NewIngestService signature is unchanged.
 	addressBookReconciler AddressBookReconciler
+	// venue resolves the shared-container venue node for phone-call and
+	// anarlog-session interactions, so venue_id is set atomically with the
+	// insert. Optional (nil-safe); wired post-construction via SetVenueResolver
+	// to keep the NewIngestService signature unchanged.
+	venue IngestVenueResolver
+}
+
+// IngestVenueResolver is the venue-resolution surface the phone-call and
+// anarlog-session recorders need: resolve a container the recorder already has
+// in hand (phone call_unique_id, anarlog session id), and resolve the meeting
+// venue of a linked calendar_event (anarlog→gcal reuse). Satisfied by
+// *repository.VenueResolverRegistry.
+type IngestVenueResolver interface {
+	ResolveVenueForInteractionTx(ctx context.Context, tx pgx.Tx, source, kind, containerKey, title string) (uuid.UUID, error)
+	ResolveGCalVenueTx(ctx context.Context, tx pgx.Tx, calendarEventID uuid.UUID) (*uuid.UUID, error)
+}
+
+// SetVenueResolver injects the venue resolver. Optional — when unset, the
+// phone-call and anarlog recorders record interactions with a NULL venue_id.
+// Mirrors SetAddressBookReconciler's post-construction injection.
+func (s *IngestService) SetVenueResolver(v IngestVenueResolver) {
+	s.venue = v
 }
 
 // SetAddressBookReconciler injects the post-commit address-book method
@@ -2238,6 +2260,17 @@ func (s *IngestService) handleMeetingNoteRecorded(
 		// cadence + follow-up evaluation fire correctly). Capture the
 		// FollowUpFn closures so the dispatch loop can run them after
 		// the outer tx commits.
+		// Resolve the session venue once for the whole batch (all desired
+		// interactions belong to the same session): reuse the linked gcal
+		// meeting venue when this note links to an event, else mint a session
+		// venue. Best-effort — a resolution error leaves venue_id NULL.
+		sessionVenueID, venueErr := resolveAnarlogSessionVenue(ctx, tx, s.venue, sessionID, finalLinkedKind, finalLinkedID)
+		if venueErr != nil {
+			return nil, nil, &IngestPerEventRejection{
+				Code:    ingestRejectInteractionWriteFailed,
+				Message: fmt.Sprintf("resolve session venue: %s", venueErr.Error()),
+			}
+		}
 		for ref, d := range desiredByRef {
 			if _, have := existingByRef[ref]; have {
 				continue
@@ -2250,6 +2283,7 @@ func (s *IngestService) handleMeetingNoteRecorded(
 				OccurredAt:  p.MeetingAt,
 				Description: p.Title,
 				Direction:   repository.InteractionDirectionMutual,
+				VenueID:     sessionVenueID,
 			}
 			res, err := s.contactSvc.RecordInteractionTx(ctx, tx, false, req)
 			if err != nil {
@@ -2332,6 +2366,40 @@ func (s *IngestService) handleMeetingNoteRecorded(
 		Msg("meeting_note linkage decision")
 
 	return needs, followUps, nil
+}
+
+// resolveAnarlogSessionVenue resolves the venue node id for an anarlog session's
+// interactions. When the note links to a calendar event (linked_kind='event')
+// the session REUSES that event's meeting venue (the only cross-source venue
+// merge); otherwise it mints/finds a session venue keyed on the session id.
+// Best-effort: returns (nil, nil) when the venue resolver is unwired or the
+// linked gcal venue can't be resolved, so the interaction records with a NULL
+// venue_id rather than failing. Only a real DB error propagates. Shared by the
+// ingest inline handler and MeetingNoteService's resolve-link path.
+func resolveAnarlogSessionVenue(
+	ctx context.Context, tx pgx.Tx, venue IngestVenueResolver, sessionID uuid.UUID, linkedKind *string, linkedID *uuid.UUID,
+) (*uuid.UUID, error) {
+	if venue == nil {
+		return nil, nil
+	}
+	// Linked to a calendar event → reuse the gcal meeting venue.
+	if linkedKind != nil && *linkedKind == repository.LinkedKindEvent && linkedID != nil {
+		venueID, err := venue.ResolveGCalVenueTx(ctx, tx, *linkedID)
+		if err != nil {
+			return nil, err
+		}
+		if venueID != nil {
+			return venueID, nil
+		}
+		// Linked event venue couldn't be resolved (event row gone) → fall
+		// through to a session venue so the session still gets a container.
+	}
+	venueID, err := venue.ResolveVenueForInteractionTx(
+		ctx, tx, repository.InteractionSourceAnarlogSessions, repository.VenueKindSession, sessionID.String(), "")
+	if err != nil {
+		return nil, err
+	}
+	return &venueID, nil
 }
 
 // coalesceCandidates collapses semantically-identical linkage candidates

--- a/backend/internal/service/ingest.go
+++ b/backend/internal/service/ingest.go
@@ -2391,6 +2391,15 @@ func (s *IngestService) handleMeetingNoteRecorded(
 // unwired or the linked gcal venue can't be resolved (e.g. the event row is
 // gone). A real DB error propagates so the caller rolls back. Shared by the
 // ingest inline handler and MeetingNoteService's resolve-link path.
+//
+// Backfill↔live asymmetry (intentional, documented): the live path CREATES the
+// gcal meeting venue if it doesn't exist yet (via ResolveGCalVenueTx), while the
+// 069 backfill Step-1 only REUSES an already-existing gcal meeting venue (which
+// requires a backfilled gcal interaction for that event). So a linked anarlog
+// session whose calendar_event has no gcal interaction gets a meeting venue live
+// but a session venue from the backfill. Node ids stay deterministic so the
+// common case (gcal interaction present) converges; the edge case just mints a
+// different venue node — every session still gets a venue, no data corruption.
 func resolveAnarlogSessionVenue(
 	ctx context.Context, tx pgx.Tx, venue IngestVenueResolver, sessionID uuid.UUID, linkedKind *string, linkedID *uuid.UUID,
 ) (*uuid.UUID, error) {

--- a/backend/internal/service/ingest.go
+++ b/backend/internal/service/ingest.go
@@ -221,6 +221,7 @@ type PhoneCallLinkageReader interface {
 type InteractionWriter interface {
 	ListSessionAttributedInteractionsTx(ctx context.Context, tx pgx.Tx, sourceRefPrefix string) ([]repository.Interaction, error)
 	SoftDeleteInteractionTx(ctx context.Context, tx pgx.Tx, id uuid.UUID) error
+	UpdateInteractionVenueTx(ctx context.Context, tx pgx.Tx, id uuid.UUID, venueID *uuid.UUID) error
 }
 
 // AnarlogIdentityLookup is the narrow surface used by the
@@ -2210,6 +2211,19 @@ func (s *IngestService) handleMeetingNoteRecorded(
 		for _, d := range desired {
 			desiredByRef[d.SourceRef] = d
 		}
+		// Resolve the session venue once for the whole batch (all desired
+		// interactions belong to the same session): reuse the linked gcal meeting
+		// venue when this note links to an event, else mint a session venue. Used
+		// for BOTH retained interactions (whose linkage may have changed on this
+		// re-sync) and newly-added ones. Best-effort — a resolution error leaves
+		// venue_id NULL.
+		sessionVenueID, venueErr := resolveAnarlogSessionVenue(ctx, tx, s.venue, sessionID, finalLinkedKind, finalLinkedID)
+		if venueErr != nil {
+			return nil, nil, &IngestPerEventRejection{
+				Code:    ingestRejectInteractionWriteFailed,
+				Message: fmt.Sprintf("resolve session venue: %s", venueErr.Error()),
+			}
+		}
 		// to_drop = existing \ desired
 		for ref, x := range existingByRef {
 			if _, want := desiredByRef[ref]; want {
@@ -2240,6 +2254,18 @@ func (s *IngestService) handleMeetingNoteRecorded(
 			if !have {
 				continue
 			}
+			// Move a retained interaction to the (possibly re-resolved) session
+			// venue when its linkage changed on this re-sync (e.g. session ->
+			// gcal event). venue_id is not a cadence column, so this is a plain
+			// update separate from the content refresh below.
+			if !uuidPtrEqual(x.VenueID, sessionVenueID) {
+				if err := s.interactions.UpdateInteractionVenueTx(ctx, tx, x.ID, sessionVenueID); err != nil {
+					return nil, nil, &IngestPerEventRejection{
+						Code:    ingestRejectInteractionWriteFailed,
+						Message: fmt.Sprintf("update session interaction venue: %s", err.Error()),
+					}
+				}
+			}
 			needsRefresh := !x.OccurredAt.Equal(p.MeetingAt) ||
 				!stringPtrEqual(x.Description, p.Title)
 			if !needsRefresh {
@@ -2259,18 +2285,7 @@ func (s *IngestService) handleMeetingNoteRecorded(
 		// to_add = desired \ existing (route through ContactService so
 		// cadence + follow-up evaluation fire correctly). Capture the
 		// FollowUpFn closures so the dispatch loop can run them after
-		// the outer tx commits.
-		// Resolve the session venue once for the whole batch (all desired
-		// interactions belong to the same session): reuse the linked gcal
-		// meeting venue when this note links to an event, else mint a session
-		// venue. Best-effort — a resolution error leaves venue_id NULL.
-		sessionVenueID, venueErr := resolveAnarlogSessionVenue(ctx, tx, s.venue, sessionID, finalLinkedKind, finalLinkedID)
-		if venueErr != nil {
-			return nil, nil, &IngestPerEventRejection{
-				Code:    ingestRejectInteractionWriteFailed,
-				Message: fmt.Sprintf("resolve session venue: %s", venueErr.Error()),
-			}
-		}
+		// the outer tx commits. sessionVenueID was resolved above.
 		for ref, d := range desiredByRef {
 			if _, have := existingByRef[ref]; have {
 				continue
@@ -2372,9 +2387,9 @@ func (s *IngestService) handleMeetingNoteRecorded(
 // interactions. When the note links to a calendar event (linked_kind='event')
 // the session REUSES that event's meeting venue (the only cross-source venue
 // merge); otherwise it mints/finds a session venue keyed on the session id.
-// Best-effort: returns (nil, nil) when the venue resolver is unwired or the
-// linked gcal venue can't be resolved, so the interaction records with a NULL
-// venue_id rather than failing. Only a real DB error propagates. Shared by the
+// Returns (nil, nil) — record with NULL venue_id — when the venue resolver is
+// unwired or the linked gcal venue can't be resolved (e.g. the event row is
+// gone). A real DB error propagates so the caller rolls back. Shared by the
 // ingest inline handler and MeetingNoteService's resolve-link path.
 func resolveAnarlogSessionVenue(
 	ctx context.Context, tx pgx.Tx, venue IngestVenueResolver, sessionID uuid.UUID, linkedKind *string, linkedID *uuid.UUID,
@@ -2893,6 +2908,18 @@ func (s *IngestService) handleMeetingNoteDeleted(
 // stringPtrEqual reports whether two *string pointers point to the
 // same string value (nil == nil; nil != "x").
 func stringPtrEqual(a, b *string) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}
+
+// uuidPtrEqual reports whether two *uuid.UUID pointers point to the same value
+// (nil == nil; nil != a set id).
+func uuidPtrEqual(a, b *uuid.UUID) bool {
 	if a == nil && b == nil {
 		return true
 	}

--- a/backend/internal/service/ingest_call.go
+++ b/backend/internal/service/ingest_call.go
@@ -249,6 +249,20 @@ func (s *IngestService) handleCall(
 		Description: &descCopy,
 		Direction:   interactionDirection,
 	}
+	// Resolve the call venue from the call's unique id, set atomically with the
+	// insert. Best-effort: a resolution error leaves venue_id NULL rather than
+	// rejecting the call.
+	if s.venue != nil {
+		venueID, venueErr := s.venue.ResolveVenueForInteractionTx(
+			ctx, tx, repository.InteractionSourcePhoneCalls, repository.VenueKindCall, p.CallUniqueID, "")
+		if venueErr != nil {
+			return nil, &IngestPerEventRejection{
+				Code:    ingestRejectStagingUpsertFailed,
+				Message: fmt.Sprintf("resolve call venue: %s", venueErr.Error()),
+			}
+		}
+		recReq.VenueID = &venueID
+	}
 
 	res, err := s.contactRecorder.RecordInteractionTx(ctx, tx, true, recReq)
 	if err != nil {

--- a/backend/internal/service/ingest_call.go
+++ b/backend/internal/service/ingest_call.go
@@ -250,8 +250,8 @@ func (s *IngestService) handleCall(
 		Direction:   interactionDirection,
 	}
 	// Resolve the call venue from the call's unique id, set atomically with the
-	// insert. Best-effort: a resolution error leaves venue_id NULL rather than
-	// rejecting the call.
+	// insert. A real DB error rejects the event (the batch retries); an unwired
+	// resolver leaves venue_id NULL.
 	if s.venue != nil {
 		venueID, venueErr := s.venue.ResolveVenueForInteractionTx(
 			ctx, tx, repository.InteractionSourcePhoneCalls, repository.VenueKindCall, p.CallUniqueID, "")

--- a/backend/internal/service/meeting_note.go
+++ b/backend/internal/service/meeting_note.go
@@ -279,7 +279,10 @@ func (s *MeetingNoteService) resolveToLinked(ctx context.Context, tx pgx.Tx, pri
 	}
 
 	walkins := stepFiveWalkins(*candidate, resolvedTagged, prior.AnarlogSessionID)
-	created, followUps, err := s.writeDesiredInteractions(ctx, tx, prior, walkins)
+	// Use the candidate being linked (input.Kind/input.ID) for venue resolution,
+	// NOT prior's stale linkage — the link is written below (ResolveMeetingNoteToLinkedTx)
+	// in this same tx, so an event-linked session reuses the gcal meeting venue.
+	created, followUps, err := s.writeDesiredInteractions(ctx, tx, prior, &input.Kind, &input.ID, walkins)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -365,7 +368,8 @@ func (s *MeetingNoteService) resolveNoneOfThese(ctx context.Context, tx pgx.Tx, 
 		titleMatched,
 	)
 
-	created, followUps, err := s.writeDesiredInteractions(ctx, tx, prior, desired)
+	// none_of_these → no calendar link → a session venue (nil linkage).
+	created, followUps, err := s.writeDesiredInteractions(ctx, tx, prior, nil, nil, desired)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -480,7 +484,8 @@ func (s *MeetingNoteService) resolveOrphanToImpromptu(ctx context.Context, tx pg
 		return nil, nil, nil, fmt.Errorf("compute resolved set hash: %w", err)
 	}
 
-	created, followUps, err := s.writeDesiredInteractions(ctx, tx, prior, desired)
+	// orphan → impromptu → no calendar link → a session venue (nil linkage).
+	created, followUps, err := s.writeDesiredInteractions(ctx, tx, prior, nil, nil, desired)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -537,7 +542,14 @@ func (s *MeetingNoteService) reResolveTagged(ctx context.Context, tx pgx.Tx, par
 // ContactInteractionRecorder.RecordInteractionTx so cadence + follow-up
 // state apply correctly. Returns the materialized list for the response
 // PLUS the post-commit follow-up closures.
-func (s *MeetingNoteService) writeDesiredInteractions(ctx context.Context, tx pgx.Tx, prior *repository.MeetingNote, desired []desiredInteraction) ([]CreatedInteraction, []func(context.Context), error) {
+//
+// linkedKind/linkedID are the EFFECTIVE post-resolution linkage for venue
+// resolution — NOT necessarily prior.LinkedKind/LinkedID, which may be stale in
+// the resolve-link path (the link is written later in the same tx). The
+// resolve-to-candidate caller passes the candidate it is linking to so an
+// event-linked session reuses the gcal meeting venue; the none/impromptu callers
+// pass nil so the session gets its own venue.
+func (s *MeetingNoteService) writeDesiredInteractions(ctx context.Context, tx pgx.Tx, prior *repository.MeetingNote, linkedKind *string, linkedID *uuid.UUID, desired []desiredInteraction) ([]CreatedInteraction, []func(context.Context), error) {
 	if s.contactRecorder == nil || len(desired) == 0 {
 		return nil, nil, nil
 	}
@@ -545,7 +557,7 @@ func (s *MeetingNoteService) writeDesiredInteractions(ctx context.Context, tx pg
 	var followUps []func(context.Context)
 	// Resolve the session venue once (all desired interactions share the
 	// session): reuse a linked gcal meeting venue, else mint a session venue.
-	sessionVenueID, venueErr := resolveAnarlogSessionVenue(ctx, tx, s.venue, prior.AnarlogSessionID, prior.LinkedKind, prior.LinkedID)
+	sessionVenueID, venueErr := resolveAnarlogSessionVenue(ctx, tx, s.venue, prior.AnarlogSessionID, linkedKind, linkedID)
 	if venueErr != nil {
 		return nil, nil, fmt.Errorf("resolve session venue: %w", venueErr)
 	}

--- a/backend/internal/service/meeting_note.go
+++ b/backend/internal/service/meeting_note.go
@@ -95,6 +95,18 @@ type MeetingNoteService struct {
 	titleDiscovery  IngestTitleDiscoveryWriter
 	contactRecorder ContactInteractionRecorder
 	contactNames    ContactNameReader
+	// venue resolves the session venue (reusing a linked gcal meeting venue, or
+	// minting a session venue) so resolve-link-path interactions get venue_id
+	// set atomically. Optional (nil-safe); wired post-construction via
+	// SetVenueResolver. Same surface IngestService uses.
+	venue IngestVenueResolver
+}
+
+// SetVenueResolver injects the venue resolver used to populate venue_id on the
+// resolve-link interaction path. Optional — when unset, those interactions get
+// a NULL venue_id.
+func (s *MeetingNoteService) SetVenueResolver(v IngestVenueResolver) {
+	s.venue = v
 }
 
 // NewMeetingNoteService constructs a MeetingNoteService bound to its
@@ -531,6 +543,12 @@ func (s *MeetingNoteService) writeDesiredInteractions(ctx context.Context, tx pg
 	}
 	created := make([]CreatedInteraction, 0, len(desired))
 	var followUps []func(context.Context)
+	// Resolve the session venue once (all desired interactions share the
+	// session): reuse a linked gcal meeting venue, else mint a session venue.
+	sessionVenueID, venueErr := resolveAnarlogSessionVenue(ctx, tx, s.venue, prior.AnarlogSessionID, prior.LinkedKind, prior.LinkedID)
+	if venueErr != nil {
+		return nil, nil, fmt.Errorf("resolve session venue: %w", venueErr)
+	}
 	for _, d := range desired {
 		sourceRef := d.SourceRef
 		req := repository.RecordInteractionRequest{
@@ -540,6 +558,7 @@ func (s *MeetingNoteService) writeDesiredInteractions(ctx context.Context, tx pg
 			OccurredAt:  prior.MeetingAt,
 			Description: prior.Title,
 			Direction:   repository.InteractionDirectionMutual,
+			VenueID:     sessionVenueID,
 		}
 		res, err := s.contactRecorder.RecordInteractionTx(ctx, tx, false, req)
 		if err != nil {

--- a/backend/internal/synthetic/replay/gcal.go
+++ b/backend/internal/synthetic/replay/gcal.go
@@ -142,5 +142,8 @@ func (h *Harness) ReplayGCal(ctx context.Context, contactID uuid.UUID, spec fact
 		return GCalResult{}, err
 	}
 	h.trackContactInteractions(ctx, contactID)
+	if err := h.assertContactVenue(ctx, contactID, repository.InteractionSourceGCal); err != nil {
+		return GCalResult{}, err
+	}
 	return GCalResult{ContactID: contactID, GcalEventID: spec.GcalEventID, Matched: true}, nil
 }

--- a/backend/internal/synthetic/replay/gchat.go
+++ b/backend/internal/synthetic/replay/gchat.go
@@ -94,5 +94,8 @@ func (h *Harness) ReplayGChat(ctx context.Context, contactID uuid.UUID, spec fac
 		return GChatResult{}, err
 	}
 	h.trackContactInteractions(ctx, contactID)
+	if err := h.assertContactVenue(ctx, contactID, repository.InteractionSourceGChat); err != nil {
+		return GChatResult{}, err
+	}
 	return GChatResult{ContactID: contactID, ExternalID: spec.ExternalID, Matched: true}, nil
 }

--- a/backend/internal/synthetic/replay/gmail.go
+++ b/backend/internal/synthetic/replay/gmail.go
@@ -74,5 +74,8 @@ func (h *Harness) ReplayGmail(ctx context.Context, contactID uuid.UUID, spec fac
 		return GmailResult{}, err
 	}
 	h.trackContactInteractions(ctx, contactID)
+	if err := h.assertContactVenue(ctx, contactID, repository.InteractionSourceEmail); err != nil {
+		return GmailResult{}, err
+	}
 	return GmailResult{ContactID: contactID, ExternalID: spec.ExternalID, Matched: true}, nil
 }

--- a/backend/internal/synthetic/replay/harness_cleanup.go
+++ b/backend/internal/synthetic/replay/harness_cleanup.go
@@ -259,6 +259,19 @@ func (h *Harness) cleanup(ctx context.Context) error {
 		_, err := h.support.DeleteNodesByIds(ctx, c.contactIDs)
 		return err
 	})
+	// 13b. venue node (interaction.venue_id → node): the real recorders mint a
+	// venue node per distinct container on the replay path. They are not contacts
+	// (so person_node misses them) and have an empty canonical_label (so the
+	// ns-prefix node delete misses them), so cleanup deletes them by the tracked
+	// id set. Ordered AFTER the interaction delete (step 2) so the
+	// interaction→venue restrict FK is already clear; the delete is additionally
+	// guarded NOT EXISTS any remaining interaction, so a venue shared with an
+	// un-cleaned interaction is left intact rather than FK-violating. The venue
+	// subtype row cascades on the node delete.
+	step("venue_node", func() error {
+		_, err := h.support.DeleteVenueNodesByIds(ctx, c.venueNodeIDs)
+		return err
+	})
 	// meeting_note scoped to the seeded synthetic host, BEFORE the mac_host
 	// delete. A profile may seed orphan_needs_review meeting_note rows against
 	// this host; the mac_host FK is ON DELETE SET NULL, so deleting the host
@@ -282,6 +295,14 @@ func (h *Harness) cleanup(ctx context.Context) error {
 // cleanup emptied the namespace).
 func (h *Harness) ContactsRemaining(ctx context.Context) (int64, error) {
 	return h.support.CountContactsByIds(ctx, h.snapshotContactIDs())
+}
+
+// VenueNodesRemaining counts how many of THIS run's tracked venue nodes still
+// exist (test assertion that cleanup removed the venue nodes the real recorders
+// minted on the replay path). Scoped to the tracked ids, so it is immune to
+// parallel tests creating their own venue nodes on the shared DB.
+func (h *Harness) VenueNodesRemaining(ctx context.Context) (int64, error) {
+	return h.support.CountVenueNodesByIds(ctx, h.snapshotVenueNodeIDs())
 }
 
 // --- deferred shim workers (bus needs client; real workers need bus) -------

--- a/backend/internal/synthetic/replay/harness_setup.go
+++ b/backend/internal/synthetic/replay/harness_setup.go
@@ -199,7 +199,22 @@ func newHarness(ctx context.Context, database *db.Database, namespace string, se
 		repository.InteractionSourceGChat:    repository.NewCommsSessionStagingProcessor(commsRepo),
 	})
 
+	// Venue resolver: populates interaction.venue_id so replay adapters can
+	// assert a venue node was created for each venue-bearing source. Mirrors the
+	// main.go wiring.
+	venueRepo := repository.NewVenueRepository(database.Queries)
+	venueResolver := repository.NewVenueResolverRegistry(
+		venueRepo,
+		map[string]repository.VenueContainerReader{
+			repository.InteractionSourceTelegram: repository.NewTelegramVenueContainerReader(),
+			repository.InteractionSourceMessages: repository.NewMessagesVenueContainerReader(),
+			repository.InteractionSourceGChat:    repository.NewGChatVenueContainerReader(),
+		},
+		calendarEventRepo,
+	)
+
 	recorder := consumer.NewInteractionRecorder(contactService, stagingRegistry, bus, cadenceUpdater, nil, calendarEventRepo)
+	recorder.SetVenueResolver(venueResolver)
 	recorderShim.real = consumer.NewInteractionRecorderWorker(bus, database.Pool, recorder, nil)
 	cadenceShim.real = consumer.NewCadenceUpdaterWorker(bus, database.Pool, cadenceUpdater)
 
@@ -224,6 +239,7 @@ func newHarness(ctx context.Context, database *db.Database, namespace string, se
 		contactService, commsRepo, interactionRepo, contactService,
 		bus, cadenceUpdater, followUpManager,
 	)
+	emailConsumer.SetVenueResolver(venueRepo)
 	emailShim.real = consumer.NewEmailInteractionConsumerWorker(bus, database.Pool, emailConsumer)
 
 	// Messaging aggregate worker: engines for source=messages (iMessage) +
@@ -289,6 +305,7 @@ func newHarness(ctx context.Context, database *db.Database, namespace string, se
 		externalRepo:    externalRepo,
 		telegramRepo:    telegramRepo,
 		messagesRepo:    messagesRepo,
+		venueRepo:       venueRepo,
 		identityService: identityService,
 		contactService:  contactService,
 		cadenceUpdater:  cadenceUpdater,

--- a/backend/internal/synthetic/replay/helpers.go
+++ b/backend/internal/synthetic/replay/helpers.go
@@ -99,8 +99,13 @@ func (h *Harness) assertContactVenue(ctx context.Context, contactID uuid.UUID, e
 }
 
 // trackContactInteractions records the contact's interaction ids into the ledger
-// so Cleanup deletes them by id (step 2) before the contact delete. Best-effort:
-// a read error leaves the by-contact path to cover them.
+// so Cleanup deletes them by id (step 2) before the contact delete. It ALSO
+// records each interaction's venue_id (the venue node the real recorder minted)
+// so Cleanup can delete those venue nodes by id — they are not contacts and have
+// an empty canonical_label, so neither the person-node nor the ns-prefix node
+// delete catches them. Best-effort: a read error leaves the by-contact path to
+// cover interactions; venue nodes whose interaction wasn't tracked are caught by
+// no other path, which is why we track them here on the same scan.
 func (h *Harness) trackContactInteractions(ctx context.Context, contactID uuid.UUID) {
 	rows, err := h.interactionRepo.ListContactInteractions(ctx, contactID, 100, 0)
 	if err != nil {
@@ -109,6 +114,9 @@ func (h *Harness) trackContactInteractions(ctx context.Context, contactID uuid.U
 	h.track(func(c *created) {
 		for _, r := range rows {
 			c.addInteraction(r.ID)
+			if r.VenueID != nil {
+				c.addVenueNode(*r.VenueID)
+			}
 		}
 	})
 }

--- a/backend/internal/synthetic/replay/helpers.go
+++ b/backend/internal/synthetic/replay/helpers.go
@@ -70,12 +70,17 @@ func (h *Harness) gcalSettled(gcalEventID string, contactID uuid.UUID) gateA {
 
 // assertContactVenue verifies that the contact has at least one interaction of
 // the given source whose venue_id resolves to a live venue node. Called by the
-// venue-bearing replay adapters (telegram/messages/gchat/email/gcal/anarlog)
-// after settle so a replay fails loudly if the venue-populating recorder path
-// silently stopped setting venue_id. Returns an error (not a panic) so the
-// adapter surfaces it like any other replay failure. expectedSource scopes the
-// check to this replay's source so an unrelated prior interaction can't satisfy
-// it.
+// replay adapters that drive a venue-bearing recorder through the bus
+// (telegram/messages/gchat/email/gcal) after settle, so a replay fails loudly if
+// the venue-populating recorder path silently stopped setting venue_id. Returns
+// an error (not a panic) so the adapter surfaces it like any other replay
+// failure. expectedSource scopes the check to this replay's source so an
+// unrelated prior interaction can't satisfy it.
+//
+// phone_calls + anarlog_sessions have NO replay adapter (they are ingest-driven
+// via IngestService.handleCall / handleMeetingNoteRecorded, not a Replay* path),
+// so their live venue population is instead covered by the ingest integration
+// tests and the venue backfill integration test's per-source seeds.
 func (h *Harness) assertContactVenue(ctx context.Context, contactID uuid.UUID, expectedSource string) error {
 	rows, err := h.interactionRepo.ListContactInteractions(ctx, contactID, 100, 0)
 	if err != nil {

--- a/backend/internal/synthetic/replay/helpers.go
+++ b/backend/internal/synthetic/replay/helpers.go
@@ -3,6 +3,7 @@ package replay
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"personal-crm/backend/internal/accelerated"
@@ -65,6 +66,31 @@ func (h *Harness) gcalSettled(gcalEventID string, contactID uuid.UUID) gateA {
 		n, err := h.support.CountProcessedCalendarEventByGcalID(ctx, gcalEventID, contactID)
 		return n > 0, err
 	}
+}
+
+// assertContactVenue verifies that the contact has at least one interaction of
+// the given source whose venue_id resolves to a live venue node. Called by the
+// venue-bearing replay adapters (telegram/messages/gchat/email/gcal/anarlog)
+// after settle so a replay fails loudly if the venue-populating recorder path
+// silently stopped setting venue_id. Returns an error (not a panic) so the
+// adapter surfaces it like any other replay failure. expectedSource scopes the
+// check to this replay's source so an unrelated prior interaction can't satisfy
+// it.
+func (h *Harness) assertContactVenue(ctx context.Context, contactID uuid.UUID, expectedSource string) error {
+	rows, err := h.interactionRepo.ListContactInteractions(ctx, contactID, 100, 0)
+	if err != nil {
+		return fmt.Errorf("list interactions for venue assert: %w", err)
+	}
+	for _, r := range rows {
+		if r.Source != expectedSource || r.VenueID == nil {
+			continue
+		}
+		if _, err := h.venueRepo.GetVenue(ctx, *r.VenueID); err != nil {
+			return fmt.Errorf("interaction %s venue %s not found: %w", r.ID, *r.VenueID, err)
+		}
+		return nil // found a source-matched interaction with a live venue
+	}
+	return fmt.Errorf("no %s interaction with a venue for contact %s", expectedSource, contactID)
 }
 
 // trackContactInteractions records the contact's interaction ids into the ledger

--- a/backend/internal/synthetic/replay/ingest.go
+++ b/backend/internal/synthetic/replay/ingest.go
@@ -110,5 +110,8 @@ func (h *Harness) ReplayIMessage(ctx context.Context, contactID uuid.UUID, spec 
 		return IMessageResult{}, err
 	}
 	h.trackContactInteractions(ctx, contactID)
+	if err := h.assertContactVenue(ctx, contactID, repository.InteractionSourceMessages); err != nil {
+		return IMessageResult{}, err
+	}
 	return IMessageResult{ContactID: contactID, Guid: spec.Guid, Matched: true}, nil
 }

--- a/backend/internal/synthetic/replay/replay.go
+++ b/backend/internal/synthetic/replay/replay.go
@@ -118,6 +118,7 @@ type Harness struct {
 	externalRepo    *repository.ExternalContactRepository
 	telegramRepo    *repository.TelegramMessageRepository
 	messagesRepo    *repository.MessagesMessageRepository
+	venueRepo       *repository.VenueRepository
 	identityService *service.IdentityService
 	contactService  *service.ContactService
 	cadenceUpdater  *consumer.CadenceUpdater
@@ -161,6 +162,26 @@ func (h *Harness) ExternalContactRepo() *repository.ExternalContactRepository {
 }
 func (h *Harness) TelegramRepo() *repository.TelegramMessageRepository { return h.telegramRepo }
 func (h *Harness) MessagesRepo() *repository.MessagesMessageRepository { return h.messagesRepo }
+func (h *Harness) VenueRepo() *repository.VenueRepository              { return h.venueRepo }
+
+// AssertInteractionHasVenue fetches the interaction by id and verifies it has a
+// venue_id pointing at a live venue node. Used by the replay adapters to assert
+// the venue-populating recorder paths created a venue. Returns the resolved
+// Venue on success.
+func (h *Harness) AssertInteractionHasVenue(ctx context.Context, interactionID uuid.UUID) (*repository.Venue, error) {
+	interaction, err := h.interactionRepo.GetInteraction(ctx, interactionID)
+	if err != nil {
+		return nil, fmt.Errorf("get interaction %s: %w", interactionID, err)
+	}
+	if interaction.VenueID == nil {
+		return nil, fmt.Errorf("interaction %s has no venue_id", interactionID)
+	}
+	venue, err := h.venueRepo.GetVenue(ctx, *interaction.VenueID)
+	if err != nil {
+		return nil, fmt.Errorf("get venue %s for interaction %s: %w", *interaction.VenueID, interactionID, err)
+	}
+	return venue, nil
+}
 
 // MacHostID is the seeded revoked synthetic host id passed as hostID to ingest.
 func (h *Harness) MacHostID() uuid.UUID { return h.macHostID }

--- a/backend/internal/synthetic/replay/replay.go
+++ b/backend/internal/synthetic/replay/replay.go
@@ -82,6 +82,13 @@ type created struct {
 	// cleanup removes exactly them, even on cadence-bearing contacts the replay
 	// did not seed.
 	contactTaskIDs []uuid.UUID
+	// venueNodeIDs are venue node ids the real recorders minted on the replay
+	// path (interaction.venue_id → node). They are NOT contacts, so the
+	// person-node delete misses them, and their canonical_label is empty so the
+	// ns-prefix node delete misses them too — cleanup MUST delete them by id
+	// (after the interaction delete, which clears the restrict FK) or the shared
+	// DB leaks a venue node per distinct container.
+	venueNodeIDs []uuid.UUID
 	// directSources is the set of sources the adapters published root events
 	// under, so Cleanup can capture no-contact root events that the
 	// contact-scoped read misses.
@@ -94,6 +101,7 @@ func newCreated() *created {
 
 func (c *created) addContact(id uuid.UUID)       { c.contactIDs = append(c.contactIDs, id) }
 func (c *created) addInteraction(id uuid.UUID)   { c.interactionIDs = append(c.interactionIDs, id) }
+func (c *created) addVenueNode(id uuid.UUID)     { c.venueNodeIDs = append(c.venueNodeIDs, id) }
 func (c *created) addTelegramPeer(id int64)      { c.telegramPeerIDs = append(c.telegramPeerIDs, id) }
 func (c *created) addTelegramChat(id int64)      { c.telegramChatIDs = append(c.telegramChatIDs, id) }
 func (c *created) addContactTask(id uuid.UUID)   { c.contactTaskIDs = append(c.contactTaskIDs, id) }
@@ -408,6 +416,12 @@ func (h *Harness) snapshotContactIDs() []uuid.UUID {
 	h.createdMu.Lock()
 	defer h.createdMu.Unlock()
 	return append([]uuid.UUID(nil), h.created.contactIDs...)
+}
+
+func (h *Harness) snapshotVenueNodeIDs() []uuid.UUID {
+	h.createdMu.Lock()
+	defer h.createdMu.Unlock()
+	return append([]uuid.UUID(nil), h.created.venueNodeIDs...)
 }
 
 // gateBClear reports whether Gate B has reached zero for this replay's contacts.

--- a/backend/internal/synthetic/replay/telegram.go
+++ b/backend/internal/synthetic/replay/telegram.go
@@ -87,5 +87,8 @@ func (h *Harness) ReplayTelegram(ctx context.Context, contactID uuid.UUID, spec 
 		return TelegramResult{}, err
 	}
 	h.trackContactInteractions(ctx, contactID)
+	if err := h.assertContactVenue(ctx, contactID, repository.InteractionSourceTelegram); err != nil {
+		return TelegramResult{}, err
+	}
 	return TelegramResult{ContactID: contactID, PeerUserID: spec.PeerUserID, Matched: true}, nil
 }

--- a/backend/internal/synthetic/replay/telegram_group_test_support.go
+++ b/backend/internal/synthetic/replay/telegram_group_test_support.go
@@ -125,6 +125,9 @@ func (h *Harness) ReplayTelegramGroup(ctx context.Context, contactID uuid.UUID, 
 		return TelegramGroupResult{}, err
 	}
 	h.trackContactInteractions(ctx, contactID)
+	if err := h.assertContactVenue(ctx, contactID, repository.InteractionSourceTelegram); err != nil {
+		return TelegramGroupResult{}, err
+	}
 	return TelegramGroupResult{ContactID: contactID, ChatID: spec.ChatID, SenderUserID: spec.SenderUserID, Matched: true, Tracked: true}, nil
 }
 
@@ -163,6 +166,9 @@ func (h *Harness) ReplayTelegramGroupMessages(ctx context.Context, contactID uui
 		return TelegramGroupResult{}, err
 	}
 	h.trackContactInteractions(ctx, contactID)
+	if err := h.assertContactVenue(ctx, contactID, repository.InteractionSourceTelegram); err != nil {
+		return TelegramGroupResult{}, err
+	}
 	return TelegramGroupResult{ContactID: contactID, ChatID: last.ChatID, SenderUserID: last.SenderUserID, Matched: true, Tracked: true}, nil
 }
 

--- a/backend/migrations/069_interaction_venue.down.sql
+++ b/backend/migrations/069_interaction_venue.down.sql
@@ -6,10 +6,10 @@
 -- delete time is assertion/merge references only (NOT interaction.venue_id,
 -- which no longer exists): a venue node referenced by an assertion (or a
 -- merge-loser) is left intact, so the down degrades gracefully if the graph has
--- grown beyond this migration's seed. (The plan's interaction.venue_id-based
--- guard is subsumed: after the column drop, no interaction can reference a venue
--- node, so ALL backfilled venues become deletion candidates and only the
--- assertion/merge-load-bearing ones are kept.)
+-- grown beyond this migration's seed. An interaction.venue_id-based guard is
+-- moot here: after the column drop, no interaction can reference a venue node,
+-- so ALL backfilled venues become deletion candidates and only the
+-- assertion/merge-load-bearing ones are kept.
 --
 -- Wrapped in an explicit transaction for the same reason as the up: the
 -- postgres driver does not auto-wrap, and this drops a column AND deletes data.

--- a/backend/migrations/069_interaction_venue.down.sql
+++ b/backend/migrations/069_interaction_venue.down.sql
@@ -2,9 +2,14 @@
 --
 -- Drops the venue_id index + column, then removes the venue nodes the backfill
 -- created — but only those that have become non-load-bearing (guarded like the
--- person-node down in 068). A venue node still referenced by a live interaction
--- (via venue_id) or by an assertion is left intact, so the down degrades
--- gracefully if the graph has grown beyond this migration's seed.
+-- person-node down in 068). Because the column is dropped FIRST, the guard at
+-- delete time is assertion/merge references only (NOT interaction.venue_id,
+-- which no longer exists): a venue node referenced by an assertion (or a
+-- merge-loser) is left intact, so the down degrades gracefully if the graph has
+-- grown beyond this migration's seed. (The plan's interaction.venue_id-based
+-- guard is subsumed: after the column drop, no interaction can reference a venue
+-- node, so ALL backfilled venues become deletion candidates and only the
+-- assertion/merge-load-bearing ones are kept.)
 --
 -- Wrapped in an explicit transaction for the same reason as the up: the
 -- postgres driver does not auto-wrap, and this drops a column AND deletes data.

--- a/backend/migrations/069_interaction_venue.down.sql
+++ b/backend/migrations/069_interaction_venue.down.sql
@@ -1,0 +1,40 @@
+-- Reverse the venue model on interaction.
+--
+-- Drops the venue_id index + column, then removes the venue nodes the backfill
+-- created — but only those that have become non-load-bearing (guarded like the
+-- person-node down in 068). A venue node still referenced by a live interaction
+-- (via venue_id) or by an assertion is left intact, so the down degrades
+-- gracefully if the graph has grown beyond this migration's seed.
+--
+-- Wrapped in an explicit transaction for the same reason as the up: the
+-- postgres driver does not auto-wrap, and this drops a column AND deletes data.
+
+BEGIN;
+
+-- Drop the column first so no live interaction.venue_id reference can block the
+-- venue/node cleanup below. Dropping the column removes the FK to node, so the
+-- subsequent DELETE FROM venue/node only needs to guard against assertions.
+DROP INDEX IF EXISTS idx_interaction_venue_id;
+ALTER TABLE interaction DROP COLUMN IF EXISTS venue_id;
+
+-- Remove venue subtype rows whose node nothing else references. The venue→node
+-- FK is ON DELETE CASCADE, so deleting the node deletes the venue row too;
+-- delete the node and let the cascade clear the venue.
+DELETE FROM node
+WHERE type = 'venue'
+  -- Skip merge winners still pointed at by a preserved loser's merged_into
+  -- self-FK (restrict): without this guard the delete would FK-violate.
+  AND merged_into IS NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM node child
+    WHERE child.merged_into = node.id
+  )
+  -- Skip nodes any assertion references (subject or object): the assertion→node
+  -- FK is restrict, so deleting them would FK-violate / orphan history.
+  AND NOT EXISTS (
+    SELECT 1 FROM assertion a
+    WHERE a.subject_node_id = node.id
+       OR a.object_node_id = node.id
+  );
+
+COMMIT;

--- a/backend/migrations/069_interaction_venue.up.sql
+++ b/backend/migrations/069_interaction_venue.up.sql
@@ -280,6 +280,12 @@ WHERE i.source = 'gcal'
 -- mints a session venue for everything else.
 
 -- Step 1: REUSE the linked gcal meeting venue (the only cross-source merge).
+-- This only REUSES an already-existing gcal meeting venue (the JOIN to venue);
+-- a linked session whose calendar_event had no backfilled gcal interaction has
+-- no meeting venue yet, so it falls through to Step-2's session venue. The LIVE
+-- resolver (resolveAnarlogSessionVenue) instead CREATES the gcal meeting venue
+-- when missing — a documented, deterministic-id backfill↔live asymmetry for that
+-- edge case (every session still gets a venue; no corruption).
 UPDATE interaction i
 SET venue_id = ce_venue.node_id
 FROM meeting_note mn

--- a/backend/migrations/069_interaction_venue.up.sql
+++ b/backend/migrations/069_interaction_venue.up.sql
@@ -294,6 +294,9 @@ JOIN venue ce_venue
 WHERE i.source = 'anarlog_sessions'
   AND i.venue_id IS NULL AND i.deleted_at IS NULL
   AND i.source_ref IS NOT NULL
+  -- Guard the ::uuid cast: skip a malformed source_ref (segment 2 not a UUID)
+  -- rather than aborting the whole BEGIN..COMMIT migration on one bad row.
+  AND split_part(i.source_ref, ':', 2) ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
   AND mn.anarlog_session_id = split_part(i.source_ref, ':', 2)::uuid
   AND mn.deleted_at IS NULL
   AND mn.linked_kind = 'event';

--- a/backend/migrations/069_interaction_venue.up.sql
+++ b/backend/migrations/069_interaction_venue.up.sql
@@ -56,9 +56,9 @@ STRICT
 AS $$
     SELECT uuid_generate_v5(
         'a4f7c0e2-1b3d-4c6a-9e8f-2d5b7a1c0e94'::uuid,
-        length(p_source)::text || ':' || p_source || '|' ||
-        length(p_kind)::text || ':' || p_kind || '|' ||
-        length(p_container)::text || ':' || p_container
+        octet_length(p_source)::text || ':' || p_source || '|' ||
+        octet_length(p_kind)::text || ':' || p_kind || '|' ||
+        octet_length(p_container)::text || ':' || p_container
     );
 $$;
 
@@ -207,17 +207,17 @@ WHERE pc.interaction_id = i.id
 -- Ordered BEFORE anarlog so the meeting venue exists for the reuse step.
 WITH containers AS (
     SELECT DISTINCT
-        length(ce.gcal_event_id)::text || ':' || ce.gcal_event_id || '|' ||
-        length(ce.gcal_calendar_id)::text || ':' || ce.gcal_calendar_id || '|' ||
-        length(ce.google_account_id)::text || ':' || ce.google_account_id AS container_id,
+        octet_length(ce.gcal_event_id)::text || ':' || ce.gcal_event_id || '|' ||
+        octet_length(ce.gcal_calendar_id)::text || ':' || ce.gcal_calendar_id || '|' ||
+        octet_length(ce.google_account_id)::text || ':' || ce.google_account_id AS container_id,
         NULLIF(MAX(ce.title), '') AS title
     FROM calendar_event ce
     JOIN interaction i ON i.source = 'gcal' AND i.source_ref = ce.id::text
     WHERE i.venue_id IS NULL AND i.deleted_at IS NULL
     GROUP BY
-        length(ce.gcal_event_id)::text || ':' || ce.gcal_event_id || '|' ||
-        length(ce.gcal_calendar_id)::text || ':' || ce.gcal_calendar_id || '|' ||
-        length(ce.google_account_id)::text || ':' || ce.google_account_id
+        octet_length(ce.gcal_event_id)::text || ':' || ce.gcal_event_id || '|' ||
+        octet_length(ce.gcal_calendar_id)::text || ':' || ce.gcal_calendar_id || '|' ||
+        octet_length(ce.google_account_id)::text || ':' || ce.google_account_id
 ), ins_node AS (
     INSERT INTO node (id, type, canonical_label)
     SELECT venue_node_id('gcal', 'meeting', container_id), 'venue', ''
@@ -232,9 +232,9 @@ ON CONFLICT (source, kind, source_container_id) DO NOTHING;
 
 UPDATE interaction i
 SET venue_id = venue_node_id('gcal', 'meeting',
-        length(ce.gcal_event_id)::text || ':' || ce.gcal_event_id || '|' ||
-        length(ce.gcal_calendar_id)::text || ':' || ce.gcal_calendar_id || '|' ||
-        length(ce.google_account_id)::text || ':' || ce.google_account_id)
+        octet_length(ce.gcal_event_id)::text || ':' || ce.gcal_event_id || '|' ||
+        octet_length(ce.gcal_calendar_id)::text || ':' || ce.gcal_calendar_id || '|' ||
+        octet_length(ce.google_account_id)::text || ':' || ce.google_account_id)
 FROM calendar_event ce
 WHERE i.source = 'gcal'
   AND i.source_ref = ce.id::text
@@ -252,18 +252,18 @@ WHERE i.source = 'gcal'
 -- Step 1: REUSE the linked gcal meeting venue (the only cross-source merge).
 UPDATE interaction i
 SET venue_id = venue_node_id('gcal', 'meeting',
-        length(ce.gcal_event_id)::text || ':' || ce.gcal_event_id || '|' ||
-        length(ce.gcal_calendar_id)::text || ':' || ce.gcal_calendar_id || '|' ||
-        length(ce.google_account_id)::text || ':' || ce.google_account_id)
+        octet_length(ce.gcal_event_id)::text || ':' || ce.gcal_event_id || '|' ||
+        octet_length(ce.gcal_calendar_id)::text || ':' || ce.gcal_calendar_id || '|' ||
+        octet_length(ce.google_account_id)::text || ':' || ce.google_account_id)
 FROM meeting_note mn
 JOIN calendar_event ce ON ce.id = mn.linked_id
 JOIN venue ce_venue
   ON ce_venue.source = 'gcal'
  AND ce_venue.kind = 'meeting'
  AND ce_venue.source_container_id =
-        length(ce.gcal_event_id)::text || ':' || ce.gcal_event_id || '|' ||
-        length(ce.gcal_calendar_id)::text || ':' || ce.gcal_calendar_id || '|' ||
-        length(ce.google_account_id)::text || ':' || ce.google_account_id
+        octet_length(ce.gcal_event_id)::text || ':' || ce.gcal_event_id || '|' ||
+        octet_length(ce.gcal_calendar_id)::text || ':' || ce.gcal_calendar_id || '|' ||
+        octet_length(ce.google_account_id)::text || ':' || ce.google_account_id
 WHERE i.source = 'anarlog_sessions'
   AND i.venue_id IS NULL AND i.deleted_at IS NULL
   AND i.source_ref IS NOT NULL

--- a/backend/migrations/069_interaction_venue.up.sql
+++ b/backend/migrations/069_interaction_venue.up.sql
@@ -79,9 +79,16 @@ WITH containers AS (
       AND cm.thread_id IS NOT NULL AND cm.thread_id <> ''
       AND cm.source IN ('email', 'gchat')
 ), ins_node AS (
+    -- Mint the deterministic venue node ONLY when no venue exists yet for this
+    -- container (the WHERE NOT EXISTS guard prevents an orphan node when a venue
+    -- pre-exists with a different node id; the venue insert below would DO
+    -- NOTHING in that case, stranding an un-minted node otherwise).
     INSERT INTO node (id, type, canonical_label)
-    SELECT venue_node_id(source, kind, container_id), 'venue', ''
-    FROM containers
+    SELECT venue_node_id(c.source, c.kind, c.container_id), 'venue', ''
+    FROM containers c
+    WHERE NOT EXISTS (
+        SELECT 1 FROM venue v
+        WHERE v.source = c.source AND v.kind = c.kind AND v.source_container_id = c.container_id)
     ON CONFLICT (id) DO NOTHING
     RETURNING id
 )
@@ -115,8 +122,11 @@ WITH containers AS (
       AND mm.chat_guid IS NOT NULL AND mm.chat_guid <> ''
 ), ins_node AS (
     INSERT INTO node (id, type, canonical_label)
-    SELECT venue_node_id('messages', kind, container_id), 'venue', ''
-    FROM containers
+    SELECT venue_node_id('messages', c.kind, c.container_id), 'venue', ''
+    FROM containers c
+    WHERE NOT EXISTS (
+        SELECT 1 FROM venue v
+        WHERE v.source = 'messages' AND v.kind = c.kind AND v.source_container_id = c.container_id)
     ON CONFLICT (id) DO NOTHING
     RETURNING id
 )
@@ -153,8 +163,11 @@ WITH containers AS (
              CASE WHEN tm.chat_type = 'private' THEN 'dm' ELSE 'group_chat' END
 ), ins_node AS (
     INSERT INTO node (id, type, canonical_label)
-    SELECT venue_node_id('telegram', kind, container_id), 'venue', ''
-    FROM containers
+    SELECT venue_node_id('telegram', c.kind, c.container_id), 'venue', ''
+    FROM containers c
+    WHERE NOT EXISTS (
+        SELECT 1 FROM venue v
+        WHERE v.source = 'telegram' AND v.kind = c.kind AND v.source_container_id = c.container_id)
     ON CONFLICT (id) DO NOTHING
     RETURNING id
 )
@@ -183,8 +196,11 @@ WITH containers AS (
     WHERE i.venue_id IS NULL AND i.deleted_at IS NULL
 ), ins_node AS (
     INSERT INTO node (id, type, canonical_label)
-    SELECT venue_node_id('phone_calls', 'call', container_id), 'venue', ''
-    FROM containers
+    SELECT venue_node_id('phone_calls', 'call', c.container_id), 'venue', ''
+    FROM containers c
+    WHERE NOT EXISTS (
+        SELECT 1 FROM venue v
+        WHERE v.source = 'phone_calls' AND v.kind = 'call' AND v.source_container_id = c.container_id)
     ON CONFLICT (id) DO NOTHING
     RETURNING id
 )
@@ -227,8 +243,11 @@ WITH containers AS (
         octet_length(ce.google_account_id)::text || ':' || ce.google_account_id
 ), ins_node AS (
     INSERT INTO node (id, type, canonical_label)
-    SELECT venue_node_id('gcal', 'meeting', container_id), 'venue', ''
-    FROM containers
+    SELECT venue_node_id('gcal', 'meeting', c.container_id), 'venue', ''
+    FROM containers c
+    WHERE NOT EXISTS (
+        SELECT 1 FROM venue v
+        WHERE v.source = 'gcal' AND v.kind = 'meeting' AND v.source_container_id = c.container_id)
     ON CONFLICT (id) DO NOTHING
     RETURNING id
 )
@@ -289,8 +308,11 @@ WITH containers AS (
       AND split_part(i.source_ref, ':', 2) <> ''
 ), ins_node AS (
     INSERT INTO node (id, type, canonical_label)
-    SELECT venue_node_id('anarlog_sessions', 'session', container_id), 'venue', ''
-    FROM containers
+    SELECT venue_node_id('anarlog_sessions', 'session', c.container_id), 'venue', ''
+    FROM containers c
+    WHERE NOT EXISTS (
+        SELECT 1 FROM venue v
+        WHERE v.source = 'anarlog_sessions' AND v.kind = 'session' AND v.source_container_id = c.container_id)
     ON CONFLICT (id) DO NOTHING
     RETURNING id
 )

--- a/backend/migrations/069_interaction_venue.up.sql
+++ b/backend/migrations/069_interaction_venue.up.sql
@@ -1,0 +1,303 @@
+-- Venue model on interaction (graph foundation).
+--
+-- Adds interaction.venue_id (the shared-container node an interaction happened
+-- in) and backfills it for every existing interaction whose source has a
+-- resolvable container. A venue is one node per real container, keyed on the
+-- venue (source, kind, source_container_id) unique from migration 064.
+--
+-- Wrapped in an explicit transaction: the postgres migration driver does NOT
+-- auto-wrap a migration file, so this DDL + multi-statement backfill self-wraps
+-- to stay all-or-nothing on a mid-file failure (Postgres DDL is transactional).
+-- The whole file is idempotent (re-runnable): ADD COLUMN/INDEX IF NOT EXISTS;
+-- the venue node id is a deterministic uuid_generate_v5 of (source, kind,
+-- container) so a re-run computes the same id and ON CONFLICT DO NOTHING on both
+-- node (PK) and venue (unique) makes it a no-op with no orphan node; the
+-- venue_id UPDATEs are scoped to WHERE venue_id IS NULL.
+--
+-- The deterministic node id is the SAME function the live
+-- ResolveVenueForInteraction helper uses (Go uuid.NewSHA1 over the same
+-- namespace + name), so the backfill and the live recorders converge on one
+-- venue node per container; a PR6 test asserts they agree.
+--
+-- Per-source container key:
+--   email/gchat        -> comms_message.thread_id        (via interaction_id FK)
+--   messages           -> messages_message.chat_guid     (via interaction_id FK)
+--   telegram           -> telegram_message.telegram_chat_id (via interaction_id FK)
+--   gcal               -> length-prefixed (gcal_event_id || gcal_calendar_id ||
+--                         google_account_id) 3-tuple, joined by
+--                         interaction.source_ref = calendar_event.id::text
+--   phone_calls        -> phone_call.call_unique_id       (via interaction_id FK)
+--   anarlog_sessions   -> meeting_note.anarlog_session_id, extracted from
+--                         interaction.source_ref ('anarlog:<sid>:<cid>'); reuses
+--                         the linked gcal meeting venue when linked to an event
+--   manual / todoist   -> no container; venue_id stays NULL
+--
+-- gcal is ordered BEFORE anarlog so the anarlog->gcal venue reuse finds the
+-- meeting venue that gcal just created.
+
+BEGIN;
+
+ALTER TABLE interaction ADD COLUMN IF NOT EXISTS venue_id UUID REFERENCES node(id);
+
+CREATE INDEX IF NOT EXISTS idx_interaction_venue_id
+    ON interaction (venue_id)
+    WHERE venue_id IS NOT NULL AND deleted_at IS NULL;
+
+-- venue_node_id(source, kind, container) -> the deterministic venue node id.
+-- uuid_generate_v5 over a fixed venue namespace and the length-prefixed
+-- (source, kind, container) name. STRICT IMMUTABLE so it can drive set-based
+-- backfill SELECTs and a NULL component yields NULL (never a bogus id). The
+-- namespace is an arbitrary fixed UUID dedicated to venue identity.
+CREATE FUNCTION venue_node_id(p_source TEXT, p_kind TEXT, p_container TEXT)
+RETURNS UUID
+LANGUAGE sql
+IMMUTABLE
+STRICT
+AS $$
+    SELECT uuid_generate_v5(
+        'a4f7c0e2-1b3d-4c6a-9e8f-2d5b7a1c0e94'::uuid,
+        length(p_source)::text || ':' || p_source || '|' ||
+        length(p_kind)::text || ':' || p_kind || '|' ||
+        length(p_container)::text || ':' || p_container
+    );
+$$;
+
+-- ============================================================================
+-- email + gchat -> email_thread / group_chat, keyed on comms_message.thread_id
+-- ============================================================================
+-- comms_message carries the interaction_id FK and the thread_id container key.
+-- email rows are email threads; gchat rows are group chats (space/chat scope).
+-- A NULL/empty thread_id has no shared container, so those rows are skipped.
+WITH containers AS (
+    SELECT DISTINCT
+        cm.source,
+        CASE WHEN cm.source = 'email' THEN 'email_thread' ELSE 'group_chat' END AS kind,
+        cm.thread_id AS container_id
+    FROM comms_message cm
+    JOIN interaction i ON i.id = cm.interaction_id
+    WHERE i.venue_id IS NULL AND i.deleted_at IS NULL
+      AND cm.thread_id IS NOT NULL AND cm.thread_id <> ''
+      AND cm.source IN ('email', 'gchat')
+), ins_node AS (
+    INSERT INTO node (id, type, canonical_label)
+    SELECT venue_node_id(source, kind, container_id), 'venue', ''
+    FROM containers
+    ON CONFLICT (id) DO NOTHING
+    RETURNING id
+)
+INSERT INTO venue (node_id, kind, source, source_container_id, title)
+SELECT venue_node_id(source, kind, container_id), kind, source, container_id, NULL
+FROM containers
+ON CONFLICT (source, kind, source_container_id) DO NOTHING;
+
+UPDATE interaction i
+SET venue_id = venue_node_id(
+        cm.source,
+        CASE WHEN cm.source = 'email' THEN 'email_thread' ELSE 'group_chat' END,
+        cm.thread_id)
+FROM comms_message cm
+WHERE cm.interaction_id = i.id
+  AND i.venue_id IS NULL AND i.deleted_at IS NULL
+  AND cm.thread_id IS NOT NULL AND cm.thread_id <> ''
+  AND cm.source IN ('email', 'gchat');
+
+-- ============================================================================
+-- messages -> dm / group_chat, keyed on messages_message.chat_guid
+-- ============================================================================
+WITH containers AS (
+    SELECT DISTINCT
+        mm.chat_guid AS container_id,
+        CASE WHEN mm.is_group_chat THEN 'group_chat' ELSE 'dm' END AS kind
+    FROM messages_message mm
+    JOIN interaction i ON i.id = mm.interaction_id
+    WHERE i.venue_id IS NULL AND i.deleted_at IS NULL
+      AND mm.chat_guid IS NOT NULL AND mm.chat_guid <> ''
+), ins_node AS (
+    INSERT INTO node (id, type, canonical_label)
+    SELECT venue_node_id('messages', kind, container_id), 'venue', ''
+    FROM containers
+    ON CONFLICT (id) DO NOTHING
+    RETURNING id
+)
+INSERT INTO venue (node_id, kind, source, source_container_id, title)
+SELECT venue_node_id('messages', kind, container_id), kind, 'messages', container_id, NULL
+FROM containers
+ON CONFLICT (source, kind, source_container_id) DO NOTHING;
+
+UPDATE interaction i
+SET venue_id = venue_node_id(
+        'messages',
+        CASE WHEN mm.is_group_chat THEN 'group_chat' ELSE 'dm' END,
+        mm.chat_guid)
+FROM messages_message mm
+WHERE mm.interaction_id = i.id
+  AND i.venue_id IS NULL AND i.deleted_at IS NULL
+  AND mm.chat_guid IS NOT NULL AND mm.chat_guid <> '';
+
+-- ============================================================================
+-- telegram -> dm / group_chat, keyed on telegram_message.telegram_chat_id
+-- ============================================================================
+-- chat_type 'private' is a DM; 'group'/'supergroup' are group chats. The
+-- chat id is a BIGINT, stored as text in the venue container key.
+WITH containers AS (
+    SELECT DISTINCT
+        tm.telegram_chat_id::text AS container_id,
+        CASE WHEN tm.chat_type = 'private' THEN 'dm' ELSE 'group_chat' END AS kind,
+        NULLIF(MAX(tm.chat_title), '') AS title
+    FROM telegram_message tm
+    JOIN interaction i ON i.id = tm.interaction_id
+    WHERE i.venue_id IS NULL AND i.deleted_at IS NULL
+    GROUP BY tm.telegram_chat_id::text,
+             CASE WHEN tm.chat_type = 'private' THEN 'dm' ELSE 'group_chat' END
+), ins_node AS (
+    INSERT INTO node (id, type, canonical_label)
+    SELECT venue_node_id('telegram', kind, container_id), 'venue', ''
+    FROM containers
+    ON CONFLICT (id) DO NOTHING
+    RETURNING id
+)
+INSERT INTO venue (node_id, kind, source, source_container_id, title)
+SELECT venue_node_id('telegram', kind, container_id), kind, 'telegram', container_id, title
+FROM containers
+ON CONFLICT (source, kind, source_container_id) DO NOTHING;
+
+UPDATE interaction i
+SET venue_id = venue_node_id(
+        'telegram',
+        CASE WHEN tm.chat_type = 'private' THEN 'dm' ELSE 'group_chat' END,
+        tm.telegram_chat_id::text)
+FROM telegram_message tm
+WHERE tm.interaction_id = i.id
+  AND i.venue_id IS NULL AND i.deleted_at IS NULL;
+
+-- ============================================================================
+-- phone_calls -> call, keyed on phone_call.call_unique_id
+-- ============================================================================
+WITH containers AS (
+    SELECT DISTINCT pc.call_unique_id AS container_id
+    FROM phone_call pc
+    JOIN interaction i ON i.id = pc.interaction_id
+    WHERE i.venue_id IS NULL AND i.deleted_at IS NULL
+), ins_node AS (
+    INSERT INTO node (id, type, canonical_label)
+    SELECT venue_node_id('phone_calls', 'call', container_id), 'venue', ''
+    FROM containers
+    ON CONFLICT (id) DO NOTHING
+    RETURNING id
+)
+INSERT INTO venue (node_id, kind, source, source_container_id, title)
+SELECT venue_node_id('phone_calls', 'call', container_id), 'call', 'phone_calls', container_id, NULL
+FROM containers
+ON CONFLICT (source, kind, source_container_id) DO NOTHING;
+
+UPDATE interaction i
+SET venue_id = venue_node_id('phone_calls', 'call', pc.call_unique_id)
+FROM phone_call pc
+WHERE pc.interaction_id = i.id
+  AND i.venue_id IS NULL AND i.deleted_at IS NULL;
+
+-- ============================================================================
+-- gcal -> meeting, keyed on the length-prefixed 3-tuple
+-- (gcal_event_id || gcal_calendar_id || google_account_id)
+-- ============================================================================
+-- The gcal interaction's source_ref is the INTERNAL calendar_event.id UUID
+-- (the forward path writes calendar_event.ID, not gcal_event_id). The container
+-- key is the calendar_event's real uniqueness — the 3-tuple — length-prefixed
+-- so a delimiter inside any component cannot alias a different tuple.
+-- Ordered BEFORE anarlog so the meeting venue exists for the reuse step.
+WITH containers AS (
+    SELECT DISTINCT
+        length(ce.gcal_event_id)::text || ':' || ce.gcal_event_id || '|' ||
+        length(ce.gcal_calendar_id)::text || ':' || ce.gcal_calendar_id || '|' ||
+        length(ce.google_account_id)::text || ':' || ce.google_account_id AS container_id,
+        NULLIF(MAX(ce.title), '') AS title
+    FROM calendar_event ce
+    JOIN interaction i ON i.source = 'gcal' AND i.source_ref = ce.id::text
+    WHERE i.venue_id IS NULL AND i.deleted_at IS NULL
+    GROUP BY
+        length(ce.gcal_event_id)::text || ':' || ce.gcal_event_id || '|' ||
+        length(ce.gcal_calendar_id)::text || ':' || ce.gcal_calendar_id || '|' ||
+        length(ce.google_account_id)::text || ':' || ce.google_account_id
+), ins_node AS (
+    INSERT INTO node (id, type, canonical_label)
+    SELECT venue_node_id('gcal', 'meeting', container_id), 'venue', ''
+    FROM containers
+    ON CONFLICT (id) DO NOTHING
+    RETURNING id
+)
+INSERT INTO venue (node_id, kind, source, source_container_id, title)
+SELECT venue_node_id('gcal', 'meeting', container_id), 'meeting', 'gcal', container_id, title
+FROM containers
+ON CONFLICT (source, kind, source_container_id) DO NOTHING;
+
+UPDATE interaction i
+SET venue_id = venue_node_id('gcal', 'meeting',
+        length(ce.gcal_event_id)::text || ':' || ce.gcal_event_id || '|' ||
+        length(ce.gcal_calendar_id)::text || ':' || ce.gcal_calendar_id || '|' ||
+        length(ce.google_account_id)::text || ':' || ce.google_account_id)
+FROM calendar_event ce
+WHERE i.source = 'gcal'
+  AND i.source_ref = ce.id::text
+  AND i.venue_id IS NULL AND i.deleted_at IS NULL;
+
+-- ============================================================================
+-- anarlog_sessions -> session, keyed on meeting_note.anarlog_session_id
+-- (or REUSE the linked gcal meeting venue)
+-- ============================================================================
+-- The anarlog interaction's source_ref is 'anarlog:<sessionID>:<contactID>', so
+-- the session id is split_part(source_ref, ':', 2). Step 1 reuses the gcal
+-- meeting venue for sessions linked to an event (linked_kind='event'); step 2
+-- mints a session venue for everything else.
+
+-- Step 1: REUSE the linked gcal meeting venue (the only cross-source merge).
+UPDATE interaction i
+SET venue_id = venue_node_id('gcal', 'meeting',
+        length(ce.gcal_event_id)::text || ':' || ce.gcal_event_id || '|' ||
+        length(ce.gcal_calendar_id)::text || ':' || ce.gcal_calendar_id || '|' ||
+        length(ce.google_account_id)::text || ':' || ce.google_account_id)
+FROM meeting_note mn
+JOIN calendar_event ce ON ce.id = mn.linked_id
+JOIN venue ce_venue
+  ON ce_venue.source = 'gcal'
+ AND ce_venue.kind = 'meeting'
+ AND ce_venue.source_container_id =
+        length(ce.gcal_event_id)::text || ':' || ce.gcal_event_id || '|' ||
+        length(ce.gcal_calendar_id)::text || ':' || ce.gcal_calendar_id || '|' ||
+        length(ce.google_account_id)::text || ':' || ce.google_account_id
+WHERE i.source = 'anarlog_sessions'
+  AND i.venue_id IS NULL AND i.deleted_at IS NULL
+  AND i.source_ref IS NOT NULL
+  AND mn.anarlog_session_id = split_part(i.source_ref, ':', 2)::uuid
+  AND mn.deleted_at IS NULL
+  AND mn.linked_kind = 'event';
+
+-- Step 2: mint a session venue for the remaining (unlinked) anarlog sessions.
+WITH containers AS (
+    SELECT DISTINCT split_part(i.source_ref, ':', 2) AS container_id
+    FROM interaction i
+    WHERE i.source = 'anarlog_sessions'
+      AND i.venue_id IS NULL AND i.deleted_at IS NULL
+      AND i.source_ref IS NOT NULL
+      AND split_part(i.source_ref, ':', 2) <> ''
+), ins_node AS (
+    INSERT INTO node (id, type, canonical_label)
+    SELECT venue_node_id('anarlog_sessions', 'session', container_id), 'venue', ''
+    FROM containers
+    ON CONFLICT (id) DO NOTHING
+    RETURNING id
+)
+INSERT INTO venue (node_id, kind, source, source_container_id, title)
+SELECT venue_node_id('anarlog_sessions', 'session', container_id), 'session', 'anarlog_sessions', container_id, NULL
+FROM containers
+ON CONFLICT (source, kind, source_container_id) DO NOTHING;
+
+UPDATE interaction i
+SET venue_id = venue_node_id('anarlog_sessions', 'session', split_part(i.source_ref, ':', 2))
+WHERE i.source = 'anarlog_sessions'
+  AND i.venue_id IS NULL AND i.deleted_at IS NULL
+  AND i.source_ref IS NOT NULL
+  AND split_part(i.source_ref, ':', 2) <> '';
+
+DROP FUNCTION venue_node_id(TEXT, TEXT, TEXT);
+
+COMMIT;

--- a/backend/migrations/069_interaction_venue.up.sql
+++ b/backend/migrations/069_interaction_venue.up.sql
@@ -294,10 +294,13 @@ JOIN venue ce_venue
 WHERE i.source = 'anarlog_sessions'
   AND i.venue_id IS NULL AND i.deleted_at IS NULL
   AND i.source_ref IS NOT NULL
-  -- Guard the ::uuid cast: skip a malformed source_ref (segment 2 not a UUID)
-  -- rather than aborting the whole BEGIN..COMMIT migration on one bad row.
-  AND split_part(i.source_ref, ':', 2) ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
-  AND mn.anarlog_session_id = split_part(i.source_ref, ':', 2)::uuid
+  -- Compare the KNOWN-VALID uuid column cast to text against the raw source_ref
+  -- segment — NOT split_part(...)::uuid. Casting the untrusted text to uuid would
+  -- raise "invalid input syntax for type uuid" on a malformed ref, and because
+  -- AND-predicate evaluation order is NOT guaranteed, a sibling regex guard can't
+  -- structurally protect that cast. Casting the canonical uuid column to text and
+  -- comparing as text never errors: a malformed segment simply doesn't match.
+  AND mn.anarlog_session_id::text = split_part(i.source_ref, ':', 2)
   AND mn.deleted_at IS NULL
   AND mn.linked_kind = 'event';
 

--- a/backend/migrations/069_interaction_venue.up.sql
+++ b/backend/migrations/069_interaction_venue.up.sql
@@ -17,7 +17,7 @@
 -- The deterministic node id is the SAME function the live
 -- ResolveVenueForInteraction helper uses (Go uuid.NewSHA1 over the same
 -- namespace + name), so the backfill and the live recorders converge on one
--- venue node per container; a PR6 test asserts they agree.
+-- venue node per container; an integration test asserts they agree.
 --
 -- Per-source container key:
 --   email/gchat        -> comms_message.thread_id        (via interaction_id FK)
@@ -91,11 +91,12 @@ FROM containers
 ON CONFLICT (source, kind, source_container_id) DO NOTHING;
 
 UPDATE interaction i
-SET venue_id = venue_node_id(
-        cm.source,
-        CASE WHEN cm.source = 'email' THEN 'email_thread' ELSE 'group_chat' END,
-        cm.thread_id)
+SET venue_id = v.node_id
 FROM comms_message cm
+JOIN venue v
+  ON v.source = cm.source
+ AND v.kind = CASE WHEN cm.source = 'email' THEN 'email_thread' ELSE 'group_chat' END
+ AND v.source_container_id = cm.thread_id
 WHERE cm.interaction_id = i.id
   AND i.venue_id IS NULL AND i.deleted_at IS NULL
   AND cm.thread_id IS NOT NULL AND cm.thread_id <> ''
@@ -125,11 +126,12 @@ FROM containers
 ON CONFLICT (source, kind, source_container_id) DO NOTHING;
 
 UPDATE interaction i
-SET venue_id = venue_node_id(
-        'messages',
-        CASE WHEN mm.is_group_chat THEN 'group_chat' ELSE 'dm' END,
-        mm.chat_guid)
+SET venue_id = v.node_id
 FROM messages_message mm
+JOIN venue v
+  ON v.source = 'messages'
+ AND v.kind = CASE WHEN mm.is_group_chat THEN 'group_chat' ELSE 'dm' END
+ AND v.source_container_id = mm.chat_guid
 WHERE mm.interaction_id = i.id
   AND i.venue_id IS NULL AND i.deleted_at IS NULL
   AND mm.chat_guid IS NOT NULL AND mm.chat_guid <> '';
@@ -162,11 +164,12 @@ FROM containers
 ON CONFLICT (source, kind, source_container_id) DO NOTHING;
 
 UPDATE interaction i
-SET venue_id = venue_node_id(
-        'telegram',
-        CASE WHEN tm.chat_type = 'private' THEN 'dm' ELSE 'group_chat' END,
-        tm.telegram_chat_id::text)
+SET venue_id = v.node_id
 FROM telegram_message tm
+JOIN venue v
+  ON v.source = 'telegram'
+ AND v.kind = CASE WHEN tm.chat_type = 'private' THEN 'dm' ELSE 'group_chat' END
+ AND v.source_container_id = tm.telegram_chat_id::text
 WHERE tm.interaction_id = i.id
   AND i.venue_id IS NULL AND i.deleted_at IS NULL;
 
@@ -191,8 +194,12 @@ FROM containers
 ON CONFLICT (source, kind, source_container_id) DO NOTHING;
 
 UPDATE interaction i
-SET venue_id = venue_node_id('phone_calls', 'call', pc.call_unique_id)
+SET venue_id = v.node_id
 FROM phone_call pc
+JOIN venue v
+  ON v.source = 'phone_calls'
+ AND v.kind = 'call'
+ AND v.source_container_id = pc.call_unique_id
 WHERE pc.interaction_id = i.id
   AND i.venue_id IS NULL AND i.deleted_at IS NULL;
 
@@ -231,11 +238,15 @@ FROM containers
 ON CONFLICT (source, kind, source_container_id) DO NOTHING;
 
 UPDATE interaction i
-SET venue_id = venue_node_id('gcal', 'meeting',
+SET venue_id = v.node_id
+FROM calendar_event ce
+JOIN venue v
+  ON v.source = 'gcal'
+ AND v.kind = 'meeting'
+ AND v.source_container_id =
         octet_length(ce.gcal_event_id)::text || ':' || ce.gcal_event_id || '|' ||
         octet_length(ce.gcal_calendar_id)::text || ':' || ce.gcal_calendar_id || '|' ||
-        octet_length(ce.google_account_id)::text || ':' || ce.google_account_id)
-FROM calendar_event ce
+        octet_length(ce.google_account_id)::text || ':' || ce.google_account_id
 WHERE i.source = 'gcal'
   AND i.source_ref = ce.id::text
   AND i.venue_id IS NULL AND i.deleted_at IS NULL;
@@ -251,10 +262,7 @@ WHERE i.source = 'gcal'
 
 -- Step 1: REUSE the linked gcal meeting venue (the only cross-source merge).
 UPDATE interaction i
-SET venue_id = venue_node_id('gcal', 'meeting',
-        octet_length(ce.gcal_event_id)::text || ':' || ce.gcal_event_id || '|' ||
-        octet_length(ce.gcal_calendar_id)::text || ':' || ce.gcal_calendar_id || '|' ||
-        octet_length(ce.google_account_id)::text || ':' || ce.google_account_id)
+SET venue_id = ce_venue.node_id
 FROM meeting_note mn
 JOIN calendar_event ce ON ce.id = mn.linked_id
 JOIN venue ce_venue
@@ -292,8 +300,12 @@ FROM containers
 ON CONFLICT (source, kind, source_container_id) DO NOTHING;
 
 UPDATE interaction i
-SET venue_id = venue_node_id('anarlog_sessions', 'session', split_part(i.source_ref, ':', 2))
-WHERE i.source = 'anarlog_sessions'
+SET venue_id = v.node_id
+FROM venue v
+WHERE v.source = 'anarlog_sessions'
+  AND v.kind = 'session'
+  AND v.source_container_id = split_part(i.source_ref, ':', 2)
+  AND i.source = 'anarlog_sessions'
   AND i.venue_id IS NULL AND i.deleted_at IS NULL
   AND i.source_ref IS NOT NULL
   AND split_part(i.source_ref, ':', 2) <> '';

--- a/backend/tests/api/meeting_note_ingest_test.go
+++ b/backend/tests/api/meeting_note_ingest_test.go
@@ -171,6 +171,12 @@ func setupMeetingNoteIngestEnv(t *testing.T) *meetingNoteIngestEnv {
 		titleDiscoveryWriter,
 		phoneCallRepo, // phone_call linkage candidates (read)
 	)
+	// Wire the venue resolver (mirrors production main.go) so the meeting_note
+	// path populates interaction.venue_id and a leak (a venue node minted with no
+	// interaction to reference it) is observable.
+	venueResolver := repository.NewVenueResolverRegistry(
+		repository.NewVenueRepository(database.Queries), nil, calendarRepo)
+	ingestService.SetVenueResolver(venueResolver)
 	ingestHandler := handlers.NewIngestHandler(ingestService)
 
 	gin.SetMode(gin.TestMode)
@@ -227,6 +233,7 @@ func setupMeetingNoteIngestEnv(t *testing.T) *meetingNoteIngestEnv {
 		contactSvc,
 		contactRepo,
 	)
+	meetingNoteService.SetVenueResolver(venueResolver)
 	meetingNoteHandler := handlers.NewMeetingNoteHandler(meetingNoteService)
 	// Wiring mirrors production main.go: resolve-link stays under
 	// the v1 API-key group; needs-attention sits under the composite
@@ -618,6 +625,10 @@ func TestMeetingNote_OrphanNoTagged(t *testing.T) {
 	env := setupMeetingNoteIngestEnv(t)
 	sessionUUID := env.newSessionUUID()
 	meetingAt := time.Date(2026, 5, 1, 14, 30, 0, 0, time.UTC)
+
+	ctx := context.Background()
+	nodeRepo := repository.NewNodeRepository(env.database.Queries)
+
 	ev := buildMNRecordedEvent(t, env.pairedHostID, sessionUUID, meetingAt, "Orphan Session", nil)
 	w := postMNIngest(t, env, map[string]any{"events": []any{ev}})
 	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
@@ -638,6 +649,18 @@ func TestMeetingNote_OrphanNoTagged(t *testing.T) {
 	require.Len(t, resp.NeedsAttention, 1)
 	require.Equal(t, sessionUUID, resp.NeedsAttention[0].SessionID)
 	require.Equal(t, "orphan", resp.NeedsAttention[0].Reason)
+
+	// No venue node was minted: a desired-less (orphan) session must not resolve a
+	// venue. Assert the SPECIFIC deterministic session-venue node for this session
+	// does not exist (parallel-test-safe — scoped to this session's id, not a
+	// global count). Without the len(desiredByRef)>0 gate the handler would mint
+	// exactly this node with no interaction to reference it.
+	sessionUUIDVal, err := uuid.Parse(sessionUUID)
+	require.NoError(t, err)
+	leakedVenueNodeID := repository.VenueNodeID(
+		repository.InteractionSourceAnarlogSessions, repository.VenueKindSession, sessionUUIDVal.String())
+	_, err = nodeRepo.GetNode(ctx, leakedVenueNodeID)
+	require.ErrorIs(t, err, db.ErrNotFound, "orphan_needs_review (no interactions) must not mint a session venue node")
 }
 
 // ----------------------------------------------------------------------------

--- a/backend/tests/api/phone_call_migration_test.go
+++ b/backend/tests/api/phone_call_migration_test.go
@@ -150,15 +150,14 @@ func TestPhoneCallMigration055(t *testing.T) {
 		t.Cleanup(func() { _ = contactRepo.SoftDeleteContact(ctx, contact.ID) })
 
 		ref := "mig-pc-ix-" + suffix
-		interaction, err := interactionRepo.CreateInteraction(ctx, repository.CreateInteractionRequest{
-			ContactID:  contact.ID,
-			Source:     "phone_calls",
-			SourceRef:  &ref,
-			OccurredAt: accelerated.GetCurrentTime().Truncate(time.Microsecond),
-			Direction:  repository.InteractionDirectionInbound,
-		})
+		// Raw insert (the clone is positioned at v55, which predates the
+		// interaction.venue_id column the production CreateInteraction now writes;
+		// the migration is the subject, so a v55-shaped raw insert is the right
+		// scaffolding here).
+		_, err = database.Pool.Exec(ctx,
+			`INSERT INTO interaction (contact_id, source, source_ref, occurred_at, direction) VALUES ($1, $2, $3, $4, $5)`,
+			contact.ID, "phone_calls", ref, accelerated.GetCurrentTime().Truncate(time.Microsecond), repository.InteractionDirectionInbound)
 		require.NoError(t, err)
-		_ = interaction // referenced for explicitness
 
 		// Down must refuse on the CHECK-revert guard.
 		mig, err := newMigrator(databaseURL)
@@ -182,15 +181,11 @@ func TestPhoneCallMigration055(t *testing.T) {
 		closeMigrator(t, mig)
 
 		// Confirm the CHECK reverted: inserting a phone_calls
-		// interaction must now fail.
+		// interaction must now fail (raw insert, same v55-shape rationale).
 		ref2 := "mig-pc-ix-post-" + suffix
-		_, err = interactionRepo.CreateInteraction(ctx, repository.CreateInteractionRequest{
-			ContactID:  contact.ID,
-			Source:     "phone_calls",
-			SourceRef:  &ref2,
-			OccurredAt: accelerated.GetCurrentTime().Truncate(time.Microsecond),
-			Direction:  repository.InteractionDirectionInbound,
-		})
+		_, err = database.Pool.Exec(ctx,
+			`INSERT INTO interaction (contact_id, source, source_ref, occurred_at, direction) VALUES ($1, $2, $3, $4, $5)`,
+			contact.ID, "phone_calls", ref2, accelerated.GetCurrentTime().Truncate(time.Microsecond), repository.InteractionDirectionInbound)
 		require.Error(t, err, "phone_calls source must be rejected after 055 down")
 		assert.True(t, strings.Contains(err.Error(), "interaction_source_check") ||
 			strings.Contains(err.Error(), "check constraint"),

--- a/backend/tests/interaction_venue_integration_test.go
+++ b/backend/tests/interaction_venue_integration_test.go
@@ -445,10 +445,13 @@ func TestInteractionVenue_MigrationAtomicity(t *testing.T) {
 
 // TestInteractionVenue_MalformedAnarlogRefIsSkipped runs the REAL 069 migration
 // over a malformed anarlog interaction (source_ref segment-2 is NOT a UUID) and
-// asserts the migration SUCCEEDS — the Step-1 ::uuid-cast guard skips the bad row
-// rather than aborting the whole BEGIN..COMMIT. A well-formed anarlog row in the
-// same run still resolves to its session venue. This test FAILS if the guard is
-// removed from the real file (the cast then raises invalid-uuid and aborts).
+// asserts the migration SUCCEEDS. Step-1's anarlog→gcal reuse compares the
+// trusted anarlog_session_id::text against the raw source_ref segment (it never
+// casts the untrusted segment to uuid), so a malformed ref cannot abort the
+// whole BEGIN..COMMIT. A linked well-formed anarlog row in the same run reuses
+// the gcal meeting venue (forcing Step-1 to actually evaluate). This test FAILS
+// if the comparison reverts to split_part(...)::uuid (the cast then raises
+// invalid-uuid and aborts the migration) — mutation-verified.
 func TestInteractionVenue_MalformedAnarlogRefIsSkipped(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")

--- a/backend/tests/interaction_venue_integration_test.go
+++ b/backend/tests/interaction_venue_integration_test.go
@@ -469,20 +469,56 @@ func TestInteractionVenue_MalformedAnarlogRefIsSkipped(t *testing.T) {
 
 	contactRepo := repository.NewContactRepository(database.Queries)
 	interactionRepo := repository.NewInteractionRepository(database.Queries)
+	calendarRepo := repository.NewCalendarEventRepository(database.Queries)
+	meetingNoteRepo := repository.NewMeetingNoteRepository(database.Queries)
 	venueRepo := repository.NewVenueRepository(database.Queries)
 	now := accelerated.GetCurrentTime().UTC()
 
 	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: "Malformed Anarlog Subject"})
 	require.NoError(t, err)
 
-	// A malformed anarlog ref: segment 2 is not a UUID. The Step-1 ::uuid cast
-	// must NOT fire on this row.
+	// A gcal event + a LINKED meeting_note + a well-formed anarlog interaction for
+	// that session. This FORCES the Step-1 anarlog→gcal join to evaluate (its
+	// meeting_note ⋈ calendar_event ⋈ venue chain produces a row), so the
+	// untrusted-source_ref comparison in Step-1 actually runs — without this setup
+	// the cast-safety guard would never be exercised by the test.
+	event, err := calendarRepo.Upsert(ctx, repository.UpsertCalendarEventRequest{
+		GcalEventID: "evt-malformed-1", GcalCalendarID: "primary", GoogleAccountID: "acct-malformed-1",
+		StartTime: now, EndTime: now.Add(time.Hour), Status: "confirmed", SyncedAt: now,
+	})
+	require.NoError(t, err)
+	// A gcal INTERACTION for the event so the gcal backfill block (which runs
+	// before anarlog) mints the meeting venue the anarlog reuse then finds.
+	gcalIxID := uuid.New()
+	gcalRef := event.ID.String()
+	_, err = interactionRepo.TestInsertInteraction(ctx, gcalIxID, contact.ID, repository.InteractionSourceGCal, &gcalRef, now, repository.InteractionDirectionMutual)
+	require.NoError(t, err)
+	linkedKind := repository.LinkedKindEvent
+	linkedSession := uuid.New()
+	mnTx, err := database.Pool.Begin(ctx)
+	require.NoError(t, err)
+	_, err = meetingNoteRepo.InsertMeetingNoteTx(ctx, mnTx, repository.InsertMeetingNoteParams{
+		AnarlogSessionID: linkedSession, LinkedKind: &linkedKind, LinkedID: &event.ID,
+		LinkageState: repository.LinkageStateLinked, MeetingAt: now,
+	})
+	require.NoError(t, err)
+	require.NoError(t, mnTx.Commit(ctx))
+	linkedID := uuid.New()
+	linkedRef := fmt.Sprintf("anarlog:%s:%s", linkedSession, contact.ID)
+	_, err = interactionRepo.TestInsertInteraction(ctx, linkedID, contact.ID, repository.InteractionSourceAnarlogSessions, &linkedRef, now, repository.InteractionDirectionMutual)
+	require.NoError(t, err)
+
+	// A MALFORMED anarlog ref (segment 2 is not a UUID) present in the SAME run.
+	// Step-1 compares anarlog_session_id::text against this raw segment; the
+	// migration must NOT raise invalid-uuid on it (it can't — there is no cast of
+	// the untrusted text). If a future edit reverts to split_part(...)::uuid this
+	// row makes the whole BEGIN..COMMIT migration abort and the test fails.
 	badID := uuid.New()
 	badRef := fmt.Sprintf("anarlog:not-a-uuid:%s", contact.ID)
 	_, err = interactionRepo.TestInsertInteraction(ctx, badID, contact.ID, repository.InteractionSourceAnarlogSessions, &badRef, now, repository.InteractionDirectionMutual)
 	require.NoError(t, err)
 
-	// A well-formed anarlog (unlinked) ref in the same run → a session venue.
+	// A well-formed UNLINKED anarlog ref → its own session venue.
 	goodSession := uuid.New()
 	goodID := uuid.New()
 	goodRef := fmt.Sprintf("anarlog:%s:%s", goodSession, contact.ID)
@@ -497,15 +533,21 @@ func TestInteractionVenue_MalformedAnarlogRefIsSkipped(t *testing.T) {
 		require.NoError(t, err)
 	}
 	require.NoError(t, m.Steps(-1), "roll the venue model down")
-	require.NoError(t, m.Steps(1), "the REAL backfill must SUCCEED despite the malformed anarlog ref (guard skips it)")
+	require.NoError(t, m.Steps(1), "the REAL backfill must SUCCEED despite the malformed anarlog ref present")
 
-	// The well-formed row resolves to its session venue.
+	// Step-1 DID fire: the linked anarlog interaction reuses the gcal MEETING
+	// venue (not a session venue) — proving the cast-safe comparison still matches
+	// a well-formed session.
+	gcalContainer := repository.GCalVenueContainerID(event.GcalEventID, event.GcalCalendarID, event.GoogleAccountID)
+	requireInteractionVenue(t, ctx, interactionRepo, venueRepo, linkedID,
+		repository.InteractionSourceGCal, repository.VenueKindMeeting, gcalContainer)
+
+	// The well-formed UNLINKED row resolves to its session venue (Step 2).
 	requireInteractionVenue(t, ctx, interactionRepo, venueRepo, goodID,
 		repository.InteractionSourceAnarlogSessions, repository.VenueKindSession, goodSession.String())
 
-	// The malformed row did NOT trip the Step-1 ::uuid cast: Step-2 (text-based)
-	// gives it a session venue keyed on the raw segment-2 text, so the migration
-	// completes. The key invariant is that the migration succeeded at all.
+	// The malformed row did NOT abort the migration: Step-2 (text-based) gives it
+	// a session venue keyed on the raw segment-2 text.
 	badInteraction, err := interactionRepo.GetInteraction(ctx, badID)
 	require.NoError(t, err)
 	require.NotNil(t, badInteraction.VenueID, "malformed row gets a session venue from the text-based Step 2")

--- a/backend/tests/interaction_venue_integration_test.go
+++ b/backend/tests/interaction_venue_integration_test.go
@@ -289,9 +289,10 @@ func TestInteractionVenue_Backfill(t *testing.T) {
 	assert.Equal(t, beforeBackfill.LastResponseAt, afterBackfill.LastResponseAt, "backfill must not touch last_response_at")
 	assert.Equal(t, beforeBackfill.ContactBy, afterBackfill.ContactBy, "backfill must not touch contact_by")
 
-	// Recompute leg (plan §459): run a CadenceUpdater apply against the now-
-	// venue-bearing interactions and assert the cadence columns are STILL
-	// byte-identical. The cadence machinery partitions purely by contact_id and
+	// Recompute leg: run a CadenceUpdater apply against the now-venue-bearing
+	// interactions and assert the cadence columns are STILL byte-identical (proves
+	// the cadence recompute path tolerates venue-bearing rows). The cadence
+	// machinery partitions purely by contact_id and
 	// never reads venue_id, so applying a stale (older-than-last_contacted)
 	// telegram interaction is a forward-only no-op that must leave cadence
 	// untouched — proving the recompute path is unperturbed by the new column.
@@ -634,8 +635,12 @@ func TestInteractionVenue_DownGuardPreservesReferencedVenue(t *testing.T) {
 // if the file has no COMMIT; to anchor against.
 func injectErrorBeforeFinalCommit(t *testing.T, sql string) string {
 	t.Helper()
+	// Require EXACTLY one COMMIT; so the anchor is unambiguous. A future edit that
+	// adds a second COMMIT; (in a string literal or a trailing comment) would
+	// otherwise shift LastIndex and could land the injected error OUTSIDE the
+	// transaction, silently weakening the atomicity proof — fail loudly instead.
+	require.Equal(t, 1, strings.Count(sql, "COMMIT;"), "the real migration must contain exactly one COMMIT; to anchor the injected error unambiguously")
 	idx := strings.LastIndex(sql, "COMMIT;")
-	require.GreaterOrEqual(t, idx, 0, "the real migration must contain a COMMIT; to anchor the injected error")
 	return sql[:idx] + "SELECT 1/0;\n" + sql[idx:]
 }
 

--- a/backend/tests/interaction_venue_integration_test.go
+++ b/backend/tests/interaction_venue_integration_test.go
@@ -102,12 +102,17 @@ type venueBackfillSeed struct {
 }
 
 // TestInteractionVenue_Backfill seeds pre-existing venue-less interactions across
-// the distinct join shapes (telegram content-FK, gcal source_ref, anarlog
-// split_part + gcal reuse, manual NULL), runs the 069 backfill via a down/up
-// round-trip on an isolated clone, and asserts each interaction resolves to the
-// expected venue — including two same-chat telegram rows sharing one node, the
-// anarlog→gcal venue reuse, the NULL-venue manual case, idempotent re-run, and
-// that the backfill node id matches the live helper's deterministic id.
+// the distinct backfill JOIN SHAPES and asserts each resolves to the expected
+// venue. The three shapes are: the content interaction_id FK (telegram here;
+// email/gchat/messages/phone share this exact shape, differing only in the
+// column read + the kind), the gcal source_ref = calendar_event.id::text join,
+// and the anarlog split_part(source_ref) extraction + the gcal-meeting-venue
+// reuse. Also covered: two same-chat telegram rows sharing one node, the
+// anarlog→gcal venue reuse, the unlinked-anarlog session venue, the NULL-venue
+// manual case, in-place idempotent re-run, and that the backfill node id matches
+// the live helper's deterministic id. (The LIVE recorder path for every source —
+// email/messages/gchat/telegram/gcal — is covered by the synthetic replay
+// adapters' assertContactVenue assertions in TestSyntheticReplay_*.)
 func TestInteractionVenue_Backfill(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -251,11 +256,26 @@ func TestInteractionVenue_Backfill(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, manualInteraction.VenueID, "manual interaction must have a NULL venue_id")
 
-	// Idempotent re-run: rolling down+up again leaves identical venue ids.
-	require.NoError(t, m.Steps(-1), "roll down again")
-	require.NoError(t, m.Steps(1), "re-run the backfill (must be idempotent)")
+	// In-place idempotency: re-execute the up migration's backfill SQL directly
+	// (no down) and assert it is a true no-op — the venue node count and every
+	// venue_id are unchanged (proves WHERE venue_id IS NULL + the ON CONFLICT
+	// guards, not just down/up symmetry).
+	venueNodesBefore := countVenueNodes(ctx, t, database)
+	upSQL, readErr := os.ReadFile(migrationsPath + "/069_interaction_venue.up.sql")
+	require.NoError(t, readErr)
+	_, err = database.Pool.Exec(ctx, string(upSQL))
+	require.NoError(t, err, "re-running the up migration backfill in-place must succeed")
+	require.Equal(t, venueNodesBefore, countVenueNodes(ctx, t, database), "in-place re-run must not create new venue nodes")
 	tg1VenueAgain := requireInteractionVenue(t, ctx, interactionRepo, venueRepo, tg1, repository.InteractionSourceTelegram, repository.VenueKindDM, tgContainer)
-	require.Equal(t, tg1Venue, tg1VenueAgain, "idempotent re-run must resolve to the same venue node")
+	require.Equal(t, tg1Venue, tg1VenueAgain, "in-place re-run must leave venue_id unchanged")
+}
+
+// countVenueNodes returns the number of venue-type nodes.
+func countVenueNodes(ctx context.Context, t *testing.T, database *db.Database) int64 {
+	t.Helper()
+	var n int64
+	require.NoError(t, database.Pool.QueryRow(ctx, `SELECT count(*) FROM node WHERE type = 'venue'`).Scan(&n))
+	return n
 }
 
 // TestInteractionVenue_MigrationAtomicity proves the 069 up migration is

--- a/backend/tests/interaction_venue_integration_test.go
+++ b/backend/tests/interaction_venue_integration_test.go
@@ -1,0 +1,392 @@
+//go:build integration_testdb
+
+package tests
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/synthetic"
+	"personal-crm/backend/internal/synthetic/factory"
+	"personal-crm/backend/internal/testdb"
+	"personal-crm/backend/tests/testsupport"
+
+	migrate "github.com/golang-migrate/migrate/v4"
+	_ "github.com/golang-migrate/migrate/v4/source/file"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// interactionVenueVersion is the golang-migrate version of the venue-model
+// migration (069). The down/up round-trip positions the clone here first so
+// Steps(-1) rolls down 069 specifically, robust to later migrations landing
+// above it.
+const interactionVenueVersion = 69
+
+// TestInteractionVenue_LivePath drives the REAL recorder pipeline (telegram)
+// and asserts the live ResolveVenueForInteraction path sets venue_id, that two
+// messages in the SAME chat share ONE venue node, and that adding venue_id does
+// not perturb the contact's cadence columns (the headline-risk regression).
+func TestInteractionVenue_LivePath(t *testing.T) {
+	testsupport.RequireLongTests(t)
+	database, ctx := newSyntheticDB(t)
+	t.Parallel()
+
+	h := synthetic.NewHarnessForNamespace(t, ctx, database, syntheticNS(t), factory.DefaultSeed)
+	gen := h.Generator()
+	spec := gen.Contact(factory.WithTelegram())
+	contact, err := h.SeedContact(ctx, spec)
+	require.NoError(t, err)
+
+	// First telegram message in the chat → matched interaction with a venue.
+	tgMsg1 := gen.TelegramMessage(spec, factory.MatchSeeded)
+	res1, err := h.ReplayTelegram(ctx, contact.ID, tgMsg1)
+	require.NoError(t, err)
+	require.True(t, res1.Matched)
+
+	// Snapshot cadence columns AFTER the first interaction settled but BEFORE the
+	// second — the venue is already populated, so a second same-chat interaction
+	// must reuse the node and must not perturb cadence beyond the normal
+	// interaction effect.
+	afterFirst, err := h.ContactRepo().GetContact(ctx, contact.ID)
+	require.NoError(t, err)
+
+	// Second message in the SAME chat (reuse the peer/chat id, bump the message
+	// id) so the two interactions share one venue container.
+	tgMsg2 := tgMsg1
+	tgMsg2.TelegramMessageID = tgMsg1.TelegramMessageID + 1
+	res2, err := h.ReplayTelegram(ctx, contact.ID, tgMsg2)
+	require.NoError(t, err)
+	require.True(t, res2.Matched)
+
+	// Both telegram interactions resolve to the SAME venue node (one container).
+	venueIDs := distinctVenueNodeIDs(t, ctx, h, contact.ID, repository.InteractionSourceTelegram)
+	require.Len(t, venueIDs, 1, "two messages in one chat must share exactly one venue node")
+
+	// The venue node is a live telegram dm/group_chat venue.
+	venue, err := h.VenueRepo().GetVenue(ctx, venueIDs[0])
+	require.NoError(t, err)
+	require.Equal(t, repository.InteractionSourceTelegram, venue.Source)
+	assert.Contains(t, []string{repository.VenueKindDM, repository.VenueKindGroupChat}, venue.Kind)
+
+	// Cadence regression: the venue resolution must not regress the cadence math.
+	// last_contacted advances only by the (normal) second-interaction effect, and
+	// the venue write touches no cadence column — assert the cadence fields move
+	// only as a normal second interaction would (never NULL-ed, never reset).
+	afterSecond, err := h.ContactRepo().GetContact(ctx, contact.ID)
+	require.NoError(t, err)
+	require.NotNil(t, afterSecond.LastInteractionAt, "venue write must not null last_interaction_at")
+	if afterFirst.LastInteractionAt != nil {
+		require.False(t, afterSecond.LastInteractionAt.Before(*afterFirst.LastInteractionAt),
+			"last_interaction_at must not move backward across the venue-bearing second interaction")
+	}
+}
+
+// venueBackfillSeed is one seeded interaction (+ optional content) for the
+// backfill test, plus the venue identity the backfill must resolve it to.
+type venueBackfillSeed struct {
+	interactionID   uuid.UUID
+	source          string
+	expectKind      string // "" → expect NULL venue (manual)
+	expectContainer string
+}
+
+// TestInteractionVenue_Backfill seeds pre-existing venue-less interactions across
+// the distinct join shapes (telegram content-FK, gcal source_ref, anarlog
+// split_part + gcal reuse, manual NULL), runs the 069 backfill via a down/up
+// round-trip on an isolated clone, and asserts each interaction resolves to the
+// expected venue — including two same-chat telegram rows sharing one node, the
+// anarlog→gcal venue reuse, the NULL-venue manual case, idempotent re-run, and
+// that the backfill node id matches the live helper's deterministic id.
+func TestInteractionVenue_Backfill(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	if os.Getenv("DATABASE_URL") == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+	// Migration-subject test: rolls the schema down, so it stays serial and uses
+	// an isolated clone (never the shared package DB).
+
+	ctx := context.Background()
+	cloneURL, drop := testdb.NewEphemeralClone(t)
+	t.Cleanup(drop)
+	migrationsPath := getMigrationsPath()
+
+	cfg := config.TestConfig()
+	cfg.Database.URL = cloneURL
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	t.Cleanup(database.Close)
+
+	contactRepo := repository.NewContactRepository(database.Queries)
+	interactionRepo := repository.NewInteractionRepository(database.Queries)
+	calendarRepo := repository.NewCalendarEventRepository(database.Queries)
+	meetingNoteRepo := repository.NewMeetingNoteRepository(database.Queries)
+	venueRepo := repository.NewVenueRepository(database.Queries)
+
+	now := accelerated.GetCurrentTime().UTC()
+
+	// A contact + its person node (the interaction FK target).
+	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: "Venue Backfill Subject"})
+	require.NoError(t, err)
+
+	// --- telegram: two messages in ONE chat (must share one venue node) ---
+	tgChatID := int64(778899)
+	tg1 := uuid.New()
+	tg2 := uuid.New()
+	seedTelegramInteraction(ctx, t, interactionRepo, database.Queries, tg1, contact.ID, tgChatID, 1, now)
+	seedTelegramInteraction(ctx, t, interactionRepo, database.Queries, tg2, contact.ID, tgChatID, 2, now)
+	tgContainer := fmt.Sprintf("%d", tgChatID)
+
+	// --- gcal: an event + an interaction joined by source_ref = calendar_event.id ---
+	event, err := calendarRepo.Upsert(ctx, repository.UpsertCalendarEventRequest{
+		GcalEventID:     "evt-backfill-1",
+		GcalCalendarID:  "primary",
+		GoogleAccountID: "acct-backfill-1",
+		StartTime:       now,
+		EndTime:         now.Add(time.Hour),
+		Status:          "confirmed",
+		SyncedAt:        now,
+	})
+	require.NoError(t, err)
+	gcalID := uuid.New()
+	gcalRef := event.ID.String()
+	_, err = interactionRepo.TestInsertInteraction(ctx, gcalID, contact.ID, repository.InteractionSourceGCal, &gcalRef, now, repository.InteractionDirectionMutual)
+	require.NoError(t, err)
+	gcalContainer := repository.GCalVenueContainerID(event.GcalEventID, event.GcalCalendarID, event.GoogleAccountID)
+
+	// --- anarlog linked to the gcal event: must REUSE the gcal meeting venue ---
+	linkedKind := repository.LinkedKindEvent
+	linkedSession := uuid.New()
+	mnTx, err := database.Pool.Begin(ctx)
+	require.NoError(t, err)
+	_, err = meetingNoteRepo.InsertMeetingNoteTx(ctx, mnTx, repository.InsertMeetingNoteParams{
+		AnarlogSessionID: linkedSession,
+		LinkedKind:       &linkedKind,
+		LinkedID:         &event.ID,
+		LinkageState:     repository.LinkageStateLinked,
+		MeetingAt:        now,
+	})
+	require.NoError(t, err)
+	require.NoError(t, mnTx.Commit(ctx))
+	anarlogLinkedID := uuid.New()
+	anarlogLinkedRef := fmt.Sprintf("anarlog:%s:%s", linkedSession, contact.ID)
+	_, err = interactionRepo.TestInsertInteraction(ctx, anarlogLinkedID, contact.ID, repository.InteractionSourceAnarlogSessions, &anarlogLinkedRef, now, repository.InteractionDirectionMutual)
+	require.NoError(t, err)
+
+	// --- anarlog UNLINKED: gets its own session venue ---
+	unlinkedSession := uuid.New()
+	anarlogUnlinkedID := uuid.New()
+	anarlogUnlinkedRef := fmt.Sprintf("anarlog:%s:%s", unlinkedSession, contact.ID)
+	_, err = interactionRepo.TestInsertInteraction(ctx, anarlogUnlinkedID, contact.ID, repository.InteractionSourceAnarlogSessions, &anarlogUnlinkedRef, now, repository.InteractionDirectionMutual)
+	require.NoError(t, err)
+
+	// --- manual: no container → venue_id stays NULL ---
+	manualID := uuid.New()
+	_, err = interactionRepo.TestInsertInteraction(ctx, manualID, contact.ID, repository.InteractionSourceManual, nil, now, repository.InteractionDirectionMutual)
+	require.NoError(t, err)
+
+	// Cadence regression (the headline risk): snapshot the contact's cadence
+	// columns BEFORE the backfill so we can prove the backfill touches NO cadence
+	// state — it only populates interaction.venue_id.
+	beforeBackfill, err := contactRepo.GetContact(ctx, contact.ID)
+	require.NoError(t, err)
+
+	// Run the backfill by rolling 069 down then up on the clone.
+	m, err := migrate.New(fmt.Sprintf("file://%s", migrationsPath), cloneURL)
+	require.NoError(t, err)
+	t.Cleanup(func() { _, _ = m.Close() })
+	if err := m.Migrate(interactionVenueVersion); err != nil && !errors.Is(err, migrate.ErrNoChange) {
+		require.NoError(t, err, "position the clone at the venue-model tip")
+	}
+	require.NoError(t, m.Steps(-1), "roll the venue-model migration down")
+	require.NoError(t, m.Steps(1), "re-apply the venue model (runs the backfill over the seeded rows)")
+
+	// Cadence columns are byte-identical after the backfill (it never touches the
+	// contact row).
+	afterBackfill, err := contactRepo.GetContact(ctx, contact.ID)
+	require.NoError(t, err)
+	assert.Equal(t, beforeBackfill.LastContacted, afterBackfill.LastContacted, "backfill must not touch last_contacted")
+	assert.Equal(t, beforeBackfill.LastInteractionAt, afterBackfill.LastInteractionAt, "backfill must not touch last_interaction_at")
+	assert.Equal(t, beforeBackfill.LastOutreachAt, afterBackfill.LastOutreachAt, "backfill must not touch last_outreach_at")
+	assert.Equal(t, beforeBackfill.LastResponseAt, afterBackfill.LastResponseAt, "backfill must not touch last_response_at")
+	assert.Equal(t, beforeBackfill.ContactBy, afterBackfill.ContactBy, "backfill must not touch contact_by")
+
+	// gcal interaction resolves to a meeting venue keyed on the 3-tuple.
+	gcalVenueID := requireInteractionVenue(t, ctx, interactionRepo, venueRepo, gcalID, repository.InteractionSourceGCal, repository.VenueKindMeeting, gcalContainer)
+
+	// telegram: both rows resolve to the SAME venue node (one container).
+	tg1Venue := requireInteractionVenue(t, ctx, interactionRepo, venueRepo, tg1, repository.InteractionSourceTelegram, repository.VenueKindDM, tgContainer)
+	tg2Venue := requireInteractionVenue(t, ctx, interactionRepo, venueRepo, tg2, repository.InteractionSourceTelegram, repository.VenueKindDM, tgContainer)
+	require.Equal(t, tg1Venue, tg2Venue, "two messages in one chat must share one venue node")
+
+	// The backfill node id matches the live helper's deterministic id (they must
+	// stay in sync so live recorders and the backfill converge on one node).
+	require.Equal(t, repository.VenueNodeID(repository.InteractionSourceTelegram, repository.VenueKindDM, tgContainer), tg1Venue,
+		"backfill venue node id must equal the live helper's deterministic id")
+
+	// anarlog LINKED reuses the gcal meeting venue (the only cross-source merge).
+	linkedInteraction, err := interactionRepo.GetInteraction(ctx, anarlogLinkedID)
+	require.NoError(t, err)
+	require.NotNil(t, linkedInteraction.VenueID)
+	require.Equal(t, gcalVenueID, *linkedInteraction.VenueID, "anarlog linked to a gcal event must reuse the gcal meeting venue")
+
+	// anarlog UNLINKED gets its own session venue.
+	requireInteractionVenue(t, ctx, interactionRepo, venueRepo, anarlogUnlinkedID,
+		repository.InteractionSourceAnarlogSessions, repository.VenueKindSession, unlinkedSession.String())
+
+	// manual interaction has NO venue.
+	manualInteraction, err := interactionRepo.GetInteraction(ctx, manualID)
+	require.NoError(t, err)
+	require.Nil(t, manualInteraction.VenueID, "manual interaction must have a NULL venue_id")
+
+	// Idempotent re-run: rolling down+up again leaves identical venue ids.
+	require.NoError(t, m.Steps(-1), "roll down again")
+	require.NoError(t, m.Steps(1), "re-run the backfill (must be idempotent)")
+	tg1VenueAgain := requireInteractionVenue(t, ctx, interactionRepo, venueRepo, tg1, repository.InteractionSourceTelegram, repository.VenueKindDM, tgContainer)
+	require.Equal(t, tg1Venue, tg1VenueAgain, "idempotent re-run must resolve to the same venue node")
+}
+
+// TestInteractionVenue_MigrationAtomicity proves the 069 up migration is
+// explicitly transactional: a forced mid-migration error must leave NO venue_id
+// column (the explicit BEGIN/COMMIT rolls back the ADD COLUMN + CREATE INDEX
+// that ran before the error). Without the explicit tx the postgres driver would
+// leave the partial DDL committed.
+func TestInteractionVenue_MigrationAtomicity(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	if os.Getenv("DATABASE_URL") == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	ctx := context.Background()
+	cloneURL, drop := testdb.NewEphemeralClone(t)
+	t.Cleanup(drop)
+
+	cfg := config.TestConfig()
+	cfg.Database.URL = cloneURL
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	t.Cleanup(database.Close)
+
+	// Roll the venue model down so the column is absent, then attempt a broken
+	// up that mirrors 069's opening (ADD COLUMN + CREATE INDEX) wrapped in
+	// BEGIN/COMMIT but with a forced error before COMMIT.
+	m, err := migrate.New(fmt.Sprintf("file://%s", getMigrationsPath()), cloneURL)
+	require.NoError(t, err)
+	t.Cleanup(func() { _, _ = m.Close() })
+	if err := m.Migrate(interactionVenueVersion); err != nil && !errors.Is(err, migrate.ErrNoChange) {
+		require.NoError(t, err)
+	}
+	require.NoError(t, m.Steps(-1), "roll the venue model down so venue_id is absent")
+	require.False(t, interactionVenueColumnExists(ctx, t, database), "precondition: venue_id absent after down")
+
+	// A broken transactional migration that runs the DDL then errors before COMMIT.
+	broken := `BEGIN;
+ALTER TABLE interaction ADD COLUMN IF NOT EXISTS venue_id UUID REFERENCES node(id);
+CREATE INDEX IF NOT EXISTS idx_interaction_venue_id ON interaction (venue_id) WHERE venue_id IS NOT NULL AND deleted_at IS NULL;
+SELECT 1/0;
+COMMIT;`
+	_, execErr := database.Pool.Exec(ctx, broken)
+	require.Error(t, execErr, "the broken migration must fail (division by zero)")
+
+	// Atomicity: the explicit BEGIN/COMMIT rolled the ADD COLUMN back — no column.
+	require.False(t, interactionVenueColumnExists(ctx, t, database),
+		"venue_id must NOT survive a mid-migration error (proves the explicit transaction)")
+
+	// Re-apply the real migration cleanly so teardown is on a consistent schema.
+	require.NoError(t, m.Steps(1), "re-apply the real venue model")
+	require.True(t, interactionVenueColumnExists(ctx, t, database))
+}
+
+// --- helpers ---
+
+// seedTelegramInteraction inserts a venue-less interaction plus a telegram_message
+// content row linked back to it (private chat → dm venue). Uses the test-only
+// generated insert directly (the convention in telegram_message_all_fields_test).
+func seedTelegramInteraction(
+	ctx context.Context, t *testing.T,
+	interactionRepo *repository.InteractionRepository, queries db.Querier,
+	interactionID, contactID uuid.UUID, chatID int64, messageID int32, occurredAt time.Time,
+) {
+	t.Helper()
+	ref := fmt.Sprintf("tg:%d:%d", chatID, messageID)
+	_, err := interactionRepo.TestInsertInteraction(ctx, interactionID, contactID, repository.InteractionSourceTelegram, &ref, occurredAt, repository.InteractionDirectionInbound)
+	require.NoError(t, err)
+	ts := pgtype.Timestamptz{Time: occurredAt, Valid: true}
+	_, err = queries.InsertFullTelegramMessageForTest(ctx, db.InsertFullTelegramMessageForTestParams{
+		TelegramMessageID: messageID,
+		TelegramChatID:    chatID,
+		ChatType:          "private",
+		ChatTitle:         pgtype.Text{String: "DM with Subject", Valid: true},
+		MessageType:       "text",
+		SentAt:            ts,
+		IsOutgoing:        false,
+		MatchedContactID:  pgtype.UUID{Bytes: contactID, Valid: true},
+		InteractionID:     pgtype.UUID{Bytes: interactionID, Valid: true},
+	})
+	require.NoError(t, err)
+}
+
+// requireInteractionVenue asserts the interaction resolved to a venue with the
+// expected (source, kind, container) and returns its node id.
+func requireInteractionVenue(
+	t *testing.T, ctx context.Context,
+	interactionRepo *repository.InteractionRepository, venueRepo *repository.VenueRepository,
+	interactionID uuid.UUID, source, kind, container string,
+) uuid.UUID {
+	t.Helper()
+	interaction, err := interactionRepo.GetInteraction(ctx, interactionID)
+	require.NoError(t, err)
+	require.NotNil(t, interaction.VenueID, "interaction %s must have a venue_id", interactionID)
+	venue, err := venueRepo.GetVenue(ctx, *interaction.VenueID)
+	require.NoError(t, err)
+	assert.Equal(t, source, venue.Source)
+	assert.Equal(t, kind, venue.Kind)
+	assert.Equal(t, container, venue.SourceContainerID)
+	return *interaction.VenueID
+}
+
+// distinctVenueNodeIDs returns the distinct venue node ids across a contact's
+// interactions of the given source.
+func distinctVenueNodeIDs(t *testing.T, ctx context.Context, h *synthetic.Harness, contactID uuid.UUID, source string) []uuid.UUID {
+	t.Helper()
+	rows, err := h.InteractionRepo().ListContactInteractions(ctx, contactID, 100, 0)
+	require.NoError(t, err)
+	seen := map[uuid.UUID]struct{}{}
+	var out []uuid.UUID
+	for _, r := range rows {
+		if r.Source != source || r.VenueID == nil {
+			continue
+		}
+		if _, ok := seen[*r.VenueID]; ok {
+			continue
+		}
+		seen[*r.VenueID] = struct{}{}
+		out = append(out, *r.VenueID)
+	}
+	return out
+}
+
+// interactionVenueColumnExists reports whether interaction.venue_id is present.
+func interactionVenueColumnExists(ctx context.Context, t *testing.T, database *db.Database) bool {
+	t.Helper()
+	var exists bool
+	err := database.Pool.QueryRow(ctx, `SELECT EXISTS (
+		SELECT 1 FROM information_schema.columns
+		WHERE table_name = 'interaction' AND column_name = 'venue_id')`).Scan(&exists)
+	require.NoError(t, err)
+	return exists
+}

--- a/backend/tests/interaction_venue_integration_test.go
+++ b/backend/tests/interaction_venue_integration_test.go
@@ -7,11 +7,13 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
 	"personal-crm/backend/internal/accelerated"
 	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/consumer"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/synthetic"
@@ -130,6 +132,7 @@ func TestInteractionVenue_Backfill(t *testing.T) {
 	calendarRepo := repository.NewCalendarEventRepository(database.Queries)
 	meetingNoteRepo := repository.NewMeetingNoteRepository(database.Queries)
 	venueRepo := repository.NewVenueRepository(database.Queries)
+	nodeRepo := repository.NewNodeRepository(database.Queries)
 
 	now := accelerated.GetCurrentTime().UTC()
 
@@ -286,6 +289,28 @@ func TestInteractionVenue_Backfill(t *testing.T) {
 	assert.Equal(t, beforeBackfill.LastResponseAt, afterBackfill.LastResponseAt, "backfill must not touch last_response_at")
 	assert.Equal(t, beforeBackfill.ContactBy, afterBackfill.ContactBy, "backfill must not touch contact_by")
 
+	// Recompute leg (plan §459): run a CadenceUpdater apply against the now-
+	// venue-bearing interactions and assert the cadence columns are STILL
+	// byte-identical. The cadence machinery partitions purely by contact_id and
+	// never reads venue_id, so applying a stale (older-than-last_contacted)
+	// telegram interaction is a forward-only no-op that must leave cadence
+	// untouched — proving the recompute path is unperturbed by the new column.
+	claimRepo := repository.NewEventConsumerClaimRepository(database.Queries)
+	cadenceUpdater := consumer.NewCadenceUpdater(claimRepo, contactRepo, database.Queries, consumer.CadenceModeCutover, false)
+	recomputeTx, err := database.Pool.Begin(ctx)
+	require.NoError(t, err)
+	require.NoError(t, cadenceUpdater.ApplyInteraction(ctx, recomputeTx, repository.ApplyInteractionRequest{
+		ContactID:  contact.ID,
+		Direction:  repository.InteractionDirectionInbound,
+		Source:     repository.InteractionSourceTelegram,
+		OccurredAt: lastContacted.Add(-24 * time.Hour), // older than last_contacted → forward-only no-op
+	}))
+	require.NoError(t, recomputeTx.Commit(ctx))
+	afterRecompute, err := contactRepo.GetContact(ctx, contact.ID)
+	require.NoError(t, err)
+	assert.Equal(t, afterBackfill.LastContacted, afterRecompute.LastContacted, "cadence recompute must be identical post-backfill")
+	assert.Equal(t, afterBackfill.ContactBy, afterRecompute.ContactBy, "cadence recompute must be identical post-backfill")
+
 	// gcal interaction resolves to a meeting venue keyed on the 3-tuple.
 	gcalVenueID := requireInteractionVenue(t, ctx, interactionRepo, venueRepo, gcalID, repository.InteractionSourceGCal, repository.VenueKindMeeting, gcalContainer)
 
@@ -322,7 +347,7 @@ func TestInteractionVenue_Backfill(t *testing.T) {
 
 	// No orphan venue nodes: every venue-type node is referenced by at least one
 	// interaction (proves the WHERE NOT EXISTS node-mint guard).
-	require.Zero(t, countOrphanVenueNodes(ctx, t, database), "backfill must leave no orphan venue nodes")
+	require.Zero(t, countOrphanVenueNodes(ctx, t, nodeRepo), "backfill must leave no orphan venue nodes")
 
 	// manual interaction has NO venue.
 	manualInteraction, err := interactionRepo.GetInteraction(ctx, manualID)
@@ -333,41 +358,42 @@ func TestInteractionVenue_Backfill(t *testing.T) {
 	// (no down) and assert it is a true no-op — the venue node count and every
 	// venue_id are unchanged (proves WHERE venue_id IS NULL + the ON CONFLICT
 	// guards, not just down/up symmetry).
-	venueNodesBefore := countVenueNodes(ctx, t, database)
+	venueNodesBefore := countVenueNodes(ctx, t, nodeRepo)
 	upSQL, readErr := os.ReadFile(migrationsPath + "/069_interaction_venue.up.sql")
 	require.NoError(t, readErr)
 	_, err = database.Pool.Exec(ctx, string(upSQL))
 	require.NoError(t, err, "re-running the up migration backfill in-place must succeed")
-	require.Equal(t, venueNodesBefore, countVenueNodes(ctx, t, database), "in-place re-run must not create new venue nodes")
+	require.Equal(t, venueNodesBefore, countVenueNodes(ctx, t, nodeRepo), "in-place re-run must not create new venue nodes")
 	tg1VenueAgain := requireInteractionVenue(t, ctx, interactionRepo, venueRepo, tg1, repository.InteractionSourceTelegram, repository.VenueKindDM, tgContainer)
 	require.Equal(t, tg1Venue, tg1VenueAgain, "in-place re-run must leave venue_id unchanged")
 }
 
-// countVenueNodes returns the number of venue-type nodes.
-func countVenueNodes(ctx context.Context, t *testing.T, database *db.Database) int64 {
+// countVenueNodes returns the number of venue-type nodes (via the test-only
+// sqlc count, not raw SQL).
+func countVenueNodes(ctx context.Context, t *testing.T, nodeRepo *repository.NodeRepository) int64 {
 	t.Helper()
-	var n int64
-	require.NoError(t, database.Pool.QueryRow(ctx, `SELECT count(*) FROM node WHERE type = 'venue'`).Scan(&n))
+	n, err := nodeRepo.TestCountVenueNodes(ctx)
+	require.NoError(t, err)
 	return n
 }
 
 // countOrphanVenueNodes returns the number of venue-type nodes that no live
-// interaction references via venue_id.
-func countOrphanVenueNodes(ctx context.Context, t *testing.T, database *db.Database) int64 {
+// interaction references via venue_id (via the test-only sqlc count).
+func countOrphanVenueNodes(ctx context.Context, t *testing.T, nodeRepo *repository.NodeRepository) int64 {
 	t.Helper()
-	var n int64
-	require.NoError(t, database.Pool.QueryRow(ctx, `
-		SELECT count(*) FROM node nd
-		WHERE nd.type = 'venue'
-		  AND NOT EXISTS (SELECT 1 FROM interaction i WHERE i.venue_id = nd.id)`).Scan(&n))
+	n, err := nodeRepo.TestCountOrphanVenueNodes(ctx)
+	require.NoError(t, err)
 	return n
 }
 
-// TestInteractionVenue_MigrationAtomicity proves the 069 up migration is
-// explicitly transactional: a forced mid-migration error must leave NO venue_id
-// column (the explicit BEGIN/COMMIT rolls back the ADD COLUMN + CREATE INDEX
-// that ran before the error). Without the explicit tx the postgres driver would
-// leave the partial DDL committed.
+// TestInteractionVenue_MigrationAtomicity proves the REAL 069 up migration is
+// explicitly transactional: it runs the actual 069_interaction_venue.up.sql
+// content (with a deterministic error injected just before its own COMMIT) and
+// asserts venue_id did NOT survive. Because the injected error is placed inside
+// the real file's own BEGIN..COMMIT boundary, the test FAILS if a future edit
+// strips BEGIN;/COMMIT; from the real file (the ADD COLUMN would then commit
+// before the error). The companion guard-skip case below proves the actual file
+// also tolerates a malformed anarlog source_ref without aborting.
 func TestInteractionVenue_MigrationAtomicity(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
@@ -386,10 +412,10 @@ func TestInteractionVenue_MigrationAtomicity(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(database.Close)
 
-	// Roll the venue model down so the column is absent, then attempt a broken
-	// up that mirrors 069's opening (ADD COLUMN + CREATE INDEX) wrapped in
-	// BEGIN/COMMIT but with a forced error before COMMIT.
-	m, err := migrate.New(fmt.Sprintf("file://%s", getMigrationsPath()), cloneURL)
+	migrationsPath := getMigrationsPath()
+
+	// Roll the venue model down so the column is absent.
+	m, err := migrate.New(fmt.Sprintf("file://%s", migrationsPath), cloneURL)
 	require.NoError(t, err)
 	t.Cleanup(func() { _, _ = m.Close() })
 	if err := m.Migrate(interactionVenueVersion); err != nil && !errors.Is(err, migrate.ErrNoChange) {
@@ -398,25 +424,175 @@ func TestInteractionVenue_MigrationAtomicity(t *testing.T) {
 	require.NoError(t, m.Steps(-1), "roll the venue model down so venue_id is absent")
 	require.False(t, interactionVenueColumnExists(ctx, t, database), "precondition: venue_id absent after down")
 
-	// A broken transactional migration that runs the DDL then errors before COMMIT.
-	broken := `BEGIN;
-ALTER TABLE interaction ADD COLUMN IF NOT EXISTS venue_id UUID REFERENCES node(id);
-CREATE INDEX IF NOT EXISTS idx_interaction_venue_id ON interaction (venue_id) WHERE venue_id IS NOT NULL AND deleted_at IS NULL;
-SELECT 1/0;
-COMMIT;`
-	_, execErr := database.Pool.Exec(ctx, broken)
-	require.Error(t, execErr, "the broken migration must fail (division by zero)")
-
-	// Atomicity: the explicit BEGIN/COMMIT rolled the ADD COLUMN back — no column.
+	// Take the REAL 069 up SQL and inject a deterministic error immediately
+	// before its OWN final COMMIT; — so the whole real file (its BEGIN, its DDL,
+	// its backfill) runs and then errors while still inside the file's own
+	// transaction. If BEGIN;/COMMIT; are present (they are), the ADD COLUMN rolls
+	// back. If a future edit removes them, the ADD COLUMN auto-commits before the
+	// error and this assertion fails — which is exactly the regression we guard.
+	realUp, readErr := os.ReadFile(migrationsPath + "/069_interaction_venue.up.sql")
+	require.NoError(t, readErr)
+	brokenReal := injectErrorBeforeFinalCommit(t, string(realUp))
+	_, execErr := database.Pool.Exec(ctx, brokenReal)
+	require.Error(t, execErr, "the error injected into the real migration must fail it")
 	require.False(t, interactionVenueColumnExists(ctx, t, database),
-		"venue_id must NOT survive a mid-migration error (proves the explicit transaction)")
+		"venue_id must NOT survive an error inside the real file's BEGIN..COMMIT (proves it is explicitly transactional)")
 
 	// Re-apply the real migration cleanly so teardown is on a consistent schema.
 	require.NoError(t, m.Steps(1), "re-apply the real venue model")
 	require.True(t, interactionVenueColumnExists(ctx, t, database))
 }
 
+// TestInteractionVenue_MalformedAnarlogRefIsSkipped runs the REAL 069 migration
+// over a malformed anarlog interaction (source_ref segment-2 is NOT a UUID) and
+// asserts the migration SUCCEEDS — the Step-1 ::uuid-cast guard skips the bad row
+// rather than aborting the whole BEGIN..COMMIT. A well-formed anarlog row in the
+// same run still resolves to its session venue. This test FAILS if the guard is
+// removed from the real file (the cast then raises invalid-uuid and aborts).
+func TestInteractionVenue_MalformedAnarlogRefIsSkipped(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	if os.Getenv("DATABASE_URL") == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	ctx := context.Background()
+	cloneURL, drop := testdb.NewEphemeralClone(t)
+	t.Cleanup(drop)
+
+	cfg := config.TestConfig()
+	cfg.Database.URL = cloneURL
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	t.Cleanup(database.Close)
+
+	contactRepo := repository.NewContactRepository(database.Queries)
+	interactionRepo := repository.NewInteractionRepository(database.Queries)
+	venueRepo := repository.NewVenueRepository(database.Queries)
+	now := accelerated.GetCurrentTime().UTC()
+
+	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: "Malformed Anarlog Subject"})
+	require.NoError(t, err)
+
+	// A malformed anarlog ref: segment 2 is not a UUID. The Step-1 ::uuid cast
+	// must NOT fire on this row.
+	badID := uuid.New()
+	badRef := fmt.Sprintf("anarlog:not-a-uuid:%s", contact.ID)
+	_, err = interactionRepo.TestInsertInteraction(ctx, badID, contact.ID, repository.InteractionSourceAnarlogSessions, &badRef, now, repository.InteractionDirectionMutual)
+	require.NoError(t, err)
+
+	// A well-formed anarlog (unlinked) ref in the same run → a session venue.
+	goodSession := uuid.New()
+	goodID := uuid.New()
+	goodRef := fmt.Sprintf("anarlog:%s:%s", goodSession, contact.ID)
+	_, err = interactionRepo.TestInsertInteraction(ctx, goodID, contact.ID, repository.InteractionSourceAnarlogSessions, &goodRef, now, repository.InteractionDirectionMutual)
+	require.NoError(t, err)
+
+	// Run the REAL 069 by rolling it down then up over the seeded rows.
+	m, err := migrate.New(fmt.Sprintf("file://%s", getMigrationsPath()), cloneURL)
+	require.NoError(t, err)
+	t.Cleanup(func() { _, _ = m.Close() })
+	if err := m.Migrate(interactionVenueVersion); err != nil && !errors.Is(err, migrate.ErrNoChange) {
+		require.NoError(t, err)
+	}
+	require.NoError(t, m.Steps(-1), "roll the venue model down")
+	require.NoError(t, m.Steps(1), "the REAL backfill must SUCCEED despite the malformed anarlog ref (guard skips it)")
+
+	// The well-formed row resolves to its session venue.
+	requireInteractionVenue(t, ctx, interactionRepo, venueRepo, goodID,
+		repository.InteractionSourceAnarlogSessions, repository.VenueKindSession, goodSession.String())
+
+	// The malformed row did NOT trip the Step-1 ::uuid cast: Step-2 (text-based)
+	// gives it a session venue keyed on the raw segment-2 text, so the migration
+	// completes. The key invariant is that the migration succeeded at all.
+	badInteraction, err := interactionRepo.GetInteraction(ctx, badID)
+	require.NoError(t, err)
+	require.NotNil(t, badInteraction.VenueID, "malformed row gets a session venue from the text-based Step 2")
+}
+
+// TestInteractionVenue_DownGuardPreservesReferencedVenue runs the 069 DOWN over
+// two venue nodes — one referenced by an assertion, one not — and asserts the
+// guarded cleanup deletes ONLY the unreferenced one. This exercises the down
+// migration's assertion-reference guard (otherwise only ever run as a bare
+// reposition Steps(-1)).
+func TestInteractionVenue_DownGuardPreservesReferencedVenue(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	if os.Getenv("DATABASE_URL") == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	ctx := context.Background()
+	cloneURL, drop := testdb.NewEphemeralClone(t)
+	t.Cleanup(drop)
+
+	cfg := config.TestConfig()
+	cfg.Database.URL = cloneURL
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	t.Cleanup(database.Close)
+
+	nodeRepo := repository.NewNodeRepository(database.Queries)
+	venueRepo := repository.NewVenueRepository(database.Queries)
+	assertionRepo := repository.NewAssertionRepository(database.Queries)
+	now := accelerated.GetCurrentTime().UTC()
+
+	// Two venue nodes via the resolver (clone is at the tip, venue_id present).
+	tx, err := database.Pool.Begin(ctx)
+	require.NoError(t, err)
+	referencedVenue, err := venueRepo.ResolveVenueForInteraction(ctx, tx, repository.InteractionSourceTelegram, repository.VenueKindDM, "down-guard-referenced", "")
+	require.NoError(t, err)
+	unreferencedVenue, err := venueRepo.ResolveVenueForInteraction(ctx, tx, repository.InteractionSourceTelegram, repository.VenueKindDM, "down-guard-unreferenced", "")
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit(ctx))
+
+	// An accepted assertion whose subject is the referenced venue node. The
+	// assertion→node FK is restrict, so the down's guard must keep this node.
+	addr := "down-guard-value"
+	_, err = assertionRepo.InsertAssertion(ctx, repository.InsertAssertionParams{
+		SubjectNodeID:  referencedVenue,
+		PredicateKey:   "home_address",
+		ValueText:      &addr,
+		KnowledgeFrom:  now,
+		Confidence:     80,
+		Salience:       40,
+		Status:         repository.AssertionStatusAccepted,
+		PropositionKey: "down-guard-prop-1",
+	})
+	require.NoError(t, err)
+
+	// Roll 069 DOWN.
+	m, err := migrate.New(fmt.Sprintf("file://%s", getMigrationsPath()), cloneURL)
+	require.NoError(t, err)
+	t.Cleanup(func() { _, _ = m.Close() })
+	if err := m.Migrate(interactionVenueVersion); err != nil && !errors.Is(err, migrate.ErrNoChange) {
+		require.NoError(t, err)
+	}
+	require.NoError(t, m.Steps(-1), "roll the venue model down")
+
+	// The assertion-referenced venue node SURVIVES; the unreferenced one is gone.
+	_, err = nodeRepo.GetNode(ctx, referencedVenue)
+	require.NoError(t, err, "the assertion-referenced venue node must survive the guarded down")
+	_, err = nodeRepo.GetNode(ctx, unreferencedVenue)
+	require.ErrorIs(t, err, db.ErrNotFound, "the unreferenced venue node must be removed by the down")
+}
+
 // --- helpers ---
+
+// injectErrorBeforeFinalCommit returns the migration SQL with a deterministic
+// failing statement (SELECT 1/0) inserted immediately before the file's LAST
+// COMMIT; line. The error therefore fires INSIDE the file's own transaction —
+// so the test is sensitive to whether the real file actually has BEGIN;/COMMIT;
+// (strip them and the DDL auto-commits before the error). Fails the test loudly
+// if the file has no COMMIT; to anchor against.
+func injectErrorBeforeFinalCommit(t *testing.T, sql string) string {
+	t.Helper()
+	idx := strings.LastIndex(sql, "COMMIT;")
+	require.GreaterOrEqual(t, idx, 0, "the real migration must contain a COMMIT; to anchor the injected error")
+	return sql[:idx] + "SELECT 1/0;\n" + sql[idx:]
+}
 
 // seedTelegramInteraction inserts a venue-less interaction plus a telegram_message
 // content row linked back to it (private chat → dm venue). Uses the test-only

--- a/backend/tests/interaction_venue_integration_test.go
+++ b/backend/tests/interaction_venue_integration_test.go
@@ -92,15 +92,6 @@ func TestInteractionVenue_LivePath(t *testing.T) {
 	}
 }
 
-// venueBackfillSeed is one seeded interaction (+ optional content) for the
-// backfill test, plus the venue identity the backfill must resolve it to.
-type venueBackfillSeed struct {
-	interactionID   uuid.UUID
-	source          string
-	expectKind      string // "" → expect NULL venue (manual)
-	expectContainer string
-}
-
 // TestInteractionVenue_Backfill seeds pre-existing venue-less interactions across
 // the distinct backfill JOIN SHAPES and asserts each resolves to the expected
 // venue. The three shapes are: the content interaction_id FK (telegram here;
@@ -142,9 +133,18 @@ func TestInteractionVenue_Backfill(t *testing.T) {
 
 	now := accelerated.GetCurrentTime().UTC()
 
-	// A contact + its person node (the interaction FK target).
-	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: "Venue Backfill Subject"})
+	// A contact + its person node (the interaction FK target). Seed it with a
+	// populated cadence + last_contacted so the byte-identical cadence assertion
+	// below is a non-trivial check (a mostly-NULL contact would pass vacuously).
+	cadence := "weekly"
+	lastContacted := now.Add(-72 * time.Hour)
+	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
+		FullName:      "Venue Backfill Subject",
+		Cadence:       &cadence,
+		LastContacted: &lastContacted,
+	})
 	require.NoError(t, err)
+	require.NotNil(t, contact.LastContacted, "precondition: seeded contact has a populated cadence state")
 
 	// --- telegram: two messages in ONE chat (must share one venue node) ---
 	tgChatID := int64(778899)
@@ -195,6 +195,64 @@ func TestInteractionVenue_Backfill(t *testing.T) {
 	anarlogUnlinkedID := uuid.New()
 	anarlogUnlinkedRef := fmt.Sprintf("anarlog:%s:%s", unlinkedSession, contact.ID)
 	_, err = interactionRepo.TestInsertInteraction(ctx, anarlogUnlinkedID, contact.ID, repository.InteractionSourceAnarlogSessions, &anarlogUnlinkedRef, now, repository.InteractionDirectionMutual)
+	require.NoError(t, err)
+
+	// --- messages: group chat keyed on chat_guid (content interaction_id FK) ---
+	messagesID := uuid.New()
+	messagesContainer := "iMessage;+;chat-guid-backfill"
+	mRef := "msg-ix"
+	_, err = interactionRepo.TestInsertInteraction(ctx, messagesID, contact.ID, repository.InteractionSourceMessages, &mRef, now, repository.InteractionDirectionInbound)
+	require.NoError(t, err)
+	_, err = database.Queries.TestInsertMessagesMessageLinked(ctx, db.TestInsertMessagesMessageLinkedParams{
+		Guid: "imsg-guid-1", ChatGuid: messagesContainer, PeerHandle: "+15551110000",
+		SentAt: pgtype.Timestamptz{Time: now, Valid: true}, IsOutgoing: false, IsGroupChat: true,
+		InteractionID: pgtype.UUID{Bytes: messagesID, Valid: true},
+	})
+	require.NoError(t, err)
+
+	// --- email: thread keyed on comms_message.thread_id (content FK) ---
+	emailID := uuid.New()
+	emailContainer := "THREAD-backfill-1"
+	eRef := "email-ix"
+	_, err = interactionRepo.TestInsertInteraction(ctx, emailID, contact.ID, repository.InteractionSourceEmail, &eRef, now, repository.InteractionDirectionInbound)
+	require.NoError(t, err)
+	_, err = database.Queries.TestInsertCommsMessageLinked(ctx, db.TestInsertCommsMessageLinkedParams{
+		Source: repository.InteractionSourceEmail, ExternalID: "msgid-backfill-1",
+		ThreadID: pgtype.Text{String: emailContainer, Valid: true}, Direction: "inbound",
+		SentAt:           pgtype.Timestamptz{Time: now, Valid: true},
+		MatchedContactID: pgtype.UUID{Bytes: contact.ID, Valid: true},
+		InteractionID:    pgtype.UUID{Bytes: emailID, Valid: true},
+	})
+	require.NoError(t, err)
+
+	// --- gchat: group_chat keyed on comms_message.thread_id (space resource) ---
+	gchatID := uuid.New()
+	gchatContainer := "spaces/AAAAbackfill"
+	gcRef := "gchat-ix"
+	_, err = interactionRepo.TestInsertInteraction(ctx, gchatID, contact.ID, repository.InteractionSourceGChat, &gcRef, now, repository.InteractionDirectionInbound)
+	require.NoError(t, err)
+	_, err = database.Queries.TestInsertCommsMessageLinked(ctx, db.TestInsertCommsMessageLinkedParams{
+		Source: repository.InteractionSourceGChat, ExternalID: "gcmsg-backfill-1",
+		ThreadID: pgtype.Text{String: gchatContainer, Valid: true}, Direction: "inbound",
+		SentAt:           pgtype.Timestamptz{Time: now, Valid: true},
+		MatchedContactID: pgtype.UUID{Bytes: contact.ID, Valid: true},
+		InteractionID:    pgtype.UUID{Bytes: gchatID, Valid: true},
+	})
+	require.NoError(t, err)
+
+	// --- phone: call keyed on phone_call.call_unique_id (content FK) ---
+	phoneID := uuid.New()
+	phoneContainer := "call-uid-backfill-1"
+	pRef := "phone-ix"
+	_, err = interactionRepo.TestInsertInteraction(ctx, phoneID, contact.ID, repository.InteractionSourcePhoneCalls, &pRef, now, repository.InteractionDirectionInbound)
+	require.NoError(t, err)
+	_, err = database.Queries.TestInsertPhoneCallLinked(ctx, db.TestInsertPhoneCallLinkedParams{
+		CallUniqueID: phoneContainer, PeerHandle: "+15551110000", PeerNormalized: "+15551110000",
+		Service: "voice", Direction: "inbound", DurationSeconds: 60,
+		StartedAt:        pgtype.Timestamptz{Time: now, Valid: true},
+		MatchedContactID: pgtype.UUID{Bytes: contact.ID, Valid: true},
+		InteractionID:    pgtype.UUID{Bytes: phoneID, Valid: true},
+	})
 	require.NoError(t, err)
 
 	// --- manual: no container → venue_id stays NULL ---
@@ -251,6 +309,21 @@ func TestInteractionVenue_Backfill(t *testing.T) {
 	requireInteractionVenue(t, ctx, interactionRepo, venueRepo, anarlogUnlinkedID,
 		repository.InteractionSourceAnarlogSessions, repository.VenueKindSession, unlinkedSession.String())
 
+	// messages / email / gchat / phone each resolve to their expected venue
+	// (the content interaction_id FK join shapes).
+	requireInteractionVenue(t, ctx, interactionRepo, venueRepo, messagesID,
+		repository.InteractionSourceMessages, repository.VenueKindGroupChat, messagesContainer)
+	requireInteractionVenue(t, ctx, interactionRepo, venueRepo, emailID,
+		repository.InteractionSourceEmail, repository.VenueKindEmailThread, emailContainer)
+	requireInteractionVenue(t, ctx, interactionRepo, venueRepo, gchatID,
+		repository.InteractionSourceGChat, repository.VenueKindGroupChat, gchatContainer)
+	requireInteractionVenue(t, ctx, interactionRepo, venueRepo, phoneID,
+		repository.InteractionSourcePhoneCalls, repository.VenueKindCall, phoneContainer)
+
+	// No orphan venue nodes: every venue-type node is referenced by at least one
+	// interaction (proves the WHERE NOT EXISTS node-mint guard).
+	require.Zero(t, countOrphanVenueNodes(ctx, t, database), "backfill must leave no orphan venue nodes")
+
 	// manual interaction has NO venue.
 	manualInteraction, err := interactionRepo.GetInteraction(ctx, manualID)
 	require.NoError(t, err)
@@ -275,6 +348,18 @@ func countVenueNodes(ctx context.Context, t *testing.T, database *db.Database) i
 	t.Helper()
 	var n int64
 	require.NoError(t, database.Pool.QueryRow(ctx, `SELECT count(*) FROM node WHERE type = 'venue'`).Scan(&n))
+	return n
+}
+
+// countOrphanVenueNodes returns the number of venue-type nodes that no live
+// interaction references via venue_id.
+func countOrphanVenueNodes(ctx context.Context, t *testing.T, database *db.Database) int64 {
+	t.Helper()
+	var n int64
+	require.NoError(t, database.Pool.QueryRow(ctx, `
+		SELECT count(*) FROM node nd
+		WHERE nd.type = 'venue'
+		  AND NOT EXISTS (SELECT 1 FROM interaction i WHERE i.venue_id = nd.id)`).Scan(&n))
 	return n
 }
 

--- a/backend/tests/synthetic_seed_all_integration_test.go
+++ b/backend/tests/synthetic_seed_all_integration_test.go
@@ -80,6 +80,13 @@ func TestSyntheticSeedAll_CleanupEmptiesNamespace(t *testing.T) {
 	_, err = target.ReplayGmail(ctx, targetContact.ID, tgen.GmailMessage(tspec, factory.MatchSeeded))
 	require.NoError(t, err)
 
+	// The target's Gmail replay drives the real recorder, which mints a venue node
+	// (interaction.venue_id). Scoped to THIS run's tracked venue node ids so the
+	// check is parallel-test-safe. Non-vacuous precondition: at least one exists.
+	venueBefore, err := target.VenueNodesRemaining(ctx)
+	require.NoError(t, err)
+	require.Greater(t, venueBefore, int64(0), "the Gmail replay must mint a venue node")
+
 	// Run the target's teardown (quiesce + Gate-B-gated cleanup).
 	require.NoError(t, teardown(context.Background()))
 
@@ -87,6 +94,12 @@ func TestSyntheticSeedAll_CleanupEmptiesNamespace(t *testing.T) {
 	gone, err := target.ContactsRemaining(ctx)
 	require.NoError(t, err)
 	require.Equal(t, int64(0), gone, "target namespace cleanup should remove its contacts")
+
+	// The target's venue nodes are gone too — no leak (the exact failure class the
+	// teardown's venue_node step exists to prevent).
+	venueAfter, err := target.VenueNodesRemaining(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), venueAfter, "teardown must remove the venue nodes the replay created (no leak)")
 
 	// The sentinel's contact survives (non-destructive scoping).
 	surviving, err := sentinel.ContactsRemaining(ctx)


### PR DESCRIPTION
## SP1 Relationship Data Model — PR6: venue model on interaction

Adds a nullable `interaction.venue_id` FK into the SP1 node/venue registry, backfills it per-source, and wires every live interaction-recording path to attribute venues going forward. Part of the SP1 graph foundation (plan: PR6, migration 069).

### What changed
- **Migration 069** (explicit `BEGIN;…COMMIT;`): adds nullable `interaction.venue_id` + index, and a per-source backfill that mints a deterministic venue node per source container (`uuid_generate_v5(namespace, source, container)`) and links interactions to it. gcal is backfilled before anarlog so anarlog sessions reuse the meeting's venue. Idempotent (`WHERE venue_id IS NULL`) and re-run-safe (`WHERE NOT EXISTS` orphan guard).
- **Deterministic venue id with backfill↔live parity**: the migration backfill and the live `ResolveVenueForInteraction` helper converge on the same node id for the same container (tested), so a row backfilled offline and one resolved at ingest never diverge.
- **Live recorder wiring**: `venue_id` is set (NULL-tolerant) across InteractionRecorder, EmailInteractionConsumer, the phone-call recorder, and both anarlog meeting-note recorders (gcal-meeting venue reuse included). Unresolvable/manual/todoist → NULL; the recorder never fails on venue resolution.
- **No-orphan-node guarantees**: the live resolver reads-first then creates node+venue under a per-container advisory lock (a sqlc query, not inline SQL). The live meeting-note path resolves the session venue only when there are desired interactions to write — an orphan/conflict-pending session no longer mints an unreferenced venue node.
- **Cadence isolation**: `venue_id` is never a partition/dedup dimension. A byte-identical regression snapshots the cadence columns across the backfill and asserts they're unchanged, plus a CadenceUpdater recompute produces identical output.
- **Cast-safe anarlog join**: the Step-1 backfill compares the known-valid `anarlog_session_id::text` against `split_part(source_ref,':',2)` — it never casts untrusted input to `uuid`, so one malformed `source_ref` can't abort the migration.

### Tests
- Per-source backfill + backfill↔helper id parity.
- Real-file atomicity: drives the actual `069_interaction_venue.up.sql` (error injected before its own final `COMMIT;`) so it fails if `BEGIN;`/`COMMIT;` are stripped.
- Malformed-anarlog-ref is skipped (mutation-verified to fail if reverted to a `::uuid` cast).
- Cadence byte-identical + recompute regression; down-migration guard; synthetic replay venue-node teardown returns the namespace to baseline; live orphan-session mints no venue node.

3 pre-push review-head rounds → PASS (P0=0 P1=0). Local gate green: build, lint, sqlc (no drift), full integration suite.