### PR TITLE
fix(sync): reject nil/empty account in TriggerSync (#530)

### DIFF
--- a/backend/internal/api/handlers/sync.go
+++ b/backend/internal/api/handlers/sync.go
@@ -10,6 +10,7 @@ import (
 	"personal-crm/backend/internal/api"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
 	"personal-crm/backend/internal/sync"
 
 	"github.com/gin-gonic/gin"
@@ -144,12 +145,27 @@ func (h *SyncHandler) TriggerSync(c *gin.Context) {
 		return
 	}
 
+	accountID := req.AccountID
+
+	// Pre-flight: reject account-scoped sources triggered without an account,
+	// synchronously, so the client gets a 400 instead of a 202 that hides a
+	// background failure. Mirrors the service-layer guard.
+	for _, cfg := range h.syncService.GetAvailableProviders() {
+		if cfg.Name == source {
+			if cfg.RequiresAccount && service.AccountIDMissing(accountID) {
+				api.SendError(c, http.StatusBadRequest, api.ErrCodeValidation,
+					"Account ID is required for this source", "")
+				return
+			}
+			break
+		}
+	}
+
 	// Enqueue the sync in a background goroutine with a detached context.
 	// After #180 PR 3 this is just a river Insert (fast), but we keep the
 	// goroutine so the HTTP client gets a 202 immediately even if the DB
 	// briefly stalls. 30s timeout is plenty for an Insert under realistic
 	// load; the old 5m was sized for full sync work, which is now off-handler.
-	accountID := req.AccountID
 	srcName := source // explicit capture for goroutine
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/backend/internal/google/calendar.go
+++ b/backend/internal/google/calendar.go
@@ -255,6 +255,7 @@ func (p *CalendarSyncProvider) Config() sync.SourceConfig {
 		SupportsMultiAccount: true,
 		SupportsDiscovery:    true,
 		DefaultInterval:      CalendarDefaultInterval,
+		RequiresAccount:      true, // OAuth token is keyed by account; Sync nil-checks AccountID
 	}
 }
 

--- a/backend/internal/google/calendar_test.go
+++ b/backend/internal/google/calendar_test.go
@@ -24,6 +24,9 @@ func TestCalendarSyncProvider_Config(t *testing.T) {
 	assert.True(t, config.SupportsMultiAccount)
 	assert.True(t, config.SupportsDiscovery)
 	assert.Equal(t, CalendarDefaultInterval, config.DefaultInterval)
+	// Account-scoped: OAuth token is keyed by account, so TriggerSync must
+	// reject a nil/empty account instead of bootstrapping an erroring row.
+	assert.True(t, config.RequiresAccount)
 }
 
 func TestGetEventStatus(t *testing.T) {

--- a/backend/internal/google/contacts.go
+++ b/backend/internal/google/contacts.go
@@ -68,6 +68,7 @@ func (p *ContactsProvider) Config() sync.SourceConfig {
 		SupportsMultiAccount: true,
 		SupportsDiscovery:    true,
 		DefaultInterval:      ContactsDefaultInterval,
+		RequiresAccount:      true, // OAuth token is keyed by account; Sync nil-checks AccountID
 	}
 }
 

--- a/backend/internal/google/contacts_test.go
+++ b/backend/internal/google/contacts_test.go
@@ -20,6 +20,9 @@ func TestContactsProvider_Config(t *testing.T) {
 	assert.True(t, config.SupportsMultiAccount)
 	assert.True(t, config.SupportsDiscovery)
 	assert.Equal(t, ContactsDefaultInterval, config.DefaultInterval)
+	// Account-scoped: OAuth token is keyed by account, so TriggerSync must
+	// reject a nil/empty account instead of bootstrapping an erroring row.
+	assert.True(t, config.RequiresAccount)
 }
 
 func TestContactsProvider_ConvertPersonToRequest(t *testing.T) {

--- a/backend/internal/google/gchat.go
+++ b/backend/internal/google/gchat.go
@@ -344,6 +344,7 @@ func (p *GChatSyncProvider) Config() syncpkg.SourceConfig {
 		SupportsMultiAccount: true,
 		SupportsDiscovery:    false,
 		DefaultInterval:      GChatDefaultInterval,
+		RequiresAccount:      true, // OAuth token is keyed by account; Sync nil-checks AccountID
 	}
 }
 

--- a/backend/internal/google/gchat_test.go
+++ b/backend/internal/google/gchat_test.go
@@ -21,6 +21,19 @@ import (
 	people "google.golang.org/api/people/v1"
 )
 
+func TestGChatSyncProvider_Config(t *testing.T) {
+	p := NewGChatSyncProvider(nil, nil, nil)
+	cfg := p.Config()
+
+	assert.Equal(t, GChatSourceName, cfg.Name)
+	assert.Equal(t, "Google Chat", cfg.DisplayName)
+	assert.True(t, cfg.SupportsMultiAccount)
+	assert.Equal(t, GChatDefaultInterval, cfg.DefaultInterval)
+	// Account-scoped: OAuth token is keyed by account, so TriggerSync must
+	// reject a nil/empty account instead of bootstrapping an erroring row.
+	assert.True(t, cfg.RequiresAccount)
+}
+
 // staticResolver builds a resolver whose fake ResolvePersonEmail returns a
 // fixed mapping (and counts calls), with no caching from a prior cache.
 func staticResolver(t *testing.T, mapping map[string]string, callCount *int) *cachedEmailResolver {

--- a/backend/internal/google/gmail.go
+++ b/backend/internal/google/gmail.go
@@ -297,6 +297,7 @@ func (p *GmailSyncProvider) Config() sync.SourceConfig {
 		SupportsMultiAccount: true,
 		SupportsDiscovery:    false,
 		DefaultInterval:      GmailDefaultInterval,
+		RequiresAccount:      true, // OAuth token is keyed by account; Sync nil-checks AccountID
 	}
 }
 

--- a/backend/internal/google/gmail_test.go
+++ b/backend/internal/google/gmail_test.go
@@ -119,6 +119,9 @@ func TestGmailSyncProvider_Config(t *testing.T) {
 	require.True(t, cfg.SupportsMultiAccount)
 	require.False(t, cfg.SupportsDiscovery)
 	require.Equal(t, GmailDefaultInterval, cfg.DefaultInterval)
+	// Account-scoped: OAuth token is keyed by account, so TriggerSync must
+	// reject a nil/empty account instead of bootstrapping an erroring row.
+	require.True(t, cfg.RequiresAccount)
 }
 
 // --- OR-chunk byte budgeting + sanitization ---

--- a/backend/internal/service/sync.go
+++ b/backend/internal/service/sync.go
@@ -140,6 +140,19 @@ func (s *SyncService) ListDueAccounts(ctx context.Context) ([]repository.DueAcco
 				Msg("scheduler tick: push-strategy provider; skipping due account")
 			continue
 		}
+		// Account-scoped providers (Config().RequiresAccount) whose row has a
+		// missing account_id can never sync: the provider's Sync rejects the
+		// nil/empty account, so enqueuing only burns retry budget forever —
+		// the same poisoned-row failure mode as the unregistered-source filter
+		// above. The trigger path refuses to bootstrap such rows; this skips
+		// any that already exist. Operators disable/delete them explicitly;
+		// the stalled next_sync_at surfaces them via the staleness banner.
+		if provider.Config().RequiresAccount && AccountIDMissing(acct.AccountID) {
+			logger.Debug().
+				Str("source", acct.Source).
+				Msg("scheduler tick: account-scoped provider with missing account_id; skipping due account")
+			continue
+		}
 		accounts = append(accounts, acct)
 	}
 	return accounts, nil

--- a/backend/internal/service/sync.go
+++ b/backend/internal/service/sync.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"personal-crm/backend/internal/accelerated"
@@ -15,6 +16,21 @@ import (
 
 	"github.com/google/uuid"
 )
+
+// ErrAccountRequired is returned by TriggerSync when an account-scoped
+// provider (Config().RequiresAccount) is triggered with a nil/empty account
+// ID. Bootstrapping a sync_state row here would create a permanently-erroring
+// row, so we reject instead. Handlers can map it to a 4xx via errors.Is.
+var ErrAccountRequired = errors.New("account ID required for this source")
+
+// AccountIDMissing reports whether an account ID is absent for the purpose of
+// account-scoped provider validation: nil, empty, or whitespace-only. A
+// padded-but-nonempty ID (e.g. " acct ") is intentionally NOT treated as
+// missing — normalizing caller input is out of scope here. Exported so the
+// sync HTTP handler shares this single definition.
+func AccountIDMissing(accountID *string) bool {
+	return accountID == nil || strings.TrimSpace(*accountID) == ""
+}
 
 // Backoff intervals for error retries (exponential backoff)
 var backoffIntervals = []time.Duration{
@@ -138,6 +154,12 @@ func (s *SyncService) TriggerSync(ctx context.Context, source string, accountID 
 	provider, ok := s.registry.Get(source)
 	if !ok {
 		return fmt.Errorf("unknown sync source: %s", source)
+	}
+
+	// Reject account-scoped providers triggered without an account, before we
+	// would otherwise bootstrap a permanently-erroring sync_state row.
+	if provider.Config().RequiresAccount && AccountIDMissing(accountID) {
+		return fmt.Errorf("%w: source %q requires an account ID", ErrAccountRequired, source)
 	}
 
 	// Get or create sync state. The state itself is not needed on the

--- a/backend/internal/service/sync.go
+++ b/backend/internal/service/sync.go
@@ -20,7 +20,9 @@ import (
 // ErrAccountRequired is returned by TriggerSync when an account-scoped
 // provider (Config().RequiresAccount) is triggered with a nil/empty account
 // ID. Bootstrapping a sync_state row here would create a permanently-erroring
-// row, so we reject instead. Handlers can map it to a 4xx via errors.Is.
+// row, so we reject instead. This is a backstop for non-HTTP/internal callers;
+// the HTTP 400 is produced separately by the handler's synchronous pre-flight
+// (which shares AccountIDMissing), not by mapping this sentinel.
 var ErrAccountRequired = errors.New("account ID required for this source")
 
 // AccountIDMissing reports whether an account ID is absent for the purpose of

--- a/backend/internal/sync/provider.go
+++ b/backend/internal/sync/provider.go
@@ -17,6 +17,12 @@ type SourceConfig struct {
 	SupportsMultiAccount bool                    `json:"supports_multi_account"` // true for Google/Telegram, false for iMessage
 	SupportsDiscovery    bool                    `json:"supports_discovery"`     // true if can discover new contacts
 	DefaultInterval      time.Duration           `json:"default_interval"`       // e.g., 15 * time.Minute
+	// RequiresAccount declares that this provider's Sync requires a non-nil,
+	// non-empty account ID (e.g. its OAuth token is keyed by account). When
+	// true, TriggerSync rejects a nil/empty account instead of bootstrapping a
+	// sync_state row that would error on every dispatch. Defaults to false
+	// (the correct value for push providers whose Sync is account-agnostic).
+	RequiresAccount bool `json:"requires_account"`
 }
 
 // SyncResult represents the outcome of a sync operation

--- a/backend/internal/todoist/provider.go
+++ b/backend/internal/todoist/provider.go
@@ -163,6 +163,7 @@ func (p *CadenceSyncProvider) Config() sync.SourceConfig {
 		SupportsMultiAccount: false, // v1 supports single account only
 		SupportsDiscovery:    false, // No task discovery from Todoist in v1
 		DefaultInterval:      DefaultSyncInterval,
+		RequiresAccount:      true, // OAuth token is keyed by account; Sync nil-checks AccountID
 	}
 }
 

--- a/backend/internal/todoist/provider_config_test.go
+++ b/backend/internal/todoist/provider_config_test.go
@@ -1,0 +1,23 @@
+package todoist
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCadenceSyncProvider_Config_RequiresAccount is the real-provider config
+// invariant for #530: Todoist is account-scoped (its OAuth token is keyed by
+// account, and Sync nil-checks state.AccountID), so its Config must declare
+// RequiresAccount so TriggerSync rejects a nil/empty account instead of
+// bootstrapping a permanently-erroring sync_state row.
+//
+// Config() returns a pure struct literal and reads no instance fields, so a
+// zero-value &CadenceSyncProvider{} is safe here — the NewCadenceSyncProvider
+// constructor dereferences cfg.CORS.FrontendURL, which this sidesteps.
+func TestCadenceSyncProvider_Config_RequiresAccount(t *testing.T) {
+	cfg := (&CadenceSyncProvider{}).Config()
+
+	assert.Equal(t, SourceName, cfg.Name)
+	assert.True(t, cfg.RequiresAccount, "todoist is account-scoped; TriggerSync must reject nil/empty account")
+}

--- a/backend/internal/todoist/provider_config_test.go
+++ b/backend/internal/todoist/provider_config_test.go
@@ -7,8 +7,8 @@ import (
 )
 
 // TestCadenceSyncProvider_Config_RequiresAccount is the real-provider config
-// invariant for #530: Todoist is account-scoped (its OAuth token is keyed by
-// account, and Sync nil-checks state.AccountID), so its Config must declare
+// invariant: Todoist is account-scoped (its OAuth token is keyed by account,
+// and Sync nil-checks state.AccountID), so its Config must declare
 // RequiresAccount so TriggerSync rejects a nil/empty account instead of
 // bootstrapping a permanently-erroring sync_state row.
 //

--- a/backend/tests/unit/sync_handler_test.go
+++ b/backend/tests/unit/sync_handler_test.go
@@ -203,7 +203,7 @@ func TestTriggerSync_RequiresSource(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
-// TestTriggerSync_RejectsAccountScopedSourceWithoutAccount verifies the #530
+// TestTriggerSync_RejectsAccountScopedSourceWithoutAccount verifies the
 // synchronous pre-flight: when the source is account-scoped (RequiresAccount)
 // and the request carries no usable account ID, the handler returns 400
 // (VALIDATION_ERROR) BEFORE spawning the background goroutine — so the client

--- a/backend/tests/unit/sync_handler_test.go
+++ b/backend/tests/unit/sync_handler_test.go
@@ -25,9 +25,13 @@ import (
 // mockSyncService implements handlers.SyncService for testing
 type mockSyncService struct {
 	triggerSyncCalled  atomic.Bool
+	triggerSyncAccount *string
 	triggerSyncDelay   time.Duration
 	triggerSyncStarted chan struct{}
 	triggerSyncDone    chan struct{}
+	// availableProviders is returned by GetAvailableProviders. Defaults nil so
+	// existing tests (whose pre-flight loop finds no match) are unaffected.
+	availableProviders []psync.SourceConfig
 }
 
 // Verify mockSyncService implements handlers.SyncService
@@ -42,6 +46,7 @@ func newMockSyncService() *mockSyncService {
 
 func (m *mockSyncService) TriggerSync(ctx context.Context, source string, accountID *string) error {
 	m.triggerSyncCalled.Store(true)
+	m.triggerSyncAccount = accountID
 	if m.triggerSyncStarted != nil {
 		select {
 		case m.triggerSyncStarted <- struct{}{}:
@@ -91,7 +96,7 @@ func (m *mockSyncService) GetRecentSyncLogs(ctx context.Context, limit int32) ([
 }
 
 func (m *mockSyncService) GetAvailableProviders() []psync.SourceConfig {
-	return nil
+	return m.availableProviders
 }
 
 func setupSyncHandlerTestRouter(mockService *mockSyncService) *gin.Engine {
@@ -196,4 +201,84 @@ func TestTriggerSync_RequiresSource(t *testing.T) {
 
 	// Handler returns 400 with "Source is required" validation error
 	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestTriggerSync_RejectsAccountScopedSourceWithoutAccount verifies the #530
+// synchronous pre-flight: when the source is account-scoped (RequiresAccount)
+// and the request carries no usable account ID, the handler returns 400
+// (VALIDATION_ERROR) BEFORE spawning the background goroutine — so the client
+// sees the error instead of a 202 that hides a background failure.
+func TestTriggerSync_RejectsAccountScopedSourceWithoutAccount(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{name: "empty body", body: ""},
+		{name: "empty account_id", body: `{"account_id":""}`},
+		{name: "whitespace account_id", body: `{"account_id":"  "}`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mockService := newMockSyncService()
+			mockService.availableProviders = []psync.SourceConfig{
+				{Name: "todoist", RequiresAccount: true},
+			}
+			router := setupSyncHandlerTestRouter(mockService)
+
+			req, _ := http.NewRequest("POST", "/api/v1/sync/todoist/trigger", strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+
+			var response api.APIResponse
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+			require.False(t, response.Success)
+			require.NotNil(t, response.Error)
+			assert.Equal(t, api.ErrCodeValidation, response.Error.Code)
+
+			// No goroutine was spawned: TriggerSync must never be called. Give
+			// any (incorrectly-spawned) goroutine a moment to run before asserting.
+			time.Sleep(50 * time.Millisecond)
+			assert.False(t, mockService.triggerSyncCalled.Load(),
+				"TriggerSync must not be called when the pre-flight rejects the request")
+		})
+	}
+}
+
+// TestTriggerSync_AllowsAccountScopedSourceWithAccount verifies the pre-flight
+// lets a valid account through: an account-scoped source with a non-empty
+// account_id returns 202 and TriggerSync is invoked with the provided account.
+func TestTriggerSync_AllowsAccountScopedSourceWithAccount(t *testing.T) {
+	t.Parallel()
+	mockService := newMockSyncService()
+	mockService.availableProviders = []psync.SourceConfig{
+		{Name: "todoist", RequiresAccount: true},
+	}
+	router := setupSyncHandlerTestRouter(mockService)
+
+	req, _ := http.NewRequest("POST", "/api/v1/sync/todoist/trigger",
+		strings.NewReader(`{"account_id":"acct-1"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusAccepted, w.Code)
+
+	// Wait for the background goroutine to invoke TriggerSync.
+	select {
+	case <-mockService.triggerSyncStarted:
+		require.True(t, mockService.triggerSyncCalled.Load())
+		require.NotNil(t, mockService.triggerSyncAccount, "account ID should be passed through")
+		assert.Equal(t, "acct-1", *mockService.triggerSyncAccount)
+	case <-time.After(2 * time.Second):
+		t.Fatal("TriggerSync should have run in the background")
+	}
 }

--- a/backend/tests/unit/sync_handler_test.go
+++ b/backend/tests/unit/sync_handler_test.go
@@ -282,3 +282,36 @@ func TestTriggerSync_AllowsAccountScopedSourceWithAccount(t *testing.T) {
 		t.Fatal("TriggerSync should have run in the background")
 	}
 }
+
+// TestTriggerSync_AllowsAccountOptionalSourceWithoutAccount verifies the
+// pre-flight does NOT reject account-optional sources (RequiresAccount false,
+// e.g. push-only providers like messages): a missing account ID still returns
+// 202 and TriggerSync runs. This guards the cfg.RequiresAccount term in the
+// pre-flight condition — dropping that term would wrongly 400 account-optional
+// sources, and only this test (a RequiresAccount:false provider in the registry
+// with no account) would catch it.
+func TestTriggerSync_AllowsAccountOptionalSourceWithoutAccount(t *testing.T) {
+	t.Parallel()
+	mockService := newMockSyncService()
+	mockService.availableProviders = []psync.SourceConfig{
+		{Name: "messages", RequiresAccount: false},
+	}
+	router := setupSyncHandlerTestRouter(mockService)
+
+	req, _ := http.NewRequest("POST", "/api/v1/sync/messages/trigger", strings.NewReader("{}"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusAccepted, w.Code)
+
+	// Wait for the background goroutine to invoke TriggerSync.
+	select {
+	case <-mockService.triggerSyncStarted:
+		require.True(t, mockService.triggerSyncCalled.Load(),
+			"account-optional source must pass the pre-flight and trigger sync")
+	case <-time.After(2 * time.Second):
+		t.Fatal("TriggerSync should have run in the background")
+	}
+}

--- a/backend/tests/unit/sync_service_test.go
+++ b/backend/tests/unit/sync_service_test.go
@@ -404,6 +404,171 @@ func TestSyncService_ListDueAccounts_FiltersUnregisteredProviders(t *testing.T) 
 	assert.False(t, foundDead, "unregistered provider's source should be filtered out")
 }
 
+// TestSyncService_TriggerSync_RejectsNilAccountForAccountScopedProvider is the
+// primary #530 regression: an account-scoped provider (Config().RequiresAccount)
+// triggered with a nil account must be rejected with ErrAccountRequired and must
+// NOT bootstrap an external_sync_state row (which would error on every dispatch
+// forever). The enqueuer is wired so we can also assert no river_job was queued.
+func TestSyncService_TriggerSync_RejectsNilAccountForAccountScopedProvider(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping db-backed service test in short mode")
+	}
+	t.Parallel()
+	database, ctx := newServiceSuiteDB(t)
+
+	syncRepo := repository.NewSyncRepositoryWithPool(database.Queries, database.Pool)
+
+	source := "service_test_requires_account_nil"
+	_ = syncRepo.DeleteRiverJobsBySourceArgForTest(ctx, source)
+	_ = syncRepo.DeleteSyncStatesBySourceForTest(ctx, source)
+	t.Cleanup(func() {
+		_ = syncRepo.DeleteRiverJobsBySourceArgForTest(context.Background(), source)
+		_ = syncRepo.DeleteSyncStatesBySourceForTest(context.Background(), source)
+	})
+
+	contactRepo := repository.NewContactRepository(database.Queries)
+	registry := syncpkg.NewProviderRegistry()
+	provider := &countingProvider{cfg: syncpkg.SourceConfig{
+		Name:            source,
+		DisplayName:     source,
+		Strategy:        repository.SyncStrategyFetchAll,
+		DefaultInterval: 15 * time.Minute,
+		RequiresAccount: true,
+	}}
+	registry.Register(provider)
+
+	svc := service.NewSyncService(syncRepo, contactRepo, registry)
+	// Wire the enqueuer so the "no river_job enqueued" assertion is meaningful
+	// (the guard returns before the enqueue branch).
+	workers := river.NewWorkers()
+	river.AddWorker(workers, &syncWorkerNoop{})
+	client := mustTestClient(t, database, workers)
+	svc.SetRiverEnqueuer(client)
+
+	err := svc.TriggerSync(ctx, source, nil)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, service.ErrAccountRequired),
+		"expected ErrAccountRequired, got %v", err)
+
+	// No external_sync_state row was created. GetSyncStateBySource uses
+	// COALESCE(account_id,'') = COALESCE($2,'') so a nil lookup matches both a
+	// NULL and an empty-string row — this single check covers both variants.
+	_, getErr := syncRepo.GetSyncStateBySource(ctx, source, nil)
+	assert.True(t, errors.Is(getErr, db.ErrNotFound),
+		"no sync_state row should exist, got %v", getErr)
+
+	// Provider.Sync was never called and nothing was enqueued.
+	assert.Equal(t, 0, provider.count, "provider.Sync must not run when account is missing")
+	cnt, err := syncRepo.CountRiverJobsBySourceArgForTest(ctx, source)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), cnt, "no river_job should be enqueued for a rejected trigger")
+}
+
+// TestSyncService_TriggerSync_RejectsMissingAccountVariants covers the empty and
+// whitespace-only account paths in addition to nil. AccountIDMissing trims, so
+// "", " ", and "\t" are all rejected — without this a {"account_id":""} body
+// would bootstrap a non-NULL empty-string row that still errors at OAuth lookup.
+func TestSyncService_TriggerSync_RejectsMissingAccountVariants(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping db-backed service test in short mode")
+	}
+	t.Parallel()
+	database, ctx := newServiceSuiteDB(t)
+
+	syncRepo := repository.NewSyncRepositoryWithPool(database.Queries, database.Pool)
+	contactRepo := repository.NewContactRepository(database.Queries)
+
+	cases := []struct {
+		name      string
+		accountID *string
+	}{
+		{name: "nil", accountID: nil},
+		{name: "empty", accountID: strPtr("")},
+		{name: "whitespace", accountID: strPtr("  ")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			source := "service_test_requires_account_" + tc.name
+			_ = syncRepo.DeleteRiverJobsBySourceArgForTest(ctx, source)
+			_ = syncRepo.DeleteSyncStatesBySourceForTest(ctx, source)
+			t.Cleanup(func() {
+				_ = syncRepo.DeleteRiverJobsBySourceArgForTest(context.Background(), source)
+				_ = syncRepo.DeleteSyncStatesBySourceForTest(context.Background(), source)
+			})
+
+			registry := syncpkg.NewProviderRegistry()
+			provider := &countingProvider{cfg: syncpkg.SourceConfig{
+				Name:            source,
+				DisplayName:     source,
+				Strategy:        repository.SyncStrategyFetchAll,
+				DefaultInterval: 15 * time.Minute,
+				RequiresAccount: true,
+			}}
+			registry.Register(provider)
+			svc := service.NewSyncService(syncRepo, contactRepo, registry)
+
+			err := svc.TriggerSync(ctx, source, tc.accountID)
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, service.ErrAccountRequired),
+				"expected ErrAccountRequired for %q, got %v", tc.name, err)
+
+			// No row created for the exact value passed. The COALESCE lookup
+			// collapses NULL/'' (covering nil + empty); for whitespace we query
+			// with the same whitespace value, which the guard never wrote.
+			_, getErr := syncRepo.GetSyncStateBySource(ctx, source, tc.accountID)
+			assert.True(t, errors.Is(getErr, db.ErrNotFound),
+				"no sync_state row should exist for %q, got %v", tc.name, getErr)
+			assert.Equal(t, 0, provider.count, "provider.Sync must not run for %q", tc.name)
+		})
+	}
+}
+
+// TestSyncService_TriggerSync_AccountOptionalProviderStillBootstraps guards the
+// second acceptance criterion: a provider that does NOT require an account
+// (RequiresAccount defaults false) keeps its create-on-first-trigger behavior
+// when called with a nil account. Prevents an over-broad rejection regression.
+func TestSyncService_TriggerSync_AccountOptionalProviderStillBootstraps(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping db-backed service test in short mode")
+	}
+	t.Parallel()
+	database, ctx := newServiceSuiteDB(t)
+
+	syncRepo := repository.NewSyncRepositoryWithPool(database.Queries, database.Pool)
+
+	source := "service_test_account_optional_bootstrap"
+	_ = syncRepo.DeleteSyncStatesBySourceForTest(ctx, source)
+	_ = syncRepo.DeleteSyncLogsBySourceForTest(ctx, source)
+	t.Cleanup(func() {
+		_ = syncRepo.DeleteSyncStatesBySourceForTest(context.Background(), source)
+		_ = syncRepo.DeleteSyncLogsBySourceForTest(context.Background(), source)
+	})
+
+	contactRepo := repository.NewContactRepository(database.Queries)
+	registry := syncpkg.NewProviderRegistry()
+	provider := &countingProvider{cfg: syncpkg.SourceConfig{
+		Name:            source,
+		DisplayName:     source,
+		Strategy:        repository.SyncStrategyFetchAll,
+		DefaultInterval: 15 * time.Minute,
+		// RequiresAccount left false (the push/account-optional default).
+	}}
+	registry.Register(provider)
+
+	svc := service.NewSyncService(syncRepo, contactRepo, registry)
+	// No enqueuer: TriggerSync falls back to inline runSyncForState after
+	// bootstrapping the row.
+	require.NoError(t, svc.TriggerSync(ctx, source, nil))
+
+	// The create-on-first-trigger row exists and the inline sync ran.
+	state, err := syncRepo.GetSyncStateBySource(ctx, source, nil)
+	require.NoError(t, err)
+	assert.Equal(t, source, state.Source)
+	assert.Equal(t, 1, provider.count, "account-optional provider should still sync inline")
+}
+
 // --- test helpers ---
 
 // mustTestClient builds a test-only *river.Client[pgx.Tx] so callers can

--- a/backend/tests/unit/sync_service_test.go
+++ b/backend/tests/unit/sync_service_test.go
@@ -405,7 +405,7 @@ func TestSyncService_ListDueAccounts_FiltersUnregisteredProviders(t *testing.T) 
 }
 
 // TestSyncService_TriggerSync_RejectsNilAccountForAccountScopedProvider is the
-// primary #530 regression: an account-scoped provider (Config().RequiresAccount)
+// primary regression: an account-scoped provider (Config().RequiresAccount)
 // triggered with a nil account must be rejected with ErrAccountRequired and must
 // NOT bootstrap an external_sync_state row (which would error on every dispatch
 // forever). The enqueuer is wired so we can also assert no river_job was queued.

--- a/backend/tests/unit/sync_service_test.go
+++ b/backend/tests/unit/sync_service_test.go
@@ -404,6 +404,75 @@ func TestSyncService_ListDueAccounts_FiltersUnregisteredProviders(t *testing.T) 
 	assert.False(t, foundDead, "unregistered provider's source should be filtered out")
 }
 
+// TestSyncService_ListDueAccounts_SkipsAccountScopedRowsMissingAccount verifies
+// the scheduler tick does not enqueue an account-scoped provider's sync_state
+// row whose account_id is missing: the provider's Sync rejects the nil/empty
+// account, so the job would only burn retry budget forever. The trigger guard
+// prevents creating such rows; this covers any that already exist. A row WITH
+// an account for the same provider is still listed (positive control).
+func TestSyncService_ListDueAccounts_SkipsAccountScopedRowsMissingAccount(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping db-backed service test in short mode")
+	}
+	t.Parallel()
+	database, ctx := newServiceSuiteDB(t)
+
+	syncRepo := repository.NewSyncRepositoryWithPool(database.Queries, database.Pool)
+
+	source := "service_test_acct_scoped_source"
+	cleanup := func(c context.Context) { _ = syncRepo.DeleteSyncStatesBySourceForTest(c, source) }
+	cleanup(ctx)
+	t.Cleanup(func() { cleanup(context.Background()) })
+
+	contactRepo := repository.NewContactRepository(database.Queries)
+	registry := syncpkg.NewProviderRegistry()
+	registry.Register(&countingProvider{cfg: syncpkg.SourceConfig{
+		Name:            source,
+		DisplayName:     source,
+		Strategy:        repository.SyncStrategyFetchAll,
+		DefaultInterval: 15 * time.Minute,
+		RequiresAccount: true,
+	}})
+
+	past := accelerated.GetCurrentTime().Add(-1 * time.Minute)
+	validAccount := "service_test_valid_account"
+	// Poisoned row: account-scoped provider with no account_id.
+	_, err := syncRepo.CreateSyncState(ctx, repository.CreateSyncStateRequest{
+		Source:     source,
+		Enabled:    true,
+		Strategy:   repository.SyncStrategyFetchAll,
+		NextSyncAt: &past,
+	})
+	require.NoError(t, err)
+	// Healthy row: same provider, valid account_id.
+	_, err = syncRepo.CreateSyncState(ctx, repository.CreateSyncStateRequest{
+		Source:     source,
+		AccountID:  &validAccount,
+		Enabled:    true,
+		Strategy:   repository.SyncStrategyFetchAll,
+		NextSyncAt: &past,
+	})
+	require.NoError(t, err)
+
+	svc := service.NewSyncService(syncRepo, contactRepo, registry)
+	accounts, err := svc.ListDueAccounts(ctx)
+	require.NoError(t, err)
+
+	foundMissing, foundValid := false, false
+	for _, a := range accounts {
+		if a.Source != source {
+			continue
+		}
+		if a.AccountID == nil || *a.AccountID == "" {
+			foundMissing = true
+		} else if *a.AccountID == validAccount {
+			foundValid = true
+		}
+	}
+	assert.False(t, foundMissing, "account-scoped row with missing account_id must be skipped")
+	assert.True(t, foundValid, "account-scoped row with a valid account must still be listed")
+}
+
 // TestSyncService_TriggerSync_RejectsNilAccountForAccountScopedProvider is the
 // primary regression: an account-scoped provider (Config().RequiresAccount)
 // triggered with a nil account must be rejected with ErrAccountRequired and must


### PR DESCRIPTION
## Problem

Closes #530.

`TriggerSync` bootstrapped a fresh `external_sync_state` row on first trigger regardless of whether `accountID` was valid. For an account-scoped provider (e.g. Todoist), a nil/empty account produced an enabled-but-permanently-unusable row: every scheduler dispatch hit the provider's `Sync` nil-check, River retried forever, and the row never self-healed. Prod surfaced exactly this — an account-scoped sync row with an empty `account_id` that retried for weeks before the staleness watchdog flagged it.

## Fix

- Add an explicit `RequiresAccount bool` to `sync.SourceConfig`, set `true` on the five account-scoped providers (todoist, gcal, gmail, gchat, gcontacts).
- The service guard in `TriggerSync` now rejects an account-required provider called with a nil/empty/whitespace account (`ErrAccountRequired` sentinel + shared `AccountIDMissing` predicate) **before** the create-on-first-trigger branch.
- The handler mirrors this with a synchronous pre-flight that returns 400 before spawning the fire-and-forget goroutine, so the client sees the error instead of a 202 that hides a background failure.
- A real-provider config invariant test asserts each account-scoped provider opts in, so a forgotten flag fails loudly under the mandatory runner.

## Testing

- New service-layer tests: nil/empty/whitespace account rejected with `ErrAccountRequired`; account-optional providers still bootstrap normally.
- New handler tests: account-scoped source without account → 400 (no goroutine spawned); with account → 202 + pass-through; account-optional source without account → 202 (guards the `RequiresAccount` term — mutation-verified).
- Full local pre-push gate green (lint, unit, integration, frontend, E2E); `/review-head` PASS on `6dc1b5f`.

## Review notes (non-blocking)

Two P2s deferred by design:
- `AccountIDMissing` treats a padded-but-nonempty id (`" x "`) as present; `account_id` is system-generated from OAuth today, so this is future-proofing, not a live bug.
- No registry-sweep test enforcing that *future* account-scoped providers set `RequiresAccount`; today's five are covered per-provider.