### PR TITLE
chore(worktree): auto-install frontend deps on worktree birth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Personal CRM Makefile
 
-.PHONY: help setup dev dev-seed staging-reset build crm-admin mac-daemon test test-daemon-local clean docker-up docker-down docker-reset test-cadence-ultra test-cadence-fast prod staging testing start start-local stop restart reload status dev-stop dev-restart dev-api-stop dev-api-start dev-api-restart ci-build-backend ci-build-frontend ci-build ci-test test-e2e test-e2e-local test-e2e-diff e2e-db deploy-mac promote setup-pi setup-mac-deploy dev-native postgres-native sqlc smoke-test test-deploy-scripts worktree-env test-integration-fast test-integration-slow test-clean-clones worktree-test-pg-ensure test-pg-stop test-pg-teardown test-pg-reap test-pg-smoke check-cadence-sole-writer check-followup-sole-writer check-rematch-sole-dispatcher check-crm-marker-construction check-sqlc-select-lists lint-ingest-registry
+.PHONY: help setup dev dev-seed staging-reset build crm-admin mac-daemon test test-daemon-local clean docker-up docker-down docker-reset test-cadence-ultra test-cadence-fast prod staging testing start start-local stop restart reload status dev-stop dev-restart dev-api-stop dev-api-start dev-api-restart ci-build-backend ci-build-frontend ci-build ci-test test-e2e test-e2e-local test-e2e-diff e2e-db deploy-mac promote setup-pi setup-mac-deploy dev-native postgres-native sqlc smoke-test test-deploy-scripts worktree-env worktree-deps test-integration-fast test-integration-slow test-clean-clones worktree-test-pg-ensure test-pg-stop test-pg-teardown test-pg-reap test-pg-smoke check-cadence-sole-writer check-followup-sole-writer check-rematch-sole-dispatcher check-crm-marker-construction check-sqlc-select-lists lint-ingest-registry
 
 # Repo root (supports running make from subdirectories).
 REPO_ROOT := $(shell git rev-parse --show-toplevel)
@@ -122,6 +122,7 @@ help:
 	@echo "  dev-seed     - Seed the dev synthetic world, then start dev servers (opt-in; dev is unchanged)"
 	@echo "  dev-native   - Start dev servers with native PostgreSQL (no Docker)"
 	@echo "  worktree-env - Symlink the main checkout's gitignored env files into this worktree"
+	@echo "  worktree-deps - Install per-worktree frontend deps (node_modules) into this worktree"
 	@echo "  staging-reset - HARD reset + reseed STAGING with the prod-shaped synthetic world (refuses production)"
 	@echo "  build       - Build both frontend and backend"
 	@echo "  crm-admin   - Build the operator-only admin CLI (backend/crm-admin)"
@@ -283,6 +284,14 @@ staging-reset: ## HARD reset + reseed STAGING with the prod-shaped synthetic wor
 # checkout.
 worktree-env:
 	@WORKTREE_ENV_VERBOSE=1 bash scripts/link-worktree-env.sh
+
+# Install per-worktree dependencies that can't be symlinked (frontend
+# node_modules is branch-specific, tied to this branch's lockfile). Normally
+# automatic via the post-checkout git hook on `git worktree add`; run this
+# manually if a worktree was created before the hook existed. No-op in the main
+# checkout (use `make setup` there). Go deps need nothing (global modcache).
+worktree-deps:
+	@WORKTREE_DEPS_VERBOSE=1 bash scripts/install-worktree-deps.sh
 
 postgres-native:
 	@bash scripts/start-postgres-native.sh

--- a/scripts/hooks/check-frontend-deps.sh
+++ b/scripts/hooks/check-frontend-deps.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# check-frontend-deps.sh — stateless preflight that fails with a CLEAR message
+# when frontend/node_modules is missing or incomplete, instead of letting the
+# pre-push frontend commands fail later with a cryptic `next: command not found`
+# (exit 127).
+#
+# Why this exists: a fresh linked worktree's deps are installed at birth by
+# scripts/install-worktree-deps.sh (via the post-checkout hook), but that
+# birth-time signal is ephemeral — a programmatic worktree creator (Orca) may
+# discard its stderr, and the hook deliberately swallows the installer's exit
+# code so the checkout always succeeds. So a worktree whose install failed,
+# never ran, or was manually removed would still hit the original exit-127 at
+# pre-push. This stateless check is the durable backstop: no marker file, so it
+# also catches those cases and self-clears the moment deps are installed.
+#
+# It runs as a fast-fail GATE from scripts/hooks/pre-push (check_frontend_deps),
+# BEFORE the parallel LINT/FRONTEND phases, so its message REPLACES the cryptic
+# errors rather than printing alongside them (the LINT phase does not
+# short-circuit and runs concurrently with FRONTEND).
+#
+# Sourceable: when sourced (BASH_SOURCE != $0) it only defines functions, so the
+# pure logic can be unit-tested with an injected root (see
+# scripts/test/test-install-worktree-deps.sh). When executed it runs the check
+# and exits with its status.
+set -uo pipefail
+
+# The exact binaries the pre-push frontend commands invoke:
+#   "Frontend lint"  -> next lint && prettier --check .
+#   "Frontend tests" -> vitest run
+# Keep this list in sync with those commands (.ai/pre-push.json +
+# frontend/package.json): if the frontend ever drops or renames one of these
+# tools, the matching command changes in the same edit, so update this list
+# then too. A test asserts the 3-bin check via a partial-install fixture.
+FRONTEND_REQUIRED_BINS=(next prettier vitest)
+
+# frontend_deps_ok <repo_root> — pure predicate. Returns 0 when there is nothing
+# to check (no frontend/package.json) OR every required .bin binary is present
+# and executable; returns 1 when frontend/package.json exists but any required
+# binary is missing (catches a missing OR partial/empty install). Prints
+# nothing — the caller owns the user-facing message. Unit-testable with an
+# injected root (no git repo needed).
+frontend_deps_ok() {
+  local root="$1" bin
+  [ -f "$root/frontend/package.json" ] || return 0
+  for bin in "${FRONTEND_REQUIRED_BINS[@]}"; do
+    [ -x "$root/frontend/node_modules/.bin/$bin" ] || return 1
+  done
+  return 0
+}
+
+# check_frontend_deps_main — entry point. Resolve the repo root, run the pure
+# check, and on failure print the actionable, checkout-agnostic message + return
+# non-zero. The message leads with `cd frontend && bun install` because that
+# works in EVERY checkout (the gate also runs when pushing from the main
+# checkout, where `make worktree-deps` deliberately no-ops).
+check_frontend_deps_main() {
+  local root
+  root="$(git rev-parse --show-toplevel 2>/dev/null)" || return 0  # not a repo -> skip
+  if frontend_deps_ok "$root"; then
+    return 0
+  fi
+  echo "frontend dependencies are not installed (frontend/node_modules is missing or incomplete). Install them: 'cd frontend && bun install' (or 'make worktree-deps' in a linked worktree, 'make setup' in the main checkout). This usually means a worktree was created without provisioning." >&2
+  return 1
+}
+
+# Source-guard: run the check only when executed directly, not when sourced.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  check_frontend_deps_main
+fi

--- a/scripts/hooks/post-checkout
+++ b/scripts/hooks/post-checkout
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
 # post-checkout — provision a freshly-created linked worktree with the main
-# checkout's gitignored env files (.env, frontend/.env.local, ...).
+# checkout's gitignored env files (.env, frontend/.env.local, ...) AND the
+# per-worktree frontend deps (frontend/node_modules).
 #
-# Env files are gitignored, so a new worktree (Orca workspace, VPS dev sandbox,
-# or a plain `git worktree add`) starts WITHOUT them and the dev stack can't
-# run. This rides the git post-checkout hook — which fires wherever a worktree
-# is born — so the provisioning is environment-agnostic. The actual linking
-# lives in scripts/link-worktree-env.sh; this is just the trigger + gate.
+# Env files are gitignored and node_modules is gitignored + branch-specific, so
+# a new worktree (Orca workspace, VPS dev sandbox, or a plain `git worktree add`)
+# starts WITHOUT either and the dev stack can't run / pre-push fails late with a
+# cryptic `next: command not found`. This rides the git post-checkout hook —
+# which fires wherever a worktree is born — so the provisioning is environment-
+# agnostic. The actual work lives in scripts/link-worktree-env.sh (symlink env
+# files) and scripts/install-worktree-deps.sh (install deps); this is just the
+# trigger + gate.
 #
 # Active automatically under the project's core.hooksPath=scripts/hooks
 # (set by scripts/install-git-hooks.sh); no per-worktree wiring needed.
@@ -30,10 +34,18 @@ worktree_env_should_provision() {
 # Always returns 0 — a hook must never abort the checkout it observes.
 worktree_env_post_checkout() {
   worktree_env_should_provision "${1:-}" "${3:-}" || return 0
-  local repo_root script
+  local repo_root env_script deps_script
   repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || return 0
-  script="$repo_root/scripts/link-worktree-env.sh"
-  [ -f "$script" ] && bash "$script"
+  env_script="$repo_root/scripts/link-worktree-env.sh"
+  deps_script="$repo_root/scripts/install-worktree-deps.sh"
+  # Env-link first (fast symlinks), deps second (slower install). Order is
+  # irrelevant for correctness; this just surfaces the env files quickly. Each
+  # script's exit code is intentionally swallowed by the unconditional return 0
+  # below — a hook must never abort the checkout it observes (a failed install
+  # still leaves a usable worktree, and the pre-push frontend-deps gate is the
+  # durable backstop that catches missing deps before a push).
+  [ -f "$env_script" ] && bash "$env_script"
+  [ -f "$deps_script" ] && bash "$deps_script"
   return 0
 }
 

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -238,6 +238,26 @@ check_swift() {
   fi
 }
 
+# check_frontend_deps: fast-fail GATE that runs BEFORE the parallel block so a
+# missing/partial frontend/node_modules produces a clear, actionable message
+# instead of the concurrent LINT/FRONTEND phases' cryptic `next`/`vitest:
+# command not found` (exit 127). Modeled on check_swift. It must be a hook gate,
+# NOT a .ai/pre-push.json lint.commands[] entry: LINT does not short-circuit on
+# the first failure and runs concurrently with FRONTEND, so a config-command
+# preflight would print its message ALONGSIDE the cryptic errors, not instead of
+# them. Only the fast-fail here (under the hook's set -e, before run_phases_parallel)
+# prevents the frontend commands from running at all.
+check_frontend_deps() {
+  # Only enforce when frontend tooling will actually run (lint and/or tests on).
+  # LINT (incl. Frontend lint) runs on every push regardless of should_skip_tests,
+  # so deps are required whenever lint is enabled — even a backend-only push.
+  local lint_on test_on
+  lint_on=$(jq -r '.lint.enabled // false' "$CONFIG_FILE")
+  test_on=$(jq -r '.test.enabled // false' "$CONFIG_FILE")
+  [[ "$lint_on" == "true" || "$test_on" == "true" ]] || return 0
+  bash "$PROJECT_ROOT/scripts/hooks/check-frontend-deps.sh" || exit 1   # set -e fast-fail
+}
+
 # run_phase <log> <rcfile> <shell-command-string>
 # Runs the command string FOREGROUND in an isolating subshell, buffering all
 # output to <log> and writing the exit code to <rcfile>. The subshell isolates
@@ -535,6 +555,9 @@ check_review_log
 
 # Swift gate (path-filtered, fast-fail before the heavy parallel block)
 check_swift
+
+# Frontend-deps gate: clear message for missing deps before the parallel block.
+check_frontend_deps
 
 # L3: LINT + GO + FRONTEND + FILTER run concurrently; E2E runs exclusively last.
 # Lint is one of the aggregated phases (no longer a separate fast-fail gate).

--- a/scripts/hooks/test/test-pre-push-filters.sh
+++ b/scripts/hooks/test/test-pre-push-filters.sh
@@ -114,6 +114,8 @@ echo "--- per-worktree test-pg resolver unit (shim-only, DB/port-free) ---"
 bash scripts/test/test-worktree-test-pg.sh || fail=1
 echo "--- worktree env-link resolver + post-checkout gate (fs/git-only) ---"
 bash scripts/test/test-link-worktree-env.sh || fail=1
+echo "--- worktree dep-install + preflight + post-checkout/pre-push wiring (stubbed bun, fs/git-only) ---"
+bash scripts/test/test-install-worktree-deps.sh || fail=1
 echo "--- repo-hygiene check guard ---"
 bash scripts/hooks/test/test-repo-hygiene-check.sh || fail=1
 echo "--- e2e test-map coverage guard ---"

--- a/scripts/install-worktree-deps.sh
+++ b/scripts/install-worktree-deps.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# install-worktree-deps.sh — install the per-worktree frontend dependencies
+# (frontend/node_modules) into a linked git worktree.
+#
+# Why deps are INSTALLED, not symlinked (unlike env files): node_modules is
+# branch-specific — it is tied to this branch's frontend/bun.lock. Sharing or
+# symlinking one node_modules across worktrees breaks the moment two branches'
+# lockfiles diverge, and Next.js/watchers misbehave through a symlinked
+# node_modules. So env files get symlinked (one source of truth, see
+# link-worktree-env.sh) but deps get a real per-worktree install. Go deps need
+# nothing here: the global $GOMODCACHE resolves them in any worktree.
+#
+# Install command: `bun install --frozen-lockfile`. Frozen so the install never
+# rewrites the committed frontend/bun.lock (a fresh worktree must not sprout a
+# spurious lockfile diff) and so it is reproducible. Genuine package.json /
+# bun.lock drift makes a frozen install fail loudly — that is desirable, and
+# build-images.yml already installs frozen too. (ci.yml's test jobs use a plain
+# `bun install`; the no-lockfile-mutation property matters most at worktree
+# birth, so the divergence is deliberate, not an oversight.)
+#
+# No-op in the main checkout: its deps are owned by `make setup`
+# (scripts/setup-dev.sh runs bun install). This script only provisions LINKED
+# worktrees.
+#
+# Sourceable: when sourced (BASH_SOURCE != $0) it only defines functions, so the
+# pure logic can be unit-tested with injected input (see
+# scripts/test/test-install-worktree-deps.sh). When executed it runs the entry
+# point. Deliberately NO `set -e` (matching link-worktree-env.sh): the explicit
+# per-branch returns below are the control flow, and `set -e` would abort before
+# the loud failure messages print.
+set -uo pipefail
+
+# Reuse the canonical worktree path resolvers (resolve_main_root /
+# resolve_this_root) from link-worktree-env.sh instead of redefining them — one
+# source of truth for "where is the main checkout / this worktree". Sourcing it
+# only DEFINES functions (its source-guard suppresses the env-link gate), so
+# there are no side effects. The path is computed relative to this script so it
+# resolves whether executed by the hook (absolute path) or sourced by the test.
+_iwd_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$_iwd_dir/link-worktree-env.sh"
+
+# worktree_deps_should_install <main_root> <this_root> — pure predicate. Returns
+# 0 iff this_root is non-empty AND differs from main_root (i.e. a LINKED
+# worktree, not the main checkout). Unit-testable with injected args.
+worktree_deps_should_install() {
+  local main_root="${1:-}" this_root="${2:-}"
+  [ -n "$this_root" ] && [ "$this_root" != "$main_root" ]
+}
+
+# run_worktree_deps — side-effecting entry point. Exit codes (Decision 6, the
+# distinction is "could it do the job it exists to do?"):
+#   0  = succeeded, OR legitimately nothing to do (main checkout, no frontend).
+#   !0 = it was supposed to install but could not (bun missing, install failed).
+# The hook swallows a non-zero (the worktree is still born, a loud warning is
+# shown); `make worktree-deps` surfaces it so recovery never lies about success.
+run_worktree_deps() {
+  local main_root this_root rc
+  main_root="$(resolve_main_root)" || return 0   # not a git repo -> skip quietly
+  this_root="$(resolve_this_root)" || return 0
+  if ! worktree_deps_should_install "$main_root" "$this_root"; then
+    [ -n "${WORKTREE_DEPS_VERBOSE:-}" ] && \
+      echo "worktree-deps: this is the main checkout; nothing to install (use 'make setup')" >&2
+    return 0   # main-checkout no-op -> success
+  fi
+  if [ ! -f "$this_root/frontend/package.json" ]; then
+    echo "worktree-deps: no frontend/package.json; nothing to install" >&2
+    return 0   # legitimately nothing to do -> success
+  fi
+  if ! command -v bun >/dev/null 2>&1; then
+    echo "worktree-deps: bun not found; run 'make setup' to install it, then 'make worktree-deps'" >&2
+    return 1   # supposed to install but can't -> failure
+  fi
+  echo "worktree-deps: installing frontend deps (bun install --frozen-lockfile)..." >&2
+  ( cd "$this_root/frontend" && bun install --frozen-lockfile )
+  rc=$?
+  if [ "$rc" -eq 0 ]; then
+    echo "worktree-deps: frontend deps installed" >&2
+    return 0
+  fi
+  echo "worktree-deps: frontend dep install FAILED — run 'cd frontend && bun install' before pushing" >&2
+  return "$rc"
+}
+
+# Source-guard: run the entry point only when executed directly, not when sourced.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  run_worktree_deps
+fi

--- a/scripts/test/test-install-worktree-deps.sh
+++ b/scripts/test/test-install-worktree-deps.sh
@@ -1,0 +1,306 @@
+#!/usr/bin/env bash
+# Tests for scripts/install-worktree-deps.sh + scripts/hooks/check-frontend-deps.sh
+# + the post-checkout deps wiring + the pre-push check_frontend_deps gate wiring.
+#
+# DB-FREE + PORT-FREE + NETWORK-FREE: pure filesystem + local `git` only (temp
+# repos under mktemp), and a STUBBED `bun` (a PATH shim that records argv/cwd and
+# honors $FAKE_BUN_EXIT) — never a real install. Safe for the pre-push FILTER
+# lane; runs on any CI runner.
+#
+# Invoked from scripts/hooks/test/test-pre-push-filters.sh (like the sibling
+# env-link unit), not as a top-level pre-push command.
+#
+# Layers:
+#   1. worktree_deps_should_install   — pure gate predicate
+#   2. run_worktree_deps              — entry point (success / no-op / no-frontend
+#                                       / bun-missing / install-fail), bun stubbed
+#   3. end-to-end `git worktree add`  — hook installs deps + env-link not regressed
+#                                       + hook never aborts on install failure
+#   4. check-frontend-deps.sh         — the 3-bin preflight (present/missing/partial)
+#   5. pre-push gate wiring           — gate is called before run_phases_parallel
+set -u
+cd "$(dirname "${BASH_SOURCE[0]}")/../.." || exit 1   # repo root
+REPO="$PWD"
+
+# Sanitize hook-inherited git env BEFORE any git command. git exports GIT_DIR to
+# hooks (absolute in linked worktrees), which silently redirects every
+# `git -C "$tmp" ...` below at the REAL repo with work-tree=$tmp: `add -A` wipes
+# the real index, `commit` strands fixture commits on the pushed branch, and
+# `worktree add` mutates the real repo. Unsetting restores cwd/-C-based discovery
+# so the throwaway repos are isolated. (Same guard as test-link-worktree-env.sh.)
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE
+
+source scripts/install-worktree-deps.sh    # source-guard prevents the entry point
+source scripts/hooks/check-frontend-deps.sh # source-guard prevents the check body
+
+fail=0
+ok()  { echo "ok: $1"; }
+bad() { echo "FAIL: $1"; fail=1; }
+assert_true()  { local d="$1"; shift; if "$@"; then ok "$d"; else bad "$d"; fi; }
+assert_false() { local d="$1"; shift; if "$@"; then bad "$d"; else ok "$d"; fi; }
+
+TMPDIRS=()
+mk_tmp() { local d; d=$(mktemp -d); TMPDIRS+=("$d"); echo "$d"; }
+cleanup() { local d; for d in "${TMPDIRS[@]:-}"; do [ -n "$d" ] && rm -rf "$d"; done; }
+trap cleanup EXIT
+
+# --- Stub bun: a PATH shim recording argv + cwd, honoring $FAKE_BUN_EXIT. Never
+# does any real I/O, so the suite stays network-free. -------------------------
+FAKE_BIN=$(mk_tmp)
+cat > "$FAKE_BIN/bun" <<'STUB'
+#!/usr/bin/env bash
+{ printf 'argv=%s\n' "$*"; printf 'cwd=%s\n' "$PWD"; } >> "${FAKE_BUN_LOG:-/dev/null}"
+exit "${FAKE_BUN_EXIT:-0}"
+STUB
+chmod +x "$FAKE_BIN/bun"
+BUN_LOG=$(mk_tmp)/bun.log
+
+# Inject the worktree path resolvers so the run_worktree_deps unit cases need no
+# real git worktree — they read INJ_MAIN / INJ_THIS. (The end-to-end cases below
+# run the REAL script as a subprocess via `git worktree add`, so they exercise
+# the real resolvers; this override only affects this shell's unit calls.)
+resolve_main_root() { printf '%s\n' "${INJ_MAIN:-}"; }
+resolve_this_root() { printf '%s\n' "${INJ_THIS:-}"; }
+
+# deps_unit <main> <this> <path> <fake_exit>: run run_worktree_deps in a subshell
+# with injected resolvers + scoped PATH/env. Sets globals RC (exit code) and OUT
+# (combined stdout+stderr). Truncates the bun-stub log first.
+deps_unit() {
+  local main="$1" this="$2" pth="$3" fexit="$4"
+  : > "$BUN_LOG"
+  OUT=$(
+    export INJ_MAIN="$main" INJ_THIS="$this" PATH="$pth" \
+           FAKE_BUN_LOG="$BUN_LOG" FAKE_BUN_EXIT="$fexit"
+    run_worktree_deps 2>&1
+  )
+  RC=$?
+}
+stub_invoked() { [ -s "$BUN_LOG" ]; }
+
+# ============================================================================
+# 1. worktree_deps_should_install — pure gate predicate
+# ============================================================================
+echo "--- worktree_deps_should_install (gate) ---"
+assert_true  "linked worktree (this != main) installs"      worktree_deps_should_install "/a/main" "/a/wt"
+assert_false "main checkout (this == main) does not install" worktree_deps_should_install "/a/main" "/a/main"
+assert_false "empty this_root does not install"             worktree_deps_should_install "/a/main" ""
+
+# ============================================================================
+# 2. run_worktree_deps — success path (stub bun, linked worktree)
+# ============================================================================
+echo "--- run_worktree_deps: success ---"
+d=$(mk_tmp); s_main="$d/main"; s_this="$d/wt"
+mkdir -p "$s_main" "$s_this/frontend"
+printf '{"name":"fe"}\n' > "$s_this/frontend/package.json"
+deps_unit "$s_main" "$s_this" "$FAKE_BIN:/usr/bin:/bin" 0
+if [ "$RC" -eq 0 ] && grep -q '^argv=install --frozen-lockfile$' "$BUN_LOG"; then
+  ok "success: bun invoked with 'install --frozen-lockfile', returns 0"
+else
+  bad "success: expected rc 0 + 'install --frozen-lockfile' (rc=$RC, log=$(cat "$BUN_LOG"))"
+fi
+cwd_val=$(grep '^cwd=' "$BUN_LOG" | head -1 | cut -d= -f2-)
+if [ -n "$cwd_val" ] && [ "$cwd_val" -ef "$s_this/frontend" ]; then
+  ok "success: bun ran with cwd = <worktree>/frontend"
+else
+  bad "success: bun cwd '$cwd_val' != '$s_this/frontend'"
+fi
+
+# ============================================================================
+# 3. run_worktree_deps — no-op in the main checkout (this == main)
+# ============================================================================
+echo "--- run_worktree_deps: main-checkout no-op ---"
+d=$(mk_tmp); mkdir -p "$d/frontend"; printf '{"name":"fe"}\n' > "$d/frontend/package.json"
+deps_unit "$d" "$d" "$FAKE_BIN:/usr/bin:/bin" 0
+if [ "$RC" -eq 0 ] && ! stub_invoked; then
+  ok "main checkout: returns 0, bun NOT invoked"
+else
+  bad "main checkout: expected rc 0 + no bun (rc=$RC, log=$(cat "$BUN_LOG"))"
+fi
+
+# ============================================================================
+# 4. run_worktree_deps — bun missing while frontend/package.json exists (FAIL)
+# ============================================================================
+echo "--- run_worktree_deps: bun missing (returns non-zero) ---"
+d=$(mk_tmp); bm_main="$d/main"; bm_this="$d/wt"
+mkdir -p "$bm_main" "$bm_this/frontend"
+printf '{"name":"fe"}\n' > "$bm_this/frontend/package.json"
+# Curated PATH WITHOUT the stub (and without the user's real bun dir): only
+# /usr/bin:/bin, which provide git/coreutils but no bun.
+deps_unit "$bm_main" "$bm_this" "/usr/bin:/bin" 0
+if [ "$RC" -ne 0 ] && ! stub_invoked && printf '%s' "$OUT" | grep -q "bun not found"; then
+  ok "bun missing: non-zero exit + 'bun not found' message, no install attempted"
+else
+  bad "bun missing: expected non-zero + message + empty log (rc=$RC, out=$OUT)"
+fi
+
+# ============================================================================
+# 5. run_worktree_deps — no frontend/package.json (legitimately nothing to do)
+# ============================================================================
+echo "--- run_worktree_deps: no frontend/package.json ---"
+d=$(mk_tmp); np_main="$d/main"; np_this="$d/wt"
+mkdir -p "$np_main" "$np_this/frontend"   # frontend dir but NO package.json
+deps_unit "$np_main" "$np_this" "$FAKE_BIN:/usr/bin:/bin" 0
+if [ "$RC" -eq 0 ] && ! stub_invoked && printf '%s' "$OUT" | grep -q "no frontend/package.json"; then
+  ok "no package.json: returns 0, bun NOT invoked"
+else
+  bad "no package.json: expected rc 0 + no bun (rc=$RC, out=$OUT)"
+fi
+
+# ============================================================================
+# 6. run_worktree_deps — bun install fails (FAKE_BUN_EXIT=1) -> non-zero
+# ============================================================================
+echo "--- run_worktree_deps: install failure (returns non-zero) ---"
+d=$(mk_tmp); if_main="$d/main"; if_this="$d/wt"
+mkdir -p "$if_main" "$if_this/frontend"
+printf '{"name":"fe"}\n' > "$if_this/frontend/package.json"
+deps_unit "$if_main" "$if_this" "$FAKE_BIN:/usr/bin:/bin" 1
+if [ "$RC" -ne 0 ] && stub_invoked && printf '%s' "$OUT" | grep -q "install FAILED"; then
+  ok "install failure: non-zero exit + FAILED message (bun was attempted)"
+else
+  bad "install failure: expected non-zero + FAILED message (rc=$RC, out=$OUT)"
+fi
+
+# ============================================================================
+# 7 + 8. End-to-end: a real `git worktree add` fires the hook
+# ============================================================================
+echo "--- end-to-end: git worktree add (hook installs deps + env-link intact) ---"
+
+# setup_hooked_main <dir> — temp "main" checkout with the REAL scripts, the
+# canonical relative core.hooksPath, an env-file .gitignore + a tracked
+# .env.example, a tracked frontend/package.json, and one commit. Mirrors the
+# env-link test's helper, extended to also copy install-worktree-deps.sh.
+setup_hooked_main() {
+  local m="$1"
+  mkdir -p "$m/scripts/hooks" "$m/frontend"
+  cp "$REPO/scripts/link-worktree-env.sh"     "$m/scripts/link-worktree-env.sh"
+  cp "$REPO/scripts/install-worktree-deps.sh" "$m/scripts/install-worktree-deps.sh"
+  cp "$REPO/scripts/hooks/post-checkout"      "$m/scripts/hooks/post-checkout"
+  chmod +x "$m/scripts/link-worktree-env.sh" "$m/scripts/install-worktree-deps.sh" "$m/scripts/hooks/post-checkout"
+  printf '.env\nfrontend/.env.local\n' > "$m/.gitignore"
+  printf 'EXAMPLE=1\n' > "$m/.env.example"
+  printf '{"name":"fe"}\n' > "$m/frontend/package.json"   # tracked -> present in worktrees
+  git -C "$m" init -q -b main
+  git -C "$m" config user.email test@example.com
+  git -C "$m" config user.name "Test"
+  git -C "$m" config commit.gpgsign false
+  git -C "$m" config core.hooksPath scripts/hooks
+  git -C "$m" add -A
+  git -C "$m" -c commit.gpgsign=false commit -q -m init
+}
+
+# --- 7. Success: stub bun (exit 0) -> deps installed, env files still linked ---
+e2e=$(mk_tmp); main="$e2e/main"; setup_hooked_main "$main"
+printf 'ROOT=1\n' > "$main/.env"
+printf 'FE=1\n'   > "$main/frontend/.env.local"
+log="$e2e/bun.log"; : > "$log"
+wt="$e2e/wt"
+if ( export PATH="$FAKE_BIN:/usr/bin:/bin" FAKE_BUN_LOG="$log" FAKE_BUN_EXIT=0
+     git -C "$main" worktree add -q "$wt" -b feature HEAD ) 2>/dev/null; then
+  addrc=0
+else
+  addrc=$?
+fi
+assert_true "worktree add succeeds (exit 0)" test "$addrc" -eq 0
+# (a) deps stub ran in the new worktree's frontend/
+e2e_cwd=$(grep '^cwd=' "$log" | head -1 | cut -d= -f2-)
+if grep -q '^argv=install --frozen-lockfile$' "$log" \
+   && [ -n "$e2e_cwd" ] && [ "$e2e_cwd" -ef "$wt/frontend" ]; then
+  ok "hook ran the deps install in the new worktree's frontend/"
+else
+  bad "hook deps install: argv/cwd wrong (cwd='$e2e_cwd', log=$(cat "$log"))"
+fi
+# (b) env-link not regressed
+if [ -L "$wt/.env" ] && [ "$wt/.env" -ef "$main/.env" ] \
+   && [ -L "$wt/frontend/.env.local" ] && [ "$wt/frontend/.env.local" -ef "$main/frontend/.env.local" ]; then
+  ok "env files still symlinked into the worktree (env-link not regressed)"
+else
+  bad "env-link regressed: .env / frontend/.env.local not symlinked"
+fi
+
+# --- 8. Hook never aborts the checkout on install failure (stub bun exit 1) ---
+mainf="$e2e/mainf"; setup_hooked_main "$mainf"
+printf 'ROOT=1\n' > "$mainf/.env"
+logf="$e2e/bunf.log"; : > "$logf"
+wtf="$e2e/wtf"; errf="$e2e/wtf.err"
+if ( export PATH="$FAKE_BIN:/usr/bin:/bin" FAKE_BUN_LOG="$logf" FAKE_BUN_EXIT=1
+     git -C "$mainf" worktree add -q "$wtf" -b feature HEAD ) 2>"$errf"; then
+  addrcf=0
+else
+  addrcf=$?
+fi
+if [ "$addrcf" -eq 0 ] && [ -d "$wtf" ] && [ -f "$wtf/frontend/package.json" ]; then
+  ok "install failure: worktree add still exits 0 and the worktree exists"
+else
+  bad "install failure: worktree add should still succeed (rc=$addrcf)"
+fi
+if grep -q "install FAILED" "$errf"; then
+  ok "install failure: the FAILED message reached stderr"
+else
+  bad "install failure: expected FAILED message on stderr (got: $(cat "$errf"))"
+fi
+
+# ============================================================================
+# 9. check-frontend-deps.sh — the 3-bin preflight
+# ============================================================================
+echo "--- check-frontend-deps.sh (preflight) ---"
+
+# mk_bins <node_modules_dir> <bin...>: create executable .bin/<bin> stubs.
+mk_bins() {
+  local nm="$1"; shift; mkdir -p "$nm/.bin"
+  local b; for b in "$@"; do printf '#!/bin/sh\n' > "$nm/.bin/$b"; chmod +x "$nm/.bin/$b"; done
+}
+
+# Pure predicate matrix (no git needed).
+r=$(mk_tmp); mkdir -p "$r/frontend"; printf '{"name":"fe"}\n' > "$r/frontend/package.json"
+mk_bins "$r/frontend/node_modules" next prettier vitest
+assert_true  "frontend_deps_ok: all three bins present" frontend_deps_ok "$r"
+r=$(mk_tmp); mkdir -p "$r/frontend"; printf '{"name":"fe"}\n' > "$r/frontend/package.json"
+assert_false "frontend_deps_ok: node_modules missing" frontend_deps_ok "$r"
+r=$(mk_tmp); mkdir -p "$r/frontend"; printf '{"name":"fe"}\n' > "$r/frontend/package.json"
+mk_bins "$r/frontend/node_modules" next   # partial: missing prettier + vitest
+assert_false "frontend_deps_ok: partial install (only next)" frontend_deps_ok "$r"
+r=$(mk_tmp)   # no frontend/package.json at all
+assert_true  "frontend_deps_ok: no frontend/package.json -> nothing to check" frontend_deps_ok "$r"
+
+# Executed script (resolves the repo root via git) — exit code + message.
+mk_fe_repo() {  # mk_fe_repo <dir> ; caller populates node_modules afterward
+  local g="$1"; mkdir -p "$g/frontend"; printf '{"name":"fe"}\n' > "$g/frontend/package.json"
+  git -C "$g" init -q -b main
+  git -C "$g" config user.email test@example.com
+  git -C "$g" config user.name "Test"
+}
+g=$(mk_tmp); mk_fe_repo "$g"; mk_bins "$g/frontend/node_modules" next prettier vitest
+out=$( cd "$g" && bash "$REPO/scripts/hooks/check-frontend-deps.sh" 2>&1 ); rc=$?
+if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+  ok "check script: all bins present -> exit 0, silent"
+else
+  bad "check script: present -> expected exit 0 + silence (rc=$rc, out=$out)"
+fi
+g=$(mk_tmp); mk_fe_repo "$g"   # no node_modules
+out=$( cd "$g" && bash "$REPO/scripts/hooks/check-frontend-deps.sh" 2>&1 ); rc=$?
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q "frontend dependencies are not installed"; then
+  ok "check script: deps missing -> exit 1 + actionable message"
+else
+  bad "check script: missing -> expected exit 1 + message (rc=$rc, out=$out)"
+fi
+
+# ============================================================================
+# 10. pre-push GATE wiring (the gate must run BEFORE the parallel block)
+# ============================================================================
+echo "--- pre-push check_frontend_deps gate wiring ---"
+gate_line=$(grep -nE '^check_frontend_deps([[:space:]]|$)' "$REPO/scripts/hooks/pre-push" | head -1 | cut -d: -f1)
+rpp_line=$(grep -nE '^run_phases_parallel([[:space:]]|$)' "$REPO/scripts/hooks/pre-push" | head -1 | cut -d: -f1)
+if [ -n "$gate_line" ] && [ -n "$rpp_line" ] && [ "$gate_line" -lt "$rpp_line" ]; then
+  ok "gate is called before run_phases_parallel (lines $gate_line < $rpp_line)"
+else
+  bad "gate call ordering wrong (gate=$gate_line, run_phases_parallel=$rpp_line)"
+fi
+if ( source "$REPO/scripts/hooks/pre-push" >/dev/null 2>&1
+     declare -f check_frontend_deps >/dev/null \
+       && declare -f check_frontend_deps | grep -q 'check-frontend-deps.sh' ); then
+  ok "sourced hook defines check_frontend_deps invoking check-frontend-deps.sh"
+else
+  bad "hook must define check_frontend_deps that invokes check-frontend-deps.sh"
+fi
+
+[[ "$fail" -eq 0 ]] && { echo "ALL PASS"; exit 0; } || { echo "FAILURES"; exit 1; }

--- a/scripts/test/test-install-worktree-deps.sh
+++ b/scripts/test/test-install-worktree-deps.sh
@@ -69,6 +69,8 @@ deps_unit() {
   local main="$1" this="$2" pth="$3" fexit="$4"
   : > "$BUN_LOG"
   OUT=$(
+    # PATH/env are deliberately scoped to this subshell (per-case isolation).
+    # shellcheck disable=SC2030,SC2031
     export INJ_MAIN="$main" INJ_THIS="$this" PATH="$pth" \
            FAKE_BUN_LOG="$BUN_LOG" FAKE_BUN_EXIT="$fexit"
     run_worktree_deps 2>&1
@@ -194,6 +196,8 @@ printf 'ROOT=1\n' > "$main/.env"
 printf 'FE=1\n'   > "$main/frontend/.env.local"
 log="$e2e/bun.log"; : > "$log"
 wt="$e2e/wt"
+# PATH/env deliberately scoped to the worktree-add subshell.
+# shellcheck disable=SC2030,SC2031
 if ( export PATH="$FAKE_BIN:/usr/bin:/bin" FAKE_BUN_LOG="$log" FAKE_BUN_EXIT=0
      git -C "$main" worktree add -q "$wt" -b feature HEAD ) 2>/dev/null; then
   addrc=0
@@ -222,6 +226,8 @@ mainf="$e2e/mainf"; setup_hooked_main "$mainf"
 printf 'ROOT=1\n' > "$mainf/.env"
 logf="$e2e/bunf.log"; : > "$logf"
 wtf="$e2e/wtf"; errf="$e2e/wtf.err"
+# PATH/env deliberately scoped to the worktree-add subshell.
+# shellcheck disable=SC2030,SC2031
 if ( export PATH="$FAKE_BIN:/usr/bin:/bin" FAKE_BUN_LOG="$logf" FAKE_BUN_EXIT=1
      git -C "$mainf" worktree add -q "$wtf" -b feature HEAD ) 2>"$errf"; then
   addrcf=0


### PR DESCRIPTION
## Summary

A freshly-created linked git worktree provisions gitignored env files via the post-checkout hook but does **not** install frontend deps (`frontend/node_modules`), so `next`/`vitest` don't resolve and the pre-push hook fails late with a cryptic `next: command not found` (exit 127). This wires dep-install into worktree birth and adds a durable pre-push backstop that converts that cryptic failure into a clear, actionable message.

- **`scripts/install-worktree-deps.sh`** (new) — installs `bun install --frozen-lockfile` in `frontend/`. No-op in the main checkout (its deps are owned by `make setup`); legitimately-nothing-to-do (no `frontend/package.json`) returns success; bun-missing or install-failure returns a non-zero exit with a loud message. Reuses `link-worktree-env.sh`'s `resolve_main_root`/`resolve_this_root` via its source-guard rather than redefining them.
- **`scripts/hooks/post-checkout`** — now calls the installer after the env-link, under the same fresh-worktree gate, keeping the unconditional `return 0` so a failed install never aborts the checkout.
- **`make worktree-deps`** (new target) — manual recovery, mirroring `make worktree-env`, for worktrees created before this hook existed. Honest: non-zero exit when it cannot leave the worktree installable.
- **`scripts/hooks/check-frontend-deps.sh`** (new) + **`check_frontend_deps` gate in `scripts/hooks/pre-push`** — a stateless 3-bin preflight (`next`, `prettier`, `vitest`) wired as a fast-fail gate **before** `run_phases_parallel` (modeled on `check_swift`). Because the LINT phase doesn't short-circuit and runs concurrently with FRONTEND, this must be a hook gate, not a `.ai/pre-push.json` `lint.commands[]` entry — only a fast-fail before the parallel block prevents the cryptic commands from running at all. `.ai/pre-push.json` is intentionally untouched.
- **`scripts/test/test-install-worktree-deps.sh`** (new) — network/DB/port-free shell test (bun stubbed via a PATH shim), wired into the FILTER lane.

Go deps need nothing (the global `$GOMODCACHE` resolves them in any worktree); `node_modules` is branch-specific and must be installed per worktree, never symlinked.

## Test plan

- `bash scripts/test/test-install-worktree-deps.sh` — 22 assertions covering the should-install gate, the installer's success / main-checkout-no-op / no-frontend / bun-missing / install-failure paths, two end-to-end `git worktree add` flows (deps installed + env-link not regressed; hook never aborts on install failure), the 3-bin preflight (present/missing/partial/no-package.json), and the structural assertion that pre-push calls `check_frontend_deps` before `run_phases_parallel`.
- `bash scripts/hooks/test/test-pre-push-filters.sh` — the new test runs green within the FILTER lane; sibling env-link test unchanged (no regression).
- All new scripts are shellcheck-clean at warning+ (the residual SC1091/SC2015 info findings match the sibling `test-link-worktree-env.sh` convention).
- Dogfooded: `make worktree-deps` installed 480 packages in this worktree with no `frontend/bun.lock` diff (frozen install didn't mutate the lockfile). The full local pre-push suite (lint + GO + frontend + FILTER + E2E) passed on this branch, exercising the new `check_frontend_deps` gate.
- No Go/integration/E2E product-code changes — this touches only shell tooling + the Makefile.

## Reviewer notes (non-blocking, from /review-head)

The pre-push Claude review verdict was **PASS** (P0=0 P1=0 P2=2 P3=5). These findings are non-blocking and were deliberately **not** fixed in this PR; they're surfaced here so a human reviewer can decide whether any warrant a follow-up.

**P2 findings:**
- 3-bin gate is a heuristic a partial/interrupted install can defeat (`check-frontend-deps.sh`, `post-checkout`). The completeness signal is "are `next`/`prettier`/`vitest` present and executable." Because the hook now runs a blocking `bun install` synchronously, an interrupted install (timeout/SIGKILL/Ctrl-C) could leave a tree where those 3 sentinels exist but the install is incomplete — the gate then passes and the cryptic failure reappears at lint/test time. Acceptable as a documented heuristic (real lint still fails, just less cleanly); could soften the "partial" claim in the comment or strengthen the signal if partial-install slip turns out to bite in the Orca timeout path.
- **(most worth a follow-up)** No execution test of the gate wrapper's enable-gating or exit propagation (`pre-push` `check_frontend_deps`, `test-install-worktree-deps.sh`). The wrapper branches on `.lint.enabled`/`.test.enabled` (returns 0 when both off, else runs the script and `|| exit 1`). The test verifies the standalone script's exit codes and that the wrapper textually references `check-frontend-deps.sh`, but never *executes* the wrapper, so neither the "skip when both disabled" branch nor the `|| exit 1` propagation is dynamically exercised. A full end-to-end hook run is impractical (`check_review_log` fires first and would block on a missing review log), which justifies the static-grep compromise — but the enable-gating branch could be unit-tested by sourcing the hook and calling `check_frontend_deps` against temp `CONFIG_FILE`/`PROJECT_ROOT` values. This is the finding most worth a follow-up.

**P3 findings:**
- `# set -e fast-fail` comment in pre-push misattributes the mechanism — the left side of `||` suppresses `set -e`; the explicit `|| exit 1` is what fast-fails. Reword to make that clear.
- The gate invokes the check script without the `[ -f ]` guard the post-checkout hook uses for the sibling script — minor inconsistency (it's a tracked file; a missing tracked hook is a broken checkout anyway).
- The gate requires `vitest` even on pushes where tests are skipped — the comment frames it as "only enforce when frontend tooling will actually run," but it's really a deps-complete invariant whenever any frontend tooling is enabled; impact is negligible, comment wording is stricter than behavior.
- No "When You Change X, Check Y" row tying the frontend lint/test commands to `FRONTEND_REQUIRED_BINS` — today the list is correct, but the only sync guard is a code comment; a CLAUDE.md cross-check row is the repo's standard mechanism.
- SC2015 (`A && B || C`) on the test's summary line — safe (the true-branch `exit 0` terminates before C runs) and matches the sibling pattern; noted for completeness, no change required.

Closes #552.
