### PR TITLE
refactor(api): extract per-domain route registration from run()

### DIFF
--- a/.ai/guides/feature-development.md
+++ b/.ai/guides/feature-development.md
@@ -350,7 +350,7 @@ v1 := router.Group("/api/v1")
 | | `/host/:id` | GET/DELETE | MacHostHandler | Get / revoke host (delete cascades push-cursor rows) |
 | | `/host/pairing-token` | POST | MacHostHandler | Mint single-use pairing token (10-min TTL) |
 
-Routes defined in `backend/cmd/crm-api/main.go`.
+Routes defined in per-domain `RegisterXRoutes` helpers under `backend/internal/api/handlers/*_routes.go`; their gated call sites live in `backend/cmd/crm-api/main.go`.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ Find all instances of a layer:
 
 | What | Where |
 |------|-------|
-| API routes | `backend/cmd/crm-api/main.go` (search for `v1.Group`) |
+| API routes | `backend/internal/api/handlers/*_routes.go` (per-domain `RegisterXRoutes`); gated call sites in `backend/cmd/crm-api/main.go` (search for `RegisterXRoutes`) |
 | Scheduler/cron jobs | `backend/internal/scheduler/scheduler.go` |
 | Time acceleration | `backend/internal/accelerated/time.go` |
 | Query invalidation | `frontend/src/lib/query-invalidation.ts` |

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -1313,12 +1313,10 @@ func run() int {
 
 	// OAuth callback routes (no auth - called by provider redirects)
 	if oauthHandler != nil {
-		if googleOAuthService != nil {
-			router.GET("/api/v1/auth/google/callback", oauthHandler.GoogleCallback)
-		}
-		if oauthHandler.HasTodoistOAuth() {
-			router.GET("/api/v1/auth/todoist/callback", oauthHandler.TodoistCallback)
-		}
+		handlers.RegisterOAuthCallbackRoutes(router, handlers.OAuthCallbackDeps{
+			Handler:       oauthHandler,
+			GoogleEnabled: googleOAuthService != nil,
+		})
 	}
 
 	// Mac-daemon public + host-auth routes (Pair + heartbeat + cursor +
@@ -1344,77 +1342,42 @@ func run() int {
 			auth.APIKeyMiddleware(cfg),
 			auth.MacHostAuthMiddleware(macHostRepo, auth.DefaultPasswordComparator, auth.DefaultMacHostAuthLimiterConfig()),
 		)
-		ingestGroup := router.Group("/api/v1/ingest")
-		ingestGroup.Use(ingestAuth)
-		ingestGroup.POST("/events", ingestHandler.IngestEvents)
+		handlers.RegisterIngestRoutes(router, handlers.IngestRouteDeps{
+			Auth:        ingestAuth,
+			Ingest:      ingestHandler,
+			MeetingNote: meetingNoteHandler,
+		})
 		logger.Info().Msg("event bus ingestion endpoint enabled")
-
-		// Daemon recovery endpoint: the Mac daemon polls this on
-		// startup to reconcile its local pending-notification table
-		// against the Pi's current truth. Lives under composite auth
-		// so the daemon's X-Mac-Host-ID + Bearer pair-key path
-		// resolves; the frontend (global API key) can also reach it.
-		meetingNoteRecoveryGroup := router.Group("/api/v1/meeting-notes")
-		meetingNoteRecoveryGroup.Use(ingestAuth)
-		meetingNoteRecoveryGroup.GET("/needs-attention", meetingNoteHandler.ListNeedsAttention)
 	}
 
 	// API routes
 	v1 := router.Group("/api/v1")
 	v1.Use(auth.APIKeyMiddleware(cfg))
 	{
-		// Contact routes
-		contacts := v1.Group("/contacts")
-		{
-			contacts.POST("", contactHandler.CreateContact)
-			contacts.GET("/overdue", contactHandler.ListOverdueContacts)
-			contacts.GET("", contactHandler.ListContacts)
-			contacts.GET("/:id", contactHandler.GetContact)
-			contacts.PUT("/:id", contactHandler.UpdateContact)
-			contacts.DELETE("/:id", contactHandler.DeleteContact)
-			contacts.GET("/:id/interactions", interactionHandler.ListContactInteractions)
-			contacts.POST("/:id/interactions", interactionHandler.CreateInteraction)
-			contacts.GET("/:id/notes", noteHandler.GetContactNotepad)
-			contacts.PUT("/:id/notes", noteHandler.SaveContactNotepad)
-			// Merge routes
-			contacts.GET("/:id/merge/preview", contactHandler.GetMergePreview)
-			contacts.POST("/:id/merge", contactHandler.MergeContacts)
-		}
-
-		// Interaction routes (non-contact-scoped)
-		interactions := v1.Group("/interactions")
-		{
-			interactions.DELETE("/:id", interactionHandler.DeleteInteraction)
-		}
+		// Contact + interaction routes (unconditional).
+		handlers.RegisterContactRoutes(v1, handlers.ContactRouteDeps{
+			Contact:     contactHandler,
+			Interaction: interactionHandler,
+			Note:        noteHandler,
+		})
 
 		// Meeting-note conflict-resolution — user-driven, called from
 		// the frontend with the global API key. Stays under the v1
 		// APIKeyMiddleware group.
-		meetingNotes := v1.Group("/meeting-notes")
-		{
-			meetingNotes.POST("/:id/resolve-link", meetingNoteHandler.ResolveLink)
-		}
+		handlers.RegisterMeetingNoteRoutes(v1, meetingNoteHandler)
 
 		// Rematch routes — always registered; service no-ops when no handlers
 		// are registered (e.g. telegram-disabled deployments still get calendar).
-		rematchRoutes := v1.Group("/rematch")
-		{
-			rematchRoutes.GET("/jobs/:jobID", rematchHandler.GetJob)
-			rematchRoutes.POST("/contacts/:id/rescan", rematchHandler.Rescan)
-		}
+		handlers.RegisterRematchRoutes(v1, rematchHandler)
 
 		// Sync-staleness breaches — registered unconditionally (OUTSIDE the
 		// EnableExternalSync-gated /sync group below): heartbeat/push breaches
 		// must be visible even with external sync off. The static 2-segment
 		// path coexists with that group's 3-segment param routes.
-		v1.GET("/sync/staleness", stalenessHandler.GetActiveBreaches)
+		handlers.RegisterSyncStalenessRoutes(v1, stalenessHandler)
 
 		// System routes
-		system := v1.Group("/system")
-		{
-			system.GET("/time", systemHandler.GetSystemTime)
-			system.POST("/time/acceleration", systemHandler.SetTimeAcceleration)
-		}
+		handlers.RegisterSystemRoutes(v1, systemHandler)
 
 		// Mac-daemon admin routes (under global API key middleware).
 		// Pairing-token mint + revoke + list/get for the Mac settings UI.
@@ -1422,137 +1385,49 @@ func run() int {
 
 		// OAuth routes (feature-flagged with external sync)
 		if oauthHandler != nil {
-			authRoutes := v1.Group("/auth")
-			{
-				// Google OAuth (only if configured)
-				if googleOAuthService != nil {
-					authRoutes.GET("/google", oauthHandler.GetGoogleAuthURL)
-					authRoutes.GET("/google/accounts", oauthHandler.ListGoogleAccounts)
-					authRoutes.GET("/google/accounts/:id/status", oauthHandler.GetGoogleAccountStatus)
-					authRoutes.POST("/google/accounts/:id/revoke", oauthHandler.RevokeGoogleAccount)
-				}
-
-				// Todoist OAuth (only if configured)
-				if oauthHandler.HasTodoistOAuth() {
-					authRoutes.GET("/todoist", oauthHandler.GetTodoistAuthURL)
-					authRoutes.GET("/todoist/accounts", oauthHandler.ListTodoistAccounts)
-					authRoutes.GET("/todoist/accounts/:id/status", oauthHandler.GetTodoistAccountStatus)
-					authRoutes.POST("/todoist/accounts/:id/revoke", oauthHandler.RevokeTodoistAccount)
-				}
-			}
+			handlers.RegisterOAuthRoutes(v1, handlers.OAuthCallbackDeps{
+				Handler:       oauthHandler,
+				GoogleEnabled: googleOAuthService != nil,
+			})
 		}
 
 		// Todoist settings routes (only if Todoist is configured)
 		if todoistHandler != nil {
-			todoistRoutes := v1.Group("/todoist")
-			{
-				todoistRoutes.GET("/settings", todoistHandler.GetSettings)
-				todoistRoutes.PATCH("/settings", todoistHandler.UpdateSettings)
-				todoistRoutes.GET("/projects", todoistHandler.ListProjects)
-				todoistRoutes.GET("/labels", todoistHandler.ListLabels)
-			}
+			handlers.RegisterTodoistRoutes(v1, todoistHandler)
 		}
 
 		// Telegram routes (feature-flagged)
 		if telegramHandler != nil {
-			tgRoutes := v1.Group("/telegram")
-			{
-				tgAuth := tgRoutes.Group("/auth")
-				{
-					tgAuth.POST("/start", telegramHandler.StartAuth)
-					tgAuth.POST("/verify-code", telegramHandler.VerifyCode)
-					tgAuth.POST("/verify-password", telegramHandler.VerifyPassword)
-					tgAuth.POST("/cancel", telegramHandler.CancelAuth)
-					tgAuth.DELETE("", telegramHandler.Disconnect)
-					tgAuth.GET("/status", telegramHandler.GetStatus)
-				}
-				tgChats := tgRoutes.Group("/chats")
-				{
-					tgChats.GET("", telegramHandler.ListChats)
-					tgChats.PATCH("/:chat_id", telegramHandler.UpdateChatStatus)
-				}
-			}
+			handlers.RegisterTelegramRoutes(v1, telegramHandler)
 		}
 
 		// External sync routes (feature-flagged)
 		if cfg.Features.EnableExternalSync && syncHandler != nil {
-			syncRoutes := v1.Group("/sync")
-			{
-				syncRoutes.GET("/status", syncHandler.GetSyncStatus)
-				syncRoutes.GET("/providers", syncHandler.GetAvailableProviders)
-				syncRoutes.GET("/logs", syncHandler.GetRecentSyncLogs)
-				// Source-based routes (by source name like "gmail", "calendar")
-				syncRoutes.GET("/:source/status", syncHandler.GetSyncState)
-				syncRoutes.POST("/:source/trigger", syncHandler.TriggerSync)
-				// State-based routes (by sync state UUID)
-				syncRoutes.PATCH("/states/:id/enable", syncHandler.EnableSync)
-				syncRoutes.GET("/states/:id/logs", syncHandler.GetSyncLogs)
-			}
-
-			// Identity matching routes
-			identities := v1.Group("/identities")
-			{
-				identities.GET("/unmatched", identityHandler.ListUnmatchedIdentities)
-				identities.GET("/:id", identityHandler.GetIdentity)
-				identities.POST("/:id/link", identityHandler.LinkIdentity)
-				identities.POST("/:id/unlink", identityHandler.UnlinkIdentity)
-				identities.DELETE("/:id", identityHandler.DeleteIdentity)
-			}
-
-			// Add identity route to contacts
-			contacts.GET("/:id/identities", identityHandler.ListIdentitiesForContact)
+			handlers.RegisterSyncRoutes(v1, syncHandler)
+			handlers.RegisterIdentityRoutes(v1, identityHandler)
 
 			// Add contact task routes (manual tasks) if Todoist is configured
 			if contactTaskHandler != nil {
-				contacts.GET("/:id/tasks", contactTaskHandler.ListContactTasks)
-				contacts.POST("/:id/tasks", contactTaskHandler.CreateManualTask)
-				contacts.DELETE("/:id/tasks/:taskId", contactTaskHandler.DeleteTaskLink)
+				handlers.RegisterContactTaskRoutes(v1, contactTaskHandler)
 			}
 
 			// Add calendar event routes to contacts if calendar handler is initialized
 			if calendarHandler != nil {
-				contacts.GET("/:id/events", calendarHandler.ListEventsForContact)
-				contacts.GET("/:id/events/upcoming", calendarHandler.ListUpcomingEventsForContact)
-
-				// Add global events route
-				events := v1.Group("/events")
-				{
-					events.GET("/upcoming", calendarHandler.ListUpcomingEvents)
-				}
+				handlers.RegisterCalendarRoutes(v1, calendarHandler)
 			}
 
 			// Import candidates routes
 			if importHandler != nil {
-				imports := v1.Group("/imports")
-				{
-					imports.GET("/candidates", importHandler.ListImportCandidates)
-					// Static anarlog-title discovery routes are declared
-					// BEFORE the /:id param route so Gin's tree inserts the
-					// static segment first and /imports/anarlog-title cannot
-					// be shadowed by the :id match.
-					if anarlogDiscoveryHandler != nil {
-						imports.GET("/anarlog-title", anarlogDiscoveryHandler.ListAnarlogTitle)
-						imports.POST("/anarlog-title/resolve", anarlogDiscoveryHandler.ResolveAnarlogTitle)
-					}
-					// Static suggestions routes are likewise declared BEFORE
-					// the /:id param route so the literal `suggestions`
-					// segment is not shadowed by the :id wildcard.
-					if suggestionHandler != nil {
-						imports.GET("/suggestions", suggestionHandler.ListSuggestions)
-						imports.POST("/suggestions/:id/methods/resolve", suggestionHandler.ResolveMethodSuggestions)
-						imports.POST("/suggestions/:id/methods/dismiss", suggestionHandler.DismissMethodSuggestions)
-					}
-					imports.GET("/:id", importHandler.GetImportCandidate)
-					imports.POST("/:id/import", importHandler.ImportContact)
-					imports.POST("/:id/link", importHandler.LinkContact)
-					imports.POST("/:id/ignore", importHandler.IgnoreContact)
-				}
+				handlers.RegisterImportRoutes(v1, handlers.ImportRouteDeps{
+					Import:           importHandler,
+					AnarlogDiscovery: anarlogDiscoveryHandler,
+					Suggestions:      suggestionHandler,
+				})
 			}
 		}
 
 		// Export/Import routes
-		v1.POST("/export", systemHandler.ExportData)
-		v1.POST("/import", systemHandler.ImportData)
+		handlers.RegisterDataExchangeRoutes(v1, systemHandler)
 
 		// Test routes (gated by CRM_ENV=testing or CRM_ENV=test)
 		if cfg.Runtime.CRMEnvironment == "testing" || cfg.Runtime.CRMEnvironment == "test" {
@@ -1569,29 +1444,13 @@ func run() int {
 			if calendarHandler == nil {
 				calendarHandler = handlers.NewCalendarHandler(testCalendarRepo)
 				// Register calendar routes that weren't registered earlier (OAuth not configured)
-				contacts.GET("/:id/events", calendarHandler.ListEventsForContact)
-				contacts.GET("/:id/events/upcoming", calendarHandler.ListUpcomingEventsForContact)
-				events := v1.Group("/events")
-				{
-					events.GET("/upcoming", calendarHandler.ListUpcomingEvents)
-				}
+				handlers.RegisterCalendarRoutes(v1, calendarHandler)
 				logger.Info().Msg("calendar handler initialized for testing (no OAuth)")
 			}
 
 			testSeedService := service.NewTestSeedService(database, testExternalRepo, contactService, testCalendarRepo, macHostRepo, meetingNoteRepoForIngest)
 			testHandler := handlers.NewTestHandler(testSeedService)
-			testRoutes := v1.Group("/test")
-			{
-				testRoutes.POST("/seed/contacts", testHandler.SeedContacts)
-				testRoutes.POST("/seed/external-contacts", testHandler.SeedExternalContacts)
-				testRoutes.POST("/seed/method-suggestions", testHandler.SeedMethodSuggestions)
-				testRoutes.POST("/seed/overdue-contacts", testHandler.SeedOverdueContacts)
-				testRoutes.POST("/seed/calendar-events", testHandler.SeedCalendarEvents)
-				testRoutes.POST("/seed/mac-hosts", testHandler.SeedMacHost)
-				testRoutes.POST("/seed/meeting-notes", testHandler.SeedMeetingNotes)
-				testRoutes.POST("/cleanup", testHandler.Cleanup)
-				testRoutes.POST("/trigger-error", testHandler.TriggerError)
-			}
+			handlers.RegisterTestRoutes(v1, testHandler)
 			logger.Info().Msg("test API endpoints enabled (CRM_ENV=testing)")
 		}
 	}

--- a/backend/internal/api/handlers/anarlog_discovery_test.go
+++ b/backend/internal/api/handlers/anarlog_discovery_test.go
@@ -193,8 +193,10 @@ func TestListAnarlogTitle_NilService(t *testing.T) {
 // tree resolves the static /imports/anarlog-title segment to the
 // discovery handler while /imports/<uuid> still resolves to the :id
 // candidate handler, when the static routes are declared before :id
-// exactly as cmd/crm-api/main.go registers them. Uses sentinel handlers
-// so the test isolates routing behavior from handler internals.
+// exactly as RegisterImportRoutes registers them. Uses sentinel handlers
+// so the test isolates Gin routing behavior from handler internals; the
+// companion TestRegisterImportRoutes_StaticBeforeParamOrdering drives the
+// real helper.
 func TestAnarlogTitleRoute_DoesNotShadowGetCandidate(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	router := gin.New()

--- a/backend/internal/api/handlers/calendar_routes.go
+++ b/backend/internal/api/handlers/calendar_routes.go
@@ -1,0 +1,26 @@
+package handlers
+
+import "github.com/gin-gonic/gin"
+
+// RegisterCalendarRoutes wires the calendar-event route surface onto a
+// group whose middleware already enforces the global API key:
+//
+//   - GET /api/v1/contacts/:id/events
+//   - GET /api/v1/contacts/:id/events/upcoming
+//   - GET /api/v1/events/upcoming
+//
+// The local v1.Group("/contacts") re-creation is behavior-identical
+// (same prefix + middleware chain as the base group). Shared by two call
+// sites: the external-sync block (gated on calendarHandler != nil) and
+// the test-only fallback that constructs a read-only calendar handler
+// when OAuth is unconfigured.
+func RegisterCalendarRoutes(v1 *gin.RouterGroup, handler *CalendarHandler) {
+	contacts := v1.Group("/contacts")
+	contacts.GET("/:id/events", handler.ListEventsForContact)
+	contacts.GET("/:id/events/upcoming", handler.ListUpcomingEventsForContact)
+
+	events := v1.Group("/events")
+	{
+		events.GET("/upcoming", handler.ListUpcomingEvents)
+	}
+}

--- a/backend/internal/api/handlers/contact_routes.go
+++ b/backend/internal/api/handlers/contact_routes.go
@@ -1,0 +1,58 @@
+package handlers
+
+import "github.com/gin-gonic/gin"
+
+// ContactRouteDeps bundles the handlers backing the contact-scoped route
+// surface. Contact CRUD, per-contact interactions and notes, and the
+// merge preview/apply pair all live under /contacts and are served by
+// three distinct handlers, so the deps struct carries all three.
+type ContactRouteDeps struct {
+	Contact     *ContactHandler
+	Interaction *InteractionHandler
+	Note        *NoteHandler
+}
+
+// RegisterContactRoutes wires the unconditional contact + interaction
+// route surface onto a group whose middleware already enforces the
+// global API key:
+//
+//   - POST   /api/v1/contacts
+//   - GET    /api/v1/contacts/overdue
+//   - GET    /api/v1/contacts
+//   - GET    /api/v1/contacts/:id
+//   - PUT    /api/v1/contacts/:id
+//   - DELETE /api/v1/contacts/:id
+//   - GET    /api/v1/contacts/:id/interactions
+//   - POST   /api/v1/contacts/:id/interactions
+//   - GET    /api/v1/contacts/:id/notes
+//   - PUT    /api/v1/contacts/:id/notes
+//   - GET    /api/v1/contacts/:id/merge/preview
+//   - POST   /api/v1/contacts/:id/merge
+//   - DELETE /api/v1/interactions/:id
+//
+// Caller must pass the same /api/v1 group it has applied
+// auth.APIKeyMiddleware on; this helper does NOT add the middleware.
+func RegisterContactRoutes(v1 *gin.RouterGroup, deps ContactRouteDeps) {
+	contacts := v1.Group("/contacts")
+	{
+		contacts.POST("", deps.Contact.CreateContact)
+		contacts.GET("/overdue", deps.Contact.ListOverdueContacts)
+		contacts.GET("", deps.Contact.ListContacts)
+		contacts.GET("/:id", deps.Contact.GetContact)
+		contacts.PUT("/:id", deps.Contact.UpdateContact)
+		contacts.DELETE("/:id", deps.Contact.DeleteContact)
+		contacts.GET("/:id/interactions", deps.Interaction.ListContactInteractions)
+		contacts.POST("/:id/interactions", deps.Interaction.CreateInteraction)
+		contacts.GET("/:id/notes", deps.Note.GetContactNotepad)
+		contacts.PUT("/:id/notes", deps.Note.SaveContactNotepad)
+		// Merge routes
+		contacts.GET("/:id/merge/preview", deps.Contact.GetMergePreview)
+		contacts.POST("/:id/merge", deps.Contact.MergeContacts)
+	}
+
+	// Interaction routes (non-contact-scoped)
+	interactions := v1.Group("/interactions")
+	{
+		interactions.DELETE("/:id", deps.Interaction.DeleteInteraction)
+	}
+}

--- a/backend/internal/api/handlers/contact_task_routes.go
+++ b/backend/internal/api/handlers/contact_task_routes.go
@@ -1,0 +1,21 @@
+package handlers
+
+import "github.com/gin-gonic/gin"
+
+// RegisterContactTaskRoutes wires the manual contact-task route surface
+// onto a group whose middleware already enforces the global API key:
+//
+//   - GET    /api/v1/contacts/:id/tasks
+//   - POST   /api/v1/contacts/:id/tasks
+//   - DELETE /api/v1/contacts/:id/tasks/:taskId
+//
+// The local v1.Group("/contacts") re-creation is behavior-identical
+// (same prefix + middleware chain as the base group). Caller gates the
+// whole call on cfg.Features.EnableExternalSync && syncHandler != nil &&
+// contactTaskHandler != nil.
+func RegisterContactTaskRoutes(v1 *gin.RouterGroup, handler *ContactTaskHandler) {
+	contacts := v1.Group("/contacts")
+	contacts.GET("/:id/tasks", handler.ListContactTasks)
+	contacts.POST("/:id/tasks", handler.CreateManualTask)
+	contacts.DELETE("/:id/tasks/:taskId", handler.DeleteTaskLink)
+}

--- a/backend/internal/api/handlers/identity_routes.go
+++ b/backend/internal/api/handlers/identity_routes.go
@@ -1,0 +1,33 @@
+package handlers
+
+import "github.com/gin-gonic/gin"
+
+// RegisterIdentityRoutes wires the identity-matching route surface onto
+// a group whose middleware already enforces the global API key:
+//
+//   - GET    /api/v1/identities/unmatched
+//   - GET    /api/v1/identities/:id
+//   - POST   /api/v1/identities/:id/link
+//   - POST   /api/v1/identities/:id/unlink
+//   - DELETE /api/v1/identities/:id
+//   - GET    /api/v1/contacts/:id/identities
+//
+// The cross-group /contacts/:id/identities route travels with its
+// handler's domain; the local v1.Group("/contacts") re-creation is
+// behavior-identical (same prefix + middleware chain as the base group).
+// Caller gates the whole call on cfg.Features.EnableExternalSync &&
+// syncHandler != nil.
+func RegisterIdentityRoutes(v1 *gin.RouterGroup, handler *IdentityHandler) {
+	identities := v1.Group("/identities")
+	{
+		identities.GET("/unmatched", handler.ListUnmatchedIdentities)
+		identities.GET("/:id", handler.GetIdentity)
+		identities.POST("/:id/link", handler.LinkIdentity)
+		identities.POST("/:id/unlink", handler.UnlinkIdentity)
+		identities.DELETE("/:id", handler.DeleteIdentity)
+	}
+
+	// Add identity route to contacts
+	contacts := v1.Group("/contacts")
+	contacts.GET("/:id/identities", handler.ListIdentitiesForContact)
+}

--- a/backend/internal/api/handlers/import_routes.go
+++ b/backend/internal/api/handlers/import_routes.go
@@ -1,0 +1,61 @@
+package handlers
+
+import "github.com/gin-gonic/gin"
+
+// ImportRouteDeps bundles the import-candidate handler plus the two
+// optional discovery handlers whose static routes must register BEFORE
+// the /:id param route. AnarlogDiscovery and Suggestions are gated
+// internally (nil ⇒ their sub-routes are skipped) because they gate
+// segments of the /imports group whose ORDER against /:id is
+// load-bearing — keeping the ordering in one function is safer than
+// splitting it across call sites.
+type ImportRouteDeps struct {
+	Import           *ImportHandler
+	AnarlogDiscovery *AnarlogDiscoveryHandler
+	Suggestions      *SuggestionHandler
+}
+
+// RegisterImportRoutes wires the import-candidate route surface onto a
+// group whose middleware already enforces the global API key, in EXACT
+// registration order (static segments before the /:id param route so
+// Gin's tree cannot shadow them):
+//
+//   - GET  /api/v1/imports/candidates
+//   - GET  /api/v1/imports/anarlog-title                   (only if AnarlogDiscovery != nil)
+//   - POST /api/v1/imports/anarlog-title/resolve           (only if AnarlogDiscovery != nil)
+//   - GET  /api/v1/imports/suggestions                     (only if Suggestions != nil)
+//   - POST /api/v1/imports/suggestions/:id/methods/resolve (only if Suggestions != nil)
+//   - POST /api/v1/imports/suggestions/:id/methods/dismiss (only if Suggestions != nil)
+//   - GET  /api/v1/imports/:id
+//   - POST /api/v1/imports/:id/import
+//   - POST /api/v1/imports/:id/link
+//   - POST /api/v1/imports/:id/ignore
+//
+// Caller gates the whole call on cfg.Features.EnableExternalSync &&
+// syncHandler != nil && importHandler != nil.
+func RegisterImportRoutes(v1 *gin.RouterGroup, deps ImportRouteDeps) {
+	imports := v1.Group("/imports")
+	{
+		imports.GET("/candidates", deps.Import.ListImportCandidates)
+		// Static anarlog-title discovery routes are declared
+		// BEFORE the /:id param route so Gin's tree inserts the
+		// static segment first and /imports/anarlog-title cannot
+		// be shadowed by the :id match.
+		if deps.AnarlogDiscovery != nil {
+			imports.GET("/anarlog-title", deps.AnarlogDiscovery.ListAnarlogTitle)
+			imports.POST("/anarlog-title/resolve", deps.AnarlogDiscovery.ResolveAnarlogTitle)
+		}
+		// Static suggestions routes are likewise declared BEFORE
+		// the /:id param route so the literal `suggestions`
+		// segment is not shadowed by the :id wildcard.
+		if deps.Suggestions != nil {
+			imports.GET("/suggestions", deps.Suggestions.ListSuggestions)
+			imports.POST("/suggestions/:id/methods/resolve", deps.Suggestions.ResolveMethodSuggestions)
+			imports.POST("/suggestions/:id/methods/dismiss", deps.Suggestions.DismissMethodSuggestions)
+		}
+		imports.GET("/:id", deps.Import.GetImportCandidate)
+		imports.POST("/:id/import", deps.Import.ImportContact)
+		imports.POST("/:id/link", deps.Import.LinkContact)
+		imports.POST("/:id/ignore", deps.Import.IgnoreContact)
+	}
+}

--- a/backend/internal/api/handlers/import_routes_test.go
+++ b/backend/internal/api/handlers/import_routes_test.go
@@ -1,0 +1,118 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+)
+
+// emptySuggestionDeps satisfies every dependency interface of
+// SuggestionService with zero-value returns, so ListSuggestions resolves
+// to a clean empty 200 without a database. It exists only to give the
+// suggestions route a live, non-panicking handler in the ordering test
+// below.
+type emptySuggestionDeps struct{}
+
+func (emptySuggestionDeps) GetByID(ctx context.Context, id uuid.UUID) (*repository.ExternalContact, error) {
+	return nil, nil
+}
+func (emptySuggestionDeps) ListUnmatched(ctx context.Context, source string, limit, offset int32, includeUnresolvedTelegram bool) ([]repository.ExternalContact, error) {
+	return nil, nil
+}
+func (emptySuggestionDeps) ListAllUnmatched(ctx context.Context, limit, offset int32, includeUnresolvedTelegram bool) ([]repository.ExternalContact, error) {
+	return nil, nil
+}
+func (emptySuggestionDeps) CountHiddenUnresolvedTelegram(ctx context.Context, source string) (int64, error) {
+	return 0, nil
+}
+func (emptySuggestionDeps) ListPendingMethodSuggestionRows(ctx context.Context, sourceFilter string) ([]repository.PendingMethodSuggestionRow, error) {
+	return nil, nil
+}
+func (emptySuggestionDeps) ResolveReconcileTarget(ctx context.Context, id uuid.UUID) (*repository.ReconcileTarget, error) {
+	return nil, nil
+}
+func (emptySuggestionDeps) GetForUpdateTx(ctx context.Context, tx pgx.Tx, id uuid.UUID) (*repository.ExternalContact, error) {
+	return nil, nil
+}
+func (emptySuggestionDeps) SetMethodSuggestionSetsTx(ctx context.Context, tx pgx.Tx, id uuid.UUID, pending, dismissed []repository.PendingMethodSuggestion) (*repository.ExternalContact, error) {
+	return nil, nil
+}
+func (emptySuggestionDeps) GetContact(ctx context.Context, id uuid.UUID) (*repository.Contact, error) {
+	return nil, nil
+}
+func (emptySuggestionDeps) ListContactMethodsByContact(ctx context.Context, contactID uuid.UUID) ([]repository.ContactMethod, error) {
+	return nil, nil
+}
+func (emptySuggestionDeps) EnrichContactFromExternalWithSelections(ctx context.Context, crmContactID uuid.UUID, external *repository.ExternalContact, selectedMethods []service.MethodSelection, conflictResolutions map[string]string, cadenceArg *string, name *string) (uuid.UUID, error) {
+	return uuid.Nil, nil
+}
+func (emptySuggestionDeps) FindBestMatchesBatch(ctx context.Context, externals []*repository.ExternalContact) ([]*service.ImportSuggestedMatch, error) {
+	return nil, nil
+}
+
+// TestRegisterImportRoutes_StaticBeforeParamOrdering pins the
+// static-before-param registration order INSIDE RegisterImportRoutes:
+// the literal /imports/anarlog-title and /imports/suggestions segments
+// must resolve to their own handlers, not be swallowed by the /imports/:id
+// param route. It drives the real helper (all three deps set) so a future
+// reorder of the registrations inside RegisterImportRoutes is caught here.
+//
+// Distinguishing signals are dependency-free:
+//   - anarlog ListAnarlogTitle with a nil service returns 503,
+//   - suggestions ListSuggestions with empty deps returns 200,
+//   - GetImportCandidate rejects a non-UUID :id with 400 before any repo call,
+//
+// so a shadow of either static route by /:id would surface as a 400
+// ("Invalid external contact ID") instead of the handler's own status.
+func TestRegisterImportRoutes_StaticBeforeParamOrdering(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	v1 := router.Group("/api/v1")
+
+	importHandler := NewImportHandler(nil, nil, nil, nil, nil, nil)
+	anarlogHandler := NewAnarlogDiscoveryHandler(nil)
+	deps := emptySuggestionDeps{}
+	suggestionSvc := service.NewSuggestionService(deps, deps, deps, deps, deps, nil)
+	suggestionHandler := NewSuggestionHandler(suggestionSvc)
+
+	RegisterImportRoutes(v1, ImportRouteDeps{
+		Import:           importHandler,
+		AnarlogDiscovery: anarlogHandler,
+		Suggestions:      suggestionHandler,
+	})
+
+	cases := []struct {
+		name       string
+		method     string
+		path       string
+		wantStatus int
+	}{
+		{"anarlog-title static wins", http.MethodGet, "/api/v1/imports/anarlog-title", http.StatusServiceUnavailable},
+		{"suggestions static wins", http.MethodGet, "/api/v1/imports/suggestions", http.StatusOK},
+		{"non-static segment falls to :id", http.MethodGet, "/api/v1/imports/not-a-uuid", http.StatusBadRequest},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			router.ServeHTTP(w, req)
+			require.Equal(t, tc.wantStatus, w.Code, tc.path)
+		})
+	}
+
+	// The :id route must reach GetImportCandidate specifically — assert on
+	// its distinctive validation error so a wrong-handler binding is caught.
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/imports/not-a-uuid", nil)
+	router.ServeHTTP(w, req)
+	require.Contains(t, w.Body.String(), "Invalid external contact ID")
+}

--- a/backend/internal/api/handlers/ingest_routes.go
+++ b/backend/internal/api/handlers/ingest_routes.go
@@ -1,0 +1,40 @@
+package handlers
+
+import "github.com/gin-gonic/gin"
+
+// IngestRouteDeps bundles the composite auth middleware and the two
+// handlers backing the event-bus ingest surface. Auth is the pre-built
+// IngestAuthMiddleware (branches per-request between MacHost bearer and
+// global API key); the caller constructs it and passes it in so this
+// package stays free of auth-construction concerns.
+type IngestRouteDeps struct {
+	Auth        gin.HandlerFunc
+	Ingest      *IngestHandler
+	MeetingNote *MeetingNoteHandler
+}
+
+// RegisterIngestRoutes wires the event-bus ingest surface directly onto
+// the bare router as SIBLINGS of /api/v1 (not inside it) so the composite
+// IngestAuthMiddleware can branch per-request:
+//
+//   - POST /api/v1/ingest/events               (composite auth)
+//   - GET  /api/v1/meeting-notes/needs-attention (composite auth)
+//
+// gin route trees reject duplicate registration of the same prefix under
+// different middleware groups, so the composite dispatch is the minimum
+// seam to support both auth paths on one URL. Caller gates the whole call
+// on cfg.Features.EnableEventBusIngest.
+func RegisterIngestRoutes(router *gin.Engine, deps IngestRouteDeps) {
+	ingestGroup := router.Group("/api/v1/ingest")
+	ingestGroup.Use(deps.Auth)
+	ingestGroup.POST("/events", deps.Ingest.IngestEvents)
+
+	// Daemon recovery endpoint: the Mac daemon polls this on startup to
+	// reconcile its local pending-notification table against the Pi's
+	// current truth. Lives under composite auth so the daemon's
+	// X-Mac-Host-ID + Bearer pair-key path resolves; the frontend
+	// (global API key) can also reach it.
+	meetingNoteRecoveryGroup := router.Group("/api/v1/meeting-notes")
+	meetingNoteRecoveryGroup.Use(deps.Auth)
+	meetingNoteRecoveryGroup.GET("/needs-attention", deps.MeetingNote.ListNeedsAttention)
+}

--- a/backend/internal/api/handlers/meeting_note_routes.go
+++ b/backend/internal/api/handlers/meeting_note_routes.go
@@ -1,0 +1,20 @@
+package handlers
+
+import "github.com/gin-gonic/gin"
+
+// RegisterMeetingNoteRoutes wires the user-driven meeting-note
+// conflict-resolution endpoint onto a group whose middleware already
+// enforces the global API key:
+//
+//   - POST /api/v1/meeting-notes/:id/resolve-link
+//
+// This is the frontend-facing resolve endpoint (global API key). The
+// daemon-recovery GET /meeting-notes/needs-attention lives on the
+// composite-auth ingest surface (see RegisterIngestRoutes) and is not
+// registered here.
+func RegisterMeetingNoteRoutes(v1 *gin.RouterGroup, handler *MeetingNoteHandler) {
+	meetingNotes := v1.Group("/meeting-notes")
+	{
+		meetingNotes.POST("/:id/resolve-link", handler.ResolveLink)
+	}
+}

--- a/backend/internal/api/handlers/oauth_routes.go
+++ b/backend/internal/api/handlers/oauth_routes.go
@@ -1,0 +1,65 @@
+package handlers
+
+import "github.com/gin-gonic/gin"
+
+// OAuthCallbackDeps bundles the OAuth handler and the per-provider gate
+// that both the callback routes and the authenticated auth-URL routes
+// need. GoogleEnabled mirrors run()'s googleOAuthService != nil check;
+// the Todoist gate is read from Handler.HasTodoistOAuth() so the two
+// providers register independently, matching today's per-route gating.
+type OAuthCallbackDeps struct {
+	Handler       *OAuthHandler
+	GoogleEnabled bool
+}
+
+// RegisterOAuthCallbackRoutes wires the provider-redirect callback routes
+// directly onto the bare router (NO auth — external providers cannot
+// carry the global API key):
+//
+//   - GET /api/v1/auth/google/callback  (only if GoogleEnabled)
+//   - GET /api/v1/auth/todoist/callback (only if Handler.HasTodoistOAuth())
+//
+// Caller gates the whole call on oauthHandler != nil.
+func RegisterOAuthCallbackRoutes(router *gin.Engine, deps OAuthCallbackDeps) {
+	if deps.GoogleEnabled {
+		router.GET("/api/v1/auth/google/callback", deps.Handler.GoogleCallback)
+	}
+	if deps.Handler.HasTodoistOAuth() {
+		router.GET("/api/v1/auth/todoist/callback", deps.Handler.TodoistCallback)
+	}
+}
+
+// RegisterOAuthRoutes wires the authenticated OAuth auth-URL + account
+// management route surface onto a group whose middleware already
+// enforces the global API key:
+//
+//   - GET  /api/v1/auth/google                        (only if GoogleEnabled)
+//   - GET  /api/v1/auth/google/accounts               (only if GoogleEnabled)
+//   - GET  /api/v1/auth/google/accounts/:id/status    (only if GoogleEnabled)
+//   - POST /api/v1/auth/google/accounts/:id/revoke    (only if GoogleEnabled)
+//   - GET  /api/v1/auth/todoist                       (only if Handler.HasTodoistOAuth())
+//   - GET  /api/v1/auth/todoist/accounts              (only if Handler.HasTodoistOAuth())
+//   - GET  /api/v1/auth/todoist/accounts/:id/status   (only if Handler.HasTodoistOAuth())
+//   - POST /api/v1/auth/todoist/accounts/:id/revoke   (only if Handler.HasTodoistOAuth())
+//
+// Caller gates the whole call on oauthHandler != nil.
+func RegisterOAuthRoutes(v1 *gin.RouterGroup, deps OAuthCallbackDeps) {
+	authRoutes := v1.Group("/auth")
+	{
+		// Google OAuth (only if configured)
+		if deps.GoogleEnabled {
+			authRoutes.GET("/google", deps.Handler.GetGoogleAuthURL)
+			authRoutes.GET("/google/accounts", deps.Handler.ListGoogleAccounts)
+			authRoutes.GET("/google/accounts/:id/status", deps.Handler.GetGoogleAccountStatus)
+			authRoutes.POST("/google/accounts/:id/revoke", deps.Handler.RevokeGoogleAccount)
+		}
+
+		// Todoist OAuth (only if configured)
+		if deps.Handler.HasTodoistOAuth() {
+			authRoutes.GET("/todoist", deps.Handler.GetTodoistAuthURL)
+			authRoutes.GET("/todoist/accounts", deps.Handler.ListTodoistAccounts)
+			authRoutes.GET("/todoist/accounts/:id/status", deps.Handler.GetTodoistAccountStatus)
+			authRoutes.POST("/todoist/accounts/:id/revoke", deps.Handler.RevokeTodoistAccount)
+		}
+	}
+}

--- a/backend/internal/api/handlers/rematch_routes.go
+++ b/backend/internal/api/handlers/rematch_routes.go
@@ -1,0 +1,20 @@
+package handlers
+
+import "github.com/gin-gonic/gin"
+
+// RegisterRematchRoutes wires the rematch job/rescan route surface onto
+// a group whose middleware already enforces the global API key:
+//
+//   - GET  /api/v1/rematch/jobs/:jobID
+//   - POST /api/v1/rematch/contacts/:id/rescan
+//
+// Registered unconditionally; the rematch service no-ops when no
+// providers registered a handler (e.g. telegram-disabled deployments
+// still get calendar).
+func RegisterRematchRoutes(v1 *gin.RouterGroup, handler *RematchHandler) {
+	rematchRoutes := v1.Group("/rematch")
+	{
+		rematchRoutes.GET("/jobs/:jobID", handler.GetJob)
+		rematchRoutes.POST("/contacts/:id/rescan", handler.Rescan)
+	}
+}

--- a/backend/internal/api/handlers/sync_routes.go
+++ b/backend/internal/api/handlers/sync_routes.go
@@ -1,0 +1,31 @@
+package handlers
+
+import "github.com/gin-gonic/gin"
+
+// RegisterSyncRoutes wires the external-sync status/trigger route surface
+// onto a group whose middleware already enforces the global API key:
+//
+//   - GET   /api/v1/sync/status
+//   - GET   /api/v1/sync/providers
+//   - GET   /api/v1/sync/logs
+//   - GET   /api/v1/sync/:source/status
+//   - POST  /api/v1/sync/:source/trigger
+//   - PATCH /api/v1/sync/states/:id/enable
+//   - GET   /api/v1/sync/states/:id/logs
+//
+// Caller gates the whole call on cfg.Features.EnableExternalSync &&
+// syncHandler != nil.
+func RegisterSyncRoutes(v1 *gin.RouterGroup, handler *SyncHandler) {
+	syncRoutes := v1.Group("/sync")
+	{
+		syncRoutes.GET("/status", handler.GetSyncStatus)
+		syncRoutes.GET("/providers", handler.GetAvailableProviders)
+		syncRoutes.GET("/logs", handler.GetRecentSyncLogs)
+		// Source-based routes (by source name like "gmail", "calendar")
+		syncRoutes.GET("/:source/status", handler.GetSyncState)
+		syncRoutes.POST("/:source/trigger", handler.TriggerSync)
+		// State-based routes (by sync state UUID)
+		syncRoutes.PATCH("/states/:id/enable", handler.EnableSync)
+		syncRoutes.GET("/states/:id/logs", handler.GetSyncLogs)
+	}
+}

--- a/backend/internal/api/handlers/sync_staleness_routes.go
+++ b/backend/internal/api/handlers/sync_staleness_routes.go
@@ -1,0 +1,16 @@
+package handlers
+
+import "github.com/gin-gonic/gin"
+
+// RegisterSyncStalenessRoutes wires the sync-staleness breach endpoint
+// onto a group whose middleware already enforces the global API key:
+//
+//   - GET /api/v1/sync/staleness
+//
+// Registered unconditionally, OUTSIDE the EnableExternalSync-gated /sync
+// group: heartbeat/push breaches must be visible even with external sync
+// off. The static 2-segment path coexists with the sync group's
+// 3-segment param routes (e.g. /sync/:source/status).
+func RegisterSyncStalenessRoutes(v1 *gin.RouterGroup, handler *StalenessHandler) {
+	v1.GET("/sync/staleness", handler.GetActiveBreaches)
+}

--- a/backend/internal/api/handlers/system_routes.go
+++ b/backend/internal/api/handlers/system_routes.go
@@ -1,0 +1,31 @@
+package handlers
+
+import "github.com/gin-gonic/gin"
+
+// RegisterSystemRoutes wires the system time/acceleration route surface
+// onto a group whose middleware already enforces the global API key:
+//
+//   - GET  /api/v1/system/time
+//   - POST /api/v1/system/time/acceleration
+//
+// The data-exchange routes (/export, /import) are served by the same
+// SystemHandler but register through RegisterDataExchangeRoutes so each
+// call site keeps its original position in run()'s registration order.
+func RegisterSystemRoutes(v1 *gin.RouterGroup, handler *SystemHandler) {
+	system := v1.Group("/system")
+	{
+		system.GET("/time", handler.GetSystemTime)
+		system.POST("/time/acceleration", handler.SetTimeAcceleration)
+	}
+}
+
+// RegisterDataExchangeRoutes wires the full-database export/import route
+// surface onto a group whose middleware already enforces the global API
+// key:
+//
+//   - POST /api/v1/export
+//   - POST /api/v1/import
+func RegisterDataExchangeRoutes(v1 *gin.RouterGroup, handler *SystemHandler) {
+	v1.POST("/export", handler.ExportData)
+	v1.POST("/import", handler.ImportData)
+}

--- a/backend/internal/api/handlers/telegram_routes.go
+++ b/backend/internal/api/handlers/telegram_routes.go
@@ -1,0 +1,36 @@
+package handlers
+
+import "github.com/gin-gonic/gin"
+
+// RegisterTelegramRoutes wires the Telegram auth + chats route surface
+// onto a group whose middleware already enforces the global API key:
+//
+//   - POST   /api/v1/telegram/auth/start
+//   - POST   /api/v1/telegram/auth/verify-code
+//   - POST   /api/v1/telegram/auth/verify-password
+//   - POST   /api/v1/telegram/auth/cancel
+//   - DELETE /api/v1/telegram/auth
+//   - GET    /api/v1/telegram/auth/status
+//   - GET    /api/v1/telegram/chats
+//   - PATCH  /api/v1/telegram/chats/:chat_id
+//
+// Caller gates the whole call on telegramHandler != nil.
+func RegisterTelegramRoutes(v1 *gin.RouterGroup, handler *TelegramHandler) {
+	tgRoutes := v1.Group("/telegram")
+	{
+		tgAuth := tgRoutes.Group("/auth")
+		{
+			tgAuth.POST("/start", handler.StartAuth)
+			tgAuth.POST("/verify-code", handler.VerifyCode)
+			tgAuth.POST("/verify-password", handler.VerifyPassword)
+			tgAuth.POST("/cancel", handler.CancelAuth)
+			tgAuth.DELETE("", handler.Disconnect)
+			tgAuth.GET("/status", handler.GetStatus)
+		}
+		tgChats := tgRoutes.Group("/chats")
+		{
+			tgChats.GET("", handler.ListChats)
+			tgChats.PATCH("/:chat_id", handler.UpdateChatStatus)
+		}
+	}
+}

--- a/backend/internal/api/handlers/test_routes.go
+++ b/backend/internal/api/handlers/test_routes.go
@@ -1,0 +1,32 @@
+package handlers
+
+import "github.com/gin-gonic/gin"
+
+// RegisterTestRoutes wires the test-only seeding/cleanup route surface
+// onto a group whose middleware already enforces the global API key:
+//
+//   - POST /api/v1/test/seed/contacts
+//   - POST /api/v1/test/seed/external-contacts
+//   - POST /api/v1/test/seed/method-suggestions
+//   - POST /api/v1/test/seed/overdue-contacts
+//   - POST /api/v1/test/seed/calendar-events
+//   - POST /api/v1/test/seed/mac-hosts
+//   - POST /api/v1/test/seed/meeting-notes
+//   - POST /api/v1/test/cleanup
+//   - POST /api/v1/test/trigger-error
+//
+// Caller gates the whole call on CRM_ENV in {testing, test}.
+func RegisterTestRoutes(v1 *gin.RouterGroup, handler *TestHandler) {
+	testRoutes := v1.Group("/test")
+	{
+		testRoutes.POST("/seed/contacts", handler.SeedContacts)
+		testRoutes.POST("/seed/external-contacts", handler.SeedExternalContacts)
+		testRoutes.POST("/seed/method-suggestions", handler.SeedMethodSuggestions)
+		testRoutes.POST("/seed/overdue-contacts", handler.SeedOverdueContacts)
+		testRoutes.POST("/seed/calendar-events", handler.SeedCalendarEvents)
+		testRoutes.POST("/seed/mac-hosts", handler.SeedMacHost)
+		testRoutes.POST("/seed/meeting-notes", handler.SeedMeetingNotes)
+		testRoutes.POST("/cleanup", handler.Cleanup)
+		testRoutes.POST("/trigger-error", handler.TriggerError)
+	}
+}

--- a/backend/internal/api/handlers/todoist_routes.go
+++ b/backend/internal/api/handlers/todoist_routes.go
@@ -1,0 +1,22 @@
+package handlers
+
+import "github.com/gin-gonic/gin"
+
+// RegisterTodoistRoutes wires the Todoist settings route surface onto a
+// group whose middleware already enforces the global API key:
+//
+//   - GET   /api/v1/todoist/settings
+//   - PATCH /api/v1/todoist/settings
+//   - GET   /api/v1/todoist/projects
+//   - GET   /api/v1/todoist/labels
+//
+// Caller gates the whole call on todoistHandler != nil.
+func RegisterTodoistRoutes(v1 *gin.RouterGroup, handler *TodoistHandler) {
+	todoistRoutes := v1.Group("/todoist")
+	{
+		todoistRoutes.GET("/settings", handler.GetSettings)
+		todoistRoutes.PATCH("/settings", handler.UpdateSettings)
+		todoistRoutes.GET("/projects", handler.ListProjects)
+		todoistRoutes.GET("/labels", handler.ListLabels)
+	}
+}

--- a/scripts/dev/route-parity.sh
+++ b/scripts/dev/route-parity.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+#
+# route-parity.sh — contract-7 route-table parity harness for the
+# composition-root refactor arc (PR3/PR4).
+#
+# Boots the crm-api backend from two working trees under each of six
+# config shapes, captures the gin [GIN-debug] route table + boot log from
+# each, and asserts:
+#   1. the normalized (METHOD PATH SYMBOL, sorted) route tables are
+#      byte-identical between the two trees, per shape; and
+#   2. per-shape presence/absence sentinels fired (proving the gate that
+#      shape exercises actually ran, so parity is not a false-pass from
+#      both trees identically skipping a branch).
+#
+# This is a dev/verification tool. It is NOT wired into CI or pre-push.
+#
+# Usage:
+#   scripts/dev/route-parity.sh <tree-a> <tree-b> [shape ...]
+#
+#   <tree-a>, <tree-b>  repo working-tree roots (each containing backend/).
+#                       Typically a develop checkout and this branch.
+#   [shape ...]         one or more of 1..6; default: all six.
+#
+# Env (all optional; sensible defaults for the shared local test DB):
+#   DATABASE_URL   Postgres URL (default: shared :5432 personal_crm_test)
+#   API_KEY        API key handed to the boot (default: route-parity-key)
+#   BOOT_TIMEOUT   seconds to wait for the "starting server" line (default 120)
+#   BASE_PORT      first TCP port to bind (default 18090; each boot +1)
+#
+# Exit status: 0 iff every requested shape passed (identical routes + all
+# sentinels). Non-zero on any diff, missing/forbidden sentinel, or boot
+# failure.
+
+set -uo pipefail
+
+# --- args ---------------------------------------------------------------
+if [[ $# -lt 2 ]]; then
+  echo "usage: $0 <tree-a> <tree-b> [shape ...]" >&2
+  exit 2
+fi
+TREE_A="$(cd "$1" && pwd)"; shift
+TREE_B="$(cd "$1" && pwd)"; shift
+SHAPES=("$@")
+if [[ ${#SHAPES[@]} -eq 0 ]]; then
+  SHAPES=(1 2 3 4 5 6)
+fi
+
+DATABASE_URL="${DATABASE_URL:-postgres://crm_user:crm_password@localhost:5432/personal_crm_test?sslmode=disable}"
+API_KEY="${API_KEY:-route-parity-key}"
+BOOT_TIMEOUT="${BOOT_TIMEOUT:-120}"
+BASE_PORT="${BASE_PORT:-18090}"
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/route-parity.XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+# A valid 64-hex token-encryption key (dummy — never a real secret).
+TOKEN_KEY="0000000000000000000000000000000000000000000000000000000000000000"
+
+PORT_SEQ=0
+
+# --- shape env deltas ---------------------------------------------------
+# Emits `KEY=VALUE` lines (one per line) for the shape's delta env on top
+# of the base env applied in boot_tree.
+shape_env() {
+  local shape="$1"
+  case "$shape" in
+    1) : ;;                                   # base only
+    2) echo "CRM_ENV=production" ;;           # prod alias — test routes absent
+    3)
+      echo "ENABLE_EXTERNAL_SYNC=true"
+      echo "GOOGLE_CLIENT_ID=dummy-google-id"
+      echo "GOOGLE_CLIENT_SECRET=dummy-google-secret"
+      echo "TODOIST_CLIENT_ID=dummy-todoist-id"
+      echo "TODOIST_CLIENT_SECRET=dummy-todoist-secret"
+      echo "TOKEN_ENCRYPTION_KEY=$TOKEN_KEY"
+      ;;
+    4)
+      echo "ENABLE_TELEGRAM_SYNC=true"
+      echo "TELEGRAM_API_ID=12345"            # NONZERO — getEnvAsInt falls back to 0 on non-numeric, which config rejects
+      echo "TELEGRAM_API_HASH=dummy-telegram-hash"
+      echo "TOKEN_ENCRYPTION_KEY=$TOKEN_KEY"
+      ;;
+    5) echo "EVENT_BUS_INGEST_ENABLED=true" ;;
+    6)
+      echo "ENABLE_EXTERNAL_SYNC=true"
+      echo "GOOGLE_CLIENT_ID=dummy-google-id"
+      echo "GOOGLE_CLIENT_SECRET=dummy-google-secret"
+      echo "TODOIST_CLIENT_ID=dummy-todoist-id"
+      echo "TODOIST_CLIENT_SECRET=dummy-todoist-secret"
+      echo "TOKEN_ENCRYPTION_KEY=$TOKEN_KEY"
+      echo "EVENT_BUS_INTERACTION_MODE=off"
+      ;;
+    *) echo "unknown shape: $shape" >&2; return 1 ;;
+  esac
+}
+
+# --- boot one tree under one shape; write routes + log -----------------
+# boot_tree <tree> <shape> <routes_out> <log_out>
+# Returns 0 on a clean boot (reached "starting server"), non-zero otherwise.
+boot_tree() {
+  local tree="$1" shape="$2" routes_out="$3" log_out="$4"
+  local port=$((BASE_PORT + PORT_SEQ))
+  PORT_SEQ=$((PORT_SEQ + 1))
+
+  # Base env (contract 7): NODE_ENV=development keeps gin in debug mode so
+  # [GIN-debug] route lines print; CRM_ENV=testing is the shape-1 baseline
+  # (shape 2 overrides it via shape_env).
+  local -a env=(
+    "DATABASE_URL=$DATABASE_URL"
+    "MIGRATIONS_PATH=$tree/backend/migrations"
+    "API_KEY=$API_KEY"
+    "NODE_ENV=development"
+    "CRM_ENV=testing"
+    "PORT=$port"
+    "HOST=127.0.0.1"
+  )
+  # Layer the shape delta (later assignments win in `env`).
+  local line
+  while IFS= read -r line; do
+    [[ -n "$line" ]] && env+=("$line")
+  done < <(shape_env "$shape")
+
+  # Boot in its own session so we can kill the go-run parent AND its
+  # compiled child by process group. Direct redirect (NOT nohup) so
+  # zerolog lines reliably reach the file — the shape-3/6 log sentinels
+  # depend on this.
+  setsid env "${env[@]}" go run ./cmd/crm-api >"$log_out" 2>&1 &
+  local pid=$!
+
+  # Poll for the ready line or a fatal, up to BOOT_TIMEOUT.
+  local waited=0 ok=1
+  while (( waited < BOOT_TIMEOUT )); do
+    if grep -q "starting server" "$log_out" 2>/dev/null; then ok=0; break; fi
+    if grep -qiE '"level":"fatal"|failed to bind listener|panic:' "$log_out" 2>/dev/null; then ok=1; break; fi
+    if ! kill -0 "$pid" 2>/dev/null; then ok=1; break; fi
+    sleep 1; waited=$((waited + 1))
+  done
+
+  # Give gin a beat to have flushed all route lines (they print during
+  # registration, before "starting server", so they are already present).
+  kill -TERM -"$pid" 2>/dev/null
+  wait "$pid" 2>/dev/null
+
+  # Extract + normalize the route table: METHOD PATH SYMBOL, sorted.
+  grep -F -- '-->' "$log_out" 2>/dev/null \
+    | grep -F '[GIN-debug]' \
+    | sed -E 's/^\[GIN-debug\][[:space:]]+([A-Z]+)[[:space:]]+([^[:space:]]+)[[:space:]]+-->[[:space:]]+([^[:space:]]+).*/\1 \2 \3/' \
+    | sort >"$routes_out"
+
+  return $ok
+}
+
+# --- sentinel checks per shape -----------------------------------------
+# assert_present <label> <file> <needle>   — fail if needle absent
+# assert_absent  <label> <file> <needle>   — fail if needle present
+SENTINEL_FAIL=0
+assert_present() {
+  if ! grep -qF -- "$3" "$2"; then
+    echo "    SENTINEL FAIL: expected present but MISSING: $1 ($3)"; SENTINEL_FAIL=1
+  else
+    echo "    sentinel ok (present): $1"
+  fi
+}
+assert_absent() {
+  if grep -qF -- "$3" "$2"; then
+    echo "    SENTINEL FAIL: expected absent but PRESENT: $1 ($3)"; SENTINEL_FAIL=1
+  else
+    echo "    sentinel ok (absent):  $1"
+  fi
+}
+
+# check_sentinels <shape> <routes_file> <log_file>
+check_sentinels() {
+  local shape="$1" routes="$2" log="$3"
+  SENTINEL_FAIL=0
+  case "$shape" in
+    1) assert_present "test-only routes"        "$routes" "/api/v1/test/" ;;
+    2) assert_absent  "test-only routes"        "$routes" "/api/v1/test/" ;;
+    3)
+      assert_present "google OAuth callback"    "$routes" "/api/v1/auth/google/callback"
+      assert_present "google auth-url route"    "$routes" "/api/v1/auth/google"
+      assert_present "todoist settings routes"  "$routes" "/api/v1/todoist/settings"
+      assert_present "gmail-registered log"     "$log"    "Gmail sync provider + rematch handler + correspondence discovery registered"
+      ;;
+    4) assert_present "telegram routes"         "$routes" "/api/v1/telegram/" ;;
+    5) assert_present "ingest events route"     "$routes" "/api/v1/ingest/events" ;;
+    6)
+      assert_present "gmail-off-mode warn log"  "$log"    "Gmail provider NOT registered: event-bus interaction mode=off (pubBus nil)"
+      assert_absent  "gmail-registered log"     "$log"    "Gmail sync provider + rematch handler + correspondence discovery registered"
+      ;;
+  esac
+  return $SENTINEL_FAIL
+}
+
+# --- preflight: DB reachable -------------------------------------------
+echo "route-parity: tree-a=$TREE_A"
+echo "route-parity: tree-b=$TREE_B"
+echo "route-parity: shapes=${SHAPES[*]}"
+echo "route-parity: DATABASE_URL=$DATABASE_URL"
+echo
+
+# --- main loop ----------------------------------------------------------
+OVERALL=0
+for shape in "${SHAPES[@]}"; do
+  echo "=== shape $shape ==="
+  ra="$WORKDIR/shape${shape}.a.routes"; la="$WORKDIR/shape${shape}.a.log"
+  rb="$WORKDIR/shape${shape}.b.routes"; lb="$WORKDIR/shape${shape}.b.log"
+
+  boot_a_ok=0; boot_b_ok=0
+  cd "$TREE_A/backend"
+  boot_tree "$TREE_A" "$shape" "$ra" "$la"; boot_a_ok=$?
+  cd "$TREE_B/backend"
+  boot_tree "$TREE_B" "$shape" "$rb" "$lb"; boot_b_ok=$?
+
+  if [[ $boot_a_ok -ne 0 || $boot_b_ok -ne 0 ]]; then
+    echo "  BOOT FAIL (a=$boot_a_ok b=$boot_b_ok) — see $la / $lb"
+    [[ $boot_a_ok -ne 0 ]] && tail -3 "$la" | sed 's/^/    a| /'
+    [[ $boot_b_ok -ne 0 ]] && tail -3 "$lb" | sed 's/^/    b| /'
+    OVERALL=1
+    echo
+    continue
+  fi
+
+  na=$(wc -l <"$ra"); nb=$(wc -l <"$rb")
+  echo "  routes: tree-a=$na  tree-b=$nb"
+
+  if diff -u "$ra" "$rb" >"$WORKDIR/shape${shape}.diff"; then
+    echo "  ROUTE PARITY: identical"
+  else
+    echo "  ROUTE PARITY: DIFF (tree-a=< tree-b=>)"
+    sed 's/^/    /' "$WORKDIR/shape${shape}.diff"
+    OVERALL=1
+  fi
+
+  # Sentinels on the branch tree's captures (parity already proved the two
+  # dumps identical; the log sentinels for shapes 3/6 are checked on b).
+  if check_sentinels "$shape" "$rb" "$lb"; then
+    :
+  else
+    OVERALL=1
+  fi
+  echo
+done
+
+if [[ $OVERALL -eq 0 ]]; then
+  echo "route-parity: ALL SHAPES PASS"
+else
+  echo "route-parity: FAILURES DETECTED"
+fi
+exit $OVERALL


### PR DESCRIPTION
## Summary

PR3 of the composition-root refactor arc (follows #573, #576). Extracts all ~88 inline route registrations from `main.go`'s `run()` into **15 per-domain `Register*Routes` files** in `internal/api/handlers`, following the existing `RegisterMacHostRoutes` deps-struct pattern. Second commit adds the arc's route-parity harness.

- Every conditional gate stays at its `run()` call site (all nine, plus the two pre-existing internal gates in import/OAuth registration) — gate semantics are untouched.
- All three gate-outcome log lines are retained in `run()` under their original gates.
- Route accounting reconciles exactly: 86 registrations leave `main.go`, 83 land in the new files; the 3-route delta is the calendar trio `develop` registered twice, now deduped through one shared `RegisterCalendarRoutes` (planned).
- New required test pins `RegisterImportRoutes`' static-before-`:id` ordering (a param-first reorder panics gin at registration).
- `scripts/dev/route-parity.sh`: six-shape config-matrix harness comparing method+path+handler-symbol route tables develop-vs-branch, with presence/absence and log sentinels per shape.

## Behavior

Zero behavior change, proven mechanically: parity PASS on **all six config shapes** (route counts 47/35/87/55/49/87, tables byte-identical, Gmail event-bus sentinels correct for shapes 3/6). An adversarial second review independently confirmed byte-faithful movement, correct deps-struct wiring (no typed-nil traps), and zero route-order movement.

## Verification

- Parity harness: 6/6 shapes PASS develop-vs-branch.
- `make lint` 0 issues; unit, integration (9 pkgs), frontend (366 tests), e2e-diff all green.
- Codex review: PASS round 1 (P0=0 P1=0 P2=3). Fresh-context review-head: PASS (P0=0 P1=0 P2=3 P3=1) — the P2s (parity-script fail-open hardening, feature-development.md §6 tutorial rewrite) are follow-ups assigned to PR4, which consumes the harness as its gate.

Note: the new `*_routes.go` files are intentionally not added to `frontend/tests/e2e/test-map.json` in this PR — routing behavior is unchanged and mappings stay accurate at the domain level; e2e-diff emits a non-blocking warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PAkTD635qUGdkzipVK7uhh