### PR TITLE
refactor(frontend): single source of truth for contact-list URL params

### DIFF
--- a/frontend/src/app/contacts/[id]/page.tsx
+++ b/frontend/src/app/contacts/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useRef, useEffect, useCallback } from 'react'
+import { useState, useRef, useEffect, useCallback, useMemo } from 'react'
 import { useParams, useRouter, useSearchParams } from 'next/navigation'
 import { Navigation } from '@/components/layout/navigation'
 import { ContactForm } from '@/components/contacts/contact-form'
@@ -36,6 +36,11 @@ import {
   sortContactMethods,
 } from '@/lib/contact-methods'
 import type { ContactSubmitData } from '@/lib/validations/contact'
+import {
+  buildContactDetailUrl,
+  buildContactListUrl,
+  parseListContext,
+} from '@/lib/contact-list-params'
 import { MergeContactModal } from '@/components/contacts/merge-contact-modal'
 import { TasksSection } from '@/components/contacts/tasks-section'
 import { LogInteractionModal } from '@/components/contacts/log-interaction-modal'
@@ -71,15 +76,7 @@ export default function ContactDetailPage() {
   const notesRef = useRef<HTMLDivElement>(null)
 
   // Extract list context from URL params (or use defaults)
-  const listContext = {
-    sort: searchParams.get('sort') || 'cadence',
-    order: (searchParams.get('order') as 'asc' | 'desc') || 'desc',
-    search: searchParams.get('search') || undefined,
-    cadence_filter:
-      (searchParams.get('cadence_filter') as 'has_cadence' | 'no_cadence') || undefined,
-    followup_filter:
-      (searchParams.get('followup_filter') as 'has_followup' | 'no_followup') || undefined,
-  }
+  const listContext = useMemo(() => parseListContext(searchParams), [searchParams])
 
   const { data: contact, isLoading, error } = useContact(contactId)
   const { data: contactNote } = useContactNote(contactId)
@@ -114,24 +111,9 @@ export default function ContactDetailPage() {
 
   // Build URL preserving list context params
   const buildNavigationUrl = useCallback(
-    (newId?: string) => {
-      const params = new URLSearchParams()
-      if (listContext.sort) params.set('sort', listContext.sort)
-      if (listContext.order) params.set('order', listContext.order)
-      if (listContext.search) params.set('search', listContext.search)
-      if (listContext.cadence_filter) params.set('cadence_filter', listContext.cadence_filter)
-      if (listContext.followup_filter) params.set('followup_filter', listContext.followup_filter)
-      const queryString = params.toString()
-      const path = newId ? `/contacts/${newId}` : '/contacts'
-      return `${path}${queryString ? `?${queryString}` : ''}`
-    },
-    [
-      listContext.sort,
-      listContext.order,
-      listContext.search,
-      listContext.cadence_filter,
-      listContext.followup_filter,
-    ]
+    (newId?: string) =>
+      newId ? buildContactDetailUrl(listContext, newId) : buildContactListUrl(listContext),
+    [listContext]
   )
 
   // Keyboard navigation

--- a/frontend/src/app/contacts/page.tsx
+++ b/frontend/src/app/contacts/page.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { Suspense, useState, useEffect, useRef, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import {
   Plus,
   Search,
@@ -24,36 +24,25 @@ import { Pagination } from '@/components/ui/pagination'
 import { Navigation } from '@/components/layout/navigation'
 import { FORM_CONTROL_WITH_ICON, FORM_SELECT_BASE } from '@/lib/form-classes'
 import { formatDateOnly, formatCadence, formatBirthday } from '@/lib/utils'
-import type { Contact, ContactListParams } from '@/types/contact'
-
-type SortField =
-  | 'name'
-  | 'location'
-  | 'birthday'
-  | 'last_contacted'
-  | 'last_response_at'
-  | 'contact_by'
-  | 'cadence'
-
-// Default sort configuration
-const DEFAULT_SORT_FIELD: SortField = 'cadence'
-const DEFAULT_SORT_ORDER: 'asc' | 'desc' = 'desc'
+import type { Contact } from '@/types/contact'
+import {
+  buildContactDetailUrl,
+  buildContactListUrl,
+  defaultOrderFor,
+  parseListContext,
+  type ContactListContext,
+  type SortField,
+} from '@/lib/contact-list-params'
 
 function ContactsTable({
   contacts,
   loading,
-  sortBy,
-  sortOrder,
-  searchTerm,
-  cadenceFilter,
+  listContext,
   onSort,
 }: {
   contacts: Contact[]
   loading: boolean
-  sortBy?: SortField
-  sortOrder?: 'asc' | 'desc'
-  searchTerm?: string
-  cadenceFilter?: 'has_cadence' | 'no_cadence'
+  listContext: ContactListContext
   onSort: (field: SortField) => void
 }) {
   const router = useRouter()
@@ -71,27 +60,20 @@ function ContactsTable({
   }, [])
 
   const getSortIcon = (field: SortField) => {
-    if (sortBy !== field) {
+    if (listContext.sort !== field) {
       return <ArrowUpDown className="w-4 h-4 ml-1 text-gray-400" />
     }
-    return sortOrder === 'asc' ? (
+    return listContext.order === 'asc' ? (
       <ArrowUp className="w-4 h-4 ml-1 text-blue-600" />
     ) : (
       <ArrowDown className="w-4 h-4 ml-1 text-blue-600" />
     )
   }
 
-  // Build URL with navigation context params
-  // Always include sort/order so navigation order matches list order
-  const buildContactUrl = (contactId: string, action?: 'edit' | 'merge') => {
-    const params = new URLSearchParams()
-    params.set('sort', sortBy || DEFAULT_SORT_FIELD)
-    params.set('order', sortOrder || DEFAULT_SORT_ORDER)
-    if (searchTerm) params.set('search', searchTerm)
-    if (cadenceFilter) params.set('cadence_filter', cadenceFilter)
-    if (action) params.set('action', action)
-    return `/contacts/${contactId}?${params.toString()}`
-  }
+  // Links into detail pages carry the full list context so navigation
+  // order matches list order and back-to-list restores this view.
+  const buildContactUrl = (contactId: string, action?: 'edit' | 'merge') =>
+    buildContactDetailUrl(listContext, contactId, action)
 
   const handleRowClick = (contactId: string) => {
     router.push(buildContactUrl(contactId))
@@ -422,43 +404,79 @@ function ContactsTable({
   )
 }
 
-export default function ContactsPage() {
-  const [searchTerm, setSearchTerm] = useState('')
-  const [params, setParams] = useState<ContactListParams>({
-    page: 1,
-    limit: 20,
-    sort: DEFAULT_SORT_FIELD,
-    order: DEFAULT_SORT_ORDER,
-  })
+function ContactsPageContent() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  // The URL is the source of truth for the list view: sort, order, and
+  // filters are derived from it every render, and event handlers write the
+  // next view straight back to it (replace, not push — view tweaks
+  // shouldn't grow history). Back-to-list, refresh, bookmarks, and
+  // same-route navigation all restore the view for free. Pagination is
+  // deliberately kept out of the URL.
+  const urlContext = parseListContext(searchParams)
+  const [page, setPage] = useState(1)
+
+  // The search input keeps local state so keystrokes render instantly
+  // (router.replace is async), overlaying the URL's search value.
+  const [searchTerm, setSearchTerm] = useState(urlContext.search ?? '')
+  const searchInputRef = useRef<HTMLInputElement>(null)
+
+  const listContext: ContactListContext = {
+    sort: urlContext.sort,
+    order: urlContext.order,
+    ...(searchTerm ? { search: searchTerm } : {}),
+    ...(urlContext.cadence_filter ? { cadence_filter: urlContext.cadence_filter } : {}),
+    ...(urlContext.followup_filter ? { followup_filter: urlContext.followup_filter } : {}),
+  }
+
+  const applyContext = (next: ContactListContext) => {
+    setPage(1)
+    router.replace(buildContactListUrl(next), { scroll: false })
+  }
+
+  // Sync the search input when the URL's search changes under us (nav link,
+  // back/forward). Skipped while the user is typing — during typing the URL
+  // briefly lags the input, and adopting the lagged value would eat
+  // keystrokes.
+  useEffect(() => {
+    if (document.activeElement === searchInputRef.current) return
+    setSearchTerm(urlContext.search ?? '')
+  }, [urlContext.search])
 
   const { data, isLoading, error } = useContacts({
-    ...params,
+    page,
+    limit: 20,
+    sort: listContext.sort,
+    order: listContext.order,
+    cadence_filter: listContext.cadence_filter,
+    followup_filter: listContext.followup_filter,
     ...(searchTerm && { search: searchTerm }),
   })
 
+  const handleSearchInput = (value: string) => {
+    setSearchTerm(value)
+    router.replace(buildContactListUrl({ ...listContext, search: value || undefined }), {
+      scroll: false,
+    })
+  }
+
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault()
-    setParams(prev => ({ ...prev, page: 1 }))
+    setPage(1)
   }
 
   const handleSort = (field: SortField) => {
-    setParams(prev => {
-      // If clicking the same field, toggle order
-      if (prev.sort === field) {
-        return {
-          ...prev,
-          order: prev.order === 'asc' ? 'desc' : 'asc',
-          page: 1, // Reset to first page when sorting
-        }
-      }
-      // Default sort: cadence/last_response_at → desc (most frequent/recent first)
-      // contact_by/birthday/name/location → asc (soonest due/alphabetical first)
-      return {
-        ...prev,
-        sort: field,
-        order: field === 'cadence' || field === 'last_response_at' ? 'desc' : 'asc',
-        page: 1,
-      }
+    applyContext({
+      ...listContext,
+      sort: field,
+      // Same field toggles direction; a new field starts at its natural order
+      order:
+        listContext.sort === field
+          ? listContext.order === 'asc'
+            ? 'desc'
+            : 'asc'
+          : defaultOrderFor(field),
     })
   }
 
@@ -495,10 +513,11 @@ export default function ContactsPage() {
                 <Search className="h-5 w-5 text-gray-400" />
               </div>
               <input
+                ref={searchInputRef}
                 type="text"
                 placeholder="Search contacts..."
                 value={searchTerm}
-                onChange={e => setSearchTerm(e.target.value)}
+                onChange={e => handleSearchInput(e.target.value)}
                 className={FORM_CONTROL_WITH_ICON}
               />
             </div>
@@ -508,14 +527,13 @@ export default function ContactsPage() {
               <ListFilter className="h-5 w-5 text-gray-400" />
             </div>
             <select
-              value={params.cadence_filter || ''}
+              value={listContext.cadence_filter || ''}
               onChange={e =>
-                setParams(prev => ({
-                  ...prev,
+                applyContext({
+                  ...listContext,
                   cadence_filter:
-                    (e.target.value as ContactListParams['cadence_filter']) || undefined,
-                  page: 1,
-                }))
+                    (e.target.value as ContactListContext['cadence_filter']) || undefined,
+                })
               }
               className={FORM_SELECT_BASE + ' pl-10 w-auto'}
               aria-label="Filter by cadence"
@@ -534,7 +552,7 @@ export default function ContactsPage() {
               page={data.page}
               pages={data.pages}
               total={data.total}
-              onPageChange={p => setParams(prev => ({ ...prev, page: p }))}
+              onPageChange={p => setPage(p)}
               noun="contacts"
             />
           </div>
@@ -568,10 +586,7 @@ export default function ContactsPage() {
           <ContactsTable
             contacts={data?.contacts || []}
             loading={isLoading}
-            sortBy={params.sort}
-            sortOrder={params.order}
-            searchTerm={searchTerm || undefined}
-            cadenceFilter={params.cadence_filter}
+            listContext={listContext}
             onSort={handleSort}
           />
         </div>
@@ -583,12 +598,22 @@ export default function ContactsPage() {
               page={data.page}
               pages={data.pages}
               total={data.total}
-              onPageChange={p => setParams(prev => ({ ...prev, page: p }))}
+              onPageChange={p => setPage(p)}
               noun="contacts"
             />
           </div>
         )}
       </div>
     </div>
+  )
+}
+
+// useSearchParams forces a client-side bailout, so the statically
+// prerendered page needs a Suspense boundary around the content.
+export default function ContactsPage() {
+  return (
+    <Suspense>
+      <ContactsPageContent />
+    </Suspense>
   )
 }

--- a/frontend/src/lib/__tests__/contact-list-params.test.ts
+++ b/frontend/src/lib/__tests__/contact-list-params.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  DEFAULT_SORT_FIELD,
+  DEFAULT_SORT_ORDER,
+  buildContactDetailUrl,
+  buildContactListUrl,
+  defaultOrderFor,
+  listContextSearchParams,
+  parseListContext,
+  type ContactListContext,
+} from '../contact-list-params'
+
+describe('contact-list-params', () => {
+  describe('parseListContext', () => {
+    it('falls back to defaults for an empty URL', () => {
+      const ctx = parseListContext(new URLSearchParams())
+      expect(ctx).toEqual({ sort: DEFAULT_SORT_FIELD, order: DEFAULT_SORT_ORDER })
+    })
+
+    it('reads all five params', () => {
+      const ctx = parseListContext(
+        new URLSearchParams(
+          'sort=name&order=asc&search=jane&cadence_filter=has_cadence&followup_filter=no_followup'
+        )
+      )
+      expect(ctx).toEqual({
+        sort: 'name',
+        order: 'asc',
+        search: 'jane',
+        cadence_filter: 'has_cadence',
+        followup_filter: 'no_followup',
+      })
+    })
+
+    it('rejects invalid values and falls back to defaults', () => {
+      const ctx = parseListContext(
+        new URLSearchParams('sort=DROP+TABLE&order=sideways&cadence_filter=bogus&followup_filter=x')
+      )
+      expect(ctx).toEqual({ sort: DEFAULT_SORT_FIELD, order: DEFAULT_SORT_ORDER })
+    })
+
+    it('treats empty strings as absent', () => {
+      const ctx = parseListContext(new URLSearchParams('sort=&order=&search=&cadence_filter='))
+      expect(ctx).toEqual({ sort: DEFAULT_SORT_FIELD, order: DEFAULT_SORT_ORDER })
+    })
+  })
+
+  describe('round-trip symmetry', () => {
+    it('parse(build(ctx)) returns the same context, filters included', () => {
+      const ctx: ContactListContext = {
+        sort: 'birthday',
+        order: 'asc',
+        search: 'smith',
+        cadence_filter: 'no_cadence',
+        followup_filter: 'has_followup',
+      }
+      const roundTripped = parseListContext(listContextSearchParams(ctx))
+      expect(roundTripped).toEqual(ctx)
+    })
+
+    it('carries followup_filter through detail URLs (regression: buildContactUrl dropped it)', () => {
+      const ctx: ContactListContext = {
+        sort: 'cadence',
+        order: 'desc',
+        followup_filter: 'has_followup',
+      }
+      const url = buildContactDetailUrl(ctx, 'abc-123')
+      expect(url).toContain('followup_filter=has_followup')
+      const parsed = parseListContext(new URL(url, 'http://x').searchParams)
+      expect(parsed.followup_filter).toBe('has_followup')
+    })
+  })
+
+  describe('URL builders', () => {
+    const ctx: ContactListContext = { sort: 'name', order: 'asc', search: 'q' }
+
+    it('always writes sort and order, even at defaults', () => {
+      const url = buildContactListUrl({ sort: DEFAULT_SORT_FIELD, order: DEFAULT_SORT_ORDER })
+      expect(url).toBe('/contacts?sort=cadence&order=desc')
+    })
+
+    it('builds detail URLs with the action param last', () => {
+      expect(buildContactDetailUrl(ctx, 'id-1', 'edit')).toBe(
+        '/contacts/id-1?sort=name&order=asc&search=q&action=edit'
+      )
+    })
+
+    it('omits absent search and filters', () => {
+      expect(buildContactListUrl({ sort: 'name', order: 'asc' })).toBe(
+        '/contacts?sort=name&order=asc'
+      )
+    })
+  })
+
+  describe('defaultOrderFor', () => {
+    it('sorts cadence and last_response_at descending by default', () => {
+      expect(defaultOrderFor('cadence')).toBe('desc')
+      expect(defaultOrderFor('last_response_at')).toBe('desc')
+    })
+
+    it('sorts the remaining fields ascending by default', () => {
+      for (const field of [
+        'name',
+        'location',
+        'birthday',
+        'last_contacted',
+        'contact_by',
+      ] as const) {
+        expect(defaultOrderFor(field)).toBe('asc')
+      }
+    })
+  })
+})

--- a/frontend/src/lib/contact-list-params.ts
+++ b/frontend/src/lib/contact-list-params.ts
@@ -1,0 +1,115 @@
+// Single source of truth for contact-list URL parameters.
+//
+// The sort/filter/search state of the contacts list travels through URLs in
+// three places: the list page itself, list→detail links, and the detail
+// page's prev/next + back-to-list navigation. Every reader and writer of
+// those params must go through this module so the three stay symmetric —
+// a param dropped by one builder silently breaks round-tripping.
+
+export type SortField =
+  | 'name'
+  | 'location'
+  | 'birthday'
+  | 'last_contacted'
+  | 'last_response_at'
+  | 'contact_by'
+  | 'cadence'
+export type SortOrder = 'asc' | 'desc'
+export type CadenceFilter = 'has_cadence' | 'no_cadence'
+export type FollowupFilter = 'has_followup' | 'no_followup'
+
+export const SORT_FIELDS: readonly SortField[] = [
+  'name',
+  'location',
+  'birthday',
+  'last_contacted',
+  'last_response_at',
+  'contact_by',
+  'cadence',
+]
+
+export const DEFAULT_SORT_FIELD: SortField = 'cadence'
+export const DEFAULT_SORT_ORDER: SortOrder = 'desc'
+
+// Order applied when a column is first selected: most-frequent/most-recent
+// first for cadence and last_response_at, ascending for everything else.
+export function defaultOrderFor(field: SortField): SortOrder {
+  return field === 'cadence' || field === 'last_response_at' ? 'desc' : 'asc'
+}
+
+// The list context that travels through URLs. sort/order are always
+// resolved (defaults applied); the filters and search are optional.
+export interface ContactListContext {
+  sort: SortField
+  order: SortOrder
+  search?: string
+  cadence_filter?: CadenceFilter
+  followup_filter?: FollowupFilter
+}
+
+export const DEFAULT_LIST_CONTEXT: ContactListContext = {
+  sort: DEFAULT_SORT_FIELD,
+  order: DEFAULT_SORT_ORDER,
+}
+
+function isSortField(value: string): value is SortField {
+  return (SORT_FIELDS as readonly string[]).includes(value)
+}
+
+// parseListContext reads the list context from URL search params, falling
+// back to defaults for missing or invalid values. Accepts anything with a
+// URLSearchParams-style get() so both next/navigation's
+// ReadonlyURLSearchParams and plain URLSearchParams work.
+export function parseListContext(searchParams: {
+  get(name: string): string | null
+}): ContactListContext {
+  const rawSort = searchParams.get('sort') ?? ''
+  const rawOrder = searchParams.get('order') ?? ''
+  const search = searchParams.get('search') ?? undefined
+  const rawCadence = searchParams.get('cadence_filter') ?? ''
+  const rawFollowup = searchParams.get('followup_filter') ?? ''
+
+  return {
+    sort: isSortField(rawSort) ? rawSort : DEFAULT_SORT_FIELD,
+    order: rawOrder === 'asc' || rawOrder === 'desc' ? rawOrder : DEFAULT_SORT_ORDER,
+    ...(search ? { search } : {}),
+    ...(rawCadence === 'has_cadence' || rawCadence === 'no_cadence'
+      ? { cadence_filter: rawCadence }
+      : {}),
+    ...(rawFollowup === 'has_followup' || rawFollowup === 'no_followup'
+      ? { followup_filter: rawFollowup }
+      : {}),
+  }
+}
+
+// listContextSearchParams serializes a context back to URL params. sort and
+// order are always written (navigation order must match list order even at
+// defaults); search and filters only when present.
+export function listContextSearchParams(context: ContactListContext): URLSearchParams {
+  const params = new URLSearchParams()
+  params.set('sort', context.sort)
+  params.set('order', context.order)
+  if (context.search) params.set('search', context.search)
+  if (context.cadence_filter) params.set('cadence_filter', context.cadence_filter)
+  if (context.followup_filter) params.set('followup_filter', context.followup_filter)
+  return params
+}
+
+// buildContactListUrl builds the list page URL carrying the full context
+// (the detail page's "back to list" target).
+export function buildContactListUrl(context: ContactListContext): string {
+  return `/contacts?${listContextSearchParams(context).toString()}`
+}
+
+// buildContactDetailUrl builds a detail page URL carrying the full context
+// (list→detail links and prev/next navigation), plus an optional one-shot
+// action param consumed by the detail page.
+export function buildContactDetailUrl(
+  context: ContactListContext,
+  contactId: string,
+  action?: 'edit' | 'merge'
+): string {
+  const params = listContextSearchParams(context)
+  if (action) params.set('action', action)
+  return `/contacts/${contactId}?${params.toString()}`
+}

--- a/frontend/src/lib/contacts-api.ts
+++ b/frontend/src/lib/contacts-api.ts
@@ -6,6 +6,7 @@ import type {
   ContactListParams,
   OverdueContact,
 } from '@/types/contact'
+import type { CadenceFilter, FollowupFilter, SortField, SortOrder } from './contact-list-params'
 
 export interface ContactsListResponse {
   contacts: Contact[]
@@ -21,11 +22,11 @@ export interface ContactIDsResponse {
 }
 
 export interface ContactIDsParams {
-  sort?: string
-  order?: 'asc' | 'desc'
+  sort?: SortField
+  order?: SortOrder
   search?: string
-  cadence_filter?: 'has_cadence' | 'no_cadence'
-  followup_filter?: 'has_followup' | 'no_followup'
+  cadence_filter?: CadenceFilter
+  followup_filter?: FollowupFilter
 }
 
 export const contactsApi = {

--- a/frontend/src/types/contact.ts
+++ b/frontend/src/types/contact.ts
@@ -1,3 +1,5 @@
+import type { CadenceFilter, FollowupFilter, SortField, SortOrder } from '@/lib/contact-list-params'
+
 export type ContactMethodType =
   | 'email'
   | 'phone'
@@ -66,15 +68,8 @@ export interface ContactListParams {
   page?: number
   limit?: number
   search?: string
-  sort?:
-    | 'name'
-    | 'location'
-    | 'birthday'
-    | 'last_contacted'
-    | 'last_response_at'
-    | 'contact_by'
-    | 'cadence'
-  order?: 'asc' | 'desc'
-  cadence_filter?: 'has_cadence' | 'no_cadence'
-  followup_filter?: 'has_followup' | 'no_followup'
+  sort?: SortField
+  order?: SortOrder
+  cadence_filter?: CadenceFilter
+  followup_filter?: FollowupFilter
 }

--- a/frontend/tests/e2e/contact-navigation.spec.ts
+++ b/frontend/tests/e2e/contact-navigation.spec.ts
@@ -264,4 +264,41 @@ test.describe('Contact Keyboard Navigation @area:contact-navigation', () => {
     // Should be back on contacts list
     await expect(page.getByRole('heading', { name: 'Contacts' })).toBeVisible()
   })
+
+  test('should restore search and sort state after Escape back to list', async ({ page }) => {
+    // Two contacts so search + sort visibly shape the list
+    await testApi.seedContacts([
+      { full_name: 'Restore State Alpha' },
+      { full_name: 'Restore State Beta' },
+    ])
+
+    const fullNameAlpha = `${testApi.prefix}-Restore State Alpha`
+
+    // Apply a search and a name-asc sort on the list
+    await page.goto('/contacts')
+    await page.waitForLoadState('domcontentloaded')
+    await page.getByPlaceholder('Search contacts...').fill(testApi.prefix)
+    await expect(page.getByText(fullNameAlpha)).toBeVisible({ timeout: 15000 })
+    await page.getByRole('columnheader').filter({ hasText: /^Name/ }).click()
+
+    // The list mirrors its state into the URL
+    await expect(page).toHaveURL(/sort=name/)
+    await expect(page).toHaveURL(/order=asc/)
+
+    // Enter a detail page, then Escape back
+    await page.getByText(fullNameAlpha).click()
+    await page.waitForURL(/\/contacts\/[A-Za-z0-9-]+/)
+    await page.waitForLoadState('domcontentloaded')
+    await expect(page.getByRole('heading', { name: fullNameAlpha })).toBeVisible({
+      timeout: 15000,
+    })
+    await page.keyboard.press('Escape')
+    await page.waitForLoadState('domcontentloaded')
+
+    // Back on the list with search + sort restored, not reset to defaults
+    await expect(page.getByRole('heading', { name: 'Contacts' })).toBeVisible()
+    await expect(page).toHaveURL(/sort=name/)
+    await expect(page).toHaveURL(/order=asc/)
+    await expect(page.getByPlaceholder('Search contacts...')).toHaveValue(testApi.prefix)
+  })
 })

--- a/frontend/tests/e2e/test-map.json
+++ b/frontend/tests/e2e/test-map.json
@@ -225,6 +225,10 @@
     "tags": ["@area:contacts", "@area:contact-navigation", "@area:overdue"]
   },
   {
+    "pattern": "^frontend/src/lib/contact-list-params\\.ts$",
+    "tags": ["@area:contacts", "@area:contact-navigation", "@area:overdue"]
+  },
+  {
     "pattern": "^frontend/src/lib/contact-methods\\.ts$",
     "tags": ["@area:contacts", "@area:contact-merge"]
   },


### PR DESCRIPTION
## Summary

Frontend URL-plumbing piece of the "contract spine" arc (finding 5; follows #577, sibling of #578). The contact list's sort/search/filter state flowed through three divergent hand-rolled builders — and the list page never read the URL at all, so state written into URLs by the detail page was silently discarded.

### What changed

- **New `lib/contact-list-params.ts`** owns the canonical types (`SortField`, `SortOrder`, `CadenceFilter`, `FollowupFilter`, `ContactListContext`), the default sort constants, the per-field first-click order rule (previously trapped inside `handleSort`), and symmetric `parseListContext` / `buildContactListUrl` / `buildContactDetailUrl`.
- **The URL is now actually the source of truth on the list page**: sort/order/filters are derived from `useSearchParams` every render, and event handlers write the next view back with `router.replace` (no history spam, no state mirror). Same-route navigation (nav link, back/forward) works structurally. The search input keeps local state for keystroke latency, with one small focus-guarded sync effect. A `Suspense` boundary satisfies the static-prerender bailout rule.
- **Bug fixes**:
  - Back-to-list (Escape from a detail page) now restores sort, search, and filters — previously the detail page wrote a context URL the list never consumed, snapping back to defaults.
  - `followup_filter` now survives list→detail links — `buildContactUrl` dropped it while `buildNavigationUrl` forwarded it.
- The detail page's inline `listContext` + `buildNavigationUrl` collapse to module calls; the duplicated sort unions in `types/contact.ts` and `contacts-api.ts` now point at the module.

### Tests

- Unit (11 new): parse/build round-trip symmetry, invalid-value fallback (bad sort/order/filters → defaults), the `followup_filter` regression, always-writing sort/order, per-field default order.
- E2E (new): apply search + name sort on the list, enter a detail page, Escape back — asserts URL params and search input are restored, not reset. The pre-existing Escape test only checked the heading, which is why this bug survived.

## Verification

- `tsc --noEmit`, `bun run lint`, vitest 379/379, and `next build` (with the #577 gates armed) all pass.
- E2E not runnable in this sandbox (no docker); CI runs the full suite.
- Codex review (two rounds): round 1 flagged a real P2 — state hydrated once meant same-route nav could be clobbered by the stale mirror; fixed by deriving state from the URL instead of mirroring duplicated state (also simpler). Round 2 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017vsYuFc34StHBxnrQ47FyJ