### PR TITLE
refactor(api): centralize handler error handling; log 500 causes, stop leaking err text

### DIFF
--- a/backend/internal/api/handlers/anarlog_discovery.go
+++ b/backend/internal/api/handlers/anarlog_discovery.go
@@ -26,7 +26,7 @@ type AnarlogDiscoveryHandler struct {
 func NewAnarlogDiscoveryHandler(svc *service.AnarlogDiscoveryService) *AnarlogDiscoveryHandler {
 	return &AnarlogDiscoveryHandler{
 		svc:       svc,
-		validator: validator.New(),
+		validator: sharedValidator,
 	}
 }
 

--- a/backend/internal/api/handlers/anarlog_discovery.go
+++ b/backend/internal/api/handlers/anarlog_discovery.go
@@ -59,7 +59,7 @@ func (h *AnarlogDiscoveryHandler) ListAnarlogTitle(c *gin.Context) {
 	}
 	groups, err := h.svc.ListGroups(c.Request.Context())
 	if err != nil {
-		api.SendInternalError(c, err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 	api.SendSuccess(c, http.StatusOK, groups, nil)
@@ -125,6 +125,6 @@ func (h *AnarlogDiscoveryHandler) mapResolveError(c *gin.Context, err error) {
 	case errors.Is(err, service.ErrDiscoveryContactMissing):
 		api.SendNotFound(c, "Contact")
 	default:
-		api.SendInternalError(c, err.Error())
+		api.RespondInternal(c, err)
 	}
 }

--- a/backend/internal/api/handlers/calendar.go
+++ b/backend/internal/api/handlers/calendar.go
@@ -113,7 +113,7 @@ func (h *CalendarHandler) ListEventsForContact(c *gin.Context) {
 	// Fetch events
 	events, err := h.calendarRepo.ListEventsForContact(c.Request.Context(), contactID, limit, offset)
 	if err != nil {
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to fetch events", err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 
@@ -153,7 +153,7 @@ func (h *CalendarHandler) ListUpcomingEventsForContact(c *gin.Context) {
 	now := accelerated.GetCurrentTime()
 	events, err := h.calendarRepo.ListUpcomingEventsForContact(c.Request.Context(), contactID, now, limit)
 	if err != nil {
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to fetch events", err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 
@@ -184,7 +184,7 @@ func (h *CalendarHandler) ListUpcomingEvents(c *gin.Context) {
 	now := accelerated.GetCurrentTime()
 	events, err := h.calendarRepo.ListUpcomingEventsWithContacts(c.Request.Context(), now, limit, offset)
 	if err != nil {
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to fetch events", err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 

--- a/backend/internal/api/handlers/calendar.go
+++ b/backend/internal/api/handlers/calendar.go
@@ -9,7 +9,6 @@ import (
 	"personal-crm/backend/internal/repository"
 
 	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
 )
 
 // CalendarHandler handles calendar-related HTTP requests
@@ -100,10 +99,8 @@ func convertToEventResponse(event *repository.CalendarEvent) CalendarEventRespon
 // @Router /contacts/{id}/events [get]
 func (h *CalendarHandler) ListEventsForContact(c *gin.Context) {
 	// Parse contact ID
-	idStr := c.Param("id")
-	contactID, err := uuid.Parse(idStr)
-	if err != nil {
-		api.SendError(c, http.StatusBadRequest, api.ErrCodeValidation, "Invalid contact ID", err.Error())
+	contactID, ok := api.ParseUUIDParam(c, "id", "contact")
+	if !ok {
 		return
 	}
 
@@ -139,10 +136,8 @@ func (h *CalendarHandler) ListEventsForContact(c *gin.Context) {
 // @Router /contacts/{id}/events/upcoming [get]
 func (h *CalendarHandler) ListUpcomingEventsForContact(c *gin.Context) {
 	// Parse contact ID
-	idStr := c.Param("id")
-	contactID, err := uuid.Parse(idStr)
-	if err != nil {
-		api.SendError(c, http.StatusBadRequest, api.ErrCodeValidation, "Invalid contact ID", err.Error())
+	contactID, ok := api.ParseUUIDParam(c, "id", "contact")
+	if !ok {
 		return
 	}
 

--- a/backend/internal/api/handlers/contact.go
+++ b/backend/internal/api/handlers/contact.go
@@ -316,10 +316,8 @@ func (h *ContactHandler) CreateContact(c *gin.Context) {
 // @Failure 500 {object} api.APIResponse{error=api.APIError} "Internal server error"
 // @Router /contacts/{id} [get]
 func (h *ContactHandler) GetContact(c *gin.Context) {
-	idStr := c.Param("id")
-	id, err := uuid.Parse(idStr)
-	if err != nil {
-		api.SendValidationError(c, "Invalid contact ID", "ID must be a valid UUID")
+	id, ok := api.ParseUUIDParam(c, "id", "contact")
+	if !ok {
 		return
 	}
 
@@ -484,10 +482,8 @@ func (h *ContactHandler) ListContacts(c *gin.Context) {
 // @Failure 500 {object} api.APIResponse{error=api.APIError} "Internal server error"
 // @Router /contacts/{id} [put]
 func (h *ContactHandler) UpdateContact(c *gin.Context) {
-	idStr := c.Param("id")
-	id, err := uuid.Parse(idStr)
-	if err != nil {
-		api.SendValidationError(c, "Invalid contact ID", "ID must be a valid UUID")
+	id, ok := api.ParseUUIDParam(c, "id", "contact")
+	if !ok {
 		return
 	}
 
@@ -544,14 +540,12 @@ func (h *ContactHandler) UpdateContact(c *gin.Context) {
 // @Failure 500 {object} api.APIResponse{error=api.APIError} "Internal server error"
 // @Router /contacts/{id} [delete]
 func (h *ContactHandler) DeleteContact(c *gin.Context) {
-	idStr := c.Param("id")
-	id, err := uuid.Parse(idStr)
-	if err != nil {
-		api.SendValidationError(c, "Invalid contact ID", "ID must be a valid UUID")
+	id, ok := api.ParseUUIDParam(c, "id", "contact")
+	if !ok {
 		return
 	}
 
-	err = h.contactService.DeleteContact(c.Request.Context(), id)
+	err := h.contactService.DeleteContact(c.Request.Context(), id)
 	if err != nil {
 		api.RespondError(c, err, "Contact")
 		return
@@ -722,10 +716,8 @@ type MergePreviewResponse struct {
 // @Router /contacts/{id}/merge/preview [get]
 func (h *ContactHandler) GetMergePreview(c *gin.Context) {
 	// Parse target contact ID from path
-	targetIDStr := c.Param("id")
-	targetID, err := uuid.Parse(targetIDStr)
-	if err != nil {
-		api.SendValidationError(c, "Invalid target contact ID", "ID must be a valid UUID")
+	targetID, ok := api.ParseUUIDParam(c, "id", "target contact")
+	if !ok {
 		return
 	}
 
@@ -775,10 +767,8 @@ func (h *ContactHandler) GetMergePreview(c *gin.Context) {
 // @Router /contacts/{id}/merge [post]
 func (h *ContactHandler) MergeContacts(c *gin.Context) {
 	// Parse target contact ID from path
-	targetIDStr := c.Param("id")
-	targetID, err := uuid.Parse(targetIDStr)
-	if err != nil {
-		api.SendValidationError(c, "Invalid target contact ID", "ID must be a valid UUID")
+	targetID, ok := api.ParseUUIDParam(c, "id", "target contact")
+	if !ok {
 		return
 	}
 

--- a/backend/internal/api/handlers/contact.go
+++ b/backend/internal/api/handlers/contact.go
@@ -451,18 +451,8 @@ func (h *ContactHandler) ListContacts(c *gin.Context) {
 		responses[i] = contactToResponse(&contact)
 	}
 
-	totalPages := int(total) / query.Limit
-	if int(total)%query.Limit > 0 {
-		totalPages++
-	}
-
 	meta := &api.Meta{
-		Pagination: &api.PaginationMeta{
-			Page:  query.Page,
-			Limit: query.Limit,
-			Total: total,
-			Pages: totalPages,
-		},
+		Pagination: api.BuildPaginationMeta(query.Page, query.Limit, total),
 	}
 
 	api.SendSuccess(c, http.StatusOK, responses, meta)

--- a/backend/internal/api/handlers/contact.go
+++ b/backend/internal/api/handlers/contact.go
@@ -10,7 +10,6 @@ import (
 
 	"personal-crm/backend/internal/accelerated"
 	"personal-crm/backend/internal/api"
-	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/logger"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/service"
@@ -296,7 +295,7 @@ func (h *ContactHandler) CreateContact(c *gin.Context) {
 		buildContactMethodInputs(req.Methods),
 	)
 	if err != nil {
-		api.SendInternalError(c, "Failed to create contact")
+		api.RespondInternal(c, err)
 		return
 	}
 
@@ -326,11 +325,7 @@ func (h *ContactHandler) GetContact(c *gin.Context) {
 
 	contact, err := h.contactService.GetContact(c.Request.Context(), id)
 	if err != nil {
-		if errors.Is(err, db.ErrNotFound) {
-			api.SendNotFound(c, "Contact")
-			return
-		}
-		api.SendInternalError(c, "Failed to retrieve contact")
+		api.RespondError(c, err, "Contact")
 		return
 	}
 
@@ -399,7 +394,7 @@ func (h *ContactHandler) ListContacts(c *gin.Context) {
 			FollowupFilter: query.FollowupFilter,
 		})
 		if err != nil {
-			api.SendInternalError(c, "Failed to retrieve contact IDs")
+			api.RespondInternal(c, err)
 			return
 		}
 
@@ -448,7 +443,7 @@ func (h *ContactHandler) ListContacts(c *gin.Context) {
 	}
 
 	if err != nil {
-		api.SendInternalError(c, "Failed to retrieve contacts")
+		api.RespondInternal(c, err)
 		return
 	}
 
@@ -528,11 +523,7 @@ func (h *ContactHandler) UpdateContact(c *gin.Context) {
 		methodsProvided,
 	)
 	if err != nil {
-		if errors.Is(err, db.ErrNotFound) {
-			api.SendNotFound(c, "Contact")
-			return
-		}
-		api.SendInternalError(c, "Failed to update contact")
+		api.RespondError(c, err, "Contact")
 		return
 	}
 
@@ -562,11 +553,7 @@ func (h *ContactHandler) DeleteContact(c *gin.Context) {
 
 	err = h.contactService.DeleteContact(c.Request.Context(), id)
 	if err != nil {
-		if errors.Is(err, db.ErrNotFound) {
-			api.SendNotFound(c, "Contact")
-			return
-		}
-		api.SendInternalError(c, "Failed to delete contact")
+		api.RespondError(c, err, "Contact")
 		return
 	}
 
@@ -584,7 +571,7 @@ func (h *ContactHandler) DeleteContact(c *gin.Context) {
 func (h *ContactHandler) ListOverdueContacts(c *gin.Context) {
 	overdueContacts, err := h.contactService.ListOverdueContacts(c.Request.Context())
 	if err != nil {
-		api.SendInternalError(c, "Failed to retrieve contacts")
+		api.RespondInternal(c, err)
 		return
 	}
 
@@ -756,11 +743,7 @@ func (h *ContactHandler) GetMergePreview(c *gin.Context) {
 
 	preview, err := h.contactService.GetMergePreview(c.Request.Context(), sourceID, targetID)
 	if err != nil {
-		if errors.Is(err, db.ErrNotFound) {
-			api.SendNotFound(c, "Contact")
-			return
-		}
-		api.SendInternalError(c, "Failed to get merge preview")
+		api.RespondError(c, err, "Contact")
 		return
 	}
 
@@ -830,11 +813,7 @@ func (h *ContactHandler) MergeContacts(c *gin.Context) {
 
 	mergedContact, err := h.contactService.MergeContacts(c.Request.Context(), serviceReq)
 	if err != nil {
-		if errors.Is(err, db.ErrNotFound) {
-			api.SendNotFound(c, "Contact")
-			return
-		}
-		api.SendInternalError(c, "Failed to merge contacts")
+		api.RespondError(c, err, "Contact")
 		return
 	}
 

--- a/backend/internal/api/handlers/contact.go
+++ b/backend/internal/api/handlers/contact.go
@@ -70,7 +70,7 @@ type ContactHandler struct {
 func NewContactHandler(contactService *service.ContactService) *ContactHandler {
 	return &ContactHandler{
 		contactService: contactService,
-		validator:      validator.New(),
+		validator:      sharedValidator,
 	}
 }
 

--- a/backend/internal/api/handlers/contact_task.go
+++ b/backend/internal/api/handlers/contact_task.go
@@ -24,7 +24,7 @@ type ContactTaskHandler struct {
 func NewContactTaskHandler(contactTaskService *service.ContactTaskService) *ContactTaskHandler {
 	return &ContactTaskHandler{
 		contactTaskService: contactTaskService,
-		validator:          validator.New(),
+		validator:          sharedValidator,
 	}
 }
 

--- a/backend/internal/api/handlers/contact_task.go
+++ b/backend/internal/api/handlers/contact_task.go
@@ -119,7 +119,7 @@ func (h *ContactTaskHandler) CreateManualTask(c *gin.Context) {
 			api.SendError(c, http.StatusBadRequest, api.ErrCodeBadRequest, "Todoist settings not configured", "Configure Todoist project and label in Settings")
 			return
 		}
-		api.SendInternalError(c, "Failed to create task")
+		api.RespondInternal(c, err)
 		return
 	}
 
@@ -192,11 +192,7 @@ func (h *ContactTaskHandler) ListContactTasks(c *gin.Context) {
 	// List tasks
 	tasks, err := h.contactTaskService.ListContactTasks(ctx, contactID, stateFilter, kindFilter, lifecycleFilter)
 	if err != nil {
-		if errors.Is(err, db.ErrNotFound) {
-			api.SendNotFound(c, "Contact")
-			return
-		}
-		api.SendInternalError(c, "Failed to list tasks")
+		api.RespondError(c, err, "Contact")
 		return
 	}
 
@@ -240,11 +236,7 @@ func (h *ContactTaskHandler) DeleteTaskLink(c *gin.Context) {
 	// Delete task link
 	err = h.contactTaskService.DeleteTaskLink(ctx, contactID, taskID)
 	if err != nil {
-		if errors.Is(err, db.ErrNotFound) {
-			api.SendNotFound(c, "Task")
-			return
-		}
-		api.SendInternalError(c, "Failed to delete task link")
+		api.RespondError(c, err, "Task")
 		return
 	}
 

--- a/backend/internal/api/handlers/contact_task.go
+++ b/backend/internal/api/handlers/contact_task.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/go-playground/validator/v10"
-	"github.com/google/uuid"
 )
 
 // ContactTaskHandler handles contact task-related HTTP requests
@@ -75,9 +74,8 @@ func (h *ContactTaskHandler) CreateManualTask(c *gin.Context) {
 	ctx := c.Request.Context()
 
 	// Parse contact ID
-	contactID, err := uuid.Parse(c.Param("id"))
-	if err != nil {
-		api.SendValidationError(c, "Invalid contact ID", "ID must be a valid UUID")
+	contactID, ok := api.ParseUUIDParam(c, "id", "contact")
+	if !ok {
 		return
 	}
 
@@ -158,9 +156,8 @@ func (h *ContactTaskHandler) ListContactTasks(c *gin.Context) {
 	ctx := c.Request.Context()
 
 	// Parse contact ID
-	contactID, err := uuid.Parse(c.Param("id"))
-	if err != nil {
-		api.SendValidationError(c, "Invalid contact ID", "ID must be a valid UUID")
+	contactID, ok := api.ParseUUIDParam(c, "id", "contact")
+	if !ok {
 		return
 	}
 
@@ -220,21 +217,19 @@ func (h *ContactTaskHandler) DeleteTaskLink(c *gin.Context) {
 	ctx := c.Request.Context()
 
 	// Parse contact ID
-	contactID, err := uuid.Parse(c.Param("id"))
-	if err != nil {
-		api.SendValidationError(c, "Invalid contact ID", "ID must be a valid UUID")
+	contactID, ok := api.ParseUUIDParam(c, "id", "contact")
+	if !ok {
 		return
 	}
 
 	// Parse task ID
-	taskID, err := uuid.Parse(c.Param("taskId"))
-	if err != nil {
-		api.SendValidationError(c, "Invalid task ID", "ID must be a valid UUID")
+	taskID, ok := api.ParseUUIDParam(c, "taskId", "task")
+	if !ok {
 		return
 	}
 
 	// Delete task link
-	err = h.contactTaskService.DeleteTaskLink(ctx, contactID, taskID)
+	err := h.contactTaskService.DeleteTaskLink(ctx, contactID, taskID)
 	if err != nil {
 		api.RespondError(c, err, "Task")
 		return

--- a/backend/internal/api/handlers/identity.go
+++ b/backend/internal/api/handlers/identity.go
@@ -94,10 +94,8 @@ func (h *IdentityHandler) ListUnmatchedIdentities(c *gin.Context) {
 // @Failure 500 {object} api.APIResponse{error=api.APIError}
 // @Router /identities/{id} [get]
 func (h *IdentityHandler) GetIdentity(c *gin.Context) {
-	idStr := c.Param("id")
-	id, err := uuid.Parse(idStr)
-	if err != nil {
-		api.SendValidationError(c, "Invalid identity ID", err.Error())
+	id, ok := api.ParseUUIDParam(c, "id", "identity")
+	if !ok {
 		return
 	}
 
@@ -124,10 +122,8 @@ func (h *IdentityHandler) GetIdentity(c *gin.Context) {
 // @Failure 500 {object} api.APIResponse{error=api.APIError}
 // @Router /identities/{id}/link [post]
 func (h *IdentityHandler) LinkIdentity(c *gin.Context) {
-	idStr := c.Param("id")
-	identityID, err := uuid.Parse(idStr)
-	if err != nil {
-		api.SendValidationError(c, "Invalid identity ID", err.Error())
+	identityID, ok := api.ParseUUIDParam(c, "id", "identity")
+	if !ok {
 		return
 	}
 
@@ -164,10 +160,8 @@ func (h *IdentityHandler) LinkIdentity(c *gin.Context) {
 // @Failure 500 {object} api.APIResponse{error=api.APIError}
 // @Router /identities/{id}/unlink [post]
 func (h *IdentityHandler) UnlinkIdentity(c *gin.Context) {
-	idStr := c.Param("id")
-	identityID, err := uuid.Parse(idStr)
-	if err != nil {
-		api.SendValidationError(c, "Invalid identity ID", err.Error())
+	identityID, ok := api.ParseUUIDParam(c, "id", "identity")
+	if !ok {
 		return
 	}
 
@@ -191,10 +185,8 @@ func (h *IdentityHandler) UnlinkIdentity(c *gin.Context) {
 // @Failure 500 {object} api.APIResponse{error=api.APIError}
 // @Router /identities/{id} [delete]
 func (h *IdentityHandler) DeleteIdentity(c *gin.Context) {
-	idStr := c.Param("id")
-	id, err := uuid.Parse(idStr)
-	if err != nil {
-		api.SendValidationError(c, "Invalid identity ID", err.Error())
+	id, ok := api.ParseUUIDParam(c, "id", "identity")
+	if !ok {
 		return
 	}
 
@@ -217,10 +209,8 @@ func (h *IdentityHandler) DeleteIdentity(c *gin.Context) {
 // @Failure 500 {object} api.APIResponse{error=api.APIError}
 // @Router /contacts/{id}/identities [get]
 func (h *IdentityHandler) ListIdentitiesForContact(c *gin.Context) {
-	idStr := c.Param("id")
-	contactID, err := uuid.Parse(idStr)
-	if err != nil {
-		api.SendValidationError(c, "Invalid contact ID", err.Error())
+	contactID, ok := api.ParseUUIDParam(c, "id", "contact")
+	if !ok {
 		return
 	}
 

--- a/backend/internal/api/handlers/identity.go
+++ b/backend/internal/api/handlers/identity.go
@@ -1,12 +1,10 @@
 package handlers
 
 import (
-	"errors"
 	"net/http"
 	"strconv"
 
 	"personal-crm/backend/internal/api"
-	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/service"
 
 	"github.com/gin-gonic/gin"
@@ -59,13 +57,13 @@ func (h *IdentityHandler) ListUnmatchedIdentities(c *gin.Context) {
 
 	identities, err := h.identityService.ListUnmatchedIdentities(c.Request.Context(), int32(limit), offset)
 	if err != nil {
-		api.SendInternalError(c, "Failed to list unmatched identities")
+		api.RespondInternal(c, err)
 		return
 	}
 
 	total, err := h.identityService.CountUnmatchedIdentities(c.Request.Context())
 	if err != nil {
-		api.SendInternalError(c, "Failed to count unmatched identities")
+		api.RespondInternal(c, err)
 		return
 	}
 
@@ -105,11 +103,7 @@ func (h *IdentityHandler) GetIdentity(c *gin.Context) {
 
 	identity, err := h.identityService.GetIdentity(c.Request.Context(), id)
 	if err != nil {
-		if errors.Is(err, db.ErrNotFound) {
-			api.SendNotFound(c, "Identity")
-			return
-		}
-		api.SendInternalError(c, "Failed to get identity")
+		api.RespondError(c, err, "Identity")
 		return
 	}
 
@@ -151,11 +145,7 @@ func (h *IdentityHandler) LinkIdentity(c *gin.Context) {
 
 	identity, err := h.identityService.LinkIdentity(c.Request.Context(), identityID, contactID)
 	if err != nil {
-		if errors.Is(err, db.ErrNotFound) {
-			api.SendNotFound(c, "Identity")
-			return
-		}
-		api.SendInternalError(c, "Failed to link identity")
+		api.RespondError(c, err, "Identity")
 		return
 	}
 
@@ -183,11 +173,7 @@ func (h *IdentityHandler) UnlinkIdentity(c *gin.Context) {
 
 	identity, err := h.identityService.UnlinkIdentity(c.Request.Context(), identityID)
 	if err != nil {
-		if errors.Is(err, db.ErrNotFound) {
-			api.SendNotFound(c, "Identity")
-			return
-		}
-		api.SendInternalError(c, "Failed to unlink identity")
+		api.RespondError(c, err, "Identity")
 		return
 	}
 
@@ -213,7 +199,7 @@ func (h *IdentityHandler) DeleteIdentity(c *gin.Context) {
 	}
 
 	if err := h.identityService.DeleteIdentity(c.Request.Context(), id); err != nil {
-		api.SendInternalError(c, "Failed to delete identity")
+		api.RespondInternal(c, err)
 		return
 	}
 
@@ -240,7 +226,7 @@ func (h *IdentityHandler) ListIdentitiesForContact(c *gin.Context) {
 
 	identities, err := h.identityService.ListIdentitiesForContact(c.Request.Context(), contactID)
 	if err != nil {
-		api.SendInternalError(c, "Failed to list identities for contact")
+		api.RespondInternal(c, err)
 		return
 	}
 

--- a/backend/internal/api/handlers/identity.go
+++ b/backend/internal/api/handlers/identity.go
@@ -67,18 +67,8 @@ func (h *IdentityHandler) ListUnmatchedIdentities(c *gin.Context) {
 		return
 	}
 
-	pages := int(total) / limit
-	if int(total)%limit > 0 {
-		pages++
-	}
-
 	api.SendSuccess(c, http.StatusOK, identities, &api.Meta{
-		Pagination: &api.PaginationMeta{
-			Page:  page,
-			Limit: limit,
-			Total: total,
-			Pages: pages,
-		},
+		Pagination: api.BuildPaginationMeta(page, limit, total),
 	})
 }
 

--- a/backend/internal/api/handlers/identity.go
+++ b/backend/internal/api/handlers/identity.go
@@ -22,7 +22,7 @@ type IdentityHandler struct {
 func NewIdentityHandler(identityService *service.IdentityService) *IdentityHandler {
 	return &IdentityHandler{
 		identityService: identityService,
-		validator:       validator.New(),
+		validator:       sharedValidator,
 	}
 }
 

--- a/backend/internal/api/handlers/import.go
+++ b/backend/internal/api/handlers/import.go
@@ -374,7 +374,6 @@ func (h *ImportHandler) ImportContact(c *gin.Context) {
 	// errors as 500 because a silent failure would leave the user with
 	// an imported contact whose anarlog sessions don't link to it.
 	if err := h.backfillAnarlogIdentity(ctx, external, contact.ID); err != nil {
-		logger.Error().Err(err).Str("external_id", id.String()).Msg("anarlog import backfill failed")
 		api.RespondInternal(c, err)
 		return
 	}
@@ -560,7 +559,6 @@ func (h *ImportHandler) LinkContact(c *gin.Context) {
 	// resolves the human and produces the right interaction. Surfaces
 	// errors as 500 — see ImportContact above for the rationale.
 	if err := h.backfillAnarlogIdentity(ctx, external, crmContactID); err != nil {
-		logger.Error().Err(err).Str("external_id", id.String()).Msg("anarlog import backfill failed")
 		api.RespondInternal(c, err)
 		return
 	}

--- a/backend/internal/api/handlers/import.go
+++ b/backend/internal/api/handlers/import.go
@@ -214,19 +214,9 @@ func (h *ImportHandler) ListImportCandidates(c *gin.Context) {
 
 	paginatedCandidates := candidates[offset:end]
 
-	totalPages := int(total) / limit
-	if int(total)%limit > 0 {
-		totalPages++
-	}
-
 	api.SendSuccess(c, http.StatusOK, paginatedCandidates, &api.Meta{
 		HiddenUnresolvedTelegramCount: hiddenCount,
-		Pagination: &api.PaginationMeta{
-			Page:  page,
-			Limit: limit,
-			Total: total,
-			Pages: totalPages,
-		},
+		Pagination:                    api.BuildPaginationMeta(page, limit, total),
 	})
 }
 

--- a/backend/internal/api/handlers/import.go
+++ b/backend/internal/api/handlers/import.go
@@ -185,12 +185,12 @@ func (h *ImportHandler) ListImportCandidates(c *gin.Context) {
 	// at the DB level.
 	sorted, err := h.suggestionSvc.BuildSortedCandidates(ctx, source, MaxCandidatesForSorting, includeUnresolvedTelegram)
 	if err != nil {
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to list candidates", err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 	hiddenCount, err := h.externalRepo.CountHiddenUnresolvedTelegram(ctx, source)
 	if err != nil {
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to count hidden candidates", err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 
@@ -251,7 +251,7 @@ func (h *ImportHandler) GetImportCandidate(c *gin.Context) {
 
 	contact, err := h.externalRepo.GetByID(ctx, id)
 	if err != nil {
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to get candidate", err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 	if contact == nil {
@@ -298,7 +298,7 @@ func (h *ImportHandler) ImportContact(c *gin.Context) {
 	// Get external contact
 	external, err := h.externalRepo.GetByID(ctx, id)
 	if err != nil {
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to get candidate", err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 	if external == nil {
@@ -361,7 +361,7 @@ func (h *ImportHandler) ImportContact(c *gin.Context) {
 	// Create the CRM contact
 	contact, rematchJobID, err := h.contactSvc.CreateContact(ctx, createReq, methods)
 	if err != nil {
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to create contact", err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 
@@ -387,7 +387,7 @@ func (h *ImportHandler) ImportContact(c *gin.Context) {
 	// an imported contact whose anarlog sessions don't link to it.
 	if err := h.backfillAnarlogIdentity(ctx, external, contact.ID); err != nil {
 		logger.Error().Err(err).Str("external_id", id.String()).Msg("anarlog import backfill failed")
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to link anarlog identity to imported contact", err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 
@@ -502,7 +502,7 @@ func (h *ImportHandler) LinkContact(c *gin.Context) {
 	// Get external contact
 	external, err := h.externalRepo.GetByID(ctx, id)
 	if err != nil {
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to get candidate", err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 	if external == nil {
@@ -533,7 +533,7 @@ func (h *ImportHandler) LinkContact(c *gin.Context) {
 	// Update match status
 	updated, err := h.externalRepo.UpdateMatch(ctx, id, &crmContactID, linkStatus)
 	if err != nil {
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to link contact", err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 
@@ -574,7 +574,7 @@ func (h *ImportHandler) LinkContact(c *gin.Context) {
 	// errors as 500 — see ImportContact above for the rationale.
 	if err := h.backfillAnarlogIdentity(ctx, external, crmContactID); err != nil {
 		logger.Error().Err(err).Str("external_id", id.String()).Msg("anarlog import backfill failed")
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to link anarlog identity to linked contact", err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 
@@ -647,7 +647,7 @@ func (h *ImportHandler) IgnoreContact(c *gin.Context) {
 	}
 
 	if err := h.externalRepo.Ignore(ctx, id); err != nil {
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to ignore contact", err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 

--- a/backend/internal/api/handlers/import.go
+++ b/backend/internal/api/handlers/import.go
@@ -68,7 +68,7 @@ func NewImportHandler(
 		matchSvc:      matchSvc,
 		enricher:      enricher,
 		suggestionSvc: suggestionSvc,
-		validator:     validator.New(),
+		validator:     sharedValidator,
 	}
 }
 

--- a/backend/internal/api/handlers/import.go
+++ b/backend/internal/api/handlers/import.go
@@ -243,9 +243,8 @@ func (h *ImportHandler) ListImportCandidates(c *gin.Context) {
 func (h *ImportHandler) GetImportCandidate(c *gin.Context) {
 	ctx := c.Request.Context()
 
-	id, err := uuid.Parse(c.Param("id"))
-	if err != nil {
-		api.SendError(c, http.StatusBadRequest, api.ErrCodeValidation, "Invalid ID", err.Error())
+	id, ok := api.ParseUUIDParam(c, "id", "external contact")
+	if !ok {
 		return
 	}
 
@@ -278,9 +277,8 @@ func (h *ImportHandler) GetImportCandidate(c *gin.Context) {
 func (h *ImportHandler) ImportContact(c *gin.Context) {
 	ctx := c.Request.Context()
 
-	id, err := uuid.Parse(c.Param("id"))
-	if err != nil {
-		api.SendError(c, http.StatusBadRequest, api.ErrCodeValidation, "Invalid ID", err.Error())
+	id, ok := api.ParseUUIDParam(c, "id", "external contact")
+	if !ok {
 		return
 	}
 
@@ -475,9 +473,8 @@ func (h *ImportHandler) buildMethodsFromSelection(external *repository.ExternalC
 func (h *ImportHandler) LinkContact(c *gin.Context) {
 	ctx := c.Request.Context()
 
-	id, err := uuid.Parse(c.Param("id"))
-	if err != nil {
-		api.SendError(c, http.StatusBadRequest, api.ErrCodeValidation, "Invalid ID", err.Error())
+	id, ok := api.ParseUUIDParam(c, "id", "external contact")
+	if !ok {
 		return
 	}
 
@@ -640,9 +637,8 @@ func toEnrichmentMethodSelections(selections []SelectedMethodInput) []service.Me
 func (h *ImportHandler) IgnoreContact(c *gin.Context) {
 	ctx := c.Request.Context()
 
-	id, err := uuid.Parse(c.Param("id"))
-	if err != nil {
-		api.SendError(c, http.StatusBadRequest, api.ErrCodeValidation, "Invalid ID", err.Error())
+	id, ok := api.ParseUUIDParam(c, "id", "external contact")
+	if !ok {
 		return
 	}
 

--- a/backend/internal/api/handlers/import_suggestions.go
+++ b/backend/internal/api/handlers/import_suggestions.go
@@ -114,7 +114,7 @@ func (h *SuggestionHandler) ListSuggestions(c *gin.Context) {
 		IncludeUnresolvedTelegram: includeUnresolvedTelegramParam(c),
 	}, MaxCandidatesForSorting)
 	if err != nil {
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to list suggestions", err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 
@@ -272,7 +272,7 @@ func (h *SuggestionHandler) sendActionError(c *gin.Context, err error) {
 	case errors.Is(err, service.ErrSuggestionInvalidMethod):
 		api.SendError(c, http.StatusBadRequest, api.ErrCodeValidation, "Malformed method (empty type or value)", "")
 	default:
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to process suggestion", err.Error())
+		api.RespondInternal(c, err)
 	}
 }
 

--- a/backend/internal/api/handlers/import_suggestions.go
+++ b/backend/internal/api/handlers/import_suggestions.go
@@ -136,14 +136,11 @@ func (h *SuggestionHandler) ListSuggestions(c *gin.Context) {
 		})
 	}
 
+	// list.Pages is the service's ceil(CandidateTotal/Limit); BuildPaginationMeta
+	// reproduces that exact formula, so meta.pagination is unchanged.
 	api.SendSuccess(c, http.StatusOK, items, &api.Meta{
 		HiddenUnresolvedTelegramCount: list.HiddenUnresolvedTelegramCount,
-		Pagination: &api.PaginationMeta{
-			Page:  list.Page,
-			Limit: list.Limit,
-			Total: int64(list.CandidateTotal),
-			Pages: list.Pages,
-		},
+		Pagination:                    api.BuildPaginationMeta(list.Page, list.Limit, int64(list.CandidateTotal)),
 	})
 }
 

--- a/backend/internal/api/handlers/import_suggestions.go
+++ b/backend/internal/api/handlers/import_suggestions.go
@@ -12,7 +12,6 @@ import (
 	"personal-crm/backend/internal/service"
 
 	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
 )
 
 // bindOptionalJSON binds a JSON body that may legitimately be empty. An
@@ -196,9 +195,8 @@ type DismissMethodSuggestionsResponse struct {
 func (h *SuggestionHandler) ResolveMethodSuggestions(c *gin.Context) {
 	ctx := c.Request.Context()
 
-	id, err := uuid.Parse(c.Param("id"))
-	if err != nil {
-		api.SendError(c, http.StatusBadRequest, api.ErrCodeValidation, "Invalid ID", err.Error())
+	id, ok := api.ParseUUIDParam(c, "id", "external contact")
+	if !ok {
 		return
 	}
 
@@ -235,9 +233,8 @@ func (h *SuggestionHandler) ResolveMethodSuggestions(c *gin.Context) {
 func (h *SuggestionHandler) DismissMethodSuggestions(c *gin.Context) {
 	ctx := c.Request.Context()
 
-	id, err := uuid.Parse(c.Param("id"))
-	if err != nil {
-		api.SendError(c, http.StatusBadRequest, api.ErrCodeValidation, "Invalid ID", err.Error())
+	id, ok := api.ParseUUIDParam(c, "id", "external contact")
+	if !ok {
 		return
 	}
 

--- a/backend/internal/api/handlers/ingest.go
+++ b/backend/internal/api/handlers/ingest.go
@@ -255,12 +255,15 @@ func (h *IngestHandler) IngestEvents(c *gin.Context) {
 				"host revoked during ingest batch", "")
 			return
 		}
+		// Keep the structured diagnostic log: batch_size/validated_batch_size are
+		// not recoverable from the request path. RespondInternal adds the request_id
+		// log + c.Error revival on top.
 		logger.Error().
 			Err(err).
 			Int("batch_size", len(req.Events)).
 			Int("validated_batch_size", len(envsToIngest)).
 			Msg("event batch ingest failed (tx rolled back)")
-		api.SendInternalError(c, "Failed to ingest events")
+		api.RespondInternal(c, err)
 		return
 	}
 

--- a/backend/internal/api/handlers/interaction.go
+++ b/backend/internal/api/handlers/interaction.go
@@ -1,14 +1,12 @@
 package handlers
 
 import (
-	"errors"
 	"net/http"
 	"strconv"
 	"time"
 
 	"personal-crm/backend/internal/accelerated"
 	"personal-crm/backend/internal/api"
-	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/service"
 
@@ -100,13 +98,13 @@ func (h *InteractionHandler) ListContactInteractions(c *gin.Context) {
 
 	interactions, err := h.interactionRepo.ListContactInteractions(c.Request.Context(), contactID, int32(limit), int32(offset))
 	if err != nil {
-		api.SendInternalError(c, "Failed to list interactions")
+		api.RespondInternal(c, err)
 		return
 	}
 
 	total, err := h.interactionRepo.CountContactInteractions(c.Request.Context(), contactID)
 	if err != nil {
-		api.SendInternalError(c, "Failed to count interactions")
+		api.RespondInternal(c, err)
 		return
 	}
 
@@ -202,11 +200,7 @@ func (h *InteractionHandler) CreateInteraction(c *gin.Context) {
 
 	interaction, err := h.manualHandler.Run(c.Request.Context(), contactID, direction, occurredAt, description)
 	if err != nil {
-		if errors.Is(err, db.ErrNotFound) {
-			api.SendNotFound(c, "Contact")
-			return
-		}
-		api.SendInternalError(c, "Failed to create interaction")
+		api.RespondError(c, err, "Contact")
 		return
 	}
 
@@ -230,16 +224,12 @@ func (h *InteractionHandler) DeleteInteraction(c *gin.Context) {
 	// Verify interaction exists
 	_, err = h.interactionRepo.GetInteraction(c.Request.Context(), id)
 	if err != nil {
-		if errors.Is(err, db.ErrNotFound) {
-			api.SendNotFound(c, "Interaction")
-			return
-		}
-		api.SendInternalError(c, "Failed to retrieve interaction")
+		api.RespondError(c, err, "Interaction")
 		return
 	}
 
 	if err := h.interactionRepo.SoftDeleteInteraction(c.Request.Context(), id); err != nil {
-		api.SendInternalError(c, "Failed to delete interaction")
+		api.RespondInternal(c, err)
 		return
 	}
 

--- a/backend/internal/api/handlers/interaction.go
+++ b/backend/internal/api/handlers/interaction.go
@@ -110,18 +110,8 @@ func (h *InteractionHandler) ListContactInteractions(c *gin.Context) {
 		responses[i] = interactionToResponse(&interaction)
 	}
 
-	totalPages := int(total) / limit
-	if int(total)%limit > 0 {
-		totalPages++
-	}
-
 	meta := &api.Meta{
-		Pagination: &api.PaginationMeta{
-			Page:  page,
-			Limit: limit,
-			Total: total,
-			Pages: totalPages,
-		},
+		Pagination: api.BuildPaginationMeta(page, limit, total),
 	}
 
 	api.SendSuccess(c, http.StatusOK, responses, meta)

--- a/backend/internal/api/handlers/interaction.go
+++ b/backend/internal/api/handlers/interaction.go
@@ -11,7 +11,6 @@ import (
 	"personal-crm/backend/internal/service"
 
 	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
 )
 
 // InteractionHandler handles interaction-related HTTP requests.
@@ -79,10 +78,8 @@ func interactionToResponse(i *repository.Interaction) InteractionResponse {
 // @Success 200 {object} api.APIResponse{data=[]InteractionResponse}
 // @Router /contacts/{id}/interactions [get]
 func (h *InteractionHandler) ListContactInteractions(c *gin.Context) {
-	idStr := c.Param("id")
-	contactID, err := uuid.Parse(idStr)
-	if err != nil {
-		api.SendValidationError(c, "Invalid contact ID", "ID must be a valid UUID")
+	contactID, ok := api.ParseUUIDParam(c, "id", "contact")
+	if !ok {
 		return
 	}
 
@@ -140,10 +137,8 @@ func (h *InteractionHandler) ListContactInteractions(c *gin.Context) {
 // @Success 201 {object} api.APIResponse{data=InteractionResponse}
 // @Router /contacts/{id}/interactions [post]
 func (h *InteractionHandler) CreateInteraction(c *gin.Context) {
-	idStr := c.Param("id")
-	contactID, err := uuid.Parse(idStr)
-	if err != nil {
-		api.SendValidationError(c, "Invalid contact ID", "ID must be a valid UUID")
+	contactID, ok := api.ParseUUIDParam(c, "id", "contact")
+	if !ok {
 		return
 	}
 
@@ -214,15 +209,13 @@ func (h *InteractionHandler) CreateInteraction(c *gin.Context) {
 // @Success 204 "Interaction deleted"
 // @Router /interactions/{id} [delete]
 func (h *InteractionHandler) DeleteInteraction(c *gin.Context) {
-	idStr := c.Param("id")
-	id, err := uuid.Parse(idStr)
-	if err != nil {
-		api.SendValidationError(c, "Invalid interaction ID", "ID must be a valid UUID")
+	id, ok := api.ParseUUIDParam(c, "id", "interaction")
+	if !ok {
 		return
 	}
 
 	// Verify interaction exists
-	_, err = h.interactionRepo.GetInteraction(c.Request.Context(), id)
+	_, err := h.interactionRepo.GetInteraction(c.Request.Context(), id)
 	if err != nil {
 		api.RespondError(c, err, "Interaction")
 		return

--- a/backend/internal/api/handlers/mac_host.go
+++ b/backend/internal/api/handlers/mac_host.go
@@ -182,8 +182,7 @@ func (h *MacHostHandler) Pair(c *gin.Context) {
 			api.SendValidationError(c, err.Error(), "")
 			return
 		}
-		logger.Error().Err(err).Msg("pair handler: unexpected error")
-		api.SendInternalError(c, "pairing failed")
+		api.RespondInternal(c, err)
 		return
 	}
 	api.SendSuccess(c, http.StatusOK, pairResponse{
@@ -217,7 +216,7 @@ type heartbeatResponse struct {
 func (h *MacHostHandler) Heartbeat(c *gin.Context) {
 	hostID, ok := auth.MacHostIDFromContext(c)
 	if !ok {
-		api.SendInternalError(c, "missing mac_host context")
+		api.RespondInternal(c, errors.New("missing mac_host context"))
 		return
 	}
 	var req heartbeatRequest
@@ -251,8 +250,7 @@ func (h *MacHostHandler) Heartbeat(c *gin.Context) {
 			api.SendError(c, http.StatusUnauthorized, "UNKNOWN_HOST", "host not found or revoked", "")
 			return
 		}
-		logger.Error().Err(err).Msg("heartbeat: update failed")
-		api.SendInternalError(c, "heartbeat failed")
+		api.RespondInternal(c, err)
 		return
 	}
 	api.SendSuccess(c, http.StatusOK, heartbeatResponse{
@@ -290,7 +288,7 @@ type rotateKeyResponse struct {
 func (h *MacHostHandler) RotateKey(c *gin.Context) {
 	host, ok := auth.MacHostFromContext(c)
 	if !ok {
-		api.SendInternalError(c, "missing mac_host context")
+		api.RespondInternal(c, errors.New("missing mac_host context"))
 		return
 	}
 
@@ -332,8 +330,7 @@ func (h *MacHostHandler) RotateKey(c *gin.Context) {
 			api.SendNotFound(c, "Mac host")
 			return
 		}
-		logger.Error().Err(err).Msg("rotate key handler: unexpected error")
-		api.SendInternalError(c, "rotate key failed")
+		api.RespondInternal(c, err)
 		return
 	}
 	api.SendSuccess(c, http.StatusOK, rotateKeyResponse{
@@ -356,7 +353,7 @@ type cursorResponse struct {
 func (h *MacHostHandler) GetCursor(c *gin.Context) {
 	host, ok := auth.MacHostFromContext(c)
 	if !ok {
-		api.SendInternalError(c, "missing mac_host context")
+		api.RespondInternal(c, errors.New("missing mac_host context"))
 		return
 	}
 	source := c.Param("source")
@@ -370,8 +367,7 @@ func (h *MacHostHandler) GetCursor(c *gin.Context) {
 	}
 	cur, err := h.svc.GetCursor(c.Request.Context(), source, host.ID)
 	if err != nil && !errors.Is(err, db.ErrNotFound) {
-		logger.Error().Err(err).Msg("get cursor: failed")
-		api.SendInternalError(c, "get cursor failed")
+		api.RespondInternal(c, err)
 		return
 	}
 	resp := cursorResponse{
@@ -407,7 +403,7 @@ type commitCursorConflict struct {
 func (h *MacHostHandler) CommitCursor(c *gin.Context) {
 	host, ok := auth.MacHostFromContext(c)
 	if !ok {
-		api.SendInternalError(c, "missing mac_host context")
+		api.RespondInternal(c, errors.New("missing mac_host context"))
 		return
 	}
 	source := c.Param("source")
@@ -475,8 +471,7 @@ func (h *MacHostHandler) CommitCursor(c *gin.Context) {
 		return
 	}
 
-	logger.Error().Err(err).Msg("commit cursor: unexpected error")
-	api.SendInternalError(c, "commit cursor failed")
+	api.RespondInternal(c, err)
 }
 
 // KnownIDs returns the per-(host, source) set of live
@@ -494,7 +489,7 @@ func (h *MacHostHandler) CommitCursor(c *gin.Context) {
 func (h *MacHostHandler) KnownIDs(c *gin.Context) {
 	host, ok := auth.MacHostFromContext(c)
 	if !ok {
-		api.SendInternalError(c, "missing mac_host context")
+		api.RespondInternal(c, errors.New("missing mac_host context"))
 		return
 	}
 	source := c.Param("source")
@@ -508,8 +503,7 @@ func (h *MacHostHandler) KnownIDs(c *gin.Context) {
 	}
 	ids, err := h.svc.KnownIDsForSource(c.Request.Context(), host.ID, source)
 	if err != nil {
-		logger.Error().Err(err).Msg("known IDs: failed")
-		api.SendInternalError(c, "known IDs failed")
+		api.RespondInternal(c, err)
 		return
 	}
 	// Always emit a non-nil slice so the JSON encodes as `[]`, not `null`.
@@ -535,8 +529,7 @@ func (h *MacHostHandler) KnownIDs(c *gin.Context) {
 func (h *MacHostHandler) KnownIdentifiers(c *gin.Context) {
 	result, err := h.svc.KnownIdentifiers(c.Request.Context())
 	if err != nil {
-		logger.Error().Err(err).Msg("known-identifiers: failed")
-		api.SendInternalError(c, "known identifiers failed")
+		api.RespondInternal(c, err)
 		return
 	}
 	api.SendSuccess(c, http.StatusOK, result, nil)
@@ -546,8 +539,7 @@ func (h *MacHostHandler) KnownIdentifiers(c *gin.Context) {
 func (h *MacHostHandler) ListHosts(c *gin.Context) {
 	hosts, err := h.svc.ListActiveHosts(c.Request.Context())
 	if err != nil {
-		logger.Error().Err(err).Msg("list mac hosts: failed")
-		api.SendInternalError(c, "list hosts failed")
+		api.RespondInternal(c, err)
 		return
 	}
 	views := make([]MacHostView, 0, len(hosts))
@@ -566,12 +558,7 @@ func (h *MacHostHandler) GetHostAdmin(c *gin.Context) {
 	}
 	host, err := h.svc.GetHost(c.Request.Context(), id)
 	if err != nil {
-		if errors.Is(err, db.ErrNotFound) {
-			api.SendNotFound(c, "Mac host")
-			return
-		}
-		logger.Error().Err(err).Msg("get mac host: failed")
-		api.SendInternalError(c, "get host failed")
+		api.RespondError(c, err, "Mac host")
 		return
 	}
 	api.SendSuccess(c, http.StatusOK, toMacHostView(host), nil)
@@ -596,12 +583,7 @@ func (h *MacHostHandler) GetSourceCounts(c *gin.Context) {
 	}
 	counts, err := h.svc.GetSourceCounts(c.Request.Context(), id)
 	if err != nil {
-		if errors.Is(err, db.ErrNotFound) {
-			api.SendNotFound(c, "Mac host")
-			return
-		}
-		logger.Error().Err(err).Msg("get source counts: failed")
-		api.SendInternalError(c, "get source counts failed")
+		api.RespondError(c, err, "Mac host")
 		return
 	}
 	api.SendSuccess(c, http.StatusOK, sourceCountsResponse{Counts: counts}, nil)
@@ -617,12 +599,7 @@ func (h *MacHostHandler) DeleteHost(c *gin.Context) {
 		return
 	}
 	if err := h.svc.RevokeHost(c.Request.Context(), id); err != nil {
-		if errors.Is(err, db.ErrNotFound) {
-			api.SendNotFound(c, "Mac host")
-			return
-		}
-		logger.Error().Err(err).Msg("revoke mac host: failed")
-		api.SendInternalError(c, "revoke host failed")
+		api.RespondError(c, err, "Mac host")
 		return
 	}
 	api.SendSuccess(c, http.StatusOK, gin.H{"ok": true}, nil)
@@ -641,8 +618,7 @@ type createPairingTokenResponse struct {
 func (h *MacHostHandler) CreatePairingToken(c *gin.Context) {
 	token, expiresAt, err := h.svc.CreatePairingToken(c.Request.Context())
 	if err != nil {
-		logger.Error().Err(err).Msg("create pairing token: failed")
-		api.SendInternalError(c, "create pairing token failed")
+		api.RespondInternal(c, err)
 		return
 	}
 	api.SendSuccess(c, http.StatusOK, createPairingTokenResponse{

--- a/backend/internal/api/handlers/mac_host.go
+++ b/backend/internal/api/handlers/mac_host.go
@@ -551,9 +551,8 @@ func (h *MacHostHandler) ListHosts(c *gin.Context) {
 
 // GetHostAdmin returns a single host (admin view) including revoked.
 func (h *MacHostHandler) GetHostAdmin(c *gin.Context) {
-	id, err := uuid.Parse(c.Param("id"))
-	if err != nil {
-		api.SendValidationError(c, "invalid id", err.Error())
+	id, ok := api.ParseUUIDParam(c, "id", "Mac host")
+	if !ok {
 		return
 	}
 	host, err := h.svc.GetHost(c.Request.Context(), id)
@@ -576,9 +575,8 @@ type sourceCountsResponse struct {
 // the host. Admin endpoint (global API key); powers the Hosts page's
 // "Cursor" column substitute for icloud_contacts (issue #327).
 func (h *MacHostHandler) GetSourceCounts(c *gin.Context) {
-	id, err := uuid.Parse(c.Param("id"))
-	if err != nil {
-		api.SendValidationError(c, "invalid id", err.Error())
+	id, ok := api.ParseUUIDParam(c, "id", "Mac host")
+	if !ok {
 		return
 	}
 	counts, err := h.svc.GetSourceCounts(c.Request.Context(), id)
@@ -593,9 +591,8 @@ func (h *MacHostHandler) GetSourceCounts(c *gin.Context) {
 // cascades by deleting push-strategy external_sync_state rows. 404 if
 // the host is missing or already revoked.
 func (h *MacHostHandler) DeleteHost(c *gin.Context) {
-	id, err := uuid.Parse(c.Param("id"))
-	if err != nil {
-		api.SendValidationError(c, "invalid id", err.Error())
+	id, ok := api.ParseUUIDParam(c, "id", "Mac host")
+	if !ok {
 		return
 	}
 	if err := h.svc.RevokeHost(c.Request.Context(), id); err != nil {

--- a/backend/internal/api/handlers/meeting_note.go
+++ b/backend/internal/api/handlers/meeting_note.go
@@ -77,9 +77,8 @@ const (
 
 // ResolveLink implements POST /api/v1/meeting-notes/:id/resolve-link.
 func (h *MeetingNoteHandler) ResolveLink(c *gin.Context) {
-	mnID, err := uuid.Parse(c.Param("id"))
-	if err != nil {
-		api.SendValidationError(c, "Invalid meeting_note id", "id must be a valid UUID")
+	mnID, ok := api.ParseUUIDParam(c, "id", "meeting_note")
+	if !ok {
 		return
 	}
 

--- a/backend/internal/api/handlers/meeting_note.go
+++ b/backend/internal/api/handlers/meeting_note.go
@@ -55,7 +55,7 @@ type MeetingNoteHandler struct {
 func NewMeetingNoteHandler(svc *service.MeetingNoteService) *MeetingNoteHandler {
 	return &MeetingNoteHandler{
 		svc:       svc,
-		validator: validator.New(),
+		validator: sharedValidator,
 	}
 }
 

--- a/backend/internal/api/handlers/meeting_note.go
+++ b/backend/internal/api/handlers/meeting_note.go
@@ -155,7 +155,7 @@ func (h *MeetingNoteHandler) mapResolveError(c *gin.Context, err error) {
 		api.SendError(c, http.StatusUnprocessableEntity, api.ErrCodeValidation,
 			"conflict_candidates snapshot missing on conflict_pending row; please re-trigger sync", "")
 	default:
-		api.SendInternalError(c, err.Error())
+		api.RespondInternal(c, err)
 	}
 }
 
@@ -181,7 +181,7 @@ func (h *MeetingNoteHandler) ListNeedsAttention(c *gin.Context) {
 
 	items, err := h.svc.ListNeedsAttention(c.Request.Context(), hostID)
 	if err != nil {
-		api.SendInternalError(c, err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 	api.SendSuccess(c, http.StatusOK, items, nil)

--- a/backend/internal/api/handlers/meeting_note_test.go
+++ b/backend/internal/api/handlers/meeting_note_test.go
@@ -62,7 +62,7 @@ func TestResolveLink_PathParamInvalidUUID(t *testing.T) {
 	w := post(t, router, "/api/v1/meeting-notes/not-a-uuid/resolve-link",
 		map[string]interface{}{"action": "none_of_these"})
 	require.Equal(t, http.StatusBadRequest, w.Code)
-	require.Contains(t, w.Body.String(), "Invalid meeting_note id")
+	require.Contains(t, w.Body.String(), "Invalid meeting_note ID")
 }
 
 // TestResolveLink_EmptyBody — handler returns 400 when the body is

--- a/backend/internal/api/handlers/meeting_note_test.go
+++ b/backend/internal/api/handlers/meeting_note_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -175,6 +176,39 @@ func TestListNeedsAttention_InvalidHostID(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/meeting-notes/needs-attention?host_id=not-uuid", nil)
 	router.ServeHTTP(w, req)
 	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// TestMapResolveError_DomainNotFound — a domain not-found sentinel still
+// maps to 404 after the default arm was routed through RespondInternal.
+func TestMapResolveError_DomainNotFound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := NewMeetingNoteHandler(nil) // mapResolveError does not touch svc
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	h.mapResolveError(c, service.ErrResolveLinkRowNotFound)
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+	require.Contains(t, w.Body.String(), "Meeting note not found")
+	// A not-found is expected, not a server fault: c.Errors stays empty.
+	require.Empty(t, c.Errors)
+}
+
+// TestMapResolveError_GenericNoLeak — an unmapped error hits the default
+// arm: it must 500 with a generic body (no err.Error() leak) and append
+// the cause to c.Errors so the access log carries it.
+func TestMapResolveError_GenericNoLeak(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := NewMeetingNoteHandler(nil)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	h.mapResolveError(c, errors.New("secret internal detail"))
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	require.NotContains(t, w.Body.String(), "secret internal detail")
+	require.Contains(t, w.Body.String(), `"success":false`)
+	require.Len(t, c.Errors, 1)
 }
 
 // Ensure stubMeetingNoteService stays a placeholder — used only to

--- a/backend/internal/api/handlers/note.go
+++ b/backend/internal/api/handlers/note.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/go-playground/validator/v10"
-	"github.com/google/uuid"
 )
 
 // NoteHandler handles note-related HTTP requests
@@ -67,10 +66,8 @@ func noteToResponse(note *repository.Note) NoteResponse {
 // @Failure 500 {object} api.APIResponse{error=api.APIError} "Internal server error"
 // @Router /contacts/{id}/notes [get]
 func (h *NoteHandler) GetContactNotepad(c *gin.Context) {
-	idStr := c.Param("id")
-	contactID, err := uuid.Parse(idStr)
-	if err != nil {
-		api.SendValidationError(c, "Invalid contact ID", "ID must be a valid UUID")
+	contactID, ok := api.ParseUUIDParam(c, "id", "contact")
+	if !ok {
 		return
 	}
 
@@ -104,10 +101,8 @@ func (h *NoteHandler) GetContactNotepad(c *gin.Context) {
 // @Failure 500 {object} api.APIResponse{error=api.APIError} "Internal server error"
 // @Router /contacts/{id}/notes [put]
 func (h *NoteHandler) SaveContactNotepad(c *gin.Context) {
-	idStr := c.Param("id")
-	contactID, err := uuid.Parse(idStr)
-	if err != nil {
-		api.SendValidationError(c, "Invalid contact ID", "ID must be a valid UUID")
+	contactID, ok := api.ParseUUIDParam(c, "id", "contact")
+	if !ok {
 		return
 	}
 

--- a/backend/internal/api/handlers/note.go
+++ b/backend/internal/api/handlers/note.go
@@ -22,7 +22,7 @@ type NoteHandler struct {
 func NewNoteHandler(noteService *service.NoteService) *NoteHandler {
 	return &NoteHandler{
 		noteService: noteService,
-		validator:   validator.New(),
+		validator:   sharedValidator,
 	}
 }
 

--- a/backend/internal/api/handlers/note.go
+++ b/backend/internal/api/handlers/note.go
@@ -1,12 +1,10 @@
 package handlers
 
 import (
-	"errors"
 	"net/http"
 	"time"
 
 	"personal-crm/backend/internal/api"
-	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/service"
 
@@ -78,11 +76,7 @@ func (h *NoteHandler) GetContactNotepad(c *gin.Context) {
 
 	note, err := h.noteService.GetContactNotepad(c.Request.Context(), contactID)
 	if err != nil {
-		if errors.Is(err, db.ErrNotFound) {
-			api.SendNotFound(c, "Contact")
-			return
-		}
-		api.SendInternalError(c, "Failed to retrieve note")
+		api.RespondError(c, err, "Contact")
 		return
 	}
 
@@ -130,11 +124,7 @@ func (h *NoteHandler) SaveContactNotepad(c *gin.Context) {
 
 	note, err := h.noteService.SaveContactNotepad(c.Request.Context(), contactID, req.Body)
 	if err != nil {
-		if errors.Is(err, db.ErrNotFound) {
-			api.SendNotFound(c, "Contact")
-			return
-		}
-		api.SendInternalError(c, "Failed to save note")
+		api.RespondError(c, err, "Contact")
 		return
 	}
 

--- a/backend/internal/api/handlers/oauth.go
+++ b/backend/internal/api/handlers/oauth.go
@@ -14,7 +14,6 @@ import (
 	"personal-crm/backend/internal/todoist"
 
 	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
 )
 
 // OAuthHandler handles OAuth-related HTTP requests
@@ -283,10 +282,8 @@ func (h *OAuthHandler) ListGoogleAccounts(c *gin.Context) {
 // @Failure 500 {object} api.APIResponse{error=api.APIError}
 // @Router /auth/google/accounts/{id}/status [get]
 func (h *OAuthHandler) GetGoogleAccountStatus(c *gin.Context) {
-	idStr := c.Param("id")
-	id, err := uuid.Parse(idStr)
-	if err != nil {
-		api.SendError(c, http.StatusBadRequest, api.ErrCodeValidation, "Invalid account ID", err.Error())
+	id, ok := api.ParseUUIDParam(c, "id", "account")
+	if !ok {
 		return
 	}
 
@@ -324,14 +321,12 @@ func (h *OAuthHandler) GetGoogleAccountStatus(c *gin.Context) {
 // @Failure 500 {object} api.APIResponse{error=api.APIError}
 // @Router /auth/google/accounts/{id}/revoke [post]
 func (h *OAuthHandler) RevokeGoogleAccount(c *gin.Context) {
-	idStr := c.Param("id")
-	id, err := uuid.Parse(idStr)
-	if err != nil {
-		api.SendError(c, http.StatusBadRequest, api.ErrCodeValidation, "Invalid account ID", err.Error())
+	id, ok := api.ParseUUIDParam(c, "id", "account")
+	if !ok {
 		return
 	}
 
-	err = h.googleOAuth.RevokeAccount(c.Request.Context(), id)
+	err := h.googleOAuth.RevokeAccount(c.Request.Context(), id)
 	if err != nil {
 		api.RespondError(c, err, "Account")
 		return
@@ -484,10 +479,8 @@ func (h *OAuthHandler) ListTodoistAccounts(c *gin.Context) {
 // @Failure 500 {object} api.APIResponse{error=api.APIError}
 // @Router /auth/todoist/accounts/{id}/status [get]
 func (h *OAuthHandler) GetTodoistAccountStatus(c *gin.Context) {
-	idStr := c.Param("id")
-	id, err := uuid.Parse(idStr)
-	if err != nil {
-		api.SendError(c, http.StatusBadRequest, api.ErrCodeValidation, "Invalid account ID", err.Error())
+	id, ok := api.ParseUUIDParam(c, "id", "account")
+	if !ok {
 		return
 	}
 
@@ -525,14 +518,12 @@ func (h *OAuthHandler) GetTodoistAccountStatus(c *gin.Context) {
 // @Failure 500 {object} api.APIResponse{error=api.APIError}
 // @Router /auth/todoist/accounts/{id}/revoke [post]
 func (h *OAuthHandler) RevokeTodoistAccount(c *gin.Context) {
-	idStr := c.Param("id")
-	id, err := uuid.Parse(idStr)
-	if err != nil {
-		api.SendError(c, http.StatusBadRequest, api.ErrCodeValidation, "Invalid account ID", err.Error())
+	id, ok := api.ParseUUIDParam(c, "id", "account")
+	if !ok {
 		return
 	}
 
-	err = h.todoistOAuth.RevokeAccount(c.Request.Context(), id)
+	err := h.todoistOAuth.RevokeAccount(c.Request.Context(), id)
 	if err != nil {
 		api.RespondError(c, err, "Account")
 		return

--- a/backend/internal/api/handlers/oauth.go
+++ b/backend/internal/api/handlers/oauth.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"net/url"
 	"sync"
@@ -10,7 +9,6 @@ import (
 
 	"personal-crm/backend/internal/accelerated"
 	"personal-crm/backend/internal/api"
-	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/google"
 	"personal-crm/backend/internal/logger"
 	"personal-crm/backend/internal/todoist"
@@ -150,7 +148,7 @@ type GoogleAccountResponse struct {
 func (h *OAuthHandler) GetGoogleAuthURL(c *gin.Context) {
 	state, err := google.GenerateState()
 	if err != nil {
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to generate state", err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 
@@ -250,7 +248,7 @@ func (h *OAuthHandler) GoogleCallback(c *gin.Context) {
 func (h *OAuthHandler) ListGoogleAccounts(c *gin.Context) {
 	accounts, err := h.googleOAuth.ListAccounts(c.Request.Context())
 	if err != nil {
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to list accounts", err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 
@@ -294,11 +292,7 @@ func (h *OAuthHandler) GetGoogleAccountStatus(c *gin.Context) {
 
 	status, err := h.googleOAuth.GetAccountStatus(c.Request.Context(), id)
 	if err != nil {
-		if errors.Is(err, db.ErrNotFound) {
-			api.SendError(c, http.StatusNotFound, api.ErrCodeNotFound, "Account not found", "")
-			return
-		}
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to get account status", err.Error())
+		api.RespondError(c, err, "Account")
 		return
 	}
 
@@ -339,11 +333,7 @@ func (h *OAuthHandler) RevokeGoogleAccount(c *gin.Context) {
 
 	err = h.googleOAuth.RevokeAccount(c.Request.Context(), id)
 	if err != nil {
-		if errors.Is(err, db.ErrNotFound) {
-			api.SendError(c, http.StatusNotFound, api.ErrCodeNotFound, "Account not found", "")
-			return
-		}
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to revoke account", err.Error())
+		api.RespondError(c, err, "Account")
 		return
 	}
 
@@ -380,7 +370,7 @@ type TodoistAccountResponse struct {
 func (h *OAuthHandler) GetTodoistAuthURL(c *gin.Context) {
 	state, err := google.GenerateState() // Reuse state generation from google package
 	if err != nil {
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to generate state", err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 
@@ -459,7 +449,7 @@ func (h *OAuthHandler) TodoistCallback(c *gin.Context) {
 func (h *OAuthHandler) ListTodoistAccounts(c *gin.Context) {
 	accounts, err := h.todoistOAuth.ListAccounts(c.Request.Context())
 	if err != nil {
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to list accounts", err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 
@@ -503,11 +493,7 @@ func (h *OAuthHandler) GetTodoistAccountStatus(c *gin.Context) {
 
 	status, err := h.todoistOAuth.GetAccountStatus(c.Request.Context(), id)
 	if err != nil {
-		if errors.Is(err, db.ErrNotFound) {
-			api.SendError(c, http.StatusNotFound, api.ErrCodeNotFound, "Account not found", "")
-			return
-		}
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to get account status", err.Error())
+		api.RespondError(c, err, "Account")
 		return
 	}
 
@@ -548,11 +534,7 @@ func (h *OAuthHandler) RevokeTodoistAccount(c *gin.Context) {
 
 	err = h.todoistOAuth.RevokeAccount(c.Request.Context(), id)
 	if err != nil {
-		if errors.Is(err, db.ErrNotFound) {
-			api.SendError(c, http.StatusNotFound, api.ErrCodeNotFound, "Account not found", "")
-			return
-		}
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to revoke account", err.Error())
+		api.RespondError(c, err, "Account")
 		return
 	}
 

--- a/backend/internal/api/handlers/rematch.go
+++ b/backend/internal/api/handlers/rematch.go
@@ -9,7 +9,6 @@ import (
 	"personal-crm/backend/internal/service"
 
 	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
 )
 
 // RematchHandler exposes HTTP endpoints for inspecting and triggering rematch
@@ -61,9 +60,8 @@ type RescanResponse struct {
 // @Failure 404 {object} api.APIResponse{error=api.APIError}
 // @Router /rematch/jobs/{jobID} [get]
 func (h *RematchHandler) GetJob(c *gin.Context) {
-	id, err := uuid.Parse(c.Param("jobID"))
-	if err != nil {
-		api.SendValidationError(c, "Invalid job ID", "ID must be a valid UUID")
+	id, ok := api.ParseUUIDParam(c, "jobID", "job")
+	if !ok {
 		return
 	}
 
@@ -93,9 +91,8 @@ func (h *RematchHandler) GetJob(c *gin.Context) {
 func (h *RematchHandler) Rescan(c *gin.Context) {
 	ctx := c.Request.Context()
 
-	id, err := uuid.Parse(c.Param("id"))
-	if err != nil {
-		api.SendValidationError(c, "Invalid contact ID", "ID must be a valid UUID")
+	id, ok := api.ParseUUIDParam(c, "id", "contact")
+	if !ok {
 		return
 	}
 

--- a/backend/internal/api/handlers/rematch.go
+++ b/backend/internal/api/handlers/rematch.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"personal-crm/backend/internal/api"
-	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/service"
 
 	"github.com/gin-gonic/gin"
@@ -74,7 +73,7 @@ func (h *RematchHandler) GetJob(c *gin.Context) {
 			api.SendNotFound(c, "Rematch job")
 			return
 		}
-		api.SendInternalError(c, "Failed to load rematch job")
+		api.RespondInternal(c, err)
 		return
 	}
 
@@ -102,11 +101,7 @@ func (h *RematchHandler) Rescan(c *gin.Context) {
 
 	jobID, err := h.contactSvc.RescanRematch(ctx, id)
 	if err != nil {
-		if errors.Is(err, db.ErrNotFound) {
-			api.SendNotFound(c, "Contact")
-			return
-		}
-		api.SendInternalError(c, "Failed to start rematch")
+		api.RespondError(c, err, "Contact")
 		return
 	}
 	api.SendSuccess(c, http.StatusOK, RescanResponse{

--- a/backend/internal/api/handlers/staleness.go
+++ b/backend/internal/api/handlers/staleness.go
@@ -37,7 +37,7 @@ func NewStalenessHandler(reader StalenessReader) *StalenessHandler {
 func (h *StalenessHandler) GetActiveBreaches(c *gin.Context) {
 	breaches, err := h.reader.ListActiveBreaches(c.Request.Context())
 	if err != nil {
-		api.SendInternalError(c, err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 	api.SendSuccess(c, http.StatusOK, breaches, nil)

--- a/backend/internal/api/handlers/staleness_test.go
+++ b/backend/internal/api/handlers/staleness_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -10,6 +11,8 @@ import (
 	"time"
 
 	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/api"
+	"personal-crm/backend/internal/logger"
 	"personal-crm/backend/internal/repository"
 
 	"github.com/gin-gonic/gin"
@@ -82,7 +85,7 @@ func TestStalenessHandler_GetActiveBreaches_EmptyIsArrayNotNull(t *testing.T) {
 }
 
 func TestStalenessHandler_GetActiveBreaches_ErrorReturns500(t *testing.T) {
-	reader := &fakeStalenessReader{err: errors.New("db down")}
+	reader := &fakeStalenessReader{err: errors.New("db down secret detail")}
 	r := newStalenessTestRouter(reader)
 
 	w := httptest.NewRecorder()
@@ -91,4 +94,34 @@ func TestStalenessHandler_GetActiveBreaches_ErrorReturns500(t *testing.T) {
 
 	require.Equal(t, http.StatusInternalServerError, w.Code)
 	assert.Contains(t, w.Body.String(), `"success":false`)
+	// The raw cause must not leak into the 500 body.
+	assert.NotContains(t, w.Body.String(), "db down secret detail")
+	assert.NotContains(t, w.Body.String(), `"details"`)
+}
+
+// TestStalenessHandler_GetActiveBreaches_LogsCauseThroughMiddleware proves the
+// end-to-end acceptance criterion: a 500 logs its cause with request_id, and the
+// revived c.Error revives the LoggingMiddleware access-log error branch. It is SERIAL
+// (no t.Parallel) because it mutates the process-global logger via logger.SetOutput.
+func TestStalenessHandler_GetActiveBreaches_LogsCauseThroughMiddleware(t *testing.T) {
+	var buf bytes.Buffer
+	restore := logger.SetOutput(&buf)
+	defer restore()
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(api.RequestIDMiddleware(), api.LoggingMiddleware())
+	h := NewStalenessHandler(&fakeStalenessReader{err: errors.New("upstream exploded")})
+	r.GET("/sync/staleness", h.GetActiveBreaches)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/sync/staleness", nil)
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	logOutput := buf.String()
+	// The explicit handler-error log carries the cause...
+	assert.Contains(t, logOutput, "upstream exploded")
+	// ...and the access-log line now carries the error field (c.Error revived the branch).
+	assert.Contains(t, logOutput, `"error"`)
 }

--- a/backend/internal/api/handlers/sync.go
+++ b/backend/internal/api/handlers/sync.go
@@ -2,13 +2,11 @@ package handlers
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"strconv"
 	"time"
 
 	"personal-crm/backend/internal/api"
-	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/service"
 	"personal-crm/backend/internal/sync"
@@ -63,7 +61,7 @@ type TriggerSyncRequest struct {
 func (h *SyncHandler) GetSyncStatus(c *gin.Context) {
 	states, err := h.syncService.GetSyncStatus(c.Request.Context())
 	if err != nil {
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to get sync status", err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 
@@ -108,11 +106,7 @@ func (h *SyncHandler) GetSyncState(c *gin.Context) {
 
 	state, err := h.syncService.GetSyncStateBySource(c.Request.Context(), source, accountIDPtr)
 	if err != nil {
-		if errors.Is(err, db.ErrNotFound) {
-			api.SendError(c, http.StatusNotFound, api.ErrCodeNotFound, "Sync state not found", "")
-			return
-		}
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to get sync state", err.Error())
+		api.RespondError(c, err, "Sync state")
 		return
 	}
 
@@ -217,11 +211,7 @@ func (h *SyncHandler) EnableSync(c *gin.Context) {
 
 	state, err := h.syncService.EnableSync(c.Request.Context(), id, enabled)
 	if err != nil {
-		if errors.Is(err, db.ErrNotFound) {
-			api.SendError(c, http.StatusNotFound, api.ErrCodeNotFound, "Sync state not found", "")
-			return
-		}
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to update sync state", err.Error())
+		api.RespondError(c, err, "Sync state")
 		return
 	}
 
@@ -262,14 +252,14 @@ func (h *SyncHandler) GetSyncLogs(c *gin.Context) {
 
 	logs, err := h.syncService.GetSyncLogs(c.Request.Context(), id, int32(limit), offset)
 	if err != nil {
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to get sync logs", err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 
 	// Get total count for pagination
 	total, err := h.syncService.CountSyncLogs(c.Request.Context(), id)
 	if err != nil {
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to count sync logs", err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 
@@ -306,7 +296,7 @@ func (h *SyncHandler) GetRecentSyncLogs(c *gin.Context) {
 
 	logs, err := h.syncService.GetRecentSyncLogs(c.Request.Context(), int32(limit))
 	if err != nil {
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to get sync logs", err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 

--- a/backend/internal/api/handlers/sync.go
+++ b/backend/internal/api/handlers/sync.go
@@ -40,7 +40,7 @@ type SyncHandler struct {
 func NewSyncHandler(syncService SyncService) *SyncHandler {
 	return &SyncHandler{
 		syncService: syncService,
-		validator:   validator.New(),
+		validator:   sharedValidator,
 	}
 }
 

--- a/backend/internal/api/handlers/sync.go
+++ b/backend/internal/api/handlers/sync.go
@@ -190,10 +190,8 @@ func (h *SyncHandler) TriggerSync(c *gin.Context) {
 // @Failure 500 {object} api.APIResponse{error=api.APIError}
 // @Router /sync/{id}/enable [patch]
 func (h *SyncHandler) EnableSync(c *gin.Context) {
-	idStr := c.Param("id")
-	id, err := uuid.Parse(idStr)
-	if err != nil {
-		api.SendError(c, http.StatusBadRequest, api.ErrCodeValidation, "Invalid sync state ID", err.Error())
+	id, ok := api.ParseUUIDParam(c, "id", "sync state")
+	if !ok {
 		return
 	}
 
@@ -231,10 +229,8 @@ func (h *SyncHandler) EnableSync(c *gin.Context) {
 // @Failure 500 {object} api.APIResponse{error=api.APIError}
 // @Router /sync/{id}/logs [get]
 func (h *SyncHandler) GetSyncLogs(c *gin.Context) {
-	idStr := c.Param("id")
-	id, err := uuid.Parse(idStr)
-	if err != nil {
-		api.SendError(c, http.StatusBadRequest, api.ErrCodeValidation, "Invalid sync state ID", err.Error())
+	id, ok := api.ParseUUIDParam(c, "id", "sync state")
+	if !ok {
 		return
 	}
 

--- a/backend/internal/api/handlers/sync.go
+++ b/backend/internal/api/handlers/sync.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"personal-crm/backend/internal/api"
+	"personal-crm/backend/internal/logger"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/service"
 	"personal-crm/backend/internal/sync"
@@ -14,7 +15,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/go-playground/validator/v10"
 	"github.com/google/uuid"
-	"github.com/rs/zerolog/log"
 )
 
 // SyncService defines the interface for sync operations used by the handler.
@@ -167,7 +167,7 @@ func (h *SyncHandler) TriggerSync(c *gin.Context) {
 
 		if err := h.syncService.TriggerSync(ctx, srcName, accountID); err != nil {
 			// Log error - can't return to client since request already responded
-			log.Error().Err(err).Str("source", srcName).Msg("background enqueue failed")
+			logger.Error().Err(err).Str("source", srcName).Msg("background enqueue failed")
 		}
 	}()
 

--- a/backend/internal/api/handlers/sync.go
+++ b/backend/internal/api/handlers/sync.go
@@ -259,18 +259,8 @@ func (h *SyncHandler) GetSyncLogs(c *gin.Context) {
 		return
 	}
 
-	pages := int(total) / limit
-	if int(total)%limit > 0 {
-		pages++
-	}
-
 	api.SendSuccess(c, http.StatusOK, logs, &api.Meta{
-		Pagination: &api.PaginationMeta{
-			Page:  page,
-			Limit: limit,
-			Total: total,
-			Pages: pages,
-		},
+		Pagination: api.BuildPaginationMeta(page, limit, total),
 	})
 }
 

--- a/backend/internal/api/handlers/sync_test.go
+++ b/backend/internal/api/handlers/sync_test.go
@@ -1,0 +1,104 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/sync"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeSyncService implements SyncService, returning configurable errors so the
+// migrated RespondError / RespondInternal paths can be exercised without a DB.
+type fakeSyncService struct {
+	err error
+}
+
+func (f *fakeSyncService) TriggerSync(_ context.Context, _ string, _ *string) error {
+	return f.err
+}
+
+func (f *fakeSyncService) GetSyncStatus(_ context.Context) ([]repository.SyncState, error) {
+	return nil, f.err
+}
+
+func (f *fakeSyncService) GetSyncStateBySource(_ context.Context, _ string, _ *string) (*repository.SyncState, error) {
+	return nil, f.err
+}
+
+func (f *fakeSyncService) EnableSync(_ context.Context, _ uuid.UUID, _ bool) (*repository.SyncState, error) {
+	return nil, f.err
+}
+
+func (f *fakeSyncService) GetSyncLogs(_ context.Context, _ uuid.UUID, _, _ int32) ([]repository.SyncLog, error) {
+	return nil, f.err
+}
+
+func (f *fakeSyncService) CountSyncLogs(_ context.Context, _ uuid.UUID) (int64, error) {
+	return 0, f.err
+}
+
+func (f *fakeSyncService) GetRecentSyncLogs(_ context.Context, _ int32) ([]repository.SyncLog, error) {
+	return nil, f.err
+}
+
+func (f *fakeSyncService) GetAvailableProviders() []sync.SourceConfig {
+	return nil
+}
+
+func newSyncTestRouter(svc SyncService) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	h := NewSyncHandler(svc)
+	r.GET("/sync/status", h.GetSyncStatus)
+	r.GET("/sync/:source/status", h.GetSyncState)
+	return r
+}
+
+// TestSyncHandler_GetSyncState_NotFound proves RespondError keeps the
+// db.ErrNotFound → 404 mapping on a real migrated interface-backed handler.
+func TestSyncHandler_GetSyncState_NotFound(t *testing.T) {
+	r := newSyncTestRouter(&fakeSyncService{err: db.ErrNotFound})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/sync/gmail/status", nil)
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+	assert.Contains(t, w.Body.String(), "Sync state not found")
+}
+
+// TestSyncHandler_GetSyncState_GenericError proves a non-not-found error still
+// 500s (no drift to 404) with no raw cause leaking into the body.
+func TestSyncHandler_GetSyncState_GenericError(t *testing.T) {
+	r := newSyncTestRouter(&fakeSyncService{err: errors.New("connection reset secret")})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/sync/gmail/status", nil)
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.NotContains(t, w.Body.String(), "connection reset secret")
+	assert.NotContains(t, w.Body.String(), `"details"`)
+}
+
+func TestSyncHandler_GetSyncStatus_GenericError(t *testing.T) {
+	r := newSyncTestRouter(&fakeSyncService{err: errors.New("db offline secret")})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/sync/status", nil)
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.NotContains(t, w.Body.String(), "db offline secret")
+	assert.NotContains(t, w.Body.String(), `"details"`)
+}

--- a/backend/internal/api/handlers/system.go
+++ b/backend/internal/api/handlers/system.go
@@ -89,6 +89,9 @@ func (h *SystemHandler) SetTimeAcceleration(c *gin.Context) {
 
 	// Set environment variables (note: this only affects current process)
 	if err := os.Setenv("TIME_ACCELERATION", strconv.Itoa(settings.Factor)); err != nil {
+		// Preserve the existing non-standard body (system.go is E2E-selected); just
+		// add the logged cause + c.Error revival.
+		api.LogServerError(c, err)
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error": "Failed to set TIME_ACCELERATION environment variable",
 		})
@@ -96,6 +99,7 @@ func (h *SystemHandler) SetTimeAcceleration(c *gin.Context) {
 	}
 	if settings.Factor > 1 {
 		if err := os.Setenv("TIME_BASE", strconv.FormatInt(time.Now().Unix(), 10)); err != nil { //nolint:forbidigo // Need wall-clock base for acceleration
+			api.LogServerError(c, err)
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"error": "Failed to set TIME_BASE environment variable",
 			})
@@ -103,6 +107,7 @@ func (h *SystemHandler) SetTimeAcceleration(c *gin.Context) {
 		}
 	} else {
 		if err := os.Unsetenv("TIME_BASE"); err != nil {
+			api.LogServerError(c, err)
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"error": "Failed to unset TIME_BASE environment variable",
 			})
@@ -128,6 +133,7 @@ func (h *SystemHandler) ExportData(c *gin.Context) {
 		Limit: 1000, // Large limit to get all
 	})
 	if err != nil {
+		api.LogServerError(c, err)
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"success": false,
 			"error": gin.H{

--- a/backend/internal/api/handlers/telegram.go
+++ b/backend/internal/api/handlers/telegram.go
@@ -69,7 +69,7 @@ func (h *TelegramHandler) StartAuth(c *gin.Context) {
 			api.SendConflict(c, "Already connected — disconnect first")
 			return
 		}
-		api.SendInternalError(c, "Failed to start auth")
+		api.RespondInternal(c, err)
 		return
 	}
 
@@ -109,7 +109,7 @@ func (h *TelegramHandler) VerifyCode(c *gin.Context) {
 			return
 		}
 		if errors.Is(err, tg.ErrAuthInternal) {
-			api.SendInternalError(c, "Failed to verify code")
+			api.RespondInternal(c, err)
 			return
 		}
 		api.SendError(c, http.StatusUnauthorized, "UNAUTHORIZED", "Invalid verification code", "")
@@ -155,7 +155,7 @@ func (h *TelegramHandler) VerifyPassword(c *gin.Context) {
 			return
 		}
 		if errors.Is(err, tg.ErrAuthInternal) {
-			api.SendInternalError(c, "Failed to verify password")
+			api.RespondInternal(c, err)
 			return
 		}
 		api.SendError(c, http.StatusUnauthorized, "UNAUTHORIZED", "Invalid password", "")
@@ -182,7 +182,7 @@ func (h *TelegramHandler) CancelAuth(c *gin.Context) {
 // Disconnect handles DELETE /api/v1/telegram/auth
 func (h *TelegramHandler) Disconnect(c *gin.Context) {
 	if err := h.manager.Disconnect(c.Request.Context()); err != nil {
-		api.SendInternalError(c, "Failed to disconnect")
+		api.RespondInternal(c, err)
 		return
 	}
 	api.SendSuccess(c, http.StatusOK, gin.H{"status": "disconnected"}, nil)
@@ -232,7 +232,7 @@ type updateChatStatusRequest struct {
 func (h *TelegramHandler) ListChats(c *gin.Context) {
 	chats, err := h.manager.ListChats(c.Request.Context())
 	if err != nil {
-		api.SendInternalError(c, "Failed to list chats")
+		api.RespondInternal(c, err)
 		return
 	}
 
@@ -268,17 +268,13 @@ func (h *TelegramHandler) UpdateChatStatus(c *gin.Context) {
 	// Get current status to detect changes (not-found is fine — chat may not exist yet)
 	previousStatus, err := h.manager.GetChatStatus(c.Request.Context(), chatID)
 	if err != nil && !errors.Is(err, db.ErrNotFound) {
-		api.SendInternalError(c, "Failed to read chat status")
+		api.RespondInternal(c, err)
 		return
 	}
 
 	chat, err := h.manager.UpdateChatStatus(c.Request.Context(), chatID, status)
 	if err != nil {
-		if errors.Is(err, db.ErrNotFound) {
-			api.SendNotFound(c, "Chat")
-			return
-		}
-		api.SendInternalError(c, "Failed to update chat status")
+		api.RespondError(c, err, "Chat")
 		return
 	}
 

--- a/backend/internal/api/handlers/telegram.go
+++ b/backend/internal/api/handlers/telegram.go
@@ -9,10 +9,10 @@ import (
 
 	"personal-crm/backend/internal/api"
 	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/logger"
 	tg "personal-crm/backend/internal/telegram"
 
 	"github.com/gin-gonic/gin"
-	"github.com/rs/zerolog/log"
 )
 
 var phoneRegex = regexp.MustCompile(`^\+[0-9]{7,15}$`)
@@ -281,7 +281,7 @@ func (h *TelegramHandler) UpdateChatStatus(c *gin.Context) {
 	// Trigger retroactive backfill only when status changes TO "tracked"
 	if status == "tracked" && previousStatus != "tracked" {
 		if err := h.manager.TriggerChatBackfill(c.Request.Context(), chatID); err != nil {
-			log.Warn().Err(err).Int64("chat_id", chatID).Msg("telegram: failed to trigger backfill")
+			logger.Warn().Err(err).Int64("chat_id", chatID).Msg("telegram: failed to trigger backfill")
 		}
 	}
 

--- a/backend/internal/api/handlers/test.go
+++ b/backend/internal/api/handlers/test.go
@@ -169,7 +169,7 @@ func (h *TestHandler) SeedExternalContacts(c *gin.Context) {
 
 	ids, err := h.seedSvc.SeedExternalContacts(ctx, inputs)
 	if err != nil {
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to create external contact", err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 
@@ -266,7 +266,7 @@ func (h *TestHandler) SeedMethodSuggestions(c *gin.Context) {
 
 	res, err := h.seedSvc.SeedMethodSuggestions(ctx, input)
 	if err != nil {
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to seed method suggestions", err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 
@@ -378,7 +378,7 @@ func (h *TestHandler) SeedContacts(c *gin.Context) {
 
 	ids, err := h.seedSvc.SeedContacts(ctx, inputs)
 	if err != nil {
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to create contact", err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 
@@ -446,7 +446,7 @@ func (h *TestHandler) SeedOverdueContacts(c *gin.Context) {
 
 	ids, err := h.seedSvc.SeedOverdueContacts(ctx, inputs)
 	if err != nil {
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to create contact", err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 
@@ -567,7 +567,7 @@ func (h *TestHandler) SeedCalendarEvents(c *gin.Context) {
 
 	ids, err := h.seedSvc.SeedCalendarEvents(ctx, inputs)
 	if err != nil {
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to create calendar event", err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 
@@ -637,7 +637,7 @@ func (h *TestHandler) Cleanup(c *gin.Context) {
 
 	res, err := h.seedSvc.Cleanup(ctx, req.Prefix, hostID)
 	if err != nil {
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to clean up test data", err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 
@@ -696,7 +696,7 @@ func (h *TestHandler) SeedMacHost(c *gin.Context) {
 		SourceHealth:    req.SourceHealth,
 	})
 	if err != nil {
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "seed host failed", err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 
@@ -812,7 +812,7 @@ func (h *TestHandler) SeedMeetingNotes(c *gin.Context) {
 
 	ids, err := h.seedSvc.SeedMeetingNotes(ctx, hostID, notes)
 	if err != nil {
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to create meeting note", err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 

--- a/backend/internal/api/handlers/test.go
+++ b/backend/internal/api/handlers/test.go
@@ -31,7 +31,7 @@ type TestHandler struct {
 func NewTestHandler(seedSvc *service.TestSeedService) *TestHandler {
 	return &TestHandler{
 		seedSvc:   seedSvc,
-		validator: validator.New(),
+		validator: sharedValidator,
 	}
 }
 

--- a/backend/internal/api/handlers/todoist.go
+++ b/backend/internal/api/handlers/todoist.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 
 	"personal-crm/backend/internal/api"
-	"personal-crm/backend/internal/logger"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/todoist"
 
@@ -71,7 +70,7 @@ func (h *TodoistHandler) GetSettings(c *gin.Context) {
 	// Get the first (and only for v1) Todoist account
 	accounts, err := h.oauthService.ListAccounts(ctx)
 	if err != nil {
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to list accounts", err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 
@@ -154,7 +153,7 @@ func (h *TodoistHandler) UpdateSettings(c *gin.Context) {
 	// Get the first (and only for v1) Todoist account
 	accounts, err := h.oauthService.ListAccounts(ctx)
 	if err != nil {
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to list accounts", err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 
@@ -176,7 +175,7 @@ func (h *TodoistHandler) UpdateSettings(c *gin.Context) {
 			Strategy:  repository.SyncStrategyFetchAll,
 		})
 		if err != nil {
-			api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to create sync state", err.Error())
+			api.RespondInternal(c, err)
 			return
 		}
 	}
@@ -210,7 +209,7 @@ func (h *TodoistHandler) UpdateSettings(c *gin.Context) {
 	// Update metadata
 	_, err = h.syncRepo.UpdateSyncStateMetadata(ctx, state.ID, metadata)
 	if err != nil {
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to update settings", err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 
@@ -250,7 +249,7 @@ func (h *TodoistHandler) ListProjects(c *gin.Context) {
 	// Get the first (and only for v1) Todoist account
 	accounts, err := h.oauthService.ListAccounts(ctx)
 	if err != nil {
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to list accounts", err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 
@@ -264,7 +263,7 @@ func (h *TodoistHandler) ListProjects(c *gin.Context) {
 	// Get access token
 	accessToken, err := h.oauthService.GetAccessToken(ctx, accountID)
 	if err != nil {
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to get access token", err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 
@@ -272,8 +271,7 @@ func (h *TodoistHandler) ListProjects(c *gin.Context) {
 	client := todoist.NewSyncClient(accessToken)
 	syncResp, err := client.Sync(ctx, "*", []string{"projects"}, nil)
 	if err != nil {
-		logger.Error().Err(err).Msg("failed to fetch Todoist projects")
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to fetch projects", err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 
@@ -306,7 +304,7 @@ func (h *TodoistHandler) ListLabels(c *gin.Context) {
 	// Get the first (and only for v1) Todoist account
 	accounts, err := h.oauthService.ListAccounts(ctx)
 	if err != nil {
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to list accounts", err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 
@@ -320,7 +318,7 @@ func (h *TodoistHandler) ListLabels(c *gin.Context) {
 	// Get access token
 	accessToken, err := h.oauthService.GetAccessToken(ctx, accountID)
 	if err != nil {
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to get access token", err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 
@@ -328,8 +326,7 @@ func (h *TodoistHandler) ListLabels(c *gin.Context) {
 	client := todoist.NewSyncClient(accessToken)
 	syncResp, err := client.Sync(ctx, "*", []string{"labels"}, nil)
 	if err != nil {
-		logger.Error().Err(err).Msg("failed to fetch Todoist labels")
-		api.SendError(c, http.StatusInternalServerError, api.ErrCodeInternal, "Failed to fetch labels", err.Error())
+		api.RespondInternal(c, err)
 		return
 	}
 

--- a/backend/internal/api/handlers/validator.go
+++ b/backend/internal/api/handlers/validator.go
@@ -1,0 +1,9 @@
+package handlers
+
+import "github.com/go-playground/validator/v10"
+
+// sharedValidator is the single validator instance shared by every handler.
+// validator.Validate is concurrency-safe (it caches struct metadata under a
+// mutex), and no handler registers custom validations/aliases, so one instance
+// is safe to share and avoids constructing nine identical validators at wire-up.
+var sharedValidator = validator.New()

--- a/backend/internal/api/request.go
+++ b/backend/internal/api/request.go
@@ -1,0 +1,19 @@
+package api
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+// ParseUUIDParam parses a path parameter as a UUID. On failure it writes a
+// 400 validation error with a normalized message and returns ok=false, so the
+// caller can `if !ok { return }`. The status (400) matches every prior hand-rolled
+// path-param parse; only the message text is normalized, and no err.Error() leaks.
+func ParseUUIDParam(c *gin.Context, param, resource string) (uuid.UUID, bool) {
+	id, err := uuid.Parse(c.Param(param))
+	if err != nil {
+		SendValidationError(c, "Invalid "+resource+" ID", "ID must be a valid UUID")
+		return uuid.Nil, false
+	}
+	return id, true
+}

--- a/backend/internal/api/request_test.go
+++ b/backend/internal/api/request_test.go
@@ -1,0 +1,49 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseUUIDParam_Valid(t *testing.T) {
+	want := uuid.New()
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{{Key: "id", Value: want.String()}}
+
+	got, ok := ParseUUIDParam(c, "id", "contact")
+
+	require.True(t, ok)
+	assert.Equal(t, want, got)
+	// On success nothing is written to the response.
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, w.Body.String())
+}
+
+func TestParseUUIDParam_Invalid(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{{Key: "id", Value: "not-a-uuid"}}
+
+	got, ok := ParseUUIDParam(c, "id", "contact")
+
+	require.False(t, ok)
+	assert.Equal(t, uuid.Nil, got)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, ErrCodeValidation, resp.Error.Code)
+	assert.Equal(t, "Invalid contact ID", resp.Error.Message)
+	assert.Equal(t, "ID must be a valid UUID", resp.Error.Details)
+	// The normalized 400 must not leak the raw parse error.
+	assert.NotContains(t, w.Body.String(), "invalid UUID")
+}

--- a/backend/internal/api/response.go
+++ b/backend/internal/api/response.go
@@ -1,7 +1,11 @@
 package api
 
 import (
+	"errors"
 	"net/http"
+
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/logger"
 
 	"github.com/gin-gonic/gin"
 )
@@ -89,4 +93,45 @@ func SendConflict(c *gin.Context, message string) {
 
 func SendBadRequest(c *gin.Context, message string) {
 	SendError(c, http.StatusBadRequest, ErrCodeBadRequest, message, "")
+}
+
+// LogServerError logs an unexpected server-fault cause correlated by request_id and
+// calls c.Error(err) so the LoggingMiddleware access-log branch fires. It does NOT write
+// a response — callers that must preserve an existing non-standard body (e.g. system.go's
+// raw c.JSON shapes) call this, then write their own response.
+func LogServerError(c *gin.Context, err error) {
+	if err == nil {
+		return // gin panics on c.Error(nil); nothing to log either
+	}
+	requestID := "unknown"
+	if id, ok := c.Get("request_id"); ok {
+		if s, ok := id.(string); ok {
+			requestID = s
+		}
+	}
+	logger.Error().Str("request_id", requestID).Err(err).Msg("handler error")
+	_ = c.Error(err)
+}
+
+// RespondInternal always responds 500 with a generic body (no err.Error() in Details),
+// after LogServerError. Use at every site that currently 500s unconditionally. NEVER
+// introduces a 404, so it cannot drift a current 500 into a 4xx.
+func RespondInternal(c *gin.Context, err error) {
+	LogServerError(c, err)
+	SendInternalError(c, "") // generic body, empty Details, no leak
+}
+
+// RespondError handles sites that currently map db.ErrNotFound → 404 via SendNotFound:
+//
+//	db.ErrNotFound (incl. wrapped) → 404 "<resource> not found"  (expected; no error log)
+//	anything else                  → RespondInternal (500 + log + c.Error)
+//
+// Use ONLY where the existing block is `if errors.Is(err, db.ErrNotFound) { SendNotFound }
+// else { 500 }`, so the mapping is provably identical.
+func RespondError(c *gin.Context, err error, resource string) {
+	if err != nil && errors.Is(err, db.ErrNotFound) {
+		SendNotFound(c, resource)
+		return
+	}
+	RespondInternal(c, err)
 }

--- a/backend/internal/api/response.go
+++ b/backend/internal/api/response.go
@@ -50,6 +50,21 @@ const (
 	ErrCodeBadRequest   = "BAD_REQUEST"
 )
 
+// BuildPaginationMeta computes pagination metadata using ceil-style page counting.
+// It reproduces the hand-rolled formula every call site used (pages = ceil(total/limit)),
+// so meta.pagination is byte-identical before/after adoption. The limit > 0 guard is
+// purely defensive — no current caller passes limit == 0.
+func BuildPaginationMeta(page, limit int, total int64) *PaginationMeta {
+	pages := 0
+	if limit > 0 {
+		pages = int(total) / limit
+		if int(total)%limit > 0 {
+			pages++
+		}
+	}
+	return &PaginationMeta{Page: page, Limit: limit, Total: total, Pages: pages}
+}
+
 // SendSuccess sends a successful response
 func SendSuccess(c *gin.Context, statusCode int, data interface{}, meta *Meta) {
 	response := APIResponse{

--- a/backend/internal/api/response_test.go
+++ b/backend/internal/api/response_test.go
@@ -156,6 +156,33 @@ func TestRespondInternal_ConstructedSentinel(t *testing.T) {
 	assert.Contains(t, buf.String(), "missing mac_host context")
 }
 
+// handRolledPages is the exact formula every call site used before adoption.
+func handRolledPages(total int64, limit int) int {
+	pages := int(total) / limit
+	if int(total)%limit > 0 {
+		pages++
+	}
+	return pages
+}
+
+func TestBuildPaginationMeta_MatchesHandRolledFormula(t *testing.T) {
+	const limit = 20
+	for _, total := range []int64{0, 1, 19, 20, 21, 40} {
+		meta := BuildPaginationMeta(3, limit, total)
+		assert.Equal(t, 3, meta.Page)
+		assert.Equal(t, limit, meta.Limit)
+		assert.Equal(t, total, meta.Total)
+		assert.Equal(t, handRolledPages(total, limit), meta.Pages, "total=%d", total)
+	}
+}
+
+func TestBuildPaginationMeta_ZeroLimitGuard(t *testing.T) {
+	meta := BuildPaginationMeta(1, 0, 100)
+	assert.Equal(t, 0, meta.Pages)
+	assert.Equal(t, 0, meta.Limit)
+	assert.Equal(t, int64(100), meta.Total)
+}
+
 func TestLogServerError_NilIsNoop(t *testing.T) {
 	var buf bytes.Buffer
 	restore := logger.SetOutput(&buf)

--- a/backend/internal/api/response_test.go
+++ b/backend/internal/api/response_test.go
@@ -1,0 +1,183 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/logger"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+// newTestContext returns a gin context backed by a fresh recorder.
+func newTestContext() (*gin.Context, *httptest.ResponseRecorder) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	return c, w
+}
+
+func decodeError(t *testing.T, w *httptest.ResponseRecorder) APIResponse {
+	t.Helper()
+	var resp APIResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	return resp
+}
+
+func TestRespondError_BareNotFound(t *testing.T) {
+	c, w := newTestContext()
+
+	RespondError(c, db.ErrNotFound, "Contact")
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+	resp := decodeError(t, w)
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, ErrCodeNotFound, resp.Error.Code)
+	assert.Equal(t, "Contact not found", resp.Error.Message)
+	// A not-found is expected, not a server fault: it must NOT populate c.Errors.
+	assert.Empty(t, c.Errors)
+}
+
+func TestRespondError_WrappedNotFound(t *testing.T) {
+	c, w := newTestContext()
+
+	// Proves errors.Is matching, not == comparison.
+	wrapped := fmt.Errorf("get contact: %w", db.ErrNotFound)
+	RespondError(c, wrapped, "Contact")
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+	resp := decodeError(t, w)
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, ErrCodeNotFound, resp.Error.Code)
+	assert.Empty(t, c.Errors)
+}
+
+func TestRespondError_GenericDelegatesToInternal(t *testing.T) {
+	c, w := newTestContext()
+
+	RespondError(c, errors.New("db exploded"), "Contact")
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	resp := decodeError(t, w)
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, ErrCodeInternal, resp.Error.Code)
+	assert.Equal(t, "Internal server error", resp.Error.Message)
+	// No raw cause leaks into the body.
+	assert.Empty(t, resp.Error.Details)
+	assert.NotContains(t, w.Body.String(), "db exploded")
+	// The cause is captured for the access log.
+	require.Len(t, c.Errors, 1)
+}
+
+func TestRespondError_NilErr(t *testing.T) {
+	c, w := newTestContext()
+
+	require.NotPanics(t, func() { RespondError(c, nil, "Contact") })
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	// nil err must not populate c.Errors (gin panics on c.Error(nil)).
+	assert.Empty(t, c.Errors)
+}
+
+func TestRespondInternal_GenericError(t *testing.T) {
+	c, w := newTestContext()
+
+	RespondInternal(c, errors.New("connection refused"))
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	resp := decodeError(t, w)
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, ErrCodeInternal, resp.Error.Code)
+	assert.Equal(t, "Internal server error", resp.Error.Message)
+	assert.Empty(t, resp.Error.Details)
+	assert.NotContains(t, w.Body.String(), "connection refused")
+	require.Len(t, c.Errors, 1)
+	assert.Contains(t, c.Errors[0].Error(), "connection refused")
+}
+
+func TestRespondInternal_NilErr(t *testing.T) {
+	c, w := newTestContext()
+
+	require.NotPanics(t, func() { RespondInternal(c, nil) })
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	resp := decodeError(t, w)
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, ErrCodeInternal, resp.Error.Code)
+	assert.Empty(t, resp.Error.Details)
+	// nil err: no c.Error, no log line (guarded).
+	assert.Empty(t, c.Errors)
+}
+
+// TestRespondInternal_LogsCause is SERIAL (no t.Parallel) because it mutates the
+// process-global logger via logger.SetOutput. It proves the acceptance criterion that a
+// 500 logs its cause with request_id at error level.
+func TestRespondInternal_LogsCause(t *testing.T) {
+	var buf bytes.Buffer
+	restore := logger.SetOutput(&buf)
+	defer restore()
+
+	c, _ := newTestContext()
+	c.Set("request_id", "req-abc-123")
+
+	RespondInternal(c, errors.New("upstream timeout"))
+
+	logLine := buf.String()
+	assert.Contains(t, logLine, `"level":"error"`)
+	assert.Contains(t, logLine, "req-abc-123")
+	assert.Contains(t, logLine, "upstream timeout")
+}
+
+// TestRespondInternal_ConstructedSentinel covers the no-underlying-err sites (e.g.
+// mac_host's "missing mac_host context" invariant) that pass a constructed error so they
+// still get c.Error + a logged cause.
+func TestRespondInternal_ConstructedSentinel(t *testing.T) {
+	var buf bytes.Buffer
+	restore := logger.SetOutput(&buf)
+	defer restore()
+
+	c, w := newTestContext()
+
+	RespondInternal(c, errors.New("missing mac_host context"))
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	require.Len(t, c.Errors, 1)
+	assert.Contains(t, buf.String(), "missing mac_host context")
+}
+
+func TestLogServerError_NilIsNoop(t *testing.T) {
+	var buf bytes.Buffer
+	restore := logger.SetOutput(&buf)
+	defer restore()
+
+	c, _ := newTestContext()
+
+	require.NotPanics(t, func() { LogServerError(c, nil) })
+	assert.Empty(t, c.Errors)
+	assert.Empty(t, buf.String())
+}
+
+func TestLogServerError_UnknownRequestID(t *testing.T) {
+	var buf bytes.Buffer
+	restore := logger.SetOutput(&buf)
+	defer restore()
+
+	c, _ := newTestContext() // no request_id set
+
+	LogServerError(c, errors.New("boom"))
+
+	require.Len(t, c.Errors, 1)
+	assert.Contains(t, buf.String(), "unknown")
+	assert.Contains(t, buf.String(), "boom")
+}

--- a/backend/internal/logger/logger.go
+++ b/backend/internal/logger/logger.go
@@ -65,6 +65,18 @@ func Get() *zerolog.Logger {
 	return &log
 }
 
+// SetOutput swaps the global logger's writer (preserving level) and returns a restore
+// func that puts the previous logger back. TEST-ONLY: the global logger is process-global
+// mutable state, so any test using SetOutput MUST run serially (no t.Parallel) and MUST
+// `defer restore()` to avoid cross-test interleaving.
+func SetOutput(w io.Writer) (restore func()) {
+	prev := log
+	log = log.Output(w)
+	return func() {
+		log = prev
+	}
+}
+
 // Debug returns a debug level event
 func Debug() *zerolog.Event {
 	return log.Debug()

--- a/backend/internal/logger/logger_test.go
+++ b/backend/internal/logger/logger_test.go
@@ -157,6 +157,40 @@ func TestWith(t *testing.T) {
 	})
 }
 
+func TestSetOutput(t *testing.T) {
+	// Establish a known baseline logger writing to origBuf.
+	var origBuf bytes.Buffer
+	log = zerolog.New(&origBuf).Level(zerolog.InfoLevel)
+
+	t.Run("redirects output and restores", func(t *testing.T) {
+		var capture bytes.Buffer
+		restore := SetOutput(&capture)
+
+		Error().Str("request_id", "rid-1").Msg("captured")
+		assert.Contains(t, capture.String(), "captured")
+		assert.Contains(t, capture.String(), "rid-1")
+		assert.Empty(t, origBuf.String(), "output should not reach the original writer")
+
+		restore()
+
+		origBuf.Reset()
+		Error().Msg("after restore")
+		assert.Contains(t, origBuf.String(), "after restore")
+	})
+
+	t.Run("preserves the configured level", func(t *testing.T) {
+		log = zerolog.New(&origBuf).Level(zerolog.WarnLevel)
+		var capture bytes.Buffer
+		restore := SetOutput(&capture)
+		defer restore()
+
+		Info().Msg("filtered info")
+		Warn().Msg("kept warn")
+		assert.NotContains(t, capture.String(), "filtered info")
+		assert.Contains(t, capture.String(), "kept warn")
+	})
+}
+
 func TestLogLevelFiltering(t *testing.T) {
 	var buf bytes.Buffer
 


### PR DESCRIPTION
## Summary

Centralizes handler error handling so production 500s log their root cause and stop leaking raw `err.Error()` into response bodies (issue #448). Previously `LoggingMiddleware`'s `c.Errors` branch never fired because no handler called `c.Error()`, so a Pi-side 500 logged only `status=500` with no cause; meanwhile several handlers embedded raw `err.Error()` in the 500 response Details field.

Adds three helpers in `internal/api`:
- `RespondError(c, err, resource)` — maps `db.ErrNotFound`→404, defaults to 500; logs the cause with request_id and calls `c.Error()` so the access log carries it; generic 500 body (no raw err text).
- `RespondInternal(c, err)` — always 500, logs + `c.Error()`, generic body.
- `LogServerError(c, err)` — log + `c.Error()` only, for the few sites that must keep a non-standard body (system.go).

Plus the opted-in boilerplate consolidation: `ParseUUIDParam(c, name)`, a single shared validator instance, `BuildPaginationMeta`, and sync.go/telegram.go standardized on `internal/logger`.

Migrates the full 500-leak surface (~24 handler files), not just the issue's 9 enumerated sites, per the project's "fix ALL instances of a pattern" rule.

## Invariants (verified, adversarially)

- **Zero externally-observable 4xx/5xx status drift.** Every migrated site reproduces its original status mapping byte-identically. The four custom not-found carve-outs (mac_host.go ~248/372/440, telegram.go ~270) are kept verbatim; handlers mapping `ErrNotFound` to 401 / empty-cursor / success are unchanged.
- **No raw `err.Error()` in any 500 body.** system.go's four `c.JSON(500)` sites keep their non-standard bodies but are now `LogServerError`-guarded; the only remaining `err.Error()` are 400/validation bodies (out of scope) and a test fixture that echoes a client-supplied message.

## Tests

Helper unit tests (no DB) as the primary proof — `ErrNotFound`→404, generic→500 with no leaked text, and `c.Errors` populated so `LoggingMiddleware` logs the cause — plus handler error-path tests and the api integration suite (60 status-code assertions confirm zero drift across mac_host/telegram/sync). `go build ./...`, `make lint`, and `make test-unit` are green.

## Known non-blocking follow-ups

- `LogsCauseThroughMiddleware` test is near-tautological (the `c.Error()` revival is genuinely covered by `TestRespondInternal_GenericError`'s `c.Errors` length assertion).
- ingest.go double-logs the same err.
- import.go anarlog-backfill sites dropped the `external_id` structured field (recoverable from the request path).

Closes #448
