### PR TITLE
perf(db): add comms_message eligible/stale-claim partial indexes

### DIFF
--- a/backend/internal/db/models.go
+++ b/backend/internal/db/models.go
@@ -452,6 +452,13 @@ type PgConstraint struct {
 	Conrelid pgtype.Uint32 `json:"conrelid"`
 }
 
+type PgIndex struct {
+	Schemaname string `json:"schemaname"`
+	Tablename  string `json:"tablename"`
+	Indexname  string `json:"indexname"`
+	Indexdef   string `json:"indexdef"`
+}
+
 type PhoneCall struct {
 	ID               pgtype.UUID        `json:"id"`
 	CallUniqueID     string             `json:"call_unique_id"`

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -2043,6 +2043,11 @@ type Querier interface {
 	// proving the cadence/no-method states SURVIVE (a settling replay would
 	// overwrite last_contacted). Caller passes a BARE prefix; '%' appended.
 	TestListContactBucketsByNamePrefix(ctx context.Context, namePrefix pgtype.Text) ([]*TestListContactBucketsByNamePrefixRow, error)
+	// Index-definition test only: enumerate every index on comms_message with
+	// Postgres's own deterministic indexdef reconstruction, so a test can assert the
+	// exact key columns + partial predicate of the eligible/stale-claim indexes
+	// (migration 073). Read-only catalog access, mirroring TestListPublicTables.
+	TestListIndexDefsForComms(ctx context.Context) ([]*TestListIndexDefsForCommsRow, error)
 	// Reset integration test only: enumerate every base table in the public schema
 	// so the catalog guard can assert each is in the wiped list, is schema_migrations,
 	// or matches the river_% allowlist. Read-only catalog access.

--- a/backend/internal/db/queries/test.sql
+++ b/backend/internal/db/queries/test.sql
@@ -731,6 +731,15 @@ SELECT table_name::text FROM information_schema.tables
 WHERE table_schema = 'public' AND table_type = 'BASE TABLE'
 ORDER BY table_name;
 
+-- name: TestListIndexDefsForComms :many
+-- Index-definition test only: enumerate every index on comms_message with
+-- Postgres's own deterministic indexdef reconstruction, so a test can assert the
+-- exact key columns + partial predicate of the eligible/stale-claim indexes
+-- (migration 073). Read-only catalog access, mirroring TestListPublicTables.
+SELECT indexname::text, indexdef::text FROM pg_indexes
+WHERE schemaname = 'public' AND tablename = 'comms_message'
+ORDER BY indexname;
+
 -- name: TestInsertNonFinalRiverJob :exec
 -- Reset/additive-seed test only: plant ONE queued (non-finalized) river_job so a
 -- test can assert the additive --seed preflight REFUSES while --reset-and-seed

--- a/backend/internal/db/test.sql.go
+++ b/backend/internal/db/test.sql.go
@@ -1997,6 +1997,41 @@ func (q *Queries) TestListContactBucketsByNamePrefix(ctx context.Context, namePr
 	return items, nil
 }
 
+const TestListIndexDefsForComms = `-- name: TestListIndexDefsForComms :many
+SELECT indexname::text, indexdef::text FROM pg_indexes
+WHERE schemaname = 'public' AND tablename = 'comms_message'
+ORDER BY indexname
+`
+
+type TestListIndexDefsForCommsRow struct {
+	Indexname string `json:"indexname"`
+	Indexdef  string `json:"indexdef"`
+}
+
+// Index-definition test only: enumerate every index on comms_message with
+// Postgres's own deterministic indexdef reconstruction, so a test can assert the
+// exact key columns + partial predicate of the eligible/stale-claim indexes
+// (migration 073). Read-only catalog access, mirroring TestListPublicTables.
+func (q *Queries) TestListIndexDefsForComms(ctx context.Context) ([]*TestListIndexDefsForCommsRow, error) {
+	rows, err := q.db.Query(ctx, TestListIndexDefsForComms)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []*TestListIndexDefsForCommsRow{}
+	for rows.Next() {
+		var i TestListIndexDefsForCommsRow
+		if err := rows.Scan(&i.Indexname, &i.Indexdef); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const TestListPublicTables = `-- name: TestListPublicTables :many
 SELECT table_name::text FROM information_schema.tables
 WHERE table_schema = 'public' AND table_type = 'BASE TABLE'

--- a/backend/internal/repository/synthetic_support.go
+++ b/backend/internal/repository/synthetic_support.go
@@ -586,6 +586,22 @@ func (r *SyntheticSupportRepository) ListPublicTables(ctx context.Context) ([]st
 	return r.queries.TestListPublicTables(ctx)
 }
 
+// ListCommsIndexDefs returns Postgres's deterministic index definition for every
+// index on comms_message, keyed by index name. Backs the migration-073
+// index-definition test (exact key-column + partial-predicate assertions).
+// Index-definition test only.
+func (r *SyntheticSupportRepository) ListCommsIndexDefs(ctx context.Context) (map[string]string, error) {
+	rows, err := r.queries.TestListIndexDefsForComms(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defs := make(map[string]string, len(rows))
+	for _, row := range rows {
+		defs[row.Indexname] = row.Indexdef
+	}
+	return defs, nil
+}
+
 // InsertNonFinalRiverJob plants one queued river_job so a test can assert the
 // additive --seed preflight refuses while --reset-and-seed proceeds. Test only.
 func (r *SyntheticSupportRepository) InsertNonFinalRiverJob(ctx context.Context) error {

--- a/backend/migrations/073_comms_message_eligible_indexes.down.sql
+++ b/backend/migrations/073_comms_message_eligible_indexes.down.sql
@@ -1,0 +1,6 @@
+-- 073_comms_message_eligible_indexes.down.sql
+-- Drops the two partial indexes added by the up migration. Idempotent
+-- (IF EXISTS) so a partial-apply / Force / SetVersion recovery path is robust.
+-- Dropping an index destroys no data, so no row-count guard is needed.
+DROP INDEX IF EXISTS idx_comms_message_stale_claim;
+DROP INDEX IF EXISTS idx_comms_message_unprocessed_eligible;

--- a/backend/migrations/073_comms_message_eligible_indexes.up.sql
+++ b/backend/migrations/073_comms_message_eligible_indexes.up.sql
@@ -1,0 +1,48 @@
+-- 073_comms_message_eligible_indexes.up.sql
+-- Two partial indexes backing the eligible-row scans on comms_message, mirroring
+-- the sibling tables' 049 pattern (telegram_message / messages_message) adapted
+-- for comms_message's multi-source `source` column.
+--
+-- Five queries in queries/comms_message.sql filter the eligible predicate
+--   processed_at IS NULL
+--   AND (claimed_at IS NULL OR claimed_at < NOW() - INTERVAL '5 minutes')
+--   AND deleted_at IS NULL
+-- The 5-min messaging sweeper runs ListUnprocessedCommsContactIDs on every tick.
+-- Without these indexes the planner prefix-scans the dedup index on `source` and
+-- heap-filters all-time source history; with them the recurring sweep is
+-- O(eligible rows). The (claimed_at IS NULL OR claimed_at < ...) disjunction is
+-- served by BitmapOr-ing the two partial indexes (one per branch). Both stay
+-- near-empty in steady state because a row leaves the index once processed_at is
+-- set.
+--
+-- `source` LEADS the key (vs. 049's matched_contact_id-first key): comms_message
+-- is multi-source and every eligible query equality-filters `source = @source`,
+-- so a single seek lands on the per-source slice. This matches the column order
+-- the existing dedup index (source, external_id, matched_contact_id) and thread
+-- index (source, thread_id) already use.
+--
+-- `matched_contact_id IS NOT NULL` is OMITTED from the partial predicate (049
+-- includes it): on comms_message that column is NOT NULL (058:20), so the clause
+-- would be permanently true — dead weight that also implies a nullability the
+-- column does not have.
+--
+-- Plain (non-concurrent) CREATE INDEX, mirroring 049: takes a SHARE lock (blocks
+-- writes, allows reads) and scans the full heap to evaluate each partial
+-- predicate. golang-migrate runs this whole file as one implicit transaction, so
+-- the lock spans both builds. At the expected comms_message size this is a
+-- sub-second-to-few-seconds write stall during a deploy migration, which is
+-- acceptable. No migration in backend/migrations/ uses CONCURRENTLY.
+
+-- Unprocessed-eligible scan (claimed_at IS NULL branch).
+CREATE INDEX idx_comms_message_unprocessed_eligible
+    ON comms_message(source, matched_contact_id, sent_at)
+    WHERE processed_at IS NULL
+      AND claimed_at IS NULL
+      AND deleted_at IS NULL;
+
+-- Stale-claim recovery scan (claimed_at IS NOT NULL branch).
+CREATE INDEX idx_comms_message_stale_claim
+    ON comms_message(source, matched_contact_id, claimed_at)
+    WHERE processed_at IS NULL
+      AND claimed_at IS NOT NULL
+      AND deleted_at IS NULL;

--- a/backend/sqlc_schema/pg_catalog.sql
+++ b/backend/sqlc_schema/pg_catalog.sql
@@ -18,3 +18,15 @@ CREATE TABLE pg_constraint (
 CREATE FUNCTION pg_get_constraintdef(constraint_oid oid) RETURNS text AS $$
     SELECT ''::text;
 $$ LANGUAGE sql;
+
+-- pg_indexes is a system catalog VIEW (over pg_class/pg_index) that sqlc
+-- v1.30.0 does not model; the read-only catalog query TestListIndexDefsForComms
+-- (internal/db/queries/test.sql) fails to compile without this stub. We declare
+-- only the columns that query touches. As above, the live catalog is the source
+-- of truth at runtime; this file is never applied by golang-migrate.
+CREATE TABLE pg_indexes (
+    schemaname text NOT NULL,
+    tablename  text NOT NULL,
+    indexname  text NOT NULL,
+    indexdef   text NOT NULL
+);

--- a/backend/tests/comms_message_eligible_index_test.go
+++ b/backend/tests/comms_message_eligible_index_test.go
@@ -1,0 +1,123 @@
+//go:build integration_testdb
+
+package tests
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"personal-crm/backend/internal/repository"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Index-definition coverage for migration 073's two partial indexes on
+// comms_message. An index is only an access path: a wrong-but-narrower predicate
+// or a wrong column order ships green through the query-correctness suite (the
+// planner just declines to use the index). So this test reads Postgres's own
+// deterministic indexdef reconstruction and asserts the EXACT key-column list
+// (order-sensitive) and the EXACT set of partial-predicate conjuncts
+// (order-insensitive but rejecting any extra/missing conjunct). It READS only
+// the catalog, so it runs against the shared package DB — no isolated clone.
+
+// usingKeyColumns parses the key-column list out of a pg_indexes.indexdef string
+// (the "(col, col, ...)" that follows "USING <method>"). Returns the columns
+// trimmed, in index order.
+func usingKeyColumns(t *testing.T, def string) []string {
+	t.Helper()
+	m := regexp.MustCompile(`USING \w+ \(([^)]+)\)`).FindStringSubmatch(def)
+	require.Lenf(t, m, 2, "could not parse key columns from indexdef: %s", def)
+	parts := strings.Split(m[1], ",")
+	cols := make([]string, len(parts))
+	for i, p := range parts {
+		cols[i] = strings.TrimSpace(p)
+	}
+	return cols
+}
+
+// predicateConjuncts parses the partial WHERE predicate out of an indexdef and
+// returns its flat list of conjuncts, normalized. Postgres renders partial
+// predicates with per-clause parens, e.g.
+//
+//	WHERE ((processed_at IS NULL) AND (claimed_at IS NULL) AND (deleted_at IS NULL))
+//
+// so we lowercase, strip ALL parens (the predicate is a flat conjunction with no
+// grouping that changes meaning), collapse whitespace, then split on " and ".
+// The caller compares the result as a set, which rejects any extra or missing
+// conjunct (e.g. a stray "source = 'gchat'" or the redundant
+// "matched_contact_id IS NOT NULL" that the migration deliberately omits).
+func predicateConjuncts(t *testing.T, def string) []string {
+	t.Helper()
+	parts := strings.SplitN(def, " WHERE ", 2)
+	require.Lenf(t, parts, 2, "indexdef has no WHERE clause (expected a partial index): %s", def)
+	pred := strings.ToLower(parts[1])
+	pred = strings.NewReplacer("(", " ", ")", " ").Replace(pred)
+	pred = strings.Join(strings.Fields(pred), " ") // collapse whitespace
+	conj := strings.Split(pred, " and ")
+	for i := range conj {
+		conj[i] = strings.TrimSpace(conj[i])
+	}
+	return conj
+}
+
+func TestCommsMessageEligibleIndexes_Definitions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	database, ctx := graphTestDB(t)
+	support := repository.NewSyntheticSupportRepository(database.Queries)
+
+	defs, err := support.ListCommsIndexDefs(ctx)
+	require.NoError(t, err)
+
+	cases := []struct {
+		name string
+		cols []string // exact key columns, in order
+		pred []string // exact set of normalized predicate conjuncts
+	}{
+		{
+			name: "idx_comms_message_unprocessed_eligible",
+			cols: []string{"source", "matched_contact_id", "sent_at"},
+			pred: []string{"processed_at is null", "claimed_at is null", "deleted_at is null"},
+		},
+		{
+			name: "idx_comms_message_stale_claim",
+			cols: []string{"source", "matched_contact_id", "claimed_at"},
+			pred: []string{"processed_at is null", "claimed_at is not null", "deleted_at is null"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			def, ok := defs[tc.name]
+			require.Truef(t, ok, "index %s not found on comms_message; have %v", tc.name, indexNames(defs))
+
+			// Key columns: exact list AND order — a wrong/missing/extra/reordered
+			// column fails.
+			assert.Equal(t, tc.cols, usingKeyColumns(t, def), "key columns (order-sensitive)")
+
+			// Partial predicate: exact set of conjuncts — any extra (e.g. a
+			// source restriction or the omitted matched_contact_id IS NOT NULL),
+			// missing, or altered conjunct fails. ElementsMatch is exact set
+			// membership, not substring.
+			assert.ElementsMatch(t, tc.pred, predicateConjuncts(t, def), "partial predicate conjuncts (exact set)")
+		})
+	}
+}
+
+// indexNames returns the sorted index names present, for a readable failure
+// message when an expected index is missing.
+func indexNames(defs map[string]string) []string {
+	names := make([]string, 0, len(defs))
+	for name := range defs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}


### PR DESCRIPTION
## Summary

Adds **migration 073** creating two partial indexes on `comms_message`, mirroring the sibling tables' `049` pattern (`telegram_message` / `messages_message`) but with `source` promoted to the leading key since `comms_message` is multi-source. These back the eligible-row scans the messaging aggregation engine runs — most notably `ListUnprocessedCommsContactIDs`, which the gchat sweeper runs on every 5-minute tick — so the recurring scan is O(eligible rows) instead of O(all-time source history).

- `idx_comms_message_unprocessed_eligible (source, matched_contact_id, sent_at)` WHERE `processed_at IS NULL AND claimed_at IS NULL AND deleted_at IS NULL`
- `idx_comms_message_stale_claim (source, matched_contact_id, claimed_at)` WHERE `processed_at IS NULL AND claimed_at IS NOT NULL AND deleted_at IS NULL`

The planner `BitmapOr`s the pair to serve the `(claimed_at IS NULL OR claimed_at < NOW() - INTERVAL '5 minutes')` disjunction. Both stay near-empty in steady state because a row leaves the index once `processed_at` is set.

### Design notes

- **`source` leads the key** (vs. 049's `matched_contact_id`-first): every eligible query equality-filters `source = @source`, so a single seek lands on the per-source slice — matching the column order the existing dedup `(source, external_id, matched_contact_id)` and thread `(source, thread_id)` indexes already use.
- **`matched_contact_id IS NOT NULL` is omitted** from the partial predicate (049 includes it) because the column is `NOT NULL` on `comms_message` — the clause would be permanently true.
- **No production query/sqlc changes.** The indexes are transparent to query results; only the access path changes.
- **Plain `CREATE INDEX`** (not `CONCURRENTLY`), mirroring 049 and the repo convention (zero migrations use `CONCURRENTLY`). See the size-check note below for the decision gate.

## Changes

- `backend/migrations/073_comms_message_eligible_indexes.{up,down}.sql` — the two `CREATE INDEX` statements + idempotent `DROP INDEX IF EXISTS` down.
- `backend/tests/comms_message_eligible_index_test.go` — committed index-definition integration test. Asserts the **exact** key-column list (order-sensitive) and the **exact** set of normalized partial-predicate conjuncts (rejecting any extra/missing/reordered column or conjunct — e.g. a stray source restriction or the omitted `matched_contact_id IS NOT NULL`). This closes the gap the query-correctness suite cannot cover: a wrong-but-narrower predicate or wrong column order ships green there because the planner just declines to use the index.
- Test-only catalog plumbing (raw SQL stays banned in Go): `TestListIndexDefsForComms` in `queries/test.sql`, `ListCommsIndexDefs` wrapper on `SyntheticSupportRepository` (returns `map[string]string`, no generated `db.*` type leaks past the boundary), and a `pg_indexes` stub in `sqlc_schema/pg_catalog.sql` so sqlc resolves the catalog read — mirroring the existing `TestListPublicTables` / `pg_constraint` precedent.
- Generated by `make sqlc`: `test.sql.go`, `querier.go` (one new method), `models.go` (one new `PgIndex` stub model).

## Test plan

- `make sqlc` — clean regeneration (only the one test-only query added).
- `go build ./cmd/crm-api` + `./internal/repository` — compiles.
- `make lint` — 0 issues.
- `make test-integration-fast INTEGRATION_RUN='TestCommsMessageEligibleIndexes_Definitions'` — passes (both subtests). This also exercises migration 073 applying cleanly in the full migration chain (the integration harness builds a migrated template).

## Honest EXPLAIN ANALYZE activation proof

Seeded a fresh scratch DB (cloned from the migrated test template, dropped afterward) with **50,000 processed** gchat rows (excluded from both partial indexes), **50 eligible** (unclaimed), and **10 stale-claimed** rows; `ANALYZE`d; then `EXPLAIN (ANALYZE, BUFFERS)` with **no planner overrides** (no `enable_seqscan=off`) per core.md. Both real query shapes activate the indexes via the textbook `BitmapOr` plan — reading ~2-4 buffer pages instead of seq-scanning all 50,060 rows:

**Q1 — `ListUnprocessedCommsContactIDs` (source-wide DISTINCT sweep):**

```
Unique  (rows=1)
  ->  Sort
        ->  Bitmap Heap Scan on comms_message  (actual rows=60, Heap Blocks: exact=2, Buffers: shared hit=4)
              ->  BitmapOr
                    ->  Bitmap Index Scan on idx_comms_message_unprocessed_eligible  (actual rows=50)
                          Index Cond: ((source = 'gchat') AND (matched_contact_id IS NOT NULL))
                    ->  Bitmap Index Scan on idx_comms_message_stale_claim  (actual rows=10)
                          Index Cond: ((source = 'gchat') AND (matched_contact_id IS NOT NULL) AND (claimed_at < (now() - '00:05:00')))
 Execution Time: 0.037 ms
```

**Q2 — `ListUnprocessedCommsByContact` (per-contact):**

```
Sort  (Sort Key: thread_id, sent_at)
  ->  Bitmap Heap Scan on comms_message  (actual rows=60, Heap Blocks: exact=2, Buffers: shared hit=4)
        ->  BitmapOr
              ->  Bitmap Index Scan on idx_comms_message_unprocessed_eligible  (actual rows=50)
                    Index Cond: ((source = 'gchat') AND (matched_contact_id = <throwaway-contact-uuid>))
              ->  Bitmap Index Scan on idx_comms_message_stale_claim  (actual rows=10)
                    Index Cond: ((source = 'gchat') AND (matched_contact_id = <throwaway-contact-uuid>) AND (claimed_at < (now() - '00:05:00')))
 Execution Time: 0.052 ms
```

Honest caveat (per the plan + core.md): activation depends on the excluded (processed) set being large enough that a seq scan loses. At low volume a seq scan legitimately wins, and that is correct planner behavior — the proof is "the index activates once the excluded set is large," which the 50k:60 ratio above demonstrates without any planner override. (The proof used a single throwaway contact for the FK; the access-path decision turns on the excluded-set size, not contact cardinality.)

## Pre-deploy size check (lock-window sizing — run before promoting)

Plain `CREATE INDEX` takes a write-blocking `SHARE` lock and scans the full heap to evaluate each partial predicate; golang-migrate runs the file's two `CREATE INDEX`es under one transaction, so the lock spans two full-heap scans. At the expected `comms_message` size (email since Gmail go-live: tens to low-hundreds of thousands of rows) the combined stall is sub-second to a few seconds during a deploy migration — acceptable (`deploy-artifact.sh` snapshots + migrates before swapping). Size it against prod before promoting:

```
# On the Pi (rootless podman), via the documented crm-rootless prefix:
podman exec crm-postgres psql -U crm_user -d personal_crm -c \
  "SELECT count(*) AS rows, pg_size_pretty(pg_total_relation_size('comms_message')) AS size FROM comms_message;"
```

**Decision gate:** at the expected size, plain `CREATE INDEX` is correct (this PR). If the count is unexpectedly large (well into the millions, such that a multi-second write stall on ingestion is a concern), fall back to two single-statement `CREATE INDEX CONCURRENTLY` migration files — documented in the migration header and plan §3.4.

## Links

- Plan: `.ai/log/plan/comms-message-eligible-stale-indexes.md`
- Closes #454
