### PR TITLE
feat(synthetic): seed entity nodes + person→entity edges

### DIFF
--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -1663,6 +1663,12 @@ type Querier interface {
 	// rows whose normalized value shares the namespace's phone prefix. Caller passes
 	// a BARE prefix; '%' is appended here.
 	SyntheticCountContactMethodsByValueNormalizedPrefix(ctx context.Context, valueNormalizedPrefix pgtype.Text) (int64, error)
+	// Profile coverage test only: count legacy contact_tag rows whose contact's
+	// full_name is ns-prefixed. The prod-shaped seed models tags as `tagged_as` graph
+	// edges (the SP1 live path), NOT legacy contact_tag rows, so this MUST stay ZERO —
+	// a positive guard so a future reader does not "fix" a perceived gap by re-seeding
+	// the legacy table. Caller passes a BARE prefix; '%' is appended here.
+	SyntheticCountContactTagsByContactNamePrefix(ctx context.Context, namePrefix pgtype.Text) (int64, error)
 	// Profile coverage test only: count contact_task rows in a given state whose
 	// contact's full_name is ns-prefixed, so the prod-shaped coverage check can assert
 	// each surface state (managed/unmanaged/completed/dismissed) has ≥1 representative
@@ -1897,6 +1903,17 @@ type Querier interface {
 	// cleanup removes exactly those rows and never strands a task on an unrelated
 	// contact in the shared test DB.
 	SyntheticListContactTaskIdsByProvider(ctx context.Context, provider string) ([]pgtype.UUID, error)
+	// Profile coverage + determinism + teardown test support: list the entity subtype
+	// rows whose node's canonical_label is ns-prefixed — the org/topic/tag pool nodes
+	// (SeedEntity) AND the place nodes the contact-create authority flip minted from
+	// WithLocation. The coverage check asserts each expected subtype (place/
+	// organization/topic/tag) is present; the determinism check fingerprints the sorted
+	// (subtype, normalized_name) set across a re-run (these are deterministic
+	// ns-prefixed synthetic strings — the entity-node generated-id kind); the
+	// teardown check asserts the list is EMPTY after cleanup (the entity nodes were
+	// swept). Deterministically ordered so the fingerprint is stable. Caller passes a
+	// BARE prefix; '%' is appended here.
+	SyntheticListEntityNamesByNodePrefix(ctx context.Context, labelPrefix pgtype.Text) ([]*SyntheticListEntityNamesByNodePrefixRow, error)
 	// Cleanup event-id capture (part 2): adapter-direct root events that carry NO
 	// CRM contact id (raw_message.* / external_contact.upserted roots, and
 	// unknown/pending replays that touch no seeded contact). Keyed by the

--- a/backend/internal/db/queries/test.sql
+++ b/backend/internal/db/queries/test.sql
@@ -568,6 +568,34 @@ SELECT COUNT(*) FROM node WHERE canonical_label LIKE @label_prefix || '%';
 -- prefix; '%' is appended here.
 DELETE FROM node WHERE canonical_label LIKE @label_prefix || '%';
 
+-- name: SyntheticListEntityNamesByNodePrefix :many
+-- Profile coverage + determinism + teardown test support: list the entity subtype
+-- rows whose node's canonical_label is ns-prefixed — the org/topic/tag pool nodes
+-- (SeedEntity) AND the place nodes the contact-create authority flip minted from
+-- WithLocation. The coverage check asserts each expected subtype (place/
+-- organization/topic/tag) is present; the determinism check fingerprints the sorted
+-- (subtype, normalized_name) set across a re-run (these are deterministic
+-- ns-prefixed synthetic strings — the entity-node generated-id kind); the
+-- teardown check asserts the list is EMPTY after cleanup (the entity nodes were
+-- swept). Deterministically ordered so the fingerprint is stable. Caller passes a
+-- BARE prefix; '%' is appended here.
+SELECT e.subtype, e.normalized_name
+FROM entity e
+JOIN node n ON e.node_id = n.id
+WHERE n.canonical_label LIKE @label_prefix || '%'
+ORDER BY e.subtype, e.normalized_name;
+
+-- name: SyntheticCountContactTagsByContactNamePrefix :one
+-- Profile coverage test only: count legacy contact_tag rows whose contact's
+-- full_name is ns-prefixed. The prod-shaped seed models tags as `tagged_as` graph
+-- edges (the SP1 live path), NOT legacy contact_tag rows, so this MUST stay ZERO —
+-- a positive guard so a future reader does not "fix" a perceived gap by re-seeding
+-- the legacy table. Caller passes a BARE prefix; '%' is appended here.
+SELECT COUNT(*)
+FROM contact_tag ct
+JOIN contact c ON ct.contact_id = c.id
+WHERE c.full_name LIKE @name_prefix || '%';
+
 -- name: SyntheticCountAssertionsForSubject :one
 -- Assertion-store test support: count the assertions whose subject is a given
 -- node, so a test scopes its assertions to its own namespace's subject node on

--- a/backend/internal/db/test.sql.go
+++ b/backend/internal/db/test.sql.go
@@ -783,6 +783,25 @@ func (q *Queries) SyntheticCountContactMethodsByValueNormalizedPrefix(ctx contex
 	return count, err
 }
 
+const SyntheticCountContactTagsByContactNamePrefix = `-- name: SyntheticCountContactTagsByContactNamePrefix :one
+SELECT COUNT(*)
+FROM contact_tag ct
+JOIN contact c ON ct.contact_id = c.id
+WHERE c.full_name LIKE $1 || '%'
+`
+
+// Profile coverage test only: count legacy contact_tag rows whose contact's
+// full_name is ns-prefixed. The prod-shaped seed models tags as `tagged_as` graph
+// edges (the SP1 live path), NOT legacy contact_tag rows, so this MUST stay ZERO —
+// a positive guard so a future reader does not "fix" a perceived gap by re-seeding
+// the legacy table. Caller passes a BARE prefix; '%' is appended here.
+func (q *Queries) SyntheticCountContactTagsByContactNamePrefix(ctx context.Context, namePrefix pgtype.Text) (int64, error) {
+	row := q.db.QueryRow(ctx, SyntheticCountContactTagsByContactNamePrefix, namePrefix)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const SyntheticCountContactTasksByStateAndNamePrefix = `-- name: SyntheticCountContactTasksByStateAndNamePrefix :one
 SELECT COUNT(*)
 FROM contact_task ct
@@ -1677,6 +1696,49 @@ func (q *Queries) SyntheticListContactTaskIdsByProvider(ctx context.Context, pro
 			return nil, err
 		}
 		items = append(items, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const SyntheticListEntityNamesByNodePrefix = `-- name: SyntheticListEntityNamesByNodePrefix :many
+SELECT e.subtype, e.normalized_name
+FROM entity e
+JOIN node n ON e.node_id = n.id
+WHERE n.canonical_label LIKE $1 || '%'
+ORDER BY e.subtype, e.normalized_name
+`
+
+type SyntheticListEntityNamesByNodePrefixRow struct {
+	Subtype        string `json:"subtype"`
+	NormalizedName string `json:"normalized_name"`
+}
+
+// Profile coverage + determinism + teardown test support: list the entity subtype
+// rows whose node's canonical_label is ns-prefixed — the org/topic/tag pool nodes
+// (SeedEntity) AND the place nodes the contact-create authority flip minted from
+// WithLocation. The coverage check asserts each expected subtype (place/
+// organization/topic/tag) is present; the determinism check fingerprints the sorted
+// (subtype, normalized_name) set across a re-run (these are deterministic
+// ns-prefixed synthetic strings — the entity-node generated-id kind); the
+// teardown check asserts the list is EMPTY after cleanup (the entity nodes were
+// swept). Deterministically ordered so the fingerprint is stable. Caller passes a
+// BARE prefix; '%' is appended here.
+func (q *Queries) SyntheticListEntityNamesByNodePrefix(ctx context.Context, labelPrefix pgtype.Text) ([]*SyntheticListEntityNamesByNodePrefixRow, error) {
+	rows, err := q.db.Query(ctx, SyntheticListEntityNamesByNodePrefix, labelPrefix)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []*SyntheticListEntityNamesByNodePrefixRow{}
+	for rows.Next() {
+		var i SyntheticListEntityNamesByNodePrefixRow
+		if err := rows.Scan(&i.Subtype, &i.NormalizedName); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/backend/internal/repository/synthetic_support.go
+++ b/backend/internal/repository/synthetic_support.go
@@ -904,3 +904,37 @@ func (r *SyntheticSupportRepository) DeleteTagsByIds(ctx context.Context, tagIDs
 func (r *SyntheticSupportRepository) CountTaggedAsAssertionsForSubject(ctx context.Context, subjectNodeID uuid.UUID) (int64, error) {
 	return r.queries.TestCountTaggedAsAssertionsForSubject(ctx, pgtype.UUID{Bytes: subjectNodeID, Valid: true})
 }
+
+// EntityNameSummary is the (subtype, normalized_name) projection of an entity node
+// whose node label is ns-prefixed — the profile coverage / determinism / teardown
+// fingerprint of the org/topic/tag pool + the place nodes the contact-create
+// authority flip minted from WithLocation.
+type EntityNameSummary struct {
+	Subtype        string
+	NormalizedName string
+}
+
+// ListEntityNamesByNodePrefix returns the entity subtype rows whose node's
+// canonical_label is ns-prefixed, sorted, so a profile test can assert each
+// expected subtype is present (coverage), fingerprint the generated normalized
+// names across a re-run (determinism), and assert the list is empty after teardown
+// (cleanup). Caller passes a BARE prefix.
+func (r *SyntheticSupportRepository) ListEntityNamesByNodePrefix(ctx context.Context, prefix string) ([]EntityNameSummary, error) {
+	rows, err := r.queries.SyntheticListEntityNamesByNodePrefix(ctx, pgtype.Text{String: prefix, Valid: true})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]EntityNameSummary, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, EntityNameSummary{Subtype: row.Subtype, NormalizedName: row.NormalizedName})
+	}
+	return out, nil
+}
+
+// CountContactTagsByContactNamePrefix counts legacy contact_tag rows whose
+// contact's full_name is ns-prefixed, so the prod-shaped coverage check can assert
+// the seed leaves the legacy table at ZERO (tags are modeled as `tagged_as` graph
+// edges, not contact_tag rows). Caller passes a BARE prefix.
+func (r *SyntheticSupportRepository) CountContactTagsByContactNamePrefix(ctx context.Context, namePrefix string) (int64, error) {
+	return r.queries.SyntheticCountContactTagsByContactNamePrefix(ctx, pgtype.Text{String: namePrefix, Valid: true})
+}

--- a/backend/internal/synthetic/factory/domain.go
+++ b/backend/internal/synthetic/factory/domain.go
@@ -50,6 +50,7 @@ type contactConfig struct {
 	recent       bool
 	birthday     *time.Time
 	howMet       *string
+	location     *string
 	unicodeName  bool
 	descender    bool
 }
@@ -113,6 +114,20 @@ func WithHowMet(s string) ContactOption {
 	}
 }
 
+// WithLocation sets the contact's location (a flat place label). It routes
+// through the contact-create authority flip into an accepted `lives_in` edge to a
+// place entity node (EnsurePlaceTx find-or-creates the flat place node from the
+// label — no synonym/hierarchy resolution, so no `within` edge). The label must
+// be namespace-prefixed so the entity teardown's label-prefix sweep catches the
+// auto-created place node. A blank string is normalized away by the service, so
+// callers pass a meaningful value.
+func WithLocation(s string) ContactOption {
+	return func(c *contactConfig) {
+		v := s
+		c.location = &v
+	}
+}
+
 // WithUnicodeName uses a unicode-bearing display name (edge case).
 func WithUnicodeName() ContactOption { return func(c *contactConfig) { c.unicodeName = true } }
 
@@ -153,6 +168,7 @@ func (g *Generator) Contact(opts ...ContactOption) ContactSpec {
 		Cadence:  cfg.cadence,
 		Birthday: cfg.birthday,
 		HowMet:   cfg.howMet,
+		Location: cfg.location,
 	}
 
 	if cfg.withEmail {

--- a/backend/internal/synthetic/profiles.go
+++ b/backend/internal/synthetic/profiles.go
@@ -53,11 +53,14 @@ type ProfileResult struct {
 	UnmatchedCalendar int
 	OrphanMeetingNote int
 	SeededAssertions  int
-	// ContactsWithBirthday / ContactsWithHowMet count the catalog contacts that
-	// carried a birthday / how_met bio fact (produced through the contact-create
-	// authority-flip path, not the Phase-4 assertion loop). Counts-only / no PII.
+	// ContactsWithBirthday / ContactsWithHowMet / ContactsWithLocation count the
+	// catalog contacts that carried a birthday / how_met / location bio fact
+	// (produced through the contact-create authority-flip path, not the Phase-4
+	// assertion loop). A location additionally mints a place entity node + a
+	// `lives_in` edge. Counts-only / no PII.
 	ContactsWithBirthday int
 	ContactsWithHowMet   int
+	ContactsWithLocation int
 	// SeededTasks counts the contact_task rows the profile seeded — one `managed`
 	// cadence task per cadence-bearing catalog contact (via ReplayTodoist's
 	// reconcile), a deterministic three of which are then transitioned to the
@@ -72,6 +75,13 @@ type ProfileResult struct {
 	SeededBoolFacts     int
 	SeededRelationships int
 	SeededDateFacts     int
+	// SeededEntities / SeededEntityEdges count the graph rows the entity layer
+	// seeded: the org/topic/tag entity nodes in the pool, and the person→entity edge
+	// assertions (works_at/interested_in/tagged_as) drawn from that pool. Counts-only
+	// / no PII. (The place entity nodes + lives_in edges from WithLocation are
+	// reflected by ContactsWithLocation, not here.)
+	SeededEntities    int
+	SeededEntityEdges int
 }
 
 // ProfileParams returns the default SeedParams for a named profile (error on an
@@ -105,6 +115,10 @@ func ProfileParams(name Profile) (SeedParams, error) {
 				// cadence-bearing, so reconcile creates a managed task on each and
 				// three are transitioned for surface coverage.
 				SeededTasks: 1,
+				// Small entity pool (1 org + 1 topic + 1 tag) + a few person→entity
+				// edges so the dev graph surfaces show works_at/interested_in/tagged_as.
+				SeededEntities:    3,
+				SeededEntityEdges: 6,
 			},
 		}, nil
 	case ProfileProdShaped:
@@ -135,6 +149,12 @@ func ProfileParams(name Profile) (SeedParams, error) {
 				// each (catalog-wide, like prod) and three are transitioned to the
 				// completed/dismissed/unmanaged surface states.
 				SeededTasks: 1,
+				// Small org/topic/tag pool (3 each) + ~1/5 of the catalog carrying a
+				// person→entity edge (works_at/interested_in/tagged_as), drawn from the
+				// pool so the few entities repeat across many people (prod-like). The
+				// coverage + determinism tests override these down for CI.
+				SeededEntities:    9,
+				SeededEntityEdges: 30,
 			},
 		}, nil
 	default:
@@ -238,6 +258,9 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		}
 		if spec.HowMet != nil {
 			res.ContactsWithHowMet++
+		}
+		if spec.Location != nil {
+			res.ContactsWithLocation++
 		}
 		catalogContactIDs = append(catalogContactIDs, contact.ID)
 		if spec.Cadence != nil && *spec.Cadence != "" {
@@ -465,6 +488,81 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		res.SeededRelationships++
 	}
 
+	// Entity nodes (org/topic/tag pool) + person→entity EDGE assertions. Seeded
+	// LAST because gen.Entity DRAWS the name PRNG (givenName) — appending it after
+	// the source replays + the person-subject assertion spread above keeps the
+	// deterministic id/handle sequence those earlier replays depend on unshifted.
+	// (The person→entity gen.EdgeAssertion calls draw no name PRNG, only sourceIDSeq.)
+	//
+	// The pool is small and round-robins org/topic/tag, so the edges below draw
+	// objects from it repeatedly — prod-like (many people share a few orgs/topics/
+	// tags). place entity nodes + lives_in edges are NOT seeded here; they ride the
+	// contact-create authority flip via WithLocation (Phase 1 above).
+	var orgNodeIDs, topicNodeIDs, tagNodeIDs []uuid.UUID
+	for j := 0; j < params.Counts.SeededEntities; j++ {
+		subtype := catalogEntitySubtypes[j%len(catalogEntitySubtypes)]
+		entityID, err := h.SeedEntity(ctx, gen.Entity(subtype))
+		if err != nil {
+			return res, fmt.Errorf("profile %s: seed entity %d: %w", params.Profile, j, err)
+		}
+		switch subtype {
+		case repository.EntitySubtypeOrganization:
+			orgNodeIDs = append(orgNodeIDs, entityID)
+		case repository.EntitySubtypeTopic:
+			topicNodeIDs = append(topicNodeIDs, entityID)
+		case repository.EntitySubtypeTag:
+			tagNodeIDs = append(tagNodeIDs, entityID)
+		}
+		res.SeededEntities++
+	}
+
+	// Person→entity edges cycle works_at→org / interested_in→topic / tagged_as→tag,
+	// all auto-if-confident → accepted. The subject is a distinct catalog contact
+	// per edge (works_at is single-cardinality, so a distinct subject keeps it from
+	// superseding); the object is drawn from the matching subtype pool (round-robin,
+	// so the small pool repeats across subjects). Both review surfaces for these
+	// predicates are accepted; the proposed surface is covered by the person→person
+	// sibling_of edge above. A subtype with an empty pool is skipped (only possible
+	// when SeededEntities < 3, which the profiles avoid).
+	entityEdges := params.Counts.SeededEntityEdges
+	if entityEdges > len(catalogContactIDs) {
+		entityEdges = len(catalogContactIDs)
+	}
+	for i := 0; i < entityEdges; i++ {
+		subject := catalogContactIDs[i]
+		// cursor is the per-predicate occurrence index (0,0,0,1,1,1,2,...): the loop
+		// picks a predicate by i%3, so for a fixed predicate i advances in steps of 3.
+		// Indexing the object pool by i would therefore stride by 3 and pin every edge
+		// of a predicate to one entity whenever the pool size divides 3 (the prod pool
+		// is 3 per subtype). Indexing by i/3 advances one slot per occurrence, so the
+		// edges walk the whole pool and wrap once the catalog outgrows it (prod-like:
+		// many people share a few orgs/topics/tags).
+		cursor := i / len(catalogEntityEdgePredicates)
+		var predicate string
+		var object uuid.UUID
+		switch i % len(catalogEntityEdgePredicates) {
+		case 0:
+			if len(orgNodeIDs) == 0 {
+				continue
+			}
+			predicate, object = "works_at", orgNodeIDs[cursor%len(orgNodeIDs)]
+		case 1:
+			if len(topicNodeIDs) == 0 {
+				continue
+			}
+			predicate, object = "interested_in", topicNodeIDs[cursor%len(topicNodeIDs)]
+		default:
+			if len(tagNodeIDs) == 0 {
+				continue
+			}
+			predicate, object = "tagged_as", tagNodeIDs[cursor%len(tagNodeIDs)]
+		}
+		if _, err := h.ReplayAssertion(ctx, subject, gen.EdgeAssertion(predicate, object)); err != nil {
+			return res, fmt.Errorf("profile %s: replay entity edge %d: %w", params.Profile, i, err)
+		}
+		res.SeededEntityEdges++
+	}
+
 	// Cadence tasks (Todoist) on the cadence-bearing catalog contacts. ReplayTodoist
 	// drives the REAL CadenceSyncProvider reconcile, which reads
 	// ListContactsWithContactBy (contact_by auto-computed from cadence by
@@ -542,6 +640,38 @@ var catalogEdgePredicates = []string{
 	"sibling_of",
 }
 
+// catalogEntitySubtypes is the round-robin order the entity pool is built in, so a
+// SeededEntities value ≥3 yields ≥1 of each subtype. They are migration-066
+// curated entity subtypes.
+var catalogEntitySubtypes = []string{
+	repository.EntitySubtypeOrganization,
+	repository.EntitySubtypeTopic,
+	repository.EntitySubtypeTag,
+}
+
+// catalogEntityEdgePredicates is the person→entity edge predicate cycle, aligned
+// 1:1 with catalogEntitySubtypes (works_at→org, interested_in→topic,
+// tagged_as→tag). All three are auto-if-confident → accepted (migration-066
+// catalog person→entity edge predicates). NOTE the alignment with
+// catalogEntitySubtypes is load-bearing: the edge loop's `i % 3` branch picks the
+// object pool for the matching subtype.
+var catalogEntityEdgePredicates = []string{
+	"works_at",
+	"interested_in",
+	"tagged_as",
+}
+
+// catalogLocationStems is the small fixed pool the lives_in location rotates over
+// so locations repeat across contacts (prod-like) while staying deterministic. The
+// values are flat (no comma/hierarchy) so EnsurePlaceTx mints a flat place node
+// with no `within` parent edge.
+var catalogLocationStems = []string{
+	"riverton",
+	"lakeside",
+	"hillcrest",
+	"meadowbrook",
+}
+
 // catalogOptionsFor returns the contact-builder options for catalog contact i of
 // n, deterministically spreading the edge-case shapes across the population:
 // cadence states (overdue / recent / never-contacted), the 1900 birthday
@@ -604,6 +734,16 @@ func catalogOptionsFor(i, n int, anchor time.Time, prefix string) []factory.Cont
 	if i%4 == 1 {
 		stem := catalogHowMetStems[(i/4)%len(catalogHowMetStems)]
 		opts = append(opts, factory.WithHowMet(prefix+"met-"+stem))
+	}
+
+	// lives_in location on ~1/5 of contacts (ns-prefixed flat label → place entity
+	// node + lives_in edge via the contact-create authority flip). Rotated stem so
+	// locations repeat across contacts (prod-like); ns-prefixed so the entity
+	// teardown's label-prefix sweep catches the auto-created place node. Avoids
+	// i == 3 (the no-method slot returns early above).
+	if i%5 == 4 {
+		stem := catalogLocationStems[(i/5)%len(catalogLocationStems)]
+		opts = append(opts, factory.WithLocation(prefix+"place-"+stem))
 	}
 
 	return opts

--- a/backend/internal/synthetic/profiles_test.go
+++ b/backend/internal/synthetic/profiles_test.go
@@ -79,6 +79,10 @@ func TestProfileParams(t *testing.T) {
 	// prod-shaped enables cadence-task seeding (>0 gate) so the coverage check has
 	// contact_task rows to assert per-state.
 	require.Greater(t, prod.Counts.SeededTasks, 0)
+	// prod-shaped seeds an entity pool + person→entity edges so the coverage check
+	// has org/topic/tag entity nodes + works_at/interested_in/tagged_as edges.
+	require.Greater(t, prod.Counts.SeededEntities, 0)
+	require.Greater(t, prod.Counts.SeededEntityEdges, 0)
 }
 
 // TestDefaultParamsUnchanged pins DefaultParams field-for-field so the
@@ -100,4 +104,6 @@ func TestDefaultParamsUnchanged(t *testing.T) {
 	require.Equal(t, 0, p.Counts.SeededBoolFacts)
 	require.Equal(t, 0, p.Counts.SeededRelationships)
 	require.Equal(t, 0, p.Counts.SeededTasks)
+	require.Equal(t, 0, p.Counts.SeededEntities)
+	require.Equal(t, 0, p.Counts.SeededEntityEdges)
 }

--- a/backend/internal/synthetic/replay/harness_cleanup.go
+++ b/backend/internal/synthetic/replay/harness_cleanup.go
@@ -259,6 +259,21 @@ func (h *Harness) cleanup(ctx context.Context) error {
 		_, err := h.support.DeleteNodesByIds(ctx, c.contactIDs)
 		return err
 	})
+	// 13a-entity. entity nodes (place/org/topic/tag): SeedEntity mints org/topic/tag
+	// nodes and the contact-create authority flip (WithLocation) mints place nodes;
+	// both carry an ns-prefixed canonical_label, so one label-prefix sweep removes
+	// them (the entity subtype rows cascade on the node delete). Runs AFTER the
+	// assertions step (the assertion→node FK is RESTRICT, and person→entity edges
+	// reference these nodes as the OBJECT) so no edge still points at them. It
+	// re-matches the already-deleted ns-prefixed person nodes harmlessly (0 rows) and
+	// misses the empty-label venue nodes (cleaned by the by-id venue step below). A
+	// surviving place→place `within` edge — which EnsurePlaceTx does NOT mint today
+	// (flat place nodes) — would FK-block this delete loudly; the coverage test
+	// asserts zero such edges so the regression is caught before this point.
+	step("graph_entity_nodes", func() error {
+		_, err := h.support.DeleteNodesByLabelPrefix(ctx, prefix)
+		return err
+	})
 	// 13b. venue node (interaction.venue_id → node): the real recorders mint a
 	// venue node per distinct container on the replay path. They are not contacts
 	// (so person_node misses them) and have an empty canonical_label (so the

--- a/backend/internal/synthetic/replay/replay.go
+++ b/backend/internal/synthetic/replay/replay.go
@@ -230,6 +230,42 @@ func (h *Harness) SeedContact(ctx context.Context, spec factory.ContactSpec) (*r
 	return contact, nil
 }
 
+// SeedEntity creates an entity node + its entity subtype row (org / topic / tag)
+// in one tx, mirroring the find-or-create-tag-node path in the tag migration but
+// always creating (the synthetic pool is a fresh, per-namespace set, so there is
+// no find step). The node's canonical_label is namespace-prefixed (from
+// gen.Entity), so the teardown's graph_entity_nodes label-prefix sweep removes it
+// — no per-id ledger tracking is needed. Returns the created node id so the caller
+// can point person→entity edge assertions at it.
+func (h *Harness) SeedEntity(ctx context.Context, spec factory.EntitySpec) (uuid.UUID, error) {
+	nodeRepo := repository.NewNodeRepository(h.database.Queries)
+	entityRepo := repository.NewEntityRepository(h.database.Queries)
+
+	nodeID := uuid.New()
+	tx, err := h.database.Pool.Begin(ctx)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("seed entity: begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+
+	// node + entity must commit together: the entity.node_id FK requires the node,
+	// and a partial entity node must never linger on the shared DB.
+	if _, err := nodeRepo.CreateNodeTx(ctx, tx, nodeID, repository.NodeTypeEntity, spec.Node.CanonicalLabel); err != nil {
+		return uuid.Nil, fmt.Errorf("seed entity: create node: %w", err)
+	}
+	if _, err := entityRepo.CreateEntityTx(ctx, tx, repository.CreateEntityRequest{
+		NodeID:         nodeID,
+		Subtype:        spec.Subtype,
+		NormalizedName: spec.NormalizedName,
+	}); err != nil {
+		return uuid.Nil, fmt.Errorf("seed entity: create entity: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return uuid.Nil, fmt.Errorf("seed entity: commit: %w", err)
+	}
+	return nodeID, nil
+}
+
 // SeedNote attaches a notepad note to a seeded contact via the EXISTING
 // NoteRepository (orchestration over an existing repo, not new machinery). The
 // contact must be one the harness seeded (so the teardown's note step — delete

--- a/backend/internal/synthetic/synthetic.go
+++ b/backend/internal/synthetic/synthetic.go
@@ -107,6 +107,21 @@ type Counts struct {
 	// for surface coverage. ProfileResult.SeededTasks reports the actual rows. 0
 	// disables (minimal-scoped stays task-free / byte-stable).
 	SeededTasks int
+	// SeededEntities is the size of the org/topic/tag entity pool the profile
+	// creates (round-robin across the three subtypes, so a value ≥3 yields ≥1 of
+	// each). The pool is intentionally SMALL so the person→entity edges below draw
+	// objects from it repeatedly (prod-like: many people share a few orgs/topics/
+	// tags). >0 enables the entity pool + person→entity edge seeding; 0 disables.
+	SeededEntities int
+	// SeededEntityEdges is the number of person→entity EDGE assertions seeded across
+	// the catalog person nodes (cycling works_at→org / interested_in→topic /
+	// tagged_as→tag, all auto-if-confident → accepted), with objects drawn from the
+	// SeededEntities pool. Bounded by the catalog size at run time (works_at and
+	// lives_in are single-cardinality, so one per subject). Needs SeededEntities ≥3
+	// so every edge type has an object. 0 disables. (lives_in is NOT counted here —
+	// it rides the contact-create authority flip via WithLocation, index-spread like
+	// the birthday/how_met bio facts.)
+	SeededEntityEdges int
 }
 
 // SeedParams is the profile/volume seam consumed by the seed orchestration.

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -101,6 +101,13 @@ func TestSyntheticProfile_DevCoversCatalog(t *testing.T) {
 	require.Equal(t, params.Counts.SeededBoolFacts, res.SeededBoolFacts, "dev profile seeds bool facts")
 	require.Equal(t, params.Counts.SeededRelationships, res.SeededRelationships, "dev profile seeds person→person edges")
 	require.Equal(t, 1, res.SeededDateFacts, "dev profile seeds one toolkit date fact")
+	// Entity pool + person→entity edges: the dev catalog (18) far exceeds the small
+	// dev knob counts, so the seeded counts are exact (no catalog-size bounding).
+	require.Equal(t, params.Counts.SeededEntities, res.SeededEntities, "dev profile seeds the entity pool")
+	require.Equal(t, params.Counts.SeededEntityEdges, res.SeededEntityEdges, "dev profile seeds person→entity edges")
+	// lives_in locations ride the contact-create authority flip, spread by catalog
+	// index; the dev catalog is large enough to carry ≥1.
+	require.GreaterOrEqual(t, res.ContactsWithLocation, 1, "dev profile seeds location bio facts")
 
 	remaining, err := h.ContactsRemaining(ctx)
 	require.NoError(t, err)
@@ -143,6 +150,12 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 	// cadence-bearing, so reconcile creates 9 `managed` tasks and three are
 	// transitioned to completed/dismissed/unmanaged — every surface state present.
 	params.Counts.SeededTasks = 1
+	// Entity pool of 3 (1 org + 1 topic + 1 tag) + one full person→entity edge cycle
+	// (works_at/interested_in/tagged_as) so every entity subtype + edge type is
+	// exercised. lives_in rides WithLocation (index-spread, present at this catalog
+	// size) — not a count knob.
+	params.Counts.SeededEntities = 3
+	params.Counts.SeededEntityEdges = 3
 
 	h := synthetic.NewHarnessForNamespace(t, ctx, database, params.Namespace, params.Seed)
 	res, err := synthetic.RunProfile(ctx, h, params)
@@ -201,10 +214,12 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 	require.GreaterOrEqual(t, neverContacted, 1, "≥1 cadence-bearing never-contacted contact (NULL last_contacted survived)")
 	require.GreaterOrEqual(t, noMethod, 1, "≥1 no-method contact (the no-method bucket exists)")
 
-	// Bio facts (item 4 how_met + item 5 real-year birthdays) ride on the
-	// contact-create authority flip; the catalog carries ≥1 of each.
+	// Bio facts (how_met, location, real-year birthdays) ride on the contact-create
+	// authority flip; the catalog carries ≥1 of each. A location additionally mints
+	// a place entity node + a lives_in edge (asserted below).
 	require.GreaterOrEqual(t, res.ContactsWithBirthday, 1, "≥1 contact with a birthday bio fact")
 	require.GreaterOrEqual(t, res.ContactsWithHowMet, 1, "≥1 contact with a how_met bio fact")
+	require.GreaterOrEqual(t, res.ContactsWithLocation, 1, "≥1 contact with a location bio fact")
 
 	// Accept/pending coverage (D6) + full text-fact spread: assert the SPECIFIC
 	// (predicate, review-policy) outcome for EVERY predicate in the Phase-4 cycle,
@@ -221,6 +236,12 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 	var boolFactTrue bool
 	for _, a := range assertions {
 		seen[a.PredicateKey+"/"+a.Status] = true
+		// Positive guard: EnsurePlaceTx mints FLAT place nodes (no synonym /
+		// hierarchy resolution), so the seed must produce ZERO place→place `within`
+		// edges. A surviving `within` would FK-block the entity-node teardown sweep;
+		// catching it here makes the regression loud at seed time. (A `within`
+		// subject is an ns-prefixed place node, so it would appear in this list.)
+		require.NotEqual(t, "within", a.PredicateKey, "no place→place within hierarchy assertion (flat place nodes)")
 		// item 5: a real-year birthday from the spread must exist, not just the
 		// 1900 month/day-only sentinel (which alone would satisfy
 		// ContactsWithBirthday even if the real-year spread regressed).
@@ -248,6 +269,13 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 		"knows/" + repository.AssertionStatusAccepted,
 		"introduced_by/" + repository.AssertionStatusAccepted,
 		"sibling_of/" + repository.AssertionStatusProposed,
+		// person→entity edges — all auto-if-confident → accepted. lives_in rides the
+		// contact-create authority flip (WithLocation); works_at/interested_in/
+		// tagged_as ride the entity pool + edge spread.
+		"lives_in/" + repository.AssertionStatusAccepted,
+		"works_at/" + repository.AssertionStatusAccepted,
+		"interested_in/" + repository.AssertionStatusAccepted,
+		"tagged_as/" + repository.AssertionStatusAccepted,
 	} {
 		require.True(t, seen[want], "graph value-type/edge spread must land %s", want)
 	}
@@ -260,6 +288,34 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 	require.GreaterOrEqual(t, res.SeededRelationships, 1, "person→person edges seeded")
 	require.GreaterOrEqual(t, res.SeededDateFacts, 1, "toolkit-authored date fact seeded")
 
+	// Entity layer: the org/topic/tag pool + the place nodes from WithLocation must
+	// all be present, and the person→entity edges seeded. Scoped to the namespace via
+	// the node label prefix.
+	require.GreaterOrEqual(t, res.SeededEntities, 1, "entity pool seeded")
+	require.GreaterOrEqual(t, res.SeededEntityEdges, 1, "person→entity edges seeded")
+	prefix := h.Generator().Prefix()
+	entityNames, err := support.ListEntityNamesByNodePrefix(ctx, prefix)
+	require.NoError(t, err)
+	subtypesSeen := make(map[string]bool)
+	for _, e := range entityNames {
+		subtypesSeen[e.Subtype] = true
+	}
+	for _, subtype := range []string{
+		repository.EntitySubtypePlace, // from WithLocation (contact-create authority flip)
+		repository.EntitySubtypeOrganization,
+		repository.EntitySubtypeTopic,
+		repository.EntitySubtypeTag,
+	} {
+		require.True(t, subtypesSeen[subtype], "≥1 %q entity node present", subtype)
+	}
+
+	// Positive guard: tags are modeled as `tagged_as` graph edges (asserted above),
+	// NOT legacy contact_tag rows — the legacy table MUST stay zero for the
+	// namespace, so a future reader does not "fix" a perceived gap by re-seeding it.
+	legacyContactTags, err := support.CountContactTagsByContactNamePrefix(ctx, prefix)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), legacyContactTags, "tags seeded as tagged_as edges, not legacy contact_tag rows")
+
 	// Cadence tasks: ReplayTodoist seeds a `managed` cadence task on each
 	// cadence-bearing catalog contact, and the profile transitions a deterministic
 	// three to completed/dismissed/unmanaged. Assert ≥1 row in EACH state the seed
@@ -267,7 +323,6 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 	// renders has content. pending_remote_create is out of scope (a transient
 	// create-in-flight state the seed does not produce).
 	require.GreaterOrEqual(t, res.SeededTasks, 1, "cadence tasks seeded")
-	prefix := h.Generator().Prefix()
 	for _, state := range []repository.ContactTaskState{
 		repository.ContactTaskStateManaged,
 		repository.ContactTaskStateUnmanaged,
@@ -312,6 +367,10 @@ func TestSyntheticProfile_ProdShapedDeterministic(t *testing.T) {
 	// One full bool-fact + edge cycle each (bounded, deterministic at this scale).
 	params.Counts.SeededBoolFacts = 3
 	params.Counts.SeededRelationships = 3
+	// Entity pool (1 org + 1 topic + 1 tag) + one full person→entity edge cycle, so
+	// the entity normalized_name fingerprint covers org/topic/tag/place subtypes.
+	params.Counts.SeededEntities = 3
+	params.Counts.SeededEntityEdges = 3
 	params.Counts.UnmatchedExternal = 1
 	params.Counts.StrandedTelegram = 1
 	params.Counts.StrandedMessages = 1
@@ -327,25 +386,38 @@ func TestSyntheticProfile_ProdShapedDeterministic(t *testing.T) {
 	anchor := accelerated.GetCurrentTime()
 	support := repository.NewSyntheticSupportRepository(database.Queries)
 
-	// run seeds the profile, captures (ProfileResult, assertion fingerprint), then
-	// fully tears down so the next run starts from a clean namespace.
-	run := func() (synthetic.ProfileResult, []repository.AssertionSummary) {
+	// run seeds the profile, captures (ProfileResult, assertion fingerprint, entity
+	// normalized_name fingerprint), then fully tears down so the next run starts from
+	// a clean namespace. It also asserts the teardown swept every entity node (pool
+	// + place) — a leaked entity node would FK-block or duplicate-violate the next
+	// run, and a surviving place node from a `within` edge would FK-block the sweep.
+	run := func() (synthetic.ProfileResult, []repository.AssertionSummary, []repository.EntityNameSummary) {
 		h, teardown, err := synthetic.NewHarnessWithDBForNamespaceAt(ctx, database, params.Namespace, params.Seed, anchor)
 		require.NoError(t, err)
 		res, err := synthetic.RunProfile(ctx, h, params)
 		require.NoError(t, err)
-		fp, err := support.ListAssertionsByNodePrefix(ctx, h.Generator().Prefix())
+		prefix := h.Generator().Prefix()
+		fp, err := support.ListAssertionsByNodePrefix(ctx, prefix)
+		require.NoError(t, err)
+		entFP, err := support.ListEntityNamesByNodePrefix(ctx, prefix)
 		require.NoError(t, err)
 		require.NoError(t, teardown(context.Background()))
-		return res, fp
+		// Teardown correctness: the entity nodes (org/topic/tag pool + place nodes)
+		// are swept, so the namespace is clean for the next run.
+		remaining, err := support.ListEntityNamesByNodePrefix(ctx, prefix)
+		require.NoError(t, err)
+		require.Empty(t, remaining, "entity nodes (pool + place) swept by teardown")
+		return res, fp, entFP
 	}
 
-	res1, fp1 := run()
-	res2, fp2 := run()
+	res1, fp1, ent1 := run()
+	res2, fp2, ent2 := run()
 
 	require.Equal(t, res1, res2, "prod-shaped ProfileResult must be deterministic across runs")
 	require.NotEmpty(t, fp1, "the seed must produce assertions to fingerprint")
 	require.Equal(t, fp1, fp2, "assertion (value_text, value_date, value_bool) fingerprint must be deterministic across runs")
+	require.NotEmpty(t, ent1, "the seed must produce entity nodes to fingerprint")
+	require.Equal(t, ent1, ent2, "entity (subtype, normalized_name) fingerprint must be deterministic across runs")
 }
 
 // TestSyntheticProfile_QuiesceLeavesRows proves the seed-and-leave lifecycle:

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -456,7 +456,7 @@ func TestSyntheticProfile_ProdShapedDeterministic(t *testing.T) {
 	require.NotEmpty(t, ent1, "the seed must produce entity nodes to fingerprint")
 	require.Equal(t, ent1, ent2, "entity (subtype, normalized_name) fingerprint must be deterministic across runs")
 
-	// Ordering guard for the "seed gen.X() LAST" rule (D2/R3). The run-to-run
+	// Ordering guard for the "seed gen.X() LAST" rule. The run-to-run
 	// comparison above catches NON-deterministic drift but NOT a DETERMINISTIC
 	// mis-ordering of the gen.Entity pool (both runs would shift identically). A
 	// literal name golden is precluded here — syntheticNS(t) randomizes the namespace
@@ -491,7 +491,7 @@ func TestSyntheticProfile_ProdShapedDeterministic(t *testing.T) {
 	require.GreaterOrEqual(t, maxTextFactSeq, 0, "the seed must produce text-fact assertions with a seq witness")
 	require.GreaterOrEqual(t, minEntitySeq, 0, "the seed must produce gen.Entity pool nodes with a seq witness")
 	require.Greater(t, minEntitySeq, maxTextFactSeq,
-		"gen.Entity pool must be seeded LAST (after the text-fact spread): entity seq %d must exceed max text-fact seq %d — a smaller entity seq means a mis-ordered gen.X() insertion (D2/R3)",
+		"gen.Entity pool must be seeded LAST (after the text-fact spread): entity seq %d must exceed max text-fact seq %d — a smaller entity seq means a mis-ordered gen.X() insertion",
 		minEntitySeq, maxTextFactSeq)
 }
 

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -369,18 +369,22 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 // generated values — so the (value_text, value_date, value_bool) fingerprint is
 // the drift detector.
 //
-// Scope (what this catches vs. where): a run-to-run comparison detects
-// NON-deterministic drift only. It cannot detect a DETERMINISTIC mis-ordering of a
-// gen.X() call (the "seed gen.X() LAST" rule), because both runs shift identically
-// and still match — and a golden/pinned fingerprint is not an option here:
-// syntheticNS(t) randomizes the namespace per run and the generator PRNG is seeded
-// with fnv(namespace), so there is no run-stable canonical sequence to pin. The
-// "seed LAST" rule is instead enforced by the coverage test's Gate-A settle: a
-// mis-placed gen.X() shifts later source-replay ids into a cross-contact peer-id
-// collision that fails the settle loudly (the original SP1 mis-order regression
-// surfaced exactly this way). A mis-ordering that shifts NO subsequent source-replay
-// draw is harmless (distinct-but-valid synthetic data), so the two guards together
-// cover the load-bearing class.
+// Scope (what this catches vs. where): the "seed gen.X() LAST" rule is covered by
+// THREE complementary guards. (1) This run-to-run fingerprint comparison detects
+// NON-deterministic drift only (map iteration, wall-clock leak); on its own it
+// cannot see a DETERMINISTIC mis-ordering (both runs shift identically and still
+// match), and a full-VALUE golden is precluded — syntheticNS(t) randomizes the
+// namespace per run and the PRNG is seeded with fnv(namespace), so the fingerprinted
+// values have no run-stable form to pin. (2) The ordering guard below pins the one
+// thing that IS run-stable: the monotonic sourceIDSeq counter (namespace-independent),
+// asserting every gen.Entity-pool seq exceeds every text-fact seq — so a deterministic
+// mis-ordering of the entity block (the case (1) can't see) fails there. (3) The
+// coverage test's Gate-A settle catches a mis-placed gen.X() that shifts later
+// source-replay ids into a cross-contact peer-id collision that fails the settle
+// loudly (the original SP1 mis-order regression surfaced exactly this way). A
+// mis-ordering that shifts NO subsequent source-replay draw is harmless
+// (distinct-but-valid synthetic data), so the three guards together cover the
+// load-bearing class.
 //
 // Both runs share the SAME namespace (with a full teardown
 // between) so the ns-prefix + PRNG stream line up, AND a PINNED generator anchor

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -345,7 +345,22 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 // generated assertion values. Count-pinning alone is insufficient — counts can
 // match while a non-deterministic source (map iteration, wall-clock leak) shifts
 // generated values — so the (value_text, value_date, value_bool) fingerprint is
-// the drift detector. Both runs share the SAME namespace (with a full teardown
+// the drift detector.
+//
+// Scope (what this catches vs. where): a run-to-run comparison detects
+// NON-deterministic drift only. It cannot detect a DETERMINISTIC mis-ordering of a
+// gen.X() call (the "seed gen.X() LAST" rule), because both runs shift identically
+// and still match — and a golden/pinned fingerprint is not an option here:
+// syntheticNS(t) randomizes the namespace per run and the generator PRNG is seeded
+// with fnv(namespace), so there is no run-stable canonical sequence to pin. The
+// "seed LAST" rule is instead enforced by the coverage test's Gate-A settle: a
+// mis-placed gen.X() shifts later source-replay ids into a cross-contact peer-id
+// collision that fails the settle loudly (the original SP1 mis-order regression
+// surfaced exactly this way). A mis-ordering that shifts NO subsequent source-replay
+// draw is harmless (distinct-but-valid synthetic data), so the two guards together
+// cover the load-bearing class.
+//
+// Both runs share the SAME namespace (with a full teardown
 // between) so the ns-prefix + PRNG stream line up, AND a PINNED generator anchor
 // so the anchor-relative timestamps (birthday date) are byte-identical too —
 // without the pin, birthday value_date would legitimately drift between runs

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -15,6 +16,27 @@ import (
 
 	"github.com/stretchr/testify/require"
 )
+
+// trailingSeqRE extracts the generator's monotonic sourceIDSeq embedded as the
+// trailing "-<digits>" of a synthetic value_text / entity normalized_name (e.g.
+// "synth-<ns>-organization-Alice-42" → 42). The seq is namespace-INDEPENDENT (a
+// pure counter, unlike the PRNG-drawn name component), so it is a stable
+// cross-run/cross-namespace ordering witness. Returns ok=false for values with no
+// trailing seq (e.g. the how_met "synth-<ns>-met-<stem>" or a place
+// "synth-<ns>-place-<stem>"), which the caller skips.
+var trailingSeqRE = regexp.MustCompile(`-(\d+)$`)
+
+func trailingSeq(s string) (int, bool) {
+	m := trailingSeqRE.FindStringSubmatch(s)
+	if m == nil {
+		return 0, false
+	}
+	n, err := strconv.Atoi(m[1])
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
 
 // fixedAccelBaseUnix is a deterministic TIME_BASE (a fixed Unix second) for the
 // high-acceleration settle-budget test, so the fixture makes no wall-clock call.
@@ -433,6 +455,44 @@ func TestSyntheticProfile_ProdShapedDeterministic(t *testing.T) {
 	require.Equal(t, fp1, fp2, "assertion (value_text, value_date, value_bool) fingerprint must be deterministic across runs")
 	require.NotEmpty(t, ent1, "the seed must produce entity nodes to fingerprint")
 	require.Equal(t, ent1, ent2, "entity (subtype, normalized_name) fingerprint must be deterministic across runs")
+
+	// Ordering guard for the "seed gen.X() LAST" rule (D2/R3). The run-to-run
+	// comparison above catches NON-deterministic drift but NOT a DETERMINISTIC
+	// mis-ordering of the gen.Entity pool (both runs would shift identically). A
+	// literal name golden is precluded here — syntheticNS(t) randomizes the namespace
+	// per run and the PRNG is seeded fnv(namespace), so the name component is not
+	// run-stable. The embedded sourceIDSeq IS run-stable (a pure counter, namespace-
+	// independent), so it is the pinnable witness: gen.Entity is seeded LAST, after
+	// the Phase-4 text-fact spread, so every gen.Entity-pool seq must exceed every
+	// text-fact value seq. A mis-ordered entity block (moved before the spread, or
+	// earlier among the source replays) inverts this and fails loudly — the
+	// regression class a same-impl two-run comparison cannot see. (place nodes ride
+	// WithLocation, not gen.Entity, and carry a stem not a seq, so they are excluded.)
+	maxTextFactSeq := -1
+	for _, a := range fp1 {
+		if a.ValueText == nil {
+			continue
+		}
+		if seq, ok := trailingSeq(*a.ValueText); ok && seq > maxTextFactSeq {
+			maxTextFactSeq = seq
+		}
+	}
+	minEntitySeq := -1
+	for _, e := range ent1 {
+		if e.Subtype == repository.EntitySubtypePlace {
+			continue // place names carry a stem, not a seq
+		}
+		seq, ok := trailingSeq(e.NormalizedName)
+		require.True(t, ok, "gen.Entity normalized_name %q must carry a trailing sourceIDSeq", e.NormalizedName)
+		if minEntitySeq == -1 || seq < minEntitySeq {
+			minEntitySeq = seq
+		}
+	}
+	require.GreaterOrEqual(t, maxTextFactSeq, 0, "the seed must produce text-fact assertions with a seq witness")
+	require.GreaterOrEqual(t, minEntitySeq, 0, "the seed must produce gen.Entity pool nodes with a seq witness")
+	require.Greater(t, minEntitySeq, maxTextFactSeq,
+		"gen.Entity pool must be seeded LAST (after the text-fact spread): entity seq %d must exceed max text-fact seq %d — a smaller entity seq means a mis-ordered gen.X() insertion (D2/R3)",
+		minEntitySeq, maxTextFactSeq)
 }
 
 // TestSyntheticProfile_QuiesceLeavesRows proves the seed-and-leave lifecycle:


### PR DESCRIPTION
## Summary

PR4 of the 8-PR synthetic seed enrichment (plan: `.ai/log/plan/seed-enrichment-prodshaped.md`). Adds the entity layer to the prod-shaped/dev seeds so the SP1 graph has organizations, topics, tags, and places — not just person nodes.

## Changes

- **Entity nodes + person→entity edges:** a `gen.Entity` + `SeedEntity` path seeds a small org/topic/tag pool; person→entity edge assertions (`works_at`→org, `interested_in`→topic, `tagged_as`→tag). `lives_in`→place is driven by `WithLocation` through the contact-create assertion path (flat ns-prefixed labels → no `within` hierarchy).
- **Tags = `tagged_as` edges** to tag entity nodes (the SP1 live path), NOT legacy `contact_tag` (which stays 0).
- **Entity-node teardown:** the integration teardown sweeps all ns-prefixed entity nodes (asserted to 0 post-teardown; zero `within` assertions).
- **Strengthened determinism guard:** beyond the run-twice fingerprint, the determinism test now pins the namespace-independent `sourceIDSeq` — asserting every entity-pool seq exceeds every text-fact seq, so a *deterministic* mis-ordering of the entity block (which run-twice-compare can't see) fails loudly. (Closes a real gap the determinism guard had since PR1.)

## Verification

- `go build ./...`, `make lint` (0), `make sqlc` clean.
- Full `make test-integration` (LONG_TESTS) green incl. ProdShapedCoverageCheck + ProdShapedDeterministic (exercises the new seq-witness).
- Codex review converged PASS; `/review-head` PASS (P0=0, P1=0) — independently confirmed the seq-witness guard is sound and entity teardown sweeps clean. Non-blocking P3s noted.

PRNG-LAST ordering preserved. Branched off `develop` after PR3 (#559).