### PR TITLE
feat(synthetic): seed merge + soft-delete graph scenarios

### DIFF
--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -1650,6 +1650,12 @@ type Querier interface {
 	// node, so a test scopes its assertions to its own namespace's subject node on
 	// the shared test DB.
 	SyntheticCountAssertionsForSubject(ctx context.Context, subjectNodeID pgtype.UUID) (int64, error)
+	// Merge/soft-delete coverage test support: count ALL assertions (live or not — no
+	// node-liveness join) whose subject is one of the given nodes, scoped to THIS run's
+	// tracked node ids. Used to assert (a) a soft-deleted contact's assertions are
+	// RETAINED in the table (≥1) even though its node is tombstoned, and (b) a merge
+	// loser's assertions are re-pointed OFF the loser (==0) onto the winner.
+	SyntheticCountAssertionsForSubjects(ctx context.Context, nodeIds []pgtype.UUID) (int64, error)
 	// Settle Gate A (GCal decline terminal): count ALL calendar_event rows for the
 	// gcal id regardless of status/match. The cutover decline branch DELETES the
 	// row, so the decline test settles on this reaching 0. calendar_event has no
@@ -1702,9 +1708,26 @@ type Querier interface {
 	// checked; scoping by both means a colliding-message-id row in another namespace
 	// (necessarily a different peer band) can never satisfy this predicate early.
 	SyntheticCountLinkedTelegramMessageByMessageId(ctx context.Context, arg SyntheticCountLinkedTelegramMessageByMessageIdParams) (int64, error)
+	// Merge/soft-delete coverage test support: count the assertions whose subject is one
+	// of the given nodes AND whose subject node is live (deleted_at IS NULL), scoped to
+	// THIS run's tracked node ids. Used to assert (a) a soft-deleted contact's assertions
+	// DROP from live graph reads (==0, node tombstoned), and (b) a merge winner carries
+	// its own + the re-pointed loser assertions on its still-live node (≥1).
+	SyntheticCountLiveAssertionsForSubjects(ctx context.Context, nodeIds []pgtype.UUID) (int64, error)
+	// Merge/soft-delete coverage test support: count the live (deleted_at IS NULL) nodes
+	// among the given ids, scoped to THIS run's tracked node ids. Used to assert a merge
+	// winner node stays live (== id count) while soft-deleted + merge-loser nodes are
+	// tombstoned (== 0).
+	SyntheticCountLiveNodesByIds(ctx context.Context, nodeIds []pgtype.UUID) (int64, error)
 	// Settle Gate A (Mac-contact seeded): the external_contact row for the entity
 	// id exists linked to a CRM contact (match_status='matched').
 	SyntheticCountMatchedExternalContactBySourceId(ctx context.Context, sourceID string) (int64, error)
+	// Merge coverage test support: count the nodes among the given ids that carry a
+	// merge alias (merged_into IS NOT NULL), scoped to THIS run's tracked node ids. Used
+	// to assert every merge-loser node was tombstoned via SetNodeMergedInto (== loser
+	// count); a soft-deleted (non-merged) node has merged_into NULL, so this stays 0 for
+	// the soft-delete set.
+	SyntheticCountMergedIntoNodesByIds(ctx context.Context, nodeIds []pgtype.UUID) (int64, error)
 	// Graph identity test support: count nodes whose canonical_label is ns-prefixed,
 	// so a test can scope assertions to its own namespace's nodes on the shared test
 	// DB. Caller passes a BARE prefix; '%' is appended here.
@@ -1897,7 +1920,10 @@ type Querier interface {
 	SyntheticGetNodeForContact(ctx context.Context, id pgtype.UUID) (*Node, error)
 	// Profile coverage + determinism test support: list the LIVE (proposed/accepted)
 	// assertions whose subject node is ns-prefixed (catalog person nodes own
-	// ns-prefixed canonical_labels). The coverage check uses (predicate_key, status)
+	// ns-prefixed canonical_labels) AND whose subject node is itself live
+	// (deleted_at IS NULL) — so a soft-deleted or merged-away (tombstoned) node's
+	// assertions drop from this LIVE projection, matching the graph read path. The
+	// coverage check uses (predicate_key, status)
 	// to assert the accepted vs proposed split; the determinism check fingerprints
 	// (value_text, value_date, value_bool) across a re-run — exactly one value column
 	// is set per fact (text → value_text, birthday → value_date, bool facts →

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -1708,11 +1708,17 @@ type Querier interface {
 	// checked; scoping by both means a colliding-message-id row in another namespace
 	// (necessarily a different peer band) can never satisfy this predicate early.
 	SyntheticCountLinkedTelegramMessageByMessageId(ctx context.Context, arg SyntheticCountLinkedTelegramMessageByMessageIdParams) (int64, error)
-	// Merge/soft-delete coverage test support: count the assertions whose subject is one
-	// of the given nodes AND whose subject node is live (deleted_at IS NULL), scoped to
-	// THIS run's tracked node ids. Used to assert (a) a soft-deleted contact's assertions
-	// DROP from live graph reads (==0, node tombstoned), and (b) a merge winner carries
-	// its own + the re-pointed loser assertions on its still-live node (≥1).
+	// Merge/soft-delete coverage test support: count the LIVE assertions whose subject
+	// is one of the given nodes, scoped to THIS run's tracked node ids. LIVE mirrors the
+	// production live-graph read: subject node live (deleted_at IS NULL) AND — for an
+	// edge (object_node_id set) — object node live AND status IN (proposed,accepted) AND
+	// knowledge-open (knowledge_to IS NULL). A fact (object_node_id NULL) is gated on the
+	// subject endpoint only. The object join MUST be a LEFT JOIN: facts carry a NULL
+	// object_node_id and an inner join would silently drop every fact row. Used to assert
+	// (a) a soft-deleted contact's assertions DROP from live graph reads (==0, node
+	// tombstoned), and (b) a merge winner carries its own + the re-pointed loser
+	// assertions as LIVE on its still-live node (≥1) — so the count proves re-pointing,
+	// not just presence of a terminal/closed row.
 	SyntheticCountLiveAssertionsForSubjects(ctx context.Context, nodeIds []pgtype.UUID) (int64, error)
 	// Merge/soft-delete coverage test support: count the live (deleted_at IS NULL) nodes
 	// among the given ids, scoped to THIS run's tracked node ids. Used to assert a merge
@@ -1918,21 +1924,25 @@ type Querier interface {
 	// (node.id == contact.id). Returns the live (non-soft-deleted) node row so a
 	// test can assert the dual-write created it with the expected type/label.
 	SyntheticGetNodeForContact(ctx context.Context, id pgtype.UUID) (*Node, error)
-	// Profile coverage + determinism test support: list the LIVE (proposed/accepted)
-	// assertions whose subject node is ns-prefixed (catalog person nodes own
-	// ns-prefixed canonical_labels) AND whose subject node is itself live
-	// (deleted_at IS NULL) — so a soft-deleted or merged-away (tombstoned) node's
-	// assertions drop from this LIVE projection, matching the graph read path. The
-	// coverage check uses (predicate_key, status)
-	// to assert the accepted vs proposed split; the determinism check fingerprints
-	// (value_text, value_date, value_bool) across a re-run — exactly one value column
-	// is set per fact (text → value_text, birthday → value_date, bool facts →
-	// value_bool) and edges set none, so all three are projected so no value-type
-	// surface is a blind spot. The object node id (and proposition_key) are NOT used
-	// because they embed the per-run subject/object UUID and so are not run-stable;
-	// an edge therefore contributes only (predicate_key, status) to the fingerprint.
-	// Deterministically ordered so the fingerprint is stable. Caller passes a BARE
-	// prefix; '%' is appended here.
+	// Profile coverage + determinism test support: list the LIVE assertions whose
+	// subject node is ns-prefixed (catalog person nodes own ns-prefixed
+	// canonical_labels). LIVE mirrors the production live-graph read: subject node
+	// live (deleted_at IS NULL) AND — for an edge (object_node_id set) — object node
+	// live AND status IN (proposed,accepted) AND knowledge-open (knowledge_to IS
+	// NULL). A fact (object_node_id NULL) is gated on the subject endpoint only. So a
+	// soft-deleted/merged-away (tombstoned) endpoint, a terminal/superseded row, or a
+	// knowledge-closed row drops from this projection, matching the graph read path.
+	// The object join MUST be a LEFT JOIN: facts carry a NULL object_node_id and an
+	// inner join would silently drop every fact row. The coverage check uses
+	// (predicate_key, status) to assert the accepted vs proposed split; the
+	// determinism check fingerprints (value_text, value_date, value_bool) across a
+	// re-run — exactly one value column is set per fact (text → value_text, birthday
+	// → value_date, bool facts → value_bool) and edges set none, so all three are
+	// projected so no value-type surface is a blind spot. The object node id (and
+	// proposition_key) are NOT used because they embed the per-run subject/object
+	// UUID and so are not run-stable; an edge therefore contributes only
+	// (predicate_key, status) to the fingerprint. Deterministically ordered so the
+	// fingerprint is stable. Caller passes a BARE prefix; '%' is appended here.
 	SyntheticListAssertionsByNodePrefix(ctx context.Context, labelPrefix pgtype.Text) ([]*SyntheticListAssertionsByNodePrefixRow, error)
 	// Todoist replay: snapshot the set of contact_task ids for a provider so the
 	// replay can diff before/after its (globally-scoped) reconcile and track the

--- a/backend/internal/db/queries/test.sql
+++ b/backend/internal/db/queries/test.sql
@@ -603,27 +603,34 @@ WHERE c.full_name LIKE @name_prefix || '%';
 SELECT COUNT(*) FROM assertion WHERE subject_node_id = $1;
 
 -- name: SyntheticListAssertionsByNodePrefix :many
--- Profile coverage + determinism test support: list the LIVE (proposed/accepted)
--- assertions whose subject node is ns-prefixed (catalog person nodes own
--- ns-prefixed canonical_labels) AND whose subject node is itself live
--- (deleted_at IS NULL) — so a soft-deleted or merged-away (tombstoned) node's
--- assertions drop from this LIVE projection, matching the graph read path. The
--- coverage check uses (predicate_key, status)
--- to assert the accepted vs proposed split; the determinism check fingerprints
--- (value_text, value_date, value_bool) across a re-run — exactly one value column
--- is set per fact (text → value_text, birthday → value_date, bool facts →
--- value_bool) and edges set none, so all three are projected so no value-type
--- surface is a blind spot. The object node id (and proposition_key) are NOT used
--- because they embed the per-run subject/object UUID and so are not run-stable;
--- an edge therefore contributes only (predicate_key, status) to the fingerprint.
--- Deterministically ordered so the fingerprint is stable. Caller passes a BARE
--- prefix; '%' is appended here.
+-- Profile coverage + determinism test support: list the LIVE assertions whose
+-- subject node is ns-prefixed (catalog person nodes own ns-prefixed
+-- canonical_labels). LIVE mirrors the production live-graph read: subject node
+-- live (deleted_at IS NULL) AND — for an edge (object_node_id set) — object node
+-- live AND status IN (proposed,accepted) AND knowledge-open (knowledge_to IS
+-- NULL). A fact (object_node_id NULL) is gated on the subject endpoint only. So a
+-- soft-deleted/merged-away (tombstoned) endpoint, a terminal/superseded row, or a
+-- knowledge-closed row drops from this projection, matching the graph read path.
+-- The object join MUST be a LEFT JOIN: facts carry a NULL object_node_id and an
+-- inner join would silently drop every fact row. The coverage check uses
+-- (predicate_key, status) to assert the accepted vs proposed split; the
+-- determinism check fingerprints (value_text, value_date, value_bool) across a
+-- re-run — exactly one value column is set per fact (text → value_text, birthday
+-- → value_date, bool facts → value_bool) and edges set none, so all three are
+-- projected so no value-type surface is a blind spot. The object node id (and
+-- proposition_key) are NOT used because they embed the per-run subject/object
+-- UUID and so are not run-stable; an edge therefore contributes only
+-- (predicate_key, status) to the fingerprint. Deterministically ordered so the
+-- fingerprint is stable. Caller passes a BARE prefix; '%' is appended here.
 SELECT a.predicate_key, a.status, a.value_text, a.value_date, a.value_bool
 FROM assertion a
 JOIN node n ON a.subject_node_id = n.id
+LEFT JOIN node ob ON ob.id = a.object_node_id
 WHERE n.canonical_label LIKE @label_prefix || '%'
   AND n.deleted_at IS NULL
+  AND (a.object_node_id IS NULL OR ob.deleted_at IS NULL)
   AND a.status IN ('proposed', 'accepted')
+  AND a.knowledge_to IS NULL
 ORDER BY a.predicate_key, a.value_text NULLS LAST, a.value_date NULLS LAST, a.value_bool NULLS LAST, a.status;
 
 -- name: SyntheticGetNodeForContact :one
@@ -695,14 +702,25 @@ SELECT COUNT(*) FROM relationship_signal WHERE subject_node_id = ANY(@node_ids::
 SELECT COUNT(*) FROM assertion WHERE subject_node_id = ANY(@node_ids::uuid[]);
 
 -- name: SyntheticCountLiveAssertionsForSubjects :one
--- Merge/soft-delete coverage test support: count the assertions whose subject is one
--- of the given nodes AND whose subject node is live (deleted_at IS NULL), scoped to
--- THIS run's tracked node ids. Used to assert (a) a soft-deleted contact's assertions
--- DROP from live graph reads (==0, node tombstoned), and (b) a merge winner carries
--- its own + the re-pointed loser assertions on its still-live node (≥1).
+-- Merge/soft-delete coverage test support: count the LIVE assertions whose subject
+-- is one of the given nodes, scoped to THIS run's tracked node ids. LIVE mirrors the
+-- production live-graph read: subject node live (deleted_at IS NULL) AND — for an
+-- edge (object_node_id set) — object node live AND status IN (proposed,accepted) AND
+-- knowledge-open (knowledge_to IS NULL). A fact (object_node_id NULL) is gated on the
+-- subject endpoint only. The object join MUST be a LEFT JOIN: facts carry a NULL
+-- object_node_id and an inner join would silently drop every fact row. Used to assert
+-- (a) a soft-deleted contact's assertions DROP from live graph reads (==0, node
+-- tombstoned), and (b) a merge winner carries its own + the re-pointed loser
+-- assertions as LIVE on its still-live node (≥1) — so the count proves re-pointing,
+-- not just presence of a terminal/closed row.
 SELECT COUNT(*) FROM assertion a
 JOIN node n ON a.subject_node_id = n.id
-WHERE a.subject_node_id = ANY(@node_ids::uuid[]) AND n.deleted_at IS NULL;
+LEFT JOIN node ob ON ob.id = a.object_node_id
+WHERE a.subject_node_id = ANY(@node_ids::uuid[])
+  AND n.deleted_at IS NULL
+  AND (a.object_node_id IS NULL OR ob.deleted_at IS NULL)
+  AND a.status IN ('proposed', 'accepted')
+  AND a.knowledge_to IS NULL;
 
 -- name: SyntheticCountLiveNodesByIds :one
 -- Merge/soft-delete coverage test support: count the live (deleted_at IS NULL) nodes

--- a/backend/internal/db/queries/test.sql
+++ b/backend/internal/db/queries/test.sql
@@ -605,7 +605,10 @@ SELECT COUNT(*) FROM assertion WHERE subject_node_id = $1;
 -- name: SyntheticListAssertionsByNodePrefix :many
 -- Profile coverage + determinism test support: list the LIVE (proposed/accepted)
 -- assertions whose subject node is ns-prefixed (catalog person nodes own
--- ns-prefixed canonical_labels). The coverage check uses (predicate_key, status)
+-- ns-prefixed canonical_labels) AND whose subject node is itself live
+-- (deleted_at IS NULL) — so a soft-deleted or merged-away (tombstoned) node's
+-- assertions drop from this LIVE projection, matching the graph read path. The
+-- coverage check uses (predicate_key, status)
 -- to assert the accepted vs proposed split; the determinism check fingerprints
 -- (value_text, value_date, value_bool) across a re-run — exactly one value column
 -- is set per fact (text → value_text, birthday → value_date, bool facts →
@@ -619,6 +622,7 @@ SELECT a.predicate_key, a.status, a.value_text, a.value_date, a.value_bool
 FROM assertion a
 JOIN node n ON a.subject_node_id = n.id
 WHERE n.canonical_label LIKE @label_prefix || '%'
+  AND n.deleted_at IS NULL
   AND a.status IN ('proposed', 'accepted')
 ORDER BY a.predicate_key, a.value_text NULLS LAST, a.value_date NULLS LAST, a.value_bool NULLS LAST, a.status;
 
@@ -681,6 +685,39 @@ DELETE FROM relationship_signal WHERE subject_node_id = ANY(@node_ids::uuid[]);
 -- seeding their own signals on the shared DB). Used to assert ≥1 signal exists for
 -- the seeded nodes (coverage) and that 0 remain after teardown.
 SELECT COUNT(*) FROM relationship_signal WHERE subject_node_id = ANY(@node_ids::uuid[]);
+
+-- name: SyntheticCountAssertionsForSubjects :one
+-- Merge/soft-delete coverage test support: count ALL assertions (live or not — no
+-- node-liveness join) whose subject is one of the given nodes, scoped to THIS run's
+-- tracked node ids. Used to assert (a) a soft-deleted contact's assertions are
+-- RETAINED in the table (≥1) even though its node is tombstoned, and (b) a merge
+-- loser's assertions are re-pointed OFF the loser (==0) onto the winner.
+SELECT COUNT(*) FROM assertion WHERE subject_node_id = ANY(@node_ids::uuid[]);
+
+-- name: SyntheticCountLiveAssertionsForSubjects :one
+-- Merge/soft-delete coverage test support: count the assertions whose subject is one
+-- of the given nodes AND whose subject node is live (deleted_at IS NULL), scoped to
+-- THIS run's tracked node ids. Used to assert (a) a soft-deleted contact's assertions
+-- DROP from live graph reads (==0, node tombstoned), and (b) a merge winner carries
+-- its own + the re-pointed loser assertions on its still-live node (≥1).
+SELECT COUNT(*) FROM assertion a
+JOIN node n ON a.subject_node_id = n.id
+WHERE a.subject_node_id = ANY(@node_ids::uuid[]) AND n.deleted_at IS NULL;
+
+-- name: SyntheticCountLiveNodesByIds :one
+-- Merge/soft-delete coverage test support: count the live (deleted_at IS NULL) nodes
+-- among the given ids, scoped to THIS run's tracked node ids. Used to assert a merge
+-- winner node stays live (== id count) while soft-deleted + merge-loser nodes are
+-- tombstoned (== 0).
+SELECT COUNT(*) FROM node WHERE id = ANY(@node_ids::uuid[]) AND deleted_at IS NULL;
+
+-- name: SyntheticCountMergedIntoNodesByIds :one
+-- Merge coverage test support: count the nodes among the given ids that carry a
+-- merge alias (merged_into IS NOT NULL), scoped to THIS run's tracked node ids. Used
+-- to assert every merge-loser node was tombstoned via SetNodeMergedInto (== loser
+-- count); a soft-deleted (non-merged) node has merged_into NULL, so this stays 0 for
+-- the soft-delete set.
+SELECT COUNT(*) FROM node WHERE id = ANY(@node_ids::uuid[]) AND merged_into IS NOT NULL;
 
 -- name: TestInsertContactAtID :exec
 -- Latent-person promotion test support: insert a contact row AT a caller-supplied

--- a/backend/internal/db/test.sql.go
+++ b/backend/internal/db/test.sql.go
@@ -746,6 +746,22 @@ func (q *Queries) SyntheticCountAssertionsForSubject(ctx context.Context, subjec
 	return count, err
 }
 
+const SyntheticCountAssertionsForSubjects = `-- name: SyntheticCountAssertionsForSubjects :one
+SELECT COUNT(*) FROM assertion WHERE subject_node_id = ANY($1::uuid[])
+`
+
+// Merge/soft-delete coverage test support: count ALL assertions (live or not — no
+// node-liveness join) whose subject is one of the given nodes, scoped to THIS run's
+// tracked node ids. Used to assert (a) a soft-deleted contact's assertions are
+// RETAINED in the table (≥1) even though its node is tombstoned, and (b) a merge
+// loser's assertions are re-pointed OFF the loser (==0) onto the winner.
+func (q *Queries) SyntheticCountAssertionsForSubjects(ctx context.Context, nodeIds []pgtype.UUID) (int64, error) {
+	row := q.db.QueryRow(ctx, SyntheticCountAssertionsForSubjects, nodeIds)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const SyntheticCountCalendarEventByGcalId = `-- name: SyntheticCountCalendarEventByGcalId :one
 SELECT COUNT(*) FROM calendar_event
 WHERE gcal_event_id = $1
@@ -938,6 +954,39 @@ func (q *Queries) SyntheticCountLinkedTelegramMessageByMessageId(ctx context.Con
 	return count, err
 }
 
+const SyntheticCountLiveAssertionsForSubjects = `-- name: SyntheticCountLiveAssertionsForSubjects :one
+SELECT COUNT(*) FROM assertion a
+JOIN node n ON a.subject_node_id = n.id
+WHERE a.subject_node_id = ANY($1::uuid[]) AND n.deleted_at IS NULL
+`
+
+// Merge/soft-delete coverage test support: count the assertions whose subject is one
+// of the given nodes AND whose subject node is live (deleted_at IS NULL), scoped to
+// THIS run's tracked node ids. Used to assert (a) a soft-deleted contact's assertions
+// DROP from live graph reads (==0, node tombstoned), and (b) a merge winner carries
+// its own + the re-pointed loser assertions on its still-live node (≥1).
+func (q *Queries) SyntheticCountLiveAssertionsForSubjects(ctx context.Context, nodeIds []pgtype.UUID) (int64, error) {
+	row := q.db.QueryRow(ctx, SyntheticCountLiveAssertionsForSubjects, nodeIds)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const SyntheticCountLiveNodesByIds = `-- name: SyntheticCountLiveNodesByIds :one
+SELECT COUNT(*) FROM node WHERE id = ANY($1::uuid[]) AND deleted_at IS NULL
+`
+
+// Merge/soft-delete coverage test support: count the live (deleted_at IS NULL) nodes
+// among the given ids, scoped to THIS run's tracked node ids. Used to assert a merge
+// winner node stays live (== id count) while soft-deleted + merge-loser nodes are
+// tombstoned (== 0).
+func (q *Queries) SyntheticCountLiveNodesByIds(ctx context.Context, nodeIds []pgtype.UUID) (int64, error) {
+	row := q.db.QueryRow(ctx, SyntheticCountLiveNodesByIds, nodeIds)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const SyntheticCountMatchedExternalContactBySourceId = `-- name: SyntheticCountMatchedExternalContactBySourceId :one
 SELECT COUNT(*) FROM external_contact
 WHERE source_id = $1
@@ -950,6 +999,22 @@ WHERE source_id = $1
 // id exists linked to a CRM contact (match_status='matched').
 func (q *Queries) SyntheticCountMatchedExternalContactBySourceId(ctx context.Context, sourceID string) (int64, error) {
 	row := q.db.QueryRow(ctx, SyntheticCountMatchedExternalContactBySourceId, sourceID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const SyntheticCountMergedIntoNodesByIds = `-- name: SyntheticCountMergedIntoNodesByIds :one
+SELECT COUNT(*) FROM node WHERE id = ANY($1::uuid[]) AND merged_into IS NOT NULL
+`
+
+// Merge coverage test support: count the nodes among the given ids that carry a
+// merge alias (merged_into IS NOT NULL), scoped to THIS run's tracked node ids. Used
+// to assert every merge-loser node was tombstoned via SetNodeMergedInto (== loser
+// count); a soft-deleted (non-merged) node has merged_into NULL, so this stays 0 for
+// the soft-delete set.
+func (q *Queries) SyntheticCountMergedIntoNodesByIds(ctx context.Context, nodeIds []pgtype.UUID) (int64, error) {
+	row := q.db.QueryRow(ctx, SyntheticCountMergedIntoNodesByIds, nodeIds)
 	var count int64
 	err := row.Scan(&count)
 	return count, err
@@ -1656,6 +1721,7 @@ SELECT a.predicate_key, a.status, a.value_text, a.value_date, a.value_bool
 FROM assertion a
 JOIN node n ON a.subject_node_id = n.id
 WHERE n.canonical_label LIKE $1 || '%'
+  AND n.deleted_at IS NULL
   AND a.status IN ('proposed', 'accepted')
 ORDER BY a.predicate_key, a.value_text NULLS LAST, a.value_date NULLS LAST, a.value_bool NULLS LAST, a.status
 `
@@ -1670,7 +1736,10 @@ type SyntheticListAssertionsByNodePrefixRow struct {
 
 // Profile coverage + determinism test support: list the LIVE (proposed/accepted)
 // assertions whose subject node is ns-prefixed (catalog person nodes own
-// ns-prefixed canonical_labels). The coverage check uses (predicate_key, status)
+// ns-prefixed canonical_labels) AND whose subject node is itself live
+// (deleted_at IS NULL) — so a soft-deleted or merged-away (tombstoned) node's
+// assertions drop from this LIVE projection, matching the graph read path. The
+// coverage check uses (predicate_key, status)
 // to assert the accepted vs proposed split; the determinism check fingerprints
 // (value_text, value_date, value_bool) across a re-run — exactly one value column
 // is set per fact (text → value_text, birthday → value_date, bool facts →

--- a/backend/internal/db/test.sql.go
+++ b/backend/internal/db/test.sql.go
@@ -957,14 +957,25 @@ func (q *Queries) SyntheticCountLinkedTelegramMessageByMessageId(ctx context.Con
 const SyntheticCountLiveAssertionsForSubjects = `-- name: SyntheticCountLiveAssertionsForSubjects :one
 SELECT COUNT(*) FROM assertion a
 JOIN node n ON a.subject_node_id = n.id
-WHERE a.subject_node_id = ANY($1::uuid[]) AND n.deleted_at IS NULL
+LEFT JOIN node ob ON ob.id = a.object_node_id
+WHERE a.subject_node_id = ANY($1::uuid[])
+  AND n.deleted_at IS NULL
+  AND (a.object_node_id IS NULL OR ob.deleted_at IS NULL)
+  AND a.status IN ('proposed', 'accepted')
+  AND a.knowledge_to IS NULL
 `
 
-// Merge/soft-delete coverage test support: count the assertions whose subject is one
-// of the given nodes AND whose subject node is live (deleted_at IS NULL), scoped to
-// THIS run's tracked node ids. Used to assert (a) a soft-deleted contact's assertions
-// DROP from live graph reads (==0, node tombstoned), and (b) a merge winner carries
-// its own + the re-pointed loser assertions on its still-live node (≥1).
+// Merge/soft-delete coverage test support: count the LIVE assertions whose subject
+// is one of the given nodes, scoped to THIS run's tracked node ids. LIVE mirrors the
+// production live-graph read: subject node live (deleted_at IS NULL) AND — for an
+// edge (object_node_id set) — object node live AND status IN (proposed,accepted) AND
+// knowledge-open (knowledge_to IS NULL). A fact (object_node_id NULL) is gated on the
+// subject endpoint only. The object join MUST be a LEFT JOIN: facts carry a NULL
+// object_node_id and an inner join would silently drop every fact row. Used to assert
+// (a) a soft-deleted contact's assertions DROP from live graph reads (==0, node
+// tombstoned), and (b) a merge winner carries its own + the re-pointed loser
+// assertions as LIVE on its still-live node (≥1) — so the count proves re-pointing,
+// not just presence of a terminal/closed row.
 func (q *Queries) SyntheticCountLiveAssertionsForSubjects(ctx context.Context, nodeIds []pgtype.UUID) (int64, error) {
 	row := q.db.QueryRow(ctx, SyntheticCountLiveAssertionsForSubjects, nodeIds)
 	var count int64
@@ -1720,9 +1731,12 @@ const SyntheticListAssertionsByNodePrefix = `-- name: SyntheticListAssertionsByN
 SELECT a.predicate_key, a.status, a.value_text, a.value_date, a.value_bool
 FROM assertion a
 JOIN node n ON a.subject_node_id = n.id
+LEFT JOIN node ob ON ob.id = a.object_node_id
 WHERE n.canonical_label LIKE $1 || '%'
   AND n.deleted_at IS NULL
+  AND (a.object_node_id IS NULL OR ob.deleted_at IS NULL)
   AND a.status IN ('proposed', 'accepted')
+  AND a.knowledge_to IS NULL
 ORDER BY a.predicate_key, a.value_text NULLS LAST, a.value_date NULLS LAST, a.value_bool NULLS LAST, a.status
 `
 
@@ -1734,21 +1748,25 @@ type SyntheticListAssertionsByNodePrefixRow struct {
 	ValueBool    pgtype.Bool `json:"value_bool"`
 }
 
-// Profile coverage + determinism test support: list the LIVE (proposed/accepted)
-// assertions whose subject node is ns-prefixed (catalog person nodes own
-// ns-prefixed canonical_labels) AND whose subject node is itself live
-// (deleted_at IS NULL) — so a soft-deleted or merged-away (tombstoned) node's
-// assertions drop from this LIVE projection, matching the graph read path. The
-// coverage check uses (predicate_key, status)
-// to assert the accepted vs proposed split; the determinism check fingerprints
-// (value_text, value_date, value_bool) across a re-run — exactly one value column
-// is set per fact (text → value_text, birthday → value_date, bool facts →
-// value_bool) and edges set none, so all three are projected so no value-type
-// surface is a blind spot. The object node id (and proposition_key) are NOT used
-// because they embed the per-run subject/object UUID and so are not run-stable;
-// an edge therefore contributes only (predicate_key, status) to the fingerprint.
-// Deterministically ordered so the fingerprint is stable. Caller passes a BARE
-// prefix; '%' is appended here.
+// Profile coverage + determinism test support: list the LIVE assertions whose
+// subject node is ns-prefixed (catalog person nodes own ns-prefixed
+// canonical_labels). LIVE mirrors the production live-graph read: subject node
+// live (deleted_at IS NULL) AND — for an edge (object_node_id set) — object node
+// live AND status IN (proposed,accepted) AND knowledge-open (knowledge_to IS
+// NULL). A fact (object_node_id NULL) is gated on the subject endpoint only. So a
+// soft-deleted/merged-away (tombstoned) endpoint, a terminal/superseded row, or a
+// knowledge-closed row drops from this projection, matching the graph read path.
+// The object join MUST be a LEFT JOIN: facts carry a NULL object_node_id and an
+// inner join would silently drop every fact row. The coverage check uses
+// (predicate_key, status) to assert the accepted vs proposed split; the
+// determinism check fingerprints (value_text, value_date, value_bool) across a
+// re-run — exactly one value column is set per fact (text → value_text, birthday
+// → value_date, bool facts → value_bool) and edges set none, so all three are
+// projected so no value-type surface is a blind spot. The object node id (and
+// proposition_key) are NOT used because they embed the per-run subject/object
+// UUID and so are not run-stable; an edge therefore contributes only
+// (predicate_key, status) to the fingerprint. Deterministically ordered so the
+// fingerprint is stable. Caller passes a BARE prefix; '%' is appended here.
 func (q *Queries) SyntheticListAssertionsByNodePrefix(ctx context.Context, labelPrefix pgtype.Text) ([]*SyntheticListAssertionsByNodePrefixRow, error) {
 	rows, err := q.db.Query(ctx, SyntheticListAssertionsByNodePrefix, labelPrefix)
 	if err != nil {

--- a/backend/internal/repository/synthetic_support.go
+++ b/backend/internal/repository/synthetic_support.go
@@ -1009,3 +1009,49 @@ func (r *SyntheticSupportRepository) CountRelationshipSignalsForNodes(ctx contex
 	}
 	return r.queries.SyntheticCountRelationshipSignalsForNodes(ctx, pgUUIDs(nodeIDs))
 }
+
+// CountAssertionsForSubjects counts ALL assertions (live or not) whose subject is
+// one of the given nodes, scoped to the run's tracked node ids (parallel-test-safe).
+// Used by the merge/soft-delete coverage check to assert a soft-deleted contact's
+// assertions are RETAINED in the table (≥1) and a merge loser's are re-pointed OFF
+// the loser (==0).
+func (r *SyntheticSupportRepository) CountAssertionsForSubjects(ctx context.Context, nodeIDs []uuid.UUID) (int64, error) {
+	if len(nodeIDs) == 0 {
+		return 0, nil
+	}
+	return r.queries.SyntheticCountAssertionsForSubjects(ctx, pgUUIDs(nodeIDs))
+}
+
+// CountLiveAssertionsForSubjects counts the assertions whose subject is one of the
+// given nodes AND whose subject node is live (deleted_at IS NULL), scoped to the
+// run's tracked node ids. Used by the merge/soft-delete coverage check to assert a
+// soft-deleted contact's assertions DROP from live graph reads (==0) and a merge
+// winner carries its own + the re-pointed loser assertions on its live node (≥1).
+func (r *SyntheticSupportRepository) CountLiveAssertionsForSubjects(ctx context.Context, nodeIDs []uuid.UUID) (int64, error) {
+	if len(nodeIDs) == 0 {
+		return 0, nil
+	}
+	return r.queries.SyntheticCountLiveAssertionsForSubjects(ctx, pgUUIDs(nodeIDs))
+}
+
+// CountLiveNodesByIds counts the live (deleted_at IS NULL) nodes among the given
+// ids, scoped to the run's tracked node ids. Used by the merge/soft-delete coverage
+// check to assert a merge winner stays live (== id count) while soft-deleted +
+// merge-loser nodes are tombstoned (==0).
+func (r *SyntheticSupportRepository) CountLiveNodesByIds(ctx context.Context, nodeIDs []uuid.UUID) (int64, error) {
+	if len(nodeIDs) == 0 {
+		return 0, nil
+	}
+	return r.queries.SyntheticCountLiveNodesByIds(ctx, pgUUIDs(nodeIDs))
+}
+
+// CountMergedIntoNodesByIds counts the nodes among the given ids that carry a merge
+// alias (merged_into IS NOT NULL), scoped to the run's tracked node ids. Used by the
+// merge coverage check to assert every merge-loser node was tombstoned via
+// SetNodeMergedInto (== loser count); soft-deleted nodes carry no merged_into.
+func (r *SyntheticSupportRepository) CountMergedIntoNodesByIds(ctx context.Context, nodeIDs []uuid.UUID) (int64, error) {
+	if len(nodeIDs) == 0 {
+		return 0, nil
+	}
+	return r.queries.SyntheticCountMergedIntoNodesByIds(ctx, pgUUIDs(nodeIDs))
+}

--- a/backend/internal/synthetic/profiles.go
+++ b/backend/internal/synthetic/profiles.go
@@ -94,6 +94,14 @@ type ProfileResult struct {
 	// upper bound on the interaction rows produced (same-day messages on one contact
 	// would aggregate, but the spread lands them on distinct days). Counts-only / no PII.
 	SettledInteractions int
+	// SeededSoftDeleted / SeededMerged count the merge + soft-delete scenarios the
+	// profile seeded: soft-deleted contacts (person node tombstoned via DeleteContact,
+	// assertion dropped from live reads but retained in the table) and merged pairs
+	// (loser node tombstoned via MergeContacts, its assertions re-pointed onto the
+	// winner). SeededMerged is the PAIR count (each pair is two contacts). Counts-only
+	// / no PII.
+	SeededSoftDeleted int
+	SeededMerged      int
 }
 
 // ProfileParams returns the default SeedParams for a named profile (error on an
@@ -138,6 +146,10 @@ func ProfileParams(name Profile) (SeedParams, error) {
 				// so the dev graph shows a small multi-interaction history (fast: the dev
 				// per-source settled count is 1).
 				MessagesPerContact: 2,
+				// One soft-deleted contact + one merged pair so the dev graph surfaces the
+				// tombstone + merge re-point scenarios.
+				SeededSoftDeleted: 1,
+				SeededMerged:      1,
 			},
 		}, nil
 	case ProfileProdShaped:
@@ -184,6 +196,11 @@ func ProfileParams(name Profile) (SeedParams, error) {
 				// source instead of a single recent message. The coverage + determinism
 				// tests override this down for CI runtime.
 				MessagesPerContact: 4,
+				// A handful of soft-deleted contacts + merged pairs so staging shows the
+				// tombstoned-contact and merge re-point surfaces. The coverage + determinism
+				// tests override these down for CI.
+				SeededSoftDeleted: 3,
+				SeededMerged:      3,
 			},
 		}, nil
 	default:
@@ -676,8 +693,48 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		res.SeededTasks = len(cadenceBearingCatalogIDs)
 	}
 
+	// Merge + soft-delete scenarios. Seeded LAST: each draws gen.Contact (name PRNG)
+	// + gen.BoolFact, so appending them after every other generator-driven block keeps
+	// the deterministic id/handle sequence the earlier source replays depend on
+	// unshifted. They are STANDALONE contacts (not catalog slots) that route through
+	// the production ContactService.DeleteContact / MergeContacts paths; SeedContact
+	// already tracks their ids, so the existing by-id teardown sweeps clean the
+	// tombstoned + merged rows (the merged_into self-FK is NO ACTION, dropped in one
+	// statement). The assertions are BOOL facts (value_bool, not value_text) so they
+	// add no live value_text on the surviving merge winner — keeping the determinism
+	// ordering guard's "entity pool seq > text-fact seq" invariant intact.
+	for i := 0; i < params.Counts.SeededSoftDeleted; i++ {
+		if _, err := h.SeedSoftDeletedContact(ctx, gen.Contact(),
+			gen.BoolFact(softDeleteFactPredicate, true)); err != nil {
+			return res, fmt.Errorf("profile %s: seed soft-deleted contact %d: %w", params.Profile, i, err)
+		}
+		res.SeededSoftDeleted++
+	}
+	for i := 0; i < params.Counts.SeededMerged; i++ {
+		// Distinct winner/loser predicates so the re-pointed loser fact lands beside the
+		// winner's own without single-cardinality supersession.
+		if _, _, err := h.SeedMergedContact(ctx,
+			gen.Contact(), gen.Contact(),
+			gen.BoolFact(mergeWinnerFactPredicate, true),
+			gen.BoolFact(mergeLoserFactPredicate, true)); err != nil {
+			return res, fmt.Errorf("profile %s: seed merged contact %d: %w", params.Profile, i, err)
+		}
+		res.SeededMerged++
+	}
+
 	return res, nil
 }
+
+// softDeleteFactPredicate / mergeWinnerFactPredicate / mergeLoserFactPredicate are
+// the bool-fact predicates the merge + soft-delete scenarios assert (all
+// auto-if-confident → accepted, migration-066 catalog bool predicates). The merge
+// winner + loser use DISTINCT predicates so the re-pointed loser fact does not
+// supersede the winner's own (each bool predicate is single-cardinality).
+const (
+	softDeleteFactPredicate  = "job_seeking"
+	mergeWinnerFactPredicate = "traveling"
+	mergeLoserFactPredicate  = "on_sabbatical"
+)
 
 // nonManagedTaskStates is the deterministic spread of non-`managed` contact_task
 // surface states the profile transitions cadence tasks into (one each), so staging

--- a/backend/internal/synthetic/profiles_test.go
+++ b/backend/internal/synthetic/profiles_test.go
@@ -89,6 +89,10 @@ func TestProfileParams(t *testing.T) {
 	// prod-shaped seeds MULTIPLE settled interactions per dedicated source contact
 	// (>1) so the coverage check has a multi-interaction temporal spread to assert.
 	require.Greater(t, prod.Counts.MessagesPerContact, 1)
+	// prod-shaped seeds merge + soft-delete scenarios so the coverage check has
+	// tombstoned + re-pointed graph rows to assert.
+	require.Greater(t, prod.Counts.SeededSoftDeleted, 0)
+	require.Greater(t, prod.Counts.SeededMerged, 0)
 }
 
 // TestDefaultParamsUnchanged pins DefaultParams field-for-field so the
@@ -114,4 +118,6 @@ func TestDefaultParamsUnchanged(t *testing.T) {
 	require.Equal(t, 0, p.Counts.SeededEntityEdges)
 	require.Equal(t, 0, p.Counts.SeededSignals)
 	require.Equal(t, 0, p.Counts.MessagesPerContact)
+	require.Equal(t, 0, p.Counts.SeededSoftDeleted)
+	require.Equal(t, 0, p.Counts.SeededMerged)
 }

--- a/backend/internal/synthetic/replay/replay.go
+++ b/backend/internal/synthetic/replay/replay.go
@@ -94,6 +94,17 @@ type created struct {
 	// subject_node_id → node FK is NO ACTION, so cleanup MUST delete these rows by
 	// the tracked node ids BEFORE the node deletes.
 	signalNodeIDs []uuid.UUID
+	// softDeletedNodeIDs / mergedLoserNodeIDs / mergedWinnerNodeIDs are person node
+	// ids a soft-delete / merge scenario produced, tracked ONLY for the seed-shape
+	// invariant assertions (tombstone + assertion re-point checks). Teardown needs no
+	// separate step for them: each is a node.id == contact.id that SeedContact already
+	// added to contactIDs, so the existing by-id assertion → person_node → contact
+	// sweeps remove the tombstoned (soft-deleted / merged-loser) and live (merge
+	// winner) rows. The merged_into self-FK is NO ACTION, so the single-statement
+	// person_node delete drops a merged pair together without ordering grief.
+	softDeletedNodeIDs  []uuid.UUID
+	mergedLoserNodeIDs  []uuid.UUID
+	mergedWinnerNodeIDs []uuid.UUID
 	// directSources is the set of sources the adapters published root events
 	// under, so Cleanup can capture no-contact root events that the
 	// contact-scoped read misses.
@@ -104,10 +115,17 @@ func newCreated() *created {
 	return &created{directSources: map[string]struct{}{}}
 }
 
-func (c *created) addContact(id uuid.UUID)       { c.contactIDs = append(c.contactIDs, id) }
-func (c *created) addInteraction(id uuid.UUID)   { c.interactionIDs = append(c.interactionIDs, id) }
-func (c *created) addVenueNode(id uuid.UUID)     { c.venueNodeIDs = append(c.venueNodeIDs, id) }
-func (c *created) addSignalNode(id uuid.UUID)    { c.signalNodeIDs = append(c.signalNodeIDs, id) }
+func (c *created) addContact(id uuid.UUID)     { c.contactIDs = append(c.contactIDs, id) }
+func (c *created) addInteraction(id uuid.UUID) { c.interactionIDs = append(c.interactionIDs, id) }
+func (c *created) addVenueNode(id uuid.UUID)   { c.venueNodeIDs = append(c.venueNodeIDs, id) }
+func (c *created) addSignalNode(id uuid.UUID)  { c.signalNodeIDs = append(c.signalNodeIDs, id) }
+func (c *created) addSoftDeletedNode(id uuid.UUID) {
+	c.softDeletedNodeIDs = append(c.softDeletedNodeIDs, id)
+}
+func (c *created) addMergedPair(winner, loser uuid.UUID) {
+	c.mergedWinnerNodeIDs = append(c.mergedWinnerNodeIDs, winner)
+	c.mergedLoserNodeIDs = append(c.mergedLoserNodeIDs, loser)
+}
 func (c *created) addTelegramPeer(id int64)      { c.telegramPeerIDs = append(c.telegramPeerIDs, id) }
 func (c *created) addTelegramChat(id int64)      { c.telegramChatIDs = append(c.telegramChatIDs, id) }
 func (c *created) addContactTask(id uuid.UUID)   { c.contactTaskIDs = append(c.contactTaskIDs, id) }
@@ -285,6 +303,67 @@ func (h *Harness) SeedRelationshipSignal(ctx context.Context, subjectNodeID uuid
 	}
 	h.track(func(c *created) { c.addSignalNode(subjectNodeID) })
 	return nil
+}
+
+// SeedSoftDeletedContact seeds a contact (with one assertion on its person node),
+// then routes it through the PRODUCTION ContactService.DeleteContact path so the
+// person node (node.id == contact.id) is tombstoned: the assertion drops from LIVE
+// graph reads while remaining in the assertion table. The contact id is already in
+// the cleanup ledger (SeedContact tracked it) and the assertion rides the node, so
+// the existing by-id assertion → node → contact teardown sweeps remove the whole
+// set — no extra cleanup step. The node id is tracked separately ONLY so the
+// coverage check can assert the tombstone + retained-vs-live-assertion invariant.
+// Returns the soft-deleted contact id.
+func (h *Harness) SeedSoftDeletedContact(ctx context.Context, spec factory.ContactSpec, fact factory.AssertionSpec) (uuid.UUID, error) {
+	contact, err := h.SeedContact(ctx, spec)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("seed soft-deleted contact: %w", err)
+	}
+	if _, err := h.ReplayAssertion(ctx, contact.ID, fact); err != nil {
+		return uuid.Nil, fmt.Errorf("seed soft-deleted contact assertion: %w", err)
+	}
+	if err := h.contactService.DeleteContact(ctx, contact.ID); err != nil {
+		return uuid.Nil, fmt.Errorf("soft-delete contact %s: %w", contact.ID, err)
+	}
+	h.track(func(c *created) { c.addSoftDeletedNode(contact.ID) })
+	return contact.ID, nil
+}
+
+// SeedMergedContact seeds TWO contacts — a winner + a loser, each with one assertion
+// on its person node — then merges the loser INTO the winner via the PRODUCTION
+// ContactService.MergeContacts path. That re-points the loser's assertions onto the
+// winner (MergeAssertionsTx), tombstones the loser node (merged_into=winner +
+// deleted_at via SetNodeMergedInto), and soft-deletes the loser contact. Give the
+// winner + loser DISTINCT predicates so the re-pointed loser fact lands beside the
+// winner's own without single-cardinality supersession (the merge internals are
+// exhaustively covered elsewhere; this is a SEED, not a re-derivation). Both contact
+// ids are already in the cleanup ledger (SeedContact); the merged_into self-FK is NO
+// ACTION, so the existing single-statement by-id person_node sweep drops the pair
+// together at teardown. The winner/loser node ids are tracked separately ONLY for
+// the coverage check's tombstone + re-point invariants. Returns (winnerID, loserID).
+func (h *Harness) SeedMergedContact(ctx context.Context, winnerSpec, loserSpec factory.ContactSpec, winnerFact, loserFact factory.AssertionSpec) (winnerID, loserID uuid.UUID, err error) {
+	winner, err := h.SeedContact(ctx, winnerSpec)
+	if err != nil {
+		return uuid.Nil, uuid.Nil, fmt.Errorf("seed merge winner: %w", err)
+	}
+	if _, err := h.ReplayAssertion(ctx, winner.ID, winnerFact); err != nil {
+		return uuid.Nil, uuid.Nil, fmt.Errorf("seed merge winner assertion: %w", err)
+	}
+	loser, err := h.SeedContact(ctx, loserSpec)
+	if err != nil {
+		return uuid.Nil, uuid.Nil, fmt.Errorf("seed merge loser: %w", err)
+	}
+	if _, err := h.ReplayAssertion(ctx, loser.ID, loserFact); err != nil {
+		return uuid.Nil, uuid.Nil, fmt.Errorf("seed merge loser assertion: %w", err)
+	}
+	if _, err := h.contactService.MergeContacts(ctx, service.MergeContactsRequest{
+		SourceContactID: loser.ID,  // source = archived loser
+		TargetContactID: winner.ID, // target = surviving winner
+	}); err != nil {
+		return uuid.Nil, uuid.Nil, fmt.Errorf("merge contact %s into %s: %w", loser.ID, winner.ID, err)
+	}
+	h.track(func(c *created) { c.addMergedPair(winner.ID, loser.ID) })
+	return winner.ID, loser.ID, nil
 }
 
 // SeedNote attaches a notepad note to a seeded contact via the EXISTING
@@ -485,6 +564,29 @@ func (h *Harness) snapshotSignalNodeIDs() []uuid.UUID {
 	h.createdMu.Lock()
 	defer h.createdMu.Unlock()
 	return append([]uuid.UUID(nil), h.created.signalNodeIDs...)
+}
+
+// SoftDeletedNodeIDs / MergedLoserNodeIDs / MergedWinnerNodeIDs return THIS run's
+// tracked soft-delete / merge person node ids so a coverage test can scope its
+// tombstone + assertion-re-point invariant assertions to its own namespace's nodes
+// on the shared DB. Snapshots (mutex-guarded copies), so a caller can range them
+// without holding the ledger lock.
+func (h *Harness) SoftDeletedNodeIDs() []uuid.UUID {
+	h.createdMu.Lock()
+	defer h.createdMu.Unlock()
+	return append([]uuid.UUID(nil), h.created.softDeletedNodeIDs...)
+}
+
+func (h *Harness) MergedLoserNodeIDs() []uuid.UUID {
+	h.createdMu.Lock()
+	defer h.createdMu.Unlock()
+	return append([]uuid.UUID(nil), h.created.mergedLoserNodeIDs...)
+}
+
+func (h *Harness) MergedWinnerNodeIDs() []uuid.UUID {
+	h.createdMu.Lock()
+	defer h.createdMu.Unlock()
+	return append([]uuid.UUID(nil), h.created.mergedWinnerNodeIDs...)
 }
 
 // gateBClear reports whether Gate B has reached zero for this replay's contacts.

--- a/backend/internal/synthetic/synthetic.go
+++ b/backend/internal/synthetic/synthetic.go
@@ -128,6 +128,17 @@ type Counts struct {
 	// run time. Written through the production UpsertRelationshipSignal path
 	// (storage-only — SP1 has no signal generators). 0 disables.
 	SeededSignals int
+	// SeededSoftDeleted is the number of soft-deleted contact scenarios to seed: a
+	// contact with one assertion routed through ContactService.DeleteContact, so its
+	// person node is tombstoned and the assertion drops from live graph reads while
+	// remaining in the table. Each is a standalone contact (not a catalog slot). 0
+	// disables.
+	SeededSoftDeleted int
+	// SeededMerged is the number of merge scenarios to seed: a pair of contacts
+	// (winner + loser, each with one assertion) merged via ContactService.MergeContacts
+	// so the loser node is tombstoned (merged_into=winner) and its assertions are
+	// re-pointed onto the winner. Each pair is two standalone contacts. 0 disables.
+	SeededMerged int
 	// MessagesPerContact is how many settled interactions each DEDICATED per-source
 	// settled contact receives, spread back over time on distinct days (a prod-like
 	// interaction history) rather than a single ~1h window. The source replay for a

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -140,6 +140,10 @@ func TestSyntheticProfile_DevCoversCatalog(t *testing.T) {
 	require.Equal(t, settledContacts*params.Counts.MessagesPerContact, res.SettledInteractions,
 		"dev profile spreads MessagesPerContact interactions per settled contact")
 	require.Greater(t, res.SettledInteractions, settledContacts, "dev profile seeds >1 interaction per settled contact")
+	// Merge + soft-delete scenarios are standalone contacts seeded at full count
+	// (independent of catalog size), so the dev result equals the dev knobs.
+	require.Equal(t, params.Counts.SeededSoftDeleted, res.SeededSoftDeleted, "dev profile seeds soft-deleted contacts")
+	require.Equal(t, params.Counts.SeededMerged, res.SeededMerged, "dev profile seeds merged contact pairs")
 
 	remaining, err := h.ContactsRemaining(ctx)
 	require.NoError(t, err)
@@ -196,6 +200,10 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 	// interactionSpreadInterval (~3 weeks) older, so the per-contact span clears the
 	// multi-day floor asserted below. Kept small to bound the settle budget.
 	params.Counts.MessagesPerContact = 2
+	// One soft-deleted contact + one merged pair (the CI-safe minimum): enough to
+	// assert the tombstone + assertion re-point invariants below.
+	params.Counts.SeededSoftDeleted = 1
+	params.Counts.SeededMerged = 1
 
 	h := synthetic.NewHarnessForNamespace(t, ctx, database, params.Namespace, params.Seed)
 	res, err := synthetic.RunProfile(ctx, h, params)
@@ -409,6 +417,51 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 	}
 	require.True(t, spread, "≥1 settled contact has ≥2 interactions spanning ≥7 days (temporal spread, not one window)")
 
+	// Merge + soft-delete scenarios (item 12). These are standalone contacts seeded
+	// at full count (independent of the catalog), so the result equals the override.
+	require.Equal(t, params.Counts.SeededSoftDeleted, res.SeededSoftDeleted, "soft-deleted contacts seeded")
+	require.Equal(t, params.Counts.SeededMerged, res.SeededMerged, "merged contact pairs seeded")
+
+	// Soft-delete invariant: the person node is tombstoned, so its assertion is
+	// RETAINED in the table but DROPS from live graph reads. Scoped to THIS run's
+	// tracked soft-delete node ids.
+	softNodeIDs := h.SoftDeletedNodeIDs()
+	require.Len(t, softNodeIDs, res.SeededSoftDeleted, "tracked soft-delete node ids match the result count")
+	softInTable, err := support.CountAssertionsForSubjects(ctx, softNodeIDs)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, softInTable, int64(len(softNodeIDs)), "soft-deleted assertions retained in the table")
+	softLive, err := support.CountLiveAssertionsForSubjects(ctx, softNodeIDs)
+	require.NoError(t, err)
+	require.Zero(t, softLive, "soft-deleted assertions dropped from live graph reads")
+	softLiveNodes, err := support.CountLiveNodesByIds(ctx, softNodeIDs)
+	require.NoError(t, err)
+	require.Zero(t, softLiveNodes, "soft-deleted person nodes tombstoned (not live)")
+
+	// Merge invariant: the loser node is tombstoned with merged_into set, its
+	// assertions are re-pointed OFF the loser onto the live winner, and the winner
+	// stays live carrying its own + the re-pointed assertions. Scoped to THIS run's
+	// tracked merge node ids.
+	loserIDs := h.MergedLoserNodeIDs()
+	winnerIDs := h.MergedWinnerNodeIDs()
+	require.Len(t, loserIDs, res.SeededMerged, "tracked merge-loser node ids match the pair count")
+	require.Len(t, winnerIDs, res.SeededMerged, "tracked merge-winner node ids match the pair count")
+	loserMerged, err := support.CountMergedIntoNodesByIds(ctx, loserIDs)
+	require.NoError(t, err)
+	require.Equal(t, int64(len(loserIDs)), loserMerged, "every merge-loser node carries merged_into")
+	loserLiveNodes, err := support.CountLiveNodesByIds(ctx, loserIDs)
+	require.NoError(t, err)
+	require.Zero(t, loserLiveNodes, "merge-loser nodes tombstoned (not live)")
+	loserAssertions, err := support.CountAssertionsForSubjects(ctx, loserIDs)
+	require.NoError(t, err)
+	require.Zero(t, loserAssertions, "merge-loser assertions re-pointed off the loser")
+	winnerLiveNodes, err := support.CountLiveNodesByIds(ctx, winnerIDs)
+	require.NoError(t, err)
+	require.Equal(t, int64(len(winnerIDs)), winnerLiveNodes, "merge-winner nodes stay live")
+	winnerLiveAssertions, err := support.CountLiveAssertionsForSubjects(ctx, winnerIDs)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, winnerLiveAssertions, int64(2*len(winnerIDs)),
+		"merge-winner carries its own + the re-pointed loser assertion (≥2 per pair)")
+
 	remaining, err := h.ContactsRemaining(ctx)
 	require.NoError(t, err)
 	require.Greater(t, remaining, int64(0), "prod-shaped profile seeds contacts")
@@ -479,6 +532,11 @@ func TestSyntheticProfile_ProdShapedDeterministic(t *testing.T) {
 	params.Counts.StrandedMessages = 1
 	params.Counts.UnmatchedCalendar = 1
 	params.Counts.OrphanMeetingNote = 1
+	// One soft-deleted contact + one merged pair so the run-to-run ProfileResult
+	// count is exercised and the teardown of the tombstoned + merged rows (the
+	// merged_into self-FK is the trickiest sweep) is asserted FK-clean below.
+	params.Counts.SeededSoftDeleted = 1
+	params.Counts.SeededMerged = 1
 
 	// Capture the generator anchor ONCE and reuse it for both runs: identical
 	// across runs (so timestamped output incl. birthday value_date is
@@ -516,6 +574,14 @@ func TestSyntheticProfile_ProdShapedDeterministic(t *testing.T) {
 		sigRemaining, err := h.SignalsRemaining(ctx)
 		require.NoError(t, err)
 		require.Zero(t, sigRemaining, "relationship_signal rows swept by teardown")
+		// Teardown correctness for merge + soft-delete: the require.NoError(teardown)
+		// above already proves the merged_into self-FK did not block the
+		// single-statement node sweep; this confirms every seeded contact (incl. the
+		// tombstoned soft-deleted + merged-loser rows) was hard-deleted, leaving no
+		// stranded node/assertion behind.
+		contactsRemaining, err := h.ContactsRemaining(ctx)
+		require.NoError(t, err)
+		require.Zero(t, contactsRemaining, "all seeded contacts (incl. merge/soft-delete) swept by teardown")
 		return res, fp, entFP
 	}
 


### PR DESCRIPTION
## What

PR7 of the prod-shaped synthetic-seed enrichment. Seeds merge + soft-delete graph scenarios so the staging seed exercises those surfaces of the SP1 graph model.

- `Harness.SeedSoftDeletedContact` — seed a contact + assertion, then route through the production `ContactService.DeleteContact` so the person node is tombstoned (assertion drops from live graph reads, retained in the table).
- `Harness.SeedMergedContact` — seed winner + loser (distinct bool predicates), then `ContactService.MergeContacts` tombstones the loser (`merged_into`=winner) and re-points the loser's assertions onto the winner.
- Knobs `SeededSoftDeleted` / `SeededMerged` (full mechanics: Counts, ProfileResult, ProfileParams, runCatalogProfile, profiles_test, coverage check, DevCoversCatalog).
- Mirrors the production live-graph predicate (`ListLiveEdgesForNode`) in the two test-only assertion helpers so the `winnerLiveAssertions >= 2` invariant proves the merge re-pointed assertions as **live**, not on a terminal row.
- Applies R7: `AND n.deleted_at IS NULL` on `SyntheticListAssertionsByNodePrefix`.

This SEEDS merge/soft-delete by calling the already-tested production paths — it does not re-implement merge logic (covered by SP1 PR10's `contact_merge_node_integration_test.go`).

## Tests

Invariant assertions in `ProdShapedCoverageCheck`: soft-deleted assertion retained-but-not-live + node tombstoned; merge-loser `merged_into` set, node tombstoned, assertions re-pointed off; winner live carrying its own + re-pointed loser as live. `ProdShapedDeterministic` exercises both + asserts FK-clean teardown (the `merged_into` NO-ACTION self-FK lets the by-id node sweep drop the pair together — no new teardown step needed). All timestamps via `accelerated.GetCurrentTime()`; new `gen.X()` seeded LAST; new SQL is test-only sqlc.

## Review

- Local Codex (xhigh) re-review: PASS — P0=0 P1=0 P2=0 P3=0.
- `/review-head`: PASS — P0=0 P1=0 P2=0, one non-blocking P3 (comment-wording clarity on the subject-only scoping of the helpers; tracked).