### PR TITLE
feat(spec): backfill behavior corpus for 9 remaining domains

### DIFF
--- a/spec/README.md
+++ b/spec/README.md
@@ -43,7 +43,7 @@ Field rules:
 - **`type`** — what kind of consumer cares:
   - `business-logic` — domain rules observable through outcomes (state machines, computations).
   - `api` — HTTP contract (status codes, validation, response shapes). Track A's handler tests.
-  - `ux` — what the user can see/do at a surface, expressed DOM-free (no selectors, no copy). Track B's judge.
+  - `ux` — what the user can see/do at a surface, expressed DOM-free (no selectors, no copy). Track B's judge. `ux` behaviors are also produced *forward* by design sessions (including AI design work): a design mints its intended surface behavior as `status: proposed`, the implementation PR flips it to `current` under the maintenance rule, and a design that reverses an existing surface follows retire-and-mint.
   - `invariant` — always-true cross-cutting property (e.g. soft-delete filtering, deterministic ordering).
   - `data` — persistence/derived-data correctness (cascades, dedup, derived cache columns).
 - **`status`** — carries the is/ought split. `current` = faithfully describes today's behavior. `proposed` = desired behavior that does not (fully) hold today. If curation reveals today's behavior is a bug, the intended behavior is written as `proposed` (optionally with a filed bug) — **a bug is never enshrined as `current` intent**. `retired` = tombstone; the row stays intact so the ID is never reused, with a pointer in `notes` if superseded.
@@ -86,8 +86,8 @@ A behavior that moves domains gets a new ID; the old one is retired with a point
 
 ## Curation rules
 
-- **One domain per PR.** Derivation is an interactive session: the agent drafts behaviors with `type`/`status`/`provenance`, then an in-session chunked walkthrough (~10 behaviors per chunk) happens **before the PR opens** — the human accepts / edits / rejects / reclassifies each behavior (`current` → `proposed` for anything that is actually a bug or an aspiration).
-- The PR lands the file at `maturity: reviewed`, and the PR description records what the walkthrough rejected or rewrote — durable evidence that curation happened.
+- **Curation is an adversarial-review pass, not an interactive walkthrough.** The agent drafts behaviors with `type`/`status`/`provenance`, then a fresh-context reviewer (Codex at xhigh, or a Claude reviewer when Codex is quota-blocked) audits the whole file for completeness (missing in-scope behaviors) and correctness (fidelity to code, `current`-vs-`proposed` classification, type/consumer-harness fit) until it passes with zero blocking findings; a final cross-corpus consistency pass over the whole SSOT catches inter-file duplication, contradiction, and boundary drift. Every derived behavior is verified against code before it is enshrined, and a bug is written as `proposed`, never `current`. (The earlier interactive human-by-behavior walkthrough is superseded by this pass.)
+- **PR granularity is flexible.** One domain per PR is the default and keeps git history clean, but a batched multi-domain PR is fine when the whole set went through the review + consistency pass together (the exemplar backfill landed nine domains in one PR). Either way the PR lands the file(s) at `maturity: reviewed`, and the PR description records what review rejected or rewrote — durable evidence that curation happened.
 - **Granularity:** one behavior = one durable intent, one `when`; `then` lists enumerate facets of that single intent. Rough expectation: 20–50 behaviors per domain. Derivation is not transcription — write at the intent level (survives any UI redesign), not one-per-test-assertion.
 - **PII:** behaviors are generic statements of intent. No real contact data, UUIDs, or hostnames appear in spec files (standard repo privacy rule).
 

--- a/spec/calendar.yaml
+++ b/spec/calendar.yaml
@@ -1,0 +1,370 @@
+domain: calendar
+prefix: CAL
+maturity: reviewed
+behaviors:
+  # --- Sync provider config & entry ---
+
+  - id: CAL-001
+    title: Calendar syncs as an account-scoped fetch-all provider
+    type: business-logic
+    status: current
+    given: the Google Calendar sync provider
+    when: its configuration is read by the scheduler
+    then:
+      - it identifies as source gcal, display name Google Calendar
+      - it uses a fetch-all strategy (scheduler-ticked, not push) with a default 15-minute interval
+      - it supports multiple accounts and attendee discovery, and requires an account to run
+    provenance: [CalendarSyncProvider.Config, sync.SourceConfig]
+    notes: Interval enforcement and scheduler tick wiring are generic sync-state scope — cross-reference the ingest domain.
+
+  - id: CAL-002
+    title: A calendar sync is scoped to one Google account
+    type: business-logic
+    status: current
+    given: a sync invocation for the calendar provider
+    when: the sync runs
+    then:
+      - a sync with no account id fails fast rather than syncing a default calendar
+      - the account id keys the OAuth token used to fetch events
+    provenance: [CalendarSyncProvider.Sync, CalendarSyncProvider.ValidateCredentials]
+    notes: The OAuth token lifecycle and account listing are settings-domain scope (SET).
+
+  - id: CAL-003
+    title: The stored cursor selects a full or incremental sync
+    type: business-logic
+    status: current
+    given: a sync invocation carrying the account's stored sync cursor
+    when: the sync path is chosen
+    then:
+      - an empty or unset cursor triggers a full-window initial sync
+      - a non-empty cursor (a Google sync token) triggers an incremental sync of only changed events
+      - each path records the next sync token as the new cursor once the final page is fetched
+    provenance: [CalendarSyncProvider.Sync, initialSync, incrementalSync]
+
+  - id: CAL-004
+    title: Initial sync spans one year past to thirty days ahead
+    type: business-logic
+    status: current
+    given: an initial (full) calendar sync
+    when: the event window is computed
+    then:
+      - the window runs from 365 days before the current time to 30 days after it
+      - events are requested expanded to single instances, ordered by start time, and paginated
+      - the current time follows the app's accelerated clock, not wall-clock time
+    provenance: [initialSync, CalendarPastSyncDays, CalendarFutureSyncDays, accelerated.GetCurrentTime]
+
+  - id: CAL-005
+    title: An expired sync token falls back to a full resync
+    type: business-logic
+    status: current
+    given: an incremental sync whose stored sync token is no longer valid
+    when: the calendar API reports the token expired (410 / full sync required)
+    then:
+      - the provider abandons the incremental path and re-runs a full initial sync
+      - a fresh sync token is captured for subsequent incremental syncs
+    provenance: [incrementalSync]
+
+  - id: CAL-006
+    title: One malformed event never aborts the whole sync
+    type: business-logic
+    status: current
+    given: a sync page containing an event that fails to process
+    when: that event is handled
+    then:
+      - the failure is logged and the event is skipped
+      - remaining events in the page and later pages still process
+    provenance: [initialSync, incrementalSync, processEvent]
+
+  # --- Keep / remove gate ---
+
+  - id: CAL-007
+    title: The CRM stores an event only while the user has accepted it
+    type: business-logic
+    status: current
+    given: a calendar event observed during sync
+    when: the keep decision is evaluated
+    then:
+      - an event is stored only when the user's response is accepted and its status is not cancelled
+      - the account holder acting as organizer counts as accepted
+      - all-day events (holidays, birthdays) are never stored as meetings
+      - any other observation (declined, tentative, needs-action, user-removed, cancelled) triggers the remove branch
+    provenance: [processEvent, getUserResponse, getEventStatus]
+    notes: The keep decision is evaluated before time-parsing so a cancelled event arriving as a minimal stub with no start/end time is still routed to removal.
+
+  - id: CAL-008
+    title: A previously-stored event that turns non-accepted is removed and its interactions cleaned up
+    type: business-logic
+    status: current
+    given: an event the CRM had stored that is now observed non-accepted (declined, tentative, needs-action, cancelled, or user-removed)
+    when: the remove branch runs
+    then:
+      - the stored calendar event is deleted and a decline is emitted for each matched contact so the derived interactions are cleaned up
+      - a decline observed for an event that was never stored emits nothing (no interaction to clean up)
+    provenance: [removeDeclinedEvent, publishCalendarDeclinedTx]
+    notes: 'Cutover mode publishes the declines and deletes the row in one transaction. In event-bus off mode the provider instead marks the stored row cancelled (deferred cleanup) so a later cutover resume can finish it; interaction cleanup itself is business-logic CAL-016.'
+
+  # --- Attendee assembly & candidate discovery (CAL-owned; matching mechanics are IMP) ---
+
+  - id: CAL-009
+    title: The attendee list is assembled with the organizer always included
+    type: business-logic
+    status: current
+    given: a stored calendar event
+    when: its attendee list is built
+    then:
+      - every attendee on the event is captured with display name and response status
+      - the organizer is added as a synthetic attendee when the event omits them from the attendee array
+      - the account holder is flagged as self across both their attendee entry and organizer aliases
+    provenance: [buildAttendeeList]
+
+  - id: CAL-010
+    title: System and resource addresses are excluded from attendee matching
+    type: business-logic
+    status: current
+    given: an event's assembled attendee list
+    when: attendees are considered for contact matching
+    then:
+      - the account holder's own entry and any attendee with no email are skipped
+      - attendees on Google calendar/resource/temp-account domains are skipped
+      - attendees whose local part is an automated-mailer prefix (noreply, notifications, mailer-daemon, postmaster, and similar) are skipped
+    provenance: [matchAttendees, isBlockedCalendarEmail, blockedCalendarDomains, blockedEmailPrefixes]
+    notes: The matching itself (exact via identity, fuzzy via name+method overlap) is imports-matching scope — cross-reference IMP-002.
+
+  - id: CAL-011
+    title: Unmatched attendees become per-person import candidates with meeting context
+    type: business-logic
+    status: current
+    given: an attendee who matched no existing contact
+    when: the attendee is recorded for later import
+    then:
+      - an external contact is upserted under source gcal_attendee, keyed by normalized email so one person yields a single candidate across meetings
+      - meeting title, date, and link are stored as discovery context
+      - a display name is inferred from the email local part when the invite carried none
+    provenance: [storeUnmatchedAttendee, inferNameFromEmail]
+    notes: The import-candidate review surface and the per-source/per-address dedup lifecycle are imports-matching scope — cross-reference IMP-006.
+
+  # --- Event-to-interaction projection ---
+
+  - id: CAL-012
+    title: Past accepted meetings project a mutual interaction per matched contact
+    type: business-logic
+    status: current
+    given: a stored, confirmed event with matched contacts whose end time is in the past
+    when: past-event projection runs after each sync
+    then:
+      - a mutual-direction interaction is recorded for each matched contact, timestamped at the event end and described by the event title
+      - a future accepted event is stored but projects no interaction until it is past
+      - the event is marked processed only once every matched contact's interaction has been emitted
+    provenance: [updateLastContactedForPastEvents, publishCalendarAttended, ListPastEventsNeedingUpdate]
+    notes: The interaction feeds the contact's last-contacted cadence timestamps — cross-reference CAD-006.
+
+  - id: CAL-013
+    title: One meeting with N attendees yields N independent interactions
+    type: data
+    status: current
+    given: a single calendar event with several matched contacts
+    when: attendance is projected and interactions are recorded
+    then:
+      - the emitted event carries a per-(event, contact) identity so contacts two through N are not collapsed against the first by the event-log uniqueness constraint
+      - each contact's interaction is deduplicated independently on contact plus source plus the event's internal id
+      - re-emitting an already-recorded pair is a no-op, so partial-failure retries never double-record
+    provenance: [publishCalendarAttended, interaction_recorder.go calendar.attended branch, idx_event_source_source_id]
+    notes: The generic event-log and interaction dedup-window rules are ingest scope (ING). This behavior is the calendar-specific guard against fan-out collapse.
+
+  - id: CAL-014
+    title: A calendar event is uniquely one row per event, calendar, and account
+    type: data
+    status: current
+    given: repeated syncs observing the same Google event
+    when: the event is written
+    then:
+      - the event upserts on the natural key of Google event id, calendar id, and account id
+      - re-syncing an unchanged event updates it in place rather than duplicating it
+    provenance: [UpsertCalendarEvent, migrations/016_calendar_event.up.sql]
+
+  - id: CAL-015
+    title: Re-matching an event reopens it for projection without re-projecting unchanged ones
+    type: data
+    status: current
+    given: an event being re-synced whose matched-contact set may have changed
+    when: the event is upserted
+    then:
+      - the processed flag is cleared only when the matched-contact set actually changes, compared order-insensitively
+      - an unchanged matched-contact set preserves the processed flag so already-projected attendance is not re-emitted
+    provenance: [UpsertCalendarEvent last_contacted_updated CASE]
+
+  # --- Decline cleanup & ordering guarantees ---
+
+  - id: CAL-016
+    title: Declining a past meeting retracts the interaction it created
+    type: business-logic
+    status: current
+    given: a matched contact with an interaction derived from a now-declined event
+    when: the decline is handled
+    then:
+      - the derived interaction is soft-deleted and the contact's cadence dates are recomputed from remaining history
+      - a decline for an interaction that was never recorded (a future meeting, or an already-cleaned replay) is a benign no-op
+    provenance: [CalendarDeclineHandler.HandleEvent, RecomputeContactDatesAfterDeleteTx]
+    notes: The date recompute is cadence/contacts scope — cross-reference CAD-010. A decline whose contact was concurrently deleted is also a no-op rather than a retry-poisoning error.
+
+  - id: CAL-017
+    title: Calendar state changes publish their downstream event before they mutate
+    type: invariant
+    status: current
+    statement: every calendar removal or re-link publishes its downstream event before it mutates the backing state, so a publish failure never strands a false or orphaned interaction and the next sync or rematch re-runs cleanly. The decline remove branch is atomic — it publishes each contact's decline and deletes the event row in a single transaction, so a publish failure rolls back the delete. Rematch is not transactional — it publishes attendance in its own already-committed transaction, then appends the contact as a separate write, so a publish failure skips the append and leaves the matched set unchanged; the next rematch re-selects the pair, the publish dedups as a no-op, and only the append retries.
+    provenance: [removeDeclinedEvent, CalendarRematchHandler.Rematch, publishCalendarDeclinedTx, publishCalendarAttended, events.Bus.Publish]
+
+  - id: CAL-018
+    title: A decline racing an attendance projection never leaves a false interaction
+    type: data
+    status: current
+    given: a past-attendance projection and a decline of the same event racing
+    when: the attendance interaction is about to be inserted
+    then:
+      - the insert takes a share lock on the backing calendar event
+      - if the event was already deleted by the winning decline, the insert is skipped and no interaction is written
+    provenance: [interaction_recorder.go calendar.attended lock branch, GetCalendarEventByIDForShare]
+    notes: The decline emission carries a distinct namespace so it can never dedup-collide with the attendance emission on the event log (which would strand the interaction with no cleanup handler).
+
+  # --- Rematch (calendar side; trigger dispatch is IMP) ---
+
+  - id: CAL-019
+    title: Adding a matching email retroactively links a contact to past meetings
+    type: business-logic
+    status: current
+    given: a contact who gains an email address that appears on stored events not yet linked to them
+    when: a calendar rematch runs for that email
+    then:
+      - the contact is appended to each matching event's matched set
+      - past confirmed events additionally project the contact's attendance, while future events are only linked
+      - the append does not reset the event's processed flag, so already-projected attendees are not re-emitted
+    provenance: [CalendarRematchHandler.Rematch, AppendMatchedContact, FindEventsByAttendeeEmailUnmatchedForContact]
+    notes: The rematch trigger and job dispatch are imports-matching scope — cross-reference IMP-019 and IMP-020.
+
+  # --- Cross-cutting invariants ---
+
+  - id: CAL-020
+    title: Calendar events are hard-deleted and cancelled ones are invisible
+    type: invariant
+    status: current
+    statement: the calendar event table has no soft-delete column — removal is a hard delete — and every contact-facing read filters out cancelled events, so cancelled or removed meetings never appear in any contact's event list, count, or upcoming view.
+    provenance: [DeleteCalendarEventByGcalID, calendar_event.sql status filters, migrations/016_calendar_event.up.sql]
+
+  - id: CAL-021
+    title: Every contact-facing event read has a deterministic order
+    type: invariant
+    status: current
+    statement: all contact-facing calendar reads impose an explicit order — meeting history is returned most-recent-first and upcoming lists soonest-first — so results never depend on arbitrary database ordering.
+    provenance: [ListEventsForContact, ListUpcomingEventsForContact, calendar_event.sql ORDER BY clauses]
+
+  # --- API ---
+
+  - id: CAL-022
+    title: Calendar events are exposed only through read endpoints
+    type: api
+    status: current
+    given: the calendar HTTP surface
+    when: a client requests events
+    then:
+      - a contact's events, a contact's upcoming events, and a global upcoming-events feed are readable
+      - page size is clamped to a bounded maximum with a sensible default
+      - a malformed contact id is rejected with a validation error (400)
+      - no endpoint creates, updates, or deletes an event — all writes flow through sync
+    provenance: [RegisterCalendarRoutes, handlers/calendar.go, parsePagination]
+
+  - id: CAL-023
+    title: Event responses expose an attendee count, never attendee addresses
+    type: api
+    status: current
+    given: a calendar event serialized for an API response
+    when: the response body is built
+    then:
+      - the response reports the number of attendees
+      - raw attendee emails and names are never included in the response
+    provenance: [CalendarEventResponse, convertToEventResponse]
+
+  # --- Surfaces (contact detail Meetings, settings) ---
+
+  - id: CAL-024
+    title: The Meetings section appears only when a contact has events
+    type: ux
+    status: current
+    given: a contact detail page
+    when: the page renders
+    then:
+      - a Meetings section is shown when the contact has at least one calendar event
+      - nothing is shown when the contact has no events or the events fail to load
+    provenance: [contacts detail page, components/contacts/meetings.tsx]
+
+  - id: CAL-025
+    title: Meetings can be filtered into all, upcoming, and past with live counts
+    type: ux
+    status: current
+    given: a contact with a mix of upcoming and past meetings
+    when: the Meetings section is used
+    then:
+      - three filters — all, upcoming, and past — each show a live count
+      - upcoming is the default view
+      - a meeting is classified as past once its end time is before the app's accelerated current time
+      - past meetings are ordered most-recent-first
+    provenance: [components/contacts/meetings.tsx, useAcceleratedTime]
+
+  - id: CAL-026
+    title: A meeting card summarizes its time, place, and size
+    type: ux
+    status: current
+    given: a meeting in the Meetings section
+    when: its card renders
+    then:
+      - it shows the title (a fallback label when untitled), the date, and the start-to-end time range
+      - it shows a location when the meeting has one
+      - it shows an attendee count only when the meeting has more than one attendee
+      - a past meeting is visually de-emphasized and carries a past marker
+    provenance: [components/contacts/meetings.tsx MeetingCard]
+
+  - id: CAL-027
+    title: A meeting with a source link opens it externally
+    type: ux
+    status: current
+    given: a meeting card
+    when: the meeting carries a source link
+    then:
+      - the title becomes a link that opens the meeting in a new tab with an external-link affordance
+      - a meeting without a link renders as plain text
+    provenance: [components/contacts/meetings.tsx html_link branch]
+
+  - id: CAL-028
+    title: A long meeting list reveals progressively
+    type: ux
+    status: current
+    given: a filtered meeting list longer than the initial page
+    when: the user asks for more
+    then:
+      - a fixed number of meetings show initially, with a control reporting how many remain
+      - each activation reveals more until the list is exhausted, when the control disappears
+      - switching filters resets the reveal back to the initial page
+    provenance: [components/contacts/meetings.tsx displayLimit]
+
+  - id: CAL-029
+    title: Each calendar-enabled account offers a manual sync with visible state
+    type: ux
+    status: current
+    given: a connected Google account granted calendar access
+    when: the settings account section renders
+    then:
+      - a calendar sync control shows the account's current calendar sync state and lets the user trigger a sync on demand
+      - a triggered sync reports that it started and reflects progress or errors as the state polls
+    provenance: [components/settings/google-accounts-section.tsx, hooks/use-sync-states.ts]
+    notes: The OAuth connect and reconnect flows themselves are settings scope (SET); the reconnect-on-auth-failure prompt is SET-025 and the scope-gated visibility of this sync affordance is SET-024. This behavior covers only the calendar sync trigger and its state surface.
+
+  - id: CAL-030
+    title: A stalled calendar sync surfaces in the settings banner
+    type: ux
+    status: current
+    given: the calendar sync has stalled past its watchdog threshold
+    when: the settings page renders
+    then:
+      - a staleness banner names Google Calendar among the stalled sources
+      - the banner stays quiet while loading or when nothing is stalled
+    provenance: [components/sync-staleness-banner.tsx]
+    notes: The watchdog that detects staleness is settings/ingest scope; this behavior covers only the calendar labeling on the banner.

--- a/spec/dashboard.yaml
+++ b/spec/dashboard.yaml
@@ -1,0 +1,108 @@
+domain: dashboard
+prefix: DSH
+maturity: reviewed
+behaviors:
+  - id: DSH-001
+    title: The dashboard is the application's default landing surface
+    type: ux
+    status: current
+    given: the application root is opened
+    when: the entry route resolves
+    then:
+      - the user is taken to the dashboard as the default destination
+      - a brief loading indicator shows while the redirect resolves
+    provenance: [app/page.tsx, dashboard.spec.ts]
+    notes: The dashboard's overdue content is CAD-026; this behavior only pins that the dashboard is where the app opens.
+
+  - id: DSH-002
+    title: Every primary surface is reachable from a persistent global navigation
+    type: ux
+    status: current
+    given: any primary application surface, including the dashboard
+    when: the global navigation renders
+    then:
+      - at wide (>= sm) viewports, links to the dashboard, contacts, birthdays, imports, and settings sections are present
+      - the link matching the current section is visually marked active
+      - the navigation bar stays visible while the page scrolls (sticky)
+    provenance: [components/layout/navigation.tsx, dashboard.spec.ts]
+    notes: The bar also hosts a time-acceleration control and an aggregate sync-status indicator on the imports link — those belong to the settings and imports domains respectively. The birthdays surface itself is CON-045. App-shell nav renders on every primary surface, not only the dashboard; it is captured here because no dedicated navigation domain exists. Scoped to wide (>= sm) viewports deliberately — at narrow (below-sm) widths the link list is hidden (`hidden sm:flex`) and collapses to a menu button that is currently non-functional (no open/close state, no menu panel rendered), so navigation is not reachable on mobile. That mobile gap is a known bug, not claimed as working here.
+
+  - id: DSH-003
+    title: The dashboard always offers a path to add or browse contacts
+    type: ux
+    status: current
+    given: the dashboard is open
+    when: the surface renders in any state
+    then:
+      - an add-contact action is always available from the header
+      - the caught-up state additionally offers a path to add a contact and to view the full contact list
+    provenance: [dashboard/page.tsx header CTA, EmptyState]
+    notes: The caught-up (all-clear) state itself is CAD-026; this pins the follow-on affordances it offers.
+
+  - id: DSH-004
+    title: The overdue widget distinguishes loading and error states from its content
+    type: ux
+    status: current
+    given: the overdue widget is loading or its request has failed
+    when: the dashboard renders
+    then:
+      - while loading, placeholder content is shown rather than an empty or caught-up state
+      - on request failure, an error state carrying the failure reason is shown rather than an empty or caught-up state
+    provenance: [dashboard/page.tsx loading and error branches]
+    notes: The populated and caught-up states are CAD-026; this fills the loading and error states CAD does not cover.
+
+  - id: DSH-005
+    title: The overdue widget reflects overdue-membership changes made in other flows
+    type: ux
+    status: current
+    given: an open dashboard whose overdue list has been fetched
+    when: an action elsewhere changes who is overdue
+    then:
+      - the overdue list refreshes to reflect the change without a manual page reload
+      - this covers logging an interaction, merging contacts, and resolving a meeting note that touches a contact's cadence
+      - purely cosmetic contact edits that do not change overdue membership do not disturb the list
+      - returning focus to the window re-checks freshness, but refetches only once the list has gone stale (a 5-minute staleTime); refocusing sooner does not refetch
+    provenance: [query-invalidation.ts overdue invalidation rules, use-contacts.ts useOverdueContacts]
+    notes: The mark-as-contacted-from-dashboard path specifically is CAD-028; this pins the freshness contract for the flows that DO invalidate the overdue key today — interaction:created, contact:merged, and meeting-note:resolved. The import-link resolution and cadence-changing contact-edit flows do NOT refresh overdue today; that intended-but-broken freshness is DSH-009 (proposed), so it is deliberately excluded from this current claim. refetchOnWindowFocus is on but gated by the query's 5-minute staleTime (useOverdueContacts), so refocus refetches only when the list is already stale; there is no polling interval.
+
+  - id: DSH-006
+    title: A failed dashboard mark-as-contacted surfaces an error to the user
+    type: ux
+    status: proposed
+    given: a dashboard mark-as-contacted action that fails
+    when: the failure occurs
+    then:
+      - the user sees an error indication rather than silent inaction
+    provenance: [dashboard/page.tsx handleMarkContacted]
+    notes: 'Proposed: today the failure is logged to the console only, with no user-facing feedback. The success path is CAD-028; this pins the failure path, which CAD-028 does not cover. Sibling gap on the contact-list/detail surfaces is CON-046.'
+
+  - id: DSH-007
+    title: Search is the contact list's search; the dashboard exposes no separate global search
+    type: ux
+    status: current
+    given: a user wanting to find a contact by text
+    when: they look for a search affordance
+    then:
+      - contact text search is provided through the contact list's search input
+      - no dedicated dashboard-level or app-global search surface exists (no top-bar search box or command palette)
+    provenance: [components/layout/navigation.tsx, contacts/page.tsx search input, contacts-api.ts]
+    notes: Full-text matching semantics and relevance ordering are CON-023; this behavior records that the domain's "search" scope resolves to the contact list rather than a distinct surface, so the boundary is explicit.
+
+  - id: DSH-008
+    title: The dashboard owns no persisted state of its own
+    type: invariant
+    status: current
+    statement: the dashboard materializes no data or scheduled job of its own — every widget is a live read over existing contact and cadence data, and its only write is the mark-as-contacted interaction (CAD-028); there is no dashboard-specific table, cron, or cached aggregate.
+    provenance: [dashboard/page.tsx, ContactService.ListOverdueContacts, no dashboard scheduler job]
+    notes: Consequence — dashboard correctness follows entirely from the contacts and cadence domains; there is nothing to backfill or reconcile on the dashboard side.
+
+  - id: DSH-009
+    title: Import-link and cadence-changing contact edits should refresh the overdue widget
+    type: ux
+    status: proposed
+    given: an open dashboard whose overdue list has been fetched
+    when: a flow whose invalidation rule omits the overdue key changes who is overdue
+    then:
+      - the overdue list refreshes to reflect the resulting membership change without a manual page reload
+    provenance: [query-invalidation.ts import:linked and contact:updated rules, use-imports.ts useLinkCandidate, use-contacts.ts useUpdateContact, import.go ImportHandler.LinkContact]
+    notes: 'Proposed: two concrete flows leak staleness today. import:linked invalidates importKeys.lists/suggestionsLists + contactKeys.lists() but NOT contactKeys.overdue(), even though ImportHandler.LinkContact can set cadence via EnrichContactFromExternalWithSelections (import.go) — so linking a match that changes cadence leaves the overdue widget stale. contact:updated invalidates only contactKeys.lists(), so a contact edit that changes cadence likewise does not refresh overdue. Both recover only on a manual reload or window refocus (refetchOnWindowFocus). The sibling flows in DSH-005 (interaction:created, contact:merged, meeting-note:resolved) already invalidate overdue. Import resolution is imports-matching scope, cross-ref IMP.'

--- a/spec/ingest.yaml
+++ b/spec/ingest.yaml
@@ -1,0 +1,435 @@
+domain: ingest
+prefix: ING
+maturity: reviewed
+behaviors:
+  # --- HTTP ingest surface ---
+
+  - id: ING-001
+    title: The ingest endpoint is feature-gated and auth-dispatched by request header
+    type: api
+    status: current
+    given: the daemon ingest events endpoint
+    when: a batch is posted to the ingest endpoint
+    then:
+      - the endpoint is registered only when event-bus ingest is enabled
+      - a request carrying the Mac-host header is authenticated as a daemon host and that host identity is threaded into batch processing
+      - a request without the host header is authenticated by the global API key and carries no host identity
+    provenance: [IngestHandler.IngestEvents, IngestAuthMiddleware, auth.MacHostIDFromContext, EnableEventBusIngest]
+
+  - id: ING-002
+    title: Request-level limits reject the whole ingest request
+    type: api
+    status: current
+    given: a POST to the ingest endpoint
+    when: the request envelope is checked before per-event processing
+    then:
+      - a body over the size cap is rejected as payload-too-large (413)
+      - a malformed JSON body is rejected with a validation error (400)
+      - an empty events array is rejected with a validation error (400)
+      - a batch exceeding the maximum event count is rejected with a validation error (400)
+    provenance: [IngestHandler.IngestEvents, maxIngestBodyBytes, maxBatchSize]
+
+  - id: ING-003
+    title: A bad event is rejected individually without failing the batch
+    type: api
+    status: current
+    given: a batch of events that pass request-level checks
+    when: the batch is processed
+    then:
+      - the HTTP response is success (200) even when every event in the batch is rejected
+      - each rejected event appears in an errors list with its original request-array index and a stable error code
+      - the response reports separate accepted, duplicate, and rejected counts and is deliberately not wrapped in the standard API envelope
+    provenance: [IngestHandler.IngestEvents, IngestResponse, IngestError]
+    notes: Attention items for sessions needing review are surfaced separately (ING-035).
+
+  - id: ING-004
+    title: Per-event validation checks fields, bounds, kind, and payload shape
+    type: api
+    status: current
+    given: a single event in the batch
+    when: the event is validated
+    then:
+      - source is required and length-bounded, and source_id is length-bounded
+      - kind is required and must be a known event kind
+      - observed_at is required and must be a non-zero timestamp
+      - payload is required, size-bounded, and must pass structural validation for its kind (a literal JSON null is rejected)
+    provenance: [validateIngestEvent, events.IsKnownKind, events.ValidatePayload]
+
+  - id: ING-005
+    title: The daemon payload version envelope gates on a known version
+    type: api
+    status: current
+    given: a daemon-emitted event (message, external-contact, meeting-note, or call)
+    when: the payload version is checked
+    then:
+      - a version below the supported minimum is rejected as an invalid payload
+      - a version above the highest known version is rejected as an invalid payload with an upgrade signal
+    provenance: [validateRawMessagePayload, validateCallPayloadVersion, validateExternalContactPayloadVersion, validateMeetingNotePayloadVersion]
+    notes: The "upgrade Pi" rejection makes an out-of-range daemon build fail loudly instead of silently dropping unknown fields on a lenient decode.
+
+  - id: ING-006
+    title: A host revoked mid-batch stops the daemon
+    type: api
+    status: current
+    given: a daemon batch whose host is revoked between authentication and commit
+    when: the batch reaches its in-transaction host-liveness check
+    then:
+      - the whole batch is rolled back with nothing persisted
+      - the response is unauthorized (401) so the daemon stops retrying
+    provenance: [IngestHandler.IngestEvents, service.ErrHostRevokedDuringBatch]
+
+  # --- Auth-path allowlist ---
+
+  - id: ING-007
+    title: Event kinds are partitioned across the two auth paths
+    type: business-logic
+    status: current
+    given: an authenticated ingest request
+    when: each event's kind is checked against the auth path it arrived on
+    then:
+      - daemon-push kinds are accepted only on the host-auth path
+      - internally-published kinds are accepted only on the global-key path
+      - a kind on the wrong path is rejected for that event without failing the batch
+    provenance: [isHostOnlyKind, IngestService.IngestBatch]
+    notes: A daemon-push kind is one that belongs to a registered ingest family (ING-024); these kinds have exactly one legitimate producer.
+
+  # --- Batch transaction state machine ---
+
+  - id: ING-008
+    title: Domain failures reject one event while infrastructure failures roll back the batch
+    type: business-logic
+    status: current
+    given: a batch persisted in a single transaction
+    when: an event fails
+    then:
+      - a domain-level failure (auth-path, payload invariant, identity match, staging write) rejects just that event and the batch continues
+      - an infrastructure-level failure (begin, the batch's durable-event publish, savepoint commit, aggregator enqueue, outer commit) aborts the whole batch and returns all counts as zero
+    provenance: [IngestService.IngestBatch, IngestPerEventRejection]
+    notes: The batch-aborting publish is the durable event-log publish; a secondary interaction.recorded publish failure inside the inline call handler is instead treated as a per-event rejection (savepoint rollback, batch continues), not a batch abort.
+
+  - id: ING-009
+    title: Each event's writes are isolated in a savepoint
+    type: invariant
+    status: current
+    statement: every event in a batch is processed inside its own nested savepoint, so a domain rejection rolls back only that event's writes (event-log row, identity row, staging row) while already-committed events in the same batch are unaffected.
+    provenance: [IngestService.IngestBatch]
+
+  - id: ING-010
+    title: Ingest side effects are ordered around the transaction boundary
+    type: invariant
+    status: current
+    statement: within batch processing, payload invariants are verified before any savepoint opens, the durable event row is published before its domain mutation, aggregator jobs are enqueued in the outer transaction, and external HTTP side effects (follow-up task sync) run only after the transaction commits.
+    provenance: [IngestService.IngestBatch, batchPostCommit]
+    notes: Publish-before-mutate keeps events from being stranded on a mutation failure, and external-HTTP-after-commit keeps network I/O from stalling the connection inside the transaction.
+
+  - id: ING-011
+    title: A duplicate re-submit is a counted no-op
+    type: business-logic
+    status: current
+    given: an event whose (source, source_id) already exists in the event log
+    when: it is re-submitted in a batch
+    then:
+      - the event is counted as a duplicate, separate from accepted events
+      - the inline domain handler is skipped so no staging revive, last-seen bump, or re-enqueue occurs
+      - the sole exception re-runs the inline handler for a re-recorded meeting note, so a tombstone can revive or participant-resolution drift can be absorbed
+    provenance: [IngestService.IngestBatch, shouldRunInlineOnDuplicate]
+
+  - id: ING-012
+    title: Host liveness is re-checked inside the batch transaction
+    type: business-logic
+    status: current
+    given: a daemon batch on the host-auth path
+    when: the batch transaction opens
+    then:
+      - the host row is re-read under a row lock so a concurrent revoke serializes against the batch
+      - an already-revoked host aborts the batch before any event is written
+    provenance: [IngestService.IngestBatch, GetActiveHostByIDForUpdateTx]
+    notes: Closes the race between the auth-middleware read and the commit; the 401 the handler maps this to is ING-006.
+
+  # --- Event bus ---
+
+  - id: ING-013
+    title: Event publication is idempotent by source identity
+    type: data
+    status: current
+    given: an event carrying a non-empty source_id
+    when: it is published within a transaction
+    then:
+      - a first publish inserts the event row and enqueues its consumer jobs
+      - a re-publish of the same (source, source_id) is a no-op that inserts nothing and enqueues no jobs
+    provenance: [Bus.PublishTx, idx_event_source_source_id]
+
+  - id: ING-014
+    title: Consumer routing runs before the event row is inserted
+    type: invariant
+    status: current
+    statement: consumer-job routing is resolved before the event row is inserted, so a routing or payload-decode failure rolls the transaction back without leaving a durable event row that has no consumer attached.
+    provenance: [Bus.PublishTx, consumerJobsForKind]
+
+  - id: ING-015
+    title: Malformed envelopes are refused at publish
+    type: business-logic
+    status: current
+    given: an event envelope handed to the bus
+    when: it is published
+    then:
+      - a nil envelope or transaction, an empty kind, source, or payload, or a zero observed_at is refused
+      - an unknown kind is refused so arbitrary strings never reach the event log
+    provenance: [Bus.PublishTx, kindPayloadTypes]
+
+  - id: ING-016
+    title: Each event kind routes to a fixed set of consumers
+    type: business-logic
+    status: current
+    given: a published event
+    when: its consumer jobs are enqueued
+    then:
+      - message, calendar-attended, and task completion/outreach kinds route to the interaction recorder
+      - a recorded-interaction event fans out to both the cadence and follow-up consumers
+      - calendar-declined, email, contact-methods-added, and accepted/superseded-assertion kinds each route to their own dedicated consumer
+      - proposed/rejected/provenance assertion kinds, task-skipped, and interaction.manual route to no consumer — the assertion/task kinds land durably for audit, while interaction.manual is invoked inline by the manual handler
+    provenance: [consumerJobsForKind]
+    notes: Consumer internals belong to their own domains (CAD for cadence/follow-up, IMP for rematch, KNW for the knowledge cache, CAL for calendar decline); ING owns only the routing table.
+
+  - id: ING-017
+    title: The event log is an append-only durable record
+    type: invariant
+    status: current
+    statement: published events are written to an append-only log that is never updated or deleted in place, giving every ingested signal a durable audit row independent of whether its downstream consumers succeed.
+    provenance: [InsertEvent, migrations/036_event_table.up.sql]
+
+  # --- Interaction dedup ---
+
+  - id: ING-018
+    title: Interaction dedup is source-aware
+    type: data
+    status: current
+    given: an interaction being recorded
+    when: the recorder checks for an existing row
+    then:
+      - a source that carries a source_ref dedups on the exact (contact, source, source_ref) tuple
+      - a source with no source_ref (manual entry) dedups within a fixed time window around the timestamp
+      - a dedup hit returns the existing interaction and records nothing new
+    provenance: [ContactService.RecordInteractionTx, FindInteractionBySourceRef, FindInteractionInWindow]
+
+  - id: ING-019
+    title: The time-window dedup key includes direction
+    type: data
+    status: current
+    given: two manual interactions for the same contact within the dedup window
+    when: they carry opposite directions
+    then:
+      - they are treated as distinct interactions rather than collapsed into one row
+    provenance: [FindInteractionInWindow, interaction.sql]
+    notes: Direction is part of the window key so an outbound logged just before an inbound reply both survive.
+
+  - id: ING-020
+    title: A replayed interaction fires no downstream side effects
+    type: invariant
+    status: current
+    statement: source_ref interaction uniqueness is enforced by a partial unique index, and a dedup/replay hit short-circuits before the recorded-event emit, so redelivery of the same source event never re-fires cadence, follow-up, or aggregation side effects.
+    provenance: [idx_interaction_source_ref, ContactService.RecordInteractionTx, RecordInteractionResult.IsReplay]
+
+  # --- Per-entity source_ref ---
+
+  - id: ING-021
+    title: Multi-entity events attribute one interaction per entity via per-entity source_ref
+    type: data
+    status: current
+    given: a single ingested event that concerns several contacts (e.g. a meeting with several participants)
+    when: interactions are written for that event
+    then:
+      - each contact's interaction carries a source_ref that embeds both the event and the contact
+      - the per-entity ref keeps the rows from deduplicating against each other under the shared (contact, source, source_ref) key
+    provenance: [handleMeetingNoteRecorded, taggedImpromptuInteractions, stepFiveWalkins]
+
+  # --- Sole-writer / ordering ---
+
+  - id: ING-022
+    title: One recorder is the sole writer of ingested interactions
+    type: invariant
+    status: current
+    statement: interaction rows for the recorder's input kinds (messages, calendar-attended, task completion/outreach, manual) are written only through the shared record-interaction path, so dedup and cadence application stay centralized and no ingest path inserts interaction rows directly.
+    provenance: [InteractionRecorder, ContactService.RecordInteractionTx]
+
+  - id: ING-023
+    title: Recorded interactions apply cadence and follow-up in the same transaction
+    type: invariant
+    status: current
+    statement: when an ingested interaction is recorded it publishes a recorded-interaction event and applies cadence and follow-up inline in the same transaction (claimed exactly-once against redelivery), while the external follow-up task sync is deferred to a post-commit step.
+    provenance: [InteractionRecorder.HandleEvent, ContactService.RecordInteractionTx, event_consumer_claim]
+    notes: The cadence math and follow-up task lifecycle are cadence-followup scope (see CAD-005, CAD-011); ING owns the ordering and the sole-writer routing.
+
+  # --- Ingest source registry ---
+
+  - id: ING-024
+    title: The ingest source registry is the single descriptor table for daemon families
+    type: invariant
+    status: current
+    statement: the four daemon-push families (message, external-contact, meeting-note, call) are defined in one descriptor table that owns each family's kinds, allowed sources, verifier, and interaction pairing; every kind belongs to at most one family, and a family writes interactions if and only if it declares an interaction source.
+    provenance: [daemonFamilies, kindToFamily, buildKindToFamilyIndex]
+    notes: Cross-package agreement (event kinds, allowed push sources, the interaction.source SQL CHECK, provider stubs) is enforced against this table by tests, not by runtime wiring.
+
+  - id: ING-025
+    title: Batch routing carries no hard-coded per-kind branching
+    type: invariant
+    status: current
+    statement: batch dispatch routes every event through the registry index rather than per-kind constants or family predicates, enforced by a lint guard over the batch function, so a new family is added by extending the descriptor table instead of editing the batch control flow.
+    provenance: [scripts/check-ingest-registry.sh, ingest_registry_guard_static_test.go]
+
+  # --- Comms aggregation into interactions ---
+
+  - id: ING-026
+    title: Staged messages aggregate into interactions with reply-bridging and coalescing
+    type: business-logic
+    status: current
+    given: unprocessed staged messages for a contact and chat
+    when: incremental aggregation runs
+    then:
+      - an explicit or time-based reply to a prior outbound message promotes that interaction to mutual
+      - same-direction messages within the burst window extend the existing interaction rather than creating a new one
+      - otherwise a new interaction is created by publishing a message event
+    provenance: [Engine.AggregateForContact, tryExplicitReplyBridge]
+    notes: Batch/backfill aggregation is create-only (no extend or bridge); provider-specific staging adapters are CAL/TGM/MAC scope.
+
+  - id: ING-027
+    title: Reply bridging never crosses contacts
+    type: business-logic
+    status: current
+    given: a reply whose referenced message resolves to an existing interaction
+    when: the bridge is considered
+    then:
+      - the promotion applies only when the referenced interaction belongs to the contact being aggregated
+      - a referenced interaction on another contact is left untouched
+    provenance: [Engine.tryExplicitReplyBridge]
+
+  - id: ING-028
+    title: Aggregation is enqueued per batch and backstopped by a periodic sweeper
+    type: business-logic
+    status: current
+    given: staged messages awaiting aggregation
+    when: they need to become interactions
+    then:
+      - an ingest batch that stages messages enqueues a per-contact aggregation job, deduplicated within the batch and against in-flight jobs
+      - a periodic sweeper independently enqueues aggregation for contacts with eligible staged rows, bounding how long a stranded row waits
+    provenance: [IngestService.IngestBatch, MessagingAggregateSweeperWorker, MessagingAggregateUniqueOpts]
+
+  # --- Per-pipeline ingest mechanics ---
+
+  - id: ING-029
+    title: Raw messages stage with first-push-wins cross-host dedup
+    type: data
+    status: current
+    given: a raw message event from a host
+    when: it is staged
+    then:
+      - the staging row is keyed on the message guid and deduplicated across hosts (first push wins)
+      - the same guid is the event-log dedup key, so the event key and the staging key never diverge
+    provenance: [handleRawMessage, verifyRawMessageInvariants, UpsertMessagesMessage]
+
+  - id: ING-030
+    title: Call outcome decides whether an interaction is recorded
+    type: business-logic
+    status: current
+    given: an ingested call
+    when: the interaction-creation decision is applied
+    then:
+      - an outbound call always records an outbound interaction (connected or attempted)
+      - an answered inbound call, or a missed inbound call that left a voicemail, records an inbound interaction
+      - a missed inbound call with no voicemail records no interaction but keeps its staging row for audit
+    provenance: [decideCallInteraction, handleCall]
+
+  - id: ING-031
+    title: Peer-resolution outcomes differ across the message and call pipelines
+    type: business-logic
+    status: current
+    given: an ingested message or call
+    when: its peer handle is resolved to a contact
+    then:
+      - a peer that cannot be normalized is rejected in both pipelines so the daemon holds its cursor and retries
+      - a normalizable but unmatched peer is rejected for calls (no discovery path) yet retained for messages (staged, with aggregation skipped)
+    provenance: [handleRawMessage, handleCall, NormalizationFailEmpty]
+    notes: Identity normalization and matching internals are IMP; the message unknown-peer discovery candidate is IMP-023.
+
+  - id: ING-032
+    title: A re-recorded meeting note dedups via content and resolution hashes
+    type: business-logic
+    status: current
+    given: a meeting note that already exists for its session
+    when: it is re-recorded
+    then:
+      - an unchanged content hash and resolution hash carry the existing linkage forward without rewriting interactions
+      - a changed hash re-links the session and diffs its interactions
+      - a tombstoned session re-recorded with identical content is revived
+    provenance: [handleMeetingNoteRecorded, input_hash, resolved_set_hash]
+    notes: Meeting-note linkage states are notes-meetings scope; conflict/orphan surfacing is IMP (IMP-024, IMP-025). ING owns the hash-keyed idempotency branch and the interaction writes.
+
+  - id: ING-033
+    title: Deleting a meeting note cascades soft-delete to its session interactions
+    type: data
+    status: current
+    given: a meeting-note deletion for a known session
+    when: the deletion is applied
+    then:
+      - every interaction attributed to that session is soft-deleted explicitly
+      - the meeting-note row is then soft-deleted
+      - an unknown session, an already-tombstoned session, or one owned by another host is a silent no-op
+    provenance: [handleMeetingNoteDeleted]
+    notes: A soft-delete does not fire ON DELETE CASCADE, so the interaction cascade is done explicitly.
+
+  - id: ING-034
+    title: Session interaction re-sync diffs through the sole-writer path
+    type: business-logic
+    status: current
+    given: a re-recorded meeting note whose resolved participant set changed
+    when: its session interactions are reconciled
+    then:
+      - interactions no longer desired are soft-deleted
+      - interactions still desired are refreshed only when their timestamp or description actually changed
+      - newly desired interactions are added
+      - every write routes through the shared record/extend path so cadence stays under the sole writer, and only session-attributed rows are touched
+    provenance: [handleMeetingNoteRecorded, ListSessionAttributedInteractions, ContactService.ExtendInteractionTx]
+
+  - id: ING-035
+    title: Sessions needing review are surfaced in the ingest response
+    type: api
+    status: current
+    given: a batch containing meeting-note recordings
+    when: a recording lands in a conflict or orphan state
+    then:
+      - the response carries a needs-attention entry naming the session and the reason
+      - the field is omitted for daemons that predate it
+    provenance: [IngestResponse.NeedsAttention, NeedsAttentionItem]
+    notes: What makes a session a conflict or an orphan is imports-matching scope (IMP-025).
+
+  - id: ING-036
+    title: Daemon-asserted payload facts are re-verified server-side
+    type: invariant
+    status: current
+    statement: for every daemon family the server re-checks the daemon's claims before trusting them — the payload host id must equal the authenticated host, the envelope source must be in the family's allow-list, and the source_id must match the payload's own dedup key (verbatim for message and call, or as an <entity>@<content-hash> composite whose entity prefix must match the payload and whose hash suffix must equal a server-recomputed content hash, for external-contact and meeting-note); normalized phone peers are likewise recomputed and must match — so a buggy or compromised daemon is rejected rather than allowed to corrupt state.
+    provenance: [verifyRawMessageInvariants, verifyCallInvariants, verifyExternalContactInvariants, verifyMeetingNoteInvariants, ComputeContentHash]
+    notes: External-contact match-state and revive lifecycle is IMP (IMP-007, IMP-008); this behavior covers only the ingest-side integrity re-checks.
+
+  - id: ING-037
+    title: Call direction forces the answered and voicemail fields during staging
+    type: business-logic
+    status: current
+    given: a call being staged
+    when: direction-specific fields are normalized
+    then:
+      - an outbound call forces answered to unset and voicemail to false, ignoring any daemon-supplied values
+      - an inbound call keeps the daemon-supplied answered value
+    provenance: [IngestService.handleCall direction normalization]
+    notes: Calls reach ingest exclusively from the Mac daemon's call log (mac-host anarlog); this pins the backend-side field normalization, distinct from the interaction decision (ING-030).
+
+  - id: ING-038
+    title: Phone calls deduplicate on the Apple call id across hosts
+    type: data
+    status: current
+    given: the same call pushed more than once, including from two hosts
+    when: it is upserted into the phone-call staging table
+    then:
+      - the upsert deduplicates on the globally-unique call id and converges to a single row
+      - a re-push is a no-op that returns the existing row
+    provenance: [phone_call.call_unique_id UNIQUE, UpsertPhoneCall ON CONFLICT DO UPDATE]
+    notes: The call-staging analog of the message-guid dedup (ING-029). A late-arriving field change (e.g. a voicemail flag flip) is deduplicated by the event log before reaching the upsert and is dropped — an accepted v1.5 limitation.

--- a/spec/knowledge.yaml
+++ b/spec/knowledge.yaml
@@ -1,0 +1,446 @@
+domain: knowledge
+prefix: KNW
+maturity: reviewed
+behaviors:
+  # --- Assertion write path ---
+
+  - id: KNW-001
+    title: All assertion-store writes go through one validated write path
+    type: invariant
+    status: current
+    statement: every producer of knowledge (user profile edits, contact merges, enrichment inference, operator backfills) writes to the assertion store through the single validated assert path — which owns proposition identity, cardinality and supersession, the bi-temporal clocks, provenance dedup, and event emission in one transaction — and a validation failure rejects the write (rolling back the transaction) rather than silently dropping the assertion.
+    provenance: [AssertService, ErrAssertValidation, knowledgeWriter, ContactKnowledgeMigrationService, TagMigrationService]
+    notes: There is no raw-INSERT side door; even the tag/column data migrations route through this path so dedup and events apply uniformly.
+
+  - id: KNW-002
+    title: Assertion writes are validated against the catalog and the live graph
+    type: business-logic
+    status: current
+    given: an assert request naming a subject, predicate, and payload
+    when: the write is validated
+    then:
+      - the predicate must exist in the predicate catalog
+      - the subject node must exist, not be soft-deleted, and match the predicate's subject type (person, venue, or a specific entity subtype)
+      - an edge predicate requires a live, type-matched object node and no scalar value
+      - a fact predicate requires exactly one scalar value matching the predicate's value type, and text values must be non-empty after trimming
+      - confidence must be within 0-100, and any salience override within 0-100 (salience defaults from the predicate)
+      - a validity range whose end does not fall after its effective start is rejected as degenerate, even when an existing row would otherwise have matched
+    provenance: [AssertService.validate, validateFactValue, matchNodeType]
+    notes: The salience range check runs on the new-row path; a write that corroborates an existing live proposition never touches salience, so an out-of-range override there is ignored rather than rejected.
+
+  - id: KNW-003
+    title: Provenance locators are validated per source kind
+    type: business-logic
+    status: current
+    given: an assert request carrying provenance locators
+    when: the locators are validated
+    then:
+      - at least one locator is required on every assertion
+      - producer kind and source kind must come from their closed vocabularies
+      - metadata-only sources (phone calls, calendar events) may not back a fact assertion
+      - a locator referencing a content row must point at an existing (non-deleted) row at write time
+      - locators without a content row (user, agent session, transcript kinds) still require a stable non-empty source id, since it keys idempotent re-runs
+    provenance: [AssertService.validateLocators, SourceKindRequiresExistenceCheck, assertion_provenance.sql]
+
+  - id: KNW-004
+    title: Landing status follows the predicate's review policy
+    type: business-logic
+    status: current
+    given: a valid assert request for a predicate with a default review policy
+    when: the new assertion lands
+    then:
+      - an auto-if-confident predicate lands the assertion as accepted
+      - an always-confirm predicate lands it as proposed, awaiting review
+      - a caller may force an otherwise auto-applied write to land proposed
+    provenance: [AssertService.AssertTx landingAccepted, predicate.default_review_policy, 066_seed_predicate_catalog.up.sql]
+
+  - id: KNW-005
+    title: Relationship edges are stored in one canonical form
+    type: data
+    status: current
+    given: an edge assertion whose predicate is symmetric or has an inverse
+    when: the edge is written
+    then:
+      - a symmetric edge stores its pair in a deterministic participant order, so both statements of the relationship are one row
+      - an inverse pair rewrites to the canonical predicate with subject and object swapped, so the relationship stated from either side collapses to one row
+    provenance: [canonicalEdge, 066_seed_predicate_catalog.up.sql inverse seeding]
+
+  - id: KNW-006
+    title: Re-asserting an existing proposition corroborates instead of duplicating
+    type: data
+    status: current
+    given: a live assertion whose proposition identity (canonical subject, predicate, normalized value, valid-time bucket) matches an incoming write
+    when: the write is applied
+    then:
+      - no new assertion row is created
+      - the incoming provenance locators are appended, with already-known locators deduplicated on their full locator identity
+      - confidence re-aggregates to the maximum across old and new evidence
+      - the trust tier re-aggregates to the strongest producer across all locators (user over agent over extractor)
+      - a proposed row that is corroborated by an accepted-landing write is upgraded to accepted, including accept-time conflict resolution
+    provenance: [computePropositionKey, AssertService.corroborate, appendProvenance, computeLocatorHash]
+    notes: Value normalization for identity is case/whitespace-insensitive for text, calendar-day for dates, canonical float form for numbers; valid-time bucketing granularity is per-predicate (day/month/year/none).
+
+  - id: KNW-007
+    title: At most one live assertion exists per proposition
+    type: invariant
+    status: current
+    statement: the database enforces at most one live (proposed or accepted, knowledge-open) assertion per proposition key via a partial unique index, and a concurrent identical write that loses the race is recovered inside the transaction (savepoint rollback, re-read, corroborate the winner) rather than failing the caller.
+    provenance: [idx_assertion_live_proposition, insertAssertionWithRecover, isLivePropositionViolation]
+
+  - id: KNW-008
+    title: A different value written to a single-cardinality slot supersedes the current one
+    type: business-logic
+    status: current
+    given: a single-cardinality slot (e.g. a person's current location) holding an accepted value
+    when: a different value is asserted as accepted with an overlapping validity window
+    then:
+      - the new row is inserted and becomes the current value
+      - the prior row is closed as superseded with a pointer to its successor and its knowledge window closed
+      - exactly one accepted row remains current for the slot
+    provenance: [AssertService.writeNew, closeConflicts, FindAcceptedForSlot]
+    notes: Concurrent writers to the same slot serialize on a per-slot advisory lock taken before any row lock; symmetric predicates lock per participant in sorted order to stay deadlock-free.
+
+  - id: KNW-009
+    title: Reaffirming the same value widens the existing stint instead of superseding it
+    type: business-logic
+    status: current
+    given: an accepted assertion and an incoming accepted write carrying the same value for the same slot with an overlapping window
+    when: the write is applied
+    then:
+      - no new row is created and nothing is superseded as a value change
+      - the surviving row's validity window widens to the union of the windows
+      - a window that bridges several non-contiguous same-value stints merges them all into one survivor (provenance moved, losers closed pointing at the survivor)
+      - a survivor already bounded by a pending future successor keeps that upper bound (only the backward extension applies)
+    provenance: [widenReaffirmation, sameValueConflicts, mergeSameValue]
+
+  - id: KNW-010
+    title: Past-bounded history coexists with the current value
+    type: business-logic
+    status: current
+    given: a slot with a current accepted value
+    when: a different value is asserted with a validity window that ended in the past
+    then:
+      - the historical row is inserted alongside the current one without superseding it
+      - the current value is unchanged
+      - a same-value past stint still merges into the existing row for that value rather than duplicating it
+    provenance: [AssertService.writeNew pastBounded branch]
+
+  - id: KNW-011
+    title: A future-dated successor bounds the current value until its date arrives
+    type: business-logic
+    status: current
+    given: a slot with a current accepted value
+    when: a different value is asserted with a validity start in the future
+    then:
+      - the prior stays accepted (still the current value) but its validity end is bounded at the successor's start and it records the successor
+      - a prior that would never be current under the new timeline is terminalized immediately, keeping its own validity end
+    provenance: [closeConflicts, closeBoundary, BoundPendingSuccessor]
+
+  - id: KNW-012
+    title: A scheduled rollover terminalizes bounded values whose date has passed
+    type: business-logic
+    status: current
+    given: accepted assertions bounded by a pending successor whose validity end has been reached
+    when: the periodic rollover sweep runs
+    then:
+      - each due row flips to superseded with its knowledge window closed, and a superseded event is emitted per row in the same transaction
+      - an event-publish failure rolls the flip back so the next run retries
+      - the sweep is stateless and idempotent, runs daily, and catches up overdue rollovers on startup
+      - a bounded-past row with no successor is never touched (it remains legitimate accepted history)
+    provenance: [AssertService.RunRollover, RolloverDueBoundedSuccessors, AssertionRolloverWorker]
+
+  - id: KNW-013
+    title: Clearing a slot closes the current value with no successor
+    type: business-logic
+    status: current
+    given: a single-cardinality slot
+    when: a closure is requested for the slot
+    then:
+      - the current accepted row, if any, is closed as ended at the current time with no successor, and the slot becomes a gap
+      - with no current row the closure is an idempotent no-op
+    provenance: [AssertService.AssertClosure, ClosureReasonEnded]
+    notes: This is what a user clearing the location or birthday field on the contact form invokes (see KNW-028 and CON-006) — history is closed, never deleted.
+
+  - id: KNW-014
+    title: Accepting a proposed assertion applies full slot conflict resolution
+    type: business-logic
+    status: current
+    given: a proposed assertion under review
+    when: it is accepted
+    then:
+      - only a proposed assertion may be accepted; any other status is rejected as a validation error
+      - the acceptance runs single-cardinality conflict resolution as if the value were being written now, superseding different-value priors
+      - an acceptance that reaffirms an existing accepted value is absorbed into that survivor (provenance and confidence folded in, the accepting row closed) and the survivor is returned
+      - a past-bounded row is accepted as coexisting history without superseding anything
+      - concurrent lifecycle transitions on the same row are serialized so only one succeeds
+    provenance: [AssertService.Accept, resolveAcceptConflicts, GetAssertionForUpdate]
+
+  - id: KNW-015
+    title: Reject and retract are status-guarded terminal transitions
+    type: business-logic
+    status: current
+    given: an assertion under review or correction
+    when: a reject or retract transition is applied
+    then:
+      - only a proposed assertion may be rejected; only an accepted assertion may be retracted
+      - the row becomes terminal with its closure reason recorded and its knowledge window closed
+      - a rejected proposal never becomes a current value
+      - a retraction removes the value from current knowledge and is announced as a supersession (there is no separate retract event kind); the closure reason distinguishes it
+    provenance: [AssertService.Reject, AssertService.Retract, terminalTransition]
+
+  - id: KNW-016
+    title: The assertion row enforces its shape and clocks at the schema level
+    type: data
+    status: current
+    given: any attempt to persist an assertion row
+    when: the row is written
+    then:
+      - exactly one payload is set (an object node reference, or one typed scalar)
+      - the knowledge window is closed if and only if the status is terminal (rejected, superseded, retracted)
+      - when both validity bounds are present the end is strictly after the start
+      - the knowledge end is never before the knowledge start
+      - numeric values must be finite (NaN and infinities are rejected)
+      - status, confidence, and salience are constrained to their closed sets and 0-100 ranges
+      - node and predicate references restrict hard deletes rather than cascading
+    provenance: [067_assertion_store.up.sql CHECK constraints]
+
+  - id: KNW-017
+    title: Every assertion state change emits a durable event inside the write transaction
+    type: invariant
+    status: current
+    statement: assertion lifecycle changes (proposed, accepted, superseded, rejected) and provenance additions publish events on the transactional event bus within the same transaction as the state change, keyed idempotently (one-shot per lifecycle transition, per-locator for provenance, per merge-destination for merge moves) so retries never double-publish; the event bus is mandatory wiring — the write path does not operate without it.
+    provenance: [emitAssertionEvent, emitProvenanceAddedEvent, emitMergeMoveEvent, busPublisher]
+
+  - id: KNW-018
+    title: Only accepted and superseded events drive downstream recomputation
+    type: business-logic
+    status: current
+    given: a published assertion event
+    when: consumer jobs are routed
+    then:
+      - accepted and superseded events enqueue the knowledge-cache refresh worker (with bounded retries)
+      - proposed, rejected, and provenance-added events deliberately have no consumer — they never change a current value and land durably for audit only
+    provenance: [events/bus.go consumerJobsForKind, KnowledgeCacheUpdaterJobArgs]
+
+  # --- Graph nodes and entities ---
+
+  - id: KNW-019
+    title: Node tombstones gate all live graph reads
+    type: invariant
+    status: current
+    statement: a node's single tombstone (deleted-at, set by contact deletion or merge) removes it from every live graph read — an assertion is only current/live when its subject node is live and, for an edge, its object node is live — and entity and venue subtype rows carry no tombstone of their own, inheriting liveness from their parent node; assertion rows themselves are retained as history.
+    provenance: [GetCurrentAccepted, ListLiveEdgesForNode, node.deleted_at, entity.sql]
+    notes: This is why a deleted or merged-away contact's knowledge never resurfaces (see KNW-026); node soft-deletion itself is contact-domain scope (CON-010, CON-033).
+
+  - id: KNW-020
+    title: Place entities deduplicate on their normalized name
+    type: data
+    status: current
+    given: a location label to resolve to a place node
+    when: the place is ensured
+    then:
+      - the place is found or created by its case- and whitespace-insensitive normalized name, so the same place asserted across contacts or edits resolves to one node
+      - the node's display label preserves the original casing and spacing of its first write
+      - an empty label is rejected as a validation error
+      - two concurrent first-writes of the same new place resolve to a single node (the loser recovers from the uniqueness collision and adopts the winner's node)
+    provenance: [EnsurePlaceTx, idx_entity_subtype_name, isPlaceNameViolation]
+
+  # --- Node merge mechanics (invoked by contact merge — CON-033) ---
+
+  - id: KNW-021
+    title: Merging nodes re-canonicalizes repointed assertions and resolves winner-side collisions
+    type: business-logic
+    status: current
+    given: a loser node being merged into a winner (the loser already tombstoned with a merge alias)
+    when: the assertion merge runs
+    then:
+      - every assertion touching the loser (as subject or object) is rewritten onto the winner, re-canonicalized, and its proposition identity recomputed
+      - terminal rows are repointed silently as history
+      - a live row whose recomputed identity collides with a live winner-side row merges into it, and the accepted row always survives a collision with a proposed one — a merge never demotes accepted knowledge
+      - repointed live rows announce their move with an event keyed per merge destination, so retrying the same merge is idempotent while a chained merge announces again
+      - all implied single-cardinality slot locks are collected up front and acquired in sorted order
+    provenance: [MergeAssertionsTx, planRepoint, applyRepoint, emitMergeMoveEvent]
+    notes: The domain boundary is intentional. CON-033 owns the merge-level contract (loser assertions repoint onto the winner node, before the field-selection apply so the user's choices win); this behavior owns the knowledge-side mechanics that bare repointing elides — re-canonicalization, proposition-identity recompute, winner-side collision resolution (accepted always survives), self-loop closure (KNW-022), slot re-competition (KNW-023), and per-destination merge events. When the graph merge runs relative to the field-selection apply is contact-domain scope — CON-033.
+
+  - id: KNW-022
+    title: Edges between the merging pair collapse and close
+    type: business-logic
+    status: current
+    given: an edge connecting the loser and winner of a node merge
+    when: the merge rewrite would turn it into a self-referencing edge
+    then:
+      - a live self-collapsed edge is closed as ended (a node cannot relate to itself), with its validity end stamped only if the edge was genuinely open at that moment
+      - a terminal self-collapsed edge is left untouched as dead history
+    provenance: [closeSelfLoop, repointedAssertion.selfLoop]
+
+  - id: KNW-023
+    title: A repointed current value competes in the winner's slot
+    type: business-logic
+    status: current
+    given: an accepted single-cardinality assertion repointed onto the winner during a node merge
+    when: it lands in the winner's slot
+    then:
+      - same-value priors on the winner widen into the repointed row (windows unioned, provenance folded)
+      - the widened survivor inherits the tightest pending-future-successor bound among the rows folded in, so the scheduled rollover still terminalizes it on time
+      - different-value overlapping priors are superseded exactly as on the normal write path
+      - a past-bounded repointed row coexists as history and supersedes nothing
+    provenance: [applyRepoint slot resolution, widenMergedSurvivor]
+
+  # --- Derived cache columns (contact location / birthday / how-met) ---
+
+  - id: KNW-024
+    title: Contact knowledge columns are derived from current-accepted assertions
+    type: data
+    status: current
+    given: a contact's location, birthday, and how-met cache columns
+    when: a cache refresh recomputes a column
+    then:
+      - the value is recomputed from scratch from the current-accepted assertion for that contact and predicate (never patched incrementally), which makes supersession, closure, and retraction all land correctly
+      - when no current-accepted assertion exists, the column is cleared to NULL
+      - the location column carries the linked place node's display label
+      - a current location edge with no place node is surfaced as a hard error, never a silently blank cache
+    provenance: [KnowledgeCacheUpdater.RefreshTx, resolveLivesInLabel, GetCurrentAccepted]
+    notes: The contact-side rule that contact writes never touch these columns directly is CON-004; this behavior owns the derivation itself.
+
+  - id: KNW-025
+    title: Cache refresh is inline for the writer and event-driven for everyone else
+    type: business-logic
+    status: current
+    given: an assertion write that affects a contact knowledge column
+    when: the cache is refreshed
+    then:
+      - writes made inside a contact create/update/merge/enrichment transaction refresh the columns inline in that transaction, so the returned contact already reflects the new values on commit
+      - accepted and superseded assertion events from any other producer refresh the column asynchronously via a queued worker with bounded retries
+      - the event path ignores predicates that do not back a cache column, while a direct refresh call with an unsupported predicate is rejected as a programming error
+    provenance: [knowledgeWriter.refreshAll, KnowledgeCacheUpdater.HandleEvent, KnowledgeCacheUpdaterWorker]
+
+  - id: KNW-026
+    title: Cache maintenance is bookkeeping, not a profile edit
+    type: data
+    status: current
+    given: a contact whose knowledge cache column is being refreshed
+    when: the column update is applied
+    then:
+      - the contact's updated-at timestamp is not bumped
+      - a soft-deleted contact row is never written
+      - a deleted or merged-away contact has no current-accepted values (node liveness gating), so its cached knowledge never resurrects
+    provenance: [UpdateContactLocationCache, contact.sql cache queries, GetCurrentAccepted node join]
+
+  # --- Contact profile fields as knowledge (the cutover write path) ---
+
+  - id: KNW-027
+    title: Contact profile knowledge fields are written as assertions
+    type: business-logic
+    status: current
+    given: a contact create, update, or merge carrying location, birthday, or how-met values
+    when: the profile write is applied
+    then:
+      - each field value becomes an accepted assertion (location as an edge to a deduplicated place, birthday as a date fact, how-met as a text fact) in the same transaction as the contact write
+      - a direct user edit carries user provenance at full confidence
+      - the provenance locator is deterministic per source, contact, and field, so a retry or re-run corroborates the same assertion instead of duplicating it
+      - the services refuse to run without the knowledge writer wired, rather than silently dropping a value
+    provenance: [knowledgeWriter.assertCreate, knowledgeWriter.locator, knowledgeAssertConfidence, ContactService.SetKnowledgeWriter]
+    notes: The contact-domain statements of this seam are CON-004 (columns never written directly) and CON-006 (clear semantics); this behavior owns the assertion-side mechanics.
+
+  - id: KNW-028
+    title: Blank knowledge values mean no value, and clears close slots
+    type: business-logic
+    status: current
+    given: a contact write whose location or how-met value is blank or whitespace-only, or whose location/birthday was cleared
+    when: the knowledge fields are reconciled
+    then:
+      - a whitespace-only location or how-met normalizes to no-value; a blank location never mints a place node
+      - on update, a cleared location or birthday closes that slot (KNW-013), preserving the assertion history
+      - an absent how-met on update is a no-op rather than a clear, because the contact form carries no how-met input and its absence must not wipe history
+    provenance: [knowledgeFieldValues.normalized, knowledgeWriter.applyUpdate, reconcileClearable]
+
+  # --- Enrichment-inferred knowledge ---
+
+  - id: KNW-029
+    title: Enrichment infers knowledge only into empty fields, as agent-provenance assertions
+    type: business-logic
+    status: current
+    given: a contact being enriched from a linked external contact
+    when: the enrichment computes inferred fields
+    then:
+      - an inferred birthday or location is taken only when the contact's corresponding field is currently empty; existing values are never overwritten
+      - inferred values land as assertions with agent provenance at reduced (non-certain) confidence, in the same transaction as the profile update
+      - the enrichment provenance locator is deterministic, so re-running the enrichment corroborates rather than duplicates
+    provenance: [EnrichmentService.EnrichContactFromExternal, assertInferredKnowledge, knowledgeAssertConfidence]
+    notes: The enrichment trigger and method-enrichment mechanics are imports-domain scope (IMP-015 cross-references this seam).
+
+  - id: KNW-030
+    title: Losing an inferred knowledge value is an error, not a warning
+    type: business-logic
+    status: current
+    given: an enrichment that inferred a location or birthday
+    when: the transaction persisting the inferred assertions fails, or the knowledge writer is not wired
+    then:
+      - the enrichment surfaces an error instead of reporting success, because the assertion store is the value's only home
+      - an enrichment carrying no inferred knowledge (photo, cadence, or name only) keeps best-effort warn-and-continue semantics for profile-write failures
+    provenance: [EnrichmentService inferred-knowledge error branches]
+
+  # --- Operator backfills ---
+
+  - id: KNW-031
+    title: The knowledge-column backfill is an idempotent mirror into the graph
+    type: business-logic
+    status: current
+    given: legacy contact rows with location, birthday, or how-met column values
+    when: the operator runs the knowledge-column migration command
+    then:
+      - each populated column of every live contact becomes an accepted assertion through the standard write path (location via the deduplicated place entity)
+      - migrated assertions carry user provenance at full confidence, with the contact's creation time preserved as the knowledge time
+      - soft-deleted contacts and blank values are skipped
+      - re-running the command corroborates existing assertions instead of duplicating them (deterministic per-contact-per-column locators)
+    provenance: [ContactKnowledgeMigrationService, ListContactsWithKnowledgeColumns, crm-admin --migrate-contact-knowledge-columns]
+    notes: Preserving historical knowledge time (the override) is reserved for migrations/backfills; live producers always get the current time as knowledge time.
+
+  - id: KNW-032
+    title: The tag migration mirrors legacy tags into the graph, failing loudly on ambiguity
+    type: business-logic
+    status: current
+    given: legacy tags and contact-tag links
+    when: the operator runs the tag migration command
+    then:
+      - each distinct case-insensitive tag name becomes one tag entity node, preserving the original display casing and carrying the tag color in the entity detail
+      - each tag link of a live contact becomes an accepted tagged-as assertion with user provenance, using the link's creation time as knowledge time when known (otherwise the current time)
+      - tags whose names differ only by case abort the whole run before any node is created, listing the collisions for the operator to resolve
+      - a link referencing an unknown tag, or a contact missing its person node, fails the run loudly rather than skipping silently
+      - links of soft-deleted contacts are skipped and counted
+      - a re-run is idempotent (deterministic locators corroborate)
+    provenance: [TagMigrationService, ErrTagCaseCollision, assertTaggedAs, crm-admin --migrate-tags]
+    notes: Live tag CRUD does not currently dual-write tagged-as assertions — the graph mirror exists only via this migration. Deliberate phasing, with the graph consuming tags in a later phase.
+
+  # --- Surfaces ---
+
+  - id: KNW-033
+    title: Knowledge reaches the user only through the contact's derived fields
+    type: invariant
+    status: current
+    statement: no HTTP endpoint exposes assertions, graph nodes, edges, predicates, or provenance — the assertion store is invisible to clients, and the only client-visible projection of the knowledge graph is the contact payload's derived location, birthday, and how-met fields.
+    provenance: [cmd/crm-api/main.go SP1 no-handler comment, contact_dto.go]
+    notes: Deliberate phasing — the write API exists for later phases to consume over HTTP. how-met is carried on the wire contract but currently has no rendering or editing surface anywhere in the UI (which is why its absence on update is a no-op — KNW-028).
+
+  - id: KNW-034
+    title: Contact detail shows knowledge fields only when known
+    type: ux
+    status: current
+    given: a contact detail page
+    when: the profile section renders
+    then:
+      - a known location appears as a labeled row; an unknown location renders no row at all
+      - a known birthday appears as a labeled, human-readable date row; an unknown birthday renders no row
+    provenance: ["contacts/[id]/page.tsx knowledge rows"]
+
+  - id: KNW-035
+    title: Year-less birthdays display without a year or age
+    type: ux
+    status: current
+    given: a contact whose birthday was stored with the placeholder year that marks a year-less (imported) birthday
+    when: the birthday is displayed on any surface
+    then:
+      - the date renders as month and day only, with the placeholder year never shown
+      - no age is computed or displayed for it
+    provenance: [formatBirthday, isPlaceholderBirthday, birthdays.spec.ts placeholder assertions]
+    notes: The placeholder-year sentinel convention and the year-less rendering (formatBirthday drops the year on every surface — contact detail per KNW-034, the birthdays page, etc.) are the knowledge-domain derived-data concern owned here. Because no real year is stored there is no year to derive an age from; the landed CON-045 owns the birthdays-page display of that age-suppression outcome. The two are consistent, not competing — this row does not claim authority over CON-045.

--- a/spec/mac-host.yaml
+++ b/spec/mac-host.yaml
@@ -1,0 +1,453 @@
+domain: mac-host
+prefix: MAC
+maturity: reviewed
+behaviors:
+  # --- Pairing & token lifecycle ---
+
+  - id: MAC-001
+    title: Pairing tokens are short-lived single-use secrets stored only as a hash
+    type: business-logic
+    status: current
+    given: an operator mints a pairing token
+    when: the token is created
+    then:
+      - a high-entropy random token is generated and returned to the operator exactly once
+      - only a hash of the token is persisted; the plaintext is never stored at rest
+      - the token expires after a short fixed lifetime
+    provenance: [MacHostService.CreatePairingToken, hashPairingToken, PairingTokenTTL]
+
+  - id: MAC-002
+    title: Pairing atomically consumes the token and provisions the host
+    type: business-logic
+    status: current
+    given: a valid unconsumed unexpired pairing token
+    when: a host pairs with it
+    then:
+      - the token is validated under a row lock before the api key is minted, so the expensive key hashing cost is paid only for a valid token
+      - token consume, host creation, and api-key mint commit together in a single transaction
+      - if the singleton constraint rejects a second host the whole transaction rolls back and the token is left unconsumed
+    provenance: [MacHostService.PairWithToken, GetTokenByHashForUpdateTx, CreateHostTx, MarkConsumedTx]
+
+  - id: MAC-003
+    title: Pair endpoint contract
+    type: api
+    status: current
+    given: a request to the pairing endpoint
+    when: it is handled
+    then:
+      - a valid token pairs the host and returns the host id, plaintext api key, and current cursor epoch, with the api key shown only once
+      - an invalid, already-consumed, or expired token all collapse to a single opaque gone response (410) that does not reveal which condition failed
+      - a second pairing attempt while a host is already live is rejected as a conflict (409)
+      - a missing pairing token or hostname is a validation error (400)
+    provenance: [MacHostHandler.Pair, pairResponse]
+    notes: The opaque 410 is deliberate — distinct token-state codes would let a caller probe whether a guessed token ever existed. Rotation deliberately does the opposite (MAC-010).
+
+  - id: MAC-004
+    title: At most one live host exists at any time
+    type: invariant
+    status: current
+    statement: at most one non-revoked mac_host row exists at a time, enforced by a partial unique index over live rows; revoked host rows may coexist freely, and a pairing attempt while a host is already live is rejected rather than creating a second host.
+    provenance: [idx_mac_host_singleton, migrations/047_mac_host.up.sql, ErrHostAlreadyPaired]
+    notes: Multi-host is deferred (cross-host content-hash source_id collisions are unresolved).
+
+  - id: MAC-005
+    title: Pairing is rate-limited per source address ahead of any lookup
+    type: business-logic
+    status: current
+    given: repeated pairing attempts from one source address
+    when: the per-address limit is exceeded
+    then:
+      - further attempts are rejected as rate-limited before any database lookup
+      - the limiter keys on the raw connection address and ignores client-supplied forwarding headers, so a Tailnet peer cannot spoof its way around the limit
+      - the limiter is bounded so a flood of distinct addresses cannot grow memory unboundedly
+    provenance: [PairingIPRateLimiter, MacHostHandler.remoteIP, ipRateLimiter]
+
+  - id: MAC-006
+    title: Expired unconsumed pairing tokens are reaped
+    type: data
+    status: current
+    given: pairing tokens that expired without being consumed
+    when: the periodic janitor runs
+    then:
+      - expired unconsumed tokens are hard-deleted
+      - consumed tokens are retained so the consuming host can still be audited
+    provenance: [DeleteExpiredPairingTokens, pairing_token_janitor_worker.go, consumed_host_id FK]
+
+  # --- Daemon authentication ---
+
+  - id: MAC-007
+    title: Daemon authentication flow and error taxonomy
+    type: api
+    status: current
+    given: a request to a daemon-authenticated endpoint
+    when: authentication runs
+    then:
+      - a missing or malformed host-id header is rejected (401)
+      - presenting global-api-key auth alongside daemon auth is rejected as ambiguous (400)
+      - a missing or empty bearer token is rejected (401)
+      - an unknown or revoked host is rejected (401)
+      - a bearer token that fails the constant-time key comparison is rejected (401)
+      - a route id parameter that does not match the header host id is rejected as an authorization failure (403), distinct from an authentication failure
+    provenance: [MacHostAuthMiddleware, abortAuth]
+
+  - id: MAC-008
+    title: Per-host failed-auth limiting precedes the key comparison and refunds on success
+    type: business-logic
+    status: current
+    given: repeated failed authentication attempts for one host id
+    when: the per-host limiter is consulted
+    then:
+      - a token is reserved from the host's bucket before the expensive key comparison runs
+      - exhausting the budget returns a rate-limited response without performing the comparison
+      - a successful authentication refunds the token so a legitimate daemon is not penalized for earlier typos
+      - concurrent attempts for one host serialize on the bucket so only the burst budget reaches the comparison
+    provenance: [macHostAuthLimiter, macHostAuthReservation, reserve/Commit/Refund]
+
+  # --- API-key rotation ---
+
+  - id: MAC-009
+    title: API-key rotation is compare-and-swap guarded and identity-preserving
+    type: business-logic
+    status: current
+    given: a rotate request authenticated with the current key plus a pairing token
+    when: rotation runs
+    then:
+      - the host row is locked and its live key hash is compared against the hash the caller authenticated with; a mismatch aborts as stale-auth and leaves the token unconsumed
+      - a new key is minted and swapped in atomically with consuming the pairing token
+      - the host id, cursor epoch, hostname, permissions, and source health are all preserved
+      - the previous key stops authenticating immediately after commit
+    provenance: [MacHostService.RotateAPIKey, GetActiveHostByIDForUpdateTx, RotateAPIKeyTx]
+
+  - id: MAC-010
+    title: Rotate-key endpoint contract
+    type: api
+    status: current
+    given: a rotate-key request
+    when: it is handled
+    then:
+      - success returns the new plaintext key and rotation timestamp (200), with the key shown only once
+      - token-state failures return distinct client-error codes for invalid, already-used, and expired, because the caller has already proven control of the current key
+      - a key rotated out from under the caller returns stale-auth (401)
+      - a missing or revoked host returns not-found (404)
+    provenance: [MacHostHandler.RotateKey, rotateKeyResponse]
+    notes: The distinct token-state codes are the opposite choice from pairing (MAC-003) — leaking token state is safe here because the caller already holds the current key.
+
+  # --- Heartbeat & protocol ---
+
+  - id: MAC-011
+    title: Heartbeat records liveness and echoes restore-detection state
+    type: api
+    status: current
+    given: an authenticated daemon heartbeat
+    when: it is handled
+    then:
+      - the host's last-heartbeat time, daemon version, protocol version, permissions, and source health are recorded
+      - the response echoes the current cursor epoch so the daemon can detect a backend backup-restore
+      - the response reports the server's current and minimum protocol versions
+      - a host revoked between authentication and the write returns unknown-host (401)
+    provenance: [MacHostHandler.Heartbeat, UpdateMacHostHeartbeat, heartbeatResponse]
+
+  - id: MAC-012
+    title: Heartbeat enforces a minimum daemon protocol version
+    type: api
+    status: current
+    given: a heartbeat whose protocol version is below the server minimum
+    when: it is handled
+    then:
+      - the request is rejected with an upgrade-required response (412) before any database write
+      - the response carries the minimum acceptable protocol version
+    provenance: [MacHostHandler.Heartbeat protocol gate, mac.MinProtocolVersion]
+    notes: Newer additive versions are accepted (older daemons simply do not emit newer event kinds), so the floor moves only on breaking contract changes.
+
+  - id: MAC-013
+    title: Push sources are a fixed allowlist
+    type: invariant
+    status: current
+    statement: the cursor get/commit and known-ids endpoints accept only a fixed allowlist of push sources (messages, icloud_contacts, anarlog_humans, anarlog_sessions, phone_calls), validated at the handler before any database access; the cursor get/commit service methods additionally re-check the allowlist as defence-in-depth for a non-HTTP caller, while known-ids relies on the handler check (an unguarded unknown source there merely returns an empty set). An unknown source is a validation error, which prevents a daemon from creating a push-strategy sync row keyed on a poll-strategy source name.
+    provenance: [mac.AllowedPushSources, IsAllowedPushSource, MacHostService.CommitCursor/GetCursor]
+
+  # --- Cursor protocol ---
+
+  - id: MAC-014
+    title: Cursor commit is an epoch-and-base compare-and-swap
+    type: business-logic
+    status: current
+    given: a cursor commit carrying a claimed epoch and a base cursor
+    when: the commit runs
+    then:
+      - the host is locked and its epoch read in the same transaction
+      - a claimed epoch not matching the server epoch is rejected as an epoch-mismatch conflict
+      - a base cursor not matching the stored cursor is rejected as a base-mismatch conflict
+      - both conflicts return the current cursor and epoch so the daemon can reconcile
+      - a concurrent writer that loses the race re-reads and surfaces the same conflict rather than double-writing
+    provenance: [SyncRepository.CommitMacHostCursor, ErrCursorEpochMismatch, ErrCursorBaseMismatch, MacHostHandler.CommitCursor]
+
+  - id: MAC-015
+    title: Reading a cursor returns committed state or an empty baseline
+    type: api
+    status: current
+    given: a daemon reading its cursor for a source
+    when: the read is handled
+    then:
+      - a committed cursor is returned along with the daemon-owned backfill-complete flag
+      - before any commit, an empty cursor and the host's current epoch are returned
+      - the backfill-complete flag is opaque to the backend and defaults to false when absent or malformed
+    provenance: [MacHostHandler.GetCursor, extractBackfillComplete, cursorResponse]
+
+  # --- Admin & revoke ---
+
+  - id: MAC-016
+    title: Revoking a host cascades its cursor rows atomically
+    type: data
+    status: current
+    given: a live host with push-strategy cursor rows
+    when: the host is revoked
+    then:
+      - the host row is marked revoked and its push cursor rows are hard-deleted in one transaction
+      - a missing or already-revoked host returns not-found
+    provenance: [MacHostService.RevokeHost, RevokeHostTx, DeleteMacHostSyncStatesTx]
+    notes: The cascade is explicit application logic — revoke does not fire an FK cascade — and is required so a stale cursor row cannot block a future re-pair.
+
+  - id: MAC-017
+    title: Revoked hosts are invisible to all authentication and ingest reads
+    type: invariant
+    status: current
+    statement: every authentication and ingest-liveness read filters out revoked hosts, so a revoked host cannot authenticate, heartbeat, rotate, commit a cursor, or ingest; only the admin detail view returns revoked host rows.
+    provenance: [GetActiveMacHostByID, GetActiveMacHostByIDForUpdate, RevokeMacHost/UpdateMacHostHeartbeat/RotateMacHostAPIKey WHERE clauses]
+
+  - id: MAC-018
+    title: Admin host surfaces list, inspect, count, mint, and revoke
+    type: api
+    status: current
+    given: admin requests (global api key) against the hosts collection
+    when: they are handled
+    then:
+      - the list returns the live hosts
+      - the detail view returns a single host including revoked ones, and not-found (404) for an unknown id
+      - per-source live counts distinguish a missing host (404) from a host with no rows (an empty count map)
+      - an admin can mint a fresh pairing token and revoke a host
+    provenance: [MacHostHandler.ListHosts/GetHostAdmin/GetSourceCounts/CreatePairingToken/DeleteHost, RegisterMacHostAdminRoutes]
+
+  # --- Daemon read endpoints ---
+
+  - id: MAC-019
+    title: Known-IDs drives daemon tombstone reconciliation
+    type: business-logic
+    status: current
+    given: a daemon requests its known ids for a source
+    when: the set is computed
+    then:
+      - the live source ids owned by the host (external-contact rows, or meeting-note session ids for the anarlog-sessions source) are returned, each with its last observed content hash
+      - the set is scoped to the calling host and source, excludes tombstoned rows, and is sorted deterministically by source id
+      - the response is always a possibly-empty array, never null
+    provenance: [MacHostService.KnownIDsForSource, ListKnownIDsByHostAndSource, ListKnownMeetingNoteSessionIDsByHost]
+    notes: The daemon set-diffs this against a fresh upstream scan to emit deletes; the last content hash supplies the prior-hash component of the delete source id. Matching and dedup of these external-contact rows is imports-matching scope (see IMP-006).
+
+  - id: MAC-020
+    title: Known-identifiers exposes the user's canonical contact identifiers
+    type: business-logic
+    status: current
+    given: a daemon polls for the user's known identifiers
+    when: the set is computed
+    then:
+      - the distinct canonical phone and email values across all live contacts are returned under separate keys
+      - both arrays are sorted and deduplicated, and are empty on a fresh CRM
+    provenance: [MacHostService.KnownIdentifiers, ListCanonicalIdentifiersByType]
+    notes: The daemon filters incoming message senders against this set. The canonical-identifier normalization itself is contacts scope (see CON-012).
+
+  # --- Daemon external-contact host ownership ---
+  # The generic ingest auth dispatch, in-transaction host-liveness recheck, event-kind/auth-path
+  # partition, and server-side payload re-verification (host-id binding, source allow-list, content-hash
+  # parity) are the ingest domain's (ING-001, ING-006, ING-007, ING-012, ING-036); mac-host keeps only
+  # the external-contact host-ownership facets below.
+
+  - id: MAC-025
+    title: External-contact host ownership is claimed once and preserved
+    type: data
+    status: current
+    given: a daemon upsert of an external contact
+    when: ownership is written
+    then:
+      - the host id is claimed on the first non-null emit and preserved thereafter, never re-owned by a later emit
+      - the last observed content hash is written on both insert and update
+    provenance: [external_contact.sql upsert COALESCE(host_id, EXCLUDED.host_id), repository/external_contact.go last_content_hash]
+    notes: Forward-only revive and soft-delete are separate defensive paths; the upsert's linkage-preservation facet (update refreshes content but never touches soft-delete, crm-contact link, or match status) and external-contact dedup/match lifecycle are imports-matching scope (see IMP-006, IMP-008).
+
+  - id: MAC-026
+    title: External-contact deletes validate the daemon content hash against stored state
+    type: invariant
+    status: current
+    statement: an external-contact delete carries a source-id hash suffix that the backend validates against the row's stored last content hash before tombstoning, rejecting a stale delete, with defined bypasses for the unknown-hash sentinel and already-tombstoned rows; the daemon and backend compute this hash identically (strip the top-level host id, canonicalize, then hash).
+    provenance: [service/ingest.go EXTERNAL_CONTACT_DELETE_HASH_MISMATCH, external_contact_hash.go, CRMMacCore/ContentHasher.swift]
+    notes: The upsert-side content-hash parity — rejecting an upsert whose source-id hash suffix disagrees with the server recompute — is the ingest server-side re-verification invariant ING-036; this row pins the delete-side validation, which ING-036 does not cover.
+
+  - id: MAC-027
+    title: External-contact deletes are host-scoped and idempotent
+    type: business-logic
+    status: current
+    given: a daemon delete for an external contact
+    when: the delete is processed
+    then:
+      - a live row owned by a different host is left untouched as a silent no-op rather than a rejection, so a delete stranded after a re-pair does not stall the cursor
+      - a delete of an unknown or already-tombstoned row is an idempotent no-op that preserves the audit event
+    provenance: [service/ingest.go external_contact.deleted host-scope guard, unknown/already-tombstoned no-op paths]
+
+  # --- Address-book reconcile ---
+  # The call pipeline — cross-field call verification, the call-outcome interaction decision, call
+  # peer resolution, direction-field normalization, and phone-call staging dedup — is the ingest
+  # domain's (ING-030, ING-031, ING-036, ING-037, ING-038). Calls originate solely from the daemon's
+  # anarlog call log, but the backend staging/decision logic lives in the ingest service.
+
+  - id: MAC-033
+    title: Address-book reconcile triggers method re-propagation for linked contacts
+    type: business-logic
+    status: current
+    given: an address-book external contact already linked to a CRM contact that later gains a method upstream
+    when: reconcile runs for that row
+    then:
+      - the row's linked contact is re-evaluated for methods gained upstream so a source that enriched only once (or never) no longer leaks
+    provenance: [AddressBookReconcileService.ReconcileLinkedExternalContactMethods]
+    notes: The propagate-for-auto-matched vs record-a-pending-suggestion-for-curated-import decision (and any other-status no-op) is the landed IMP-017 rule, applied here; the rematch fan-out is IMP-019. This row pins only the address-book reconcile trigger that invokes it.
+
+  - id: MAC-034
+    title: Reconcile skips dead targets and survives per-row failures
+    type: business-logic
+    status: current
+    given: an address-book row still pointing at a contact
+    when: reconcile evaluates the target
+    then:
+      - a soft-deleted contact (whose external pointer was not cleared) is skipped rather than erroring or recording suggestions against a dead contact
+      - the one-time catchup continues past a failing row and reports how many rows failed
+    provenance: [ReconcileLinkedExternalContactMethods liveness guard, ReconcileAllAddressBookMethods]
+
+  # --- Staleness watchdog ---
+
+  - id: MAC-035
+    title: A silent host raises a heartbeat-staleness breach
+    type: business-logic
+    status: current
+    given: an active host whose last heartbeat is older than the heartbeat threshold
+    when: the staleness watchdog runs
+    then:
+      - a heartbeat breach is opened for the host
+      - the staleness boundary is exclusive, so an age exactly equal to the threshold is not stale
+      - the host's creation time is the reference when no heartbeat has yet been recorded
+    provenance: [StalenessService.evaluateHeartbeatBreaches, isStale]
+
+  - id: MAC-036
+    title: A stale enabled source raises a push-staleness breach
+    type: business-logic
+    status: current
+    given: a host reporting per-source health with enabled sources
+    when: the watchdog evaluates push freshness
+    then:
+      - an enabled source whose last push is older than the push threshold opens a push breach for that source
+      - malformed source health is skipped with a warning, and heartbeat evaluation still covers the host's liveness
+      - a source with no recorded last-push timestamp is skipped
+    provenance: [StalenessService.evaluatePushBreaches, parseSourceHealth]
+
+  - id: MAC-037
+    title: Breaches are reconciled to the current candidate set
+    type: business-logic
+    status: current
+    given: the set of current breach candidates
+    when: the watchdog reconciles
+    then:
+      - each candidate breach is opened or refreshed idempotently, with at most one open breach per source, account, and breach type
+      - a breach whose condition has cleared (recovery, disable, revoke, or feature-flag-off) is resolved
+      - long-resolved breaches are pruned after a retention window
+    provenance: [StalenessService.RunChecks, idx_sync_staleness_breach_open]
+    notes: Sync-stale and sync-error breaches over non-push sources are ingest/sync-domain adjacency.
+
+  # --- Daemon-side (intent level) ---
+
+  - id: MAC-038
+    title: The daemon persists its api key device-locally and config-independently
+    type: invariant
+    status: current
+    statement: the daemon stores its api key on-device only and never iCloud-synced, keyed by a constant account name rather than the host id so the key survives a corrupted config, and the file-store fallback writes atomically with restrictive permissions.
+    provenance: [ProductionKeychainStore.swift, FileAPIKeyStore.swift]
+    notes: File-store fallback details are asserted from the surface inventory, not read line-by-line.
+
+  - id: MAC-039
+    title: Daemon exit codes surface operator-actionable states
+    type: business-logic
+    status: current
+    given: the launchd-managed daemon terminates
+    when: it exits
+    then:
+      - distinct exit codes distinguish a clean shutdown, an auth-revoked heartbeat, an upgrade-required heartbeat, a missing or corrupt config, a missing or access-denied key, a missing or corrupt state file, and an already-running instance
+    provenance: [DaemonCommand.swift exit-code map, DaemonStartupError]
+
+  - id: MAC-040
+    title: Source plugins run on independent schedules
+    type: business-logic
+    status: current
+    given: the running daemon
+    when: its source plugins are scheduled
+    then:
+      - message, call, contact, and anarlog sources each tick on their own interval, and a filesystem change under the sessions directory triggers a sessions tick promptly
+      - the orphan-notification reconcile runs once after the first successful heartbeat and then on a steady-state loop
+    provenance: [DaemonCommand.swift plugin wiring, NotificationReconcileLoopPlugin, FirstSuccessLatch.swift]
+
+  - id: MAC-041
+    title: Sessions needing attention raise self-healing macOS notifications
+    type: ux
+    status: current
+    given: the daemon learns a meeting session needs attention as an orphan or a conflict
+    when: it surfaces a notification
+    then:
+      - an orphan prompts the operator to tag the session's participants, and a conflict prompts resolving it in the imports UI
+      - tapping an orphan opens the note-taking app while tapping a conflict opens the imports page scoped to that session
+      - notifications for sessions that no longer need attention are removed on the next reconcile
+      - an unrecognized linkage state is dropped without crashing
+    provenance: [OrphanNotificationCenter.swift, clickTargetURL, LinkageStateMapping.swift]
+    notes: The needs-attention review queue and linkage-state semantics are imports-matching scope (see IMP-025); this pins the daemon notification surface.
+
+  - id: MAC-042
+    title: Notification delivery recovers from denial and collapses duplicates
+    type: business-logic
+    status: current
+    given: a notification whose delivery is denied or fails
+    when: the daemon next reconciles
+    then:
+      - a denied or failed entry is retried rather than permanently lost
+      - within one batch, duplicate notifications for the same session and reason collapse to one
+    provenance: [OrphanNotificationCenter.swift delivery de-dup + retry paths]
+
+  - id: MAC-043
+    title: Status and doctor are read-only operator diagnostics
+    type: ux
+    status: current
+    given: an operator runs the daemon's status or doctor command
+    when: it executes
+    then:
+      - status reports install, registration, and pairing state plus per-source watermarks without making any network call
+      - doctor runs health checks (key presence, agent registration, config and state integrity, Pi reachability, and permissions) and exits non-zero by the count of failing checks
+    provenance: [StatusCommand.swift, DoctorCommand.swift, Doctor.swift]
+    notes: CLI specifics asserted from the surface inventory, not read line-by-line.
+
+  - id: MAC-044
+    title: Operator ops commands refuse to run against a live daemon
+    type: ux
+    status: current
+    given: an operator runs an ops command such as configure, backfill, scan, or cursor-reset
+    when: the daemon is running
+    then:
+      - the command refuses and instructs the operator to stop the daemon first
+      - backfill and scan commit Pi-side through the same cursor compare-and-swap the daemon uses, and local state mirrors the result on the next tick
+    provenance: [ConfigureCommand.swift pidfile guard, MessagesCommand.swift, CallHistoryOps.swift]
+    notes: CLI specifics asserted from the surface inventory, not read line-by-line.
+
+  - id: MAC-045
+    title: Install pairs, registers, and provisions the daemon
+    type: ux
+    status: current
+    given: an operator installs the daemon with pairing
+    when: install runs
+    then:
+      - it pairs with the Pi, registers the launchd agent, and provisions the contacts permission and container allowlist
+      - a plaintext non-loopback Pi URL warns about bearer-key leakage but does not block
+      - re-pair rotates the key in place, and a failure to persist the rotated key prints the plaintext key so the operator can recover
+    provenance: [InstallCommand.swift]
+    notes: CLI specifics asserted from the surface inventory, not read line-by-line.

--- a/spec/notes-meetings.yaml
+++ b/spec/notes-meetings.yaml
@@ -1,0 +1,310 @@
+domain: notes-meetings
+prefix: NTS
+maturity: reviewed
+behaviors:
+  # --- Contact notepad note (per-contact freeform scratchpad) ---
+
+  - id: NTS-001
+    title: A contact has at most one notepad note
+    type: data
+    status: current
+    given: a contact
+    when: its notepad note is saved
+    then:
+      - at most one notepad note exists per contact, enforced by a partial unique index over notepad-category rows
+      - the notepad is the single note keyed by the reserved notepad category
+      - concurrent saves resolve to one row via an atomic upsert rather than creating duplicates
+    provenance: [idx_note_contact_notepad_unique, UpsertContactNoteByCategory, NoteRepository.UpsertNotepad, migration 024]
+    notes: The note table's category is otherwise free-form text, but notepad is the only category any live path writes.
+
+  - id: NTS-002
+    title: Saving the notepad is an upsert-or-delete keyed on emptiness
+    type: business-logic
+    status: current
+    given: a save of a contact's notepad body
+    when: the body is applied
+    then:
+      - the body is trimmed of surrounding whitespace before persistence
+      - a whitespace-only or empty body deletes the notepad, idempotently even when none exists
+      - a non-empty body creates or updates the single notepad note with the trimmed text
+    provenance: [NoteService.SaveContactNotepad]
+    notes: The same save endpoint is both save and delete; there is no separate delete route.
+
+  - id: NTS-003
+    title: Notepad notes are hard-deleted
+    type: invariant
+    status: current
+    statement: the note table has no soft-delete column, so deleting a notepad is a hard row delete — no liveness filter applies to notes and a deleted notepad leaves no recoverable row.
+    provenance: [note schema migration 001, DeleteContactNoteByCategory, NoteRepository.DeleteContactNotepad]
+    notes: Deliberately unlike contacts (soft-deleted) — the notepad is a single-user scratchpad with no audit requirement.
+
+  - id: NTS-004
+    title: Fetching a contact's notepad reports presence or absence
+    type: api
+    status: current
+    given: a GET for a contact's notepad
+    when: the request is handled
+    then:
+      - a live contact with a notepad returns it (200)
+      - a live contact without a notepad returns no content (204)
+      - a malformed contact id returns a validation error (400)
+      - an unknown or soft-deleted contact returns not-found (404)
+    provenance: [NoteHandler.GetContactNotepad, NoteResponse]
+
+  - id: NTS-005
+    title: Saving the notepad validates and returns the saved note or no content
+    type: api
+    status: current
+    given: a PUT of a contact's notepad body
+    when: the request is handled
+    then:
+      - a non-empty body returns the saved note (200)
+      - an empty or whitespace-only body deletes the note and returns no content (204)
+      - the body is limited to 50000 characters, else a validation error (400)
+      - a malformed contact id or unparseable body returns a validation error (400)
+      - an unknown or soft-deleted contact returns not-found (404)
+    provenance: [NoteHandler.SaveContactNotepad, SaveNoteRequest]
+    notes: The length cap is validated on the raw body before trimming, so an over-length whitespace-only body is rejected rather than treated as an empty delete.
+
+  - id: NTS-006
+    title: Notepad access is gated on a live contact
+    type: business-logic
+    status: current
+    given: a notepad read or save
+    when: the target contact is checked
+    then:
+      - the contact's existence is verified before the notepad is read or written
+      - a missing or soft-deleted contact yields not-found rather than a server error
+    provenance: [NoteService.GetContactNotepad, NoteService.SaveContactNotepad]
+    notes: After a contact soft-delete its retained notes become inaccessible through this liveness gate (cross-ref CON-010). Merge combining of notepad bodies is cross-ref CON-028.
+
+  - id: NTS-007
+    title: The notepad displays on the contact detail with overflow-aware truncation
+    type: ux
+    status: current
+    given: a contact detail page
+    when: the notepad renders
+    then:
+      - the notepad appears only when it has content; an empty or absent notepad shows nothing
+      - the body preserves the user's line breaks
+      - long content is clamped with an expand and collapse control that appears only when the content overflows
+    provenance: [contact detail notes block, contacts.spec.ts]
+
+  - id: NTS-008
+    title: The notepad is edited through the contact form and saved separately
+    type: ux
+    status: current
+    given: the contact edit or create form
+    when: the notepad field is edited and the form is submitted
+    then:
+      - the notepad is saved as its own operation alongside the contact update, both completing before edit mode closes
+      - clearing the notepad field removes the note
+      - the displayed notepad reflects the new content after a successful save
+    provenance: [contact-form.tsx notes field, contact detail submit, new contact page]
+
+  # --- Meeting-note linkage states and user-driven resolution ---
+
+  - id: NTS-009
+    title: Meeting-note linkage states are a closed set with two resolvable states
+    type: data
+    status: current
+    given: a meeting_note row
+    when: its linkage_state is written
+    then:
+      - linkage_state is one of linked, linked_impromptu, orphan_title_augmented, orphan_needs_review, or conflict_pending, enforced by a database CHECK
+      - only conflict_pending and orphan_needs_review are user-resolvable; the other three are terminal
+      - every writer supplies the state explicitly, as the column has no database default
+    provenance: [meeting_note_linkage_state_check migration 053, repository LinkageState constants]
+    notes: How ingest first assigns these states (the decideLinkage detection algorithm) is ingest-domain (ING); the review-queue surfacing of the two attention states is cross-ref IMP-025.
+
+  - id: NTS-010
+    title: Resolving a conflict by linking a candidate transitions to linked
+    type: business-logic
+    status: current
+    given: a meeting_note in conflict_pending
+    when: the user links one of its recorded candidates
+    then:
+      - the chosen kind-and-id must be present in the persisted candidate snapshot
+      - the target row's existence is re-checked inside the resolve transaction
+      - on success the row transitions to linked with the chosen kind and id and its snapshot cleared
+      - walk-in interactions are written for tagged participants outside the linked candidate's attendee set
+    provenance: [MeetingNoteService.resolveToLinked, ResolveMeetingNoteToLinkedTx]
+
+  - id: NTS-011
+    title: Resolving a conflict with none-of-these recomputes the zero-candidate outcome
+    type: business-logic
+    status: current
+    given: a meeting_note in conflict_pending
+    when: the user chooses none-of-these
+    then:
+      - linkage is recomputed as if there were no time-overlap candidates
+      - the row lands in linked_impromptu, orphan_title_augmented, or orphan_needs_review according to its tagged and title-matched participants
+      - the candidate snapshot is cleared and the desired interactions are written with no linked meeting
+    provenance: [MeetingNoteService.resolveNoneOfThese, ClearMeetingNoteConflictTx]
+
+  - id: NTS-012
+    title: Resolving an orphan forces an impromptu log
+    type: business-logic
+    status: current
+    given: a meeting_note in orphan_needs_review
+    when: the user logs it as impromptu (none-of-these)
+    then:
+      - the row is forced to linked_impromptu regardless of whether any interactions result
+      - only tagged-participant interactions are created, never title-derived ones
+      - a genuine orphan with no resolvable participants still lands linked_impromptu, with zero interactions
+    provenance: [MeetingNoteService.resolveOrphanToImpromptu]
+    notes: Forcing the state prevents the recompute-to-orphan loop that would otherwise keep the row in the queue forever; the decision's persistence across re-sync is NTS-020.
+
+  - id: NTS-013
+    title: Orphans cannot be resolved by linking a candidate
+    type: business-logic
+    status: current
+    given: a meeting_note in orphan_needs_review
+    when: a link action is submitted
+    then:
+      - the request is rejected because an orphan carries no candidate snapshot to validate against
+    provenance: [MeetingNoteService.ResolveLink orphan branch]
+
+  - id: NTS-014
+    title: Only attention-state rows are resolvable, and resolves are serialized
+    type: business-logic
+    status: current
+    given: a resolve-link request against a meeting_note
+    when: the row's state is checked under a row lock
+    then:
+      - a terminal, soft-deleted, or missing row is rejected rather than mutated
+      - the row is read for update so concurrent resolves are serialized and a lost race is rejected rather than double-applied
+    provenance: [MeetingNoteService.ResolveLink switch, GetMeetingNoteByIDForUpdateTx, state-guarded resolve writes]
+
+  - id: NTS-015
+    title: The conflict snapshot exists exactly while the row is in conflict
+    type: invariant
+    status: current
+    statement: a meeting_note's conflict_candidates snapshot is non-null exactly when linkage_state is conflict_pending — every transition out of conflict_pending clears it and no non-conflict outcome ever persists a snapshot; the rule is enforced in application code, not by a database constraint.
+    provenance: [migration 056, ResolveMeetingNoteToLinkedTx, ClearMeetingNoteConflictTx, decideLinkage snapshot handling]
+
+  - id: NTS-016
+    title: The candidate snapshot is the authorization list for linking
+    type: business-logic
+    status: current
+    given: a link resolution of a conflict_pending meeting_note
+    when: the chosen candidate is validated
+    then:
+      - a chosen kind-and-id absent from the persisted snapshot is rejected as a non-candidate
+      - a conflict_pending row whose snapshot is missing is rejected defensively rather than linked
+      - a snapshot-referenced target that no longer exists is reported as a missing target
+    provenance: [MeetingNoteService.resolveToLinked, snapshotContains, fetchCandidateAsLinkageTx]
+
+  - id: NTS-017
+    title: Polymorphic linkage pointer is paired but has no foreign key
+    type: data
+    status: current
+    given: a meeting_note linked to an interaction-bearing target
+    when: its link columns are written
+    then:
+      - linked_kind is event or phone_call, or both link columns are null together (both-or-neither)
+      - the pointer carries no foreign key, so referential integrity is not enforced by the database
+    provenance: [meeting_note_linked_kind_check, meeting_note_linked_pair_check migration 053]
+    notes: The calendar-event and phone-call target rows are owned by CAL; cross-ref CAL.
+
+  - id: NTS-018
+    title: Resolve-link exposes a validated action contract
+    type: api
+    status: current
+    given: a POST to resolve-link for a meeting_note
+    when: the request is handled
+    then:
+      - action is required and must be link or none_of_these
+      - action=link requires kind in event or phone_call and an id parseable as a UUID, else a validation error (400)
+      - a successful resolve returns the updated meeting note and the interactions created (200)
+      - a missing row, or a snapshot target that no longer exists, returns not-found (404)
+      - a row not in an attention state returns conflict (409)
+      - a chosen id absent from the snapshot returns a validation error (400)
+      - a conflict_pending row missing its snapshot returns unprocessable content (422)
+    provenance: [MeetingNoteHandler.ResolveLink, mapResolveError]
+
+  - id: NTS-019
+    title: Resolution writes session interactions through the shared cadence path
+    type: business-logic
+    status: current
+    given: a resolve-link that produces interactions
+    when: the interactions are written
+    then:
+      - each interaction is attributed to the anarlog-session source with a per-session-per-contact source ref
+      - interactions are written through the same recorder that updates cadence and follow-up state, inside the resolve transaction
+      - the session venue is resolved once, and only when at least one interaction will carry it
+    provenance: [MeetingNoteService.writeDesiredInteractions, ContactInteractionRecorder.RecordInteractionTx, resolveAnarlogSessionVenue]
+    notes: Cadence and follow-up recompute is cadence-domain (CAD); the daemon re-sync interaction reconciliation and the interaction cascade on meeting-note delete are ingest-domain (ING). Downstream surface refresh on resolve is cross-ref IMP-031.
+
+  - id: NTS-020
+    title: A user's linkage decision survives daemon re-sync
+    type: business-logic
+    status: current
+    given: a resolved meeting_note
+    when: its resolved_set_hash is written
+    then:
+      - the hash is computed over the union of tag-resolved and title-matched contacts, matching the daemon's recipe byte-for-byte
+      - an identical re-sync recognizes the decision and carries the resolved state forward rather than recomputing a divergent one
+    provenance: [computeResolvedSetHash, resolveOrphanToImpromptu, resolveNoneOfThese]
+    notes: The daemon-side re-sync and carry-forward mechanics are ingest-domain (ING); this pins only the resolve-side contract that makes carry-forward possible.
+
+  - id: NTS-021
+    title: Resolve is transactional with best-effort follow-ups
+    type: business-logic
+    status: current
+    given: a resolve-link in progress
+    when: the transaction commits
+    then:
+      - the interaction writes and the state transition commit atomically or roll back together
+      - cadence and task follow-ups run after commit, best-effort, and a follow-up failure or panic never fails the response
+    provenance: [MeetingNoteService.ResolveLink tx, runFollowUpBestEffort]
+
+  - id: NTS-022
+    title: Deleting a meeting note tombstones it, preserving content for revive
+    type: data
+    status: current
+    given: a live meeting_note for an anarlog session
+    when: the session's meeting note is soft-deleted
+    then:
+      - the row is soft-deleted while its content and hashes are preserved for a later revive
+      - session-id uniqueness is enforced only over live rows, so the tombstone and a fresh live row for the same session can coexist
+    provenance: [SoftDeleteMeetingNoteBySessionID, idx_meeting_note_session_id]
+    notes: The ingest re-sync flow that drives the delete, and the explicit interaction cascade on delete, are ingest-domain (ING); this pins the entity's soft-delete persistence contract. The revive half of the lifecycle is NTS-024.
+
+  - id: NTS-023
+    title: Stale linkage pointers are reconciled to null
+    type: data
+    status: proposed
+    given: a meeting_note whose linked target row has been deleted
+    when: the stale pointer is reconciled
+    then:
+      - the linked_kind and linked_id pair is nullified so the row no longer points at a missing target
+    provenance: [migration 053 cleanup-job comment]
+    notes: 'Proposed: the periodic cleanup job the schema promises does not exist. Today a deleted target is only detected lazily at read time (surfaced as target-missing in the review queue) and the stale pointer is never cleared. Reviewer should probe whether lazy read-time detection is acceptable and this ought retired instead.'
+
+  - id: NTS-024
+    title: A reappearing session revives its tombstoned meeting note
+    type: data
+    status: current
+    given: a tombstoned meeting_note for an anarlog session
+    when: the same session reappears in a re-sync
+    then:
+      - the tombstoned row is revived in place with the new content and hashes rather than orphaned or duplicated
+      - revive is idempotent under concurrent races, guarded to act only on a still-tombstoned row
+    provenance: [ReviveMeetingNote, GetTombstonedMeetingNoteBySessionID, idx_meeting_note_session_id]
+    notes: The ingest re-sync flow that detects reappearance and drives the revive is ingest-domain (ING); this pins the entity's revive persistence contract. The soft-delete half of the lifecycle is NTS-022.
+
+  - id: NTS-025
+    title: The needs-attention list exposes a projected review-queue contract
+    type: api
+    status: current
+    given: a GET to needs-attention for meeting notes
+    when: the request is handled
+    then:
+      - a malformed host_id query parameter returns a validation error (400)
+      - the response returns every live meeting note in an attention state, newest first, optionally scoped to a host_id (200)
+      - each conflict_pending row carries a candidates array projecting each snapshot candidate with a per-kind preview; an orphan_needs_review row carries no candidates
+      - a snapshot candidate whose target row has been deleted is marked target-missing with a null preview rather than dropped from the response
+      - each candidate's overlap count is carried independently of the per-attendee matched flags, which drive only visual emphasis
+    provenance: [MeetingNoteHandler.ListNeedsAttention, MeetingNoteService.ListNeedsAttention, projectCandidates, candidatePreview, ListMeetingNotesNeedingAttention]
+    notes: The business-logic of what makes a session a conflict versus an orphan is cross-ref IMP-025; this pins the read endpoint's API and projection contract, mirroring NTS-018 for the resolve-link write endpoint.

--- a/spec/settings.yaml
+++ b/spec/settings.yaml
@@ -1,0 +1,406 @@
+domain: settings
+prefix: SET
+maturity: reviewed
+behaviors:
+  # --- OAuth flow & auth boundary ---
+
+  - id: SET-001
+    title: Provider redirect callbacks are the only OAuth routes reachable without the API key
+    type: invariant
+    status: current
+    statement: the provider redirect callback routes are registered outside the global-API-key middleware (external providers cannot carry the key), while every OAuth auth-URL and account-management route is registered inside the API-key-protected group and requires the key.
+    provenance: [RegisterOAuthCallbackRoutes, RegisterOAuthRoutes, cmd/crm-api/main.go v1.Use APIKeyMiddleware]
+    notes: The callback routes only redirect to the settings surface with an outcome (SET-004); they never expose account data, so no-auth exposure is bounded to the CSRF-gated exchange.
+
+  - id: SET-002
+    title: Requesting a provider auth URL mints a single-use CSRF state
+    type: business-logic
+    status: current
+    given: a configured OAuth provider
+    when: the frontend requests that provider's authorization URL
+    then:
+      - a random CSRF state is generated and stored server-side
+      - the stored state expires after ten minutes
+      - the response returns the provider authorization URL and the state
+    provenance: [OAuthHandler.GetGoogleAuthURL, OAuthHandler.GetTodoistAuthURL, storeState, google.GenerateState]
+    notes: The state store is in-process and not persisted, so a backend restart between issuance and callback invalidates outstanding states (they then fail as invalid_state). Google and Todoist share one state namespace with no provider tag; states are 32 random bytes so cross-provider collision is not a practical concern.
+
+  - id: SET-003
+    title: The OAuth callback validates CSRF state before exchanging the code
+    type: business-logic
+    status: current
+    given: a provider redirect back to the callback route
+    when: the callback is processed
+    then:
+      - a provider-supplied error parameter short-circuits before any state check or code exchange
+      - the CSRF state is validated and consumed before the authorization code is exchanged
+      - a state is accepted at most once, so replaying the same state fails validation
+      - an expired, unknown, or already-used state aborts the flow without exchanging the code
+    provenance: [OAuthHandler.GoogleCallback, OAuthHandler.TodoistCallback, validateState]
+
+  - id: SET-004
+    title: OAuth callbacks always redirect to the settings surface with an injection-safe outcome
+    type: api
+    status: current
+    given: a completed or failed OAuth callback
+    when: the callback responds
+    then:
+      - the response is a redirect back to the settings surface, never a rendered page or JSON body
+      - a success carries an outcome of success plus the provider name
+      - a failure carries an outcome of error plus the provider name and a typed reason (the provider error, invalid_state, or exchange_failed)
+      - all redirect query parameters are URL-encoded rather than string-concatenated
+    provenance: [OAuthHandler.GoogleCallback, OAuthHandler.TodoistCallback, url.Values.Encode]
+    notes: Google's callback additionally runs email/gchat sync reconciliation post-exchange (SET-013); those steps are non-fatal and do not change the redirect outcome.
+
+  - id: SET-005
+    title: A provider's OAuth routes exist only when that provider is configured
+    type: invariant
+    status: current
+    statement: a provider's callback, auth-URL, and account-management routes are registered only when external sync is enabled and that provider's client credentials are configured; a provider that is disabled or unconfigured exposes none of its routes and its callback URL returns not-found (404).
+    provenance: [RegisterOAuthCallbackRoutes GoogleEnabled/HasTodoistOAuth gates, cmd/crm-api/main.go oauthHandler construction]
+    notes: Google and Todoist gate independently, so a Todoist-only deployment serves Todoist OAuth routes while Google's 404.
+
+  # --- API key handling ---
+
+  - id: SET-006
+    title: The global API key is accepted from either header form and rejected with a typed 401
+    type: api
+    status: current
+    given: a request to an API-key-protected route
+    when: the API key is checked
+    then:
+      - the key is read from an X-API-Key header, falling back to an Authorization header of the form ApiKey <key>
+      - a missing key is rejected with 401 and a missing-key error code
+      - a key that does not match the configured key is rejected with 401 and an invalid-key error code
+      - a matching key allows the request to proceed
+    provenance: [auth.APIKeyMiddleware]
+
+  - id: SET-007
+    title: API key comparison is constant-time
+    type: invariant
+    status: proposed
+    statement: the submitted API key is compared against the configured key in constant time, so comparison latency does not leak how many leading bytes matched.
+    provenance: [auth.APIKeyMiddleware]
+    notes: 'Proposed: today the comparison is a plain inequality, which is not timing-safe. Low priority under the single-user, local-first, Tailscale-only threat model; recorded as defence-in-depth intent for the reviewer to weigh.'
+
+  # --- Connected-account management ---
+
+  - id: SET-008
+    title: Account listing, status, and revoke share a validation-and-not-found contract
+    type: api
+    status: current
+    given: a request to one of a provider's connected-account management routes (list, status read, or revoke)
+    when: the request is handled
+    then:
+      - listing returns an array of connected accounts (200)
+      - a malformed account id returns a validation error (400)
+      - an unknown account id returns not-found (404)
+      - a successful status read returns the account (200) and a successful revoke returns a confirmation (200)
+    provenance: [OAuthHandler.ListGoogleAccounts, OAuthHandler.GetGoogleAccountStatus, OAuthHandler.RevokeGoogleAccount, OAuthHandler Todoist counterparts]
+
+  - id: SET-009
+    title: OAuth tokens are encrypted at rest and never leave the backend
+    type: invariant
+    status: current
+    statement: OAuth access and refresh tokens are stored encrypted (each token under its own nonce) and the encrypted token bytes and nonces are never serialized into any API response — account listing and status responses expose only non-sensitive account metadata.
+    provenance: [google/oauth.go storeToken AES-256-GCM, repository/oauth.go json:"-" token fields, GoogleAccountResponse/TodoistAccountResponse]
+
+  - id: SET-010
+    title: Revoking an account removes it locally even when remote revocation fails
+    type: business-logic
+    status: current
+    given: a connected provider account
+    when: the account is revoked
+    then:
+      - the account's sync states are deleted first, best-effort
+      - the provider is asked to revoke the token remotely, best-effort
+      - the local credential is deleted, and this is the only step that can fail the revoke
+      - a failure to decrypt the token or reach the provider is logged and does not block local deletion
+    provenance: [google/oauth.go RevokeAccount, todoist/oauth.go RevokeAccount]
+
+  - id: SET-011
+    title: One credential per provider account, preserving a refresh token across re-exchange
+    type: data
+    status: current
+    given: an existing stored credential for a provider account
+    when: the same provider account completes OAuth again
+    then:
+      - the credential is upserted on the unique provider-and-account key rather than duplicated
+      - a re-exchange that returns no refresh token preserves the previously stored refresh token
+    provenance: [oauth.sql UpsertOAuthCredential ON CONFLICT + COALESCE, idx_oauth_credential_provider_account, migrations 013/062]
+
+  - id: SET-012
+    title: Revoke cleanup deletes only the account's own sync states
+    type: data
+    status: current
+    given: a revoke that cascades into sync-state cleanup
+    when: sync states are deleted for the account
+    then:
+      - only sync states whose account id matches the revoked account are deleted
+      - sync states with no account id (local sources) are never touched
+    provenance: [external_sync.sql DeleteSyncStatesByAccountID]
+
+  # --- Enablement / reconciliation ---
+
+  - id: SET-013
+    title: A successful Google connect enables the account's downstream sync without a reboot
+    type: business-logic
+    status: current
+    given: a Google account completing OAuth
+    when: the callback finishes exchanging the code
+    then:
+      - the account's email and Google Chat sync states are reconciled immediately rather than waiting for a restart
+      - reconciliation is idempotent, so reconnecting an already-reconciled account changes nothing
+      - a reconciliation failure is non-fatal and leaves the account connected
+    provenance: [OAuthHandler.GoogleCallback emailStateReconciler/gchatStateReconciler]
+    notes: What each reconciled sync state then sweeps, the scope-gating that decides whether a state is created, and the guarantee that a user-disabled state is never re-enabled are calendar/telegram/todoist-domain scope; settings owns only that the connect act triggers reconciliation.
+
+  - id: SET-014
+    title: Toggling a sync state's enablement requires an explicit flag and sets a matching status
+    type: api
+    status: current
+    given: an existing sync state
+    when: its enablement is toggled
+    then:
+      - the enabled value is required and must parse as a boolean, otherwise a validation error (400) is returned
+      - a malformed sync-state id returns a validation error (400) and an unknown one returns not-found (404)
+      - disabling sets the state's status to disabled and enabling sets it to idle
+    provenance: [SyncHandler.EnableSync, external_sync.sql UpdateSyncStateEnabled]
+
+  # --- Todoist settings surface ---
+
+  - id: SET-015
+    title: Reading Todoist settings requires a connected account
+    type: api
+    status: current
+    given: a request for the current Todoist integration settings
+    when: the settings are read
+    then:
+      - with no Todoist account connected, the request returns not-found (404)
+      - with an account connected but no sync state yet, empty settings are returned (200)
+      - with a sync state present, the stored project, label, and related settings are returned (200)
+    provenance: [TodoistHandler.GetSettings]
+
+  - id: SET-016
+    title: Updating Todoist settings merges metadata and lazily provisions the sync state
+    type: api
+    status: current
+    given: a Todoist settings update for the connected account
+    when: the update is applied
+    then:
+      - a malformed body returns a validation error (400) and no connected account returns not-found (404)
+      - the sync state is created if absent (enabled, fetch-all) before the update is written
+      - the update merges into the existing settings metadata rather than replacing it wholesale
+      - an integration instance id is generated once if absent and then left stable
+    provenance: [TodoistHandler.UpdateSettings, UpdateSyncStateMetadata]
+
+  - id: SET-017
+    title: Changing the Todoist label invalidates the cached label name
+    type: business-logic
+    status: current
+    given: stored Todoist settings carrying a cached label name
+    when: the label id is changed
+    then:
+      - the cached label name is cleared so it is refreshed on the next sync
+    provenance: [TodoistHandler.UpdateSettings label_id path]
+
+  - id: SET-018
+    title: Todoist project and label pickers list live provider entries excluding deleted ones
+    type: api
+    status: current
+    given: a connected Todoist account
+    when: the available projects or labels are requested
+    then:
+      - with no account connected the request returns not-found (404)
+      - the live provider is queried and deleted entries are filtered out of the result
+      - a token or provider-API failure surfaces as a server error (500)
+    provenance: [TodoistHandler.ListProjects, TodoistHandler.ListLabels]
+
+  # --- Settings surfaces (Track B) ---
+
+  - id: SET-019
+    title: The settings page presents provider connection sections
+    type: ux
+    status: current
+    given: the settings page
+    when: it renders
+    then:
+      - each supported provider has its own section showing whether an account is connected
+      - a connected account shows its identity and when it was connected
+      - each section offers a way to connect an account and to disconnect a connected one
+    provenance: [settings/page.tsx, google-accounts-section.tsx, todoist-accounts-section.tsx]
+
+  - id: SET-020
+    title: Connecting a provider hands off to the provider's consent screen
+    type: ux
+    status: current
+    given: a provider section with a connect affordance
+    when: the user starts connecting
+    then:
+      - the app fetches the provider authorization URL and navigates the whole page to the provider's consent screen
+    provenance: [startGoogleOAuthFlow, startTodoistOAuthFlow, oauth-api.ts]
+
+  - id: SET-021
+    title: Returning from a connect shows the outcome and clears the one-time parameters
+    type: ux
+    status: current
+    given: a redirect back to the settings surface carrying a connect outcome
+    when: the settings page mounts
+    then:
+      - a success outcome shows a success indication and refreshes the account list
+      - an error outcome shows the failure reason to the user
+      - the one-time outcome parameters are stripped from the URL so a refresh does not re-trigger the notification
+    provenance: [google-accounts-section.tsx auth-param effect, todoist-accounts-section.tsx, .ai/rules/core.md one-time action gotcha]
+
+  - id: SET-022
+    title: Disconnecting an account requires explicit confirmation
+    type: ux
+    status: current
+    given: a connected provider account
+    when: the user asks to disconnect it
+    then:
+      - a confirmation prompt identifies the account and warns what access is revoked
+      - only on confirmation is the account revoked
+      - the outcome is reported and the account list reflects the removal
+    provenance: [google-accounts-section.tsx handleDisconnect, todoist-accounts-section.tsx handleDisconnect]
+
+  - id: SET-023
+    title: An unconfigured or errored provider section collapses to a not-connected state with setup guidance
+    type: ux
+    status: current
+    given: a provider whose credentials are not configured or whose account list failed to load
+    when: its section renders
+    then:
+      - the section shows a not-connected empty state rather than an error stack
+      - the section lists the configuration the deployment must supply to enable the provider
+    provenance: [google-accounts-section.tsx showEmptyState, todoist-accounts-section.tsx, Configuration Required panels]
+    notes: Treating a not-configured provider (a 4xx from its routes per SET-005) as an empty state is deliberate — the surface degrades gracefully on a deployment that never set the provider up.
+
+  - id: SET-024
+    title: Per-scope sync affordances follow the account's granted scopes
+    type: ux
+    status: current
+    given: a connected Google account with a stored scope set
+    when: its section renders
+    then:
+      - a per-source sync affordance appears only when the account holds the scope that source requires
+      - the Google Chat affordance appears only when all of the chat scopes are held; a partial grant shows a reconnect prompt instead
+    provenance: [google-accounts-section.tsx accountHasChatScopes/GCHAT_REQUIRED_SCOPES, SyncBadge]
+    notes: The badges key off the stored requested-scope list as a proxy, not a live grant check. What each triggered sync source does once run is calendar/contacts/gmail/gchat-domain scope.
+
+  - id: SET-025
+    title: An account whose sync failed on authentication surfaces a reconnect prompt
+    type: ux
+    status: current
+    given: a connected account whose sync state is in an auth-related error
+    when: its section renders
+    then:
+      - a reconnect affordance appears for that account
+      - the prompt is suppressed once the account credential is newer than the failing sync state
+    provenance: [use-sync-states.ts accountNeedsReconnection, google-accounts-section.tsx, todoist-accounts-section.tsx]
+    notes: The error strings this keys on are produced by the sync providers (calendar/gmail/gchat/todoist domains); settings owns only the reconnect affordance the errored state drives.
+
+  - id: SET-026
+    title: The Todoist configuration surface guides selecting a project and label
+    type: ux
+    status: current
+    given: a connected Todoist account
+    when: the Todoist configuration is shown
+    then:
+      - project and label pickers are offered, each populated from the live provider lists
+      - selecting a project or label persists that choice and reports the outcome
+      - the surface indicates that both a project and a label must be chosen before cadence sync is active
+    provenance: [todoist-accounts-section.tsx Sync Configuration, use-todoist-settings.ts]
+
+  - id: SET-027
+    title: The Telegram section renders on settings with a not-configured state when the feature is off
+    type: ux
+    status: current
+    given: the settings page
+    when: the Telegram section renders
+    then:
+      - the section is present on the settings surface
+      - when the Telegram feature is not enabled on the backend, the section shows a not-configured state naming the configuration required to enable it
+    provenance: [telegram-section.tsx not_configured state, use-telegram.ts status 404 handling]
+    notes: The connect / code-verification / two-factor / disconnect flow and group-chat tracking live under this section but are telegram-domain scope; settings owns only that the section renders and its not-configured empty state.
+
+  # --- Data backup & restore ---
+
+  - id: SET-028
+    title: The settings page presents a data backup and restore surface
+    type: ux
+    status: current
+    given: the settings page
+    when: the data backup and restore section renders
+    then:
+      - an export affordance downloads the user's data as a JSON backup file
+      - an import affordance accepts a backup file to restore from
+      - the surface communicates that import does not yet modify stored data
+    provenance: [settings/page.tsx Data Backup & Restore section, handleExportData, handleImportData]
+    notes: Export is live and its HTTP contract is SET-030; it streams the current dataset — contacts only today — as a JSON download, even though the surface copy frames it as a complete backup. The restore path itself is not yet implemented and is recorded as proposed (SET-029).
+
+  - id: SET-029
+    title: Importing a backup restores its records
+    type: api
+    status: proposed
+    given: a previously exported backup file
+    when: the backup is submitted to the import endpoint
+    then:
+      - the backup file is parsed and its format validated, with a malformed backup returning a validation error (400)
+      - the records the backup contains are restored into the database
+      - a summary of the restored data is returned (200)
+    provenance: [SystemHandler.ImportData, settings/page.tsx handleImportData]
+    notes: 'Proposed: today the import endpoint is a placeholder that ignores the uploaded file and returns a not-implemented message (no parse, no validation, no write), while the settings surface labels import as validation-only. Restore is unimplemented, so the intended behavior is recorded as proposed rather than current.'
+
+  - id: SET-030
+    title: Exporting data returns a contacts-only JSON backup attachment
+    type: api
+    status: current
+    given: a request to the data export endpoint
+    when: the export is requested
+    then:
+      - the response is a JSON attachment (a Content-Disposition download) wrapping an export envelope
+      - the envelope carries a version tag and an export timestamp
+      - the exported dataset contains the contact records only — interactions and notes are not included
+      - a failure to read the contacts returns a server error (500)
+    provenance: [SystemHandler.ExportData, system_routes.go RegisterDataExchangeRoutes]
+    notes: The settings surface (SET-028) frames export as a complete backup, but today the endpoint serializes contacts only; widening the payload to interactions and notes is unbuilt and recorded as proposed (SET-033). The contacts read is bounded by a large fixed limit rather than true pagination.
+
+  # --- Google token lifecycle ---
+
+  - id: SET-031
+    title: Google authorization requests offline access and forces re-consent
+    type: business-logic
+    status: current
+    given: a Google authorization URL being built
+    when: the consent URL is constructed
+    then:
+      - offline access is requested so the provider returns a refresh token
+      - consent is forced so an already-connected account re-consents when its scope set changes
+    provenance: [google.OAuthService.GetAuthURL]
+    notes: Re-consent is what lets a scope addition (e.g. chat scopes) reach an existing account; the refresh token it yields backs the lazy refresh in SET-032 and the preservation rule in SET-011. Todoist issues no refresh token.
+
+  - id: SET-032
+    title: Google access tokens refresh on demand and persist exactly once
+    type: business-logic
+    status: current
+    given: a connected Google account whose access token is expired or near expiry
+    when: a client for that account is requested
+    then:
+      - the access token is refreshed using the stored refresh token
+      - a changed token is persisted back to the credential store exactly once
+      - a persistence failure is non-fatal and still yields a usable token
+      - there is no proactive scheduled refresh; refresh happens only on demand
+    provenance: [google.OAuthService.GetClientForAccount, persistOnRefreshSource, UpdateOAuthCredentialTokens]
+
+  - id: SET-033
+    title: A data export contains the full backup the surface promises
+    type: api
+    status: proposed
+    given: a request to the data export endpoint
+    when: the export is requested
+    then:
+      - the exported envelope contains contacts together with their interactions and notes
+      - the payload matches the complete-backup scope the settings surface advertises
+    provenance: [SystemHandler.ExportData, settings/page.tsx Export Data copy]
+    notes: 'Proposed: today the endpoint serializes contacts only (SET-030), while the settings surface frames export as a complete backup including interactions and notes. The widened scope is unbuilt, so the intended behavior is recorded as proposed rather than current.'

--- a/spec/telegram.yaml
+++ b/spec/telegram.yaml
@@ -1,0 +1,443 @@
+domain: telegram
+prefix: TGM
+maturity: reviewed
+behaviors:
+  # --- Enablement & config gating ---
+
+  - id: TGM-001
+    title: Telegram integration is gated on the feature flag and credentials
+    type: invariant
+    status: current
+    statement: Telegram runs only when the sync feature flag is enabled and non-zero MTProto API credentials are configured; when disabled, no Telegram HTTP routes are registered, no MTProto connection is attempted, the post-import hook is not wired, and the Telegram aggregation reenqueuer is a no-op.
+    provenance: [config.Features.EnableTelegramSync, cmd/crm-api/main.go gate, RegisterTelegramRoutes, NoopAggregatorReenqueuer]
+    notes: The settings surface that exposes enablement/connection to the user is settings-domain scope; this pins only the backend gating.
+
+  - id: TGM-002
+    title: Enabling Telegram sync requires credentials at startup
+    type: business-logic
+    status: current
+    given: the Telegram sync feature flag is enabled
+    when: configuration is validated at startup
+    then:
+      - a non-zero API id and a non-empty API hash are required, and missing either fails startup with a configuration error
+      - a token-encryption key is required to construct the session encryptor
+    provenance: [config.Validate, crypto.NewTokenEncryptor]
+
+  - id: TGM-034
+    title: MTProto session data is encrypted at rest
+    type: data
+    status: current
+    given: a Telegram MTProto session persisted during or after key exchange
+    when: the session bytes are stored and later loaded
+    then:
+      - session bytes are encrypted through the token encryptor before being written to the session row
+      - loading the session decrypts the stored ciphertext with its nonce before returning it to the client
+    provenance: [DatabaseSessionStorage.StoreSession, DatabaseSessionStorage.LoadSession, telegram_session.session_data_encrypted]
+
+  - id: TGM-037
+    title: MTProto update state is persisted so reconnects resume without gaps
+    type: data
+    status: current
+    given: an active MTProto connection whose update manager tracks gap-recovery state
+    when: the update manager persists and reloads MTProto state
+    then:
+      - global pts/qts/seq/date are persisted per user and reloaded on reconnect so recovery resumes from the last acknowledged point
+      - per-channel pts and access hash are persisted per channel, and an access-hash write preserves the existing pts
+      - a missing state row is reported as absent (fresh start), not an error
+    provenance: [PostgresStateStorage, PostgresChannelHasher, telegram_update_state, telegram_channel_state, manager.go updates.Config]
+
+  # --- Auth flow ---
+
+  - id: TGM-003
+    title: An in-flight Telegram auth flow expires after a fixed TTL and tears down
+    type: business-logic
+    status: current
+    given: an in-flight auth session (at most one exists at a time)
+    when: its fixed 5-minute TTL expires
+    then:
+      - the flow is torn down — its client context is cancelled and any partial session row written during key exchange is deleted
+      - the in-memory session is cleared, so a later verification against the expired token is rejected as an invalid token
+      - only a verification already in flight when the timer fires observes the token as expired
+    provenance: [AuthSessionManager, authTTL, cleanup, ErrAuthTokenExpired]
+
+  - id: TGM-004
+    title: Starting auth sends a login code
+    type: business-logic
+    status: current
+    given: no connected session and no auth flow in progress
+    when: auth is started for a phone number
+    then:
+      - an already-connected account is rejected, and a second concurrent start is rejected
+      - a login code is requested and the flow advances to awaiting-code
+      - the delivery channel (app, sms, or call; any other sent-code type maps to unknown) and a token with a 5-minute expiry are returned
+    provenance: [AuthSessionManager.StartAuth, mapSentCodeType, ErrAlreadyConnected, ErrAuthInProgress]
+
+  - id: TGM-005
+    title: Verification progresses code then optional password to connected
+    type: business-logic
+    status: current
+    given: an auth flow awaiting a verification step
+    when: a verification value is submitted
+    then:
+      - the submission must carry the flow's token and match the currently-expected step, else it is rejected
+      - a valid code either connects the account or, for a two-factor account, advances to a password step
+      - a valid password connects the account
+      - on connect the session is persisted with the resolved user id and username and marked connected
+    provenance: [AuthSessionManager.VerifyCode, AuthSessionManager.VerifyPassword, UpdateUserInfo, UpdateAuthState]
+
+  - id: TGM-006
+    title: Auth rejections are retryable while infrastructure errors abort
+    type: business-logic
+    status: current
+    given: a verification submission that Telegram rejects
+    when: the error is classified
+    then:
+      - known user rejections (invalid or expired code, invalid password) are retryable within the TTL without ending the flow
+      - infrastructure or transport errors abort the flow
+    provenance: [classifyAuthError, ErrAuthInternal]
+
+  - id: TGM-007
+    title: Telegram auth endpoints map outcomes to status codes
+    type: api
+    status: current
+    given: requests to the Telegram auth endpoints
+    when: they are handled
+    then:
+      - an empty or malformed phone number, or a missing token, code, or password, is a validation error (400)
+      - an auth-already-in-progress or already-connected start is a conflict (409)
+      - an invalid token is a client error (400) and an expired token is gone (410)
+      - a wrong code or password is unauthorized (401) and an internal auth error is a server error (500)
+      - cancel always succeeds (200) and a successful step returns 200 with the flow status
+      - disconnect succeeds (200) unless the session-row delete fails, which is a server error (500)
+      - status always returns 200 with the current connection state
+    provenance: [TelegramHandler.StartAuth, TelegramHandler.VerifyCode, TelegramHandler.VerifyPassword, TelegramHandler.CancelAuth, TelegramHandler.Disconnect, TelegramHandler.GetStatus]
+
+  - id: TGM-008
+    title: Disconnect tears down in order and requires the session row to clear
+    type: business-logic
+    status: current
+    given: a connected or authenticating Telegram integration
+    when: the user disconnects
+    then:
+      - any in-progress auth is cancelled and the live client is stopped
+      - deleting the persisted session row is required — if it fails the teardown is not committed and status keeps reflecting the database so the user can retry
+      - on success the in-memory connection state is cleared and the sync-state row is best-effort deleted
+    provenance: [TelegramManager.Disconnect]
+
+  # --- Connection lifecycle ---
+
+  - id: TGM-009
+    title: The connection starts only when authenticated
+    type: business-logic
+    status: current
+    given: a stored Telegram session
+    when: the manager starts
+    then:
+      - startup connects only when a session exists and is marked connected; otherwise it stays idle
+      - a running connection is single-flighted so a second start does not spawn a duplicate
+    provenance: [TelegramManager.Start, startConnection]
+
+  - id: TGM-010
+    title: Reported status resolves from the live connection then the database
+    type: business-logic
+    status: current
+    given: a request for Telegram status
+    when: the status is resolved
+    then:
+      - a running connection reports its in-memory state enriched with last-sync time and any backfill progress
+      - an explicit disconnect reports not-connected without falling back to stale database state
+      - otherwise the stored session's connected flag, username, and phone are reported
+    provenance: [TelegramManager.Status, enrichStatusFromSyncState]
+
+  - id: TGM-033
+    title: A dropped connection reconnects with bounded backoff
+    type: business-logic
+    status: current
+    given: a running Telegram connection
+    when: the live connection drops
+    then:
+      - a dropped connection reconnects with exponential backoff bounded between five seconds and five minutes, reset on a clean connect
+      - a cancelled context exits cleanly without reconnecting
+    provenance: [runWithReconnect, reconnectBaseDelay, reconnectMaxDelay]
+
+  # --- Chat tracking ---
+
+  - id: TGM-011
+    title: Effective tracking derives from status and chat size
+    type: business-logic
+    status: current
+    given: a group chat with a tracking status and a known-or-unknown member count
+    when: effective tracking is computed
+    then:
+      - tracked is always tracked and ignored is never tracked
+      - auto is tracked when the member count is unknown or at or below the configured group maximum
+      - private chats are always tracked and are not exposed for user management
+    provenance: [EffectiveTracked, TelegramManager.ListChats]
+
+  - id: TGM-012
+    title: A first-seen group chat is auto-configured before the tracking gate
+    type: business-logic
+    status: current
+    given: a message from a group chat with no config row yet
+    when: it is ingested
+    then:
+      - a config row is created with status auto and the observed member count
+      - the message is stored only if the chat is effectively tracked
+    provenance: [MessageHandler.shouldTrackChat]
+
+  - id: TGM-013
+    title: Switching a chat to tracked backfills its history retroactively
+    type: business-logic
+    status: current
+    given: a chat whose status changes to tracked from a non-tracked status
+    when: the change is applied
+    then:
+      - the chat's backfill state is reset and a retroactive backfill of its history is triggered
+    provenance: [TelegramHandler.UpdateChatStatus, TelegramManager.TriggerChatBackfill]
+
+  - id: TGM-035
+    title: Participant changes refresh a group chat's member count
+    type: business-logic
+    status: current
+    given: an existing group chat config
+    when: a chat-participant update is handled
+    then:
+      - the full chat is fetched and the config row's member count is updated from the current participant list
+      - a fetch failure is a non-fatal no-op that is logged; a non-regular-chat participant shape is a silent non-fatal no-op
+    provenance: [MessageHandler.HandleChatParticipant, UpdateTelegramChatConfigMemberCount]
+    notes: Member count feeds EffectiveTracked (TGM-011), so refreshing it can flip an auto chat's effective-tracked state.
+
+  - id: TGM-014
+    title: The chats endpoints list groups and validate status updates
+    type: api
+    status: current
+    given: requests to the Telegram chats endpoints
+    when: they are handled
+    then:
+      - the list returns only group chats, each with its effective-tracked flag
+      - a status update accepts only auto, ignored, or tracked, else a validation error (400)
+      - a non-numeric chat id is a validation error (400) and an unknown chat on update is not-found (404)
+    provenance: [TelegramHandler.ListChats, TelegramHandler.UpdateChatStatus]
+
+  # --- Message ingest & parsing ---
+
+  - id: TGM-015
+    title: Only person-to-person messages are ingested
+    type: business-logic
+    status: current
+    given: an incoming Telegram update
+    when: it is parsed
+    then:
+      - self-chat (Saved Messages), bot conversations, and channel or supergroup peers are filtered out
+      - private and regular-group messages are stored with direction, media class (text, photo, voice, video, sticker, document, or other), reply target, and edit time
+      - a self-authored group message is stored without peer info
+    provenance: [ParseMessage, classifyMedia]
+
+  - id: TGM-016
+    title: Post-store matching and aggregation are best-effort
+    type: business-logic
+    status: current
+    given: a stored live message
+    when: post-store processing runs
+    then:
+      - only the message upsert itself can fail ingest
+      - peer matching, and either aggregation for a matched peer or a discovery-candidate update for an unmatched peer, run best-effort with failures logged, not fatal
+    provenance: [MessageHandler.HandleNewMessage]
+
+  - id: TGM-017
+    title: Sparse peer entities are backfilled without overriding authoritative data
+    type: business-logic
+    status: current
+    given: an ingested message
+    when: its peer entity fields are resolved
+    then:
+      - when the update carried no authoritative peer entity, missing peer fields are filled from the best-known cached entity
+      - when the update carried entity data it is trusted verbatim, including empty fields that signal a user-removed value
+    provenance: [MessageHandler.enrichSparseEntity, ParseMessage PeerEntityResolved]
+
+  - id: TGM-018
+    title: Edits re-store the message text
+    type: data
+    status: current
+    given: an edit update for a tracked chat
+    when: it is handled
+    then:
+      - an edit re-upserts the message with its new text and edit time
+    provenance: [MessageHandler.HandleEditMessage, UpsertTelegramMessage]
+
+  - id: TGM-036
+    title: Deletes soft-delete by message id and do not revive
+    type: data
+    status: current
+    given: a delete update
+    when: it is handled
+    then:
+      - a delete soft-deletes messages by Telegram message id, since the delete update carries no chat scope
+      - re-ingesting a soft-deleted message does not revive it, since the upsert never clears deleted_at
+    provenance: [MessageHandler.HandleDeleteMessages, SoftDeleteTelegramMessages, UpsertTelegramMessage]
+
+  # --- telegram_message data semantics ---
+
+  - id: TGM-019
+    title: Re-ingest deduplicates and preserves known peer data
+    type: data
+    status: current
+    given: a message re-ingested for a chat and message id already stored
+    when: it is upserted
+    then:
+      - dedup is on the chat id and message id pair
+      - message text is overwritten while edit time and populated peer fields are preserved rather than blanked
+      - the resolved-entity flag is monotonic — a true resolution is never downgraded by a later sparse re-ingest
+    provenance: [UpsertTelegramMessage]
+
+  - id: TGM-020
+    title: Soft-deleted Telegram messages are invisible to production reads
+    type: invariant
+    status: current
+    statement: every production read of telegram_message excludes soft-deleted rows; only explicitly test-only queries bypass the deleted-at filter.
+    provenance: [telegram_message.sql deleted_at filters, idx_telegram_message_not_deleted]
+
+  - id: TGM-021
+    title: Automated matching never re-points an already-matched message
+    type: data
+    status: current
+    given: stored messages for a peer
+    when: the peer is matched to a contact by the automated path
+    then:
+      - the matched contact is set only on messages whose match is currently empty
+      - an existing match is never overwritten by automated matching
+    provenance: [UpdateTelegramMessageContact]
+    notes: Manual re-linking via the import queue is imports-domain scope (IMP-013).
+
+  - id: TGM-022
+    title: Telegram tables enforce closed vocabularies and identity keys
+    type: invariant
+    status: current
+    statement: chat type, message type, chat status, and session auth-state are each constrained to closed sets; the session is a singleton row; a chat config is unique per Telegram chat id; and a message is unique per chat-and-message-id pair.
+    provenance: [migration 032_telegram.up.sql CHECK and UNIQUE constraints]
+
+  - id: TGM-023
+    title: Re-discovering a chat preserves the user's tracking choice
+    type: data
+    status: current
+    given: an existing chat config
+    when: discovery re-upserts it
+    then:
+      - the title and member count are preserved when the new record omits them
+      - a user-set status (tracked or ignored) is never overwritten by discovery
+    provenance: [UpsertTelegramChatConfig status preserve]
+
+  # --- Aggregation binding (telegram-specific) ---
+
+  - id: TGM-024
+    title: Telegram interactions carry a stable source reference and labels
+    type: data
+    status: current
+    given: Telegram messages aggregated into an interaction
+    when: the interaction is written
+    then:
+      - the source is telegram and the source reference is the chat id joined with the first message id, forming the dedup key
+      - the description labels an outbound session outreach, an inbound session response, and a mixed session exchange, with the message count
+    provenance: [telegramAdapter.SourceRef, telegramAdapter.Description, InteractionSourceTelegram]
+    notes: The shared burst/session/claim/event machinery that produces the interaction is ingest-domain scope; this pins only the telegram-specific binding.
+
+  - id: TGM-025
+    title: Live messages aggregate incrementally while batches create only
+    type: business-logic
+    status: current
+    given: a trigger to aggregate a contact's Telegram messages
+    when: aggregation runs
+    then:
+      - a live single-message match aggregates incrementally for that contact and chat, coalescing within the burst window and bridging replies within the reply-bridge window
+      - post-import, post-backfill, and rematch use the batch create-only path with no extend or bridge
+    provenance: [AggregationEngine.AggregateForContact, AggregationEngine.AggregateForContactBatch]
+    notes: Window sizes and the shared aggregation semantics are ingest-domain scope.
+
+  # --- Identity linkage ---
+
+  - id: TGM-026
+    title: Peer matching tries username then phone and syncs on match
+    type: business-logic
+    status: current
+    given: a peer carrying a username and/or phone
+    when: it is matched to a contact
+    then:
+      - the Telegram username identity is tried first, then the phone
+      - a phone match also links the Telegram username identity so future matches resolve by handle
+      - on any match the peer's messages are re-pointed, an existing discovery candidate is marked matched, and the Telegram handle is synced as a contact method
+    provenance: [PeerMatcher.MatchPeer, PeerMatcher.ensureMethodsOnMatch]
+    notes: Telegram is a valid contact-method type with handle normalization (CON-011, CON-012); the identity-service match/create mechanics are imports-domain scope. Whether the method-sync path itself publishes a rematch event is tracked as proposed in IMP-034.
+
+  - id: TGM-027
+    title: A Telegram peer over the discovery minimum is normalized into a discovery candidate
+    type: business-logic
+    status: current
+    given: messages from a peer matched to no contact
+    when: the peer's message count reaches the configured discovery minimum
+    then:
+      - a discovery candidate is upserted for the peer, carrying message-count and handle metadata
+      - blank peer fields are normalized to absent so stored names and handles are preserved
+    provenance: [PeerMatcher.UpdateDiscoveryCandidatesForPeer, PeerMatcher.UpdateDiscoveryCandidates, nilIfEmpty]
+    notes: The queue-side upsert and dedup contract for the discovery candidate is imports-domain scope (IMP-023).
+
+  - id: TGM-028
+    title: Linking a peer to a contact backfills its message history
+    type: business-logic
+    status: current
+    given: a Telegram peer linked to a contact through import, link, or rematch
+    when: the link is recorded
+    then:
+      - the Telegram identity is linked to the contact
+      - all of the peer's messages are re-pointed to the contact
+      - the contact's Telegram messages are aggregated into interactions
+    provenance: [PeerMatcher.OnPeerLinked, TelegramManager.OnPeerLinked]
+
+  - id: TGM-029
+    title: Rematch links stranded Telegram peers by handle or phone
+    type: business-logic
+    status: current
+    given: new Telegram-username or phone methods on a contact
+    when: a rematch job runs for that contact
+    then:
+      - stranded unmatched peers whose username matches case-insensitively, or whose phone matches by digits, are linked to the contact
+      - the newly-linked peers' messages are aggregated
+    provenance: [UsernameRematchHandler, PhoneRematchHandler, rematchPeers]
+    notes: The rematch dispatcher and fan-out across sources are imports-domain scope (IMP-020).
+
+  - id: TGM-030
+    title: Matching an ignored peer must not resurrect it
+    type: business-logic
+    status: proposed
+    given: a Telegram discovery candidate the user has ignored
+    when: a later message matches that peer's identity to a contact
+    then:
+      - the ignore is respected and the candidate is not flipped back into the queue
+    provenance: [PeerMatcher.markExternalContactMatched, UpdateExternalContactMatch]
+    notes: 'Proposed: today the mark-matched step skips only already-matched or imported rows, so an ignored candidate is overwritten to matched — violating the sticky-ignore lifecycle (IMP-007).'
+
+  # --- Backfill ---
+
+  - id: TGM-031
+    title: Backfill discovers dialogs and fetches history to a horizon
+    type: business-logic
+    status: current
+    given: a fresh or reconnecting authenticated connection needing history
+    when: backfill runs
+    then:
+      - dialogs are discovered as private chats and regular groups, skipping self, bots, and channels
+      - only effectively-tracked chats are backfilled; the rest are marked complete without fetching
+      - history is fetched back to the configured backfill-since date
+      - a cursor is persisted periodically so an interrupted backfill resumes, and flood-wait limits are respected
+    provenance: [Backfiller.Run, Backfiller.discoverDialogs, Backfiller.backfillChatWithPeer]
+
+  - id: TGM-032
+    title: Backfill completion reconciles matches, interactions, and candidates
+    type: business-logic
+    status: current
+    given: a completed backfill pass
+    when: the batch reconcile phase runs
+    then:
+      - all unmatched peers are re-run through identity matching
+      - all unprocessed messages are aggregated into interactions
+      - discovery candidates are refreshed for peers over the threshold
+    provenance: [TelegramManager.maybeStartBackfill, PeerMatcher.MatchAllUnmatched, AggregationEngine.AggregateAll, PeerMatcher.UpdateDiscoveryCandidates]

--- a/spec/todoist.yaml
+++ b/spec/todoist.yaml
@@ -1,0 +1,397 @@
+domain: todoist
+prefix: TDS
+maturity: reviewed
+behaviors:
+  # --- Provider identity and sync orchestration ---
+
+  - id: TDS-001
+    title: Todoist is a single-account, account-required cadence-task sync provider
+    type: business-logic
+    status: current
+    given: the Todoist sync provider
+    when: its configuration is resolved
+    then:
+      - the source is identified as todoist with a fetch-all sync strategy and no task discovery (new tasks are never discovered from Todoist)
+      - a connected account is required, and only one account is supported
+      - the default sync interval is five minutes
+    provenance: [CadenceSyncProvider.Config, DefaultSyncInterval]
+    notes: Account connection and OAuth token issuance are settings-domain scope (SET); this pins the provider's own shape.
+
+  - id: TDS-002
+    title: Sync will not run until a projection target is configured
+    type: business-logic
+    status: current
+    given: a sync attempt for a connected account
+    when: the provider validates its preconditions
+    then:
+      - a project and a label must both be configured, otherwise the sync fails without issuing any request
+      - the sync also fails when the account id or a required dependency is missing
+    provenance: [CadenceSyncProvider.Sync, getSettingsFromMetadata]
+
+  - id: TDS-003
+    title: Outbound Todoist writes are structurally refused outside production
+    type: invariant
+    status: current
+    statement: a Todoist client built for a non-production CRM environment refuses every outbound write (any command-carrying sync and every quick-add) before issuing HTTP, while read-only syncs are always allowed so a non-prod instance can still fetch remote state for comparison; production write paths must build the client with the runtime CRM environment so the guard applies.
+    provenance: [ErrNonProdWriteRefused, SyncClient.Sync, SyncClient.QuickAdd, config.IsProductionCRMEnv, NewClientFactory]
+    notes: Defense-in-depth against a restored prod DB or partial env copy mutating the operator's real Todoist account. A verbatim full prod-env clone carrying a production CRM_ENV is intentionally not defended by this guard.
+
+  - id: TDS-004
+    title: Sync uses full-then-incremental fetch with bounded command batches
+    type: business-logic
+    status: current
+    given: a sync tick
+    when: the provider exchanges state with Todoist
+    then:
+      - a first-time sync requests full state, otherwise it resumes from the stored cursor
+      - a first-time full sync is immediately followed by an incremental item fetch whose only effect is to advance the stored cursor to the latest point, so the next tick resumes from there
+      - outbound commands are split into batches within the provider's per-request command limit
+    provenance: [CadenceSyncProvider.Sync, BatchCommands]
+    notes: The follow-up fetch after a full sync advances the cursor only; its item payload is not fed into item processing or reconciliation (reconciliation reads current DB state, not the fetched items).
+
+  - id: TDS-005
+    title: A fatal item error replays the batch and never orphans remote cleanup
+    type: business-logic
+    status: current
+    given: a batch of synced items where one item fails fatally mid-processing
+    when: the sync tick finishes
+    then:
+      - the sync cursor is not advanced, so the next tick reprocesses the batch from the pre-batch cursor
+      - every command already accumulated by items that committed before the failing item is still flushed to Todoist before the error is returned — this includes a skip's replacement create, not only remote-cleanup close/delete commands
+    provenance: [CadenceSyncProvider.Sync, processItems]
+    notes: Each successfully processed item commits in its own transaction. On replay a completion or dismissal short-circuits because its row is already terminal (TDS-006); a skip leaves its row managed, so its replay is instead deduped by the skip event key (TDS-011).
+
+  - id: TDS-006
+    title: A task not in the managed state is inert to incremental processing
+    type: invariant
+    status: current
+    statement: incremental item processing only acts on tasks whose local row is in the managed state; completed, dismissed, and unmanaged rows short-circuit so a replayed or stale item redelivery cannot re-fire completion, skip, or dismissal handling.
+    provenance: [CadenceSyncProvider.processItem]
+
+  - id: TDS-007
+    title: Project, label, and timezone renames are self-healed from each sync
+    type: data
+    status: current
+    given: a configured Todoist project and label whose names change, or an updated account timezone
+    when: a sync response is processed
+    then:
+      - the stored project name, label name, and user timezone are refreshed from the response
+      - the configured project id and label id are unchanged by a rename
+    provenance: [CadenceSyncProvider.Sync, updateSyncStateMetadata]
+
+  - id: TDS-008
+    title: Todoist API errors are classified to drive retry and backoff
+    type: business-logic
+    status: current
+    given: a Todoist API error response
+    when: the error is classified
+    then:
+      - authentication failures (unauthorized or forbidden) are surfaced as an authentication error
+      - rate-limit responses are surfaced as rate-limited, carrying any retry-after hint
+      - server and rate-limit responses are treated as transient
+    provenance: [APIError, handleSyncError]
+    notes: The escalating backoff schedule and success reset live in the shared sync service, not the Todoist provider.
+
+  # --- Per-item detection and event projection ---
+
+  - id: TDS-009
+    title: Completing a Todoist task publishes a completion event atomically
+    type: business-logic
+    status: current
+    given: a managed reach-out, send, or legacy task marked complete in Todoist
+    when: the completion is processed
+    then:
+      - a task-completed event is published and the local state advanced to completed in one transaction, publishing before the state mutation
+      - the event carries the interaction direction and follow-up-suppression flag derived from the task kind
+      - the event is keyed on the task's stable internal id so a duplicate publish short-circuits without a second state change
+      - a reminder-kind completion short-circuits to completed with no event and no interaction
+    provenance: [handleTaskCompletion, events.KindTaskCompleted, PublishTx]
+    notes: What the downstream consumer records from the event (interaction direction, follow-up loop) is CAD-017. The internal-id event key survives the temp-to-real external id swap; the downstream interaction row keys on the external id instead.
+
+  - id: TDS-010
+    title: Removing a task's managed markers is routed to a skip by lifecycle
+    type: business-logic
+    status: current
+    given: a managed task that is deleted, has its CRM label removed, or has its deadline removed in Todoist
+    when: the change is detected
+    then:
+      - a follow-up-loop task is dismissed
+      - a cadence-due task is skipped (its schedule advanced)
+      - a manual task is dismissed, and a legacy action task is relinquished to unmanaged (action tasks unmanage only on deletion or CRM-label removal, never on deadline removal — they are dispatched by kind before the deadline-based skip check)
+    provenance: [CadenceSyncProvider.processItem, handleSkipTrigger, handleFollowUpDismissal, handleManualDismissal, handleActionTaskTriggers]
+    notes: The CRM-side outcomes of each route are CAD-016 (follow-up dismissal), CAD-019 (cadence skip), and CAD-021 (manual/action dismissal); this pins the Todoist-side detection and routing.
+
+  - id: TDS-011
+    title: A cadence skip dedups replays and enqueues its replacement post-commit
+    type: business-logic
+    status: current
+    given: a cadence-due task being skipped
+    when: the skip is applied
+    then:
+      - the skip event is keyed on the task id plus the item's last-updated marker, so a replay of the unchanged item dedups while a genuine re-edit produces a fresh event
+      - the schedule advance and event publish commit together, publish-before-mutate
+      - the replacement cadence task's create command is only emitted after the commit succeeds
+    provenance: [handleSkipTrigger]
+    notes: The schedule-advance arithmetic (later of today or the old date, plus one interval) is CAD-019.
+
+  - id: TDS-012
+    title: A recurring Todoist task is relinquished rather than managed
+    type: business-logic
+    status: current
+    given: a managed task the user has made recurring in Todoist
+    when: the recurrence is detected
+    then:
+      - the task is set to unmanaged, so the CRM stops reconciling it
+      - no interaction and no schedule change result
+    provenance: [handleRecurringDetection]
+
+  - id: TDS-013
+    title: A task whose contact is gone is deleted remotely and locally
+    type: data
+    status: current
+    given: a managed task whose contact has been soft-deleted (or otherwise reads as not-live)
+    when: the task's item is processed on the next sync
+    then:
+      - a delete command is emitted to remove the task from Todoist
+      - the local task row is hard-deleted
+    provenance: [CadenceSyncProvider.processItem]
+    notes: Contact soft-delete does not cascade to contact_task rows (CON-010); this deferred sync-time cleanup is how orphaned Todoist tasks are removed.
+
+  - id: TDS-014
+    title: A remote deadline edit on a cadence task wins over the last pushed date
+    type: business-logic
+    status: current
+    given: a cadence-due task whose deadline differs from the contact's next-contact date
+    when: the deadline change is processed
+    then:
+      - a deadline equal to the last date the CRM pushed is recognized as a stale redelivery and does not override
+      - a genuine user edit overrides the contact's next-contact date and records the new pushed-date watermark in the same transaction
+      - a missing watermark (legacy task) is treated as a real edit so a genuine change is never silently dropped
+      - follow-up-loop task deadlines are never allowed to move the next-contact date
+    provenance: [CadenceSyncProvider.processItem deadline-edit branch, MetadataKeySyncedDeadline]
+    notes: The cadence-side outcome (next-contact date overridden via the sole writer) is CAD-035; this pins the watermark/stale-detection mechanics on the Todoist side.
+
+  # --- Reconciliation ---
+
+  - id: TDS-015
+    title: Reconciliation projects one cadence-due task per cadence-bearing contact
+    type: business-logic
+    status: current
+    given: a contact with a cadence and a next-contact date but no live cadence-due task
+    when: reconciliation runs on a sync tick
+    then:
+      - a create command for a reach-out cadence-due task is emitted and a local row recorded in the managed state with pending-create watermarks
+      - reconciliation is skipped for a contact that has a live follow-up (the follow-up already covers it)
+    provenance: [CadenceSyncProvider.reconcileContactTasks, FindPendingFollowUp]
+    notes: The one-cadence-task-per-contact intent and the follow-up grace deferral are CAD-018; this pins the provider-side projection. There is no dedicated cron — reconciliation rides the sync tick.
+
+  - id: TDS-016
+    title: Outreach detected outside Todoist closes the cadence task via a watermark
+    type: business-logic
+    status: current
+    given: a managed cadence-due task whose contact was reached out to since the last sync
+    when: reconciliation evaluates the task
+    then:
+      - fresh outreach is recognized by comparing the contact's last-outreach time against a stored watermark
+      - the local task is completed first, then a remote close command is emitted only when the task has a real external id
+      - the outreach watermark is advanced so the same outreach does not re-close on a later tick
+    provenance: [closeOnOutreach, wasReachedOutSinceSync]
+    notes: The CRM-side intent (outreach closes the open cadence task) is CAD-020; this pins the watermark and remote-close mechanics.
+
+  - id: TDS-017
+    title: Drift is corrected by replacing the remote task, never by writing the date
+    type: business-logic
+    status: current
+    given: a managed cadence-due task whose remote deadline no longer matches the contact's next-contact date
+    when: reconciliation detects the drift
+    then:
+      - the old remote task is closed (when it has a real external id) and a new task is created for the current date
+      - the new task's deadline is read from the live contact record; reconciliation never itself writes the next-contact date
+    provenance: [reconcileExistingTask]
+    notes: The next-contact date is written only by the cadence engine (CAD-005); the provider deliberately reads it live rather than recomputing.
+
+  - id: TDS-018
+    title: Skip-drift recovery re-emits a lost create and defers when ambiguous
+    type: business-logic
+    status: current
+    given: a task whose recorded pending temp id differs from its external id (the create command never landed remotely)
+    when: reconciliation processes it
+    then:
+      - a close-old plus create-new pair is re-emitted, and the new pending temp id is persisted before the commands are emitted
+      - the recovery is suppressed for one tick when temp-id mapping was ambiguous this tick, to avoid a duplicate create against an already-created remote task
+    provenance: [reconcileExistingTask skip-drift branch, deferSkipDrift]
+
+  - id: TDS-019
+    title: Legacy tasks backfill their watermarks and detection requires them
+    type: data
+    status: current
+    given: a legacy task missing its synced-state watermark metadata
+    when: it is reconciled
+    then:
+      - the missing watermark keys are backfilled, including a pre-gate backfill so contacts with a pending follow-up are still covered
+      - since-last-sync outreach and contact detection require the watermark to be present, so an unbackfilled legacy task never produces a false positive
+    provenance: [reconcileExistingTask backfill, closeOnOutreach pre-gate backfill, wasContactedSinceSync, wasReachedOutSinceSync]
+
+  - id: TDS-020
+    title: Task metadata is mutated key-wise, never wholesale replaced
+    type: invariant
+    status: current
+    statement: every write to a task's metadata (marker link, pending temp id, and the synced-deadline / synced-last-contacted / synced-last-outreach watermarks) preserves the sibling keys rather than replacing the whole object, so no path drops a marker or watermark it did not intend to touch.
+    provenance: [setPendingCreateState, setSyncedLastContacted, setSyncedLastOutreachAt, UpdateContactTaskMetadataTx]
+
+  # --- Temp-id recovery and finalize ---
+
+  - id: TDS-021
+    title: Temp-to-real id finalize is forward-only and never resurrects a dead row
+    type: data
+    status: current
+    given: a create command whose Todoist-assigned real id has arrived while the local row may have advanced state
+    when: the temp-to-real id mapping is finalized
+    then:
+      - the row state is re-read inside the finalize transaction, since it may have changed since the pre-transaction snapshot
+      - a still-managed row records the real id and stays managed
+      - a terminal-state row records the real id without being flipped back to managed
+      - the pending temp id is cleared in every case
+    provenance: [finalizeTempIDMappingTx, UpdateContactTaskExternalIDTx, SetContactTaskExternalIDOnlyTx]
+
+  - id: TDS-022
+    title: Marker-based temp-id recovery is cadence-only and defers skip-drift on failure
+    type: business-logic
+    status: current
+    given: an incoming item with no external-id match but a decodable CRM marker
+    when: recovery attempts to reattach it to a pending local task
+    then:
+      - recovery only proceeds for a cadence-due marker; follow-up and manual markers are not recovered this way
+      - a recovery whose transaction rolls back forces skip-drift to be deferred for the current tick, so no duplicate create is emitted against the freshly delivered remote item
+    provenance: [tryRecoverPendingTempID, processTempIDMappings]
+
+  - id: TDS-023
+    title: Finalizing an already-completed row enqueues a durable remote close
+    type: business-logic
+    status: current
+    given: a temp-id finalize landing on a row that has already completed
+    when: the real id is recorded
+    then:
+      - a durable, retried background job is enqueued to close the now-identifiable remote task
+      - if remote close is disabled or the job runner is unwired, the id is still recorded locally and the condition is logged rather than lost silently
+    provenance: [finalizeTempIDMappingTx, TodoistFollowUpCloseJob]
+
+  # --- CRM marker codec ---
+
+  - id: TDS-024
+    title: The CRM marker is the sole-constructor task-to-contact link
+    type: invariant
+    status: current
+    statement: the JSON marker embedded in a managed Todoist task description — the canonical sorted-key object linking the task to a contact id, kind, lifecycle, and instance — is produced only through the single sanctioned encoder, enforced by a construction guard that forbids any other code path from building it.
+    provenance: [contacttask.EncodeMarker, crm_marker_construction_static_test.go]
+
+  - id: TDS-025
+    title: Marker decoding tolerates markdown prefixes and normalizes legacy kinds
+    type: business-logic
+    status: current
+    given: a Todoist task description that may carry a plain or markdown-prefixed CRM marker, possibly in a pre-split legacy shape
+    when: the marker is decoded
+    then:
+      - a marker embedded after leading text is recovered by parsing from the last opening brace
+      - a legacy kind is mapped to its modern kind and lifecycle pair
+      - a description with no valid CRM marker, or an unrecognized legacy kind, is rejected as not-a-marker
+    provenance: [DecodeMarker, parseMarker, normalizeLegacyMarker]
+
+  - id: TDS-026
+    title: A projected task carries a contact deep link in its title and a marker in its description
+    type: business-logic
+    status: current
+    given: a task being created in Todoist for a contact
+    when: the create command is built
+    then:
+      - the task title carries a human-readable contact link into the CRM
+      - the task description carries the CRM marker used for later reconciliation
+    provenance: [createTaskCommand, ContactTaskService.CreateManualTask]
+
+  - id: TDS-027
+    title: A manual task is projected via quick-add then a marker attach, cleaning up on failure
+    type: business-logic
+    status: current
+    given: a user creating a manual task on a contact
+    when: the task is projected to Todoist
+    then:
+      - the task text is sent through the natural-language quick-add so dates, project, label, and priority syntax are parsed by Todoist
+      - the CRM marker is attached in a second step that updates the task description
+      - if the marker attach fails, the remote task is deleted so no unreconcilable task is left behind
+    provenance: [ContactTaskService.CreateManualTask, NewItemUpdateCommand]
+    notes: The user-facing add-task flow and validation are CAD-031. Quick-add's note parameter creates comments, not descriptions, which is why the marker is applied via a description update.
+
+  # --- Follow-up loop projection ---
+
+  - id: TDS-028
+    title: The follow-up loop is projected to Todoist by durable, cutover-gated jobs
+    type: business-logic
+    status: current
+    given: a follow-up loop transition owned by the cadence domain (create, refresh, or close)
+    when: the transition is projected to Todoist
+    then:
+      - each projection runs as a durable background job that retries on failure
+      - all three projection jobs hard-fail if invoked while follow-up cutover mode is not enabled
+    provenance: [TodoistFollowUpCreateJobWorker, TodoistFollowUpCloseJobWorker, TodoistFollowUpRefreshJobWorker]
+    notes: The follow-up loop state machine (create-on-outbound, refresh, close-on-reply, one-live-follow-up) is CAD-013/CAD-014/CAD-015; this pins the Todoist-side projection workers.
+
+  - id: TDS-029
+    title: The follow-up create projection is crash-safe and idempotent
+    type: data
+    status: current
+    given: a follow-up create job, possibly retried or racing a concurrent worker
+    when: the remote task is created
+    then:
+      - the work is split into read, remote-call, and write phases so no database transaction is held open across the HTTP call
+      - the remote create uses deterministic command identifiers so a crash-retry does not create a duplicate task
+      - a row already finalized by another worker is an idempotent no-op, and a reply that completed the row mid-create records the real id without resurrecting the row and ensures the remote task is closed
+    provenance: [TodoistFollowUpCreateJobWorker, buildItemAddCommandFromMetadata, deterministicCommandUUID]
+    notes: The CRM-side crash-safety and idempotency guarantees are CAD-014; this pins the projection worker's phasing.
+
+  - id: TDS-030
+    title: Remote close is only ever propagated for a task with a real external id
+    type: invariant
+    status: current
+    statement: across every path that closes a Todoist task (reply-driven close, temp-id finalize, cadence outreach, and merge cleanup), a remote close command is issued only when the task holds a real external id; a task still carrying its pending temp id is closed by whichever create path owns it, never by a second close against a non-existent remote task.
+    provenance: [isPendingTempID, closeOnOutreach, finalizeTempIDMappingTx, ContactService.MergeContacts task close]
+    notes: The reply-driven close single-owner rule is CAD-015; the merge-time close is CON-031. This pins the shared real-id gate.
+
+  # --- Settings and surfaces ---
+
+  - id: TDS-034
+    title: A Todoist task sync can be triggered on demand from settings
+    type: ux
+    status: current
+    given: a connected Todoist account
+    when: the user triggers a manual task sync
+    then:
+      - a sync is requested for that account and its success or failure is indicated
+      - the account's read/write permission state is visible
+    provenance: [todoist-accounts-section.tsx sync badge, useTriggerSync]
+    notes: The Todoist projection-target settings surface — the read/write settings endpoints, the project and label pickers, and the sync-configuration UI — is owned by the settings domain (SET-015, SET-016, SET-017, SET-018, SET-026), not re-minted here. This row pins only the on-demand sync trigger.
+
+  - id: TDS-035
+    title: Projected tasks display cleaned content with a deep link into Todoist
+    type: ux
+    status: current
+    given: a contact with tasks projected into Todoist
+    when: the contact's tasks are shown
+    then:
+      - the CRM link markers are stripped so the task shows human-readable content, falling back to a placeholder when empty
+      - each linked task offers a deep link that opens it in the Todoist app
+      - the cadence-due projection is not surfaced on the contact page (cadence is surfaced through the overdue and recent-activity surfaces instead)
+    provenance: [tasks-section.tsx, contact detail task queries]
+    notes: The tasks-section layout, badges, and completed-toggle are CAD-030; unlinking (which keeps the task alive in Todoist) is CAD-033. This pins the Todoist-projection-specific display concerns.
+
+  - id: TDS-037
+    title: The follow-up refresh projection pushes the new deadline and no-ops before the task exists
+    type: business-logic
+    status: current
+    given: a follow-up whose local deadline changed after its create was projected
+    when: the refresh projection runs
+    then:
+      - an item_update carrying the stored deadline is issued so Todoist is brought back in line with the local row
+      - the job is a no-op when the row has no real external id yet, since the pending create will pick up the new deadline
+      - the create worker enqueues a durable refresh job when the deadline drifted between its read and write phases, so a late deadline change is not stranded on the old remote task
+    provenance: [TodoistFollowUpRefreshJobWorker.Work, TodoistFollowUpCreateJobWorker drift-refresh enqueue]
+    notes: The three durable cutover-gated projection jobs are enumerated in TDS-028; this pins the refresh job's Todoist-side semantics, parallel to create (TDS-029) and close (TDS-023/TDS-030). The local row is authoritative — the refresh worker only keeps Todoist eventually consistent.


### PR DESCRIPTION
## Summary

Backfills the behavior SSOT for the **9 remaining domains**, completing the 12-domain corpus started by the exemplar cycle (contacts/cadence-followup/imports-matching). Adds 276 behaviors across knowledge, todoist, settings, dashboard, ingest, calendar, telegram, mac-host, and notes-meetings — all landing at `maturity: reviewed`. Spec-only change: the corpus now totals **12 files / 393 behaviors**, and `make spec-lint` passes.

This is Piece 1 of #380 (Behavior SSOT). Per-domain files were derived and curated by an adversarial multi-agent pass (inventory → draft → fresh-context reviewer loop to zero blocking findings), followed by a **cross-corpus consistency pass** over all 12 files, then coordinator adjudication of the cross-file findings (below).

| Domain | Prefix | Behaviors | Proposed | Review |
|---|---|---:|---:|---|
| knowledge | KNW | 35 | 0 | polish-only |
| todoist | TDS | 33 | 0 | 2 rounds |
| settings | SET | 33 | 3 | polish-only |
| dashboard | DSH | 9 | 2 | 2 rounds |
| ingest | ING | 38 | 0 | polish-only |
| calendar | CAL | 30 | 0 | 2 rounds |
| telegram | TGM | 37 | 1 | 3 rounds |
| mac-host | MAC | 36 | 0 | 2 rounds |
| notes-meetings | NTS | 25 | 1 | polish-only |

## Curation evidence — bugs surfaced, written as `proposed` (never enshrined as `current`)

Adversarial review caught several draft behaviors that misdescribed today's code while marked `current`. Each was corrected — either re-verified against code and reworded, or reclassified `proposed` where today's behavior is a genuine bug:

- **TGM-007 / TGM-014** — draft claimed validation failures return HTTP 422; the code returns 400 (`SendValidationError`). Corrected to 400.
- **TGM-003** — draft misdescribed expired-token verification behavior; reworded to match the actual gone/expired path.
- **CAL-017** — invariant misdescribed the rematch (re-link) branch's publish-before-mutate ordering; corrected against the consumer code.
- **TDS-004** — overclaimed that the post-full-sync incremental fetch makes the freshest state authoritative for reconciliation; narrowed to what the sync path guarantees.
- **MAC-013** — invariant overclaimed which endpoint groups are host-validated; scoped to the groups that actually are.
- **DSH-005 / DSH-006 / DSH-009** — the overdue-widget freshness contract: flows whose invalidation rules omit the overdue key (import-link resolution, cadence-changing edits) leave the widget stale today, and a failed dashboard mark-as-contacted is silent. The working invalidations are `current` (DSH-005); the broken-freshness and silent-failure intents are `proposed` (DSH-009, DSH-006).
- **SET** proposed items and **NTS-`proposed`** similarly capture intended-but-not-fully-holding surface behavior.

## Cross-corpus consistency pass — resolutions applied

The final consistency stage compared all 12 files. The negative-space audit came back clean (every README taxonomy area covered, no PII, all IDs/prefixes globally unique, all files lint clean). It flagged cross-file duplication the per-domain reviewers could not see; I adjudicated and applied:

- **Todoist settings surface (TDS ↔ SET).** The settings endpoints + config UI were minted in both files. Following the CAL→SET precedent, **SET owns the surface** (SET-015/016/017/018/026); the four duplicate TDS rows (TDS-031/032/033/036) were removed and TDS-034 cross-references SET.
- **Call pipeline + daemon-auth (MAC ↔ ING).** mac-host re-derived ingest's call pipeline and the daemon auth/payload-verification slice (MAC-030 was a verbatim ING-030). **ING owns call semantics and the generic ingest envelope**; the eight duplicate MAC rows (MAC-021/022/023/024/026/028/030/031) were removed. Two genuine call-staging facets not present in ING (call direction-field normalization; phone-call staging dedup) were **relocated into ingest as ING-037/ING-038** rather than dropped. mac-host keeps only its host-binding/integrity facets (MAC-025/026-narrowed/027) with cross-refs. MAC-026 was narrowed to the external-contact **delete**-hash validation (which ING-036 does not cover).
- **MAC-033 ↔ landed IMP-017.** MAC-033 restated IMP-017's auto-propagate-vs-suggest rule verbatim; trimmed to the address-book reconcile trigger and deferred the rule to IMP-017.
- **SET-016** retyped `business-logic` → `api` (it leads with HTTP status-code outcomes like its `api` siblings).
- **KNW-035** note no longer claims cross-surface authority over the landed CON-045 (age suppression); the two are stated as consistent.
- **dashboard.yaml** — removed an 18-line embedded curator-walkthrough comment block (belongs in the PR, not the source).

Pre-landing removals (per the README rule, recorded here rather than tombstoned since these IDs never landed): TDS-031/032/033/036; MAC-021/022/023/024/028/029/030/031/032. IDs are not renumbered — the gaps are intentional.

## README updates

- The **curation rule** now describes the adversarial-review model (fresh-context reviewer loop + cross-corpus consistency pass), superseding the interactive human-by-behavior walkthrough, and makes PR granularity flexible (batched multi-domain PRs are fine when the whole set went through the pass together — as this one did).
- The **`ux` type** gains its forward producer path: design sessions (including AI design work) mint intended surface behavior as `proposed`, implementation flips it to `current`, reversals retire-and-mint.

## CI

Spec-only change — only the `Spec Lint` job runs (all other CI jobs skip via the `spec` path group). Verified locally: `make spec-lint` → `12 files, 393 behaviors — OK`.
