### PR TITLE
test(river): fix load-test ctx cancellation flake

### DIFF
--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -188,6 +188,18 @@ type Querier interface {
 	// external_identity.contact_id pointing at a soft-deleted (e.g. merged-away)
 	// contact must not short-circuit the discovery path.
 	ContactIsLive(ctx context.Context, id pgtype.UUID) (bool, error)
+	// Test-only count of ACTIVE sync_provider_account river_job rows whose args
+	// JSON source = @source. "Active" means not yet finalized (available, pending,
+	// running, retryable, scheduled); completed/discarded/cancelled are excluded.
+	// Used by the load test's drain-to-zero convergence check (core.md rule 2).
+	CountActiveRiverJobsBySourceArgForTest(ctx context.Context, source string) (int64, error)
+	// Test-only per-state breakdown of ACTIVE sync_provider_account river_job rows
+	// whose args JSON source = @source, using the SAME active-state predicate as
+	// CountActiveRiverJobsBySourceArgForTest. Backs the load test's drain-timeout
+	// diagnostic so a stuck backlog is reported per state (all 'available' means a
+	// dead fetch loop; jobs cycling through 'running' means genuine starvation).
+	// ORDER BY state for deterministic output.
+	CountActiveRiverJobsByStateBySourceForTest(ctx context.Context, source string) ([]*CountActiveRiverJobsByStateBySourceForTestRow, error)
 	CountAllUnmatchedExternalContacts(ctx context.Context, includeUnresolvedTelegram bool) (int64, error)
 	CountContactInteractions(ctx context.Context, contactID pgtype.UUID) (int64, error)
 	CountContactNotes(ctx context.Context, contactID pgtype.UUID) (int64, error)
@@ -296,6 +308,14 @@ type Querier interface {
 	// never calls this.
 	CountStalenessBreachesByAccountForTest(ctx context.Context, accountID string) (int64, error)
 	CountSyncLogsByState(ctx context.Context, syncStateID pgtype.UUID) (int64, error)
+	// Test-only count of external_sync_log rows for a given source in a given
+	// status. Backs the load test's quiescence assertion that no log row ends in
+	// 'running' (core.md rule 2).
+	CountSyncLogsByStatusForTest(ctx context.Context, arg CountSyncLogsByStatusForTestParams) (int64, error)
+	// Test-only count of external_sync_state rows for a given source in a given
+	// status. Backs the load test's quiescence assertion that no state row ends
+	// in 'syncing' (core.md rule 2).
+	CountSyncStatesByStatusForTest(ctx context.Context, arg CountSyncStatesByStatusForTestParams) (int64, error)
 	CountTelegramMessagesByChat(ctx context.Context) ([]*CountTelegramMessagesByChatRow, error)
 	CountTelegramMessagesByPeer(ctx context.Context) ([]*CountTelegramMessagesByPeerRow, error)
 	// Count messages for a single peer (for incremental discovery threshold check)

--- a/backend/internal/db/queries/test.sql
+++ b/backend/internal/db/queries/test.sql
@@ -1072,6 +1072,44 @@ SELECT COUNT(*) FROM river_job
 WHERE kind = 'sync_provider_account'
   AND (args->>'source') = sqlc.arg('source')::text;
 
+-- name: CountActiveRiverJobsBySourceArgForTest :one
+-- Test-only count of ACTIVE sync_provider_account river_job rows whose args
+-- JSON source = @source. "Active" means not yet finalized (available, pending,
+-- running, retryable, scheduled); completed/discarded/cancelled are excluded.
+-- Used by the load test's drain-to-zero convergence check (core.md rule 2).
+SELECT COUNT(*) FROM river_job
+WHERE kind = 'sync_provider_account'
+  AND (args->>'source') = sqlc.arg('source')::text
+  AND state IN ('available', 'pending', 'running', 'retryable', 'scheduled');
+
+-- name: CountActiveRiverJobsByStateBySourceForTest :many
+-- Test-only per-state breakdown of ACTIVE sync_provider_account river_job rows
+-- whose args JSON source = @source, using the SAME active-state predicate as
+-- CountActiveRiverJobsBySourceArgForTest. Backs the load test's drain-timeout
+-- diagnostic so a stuck backlog is reported per state (all 'available' means a
+-- dead fetch loop; jobs cycling through 'running' means genuine starvation).
+-- ORDER BY state for deterministic output.
+SELECT state, COUNT(*) AS count FROM river_job
+WHERE kind = 'sync_provider_account'
+  AND (args->>'source') = sqlc.arg('source')::text
+  AND state IN ('available', 'pending', 'running', 'retryable', 'scheduled')
+GROUP BY state
+ORDER BY state;
+
+-- name: CountSyncStatesByStatusForTest :one
+-- Test-only count of external_sync_state rows for a given source in a given
+-- status. Backs the load test's quiescence assertion that no state row ends
+-- in 'syncing' (core.md rule 2).
+SELECT COUNT(*) FROM external_sync_state
+WHERE source = @source AND status = @status;
+
+-- name: CountSyncLogsByStatusForTest :one
+-- Test-only count of external_sync_log rows for a given source in a given
+-- status. Backs the load test's quiescence assertion that no log row ends in
+-- 'running' (core.md rule 2).
+SELECT COUNT(*) FROM external_sync_log
+WHERE source = @source AND status = @status;
+
 -- name: InsertRiverJobForTest :exec
 -- Test-only seed of an in-flight sync_provider_account river_job row so
 -- the atomic-claim dedup path observes count>0. Mirrors the row a real

--- a/backend/internal/db/test.sql.go
+++ b/backend/internal/db/test.sql.go
@@ -11,6 +11,64 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const CountActiveRiverJobsBySourceArgForTest = `-- name: CountActiveRiverJobsBySourceArgForTest :one
+SELECT COUNT(*) FROM river_job
+WHERE kind = 'sync_provider_account'
+  AND (args->>'source') = $1::text
+  AND state IN ('available', 'pending', 'running', 'retryable', 'scheduled')
+`
+
+// Test-only count of ACTIVE sync_provider_account river_job rows whose args
+// JSON source = @source. "Active" means not yet finalized (available, pending,
+// running, retryable, scheduled); completed/discarded/cancelled are excluded.
+// Used by the load test's drain-to-zero convergence check (core.md rule 2).
+func (q *Queries) CountActiveRiverJobsBySourceArgForTest(ctx context.Context, source string) (int64, error) {
+	row := q.db.QueryRow(ctx, CountActiveRiverJobsBySourceArgForTest, source)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const CountActiveRiverJobsByStateBySourceForTest = `-- name: CountActiveRiverJobsByStateBySourceForTest :many
+SELECT state, COUNT(*) AS count FROM river_job
+WHERE kind = 'sync_provider_account'
+  AND (args->>'source') = $1::text
+  AND state IN ('available', 'pending', 'running', 'retryable', 'scheduled')
+GROUP BY state
+ORDER BY state
+`
+
+type CountActiveRiverJobsByStateBySourceForTestRow struct {
+	State RiverJobState `json:"state"`
+	Count int64         `json:"count"`
+}
+
+// Test-only per-state breakdown of ACTIVE sync_provider_account river_job rows
+// whose args JSON source = @source, using the SAME active-state predicate as
+// CountActiveRiverJobsBySourceArgForTest. Backs the load test's drain-timeout
+// diagnostic so a stuck backlog is reported per state (all 'available' means a
+// dead fetch loop; jobs cycling through 'running' means genuine starvation).
+// ORDER BY state for deterministic output.
+func (q *Queries) CountActiveRiverJobsByStateBySourceForTest(ctx context.Context, source string) ([]*CountActiveRiverJobsByStateBySourceForTestRow, error) {
+	rows, err := q.db.Query(ctx, CountActiveRiverJobsByStateBySourceForTest, source)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []*CountActiveRiverJobsByStateBySourceForTestRow{}
+	for rows.Next() {
+		var i CountActiveRiverJobsByStateBySourceForTestRow
+		if err := rows.Scan(&i.State, &i.Count); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const CountContactsByNamePrefix = `-- name: CountContactsByNamePrefix :one
 SELECT COUNT(*) FROM contact WHERE full_name LIKE $1 || '%'
 `
@@ -129,6 +187,46 @@ WHERE kind = 'sync_provider_account'
 // behavior without inlining raw SQL (core.md rule 2).
 func (q *Queries) CountRiverJobsBySourceArgForTest(ctx context.Context, source string) (int64, error) {
 	row := q.db.QueryRow(ctx, CountRiverJobsBySourceArgForTest, source)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const CountSyncLogsByStatusForTest = `-- name: CountSyncLogsByStatusForTest :one
+SELECT COUNT(*) FROM external_sync_log
+WHERE source = $1 AND status = $2
+`
+
+type CountSyncLogsByStatusForTestParams struct {
+	Source string `json:"source"`
+	Status string `json:"status"`
+}
+
+// Test-only count of external_sync_log rows for a given source in a given
+// status. Backs the load test's quiescence assertion that no log row ends in
+// 'running' (core.md rule 2).
+func (q *Queries) CountSyncLogsByStatusForTest(ctx context.Context, arg CountSyncLogsByStatusForTestParams) (int64, error) {
+	row := q.db.QueryRow(ctx, CountSyncLogsByStatusForTest, arg.Source, arg.Status)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const CountSyncStatesByStatusForTest = `-- name: CountSyncStatesByStatusForTest :one
+SELECT COUNT(*) FROM external_sync_state
+WHERE source = $1 AND status = $2
+`
+
+type CountSyncStatesByStatusForTestParams struct {
+	Source string `json:"source"`
+	Status string `json:"status"`
+}
+
+// Test-only count of external_sync_state rows for a given source in a given
+// status. Backs the load test's quiescence assertion that no state row ends
+// in 'syncing' (core.md rule 2).
+func (q *Queries) CountSyncStatesByStatusForTest(ctx context.Context, arg CountSyncStatesByStatusForTestParams) (int64, error) {
+	row := q.db.QueryRow(ctx, CountSyncStatesByStatusForTest, arg.Source, arg.Status)
 	var count int64
 	err := row.Scan(&count)
 	return count, err

--- a/backend/internal/repository/sync.go
+++ b/backend/internal/repository/sync.go
@@ -1031,6 +1031,56 @@ func (r *SyncRepository) CountRiverJobsBySourceArgForTest(ctx context.Context, s
 	return r.queries.CountRiverJobsBySourceArgForTest(ctx, source)
 }
 
+// CountActiveRiverJobsBySourceArgForTest returns the number of ACTIVE (not yet
+// finalized) sync_provider_account river_job rows whose args JSON source
+// matches. TEST ONLY — backs the load test's drain-to-zero convergence check.
+func (r *SyncRepository) CountActiveRiverJobsBySourceArgForTest(ctx context.Context, source string) (int64, error) {
+	return r.queries.CountActiveRiverJobsBySourceArgForTest(ctx, source)
+}
+
+// ActiveRiverJobStateCountForTest pairs a river_job state with the number of
+// active jobs in it. TEST ONLY — used for the load test's drain-timeout
+// diagnostic breakdown.
+type ActiveRiverJobStateCountForTest struct {
+	State string
+	Count int64
+}
+
+// CountActiveRiverJobsByStateBySourceForTest returns the per-state breakdown of
+// ACTIVE sync_provider_account river_job rows whose args JSON source matches,
+// ordered by state. TEST ONLY.
+func (r *SyncRepository) CountActiveRiverJobsByStateBySourceForTest(ctx context.Context, source string) ([]ActiveRiverJobStateCountForTest, error) {
+	rows, err := r.queries.CountActiveRiverJobsByStateBySourceForTest(ctx, source)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]ActiveRiverJobStateCountForTest, len(rows))
+	for i, row := range rows {
+		out[i] = ActiveRiverJobStateCountForTest{State: string(row.State), Count: row.Count}
+	}
+	return out, nil
+}
+
+// CountSyncStatesByStatusForTest counts external_sync_state rows for the given
+// source in the given status. TEST ONLY — backs the load test's 'syncing'
+// quiescence assertion.
+func (r *SyncRepository) CountSyncStatesByStatusForTest(ctx context.Context, source, status string) (int64, error) {
+	return r.queries.CountSyncStatesByStatusForTest(ctx, db.CountSyncStatesByStatusForTestParams{
+		Source: source,
+		Status: status,
+	})
+}
+
+// CountSyncLogsByStatusForTest counts external_sync_log rows for the given
+// source in the given status. TEST ONLY — backs the load test's 'running'
+// quiescence assertion.
+func (r *SyncRepository) CountSyncLogsByStatusForTest(ctx context.Context, source, status string) (int64, error) {
+	return r.queries.CountSyncLogsByStatusForTest(ctx, db.CountSyncLogsByStatusForTestParams{
+		Source: source,
+		Status: status,
+	})
+}
+
 // InsertRiverJobForTest seeds an in-flight sync_provider_account river_job
 // row with the given args JSON so the atomic-claim dedup path observes
 // count>0. TEST ONLY.

--- a/backend/tests/river/sync_worker_leased_retry_test.go
+++ b/backend/tests/river/sync_worker_leased_retry_test.go
@@ -123,9 +123,10 @@ func TestSyncWorker_ContextCancelledRetry(t *testing.T) {
 	require.NoError(t, err)
 	svc.SetRiverEnqueuer(client)
 
-	startCtx, startCancel := context.WithTimeout(ctx, 10*time.Second)
-	defer startCancel()
-	require.NoError(t, client.Start(startCtx))
+	// Root ctx, not a timeout-derived one: River binds its fetch/work loops to
+	// the Start ctx, so a start-deadline cancel silently stops fetching
+	// (documented project gotcha; applies to test harnesses too).
+	require.NoError(t, client.Start(ctx))
 	t.Cleanup(func() {
 		stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer stopCancel()

--- a/backend/tests/river/sync_worker_load_test.go
+++ b/backend/tests/river/sync_worker_load_test.go
@@ -107,13 +107,16 @@ func TestSyncWorker_LoadNoDuplicateConcurrentSyncs(t *testing.T) {
 
 	source := "load_test_provider"
 
-	// Clean up previous runs.
-	_, _ = database.Pool.Exec(ctx,
-		`DELETE FROM river_job WHERE kind = 'sync_provider_account' AND (args->>'source') = $1`, source)
-	_, _ = database.Pool.Exec(ctx, `DELETE FROM external_sync_log WHERE source = $1`, source)
-	_, _ = database.Pool.Exec(ctx, `DELETE FROM external_sync_state WHERE source = $1`, source)
-
 	syncRepo := repository.NewSyncRepositoryWithPool(database.Queries, database.Pool)
+
+	// Clean up previous runs (hard-delete via test-only sqlc helpers, not raw
+	// SQL — core.md rule 2).
+	cleanup := func(c context.Context) {
+		_ = syncRepo.DeleteRiverJobsBySourceArgForTest(c, source)
+		_ = syncRepo.DeleteSyncLogsBySourceForTest(c, source)
+		_ = syncRepo.DeleteSyncStatesBySourceForTest(c, source)
+	}
+	cleanup(ctx)
 	contactRepo := repository.NewContactRepository(database.Queries)
 	registry := syncpkg.NewProviderRegistry()
 	provider := &loadTestProvider{
@@ -144,12 +147,7 @@ func TestSyncWorker_LoadNoDuplicateConcurrentSyncs(t *testing.T) {
 		})
 		require.NoError(t, err)
 	}
-	t.Cleanup(func() {
-		_, _ = database.Pool.Exec(context.Background(),
-			`DELETE FROM river_job WHERE kind = 'sync_provider_account' AND (args->>'source') = $1`, source)
-		_, _ = database.Pool.Exec(context.Background(), `DELETE FROM external_sync_log WHERE source = $1`, source)
-		_, _ = database.Pool.Exec(context.Background(), `DELETE FROM external_sync_state WHERE source = $1`, source)
-	})
+	t.Cleanup(func() { cleanup(context.Background()) })
 
 	workers := river.NewWorkers()
 	river.AddWorker(workers, scheduler.NewSchedulerTickWorker(svc))
@@ -164,9 +162,12 @@ func TestSyncWorker_LoadNoDuplicateConcurrentSyncs(t *testing.T) {
 	require.NoError(t, err)
 	svc.SetRiverEnqueuer(client)
 
-	startCtx, startCancel := context.WithTimeout(ctx, 10*time.Second)
-	defer startCancel()
-	require.NoError(t, client.Start(startCtx))
+	// Start with the root ctx, never a timeout-derived context: River binds
+	// its fetch/work loops to the context passed to Start, so a start-deadline
+	// cancel silently stops fetching mid-test and strands enqueued jobs
+	// (documented project gotcha; applies to test harnesses too). client.Stop
+	// keeps its own bounded ctx below — that bound is legitimate.
+	require.NoError(t, client.Start(ctx))
 	t.Cleanup(func() {
 		stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer stopCancel()
@@ -190,35 +191,35 @@ drive:
 		}
 	}
 
-	// Drain: poll until no active river_job rows remain for this source,
-	// so the subsequent assertions see a steady state. Replaces a fixed
-	// time.Sleep that was flaky under CI load.
-	drainCtx, drainCancel := context.WithTimeout(ctx, 10*time.Second)
-	defer drainCancel()
-	drainTicker := time.NewTicker(50 * time.Millisecond)
-	defer drainTicker.Stop()
-	for {
-		var active int
-		err := database.Pool.QueryRow(drainCtx,
-			`SELECT COUNT(*) FROM river_job
-			 WHERE kind = 'sync_provider_account'
-			   AND (args->>'source') = $1
-			   AND state IN ('available','pending','running','retryable','scheduled')`,
-			source).Scan(&active)
-		if err == nil && active == 0 {
+	// Drain to quiescence: poll until no ACTIVE river_job rows remain for this
+	// source. This is a HARD pass condition, not a best-effort wait — with a
+	// live fetch loop (root Start ctx) this workload drains in low single-digit
+	// seconds even under load, so a stuck backlog is the dead-fetch-loop
+	// regression signature (or genuine starvation), and failing loudly here is
+	// the whole point. Assertions 3/4 below are only meaningful at quiescence:
+	// zero active jobs means every worker's CompleteSyncLog call has returned,
+	// so any row still 'syncing'/'running' is a genuine lifecycle bug, not a
+	// timing artifact. Fixed attempt count + Sleep (no time.Now — core.md rule
+	// 1); ~20s budget is an order of magnitude over the healthy drain time.
+	const drainAttempts = 200
+	const drainInterval = 100 * time.Millisecond
+	drained := false
+	for i := 0; i < drainAttempts; i++ {
+		active, err := syncRepo.CountActiveRiverJobsBySourceArgForTest(ctx, source)
+		require.NoError(t, err)
+		if active == 0 {
+			drained = true
 			break
 		}
-		select {
-		case <-drainCtx.Done():
-			// Timeout: fall through and run the assertions with the
-			// state we have. Don't Fatalf here — the original sleep
-			// wasn't load-bearing, and a slow CI node shouldn't fail the
-			// test as long as the invariants below hold.
-			goto assertions
-		case <-drainTicker.C:
-		}
+		time.Sleep(drainInterval)
 	}
-assertions:
+	if !drained {
+		breakdown, err := syncRepo.CountActiveRiverJobsByStateBySourceForTest(ctx, source)
+		require.NoError(t, err)
+		t.Fatalf("river_job did not drain to zero within %s; remaining active jobs by state: %v "+
+			"(all 'available' => fetch loop dead; jobs cycling through 'running' => genuine starvation)",
+			time.Duration(drainAttempts)*drainInterval, breakdown)
+	}
 
 	// Assertion 1: every account was invoked at least once by provider.Sync.
 	// We don't have per-account counters on the provider, but the easier
@@ -232,16 +233,12 @@ assertions:
 		"dedup broke: detected overlapping Sync calls for the same account")
 
 	// Assertion 3: no lingering 'syncing' rows.
-	var syncing int
-	require.NoError(t, database.Pool.QueryRow(ctx,
-		`SELECT COUNT(*) FROM external_sync_state WHERE source = $1 AND status = 'syncing'`, source,
-	).Scan(&syncing))
-	assert.Equal(t, 0, syncing, "no external_sync_state row should end in 'syncing'")
+	syncing, err := syncRepo.CountSyncStatesByStatusForTest(ctx, source, "syncing")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), syncing, "no external_sync_state row should end in 'syncing'")
 
 	// Assertion 4: no 'running' external_sync_log rows left behind.
-	var running int
-	require.NoError(t, database.Pool.QueryRow(ctx,
-		`SELECT COUNT(*) FROM external_sync_log WHERE source = $1 AND status = 'running'`, source,
-	).Scan(&running))
-	assert.Equal(t, 0, running, "no external_sync_log row should end in 'running'")
+	running, err := syncRepo.CountSyncLogsByStatusForTest(ctx, source, "running")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), running, "no external_sync_log row should end in 'running'")
 }

--- a/backend/tests/river/sync_worker_load_test.go
+++ b/backend/tests/river/sync_worker_load_test.go
@@ -109,14 +109,20 @@ func TestSyncWorker_LoadNoDuplicateConcurrentSyncs(t *testing.T) {
 
 	syncRepo := repository.NewSyncRepositoryWithPool(database.Queries, database.Pool)
 
-	// Clean up previous runs (hard-delete via test-only sqlc helpers, not raw
-	// SQL — core.md rule 2).
-	cleanup := func(c context.Context) {
-		_ = syncRepo.DeleteRiverJobsBySourceArgForTest(c, source)
-		_ = syncRepo.DeleteSyncLogsBySourceForTest(c, source)
-		_ = syncRepo.DeleteSyncStatesBySourceForTest(c, source)
+	// Clean up rows from prior runs (hard-delete via test-only sqlc helpers,
+	// not raw SQL — core.md rule 2).
+	cleanup := func(c context.Context) error {
+		if err := syncRepo.DeleteRiverJobsBySourceArgForTest(c, source); err != nil {
+			return err
+		}
+		if err := syncRepo.DeleteSyncLogsBySourceForTest(c, source); err != nil {
+			return err
+		}
+		return syncRepo.DeleteSyncStatesBySourceForTest(c, source)
 	}
-	cleanup(ctx)
+	// Setup cleanup must succeed: a failed delete would leave stale rows that
+	// corrupt the drain/assertions. Teardown cleanup (below) is best-effort.
+	require.NoError(t, cleanup(ctx))
 	contactRepo := repository.NewContactRepository(database.Queries)
 	registry := syncpkg.NewProviderRegistry()
 	provider := &loadTestProvider{
@@ -147,7 +153,7 @@ func TestSyncWorker_LoadNoDuplicateConcurrentSyncs(t *testing.T) {
 		})
 		require.NoError(t, err)
 	}
-	t.Cleanup(func() { cleanup(context.Background()) })
+	t.Cleanup(func() { _ = cleanup(context.Background()) })
 
 	workers := river.NewWorkers()
 	river.AddWorker(workers, scheduler.NewSchedulerTickWorker(svc))

--- a/backend/tests/river_integration_test.go
+++ b/backend/tests/river_integration_test.go
@@ -106,9 +106,10 @@ func TestRiverClient_StartStop_Integration(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	startCtx, startCancel := context.WithTimeout(ctx, 10*time.Second)
-	defer startCancel()
-	require.NoError(t, client.Start(startCtx))
+	// Root ctx, not a timeout-derived one: River binds its fetch/work loops to
+	// the Start ctx, so a start-deadline cancel silently stops fetching
+	// (documented project gotcha; applies to test harnesses too).
+	require.NoError(t, client.Start(ctx))
 
 	stopCtx, stopCancel := context.WithTimeout(ctx, 10*time.Second)
 	defer stopCancel()
@@ -147,9 +148,10 @@ func TestRiverClient_InsertAndWork_Integration(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	startCtx, startCancel := context.WithTimeout(ctx, 10*time.Second)
-	defer startCancel()
-	require.NoError(t, client.Start(startCtx))
+	// Root ctx, not a timeout-derived one: River binds its fetch/work loops to
+	// the Start ctx, so a start-deadline cancel silently stops fetching
+	// (documented project gotcha; applies to test harnesses too).
+	require.NoError(t, client.Start(ctx))
 
 	t.Cleanup(func() {
 		stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -218,9 +220,10 @@ func TestRiverClient_BootsWithNoopWorkerOnly(t *testing.T) {
 	})
 	require.NoError(t, err, "river.NewClient must accept a Workers bundle with just the noop worker")
 
-	startCtx, startCancel := context.WithTimeout(ctx, 10*time.Second)
-	defer startCancel()
-	require.NoError(t, client.Start(startCtx), "client.Start must succeed when only the noop worker is registered")
+	// Root ctx, not a timeout-derived one: River binds its fetch/work loops to
+	// the Start ctx, so a start-deadline cancel silently stops fetching
+	// (documented project gotcha; applies to test harnesses too).
+	require.NoError(t, client.Start(ctx), "client.Start must succeed when only the noop worker is registered")
 
 	stopCtx, stopCancel := context.WithTimeout(ctx, 10*time.Second)
 	defer stopCancel()

--- a/backend/tests/scheduler/river_periodic_scheduler_tick_test.go
+++ b/backend/tests/scheduler/river_periodic_scheduler_tick_test.go
@@ -236,9 +236,10 @@ func TestPeriodicTick_FiresOnStart(t *testing.T) {
 	require.NoError(t, err)
 	svc.SetRiverEnqueuer(client)
 
-	startCtx, startCancel := context.WithTimeout(ctx, 30*time.Second)
-	defer startCancel()
-	require.NoError(t, client.Start(startCtx))
+	// Root ctx, not a timeout-derived one: River binds its fetch/work loops to
+	// the Start ctx, so a start-deadline cancel silently stops fetching
+	// (documented project gotcha; applies to test harnesses too).
+	require.NoError(t, client.Start(ctx))
 	t.Cleanup(func() {
 		stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer stopCancel()


### PR DESCRIPTION
Fixes #608.

## Root cause

`TestSyncWorker_LoadNoDuplicateConcurrentSyncs` flaked ~50% under the pre-push hook's parallel `-p 8` run. The test gave `river.Client.Start` a **timeout-derived context** (the documented repo gotcha) that cancelled the fetch loop mid-test: the notifier then storm-reconnected (608,799 log lines / ~304k attempts in the 41s from ctx-expiry to test-end), starving the connection pool, and jobs in flight at the cancel boundary stranded `external_sync_log` rows in `'running'` whose healing retries the dead fetch loop could never deliver — so the assertion failed.

## Fix

- **Root ctx at all five straggler `client.Start` sites** (the load test + leased-retry + `river_integration` ×3 + periodic-tick). No timeout-derived Start remains in the tree; the sole prod Start (`main.go:301`) was already root-ctx and is unchanged.
- **Hard drain-to-zero gate**: the test now requires active River jobs to drain to zero (200×100ms, `t.Fatalf` + per-state diagnostic on failure) *before* any assertion — replacing the unsound `goto assertions` escape that let a non-quiescent state through (the vacuous-pass hole).
- **No raw SQL** (core rule #2): the test's raw SQL is converted to existing `*ForTest` helpers plus four new test-only sqlc queries with `SyncRepository` wrappers; the active-state predicate covers all five non-terminal River states.

## Verification

- Targeted `-count=3`: PASS ~32s each (was hitting the ~50s dead-drain ceiling).
- Full `make test-integration`: exit 0, **0** `notifier.Notifier` storm lines (was 608,799), load test PASS at ~33s in-suite.
- Zero production behavior change — only test files + test-only sqlc/repo helpers.

Test-only change. Part of the push-hardening arc (#600, #603); rebased onto PR5 (#613) whose lint-timeout + shim-race hardening let this land through the gate cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDsCf4fuRWyhsgv12jZM9g