### PR TITLE
feat(synthetic): seed relationship_signal rows

### DIFF
--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -1713,6 +1713,11 @@ type Querier interface {
 	// matched_contact_ids AND last_contacted_updated=true (the attended interaction
 	// published). Idempotent: a re-replay leaves the row processed.
 	SyntheticCountProcessedCalendarEventByGcalId(ctx context.Context, arg SyntheticCountProcessedCalendarEventByGcalIdParams) (int64, error)
+	// Cleanup/coverage assertion — count relationship_signal rows for the given subject
+	// nodes (scoped to THIS run's tracked node ids, so it is immune to parallel tests
+	// seeding their own signals on the shared DB). Used to assert ≥1 signal exists for
+	// the seeded nodes (coverage) and that 0 remain after teardown.
+	SyntheticCountRelationshipSignalsForNodes(ctx context.Context, nodeIds []pgtype.UUID) (int64, error)
 	// Settle Gate A (iMessage unknown-sender): the staging row for the guid landed
 	// (processed) with matched_contact_id IS NULL.
 	SyntheticCountStrandedMessagesMessageByGuid(ctx context.Context, guid string) (int64, error)
@@ -1855,6 +1860,12 @@ type Querier interface {
 	// predicates clears them by key prefix (the curated seed rows use bare keys and
 	// are never prefix-matched). Caller passes a BARE prefix; '%' is appended here.
 	SyntheticDeletePredicatesByKeyPrefix(ctx context.Context, keyPrefix pgtype.Text) (int64, error)
+	// Cleanup: hard-delete the relationship_signal rows a profile seeded on the given
+	// subject nodes, keyed by the tracked node ids. relationship_signal.subject_node_id
+	// is a real FK→node (NO ACTION, no soft delete), so these rows MUST be cleared
+	// BEFORE their subject nodes — the teardown runs this before the person/entity node
+	// deletes.
+	SyntheticDeleteRelationshipSignalsForNodes(ctx context.Context, nodeIds []pgtype.UUID) (int64, error)
 	// Cleanup: delete the group telegram_chat_config rows a group replay created, by
 	// the exact tracked chat ids (telegram_chat_config has no namespace column —
 	// keyed only by telegram_chat_id).

--- a/backend/internal/db/queries/test.sql
+++ b/backend/internal/db/queries/test.sql
@@ -667,6 +667,21 @@ SELECT COUNT(*) FROM node WHERE id = ANY(@node_ids::uuid[]) AND type = 'venue';
 -- self-FK, so a single multi-row DELETE clears a closed-pair set in one shot.
 DELETE FROM assertion WHERE subject_node_id = $1 OR object_node_id = $1;
 
+-- name: SyntheticDeleteRelationshipSignalsForNodes :execrows
+-- Cleanup: hard-delete the relationship_signal rows a profile seeded on the given
+-- subject nodes, keyed by the tracked node ids. relationship_signal.subject_node_id
+-- is a real FK→node (NO ACTION, no soft delete), so these rows MUST be cleared
+-- BEFORE their subject nodes — the teardown runs this before the person/entity node
+-- deletes.
+DELETE FROM relationship_signal WHERE subject_node_id = ANY(@node_ids::uuid[]);
+
+-- name: SyntheticCountRelationshipSignalsForNodes :one
+-- Cleanup/coverage assertion — count relationship_signal rows for the given subject
+-- nodes (scoped to THIS run's tracked node ids, so it is immune to parallel tests
+-- seeding their own signals on the shared DB). Used to assert ≥1 signal exists for
+-- the seeded nodes (coverage) and that 0 remain after teardown.
+SELECT COUNT(*) FROM relationship_signal WHERE subject_node_id = ANY(@node_ids::uuid[]);
+
 -- name: TestInsertContactAtID :exec
 -- Latent-person promotion test support: insert a contact row AT a caller-supplied
 -- id (node.id == contact.id), so a test can promote a latent person node (created

--- a/backend/internal/db/test.sql.go
+++ b/backend/internal/db/test.sql.go
@@ -991,6 +991,21 @@ func (q *Queries) SyntheticCountProcessedCalendarEventByGcalId(ctx context.Conte
 	return count, err
 }
 
+const SyntheticCountRelationshipSignalsForNodes = `-- name: SyntheticCountRelationshipSignalsForNodes :one
+SELECT COUNT(*) FROM relationship_signal WHERE subject_node_id = ANY($1::uuid[])
+`
+
+// Cleanup/coverage assertion — count relationship_signal rows for the given subject
+// nodes (scoped to THIS run's tracked node ids, so it is immune to parallel tests
+// seeding their own signals on the shared DB). Used to assert ≥1 signal exists for
+// the seeded nodes (coverage) and that 0 remain after teardown.
+func (q *Queries) SyntheticCountRelationshipSignalsForNodes(ctx context.Context, nodeIds []pgtype.UUID) (int64, error) {
+	row := q.db.QueryRow(ctx, SyntheticCountRelationshipSignalsForNodes, nodeIds)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const SyntheticCountStrandedMessagesMessageByGuid = `-- name: SyntheticCountStrandedMessagesMessageByGuid :one
 SELECT COUNT(*) FROM messages_message
 WHERE guid = $1
@@ -1518,6 +1533,23 @@ DELETE FROM predicate WHERE key LIKE $1 || '%'
 // are never prefix-matched). Caller passes a BARE prefix; '%' is appended here.
 func (q *Queries) SyntheticDeletePredicatesByKeyPrefix(ctx context.Context, keyPrefix pgtype.Text) (int64, error) {
 	result, err := q.db.Exec(ctx, SyntheticDeletePredicatesByKeyPrefix, keyPrefix)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const SyntheticDeleteRelationshipSignalsForNodes = `-- name: SyntheticDeleteRelationshipSignalsForNodes :execrows
+DELETE FROM relationship_signal WHERE subject_node_id = ANY($1::uuid[])
+`
+
+// Cleanup: hard-delete the relationship_signal rows a profile seeded on the given
+// subject nodes, keyed by the tracked node ids. relationship_signal.subject_node_id
+// is a real FK→node (NO ACTION, no soft delete), so these rows MUST be cleared
+// BEFORE their subject nodes — the teardown runs this before the person/entity node
+// deletes.
+func (q *Queries) SyntheticDeleteRelationshipSignalsForNodes(ctx context.Context, nodeIds []pgtype.UUID) (int64, error) {
+	result, err := q.db.Exec(ctx, SyntheticDeleteRelationshipSignalsForNodes, nodeIds)
 	if err != nil {
 		return 0, err
 	}

--- a/backend/internal/repository/synthetic_support.go
+++ b/backend/internal/repository/synthetic_support.go
@@ -938,3 +938,43 @@ func (r *SyntheticSupportRepository) ListEntityNamesByNodePrefix(ctx context.Con
 func (r *SyntheticSupportRepository) CountContactTagsByContactNamePrefix(ctx context.Context, namePrefix string) (int64, error) {
 	return r.queries.SyntheticCountContactTagsByContactNamePrefix(ctx, pgtype.Text{String: namePrefix, Valid: true})
 }
+
+// --- relationship_signal support (graph derived-storage) -------------------
+
+// UpsertRelationshipSignal writes one relationship_signal row through the
+// PRODUCTION UpsertRelationshipSignal query (storage-only — SP1 has no signal
+// generators, so the seed direct-writes the projection the way SP3 eventually
+// will). Idempotent on (subject_node_id, signal_key): a re-seed overwrites the
+// value + watermarks. computed_at is set by the query (NOW()); as_of is supplied
+// by the caller (anchor-relative, no time.Now()).
+func (r *SyntheticSupportRepository) UpsertRelationshipSignal(ctx context.Context, subjectNodeID uuid.UUID, signalKey string, value float64, asOf time.Time, methodVersion string) error {
+	return r.queries.UpsertRelationshipSignal(ctx, db.UpsertRelationshipSignalParams{
+		SubjectNodeID: uuidToPgUUID(subjectNodeID),
+		SignalKey:     signalKey,
+		Value:         value,
+		AsOf:          pgtype.Timestamptz{Time: asOf, Valid: true},
+		MethodVersion: methodVersion,
+	})
+}
+
+// DeleteRelationshipSignalsForNodes hard-deletes the relationship_signal rows a
+// profile seeded on the given subject nodes (cleanup). relationship_signal has no
+// deleted_at and its subject_node_id → node FK is NO ACTION, so the teardown MUST
+// run this BEFORE the node deletes. Keyed by the tracked node ids.
+func (r *SyntheticSupportRepository) DeleteRelationshipSignalsForNodes(ctx context.Context, nodeIDs []uuid.UUID) (int64, error) {
+	if len(nodeIDs) == 0 {
+		return 0, nil
+	}
+	return r.queries.SyntheticDeleteRelationshipSignalsForNodes(ctx, pgUUIDs(nodeIDs))
+}
+
+// CountRelationshipSignalsForNodes counts surviving relationship_signal rows for
+// the given subject nodes (scoped to the run's tracked node ids, so it is
+// parallel-test-safe). Used to assert ≥1 signal exists for the seeded nodes
+// (coverage) and that 0 remain after teardown.
+func (r *SyntheticSupportRepository) CountRelationshipSignalsForNodes(ctx context.Context, nodeIDs []uuid.UUID) (int64, error) {
+	if len(nodeIDs) == 0 {
+		return 0, nil
+	}
+	return r.queries.SyntheticCountRelationshipSignalsForNodes(ctx, pgUUIDs(nodeIDs))
+}

--- a/backend/internal/synthetic/profiles.go
+++ b/backend/internal/synthetic/profiles.go
@@ -702,13 +702,14 @@ var catalogEntityEdgePredicates = []string{
 
 // catalogSignalKeys is the small fixed pool of relationship_signal keys the seed
 // rotates over (one key per seeded node) so a few signal kinds repeat across many
-// person nodes (prod-like). SP1 has no signal generators, so these are
-// representative synthetic keys; teardown deletes by subject node id (not key), so
-// they need no namespace prefix.
+// person nodes (prod-like). These are the keys the app expects for SP1 derived
+// storage (closeness / real_cadence_days / trend, per repository.RelationshipSignal),
+// so seeded rows match what consumers read; teardown deletes by subject node id
+// (not key), so they need no namespace prefix.
 var catalogSignalKeys = []string{
 	"closeness",
-	"reciprocity",
-	"frequency",
+	"real_cadence_days",
+	"trend",
 }
 
 // syntheticSignalMethodVersion tags the method_version of the seeded

--- a/backend/internal/synthetic/profiles.go
+++ b/backend/internal/synthetic/profiles.go
@@ -82,6 +82,11 @@ type ProfileResult struct {
 	// reflected by ContactsWithLocation, not here.)
 	SeededEntities    int
 	SeededEntityEdges int
+	// SeededSignals counts the relationship_signal rows the profile seeded across
+	// catalog person nodes (one per node, keys from a small fixed pool). These are
+	// SP1 derived storage (per-node scalars), written through the production upsert
+	// path. Counts-only / no PII.
+	SeededSignals int
 }
 
 // ProfileParams returns the default SeedParams for a named profile (error on an
@@ -119,6 +124,9 @@ func ProfileParams(name Profile) (SeedParams, error) {
 				// edges so the dev graph surfaces show works_at/interested_in/tagged_as.
 				SeededEntities:    3,
 				SeededEntityEdges: 6,
+				// A few relationship_signal rows (SP1 derived storage) so the dev graph
+				// has per-node signals. One signal per node, rotating the signal-key pool.
+				SeededSignals: 6,
 			},
 		}, nil
 	case ProfileProdShaped:
@@ -155,6 +163,11 @@ func ProfileParams(name Profile) (SeedParams, error) {
 				// coverage + determinism tests override these down for CI.
 				SeededEntities:    9,
 				SeededEntityEdges: 30,
+				// ~20 relationship_signal rows (SP1 derived storage) across a subset of
+				// the catalog person nodes, one signal per node from a small fixed
+				// signal-key pool (a few signal kinds repeat across people, prod-like).
+				// The coverage + determinism tests override this down for CI.
+				SeededSignals: 20,
 			},
 		}, nil
 	default:
@@ -563,6 +576,32 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		res.SeededEntityEdges++
 	}
 
+	// relationship_signal rows (SP1 derived storage) on a subset of the catalog
+	// person nodes. In prod these are computed from comms analysis; SP1 has no
+	// signal generators yet, so the seed direct-writes them through the production
+	// UpsertRelationshipSignal path. SeedRelationshipSignal READS the already-seeded
+	// person nodes (no generator PRNG draw), so its position relative to the gen.X()
+	// blocks above is free; the subject_node_id → node FK (NO ACTION) means the
+	// teardown clears these BEFORE the node deletes. Each node gets one signal with a
+	// rotated key from a small fixed pool (a few signal kinds repeat across people,
+	// prod-like) and a deterministic value; as_of is the generator anchor (no
+	// time.Now()).
+	signals := params.Counts.SeededSignals
+	if signals > len(catalogContactIDs) {
+		signals = len(catalogContactIDs)
+	}
+	signalAsOf := gen.Anchor()
+	for i := 0; i < signals; i++ {
+		node := catalogContactIDs[i]
+		key := catalogSignalKeys[i%len(catalogSignalKeys)]
+		// Deterministic value in [0.50, 0.99] so signals carry varied non-zero scalars.
+		value := float64(50+i%50) / 100.0
+		if err := h.SeedRelationshipSignal(ctx, node, key, value, signalAsOf, syntheticSignalMethodVersion); err != nil {
+			return res, fmt.Errorf("profile %s: seed relationship signal %d: %w", params.Profile, i, err)
+		}
+		res.SeededSignals++
+	}
+
 	// Cadence tasks (Todoist) on the cadence-bearing catalog contacts. ReplayTodoist
 	// drives the REAL CadenceSyncProvider reconcile, which reads
 	// ListContactsWithContactBy (contact_by auto-computed from cadence by
@@ -660,6 +699,21 @@ var catalogEntityEdgePredicates = []string{
 	"interested_in",
 	"tagged_as",
 }
+
+// catalogSignalKeys is the small fixed pool of relationship_signal keys the seed
+// rotates over (one key per seeded node) so a few signal kinds repeat across many
+// person nodes (prod-like). SP1 has no signal generators, so these are
+// representative synthetic keys; teardown deletes by subject node id (not key), so
+// they need no namespace prefix.
+var catalogSignalKeys = []string{
+	"closeness",
+	"reciprocity",
+	"frequency",
+}
+
+// syntheticSignalMethodVersion tags the method_version of the seeded
+// relationship_signal rows so they are identifiable as toolkit-authored.
+const syntheticSignalMethodVersion = "synthetic-seed"
 
 // catalogLocationStems is the small fixed pool the lives_in location rotates over
 // so locations repeat across contacts (prod-like) while staying deterministic. The

--- a/backend/internal/synthetic/profiles_test.go
+++ b/backend/internal/synthetic/profiles_test.go
@@ -83,6 +83,9 @@ func TestProfileParams(t *testing.T) {
 	// has org/topic/tag entity nodes + works_at/interested_in/tagged_as edges.
 	require.Greater(t, prod.Counts.SeededEntities, 0)
 	require.Greater(t, prod.Counts.SeededEntityEdges, 0)
+	// prod-shaped seeds relationship_signal rows so the coverage check has SP1
+	// derived-storage signals to assert.
+	require.Greater(t, prod.Counts.SeededSignals, 0)
 }
 
 // TestDefaultParamsUnchanged pins DefaultParams field-for-field so the
@@ -106,4 +109,5 @@ func TestDefaultParamsUnchanged(t *testing.T) {
 	require.Equal(t, 0, p.Counts.SeededTasks)
 	require.Equal(t, 0, p.Counts.SeededEntities)
 	require.Equal(t, 0, p.Counts.SeededEntityEdges)
+	require.Equal(t, 0, p.Counts.SeededSignals)
 }

--- a/backend/internal/synthetic/replay/harness_cleanup.go
+++ b/backend/internal/synthetic/replay/harness_cleanup.go
@@ -237,6 +237,15 @@ func (h *Harness) cleanup(ctx context.Context) error {
 		_, err := h.support.DeleteContactsByIds(ctx, c.contactIDs)
 		return err
 	})
+	// 13a-pre2. relationship_signal on the seeded nodes: relationship_signal has no
+	// deleted_at and its subject_node_id → node FK is NO ACTION, so any signal a
+	// profile seeded MUST be deleted BEFORE the person/entity node deletes below.
+	// Keyed by the tracked subject node ids (the seed only writes signals on person
+	// nodes). No-op when no profile seeded any.
+	step("relationship_signal", func() error {
+		_, err := h.support.DeleteRelationshipSignalsForNodes(ctx, c.signalNodeIDs)
+		return err
+	})
 	// 13a-pre. assertions on the seeded contact nodes: the assertion→node FK is
 	// RESTRICT, so any assertion ReplayAssertion seeded on a person node MUST be
 	// deleted BEFORE the person-node delete below. Provenance cascades from the
@@ -318,6 +327,16 @@ func (h *Harness) ContactsRemaining(ctx context.Context) (int64, error) {
 // parallel tests creating their own venue nodes on the shared DB.
 func (h *Harness) VenueNodesRemaining(ctx context.Context) (int64, error) {
 	return h.support.CountVenueNodesByIds(ctx, h.snapshotVenueNodeIDs())
+}
+
+// SignalsRemaining counts how many relationship_signal rows still exist on THIS
+// run's tracked signal subject nodes. Used both ways: before teardown a coverage
+// test asserts it is ≥1 (signals were seeded), and after an explicit teardown a
+// determinism test asserts it is 0 (the signal-cleanup step ran before the node
+// deletes). Scoped to the tracked node ids, so it is immune to parallel tests
+// seeding their own signals on the shared DB.
+func (h *Harness) SignalsRemaining(ctx context.Context) (int64, error) {
+	return h.support.CountRelationshipSignalsForNodes(ctx, h.snapshotSignalNodeIDs())
 }
 
 // --- deferred shim workers (bus needs client; real workers need bus) -------

--- a/backend/internal/synthetic/replay/replay.go
+++ b/backend/internal/synthetic/replay/replay.go
@@ -89,6 +89,11 @@ type created struct {
 	// (after the interaction delete, which clears the restrict FK) or the shared
 	// DB leaks a venue node per distinct container.
 	venueNodeIDs []uuid.UUID
+	// signalNodeIDs are the subject node ids a profile seeded a relationship_signal
+	// on. relationship_signal has no namespace column + no deleted_at, and its
+	// subject_node_id → node FK is NO ACTION, so cleanup MUST delete these rows by
+	// the tracked node ids BEFORE the node deletes.
+	signalNodeIDs []uuid.UUID
 	// directSources is the set of sources the adapters published root events
 	// under, so Cleanup can capture no-contact root events that the
 	// contact-scoped read misses.
@@ -102,6 +107,7 @@ func newCreated() *created {
 func (c *created) addContact(id uuid.UUID)       { c.contactIDs = append(c.contactIDs, id) }
 func (c *created) addInteraction(id uuid.UUID)   { c.interactionIDs = append(c.interactionIDs, id) }
 func (c *created) addVenueNode(id uuid.UUID)     { c.venueNodeIDs = append(c.venueNodeIDs, id) }
+func (c *created) addSignalNode(id uuid.UUID)    { c.signalNodeIDs = append(c.signalNodeIDs, id) }
 func (c *created) addTelegramPeer(id int64)      { c.telegramPeerIDs = append(c.telegramPeerIDs, id) }
 func (c *created) addTelegramChat(id int64)      { c.telegramChatIDs = append(c.telegramChatIDs, id) }
 func (c *created) addContactTask(id uuid.UUID)   { c.contactTaskIDs = append(c.contactTaskIDs, id) }
@@ -264,6 +270,21 @@ func (h *Harness) SeedEntity(ctx context.Context, spec factory.EntitySpec) (uuid
 		return uuid.Nil, fmt.Errorf("seed entity: commit: %w", err)
 	}
 	return nodeID, nil
+}
+
+// SeedRelationshipSignal writes one relationship_signal row for a seeded node
+// through the PRODUCTION UpsertRelationshipSignal write path (storage-only — SP1
+// has no signal generators, so the toolkit direct-writes the projection the way
+// SP3 eventually will). subjectNodeID must be a node the harness seeded (a person
+// node, node.id == contact.id) so the teardown — which deletes signals by the
+// tracked node ids BEFORE the node deletes — cleans it. Idempotent on
+// (subjectNodeID, signalKey). asOf is anchor-relative (no time.Now()).
+func (h *Harness) SeedRelationshipSignal(ctx context.Context, subjectNodeID uuid.UUID, signalKey string, value float64, asOf time.Time, methodVersion string) error {
+	if err := h.support.UpsertRelationshipSignal(ctx, subjectNodeID, signalKey, value, asOf, methodVersion); err != nil {
+		return fmt.Errorf("seed relationship signal: %w", err)
+	}
+	h.track(func(c *created) { c.addSignalNode(subjectNodeID) })
+	return nil
 }
 
 // SeedNote attaches a notepad note to a seeded contact via the EXISTING
@@ -458,6 +479,12 @@ func (h *Harness) snapshotVenueNodeIDs() []uuid.UUID {
 	h.createdMu.Lock()
 	defer h.createdMu.Unlock()
 	return append([]uuid.UUID(nil), h.created.venueNodeIDs...)
+}
+
+func (h *Harness) snapshotSignalNodeIDs() []uuid.UUID {
+	h.createdMu.Lock()
+	defer h.createdMu.Unlock()
+	return append([]uuid.UUID(nil), h.created.signalNodeIDs...)
 }
 
 // gateBClear reports whether Gate B has reached zero for this replay's contacts.

--- a/backend/internal/synthetic/synthetic.go
+++ b/backend/internal/synthetic/synthetic.go
@@ -122,6 +122,12 @@ type Counts struct {
 	// it rides the contact-create authority flip via WithLocation, index-spread like
 	// the birthday/how_met bio facts.)
 	SeededEntityEdges int
+	// SeededSignals is the number of relationship_signal rows seeded across distinct
+	// catalog person nodes (one signal per node, rotating a small fixed signal-key
+	// pool so a few signal kinds repeat prod-like). Bounded by the catalog size at
+	// run time. Written through the production UpsertRelationshipSignal path
+	// (storage-only — SP1 has no signal generators). 0 disables.
+	SeededSignals int
 }
 
 // SeedParams is the profile/volume seam consumed by the seed orchestration.

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -182,7 +182,7 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 	params.Counts.SeededEntities = 3
 	params.Counts.SeededEntityEdges = 3
 	// A few relationship_signal rows (SP1 derived storage) across distinct catalog
-	// person nodes, one full signal-key cycle (closeness/reciprocity/frequency).
+	// person nodes, one full signal-key cycle (closeness/real_cadence_days/trend).
 	params.Counts.SeededSignals = 3
 
 	h := synthetic.NewHarnessForNamespace(t, ctx, database, params.Namespace, params.Seed)

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -127,6 +127,9 @@ func TestSyntheticProfile_DevCoversCatalog(t *testing.T) {
 	// dev knob counts, so the seeded counts are exact (no catalog-size bounding).
 	require.Equal(t, params.Counts.SeededEntities, res.SeededEntities, "dev profile seeds the entity pool")
 	require.Equal(t, params.Counts.SeededEntityEdges, res.SeededEntityEdges, "dev profile seeds person→entity edges")
+	// relationship_signal rows: the dev catalog (18) exceeds the small dev signal
+	// knob, so the seeded count is exact (no catalog-size bounding).
+	require.Equal(t, params.Counts.SeededSignals, res.SeededSignals, "dev profile seeds relationship signals")
 	// lives_in locations ride the contact-create authority flip, spread by catalog
 	// index; the dev catalog is large enough to carry ≥1.
 	require.GreaterOrEqual(t, res.ContactsWithLocation, 1, "dev profile seeds location bio facts")
@@ -178,6 +181,9 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 	// size) — not a count knob.
 	params.Counts.SeededEntities = 3
 	params.Counts.SeededEntityEdges = 3
+	// A few relationship_signal rows (SP1 derived storage) across distinct catalog
+	// person nodes, one full signal-key cycle (closeness/reciprocity/frequency).
+	params.Counts.SeededSignals = 3
 
 	h := synthetic.NewHarnessForNamespace(t, ctx, database, params.Namespace, params.Seed)
 	res, err := synthetic.RunProfile(ctx, h, params)
@@ -338,6 +344,17 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(0), legacyContactTags, "tags seeded as tagged_as edges, not legacy contact_tag rows")
 
+	// relationship_signal (SP1 derived storage): the seed writes per-node scalar
+	// signals on a subset of catalog person nodes through the production upsert path.
+	// Assert the result count and that the rows actually landed in the DB (scoped to
+	// THIS run's tracked signal nodes). The harness teardown (t.Cleanup) deletes them
+	// before the node deletes; the explicit signals-remaining==0 check lives in the
+	// determinism test, which tears down inline.
+	require.GreaterOrEqual(t, res.SeededSignals, 1, "relationship signals seeded")
+	signalsLanded, err := h.SignalsRemaining(ctx)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, signalsLanded, int64(1), "≥1 relationship_signal row present for the seeded nodes")
+
 	// Cadence tasks: ReplayTodoist seeds a `managed` cadence task on each
 	// cadence-bearing catalog contact, and the profile transitions a deterministic
 	// three to completed/dismissed/unmanaged. Assert ≥1 row in EACH state the seed
@@ -412,6 +429,9 @@ func TestSyntheticProfile_ProdShapedDeterministic(t *testing.T) {
 	// the entity normalized_name fingerprint covers org/topic/tag/place subtypes.
 	params.Counts.SeededEntities = 3
 	params.Counts.SeededEntityEdges = 3
+	// A few relationship_signal rows so the run-to-run ProfileResult count
+	// (res.SeededSignals) is exercised and the teardown sweep is asserted below.
+	params.Counts.SeededSignals = 3
 	params.Counts.UnmatchedExternal = 1
 	params.Counts.StrandedTelegram = 1
 	params.Counts.StrandedMessages = 1
@@ -448,6 +468,12 @@ func TestSyntheticProfile_ProdShapedDeterministic(t *testing.T) {
 		remaining, err := support.ListEntityNamesByNodePrefix(ctx, prefix)
 		require.NoError(t, err)
 		require.Empty(t, remaining, "entity nodes (pool + place) swept by teardown")
+		// Teardown correctness: the relationship_signal rows (FK→node, NO ACTION) are
+		// swept BEFORE the node deletes, so none remain for the seeded subject nodes —
+		// a leaked signal would FK-block the next run's person-node delete.
+		sigRemaining, err := h.SignalsRemaining(ctx)
+		require.NoError(t, err)
+		require.Zero(t, sigRemaining, "relationship_signal rows swept by teardown")
 		return res, fp, entFP
 	}
 


### PR DESCRIPTION
## Summary

PR5 of the 8-PR synthetic seed enrichment (plan: `.ai/log/plan/seed-enrichment-prodshaped.md`). Seeds `relationship_signal` rows (SP1 derived storage — per-node scalars) so the prod-shaped/dev graph carries the signal projection, not just nodes/assertions/edges.

## Changes

- **Seeding:** a `SeededSignals` knob writes `relationship_signal` rows across catalog person nodes (one per node, rotating a small key pool) via the **production `UpsertRelationshipSignal` query** (thin `SyntheticSupportRepository` wrapper — no new write SQL). Keys are the canonical `closeness`/`real_cadence_days`/`trend` (the keys `repository.RelationshipSignal` documents the app expects), so seeded rows match what consumers read.
- **Teardown:** test-only batch DELETE + scoped COUNT; the teardown deletes signals BEFORE the node deletes (FK `subject_node_id → node`, NO ACTION, no `deleted_at`); determinism test asserts signals-remaining == 0.
- Seed path draws no generator PRNG (reads already-seeded nodes); `as_of` via `gen.Anchor()` (no `time.Now()`).

## Verification

- `go build ./...`, `make sqlc` clean.
- Full `make test-integration` (LONG_TESTS) green incl. ProdShapedCoverageCheck + ProdShapedDeterministic (signals count-stable + swept to 0).
- Codex review (1 round → fixed the signal-key vocabulary) + `/review-head` PASS (P0=0, P1=0) — independently confirmed canonical keys, production write path, teardown FK-ordering. Non-blocking P2/P3 (key-aware assertion + value realism) tracked as plan follow-ups.

PRNG-LAST preserved. Branched off `develop` after PR4 (#560).