### PR TITLE
refactor: convert service setters to constructor args

### DIFF
--- a/backend/cmd/crm-admin/main.go
+++ b/backend/cmd/crm-admin/main.go
@@ -1287,16 +1287,15 @@ func buildProductionDeps(ctx context.Context, cfg *config.Config, database *db.D
 	contactMethodRepo := repository.NewContactMethodRepository(database.Queries)
 	enrichmentRepo := repository.NewEnrichmentRepository(database.Queries)
 	eventBus := events.NewBus(database.Pool, riverClient, repository.NewEventRepository(database.Queries))
-	enrichmentService := service.NewEnrichmentService(
-		database, contactRepo, contactMethodRepo, enrichmentRepo, eventBus, rematchService,
-	)
-	addressBookReconcile := service.NewAddressBookReconcileService(
-		enrichmentService, contactRepo, contactMethodRepo, externalContactRepo,
-	)
 
-	// Tag→graph migration. Reuses the same event bus (so the tagged_as asserts
-	// emit assertion.* events) + the graph repos. AssertService owns proposition
-	// identity / dedup, which makes --migrate-tags idempotent.
+	// Graph repos + AssertService + knowledge-cache updater. Reuses the same
+	// event bus (so the tagged_as asserts emit assertion.* events); AssertService
+	// owns proposition identity / dedup, which makes --migrate-tags idempotent.
+	// Built ABOVE NewEnrichmentService so the knowledge-writer pair can be passed
+	// as constructor args: the address-book reconcile path
+	// (--reconcile-address-book-methods → EnrichContactFromExternal) persists an
+	// inferred location/birthday through the assertion store + refreshes the cache
+	// inline, instead of erroring on the now-required knowledge writer.
 	graphNodeRepo := repository.NewNodeRepository(database.Queries)
 	graphEntityRepo := repository.NewEntityRepository(database.Queries)
 	graphPredicateRepo := repository.NewPredicateRepository(database.Queries)
@@ -1304,12 +1303,18 @@ func buildProductionDeps(ctx context.Context, cfg *config.Config, database *db.D
 	assertService := service.NewAssertService(
 		database.Pool, graphNodeRepo, graphEntityRepo, graphPredicateRepo, graphAssertionRepo, eventBus,
 	)
-	// Wire the knowledge writer into EnrichmentService so the address-book
-	// reconcile path (--reconcile-address-book-methods → EnrichContactFromExternal)
-	// persists an inferred location/birthday through the assertion store + refreshes
-	// the cache inline, instead of erroring on the now-required knowledge writer.
 	knowledgeCacheUpdater := consumer.NewKnowledgeCacheUpdater(graphAssertionRepo, graphNodeRepo, contactRepo)
-	enrichmentService.SetKnowledgeWriter(assertService, knowledgeCacheUpdater)
+
+	// crm-admin never wires enrichment cadence (its paths never pass a cadence
+	// override), so cadence is nil — preserving today's unset-cadence behavior.
+	enrichmentService := service.NewEnrichmentService(
+		database, contactRepo, contactMethodRepo, enrichmentRepo, eventBus, rematchService,
+		nil, assertService, knowledgeCacheUpdater,
+	)
+	addressBookReconcile := service.NewAddressBookReconcileService(
+		enrichmentService, contactRepo, contactMethodRepo, externalContactRepo,
+	)
+
 	tagMigration := service.NewTagMigrationService(
 		database.Pool, repository.NewTagRepository(database.Queries),
 		graphNodeRepo, graphEntityRepo, assertService,

--- a/backend/cmd/crm-api/adapters.go
+++ b/backend/cmd/crm-api/adapters.go
@@ -50,9 +50,8 @@ func (*noopWorker) Work(_ context.Context, _ *river.Job[noopJobArgs]) error {
 // consumer.ErrTodoistUnconfigured to keep the consumer's Todoist-dependent
 // post-commit paths a best-effort no-op.
 type followUpSettingsRef struct {
-	oauth       *todoist.OAuthService
-	sync        *repository.SyncRepository
-	frontendURL string
+	oauth *todoist.OAuthService
+	sync  *repository.SyncRepository
 }
 
 // fn returns a TodoistSettingsFunc closure that resolves settings

--- a/backend/cmd/crm-api/main.go
+++ b/backend/cmd/crm-api/main.go
@@ -162,33 +162,42 @@ func run() int {
 	meetingNoteRepoForIngest := ingest.MeetingNote
 	calendarRepoForIngest := ingest.CalendarEvent
 
-	// Rematch service + ContactService + graph (SP1) store. Rematch is
-	// constructed above ContactService so it can be passed as the
-	// RematchRegistry constructor arg.
-	graph := buildContactGraphCore(database, core, eventBus)
-	contactService := graph.ContactService
+	// Rematch service + graph (SP1) store. ContactService is NOT built here
+	// (INV-5): it depends on the event-bus consumers, so it is constructed by
+	// buildContactService once those exist.
+	graph := buildGraphCore(database, eventBus)
 
 	// Message-store repos + staging registry + venue resolver.
 	messaging := buildMessagingFoundation(database.Queries, messagesMessageRepo, calendarRepoForIngest)
 
-	// Event-bus consumers (Cadence / Knowledge / FollowUp / InteractionRecorder)
-	// + their shared collaborators, wired into ContactService via its setters.
-	consumers := buildEventConsumers(cfg, database, core, graph, ingest, messaging, eventBus, riverClient)
+	// Event-bus consumers (Cadence / Knowledge / FollowUp) + their shared
+	// collaborators, built BEFORE ContactService so they can be passed to
+	// NewContactService as constructor args (INV-5 reorder).
+	consumers := buildDomainConsumers(cfg, database, core, graph, eventBus, riverClient)
+
+	// ContactService — constructed with the consumers + AssertService as
+	// constructor args (the setters are gone). The merge-time task-close
+	// enqueuer (a cross-block dep) is wired inside buildContactService.
+	contactService := buildContactService(cfg, database, core, graph, consumers, eventBus, riverClient)
+
+	// InteractionRecorder — takes ContactService as a ctor arg, so it is
+	// built after buildContactService.
+	interactionRecorder := buildInteractionRecorder(contactService, messaging, ingest, consumers, eventBus)
 
 	// IngestService + meeting-note conflict-resolution surface. Hoisted
 	// after the consumers so the call.* inline handler can reuse them in
 	// the same tx as the staging-row write.
-	ingestStk := buildIngestStack(database, core, graph, ingest, messaging, consumers, eventBus, riverClient)
+	ingestStk := buildIngestStack(database, core, contactService, ingest, messaging, consumers, eventBus, riverClient)
 	ingestHandler := ingestStk.IngestHandler
 	meetingNoteHandler := ingestStk.MeetingNoteHandler
 
 	// Register the three always-on core consumer workers (recorder,
 	// calendar-decline, email-interaction).
-	registerCoreConsumerWorkers(reg, database, core, graph, messaging, consumers, eventBus)
+	registerCoreConsumerWorkers(reg, database, core, contactService, interactionRecorder, messaging, consumers, eventBus)
 
 	// Interaction-mode wiring gate → pubBus (concrete *events.Bus, nil in
 	// off mode) + manual handler.
-	pubBus, manualHandler := resolveInteractionMode(cfg, database, consumers, eventBus)
+	pubBus, manualHandler := resolveInteractionMode(cfg, database, interactionRecorder, eventBus)
 
 	// Register the cadence / knowledge-cache / follow-up / Todoist workers
 	// + their mode boot logs.
@@ -211,7 +220,7 @@ func run() int {
 	// here so buildExternalSync runs only when the feature is on.
 	var syncStk syncStack
 	if cfg.Features.EnableExternalSync {
-		syncStk = buildExternalSync(ctx, cfg, database, core, graph, ingest, messaging, consumers, domain, eventBus, riverClient, pubBus)
+		syncStk = buildExternalSync(ctx, cfg, database, core, contactService, graph, ingest, messaging, consumers, domain, eventBus, riverClient, pubBus)
 	}
 	syncHandler := syncStk.SyncHandler
 	identityHandler := syncStk.IdentityHandler
@@ -231,14 +240,14 @@ func run() int {
 	// telegramStack reproduces today's nil manager/handler when disabled.
 	var telegramStk telegramStack
 	if cfg.Features.EnableTelegramSync && cfg.External.TelegramAPIID != 0 {
-		telegramStk = buildTelegram(ctx, cfg, database, core, graph, messaging, domain, pubBus, riverClient)
+		telegramStk = buildTelegram(ctx, cfg, database, core, contactService, graph, messaging, domain, pubBus, riverClient)
 	}
 	telegramManager := telegramStk.Manager
 	telegramHandler := telegramStk.Handler
 	// The Stop defer lives here (not inside buildTelegram) so it fires on
 	// run() return, not when the wire function returns. Nil-guarded:
 	// registers only when a manager was built, exactly as the old
-	// branch-local defer did (decision 4).
+	// branch-local defer did.
 	if telegramManager != nil {
 		defer telegramManager.Stop()
 	}
@@ -249,13 +258,13 @@ func run() int {
 	}
 
 	// Aggregation engines (messages + gchat) + reenqueuer registry.
-	agg := buildAggregationEngines(database, core, graph, ingest, messaging, consumers, eventBus, riverClient, telegramManager, gchatProvider, gchatSyncStates)
+	agg := buildAggregationEngines(database, core, contactService, graph, ingest, messaging, consumers, eventBus, riverClient, telegramManager, gchatProvider, gchatSyncStates)
 
 	// Register the chat-aware messaging aggregate worker + sweeper (+ periodic).
 	registerMessagingWorkers(reg, ingest, messaging, agg, riverClient)
 
 	// Core HTTP handlers.
-	handlersCore := buildCoreHandlers(core, graph, cfg, noteService, manualHandler)
+	handlersCore := buildCoreHandlers(core, contactService, graph, cfg, noteService, manualHandler)
 	contactHandler := handlersCore.Contact
 	noteHandler := handlersCore.Note
 	interactionHandler := handlersCore.Interaction

--- a/backend/cmd/crm-api/wire_aggregation.go
+++ b/backend/cmd/crm-api/wire_aggregation.go
@@ -9,6 +9,7 @@ import (
 	"personal-crm/backend/internal/messages"
 	"personal-crm/backend/internal/messaging/aggregation"
 	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
 	tgpkg "personal-crm/backend/internal/telegram"
 
 	"github.com/jackc/pgx/v5"
@@ -31,7 +32,8 @@ type aggregationStack struct {
 func buildAggregationEngines(
 	database *db.Database,
 	core coreRepos,
-	graph contactCore,
+	contactService *service.ContactService,
+	graph graphCore,
 	ingest ingestRepos,
 	messaging messagingFoundation,
 	consumers eventConsumers,
@@ -42,7 +44,6 @@ func buildAggregationEngines(
 	gchatSyncStates google.GChatSyncStateLister,
 ) aggregationStack {
 	interactionRepo := core.Interaction
-	contactService := graph.ContactService
 	rematchService := graph.RematchService
 	messagesMessageRepo := ingest.MessagesMessage
 	commsMessageRepo := messaging.CommsMessageRepo

--- a/backend/cmd/crm-api/wire_consumers.go
+++ b/backend/cmd/crm-api/wire_consumers.go
@@ -15,13 +15,14 @@ import (
 )
 
 // eventConsumers holds the event-bus consumers + their shared collaborators
-// constructed before the interaction-mode gate. The InteractionRecorder,
-// CadenceUpdater, KnowledgeCacheUpdater, and FollowUpManager are the sole
-// writers of their respective columns; the holders carry deferred wiring
-// (Telegram aggregation engine, Todoist settings) populated later.
+// constructed before ContactService (INV-5 order). The CadenceUpdater,
+// KnowledgeCacheUpdater, and FollowUpManager are the sole writers of their
+// respective columns; the holders carry deferred wiring (Telegram aggregation
+// engine, Todoist settings) populated later. The InteractionRecorder is NOT
+// held here — it takes ContactService as a ctor arg, so it is built by
+// buildInteractionRecorder after buildContactService.
 type eventConsumers struct {
 	AggregatorReenqueuerHolder *deferredAggregatorReenqueuer
-	EventClaimRepo             *repository.EventConsumerClaimRepository
 	CadenceUpdater             *consumer.CadenceUpdater
 	KnowledgeCacheUpdater      *consumer.KnowledgeCacheUpdater
 	TodoistClientFactory       todoist.ClientFactory
@@ -29,36 +30,30 @@ type eventConsumers struct {
 	FollowUpSettingsHolder     *followUpSettingsRef
 	FollowUpSettings           consumer.TodoistSettingsFunc
 	FollowUpManager            *consumer.FollowUpManager
-	InteractionRecorder        *consumer.InteractionRecorder
 }
 
-// buildEventConsumers constructs the CadenceUpdater, KnowledgeCacheUpdater,
-// FollowUpManager, and InteractionRecorder in their required order (each
-// downstream consumer takes the earlier ones as constructor args), wiring
-// them into ContactService via its setters exactly as before. The Todoist
-// client factory + writes-enabled boot log and the deferred holders are
-// created here too. No River workers are registered here — that happens in
-// registerCoreConsumerWorkers / registerModeWorkers.
-func buildEventConsumers(
+// buildDomainConsumers constructs the CadenceUpdater, KnowledgeCacheUpdater,
+// and FollowUpManager in their required order (each downstream consumer takes
+// the earlier ones as constructor args). These are built BEFORE ContactService
+// (INV-5) so they can be passed to NewContactService as constructor args. The
+// Todoist client factory + writes-enabled boot log and the deferred holders
+// are created here too. The InteractionRecorder is built separately
+// (buildInteractionRecorder) after ContactService exists. No River workers are
+// registered here — that happens in registerCoreConsumerWorkers /
+// registerModeWorkers.
+func buildDomainConsumers(
 	cfg *config.Config,
 	database *db.Database,
 	core coreRepos,
-	graph contactCore,
-	ingest ingestRepos,
-	messaging messagingFoundation,
+	graph graphCore,
 	eventBus *events.Bus,
 	riverClient *river.Client[pgx.Tx],
 ) eventConsumers {
 	contactRepo := core.Contact
 	contactTaskRepo := core.ContactTask
 	interactionRepo := core.Interaction
-	contactService := graph.ContactService
-	assertService := graph.AssertService
 	graphAssertionRepo := graph.GraphAssertion
 	graphNodeRepo := graph.GraphNode
-	stagingRegistry := messaging.StagingRegistry
-	venueResolver := messaging.VenueResolver
-	calendarRepoForIngest := ingest.CalendarEvent
 
 	// Aggregator reenqueuer holder. The Telegram entry needs the
 	// Telegram aggregation engine, which is constructed later (inside
@@ -71,14 +66,13 @@ func buildEventConsumers(
 	// interaction has already committed.
 	aggregatorReenqueuerHolder := &deferredAggregatorReenqueuer{}
 
-	// CadenceUpdater must be constructed BEFORE InteractionRecorder so
-	// the recorder can inline-invoke it after bus.PublishTx on fresh
-	// writes. Wired here even though its worker is registered further
-	// down, so the construction order matches the runtime dispatch
-	// order. contactRepo.SetPool is called at the first writer-path
-	// construction so the cadence updater can open its own tx if ever
-	// needed outside the caller's tx (defensive — the current path
-	// always runs in the caller's tx).
+	// CadenceUpdater must be constructed BEFORE ContactService so it can be
+	// passed as a NewContactService arg (inline-invoked after bus.PublishTx on
+	// fresh writes). Wired here even though its worker is registered further
+	// down, so the construction order matches the runtime dispatch order.
+	// contactRepo.SetPool is called at the first writer-path construction so
+	// the cadence updater can open its own tx if ever needed outside the
+	// caller's tx (defensive — the current path always runs in the caller's tx).
 	contactRepo.SetPool(database.Pool)
 	eventClaimRepo := repository.NewEventConsumerClaimRepository(database.Queries)
 	cadenceUpdater := consumer.NewCadenceUpdater(
@@ -89,19 +83,15 @@ func buildEventConsumers(
 		cfg.EventBus.UnsafeAllowOffMode,
 	)
 
-	// Wire CadenceUpdater into ContactService so Merge / Extend / Promote
-	// / UpdateContact cadence-edit paths route cadence writes through
-	// the sole writer.
-	contactService.SetCadenceUpdater(cadenceUpdater)
-
 	// Knowledge-cache consumer (the location/birthday/how_met authority flip):
 	// the sole writer of those three derived cache columns. ContactService emits
 	// lives_in/birthday/how_met assertions through AssertService and calls
 	// knowledgeCacheUpdater.RefreshTx inline (no read-path gap on a user edit);
 	// the registered KnowledgeCacheUpdaterWorker (below) handles assertion.accepted
 	// /superseded events from any other producer (extractors, rollover, retraction).
+	// Built before ContactService so it (with graph.AssertService) is passed as
+	// the knowledge-writer ctor pair.
 	knowledgeCacheUpdater := consumer.NewKnowledgeCacheUpdater(graphAssertionRepo, graphNodeRepo, contactRepo)
-	contactService.SetKnowledgeWriter(assertService, knowledgeCacheUpdater)
 
 	// Todoist client factory, built once with the running CRM_ENV so the
 	// outbound-write guard (Spec C) applies at every production write site.
@@ -128,14 +118,14 @@ func buildEventConsumers(
 
 	// FollowUpManager consumer — the sole writer of
 	// contact_task.kind='follow_up' lifecycle post-cutover. Constructed
-	// BEFORE the InteractionRecorder because the recorder takes it as a
-	// constructor arg (inline-invoke on fresh writes). Todoist settings
-	// are looked up via a deferred holder populated later in the
-	// external-sync branch; until populated, Todoist-dependent post-
-	// commit paths (refresh item_update, close retries) degrade to
+	// BEFORE ContactService because it is passed to NewContactService as the
+	// followUp arg (and to the InteractionRecorder for inline-invoke on fresh
+	// writes). Todoist settings are looked up via a deferred holder populated
+	// later in the external-sync branch; until populated, Todoist-dependent
+	// post-commit paths (refresh item_update, close retries) degrade to
 	// local-only writes with a logged warning.
 	followUpMode := consumer.FollowUpModeFromConfig(cfg.EventBus.FollowUpMode)
-	followUpSettingsHolder := &followUpSettingsRef{frontendURL: cfg.CORS.FrontendURL}
+	followUpSettingsHolder := &followUpSettingsRef{}
 	followUpSettings := followUpSettingsHolder.fn()
 	followUpManager := consumer.NewFollowUpManager(
 		followUpMode,
@@ -151,47 +141,9 @@ func buildEventConsumers(
 		cfg.CORS.FrontendURL,
 		cfg.Watchdog,
 	)
-	// Wire the consumer as the sole follow-up writer on the direct path.
-	// Non-bus callers (Todoist completion, Promote/Extend) route through
-	// FollowUpManager.ApplyInteraction via ContactService.
-	contactService.SetFollowUpConsumer(followUpManager)
-
-	// Wire the merge-time task-close enqueuer. MergeContacts closes the
-	// source contact's live automated tasks and enqueues the durable Todoist
-	// close job for rows with a real external id; the mode gate matches the
-	// close worker's cutover-only contract (enqueuing in mode 'off' would
-	// only manufacture failing jobs — merge then closes locally with a WARN,
-	// that mode's documented "completion disabled" semantics).
-	contactService.SetTaskCloseEnqueuer(riverClient, cfg.EventBus.FollowUpMode == config.EventBusFollowUpModeCutover)
-
-	// InteractionRecorder consumer + manual handler (spec §3.4.1).
-	// Delegates the write to ContactService.RecordInteractionTx, then
-	// marks telegram_messages processed (for message.* kinds) and emits
-	// interaction.recorded — all inside the caller's tx. After emitting
-	// interaction.recorded, the recorder inline-invokes
-	// cadenceUpdater.HandleEvent + followUpManager.HandleEvent on
-	// fresh writes so cadence + follow-up state apply synchronously and
-	// queued re-deliveries become durable no-ops via
-	// event_consumer_claim.
-	interactionRecorder := consumer.NewInteractionRecorder(
-		contactService,
-		stagingRegistry,
-		eventBus,
-		cadenceUpdater,
-		followUpManager,
-		// calendarRepoForIngest satisfies calendarEventLocker: the
-		// calendar.attended branch takes a FOR SHARE lock on the backing
-		// calendar_event so a concurrent decline DELETE cannot strand a
-		// false interaction.
-		calendarRepoForIngest,
-	)
-	// Populate interaction.venue_id for message.* (telegram/messages/gchat) and
-	// gcal interactions this recorder writes.
-	interactionRecorder.SetVenueResolver(venueResolver)
 
 	return eventConsumers{
 		AggregatorReenqueuerHolder: aggregatorReenqueuerHolder,
-		EventClaimRepo:             eventClaimRepo,
 		CadenceUpdater:             cadenceUpdater,
 		KnowledgeCacheUpdater:      knowledgeCacheUpdater,
 		TodoistClientFactory:       todoistClientFactory,
@@ -199,8 +151,41 @@ func buildEventConsumers(
 		FollowUpSettingsHolder:     followUpSettingsHolder,
 		FollowUpSettings:           followUpSettings,
 		FollowUpManager:            followUpManager,
-		InteractionRecorder:        interactionRecorder,
 	}
+}
+
+// buildInteractionRecorder constructs the InteractionRecorder — the consumer
+// that delegates the write to ContactService.RecordInteractionTx, marks
+// telegram_messages processed (for message.* kinds), and emits
+// interaction.recorded (all inside the caller's tx). After emitting
+// interaction.recorded, the recorder inline-invokes cadenceUpdater.HandleEvent
+// + followUpManager.HandleEvent on fresh writes so cadence + follow-up state
+// apply synchronously and queued re-deliveries become durable no-ops via
+// event_consumer_claim. Built AFTER ContactService (it takes contactService as
+// a ctor arg), unlike the sole-writer consumers built in buildDomainConsumers.
+func buildInteractionRecorder(
+	contactService *service.ContactService,
+	messaging messagingFoundation,
+	ingest ingestRepos,
+	consumers eventConsumers,
+	eventBus *events.Bus,
+) *consumer.InteractionRecorder {
+	interactionRecorder := consumer.NewInteractionRecorder(
+		contactService,
+		messaging.StagingRegistry,
+		eventBus,
+		consumers.CadenceUpdater,
+		consumers.FollowUpManager,
+		// ingest.CalendarEvent satisfies calendarEventLocker: the
+		// calendar.attended branch takes a FOR SHARE lock on the backing
+		// calendar_event so a concurrent decline DELETE cannot strand a
+		// false interaction.
+		ingest.CalendarEvent,
+	)
+	// Populate interaction.venue_id for message.* (telegram/messages/gchat) and
+	// gcal interactions this recorder writes.
+	interactionRecorder.SetVenueResolver(messaging.VenueResolver)
+	return interactionRecorder
 }
 
 // registerCoreConsumerWorkers registers the three always-on core consumer
@@ -213,17 +198,16 @@ func registerCoreConsumerWorkers(
 	reg *riverRegistrar,
 	database *db.Database,
 	core coreRepos,
-	graph contactCore,
+	contactService *service.ContactService,
+	interactionRecorder *consumer.InteractionRecorder,
 	messaging messagingFoundation,
 	consumers eventConsumers,
 	eventBus *events.Bus,
 ) {
 	interactionRepo := core.Interaction
 	contactRepo := core.Contact
-	contactService := graph.ContactService
 	commsMessageRepo := messaging.CommsMessageRepo
 	venueRepo := messaging.VenueRepo
-	interactionRecorder := consumers.InteractionRecorder
 	aggregatorReenqueuerHolder := consumers.AggregatorReenqueuerHolder
 	cadenceUpdater := consumers.CadenceUpdater
 	followUpManager := consumers.FollowUpManager
@@ -271,9 +255,7 @@ func registerCoreConsumerWorkers(
 // is `git revert`. Returns pubBus as a CONCRETE *events.Bus (nil in off
 // mode) so it is threaded by concrete type through the provider wiring, and
 // the manual-interaction handler (nil in off mode).
-func resolveInteractionMode(cfg *config.Config, database *db.Database, consumers eventConsumers, eventBus *events.Bus) (*events.Bus, *service.ManualInteractionHandler) {
-	interactionRecorder := consumers.InteractionRecorder
-
+func resolveInteractionMode(cfg *config.Config, database *db.Database, interactionRecorder *consumer.InteractionRecorder, eventBus *events.Bus) (*events.Bus, *service.ManualInteractionHandler) {
 	effectiveMode := cfg.EventBus.InteractionMode
 	var pubBus *events.Bus
 	var manualHandler *service.ManualInteractionHandler
@@ -398,7 +380,7 @@ func registerModeWorkers(
 // kill-switch mode would permanently ack queued jobs, so rollback is
 // `git revert` only. Rematch handlers themselves (calendar, telegram) are
 // registered elsewhere once their deps are constructed.
-func registerRematchDispatcher(reg *riverRegistrar, graph contactCore, database *db.Database, eventBus *events.Bus) {
+func registerRematchDispatcher(reg *riverRegistrar, graph graphCore, database *db.Database, eventBus *events.Bus) {
 	rematchService := graph.RematchService
 
 	rematchDispatcher := consumer.NewRematchDispatcher(rematchService)

--- a/backend/cmd/crm-api/wire_core.go
+++ b/backend/cmd/crm-api/wire_core.go
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"personal-crm/backend/internal/config"
 	"personal-crm/backend/internal/db"
 	"personal-crm/backend/internal/events"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/service"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/riverqueue/river"
 )
 
 // coreRepos holds the six core-entity repositories every downstream
@@ -70,28 +74,24 @@ func buildIngestRepos(queries db.Querier) ingestRepos {
 	}
 }
 
-// contactCore holds the rematch service, contact service, and graph
-// (SP1) store built around the core repos + event bus.
-type contactCore struct {
+// graphCore holds the rematch service and the graph (SP1) store built
+// around the core repos + event bus. ContactService is NOT built here —
+// it depends on the event-bus consumers (cadence / knowledge / follow-up),
+// so it is constructed by buildContactService once those exist.
+type graphCore struct {
 	RematchService *service.RematchService
-	ContactService *service.ContactService
 	GraphNode      *repository.NodeRepository
-	GraphEntity    *repository.EntityRepository
-	GraphPredicate *repository.PredicateRepository
 	GraphAssertion *repository.AssertionRepository
 	AssertService  *service.AssertService
 }
 
-// buildContactGraphCore constructs the rematch service (above
-// ContactService so it can be passed as the RematchRegistry constructor
-// arg), the ContactService, and the graph (SP1) write store. Handlers
-// register later once their dependencies are constructed.
-func buildContactGraphCore(database *db.Database, repos coreRepos, eventBus *events.Bus) contactCore {
-	// Rematch service — constructed above ContactService so it can be
-	// passed as the RematchRegistry constructor arg.
+// buildGraphCore constructs the rematch service (passed as the ContactService
+// RematchRegistry constructor arg once ContactService is built) and the graph
+// (SP1) write store. Handlers register later once their dependencies are
+// constructed.
+func buildGraphCore(database *db.Database, eventBus *events.Bus) graphCore {
+	// Rematch service — the RematchRegistry ContactService takes as a ctor arg.
 	rematchService := service.NewRematchService()
-
-	contactService := service.NewContactService(database, repos.Contact, repos.ContactMethod, repos.Interaction, repos.ContactTask, eventBus, rematchService)
 
 	// Graph (SP1) write API — the single validated assert() write path over the
 	// node/entity/predicate/assertion store. SP1 ships the service + the daily
@@ -104,15 +104,46 @@ func buildContactGraphCore(database *db.Database, repos coreRepos, eventBus *eve
 		database.Pool, graphNodeRepo, graphEntityRepo, graphPredicateRepo, graphAssertionRepo, eventBus,
 	)
 
-	return contactCore{
+	return graphCore{
 		RematchService: rematchService,
-		ContactService: contactService,
 		GraphNode:      graphNodeRepo,
-		GraphEntity:    graphEntityRepo,
-		GraphPredicate: graphPredicateRepo,
 		GraphAssertion: graphAssertionRepo,
 		AssertService:  assertService,
 	}
+}
+
+// buildContactService constructs the ContactService with its consumer
+// dependencies as constructor args (the INV-5 reorder: the cadence /
+// knowledge / follow-up consumers and the AssertService are all built before
+// the service). cadence + the assertSvc/knowledgeCache pair are the HARD-
+// required deps (their nil-guards fire on the cadence/knowledge write paths);
+// followUp is nil-tolerant. The merge-time task-close enqueuer is a
+// cross-block dependency (the river client is decided here), so it stays a
+// setter, called immediately after construction.
+func buildContactService(
+	cfg *config.Config,
+	database *db.Database,
+	core coreRepos,
+	graph graphCore,
+	consumers eventConsumers,
+	eventBus *events.Bus,
+	riverClient *river.Client[pgx.Tx],
+) *service.ContactService {
+	contactService := service.NewContactService(
+		database, core.Contact, core.ContactMethod, core.Interaction, core.ContactTask,
+		eventBus, graph.RematchService,
+		consumers.CadenceUpdater, graph.AssertService, consumers.KnowledgeCacheUpdater, consumers.FollowUpManager,
+	)
+
+	// Wire the merge-time task-close enqueuer. MergeContacts closes the
+	// source contact's live automated tasks and enqueues the durable Todoist
+	// close job for rows with a real external id; the mode gate matches the
+	// close worker's cutover-only contract (enqueuing in mode 'off' would
+	// only manufacture failing jobs — merge then closes locally with a WARN,
+	// that mode's documented "completion disabled" semantics).
+	contactService.SetTaskCloseEnqueuer(riverClient, cfg.EventBus.FollowUpMode == config.EventBusFollowUpModeCutover)
+
+	return contactService
 }
 
 // messagingFoundation holds the message-store repositories, the

--- a/backend/cmd/crm-api/wire_golden_test.go
+++ b/backend/cmd/crm-api/wire_golden_test.go
@@ -37,6 +37,9 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	// Hoisted out of buildWireChainForGolden (called from parallel subtests) so
+	// the global logger is initialized once, avoiding a data race on logger.Get.
+	logger.Init(config.TestConfig().Logger)
 	os.Exit(testdb.SetupPackage(m, testdb.WithMigrationsPath(migrationsPathForTest())))
 }
 
@@ -187,7 +190,6 @@ func TestWireGoldenLists(t *testing.T) {
 // external-sync stack (for provider enumeration).
 func buildWireChainForGolden(t *testing.T, cfg *config.Config) (*riverRegistrar, syncStack) {
 	t.Helper()
-	logger.Init(cfg.Logger)
 	ctx := context.Background()
 
 	database, err := db.NewDatabase(ctx, cfg.Database)
@@ -217,24 +219,26 @@ func buildWireChainForGolden(t *testing.T, cfg *config.Config) (*riverRegistrar,
 	eventBus := events.NewBus(database.Pool, riverClient, eventRepo)
 
 	ingest := buildIngestRepos(database.Queries)
-	graph := buildContactGraphCore(database, core, eventBus)
+	graph := buildGraphCore(database, eventBus)
 	messaging := buildMessagingFoundation(database.Queries, ingest.MessagesMessage, ingest.CalendarEvent)
-	consumers := buildEventConsumers(cfg, database, core, graph, ingest, messaging, eventBus, riverClient)
-	ingestStk := buildIngestStack(database, core, graph, ingest, messaging, consumers, eventBus, riverClient)
-	registerCoreConsumerWorkers(reg, database, core, graph, messaging, consumers, eventBus)
-	pubBus, _ := resolveInteractionMode(cfg, database, consumers, eventBus)
+	consumers := buildDomainConsumers(cfg, database, core, graph, eventBus, riverClient)
+	contactService := buildContactService(cfg, database, core, graph, consumers, eventBus, riverClient)
+	interactionRecorder := buildInteractionRecorder(contactService, messaging, ingest, consumers, eventBus)
+	ingestStk := buildIngestStack(database, core, contactService, ingest, messaging, consumers, eventBus, riverClient)
+	registerCoreConsumerWorkers(reg, database, core, contactService, interactionRecorder, messaging, consumers, eventBus)
+	pubBus, _ := resolveInteractionMode(cfg, database, interactionRecorder, eventBus)
 	registerModeWorkers(reg, cfg, database, core, consumers, eventBus, riverClient)
 	domain := buildDomainServices(database, core, graph, ingest, consumers, ingestStk, eventBus)
 	registerRematchDispatcher(reg, graph, database, eventBus)
 
 	var syncStk syncStack
 	if cfg.Features.EnableExternalSync {
-		syncStk = buildExternalSync(ctx, cfg, database, core, graph, ingest, messaging, consumers, domain, eventBus, riverClient, pubBus)
+		syncStk = buildExternalSync(ctx, cfg, database, core, contactService, graph, ingest, messaging, consumers, domain, eventBus, riverClient, pubBus)
 	}
 
 	// Telegram is intentionally SKIPPED (Start must not run); a nil
 	// telegramManager is exactly a telegram-disabled boot for aggregation.
-	agg := buildAggregationEngines(database, core, graph, ingest, messaging, consumers, eventBus, riverClient, nil, syncStk.GChatProvider, syncStk.GChatSyncStates)
+	agg := buildAggregationEngines(database, core, contactService, graph, ingest, messaging, consumers, eventBus, riverClient, nil, syncStk.GChatProvider, syncStk.GChatSyncStates)
 	registerMessagingWorkers(reg, ingest, messaging, agg, riverClient)
 
 	machost := buildMacHost(reg, database, core, ingest)

--- a/backend/cmd/crm-api/wire_google.go
+++ b/backend/cmd/crm-api/wire_google.go
@@ -120,7 +120,7 @@ func registerGoogleProviders(deps googleProviderDeps) (*google.GChatSyncProvider
 	}
 
 	// GChat provider: registered into providerRegistry so the scheduler
-	// can run it — this is the go-live switch (PR 3). It stays inert
+	// can run it — this is the go-live switch. It stays inert
 	// until enablement reconciliation creates an enabled gchat sync state
 	// (no state → ListDueSyncStates filters enabled=TRUE → nothing to
 	// dispatch). It is store-only + event-free, so unlike Gmail it does

--- a/backend/cmd/crm-api/wire_handlers.go
+++ b/backend/cmd/crm-api/wire_handlers.go
@@ -21,14 +21,14 @@ type coreHandlers struct {
 // InteractionHandler tolerates a nil manual handler exactly as today).
 func buildCoreHandlers(
 	core coreRepos,
-	graph contactCore,
+	contactService *service.ContactService,
+	graph graphCore,
 	cfg *config.Config,
 	noteService *service.NoteService,
 	manualHandler *service.ManualInteractionHandler,
 ) coreHandlers {
 	contactRepo := core.Contact
 	interactionRepo := core.Interaction
-	contactService := graph.ContactService
 	rematchService := graph.RematchService
 
 	return coreHandlers{

--- a/backend/cmd/crm-api/wire_ingest.go
+++ b/backend/cmd/crm-api/wire_ingest.go
@@ -29,7 +29,7 @@ type ingestStack struct {
 func buildIngestStack(
 	database *db.Database,
 	core coreRepos,
-	graph contactCore,
+	contactService *service.ContactService,
 	ingest ingestRepos,
 	messaging messagingFoundation,
 	consumers eventConsumers,
@@ -38,7 +38,6 @@ func buildIngestStack(
 ) ingestStack {
 	contactRepo := core.Contact
 	interactionRepo := core.Interaction
-	contactService := graph.ContactService
 	identityServiceForIngest := ingest.IdentityService
 	messagesMessageRepo := ingest.MessagesMessage
 	externalContactRepoForIngest := ingest.ExternalContact

--- a/backend/cmd/crm-api/wire_scheduler.go
+++ b/backend/cmd/crm-api/wire_scheduler.go
@@ -118,7 +118,7 @@ func buildStaleness(reg *riverRegistrar, cfg *config.Config, database *db.Databa
 // registerAssertionRollover registers the daily assertion valid-time
 // rollover worker + its periodic job. Stateless; RunOnStart catches up any
 // overdue rollovers on boot.
-func registerAssertionRollover(reg *riverRegistrar, graph contactCore) {
+func registerAssertionRollover(reg *riverRegistrar, graph graphCore) {
 	assertService := graph.AssertService
 
 	// Assertion valid-time rollover — a daily catch-up sweep that terminalizes the

--- a/backend/cmd/crm-api/wire_services.go
+++ b/backend/cmd/crm-api/wire_services.go
@@ -24,7 +24,7 @@ type domainServices struct {
 func buildDomainServices(
 	database *db.Database,
 	core coreRepos,
-	graph contactCore,
+	graph graphCore,
 	ingest ingestRepos,
 	consumers eventConsumers,
 	ingestStk ingestStack,
@@ -45,13 +45,15 @@ func buildDomainServices(
 	importMatchService := service.NewImportMatchService(contactRepo)
 	// EnrichmentService is shared by the import handler (link/import flows) and
 	// the Telegram peer matcher (auto-match enrichment). Constructed at outer
-	// scope so both feature blocks share a single instance.
-	enrichmentService := service.NewEnrichmentService(database, contactRepo, contactMethodRepo, enrichmentRepo, eventBus, rematchService)
-	enrichmentService.SetCadenceUpdater(cadenceUpdater)
-	// Inferred location/birthday from external contact data flow through the
-	// assertion store (agent provenance), not the contact SQL — wire the same
-	// knowledge writer the contact service uses.
-	enrichmentService.SetKnowledgeWriter(assertService, knowledgeCacheUpdater)
+	// scope so both feature blocks share a single instance. The cadence writer
+	// (link/import cadence override) and the knowledge writer (inferred
+	// location/birthday from external contact data flow through the assertion
+	// store, agent provenance, not the contact SQL — the same knowledge writer
+	// the contact service uses) are constructor args.
+	enrichmentService := service.NewEnrichmentService(
+		database, contactRepo, contactMethodRepo, enrichmentRepo, eventBus, rematchService,
+		cadenceUpdater, assertService, knowledgeCacheUpdater,
+	)
 
 	// Address-book method reconcile: re-propagates address-book methods
 	// onto already-linked contacts (auto-propagate for matched, record

--- a/backend/cmd/crm-api/wire_sync.go
+++ b/backend/cmd/crm-api/wire_sync.go
@@ -13,7 +13,6 @@ import (
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/service"
 	"personal-crm/backend/internal/sync"
-	"personal-crm/backend/internal/todoist"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/riverqueue/river"
@@ -34,7 +33,6 @@ type syncStack struct {
 	TodoistHandler          *handlers.TodoistHandler
 	ContactTaskHandler      *handlers.ContactTaskHandler
 	GoogleOAuthService      *google.OAuthService
-	TodoistOAuthService     *todoist.OAuthService
 	ExternalContactRepo     *repository.ExternalContactRepository
 	GChatProvider           *google.GChatSyncProvider
 	GChatSyncStates         google.GChatSyncStateLister
@@ -50,7 +48,8 @@ func buildExternalSync(
 	cfg *config.Config,
 	database *db.Database,
 	core coreRepos,
-	graph contactCore,
+	contactService *service.ContactService,
+	graph graphCore,
 	ingest ingestRepos,
 	messaging messagingFoundation,
 	consumers eventConsumers,
@@ -63,7 +62,6 @@ func buildExternalSync(
 	contactMethodRepo := core.ContactMethod
 	contactTaskRepo := core.ContactTask
 	rematchService := graph.RematchService
-	contactService := graph.ContactService
 	commsMessageRepo := messaging.CommsMessageRepo
 	cadenceUpdater := consumers.CadenceUpdater
 	todoistClientFactory := consumers.TodoistClientFactory
@@ -85,7 +83,6 @@ func buildExternalSync(
 	googleOAuthService, oauthHandler := buildGoogleOAuth(cfg, oauthRepo, syncRepo)
 	todoistOAuthService, oauthHandler, todoistHandler := buildTodoistOAuth(cfg, oauthRepo, syncRepo, oauthHandler, followUpSettingsHolder)
 	stack.GoogleOAuthService = googleOAuthService
-	stack.TodoistOAuthService = todoistOAuthService
 	stack.OAuthHandler = oauthHandler
 	stack.TodoistHandler = todoistHandler
 

--- a/backend/cmd/crm-api/wire_telegram.go
+++ b/backend/cmd/crm-api/wire_telegram.go
@@ -36,14 +36,14 @@ func buildTelegram(
 	cfg *config.Config,
 	database *db.Database,
 	core coreRepos,
-	graph contactCore,
+	contactService *service.ContactService,
+	graph graphCore,
 	messaging messagingFoundation,
 	domain domainServices,
 	pubBus *events.Bus,
 	riverClient *river.Client[pgx.Tx],
 ) telegramStack {
 	interactionRepo := core.Interaction
-	contactService := graph.ContactService
 	rematchService := graph.RematchService
 	telegramMessageRepo := messaging.TelegramMessageRepo
 	enrichmentService := domain.EnrichmentService

--- a/backend/internal/google/contacts_forward_hook_test.go
+++ b/backend/internal/google/contacts_forward_hook_test.go
@@ -59,7 +59,7 @@ func setupGcontactsForwardEnv(t *testing.T) *gcontactsForwardEnv {
 	// nil bus/registry → enrichment adds methods but skips publish (the
 	// forward-hook assertion is on the method landing, not the rematch
 	// event, which the reconcile integration suite covers).
-	enrichSvc := service.NewEnrichmentService(database, contactRepo, methodRepo, enrichmentRepo, nil, nil)
+	enrichSvc := service.NewEnrichmentService(database, contactRepo, methodRepo, enrichmentRepo, nil, nil, nil, nil, nil)
 	reconcile := service.NewAddressBookReconcileService(enrichSvc, contactRepo, methodRepo, externalRepo)
 
 	provider := NewContactsProvider(nil, externalRepo, enrichSvc, identitySvc, reconcile)

--- a/backend/internal/service/contact.go
+++ b/backend/internal/service/contact.go
@@ -74,11 +74,11 @@ type ContactService struct {
 	interactionRepo   *repository.InteractionRepository
 	contactTaskRepo   *repository.ContactTaskRepository
 	// followUp is the FollowUpManager consumer — the sole writer of
-	// contact_task.kind='follow_up' lifecycle post-cutover. Injected via
-	// SetFollowUpConsumer after construction to avoid a circular dep
-	// with consumer wiring. Non-bus callers (Todoist completion path,
-	// Promote/Extend) route through followUp.ApplyInteraction inside
-	// deriveFollowUpClosure.
+	// contact_task.kind='follow_up' lifecycle post-cutover. Passed to
+	// NewContactService. Nil-tolerant: when nil, deriveFollowUpClosure
+	// returns a nil closure and non-bus follow-up work is silently
+	// skipped. Non-bus callers (Todoist completion path, Promote/Extend)
+	// route through followUp.ApplyInteraction inside deriveFollowUpClosure.
 	followUp FollowUpConsumer
 	// bus is the event bus used to publish contact_methods.added on
 	// method-adding mutations. Required in production wiring (main.go).
@@ -92,9 +92,8 @@ type ContactService struct {
 	// bus in production; nil-safe for tests.
 	rematchRegistry RematchRegistry
 	// cadence is the direct-invoke writer (the sole writer of the four
-	// cadence columns post-cutover). Injected via SetCadenceUpdater
-	// after construction to avoid a circular dep with consumer wiring.
-	// When unset, MergeContacts / ExtendInteraction /
+	// cadence columns post-cutover). Passed to NewContactService.
+	// When nil, MergeContacts / ExtendInteraction /
 	// PromoteInteractionToMutual / cadence-edit UpdateContact paths
 	// return an error rather than silently no-op-ing on a code path
 	// that was supposed to mutate cadence state.
@@ -102,12 +101,12 @@ type ContactService struct {
 	// knowledge emits the lives_in/birthday/how_met assertions for
 	// location/birthday/how_met and refreshes the derived cache columns
 	// inline (the authority flip — the assertion store is the source of
-	// truth, the columns are a cache). Injected via SetKnowledgeWriter
-	// after construction to avoid a circular dep with the assert service +
-	// cache-consumer wiring. When unset, CreateContact / UpdateContact /
-	// MergeContacts return an error rather than silently dropping a
-	// location/birthday/how_met write (the columns are no longer written
-	// by the contact SQL).
+	// truth, the columns are a cache). Built by NewContactService from the
+	// (assertSvc, knowledgeCache) pair when both are provided; left nil
+	// when neither is (a half-set pair is a constructor-time panic). When
+	// nil, CreateContact / UpdateContact / MergeContacts return an error
+	// rather than silently dropping a location/birthday/how_met write (the
+	// columns are no longer written by the contact SQL).
 	knowledge *knowledgeWriter
 	// commsRepo carries the savepoint-wrapped comms_message merge repoint
 	// (dedup soft-delete + repoint with one scoped retry). Constructed
@@ -115,8 +114,8 @@ type ContactService struct {
 	commsRepo *repository.CommsMessageRepository
 	// taskCloseEnqueuer inserts the durable Todoist close job for automated
 	// contact_task rows the merge closes with a REAL external id. Injected
-	// via SetTaskCloseEnqueuer after construction (same convention as
-	// SetCadenceUpdater). taskCloseConfigured tracks "setter called"
+	// via SetTaskCloseEnqueuer after construction (a cross-block dependency:
+	// the river client is decided later). taskCloseConfigured tracks "setter called"
 	// separately from taskCloseRemoteEnabled: setter never called + eligible
 	// refs exist → error (wiring bug); called with remoteEnabled=false
 	// (follow-up mode 'off', the documented completion-disabled emergency
@@ -139,6 +138,16 @@ type ContactService struct {
 // contact_methods.added through bus and seed the in-memory job entry via
 // rematchRegistry. Tests that don't exercise rematch may pass nil for
 // both — the publisher silently skips when bus is nil.
+//
+// The promoted consumer dependencies (cadence, assertSvc+knowledgeCache,
+// followUp) carry the nil semantics their former setters had:
+//   - cadence: nil ⇒ Merge/Extend/Promote/cadence-edit paths error (they
+//     must mutate cadence state; a nil writer is a wiring bug on those paths).
+//   - assertSvc + knowledgeCache: both-or-neither. Both non-nil ⇒ the
+//     knowledge writer is built; both nil ⇒ knowledge stays nil and the
+//     create/update/merge knowledge guards error. A HALF-set pair is a
+//     wiring bug and panics at construction (the writer needs both).
+//   - followUp: nil-tolerant ⇒ non-bus follow-up work is silently skipped.
 func NewContactService(
 	database *db.Database,
 	contactRepo *repository.ContactRepository,
@@ -147,6 +156,10 @@ func NewContactService(
 	contactTaskRepo *repository.ContactTaskRepository,
 	bus *events.Bus,
 	rematchRegistry RematchRegistry,
+	cadence cadenceWriter,
+	assertSvc *AssertService,
+	knowledgeCache knowledgeCacheRefresher,
+	followUp FollowUpConsumer,
 ) *ContactService {
 	return &ContactService{
 		database:          database,
@@ -157,6 +170,25 @@ func NewContactService(
 		commsRepo:         repository.NewCommsMessageRepository(database.Queries),
 		bus:               bus,
 		rematchRegistry:   rematchRegistry,
+		cadence:           cadence,
+		knowledge:         buildKnowledgeWriter(assertSvc, knowledgeCache),
+		followUp:          followUp,
+	}
+}
+
+// buildKnowledgeWriter enforces the both-or-neither knowledge-pair rule shared
+// by NewContactService and NewEnrichmentService: both non-nil builds the
+// writer, both nil leaves it nil (the "not wired" guards fire), a half-set pair
+// panics loudly at construction (a wiring bug — the writer cannot persist
+// location/birthday/how_met without both the assert service and the cache).
+func buildKnowledgeWriter(assertSvc *AssertService, knowledgeCache knowledgeCacheRefresher) *knowledgeWriter {
+	switch {
+	case assertSvc != nil && knowledgeCache != nil:
+		return newKnowledgeWriter(assertSvc, knowledgeCache)
+	case assertSvc == nil && knowledgeCache == nil:
+		return nil
+	default:
+		panic("service: knowledge writer requires both assertSvc and knowledgeCache (or neither)")
 	}
 }
 
@@ -182,16 +214,6 @@ func (s *ContactService) InjectMergeCommitBarrierForTest(fn func()) {
 	s.mergeCommitBarrier = fn
 }
 
-// SetFollowUpConsumer injects the FollowUpManager consumer. Matches
-// SetCadenceUpdater's setter-after-construction pattern so main.go
-// can build the service and consumer independently and wire them
-// together once both exist. Non-bus callers (Todoist completion,
-// Promote/Extend) require this dependency to be set — otherwise
-// deriveFollowUpClosure returns nil and no follow-up work fires.
-func (s *ContactService) SetFollowUpConsumer(fm FollowUpConsumer) {
-	s.followUp = fm
-}
-
 // InjectBusForTest swaps the event bus reference after construction.
 // Integration tests have a chicken-and-egg dependency where the bus
 // needs the ContactService (via InteractionRecorder) AND the
@@ -202,29 +224,6 @@ func (s *ContactService) SetFollowUpConsumer(fm FollowUpConsumer) {
 // service is used concurrently; no synchronization is performed.
 func (s *ContactService) InjectBusForTest(bus *events.Bus) {
 	s.bus = bus
-}
-
-// SetCadenceUpdater injects the cadence writer. Main.go wires this
-// after constructing both the service and the consumer.CadenceUpdater;
-// the deferred wire-in avoids a circular construction dependency.
-// Non-event-bus cadence entry points (MergeContacts, ExtendInteraction,
-// PromoteInteractionToMutual, user-driven cadence edits in
-// UpdateContact) require this dependency to be set — otherwise they
-// return an error rather than silently no-op-ing on a code path that
-// was supposed to mutate cadence state.
-func (s *ContactService) SetCadenceUpdater(c cadenceWriter) {
-	s.cadence = c
-}
-
-// SetKnowledgeWriter injects the assertion-store knowledge writer. Main.go
-// wires this after constructing both the AssertService and the
-// KnowledgeCacheUpdater consumer; the deferred wire-in avoids a circular
-// construction dependency (the cache consumer reads the assertion store the
-// AssertService writes). CreateContact / UpdateContact / MergeContacts require
-// it to be set — otherwise a location/birthday/how_met write would silently
-// vanish, since the contact SQL no longer writes those cache columns.
-func (s *ContactService) SetKnowledgeWriter(assertSvc *AssertService, cache knowledgeCacheRefresher) {
-	s.knowledge = newKnowledgeWriter(assertSvc, cache)
 }
 
 // HasPendingFollowUp checks if a contact has a pending follow-up task
@@ -284,7 +283,7 @@ func (s *ContactService) CreateContact(ctx context.Context, req repository.Creat
 		// written by the contact SQL — they flow from the assertion store via
 		// the knowledge writer. Refusing to operate without it prevents a
 		// silent drop of those fields.
-		return nil, uuid.Nil, errors.New("create contact: knowledge writer not wired (call SetKnowledgeWriter)")
+		return nil, uuid.Nil, errors.New("create contact: knowledge writer not wired (pass assertSvc+knowledgeCache to NewContactService)")
 	}
 	tx, err := s.database.Pool.Begin(ctx)
 	if err != nil {
@@ -388,12 +387,12 @@ func (s *ContactService) UpdateContact(ctx context.Context, id uuid.UUID, req re
 		// edits must route through CadenceUpdater. Refusing to operate
 		// without it prevents a silent rollback to the direct-path
 		// behavior.
-		return nil, uuid.Nil, errors.New("update contact: cadence updater not wired (call SetCadenceUpdater)")
+		return nil, uuid.Nil, errors.New("update contact: cadence updater not wired (pass cadence to NewContactService)")
 	}
 	if s.knowledge == nil {
 		// Authority-flip invariant: location/birthday/how_met flow from the
-		// assertion store, not the contact SQL. See SetKnowledgeWriter.
-		return nil, uuid.Nil, errors.New("update contact: knowledge writer not wired (call SetKnowledgeWriter)")
+		// assertion store, not the contact SQL.
+		return nil, uuid.Nil, errors.New("update contact: knowledge writer not wired (pass assertSvc+knowledgeCache to NewContactService)")
 	}
 	tx, err := s.database.Pool.Begin(ctx)
 	if err != nil {
@@ -715,7 +714,7 @@ func (s *ContactService) RecordInteractionTx(
 	// queued delivery.
 	if !publishesEvent {
 		if s.cadence == nil {
-			return nil, errors.New("record interaction: cadence updater not wired (call SetCadenceUpdater)")
+			return nil, errors.New("record interaction: cadence updater not wired (pass cadence to NewContactService)")
 		}
 		if err := s.cadence.ApplyInteraction(ctx, tx, repository.ApplyInteractionRequest{
 			ContactID:  req.ContactID,
@@ -783,7 +782,7 @@ func (s *ContactService) PromoteInteractionToMutualTx(
 	ctx context.Context, tx pgx.Tx, interactionID, contactID uuid.UUID, replyAt time.Time,
 ) (func(context.Context), error) {
 	if s.cadence == nil {
-		return nil, errors.New("promote interaction: cadence updater not wired (call SetCadenceUpdater)")
+		return nil, errors.New("promote interaction: cadence updater not wired (pass cadence to NewContactService)")
 	}
 	updated, err := s.updateInteractionDirectionTx(ctx, tx, interactionID, repository.InteractionDirectionMutual, replyAt)
 	if err != nil {
@@ -836,7 +835,7 @@ func (s *ContactService) ExtendInteractionTx(
 	ctx context.Context, tx pgx.Tx, interactionID, contactID uuid.UUID, direction string, occurredAt time.Time, description *string,
 ) (func(context.Context), error) {
 	if s.cadence == nil {
-		return nil, errors.New("extend interaction: cadence updater not wired (call SetCadenceUpdater)")
+		return nil, errors.New("extend interaction: cadence updater not wired (pass cadence to NewContactService)")
 	}
 	updated, err := s.updateInteractionTimestampTx(ctx, tx, interactionID, occurredAt, description)
 	if err != nil {
@@ -1497,7 +1496,7 @@ func (s *ContactService) MergeContacts(ctx context.Context, req MergeContactsReq
 	}
 
 	if s.knowledge == nil {
-		return nil, errors.New("merge contacts: knowledge writer not wired (call SetKnowledgeWriter)")
+		return nil, errors.New("merge contacts: knowledge writer not wired (pass assertSvc+knowledgeCache to NewContactService)")
 	}
 
 	// 7-graph. Graph merge FIRST: tombstone the source person node
@@ -1536,7 +1535,7 @@ func (s *ContactService) MergeContacts(ctx context.Context, req MergeContactsReq
 	// the pre-merge target.cadence, which might have been overwritten
 	// above.
 	if s.cadence == nil {
-		return nil, errors.New("merge contacts: cadence updater not wired (call SetCadenceUpdater)")
+		return nil, errors.New("merge contacts: cadence updater not wired (pass cadence to NewContactService)")
 	}
 	mergedFields := buildMergeCadenceFields(targetContact, sourceContact, updateReq.Cadence)
 	if err := s.cadence.BulkApply(ctx, tx, req.TargetContactID, mergedFields); err != nil {

--- a/backend/internal/service/enrichment.go
+++ b/backend/internal/service/enrichment.go
@@ -43,9 +43,10 @@ type EnrichmentService struct {
 	// knowledge persists inferred location/birthday/how_met as assertions and
 	// refreshes the derived cache columns inline. Post-cutover the contact SQL
 	// no longer writes those columns, so an enrichment that infers them MUST
-	// route through this writer or the value silently vanishes. Injected via
-	// SetKnowledgeWriter; when unset, an enrichment that would set one of those
-	// three fields returns an error rather than dropping it.
+	// route through this writer or the value silently vanishes. Built by
+	// NewEnrichmentService from the (assertSvc, knowledgeCache) pair; when nil,
+	// an enrichment that would set one of those three fields returns an error
+	// rather than dropping it.
 	knowledge *knowledgeWriter
 }
 
@@ -57,6 +58,17 @@ type EnrichmentService struct {
 // and seed the in-memory job entry via rematchRegistry. Tests that
 // don't exercise rematch may pass nil for both — the publisher silently
 // skips when bus is nil.
+//
+// The promoted consumer dependencies carry the nil semantics their former
+// setters had:
+//   - cadence: conditionally required ⇒ nil is legal (crm-admin passes nil);
+//     only a cadence-override request errors when it is nil.
+//   - assertSvc + knowledgeCache: both-or-neither. Both non-nil builds the
+//     knowledge writer; both nil leaves it nil (an inferred
+//     location/birthday enrichment then errors). A half-set pair panics at
+//     construction. Inferred enrichment is stamped with agent provenance
+//     (producer=agent, source_kind=agent_session) since it is derived from
+//     external contact data, not a direct user edit.
 func NewEnrichmentService(
 	database *db.Database,
 	contactRepo *repository.ContactRepository,
@@ -64,6 +76,9 @@ func NewEnrichmentService(
 	enrichmentRepo *repository.EnrichmentRepository,
 	bus *events.Bus,
 	rematchRegistry RematchRegistry,
+	cadence cadenceWriter,
+	assertSvc *AssertService,
+	knowledgeCache knowledgeCacheRefresher,
 ) *EnrichmentService {
 	return &EnrichmentService{
 		database:        database,
@@ -72,24 +87,9 @@ func NewEnrichmentService(
 		enrichmentRepo:  enrichmentRepo,
 		bus:             bus,
 		rematchRegistry: rematchRegistry,
+		cadence:         cadence,
+		knowledge:       buildKnowledgeWriter(assertSvc, knowledgeCache),
 	}
-}
-
-// SetCadenceUpdater injects the cadence writer. Required for the
-// cadence-present link/import override path. When unset, cadence-
-// present enrichment calls return an error rather than silently
-// skipping the sole-writer invariant.
-func (s *EnrichmentService) SetCadenceUpdater(c cadenceWriter) {
-	s.cadence = c
-}
-
-// SetKnowledgeWriter injects the assertion-store knowledge writer. Required for
-// any enrichment that infers location/birthday/how_met (those columns are no
-// longer written by the contact SQL). Inferred enrichment is stamped with agent
-// provenance (producer=agent, source_kind=agent_session) since it is derived
-// from external contact data, not a direct user edit.
-func (s *EnrichmentService) SetKnowledgeWriter(assertSvc *AssertService, cache knowledgeCacheRefresher) {
-	s.knowledge = newKnowledgeWriter(assertSvc, cache)
 }
 
 // InjectBusForTest swaps the event bus reference after construction.
@@ -156,7 +156,7 @@ func (s *EnrichmentService) EnrichContactFromExternal(
 	}
 
 	if (inferred.Location != nil || inferred.Birthday != nil) && s.knowledge == nil {
-		return uuid.Nil, errors.New("enrichment: inferred location/birthday but knowledge writer not wired")
+		return uuid.Nil, errors.New("enrichment: inferred location/birthday but knowledge writer not wired (pass assertSvc+knowledgeCache to NewEnrichmentService)")
 	}
 
 	// Apply updates to contact if any enrichment occurred. This path never
@@ -332,7 +332,7 @@ func (s *EnrichmentService) EnrichContactFromExternalWithSelections(
 	}
 
 	if (inferred.Location != nil || inferred.Birthday != nil) && s.knowledge == nil {
-		return uuid.Nil, errors.New("enrichment: inferred location/birthday but knowledge writer not wired")
+		return uuid.Nil, errors.New("enrichment: inferred location/birthday but knowledge writer not wired (pass assertSvc+knowledgeCache to NewEnrichmentService)")
 	}
 
 	// Update cadence if provided. Explicit cadence overrides from the
@@ -363,7 +363,7 @@ func (s *EnrichmentService) EnrichContactFromExternalWithSelections(
 		var newContactBy *time.Time
 		if cadencePresent {
 			if s.cadence == nil {
-				return uuid.Nil, errors.New("enrichment: cadence override requested but CadenceUpdater not wired")
+				return uuid.Nil, errors.New("enrichment: cadence override requested but cadence updater not wired (pass cadence to NewEnrichmentService)")
 			}
 			newContactBy = deriveContactByFromCadence(contact, cadenceArg)
 		}

--- a/backend/internal/service/ingest.go
+++ b/backend/internal/service/ingest.go
@@ -363,8 +363,9 @@ func (s *IngestService) SetVenueResolver(v IngestVenueResolver) {
 // reconciler. Optional — when unset, handleExternalContactUpserted skips
 // scheduling the reconcile closure (icloud method propagation then only
 // happens via the one-time catchup subcommand). Must be called before
-// the service handles concurrent batches. Mirrors EnrichmentService's
-// SetCadenceUpdater injection pattern.
+// the service handles concurrent batches. This is a genuine cross-block
+// deferred wire-in (the reconciler is built after the IngestService),
+// so it stays a setter.
 func (s *IngestService) SetAddressBookReconciler(r AddressBookReconciler) {
 	s.addressBookReconciler = r
 }

--- a/backend/internal/service/wiring_guards_test.go
+++ b/backend/internal/service/wiring_guards_test.go
@@ -1,0 +1,94 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/db"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests pin the nil semantics preserved by the setter→constructor-arg
+// conversion (PR5): the promoted consumer args carry exactly the behavior their
+// former setters had. A fully-nil consumer set is the "setter never called"
+// posture — the guarded write paths must still return their "not wired" ERRORS
+// (not panic), and a HALF-set knowledge pair must fail LOUDLY at construction.
+
+// stubCacheRefresher is a non-nil knowledgeCacheRefresher for the half-set-pair
+// construction tests (a real cache would drag in the consumer package).
+type stubCacheRefresher struct{}
+
+func (stubCacheRefresher) RefreshTx(context.Context, pgx.Tx, uuid.UUID, string) error { return nil }
+
+// nilContactService builds a ContactService with the fully-nil consumer set.
+// The core repos are nil too: every guarded path asserted below returns its
+// not-wired error BEFORE touching a repo or the pool.
+func nilContactService() *ContactService {
+	return NewContactService(&db.Database{}, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+}
+
+func TestContactService_NilKnowledge_CreateContactErrors(t *testing.T) {
+	t.Parallel()
+	_, _, err := nilContactService().CreateContact(
+		context.Background(), repository.CreateContactRequest{FullName: "guard"}, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "knowledge writer not wired")
+}
+
+func TestContactService_NilCadence_PromoteErrors(t *testing.T) {
+	t.Parallel()
+	_, err := nilContactService().PromoteInteractionToMutualTx(
+		context.Background(), nil, uuid.New(), uuid.New(), time.Time{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cadence updater not wired")
+}
+
+func TestContactService_NilCadence_ExtendErrors(t *testing.T) {
+	t.Parallel()
+	_, err := nilContactService().ExtendInteractionTx(
+		context.Background(), nil, uuid.New(), uuid.New(), repository.InteractionDirectionMutual, time.Time{}, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cadence updater not wired")
+}
+
+func TestNewContactService_HalfSetKnowledgePairPanics(t *testing.T) {
+	t.Parallel()
+	assertSvc := NewAssertService(nil, nil, nil, nil, nil, nil)
+	// assertSvc set, cache nil → half-set → panic.
+	require.Panics(t, func() {
+		NewContactService(&db.Database{}, nil, nil, nil, nil, nil, nil, nil, assertSvc, nil, nil)
+	})
+	// cache set, assertSvc nil → half-set → panic.
+	require.Panics(t, func() {
+		NewContactService(&db.Database{}, nil, nil, nil, nil, nil, nil, nil, nil, stubCacheRefresher{}, nil)
+	})
+}
+
+func TestNewEnrichmentService_HalfSetKnowledgePairPanics(t *testing.T) {
+	t.Parallel()
+	assertSvc := NewAssertService(nil, nil, nil, nil, nil, nil)
+	require.Panics(t, func() {
+		NewEnrichmentService(&db.Database{}, nil, nil, nil, nil, nil, nil, assertSvc, nil)
+	})
+	require.Panics(t, func() {
+		NewEnrichmentService(&db.Database{}, nil, nil, nil, nil, nil, nil, nil, stubCacheRefresher{})
+	})
+}
+
+// TestNewServices_NilPairLeavesKnowledgeNil documents the both-neither branch:
+// a fully-nil pair must NOT build a knowledge writer (an unconditional wrap
+// would flip the clean "not wired" guard into a nil-pointer panic deep in
+// assertCreate). Proven indirectly by the guarded-path error tests above +
+// asserted here at construction (no panic, service constructs cleanly).
+func TestNewServices_NilPairConstructsCleanly(t *testing.T) {
+	t.Parallel()
+	require.NotPanics(t, func() {
+		nilContactService()
+		NewEnrichmentService(&db.Database{}, nil, nil, nil, nil, nil, nil, nil, nil)
+	})
+}

--- a/backend/internal/synthetic/replay/harness_setup.go
+++ b/backend/internal/synthetic/replay/harness_setup.go
@@ -162,9 +162,6 @@ func newHarness(ctx context.Context, database *db.Database, namespace string, se
 	}
 
 	identityService := service.NewIdentityService(identityRepo)
-	// Contact service built with nil bus first; the real bus is injected after
-	// the client/bus exist (chicken-and-egg, mirroring the canonical harness).
-	contactService := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, contactTaskRepo, nil, nil)
 
 	// River workers: the deferred-shim construction order (bus needs client; the
 	// real workers need bus). Real workers: interaction_recorder, cadence_updater,
@@ -199,22 +196,31 @@ func newHarness(ctx context.Context, database *db.Database, namespace string, se
 	}
 
 	bus := events.NewBus(database.Pool, client, eventRepo)
-	contactService.InjectBusForTest(bus)
 
-	// Cadence updater (cutover) wired into the contact service.
+	// Cadence updater (cutover) — passed to NewContactService as a ctor arg.
 	cadenceUpdater := consumer.NewCadenceUpdater(claimRepo, contactRepo, database.Queries, consumer.CadenceModeCutover, false)
-	contactService.SetCadenceUpdater(cadenceUpdater)
 
 	// Knowledge writer (location/birthday/how_met authority flip): the contact
 	// service emits lives_in/birthday/how_met assertions through AssertService and
-	// refreshes the derived cache columns inline via KnowledgeCacheUpdater.
+	// refreshes the derived cache columns inline via KnowledgeCacheUpdater. Both
+	// are passed to NewContactService as the knowledge-writer ctor pair.
 	graphNodeRepo := repository.NewNodeRepository(database.Queries)
 	graphEntityRepo := repository.NewEntityRepository(database.Queries)
 	graphPredicateRepo := repository.NewPredicateRepository(database.Queries)
 	graphAssertionRepo := repository.NewAssertionRepository(database.Queries)
 	assertService := service.NewAssertService(database.Pool, graphNodeRepo, graphEntityRepo, graphPredicateRepo, graphAssertionRepo, bus)
 	knowledgeCache := consumer.NewKnowledgeCacheUpdater(graphAssertionRepo, graphNodeRepo, contactRepo)
-	contactService.SetKnowledgeWriter(assertService, knowledgeCache)
+
+	// Contact service — built AFTER cadence + assertService + knowledgeCache so
+	// they pass as ctor args (INV-5 order). followUp is deliberately nil (this
+	// harness never wires non-bus follow-up work). The real bus is injected after
+	// construction because it needs the client (chicken-and-egg), mirroring the
+	// canonical harness.
+	contactService := service.NewContactService(
+		database, contactRepo, methodRepo, interactionRepo, contactTaskRepo, nil, nil,
+		cadenceUpdater, assertService, knowledgeCache, nil,
+	)
+	contactService.InjectBusForTest(bus)
 
 	// Merge-time task-close enqueuer. Replay merge scenarios seed STANDALONE
 	// contacts (no cadence tasks), so no enqueue-eligible refs exist today;

--- a/backend/tests/address_book_reconcile_integration_test.go
+++ b/backend/tests/address_book_reconcile_integration_test.go
@@ -53,7 +53,7 @@ func setupABReconcileEnv(t *testing.T) *abReconcileEnv {
 	rematchSvc.Register(stubRematchHandler{idType: "phone"})
 	bus := setupRematchEnqueueOnlyBus(t, database)
 
-	enrichmentSvc := service.NewEnrichmentService(database, contactRepo, methodRepo, enrichmentRepo, bus, rematchSvc)
+	enrichmentSvc := service.NewEnrichmentService(database, contactRepo, methodRepo, enrichmentRepo, bus, rematchSvc, nil, nil, nil)
 	reconcile := service.NewAddressBookReconcileService(enrichmentSvc, contactRepo, methodRepo, externalRepo)
 	matchSvc := service.NewImportMatchService(contactRepo)
 

--- a/backend/tests/api/anarlog_discovery_test.go
+++ b/backend/tests/api/anarlog_discovery_test.go
@@ -53,9 +53,10 @@ func setupDiscoveryEnv(t *testing.T) *discoveryTestEnv {
 	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
 	meetingRepo := repository.NewMeetingNoteRepository(database.Queries)
 
-	contactSvc := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, nil, service.NewRematchService())
-	contactSvc.SetCadenceUpdater(wireCadenceUpdaterForAPITest(t, database, contactSvc))
-	wireKnowledgeWriterForAPITest(t, database, nil, contactSvc)
+	cadenceUpdater := buildCadenceUpdaterForAPITest(t, database)
+	assertSvc, cache := buildKnowledgeDepsForAPITest(t, database, nil)
+	contactSvc := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, nil, service.NewRematchService(),
+		cadenceUpdater, assertSvc, cache, nil)
 
 	svc := service.NewAnarlogDiscoveryService(externalRepo, contactSvc)
 

--- a/backend/tests/api/contact_ids_test.go
+++ b/backend/tests/api/contact_ids_test.go
@@ -47,9 +47,9 @@ func setupContactIDsTestRouter() (*gin.Engine, *repository.ContactRepository, fu
 	contactRepo := repository.NewContactRepository(database.Queries)
 	contactMethodRepo := repository.NewContactMethodRepository(database.Queries)
 	interactionRepo := repository.NewInteractionRepository(database.Queries)
-	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, repository.NewContactTaskRepository(database.Queries), nil, nil)
-	wireCadenceUpdaterForAPITest(nil, database, contactService)
-	wireKnowledgeWriterForAPITest(nil, database, nil, contactService)
+	cadenceUpdater := buildCadenceUpdaterForAPITest(nil, database)
+	assertSvc, cache := buildKnowledgeDepsForAPITest(nil, database, nil)
+	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, repository.NewContactTaskRepository(database.Queries), nil, nil, cadenceUpdater, assertSvc, cache, nil)
 	contactHandler := handlers.NewContactHandler(contactService)
 
 	router := gin.New()

--- a/backend/tests/api/contact_merge_test.go
+++ b/backend/tests/api/contact_merge_test.go
@@ -65,9 +65,9 @@ func TestContactMerge_Integration(t *testing.T) {
 
 	// Create service
 	interactionRepo := repository.NewInteractionRepository(database.Queries)
-	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, repository.NewContactTaskRepository(database.Queries), nil, nil)
-	wireCadenceUpdaterForAPITest(t, database, contactService)
-	wireKnowledgeWriterForAPITest(t, database, nil, contactService)
+	cadenceUpdater := buildCadenceUpdaterForAPITest(t, database)
+	assertSvc, cache := buildKnowledgeDepsForAPITest(t, database, nil)
+	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, repository.NewContactTaskRepository(database.Queries), nil, nil, cadenceUpdater, assertSvc, cache, nil)
 
 	t.Run("GetMergePreview_BasicCounts", func(t *testing.T) {
 		// Create target contact

--- a/backend/tests/api/contact_validation_test.go
+++ b/backend/tests/api/contact_validation_test.go
@@ -66,9 +66,9 @@ func setupContactValidationTestRouter() (*gin.Engine, func()) {
 	contactRepo := repository.NewContactRepository(database.Queries)
 	contactMethodRepo := repository.NewContactMethodRepository(database.Queries)
 	interactionRepo := repository.NewInteractionRepository(database.Queries)
-	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, repository.NewContactTaskRepository(database.Queries), nil, nil)
-	wireCadenceUpdaterForAPITest(nil, database, contactService)
-	wireKnowledgeWriterForAPITest(nil, database, nil, contactService)
+	cadenceUpdater := buildCadenceUpdaterForAPITest(nil, database)
+	assertSvc, cache := buildKnowledgeDepsForAPITest(nil, database, nil)
+	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, repository.NewContactTaskRepository(database.Queries), nil, nil, cadenceUpdater, assertSvc, cache, nil)
 	contactHandler := handlers.NewContactHandler(contactService)
 
 	router := gin.New()

--- a/backend/tests/api/external_contact_ingest_test.go
+++ b/backend/tests/api/external_contact_ingest_test.go
@@ -113,7 +113,7 @@ func setupExtContactIngestEnv(t *testing.T) *extContactIngestEnv {
 	// rows that don't resolve to a linked contact, so wiring it here does
 	// not change the behavior of the existing non-reconcile tests.
 	enrichmentRepo := repository.NewEnrichmentRepository(database.Queries)
-	enrichSvc := service.NewEnrichmentService(database, contactRepo, contactMethodRepo, enrichmentRepo, nil, nil)
+	enrichSvc := service.NewEnrichmentService(database, contactRepo, contactMethodRepo, enrichmentRepo, nil, nil, nil, nil, nil)
 	addressBookReconcile := service.NewAddressBookReconcileService(enrichSvc, contactRepo, contactMethodRepo, externalRepo)
 	ingestService.SetAddressBookReconciler(addressBookReconcile)
 

--- a/backend/tests/api/import_with_selections_test.go
+++ b/backend/tests/api/import_with_selections_test.go
@@ -51,13 +51,13 @@ func setupImportTestRouter() (*gin.Engine, *repository.ExternalContactRepository
 
 	// Create services
 	interactionRepo := repository.NewInteractionRepository(database.Queries)
-	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, repository.NewContactTaskRepository(database.Queries), nil, nil)
-	cadenceUpdater := wireCadenceUpdaterForAPITest(nil, database, contactService)
-	knowledgeAssertSvc, knowledgeCache := wireKnowledgeWriterForAPITest(nil, database, nil, contactService)
+	cadenceUpdater := buildCadenceUpdaterForAPITest(nil, database)
+	knowledgeAssertSvc, knowledgeCache := buildKnowledgeDepsForAPITest(nil, database, nil)
+	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, repository.NewContactTaskRepository(database.Queries), nil, nil,
+		cadenceUpdater, knowledgeAssertSvc, knowledgeCache, nil)
 	matchService := service.NewImportMatchService(contactRepo)
-	enrichmentService := service.NewEnrichmentService(database, contactRepo, contactMethodRepo, enrichmentRepo, nil, nil)
-	enrichmentService.SetCadenceUpdater(cadenceUpdater)
-	enrichmentService.SetKnowledgeWriter(knowledgeAssertSvc, knowledgeCache)
+	enrichmentService := service.NewEnrichmentService(database, contactRepo, contactMethodRepo, enrichmentRepo, nil, nil,
+		cadenceUpdater, knowledgeAssertSvc, knowledgeCache)
 	suggestionService := service.NewSuggestionService(externalRepo, contactRepo, contactMethodRepo, enrichmentService, matchService, database)
 
 	// Create handler

--- a/backend/tests/api/ingest_merge_attribution_test.go
+++ b/backend/tests/api/ingest_merge_attribution_test.go
@@ -41,12 +41,11 @@ func newMergeCapableContactService(t *testing.T, env *ingestRawTestEnv) *service
 	assertSvc := service.NewAssertService(database.Pool, nodeRepo, entityRepo, predicateRepo, assertionRepo, bus)
 	cache := consumer.NewKnowledgeCacheUpdater(assertionRepo, nodeRepo, env.contactRepo)
 
-	svc := service.NewContactService(database, env.contactRepo, env.cmRepo, interactionRepo, taskRepo, nil, nil)
-	svc.SetKnowledgeWriter(assertSvc, cache)
-
 	claimRepo := repository.NewEventConsumerClaimRepository(database.Queries)
 	cadenceUpdater := consumer.NewCadenceUpdater(claimRepo, env.contactRepo, database.Queries, consumer.CadenceModeCutover, false)
-	svc.SetCadenceUpdater(cadenceUpdater)
+
+	svc := service.NewContactService(database, env.contactRepo, env.cmRepo, interactionRepo, taskRepo, nil, nil,
+		cadenceUpdater, assertSvc, cache, nil)
 
 	// No contact tasks are seeded in this env; wired defensively so a merge
 	// that ever closes an eligible task takes the WARN-skip path, not the

--- a/backend/tests/api/ingest_raw_message_e2e_test.go
+++ b/backend/tests/api/ingest_raw_message_e2e_test.go
@@ -74,10 +74,10 @@ func setupRawMessageE2E(t *testing.T) *rawMessageE2EEnv {
 	claimRepo := repository.NewEventConsumerClaimRepository(database.Queries)
 	eventRepo := repository.NewEventRepository(database.Queries)
 	rematchSvc := service.NewRematchService()
-	contactSvc := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, nil, rematchSvc)
 	cadenceUpdater := consumer.NewCadenceUpdater(claimRepo, contactRepo, database.Queries, consumer.CadenceModeCutover, false)
-	contactSvc.SetCadenceUpdater(cadenceUpdater)
-	wireKnowledgeWriterForAPITest(t, database, nil, contactSvc)
+	assertSvc, cache := buildKnowledgeDepsForAPITest(t, database, nil)
+	contactSvc := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, nil, rematchSvc,
+		cadenceUpdater, assertSvc, cache, nil)
 	macService := service.NewMacHostService(hostRepo, pairingRepo, syncRepo, nil, nil, nil, database.Pool, 4)
 
 	// River client — wires the real MessagingAggregateForContactWorker

--- a/backend/tests/api/manual_handler_helper_test.go
+++ b/backend/tests/api/manual_handler_helper_test.go
@@ -38,8 +38,6 @@ func buildManualHandlerForTest(ctx context.Context, database *db.Database, cfg *
 	telegramMessageRepo := repository.NewTelegramMessageRepository(database.Queries)
 	eventRepo := repository.NewEventRepository(database.Queries)
 
-	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, nil, nil)
-
 	// Chicken-and-egg: the worker needs the bus, the bus needs the client,
 	// the client needs the workers bundle pre-registered. Register a shim
 	// pointer-wrapper worker, construct client + bus + real recorder, then
@@ -66,7 +64,7 @@ func buildManualHandlerForTest(ctx context.Context, database *db.Database, cfg *
 	}
 
 	bus := events.NewBus(database.Pool, client, eventRepo)
-	// Wire a real CadenceUpdater so API manual-handler tests exercise
+	// Build a real CadenceUpdater so API manual-handler tests exercise
 	// the inline apply-on-publish path against a live DB. contactRepo's
 	// pool is already set upstream by the router wiring; if not,
 	// cadence_updater direct-invoke APIs fall back to the caller's tx.
@@ -77,12 +75,16 @@ func buildManualHandlerForTest(ctx context.Context, database *db.Database, cfg *
 		consumer.CadenceModeCutover, // API tests exercise the cutover writer
 		false,
 	)
-	// Wire cadenceUpdater into the contact service so direct-invoke
-	// paths (Merge / Extend / Promote / RecordInteraction non-bus
-	// wrapper / UpdateContact cadence-edit) reach the sole writer in
-	// these tests.
-	contactService.SetCadenceUpdater(cadenceUpdater)
-	wireKnowledgeWriterForAPITest(nil, database, bus, contactService)
+	// Build the knowledge writer deps + construct the contact service with
+	// cadence + knowledge as ctor args (the setters are gone) so direct-invoke
+	// paths (Merge / Extend / Promote / RecordInteraction non-bus wrapper /
+	// UpdateContact cadence-edit + location/birthday/how_met) reach the sole
+	// writers in these tests.
+	assertSvc, cache := buildKnowledgeDepsForAPITest(nil, database, bus)
+	contactService := service.NewContactService(
+		database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, nil, nil,
+		cadenceUpdater, assertSvc, cache, nil,
+	)
 	stagingRegistry := repository.NewStagingProcessorRegistry(map[string]repository.StagingProcessor{
 		repository.InteractionSourceTelegram: repository.NewTelegramStagingProcessor(telegramMessageRepo),
 	})
@@ -119,44 +121,26 @@ func mustBuildManualHandlerForTest(t *testing.T, ctx context.Context, database *
 	return mh, cs
 }
 
-// wireCadenceUpdaterForAPITest constructs a real CadenceUpdater
-// against the given database and injects it into contactService so
-// cadence entry points (RecordInteraction direct path, MergeContacts,
-// cadence edits via UpdateContact, link/import cadence overrides)
-// exercise the sole writer in API-layer tests that don't need the full
-// event-bus wiring of buildManualHandlerForTest. Returns the
-// constructed CadenceUpdater so callers can also wire it into
-// EnrichmentService. Takes *testing.T so callers that have one can
-// still use t.Helper; pass nil from non-test helpers like
-// setupImportTestRouter.
-func wireCadenceUpdaterForAPITest(t *testing.T, database *db.Database, contactService *service.ContactService) *consumer.CadenceUpdater {
+// buildCadenceUpdaterForAPITest constructs a real CadenceUpdater against the
+// given database so callers can pass it as the cadence ctor arg to
+// NewContactService / NewEnrichmentService and exercise cadence entry points
+// (RecordInteraction direct path, MergeContacts, cadence edits via
+// UpdateContact, link/import cadence overrides) in API-layer tests that don't
+// need the full event-bus wiring of buildManualHandlerForTest. Takes *testing.T
+// so callers that have one can still use t.Helper; pass nil from non-test
+// helpers like setupImportTestRouter.
+func buildCadenceUpdaterForAPITest(t *testing.T, database *db.Database) *consumer.CadenceUpdater {
 	if t != nil {
 		t.Helper()
 	}
 	contactRepo := repository.NewContactRepository(database.Queries)
 	contactRepo.SetPool(database.Pool)
 	claimRepo := repository.NewEventConsumerClaimRepository(database.Queries)
-	cadenceUpdater := consumer.NewCadenceUpdater(
+	return consumer.NewCadenceUpdater(
 		claimRepo, contactRepo, database.Queries,
 		consumer.CadenceModeCutover,
 		false,
 	)
-	contactService.SetCadenceUpdater(cadenceUpdater)
-	return cadenceUpdater
-}
-
-// wireKnowledgeWriterForAPITest wires the location/birthday/how_met authority-flip
-// writer into the contact service. A non-nil bus is reused; a nil bus builds a
-// self-contained insert-only bus so contact-only API tests can still create
-// contacts. Returns the assert service + cache so a caller can also wire an
-// enrichment service against the same instances.
-func wireKnowledgeWriterForAPITest(t *testing.T, database *db.Database, bus *events.Bus, contactService *service.ContactService) (*service.AssertService, *consumer.KnowledgeCacheUpdater) {
-	if t != nil {
-		t.Helper()
-	}
-	assertSvc, cache := buildKnowledgeDepsForAPITest(t, database, bus)
-	contactService.SetKnowledgeWriter(assertSvc, cache)
-	return assertSvc, cache
 }
 
 // buildKnowledgeDepsForAPITest constructs the AssertService + KnowledgeCacheUpdater

--- a/backend/tests/api/meeting_note_ingest_test.go
+++ b/backend/tests/api/meeting_note_ingest_test.go
@@ -144,9 +144,10 @@ func setupMeetingNoteIngestEnv(t *testing.T) *meetingNoteIngestEnv {
 	// publishesEvent=false which would normally require cadence. Wire a
 	// minimal cadence updater for completeness so the tests exercise the
 	// full path the production wiring uses.
-	contactSvc := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, eventBus, service.NewRematchService())
-	contactSvc.SetCadenceUpdater(wireCadenceUpdaterForAPITest(t, database, contactSvc))
-	knowledgeAssertSvc, knowledgeCache := wireKnowledgeWriterForAPITest(t, database, nil, contactSvc)
+	cadenceUpdater := buildCadenceUpdaterForAPITest(t, database)
+	knowledgeAssertSvc, knowledgeCache := buildKnowledgeDepsForAPITest(t, database, nil)
+	contactSvc := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, eventBus, service.NewRematchService(),
+		cadenceUpdater, knowledgeAssertSvc, knowledgeCache, nil)
 
 	titleMatcher := anarlog.NewTitleMatcher(contactRepo)
 	titleDiscoveryWriter := anarlog.NewDiscoveryWriter(externalRepo)
@@ -208,9 +209,8 @@ func setupMeetingNoteIngestEnv(t *testing.T) *meetingNoteIngestEnv {
 	// row to the imported contact).
 	enrichmentRepo := repository.NewEnrichmentRepository(database.Queries)
 	matchService := service.NewImportMatchService(contactRepo)
-	enrichmentSvc := service.NewEnrichmentService(database, contactRepo, contactMethodRepo, enrichmentRepo, nil, nil)
-	enrichmentSvc.SetCadenceUpdater(wireCadenceUpdaterForAPITest(t, database, contactSvc))
-	enrichmentSvc.SetKnowledgeWriter(knowledgeAssertSvc, knowledgeCache)
+	enrichmentSvc := service.NewEnrichmentService(database, contactRepo, contactMethodRepo, enrichmentRepo, nil, nil,
+		buildCadenceUpdaterForAPITest(t, database), knowledgeAssertSvc, knowledgeCache)
 	suggestionSvc := service.NewSuggestionService(externalRepo, contactRepo, contactMethodRepo, enrichmentSvc, matchService, database)
 	importHandler := handlers.NewImportHandler(externalRepo, identityService, contactSvc, matchService, enrichmentSvc, suggestionSvc)
 	imports := router.Group("/api/v1/imports")

--- a/backend/tests/api/note_test.go
+++ b/backend/tests/api/note_test.go
@@ -50,9 +50,9 @@ func setupNoteTestRouter() (*gin.Engine, func()) {
 
 	// Set up services
 	interactionRepo := repository.NewInteractionRepository(database.Queries)
-	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, repository.NewContactTaskRepository(database.Queries), nil, nil)
-	wireCadenceUpdaterForAPITest(nil, database, contactService)
-	wireKnowledgeWriterForAPITest(nil, database, nil, contactService)
+	cadenceUpdater := buildCadenceUpdaterForAPITest(nil, database)
+	assertSvc, cache := buildKnowledgeDepsForAPITest(nil, database, nil)
+	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, repository.NewContactTaskRepository(database.Queries), nil, nil, cadenceUpdater, assertSvc, cache, nil)
 	noteService := service.NewNoteService(noteRepo, contactRepo)
 
 	// Set up handlers

--- a/backend/tests/api/phone_call_ingest_integration_test.go
+++ b/backend/tests/api/phone_call_ingest_integration_test.go
@@ -162,7 +162,6 @@ func setupPhoneCallIngestEnv(t *testing.T) *phoneCallIngestEnv {
 	// Started — avoiding the leadership-Elector teardown cost.
 
 	eventBus := events.NewBus(database.Pool, riverClient, eventRepo)
-	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, eventBus, nil)
 
 	eventClaimRepo := repository.NewEventConsumerClaimRepository(database.Queries)
 	cadenceUpdater := consumer.NewCadenceUpdater(
@@ -172,8 +171,7 @@ func setupPhoneCallIngestEnv(t *testing.T) *phoneCallIngestEnv {
 		consumer.CadenceModeCutover,
 		false,
 	)
-	contactService.SetCadenceUpdater(cadenceUpdater)
-	wireKnowledgeWriterForAPITest(t, database, eventBus, contactService)
+	knowledgeAssertSvc, knowledgeCache := buildKnowledgeDepsForAPITest(t, database, eventBus)
 
 	// FollowUpManager wired to ErrTodoistUnconfigured so the post-commit
 	// Todoist branch degrades to local-only writes. Phone_calls v1.5 has
@@ -196,7 +194,9 @@ func setupPhoneCallIngestEnv(t *testing.T) *phoneCallIngestEnv {
 		cfg.CORS.FrontendURL,
 		cfg.Watchdog,
 	)
-	contactService.SetFollowUpConsumer(followUpManager)
+
+	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, eventBus, nil,
+		cadenceUpdater, knowledgeAssertSvc, knowledgeCache, followUpManager)
 
 	// Optional fail-writer wrapper. failWriter starts disabled (both
 	// failOn* fields nil) so it behaves identically to the real repo.

--- a/backend/tests/api/telegram_chat_api_test.go
+++ b/backend/tests/api/telegram_chat_api_test.go
@@ -86,9 +86,9 @@ func setupTelegramChatRouter(t *testing.T) (*gin.Engine, *repository.TelegramCha
 	contactRepo := repository.NewContactRepository(database.Queries)
 	contactMethodRepo := repository.NewContactMethodRepository(database.Queries)
 	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
-	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, nil, nil)
-	wireCadenceUpdaterForAPITest(t, database, contactService)
-	wireKnowledgeWriterForAPITest(t, database, nil, contactService)
+	cadenceUpdater := buildCadenceUpdaterForAPITest(t, database)
+	assertSvc, cache := buildKnowledgeDepsForAPITest(t, database, nil)
+	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, nil, nil, cadenceUpdater, assertSvc, cache, nil)
 
 	manager := tgpkg.NewTelegramManager(
 		sessionRepo,

--- a/backend/tests/comms_gchat_engine_test.go
+++ b/backend/tests/comms_gchat_engine_test.go
@@ -51,11 +51,12 @@ func setupGChatEngineTest(t *testing.T) *gchatTestEnv {
 	commsRepo := repository.NewCommsMessageRepository(database.Queries)
 	interactionRepo := repository.NewInteractionRepository(database.Queries)
 	contactRepo := repository.NewContactRepository(database.Queries)
-	contactMethodRepo := repository.NewContactMethodRepository(database.Queries)
-	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
-	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, nil, nil)
 
-	bus := setupGChatEventBus(t, ctx, database, contactService, commsRepo)
+	// setupGChatEventBus builds the bus + the ContactService together: the
+	// service takes the cadence/knowledge consumers as ctor args, and the
+	// knowledge writer needs the bus, so the bus must exist first (the bus's
+	// recorder worker is a deferred shim, filled after the service exists).
+	bus, contactService := setupGChatEventBus(t, ctx, database, commsRepo)
 
 	engine := google.NewGChatAggregationEngine(
 		2, 48, // burst window 2h, reply bridge 48h
@@ -83,9 +84,8 @@ func setupGChatEventBus(
 	t *testing.T,
 	ctx context.Context,
 	database *db.Database,
-	contactService *service.ContactService,
 	commsRepo *repository.CommsMessageRepository,
-) *events.Bus {
+) (*events.Bus, *service.ContactService) {
 	t.Helper()
 
 	eventRepo := repository.NewEventRepository(database.Queries)
@@ -116,8 +116,15 @@ func setupGChatEventBus(
 		consumer.CadenceModeCutover,
 		false,
 	)
-	contactService.SetCadenceUpdater(cadenceUpdater)
-	wireKnowledgeWriterForTest(t, database, bus, contactService)
+	assertSvc, cache := buildKnowledgeDeps(t, database, bus)
+	contactService := service.NewContactService(
+		database, contactRepo,
+		repository.NewContactMethodRepository(database.Queries),
+		repository.NewInteractionRepository(database.Queries),
+		repository.NewContactTaskRepository(database.Queries),
+		nil, nil,
+		cadenceUpdater, assertSvc, cache, nil,
+	)
 	// The gchat session-scoped processor is the load-bearing decision-8b entry.
 	stagingRegistry := repository.NewStagingProcessorRegistry(map[string]repository.StagingProcessor{
 		repository.InteractionSourceGChat: repository.NewCommsSessionStagingProcessor(commsRepo),
@@ -132,7 +139,7 @@ func setupGChatEventBus(
 		_ = client.Stop(stopCtx)
 	})
 
-	return bus
+	return bus, contactService
 }
 
 // newGChatContact creates a contact and registers hard-delete cleanup for its

--- a/backend/tests/consumer_interaction_recorder_integration_test.go
+++ b/backend/tests/consumer_interaction_recorder_integration_test.go
@@ -137,10 +137,9 @@ func newConsumerTestEnv(t *testing.T, ctx context.Context) *consumerTestEnv {
 	var recorder *consumer.InteractionRecorder
 	bus := newConsumerTestBus(t, ctx, database, cfg, &recorder)
 
-	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, nil, nil)
-	// Wire a real CadenceUpdater so the recorder's inline-apply seam
+	// Build a real CadenceUpdater so the recorder's inline-apply seam
 	// writes cadence columns against a live DB in these integration
-	// tests.
+	// tests. cadence + knowledge are ctor args (the setters are gone).
 	contactRepo.SetPool(database.Pool)
 	claimRepo := repository.NewEventConsumerClaimRepository(database.Queries)
 	cadenceUpdater := consumer.NewCadenceUpdater(
@@ -148,8 +147,9 @@ func newConsumerTestEnv(t *testing.T, ctx context.Context) *consumerTestEnv {
 		consumer.CadenceModeCutover,
 		false,
 	)
-	contactService.SetCadenceUpdater(cadenceUpdater)
-	wireKnowledgeWriterForTest(t, database, bus, contactService)
+	assertSvc, cache := buildKnowledgeDeps(t, database, bus)
+	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, nil, nil,
+		cadenceUpdater, assertSvc, cache, nil)
 	stagingRegistry := repository.NewStagingProcessorRegistry(map[string]repository.StagingProcessor{
 		repository.InteractionSourceTelegram: repository.NewTelegramStagingProcessor(telegramMessageRepo),
 	})

--- a/backend/tests/contact_by_integration_test.go
+++ b/backend/tests/contact_by_integration_test.go
@@ -345,9 +345,9 @@ func TestContactBy_CadenceStateTransitions(t *testing.T) {
 	contactMethodRepo := repository.NewContactMethodRepository(database.Queries)
 	interactionRepo := repository.NewInteractionRepository(database.Queries)
 	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
-	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, nil, nil)
-	wireCadenceUpdaterForTest(t, database, contactService)
-	wireKnowledgeWriterForTest(t, database, nil, contactService)
+	cadenceUpdater := buildCadenceUpdaterForTest(t, database)
+	assertSvc, cache := buildKnowledgeDeps(t, database, nil)
+	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, nil, nil, cadenceUpdater, assertSvc, cache, nil)
 
 	t.Run("set cadence -> clear cadence -> set cadence", func(t *testing.T) {
 		weeklyStr := "weekly"

--- a/backend/tests/contact_knowledge_cutover_integration_test.go
+++ b/backend/tests/contact_knowledge_cutover_integration_test.go
@@ -81,13 +81,12 @@ func newKnowledgeCutoverHarness(t *testing.T, ctx context.Context) *knowledgeCut
 	assertSvc := service.NewAssertService(database.Pool, nodeRepo, entityRepo, predicateRepo, assertionRepo, bus)
 	cacheUpdater := consumer.NewKnowledgeCacheUpdater(assertionRepo, nodeRepo, contactRepo)
 
-	contactSvc := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, taskRepo, nil, nil)
-	contactSvc.SetKnowledgeWriter(assertSvc, cacheUpdater)
-	wireCadenceUpdaterForTest(t, database, contactSvc)
+	contactSvc := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, taskRepo, nil, nil,
+		buildCadenceUpdaterForTest(t, database), assertSvc, cacheUpdater, nil)
 
 	enrichmentRepo := repository.NewEnrichmentRepository(database.Queries)
-	enrichSvc := service.NewEnrichmentService(database, contactRepo, methodRepo, enrichmentRepo, nil, nil)
-	enrichSvc.SetKnowledgeWriter(assertSvc, cacheUpdater)
+	enrichSvc := service.NewEnrichmentService(database, contactRepo, methodRepo, enrichmentRepo, nil, nil,
+		nil, assertSvc, cacheUpdater)
 
 	migrationSvc := service.NewContactKnowledgeMigrationService(database.Pool, contactRepo, assertSvc)
 

--- a/backend/tests/contact_merge_identity_attribution_integration_test.go
+++ b/backend/tests/contact_merge_identity_attribution_integration_test.go
@@ -104,9 +104,8 @@ func newMergeAttrHarnessWith(t *testing.T, ctx context.Context, wireTaskCloseEnq
 	assertSvc := service.NewAssertService(database.Pool, nodeRepo, entityRepo, predicateRepo, assertionRepo, bus)
 	cacheUpdater := consumer.NewKnowledgeCacheUpdater(assertionRepo, nodeRepo, contactRepo)
 
-	contactSvc := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, taskRepo, nil, nil)
-	contactSvc.SetKnowledgeWriter(assertSvc, cacheUpdater)
-	wireCadenceUpdaterForTest(t, database, contactSvc)
+	contactSvc := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, taskRepo, nil, nil,
+		buildCadenceUpdaterForTest(t, database), assertSvc, cacheUpdater, nil)
 	if wireTaskCloseEnqueuer {
 		contactSvc.SetTaskCloseEnqueuer(client, remoteCloseEnabled)
 	}

--- a/backend/tests/contact_merge_node_integration_test.go
+++ b/backend/tests/contact_merge_node_integration_test.go
@@ -73,9 +73,8 @@ func newMergeNodeHarness(t *testing.T, ctx context.Context) *mergeNodeHarness {
 	assertSvc := service.NewAssertService(database.Pool, nodeRepo, entityRepo, predicateRepo, assertionRepo, bus)
 	cacheUpdater := consumer.NewKnowledgeCacheUpdater(assertionRepo, nodeRepo, contactRepo)
 
-	contactSvc := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, taskRepo, nil, nil)
-	contactSvc.SetKnowledgeWriter(assertSvc, cacheUpdater)
-	wireCadenceUpdaterForTest(t, database, contactSvc)
+	contactSvc := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, taskRepo, nil, nil,
+		buildCadenceUpdaterForTest(t, database), assertSvc, cacheUpdater, nil)
 
 	h := &mergeNodeHarness{
 		database:      database,

--- a/backend/tests/contact_node_dualwrite_integration_test.go
+++ b/backend/tests/contact_node_dualwrite_integration_test.go
@@ -76,9 +76,9 @@ func TestContactNodeDualWrite_Integration(t *testing.T) {
 		methodRepo := repository.NewContactMethodRepository(database.Queries)
 		interactionRepo := repository.NewInteractionRepository(database.Queries)
 		taskRepo := repository.NewContactTaskRepository(database.Queries)
-		svc := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, taskRepo, nil, nil)
-		wireCadenceUpdaterForTest(t, database, svc)
-		wireKnowledgeWriterForTest(t, database, nil, svc)
+		cadenceUpdater := buildCadenceUpdaterForTest(t, database)
+		assertSvc, cache := buildKnowledgeDeps(t, database, nil)
+		svc := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, taskRepo, nil, nil, cadenceUpdater, assertSvc, cache, nil)
 
 		spec := gen.Contact()
 		contact, _, err := svc.CreateContact(ctx, repository.CreateContactRequest{
@@ -109,9 +109,9 @@ func TestContactNodeDualWrite_Integration(t *testing.T) {
 		methodRepo := repository.NewContactMethodRepository(database.Queries)
 		interactionRepo := repository.NewInteractionRepository(database.Queries)
 		taskRepo := repository.NewContactTaskRepository(database.Queries)
-		svc := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, taskRepo, nil, nil)
-		wireCadenceUpdaterForTest(t, database, svc)
-		wireKnowledgeWriterForTest(t, database, nil, svc)
+		cadenceUpdater := buildCadenceUpdaterForTest(t, database)
+		assertSvc, cache := buildKnowledgeDeps(t, database, nil)
+		svc := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, taskRepo, nil, nil, cadenceUpdater, assertSvc, cache, nil)
 
 		spec := gen.Contact()
 		contact, _, err := svc.CreateContact(ctx, repository.CreateContactRequest{
@@ -148,12 +148,12 @@ func TestContactNodeDualWrite_Integration(t *testing.T) {
 		taskRepo := repository.NewContactTaskRepository(database.Queries)
 		enrichmentRepo := repository.NewEnrichmentRepository(database.Queries)
 		externalRepo := repository.NewExternalContactRepository(database.Queries)
-		svc := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, taskRepo, nil, nil)
-		// nil bus/registry → enrichment skips publish.
-		enrichSvc := service.NewEnrichmentService(database, contactRepo, methodRepo, enrichmentRepo, nil, nil)
 		knowledgeAssertSvc, knowledgeCache := buildKnowledgeDeps(t, database, nil)
-		svc.SetKnowledgeWriter(knowledgeAssertSvc, knowledgeCache)
-		enrichSvc.SetKnowledgeWriter(knowledgeAssertSvc, knowledgeCache)
+		svc := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, taskRepo, nil, nil,
+			nil, knowledgeAssertSvc, knowledgeCache, nil)
+		// nil bus/registry → enrichment skips publish.
+		enrichSvc := service.NewEnrichmentService(database, contactRepo, methodRepo, enrichmentRepo, nil, nil,
+			nil, knowledgeAssertSvc, knowledgeCache)
 
 		spec := gen.Contact()
 		contact, _, err := svc.CreateContact(ctx, repository.CreateContactRequest{
@@ -193,15 +193,14 @@ func TestContactNodeDualWrite_Integration(t *testing.T) {
 		taskRepo := repository.NewContactTaskRepository(database.Queries)
 		enrichmentRepo := repository.NewEnrichmentRepository(database.Queries)
 		externalRepo := repository.NewExternalContactRepository(database.Queries)
-		svc := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, taskRepo, nil, nil)
-		enrichSvc := service.NewEnrichmentService(database, contactRepo, methodRepo, enrichmentRepo, nil, nil)
 		// The cadence-present branch routes through CadenceUpdater and writes
-		// the node label inside the same tx — wire cadence on both services.
-		cadenceUpdater := wireCadenceUpdaterForTest(t, database, svc)
-		enrichSvc.SetCadenceUpdater(cadenceUpdater)
+		// the node label inside the same tx — pass cadence to both services.
+		cadenceUpdater := buildCadenceUpdaterForTest(t, database)
 		assertSvc, knowledgeCache := buildKnowledgeDeps(t, database, nil)
-		svc.SetKnowledgeWriter(assertSvc, knowledgeCache)
-		enrichSvc.SetKnowledgeWriter(assertSvc, knowledgeCache)
+		svc := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, taskRepo, nil, nil,
+			cadenceUpdater, assertSvc, knowledgeCache, nil)
+		enrichSvc := service.NewEnrichmentService(database, contactRepo, methodRepo, enrichmentRepo, nil, nil,
+			cadenceUpdater, assertSvc, knowledgeCache)
 
 		spec := gen.Contact()
 		contact, _, err := svc.CreateContact(ctx, repository.CreateContactRequest{
@@ -242,11 +241,11 @@ func TestContactNodeDualWrite_Integration(t *testing.T) {
 		taskRepo := repository.NewContactTaskRepository(database.Queries)
 		enrichmentRepo := repository.NewEnrichmentRepository(database.Queries)
 		externalRepo := repository.NewExternalContactRepository(database.Queries)
-		svc := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, taskRepo, nil, nil)
-		enrichSvc := service.NewEnrichmentService(database, contactRepo, methodRepo, enrichmentRepo, nil, nil)
 		knowledgeAssertSvc, knowledgeCache := buildKnowledgeDeps(t, database, nil)
-		svc.SetKnowledgeWriter(knowledgeAssertSvc, knowledgeCache)
-		enrichSvc.SetKnowledgeWriter(knowledgeAssertSvc, knowledgeCache)
+		svc := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, taskRepo, nil, nil,
+			nil, knowledgeAssertSvc, knowledgeCache, nil)
+		enrichSvc := service.NewEnrichmentService(database, contactRepo, methodRepo, enrichmentRepo, nil, nil,
+			nil, knowledgeAssertSvc, knowledgeCache)
 
 		spec := gen.Contact()
 		contact, _, err := svc.CreateContact(ctx, repository.CreateContactRequest{
@@ -285,9 +284,9 @@ func TestContactNodeDualWrite_Integration(t *testing.T) {
 		methodRepo := repository.NewContactMethodRepository(database.Queries)
 		interactionRepo := repository.NewInteractionRepository(database.Queries)
 		taskRepo := repository.NewContactTaskRepository(database.Queries)
-		svc := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, taskRepo, nil, nil)
-		wireCadenceUpdaterForTest(t, database, svc)
-		wireKnowledgeWriterForTest(t, database, nil, svc)
+		cadenceUpdater := buildCadenceUpdaterForTest(t, database)
+		assertSvc, cache := buildKnowledgeDeps(t, database, nil)
+		svc := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, taskRepo, nil, nil, cadenceUpdater, assertSvc, cache, nil)
 
 		monthly := "monthly"
 		target, _, err := svc.CreateContact(ctx, repository.CreateContactRequest{
@@ -323,8 +322,8 @@ func TestContactNodeDualWrite_Integration(t *testing.T) {
 		methodRepo := repository.NewContactMethodRepository(database.Queries)
 		interactionRepo := repository.NewInteractionRepository(database.Queries)
 		taskRepo := repository.NewContactTaskRepository(database.Queries)
-		svc := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, taskRepo, nil, nil)
-		wireKnowledgeWriterForTest(t, database, nil, svc)
+		assertSvc, cache := buildKnowledgeDeps(t, database, nil)
+		svc := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, taskRepo, nil, nil, nil, assertSvc, cache, nil)
 
 		// Force a failure AFTER the contact + node inserts but inside the same
 		// tx: an invalid contact_method type violates the contact_method CHECK
@@ -383,11 +382,12 @@ func TestContactNodeDualWrite_MigrationDownUp(t *testing.T) {
 	// Seed a contact via the dual-write service path so a live person node
 	// exists at the contact's id (this is what 068's down must consider). It
 	// has no assertions, so the guarded down is free to delete it.
+	assertSvc, cache := buildKnowledgeDeps(t, database, nil)
 	contactSvc := service.NewContactService(database, contactRepo,
 		repository.NewContactMethodRepository(database.Queries),
 		repository.NewInteractionRepository(database.Queries),
-		repository.NewContactTaskRepository(database.Queries), nil, nil)
-	wireKnowledgeWriterForTest(t, database, nil, contactSvc)
+		repository.NewContactTaskRepository(database.Queries), nil, nil,
+		nil, assertSvc, cache, nil)
 	unreferenced, _, err := contactSvc.CreateContact(ctx, repository.CreateContactRequest{
 		FullName: "migration-unreferenced-person",
 	}, nil)

--- a/backend/tests/email_interaction_integration_test.go
+++ b/backend/tests/email_interaction_integration_test.go
@@ -56,8 +56,12 @@ func newEmailEnv(t *testing.T, ctx context.Context) *emailEnv {
 	commsRepo := repository.NewCommsMessageRepository(database.Queries)
 
 	// nil bus + nil rematch: the email consumer publishes interaction.recorded
-	// through the live bus the harness builds, not through the service.
-	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, nil, nil)
+	// through the live bus the harness builds, not through the service. cadence +
+	// knowledge are ctor args (the setters are gone).
+	cadenceUpdater := buildCadenceUpdaterForTest(t, database)
+	assertSvc, cache := buildKnowledgeDeps(t, database, nil)
+	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, nil, nil,
+		cadenceUpdater, assertSvc, cache, nil)
 
 	bus, emailConsumer := setupTestEventBusForEmail(t, ctx, database, contactService)
 

--- a/backend/tests/gchat_golive_integration_test.go
+++ b/backend/tests/gchat_golive_integration_test.go
@@ -60,9 +60,10 @@ func TestGChatGoLive_RegisteredProvider_SchedulerSweep_ProducesInteractionsAndCa
 	// Known contact + email method (appears in the provider's dual-source known
 	// map). A cadence makes the contact_by recompute observable. Seeded via the
 	// nil-bus ContactService (single-tx contact+method write, no River client).
+	assertSvc, cache := buildKnowledgeDeps(t, e.database, nil)
 	contactSvc := service.NewContactService(e.database, contactRepo, methodRepo,
-		e.interactionRepo, repository.NewContactTaskRepository(e.database.Queries), nil, nil)
-	wireKnowledgeWriterForTest(t, e.database, nil, contactSvc)
+		e.interactionRepo, repository.NewContactTaskRepository(e.database.Queries), nil, nil,
+		nil, assertSvc, cache, nil)
 	spec := gen.Contact(factory.WithEmail(), factory.WithCadence("weekly"))
 	peerEmail := spec.Email
 	contact, _, err := contactSvc.CreateContact(e.ctx, repository.CreateContactRequest{

--- a/backend/tests/gchat_provider_integration_test.go
+++ b/backend/tests/gchat_provider_integration_test.go
@@ -53,8 +53,9 @@ func setupGChatProviderTest(t *testing.T) *gchatProviderEnv {
 	interactionRepo := repository.NewInteractionRepository(database.Queries)
 	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
 	// nil bus + nil rematch: a single-tx multi-method seed write, no River client.
-	contactService := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, contactTaskRepo, nil, nil)
-	wireKnowledgeWriterForTest(t, database, nil, contactService)
+	assertSvc, cache := buildKnowledgeDeps(t, database, nil)
+	contactService := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, contactTaskRepo, nil, nil,
+		nil, assertSvc, cache, nil)
 
 	gen, _ := migrationGenerator(t)
 

--- a/backend/tests/gmail_correspondence_integration_test.go
+++ b/backend/tests/gmail_correspondence_integration_test.go
@@ -73,7 +73,10 @@ func newDiscoveryEnv(t *testing.T) *discoveryEnv {
 	eventRepo := repository.NewEventRepository(database.Queries)
 	interactionRepo := repository.NewInteractionRepository(database.Queries)
 	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
-	contactService := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, contactTaskRepo, nil, nil)
+	cadenceUpdater := buildCadenceUpdaterForTest(t, database)
+	assertSvc, cache := buildKnowledgeDeps(t, database, nil)
+	contactService := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, contactTaskRepo, nil, nil,
+		cadenceUpdater, assertSvc, cache, nil)
 
 	// Sync early-returns when bus == nil, so wire a live bus + pool (the shared
 	// harness). email.* kinds are drained by the harness's no-op email worker.
@@ -281,7 +284,7 @@ func TestDiscovery_LinkAddsMethodAndDispatchesRematch(t *testing.T) {
 	rematchSvc := service.NewRematchService()
 	rematchSvc.Register(discoveryEmailEligibleHandler{})
 	enrichmentRepo := repository.NewEnrichmentRepository(e.database.Queries)
-	enrichment := service.NewEnrichmentService(e.database, e.contactRepo, e.methodRepo, enrichmentRepo, bus, rematchSvc)
+	enrichment := service.NewEnrichmentService(e.database, e.contactRepo, e.methodRepo, enrichmentRepo, bus, rematchSvc, nil, nil, nil)
 
 	jobID, err := enrichment.EnrichContactFromExternalWithSelections(
 		e.ctx, contactB.ID, row,

--- a/backend/tests/gmail_golive_integration_test.go
+++ b/backend/tests/gmail_golive_integration_test.go
@@ -60,7 +60,10 @@ func TestGmailGoLive_RegisteredProvider_SchedulerSweep_ProducesInteractionsAndCa
 
 	// nil bus + nil rematch on this ContactService: the email consumer
 	// publishes interaction.recorded through the live bus the harness builds.
-	contactService := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, contactTaskRepo, nil, nil)
+	cadenceUpdater := buildCadenceUpdaterForTest(t, database)
+	assertSvc, cache := buildKnowledgeDeps(t, database, nil)
+	contactService := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, contactTaskRepo, nil, nil,
+		cadenceUpdater, assertSvc, cache, nil)
 
 	// Live bus with the REAL EmailInteractionConsumer + CadenceUpdater wired
 	// (FollowUpManager in off-mode to drain) — derived interactions + cadence

--- a/backend/tests/gmail_provider_integration_test.go
+++ b/backend/tests/gmail_provider_integration_test.go
@@ -77,7 +77,10 @@ func newGmailProviderEnv(t *testing.T) *gmailProviderEnv {
 	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
 	eventRepo := repository.NewEventRepository(database.Queries)
 	// nil bus + nil rematch: a single-tx multi-method seed write, no River client.
-	contactService := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, contactTaskRepo, nil, nil)
+	cadenceUpdater := buildCadenceUpdaterForTest(t, database)
+	assertSvc, cache := buildKnowledgeDeps(t, database, nil)
+	contactService := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, contactTaskRepo, nil, nil,
+		cadenceUpdater, assertSvc, cache, nil)
 
 	// Live bus via the shared harness. email.* kinds enqueue an
 	// email_interaction_consumer job, drained by the harness's no-op email

--- a/backend/tests/gmail_rematch_integration_test.go
+++ b/backend/tests/gmail_rematch_integration_test.go
@@ -97,7 +97,10 @@ func newGmailRematchEnv(t *testing.T, accountIDs []string) *gmailRematchEnv {
 	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
 	eventRepo := repository.NewEventRepository(database.Queries)
 	syncRepo := repository.NewSyncRepository(database.Queries)
-	contactService := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, contactTaskRepo, nil, nil)
+	cadenceUpdater := buildCadenceUpdaterForTest(t, database)
+	assertSvc, cache := buildKnowledgeDeps(t, database, nil)
+	contactService := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, contactTaskRepo, nil, nil,
+		cadenceUpdater, assertSvc, cache, nil)
 
 	// Real email consumer wired on the live bus so the handler's published
 	// email.* events are turned into interactions (not just logged).

--- a/backend/tests/interaction_direction_test.go
+++ b/backend/tests/interaction_direction_test.go
@@ -41,9 +41,9 @@ func setupDirectionTestDeps(t *testing.T) (*service.ContactService, *repository.
 	contactMethodRepo := repository.NewContactMethodRepository(database.Queries)
 	interactionRepo := repository.NewInteractionRepository(database.Queries)
 	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
-	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, nil, nil)
-	wireCadenceUpdaterForTest(t, database, contactService)
-	wireKnowledgeWriterForTest(t, database, nil, contactService)
+	cadenceUpdater := buildCadenceUpdaterForTest(t, database)
+	assertSvc, cache := buildKnowledgeDeps(t, database, nil)
+	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, nil, nil, cadenceUpdater, assertSvc, cache, nil)
 
 	cleanup := func() {
 		database.Close()

--- a/backend/tests/interaction_integration_test.go
+++ b/backend/tests/interaction_integration_test.go
@@ -41,9 +41,9 @@ func setupInteractionTestDeps(t *testing.T) (*service.ContactService, *repositor
 	contactRepo := repository.NewContactRepository(database.Queries)
 	contactMethodRepo := repository.NewContactMethodRepository(database.Queries)
 	interactionRepo := repository.NewInteractionRepository(database.Queries)
-	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, repository.NewContactTaskRepository(database.Queries), nil, nil)
-	wireCadenceUpdaterForTest(t, database, contactService)
-	wireKnowledgeWriterForTest(t, database, nil, contactService)
+	cadenceUpdater := buildCadenceUpdaterForTest(t, database)
+	assertSvc, cache := buildKnowledgeDeps(t, database, nil)
+	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, repository.NewContactTaskRepository(database.Queries), nil, nil, cadenceUpdater, assertSvc, cache, nil)
 
 	cleanup := func() {
 		database.Close()

--- a/backend/tests/link_contact_curated_status_integration_test.go
+++ b/backend/tests/link_contact_curated_status_integration_test.go
@@ -54,17 +54,16 @@ func setupLinkCuratedEnv(t *testing.T) *linkCuratedEnv {
 	identityRepo := repository.NewIdentityRepository(database.Queries)
 
 	identitySvc := service.NewIdentityService(identityRepo)
-	contactSvc := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, contactTaskRepo, nil, nil)
-	wireCadenceUpdaterForTest(t, database, contactSvc)
 	matchSvc := service.NewImportMatchService(contactRepo)
-	// nil bus/registry → enrichment skips publish (no rematch wiring needed
-	// for the status-classification assertion).
-	enrichSvc := service.NewEnrichmentService(database, contactRepo, methodRepo, enrichmentRepo, nil, nil)
 	// CreateContact (import path) + enrichment infer location/birthday through the
 	// assertion store now, so both services need the knowledge writer.
 	assertSvc, knowledgeCache := buildKnowledgeDeps(t, database, nil)
-	contactSvc.SetKnowledgeWriter(assertSvc, knowledgeCache)
-	enrichSvc.SetKnowledgeWriter(assertSvc, knowledgeCache)
+	contactSvc := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, contactTaskRepo, nil, nil,
+		buildCadenceUpdaterForTest(t, database), assertSvc, knowledgeCache, nil)
+	// nil bus/registry → enrichment skips publish (no rematch wiring needed
+	// for the status-classification assertion).
+	enrichSvc := service.NewEnrichmentService(database, contactRepo, methodRepo, enrichmentRepo, nil, nil,
+		nil, assertSvc, knowledgeCache)
 	suggestionSvc := service.NewSuggestionService(externalRepo, contactRepo, methodRepo, enrichSvc, matchSvc, database)
 	handler := handlers.NewImportHandler(externalRepo, identitySvc, contactSvc, matchSvc, enrichSvc, suggestionSvc)
 

--- a/backend/tests/rematch_integration_test.go
+++ b/backend/tests/rematch_integration_test.go
@@ -68,8 +68,12 @@ func setupRematchEnv(t *testing.T) *rematchTestEnv {
 	// is gone). Handlers register AFTER the bus exists, below.
 	rematchSvc := service.NewRematchService()
 
-	contactSvc := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, nil, rematchSvc)
-	enrichmentSvc := service.NewEnrichmentService(database, contactRepo, contactMethodRepo, enrichmentRepo, nil, rematchSvc)
+	cadenceUpdater := buildCadenceUpdaterForTest(t, database)
+	assertSvc, cache := buildKnowledgeDeps(t, database, nil)
+	contactSvc := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, nil, rematchSvc,
+		cadenceUpdater, assertSvc, cache, nil)
+	enrichmentSvc := service.NewEnrichmentService(database, contactRepo, contactMethodRepo, enrichmentRepo, nil, rematchSvc,
+		cadenceUpdater, assertSvc, cache)
 
 	// Cutover wiring: live bus + InteractionRecorderWorker +
 	// RematchDispatcherWorker so UpdateContact's publish flows through

--- a/backend/tests/service_nil_pair_guards_integration_test.go
+++ b/backend/tests/service_nil_pair_guards_integration_test.go
@@ -1,0 +1,68 @@
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/repository"
+	"personal-crm/backend/internal/service"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestEnrichmentService_NilPairGuards pins the EnrichmentService nil semantics
+// preserved by the PR5 setter→constructor-arg conversion: a nil knowledge pair
+// still errors on inferred location/birthday, and a nil cadence still errors on
+// a cadence-override request — the same "not wired" errors the deleted setters
+// guarded, not panics. (crm-admin passes nil cadence in production, so the
+// cadence guard is live semantics, not dead code.) The ContactService + half-set
+// construction guards are unit-tested in internal/service/wiring_guards_test.go.
+func TestEnrichmentService_NilPairGuards(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	t.Parallel()
+
+	ctx := context.Background()
+	database, _ := newSharedTestDB(t, ctx)
+
+	contactRepo := repository.NewContactRepository(database.Queries)
+	methodRepo := repository.NewContactMethodRepository(database.Queries)
+	enrichmentRepo := repository.NewEnrichmentRepository(database.Queries)
+
+	// Seed a contact directly through the repo (no knowledge writer needed for a
+	// bare row) with no birthday/location so enrichment infers them below.
+	contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{
+		FullName: "nil-pair guard subject " + t.Name(),
+	})
+	require.NoError(t, err)
+
+	t.Run("inferred birthday but nil knowledge pair errors", func(t *testing.T) {
+		t.Parallel()
+		// nil pair (nil assertSvc + nil cache) ⇒ knowledge stays nil.
+		enrichSvc := service.NewEnrichmentService(
+			database, contactRepo, methodRepo, enrichmentRepo, nil, nil, nil, nil, nil)
+		bday := time.Date(1990, 1, 2, 0, 0, 0, 0, time.UTC)
+		external := &repository.ExternalContact{Birthday: &bday}
+		_, err := enrichSvc.EnrichContactFromExternal(ctx, contact.ID, external)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "knowledge writer not wired")
+	})
+
+	t.Run("cadence override but nil cadence errors", func(t *testing.T) {
+		t.Parallel()
+		// Knowledge wired (so the knowledge guard is skipped), cadence nil (the
+		// crm-admin posture) ⇒ a cadence override must error.
+		assertSvc, cache := buildKnowledgeDeps(t, database, nil)
+		enrichSvc := service.NewEnrichmentService(
+			database, contactRepo, methodRepo, enrichmentRepo, nil, nil, nil, assertSvc, cache)
+		// External with no birthday/location so only the cadence branch triggers.
+		external := &repository.ExternalContact{}
+		cadence := "weekly"
+		_, err := enrichSvc.EnrichContactFromExternalWithSelections(
+			ctx, contact.ID, external, nil, nil, &cadence, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "cadence updater not wired")
+	})
+}

--- a/backend/tests/synthetic_migration_helpers_test.go
+++ b/backend/tests/synthetic_migration_helpers_test.go
@@ -70,11 +70,12 @@ func seedMigrationContact(
 
 	// nil bus + nil rematchRegistry → CreateContact writes contact+methods in one
 	// tx with no event publish, no River client (the lightweight seed path).
-	contactSvc := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, taskRepo, nil, nil)
 	// CreateContact persists location/birthday/how_met through the assertion
 	// store now (the spec carries those fields), so the knowledge writer must be
-	// wired or the create errors.
-	wireKnowledgeWriterForTest(t, database, nil, contactSvc)
+	// passed to the constructor or the create errors.
+	assertSvc, cache := buildKnowledgeDeps(t, database, nil)
+	contactSvc := service.NewContactService(database, contactRepo, methodRepo, interactionRepo, taskRepo, nil, nil,
+		nil, assertSvc, cache, nil)
 
 	spec := gen.Contact(opts...)
 	methods := make([]service.ContactMethodInput, 0, len(spec.Methods))

--- a/backend/tests/task_close_wiring_static_test.go
+++ b/backend/tests/task_close_wiring_static_test.go
@@ -49,7 +49,7 @@ func readCrmAPISource(t *testing.T) []byte {
 
 // TestTaskCloseEnqueuerWiring_Static asserts the crm-api wiring calls the
 // merge-time close enqueuer with the river client and the follow-up
-// cutover-mode gate (in buildEventConsumers).
+// cutover-mode gate (in buildContactService).
 func TestTaskCloseEnqueuerWiring_Static(t *testing.T) {
 	t.Parallel()
 	src := readCrmAPISource(t)
@@ -73,5 +73,16 @@ func TestCadenceProviderCloseDepsWiring_Static(t *testing.T) {
 		`todoist\.NewCadenceSyncProvider\((?s:.*?)deps\.RiverClient,\s*deps\.Config\.EventBus\.FollowUpMode == config\.EventBusFollowUpModeCutover,\s*\)`)
 	if !provider.Match(src) {
 		t.Error("crm-api must pass the river client + the cutover-mode gate to todoist.NewCadenceSyncProvider — without them the temp-ID finalize on a completed row cannot enqueue the durable remote close")
+	}
+
+	// The provider reads deps.RiverClient / deps.Config, but only if the caller
+	// actually POPULATES those fields in the todoistProviderDeps literal. Assert
+	// the construction→wiring span: the literal must set RiverClient: riverClient
+	// and Config: cfg (otherwise the provider silently receives nil/zero and the
+	// remote close never enqueues).
+	literal := regexp.MustCompile(
+		`registerTodoistProvider\(todoistProviderDeps\{(?s:.*?)Config:\s*cfg,(?s:.*?)RiverClient:\s*riverClient,(?s:.*?)\}\)`)
+	if !literal.Match(src) {
+		t.Error("crm-api must populate the todoistProviderDeps literal with Config: cfg and RiverClient: riverClient — without them registerTodoistProvider passes a zero river client / config to the cadence provider and the durable remote close never enqueues")
 	}
 }

--- a/backend/tests/telegram_aggregation_test.go
+++ b/backend/tests/telegram_aggregation_test.go
@@ -72,7 +72,10 @@ func setupAggregationTest(t *testing.T) (
 	contactRepo := repository.NewContactRepository(database.Queries)
 	contactMethodRepo := repository.NewContactMethodRepository(database.Queries)
 	contactTaskRepo := repository.NewContactTaskRepository(database.Queries)
-	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, nil, nil)
+	cadenceUpdater := buildCadenceUpdaterForTest(t, database)
+	assertSvc, cache := buildKnowledgeDeps(t, database, nil)
+	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, contactTaskRepo, nil, nil,
+		cadenceUpdater, assertSvc, cache, nil)
 
 	// Cutover wiring: a live events.Bus with the InteractionRecorder worker
 	// running so aggregation publishes → async consumer writes interaction

--- a/backend/tests/telegram_import_suggestion_test.go
+++ b/backend/tests/telegram_import_suggestion_test.go
@@ -64,14 +64,13 @@ func setupTelegramImportSuggestionTest(t *testing.T) (
 	enrichmentRepo := repository.NewEnrichmentRepository(database.Queries)
 	interactionRepo := repository.NewInteractionRepository(database.Queries)
 
-	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, repository.NewContactTaskRepository(database.Queries), nil, nil)
-	cadenceUpdater := wireCadenceUpdaterForTest(t, database, contactService)
+	cadenceUpdater := buildCadenceUpdaterForTest(t, database)
 	assertSvc, knowledgeCache := buildKnowledgeDeps(t, database, nil)
-	contactService.SetKnowledgeWriter(assertSvc, knowledgeCache)
+	contactService := service.NewContactService(database, contactRepo, contactMethodRepo, interactionRepo, repository.NewContactTaskRepository(database.Queries), nil, nil,
+		cadenceUpdater, assertSvc, knowledgeCache, nil)
 	matchService := service.NewImportMatchService(contactRepo)
-	enrichmentService := service.NewEnrichmentService(database, contactRepo, contactMethodRepo, enrichmentRepo, nil, nil)
-	enrichmentService.SetCadenceUpdater(cadenceUpdater)
-	enrichmentService.SetKnowledgeWriter(assertSvc, knowledgeCache)
+	enrichmentService := service.NewEnrichmentService(database, contactRepo, contactMethodRepo, enrichmentRepo, nil, nil,
+		cadenceUpdater, assertSvc, knowledgeCache)
 
 	suggestionService := service.NewSuggestionService(externalRepo, contactRepo, contactMethodRepo, enrichmentService, matchService, database)
 	importHandler := handlers.NewImportHandler(externalRepo, nil, contactService, matchService, enrichmentService, suggestionService)

--- a/backend/tests/telegram_matcher_enrichment_test.go
+++ b/backend/tests/telegram_matcher_enrichment_test.go
@@ -67,7 +67,7 @@ func setupMatcherEnrichmentTest(t *testing.T) *matcherEnrichTestEnv {
 	messageRepo := repository.NewTelegramMessageRepository(database.Queries)
 
 	identitySvc := service.NewIdentityService(identityRepo)
-	enrichmentSvc := service.NewEnrichmentService(database, contactRepo, methodRepo, enrichmentRepo, nil, nil)
+	enrichmentSvc := service.NewEnrichmentService(database, contactRepo, methodRepo, enrichmentRepo, nil, nil, nil, nil, nil)
 
 	matcher := tgpkg.NewPeerMatcher(identitySvc, messageRepo, externalRepo, enrichmentSvc, 100)
 

--- a/backend/tests/telegram_sparse_entity_enrichment_test.go
+++ b/backend/tests/telegram_sparse_entity_enrichment_test.go
@@ -80,7 +80,7 @@ func setupSparseEnrichTest(t *testing.T) *sparseEnrichEnv {
 	identityRepo := repository.NewIdentityRepository(database.Queries)
 
 	identitySvc := service.NewIdentityService(identityRepo)
-	enrichmentSvc := service.NewEnrichmentService(database, contactRepo, contactMethodRepo, enrichmentRepo, nil, nil)
+	enrichmentSvc := service.NewEnrichmentService(database, contactRepo, contactMethodRepo, enrichmentRepo, nil, nil, nil, nil, nil)
 	matcher := tgpkg.NewPeerMatcher(identitySvc, messageRepo, externalRepo, enrichmentSvc, 1)
 
 	handler := tgpkg.NewMessageHandler(

--- a/backend/tests/test_event_bus_harness_test.go
+++ b/backend/tests/test_event_bus_harness_test.go
@@ -93,7 +93,9 @@ func setupTestEventBus(
 
 	bus := events.NewBus(database.Pool, client, eventRepo)
 	// Build a real CadenceUpdater so the recorder's inline apply fires
-	// in these end-to-end integration tests.
+	// in these end-to-end integration tests. The caller passes its own
+	// cadence + knowledge deps to NewContactService (the setters are gone);
+	// this instance drives the recorder's inline-apply seam.
 	contactRepo := repository.NewContactRepository(database.Queries)
 	contactRepo.SetPool(database.Pool)
 	claimRepo := repository.NewEventConsumerClaimRepository(database.Queries)
@@ -102,12 +104,6 @@ func setupTestEventBus(
 		consumer.CadenceModeCutover,
 		false,
 	)
-	// Wire cadenceUpdater into the contact service so direct-invoke
-	// paths (Merge / Extend / Promote / RecordInteraction non-bus
-	// wrapper / UpdateContact cadence-edit) work in these async
-	// integration tests.
-	contactService.SetCadenceUpdater(cadenceUpdater)
-	wireKnowledgeWriterForTest(t, database, bus, contactService)
 	stagingRegistry := repository.NewStagingProcessorRegistry(map[string]repository.StagingProcessor{
 		repository.InteractionSourceTelegram: repository.NewTelegramStagingProcessor(telegramMessageRepo),
 	})
@@ -189,8 +185,6 @@ func setupTestEventBusWithRematch(
 		consumer.CadenceModeCutover,
 		false,
 	)
-	contactService.SetCadenceUpdater(cadenceUpdater)
-	wireKnowledgeWriterForTest(t, database, bus, contactService)
 	stagingRegistry2 := repository.NewStagingProcessorRegistry(map[string]repository.StagingProcessor{
 		repository.InteractionSourceTelegram: repository.NewTelegramStagingProcessor(telegramMessageRepo),
 	})
@@ -263,7 +257,6 @@ func setupTestEventBusForEmail(
 		consumer.CadenceModeCutover,
 		false,
 	)
-	contactService.SetCadenceUpdater(cadenceUpdater)
 
 	// Off-mode FollowUpManager: cutover-only Todoist deps are nil (gated on
 	// mode == cutover per NewFollowUpManager's doc comment).
@@ -292,7 +285,6 @@ func setupTestEventBusForEmail(
 	require.NoError(t, err)
 
 	bus := events.NewBus(database.Pool, client, eventRepo)
-	wireKnowledgeWriterForTest(t, database, bus, contactService)
 
 	emailConsumer := consumer.NewEmailInteractionConsumer(
 		contactService, commsMessageRepo, interactionRepo, contactService,
@@ -427,38 +419,23 @@ func (w *deferredRecorderWorker) Timeout(j *river.Job[consumerjobs.InteractionRe
 	return w.real.Timeout(j)
 }
 
-// wireCadenceUpdaterForTest constructs a real CadenceUpdater against
-// the given database and injects it into contactService so cadence
-// entry points (RecordInteraction direct path, MergeContacts,
-// ExtendInteraction, PromoteInteractionToMutual, UpdateContact cadence
-// edits) work in tests without needing the full event-bus harness.
-// Uses cutover mode so cadence columns get written.
-func wireCadenceUpdaterForTest(t *testing.T, database *db.Database, contactService *service.ContactService) *consumer.CadenceUpdater {
+// buildCadenceUpdaterForTest constructs a real CadenceUpdater against the given
+// database so callers can pass it as the cadence ctor arg to
+// NewContactService / NewEnrichmentService and exercise cadence entry points
+// (RecordInteraction direct path, MergeContacts, ExtendInteraction,
+// PromoteInteractionToMutual, UpdateContact cadence edits) in tests without
+// needing the full event-bus harness. Uses cutover mode so cadence columns get
+// written.
+func buildCadenceUpdaterForTest(t *testing.T, database *db.Database) *consumer.CadenceUpdater {
 	t.Helper()
 	contactRepo := repository.NewContactRepository(database.Queries)
 	contactRepo.SetPool(database.Pool)
 	claimRepo := repository.NewEventConsumerClaimRepository(database.Queries)
-	cadenceUpdater := consumer.NewCadenceUpdater(
+	return consumer.NewCadenceUpdater(
 		claimRepo, contactRepo, database.Queries,
 		consumer.CadenceModeCutover,
 		false,
 	)
-	contactService.SetCadenceUpdater(cadenceUpdater)
-	return cadenceUpdater
-}
-
-// wireKnowledgeWriterForTest wires the location/birthday/how_met authority-flip
-// writer into the contact service so CreateContact / UpdateContact /
-// MergeContacts persist those fields via the assertion store + refresh the cache
-// columns inline. When bus is non-nil it is reused (so the emitted assertion.*
-// events land in the same event log the harness asserts on); when nil, a
-// self-contained insert-only bus is built so contact-only tests (no event bus)
-// can still create contacts. The inline cache refresh happens regardless of the
-// bus, so cache columns are correct on commit either way.
-func wireKnowledgeWriterForTest(t *testing.T, database *db.Database, bus *events.Bus, contactService *service.ContactService) {
-	t.Helper()
-	assertSvc, cache := buildKnowledgeDeps(t, database, bus)
-	contactService.SetKnowledgeWriter(assertSvc, cache)
 }
 
 // buildKnowledgeDeps constructs the AssertService + KnowledgeCacheUpdater the


### PR DESCRIPTION
## Summary

PR5 of the composition-root refactor arc (follows #573, #576, #581, #588) — the final zero-behavior-change PR, and the one that pays off the arc's motivation. Converts the 5 mandatory post-construction setters (`ContactService`: cadence/knowledge/followup; `EnrichmentService`: cadence/followup) into **constructor arguments**, so a forgotten dependency is now a compile error instead of a silent runtime nil.

- **Dissolves the service-consumer construction cycle** via wire-function splits: `buildContactGraphCore` → `buildGraphCore` + `buildContactService`, `buildEventConsumers` → `buildDomainConsumers` + `buildInteractionRecorder` (the recorder being the only ContactService-dependent block). `run()` now builds the domain-writer consumers *before* the services that need them — this is the one PR in the arc that intentionally changes construction order.
- **Nil semantics preserved bit-for-bit**: the knowledge-pair both-or-neither rule is enforced in `buildKnowledgeWriter` (nil pair → nil writer; half-set → panic, matching the old `SetKnowledgeWriter`); `EnrichmentService.cadence` stays nil-legal (crm-admin passes nil); `followUp` stays nil-tolerant. Every guard branch preserved, including the promote-path cadence guard. Only error strings changed.
- Constructor blast radius: ~44 files / ~40 test callers updated; both mandated greps clean (no lingering `Set*` calls, all `New*Service` sites updated). `wire*ForTest` helpers became build-and-return, resolving a genuine `InjectBusForTest` cycle.
- crm-admin + synthetic harness reordered to match. Five review-head carry-overs from prior PRs folded in (dead struct fields dropped, `logger.Init` hoisted, static todoist-literal assertion, comment hygiene, `frontendURL` write-only field removed).

## Behavior

Zero behavior change despite the reorder, verified: route-parity **6/6 shapes byte-identical**, golden-list **4/4 shapes** (no route/worker registration moved), both greps clean, and an adversarial review confirmed each constructor arg preserves its setter's exact nil-tolerance and that no pre-ContactService consumer references it (compile-proven). New nil-pair guard tests pin the half-set panic.

## Verification

- `make lint` 0 issues; unit + integration green (one unrelated shared-DB flake, `TestAssert_ValidTime/24`, passes isolated); both packages build + vet.
- Codex review: PASS (P0=0 P1=0 P2=0 P3=2). Fresh-context review-head + adversarial sub-review: PASS (P0=0 P1=0 P2=1 P3=2), findings adjudicated inert.

Note: Codex GitHub bot is quota-exhausted; per repo-owner decision this PR merges on CI green (two independent pre-push reviews already attached), post-merge re-check if quota returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PAkTD635qUGdkzipVK7uhh