### PR TITLE
feat(synthetic): seed bool/date facts + person→person edges

### DIFF
--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -1882,12 +1882,14 @@ type Querier interface {
 	// assertions whose subject node is ns-prefixed (catalog person nodes own
 	// ns-prefixed canonical_labels). The coverage check uses (predicate_key, status)
 	// to assert the accepted vs proposed split; the determinism check fingerprints
-	// (value_text, value_date) across a re-run — value_text is NULL for date payloads
-	// (birthday) and value_date is NULL for text payloads, so both are projected so
-	// neither bio surface is a blind spot. proposition_key is NOT used because it
-	// embeds the per-run subject UUID and so is not run-stable. Deterministically
-	// ordered so the fingerprint is stable. Caller passes a BARE prefix; '%' is
-	// appended here.
+	// (value_text, value_date, value_bool) across a re-run — exactly one value column
+	// is set per fact (text → value_text, birthday → value_date, bool facts →
+	// value_bool) and edges set none, so all three are projected so no value-type
+	// surface is a blind spot. The object node id (and proposition_key) are NOT used
+	// because they embed the per-run subject/object UUID and so are not run-stable;
+	// an edge therefore contributes only (predicate_key, status) to the fingerprint.
+	// Deterministically ordered so the fingerprint is stable. Caller passes a BARE
+	// prefix; '%' is appended here.
 	SyntheticListAssertionsByNodePrefix(ctx context.Context, labelPrefix pgtype.Text) ([]*SyntheticListAssertionsByNodePrefixRow, error)
 	// Todoist replay: snapshot the set of contact_task ids for a provider so the
 	// replay can diff before/after its (globally-scoped) reconcile and track the

--- a/backend/internal/db/queries/test.sql
+++ b/backend/internal/db/queries/test.sql
@@ -579,18 +579,20 @@ SELECT COUNT(*) FROM assertion WHERE subject_node_id = $1;
 -- assertions whose subject node is ns-prefixed (catalog person nodes own
 -- ns-prefixed canonical_labels). The coverage check uses (predicate_key, status)
 -- to assert the accepted vs proposed split; the determinism check fingerprints
--- (value_text, value_date) across a re-run — value_text is NULL for date payloads
--- (birthday) and value_date is NULL for text payloads, so both are projected so
--- neither bio surface is a blind spot. proposition_key is NOT used because it
--- embeds the per-run subject UUID and so is not run-stable. Deterministically
--- ordered so the fingerprint is stable. Caller passes a BARE prefix; '%' is
--- appended here.
-SELECT a.predicate_key, a.status, a.value_text, a.value_date
+-- (value_text, value_date, value_bool) across a re-run — exactly one value column
+-- is set per fact (text → value_text, birthday → value_date, bool facts →
+-- value_bool) and edges set none, so all three are projected so no value-type
+-- surface is a blind spot. The object node id (and proposition_key) are NOT used
+-- because they embed the per-run subject/object UUID and so are not run-stable;
+-- an edge therefore contributes only (predicate_key, status) to the fingerprint.
+-- Deterministically ordered so the fingerprint is stable. Caller passes a BARE
+-- prefix; '%' is appended here.
+SELECT a.predicate_key, a.status, a.value_text, a.value_date, a.value_bool
 FROM assertion a
 JOIN node n ON a.subject_node_id = n.id
 WHERE n.canonical_label LIKE @label_prefix || '%'
   AND a.status IN ('proposed', 'accepted')
-ORDER BY a.predicate_key, a.value_text NULLS LAST, a.value_date NULLS LAST, a.status;
+ORDER BY a.predicate_key, a.value_text NULLS LAST, a.value_date NULLS LAST, a.value_bool NULLS LAST, a.status;
 
 -- name: SyntheticGetNodeForContact :one
 -- Contact→node dual-write test support: fetch the person node a contact owns

--- a/backend/internal/db/test.sql.go
+++ b/backend/internal/db/test.sql.go
@@ -1601,12 +1601,12 @@ func (q *Queries) SyntheticGetNodeForContact(ctx context.Context, id pgtype.UUID
 }
 
 const SyntheticListAssertionsByNodePrefix = `-- name: SyntheticListAssertionsByNodePrefix :many
-SELECT a.predicate_key, a.status, a.value_text, a.value_date
+SELECT a.predicate_key, a.status, a.value_text, a.value_date, a.value_bool
 FROM assertion a
 JOIN node n ON a.subject_node_id = n.id
 WHERE n.canonical_label LIKE $1 || '%'
   AND a.status IN ('proposed', 'accepted')
-ORDER BY a.predicate_key, a.value_text NULLS LAST, a.value_date NULLS LAST, a.status
+ORDER BY a.predicate_key, a.value_text NULLS LAST, a.value_date NULLS LAST, a.value_bool NULLS LAST, a.status
 `
 
 type SyntheticListAssertionsByNodePrefixRow struct {
@@ -1614,18 +1614,21 @@ type SyntheticListAssertionsByNodePrefixRow struct {
 	Status       string      `json:"status"`
 	ValueText    pgtype.Text `json:"value_text"`
 	ValueDate    pgtype.Date `json:"value_date"`
+	ValueBool    pgtype.Bool `json:"value_bool"`
 }
 
 // Profile coverage + determinism test support: list the LIVE (proposed/accepted)
 // assertions whose subject node is ns-prefixed (catalog person nodes own
 // ns-prefixed canonical_labels). The coverage check uses (predicate_key, status)
 // to assert the accepted vs proposed split; the determinism check fingerprints
-// (value_text, value_date) across a re-run — value_text is NULL for date payloads
-// (birthday) and value_date is NULL for text payloads, so both are projected so
-// neither bio surface is a blind spot. proposition_key is NOT used because it
-// embeds the per-run subject UUID and so is not run-stable. Deterministically
-// ordered so the fingerprint is stable. Caller passes a BARE prefix; '%' is
-// appended here.
+// (value_text, value_date, value_bool) across a re-run — exactly one value column
+// is set per fact (text → value_text, birthday → value_date, bool facts →
+// value_bool) and edges set none, so all three are projected so no value-type
+// surface is a blind spot. The object node id (and proposition_key) are NOT used
+// because they embed the per-run subject/object UUID and so are not run-stable;
+// an edge therefore contributes only (predicate_key, status) to the fingerprint.
+// Deterministically ordered so the fingerprint is stable. Caller passes a BARE
+// prefix; '%' is appended here.
 func (q *Queries) SyntheticListAssertionsByNodePrefix(ctx context.Context, labelPrefix pgtype.Text) ([]*SyntheticListAssertionsByNodePrefixRow, error) {
 	rows, err := q.db.Query(ctx, SyntheticListAssertionsByNodePrefix, labelPrefix)
 	if err != nil {
@@ -1640,6 +1643,7 @@ func (q *Queries) SyntheticListAssertionsByNodePrefix(ctx context.Context, label
 			&i.Status,
 			&i.ValueText,
 			&i.ValueDate,
+			&i.ValueBool,
 		); err != nil {
 			return nil, err
 		}

--- a/backend/internal/repository/synthetic_support.go
+++ b/backend/internal/repository/synthetic_support.go
@@ -728,14 +728,16 @@ func (r *SyntheticSupportRepository) CountAssertionsForSubject(ctx context.Conte
 
 // AssertionSummary is the status + value projection of a LIVE assertion
 // (proposed/accepted) on an ns-prefixed subject node — profile coverage +
-// determinism test only. Exactly one of ValueText / ValueDate is set per the
-// payload (ValueText for text facts, ValueDate "2006-01-02" for birthday); both
-// are projected so the determinism fingerprint covers text AND date bio facts.
+// determinism test only. At most one value carrier is set per the payload
+// (ValueText for text facts, ValueDate "2006-01-02" for birthday, ValueBool for
+// bool facts); an edge sets none. All three are projected so the determinism
+// fingerprint covers every value-type surface.
 type AssertionSummary struct {
 	PredicateKey string
 	Status       string
 	ValueText    *string
 	ValueDate    *string
+	ValueBool    *bool
 }
 
 // ListAssertionsByNodePrefix returns the LIVE assertions whose subject node's
@@ -757,6 +759,10 @@ func (r *SyntheticSupportRepository) ListAssertionsByNodePrefix(ctx context.Cont
 		if row.ValueDate.Valid {
 			d := row.ValueDate.Time.Format("2006-01-02")
 			s.ValueDate = &d
+		}
+		if row.ValueBool.Valid {
+			b := row.ValueBool.Bool
+			s.ValueBool = &b
 		}
 		out = append(out, s)
 	}

--- a/backend/internal/synthetic/factory/domain.go
+++ b/backend/internal/synthetic/factory/domain.go
@@ -3,6 +3,8 @@ package factory
 import (
 	"fmt"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 // MethodSpec is a synthetic contact_method description. The replay harness maps
@@ -266,17 +268,24 @@ func (g *Generator) Venue(source, kind string) VenueSpec {
 	}
 }
 
-// AssertionSpec is a synthetic fact-assertion description. The caller supplies
-// the SubjectNodeID and PredicateKey when persisting (the factory does not know
-// the subject's id or which catalog predicate to use). ValueText and
+// AssertionSpec is a synthetic fact/edge-assertion description. The caller
+// supplies the SubjectNodeID and PredicateKey when persisting (the factory does
+// not know the subject's id or which catalog predicate to use). ValueText and
 // PropositionKey are namespace-prefixed so a test scopes its reads to its own
 // namespace on the shared DB; Confidence/Salience are sensible defaults the test
-// may override. The write LOGIC (the real proposition_key derivation) is a later
-// layer — this spec is for the repository round-trip tests that insert via the
-// repository directly.
+// may override.
+//
+// Exactly one value carrier is set per the predicate's kind (ReplayAssertion
+// routes whichever is non-nil onto AssertRequest): ObjectNodeID for an edge
+// predicate (person→person, etc.); ValueBool / ValueDate for a bool / date fact;
+// otherwise ValueText for a text fact. A non-nil ObjectNodeID takes precedence
+// (edges carry no scalar), then ValueBool, then ValueDate, then ValueText.
 type AssertionSpec struct {
 	PredicateKey   string
 	ValueText      string
+	ValueBool      *bool
+	ValueDate      *time.Time
+	ObjectNodeID   *uuid.UUID
 	Confidence     int16
 	Salience       int16
 	PropositionKey string
@@ -296,4 +305,50 @@ func (g *Generator) FactAssertion(predicateKey string) AssertionSpec {
 		Salience:       50,
 		PropositionKey: fmt.Sprintf("%sprop-%s-%d", g.Prefix(), predicateKey, g.sourceIDSeq),
 	}
+}
+
+// valueCarrierSpec is the shared base for the value-carrier AssertionSpecs (bool
+// / date facts + edges). They have NO text value, so unlike FactAssertion they
+// draw NO name PRNG — only the monotonic sourceIDSeq for a distinct proposition_key.
+// That makes them strictly ordering-safe to append after the name-drawing
+// generators (they cannot shift the name/handle stream), but they still bump
+// sourceIDSeq, so callers seed them LAST per the profile ordering rule.
+func (g *Generator) valueCarrierSpec(predicateKey string) AssertionSpec {
+	g.sourceIDSeq++
+	return AssertionSpec{
+		PredicateKey:   predicateKey,
+		Confidence:     80,
+		Salience:       50,
+		PropositionKey: fmt.Sprintf("%sprop-%s-%d", g.Prefix(), predicateKey, g.sourceIDSeq),
+	}
+}
+
+// BoolFact builds a deterministic bool-fact AssertionSpec (e.g. job_seeking /
+// on_sabbatical / traveling) carrying ValueBool. Draws no name PRNG.
+func (g *Generator) BoolFact(predicateKey string, value bool) AssertionSpec {
+	spec := g.valueCarrierSpec(predicateKey)
+	v := value
+	spec.ValueBool = &v
+	return spec
+}
+
+// DateFact builds a deterministic date-fact AssertionSpec (e.g. birthday)
+// carrying ValueDate, asserted DIRECTLY through the assert write path (distinct
+// from the contact-create authority-flip birthday path). Draws no name PRNG.
+func (g *Generator) DateFact(predicateKey string, value time.Time) AssertionSpec {
+	spec := g.valueCarrierSpec(predicateKey)
+	d := value
+	spec.ValueDate = &d
+	return spec
+}
+
+// EdgeAssertion builds a deterministic edge AssertionSpec for the given edge
+// predicate (e.g. knows / introduced_by / sibling_of) pointing at an
+// already-seeded object node. Carries ObjectNodeID and NO scalar value (the
+// assert validator rejects an edge with any scalar). Draws no name PRNG.
+func (g *Generator) EdgeAssertion(predicateKey string, objectNodeID uuid.UUID) AssertionSpec {
+	spec := g.valueCarrierSpec(predicateKey)
+	id := objectNodeID
+	spec.ObjectNodeID = &id
+	return spec
 }

--- a/backend/internal/synthetic/profiles.go
+++ b/backend/internal/synthetic/profiles.go
@@ -64,6 +64,14 @@ type ProfileResult struct {
 	// completed/dismissed/unmanaged surface states. The state-transitions do not
 	// change the row count, so this is the total cadence-task population.
 	SeededTasks int
+	// SeededBoolFacts / SeededRelationships / SeededDateFacts count the graph rows
+	// the value-type + edge plumbing seeded: bool facts (job_seeking etc.) on
+	// catalog person nodes, person→person edge assertions among catalog person
+	// nodes, and the single toolkit-authored date fact (a birthday asserted
+	// directly through the assert path). Counts-only / no PII.
+	SeededBoolFacts     int
+	SeededRelationships int
+	SeededDateFacts     int
 }
 
 // ProfileParams returns the default SeedParams for a named profile (error on an
@@ -88,6 +96,11 @@ func ProfileParams(name Profile) (SeedParams, error) {
 				UnmatchedCalendar: 1,
 				OrphanMeetingNote: 1,
 				SeededAssertions:  2,
+				// Bool facts + person→person edges (small, fast) so the dev graph
+				// surfaces have content. Both exercise the value-type/edge assert
+				// plumbing; the bool-fact gate also seeds one toolkit date fact.
+				SeededBoolFacts:     2,
+				SeededRelationships: 2,
 				// Enable cadence-task seeding (>0 gate). The dev catalog is all
 				// cadence-bearing, so reconcile creates a managed task on each and
 				// three are transitioned for surface coverage.
@@ -111,6 +124,12 @@ func ProfileParams(name Profile) (SeedParams, error) {
 				// health_condition across distinct contacts). The coverage test
 				// overrides this down to a CI-safe minimum.
 				SeededAssertions: 50,
+				// Prod-shaped graph slice: ~1/10 of the catalog carry a bool fact and
+				// ~12 person→person edges connect the catalog (knows/introduced_by +
+				// a few family edges). Bounded by the catalog size at run time; the
+				// coverage + determinism tests override these down for CI.
+				SeededBoolFacts:     15,
+				SeededRelationships: 12,
 				// Enable cadence-task seeding (>0 gate). The prod-shaped catalog is
 				// all cadence-bearing, so reconcile creates a managed cadence task on
 				// each (catalog-wide, like prod) and three are transitioned to the
@@ -197,6 +216,10 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 	// contact). Tracked off the spec rather than assumed so a future catalog change
 	// that drops cadence from a slot is reflected in res.SeededTasks.
 	cadenceBearingCatalogIDs := make([]uuid.UUID, 0, n)
+	// catalogContactsWithoutBirthday is the subset that carries NO contact-path
+	// birthday, so the toolkit-authored date fact (a `birthday`, single-cardinality)
+	// can occupy a fresh slot rather than superseding a contact-create birthday.
+	catalogContactsWithoutBirthday := make([]uuid.UUID, 0, n)
 	for i := 0; i < n; i++ {
 		opts := catalogOptionsFor(i, n, gen.Anchor(), gen.Prefix())
 		spec := gen.Contact(opts...)
@@ -210,6 +233,8 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		// the coverage check can assert the bio surfaces are populated.
 		if spec.Birthday != nil {
 			res.ContactsWithBirthday++
+		} else {
+			catalogContactsWithoutBirthday = append(catalogContactsWithoutBirthday, contact.ID)
 		}
 		if spec.HowMet != nil {
 			res.ContactsWithHowMet++
@@ -377,6 +402,69 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		}
 	}
 
+	// Graph (SP1) value-type + edge assertions. These ride the SAME "seeded LAST"
+	// rule as the text-fact spread above: the gen.BoolFact / gen.DateFact /
+	// gen.EdgeAssertion constructors bump the generator's sourceIDSeq, so they run
+	// AFTER the source replays whose ids depend on the sequence. (They draw NO name
+	// PRNG — only sourceIDSeq — so they cannot shift the name/handle stream; the §6
+	// determinism fingerprint guards any drift regardless.)
+	//
+	// Bool facts (job_seeking/on_sabbatical/traveling) on distinct catalog person
+	// nodes — all auto-if-confident → accepted. Bounded by the catalog size so a
+	// distinct subject per fact keeps the single-cardinality bool predicates from
+	// superseding one another.
+	boolFacts := params.Counts.SeededBoolFacts
+	if boolFacts > len(catalogContactIDs) {
+		boolFacts = len(catalogContactIDs)
+	}
+	for i := 0; i < boolFacts; i++ {
+		subject := catalogContactIDs[i]
+		predicate := catalogBoolFactPredicates[i%len(catalogBoolFactPredicates)]
+		if _, err := h.ReplayAssertion(ctx, subject, gen.BoolFact(predicate, true)); err != nil {
+			return res, fmt.Errorf("profile %s: replay bool fact %d: %w", params.Profile, i, err)
+		}
+		res.SeededBoolFacts++
+	}
+
+	// One toolkit-authored date fact (a `birthday`) asserted DIRECTLY through the
+	// assert path (distinct from the contact-create authority-flip birthday path),
+	// to exercise the new ValueDate plumbing end-to-end. Seeded on a catalog
+	// contact that carries no contact-path birthday so it occupies a fresh
+	// single-cardinality slot. Gated with the bool facts (both demonstrate the new
+	// value-type routing). Anchor-relative so no time.Now().
+	if boolFacts > 0 && len(catalogContactsWithoutBirthday) > 0 {
+		bday := time.Date(gen.Anchor().Year()-40, time.April, 12, 0, 0, 0, 0, time.UTC)
+		if _, err := h.ReplayAssertion(ctx, catalogContactsWithoutBirthday[0], gen.DateFact("birthday", bday)); err != nil {
+			return res, fmt.Errorf("profile %s: replay date fact: %w", params.Profile, err)
+		}
+		res.SeededDateFacts++
+	}
+
+	// Person→person EDGE assertions among already-seeded catalog person nodes (no
+	// new entity nodes — those are a later PR). knows/introduced_by are
+	// auto-if-confident → accepted; sibling_of is always-confirm → proposed, so the
+	// spread covers BOTH review surfaces (D6). The object is the NEXT catalog
+	// contact (wrapping), so there is never a self-edge; bounded by the catalog size
+	// so each subject is distinct (the single-cardinality introduced_by never
+	// supersedes). Both endpoints are person nodes, so the existing per-node
+	// assertion teardown sweep (subject OR object) already removes them.
+	relationships := params.Counts.SeededRelationships
+	if len(catalogContactIDs) < 2 {
+		relationships = 0 // an edge needs two distinct nodes
+	}
+	if relationships > len(catalogContactIDs) {
+		relationships = len(catalogContactIDs)
+	}
+	for i := 0; i < relationships; i++ {
+		subject := catalogContactIDs[i]
+		object := catalogContactIDs[(i+1)%len(catalogContactIDs)]
+		predicate := catalogEdgePredicates[i%len(catalogEdgePredicates)]
+		if _, err := h.ReplayAssertion(ctx, subject, gen.EdgeAssertion(predicate, object)); err != nil {
+			return res, fmt.Errorf("profile %s: replay relationship %d: %w", params.Profile, i, err)
+		}
+		res.SeededRelationships++
+	}
+
 	// Cadence tasks (Todoist) on the cadence-bearing catalog contacts. ReplayTodoist
 	// drives the REAL CadenceSyncProvider reconcile, which reads
 	// ListContactsWithContactBy (contact_by auto-computed from cadence by
@@ -433,6 +521,25 @@ var catalogTextFactPredicates = []string{
 	"job_title",
 	"preference",
 	"occurrence",
+}
+
+// catalogBoolFactPredicates is the bool-fact predicate cycle the value-type
+// spread walks. All three are auto-if-confident → accepted (migration-066
+// catalog bool predicates). Asserted with value=true ("currently X").
+var catalogBoolFactPredicates = []string{
+	"job_seeking",
+	"on_sabbatical",
+	"traveling",
+}
+
+// catalogEdgePredicates is the person→person edge predicate cycle. knows and
+// introduced_by are auto-if-confident → accepted; sibling_of is always-confirm →
+// proposed, so a full cycle covers both the accepted and pending edge surfaces
+// (D6). All are migration-066 catalog person→person edge predicates.
+var catalogEdgePredicates = []string{
+	"knows",
+	"introduced_by",
+	"sibling_of",
 }
 
 // catalogOptionsFor returns the contact-builder options for catalog contact i of

--- a/backend/internal/synthetic/profiles.go
+++ b/backend/internal/synthetic/profiles.go
@@ -406,7 +406,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 	// rule as the text-fact spread above: the gen.BoolFact / gen.DateFact /
 	// gen.EdgeAssertion constructors bump the generator's sourceIDSeq, so they run
 	// AFTER the source replays whose ids depend on the sequence. (They draw NO name
-	// PRNG — only sourceIDSeq — so they cannot shift the name/handle stream; the §6
+	// PRNG — only sourceIDSeq — so they cannot shift the name/handle stream; the
 	// determinism fingerprint guards any drift regardless.)
 	//
 	// Bool facts (job_seeking/on_sabbatical/traveling) on distinct catalog person
@@ -443,10 +443,10 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 	// Person→person EDGE assertions among already-seeded catalog person nodes (no
 	// new entity nodes — those are a later PR). knows/introduced_by are
 	// auto-if-confident → accepted; sibling_of is always-confirm → proposed, so the
-	// spread covers BOTH review surfaces (D6). The object is the NEXT catalog
-	// contact (wrapping), so there is never a self-edge; bounded by the catalog size
-	// so each subject is distinct (the single-cardinality introduced_by never
-	// supersedes). Both endpoints are person nodes, so the existing per-node
+	// spread covers BOTH the accepted and pending review surfaces. The object is the
+	// NEXT catalog contact (wrapping), so there is never a self-edge; bounded by the
+	// catalog size so each subject is distinct (the single-cardinality introduced_by
+	// never supersedes). Both endpoints are person nodes, so the existing per-node
 	// assertion teardown sweep (subject OR object) already removes them.
 	relationships := params.Counts.SeededRelationships
 	if len(catalogContactIDs) < 2 {
@@ -534,8 +534,8 @@ var catalogBoolFactPredicates = []string{
 
 // catalogEdgePredicates is the person→person edge predicate cycle. knows and
 // introduced_by are auto-if-confident → accepted; sibling_of is always-confirm →
-// proposed, so a full cycle covers both the accepted and pending edge surfaces
-// (D6). All are migration-066 catalog person→person edge predicates.
+// proposed, so a full cycle covers both the accepted and pending edge surfaces.
+// All are migration-066 catalog person→person edge predicates.
 var catalogEdgePredicates = []string{
 	"knows",
 	"introduced_by",

--- a/backend/internal/synthetic/profiles_test.go
+++ b/backend/internal/synthetic/profiles_test.go
@@ -72,6 +72,10 @@ func TestProfileParams(t *testing.T) {
 	// prod-shaped seeds a prod-shaped slice of text-fact assertions (~1/3 of the
 	// catalog); the coverage check overrides this down for CI.
 	require.Greater(t, prod.Counts.SeededAssertions, 0)
+	// prod-shaped seeds bool facts + person→person edges (the value-type/edge
+	// plumbing) so the coverage check has graph rows to assert per-status.
+	require.Greater(t, prod.Counts.SeededBoolFacts, 0)
+	require.Greater(t, prod.Counts.SeededRelationships, 0)
 	// prod-shaped enables cadence-task seeding (>0 gate) so the coverage check has
 	// contact_task rows to assert per-state.
 	require.Greater(t, prod.Counts.SeededTasks, 0)
@@ -93,5 +97,7 @@ func TestDefaultParamsUnchanged(t *testing.T) {
 	require.Equal(t, 0, p.Counts.UnmatchedCalendar)
 	require.Equal(t, 0, p.Counts.OrphanMeetingNote)
 	require.Equal(t, 0, p.Counts.SeededAssertions)
+	require.Equal(t, 0, p.Counts.SeededBoolFacts)
+	require.Equal(t, 0, p.Counts.SeededRelationships)
 	require.Equal(t, 0, p.Counts.SeededTasks)
 }

--- a/backend/internal/synthetic/replay/assertion.go
+++ b/backend/internal/synthetic/replay/assertion.go
@@ -47,17 +47,33 @@ func (h *Harness) assertService() *service.AssertService {
 // RESTRICT).
 func (h *Harness) ReplayAssertion(ctx context.Context, subjectNodeID uuid.UUID, spec factory.AssertionSpec) (AssertionResult, error) {
 	svc := h.assertService()
-	value := spec.ValueText
 	req := service.AssertRequest{
 		SubjectNodeID: subjectNodeID,
 		PredicateKey:  spec.PredicateKey,
-		ValueText:     &value,
 		Confidence:    spec.Confidence,
 		Locators: []service.ProvenanceLocator{{
 			SourceKind:   repository.SourceKindUser,
 			SourceID:     spec.PropositionKey + ":user",
 			ProducerKind: repository.ProducerKindUser,
 		}},
+	}
+	// Route exactly one value carrier per the spec's kind. scalarCount counts ANY
+	// non-nil value pointer, so an edge must set object-only (no empty ValueText)
+	// and a bool/date fact must set its scalar only. ObjectNodeID wins (edges carry
+	// no scalar), then ValueBool, then ValueDate, else a text fact.
+	switch {
+	case spec.ObjectNodeID != nil:
+		obj := *spec.ObjectNodeID
+		req.ObjectNodeID = &obj
+	case spec.ValueBool != nil:
+		v := *spec.ValueBool
+		req.ValueBool = &v
+	case spec.ValueDate != nil:
+		d := *spec.ValueDate
+		req.ValueDate = &d
+	default:
+		value := spec.ValueText
+		req.ValueText = &value
 	}
 	a, err := svc.Assert(ctx, req)
 	if err != nil {

--- a/backend/internal/synthetic/synthetic.go
+++ b/backend/internal/synthetic/synthetic.go
@@ -89,6 +89,17 @@ type Counts struct {
 	UnmatchedCalendar int // calendar_event rows with an unmatched attendee
 	OrphanMeetingNote int // orphan_needs_review meeting_note rows
 	SeededAssertions  int // graph (SP1) text-fact assertions spread across catalog contact nodes
+	// SeededBoolFacts is the number of bool-fact assertions (job_seeking /
+	// on_sabbatical / traveling, all auto-if-confident → accepted) seeded across
+	// distinct catalog person nodes; bounded by the catalog size at run time. >0
+	// also gates the single toolkit-authored date fact (both exercise the new
+	// value-type assert plumbing). 0 disables.
+	SeededBoolFacts int
+	// SeededRelationships is the number of person→person EDGE assertions seeded
+	// among already-seeded catalog person nodes (knows/introduced_by → accepted,
+	// sibling_of → proposed, so the spread covers both review surfaces); bounded by
+	// the catalog size at run time. Needs ≥2 catalog contacts. 0 disables.
+	SeededRelationships int
 	// SeededTasks is a >0 GATE (not a hard cap) for Todoist cadence-task seeding:
 	// when non-zero the profile runs ReplayTodoist, whose reconcile creates one
 	// `managed` cadence task per cadence-bearing catalog contact (catalog-wide, like

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -227,8 +227,8 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 		if a.PredicateKey == "birthday" && a.ValueDate != nil && !strings.HasPrefix(*a.ValueDate, "1900-") {
 			realYearBirthday = true
 		}
-		// item 6: a bool fact must carry value_bool (proves the ValueBool plumbing
-		// routes the scalar, not just the predicate).
+		// A bool fact must carry value_bool (proves the ValueBool plumbing routes
+		// the scalar, not just the predicate).
 		if a.ValueBool != nil && *a.ValueBool {
 			boolFactTrue = true
 		}
@@ -239,11 +239,11 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 		"home_address/" + repository.AssertionStatusAccepted,
 		"job_title/" + repository.AssertionStatusAccepted,
 		"preference/" + repository.AssertionStatusAccepted,
-		// item 6 (bool facts) — all auto-if-confident → accepted.
+		// bool facts — all auto-if-confident → accepted.
 		"job_seeking/" + repository.AssertionStatusAccepted,
 		"on_sabbatical/" + repository.AssertionStatusAccepted,
 		"traveling/" + repository.AssertionStatusAccepted,
-		// item 9 (person→person edges) — knows/introduced_by accepted, sibling_of
+		// person→person edges — knows/introduced_by accepted, sibling_of
 		// (always-confirm) proposed, so BOTH edge review surfaces are present.
 		"knows/" + repository.AssertionStatusAccepted,
 		"introduced_by/" + repository.AssertionStatusAccepted,
@@ -254,8 +254,8 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 	require.True(t, realYearBirthday, "≥1 real-year (non-1900-sentinel) birthday from the spread")
 	require.True(t, boolFactTrue, "≥1 bool fact carrying value_bool=true")
 
-	// Value-type + edge result counts (item 6 bool facts + the toolkit date fact,
-	// item 9 person→person edges). The CI override seeds one full cycle of each.
+	// Value-type + edge result counts (bool facts + the toolkit date fact +
+	// person→person edges). The CI override seeds one full cycle of each.
 	require.GreaterOrEqual(t, res.SeededBoolFacts, 1, "bool facts seeded")
 	require.GreaterOrEqual(t, res.SeededRelationships, 1, "person→person edges seeded")
 	require.GreaterOrEqual(t, res.SeededDateFacts, 1, "toolkit-authored date fact seeded")
@@ -345,7 +345,7 @@ func TestSyntheticProfile_ProdShapedDeterministic(t *testing.T) {
 
 	require.Equal(t, res1, res2, "prod-shaped ProfileResult must be deterministic across runs")
 	require.NotEmpty(t, fp1, "the seed must produce assertions to fingerprint")
-	require.Equal(t, fp1, fp2, "assertion (value_text, value_date) fingerprint must be deterministic across runs")
+	require.Equal(t, fp1, fp2, "assertion (value_text, value_date, value_bool) fingerprint must be deterministic across runs")
 }
 
 // TestSyntheticProfile_QuiesceLeavesRows proves the seed-and-leave lifecycle:

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -95,6 +95,12 @@ func TestSyntheticProfile_DevCoversCatalog(t *testing.T) {
 	// managed task per contact (res.SeededTasks is the actual rows, a catalog-wide
 	// count, not the >0 gate value in Counts.SeededTasks).
 	require.GreaterOrEqual(t, res.SeededTasks, 1, "dev profile seeds cadence tasks")
+	// Value-type + edge graph rows: the dev catalog (18) far exceeds the small
+	// dev knob counts, so the seeded counts are exact (no catalog-size bounding),
+	// and the bool-fact gate produces exactly one toolkit date fact.
+	require.Equal(t, params.Counts.SeededBoolFacts, res.SeededBoolFacts, "dev profile seeds bool facts")
+	require.Equal(t, params.Counts.SeededRelationships, res.SeededRelationships, "dev profile seeds person→person edges")
+	require.Equal(t, 1, res.SeededDateFacts, "dev profile seeds one toolkit date fact")
 
 	remaining, err := h.ContactsRemaining(ctx)
 	require.NoError(t, err)
@@ -126,6 +132,13 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 	// proposed) and the accepted ones (home_address/job_title/preference) — is
 	// exercised.
 	params.Counts.SeededAssertions = 5
+	// One full bool-fact cycle (job_seeking/on_sabbatical/traveling) + one full
+	// edge cycle (knows/introduced_by/sibling_of) so every new predicate — incl.
+	// the always-confirm sibling_of (→ proposed) and the auto-if-confident rest
+	// (→ accepted) — is exercised. The bool-fact gate also seeds one toolkit date
+	// fact.
+	params.Counts.SeededBoolFacts = 3
+	params.Counts.SeededRelationships = 3
 	// Enable cadence-task seeding (>0 gate). The 9-contact catalog is all
 	// cadence-bearing, so reconcile creates 9 `managed` tasks and three are
 	// transitioned to completed/dismissed/unmanaged — every surface state present.
@@ -205,6 +218,7 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 	require.NoError(t, err)
 	seen := make(map[string]bool) // "<predicate>/<status>"
 	var realYearBirthday bool
+	var boolFactTrue bool
 	for _, a := range assertions {
 		seen[a.PredicateKey+"/"+a.Status] = true
 		// item 5: a real-year birthday from the spread must exist, not just the
@@ -213,6 +227,11 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 		if a.PredicateKey == "birthday" && a.ValueDate != nil && !strings.HasPrefix(*a.ValueDate, "1900-") {
 			realYearBirthday = true
 		}
+		// item 6: a bool fact must carry value_bool (proves the ValueBool plumbing
+		// routes the scalar, not just the predicate).
+		if a.ValueBool != nil && *a.ValueBool {
+			boolFactTrue = true
+		}
 	}
 	for _, want := range []string{
 		"health_condition/" + repository.AssertionStatusProposed,
@@ -220,10 +239,26 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 		"home_address/" + repository.AssertionStatusAccepted,
 		"job_title/" + repository.AssertionStatusAccepted,
 		"preference/" + repository.AssertionStatusAccepted,
+		// item 6 (bool facts) — all auto-if-confident → accepted.
+		"job_seeking/" + repository.AssertionStatusAccepted,
+		"on_sabbatical/" + repository.AssertionStatusAccepted,
+		"traveling/" + repository.AssertionStatusAccepted,
+		// item 9 (person→person edges) — knows/introduced_by accepted, sibling_of
+		// (always-confirm) proposed, so BOTH edge review surfaces are present.
+		"knows/" + repository.AssertionStatusAccepted,
+		"introduced_by/" + repository.AssertionStatusAccepted,
+		"sibling_of/" + repository.AssertionStatusProposed,
 	} {
-		require.True(t, seen[want], "Phase-4 text-fact spread must land %s", want)
+		require.True(t, seen[want], "graph value-type/edge spread must land %s", want)
 	}
 	require.True(t, realYearBirthday, "≥1 real-year (non-1900-sentinel) birthday from the spread")
+	require.True(t, boolFactTrue, "≥1 bool fact carrying value_bool=true")
+
+	// Value-type + edge result counts (item 6 bool facts + the toolkit date fact,
+	// item 9 person→person edges). The CI override seeds one full cycle of each.
+	require.GreaterOrEqual(t, res.SeededBoolFacts, 1, "bool facts seeded")
+	require.GreaterOrEqual(t, res.SeededRelationships, 1, "person→person edges seeded")
+	require.GreaterOrEqual(t, res.SeededDateFacts, 1, "toolkit-authored date fact seeded")
 
 	// Cadence tasks: ReplayTodoist seeds a `managed` cadence task on each
 	// cadence-bearing catalog contact, and the profile transitions a deterministic
@@ -254,13 +289,15 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 // byte-identical ProfileResult counts AND an identical fingerprint of the
 // generated assertion values. Count-pinning alone is insufficient — counts can
 // match while a non-deterministic source (map iteration, wall-clock leak) shifts
-// generated values — so the (value_text, value_date) fingerprint is the drift
-// detector. Both runs share the SAME namespace (with a full teardown between) so
-// the ns-prefix + PRNG stream line up, AND a PINNED generator anchor so the
-// anchor-relative timestamps (birthday date) are byte-identical too — without the
-// pin, birthday value_date would legitimately drift between runs (anchor-relative
-// per the factory contract) and could not be fingerprinted. proposition_key is
-// NOT fingerprinted (it embeds the per-run subject UUID, so it is not run-stable).
+// generated values — so the (value_text, value_date, value_bool) fingerprint is
+// the drift detector. Both runs share the SAME namespace (with a full teardown
+// between) so the ns-prefix + PRNG stream line up, AND a PINNED generator anchor
+// so the anchor-relative timestamps (birthday date) are byte-identical too —
+// without the pin, birthday value_date would legitimately drift between runs
+// (anchor-relative per the factory contract) and could not be fingerprinted.
+// proposition_key and the edge object node id are NOT fingerprinted (they embed
+// the per-run subject/object UUID, so they are not run-stable); a person→person
+// edge therefore contributes only its (predicate_key, status) to the fingerprint.
 func TestSyntheticProfile_ProdShapedDeterministic(t *testing.T) {
 	testsupport.RequireLongTests(t)
 	database, ctx := newSyntheticDB(t)
@@ -272,6 +309,9 @@ func TestSyntheticProfile_ProdShapedDeterministic(t *testing.T) {
 	// of the scale. 5 assertions walk the full predicate cycle.
 	params.Counts.SeededContacts = 5
 	params.Counts.SeededAssertions = 5
+	// One full bool-fact + edge cycle each (bounded, deterministic at this scale).
+	params.Counts.SeededBoolFacts = 3
+	params.Counts.SeededRelationships = 3
 	params.Counts.UnmatchedExternal = 1
 	params.Counts.StrandedTelegram = 1
 	params.Counts.StrandedMessages = 1


### PR DESCRIPTION
## Summary

PR3 of the 8-PR synthetic seed enrichment (plan: `.ai/log/plan/seed-enrichment-prodshaped.md`). The foundational Tier-2 plumbing PR: extends the assertion toolkit with value-types and edges, then seeds bool/date facts and person→person relationships so the prod-shaped/dev seeds exercise the SP1 graph beyond text facts.

## Changes

- **Plumbing:** `factory.AssertionSpec` gains `ValueBool`/`ValueDate`/`ObjectNodeID`; `ReplayAssertion` routes them into `service.AssertRequest` (sets `ObjectNodeID` only for edges — no stray `ValueText`; the validator rejects edge+scalar). New `gen.BoolFact`/`DateFact`/`EdgeAssertion` constructors.
- **Seeding:** bool facts (`job_seeking`/`on_sabbatical`/`traveling`) + one toolkit-authored date fact + person→person edge assertions between already-seeded contact nodes — `knows`/`introduced_by` (accepted) and `sibling_of` (proposed, always-confirm policy). Seeded LAST (no name-PRNG draw → no Gate-A id shift).
- **Knobs/tests:** new `SeededBoolFacts`/`SeededRelationships`; determinism fingerprint extended to `value_bool`; coverage assertions for the accepted/proposed split + `value_bool` routing.

## Verification

- `go build ./...`, `make lint` (0), `make sqlc` clean.
- Full `TestSyntheticProfile` LONG_TESTS green (coverage + determinism); full backend integration suite exit 0.
- Codex review PASS (P0=0, P1=0); `/review-head` PASS (P0=0, P1=0; independent + adversarial-Opus + full test run converge). 4 non-blocking P3 nits noted in review.

Edge teardown covered by the pre-existing subject-OR-object assertion sweep. Branched off `develop` after PR2 (#558).