### PR TITLE
feat(synthetic): seed cadence tasks via ReplayTodoist + task-state coverage

### DIFF
--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -1663,6 +1663,13 @@ type Querier interface {
 	// rows whose normalized value shares the namespace's phone prefix. Caller passes
 	// a BARE prefix; '%' is appended here.
 	SyntheticCountContactMethodsByValueNormalizedPrefix(ctx context.Context, valueNormalizedPrefix pgtype.Text) (int64, error)
+	// Profile coverage test only: count contact_task rows in a given state whose
+	// contact's full_name is ns-prefixed, so the prod-shaped coverage check can assert
+	// each surface state (managed/unmanaged/completed/dismissed) has ≥1 representative
+	// scoped to its own namespace on the shared test DB. contact_task has no
+	// deleted_at; the contact soft-delete filter scopes to live catalog contacts.
+	// Caller passes a BARE prefix; '%' appended.
+	SyntheticCountContactTasksByStateAndNamePrefix(ctx context.Context, arg SyntheticCountContactTasksByStateAndNamePrefixParams) (int64, error)
 	// Contact→node dual-write test support: count contacts with an exact full_name
 	// (namespace-prefixed names are unique per test), so a rollback test asserts a
 	// failed-tx contact did not survive without paging the whole contact list.

--- a/backend/internal/db/queries/test.sql
+++ b/backend/internal/db/queries/test.sql
@@ -307,6 +307,20 @@ SELECT id FROM contact_task WHERE provider = @provider;
 -- created (the before/after diff from SyntheticListContactTaskIdsByProvider).
 DELETE FROM contact_task WHERE id = ANY(@task_ids::uuid[]);
 
+-- name: SyntheticCountContactTasksByStateAndNamePrefix :one
+-- Profile coverage test only: count contact_task rows in a given state whose
+-- contact's full_name is ns-prefixed, so the prod-shaped coverage check can assert
+-- each surface state (managed/unmanaged/completed/dismissed) has ≥1 representative
+-- scoped to its own namespace on the shared test DB. contact_task has no
+-- deleted_at; the contact soft-delete filter scopes to live catalog contacts.
+-- Caller passes a BARE prefix; '%' appended.
+SELECT COUNT(*)
+FROM contact_task ct
+JOIN contact c ON ct.contact_id = c.id
+WHERE c.full_name LIKE @name_prefix || '%'
+  AND ct.state = @state
+  AND c.deleted_at IS NULL;
+
 -- name: SyntheticDeleteContactMethodsByContactIds :execrows
 -- Cleanup step 11: contact_method by contact.
 DELETE FROM contact_method WHERE contact_id = ANY(@contact_ids::uuid[]);

--- a/backend/internal/db/test.sql.go
+++ b/backend/internal/db/test.sql.go
@@ -783,6 +783,33 @@ func (q *Queries) SyntheticCountContactMethodsByValueNormalizedPrefix(ctx contex
 	return count, err
 }
 
+const SyntheticCountContactTasksByStateAndNamePrefix = `-- name: SyntheticCountContactTasksByStateAndNamePrefix :one
+SELECT COUNT(*)
+FROM contact_task ct
+JOIN contact c ON ct.contact_id = c.id
+WHERE c.full_name LIKE $1 || '%'
+  AND ct.state = $2
+  AND c.deleted_at IS NULL
+`
+
+type SyntheticCountContactTasksByStateAndNamePrefixParams struct {
+	NamePrefix pgtype.Text `json:"name_prefix"`
+	State      string      `json:"state"`
+}
+
+// Profile coverage test only: count contact_task rows in a given state whose
+// contact's full_name is ns-prefixed, so the prod-shaped coverage check can assert
+// each surface state (managed/unmanaged/completed/dismissed) has ≥1 representative
+// scoped to its own namespace on the shared test DB. contact_task has no
+// deleted_at; the contact soft-delete filter scopes to live catalog contacts.
+// Caller passes a BARE prefix; '%' appended.
+func (q *Queries) SyntheticCountContactTasksByStateAndNamePrefix(ctx context.Context, arg SyntheticCountContactTasksByStateAndNamePrefixParams) (int64, error) {
+	row := q.db.QueryRow(ctx, SyntheticCountContactTasksByStateAndNamePrefix, arg.NamePrefix, arg.State)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const SyntheticCountContactsByFullName = `-- name: SyntheticCountContactsByFullName :one
 SELECT COUNT(*) FROM contact WHERE full_name = $1 AND deleted_at IS NULL
 `

--- a/backend/internal/repository/synthetic_support.go
+++ b/backend/internal/repository/synthetic_support.go
@@ -264,6 +264,18 @@ func (r *SyntheticSupportRepository) DeleteContactTasksByIds(ctx context.Context
 	return r.queries.SyntheticDeleteContactTasksByIds(ctx, pgUUIDs(taskIDs))
 }
 
+// CountContactTasksByStateAndNamePrefix counts contact_task rows in a given state
+// whose contact's full_name is ns-prefixed, so the prod-shaped coverage test can
+// assert each surface state (managed/unmanaged/completed/dismissed) has ≥1
+// representative scoped to its own namespace on the shared test DB. Caller passes
+// a BARE prefix.
+func (r *SyntheticSupportRepository) CountContactTasksByStateAndNamePrefix(ctx context.Context, state, namePrefix string) (int64, error) {
+	return r.queries.SyntheticCountContactTasksByStateAndNamePrefix(ctx, db.SyntheticCountContactTasksByStateAndNamePrefixParams{
+		NamePrefix: pgtype.Text{String: namePrefix, Valid: true},
+		State:      state,
+	})
+}
+
 // DeleteContactMethodsByContactIds removes contact_method rows by contact
 // (cleanup step 11).
 func (r *SyntheticSupportRepository) DeleteContactMethodsByContactIds(ctx context.Context, contactIDs []uuid.UUID) (int64, error) {

--- a/backend/internal/synthetic/profiles.go
+++ b/backend/internal/synthetic/profiles.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/synthetic/factory"
 
 	"github.com/google/uuid"
@@ -57,6 +58,12 @@ type ProfileResult struct {
 	// authority-flip path, not the Phase-4 assertion loop). Counts-only / no PII.
 	ContactsWithBirthday int
 	ContactsWithHowMet   int
+	// SeededTasks counts the contact_task rows the profile seeded — one `managed`
+	// cadence task per cadence-bearing catalog contact (via ReplayTodoist's
+	// reconcile), a deterministic three of which are then transitioned to the
+	// completed/dismissed/unmanaged surface states. The state-transitions do not
+	// change the row count, so this is the total cadence-task population.
+	SeededTasks int
 }
 
 // ProfileParams returns the default SeedParams for a named profile (error on an
@@ -81,6 +88,10 @@ func ProfileParams(name Profile) (SeedParams, error) {
 				UnmatchedCalendar: 1,
 				OrphanMeetingNote: 1,
 				SeededAssertions:  2,
+				// Enable cadence-task seeding (>0 gate). The dev catalog is all
+				// cadence-bearing, so reconcile creates a managed task on each and
+				// three are transitioned for surface coverage.
+				SeededTasks: 1,
 			},
 		}, nil
 	case ProfileProdShaped:
@@ -100,6 +111,11 @@ func ProfileParams(name Profile) (SeedParams, error) {
 				// health_condition across distinct contacts). The coverage test
 				// overrides this down to a CI-safe minimum.
 				SeededAssertions: 50,
+				// Enable cadence-task seeding (>0 gate). The prod-shaped catalog is
+				// all cadence-bearing, so reconcile creates a managed cadence task on
+				// each (catalog-wide, like prod) and three are transitioned to the
+				// completed/dismissed/unmanaged surface states.
+				SeededTasks: 1,
 			},
 		}, nil
 	default:
@@ -175,6 +191,12 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 	// dedicated contacts below instead.
 	var firstCatalogContactID uuid.UUID
 	catalogContactIDs := make([]uuid.UUID, 0, n)
+	// cadenceBearingCatalogIDs is the subset whose spec carries a cadence —
+	// CreateContact auto-computes contact_by from cadence, making them eligible for
+	// ReplayTodoist's reconcile (which seeds one `managed` cadence task per such
+	// contact). Tracked off the spec rather than assumed so a future catalog change
+	// that drops cadence from a slot is reflected in res.SeededTasks.
+	cadenceBearingCatalogIDs := make([]uuid.UUID, 0, n)
 	for i := 0; i < n; i++ {
 		opts := catalogOptionsFor(i, n, gen.Anchor(), gen.Prefix())
 		spec := gen.Contact(opts...)
@@ -193,6 +215,9 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 			res.ContactsWithHowMet++
 		}
 		catalogContactIDs = append(catalogContactIDs, contact.ID)
+		if spec.Cadence != nil && *spec.Cadence != "" {
+			cadenceBearingCatalogIDs = append(cadenceBearingCatalogIDs, contact.ID)
+		}
 		if i == 0 {
 			firstCatalogContactID = contact.ID
 		}
@@ -352,7 +377,48 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		}
 	}
 
+	// Cadence tasks (Todoist) on the cadence-bearing catalog contacts. ReplayTodoist
+	// drives the REAL CadenceSyncProvider reconcile, which reads
+	// ListContactsWithContactBy (contact_by auto-computed from cadence by
+	// CreateContact) and creates one `managed` cadence-due task per cadence-bearing
+	// contact — the live cadence-task state. It draws NO generator PRNG (it only
+	// READS the seeded contacts), so it runs after the gen.X() assertion spread above
+	// without shifting the deterministic id sequence the earlier replays depend on.
+	//
+	// The empty fake-Todoist sync produces only `managed` rows, so the remaining
+	// surface states are seeded by transitioning a deterministic three of the
+	// just-created tasks via the production UpdateContactTaskState path:
+	// completed / dismissed / unmanaged. pending_remote_create (a transient
+	// create-in-flight state) is out of scope.
+	if params.Counts.SeededTasks > 0 && len(cadenceBearingCatalogIDs) > 0 {
+		if _, err := h.ReplayTodoist(ctx, cadenceBearingCatalogIDs); err != nil {
+			return res, fmt.Errorf("profile %s: replay todoist: %w", params.Profile, err)
+		}
+		// Each transition flips one managed task's state; the row count is unchanged,
+		// so res.SeededTasks (the cadence-bearing population) still reflects every row.
+		for idx, state := range nonManagedTaskStates {
+			if idx >= len(cadenceBearingCatalogIDs) {
+				break
+			}
+			if _, err := h.TransitionTodoistCadenceTaskState(ctx, cadenceBearingCatalogIDs[idx], state); err != nil {
+				return res, fmt.Errorf("profile %s: transition cadence task %d: %w", params.Profile, idx, err)
+			}
+		}
+		res.SeededTasks = len(cadenceBearingCatalogIDs)
+	}
+
 	return res, nil
+}
+
+// nonManagedTaskStates is the deterministic spread of non-`managed` contact_task
+// surface states the profile transitions cadence tasks into (one each), so staging
+// shows every state the cadence-task UI renders. `managed` is the reconcile
+// default (the remaining, un-transitioned tasks); pending_remote_create is a
+// transient create-in-flight state and is out of scope.
+var nonManagedTaskStates = []repository.ContactTaskState{
+	repository.ContactTaskStateCompleted,
+	repository.ContactTaskStateDismissed,
+	repository.ContactTaskStateUnmanaged,
 }
 
 // catalogTextFactPredicates is the predicate cycle the Phase-4 assertion spread

--- a/backend/internal/synthetic/profiles_test.go
+++ b/backend/internal/synthetic/profiles_test.go
@@ -72,6 +72,9 @@ func TestProfileParams(t *testing.T) {
 	// prod-shaped seeds a prod-shaped slice of text-fact assertions (~1/3 of the
 	// catalog); the coverage check overrides this down for CI.
 	require.Greater(t, prod.Counts.SeededAssertions, 0)
+	// prod-shaped enables cadence-task seeding (>0 gate) so the coverage check has
+	// contact_task rows to assert per-state.
+	require.Greater(t, prod.Counts.SeededTasks, 0)
 }
 
 // TestDefaultParamsUnchanged pins DefaultParams field-for-field so the
@@ -90,4 +93,5 @@ func TestDefaultParamsUnchanged(t *testing.T) {
 	require.Equal(t, 0, p.Counts.UnmatchedCalendar)
 	require.Equal(t, 0, p.Counts.OrphanMeetingNote)
 	require.Equal(t, 0, p.Counts.SeededAssertions)
+	require.Equal(t, 0, p.Counts.SeededTasks)
 }

--- a/backend/internal/synthetic/replay/todoist.go
+++ b/backend/internal/synthetic/replay/todoist.go
@@ -158,3 +158,25 @@ func (h *Harness) ReplayTodoist(ctx context.Context, contactIDs []uuid.UUID) (To
 	}
 	return TodoistResult{ContactIDs: contactIDs}, nil
 }
+
+// TransitionTodoistCadenceTaskState fetches the seeded contact's managed Todoist
+// cadence-due task (created by ReplayTodoist's reconcile) and transitions it to
+// the target state via the production UpdateContactTaskState path, returning the
+// task id. The prod-shaped profile uses it to cover the non-managed contact_task
+// surface states (completed/dismissed/unmanaged) that the empty fake-Todoist sync
+// never produces — reconcile alone creates only `managed` rows. The task id is
+// already in the cleanup ledger (ReplayTodoist tracked it), so no extra tracking
+// is needed. Errors (rather than no-ops) if the contact has no cadence-due Todoist
+// task, so a mis-wired seed fails loudly.
+func (h *Harness) TransitionTodoistCadenceTaskState(ctx context.Context, contactID uuid.UUID, state repository.ContactTaskState) (uuid.UUID, error) {
+	taskRepo := repository.NewContactTaskRepository(h.database.Queries)
+	task, err := taskRepo.GetContactTaskByContactCadenceDue(ctx, contactID, todoist.SourceName)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("get cadence-due task for contact %s: %w", contactID, err)
+	}
+	updated, err := taskRepo.UpdateContactTaskState(ctx, task.ID, state)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("transition contact_task %s to %s: %w", task.ID, state, err)
+	}
+	return updated.ID, nil
+}

--- a/backend/internal/synthetic/synthetic.go
+++ b/backend/internal/synthetic/synthetic.go
@@ -89,6 +89,13 @@ type Counts struct {
 	UnmatchedCalendar int // calendar_event rows with an unmatched attendee
 	OrphanMeetingNote int // orphan_needs_review meeting_note rows
 	SeededAssertions  int // graph (SP1) text-fact assertions spread across catalog contact nodes
+	// SeededTasks is a >0 GATE (not a hard cap) for Todoist cadence-task seeding:
+	// when non-zero the profile runs ReplayTodoist, whose reconcile creates one
+	// `managed` cadence task per cadence-bearing catalog contact (catalog-wide, like
+	// prod), then transitions a deterministic three to completed/dismissed/unmanaged
+	// for surface coverage. ProfileResult.SeededTasks reports the actual rows. 0
+	// disables (minimal-scoped stays task-free / byte-stable).
+	SeededTasks int
 }
 
 // SeedParams is the profile/volume seam consumed by the seed orchestration.

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -91,6 +91,10 @@ func TestSyntheticProfile_DevCoversCatalog(t *testing.T) {
 	// spread by catalog index; the dev catalog is large enough to carry ≥1 of each.
 	require.GreaterOrEqual(t, res.ContactsWithBirthday, 1, "dev profile seeds birthday bio facts")
 	require.GreaterOrEqual(t, res.ContactsWithHowMet, 1, "dev profile seeds how_met bio facts")
+	// Cadence tasks: the dev catalog is cadence-bearing, so ReplayTodoist seeds a
+	// managed task per contact (res.SeededTasks is the actual rows, a catalog-wide
+	// count, not the >0 gate value in Counts.SeededTasks).
+	require.GreaterOrEqual(t, res.SeededTasks, 1, "dev profile seeds cadence tasks")
 
 	remaining, err := h.ContactsRemaining(ctx)
 	require.NoError(t, err)
@@ -122,6 +126,10 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 	// proposed) and the accepted ones (home_address/job_title/preference) — is
 	// exercised.
 	params.Counts.SeededAssertions = 5
+	// Enable cadence-task seeding (>0 gate). The 9-contact catalog is all
+	// cadence-bearing, so reconcile creates 9 `managed` tasks and three are
+	// transitioned to completed/dismissed/unmanaged — every surface state present.
+	params.Counts.SeededTasks = 1
 
 	h := synthetic.NewHarnessForNamespace(t, ctx, database, params.Namespace, params.Seed)
 	res, err := synthetic.RunProfile(ctx, h, params)
@@ -216,6 +224,25 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 		require.True(t, seen[want], "Phase-4 text-fact spread must land %s", want)
 	}
 	require.True(t, realYearBirthday, "≥1 real-year (non-1900-sentinel) birthday from the spread")
+
+	// Cadence tasks: ReplayTodoist seeds a `managed` cadence task on each
+	// cadence-bearing catalog contact, and the profile transitions a deterministic
+	// three to completed/dismissed/unmanaged. Assert ≥1 row in EACH state the seed
+	// produces (namespace-scoped), so every cadence-task surface the staging UI
+	// renders has content. pending_remote_create is out of scope (a transient
+	// create-in-flight state the seed does not produce).
+	require.GreaterOrEqual(t, res.SeededTasks, 1, "cadence tasks seeded")
+	prefix := h.Generator().Prefix()
+	for _, state := range []repository.ContactTaskState{
+		repository.ContactTaskStateManaged,
+		repository.ContactTaskStateUnmanaged,
+		repository.ContactTaskStateCompleted,
+		repository.ContactTaskStateDismissed,
+	} {
+		count, err := support.CountContactTasksByStateAndNamePrefix(ctx, string(state), prefix)
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, count, int64(1), "≥1 contact_task in state %q", state)
+	}
 
 	remaining, err := h.ContactsRemaining(ctx)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

PR2 of the 8-PR synthetic seed enrichment (plan: `.ai/log/plan/seed-enrichment-prodshaped.md`). Wires the existing `ReplayTodoist` adapter into `runCatalogProfile` so the prod-shaped/dev seeds populate `contact_task` rows, exercising the cadence-task surface.

## Changes

- **Profiles:** `ReplayTodoist` reconcile creates one `managed` cadence task per cadence-bearing catalog contact (catalog-wide, like prod — not capped). A deterministic three contacts (`[0]/[1]/[2]`) are then transitioned to `completed`/`dismissed`/`unmanaged` via the production `UpdateContactTaskState` path for per-state surface coverage.
- **Knob:** new `SeededTasks` field on `Counts`/`ProfileResult` (a `>0` gate; reconcile stays catalog-wide).
- **Test infra:** a `TransitionTodoistCadenceTaskState` harness method and a test-only namespace-scoped per-state count query (`SyntheticCountContactTasksByStateAndNamePrefix`) backing the coverage assertions.

## Verification

- `go build ./...`, `go vet`, `make lint` (0), `make sqlc` clean.
- Full `TestSyntheticProfile` LONG_TESTS green — ProdShapedCoverageCheck asserts `managed`/`unmanaged`/`completed`/`dismissed` each ≥1; ProdShapedDeterministic runs `ReplayTodoist` twice; plus the existing ReplayTodoist cross-namespace regression tests.
- Codex review PASS (P0=0, P1=0); `/review-head` PASS (P0=0, P1=0). Non-blocking P2/P3 notes (count-wording, an undocumented catalog-size invariant, and a pre-existing ReplayTodoist cleanup-ledger delta) tracked as follow-up R8 in the plan.

PRNG-last ordering preserved (`ReplayTodoist` draws no PRNG and runs after the generator-driven phases). Branched off `develop` after PR1 (#557).