### PR TITLE
refactor: relocate crm-api orphan adapter types to proper homes

### DIFF
--- a/backend/cmd/crm-api/adapters.go
+++ b/backend/cmd/crm-api/adapters.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	stdsync "sync"
+
+	"personal-crm/backend/internal/consumer"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/scheduler"
+	"personal-crm/backend/internal/todoist"
+
+	"github.com/google/uuid"
+	"github.com/riverqueue/river"
+)
+
+// noopJobArgs is the args type for the placeholder worker below. It is
+// never enqueued in production; its sole purpose is to satisfy river's
+// "must have at least one registered worker" invariant when external
+// sync is disabled.
+type noopJobArgs struct{}
+
+func (noopJobArgs) Kind() string { return "noop" }
+
+// noopWorker exists so the river client always has at least one
+// registered worker, even when cfg.Features.EnableExternalSync is false
+// and the scheduler workers are not registered. river.NewClient rejects
+// an empty Workers bundle (the constructor returns an error), so the
+// API fails to boot in the default non-sync configuration without this
+// placeholder.
+type noopWorker struct {
+	river.WorkerDefaults[noopJobArgs]
+}
+
+// Work implements river.Worker. Since no 'noop' jobs are enqueued
+// anywhere in the codebase, this method is never called at runtime.
+func (*noopWorker) Work(_ context.Context, _ *river.Job[noopJobArgs]) error {
+	return nil
+}
+
+// followUpSettingsRef holds a deferred reference to the Todoist OAuth
+// service + sync repo so the FollowUpManager settings func can be
+// wired at construction time (before the external-sync branch decides
+// whether Todoist is configured). The external-sync branch populates
+// oauth+sync when Todoist is initialized; until then fn() returns
+// service.ErrNoTodoistAccount to keep the consumer's Todoist-dependent
+// post-commit paths a best-effort no-op.
+type followUpSettingsRef struct {
+	oauth       *todoist.OAuthService
+	sync        *repository.SyncRepository
+	frontendURL string
+}
+
+// fn returns a TodoistSettingsFunc closure that resolves settings
+// through the populated refs. Todoist-unconfigured states (no account,
+// no sync state, missing label) collapse to consumer.ErrTodoistUnconfigured
+// so the follow-up consumer can treat them as a non-fatal skip rather
+// than rolling back the interaction write.
+func (r *followUpSettingsRef) fn() consumer.TodoistSettingsFunc {
+	return func(ctx context.Context) (*todoist.Settings, string, error) {
+		if r.oauth == nil || r.sync == nil {
+			return nil, "", consumer.ErrTodoistUnconfigured
+		}
+		accounts, err := r.oauth.ListAccounts(ctx)
+		if err != nil {
+			return nil, "", fmt.Errorf("list todoist accounts: %w", err)
+		}
+		if len(accounts) == 0 {
+			return nil, "", consumer.ErrTodoistUnconfigured
+		}
+		accountID := accounts[0].AccountID
+		accessToken, err := r.oauth.GetAccessToken(ctx, accountID)
+		if err != nil {
+			return nil, "", fmt.Errorf("get access token: %w", err)
+		}
+		state, err := r.sync.GetSyncStateBySource(ctx, todoist.SourceName, &accountID)
+		if err != nil {
+			if errors.Is(err, db.ErrNotFound) {
+				return nil, "", consumer.ErrTodoistUnconfigured
+			}
+			return nil, "", fmt.Errorf("get sync state: %w", err)
+		}
+		settings := &todoist.Settings{}
+		if state.Metadata != nil {
+			if v, ok := state.Metadata[todoist.MetadataKeyProjectID].(string); ok {
+				settings.ProjectID = v
+			}
+			if v, ok := state.Metadata[todoist.MetadataKeyProjectName].(string); ok {
+				settings.ProjectName = v
+			}
+			if v, ok := state.Metadata[todoist.MetadataKeyLabelID].(string); ok {
+				settings.LabelID = v
+			}
+			if v, ok := state.Metadata[todoist.MetadataKeyLabelName].(string); ok {
+				settings.LabelName = v
+			}
+			if v, ok := state.Metadata[todoist.MetadataKeyIntegrationInstance].(string); ok {
+				settings.IntegrationInstanceID = v
+			}
+		}
+		if settings.LabelID == "" {
+			return nil, "", consumer.ErrTodoistUnconfigured
+		}
+		return settings, accessToken, nil
+	}
+}
+
+// deferredAggregatorReenqueuer is a thread-safe holder that the
+// InteractionRecorderWorker is constructed against before the
+// Telegram aggregation engine exists. The cfg.Features.EnableTelegramSync
+// branch calls .set once telegramManager is built; until then the
+// holder dispatches every Reenqueue call to a logged-warn no-op.
+//
+// Satisfies consumer.AggregatorReenqueuer (via the holder pointer);
+// safe to pass to the worker constructor before the inner registry
+// is wired.
+type deferredAggregatorReenqueuer struct {
+	mu    stdsync.RWMutex
+	inner consumer.AggregatorReenqueuer
+}
+
+// set installs the concrete reenqueuer. May be called once after the
+// Telegram aggregation engine exists.
+func (d *deferredAggregatorReenqueuer) set(inner consumer.AggregatorReenqueuer) {
+	d.mu.Lock()
+	d.inner = inner
+	d.mu.Unlock()
+}
+
+// Reenqueue implements consumer.AggregatorReenqueuer. Falls back to a
+// logged-warn no-op when the inner registry has not been wired yet
+// (e.g. cfg.Features.EnableTelegramSync is false).
+func (d *deferredAggregatorReenqueuer) Reenqueue(ctx context.Context, env *events.Envelope, contactID uuid.UUID) error {
+	d.mu.RLock()
+	inner := d.inner
+	d.mu.RUnlock()
+	if inner == nil {
+		log.Printf("aggregator-reenqueuer: registry not yet wired; skipping (source=%s contact=%s)",
+			env.Source, contactID.String())
+		return nil
+	}
+	return inner.Reenqueue(ctx, env, contactID)
+}
+
+// commsSourceContactLister pins the multi-source comms_message repository to a
+// single source so it satisfies the sweeper's single-source
+// scheduler.UnprocessedContactLister interface (ListUnprocessedContactIDs(ctx)).
+// It carries no persistence logic — only source-pinning delegation.
+type commsSourceContactLister struct {
+	repo   *repository.CommsMessageRepository
+	source string
+}
+
+var _ scheduler.UnprocessedContactLister = (*commsSourceContactLister)(nil)
+
+// newCommsSourceContactLister builds the source-bound sweeper lister adapter.
+func newCommsSourceContactLister(repo *repository.CommsMessageRepository, source string) *commsSourceContactLister {
+	return &commsSourceContactLister{repo: repo, source: source}
+}
+
+// ListUnprocessedContactIDs implements scheduler.UnprocessedContactLister.
+func (l *commsSourceContactLister) ListUnprocessedContactIDs(ctx context.Context) ([]uuid.UUID, error) {
+	return l.repo.ListUnprocessedContactIDsForSource(ctx, l.source)
+}

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -30,7 +30,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	stdsync "sync"
 	"syscall"
 	"time"
 
@@ -58,7 +57,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5"
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	swaggerFiles "github.com/swaggo/files"
@@ -73,166 +71,6 @@ import (
 // river_job) rely on. Single-user row counts are trivial, so we keep discarded
 // jobs for 90 days. Not exposed via config — no caller needs to vary it.
 const riverDiscardedJobRetention = 90 * 24 * time.Hour
-
-// noopJobArgs is the args type for the placeholder worker below. It is
-// never enqueued in production; its sole purpose is to satisfy river's
-// "must have at least one registered worker" invariant when external
-// sync is disabled.
-type noopJobArgs struct{}
-
-func (noopJobArgs) Kind() string { return "noop" }
-
-// noopWorker exists so the river client always has at least one
-// registered worker, even when cfg.Features.EnableExternalSync is false
-// and the scheduler workers are not registered. river.NewClient rejects
-// an empty Workers bundle (the constructor returns an error), so the
-// API fails to boot in the default non-sync configuration without this
-// placeholder.
-type noopWorker struct {
-	river.WorkerDefaults[noopJobArgs]
-}
-
-// Work implements river.Worker. Since no 'noop' jobs are enqueued
-// anywhere in the codebase, this method is never called at runtime.
-func (*noopWorker) Work(_ context.Context, _ *river.Job[noopJobArgs]) error {
-	return nil
-}
-
-// followUpSettingsRef holds a deferred reference to the Todoist OAuth
-// service + sync repo so the FollowUpManager settings func can be
-// wired at construction time (before the external-sync branch decides
-// whether Todoist is configured). The external-sync branch populates
-// oauth+sync when Todoist is initialized; until then fn() returns
-// service.ErrNoTodoistAccount to keep the consumer's Todoist-dependent
-// post-commit paths a best-effort no-op.
-type followUpSettingsRef struct {
-	oauth       *todoist.OAuthService
-	sync        *repository.SyncRepository
-	frontendURL string
-}
-
-// fn returns a TodoistSettingsFunc closure that resolves settings
-// through the populated refs. Todoist-unconfigured states (no account,
-// no sync state, missing label) collapse to consumer.ErrTodoistUnconfigured
-// so the follow-up consumer can treat them as a non-fatal skip rather
-// than rolling back the interaction write.
-func (r *followUpSettingsRef) fn() consumer.TodoistSettingsFunc {
-	return func(ctx context.Context) (*todoist.Settings, string, error) {
-		if r.oauth == nil || r.sync == nil {
-			return nil, "", consumer.ErrTodoistUnconfigured
-		}
-		accounts, err := r.oauth.ListAccounts(ctx)
-		if err != nil {
-			return nil, "", fmt.Errorf("list todoist accounts: %w", err)
-		}
-		if len(accounts) == 0 {
-			return nil, "", consumer.ErrTodoistUnconfigured
-		}
-		accountID := accounts[0].AccountID
-		accessToken, err := r.oauth.GetAccessToken(ctx, accountID)
-		if err != nil {
-			return nil, "", fmt.Errorf("get access token: %w", err)
-		}
-		state, err := r.sync.GetSyncStateBySource(ctx, todoist.SourceName, &accountID)
-		if err != nil {
-			if errors.Is(err, db.ErrNotFound) {
-				return nil, "", consumer.ErrTodoistUnconfigured
-			}
-			return nil, "", fmt.Errorf("get sync state: %w", err)
-		}
-		settings := &todoist.Settings{}
-		if state.Metadata != nil {
-			if v, ok := state.Metadata[todoist.MetadataKeyProjectID].(string); ok {
-				settings.ProjectID = v
-			}
-			if v, ok := state.Metadata[todoist.MetadataKeyProjectName].(string); ok {
-				settings.ProjectName = v
-			}
-			if v, ok := state.Metadata[todoist.MetadataKeyLabelID].(string); ok {
-				settings.LabelID = v
-			}
-			if v, ok := state.Metadata[todoist.MetadataKeyLabelName].(string); ok {
-				settings.LabelName = v
-			}
-			if v, ok := state.Metadata[todoist.MetadataKeyIntegrationInstance].(string); ok {
-				settings.IntegrationInstanceID = v
-			}
-		}
-		if settings.LabelID == "" {
-			return nil, "", consumer.ErrTodoistUnconfigured
-		}
-		return settings, accessToken, nil
-	}
-}
-
-// deferredAggregatorReenqueuer is a thread-safe holder that the
-// InteractionRecorderWorker is constructed against before the
-// Telegram aggregation engine exists. The cfg.Features.EnableTelegramSync
-// branch calls .set once telegramManager is built; until then the
-// holder dispatches every Reenqueue call to a logged-warn no-op.
-//
-// Satisfies consumer.AggregatorReenqueuer (via the holder pointer);
-// safe to pass to the worker constructor before the inner registry
-// is wired.
-type deferredAggregatorReenqueuer struct {
-	mu    stdsync.RWMutex
-	inner consumer.AggregatorReenqueuer
-}
-
-// set installs the concrete reenqueuer. May be called once after the
-// Telegram aggregation engine exists.
-func (d *deferredAggregatorReenqueuer) set(inner consumer.AggregatorReenqueuer) {
-	d.mu.Lock()
-	d.inner = inner
-	d.mu.Unlock()
-}
-
-// Reenqueue implements consumer.AggregatorReenqueuer. Falls back to a
-// logged-warn no-op when the inner registry has not been wired yet
-// (e.g. cfg.Features.EnableTelegramSync is false).
-func (d *deferredAggregatorReenqueuer) Reenqueue(ctx context.Context, env *events.Envelope, contactID uuid.UUID) error {
-	d.mu.RLock()
-	inner := d.inner
-	d.mu.RUnlock()
-	if inner == nil {
-		log.Printf("aggregator-reenqueuer: registry not yet wired; skipping (source=%s contact=%s)",
-			env.Source, contactID.String())
-		return nil
-	}
-	return inner.Reenqueue(ctx, env, contactID)
-}
-
-// meetingNoteLinkageTargetReader adapts the calendar + phone_call
-// repositories into the polymorphic service.LinkageTargetReader
-// interface that MeetingNoteService consumes. Kept inline in main.go
-// per the single-file build convention (any file the binary needs must
-// be compilable as part of `go build cmd/crm-api/main.go`).
-type meetingNoteLinkageTargetReader struct {
-	calendarRepo  *repository.CalendarEventRepository
-	phoneCallRepo *repository.PhoneCallRepository
-}
-
-// GetEventByID satisfies service.LinkageTargetReader.
-func (r *meetingNoteLinkageTargetReader) GetEventByID(ctx context.Context, id uuid.UUID) (*repository.CalendarEvent, error) {
-	return r.calendarRepo.GetByID(ctx, id)
-}
-
-// GetPhoneCallByID satisfies service.LinkageTargetReader.
-func (r *meetingNoteLinkageTargetReader) GetPhoneCallByID(ctx context.Context, id uuid.UUID) (*repository.PhoneCall, error) {
-	return r.phoneCallRepo.GetCallByID(ctx, id)
-}
-
-// GetEventByIDTx satisfies service.LinkageTargetReader for the
-// tx-bound resolve flow.
-func (r *meetingNoteLinkageTargetReader) GetEventByIDTx(ctx context.Context, tx pgx.Tx, id uuid.UUID) (*repository.CalendarEvent, error) {
-	return r.calendarRepo.GetByIDTx(ctx, tx, id)
-}
-
-// GetPhoneCallByIDTx satisfies service.LinkageTargetReader for the
-// tx-bound resolve flow.
-func (r *meetingNoteLinkageTargetReader) GetPhoneCallByIDTx(ctx context.Context, tx pgx.Tx, id uuid.UUID) (*repository.PhoneCall, error) {
-	return r.phoneCallRepo.GetCallByIDTx(ctx, tx, id)
-}
 
 func main() {
 	// Run the server body in a helper so its defers (database.Close,
@@ -615,10 +453,7 @@ func run() int {
 	// Mirrors the daemon-side IngestService.handleMeetingNoteRecorded
 	// path; uses a small adapter to satisfy the polymorphic
 	// LinkageTargetReader interface (event vs phone_call lookup by UUID).
-	meetingNoteLinkageTargets := &meetingNoteLinkageTargetReader{
-		calendarRepo:  calendarRepoForIngest,
-		phoneCallRepo: phoneCallRepoForIngest,
-	}
+	meetingNoteLinkageTargets := service.NewLinkageTargetReader(calendarRepoForIngest, phoneCallRepoForIngest)
 	meetingNoteService := service.NewMeetingNoteService(
 		database,
 		meetingNoteRepoForIngest,
@@ -1300,9 +1135,8 @@ func run() int {
 	sweeperListers := map[string]scheduler.UnprocessedContactLister{
 		repository.InteractionSourceMessages: messagesMessageRepo,
 		// Source-bound adapter: comms_message is multi-source, so wrap the
-		// repo with a 'gchat'-pinned lister (built type, not inline struct,
-		// per the single-file build convention).
-		repository.InteractionSourceGChat: repository.NewCommsSourceContactLister(commsMessageRepo, repository.InteractionSourceGChat),
+		// repo with a 'gchat'-pinned lister.
+		repository.InteractionSourceGChat: newCommsSourceContactLister(commsMessageRepo, repository.InteractionSourceGChat),
 	}
 	river.AddWorker(riverWorkers, scheduler.NewMessagingAggregateSweeperWorker(sweeperListers, riverClient))
 	riverClient.PeriodicJobs().Add(river.NewPeriodicJob(

--- a/backend/internal/repository/comms_message.go
+++ b/backend/internal/repository/comms_message.go
@@ -707,26 +707,6 @@ func (r *CommsMessageRepository) GetLatestByExternalID(ctx context.Context, sour
 	return &msg, nil
 }
 
-// CommsSourceContactLister adapts *CommsMessageRepository to the source-neutral
-// scheduler.UnprocessedContactLister interface, pinning a source. The sweeper's
-// interface is single-source (ListUnprocessedContactIDs(ctx)) but comms_message
-// is multi-source; this adapter binds the source so main.go references a built
-// type (single-file build convention) rather than an inline closure-struct.
-type CommsSourceContactLister struct {
-	repo   *CommsMessageRepository
-	source string
-}
-
-// NewCommsSourceContactLister builds the source-bound sweeper lister adapter.
-func NewCommsSourceContactLister(repo *CommsMessageRepository, source string) *CommsSourceContactLister {
-	return &CommsSourceContactLister{repo: repo, source: source}
-}
-
-// ListUnprocessedContactIDs implements scheduler.UnprocessedContactLister.
-func (l *CommsSourceContactLister) ListUnprocessedContactIDs(ctx context.Context) ([]uuid.UUID, error) {
-	return l.repo.ListUnprocessedContactIDsForSource(ctx, l.source)
-}
-
 // CommsSessionStagingProcessor adapts *CommsMessageRepository to the
 // source-neutral StagingProcessor interface for CHAT sources (gchat). It uses
 // the SESSION-scoped, claim-clearing MarkProcessedForSessionTx — unlike the

--- a/backend/internal/service/meeting_note.go
+++ b/backend/internal/service/meeting_note.go
@@ -30,7 +30,7 @@ import (
 // the resolve tx so the read+write are serializable) and the
 // needs-attention preview projection (best-effort, no tx). Concrete is
 // a small adapter over CalendarEventRepository + PhoneCallRepository
-// (see meetingNoteLinkageTargetReader in cmd/crm-api/main.go).
+// (see NewLinkageTargetReader in meeting_note_linkage.go).
 type LinkageTargetReader interface {
 	GetEventByID(ctx context.Context, id uuid.UUID) (*repository.CalendarEvent, error)
 	GetPhoneCallByID(ctx context.Context, id uuid.UUID) (*repository.PhoneCall, error)

--- a/backend/internal/service/meeting_note_linkage.go
+++ b/backend/internal/service/meeting_note_linkage.go
@@ -1,0 +1,44 @@
+package service
+
+import (
+	"context"
+
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// meetingNoteLinkageTargetReader adapts the calendar + phone_call
+// repositories into the polymorphic LinkageTargetReader interface that
+// MeetingNoteService consumes (event vs phone_call lookup by UUID).
+type meetingNoteLinkageTargetReader struct {
+	calendarRepo  *repository.CalendarEventRepository
+	phoneCallRepo *repository.PhoneCallRepository
+}
+
+// NewLinkageTargetReader adapts the calendar + phone-call repositories into the
+// polymorphic LinkageTargetReader that MeetingNoteService consumes.
+func NewLinkageTargetReader(calendarRepo *repository.CalendarEventRepository, phoneCallRepo *repository.PhoneCallRepository) LinkageTargetReader {
+	return &meetingNoteLinkageTargetReader{calendarRepo: calendarRepo, phoneCallRepo: phoneCallRepo}
+}
+
+// GetEventByID satisfies LinkageTargetReader.
+func (r *meetingNoteLinkageTargetReader) GetEventByID(ctx context.Context, id uuid.UUID) (*repository.CalendarEvent, error) {
+	return r.calendarRepo.GetByID(ctx, id)
+}
+
+// GetPhoneCallByID satisfies LinkageTargetReader.
+func (r *meetingNoteLinkageTargetReader) GetPhoneCallByID(ctx context.Context, id uuid.UUID) (*repository.PhoneCall, error) {
+	return r.phoneCallRepo.GetCallByID(ctx, id)
+}
+
+// GetEventByIDTx satisfies LinkageTargetReader for the tx-bound resolve flow.
+func (r *meetingNoteLinkageTargetReader) GetEventByIDTx(ctx context.Context, tx pgx.Tx, id uuid.UUID) (*repository.CalendarEvent, error) {
+	return r.calendarRepo.GetByIDTx(ctx, tx, id)
+}
+
+// GetPhoneCallByIDTx satisfies LinkageTargetReader for the tx-bound resolve flow.
+func (r *meetingNoteLinkageTargetReader) GetPhoneCallByIDTx(ctx context.Context, tx pgx.Tx, id uuid.UUID) (*repository.PhoneCall, error) {
+	return r.phoneCallRepo.GetCallByIDTx(ctx, tx, id)
+}

--- a/backend/tests/api/meeting_note_ingest_test.go
+++ b/backend/tests/api/meeting_note_ingest_test.go
@@ -2518,7 +2518,8 @@ func TestMeetingNote_TitleMatch_LegacySessionBackfillsDiscoveryOnCarryForward(t 
 
 // mnTestLinkageTargetReader adapts the calendar + phone_call repositories
 // into the polymorphic service.LinkageTargetReader interface used by
-// MeetingNoteService. Mirrors the production adapter in cmd/crm-api/main.go.
+// MeetingNoteService. Mirrors the production adapter service.NewLinkageTargetReader
+// (internal/service/meeting_note_linkage.go).
 type mnTestLinkageTargetReader struct {
 	calendarRepo  *repository.CalendarEventRepository
 	phoneCallRepo *repository.PhoneCallRepository


### PR DESCRIPTION
## Summary

PR2 of the composition-root refactor arc (follows #573). Pure type relocation — moves the four orphan adapter types that the old single-file build convention forced into `cmd/crm-api/main.go`, and evicts the wiring shim that the same convention exiled into the repository layer.

- **New `backend/cmd/crm-api/adapters.go`** (package main): `noopWorker`/`noopJobArgs`, `followUpSettingsRef`, `deferredAggregatorReenqueuer` moved verbatim from `main.go`, plus a new unexported `commsSourceContactLister` adapter.
- **New `backend/internal/service/meeting_note_linkage.go`**: `meetingNoteLinkageTargetReader` moved to the service layer with an exported `NewLinkageTargetReader` constructor.
- **`repository/comms_message.go`**: `NewCommsSourceContactLister` removed — the shim existed there only because of the old convention (its comment said so); the replacement lives with the wiring in package main.
- `main.go` loses the four orphan blocks and two now-unused imports; the two construction call sites updated.

## Behavior

Zero behavior change. The adversarial review verified the moved blocks are byte-for-byte identical to the removed originals, all holder call sites survive in the same relative order with the same arguments, and the repo has zero remaining references to the old exported shim.

## Verification

- `go build ./...`, `go vet`, `golangci-lint` clean; `make test` 0 failures; `make test-e2e-diff` 86 passed.
- Codex review: all-clean (P0=P1=P2=P3=0).
- Fresh-context review-head: PASS (P0=0 P1=0 P2=0; 3 P3s are pre-existing carry-overs preserved by the verbatim-move contract, deferred to PR4/PR5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PAkTD635qUGdkzipVK7uhh