### PR TITLE
fix(testdb): wait for template backends to drain before reap

### DIFF
--- a/backend/internal/testdb/testdb_reaper_integration_test.go
+++ b/backend/internal/testdb/testdb_reaper_integration_test.go
@@ -122,6 +122,26 @@ func createSyntheticTemplate(t *testing.T, ctx context.Context, admin *pgx.Conn,
 	}
 }
 
+// waitForZeroBackends waits (bounded) until pg_stat_database reports no
+// backends on name — client disconnects release backends asynchronously, and
+// under parallel-suite load the lag is long enough to race reapTemplates's
+// open-backend skip. Fixed attempt count, no time.Now() (core rule #1).
+func waitForZeroBackends(t *testing.T, ctx context.Context, admin *pgx.Conn, name string) {
+	t.Helper()
+	const maxAttempts = 50 // ~5s total at 100ms between attempts
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		n, err := templateActiveBackends(ctx, admin, name)
+		if err != nil {
+			t.Fatalf("templateActiveBackends(%q): %v", name, err)
+		}
+		if n == 0 {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("backends on %q did not reach zero within %d attempts", name, maxAttempts)
+}
+
 func mustOID(t *testing.T, ctx context.Context, admin *pgx.Conn, name string) uint32 {
 	t.Helper()
 	oid, ok, err := databaseOID(ctx, admin, name)
@@ -299,6 +319,7 @@ func TestTestdbReaperSweepsStaleTemplate(t *testing.T) {
 
 	_, hash, templateName := syntheticMigDir(t)
 	createSyntheticTemplate(t, ctx, admin, baseURL, templateName, hash)
+	waitForZeroBackends(t, ctx, admin, templateName)
 
 	dropped, err := reapTemplates(ctx, admin, []string{templateName}, "")
 	if err != nil {
@@ -328,6 +349,7 @@ func TestTestdbReaperBlocksOnAdvisoryLock(t *testing.T) {
 
 	_, hash, templateName := syntheticMigDir(t)
 	createSyntheticTemplate(t, ctx, admin, baseURL, templateName, hash)
+	waitForZeroBackends(t, ctx, admin, templateName)
 
 	// Three distinct connections: `holder` holds the lock, `reaperConn` runs the
 	// blocked reapTemplates in a goroutine, and `admin` stays free for the main


### PR DESCRIPTION
Fixes #603.

## Problem

`TestTestdbReaperSweepsStaleTemplate` flakes under the pre-push hook's parallel run: PostgreSQL backends linger briefly after client disconnect (slower under load), so the reaper's open-backend guard — working as designed — skips the test's own synthetic stale template, and the test's `dropped == 1` assertion fails. The same latent race exists in `TestTestdbReaperBlocksOnAdvisoryLock`.

## Fix

Adds a `waitForZeroBackends` helper that polls `templateActiveBackends` — the exact counter the reaper's skip guard reads (no semantic gap between what the wait observes and what reap checks) — with a fixed 50×100ms budget, failing loud via `t.Fatalf` on a genuinely stuck backend. Called in both affected tests after `createSyntheticTemplate`: before `reapTemplates` in the sweep test, and before the advisory-lock acquire in the blocks test (so it cannot distort that test's 500ms block-timing assertion).

A broken reaper guard still fails the existing assertions — the wait removes only the false-positive path, not the test's teeth.

## Tests

- `go test -tags integration_testdb -run TestTestdbReaper -count=5` — 10/10 green.
- `make test-unit` and `make test-integration` green (×2 back-to-back).
- Mirrors the existing `SkipsOpenSession` retry-loop idiom; no `time.Now()` (fixed-iteration `time.Sleep` loop).

Part of the autonomous-push-hardening arc (#600, #603); siblings: #609 (merged), #610.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDsCf4fuRWyhsgv12jZM9g