### PR TITLE
fix(hooks): harden lint timeout + shim lock-holder race

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
         with:
           version: latest
           working-directory: backend
-          args: --timeout=5m
+          # No --timeout flag: inherit the single source in .golangci.yml (10m).
 
       - name: Check cadence sole-writer invariant
         run: ./scripts/check-cadence-sole-writer.sh

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,10 @@
 version: "2"
 
 run:
-  timeout: 5m
+  # 10m (not 5m): the pre-push hook runs lint CONCURRENTLY with the -p 8 GO lane,
+  # starving golangci-lint's package-load phase past a 5m budget under load.
+  # Standalone lint finishes in ~1-2m; 10m is a real backstop, not a hang mask.
+  timeout: 10m
 
 linters:
   enable:

--- a/path-filters.yml
+++ b/path-filters.yml
@@ -34,6 +34,7 @@ backend:
   - 'go.sum'
   - 'scripts/**'
   - 'Makefile'
+  - '.golangci.yml'
   - '.github/workflows/ci.yml'
   - '.github/workflows/deploy-staging.yml'
   - 'path-filters.yml'

--- a/scripts/hooks/test/test-pre-push-filters.sh
+++ b/scripts/hooks/test/test-pre-push-filters.sh
@@ -67,6 +67,8 @@ assert_in_group     "frontend/playwright.config.ts" frontend
 assert_not_in_group "frontendx/y.ts" frontend
 # Self-gating regression guard: the filter file routes to validation.
 assert_in_group     "path-filters.yml" backend
+# Lint config is in backend so a config-only lint change triggers CI's lint job.
+assert_in_group     ".golangci.yml" backend
 
 # --- seed group: the staging auto-reseed surface (orthogonal to test selection) ---
 # Synthetic toolkit + profiles ARE the seed surface.

--- a/scripts/test/test-worktree-test-pg.sh
+++ b/scripts/test/test-worktree-test-pg.sh
@@ -15,6 +15,29 @@ fail=0
 ok()  { echo "ok: $1"; }
 bad() { echo "FAIL: $1"; fail=1; }
 
+# --- Deterministic lock holder (no fixed timing window) --------------------
+# start_lock_holder backgrounds a child that ACQUIRES the per-instance lock,
+# signals readiness, then BLOCKS holding it until release_lock_holder writes to
+# the fifo. It returns only once the lock is provably held (readiness poll), so a
+# subsequent lock-contending command is GUARANTEED to hit a held lock regardless
+# of scheduling latency — replacing the old ( flock 200; sleep 2 ) fixed window
+# that could release before a starved `ensure` reached its flock attempt.
+# Sets HOLDER_PID + HOLDER_FIFO for release_lock_holder.
+start_lock_holder() {                     # <lockfile>
+  local lockfile="$1" readyf i
+  HOLDER_FIFO=$(mktemp -u); mkfifo "$HOLDER_FIFO"
+  readyf=$(mktemp -u)                     # NON-precreated: [ -e ] flips only once the holder creates it
+  ( flock 200; : > "$readyf"; read -r _ < "$HOLDER_FIFO" ) 200>"$lockfile" & HOLDER_PID=$!
+  for i in $(seq 1 100); do [ -e "$readyf" ] && break; sleep 0.05; done
+  [ -e "$readyf" ] || bad "lock holder failed to acquire the lock (setup)"
+  rm -f "$readyf"
+}
+release_lock_holder() {                   # release + reap so the next case can re-lock
+  echo x > "$HOLDER_FIFO" 2>/dev/null || true
+  wait "$HOLDER_PID" 2>/dev/null || true
+  rm -f "$HOLDER_FIFO"
+}
+
 # --- Fake toolchain factory -------------------------------------------------
 # Builds a temp dir with: a fake git (configurable git-dir/common-dir + worktree
 # list), a fake bindir (initdb/pg_ctl/postgres/psql/pg_isready/pg_config), a
@@ -462,19 +485,17 @@ if command -v flock >/dev/null 2>&1; then
   d=$(make_env | tail -1); set_linked "$d" locknone
   id=$(run "$d" status | grep -oE 'id=[0-9a-f]+' | sed 's/id=//')
   lockdir="$d/pghome/$id"; mkdir -p "$lockdir"; lockfile="$lockdir/lock"
-  ( flock 200; sleep 2 ) 200>"$lockfile" & holder=$!
-  sleep 0.3
+  start_lock_holder "$lockfile"
   CRM_WORKTREE_PG_LOCK_TIMEOUT=1 run "$d" ensure 2>"$d/err"; rc=$?
   [ "$rc" -eq 0 ] && ok "lock-timeout not-running non-strict: exit 0" || bad "lock-timeout not-running non-strict exit=$rc"
   grep -qi 'pg_ctl -D' "$d/err" && ok "lock-timeout not-running: loud warning names pg_ctl recovery" || bad "lock-timeout not-running: no pg_ctl recovery hint ($(cat "$d/err"))"
   [ -z "$(run "$d" url)" ] && ok "lock-timeout not-running: url empty (genuine shared fallback)" || bad "lock-timeout not-running: url not empty"
-  wait "$holder" 2>/dev/null || true
+  release_lock_holder
   # strict: same setup -> non-zero exit
-  ( flock 200; sleep 2 ) 200>"$lockfile" & holder=$!
-  sleep 0.3
+  start_lock_holder "$lockfile"
   CRM_WORKTREE_PG_LOCK_TIMEOUT=1 CRM_WORKTREE_PG=strict run "$d" ensure 2>/dev/null; rc=$?
   [ "$rc" -ne 0 ] && ok "lock-timeout not-running strict: exit non-zero ($rc)" || bad "lock-timeout not-running strict: exit 0"
-  wait "$holder" 2>/dev/null || true
+  release_lock_holder
 
   # 20. Lock timeout, RUNNING branch: warm a real (fake) instance, hold its lock,
   # ensure with a 1s timeout. Non-strict proceeds against the running instance
@@ -485,19 +506,17 @@ if command -v flock >/dev/null 2>&1; then
   id=$(run "$d" status | grep -oE 'id=[0-9a-f]+' | sed 's/id=//')
   runurl=$(run "$d" url)
   lockfile="$d/pghome/$id/lock"
-  ( flock 200; sleep 2 ) 200>"$lockfile" & holder=$!
-  sleep 0.3
+  start_lock_holder "$lockfile"
   CRM_WORKTREE_PG_LOCK_TIMEOUT=1 run "$d" ensure 2>"$d/err"; rc=$?
   [ "$rc" -eq 0 ] && ok "lock-timeout running non-strict: exit 0" || bad "lock-timeout running non-strict exit=$rc"
   grep -qi 'server is up' "$d/err" && ok "lock-timeout running: warn says the server is up" || bad "lock-timeout running: no 'server is up' warning ($(cat "$d/err"))"
   [ "$(run "$d" url)" = "$runurl" ] && ok "lock-timeout running: url still emits the instance (no false fallback)" || bad "lock-timeout running: url changed/empty"
-  wait "$holder" 2>/dev/null || true
+  release_lock_holder
   # strict: same setup -> non-zero exit
-  ( flock 200; sleep 2 ) 200>"$lockfile" & holder=$!
-  sleep 0.3
+  start_lock_holder "$lockfile"
   CRM_WORKTREE_PG_LOCK_TIMEOUT=1 CRM_WORKTREE_PG=strict run "$d" ensure 2>/dev/null; rc=$?
   [ "$rc" -ne 0 ] && ok "lock-timeout running strict: exit non-zero ($rc)" || bad "lock-timeout running strict: exit 0"
-  wait "$holder" 2>/dev/null || true
+  release_lock_holder
 else
   ok "flock absent -> skipping lock-timeout branch tests (mkdir backend ceiling covered elsewhere)"
 fi


### PR DESCRIPTION
Hardens the two dominant pre-push-gate flakes that were forcing push retries — the last thing standing between this sandbox and autonomous pushes without human intervention. Part of the push-hardening arc (#600, #603); siblings #609/#611/#610 merged.

## FIX 1 — golangci-lint timeout exceeded under concurrent load

`.golangci.yml` has had `run.timeout: 5m` since Dec 2025 and it *is* applied — but under the pre-push hook's concurrent GO lane (`-p 8` integration suite starving the CPU), `go/packages` loading eats the wall budget and lint errors "Timeout exceeded" (the `0 issues.` line prints first — the analysis finished, the load ate the clock). CI separately pinned 5m via an explicit `--timeout=5m` flag that overrode the config.

- Raise `run.timeout` to `10m` in `.golangci.yml` (verified schema-valid for golangci-lint v2.1.6 via `config verify`).
- Drop CI's `--timeout=5m` flag so local + CI both inherit the single config source (CI's `working-directory: backend` discovers the repo-root config → 10m, not golangci's disabled default).
- Add `.golangci.yml` to the `backend` path-filter group (+ a pinning assertion in the filter harness) so a config-only lint change still triggers CI.

Measured: `make lint` completes in ~131s standalone / ~142s under load — ample headroom under 10m.

## FIX 2 — shim guard test lock-holder timing race

`scripts/test/test-worktree-test-pg.sh` had four `( flock 200; sleep 2 )` fixed-window lock holders. The tests assumed `ensure` (with `CRM_WORKTREE_PG_LOCK_TIMEOUT=1`) attempts the lock within that 2s window — but under concurrent GO-lane load, `ensure`'s bash startup can slip past 2s, the holder releases, `ensure` acquires the lock, and the strict-mode test sees exit 0 instead of the expected timeout-fail.

- Replace all four with a deterministic `start_lock_holder`/`release_lock_holder` fifo handshake: the holder signals readiness only *after* `flock` returns (non-precreated file checked with `[ -e ]`, not `[ -s ]` — an empty file has zero size) and holds the lock until the test explicitly releases it, then is `wait`-reaped before the lockfile is reused. The lock is provably held when `ensure` attempts it, regardless of scheduling latency.

Verified: shim suite green standalone AND 5× under 8-core CPU load (76 assertions each), render guard no-drift, filter harness green with the new assertion.

## Scope honesty

This removes the two *dominant* flake sources; it does not fully close the concurrent-load-fragility class. #607 (frontend vitest) remains open, and other timing-fragile tests could surface. The class-level fix — reducing the hook's peak lane concurrency — is out of scope here and noted in the plan's risks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDsCf4fuRWyhsgv12jZM9g