### PR TITLE
test(calendar): cited handler API tests (CAL-022, CAL-023)

### DIFF
--- a/backend/tests/api/calendar_api_test.go
+++ b/backend/tests/api/calendar_api_test.go
@@ -263,6 +263,14 @@ func TestCalendarAPI_AttendeeRedaction(t *testing.T) {
 		w := doCalendarGet(router, "/api/v1/contacts/"+contactID.String()+"/events")
 		require.Equal(t, http.StatusOK, w.Code)
 
+		// Prove the attendees were actually stored before asserting their
+		// absence from the body — otherwise a seed path that silently drops
+		// attendees would make the redaction assertions pass vacuously.
+		var envelope calendarEventsEnvelope
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &envelope))
+		require.Len(t, envelope.Data, 1)
+		require.Equal(t, 2, envelope.Data[0].AttendeeCount)
+
 		body := w.Body.String()
 		assert.NotContains(t, body, organizerEmail, "response must not leak the organizer's raw email")
 		assert.NotContains(t, body, organizerName, "response must not leak the organizer's display name")

--- a/backend/tests/api/calendar_api_test.go
+++ b/backend/tests/api/calendar_api_test.go
@@ -32,7 +32,7 @@ type calendarEventsEnvelope struct {
 // (newIsolatedRiverTestDB) and a router carrying only the production
 // calendar route surface (handlers.RegisterCalendarRoutes). Because the
 // clone starts empty, global-feed and pagination assertions in the caller
-// are exact and independent of sibling subtests/tests (DC1). Returns the
+// are exact and independent of sibling subtests/tests. Returns the
 // router, the calendar repository (for seeding events), and a seedContact
 // helper (for seeding a matched contact).
 func newCalendarAPITest(t *testing.T, ctx context.Context) (*gin.Engine, *repository.CalendarEventRepository, func(name string) uuid.UUID) {
@@ -152,7 +152,7 @@ func TestCalendarAPI_ReadEndpoints(t *testing.T) {
 		var envelope calendarEventsEnvelope
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &envelope))
 		require.True(t, envelope.Success)
-		// The clone is empty apart from this subtest's own seeding (DC1), so
+		// The clone is empty apart from this subtest's own seeding, so
 		// the global feed is exactly the seeded future event.
 		require.Len(t, envelope.Data, 1)
 		assert.Equal(t, future.ID.String(), envelope.Data[0].ID)

--- a/backend/tests/api/calendar_api_test.go
+++ b/backend/tests/api/calendar_api_test.go
@@ -125,6 +125,10 @@ func TestCalendarAPI_ReadEndpoints(t *testing.T) {
 		contactID := seedContact("Calendar Upcoming Test Contact " + ns)
 		now := accelerated.GetCurrentTime()
 		seedEvent(t, ctx, calendarRepo, ns, "past", now.Add(-48*time.Hour), now.Add(-47*time.Hour), []uuid.UUID{contactID}, nil)
+		// Started-but-not-ended: excluded because the contract keys on start
+		// time — a regression filtering on end_time > now would wrongly
+		// include this in-progress event.
+		seedEvent(t, ctx, calendarRepo, ns, "inprogress", now.Add(-30*time.Minute), now.Add(time.Hour), []uuid.UUID{contactID}, nil)
 		future := seedEvent(t, ctx, calendarRepo, ns, "future", now.Add(48*time.Hour), now.Add(49*time.Hour), []uuid.UUID{contactID}, nil)
 
 		w := doCalendarGet(router, "/api/v1/contacts/"+contactID.String()+"/events/upcoming")
@@ -133,7 +137,7 @@ func TestCalendarAPI_ReadEndpoints(t *testing.T) {
 		var envelope calendarEventsEnvelope
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &envelope))
 		require.True(t, envelope.Success)
-		require.Len(t, envelope.Data, 1, "only the future event should be returned")
+		require.Len(t, envelope.Data, 1, "only the future event should be returned; past and in-progress events must be excluded")
 		assert.Equal(t, future.ID.String(), envelope.Data[0].ID)
 	})
 
@@ -144,6 +148,8 @@ func TestCalendarAPI_ReadEndpoints(t *testing.T) {
 		ns := "cal-global-" + uuid.NewString()[:8]
 		contactID := seedContact("Calendar Global Test Contact " + ns)
 		now := accelerated.GetCurrentTime()
+		seedEvent(t, ctx, calendarRepo, ns, "past", now.Add(-24*time.Hour), now.Add(-23*time.Hour), []uuid.UUID{contactID}, nil)
+		seedEvent(t, ctx, calendarRepo, ns, "inprogress", now.Add(-30*time.Minute), now.Add(time.Hour), []uuid.UUID{contactID}, nil)
 		future := seedEvent(t, ctx, calendarRepo, ns, "future", now.Add(24*time.Hour), now.Add(25*time.Hour), []uuid.UUID{contactID}, nil)
 
 		w := doCalendarGet(router, "/api/v1/events/upcoming")
@@ -152,8 +158,9 @@ func TestCalendarAPI_ReadEndpoints(t *testing.T) {
 		var envelope calendarEventsEnvelope
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &envelope))
 		require.True(t, envelope.Success)
-		// The clone is empty apart from this subtest's own seeding, so
-		// the global feed is exactly the seeded future event.
+		// The clone is empty apart from this subtest's own seeding, so the
+		// global feed is exactly the seeded future event — the past and
+		// in-progress (started-but-not-ended) events must be excluded.
 		require.Len(t, envelope.Data, 1)
 		assert.Equal(t, future.ID.String(), envelope.Data[0].ID)
 	})

--- a/backend/tests/api/calendar_api_test.go
+++ b/backend/tests/api/calendar_api_test.go
@@ -1,0 +1,272 @@
+//go:build integration_testdb
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/api/handlers"
+	"personal-crm/backend/internal/repository"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// calendarEventsEnvelope mirrors api.APIResponse for the calendar list
+// endpoints, unwrapping straight into the exported handlers response type.
+type calendarEventsEnvelope struct {
+	Success bool                             `json:"success"`
+	Data    []handlers.CalendarEventResponse `json:"data"`
+}
+
+// newCalendarAPITest builds a fresh, empty per-subtest DB clone
+// (newIsolatedRiverTestDB) and a router carrying only the production
+// calendar route surface (handlers.RegisterCalendarRoutes). Because the
+// clone starts empty, global-feed and pagination assertions in the caller
+// are exact and independent of sibling subtests/tests (DC1). Returns the
+// router, the calendar repository (for seeding events), and a seedContact
+// helper (for seeding a matched contact).
+func newCalendarAPITest(t *testing.T, ctx context.Context) (*gin.Engine, *repository.CalendarEventRepository, func(name string) uuid.UUID) {
+	t.Helper()
+
+	database, _ := newIsolatedRiverTestDB(t, ctx)
+
+	calendarRepo := repository.NewCalendarEventRepository(database.Queries)
+	contactRepo := repository.NewContactRepository(database.Queries)
+	handler := handlers.NewCalendarHandler(calendarRepo)
+
+	router := gin.New()
+	v1 := router.Group("/api/v1")
+	handlers.RegisterCalendarRoutes(v1, handler)
+
+	seedContact := func(name string) uuid.UUID {
+		t.Helper()
+		contact, err := contactRepo.CreateContact(ctx, repository.CreateContactRequest{FullName: name})
+		require.NoError(t, err)
+		return contact.ID
+	}
+
+	return router, calendarRepo, seedContact
+}
+
+// seedEvent upserts a calendar event via the real repository (never raw
+// SQL). suffix must be unique within the calling subtest's namespace so the
+// (gcal_event_id, gcal_calendar_id, google_account_id) unique constraint
+// never collides.
+func seedEvent(t *testing.T, ctx context.Context, repo *repository.CalendarEventRepository, ns, suffix string, start, end time.Time, contactIDs []uuid.UUID, attendees []repository.Attendee) *repository.CalendarEvent {
+	t.Helper()
+	title := "Calendar API Test Event"
+	ev, err := repo.Upsert(ctx, repository.UpsertCalendarEventRequest{
+		GcalEventID:       ns + "-" + suffix,
+		GcalCalendarID:    ns + "-cal",
+		GoogleAccountID:   ns + "-acct",
+		Title:             &title,
+		StartTime:         start,
+		EndTime:           end,
+		Status:            "confirmed",
+		Attendees:         attendees,
+		MatchedContactIDs: contactIDs,
+		SyncedAt:          accelerated.GetCurrentTime(),
+	})
+	require.NoError(t, err)
+	return ev
+}
+
+// doCalendarGet serves a GET request against the router and returns the
+// recorder.
+func doCalendarGet(router *gin.Engine, path string) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	router.ServeHTTP(w, req)
+	return w
+}
+
+// spec: CAL-022
+//
+// TestCalendarAPI_ReadEndpoints proves the calendar HTTP surface is
+// readable, paginated with a bounded/default limit, rejects malformed
+// contact ids, and exposes no write endpoints.
+func TestCalendarAPI_ReadEndpoints(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ContactEvents_ReturnsSeededEvent", func(t *testing.T) {
+		ctx := context.Background()
+		router, calendarRepo, seedContact := newCalendarAPITest(t, ctx)
+
+		ns := "cal-read-" + uuid.NewString()[:8]
+		contactID := seedContact("Calendar Read Test Contact " + ns)
+		now := accelerated.GetCurrentTime()
+		ev := seedEvent(t, ctx, calendarRepo, ns, "past", now.Add(-48*time.Hour), now.Add(-47*time.Hour), []uuid.UUID{contactID}, nil)
+
+		w := doCalendarGet(router, "/api/v1/contacts/"+contactID.String()+"/events")
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var envelope calendarEventsEnvelope
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &envelope))
+		require.True(t, envelope.Success)
+		require.Len(t, envelope.Data, 1)
+		assert.Equal(t, ev.ID.String(), envelope.Data[0].ID)
+	})
+
+	t.Run("UpcomingForContact_FiltersToFuture", func(t *testing.T) {
+		ctx := context.Background()
+		router, calendarRepo, seedContact := newCalendarAPITest(t, ctx)
+
+		ns := "cal-upcoming-" + uuid.NewString()[:8]
+		contactID := seedContact("Calendar Upcoming Test Contact " + ns)
+		now := accelerated.GetCurrentTime()
+		seedEvent(t, ctx, calendarRepo, ns, "past", now.Add(-48*time.Hour), now.Add(-47*time.Hour), []uuid.UUID{contactID}, nil)
+		future := seedEvent(t, ctx, calendarRepo, ns, "future", now.Add(48*time.Hour), now.Add(49*time.Hour), []uuid.UUID{contactID}, nil)
+
+		w := doCalendarGet(router, "/api/v1/contacts/"+contactID.String()+"/events/upcoming")
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var envelope calendarEventsEnvelope
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &envelope))
+		require.True(t, envelope.Success)
+		require.Len(t, envelope.Data, 1, "only the future event should be returned")
+		assert.Equal(t, future.ID.String(), envelope.Data[0].ID)
+	})
+
+	t.Run("GlobalUpcoming_ReturnsFutureEvents", func(t *testing.T) {
+		ctx := context.Background()
+		router, calendarRepo, seedContact := newCalendarAPITest(t, ctx)
+
+		ns := "cal-global-" + uuid.NewString()[:8]
+		contactID := seedContact("Calendar Global Test Contact " + ns)
+		now := accelerated.GetCurrentTime()
+		future := seedEvent(t, ctx, calendarRepo, ns, "future", now.Add(24*time.Hour), now.Add(25*time.Hour), []uuid.UUID{contactID}, nil)
+
+		w := doCalendarGet(router, "/api/v1/events/upcoming")
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var envelope calendarEventsEnvelope
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &envelope))
+		require.True(t, envelope.Success)
+		// The clone is empty apart from this subtest's own seeding (DC1), so
+		// the global feed is exactly the seeded future event.
+		require.Len(t, envelope.Data, 1)
+		assert.Equal(t, future.ID.String(), envelope.Data[0].ID)
+	})
+
+	t.Run("Pagination_ClampsAndDefaults", func(t *testing.T) {
+		ctx := context.Background()
+		router, calendarRepo, seedContact := newCalendarAPITest(t, ctx)
+
+		ns := "cal-page-" + uuid.NewString()[:8]
+		contactID := seedContact("Calendar Pagination Test Contact " + ns)
+		now := accelerated.GetCurrentTime()
+		for i := 0; i < 101; i++ {
+			start := now.Add(time.Duration(i+1) * time.Hour)
+			seedEvent(t, ctx, calendarRepo, ns, fmt.Sprintf("page-%d", i), start, start.Add(30*time.Minute), []uuid.UUID{contactID}, nil)
+		}
+
+		// limit=1000 clamps to the hard max (100) — exercises the
+		// limit > maxLimit branch, the load-bearing "bounded maximum" facet.
+		w := doCalendarGet(router, "/api/v1/contacts/"+contactID.String()+"/events?limit=1000")
+		require.Equal(t, http.StatusOK, w.Code)
+		var clamped calendarEventsEnvelope
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &clamped))
+		assert.Len(t, clamped.Data, 100, "limit above the hard max must clamp to 100")
+
+		// No limit -> the sensible default of 20.
+		w = doCalendarGet(router, "/api/v1/contacts/"+contactID.String()+"/events")
+		require.Equal(t, http.StatusOK, w.Code)
+		var defaulted calendarEventsEnvelope
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &defaulted))
+		assert.Len(t, defaulted.Data, 20, "an omitted limit must default to 20")
+
+		// limit=5 -> honored exactly.
+		w = doCalendarGet(router, "/api/v1/contacts/"+contactID.String()+"/events?limit=5")
+		require.Equal(t, http.StatusOK, w.Code)
+		var limited calendarEventsEnvelope
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &limited))
+		assert.Len(t, limited.Data, 5, "an explicit limit under the max must be honored")
+	})
+
+	t.Run("MalformedContactID_Returns400", func(t *testing.T) {
+		ctx := context.Background()
+		router, _, _ := newCalendarAPITest(t, ctx)
+
+		w := doCalendarGet(router, "/api/v1/contacts/not-a-uuid/events")
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("RoutesAreReadOnly", func(t *testing.T) {
+		ctx := context.Background()
+		router, _, _ := newCalendarAPITest(t, ctx)
+
+		routes := router.Routes()
+		require.NotEmpty(t, routes, "the calendar router must register at least one route")
+		for _, route := range routes {
+			assert.Equal(t, http.MethodGet, route.Method, "calendar route %s %s must be GET-only — no endpoint creates, updates, or deletes an event", route.Method, route.Path)
+		}
+	})
+}
+
+// spec: CAL-023
+//
+// TestCalendarAPI_AttendeeRedaction proves event responses report an
+// attendee count but never leak raw attendee emails or display names.
+func TestCalendarAPI_AttendeeRedaction(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Response_ReportsAttendeeCount", func(t *testing.T) {
+		ctx := context.Background()
+		router, calendarRepo, seedContact := newCalendarAPITest(t, ctx)
+
+		ns := "cal-redact-count-" + uuid.NewString()[:8]
+		contactID := seedContact("Calendar Redaction Count Test Contact " + ns)
+		now := accelerated.GetCurrentTime()
+		attendees := []repository.Attendee{
+			{Email: "organizer-" + ns + "@example.test", DisplayName: "Organizer " + ns, Organizer: true, Self: true},
+			{Email: "attendee-" + ns + "@example.test", DisplayName: "Attendee Two " + ns},
+		}
+		seedEvent(t, ctx, calendarRepo, ns, "redact", now.Add(-time.Hour), now, []uuid.UUID{contactID}, attendees)
+
+		w := doCalendarGet(router, "/api/v1/contacts/"+contactID.String()+"/events")
+		require.Equal(t, http.StatusOK, w.Code)
+
+		var envelope calendarEventsEnvelope
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &envelope))
+		require.True(t, envelope.Success)
+		require.Len(t, envelope.Data, 1)
+		assert.Equal(t, 2, envelope.Data[0].AttendeeCount)
+	})
+
+	t.Run("Response_OmitsAttendeeAddresses", func(t *testing.T) {
+		ctx := context.Background()
+		router, calendarRepo, seedContact := newCalendarAPITest(t, ctx)
+
+		ns := "cal-redact-omit-" + uuid.NewString()[:8]
+		contactID := seedContact("Calendar Redaction Omit Test Contact " + ns)
+		now := accelerated.GetCurrentTime()
+		organizerEmail := "organizer-" + ns + "@example.test"
+		organizerName := "Organizer " + ns
+		attendeeEmail := "attendee-" + ns + "@example.test"
+		attendeeName := "Attendee Two " + ns
+		attendees := []repository.Attendee{
+			{Email: organizerEmail, DisplayName: organizerName, Organizer: true, Self: true},
+			{Email: attendeeEmail, DisplayName: attendeeName},
+		}
+		seedEvent(t, ctx, calendarRepo, ns, "redact", now.Add(-time.Hour), now, []uuid.UUID{contactID}, attendees)
+
+		w := doCalendarGet(router, "/api/v1/contacts/"+contactID.String()+"/events")
+		require.Equal(t, http.StatusOK, w.Code)
+
+		body := w.Body.String()
+		assert.NotContains(t, body, organizerEmail, "response must not leak the organizer's raw email")
+		assert.NotContains(t, body, organizerName, "response must not leak the organizer's display name")
+		assert.NotContains(t, body, attendeeEmail, "response must not leak the attendee's raw email")
+		assert.NotContains(t, body, attendeeName, "response must not leak the attendee's display name")
+	})
+}

--- a/spec/calendar.yaml
+++ b/spec/calendar.yaml
@@ -267,6 +267,7 @@ behaviors:
     when: a client requests events
     then:
       - a contact's events, a contact's upcoming events, and a global upcoming-events feed are readable
+      - the upcoming feeds exclude events that have already started
       - page size is clamped to a bounded maximum with a sensible default
       - a malformed contact id is rejected with a validation error (400)
       - no endpoint creates, updates, or deletes an event — all writes flow through sync


### PR DESCRIPTION
## What

PR2 of the Piece 2 · Track A arc (#380) — the second application of the `// spec:` test→behavior citation convention that landed in #596.

Adds `backend/tests/api/calendar_api_test.go`, a cited integration test suite for the read-only `CalendarHandler`:

- **`TestCalendarAPI_ReadEndpoints`** (`// spec: CAL-022`): contact events readable, upcoming feeds filter to future, global upcoming feed readable, pagination clamp/default/honored proven with 101 seeded events (`?limit=1000` → exactly 100, no limit → exactly 20, `?limit=5` → exactly 5), 400 on malformed contact id, and a structural `router.Routes()` assertion that every calendar route is GET-only.
- **`TestCalendarAPI_AttendeeRedaction`** (`// spec: CAL-023`): responses report `attendee_count` and never contain seeded attendee emails/names (presence proven via the count before absence is asserted, so the redaction check can't pass vacuously).

One spec edit (arc-sanctioned extend-in-place): CAL-022 gains the then-item "the upcoming feeds exclude events that have already started" — the suite proves this filtering contract and the then-items didn't previously enumerate it. `make spec-lint` OK.

## How

Per-subtest ephemeral DB clones (`newIsolatedRiverTestDB` inside each `t.Run`) so exact-count feed/pagination assertions are isolation-safe and order-independent; top-level `t.Parallel()`. Seeding via `CalendarEventRepository.Upsert` (no raw SQL); synthetic attendee data only.

## Verification

- `go test -tags integration_testdb ./tests/api/ -run TestCalendarAPI -race -count=10 -shuffle=on` → ok
- Dead-citation grep over the new file → empty (CAL-022/023 both `status: current`)
- Codex review (xhigh): round 1 `FINDINGS: P0=0 P1=0 P2=1 P3=0` RESULT=PASS (P2 applied)
- review-head: RESULT=PASS (0×P0/P1; both P2s applied in `99ab5ad`)