### PR TITLE
feat(staging): run reseed-host provisioning from a Mac over ssh

### DIFF
--- a/scripts/admin/README.md
+++ b/scripts/admin/README.md
@@ -84,34 +84,54 @@ read-only) and carry **no** `SETENV`/`env_keep`, preserving the env-trust
 seam that pins the staging tenant identity inside the wrappers (sudo
 resets the environment; nothing is passed from the workflow).
 
-**When to run:** once, on the staging host, after the staging code-deploy
-standup is complete and before the first seed-touching staging deploy is
-expected to actually reseed.
+**When to run:** once, after the staging code-deploy standup is complete
+and before the first seed-touching staging deploy is expected to actually
+reseed.
 
-**Preconditions (fail-loud):** must run as root; the staging runner user
-must exist (default `gha-runner`; override with `RUNNER_USER=…` — the
-account the `[self-hosted, staging]` agent runs as); and
-`/usr/local/sbin/deploy-staging.sh` must already be installed (this
-script does **not** install it — a host missing it is only partially
-stood up, so the script refuses). This is the **staging** standup, not
-the Pi/prod runner install — the runbook
-(`infra/runner-installation-runbook.md`) is only a *pattern reference*
-for the `install`/`visudo` mechanics; staging differs (`[self-hosted,
-staging]` label, `deploy-staging.sh`, the reseed wrappers).
+**Two modes (mirrors `staging-reset.sh`):** there is no repo checkout on
+the staging host, so the **default** mode runs from a dev Mac and
+provisions `STAGING_HOST` (default `stovepipes`) over ssh — it ships the
+installer + the three source scripts to a temp dir on the host and
+re-invokes itself there with `--local` (the temp dir is removed
+afterward). `ssh -t` allocates a TTY so `sudo` can prompt for a password.
+The `--local` mode does the real install/sudoers work on the host itself
+(this is what the ssh mode calls on the far side); run it directly only
+if you already have a checkout on the host.
+
+**Preconditions (fail-loud):**
+- *ssh mode:* `ssh` + `tar` on PATH; the three source scripts present in
+  this checkout; `STAGING_HOST` reachable over ssh.
+- *`--local` mode:* must run as root; the staging runner user must exist
+  (default `gha-runner`; override with `RUNNER_USER=…` — the account the
+  `[self-hosted, staging]` agent runs as); and
+  `/usr/local/sbin/deploy-staging.sh` must already be installed (this
+  script does **not** install it — a host missing it is only partially
+  stood up, so the script refuses).
+
+This is the **staging** standup, not the Pi/prod runner install — the
+runbook (`infra/runner-installation-runbook.md`) is only a *pattern
+reference* for the `install`/`visudo` mechanics; staging differs
+(`[self-hosted, staging]` label, `deploy-staging.sh`, the reseed
+wrappers).
 
 **Usage:**
 ```bash
-# On the staging host, from a repo checkout:
-sudo scripts/admin/setup-staging-reseed-host.sh
+# From a dev Mac (default): provisions STAGING_HOST over ssh
+./scripts/admin/setup-staging-reseed-host.sh
 
-# With a non-default runner account:
-sudo RUNNER_USER=my-runner scripts/admin/setup-staging-reseed-host.sh
+# Non-default host and/or runner account:
+STAGING_HOST=my-staging RUNNER_USER=my-runner ./scripts/admin/setup-staging-reseed-host.sh
+
+# On the staging host itself, from a checkout, as root:
+sudo ./scripts/admin/setup-staging-reseed-host.sh --local
 ```
 
-The script is idempotent (install overwrites in place; the sudoers
-drop-in is a fixed-name file overwritten atomically — no appends, no
-duplicate lines) and safe to re-run. The sudoers drop-in is validated
-with `visudo -cf` before install and re-validated after.
+In ssh mode `RUNNER_USER` is threaded to the host as a `--runner-user`
+flag (args survive `sudo`; env does not — no `SETENV` needed). The script
+is idempotent (install overwrites in place; the sudoers drop-in is a
+fixed-name file overwritten atomically — no appends, no duplicate lines)
+and safe to re-run. The sudoers drop-in is validated with `visudo -cf`
+before install and re-validated after.
 
 ## Same-host reinstall (no script needed)
 

--- a/scripts/admin/setup-staging-reseed-host.sh
+++ b/scripts/admin/setup-staging-reseed-host.sh
@@ -21,17 +21,48 @@
 # staging code-deploy standup) — it ASSERTS both and refuses loudly if either is
 # missing, so a partial standup is caught before the first seed-touching deploy.
 #
-# Usage (on the staging host, from a repo checkout):
-#   sudo scripts/admin/setup-staging-reseed-host.sh
-#   sudo RUNNER_USER=my-runner scripts/admin/setup-staging-reseed-host.sh
+# TWO MODES (mirrors staging-reset.sh):
+#   default (ssh)  Run from a dev Mac against STAGING_HOST (default stovepipes).
+#                  There is no repo checkout on the host, so this ships the
+#                  installer + the three source scripts to a temp dir on the host
+#                  and re-invokes itself there with --local. Uses `ssh -t` so sudo
+#                  can prompt for a password interactively; the temp dir is removed
+#                  afterward. The source of truth is THIS local checkout.
+#   --local        Run on the staging host itself, as root, from a repo checkout
+#                  (the ssh mode calls this on the far side). Does the real install
+#                  + sudoers work described above.
+#
+# Usage:
+#   # from a dev Mac (default): provisions STAGING_HOST over ssh
+#   ./scripts/admin/setup-staging-reseed-host.sh
+#   STAGING_HOST=my-staging RUNNER_USER=my-runner ./scripts/admin/setup-staging-reseed-host.sh
+#   # on the staging host, from a checkout, as root:
+#   sudo ./scripts/admin/setup-staging-reseed-host.sh --local
+#   sudo RUNNER_USER=my-runner ./scripts/admin/setup-staging-reseed-host.sh --local
 
 set -euo pipefail
 
+# --- Args / mode ---------------------------------------------------------------
+LOCAL=false
+RUNNER_USER_FLAG=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --local) LOCAL=true; shift ;;
+        --runner-user)
+            [ $# -ge 2 ] || { echo "setup-staging-reseed-host: --runner-user needs a value" >&2; exit 2; }
+            RUNNER_USER_FLAG="$2"; shift 2 ;;
+        *) echo "setup-staging-reseed-host: unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
-# Runner account the sudoers capability is granted to. Overridable in case the
-# staging runner account name differs from the prod one.
-RUNNER_USER="${RUNNER_USER:-gha-runner}"
+# Runner account the sudoers capability is granted to. Precedence: --runner-user
+# flag (how ssh mode threads it through sudo, which resets env) > RUNNER_USER env >
+# default. Overridable in case the staging runner account name differs from prod.
+RUNNER_USER="${RUNNER_USER_FLAG:-${RUNNER_USER:-gha-runner}}"
+# Staging host targeted in ssh mode. Mirrors staging-reset.sh's default.
+STAGING_HOST="${STAGING_HOST:-stovepipes}"
 # Install destination + sudoers dir. Real defaults; overridable so the test can
 # redirect without root. The sudoers LINES always reference the canonical
 # /usr/local/sbin path (that is what the runner sudo-invokes at runtime).
@@ -46,9 +77,51 @@ INSTALL_SCRIPTS=(staging-reset.sh staging-reseed.sh staging-deployed-sha.sh)
 
 die() { echo "setup-staging-reseed-host: $*" >&2; exit 1; }
 
-# --- Preconditions (fail-loud) -------------------------------------------------
+# --- SSH mode (default): bootstrap onto the host, then run --local there --------
+# There is no repo checkout on the staging host, so ship the installer + the three
+# source scripts over ssh and re-invoke this script with --local on the far side.
+# All the real install/sudoers logic lives in the --local path below (one source of
+# truth); this branch is purely the transport.
+if [ "$LOCAL" != true ]; then
+    command -v ssh >/dev/null 2>&1 || die "'ssh' not found on PATH"
+    command -v tar >/dev/null 2>&1 || die "'tar' not found on PATH"
 
-[ "$(id -u)" -eq 0 ] || die "must run as root — re-run: sudo RUNNER_USER=$RUNNER_USER scripts/admin/setup-staging-reseed-host.sh"
+    # Validate the local sources BEFORE touching the host (friendlier than a remote
+    # failure). The installer itself + the three scripts it installs.
+    [ -r "$REPO_ROOT/scripts/admin/setup-staging-reseed-host.sh" ] \
+        || die "installer not found in this checkout: $REPO_ROOT/scripts/admin/setup-staging-reseed-host.sh"
+    for name in "${INSTALL_SCRIPTS[@]}"; do
+        [ -r "$REPO_ROOT/scripts/$name" ] || die "source script not found or unreadable: $REPO_ROOT/scripts/$name"
+    done
+
+    if ! ssh -q -o ConnectTimeout=5 "$STAGING_HOST" exit; then
+        die "cannot reach STAGING_HOST '$STAGING_HOST' over ssh (set STAGING_HOST=... to override)"
+    fi
+
+    echo "Provisioning '$STAGING_HOST' over ssh (installer runs there as root; sudo may prompt)..."
+
+    # 1. Ship installer + sources to a fresh 0700 temp dir on the host; capture it.
+    #    Non-TTY ssh here so the tarball can stream on stdin.
+    remote_dir="$(tar czf - -C "$REPO_ROOT" \
+        scripts/admin/setup-staging-reseed-host.sh \
+        scripts/staging-reset.sh scripts/staging-reseed.sh scripts/staging-deployed-sha.sh \
+        | ssh "$STAGING_HOST" 'd="$(mktemp -d /tmp/crm-reseed-provision.XXXXXX)" && tar xzf - -C "$d" && printf %s "$d"')" \
+        || die "failed to ship the provisioning bundle to '$STAGING_HOST'"
+    [ -n "$remote_dir" ] || die "could not create a staging temp dir on '$STAGING_HOST'"
+
+    # 2. Run the installer on the host as root, then remove the temp dir. `-t`
+    #    allocates a TTY so sudo can prompt. RUNNER_USER is passed as a --local
+    #    FLAG (args survive sudo; env does not) — no SETENV needed. printf %q keeps
+    #    the interpolated values shell-safe in the remote command string.
+    remote_installer="$remote_dir/scripts/admin/setup-staging-reseed-host.sh"
+    remote_cmd="sudo bash $(printf %q "$remote_installer") --local --runner-user $(printf %q "$RUNNER_USER"); rc=\$?; rm -rf $(printf %q "$remote_dir"); exit \$rc"
+    ssh -t "$STAGING_HOST" "$remote_cmd"
+    exit $?
+fi
+
+# --- LOCAL mode: install on THIS host (must be root) ----------------------------
+
+[ "$(id -u)" -eq 0 ] || die "must run as root — re-run: sudo RUNNER_USER=$RUNNER_USER scripts/admin/setup-staging-reseed-host.sh --local"
 
 command -v install >/dev/null 2>&1 || die "'install' not found on PATH"
 command -v visudo  >/dev/null 2>&1 || die "'visudo' not found on PATH"

--- a/scripts/admin/setup-staging-reseed-host.sh.test.sh
+++ b/scripts/admin/setup-staging-reseed-host.sh.test.sh
@@ -79,6 +79,44 @@ run_setup() {
     PATH="$SANDBOX/bin:$PATH" \
         USRLOCALSBIN="$SANDBOX/sbin" \
         SUDOERSD="$SANDBOX/sudoers.d" \
+        bash "$SCRIPT" --local >/dev/null 2>"$SANDBOX/stderr"
+    RC=$?
+}
+
+# setup_ssh_stubs : add ssh + tar stubs so ssh mode (the default) can be exercised
+# without a real host. The ssh stub records argv, drains any piped tarball, and
+# answers the three call shapes the script makes: the reachability probe
+# (-o ConnectTimeout), the bundle-ship step (mktemp — echoes a fake remote dir so
+# the caller's $(...) capture is non-empty), and the remote run step (sudo).
+setup_ssh_stubs() {
+    cat > "$SANDBOX/bin/ssh" <<EOF
+#!/usr/bin/env bash
+echo "ssh \$*" >> "$CALL_LOG"
+cat >/dev/null 2>&1 || true   # drain a piped tarball if present
+case " \$* " in
+    *ConnectTimeout*) exit 0 ;;                       # reachability probe
+    *mktemp*)         echo "$SANDBOX/remote_stage" ;; # bundle-ship: echo remote dir
+    *sudo*)                                           # remote --local run
+        # Capture the remote command (the last positional arg) so a test can
+        # re-parse it under a controlled shell and prove %q quoting + rc handling.
+        for _last in "\$@"; do :; done
+        printf '%s' "\$_last" > "$SANDBOX/remote_cmd.txt"
+        exit "\${STUB_SSH_RUN_RC:-0}" ;;
+    *)                exit 0 ;;
+esac
+EOF
+    cat > "$SANDBOX/bin/tar" <<EOF
+#!/usr/bin/env bash
+echo "tar \$*" >> "$CALL_LOG"
+printf 'TARBYTES'   # give the pipe some content
+exit 0
+EOF
+    chmod +x "$SANDBOX/bin/ssh" "$SANDBOX/bin/tar"
+}
+
+# run_ssh : run the script in ssh mode (default, no --local). Caller may prefix env.
+run_ssh() {
+    PATH="$SANDBOX/bin:$PATH" \
         bash "$SCRIPT" >/dev/null 2>"$SANDBOX/stderr"
     RC=$?
 }
@@ -198,7 +236,7 @@ test_fail_missing_source_script() {
     PATH="$SANDBOX/bin:$PATH" \
         USRLOCALSBIN="$SANDBOX/sbin" \
         SUDOERSD="$SANDBOX/sudoers.d" \
-        bash "$fake/scripts/admin/setup-staging-reseed-host.sh" >/dev/null 2>"$SANDBOX/stderr"
+        bash "$fake/scripts/admin/setup-staging-reseed-host.sh" --local >/dev/null 2>"$SANDBOX/stderr"
     RC=$?
     if [ "$RC" -ne 0 ]; then ok; else fail "missing source script must fail, got $RC"; fi
     if grep -q 'staging-reset.sh' "$SANDBOX/stderr"; then ok; else fail "message must name the missing source script"; fi
@@ -218,6 +256,112 @@ test_idempotent_second_run() {
     cleanup_sandbox
 }
 
+test_ssh_mode_bootstraps_remote() {
+    echo "test: ssh mode (default) ships the bundle and runs the installer --local on the host"
+    make_sandbox
+    setup_ssh_stubs
+    # No --local, and STUB_NOT_ROOT=1 to prove ssh mode does NOT require local root.
+    STUB_NOT_ROOT=1 run_ssh
+    if [ "$RC" -eq 0 ]; then ok; else fail "ssh mode should exit 0, got $RC ($(cat "$SANDBOX/stderr"))"; fi
+    # ships the installer via tar
+    if grep -F 'tar ' "$CALL_LOG" | grep -q 'setup-staging-reseed-host.sh'; then ok; else fail "must tar the installer bundle"; fi
+    # remote command runs the installer in --local mode, via sudo, with the runner flag
+    if grep -F 'ssh ' "$CALL_LOG" | grep -F 'sudo' | grep -q -- '--local'; then ok; else fail "remote command must sudo-run the installer with --local"; fi
+    if grep -F 'ssh ' "$CALL_LOG" | grep -q -- '--runner-user gha-runner'; then ok; else fail "remote command must thread --runner-user (default gha-runner)"; fi
+    # uses an interactive TTY so sudo can prompt
+    if grep -F 'ssh ' "$CALL_LOG" | grep -F 'sudo' | grep -q -- '-t'; then ok; else fail "remote run must use ssh -t for the sudo prompt"; fi
+    # cleans up the remote temp dir
+    if grep -F 'ssh ' "$CALL_LOG" | grep -q 'rm -rf'; then ok; else fail "remote command must remove the temp dir"; fi
+    # no local install happened (the real work is on the far side)
+    if grep -qF 'install ' "$CALL_LOG"; then fail "ssh mode must NOT install locally"; else ok; fi
+    cleanup_sandbox
+}
+
+test_ssh_mode_runner_user_override() {
+    echo "test: ssh mode threads a RUNNER_USER override to the remote --runner-user flag"
+    make_sandbox
+    setup_ssh_stubs
+    RUNNER_USER=custom-runner run_ssh
+    if [ "$RC" -eq 0 ]; then ok; else fail "ssh override run should exit 0, got $RC ($(cat "$SANDBOX/stderr"))"; fi
+    if grep -F 'ssh ' "$CALL_LOG" | grep -q -- '--runner-user custom-runner'; then ok; else fail "override must pass --runner-user custom-runner to the remote"; fi
+    cleanup_sandbox
+}
+
+test_ssh_mode_quotes_hostile_runner_user() {
+    echo "test: ssh mode %q-quotes a hostile RUNNER_USER (no injection; value survives as one token)"
+    make_sandbox
+    setup_ssh_stubs
+    # A value with a shell metachar + command separator. ssh mode does NOT validate
+    # the runner locally (that is the remote --local's job), so it flows straight
+    # into the remote command string — the exact thing printf %q must neutralize.
+    local hostile='a b; touch pwned'
+    RUNNER_USER="$hostile" run_ssh
+    if [ "$RC" -eq 0 ]; then ok; else fail "ssh mode run should exit 0, got $RC ($(cat "$SANDBOX/stderr"))"; fi
+    local rc_file="$SANDBOX/remote_cmd.txt"
+    if [ ! -f "$rc_file" ]; then fail "no remote command captured"; cleanup_sandbox; return; fi
+
+    # Re-parse the captured remote command under a controlled shell. A `sudo` stub
+    # records the args it receives (the `bash <installer> --local --runner-user X`
+    # invocation) instead of running them, so a failed %q cannot do harm and the
+    # reconstructed argv is captured. `touch` is deliberately REAL — if %q failed,
+    # the injected `; touch pwned` would run as its own statement and create the file.
+    # (The stub is named `sudo`, NOT `bash`, so a bash-named stub can't recurse into
+    # itself via its own #!/usr/bin/env bash shebang.)
+    mkdir -p "$SANDBOX/parsebin"
+    cat > "$SANDBOX/parsebin/sudo" <<PB
+#!/usr/bin/env bash
+printf '%s\n' "\$@" > "$SANDBOX/remote_argv.txt"
+exit 0
+PB
+    chmod +x "$SANDBOX/parsebin/sudo"
+    ( cd "$SANDBOX" && PATH="$SANDBOX/parsebin:$PATH" bash -c "$(cat "$rc_file")" ) >/dev/null 2>&1 || true
+
+    # No injection: the metacharacter payload must NOT have executed.
+    if [ -e "$SANDBOX/pwned" ]; then fail "injection: 'pwned' created — %q did not neutralize the hostile value"; else ok; fi
+    # The runner value must reconstruct as EXACTLY one token equal to the original.
+    if [ -f "$SANDBOX/remote_argv.txt" ]; then
+        local val
+        val="$(awk '/^--runner-user$/{getline; print; exit}' "$SANDBOX/remote_argv.txt")"
+        if [ "$val" = "$hostile" ]; then ok; else fail "runner-user not reconstructed as one token (got: '$val')"; fi
+    else
+        fail "installer argv not captured from the reconstructed remote command"
+    fi
+    cleanup_sandbox
+}
+
+test_ssh_mode_propagates_remote_rc_and_cleans_up() {
+    echo "test: ssh mode propagates the remote exit code and still removes the temp dir"
+    make_sandbox
+    setup_ssh_stubs
+    STUB_SSH_RUN_RC=7 run_ssh
+    if [ "$RC" -eq 7 ]; then ok; else fail "remote rc must propagate to the local exit, got $RC"; fi
+    # Cleanup is part of the remote command, so it runs even when the install fails.
+    if [ -f "$SANDBOX/remote_cmd.txt" ] && grep -q 'rm -rf' "$SANDBOX/remote_cmd.txt"; then ok
+    else fail "remote command must remove the temp dir even on a failed run"; fi
+    cleanup_sandbox
+}
+
+test_ssh_mode_missing_local_source_fails_before_ssh() {
+    echo "test: ssh mode validates local sources BEFORE contacting the host"
+    make_sandbox
+    setup_ssh_stubs
+    # Run a copy from a fake checkout missing one source script; ssh mode (default).
+    local fake="$SANDBOX/fakerepo"
+    mkdir -p "$fake/scripts/admin"
+    cp "$SCRIPT" "$fake/scripts/admin/setup-staging-reseed-host.sh"
+    echo '#!/bin/bash' > "$fake/scripts/staging-reseed.sh"
+    echo '#!/bin/bash' > "$fake/scripts/staging-deployed-sha.sh"
+    # staging-reset.sh deliberately absent.
+    PATH="$SANDBOX/bin:$PATH" \
+        bash "$fake/scripts/admin/setup-staging-reseed-host.sh" >/dev/null 2>"$SANDBOX/stderr"
+    RC=$?
+    if [ "$RC" -ne 0 ]; then ok; else fail "missing local source must fail, got $RC"; fi
+    if grep -q 'staging-reset.sh' "$SANDBOX/stderr"; then ok; else fail "message must name the missing source"; fi
+    # must fail BEFORE any ssh run of the installer
+    if grep -F 'ssh ' "$CALL_LOG" | grep -q 'sudo'; then fail "must not contact the host when a local source is missing"; else ok; fi
+    cleanup_sandbox
+}
+
 # ---------------------------------------------------------------------------
 main() {
     test_installs_three_scripts_root_0755
@@ -229,6 +373,11 @@ main() {
     test_fail_missing_deploy_staging
     test_fail_missing_source_script
     test_idempotent_second_run
+    test_ssh_mode_bootstraps_remote
+    test_ssh_mode_runner_user_override
+    test_ssh_mode_quotes_hostile_runner_user
+    test_ssh_mode_propagates_remote_rc_and_cleans_up
+    test_ssh_mode_missing_local_source_fails_before_ssh
 
     echo ""
     echo "===================="


### PR DESCRIPTION
Follow-up to #569. The staging host has no repo checkout, so the reseed-host provisioning helper (`scripts/admin/setup-staging-reseed-host.sh`) couldn't be run there directly. This adds an **ssh mode** so it can be driven from a dev Mac.

## What changed
Mirrors `staging-reset.sh`'s two-mode convention:
- **default (ssh)** — run from a Mac; provisions `STAGING_HOST` (default `stovepipes`) over ssh. With no checkout on the host, it ships the installer + the three source scripts to a fresh `0700` temp dir on the host and re-invokes itself there with `--local`, then removes the temp dir. `ssh -t` allocates a TTY so `sudo` can prompt for a password.
- **`--local`** — the original on-host behavior (root check, precondition asserts, install to `/usr/local/sbin`, validated sudoers drop-in). Logic unchanged; this is what ssh mode calls on the far side, so all install/sudoers logic stays single-sourced.

`RUNNER_USER` is threaded to the host via a `--runner-user` flag (args survive `sudo`; env does not — no `SETENV` needed). Interpolated values are `printf %q`-quoted so the single remote shell parse reconstructs the exact argv.

## Testing
`scripts/admin/setup-staging-reseed-host.sh.test.sh` → 46/0 (adds ssh-mode coverage incl. a hostile-`RUNNER_USER` injection-safety test and remote exit-code propagation). `make test-deploy-scripts` green; `bash -n` clean. Local `/review-head` PASS (P0=0 P1=0); the reviewer mutation-tested the two new security tests to confirm they're non-vacuous.

## Review notes (non-blocking)
- P2: the cleanup-on-failure assertion is a presence grep (the remote `rm -rf` is embedded in the command string, so it runs on the `; rc=$?; rm -rf ...` path regardless of the install's exit).
- P3: the test's `ssh` stub drains stdin unconditionally, which can block under an *open* interactive stdin; benign under CI/pre-push (closed stdin). Left as-is to match the existing stub pattern.