### PR TITLE
fix(merge): repoint identity attribution to the merge survivor

### DIFF
--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -542,6 +542,14 @@ func run() int {
 	// FollowUpManager.ApplyInteraction via ContactService.
 	contactService.SetFollowUpConsumer(followUpManager)
 
+	// Wire the merge-time task-close enqueuer. MergeContacts closes the
+	// source contact's live automated tasks and enqueues the durable Todoist
+	// close job for rows with a real external id; the mode gate matches the
+	// close worker's cutover-only contract (enqueuing in mode 'off' would
+	// only manufacture failing jobs — merge then closes locally with a WARN,
+	// that mode's documented "completion disabled" semantics).
+	contactService.SetTaskCloseEnqueuer(riverClient, cfg.EventBus.FollowUpMode == config.EventBusFollowUpModeCutover)
+
 	// InteractionRecorder consumer + manual handler (spec §3.4.1).
 	// Delegates the write to ContactService.RecordInteractionTx, then
 	// marks telegram_messages processed (for message.* kinds) and emits
@@ -1000,6 +1008,8 @@ func run() int {
 				cadenceUpdater,
 				database.Pool,
 				todoistClientFactory,
+				riverClient,
+				cfg.EventBus.FollowUpMode == config.EventBusFollowUpModeCutover,
 			)
 			providerRegistry.Register(todoistProvider)
 			logger.Info().Msg("Todoist Cadence sync provider registered")

--- a/backend/internal/db/comms_message.sql.go
+++ b/backend/internal/db/comms_message.sql.go
@@ -854,6 +854,28 @@ func (q *Queries) MarkCommsMessagesProcessedForSession(ctx context.Context, arg 
 	return result.RowsAffected(), nil
 }
 
+const RepointCommsMessageContact = `-- name: RepointCommsMessageContact :exec
+UPDATE comms_message
+SET matched_contact_id = $1
+WHERE matched_contact_id = $2
+`
+
+type RepointCommsMessageContactParams struct {
+	TargetContactID pgtype.UUID `json:"target_contact_id"`
+	SourceContactID pgtype.UUID `json:"source_contact_id"`
+}
+
+// Merge dedup step 2: re-point ALL remaining source-matched rows (live +
+// soft-deleted — the dedup index is partial on deleted_at IS NULL, so
+// soft-deleted rows cannot collide; including them mirrors
+// TransferInteractions' includes-soft-deleted audit stance). Runs strictly
+// AFTER SoftDeleteDuplicateCommsMessagesForMerge inside
+// RepointContactForMergeTx's savepoint.
+func (q *Queries) RepointCommsMessageContact(ctx context.Context, arg RepointCommsMessageContactParams) error {
+	_, err := q.db.Exec(ctx, RepointCommsMessageContact, arg.TargetContactID, arg.SourceContactID)
+	return err
+}
+
 const SoftDeleteCommsMessageByID = `-- name: SoftDeleteCommsMessageByID :exec
 UPDATE comms_message
 SET deleted_at = NOW()
@@ -893,6 +915,39 @@ func (q *Queries) SoftDeleteCommsMessagesByExternalID(ctx context.Context, arg S
 		return 0, err
 	}
 	return result.RowsAffected(), nil
+}
+
+const SoftDeleteDuplicateCommsMessagesForMerge = `-- name: SoftDeleteDuplicateCommsMessagesForMerge :exec
+UPDATE comms_message
+SET deleted_at = NOW()
+WHERE comms_message.matched_contact_id = $1
+  AND comms_message.deleted_at IS NULL
+  AND EXISTS (
+    SELECT 1 FROM comms_message t
+    WHERE t.source = comms_message.source
+      AND t.external_id = comms_message.external_id
+      AND t.matched_contact_id = $2
+      AND t.deleted_at IS NULL
+  )
+`
+
+type SoftDeleteDuplicateCommsMessagesForMergeParams struct {
+	SourceContactID pgtype.UUID `json:"source_contact_id"`
+	TargetContactID pgtype.UUID `json:"target_contact_id"`
+}
+
+// Merge dedup step 1 (see CommsMessageRepository.RepointContactForMergeTx):
+// tombstone the merge source's live copy of any (source, external_id) the
+// target ALSO has live — the email-fanout shape, where one upstream message
+// produced a row under both contacts. Without this, the follow-up repoint
+// would collide on idx_comms_message_dedup (partial UNIQUE (source,
+// external_id, matched_contact_id) WHERE deleted_at IS NULL). Soft-delete
+// (not hard DELETE) preserves the row for audit, matching the table's
+// tombstone semantics; the surviving target row carries the same upstream
+// message. MUST run strictly BEFORE RepointCommsMessageContact.
+func (q *Queries) SoftDeleteDuplicateCommsMessagesForMerge(ctx context.Context, arg SoftDeleteDuplicateCommsMessagesForMergeParams) error {
+	_, err := q.db.Exec(ctx, SoftDeleteDuplicateCommsMessagesForMerge, arg.SourceContactID, arg.TargetContactID)
+	return err
 }
 
 const TestInsertCommsMessageLinked = `-- name: TestInsertCommsMessageLinked :one

--- a/backend/internal/db/contact.sql.go
+++ b/backend/internal/db/contact.sql.go
@@ -83,6 +83,23 @@ func (q *Queries) ComputeContactDatesAfterDelete(ctx context.Context, arg Comput
 	return &i, err
 }
 
+const ContactIsLive = `-- name: ContactIsLive :one
+SELECT EXISTS(
+    SELECT 1 FROM contact
+    WHERE id = $1 AND deleted_at IS NULL
+) AS is_live
+`
+
+// Liveness probe for the identity-match guard: a cached
+// external_identity.contact_id pointing at a soft-deleted (e.g. merged-away)
+// contact must not short-circuit the discovery path.
+func (q *Queries) ContactIsLive(ctx context.Context, id pgtype.UUID) (bool, error) {
+	row := q.db.QueryRow(ctx, ContactIsLive, id)
+	var is_live bool
+	err := row.Scan(&is_live)
+	return is_live, err
+}
+
 const CountContacts = `-- name: CountContacts :one
 SELECT COUNT(*) FROM contact
 WHERE deleted_at IS NULL

--- a/backend/internal/db/contact_merge.sql.go
+++ b/backend/internal/db/contact_merge.sql.go
@@ -191,6 +191,107 @@ func (q *Queries) ReplaceContactInCalendarEvents(ctx context.Context, arg Replac
 	return err
 }
 
+const RepointExternalContactsToContact = `-- name: RepointExternalContactsToContact :exec
+UPDATE external_contact
+SET crm_contact_id = $1,
+    updated_at = NOW()
+WHERE crm_contact_id = $2
+`
+
+type RepointExternalContactsToContactParams struct {
+	TargetContactID pgtype.UUID `json:"target_contact_id"`
+	SourceContactID pgtype.UUID `json:"source_contact_id"`
+}
+
+// Re-point import links from the merge source to the target. Both
+// crm_contact_id indexes are non-unique, so this is collision-free. The
+// external_contact upsert preserves crm_contact_id on re-sync, so the
+// repoint is not overwritten by the next daemon sync.
+func (q *Queries) RepointExternalContactsToContact(ctx context.Context, arg RepointExternalContactsToContactParams) error {
+	_, err := q.db.Exec(ctx, RepointExternalContactsToContact, arg.TargetContactID, arg.SourceContactID)
+	return err
+}
+
+const RepointIdentitiesToContact = `-- name: RepointIdentitiesToContact :exec
+UPDATE external_identity
+SET contact_id = $1,
+    updated_at = NOW()
+WHERE contact_id = $2
+`
+
+type RepointIdentitiesToContactParams struct {
+	TargetContactID pgtype.UUID `json:"target_contact_id"`
+	SourceContactID pgtype.UUID `json:"source_contact_id"`
+}
+
+// Re-point identity-cache rows from the merge source (loser) to the target
+// (winner) so future inbound events from the loser's handles attribute to
+// the survivor. Collision-free: external_identity uniqueness is on
+// (identifier, identifier_type, source) globally, so at most one row exists
+// per triple regardless of contact.
+func (q *Queries) RepointIdentitiesToContact(ctx context.Context, arg RepointIdentitiesToContactParams) error {
+	_, err := q.db.Exec(ctx, RepointIdentitiesToContact, arg.TargetContactID, arg.SourceContactID)
+	return err
+}
+
+const RepointMessagesMessageContact = `-- name: RepointMessagesMessageContact :exec
+UPDATE messages_message
+SET matched_contact_id = $1
+WHERE matched_contact_id = $2
+`
+
+type RepointMessagesMessageContactParams struct {
+	TargetContactID pgtype.UUID `json:"target_contact_id"`
+	SourceContactID pgtype.UUID `json:"source_contact_id"`
+}
+
+// Re-point iMessage staging rows (committed pre-merge, incl. unprocessed)
+// from the merge source to the target. messages_message uniqueness is on
+// the message guid, not the contact — collision-free. NOTE: the table has
+// no updated_at column (049); do not set one.
+func (q *Queries) RepointMessagesMessageContact(ctx context.Context, arg RepointMessagesMessageContactParams) error {
+	_, err := q.db.Exec(ctx, RepointMessagesMessageContact, arg.TargetContactID, arg.SourceContactID)
+	return err
+}
+
+const RepointPhoneCallContact = `-- name: RepointPhoneCallContact :exec
+UPDATE phone_call
+SET matched_contact_id = $1
+WHERE matched_contact_id = $2
+`
+
+type RepointPhoneCallContactParams struct {
+	TargetContactID pgtype.UUID `json:"target_contact_id"`
+	SourceContactID pgtype.UUID `json:"source_contact_id"`
+}
+
+// Re-point call staging rows from the merge source to the target.
+// Uniqueness is on call_unique_id — collision-free. NOTE: phone_call has
+// no updated_at column (055); do not set one.
+func (q *Queries) RepointPhoneCallContact(ctx context.Context, arg RepointPhoneCallContactParams) error {
+	_, err := q.db.Exec(ctx, RepointPhoneCallContact, arg.TargetContactID, arg.SourceContactID)
+	return err
+}
+
+const RepointTelegramMessageContact = `-- name: RepointTelegramMessageContact :exec
+UPDATE telegram_message
+SET matched_contact_id = $1
+WHERE matched_contact_id = $2
+`
+
+type RepointTelegramMessageContactParams struct {
+	TargetContactID pgtype.UUID `json:"target_contact_id"`
+	SourceContactID pgtype.UUID `json:"source_contact_id"`
+}
+
+// Re-point Telegram staging rows from the merge source to the target.
+// Uniqueness is on (telegram_chat_id, telegram_message_id) — collision-free.
+// NOTE: telegram_message has no updated_at column (032); do not set one.
+func (q *Queries) RepointTelegramMessageContact(ctx context.Context, arg RepointTelegramMessageContactParams) error {
+	_, err := q.db.Exec(ctx, RepointTelegramMessageContact, arg.TargetContactID, arg.SourceContactID)
+	return err
+}
+
 const TransferContactMethods = `-- name: TransferContactMethods :exec
 
 UPDATE contact_method

--- a/backend/internal/db/contact_task.sql.go
+++ b/backend/internal/db/contact_task.sql.go
@@ -57,6 +57,64 @@ func (q *Queries) CompleteFollowUpForContact(ctx context.Context, contactID pgty
 	return items, nil
 }
 
+const CompleteLiveContactTasksForContact = `-- name: CompleteLiveContactTasksForContact :many
+UPDATE contact_task
+SET state = 'completed',
+    updated_at = NOW()
+WHERE contact_id = $1
+  AND lifecycle IN ('cadence_due', 'followup_loop')
+  AND state IN ('managed', 'pending_remote_create')
+RETURNING id, external_task_id, provider,
+    COALESCE(metadata->>$2::text, '')::text AS pending_temp_id
+`
+
+type CompleteLiveContactTasksForContactParams struct {
+	ContactID        pgtype.UUID `json:"contact_id"`
+	PendingTempIDKey string      `json:"pending_temp_id_key"`
+}
+
+type CompleteLiveContactTasksForContactRow struct {
+	ID             pgtype.UUID `json:"id"`
+	ExternalTaskID string      `json:"external_task_id"`
+	Provider       string      `json:"provider"`
+	PendingTempID  string      `json:"pending_temp_id"`
+}
+
+// Merge-time close of the source contact's live AUTOMATED tasks (cadence_due
+// + followup_loop). Manual-lifecycle rows are deliberately excluded — they
+// are user content and are REPOINTED to the merge target instead (see
+// RepointManualContactTasksToContact). Automated rows cannot be repointed:
+// unique_contact_provider_cadence has no state filter, so a repoint collides
+// whenever the target has ANY cadence_due row, and the target's own automated
+// rows already cover the survivor. Returns the closed rows' identifying
+// fields plus the pending_temp_id metadata key so the service can decide
+// remote-close enqueue eligibility (real external id only — never a pending
+// temp id, mirroring todoist.isPendingTempID).
+func (q *Queries) CompleteLiveContactTasksForContact(ctx context.Context, arg CompleteLiveContactTasksForContactParams) ([]*CompleteLiveContactTasksForContactRow, error) {
+	rows, err := q.db.Query(ctx, CompleteLiveContactTasksForContact, arg.ContactID, arg.PendingTempIDKey)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []*CompleteLiveContactTasksForContactRow{}
+	for rows.Next() {
+		var i CompleteLiveContactTasksForContactRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.ExternalTaskID,
+			&i.Provider,
+			&i.PendingTempID,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const CountContactTasksByProvider = `-- name: CountContactTasksByProvider :one
 SELECT COUNT(*) FROM contact_task
 WHERE provider = $1 AND state = $2
@@ -746,6 +804,32 @@ func (q *Queries) ListManagedContactTasks(ctx context.Context, provider string) 
 		return nil, err
 	}
 	return items, nil
+}
+
+const RepointManualContactTasksToContact = `-- name: RepointManualContactTasksToContact :exec
+UPDATE contact_task
+SET contact_id = $1,
+    updated_at = NOW()
+WHERE contact_id = $2
+  AND lifecycle = 'manual'
+`
+
+type RepointManualContactTasksToContactParams struct {
+	TargetContactID pgtype.UUID `json:"target_contact_id"`
+	SourceContactID pgtype.UUID `json:"source_contact_id"`
+}
+
+// Merge-time repoint of the source contact's MANUAL tasks (user to-dos) to
+// the target, all states — closing one would silently check off the user's
+// live task, and leaving it would let the Todoist sync's contact-deleted
+// branch hard-DELETE the remote task. Collision-free: neither partial unique
+// index covers lifecycle='manual', and unique_external_task_id keys on
+// external_task_id, which this update does not touch. Repointing terminal
+// states too keeps the survivor's task history intact (mirrors
+// TransferInteractions).
+func (q *Queries) RepointManualContactTasksToContact(ctx context.Context, arg RepointManualContactTasksToContactParams) error {
+	_, err := q.db.Exec(ctx, RepointManualContactTasksToContact, arg.TargetContactID, arg.SourceContactID)
+	return err
 }
 
 const SetContactTaskExternalIDOnly = `-- name: SetContactTaskExternalIDOnly :exec

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -158,6 +158,17 @@ type Querier interface {
 	// so an inbound arriving while the create worker is mid-flight still
 	// transitions the row to completed.
 	CompleteFollowUpForContact(ctx context.Context, contactID pgtype.UUID) ([]*ContactTask, error)
+	// Merge-time close of the source contact's live AUTOMATED tasks (cadence_due
+	// + followup_loop). Manual-lifecycle rows are deliberately excluded — they
+	// are user content and are REPOINTED to the merge target instead (see
+	// RepointManualContactTasksToContact). Automated rows cannot be repointed:
+	// unique_contact_provider_cadence has no state filter, so a repoint collides
+	// whenever the target has ANY cadence_due row, and the target's own automated
+	// rows already cover the survivor. Returns the closed rows' identifying
+	// fields plus the pending_temp_id metadata key so the service can decide
+	// remote-close enqueue eligibility (real external id only — never a pending
+	// temp id, mirroring todoist.isPendingTempID).
+	CompleteLiveContactTasksForContact(ctx context.Context, arg CompleteLiveContactTasksForContactParams) ([]*CompleteLiveContactTasksForContactRow, error)
 	CompleteSyncLog(ctx context.Context, arg CompleteSyncLogParams) (*ExternalSyncLog, error)
 	// Returns the surgically-recomputed timestamp columns (each touched ONLY
 	// when the deleted interaction at @deleted_at_ts was its source: column =
@@ -173,6 +184,10 @@ type Querier interface {
 	// FOR UPDATE retained below re-takes the held lock; the load-bearing
 	// serialization is the prior LockContactForDateRecompute statement).
 	ComputeContactDatesAfterDelete(ctx context.Context, arg ComputeContactDatesAfterDeleteParams) (*ComputeContactDatesAfterDeleteRow, error)
+	// Liveness probe for the identity-match guard: a cached
+	// external_identity.contact_id pointing at a soft-deleted (e.g. merged-away)
+	// contact must not short-circuit the discovery path.
+	ContactIsLive(ctx context.Context, id pgtype.UUID) (bool, error)
 	CountAllUnmatchedExternalContacts(ctx context.Context, includeUnresolvedTelegram bool) (int64, error)
 	CountContactInteractions(ctx context.Context, contactID pgtype.UUID) (int64, error)
 	CountContactNotes(ctx context.Context, contactID pgtype.UUID) (int64, error)
@@ -1464,6 +1479,46 @@ type Querier interface {
 	// winner and set the recomputed proposition_key. Called only by the merge
 	// procedure, never the normal write path.
 	RepointAssertionSubject(ctx context.Context, arg RepointAssertionSubjectParams) error
+	// Merge dedup step 2: re-point ALL remaining source-matched rows (live +
+	// soft-deleted — the dedup index is partial on deleted_at IS NULL, so
+	// soft-deleted rows cannot collide; including them mirrors
+	// TransferInteractions' includes-soft-deleted audit stance). Runs strictly
+	// AFTER SoftDeleteDuplicateCommsMessagesForMerge inside
+	// RepointContactForMergeTx's savepoint.
+	RepointCommsMessageContact(ctx context.Context, arg RepointCommsMessageContactParams) error
+	// Re-point import links from the merge source to the target. Both
+	// crm_contact_id indexes are non-unique, so this is collision-free. The
+	// external_contact upsert preserves crm_contact_id on re-sync, so the
+	// repoint is not overwritten by the next daemon sync.
+	RepointExternalContactsToContact(ctx context.Context, arg RepointExternalContactsToContactParams) error
+	// Re-point identity-cache rows from the merge source (loser) to the target
+	// (winner) so future inbound events from the loser's handles attribute to
+	// the survivor. Collision-free: external_identity uniqueness is on
+	// (identifier, identifier_type, source) globally, so at most one row exists
+	// per triple regardless of contact.
+	RepointIdentitiesToContact(ctx context.Context, arg RepointIdentitiesToContactParams) error
+	// Merge-time repoint of the source contact's MANUAL tasks (user to-dos) to
+	// the target, all states — closing one would silently check off the user's
+	// live task, and leaving it would let the Todoist sync's contact-deleted
+	// branch hard-DELETE the remote task. Collision-free: neither partial unique
+	// index covers lifecycle='manual', and unique_external_task_id keys on
+	// external_task_id, which this update does not touch. Repointing terminal
+	// states too keeps the survivor's task history intact (mirrors
+	// TransferInteractions).
+	RepointManualContactTasksToContact(ctx context.Context, arg RepointManualContactTasksToContactParams) error
+	// Re-point iMessage staging rows (committed pre-merge, incl. unprocessed)
+	// from the merge source to the target. messages_message uniqueness is on
+	// the message guid, not the contact — collision-free. NOTE: the table has
+	// no updated_at column (049); do not set one.
+	RepointMessagesMessageContact(ctx context.Context, arg RepointMessagesMessageContactParams) error
+	// Re-point call staging rows from the merge source to the target.
+	// Uniqueness is on call_unique_id — collision-free. NOTE: phone_call has
+	// no updated_at column (055); do not set one.
+	RepointPhoneCallContact(ctx context.Context, arg RepointPhoneCallContactParams) error
+	// Re-point Telegram staging rows from the merge source to the target.
+	// Uniqueness is on (telegram_chat_id, telegram_message_id) — collision-free.
+	// NOTE: telegram_message has no updated_at column (032); do not set one.
+	RepointTelegramMessageContact(ctx context.Context, arg RepointTelegramMessageContactParams) error
 	ResetSyncStateBackfillCursor(ctx context.Context, arg ResetSyncStateBackfillCursorParams) (*ExternalSyncState, error)
 	// ============================================================================
 	// crm-admin --reset-and-seed support: a HARD wipe of every live data table
@@ -1618,6 +1673,16 @@ type Querier interface {
 	// affects 0 rows.
 	SoftDeleteCommsMessagesByExternalID(ctx context.Context, arg SoftDeleteCommsMessagesByExternalIDParams) (int64, error)
 	SoftDeleteContact(ctx context.Context, id pgtype.UUID) error
+	// Merge dedup step 1 (see CommsMessageRepository.RepointContactForMergeTx):
+	// tombstone the merge source's live copy of any (source, external_id) the
+	// target ALSO has live — the email-fanout shape, where one upstream message
+	// produced a row under both contacts. Without this, the follow-up repoint
+	// would collide on idx_comms_message_dedup (partial UNIQUE (source,
+	// external_id, matched_contact_id) WHERE deleted_at IS NULL). Soft-delete
+	// (not hard DELETE) preserves the row for audit, matching the table's
+	// tombstone semantics; the surviving target row carries the same upstream
+	// message. MUST run strictly BEFORE RepointCommsMessageContact.
+	SoftDeleteDuplicateCommsMessagesForMerge(ctx context.Context, arg SoftDeleteDuplicateCommsMessagesForMergeParams) error
 	// Tombstones a live row. Defensive WHERE deleted_at IS NULL keeps the
 	// statement idempotent against a concurrent delete. crm_contact_id,
 	// match_status, and duplicate_of_id are preserved per the external_contact

--- a/backend/internal/db/queries/comms_message.sql
+++ b/backend/internal/db/queries/comms_message.sql
@@ -155,6 +155,39 @@ WHERE id = ANY(@message_ids::uuid[])
   AND processed_at IS NULL
   AND deleted_at IS NULL;
 
+-- name: SoftDeleteDuplicateCommsMessagesForMerge :exec
+-- Merge dedup step 1 (see CommsMessageRepository.RepointContactForMergeTx):
+-- tombstone the merge source's live copy of any (source, external_id) the
+-- target ALSO has live — the email-fanout shape, where one upstream message
+-- produced a row under both contacts. Without this, the follow-up repoint
+-- would collide on idx_comms_message_dedup (partial UNIQUE (source,
+-- external_id, matched_contact_id) WHERE deleted_at IS NULL). Soft-delete
+-- (not hard DELETE) preserves the row for audit, matching the table's
+-- tombstone semantics; the surviving target row carries the same upstream
+-- message. MUST run strictly BEFORE RepointCommsMessageContact.
+UPDATE comms_message
+SET deleted_at = NOW()
+WHERE comms_message.matched_contact_id = sqlc.arg(source_contact_id)
+  AND comms_message.deleted_at IS NULL
+  AND EXISTS (
+    SELECT 1 FROM comms_message t
+    WHERE t.source = comms_message.source
+      AND t.external_id = comms_message.external_id
+      AND t.matched_contact_id = sqlc.arg(target_contact_id)
+      AND t.deleted_at IS NULL
+  );
+
+-- name: RepointCommsMessageContact :exec
+-- Merge dedup step 2: re-point ALL remaining source-matched rows (live +
+-- soft-deleted — the dedup index is partial on deleted_at IS NULL, so
+-- soft-deleted rows cannot collide; including them mirrors
+-- TransferInteractions' includes-soft-deleted audit stance). Runs strictly
+-- AFTER SoftDeleteDuplicateCommsMessagesForMerge inside
+-- RepointContactForMergeTx's savepoint.
+UPDATE comms_message
+SET matched_contact_id = sqlc.arg(target_contact_id)
+WHERE matched_contact_id = sqlc.arg(source_contact_id);
+
 -- name: HardDeleteCommsMessagesByContact :exec
 -- Test-only cleanup helper (scoped by matched_contact_id). Hard delete because
 -- the upsert does not clear deleted_at on conflict, so soft-deleted rows would

--- a/backend/internal/db/queries/contact.sql
+++ b/backend/internal/db/queries/contact.sql
@@ -4,6 +4,15 @@
 SELECT * FROM contact
 WHERE id = $1 AND deleted_at IS NULL;
 
+-- name: ContactIsLive :one
+-- Liveness probe for the identity-match guard: a cached
+-- external_identity.contact_id pointing at a soft-deleted (e.g. merged-away)
+-- contact must not short-circuit the discovery path.
+SELECT EXISTS(
+    SELECT 1 FROM contact
+    WHERE id = $1 AND deleted_at IS NULL
+) AS is_live;
+
 -- name: ListContacts :many
 -- cadence_filter: '' = no filter (Go zero value), 'has_cadence' = non-empty cadence,
 -- 'no_cadence' = NULL or empty string (defensive; CHECK constraint prevents empty strings)

--- a/backend/internal/db/queries/contact_merge.sql
+++ b/backend/internal/db/queries/contact_merge.sql
@@ -43,6 +43,52 @@ WHERE sqlc.arg(target_contact_id)::uuid = ANY(matched_contact_ids)
     SELECT COUNT(*) FROM unnest(matched_contact_ids) AS cid WHERE cid = sqlc.arg(target_contact_id)::uuid
   ) > 1;
 
+-- name: RepointIdentitiesToContact :exec
+-- Re-point identity-cache rows from the merge source (loser) to the target
+-- (winner) so future inbound events from the loser's handles attribute to
+-- the survivor. Collision-free: external_identity uniqueness is on
+-- (identifier, identifier_type, source) globally, so at most one row exists
+-- per triple regardless of contact.
+UPDATE external_identity
+SET contact_id = sqlc.arg(target_contact_id),
+    updated_at = NOW()
+WHERE contact_id = sqlc.arg(source_contact_id);
+
+-- name: RepointExternalContactsToContact :exec
+-- Re-point import links from the merge source to the target. Both
+-- crm_contact_id indexes are non-unique, so this is collision-free. The
+-- external_contact upsert preserves crm_contact_id on re-sync, so the
+-- repoint is not overwritten by the next daemon sync.
+UPDATE external_contact
+SET crm_contact_id = sqlc.arg(target_contact_id),
+    updated_at = NOW()
+WHERE crm_contact_id = sqlc.arg(source_contact_id);
+
+-- name: RepointMessagesMessageContact :exec
+-- Re-point iMessage staging rows (committed pre-merge, incl. unprocessed)
+-- from the merge source to the target. messages_message uniqueness is on
+-- the message guid, not the contact — collision-free. NOTE: the table has
+-- no updated_at column (049); do not set one.
+UPDATE messages_message
+SET matched_contact_id = sqlc.arg(target_contact_id)
+WHERE matched_contact_id = sqlc.arg(source_contact_id);
+
+-- name: RepointTelegramMessageContact :exec
+-- Re-point Telegram staging rows from the merge source to the target.
+-- Uniqueness is on (telegram_chat_id, telegram_message_id) — collision-free.
+-- NOTE: telegram_message has no updated_at column (032); do not set one.
+UPDATE telegram_message
+SET matched_contact_id = sqlc.arg(target_contact_id)
+WHERE matched_contact_id = sqlc.arg(source_contact_id);
+
+-- name: RepointPhoneCallContact :exec
+-- Re-point call staging rows from the merge source to the target.
+-- Uniqueness is on call_unique_id — collision-free. NOTE: phone_call has
+-- no updated_at column (055); do not set one.
+UPDATE phone_call
+SET matched_contact_id = sqlc.arg(target_contact_id)
+WHERE matched_contact_id = sqlc.arg(source_contact_id);
+
 -- name: CountMergeContactMethods :one
 -- Count contact methods for a contact (for merge preview)
 SELECT COUNT(*) FROM contact_method

--- a/backend/internal/db/queries/contact_task.sql
+++ b/backend/internal/db/queries/contact_task.sql
@@ -226,6 +226,41 @@ WHERE contact_id = $1
   AND state IN ('managed', 'pending_remote_create')
 RETURNING *;
 
+-- name: CompleteLiveContactTasksForContact :many
+-- Merge-time close of the source contact's live AUTOMATED tasks (cadence_due
+-- + followup_loop). Manual-lifecycle rows are deliberately excluded — they
+-- are user content and are REPOINTED to the merge target instead (see
+-- RepointManualContactTasksToContact). Automated rows cannot be repointed:
+-- unique_contact_provider_cadence has no state filter, so a repoint collides
+-- whenever the target has ANY cadence_due row, and the target's own automated
+-- rows already cover the survivor. Returns the closed rows' identifying
+-- fields plus the pending_temp_id metadata key so the service can decide
+-- remote-close enqueue eligibility (real external id only — never a pending
+-- temp id, mirroring todoist.isPendingTempID).
+UPDATE contact_task
+SET state = 'completed',
+    updated_at = NOW()
+WHERE contact_id = @contact_id
+  AND lifecycle IN ('cadence_due', 'followup_loop')
+  AND state IN ('managed', 'pending_remote_create')
+RETURNING id, external_task_id, provider,
+    COALESCE(metadata->>sqlc.arg(pending_temp_id_key)::text, '')::text AS pending_temp_id;
+
+-- name: RepointManualContactTasksToContact :exec
+-- Merge-time repoint of the source contact's MANUAL tasks (user to-dos) to
+-- the target, all states — closing one would silently check off the user's
+-- live task, and leaving it would let the Todoist sync's contact-deleted
+-- branch hard-DELETE the remote task. Collision-free: neither partial unique
+-- index covers lifecycle='manual', and unique_external_task_id keys on
+-- external_task_id, which this update does not touch. Repointing terminal
+-- states too keeps the survivor's task history intact (mirrors
+-- TransferInteractions).
+UPDATE contact_task
+SET contact_id = sqlc.arg(target_contact_id),
+    updated_at = NOW()
+WHERE contact_id = sqlc.arg(source_contact_id)
+  AND lifecycle = 'manual';
+
 -- name: FindPendingFollowUpTx :one
 -- Transactional sibling of FindPendingFollowUp. Matches both 'managed'
 -- and 'pending_remote_create' live states so the future cutover's

--- a/backend/internal/repository/comms_message.go
+++ b/backend/internal/repository/comms_message.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"time"
 
 	"personal-crm/backend/internal/db"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgerrcode"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
@@ -89,11 +92,107 @@ type GChatIdentity struct {
 // CommsMessageRepository wraps the sqlc-generated comms_message queries.
 type CommsMessageRepository struct {
 	queries db.Querier
+	// repointBarrierForTest, when non-nil, is invoked between the dedup and
+	// repoint statements of RepointContactForMergeTx's FIRST savepoint attempt
+	// only. Test-only hook (same convention as
+	// ContactService.InjectMergeCommitBarrierForTest) that lets a test commit
+	// a colliding row from a second connection at exactly the point where the
+	// READ COMMITTED race fires, making the savepoint-retry path
+	// deterministic. Nil in production.
+	repointBarrierForTest func()
 }
 
 // NewCommsMessageRepository creates a new comms_message repository.
 func NewCommsMessageRepository(queries db.Querier) *CommsMessageRepository {
 	return &CommsMessageRepository{queries: queries}
+}
+
+// commsMessageDedupIndex is the partial unique index
+// (source, external_id, matched_contact_id) WHERE deleted_at IS NULL that the
+// merge repoint can collide with when a concurrent ingest commits a target-
+// contact row between the dedup and repoint statements.
+const commsMessageDedupIndex = "idx_comms_message_dedup"
+
+// SetRepointBarrierForTest installs the test-only barrier hook. Must only be
+// called before the repository is used concurrently; no synchronization.
+func (r *CommsMessageRepository) SetRepointBarrierForTest(fn func()) {
+	r.repointBarrierForTest = fn
+}
+
+// isCommsDedupUniqueViolation reports whether err is a 23505 raised against
+// idx_comms_message_dedup. Scoped narrowly so unrelated unique violations
+// still propagate.
+func isCommsDedupUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		return false
+	}
+	return pgErr.Code == pgerrcode.UniqueViolation && pgErr.ConstraintName == commsMessageDedupIndex
+}
+
+// RepointContactForMergeTx re-points the merge source contact's comms_message
+// rows to the target inside the caller's tx. Two ordered steps: (1) soft-
+// delete the source's live rows whose (source, external_id) the target ALSO
+// has live (the email-fanout dedup collision, D-index idx_comms_message_dedup),
+// then (2) re-point the remainder (incl. previously soft-deleted rows — the
+// partial index ignores them).
+//
+// The pair runs in a savepoint (nested tx) with ONE retry scoped to a 23505
+// on idx_comms_message_dedup: at READ COMMITTED, a concurrent ingest can
+// commit a target-contact row for the same (source, external_id) between the
+// two statements, making the repoint collide even though the dedup statement
+// saw nothing. The savepoint confines the abort, and the retry's dedup
+// statement takes a fresh snapshot that sees the raced row. A second
+// collision (sustained concurrent inserts) propagates and fails the merge
+// safely — full rollback, user retries.
+func (r *CommsMessageRepository) RepointContactForMergeTx(ctx context.Context, tx pgx.Tx, sourceContactID, targetContactID uuid.UUID) error {
+	attempt := func(withBarrier bool) error {
+		sp, err := tx.Begin(ctx)
+		if err != nil {
+			return fmt.Errorf("open comms repoint savepoint: %w", err)
+		}
+		q := db.New(sp)
+		if err := q.SoftDeleteDuplicateCommsMessagesForMerge(ctx, db.SoftDeleteDuplicateCommsMessagesForMergeParams{
+			SourceContactID: uuidToPgUUID(sourceContactID),
+			TargetContactID: uuidToPgUUID(targetContactID),
+		}); err != nil {
+			if rbErr := sp.Rollback(ctx); rbErr != nil {
+				return fmt.Errorf("rollback comms repoint savepoint: %w (dedup: %w)", rbErr, err)
+			}
+			return fmt.Errorf("soft-delete duplicate comms messages: %w", err)
+		}
+		if withBarrier && r.repointBarrierForTest != nil {
+			r.repointBarrierForTest()
+		}
+		if err := q.RepointCommsMessageContact(ctx, db.RepointCommsMessageContactParams{
+			SourceContactID: uuidToPgUUID(sourceContactID),
+			TargetContactID: uuidToPgUUID(targetContactID),
+		}); err != nil {
+			if rbErr := sp.Rollback(ctx); rbErr != nil {
+				return fmt.Errorf("rollback comms repoint savepoint: %w (repoint: %w)", rbErr, err)
+			}
+			return fmt.Errorf("repoint comms messages: %w", err)
+		}
+		if err := sp.Commit(ctx); err != nil {
+			return fmt.Errorf("commit comms repoint savepoint: %w", err)
+		}
+		return nil
+	}
+
+	err := attempt(true)
+	if err == nil {
+		return nil
+	}
+	if !isCommsDedupUniqueViolation(err) {
+		return err
+	}
+	// Raced insert committed between the dedup and repoint statements; the
+	// savepoint rollback confined the abort. Retry once — the fresh dedup
+	// snapshot sees the raced row and tombstones the collision first.
+	if retryErr := attempt(false); retryErr != nil {
+		return fmt.Errorf("comms repoint retry after dedup collision: %w", retryErr)
+	}
+	return nil
 }
 
 func convertDbCommsMessage(m *db.CommsMessage) CommsMessage {

--- a/backend/internal/repository/contact_task.go
+++ b/backend/internal/repository/contact_task.go
@@ -732,6 +732,55 @@ func (r *ContactTaskRepository) UpdateContactTaskExternalIDTx(ctx context.Contex
 	return &task, nil
 }
 
+// CompletedTaskRef identifies a contact_task row the merge-time close
+// transitioned to 'completed', with the fields the service needs to decide
+// remote-close enqueue eligibility (a real external id — non-empty AND not a
+// pending temp id).
+type CompletedTaskRef struct {
+	ID             uuid.UUID
+	ExternalTaskID string
+	Provider       string
+	// PendingTempID is metadata->>'pending_temp_id' ('' when absent). When it
+	// equals ExternalTaskID the row still carries a Todoist temp id, so no
+	// close job may be enqueued for it (mirrors todoist.isPendingTempID).
+	PendingTempID string
+}
+
+// CompleteLiveTasksForContactTx closes (state='completed') the contact's live
+// AUTOMATED tasks (lifecycle cadence_due/followup_loop, state managed/
+// pending_remote_create) inside the caller's tx and returns refs for the
+// closed rows. Manual-lifecycle rows are untouched — the merge repoints them
+// instead (RepointManualContactTasksToContact). pendingTempIDKey is the
+// metadata key holding the provider's pending temp id
+// (todoist.MetadataKeyPendingTempID), passed in so the repository stays
+// provider-blind.
+func (r *ContactTaskRepository) CompleteLiveTasksForContactTx(ctx context.Context, tx pgx.Tx, contactID uuid.UUID, pendingTempIDKey string) ([]CompletedTaskRef, error) {
+	q := r.queries
+	if tx != nil {
+		q = db.New(tx)
+	}
+	rows, err := q.CompleteLiveContactTasksForContact(ctx, db.CompleteLiveContactTasksForContactParams{
+		ContactID:        uuidToPgUUID(contactID),
+		PendingTempIDKey: pendingTempIDKey,
+	})
+	if err != nil {
+		return nil, err
+	}
+	refs := make([]CompletedTaskRef, 0, len(rows))
+	for _, row := range rows {
+		ref := CompletedTaskRef{
+			ExternalTaskID: row.ExternalTaskID,
+			Provider:       row.Provider,
+			PendingTempID:  row.PendingTempID,
+		}
+		if row.ID.Valid {
+			ref.ID = uuid.UUID(row.ID.Bytes)
+		}
+		refs = append(refs, ref)
+	}
+	return refs, nil
+}
+
 // SetContactTaskExternalIDOnlyTx persists external_task_id WITHOUT
 // touching state. Used only by the close-while-pending race path in the
 // cutover follow-up create worker — the row is already in state='completed'

--- a/backend/internal/repository/identity.go
+++ b/backend/internal/repository/identity.go
@@ -323,6 +323,37 @@ func (r *IdentityRepository) UnlinkFromContact(ctx context.Context, id uuid.UUID
 	return &ident, nil
 }
 
+// UnlinkFromContactTx is the tx-bound variant of UnlinkFromContact. Used by
+// IdentityService's liveness guard when the cached contact is tombstoned and
+// discovery finds no live match: clearing contact_id (+ match_type unmatched)
+// surfaces the identity in the unmatched queue instead of leaving it pinned
+// to a dead contact (the upsert's COALESCE would preserve the stale link).
+func (r *IdentityRepository) UnlinkFromContactTx(ctx context.Context, tx pgx.Tx, id uuid.UUID) (*ExternalIdentity, error) {
+	dbIdentity, err := db.New(tx).UnlinkIdentityFromContact(ctx, uuidToPgUUID(id))
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, db.ErrNotFound
+		}
+		return nil, err
+	}
+	ident := convertDbIdentity(dbIdentity)
+	return &ident, nil
+}
+
+// ContactIsLive reports whether the contact exists and is not soft-deleted.
+// Backs the identity-match liveness guard: a cached external_identity row
+// pointing at a merged-away (tombstoned) contact must not short-circuit the
+// discovery path. Lives on IdentityRepository because the guard's caller is
+// the identity service (which already joins contact in discovery).
+func (r *IdentityRepository) ContactIsLive(ctx context.Context, id uuid.UUID) (bool, error) {
+	return r.queries.ContactIsLive(ctx, uuidToPgUUID(id))
+}
+
+// ContactIsLiveTx is the tx-bound variant of ContactIsLive.
+func (r *IdentityRepository) ContactIsLiveTx(ctx context.Context, tx pgx.Tx, id uuid.UUID) (bool, error) {
+	return db.New(tx).ContactIsLive(ctx, uuidToPgUUID(id))
+}
+
 // ListUnmatched lists unmatched identities with pagination
 func (r *IdentityRepository) ListUnmatched(ctx context.Context, limit, offset int32) ([]ExternalIdentity, error) {
 	dbIdentities, err := r.queries.ListUnmatchedIdentities(ctx, db.ListUnmatchedIdentitiesParams{

--- a/backend/internal/service/contact.go
+++ b/backend/internal/service/contact.go
@@ -9,14 +9,17 @@ import (
 
 	"personal-crm/backend/internal/accelerated"
 	"personal-crm/backend/internal/cadence"
+	"personal-crm/backend/internal/consumer/consumerjobs"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/events"
 	"personal-crm/backend/internal/logger"
 	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/todoist"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/riverqueue/river"
 )
 
 type ContactMethodInput struct {
@@ -106,6 +109,28 @@ type ContactService struct {
 	// location/birthday/how_met write (the columns are no longer written
 	// by the contact SQL).
 	knowledge *knowledgeWriter
+	// commsRepo carries the savepoint-wrapped comms_message merge repoint
+	// (dedup soft-delete + repoint with one scoped retry). Constructed
+	// internally from database.Queries — no new constructor arg.
+	commsRepo *repository.CommsMessageRepository
+	// taskCloseEnqueuer inserts the durable Todoist close job for automated
+	// contact_task rows the merge closes with a REAL external id. Injected
+	// via SetTaskCloseEnqueuer after construction (same convention as
+	// SetCadenceUpdater). taskCloseConfigured tracks "setter called"
+	// separately from taskCloseRemoteEnabled: setter never called + eligible
+	// refs exist → error (wiring bug); called with remoteEnabled=false
+	// (follow-up mode 'off', the documented completion-disabled emergency
+	// override) → WARN + skip enqueue; enabled → enqueue.
+	taskCloseEnqueuer      repository.JobEnqueuer
+	taskCloseConfigured    bool
+	taskCloseRemoteEnabled bool
+	// mergeCommitBarrier, when non-nil, is invoked after the in-tx
+	// attribution repoints and immediately before the merge tx commit.
+	// Test-only hook (InjectMergeCommitBarrierForTest) that makes the
+	// concurrent-ingest race deterministic: a test commits a raced
+	// source-attributed row from a second connection inside the hook, and
+	// the post-commit second pass must repoint it. Nil in production.
+	mergeCommitBarrier func()
 }
 
 // NewContactService constructs a ContactService. bus and rematchRegistry
@@ -129,9 +154,32 @@ func NewContactService(
 		contactMethodRepo: contactMethodRepo,
 		interactionRepo:   interactionRepo,
 		contactTaskRepo:   contactTaskRepo,
+		commsRepo:         repository.NewCommsMessageRepository(database.Queries),
 		bus:               bus,
 		rematchRegistry:   rematchRegistry,
 	}
+}
+
+// SetTaskCloseEnqueuer injects the river job enqueuer MergeContacts uses to
+// schedule remote Todoist closes for the source contact's automated tasks.
+// remoteCloseEnabled reflects the follow-up mode gate (cutover only): the
+// close worker refuses to run outside cutover, so enqueuing in mode 'off'
+// would only manufacture failing jobs — MergeContacts skips the enqueue with
+// a WARN instead (that mode's documented contract is "completion disabled").
+// Calling the setter at all marks the dependency as configured; a merge that
+// closes an enqueue-eligible task without the setter ever being called
+// errors, surfacing the wiring bug instead of stranding a remote task.
+func (s *ContactService) SetTaskCloseEnqueuer(e repository.JobEnqueuer, remoteCloseEnabled bool) {
+	s.taskCloseEnqueuer = e
+	s.taskCloseConfigured = true
+	s.taskCloseRemoteEnabled = remoteCloseEnabled
+}
+
+// InjectMergeCommitBarrierForTest installs the test-only pre-commit barrier
+// for MergeContacts (see the mergeCommitBarrier field). Must only be called
+// before the service is used concurrently; no synchronization is performed.
+func (s *ContactService) InjectMergeCommitBarrierForTest(fn func()) {
+	s.mergeCommitBarrier = fn
 }
 
 // SetFollowUpConsumer injects the FollowUpManager consumer. Matches
@@ -1383,6 +1431,95 @@ func (s *ContactService) MergeContacts(ctx context.Context, req MergeContactsReq
 		return nil, fmt.Errorf("deduplicate calendar event contacts: %w", err)
 	}
 
+	// 6b. Re-point identity + attribution state. Soft-deleting the source
+	// below fires no FK cascades, so every one of these references would
+	// otherwise dangle at a live-but-tombstoned row: the external_identity
+	// cache would keep attributing future inbound events from the source's
+	// handles to the dead contact, and already-committed staging rows
+	// (including unprocessed ones) would strand against it.
+	if err := txQueries.RepointIdentitiesToContact(ctx, db.RepointIdentitiesToContactParams{
+		SourceContactID: sourceUUID,
+		TargetContactID: targetUUID,
+	}); err != nil {
+		return nil, fmt.Errorf("repoint external identities: %w", err)
+	}
+	if err := txQueries.RepointExternalContactsToContact(ctx, db.RepointExternalContactsToContactParams{
+		SourceContactID: sourceUUID,
+		TargetContactID: targetUUID,
+	}); err != nil {
+		return nil, fmt.Errorf("repoint external contacts: %w", err)
+	}
+	if err := txQueries.RepointMessagesMessageContact(ctx, db.RepointMessagesMessageContactParams{
+		SourceContactID: sourceUUID,
+		TargetContactID: targetUUID,
+	}); err != nil {
+		return nil, fmt.Errorf("repoint messages_message staging rows: %w", err)
+	}
+	if err := txQueries.RepointTelegramMessageContact(ctx, db.RepointTelegramMessageContactParams{
+		SourceContactID: sourceUUID,
+		TargetContactID: targetUUID,
+	}); err != nil {
+		return nil, fmt.Errorf("repoint telegram_message staging rows: %w", err)
+	}
+	if err := txQueries.RepointPhoneCallContact(ctx, db.RepointPhoneCallContactParams{
+		SourceContactID: sourceUUID,
+		TargetContactID: targetUUID,
+	}); err != nil {
+		return nil, fmt.Errorf("repoint phone_call staging rows: %w", err)
+	}
+	// comms_message needs the savepoint-wrapped two-step (dedup soft-delete
+	// then repoint): its dedup unique index includes matched_contact_id, so
+	// an email fanned out to both contacts collides on a bare repoint.
+	if err := s.commsRepo.RepointContactForMergeTx(ctx, tx, req.SourceContactID, req.TargetContactID); err != nil {
+		return nil, fmt.Errorf("repoint comms_message staging rows: %w", err)
+	}
+
+	// 6c. contact_task, split by lifecycle: manual rows are USER CONTENT and
+	// follow the survivor (collision-free — no unique index covers
+	// lifecycle='manual'); automated rows (cadence_due/followup_loop) are
+	// CLOSED instead, because repointing them collides with the target's own
+	// automated rows (unique_contact_provider_cadence has no state filter)
+	// and the target's rows already cover the survivor.
+	if err := txQueries.RepointManualContactTasksToContact(ctx, db.RepointManualContactTasksToContactParams{
+		SourceContactID: sourceUUID,
+		TargetContactID: targetUUID,
+	}); err != nil {
+		return nil, fmt.Errorf("repoint manual contact tasks: %w", err)
+	}
+	closedRefs, err := s.contactTaskRepo.CompleteLiveTasksForContactTx(ctx, tx, req.SourceContactID, todoist.MetadataKeyPendingTempID)
+	if err != nil {
+		return nil, fmt.Errorf("close live contact tasks: %w", err)
+	}
+	// Remote-close enqueue for rows with a REAL external id (non-empty and
+	// not a pending temp id — mirrors every existing close path's
+	// isPendingTempID gate; the close worker has no temp-id guard of its
+	// own). Temp-ID and empty-ID rows are closed locally only: their remote
+	// cleanup is owned by the create worker's close-while-pending branch
+	// (empty id) and the state-aware temp-mapping finalize (temp id).
+	var eligibleRefs []repository.CompletedTaskRef
+	for _, ref := range closedRefs {
+		if ref.ExternalTaskID != "" && ref.PendingTempID != ref.ExternalTaskID {
+			eligibleRefs = append(eligibleRefs, ref)
+		}
+	}
+	if len(eligibleRefs) > 0 {
+		switch {
+		case !s.taskCloseConfigured:
+			return nil, errors.New("merge contacts: task close enqueuer not wired (call SetTaskCloseEnqueuer)")
+		case !s.taskCloseRemoteEnabled:
+			logger.Warn().
+				Str("source_contact_id", req.SourceContactID.String()).
+				Int("closed_tasks", len(eligibleRefs)).
+				Msg("merge: remote task close disabled (follow-up mode off); tasks closed locally only")
+		default:
+			for _, ref := range eligibleRefs {
+				if _, err := s.taskCloseEnqueuer.InsertTx(ctx, tx, consumerjobs.TodoistFollowUpCloseJobArgs{ContactTaskID: ref.ID}, &river.InsertOpts{MaxAttempts: 10}); err != nil {
+					return nil, fmt.Errorf("enqueue todoist close for merged task %s: %w", ref.ID, err)
+				}
+			}
+		}
+	}
+
 	// 7. Update target contact with field selections and optional new
 	// name. This write is profile-only (name/location/birthday/cadence/
 	// photo/how_met) and NEVER touches the four cadence columns.
@@ -1464,10 +1601,32 @@ func (s *ContactService) MergeContacts(ctx context.Context, req MergeContactsReq
 		return nil, fmt.Errorf("soft delete source contact: %w", err)
 	}
 
+	// Test-only commit barrier: lets a race test commit a source-attributed
+	// row from a second connection between the in-tx repoints above and the
+	// commit below, deterministically exercising the post-commit second
+	// pass. Nil in production.
+	if s.mergeCommitBarrier != nil {
+		s.mergeCommitBarrier()
+	}
+
 	// Commit transaction
 	if err := tx.Commit(ctx); err != nil {
 		return nil, fmt.Errorf("commit: %w", err)
 	}
+
+	// Post-commit second pass over the attribution repoints. The merge tx
+	// runs at READ COMMITTED and only tombstones the source at commit, so a
+	// concurrently racing ingest can read the pre-merge identity row (cache
+	// hit → source) and commit a source-attributed row AFTER the in-tx
+	// repoint statements took their snapshots. Re-running the idempotent
+	// repoints once post-commit catches every raced row committed before
+	// this pass. Best-effort: the merge itself committed, so failures are
+	// logged at ERROR and do not fail the merge. (Residual: a raced ingest
+	// committing after this pass strands at most one row — staging rows
+	// self-heal via the identity liveness guard on the next event;
+	// external_contact is the documented indefinite residual, fixed
+	// manually via the import UI.)
+	s.repointMergedAttributionSecondPass(ctx, req.SourceContactID, req.TargetContactID)
 
 	// Attach methods to the merged contact
 	if err := s.attachMethods(ctx, mergedContact); err != nil {
@@ -1475,6 +1634,57 @@ func (s *ContactService) MergeContacts(ctx context.Context, req MergeContactsReq
 	}
 
 	return mergedContact, nil
+}
+
+// repointMergedAttributionSecondPass re-runs the merge's identity +
+// external_contact + staging repoints once via the non-tx path. Every
+// statement is an idempotent "WHERE ... = source" update, so re-running after
+// commit is safe; comms_message reuses the savepoint-wrapped two-step inside
+// a short transaction. Errors are logged at ERROR and swallowed — see the
+// call site in MergeContacts.
+func (s *ContactService) repointMergedAttributionSecondPass(ctx context.Context, sourceID, targetID uuid.UUID) {
+	sourceUUID := uuidToPgUUID(sourceID)
+	targetUUID := uuidToPgUUID(targetID)
+	q := s.database.Queries
+
+	logSecondPassErr := func(step string, err error) {
+		logger.Error().Err(err).
+			Str("source_contact_id", sourceID.String()).
+			Str("target_contact_id", targetID.String()).
+			Str("step", step).
+			Msg("merge attribution second pass failed; raced rows may remain attributed to the merged-away contact")
+	}
+
+	if err := q.RepointIdentitiesToContact(ctx, db.RepointIdentitiesToContactParams{
+		SourceContactID: sourceUUID, TargetContactID: targetUUID,
+	}); err != nil {
+		logSecondPassErr("external_identity", err)
+	}
+	if err := q.RepointExternalContactsToContact(ctx, db.RepointExternalContactsToContactParams{
+		SourceContactID: sourceUUID, TargetContactID: targetUUID,
+	}); err != nil {
+		logSecondPassErr("external_contact", err)
+	}
+	if err := q.RepointMessagesMessageContact(ctx, db.RepointMessagesMessageContactParams{
+		SourceContactID: sourceUUID, TargetContactID: targetUUID,
+	}); err != nil {
+		logSecondPassErr("messages_message", err)
+	}
+	if err := q.RepointTelegramMessageContact(ctx, db.RepointTelegramMessageContactParams{
+		SourceContactID: sourceUUID, TargetContactID: targetUUID,
+	}); err != nil {
+		logSecondPassErr("telegram_message", err)
+	}
+	if err := q.RepointPhoneCallContact(ctx, db.RepointPhoneCallContactParams{
+		SourceContactID: sourceUUID, TargetContactID: targetUUID,
+	}); err != nil {
+		logSecondPassErr("phone_call", err)
+	}
+	if err := pgx.BeginTxFunc(ctx, s.database.Pool, pgx.TxOptions{}, func(tx pgx.Tx) error {
+		return s.commsRepo.RepointContactForMergeTx(ctx, tx, sourceID, targetID)
+	}); err != nil {
+		logSecondPassErr("comms_message", err)
+	}
 }
 
 // buildMergeUpdateRequest creates an UpdateContactRequest based on field selections

--- a/backend/internal/service/identity.go
+++ b/backend/internal/service/identity.go
@@ -132,24 +132,52 @@ func (s *IdentityService) MatchOrCreate(ctx context.Context, req MatchRequest) (
 		return s.recordKnownMatch(ctx, normalized, req)
 	}
 
-	// 3. Discovery path: check cache first
+	// 3. Discovery path: check cache first. Liveness guard: only
+	// short-circuit when the cached contact is still live — a cached
+	// contact_id pointing at a soft-deleted contact (e.g. merged away)
+	// must fall through to discovery, which filters deleted_at and finds
+	// the survivor via the transferred contact_method.
+	var staleIdentityID *uuid.UUID
 	existing, err := s.identityRepo.GetByIdentifier(ctx, req.Type, normalized, req.Source)
 	if err == nil && existing.ContactID != nil {
+		live, lerr := s.identityRepo.ContactIsLive(ctx, *existing.ContactID)
+		if lerr != nil {
+			return nil, fmt.Errorf("check cached contact liveness: %w", lerr)
+		}
+		if live {
+			logger.Debug().
+				Str("identifier", normalized).
+				Str("source", req.Source).
+				Str("contact_id", existing.ContactID.String()).
+				Msg("found cached identity match")
+			return &MatchResult{
+				Identity:  existing,
+				ContactID: existing.ContactID,
+				MatchType: existing.MatchType,
+				Cached:    true,
+			}, nil
+		}
+		staleIdentityID = &existing.ID
 		logger.Debug().
 			Str("identifier", normalized).
 			Str("source", req.Source).
 			Str("contact_id", existing.ContactID.String()).
-			Msg("found cached identity match")
-		return &MatchResult{
-			Identity:  existing,
-			ContactID: existing.ContactID,
-			MatchType: existing.MatchType,
-			Cached:    true,
-		}, nil
+			Msg("cached identity points at tombstoned contact; falling through to discovery")
 	}
 
 	// 4. Discovery path: search contact_method table for matches
 	contactID, matchType := s.findContactByMethod(ctx, normalized, req.Type)
+
+	// 4b. No live match for a stale cached identity: explicitly unlink so
+	// the row surfaces in the unmatched queue — UpsertIdentity's
+	// COALESCE(EXCLUDED.contact_id, existing) would otherwise preserve the
+	// dead contact_id forever. Covers both no-match and ambiguous
+	// multi-match (discovery returns nil for both).
+	if contactID == nil && staleIdentityID != nil {
+		if _, uerr := s.identityRepo.UnlinkFromContact(ctx, *staleIdentityID); uerr != nil {
+			return nil, fmt.Errorf("unlink stale identity from tombstoned contact: %w", uerr)
+		}
+	}
 
 	// 5. Store/update the identity record
 	now := accelerated.GetCurrentTime()
@@ -273,15 +301,32 @@ func (s *IdentityService) MatchOrCreateTx(ctx context.Context, tx pgx.Tx, req Ma
 
 	// Cache check (matches MatchOrCreate's step 3): if we already
 	// know this identifier for this source AND a contact, return the
-	// cached match.
+	// cached match. Liveness guard: only short-circuit when the cached
+	// contact is still live — a cached contact_id pointing at a
+	// soft-deleted contact (e.g. merged away) must fall through to
+	// discovery, which filters deleted_at and finds the survivor via the
+	// transferred contact_method.
+	var staleIdentityID *uuid.UUID
 	existing, err := s.identityRepo.GetByIdentifierTx(ctx, tx, req.Type, normalized, req.Source)
 	if err == nil && existing.ContactID != nil {
-		return &MatchResult{
-			Identity:  existing,
-			ContactID: existing.ContactID,
-			MatchType: existing.MatchType,
-			Cached:    true,
-		}, nil
+		live, lerr := s.identityRepo.ContactIsLiveTx(ctx, tx, *existing.ContactID)
+		if lerr != nil {
+			return nil, fmt.Errorf("check cached contact liveness: %w", lerr)
+		}
+		if live {
+			return &MatchResult{
+				Identity:  existing,
+				ContactID: existing.ContactID,
+				MatchType: existing.MatchType,
+				Cached:    true,
+			}, nil
+		}
+		staleIdentityID = &existing.ID
+		logger.Debug().
+			Str("identifier", normalized).
+			Str("source", req.Source).
+			Str("contact_id", existing.ContactID.String()).
+			Msg("cached identity points at tombstoned contact; falling through to discovery")
 	}
 
 	// Discovery path: search contact_method for a match. Error
@@ -290,6 +335,17 @@ func (s *IdentityService) MatchOrCreateTx(ctx context.Context, tx pgx.Tx, req Ma
 	contactID, matchType, err := s.findContactByMethodTx(ctx, tx, normalized, req.Type)
 	if err != nil {
 		return nil, fmt.Errorf("find contact methods: %w", err)
+	}
+
+	// No live match for a stale cached identity: explicitly unlink so the
+	// row surfaces in the unmatched queue — UpsertIdentity's
+	// COALESCE(EXCLUDED.contact_id, existing) would otherwise preserve the
+	// dead contact_id forever. Covers both no-match and ambiguous
+	// multi-match (discovery returns nil for both).
+	if contactID == nil && staleIdentityID != nil {
+		if _, uerr := s.identityRepo.UnlinkFromContactTx(ctx, tx, *staleIdentityID); uerr != nil {
+			return nil, fmt.Errorf("unlink stale identity from tombstoned contact: %w", uerr)
+		}
 	}
 
 	now := accelerated.GetCurrentTime()

--- a/backend/internal/synthetic/replay/harness_setup.go
+++ b/backend/internal/synthetic/replay/harness_setup.go
@@ -216,6 +216,13 @@ func newHarness(ctx context.Context, database *db.Database, namespace string, se
 	knowledgeCache := consumer.NewKnowledgeCacheUpdater(graphAssertionRepo, graphNodeRepo, contactRepo)
 	contactService.SetKnowledgeWriter(assertService, knowledgeCache)
 
+	// Merge-time task-close enqueuer. Replay merge scenarios seed STANDALONE
+	// contacts (no cadence tasks), so no enqueue-eligible refs exist today;
+	// wiring with remoteCloseEnabled=false (mirroring this harness's
+	// follow-up mode: off) keeps a future profile that merges a task-bearing
+	// contact on the safe WARN-and-skip path instead of erroring.
+	contactService.SetTaskCloseEnqueuer(client, false)
+
 	// Staging registry covers telegram + messages + gchat sources. The gchat
 	// session processor is REQUIRED: without it the InteractionRecorder cannot
 	// mark comms_message(source='gchat') rows processed, the zero-rows rollback

--- a/backend/internal/synthetic/replay/todoist.go
+++ b/backend/internal/synthetic/replay/todoist.go
@@ -111,6 +111,11 @@ func (h *Harness) ReplayTodoist(ctx context.Context, contactIDs []uuid.UUID) (To
 		h.cadenceUpdater,
 		h.database.Pool,
 		func(string) todoist.Client { return fakeTodoistClient{} },
+		// Temp-ID finalize deps: the fake client returns an empty sync (no
+		// temp_id_mapping), so the state-aware finalize never runs here.
+		// remoteCloseEnabled=false mirrors the harness's follow-up mode (off).
+		nil,
+		false,
 	)
 
 	// Snapshot todoist contact_task ids before the (globally-scoped) reconcile.

--- a/backend/internal/todoist/provider.go
+++ b/backend/internal/todoist/provider.go
@@ -10,6 +10,7 @@ import (
 	"personal-crm/backend/internal/accelerated"
 	"personal-crm/backend/internal/cadence"
 	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/consumer/consumerjobs"
 	"personal-crm/backend/internal/contacttask"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/events"
@@ -20,6 +21,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
 )
 
 const (
@@ -85,6 +87,7 @@ type contactTaskWriter interface {
 	GetContactTaskByContactCadenceDue(ctx context.Context, contactID uuid.UUID, provider string) (*repository.ContactTask, error)
 	GetContactTaskByPendingTempID(ctx context.Context, provider, tempID string) (*repository.ContactTask, error)
 	GetContactTask(ctx context.Context, id uuid.UUID) (*repository.ContactTask, error)
+	GetContactTaskTx(ctx context.Context, tx pgx.Tx, id uuid.UUID) (*repository.ContactTask, error)
 	CreateContactTask(ctx context.Context, req repository.CreateContactTaskRequest) (*repository.ContactTask, error)
 	DeleteContactTask(ctx context.Context, id uuid.UUID) error
 	UpdateContactTaskState(ctx context.Context, id uuid.UUID, state repository.ContactTaskState) (*repository.ContactTask, error)
@@ -93,6 +96,7 @@ type contactTaskWriter interface {
 	UpdateContactTaskMetadataTx(ctx context.Context, tx pgx.Tx, id uuid.UUID, metadata map[string]any) (*repository.ContactTask, error)
 	UpdateContactTaskExternalID(ctx context.Context, id uuid.UUID, externalID string) (*repository.ContactTask, error)
 	UpdateContactTaskExternalIDTx(ctx context.Context, tx pgx.Tx, id uuid.UUID, externalID string) (*repository.ContactTask, error)
+	SetContactTaskExternalIDOnlyTx(ctx context.Context, tx pgx.Tx, id uuid.UUID, externalTaskID string) error
 	FindPendingFollowUp(ctx context.Context, contactID uuid.UUID) (*repository.ContactTask, error)
 	ListContactTasksByContact(ctx context.Context, contactID uuid.UUID) ([]repository.ContactTask, error)
 }
@@ -127,9 +131,23 @@ type CadenceSyncProvider struct {
 	pool          *pgxpool.Pool
 	clientFactory ClientFactory
 	frontendURL   string
+	// riverInserter + remoteCloseEnabled back the state-aware temp-ID
+	// finalize: when a temp mapping lands on a row that is no longer
+	// 'managed' (e.g. completed by a contact merge mid-flight), the finalize
+	// records the real external id WITHOUT resurrecting the row, and — for
+	// completed rows — enqueues the durable todoist_followup_close job in
+	// the same per-task tx. remoteCloseEnabled mirrors the follow-up
+	// cutover-mode gate (the close worker refuses to run outside cutover);
+	// when false the enqueue is skipped with a WARN. A nil riverInserter on
+	// the enqueue path is a wiring bug and is logged at ERROR.
+	riverInserter      repository.JobEnqueuer
+	remoteCloseEnabled bool
 }
 
-// NewCadenceSyncProvider creates a new Todoist cadence sync provider
+// NewCadenceSyncProvider creates a new Todoist cadence sync provider.
+// riverInserter + remoteCloseEnabled feed the state-aware temp-ID finalize
+// (see the struct fields); main.go passes the river client and the
+// follow-up cutover-mode gate.
 func NewCadenceSyncProvider(
 	oauthService oauthTokenProvider,
 	contactTaskRepo contactTaskWriter,
@@ -140,17 +158,21 @@ func NewCadenceSyncProvider(
 	cadenceUpdater cadenceOverrider,
 	pool *pgxpool.Pool,
 	clientFactory ClientFactory,
+	riverInserter repository.JobEnqueuer,
+	remoteCloseEnabled bool,
 ) *CadenceSyncProvider {
 	return &CadenceSyncProvider{
-		oauthService:    oauthService,
-		contactTaskRepo: contactTaskRepo,
-		contactRepo:     contactRepo,
-		cadenceUpdater:  cadenceUpdater,
-		syncRepo:        syncRepo,
-		bus:             bus,
-		pool:            pool,
-		clientFactory:   clientFactory,
-		frontendURL:     cfg.CORS.FrontendURL,
+		oauthService:       oauthService,
+		contactTaskRepo:    contactTaskRepo,
+		contactRepo:        contactRepo,
+		cadenceUpdater:     cadenceUpdater,
+		syncRepo:           syncRepo,
+		bus:                bus,
+		pool:               pool,
+		clientFactory:      clientFactory,
+		frontendURL:        cfg.CORS.FrontendURL,
+		riverInserter:      riverInserter,
+		remoteCloseEnabled: remoteCloseEnabled,
 	}
 }
 
@@ -1554,16 +1576,22 @@ func (p *CadenceSyncProvider) tryRecoverPendingTempID(ctx context.Context, item 
 		return nil, true
 	}
 
-	// Broadened guard: any managed task with a non-empty pending_temp_id
-	// is a candidate for finalizing the mapping. See function docstring.
+	// Broadened guard: any task with a non-empty pending_temp_id is a
+	// candidate for finalizing the mapping. The row's state is dispatched
+	// INSIDE the per-task tx (finalizeTempIDMappingTx): managed rows take
+	// the normal external_id + state='managed' update; rows in a terminal
+	// state (e.g. completed by a merge while the item_add was in flight)
+	// record the real id without resurrecting, and completed rows enqueue
+	// the durable remote close.
 	pendingTempID, _ := task.Metadata[MetadataKeyPendingTempID].(string)
-	if task.State != repository.ContactTaskStateManaged || pendingTempID == "" {
+	if pendingTempID == "" {
 		return nil, false
 	}
 
 	oldID := task.ExternalTaskID
 
-	// Atomic: external_id update + metadata clear inside one tx.
+	// Atomic: external_id update + metadata clear (+ any close-job enqueue)
+	// inside one tx.
 	tx, err := p.pool.Begin(ctx)
 	if err != nil {
 		logger.Warn().Err(err).
@@ -1573,22 +1601,13 @@ func (p *CadenceSyncProvider) tryRecoverPendingTempID(ctx context.Context, item 
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	if _, err := p.contactTaskRepo.UpdateContactTaskExternalIDTx(ctx, tx, task.ID, item.ID); err != nil {
+	fresh, err := p.finalizeTempIDMappingTx(ctx, tx, task.ID, item.ID)
+	if err != nil {
 		logger.Warn().Err(err).
 			Str("contactId", marker.ContactID).
 			Str("oldExternalId", oldID).
 			Str("newExternalId", item.ID).
-			Msg("tryRecoverPendingTempID: update external_id failed")
-		return task, true
-	}
-
-	metadata := task.Metadata
-	if metadata == nil {
-		metadata = make(map[string]any)
-	}
-	delete(metadata, MetadataKeyPendingTempID)
-	if _, err := p.contactTaskRepo.UpdateContactTaskMetadataTx(ctx, tx, task.ID, metadata); err != nil {
-		logger.Warn().Err(err).Msg("tryRecoverPendingTempID: clear pending_temp_id failed")
+			Msg("tryRecoverPendingTempID: finalize failed")
 		return task, true
 	}
 
@@ -1597,17 +1616,84 @@ func (p *CadenceSyncProvider) tryRecoverPendingTempID(ctx context.Context, item 
 		return task, true
 	}
 
-	// Reflect in the returned task (in-memory).
-	task.ExternalTaskID = item.ID
-	task.Metadata = metadata
-
 	logger.Info().
 		Str("contactId", marker.ContactID).
 		Str("oldTempId", oldID).
 		Str("realId", item.ID).
+		Str("state", string(fresh.State)).
 		Msg("recovered pending temp ID mapping (atomic commit)")
 
-	return task, false
+	return fresh, false
+}
+
+// finalizeTempIDMappingTx records the real Todoist id for a task whose temp
+// mapping (or marker-matched sync item) arrived, dispatching on the row's
+// CURRENT state re-read inside the caller's tx — the caller's pre-tx snapshot
+// can be stale when a concurrent close (contact merge, inbound response)
+// landed between lookup and tx start. Mirrors the follow-up create worker's
+// phase-3 dispatch:
+//   - managed: normal finalize (external_id + state='managed' in one UPDATE).
+//   - terminal states: record the id WITHOUT touching state —
+//     UpdateContactTaskExternalIDTx sets state='managed' unconditionally,
+//     which would resurrect a closed row (on a merged-away contact that
+//     zombie would be invisible to reconcile forever, since
+//     ListManagedContactTasks joins live contacts only).
+//   - completed additionally enqueues the durable todoist_followup_close job
+//     (river, MaxAttempts 10) in the same tx, mode- and wiring-gated. Durable
+//     rather than an inline command-batch close because batch failures are
+//     logged-and-forgotten while the sync cursor advances, and a completed
+//     row is skipped by every future reconcile — an inline close that fails
+//     once would strand the remote task permanently. Other terminal states
+//     (dismissed, unmanaged) deliberately get NO remote close: they mean the
+//     user dismissed the task or the CRM stopped managing it.
+//
+// Clears pending_temp_id from the FRESH row's metadata (in-tx read-modify-
+// write). Returns the fresh task with the new external id + cleared metadata
+// reflected in-memory.
+func (p *CadenceSyncProvider) finalizeTempIDMappingTx(ctx context.Context, tx pgx.Tx, taskID uuid.UUID, realID string) (*repository.ContactTask, error) {
+	fresh, err := p.contactTaskRepo.GetContactTaskTx(ctx, tx, taskID)
+	if err != nil {
+		return nil, fmt.Errorf("re-read contact_task: %w", err)
+	}
+	metadata := fresh.Metadata
+	if metadata == nil {
+		metadata = make(map[string]any)
+	}
+	delete(metadata, MetadataKeyPendingTempID)
+
+	if fresh.State == repository.ContactTaskStateManaged {
+		if _, err := p.contactTaskRepo.UpdateContactTaskExternalIDTx(ctx, tx, taskID, realID); err != nil {
+			return nil, fmt.Errorf("update external_id: %w", err)
+		}
+	} else {
+		if err := p.contactTaskRepo.SetContactTaskExternalIDOnlyTx(ctx, tx, taskID, realID); err != nil {
+			return nil, fmt.Errorf("persist external_id on %s row: %w", fresh.State, err)
+		}
+		if fresh.State == repository.ContactTaskStateCompleted {
+			switch {
+			case !p.remoteCloseEnabled:
+				logger.Warn().
+					Str("contactTaskId", taskID.String()).
+					Msg("temp-id finalize on completed row: remote close disabled (follow-up mode off); recorded id locally only")
+			case p.riverInserter == nil:
+				logger.Error().
+					Str("contactTaskId", taskID.String()).
+					Msg("temp-id finalize on completed row: river inserter not wired; remote Todoist task will dangle")
+			default:
+				if _, err := p.riverInserter.InsertTx(ctx, tx, consumerjobs.TodoistFollowUpCloseJobArgs{ContactTaskID: taskID}, &river.InsertOpts{MaxAttempts: 10}); err != nil {
+					return nil, fmt.Errorf("enqueue close for completed row: %w", err)
+				}
+			}
+		}
+	}
+
+	if _, err := p.contactTaskRepo.UpdateContactTaskMetadataTx(ctx, tx, taskID, metadata); err != nil {
+		return nil, fmt.Errorf("clear pending_temp_id: %w", err)
+	}
+
+	fresh.ExternalTaskID = realID
+	fresh.Metadata = metadata
+	return fresh, nil
 }
 
 // createTaskCommand creates a Todoist task creation command
@@ -1688,16 +1774,12 @@ func (p *CadenceSyncProvider) processTempIDMappings(ctx context.Context, tempIDM
 			}
 			defer func() { _ = tx.Rollback(ctx) }()
 
-			if _, err := p.contactTaskRepo.UpdateContactTaskExternalIDTx(ctx, tx, task.ID, realID); err != nil {
-				return fmt.Errorf("update external_id: %w", err)
-			}
-			metadata := task.Metadata
-			if metadata == nil {
-				metadata = make(map[string]any)
-			}
-			delete(metadata, MetadataKeyPendingTempID)
-			if _, err := p.contactTaskRepo.UpdateContactTaskMetadataTx(ctx, tx, task.ID, metadata); err != nil {
-				return fmt.Errorf("clear pending_temp_id: %w", err)
+			// State-aware finalize (re-reads the row inside the tx): a row
+			// closed mid-flight (e.g. by a contact merge) records the real
+			// id without being resurrected to 'managed', and a completed
+			// row's remote task is closed via the durable river job.
+			if _, err := p.finalizeTempIDMappingTx(ctx, tx, task.ID, realID); err != nil {
+				return err
 			}
 			return tx.Commit(ctx)
 		}()

--- a/backend/internal/todoist/provider_atomic_tx_integration_test.go
+++ b/backend/internal/todoist/provider_atomic_tx_integration_test.go
@@ -180,6 +180,8 @@ func setupAtomicTxTestEnv(t *testing.T) (*atomicTxTestEnv, func()) {
 		cadenceFake,
 		database.Pool,
 		DefaultClientFactory,
+		riverClient,
+		true,
 	)
 
 	cleanup := func() {
@@ -861,6 +863,8 @@ func TestTodoist_Sync_ReconcileDefersSkipDriftAfterMappingRollback(t *testing.T)
 		env.cadenceFake,
 		env.pool,
 		func(_ string) Client { return mock },
+		env.riverClient,
+		true,
 	)
 
 	// Prime the post-items TempIDMap by pre-registering the temp_id.
@@ -1077,6 +1081,8 @@ func TestSync_StaleTodoistDeadline_OutreachRecovery(t *testing.T) {
 		env.cadenceFake,
 		env.pool,
 		func(_ string) Client { return mock },
+		env.riverClient,
+		true,
 	)
 
 	state := makeStaleDeadlineSyncState(env)
@@ -1173,6 +1179,8 @@ func TestSync_StaleTodoistDeadline_CRMDriftPath(t *testing.T) {
 		env.cadenceFake,
 		env.pool,
 		func(_ string) Client { return mock },
+		env.riverClient,
+		true,
 	)
 
 	state := makeStaleDeadlineSyncState(env)
@@ -1285,6 +1293,8 @@ func TestProcessItem_DeadlineEditTxFailure_RollsBackAndSurfacesErr(t *testing.T)
 		env.cadenceFake,
 		env.pool,
 		func(_ string) Client { return mock },
+		env.riverClient,
+		true,
 	)
 
 	state := makeStaleDeadlineSyncState(env)
@@ -1370,6 +1380,8 @@ func TestSync_LegitimateTodoistEdit_SameTickReconcileIsNotSpuriousCloseCreate(t 
 		env.cadenceFake,
 		env.pool,
 		func(_ string) Client { return mock },
+		env.riverClient,
+		true,
 	)
 
 	state := makeStaleDeadlineSyncState(env)

--- a/backend/internal/todoist/provider_atomic_tx_integration_test.go
+++ b/backend/internal/todoist/provider_atomic_tx_integration_test.go
@@ -155,6 +155,9 @@ func setupAtomicTxTestEnv(t *testing.T) (*atomicTxTestEnv, func()) {
 	river.AddWorker(workers, &noopCadenceUpdaterWorker{})
 	river.AddWorker(workers, &noopFollowUpManagerWorker{})
 	river.AddWorker(workers, &noopRematchDispatcherWorker{})
+	// The state-aware temp-ID finalize enqueues todoist_followup_close for a
+	// completed row; register a noop worker so the insert validates.
+	river.AddWorker(workers, &noopTodoistCloseWorker{})
 
 	riverClient, err := river.NewClient(riverpgxv5.New(database.Pool), &river.Config{
 		Queues: map[string]river.QueueConfig{

--- a/backend/internal/todoist/provider_dismissal_test.go
+++ b/backend/internal/todoist/provider_dismissal_test.go
@@ -166,6 +166,8 @@ func newProviderTestEnv(t *testing.T) *providerTestEnv {
 		cadenceFake,
 		database.Pool,
 		DefaultClientFactory,
+		nil,   // riverInserter: dismissal paths never reach the temp-ID finalize
+		false, // remoteCloseEnabled: mirrors follow-up mode off in this harness
 	)
 
 	settings := Settings{

--- a/backend/internal/todoist/provider_tempid_finalize_test.go
+++ b/backend/internal/todoist/provider_tempid_finalize_test.go
@@ -1,0 +1,179 @@
+package todoist
+
+// State-aware temp-ID finalize tests: a cadence row whose temp mapping (or
+// marker-matched sync item) arrives AFTER the row left 'managed' (e.g.
+// completed by a contact merge mid-flight) must record the real external id
+// WITHOUT being resurrected to 'managed', and a completed row must get the
+// durable todoist_followup_close job. Same-package so the tests can call the
+// unexported processTempIDMappings / processItem directly.
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/consumer/consumerjobs"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/riverqueue/river"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// noopTodoistCloseWorker satisfies the todoist_followup_close kind on the
+// atomic env's TestOnly river client so finalize enqueues validate at insert
+// time. It never performs remote work.
+type noopTodoistCloseWorker struct {
+	river.WorkerDefaults[consumerjobs.TodoistFollowUpCloseJobArgs]
+}
+
+func (*noopTodoistCloseWorker) Work(context.Context, *river.Job[consumerjobs.TodoistFollowUpCloseJobArgs]) error {
+	return nil
+}
+
+// seedPendingTempIDTask puts a managed cadence task into the mid-create
+// shape: external_task_id == metadata.pending_temp_id == tempID.
+func seedPendingTempIDTask(t *testing.T, env *atomicTxTestEnv, namePrefix, tempID string) (*repository.Contact, *repository.ContactTask) {
+	t.Helper()
+	contact, task := createManagedCadenceTask(t, env, namePrefix)
+	_, err := env.contactTaskRepo.UpdateContactTaskExternalID(env.ctx, task.ID, tempID)
+	require.NoError(t, err)
+	_, err = env.contactTaskRepo.UpdateContactTaskMetadata(env.ctx, task.ID, map[string]any{
+		MetadataKeyPendingTempID: tempID,
+	})
+	require.NoError(t, err)
+	return contact, task
+}
+
+func closeJobCountFor(t *testing.T, env *atomicTxTestEnv, taskID uuid.UUID) int64 {
+	t.Helper()
+	n, err := env.contactTaskRepo.CountRiverJobsByContactTask(env.ctx, "todoist_followup_close", taskID)
+	require.NoError(t, err)
+	return n
+}
+
+// TestTodoist_TempIDFinalize_CompletedRowStaysCompletedAndClosesRemote pins
+// the merge-race fix: a row completed while its item_add was in flight must
+// NOT be flipped back to 'managed' by the temp mapping (the old
+// UpdateContactTaskExternalID path set state='managed' unconditionally —
+// resurrecting a zombie on a tombstoned contact), and the freshly-created
+// remote task must be closed via the durable river job.
+func TestTodoist_TempIDFinalize_CompletedRowStaysCompletedAndClosesRemote(t *testing.T) {
+	env, cleanup := setupAtomicTxTestEnv(t)
+	defer cleanup()
+
+	tempID := "temp-done-" + uuid.New().String()[:8]
+	_, task := seedPendingTempIDTask(t, env, "TempDone", tempID)
+
+	// The row leaves 'managed' (e.g. a contact merge closed it) while the
+	// item_add / temp mapping is still in flight.
+	_, err := env.contactTaskRepo.UpdateContactTaskState(env.ctx, task.ID, repository.ContactTaskStateCompleted)
+	require.NoError(t, err)
+
+	realID := "real-done-" + uuid.New().String()[:8]
+	rolledBack := env.provider.processTempIDMappings(env.ctx, map[string]string{tempID: realID})
+	assert.False(t, rolledBack)
+
+	reloaded, err := env.contactTaskRepo.GetContactTask(env.ctx, task.ID)
+	require.NoError(t, err)
+	assert.Equal(t, repository.ContactTaskStateCompleted, reloaded.State, "finalize must NOT resurrect a completed row to managed")
+	assert.Equal(t, realID, reloaded.ExternalTaskID, "real id recorded")
+	_, hasPending := reloaded.Metadata[MetadataKeyPendingTempID]
+	assert.False(t, hasPending, "pending_temp_id cleared")
+	assert.EqualValues(t, 1, closeJobCountFor(t, env, task.ID), "durable close job enqueued for the completed row")
+}
+
+// TestTodoist_TempIDFinalize_ManagedRowUnchanged is the regression pin: the
+// managed path is byte-identical to the old behavior — state stays managed,
+// real id recorded, no close job.
+func TestTodoist_TempIDFinalize_ManagedRowUnchanged(t *testing.T) {
+	env, cleanup := setupAtomicTxTestEnv(t)
+	defer cleanup()
+
+	tempID := "temp-mgd-" + uuid.New().String()[:8]
+	_, task := seedPendingTempIDTask(t, env, "TempManaged", tempID)
+
+	realID := "real-mgd-" + uuid.New().String()[:8]
+	rolledBack := env.provider.processTempIDMappings(env.ctx, map[string]string{tempID: realID})
+	assert.False(t, rolledBack)
+
+	reloaded, err := env.contactTaskRepo.GetContactTask(env.ctx, task.ID)
+	require.NoError(t, err)
+	assert.Equal(t, repository.ContactTaskStateManaged, reloaded.State)
+	assert.Equal(t, realID, reloaded.ExternalTaskID)
+	_, hasPending := reloaded.Metadata[MetadataKeyPendingTempID]
+	assert.False(t, hasPending)
+	assert.EqualValues(t, 0, closeJobCountFor(t, env, task.ID), "no close job on the managed path")
+}
+
+// TestTodoist_TempIDFinalize_RemoteCloseDisabledSkipsEnqueue covers the
+// mode-'off' gate: the finalize still preserves state + records the real id,
+// but no close job is enqueued (WARN path).
+func TestTodoist_TempIDFinalize_RemoteCloseDisabledSkipsEnqueue(t *testing.T) {
+	env, cleanup := setupAtomicTxTestEnv(t)
+	defer cleanup()
+
+	// Provider with remote close DISABLED (follow-up mode off).
+	provider := NewCadenceSyncProvider(
+		stubOAuthProvider{},
+		env.faultyTaskWriter,
+		env.contactRepo,
+		nil,
+		config.TestConfig(),
+		env.bus,
+		env.cadenceFake,
+		env.pool,
+		DefaultClientFactory,
+		env.riverClient,
+		false,
+	)
+
+	tempID := "temp-off-" + uuid.New().String()[:8]
+	_, task := seedPendingTempIDTask(t, env, "TempOff", tempID)
+	_, err := env.contactTaskRepo.UpdateContactTaskState(env.ctx, task.ID, repository.ContactTaskStateCompleted)
+	require.NoError(t, err)
+
+	realID := "real-off-" + uuid.New().String()[:8]
+	rolledBack := provider.processTempIDMappings(env.ctx, map[string]string{tempID: realID})
+	assert.False(t, rolledBack)
+
+	reloaded, err := env.contactTaskRepo.GetContactTask(env.ctx, task.ID)
+	require.NoError(t, err)
+	assert.Equal(t, repository.ContactTaskStateCompleted, reloaded.State)
+	assert.Equal(t, realID, reloaded.ExternalTaskID)
+	assert.EqualValues(t, 0, closeJobCountFor(t, env, task.ID), "no close job when remote close is disabled")
+}
+
+// TestTodoist_TryRecoverPendingTempID_CompletedRowViaProcessItem mirrors the
+// completed-row finalize through the OTHER site: processItem falls back to
+// tryRecoverPendingTempID when the item's real id has no contact_task row,
+// and the marker-matched completed row must be finalized without resurrection
+// (processItem then skips it as non-managed).
+func TestTodoist_TryRecoverPendingTempID_CompletedRowViaProcessItem(t *testing.T) {
+	env, cleanup := setupAtomicTxTestEnv(t)
+	defer cleanup()
+
+	tempID := "temp-item-" + uuid.New().String()[:8]
+	contact, task := seedPendingTempIDTask(t, env, "TempItem", tempID)
+	_, err := env.contactTaskRepo.UpdateContactTaskState(env.ctx, task.ID, repository.ContactTaskStateCompleted)
+	require.NoError(t, err)
+
+	realID := "real-item-" + uuid.New().String()[:8]
+	marker := fmt.Sprintf(`{"crm":true,"contact_id":"%s","kind":"cadence","instance":"x"}`, contact.ID.String())
+	result := env.provider.processItem(env.ctx, SyncItem{
+		ID:          realID,
+		Description: marker,
+	}, env.settings, env.accountID)
+	require.NoError(t, result.Err)
+	assert.False(t, result.RecoveryFailed)
+
+	reloaded, err := env.contactTaskRepo.GetContactTask(env.ctx, task.ID)
+	require.NoError(t, err)
+	assert.Equal(t, repository.ContactTaskStateCompleted, reloaded.State, "recovery must NOT resurrect a completed row")
+	assert.Equal(t, realID, reloaded.ExternalTaskID)
+	_, hasPending := reloaded.Metadata[MetadataKeyPendingTempID]
+	assert.False(t, hasPending)
+	assert.EqualValues(t, 1, closeJobCountFor(t, env, task.ID), "durable close job enqueued via the recovery site")
+}

--- a/backend/tests/api/ingest_merge_attribution_test.go
+++ b/backend/tests/api/ingest_merge_attribution_test.go
@@ -1,0 +1,133 @@
+package api
+
+// End-to-end confirmation of the merge identity-attribution fix through the
+// REAL ingest path: a raw_message from the loser's handle is ingested (seeding
+// the identity cache), the loser is merged into the winner via the production
+// MergeContacts, and a SECOND raw_message from the same handle must stage with
+// matched_contact_id = the winner — not the tombstoned loser.
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"personal-crm/backend/internal/consumer"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// newMergeCapableContactService wires a ContactService against the ingest
+// env's per-test clone with the dependencies MergeContacts requires (cadence
+// updater + knowledge writer + task-close enqueuer). The knowledge bus reuses
+// the env's insert-only river client (apiKnowledgeCacheNoopWorker registers
+// the assertion job kind).
+func newMergeCapableContactService(t *testing.T, env *ingestRawTestEnv) *service.ContactService {
+	t.Helper()
+	database := env.database
+
+	interactionRepo := repository.NewInteractionRepository(database.Queries)
+	taskRepo := repository.NewContactTaskRepository(database.Queries)
+	nodeRepo := repository.NewNodeRepository(database.Queries)
+	entityRepo := repository.NewEntityRepository(database.Queries)
+	predicateRepo := repository.NewPredicateRepository(database.Queries)
+	assertionRepo := repository.NewAssertionRepository(database.Queries)
+	eventRepo := repository.NewEventRepository(database.Queries)
+
+	bus := events.NewBus(database.Pool, env.riverClient, eventRepo)
+	assertSvc := service.NewAssertService(database.Pool, nodeRepo, entityRepo, predicateRepo, assertionRepo, bus)
+	cache := consumer.NewKnowledgeCacheUpdater(assertionRepo, nodeRepo, env.contactRepo)
+
+	svc := service.NewContactService(database, env.contactRepo, env.cmRepo, interactionRepo, taskRepo, nil, nil)
+	svc.SetKnowledgeWriter(assertSvc, cache)
+
+	claimRepo := repository.NewEventConsumerClaimRepository(database.Queries)
+	cadenceUpdater := consumer.NewCadenceUpdater(claimRepo, env.contactRepo, database.Queries, consumer.CadenceModeCutover, false)
+	svc.SetCadenceUpdater(cadenceUpdater)
+
+	// No contact tasks are seeded in this env; wired defensively so a merge
+	// that ever closes an eligible task takes the WARN-skip path, not the
+	// wiring-bug error.
+	svc.SetTaskCloseEnqueuer(env.riverClient, false)
+	return svc
+}
+
+// TestIngestRawMessage_AfterMerge_AttributesToSurvivor is the faithful
+// reproduction of the report: ingest a message from a loser handle, merge the
+// loser into the winner, ingest again, and assert BOTH the historical and the
+// new staging rows attribute to the winner.
+func TestIngestRawMessage_AfterMerge_AttributesToSurvivor(t *testing.T) {
+	env := setupRawIngestEnv(t)
+	t.Parallel()
+	ctx := context.Background()
+
+	contactSvc := newMergeCapableContactService(t, env)
+
+	// Winner + loser created through the production service path (so their
+	// person nodes exist for the merge's graph step). The loser owns the
+	// handle the daemon reports.
+	const loserHandle = "+15559990001"
+	winner, _, err := contactSvc.CreateContact(ctx, repository.CreateContactRequest{
+		FullName: "Merge E2E Winner",
+	}, nil)
+	require.NoError(t, err)
+	loser, _, err := contactSvc.CreateContact(ctx, repository.CreateContactRequest{
+		FullName: "Merge E2E Loser",
+	}, nil)
+	require.NoError(t, err)
+	_, err = env.cmRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
+		ContactID: loser.ID,
+		Type:      "phone",
+		Value:     loserHandle,
+	})
+	require.NoError(t, err)
+
+	// First ingest: discovery matches the loser and seeds the identity cache.
+	guid1 := "merge-e2e-guid-" + uuid.NewString()
+	ev1 := buildRawMessageEvent(t, events.KindRawMessageReceived, env.pairedHostID,
+		guid1, "merge-e2e-chat", loserHandle)
+	w := postIngestRaw(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{ev1},
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp := parseIngestResp(t, w)
+	require.Equal(t, 1, resp.Accepted, "errors: %+v", resp.Errors)
+
+	msg1, err := env.messagesRepo.GetMessage(ctx, guid1)
+	require.NoError(t, err)
+	require.NotNil(t, msg1.MatchedContactID)
+	require.Equal(t, loser.ID, *msg1.MatchedContactID, "pre-merge attribution goes to the loser")
+
+	// Merge the loser into the winner via the production path.
+	_, err = contactSvc.MergeContacts(ctx, service.MergeContactsRequest{
+		SourceContactID: loser.ID,
+		TargetContactID: winner.ID,
+	})
+	require.NoError(t, err)
+
+	// Second ingest from the SAME handle: the cached identity must not
+	// short-circuit to the tombstoned loser.
+	guid2 := "merge-e2e-guid-" + uuid.NewString()
+	ev2 := buildRawMessageEvent(t, events.KindRawMessageReceived, env.pairedHostID,
+		guid2, "merge-e2e-chat", loserHandle)
+	w = postIngestRaw(t, env, &env.pairedHostID, env.pairedHostKey, map[string]any{
+		"events": []any{ev2},
+	})
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	resp = parseIngestResp(t, w)
+	require.Equal(t, 1, resp.Accepted, "errors: %+v", resp.Errors)
+
+	msg2, err := env.messagesRepo.GetMessage(ctx, guid2)
+	require.NoError(t, err)
+	require.NotNil(t, msg2.MatchedContactID)
+	require.Equal(t, winner.ID, *msg2.MatchedContactID, "post-merge ingest attributes to the survivor")
+
+	// The historical staging row was repointed by the merge as well.
+	msg1After, err := env.messagesRepo.GetMessage(ctx, guid1)
+	require.NoError(t, err)
+	require.NotNil(t, msg1After.MatchedContactID)
+	require.Equal(t, winner.ID, *msg1After.MatchedContactID, "pre-merge staging row repointed to the survivor")
+}

--- a/backend/tests/contact_merge_identity_attribution_integration_test.go
+++ b/backend/tests/contact_merge_identity_attribution_integration_test.go
@@ -6,13 +6,17 @@ import (
 	"context"
 	"testing"
 
+	"personal-crm/backend/internal/accelerated"
 	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/consumer"
+	"personal-crm/backend/internal/consumer/consumerjobs"
+	"personal-crm/backend/internal/contacttask"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/events"
 	"personal-crm/backend/internal/identity"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/service"
+	"personal-crm/backend/internal/todoist"
 
 	"github.com/google/uuid"
 	"github.com/riverqueue/river"
@@ -20,6 +24,17 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// mergeCloseNoopWorker satisfies the todoist_followup_close kind on the
+// harness's insert-only river client so MergeContacts' close-job enqueues
+// validate at insert time. Never runs (the client is not started).
+type mergeCloseNoopWorker struct {
+	river.WorkerDefaults[consumerjobs.TodoistFollowUpCloseJobArgs]
+}
+
+func (*mergeCloseNoopWorker) Work(context.Context, *river.Job[consumerjobs.TodoistFollowUpCloseJobArgs]) error {
+	return nil
+}
 
 // mergeAttrHarness bundles a fully-wired ContactService plus the identity
 // service and the staging/task repositories a merge-attribution test reads
@@ -42,7 +57,15 @@ type mergeAttrHarness struct {
 	taskRepo     *repository.ContactTaskRepository
 }
 
+// newMergeAttrHarness builds the default harness: the task-close enqueuer is
+// wired (like production main.go in cutover mode). Tests exercising the D9
+// wiring contract use newMergeAttrHarnessWith directly.
 func newMergeAttrHarness(t *testing.T, ctx context.Context) *mergeAttrHarness {
+	t.Helper()
+	return newMergeAttrHarnessWith(t, ctx, true, true)
+}
+
+func newMergeAttrHarnessWith(t *testing.T, ctx context.Context, wireTaskCloseEnqueuer, remoteCloseEnabled bool) *mergeAttrHarness {
 	t.Helper()
 	database, cfg := newIsolatedRiverTestDB(t, ctx)
 
@@ -69,6 +92,7 @@ func newMergeAttrHarness(t *testing.T, ctx context.Context) *mergeAttrHarness {
 	// close-job enqueue path exercised by the merge tests.
 	workers := river.NewWorkers()
 	river.AddWorker(workers, &knowledgeCacheNoopWorker{})
+	river.AddWorker(workers, &mergeCloseNoopWorker{})
 	client, err := river.NewClient(riverpgxv5.New(database.Pool), &river.Config{
 		Queues:   map[string]river.QueueConfig{river.QueueDefault: {MaxWorkers: cfg.River.WorkerConcurrency}},
 		Workers:  workers,
@@ -83,6 +107,9 @@ func newMergeAttrHarness(t *testing.T, ctx context.Context) *mergeAttrHarness {
 	contactSvc := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, taskRepo, nil, nil)
 	contactSvc.SetKnowledgeWriter(assertSvc, cacheUpdater)
 	wireCadenceUpdaterForTest(t, database, contactSvc)
+	if wireTaskCloseEnqueuer {
+		contactSvc.SetTaskCloseEnqueuer(client, remoteCloseEnabled)
+	}
 
 	identitySvc := service.NewIdentityService(identityRepo)
 
@@ -177,4 +204,578 @@ func TestMergeContacts_IdentityAttribution_FollowsSurvivor(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, post.ContactID)
 	assert.Equal(t, a.ID, *post.ContactID, "post-merge attribution must follow the survivor A")
+}
+
+// TestMergeContacts_RepointsIdentityAndAttribution asserts the historical-row
+// half of the fix: after merging B into A, the identity-cache row, the
+// external_contact import link, and a pre-merge B-attributed row in EACH of
+// the four ingest-staging tables all point at A.
+func TestMergeContacts_RepointsIdentityAndAttribution(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	t.Parallel()
+	ctx := ctx0()
+
+	h := newMergeAttrHarness(t, ctx)
+	now := accelerated.GetCurrentTime()
+
+	const phone = "+15550100001"
+	a := h.createContact(t, ctx, "repoint survivor")
+	b := h.createContact(t, ctx, "repoint loser")
+	h.addPhone(t, ctx, b.ID, phone)
+
+	// Identity cache → B.
+	pre, err := h.identitySvc.MatchOrCreate(ctx, service.MatchRequest{
+		RawIdentifier: phone,
+		Type:          identity.IdentifierTypePhone,
+		Source:        "messages",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, pre.ContactID)
+	require.Equal(t, b.ID, *pre.ContactID)
+
+	// external_contact linked to B.
+	ec, err := h.externalRepo.Upsert(ctx, repository.UpsertExternalContactRequest{
+		Source:   "google_contacts",
+		SourceID: "merge-attr-ec-1",
+	})
+	require.NoError(t, err)
+	_, err = h.externalRepo.UpdateMatch(ctx, ec.ID, &b.ID, repository.MatchStatusMatched)
+	require.NoError(t, err)
+
+	// One B-attributed staging row per table.
+	_, err = h.messagesRepo.UpsertMessage(ctx, repository.UpsertMessagesMessageParams{
+		Guid:             "merge-attr-guid-1",
+		ChatGuid:         "merge-attr-chat-1",
+		PeerHandle:       phone,
+		MessageType:      "text",
+		SentAt:           now,
+		MatchedContactID: &b.ID,
+	})
+	require.NoError(t, err)
+
+	peerUserID := int64(910001)
+	_, err = h.telegramRepo.UpsertMessage(ctx, repository.UpsertTelegramMessageParams{
+		TelegramMessageID: 42001,
+		TelegramChatID:    910001,
+		ChatType:          "private",
+		MessageType:       "text",
+		SentAt:            now,
+		PeerUserID:        &peerUserID,
+	})
+	require.NoError(t, err)
+	require.NoError(t, h.telegramRepo.UpdateMessageContact(ctx, peerUserID, b.ID))
+
+	_, err = h.phoneRepo.UpsertCall(ctx, repository.UpsertPhoneCallParams{
+		CallUniqueID:     "merge-attr-call-1",
+		PeerHandle:       phone,
+		PeerNormalized:   identity.Normalize(phone, identity.IdentifierTypePhone),
+		Service:          "voice",
+		Direction:        "inbound",
+		DurationSeconds:  30,
+		StartedAt:        now,
+		MatchedContactID: &b.ID,
+	})
+	require.NoError(t, err)
+
+	gmailID := "gm-merge-attr-1"
+	_, err = h.commsRepo.UpsertMessage(ctx, repository.UpsertCommsMessageParams{
+		Source:           "email",
+		ExternalID:       "merge-attr-email-1",
+		Direction:        "inbound",
+		SentAt:           now,
+		SourceMetadata:   []byte(`{}`),
+		MatchedContactID: b.ID,
+		GmailMessageID:   &gmailID,
+	})
+	require.NoError(t, err)
+
+	// Merge B → A.
+	_, err = h.contactSvc.MergeContacts(ctx, service.MergeContactsRequest{
+		SourceContactID: b.ID,
+		TargetContactID: a.ID,
+	})
+	require.NoError(t, err)
+
+	// Identity cache repointed.
+	ident, err := h.identityRepo.GetByIdentifier(ctx, identity.IdentifierTypePhone,
+		identity.Normalize(phone, identity.IdentifierTypePhone), "messages")
+	require.NoError(t, err)
+	require.NotNil(t, ident.ContactID)
+	assert.Equal(t, a.ID, *ident.ContactID, "external_identity repointed to A")
+
+	// external_contact repointed.
+	ecAfter, err := h.externalRepo.GetByID(ctx, ec.ID)
+	require.NoError(t, err)
+	require.NotNil(t, ecAfter.CRMContactID)
+	assert.Equal(t, a.ID, *ecAfter.CRMContactID, "external_contact.crm_contact_id repointed to A")
+
+	// All four staging tables repointed.
+	mm, err := h.messagesRepo.GetMessage(ctx, "merge-attr-guid-1")
+	require.NoError(t, err)
+	require.NotNil(t, mm.MatchedContactID)
+	assert.Equal(t, a.ID, *mm.MatchedContactID, "messages_message repointed to A")
+
+	tm, err := h.telegramRepo.GetMessage(ctx, 910001, 42001)
+	require.NoError(t, err)
+	require.NotNil(t, tm.MatchedContactID)
+	assert.Equal(t, a.ID, *tm.MatchedContactID, "telegram_message repointed to A")
+
+	pc, err := h.phoneRepo.GetCallByUniqueID(ctx, "merge-attr-call-1")
+	require.NoError(t, err)
+	require.NotNil(t, pc.MatchedContactID)
+	assert.Equal(t, a.ID, *pc.MatchedContactID, "phone_call repointed to A")
+
+	cm, err := h.commsRepo.GetMessage(ctx, "email", "merge-attr-email-1", a.ID)
+	require.NoError(t, err)
+	assert.Equal(t, a.ID, cm.MatchedContactID, "comms_message repointed to A")
+}
+
+// TestMergeContacts_CommsMessageDedupCollision covers the email-fanout shape:
+// one upstream message stored live under BOTH contacts. A bare repoint would
+// abort the merge with a 23505 on idx_comms_message_dedup; the two-step
+// (soft-delete B's colliding copy, then repoint the rest) must succeed.
+func TestMergeContacts_CommsMessageDedupCollision(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	t.Parallel()
+	ctx := ctx0()
+
+	h := newMergeAttrHarness(t, ctx)
+	now := accelerated.GetCurrentTime()
+
+	a := h.createContact(t, ctx, "comms dedup survivor")
+	b := h.createContact(t, ctx, "comms dedup loser")
+
+	gmailID := "gm-fanout-1"
+	seed := func(extID string, contactID uuid.UUID) {
+		t.Helper()
+		_, err := h.commsRepo.UpsertMessage(ctx, repository.UpsertCommsMessageParams{
+			Source:           "email",
+			ExternalID:       extID,
+			Direction:        "inbound",
+			SentAt:           now,
+			SourceMetadata:   []byte(`{}`),
+			MatchedContactID: contactID,
+			GmailMessageID:   &gmailID,
+		})
+		require.NoError(t, err)
+	}
+	// The fanout collision: same (source, external_id) live under A AND B.
+	seed("fanout-1", a.ID)
+	seed("fanout-1", b.ID)
+	// A non-colliding B row that must simply follow the survivor.
+	seed("solo-1", b.ID)
+
+	_, err := h.contactSvc.MergeContacts(ctx, service.MergeContactsRequest{
+		SourceContactID: b.ID,
+		TargetContactID: a.ID,
+	})
+	require.NoError(t, err, "merge must not abort on the comms dedup collision")
+
+	// A's fanout row is untouched and is the ONLY live row for that message.
+	fanout, err := h.commsRepo.GetMessage(ctx, "email", "fanout-1", a.ID)
+	require.NoError(t, err)
+	assert.Equal(t, a.ID, fanout.MatchedContactID)
+
+	// B's non-colliding row followed the survivor.
+	solo, err := h.commsRepo.GetMessage(ctx, "email", "solo-1", a.ID)
+	require.NoError(t, err)
+	assert.Equal(t, a.ID, solo.MatchedContactID)
+
+	// No live rows remain attributed to B (the colliding copy was
+	// soft-deleted, then repointed as a tombstone).
+	remaining, err := h.commsRepo.ListByContact(ctx, b.ID)
+	require.NoError(t, err)
+	assert.Empty(t, remaining, "no live comms rows may remain on the tombstoned B")
+
+	// Exactly one live row for the fanned-out message overall.
+	aRows, err := h.commsRepo.ListByContact(ctx, a.ID)
+	require.NoError(t, err)
+	fanoutCount := 0
+	for _, row := range aRows {
+		if row.ExternalID == "fanout-1" {
+			fanoutCount++
+		}
+	}
+	assert.Equal(t, 1, fanoutCount, "exactly one live copy of the fanned-out message")
+}
+
+// TestCommsRepointForMerge_RacedInsertRetries deterministically exercises the
+// savepoint-retry path in RepointContactForMergeTx: a second connection
+// commits A's copy of the message between the dedup and repoint statements
+// (via the test barrier), the repoint hits 23505 on idx_comms_message_dedup,
+// and the scoped retry must recover WITHOUT aborting the outer tx. This test
+// fails if the savepoint/retry is removed.
+func TestCommsRepointForMerge_RacedInsertRetries(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	t.Parallel()
+	ctx := ctx0()
+
+	h := newMergeAttrHarness(t, ctx)
+	now := accelerated.GetCurrentTime()
+
+	a := h.createContact(t, ctx, "comms race survivor")
+	b := h.createContact(t, ctx, "comms race loser")
+
+	gmailID := "gm-race-1"
+	// B's live row exists BEFORE the repoint; A has none yet, so the first
+	// attempt's dedup statement sees nothing to tombstone.
+	_, err := h.commsRepo.UpsertMessage(ctx, repository.UpsertCommsMessageParams{
+		Source:           "email",
+		ExternalID:       "race-1",
+		Direction:        "inbound",
+		SentAt:           now,
+		SourceMetadata:   []byte(`{}`),
+		MatchedContactID: b.ID,
+		GmailMessageID:   &gmailID,
+	})
+	require.NoError(t, err)
+
+	// Barrier: commit A's copy from a SECOND pool connection between the
+	// dedup and repoint statements of the first savepoint attempt.
+	h.commsRepo.SetRepointBarrierForTest(func() {
+		_, berr := h.commsRepo.UpsertMessage(ctx, repository.UpsertCommsMessageParams{
+			Source:           "email",
+			ExternalID:       "race-1",
+			Direction:        "inbound",
+			SentAt:           now,
+			SourceMetadata:   []byte(`{}`),
+			MatchedContactID: a.ID,
+			GmailMessageID:   &gmailID,
+		})
+		require.NoError(t, berr)
+	})
+
+	tx, err := h.database.Pool.Begin(ctx)
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	require.NoError(t, h.commsRepo.RepointContactForMergeTx(ctx, tx, b.ID, a.ID),
+		"savepoint retry must recover from the raced insert without aborting the outer tx")
+
+	// The outer tx is still usable (NOT aborted) — commit must succeed.
+	require.NoError(t, tx.Commit(ctx))
+
+	// B's raced-colliding row was tombstoned by the retry's dedup pass; A's
+	// row survives as the single live copy.
+	live, err := h.commsRepo.GetMessage(ctx, "email", "race-1", a.ID)
+	require.NoError(t, err)
+	assert.Equal(t, a.ID, live.MatchedContactID)
+	remaining, err := h.commsRepo.ListByContact(ctx, b.ID)
+	require.NoError(t, err)
+	assert.Empty(t, remaining, "no live comms rows may remain on B after the retried repoint")
+}
+
+// TestMergeContacts_SecondPassRepointsRacedRows deterministically exercises
+// the D8 post-commit second pass: rows committed by a concurrent ingest AFTER
+// the in-tx repoints took their snapshots (simulated via the merge commit
+// barrier) must still end up attributed to the survivor. This test fails if
+// the post-commit second pass is removed.
+func TestMergeContacts_SecondPassRepointsRacedRows(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	t.Parallel()
+	ctx := ctx0()
+
+	h := newMergeAttrHarness(t, ctx)
+	now := accelerated.GetCurrentTime()
+
+	a := h.createContact(t, ctx, "second-pass survivor")
+	b := h.createContact(t, ctx, "second-pass loser")
+
+	var racedExternalContactID uuid.UUID
+	h.contactSvc.InjectMergeCommitBarrierForTest(func() {
+		// Second-connection commits while the merge tx is still open: a
+		// B-attributed staging row AND a B-linked external_contact. Both
+		// land AFTER the in-tx repoint statements ran, so only the
+		// post-commit second pass can fix them.
+		_, err := h.messagesRepo.UpsertMessage(ctx, repository.UpsertMessagesMessageParams{
+			Guid:             "raced-guid-1",
+			ChatGuid:         "raced-chat-1",
+			PeerHandle:       "+15550100002",
+			MessageType:      "text",
+			SentAt:           now,
+			MatchedContactID: &b.ID,
+		})
+		require.NoError(t, err)
+
+		ec, err := h.externalRepo.Upsert(ctx, repository.UpsertExternalContactRequest{
+			Source:   "google_contacts",
+			SourceID: "raced-ec-1",
+		})
+		require.NoError(t, err)
+		_, err = h.externalRepo.UpdateMatch(ctx, ec.ID, &b.ID, repository.MatchStatusMatched)
+		require.NoError(t, err)
+		racedExternalContactID = ec.ID
+	})
+
+	_, err := h.contactSvc.MergeContacts(ctx, service.MergeContactsRequest{
+		SourceContactID: b.ID,
+		TargetContactID: a.ID,
+	})
+	require.NoError(t, err)
+
+	mm, err := h.messagesRepo.GetMessage(ctx, "raced-guid-1")
+	require.NoError(t, err)
+	require.NotNil(t, mm.MatchedContactID)
+	assert.Equal(t, a.ID, *mm.MatchedContactID, "second pass repointed the raced staging row")
+
+	ec, err := h.externalRepo.GetByID(ctx, racedExternalContactID)
+	require.NoError(t, err)
+	require.NotNil(t, ec.CRMContactID)
+	assert.Equal(t, a.ID, *ec.CRMContactID, "second pass repointed the raced external_contact link")
+}
+
+// seedTask creates a contact_task row directly through the repository with an
+// explicit (kind, lifecycle, state, external id, metadata) shape.
+func (h *mergeAttrHarness) seedTask(t *testing.T, ctx context.Context, contactID uuid.UUID, lifecycle, state, externalID string, metadata map[string]any) *repository.ContactTask {
+	t.Helper()
+	task, err := h.taskRepo.CreateContactTask(ctx, repository.CreateContactTaskRequest{
+		ContactID:      contactID,
+		Provider:       todoist.SourceName,
+		Kind:           contacttask.KindReachOut,
+		Lifecycle:      lifecycle,
+		ExternalTaskID: externalID,
+		State:          state,
+		Metadata:       metadata,
+	})
+	require.NoError(t, err)
+	return task
+}
+
+// requireTaskState re-reads a task and asserts its state and contact.
+func (h *mergeAttrHarness) requireTaskState(t *testing.T, ctx context.Context, id uuid.UUID, state repository.ContactTaskState, contactID uuid.UUID) {
+	t.Helper()
+	task, err := h.taskRepo.GetContactTask(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, state, task.State)
+	assert.Equal(t, contactID, task.ContactID)
+}
+
+// closeJobCount counts todoist_followup_close river jobs for a task.
+func (h *mergeAttrHarness) closeJobCount(t *testing.T, ctx context.Context, taskID uuid.UUID) int64 {
+	t.Helper()
+	n, err := h.taskRepo.CountRiverJobsByContactTask(ctx, "todoist_followup_close", taskID)
+	require.NoError(t, err)
+	return n
+}
+
+// TestMergeContacts_ClosesLiveContactTasks covers the D4 lifecycle split:
+// automated rows (cadence_due / followup_loop) close (with a durable remote
+// close job only for real external ids), manual rows repoint to the survivor.
+func TestMergeContacts_ClosesLiveContactTasks(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	t.Parallel()
+	ctx := ctx0()
+
+	h := newMergeAttrHarness(t, ctx)
+
+	t.Run("real external id closes and enqueues, colliding target row survives", func(t *testing.T) {
+		a := h.createContact(t, ctx, "task close survivor 1")
+		b := h.createContact(t, ctx, "task close loser 1")
+		// COLLISION SHAPE: A and B EACH have a live follow-up. A repoint
+		// would violate idx_contact_task_followup_unique_live; the close
+		// path must not.
+		aTask := h.seedTask(t, ctx, a.ID, contacttask.LifecycleFollowUpLoop, "managed", "tsk-real-a1", nil)
+		bTask := h.seedTask(t, ctx, b.ID, contacttask.LifecycleFollowUpLoop, "managed", "tsk-real-b1", nil)
+
+		_, err := h.contactSvc.MergeContacts(ctx, service.MergeContactsRequest{
+			SourceContactID: b.ID,
+			TargetContactID: a.ID,
+		})
+		require.NoError(t, err, "close-not-repoint must avoid the unique-index collision")
+
+		h.requireTaskState(t, ctx, bTask.ID, repository.ContactTaskStateCompleted, b.ID)
+		h.requireTaskState(t, ctx, aTask.ID, repository.ContactTaskStateManaged, a.ID)
+		assert.EqualValues(t, 1, h.closeJobCount(t, ctx, bTask.ID), "close job enqueued for B's real-id follow-up")
+		assert.EqualValues(t, 0, h.closeJobCount(t, ctx, aTask.ID), "no close job for the survivor's own follow-up")
+	})
+
+	t.Run("pending shapes close locally without a close job", func(t *testing.T) {
+		a := h.createContact(t, ctx, "task close survivor 2")
+		b := h.createContact(t, ctx, "task close loser 2")
+		// pending_remote_create follow-up: no external id yet.
+		pendingTask := h.seedTask(t, ctx, b.ID, contacttask.LifecycleFollowUpLoop, "pending_remote_create", "", nil)
+		// cadence row still carrying its Todoist temp id.
+		tempID := "temp-cadence-b2"
+		tempTask := h.seedTask(t, ctx, b.ID, contacttask.LifecycleCadenceDue, "managed", tempID,
+			map[string]any{todoist.MetadataKeyPendingTempID: tempID})
+
+		_, err := h.contactSvc.MergeContacts(ctx, service.MergeContactsRequest{
+			SourceContactID: b.ID,
+			TargetContactID: a.ID,
+		})
+		require.NoError(t, err)
+
+		h.requireTaskState(t, ctx, pendingTask.ID, repository.ContactTaskStateCompleted, b.ID)
+		h.requireTaskState(t, ctx, tempTask.ID, repository.ContactTaskStateCompleted, b.ID)
+		assert.EqualValues(t, 0, h.closeJobCount(t, ctx, pendingTask.ID), "no close job for an empty external id")
+		assert.EqualValues(t, 0, h.closeJobCount(t, ctx, tempTask.ID), "no close job for a pending temp id")
+	})
+
+	t.Run("manual tasks repoint to the survivor", func(t *testing.T) {
+		a := h.createContact(t, ctx, "task close survivor 3")
+		b := h.createContact(t, ctx, "task close loser 3")
+		// Both sides have a live manual task — no unique index covers
+		// lifecycle='manual', so the repoint must be collision-free.
+		aManual := h.seedTask(t, ctx, a.ID, contacttask.LifecycleManual, "managed", "tsk-man-a3", nil)
+		bManual := h.seedTask(t, ctx, b.ID, contacttask.LifecycleManual, "managed", "tsk-man-b3", nil)
+
+		_, err := h.contactSvc.MergeContacts(ctx, service.MergeContactsRequest{
+			SourceContactID: b.ID,
+			TargetContactID: a.ID,
+		})
+		require.NoError(t, err)
+
+		// B's manual task is USER CONTENT: still live, now on A, no close.
+		h.requireTaskState(t, ctx, bManual.ID, repository.ContactTaskStateManaged, a.ID)
+		h.requireTaskState(t, ctx, aManual.ID, repository.ContactTaskStateManaged, a.ID)
+		assert.EqualValues(t, 0, h.closeJobCount(t, ctx, bManual.ID), "manual tasks are never remotely closed by merge")
+	})
+}
+
+// TestMergeContacts_EnqueuerNotWired_Errors pins the D9 wiring contract:
+// enqueue-eligible refs with the setter never called is a wiring bug (error +
+// rollback); setter called with remoteCloseEnabled=false (follow-up mode
+// 'off') closes locally with no job.
+func TestMergeContacts_EnqueuerNotWired_Errors(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	t.Parallel()
+	ctx := ctx0()
+
+	t.Run("setter never called errors and rolls back", func(t *testing.T) {
+		t.Parallel()
+		h := newMergeAttrHarnessWith(t, ctx, false, false)
+		a := h.createContact(t, ctx, "enqueuer survivor 1")
+		b := h.createContact(t, ctx, "enqueuer loser 1")
+		bTask := h.seedTask(t, ctx, b.ID, contacttask.LifecycleFollowUpLoop, "managed", "tsk-wire-b1", nil)
+
+		_, err := h.contactSvc.MergeContacts(ctx, service.MergeContactsRequest{
+			SourceContactID: b.ID,
+			TargetContactID: a.ID,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "SetTaskCloseEnqueuer")
+
+		// Whole merge rolled back: task still live on B, B still live.
+		h.requireTaskState(t, ctx, bTask.ID, repository.ContactTaskStateManaged, b.ID)
+		_, err = h.contactRepo.GetContact(ctx, b.ID)
+		require.NoError(t, err, "merge tx rolled back, B must still be live")
+	})
+
+	t.Run("remote close disabled closes locally without a job", func(t *testing.T) {
+		t.Parallel()
+		h := newMergeAttrHarnessWith(t, ctx, true, false)
+		a := h.createContact(t, ctx, "enqueuer survivor 2")
+		b := h.createContact(t, ctx, "enqueuer loser 2")
+		bTask := h.seedTask(t, ctx, b.ID, contacttask.LifecycleFollowUpLoop, "managed", "tsk-wire-b2", nil)
+
+		_, err := h.contactSvc.MergeContacts(ctx, service.MergeContactsRequest{
+			SourceContactID: b.ID,
+			TargetContactID: a.ID,
+		})
+		require.NoError(t, err, "mode 'off' must not make merge unusable")
+
+		h.requireTaskState(t, ctx, bTask.ID, repository.ContactTaskStateCompleted, b.ID)
+		assert.EqualValues(t, 0, h.closeJobCount(t, ctx, bTask.ID), "no close job in mode off")
+	})
+}
+
+// TestMatchOrCreate_TombstonedCacheFallsThroughToSurvivor isolates the
+// liveness guard from the merge repoint: a DIRECT soft-delete (no repoint)
+// leaves the identity cache pointing at a tombstoned contact, and the guard
+// must fall through to discovery — self-healing to the surviving holder of
+// the handle, or unlinking when no live holder exists.
+func TestMatchOrCreate_TombstonedCacheFallsThroughToSurvivor(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	t.Parallel()
+	ctx := ctx0()
+
+	h := newMergeAttrHarness(t, ctx)
+
+	t.Run("survivor found and cache self-heals", func(t *testing.T) {
+		const phone = "+15550100003"
+		normalized := identity.Normalize(phone, identity.IdentifierTypePhone)
+
+		b := h.createContact(t, ctx, "guard deleted holder")
+		h.addPhone(t, ctx, b.ID, phone)
+
+		pre, err := h.identitySvc.MatchOrCreate(ctx, service.MatchRequest{
+			RawIdentifier: phone,
+			Type:          identity.IdentifierTypePhone,
+			Source:        "messages",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, pre.ContactID)
+		require.Equal(t, b.ID, *pre.ContactID)
+
+		// A second live holder of the same handle, then delete B directly
+		// (no merge, no repoint — the cache row still points at B).
+		a := h.createContact(t, ctx, "guard surviving holder")
+		h.addPhone(t, ctx, a.ID, phone)
+		require.NoError(t, h.contactSvc.DeleteContact(ctx, b.ID))
+
+		post, err := h.identitySvc.MatchOrCreate(ctx, service.MatchRequest{
+			RawIdentifier: phone,
+			Type:          identity.IdentifierTypePhone,
+			Source:        "messages",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, post.ContactID)
+		assert.Equal(t, a.ID, *post.ContactID, "guard falls through; discovery finds the only live holder")
+		assert.False(t, post.Cached, "tombstoned cache hit must not short-circuit")
+
+		// The identity row itself self-healed to A.
+		ident, err := h.identityRepo.GetByIdentifier(ctx, identity.IdentifierTypePhone, normalized, "messages")
+		require.NoError(t, err)
+		require.NotNil(t, ident.ContactID)
+		assert.Equal(t, a.ID, *ident.ContactID)
+	})
+
+	t.Run("no survivor unlinks the identity", func(t *testing.T) {
+		const phone = "+15550100004"
+		normalized := identity.Normalize(phone, identity.IdentifierTypePhone)
+
+		c := h.createContact(t, ctx, "guard sole holder")
+		h.addPhone(t, ctx, c.ID, phone)
+
+		pre, err := h.identitySvc.MatchOrCreate(ctx, service.MatchRequest{
+			RawIdentifier: phone,
+			Type:          identity.IdentifierTypePhone,
+			Source:        "messages",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, pre.ContactID)
+		require.Equal(t, c.ID, *pre.ContactID)
+
+		require.NoError(t, h.contactSvc.DeleteContact(ctx, c.ID))
+
+		post, err := h.identitySvc.MatchOrCreate(ctx, service.MatchRequest{
+			RawIdentifier: phone,
+			Type:          identity.IdentifierTypePhone,
+			Source:        "messages",
+		})
+		require.NoError(t, err)
+		assert.Nil(t, post.ContactID, "no live holder — unmatched")
+		assert.Equal(t, repository.MatchTypeUnmatched, post.MatchType)
+
+		// The stale link was explicitly cleared (COALESCE in the upsert
+		// would otherwise have preserved the dead contact_id), so the row
+		// surfaces in the unmatched queue.
+		ident, err := h.identityRepo.GetByIdentifier(ctx, identity.IdentifierTypePhone, normalized, "messages")
+		require.NoError(t, err)
+		assert.Nil(t, ident.ContactID, "identity unlinked from the tombstoned contact")
+	})
 }

--- a/backend/tests/contact_merge_identity_attribution_integration_test.go
+++ b/backend/tests/contact_merge_identity_attribution_integration_test.go
@@ -1,0 +1,180 @@
+//go:build integration_testdb
+
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/consumer"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/identity"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+
+	"github.com/google/uuid"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mergeAttrHarness bundles a fully-wired ContactService plus the identity
+// service and the staging/task repositories a merge-attribution test reads
+// back. It uses a per-test isolated clone (newIsolatedRiverTestDB) so the
+// insert-only River client used for the contact_task close-job enqueue path
+// does not steal jobs from parallel tests.
+type mergeAttrHarness struct {
+	database     *db.Database
+	cfg          *config.Config
+	contactSvc   *service.ContactService
+	identitySvc  *service.IdentityService
+	contactRepo  *repository.ContactRepository
+	methodRepo   *repository.ContactMethodRepository
+	identityRepo *repository.IdentityRepository
+	externalRepo *repository.ExternalContactRepository
+	messagesRepo *repository.MessagesMessageRepository
+	telegramRepo *repository.TelegramMessageRepository
+	phoneRepo    *repository.PhoneCallRepository
+	commsRepo    *repository.CommsMessageRepository
+	taskRepo     *repository.ContactTaskRepository
+}
+
+func newMergeAttrHarness(t *testing.T, ctx context.Context) *mergeAttrHarness {
+	t.Helper()
+	database, cfg := newIsolatedRiverTestDB(t, ctx)
+
+	contactRepo := repository.NewContactRepository(database.Queries)
+	contactRepo.SetPool(database.Pool)
+	methodRepo := repository.NewContactMethodRepository(database.Queries)
+	interactionRepo := repository.NewInteractionRepository(database.Queries)
+	taskRepo := repository.NewContactTaskRepository(database.Queries)
+	identityRepo := repository.NewIdentityRepository(database.Queries)
+	externalRepo := repository.NewExternalContactRepository(database.Queries)
+	messagesRepo := repository.NewMessagesMessageRepository(database.Queries)
+	telegramRepo := repository.NewTelegramMessageRepository(database.Queries)
+	phoneRepo := repository.NewPhoneCallRepository(database.Queries)
+	commsRepo := repository.NewCommsMessageRepository(database.Queries)
+	nodeRepo := repository.NewNodeRepository(database.Queries)
+	entityRepo := repository.NewEntityRepository(database.Queries)
+	predicateRepo := repository.NewPredicateRepository(database.Queries)
+	assertionRepo := repository.NewAssertionRepository(database.Queries)
+	eventRepo := repository.NewEventRepository(database.Queries)
+
+	// Insert-only River client (no fetch loop): AssertService.PublishTx
+	// enqueues assertion.* jobs the no-op worker registers; the knowledge
+	// cache is filled inline. The same client backs the contact_task
+	// close-job enqueue path exercised by the merge tests.
+	workers := river.NewWorkers()
+	river.AddWorker(workers, &knowledgeCacheNoopWorker{})
+	client, err := river.NewClient(riverpgxv5.New(database.Pool), &river.Config{
+		Queues:   map[string]river.QueueConfig{river.QueueDefault: {MaxWorkers: cfg.River.WorkerConcurrency}},
+		Workers:  workers,
+		TestOnly: true,
+	})
+	require.NoError(t, err)
+	bus := events.NewBus(database.Pool, client, eventRepo)
+
+	assertSvc := service.NewAssertService(database.Pool, nodeRepo, entityRepo, predicateRepo, assertionRepo, bus)
+	cacheUpdater := consumer.NewKnowledgeCacheUpdater(assertionRepo, nodeRepo, contactRepo)
+
+	contactSvc := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, taskRepo, nil, nil)
+	contactSvc.SetKnowledgeWriter(assertSvc, cacheUpdater)
+	wireCadenceUpdaterForTest(t, database, contactSvc)
+
+	identitySvc := service.NewIdentityService(identityRepo)
+
+	return &mergeAttrHarness{
+		database:     database,
+		cfg:          cfg,
+		contactSvc:   contactSvc,
+		identitySvc:  identitySvc,
+		contactRepo:  contactRepo,
+		methodRepo:   methodRepo,
+		identityRepo: identityRepo,
+		externalRepo: externalRepo,
+		messagesRepo: messagesRepo,
+		telegramRepo: telegramRepo,
+		phoneRepo:    phoneRepo,
+		commsRepo:    commsRepo,
+		taskRepo:     taskRepo,
+	}
+}
+
+// createContact creates a bare contact via the wired ContactService.
+func (h *mergeAttrHarness) createContact(t *testing.T, ctx context.Context, name string) *repository.Contact {
+	t.Helper()
+	contact, _, err := h.contactSvc.CreateContact(ctx, repository.CreateContactRequest{FullName: name}, nil)
+	require.NoError(t, err)
+	return contact
+}
+
+// addPhone attaches a phone contact_method so the identity discovery path can
+// find the contact by its normalized value.
+func (h *mergeAttrHarness) addPhone(t *testing.T, ctx context.Context, contactID uuid.UUID, phone string) {
+	t.Helper()
+	_, err := h.methodRepo.CreateContactMethod(ctx, repository.CreateContactMethodRequest{
+		ContactID: contactID,
+		Type:      "phone",
+		Value:     phone,
+	})
+	require.NoError(t, err)
+}
+
+// TestMergeContacts_IdentityAttribution_FollowsSurvivor is the core RED→GREEN
+// reproduction: once a message from B's handle has been ingested (caching
+// external_identity.contact_id = B), a merge of B into A must re-point the
+// identity cache so a subsequent match on the same handle attributes to the
+// survivor A — not the tombstoned loser B.
+func TestMergeContacts_IdentityAttribution_FollowsSurvivor(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	t.Parallel()
+	ctx := ctx0()
+
+	h := newMergeAttrHarness(t, ctx)
+
+	const phone = "+15558675309"
+
+	// A is the survivor (winner); B is the loser (source).
+	a := h.createContact(t, ctx, "merge-attr survivor")
+	b := h.createContact(t, ctx, "merge-attr loser")
+	h.addPhone(t, ctx, b.ID, phone)
+
+	// Seed the identity cache the realistic way: discovery finds B (B owns
+	// the phone) and caches external_identity(phone, messages).contact_id = B.
+	pre, err := h.identitySvc.MatchOrCreate(ctx, service.MatchRequest{
+		RawIdentifier: phone,
+		Type:          identity.IdentifierTypePhone,
+		Source:        "messages",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, pre.ContactID)
+	require.Equal(t, b.ID, *pre.ContactID, "pre-merge attribution should point at B")
+
+	// Merge B into A. The transfer step moves B's phone method to A.
+	_, err = h.contactSvc.MergeContacts(ctx, service.MergeContactsRequest{
+		SourceContactID: b.ID,
+		TargetContactID: a.ID,
+	})
+	require.NoError(t, err)
+
+	// A subsequent tx-bound match on the SAME handle must attribute to the
+	// survivor A. Today this returns the tombstoned B (the cache short-circuits
+	// before the liveness-aware discovery path).
+	tx, err := h.database.Pool.Begin(ctx)
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	post, err := h.identitySvc.MatchOrCreateTx(ctx, tx, service.MatchRequest{
+		RawIdentifier: phone,
+		Type:          identity.IdentifierTypePhone,
+		Source:        "messages",
+	}, service.NormalizationFailEmpty)
+	require.NoError(t, err)
+	require.NotNil(t, post.ContactID)
+	assert.Equal(t, a.ID, *post.ContactID, "post-merge attribution must follow the survivor A")
+}

--- a/backend/tests/task_close_wiring_static_test.go
+++ b/backend/tests/task_close_wiring_static_test.go
@@ -1,0 +1,58 @@
+// Package tests — static wiring guard for the merge-time task-close enqueuer.
+//
+// MergeContacts errors when it closes an enqueue-eligible contact_task and
+// SetTaskCloseEnqueuer was never called, so production wiring MUST call the
+// setter in main.go. Similarly, the Todoist provider's state-aware temp-ID
+// finalize needs the river client + cutover-mode gate passed at construction.
+// Integration tests cannot cover main.go (it is a binary), so this static
+// test greps the source — the same belt the ingest-registry and sole-writer
+// guards use.
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+)
+
+func readMainGoSource(t *testing.T) []byte {
+	t.Helper()
+	moduleRoot, err := backendModuleRoot()
+	if err != nil {
+		t.Fatalf("locate backend module root: %v", err)
+	}
+	mainPath := filepath.Join(moduleRoot, "cmd", "crm-api", "main.go")
+	src, err := os.ReadFile(mainPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", mainPath, err)
+	}
+	return src
+}
+
+// TestTaskCloseEnqueuerWiring_Static asserts main.go wires the merge-time
+// close enqueuer with the river client and the follow-up cutover-mode gate.
+func TestTaskCloseEnqueuerWiring_Static(t *testing.T) {
+	t.Parallel()
+	src := readMainGoSource(t)
+
+	setter := regexp.MustCompile(
+		`contactService\.SetTaskCloseEnqueuer\(\s*riverClient,\s*cfg\.EventBus\.FollowUpMode == config\.EventBusFollowUpModeCutover\s*\)`)
+	if !setter.Match(src) {
+		t.Error("main.go must call contactService.SetTaskCloseEnqueuer(riverClient, cfg.EventBus.FollowUpMode == config.EventBusFollowUpModeCutover) — without it MergeContacts errors on any merge that closes a real-external-id task")
+	}
+}
+
+// TestCadenceProviderCloseDepsWiring_Static asserts main.go passes the river
+// client + cutover-mode gate to the Todoist cadence provider so the
+// state-aware temp-ID finalize can enqueue the durable remote close.
+func TestCadenceProviderCloseDepsWiring_Static(t *testing.T) {
+	t.Parallel()
+	src := readMainGoSource(t)
+
+	provider := regexp.MustCompile(
+		`todoist\.NewCadenceSyncProvider\((?s:.*?)riverClient,\s*cfg\.EventBus\.FollowUpMode == config\.EventBusFollowUpModeCutover,\s*\)`)
+	if !provider.Match(src) {
+		t.Error("main.go must pass riverClient + the cutover-mode gate to todoist.NewCadenceSyncProvider — without them the temp-ID finalize on a completed row cannot enqueue the durable remote close")
+	}
+}


### PR DESCRIPTION
## Problem

After merging contact B into contact A, inbound messages/calls from B's handles kept attributing to the tombstoned loser: `ContactService.MergeContacts` transferred methods/notes/interactions/assertions but never repointed `external_identity.contact_id`, `external_contact.matched_contact_id`, staged ingest rows, or live `contact_task` rows — and `IdentityService.MatchOrCreate{,Tx}` returned the cached identity match without checking the mapped contact was live, short-circuiting the contact-method fallback that would have found the survivor. Cadence updates then silently no-op'd behind `deleted_at IS NULL` filters and the winner missed interactions until manual relink.

## Fix

- **In-merge-tx repoints:** `external_identity` and `external_contact` rows move to the winner inside the merge transaction, along with all four ingest-staging tables. The `comms_message` repoint is a savepoint-wrapped dedup-then-repoint (its dedup unique index includes the contact id) with one constraint-scoped 23505 retry.
- **Liveness guard in identity matching:** both `MatchOrCreate` paths now verify the cached match points at a live contact; if not, they fall back to the contact-method survivor and repair the link, or explicitly unlink when no survivor exists so the row surfaces in the unmatched queue instead of silently mis-attributing.
- **`contact_task` policy, split by lifecycle:** automated cadence rows on the loser are closed (with a durable river job to close the remote Todoist task; mode-aware enqueue gated to cutover), while manual user to-dos are repointed to the survivor. Temp-ID finalization is now state-aware so a merge-closed task can't resurrect to `managed`.
- **Concurrent-ingest race:** a post-commit second pass re-repoints rows that in-flight ingests linked to the loser between the merge tx's snapshot and commit, covered by a deterministic barrier-hook test.

No schema migration; all data movement is via new sqlc queries behind repository wrappers.

## Testing

- TDD: the first commit is a failing reproduction (merge loser with identities + methods, ingest from a loser handle, assert winner attribution); the fix commit turns it green.
- 8-test merge-attribution integration suite (repoints across all tables, comms dedup collision + race, task lifecycle split, no-survivor unlink) plus 4 Todoist provider tests for the temp-ID finalize states, an ingest e2e, and static wiring guards against `main.go`.
- Full pre-push gate (lint + backend suites + diff-selected E2E) green locally; review-head verdict PASS (P0=0 P1=0 P2=0 P3=3).

## Notes

Three non-blocking P3s from pre-push review, tracked not fixed here: plan-decision labels left in a few test comments, a `match_type` provenance nuance when re-linking a formerly-manual identity, and the multi-holder unlink branch exercised only via the shared no-match route.