### PR TITLE
fix(scripts): close instance-lock fd in spawned postmaster

### DIFF
--- a/scripts/test/smoke-worktree-test-pg.sh
+++ b/scripts/test/smoke-worktree-test-pg.sh
@@ -19,6 +19,12 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 RESOLVER="$REPO_ROOT/scripts/worktree-test-pg.sh"
 REQUIRED="${CRM_PG_SMOKE_REQUIRED:-0}"
 
+# Bound every lock this smoke takes: with the #600 fix all locks acquire
+# instantly, so this is invisible on a healthy tree; a regression that re-leaks
+# fd 200 into the postmaster would otherwise HANG here forever — instead it fails
+# LOUD after the timeout. Overridable, defaults to a generous 60s.
+export CRM_WORKTREE_PG_LOCK_TIMEOUT="${CRM_WORKTREE_PG_LOCK_TIMEOUT:-60}"
+
 fail=0
 ok()   { echo "ok: $1"; }
 bad()  { echo "FAIL: $1"; fail=1; }
@@ -120,6 +126,36 @@ done
 # real TestFindSimilarContactsBatch_Integration run in Phase C below.
 sim=$( "${PSQL[@]}" -c "SELECT (similarity('Jonathan','Jonathon') > 0.4);" | tr -d '[:space:]' )
 [ "$sim" = "t" ] && ok "pg_trgm similarity('Jonathan','Jonathon')>0.4 (collation-correct scoring)" || bad "trigram probe returned '$sim'"
+
+# --- #600 regression: the REAL postmaster must NOT have inherited fd 200 -----
+# A leaked fd 200 keeps the per-instance flock held for the postmaster's whole
+# life, wedging every later ensure/stop/teardown/reap. This is the exact leak
+# signature from the issue (/proc/<postmaster>/fd/200 -> the instance lock). The
+# shim suite proves this with fakes one inheritance level deep; this proves it
+# against a real daemonized postmaster. Linux-only (/proc); a clean skip on macOS.
+note "#600: real postmaster did not inherit the instance-lock fd"
+if [ -d /proc ]; then
+  DD_B=$(run_in_wt bash "$RESOLVER" status | grep -oE 'datadir=[^ ]+' | sed 's/datadir=//')
+  LOCKPATH_B="$(dirname "$DD_B")/lock"
+  PMPID_B=$(head -1 "$DD_B/postmaster.pid" 2>/dev/null || true)
+  leaked=0
+  if [ -n "$PMPID_B" ] && [ -d "/proc/$PMPID_B/fd" ]; then
+    for fdlink in /proc/"$PMPID_B"/fd/*; do
+      [ "$(readlink "$fdlink" 2>/dev/null || true)" = "$LOCKPATH_B" ] && leaked=1
+    done
+  fi
+  [ "$leaked" -eq 0 ] && ok "#600: postmaster (pid $PMPID_B) did not inherit the instance-lock fd" \
+    || bad "#600: postmaster leaked the instance-lock fd ($LOCKPATH_B) — the wedge bug is back"
+else
+  note "no /proc; skipping the postmaster fd-leak check (macOS)"
+fi
+
+# A second ensure must complete under the (bounded) lock timeout — the direct
+# functional proof that the first ensure did not wedge the lock.
+note "#600: a second ensure returns under the lock timeout"
+run_in_wt env CRM_WORKTREE_PG=strict bash "$RESOLVER" ensure \
+  && ok "#600: second ensure returned under the lock timeout (lock not wedged)" \
+  || bad "#600: second ensure did not return under the lock timeout (lock wedged?)"
 
 # ---------------------------------------------------------------------------
 # Phase C: end-to-end through the REAL Make recipe (cold-first-run ordering).

--- a/scripts/test/test-worktree-test-pg.sh
+++ b/scripts/test/test-worktree-test-pg.sh
@@ -479,7 +479,7 @@ if command -v flock >/dev/null 2>&1; then
   # 20. Lock timeout, RUNNING branch: warm a real (fake) instance, hold its lock,
   # ensure with a 1s timeout. Non-strict proceeds against the running instance
   # (warn says "server is up", url still emits the instance URL — NOT a false
-  # fallback claim); strict fails. Pins D3's routing for both timeout branches.
+  # fallback claim); strict fails. Exercises both mode routings of this branch.
   d=$(make_env | tail -1); set_linked "$d" lockrun
   run "$d" ensure >/dev/null 2>&1                       # cold -> warm
   id=$(run "$d" status | grep -oE 'id=[0-9a-f]+' | sed 's/id=//')
@@ -502,13 +502,27 @@ else
   ok "flock absent -> skipping lock-timeout branch tests (mkdir backend ceiling covered elsewhere)"
 fi
 
-# 21. Knob validation: an invalid CRM_WORKTREE_PG_LOCK_TIMEOUT warns and falls
-# back to the default (ensure still provisions, exits 0).
+# 21. Knob validation. Every INVALID form (non-numeric, empty-but-set, zero,
+# negative) warns on a side-effecting subcommand and falls back to the default
+# (ensure still provisions, exits 0). A VALID positive integer is accepted
+# silently. And the render-safe `url` NEVER warns, even for an invalid knob.
+for badval in banana "" 0 -5; do
+  d=$(make_env | tail -1); set_linked "$d"
+  CRM_WORKTREE_PG_LOCK_TIMEOUT="$badval" run "$d" ensure 2>"$d/err"; rc=$?
+  label="'$badval'"
+  [ "$rc" -eq 0 ] && ok "invalid knob $label: ensure exits 0" || bad "invalid knob $label exit=$rc"
+  grep -q '^pg_ctl .*start' "$d/calls" && ok "invalid knob $label: still provisioned (default 120s)" || bad "invalid knob $label: not provisioned"
+  grep -qi 'invalid CRM_WORKTREE_PG_LOCK_TIMEOUT' "$d/err" && ok "invalid knob $label: loud warning" || bad "invalid knob $label: no warning ($(cat "$d/err"))"
+done
+# Valid positive integer -> accepted, NO warning.
 d=$(make_env | tail -1); set_linked "$d"
-CRM_WORKTREE_PG_LOCK_TIMEOUT=banana run "$d" ensure 2>"$d/err"; rc=$?
-[ "$rc" -eq 0 ] && ok "invalid lock-timeout knob: ensure exits 0" || bad "invalid lock-timeout knob exit=$rc"
-grep -q '^pg_ctl .*start' "$d/calls" && ok "invalid lock-timeout knob: instance still provisioned (default 120s)" || bad "invalid knob: instance not provisioned"
-grep -qi 'invalid CRM_WORKTREE_PG_LOCK_TIMEOUT' "$d/err" && ok "invalid lock-timeout knob: loud warning" || bad "invalid knob: no warning ($(cat "$d/err"))"
+CRM_WORKTREE_PG_LOCK_TIMEOUT=30 run "$d" ensure 2>"$d/err"; rc=$?
+[ "$rc" -eq 0 ] && ok "valid lock-timeout knob (30): ensure exits 0" || bad "valid knob exit=$rc"
+! grep -qi 'invalid CRM_WORKTREE_PG_LOCK_TIMEOUT' "$d/err" && ok "valid lock-timeout knob: no warning" || bad "valid knob warned: $(cat "$d/err")"
+# render-safe `url` stays SILENT even with an invalid knob (url NEVER warns).
+d=$(make_env | tail -1); set_linked "$d"
+CRM_WORKTREE_PG_LOCK_TIMEOUT=banana run "$d" url >/dev/null 2>"$d/err"
+[ ! -s "$d/err" ] && ok "invalid knob: url still silent on stderr (render-safe)" || bad "invalid knob: url wrote stderr: $(cat "$d/err")"
 
 # 17. Test-hook counter: increments once per invocation
 d=$(make_env | tail -1); set_linked "$d"

--- a/scripts/test/test-worktree-test-pg.sh
+++ b/scripts/test/test-worktree-test-pg.sh
@@ -89,7 +89,15 @@ port=\$(echo "\$opts" | grep -oE -- '-p [0-9]+' | grep -oE '[0-9]+')
 case "\$mode" in
   start)
     [ -n "\$dd" ] && { echo "\${FAKE_PG_PID:-\$\$}" > "\$dd/postmaster.pid"; [ -n "\$port" ] && echo "\$port" > "\$dd/.fakeport"; }
-    [ -n "\$port" ] && echo "\$port" >> "$d/port_busy" ;;
+    [ -n "\$port" ] && echo "\$port" >> "$d/port_busy"
+    # Optional (\$d/pgctl_spawn_child): mimic daemonization ONE level deep — the
+    # exact pg_ctl -> postmaster edge. Background a child that (a) records, in ITS
+    # OWN context, whether fd 200 is writable (open) and (b) lingers, so a LEAKED
+    # fd 200 would keep the instance lock held for the child's whole life. The
+    # single quotes are literal in this heredoc; only \$d expands (bakes the path).
+    if [ -f "$d/pgctl_spawn_child" ]; then
+      bash -c 'if { true >&200; } 2>/dev/null; then echo open; else echo closed; fi > "$d/fd200"; sleep 8' &
+    fi ;;
   stop)
     [ -n "\$dd" ] && rm -f "\$dd/postmaster.pid" 2>/dev/null
     [ -n "\$port" ] && { grep -vx "\$port" "$d/port_busy" 2>/dev/null > "$d/port_busy.tmp" || true; mv "$d/port_busy.tmp" "$d/port_busy" 2>/dev/null || true; } ;;
@@ -425,6 +433,82 @@ grep -qi 'could not stop' "$d/err" && ok "16b: reap warned about the un-stoppabl
 rm -f "$d/pgctl_fail"                         # now stoppable
 run "$d" reap >/dev/null 2>&1
 [ ! -d "$dead" ] && ok "16b: reap prunes the dead instance once stoppable again" || bad "16b: dead instance left after recoverable reap"
+
+# 18. fd 200 NOT leaked into the daemonized postmaster (#600). The fake pg_ctl
+# backgrounds a child one level deep (the pg_ctl -> postmaster edge) that records
+# whether fd 200 is open in ITS OWN context. With the `200>&-` fix the child sees
+# fd 200 CLOSED; a regression (no close) would leak the with_lock fd into it.
+d=$(make_env | tail -1); set_linked "$d"
+touch "$d/pgctl_spawn_child"
+run "$d" ensure >/dev/null 2>&1
+for _ in 1 2 3 4 5 6 7 8 9 10; do [ -s "$d/fd200" ] && break; sleep 0.2; done
+[ "$(cat "$d/fd200" 2>/dev/null)" = "closed" ] && ok "fd 200 closed in the daemonized child (no lock leak)" \
+  || bad "fd 200 leaked into the daemonized child: '$(cat "$d/fd200" 2>/dev/null)'"
+
+# 18b. Functional lock-liveness pin (the actual #600 symptom): with that child
+# STILL alive (sleeping), a second lock-taking command must acquire the lock
+# promptly. If fd 200 leaked into the child, `stop`'s flock -w would expire and
+# with_lock returns 124 (non-zero). A low timeout keeps the regression fast.
+CRM_WORKTREE_PG_LOCK_TIMEOUT=4 run "$d" stop 2>"$d/err"; rc=$?
+[ "$rc" -eq 0 ] && ok "instance lock live after the daemonized-child spawn (stop acquired promptly)" \
+  || bad "stop rc=$rc after child spawn — fd 200 leaked and wedged the lock"
+
+# 19. Lock timeout, NOT-running branch: hold an UNPROVISIONED worktree's instance
+# lock from the background, then ensure with a 1s timeout. Non-strict fails LOUD
+# (naming the direct pg_ctl recovery) but exits 0 with a genuine shared-instance
+# fallback (url empty); strict exits non-zero. flock-only (the mkdir backend's
+# ceiling is already covered and can't be held this precisely from a subshell).
+if command -v flock >/dev/null 2>&1; then
+  d=$(make_env | tail -1); set_linked "$d" locknone
+  id=$(run "$d" status | grep -oE 'id=[0-9a-f]+' | sed 's/id=//')
+  lockdir="$d/pghome/$id"; mkdir -p "$lockdir"; lockfile="$lockdir/lock"
+  ( flock 200; sleep 2 ) 200>"$lockfile" & holder=$!
+  sleep 0.3
+  CRM_WORKTREE_PG_LOCK_TIMEOUT=1 run "$d" ensure 2>"$d/err"; rc=$?
+  [ "$rc" -eq 0 ] && ok "lock-timeout not-running non-strict: exit 0" || bad "lock-timeout not-running non-strict exit=$rc"
+  grep -qi 'pg_ctl -D' "$d/err" && ok "lock-timeout not-running: loud warning names pg_ctl recovery" || bad "lock-timeout not-running: no pg_ctl recovery hint ($(cat "$d/err"))"
+  [ -z "$(run "$d" url)" ] && ok "lock-timeout not-running: url empty (genuine shared fallback)" || bad "lock-timeout not-running: url not empty"
+  wait "$holder" 2>/dev/null || true
+  # strict: same setup -> non-zero exit
+  ( flock 200; sleep 2 ) 200>"$lockfile" & holder=$!
+  sleep 0.3
+  CRM_WORKTREE_PG_LOCK_TIMEOUT=1 CRM_WORKTREE_PG=strict run "$d" ensure 2>/dev/null; rc=$?
+  [ "$rc" -ne 0 ] && ok "lock-timeout not-running strict: exit non-zero ($rc)" || bad "lock-timeout not-running strict: exit 0"
+  wait "$holder" 2>/dev/null || true
+
+  # 20. Lock timeout, RUNNING branch: warm a real (fake) instance, hold its lock,
+  # ensure with a 1s timeout. Non-strict proceeds against the running instance
+  # (warn says "server is up", url still emits the instance URL — NOT a false
+  # fallback claim); strict fails. Pins D3's routing for both timeout branches.
+  d=$(make_env | tail -1); set_linked "$d" lockrun
+  run "$d" ensure >/dev/null 2>&1                       # cold -> warm
+  id=$(run "$d" status | grep -oE 'id=[0-9a-f]+' | sed 's/id=//')
+  runurl=$(run "$d" url)
+  lockfile="$d/pghome/$id/lock"
+  ( flock 200; sleep 2 ) 200>"$lockfile" & holder=$!
+  sleep 0.3
+  CRM_WORKTREE_PG_LOCK_TIMEOUT=1 run "$d" ensure 2>"$d/err"; rc=$?
+  [ "$rc" -eq 0 ] && ok "lock-timeout running non-strict: exit 0" || bad "lock-timeout running non-strict exit=$rc"
+  grep -qi 'server is up' "$d/err" && ok "lock-timeout running: warn says the server is up" || bad "lock-timeout running: no 'server is up' warning ($(cat "$d/err"))"
+  [ "$(run "$d" url)" = "$runurl" ] && ok "lock-timeout running: url still emits the instance (no false fallback)" || bad "lock-timeout running: url changed/empty"
+  wait "$holder" 2>/dev/null || true
+  # strict: same setup -> non-zero exit
+  ( flock 200; sleep 2 ) 200>"$lockfile" & holder=$!
+  sleep 0.3
+  CRM_WORKTREE_PG_LOCK_TIMEOUT=1 CRM_WORKTREE_PG=strict run "$d" ensure 2>/dev/null; rc=$?
+  [ "$rc" -ne 0 ] && ok "lock-timeout running strict: exit non-zero ($rc)" || bad "lock-timeout running strict: exit 0"
+  wait "$holder" 2>/dev/null || true
+else
+  ok "flock absent -> skipping lock-timeout branch tests (mkdir backend ceiling covered elsewhere)"
+fi
+
+# 21. Knob validation: an invalid CRM_WORKTREE_PG_LOCK_TIMEOUT warns and falls
+# back to the default (ensure still provisions, exits 0).
+d=$(make_env | tail -1); set_linked "$d"
+CRM_WORKTREE_PG_LOCK_TIMEOUT=banana run "$d" ensure 2>"$d/err"; rc=$?
+[ "$rc" -eq 0 ] && ok "invalid lock-timeout knob: ensure exits 0" || bad "invalid lock-timeout knob exit=$rc"
+grep -q '^pg_ctl .*start' "$d/calls" && ok "invalid lock-timeout knob: instance still provisioned (default 120s)" || bad "invalid knob: instance not provisioned"
+grep -qi 'invalid CRM_WORKTREE_PG_LOCK_TIMEOUT' "$d/err" && ok "invalid lock-timeout knob: loud warning" || bad "invalid knob: no warning ($(cat "$d/err"))"
 
 # 17. Test-hook counter: increments once per invocation
 d=$(make_env | tail -1); set_linked "$d"

--- a/scripts/worktree-test-pg.sh
+++ b/scripts/worktree-test-pg.sh
@@ -40,6 +40,13 @@
 #                               real pg16 install on the host).
 #   CRM_WORKTREE_PG_BASE_PORT   port seed base (default 5440).
 #   CRM_WORKTREE_PG_PORT_SPAN   port seed span (default 200).
+#   CRM_WORKTREE_PG_LOCK_TIMEOUT  seconds to wait for a per-instance lock before
+#                               failing LOUD instead of blocking forever (default
+#                               120). Positive integer; empty/zero/negative/non-
+#                               numeric values warn and fall back to 120. Mainly a
+#                               test hook. On timeout `ensure` degrades per mode
+#                               (proceeds against a running instance, else falls
+#                               back to shared); stop/teardown/reap fail loud.
 set -euo pipefail
 
 # --- Test hook: count real invocations (render-guard laziness assertion) ----
@@ -271,8 +278,36 @@ instance_running() {
 # callback so both backends share one call shape.
 LOCK_STALE_SECS=120
 
+# Seconds to wait for a per-instance lock before failing LOUD (rc 124) instead
+# of blocking forever. Resolved ONCE, at top-level scope (NOT local to with_lock)
+# so both lock backends AND cmd_ensure's rc-124 messages can reference it without
+# tripping `set -u`. rc 124 is the timeout sentinel (matches timeout(1)); the
+# locked callbacks (_ensure_locked/_stop_locked/_teardown_locked/_reap_one) return
+# only 0/1 today, so 124 can't collide — a future callback returning 124 would be
+# misread as a lock timeout.
+LOCK_TIMEOUT_SECS=120
+case "${CRM_WORKTREE_PG_LOCK_TIMEOUT:-}" in
+  '') ;;                                       # unset/empty -> default
+  *[!0-9]*)                                    # negative / non-numeric
+    warn "ignoring invalid CRM_WORKTREE_PG_LOCK_TIMEOUT='${CRM_WORKTREE_PG_LOCK_TIMEOUT}' (want a positive integer); using ${LOCK_TIMEOUT_SECS}s" ;;
+  *)                                           # all-digits, non-empty
+    if [ "$CRM_WORKTREE_PG_LOCK_TIMEOUT" -gt 0 ]; then
+      LOCK_TIMEOUT_SECS="$CRM_WORKTREE_PG_LOCK_TIMEOUT"
+    else
+      warn "ignoring invalid CRM_WORKTREE_PG_LOCK_TIMEOUT='${CRM_WORKTREE_PG_LOCK_TIMEOUT}' (want a positive integer); using ${LOCK_TIMEOUT_SECS}s"
+    fi ;;
+esac
+
+# Loud, actionable warning shared by both lock backends on a wait timeout. Names
+# the DIRECT pg_ctl recovery: stop/teardown/reap all contend on this same lock,
+# so they cannot recover a leaked one.
+_lock_timeout_warn() {
+  warn "timed out after ${LOCK_TIMEOUT_SECS}s waiting for lock $1; if a per-worktree postmaster leaked this lock, stop it DIRECTLY: pg_ctl -D <datadir> -m fast stop (make test-pg-teardown/stop would block on this same lock)."
+}
+
 with_lock() {
-  # with_lock <lockpath> <command...>
+  # with_lock <lockpath> <command...>. Returns the callback's rc, or 124 if the
+  # lock could not be acquired within LOCK_TIMEOUT_SECS (fail loud, never wedge).
   local lockpath="$1"; shift
   mkdir -p "$(dirname "$lockpath")"
   if command -v flock >/dev/null 2>&1; then
@@ -280,8 +315,12 @@ with_lock() {
     # bash 3.2 — macOS's default bash — where it errors `exec: {fd}: not found`).
     local rc=0
     {
-      flock 200
-      "$@" || rc=$?
+      if flock -w "$LOCK_TIMEOUT_SECS" 200; then
+        "$@" || rc=$?
+      else
+        _lock_timeout_warn "$lockpath"
+        rc=124
+      fi
     } 200>"$lockpath"
     return $rc
   fi
@@ -303,9 +342,10 @@ with_lock() {
     fi
     sleep 0.2
     waited=$((waited + 1))
-    if [ "$waited" -gt 600 ]; then  # ~120s ceiling
-      warn "timed out acquiring lock $lockpath"
-      return 1
+    # Ceiling derived from the same knob: 0.2s steps => 5 iterations/second.
+    if [ "$waited" -gt $((LOCK_TIMEOUT_SECS * 5)) ]; then
+      _lock_timeout_warn "$lockpath"
+      return 124
     fi
   done
   echo "$$" > "$dir/pid" 2>/dev/null || true
@@ -441,7 +481,33 @@ cmd_ensure() {
 
   local id; id=$(worktree_id) || { _ensure_fail "$mode" "could not derive worktree id"; return $?; }
   # Serialize same-worktree ensure/stop/teardown under the per-worktree lock.
-  with_lock "$(instance_dir "$id")/lock" _ensure_locked "$id" "$mode"
+  # Capture rc (|| rc=$? keeps set -e from aborting on a non-zero return) so a
+  # lock timeout (124) maps to an HONEST outcome instead of hard-failing the
+  # Makefile ensure prereq even in non-strict mode.
+  local rc=0
+  with_lock "$(instance_dir "$id")/lock" _ensure_locked "$id" "$mode" || rc=$?
+  if [ "$rc" -eq 124 ]; then
+    if instance_running "$id"; then
+      # Lock busy but the server is up and serving. url reads meta lock-free and
+      # emits this instance's URL regardless, so the only skipped work is the
+      # idempotent password reconcile (a stale password surfaces as an auth
+      # failure in the tests, not silently). NON-STRICT: proceed against it.
+      # STRICT: fail — an expired wait on a running instance signals a leaked
+      # lock or an abnormally long sibling ensure, both worth failing over.
+      # Mode-specific wording so strict stderr does not claim "proceeding".
+      if [ "$mode" = strict ]; then
+        _ensure_fail "$mode" "instance lock busy after ${LOCK_TIMEOUT_SECS}s with the server up; strict mode fails rather than proceed unreconciled. If this repeats: pg_ctl -D $(data_dir "$id") -m fast stop"
+      else
+        _ensure_fail "$mode" "instance lock busy after ${LOCK_TIMEOUT_SECS}s but the server is up; proceeding against it. If this repeats: pg_ctl -D $(data_dir "$id") -m fast stop"
+      fi
+      return $?
+    fi
+    # Not running: the fallback claim is genuinely true — url emits nothing and
+    # the Makefile falls back to the shared instance.
+    _ensure_fail "$mode" "timed out waiting for the instance lock and no server is running; falling back to the shared instance. Recover: pg_ctl -D $(data_dir "$id") -m fast stop (make test-pg-teardown would block on the same lock)."
+    return $?
+  fi
+  return $rc
 }
 
 _ensure_locked() {
@@ -519,9 +585,15 @@ _ensure_locked() {
 
   local logf sockdir; logf=$(log_file "$id"); sockdir=$(socket_dir "$id")
   mkdir -p "$sockdir"
+  # Close fd 200 (the per-instance lock held by the enclosing with_lock) for
+  # pg_ctl and, crucially, for the postmaster it daemonizes. flock locks live on
+  # the OPEN FILE DESCRIPTION, so a postmaster that inherited fd 200 would hold
+  # this instance's lock for its ENTIRE lifetime — wedging every later ensure/
+  # stop/teardown/reap on that instance. `200>&-` closes it only for this child;
+  # the shell's own fd 200 (the lock holder) is untouched.
   if ! "$bindir/pg_ctl" -D "$datadir" -w -t 30 \
       -o "-p $port -c max_connections=$MAX_CONNECTIONS -c listen_addresses=127.0.0.1 -c unix_socket_directories=$sockdir" \
-      -l "$logf" start >/dev/null 2>&1; then
+      -l "$logf" start >/dev/null 2>&1 200>&-; then
     warn "pg_ctl start failed on port $port (see $logf)"
     clear_meta_claim "$id"   # failed-start cleanup: release the port claim
     _ensure_fail "$mode" "Postgres failed to start. Falling back to the shared instance."
@@ -747,8 +819,10 @@ EOF
     esac
     # Dead worktree: stop (if running) + remove the data dir, serialized under
     # the per-worktree lock (same as ensure/stop/teardown). Operates ONLY under
-    # $home — never :5432, never Docker.
-    with_lock "$(instance_dir "$id")/lock" _reap_one "$id" "$bindir"
+    # $home — never :5432, never Docker. Guard with `|| true`: under set -e a
+    # non-zero with_lock (e.g. a 124 lock timeout on one wedged instance) would
+    # abort the loop and strand the reap of every remaining instance.
+    with_lock "$(instance_dir "$id")/lock" _reap_one "$id" "$bindir" || true
   done
   shopt -u nullglob
 }

--- a/scripts/worktree-test-pg.sh
+++ b/scripts/worktree-test-pg.sh
@@ -285,18 +285,25 @@ LOCK_STALE_SECS=120
 # locked callbacks (_ensure_locked/_stop_locked/_teardown_locked/_reap_one) return
 # only 0/1 today, so 124 can't collide — a future callback returning 124 would be
 # misread as a lock timeout.
+# Resolve the VALUE here (silently) so it is ready before any dispatch; the
+# invalid-value WARNING is deferred to main() and emitted only for side-effecting
+# subcommands, so `url`/`active`/`port`/`status` stay silent (the render-safe
+# `url` contract is "NEVER warns"). An empty-but-SET value is invalid (distinct
+# from unset, which is a plain default).
 LOCK_TIMEOUT_SECS=120
-case "${CRM_WORKTREE_PG_LOCK_TIMEOUT:-}" in
-  '') ;;                                       # unset/empty -> default
-  *[!0-9]*)                                    # negative / non-numeric
-    warn "ignoring invalid CRM_WORKTREE_PG_LOCK_TIMEOUT='${CRM_WORKTREE_PG_LOCK_TIMEOUT}' (want a positive integer); using ${LOCK_TIMEOUT_SECS}s" ;;
-  *)                                           # all-digits, non-empty
-    if [ "$CRM_WORKTREE_PG_LOCK_TIMEOUT" -gt 0 ]; then
-      LOCK_TIMEOUT_SECS="$CRM_WORKTREE_PG_LOCK_TIMEOUT"
-    else
-      warn "ignoring invalid CRM_WORKTREE_PG_LOCK_TIMEOUT='${CRM_WORKTREE_PG_LOCK_TIMEOUT}' (want a positive integer); using ${LOCK_TIMEOUT_SECS}s"
-    fi ;;
-esac
+LOCK_TIMEOUT_KNOB_INVALID=""                   # "1" when the knob was set invalid
+if [ "${CRM_WORKTREE_PG_LOCK_TIMEOUT+set}" = set ]; then
+  case "$CRM_WORKTREE_PG_LOCK_TIMEOUT" in
+    ''|*[!0-9]*)                               # empty / negative / non-numeric
+      LOCK_TIMEOUT_KNOB_INVALID=1 ;;
+    *)                                         # all-digits, non-empty
+      if [ "$CRM_WORKTREE_PG_LOCK_TIMEOUT" -gt 0 ]; then
+        LOCK_TIMEOUT_SECS="$CRM_WORKTREE_PG_LOCK_TIMEOUT"
+      else                                     # zero
+        LOCK_TIMEOUT_KNOB_INVALID=1
+      fi ;;
+  esac
+fi
 
 # Loud, actionable warning shared by both lock backends on a wait timeout. Names
 # the DIRECT pg_ctl recovery: stop/teardown/reap all contend on this same lock,
@@ -866,6 +873,13 @@ cmd_port() {
 # ===========================================================================
 main() {
   local sub="${1:-}"
+  # Warn about an invalid lock-timeout knob only for side-effecting subcommands;
+  # the render-safe read-only ones (url/active/port/status) must stay silent.
+  case "$sub" in
+    ensure|stop|teardown|reap)
+      [ -n "$LOCK_TIMEOUT_KNOB_INVALID" ] && \
+        warn "ignoring invalid CRM_WORKTREE_PG_LOCK_TIMEOUT='${CRM_WORKTREE_PG_LOCK_TIMEOUT:-}' (want a positive integer); using ${LOCK_TIMEOUT_SECS}s" ;;
+  esac
   case "$sub" in
     url)      cmd_url ;;
     active)   cmd_active ;;


### PR DESCRIPTION
Fixes #600.

## Problem

`worktree-test-pg.sh ensure` holds the per-instance lock on fd 200 while spawning the postmaster via `pg_ctl start`. The daemonized postmaster inherits the fd, and since flock locks belong to the open file description, the exclusive lock stays held for the postmaster's entire lifetime. Every later `ensure` needing that instance's lock blocks forever — observed as hook-gated pushes hanging until GitHub closed the idle SSH connection.

## Fix

- Close fd 200 in the spawned server (`200>&-` on the single `pg_ctl start` site — audited: it is the only long-lived child spawned under any lock section; initdb/psql/pg_ctl-stop are all short-lived).
- Defense-in-depth: the lock acquisition now uses a bounded `flock -w` (default 120s, `CRM_WORKTREE_PG_LOCK_TIMEOUT` knob, validated) so any future fd leak fails loud instead of wedging pushes forever. Timeout handling follows the shim's honest-outcome contract per branch: instance running → proceed against it with a warning (non-strict) / fail (strict); instance not running → genuine shared-:5432 fallback. The reap loop survives one wedged instance instead of aborting.

## Tests

- New shim-suite cases (60 assertions total): fd-200 daemonized-child pin, lock-liveness pin, both timeout branches, knob validation. Regression confirmed both directions — reverting `200>&-` fails the new tests.
- Real-cluster proof: `make test-pg-smoke` green including the literal #600 leak-signature assertions (`/proc/<pid>/fd` of the daemonized postmaster contains no link to the instance lock; a second ensure returns under the lock bound).
- Render guard green (no Makefile change; forced-shared/CI render byte-identical).

Part of the autonomous-push-hardening arc (#600, #603); siblings: #609 (hook topology) and the reaper-flake fix PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDsCf4fuRWyhsgv12jZM9g