### PR TITLE
feat(graph): migrate tags to graph — crm-admin --migrate-tags (SP1 PR8, migration 071)

### DIFF
--- a/.ai/guides/architecture.md
+++ b/.ai/guides/architecture.md
@@ -161,7 +161,7 @@ sequenceDiagram
 | `contact` | People in CRM. ContactService dual-writes a `node(type='person')` at the contact's own id in the same tx on create — the `contact.id == node.id` invariant — and syncs `node.canonical_label` on rename | Parent of most entities; 1:1 person `node` (shared id) |
 | `contact_method` | Email, phone, social handles | → contact |
 | `note` | Freeform notes | → contact |
-| `tag` | Contact categorization | ↔ contact (via contact_tag) |
+| `tag` | Contact categorization. Mirrored into the graph by `crm-admin --migrate-tags` (each tag → a `tag` entity node carrying its color in `entity.detail`; each `contact_tag` of a non-deleted contact → an accepted `tagged_as` assertion with user provenance). The legacy `tag`/`contact_tag` tables are retained as a rollback anchor (dropped in a later migration) | ↔ contact (via contact_tag) |
 | **Sync & Identity** | | |
 | `external_sync_state` | Sync status per provider/account | |
 | `external_sync_log` | Audit log of sync runs | → external_sync_state |

--- a/backend/cmd/crm-admin/main.go
+++ b/backend/cmd/crm-admin/main.go
@@ -930,12 +930,13 @@ func runMigrateTags(ctx context.Context, deps adminDeps) error {
 		return fmt.Errorf("migrate tags: %w", err)
 	}
 	if _, err := fmt.Fprintf(deps.stdout, "migrate-tags summary:\n"+
-		"  tags:                 %d\n"+
-		"  tag_nodes_created:    %d\n"+
-		"  tag_nodes_existing:   %d\n"+
-		"  contact_tags:         %d\n"+
-		"  assertions_asserted:  %d\n",
-		res.Tags, res.TagNodesCreated, res.TagNodesExisting, res.ContactTags, res.AssertionsAsserted); err != nil {
+		"  tags:                          %d\n"+
+		"  tag_nodes_created:             %d\n"+
+		"  tag_nodes_existing:            %d\n"+
+		"  contact_tags_migrated:         %d\n"+
+		"  contact_tags_skipped_deleted:  %d\n"+
+		"  assertions_asserted:           %d\n",
+		res.Tags, res.TagNodesCreated, res.TagNodesExisting, res.ContactTags, res.SkippedDeletedContacts, res.AssertionsAsserted); err != nil {
 		return fmt.Errorf("write summary: %w", err)
 	}
 	return nil

--- a/backend/cmd/crm-admin/main.go
+++ b/backend/cmd/crm-admin/main.go
@@ -125,6 +125,21 @@
 //	                              Consumers are idempotent, so retrying an
 //	                              already-side-effected job re-runs into a no-op.
 //
+//	--migrate-tags                Mirror the legacy tag / contact_tag tables into
+//	                              the graph: each tag becomes a `tag` entity node
+//	                              (color carried in the entity's detail JSONB) and
+//	                              each contact_tag of a NON-deleted contact becomes
+//	                              an accepted `tagged_as` assertion authored by the
+//	                              user (knowledge time = contact_tag.created_at).
+//	                              FAILS LOUDLY on a case-insensitive tag-name
+//	                              collision (e.g. "Friend" vs "friend") so the
+//	                              operator dedups the legacy tags first. Idempotent
+//	                              (routes through AssertService proposition
+//	                              identity + find-or-create entity nodes) — safe to
+//	                              re-run. Prints a counts-only summary. The legacy
+//	                              tag / contact_tag tables are NOT dropped (rollback
+//	                              anchor, removed in a later migration).
+//
 // The seed/reset subcommands inherit the process env (CRM_ENV / TIME_BASE /
 // TIME_ACCELERATION / DATABASE_URL / MIGRATIONS_PATH) — on the Pi via
 // `set -a; . /srv/personalcrm/.env; set +a` — so the seeded world's cadence /
@@ -220,6 +235,12 @@ type gmailBackfillCursorResetter interface {
 	ResetGmailBackfillCursors(ctx context.Context) (service.EmailBackfillCursorResetResult, error)
 }
 
+// tagMigrator is the narrow interface --migrate-tags needs. Production wires this
+// to *service.TagMigrationService.MigrateTags.
+type tagMigrator interface {
+	MigrateTags(ctx context.Context) (service.TagMigrationResult, error)
+}
+
 // seedRunner is the narrow interface --seed / --reset-and-seed need. Production
 // wires this to a seedAdapter over the synthetic toolkit. Seed is additive (it
 // runs the non-final-river_job drain preflight); ResetAndSeed hard-wipes the live
@@ -262,9 +283,12 @@ type adminDeps struct {
 	// jobs serves --list-jobs / --retry-job. Wired to the insert-only river
 	// client in buildProductionDeps (JobList/JobRetry go through the driver,
 	// no worker pool needed).
-	jobs   riverJobAdmin
-	stdout io.Writer
-	stderr io.Writer
+	jobs riverJobAdmin
+	// migrateTags serves --migrate-tags (mirror legacy tag/contact_tag into the
+	// graph via AssertService). Wired to a TagMigrationService.
+	migrateTags tagMigrator
+	stdout      io.Writer
+	stderr      io.Writer
 }
 
 // runOptions captures parsed flags. Exposed as a struct so tests can
@@ -303,6 +327,9 @@ type runOptions struct {
 	jobState   string
 	jobLimit   int
 	retryJobID int64
+	// migrateTags ← --migrate-tags (mirror legacy tag/contact_tag into the graph
+	// via the validated assertion write path). Idempotent; counts-only output.
+	migrateTags bool
 }
 
 // exitErr carries an explicit process exit code so a subcommand can drive a
@@ -450,6 +477,9 @@ func validateSubcommand(opts runOptions) error {
 	if opts.retryJobID != 0 {
 		active++
 	}
+	if opts.migrateTags {
+		active++
+	}
 	if active == 0 {
 		return errors.New("no subcommand specified; pass exactly one of " +
 			subcommandList)
@@ -466,7 +496,7 @@ func validateSubcommand(opts runOptions) error {
 const subcommandList = "--messages-rematch-stranded, --reconcile-address-book-methods, " +
 	"--rederive-correspondence-names, --reset-gmail-backfill-cursors, --mint-pairing-token, " +
 	"--list-hosts, --revoke-host <uuid>, --rotate-host-key <uuid>, --seed, --reset-and-seed, " +
-	"--migrate, --migrate-check, --list-jobs, --retry-job <id>"
+	"--migrate, --migrate-check, --list-jobs, --retry-job <id>, --migrate-tags"
 
 // parseArgs uses a private FlagSet so tests can drive the parser
 // without polluting flag's global state.
@@ -539,6 +569,10 @@ func parseArgs(args []string) (runOptions, error) {
 	fs.Int64Var(&opts.retryJobID, "retry-job", 0,
 		"Make a single River job (by numeric id from --list-jobs) available to run again. "+
 			"On an exhausted job River bumps max_attempts. Safe with crm-api running.")
+	fs.BoolVar(&opts.migrateTags, "migrate-tags", false,
+		"Mirror the legacy tag/contact_tag tables into the graph (tag entity nodes + accepted "+
+			"tagged_as assertions for non-deleted contacts). FAILS LOUDLY on a case-insensitive "+
+			"tag-name collision. Idempotent; counts-only output. Legacy tables retained.")
 	if err := fs.Parse(args); err != nil {
 		return runOptions{}, err
 	}
@@ -642,6 +676,8 @@ func run(ctx context.Context, opts runOptions, deps adminDeps) error {
 		return runListJobs(ctx, opts, deps)
 	case opts.retryJobID != 0:
 		return runRetryJob(ctx, opts, deps)
+	case opts.migrateTags:
+		return runMigrateTags(ctx, deps)
 	case opts.migrate, opts.migrateCheck:
 		// Migration subcommands are dispatched PRE-DB in runMain (they need
 		// only the database URL + migrations path, not deps), so they never
@@ -879,6 +915,27 @@ func runRematchStranded(ctx context.Context, deps adminDeps) error {
 		"  enqueued:       %d\n"+
 		"  errors:         %d\n",
 		res.Scanned, res.Matched, res.StillStranded, res.Enqueued, res.Errors); err != nil {
+		return fmt.Errorf("write summary: %w", err)
+	}
+	return nil
+}
+
+// runMigrateTags mirrors the legacy tag / contact_tag tables into the graph and
+// prints a counts-only summary. Returns a non-nil error on a case-insensitive
+// tag-name collision (nothing is written) so the operator dedups the legacy tags
+// and re-runs; otherwise the run is idempotent.
+func runMigrateTags(ctx context.Context, deps adminDeps) error {
+	res, err := deps.migrateTags.MigrateTags(ctx)
+	if err != nil {
+		return fmt.Errorf("migrate tags: %w", err)
+	}
+	if _, err := fmt.Fprintf(deps.stdout, "migrate-tags summary:\n"+
+		"  tags:                 %d\n"+
+		"  tag_nodes_created:    %d\n"+
+		"  tag_nodes_existing:   %d\n"+
+		"  contact_tags:         %d\n"+
+		"  assertions_asserted:  %d\n",
+		res.Tags, res.TagNodesCreated, res.TagNodesExisting, res.ContactTags, res.AssertionsAsserted); err != nil {
 		return fmt.Errorf("write summary: %w", err)
 	}
 	return nil
@@ -1174,6 +1231,21 @@ func buildProductionDeps(ctx context.Context, cfg *config.Config, database *db.D
 		enrichmentService, contactRepo, contactMethodRepo, externalContactRepo,
 	)
 
+	// Tag→graph migration. Reuses the same event bus (so the tagged_as asserts
+	// emit assertion.* events) + the graph repos. AssertService owns proposition
+	// identity / dedup, which makes --migrate-tags idempotent.
+	graphNodeRepo := repository.NewNodeRepository(database.Queries)
+	graphEntityRepo := repository.NewEntityRepository(database.Queries)
+	graphPredicateRepo := repository.NewPredicateRepository(database.Queries)
+	graphAssertionRepo := repository.NewAssertionRepository(database.Queries)
+	assertService := service.NewAssertService(
+		database.Pool, graphNodeRepo, graphEntityRepo, graphPredicateRepo, graphAssertionRepo, eventBus,
+	)
+	tagMigration := service.NewTagMigrationService(
+		database.Pool, repository.NewTagRepository(database.Queries),
+		graphNodeRepo, graphEntityRepo, assertService,
+	)
+
 	deps := adminDeps{
 		tokens:     hostService,
 		hosts:      hostService,
@@ -1187,7 +1259,8 @@ func buildProductionDeps(ctx context.Context, cfg *config.Config, database *db.D
 		},
 		// --list-jobs / --retry-job: the insert-only river client also satisfies
 		// JobList / JobRetry (both go through the driver, no worker pool needed).
-		jobs: riverClient,
+		jobs:        riverClient,
+		migrateTags: tagMigration,
 	}
 
 	// LAZY: build the correspondence re-derivation stack ONLY for

--- a/backend/cmd/crm-admin/main_test.go
+++ b/backend/cmd/crm-admin/main_test.go
@@ -555,7 +555,7 @@ func (f *fakeTagMigrator) MigrateTags(_ context.Context) (service.TagMigrationRe
 func TestRunMigrateTagsHappy(t *testing.T) {
 	deps, stdout, _, _, _, _ := newTestDeps()
 	migrator := &fakeTagMigrator{result: service.TagMigrationResult{
-		Tags: 4, TagNodesCreated: 3, TagNodesExisting: 1, ContactTags: 9, AssertionsAsserted: 9,
+		Tags: 4, TagNodesCreated: 3, TagNodesExisting: 1, ContactTags: 9, SkippedDeletedContacts: 2, AssertionsAsserted: 9,
 	}}
 	deps.migrateTags = migrator
 
@@ -567,10 +567,17 @@ func TestRunMigrateTagsHappy(t *testing.T) {
 		t.Fatalf("expected 1 migrate call, got %d", migrator.calls)
 	}
 	out := stdout.String()
-	for _, want := range []string{"tags:                 4", "tag_nodes_created:    3", "tag_nodes_existing:   1", "contact_tags:         9", "assertions_asserted:  9"} {
+	for _, want := range []string{
+		"tags:", "tag_nodes_created:", "tag_nodes_existing:",
+		"contact_tags_migrated:", "contact_tags_skipped_deleted:", "assertions_asserted:",
+	} {
 		if !strings.Contains(out, want) {
-			t.Fatalf("output missing %q: %s", want, out)
+			t.Fatalf("output missing label %q: %s", want, out)
 		}
+	}
+	// The skipped-soft-deleted count is surfaced explicitly (not silently dropped).
+	if !strings.Contains(out, "contact_tags_skipped_deleted:  2") {
+		t.Fatalf("output missing skipped-deleted count: %s", out)
 	}
 }
 

--- a/backend/cmd/crm-admin/main_test.go
+++ b/backend/cmd/crm-admin/main_test.go
@@ -538,6 +538,67 @@ func TestRunReconcileMutualExclusion(t *testing.T) {
 	}
 }
 
+type fakeTagMigrator struct {
+	result service.TagMigrationResult
+	err    error
+	calls  int
+}
+
+func (f *fakeTagMigrator) MigrateTags(_ context.Context) (service.TagMigrationResult, error) {
+	f.calls++
+	if f.err != nil {
+		return service.TagMigrationResult{}, f.err
+	}
+	return f.result, nil
+}
+
+func TestRunMigrateTagsHappy(t *testing.T) {
+	deps, stdout, _, _, _, _ := newTestDeps()
+	migrator := &fakeTagMigrator{result: service.TagMigrationResult{
+		Tags: 4, TagNodesCreated: 3, TagNodesExisting: 1, ContactTags: 9, AssertionsAsserted: 9,
+	}}
+	deps.migrateTags = migrator
+
+	err := run(context.Background(), runOptions{migrateTags: true}, deps)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if migrator.calls != 1 {
+		t.Fatalf("expected 1 migrate call, got %d", migrator.calls)
+	}
+	out := stdout.String()
+	for _, want := range []string{"tags:                 4", "tag_nodes_created:    3", "tag_nodes_existing:   1", "contact_tags:         9", "assertions_asserted:  9"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q: %s", want, out)
+		}
+	}
+}
+
+func TestRunMigrateTagsError(t *testing.T) {
+	deps, _, _, _, _, _ := newTestDeps()
+	deps.migrateTags = &fakeTagMigrator{err: service.ErrTagCaseCollision}
+
+	err := run(context.Background(), runOptions{migrateTags: true}, deps)
+	if err == nil {
+		t.Fatal("expected error when the tag migrator errors (e.g. case collision)")
+	}
+	if !errors.Is(err, service.ErrTagCaseCollision) {
+		t.Fatalf("expected wrapped ErrTagCaseCollision, got %v", err)
+	}
+}
+
+func TestRunMigrateTagsMutualExclusion(t *testing.T) {
+	deps, _, _, _, _, _ := newTestDeps()
+	deps.migrateTags = &fakeTagMigrator{}
+	err := run(context.Background(), runOptions{
+		migrateTags: true,
+		listHosts:   true,
+	}, deps)
+	if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("expected mutual-exclusion error, got %v", err)
+	}
+}
+
 func TestRunResetGmailBackfillMutualExclusion(t *testing.T) {
 	deps, _, _, _, _, _ := newTestDeps()
 	err := run(context.Background(), runOptions{

--- a/backend/cmd/crm-admin/main_test.go
+++ b/backend/cmd/crm-admin/main_test.go
@@ -750,6 +750,15 @@ func TestParseArgsAllFlags(t *testing.T) {
 				}
 			},
 		},
+		{
+			"migrate-tags",
+			[]string{"--migrate-tags"},
+			func(t *testing.T, o runOptions) {
+				if !o.migrateTags {
+					t.Fatal("--migrate-tags not set")
+				}
+			},
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -1064,6 +1064,12 @@ type Querier interface {
 	// Contact method queries
 	ListContactMethodsByContact(ctx context.Context, contactID pgtype.UUID) ([]*ContactMethod, error)
 	ListContactNotes(ctx context.Context, arg ListContactNotesParams) ([]*Note, error)
+	// ListContactTagsWithLiveContact returns every contact_tag whose contact is NOT
+	// soft-deleted (the `crm-admin --migrate-tags` source set). Deleted contacts are
+	// skipped permanently — the assertion write path rejects a tombstoned subject
+	// node anyway. Ordered deterministically so the migration processes rows in a
+	// stable sequence.
+	ListContactTagsWithLiveContact(ctx context.Context) ([]*ContactTag, error)
 	// List all tasks for a contact
 	ListContactTasksByContact(ctx context.Context, contactID pgtype.UUID) ([]*ContactTask, error)
 	// List tasks for a contact with optional state, kind, and lifecycle filters
@@ -1876,14 +1882,24 @@ type Querier interface {
 	// Test-only: counts venue-type nodes that no live interaction references via
 	// venue_id. Used by the venue backfill test to assert the no-orphan-node guard.
 	TestCountOrphanVenueNodes(ctx context.Context) (int64, error)
+	// Tag-migration test only: count the LIVE accepted `tagged_as` assertions whose
+	// subject is a given node, so a test asserts exactly one per migrated contact_tag
+	// and that an idempotent re-run creates no duplicates.
+	TestCountTaggedAsAssertionsForSubject(ctx context.Context, subjectNodeID pgtype.UUID) (int64, error)
 	// Test-only: counts venue-type nodes. Used by the venue backfill test.
 	TestCountVenueNodes(ctx context.Context) (int64, error)
 	// TEST ONLY. Hard-deletes calendar_event rows whose gcal_event_id starts
 	// with the given prefix. Used by t.Cleanup to remove fixtures.
 	TestDeleteCalendarEventsByGcalEventIDPrefix(ctx context.Context, prefix string) error
+	// Tag-migration cleanup: hard-delete the contact_tag rows a test seeded, keyed by
+	// the tracked contact ids (scoped to the test's own contacts on the shared DB).
+	TestDeleteContactTagsByContactIds(ctx context.Context, contactIds []pgtype.UUID) (int64, error)
 	// TEST ONLY. Hard-deletes external_contact rows whose source_id starts with
 	// the given prefix. Used by t.Cleanup to remove fixtures inserted by a test.
 	TestDeleteExternalContactsBySourceIDPrefix(ctx context.Context, prefix string) error
+	// Tag-migration cleanup: hard-delete the legacy tag rows a test seeded, keyed by
+	// the tracked tag ids (scoped to the test's own tags on the shared DB).
+	TestDeleteTagsByIds(ctx context.Context, tagIds []pgtype.UUID) (int64, error)
 	// TEST ONLY. Probe a calendar_event row with FOR UPDATE NOWAIT: returns the
 	// row if no conflicting lock is held, or fails immediately (lock_not_available)
 	// when another tx holds a conflicting lock (e.g. a FOR SHARE from the attended
@@ -1917,6 +1933,11 @@ type Querier interface {
 	// the venue backfill test to seed an email/gchat thread container row.
 	// Production code MUST NOT call this.
 	TestInsertCommsMessageLinked(ctx context.Context, arg TestInsertCommsMessageLinkedParams) (*CommsMessage, error)
+	// Tag-migration test only: seed a contact_tag row with an explicit created_at so
+	// a test can assert the migration preserves it as the assertion's KnowledgeFrom
+	// (KnowledgeFromOverride). The (contact_id, tag_id) PK makes re-seeding a no-op
+	// under ON CONFLICT (not needed here — tests use fresh ids).
+	TestInsertContactTagAtTime(ctx context.Context, arg TestInsertContactTagAtTimeParams) error
 	// Reset test only: a person node with a fixed sentinel id that the embedding and
 	// relationship_signal markers anchor to (relationship_signal.subject_node_id is a
 	// real FK→node, so the node must exist first). Idempotent so the marker seeding
@@ -1976,6 +1997,10 @@ type Querier interface {
 	// TestInsertNonFinalRiverJob: River requires kind, queue, state, args,
 	// metadata, max_attempts.
 	TestInsertRiverJobWithStateForTest(ctx context.Context, arg TestInsertRiverJobWithStateForTestParams) error
+	// Tag-migration test only: seed a legacy tag row with an explicit name + color
+	// so a test can run `--migrate-tags` over it and assert the color survives into
+	// the tag entity node's detail JSONB. Returns the generated id.
+	TestInsertTagForMigration(ctx context.Context, arg TestInsertTagForMigrationParams) (pgtype.UUID, error)
 	// Reset test only: a marker row in tag (a standalone table the harness does not
 	// touch).
 	TestInsertTagMarker(ctx context.Context) error

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -1938,6 +1938,10 @@ type Querier interface {
 	// (KnowledgeFromOverride). The (contact_id, tag_id) PK makes re-seeding a no-op
 	// under ON CONFLICT (not needed here — tests use fresh ids).
 	TestInsertContactTagAtTime(ctx context.Context, arg TestInsertContactTagAtTimeParams) error
+	// Tag-migration test only: seed a contact_tag row with a NULL created_at (the
+	// column is nullable), so a test can assert the migration falls back to "now" for
+	// the assertion knowledge time rather than stamping a bogus zero time.
+	TestInsertContactTagNullCreatedAt(ctx context.Context, arg TestInsertContactTagNullCreatedAtParams) error
 	// Reset test only: a person node with a fixed sentinel id that the embedding and
 	// relationship_signal markers anchor to (relationship_signal.subject_node_id is a
 	// real FK→node, so the node must exist first). Idempotent so the marker seeding

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -176,6 +176,11 @@ type Querier interface {
 	CountAllUnmatchedExternalContacts(ctx context.Context, includeUnresolvedTelegram bool) (int64, error)
 	CountContactInteractions(ctx context.Context, contactID pgtype.UUID) (int64, error)
 	CountContactNotes(ctx context.Context, contactID pgtype.UUID) (int64, error)
+	// CountContactTagsWithDeletedContact counts the contact_tag rows the migration
+	// SKIPS because their contact is soft-deleted, so the `--migrate-tags` summary can
+	// report the skip explicitly and the operator isn't misled when the migrated
+	// count doesn't match the raw contact_tag table.
+	CountContactTagsWithDeletedContact(ctx context.Context) (int64, error)
 	CountContactTasksByProvider(ctx context.Context, arg CountContactTasksByProviderParams) (int64, error)
 	CountContacts(ctx context.Context, arg CountContactsParams) (int64, error)
 	CountContactsByNamePrefix(ctx context.Context, dollar_1 pgtype.Text) (int64, error)

--- a/backend/internal/db/queries/tag.sql
+++ b/backend/internal/db/queries/tag.sql
@@ -9,6 +9,18 @@ SELECT * FROM tag WHERE name = $1;
 -- name: ListTags :many
 SELECT * FROM tag ORDER BY name ASC;
 
+-- ListContactTagsWithLiveContact returns every contact_tag whose contact is NOT
+-- soft-deleted (the `crm-admin --migrate-tags` source set). Deleted contacts are
+-- skipped permanently — the assertion write path rejects a tombstoned subject
+-- node anyway. Ordered deterministically so the migration processes rows in a
+-- stable sequence.
+-- name: ListContactTagsWithLiveContact :many
+SELECT ct.contact_id, ct.tag_id, ct.created_at
+FROM contact_tag ct
+JOIN contact c ON c.id = ct.contact_id
+WHERE c.deleted_at IS NULL
+ORDER BY ct.contact_id ASC, ct.tag_id ASC;
+
 -- name: CreateTag :one
 INSERT INTO tag (name, color) VALUES ($1, $2) RETURNING *;
 

--- a/backend/internal/db/queries/tag.sql
+++ b/backend/internal/db/queries/tag.sql
@@ -21,6 +21,16 @@ JOIN contact c ON c.id = ct.contact_id
 WHERE c.deleted_at IS NULL
 ORDER BY ct.contact_id ASC, ct.tag_id ASC;
 
+-- CountContactTagsWithDeletedContact counts the contact_tag rows the migration
+-- SKIPS because their contact is soft-deleted, so the `--migrate-tags` summary can
+-- report the skip explicitly and the operator isn't misled when the migrated
+-- count doesn't match the raw contact_tag table.
+-- name: CountContactTagsWithDeletedContact :one
+SELECT COUNT(*)
+FROM contact_tag ct
+JOIN contact c ON c.id = ct.contact_id
+WHERE c.deleted_at IS NOT NULL;
+
 -- name: CreateTag :one
 INSERT INTO tag (name, color) VALUES ($1, $2) RETURNING *;
 

--- a/backend/internal/db/queries/test.sql
+++ b/backend/internal/db/queries/test.sql
@@ -786,6 +786,40 @@ INSERT INTO relationship_signal (subject_node_id, signal_key, value, as_of, meth
 VALUES ('00000000-0000-0000-0000-0000000000d5'::uuid, 'synthetic-reset-marker', 0, NOW(),
         'synthetic-reset-marker');
 
+-- name: TestInsertTagForMigration :one
+-- Tag-migration test only: seed a legacy tag row with an explicit name + color
+-- so a test can run `--migrate-tags` over it and assert the color survives into
+-- the tag entity node's detail JSONB. Returns the generated id.
+INSERT INTO tag (name, color) VALUES (@name, @color) RETURNING id;
+
+-- name: TestInsertContactTagAtTime :exec
+-- Tag-migration test only: seed a contact_tag row with an explicit created_at so
+-- a test can assert the migration preserves it as the assertion's KnowledgeFrom
+-- (KnowledgeFromOverride). The (contact_id, tag_id) PK makes re-seeding a no-op
+-- under ON CONFLICT (not needed here — tests use fresh ids).
+INSERT INTO contact_tag (contact_id, tag_id, created_at)
+VALUES (@contact_id, @tag_id, @created_at);
+
+-- name: TestDeleteContactTagsByContactIds :execrows
+-- Tag-migration cleanup: hard-delete the contact_tag rows a test seeded, keyed by
+-- the tracked contact ids (scoped to the test's own contacts on the shared DB).
+DELETE FROM contact_tag WHERE contact_id = ANY(@contact_ids::uuid[]);
+
+-- name: TestDeleteTagsByIds :execrows
+-- Tag-migration cleanup: hard-delete the legacy tag rows a test seeded, keyed by
+-- the tracked tag ids (scoped to the test's own tags on the shared DB).
+DELETE FROM tag WHERE id = ANY(@tag_ids::uuid[]);
+
+-- name: TestCountTaggedAsAssertionsForSubject :one
+-- Tag-migration test only: count the LIVE accepted `tagged_as` assertions whose
+-- subject is a given node, so a test asserts exactly one per migrated contact_tag
+-- and that an idempotent re-run creates no duplicates.
+SELECT COUNT(*) FROM assertion
+WHERE subject_node_id = $1
+  AND predicate_key = 'tagged_as'
+  AND status = 'accepted'
+  AND knowledge_to IS NULL;
+
 -- name: TestListContactBucketsByNamePrefix :many
 -- Profile coverage test only: list the namespace's contacts (by full_name
 -- prefix) with the bucket-defining columns + a method count, so the test can

--- a/backend/internal/db/queries/test.sql
+++ b/backend/internal/db/queries/test.sql
@@ -800,6 +800,13 @@ INSERT INTO tag (name, color) VALUES (@name, @color) RETURNING id;
 INSERT INTO contact_tag (contact_id, tag_id, created_at)
 VALUES (@contact_id, @tag_id, @created_at);
 
+-- name: TestInsertContactTagNullCreatedAt :exec
+-- Tag-migration test only: seed a contact_tag row with a NULL created_at (the
+-- column is nullable), so a test can assert the migration falls back to "now" for
+-- the assertion knowledge time rather than stamping a bogus zero time.
+INSERT INTO contact_tag (contact_id, tag_id, created_at)
+VALUES (@contact_id, @tag_id, NULL);
+
 -- name: TestDeleteContactTagsByContactIds :execrows
 -- Tag-migration cleanup: hard-delete the contact_tag rows a test seeded, keyed by
 -- the tracked contact ids (scoped to the test's own contacts on the shared DB).

--- a/backend/internal/db/tag.sql.go
+++ b/backend/internal/db/tag.sql.go
@@ -122,6 +122,39 @@ func (q *Queries) GetTagByName(ctx context.Context, name string) (*Tag, error) {
 	return &i, err
 }
 
+const ListContactTagsWithLiveContact = `-- name: ListContactTagsWithLiveContact :many
+SELECT ct.contact_id, ct.tag_id, ct.created_at
+FROM contact_tag ct
+JOIN contact c ON c.id = ct.contact_id
+WHERE c.deleted_at IS NULL
+ORDER BY ct.contact_id ASC, ct.tag_id ASC
+`
+
+// ListContactTagsWithLiveContact returns every contact_tag whose contact is NOT
+// soft-deleted (the `crm-admin --migrate-tags` source set). Deleted contacts are
+// skipped permanently — the assertion write path rejects a tombstoned subject
+// node anyway. Ordered deterministically so the migration processes rows in a
+// stable sequence.
+func (q *Queries) ListContactTagsWithLiveContact(ctx context.Context) ([]*ContactTag, error) {
+	rows, err := q.db.Query(ctx, ListContactTagsWithLiveContact)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []*ContactTag{}
+	for rows.Next() {
+		var i ContactTag
+		if err := rows.Scan(&i.ContactID, &i.TagID, &i.CreatedAt); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const ListTags = `-- name: ListTags :many
 SELECT id, name, color, created_at FROM tag ORDER BY name ASC
 `

--- a/backend/internal/db/tag.sql.go
+++ b/backend/internal/db/tag.sql.go
@@ -26,6 +26,24 @@ func (q *Queries) AddContactTag(ctx context.Context, arg AddContactTagParams) er
 	return err
 }
 
+const CountContactTagsWithDeletedContact = `-- name: CountContactTagsWithDeletedContact :one
+SELECT COUNT(*)
+FROM contact_tag ct
+JOIN contact c ON c.id = ct.contact_id
+WHERE c.deleted_at IS NOT NULL
+`
+
+// CountContactTagsWithDeletedContact counts the contact_tag rows the migration
+// SKIPS because their contact is soft-deleted, so the `--migrate-tags` summary can
+// report the skip explicitly and the operator isn't misled when the migrated
+// count doesn't match the raw contact_tag table.
+func (q *Queries) CountContactTagsWithDeletedContact(ctx context.Context) (int64, error) {
+	row := q.db.QueryRow(ctx, CountContactTagsWithDeletedContact)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const CreateTag = `-- name: CreateTag :one
 INSERT INTO tag (name, color) VALUES ($1, $2) RETURNING id, name, color, created_at
 `

--- a/backend/internal/db/test.sql.go
+++ b/backend/internal/db/test.sql.go
@@ -1758,6 +1758,24 @@ func (q *Queries) TestInsertContactTagAtTime(ctx context.Context, arg TestInsert
 	return err
 }
 
+const TestInsertContactTagNullCreatedAt = `-- name: TestInsertContactTagNullCreatedAt :exec
+INSERT INTO contact_tag (contact_id, tag_id, created_at)
+VALUES ($1, $2, NULL)
+`
+
+type TestInsertContactTagNullCreatedAtParams struct {
+	ContactID pgtype.UUID `json:"contact_id"`
+	TagID     pgtype.UUID `json:"tag_id"`
+}
+
+// Tag-migration test only: seed a contact_tag row with a NULL created_at (the
+// column is nullable), so a test can assert the migration falls back to "now" for
+// the assertion knowledge time rather than stamping a bogus zero time.
+func (q *Queries) TestInsertContactTagNullCreatedAt(ctx context.Context, arg TestInsertContactTagNullCreatedAtParams) error {
+	_, err := q.db.Exec(ctx, TestInsertContactTagNullCreatedAt, arg.ContactID, arg.TagID)
+	return err
+}
+
 const TestInsertDerivedStorageMarkerNode = `-- name: TestInsertDerivedStorageMarkerNode :exec
 INSERT INTO node (id, type, canonical_label)
 VALUES ('00000000-0000-0000-0000-0000000000d5'::uuid, 'person', 'synthetic-reset-marker')

--- a/backend/internal/db/test.sql.go
+++ b/backend/internal/db/test.sql.go
@@ -1692,6 +1692,72 @@ func (q *Queries) TestCountAllRows(ctx context.Context, tableName string) (int64
 	return column_1, err
 }
 
+const TestCountTaggedAsAssertionsForSubject = `-- name: TestCountTaggedAsAssertionsForSubject :one
+SELECT COUNT(*) FROM assertion
+WHERE subject_node_id = $1
+  AND predicate_key = 'tagged_as'
+  AND status = 'accepted'
+  AND knowledge_to IS NULL
+`
+
+// Tag-migration test only: count the LIVE accepted `tagged_as` assertions whose
+// subject is a given node, so a test asserts exactly one per migrated contact_tag
+// and that an idempotent re-run creates no duplicates.
+func (q *Queries) TestCountTaggedAsAssertionsForSubject(ctx context.Context, subjectNodeID pgtype.UUID) (int64, error) {
+	row := q.db.QueryRow(ctx, TestCountTaggedAsAssertionsForSubject, subjectNodeID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const TestDeleteContactTagsByContactIds = `-- name: TestDeleteContactTagsByContactIds :execrows
+DELETE FROM contact_tag WHERE contact_id = ANY($1::uuid[])
+`
+
+// Tag-migration cleanup: hard-delete the contact_tag rows a test seeded, keyed by
+// the tracked contact ids (scoped to the test's own contacts on the shared DB).
+func (q *Queries) TestDeleteContactTagsByContactIds(ctx context.Context, contactIds []pgtype.UUID) (int64, error) {
+	result, err := q.db.Exec(ctx, TestDeleteContactTagsByContactIds, contactIds)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const TestDeleteTagsByIds = `-- name: TestDeleteTagsByIds :execrows
+DELETE FROM tag WHERE id = ANY($1::uuid[])
+`
+
+// Tag-migration cleanup: hard-delete the legacy tag rows a test seeded, keyed by
+// the tracked tag ids (scoped to the test's own tags on the shared DB).
+func (q *Queries) TestDeleteTagsByIds(ctx context.Context, tagIds []pgtype.UUID) (int64, error) {
+	result, err := q.db.Exec(ctx, TestDeleteTagsByIds, tagIds)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const TestInsertContactTagAtTime = `-- name: TestInsertContactTagAtTime :exec
+INSERT INTO contact_tag (contact_id, tag_id, created_at)
+VALUES ($1, $2, $3)
+`
+
+type TestInsertContactTagAtTimeParams struct {
+	ContactID pgtype.UUID        `json:"contact_id"`
+	TagID     pgtype.UUID        `json:"tag_id"`
+	CreatedAt pgtype.Timestamptz `json:"created_at"`
+}
+
+// Tag-migration test only: seed a contact_tag row with an explicit created_at so
+// a test can assert the migration preserves it as the assertion's KnowledgeFrom
+// (KnowledgeFromOverride). The (contact_id, tag_id) PK makes re-seeding a no-op
+// under ON CONFLICT (not needed here — tests use fresh ids).
+func (q *Queries) TestInsertContactTagAtTime(ctx context.Context, arg TestInsertContactTagAtTimeParams) error {
+	_, err := q.db.Exec(ctx, TestInsertContactTagAtTime, arg.ContactID, arg.TagID, arg.CreatedAt)
+	return err
+}
+
 const TestInsertDerivedStorageMarkerNode = `-- name: TestInsertDerivedStorageMarkerNode :exec
 INSERT INTO node (id, type, canonical_label)
 VALUES ('00000000-0000-0000-0000-0000000000d5'::uuid, 'person', 'synthetic-reset-marker')
@@ -1805,6 +1871,25 @@ func (q *Queries) TestInsertRiverJobWithStateForTest(ctx context.Context, arg Te
 		arg.FinalizedAt,
 	)
 	return err
+}
+
+const TestInsertTagForMigration = `-- name: TestInsertTagForMigration :one
+INSERT INTO tag (name, color) VALUES ($1, $2) RETURNING id
+`
+
+type TestInsertTagForMigrationParams struct {
+	Name  string      `json:"name"`
+	Color pgtype.Text `json:"color"`
+}
+
+// Tag-migration test only: seed a legacy tag row with an explicit name + color
+// so a test can run `--migrate-tags` over it and assert the color survives into
+// the tag entity node's detail JSONB. Returns the generated id.
+func (q *Queries) TestInsertTagForMigration(ctx context.Context, arg TestInsertTagForMigrationParams) (pgtype.UUID, error) {
+	row := q.db.QueryRow(ctx, TestInsertTagForMigration, arg.Name, arg.Color)
+	var id pgtype.UUID
+	err := row.Scan(&id)
+	return id, err
 }
 
 const TestInsertTagMarker = `-- name: TestInsertTagMarker :exec

--- a/backend/internal/repository/synthetic_support.go
+++ b/backend/internal/repository/synthetic_support.go
@@ -761,3 +761,54 @@ func (r *SyntheticSupportRepository) CountVenueNodesByIds(ctx context.Context, n
 func (r *SyntheticSupportRepository) DeleteAssertionsForNode(ctx context.Context, nodeID uuid.UUID) (int64, error) {
 	return r.queries.SyntheticDeleteAssertionsForNode(ctx, pgtype.UUID{Bytes: nodeID, Valid: true})
 }
+
+// InsertTagForMigration seeds a legacy tag row with an explicit name + color (a
+// nil color round-trips as SQL NULL), returning the generated id, so a
+// --migrate-tags test can assert the color survives into the tag entity node's
+// detail JSONB.
+func (r *SyntheticSupportRepository) InsertTagForMigration(ctx context.Context, name string, color *string) (uuid.UUID, error) {
+	id, err := r.queries.TestInsertTagForMigration(ctx, db.TestInsertTagForMigrationParams{
+		Name:  name,
+		Color: stringToPgText(color),
+	})
+	if err != nil {
+		return uuid.Nil, err
+	}
+	return uuid.UUID(id.Bytes), nil
+}
+
+// InsertContactTagAtTime seeds a contact_tag row with an explicit created_at so a
+// --migrate-tags test can assert the migration preserves it as the assertion's
+// KnowledgeFrom (KnowledgeFromOverride).
+func (r *SyntheticSupportRepository) InsertContactTagAtTime(ctx context.Context, contactID, tagID uuid.UUID, createdAt time.Time) error {
+	return r.queries.TestInsertContactTagAtTime(ctx, db.TestInsertContactTagAtTimeParams{
+		ContactID: pgtype.UUID{Bytes: contactID, Valid: true},
+		TagID:     pgtype.UUID{Bytes: tagID, Valid: true},
+		CreatedAt: pgtype.Timestamptz{Time: createdAt, Valid: true},
+	})
+}
+
+// DeleteContactTagsByContactIds hard-deletes the contact_tag rows a test seeded,
+// keyed by the tracked contact ids.
+func (r *SyntheticSupportRepository) DeleteContactTagsByContactIds(ctx context.Context, contactIDs []uuid.UUID) (int64, error) {
+	if len(contactIDs) == 0 {
+		return 0, nil
+	}
+	return r.queries.TestDeleteContactTagsByContactIds(ctx, pgUUIDs(contactIDs))
+}
+
+// DeleteTagsByIds hard-deletes the legacy tag rows a test seeded, keyed by the
+// tracked tag ids.
+func (r *SyntheticSupportRepository) DeleteTagsByIds(ctx context.Context, tagIDs []uuid.UUID) (int64, error) {
+	if len(tagIDs) == 0 {
+		return 0, nil
+	}
+	return r.queries.TestDeleteTagsByIds(ctx, pgUUIDs(tagIDs))
+}
+
+// CountTaggedAsAssertionsForSubject counts the LIVE accepted `tagged_as`
+// assertions whose subject is a given node, so a test asserts exactly one per
+// migrated contact_tag and that an idempotent re-run creates no duplicates.
+func (r *SyntheticSupportRepository) CountTaggedAsAssertionsForSubject(ctx context.Context, subjectNodeID uuid.UUID) (int64, error) {
+	return r.queries.TestCountTaggedAsAssertionsForSubject(ctx, pgtype.UUID{Bytes: subjectNodeID, Valid: true})
+}

--- a/backend/internal/repository/synthetic_support.go
+++ b/backend/internal/repository/synthetic_support.go
@@ -788,6 +788,16 @@ func (r *SyntheticSupportRepository) InsertContactTagAtTime(ctx context.Context,
 	})
 }
 
+// InsertContactTagNullCreatedAt seeds a contact_tag row with a NULL created_at
+// (the column is nullable), so a --migrate-tags test can assert the migration
+// falls back to "now" for the assertion knowledge time rather than a zero time.
+func (r *SyntheticSupportRepository) InsertContactTagNullCreatedAt(ctx context.Context, contactID, tagID uuid.UUID) error {
+	return r.queries.TestInsertContactTagNullCreatedAt(ctx, db.TestInsertContactTagNullCreatedAtParams{
+		ContactID: pgtype.UUID{Bytes: contactID, Valid: true},
+		TagID:     pgtype.UUID{Bytes: tagID, Valid: true},
+	})
+}
+
 // DeleteContactTagsByContactIds hard-deletes the contact_tag rows a test seeded,
 // keyed by the tracked contact ids.
 func (r *SyntheticSupportRepository) DeleteContactTagsByContactIds(ctx context.Context, contactIDs []uuid.UUID) (int64, error) {

--- a/backend/internal/repository/tag.go
+++ b/backend/internal/repository/tag.go
@@ -61,6 +61,13 @@ func (r *TagRepository) ListTags(ctx context.Context) ([]Tag, error) {
 	return tags, nil
 }
 
+// CountContactTagsWithDeletedContact counts the contact_tag rows the migration
+// skips because their contact is soft-deleted, so the run summary can report the
+// skip explicitly.
+func (r *TagRepository) CountContactTagsWithDeletedContact(ctx context.Context) (int64, error) {
+	return r.queries.CountContactTagsWithDeletedContact(ctx)
+}
+
 // ListContactTagsWithLiveContact returns every contact_tag whose contact is NOT
 // soft-deleted — the migration source set. Deleted contacts are skipped
 // permanently (the assertion write path rejects a tombstoned subject node).

--- a/backend/internal/repository/tag.go
+++ b/backend/internal/repository/tag.go
@@ -19,12 +19,13 @@ type Tag struct {
 }
 
 // ContactTagLink is one legacy contact_tag edge: which contact carries which
-// tag, and when the link was created (preserved as the assertion's knowledge
-// time during migration).
+// tag, and when the link was created. CreatedAt is nil when the legacy row's
+// created_at is NULL (the column is nullable: DEFAULT NOW() but no NOT NULL), so
+// the migration can fall back to "now" rather than stamping a bogus zero time.
 type ContactTagLink struct {
 	ContactID uuid.UUID
 	TagID     uuid.UUID
-	CreatedAt time.Time
+	CreatedAt *time.Time
 }
 
 // TagRepository reads the legacy tag / contact_tag tables for the tag→graph
@@ -70,11 +71,17 @@ func (r *TagRepository) ListContactTagsWithLiveContact(ctx context.Context) ([]C
 	}
 	links := make([]ContactTagLink, 0, len(dbLinks))
 	for _, l := range dbLinks {
-		links = append(links, ContactTagLink{
+		link := ContactTagLink{
 			ContactID: uuid.UUID(l.ContactID.Bytes),
 			TagID:     uuid.UUID(l.TagID.Bytes),
-			CreatedAt: l.CreatedAt.Time.UTC(),
-		})
+		}
+		// created_at is nullable; only carry it when present (an invalid
+		// pgtype.Timestamptz would otherwise read as Go zero time).
+		if l.CreatedAt.Valid {
+			t := l.CreatedAt.Time.UTC()
+			link.CreatedAt = &t
+		}
+		links = append(links, link)
 	}
 	return links, nil
 }

--- a/backend/internal/repository/tag.go
+++ b/backend/internal/repository/tag.go
@@ -1,0 +1,80 @@
+package repository
+
+import (
+	"context"
+	"time"
+
+	"personal-crm/backend/internal/db"
+
+	"github.com/google/uuid"
+)
+
+// Tag is the legacy user-defined tag row. The tag→graph migration mirrors each
+// one into a `tag` entity node (color carried in the entity's detail JSONB);
+// these reads exist only to drive that one-time `crm-admin --migrate-tags` run.
+type Tag struct {
+	ID    uuid.UUID
+	Name  string
+	Color *string
+}
+
+// ContactTagLink is one legacy contact_tag edge: which contact carries which
+// tag, and when the link was created (preserved as the assertion's knowledge
+// time during migration).
+type ContactTagLink struct {
+	ContactID uuid.UUID
+	TagID     uuid.UUID
+	CreatedAt time.Time
+}
+
+// TagRepository reads the legacy tag / contact_tag tables for the tag→graph
+// migration. There is no live tag UI, so these are the only consumers of the
+// legacy tables until they are dropped.
+type TagRepository struct {
+	queries db.Querier
+}
+
+// NewTagRepository creates a new TagRepository.
+func NewTagRepository(queries db.Querier) *TagRepository {
+	return &TagRepository{queries: queries}
+}
+
+// ListTags returns every legacy tag, ordered by name.
+func (r *TagRepository) ListTags(ctx context.Context) ([]Tag, error) {
+	dbTags, err := r.queries.ListTags(ctx)
+	if err != nil {
+		return nil, err
+	}
+	tags := make([]Tag, 0, len(dbTags))
+	for _, t := range dbTags {
+		tag := Tag{
+			ID:   uuid.UUID(t.ID.Bytes),
+			Name: t.Name,
+		}
+		if t.Color.Valid {
+			color := t.Color.String
+			tag.Color = &color
+		}
+		tags = append(tags, tag)
+	}
+	return tags, nil
+}
+
+// ListContactTagsWithLiveContact returns every contact_tag whose contact is NOT
+// soft-deleted — the migration source set. Deleted contacts are skipped
+// permanently (the assertion write path rejects a tombstoned subject node).
+func (r *TagRepository) ListContactTagsWithLiveContact(ctx context.Context) ([]ContactTagLink, error) {
+	dbLinks, err := r.queries.ListContactTagsWithLiveContact(ctx)
+	if err != nil {
+		return nil, err
+	}
+	links := make([]ContactTagLink, 0, len(dbLinks))
+	for _, l := range dbLinks {
+		links = append(links, ContactTagLink{
+			ContactID: uuid.UUID(l.ContactID.Bytes),
+			TagID:     uuid.UUID(l.TagID.Bytes),
+			CreatedAt: l.CreatedAt.Time.UTC(),
+		})
+	}
+	return links, nil
+}

--- a/backend/internal/service/tag_migration.go
+++ b/backend/internal/service/tag_migration.go
@@ -218,11 +218,10 @@ func tagDetailJSON(color *string) ([]byte, error) {
 // entity node. User provenance + the contact_tag's created_at as the knowledge
 // time make this a faithful, idempotent mirror of the legacy link.
 func (s *TagMigrationService) assertTaggedAs(ctx context.Context, link repository.ContactTagLink, tagNodeID uuid.UUID) error {
-	knowledgeFrom := link.CreatedAt
 	// A deterministic source_id keys the provenance idempotently: a re-run hashes
 	// to the same locator and ON CONFLICT no-ops rather than appending a duplicate.
 	sourceID := fmt.Sprintf("tag-migration:%s:%s", link.ContactID, link.TagID)
-	_, err := s.assertSvc.Assert(ctx, AssertRequest{
+	req := AssertRequest{
 		SubjectNodeID: link.ContactID,
 		PredicateKey:  "tagged_as",
 		ObjectNodeID:  &tagNodeID,
@@ -232,7 +231,14 @@ func (s *TagMigrationService) assertTaggedAs(ctx context.Context, link repositor
 			SourceID:     sourceID,
 			ProducerKind: repository.ProducerKindUser,
 		}},
-		KnowledgeFromOverride: &knowledgeFrom,
-	})
+	}
+	// Preserve the legacy link's created_at as the knowledge time when present; a
+	// NULL legacy created_at has no knowable knowledge time, so leave the override
+	// nil and let AssertService default knowledge_from to now (the honest fallback,
+	// not a bogus zero time).
+	if link.CreatedAt != nil {
+		req.KnowledgeFromOverride = link.CreatedAt
+	}
+	_, err := s.assertSvc.Assert(ctx, req)
 	return err
 }

--- a/backend/internal/service/tag_migration.go
+++ b/backend/internal/service/tag_migration.go
@@ -28,11 +28,12 @@ var ErrTagCaseCollision = errors.New("tag-migration: case-insensitive name colli
 
 // TagMigrationResult is the counts-only summary of a --migrate-tags run.
 type TagMigrationResult struct {
-	Tags               int // legacy tag rows scanned
-	TagNodesCreated    int // tag entity nodes newly created (re-runs reuse existing)
-	TagNodesExisting   int // tag entity nodes already present (idempotent re-run)
-	ContactTags        int // contact_tag rows of non-deleted contacts processed
-	AssertionsAsserted int // tagged_as asserts issued (deduped downstream by AssertService)
+	Tags                   int // legacy tag rows scanned
+	TagNodesCreated        int // tag entity nodes newly created (re-runs reuse existing)
+	TagNodesExisting       int // tag entity nodes already present (idempotent re-run)
+	ContactTags            int // contact_tag rows of non-deleted contacts processed (migrated)
+	SkippedDeletedContacts int // contact_tag rows skipped because their contact is soft-deleted
+	AssertionsAsserted     int // tagged_as asserts issued (deduped downstream by AssertService)
 }
 
 // TagMigrationService mirrors the legacy tag / contact_tag tables into the graph:
@@ -103,6 +104,15 @@ func (s *TagMigrationService) MigrateTags(ctx context.Context) (TagMigrationResu
 		}
 	}
 
+	// Count the contact_tags skipped because their contact is soft-deleted, so the
+	// summary reports the skip explicitly (the migrated count below covers only
+	// non-deleted contacts, which won't match the raw contact_tag table otherwise).
+	skipped, err := s.tagRepo.CountContactTagsWithDeletedContact(ctx)
+	if err != nil {
+		return result, fmt.Errorf("count skipped contact_tags: %w", err)
+	}
+	result.SkippedDeletedContacts = int(skipped)
+
 	// Mirror each contact_tag of a non-deleted contact into a tagged_as assertion.
 	links, err := s.tagRepo.ListContactTagsWithLiveContact(ctx)
 	if err != nil {
@@ -158,6 +168,15 @@ func detectTagCaseCollisions(tags []repository.Tag) error {
 func (s *TagMigrationService) findOrCreateTagNode(ctx context.Context, tag repository.Tag) (uuid.UUID, bool, error) {
 	normalizedName := strings.ToLower(strings.TrimSpace(tag.Name))
 
+	// Find-first idempotency rests on a constraint mismatch worth flagging:
+	// FindEntityBySubtypeName excludes a tag whose node is soft-deleted (it joins
+	// node and filters node.deleted_at), but the entity `(subtype, normalized_name)`
+	// unique index does NOT. There is no tag-node soft-delete path in the graph
+	// today, so this is unreachable; if a future tag-delete feature ever tombstones
+	// a tag node, re-running this migration would find nothing here and then hit a
+	// 23505 on the re-create. That fails LOUDLY (no silent corruption), but a future
+	// tag-delete path must resurrect the existing node (clear deleted_at) instead of
+	// creating a second one.
 	existing, err := s.entityRepo.FindEntityBySubtypeName(ctx, repository.EntitySubtypeTag, normalizedName)
 	if err == nil {
 		return existing.NodeID, false, nil
@@ -213,10 +232,13 @@ func tagDetailJSON(color *string) ([]byte, error) {
 }
 
 // assertTaggedAs issues the accepted tagged_as edge for one contact_tag link. The
-// subject is the contact's person node (node.id == contact.id, guaranteed by the
-// person-node backfill for every non-deleted contact); the object is the tag
-// entity node. User provenance + the contact_tag's created_at as the knowledge
-// time make this a faithful, idempotent mirror of the legacy link.
+// subject is the contact's person node (node.id == contact.id); the
+// person-node backfill creates one for every non-deleted contact, so in normal
+// operation it exists — but if it is missing, AssertService rejects the write
+// loudly (subject-node validation) and the migration aborts rather than skipping
+// silently. The object is the tag entity node. User provenance + the
+// contact_tag's created_at as the knowledge time make this a faithful, idempotent
+// mirror of the legacy link.
 func (s *TagMigrationService) assertTaggedAs(ctx context.Context, link repository.ContactTagLink, tagNodeID uuid.UUID) error {
 	// A deterministic source_id keys the provenance idempotently: a re-run hashes
 	// to the same locator and ON CONFLICT no-ops rather than appending a duplicate.

--- a/backend/internal/service/tag_migration.go
+++ b/backend/internal/service/tag_migration.go
@@ -1,0 +1,238 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// TagMigrationConfidence is the confidence stamped on a migrated tag assertion.
+// Tags are an explicit user action, so they land at full confidence.
+const TagMigrationConfidence = 100
+
+// ErrTagCaseCollision is returned when two legacy tags differ only by case
+// (e.g. "Friend" and "friend"). The entity store is unique on
+// (subtype, lower(name)), so collapsing them silently would merge two distinct
+// user tags. The migration fails loudly and the operator dedups the legacy tags
+// first, picking the canonical casing.
+var ErrTagCaseCollision = errors.New("tag-migration: case-insensitive name collision")
+
+// TagMigrationResult is the counts-only summary of a --migrate-tags run.
+type TagMigrationResult struct {
+	Tags               int // legacy tag rows scanned
+	TagNodesCreated    int // tag entity nodes newly created (re-runs reuse existing)
+	TagNodesExisting   int // tag entity nodes already present (idempotent re-run)
+	ContactTags        int // contact_tag rows of non-deleted contacts processed
+	AssertionsAsserted int // tagged_as asserts issued (deduped downstream by AssertService)
+}
+
+// TagMigrationService mirrors the legacy tag / contact_tag tables into the graph:
+// each tag becomes a `tag` entity node (color carried in the entity's detail
+// JSONB) and each contact_tag of a non-deleted contact becomes an accepted
+// `tagged_as` assertion authored by the user. It routes every assertion through
+// AssertService so proposition identity + dedup + event emission apply, which
+// makes the whole run idempotent (re-running corroborates rather than
+// duplicates).
+type TagMigrationService struct {
+	pool       *pgxpool.Pool
+	tagRepo    *repository.TagRepository
+	nodeRepo   *repository.NodeRepository
+	entityRepo *repository.EntityRepository
+	assertSvc  *AssertService
+}
+
+// NewTagMigrationService wires the migration over the legacy tag reads + the
+// graph node/entity repos + the validated assertion write path.
+func NewTagMigrationService(
+	pool *pgxpool.Pool,
+	tagRepo *repository.TagRepository,
+	nodeRepo *repository.NodeRepository,
+	entityRepo *repository.EntityRepository,
+	assertSvc *AssertService,
+) *TagMigrationService {
+	return &TagMigrationService{
+		pool:       pool,
+		tagRepo:    tagRepo,
+		nodeRepo:   nodeRepo,
+		entityRepo: entityRepo,
+		assertSvc:  assertSvc,
+	}
+}
+
+// MigrateTags runs the full tag→graph migration. It is idempotent: a re-run
+// reuses existing tag entity nodes (find-or-create by (subtype, lower(name)))
+// and re-asserts each tagged_as edge, which AssertService corroborates rather
+// than duplicates.
+func (s *TagMigrationService) MigrateTags(ctx context.Context) (TagMigrationResult, error) {
+	var result TagMigrationResult
+
+	tags, err := s.tagRepo.ListTags(ctx)
+	if err != nil {
+		return result, fmt.Errorf("list tags: %w", err)
+	}
+	result.Tags = len(tags)
+
+	// Case-collision preflight: detect legacy tags that differ only by case
+	// BEFORE creating any node, so the run is all-or-nothing on collision.
+	if err := detectTagCaseCollisions(tags); err != nil {
+		return result, err
+	}
+
+	// Find-or-create one tag entity node per lower(name), recording the node id
+	// so the contact_tag pass can resolve each tag's object node.
+	tagNodeByTagID := make(map[uuid.UUID]uuid.UUID, len(tags))
+	for _, tag := range tags {
+		nodeID, created, err := s.findOrCreateTagNode(ctx, tag)
+		if err != nil {
+			return result, fmt.Errorf("find-or-create tag node %q: %w", tag.Name, err)
+		}
+		tagNodeByTagID[tag.ID] = nodeID
+		if created {
+			result.TagNodesCreated++
+		} else {
+			result.TagNodesExisting++
+		}
+	}
+
+	// Mirror each contact_tag of a non-deleted contact into a tagged_as assertion.
+	links, err := s.tagRepo.ListContactTagsWithLiveContact(ctx)
+	if err != nil {
+		return result, fmt.Errorf("list contact_tags: %w", err)
+	}
+	result.ContactTags = len(links)
+	for _, link := range links {
+		tagNodeID, ok := tagNodeByTagID[link.TagID]
+		if !ok {
+			// A contact_tag referencing a tag not in the tag table is a data
+			// inconsistency (the tag_id FK is ON DELETE CASCADE, so this should be
+			// impossible). Fail loudly rather than silently skip.
+			return result, fmt.Errorf("contact_tag references unknown tag %s", link.TagID)
+		}
+		if err := s.assertTaggedAs(ctx, link, tagNodeID); err != nil {
+			return result, fmt.Errorf("assert tagged_as (contact %s tag %s): %w", link.ContactID, link.TagID, err)
+		}
+		result.AssertionsAsserted++
+	}
+
+	return result, nil
+}
+
+// detectTagCaseCollisions groups tags by lower(name) and returns
+// ErrTagCaseCollision (listing every colliding group's original names) if any
+// group has more than one member. Names within a group are sorted for a stable
+// error message.
+func detectTagCaseCollisions(tags []repository.Tag) error {
+	byLower := make(map[string][]string)
+	for _, tag := range tags {
+		key := strings.ToLower(strings.TrimSpace(tag.Name))
+		byLower[key] = append(byLower[key], tag.Name)
+	}
+	var groups []string
+	for _, names := range byLower {
+		if len(names) > 1 {
+			sort.Strings(names)
+			groups = append(groups, fmt.Sprintf("{%s}", strings.Join(names, ", ")))
+		}
+	}
+	if len(groups) == 0 {
+		return nil
+	}
+	sort.Strings(groups)
+	return fmt.Errorf("%w: dedup these legacy tags (pick one canonical casing per group) before re-running: %s",
+		ErrTagCaseCollision, strings.Join(groups, " "))
+}
+
+// findOrCreateTagNode resolves the tag entity node for a legacy tag, creating
+// the node + entity row (with color in detail) when absent. Returns the node id
+// and whether it was newly created. Find-first makes a re-run reuse the existing
+// node (no duplicate entity nodes).
+func (s *TagMigrationService) findOrCreateTagNode(ctx context.Context, tag repository.Tag) (uuid.UUID, bool, error) {
+	normalizedName := strings.ToLower(strings.TrimSpace(tag.Name))
+
+	existing, err := s.entityRepo.FindEntityBySubtypeName(ctx, repository.EntitySubtypeTag, normalizedName)
+	if err == nil {
+		return existing.NodeID, false, nil
+	}
+	if !errors.Is(err, db.ErrNotFound) {
+		return uuid.Nil, false, fmt.Errorf("find tag entity: %w", err)
+	}
+
+	detail, err := tagDetailJSON(tag.Color)
+	if err != nil {
+		return uuid.Nil, false, err
+	}
+
+	// Create the node + entity rows atomically: the entity.node_id FK requires the
+	// node to exist, and both must commit together so a partial tag node never
+	// lingers.
+	nodeID := uuid.New()
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return uuid.Nil, false, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := s.nodeRepo.CreateNodeTx(ctx, tx, nodeID, repository.NodeTypeEntity, tag.Name); err != nil {
+		return uuid.Nil, false, fmt.Errorf("create tag node: %w", err)
+	}
+	if _, err := s.entityRepo.CreateEntityTx(ctx, tx, repository.CreateEntityRequest{
+		NodeID:         nodeID,
+		Subtype:        repository.EntitySubtypeTag,
+		NormalizedName: normalizedName,
+		Detail:         detail,
+	}); err != nil {
+		return uuid.Nil, false, fmt.Errorf("create tag entity: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return uuid.Nil, false, fmt.Errorf("commit tag node: %w", err)
+	}
+	return nodeID, true, nil
+}
+
+// tagDetailJSON builds the entity detail JSONB carrying the tag's color. A nil
+// color yields nil detail (the entity repo defaults it to '{}'), so the color
+// has a single source of truth (the entity node) for both migrated and new tags.
+func tagDetailJSON(color *string) ([]byte, error) {
+	if color == nil || strings.TrimSpace(*color) == "" {
+		return nil, nil
+	}
+	detail, err := json.Marshal(map[string]string{"color": *color})
+	if err != nil {
+		return nil, fmt.Errorf("marshal tag detail: %w", err)
+	}
+	return detail, nil
+}
+
+// assertTaggedAs issues the accepted tagged_as edge for one contact_tag link. The
+// subject is the contact's person node (node.id == contact.id, guaranteed by the
+// person-node backfill for every non-deleted contact); the object is the tag
+// entity node. User provenance + the contact_tag's created_at as the knowledge
+// time make this a faithful, idempotent mirror of the legacy link.
+func (s *TagMigrationService) assertTaggedAs(ctx context.Context, link repository.ContactTagLink, tagNodeID uuid.UUID) error {
+	knowledgeFrom := link.CreatedAt
+	// A deterministic source_id keys the provenance idempotently: a re-run hashes
+	// to the same locator and ON CONFLICT no-ops rather than appending a duplicate.
+	sourceID := fmt.Sprintf("tag-migration:%s:%s", link.ContactID, link.TagID)
+	_, err := s.assertSvc.Assert(ctx, AssertRequest{
+		SubjectNodeID: link.ContactID,
+		PredicateKey:  "tagged_as",
+		ObjectNodeID:  &tagNodeID,
+		Confidence:    TagMigrationConfidence,
+		Locators: []ProvenanceLocator{{
+			SourceKind:   repository.SourceKindUser,
+			SourceID:     sourceID,
+			ProducerKind: repository.ProducerKindUser,
+		}},
+		KnowledgeFromOverride: &knowledgeFrom,
+	})
+	return err
+}

--- a/backend/migrations/071_migrate_tags_to_graph.down.sql
+++ b/backend/migrations/071_migrate_tags_to_graph.down.sql
@@ -1,0 +1,8 @@
+-- Down marker for the tag→graph data migration (071 up is a no-op marker).
+--
+-- Nothing to revert at the schema layer: the up migration creates no objects.
+-- The graph rows the `crm-admin --migrate-tags` command writes (tag entity nodes
+-- + `tagged_as` assertions) live in the node / entity / assertion tables created
+-- by earlier migrations; they are not owned by this migration and are left in
+-- place. The legacy `tag` / `contact_tag` tables were never dropped, so the
+-- legacy representation remains intact as the rollback source of truth.

--- a/backend/migrations/071_migrate_tags_to_graph.up.sql
+++ b/backend/migrations/071_migrate_tags_to_graph.up.sql
@@ -1,0 +1,16 @@
+-- Tag migration into the graph — DATA-ONLY, performed by `crm-admin --migrate-tags`.
+--
+-- This migration is intentionally a NO-OP marker. The real work (mirror each
+-- legacy `tag` row into a `tag` entity node, and each `contact_tag` row of a
+-- NON-deleted contact into an accepted `tagged_as` assertion) must route through
+-- the validated assertion write path (proposition identity, dedup, event
+-- emission), which lives in Go — not a raw INSERT. So the data step is the
+-- operator-run `crm-admin --migrate-tags` subcommand, not this file.
+--
+-- The file exists for version-sequence continuity and to document, at the schema
+-- layer, where the tag→graph cutover happens. The legacy `tag` / `contact_tag`
+-- tables are NOT dropped here: they are retained as a rollback anchor and dropped
+-- in a later migration once the graph mirror is proven in production.
+--
+-- `crm-admin --migrate-tags` is idempotent (it routes through AssertService
+-- proposition identity and find-or-create entity nodes), so it is safe to re-run.

--- a/backend/tests/tag_migration_integration_test.go
+++ b/backend/tests/tag_migration_integration_test.go
@@ -250,8 +250,10 @@ func TestTagMigration_Integration(t *testing.T) {
 
 		h.softDeleteContact(t, ctx, deletedID)
 
-		_, err := h.svc.MigrateTags(ctx)
+		res, err := h.svc.MigrateTags(ctx)
 		require.NoError(t, err)
+		// The skip is surfaced in the summary (global count, so >= our one row).
+		assert.GreaterOrEqual(t, res.SkippedDeletedContacts, 1, "skipped-deleted count must include the deleted contact's tag")
 
 		// The live contact got its tagged_as; the deleted contact got none.
 		liveCount, err := h.support.CountTaggedAsAssertionsForSubject(ctx, liveID)

--- a/backend/tests/tag_migration_integration_test.go
+++ b/backend/tests/tag_migration_integration_test.go
@@ -1,0 +1,355 @@
+//go:build integration_testdb
+
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+
+	"github.com/google/uuid"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// tagMigrationHarness bundles the migration service under test + the repos a
+// test reads back. The legacy tag/contact_tag tables are not namespace-scoped
+// columns, so the test tracks every seeded tag/contact_tag id and cleans them
+// up explicitly (the migrate command itself is a global one-shot).
+type tagMigrationHarness struct {
+	svc           *service.TagMigrationService
+	contactRepo   *repository.ContactRepository
+	nodeRepo      *repository.NodeRepository
+	entityRepo    *repository.EntityRepository
+	assertionRepo *repository.AssertionRepository
+	eventRepo     *repository.EventRepository
+	support       *repository.SyntheticSupportRepository
+
+	// tracked ids for teardown.
+	contactIDs    []uuid.UUID
+	tagIDs        []uuid.UUID
+	tagNormalized []string // lower(name) of every seeded tag, to resolve its entity node for cleanup
+}
+
+func newTagMigrationHarness(t *testing.T, ctx context.Context) (*tagMigrationHarness, context.Context) {
+	t.Helper()
+	database, cfg := newSharedTestDB(t, ctx)
+
+	eventRepo := repository.NewEventRepository(database.Queries)
+	workers := river.NewWorkers()
+	river.AddWorker(workers, &assertNoopWorker{})
+	client, err := river.NewClient(riverpgxv5.New(database.Pool), &river.Config{
+		Queues:   map[string]river.QueueConfig{river.QueueDefault: {MaxWorkers: cfg.River.WorkerConcurrency}},
+		Workers:  workers,
+		TestOnly: true,
+	})
+	require.NoError(t, err)
+	bus := events.NewBus(database.Pool, client, eventRepo)
+
+	nodeRepo := repository.NewNodeRepository(database.Queries)
+	entityRepo := repository.NewEntityRepository(database.Queries)
+	predicateRepo := repository.NewPredicateRepository(database.Queries)
+	assertionRepo := repository.NewAssertionRepository(database.Queries)
+	assertSvc := service.NewAssertService(database.Pool, nodeRepo, entityRepo, predicateRepo, assertionRepo, bus)
+	tagRepo := repository.NewTagRepository(database.Queries)
+	svc := service.NewTagMigrationService(database.Pool, tagRepo, nodeRepo, entityRepo, assertSvc)
+
+	return &tagMigrationHarness{
+		svc:           svc,
+		contactRepo:   repository.NewContactRepository(database.Queries),
+		nodeRepo:      nodeRepo,
+		entityRepo:    entityRepo,
+		assertionRepo: assertionRepo,
+		eventRepo:     eventRepo,
+		support:       repository.NewSyntheticSupportRepository(database.Queries),
+	}, ctx
+}
+
+// seedContactWithNode creates a contact and its person node (node.id ==
+// contact.id), mirroring the production person-node backfill that guarantees
+// every non-deleted contact has a node. Returns the contact id.
+func (h *tagMigrationHarness) seedContactWithNode(t *testing.T, ctx context.Context, fullName string) uuid.UUID {
+	t.Helper()
+	contact, err := h.contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: fullName})
+	require.NoError(t, err)
+	_, err = h.nodeRepo.CreateNode(ctx, contact.ID, repository.NodeTypePerson, fullName)
+	require.NoError(t, err)
+	h.contactIDs = append(h.contactIDs, contact.ID)
+	return contact.ID
+}
+
+// softDeleteContact soft-deletes a contact AND its person node, mirroring the
+// production soft-delete + node tombstone, so the migration's
+// non-deleted-contact filter (and the assert path's tombstone rejection) apply.
+func (h *tagMigrationHarness) softDeleteContact(t *testing.T, ctx context.Context, contactID uuid.UUID) {
+	t.Helper()
+	require.NoError(t, h.contactRepo.SoftDeleteContact(ctx, contactID))
+	require.NoError(t, h.nodeRepo.SoftDeleteNode(ctx, contactID))
+}
+
+// seedTag creates a legacy tag row with the given name + optional color, tracks
+// its id + normalized name for teardown, and returns the id.
+func (h *tagMigrationHarness) seedTag(t *testing.T, ctx context.Context, name string, color *string) uuid.UUID {
+	t.Helper()
+	id, err := h.support.InsertTagForMigration(ctx, name, color)
+	require.NoError(t, err)
+	h.tagIDs = append(h.tagIDs, id)
+	h.tagNormalized = append(h.tagNormalized, strings.ToLower(strings.TrimSpace(name)))
+	return id
+}
+
+// seedContactTag links a contact to a tag at an explicit created_at (the
+// knowledge time the migration should preserve).
+func (h *tagMigrationHarness) seedContactTag(t *testing.T, ctx context.Context, contactID, tagID uuid.UUID, createdAt time.Time) {
+	t.Helper()
+	require.NoError(t, h.support.InsertContactTagAtTime(ctx, contactID, tagID, createdAt))
+}
+
+// registerCleanup tears down everything the test created, FK-ordered. Registered
+// once per test; t.Cleanup runs LIFO so call it right after the harness is built
+// (before seeding), and it executes after every subtest finishes.
+//
+// Order inside the closure (assertion→node FK is restrict, so assertions clear
+// before nodes): delete each contact node's assertions (+ provenance cascade) and
+// their event rows; delete contact_tags; resolve + delete the tag entity nodes
+// (entity cascades); delete the person nodes; delete contacts + legacy tags.
+func (h *tagMigrationHarness) registerCleanup(t *testing.T, ctx context.Context) {
+	t.Cleanup(func() {
+		for _, cid := range h.contactIDs {
+			assertions, _ := h.assertionRepo.ListAssertionsBySubject(ctx, cid)
+			for _, a := range assertions {
+				_ = h.eventRepo.HardDeleteEventsBySourceAndSourceIDPrefix(ctx, "assertion", a.ID.String())
+			}
+			_, _ = h.support.DeleteAssertionsForNode(ctx, cid)
+		}
+		_, _ = h.support.DeleteContactTagsByContactIds(ctx, h.contactIDs)
+
+		// Resolve the tag entity node ids the migration created (node.id != tag.id)
+		// by their normalized name, then hard-delete those nodes (entity cascades).
+		var tagNodeIDs []uuid.UUID
+		for _, norm := range h.tagNormalized {
+			entity, err := h.entityRepo.FindEntityBySubtypeName(ctx, repository.EntitySubtypeTag, norm)
+			if err == nil {
+				tagNodeIDs = append(tagNodeIDs, entity.NodeID)
+			}
+		}
+		_, _ = h.support.DeleteNodesByIds(ctx, tagNodeIDs)
+
+		_, _ = h.support.DeleteNodesByIds(ctx, h.contactIDs)
+		_, _ = h.support.DeleteContactTasksByContactIds(ctx, h.contactIDs)
+		_, _ = h.support.DeleteContactsByIds(ctx, h.contactIDs)
+		_, _ = h.support.DeleteTagsByIds(ctx, h.tagIDs)
+	})
+}
+
+// findTaggedAs returns the single LIVE accepted tagged_as assertion linking
+// subject → objectNode, or fails if it is absent / not unique.
+func (h *tagMigrationHarness) findTaggedAs(t *testing.T, ctx context.Context, subject, objectNode uuid.UUID) repository.Assertion {
+	t.Helper()
+	assertions, err := h.assertionRepo.ListAssertionsBySubject(ctx, subject)
+	require.NoError(t, err)
+	var found []repository.Assertion
+	for _, a := range assertions {
+		if a.PredicateKey == "tagged_as" && a.Status == repository.AssertionStatusAccepted &&
+			a.KnowledgeTo == nil && a.ObjectNodeID != nil && *a.ObjectNodeID == objectNode {
+			found = append(found, a)
+		}
+	}
+	require.Len(t, found, 1, "expected exactly one live accepted tagged_as for subject %s → %s", subject, objectNode)
+	return found[0]
+}
+
+// TestTagMigration_Integration covers the --migrate-tags command end to end. It
+// runs SERIAL (no t.Parallel): the migrate command reads the GLOBAL tag table
+// (not namespace-scoped), so concurrent tag-touching tests would perturb its
+// input. Each subtest builds a fresh harness, seeds only its own tags, and cleans
+// them up, so the global tag set during a subtest is just that subtest's tags.
+func TestTagMigration_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	ctx := context.Background()
+
+	t.Run("migrates tags + contact_tags with user provenance and color", func(t *testing.T) {
+		h, ctx := newTagMigrationHarness(t, ctx)
+		h.registerCleanup(t, ctx)
+		ns := syntheticNS(t)
+
+		contactID := h.seedContactWithNode(t, ctx, ns+" Alice")
+		color := "#ff8800"
+		coloredTagID := h.seedTag(t, ctx, ns+"-vip", &color)
+		plainTagID := h.seedTag(t, ctx, ns+"-lead", nil)
+
+		// Distinct knowledge times so we can assert KnowledgeFromOverride preserves
+		// each contact_tag.created_at.
+		coloredAt := accelerated.GetCurrentTime().UTC().Add(-72 * time.Hour).Truncate(time.Microsecond)
+		plainAt := accelerated.GetCurrentTime().UTC().Add(-24 * time.Hour).Truncate(time.Microsecond)
+		h.seedContactTag(t, ctx, contactID, coloredTagID, coloredAt)
+		h.seedContactTag(t, ctx, contactID, plainTagID, plainAt)
+
+		res, err := h.svc.MigrateTags(ctx)
+		require.NoError(t, err)
+		// Global counts include any stray tag (e.g. a reset marker), so assert >=
+		// our seeded volume rather than exact equality on the global figures.
+		assert.GreaterOrEqual(t, res.Tags, 2)
+		assert.GreaterOrEqual(t, res.ContactTags, 2)
+
+		// Both tag entity nodes exist with subtype='tag'; the colored one carries
+		// its color in detail, the plain one has no color key.
+		coloredEntity, err := h.entityRepo.FindEntityBySubtypeName(ctx, repository.EntitySubtypeTag, ns+"-vip")
+		require.NoError(t, err)
+		assert.Equal(t, color, detailColor(t, coloredEntity.Detail))
+
+		plainEntity, err := h.entityRepo.FindEntityBySubtypeName(ctx, repository.EntitySubtypeTag, ns+"-lead")
+		require.NoError(t, err)
+		assert.Empty(t, detailColor(t, plainEntity.Detail), "plain tag must carry no color")
+
+		// Each contact_tag became a live accepted tagged_as assertion with user
+		// provenance and the contact_tag's created_at as knowledge time.
+		coloredAssertion := h.findTaggedAs(t, ctx, contactID, coloredEntity.NodeID)
+		assert.Equal(t, coloredAt, coloredAssertion.KnowledgeFrom.UTC().Truncate(time.Microsecond))
+		assertUserProvenance(t, ctx, h, coloredAssertion.ID)
+
+		plainAssertion := h.findTaggedAs(t, ctx, contactID, plainEntity.NodeID)
+		assert.Equal(t, plainAt, plainAssertion.KnowledgeFrom.UTC().Truncate(time.Microsecond))
+		assertUserProvenance(t, ctx, h, plainAssertion.ID)
+
+		count, err := h.support.CountTaggedAsAssertionsForSubject(ctx, contactID)
+		require.NoError(t, err)
+		assert.EqualValues(t, 2, count)
+	})
+
+	t.Run("skips a soft-deleted contact's tags", func(t *testing.T) {
+		h, ctx := newTagMigrationHarness(t, ctx)
+		h.registerCleanup(t, ctx)
+		ns := syntheticNS(t)
+
+		liveID := h.seedContactWithNode(t, ctx, ns+" Live")
+		deletedID := h.seedContactWithNode(t, ctx, ns+" Gone")
+		tagID := h.seedTag(t, ctx, ns+"-shared", nil)
+		at := accelerated.GetCurrentTime().UTC().Add(-time.Hour).Truncate(time.Microsecond)
+		h.seedContactTag(t, ctx, liveID, tagID, at)
+		h.seedContactTag(t, ctx, deletedID, tagID, at)
+
+		h.softDeleteContact(t, ctx, deletedID)
+
+		_, err := h.svc.MigrateTags(ctx)
+		require.NoError(t, err)
+
+		// The live contact got its tagged_as; the deleted contact got none.
+		liveCount, err := h.support.CountTaggedAsAssertionsForSubject(ctx, liveID)
+		require.NoError(t, err)
+		assert.EqualValues(t, 1, liveCount, "live contact's tag should migrate")
+
+		deletedCount, err := h.support.CountTaggedAsAssertionsForSubject(ctx, deletedID)
+		require.NoError(t, err)
+		assert.EqualValues(t, 0, deletedCount, "soft-deleted contact's tag must be skipped")
+	})
+
+	t.Run("fails loudly on a case-insensitive name collision", func(t *testing.T) {
+		h, ctx := newTagMigrationHarness(t, ctx)
+		h.registerCleanup(t, ctx)
+		ns := syntheticNS(t)
+
+		contactID := h.seedContactWithNode(t, ctx, ns+" Carol")
+		upperID := h.seedTag(t, ctx, ns+"-Friend", nil)
+		lowerID := h.seedTag(t, ctx, ns+"-friend", nil)
+		at := accelerated.GetCurrentTime().UTC().Truncate(time.Microsecond)
+		h.seedContactTag(t, ctx, contactID, upperID, at)
+		h.seedContactTag(t, ctx, contactID, lowerID, at)
+
+		_, err := h.svc.MigrateTags(ctx)
+		require.Error(t, err)
+		require.ErrorIs(t, err, service.ErrTagCaseCollision)
+		// The error names BOTH colliding originals so the operator can dedup.
+		assert.Contains(t, err.Error(), ns+"-Friend")
+		assert.Contains(t, err.Error(), ns+"-friend")
+
+		// Nothing was written: no tagged_as assertion for the contact, and the
+		// colliding tag entity node was not created (preflight runs before any
+		// node creation).
+		count, err := h.support.CountTaggedAsAssertionsForSubject(ctx, contactID)
+		require.NoError(t, err)
+		assert.EqualValues(t, 0, count, "a collision must create no assertions")
+
+		_, findErr := h.entityRepo.FindEntityBySubtypeName(ctx, repository.EntitySubtypeTag, strings.ToLower(ns+"-friend"))
+		require.ErrorIs(t, findErr, db.ErrNotFound, "a collision must create no tag entity node")
+	})
+
+	t.Run("is idempotent across re-runs", func(t *testing.T) {
+		h, ctx := newTagMigrationHarness(t, ctx)
+		h.registerCleanup(t, ctx)
+		ns := syntheticNS(t)
+
+		contactID := h.seedContactWithNode(t, ctx, ns+" Dave")
+		tagID := h.seedTag(t, ctx, ns+"-repeat", nil)
+		at := accelerated.GetCurrentTime().UTC().Add(-time.Hour).Truncate(time.Microsecond)
+		h.seedContactTag(t, ctx, contactID, tagID, at)
+
+		_, err := h.svc.MigrateTags(ctx)
+		require.NoError(t, err)
+
+		entity, err := h.entityRepo.FindEntityBySubtypeName(ctx, repository.EntitySubtypeTag, ns+"-repeat")
+		require.NoError(t, err)
+		firstAssertion := h.findTaggedAs(t, ctx, contactID, entity.NodeID)
+		firstEventIDs, err := h.support.ListEventIdsBySourceAndSourceIDPrefix(ctx, "assertion", firstAssertion.ID.String())
+		require.NoError(t, err)
+
+		// Re-run: same proposition identity → corroborate, not duplicate.
+		_, err = h.svc.MigrateTags(ctx)
+		require.NoError(t, err)
+
+		// Still exactly one tag entity node (find-or-create reused it) and one
+		// live accepted tagged_as assertion (same id), with no new event rows.
+		entity2, err := h.entityRepo.FindEntityBySubtypeName(ctx, repository.EntitySubtypeTag, ns+"-repeat")
+		require.NoError(t, err)
+		assert.Equal(t, entity.NodeID, entity2.NodeID, "re-run must reuse the tag entity node")
+
+		secondAssertion := h.findTaggedAs(t, ctx, contactID, entity.NodeID)
+		assert.Equal(t, firstAssertion.ID, secondAssertion.ID, "re-run must not create a new assertion")
+
+		count, err := h.support.CountTaggedAsAssertionsForSubject(ctx, contactID)
+		require.NoError(t, err)
+		assert.EqualValues(t, 1, count, "re-run must not duplicate the assertion")
+
+		secondEventIDs, err := h.support.ListEventIdsBySourceAndSourceIDPrefix(ctx, "assertion", firstAssertion.ID.String())
+		require.NoError(t, err)
+		assert.Equal(t, len(firstEventIDs), len(secondEventIDs), "re-run must emit no new assertion events")
+	})
+}
+
+// detailColor extracts the color string from an entity detail JSONB (empty when
+// absent).
+func detailColor(t *testing.T, detail []byte) string {
+	t.Helper()
+	if len(detail) == 0 {
+		return ""
+	}
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(detail, &m))
+	if c, ok := m["color"].(string); ok {
+		return c
+	}
+	return ""
+}
+
+// assertUserProvenance asserts the assertion has exactly one provenance row, with
+// user source_kind + user producer_kind (the migration's authorship).
+func assertUserProvenance(t *testing.T, ctx context.Context, h *tagMigrationHarness, assertionID uuid.UUID) {
+	t.Helper()
+	provs, err := h.assertionRepo.ListProvenance(ctx, assertionID)
+	require.NoError(t, err)
+	require.Len(t, provs, 1)
+	assert.Equal(t, repository.SourceKindUser, provs[0].SourceKind)
+	assert.Equal(t, repository.ProducerKindUser, provs[0].ProducerKind)
+}

--- a/backend/tests/tag_migration_integration_test.go
+++ b/backend/tests/tag_migration_integration_test.go
@@ -115,6 +115,13 @@ func (h *tagMigrationHarness) seedContactTag(t *testing.T, ctx context.Context, 
 	require.NoError(t, h.support.InsertContactTagAtTime(ctx, contactID, tagID, createdAt))
 }
 
+// seedContactTagNull links a contact to a tag with a NULL created_at (the legacy
+// column is nullable), so a test can assert the migration falls back to "now".
+func (h *tagMigrationHarness) seedContactTagNull(t *testing.T, ctx context.Context, contactID, tagID uuid.UUID) {
+	t.Helper()
+	require.NoError(t, h.support.InsertContactTagNullCreatedAt(ctx, contactID, tagID))
+}
+
 // registerCleanup tears down everything the test created, FK-ordered. Registered
 // once per test; t.Cleanup runs LIFO so call it right after the harness is built
 // (before seeding), and it executes after every subtest finishes.
@@ -325,6 +332,30 @@ func TestTagMigration_Integration(t *testing.T) {
 		secondEventIDs, err := h.support.ListEventIdsBySourceAndSourceIDPrefix(ctx, "assertion", firstAssertion.ID.String())
 		require.NoError(t, err)
 		assert.Equal(t, len(firstEventIDs), len(secondEventIDs), "re-run must emit no new assertion events")
+	})
+
+	t.Run("falls back to now when contact_tag.created_at is NULL", func(t *testing.T) {
+		h, ctx := newTagMigrationHarness(t, ctx)
+		h.registerCleanup(t, ctx)
+		ns := syntheticNS(t)
+
+		contactID := h.seedContactWithNode(t, ctx, ns+" Erin")
+		tagID := h.seedTag(t, ctx, ns+"-nulltime", nil)
+		h.seedContactTagNull(t, ctx, contactID, tagID)
+
+		before := accelerated.GetCurrentTime().UTC()
+		_, err := h.svc.MigrateTags(ctx)
+		require.NoError(t, err)
+		after := accelerated.GetCurrentTime().UTC()
+
+		entity, err := h.entityRepo.FindEntityBySubtypeName(ctx, repository.EntitySubtypeTag, ns+"-nulltime")
+		require.NoError(t, err)
+		a := h.findTaggedAs(t, ctx, contactID, entity.NodeID)
+		// A NULL legacy created_at must NOT become a zero/ancient knowledge time:
+		// it falls back to "now" (knowledge_from is within the run window).
+		kf := a.KnowledgeFrom.UTC()
+		assert.Falsef(t, kf.Before(before.Add(-time.Minute)), "knowledge_from %s must not predate the run (no zero-time)", kf)
+		assert.Falsef(t, kf.After(after.Add(time.Minute)), "knowledge_from %s must not postdate the run", kf)
 	})
 }
 


### PR DESCRIPTION
## SP1 Relationship Data Model — PR8: tag migration (first Bucket B PR, backend-only)

Mirrors the legacy `tag`/`contact_tag` tables into the SP1 graph: each tag becomes a `tag` entity node, each contact_tag becomes an accepted `tagged_as` assertion. The legacy tables are **retained** (rollback anchor) — nothing is dropped.

### Scope note (re-scoped vs the original plan)
The plan classified PR8 as Bucket B because it assumed a **tag UI** (list / chips / filter) needed repointing. There is no tag UI — verified: the `tag.sql.go` query layer has zero callers, no tag route in `main.go`, no tag hooks; the only frontend "tag" hits are a CSS comment and a DOM `tagName`. So PR8 is **purely backend-additive** (no `frontend/` changes), and the plan's now-moot stateless-UNION read-fallback + deploy-ordering gate are dropped (there is no tag read path to keep alive).

### What changed
- **Migration 071** (`migrate_tags_to_graph`): a comment-marker — the data work routes through the validated write path (`AssertService`), not raw INSERTs. The `tag`/`contact_tag` tables are **not** dropped.
- **`crm-admin --migrate-tags`** + `TagMigrationService`:
  - **Case-collision preflight:** groups legacy tags by `lower(name)`; if `Friend` and `friend` collide, **fails loudly** listing the names and creates nothing (no silent collapse of distinct user tags).
  - **tag → entity node:** `type='entity'`, `subtype='tag'`, `normalized_name=lower(name)`, `canonical_label=name`, with the legacy `tag.color` stored in the per-instance `entity.detail` JSONB (single source of truth).
  - **contact_tag → `tagged_as` accepted assertion** via `AssertService`: user provenance (`source_kind='user'`, `confidence=100`), `KnowledgeFromOverride=contact_tag.created_at` (nullable → falls back to `accelerated.GetCurrentTime()`, never Go zero-time). Soft-deleted contacts are skipped permanently (a tombstoned subject node is rejected by the write path).
  - **Idempotent:** find-or-create entity nodes + AssertService proposition identity + deterministic `source_id` → a re-run corroborates, creating no duplicate nodes / assertions / events.
  - **Operator summary** reports `contact_tags_migrated` and `contact_tags_skipped_deleted` explicitly.

### Tests
- 5 namespace-scoped integration subtests: happy-path (user provenance + color in `entity.detail` + created_at→knowledge_from), soft-deleted-contact skip (+ surfaced skip count), loud case-collision (creates nothing), idempotent re-run (same ids, no new events), NULL-created_at fallback-to-now. Plus crm-admin unit tests for dispatch/parse/summary.

review-head PASS (P0=0 P1=0) — it was the primary gate (local Codex hit quota mid-run) and ran the suites + adversarially verified the nullable-created_at fix, idempotency, case-collision, and teardown. 3 minor comment/summary findings folded. Build (both binaries), lint, full integration suite green.