### PR TITLE
refactor: split run() composition into per-domain wire files

### DIFF
--- a/.ai/guides/feature-development.md
+++ b/.ai/guides/feature-development.md
@@ -279,25 +279,44 @@ See [`.ai/patterns/backend.md`](../patterns/backend.md) for full handler and err
 
 ## 6. Register Routes
 
+Routes live in a per-domain `RegisterXRoutes` helper in
+`backend/internal/api/handlers/<domain>_routes.go` (follow the
+`mac_host_routes.go` template). Construction of the handler goes in the
+matching `backend/cmd/crm-api/wire_*.go` file; the gated call site goes in
+`backend/cmd/crm-api/routes.go`. Do NOT inline `v1.Group(...)` route
+registration into `main.go` — `run()` is a lifecycle orchestrator only.
+
 ```go
-// backend/cmd/crm-api/main.go
+// backend/internal/api/handlers/new_table_routes.go
 
-// Initialize repository and handler
-newTableRepo := repository.NewNewTableRepository(database.Queries)
-newTableHandler := handlers.NewNewTableHandler(newTableRepo)
+// NewTableRouteDeps carries the handlers this domain's routes need.
+type NewTableRouteDeps struct {
+    NewTable *NewTableHandler
+}
 
-// Add routes
-v1 := router.Group("/api/v1")
-{
+// RegisterNewTableRoutes registers the domain's routes on the authenticated
+// v1 group (caller has already applied APIKeyMiddleware).
+func RegisterNewTableRoutes(v1 *gin.RouterGroup, deps NewTableRouteDeps) {
     newTables := v1.Group("/new-tables")
     {
-        newTables.POST("", newTableHandler.CreateNewTable)
-        newTables.GET("/:id", newTableHandler.GetNewTable)
-        newTables.GET("", newTableHandler.ListNewTables)
-        newTables.PUT("/:id", newTableHandler.UpdateNewTable)
-        newTables.DELETE("/:id", newTableHandler.DeleteNewTable)
+        newTables.POST("", deps.NewTable.CreateNewTable)
+        newTables.GET("/:id", deps.NewTable.GetNewTable)
+        newTables.GET("", deps.NewTable.ListNewTables)
+        newTables.PUT("/:id", deps.NewTable.UpdateNewTable)
+        newTables.DELETE("/:id", deps.NewTable.DeleteNewTable)
     }
 }
+```
+
+Construct the repository + handler in a `wire_*.go` `build*` function (add a
+field to the matching deps struct returned to `run()`), then call the
+helper from `registerRoutes` in `backend/cmd/crm-api/routes.go`:
+
+```go
+// backend/cmd/crm-api/routes.go — inside registerRoutes, in the v1 group
+handlers.RegisterNewTableRoutes(v1, handlers.NewTableRouteDeps{
+    NewTable: deps.NewTableHandler,
+})
 ```
 
 ### Current API Routes
@@ -350,7 +369,7 @@ v1 := router.Group("/api/v1")
 | | `/host/:id` | GET/DELETE | MacHostHandler | Get / revoke host (delete cascades push-cursor rows) |
 | | `/host/pairing-token` | POST | MacHostHandler | Mint single-use pairing token (10-min TTL) |
 
-Routes defined in per-domain `RegisterXRoutes` helpers under `backend/internal/api/handlers/*_routes.go`; their gated call sites live in `backend/cmd/crm-api/main.go`.
+Routes defined in per-domain `RegisterXRoutes` helpers under `backend/internal/api/handlers/*_routes.go`; their gated call sites live in `registerRoutes` in `backend/cmd/crm-api/routes.go`.
 
 ---
 

--- a/.ai/patterns/sync.md
+++ b/.ai/patterns/sync.md
@@ -12,11 +12,12 @@
 | iCloud Contacts | `icloud_contacts` | `push` | `backend/internal/icloudcontacts/provider.go` |
 | Phone & FaceTime | `phone_calls` | `push` | `backend/internal/phonecalls/provider.go` |
 
-The poll-strategy providers register themselves in
-`backend/cmd/crm-api/main.go` via `providerRegistry.Register()`. The three
-**push** providers register through one helper,
-`push.RegisterPushProviders(providerRegistry)`
-(`backend/internal/push/push.go`), which main.go calls once.
+The poll-strategy providers register via `providerRegistry.Register()` in
+the external-sync wire files (`backend/cmd/crm-api/wire_google.go` for
+gcontacts/gcal/gmail/gchat, `wire_todoist.go` for todoist), orchestrated by
+`buildExternalSync` in `wire_sync.go`. The three **push** providers register
+through one helper, `push.RegisterPushProviders(providerRegistry)`
+(`backend/internal/push/push.go`), which `buildExternalSync` calls once.
 
 **Google Chat is registered but enablement-gated.** `gchat` registers
 unconditionally whenever Google OAuth is configured (it is store-only +

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ Find all instances of a layer:
 
 | What | Where |
 |------|-------|
-| API routes | `backend/internal/api/handlers/*_routes.go` (per-domain `RegisterXRoutes`); gated call sites in `backend/cmd/crm-api/main.go` (search for `RegisterXRoutes`) |
+| API routes | `backend/internal/api/handlers/*_routes.go` (per-domain `RegisterXRoutes`); gated call sites in `registerRoutes` in `backend/cmd/crm-api/routes.go` (search for `RegisterXRoutes`) |
 | Scheduler/cron jobs | `backend/internal/scheduler/scheduler.go` |
 | Time acceleration | `backend/internal/accelerated/time.go` |
 | Query invalidation | `frontend/src/lib/query-invalidation.ts` |

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ GOTEST_VERBOSE ?= -v
 #   INTEGRATION_RUN  -> appends -run '<regex>' when non-empty (else no -run).
 #   INTEGRATION_PKGS -> the package list (default = today's full list).
 INTEGRATION_RUN ?=
-INTEGRATION_PKGS ?= ./tests/... ./internal/todoist/... ./internal/google/... ./internal/testdb/... ./cmd/crm-admin/...
+INTEGRATION_PKGS ?= ./tests/... ./internal/todoist/... ./internal/google/... ./internal/testdb/... ./cmd/crm-admin/... ./cmd/crm-api/...
 # The leading space is embedded ONLY when non-empty so the recipe is
 # byte-identical to today when the knob is unset (no trailing/double space).
 INTEGRATION_RUN_FLAG := $(if $(INTEGRATION_RUN), -run '$(INTEGRATION_RUN)')

--- a/backend/cmd/crm-api/adapters.go
+++ b/backend/cmd/crm-api/adapters.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	stdsync "sync"
+	"sync"
 
 	"personal-crm/backend/internal/consumer"
 	"personal-crm/backend/internal/db"
@@ -47,7 +47,7 @@ func (*noopWorker) Work(_ context.Context, _ *river.Job[noopJobArgs]) error {
 // wired at construction time (before the external-sync branch decides
 // whether Todoist is configured). The external-sync branch populates
 // oauth+sync when Todoist is initialized; until then fn() returns
-// service.ErrNoTodoistAccount to keep the consumer's Todoist-dependent
+// consumer.ErrTodoistUnconfigured to keep the consumer's Todoist-dependent
 // post-commit paths a best-effort no-op.
 type followUpSettingsRef struct {
 	oauth       *todoist.OAuthService
@@ -119,7 +119,7 @@ func (r *followUpSettingsRef) fn() consumer.TodoistSettingsFunc {
 // safe to pass to the worker constructor before the inner registry
 // is wired.
 type deferredAggregatorReenqueuer struct {
-	mu    stdsync.RWMutex
+	mu    sync.RWMutex
 	inner consumer.AggregatorReenqueuer
 }
 

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -33,7 +33,6 @@ import (
 	"syscall"
 	"time"
 
-	"personal-crm/backend/internal/anarlog"
 	"personal-crm/backend/internal/api"
 	"personal-crm/backend/internal/api/handlers"
 	"personal-crm/backend/internal/auth"
@@ -181,14 +180,12 @@ func run() int {
 	// Several instances are reused by the external-sync / mac-host /
 	// calendar / telegram blocks below.
 	ingest := buildIngestRepos(database.Queries)
-	identityRepoForIngest := ingest.Identity
 	identityServiceForIngest := ingest.IdentityService
 	messagesMessageRepo := ingest.MessagesMessage
 	externalContactRepoForIngest := ingest.ExternalContact
 	macHostRepoForIngest := ingest.MacHost
 	meetingNoteRepoForIngest := ingest.MeetingNote
 	calendarRepoForIngest := ingest.CalendarEvent
-	phoneCallRepoForIngest := ingest.PhoneCall
 
 	// Rematch service + ContactService + graph (SP1) store. Rematch is
 	// constructed above ContactService so it can be passed as the
@@ -196,210 +193,34 @@ func run() int {
 	graph := buildContactGraphCore(database, core, eventBus)
 	rematchService := graph.RematchService
 	contactService := graph.ContactService
-	graphNodeRepo := graph.GraphNode
-	graphAssertionRepo := graph.GraphAssertion
 	assertService := graph.AssertService
 
 	// Message-store repos + staging registry + venue resolver.
 	messaging := buildMessagingFoundation(database.Queries, messagesMessageRepo, calendarRepoForIngest)
 	telegramMessageRepo := messaging.TelegramMessageRepo
 	commsMessageRepo := messaging.CommsMessageRepo
-	stagingRegistry := messaging.StagingRegistry
 	venueRepo := messaging.VenueRepo
-	venueResolver := messaging.VenueResolver
 
-	// Aggregator reenqueuer holder. The Telegram entry needs the
-	// Telegram aggregation engine, which is constructed later (inside
-	// the cfg.Features.EnableTelegramSync branch). The worker is
-	// constructed earlier, so we wrap the registry in a deferred
-	// pointer that the Telegram branch fills in once the engine
-	// exists. When Telegram is disabled the registry's telegram entry
-	// stays unset and the consumer's reenqueue degrades to "no entry
-	// registered for source" (logged warn) — safe, the consumer's
-	// interaction has already committed.
-	aggregatorReenqueuerHolder := &deferredAggregatorReenqueuer{}
+	// Event-bus consumers (Cadence / Knowledge / FollowUp / InteractionRecorder)
+	// + their shared collaborators, wired into ContactService via its setters.
+	consumers := buildEventConsumers(cfg, database, core, graph, ingest, messaging, eventBus, riverClient)
+	aggregatorReenqueuerHolder := consumers.AggregatorReenqueuerHolder
+	cadenceUpdater := consumers.CadenceUpdater
+	knowledgeCacheUpdater := consumers.KnowledgeCacheUpdater
+	todoistClientFactory := consumers.TodoistClientFactory
+	followUpMode := consumers.FollowUpMode
+	followUpSettingsHolder := consumers.FollowUpSettingsHolder
+	followUpSettings := consumers.FollowUpSettings
+	followUpManager := consumers.FollowUpManager
+	interactionRecorder := consumers.InteractionRecorder
 
-	// CadenceUpdater must be constructed BEFORE InteractionRecorder so
-	// the recorder can inline-invoke it after bus.PublishTx on fresh
-	// writes. Wired here even though its worker is registered further
-	// down, so the construction order matches the runtime dispatch
-	// order. contactRepo.SetPool is called at the first writer-path
-	// construction so the cadence updater can open its own tx if ever
-	// needed outside the caller's tx (defensive — the current path
-	// always runs in the caller's tx).
-	contactRepo.SetPool(database.Pool)
-	eventClaimRepo := repository.NewEventConsumerClaimRepository(database.Queries)
-	cadenceUpdater := consumer.NewCadenceUpdater(
-		eventClaimRepo,
-		contactRepo,
-		database.Queries,
-		consumer.CadenceModeFromConfig(cfg.EventBus.CadenceMode),
-		cfg.EventBus.UnsafeAllowOffMode,
-	)
-
-	// Wire CadenceUpdater into ContactService so Merge / Extend / Promote
-	// / UpdateContact cadence-edit paths route cadence writes through
-	// the sole writer.
-	contactService.SetCadenceUpdater(cadenceUpdater)
-
-	// Knowledge-cache consumer (the location/birthday/how_met authority flip):
-	// the sole writer of those three derived cache columns. ContactService emits
-	// lives_in/birthday/how_met assertions through AssertService and calls
-	// knowledgeCacheUpdater.RefreshTx inline (no read-path gap on a user edit);
-	// the registered KnowledgeCacheUpdaterWorker (below) handles assertion.accepted
-	// /superseded events from any other producer (extractors, rollover, retraction).
-	knowledgeCacheUpdater := consumer.NewKnowledgeCacheUpdater(graphAssertionRepo, graphNodeRepo, contactRepo)
-	contactService.SetKnowledgeWriter(assertService, knowledgeCacheUpdater)
-
-	// Todoist client factory, built once with the running CRM_ENV so the
-	// outbound-write guard (Spec C) applies at every production write site.
-	// Non-prod instances holding real OAuth tokens (a restored prod DB, a
-	// partial env copy) refuse Todoist writes; see todoist.ErrNonProdWriteRefused.
-	todoistClientFactory := todoist.NewClientFactory(cfg.Runtime.CRMEnvironment)
-	if config.IsProductionCRMEnv(cfg.Runtime.CRMEnvironment) {
-		// Logged at Warn so it survives prod's LOG_LEVEL=warn threshold — this
-		// is the operator-facing signal that writes are live. Expected on every
-		// prod boot; the stable "event" field lets alerting route it as
-		// informational.
-		logger.Warn().
-			Str("event", "todoist_writes_enabled").
-			Str("crm_env", cfg.Runtime.CRMEnvironment).
-			Bool("todoist_writes_enabled", true).
-			Msg("Todoist outbound writes ENABLED (production CRM_ENV)")
-	} else {
-		logger.Info().
-			Str("event", "todoist_writes_enabled").
-			Str("crm_env", cfg.Runtime.CRMEnvironment).
-			Bool("todoist_writes_enabled", false).
-			Msg("Todoist outbound writes refused (non-production CRM_ENV)")
-	}
-
-	// FollowUpManager consumer — the sole writer of
-	// contact_task.kind='follow_up' lifecycle post-cutover. Constructed
-	// BEFORE the InteractionRecorder because the recorder takes it as a
-	// constructor arg (inline-invoke on fresh writes). Todoist settings
-	// are looked up via a deferred holder populated later in the
-	// external-sync branch; until populated, Todoist-dependent post-
-	// commit paths (refresh item_update, close retries) degrade to
-	// local-only writes with a logged warning.
-	followUpMode := consumer.FollowUpModeFromConfig(cfg.EventBus.FollowUpMode)
-	followUpSettingsHolder := &followUpSettingsRef{frontendURL: cfg.CORS.FrontendURL}
-	followUpSettings := followUpSettingsHolder.fn()
-	followUpManager := consumer.NewFollowUpManager(
-		followUpMode,
-		eventClaimRepo,
-		contactRepo,
-		contactTaskRepo,
-		contactTaskRepo,
-		interactionRepo,
-		riverClient,
-		database.Pool,
-		followUpSettings,
-		todoistClientFactory,
-		cfg.CORS.FrontendURL,
-		cfg.Watchdog,
-	)
-	// Wire the consumer as the sole follow-up writer on the direct path.
-	// Non-bus callers (Todoist completion, Promote/Extend) route through
-	// FollowUpManager.ApplyInteraction via ContactService.
-	contactService.SetFollowUpConsumer(followUpManager)
-
-	// Wire the merge-time task-close enqueuer. MergeContacts closes the
-	// source contact's live automated tasks and enqueues the durable Todoist
-	// close job for rows with a real external id; the mode gate matches the
-	// close worker's cutover-only contract (enqueuing in mode 'off' would
-	// only manufacture failing jobs — merge then closes locally with a WARN,
-	// that mode's documented "completion disabled" semantics).
-	contactService.SetTaskCloseEnqueuer(riverClient, cfg.EventBus.FollowUpMode == config.EventBusFollowUpModeCutover)
-
-	// InteractionRecorder consumer + manual handler (spec §3.4.1).
-	// Delegates the write to ContactService.RecordInteractionTx, then
-	// marks telegram_messages processed (for message.* kinds) and emits
-	// interaction.recorded — all inside the caller's tx. After emitting
-	// interaction.recorded, the recorder inline-invokes
-	// cadenceUpdater.HandleEvent + followUpManager.HandleEvent on
-	// fresh writes so cadence + follow-up state apply synchronously and
-	// queued re-deliveries become durable no-ops via
-	// event_consumer_claim.
-	interactionRecorder := consumer.NewInteractionRecorder(
-		contactService,
-		stagingRegistry,
-		eventBus,
-		cadenceUpdater,
-		followUpManager,
-		// calendarRepoForIngest satisfies calendarEventLocker: the
-		// calendar.attended branch takes a FOR SHARE lock on the backing
-		// calendar_event so a concurrent decline DELETE cannot strand a
-		// false interaction.
-		calendarRepoForIngest,
-	)
-	// Populate interaction.venue_id for message.* (telegram/messages/gchat) and
-	// gcal interactions this recorder writes.
-	interactionRecorder.SetVenueResolver(venueResolver)
-
-	// IngestService — hoisted here so the call.* inline handler can
-	// reuse contactService.RecordInteractionTx, cadenceUpdater,
-	// followUpManager, and eventBus.PublishTx to emit
-	// interaction.recorded + apply cadence + follow-up in the SAME tx
-	// as the phone_call staging row write (spec §`phone_calls`
-	// content-delivered cadence). raw_message.* and external_contact.*
-	// inline handlers don't need these four — they were nil before the
-	// v1.5 expansion. The meeting_note.* inline handler reuses
-	// contactService via the ContactInteractionRecorder interface for
-	// session-attributed interaction writes so cadence + follow-up
-	// fire correctly.
-	//
-	// anarlog title-extraction deps for the meeting_note.recorded inline
-	// handler: TitleMatcher disambiguates a single name token against
-	// the CRM contact table (trigram + collision-gap); DiscoveryWriter
-	// persists weak-candidate anarlog_title rows for unmatched tokens.
-	titleMatcher := anarlog.NewTitleMatcher(contactRepo)
-	titleDiscoveryWriter := anarlog.NewDiscoveryWriter(externalContactRepoForIngest)
-	ingestService := service.NewIngestService(
-		database,
-		eventBus,
-		identityServiceForIngest,
-		messagesMessageRepo,
-		riverClient,
-		externalContactRepoForIngest,
-		macHostRepoForIngest, // host-liveness re-check inside the batch tx
-		meetingNoteRepoForIngest,
-		calendarRepoForIngest,
-		interactionRepo,
-		identityRepoForIngest,
-		contactService,
-		phoneCallRepoForIngest,
-		contactService,
-		cadenceUpdater,
-		followUpManager,
-		titleMatcher,
-		titleDiscoveryWriter,
-		phoneCallRepoForIngest, // phone_call linkage candidates for meeting_note Step 1
-	)
-	// Populate interaction.venue_id for phone_calls + anarlog_sessions
-	// interactions the ingest inline handlers write.
-	ingestService.SetVenueResolver(venueResolver)
-	ingestHandler := handlers.NewIngestHandler(ingestService)
-
-	// User-driven conflict-resolution surface for meeting_note rows.
-	// Mirrors the daemon-side IngestService.handleMeetingNoteRecorded
-	// path; uses a small adapter to satisfy the polymorphic
-	// LinkageTargetReader interface (event vs phone_call lookup by UUID).
-	meetingNoteLinkageTargets := service.NewLinkageTargetReader(calendarRepoForIngest, phoneCallRepoForIngest)
-	meetingNoteService := service.NewMeetingNoteService(
-		database,
-		meetingNoteRepoForIngest,
-		meetingNoteRepoForIngest,
-		meetingNoteLinkageTargets,
-		identityRepoForIngest,
-		titleMatcher,
-		titleDiscoveryWriter,
-		contactService,
-		contactRepo,
-	)
-	// Populate venue_id on the resolve-link interaction path.
-	meetingNoteService.SetVenueResolver(venueResolver)
-	meetingNoteHandler := handlers.NewMeetingNoteHandler(meetingNoteService)
+	// IngestService + meeting-note conflict-resolution surface. Hoisted
+	// after the consumers so the call.* inline handler can reuse them in
+	// the same tx as the staging-row write.
+	ingestStk := buildIngestStack(database, core, graph, ingest, messaging, consumers, eventBus, riverClient)
+	ingestService := ingestStk.IngestService
+	ingestHandler := ingestStk.IngestHandler
+	meetingNoteHandler := ingestStk.MeetingNoteHandler
 
 	// Register the consumer worker. The worker is registered UNCONDITIONALLY —
 	// river rejects unknown job kinds at dequeue time, so having the worker

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -122,12 +122,13 @@ func run() int {
 	logger.Info().Msg("database connected successfully")
 
 	// Initialize repositories
-	contactRepo := repository.NewContactRepository(database.Queries)
-	contactMethodRepo := repository.NewContactMethodRepository(database.Queries)
-	noteRepo := repository.NewNoteRepository(database.Queries)
-	interactionRepo := repository.NewInteractionRepository(database.Queries)
-	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
-	enrichmentRepo := repository.NewEnrichmentRepository(database.Queries)
+	core := buildCoreRepos(database.Queries)
+	contactRepo := core.Contact
+	contactMethodRepo := core.ContactMethod
+	noteRepo := core.Note
+	interactionRepo := core.Interaction
+	contactTaskRepo := core.ContactTask
+	enrichmentRepo := core.Enrichment
 
 	// River client + event bus + consumer wiring. Built EARLY (before
 	// downstream services) so `pubBus` and `manualHandler` are in scope
@@ -141,7 +142,14 @@ func run() int {
 	// args (the rematch registry is required; SetRematchService setter
 	// is gone).
 	riverWorkers := river.NewWorkers()
-	river.AddWorker(riverWorkers, &noopWorker{})
+	// Recording delegate over the worker + periodic-job bundles. Built
+	// around riverWorkers BEFORE river.NewClient so the noopWorker
+	// registration is recorded; its periodic bundle is attached
+	// immediately after NewClient returns. The wire functions register
+	// through reg instead of calling river.AddWorker / PeriodicJobs().Add
+	// directly, so the golden-list test can pin the registration set.
+	reg := newRiverRegistrar(riverWorkers)
+	addWorker(reg, &noopWorker{})
 
 	riverClient, err := river.NewClient(riverpgxv5.New(database.Pool), &river.Config{
 		JobTimeout: cfg.River.JobTimeout,
@@ -161,128 +169,44 @@ func run() int {
 	if err != nil {
 		logger.Fatal().Err(err).Msg("failed to build river client")
 	}
+	// Attach the periodic-job bundle now that the client exists. Every
+	// addPeriodic call happens later in the wire chain, so this late
+	// attach is safe by construction.
+	reg.periodic = riverClient.PeriodicJobs()
 
 	eventRepo := repository.NewEventRepository(database.Queries)
 	eventBus := events.NewBus(database.Pool, riverClient, eventRepo)
 
-	// Identity repository + service for the ingest path. The host-auth
-	// ingest path (raw_message.* envelopes from the Mac daemon) needs a
-	// tx-bound identity matcher so the per-event savepoint can roll back
-	// the identity write atomically with the staging-row insert on
-	// failure. The external-sync block (further down) constructs its own
-	// IdentityService for the providers that use it — IdentityService is
-	// stateless so the two instances are interchangeable.
-	identityRepoForIngest := repository.NewIdentityRepository(database.Queries)
-	identityServiceForIngest := service.NewIdentityService(identityRepoForIngest)
+	// Ingest repositories + identity service (host-auth ingest path).
+	// Several instances are reused by the external-sync / mac-host /
+	// calendar / telegram blocks below.
+	ingest := buildIngestRepos(database.Queries)
+	identityRepoForIngest := ingest.Identity
+	identityServiceForIngest := ingest.IdentityService
+	messagesMessageRepo := ingest.MessagesMessage
+	externalContactRepoForIngest := ingest.ExternalContact
+	macHostRepoForIngest := ingest.MacHost
+	meetingNoteRepoForIngest := ingest.MeetingNote
+	calendarRepoForIngest := ingest.CalendarEvent
+	phoneCallRepoForIngest := ingest.PhoneCall
 
-	// Messages staging repo (Mac daemon spec §3). Wired here so the
-	// InteractionRecorder's staging registry can dispatch
-	// source="messages" mark-processed calls correctly once the Mac
-	// daemon ingest writer is live, and so the IngestService can upsert
-	// staging rows from raw_message.* envelopes inside its per-event
-	// savepoint.
-	messagesMessageRepo := repository.NewMessagesMessageRepository(database.Queries)
+	// Rematch service + ContactService + graph (SP1) store. Rematch is
+	// constructed above ContactService so it can be passed as the
+	// RematchRegistry constructor arg.
+	graph := buildContactGraphCore(database, core, eventBus)
+	rematchService := graph.RematchService
+	contactService := graph.ContactService
+	graphNodeRepo := graph.GraphNode
+	graphAssertionRepo := graph.GraphAssertion
+	assertService := graph.AssertService
 
-	// External contact repo for the IngestService's inline
-	// external_contact.* handler (Mac daemon iCloud Contacts watcher
-	// path). Constructed unconditionally because the IngestService is
-	// always wired even when external sync is disabled — the daemon
-	// can still call /api/v1/ingest/events on a host-auth path. A
-	// later block under `if cfg.Features.EnableExternalSync` reuses
-	// the same instance for the Import / Calendar rematch wiring.
-	externalContactRepoForIngest := repository.NewExternalContactRepository(database.Queries)
-
-	// Mac host repo for the IngestService's per-batch host-liveness
-	// re-check (SELECT ... FOR UPDATE on mac_host inside the batch tx).
-	// Constructed here so the IngestService can take it as a dep; the
-	// host-auth / pairing / heartbeat handlers below construct their
-	// own MacHostService that wraps the same repo instance.
-	macHostRepoForIngest := repository.NewMacHostRepository(database.Queries)
-
-	// meeting_note repo + calendar repo + identity repo for the inline
-	// meeting_note.recorded / .deleted handlers. Constructed
-	// unconditionally because the IngestService is always wired even
-	// when external sync is disabled — the Mac daemon can still post
-	// meeting_note.* on the host-auth path. The calendarRepo here is
-	// the same logical resource the feature-flagged
-	// google.NewCalendarRematchHandler block below constructs; safe to
-	// have two instances pointing at the same queries since
-	// CalendarEventRepository is stateless.
-	meetingNoteRepoForIngest := repository.NewMeetingNoteRepository(database.Queries)
-	calendarRepoForIngest := repository.NewCalendarEventRepository(database.Queries)
-
-	// PhoneCall repository for the IngestService's call.* inline
-	// handler (phase 1.5).
-	phoneCallRepoForIngest := repository.NewPhoneCallRepository(database.Queries)
-
-	// Note: ingestService construction is hoisted DOWN to after
-	// contactService / cadenceUpdater / followUpManager are built —
-	// the call.* inline handler needs those collaborators to emit
-	// interaction.recorded + apply cadence/follow-up in the same tx
-	// as the staging-row write. See the construction near
-	// "ingestService := service.NewIngestService" further below.
-
-	// Rematch service — constructed above ContactService so it can be
-	// passed as the RematchRegistry constructor arg. Handlers register
-	// later once their dependencies are constructed.
-	rematchService := service.NewRematchService()
-
-	// Initialize services
-	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, eventBus, rematchService)
-
-	// Graph (SP1) write API — the single validated assert() write path over the
-	// node/entity/predicate/assertion store. SP1 ships the service + the daily
-	// rollover worker (registered below); no HTTP handler yet (SP3/SP4 consume it).
-	graphNodeRepo := repository.NewNodeRepository(database.Queries)
-	graphEntityRepo := repository.NewEntityRepository(database.Queries)
-	graphPredicateRepo := repository.NewPredicateRepository(database.Queries)
-	graphAssertionRepo := repository.NewAssertionRepository(database.Queries)
-	assertService := service.NewAssertService(
-		database.Pool, graphNodeRepo, graphEntityRepo, graphPredicateRepo, graphAssertionRepo, eventBus,
-	)
-
-	// Telegram message repo construction (hoisted above the
-	// InteractionRecorder wiring so the consumer can mark messages
-	// processed in the same tx as the interaction insert).
-	telegramMessageRepo := repository.NewTelegramMessageRepository(database.Queries)
-	// Comms message repo (shared cross-source content store). Hoisted here
-	// so the staging registry below can add the gchat session-scoped
-	// processor; also reused by the email-consumer wiring + the gchat
-	// aggregation engine further down.
-	commsMessageRepo := repository.NewCommsMessageRepository(database.Queries)
-
-	// Source-neutral staging registry — InteractionRecorder dispatches
-	// MarkProcessedTx by env.Source to the right repository. Unknown
-	// sources are a logged warning (not an error) so non-message kinds
-	// continue to bypass the registry without erroring.
-	stagingRegistry := repository.NewStagingProcessorRegistry(
-		map[string]repository.StagingProcessor{
-			repository.InteractionSourceTelegram: repository.NewTelegramStagingProcessor(telegramMessageRepo),
-			repository.InteractionSourceMessages: repository.NewMessagesStagingProcessor(messagesMessageRepo),
-			// GChat create-path: the InteractionRecorder consumer marks
-			// comms_message(source='gchat') rows processed via this
-			// session-scoped processor. Without it the recorder's
-			// zero-rows-affected rollback fires and the engine reprocesses
-			// forever. Inert until a chat provider writes gchat rows.
-			repository.InteractionSourceGChat: repository.NewCommsSessionStagingProcessor(commsMessageRepo),
-		},
-	)
-
-	// Venue resolution — populates interaction.venue_id (the shared-container
-	// node an interaction happened in). The registry routes message.* sources
-	// to per-source container readers and resolves gcal via the calendar 3-tuple;
-	// the venue repo also serves the email + phone + anarlog recorders directly.
-	// Wired into each recorder via its SetVenueResolver setter below.
-	venueRepo := repository.NewVenueRepository(database.Queries)
-	venueResolver := repository.NewVenueResolverRegistry(
-		venueRepo,
-		map[string]repository.VenueContainerReader{
-			repository.InteractionSourceTelegram: repository.NewTelegramVenueContainerReader(),
-			repository.InteractionSourceMessages: repository.NewMessagesVenueContainerReader(),
-			repository.InteractionSourceGChat:    repository.NewGChatVenueContainerReader(),
-		},
-		calendarRepoForIngest,
-	)
+	// Message-store repos + staging registry + venue resolver.
+	messaging := buildMessagingFoundation(database.Queries, messagesMessageRepo, calendarRepoForIngest)
+	telegramMessageRepo := messaging.TelegramMessageRepo
+	commsMessageRepo := messaging.CommsMessageRepo
+	stagingRegistry := messaging.StagingRegistry
+	venueRepo := messaging.VenueRepo
+	venueResolver := messaging.VenueResolver
 
 	// Aggregator reenqueuer holder. The Telegram entry needs the
 	// Telegram aggregation engine, which is constructed later (inside

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -34,22 +34,16 @@ import (
 	"time"
 
 	"personal-crm/backend/internal/api"
-	"personal-crm/backend/internal/api/handlers"
-	"personal-crm/backend/internal/auth"
 	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/events"
 	"personal-crm/backend/internal/health"
 	"personal-crm/backend/internal/logger"
 	"personal-crm/backend/internal/repository"
-	"personal-crm/backend/internal/scheduler"
-	"personal-crm/backend/internal/service"
 
 	"github.com/gin-gonic/gin"
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
-	swaggerFiles "github.com/swaggo/files"
-	ginSwagger "github.com/swaggo/gin-swagger"
 
 	_ "personal-crm/backend/docs" // Import generated docs
 )
@@ -306,173 +300,39 @@ func run() int {
 	router.Use(api.CORSMiddleware(cfg.CORS))
 	router.Use(api.ErrorHandlerMiddleware())
 
-	// Health check endpoint. Bare /health is the liveness probe (DB-only
-	// top-level status, today's contract); ?ready=1 aggregates the
-	// river/sync/disk components for an external pinger. The stalenessService
-	// (constructed above) and a HealthRepository over river_job back the new
-	// components; the watchdog kind ties the sync component's freshness guard to
-	// the periodic watchdog job registered on the same River client.
-	healthRepo := repository.NewHealthRepository(database.Queries)
-	healthChecker := health.NewHealthChecker(database, cfg.Database.HealthTimeout, health.Deps{
-		River:            healthRepo,
-		Staleness:        stalenessService,
-		SyncWatchdogKind: scheduler.StalenessWatchdogArgs{}.Kind(),
-		Thresholds: health.Thresholds{
-			RiverDiscardedMax:  cfg.Health.RiverDiscardedMax,
-			RiverOldestDueMax:  cfg.Health.RiverOldestDueMax,
-			SyncWatchdogMaxAge: cfg.Health.SyncWatchdogMaxAge,
-			DiskPath:           cfg.Health.DiskPath,
-			DiskMinFreePercent: cfg.Health.DiskMinFreePercent,
-		},
+	// Register the full route tree (health, OAuth callbacks, mac-host,
+	// ingest, the /api/v1 authenticated group, swagger). All conditional
+	// gates live at their call sites inside registerRoutes.
+	registerRoutes(routeDeps{
+		Router:                   router,
+		Cfg:                      cfg,
+		Database:                 database,
+		StalenessService:         stalenessService,
+		MacHostRepo:              macHostRepo,
+		MacHostHandler:           macHostHandler,
+		IngestHandler:            ingestHandler,
+		MeetingNoteHandler:       meetingNoteHandler,
+		ContactHandler:           contactHandler,
+		InteractionHandler:       interactionHandler,
+		NoteHandler:              noteHandler,
+		RematchHandler:           rematchHandler,
+		StalenessHandler:         stalenessHandler,
+		SystemHandler:            systemHandler,
+		OAuthHandler:             oauthHandler,
+		GoogleOAuthService:       googleOAuthService,
+		TodoistHandler:           todoistHandler,
+		TelegramHandler:          telegramHandler,
+		SyncHandler:              syncHandler,
+		IdentityHandler:          identityHandler,
+		ContactTaskHandler:       contactTaskHandler,
+		CalendarHandler:          calendarHandler,
+		ImportHandler:            importHandler,
+		AnarlogDiscoveryHandler:  anarlogDiscoveryHandler,
+		SuggestionHandler:        suggestionHandler,
+		ExternalContactRepo:      externalContactRepo,
+		ContactService:           contactService,
+		MeetingNoteRepoForIngest: meetingNoteRepoForIngest,
 	})
-	router.GET("/health", healthChecker.Handler)
-
-	// OAuth callback routes (no auth - called by provider redirects)
-	if oauthHandler != nil {
-		handlers.RegisterOAuthCallbackRoutes(router, handlers.OAuthCallbackDeps{
-			Handler:       oauthHandler,
-			GoogleEnabled: googleOAuthService != nil,
-		})
-	}
-
-	// Mac-daemon public + host-auth routes (Pair + heartbeat + cursor +
-	// known-ids). Registered via the shared helper so integration tests
-	// exercise the same code path. Admin routes are registered later
-	// inside the global-API-key-protected v1 group.
-	handlers.RegisterMacHostRoutes(router, handlers.MacHostRouteDeps{
-		HostRepo:    macHostRepo,
-		Handler:     macHostHandler,
-		AuthLimiter: auth.DefaultMacHostAuthLimiterConfig(),
-	})
-
-	// Event bus ingestion endpoint (feature-flagged per spec §3.9).
-	// Registered as a SIBLING of /api/v1 (not inside it) so the
-	// composite IngestAuthMiddleware can branch per-request:
-	//   - X-Mac-Host-ID present → MacHostAuthMiddleware (daemon path)
-	//   - X-Mac-Host-ID absent  → APIKeyMiddleware (global-key path)
-	// gin route trees reject duplicate registration of the same prefix
-	// under different middleware groups, so the composite dispatch is
-	// the minimum seam to support both auth paths on one URL.
-	if cfg.Features.EnableEventBusIngest {
-		ingestAuth := auth.IngestAuthMiddleware(
-			auth.APIKeyMiddleware(cfg),
-			auth.MacHostAuthMiddleware(macHostRepo, auth.DefaultPasswordComparator, auth.DefaultMacHostAuthLimiterConfig()),
-		)
-		handlers.RegisterIngestRoutes(router, handlers.IngestRouteDeps{
-			Auth:        ingestAuth,
-			Ingest:      ingestHandler,
-			MeetingNote: meetingNoteHandler,
-		})
-		logger.Info().Msg("event bus ingestion endpoint enabled")
-	}
-
-	// API routes
-	v1 := router.Group("/api/v1")
-	v1.Use(auth.APIKeyMiddleware(cfg))
-	{
-		// Contact + interaction routes (unconditional).
-		handlers.RegisterContactRoutes(v1, handlers.ContactRouteDeps{
-			Contact:     contactHandler,
-			Interaction: interactionHandler,
-			Note:        noteHandler,
-		})
-
-		// Meeting-note conflict-resolution — user-driven, called from
-		// the frontend with the global API key. Stays under the v1
-		// APIKeyMiddleware group.
-		handlers.RegisterMeetingNoteRoutes(v1, meetingNoteHandler)
-
-		// Rematch routes — always registered; service no-ops when no handlers
-		// are registered (e.g. telegram-disabled deployments still get calendar).
-		handlers.RegisterRematchRoutes(v1, rematchHandler)
-
-		// Sync-staleness breaches — registered unconditionally (OUTSIDE the
-		// EnableExternalSync-gated /sync group below): heartbeat/push breaches
-		// must be visible even with external sync off. The static 2-segment
-		// path coexists with that group's 3-segment param routes.
-		handlers.RegisterSyncStalenessRoutes(v1, stalenessHandler)
-
-		// System routes
-		handlers.RegisterSystemRoutes(v1, systemHandler)
-
-		// Mac-daemon admin routes (under global API key middleware).
-		// Pairing-token mint + revoke + list/get for the Mac settings UI.
-		handlers.RegisterMacHostAdminRoutes(v1, macHostHandler)
-
-		// OAuth routes (feature-flagged with external sync)
-		if oauthHandler != nil {
-			handlers.RegisterOAuthRoutes(v1, handlers.OAuthCallbackDeps{
-				Handler:       oauthHandler,
-				GoogleEnabled: googleOAuthService != nil,
-			})
-		}
-
-		// Todoist settings routes (only if Todoist is configured)
-		if todoistHandler != nil {
-			handlers.RegisterTodoistRoutes(v1, todoistHandler)
-		}
-
-		// Telegram routes (feature-flagged)
-		if telegramHandler != nil {
-			handlers.RegisterTelegramRoutes(v1, telegramHandler)
-		}
-
-		// External sync routes (feature-flagged)
-		if cfg.Features.EnableExternalSync && syncHandler != nil {
-			handlers.RegisterSyncRoutes(v1, syncHandler)
-			handlers.RegisterIdentityRoutes(v1, identityHandler)
-
-			// Add contact task routes (manual tasks) if Todoist is configured
-			if contactTaskHandler != nil {
-				handlers.RegisterContactTaskRoutes(v1, contactTaskHandler)
-			}
-
-			// Add calendar event routes to contacts if calendar handler is initialized
-			if calendarHandler != nil {
-				handlers.RegisterCalendarRoutes(v1, calendarHandler)
-			}
-
-			// Import candidates routes
-			if importHandler != nil {
-				handlers.RegisterImportRoutes(v1, handlers.ImportRouteDeps{
-					Import:           importHandler,
-					AnarlogDiscovery: anarlogDiscoveryHandler,
-					Suggestions:      suggestionHandler,
-				})
-			}
-		}
-
-		// Export/Import routes
-		handlers.RegisterDataExchangeRoutes(v1, systemHandler)
-
-		// Test routes (gated by CRM_ENV=testing or CRM_ENV=test)
-		if cfg.Runtime.CRMEnvironment == "testing" || cfg.Runtime.CRMEnvironment == "test" {
-			// Initialize external contact repo if not already done (for non-sync environments)
-			testExternalRepo := externalContactRepo
-			if testExternalRepo == nil {
-				testExternalRepo = repository.NewExternalContactRepository(database.Queries)
-			}
-
-			// Initialize calendar repo for test seeding
-			testCalendarRepo := repository.NewCalendarEventRepository(database.Queries)
-
-			// Initialize calendar handler if not already done (allows reading seeded events in tests)
-			if calendarHandler == nil {
-				calendarHandler = handlers.NewCalendarHandler(testCalendarRepo)
-				// Register calendar routes that weren't registered earlier (OAuth not configured)
-				handlers.RegisterCalendarRoutes(v1, calendarHandler)
-				logger.Info().Msg("calendar handler initialized for testing (no OAuth)")
-			}
-
-			testSeedService := service.NewTestSeedService(database, testExternalRepo, contactService, testCalendarRepo, macHostRepo, meetingNoteRepoForIngest)
-			testHandler := handlers.NewTestHandler(testSeedService)
-			handlers.RegisterTestRoutes(v1, testHandler)
-			logger.Info().Msg("test API endpoints enabled (CRM_ENV=testing)")
-		}
-	}
-
-	// Swagger documentation
-	router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 
 	// Start server with configured bind address
 	addr := cfg.GetBindAddress()

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -37,20 +37,15 @@ import (
 	"personal-crm/backend/internal/api/handlers"
 	"personal-crm/backend/internal/auth"
 	"personal-crm/backend/internal/config"
-	"personal-crm/backend/internal/consumer"
-	"personal-crm/backend/internal/consumer/consumerjobs"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/events"
-	"personal-crm/backend/internal/google"
 	"personal-crm/backend/internal/health"
 	"personal-crm/backend/internal/logger"
-	"personal-crm/backend/internal/messages"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/scheduler"
 	"personal-crm/backend/internal/service"
 
 	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	swaggerFiles "github.com/swaggo/files"
@@ -188,12 +183,10 @@ func run() int {
 
 	// Message-store repos + staging registry + venue resolver.
 	messaging := buildMessagingFoundation(database.Queries, messagesMessageRepo, calendarRepoForIngest)
-	commsMessageRepo := messaging.CommsMessageRepo
 
 	// Event-bus consumers (Cadence / Knowledge / FollowUp / InteractionRecorder)
 	// + their shared collaborators, wired into ContactService via its setters.
 	consumers := buildEventConsumers(cfg, database, core, graph, ingest, messaging, eventBus, riverClient)
-	aggregatorReenqueuerHolder := consumers.AggregatorReenqueuerHolder
 
 	// IngestService + meeting-note conflict-resolution surface. Hoisted
 	// after the consumers so the call.* inline handler can reuse them in
@@ -269,137 +262,11 @@ func run() int {
 		importHandler.SetPostImportHook(telegramManager)
 	}
 
-	// Messages aggregator engine + reenqueuer + worker + sweeper.
-	// Wired unconditionally — the Mac daemon push pipeline accepts
-	// raw_message.* envelopes regardless of any feature flag, and the
-	// engine is a stateless function over messagesMessageRepo (no
-	// daemon-side connection or background loop).
-	//
-	// The chat-aware AggregateForContact path is what preserves the
-	// engine's extend/bridge/coalesce contract. The
-	// MessagingAggregateForContactWorker iterates over the contact's
-	// distinct unprocessed chats and invokes it per chat; the periodic
-	// sweeper provides a 5-min safety net for the never-claimed
-	// stranded-row gap.
-	messagesEnqueuer := consumer.NewRiverInteractionRecorderEnqueuer(riverClient)
-	const messagesBurstWindowHours = 4
-	const messagesReplyBridgeHours = 48
-	messagesEngine := messages.NewAggregationEngine(
-		messagesBurstWindowHours,
-		messagesReplyBridgeHours,
-		messagesMessageRepo,
-		interactionRepo,
-		contactService,
-		contactService,
-		eventBus,
-		database.Pool,
-		messagesEnqueuer,
-	)
-	messagesReenqueuer := consumer.NewMessagesAggregatorReenqueuer(
-		messagesEngine,
-		riverClient,
-		repository.InteractionSourceMessages,
-	)
+	// Aggregation engines (messages + gchat) + reenqueuer registry.
+	agg := buildAggregationEngines(database, core, graph, ingest, messaging, consumers, eventBus, riverClient, telegramManager, gchatProvider, gchatSyncStates)
 
-	// GChat aggregation engine over comms_message. LIVE but INERT: the
-	// engine/worker/sweeper/reenqueuer for gchat run on every tick, but every
-	// query is source='gchat'-scoped and returns zero rows until a provider +
-	// enablement write comms_message(source='gchat') rows. Burst/reply windows
-	// are hard-coded here (matching how messages hard-codes its constants);
-	// env-var overrides are out of scope for now.
-	gchatEnqueuer := consumer.NewRiverInteractionRecorderEnqueuer(riverClient)
-	const gchatBurstWindowHours = 2
-	const gchatReplyBridgeHours = 48
-	gchatEngine := google.NewGChatAggregationEngine(
-		gchatBurstWindowHours,
-		gchatReplyBridgeHours,
-		commsMessageRepo,
-		interactionRepo,
-		contactService,
-		contactService,
-		eventBus,
-		database.Pool,
-		gchatEnqueuer,
-	)
-
-	// GChat rematch handlers: registered when the provider was constructed
-	// (Google OAuth configured) AND external sync is enabled. They are provably
-	// inert until an enabled gchat sync state exists — each gates FIRST on
-	// ListEnabledSyncStates filtered to source='gchat' and returns (0, nil) when
-	// that set is empty. The email handler co-registers under "email" alongside
-	// Gmail/Calendar; its gchat-scoped gate means it no-ops while the others do
-	// their real work. The provider itself is NOT registered into
-	// providerRegistry (the scheduler never runs it).
-	if gchatProvider != nil && gchatSyncStates != nil {
-		rematchService.Register(google.NewGChatHandleRematchHandler(gchatProvider, gchatSyncStates, commsMessageRepo, gchatEngine))
-		rematchService.Register(google.NewGChatEmailRematchHandler(gchatProvider, gchatSyncStates, commsMessageRepo, gchatEngine))
-		logger.Info().Msg("GChat rematch handlers registered (inert until a gchat sync state is enabled)")
-	}
-
-	gchatReenqueuer := consumer.NewCommsAggregatorReenqueuer(
-		gchatEngine,
-		riverClient,
-		repository.InteractionSourceGChat,
-	)
-
-	// Wire the per-source aggregator reenqueuer registry. The
-	// InteractionRecorderWorker holds the deferred holder; this
-	// assignment makes the post-commit reenqueue path live for both
-	// telegram-source and messages-source events. When Telegram is
-	// disabled the telegram entry is a no-op reenqueuer (so calls for
-	// telegram-source envelopes — which won't be produced anyway —
-	// degrade cleanly).
-	reenqueuerEntries := map[string]consumer.AggregatorReenqueuer{
-		repository.InteractionSourceMessages: messagesReenqueuer,
-		repository.InteractionSourceGChat:    gchatReenqueuer,
-	}
-	if telegramManager != nil {
-		reenqueuerEntries[repository.InteractionSourceTelegram] = consumer.NewTelegramAggregatorReenqueuer(telegramManager.AggregationEngine())
-	} else {
-		reenqueuerEntries[repository.InteractionSourceTelegram] = consumer.NoopAggregatorReenqueuer{}
-	}
-	aggregatorReenqueuerHolder.set(consumer.NewAggregatorReenqueuerRegistry(reenqueuerEntries))
-
-	// Register the messaging aggregate workers. The chat-lister
-	// registry maps source → repository's ListUnprocessedChatsByContact;
-	// future messaging sources (whatsapp etc) extend the map without
-	// touching the worker.
-	chatListerRegistry := scheduler.NewPerSourceChatListerRegistry(
-		map[string]func(ctx context.Context, contactID uuid.UUID) ([]string, error){
-			repository.InteractionSourceMessages: messagesMessageRepo.ListUnprocessedChatsByContact,
-			// Source-bound closure: the comms repo method is multi-source
-			// (ListUnprocessedChatsByContactForSource), so bind 'gchat'.
-			repository.InteractionSourceGChat: func(ctx context.Context, contactID uuid.UUID) ([]string, error) {
-				return commsMessageRepo.ListUnprocessedChatsByContactForSource(ctx, repository.InteractionSourceGChat, contactID)
-			},
-		},
-	)
-	river.AddWorker(riverWorkers, scheduler.NewMessagingAggregateForContactWorker(
-		map[string]scheduler.ChatAwareAggregator{
-			repository.InteractionSourceMessages: messagesEngine,
-			repository.InteractionSourceGChat:    gchatEngine,
-		},
-		chatListerRegistry,
-	))
-
-	// Periodic 5-min sweeper — drains never-claimed stranded rows that
-	// the in-line worker re-list loop AND the post-Stage-3 reenqueue
-	// both missed. Run once on startup so restart-recovery does not wait
-	// a full interval before the safety net engages.
-	sweeperListers := map[string]scheduler.UnprocessedContactLister{
-		repository.InteractionSourceMessages: messagesMessageRepo,
-		// Source-bound adapter: comms_message is multi-source, so wrap the
-		// repo with a 'gchat'-pinned lister.
-		repository.InteractionSourceGChat: newCommsSourceContactLister(commsMessageRepo, repository.InteractionSourceGChat),
-	}
-	river.AddWorker(riverWorkers, scheduler.NewMessagingAggregateSweeperWorker(sweeperListers, riverClient))
-	riverClient.PeriodicJobs().Add(river.NewPeriodicJob(
-		river.PeriodicInterval(5*time.Minute),
-		func() (river.JobArgs, *river.InsertOpts) {
-			return consumerjobs.MessagingAggregateSweeperArgs{}, nil
-		},
-		&river.PeriodicJobOpts{RunOnStart: true},
-	))
+	// Register the chat-aware messaging aggregate worker + sweeper (+ periodic).
+	registerMessagingWorkers(reg, ingest, messaging, agg, riverClient)
 
 	// Initialize handlers
 	contactHandler := handlers.NewContactHandler(contactService)

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -112,9 +112,6 @@ func run() int {
 
 	// Initialize repositories
 	core := buildCoreRepos(database.Queries)
-	contactRepo := core.Contact
-	contactMethodRepo := core.ContactMethod
-	interactionRepo := core.Interaction
 
 	// River client + event bus + consumer wiring. Built EARLY (before
 	// downstream services) so `pubBus` and `manualHandler` are in scope
@@ -168,8 +165,6 @@ func run() int {
 	// calendar / telegram blocks below.
 	ingest := buildIngestRepos(database.Queries)
 	messagesMessageRepo := ingest.MessagesMessage
-	externalContactRepoForIngest := ingest.ExternalContact
-	macHostRepoForIngest := ingest.MacHost
 	meetingNoteRepoForIngest := ingest.MeetingNote
 	calendarRepoForIngest := ingest.CalendarEvent
 
@@ -177,9 +172,7 @@ func run() int {
 	// constructed above ContactService so it can be passed as the
 	// RematchRegistry constructor arg.
 	graph := buildContactGraphCore(database, core, eventBus)
-	rematchService := graph.RematchService
 	contactService := graph.ContactService
-	assertService := graph.AssertService
 
 	// Message-store repos + staging registry + venue resolver.
 	messaging := buildMessagingFoundation(database.Queries, messagesMessageRepo, calendarRepoForIngest)
@@ -226,7 +219,6 @@ func run() int {
 	if cfg.Features.EnableExternalSync {
 		syncStk = buildExternalSync(ctx, cfg, database, core, graph, ingest, messaging, consumers, domain, eventBus, riverClient, pubBus)
 	}
-	syncService := syncStk.SyncService
 	syncHandler := syncStk.SyncHandler
 	identityHandler := syncStk.IdentityHandler
 	oauthHandler := syncStk.OAuthHandler
@@ -268,117 +260,30 @@ func run() int {
 	// Register the chat-aware messaging aggregate worker + sweeper (+ periodic).
 	registerMessagingWorkers(reg, ingest, messaging, agg, riverClient)
 
-	// Initialize handlers
-	contactHandler := handlers.NewContactHandler(contactService)
-	noteHandler := handlers.NewNoteHandler(noteService)
-	interactionHandler := handlers.NewInteractionHandler(interactionRepo, manualHandler)
-	systemHandler := handlers.NewSystemHandler(contactRepo, cfg.Runtime)
-	rematchHandler := handlers.NewRematchHandler(rematchService, contactService)
+	// Core HTTP handlers.
+	handlersCore := buildCoreHandlers(core, graph, cfg, noteService, manualHandler)
+	contactHandler := handlersCore.Contact
+	noteHandler := handlersCore.Note
+	interactionHandler := handlersCore.Interaction
+	systemHandler := handlersCore.System
+	rematchHandler := handlersCore.Rematch
 
-	// Mac-daemon host management. Wires the pairing flow, heartbeat,
-	// cursor protocol, and admin revoke. The pairing endpoint is
-	// unauthenticated (token-gated) so it lives on the bare router; the
-	// daemon endpoints live behind MacHostAuthMiddleware (sibling
-	// /api/v1 group); the admin endpoints live behind the existing
-	// global API-key middleware.
-	// macHostRepoForIngest was constructed earlier (line ~308) so the
-	// IngestService could take it as a HostLivenessChecker dep. Reuse
-	// the same instance here so the host-management service shares the
-	// same repository wrapper.
-	macHostRepo := macHostRepoForIngest
-	pairingTokenRepo := repository.NewMacHostPairingTokenRepository(database.Queries)
-	// Mac cursor commit needs a tx — use the pool-wired SyncRepository.
-	macSyncRepo := repository.NewSyncRepositoryWithPool(database.Queries, database.Pool)
-	macHostService := service.NewMacHostService(
-		macHostRepo,
-		pairingTokenRepo,
-		macSyncRepo,
-		contactMethodRepo,
-		externalContactRepoForIngest, // /known-ids reader (external_contact)
-		meetingNoteRepoForIngest,     // /known-ids reader (anarlog_sessions)
-		database.Pool,
-		0, // default bcrypt cost
-	)
-	pairingIPLimiter := auth.NewPairingIPRateLimiter()
-	macHostHandler := handlers.NewMacHostHandler(macHostService, pairingIPLimiter)
+	// Mac-daemon host management (+ pairing-token janitor worker/periodic).
+	machost := buildMacHost(reg, database, core, ingest)
+	macHostRepo := machost.Repo
+	macHostHandler := machost.Handler
 
-	// Register the pairing-token janitor periodic job (5 min). Worker
-	// registered unconditionally; the periodic-job inserter triggers it
-	// on the same River client. See
-	// backend/internal/scheduler/pairing_token_janitor_worker.go.
-	river.AddWorker(riverWorkers, scheduler.NewPairingTokenJanitorWorker(pairingTokenRepo))
-	riverClient.PeriodicJobs().Add(river.NewPeriodicJob(
-		river.PeriodicInterval(5*time.Minute),
-		func() (river.JobArgs, *river.InsertOpts) {
-			return scheduler.PairingTokenJanitorArgs{}, nil
-		},
-		&river.PeriodicJobOpts{RunOnStart: true},
-	))
+	// Sync-staleness watchdog (+ periodic).
+	staleness := buildStaleness(reg, cfg, database, machost)
+	stalenessService := staleness.Service
+	stalenessHandler := staleness.Handler
 
-	// Sync-staleness watchdog. Registered unconditionally (like the janitor):
-	// heartbeat/push breaches must be detected even with external sync off,
-	// and the watchdog reads existing freshness state rather than driving any
-	// provider sync. The endpoint reader uses the same service instance.
-	stalenessBreachRepo := repository.NewStalenessRepository(database.Queries)
-	stalenessService := service.NewStalenessService(
-		cfg.Staleness,
-		cfg.Features.EnableExternalSync,
-		macSyncRepo,
-		macHostRepo,
-		stalenessBreachRepo,
-	)
-	stalenessHandler := handlers.NewStalenessHandler(stalenessService)
-	river.AddWorker(riverWorkers, scheduler.NewStalenessWatchdogWorker(stalenessService))
-	riverClient.PeriodicJobs().Add(river.NewPeriodicJob(
-		river.PeriodicInterval(5*time.Minute),
-		func() (river.JobArgs, *river.InsertOpts) {
-			return scheduler.StalenessWatchdogArgs{}, nil
-		},
-		&river.PeriodicJobOpts{RunOnStart: true},
-	))
+	// Assertion valid-time rollover (daily worker + periodic).
+	registerAssertionRollover(reg, graph)
 
-	// Assertion valid-time rollover — a daily catch-up sweep that terminalizes the
-	// bounded-with-pending-successor assertions whose valid_to has passed (no event
-	// fires at that future date otherwise). Stateless; RunOnStart catches up any
-	// overdue rollovers on boot.
-	river.AddWorker(riverWorkers, scheduler.NewAssertionRolloverWorker(assertService))
-	riverClient.PeriodicJobs().Add(river.NewPeriodicJob(
-		river.PeriodicInterval(24*time.Hour),
-		func() (river.JobArgs, *river.InsertOpts) {
-			return scheduler.AssertionRolloverArgs{}, nil
-		},
-		&river.PeriodicJobOpts{RunOnStart: true},
-	))
-
-	// Build the River worker set, periodic-job list, and client. The
-	// scheduler-tick + sync-provider-account workers are only registered
-	// when external sync is enabled and we have a real syncService —
-	// otherwise there is nothing for them to do. See DD 6 in
-	// .ai/log/plan/event-bus-foundation-pr3-scheduler-river.md for the
-	// construction-order rationale.
-	//
-	// Sync workers + periodic job are registered AFTER syncService is
-	// constructed. Safe between NewClient (done earlier) and Start —
-	// river.AddWorker and PeriodicJobs().Add both mutate the client
-	// in-place.
-	if cfg.Features.EnableExternalSync && syncService != nil {
-		river.AddWorker(riverWorkers, scheduler.NewSchedulerTickWorker(syncService))
-		river.AddWorker(riverWorkers, scheduler.NewSyncProviderAccountWorker(syncService))
-		riverClient.PeriodicJobs().Add(river.NewPeriodicJob(
-			river.PeriodicInterval(5*time.Minute),
-			func() (river.JobArgs, *river.InsertOpts) {
-				return scheduler.SchedulerTickArgs{}, nil
-			},
-			&river.PeriodicJobOpts{RunOnStart: true},
-		))
-	}
-
-	// Wire the enqueuer onto the service BEFORE starting the client so
-	// any tick fire or TriggerSync that races with bring-up goes through
-	// river instead of falling back to inline sync. See DD 6 step 8.
-	if syncService != nil && cfg.Features.EnableExternalSync {
-		syncService.SetRiverEnqueuer(riverClient)
-	}
+	// Scheduler-tick + sync-provider workers (gated) + River enqueuer wiring,
+	// all before riverClient.Start.
+	registerSyncScheduler(reg, cfg, syncStk, riverClient)
 
 	if err := riverClient.Start(ctx); err != nil {
 		logger.Fatal().Err(err).Msg("failed to start river client")

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -124,10 +124,8 @@ func run() int {
 	core := buildCoreRepos(database.Queries)
 	contactRepo := core.Contact
 	contactMethodRepo := core.ContactMethod
-	noteRepo := core.Note
 	interactionRepo := core.Interaction
 	contactTaskRepo := core.ContactTask
-	enrichmentRepo := core.Enrichment
 
 	// River client + event bus + consumer wiring. Built EARLY (before
 	// downstream services) so `pubBus` and `manualHandler` are in scope
@@ -199,204 +197,48 @@ func run() int {
 	messaging := buildMessagingFoundation(database.Queries, messagesMessageRepo, calendarRepoForIngest)
 	telegramMessageRepo := messaging.TelegramMessageRepo
 	commsMessageRepo := messaging.CommsMessageRepo
-	venueRepo := messaging.VenueRepo
 
 	// Event-bus consumers (Cadence / Knowledge / FollowUp / InteractionRecorder)
 	// + their shared collaborators, wired into ContactService via its setters.
 	consumers := buildEventConsumers(cfg, database, core, graph, ingest, messaging, eventBus, riverClient)
 	aggregatorReenqueuerHolder := consumers.AggregatorReenqueuerHolder
 	cadenceUpdater := consumers.CadenceUpdater
-	knowledgeCacheUpdater := consumers.KnowledgeCacheUpdater
 	todoistClientFactory := consumers.TodoistClientFactory
-	followUpMode := consumers.FollowUpMode
 	followUpSettingsHolder := consumers.FollowUpSettingsHolder
-	followUpSettings := consumers.FollowUpSettings
-	followUpManager := consumers.FollowUpManager
-	interactionRecorder := consumers.InteractionRecorder
 
 	// IngestService + meeting-note conflict-resolution surface. Hoisted
 	// after the consumers so the call.* inline handler can reuse them in
 	// the same tx as the staging-row write.
 	ingestStk := buildIngestStack(database, core, graph, ingest, messaging, consumers, eventBus, riverClient)
-	ingestService := ingestStk.IngestService
 	ingestHandler := ingestStk.IngestHandler
 	meetingNoteHandler := ingestStk.MeetingNoteHandler
 
-	// Register the consumer worker. The worker is registered UNCONDITIONALLY —
-	// river rejects unknown job kinds at dequeue time, so having the worker
-	// present with mode=off costs nothing (no events route to it when
-	// pubBus is nil). Mode gating happens at the publisher sites via
-	// pubBus and at the manual-handler level via manualHandler.
-	//
-	// aggregatorReenqueuerHolder is wired in here; the actual telegram
-	// entry is filled by the cfg.Features.EnableTelegramSync branch
-	// further down. Until that branch runs (or in test/no-telegram
-	// modes), the holder dispatches to a logged-warn no-op.
-	river.AddWorker(riverWorkers, consumer.NewInteractionRecorderWorker(eventBus, database.Pool, interactionRecorder, aggregatorReenqueuerHolder))
+	// Register the three always-on core consumer workers (recorder,
+	// calendar-decline, email-interaction).
+	registerCoreConsumerWorkers(reg, database, core, graph, messaging, consumers, eventBus)
 
-	// Calendar decline consumer: when a stored calendar_event is
-	// declined / cancelled / user-removed upstream, the publisher removes
-	// the row + emits calendar.declined per matched contact; this consumer
-	// soft-deletes the derived gcal interaction and recomputes the contact's
-	// date columns. Registered unconditionally — no events route to it when
-	// the publisher (CalendarSyncProvider) is in off mode.
-	calendarDeclineHandler := consumer.NewCalendarDeclineHandler(interactionRepo, contactRepo)
-	river.AddWorker(riverWorkers, consumer.NewCalendarDeclineHandlerWorker(eventBus, database.Pool, calendarDeclineHandler))
+	// Interaction-mode wiring gate → pubBus (concrete *events.Bus, nil in
+	// off mode) + manual handler.
+	pubBus, manualHandler := resolveInteractionMode(cfg, database, consumers, eventBus)
 
-	// Email-interaction consumer: derives a per-(contact, thread, local-day)
-	// aggregated interaction from email.received / email.sent events + their
-	// comms_message content rows. contactService fills both the
-	// interactionWriter slot (create branch) and the emailAggregator slot
-	// (found-branch extend/promote). cadenceUpdater + followUpManager are the
-	// SAME instances the InteractionRecorder uses, so the create branch's
-	// inline cadence/follow-up apply shares the durable event-claim store.
-	// Registered unconditionally; it processes the email.received /
-	// email.sent events the Gmail provider publishes in production (and
-	// stays idle when no such event is routed, e.g. event-bus off mode).
-	// commsMessageRepo was hoisted earlier (above the staging registry).
-	emailInteractionConsumer := consumer.NewEmailInteractionConsumer(
-		contactService, commsMessageRepo, interactionRepo, contactService,
-		eventBus, cadenceUpdater, followUpManager,
-	)
-	// Populate interaction.venue_id with the email-thread venue on the create
-	// branch. The venue repo resolves directly (email carries thread_id).
-	emailInteractionConsumer.SetVenueResolver(venueRepo)
-	river.AddWorker(riverWorkers, consumer.NewEmailInteractionConsumerWorker(eventBus, database.Pool, emailInteractionConsumer))
+	// Register the cadence / knowledge-cache / follow-up / Todoist workers
+	// + their mode boot logs.
+	registerModeWorkers(reg, cfg, database, core, consumers, eventBus, riverClient)
 
-	// Interaction-mode wiring gate. Cutover is the normal operating
-	// posture; off is the emergency-override retained so rollback can
-	// silence publisher-driven paths without a code change. A deploy in
-	// off mode does NOT restore any pre-cutover direct path — rollback
-	// is `git revert`.
-	effectiveMode := cfg.EventBus.InteractionMode
-	var pubBus *events.Bus
-	var manualHandler *service.ManualInteractionHandler
-	switch effectiveMode {
-	case config.EventBusInteractionModeCutover:
-		pubBus = eventBus
-		manualHandler = service.NewManualInteractionHandler(database.Pool, eventBus, interactionRecorder)
-		logger.Info().
-			Str("mode", "cutover").
-			Msg("event-bus interaction consumer: cutover active")
-	default: // off
-		pubBus = nil
-		manualHandler = nil
-		logger.Warn().
-			Str("mode", effectiveMode).
-			Msg("event-bus interaction consumer: mode=off — publisher-driven " +
-				"(telegram/calendar/manual) interactions will NOT be recorded. " +
-				"HTTP ingest path is unaffected. Use EVENT_BUS_INTERACTION_MODE=cutover (default) to restore publisher paths.")
-	}
-
-	// Informational warning when ingest is enabled but cutover isn't —
-	// ingested events still write interactions (the HTTP ingest path is
-	// an intentional carve-out of the off-mode gate); this log line
-	// makes the seam visible in operator logs.
-	if cfg.Features.EnableEventBusIngest && effectiveMode != config.EventBusInteractionModeCutover {
-		logger.Warn().
-			Str("interaction_mode", effectiveMode).
-			Bool("ingest_enabled", cfg.Features.EnableEventBusIngest).
-			Msg("event-bus ingest enabled but InteractionRecorder is not in cutover mode; " +
-				"ingested events WILL still be written by the consumer — the mode=off warning " +
-				"above does NOT apply to ingested-event-driven writes.")
-	}
-
-	// CadenceUpdater is constructed above (alongside InteractionRecorder).
-	// Register its river worker unconditionally — events.consumerJobsForKind
-	// always enqueues a cadence_updater job for interaction.recorded. In
-	// cutover mode the inline recorder path claims the event first, so
-	// this worker is almost always a durable no-op on re-delivery. In
-	// mode=off HandleEvent short-circuits before any DB write.
-	river.AddWorker(riverWorkers, consumer.NewCadenceUpdaterWorker(eventBus, database.Pool, cadenceUpdater))
-
-	// KnowledgeCacheUpdater worker: refreshes the contact.location/birthday/how_met
-	// cache columns on assertion.accepted / assertion.superseded events (the bus
-	// routes both kinds here; the worker no-ops unless the predicate is one of the
-	// three cutover predicates). Covers supersession / closure / retraction from
-	// any producer; the inline RefreshTx in ContactService handles direct edits.
-	river.AddWorker(riverWorkers, consumer.NewKnowledgeCacheUpdaterWorker(eventBus, database.Pool, knowledgeCacheUpdater))
-
-	// FollowUpManager + river workers. Routing is config-blind
-	// (events.consumerJobsForKind always enqueues cadence + follow-up
-	// jobs for interaction.recorded); HandleEvent short-circuits on
-	// mode=off without DB writes. The Todoist create / close / refresh
-	// workers are registered so river knows their kinds even when
-	// Todoist isn't wired — in that case the settings func returns an
-	// ErrNoTodoistAccount-equivalent error and the worker returns a
-	// retryable failure for river to back off.
-	river.AddWorker(riverWorkers, consumer.NewFollowUpManagerWorker(eventBus, database.Pool, followUpManager))
-	river.AddWorker(riverWorkers, consumer.NewTodoistFollowUpCreateJobWorker(
-		followUpMode, contactTaskRepo, followUpSettings, todoistClientFactory, riverClient, database.Pool,
-	))
-	river.AddWorker(riverWorkers, consumer.NewTodoistFollowUpCloseJobWorker(
-		followUpMode, contactTaskRepo, followUpSettings, todoistClientFactory,
-	))
-	river.AddWorker(riverWorkers, consumer.NewTodoistFollowUpRefreshJobWorker(
-		followUpMode, contactTaskRepo, followUpSettings, todoistClientFactory,
-	))
-
-	switch cfg.EventBus.FollowUpMode {
-	case config.EventBusFollowUpModeCutover:
-		logger.Info().
-			Str("mode", "cutover").
-			Msg("event-bus FollowUpManager: cutover active (sole writer of follow-up tasks; inline recorder dispatch enabled)")
-	default: // off
-		cfg.EventBus.MaybeWarnUnsafeOff()
-		logger.Warn().
-			Str("mode", "off").
-			Msg("event-bus FollowUpManager: mode=off active — NO follow-up tasks will be created or completed until EVENT_BUS_FOLLOWUP_UNSAFE_ALLOW_OFF is unset or a `git revert` ships")
-	}
-
-	switch cfg.EventBus.CadenceMode {
-	case config.EventBusCadenceModeCutover:
-		logger.Info().
-			Str("mode", "cutover").
-			Msg("event-bus CadenceUpdater: cutover active (sole writer of cadence columns; inline recorder dispatch enabled)")
-	default: // off
-		// Validate() already rejected this unless UnsafeAllowOffMode is
-		// true; we reach here only via the emergency escape hatch. The
-		// WARN log in config.Load already fired; repeat it here for
-		// observability on the main-wire path.
-		cfg.EventBus.MaybeWarnUnsafeOff()
-		logger.Warn().
-			Str("mode", "off").
-			Msg("event-bus CadenceUpdater: mode=off active — NO cadence columns will be updated until EVENT_BUS_CADENCE_UNSAFE_ALLOW_OFF is unset or a `git revert` ships")
-	}
-	noteService := service.NewNoteService(noteRepo, contactRepo)
-	importMatchService := service.NewImportMatchService(contactRepo)
-	// EnrichmentService is shared by the import handler (link/import flows) and
-	// the Telegram peer matcher (auto-match enrichment). Constructed at outer
-	// scope so both feature blocks share a single instance.
-	enrichmentService := service.NewEnrichmentService(database, contactRepo, contactMethodRepo, enrichmentRepo, eventBus, rematchService)
-	enrichmentService.SetCadenceUpdater(cadenceUpdater)
-	// Inferred location/birthday from external contact data flow through the
-	// assertion store (agent provenance), not the contact SQL — wire the same
-	// knowledge writer the contact service uses.
-	enrichmentService.SetKnowledgeWriter(assertService, knowledgeCacheUpdater)
-
-	// Address-book method reconcile: re-propagates address-book methods
-	// onto already-linked contacts (auto-propagate for matched, record
-	// suggestion for imported). Shared by the gcontacts forward hook and
-	// the icloud post-commit hook so the auto-vs-suggest + dup precedence
-	// logic lives in one place.
-	addressBookReconcileService := service.NewAddressBookReconcileService(
-		enrichmentService,
-		contactRepo,
-		contactMethodRepo,
-		externalContactRepoForIngest,
-	)
-	ingestService.SetAddressBookReconciler(addressBookReconcileService)
+	// Domain services (note / import-match / enrichment / address-book
+	// reconcile) + the EnrichmentService setter wiring + the IngestService
+	// AddressBookReconciler back-reference.
+	domain := buildDomainServices(database, core, graph, ingest, consumers, ingestStk, eventBus)
+	noteService := domain.NoteService
+	importMatchService := domain.ImportMatchService
+	enrichmentService := domain.EnrichmentService
+	addressBookReconcileService := domain.AddressBookReconcileService
 
 	// Rematch dispatcher consumer — subscribes to contact_methods.added
 	// events and runs RematchService.Run with per-contact mutex
-	// serialization. Always-on (no mode flag): a registered River
-	// worker that returned nil in kill-switch mode would permanently
-	// ack queued jobs, so rollback is `git revert` only. Rematch
-	// handlers themselves (calendar, telegram) are registered below
-	// once their deps are constructed.
-	rematchDispatcher := consumer.NewRematchDispatcher(rematchService)
-	river.AddWorker(riverWorkers, consumer.NewRematchDispatcherWorker(eventBus, database.Pool, rematchDispatcher))
-	logger.Info().Msg("event-bus RematchDispatcher: cutover active")
+	// serialization. Rematch handlers themselves (calendar, telegram) are
+	// registered below once their deps are constructed.
+	registerRematchDispatcher(reg, graph, database, eventBus)
 
 	// Initialize external sync components (feature-flagged)
 	var syncService *service.SyncService

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -46,13 +46,10 @@ import (
 	"personal-crm/backend/internal/health"
 	"personal-crm/backend/internal/logger"
 	"personal-crm/backend/internal/messages"
-	"personal-crm/backend/internal/push"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/scheduler"
 	"personal-crm/backend/internal/service"
-	"personal-crm/backend/internal/sync"
 	tgpkg "personal-crm/backend/internal/telegram"
-	"personal-crm/backend/internal/todoist"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -125,7 +122,6 @@ func run() int {
 	contactRepo := core.Contact
 	contactMethodRepo := core.ContactMethod
 	interactionRepo := core.Interaction
-	contactTaskRepo := core.ContactTask
 
 	// River client + event bus + consumer wiring. Built EARLY (before
 	// downstream services) so `pubBus` and `manualHandler` are in scope
@@ -178,7 +174,6 @@ func run() int {
 	// Several instances are reused by the external-sync / mac-host /
 	// calendar / telegram blocks below.
 	ingest := buildIngestRepos(database.Queries)
-	identityServiceForIngest := ingest.IdentityService
 	messagesMessageRepo := ingest.MessagesMessage
 	externalContactRepoForIngest := ingest.ExternalContact
 	macHostRepoForIngest := ingest.MacHost
@@ -202,9 +197,6 @@ func run() int {
 	// + their shared collaborators, wired into ContactService via its setters.
 	consumers := buildEventConsumers(cfg, database, core, graph, ingest, messaging, eventBus, riverClient)
 	aggregatorReenqueuerHolder := consumers.AggregatorReenqueuerHolder
-	cadenceUpdater := consumers.CadenceUpdater
-	todoistClientFactory := consumers.TodoistClientFactory
-	followUpSettingsHolder := consumers.FollowUpSettingsHolder
 
 	// IngestService + meeting-note conflict-resolution surface. Hoisted
 	// after the consumers so the call.* inline handler can reuse them in
@@ -230,9 +222,7 @@ func run() int {
 	// AddressBookReconciler back-reference.
 	domain := buildDomainServices(database, core, graph, ingest, consumers, ingestStk, eventBus)
 	noteService := domain.NoteService
-	importMatchService := domain.ImportMatchService
 	enrichmentService := domain.EnrichmentService
-	addressBookReconcileService := domain.AddressBookReconcileService
 
 	// Rematch dispatcher consumer — subscribes to contact_methods.added
 	// events and runs RematchService.Run with per-contact mutex
@@ -240,305 +230,27 @@ func run() int {
 	// registered below once their deps are constructed.
 	registerRematchDispatcher(reg, graph, database, eventBus)
 
-	// Initialize external sync components (feature-flagged)
-	var syncService *service.SyncService
-	var syncHandler *handlers.SyncHandler
-	var identityHandler *handlers.IdentityHandler
-	var oauthHandler *handlers.OAuthHandler
-	var importHandler *handlers.ImportHandler
-	var suggestionHandler *handlers.SuggestionHandler
-	var anarlogDiscoveryHandler *handlers.AnarlogDiscoveryHandler
-	var calendarHandler *handlers.CalendarHandler
-	var todoistHandler *handlers.TodoistHandler
-	var contactTaskHandler *handlers.ContactTaskHandler
-	var googleOAuthService *google.OAuthService
-	var todoistOAuthService *todoist.OAuthService
-	var externalContactRepo *repository.ExternalContactRepository
-
-	// GChat provider + enabled-state lister, hoisted to function scope so the
-	// LATE depth-0 gchatEngine block (below, OUTSIDE the EnableExternalSync block)
-	// can register the gchat rematch handlers. The provider is constructed but
-	// INTENTIONALLY NOT registered into providerRegistry: the scheduler must
-	// never run it until an enablement/boot-reconciliation path creates an
-	// enabled external_sync_state(source='gchat') row (not wired here). Both stay
-	// nil unless Google OAuth is configured AND external sync is enabled.
-	var gchatProvider *google.GChatSyncProvider
-	var gchatSyncStates google.GChatSyncStateLister
-
+	// External sync components (feature-flagged). A zero syncStack
+	// reproduces today's all-nil handler set when disabled; the gate stays
+	// here so buildExternalSync runs only when the feature is on.
+	var syncStk syncStack
 	if cfg.Features.EnableExternalSync {
-		syncRepo := repository.NewSyncRepositoryWithPool(database.Queries, database.Pool)
-		identityRepo := repository.NewIdentityRepository(database.Queries)
-		oauthRepo := repository.NewOAuthRepository(database.Queries)
-		providerRegistry := sync.NewProviderRegistry()
-
-		// Initialize Google OAuth service if configured
-		if cfg.Google.ClientID != "" && cfg.Google.ClientSecret != "" {
-			var err error
-			googleOAuthService, err = google.NewOAuthService(cfg, oauthRepo, syncRepo)
-			if err != nil {
-				logger.Warn().Err(err).Msg("failed to initialize Google OAuth service")
-			} else {
-				oauthHandler = handlers.NewOAuthHandler(googleOAuthService, cfg.CORS.FrontendURL)
-				logger.Info().Msg("Google OAuth service initialized")
-			}
-		} else {
-			logger.Info().Msg("Google OAuth not configured (GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET required)")
-		}
-
-		// Initialize Todoist OAuth service if configured
-		if cfg.Todoist.ClientID != "" && cfg.Todoist.ClientSecret != "" {
-			var err error
-			todoistOAuthService, err = todoist.NewOAuthService(cfg, oauthRepo, syncRepo)
-			if err != nil {
-				logger.Warn().Err(err).Msg("failed to initialize Todoist OAuth service")
-			} else {
-				// If OAuth handler exists (from Google), add Todoist to it
-				// Otherwise create a new handler with nil Google service
-				if oauthHandler != nil {
-					oauthHandler.SetTodoistOAuth(todoistOAuthService)
-				} else {
-					oauthHandler = handlers.NewOAuthHandler(nil, cfg.CORS.FrontendURL)
-					oauthHandler.SetTodoistOAuth(todoistOAuthService)
-				}
-
-				// Initialize Todoist settings handler
-				todoistHandler = handlers.NewTodoistHandler(todoistOAuthService, syncRepo)
-
-				// Populate the FollowUpManager's deferred Todoist settings
-				// ref so the cutover consumer can resolve settings via the
-				// real OAuth service for its post-commit refresh / close /
-				// retry workers.
-				followUpSettingsHolder.oauth = todoistOAuthService
-				followUpSettingsHolder.sync = syncRepo
-
-				logger.Info().Msg("Todoist OAuth service initialized")
-			}
-		} else {
-			logger.Info().Msg("Todoist OAuth not configured (TODOIST_CLIENT_ID and TODOIST_CLIENT_SECRET required)")
-		}
-
-		// External contact repository — reuse the instance constructed
-		// at outer scope for the IngestService so all code paths share
-		// the same repo (no behavioral difference today; future stateful
-		// caching is centralized).
-		externalContactRepo = externalContactRepoForIngest
-
-		// Initialize identity service (enrichmentService is constructed at outer scope
-		// so the Telegram block can share it).
-		identityService := service.NewIdentityService(identityRepo)
-
-		// Calendar repo + handler + rematch handler are wired whenever external
-		// sync is enabled, regardless of OAuth configuration. Rematch over
-		// calendar_event is pure DB work and must run in test/local environments
-		// that don't have Google OAuth set up.
-		calendarRepo := repository.NewCalendarEventRepository(database.Queries)
-		calendarHandler = handlers.NewCalendarHandler(calendarRepo)
-		rematchService.Register(google.NewCalendarRematchHandler(calendarRepo, externalContactRepo, pubBus))
-		logger.Info().Msg("Calendar rematch handler registered")
-
-		// Register Google Contacts provider if OAuth is configured
-		if googleOAuthService != nil {
-			gcontactsProvider := google.NewContactsProvider(
-				googleOAuthService,
-				externalContactRepo,
-				enrichmentService,
-				identityService,
-				addressBookReconcileService,
-			)
-			providerRegistry.Register(gcontactsProvider)
-			logger.Info().Msg("Google Contacts sync provider registered")
-
-			// Register Google Calendar provider
-			gcalProvider := google.NewCalendarSyncProvider(
-				googleOAuthService,
-				calendarRepo,
-				contactRepo,
-				identityService,
-				externalContactRepo,
-				pubBus,
-				database.Pool,
-			)
-			providerRegistry.Register(gcalProvider)
-			logger.Info().Msg("Google Calendar sync provider registered")
-
-			// Gmail provider + rematch handler: publisher-driven, so register
-			// ONLY in cutover mode. In off-mode pubBus is a nil *events.Bus;
-			// passing it into the provider's busTx interface field would create
-			// a non-nil-interface-wrapping-typed-nil and bypass the provider's
-			// own `bus == nil` guard, panicking on the first PublishTx. Off-mode
-			// is an emergency rollback posture where no publisher should run.
-			// commsMessageRepo is reused from the email-consumer wiring above.
-			if pubBus != nil {
-				gmailProvider := google.NewGmailSyncProvider(
-					googleOAuthService,
-					commsMessageRepo,
-					pubBus,
-					database.Pool,
-				)
-				providerRegistry.Register(gmailProvider)
-				// syncRepo is the enabled-email-states lister: the rematch scan
-				// runs only over accounts whose email sync is enabled (the same
-				// gate the scheduler uses), not every connected OAuth account.
-				rematchService.Register(google.NewGmailRematchHandler(
-					gmailProvider,
-					syncRepo,
-					commsMessageRepo,
-				))
-				// Correspondence discovery: an in-sync hook that runs the link-only
-				// candidate gate over every fetched message's From/To/Cc
-				// participants (between fetch and storage), so multi-party threads
-				// the storage gate drops still surface unknown addresses that
-				// strong-match an existing contact. Wired into the provider via a
-				// setter (nil-safe; the hook is a no-op when unset). No periodic
-				// job — discovery piggybacks the existing sync fetch.
-				gmailProvider.SetCorrespondenceDiscoverer(google.NewCorrespondenceDiscoverer(
-					contactRepo,
-					externalContactRepo,
-				))
-				logger.Info().Msg("Gmail sync provider + rematch handler + correspondence discovery registered")
-			} else {
-				logger.Warn().Msg("Gmail provider NOT registered: event-bus interaction mode=off (pubBus nil)")
-			}
-
-			// GChat provider: registered into providerRegistry so the scheduler
-			// can run it — this is the go-live switch (PR 3). It stays inert
-			// until enablement reconciliation creates an enabled gchat sync state
-			// (no state → ListDueSyncStates filters enabled=TRUE → nothing to
-			// dispatch). It is store-only + event-free, so unlike Gmail it does
-			// NOT gate on pubBus. gchatSyncStates = syncRepo is the enabled-state
-			// lister the gchat rematch handlers gate on (registered in the late
-			// depth-0 block).
-			gchatProvider = google.NewGChatSyncProvider(
-				googleOAuthService,
-				commsMessageRepo,
-				syncRepo,
-			)
-			gchatSyncStates = syncRepo
-			providerRegistry.Register(gchatProvider)
-			logger.Info().Msg("GChat sync provider registered (inert until a gchat sync state is enabled)")
-		}
-
-		// Register Todoist Cadence provider if OAuth is configured
-		if todoistOAuthService != nil {
-			todoistProvider := todoist.NewCadenceSyncProvider(
-				todoistOAuthService,
-				contactTaskRepo,
-				contactRepo,
-				syncRepo,
-				cfg,
-				eventBus,
-				cadenceUpdater,
-				database.Pool,
-				todoistClientFactory,
-				riverClient,
-				cfg.EventBus.FollowUpMode == config.EventBusFollowUpModeCutover,
-			)
-			providerRegistry.Register(todoistProvider)
-			logger.Info().Msg("Todoist Cadence sync provider registered")
-
-			// Follow-up lifecycle is handled by consumer.FollowUpManager
-			// (wired above via SetFollowUpConsumer). The Todoist
-			// dependency (settings + client factory) routes through
-			// followUpSettingsHolder which was populated when Todoist
-			// OAuth initialized. No follow-up service is constructed
-			// here — FollowUpManager is the sole writer.
-
-			// Initialize contact task service and handler for action tasks
-			contactTaskService := service.NewContactTaskService(
-				contactTaskRepo,
-				contactRepo,
-				syncRepo,
-				todoistOAuthService,
-				cfg,
-			)
-			contactTaskHandler = handlers.NewContactTaskHandler(contactTaskService)
-			logger.Info().Msg("Contact task handler initialized")
-		}
-
-		// Register every Mac-daemon push-source provider. Each is
-		// push-only — data lands via /api/v1/ingest/events, never via the
-		// scheduler (ListDueAccounts skips push strategy) — so Sync() is a
-		// no-op. The registration lives in one helper so the daemonFamily
-		// agreement test can cross-check it against the descriptor table.
-		push.RegisterPushProviders(providerRegistry)
-		logger.Info().Msg("Push providers registered (messages, icloud_contacts, phone_calls)")
-
-		syncService = service.NewSyncService(syncRepo, contactRepo, providerRegistry)
-
-		// Email enablement reconciliation (Gmail go-live). Only meaningful in
-		// cutover mode with a connected Google account: the Gmail provider is
-		// registered only when pubBus != nil, so there is no point reconciling
-		// email states no registered provider can serve. Wire the account
-		// lister + OAuth-connect hook, then run the idempotent boot
-		// reconciliation BEFORE riverClient.Start so the RunOnStart tick already
-		// sees the freshly-enabled email states.
-		if googleOAuthService != nil && pubBus != nil {
-			syncService.SetEmailAccountLister(googleOAuthService)
-			if oauthHandler != nil {
-				oauthHandler.SetEmailStateReconciler(func(ctx context.Context) error {
-					return syncService.ReconcileEmailSyncStates(ctx)
-				})
-			}
-			if err := syncService.ReconcileEmailSyncStates(ctx); err != nil {
-				// Non-fatal: the scheduler simply has nothing to do for email
-				// until states exist; the next connect or next boot retries.
-				logger.Warn().Err(err).Msg("boot email sync reconciliation failed (non-fatal)")
-			}
-		}
-
-		// GChat enablement reconciliation (Chat go-live). Guarded ONLY by
-		// googleOAuthService != nil — NOT pubBus: GChat is store-only + event-free,
-		// so its registration + reconciliation are independent of the event-bus
-		// interaction mode (gating on pubBus would wrongly disable GChat in
-		// off-mode). The provider is registered above whenever Google OAuth is
-		// configured; here we wire the account lister + OAuth-connect hook, then
-		// run the idempotent, chat-scope-gated boot reconciliation BEFORE
-		// riverClient.Start so the RunOnStart tick already sees any freshly-enabled
-		// gchat states. No state is created until a connected account carries the
-		// chat scopes (re-consent), keeping the feature inert until the operator
-		// completes the Chat App config + re-consent.
-		if googleOAuthService != nil {
-			syncService.SetGChatAccountLister(googleOAuthService)
-			if oauthHandler != nil {
-				oauthHandler.SetGChatStateReconciler(func(ctx context.Context) error {
-					return syncService.ReconcileGChatSyncStates(ctx)
-				})
-			}
-			if err := syncService.ReconcileGChatSyncStates(ctx); err != nil {
-				// Non-fatal: the scheduler simply has nothing to do for gchat
-				// until states exist; the next connect or next boot retries.
-				logger.Warn().Err(err).Msg("boot gchat sync reconciliation failed (non-fatal)")
-			}
-		}
-
-		syncHandler = handlers.NewSyncHandler(syncService)
-		identityHandler = handlers.NewIdentityHandler(identityService)
-
-		// Suggestion service composes the method-suggestion group with the
-		// confidence-ranked candidate list and runs resolve/dismiss. Shared
-		// by the import handler (its candidate sort) and the suggestion
-		// handler (the new People-tab surface).
-		suggestionService := service.NewSuggestionService(
-			externalContactRepo,
-			contactRepo,
-			contactMethodRepo,
-			enrichmentService,
-			importMatchService,
-			database,
-		)
-		suggestionHandler = handlers.NewSuggestionHandler(suggestionService)
-
-		// Initialize import handler
-		importHandler = handlers.NewImportHandler(externalContactRepo, identityServiceForIngest, contactService, importMatchService, enrichmentService, suggestionService)
-
-		// Anarlog-title discovery surface (People-tab grouped weak
-		// candidates + token-group resolve). Reuses the external_contact
-		// repo and ContactService — both already constructed above.
-		anarlogDiscoveryService := service.NewAnarlogDiscoveryService(externalContactRepo, contactService)
-		anarlogDiscoveryHandler = handlers.NewAnarlogDiscoveryHandler(anarlogDiscoveryService)
-
-		logger.Info().Msg("external sync infrastructure enabled")
+		syncStk = buildExternalSync(ctx, cfg, database, core, graph, ingest, messaging, consumers, domain, eventBus, riverClient, pubBus)
 	}
+	syncService := syncStk.SyncService
+	syncHandler := syncStk.SyncHandler
+	identityHandler := syncStk.IdentityHandler
+	oauthHandler := syncStk.OAuthHandler
+	importHandler := syncStk.ImportHandler
+	suggestionHandler := syncStk.SuggestionHandler
+	anarlogDiscoveryHandler := syncStk.AnarlogDiscoveryHandler
+	calendarHandler := syncStk.CalendarHandler
+	todoistHandler := syncStk.TodoistHandler
+	contactTaskHandler := syncStk.ContactTaskHandler
+	googleOAuthService := syncStk.GoogleOAuthService
+	externalContactRepo := syncStk.ExternalContactRepo
+	gchatProvider := syncStk.GChatProvider
+	gchatSyncStates := syncStk.GChatSyncStates
 
 	// Telegram integration (independent of external sync)
 	var telegramManager *tgpkg.TelegramManager

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -39,7 +39,6 @@ import (
 	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/consumer"
 	"personal-crm/backend/internal/consumer/consumerjobs"
-	"personal-crm/backend/internal/crypto"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/events"
 	"personal-crm/backend/internal/google"
@@ -49,7 +48,6 @@ import (
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/scheduler"
 	"personal-crm/backend/internal/service"
-	tgpkg "personal-crm/backend/internal/telegram"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -190,7 +188,6 @@ func run() int {
 
 	// Message-store repos + staging registry + venue resolver.
 	messaging := buildMessagingFoundation(database.Queries, messagesMessageRepo, calendarRepoForIngest)
-	telegramMessageRepo := messaging.TelegramMessageRepo
 	commsMessageRepo := messaging.CommsMessageRepo
 
 	// Event-bus consumers (Cadence / Knowledge / FollowUp / InteractionRecorder)
@@ -222,7 +219,6 @@ func run() int {
 	// AddressBookReconciler back-reference.
 	domain := buildDomainServices(database, core, graph, ingest, consumers, ingestStk, eventBus)
 	noteService := domain.NoteService
-	enrichmentService := domain.EnrichmentService
 
 	// Rematch dispatcher consumer — subscribes to contact_methods.added
 	// events and runs RematchService.Run with per-contact mutex
@@ -252,71 +248,20 @@ func run() int {
 	gchatProvider := syncStk.GChatProvider
 	gchatSyncStates := syncStk.GChatSyncStates
 
-	// Telegram integration (independent of external sync)
-	var telegramManager *tgpkg.TelegramManager
-	var telegramHandler *handlers.TelegramHandler
-
+	// Telegram integration (independent of external sync). A zero
+	// telegramStack reproduces today's nil manager/handler when disabled.
+	var telegramStk telegramStack
 	if cfg.Features.EnableTelegramSync && cfg.External.TelegramAPIID != 0 {
-		telegramSessionRepo := repository.NewTelegramSessionRepository(database.Queries)
-		telegramUpdateStateRepo := repository.NewTelegramUpdateStateRepository(database.Queries)
-		telegramChatConfigRepo := repository.NewTelegramChatConfigRepository(database.Queries)
-		// telegramMessageRepo is hoisted above (needed by the consumer
-		// wiring); no re-construction here.
-		telegramSyncRepo := repository.NewSyncRepository(database.Queries)
-
-		// Phase 4: identity + aggregation dependencies
-		tgIdentityRepo := repository.NewIdentityRepository(database.Queries)
-		tgIdentityService := service.NewIdentityService(tgIdentityRepo)
-		tgExternalContactRepo := repository.NewExternalContactRepository(database.Queries)
-
-		encryptor, err := crypto.NewTokenEncryptor(cfg.External.TokenEncryptionKey)
-		if err != nil {
-			logger.Fatal().Err(err).Msg("failed to initialize Telegram encryptor (TOKEN_ENCRYPTION_KEY required)")
-		}
-
-		// River-backed stale-claim recovery enqueuer. Uses UniqueOpts
-		// {ByArgs: true} paired with the InteractionRecorderJobArgs.EventID
-		// `river:"unique"` tag so repeated recovery enqueues against the
-		// same event coalesce into one in-flight job (spec §3 Race
-		// Mechanics).
-		tgRecoveryEnqueuer := consumer.NewRiverInteractionRecorderEnqueuer(riverClient)
-
-		telegramManager = tgpkg.NewTelegramManager(
-			telegramSessionRepo,
-			telegramUpdateStateRepo,
-			telegramChatConfigRepo,
-			telegramMessageRepo,
-			telegramSyncRepo,
-			encryptor,
-			cfg.External.TelegramAPIID,
-			cfg.External.TelegramAPIHash,
-			&cfg.Telegram,
-			tgIdentityService,
-			tgExternalContactRepo,
-			enrichmentService,
-			interactionRepo,
-			contactService,
-			contactService,
-			pubBus,
-			database.Pool,
-			tgRecoveryEnqueuer,
-		)
-
-		if err := telegramManager.Start(ctx); err != nil {
-			logger.Warn().Err(err).Msg("failed to start Telegram connection")
-		}
+		telegramStk = buildTelegram(ctx, cfg, database, core, graph, messaging, domain, pubBus, riverClient)
+	}
+	telegramManager := telegramStk.Manager
+	telegramHandler := telegramStk.Handler
+	// The Stop defer lives here (not inside buildTelegram) so it fires on
+	// run() return, not when the wire function returns. Nil-guarded:
+	// registers only when a manager was built, exactly as the old
+	// branch-local defer did (decision 4).
+	if telegramManager != nil {
 		defer telegramManager.Stop()
-
-		telegramHandler = handlers.NewTelegramHandler(telegramManager)
-
-		// Register telegram rematch handlers (telegram + phone identifiers)
-		// against the same matcher/aggregator instances the manager owns so
-		// rematch behavior is identical to the post-import path.
-		rematchService.Register(tgpkg.NewUsernameRematchHandler(telegramMessageRepo, telegramManager.PeerMatcher(), telegramManager.AggregationEngine()))
-		rematchService.Register(tgpkg.NewPhoneRematchHandler(telegramMessageRepo, telegramManager.PeerMatcher(), telegramManager.AggregationEngine()))
-		logger.Info().Msg("Telegram rematch handlers registered")
-
-		logger.Info().Msg("Telegram integration initialized")
 	}
 
 	// Wire Telegram post-import hook (if both Telegram and imports are enabled)

--- a/backend/cmd/crm-api/routes.go
+++ b/backend/cmd/crm-api/routes.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"personal-crm/backend/internal/api/handlers"
+	"personal-crm/backend/internal/auth"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/google"
+	"personal-crm/backend/internal/health"
+	"personal-crm/backend/internal/logger"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/scheduler"
+	"personal-crm/backend/internal/service"
+
+	"github.com/gin-gonic/gin"
+	swaggerFiles "github.com/swaggo/files"
+	ginSwagger "github.com/swaggo/gin-swagger"
+)
+
+// routeDeps carries everything registerRoutes needs to register the gin
+// route tree. Conditional gates (feature flags, nil-handler checks,
+// CRM_ENV) live at their call sites inside registerRoutes exactly as they
+// did inline in run().
+type routeDeps struct {
+	Router   *gin.Engine
+	Cfg      *config.Config
+	Database *db.Database
+
+	// Health
+	StalenessService *service.StalenessService
+
+	// Mac-daemon host management
+	MacHostRepo    *repository.MacHostRepository
+	MacHostHandler *handlers.MacHostHandler
+
+	// Ingest
+	IngestHandler      *handlers.IngestHandler
+	MeetingNoteHandler *handlers.MeetingNoteHandler
+
+	// Core (always-on)
+	ContactHandler     *handlers.ContactHandler
+	InteractionHandler *handlers.InteractionHandler
+	NoteHandler        *handlers.NoteHandler
+	RematchHandler     *handlers.RematchHandler
+	StalenessHandler   *handlers.StalenessHandler
+	SystemHandler      *handlers.SystemHandler
+
+	// OAuth / external sync (feature-flagged / nil when unconfigured)
+	OAuthHandler            *handlers.OAuthHandler
+	GoogleOAuthService      *google.OAuthService
+	TodoistHandler          *handlers.TodoistHandler
+	TelegramHandler         *handlers.TelegramHandler
+	SyncHandler             *handlers.SyncHandler
+	IdentityHandler         *handlers.IdentityHandler
+	ContactTaskHandler      *handlers.ContactTaskHandler
+	CalendarHandler         *handlers.CalendarHandler
+	ImportHandler           *handlers.ImportHandler
+	AnarlogDiscoveryHandler *handlers.AnarlogDiscoveryHandler
+	SuggestionHandler       *handlers.SuggestionHandler
+
+	// Test seeding (CRM_ENV=testing/test)
+	ExternalContactRepo      *repository.ExternalContactRepository
+	ContactService           *service.ContactService
+	MeetingNoteRepoForIngest *repository.MeetingNoteRepository
+}
+
+// registerRoutes registers the health endpoint, OAuth callbacks, mac-host
+// routes, the ingest endpoint, the /api/v1 authenticated group (with all
+// conditional sub-routes), and swagger — preserving the exact registration
+// order + gates from the original run() body.
+func registerRoutes(deps routeDeps) {
+	router := deps.Router
+	cfg := deps.Cfg
+	database := deps.Database
+
+	// Health check endpoint. Bare /health is the liveness probe (DB-only
+	// top-level status, today's contract); ?ready=1 aggregates the
+	// river/sync/disk components for an external pinger. The stalenessService
+	// (constructed above) and a HealthRepository over river_job back the new
+	// components; the watchdog kind ties the sync component's freshness guard to
+	// the periodic watchdog job registered on the same River client.
+	healthRepo := repository.NewHealthRepository(database.Queries)
+	healthChecker := health.NewHealthChecker(database, cfg.Database.HealthTimeout, health.Deps{
+		River:            healthRepo,
+		Staleness:        deps.StalenessService,
+		SyncWatchdogKind: scheduler.StalenessWatchdogArgs{}.Kind(),
+		Thresholds: health.Thresholds{
+			RiverDiscardedMax:  cfg.Health.RiverDiscardedMax,
+			RiverOldestDueMax:  cfg.Health.RiverOldestDueMax,
+			SyncWatchdogMaxAge: cfg.Health.SyncWatchdogMaxAge,
+			DiskPath:           cfg.Health.DiskPath,
+			DiskMinFreePercent: cfg.Health.DiskMinFreePercent,
+		},
+	})
+	router.GET("/health", healthChecker.Handler)
+
+	// OAuth callback routes (no auth - called by provider redirects)
+	if deps.OAuthHandler != nil {
+		handlers.RegisterOAuthCallbackRoutes(router, handlers.OAuthCallbackDeps{
+			Handler:       deps.OAuthHandler,
+			GoogleEnabled: deps.GoogleOAuthService != nil,
+		})
+	}
+
+	// Mac-daemon public + host-auth routes (Pair + heartbeat + cursor +
+	// known-ids). Registered via the shared helper so integration tests
+	// exercise the same code path. Admin routes are registered later
+	// inside the global-API-key-protected v1 group.
+	handlers.RegisterMacHostRoutes(router, handlers.MacHostRouteDeps{
+		HostRepo:    deps.MacHostRepo,
+		Handler:     deps.MacHostHandler,
+		AuthLimiter: auth.DefaultMacHostAuthLimiterConfig(),
+	})
+
+	// Event bus ingestion endpoint (feature-flagged per spec §3.9).
+	// Registered as a SIBLING of /api/v1 (not inside it) so the
+	// composite IngestAuthMiddleware can branch per-request:
+	//   - X-Mac-Host-ID present → MacHostAuthMiddleware (daemon path)
+	//   - X-Mac-Host-ID absent  → APIKeyMiddleware (global-key path)
+	// gin route trees reject duplicate registration of the same prefix
+	// under different middleware groups, so the composite dispatch is
+	// the minimum seam to support both auth paths on one URL.
+	if cfg.Features.EnableEventBusIngest {
+		ingestAuth := auth.IngestAuthMiddleware(
+			auth.APIKeyMiddleware(cfg),
+			auth.MacHostAuthMiddleware(deps.MacHostRepo, auth.DefaultPasswordComparator, auth.DefaultMacHostAuthLimiterConfig()),
+		)
+		handlers.RegisterIngestRoutes(router, handlers.IngestRouteDeps{
+			Auth:        ingestAuth,
+			Ingest:      deps.IngestHandler,
+			MeetingNote: deps.MeetingNoteHandler,
+		})
+		logger.Info().Msg("event bus ingestion endpoint enabled")
+	}
+
+	// API routes
+	v1 := router.Group("/api/v1")
+	v1.Use(auth.APIKeyMiddleware(cfg))
+	{
+		// Contact + interaction routes (unconditional).
+		handlers.RegisterContactRoutes(v1, handlers.ContactRouteDeps{
+			Contact:     deps.ContactHandler,
+			Interaction: deps.InteractionHandler,
+			Note:        deps.NoteHandler,
+		})
+
+		// Meeting-note conflict-resolution — user-driven, called from
+		// the frontend with the global API key. Stays under the v1
+		// APIKeyMiddleware group.
+		handlers.RegisterMeetingNoteRoutes(v1, deps.MeetingNoteHandler)
+
+		// Rematch routes — always registered; service no-ops when no handlers
+		// are registered (e.g. telegram-disabled deployments still get calendar).
+		handlers.RegisterRematchRoutes(v1, deps.RematchHandler)
+
+		// Sync-staleness breaches — registered unconditionally (OUTSIDE the
+		// EnableExternalSync-gated /sync group below): heartbeat/push breaches
+		// must be visible even with external sync off. The static 2-segment
+		// path coexists with that group's 3-segment param routes.
+		handlers.RegisterSyncStalenessRoutes(v1, deps.StalenessHandler)
+
+		// System routes
+		handlers.RegisterSystemRoutes(v1, deps.SystemHandler)
+
+		// Mac-daemon admin routes (under global API key middleware).
+		// Pairing-token mint + revoke + list/get for the Mac settings UI.
+		handlers.RegisterMacHostAdminRoutes(v1, deps.MacHostHandler)
+
+		// OAuth routes (feature-flagged with external sync)
+		if deps.OAuthHandler != nil {
+			handlers.RegisterOAuthRoutes(v1, handlers.OAuthCallbackDeps{
+				Handler:       deps.OAuthHandler,
+				GoogleEnabled: deps.GoogleOAuthService != nil,
+			})
+		}
+
+		// Todoist settings routes (only if Todoist is configured)
+		if deps.TodoistHandler != nil {
+			handlers.RegisterTodoistRoutes(v1, deps.TodoistHandler)
+		}
+
+		// Telegram routes (feature-flagged)
+		if deps.TelegramHandler != nil {
+			handlers.RegisterTelegramRoutes(v1, deps.TelegramHandler)
+		}
+
+		// External sync routes (feature-flagged)
+		if cfg.Features.EnableExternalSync && deps.SyncHandler != nil {
+			handlers.RegisterSyncRoutes(v1, deps.SyncHandler)
+			handlers.RegisterIdentityRoutes(v1, deps.IdentityHandler)
+
+			// Add contact task routes (manual tasks) if Todoist is configured
+			if deps.ContactTaskHandler != nil {
+				handlers.RegisterContactTaskRoutes(v1, deps.ContactTaskHandler)
+			}
+
+			// Add calendar event routes to contacts if calendar handler is initialized
+			if deps.CalendarHandler != nil {
+				handlers.RegisterCalendarRoutes(v1, deps.CalendarHandler)
+			}
+
+			// Import candidates routes
+			if deps.ImportHandler != nil {
+				handlers.RegisterImportRoutes(v1, handlers.ImportRouteDeps{
+					Import:           deps.ImportHandler,
+					AnarlogDiscovery: deps.AnarlogDiscoveryHandler,
+					Suggestions:      deps.SuggestionHandler,
+				})
+			}
+		}
+
+		// Export/Import routes
+		handlers.RegisterDataExchangeRoutes(v1, deps.SystemHandler)
+
+		// Test routes (gated by CRM_ENV=testing or CRM_ENV=test)
+		if cfg.Runtime.CRMEnvironment == "testing" || cfg.Runtime.CRMEnvironment == "test" {
+			// Initialize external contact repo if not already done (for non-sync environments)
+			testExternalRepo := deps.ExternalContactRepo
+			if testExternalRepo == nil {
+				testExternalRepo = repository.NewExternalContactRepository(database.Queries)
+			}
+
+			// Initialize calendar repo for test seeding
+			testCalendarRepo := repository.NewCalendarEventRepository(database.Queries)
+
+			// Initialize calendar handler if not already done (allows reading seeded events in tests)
+			calendarHandler := deps.CalendarHandler
+			if calendarHandler == nil {
+				calendarHandler = handlers.NewCalendarHandler(testCalendarRepo)
+				// Register calendar routes that weren't registered earlier (OAuth not configured)
+				handlers.RegisterCalendarRoutes(v1, calendarHandler)
+				logger.Info().Msg("calendar handler initialized for testing (no OAuth)")
+			}
+
+			testSeedService := service.NewTestSeedService(database, testExternalRepo, deps.ContactService, testCalendarRepo, deps.MacHostRepo, deps.MeetingNoteRepoForIngest)
+			testHandler := handlers.NewTestHandler(testSeedService)
+			handlers.RegisterTestRoutes(v1, testHandler)
+			logger.Info().Msg("test API endpoints enabled (CRM_ENV=testing)")
+		}
+	}
+
+	// Swagger documentation
+	router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
+}

--- a/backend/cmd/crm-api/wire_aggregation.go
+++ b/backend/cmd/crm-api/wire_aggregation.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"personal-crm/backend/internal/consumer"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/google"
+	"personal-crm/backend/internal/logger"
+	"personal-crm/backend/internal/messages"
+	"personal-crm/backend/internal/messaging/aggregation"
+	"personal-crm/backend/internal/repository"
+	tgpkg "personal-crm/backend/internal/telegram"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/riverqueue/river"
+)
+
+// aggregationStack holds the messages + gchat aggregation engines, consumed
+// by registerMessagingWorkers.
+type aggregationStack struct {
+	MessagesEngine *aggregation.Engine
+	GChatEngine    *aggregation.Engine
+}
+
+// buildAggregationEngines constructs the messages + gchat aggregation engines
+// and their reenqueuers, registers the gchat rematch handlers (gated on a
+// constructed gchat provider), and populates the deferred aggregator-reenqueuer
+// registry. Wired unconditionally — the engines are stateless and inert until
+// their source rows exist. telegramManager / gchatProvider / gchatSyncStates
+// are nil-safe params exactly as the old inline fallbacks.
+func buildAggregationEngines(
+	database *db.Database,
+	core coreRepos,
+	graph contactCore,
+	ingest ingestRepos,
+	messaging messagingFoundation,
+	consumers eventConsumers,
+	eventBus *events.Bus,
+	riverClient *river.Client[pgx.Tx],
+	telegramManager *tgpkg.TelegramManager,
+	gchatProvider *google.GChatSyncProvider,
+	gchatSyncStates google.GChatSyncStateLister,
+) aggregationStack {
+	interactionRepo := core.Interaction
+	contactService := graph.ContactService
+	rematchService := graph.RematchService
+	messagesMessageRepo := ingest.MessagesMessage
+	commsMessageRepo := messaging.CommsMessageRepo
+	aggregatorReenqueuerHolder := consumers.AggregatorReenqueuerHolder
+
+	// Messages aggregator engine + reenqueuer + worker + sweeper.
+	// Wired unconditionally — the Mac daemon push pipeline accepts
+	// raw_message.* envelopes regardless of any feature flag, and the
+	// engine is a stateless function over messagesMessageRepo (no
+	// daemon-side connection or background loop).
+	//
+	// The chat-aware AggregateForContact path is what preserves the
+	// engine's extend/bridge/coalesce contract. The
+	// MessagingAggregateForContactWorker iterates over the contact's
+	// distinct unprocessed chats and invokes it per chat; the periodic
+	// sweeper provides a 5-min safety net for the never-claimed
+	// stranded-row gap.
+	messagesEnqueuer := consumer.NewRiverInteractionRecorderEnqueuer(riverClient)
+	const messagesBurstWindowHours = 4
+	const messagesReplyBridgeHours = 48
+	messagesEngine := messages.NewAggregationEngine(
+		messagesBurstWindowHours,
+		messagesReplyBridgeHours,
+		messagesMessageRepo,
+		interactionRepo,
+		contactService,
+		contactService,
+		eventBus,
+		database.Pool,
+		messagesEnqueuer,
+	)
+	messagesReenqueuer := consumer.NewMessagesAggregatorReenqueuer(
+		messagesEngine,
+		riverClient,
+		repository.InteractionSourceMessages,
+	)
+
+	// GChat aggregation engine over comms_message. LIVE but INERT: the
+	// engine/worker/sweeper/reenqueuer for gchat run on every tick, but every
+	// query is source='gchat'-scoped and returns zero rows until a provider +
+	// enablement write comms_message(source='gchat') rows. Burst/reply windows
+	// are hard-coded here (matching how messages hard-codes its constants);
+	// env-var overrides are out of scope for now.
+	gchatEnqueuer := consumer.NewRiverInteractionRecorderEnqueuer(riverClient)
+	const gchatBurstWindowHours = 2
+	const gchatReplyBridgeHours = 48
+	gchatEngine := google.NewGChatAggregationEngine(
+		gchatBurstWindowHours,
+		gchatReplyBridgeHours,
+		commsMessageRepo,
+		interactionRepo,
+		contactService,
+		contactService,
+		eventBus,
+		database.Pool,
+		gchatEnqueuer,
+	)
+
+	// GChat rematch handlers: registered when the provider was constructed
+	// (Google OAuth configured) AND external sync is enabled. They are provably
+	// inert until an enabled gchat sync state exists — each gates FIRST on
+	// ListEnabledSyncStates filtered to source='gchat' and returns (0, nil) when
+	// that set is empty. The email handler co-registers under "email" alongside
+	// Gmail/Calendar; its gchat-scoped gate means it no-ops while the others do
+	// their real work. The provider itself is NOT registered into
+	// providerRegistry (the scheduler never runs it).
+	if gchatProvider != nil && gchatSyncStates != nil {
+		rematchService.Register(google.NewGChatHandleRematchHandler(gchatProvider, gchatSyncStates, commsMessageRepo, gchatEngine))
+		rematchService.Register(google.NewGChatEmailRematchHandler(gchatProvider, gchatSyncStates, commsMessageRepo, gchatEngine))
+		logger.Info().Msg("GChat rematch handlers registered (inert until a gchat sync state is enabled)")
+	}
+
+	gchatReenqueuer := consumer.NewCommsAggregatorReenqueuer(
+		gchatEngine,
+		riverClient,
+		repository.InteractionSourceGChat,
+	)
+
+	// Wire the per-source aggregator reenqueuer registry. The
+	// InteractionRecorderWorker holds the deferred holder; this
+	// assignment makes the post-commit reenqueue path live for both
+	// telegram-source and messages-source events. When Telegram is
+	// disabled the telegram entry is a no-op reenqueuer (so calls for
+	// telegram-source envelopes — which won't be produced anyway —
+	// degrade cleanly).
+	reenqueuerEntries := map[string]consumer.AggregatorReenqueuer{
+		repository.InteractionSourceMessages: messagesReenqueuer,
+		repository.InteractionSourceGChat:    gchatReenqueuer,
+	}
+	if telegramManager != nil {
+		reenqueuerEntries[repository.InteractionSourceTelegram] = consumer.NewTelegramAggregatorReenqueuer(telegramManager.AggregationEngine())
+	} else {
+		reenqueuerEntries[repository.InteractionSourceTelegram] = consumer.NoopAggregatorReenqueuer{}
+	}
+	aggregatorReenqueuerHolder.set(consumer.NewAggregatorReenqueuerRegistry(reenqueuerEntries))
+
+	return aggregationStack{
+		MessagesEngine: messagesEngine,
+		GChatEngine:    gchatEngine,
+	}
+}

--- a/backend/cmd/crm-api/wire_consumers.go
+++ b/backend/cmd/crm-api/wire_consumers.go
@@ -7,6 +7,7 @@ import (
 	"personal-crm/backend/internal/events"
 	"personal-crm/backend/internal/logger"
 	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
 	"personal-crm/backend/internal/todoist"
 
 	"github.com/jackc/pgx/v5"
@@ -200,4 +201,207 @@ func buildEventConsumers(
 		FollowUpManager:            followUpManager,
 		InteractionRecorder:        interactionRecorder,
 	}
+}
+
+// registerCoreConsumerWorkers registers the three always-on core consumer
+// workers (InteractionRecorder, CalendarDecline, EmailInteraction). Each is
+// registered UNCONDITIONALLY — river rejects unknown job kinds at dequeue
+// time, so having the worker present with mode=off costs nothing (no events
+// route to it when pubBus is nil). Mode gating happens at the publisher
+// sites via pubBus and at the manual-handler level via manualHandler.
+func registerCoreConsumerWorkers(
+	reg *riverRegistrar,
+	database *db.Database,
+	core coreRepos,
+	graph contactCore,
+	messaging messagingFoundation,
+	consumers eventConsumers,
+	eventBus *events.Bus,
+) {
+	interactionRepo := core.Interaction
+	contactRepo := core.Contact
+	contactService := graph.ContactService
+	commsMessageRepo := messaging.CommsMessageRepo
+	venueRepo := messaging.VenueRepo
+	interactionRecorder := consumers.InteractionRecorder
+	aggregatorReenqueuerHolder := consumers.AggregatorReenqueuerHolder
+	cadenceUpdater := consumers.CadenceUpdater
+	followUpManager := consumers.FollowUpManager
+
+	// aggregatorReenqueuerHolder is wired in here; the actual telegram
+	// entry is filled by the cfg.Features.EnableTelegramSync branch
+	// further down. Until that branch runs (or in test/no-telegram
+	// modes), the holder dispatches to a logged-warn no-op.
+	addWorker(reg, consumer.NewInteractionRecorderWorker(eventBus, database.Pool, interactionRecorder, aggregatorReenqueuerHolder))
+
+	// Calendar decline consumer: when a stored calendar_event is
+	// declined / cancelled / user-removed upstream, the publisher removes
+	// the row + emits calendar.declined per matched contact; this consumer
+	// soft-deletes the derived gcal interaction and recomputes the contact's
+	// date columns. Registered unconditionally — no events route to it when
+	// the publisher (CalendarSyncProvider) is in off mode.
+	calendarDeclineHandler := consumer.NewCalendarDeclineHandler(interactionRepo, contactRepo)
+	addWorker(reg, consumer.NewCalendarDeclineHandlerWorker(eventBus, database.Pool, calendarDeclineHandler))
+
+	// Email-interaction consumer: derives a per-(contact, thread, local-day)
+	// aggregated interaction from email.received / email.sent events + their
+	// comms_message content rows. contactService fills both the
+	// interactionWriter slot (create branch) and the emailAggregator slot
+	// (found-branch extend/promote). cadenceUpdater + followUpManager are the
+	// SAME instances the InteractionRecorder uses, so the create branch's
+	// inline cadence/follow-up apply shares the durable event-claim store.
+	// Registered unconditionally; it processes the email.received /
+	// email.sent events the Gmail provider publishes in production (and
+	// stays idle when no such event is routed, e.g. event-bus off mode).
+	// commsMessageRepo was hoisted earlier (above the staging registry).
+	emailInteractionConsumer := consumer.NewEmailInteractionConsumer(
+		contactService, commsMessageRepo, interactionRepo, contactService,
+		eventBus, cadenceUpdater, followUpManager,
+	)
+	// Populate interaction.venue_id with the email-thread venue on the create
+	// branch. The venue repo resolves directly (email carries thread_id).
+	emailInteractionConsumer.SetVenueResolver(venueRepo)
+	addWorker(reg, consumer.NewEmailInteractionConsumerWorker(eventBus, database.Pool, emailInteractionConsumer))
+}
+
+// resolveInteractionMode applies the interaction-mode wiring gate. Cutover
+// is the normal operating posture; off is the emergency-override retained so
+// rollback can silence publisher-driven paths without a code change. A
+// deploy in off mode does NOT restore any pre-cutover direct path — rollback
+// is `git revert`. Returns pubBus as a CONCRETE *events.Bus (nil in off
+// mode) so it is threaded by concrete type through the provider wiring, and
+// the manual-interaction handler (nil in off mode).
+func resolveInteractionMode(cfg *config.Config, database *db.Database, consumers eventConsumers, eventBus *events.Bus) (*events.Bus, *service.ManualInteractionHandler) {
+	interactionRecorder := consumers.InteractionRecorder
+
+	effectiveMode := cfg.EventBus.InteractionMode
+	var pubBus *events.Bus
+	var manualHandler *service.ManualInteractionHandler
+	switch effectiveMode {
+	case config.EventBusInteractionModeCutover:
+		pubBus = eventBus
+		manualHandler = service.NewManualInteractionHandler(database.Pool, eventBus, interactionRecorder)
+		logger.Info().
+			Str("mode", "cutover").
+			Msg("event-bus interaction consumer: cutover active")
+	default: // off
+		pubBus = nil
+		manualHandler = nil
+		logger.Warn().
+			Str("mode", effectiveMode).
+			Msg("event-bus interaction consumer: mode=off — publisher-driven " +
+				"(telegram/calendar/manual) interactions will NOT be recorded. " +
+				"HTTP ingest path is unaffected. Use EVENT_BUS_INTERACTION_MODE=cutover (default) to restore publisher paths.")
+	}
+
+	// Informational warning when ingest is enabled but cutover isn't —
+	// ingested events still write interactions (the HTTP ingest path is
+	// an intentional carve-out of the off-mode gate); this log line
+	// makes the seam visible in operator logs.
+	if cfg.Features.EnableEventBusIngest && effectiveMode != config.EventBusInteractionModeCutover {
+		logger.Warn().
+			Str("interaction_mode", effectiveMode).
+			Bool("ingest_enabled", cfg.Features.EnableEventBusIngest).
+			Msg("event-bus ingest enabled but InteractionRecorder is not in cutover mode; " +
+				"ingested events WILL still be written by the consumer — the mode=off warning " +
+				"above does NOT apply to ingested-event-driven writes.")
+	}
+
+	return pubBus, manualHandler
+}
+
+// registerModeWorkers registers the cadence / knowledge-cache / follow-up /
+// Todoist follow-up workers (all config-blind; HandleEvent short-circuits on
+// mode=off) and emits the follow-up + cadence mode boot logs.
+func registerModeWorkers(
+	reg *riverRegistrar,
+	cfg *config.Config,
+	database *db.Database,
+	core coreRepos,
+	consumers eventConsumers,
+	eventBus *events.Bus,
+	riverClient *river.Client[pgx.Tx],
+) {
+	contactTaskRepo := core.ContactTask
+	cadenceUpdater := consumers.CadenceUpdater
+	knowledgeCacheUpdater := consumers.KnowledgeCacheUpdater
+	followUpManager := consumers.FollowUpManager
+	followUpMode := consumers.FollowUpMode
+	followUpSettings := consumers.FollowUpSettings
+	todoistClientFactory := consumers.TodoistClientFactory
+
+	// CadenceUpdater is constructed above (alongside InteractionRecorder).
+	// Register its river worker unconditionally — events.consumerJobsForKind
+	// always enqueues a cadence_updater job for interaction.recorded. In
+	// cutover mode the inline recorder path claims the event first, so
+	// this worker is almost always a durable no-op on re-delivery. In
+	// mode=off HandleEvent short-circuits before any DB write.
+	addWorker(reg, consumer.NewCadenceUpdaterWorker(eventBus, database.Pool, cadenceUpdater))
+
+	// KnowledgeCacheUpdater worker: refreshes the contact.location/birthday/how_met
+	// cache columns on assertion.accepted / assertion.superseded events (the bus
+	// routes both kinds here; the worker no-ops unless the predicate is one of the
+	// three cutover predicates). Covers supersession / closure / retraction from
+	// any producer; the inline RefreshTx in ContactService handles direct edits.
+	addWorker(reg, consumer.NewKnowledgeCacheUpdaterWorker(eventBus, database.Pool, knowledgeCacheUpdater))
+
+	// FollowUpManager + river workers. Routing is config-blind
+	// (events.consumerJobsForKind always enqueues cadence + follow-up
+	// jobs for interaction.recorded); HandleEvent short-circuits on
+	// mode=off without DB writes. The Todoist create / close / refresh
+	// workers are registered so river knows their kinds even when
+	// Todoist isn't wired — in that case the settings func returns an
+	// ErrNoTodoistAccount-equivalent error and the worker returns a
+	// retryable failure for river to back off.
+	addWorker(reg, consumer.NewFollowUpManagerWorker(eventBus, database.Pool, followUpManager))
+	addWorker(reg, consumer.NewTodoistFollowUpCreateJobWorker(
+		followUpMode, contactTaskRepo, followUpSettings, todoistClientFactory, riverClient, database.Pool,
+	))
+	addWorker(reg, consumer.NewTodoistFollowUpCloseJobWorker(
+		followUpMode, contactTaskRepo, followUpSettings, todoistClientFactory,
+	))
+	addWorker(reg, consumer.NewTodoistFollowUpRefreshJobWorker(
+		followUpMode, contactTaskRepo, followUpSettings, todoistClientFactory,
+	))
+
+	switch cfg.EventBus.FollowUpMode {
+	case config.EventBusFollowUpModeCutover:
+		logger.Info().
+			Str("mode", "cutover").
+			Msg("event-bus FollowUpManager: cutover active (sole writer of follow-up tasks; inline recorder dispatch enabled)")
+	default: // off
+		cfg.EventBus.MaybeWarnUnsafeOff()
+		logger.Warn().
+			Str("mode", "off").
+			Msg("event-bus FollowUpManager: mode=off active — NO follow-up tasks will be created or completed until EVENT_BUS_FOLLOWUP_UNSAFE_ALLOW_OFF is unset or a `git revert` ships")
+	}
+
+	switch cfg.EventBus.CadenceMode {
+	case config.EventBusCadenceModeCutover:
+		logger.Info().
+			Str("mode", "cutover").
+			Msg("event-bus CadenceUpdater: cutover active (sole writer of cadence columns; inline recorder dispatch enabled)")
+	default: // off
+		// Validate() already rejected this unless UnsafeAllowOffMode is
+		// true; we reach here only via the emergency escape hatch. The
+		// WARN log in config.Load already fired; repeat it here for
+		// observability on the main-wire path.
+		cfg.EventBus.MaybeWarnUnsafeOff()
+		logger.Warn().
+			Str("mode", "off").
+			Msg("event-bus CadenceUpdater: mode=off active — NO cadence columns will be updated until EVENT_BUS_CADENCE_UNSAFE_ALLOW_OFF is unset or a `git revert` ships")
+	}
+}
+
+// registerRematchDispatcher registers the rematch-dispatcher consumer worker.
+// Always-on (no mode flag): a registered River worker that returned nil in
+// kill-switch mode would permanently ack queued jobs, so rollback is
+// `git revert` only. Rematch handlers themselves (calendar, telegram) are
+// registered elsewhere once their deps are constructed.
+func registerRematchDispatcher(reg *riverRegistrar, graph contactCore, database *db.Database, eventBus *events.Bus) {
+	rematchService := graph.RematchService
+
+	rematchDispatcher := consumer.NewRematchDispatcher(rematchService)
+	addWorker(reg, consumer.NewRematchDispatcherWorker(eventBus, database.Pool, rematchDispatcher))
+	logger.Info().Msg("event-bus RematchDispatcher: cutover active")
 }

--- a/backend/cmd/crm-api/wire_consumers.go
+++ b/backend/cmd/crm-api/wire_consumers.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/consumer"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/logger"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/todoist"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/riverqueue/river"
+)
+
+// eventConsumers holds the event-bus consumers + their shared collaborators
+// constructed before the interaction-mode gate. The InteractionRecorder,
+// CadenceUpdater, KnowledgeCacheUpdater, and FollowUpManager are the sole
+// writers of their respective columns; the holders carry deferred wiring
+// (Telegram aggregation engine, Todoist settings) populated later.
+type eventConsumers struct {
+	AggregatorReenqueuerHolder *deferredAggregatorReenqueuer
+	EventClaimRepo             *repository.EventConsumerClaimRepository
+	CadenceUpdater             *consumer.CadenceUpdater
+	KnowledgeCacheUpdater      *consumer.KnowledgeCacheUpdater
+	TodoistClientFactory       todoist.ClientFactory
+	FollowUpMode               string
+	FollowUpSettingsHolder     *followUpSettingsRef
+	FollowUpSettings           consumer.TodoistSettingsFunc
+	FollowUpManager            *consumer.FollowUpManager
+	InteractionRecorder        *consumer.InteractionRecorder
+}
+
+// buildEventConsumers constructs the CadenceUpdater, KnowledgeCacheUpdater,
+// FollowUpManager, and InteractionRecorder in their required order (each
+// downstream consumer takes the earlier ones as constructor args), wiring
+// them into ContactService via its setters exactly as before. The Todoist
+// client factory + writes-enabled boot log and the deferred holders are
+// created here too. No River workers are registered here — that happens in
+// registerCoreConsumerWorkers / registerModeWorkers.
+func buildEventConsumers(
+	cfg *config.Config,
+	database *db.Database,
+	core coreRepos,
+	graph contactCore,
+	ingest ingestRepos,
+	messaging messagingFoundation,
+	eventBus *events.Bus,
+	riverClient *river.Client[pgx.Tx],
+) eventConsumers {
+	contactRepo := core.Contact
+	contactTaskRepo := core.ContactTask
+	interactionRepo := core.Interaction
+	contactService := graph.ContactService
+	assertService := graph.AssertService
+	graphAssertionRepo := graph.GraphAssertion
+	graphNodeRepo := graph.GraphNode
+	stagingRegistry := messaging.StagingRegistry
+	venueResolver := messaging.VenueResolver
+	calendarRepoForIngest := ingest.CalendarEvent
+
+	// Aggregator reenqueuer holder. The Telegram entry needs the
+	// Telegram aggregation engine, which is constructed later (inside
+	// the cfg.Features.EnableTelegramSync branch). The worker is
+	// constructed earlier, so we wrap the registry in a deferred
+	// pointer that the Telegram branch fills in once the engine
+	// exists. When Telegram is disabled the registry's telegram entry
+	// stays unset and the consumer's reenqueue degrades to "no entry
+	// registered for source" (logged warn) — safe, the consumer's
+	// interaction has already committed.
+	aggregatorReenqueuerHolder := &deferredAggregatorReenqueuer{}
+
+	// CadenceUpdater must be constructed BEFORE InteractionRecorder so
+	// the recorder can inline-invoke it after bus.PublishTx on fresh
+	// writes. Wired here even though its worker is registered further
+	// down, so the construction order matches the runtime dispatch
+	// order. contactRepo.SetPool is called at the first writer-path
+	// construction so the cadence updater can open its own tx if ever
+	// needed outside the caller's tx (defensive — the current path
+	// always runs in the caller's tx).
+	contactRepo.SetPool(database.Pool)
+	eventClaimRepo := repository.NewEventConsumerClaimRepository(database.Queries)
+	cadenceUpdater := consumer.NewCadenceUpdater(
+		eventClaimRepo,
+		contactRepo,
+		database.Queries,
+		consumer.CadenceModeFromConfig(cfg.EventBus.CadenceMode),
+		cfg.EventBus.UnsafeAllowOffMode,
+	)
+
+	// Wire CadenceUpdater into ContactService so Merge / Extend / Promote
+	// / UpdateContact cadence-edit paths route cadence writes through
+	// the sole writer.
+	contactService.SetCadenceUpdater(cadenceUpdater)
+
+	// Knowledge-cache consumer (the location/birthday/how_met authority flip):
+	// the sole writer of those three derived cache columns. ContactService emits
+	// lives_in/birthday/how_met assertions through AssertService and calls
+	// knowledgeCacheUpdater.RefreshTx inline (no read-path gap on a user edit);
+	// the registered KnowledgeCacheUpdaterWorker (below) handles assertion.accepted
+	// /superseded events from any other producer (extractors, rollover, retraction).
+	knowledgeCacheUpdater := consumer.NewKnowledgeCacheUpdater(graphAssertionRepo, graphNodeRepo, contactRepo)
+	contactService.SetKnowledgeWriter(assertService, knowledgeCacheUpdater)
+
+	// Todoist client factory, built once with the running CRM_ENV so the
+	// outbound-write guard (Spec C) applies at every production write site.
+	// Non-prod instances holding real OAuth tokens (a restored prod DB, a
+	// partial env copy) refuse Todoist writes; see todoist.ErrNonProdWriteRefused.
+	todoistClientFactory := todoist.NewClientFactory(cfg.Runtime.CRMEnvironment)
+	if config.IsProductionCRMEnv(cfg.Runtime.CRMEnvironment) {
+		// Logged at Warn so it survives prod's LOG_LEVEL=warn threshold — this
+		// is the operator-facing signal that writes are live. Expected on every
+		// prod boot; the stable "event" field lets alerting route it as
+		// informational.
+		logger.Warn().
+			Str("event", "todoist_writes_enabled").
+			Str("crm_env", cfg.Runtime.CRMEnvironment).
+			Bool("todoist_writes_enabled", true).
+			Msg("Todoist outbound writes ENABLED (production CRM_ENV)")
+	} else {
+		logger.Info().
+			Str("event", "todoist_writes_enabled").
+			Str("crm_env", cfg.Runtime.CRMEnvironment).
+			Bool("todoist_writes_enabled", false).
+			Msg("Todoist outbound writes refused (non-production CRM_ENV)")
+	}
+
+	// FollowUpManager consumer — the sole writer of
+	// contact_task.kind='follow_up' lifecycle post-cutover. Constructed
+	// BEFORE the InteractionRecorder because the recorder takes it as a
+	// constructor arg (inline-invoke on fresh writes). Todoist settings
+	// are looked up via a deferred holder populated later in the
+	// external-sync branch; until populated, Todoist-dependent post-
+	// commit paths (refresh item_update, close retries) degrade to
+	// local-only writes with a logged warning.
+	followUpMode := consumer.FollowUpModeFromConfig(cfg.EventBus.FollowUpMode)
+	followUpSettingsHolder := &followUpSettingsRef{frontendURL: cfg.CORS.FrontendURL}
+	followUpSettings := followUpSettingsHolder.fn()
+	followUpManager := consumer.NewFollowUpManager(
+		followUpMode,
+		eventClaimRepo,
+		contactRepo,
+		contactTaskRepo,
+		contactTaskRepo,
+		interactionRepo,
+		riverClient,
+		database.Pool,
+		followUpSettings,
+		todoistClientFactory,
+		cfg.CORS.FrontendURL,
+		cfg.Watchdog,
+	)
+	// Wire the consumer as the sole follow-up writer on the direct path.
+	// Non-bus callers (Todoist completion, Promote/Extend) route through
+	// FollowUpManager.ApplyInteraction via ContactService.
+	contactService.SetFollowUpConsumer(followUpManager)
+
+	// Wire the merge-time task-close enqueuer. MergeContacts closes the
+	// source contact's live automated tasks and enqueues the durable Todoist
+	// close job for rows with a real external id; the mode gate matches the
+	// close worker's cutover-only contract (enqueuing in mode 'off' would
+	// only manufacture failing jobs — merge then closes locally with a WARN,
+	// that mode's documented "completion disabled" semantics).
+	contactService.SetTaskCloseEnqueuer(riverClient, cfg.EventBus.FollowUpMode == config.EventBusFollowUpModeCutover)
+
+	// InteractionRecorder consumer + manual handler (spec §3.4.1).
+	// Delegates the write to ContactService.RecordInteractionTx, then
+	// marks telegram_messages processed (for message.* kinds) and emits
+	// interaction.recorded — all inside the caller's tx. After emitting
+	// interaction.recorded, the recorder inline-invokes
+	// cadenceUpdater.HandleEvent + followUpManager.HandleEvent on
+	// fresh writes so cadence + follow-up state apply synchronously and
+	// queued re-deliveries become durable no-ops via
+	// event_consumer_claim.
+	interactionRecorder := consumer.NewInteractionRecorder(
+		contactService,
+		stagingRegistry,
+		eventBus,
+		cadenceUpdater,
+		followUpManager,
+		// calendarRepoForIngest satisfies calendarEventLocker: the
+		// calendar.attended branch takes a FOR SHARE lock on the backing
+		// calendar_event so a concurrent decline DELETE cannot strand a
+		// false interaction.
+		calendarRepoForIngest,
+	)
+	// Populate interaction.venue_id for message.* (telegram/messages/gchat) and
+	// gcal interactions this recorder writes.
+	interactionRecorder.SetVenueResolver(venueResolver)
+
+	return eventConsumers{
+		AggregatorReenqueuerHolder: aggregatorReenqueuerHolder,
+		EventClaimRepo:             eventClaimRepo,
+		CadenceUpdater:             cadenceUpdater,
+		KnowledgeCacheUpdater:      knowledgeCacheUpdater,
+		TodoistClientFactory:       todoistClientFactory,
+		FollowUpMode:               followUpMode,
+		FollowUpSettingsHolder:     followUpSettingsHolder,
+		FollowUpSettings:           followUpSettings,
+		FollowUpManager:            followUpManager,
+		InteractionRecorder:        interactionRecorder,
+	}
+}

--- a/backend/cmd/crm-api/wire_core.go
+++ b/backend/cmd/crm-api/wire_core.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+)
+
+// coreRepos holds the six core-entity repositories every downstream
+// service depends on.
+type coreRepos struct {
+	Contact       *repository.ContactRepository
+	ContactMethod *repository.ContactMethodRepository
+	Note          *repository.NoteRepository
+	Interaction   *repository.InteractionRepository
+	ContactTask   *repository.ContactTaskRepository
+	Enrichment    *repository.EnrichmentRepository
+}
+
+// buildCoreRepos constructs the core-entity repositories.
+func buildCoreRepos(queries db.Querier) coreRepos {
+	return coreRepos{
+		Contact:       repository.NewContactRepository(queries),
+		ContactMethod: repository.NewContactMethodRepository(queries),
+		Note:          repository.NewNoteRepository(queries),
+		Interaction:   repository.NewInteractionRepository(queries),
+		ContactTask:   repository.NewContactTaskRepository(queries),
+		Enrichment:    repository.NewEnrichmentRepository(queries),
+	}
+}
+
+// ingestRepos holds the repositories + identity service the ingest path
+// needs. The host-auth ingest path (raw_message.* envelopes from the Mac
+// daemon) needs a tx-bound identity matcher so the per-event savepoint can
+// roll back the identity write atomically with the staging-row insert on
+// failure. The external-sync block constructs its own IdentityService for
+// the providers that use it — IdentityService is stateless so the two
+// instances are interchangeable.
+type ingestRepos struct {
+	Identity        *repository.IdentityRepository
+	IdentityService *service.IdentityService
+	MessagesMessage *repository.MessagesMessageRepository
+	ExternalContact *repository.ExternalContactRepository
+	MacHost         *repository.MacHostRepository
+	MeetingNote     *repository.MeetingNoteRepository
+	CalendarEvent   *repository.CalendarEventRepository
+	PhoneCall       *repository.PhoneCallRepository
+}
+
+// buildIngestRepos constructs the repositories + identity service used by
+// the IngestService and its inline event handlers. Constructed
+// unconditionally because the IngestService is always wired even when
+// external sync is disabled — the daemon can still call
+// /api/v1/ingest/events on a host-auth path. Several of these instances
+// are reused later by the external-sync / mac-host / calendar blocks; the
+// repositories are stateless so pointing two instances at the same queries
+// is safe.
+func buildIngestRepos(queries db.Querier) ingestRepos {
+	identityRepo := repository.NewIdentityRepository(queries)
+	return ingestRepos{
+		Identity:        identityRepo,
+		IdentityService: service.NewIdentityService(identityRepo),
+		MessagesMessage: repository.NewMessagesMessageRepository(queries),
+		ExternalContact: repository.NewExternalContactRepository(queries),
+		MacHost:         repository.NewMacHostRepository(queries),
+		MeetingNote:     repository.NewMeetingNoteRepository(queries),
+		CalendarEvent:   repository.NewCalendarEventRepository(queries),
+		PhoneCall:       repository.NewPhoneCallRepository(queries),
+	}
+}
+
+// contactCore holds the rematch service, contact service, and graph
+// (SP1) store built around the core repos + event bus.
+type contactCore struct {
+	RematchService *service.RematchService
+	ContactService *service.ContactService
+	GraphNode      *repository.NodeRepository
+	GraphEntity    *repository.EntityRepository
+	GraphPredicate *repository.PredicateRepository
+	GraphAssertion *repository.AssertionRepository
+	AssertService  *service.AssertService
+}
+
+// buildContactGraphCore constructs the rematch service (above
+// ContactService so it can be passed as the RematchRegistry constructor
+// arg), the ContactService, and the graph (SP1) write store. Handlers
+// register later once their dependencies are constructed.
+func buildContactGraphCore(database *db.Database, repos coreRepos, eventBus *events.Bus) contactCore {
+	// Rematch service — constructed above ContactService so it can be
+	// passed as the RematchRegistry constructor arg.
+	rematchService := service.NewRematchService()
+
+	contactService := service.NewContactService(database, repos.Contact, repos.ContactMethod, repos.Interaction, repos.ContactTask, eventBus, rematchService)
+
+	// Graph (SP1) write API — the single validated assert() write path over the
+	// node/entity/predicate/assertion store. SP1 ships the service + the daily
+	// rollover worker (registered below); no HTTP handler yet (SP3/SP4 consume it).
+	graphNodeRepo := repository.NewNodeRepository(database.Queries)
+	graphEntityRepo := repository.NewEntityRepository(database.Queries)
+	graphPredicateRepo := repository.NewPredicateRepository(database.Queries)
+	graphAssertionRepo := repository.NewAssertionRepository(database.Queries)
+	assertService := service.NewAssertService(
+		database.Pool, graphNodeRepo, graphEntityRepo, graphPredicateRepo, graphAssertionRepo, eventBus,
+	)
+
+	return contactCore{
+		RematchService: rematchService,
+		ContactService: contactService,
+		GraphNode:      graphNodeRepo,
+		GraphEntity:    graphEntityRepo,
+		GraphPredicate: graphPredicateRepo,
+		GraphAssertion: graphAssertionRepo,
+		AssertService:  assertService,
+	}
+}
+
+// messagingFoundation holds the message-store repositories, the
+// source-neutral staging registry, and the venue resolver — the shared
+// substrate the interaction recorders and aggregation engines build on.
+type messagingFoundation struct {
+	TelegramMessageRepo *repository.TelegramMessageRepository
+	CommsMessageRepo    *repository.CommsMessageRepository
+	StagingRegistry     *repository.StagingProcessorRegistry
+	VenueRepo           *repository.VenueRepository
+	VenueResolver       *repository.VenueResolverRegistry
+}
+
+// buildMessagingFoundation constructs the telegram + comms message repos,
+// the staging-processor registry (InteractionRecorder dispatches
+// MarkProcessedTx by env.Source to the right repository), and the venue
+// resolver (populates interaction.venue_id). messagesMessageRepo and
+// calendarRepo are reused from the ingest repos.
+func buildMessagingFoundation(queries db.Querier, messagesMessageRepo *repository.MessagesMessageRepository, calendarRepo *repository.CalendarEventRepository) messagingFoundation {
+	// Telegram message repo construction (hoisted above the
+	// InteractionRecorder wiring so the consumer can mark messages
+	// processed in the same tx as the interaction insert).
+	telegramMessageRepo := repository.NewTelegramMessageRepository(queries)
+	// Comms message repo (shared cross-source content store). Hoisted here
+	// so the staging registry below can add the gchat session-scoped
+	// processor; also reused by the email-consumer wiring + the gchat
+	// aggregation engine further down.
+	commsMessageRepo := repository.NewCommsMessageRepository(queries)
+
+	// Source-neutral staging registry — InteractionRecorder dispatches
+	// MarkProcessedTx by env.Source to the right repository. Unknown
+	// sources are a logged warning (not an error) so non-message kinds
+	// continue to bypass the registry without erroring.
+	stagingRegistry := repository.NewStagingProcessorRegistry(
+		map[string]repository.StagingProcessor{
+			repository.InteractionSourceTelegram: repository.NewTelegramStagingProcessor(telegramMessageRepo),
+			repository.InteractionSourceMessages: repository.NewMessagesStagingProcessor(messagesMessageRepo),
+			// GChat create-path: the InteractionRecorder consumer marks
+			// comms_message(source='gchat') rows processed via this
+			// session-scoped processor. Without it the recorder's
+			// zero-rows-affected rollback fires and the engine reprocesses
+			// forever. Inert until a chat provider writes gchat rows.
+			repository.InteractionSourceGChat: repository.NewCommsSessionStagingProcessor(commsMessageRepo),
+		},
+	)
+
+	// Venue resolution — populates interaction.venue_id (the shared-container
+	// node an interaction happened in). The registry routes message.* sources
+	// to per-source container readers and resolves gcal via the calendar 3-tuple;
+	// the venue repo also serves the email + phone + anarlog recorders directly.
+	// Wired into each recorder via its SetVenueResolver setter below.
+	venueRepo := repository.NewVenueRepository(queries)
+	venueResolver := repository.NewVenueResolverRegistry(
+		venueRepo,
+		map[string]repository.VenueContainerReader{
+			repository.InteractionSourceTelegram: repository.NewTelegramVenueContainerReader(),
+			repository.InteractionSourceMessages: repository.NewMessagesVenueContainerReader(),
+			repository.InteractionSourceGChat:    repository.NewGChatVenueContainerReader(),
+		},
+		calendarRepo,
+	)
+
+	return messagingFoundation{
+		TelegramMessageRepo: telegramMessageRepo,
+		CommsMessageRepo:    commsMessageRepo,
+		StagingRegistry:     stagingRegistry,
+		VenueRepo:           venueRepo,
+		VenueResolver:       venueResolver,
+	}
+}

--- a/backend/cmd/crm-api/wire_golden_test.go
+++ b/backend/cmd/crm-api/wire_golden_test.go
@@ -1,0 +1,252 @@
+//go:build integration_testdb
+
+// Golden-list regression pin for the composition-root wire split (contract 7,
+// PR4). River's public API does not enumerate registered workers or periodic
+// jobs, so the wire functions register through riverRegistrar, which records
+// the kind of every worker + periodic job. This test drives the wire chain in
+// run()'s exact order (MINUS buildTelegram — see the telegram-skip rule) per
+// config shape and asserts the recorded worker/periodic kinds + the
+// provider-registry contents against golden lists.
+//
+// Telegram-skip rule: buildTelegram calls telegramManager.Start(ctx), which
+// must never run in a test. Skipping it is behavior-faithful for this pin —
+// telegram registers NO workers, NO periodic jobs, and NO providers, and
+// buildAggregationEngines takes telegramManager as a nil-safe param (nil ==
+// telegram-disabled boot). So shape 4 (telegram) asserts lists IDENTICAL to
+// shape 1 (base), which is exactly what the source inventory proves.
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"testing"
+
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/logger"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/testdb"
+
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(testdb.SetupPackage(m, testdb.WithMigrationsPath(migrationsPathForTest())))
+}
+
+// migrationsPathForTest resolves the migrations dir relative to this test file
+// (cmd/crm-api → ../../migrations), honoring an absolute MIGRATIONS_PATH override.
+func migrationsPathForTest() string {
+	if path := os.Getenv("MIGRATIONS_PATH"); path != "" && filepath.IsAbs(path) {
+		return path
+	}
+	_, filename, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(filename), "..", "..", "migrations")
+}
+
+// --- golden lists (sorted) -------------------------------------------------
+
+// baseWorkerKinds is the 16 unconditionally-registered workers (shapes 1 & 4).
+var baseWorkerKinds = sortedCopy([]string{
+	"noop",
+	"interaction_recorder",
+	"calendar_decline_handler",
+	"email_interaction_consumer",
+	"cadence_updater",
+	"knowledge_cache_updater",
+	"followup_manager",
+	"todoist_followup_create",
+	"todoist_followup_close",
+	"todoist_followup_refresh",
+	"rematch_dispatcher",
+	"messaging_aggregate_for_contact",
+	"messaging_aggregate_sweeper",
+	"pairing_token_janitor",
+	"sync_staleness_watchdog",
+	"assertion_rollover",
+})
+
+// syncWorkerKinds adds the two external-sync-gated workers (shapes 3 & 6).
+var syncWorkerKinds = sortedCopy(append([]string{
+	"scheduler_tick",
+	"sync_provider_account",
+}, baseWorkerKinds...))
+
+// basePeriodicKinds is the 4 unconditionally-registered periodic jobs.
+var basePeriodicKinds = sortedCopy([]string{
+	"messaging_aggregate_sweeper",
+	"pairing_token_janitor",
+	"sync_staleness_watchdog",
+	"assertion_rollover",
+})
+
+// syncPeriodicKinds adds the external-sync-gated scheduler tick.
+var syncPeriodicKinds = sortedCopy(append([]string{"scheduler_tick"}, basePeriodicKinds...))
+
+// shape3Providers is the fully-configured external-sync provider set.
+var shape3Providers = sortedCopy([]string{
+	"gcontacts", "gcal", "email", "gchat", "todoist",
+	"messages", "icloud_contacts", "phone_calls",
+})
+
+// shape6Providers drops gmail ("email") — interaction-mode off ⇒ pubBus nil ⇒
+// the Gmail provider is NOT registered (INV-3 registry pin).
+var shape6Providers = sortedCopy([]string{
+	"gcontacts", "gcal", "gchat", "todoist",
+	"messages", "icloud_contacts", "phone_calls",
+})
+
+func TestWireGoldenLists(t *testing.T) {
+	t.Parallel()
+	if os.Getenv("DATABASE_URL") == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+
+	tests := []struct {
+		name          string
+		mutate        func(*config.Config)
+		wantWorkers   []string
+		wantPeriodic  []string
+		wantProviders []string // nil ⇒ external sync disabled, no provider assertion
+	}{
+		{
+			name:         "shape1_base",
+			mutate:       func(c *config.Config) {},
+			wantWorkers:  baseWorkerKinds,
+			wantPeriodic: basePeriodicKinds,
+		},
+		{
+			name: "shape3_external_sync",
+			mutate: func(c *config.Config) {
+				c.Features.EnableExternalSync = true
+			},
+			wantWorkers:   syncWorkerKinds,
+			wantPeriodic:  syncPeriodicKinds,
+			wantProviders: shape3Providers,
+		},
+		{
+			name: "shape4_telegram",
+			mutate: func(c *config.Config) {
+				// Telegram is skipped in the wire chain (Start must not run),
+				// so its worker/periodic lists equal shape 1's.
+				c.Features.EnableTelegramSync = true
+			},
+			wantWorkers:  baseWorkerKinds,
+			wantPeriodic: basePeriodicKinds,
+		},
+		{
+			name: "shape6_external_sync_interaction_off",
+			mutate: func(c *config.Config) {
+				c.Features.EnableExternalSync = true
+				c.EventBus.InteractionMode = config.EventBusInteractionModeOff
+			},
+			wantWorkers:   syncWorkerKinds,
+			wantPeriodic:  syncPeriodicKinds,
+			wantProviders: shape6Providers,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cloneURL, drop := testdb.NewEphemeralClone(t)
+			t.Cleanup(drop)
+
+			cfg := config.TestConfig()
+			cfg.Database.URL = cloneURL
+			cfg.Database.MigrationsPath = migrationsPathForTest()
+			tc.mutate(cfg)
+
+			reg, syncStk := buildWireChainForGolden(t, cfg)
+
+			require.Equal(t, tc.wantWorkers, sortedCopy(reg.workerKinds), "worker kinds")
+			require.Equal(t, tc.wantPeriodic, sortedCopy(reg.periodicKinds), "periodic kinds")
+
+			if tc.wantProviders != nil {
+				require.NotNil(t, syncStk.SyncService, "external sync should build a sync service")
+				var names []string
+				for _, c := range syncStk.SyncService.GetAvailableProviders() {
+					names = append(names, c.Name)
+				}
+				require.Equal(t, tc.wantProviders, sortedCopy(names), "provider registry contents")
+			}
+		})
+	}
+}
+
+// buildWireChainForGolden drives the wire chain in run()'s exact order, minus
+// buildTelegram (telegram-skip rule) and minus riverClient.Start / the HTTP
+// server. It returns the registrar (recording worker/periodic kinds) and the
+// external-sync stack (for provider enumeration).
+func buildWireChainForGolden(t *testing.T, cfg *config.Config) (*riverRegistrar, syncStack) {
+	t.Helper()
+	logger.Init(cfg.Logger)
+	ctx := context.Background()
+
+	database, err := db.NewDatabase(ctx, cfg.Database)
+	require.NoError(t, err)
+	t.Cleanup(func() { database.Close() })
+
+	core := buildCoreRepos(database.Queries)
+
+	riverWorkers := river.NewWorkers()
+	reg := newRiverRegistrar(riverWorkers)
+	addWorker(reg, &noopWorker{})
+
+	riverClient, err := river.NewClient(riverpgxv5.New(database.Pool), &river.Config{
+		JobTimeout: cfg.River.JobTimeout,
+		Queues: map[string]river.QueueConfig{
+			river.QueueDefault: {MaxWorkers: cfg.River.WorkerConcurrency},
+		},
+		Workers:                     riverWorkers,
+		ErrorHandler:                events.NewRiverErrorHandler(logger.Get()),
+		Logger:                      logger.NewSlogLogger(logger.Get()),
+		DiscardedJobRetentionPeriod: riverDiscardedJobRetention,
+	})
+	require.NoError(t, err)
+	reg.periodic = riverClient.PeriodicJobs()
+
+	eventRepo := repository.NewEventRepository(database.Queries)
+	eventBus := events.NewBus(database.Pool, riverClient, eventRepo)
+
+	ingest := buildIngestRepos(database.Queries)
+	graph := buildContactGraphCore(database, core, eventBus)
+	messaging := buildMessagingFoundation(database.Queries, ingest.MessagesMessage, ingest.CalendarEvent)
+	consumers := buildEventConsumers(cfg, database, core, graph, ingest, messaging, eventBus, riverClient)
+	ingestStk := buildIngestStack(database, core, graph, ingest, messaging, consumers, eventBus, riverClient)
+	registerCoreConsumerWorkers(reg, database, core, graph, messaging, consumers, eventBus)
+	pubBus, _ := resolveInteractionMode(cfg, database, consumers, eventBus)
+	registerModeWorkers(reg, cfg, database, core, consumers, eventBus, riverClient)
+	domain := buildDomainServices(database, core, graph, ingest, consumers, ingestStk, eventBus)
+	registerRematchDispatcher(reg, graph, database, eventBus)
+
+	var syncStk syncStack
+	if cfg.Features.EnableExternalSync {
+		syncStk = buildExternalSync(ctx, cfg, database, core, graph, ingest, messaging, consumers, domain, eventBus, riverClient, pubBus)
+	}
+
+	// Telegram is intentionally SKIPPED (Start must not run); a nil
+	// telegramManager is exactly a telegram-disabled boot for aggregation.
+	agg := buildAggregationEngines(database, core, graph, ingest, messaging, consumers, eventBus, riverClient, nil, syncStk.GChatProvider, syncStk.GChatSyncStates)
+	registerMessagingWorkers(reg, ingest, messaging, agg, riverClient)
+
+	machost := buildMacHost(reg, database, core, ingest)
+	buildStaleness(reg, cfg, database, machost)
+	registerAssertionRollover(reg, graph)
+	registerSyncScheduler(reg, cfg, syncStk, riverClient)
+
+	return reg, syncStk
+}
+
+func sortedCopy(in []string) []string {
+	out := append([]string(nil), in...)
+	sort.Strings(out)
+	return out
+}

--- a/backend/cmd/crm-api/wire_google.go
+++ b/backend/cmd/crm-api/wire_google.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"personal-crm/backend/internal/api/handlers"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/google"
+	"personal-crm/backend/internal/logger"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+	"personal-crm/backend/internal/sync"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// buildGoogleOAuth initializes the Google OAuth service (and its OAuth
+// handler) when GOOGLE_CLIENT_ID/SECRET are configured. Returns (nil, nil)
+// when unconfigured or when construction fails (logged warn) — exactly the
+// original nil semantics.
+func buildGoogleOAuth(cfg *config.Config, oauthRepo *repository.OAuthRepository, syncRepo *repository.SyncRepository) (*google.OAuthService, *handlers.OAuthHandler) {
+	if cfg.Google.ClientID != "" && cfg.Google.ClientSecret != "" {
+		googleOAuthService, err := google.NewOAuthService(cfg, oauthRepo, syncRepo)
+		if err != nil {
+			logger.Warn().Err(err).Msg("failed to initialize Google OAuth service")
+			return nil, nil
+		}
+		oauthHandler := handlers.NewOAuthHandler(googleOAuthService, cfg.CORS.FrontendURL)
+		logger.Info().Msg("Google OAuth service initialized")
+		return googleOAuthService, oauthHandler
+	}
+	logger.Info().Msg("Google OAuth not configured (GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET required)")
+	return nil, nil
+}
+
+// googleProviderDeps carries the collaborators registerGoogleProviders needs.
+// pubBus is a CONCRETE *events.Bus (nil in interaction-mode off) — never an
+// interface — so the Gmail typed-nil trap (INV-3) cannot be introduced.
+type googleProviderDeps struct {
+	GoogleOAuthService          *google.OAuthService
+	ProviderRegistry            *sync.ProviderRegistry
+	RematchService              *service.RematchService
+	CalendarRepo                *repository.CalendarEventRepository
+	ContactRepo                 *repository.ContactRepository
+	ExternalContactRepo         *repository.ExternalContactRepository
+	EnrichmentService           *service.EnrichmentService
+	IdentityService             *service.IdentityService
+	AddressBookReconcileService *service.AddressBookReconcileService
+	CommsMessageRepo            *repository.CommsMessageRepository
+	SyncRepo                    *repository.SyncRepository
+	PubBus                      *events.Bus
+	Pool                        *pgxpool.Pool
+}
+
+// registerGoogleProviders registers the Google Contacts, Calendar, Gmail
+// (cutover-only), and GChat sync providers into the registry, plus their
+// rematch handlers. Called only when googleOAuthService != nil. Returns the
+// GChat provider + enabled-state lister (hoisted for the late gchat rematch
+// block outside the external-sync branch).
+func registerGoogleProviders(deps googleProviderDeps) (*google.GChatSyncProvider, google.GChatSyncStateLister) {
+	gcontactsProvider := google.NewContactsProvider(
+		deps.GoogleOAuthService,
+		deps.ExternalContactRepo,
+		deps.EnrichmentService,
+		deps.IdentityService,
+		deps.AddressBookReconcileService,
+	)
+	deps.ProviderRegistry.Register(gcontactsProvider)
+	logger.Info().Msg("Google Contacts sync provider registered")
+
+	// Register Google Calendar provider
+	gcalProvider := google.NewCalendarSyncProvider(
+		deps.GoogleOAuthService,
+		deps.CalendarRepo,
+		deps.ContactRepo,
+		deps.IdentityService,
+		deps.ExternalContactRepo,
+		deps.PubBus,
+		deps.Pool,
+	)
+	deps.ProviderRegistry.Register(gcalProvider)
+	logger.Info().Msg("Google Calendar sync provider registered")
+
+	// Gmail provider + rematch handler: publisher-driven, so register
+	// ONLY in cutover mode. In off-mode pubBus is a nil *events.Bus;
+	// passing it into the provider's busTx interface field would create
+	// a non-nil-interface-wrapping-typed-nil and bypass the provider's
+	// own `bus == nil` guard, panicking on the first PublishTx. Off-mode
+	// is an emergency rollback posture where no publisher should run.
+	// commsMessageRepo is reused from the email-consumer wiring above.
+	if deps.PubBus != nil {
+		gmailProvider := google.NewGmailSyncProvider(
+			deps.GoogleOAuthService,
+			deps.CommsMessageRepo,
+			deps.PubBus,
+			deps.Pool,
+		)
+		deps.ProviderRegistry.Register(gmailProvider)
+		// syncRepo is the enabled-email-states lister: the rematch scan
+		// runs only over accounts whose email sync is enabled (the same
+		// gate the scheduler uses), not every connected OAuth account.
+		deps.RematchService.Register(google.NewGmailRematchHandler(
+			gmailProvider,
+			deps.SyncRepo,
+			deps.CommsMessageRepo,
+		))
+		// Correspondence discovery: an in-sync hook that runs the link-only
+		// candidate gate over every fetched message's From/To/Cc
+		// participants (between fetch and storage), so multi-party threads
+		// the storage gate drops still surface unknown addresses that
+		// strong-match an existing contact. Wired into the provider via a
+		// setter (nil-safe; the hook is a no-op when unset). No periodic
+		// job — discovery piggybacks the existing sync fetch.
+		gmailProvider.SetCorrespondenceDiscoverer(google.NewCorrespondenceDiscoverer(
+			deps.ContactRepo,
+			deps.ExternalContactRepo,
+		))
+		logger.Info().Msg("Gmail sync provider + rematch handler + correspondence discovery registered")
+	} else {
+		logger.Warn().Msg("Gmail provider NOT registered: event-bus interaction mode=off (pubBus nil)")
+	}
+
+	// GChat provider: registered into providerRegistry so the scheduler
+	// can run it — this is the go-live switch (PR 3). It stays inert
+	// until enablement reconciliation creates an enabled gchat sync state
+	// (no state → ListDueSyncStates filters enabled=TRUE → nothing to
+	// dispatch). It is store-only + event-free, so unlike Gmail it does
+	// NOT gate on pubBus. gchatSyncStates = syncRepo is the enabled-state
+	// lister the gchat rematch handlers gate on (registered in the late
+	// depth-0 block).
+	gchatProvider := google.NewGChatSyncProvider(
+		deps.GoogleOAuthService,
+		deps.CommsMessageRepo,
+		deps.SyncRepo,
+	)
+	var gchatSyncStates google.GChatSyncStateLister = deps.SyncRepo
+	deps.ProviderRegistry.Register(gchatProvider)
+	logger.Info().Msg("GChat sync provider registered (inert until a gchat sync state is enabled)")
+
+	return gchatProvider, gchatSyncStates
+}

--- a/backend/cmd/crm-api/wire_handlers.go
+++ b/backend/cmd/crm-api/wire_handlers.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"personal-crm/backend/internal/api/handlers"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/service"
+)
+
+// coreHandlers holds the always-on HTTP handlers consumed by route
+// registration.
+type coreHandlers struct {
+	Contact     *handlers.ContactHandler
+	Note        *handlers.NoteHandler
+	Interaction *handlers.InteractionHandler
+	System      *handlers.SystemHandler
+	Rematch     *handlers.RematchHandler
+}
+
+// buildCoreHandlers constructs the contact / note / interaction / system /
+// rematch handlers. manualHandler is nil in interaction-mode off (the
+// InteractionHandler tolerates a nil manual handler exactly as today).
+func buildCoreHandlers(
+	core coreRepos,
+	graph contactCore,
+	cfg *config.Config,
+	noteService *service.NoteService,
+	manualHandler *service.ManualInteractionHandler,
+) coreHandlers {
+	contactRepo := core.Contact
+	interactionRepo := core.Interaction
+	contactService := graph.ContactService
+	rematchService := graph.RematchService
+
+	return coreHandlers{
+		Contact:     handlers.NewContactHandler(contactService),
+		Note:        handlers.NewNoteHandler(noteService),
+		Interaction: handlers.NewInteractionHandler(interactionRepo, manualHandler),
+		System:      handlers.NewSystemHandler(contactRepo, cfg.Runtime),
+		Rematch:     handlers.NewRematchHandler(rematchService, contactService),
+	}
+}

--- a/backend/cmd/crm-api/wire_ingest.go
+++ b/backend/cmd/crm-api/wire_ingest.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"personal-crm/backend/internal/anarlog"
+	"personal-crm/backend/internal/api/handlers"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/service"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/riverqueue/river"
+)
+
+// ingestStack holds the IngestService (its AddressBookReconciler is wired
+// later, in buildDomainServices) plus the ingest + meeting-note handlers
+// consumed by route registration.
+type ingestStack struct {
+	IngestService      *service.IngestService
+	IngestHandler      *handlers.IngestHandler
+	MeetingNoteHandler *handlers.MeetingNoteHandler
+}
+
+// buildIngestStack constructs the IngestService (hoisted after the
+// consumers so the call.* inline handler can reuse contactService +
+// cadenceUpdater + followUpManager + eventBus to emit interaction.recorded
+// and apply cadence/follow-up in the same tx as the phone_call staging-row
+// write) and the meeting-note conflict-resolution surface. The
+// AddressBookReconciler back-reference is set later in buildDomainServices.
+func buildIngestStack(
+	database *db.Database,
+	core coreRepos,
+	graph contactCore,
+	ingest ingestRepos,
+	messaging messagingFoundation,
+	consumers eventConsumers,
+	eventBus *events.Bus,
+	riverClient *river.Client[pgx.Tx],
+) ingestStack {
+	contactRepo := core.Contact
+	interactionRepo := core.Interaction
+	contactService := graph.ContactService
+	identityServiceForIngest := ingest.IdentityService
+	messagesMessageRepo := ingest.MessagesMessage
+	externalContactRepoForIngest := ingest.ExternalContact
+	macHostRepoForIngest := ingest.MacHost
+	meetingNoteRepoForIngest := ingest.MeetingNote
+	calendarRepoForIngest := ingest.CalendarEvent
+	phoneCallRepoForIngest := ingest.PhoneCall
+	identityRepoForIngest := ingest.Identity
+	cadenceUpdater := consumers.CadenceUpdater
+	followUpManager := consumers.FollowUpManager
+	venueResolver := messaging.VenueResolver
+
+	// IngestService — hoisted here so the call.* inline handler can
+	// reuse contactService.RecordInteractionTx, cadenceUpdater,
+	// followUpManager, and eventBus.PublishTx to emit
+	// interaction.recorded + apply cadence + follow-up in the SAME tx
+	// as the phone_call staging row write (spec §`phone_calls`
+	// content-delivered cadence). raw_message.* and external_contact.*
+	// inline handlers don't need these four — they were nil before the
+	// v1.5 expansion. The meeting_note.* inline handler reuses
+	// contactService via the ContactInteractionRecorder interface for
+	// session-attributed interaction writes so cadence + follow-up
+	// fire correctly.
+	//
+	// anarlog title-extraction deps for the meeting_note.recorded inline
+	// handler: TitleMatcher disambiguates a single name token against
+	// the CRM contact table (trigram + collision-gap); DiscoveryWriter
+	// persists weak-candidate anarlog_title rows for unmatched tokens.
+	titleMatcher := anarlog.NewTitleMatcher(contactRepo)
+	titleDiscoveryWriter := anarlog.NewDiscoveryWriter(externalContactRepoForIngest)
+	ingestService := service.NewIngestService(
+		database,
+		eventBus,
+		identityServiceForIngest,
+		messagesMessageRepo,
+		riverClient,
+		externalContactRepoForIngest,
+		macHostRepoForIngest, // host-liveness re-check inside the batch tx
+		meetingNoteRepoForIngest,
+		calendarRepoForIngest,
+		interactionRepo,
+		identityRepoForIngest,
+		contactService,
+		phoneCallRepoForIngest,
+		contactService,
+		cadenceUpdater,
+		followUpManager,
+		titleMatcher,
+		titleDiscoveryWriter,
+		phoneCallRepoForIngest, // phone_call linkage candidates for meeting_note Step 1
+	)
+	// Populate interaction.venue_id for phone_calls + anarlog_sessions
+	// interactions the ingest inline handlers write.
+	ingestService.SetVenueResolver(venueResolver)
+	ingestHandler := handlers.NewIngestHandler(ingestService)
+
+	// User-driven conflict-resolution surface for meeting_note rows.
+	// Mirrors the daemon-side IngestService.handleMeetingNoteRecorded
+	// path; uses a small adapter to satisfy the polymorphic
+	// LinkageTargetReader interface (event vs phone_call lookup by UUID).
+	meetingNoteLinkageTargets := service.NewLinkageTargetReader(calendarRepoForIngest, phoneCallRepoForIngest)
+	meetingNoteService := service.NewMeetingNoteService(
+		database,
+		meetingNoteRepoForIngest,
+		meetingNoteRepoForIngest,
+		meetingNoteLinkageTargets,
+		identityRepoForIngest,
+		titleMatcher,
+		titleDiscoveryWriter,
+		contactService,
+		contactRepo,
+	)
+	// Populate venue_id on the resolve-link interaction path.
+	meetingNoteService.SetVenueResolver(venueResolver)
+	meetingNoteHandler := handlers.NewMeetingNoteHandler(meetingNoteService)
+
+	return ingestStack{
+		IngestService:      ingestService,
+		IngestHandler:      ingestHandler,
+		MeetingNoteHandler: meetingNoteHandler,
+	}
+}

--- a/backend/cmd/crm-api/wire_machost.go
+++ b/backend/cmd/crm-api/wire_machost.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"time"
+
+	"personal-crm/backend/internal/api/handlers"
+	"personal-crm/backend/internal/auth"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/scheduler"
+	"personal-crm/backend/internal/service"
+
+	"github.com/riverqueue/river"
+)
+
+// macHostStack holds the mac-host repo, pool-wired sync repo, and handler
+// consumed downstream by route registration + the staleness watchdog.
+type macHostStack struct {
+	Repo     *repository.MacHostRepository
+	SyncRepo *repository.SyncRepository
+	Handler  *handlers.MacHostHandler
+}
+
+// buildMacHost wires the Mac-daemon host management (pairing flow,
+// heartbeat, cursor protocol, admin revoke) and registers the
+// pairing-token janitor worker + its periodic job.
+func buildMacHost(reg *riverRegistrar, database *db.Database, core coreRepos, ingest ingestRepos) macHostStack {
+	contactMethodRepo := core.ContactMethod
+	externalContactRepoForIngest := ingest.ExternalContact
+	meetingNoteRepoForIngest := ingest.MeetingNote
+
+	// macHostRepoForIngest was constructed earlier so the IngestService
+	// could take it as a HostLivenessChecker dep. Reuse the same instance
+	// here so the host-management service shares the same repository wrapper.
+	macHostRepo := ingest.MacHost
+	pairingTokenRepo := repository.NewMacHostPairingTokenRepository(database.Queries)
+	// Mac cursor commit needs a tx — use the pool-wired SyncRepository.
+	macSyncRepo := repository.NewSyncRepositoryWithPool(database.Queries, database.Pool)
+	macHostService := service.NewMacHostService(
+		macHostRepo,
+		pairingTokenRepo,
+		macSyncRepo,
+		contactMethodRepo,
+		externalContactRepoForIngest, // /known-ids reader (external_contact)
+		meetingNoteRepoForIngest,     // /known-ids reader (anarlog_sessions)
+		database.Pool,
+		0, // default bcrypt cost
+	)
+	pairingIPLimiter := auth.NewPairingIPRateLimiter()
+	macHostHandler := handlers.NewMacHostHandler(macHostService, pairingIPLimiter)
+
+	// Register the pairing-token janitor periodic job (5 min). Worker
+	// registered unconditionally; the periodic-job inserter triggers it
+	// on the same River client. See
+	// backend/internal/scheduler/pairing_token_janitor_worker.go.
+	addWorker(reg, scheduler.NewPairingTokenJanitorWorker(pairingTokenRepo))
+	reg.addPeriodic(scheduler.PairingTokenJanitorArgs{}.Kind(), river.NewPeriodicJob(
+		river.PeriodicInterval(5*time.Minute),
+		func() (river.JobArgs, *river.InsertOpts) {
+			return scheduler.PairingTokenJanitorArgs{}, nil
+		},
+		&river.PeriodicJobOpts{RunOnStart: true},
+	))
+
+	return macHostStack{
+		Repo:     macHostRepo,
+		SyncRepo: macSyncRepo,
+		Handler:  macHostHandler,
+	}
+}

--- a/backend/cmd/crm-api/wire_river.go
+++ b/backend/cmd/crm-api/wire_river.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"github.com/riverqueue/river"
+)
+
+// riverRegistrar is a thin recording delegate over River's worker bundle
+// and periodic-job bundle. River's public API does not enumerate
+// registered workers or periodic jobs (river.Workers and PeriodicJobBundle
+// are opaque; the startup log prints only concurrency), so the wire
+// functions register through this delegate instead of calling
+// river.AddWorker / PeriodicJobs().Add directly. Each registration is
+// recorded as a kind string, which the golden-list test reads back to pin
+// the worker/periodic registration set per config shape.
+//
+// The delegation is behavior-identical to the direct calls: addWorker does
+// exactly what river.AddWorker does plus one slice append of the args
+// type's Kind() (a side-effect-free value method on every args type), and
+// addPeriodic does exactly what PeriodicJobs().Add does plus one append.
+//
+// Two-phase construction: the registrar is built around riverWorkers
+// BEFORE river.NewClient (so the noopWorker registration is recorded), and
+// its periodic field is attached immediately after river.NewClient returns
+// (reg.periodic = riverClient.PeriodicJobs()). Every addPeriodic call
+// happens later in the wire chain, so the late attach is safe by
+// construction; the nil-check in addPeriodic guards misuse loudly.
+type riverRegistrar struct {
+	workers  *river.Workers
+	periodic *river.PeriodicJobBundle
+
+	workerKinds   []string
+	periodicKinds []string
+}
+
+// newRiverRegistrar builds a registrar around an existing worker bundle.
+// The periodic bundle is attached later (after river.NewClient).
+func newRiverRegistrar(workers *river.Workers) *riverRegistrar {
+	return &riverRegistrar{workers: workers}
+}
+
+// addWorker registers a worker on the underlying bundle and records its
+// job-args Kind(). Pure delegation to river.AddWorker plus one append.
+func addWorker[T river.JobArgs](r *riverRegistrar, w river.Worker[T]) {
+	river.AddWorker(r.workers, w)
+	var t T
+	r.workerKinds = append(r.workerKinds, t.Kind())
+}
+
+// addPeriodic registers a periodic job on the attached bundle and records
+// its kind. The kind is the args type's Kind() at the call site
+// (source-locked to the job it registers). Panics if called before the
+// periodic bundle is attached (a wiring-order bug, never reachable in the
+// current construction order).
+func (r *riverRegistrar) addPeriodic(kind string, job *river.PeriodicJob) {
+	if r.periodic == nil {
+		panic("riverRegistrar: addPeriodic before periodic bundle attached")
+	}
+	r.periodic.Add(job)
+	r.periodicKinds = append(r.periodicKinds, kind)
+}

--- a/backend/cmd/crm-api/wire_scheduler.go
+++ b/backend/cmd/crm-api/wire_scheduler.go
@@ -4,9 +4,13 @@ import (
 	"context"
 	"time"
 
+	"personal-crm/backend/internal/api/handlers"
+	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/consumer/consumerjobs"
+	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/scheduler"
+	"personal-crm/backend/internal/service"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -69,4 +73,96 @@ func registerMessagingWorkers(
 		},
 		&river.PeriodicJobOpts{RunOnStart: true},
 	))
+}
+
+// stalenessStack holds the staleness service (consumed by the health
+// checker) + its handler (consumed by route registration).
+type stalenessStack struct {
+	Service *service.StalenessService
+	Handler *handlers.StalenessHandler
+}
+
+// buildStaleness wires the sync-staleness watchdog. Registered
+// unconditionally (like the janitor): heartbeat/push breaches must be
+// detected even with external sync off, and the watchdog reads existing
+// freshness state rather than driving any provider sync. The endpoint
+// reader uses the same service instance.
+func buildStaleness(reg *riverRegistrar, cfg *config.Config, database *db.Database, machost macHostStack) stalenessStack {
+	macSyncRepo := machost.SyncRepo
+	macHostRepo := machost.Repo
+
+	stalenessBreachRepo := repository.NewStalenessRepository(database.Queries)
+	stalenessService := service.NewStalenessService(
+		cfg.Staleness,
+		cfg.Features.EnableExternalSync,
+		macSyncRepo,
+		macHostRepo,
+		stalenessBreachRepo,
+	)
+	stalenessHandler := handlers.NewStalenessHandler(stalenessService)
+	addWorker(reg, scheduler.NewStalenessWatchdogWorker(stalenessService))
+	reg.addPeriodic(scheduler.StalenessWatchdogArgs{}.Kind(), river.NewPeriodicJob(
+		river.PeriodicInterval(5*time.Minute),
+		func() (river.JobArgs, *river.InsertOpts) {
+			return scheduler.StalenessWatchdogArgs{}, nil
+		},
+		&river.PeriodicJobOpts{RunOnStart: true},
+	))
+
+	return stalenessStack{
+		Service: stalenessService,
+		Handler: stalenessHandler,
+	}
+}
+
+// registerAssertionRollover registers the daily assertion valid-time
+// rollover worker + its periodic job. Stateless; RunOnStart catches up any
+// overdue rollovers on boot.
+func registerAssertionRollover(reg *riverRegistrar, graph contactCore) {
+	assertService := graph.AssertService
+
+	// Assertion valid-time rollover — a daily catch-up sweep that terminalizes the
+	// bounded-with-pending-successor assertions whose valid_to has passed (no event
+	// fires at that future date otherwise). Stateless; RunOnStart catches up any
+	// overdue rollovers on boot.
+	addWorker(reg, scheduler.NewAssertionRolloverWorker(assertService))
+	reg.addPeriodic(scheduler.AssertionRolloverArgs{}.Kind(), river.NewPeriodicJob(
+		river.PeriodicInterval(24*time.Hour),
+		func() (river.JobArgs, *river.InsertOpts) {
+			return scheduler.AssertionRolloverArgs{}, nil
+		},
+		&river.PeriodicJobOpts{RunOnStart: true},
+	))
+}
+
+// registerSyncScheduler registers the scheduler-tick + sync-provider-account
+// workers (+ periodic tick) and wires the River enqueuer onto the sync
+// service — all gated on external sync being enabled with a real syncService.
+// The SetRiverEnqueuer wiring happens BEFORE riverClient.Start so any tick
+// fire or TriggerSync that races with bring-up goes through river instead of
+// falling back to inline sync.
+func registerSyncScheduler(reg *riverRegistrar, cfg *config.Config, syncStk syncStack, riverClient *river.Client[pgx.Tx]) {
+	syncService := syncStk.SyncService
+
+	// The scheduler-tick + sync-provider-account workers are only registered
+	// when external sync is enabled and we have a real syncService —
+	// otherwise there is nothing for them to do.
+	if cfg.Features.EnableExternalSync && syncService != nil {
+		addWorker(reg, scheduler.NewSchedulerTickWorker(syncService))
+		addWorker(reg, scheduler.NewSyncProviderAccountWorker(syncService))
+		reg.addPeriodic(scheduler.SchedulerTickArgs{}.Kind(), river.NewPeriodicJob(
+			river.PeriodicInterval(5*time.Minute),
+			func() (river.JobArgs, *river.InsertOpts) {
+				return scheduler.SchedulerTickArgs{}, nil
+			},
+			&river.PeriodicJobOpts{RunOnStart: true},
+		))
+	}
+
+	// Wire the enqueuer onto the service BEFORE starting the client so
+	// any tick fire or TriggerSync that races with bring-up goes through
+	// river instead of falling back to inline sync.
+	if syncService != nil && cfg.Features.EnableExternalSync {
+		syncService.SetRiverEnqueuer(riverClient)
+	}
 }

--- a/backend/cmd/crm-api/wire_scheduler.go
+++ b/backend/cmd/crm-api/wire_scheduler.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	"personal-crm/backend/internal/consumer/consumerjobs"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/scheduler"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/riverqueue/river"
+)
+
+// registerMessagingWorkers registers the chat-aware messaging aggregate
+// worker + the 5-min sweeper worker and its periodic job. The chat-lister
+// and sweeper-lister registries map source → repository lister; future
+// messaging sources extend the maps without touching the workers.
+func registerMessagingWorkers(
+	reg *riverRegistrar,
+	ingest ingestRepos,
+	messaging messagingFoundation,
+	agg aggregationStack,
+	riverClient *river.Client[pgx.Tx],
+) {
+	messagesMessageRepo := ingest.MessagesMessage
+	commsMessageRepo := messaging.CommsMessageRepo
+	messagesEngine := agg.MessagesEngine
+	gchatEngine := agg.GChatEngine
+
+	// Register the messaging aggregate workers. The chat-lister
+	// registry maps source → repository's ListUnprocessedChatsByContact;
+	// future messaging sources (whatsapp etc) extend the map without
+	// touching the worker.
+	chatListerRegistry := scheduler.NewPerSourceChatListerRegistry(
+		map[string]func(ctx context.Context, contactID uuid.UUID) ([]string, error){
+			repository.InteractionSourceMessages: messagesMessageRepo.ListUnprocessedChatsByContact,
+			// Source-bound closure: the comms repo method is multi-source
+			// (ListUnprocessedChatsByContactForSource), so bind 'gchat'.
+			repository.InteractionSourceGChat: func(ctx context.Context, contactID uuid.UUID) ([]string, error) {
+				return commsMessageRepo.ListUnprocessedChatsByContactForSource(ctx, repository.InteractionSourceGChat, contactID)
+			},
+		},
+	)
+	addWorker(reg, scheduler.NewMessagingAggregateForContactWorker(
+		map[string]scheduler.ChatAwareAggregator{
+			repository.InteractionSourceMessages: messagesEngine,
+			repository.InteractionSourceGChat:    gchatEngine,
+		},
+		chatListerRegistry,
+	))
+
+	// Periodic 5-min sweeper — drains never-claimed stranded rows that
+	// the in-line worker re-list loop AND the post-Stage-3 reenqueue
+	// both missed. Run once on startup so restart-recovery does not wait
+	// a full interval before the safety net engages.
+	sweeperListers := map[string]scheduler.UnprocessedContactLister{
+		repository.InteractionSourceMessages: messagesMessageRepo,
+		// Source-bound adapter: comms_message is multi-source, so wrap the
+		// repo with a 'gchat'-pinned lister.
+		repository.InteractionSourceGChat: newCommsSourceContactLister(commsMessageRepo, repository.InteractionSourceGChat),
+	}
+	addWorker(reg, scheduler.NewMessagingAggregateSweeperWorker(sweeperListers, riverClient))
+	reg.addPeriodic(consumerjobs.MessagingAggregateSweeperArgs{}.Kind(), river.NewPeriodicJob(
+		river.PeriodicInterval(5*time.Minute),
+		func() (river.JobArgs, *river.InsertOpts) {
+			return consumerjobs.MessagingAggregateSweeperArgs{}, nil
+		},
+		&river.PeriodicJobOpts{RunOnStart: true},
+	))
+}

--- a/backend/cmd/crm-api/wire_services.go
+++ b/backend/cmd/crm-api/wire_services.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/service"
+)
+
+// domainServices holds the note / import-match / enrichment /
+// address-book-reconcile services built at outer scope so the feature
+// blocks (external sync, telegram) share single instances.
+type domainServices struct {
+	NoteService                 *service.NoteService
+	ImportMatchService          *service.ImportMatchService
+	EnrichmentService           *service.EnrichmentService
+	AddressBookReconcileService *service.AddressBookReconcileService
+}
+
+// buildDomainServices constructs the note, import-match, enrichment, and
+// address-book-reconcile services and wires the EnrichmentService setters
+// (cadence + knowledge writer) plus the IngestService's AddressBookReconciler
+// back-reference. EnrichmentService is shared by the import handler and the
+// Telegram peer matcher, so it is built once here.
+func buildDomainServices(
+	database *db.Database,
+	core coreRepos,
+	graph contactCore,
+	ingest ingestRepos,
+	consumers eventConsumers,
+	ingestStk ingestStack,
+	eventBus *events.Bus,
+) domainServices {
+	noteRepo := core.Note
+	contactRepo := core.Contact
+	contactMethodRepo := core.ContactMethod
+	enrichmentRepo := core.Enrichment
+	rematchService := graph.RematchService
+	assertService := graph.AssertService
+	cadenceUpdater := consumers.CadenceUpdater
+	knowledgeCacheUpdater := consumers.KnowledgeCacheUpdater
+	externalContactRepoForIngest := ingest.ExternalContact
+	ingestService := ingestStk.IngestService
+
+	noteService := service.NewNoteService(noteRepo, contactRepo)
+	importMatchService := service.NewImportMatchService(contactRepo)
+	// EnrichmentService is shared by the import handler (link/import flows) and
+	// the Telegram peer matcher (auto-match enrichment). Constructed at outer
+	// scope so both feature blocks share a single instance.
+	enrichmentService := service.NewEnrichmentService(database, contactRepo, contactMethodRepo, enrichmentRepo, eventBus, rematchService)
+	enrichmentService.SetCadenceUpdater(cadenceUpdater)
+	// Inferred location/birthday from external contact data flow through the
+	// assertion store (agent provenance), not the contact SQL — wire the same
+	// knowledge writer the contact service uses.
+	enrichmentService.SetKnowledgeWriter(assertService, knowledgeCacheUpdater)
+
+	// Address-book method reconcile: re-propagates address-book methods
+	// onto already-linked contacts (auto-propagate for matched, record
+	// suggestion for imported). Shared by the gcontacts forward hook and
+	// the icloud post-commit hook so the auto-vs-suggest + dup precedence
+	// logic lives in one place.
+	addressBookReconcileService := service.NewAddressBookReconcileService(
+		enrichmentService,
+		contactRepo,
+		contactMethodRepo,
+		externalContactRepoForIngest,
+	)
+	ingestService.SetAddressBookReconciler(addressBookReconcileService)
+
+	return domainServices{
+		NoteService:                 noteService,
+		ImportMatchService:          importMatchService,
+		EnrichmentService:           enrichmentService,
+		AddressBookReconcileService: addressBookReconcileService,
+	}
+}

--- a/backend/cmd/crm-api/wire_sync.go
+++ b/backend/cmd/crm-api/wire_sync.go
@@ -1,0 +1,234 @@
+package main
+
+import (
+	"context"
+
+	"personal-crm/backend/internal/api/handlers"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/google"
+	"personal-crm/backend/internal/logger"
+	"personal-crm/backend/internal/push"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+	"personal-crm/backend/internal/sync"
+	"personal-crm/backend/internal/todoist"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/riverqueue/river"
+)
+
+// syncStack holds every handler + service the external-sync branch builds.
+// A zero syncStack (returned when EnableExternalSync is false) reproduces
+// today's all-nil handler set exactly.
+type syncStack struct {
+	SyncService             *service.SyncService
+	SyncHandler             *handlers.SyncHandler
+	IdentityHandler         *handlers.IdentityHandler
+	OAuthHandler            *handlers.OAuthHandler
+	ImportHandler           *handlers.ImportHandler
+	SuggestionHandler       *handlers.SuggestionHandler
+	AnarlogDiscoveryHandler *handlers.AnarlogDiscoveryHandler
+	CalendarHandler         *handlers.CalendarHandler
+	TodoistHandler          *handlers.TodoistHandler
+	ContactTaskHandler      *handlers.ContactTaskHandler
+	GoogleOAuthService      *google.OAuthService
+	TodoistOAuthService     *todoist.OAuthService
+	ExternalContactRepo     *repository.ExternalContactRepository
+	GChatProvider           *google.GChatSyncProvider
+	GChatSyncStates         google.GChatSyncStateLister
+}
+
+// buildExternalSync constructs the entire external-sync branch: OAuth
+// services, the provider registry + Google/Todoist/push providers, the sync
+// service + boot reconciliations, and the import/suggestion/anarlog handlers.
+// pubBus is threaded as a CONCRETE *events.Bus (nil in interaction-mode off)
+// per INV-3. Called by run() only when cfg.Features.EnableExternalSync.
+func buildExternalSync(
+	ctx context.Context,
+	cfg *config.Config,
+	database *db.Database,
+	core coreRepos,
+	graph contactCore,
+	ingest ingestRepos,
+	messaging messagingFoundation,
+	consumers eventConsumers,
+	domain domainServices,
+	eventBus *events.Bus,
+	riverClient *river.Client[pgx.Tx],
+	pubBus *events.Bus,
+) syncStack {
+	contactRepo := core.Contact
+	contactMethodRepo := core.ContactMethod
+	contactTaskRepo := core.ContactTask
+	rematchService := graph.RematchService
+	contactService := graph.ContactService
+	commsMessageRepo := messaging.CommsMessageRepo
+	cadenceUpdater := consumers.CadenceUpdater
+	todoistClientFactory := consumers.TodoistClientFactory
+	followUpSettingsHolder := consumers.FollowUpSettingsHolder
+	enrichmentService := domain.EnrichmentService
+	importMatchService := domain.ImportMatchService
+	addressBookReconcileService := domain.AddressBookReconcileService
+	externalContactRepoForIngest := ingest.ExternalContact
+	identityServiceForIngest := ingest.IdentityService
+
+	var stack syncStack
+
+	syncRepo := repository.NewSyncRepositoryWithPool(database.Queries, database.Pool)
+	identityRepo := repository.NewIdentityRepository(database.Queries)
+	oauthRepo := repository.NewOAuthRepository(database.Queries)
+	providerRegistry := sync.NewProviderRegistry()
+
+	// Initialize Google + Todoist OAuth services (each nil when unconfigured).
+	googleOAuthService, oauthHandler := buildGoogleOAuth(cfg, oauthRepo, syncRepo)
+	todoistOAuthService, oauthHandler, todoistHandler := buildTodoistOAuth(cfg, oauthRepo, syncRepo, oauthHandler, followUpSettingsHolder)
+	stack.GoogleOAuthService = googleOAuthService
+	stack.TodoistOAuthService = todoistOAuthService
+	stack.OAuthHandler = oauthHandler
+	stack.TodoistHandler = todoistHandler
+
+	// External contact repository — reuse the instance constructed
+	// at outer scope for the IngestService so all code paths share
+	// the same repo (no behavioral difference today; future stateful
+	// caching is centralized).
+	externalContactRepo := externalContactRepoForIngest
+	stack.ExternalContactRepo = externalContactRepo
+
+	// Initialize identity service (enrichmentService is constructed at outer scope
+	// so the Telegram block can share it).
+	identityService := service.NewIdentityService(identityRepo)
+
+	// Calendar repo + handler + rematch handler are wired whenever external
+	// sync is enabled, regardless of OAuth configuration. Rematch over
+	// calendar_event is pure DB work and must run in test/local environments
+	// that don't have Google OAuth set up.
+	calendarRepo := repository.NewCalendarEventRepository(database.Queries)
+	stack.CalendarHandler = handlers.NewCalendarHandler(calendarRepo)
+	rematchService.Register(google.NewCalendarRematchHandler(calendarRepo, externalContactRepo, pubBus))
+	logger.Info().Msg("Calendar rematch handler registered")
+
+	// Register Google Contacts / Calendar / Gmail / GChat providers if OAuth is configured
+	if googleOAuthService != nil {
+		stack.GChatProvider, stack.GChatSyncStates = registerGoogleProviders(googleProviderDeps{
+			GoogleOAuthService:          googleOAuthService,
+			ProviderRegistry:            providerRegistry,
+			RematchService:              rematchService,
+			CalendarRepo:                calendarRepo,
+			ContactRepo:                 contactRepo,
+			ExternalContactRepo:         externalContactRepo,
+			EnrichmentService:           enrichmentService,
+			IdentityService:             identityService,
+			AddressBookReconcileService: addressBookReconcileService,
+			CommsMessageRepo:            commsMessageRepo,
+			SyncRepo:                    syncRepo,
+			PubBus:                      pubBus,
+			Pool:                        database.Pool,
+		})
+	}
+
+	// Register Todoist Cadence provider if OAuth is configured
+	if todoistOAuthService != nil {
+		stack.ContactTaskHandler = registerTodoistProvider(todoistProviderDeps{
+			TodoistOAuthService:  todoistOAuthService,
+			ProviderRegistry:     providerRegistry,
+			ContactTaskRepo:      contactTaskRepo,
+			ContactRepo:          contactRepo,
+			SyncRepo:             syncRepo,
+			Config:               cfg,
+			EventBus:             eventBus,
+			CadenceUpdater:       cadenceUpdater,
+			Pool:                 database.Pool,
+			TodoistClientFactory: todoistClientFactory,
+			RiverClient:          riverClient,
+		})
+	}
+
+	// Register every Mac-daemon push-source provider. Each is
+	// push-only — data lands via /api/v1/ingest/events, never via the
+	// scheduler (ListDueAccounts skips push strategy) — so Sync() is a
+	// no-op. The registration lives in one helper so the daemonFamily
+	// agreement test can cross-check it against the descriptor table.
+	push.RegisterPushProviders(providerRegistry)
+	logger.Info().Msg("Push providers registered (messages, icloud_contacts, phone_calls)")
+
+	syncService := service.NewSyncService(syncRepo, contactRepo, providerRegistry)
+	stack.SyncService = syncService
+
+	// Email enablement reconciliation (Gmail go-live). Only meaningful in
+	// cutover mode with a connected Google account: the Gmail provider is
+	// registered only when pubBus != nil, so there is no point reconciling
+	// email states no registered provider can serve. Wire the account
+	// lister + OAuth-connect hook, then run the idempotent boot
+	// reconciliation BEFORE riverClient.Start so the RunOnStart tick already
+	// sees the freshly-enabled email states.
+	if googleOAuthService != nil && pubBus != nil {
+		syncService.SetEmailAccountLister(googleOAuthService)
+		if oauthHandler != nil {
+			oauthHandler.SetEmailStateReconciler(func(ctx context.Context) error {
+				return syncService.ReconcileEmailSyncStates(ctx)
+			})
+		}
+		if err := syncService.ReconcileEmailSyncStates(ctx); err != nil {
+			// Non-fatal: the scheduler simply has nothing to do for email
+			// until states exist; the next connect or next boot retries.
+			logger.Warn().Err(err).Msg("boot email sync reconciliation failed (non-fatal)")
+		}
+	}
+
+	// GChat enablement reconciliation (Chat go-live). Guarded ONLY by
+	// googleOAuthService != nil — NOT pubBus: GChat is store-only + event-free,
+	// so its registration + reconciliation are independent of the event-bus
+	// interaction mode (gating on pubBus would wrongly disable GChat in
+	// off-mode). The provider is registered above whenever Google OAuth is
+	// configured; here we wire the account lister + OAuth-connect hook, then
+	// run the idempotent, chat-scope-gated boot reconciliation BEFORE
+	// riverClient.Start so the RunOnStart tick already sees any freshly-enabled
+	// gchat states. No state is created until a connected account carries the
+	// chat scopes (re-consent), keeping the feature inert until the operator
+	// completes the Chat App config + re-consent.
+	if googleOAuthService != nil {
+		syncService.SetGChatAccountLister(googleOAuthService)
+		if oauthHandler != nil {
+			oauthHandler.SetGChatStateReconciler(func(ctx context.Context) error {
+				return syncService.ReconcileGChatSyncStates(ctx)
+			})
+		}
+		if err := syncService.ReconcileGChatSyncStates(ctx); err != nil {
+			// Non-fatal: the scheduler simply has nothing to do for gchat
+			// until states exist; the next connect or next boot retries.
+			logger.Warn().Err(err).Msg("boot gchat sync reconciliation failed (non-fatal)")
+		}
+	}
+
+	stack.SyncHandler = handlers.NewSyncHandler(syncService)
+	stack.IdentityHandler = handlers.NewIdentityHandler(identityService)
+
+	// Suggestion service composes the method-suggestion group with the
+	// confidence-ranked candidate list and runs resolve/dismiss. Shared
+	// by the import handler (its candidate sort) and the suggestion
+	// handler (the new People-tab surface).
+	suggestionService := service.NewSuggestionService(
+		externalContactRepo,
+		contactRepo,
+		contactMethodRepo,
+		enrichmentService,
+		importMatchService,
+		database,
+	)
+	stack.SuggestionHandler = handlers.NewSuggestionHandler(suggestionService)
+
+	// Initialize import handler
+	stack.ImportHandler = handlers.NewImportHandler(externalContactRepo, identityServiceForIngest, contactService, importMatchService, enrichmentService, suggestionService)
+
+	// Anarlog-title discovery surface (People-tab grouped weak
+	// candidates + token-group resolve). Reuses the external_contact
+	// repo and ContactService — both already constructed above.
+	anarlogDiscoveryService := service.NewAnarlogDiscoveryService(externalContactRepo, contactService)
+	stack.AnarlogDiscoveryHandler = handlers.NewAnarlogDiscoveryHandler(anarlogDiscoveryService)
+
+	logger.Info().Msg("external sync infrastructure enabled")
+
+	return stack
+}

--- a/backend/cmd/crm-api/wire_telegram.go
+++ b/backend/cmd/crm-api/wire_telegram.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"context"
+
+	"personal-crm/backend/internal/api/handlers"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/consumer"
+	"personal-crm/backend/internal/crypto"
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/logger"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+	tgpkg "personal-crm/backend/internal/telegram"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/riverqueue/river"
+)
+
+// telegramStack holds the Telegram manager + handler. A zero telegramStack
+// (returned when Telegram sync is disabled) reproduces today's nil manager /
+// nil handler exactly.
+type telegramStack struct {
+	Manager *tgpkg.TelegramManager
+	Handler *handlers.TelegramHandler
+}
+
+// buildTelegram constructs and starts the Telegram manager and registers its
+// rematch handlers. It calls telegramManager.Start(ctx) but does NOT register
+// the Stop defer — the caller (run()) owns that as a nil-guarded defer so it
+// fires on run() return, not on this function's return. Called only when
+// EnableTelegramSync is on and a nonzero API id is configured.
+func buildTelegram(
+	ctx context.Context,
+	cfg *config.Config,
+	database *db.Database,
+	core coreRepos,
+	graph contactCore,
+	messaging messagingFoundation,
+	domain domainServices,
+	pubBus *events.Bus,
+	riverClient *river.Client[pgx.Tx],
+) telegramStack {
+	interactionRepo := core.Interaction
+	contactService := graph.ContactService
+	rematchService := graph.RematchService
+	telegramMessageRepo := messaging.TelegramMessageRepo
+	enrichmentService := domain.EnrichmentService
+
+	telegramSessionRepo := repository.NewTelegramSessionRepository(database.Queries)
+	telegramUpdateStateRepo := repository.NewTelegramUpdateStateRepository(database.Queries)
+	telegramChatConfigRepo := repository.NewTelegramChatConfigRepository(database.Queries)
+	// telegramMessageRepo is hoisted above (needed by the consumer
+	// wiring); no re-construction here.
+	telegramSyncRepo := repository.NewSyncRepository(database.Queries)
+
+	// Phase 4: identity + aggregation dependencies
+	tgIdentityRepo := repository.NewIdentityRepository(database.Queries)
+	tgIdentityService := service.NewIdentityService(tgIdentityRepo)
+	tgExternalContactRepo := repository.NewExternalContactRepository(database.Queries)
+
+	encryptor, err := crypto.NewTokenEncryptor(cfg.External.TokenEncryptionKey)
+	if err != nil {
+		logger.Fatal().Err(err).Msg("failed to initialize Telegram encryptor (TOKEN_ENCRYPTION_KEY required)")
+	}
+
+	// River-backed stale-claim recovery enqueuer. Uses UniqueOpts
+	// {ByArgs: true} paired with the InteractionRecorderJobArgs.EventID
+	// `river:"unique"` tag so repeated recovery enqueues against the
+	// same event coalesce into one in-flight job (spec §3 Race
+	// Mechanics).
+	tgRecoveryEnqueuer := consumer.NewRiverInteractionRecorderEnqueuer(riverClient)
+
+	telegramManager := tgpkg.NewTelegramManager(
+		telegramSessionRepo,
+		telegramUpdateStateRepo,
+		telegramChatConfigRepo,
+		telegramMessageRepo,
+		telegramSyncRepo,
+		encryptor,
+		cfg.External.TelegramAPIID,
+		cfg.External.TelegramAPIHash,
+		&cfg.Telegram,
+		tgIdentityService,
+		tgExternalContactRepo,
+		enrichmentService,
+		interactionRepo,
+		contactService,
+		contactService,
+		pubBus,
+		database.Pool,
+		tgRecoveryEnqueuer,
+	)
+
+	if err := telegramManager.Start(ctx); err != nil {
+		logger.Warn().Err(err).Msg("failed to start Telegram connection")
+	}
+	// NOTE: telegramManager.Stop() is deferred by the caller (run()) as a
+	// nil-guarded defer — a defer here would fire when THIS function
+	// returns, stopping the client at boot.
+
+	telegramHandler := handlers.NewTelegramHandler(telegramManager)
+
+	// Register telegram rematch handlers (telegram + phone identifiers)
+	// against the same matcher/aggregator instances the manager owns so
+	// rematch behavior is identical to the post-import path.
+	rematchService.Register(tgpkg.NewUsernameRematchHandler(telegramMessageRepo, telegramManager.PeerMatcher(), telegramManager.AggregationEngine()))
+	rematchService.Register(tgpkg.NewPhoneRematchHandler(telegramMessageRepo, telegramManager.PeerMatcher(), telegramManager.AggregationEngine()))
+	logger.Info().Msg("Telegram rematch handlers registered")
+
+	logger.Info().Msg("Telegram integration initialized")
+
+	return telegramStack{
+		Manager: telegramManager,
+		Handler: telegramHandler,
+	}
+}

--- a/backend/cmd/crm-api/wire_todoist.go
+++ b/backend/cmd/crm-api/wire_todoist.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"personal-crm/backend/internal/api/handlers"
+	"personal-crm/backend/internal/config"
+	"personal-crm/backend/internal/consumer"
+	"personal-crm/backend/internal/events"
+	"personal-crm/backend/internal/logger"
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+	"personal-crm/backend/internal/sync"
+	"personal-crm/backend/internal/todoist"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
+)
+
+// buildTodoistOAuth initializes the Todoist OAuth service when
+// TODOIST_CLIENT_ID/SECRET are configured. It shares/creates the OAuth
+// handler with Google (if oauthHandler is already non-nil it appends Todoist
+// to it, otherwise it creates a Google-less handler), builds the Todoist
+// settings handler, and populates the FollowUpManager's deferred settings
+// ref. Returns (todoistOAuthService, oauthHandler, todoistHandler) — all nil
+// (except the passed-through oauthHandler) when unconfigured or on failure.
+func buildTodoistOAuth(
+	cfg *config.Config,
+	oauthRepo *repository.OAuthRepository,
+	syncRepo *repository.SyncRepository,
+	oauthHandler *handlers.OAuthHandler,
+	followUpSettingsHolder *followUpSettingsRef,
+) (*todoist.OAuthService, *handlers.OAuthHandler, *handlers.TodoistHandler) {
+	if cfg.Todoist.ClientID != "" && cfg.Todoist.ClientSecret != "" {
+		todoistOAuthService, err := todoist.NewOAuthService(cfg, oauthRepo, syncRepo)
+		if err != nil {
+			logger.Warn().Err(err).Msg("failed to initialize Todoist OAuth service")
+			return nil, oauthHandler, nil
+		}
+		// If OAuth handler exists (from Google), add Todoist to it
+		// Otherwise create a new handler with nil Google service
+		if oauthHandler != nil {
+			oauthHandler.SetTodoistOAuth(todoistOAuthService)
+		} else {
+			oauthHandler = handlers.NewOAuthHandler(nil, cfg.CORS.FrontendURL)
+			oauthHandler.SetTodoistOAuth(todoistOAuthService)
+		}
+
+		// Initialize Todoist settings handler
+		todoistHandler := handlers.NewTodoistHandler(todoistOAuthService, syncRepo)
+
+		// Populate the FollowUpManager's deferred Todoist settings
+		// ref so the cutover consumer can resolve settings via the
+		// real OAuth service for its post-commit refresh / close /
+		// retry workers.
+		followUpSettingsHolder.oauth = todoistOAuthService
+		followUpSettingsHolder.sync = syncRepo
+
+		logger.Info().Msg("Todoist OAuth service initialized")
+		return todoistOAuthService, oauthHandler, todoistHandler
+	}
+	logger.Info().Msg("Todoist OAuth not configured (TODOIST_CLIENT_ID and TODOIST_CLIENT_SECRET required)")
+	return nil, oauthHandler, nil
+}
+
+// todoistProviderDeps carries the collaborators registerTodoistProvider needs.
+type todoistProviderDeps struct {
+	TodoistOAuthService  *todoist.OAuthService
+	ProviderRegistry     *sync.ProviderRegistry
+	ContactTaskRepo      *repository.ContactTaskRepository
+	ContactRepo          *repository.ContactRepository
+	SyncRepo             *repository.SyncRepository
+	Config               *config.Config
+	EventBus             *events.Bus
+	CadenceUpdater       *consumer.CadenceUpdater
+	Pool                 *pgxpool.Pool
+	TodoistClientFactory todoist.ClientFactory
+	RiverClient          *river.Client[pgx.Tx]
+}
+
+// registerTodoistProvider registers the Todoist Cadence sync provider and
+// builds the contact-task service + handler. Called only when
+// todoistOAuthService != nil. Returns the contact-task handler.
+func registerTodoistProvider(deps todoistProviderDeps) *handlers.ContactTaskHandler {
+	todoistProvider := todoist.NewCadenceSyncProvider(
+		deps.TodoistOAuthService,
+		deps.ContactTaskRepo,
+		deps.ContactRepo,
+		deps.SyncRepo,
+		deps.Config,
+		deps.EventBus,
+		deps.CadenceUpdater,
+		deps.Pool,
+		deps.TodoistClientFactory,
+		deps.RiverClient,
+		deps.Config.EventBus.FollowUpMode == config.EventBusFollowUpModeCutover,
+	)
+	deps.ProviderRegistry.Register(todoistProvider)
+	logger.Info().Msg("Todoist Cadence sync provider registered")
+
+	// Follow-up lifecycle is handled by consumer.FollowUpManager
+	// (wired above via SetFollowUpConsumer). The Todoist
+	// dependency (settings + client factory) routes through
+	// followUpSettingsHolder which was populated when Todoist
+	// OAuth initialized. No follow-up service is constructed
+	// here — FollowUpManager is the sole writer.
+
+	// Initialize contact task service and handler for action tasks
+	contactTaskService := service.NewContactTaskService(
+		deps.ContactTaskRepo,
+		deps.ContactRepo,
+		deps.SyncRepo,
+		deps.TodoistOAuthService,
+		deps.Config,
+	)
+	contactTaskHandler := handlers.NewContactTaskHandler(contactTaskService)
+	logger.Info().Msg("Contact task handler initialized")
+	return contactTaskHandler
+}

--- a/backend/tests/task_close_wiring_static_test.go
+++ b/backend/tests/task_close_wiring_static_test.go
@@ -2,57 +2,76 @@
 //
 // MergeContacts errors when it closes an enqueue-eligible contact_task and
 // SetTaskCloseEnqueuer was never called, so production wiring MUST call the
-// setter in main.go. Similarly, the Todoist provider's state-aware temp-ID
-// finalize needs the river client + cutover-mode gate passed at construction.
-// Integration tests cannot cover main.go (it is a binary), so this static
-// test greps the source — the same belt the ingest-registry and sole-writer
-// guards use.
+// setter. Similarly, the Todoist provider's state-aware temp-ID finalize needs
+// the river client + cutover-mode gate passed at construction. This wiring
+// lives in the crm-api composition root, which is split across
+// cmd/crm-api/*.go (main.go + the wire_*.go files) — a binary integration
+// tests cannot cover — so this static test greps the package source, the same
+// belt the ingest-registry and sole-writer guards use.
 package tests
 
 import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
 )
 
-func readMainGoSource(t *testing.T) []byte {
+// readCrmAPISource concatenates every non-test .go file in cmd/crm-api so the
+// guards match wherever the wiring lives across the composition-root files
+// (main.go + wire_*.go + routes.go).
+func readCrmAPISource(t *testing.T) []byte {
 	t.Helper()
 	moduleRoot, err := backendModuleRoot()
 	if err != nil {
 		t.Fatalf("locate backend module root: %v", err)
 	}
-	mainPath := filepath.Join(moduleRoot, "cmd", "crm-api", "main.go")
-	src, err := os.ReadFile(mainPath)
+	dir := filepath.Join(moduleRoot, "cmd", "crm-api")
+	entries, err := os.ReadDir(dir)
 	if err != nil {
-		t.Fatalf("read %s: %v", mainPath, err)
+		t.Fatalf("read %s: %v", dir, err)
 	}
-	return src
+	var buf []byte
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") || strings.HasSuffix(e.Name(), "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			t.Fatalf("read %s: %v", e.Name(), err)
+		}
+		buf = append(buf, src...)
+		buf = append(buf, '\n')
+	}
+	return buf
 }
 
-// TestTaskCloseEnqueuerWiring_Static asserts main.go wires the merge-time
-// close enqueuer with the river client and the follow-up cutover-mode gate.
+// TestTaskCloseEnqueuerWiring_Static asserts the crm-api wiring calls the
+// merge-time close enqueuer with the river client and the follow-up
+// cutover-mode gate (in buildEventConsumers).
 func TestTaskCloseEnqueuerWiring_Static(t *testing.T) {
 	t.Parallel()
-	src := readMainGoSource(t)
+	src := readCrmAPISource(t)
 
 	setter := regexp.MustCompile(
 		`contactService\.SetTaskCloseEnqueuer\(\s*riverClient,\s*cfg\.EventBus\.FollowUpMode == config\.EventBusFollowUpModeCutover\s*\)`)
 	if !setter.Match(src) {
-		t.Error("main.go must call contactService.SetTaskCloseEnqueuer(riverClient, cfg.EventBus.FollowUpMode == config.EventBusFollowUpModeCutover) — without it MergeContacts errors on any merge that closes a real-external-id task")
+		t.Error("crm-api must call contactService.SetTaskCloseEnqueuer(riverClient, cfg.EventBus.FollowUpMode == config.EventBusFollowUpModeCutover) — without it MergeContacts errors on any merge that closes a real-external-id task")
 	}
 }
 
-// TestCadenceProviderCloseDepsWiring_Static asserts main.go passes the river
-// client + cutover-mode gate to the Todoist cadence provider so the
-// state-aware temp-ID finalize can enqueue the durable remote close.
+// TestCadenceProviderCloseDepsWiring_Static asserts the crm-api wiring passes
+// the river client + cutover-mode gate to the Todoist cadence provider so the
+// state-aware temp-ID finalize can enqueue the durable remote close (in
+// registerTodoistProvider, via the todoistProviderDeps fields).
 func TestCadenceProviderCloseDepsWiring_Static(t *testing.T) {
 	t.Parallel()
-	src := readMainGoSource(t)
+	src := readCrmAPISource(t)
 
 	provider := regexp.MustCompile(
-		`todoist\.NewCadenceSyncProvider\((?s:.*?)riverClient,\s*cfg\.EventBus\.FollowUpMode == config\.EventBusFollowUpModeCutover,\s*\)`)
+		`todoist\.NewCadenceSyncProvider\((?s:.*?)deps\.RiverClient,\s*deps\.Config\.EventBus\.FollowUpMode == config\.EventBusFollowUpModeCutover,\s*\)`)
 	if !provider.Match(src) {
-		t.Error("main.go must pass riverClient + the cutover-mode gate to todoist.NewCadenceSyncProvider — without them the temp-ID finalize on a completed row cannot enqueue the durable remote close")
+		t.Error("crm-api must pass the river client + the cutover-mode gate to todoist.NewCadenceSyncProvider — without them the temp-ID finalize on a completed row cannot enqueue the durable remote close")
 	}
 }

--- a/scripts/dev/route-parity.sh
+++ b/scripts/dev/route-parity.sh
@@ -44,6 +44,16 @@ SHAPES=("$@")
 if [[ ${#SHAPES[@]} -eq 0 ]]; then
   SHAPES=(1 2 3 4 5 6)
 fi
+# Validate every requested shape against the literal set 1..6 up front.
+# shape_env's `return 1` on an unknown shape is swallowed by the
+# `< <(shape_env ...)` process substitution in boot_tree, so an unknown
+# shape would otherwise boot the BASE env and false-PASS. Reject here.
+for shape in "${SHAPES[@]}"; do
+  case "$shape" in
+    1|2|3|4|5|6) ;;
+    *) echo "error: unknown shape '$shape' (valid: 1..6)" >&2; exit 2 ;;
+  esac
+done
 
 DATABASE_URL="${DATABASE_URL:-postgres://crm_user:crm_password@localhost:5432/personal_crm_test?sslmode=disable}"
 API_KEY="${API_KEY:-route-parity-key}"
@@ -223,6 +233,20 @@ for shape in "${SHAPES[@]}"; do
 
   na=$(wc -l <"$ra"); nb=$(wc -l <"$rb")
   echo "  routes: tree-a=$na  tree-b=$nb"
+
+  # Minimum-route-count floor. Shapes 2/6 assert only absence/log
+  # sentinels, so a doubly-empty capture (both trees emitting 0
+  # [GIN-debug] lines — e.g. a botched capture) would pass parity + those
+  # sentinels trivially. The SMALLEST legitimate shape (shape 2, ~35
+  # routes) sits well above this floor; a broken/empty capture (~0) sits
+  # well below it.
+  MIN_ROUTES=25
+  if (( na < MIN_ROUTES || nb < MIN_ROUTES )); then
+    echo "  ROUTE COUNT FLOOR FAIL: tree-a=$na tree-b=$nb (min $MIN_ROUTES) — capture likely broken/empty"
+    OVERALL=1
+    echo
+    continue
+  fi
 
   if diff -u "$ra" "$rb" >"$WORKDIR/shape${shape}.diff"; then
     echo "  ROUTE PARITY: identical"


### PR DESCRIPTION
## Summary

PR4 of the composition-root refactor arc (follows #573, #576, #581) — the core decomposition. `run()`'s ~1,300-line construction body becomes **21 wire functions across 13 `wire_*.go` files + `routes.go`** in package main; `main.go` shrinks 1,541 → 417 lines and `run()` keeps only lifecycle + ordered `build*` calls.

- **1:1 contiguous block moves** — construction order preserved verbatim (the service-consumer reorder is deliberately deferred to PR5). Cross-block variables thread through small returned structs (`syncStack`, `eventConsumers`, `telegramStack`, …).
- **`riverRegistrar` recording seam** (`wire_river.go`): pure delegation around `river.AddWorker`/`PeriodicJobs().Add`, built two-phase so the noop worker is recorded too. Enables `TestWireGoldenLists`, which pins worker kinds / periodic jobs / provider-registry contents across 4 config shapes (with the shape-6 Gmail-absent typed-nil pin).
- **`route-parity.sh` hardened first** (separate commit): unknown-shape rejection + a minimum-route-count floor, closing the two fail-opens found in the PR3 review — this harness is PR4's own acceptance gate.
- **`defer telegramManager.Stop()`** stays in `run()` as a nil-guarded defer (moving it into a wire function would change shutdown semantics); `pubBus` threads as concrete `*events.Bus` everywhere (no typed-nil traps).
- Task-close static guards repointed from `main.go` to the whole `cmd/crm-api` package; docs rewritten to the new convention (feature-development §6, sync.md, AGENTS.md); adapters.go hygiene carry-overs.
- One-line Makefile change: `./cmd/crm-api/...` added to `INTEGRATION_PKGS` so the DB-bootstrapped golden test runs; verified against the test-parallelism render guards (only `-p`/`-parallel` knobs are pinned).

## Behavior

Zero behavior change, proven three ways: route-parity **6/6 shapes** identical develop-vs-branch; golden-list test **4/4 shapes**; and an adversarial review traced the linearized statement order old-`run()` → new wire chain with an independent mechanical inventory (18 AddWorker, 5 periodic, 11 provider/rematch registrations, all 20 `.Set*` calls, 4 defers) reconciling exactly.

## Verification

- `make lint` 0 issues; unit suite green; both packages build + vet (incl. integration tag); `TestHealthEndpoint_StampedBuildInfo` (ldflags stamp) green.
- Full integration suite green (one unrelated shared-DB flake in untouched code, passes isolated; pre-push re-ran on clean DB).
- Codex review: PASS (P0=0 P1=0 P2=3 P3=1). Fresh-context review-head: PASS (P0=0 P1=0 P2=1 P3=3) with Codex findings re-triaged in the verdict.

Note: the Codex GitHub bot is quota-exhausted; per repo-owner decision this PR merges on CI green (it already carries two independent pre-push reviews), with a post-merge re-check if quota returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PAkTD635qUGdkzipVK7uhh