### PR TITLE
feat(staging): auto-reseed staging when the synthetic seed surface changes

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -123,6 +123,77 @@ jobs:
       cancel-in-progress: false    # never cancel a deploy mid-migrate/rollback
     permissions:
       contents: read
+    # Auto-reseed staging when (and only when) the seed surface changed, all as
+    # ordered steps in THIS single serialized job (no separate decision job -> no
+    # cross-job needs: coupling that could block the deploy). Step ORDER is
+    # load-bearing and locked by a grep-guard line-number assertion in
+    # scripts/deploy-staging.test.sh:
+    #   capture (host-pinned base, BEFORE the swap) -> deploy -> checkout
+    #   (post-deploy, continue-on-error) -> decide -> reseed -> breadcrumb/nudges.
+    # The deploy depends ONLY on gate.outputs.sha + the host: capture + deploy run
+    # BEFORE any checkout, so a checkout/decision flake can cost only the reseed
+    # (degrades to no-reseed + a nudge), NEVER the already-completed deploy. Tenant
+    # identity + reseed flags are pinned in the root-owned /usr/local/sbin wrappers
+    # (sudo resets the env; nothing is passed from here). The diff base is the live
+    # backend unit's pinned 40-hex Image= git sha; a failed/skipped reseed advances
+    # it, so the next deploy does NOT auto-retry — recover with `make staging-reset`
+    # (also the manual escape hatch to force a reseed regardless of paths).
     steps:
+      - name: Capture live staging SHA (host-pinned reseed base, before the swap)
+        run: |
+          prev_sha=$(sudo /usr/local/sbin/staging-deployed-sha.sh || true)
+          echo "prev_sha=${prev_sha}" >> "$GITHUB_ENV"
+
       - name: Deploy
         run: sudo /usr/local/sbin/deploy-staging.sh "${{ needs.gate.outputs.sha }}"
+
+      - name: Checkout (post-deploy; for the reseed decision only)
+        uses: actions/checkout@v4
+        continue-on-error: true
+        with:
+          ref: ${{ needs.gate.outputs.sha }}
+          fetch-depth: 0
+
+      - name: Decide reseed (seed/migration diff vs the live base)
+        run: |
+          if [ -x scripts/ci/staging-reseed-decision.sh ]; then
+            scripts/ci/staging-reseed-decision.sh "$prev_sha" "${{ needs.gate.outputs.sha }}"
+          else
+            echo "reseed-decision: script missing (checkout failed?); defaulting to no-reseed" >&2
+            { echo "seed_changed=false"; echo "migrations_changed=false"; echo "base_known=false"; } >> "$GITHUB_ENV"
+          fi
+
+      - name: Auto-reseed staging (seed surface changed)
+        if: ${{ env.seed_changed == 'true' }}
+        run: |
+          sudo /usr/local/sbin/staging-reseed.sh 2>&1 | tee "$RUNNER_TEMP/reseed.out"
+          exit "${PIPESTATUS[0]}"
+
+      - name: Note OAuth-skip (sync account connected -> reseed skipped)
+        if: ${{ always() && env.seed_changed == 'true' }}
+        run: |
+          if [ -f "$RUNNER_TEMP/reseed.out" ] && grep -q 'skipping auto-reseed' "$RUNNER_TEMP/reseed.out"; then
+            {
+              echo "### Staging auto-reseed SKIPPED (sync account connected)"
+              echo ""
+              echo "A sync account is connected to staging (\`oauth_credential\` non-empty), so the auto-reseed was skipped and staging kept its existing seed. The live seed may now be stale — disconnect the account and run \`make staging-reset\` to refresh."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Nudge — migrations changed, seed did not
+        if: ${{ env.migrations_changed == 'true' && env.seed_changed != 'true' }}
+        run: |
+          {
+            echo "### Staging: schema changed, seed code did not"
+            echo ""
+            echo "Migrations changed but the seed surface (\`backend/internal/synthetic/**\`) did not, so staging kept its accumulated world (migrations transform it in place; an auto-wipe would rob us of the migration canary). Run \`make staging-reset\` to exercise the new model with fresh prod-shaped seed data."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Nudge — reseed base unknown (no auto-reseed attempted)
+        if: ${{ env.base_known == 'false' }}
+        run: |
+          {
+            echo "### Staging: reseed base could not be determined"
+            echo ""
+            echo "The live staging image was not pinned to a 40-hex git sha (first deploy / digest pin / unreadable), so the seed-change diff base was unknown and NO auto-reseed was attempted. If the seed surface changed, run \`make staging-reset\` manually."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -148,6 +148,7 @@ jobs:
         run: sudo /usr/local/sbin/deploy-staging.sh "${{ needs.gate.outputs.sha }}"
 
       - name: Checkout (post-deploy; for the reseed decision only)
+        id: checkout
         uses: actions/checkout@v4
         continue-on-error: true
         with:
@@ -155,11 +156,20 @@ jobs:
           fetch-depth: 0
 
       - name: Decide reseed (seed/migration diff vs the live base)
+        env:
+          CHECKOUT_OUTCOME: ${{ steps.checkout.outcome }}
         run: |
-          if [ -x scripts/ci/staging-reseed-decision.sh ]; then
+          # Fail-closed on a non-success checkout, NOT merely a missing script: a
+          # failed continue-on-error checkout on a persistent self-hosted runner can
+          # leave a STALE older checkout in the workspace (the script + path-filters.yml
+          # are still present, just stale), so script-existence alone would decide from
+          # stale contents. Only a CLEAN checkout (outcome == success) AND the script
+          # present runs the real decision; anything else degrades to no-reseed
+          # (persistence wins on any uncertainty after the already-completed deploy).
+          if [ "$CHECKOUT_OUTCOME" = "success" ] && [ -x scripts/ci/staging-reseed-decision.sh ]; then
             scripts/ci/staging-reseed-decision.sh "$prev_sha" "${{ needs.gate.outputs.sha }}"
           else
-            echo "reseed-decision: script missing (checkout failed?); defaulting to no-reseed" >&2
+            echo "reseed-decision: checkout outcome='$CHECKOUT_OUTCOME' or script missing; defaulting to no-reseed (fail-closed)" >&2
             { echo "seed_changed=false"; echo "migrations_changed=false"; echo "base_known=false"; } >> "$GITHUB_ENV"
           fi
 

--- a/Makefile
+++ b/Makefile
@@ -517,6 +517,7 @@ test-deploy-scripts:
 	@bash scripts/deploy-staging.test.sh
 	@bash scripts/staging-reset.test.sh
 	@bash scripts/ci/staging-reseed-decision.test.sh
+	@bash scripts/staging-deployed-sha.test.sh
 	@bash scripts/reconcile-mac-daemon.test.sh
 	@bash scripts/setup-mac-deploy.test.sh
 	@bash scripts/trigger-mac-deploy.test.sh

--- a/Makefile
+++ b/Makefile
@@ -518,6 +518,7 @@ test-deploy-scripts:
 	@bash scripts/staging-reset.test.sh
 	@bash scripts/ci/staging-reseed-decision.test.sh
 	@bash scripts/staging-deployed-sha.test.sh
+	@bash scripts/staging-reseed.test.sh
 	@bash scripts/reconcile-mac-daemon.test.sh
 	@bash scripts/setup-mac-deploy.test.sh
 	@bash scripts/trigger-mac-deploy.test.sh

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ help:
 	@echo "  dev-native   - Start dev servers with native PostgreSQL (no Docker)"
 	@echo "  worktree-env - Symlink the main checkout's gitignored env files into this worktree"
 	@echo "  worktree-deps - Install per-worktree frontend deps (node_modules) into this worktree"
-	@echo "  staging-reset - HARD reset + reseed STAGING with the prod-shaped synthetic world (fail-closed: refuses a production-alias/empty CRM_ENV)"
+	@echo "  staging-reset - HARD reset + reseed STAGING with the prod-shaped synthetic world — the manual force path / escape hatch (full wipe regardless of oauth; deploy-staging.yml auto-reseeds on seed-surface changes). Fail-closed: refuses a production-alias/empty CRM_ENV"
 	@echo "  build       - Build both frontend and backend"
 	@echo "  crm-admin   - Build the operator-only admin CLI (backend/crm-admin)"
 	@echo "  mac-daemon  - Build the macOS daemon app bundle (optionally set CRM_MAC_CODESIGN_IDENTITY)"
@@ -273,7 +273,7 @@ dev-api-restart:
 	@sleep 1
 	@make dev-api-start
 
-staging-reset: ## HARD reset + reseed STAGING with the prod-shaped synthetic world (fail-closed production refuse; STAGING-only)
+staging-reset: ## HARD reset + reseed STAGING — manual force / escape hatch (full wipe regardless of oauth; deploy-staging.yml auto-reseeds on seed-surface changes; fail-closed production refuse; STAGING-only)
 	@bash scripts/staging-reset.sh   # ssh STAGING_HOST -> refuse if CRM_ENV is a production alias or empty -> stop backend -> ephemeral crm-admin --reset-and-seed --profile prod-shaped --yes (deployed image) -> start backend
 
 # Native PostgreSQL (for containerized development without Docker-in-Docker)

--- a/Makefile
+++ b/Makefile
@@ -516,6 +516,7 @@ test-deploy-scripts:
 	@bash scripts/restore-db.test.sh
 	@bash scripts/deploy-staging.test.sh
 	@bash scripts/staging-reset.test.sh
+	@bash scripts/ci/staging-reseed-decision.test.sh
 	@bash scripts/reconcile-mac-daemon.test.sh
 	@bash scripts/setup-mac-deploy.test.sh
 	@bash scripts/trigger-mac-deploy.test.sh

--- a/path-filters.yml
+++ b/path-filters.yml
@@ -13,6 +13,10 @@
 #   mac_daemon  → CI mac-daemon-tests. NOTE: the local Swift gate (check_swift) does NOT
 #                 use this group; it uses a stricter literal 'mac-daemon/' prefix test, so a
 #                 ci.yml-only push runs mac-daemon-tests in CI but NOT swift test locally.
+#   seed        → deploy-staging.yml reseed decision (scripts/ci/staging-reseed-decision.sh,
+#                 via file_in_group). ORTHOGONAL: synthetic stays in `backend` too, so this
+#                 group changes NO CI/pre-push test selection — it only flags the seed surface
+#                 the staging auto-reseed diffs against. No CI/pre-push consumer reads it.
 
 backend:
   - 'backend/**'
@@ -29,3 +33,5 @@ frontend:
 mac_daemon:
   - 'mac-daemon/**'
   - '.github/workflows/ci.yml'
+seed:
+  - 'backend/internal/synthetic/**'

--- a/scripts/ci/path-filters-parity-guard.sh
+++ b/scripts/ci/path-filters-parity-guard.sh
@@ -9,7 +9,7 @@ grep -q 'filters: ./path-filters.yml' .github/workflows/ci.yml \
   || { echo "FAIL: ci.yml changes job must use filters: ./path-filters.yml"; exit 1; }
 grep -qE '^\s*filters:\s*\|' .github/workflows/ci.yml \
   && { echo "FAIL: ci.yml reintroduced an inline filters block"; exit 1; } || true
-for g in backend frontend mac_daemon; do
+for g in backend frontend mac_daemon seed; do
   grep -qE "^${g}:" path-filters.yml || { echo "FAIL: path-filters.yml missing group $g"; exit 1; }
 done
 echo "OK: path-filter parity"

--- a/scripts/ci/staging-reseed-decision.sh
+++ b/scripts/ci/staging-reseed-decision.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# staging-reseed-decision.sh <BASE> <HEAD>
+#
+# Decides whether the develop->staging auto-reseed should fire, by diffing the
+# git tree currently LIVE on staging (BASE — the host-pinned 40-hex Image= sha,
+# read by staging-deployed-sha.sh BEFORE the deploy swaps it) against the SHA
+# being deployed (HEAD). Writes three flags to $GITHUB_ENV (and echoes them for
+# local runs / tests):
+#   seed_changed        any changed file is in the `seed` path-filters group
+#                       (backend/internal/synthetic/**) -> reseed candidate.
+#   migrations_changed  any changed file is under backend/migrations/ -> nudge only
+#                       (migrations transform the accumulated world; never auto-wipe).
+#   base_known          true iff BASE was a resolvable commit and the diff ran.
+#
+# TWO-DOT `git diff BASE HEAD` (direct tree-vs-tree), NOT three-dot (BASE...HEAD,
+# merge-base): the comparison is live-tree vs target-tree, so a rebase/force-push
+# or non-linear history must not shift the base to a merge-base.
+#
+# FAULT-TOLERANT BY CONTRACT: this runs as a post-deploy step in deploy-staging.yml
+# AFTER the code+migrate deploy already succeeded, so it must NEVER fail the job.
+# Any ambiguity — empty/unresolvable BASE (digest pin / first-ever deploy /
+# unreadable), BASE absent from local history (force-push), a missing source file,
+# or any git error — degrades to seed_changed=false + base_known=false and exit 0
+# (conservative: never auto-wipe on uncertainty; persistence wins). The workflow
+# turns base_known=false into a "could not determine base" nudge.
+#
+# The `seed` group is matched via file_in_group sourced from the pre-push hook —
+# the SAME matcher CI/pre-push use, so the seed surface stays single-sourced in
+# path-filters.yml with no second hardcoded synthetic prefix. file_in_group reads
+# the global FILTERS_FILE, which we re-point at the real (absolute) path-filters.yml
+# so the seed definition comes from THIS checkout while `git diff` runs in the CWD
+# (the deploy checkout in prod; a throwaway fixture repo in the tests).
+
+set -uo pipefail   # NO -e: a failed diff/source must never exit non-zero.
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." 2>/dev/null && pwd)"
+
+emit() {
+  # emit <key> <value>: stdout for humans/tests + $GITHUB_ENV for the workflow.
+  printf '%s=%s\n' "$1" "$2"
+  if [ -n "${GITHUB_ENV:-}" ]; then
+    printf '%s=%s\n' "$1" "$2" >> "$GITHUB_ENV"
+  fi
+}
+
+# Conservative degrade: no reseed, base unknown. Every uncertainty path ends here.
+emit_unknown() {
+  emit seed_changed false
+  emit migrations_changed false
+  emit base_known false
+  exit 0
+}
+
+BASE="${1:-}"
+HEAD="${2:-}"
+
+# Need both endpoints and a resolvable repo root.
+[ -n "$BASE" ] || emit_unknown
+[ -n "$HEAD" ] || emit_unknown
+[ -n "$REPO_ROOT" ] || emit_unknown
+
+# file_in_group lives in the pre-push hook; the source-guard keeps the hook body
+# from running. Source by absolute path so this is CWD-independent, then re-point
+# FILTERS_FILE at the real path-filters.yml (the matcher reads that global).
+# shellcheck source=/dev/null
+source "$REPO_ROOT/scripts/hooks/pre-push" 2>/dev/null || emit_unknown
+declare -f file_in_group >/dev/null 2>&1 || emit_unknown
+FILTERS_FILE="$REPO_ROOT/path-filters.yml"
+[ -f "$FILTERS_FILE" ] || emit_unknown
+
+# Both endpoints must be real commits in the CWD repo (force-push / first-deploy /
+# digest-pin base -> not resolvable -> degrade).
+git cat-file -e "${BASE}^{commit}" 2>/dev/null || emit_unknown
+git cat-file -e "${HEAD}^{commit}" 2>/dev/null || emit_unknown
+
+# TWO-DOT diff: live tree (BASE) vs target tree (HEAD).
+changed="$(git diff --name-only "$BASE" "$HEAD" 2>/dev/null)" || emit_unknown
+
+seed_changed=false
+migrations_changed=false
+while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  if file_in_group "$f" seed; then
+    seed_changed=true
+  fi
+  case "$f" in
+    backend/migrations/*) migrations_changed=true ;;
+  esac
+done <<< "$changed"
+
+emit seed_changed "$seed_changed"
+emit migrations_changed "$migrations_changed"
+emit base_known true
+exit 0

--- a/scripts/ci/staging-reseed-decision.sh
+++ b/scripts/ci/staging-reseed-decision.sh
@@ -6,8 +6,12 @@
 # read by staging-deployed-sha.sh BEFORE the deploy swaps it) against the SHA
 # being deployed (HEAD). Writes three flags to $GITHUB_ENV (and echoes them for
 # local runs / tests):
-#   seed_changed        any changed file is in the `seed` path-filters group
-#                       (backend/internal/synthetic/**) -> reseed candidate.
+#   seed_changed        a changed file is in the `seed` path-filters group
+#                       (backend/internal/synthetic/**) AND is a RUNTIME synthetic
+#                       file -> reseed candidate. Test-only changes (`*_test.go`,
+#                       `**/testdata/**`) are NOT the built seed surface and do not
+#                       trigger a reseed (the test exclusion lives below, not in the
+#                       dual-purpose path-group which still feeds test selection).
 #   migrations_changed  any changed file is under backend/migrations/ -> nudge only
 #                       (migrations transform the accumulated world; never auto-wipe).
 #   base_known          true iff BASE was a resolvable commit and the diff ran.
@@ -80,8 +84,18 @@ seed_changed=false
 migrations_changed=false
 while IFS= read -r f; do
   [ -n "$f" ] || continue
+  # A seed-group match counts as a seed-surface change ONLY for a RUNTIME synthetic
+  # file. The `seed` path-group (backend/internal/synthetic/**) is dual-purpose — it
+  # also drives CI/pre-push test SELECTION, which legitimately includes `_test.go` +
+  # testdata — but those are NOT part of the BUILT seed surface, so a test-only
+  # change must not trigger the destructive staging reseed. (Test exclusion lives
+  # here, not in path-filters.yml, so test selection keeps seeing the test files.)
   if file_in_group "$f" seed; then
-    seed_changed=true
+    case "$f" in
+      *_test.go)    ;;  # synthetic test file — not part of the built seed surface
+      */testdata/*) ;;  # synthetic testdata fixture — not part of the built seed surface
+      *) seed_changed=true ;;  # runtime synthetic file (profiles.go, factory/*.go, ...)
+    esac
   fi
   case "$f" in
     backend/migrations/*) migrations_changed=true ;;

--- a/scripts/ci/staging-reseed-decision.sh
+++ b/scripts/ci/staging-reseed-decision.sh
@@ -10,8 +10,9 @@
 #                       (backend/internal/synthetic/**) AND is a RUNTIME synthetic
 #                       file -> reseed candidate. Test-only changes (`*_test.go`,
 #                       `**/testdata/**`) are NOT the built seed surface and do not
-#                       trigger a reseed (the test exclusion lives below, not in the
-#                       dual-purpose path-group which still feeds test selection).
+#                       trigger a reseed. The exclusion lives below, not in
+#                       path-filters.yml, which is LCD (flat globs, NO negation) and
+#                       cannot express "synthetic/** except tests".
 #   migrations_changed  any changed file is under backend/migrations/ -> nudge only
 #                       (migrations transform the accumulated world; never auto-wipe).
 #   base_known          true iff BASE was a resolvable commit and the diff ran.
@@ -85,11 +86,12 @@ migrations_changed=false
 while IFS= read -r f; do
   [ -n "$f" ] || continue
   # A seed-group match counts as a seed-surface change ONLY for a RUNTIME synthetic
-  # file. The `seed` path-group (backend/internal/synthetic/**) is dual-purpose — it
-  # also drives CI/pre-push test SELECTION, which legitimately includes `_test.go` +
-  # testdata — but those are NOT part of the BUILT seed surface, so a test-only
-  # change must not trigger the destructive staging reseed. (Test exclusion lives
-  # here, not in path-filters.yml, so test selection keeps seeing the test files.)
+  # file. `*_test.go` and `**/testdata/**` are inside the seed glob but are NOT the
+  # BUILT seed surface, so a test-only change must not fire the destructive staging
+  # reseed. The exclusion lives HERE, not in path-filters.yml, because that file is
+  # LCD (flat globs, NO negation) and cannot express "synthetic/** except tests". The
+  # `seed` group is reseed-only — orthogonal to CI/pre-push test selection (which
+  # runs off the `backend` group) — so excluding tests here can't affect selection.
   if file_in_group "$f" seed; then
     case "$f" in
       *_test.go)    ;;  # synthetic test file — not part of the built seed surface

--- a/scripts/ci/staging-reseed-decision.test.sh
+++ b/scripts/ci/staging-reseed-decision.test.sh
@@ -63,11 +63,32 @@ make_fixture() {
         git commit -q -m "unrelated change"
         C3="$(git rev-parse HEAD)"
 
-        printf '%s\n%s\n%s\n%s\n' "$C0" "$C1" "$C2" "$C3" > shas.txt
+        # Test-ONLY synthetic change (a *_test.go under synthetic/) — in the seed
+        # path-group but NOT the built seed surface, so it must NOT trigger a reseed.
+        echo "package synthetic" > backend/internal/synthetic/profiles_test.go
+        git add backend/internal/synthetic/profiles_test.go
+        git commit -q -m "synthetic test-only change"
+        C4="$(git rev-parse HEAD)"
+
+        # Synthetic testdata fixture — also not the built seed surface.
+        mkdir -p backend/internal/synthetic/testdata
+        echo "{}" > backend/internal/synthetic/testdata/seed.json
+        git add backend/internal/synthetic/testdata/seed.json
+        git commit -q -m "synthetic testdata change"
+        C5="$(git rev-parse HEAD)"
+
+        # RUNTIME synthetic change (no test file) — the built seed surface.
+        mkdir -p backend/internal/synthetic/factory
+        echo "package factory" > backend/internal/synthetic/factory/foo.go
+        git add backend/internal/synthetic/factory/foo.go
+        git commit -q -m "synthetic runtime change"
+        C6="$(git rev-parse HEAD)"
+
+        printf '%s\n%s\n%s\n%s\n%s\n%s\n%s\n' "$C0" "$C1" "$C2" "$C3" "$C4" "$C5" "$C6" > shas.txt
     )
     # Portable read (no bash-4 mapfile): the commit SHAs are set in the subshell,
     # so read them back from the fixture file, one per line.
-    { read -r C0; read -r C1; read -r C2; read -r C3; } < "$FIXTURE/shas.txt"
+    { read -r C0; read -r C1; read -r C2; read -r C3; read -r C4; read -r C5; read -r C6; } < "$FIXTURE/shas.txt"
 }
 
 cleanup_fixture() { [ -n "${FIXTURE:-}" ] && rm -rf "$FIXTURE"; }
@@ -130,6 +151,52 @@ test_both_changed() {
     cleanup_fixture
 }
 
+test_test_only_synthetic_no_reseed() {
+    echo "test: test-only synthetic change (*_test.go) -> seed_changed=false (not the built seed surface)"
+    make_fixture
+    run_decision "$C3" "$C4"
+    if [ "$RC" -eq 0 ]; then ok; else fail "must exit 0, got $RC"; fi
+    assert_flag seed_changed false
+    assert_flag base_known true
+    cleanup_fixture
+}
+
+test_testdata_synthetic_no_reseed() {
+    echo "test: synthetic testdata change -> seed_changed=false"
+    make_fixture
+    run_decision "$C4" "$C5"
+    assert_flag seed_changed false
+    assert_flag base_known true
+    cleanup_fixture
+}
+
+test_test_and_testdata_only_no_reseed() {
+    echo "test: combined test+testdata-only range (no runtime) -> seed_changed=false"
+    make_fixture
+    run_decision "$C3" "$C5"
+    assert_flag seed_changed false
+    assert_flag base_known true
+    cleanup_fixture
+}
+
+test_runtime_synthetic_reseed() {
+    echo "test: runtime synthetic change (factory/foo.go) -> seed_changed=true"
+    make_fixture
+    run_decision "$C5" "$C6"
+    assert_flag seed_changed true
+    assert_flag base_known true
+    cleanup_fixture
+}
+
+test_mixed_runtime_and_test_reseed() {
+    echo "test: mixed range (test + testdata + runtime synthetic) -> seed_changed=true (runtime present)"
+    make_fixture
+    run_decision "$C3" "$C6"   # spans profiles_test.go + testdata/seed.json + factory/foo.go
+    assert_flag seed_changed true
+    assert_flag base_known true
+    cleanup_fixture
+}
+
 test_empty_base() {
     echo "test: empty BASE -> base_known=false, seed_changed=false, exit 0"
     make_fixture
@@ -157,6 +224,11 @@ main() {
     test_migration_only
     test_unrelated_only
     test_both_changed
+    test_test_only_synthetic_no_reseed
+    test_testdata_synthetic_no_reseed
+    test_test_and_testdata_only_no_reseed
+    test_runtime_synthetic_reseed
+    test_mixed_runtime_and_test_reseed
     test_empty_base
     test_base_not_in_history
 

--- a/scripts/ci/staging-reseed-decision.test.sh
+++ b/scripts/ci/staging-reseed-decision.test.sh
@@ -13,6 +13,15 @@
 
 set -uo pipefail
 
+# Sanitize hook-inherited git env BEFORE any git command. Git pre-push hooks export
+# GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE into the environment; without unsetting them,
+# the fixture's `git init`/`git add`/`git commit` below (and the decision script's
+# own `git cat-file`/`git diff`, run in the fixture CWD) operate against the hook's
+# repo instead of the throwaway fixture and fail with "fatal: this operation must be
+# run in a work tree". Unsetting restores cwd-based discovery so the fixture is
+# isolated. (Run directly the vars are absent, so this is a no-op outside the hook.)
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE
+
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 SCRIPT="$REPO_ROOT/scripts/ci/staging-reseed-decision.sh"
 ABSENT_SHA="0123456789abcdef0123456789abcdef01234567"  # 40-hex, not in the fixture

--- a/scripts/ci/staging-reseed-decision.test.sh
+++ b/scripts/ci/staging-reseed-decision.test.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# Tests for staging-reseed-decision.sh — the seed/migration two-dot-diff decision.
+#
+# Builds a throwaway git fixture repo (commits touching a synthetic file, a
+# migration file, and an unrelated file), runs the decision against various
+# BASE..HEAD ranges, and asserts the three flags (seed_changed / migrations_changed
+# / base_known) written to a per-fixture $GITHUB_ENV. The fixture diff runs in the
+# fixture CWD; the seed-group definition comes from the REAL path-filters.yml (the
+# script re-points FILTERS_FILE there), so no fixture copy of the filters is needed.
+#
+# The fixture sets a LOCAL git identity (Ubuntu CI may have no global one).
+# Portable: no network, no BSD-only flags.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/ci/staging-reseed-decision.sh"
+ABSENT_SHA="0123456789abcdef0123456789abcdef01234567"  # 40-hex, not in the fixture
+
+PASS=0
+FAIL=0
+fail() { echo "  FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+ok()   { PASS=$((PASS + 1)); }
+
+make_fixture() {
+    FIXTURE="$(mktemp -d)"
+    GHENV="$FIXTURE/ghenv"
+    (
+        cd "$FIXTURE" || exit 1
+        git init -q
+        git config user.email "ci@example.com"
+        git config user.name "CI"
+        git config commit.gpgsign false
+
+        echo "root" > README.md
+        git add README.md
+        git commit -q -m "root"
+        C0="$(git rev-parse HEAD)"
+
+        mkdir -p backend/internal/synthetic
+        echo "package synthetic" > backend/internal/synthetic/profiles.go
+        git add backend/internal/synthetic/profiles.go
+        git commit -q -m "seed change"
+        C1="$(git rev-parse HEAD)"
+
+        mkdir -p backend/migrations
+        echo "-- up" > backend/migrations/074_x.up.sql
+        git add backend/migrations/074_x.up.sql
+        git commit -q -m "migration change"
+        C2="$(git rev-parse HEAD)"
+
+        echo "changed" >> README.md
+        git add README.md
+        git commit -q -m "unrelated change"
+        C3="$(git rev-parse HEAD)"
+
+        printf '%s\n%s\n%s\n%s\n' "$C0" "$C1" "$C2" "$C3" > shas.txt
+    )
+    # Portable read (no bash-4 mapfile): the commit SHAs are set in the subshell,
+    # so read them back from the fixture file, one per line.
+    { read -r C0; read -r C1; read -r C2; read -r C3; } < "$FIXTURE/shas.txt"
+}
+
+cleanup_fixture() { [ -n "${FIXTURE:-}" ] && rm -rf "$FIXTURE"; }
+
+# run_decision <base> <head>: runs the script in the fixture CWD with an isolated
+# GITHUB_ENV (never the real CI one); sets RC + populates $GHENV.
+run_decision() {
+    : > "$GHENV"
+    ( cd "$FIXTURE" && GITHUB_ENV="$GHENV" bash "$SCRIPT" "$1" "$2" ) >/dev/null 2>&1
+    RC=$?
+}
+
+# assert_flag <key> <expected>: the GITHUB_ENV file must carry exactly key=expected.
+assert_flag() {
+    local key="$1" want="$2" got
+    got="$(grep -E "^${key}=" "$GHENV" | tail -1 | cut -d= -f2-)"
+    if [ "$got" = "$want" ]; then ok; else fail "$key: want '$want', got '$got'"; fi
+}
+
+# ===========================================================================
+test_seed_only() {
+    echo "test: seed-only range -> seed_changed=true, migrations_changed=false, base_known=true"
+    make_fixture
+    run_decision "$C0" "$C1"
+    if [ "$RC" -eq 0 ]; then ok; else fail "decision must exit 0, got $RC"; fi
+    assert_flag seed_changed true
+    assert_flag migrations_changed false
+    assert_flag base_known true
+    cleanup_fixture
+}
+
+test_migration_only() {
+    echo "test: migration-only range -> seed_changed=false, migrations_changed=true"
+    make_fixture
+    run_decision "$C1" "$C2"
+    if [ "$RC" -eq 0 ]; then ok; else fail "decision must exit 0, got $RC"; fi
+    assert_flag seed_changed false
+    assert_flag migrations_changed true
+    assert_flag base_known true
+    cleanup_fixture
+}
+
+test_unrelated_only() {
+    echo "test: unrelated-only range -> both false, base_known=true"
+    make_fixture
+    run_decision "$C2" "$C3"
+    assert_flag seed_changed false
+    assert_flag migrations_changed false
+    assert_flag base_known true
+    cleanup_fixture
+}
+
+test_both_changed() {
+    echo "test: range spanning both -> seed_changed=true AND migrations_changed=true"
+    make_fixture
+    run_decision "$C0" "$C2"
+    assert_flag seed_changed true
+    assert_flag migrations_changed true
+    assert_flag base_known true
+    cleanup_fixture
+}
+
+test_empty_base() {
+    echo "test: empty BASE -> base_known=false, seed_changed=false, exit 0"
+    make_fixture
+    run_decision "" "$C3"
+    if [ "$RC" -eq 0 ]; then ok; else fail "empty BASE must exit 0, got $RC"; fi
+    assert_flag base_known false
+    assert_flag seed_changed false
+    assert_flag migrations_changed false
+    cleanup_fixture
+}
+
+test_base_not_in_history() {
+    echo "test: BASE not in local history -> base_known=false, seed_changed=false, exit 0"
+    make_fixture
+    run_decision "$ABSENT_SHA" "$C3"
+    if [ "$RC" -eq 0 ]; then ok; else fail "absent BASE must exit 0, got $RC"; fi
+    assert_flag base_known false
+    assert_flag seed_changed false
+    cleanup_fixture
+}
+
+# ---------------------------------------------------------------------------
+main() {
+    test_seed_only
+    test_migration_only
+    test_unrelated_only
+    test_both_changed
+    test_empty_base
+    test_base_not_in_history
+
+    echo ""
+    echo "===================="
+    echo "PASS=$PASS FAIL=$FAIL"
+    echo "===================="
+    [ "$FAIL" -eq 0 ]
+}
+
+main "$@"

--- a/scripts/deploy-staging.test.sh
+++ b/scripts/deploy-staging.test.sh
@@ -186,6 +186,74 @@ test_workflow_ci_gate_qualifier() {
     if wf_has "branch=develop"; then ok; else fail "CI gate query must include branch=develop"; fi
 }
 
+# ===========================================================================
+# Auto-reseed wiring (D2 + D5): ordered deploy-job steps over deploy-staging.yml
+# ===========================================================================
+
+test_workflow_reseed_steps_exist() {
+    echo "test: the capture/checkout/decision/reseed/breadcrumb/nudge steps all exist"
+    if wf_has "staging-deployed-sha.sh"; then ok; else fail "missing the host-pinned base capture step"; fi
+    if wf_has "uses: actions/checkout@v4"; then ok; else fail "missing the post-deploy checkout step"; fi
+    if wf_has "staging-reseed-decision.sh"; then ok; else fail "missing the reseed-decision step"; fi
+    if wf_has "/usr/local/sbin/staging-reseed.sh"; then ok; else fail "missing the reseed step"; fi
+    if wf_has "skipping auto-reseed"; then ok; else fail "missing the OAuth-skip breadcrumb (greps the stable marker)"; fi
+    if wf_has "GITHUB_STEP_SUMMARY"; then ok; else fail "nudges must write to GITHUB_STEP_SUMMARY"; fi
+    if wf_has "make staging-reset"; then ok; else fail "summaries must point at the make staging-reset escape hatch"; fi
+}
+
+test_workflow_reseed_step_order() {
+    echo "test: load-bearing step ORDER — capture < deploy < checkout < decision < reseed"
+    local cap dep chk dec res
+    cap=$(grep -n 'staging-deployed-sha.sh'            "$WORKFLOW" | head -1 | cut -d: -f1)
+    dep=$(grep -n '/usr/local/sbin/deploy-staging.sh'  "$WORKFLOW" | head -1 | cut -d: -f1)
+    chk=$(grep -n 'uses: actions/checkout@v4'          "$WORKFLOW" | head -1 | cut -d: -f1)
+    dec=$(grep -n 'staging-reseed-decision.sh'         "$WORKFLOW" | head -1 | cut -d: -f1)
+    res=$(grep -n '/usr/local/sbin/staging-reseed.sh'  "$WORKFLOW" | head -1 | cut -d: -f1)
+    if [ -n "$cap" ] && [ -n "$dep" ] && [ -n "$chk" ] && [ -n "$dec" ] && [ -n "$res" ]; then ok
+    else fail "a step marker is missing (cap=$cap dep=$dep chk=$chk dec=$dec res=$res)"; fi
+    if [ -n "$cap" ] && [ -n "$dep" ] && [ "$cap" -lt "$dep" ]; then ok; else fail "capture must precede deploy (cap=$cap dep=$dep)"; fi
+    if [ -n "$dep" ] && [ -n "$chk" ] && [ "$dep" -lt "$chk" ]; then ok; else fail "deploy must precede checkout (dep=$dep chk=$chk)"; fi
+    if [ -n "$chk" ] && [ -n "$dec" ] && [ "$chk" -lt "$dec" ]; then ok; else fail "checkout must precede decision (chk=$chk dec=$dec)"; fi
+    if [ -n "$dec" ] && [ -n "$res" ] && [ "$dec" -lt "$res" ]; then ok; else fail "decision must precede reseed (dec=$dec res=$res)"; fi
+}
+
+test_workflow_reseed_step_target_and_condition() {
+    echo "test: reseed gated on seed_changed, calls the wrapper (never reset/artifact directly), PIPESTATUS"
+    if wf_has "env.seed_changed == 'true'"; then ok; else fail "reseed must be gated on env.seed_changed == 'true'"; fi
+    if wf_has "PIPESTATUS"; then ok; else fail "reseed must propagate PIPESTATUS through the tee"; fi
+    # The workflow only ever calls the root-owned wrappers, never the reset/artifact
+    # scripts directly. ('make staging-reset' has no '.sh', so it does not match.)
+    if wf_lacks "staging-reset.sh"; then ok; else fail "workflow must NOT call staging-reset.sh directly (use the wrapper)"; fi
+    if wf_lacks "deploy-artifact.sh"; then ok; else fail "workflow must NOT call deploy-artifact.sh directly"; fi
+}
+
+test_workflow_checkout_resilient() {
+    echo "test: post-deploy checkout is resilient (fetch-depth: 0 + continue-on-error)"
+    if wf_has "fetch-depth: 0"; then ok; else fail "checkout must use fetch-depth: 0 (base + HEAD present for git diff)"; fi
+    if wf_has "continue-on-error: true"; then ok; else fail "checkout must be continue-on-error: true (a flake costs only the reseed)"; fi
+}
+
+test_workflow_decision_inline_fallback() {
+    echo "test: decision step has the inline missing-script fallback (checkout-flake safe)"
+    if wf_has "[ -x scripts/ci/staging-reseed-decision.sh ]"; then ok; else fail "decision must guard on the script being present (else a flaked checkout 127-reds the job)"; fi
+    if wf_has "seed_changed=false"; then ok; else fail "fallback must default seed_changed=false"; fi
+    if wf_has "base_known=false"; then ok; else fail "fallback must default base_known=false"; fi
+}
+
+test_workflow_single_job_no_decision_job_no_deployments() {
+    echo "test: single deploy job (needs: gate only); no reseed_decision job; no deployments permission"
+    if wf_has "needs: gate"; then ok; else fail "deploy job must keep needs: gate"; fi
+    if wf_lacks "reseed_decision"; then ok; else fail "must NOT introduce a separate reseed_decision job"; fi
+    if wf_lacks "deployments:"; then ok; else fail "must NOT add a deployments: permission"; fi
+}
+
+test_workflow_nudge_conditions() {
+    echo "test: migration-nudge + no-base-nudge conditions are exact (no double-nudge)"
+    if wf_has "env.migrations_changed == 'true' && env.seed_changed != 'true'"; then ok
+    else fail "migration nudge must fire only when migrations changed AND seed did not"; fi
+    if wf_has "env.base_known == 'false'"; then ok; else fail "no-base nudge must fire on base_known == 'false'"; fi
+}
+
 # ---------------------------------------------------------------------------
 main() {
     test_wrapper_forces_tenant_and_forwards_sha
@@ -199,6 +267,13 @@ main() {
     test_workflow_no_trusted_knob
     test_workflow_three_way_gate_and_job_split
     test_workflow_ci_gate_qualifier
+    test_workflow_reseed_steps_exist
+    test_workflow_reseed_step_order
+    test_workflow_reseed_step_target_and_condition
+    test_workflow_checkout_resilient
+    test_workflow_decision_inline_fallback
+    test_workflow_single_job_no_decision_job_no_deployments
+    test_workflow_nudge_conditions
 
     echo ""
     echo "===================="

--- a/scripts/deploy-staging.test.sh
+++ b/scripts/deploy-staging.test.sh
@@ -234,9 +234,18 @@ test_workflow_checkout_resilient() {
 }
 
 test_workflow_decision_inline_fallback() {
-    echo "test: decision step has the inline missing-script fallback (checkout-flake safe)"
-    if wf_has "[ -x scripts/ci/staging-reseed-decision.sh ]"; then ok; else fail "decision must guard on the script being present (else a flaked checkout 127-reds the job)"; fi
+    echo "test: decision degrades to no-reseed on a non-success checkout OR a missing script (stale-checkout + flake safe)"
+    # Gate on the checkout OUTCOME, not just script presence: a failed
+    # continue-on-error checkout on a persistent self-hosted runner can leave a
+    # STALE older checkout whose script still exists — so existence alone would
+    # decide from stale path-filters.yml/script contents.
+    if wf_has "id: checkout"; then ok; else fail "checkout step must have an id for outcome gating"; fi
+    if wf_has "steps.checkout.outcome"; then ok; else fail "decision must gate on steps.checkout.outcome"; fi
+    if wf_has "CHECKOUT_OUTCOME" && grep -qF 'CHECKOUT_OUTCOME" = "success"' "$WORKFLOW"; then ok
+    else fail "decision must run the real script only when CHECKOUT_OUTCOME == success"; fi
+    if wf_has "[ -x scripts/ci/staging-reseed-decision.sh ]"; then ok; else fail "decision must also guard on the script being present (else a flaked checkout 127-reds the job)"; fi
     if wf_has "seed_changed=false"; then ok; else fail "fallback must default seed_changed=false"; fi
+    if wf_has "migrations_changed=false"; then ok; else fail "fallback must default migrations_changed=false"; fi
     if wf_has "base_known=false"; then ok; else fail "fallback must default base_known=false"; fi
 }
 

--- a/scripts/hooks/test/test-pre-push-filters.sh
+++ b/scripts/hooks/test/test-pre-push-filters.sh
@@ -68,6 +68,18 @@ assert_not_in_group "frontendx/y.ts" frontend
 # Self-gating regression guard: the filter file routes to validation.
 assert_in_group     "path-filters.yml" backend
 
+# --- seed group: the staging auto-reseed surface (orthogonal to test selection) ---
+# Synthetic toolkit + profiles ARE the seed surface.
+assert_in_group     "backend/internal/synthetic/profiles.go" seed
+assert_in_group     "backend/internal/synthetic/factory/foo.go" seed
+# Orthogonality: a synthetic file is ALSO in backend, so the seed group changes no
+# Go/frontend test selection (it is a separate classification consumed only by the
+# reseed decision).
+assert_in_group     "backend/internal/synthetic/profiles.go" backend
+# Non-seed backend code and migrations are NOT in the seed group.
+assert_not_in_group "backend/internal/api/handlers/contact.go" seed
+assert_not_in_group "backend/migrations/074_x.up.sql" seed
+
 # --- any_file_in_groups: the Go/frontend gate's decision boundary ---
 # Daemon-only push does NOT run Go suite (headline invariant).
 assert_false "any_file_in_groups daemon-only -> Go suite NOT run" \

--- a/scripts/staging-deployed-sha.sh
+++ b/scripts/staging-deployed-sha.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# staging-deployed-sha.sh — print the git SHA currently LIVE on the staging tenant.
+#
+# Reads the staging backend Quadlet unit's pinned Image= line and prints its tag
+# IFF that tag is a 40-hex git sha — the steady-state pin written by
+# deploy-artifact.sh's post_migrate_swap (BACKEND_REPO:<40-hex-sha>). Anything
+# else prints NOTHING and exits non-zero, so the caller degrades to "base unknown"
+# (no auto-reseed):
+#   - a @sha256:<digest> rollback anchor (64-hex after the last ':', not 40),
+#   - the mutable :latest,
+#   - an unreadable / missing unit.
+# The tag is split on the LAST ':' (`${image##*:}`) — identical to read_image_tag /
+# rollback_ref_for in deploy-artifact.sh — so a registry host:port never confuses it.
+#
+# Root-owned wrapper invoked by deploy-staging.yml's deploy job via a single
+# args-free sudoers entry (`sudo /usr/local/sbin/staging-deployed-sha.sh`), read
+# BEFORE the deploy swaps the image (the host-pinned diff base). The tenant
+# identity is hardcoded here (not workflow-controllable), mirroring
+# staging-reseed.sh / deploy-staging.sh; sudo resets the environment, so the
+# sudoers entry must NOT use SETENV/env_keep and the workflow must NEVER use
+# sudo -E.
+set -uo pipefail
+
+CRM_USER="${CRM_USER:-staging}"
+CRM_HOME="${CRM_HOME:-/var/lib/staging}"
+BACKEND_UNIT="${STAGING_BACKEND_UNIT:-$CRM_HOME/.config/containers/systemd/personalcrm-backend.container}"
+
+# Read the pinned Image= line as the tenant (mirrors staging-reset.sh read_image_ref).
+image="$(sudo -u "$CRM_USER" sed -n 's/^Image=//p' "$BACKEND_UNIT" 2>/dev/null | head -1)"
+tag="${image##*:}"
+
+if [[ "$tag" =~ ^[0-9a-f]{40}$ ]]; then
+    printf '%s\n' "$tag"
+    exit 0
+fi
+exit 1

--- a/scripts/staging-deployed-sha.sh
+++ b/scripts/staging-deployed-sha.sh
@@ -15,15 +15,17 @@
 # Root-owned wrapper invoked by deploy-staging.yml's deploy job via a single
 # args-free sudoers entry (`sudo /usr/local/sbin/staging-deployed-sha.sh`), read
 # BEFORE the deploy swaps the image (the host-pinned diff base). The tenant
-# identity is hardcoded here (not workflow-controllable), mirroring
-# staging-reseed.sh / deploy-staging.sh; sudo resets the environment, so the
-# sudoers entry must NOT use SETENV/env_keep and the workflow must NEVER use
-# sudo -E.
+# identity + unit path are HARDCODED (not environment-overridable), mirroring
+# staging-reseed.sh / deploy-staging.sh: sudo resets the environment, and even a
+# misconfigured sudoers (SETENV/env_keep) or a `sudo -E` must NEVER let the runner
+# redirect which tenant/unit this reads. So the sudoers entry must NOT use
+# SETENV/env_keep and the workflow must NEVER use sudo -E — and as defense-in-depth
+# nothing below honors a caller-supplied CRM_USER/CRM_HOME/unit override.
 set -uo pipefail
 
-CRM_USER="${CRM_USER:-staging}"
-CRM_HOME="${CRM_HOME:-/var/lib/staging}"
-BACKEND_UNIT="${STAGING_BACKEND_UNIT:-$CRM_HOME/.config/containers/systemd/personalcrm-backend.container}"
+CRM_USER=staging
+CRM_HOME=/var/lib/staging
+BACKEND_UNIT="$CRM_HOME/.config/containers/systemd/personalcrm-backend.container"
 
 # Read the pinned Image= line as the tenant (mirrors staging-reset.sh read_image_ref).
 image="$(sudo -u "$CRM_USER" sed -n 's/^Image=//p' "$BACKEND_UNIT" 2>/dev/null | head -1)"

--- a/scripts/staging-deployed-sha.test.sh
+++ b/scripts/staging-deployed-sha.test.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Tests for staging-deployed-sha.sh — the host-pinned base reader.
+#
+# Writes a fixture backend Quadlet unit with various Image= refs and asserts the
+# script prints the 40-hex git sha ONLY for a :<40-hex> pin (digest / :latest /
+# missing unit -> empty + nonzero). PATH-shadows `sudo` so `sudo -u staging sed`
+# runs the real sed against the fixture. No Pi/podman/root.
+#
+# Portability: no BSD-only stat -f / date -r / sed -i.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/staging-deployed-sha.sh"
+SHA="1111111111111111111111111111111111111111"
+DIGEST="sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+REPO="ghcr.io/spengrah/personalcrm-backend"
+
+PASS=0
+FAIL=0
+fail() { echo "  FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+ok()   { PASS=$((PASS + 1)); }
+
+make_sandbox() {
+    SANDBOX="$(mktemp -d)"
+    mkdir -p "$SANDBOX/bin"
+    UNIT="$SANDBOX/backend.container"
+    # Minimal sudo stub: skip -u <user>, -n, and leading KEY=val env tokens until
+    # the first non-option (the command), then exec the rest verbatim.
+    cat > "$SANDBOX/bin/sudo" <<'EOF'
+#!/usr/bin/env bash
+args=("$@"); out=(); i=0; opts=1
+while [ $i -lt ${#args[@]} ]; do
+    a="${args[$i]}"
+    if [ "$opts" = "1" ]; then
+        if [ "$a" = "-u" ]; then i=$((i + 2)); continue; fi
+        if [ "$a" = "-n" ]; then i=$((i + 1)); continue; fi
+        if [[ "$a" == *=* ]]; then i=$((i + 1)); continue; fi
+        opts=0
+    fi
+    out+=("$a"); i=$((i + 1))
+done
+exec "${out[@]}"
+EOF
+    chmod +x "$SANDBOX/bin/sudo"
+}
+
+cleanup_sandbox() { [ -n "${SANDBOX:-}" ] && rm -rf "$SANDBOX"; }
+
+write_unit() { printf '[Container]\nContainerName=crm-backend\nImage=%s\nNetwork=crm.network\n' "$1" > "$UNIT"; }
+
+# run_reader : run the script with the fixture unit; sets RC + OUT (stdout).
+run_reader() {
+    OUT="$(PATH="$SANDBOX/bin:$PATH" STAGING_BACKEND_UNIT="$UNIT" bash "$SCRIPT" 2>/dev/null)"
+    RC=$?
+}
+
+# ===========================================================================
+test_sha_tag_prints() {
+    echo "test: Image=repo:<40-hex> -> prints the sha, exit 0"
+    make_sandbox
+    write_unit "$REPO:$SHA"
+    run_reader
+    if [ "$RC" -eq 0 ]; then ok; else fail "sha pin must exit 0, got $RC"; fi
+    if [ "$OUT" = "$SHA" ]; then ok; else fail "must print the sha, got '$OUT'"; fi
+    cleanup_sandbox
+}
+
+test_digest_empty() {
+    echo "test: Image=repo@sha256:<digest> -> empty + nonzero (64-hex != 40)"
+    make_sandbox
+    write_unit "$REPO@$DIGEST"
+    run_reader
+    if [ "$RC" -ne 0 ]; then ok; else fail "digest must exit nonzero, got $RC"; fi
+    if [ -z "$OUT" ]; then ok; else fail "digest must print nothing, got '$OUT'"; fi
+    cleanup_sandbox
+}
+
+test_latest_empty() {
+    echo "test: Image=repo:latest -> empty + nonzero"
+    make_sandbox
+    write_unit "$REPO:latest"
+    run_reader
+    if [ "$RC" -ne 0 ]; then ok; else fail "latest must exit nonzero, got $RC"; fi
+    if [ -z "$OUT" ]; then ok; else fail "latest must print nothing, got '$OUT'"; fi
+    cleanup_sandbox
+}
+
+test_missing_unit_empty() {
+    echo "test: missing unit -> empty + nonzero"
+    make_sandbox
+    rm -f "$UNIT"
+    run_reader
+    if [ "$RC" -ne 0 ]; then ok; else fail "missing unit must exit nonzero, got $RC"; fi
+    if [ -z "$OUT" ]; then ok; else fail "missing unit must print nothing, got '$OUT'"; fi
+    cleanup_sandbox
+}
+
+# ---------------------------------------------------------------------------
+main() {
+    test_sha_tag_prints
+    test_digest_empty
+    test_latest_empty
+    test_missing_unit_empty
+
+    echo ""
+    echo "===================="
+    echo "PASS=$PASS FAIL=$FAIL"
+    echo "===================="
+    [ "$FAIL" -eq 0 ]
+}
+
+main "$@"

--- a/scripts/staging-deployed-sha.test.sh
+++ b/scripts/staging-deployed-sha.test.sh
@@ -3,8 +3,11 @@
 #
 # Writes a fixture backend Quadlet unit with various Image= refs and asserts the
 # script prints the 40-hex git sha ONLY for a :<40-hex> pin (digest / :latest /
-# missing unit -> empty + nonzero). PATH-shadows `sudo` so `sudo -u staging sed`
-# runs the real sed against the fixture. No Pi/podman/root.
+# missing unit -> empty + nonzero). The tenant identity + unit path are HARDCODED
+# in the script (the env-trust seam), so the PATH-shadowed `sudo` stub rewrites the
+# hardcoded staging unit path to the test fixture (no /var/lib/staging touch) and
+# logs calls — and an override-rejection test confirms a caller-supplied
+# CRM_USER/CRM_HOME/STAGING_BACKEND_UNIT cannot redirect the read. No Pi/podman/root.
 #
 # Portability: no BSD-only stat -f / date -r / sed -i.
 
@@ -13,6 +16,7 @@ set -uo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCRIPT="$REPO_ROOT/scripts/staging-deployed-sha.sh"
 SHA="1111111111111111111111111111111111111111"
+EVIL_SHA="2222222222222222222222222222222222222222"
 DIGEST="sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 REPO="ghcr.io/spengrah/personalcrm-backend"
 
@@ -23,24 +27,34 @@ ok()   { PASS=$((PASS + 1)); }
 
 make_sandbox() {
     SANDBOX="$(mktemp -d)"
+    CALL_LOG="$SANDBOX/calls.log"
+    : > "$CALL_LOG"
     mkdir -p "$SANDBOX/bin"
     UNIT="$SANDBOX/backend.container"
-    # Minimal sudo stub: skip -u <user>, -n, and leading KEY=val env tokens until
-    # the first non-option (the command), then exec the rest verbatim.
-    cat > "$SANDBOX/bin/sudo" <<'EOF'
+    # sudo stub: log the full call, skip -u <user>/-n/leading KEY=val tokens until
+    # the command, then rewrite the script's HARDCODED staging unit path to the test
+    # fixture (so the read is observable without touching /var/lib/staging) and exec.
+    # A NON-staging path (e.g. an injected override) is NOT rewritten, so an
+    # override-honoring bug would read the wrong file and surface a different sha.
+    cat > "$SANDBOX/bin/sudo" <<EOF
 #!/usr/bin/env bash
-args=("$@"); out=(); i=0; opts=1
-while [ $i -lt ${#args[@]} ]; do
-    a="${args[$i]}"
-    if [ "$opts" = "1" ]; then
-        if [ "$a" = "-u" ]; then i=$((i + 2)); continue; fi
-        if [ "$a" = "-n" ]; then i=$((i + 1)); continue; fi
-        if [[ "$a" == *=* ]]; then i=$((i + 1)); continue; fi
+echo "sudo \$*" >> "$CALL_LOG"
+args=("\$@"); out=(); i=0; opts=1
+while [ \$i -lt \${#args[@]} ]; do
+    a="\${args[\$i]}"
+    if [ "\$opts" = "1" ]; then
+        if [ "\$a" = "-u" ]; then i=\$((i + 2)); continue; fi
+        if [ "\$a" = "-n" ]; then i=\$((i + 1)); continue; fi
+        if [[ "\$a" == *=* ]]; then i=\$((i + 1)); continue; fi
         opts=0
     fi
-    out+=("$a"); i=$((i + 1))
+    case "\$a" in
+        */personalcrm-backend.container) out+=("$UNIT") ;;
+        *) out+=("\$a") ;;
+    esac
+    i=\$((i + 1))
 done
-exec "${out[@]}"
+exec "\${out[@]}"
 EOF
     chmod +x "$SANDBOX/bin/sudo"
 }
@@ -49,9 +63,10 @@ cleanup_sandbox() { [ -n "${SANDBOX:-}" ] && rm -rf "$SANDBOX"; }
 
 write_unit() { printf '[Container]\nContainerName=crm-backend\nImage=%s\nNetwork=crm.network\n' "$1" > "$UNIT"; }
 
-# run_reader : run the script with the fixture unit; sets RC + OUT (stdout).
+# run_reader : run the script; sets RC + OUT (stdout). No env passed — the script
+# hardcodes its tenant identity + unit path.
 run_reader() {
-    OUT="$(PATH="$SANDBOX/bin:$PATH" STAGING_BACKEND_UNIT="$UNIT" bash "$SCRIPT" 2>/dev/null)"
+    OUT="$(PATH="$SANDBOX/bin:$PATH" bash "$SCRIPT" 2>/dev/null)"
     RC=$?
 }
 
@@ -96,12 +111,28 @@ test_missing_unit_empty() {
     cleanup_sandbox
 }
 
+test_override_rejection() {
+    echo "test: caller CRM_USER/CRM_HOME/STAGING_BACKEND_UNIT overrides are IGNORED (hardcoded seam)"
+    make_sandbox
+    write_unit "$REPO:$SHA"                                  # the real staging unit -> good sha
+    printf '[Container]\nImage=%s\n' "$REPO:$EVIL_SHA" > "$SANDBOX/evil.container"
+    OUT="$(PATH="$SANDBOX/bin:$PATH" CRM_USER=attacker CRM_HOME=/evil STAGING_BACKEND_UNIT="$SANDBOX/evil.container" bash "$SCRIPT" 2>/dev/null)"
+    RC=$?
+    if [ "$RC" -eq 0 ]; then ok; else fail "override run should still read staging + succeed, got $RC"; fi
+    if [ "$OUT" = "$SHA" ]; then ok; else fail "must read the HARDCODED staging unit (got '$OUT')"; fi
+    if [ "$OUT" = "$EVIL_SHA" ]; then fail "override redirected the read to the attacker unit"; else ok; fi
+    if grep -qF -- '-u staging' "$CALL_LOG"; then ok; else fail "must sudo to the staging tenant"; fi
+    if grep -qF -- '-u attacker' "$CALL_LOG"; then fail "must NOT sudo to a caller-supplied tenant"; else ok; fi
+    cleanup_sandbox
+}
+
 # ---------------------------------------------------------------------------
 main() {
     test_sha_tag_prints
     test_digest_empty
     test_latest_empty
     test_missing_unit_empty
+    test_override_rejection
 
     echo ""
     echo "===================="

--- a/scripts/staging-reseed.sh
+++ b/scripts/staging-reseed.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# staging-reseed.sh — root-owned auto-reseed wrapper (the env-trust seam).
+#
+# deploy-staging.yml's deploy job invokes this through a single args-free sudoers
+# entry (`sudo /usr/local/sbin/staging-reseed.sh`). sudo resets the environment, so
+# the ONLY tenant identity + reseed flags that reach the root-run reset are what
+# this runner-immutable wrapper hardcodes below — NOT anything the workflow could
+# set. Mirrors deploy-staging.sh exactly. For this seam to hold: the sudoers entry
+# must NOT use SETENV/env_keep, and the workflow must NEVER use sudo -E.
+#
+# --require-oauth-empty is pinned HERE (not workflow-controllable): the auto path
+# always carries the oauth guard, so a connected sync account (non-empty
+# oauth_credential) disables the destructive wipe and staging keeps its data.
+# Manual `make staging-reset` runs staging-reset.sh WITHOUT the flag (operator
+# force = full wipe regardless of oauth).
+set -euo pipefail
+
+export CRM_USER=staging
+export CRM_HOME=/var/lib/staging
+
+exec /usr/local/sbin/staging-reset.sh --local --require-oauth-empty

--- a/scripts/staging-reseed.test.sh
+++ b/scripts/staging-reseed.test.sh
@@ -43,8 +43,10 @@ EOF
 
 cleanup_sandbox() { [ -n "${SANDBOX:-}" ] && rm -rf "$SANDBOX"; }
 
+# run_wrapper : the wrapper is args-free by design (the sudoers entry is args-free),
+# so this passes no args — it only exercises the hardcoded exec + tenant exports.
 run_wrapper() {
-    bash "$SANDBOX/staging-reseed.sh" "$@" >/dev/null 2>&1
+    bash "$SANDBOX/staging-reseed.sh" >/dev/null 2>&1
     RC=$?
 }
 

--- a/scripts/staging-reseed.test.sh
+++ b/scripts/staging-reseed.test.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Tests for staging-reseed.sh — the root-owned auto-reseed wrapper (env-trust seam).
+#
+# The wrapper forces CRM_USER=staging + CRM_HOME=/var/lib/staging and execs
+# staging-reset.sh with EXACTLY `--local --require-oauth-empty` (the oauth guard is
+# pinned in the wrapper, not workflow-controllable). The wrapper hardcodes the
+# absolute /usr/local/sbin/staging-reset.sh path (that IS the seam), so the test
+# rewrites that one path to a recording stub via sed-to-stdout (portable; no sed -i)
+# and runs the rewritten copy — the committed wrapper stays byte-pure.
+#
+# All checks run anywhere (no Pi/podman/root).
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WRAPPER="$REPO_ROOT/scripts/staging-reseed.sh"
+
+PASS=0
+FAIL=0
+fail() { echo "  FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+ok()   { PASS=$((PASS + 1)); }
+
+make_sandbox() {
+    SANDBOX="$(mktemp -d)"
+    CALL_LOG="$SANDBOX/calls.log"
+    : > "$CALL_LOG"
+    mkdir -p "$SANDBOX/bin"
+
+    cat > "$SANDBOX/bin/staging-reset.sh" <<EOF
+#!/usr/bin/env bash
+echo "argc=\$#" >> "$CALL_LOG"
+echo "args=[\$*]" >> "$CALL_LOG"
+echo "env CRM_USER=\${CRM_USER:-<unset>} CRM_HOME=\${CRM_HOME:-<unset>}" >> "$CALL_LOG"
+exit 0
+EOF
+    chmod +x "$SANDBOX/bin/staging-reset.sh"
+
+    # Rewrite ONLY the hardcoded exec path to the stub (sed to stdout; '#'
+    # delimiter so the path slashes need no escaping). Committed wrapper untouched.
+    sed "s#/usr/local/sbin/staging-reset.sh#$SANDBOX/bin/staging-reset.sh#" \
+        "$WRAPPER" > "$SANDBOX/staging-reseed.sh"
+}
+
+cleanup_sandbox() { [ -n "${SANDBOX:-}" ] && rm -rf "$SANDBOX"; }
+
+run_wrapper() {
+    bash "$SANDBOX/staging-reseed.sh" "$@" >/dev/null 2>&1
+    RC=$?
+}
+
+# ===========================================================================
+test_wrapper_execs_reset_with_oauth_flag() {
+    echo "test: wrapper execs staging-reset.sh with EXACTLY --local --require-oauth-empty + tenant"
+    make_sandbox
+    run_wrapper
+    if [ "$RC" -eq 0 ]; then ok; else fail "wrapper should exit 0, got $RC"; fi
+    if grep -qF "args=[--local --require-oauth-empty]" "$CALL_LOG"; then ok
+    else fail "wrapper must exec with exactly '--local --require-oauth-empty'"; fi
+    if grep -qF "argc=2" "$CALL_LOG"; then ok; else fail "wrapper must pass exactly two args"; fi
+    if grep -qF "env CRM_USER=staging CRM_HOME=/var/lib/staging" "$CALL_LOG"; then ok
+    else fail "wrapper must export CRM_USER=staging + CRM_HOME=/var/lib/staging"; fi
+    cleanup_sandbox
+}
+
+test_wrapper_overrides_caller_supplied_tenant() {
+    echo "test: wrapper OVERRIDES a caller-supplied CRM_USER/CRM_HOME (defense-in-depth)"
+    make_sandbox
+    CRM_USER=attacker CRM_HOME=/evil run_wrapper
+    if grep -qF "env CRM_USER=staging CRM_HOME=/var/lib/staging" "$CALL_LOG"; then ok
+    else fail "wrapper must override a caller-supplied tenant with staging"; fi
+    if grep -qF "CRM_USER=attacker" "$CALL_LOG"; then fail "caller tenant leaked through the wrapper"; else ok; fi
+    cleanup_sandbox
+}
+
+test_committed_wrapper_pins_flags() {
+    echo "test: committed wrapper execs the absolute reset path with the pinned flags"
+    if grep -qE 'exec[[:space:]]+/usr/local/sbin/staging-reset\.sh[[:space:]]+--local[[:space:]]+--require-oauth-empty' "$WRAPPER"; then ok
+    else fail "committed wrapper must 'exec /usr/local/sbin/staging-reset.sh --local --require-oauth-empty'"; fi
+    if grep -qE '^export CRM_USER=staging' "$WRAPPER"; then ok; else fail "wrapper must export CRM_USER=staging"; fi
+    if grep -qE '^export CRM_HOME=/var/lib/staging' "$WRAPPER"; then ok; else fail "wrapper must export CRM_HOME=/var/lib/staging"; fi
+    # The wrapper execs staging-reset.sh DIRECTLY (no sudo of its own); the env-trust
+    # seam against `sudo -E`/--preserve-env is enforced on the workflow side
+    # (deploy-staging.test.sh::test_workflow_no_env_passthrough).
+}
+
+# ---------------------------------------------------------------------------
+main() {
+    test_wrapper_execs_reset_with_oauth_flag
+    test_wrapper_overrides_caller_supplied_tenant
+    test_committed_wrapper_pins_flags
+
+    echo ""
+    echo "===================="
+    echo "PASS=$PASS FAIL=$FAIL"
+    echo "===================="
+    [ "$FAIL" -eq 0 ]
+}
+
+main "$@"

--- a/scripts/staging-reset.sh
+++ b/scripts/staging-reset.sh
@@ -19,11 +19,21 @@
 # SeedAllowed gate is the authoritative in-process guard; this shell check is the
 # earlier, stricter backstop.
 #
-# Usage: ./scripts/staging-reset.sh [--local]
-#   --local   Run on the VPS as root (no ssh): the tenant podman/systemctl helpers
-#             run via `sudo -u <tenant>` locally. Default (ssh) mode targets
-#             STAGING_HOST (default stovepipes) so `make staging-reset` and the QA
-#             harness (#380) can drive it from the Mac.
+# Usage: ./scripts/staging-reset.sh [--local] [--require-oauth-empty]
+#   --local                Run on the VPS as root (no ssh): the tenant podman/
+#                          systemctl helpers run via `sudo -u <tenant>` locally.
+#                          Default (ssh) mode targets STAGING_HOST (default
+#                          stovepipes) so `make staging-reset` and the QA harness
+#                          (#380) can drive it from the Mac.
+#   --require-oauth-empty  Auto-path guard (deploy-staging.yml). BEFORE stopping
+#                          anything, count live oauth_credential rows; skip the
+#                          reseed cleanly (exit 0, service untouched, stable
+#                          "skipping auto-reseed" log marker) if any exist —
+#                          connecting a sync account to staging disables the
+#                          destructive wipe so the connection survives. Fail-closed
+#                          (exit non-zero) if the count cannot be verified. Manual
+#                          `make staging-reset` omits this (operator force = full
+#                          wipe regardless of oauth).
 #
 # Dev seeding is a SEPARATE tool: `make dev-seed` -> scripts/dev-seed.sh. Running
 # this on a dev Mac fails loudly (no staging tenant / no STAGING_HOST) — by design.
@@ -32,10 +42,15 @@ set -euo pipefail
 
 # Parse arguments
 LOCAL=false
+REQUIRE_OAUTH_EMPTY=false
 for arg in "$@"; do
     case "$arg" in
         --local) LOCAL=true ;;
-        *) echo "staging-reset: unknown argument: $arg" >&2; exit 2 ;;
+        --require-oauth-empty) REQUIRE_OAUTH_EMPTY=true ;;
+        # The fail-loud drift guard: a stale host copy that predates a newer flag
+        # hits this branch and reds the deploy reseed step instead of silently
+        # wiping. Keep the message actionable (reinstall the host copy).
+        *) echo "staging-reset: unknown argument: $arg (host copy out of date? reinstall /usr/local/sbin/staging-reset.sh)" >&2; exit 2 ;;
     esac
 done
 
@@ -65,6 +80,7 @@ if [ "$LOCAL" = true ]; then
     staging_podman() { cd /tmp && sudo -u "$CRM_USER" HOME=$CRM_HOME XDG_RUNTIME_DIR=/run/user/"$CRM_UID" podman "$@"; }
     read_crm_env()   { sudo -u "$CRM_USER" sed -n 's/^CRM_ENV=//p' "$ENV_FILE" 2>/dev/null | head -1; }
     read_image_ref() { sudo -u "$CRM_USER" sed -n 's/^Image=//p' "$BACKEND_UNIT" 2>/dev/null | head -1; }
+    read_database_url(){ sudo -u "$CRM_USER" sed -n 's/^DATABASE_URL=//p' "$ENV_FILE" 2>/dev/null | head -1; }
     env_file_exists(){ sudo -u "$CRM_USER" test -e "$ENV_FILE"; }
 else
     if ! ssh -q -o ConnectTimeout=5 "$STAGING_HOST" exit; then
@@ -84,8 +100,70 @@ else
     # shellcheck disable=SC2029
     read_image_ref() { ssh "$STAGING_HOST" "sudo -n -u $CRM_USER sed -n 's/^Image=//p' '$BACKEND_UNIT' 2>/dev/null | head -1"; }
     # shellcheck disable=SC2029
+    read_database_url(){ ssh "$STAGING_HOST" "sudo -n -u $CRM_USER sed -n 's/^DATABASE_URL=//p' '$ENV_FILE' 2>/dev/null | head -1"; }
+    # shellcheck disable=SC2029
     env_file_exists(){ ssh "$STAGING_HOST" "sudo -n -u $CRM_USER test -e '$ENV_FILE'"; }
 fi
+
+# oauth_credential_count: echo the live oauth_credential row count on stdout, or
+# fail-closed (return non-zero + a loud, specific stderr reason) on ANY uncertainty.
+# The auto path gates on this: a non-empty oauth_credential means a sync account is
+# connected to staging, so the destructive --reset-and-seed (which hard-wipes
+# oauth_credential) must be skipped to preserve that connection.
+#
+# DATABASE_URL is the SOLE authoritative source for user/dbname/host: it is the
+# only guaranteed .env contract AND the exact DB the app/reset connects with.
+# POSTGRES_USER/POSTGRES_DB are NEVER consulted — they are baked into the DB unit,
+# are not a .env contract, and can DISAGREE with the live DB; counting an empty
+# wrong DB would wipe real oauth rows. The count runs INSIDE the crm-postgres
+# container over its local socket (default pg_hba `local ... trust` -> no password
+# in podman argv/env, no -h/TCP), so it always counts THAT container's DB. We
+# therefore require DATABASE_URL's host to BE that local target before counting,
+# else the count would target a different DB than the reset wipes.
+oauth_credential_count() {
+    local url rest userinfo user after_at hostport host dbname count
+    url="$(read_database_url || true)"
+    # Strip surrounding quotes (a quoted .env value).
+    url="${url%\"}"; url="${url#\"}"
+    url="${url%\'}"; url="${url#\'}"
+    if [ -z "$url" ]; then
+        echo "staging-reset: REFUSING — DATABASE_URL not found in $ENV_FILE; cannot verify oauth_credential count" >&2
+        return 1
+    fi
+    # Parse postgres://user[:pass]@host[:port]/dbname[?query] authoritatively.
+    rest="${url#*://}"          # strip scheme
+    rest="${rest%%\?*}"         # strip ?query
+    userinfo="${rest%%@*}"      # user[:pass]
+    user="${userinfo%%:*}"      # user
+    after_at="${rest#*@}"       # host[:port]/dbname
+    hostport="${after_at%%/*}"  # host[:port]
+    host="${hostport%%:*}"      # host
+    dbname="${after_at#*/}"     # dbname (path after the first '/')
+    dbname="${dbname%%/*}"      # defensively drop any extra path segment
+    if [ -z "$user" ] || [ -z "$host" ] || [ -z "$dbname" ]; then
+        echo "staging-reset: REFUSING — could not parse user/host/dbname from DATABASE_URL; not reseeding" >&2
+        return 1
+    fi
+    # The in-container count only matches the DB the reset wipes when DATABASE_URL's
+    # host IS that local target. Refuse on a foreign host (we'd count the local DB
+    # while the reset wipes a remote one). localhost/127.0.0.1 accepted for native.
+    case "$host" in
+        crm-postgres|localhost|127.0.0.1) ;;
+        *)
+            echo "staging-reset: REFUSING — DATABASE_URL host '$host' is not the local crm-postgres target; refusing to verify a different DB than the reset wipes" >&2
+            return 1
+            ;;
+    esac
+    # Count over the in-container local socket (trust auth). `|| true` keeps a psql
+    # failure from tripping set -e before the fail-closed check below prints why.
+    count="$(staging_podman exec crm-postgres psql -U "$user" -d "$dbname" -tAc "SELECT count(*) FROM oauth_credential" 2>/dev/null | tr -d '[:space:]' || true)"
+    if [[ "$count" =~ ^[0-9]+$ ]]; then
+        printf '%s\n' "$count"
+        return 0
+    fi
+    echo "staging-reset: REFUSING — could not verify oauth_credential count (got '$count'); not reseeding (host script/DB state?)" >&2
+    return 1
+}
 
 # 1. The deployed staging .env must exist (read as the tenant; perms hold).
 if ! env_file_exists; then
@@ -114,6 +192,23 @@ IMAGE_REF="$(read_image_ref || true)"
 if [ -z "$IMAGE_REF" ]; then
     echo "staging-reset: could not read a pinned Image= from $BACKEND_UNIT" >&2
     exit 1
+fi
+
+# 3b. OAuth guard (auto path only). BEFORE the trap/stop, so every branch is a true
+#     no-op on the running service. --reset-and-seed hard-wipes oauth_credential, so
+#     a connected sync account (non-empty oauth_credential) disables the destructive
+#     path — persistence wins exactly when a sync test is in flight. Unverifiable
+#     count ⇒ fail-closed (exit non-zero, loud) — never wipe on uncertainty.
+if [ "$REQUIRE_OAUTH_EMPTY" = true ]; then
+    if ! OAUTH_COUNT="$(oauth_credential_count)"; then
+        # oauth_credential_count already logged the specific, loud refuse reason.
+        exit 1
+    fi
+    if [ "$OAUTH_COUNT" -gt 0 ]; then
+        echo "staging-reset: oauth present ($OAUTH_COUNT credential(s)); skipping auto-reseed to preserve sync connections" >&2
+        exit 0
+    fi
+    echo "staging-reset: oauth_credential empty; proceeding with auto-reseed" >&2
 fi
 
 # 4. Install the EXIT trap that restarts the backend — BEFORE the stop. If the

--- a/scripts/staging-reset.sh
+++ b/scripts/staging-reset.sh
@@ -154,14 +154,28 @@ oauth_credential_count() {
             return 1
             ;;
     esac
-    # Count over the in-container local socket (trust auth). `|| true` keeps a psql
-    # failure from tripping set -e before the fail-closed check below prints why.
-    count="$(staging_podman exec crm-postgres psql -U "$user" -d "$dbname" -tAc "SELECT count(*) FROM oauth_credential" 2>/dev/null | tr -d '[:space:]' || true)"
-    if [[ "$count" =~ ^[0-9]+$ ]]; then
-        printf '%s\n' "$count"
+    # Count over the in-container local socket (trust auth). Capture the command's
+    # exit status EXPLICITLY and reject any non-zero BEFORE validating the numeric
+    # output — a count command that fails yet still prints "0" (partial error, psql
+    # quirk) must NOT be read as verified-empty and proceed to the destructive wipe.
+    # The `if cmd; then ... else rc=$?` form keeps the failure from tripping set -e
+    # while preserving the real status (no `|| true` to swallow it).
+    local rc trimmed
+    if count="$(staging_podman exec crm-postgres psql -U "$user" -d "$dbname" -tAc "SELECT count(*) FROM oauth_credential" 2>/dev/null)"; then
+        rc=0
+    else
+        rc=$?
+    fi
+    if [ "$rc" -ne 0 ]; then
+        echo "staging-reset: REFUSING — oauth_credential count command failed (rc=$rc); not reseeding (host script/DB state?)" >&2
+        return 1
+    fi
+    trimmed="$(printf '%s' "$count" | tr -d '[:space:]')"
+    if [[ "$trimmed" =~ ^[0-9]+$ ]]; then
+        printf '%s\n' "$trimmed"
         return 0
     fi
-    echo "staging-reset: REFUSING — could not verify oauth_credential count (got '$count'); not reseeding (host script/DB state?)" >&2
+    echo "staging-reset: REFUSING — could not verify oauth_credential count (got '$trimmed'); not reseeding (host script/DB state?)" >&2
     return 1
 }
 

--- a/scripts/staging-reset.test.sh
+++ b/scripts/staging-reset.test.sh
@@ -96,7 +96,9 @@ if [ "\$1" = "exec" ]; then
     if [[ "\$*" == *oauth_credential* ]]; then
         if [ "\${STUB_OAUTH_PSQL_FAIL:-0}" = "1" ]; then exit 1; fi
         echo "\${STUB_OAUTH_COUNT:-0}"
-        exit 0
+        # STUB_OAUTH_PSQL_RC lets a test emit output AND exit non-zero (a count
+        # command that fails yet still prints a number must NOT be trusted).
+        exit "\${STUB_OAUTH_PSQL_RC:-0}"
     fi
     exit 0
 fi
@@ -400,6 +402,14 @@ test_oauth_unverifiable_fails() {
     if [ "$RC" -ne 0 ]; then ok; else fail "non-numeric count must fail-closed (exit !=0), got $RC"; fi
     if log_lacks "stop personalcrm-backend.service"; then ok; else fail "non-numeric count must NOT stop the backend"; fi
     if grep -F 'podman run' "$CALL_LOG" | grep -q -- '--reset-and-seed'; then fail "non-numeric count must NOT run the reset"; else ok; fi
+    cleanup_sandbox
+    # (c) count command emits a clean number BUT exits non-zero -> must NOT trust it
+    #     (a failed count that still prints "0" must never be read as verified-empty).
+    make_sandbox
+    STUB_OAUTH_COUNT=0 STUB_OAUTH_PSQL_RC=1 run_local_oauth
+    if [ "$RC" -ne 0 ]; then ok; else fail "count command exiting non-zero must fail-closed even with numeric output, got $RC"; fi
+    if log_lacks "stop personalcrm-backend.service"; then ok; else fail "count-command failure must NOT stop the backend"; fi
+    if grep -F 'podman run' "$CALL_LOG" | grep -q -- '--reset-and-seed'; then fail "count-command failure must NOT run the reset"; else ok; fi
     cleanup_sandbox
 }
 

--- a/scripts/staging-reset.test.sh
+++ b/scripts/staging-reset.test.sh
@@ -91,6 +91,15 @@ EOF
     cat > "$SANDBOX/bin/podman" <<EOF
 #!/usr/bin/env bash
 echo "podman \$*" >> "$CALL_LOG"
+if [ "\$1" = "exec" ]; then
+    # podman exec crm-postgres psql ... -tAc "SELECT count(*) FROM oauth_credential"
+    if [[ "\$*" == *oauth_credential* ]]; then
+        if [ "\${STUB_OAUTH_PSQL_FAIL:-0}" = "1" ]; then exit 1; fi
+        echo "\${STUB_OAUTH_COUNT:-0}"
+        exit 0
+    fi
+    exit 0
+fi
 if [ "\$1" = "run" ]; then
     for a in "\$@"; do
         if [ "\$a" = "--reset-and-seed" ]; then exit "\${STUB_RESET_RC:-0}"; fi
@@ -156,6 +165,18 @@ run_ssh() {
         bash "$SCRIPT" >/dev/null 2>"$SANDBOX/stderr"
     RC=$?
 }
+
+# run_local_oauth : --local --require-oauth-empty (the auto path's invocation).
+run_local_oauth() {
+    PATH="$SANDBOX/bin:$PATH" \
+        STAGING_ENV_FILE="$SANDBOX/staging.env" \
+        STAGING_BACKEND_UNIT="$SANDBOX/backend.container" \
+        bash "$SCRIPT" --local --require-oauth-empty >/dev/null 2>"$SANDBOX/stderr"
+    RC=$?
+}
+
+# write_env_raw <contents> : write the fixture .env verbatim (for custom URLs).
+write_env_raw() { printf '%s' "$1" > "$SANDBOX/staging.env"; }
 
 log_has()   { grep -qF -- "$1" "$CALL_LOG"; }
 log_lacks() { ! grep -qF -- "$1" "$CALL_LOG"; }
@@ -330,6 +351,110 @@ test_ssh_refuses_production() {
     cleanup_sandbox
 }
 
+# --- OAuth guard (--require-oauth-empty), the auto path's destructive-skip gate ---
+
+# psql_count_line : the recorded `podman exec ... psql ... oauth_credential` line.
+psql_count_line() { grep -F 'podman exec' "$CALL_LOG" | grep -F 'oauth_credential' | head -1; }
+
+test_oauth_empty_proceeds() {
+    echo "test: --require-oauth-empty + count 0 -> proceeds (stop -> reseed -> start)"
+    make_sandbox
+    STUB_OAUTH_COUNT=0 run_local_oauth
+    if [ "$RC" -eq 0 ]; then ok; else fail "oauth-empty must proceed (exit 0), got $RC ($(cat "$SANDBOX/stderr"))"; fi
+    if log_has "stop personalcrm-backend.service"; then ok; else fail "oauth-empty must stop the backend"; fi
+    if grep -F 'podman run' "$CALL_LOG" | grep -q -- '--reset-and-seed'; then ok; else fail "oauth-empty must run the reset"; fi
+    # The count targets the DATABASE_URL user/dbname over the in-container local
+    # socket: no PGPASSWORD, no -h/TCP (trust auth).
+    local line; line="$(psql_count_line)"
+    if [ -n "$line" ]; then ok; else fail "no oauth_credential count recorded"; fi
+    if [[ "$line" == *"-U crm_user"* ]]; then ok; else fail "count must use DATABASE_URL user (-U crm_user): $line"; fi
+    if [[ "$line" == *"-d personal_crm"* ]]; then ok; else fail "count must use DATABASE_URL dbname (-d personal_crm): $line"; fi
+    if [[ "$line" == *"PGPASSWORD"* ]]; then fail "count must NOT pass PGPASSWORD: $line"; else ok; fi
+    if [[ "$line" == *" -h "* ]]; then fail "count must NOT use -h/TCP: $line"; else ok; fi
+    cleanup_sandbox
+}
+
+test_oauth_present_skips() {
+    echo "test: --require-oauth-empty + count >0 -> clean skip (no stop, no reseed, marker)"
+    make_sandbox
+    STUB_OAUTH_COUNT=2 run_local_oauth
+    if [ "$RC" -eq 0 ]; then ok; else fail "oauth-present must skip cleanly (exit 0), got $RC"; fi
+    if log_lacks "stop personalcrm-backend.service"; then ok; else fail "oauth-present must NOT stop the backend"; fi
+    if grep -F 'podman run' "$CALL_LOG" | grep -q -- '--reset-and-seed'; then fail "oauth-present must NOT run the reset"; else ok; fi
+    if grep -qF 'skipping auto-reseed' "$SANDBOX/stderr"; then ok; else fail "oauth-present must log the stable 'skipping auto-reseed' marker"; fi
+    cleanup_sandbox
+}
+
+test_oauth_unverifiable_fails() {
+    echo "test: --require-oauth-empty + unverifiable count -> fail-closed (exit !=0, no stop/reseed)"
+    # (a) psql connection fails entirely.
+    make_sandbox
+    STUB_OAUTH_PSQL_FAIL=1 run_local_oauth
+    if [ "$RC" -ne 0 ]; then ok; else fail "psql failure must fail-closed (exit !=0), got $RC"; fi
+    if log_lacks "stop personalcrm-backend.service"; then ok; else fail "unverifiable count must NOT stop the backend"; fi
+    if grep -F 'podman run' "$CALL_LOG" | grep -q -- '--reset-and-seed'; then fail "unverifiable count must NOT run the reset"; else ok; fi
+    cleanup_sandbox
+    # (b) non-numeric count output.
+    make_sandbox
+    STUB_OAUTH_COUNT=boom run_local_oauth
+    if [ "$RC" -ne 0 ]; then ok; else fail "non-numeric count must fail-closed (exit !=0), got $RC"; fi
+    if log_lacks "stop personalcrm-backend.service"; then ok; else fail "non-numeric count must NOT stop the backend"; fi
+    if grep -F 'podman run' "$CALL_LOG" | grep -q -- '--reset-and-seed'; then fail "non-numeric count must NOT run the reset"; else ok; fi
+    cleanup_sandbox
+}
+
+test_oauth_missing_database_url_fails() {
+    echo "test: --require-oauth-empty + no DATABASE_URL -> fail-closed (exit !=0, no stop/reseed)"
+    make_sandbox
+    write_env_raw $'CRM_ENV=staging\n'   # staging passes prod-refuse, but no DATABASE_URL
+    STUB_OAUTH_COUNT=0 run_local_oauth
+    if [ "$RC" -ne 0 ]; then ok; else fail "missing DATABASE_URL must fail-closed, got $RC"; fi
+    if log_lacks "stop personalcrm-backend.service"; then ok; else fail "missing DATABASE_URL must NOT stop the backend"; fi
+    if grep -F 'podman run' "$CALL_LOG" | grep -q -- '--reset-and-seed'; then fail "missing DATABASE_URL must NOT run the reset"; else ok; fi
+    cleanup_sandbox
+}
+
+test_oauth_dbname_authoritative() {
+    echo "test: DATABASE_URL dbname/user are authoritative even when POSTGRES_* disagree"
+    make_sandbox
+    # POSTGRES_DB/POSTGRES_USER deliberately DISAGREE with DATABASE_URL; the count
+    # MUST use the DATABASE_URL values (else it could count an empty wrong DB and
+    # wipe real oauth rows). regression guard for the round-2 [P1] finding.
+    write_env_raw $'CRM_ENV=staging\nDATABASE_URL=postgres://crm_user:x@crm-postgres:5432/personal_crm\nPOSTGRES_DB=crm_staging\nPOSTGRES_USER=other\n'
+    STUB_OAUTH_COUNT=0 run_local_oauth
+    if [ "$RC" -eq 0 ]; then ok; else fail "should proceed with count 0, got $RC"; fi
+    local line; line="$(psql_count_line)"
+    if [[ "$line" == *"-d personal_crm"* ]]; then ok; else fail "count must use DATABASE_URL dbname personal_crm: $line"; fi
+    if [[ "$line" == *"crm_staging"* ]]; then fail "count must NOT use POSTGRES_DB crm_staging: $line"; else ok; fi
+    if [[ "$line" == *"-U crm_user"* ]]; then ok; else fail "count must use DATABASE_URL user crm_user: $line"; fi
+    if [[ "$line" == *"-U other"* ]]; then fail "count must NOT use POSTGRES_USER other: $line"; else ok; fi
+    cleanup_sandbox
+}
+
+test_oauth_foreign_host_fails() {
+    echo "test: DATABASE_URL host not the local target -> fail-closed BEFORE counting"
+    make_sandbox
+    write_env_raw $'CRM_ENV=staging\nDATABASE_URL=postgres://crm_user:x@db.example.com:5432/personal_crm\n'
+    STUB_OAUTH_COUNT=0 run_local_oauth
+    if [ "$RC" -ne 0 ]; then ok; else fail "foreign host must fail-closed, got $RC"; fi
+    # Refused BEFORE counting: no psql count attempted, no stop, no reseed.
+    if grep -F 'podman exec' "$CALL_LOG" | grep -q 'oauth_credential'; then fail "foreign host must NOT attempt the count"; else ok; fi
+    if log_lacks "stop personalcrm-backend.service"; then ok; else fail "foreign host must NOT stop the backend"; fi
+    if grep -F 'podman run' "$CALL_LOG" | grep -q -- '--reset-and-seed'; then fail "foreign host must NOT run the reset"; else ok; fi
+    cleanup_sandbox
+}
+
+test_oauth_flag_is_the_gate() {
+    echo "test: WITHOUT --require-oauth-empty, reseed runs regardless of oauth (no count)"
+    make_sandbox
+    STUB_OAUTH_COUNT=5 run_local   # default invocation, NO flag
+    if [ "$RC" -eq 0 ]; then ok; else fail "no-flag default must reseed (exit 0), got $RC"; fi
+    if log_has "stop personalcrm-backend.service"; then ok; else fail "no-flag default must stop the backend"; fi
+    if grep -F 'podman run' "$CALL_LOG" | grep -q -- '--reset-and-seed'; then ok; else fail "no-flag default must run the reset"; fi
+    if grep -F 'podman exec' "$CALL_LOG" | grep -q 'oauth_credential'; then fail "no-flag default must NOT count oauth_credential (flag is the gate)"; else ok; fi
+    cleanup_sandbox
+}
+
 # ---------------------------------------------------------------------------
 main() {
     test_happy_path_ordering
@@ -343,6 +468,13 @@ main() {
     test_local_does_not_ssh
     test_ssh_targets_host
     test_ssh_refuses_production
+    test_oauth_empty_proceeds
+    test_oauth_present_skips
+    test_oauth_unverifiable_fails
+    test_oauth_missing_database_url_fails
+    test_oauth_dbname_authoritative
+    test_oauth_foreign_host_fails
+    test_oauth_flag_is_the_gate
 
     echo ""
     echo "===================="

--- a/scripts/staging-reset.test.sh
+++ b/scripts/staging-reset.test.sh
@@ -419,7 +419,7 @@ test_oauth_dbname_authoritative() {
     make_sandbox
     # POSTGRES_DB/POSTGRES_USER deliberately DISAGREE with DATABASE_URL; the count
     # MUST use the DATABASE_URL values (else it could count an empty wrong DB and
-    # wipe real oauth rows). regression guard for the round-2 [P1] finding.
+    # wipe real oauth rows). Regression guard for the wrong-DB wipe hazard.
     write_env_raw $'CRM_ENV=staging\nDATABASE_URL=postgres://crm_user:x@crm-postgres:5432/personal_crm\nPOSTGRES_DB=crm_staging\nPOSTGRES_USER=other\n'
     STUB_OAUTH_COUNT=0 run_local_oauth
     if [ "$RC" -eq 0 ]; then ok; else fail "should proceed with count 0, got $RC"; fi


### PR DESCRIPTION
Closes #565.

## Summary

Staging's DB persists across deploys by design, so changes to the seed code (`backend/internal/synthetic/**`) were invisible on staging until someone manually ran `crm-admin --reset-and-seed`. This wires an auto-reseed into the staging deploy that fires **only when** the seed surface actually changed **and** it's safe to wipe — without giving up staging's deliberate persistence. `deploy-artifact.sh` (prod-shared) is untouched.

## How it works

The reseed runs as ordered steps **inside the existing serialized `deploy-staging` job** (no extra job, no Deployments API, no `deployments:` permission):

`capture-host-SHA → deploy → checkout (continue-on-error) → decide → reseed → breadcrumb/nudges`

- **`seed` path-filters group** (`backend/internal/synthetic/**`) added to `path-filters.yml` — the single source both CI's dorny filter and the pre-push hook read. Parity-guard + filter unit-test membership/orthogonality assertions updated per the cross-cutting checklist.
- **Decision** (`scripts/ci/staging-reseed-decision.sh`): two-dot `git diff` between the host-pinned live backend SHA (read from the running unit's `Image=` tag) and the deploying SHA; fault-tolerant (never exits non-zero; degrades to `base_known=false` / no-reseed on any ambiguity, **including a failed checkout** — gated on `steps.checkout.outcome == 'success'`, not mere script presence).
- **OAuth-empty guard** (destructive-safety-critical, **fail-closed**): `scripts/staging-reset.sh --require-oauth-empty` parses dbname/user/host authoritatively from `DATABASE_URL`, validates the host is the expected local `crm-postgres` target, counts `oauth_credential` over the in-container local socket (no secret in `podman` argv), captures the count command's exit status and **refuses to proceed on any uncertainty**. So connecting a real Google/Todoist/Mac-daemon account to staging implicitly disables the destructive path — persistence wins exactly when it matters.
- **Migration-only changes do NOT auto-reseed** — they get a deploy-summary nudge instead (the higher-value staging test is migrate-against-the-accumulated-world). OAuth-present and no-base cases also leave deploy-summary breadcrumbs.

## Decision surfaced to the user (D6)

Manual escape hatch = **`make staging-reset`** (documented in its help). The heavier `workflow_dispatch force_reseed` input was **deferred** to a follow-up by explicit choice.

## Review trail

- Plan: 4 Codex adversarial rounds to PASS (P1 trend 5 → 2 → 2 → 0).
- Implementation: 3 Codex rounds to PASS (P1: stale-checkout gate, oauth-count exit-status, sha-reader seam — all fixed; then a hook-env test-sanitization fix).
- Two fresh-context `/review-head` adversarial passes: PASS (0 P0 / 0 P1).
- Pre-push gate green: lint + Go unit/integration + frontend + filter + E2E.

## Non-blocking follow-ups (tracked, not blocking)

- **P2** (latent): ssh-mode `oauth_credential_count` loses psql quoting via `$*` — unreachable today (the only caller always passes `--local`) and fails closed if ever hit.
- **P3**: host-validation accepts `localhost`/`127.0.0.1` though the count target is always the `crm-postgres` container — defensive-only, fails closed both ways (documented D3 tradeoff).
- **P3**: `migrations_changed` hardcodes `backend/migrations/` rather than a path-filters group — nudge-only, no correctness impact (explicit D2 choice).

## Host provisioning (NOT in this diff — staging standup checklist)

After merge, on the staging host (`stovepipes`):
- Install `staging-reset.sh`, `staging-reseed.sh`, `staging-deployed-sha.sh` to `/usr/local/sbin` (root:root, 0755).
- Add 2 args-free `sudoers` lines (no `SETENV`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)