### PR TITLE
chore(staging): auto-reseed follow-ups (#567)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -9,19 +9,32 @@ name: Deploy to Staging
 # completed+success. The common case (the other upstream still in-flight) defers
 # quietly (green, no deploy); the last upstream to finish re-triggers and deploys.
 #
-# Two jobs so `environment: staging` attaches ONLY to a real deploy: a single job
-# carrying the environment that green-skips would record a phantom "successful
-# staging deployment" for a SHA that was never deployed. The gate runs on
-# ubuntu-latest (jq+curl preinstalled); only the deploy job touches the box.
+# Two jobs so `environment: staging` attaches only to a real staging mutation (a
+# code deploy or a manual reseed) — never to a green-skip: a single job carrying
+# the environment that green-skips would record a phantom "successful staging
+# deployment" for a SHA that was never deployed. The gate runs on ubuntu-latest
+# (jq+curl preinstalled); only the deploy job touches the box.
 #
 # workflow_run always runs this file + context from the default branch (develop)
 # and never fork code; the repo is private + solo, so no pull_request trigger.
+#
+# A second trigger, `workflow_dispatch` (force_reseed), is a manual, reseed-only
+# path: no code deploy, no CI/build gate. It reseeds against the image already live
+# on the host (deploy/checkout/decision steps are skipped) and still honors the
+# oauth guard in the reseed wrapper. It is develop-ref-only (gate if: below), and
+# an unchecked force_reseed box is a true no-op (deploy job never starts).
 
 on:
   workflow_run:
     workflows: ["CI", "Build & Push Images"]
     types: [completed]
     branches: [develop]
+  workflow_dispatch:
+    inputs:
+      force_reseed:
+        description: "Force a staging reseed regardless of path changes (still skipped if a sync account is connected — oauth_credential non-empty). No code is deployed; reseeds against the currently-deployed image."
+        type: boolean
+        default: false
 
 permissions:
   actions: read
@@ -34,7 +47,7 @@ jobs:
     # success-only prefilter would skip this job when the TRIGGERING upstream
     # failed, so a late-failing upstream would produce no red signal. All
     # conclusion handling lives in the gate step's three-way logic below.
-    if: github.event.workflow_run.head_branch == 'develop'
+    if: (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/develop') || github.event.workflow_run.head_branch == 'develop'
     permissions:
       actions: read     # query ci.yml / build-images.yml run conclusions
       contents: read    # read the current develop tip (stale-SHA guard)
@@ -47,6 +60,23 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            # Manual reseed: no code deploy, no CI/build gate needed (the reseed runs
+            # against the image already live on the host). The job-level if: already
+            # restricted this to the develop ref. deploy_ready follows force_reseed:
+            # an unchecked box does NOTHING (the deploy job never runs, so no Environment
+            # deployment is recorded). A checked box runs the deploy job for its reseed
+            # step only (deploy/checkout/decision steps are skipped on this event).
+            echo "sha=" >> "$GITHUB_OUTPUT"
+            if [ "${{ github.event.inputs.force_reseed }}" = "true" ]; then
+              echo "deploy_ready=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "force_reseed=false; nothing to do (no deploy, no reseed)."
+              echo "deploy_ready=false" >> "$GITHUB_OUTPUT"
+            fi
+            exit 0
+          fi
+
           SHA="${{ github.event.workflow_run.head_sha }}"
           echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
 
@@ -137,18 +167,23 @@ jobs:
     # (sudo resets the env; nothing is passed from here). The diff base is the live
     # backend unit's pinned 40-hex Image= git sha; a failed/skipped reseed advances
     # it, so the next deploy does NOT auto-retry — recover with `make staging-reset`
-    # (also the manual escape hatch to force a reseed regardless of paths).
+    # (the on-host escape hatch) or the GitHub Actions UI `workflow_dispatch`
+    # (force_reseed), the from-UI on-demand reseed. On a workflow_dispatch the
+    # deploy/checkout/decision steps below are skipped (reseed-only, no code deploy).
     steps:
       - name: Capture live staging SHA (host-pinned reseed base, before the swap)
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         run: |
           prev_sha=$(sudo /usr/local/sbin/staging-deployed-sha.sh || true)
           echo "prev_sha=${prev_sha}" >> "$GITHUB_ENV"
 
       - name: Deploy
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         run: sudo /usr/local/sbin/deploy-staging.sh "${{ needs.gate.outputs.sha }}"
 
       - name: Checkout (post-deploy; for the reseed decision only)
         id: checkout
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         uses: actions/checkout@v4
         continue-on-error: true
         with:
@@ -156,6 +191,7 @@ jobs:
           fetch-depth: 0
 
       - name: Decide reseed (seed/migration diff vs the live base)
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         env:
           CHECKOUT_OUTCOME: ${{ steps.checkout.outcome }}
         run: |
@@ -174,13 +210,13 @@ jobs:
           fi
 
       - name: Auto-reseed staging (seed surface changed)
-        if: ${{ env.seed_changed == 'true' }}
+        if: ${{ env.seed_changed == 'true' || (github.event_name == 'workflow_dispatch' && github.event.inputs.force_reseed == 'true') }}
         run: |
           sudo /usr/local/sbin/staging-reseed.sh 2>&1 | tee "$RUNNER_TEMP/reseed.out"
           exit "${PIPESTATUS[0]}"
 
       - name: Note OAuth-skip (sync account connected -> reseed skipped)
-        if: ${{ always() && env.seed_changed == 'true' }}
+        if: ${{ always() && (env.seed_changed == 'true' || (github.event_name == 'workflow_dispatch' && github.event.inputs.force_reseed == 'true')) }}
         run: |
           if [ -f "$RUNNER_TEMP/reseed.out" ] && grep -q 'skipping auto-reseed' "$RUNNER_TEMP/reseed.out"; then
             {

--- a/Makefile
+++ b/Makefile
@@ -519,6 +519,7 @@ test-deploy-scripts:
 	@bash scripts/ci/staging-reseed-decision.test.sh
 	@bash scripts/staging-deployed-sha.test.sh
 	@bash scripts/staging-reseed.test.sh
+	@bash scripts/admin/setup-staging-reseed-host.sh.test.sh
 	@bash scripts/reconcile-mac-daemon.test.sh
 	@bash scripts/setup-mac-deploy.test.sh
 	@bash scripts/trigger-mac-deploy.test.sh

--- a/path-filters.yml
+++ b/path-filters.yml
@@ -17,6 +17,11 @@
 #                 via file_in_group). ORTHOGONAL: synthetic stays in `backend` too, so this
 #                 group changes NO CI/pre-push test selection — it only flags the seed surface
 #                 the staging auto-reseed diffs against. No CI/pre-push consumer reads it.
+#   migrations  → deploy-staging.yml reseed decision (scripts/ci/staging-reseed-decision.sh,
+#                 via file_in_group). ORTHOGONAL: backend/migrations/** is also in the `backend`
+#                 group, so this group changes NO CI/pre-push test selection — it only flags a
+#                 schema change so the reseed decision emits a migration nudge. No CI/pre-push
+#                 consumer reads it.
 
 backend:
   - 'backend/**'
@@ -35,3 +40,5 @@ mac_daemon:
   - '.github/workflows/ci.yml'
 seed:
   - 'backend/internal/synthetic/**'
+migrations:
+  - 'backend/migrations/**'

--- a/scripts/admin/README.md
+++ b/scripts/admin/README.md
@@ -1,8 +1,9 @@
 # Admin scripts
 
-Destructive operator scripts for one-off recovery scenarios that the
-production code path deliberately does not automate. Each script
-prompts for confirmation before running.
+Operator scripts for one-off recovery and host-standup scenarios that
+the production code path deliberately does not automate. Destructive
+scripts prompt for confirmation before running; idempotent,
+non-destructive installers (e.g. `setup-staging-reseed-host.sh`) do not.
 
 ## reset_icloud_contacts.sh
 
@@ -61,6 +62,56 @@ The script:
 
 After the script finishes, the daemon's next full resync repopulates
 the rows with `host_id` set to the currently-paired host.
+
+## setup-staging-reseed-host.sh
+
+Provisions the **staging** host (`stovepipes`) for the develop→staging
+auto-reseed: installs the three reseed scripts to `/usr/local/sbin`
+(`root:root`, `0755`) and grants the staging GitHub Actions runner the
+**two** NOPASSWD sudoers lines it invokes from `deploy-staging.yml`:
+
+```
+<RUNNER_USER> ALL=(root) NOPASSWD: /usr/local/sbin/staging-reseed.sh
+<RUNNER_USER> ALL=(root) NOPASSWD: /usr/local/sbin/staging-deployed-sha.sh
+```
+
+`staging-reset.sh` is installed too (it is `exec`'d by
+`staging-reseed.sh`, already root) but gets **no** sudoers line — the
+runner never sudo-invokes it directly, so only the two wrappers it
+actually calls are granted. The sudoers lines are **args-free** (any-args
+form; both wrappers ignore args and `staging-deployed-sha.sh` is
+read-only) and carry **no** `SETENV`/`env_keep`, preserving the env-trust
+seam that pins the staging tenant identity inside the wrappers (sudo
+resets the environment; nothing is passed from the workflow).
+
+**When to run:** once, on the staging host, after the staging code-deploy
+standup is complete and before the first seed-touching staging deploy is
+expected to actually reseed.
+
+**Preconditions (fail-loud):** must run as root; the staging runner user
+must exist (default `gha-runner`; override with `RUNNER_USER=…` — the
+account the `[self-hosted, staging]` agent runs as); and
+`/usr/local/sbin/deploy-staging.sh` must already be installed (this
+script does **not** install it — a host missing it is only partially
+stood up, so the script refuses). This is the **staging** standup, not
+the Pi/prod runner install — the runbook
+(`infra/runner-installation-runbook.md`) is only a *pattern reference*
+for the `install`/`visudo` mechanics; staging differs (`[self-hosted,
+staging]` label, `deploy-staging.sh`, the reseed wrappers).
+
+**Usage:**
+```bash
+# On the staging host, from a repo checkout:
+sudo scripts/admin/setup-staging-reseed-host.sh
+
+# With a non-default runner account:
+sudo RUNNER_USER=my-runner scripts/admin/setup-staging-reseed-host.sh
+```
+
+The script is idempotent (install overwrites in place; the sudoers
+drop-in is a fixed-name file overwritten atomically — no appends, no
+duplicate lines) and safe to re-run. The sudoers drop-in is validated
+with `visudo -cf` before install and re-validated after.
 
 ## Same-host reinstall (no script needed)
 

--- a/scripts/admin/setup-staging-reseed-host.sh
+++ b/scripts/admin/setup-staging-reseed-host.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+# setup-staging-reseed-host.sh — provision the staging host for auto-reseed.
+#
+# Installs the three staging reseed scripts to /usr/local/sbin (root:root, 0755)
+# and grants the GitHub Actions staging runner the TWO NOPASSWD sudoers lines it
+# needs to drive the reseed from deploy-staging.yml:
+#   <RUNNER_USER> ALL=(root) NOPASSWD: /usr/local/sbin/staging-reseed.sh
+#   <RUNNER_USER> ALL=(root) NOPASSWD: /usr/local/sbin/staging-deployed-sha.sh
+# staging-reset.sh is installed too (it is exec'd by staging-reseed.sh, already
+# root) but gets NO sudoers line — the runner never sudo-invokes it directly.
+#
+# Safe, idempotent, fail-loud: install(1) overwrites in place (owner/mode set every
+# run, no appends), the sudoers drop-in is a fixed-name file overwritten atomically
+# (no duplicate lines), and every precondition failure exits non-zero with an
+# actionable message. The sudoers lines carry NO SETENV/env_keep, preserving the
+# env-trust seam that pins the tenant identity inside the wrappers (sudo resets env).
+#
+# CONTEXT: this is STAGING, not the Pi/prod runbook. The runner is a
+# `[self-hosted, staging]` agent whose user runs deploy-staging.sh. This script does
+# NOT create the runner user or install deploy-staging.sh (part of the earlier
+# staging code-deploy standup) — it ASSERTS both and refuses loudly if either is
+# missing, so a partial standup is caught before the first seed-touching deploy.
+#
+# Usage (on the staging host, from a repo checkout):
+#   sudo scripts/admin/setup-staging-reseed-host.sh
+#   sudo RUNNER_USER=my-runner scripts/admin/setup-staging-reseed-host.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# Runner account the sudoers capability is granted to. Overridable in case the
+# staging runner account name differs from the prod one.
+RUNNER_USER="${RUNNER_USER:-gha-runner}"
+# Install destination + sudoers dir. Real defaults; overridable so the test can
+# redirect without root. The sudoers LINES always reference the canonical
+# /usr/local/sbin path (that is what the runner sudo-invokes at runtime).
+USRLOCALSBIN="${USRLOCALSBIN:-/usr/local/sbin}"
+SUDOERSD="${SUDOERSD:-/etc/sudoers.d}"
+
+SUDOERS_DROPIN="$SUDOERSD/gha-runner-staging-reseed"
+# The three scripts installed to /usr/local/sbin. Only the two wrappers the runner
+# sudo-invokes get a sudoers line (see build_sudoers); staging-reset.sh does not.
+INSTALL_SCRIPTS=(staging-reset.sh staging-reseed.sh staging-deployed-sha.sh)
+
+die() { echo "setup-staging-reseed-host: $*" >&2; exit 1; }
+
+# --- Preconditions (fail-loud) -------------------------------------------------
+
+[ "$(id -u)" -eq 0 ] || die "must run as root — re-run: sudo RUNNER_USER=$RUNNER_USER scripts/admin/setup-staging-reseed-host.sh"
+
+command -v install >/dev/null 2>&1 || die "'install' not found on PATH"
+command -v visudo  >/dev/null 2>&1 || die "'visudo' not found on PATH"
+
+if ! id "$RUNNER_USER" >/dev/null 2>&1; then
+    die "runner user '$RUNNER_USER' does not exist. Create/confirm the STAGING runner user (default 'gha-runner'; override with RUNNER_USER=...) — the account the [self-hosted, staging] GitHub Actions agent runs as. This is the staging standup, NOT the Pi/prod runbook."
+fi
+
+# deploy-staging.sh belongs to the earlier staging code-deploy standup; this script
+# does NOT install it. A host missing it is not fully stood up — refuse rather than
+# leave a partial setup.
+[ -f "$USRLOCALSBIN/deploy-staging.sh" ] || die "$USRLOCALSBIN/deploy-staging.sh is not installed. Complete the staging code-deploy provisioning first (this script only adds the reseed scripts + sudoers)."
+
+for name in "${INSTALL_SCRIPTS[@]}"; do
+    src="$REPO_ROOT/scripts/$name"
+    [ -r "$src" ] || die "source script not found or unreadable: $src"
+done
+
+# --- Install the scripts (idempotent: install overwrites + sets owner/mode) -----
+
+echo "Installing reseed scripts to $USRLOCALSBIN (root:root, 0755)..."
+for name in "${INSTALL_SCRIPTS[@]}"; do
+    install -o root -g root -m 0755 "$REPO_ROOT/scripts/$name" "$USRLOCALSBIN/$name"
+    echo "  installed $name"
+done
+
+# --- Sudoers drop-in (idempotent: fixed name, atomic overwrite, validated) ------
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+# Two args-free NOPASSWD lines, NO SETENV/env_keep. The paths are the canonical
+# runtime locations the runner sudo-invokes from deploy-staging.yml.
+{
+    printf '%s ALL=(root) NOPASSWD: /usr/local/sbin/staging-reseed.sh\n' "$RUNNER_USER"
+    printf '%s ALL=(root) NOPASSWD: /usr/local/sbin/staging-deployed-sha.sh\n' "$RUNNER_USER"
+} > "$tmp"
+chmod 0440 "$tmp"
+
+echo "Validating sudoers drop-in..."
+visudo -cf "$tmp" || die "generated sudoers file failed validation; refusing to install it"
+
+install -o root -g root -m 0440 "$tmp" "$SUDOERS_DROPIN"
+echo "  installed $SUDOERS_DROPIN"
+
+echo "Re-validating the installed sudoers drop-in..."
+visudo -cf "$SUDOERS_DROPIN" || die "installed sudoers file failed re-validation"
+
+# --- Post-checks (fail-loud, non-destructive) ----------------------------------
+
+echo "Verifying installed scripts..."
+for name in "${INSTALL_SCRIPTS[@]}"; do
+    dest="$USRLOCALSBIN/$name"
+    meta="$(stat -c '%U %G %a' "$dest")" || die "post-check: cannot stat $dest"
+    [ "$meta" = "root root 755" ] || die "post-check: $dest has wrong owner/mode '$meta' (want 'root root 755')"
+    echo "  ok: $dest ($meta)"
+done
+
+echo "Installed sudoers drop-in ($SUDOERS_DROPIN):"
+cat "$SUDOERS_DROPIN"
+
+echo "Done. The staging runner ($RUNNER_USER) can now drive the auto-reseed."

--- a/scripts/admin/setup-staging-reseed-host.sh
+++ b/scripts/admin/setup-staging-reseed-host.sh
@@ -40,7 +40,8 @@ SUDOERSD="${SUDOERSD:-/etc/sudoers.d}"
 
 SUDOERS_DROPIN="$SUDOERSD/gha-runner-staging-reseed"
 # The three scripts installed to /usr/local/sbin. Only the two wrappers the runner
-# sudo-invokes get a sudoers line (see build_sudoers); staging-reset.sh does not.
+# sudo-invokes get a sudoers line (the two NOPASSWD lines written below);
+# staging-reset.sh does not.
 INSTALL_SCRIPTS=(staging-reset.sh staging-reseed.sh staging-deployed-sha.sh)
 
 die() { echo "setup-staging-reseed-host: $*" >&2; exit 1; }

--- a/scripts/admin/setup-staging-reseed-host.sh.test.sh
+++ b/scripts/admin/setup-staging-reseed-host.sh.test.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# Tests for setup-staging-reseed-host.sh — the staging reseed provisioning helper.
+#
+# PATH-shadowed stubs (id/install/visudo/stat) + sandbox destination dirs
+# (USRLOCALSBIN/SUDOERSD seams) so the install + sudoers writes happen without root.
+# The install stub records its argv AND copies src->dst so the generated sudoers
+# drop-in is real and its content can be asserted. Covers: the 3-script install
+# (root:root/0755), the exactly-2 args-free sudoers lines (no SETENV/env_keep), the
+# $RUNNER_USER principal (default + override), visudo ordering, the fail-loud
+# preconditions, and idempotency.
+#
+# Portability: no BSD-only stat -f / sed -i.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/admin/setup-staging-reseed-host.sh"
+
+PASS=0
+FAIL=0
+fail() { echo "  FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+ok()   { PASS=$((PASS + 1)); }
+
+make_sandbox() {
+    SANDBOX="$(mktemp -d)"
+    CALL_LOG="$SANDBOX/calls.log"
+    : > "$CALL_LOG"
+    mkdir -p "$SANDBOX/bin" "$SANDBOX/sbin" "$SANDBOX/sudoers.d"
+    # deploy-staging.sh is a precondition (installed by the earlier standup).
+    echo '#!/bin/bash' > "$SANDBOX/sbin/deploy-staging.sh"
+
+    cat > "$SANDBOX/bin/id" <<EOF
+#!/usr/bin/env bash
+echo "id \$*" >> "$CALL_LOG"
+if [ "\$1" = "-u" ]; then
+    if [ "\${STUB_NOT_ROOT:-0}" = "1" ]; then echo 1000; else echo 0; fi
+    exit 0
+fi
+# id <user>: exit 0 only for a KNOWN runner account.
+case "\$1" in
+    gha-runner|custom-runner) exit 0 ;;
+    *) exit 1 ;;
+esac
+EOF
+
+    # install stub: record argv, then copy the last two positional args (src dst)
+    # so the sudoers drop-in is a real file whose content the test can assert.
+    cat > "$SANDBOX/bin/install" <<EOF
+#!/usr/bin/env bash
+echo "install \$*" >> "$CALL_LOG"
+args=("\$@")
+n=\${#args[@]}
+# cp -f mimics install(1)'s atomic replace: overwrite even a 0440 dest (a plain
+# cp cannot reopen a read-only file, which would break the idempotent second run).
+cp -f "\${args[\$((n-2))]}" "\${args[\$((n-1))]}"
+EOF
+
+    cat > "$SANDBOX/bin/visudo" <<EOF
+#!/usr/bin/env bash
+echo "visudo \$*" >> "$CALL_LOG"
+exit "\${STUB_VISUDO_RC:-0}"
+EOF
+
+    cat > "$SANDBOX/bin/stat" <<EOF
+#!/usr/bin/env bash
+echo "stat \$*" >> "$CALL_LOG"
+echo "root root 755"
+exit 0
+EOF
+
+    chmod +x "$SANDBOX"/bin/*
+}
+
+cleanup_sandbox() { [ -n "${SANDBOX:-}" ] && rm -rf "$SANDBOX"; }
+
+# run_setup : run the provisioning script with the sandbox stubs + destinations.
+# Caller may prefix env (e.g. RUNNER_USER=custom-runner run_setup, STUB_NOT_ROOT=1).
+run_setup() {
+    PATH="$SANDBOX/bin:$PATH" \
+        USRLOCALSBIN="$SANDBOX/sbin" \
+        SUDOERSD="$SANDBOX/sudoers.d" \
+        bash "$SCRIPT" >/dev/null 2>"$SANDBOX/stderr"
+    RC=$?
+}
+
+DROPIN() { echo "$SANDBOX/sudoers.d/gha-runner-staging-reseed"; }
+
+# ===========================================================================
+test_installs_three_scripts_root_0755() {
+    echo "test: installs all 3 scripts with -o root -g root -m 0755"
+    make_sandbox
+    run_setup
+    if [ "$RC" -eq 0 ]; then ok; else fail "happy path should exit 0, got $RC ($(cat "$SANDBOX/stderr"))"; fi
+    local name n
+    for name in staging-reset.sh staging-reseed.sh staging-deployed-sha.sh; do
+        if grep -F 'install ' "$CALL_LOG" | grep -F -- '-o root -g root -m 0755' | grep -q "/sbin/$name"; then ok
+        else fail "must install $name root:root 0755 to the sbin dir"; fi
+    done
+    # Exactly 3 script installs at 0755 (the sudoers install is 0440, not counted).
+    n=$(grep -F 'install ' "$CALL_LOG" | grep -c -- '-m 0755')
+    if [ "$n" -eq 3 ]; then ok; else fail "expected exactly 3 0755 installs, got $n"; fi
+    cleanup_sandbox
+}
+
+test_sudoers_two_lines_no_setenv() {
+    echo "test: sudoers drop-in has exactly 2 args-free NOPASSWD lines, no SETENV/env_keep"
+    make_sandbox
+    run_setup
+    local f n
+    f="$(DROPIN)"
+    if [ -f "$f" ]; then ok; else fail "sudoers drop-in not written to $f"; cleanup_sandbox; return; fi
+    n=$(grep -c 'NOPASSWD:' "$f")
+    if [ "$n" -eq 2 ]; then ok; else fail "expected exactly 2 NOPASSWD lines, got $n"; fi
+    if grep -qF 'NOPASSWD: /usr/local/sbin/staging-reseed.sh' "$f"; then ok; else fail "missing the staging-reseed.sh sudoers line"; fi
+    if grep -qF 'NOPASSWD: /usr/local/sbin/staging-deployed-sha.sh' "$f"; then ok; else fail "missing the staging-deployed-sha.sh sudoers line"; fi
+    # staging-reset.sh must NOT get a sudoers line (the runner never sudo-calls it).
+    if grep -q 'staging-reset.sh' "$f"; then fail "staging-reset.sh must NOT get a sudoers line"; else ok; fi
+    if grep -q 'SETENV' "$f"; then fail "sudoers must NOT contain SETENV"; else ok; fi
+    if grep -q 'env_keep' "$f"; then fail "sudoers must NOT contain env_keep"; else ok; fi
+    cleanup_sandbox
+}
+
+test_sudoers_principal_default_and_override() {
+    echo "test: sudoers principal is \$RUNNER_USER (default gha-runner; override honored)"
+    make_sandbox
+    run_setup
+    local f
+    f="$(DROPIN)"
+    if grep -qE '^gha-runner ALL=' "$f"; then ok; else fail "default principal must be gha-runner"; fi
+    cleanup_sandbox
+    # Override with a KNOWN custom runner: the lines must start with it (proves the
+    # override actually grants the capability to the real account, not a dead knob).
+    make_sandbox
+    RUNNER_USER=custom-runner run_setup
+    f="$(DROPIN)"
+    if [ "$RC" -eq 0 ]; then ok; else fail "override run should exit 0, got $RC ($(cat "$SANDBOX/stderr"))"; fi
+    if grep -qE '^custom-runner ALL=' "$f"; then ok; else fail "override principal must be custom-runner"; fi
+    if grep -qE '^gha-runner ALL=' "$f"; then fail "override must not leave gha-runner as the principal"; else ok; fi
+    cleanup_sandbox
+}
+
+test_visudo_validates_before_install_and_after() {
+    echo "test: visudo -cf runs on the temp file BEFORE the sudoers install, and on the installed file after"
+    make_sandbox
+    run_setup
+    local i_first_visudo i_sudoers_install i_revalidate
+    i_first_visudo=$(grep -nF 'visudo -cf' "$CALL_LOG" | head -1 | cut -d: -f1)
+    i_sudoers_install=$(grep -nF 'install ' "$CALL_LOG" | grep -F 'gha-runner-staging-reseed' | head -1 | cut -d: -f1)
+    i_revalidate=$(grep -nF 'visudo -cf' "$CALL_LOG" | grep -F 'gha-runner-staging-reseed' | head -1 | cut -d: -f1)
+    if [ -n "$i_first_visudo" ] && [ -n "$i_sudoers_install" ] && [ "$i_first_visudo" -lt "$i_sudoers_install" ]; then ok
+    else fail "visudo must validate the temp file BEFORE installing it (first=$i_first_visudo install=$i_sudoers_install)"; fi
+    if [ -n "$i_revalidate" ] && [ -n "$i_sudoers_install" ] && [ "$i_sudoers_install" -lt "$i_revalidate" ]; then ok
+    else fail "visudo must re-validate the installed file AFTER install (install=$i_sudoers_install reval=$i_revalidate)"; fi
+    cleanup_sandbox
+}
+
+test_fail_not_root() {
+    echo "test: fail-loud when not root"
+    make_sandbox
+    STUB_NOT_ROOT=1 run_setup
+    if [ "$RC" -ne 0 ]; then ok; else fail "non-root must fail, got $RC"; fi
+    if grep -q 'must run as root' "$SANDBOX/stderr"; then ok; else fail "must print a root-required message"; fi
+    cleanup_sandbox
+}
+
+test_fail_missing_runner_user() {
+    echo "test: fail-loud when the runner user is absent (staging remediation, not the Pi runbook)"
+    make_sandbox
+    RUNNER_USER=ghost-runner run_setup
+    if [ "$RC" -ne 0 ]; then ok; else fail "missing runner user must fail, got $RC"; fi
+    if grep -q 'self-hosted, staging' "$SANDBOX/stderr"; then ok; else fail "message must reference the staging runner context"; fi
+    cleanup_sandbox
+}
+
+test_fail_missing_deploy_staging() {
+    echo "test: fail-loud when deploy-staging.sh is not installed (partial-standup refusal)"
+    make_sandbox
+    rm -f "$SANDBOX/sbin/deploy-staging.sh"
+    run_setup
+    if [ "$RC" -ne 0 ]; then ok; else fail "missing deploy-staging.sh must fail, got $RC"; fi
+    if grep -q 'deploy-staging.sh' "$SANDBOX/stderr"; then ok; else fail "message must reference deploy-staging.sh"; fi
+    # Must refuse BEFORE writing the sudoers drop-in.
+    if [ -f "$(DROPIN)" ]; then fail "must not write the sudoers drop-in on a partial standup"; else ok; fi
+    cleanup_sandbox
+}
+
+test_fail_missing_source_script() {
+    echo "test: fail-loud when a source script is missing from the checkout"
+    make_sandbox
+    # Build a fake repo checkout missing one of the three source scripts, and run a
+    # copy of the setup script from it (REPO_ROOT resolves relative to its location).
+    local fake="$SANDBOX/fakerepo"
+    mkdir -p "$fake/scripts/admin"
+    cp "$SCRIPT" "$fake/scripts/admin/setup-staging-reseed-host.sh"
+    echo '#!/bin/bash' > "$fake/scripts/staging-reseed.sh"
+    echo '#!/bin/bash' > "$fake/scripts/staging-deployed-sha.sh"
+    # staging-reset.sh deliberately absent.
+    PATH="$SANDBOX/bin:$PATH" \
+        USRLOCALSBIN="$SANDBOX/sbin" \
+        SUDOERSD="$SANDBOX/sudoers.d" \
+        bash "$fake/scripts/admin/setup-staging-reseed-host.sh" >/dev/null 2>"$SANDBOX/stderr"
+    RC=$?
+    if [ "$RC" -ne 0 ]; then ok; else fail "missing source script must fail, got $RC"; fi
+    if grep -q 'staging-reset.sh' "$SANDBOX/stderr"; then ok; else fail "message must name the missing source script"; fi
+    cleanup_sandbox
+}
+
+test_idempotent_second_run() {
+    echo "test: running twice converges (second run exits 0, sudoers still exactly 2 lines)"
+    make_sandbox
+    run_setup
+    local first_rc="$RC" f n
+    run_setup
+    f="$(DROPIN)"
+    if [ "$first_rc" -eq 0 ] && [ "$RC" -eq 0 ]; then ok; else fail "both runs must exit 0 (first=$first_rc second=$RC)"; fi
+    n=$(grep -c 'NOPASSWD:' "$f")
+    if [ "$n" -eq 2 ]; then ok; else fail "sudoers must still have exactly 2 lines after a second run, got $n"; fi
+    cleanup_sandbox
+}
+
+# ---------------------------------------------------------------------------
+main() {
+    test_installs_three_scripts_root_0755
+    test_sudoers_two_lines_no_setenv
+    test_sudoers_principal_default_and_override
+    test_visudo_validates_before_install_and_after
+    test_fail_not_root
+    test_fail_missing_runner_user
+    test_fail_missing_deploy_staging
+    test_fail_missing_source_script
+    test_idempotent_second_run
+
+    echo ""
+    echo "===================="
+    echo "PASS=$PASS FAIL=$FAIL"
+    echo "===================="
+    [ "$FAIL" -eq 0 ]
+}
+
+main "$@"

--- a/scripts/ci/path-filters-parity-guard.sh
+++ b/scripts/ci/path-filters-parity-guard.sh
@@ -9,7 +9,7 @@ grep -q 'filters: ./path-filters.yml' .github/workflows/ci.yml \
   || { echo "FAIL: ci.yml changes job must use filters: ./path-filters.yml"; exit 1; }
 grep -qE '^\s*filters:\s*\|' .github/workflows/ci.yml \
   && { echo "FAIL: ci.yml reintroduced an inline filters block"; exit 1; } || true
-for g in backend frontend mac_daemon seed; do
+for g in backend frontend mac_daemon seed migrations; do
   grep -qE "^${g}:" path-filters.yml || { echo "FAIL: path-filters.yml missing group $g"; exit 1; }
 done
 echo "OK: path-filter parity"

--- a/scripts/ci/staging-reseed-decision.sh
+++ b/scripts/ci/staging-reseed-decision.sh
@@ -13,8 +13,9 @@
 #                       trigger a reseed. The exclusion lives below, not in
 #                       path-filters.yml, which is LCD (flat globs, NO negation) and
 #                       cannot express "synthetic/** except tests".
-#   migrations_changed  any changed file is under backend/migrations/ -> nudge only
-#                       (migrations transform the accumulated world; never auto-wipe).
+#   migrations_changed  a changed file is in the `migrations` path-filters group
+#                       (backend/migrations/**) -> nudge only (migrations transform
+#                       the accumulated world; never auto-wipe).
 #   base_known          true iff BASE was a resolvable commit and the diff ran.
 #
 # TWO-DOT `git diff BASE HEAD` (direct tree-vs-tree), NOT three-dot (BASE...HEAD,
@@ -99,9 +100,11 @@ while IFS= read -r f; do
       *) seed_changed=true ;;  # runtime synthetic file (profiles.go, factory/*.go, ...)
     esac
   fi
-  case "$f" in
-    backend/migrations/*) migrations_changed=true ;;
-  esac
+  # migrations_changed is sourced from the same path-filters.yml group matcher as
+  # seed_changed (no second hardcoded prefix): backend/migrations/** -> nudge only.
+  if file_in_group "$f" migrations; then
+    migrations_changed=true
+  fi
 done <<< "$changed"
 
 emit seed_changed "$seed_changed"

--- a/scripts/ci/staging-reseed-decision.test.sh
+++ b/scripts/ci/staging-reseed-decision.test.sh
@@ -84,11 +84,19 @@ make_fixture() {
         git commit -q -m "synthetic runtime change"
         C6="$(git rev-parse HEAD)"
 
-        printf '%s\n%s\n%s\n%s\n%s\n%s\n%s\n' "$C0" "$C1" "$C2" "$C3" "$C4" "$C5" "$C6" > shas.txt
+        # NESTED migration path — proves the `migrations` group's ** glob matches at
+        # depth (equivalence with the old backend/migrations/* prefix case + depth).
+        mkdir -p backend/migrations/subdir
+        echo "-- up" > backend/migrations/subdir/075_y.up.sql
+        git add backend/migrations/subdir/075_y.up.sql
+        git commit -q -m "nested migration change"
+        C7="$(git rev-parse HEAD)"
+
+        printf '%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n' "$C0" "$C1" "$C2" "$C3" "$C4" "$C5" "$C6" "$C7" > shas.txt
     )
     # Portable read (no bash-4 mapfile): the commit SHAs are set in the subshell,
     # so read them back from the fixture file, one per line.
-    { read -r C0; read -r C1; read -r C2; read -r C3; read -r C4; read -r C5; read -r C6; } < "$FIXTURE/shas.txt"
+    { read -r C0; read -r C1; read -r C2; read -r C3; read -r C4; read -r C5; read -r C6; read -r C7; } < "$FIXTURE/shas.txt"
 }
 
 cleanup_fixture() { [ -n "${FIXTURE:-}" ] && rm -rf "$FIXTURE"; }
@@ -197,6 +205,17 @@ test_mixed_runtime_and_test_reseed() {
     cleanup_fixture
 }
 
+test_migration_nested_path() {
+    echo "test: nested migration path (backend/migrations/subdir/...) -> migrations_changed=true (** depth)"
+    make_fixture
+    run_decision "$C6" "$C7"
+    if [ "$RC" -eq 0 ]; then ok; else fail "must exit 0, got $RC"; fi
+    assert_flag migrations_changed true
+    assert_flag seed_changed false
+    assert_flag base_known true
+    cleanup_fixture
+}
+
 test_empty_base() {
     echo "test: empty BASE -> base_known=false, seed_changed=false, exit 0"
     make_fixture
@@ -229,6 +248,7 @@ main() {
     test_test_and_testdata_only_no_reseed
     test_runtime_synthetic_reseed
     test_mixed_runtime_and_test_reseed
+    test_migration_nested_path
     test_empty_base
     test_base_not_in_history
 

--- a/scripts/deploy-staging.test.sh
+++ b/scripts/deploy-staging.test.sh
@@ -267,7 +267,7 @@ test_workflow_nudge_conditions() {
 }
 
 # ===========================================================================
-# D6: workflow_dispatch force_reseed (manual, reseed-only, develop-ref-only)
+# workflow_dispatch force_reseed (manual, reseed-only, develop-ref-only)
 # ===========================================================================
 
 test_workflow_has_dispatch_trigger() {
@@ -299,11 +299,24 @@ test_dispatch_false_is_noop() {
     if wf_has 'echo "deploy_ready=false"'; then ok; else fail "dispatch branch must be able to set deploy_ready=false"; fi
 }
 
+# step_block_has_dispatch_guard <name-substr> : true iff the step whose "- name:"
+# line contains <name-substr> carries the dispatch-skip guard BEFORE the next step.
+# Anchoring per-step (not a raw occurrence count) catches an unguarded step even if
+# another guard is duplicated/commented elsewhere.
+step_block_has_dispatch_guard() {
+    awk -v want="$1" '
+        /^[[:space:]]*- name:/ { in_blk = (index($0, want) > 0) }
+        in_blk && index($0, "github.event_name !=") > 0 && index($0, "workflow_dispatch") > 0 { found = 1 }
+        END { exit(found ? 0 : 1) }
+    ' "$WORKFLOW"
+}
+
 test_deploy_steps_skip_on_dispatch() {
-    echo "test: capture/deploy/checkout/decide steps skip on a workflow_dispatch"
-    local n
-    n=$(grep -cF "github.event_name != 'workflow_dispatch'" "$WORKFLOW")
-    if [ "$n" -ge 4 ]; then ok; else fail "expected >=4 deploy-only step-skip guards, got $n"; fi
+    echo "test: capture/deploy/checkout/decide steps EACH carry the workflow_dispatch skip guard"
+    if step_block_has_dispatch_guard "Capture live staging SHA"; then ok; else fail "capture step must skip on workflow_dispatch"; fi
+    if step_block_has_dispatch_guard "name: Deploy"; then ok; else fail "deploy step must skip on workflow_dispatch"; fi
+    if step_block_has_dispatch_guard "Checkout (post-deploy"; then ok; else fail "checkout step must skip on workflow_dispatch"; fi
+    if step_block_has_dispatch_guard "Decide reseed"; then ok; else fail "decide step must skip on workflow_dispatch"; fi
 }
 
 test_reseed_fires_on_force() {

--- a/scripts/deploy-staging.test.sh
+++ b/scripts/deploy-staging.test.sh
@@ -166,8 +166,11 @@ test_workflow_three_way_gate_and_job_split() {
     if wf_has "deploy_ready:"; then ok; else fail "gate job must expose a deploy_ready output"; fi
     if wf_has "needs.gate.outputs.deploy_ready == 'true'"; then ok
     else fail "deploy job must gate on needs.gate.outputs.deploy_ready == 'true'"; fi
-    # environment: staging attaches to exactly one job (the deploy job), so a
-    # green-skipping gate can't record a phantom Environment deployment.
+    # environment: staging attaches to exactly one job (the deploy job), so it is
+    # recorded only for a real staging mutation (a code deploy or a manual reseed) —
+    # never for a green-skip. A force_reseed=false dispatch never starts the deploy
+    # job, so no phantom Environment deployment is recorded. The exactly-once count
+    # assertion below stays green (no second environment: is added).
     if wf_has "environment: staging"; then ok; else fail "deploy job must set environment: staging"; fi
     local n_env
     n_env=$(grep -cE '^[[:space:]]*environment:' "$WORKFLOW")
@@ -263,6 +266,58 @@ test_workflow_nudge_conditions() {
     if wf_has "env.base_known == 'false'"; then ok; else fail "no-base nudge must fire on base_known == 'false'"; fi
 }
 
+# ===========================================================================
+# D6: workflow_dispatch force_reseed (manual, reseed-only, develop-ref-only)
+# ===========================================================================
+
+test_workflow_has_dispatch_trigger() {
+    echo "test: workflow declares a workflow_dispatch trigger with a boolean force_reseed input"
+    if wf_has "workflow_dispatch:"; then ok; else fail "workflow must declare workflow_dispatch:"; fi
+    if wf_has "force_reseed:"; then ok; else fail "workflow_dispatch must expose a force_reseed input"; fi
+    if wf_has "type: boolean"; then ok; else fail "force_reseed input must be type: boolean"; fi
+}
+
+test_gate_handles_dispatch() {
+    echo "test: gate job allows the dispatch event and the gate step branches on it"
+    if wf_has "github.event_name == 'workflow_dispatch'"; then ok; else fail "gate if: must allow the workflow_dispatch event"; fi
+    if grep -qF 'if [ "${{ github.event_name }}" = "workflow_dispatch" ]' "$WORKFLOW"; then ok
+    else fail "gate step must branch at the top on the workflow_dispatch event"; fi
+}
+
+test_dispatch_is_develop_only() {
+    echo "test: a workflow_dispatch is develop-ref-only (gate if: conjoins the ref check)"
+    if grep -qF "github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/develop'" "$WORKFLOW"; then ok
+    else fail "gate if: must require github.ref == 'refs/heads/develop' on the dispatch path"; fi
+}
+
+test_dispatch_false_is_noop() {
+    echo "test: gate ties deploy_ready to force_reseed so an unchecked box is a true no-op"
+    if grep -qF 'if [ "${{ github.event.inputs.force_reseed }}" = "true" ]' "$WORKFLOW"; then ok
+    else fail "gate step must branch deploy_ready on github.event.inputs.force_reseed"; fi
+    # Both deploy_ready values must be reachable from the dispatch branch.
+    if wf_has 'echo "deploy_ready=true"'; then ok; else fail "dispatch branch must be able to set deploy_ready=true"; fi
+    if wf_has 'echo "deploy_ready=false"'; then ok; else fail "dispatch branch must be able to set deploy_ready=false"; fi
+}
+
+test_deploy_steps_skip_on_dispatch() {
+    echo "test: capture/deploy/checkout/decide steps skip on a workflow_dispatch"
+    local n
+    n=$(grep -cF "github.event_name != 'workflow_dispatch'" "$WORKFLOW")
+    if [ "$n" -ge 4 ]; then ok; else fail "expected >=4 deploy-only step-skip guards, got $n"; fi
+}
+
+test_reseed_fires_on_force() {
+    echo "test: the Auto-reseed step fires on force_reseed==true (in addition to seed_changed)"
+    if wf_has "force_reseed == 'true'"; then ok; else fail "Auto-reseed if: must include force_reseed == 'true'"; fi
+    if wf_has "env.seed_changed == 'true'"; then ok; else fail "Auto-reseed if: must keep seed_changed == 'true'"; fi
+}
+
+test_oauth_breadcrumb_covers_force() {
+    echo "test: the OAuth-skip breadcrumb also fires on a forced reseed"
+    if grep -qF "always() && (env.seed_changed == 'true' || (github.event_name == 'workflow_dispatch' && github.event.inputs.force_reseed == 'true'))" "$WORKFLOW"; then ok
+    else fail "OAuth-skip if: must broaden to cover the force_reseed dispatch path"; fi
+}
+
 # ---------------------------------------------------------------------------
 main() {
     test_wrapper_forces_tenant_and_forwards_sha
@@ -283,6 +338,13 @@ main() {
     test_workflow_decision_inline_fallback
     test_workflow_single_job_no_decision_job_no_deployments
     test_workflow_nudge_conditions
+    test_workflow_has_dispatch_trigger
+    test_gate_handles_dispatch
+    test_dispatch_is_develop_only
+    test_dispatch_false_is_noop
+    test_deploy_steps_skip_on_dispatch
+    test_reseed_fires_on_force
+    test_oauth_breadcrumb_covers_force
 
     echo ""
     echo "===================="

--- a/scripts/hooks/test/test-pre-push-filters.sh
+++ b/scripts/hooks/test/test-pre-push-filters.sh
@@ -80,6 +80,17 @@ assert_in_group     "backend/internal/synthetic/profiles.go" backend
 assert_not_in_group "backend/internal/api/handlers/contact.go" seed
 assert_not_in_group "backend/migrations/074_x.up.sql" seed
 
+# --- migrations group: the staging reseed-decision schema-change surface ---
+# Migrations at the top level and at depth are in the migrations group (** depth).
+assert_in_group     "backend/migrations/074_x.up.sql" migrations
+assert_in_group     "backend/migrations/subdir/075_y.up.sql" migrations
+# Orthogonality: a migration is ALSO in backend, so the migrations group changes no
+# Go/frontend test selection (it is a separate classification consumed only by the
+# reseed decision).
+assert_in_group     "backend/migrations/074_x.up.sql" backend
+# Non-migration backend code is NOT in the migrations group.
+assert_not_in_group "backend/internal/api/handlers/contact.go" migrations
+
 # --- any_file_in_groups: the Go/frontend gate's decision boundary ---
 # Daemon-only push does NOT run Go suite (headline invariant).
 assert_false "any_file_in_groups daemon-only -> Go suite NOT run" \

--- a/scripts/staging-reset.sh
+++ b/scripts/staging-reset.sh
@@ -90,11 +90,17 @@ else
     CRM_UID=$(ssh "$STAGING_HOST" "id -u $CRM_USER")
     USERENV="HOME=$CRM_HOME XDG_RUNTIME_DIR=/run/user/$CRM_UID DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$CRM_UID/bus"
     # Vars below deliberately expand client-side (resolved here, then sent over ssh
-    # as a literal remote command). SC2029 is the intended behavior.
+    # as a literal remote command). SC2029 is the intended behavior. Caller args are
+    # quoted per-arg with printf '%q' so the remote shell rebuilds the exact argv
+    # after its single parse — otherwise $* would flatten e.g. a quoted SQL string
+    # into bare words that the remote shell re-splits (SELECT count(*) FROM ...). The
+    # guarantee is scoped to the arg shapes these helpers pass (SQL strings,
+    # systemctl/podman subcommands, unit names — no control chars); %q emits plain
+    # backslash-escaping any POSIX shell reconstructs, not $'...' ANSI-C quoting.
     # shellcheck disable=SC2029
-    staging_ctl()    { ssh "$STAGING_HOST" "cd /tmp && sudo -n -u $CRM_USER $USERENV systemctl --user $*"; }
+    staging_ctl()    { local a; a="$(printf '%q ' "$@")"; ssh "$STAGING_HOST" "cd /tmp && sudo -n -u $CRM_USER $USERENV systemctl --user $a"; }
     # shellcheck disable=SC2029
-    staging_podman() { ssh "$STAGING_HOST" "cd /tmp && sudo -n -u $CRM_USER HOME=$CRM_HOME XDG_RUNTIME_DIR=/run/user/$CRM_UID podman $*"; }
+    staging_podman() { local a; a="$(printf '%q ' "$@")"; ssh "$STAGING_HOST" "cd /tmp && sudo -n -u $CRM_USER HOME=$CRM_HOME XDG_RUNTIME_DIR=/run/user/$CRM_UID podman $a"; }
     # shellcheck disable=SC2029
     read_crm_env()   { ssh "$STAGING_HOST" "sudo -n -u $CRM_USER sed -n 's/^CRM_ENV=//p' '$ENV_FILE' 2>/dev/null | head -1"; }
     # shellcheck disable=SC2029

--- a/scripts/staging-reset.test.sh
+++ b/scripts/staging-reset.test.sh
@@ -132,7 +132,14 @@ case "\$all" in
   *"id -u staging"*) echo $STAGING_UID; exit 0 ;;
   *"s/^CRM_ENV=//p"*) echo "\${STUB_CRM_ENV:-staging}"; exit 0 ;;
   *"s/^Image=//p"*)   echo "\${STUB_IMAGE_REF:-$SHA_REF}"; exit 0 ;;
+  *"s/^DATABASE_URL=//p"*) echo "\${STUB_DATABASE_URL:-postgres://crm_user:x@crm-postgres:5432/personal_crm}"; exit 0 ;;
   *"test -e"*) exit "\${STUB_ENV_MISSING:-0}" ;;
+  # podman exec ... psql ... oauth_credential (the ssh-mode oauth count). The SQL
+  # arrives %q-escaped in the remote command; match on the literal table name.
+  *oauth_credential*)
+    if [ "\${STUB_OAUTH_PSQL_FAIL:-0}" = "1" ]; then exit 1; fi
+    echo "\${STUB_OAUTH_COUNT:-0}"
+    exit "\${STUB_OAUTH_PSQL_RC:-0}" ;;
   *systemctl*) if [ "\${STUB_STOP_FAIL:-0}" = "1" ] && [[ "\$all" == *stop* ]]; then exit 1; fi; exit 0 ;;
   *"podman run"*) if [[ "\$all" == *--reset-and-seed* ]]; then exit "\${STUB_RESET_RC:-0}"; fi; exit 0 ;;
   *) exit 0 ;;
@@ -174,6 +181,18 @@ run_local_oauth() {
         STAGING_ENV_FILE="$SANDBOX/staging.env" \
         STAGING_BACKEND_UNIT="$SANDBOX/backend.container" \
         bash "$SCRIPT" --local --require-oauth-empty >/dev/null 2>"$SANDBOX/stderr"
+    RC=$?
+}
+
+# run_ssh_oauth : ssh mode + --require-oauth-empty (the auto path over ssh). The
+# ssh stub answers the DATABASE_URL read and the oauth_credential count so the
+# guard reaches the count instead of REFUSING on a missing DATABASE_URL first.
+run_ssh_oauth() {
+    PATH="$SANDBOX/bin:$PATH" \
+        STAGING_HOST=stovepipes \
+        STAGING_ENV_FILE=/srv/personalcrm/.env \
+        STAGING_BACKEND_UNIT=/var/lib/staging/.config/containers/systemd/personalcrm-backend.container \
+        bash "$SCRIPT" --require-oauth-empty >/dev/null 2>"$SANDBOX/stderr"
     RC=$?
 }
 
@@ -339,6 +358,31 @@ test_ssh_targets_host() {
     if grep -E '^ssh ' "$CALL_LOG" | grep -F -- '--reset-and-seed' | grep -q "$SHA_REF"; then ok
     else fail "ssh reset must run the pinned ref on the host"; fi
     if grep -E '^ssh ' "$CALL_LOG" | grep -q 'sudo -n -u staging'; then ok; else fail "ssh remote ops must use sudo -n -u staging"; fi
+    # staging_ctl args survive the %q per-arg quoting: a single-token unit name is
+    # unchanged, so the recorded systemctl remote command carries it verbatim.
+    if grep -E '^ssh ' "$CALL_LOG" | grep -F 'systemctl --user' | grep -q 'personalcrm-backend.service'; then ok
+    else fail "ssh staging_ctl must carry the unit name into the systemctl remote command"; fi
+    cleanup_sandbox
+}
+
+test_ssh_oauth_count_preserves_sql() {
+    echo "test: ssh oauth-count SQL survives the remote shell parse as ONE argument"
+    make_sandbox
+    STUB_CRM_ENV=staging STUB_OAUTH_COUNT=0 run_ssh_oauth
+    if [ "$RC" -eq 0 ]; then ok; else fail "ssh oauth-empty should proceed (exit 0), got $RC ($(cat "$SANDBOX/stderr"))"; fi
+    local line sql_part n arg
+    line="$(grep -F 'oauth_credential' "$CALL_LOG" | grep -F 'psql' | head -1)"
+    if [ -n "$line" ]; then ok; else fail "no ssh oauth_credential count recorded"; cleanup_sandbox; return; fi
+    # Everything after the -tAc flag is the single SQL argument, %q-escaped so ONE
+    # remote-shell parse rebuilds it. Assert the post-parse argv (not the raw %q
+    # bytes, which vary across bash versions): the old $* form would parse into 4
+    # tokens (SELECT / count(*) / FROM / oauth_credential); the fix yields exactly 1.
+    sql_part="${line#*-tAc }"
+    ( eval "set -- $sql_part"; printf 'count=%s\n' "$#"; printf 'arg=%s\n' "$1" ) > "$SANDBOX/parsed"
+    n="$(grep '^count=' "$SANDBOX/parsed" | cut -d= -f2)"
+    arg="$(grep '^arg=' "$SANDBOX/parsed" | cut -d= -f2-)"
+    if [ "$n" = "1" ]; then ok; else fail "SQL must reconstruct as exactly 1 arg, got $n (sql_part='$sql_part')"; fi
+    if [ "$arg" = "SELECT count(*) FROM oauth_credential" ]; then ok; else fail "reconstructed SQL wrong: '$arg'"; fi
     cleanup_sandbox
 }
 
@@ -477,6 +521,7 @@ main() {
     test_reset_failure_restarts
     test_local_does_not_ssh
     test_ssh_targets_host
+    test_ssh_oauth_count_preserves_sql
     test_ssh_refuses_production
     test_oauth_empty_proceeds
     test_oauth_present_skips


### PR DESCRIPTION
Implements the tracked, non-blocking follow-ups from #566 (auto-reseed staging), per #567. All changes are bash + YAML + one operator script + their tests — no Go/SQL/schema/product-behavior changes.

Closes #567.

## What's in scope (4 items)

**P2 — ssh-mode psql arg quoting (`scripts/staging-reset.sh`).** The ssh-mode `staging_ctl`/`staging_podman` helpers flattened caller args via `$*`, so `oauth_credential_count()`'s quoted SQL (`SELECT count(*) FROM oauth_credential`) would be word-split on the remote side into a broken query. Now each caller arg is quoted per-arg with `printf '%q '` (the established repo idiom) so the remote shell reconstructs the exact argv after its single parse. Latent today (the only caller always runs `--local`, and it fails closed if hit), fixed so the ssh path is correct if ever wired up. Applied to both ssh helpers in this file for parity.

**P3 — `migrations` path-filters group.** `migrations_changed` in `scripts/ci/staging-reseed-decision.sh` was decided by a hardcoded `backend/migrations/*` case; it now routes through `file_in_group "$f" migrations`, mirroring how `seed_changed` is sourced from `path-filters.yml`. Adds a passive `migrations` group (documented as orthogonal to CI/pre-push test selection, exactly like `seed`), the parity-guard loop entry, and `migrations`-group membership assertions in the pre-push filter test.

**D6 — `workflow_dispatch force_reseed` (`.github/workflows/deploy-staging.yml`).** A manual, on-demand reseed trigger from the Actions UI. Develop-ref-only, reseed-only (no code deploy, no CI/build gate — it reseeds against the image already live on the host), and `force_reseed=false` is a true no-op (the deploy job never starts, so no Environment deployment is recorded). The oauth guard in the reseed wrapper still applies — forcing from the UI will not silently wipe a connected sync account.

**Provisioning helper — `scripts/admin/setup-staging-reseed-host.sh`.** A fail-loud, idempotent operator script (run on the staging host) that installs the three staging scripts to `/usr/local/sbin` (root:root, 0755) and writes the two args-free, no-`SETENV` sudoers lines (`$RUNNER_USER`-parameterized, default `gha-runner`). It asserts (does not create) the runner user and an already-installed `deploy-staging.sh`, with staging-specific remediation. Includes a stubbed `.test.sh` wired into `make test-deploy-scripts`, plus a README section.

## Explicitly out of scope
- Tightening the OAuth host-validation `localhost`/`127.0.0.1` allowlist (documented D3 tradeoff, left as-is).
- Actually provisioning the staging host — that's an **operator step**: run `sudo scripts/admin/setup-staging-reseed-host.sh` on `stovepipes` before the next synthetic-runtime-changing deploy is expected to actually reseed.

## Review notes (non-blocking, tracked)
Local Codex review and a fresh-context `/review-head` both passed (P0=0, P1=0). Non-blocking findings, surfaced not fixed:
- **P2 (accepted tradeoff):** an oauth-skipped `force_reseed` dispatch still records a staging Environment deployment. A reseed is a legitimate staging mutation, so the record is truthful; not worth a third job.
- **P2 (deferred):** the same `$*` ssh-helper shape exists in `scripts/backup-db.sh` and `scripts/restore-db.sh` (verified latent, not live). This PR is scoped to `staging-reset.sh` per #567; the siblings are a candidate future follow-up.
- **P3 (cosmetic):** new test-file mode, defense-in-depth on untrusted-input interpolation, fixed sudoers drop-in filename — all acceptable as-is.

## Testing
`make test-deploy-scripts`, `bash scripts/hooks/test/test-pre-push-filters.sh`, and `bash scripts/ci/path-filters-parity-guard.sh` all green.
