### PR TITLE
feat(synthetic): spread settled interactions over time

### DIFF
--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -2096,6 +2096,14 @@ type Querier interface {
 	// exact key columns + partial predicate of the eligible/stale-claim indexes
 	// (migration 073). Read-only catalog access, mirroring TestListPublicTables.
 	TestListIndexDefsForComms(ctx context.Context) ([]*TestListIndexDefsForCommsRow, error)
+	// Profile coverage test only: for the namespace's contacts (by full_name prefix)
+	// that have interactions, return the per-contact interaction count and the span
+	// (in seconds) between the earliest and latest interaction, so the test can
+	// assert the dedicated settled contacts carry MULTIPLE interactions spread over
+	// TIME (count ≥ 2 with a multi-day span) rather than a single ~1h window. The
+	// INNER JOIN excludes the interaction-free edge-case catalog contacts. Caller
+	// passes a BARE prefix; '%' appended.
+	TestListInteractionSpreadByContactNamePrefix(ctx context.Context, namePrefix pgtype.Text) ([]*TestListInteractionSpreadByContactNamePrefixRow, error)
 	// Reset integration test only: enumerate every base table in the public schema
 	// so the catalog guard can assert each is in the wiped list, is schema_migrations,
 	// or matches the river_% allowlist. Read-only catalog access.

--- a/backend/internal/db/queries/test.sql
+++ b/backend/internal/db/queries/test.sql
@@ -933,6 +933,24 @@ FROM contact c
 WHERE c.full_name LIKE @name_prefix || '%'
   AND c.deleted_at IS NULL;
 
+-- name: TestListInteractionSpreadByContactNamePrefix :many
+-- Profile coverage test only: for the namespace's contacts (by full_name prefix)
+-- that have interactions, return the per-contact interaction count and the span
+-- (in seconds) between the earliest and latest interaction, so the test can
+-- assert the dedicated settled contacts carry MULTIPLE interactions spread over
+-- TIME (count ≥ 2 with a multi-day span) rather than a single ~1h window. The
+-- INNER JOIN excludes the interaction-free edge-case catalog contacts. Caller
+-- passes a BARE prefix; '%' appended.
+SELECT
+    c.id,
+    COUNT(i.id) AS interaction_count,
+    EXTRACT(EPOCH FROM (MAX(i.occurred_at) - MIN(i.occurred_at)))::bigint AS span_seconds
+FROM contact c
+JOIN interaction i ON i.contact_id = c.id AND i.deleted_at IS NULL
+WHERE c.full_name LIKE @name_prefix || '%'
+  AND c.deleted_at IS NULL
+GROUP BY c.id;
+
 -- name: DeleteSyncStatesBySourceForTest :execrows
 -- Test teardown only — hard-deletes external_sync_state rows for a given
 -- source. Used by sync-service tests to scope per-source cleanup without

--- a/backend/internal/db/test.sql.go
+++ b/backend/internal/db/test.sql.go
@@ -2208,6 +2208,51 @@ func (q *Queries) TestListIndexDefsForComms(ctx context.Context) ([]*TestListInd
 	return items, nil
 }
 
+const TestListInteractionSpreadByContactNamePrefix = `-- name: TestListInteractionSpreadByContactNamePrefix :many
+SELECT
+    c.id,
+    COUNT(i.id) AS interaction_count,
+    EXTRACT(EPOCH FROM (MAX(i.occurred_at) - MIN(i.occurred_at)))::bigint AS span_seconds
+FROM contact c
+JOIN interaction i ON i.contact_id = c.id AND i.deleted_at IS NULL
+WHERE c.full_name LIKE $1 || '%'
+  AND c.deleted_at IS NULL
+GROUP BY c.id
+`
+
+type TestListInteractionSpreadByContactNamePrefixRow struct {
+	ID               pgtype.UUID `json:"id"`
+	InteractionCount int64       `json:"interaction_count"`
+	SpanSeconds      int64       `json:"span_seconds"`
+}
+
+// Profile coverage test only: for the namespace's contacts (by full_name prefix)
+// that have interactions, return the per-contact interaction count and the span
+// (in seconds) between the earliest and latest interaction, so the test can
+// assert the dedicated settled contacts carry MULTIPLE interactions spread over
+// TIME (count ≥ 2 with a multi-day span) rather than a single ~1h window. The
+// INNER JOIN excludes the interaction-free edge-case catalog contacts. Caller
+// passes a BARE prefix; '%' appended.
+func (q *Queries) TestListInteractionSpreadByContactNamePrefix(ctx context.Context, namePrefix pgtype.Text) ([]*TestListInteractionSpreadByContactNamePrefixRow, error) {
+	rows, err := q.db.Query(ctx, TestListInteractionSpreadByContactNamePrefix, namePrefix)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []*TestListInteractionSpreadByContactNamePrefixRow{}
+	for rows.Next() {
+		var i TestListInteractionSpreadByContactNamePrefixRow
+		if err := rows.Scan(&i.ID, &i.InteractionCount, &i.SpanSeconds); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const TestListPublicTables = `-- name: TestListPublicTables :many
 SELECT table_name::text FROM information_schema.tables
 WHERE table_schema = 'public' AND table_type = 'BASE TABLE'

--- a/backend/internal/repository/synthetic_support.go
+++ b/backend/internal/repository/synthetic_support.go
@@ -687,6 +687,37 @@ func (r *SyntheticSupportRepository) ListContactBucketsByNamePrefix(ctx context.
 	return out, nil
 }
 
+// InteractionSpread is the per-contact interaction-history projection of a seeded
+// contact (profile coverage test only): how many interactions it carries and the
+// span between its earliest and latest one.
+type InteractionSpread struct {
+	ContactID        uuid.UUID
+	InteractionCount int64
+	Span             time.Duration
+}
+
+// ListInteractionSpreadByContactNamePrefix returns, for the namespace's contacts
+// (by full_name prefix) that have interactions, the per-contact interaction count
+// and the span between the earliest and latest interaction, so the profile
+// coverage test can assert the dedicated settled contacts carry MULTIPLE
+// interactions spread over TIME (count ≥ 2 with a multi-day span) rather than a
+// single window. Test only.
+func (r *SyntheticSupportRepository) ListInteractionSpreadByContactNamePrefix(ctx context.Context, namePrefix string) ([]InteractionSpread, error) {
+	rows, err := r.queries.TestListInteractionSpreadByContactNamePrefix(ctx, pgtype.Text{String: namePrefix, Valid: true})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]InteractionSpread, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, InteractionSpread{
+			ContactID:        uuid.UUID(row.ID.Bytes),
+			InteractionCount: row.InteractionCount,
+			Span:             time.Duration(row.SpanSeconds) * time.Second,
+		})
+	}
+	return out, nil
+}
+
 // --- Graph identity support -------------------------------------------------
 
 // CountNodesByLabelPrefix counts nodes whose canonical_label is ns-prefixed, so

--- a/backend/internal/synthetic/factory/sources.go
+++ b/backend/internal/synthetic/factory/sources.go
@@ -19,6 +19,43 @@ import (
 // MatchUnknown the factory addresses an unknown identifier the seeded contacts
 // do NOT own, exercising the per-source pending / match-only path.
 
+// MessageOption tunes a source-message payload. The only knob today is the
+// message's age — how far before the generator anchor it is timestamped — so the
+// same contact can be replayed repeatedly with its interactions spread back over
+// time (weeks/months) instead of all landing in one ~1h window.
+type MessageOption func(*messageConfig)
+
+type messageConfig struct {
+	// age is an EXTRA backward offset added on top of each source's small default
+	// offset (e.g. Gmail's −2h). Zero leaves the default (the most-recent message);
+	// growing it across a replay loop spreads older interactions back over time.
+	age time.Duration
+}
+
+// WithMessageAge shifts a source message's timestamp further back by age, added
+// on top of the source's small default offset. Looping a source replay with
+// growing ages spreads a contact's interactions over time. The anchor stays the
+// generator's (accelerated.GetCurrentTime() by default — never time.Now()), so
+// the result is still anchor-relative/deterministic. age is clamped to ≥ 0 (a
+// negative age, which would date a message into the future, is treated as 0).
+func WithMessageAge(age time.Duration) MessageOption {
+	return func(c *messageConfig) {
+		if age < 0 {
+			age = 0
+		}
+		c.age = age
+	}
+}
+
+// applyMessageOptions folds the variadic options into a config.
+func applyMessageOptions(opts []MessageOption) messageConfig {
+	var c messageConfig
+	for _, o := range opts {
+		o(&c)
+	}
+	return c
+}
+
 // --- Gmail -----------------------------------------------------------------
 
 // GmailMessageSpec bundles a *gmail.Message plus the account ("me") it was
@@ -35,7 +72,8 @@ type GmailMessageSpec struct {
 // from an unknown correspondent (MatchUnknown → match-only: no contact, no
 // interaction). SentAt is anchored before now − safety lag so the Gmail cursor
 // window includes it.
-func (g *Generator) GmailMessage(target ContactSpec, intent MatchIntent) GmailMessageSpec {
+func (g *Generator) GmailMessage(target ContactSpec, intent MatchIntent, opts ...MessageOption) GmailMessageSpec {
+	mo := applyMessageOptions(opts)
 	account := g.accountEmail()
 	from := target.Email
 	if intent == MatchUnknown {
@@ -48,8 +86,8 @@ func (g *Generator) GmailMessage(target ContactSpec, intent MatchIntent) GmailMe
 	}
 	externalID := fmt.Sprintf("<%sgmail-%d@synthetic.example>", g.Prefix(), g.bumpSourceSeq())
 	// 2h before now − safety lag (anchor-relative) so it is inside the scanned,
-	// already-closed window.
-	sentAt := g.at(-(2 * time.Hour))
+	// already-closed window; mo.age shifts it further back for the temporal spread.
+	sentAt := g.at(-(2 * time.Hour) - mo.age)
 	gmailID := g.Prefix() + "gid-" + fmt.Sprint(g.sourceIDSeq)
 
 	msg := &gmailapi.Message{
@@ -97,13 +135,14 @@ type GChatMessageSpec struct {
 // GChatMessage builds an inbound chat message from the target contact
 // (MatchSeeded) or an unknown sender (MatchUnknown → match-only: no row, no
 // interaction, no contact). Anchor-relative create time.
-func (g *Generator) GChatMessage(target ContactSpec, intent MatchIntent) GChatMessageSpec {
+func (g *Generator) GChatMessage(target ContactSpec, intent MatchIntent, opts ...MessageOption) GChatMessageSpec {
+	mo := applyMessageOptions(opts)
 	account := g.accountEmail()
 	seq := g.bumpSourceSeq()
 	ns := g.Prefix()
 	spaceName := fmt.Sprintf("spaces/%sSP-%d", ns, seq)
 	msgName := fmt.Sprintf("%s/messages/%sm-%d", spaceName, ns, seq)
-	createTime := g.at(-time.Hour)
+	createTime := g.at(-time.Hour - mo.age)
 
 	senderUser := fmt.Sprintf("users/%ssender-%d", ns, seq)
 	meUser := fmt.Sprintf("users/%sme-%d", ns, seq)
@@ -153,7 +192,8 @@ type GCalEventSpec struct {
 // contact (MatchSeeded → matched attendee + attended interaction) or with an
 // unknown attendee (MatchUnknown → unmatched attendee → matched_contact_ids='{}'
 // + external_contact candidate).
-func (g *Generator) GCalEvent(target ContactSpec, intent MatchIntent) GCalEventSpec {
+func (g *Generator) GCalEvent(target ContactSpec, intent MatchIntent, opts ...MessageOption) GCalEventSpec {
+	mo := applyMessageOptions(opts)
 	account := g.accountEmail()
 	seq := g.bumpSourceSeq()
 	gcalEventID := fmt.Sprintf("%sgcal-%d", g.Prefix(), seq)
@@ -162,9 +202,10 @@ func (g *Generator) GCalEvent(target ContactSpec, intent MatchIntent) GCalEventS
 	if intent == MatchUnknown || attendeeEmail == "" {
 		attendeeEmail = g.unknownEmail()
 	}
-	// Past meeting: started 2h ago, ended 1h ago (anchor-relative).
-	start := g.at(-2 * time.Hour)
-	end := g.at(-1 * time.Hour)
+	// Past meeting: started 2h ago, ended 1h ago (anchor-relative); mo.age shifts
+	// the whole meeting further back for the temporal spread.
+	start := g.at(-2*time.Hour - mo.age)
+	end := g.at(-1*time.Hour - mo.age)
 
 	ev := &calendarapi.Event{
 		Id:      gcalEventID,
@@ -204,12 +245,13 @@ type TelegramMessageSpec struct {
 // or an unknown peer (MatchUnknown → telegram_message.matched_contact_id IS NULL
 // + discovery candidate). PeerUserID/TelegramMessageID come from this namespace's
 // reserved numeric sub-blocks.
-func (g *Generator) TelegramMessage(target ContactSpec, intent MatchIntent) TelegramMessageSpec {
+func (g *Generator) TelegramMessage(target ContactSpec, intent MatchIntent, opts ...MessageOption) TelegramMessageSpec {
+	mo := applyMessageOptions(opts)
 	peerUserID := g.nextPeerUserID()
 	msgID := g.nextTelegramMessageID()
 	// Private chat id == peer user id (1:1 chat).
 	chatID := peerUserID
-	sentAt := g.at(-time.Hour)
+	sentAt := g.at(-time.Hour - mo.age)
 
 	handle := target.TelegramHandle
 	username := handle
@@ -319,7 +361,8 @@ type IMessageSpec struct {
 // messages_message.matched_contact_id IS NULL). hostID is the revoked synthetic
 // mac host the harness seeded (the payload's HostID field; the host-only kind
 // allowlist requires a non-nil host).
-func (g *Generator) IMessage(target ContactSpec, intent MatchIntent, hostID uuid.UUID) (IMessageSpec, error) {
+func (g *Generator) IMessage(target ContactSpec, intent MatchIntent, hostID uuid.UUID, opts ...MessageOption) (IMessageSpec, error) {
+	mo := applyMessageOptions(opts)
 	seq := g.bumpSourceSeq()
 	guid := fmt.Sprintf("%simsg-%d", g.Prefix(), seq)
 	chatGuid := fmt.Sprintf("%schat-%d", g.Prefix(), seq)
@@ -328,7 +371,7 @@ func (g *Generator) IMessage(target ContactSpec, intent MatchIntent, hostID uuid
 	if intent == MatchUnknown || peerHandle == "" {
 		peerHandle = g.unknownPhone()
 	}
-	sentAt := g.at(-time.Hour)
+	sentAt := g.at(-time.Hour - mo.age)
 
 	payload := events.RawMessageReceivedPayload{
 		Version:     1,

--- a/backend/internal/synthetic/profiles.go
+++ b/backend/internal/synthetic/profiles.go
@@ -87,6 +87,13 @@ type ProfileResult struct {
 	// SP1 derived storage (per-node scalars), written through the production upsert
 	// path. Counts-only / no PII.
 	SeededSignals int
+	// SettledInteractions counts the settled source replays the profile drove on the
+	// dedicated per-source contacts — MessagesPerContact messages each, across the
+	// five sources — so the staging history is multi-interaction and spread over
+	// time rather than one message per contact. It is the replay-call count, the
+	// upper bound on the interaction rows produced (same-day messages on one contact
+	// would aggregate, but the spread lands them on distinct days). Counts-only / no PII.
+	SettledInteractions int
 }
 
 // ProfileParams returns the default SeedParams for a named profile (error on an
@@ -127,6 +134,10 @@ func ProfileParams(name Profile) (SeedParams, error) {
 				// A few relationship_signal rows (SP1 derived storage) so the dev graph
 				// has per-node signals. One signal per node, rotating the signal-key pool.
 				SeededSignals: 6,
+				// Two settled interactions per dedicated source contact, spread over time,
+				// so the dev graph shows a small multi-interaction history (fast: the dev
+				// per-source settled count is 1).
+				MessagesPerContact: 2,
 			},
 		}, nil
 	case ProfileProdShaped:
@@ -168,6 +179,11 @@ func ProfileParams(name Profile) (SeedParams, error) {
 				// signal-key pool (a few signal kinds repeat across people, prod-like).
 				// The coverage + determinism tests override this down for CI.
 				SeededSignals: 20,
+				// Four settled interactions per dedicated source contact, spread back over
+				// ~9 weeks, so staging shows a prod-like multi-interaction history per
+				// source instead of a single recent message. The coverage + determinism
+				// tests override this down for CI runtime.
+				MessagesPerContact: 4,
 			},
 		}, nil
 	default:
@@ -294,9 +310,22 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 
 	// A few settled interactions on DEDICATED contacts per source so every source
 	// surface has matched content WITHOUT clobbering the catalog's cadence states.
-	// Each settled contact carries a recent last_contacted (the inbound message),
+	// Each settled contact carries a recent last_contacted (its newest message),
 	// which is the correct "recently contacted via X" representation.
+	//
+	// Each contact is replayed messagesPer times with growing per-message ages
+	// (interactionSpreadAge), so its interactions land on distinct days spread back
+	// over time (a prod-like history) instead of one ~1h window. The newest message
+	// (age 0) drives last_contacted; older ones never move it back (the consumers'
+	// forward-only occurred_at guard), so the "recently contacted" state holds while
+	// the contact also carries a deeper history. The spread targets ONLY these
+	// dedicated contacts — the edge-case catalog above stays interaction-free so its
+	// overdue / never-contacted / no-method buckets survive.
 	perSource := perSourceSettledCount(params.Profile)
+	messagesPer := params.Counts.MessagesPerContact
+	if messagesPer < 1 {
+		messagesPer = 1
+	}
 
 	for i := 0; i < perSource; i++ {
 		// Gmail-settled (email match).
@@ -306,8 +335,11 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 			return res, fmt.Errorf("profile %s: seed gmail contact %d: %w", params.Profile, i, err)
 		}
 		res.Contacts++
-		if _, err := h.ReplayGmail(ctx, gmContact.ID, gen.GmailMessage(gmSpec, factory.MatchSeeded)); err != nil {
-			return res, fmt.Errorf("profile %s: replay gmail %d: %w", params.Profile, i, err)
+		for j := 0; j < messagesPer; j++ {
+			if _, err := h.ReplayGmail(ctx, gmContact.ID, gen.GmailMessage(gmSpec, factory.MatchSeeded, factory.WithMessageAge(interactionSpreadAge(j)))); err != nil {
+				return res, fmt.Errorf("profile %s: replay gmail %d msg %d: %w", params.Profile, i, j, err)
+			}
+			res.SettledInteractions++
 		}
 		res.GmailSettled++
 
@@ -318,8 +350,11 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 			return res, fmt.Errorf("profile %s: seed telegram contact %d: %w", params.Profile, i, err)
 		}
 		res.Contacts++
-		if _, err := h.ReplayTelegram(ctx, tgContact.ID, gen.TelegramMessage(tgSpec, factory.MatchSeeded)); err != nil {
-			return res, fmt.Errorf("profile %s: replay telegram %d: %w", params.Profile, i, err)
+		for j := 0; j < messagesPer; j++ {
+			if _, err := h.ReplayTelegram(ctx, tgContact.ID, gen.TelegramMessage(tgSpec, factory.MatchSeeded, factory.WithMessageAge(interactionSpreadAge(j)))); err != nil {
+				return res, fmt.Errorf("profile %s: replay telegram %d msg %d: %w", params.Profile, i, j, err)
+			}
+			res.SettledInteractions++
 		}
 		res.TelegramSettled++
 
@@ -330,8 +365,11 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 			return res, fmt.Errorf("profile %s: seed gcal contact %d: %w", params.Profile, i, err)
 		}
 		res.Contacts++
-		if _, err := h.ReplayGCal(ctx, gcContact.ID, gen.GCalEvent(gcSpec, factory.MatchSeeded)); err != nil {
-			return res, fmt.Errorf("profile %s: replay gcal %d: %w", params.Profile, i, err)
+		for j := 0; j < messagesPer; j++ {
+			if _, err := h.ReplayGCal(ctx, gcContact.ID, gen.GCalEvent(gcSpec, factory.MatchSeeded, factory.WithMessageAge(interactionSpreadAge(j)))); err != nil {
+				return res, fmt.Errorf("profile %s: replay gcal %d msg %d: %w", params.Profile, i, j, err)
+			}
+			res.SettledInteractions++
 		}
 		res.GCalSettled++
 
@@ -342,8 +380,11 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 			return res, fmt.Errorf("profile %s: seed gchat contact %d: %w", params.Profile, i, err)
 		}
 		res.Contacts++
-		if _, err := h.ReplayGChat(ctx, gchatContact.ID, gen.GChatMessage(gchatSpec, factory.MatchSeeded)); err != nil {
-			return res, fmt.Errorf("profile %s: replay gchat %d: %w", params.Profile, i, err)
+		for j := 0; j < messagesPer; j++ {
+			if _, err := h.ReplayGChat(ctx, gchatContact.ID, gen.GChatMessage(gchatSpec, factory.MatchSeeded, factory.WithMessageAge(interactionSpreadAge(j)))); err != nil {
+				return res, fmt.Errorf("profile %s: replay gchat %d msg %d: %w", params.Profile, i, j, err)
+			}
+			res.SettledInteractions++
 		}
 		res.GChatSettled++
 
@@ -354,12 +395,15 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 			return res, fmt.Errorf("profile %s: seed imessage contact %d: %w", params.Profile, i, err)
 		}
 		res.Contacts++
-		imageSpec, err := gen.IMessage(imSpec, factory.MatchSeeded, h.MacHostID())
-		if err != nil {
-			return res, fmt.Errorf("profile %s: build imessage spec %d: %w", params.Profile, i, err)
-		}
-		if _, err := h.ReplayIMessage(ctx, imContact.ID, imageSpec); err != nil {
-			return res, fmt.Errorf("profile %s: replay imessage %d: %w", params.Profile, i, err)
+		for j := 0; j < messagesPer; j++ {
+			imageSpec, err := gen.IMessage(imSpec, factory.MatchSeeded, h.MacHostID(), factory.WithMessageAge(interactionSpreadAge(j)))
+			if err != nil {
+				return res, fmt.Errorf("profile %s: build imessage spec %d msg %d: %w", params.Profile, i, j, err)
+			}
+			if _, err := h.ReplayIMessage(ctx, imContact.ID, imageSpec); err != nil {
+				return res, fmt.Errorf("profile %s: replay imessage %d msg %d: %w", params.Profile, i, j, err)
+			}
+			res.SettledInteractions++
 		}
 		res.IMessageSettled++
 	}
@@ -821,6 +865,21 @@ func perSourceSettledCount(p Profile) int {
 		return 3
 	}
 	return 1
+}
+
+// interactionSpreadInterval is the deterministic gap between successive settled
+// interactions on one contact. It is wider than a day so the messaging-aggregate
+// sources (gchat / messages / telegram), which collapse same-day messages into a
+// single interaction, still yield one interaction per replayed message; ~3 weeks
+// gives a months-scale history at the profile message counts.
+const interactionSpreadInterval = 21 * 24 * time.Hour
+
+// interactionSpreadAge is the backward age of the j-th settled message on a
+// contact: 0 for the newest (so it drives last_contacted), then one
+// interactionSpreadInterval older per step. Deterministic (a pure function of j),
+// anchor-relative via the source factories' WithMessageAge (no time.Now()).
+func interactionSpreadAge(j int) time.Duration {
+	return time.Duration(j) * interactionSpreadInterval
 }
 
 // SeedAllowed is the single chokepoint guard the seed/reset entrypoints route

--- a/backend/internal/synthetic/profiles_test.go
+++ b/backend/internal/synthetic/profiles_test.go
@@ -86,6 +86,9 @@ func TestProfileParams(t *testing.T) {
 	// prod-shaped seeds relationship_signal rows so the coverage check has SP1
 	// derived-storage signals to assert.
 	require.Greater(t, prod.Counts.SeededSignals, 0)
+	// prod-shaped seeds MULTIPLE settled interactions per dedicated source contact
+	// (>1) so the coverage check has a multi-interaction temporal spread to assert.
+	require.Greater(t, prod.Counts.MessagesPerContact, 1)
 }
 
 // TestDefaultParamsUnchanged pins DefaultParams field-for-field so the
@@ -110,4 +113,5 @@ func TestDefaultParamsUnchanged(t *testing.T) {
 	require.Equal(t, 0, p.Counts.SeededEntities)
 	require.Equal(t, 0, p.Counts.SeededEntityEdges)
 	require.Equal(t, 0, p.Counts.SeededSignals)
+	require.Equal(t, 0, p.Counts.MessagesPerContact)
 }

--- a/backend/internal/synthetic/replay/gmail.go
+++ b/backend/internal/synthetic/replay/gmail.go
@@ -3,6 +3,7 @@ package replay
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"personal-crm/backend/internal/google"
 	"personal-crm/backend/internal/repository"
@@ -45,10 +46,15 @@ func (h *Harness) ReplayGmail(ctx context.Context, contactID uuid.UUID, spec fac
 	}))
 	provider.SetMeSetForTest(map[string]struct{}{spec.AccountID: {}})
 
+	// Floor the scan window just before THIS message's own send time so a message
+	// replayed at any age (the interaction temporal spread) is still inside the
+	// scanned window. InternalDate is the wire epoch the factory stamped from the
+	// (aged) anchor-relative sentAt.
+	sentAt := time.UnixMilli(spec.Message.InternalDate).UTC()
 	state := &repository.SyncState{
 		Source:    repository.InteractionSourceEmail,
 		AccountID: &spec.AccountID,
-		Metadata:  map[string]any{"backfill_since": gmailBackfillSince()},
+		Metadata:  map[string]any{"backfill_since": gmailBackfillSince(sentAt)},
 	}
 	if _, err := provider.Sync(ctx, state, nil); err != nil {
 		return GmailResult{}, fmt.Errorf("gmail sync: %w", err)

--- a/backend/internal/synthetic/replay/helpers.go
+++ b/backend/internal/synthetic/replay/helpers.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"time"
 
-	"personal-crm/backend/internal/accelerated"
 	"personal-crm/backend/internal/db"
 
 	"github.com/google/uuid"
@@ -121,11 +120,15 @@ func (h *Harness) trackContactInteractions(ctx context.Context, contactID uuid.U
 	})
 }
 
-// gmailBackfillSince returns a backfill floor far enough in the past that the
-// synthetic message (anchored ~2h before the live anchor) is inside the scanned,
-// already-closed Gmail window.
-func gmailBackfillSince() string {
-	return accelerated.GetCurrentTime().Add(-30 * 24 * time.Hour).UTC().Format("2006-01-02")
+// gmailBackfillSince returns the Gmail scan-window floor for a message sent at
+// sentAt: a couple of days before the message itself. The Gmail provider filters
+// fetched messages by internalDate against the scan window [floor, safeHorizon]
+// (the only source whose replay re-applies a time window), so a message replayed
+// at ANY age — the interaction temporal spread replays the same contact across
+// weeks/months — lands in the very first scan window regardless of how far back
+// it is dated. The floor is day-granular (the Gmail metadata format) and UTC.
+func gmailBackfillSince(sentAt time.Time) string {
+	return sentAt.Add(-2 * 24 * time.Hour).UTC().Format("2006-01-02")
 }
 
 // telegramPeerStranded reports whether a telegram_message row exists for the

--- a/backend/internal/synthetic/synthetic.go
+++ b/backend/internal/synthetic/synthetic.go
@@ -128,6 +128,14 @@ type Counts struct {
 	// run time. Written through the production UpsertRelationshipSignal path
 	// (storage-only — SP1 has no signal generators). 0 disables.
 	SeededSignals int
+	// MessagesPerContact is how many settled interactions each DEDICATED per-source
+	// settled contact receives, spread back over time on distinct days (a prod-like
+	// interaction history) rather than a single ~1h window. The source replay for a
+	// contact is looped this many times with growing per-message ages; 1 (or 0,
+	// which clamps to 1) reproduces the single-interaction shape. Applies only to
+	// the dedicated settled contacts — the edge-case catalog stays interaction-free
+	// so its overdue / never-contacted / no-method buckets survive.
+	MessagesPerContact int
 }
 
 // SeedParams is the profile/volume seam consumed by the seed orchestration.

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -133,6 +133,13 @@ func TestSyntheticProfile_DevCoversCatalog(t *testing.T) {
 	// lives_in locations ride the contact-create authority flip, spread by catalog
 	// index; the dev catalog is large enough to carry ≥1.
 	require.GreaterOrEqual(t, res.ContactsWithLocation, 1, "dev profile seeds location bio facts")
+	// MessagesPerContact spreads MULTIPLE settled interactions per dedicated source
+	// contact: SettledInteractions == (settled contacts) × MessagesPerContact, and
+	// strictly more than one interaction per contact.
+	settledContacts := res.GmailSettled + res.TelegramSettled + res.GCalSettled + res.GChatSettled + res.IMessageSettled
+	require.Equal(t, settledContacts*params.Counts.MessagesPerContact, res.SettledInteractions,
+		"dev profile spreads MessagesPerContact interactions per settled contact")
+	require.Greater(t, res.SettledInteractions, settledContacts, "dev profile seeds >1 interaction per settled contact")
 
 	remaining, err := h.ContactsRemaining(ctx)
 	require.NoError(t, err)
@@ -184,6 +191,11 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 	// A few relationship_signal rows (SP1 derived storage) across distinct catalog
 	// person nodes, one full signal-key cycle (closeness/real_cadence_days/trend).
 	params.Counts.SeededSignals = 3
+	// Two settled interactions per dedicated source contact (the CI-safe minimum
+	// that still exercises the temporal spread): the second message is one
+	// interactionSpreadInterval (~3 weeks) older, so the per-contact span clears the
+	// multi-day floor asserted below. Kept small to bound the settle budget.
+	params.Counts.MessagesPerContact = 2
 
 	h := synthetic.NewHarnessForNamespace(t, ctx, database, params.Namespace, params.Seed)
 	res, err := synthetic.RunProfile(ctx, h, params)
@@ -373,6 +385,30 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 		require.GreaterOrEqual(t, count, int64(1), "≥1 contact_task in state %q", state)
 	}
 
+	// Interaction volume: each dedicated source contact carries MessagesPerContact
+	// settled interactions, so SettledInteractions == (settled contacts) ×
+	// MessagesPerContact, strictly more than one per contact.
+	settledContacts := res.GmailSettled + res.TelegramSettled + res.GCalSettled + res.GChatSettled + res.IMessageSettled
+	require.Equal(t, settledContacts*params.Counts.MessagesPerContact, res.SettledInteractions,
+		"MessagesPerContact interactions per settled contact")
+	require.Greater(t, res.SettledInteractions, settledContacts, ">1 interaction per settled contact")
+
+	// Interaction temporal spread (DB-level): ≥1 settled contact must carry ≥2
+	// interactions whose earliest→latest span clears a multi-day floor — proving the
+	// per-message age offsets landed them on distinct days (a prod-like history),
+	// not a single ~1h window. Scoped to the namespace; the interaction-free
+	// edge-case catalog contacts are excluded by the query's INNER JOIN.
+	spreads, err := support.ListInteractionSpreadByContactNamePrefix(ctx, prefix)
+	require.NoError(t, err)
+	var spread bool
+	for _, s := range spreads {
+		if s.InteractionCount >= 2 && s.Span >= 7*24*time.Hour {
+			spread = true
+			break
+		}
+	}
+	require.True(t, spread, "≥1 settled contact has ≥2 interactions spanning ≥7 days (temporal spread, not one window)")
+
 	remaining, err := h.ContactsRemaining(ctx)
 	require.NoError(t, err)
 	require.Greater(t, remaining, int64(0), "prod-shaped profile seeds contacts")
@@ -432,6 +468,12 @@ func TestSyntheticProfile_ProdShapedDeterministic(t *testing.T) {
 	// A few relationship_signal rows so the run-to-run ProfileResult count
 	// (res.SeededSignals) is exercised and the teardown sweep is asserted below.
 	params.Counts.SeededSignals = 3
+	// One settled message per source contact: the temporal-spread timestamps are a
+	// pure function of the (pinned) anchor + message index, so they are
+	// deterministic by construction and not fingerprinted here (interactions are not
+	// in the fingerprint); keeping this at 1 holds the settle load at baseline while
+	// res.SettledInteractions still participates in the run-to-run count equality.
+	params.Counts.MessagesPerContact = 1
 	params.Counts.UnmatchedExternal = 1
 	params.Counts.StrandedTelegram = 1
 	params.Counts.StrandedMessages = 1


### PR DESCRIPTION
## What

PR6 of the prod-shaped synthetic-seed enrichment. The seed now spreads each dedicated settled contact's interactions over a realistic time span (multiple backdated messages per contact) instead of collapsing every contact to a single recent interaction.

- `WithMessageAge` factory option threaded into the 5 source message factories (Gmail/Telegram/GCal/GChat/iMessage).
- Gmail backfill floor derived from the message timestamp (so backdated messages aren't filtered out by the cursor).
- `MessagesPerContact` knob + a spread loop in `runCatalogProfile` (loops the existing replay adapters N times per dedicated settled contact, with offset anchor-relative timestamps).
- `SettledInteractions` count added to `ProfileResult`.
- Test-only sqlc query + repo wrapper for the per-contact spread assertion.

## Why

Makes the seeded world exercise realistic interaction history and cadence, closer to prod shape — settled contacts now have a believable timeline rather than one collapsed touch.

## Tests

- `ProdShapedCoverageCheck` (DB temporal-spread assertion at `MessagesPerContact=2`), `ProdShapedDeterministic`, `DevCoversCatalog` all green.
- `profiles_test.go` updated for the new knob + `SettledInteractions`.
- All timestamps via `accelerated.GetCurrentTime()`/anchor offsets — no `time.Now()`. The spread loop runs LAST in `runCatalogProfile` (PRNG-shift safety). New SQL is a test-only sqlc query.

## Review

- Local Codex (xhigh): PASS — P0=0 P1=0.
- `/review-head`: PASS — P0=0 P1=0.
- Non-blocking follow-ups (tracked in the plan): strengthen the DB spread assertion to cover every settled contact; the determinism test pins `MessagesPerContact=1` (deterministic by construction, covered functionally at `=2`).