### PR TITLE
feat(synthetic): seed prod-shaped bio facts + text-fact spread

### DIFF
--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -1874,11 +1874,13 @@ type Querier interface {
 	// Profile coverage + determinism test support: list the LIVE (proposed/accepted)
 	// assertions whose subject node is ns-prefixed (catalog person nodes own
 	// ns-prefixed canonical_labels). The coverage check uses (predicate_key, status)
-	// to assert ≥1 accepted AND ≥1 proposed landed; the determinism check
-	// fingerprints value_text across a re-run (value_text is NULL for non-text
-	// payloads like birthday — proposition_key is NOT used because it embeds the
-	// per-run subject UUID and so is not run-stable). Deterministically ordered so
-	// the fingerprint is stable. Caller passes a BARE prefix; '%' is appended here.
+	// to assert the accepted vs proposed split; the determinism check fingerprints
+	// (value_text, value_date) across a re-run — value_text is NULL for date payloads
+	// (birthday) and value_date is NULL for text payloads, so both are projected so
+	// neither bio surface is a blind spot. proposition_key is NOT used because it
+	// embeds the per-run subject UUID and so is not run-stable. Deterministically
+	// ordered so the fingerprint is stable. Caller passes a BARE prefix; '%' is
+	// appended here.
 	SyntheticListAssertionsByNodePrefix(ctx context.Context, labelPrefix pgtype.Text) ([]*SyntheticListAssertionsByNodePrefixRow, error)
 	// Todoist replay: snapshot the set of contact_task ids for a provider so the
 	// replay can diff before/after its (globally-scoped) reconcile and track the

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -1871,6 +1871,15 @@ type Querier interface {
 	// (node.id == contact.id). Returns the live (non-soft-deleted) node row so a
 	// test can assert the dual-write created it with the expected type/label.
 	SyntheticGetNodeForContact(ctx context.Context, id pgtype.UUID) (*Node, error)
+	// Profile coverage + determinism test support: list the LIVE (proposed/accepted)
+	// assertions whose subject node is ns-prefixed (catalog person nodes own
+	// ns-prefixed canonical_labels). The coverage check uses (predicate_key, status)
+	// to assert ≥1 accepted AND ≥1 proposed landed; the determinism check
+	// fingerprints value_text across a re-run (value_text is NULL for non-text
+	// payloads like birthday — proposition_key is NOT used because it embeds the
+	// per-run subject UUID and so is not run-stable). Deterministically ordered so
+	// the fingerprint is stable. Caller passes a BARE prefix; '%' is appended here.
+	SyntheticListAssertionsByNodePrefix(ctx context.Context, labelPrefix pgtype.Text) ([]*SyntheticListAssertionsByNodePrefixRow, error)
 	// Todoist replay: snapshot the set of contact_task ids for a provider so the
 	// replay can diff before/after its (globally-scoped) reconcile and track the
 	// rows it created — even for cadence-bearing contacts it did not seed — so

--- a/backend/internal/db/queries/test.sql
+++ b/backend/internal/db/queries/test.sql
@@ -560,6 +560,22 @@ DELETE FROM node WHERE canonical_label LIKE @label_prefix || '%';
 -- the shared test DB.
 SELECT COUNT(*) FROM assertion WHERE subject_node_id = $1;
 
+-- name: SyntheticListAssertionsByNodePrefix :many
+-- Profile coverage + determinism test support: list the LIVE (proposed/accepted)
+-- assertions whose subject node is ns-prefixed (catalog person nodes own
+-- ns-prefixed canonical_labels). The coverage check uses (predicate_key, status)
+-- to assert ≥1 accepted AND ≥1 proposed landed; the determinism check
+-- fingerprints value_text across a re-run (value_text is NULL for non-text
+-- payloads like birthday — proposition_key is NOT used because it embeds the
+-- per-run subject UUID and so is not run-stable). Deterministically ordered so
+-- the fingerprint is stable. Caller passes a BARE prefix; '%' is appended here.
+SELECT a.predicate_key, a.status, a.value_text
+FROM assertion a
+JOIN node n ON a.subject_node_id = n.id
+WHERE n.canonical_label LIKE @label_prefix || '%'
+  AND a.status IN ('proposed', 'accepted')
+ORDER BY a.predicate_key, a.value_text NULLS LAST, a.status;
+
 -- name: SyntheticGetNodeForContact :one
 -- Contact→node dual-write test support: fetch the person node a contact owns
 -- (node.id == contact.id). Returns the live (non-soft-deleted) node row so a

--- a/backend/internal/db/queries/test.sql
+++ b/backend/internal/db/queries/test.sql
@@ -564,17 +564,19 @@ SELECT COUNT(*) FROM assertion WHERE subject_node_id = $1;
 -- Profile coverage + determinism test support: list the LIVE (proposed/accepted)
 -- assertions whose subject node is ns-prefixed (catalog person nodes own
 -- ns-prefixed canonical_labels). The coverage check uses (predicate_key, status)
--- to assert ≥1 accepted AND ≥1 proposed landed; the determinism check
--- fingerprints value_text across a re-run (value_text is NULL for non-text
--- payloads like birthday — proposition_key is NOT used because it embeds the
--- per-run subject UUID and so is not run-stable). Deterministically ordered so
--- the fingerprint is stable. Caller passes a BARE prefix; '%' is appended here.
-SELECT a.predicate_key, a.status, a.value_text
+-- to assert the accepted vs proposed split; the determinism check fingerprints
+-- (value_text, value_date) across a re-run — value_text is NULL for date payloads
+-- (birthday) and value_date is NULL for text payloads, so both are projected so
+-- neither bio surface is a blind spot. proposition_key is NOT used because it
+-- embeds the per-run subject UUID and so is not run-stable. Deterministically
+-- ordered so the fingerprint is stable. Caller passes a BARE prefix; '%' is
+-- appended here.
+SELECT a.predicate_key, a.status, a.value_text, a.value_date
 FROM assertion a
 JOIN node n ON a.subject_node_id = n.id
 WHERE n.canonical_label LIKE @label_prefix || '%'
   AND a.status IN ('proposed', 'accepted')
-ORDER BY a.predicate_key, a.value_text NULLS LAST, a.status;
+ORDER BY a.predicate_key, a.value_text NULLS LAST, a.value_date NULLS LAST, a.status;
 
 -- name: SyntheticGetNodeForContact :one
 -- Contact→node dual-write test support: fetch the person node a contact owns

--- a/backend/internal/db/test.sql.go
+++ b/backend/internal/db/test.sql.go
@@ -1573,6 +1573,49 @@ func (q *Queries) SyntheticGetNodeForContact(ctx context.Context, id pgtype.UUID
 	return &i, err
 }
 
+const SyntheticListAssertionsByNodePrefix = `-- name: SyntheticListAssertionsByNodePrefix :many
+SELECT a.predicate_key, a.status, a.value_text
+FROM assertion a
+JOIN node n ON a.subject_node_id = n.id
+WHERE n.canonical_label LIKE $1 || '%'
+  AND a.status IN ('proposed', 'accepted')
+ORDER BY a.predicate_key, a.value_text NULLS LAST, a.status
+`
+
+type SyntheticListAssertionsByNodePrefixRow struct {
+	PredicateKey string      `json:"predicate_key"`
+	Status       string      `json:"status"`
+	ValueText    pgtype.Text `json:"value_text"`
+}
+
+// Profile coverage + determinism test support: list the LIVE (proposed/accepted)
+// assertions whose subject node is ns-prefixed (catalog person nodes own
+// ns-prefixed canonical_labels). The coverage check uses (predicate_key, status)
+// to assert ≥1 accepted AND ≥1 proposed landed; the determinism check
+// fingerprints value_text across a re-run (value_text is NULL for non-text
+// payloads like birthday — proposition_key is NOT used because it embeds the
+// per-run subject UUID and so is not run-stable). Deterministically ordered so
+// the fingerprint is stable. Caller passes a BARE prefix; '%' is appended here.
+func (q *Queries) SyntheticListAssertionsByNodePrefix(ctx context.Context, labelPrefix pgtype.Text) ([]*SyntheticListAssertionsByNodePrefixRow, error) {
+	rows, err := q.db.Query(ctx, SyntheticListAssertionsByNodePrefix, labelPrefix)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []*SyntheticListAssertionsByNodePrefixRow{}
+	for rows.Next() {
+		var i SyntheticListAssertionsByNodePrefixRow
+		if err := rows.Scan(&i.PredicateKey, &i.Status, &i.ValueText); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const SyntheticListContactTaskIdsByProvider = `-- name: SyntheticListContactTaskIdsByProvider :many
 SELECT id FROM contact_task WHERE provider = $1
 `

--- a/backend/internal/db/test.sql.go
+++ b/backend/internal/db/test.sql.go
@@ -1574,28 +1574,31 @@ func (q *Queries) SyntheticGetNodeForContact(ctx context.Context, id pgtype.UUID
 }
 
 const SyntheticListAssertionsByNodePrefix = `-- name: SyntheticListAssertionsByNodePrefix :many
-SELECT a.predicate_key, a.status, a.value_text
+SELECT a.predicate_key, a.status, a.value_text, a.value_date
 FROM assertion a
 JOIN node n ON a.subject_node_id = n.id
 WHERE n.canonical_label LIKE $1 || '%'
   AND a.status IN ('proposed', 'accepted')
-ORDER BY a.predicate_key, a.value_text NULLS LAST, a.status
+ORDER BY a.predicate_key, a.value_text NULLS LAST, a.value_date NULLS LAST, a.status
 `
 
 type SyntheticListAssertionsByNodePrefixRow struct {
 	PredicateKey string      `json:"predicate_key"`
 	Status       string      `json:"status"`
 	ValueText    pgtype.Text `json:"value_text"`
+	ValueDate    pgtype.Date `json:"value_date"`
 }
 
 // Profile coverage + determinism test support: list the LIVE (proposed/accepted)
 // assertions whose subject node is ns-prefixed (catalog person nodes own
 // ns-prefixed canonical_labels). The coverage check uses (predicate_key, status)
-// to assert ≥1 accepted AND ≥1 proposed landed; the determinism check
-// fingerprints value_text across a re-run (value_text is NULL for non-text
-// payloads like birthday — proposition_key is NOT used because it embeds the
-// per-run subject UUID and so is not run-stable). Deterministically ordered so
-// the fingerprint is stable. Caller passes a BARE prefix; '%' is appended here.
+// to assert the accepted vs proposed split; the determinism check fingerprints
+// (value_text, value_date) across a re-run — value_text is NULL for date payloads
+// (birthday) and value_date is NULL for text payloads, so both are projected so
+// neither bio surface is a blind spot. proposition_key is NOT used because it
+// embeds the per-run subject UUID and so is not run-stable. Deterministically
+// ordered so the fingerprint is stable. Caller passes a BARE prefix; '%' is
+// appended here.
 func (q *Queries) SyntheticListAssertionsByNodePrefix(ctx context.Context, labelPrefix pgtype.Text) ([]*SyntheticListAssertionsByNodePrefixRow, error) {
 	rows, err := q.db.Query(ctx, SyntheticListAssertionsByNodePrefix, labelPrefix)
 	if err != nil {
@@ -1605,7 +1608,12 @@ func (q *Queries) SyntheticListAssertionsByNodePrefix(ctx context.Context, label
 	items := []*SyntheticListAssertionsByNodePrefixRow{}
 	for rows.Next() {
 		var i SyntheticListAssertionsByNodePrefixRow
-		if err := rows.Scan(&i.PredicateKey, &i.Status, &i.ValueText); err != nil {
+		if err := rows.Scan(
+			&i.PredicateKey,
+			&i.Status,
+			&i.ValueText,
+			&i.ValueDate,
+		); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)

--- a/backend/internal/repository/synthetic_support.go
+++ b/backend/internal/repository/synthetic_support.go
@@ -714,6 +714,36 @@ func (r *SyntheticSupportRepository) CountAssertionsForSubject(ctx context.Conte
 	return r.queries.SyntheticCountAssertionsForSubject(ctx, pgtype.UUID{Bytes: subjectNodeID, Valid: true})
 }
 
+// AssertionSummary is the status + value projection of a LIVE assertion
+// (proposed/accepted) on an ns-prefixed subject node — profile coverage +
+// determinism test only. ValueText is nil for non-text payloads (e.g. birthday).
+type AssertionSummary struct {
+	PredicateKey string
+	Status       string
+	ValueText    *string
+}
+
+// ListAssertionsByNodePrefix returns the LIVE assertions whose subject node's
+// canonical_label is ns-prefixed, so a profile test can assert the
+// accepted/proposed split and fingerprint the generated value_texts across a
+// re-run. Caller passes a BARE prefix.
+func (r *SyntheticSupportRepository) ListAssertionsByNodePrefix(ctx context.Context, prefix string) ([]AssertionSummary, error) {
+	rows, err := r.queries.SyntheticListAssertionsByNodePrefix(ctx, pgtype.Text{String: prefix, Valid: true})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]AssertionSummary, 0, len(rows))
+	for _, row := range rows {
+		s := AssertionSummary{PredicateKey: row.PredicateKey, Status: row.Status}
+		if row.ValueText.Valid {
+			v := row.ValueText.String
+			s.ValueText = &v
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}
+
 // GetNodeForContact fetches the person node a contact owns (node.id ==
 // contact.id), so a contact→node dual-write test can assert the node exists
 // with the expected type and canonical_label. Returns db.ErrNotFound when no

--- a/backend/internal/repository/synthetic_support.go
+++ b/backend/internal/repository/synthetic_support.go
@@ -716,17 +716,20 @@ func (r *SyntheticSupportRepository) CountAssertionsForSubject(ctx context.Conte
 
 // AssertionSummary is the status + value projection of a LIVE assertion
 // (proposed/accepted) on an ns-prefixed subject node — profile coverage +
-// determinism test only. ValueText is nil for non-text payloads (e.g. birthday).
+// determinism test only. Exactly one of ValueText / ValueDate is set per the
+// payload (ValueText for text facts, ValueDate "2006-01-02" for birthday); both
+// are projected so the determinism fingerprint covers text AND date bio facts.
 type AssertionSummary struct {
 	PredicateKey string
 	Status       string
 	ValueText    *string
+	ValueDate    *string
 }
 
 // ListAssertionsByNodePrefix returns the LIVE assertions whose subject node's
 // canonical_label is ns-prefixed, so a profile test can assert the
-// accepted/proposed split and fingerprint the generated value_texts across a
-// re-run. Caller passes a BARE prefix.
+// accepted/proposed split and fingerprint the generated values across a re-run.
+// Caller passes a BARE prefix.
 func (r *SyntheticSupportRepository) ListAssertionsByNodePrefix(ctx context.Context, prefix string) ([]AssertionSummary, error) {
 	rows, err := r.queries.SyntheticListAssertionsByNodePrefix(ctx, pgtype.Text{String: prefix, Valid: true})
 	if err != nil {
@@ -738,6 +741,10 @@ func (r *SyntheticSupportRepository) ListAssertionsByNodePrefix(ctx context.Cont
 		if row.ValueText.Valid {
 			v := row.ValueText.String
 			s.ValueText = &v
+		}
+		if row.ValueDate.Valid {
+			d := row.ValueDate.Time.Format("2006-01-02")
+			s.ValueDate = &d
 		}
 		out = append(out, s)
 	}

--- a/backend/internal/synthetic/factory/domain.go
+++ b/backend/internal/synthetic/factory/domain.go
@@ -47,6 +47,7 @@ type contactConfig struct {
 	overdue      bool
 	recent       bool
 	birthday     *time.Time
+	howMet       *string
 	unicodeName  bool
 	descender    bool
 }
@@ -85,6 +86,28 @@ func WithBirthday1900Sentinel(month time.Month, day int) ContactOption {
 	return func(c *contactConfig) {
 		b := time.Date(1900, month, day, 0, 0, 0, 0, time.UTC)
 		c.birthday = &b
+	}
+}
+
+// WithBirthday sets a general (real-year) birthday. The caller supplies an
+// absolute date (anchor-relative so it tracks the configured time); this is the
+// non-sentinel counterpart to WithBirthday1900Sentinel. It routes through the
+// contact-create authority flip into a `birthday` date assertion.
+func WithBirthday(t time.Time) ContactOption {
+	return func(c *contactConfig) {
+		b := t
+		c.birthday = &b
+	}
+}
+
+// WithHowMet sets the contact's how_met text. It routes through the
+// contact-create authority flip into an accepted `how_met` text assertion (the
+// ContactSpec.HowMet field the harness forwards to CreateContact). A blank
+// string is normalized away by the service, so callers pass a meaningful value.
+func WithHowMet(s string) ContactOption {
+	return func(c *contactConfig) {
+		v := s
+		c.howMet = &v
 	}
 }
 
@@ -127,6 +150,7 @@ func (g *Generator) Contact(opts ...ContactOption) ContactSpec {
 		FullName: fullName,
 		Cadence:  cfg.cadence,
 		Birthday: cfg.birthday,
+		HowMet:   cfg.howMet,
 	}
 
 	if cfg.withEmail {

--- a/backend/internal/synthetic/profiles.go
+++ b/backend/internal/synthetic/profiles.go
@@ -3,6 +3,7 @@ package synthetic
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/synthetic/factory"
@@ -51,6 +52,11 @@ type ProfileResult struct {
 	UnmatchedCalendar int
 	OrphanMeetingNote int
 	SeededAssertions  int
+	// ContactsWithBirthday / ContactsWithHowMet count the catalog contacts that
+	// carried a birthday / how_met bio fact (produced through the contact-create
+	// authority-flip path, not the Phase-4 assertion loop). Counts-only / no PII.
+	ContactsWithBirthday int
+	ContactsWithHowMet   int
 }
 
 // ProfileParams returns the default SeedParams for a named profile (error on an
@@ -89,7 +95,11 @@ func ProfileParams(name Profile) (SeedParams, error) {
 				StrandedMessages:  5,
 				UnmatchedCalendar: 7,
 				OrphanMeetingNote: 4,
-				SeededAssertions:  4,
+				// ~1/3 of 150 catalog contacts carry a bio text fact (the
+				// Phase-4 spread cycles home_address/job_title/preference/
+				// health_condition across distinct contacts). The coverage test
+				// overrides this down to a CI-safe minimum.
+				SeededAssertions: 50,
 			},
 		}, nil
 	default:
@@ -164,14 +174,25 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 	// no-method bucket). The settled per-source interactions live on the
 	// dedicated contacts below instead.
 	var firstCatalogContactID uuid.UUID
+	catalogContactIDs := make([]uuid.UUID, 0, n)
 	for i := 0; i < n; i++ {
-		opts := catalogOptionsFor(i, n)
+		opts := catalogOptionsFor(i, n, gen.Anchor(), gen.Prefix())
 		spec := gen.Contact(opts...)
 		contact, err := h.SeedContact(ctx, spec)
 		if err != nil {
 			return res, fmt.Errorf("profile %s: seed catalog contact %d: %w", params.Profile, i, err)
 		}
 		res.Contacts++
+		// Bio facts ride on the contact-create authority flip (SeedContact →
+		// CreateContact → birthday/how_met assertions); count them off the spec so
+		// the coverage check can assert the bio surfaces are populated.
+		if spec.Birthday != nil {
+			res.ContactsWithBirthday++
+		}
+		if spec.HowMet != nil {
+			res.ContactsWithHowMet++
+		}
+		catalogContactIDs = append(catalogContactIDs, contact.ID)
 		if i == 0 {
 			firstCatalogContactID = contact.ID
 		}
@@ -306,17 +327,24 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		res.OrphanMeetingNote++
 	}
 
-	// Graph (SP1) assertions on the first catalog contact's person node
+	// Graph (SP1) text-fact assertions spread across the catalog person nodes
 	// (node.id == contact.id). Seeded LAST so the generator-PRNG advancement these
 	// FactAssertion calls cause does not shift the deterministic peer-id / handle
 	// sequence the earlier source replays depend on (a mid-sequence insert would
-	// collide a "stranded" peer with a seeded contact's identity). Each
-	// FactAssertion produces a distinct value + proposition_key; preference is a
-	// multi-cardinality fact so they coexist (all accepted), giving the graph
-	// surfaces content without supersession.
-	if firstCatalogContactID != uuid.Nil {
+	// collide a "stranded" peer with a seeded contact's identity).
+	//
+	// The predicate cycle covers BOTH review surfaces (D6): home_address /
+	// job_title / preference are auto-if-confident → accepted; health_condition is
+	// always-confirm → it lands proposed/pending. health_condition leads the cycle
+	// so even a single seeded assertion exercises the pending-review surface. Each
+	// FactAssertion produces a distinct value + proposition_key, and successive
+	// assertions land on distinct contacts (i % len), so the single-cardinality
+	// predicates (home_address/job_title) never supersede a same-subject prior.
+	if len(catalogContactIDs) > 0 {
 		for i := 0; i < params.Counts.SeededAssertions; i++ {
-			if _, err := h.ReplayAssertion(ctx, firstCatalogContactID, gen.FactAssertion("preference")); err != nil {
+			subject := catalogContactIDs[i%len(catalogContactIDs)]
+			predicate := catalogTextFactPredicates[i%len(catalogTextFactPredicates)]
+			if _, err := h.ReplayAssertion(ctx, subject, gen.FactAssertion(predicate)); err != nil {
 				return res, fmt.Errorf("profile %s: replay assertion %d: %w", params.Profile, i, err)
 			}
 			res.SeededAssertions++
@@ -326,17 +354,34 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 	return res, nil
 }
 
+// catalogTextFactPredicates is the predicate cycle the Phase-4 assertion spread
+// walks. health_condition (always-confirm → proposed) leads so any non-zero
+// SeededAssertions count covers the pending-review surface; the rest are
+// auto-if-confident → accepted. All are migration-066 catalog text predicates.
+var catalogTextFactPredicates = []string{
+	"health_condition",
+	"home_address",
+	"job_title",
+	"preference",
+}
+
 // catalogOptionsFor returns the contact-builder options for catalog contact i of
 // n, deterministically spreading the edge-case shapes across the population:
 // cadence states (overdue / recent / never-contacted), the 1900 birthday
-// sentinel, a unicode name, a descender name, and a no-method contact. Catalog
-// contacts get NO settling replay, so these last_contacted states survive (a
-// MatchSeeded inbound would otherwise let the cadence updater overwrite them).
+// sentinel, a unicode name, a descender name, a no-method contact, plus a
+// fraction carrying real-year birthdays and how_met bio facts. Catalog contacts
+// get NO settling replay, so these last_contacted states survive (a MatchSeeded
+// inbound would otherwise let the cadence updater overwrite them).
+//
+// anchor is the generator's clock (real-year birthdays are anchor-relative, so
+// no time.Now()); prefix is the namespace prefix the how_met value carries so it
+// stays obviously synthetic. Neither draws from the PRNG, so the options are
+// ordering-safe in place (they only set config on the existing gen.Contact call).
 //
 // The no-method slot (i == 3) carries WithNoMethods, which overrides the email
-// default — so it must NOT also request a method. The slots are mutually
-// exclusive by i, so no contact gets both.
-func catalogOptionsFor(i, n int) []factory.ContactOption {
+// default — so it must NOT also request a method; it returns early and gets no
+// bio facts. The name edge cases (unicode/descender) are mutually exclusive by i.
+func catalogOptionsFor(i, n int, anchor time.Time, prefix string) []factory.ContactOption {
 	var opts []factory.ContactOption
 
 	// The no-method bucket: a cadence-bearing contact with NO contact_method.
@@ -369,7 +414,31 @@ func catalogOptionsFor(i, n int) []factory.ContactOption {
 	case i == 2 && n > 3:
 		opts = append(opts, factory.WithDescenderName())
 	}
+
+	// Real-year birthdays on ~1/5 of contacts (excluding i == 0, which carries the
+	// 1900 sentinel above). Anchor-relative ages 25–54, deterministic month/day.
+	if i != 0 && i%5 == 2 {
+		birthYear := anchor.Year() - (25 + i%30)
+		bday := time.Date(birthYear, time.Month(1+i%12), 1+i%28, 0, 0, 0, 0, time.UTC)
+		opts = append(opts, factory.WithBirthday(bday))
+	}
+
+	// how_met on ~1/4 of contacts (ns-prefixed synthetic text, rotated stem).
+	if i%4 == 1 {
+		stem := catalogHowMetStems[(i/4)%len(catalogHowMetStems)]
+		opts = append(opts, factory.WithHowMet(prefix+"met-"+stem))
+	}
+
 	return opts
+}
+
+// catalogHowMetStems is the small fixed pool the how_met bio fact rotates over so
+// the value repeats across contacts (prod-like) while staying deterministic.
+var catalogHowMetStems = []string{
+	"at-a-conference",
+	"through-a-mutual-friend",
+	"at-work",
+	"online-community",
 }
 
 // perSourceSettledCount bounds the per-source settled-interaction count by

--- a/backend/internal/synthetic/profiles.go
+++ b/backend/internal/synthetic/profiles.go
@@ -334,12 +334,13 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 	// collide a "stranded" peer with a seeded contact's identity).
 	//
 	// The predicate cycle covers BOTH review surfaces (D6): home_address /
-	// job_title / preference are auto-if-confident → accepted; health_condition is
-	// always-confirm → it lands proposed/pending. health_condition leads the cycle
-	// so even a single seeded assertion exercises the pending-review surface. Each
-	// FactAssertion produces a distinct value + proposition_key, and successive
-	// assertions land on distinct contacts (i % len), so the single-cardinality
-	// predicates (home_address/job_title) never supersede a same-subject prior.
+	// job_title / preference are auto-if-confident → accepted; health_condition and
+	// occurrence are always-confirm → they land proposed/pending. health_condition
+	// leads the cycle so even a single seeded assertion exercises the
+	// pending-review surface. Each FactAssertion produces a distinct value +
+	// proposition_key, and successive assertions land on distinct contacts
+	// (i % len), so the single-cardinality predicates (home_address/job_title)
+	// never supersede a same-subject prior.
 	if len(catalogContactIDs) > 0 {
 		for i := 0; i < params.Counts.SeededAssertions; i++ {
 			subject := catalogContactIDs[i%len(catalogContactIDs)]
@@ -356,13 +357,16 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 
 // catalogTextFactPredicates is the predicate cycle the Phase-4 assertion spread
 // walks. health_condition (always-confirm → proposed) leads so any non-zero
-// SeededAssertions count covers the pending-review surface; the rest are
-// auto-if-confident → accepted. All are migration-066 catalog text predicates.
+// SeededAssertions count covers the pending-review surface; home_address /
+// job_title / preference are auto-if-confident → accepted; occurrence is also
+// always-confirm → proposed (seeded without a valid_from in PR1; the dated
+// valid_from is a later PR). All are migration-066 catalog text predicates.
 var catalogTextFactPredicates = []string{
 	"health_condition",
 	"home_address",
 	"job_title",
 	"preference",
+	"occurrence",
 }
 
 // catalogOptionsFor returns the contact-builder options for catalog contact i of

--- a/backend/internal/synthetic/profiles_test.go
+++ b/backend/internal/synthetic/profiles_test.go
@@ -69,6 +69,9 @@ func TestProfileParams(t *testing.T) {
 	require.Greater(t, prod.Counts.StrandedMessages, 0)
 	require.Greater(t, prod.Counts.UnmatchedCalendar, 0)
 	require.Greater(t, prod.Counts.OrphanMeetingNote, 0)
+	// prod-shaped seeds a prod-shaped slice of text-fact assertions (~1/3 of the
+	// catalog); the coverage check overrides this down for CI.
+	require.Greater(t, prod.Counts.SeededAssertions, 0)
 }
 
 // TestDefaultParamsUnchanged pins DefaultParams field-for-field so the
@@ -86,4 +89,5 @@ func TestDefaultParamsUnchanged(t *testing.T) {
 	require.Equal(t, 0, p.Counts.StrandedMessages)
 	require.Equal(t, 0, p.Counts.UnmatchedCalendar)
 	require.Equal(t, 0, p.Counts.OrphanMeetingNote)
+	require.Equal(t, 0, p.Counts.SeededAssertions)
 }

--- a/backend/internal/synthetic/replay/harness_setup.go
+++ b/backend/internal/synthetic/replay/harness_setup.go
@@ -52,7 +52,7 @@ func NewHarness(t *testing.T, ctx context.Context, database *db.Database) *Harne
 // Gate B == 0). The namespace defaults to a stable token derived from the
 // current time so concurrent harnesses do not collide.
 func NewHarnessWithDB(ctx context.Context, database *db.Database) (*Harness, func(context.Context) error, error) {
-	return newHarness(ctx, database, defaultNamespace(), factory.DefaultSeed)
+	return newHarness(ctx, database, defaultNamespace(), factory.DefaultSeed, accelerated.GetCurrentTime())
 }
 
 // NewHarnessWithDBForNamespace builds a harness without a *testing.T for an
@@ -64,7 +64,18 @@ func NewHarnessWithDB(ctx context.Context, database *db.Database) (*Harness, fun
 // so the stable namespace is used verbatim. Returns the harness + the quiesce/
 // conditional-cleanup teardown closure + an error.
 func NewHarnessWithDBForNamespace(ctx context.Context, database *db.Database, namespace string, seed uint64) (*Harness, func(context.Context) error, error) {
-	return newHarness(ctx, database, namespace, seed)
+	return newHarness(ctx, database, namespace, seed, accelerated.GetCurrentTime())
+}
+
+// NewHarnessWithDBForNamespaceAt is NewHarnessWithDBForNamespace with an EXPLICIT
+// generator anchor instead of the live accelerated clock. A determinism test
+// pins the anchor so two runs at the same (namespace, seed) produce byte-
+// identical TIMESTAMPED output too (last_contacted, birthday date) — not just the
+// non-timestamp identifiers — per the factory's anchor-relative determinism
+// contract (NewGeneratorAt). Production seed paths use the live-anchor
+// constructor above.
+func NewHarnessWithDBForNamespaceAt(ctx context.Context, database *db.Database, namespace string, seed uint64, anchor time.Time) (*Harness, func(context.Context) error, error) {
+	return newHarness(ctx, database, namespace, seed, anchor)
 }
 
 // NewHarnessForNamespace builds a harness with an explicit namespace + seed.
@@ -72,7 +83,7 @@ func NewHarnessWithDBForNamespace(ctx context.Context, database *db.Database, na
 // reuse cannot collide.
 func NewHarnessForNamespace(t *testing.T, ctx context.Context, database *db.Database, namespace string, seed uint64) *Harness {
 	t.Helper()
-	h, teardown, err := newHarness(ctx, database, namespace, seed)
+	h, teardown, err := newHarness(ctx, database, namespace, seed, accelerated.GetCurrentTime())
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		if err := teardown(context.Background()); err != nil {
@@ -102,7 +113,7 @@ func ValidateNamespace(namespace string) error {
 	return nil
 }
 
-func newHarness(ctx context.Context, database *db.Database, namespace string, seed uint64) (*Harness, func(context.Context) error, error) {
+func newHarness(ctx context.Context, database *db.Database, namespace string, seed uint64, anchor time.Time) (*Harness, func(context.Context) error, error) {
 	// Reject namespaces with characters outside the safe charset. Cleanup deletes
 	// by `LIKE 'synth-<ns>-%'`, so a namespace containing a LIKE metacharacter
 	// (`_` or `%`) would over-match and could wipe another namespace's rows;
@@ -145,7 +156,7 @@ func newHarness(ctx context.Context, database *db.Database, namespace string, se
 	// re-salt the namespace if its telegram peer sub-block is already occupied by
 	// a different namespace's live rows. Probabilistically disjoint, with this
 	// detection it is "disjoint + detected at setup," not a hard guarantee.
-	gen, namespace, err := resolveNamespace(ctx, support, namespace, seed)
+	gen, namespace, err := resolveNamespace(ctx, support, namespace, seed, anchor)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -353,10 +364,10 @@ const bandResaltAttempts = 8
 // lives — the primary cross-match origin) AND external_identity (where a replay
 // later mints the identity). The practical guarantee is "probabilistically
 // disjoint + detected at setup," not a hard mathematical guarantee.
-func resolveNamespace(ctx context.Context, support *repository.SyntheticSupportRepository, namespace string, seed uint64) (*factory.Generator, string, error) {
+func resolveNamespace(ctx context.Context, support *repository.SyntheticSupportRepository, namespace string, seed uint64, anchor time.Time) (*factory.Generator, string, error) {
 	candidate := namespace
 	for attempt := 0; attempt < bandResaltAttempts; attempt++ {
-		gen := factory.NewGenerator(seed, candidate)
+		gen := factory.NewGeneratorAt(seed, candidate, anchor)
 		peerOccupied, err := support.CountTelegramMessagesInPeerBand(ctx, gen.PeerBandStart(), gen.PeerBandEnd())
 		if err != nil {
 			return nil, "", fmt.Errorf("peer-band collision check: %w", err)

--- a/backend/internal/synthetic/synthetic.go
+++ b/backend/internal/synthetic/synthetic.go
@@ -79,7 +79,7 @@ type Counts struct {
 	StrandedMessages  int // stranded messages_message (iMessage) rows
 	UnmatchedCalendar int // calendar_event rows with an unmatched attendee
 	OrphanMeetingNote int // orphan_needs_review meeting_note rows
-	SeededAssertions  int // graph (SP1) fact assertions seeded on the first contact node
+	SeededAssertions  int // graph (SP1) text-fact assertions spread across catalog contact nodes
 }
 
 // SeedParams is the profile/volume seam consumed by the seed orchestration.

--- a/backend/internal/synthetic/synthetic.go
+++ b/backend/internal/synthetic/synthetic.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/synthetic/factory"
@@ -66,6 +67,14 @@ func NewHarnessWithDB(ctx context.Context, database *db.Database) (*Harness, fun
 // calls the returned teardown closure (stop client + clean the partial world).
 func NewHarnessWithDBForNamespace(ctx context.Context, database *db.Database, namespace string, seed uint64) (*Harness, func(context.Context) error, error) {
 	return replay.NewHarnessWithDBForNamespace(ctx, database, namespace, seed)
+}
+
+// NewHarnessWithDBForNamespaceAt is NewHarnessWithDBForNamespace with an EXPLICIT
+// generator anchor (instead of the live accelerated clock), so a determinism test
+// can pin the anchor and get byte-identical TIMESTAMPED output across two runs at
+// the same namespace + seed. Re-exported for the profile determinism check.
+func NewHarnessWithDBForNamespaceAt(ctx context.Context, database *db.Database, namespace string, seed uint64, anchor time.Time) (*Harness, func(context.Context) error, error) {
+	return replay.NewHarnessWithDBForNamespaceAt(ctx, database, namespace, seed, anchor)
 }
 
 // Counts tunes the per-entity volume a profile produces. The per-profile

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -86,6 +86,10 @@ func TestSyntheticProfile_DevCoversCatalog(t *testing.T) {
 	require.Equal(t, params.Counts.OrphanMeetingNote, res.OrphanMeetingNote)
 	require.Equal(t, params.Counts.SeededAssertions, res.SeededAssertions)
 	require.Equal(t, 2, res.SeededAssertions, "dev profile seeds graph assertions")
+	// Bio facts (birthday / how_met) ride on the contact-create authority flip,
+	// spread by catalog index; the dev catalog is large enough to carry ≥1 of each.
+	require.GreaterOrEqual(t, res.ContactsWithBirthday, 1, "dev profile seeds birthday bio facts")
+	require.GreaterOrEqual(t, res.ContactsWithHowMet, 1, "dev profile seeds how_met bio facts")
 
 	remaining, err := h.ContactsRemaining(ctx)
 	require.NoError(t, err)
@@ -112,6 +116,10 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 	params.Counts.StrandedMessages = 1
 	params.Counts.UnmatchedCalendar = 1
 	params.Counts.OrphanMeetingNote = 1
+	// 4 assertions walk the full text-fact predicate cycle once (CI-safe), so the
+	// always-confirm predicate (health_condition → proposed) is exercised
+	// alongside the accepted predicates.
+	params.Counts.SeededAssertions = 4
 
 	h := synthetic.NewHarnessForNamespace(t, ctx, database, params.Namespace, params.Seed)
 	res, err := synthetic.RunProfile(ctx, h, params)
@@ -170,9 +178,81 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 	require.GreaterOrEqual(t, neverContacted, 1, "≥1 cadence-bearing never-contacted contact (NULL last_contacted survived)")
 	require.GreaterOrEqual(t, noMethod, 1, "≥1 no-method contact (the no-method bucket exists)")
 
+	// Bio facts (item 4 how_met + item 5 real-year birthdays) ride on the
+	// contact-create authority flip; the catalog carries ≥1 of each.
+	require.GreaterOrEqual(t, res.ContactsWithBirthday, 1, "≥1 contact with a birthday bio fact")
+	require.GreaterOrEqual(t, res.ContactsWithHowMet, 1, "≥1 contact with a how_met bio fact")
+
+	// Accept/pending coverage (D6): the text-fact spread must populate BOTH the
+	// accepted-knowledge surface (home_address/job_title/preference + the
+	// how_met/birthday contact-path facts) AND the pending-review surface
+	// (health_condition is always-confirm → proposed). Scoped to the namespace.
+	assertions, err := support.ListAssertionsByNodePrefix(ctx, h.Generator().Prefix())
+	require.NoError(t, err)
+	var accepted, proposed int
+	for _, a := range assertions {
+		switch a.Status {
+		case repository.AssertionStatusAccepted:
+			accepted++
+		case repository.AssertionStatusProposed:
+			proposed++
+		}
+	}
+	require.GreaterOrEqual(t, accepted, 1, "≥1 accepted assertion (accepted-knowledge surface)")
+	require.GreaterOrEqual(t, proposed, 1, "≥1 proposed assertion (pending-review surface; health_condition)")
+
 	remaining, err := h.ContactsRemaining(ctx)
 	require.NoError(t, err)
 	require.Greater(t, remaining, int64(0), "prod-shaped profile seeds contacts")
+}
+
+// TestSyntheticProfile_ProdShapedDeterministic proves the prod-shaped seed is
+// deterministic: two runs at the same (namespace, seed) produce byte-identical
+// ProfileResult counts AND an identical fingerprint of the generated assertion
+// value_texts. Count-pinning alone is insufficient — counts can match while a
+// non-deterministic source (map iteration, wall-clock leak) shifts generated
+// identifiers — so the value_text fingerprint is the drift detector. Both runs
+// share the SAME namespace (with a full teardown between) so the ns-prefix and
+// PRNG stream line up; value_text (NOT proposition_key, which embeds the per-run
+// subject UUID) is the run-stable identifier the fingerprint reads.
+func TestSyntheticProfile_ProdShapedDeterministic(t *testing.T) {
+	testsupport.RequireLongTests(t)
+	database, ctx := newSyntheticDB(t)
+
+	params, err := synthetic.ProfileParams(synthetic.ProfileProdShaped)
+	require.NoError(t, err)
+	params.Namespace = syntheticNS(t)
+	// Bound the volume for CI: determinism is a property of the orchestration, not
+	// of the scale.
+	params.Counts.SeededContacts = 4
+	params.Counts.SeededAssertions = 4
+	params.Counts.UnmatchedExternal = 1
+	params.Counts.StrandedTelegram = 1
+	params.Counts.StrandedMessages = 1
+	params.Counts.UnmatchedCalendar = 1
+	params.Counts.OrphanMeetingNote = 1
+
+	support := repository.NewSyntheticSupportRepository(database.Queries)
+
+	// run seeds the profile, captures (ProfileResult, assertion fingerprint), then
+	// fully tears down so the next run starts from a clean namespace.
+	run := func() (synthetic.ProfileResult, []repository.AssertionSummary) {
+		h, teardown, err := synthetic.NewHarnessWithDBForNamespace(ctx, database, params.Namespace, params.Seed)
+		require.NoError(t, err)
+		res, err := synthetic.RunProfile(ctx, h, params)
+		require.NoError(t, err)
+		fp, err := support.ListAssertionsByNodePrefix(ctx, h.Generator().Prefix())
+		require.NoError(t, err)
+		require.NoError(t, teardown(context.Background()))
+		return res, fp
+	}
+
+	res1, fp1 := run()
+	res2, fp2 := run()
+
+	require.Equal(t, res1, res2, "prod-shaped ProfileResult must be deterministic across runs")
+	require.NotEmpty(t, fp1, "the seed must produce assertions to fingerprint")
+	require.Equal(t, fp1, fp2, "assertion value_text fingerprint must be deterministic across runs")
 }
 
 // TestSyntheticProfile_QuiesceLeavesRows proves the seed-and-leave lifecycle:

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"context"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -184,25 +185,37 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 	require.GreaterOrEqual(t, res.ContactsWithBirthday, 1, "≥1 contact with a birthday bio fact")
 	require.GreaterOrEqual(t, res.ContactsWithHowMet, 1, "≥1 contact with a how_met bio fact")
 
-	// Accept/pending coverage (D6): assert the SPECIFIC review-policy outcomes, not
-	// merely that some assertion of each status exists — health_condition
-	// (always-confirm) must land PROPOSED (pending-review surface) and an
-	// auto-if-confident text predicate (home_address/job_title/preference) must
-	// land ACCEPTED (accepted-knowledge surface). Scoped to the namespace.
+	// Accept/pending coverage (D6) + full text-fact spread: assert the SPECIFIC
+	// (predicate, review-policy) outcome for EVERY predicate in the Phase-4 cycle,
+	// not merely that some assertion of each status exists — so a predicate
+	// silently dropping out of the spread (e.g. occurrence) or no longer landing
+	// its expected status is caught. health_condition + occurrence (always-confirm)
+	// land PROPOSED (pending-review surface); home_address / job_title / preference
+	// (auto-if-confident) land ACCEPTED (accepted-knowledge surface). Scoped to the
+	// namespace.
 	assertions, err := support.ListAssertionsByNodePrefix(ctx, h.Generator().Prefix())
 	require.NoError(t, err)
-	acceptedTextPredicates := map[string]bool{"home_address": true, "job_title": true, "preference": true}
-	var healthProposed, textAccepted bool
+	seen := make(map[string]bool) // "<predicate>/<status>"
+	var realYearBirthday bool
 	for _, a := range assertions {
-		if a.PredicateKey == "health_condition" && a.Status == repository.AssertionStatusProposed {
-			healthProposed = true
-		}
-		if acceptedTextPredicates[a.PredicateKey] && a.Status == repository.AssertionStatusAccepted {
-			textAccepted = true
+		seen[a.PredicateKey+"/"+a.Status] = true
+		// item 5: a real-year birthday from the spread must exist, not just the
+		// 1900 month/day-only sentinel (which alone would satisfy
+		// ContactsWithBirthday even if the real-year spread regressed).
+		if a.PredicateKey == "birthday" && a.ValueDate != nil && !strings.HasPrefix(*a.ValueDate, "1900-") {
+			realYearBirthday = true
 		}
 	}
-	require.True(t, healthProposed, "health_condition (always-confirm) lands proposed (pending-review surface)")
-	require.True(t, textAccepted, "an auto-if-confident text predicate lands accepted (accepted-knowledge surface)")
+	for _, want := range []string{
+		"health_condition/" + repository.AssertionStatusProposed,
+		"occurrence/" + repository.AssertionStatusProposed,
+		"home_address/" + repository.AssertionStatusAccepted,
+		"job_title/" + repository.AssertionStatusAccepted,
+		"preference/" + repository.AssertionStatusAccepted,
+	} {
+		require.True(t, seen[want], "Phase-4 text-fact spread must land %s", want)
+	}
+	require.True(t, realYearBirthday, "≥1 real-year (non-1900-sentinel) birthday from the spread")
 
 	remaining, err := h.ContactsRemaining(ctx)
 	require.NoError(t, err)

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -116,10 +116,11 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 	params.Counts.StrandedMessages = 1
 	params.Counts.UnmatchedCalendar = 1
 	params.Counts.OrphanMeetingNote = 1
-	// 4 assertions walk the full text-fact predicate cycle once (CI-safe), so the
-	// always-confirm predicate (health_condition → proposed) is exercised
-	// alongside the accepted predicates.
-	params.Counts.SeededAssertions = 4
+	// 5 assertions walk the full text-fact predicate cycle once (CI-safe), so every
+	// predicate — incl. the always-confirm ones (health_condition, occurrence →
+	// proposed) and the accepted ones (home_address/job_title/preference) — is
+	// exercised.
+	params.Counts.SeededAssertions = 5
 
 	h := synthetic.NewHarnessForNamespace(t, ctx, database, params.Namespace, params.Seed)
 	res, err := synthetic.RunProfile(ctx, h, params)
@@ -183,23 +184,25 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 	require.GreaterOrEqual(t, res.ContactsWithBirthday, 1, "≥1 contact with a birthday bio fact")
 	require.GreaterOrEqual(t, res.ContactsWithHowMet, 1, "≥1 contact with a how_met bio fact")
 
-	// Accept/pending coverage (D6): the text-fact spread must populate BOTH the
-	// accepted-knowledge surface (home_address/job_title/preference + the
-	// how_met/birthday contact-path facts) AND the pending-review surface
-	// (health_condition is always-confirm → proposed). Scoped to the namespace.
+	// Accept/pending coverage (D6): assert the SPECIFIC review-policy outcomes, not
+	// merely that some assertion of each status exists — health_condition
+	// (always-confirm) must land PROPOSED (pending-review surface) and an
+	// auto-if-confident text predicate (home_address/job_title/preference) must
+	// land ACCEPTED (accepted-knowledge surface). Scoped to the namespace.
 	assertions, err := support.ListAssertionsByNodePrefix(ctx, h.Generator().Prefix())
 	require.NoError(t, err)
-	var accepted, proposed int
+	acceptedTextPredicates := map[string]bool{"home_address": true, "job_title": true, "preference": true}
+	var healthProposed, textAccepted bool
 	for _, a := range assertions {
-		switch a.Status {
-		case repository.AssertionStatusAccepted:
-			accepted++
-		case repository.AssertionStatusProposed:
-			proposed++
+		if a.PredicateKey == "health_condition" && a.Status == repository.AssertionStatusProposed {
+			healthProposed = true
+		}
+		if acceptedTextPredicates[a.PredicateKey] && a.Status == repository.AssertionStatusAccepted {
+			textAccepted = true
 		}
 	}
-	require.GreaterOrEqual(t, accepted, 1, "≥1 accepted assertion (accepted-knowledge surface)")
-	require.GreaterOrEqual(t, proposed, 1, "≥1 proposed assertion (pending-review surface; health_condition)")
+	require.True(t, healthProposed, "health_condition (always-confirm) lands proposed (pending-review surface)")
+	require.True(t, textAccepted, "an auto-if-confident text predicate lands accepted (accepted-knowledge surface)")
 
 	remaining, err := h.ContactsRemaining(ctx)
 	require.NoError(t, err)
@@ -207,14 +210,17 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 }
 
 // TestSyntheticProfile_ProdShapedDeterministic proves the prod-shaped seed is
-// deterministic: two runs at the same (namespace, seed) produce byte-identical
-// ProfileResult counts AND an identical fingerprint of the generated assertion
-// value_texts. Count-pinning alone is insufficient — counts can match while a
-// non-deterministic source (map iteration, wall-clock leak) shifts generated
-// identifiers — so the value_text fingerprint is the drift detector. Both runs
-// share the SAME namespace (with a full teardown between) so the ns-prefix and
-// PRNG stream line up; value_text (NOT proposition_key, which embeds the per-run
-// subject UUID) is the run-stable identifier the fingerprint reads.
+// deterministic: two runs at the same (namespace, seed, anchor) produce
+// byte-identical ProfileResult counts AND an identical fingerprint of the
+// generated assertion values. Count-pinning alone is insufficient — counts can
+// match while a non-deterministic source (map iteration, wall-clock leak) shifts
+// generated values — so the (value_text, value_date) fingerprint is the drift
+// detector. Both runs share the SAME namespace (with a full teardown between) so
+// the ns-prefix + PRNG stream line up, AND a PINNED generator anchor so the
+// anchor-relative timestamps (birthday date) are byte-identical too — without the
+// pin, birthday value_date would legitimately drift between runs (anchor-relative
+// per the factory contract) and could not be fingerprinted. proposition_key is
+// NOT fingerprinted (it embeds the per-run subject UUID, so it is not run-stable).
 func TestSyntheticProfile_ProdShapedDeterministic(t *testing.T) {
 	testsupport.RequireLongTests(t)
 	database, ctx := newSyntheticDB(t)
@@ -223,21 +229,28 @@ func TestSyntheticProfile_ProdShapedDeterministic(t *testing.T) {
 	require.NoError(t, err)
 	params.Namespace = syntheticNS(t)
 	// Bound the volume for CI: determinism is a property of the orchestration, not
-	// of the scale.
-	params.Counts.SeededContacts = 4
-	params.Counts.SeededAssertions = 4
+	// of the scale. 5 assertions walk the full predicate cycle.
+	params.Counts.SeededContacts = 5
+	params.Counts.SeededAssertions = 5
 	params.Counts.UnmatchedExternal = 1
 	params.Counts.StrandedTelegram = 1
 	params.Counts.StrandedMessages = 1
 	params.Counts.UnmatchedCalendar = 1
 	params.Counts.OrphanMeetingNote = 1
 
+	// Capture the generator anchor ONCE and reuse it for both runs: identical
+	// across runs (so timestamped output incl. birthday value_date is
+	// byte-identical and the fingerprint covers it) yet ≈now so the settle
+	// pipeline — which runs on the real system clock — is not skewed by a far-past
+	// anchor (a far-past anchor starves Gate A: the consumers never link the
+	// stale-dated messages within the real-time budget).
+	anchor := accelerated.GetCurrentTime()
 	support := repository.NewSyntheticSupportRepository(database.Queries)
 
 	// run seeds the profile, captures (ProfileResult, assertion fingerprint), then
 	// fully tears down so the next run starts from a clean namespace.
 	run := func() (synthetic.ProfileResult, []repository.AssertionSummary) {
-		h, teardown, err := synthetic.NewHarnessWithDBForNamespace(ctx, database, params.Namespace, params.Seed)
+		h, teardown, err := synthetic.NewHarnessWithDBForNamespaceAt(ctx, database, params.Namespace, params.Seed, anchor)
 		require.NoError(t, err)
 		res, err := synthetic.RunProfile(ctx, h, params)
 		require.NoError(t, err)
@@ -252,7 +265,7 @@ func TestSyntheticProfile_ProdShapedDeterministic(t *testing.T) {
 
 	require.Equal(t, res1, res2, "prod-shaped ProfileResult must be deterministic across runs")
 	require.NotEmpty(t, fp1, "the seed must produce assertions to fingerprint")
-	require.Equal(t, fp1, fp2, "assertion value_text fingerprint must be deterministic across runs")
+	require.Equal(t, fp1, fp2, "assertion (value_text, value_date) fingerprint must be deterministic across runs")
 }
 
 // TestSyntheticProfile_QuiesceLeavesRows proves the seed-and-leave lifecycle:


### PR DESCRIPTION
## Summary

PR1 of the 8-PR synthetic seed enrichment (plan: `.ai/log/plan/seed-enrichment-prodshaped.md`). Enriches the `prod-shaped` profile so `crm-admin --reset-and-seed --profile prod-shaped` produces contacts with bio facts and a realistic spread of knowledge assertions, exercising the SP1 graph model.

## Changes

- **Factory:** `WithBirthday` (real-year) + `WithHowMet` ContactOptions, applied to a deterministic fraction of catalog contacts. Birthday/how_met flow through the contact-create assertion path (birthday date-fact, how_met text-fact); the existing 1900 month/day-only sentinel is kept as an edge case.
- **Profiles:** the Phase-4 text-fact assertion loop is spread across five predicates covering both review surfaces — `health_condition` + `occurrence` land *proposed* (always-confirm policy); `home_address`/`job_title`/`preference` land *accepted*.
- **Tests:** test-only `SyntheticListAssertionsByNodePrefix` query + a fixed-anchor harness constructor backing a determinism re-run check (identical `ProfileResult` + value_text/value_date fingerprint); tightened coverage assertions (per-`(predicate, status)` pair plus a real-year birthday).

## Verification

- `go build ./...`, `make lint` (0 issues), `make sqlc` clean.
- Full `TestSyntheticProfile` LONG_TESTS green (DevCoversCatalog, ProdShapedCoverageCheck, ProdShapedDeterministic).
- Codex review converged PASS (round-1 FAIL: 2×P1 → fixed → round-2 PASS); `/review-head` PASS (P0=0, P1=0). One non-blocking P2 (a test-only query missing a `deleted_at` filter — inert until soft-deletes exist) is deferred to PR7; P3s noted in the plan.

PRNG ordering preserved (new generator-driven rows seeded last). No production query or schema changes.