### PR TITLE
fix(hooks): gate pre-push on the pushing worktree, not hooksPath

### DIFF
--- a/.ai/rules/core.md
+++ b/.ai/rules/core.md
@@ -83,6 +83,7 @@ See [Request Flow Diagram](../guides/architecture.md#why-layered) for the full s
 | sqlc changed types after regeneration | Update repository to use `pgtype.X{Value: v, Valid: true}` wrappers |
 | Assuming all tables have `updated_at` | It's per-table opt-in (explicit column + `update_updated_at_column()` trigger); many tables lack it (e.g. `tag`, `interaction`, `reminder`). Check the table's migration before selecting or setting `updated_at` |
 | `git add -A` includes binaries | Review `git status` before commit, exclude `backend/crm-api` |
+| Pre-push hook push hangs then the SSH connection dies mid-run | The pre-push hook gates the PUSHING worktree's tree (not the `core.hooksPath` checkout's), and a long hook run can outlive GitHub's ~6-min idle SSH channel. Fix: set a local HTTPS pushurl once (`git config remote.origin.pushurl https://github.com/<owner>/<repo>.git` + `git config credential."https://github.com".helper '!gh auth git-credential'`), or per-push `git -c credential.helper='!gh auth git-credential' push https://github.com/<owner>/<repo>.git <branch>` |
 | Merging PRs with UI changes | Never merge UI PRs autonomously - wait for human review |
 | `git add path/[id]/file` fails | Use quotes: `git add "path/[id]/file"` (bash interprets brackets as globs) |
 | Fixing only one instance of a pattern | Search entire codebase and fix ALL instances to maintain consistency |

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -25,7 +25,20 @@
 # To bypass (not recommended): git push --no-verify
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# Git invokes hooks with cwd = the top of the PUSHING work tree (and GIT_DIR set
+# to that worktree's git dir), so the repo root to gate must come from git, not
+# from this file's location. core.hooksPath can point at a DIFFERENT checkout
+# (e.g. a shared hooks install shared across linked worktrees) whose tree is not
+# the content being pushed — deriving PROJECT_ROOT from SCRIPT_DIR would gate
+# that other checkout instead of the pushed one. Fall back to the hook-checkout
+# root only when invoked outside any repo (manual runs, e.g. sourcing this file
+# from an empty directory for testing).
+if PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+  PROJECT_ROOT_FROM_GIT=true
+else
+  PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+  PROJECT_ROOT_FROM_GIT=false
+fi
 
 CONFIG_FILE=".ai/pre-push.json"
 
@@ -525,6 +538,20 @@ set -e
 cd "$PROJECT_ROOT"
 
 if [[ ! -f "$CONFIG_FILE" ]]; then
+  # PROJECT_ROOT resolved via git but has no config: fail CLOSED, not open — a
+  # wrong cwd/GIT_DIR resolution must never silently skip checks (fail-open) nor
+  # silently re-root to the hook checkout (which would reintroduce the bug this
+  # hardening fixes). The script-derived fallback below is only reachable when
+  # git resolution itself failed (manual invocation outside any repo).
+  if [[ "$PROJECT_ROOT_FROM_GIT" == "true" ]]; then
+    echo "" >&2
+    echo "==============================================================" >&2
+    echo "FAILED: resolved project root $PROJECT_ROOT has no $CONFIG_FILE" >&2
+    echo "Refusing to gate a tree that is not the pushed content." >&2
+    echo "Check cwd/GIT_DIR, or bypass with --no-verify." >&2
+    echo "==============================================================" >&2
+    exit 1
+  fi
   echo "Warning: No $CONFIG_FILE found, skipping pre-push checks" >&2
   exit 0
 fi

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -28,7 +28,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Git invokes hooks with cwd = the top of the PUSHING work tree (and GIT_DIR set
 # to that worktree's git dir), so the repo root to gate must come from git, not
 # from this file's location. core.hooksPath can point at a DIFFERENT checkout
-# (e.g. a shared hooks install shared across linked worktrees) whose tree is not
+# (e.g. a hooks install shared across linked worktrees) whose tree is not
 # the content being pushed — deriving PROJECT_ROOT from SCRIPT_DIR would gate
 # that other checkout instead of the pushed one. Fall back to the hook-checkout
 # root only when invoked outside any repo (manual runs, e.g. sourcing this file
@@ -540,8 +540,8 @@ cd "$PROJECT_ROOT"
 if [[ ! -f "$CONFIG_FILE" ]]; then
   # PROJECT_ROOT resolved via git but has no config: fail CLOSED, not open — a
   # wrong cwd/GIT_DIR resolution must never silently skip checks (fail-open) nor
-  # silently re-root to the hook checkout (which would reintroduce the bug this
-  # hardening fixes). The script-derived fallback below is only reachable when
+  # silently re-root to the hook checkout (gating a different
+  # checkout's tree again). The script-derived fallback below is only reachable when
   # git resolution itself failed (manual invocation outside any repo).
   if [[ "$PROJECT_ROOT_FROM_GIT" == "true" ]]; then
     echo "" >&2

--- a/scripts/hooks/test/test-pre-push-phases.sh
+++ b/scripts/hooks/test/test-pre-push-phases.sh
@@ -121,4 +121,64 @@ assert_eq "lane runs every command (2nd failure fails lane)" "1" "$([[ "$(cat "$
 
 rm -rf "$tmpd"
 
+# --- D1: PROJECT_ROOT resolves to the PUSHING worktree, not the hook-file's
+# location. Simulates core.hooksPath pointing at a DIFFERENT checkout: copy the
+# hook OUTSIDE this repo, then source/run the copy under the cwd/GIT_DIR shapes
+# git actually uses. The mutation check (revert D1 locally) confirms (a) goes
+# red against the old script-location derivation.
+repo_root="$(pwd)"
+outside_dir=$(mktemp -d) || { echo "FAIL: mktemp -d failed"; exit 1; }
+mkdir -p "$outside_dir/hooks"
+cp scripts/hooks/pre-push "$outside_dir/hooks/pre-push"
+real_git_dir="$(git rev-parse --absolute-git-dir)"
+expected_root="$(git rev-parse --show-toplevel)"
+
+# (a) hooksPath-simulation, the actual bug shape: cwd = repo root, GIT_DIR
+# exported (exactly what git sets for a pre-push hook during a linked-worktree
+# push). PROJECT_ROOT must be the pushing root, NOT the copy's grandparent
+# (outside_dir) — which is what the old script-location derivation would yield.
+# (rc captured via `|| rc=$?`, NOT a bare trailing `$?`: the harness runs under
+# `set -e` from the earlier rc-aggregation section, so a `(...)` subshell that
+# exits nonzero as a bare simple command would abort the whole script before
+# assert_eq ever ran. `||` exempts the preceding command from -e.)
+a_rc=0
+(
+  cd "$repo_root" || exit 1
+  export GIT_DIR="$real_git_dir"
+  source "$outside_dir/hooks/pre-push"
+  [[ "$PROJECT_ROOT" == "$expected_root" ]]
+) || a_rc=$?
+assert_eq "hooksPath-sim (GIT_DIR set): PROJECT_ROOT == pushing worktree root" "0" "$a_rc"
+
+# (b) no-GIT_DIR manual invocation (discovery path): same copy, cwd = repo
+# root, GIT_DIR unset. Same assertion.
+b_rc=0
+(
+  cd "$repo_root" || exit 1
+  unset GIT_DIR
+  source "$outside_dir/hooks/pre-push"
+  [[ "$PROJECT_ROOT" == "$expected_root" ]]
+) || b_rc=$?
+assert_eq "no-GIT_DIR manual invocation: PROJECT_ROOT == pushing worktree root" "0" "$b_rc"
+
+# (c) missing-config hard fail-closed: cwd = an empty temp dir OUTSIDE any repo
+# tree, GIT_DIR exported (so --show-toplevel yields that config-less dir per
+# documented git behavior: cwd is treated as toplevel when GIT_WORK_TREE is
+# unset). RUN the copy (not source — the guard sits in the executed body) with
+# promotion-shaped stdin and assert exit 1 plus the "refusing to gate" message.
+# This pins D1's fail-closed guard: a wrong resolution must neither reach the
+# fail-open "no config -> skip checks" branch NOR silently re-root to the hook
+# checkout.
+config_less_dir=$(mktemp -d) || { echo "FAIL: mktemp -d failed"; exit 1; }
+c_rc=0
+c_out=$(
+  cd "$config_less_dir" || exit 1
+  export GIT_DIR="$real_git_dir"
+  printf 'refs/heads/feat/x a refs/heads/feat/x b\n' | bash "$outside_dir/hooks/pre-push" 2>&1
+) || c_rc=$?
+assert_eq "missing-config fail-closed: exit 1"          "1" "$c_rc"
+assert_eq "missing-config fail-closed: refusing message" "1" "$(grep -c 'Refusing to gate' <<<"$c_out")"
+
+rm -rf "$outside_dir" "$config_less_dir"
+
 [[ "$fail" -eq 0 ]] && { echo "ALL PASS (pre-push phases)"; exit 0; } || { echo "FAILURES (pre-push phases)"; exit 1; }

--- a/scripts/hooks/test/test-pre-push-phases.sh
+++ b/scripts/hooks/test/test-pre-push-phases.sh
@@ -165,16 +165,20 @@ assert_eq "no-GIT_DIR manual invocation: PROJECT_ROOT == pushing worktree root" 
 # tree, GIT_DIR exported (so --show-toplevel yields that config-less dir per
 # documented git behavior: cwd is treated as toplevel when GIT_WORK_TREE is
 # unset). RUN the copy (not source — the guard sits in the executed body) with
-# promotion-shaped stdin and assert exit 1 plus the "refusing to gate" message.
-# This pins D1's fail-closed guard: a wrong resolution must neither reach the
-# fail-open "no config -> skip checks" branch NOR silently re-root to the hook
-# checkout.
+# PROMOTION-SHAPED stdin (every ref targets refs/heads/main) and assert exit 1
+# plus the "refusing to gate" message. Promotion-shaped stdin (not a feature-
+# branch ref) is deliberate: it proves the missing-config guard fires BEFORE
+# the promotion-to-main skip check — a feature-branch ref would pass this
+# assertion even if a regression moved the guard below the skip, since that ref
+# never enters the skip branch either way. This pins D1's fail-closed guard: a
+# wrong resolution must neither reach the fail-open "no config -> skip checks"
+# branch NOR silently re-root to the hook checkout.
 config_less_dir=$(mktemp -d) || { echo "FAIL: mktemp -d failed"; exit 1; }
 c_rc=0
 c_out=$(
   cd "$config_less_dir" || exit 1
   export GIT_DIR="$real_git_dir"
-  printf 'refs/heads/feat/x a refs/heads/feat/x b\n' | bash "$outside_dir/hooks/pre-push" 2>&1
+  printf 'refs/heads/develop a refs/heads/main b\n' | bash "$outside_dir/hooks/pre-push" 2>&1
 ) || c_rc=$?
 assert_eq "missing-config fail-closed: exit 1"          "1" "$c_rc"
 assert_eq "missing-config fail-closed: refusing message" "1" "$(grep -c 'Refusing to gate' <<<"$c_out")"

--- a/scripts/hooks/test/test-pre-push-phases.sh
+++ b/scripts/hooks/test/test-pre-push-phases.sh
@@ -121,10 +121,10 @@ assert_eq "lane runs every command (2nd failure fails lane)" "1" "$([[ "$(cat "$
 
 rm -rf "$tmpd"
 
-# --- D1: PROJECT_ROOT resolves to the PUSHING worktree, not the hook-file's
+# --- PROJECT_ROOT resolves to the PUSHING worktree, not the hook-file's
 # location. Simulates core.hooksPath pointing at a DIFFERENT checkout: copy the
 # hook OUTSIDE this repo, then source/run the copy under the cwd/GIT_DIR shapes
-# git actually uses. The mutation check (revert D1 locally) confirms (a) goes
+# git actually uses. The mutation check (reverting the derivation locally) confirms (a) goes
 # red against the old script-location derivation.
 repo_root="$(pwd)"
 outside_dir=$(mktemp -d) || { echo "FAIL: mktemp -d failed"; exit 1; }
@@ -170,7 +170,7 @@ assert_eq "no-GIT_DIR manual invocation: PROJECT_ROOT == pushing worktree root" 
 # branch ref) is deliberate: it proves the missing-config guard fires BEFORE
 # the promotion-to-main skip check — a feature-branch ref would pass this
 # assertion even if a regression moved the guard below the skip, since that ref
-# never enters the skip branch either way. This pins D1's fail-closed guard: a
+# never enters the skip branch either way. This pins the fail-closed guard: a
 # wrong resolution must neither reach the fail-open "no config -> skip checks"
 # branch NOR silently re-root to the hook checkout.
 config_less_dir=$(mktemp -d) || { echo "FAIL: mktemp -d failed"; exit 1; }


### PR DESCRIPTION
Fixes the pre-push hook topology so the gate runs against the tree being pushed, not the checkout that happens to host the hook files.

## Problem

`core.hooksPath` can point at a different checkout than the one pushing (shared hooks across linked worktrees). The hook derived `PROJECT_ROOT` from its own file location, so for every linked-worktree push: the review-verdict gate read the hooksPath checkout's `.ai/log/review/`, forcing verdict mirroring; and all test phases ran against that checkout's tree — whatever branch it was parked on — instead of the pushed content. See #600's "Also observed" section.

## Fix

- Derive `PROJECT_ROOT` from the pushing worktree via `git rev-parse --show-toplevel` (runs before `set -e`; behavior under `GIT_DIR` verified empirically and pinned in the guard test).
- Fail CLOSED when the git-resolved root lacks `.ai/pre-push.json`: a wrong resolution must neither silently skip checks nor silently re-root to the hook checkout. The script-location fallback remains only for manual invocation outside any repo.
- No-op for main-checkout pushes (hooksPath checkout IS the pushing checkout) and for CI (which doesn't run this hook).

## Tests

- Three new guard-test sub-cases in `scripts/hooks/test/test-pre-push-phases.sh` (31 assertions total): pushing-worktree resolution under the cwd/`GIT_DIR` shapes git actually uses, the fail-closed guard (promotion-shaped stdin proves guard-ordering vs the promotion skip), and mutation checks verifying each pin goes red against the old derivation.
- Both bash guard suites green; `make test-unit` green. No Go/SQL/frontend files touched.

Also documents the SSH-idle push-death gotcha (long hook outlives GitHub's ~6-min idle window) + the HTTPS `pushurl` recipe in `.ai/rules/core.md`.

Part of the autonomous-push-hardening arc (#600, #603); siblings: fd-leak fix and reaper-flake fix PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDsCf4fuRWyhsgv12jZM9g