### PR TITLE
feat(synthetic): seed import-source candidates for every imports subtab

### DIFF
--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -1815,9 +1815,22 @@ type Querier interface {
 	// unmatched candidates for this namespace. Caller passes a BARE prefix; '%'
 	// appended here.
 	SyntheticCountUnmatchedExternalContactByEmailPrefix(ctx context.Context, sourceIDPrefix pgtype.Text) (int64, error)
+	// Coverage (Imports subtabs): count UNMATCHED external_contact candidates for a
+	// given source whose source_id is ns-prefixed. The direct-upsert (gcontacts,
+	// gmail_correspondence) + ingest (anarlog_humans) import producers all carry an
+	// ns-prefixed source_id, so the prod-shaped coverage check asserts each subtab has
+	// ≥1 candidate scoped to its own namespace on the shared test DB. Caller passes a
+	// BARE prefix; '%' appended here.
+	SyntheticCountUnmatchedExternalContactBySourceAndSourceIdPrefix(ctx context.Context, arg SyntheticCountUnmatchedExternalContactBySourceAndSourceIdPrefixParams) (int64, error)
 	// Settle Gate A (Mac-contact unknown-sender): the external_contact row for the
 	// entity id exists with match_status='unmatched'.
 	SyntheticCountUnmatchedExternalContactBySourceId(ctx context.Context, sourceID string) (int64, error)
+	// Coverage (Imports telegram-discovery subtab): count UNMATCHED telegram discovery
+	// external_contact candidates whose source_id (the BARE peer id, NOT ns-prefixed)
+	// falls in this namespace's reserved peer band [band_start, band_end). The CASE
+	// guards the bigint cast for non-numeric telegram source_ids (other tests create
+	// text source ids), mirroring SyntheticCountTelegramBarePeerRowsInBand.
+	SyntheticCountUnmatchedTelegramDiscoveryInBand(ctx context.Context, arg SyntheticCountUnmatchedTelegramDiscoveryInBandParams) (int64, error)
 	// Cleanup assertion — count surviving venue nodes among the given ids (scoped to
 	// THIS run's tracked venue node ids, so it is immune to parallel tests creating
 	// their own venue nodes on the shared DB, unlike a global venue-node count).
@@ -1976,6 +1989,13 @@ type Querier interface {
 	// (interaction.recorded uses interaction.ID as source_id, calendar.attended
 	// uses an internal ref, etc.) generically via payload->>'contact_id'.
 	SyntheticListEventIdsForContacts(ctx context.Context, contactIds []string) ([]pgtype.UUID, error)
+	// Determinism fingerprint (import producers): the (source, source_id) of every live
+	// external_contact whose source_id is ns-prefixed, sorted, so a determinism test can
+	// assert the import-candidate source_ids are byte-identical across two seed runs in
+	// the same namespace. (Telegram discovery candidates key on the bare peer id, not the
+	// prefix, so they are excluded here — their determinism rides the deterministic peer
+	// band + the run-to-run ProfileResult count equality.) Caller passes a BARE prefix.
+	SyntheticListExternalContactSourceIdsByPrefix(ctx context.Context, sourceIDPrefix pgtype.Text) ([]*SyntheticListExternalContactSourceIdsByPrefixRow, error)
 	// Reset integration test only: count ALL rows in a single table by name. Used by
 	// the clone-DB reset test to assert each wiped table is empty after the reset and
 	// that schema_migrations survives. The table name is validated against the wiped

--- a/backend/internal/db/queries/test.sql
+++ b/backend/internal/db/queries/test.sql
@@ -478,6 +478,44 @@ WHERE source = 'gcal_attendee'
   AND match_status = 'unmatched'
   AND deleted_at IS NULL;
 
+-- name: SyntheticCountUnmatchedExternalContactBySourceAndSourceIdPrefix :one
+-- Coverage (Imports subtabs): count UNMATCHED external_contact candidates for a
+-- given source whose source_id is ns-prefixed. The direct-upsert (gcontacts,
+-- gmail_correspondence) + ingest (anarlog_humans) import producers all carry an
+-- ns-prefixed source_id, so the prod-shaped coverage check asserts each subtab has
+-- ≥1 candidate scoped to its own namespace on the shared test DB. Caller passes a
+-- BARE prefix; '%' appended here.
+SELECT COUNT(*) FROM external_contact
+WHERE source = @source
+  AND source_id LIKE @source_id_prefix || '%'
+  AND match_status = 'unmatched'
+  AND deleted_at IS NULL;
+
+-- name: SyntheticCountUnmatchedTelegramDiscoveryInBand :one
+-- Coverage (Imports telegram-discovery subtab): count UNMATCHED telegram discovery
+-- external_contact candidates whose source_id (the BARE peer id, NOT ns-prefixed)
+-- falls in this namespace's reserved peer band [band_start, band_end). The CASE
+-- guards the bigint cast for non-numeric telegram source_ids (other tests create
+-- text source ids), mirroring SyntheticCountTelegramBarePeerRowsInBand.
+SELECT COUNT(*) FROM external_contact
+WHERE source = 'telegram'
+  AND match_status = 'unmatched'
+  AND deleted_at IS NULL
+  AND (CASE WHEN source_id ~ '^[0-9]{1,18}$' THEN source_id::bigint END) >= @band_start::bigint
+  AND (CASE WHEN source_id ~ '^[0-9]{1,18}$' THEN source_id::bigint END) < @band_end::bigint;
+
+-- name: SyntheticListExternalContactSourceIdsByPrefix :many
+-- Determinism fingerprint (import producers): the (source, source_id) of every live
+-- external_contact whose source_id is ns-prefixed, sorted, so a determinism test can
+-- assert the import-candidate source_ids are byte-identical across two seed runs in
+-- the same namespace. (Telegram discovery candidates key on the bare peer id, not the
+-- prefix, so they are excluded here — their determinism rides the deterministic peer
+-- band + the run-to-run ProfileResult count equality.) Caller passes a BARE prefix.
+SELECT source, source_id FROM external_contact
+WHERE source_id LIKE @source_id_prefix || '%'
+  AND deleted_at IS NULL
+ORDER BY source, source_id;
+
 -- name: SyntheticCountTelegramMessagesByChatAndMessageId :one
 -- Group assertion: count telegram_message rows for (telegram_chat_id,
 -- telegram_message_id). Tests assert 0 for the untracked-by-size group case (the

--- a/backend/internal/db/test.sql.go
+++ b/backend/internal/db/test.sql.go
@@ -1320,6 +1320,32 @@ func (q *Queries) SyntheticCountUnmatchedExternalContactByEmailPrefix(ctx contex
 	return count, err
 }
 
+const SyntheticCountUnmatchedExternalContactBySourceAndSourceIdPrefix = `-- name: SyntheticCountUnmatchedExternalContactBySourceAndSourceIdPrefix :one
+SELECT COUNT(*) FROM external_contact
+WHERE source = $1
+  AND source_id LIKE $2 || '%'
+  AND match_status = 'unmatched'
+  AND deleted_at IS NULL
+`
+
+type SyntheticCountUnmatchedExternalContactBySourceAndSourceIdPrefixParams struct {
+	Source         string      `json:"source"`
+	SourceIDPrefix pgtype.Text `json:"source_id_prefix"`
+}
+
+// Coverage (Imports subtabs): count UNMATCHED external_contact candidates for a
+// given source whose source_id is ns-prefixed. The direct-upsert (gcontacts,
+// gmail_correspondence) + ingest (anarlog_humans) import producers all carry an
+// ns-prefixed source_id, so the prod-shaped coverage check asserts each subtab has
+// ≥1 candidate scoped to its own namespace on the shared test DB. Caller passes a
+// BARE prefix; '%' appended here.
+func (q *Queries) SyntheticCountUnmatchedExternalContactBySourceAndSourceIdPrefix(ctx context.Context, arg SyntheticCountUnmatchedExternalContactBySourceAndSourceIdPrefixParams) (int64, error) {
+	row := q.db.QueryRow(ctx, SyntheticCountUnmatchedExternalContactBySourceAndSourceIdPrefix, arg.Source, arg.SourceIDPrefix)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const SyntheticCountUnmatchedExternalContactBySourceId = `-- name: SyntheticCountUnmatchedExternalContactBySourceId :one
 SELECT COUNT(*) FROM external_contact
 WHERE source_id = $1
@@ -1331,6 +1357,32 @@ WHERE source_id = $1
 // entity id exists with match_status='unmatched'.
 func (q *Queries) SyntheticCountUnmatchedExternalContactBySourceId(ctx context.Context, sourceID string) (int64, error) {
 	row := q.db.QueryRow(ctx, SyntheticCountUnmatchedExternalContactBySourceId, sourceID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const SyntheticCountUnmatchedTelegramDiscoveryInBand = `-- name: SyntheticCountUnmatchedTelegramDiscoveryInBand :one
+SELECT COUNT(*) FROM external_contact
+WHERE source = 'telegram'
+  AND match_status = 'unmatched'
+  AND deleted_at IS NULL
+  AND (CASE WHEN source_id ~ '^[0-9]{1,18}$' THEN source_id::bigint END) >= $1::bigint
+  AND (CASE WHEN source_id ~ '^[0-9]{1,18}$' THEN source_id::bigint END) < $2::bigint
+`
+
+type SyntheticCountUnmatchedTelegramDiscoveryInBandParams struct {
+	BandStart int64 `json:"band_start"`
+	BandEnd   int64 `json:"band_end"`
+}
+
+// Coverage (Imports telegram-discovery subtab): count UNMATCHED telegram discovery
+// external_contact candidates whose source_id (the BARE peer id, NOT ns-prefixed)
+// falls in this namespace's reserved peer band [band_start, band_end). The CASE
+// guards the bigint cast for non-numeric telegram source_ids (other tests create
+// text source ids), mirroring SyntheticCountTelegramBarePeerRowsInBand.
+func (q *Queries) SyntheticCountUnmatchedTelegramDiscoveryInBand(ctx context.Context, arg SyntheticCountUnmatchedTelegramDiscoveryInBandParams) (int64, error) {
+	row := q.db.QueryRow(ctx, SyntheticCountUnmatchedTelegramDiscoveryInBand, arg.BandStart, arg.BandEnd)
 	var count int64
 	err := row.Scan(&count)
 	return count, err
@@ -1927,6 +1979,44 @@ func (q *Queries) SyntheticListEventIdsForContacts(ctx context.Context, contactI
 			return nil, err
 		}
 		items = append(items, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const SyntheticListExternalContactSourceIdsByPrefix = `-- name: SyntheticListExternalContactSourceIdsByPrefix :many
+SELECT source, source_id FROM external_contact
+WHERE source_id LIKE $1 || '%'
+  AND deleted_at IS NULL
+ORDER BY source, source_id
+`
+
+type SyntheticListExternalContactSourceIdsByPrefixRow struct {
+	Source   string `json:"source"`
+	SourceID string `json:"source_id"`
+}
+
+// Determinism fingerprint (import producers): the (source, source_id) of every live
+// external_contact whose source_id is ns-prefixed, sorted, so a determinism test can
+// assert the import-candidate source_ids are byte-identical across two seed runs in
+// the same namespace. (Telegram discovery candidates key on the bare peer id, not the
+// prefix, so they are excluded here — their determinism rides the deterministic peer
+// band + the run-to-run ProfileResult count equality.) Caller passes a BARE prefix.
+func (q *Queries) SyntheticListExternalContactSourceIdsByPrefix(ctx context.Context, sourceIDPrefix pgtype.Text) ([]*SyntheticListExternalContactSourceIdsByPrefixRow, error) {
+	rows, err := q.db.Query(ctx, SyntheticListExternalContactSourceIdsByPrefix, sourceIDPrefix)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []*SyntheticListExternalContactSourceIdsByPrefixRow{}
+	for rows.Next() {
+		var i SyntheticListExternalContactSourceIdsByPrefixRow
+		if err := rows.Scan(&i.Source, &i.SourceID); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/backend/internal/repository/synthetic_support.go
+++ b/backend/internal/repository/synthetic_support.go
@@ -475,6 +475,54 @@ func (r *SyntheticSupportRepository) CountUnmatchedExternalContactByEmailPrefix(
 	return r.queries.SyntheticCountUnmatchedExternalContactByEmailPrefix(ctx, pgtype.Text{String: prefix, Valid: true})
 }
 
+// CountUnmatchedExternalContactBySourceAndPrefix counts UNMATCHED import
+// candidates for a given source whose source_id is ns-prefixed. The direct-upsert
+// (gcontacts, gmail_correspondence) + ingest (anarlog_humans) import producers all
+// carry an ns-prefixed source_id, so the prod-shaped coverage check asserts each
+// Imports subtab has ≥1 candidate scoped to its own namespace. Caller passes a
+// BARE prefix.
+func (r *SyntheticSupportRepository) CountUnmatchedExternalContactBySourceAndPrefix(ctx context.Context, source, prefix string) (int64, error) {
+	return r.queries.SyntheticCountUnmatchedExternalContactBySourceAndSourceIdPrefix(ctx, db.SyntheticCountUnmatchedExternalContactBySourceAndSourceIdPrefixParams{
+		Source:         source,
+		SourceIDPrefix: pgtype.Text{String: prefix, Valid: true},
+	})
+}
+
+// CountUnmatchedTelegramDiscoveryInBand counts UNMATCHED telegram discovery
+// candidates whose source_id (the BARE peer id) falls in this namespace's reserved
+// peer band [bandStart, bandEnd). The telegram discovery candidate keys on the peer
+// id rather than an ns-prefix, so the coverage check scopes it by band instead.
+func (r *SyntheticSupportRepository) CountUnmatchedTelegramDiscoveryInBand(ctx context.Context, bandStart, bandEnd int64) (int64, error) {
+	return r.queries.SyntheticCountUnmatchedTelegramDiscoveryInBand(ctx, db.SyntheticCountUnmatchedTelegramDiscoveryInBandParams{
+		BandStart: bandStart,
+		BandEnd:   bandEnd,
+	})
+}
+
+// ExternalContactSummary is the (source, source_id) projection of a live
+// external_contact whose source_id is ns-prefixed — the import-producer determinism
+// fingerprint.
+type ExternalContactSummary struct {
+	Source   string
+	SourceID string
+}
+
+// ListExternalContactSourceIDsByPrefix returns the sorted (source, source_id) of
+// every live external_contact whose source_id is ns-prefixed, so a determinism test
+// can assert the import-candidate source_ids are byte-identical across two seed runs
+// in the same namespace. Caller passes a BARE prefix.
+func (r *SyntheticSupportRepository) ListExternalContactSourceIDsByPrefix(ctx context.Context, prefix string) ([]ExternalContactSummary, error) {
+	rows, err := r.queries.SyntheticListExternalContactSourceIdsByPrefix(ctx, pgtype.Text{String: prefix, Valid: true})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]ExternalContactSummary, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, ExternalContactSummary{Source: row.Source, SourceID: row.SourceID})
+	}
+	return out, nil
+}
+
 // --- revoked synthetic Mac host (host-only ingest kinds) -------------------
 
 // SeedRevokedMacHost inserts a REVOKED mac_host (api_key_revoked_at set) and

--- a/backend/internal/synthetic/factory/sources.go
+++ b/backend/internal/synthetic/factory/sources.go
@@ -412,11 +412,21 @@ type MacContactSpec struct {
 	Intent   MatchIntent
 }
 
-// MacContact builds an external_contact.upserted envelope whose email matches
-// the target contact (MatchSeeded → linked to seeded contact) or is unknown
-// (MatchUnknown → external_contact.match_status='unmatched'). hostID is the
-// revoked synthetic host.
+// MacContact builds an icloud_contacts external_contact.upserted envelope whose
+// email matches the target contact (MatchSeeded → linked to seeded contact) or
+// is unknown (MatchUnknown → external_contact.match_status='unmatched'). hostID
+// is the revoked synthetic host.
 func (g *Generator) MacContact(target ContactSpec, intent MatchIntent, hostID uuid.UUID) (MacContactSpec, error) {
+	return g.MacContactForSource(target, intent, hostID, "icloud_contacts")
+}
+
+// MacContactForSource is MacContact parameterized by the external_contact ingest
+// source. source MUST be an ingest-allowed external_contact source
+// (icloud_contacts or anarlog_humans — service.externalContactAllowedSources);
+// the ReplayMacContacts adapter feeds the envelope through IngestService, which
+// rejects any other source. Used to emit anarlog_humans import candidates (an
+// Imports subtab the icloud path does not cover) through the same ingest pipeline.
+func (g *Generator) MacContactForSource(target ContactSpec, intent MatchIntent, hostID uuid.UUID, source string) (MacContactSpec, error) {
 	seq := g.bumpSourceSeq()
 	entityID := fmt.Sprintf("%sec-%d", g.Prefix(), seq)
 
@@ -429,7 +439,7 @@ func (g *Generator) MacContact(target ContactSpec, intent MatchIntent, hostID uu
 	payload := events.ExternalContactUpsertedPayload{
 		Version:     1,
 		HostID:      hostID,
-		Source:      "icloud_contacts",
+		Source:      source,
 		EntityID:    entityID,
 		DisplayName: &displayName,
 		Emails:      []events.ExternalContactMethodValue{{Value: email, Primary: true}},
@@ -440,7 +450,7 @@ func (g *Generator) MacContact(target ContactSpec, intent MatchIntent, hostID uu
 	}
 	return MacContactSpec{
 		Envelope: &events.Envelope{
-			Source:     "icloud_contacts",
+			Source:     source,
 			SourceID:   entityID,
 			Kind:       events.KindExternalContactUpserted,
 			Payload:    raw,
@@ -449,6 +459,47 @@ func (g *Generator) MacContact(target ContactSpec, intent MatchIntent, hostID uu
 		EntityID: entityID,
 		Intent:   intent,
 	}, nil
+}
+
+// --- Direct-upsert external_contact candidates (gcontacts/gmail_correspondence) -
+
+// ExternalContactCandidateSpec is a direct-upsert (non-ingest) external_contact
+// import candidate — the shape the Google sync providers write straight through
+// ExternalContactRepository.Upsert (gcontacts via contacts.go, gmail_correspondence
+// via gmail_correspondence.go). Those sources are NOT ingest-allowed, so the seed
+// mirrors the providers' write path rather than the ingest envelope path. The
+// replay harness maps this neutral spec into an UpsertExternalContactRequest and
+// chooses the source_id keying + extra fields per source. All identifiers are
+// ns-prefixed (so the teardown's source_id-prefix sweep reclaims the row); the
+// email is an unknown *.example address no seeded contact owns, so the upsert lands
+// match_status='unmatched' (the Imports-queue surface).
+type ExternalContactCandidateSpec struct {
+	Source      string
+	EntityID    string // ns-prefixed id-shaped key (the source_id for id-keyed sources, e.g. gcontacts)
+	Email       string // unknown *.example address (the source_id for email-keyed sources, e.g. gmail_correspondence)
+	DisplayName string
+	FirstName   string
+	LastName    string
+	AccountID   string // the connected account ("me"); the harness sets it only for account-scoped sources
+}
+
+// ExternalContactCandidate builds a neutral UNMATCHED import-candidate spec for a
+// direct-upsert source. It generates deterministic ns-prefixed identifiers (id +
+// unknown email) plus display/name parts; the harness's SeedExternalContactCandidate
+// decides which become the external_contact.source_id and which extra fields apply
+// for the given source. Deterministic (source seq), no PRNG name draw.
+func (g *Generator) ExternalContactCandidate(source string) ExternalContactCandidateSpec {
+	seq := g.bumpSourceSeq()
+	ns := g.Prefix()
+	return ExternalContactCandidateSpec{
+		Source:      source,
+		EntityID:    fmt.Sprintf("%scand-%d", ns, seq),
+		Email:       fmt.Sprintf("%scand-%d@synthetic.example", ns, seq),
+		DisplayName: fmt.Sprintf("%sImport Candidate %d", ns, seq),
+		FirstName:   ns + "Import",
+		LastName:    fmt.Sprintf("Candidate%d", seq),
+		AccountID:   g.accountEmail(),
+	}
 }
 
 // --- Todoist (fake Client SyncItem) ----------------------------------------

--- a/backend/internal/synthetic/profiles.go
+++ b/backend/internal/synthetic/profiles.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/google"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/synthetic/factory"
 
@@ -102,6 +103,17 @@ type ProfileResult struct {
 	// / no PII.
 	SeededSoftDeleted int
 	SeededMerged      int
+	// UnmatchedGContacts / UnmatchedGmailCorrespondence / UnmatchedAnarlogHumans /
+	// TelegramDiscovery count the per-subtab Imports-queue candidates the profile
+	// seeded (item 13) beyond the icloud_contacts (UnmatchedExternal) + gcal_attendee
+	// (UnmatchedCalendar) surfaces above. gcontacts + gmail_correspondence ride the
+	// direct repo-upsert path (NOT ingest-allowed); anarlog_humans rides the ingest
+	// path; telegram discovery crosses the per-peer discovery threshold. All are
+	// unmatched candidates. Counts-only / no PII.
+	UnmatchedGContacts           int
+	UnmatchedGmailCorrespondence int
+	UnmatchedAnarlogHumans       int
+	TelegramDiscovery            int
 }
 
 // ProfileParams returns the default SeedParams for a named profile (error on an
@@ -150,6 +162,9 @@ func ProfileParams(name Profile) (SeedParams, error) {
 				// tombstone + merge re-point scenarios.
 				SeededSoftDeleted: 1,
 				SeededMerged:      1,
+				// One unmatched candidate per Imports subtab (gcontacts/gmail_correspondence/
+				// anarlog_humans/telegram-discovery) so every local Imports surface has content.
+				ImportCandidatesPerSource: 1,
 			},
 		}, nil
 	case ProfileProdShaped:
@@ -201,6 +216,11 @@ func ProfileParams(name Profile) (SeedParams, error) {
 				// tests override these down for CI.
 				SeededSoftDeleted: 3,
 				SeededMerged:      3,
+				// A few unmatched candidates per Imports subtab (gcontacts/gmail_correspondence/
+				// anarlog_humans/telegram-discovery) so every staging Imports subtab has a queue.
+				// The coverage + determinism tests override this down for CI runtime (telegram
+				// discovery replays 3 group messages + settles per candidate).
+				ImportCandidatesPerSource: 4,
 			},
 		}, nil
 	default:
@@ -722,8 +742,85 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		res.SeededMerged++
 	}
 
+	// Import-source candidates so EVERY Imports subtab has unmatched content (item
+	// 13). Seeded LAST — the very end of the generator-driven sequence — because
+	// gen.ExternalContactCandidate / gen.MacContactForSource / gen.TelegramGroupMessage
+	// advance the generator's source seq (and the latter two draw the name PRNG via
+	// gen.Contact); appending them here keeps the deterministic id/handle sequence the
+	// earlier source replays + graph blocks depend on unshifted. icloud_contacts
+	// (UnmatchedExternal) + gcal_attendee (UnmatchedCalendar) are already covered
+	// above; this fills the remaining subtabs:
+	//   - gcontacts + gmail_correspondence: written via the production
+	//     ExternalContactRepository.Upsert path (the Google sync providers' write path),
+	//     because the ingest registry does NOT allow these as ingest events. The upsert
+	//     lands match_status='unmatched' (the Imports-queue surface only).
+	//   - anarlog_humans: ingest-allowed → routed through ReplayMacContacts like icloud,
+	//     so it passes the 0-accepted-events guard.
+	//   - telegram discovery: telegramDiscoveryMessages group messages from ONE unknown
+	//     peer (shared chat + sender, distinct message ids) cross the per-peer discovery
+	//     threshold, so UpdateDiscoveryCandidatesForPeer upserts the discovery candidate.
+	// Teardown reclaims them via the existing external_contact source_id-prefix sweep
+	// (gcontacts/gmail_correspondence/anarlog carry an ns-prefixed source_id) and the
+	// telegram-peer sweep (the discovery candidate is keyed by the bare peer id).
+	for i := 0; i < params.Counts.ImportCandidatesPerSource; i++ {
+		// gcontacts (direct repo upsert).
+		if _, err := h.SeedExternalContactCandidate(ctx, gen.ExternalContactCandidate(importSourceGContacts)); err != nil {
+			return res, fmt.Errorf("profile %s: seed gcontacts candidate %d: %w", params.Profile, i, err)
+		}
+		res.UnmatchedGContacts++
+
+		// gmail_correspondence (direct repo upsert).
+		if _, err := h.SeedExternalContactCandidate(ctx, gen.ExternalContactCandidate(importSourceGmailCorrespondence)); err != nil {
+			return res, fmt.Errorf("profile %s: seed gmail_correspondence candidate %d: %w", params.Profile, i, err)
+		}
+		res.UnmatchedGmailCorrespondence++
+
+		// anarlog_humans (ingest path).
+		anarlogSpec, err := gen.MacContactForSource(gen.Contact(factory.WithEmail()), factory.MatchUnknown, h.MacHostID(), importSourceAnarlogHumans)
+		if err != nil {
+			return res, fmt.Errorf("profile %s: build anarlog candidate %d: %w", params.Profile, i, err)
+		}
+		if _, err := h.ReplayMacContacts(ctx, uuid.Nil, anarlogSpec); err != nil {
+			return res, fmt.Errorf("profile %s: replay anarlog candidate %d: %w", params.Profile, i, err)
+		}
+		res.UnmatchedAnarlogHumans++
+
+		// telegram discovery: a group conversation of telegramDiscoveryMessages messages
+		// sharing ONE chat + unknown sender (distinct message ids), built by copying the
+		// first spec and only bumping the message id — so the per-peer message count
+		// crosses the discovery threshold and a discovery candidate is upserted.
+		first := gen.TelegramGroupMessage(gen.Contact(factory.WithTelegram()), factory.MatchUnknown, h.GroupMaxMembers())
+		discoverySpecs := []factory.TelegramGroupMessageSpec{first}
+		for k := 1; k < telegramDiscoveryMessages; k++ {
+			next := first
+			next.TelegramMessageID = first.TelegramMessageID + int32(k)
+			discoverySpecs = append(discoverySpecs, next)
+		}
+		if _, err := h.ReplayTelegramGroupMessages(ctx, uuid.Nil, discoverySpecs); err != nil {
+			return res, fmt.Errorf("profile %s: replay telegram discovery %d: %w", params.Profile, i, err)
+		}
+		res.TelegramDiscovery++
+	}
+
 	return res, nil
 }
+
+// importSourceGContacts / importSourceGmailCorrespondence / importSourceAnarlogHumans
+// name the Imports subtabs the seed fills beyond icloud_contacts (UnmatchedExternal)
+// + gcal_attendee (UnmatchedCalendar). The two Google sources reference the providers'
+// canonical source constants so they cannot drift from the live write paths; anarlog_humans
+// matches the ingest registry's allowed-source literal (service/ingest_registry.go).
+const (
+	importSourceGContacts           = google.ContactsSourceName
+	importSourceGmailCorrespondence = google.CorrespondenceSource
+	importSourceAnarlogHumans       = "anarlog_humans"
+)
+
+// telegramDiscoveryMessages is how many group messages one unknown peer must send
+// to cross the harness's telegram discovery threshold (the peer matcher is built with
+// DiscoveryMinMessages=3 in harness_setup.go), so UpdateDiscoveryCandidatesForPeer
+// upserts a discovery candidate.
+const telegramDiscoveryMessages = 3
 
 // softDeleteFactPredicate / mergeWinnerFactPredicate / mergeLoserFactPredicate are
 // the bool-fact predicates the merge + soft-delete scenarios assert (all

--- a/backend/internal/synthetic/profiles_test.go
+++ b/backend/internal/synthetic/profiles_test.go
@@ -93,6 +93,10 @@ func TestProfileParams(t *testing.T) {
 	// tombstoned + re-pointed graph rows to assert.
 	require.Greater(t, prod.Counts.SeededSoftDeleted, 0)
 	require.Greater(t, prod.Counts.SeededMerged, 0)
+	// prod-shaped seeds per-subtab Imports candidates (gcontacts/gmail_correspondence/
+	// anarlog_humans/telegram-discovery) so the coverage check can assert every Imports
+	// subtab has a queue.
+	require.Greater(t, prod.Counts.ImportCandidatesPerSource, 0)
 }
 
 // TestDefaultParamsUnchanged pins DefaultParams field-for-field so the
@@ -120,4 +124,5 @@ func TestDefaultParamsUnchanged(t *testing.T) {
 	require.Equal(t, 0, p.Counts.MessagesPerContact)
 	require.Equal(t, 0, p.Counts.SeededSoftDeleted)
 	require.Equal(t, 0, p.Counts.SeededMerged)
+	require.Equal(t, 0, p.Counts.ImportCandidatesPerSource)
 }

--- a/backend/internal/synthetic/replay/replay.go
+++ b/backend/internal/synthetic/replay/replay.go
@@ -24,6 +24,7 @@ import (
 	"personal-crm/backend/internal/consumer"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/google"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/service"
 	"personal-crm/backend/internal/synthetic/factory"
@@ -288,6 +289,51 @@ func (h *Harness) SeedEntity(ctx context.Context, spec factory.EntitySpec) (uuid
 		return uuid.Nil, fmt.Errorf("seed entity: commit: %w", err)
 	}
 	return nodeID, nil
+}
+
+// SeedExternalContactCandidate writes one UNMATCHED external_contact import
+// candidate through the PRODUCTION ExternalContactRepository.Upsert path — the
+// SAME write the Google sync providers use for sources the ingest registry does
+// NOT allow (gcontacts: google/contacts.go; gmail_correspondence:
+// google/gmail_correspondence.go). The Upsert hardcodes match_status='unmatched'
+// on insert, so this produces an Imports-queue candidate only (matched/linked
+// candidates need the match path and are out of scope here). The field shape
+// mirrors each provider so the Imports UI renders the candidate: gcontacts is
+// account-scoped with first/last name and an id-shaped source_id; the
+// correspondence source keys its source_id on the email and carries the evidence
+// metadata the card reads. The ns-prefixed source_id is reclaimed by the
+// teardown's external_contact source_id-prefix sweep — no per-id tracking needed.
+// Returns the created row id.
+func (h *Harness) SeedExternalContactCandidate(ctx context.Context, spec factory.ExternalContactCandidateSpec) (uuid.UUID, error) {
+	now := accelerated.GetCurrentTime()
+	req := repository.UpsertExternalContactRequest{
+		Source:      spec.Source,
+		DisplayName: &spec.DisplayName,
+		Emails:      []repository.EmailEntry{{Value: spec.Email, Primary: true}},
+		SyncedAt:    &now,
+	}
+	switch spec.Source {
+	case google.CorrespondenceSource:
+		// The correspondence discoverer keys source_id on the email address and
+		// attaches the evidence metadata the card renders (observed names + count).
+		req.SourceID = spec.Email
+		req.Metadata = map[string]any{
+			"display_names_seen": []string{spec.DisplayName},
+			"message_count":      1,
+		}
+	default:
+		// Address-book sources (gcontacts) are account-scoped, id-keyed, and carry
+		// the name parts the provider extracts from the Person record.
+		req.SourceID = spec.EntityID
+		req.AccountID = &spec.AccountID
+		req.FirstName = &spec.FirstName
+		req.LastName = &spec.LastName
+	}
+	ec, err := h.externalRepo.Upsert(ctx, req)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("seed external contact candidate (%s): %w", spec.Source, err)
+	}
+	return ec.ID, nil
 }
 
 // SeedRelationshipSignal writes one relationship_signal row for a seeded node

--- a/backend/internal/synthetic/synthetic.go
+++ b/backend/internal/synthetic/synthetic.go
@@ -147,6 +147,14 @@ type Counts struct {
 	// the dedicated settled contacts — the edge-case catalog stays interaction-free
 	// so its overdue / never-contacted / no-method buckets survive.
 	MessagesPerContact int
+	// ImportCandidatesPerSource is how many UNMATCHED import candidates to seed for
+	// EACH Imports subtab the icloud_contacts (UnmatchedExternal) + gcal_attendee
+	// (UnmatchedCalendar) knobs do not already cover: gcontacts + gmail_correspondence
+	// (direct repo upsert — NOT ingest-allowed, mirroring the Google sync providers),
+	// anarlog_humans (ingest path), and telegram discovery (≥3 group messages from one
+	// unknown peer crossing the discovery threshold). All land match_status='unmatched'.
+	// 0 disables (minimal-scoped stays import-free / byte-stable).
+	ImportCandidatesPerSource int
 }
 
 // SeedParams is the profile/volume seam consumed by the seed orchestration.

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -145,6 +145,13 @@ func TestSyntheticProfile_DevCoversCatalog(t *testing.T) {
 	require.Equal(t, params.Counts.SeededSoftDeleted, res.SeededSoftDeleted, "dev profile seeds soft-deleted contacts")
 	require.Equal(t, params.Counts.SeededMerged, res.SeededMerged, "dev profile seeds merged contact pairs")
 
+	// Import-source candidates: one per subtab per ImportCandidatesPerSource, seeded at
+	// full count (independent of catalog size), so each result equals the dev knob.
+	require.Equal(t, params.Counts.ImportCandidatesPerSource, res.UnmatchedGContacts, "dev profile seeds gcontacts candidates")
+	require.Equal(t, params.Counts.ImportCandidatesPerSource, res.UnmatchedGmailCorrespondence, "dev profile seeds gmail_correspondence candidates")
+	require.Equal(t, params.Counts.ImportCandidatesPerSource, res.UnmatchedAnarlogHumans, "dev profile seeds anarlog_humans candidates")
+	require.Equal(t, params.Counts.ImportCandidatesPerSource, res.TelegramDiscovery, "dev profile seeds telegram discovery candidates")
+
 	remaining, err := h.ContactsRemaining(ctx)
 	require.NoError(t, err)
 	require.Greater(t, remaining, int64(0), "dev profile seeds catalog contacts")
@@ -204,6 +211,11 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 	// assert the tombstone + assertion re-point invariants below.
 	params.Counts.SeededSoftDeleted = 1
 	params.Counts.SeededMerged = 1
+	// One candidate per Imports subtab (gcontacts/gmail_correspondence/anarlog_humans/
+	// telegram-discovery): the CI-safe minimum that still gives each subtab ≥1 queue
+	// entry. Kept at 1 to bound the settle budget (telegram discovery replays 3 group
+	// messages + settles; anarlog ingests + settles).
+	params.Counts.ImportCandidatesPerSource = 1
 
 	h := synthetic.NewHarnessForNamespace(t, ctx, database, params.Namespace, params.Seed)
 	res, err := synthetic.RunProfile(ctx, h, params)
@@ -462,6 +474,24 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 	require.GreaterOrEqual(t, winnerLiveAssertions, int64(2*len(winnerIDs)),
 		"merge-winner carries its own + the re-pointed loser assertion (≥2 per pair)")
 
+	// Import-source candidates (item 13): EVERY Imports subtab must have ≥1 unmatched
+	// candidate so staging's Imports queue is populated. Assert both the result counter
+	// and the actual DB row, scoped to THIS namespace. gcontacts/gmail_correspondence/
+	// anarlog_humans carry an ns-prefixed source_id; telegram discovery keys on the bare
+	// peer id, so it is scoped by the namespace's reserved peer band instead.
+	require.GreaterOrEqual(t, res.UnmatchedGContacts, 1, "gcontacts candidate seeded")
+	require.GreaterOrEqual(t, res.UnmatchedGmailCorrespondence, 1, "gmail_correspondence candidate seeded")
+	require.GreaterOrEqual(t, res.UnmatchedAnarlogHumans, 1, "anarlog_humans candidate seeded")
+	require.GreaterOrEqual(t, res.TelegramDiscovery, 1, "telegram discovery candidate seeded")
+	for _, source := range []string{"gcontacts", "gmail_correspondence", "anarlog_humans"} {
+		count, err := support.CountUnmatchedExternalContactBySourceAndPrefix(ctx, source, prefix)
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, count, int64(1), "≥1 unmatched %q import candidate present", source)
+	}
+	tgDiscovery, err := support.CountUnmatchedTelegramDiscoveryInBand(ctx, h.Generator().PeerBandStart(), h.Generator().PeerBandEnd())
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, tgDiscovery, int64(1), "≥1 unmatched telegram discovery candidate present")
+
 	remaining, err := h.ContactsRemaining(ctx)
 	require.NoError(t, err)
 	require.Greater(t, remaining, int64(0), "prod-shaped profile seeds contacts")
@@ -537,6 +567,11 @@ func TestSyntheticProfile_ProdShapedDeterministic(t *testing.T) {
 	// merged_into self-FK is the trickiest sweep) is asserted FK-clean below.
 	params.Counts.SeededSoftDeleted = 1
 	params.Counts.SeededMerged = 1
+	// One candidate per Imports subtab so the import-producer source_ids participate in
+	// the determinism fingerprint (the direct-upsert + ingest source_ids are ns-prefixed)
+	// and the run-to-run ProfileResult count equality, and the teardown of the
+	// external_contact candidates is asserted clean below.
+	params.Counts.ImportCandidatesPerSource = 1
 
 	// Capture the generator anchor ONCE and reuse it for both runs: identical
 	// across runs (so timestamped output incl. birthday value_date is
@@ -548,11 +583,12 @@ func TestSyntheticProfile_ProdShapedDeterministic(t *testing.T) {
 	support := repository.NewSyntheticSupportRepository(database.Queries)
 
 	// run seeds the profile, captures (ProfileResult, assertion fingerprint, entity
-	// normalized_name fingerprint), then fully tears down so the next run starts from
-	// a clean namespace. It also asserts the teardown swept every entity node (pool
-	// + place) — a leaked entity node would FK-block or duplicate-violate the next
-	// run, and a surviving place node from a `within` edge would FK-block the sweep.
-	run := func() (synthetic.ProfileResult, []repository.AssertionSummary, []repository.EntityNameSummary) {
+	// normalized_name fingerprint, import-candidate source_id fingerprint), then fully
+	// tears down so the next run starts from a clean namespace. It also asserts the
+	// teardown swept every entity node (pool + place) — a leaked entity node would
+	// FK-block or duplicate-violate the next run, and a surviving place node from a
+	// `within` edge would FK-block the sweep — and every import-candidate row.
+	run := func() (synthetic.ProfileResult, []repository.AssertionSummary, []repository.EntityNameSummary, []repository.ExternalContactSummary) {
 		h, teardown, err := synthetic.NewHarnessWithDBForNamespaceAt(ctx, database, params.Namespace, params.Seed, anchor)
 		require.NoError(t, err)
 		res, err := synthetic.RunProfile(ctx, h, params)
@@ -562,12 +598,29 @@ func TestSyntheticProfile_ProdShapedDeterministic(t *testing.T) {
 		require.NoError(t, err)
 		entFP, err := support.ListEntityNamesByNodePrefix(ctx, prefix)
 		require.NoError(t, err)
+		// Import-producer fingerprint: the ns-prefixed external_contact source_ids
+		// (gcontacts/gmail_correspondence/anarlog_humans + the existing icloud/gcal
+		// candidates). The telegram discovery candidate keys on the bare peer id (not
+		// the prefix), so it is excluded here; its determinism rides the deterministic
+		// peer band + the run-to-run ProfileResult count equality.
+		extFP, err := support.ListExternalContactSourceIDsByPrefix(ctx, prefix)
+		require.NoError(t, err)
 		require.NoError(t, teardown(context.Background()))
 		// Teardown correctness: the entity nodes (org/topic/tag pool + place nodes)
 		// are swept, so the namespace is clean for the next run.
 		remaining, err := support.ListEntityNamesByNodePrefix(ctx, prefix)
 		require.NoError(t, err)
 		require.Empty(t, remaining, "entity nodes (pool + place) swept by teardown")
+		// Teardown correctness: the import-candidate external_contact rows are swept —
+		// the ns-prefixed ones (gcontacts/gmail_correspondence/anarlog/icloud/gcal) by
+		// the source_id-prefix sweep, the telegram discovery candidate (bare peer id) by
+		// the telegram-peer sweep — so none remain for the next run.
+		extRemaining, err := support.ListExternalContactSourceIDsByPrefix(ctx, prefix)
+		require.NoError(t, err)
+		require.Empty(t, extRemaining, "ns-prefixed external_contact candidates swept by teardown")
+		tgDiscoveryRemaining, err := support.CountUnmatchedTelegramDiscoveryInBand(ctx, h.Generator().PeerBandStart(), h.Generator().PeerBandEnd())
+		require.NoError(t, err)
+		require.Zero(t, tgDiscoveryRemaining, "telegram discovery candidate swept by teardown")
 		// Teardown correctness: the relationship_signal rows (FK→node, NO ACTION) are
 		// swept BEFORE the node deletes, so none remain for the seeded subject nodes —
 		// a leaked signal would FK-block the next run's person-node delete.
@@ -582,17 +635,19 @@ func TestSyntheticProfile_ProdShapedDeterministic(t *testing.T) {
 		contactsRemaining, err := h.ContactsRemaining(ctx)
 		require.NoError(t, err)
 		require.Zero(t, contactsRemaining, "all seeded contacts (incl. merge/soft-delete) swept by teardown")
-		return res, fp, entFP
+		return res, fp, entFP, extFP
 	}
 
-	res1, fp1, ent1 := run()
-	res2, fp2, ent2 := run()
+	res1, fp1, ent1, ext1 := run()
+	res2, fp2, ent2, ext2 := run()
 
 	require.Equal(t, res1, res2, "prod-shaped ProfileResult must be deterministic across runs")
 	require.NotEmpty(t, fp1, "the seed must produce assertions to fingerprint")
 	require.Equal(t, fp1, fp2, "assertion (value_text, value_date, value_bool) fingerprint must be deterministic across runs")
 	require.NotEmpty(t, ent1, "the seed must produce entity nodes to fingerprint")
 	require.Equal(t, ent1, ent2, "entity (subtype, normalized_name) fingerprint must be deterministic across runs")
+	require.NotEmpty(t, ext1, "the seed must produce import-candidate external_contact rows to fingerprint")
+	require.Equal(t, ext1, ext2, "import-candidate (source, source_id) fingerprint must be deterministic across runs")
 
 	// Ordering guard for the "seed gen.X() LAST" rule. The run-to-run
 	// comparison above catches NON-deterministic drift but NOT a DETERMINISTIC


### PR DESCRIPTION
## What

PR8 (final PR) of the prod-shaped synthetic-seed enrichment. Seeds unmatched import candidates for every Imports subtab so a staging environment's Imports queue has data, via D9's two mechanisms (the ingest registry only allows `icloud_contacts`/`anarlog_humans`):

- `anarlog_humans` — `MacContactForSource(source)` factory variant → existing `ReplayMacContacts` (ingest-allowed path).
- `gcontacts` + `gmail_correspondence` — `Harness.SeedExternalContactCandidate` → production `ExternalContactRepository.Upsert` (the same write path the Google sync providers use; not ingest-allowed). Upsert hardcodes `match_status='unmatched'` → unmatched candidates only.
- telegram-discovery — 3× `ReplayTelegramGroupMessages` crossing the `discoveryMinMsgs=3` threshold.
- Knob `ImportCandidatesPerSource` (dev 1 / prod-shaped 4 / default 0), 4 `ProfileResult` counters, seeded LAST in `runCatalogProfile`.

## Tests

Coverage check asserts a namespace-scoped unmatched candidate per subtab (gcontacts, gmail_correspondence, anarlog_humans, telegram-discovery); determinism fingerprint extended to import-candidate source_ids + teardown asserted clean (the anarlog source_id is the bare entity id, so the existing source_id-prefix sweep + the telegram-peer sweep reclaim everything). All timestamps via `accelerated.GetCurrentTime()`; candidate writes go through the production repo (no raw SQL); new `gen.X()` seeded LAST.

## Review

- Local Codex (xhigh): PASS — P0=0 P1=0, 2 non-blocking P2 (test-strengthening, tracked).
- `/review-head`: PASS — P0=0 P1=0, 2 P2 + 2 P3, all non-blocking and tracked. R6 mirror confirmed faithful; D9 + D5 teardown verified; full integration suite green.

Closes the seed-enrichment effort (items 1–13).