### PR TITLE
feat(tours): agentic UX QA tours harness + contacts tour

### DIFF
--- a/.ai/spec/2026-07-08-piece4-track-b-agentic-qa-harness-design.md
+++ b/.ai/spec/2026-07-08-piece4-track-b-agentic-qa-harness-design.md
@@ -123,3 +123,29 @@ Vision/screenshot escalation, free-form agentic exploration, per-PR diff-scoped 
 ## SSOT note
 
 One authoring-guidance spillover, no schema change: where relevant, ux behaviors benefit from negative/collateral `then` items ("no unrelated destructive action is visible/enabled") — the judge checks unexpected side effects only if the spec names them. Apply opportunistically during future curation; no bulk edit.
+
+## Addendum — 2026-07-09: arc refinement & implementation decisions
+
+This addendum extends the design in place (it does not supersede the narrative above) with the decisions taken when scoping the implementation as a plan-and-ship arc. Where a decision refines an earlier section, it is noted.
+
+### Arc shape
+
+The implementation ships as **three PRs (PR1 → PR2 → PR3), terminating in advisory mode**; **PR4 (reporter issue-mode) is deferred to a separate later arc**. This refines "Implementation shape (~4 PRs)" above. Rationale: the prove phase that gates issue-mode (held-out fail-precision bar + N consecutive human-confirmed clean live sweeps) is inherently time-based and human-gated, so an automated arc cannot merge its way through it. The arc therefore terminates with the harness running in advisory mode across the first cut — which is precisely the substrate the prove phase then runs on. Planning PR4 becomes sensible only once a v0 corpus exists and live sweeps are accumulating. Two human-in-the-loop gates remain: (1) corpus labeling mid-arc, (2) the prove-phase → issue-mode flip in the deferred PR4.
+
+The first-cut inventory, stated exactly (current `ux` only; `proposed` skipped): **20 current behaviors** — PR1 `contacts.tour.ts` covers 7 (CON-038/040/041/042/043/044/045; CON-046 is `proposed`); PR3 covers 13 (`dashboard.tour.ts`: DSH-001/002/003/004/005/007, with DSH-006/009 `proposed`; `cadence-followup.tour.ts`: CAD-026/027/028/029/030/031/033).
+
+### Environment
+
+The **sandbox→staging network exception is complete** (the ops prerequisite in "Environment & prerequisites"); staging is the PR1 target from day one, no local-stack workaround required. The sandbox has a Playwright chromium build available; what it lacks is docker (the app-under-test's stack manager), not the browser — which does not matter when tours point at staging over the network.
+
+### Decisions
+
+- **Reset-before-run per sweep.** Each tour sweep first invokes `scripts/staging-reset.sh` (ssh mode) to obtain a known prod-shaped world, then runs all tours against it. This makes the destructive `when`s in the contacts scope (CON-042 delete, CON-043 merge, CON-044 mark-contacted) repeatable, and the run manifest pins the resulting staging image digest.
+- **Hybrid grader (refines "Judge").** Each `then` item is classified as **deterministic-verifiable** (checkable in code from captured evidence — e.g. CON-041 URL-param stripped via regex, CON-044 interaction logged via a `/api/v1` JSON-path, "arrows inert" via aria-node presence) or **judge-only** (semantic — e.g. CON-042 "warns the action cannot be undone"). Deterministic items are checked by verifiers with ordinary unit tests; the LLM judge owns only the semantic residue, and **fail-precision (the north star) is measured over the judge's residual items**. This follows the surveyed "verifiers before judges" rule and directly lifts judge precision by removing mechanical noise. Consequence for the capture contract: captures must be stored **parseably** (queryable aria structure, `/api/v1` responses keyed by endpoint, URL as a field), not as opaque text blobs.
+- **Server-time frame per capture (refines "Capture contract").** Accelerated time cannot be frozen — `accelerated.GetCurrentTime()` returns `TIME_BASE + wall_elapsed × TIME_ACCELERATION`, always advancing. Rather than perturb staging's clock, each capture records the app's current accelerated `now` plus the acceleration factor (read from the system-time endpoint); the judge and verifiers evaluate time-dependent `then` items (CON-045 birthdays, CAD due-dates, DSH widgets) **in that recorded frame**, and time-dependent before/after brackets are kept tight enough not to straddle a day boundary.
+- **Before/after state-delta captures (refines "Capture contract").** Behaviors whose `when` mutates state are captured as an explicit before/after **pair** the grader can diff, rather than two independent snapshots — the "grade what changed in the world" discipline.
+- **Corpus labeling = agent-drafted, human-corrected (refines "Judge evals").** Doctored fails remain self-labeled by construction (a deterministic single-point mutation of a clean capture manufactures a known fail on exactly one item; the human validates the mutation). For the real/clean/ambiguous cases that need genuine ground truth, a labeling CLI pre-fills **draft** per-item verdicts + critiques using a **different/stronger model than the judge** (avoiding the circularity the "no LLM-generated ground truth" rule guards against); the maintainer reviews and corrects, and the corrected labels are the ground truth. PR2 lands the deterministic doctoring tool and this labeling CLI alongside the seed corpus.
+
+### Eval-guide fold-ins
+
+A practitioner synthesis of the BenchFlow `awesome-evals` corpus (the same sources this design already drew on) largely validated the plan; because this judge is a read-only, no-tools *criticism* classifier rather than an action agent, the survey's trajectory/world-state/RL material is out of scope. Four items were folded in: the verifier layer (→ hybrid grader above); before/after state-delta captures (→ capture contract above); a **judge self-consistency metric** (repeat-verdict stability on a fixed capture) added to the PR2 eval harness; and **error-analysis-first sequencing** — deriving the judge's failure taxonomy from an open-coding pass over the first advisory sweep's real captures before finalizing the prompt and few-shots.

--- a/.gitignore
+++ b/.gitignore
@@ -192,6 +192,9 @@ test-results/
 playwright-report/
 playwright/.cache/
 
+# Tours harness live-run output (captures + manifest + traces) — never committed
+frontend/tests/tours/.runs/
+
 # Screenshots and videos from tests
 tests/screenshots/
 tests/videos/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Personal CRM Makefile
 
-.PHONY: help setup dev dev-seed staging-reset build crm-admin mac-daemon test test-daemon-local clean docker-up docker-down docker-reset test-cadence-ultra test-cadence-fast prod staging testing start start-local stop restart reload status dev-stop dev-restart dev-api-stop dev-api-start dev-api-restart ci-build-backend ci-build-frontend ci-build ci-test test-e2e test-e2e-local test-e2e-diff e2e-db deploy-mac promote setup-pi setup-mac-deploy dev-native postgres-native sqlc smoke-test test-deploy-scripts worktree-env worktree-deps test-integration-fast test-integration-slow test-clean-clones worktree-test-pg-ensure test-pg-stop test-pg-teardown test-pg-reap test-pg-smoke check-cadence-sole-writer check-followup-sole-writer check-rematch-sole-dispatcher check-crm-marker-construction check-sqlc-select-lists lint-ingest-registry spec-lint api-types api-types-check
+.PHONY: help setup dev dev-seed staging-reset tours build crm-admin mac-daemon test test-daemon-local clean docker-up docker-down docker-reset test-cadence-ultra test-cadence-fast prod staging testing start start-local stop restart reload status dev-stop dev-restart dev-api-stop dev-api-start dev-api-restart ci-build-backend ci-build-frontend ci-build ci-test test-e2e test-e2e-local test-e2e-diff e2e-db deploy-mac promote setup-pi setup-mac-deploy dev-native postgres-native sqlc smoke-test test-deploy-scripts worktree-env worktree-deps test-integration-fast test-integration-slow test-clean-clones worktree-test-pg-ensure test-pg-stop test-pg-teardown test-pg-reap test-pg-smoke check-cadence-sole-writer check-followup-sole-writer check-rematch-sole-dispatcher check-crm-marker-construction check-sqlc-select-lists lint-ingest-registry spec-lint api-types api-types-check
 
 # Repo root (supports running make from subdirectories).
 REPO_ROOT := $(shell git rev-parse --show-toplevel)
@@ -280,6 +280,9 @@ dev-api-restart:
 
 staging-reset: ## HARD reset + reseed STAGING — manual force / escape hatch (full wipe regardless of oauth; deploy-staging.yml auto-reseeds on seed-surface changes; fail-closed production refuse; STAGING-only)
 	@bash scripts/staging-reset.sh   # ssh STAGING_HOST -> refuse if CRM_ENV is a production alias or empty -> stop backend -> ephemeral crm-admin --reset-and-seed --profile prod-shaped --yes (deployed image) -> start backend
+
+tours: ## Reset staging + run the agentic UX QA tours (#606). Config from env only: TOURS_BASE_URL, TOURS_API_KEY, TOURS_API_URL. Captures land in frontend/tests/tours/.runs/ (gitignored). TOURS_SKIP_RESET=1 skips the reset.
+	@scripts/run-tours.sh
 
 # Native PostgreSQL (for containerized development without Docker-in-Docker)
 # Symlink the main checkout's gitignored env files (.env, frontend/.env.local,

--- a/Makefile
+++ b/Makefile
@@ -281,7 +281,7 @@ dev-api-restart:
 staging-reset: ## HARD reset + reseed STAGING — manual force / escape hatch (full wipe regardless of oauth; deploy-staging.yml auto-reseeds on seed-surface changes; fail-closed production refuse; STAGING-only)
 	@bash scripts/staging-reset.sh   # ssh STAGING_HOST -> refuse if CRM_ENV is a production alias or empty -> stop backend -> ephemeral crm-admin --reset-and-seed --profile prod-shaped --yes (deployed image) -> start backend
 
-tours: ## Reset staging + run the agentic UX QA tours (#606). Config from env only: TOURS_BASE_URL, TOURS_API_KEY, TOURS_API_URL. Captures land in frontend/tests/tours/.runs/ (gitignored). TOURS_SKIP_RESET=1 skips the reset.
+tours: ## Reset staging + run the agentic UX QA tours. Config from env only: TOURS_BASE_URL, TOURS_API_KEY, TOURS_API_URL. Captures land in frontend/tests/tours/.runs/ (gitignored). TOURS_SKIP_RESET=1 skips the reset.
 	@scripts/run-tours.sh
 
 # Native PostgreSQL (for containerized development without Docker-in-Docker)

--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -8,6 +8,9 @@ dist/
 playwright-report/
 test-results/
 
+# Tours harness live-run output (captures + manifest + traces)
+tests/tours/.runs/
+
 # Dependencies
 node_modules/
 

--- a/frontend/playwright.tours.config.ts
+++ b/frontend/playwright.tours.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig, devices } from '@playwright/test'
 
-// Dedicated, ISOLATED tours config (arc §0, PR1 D1). This file is NEVER imported
+// Dedicated, ISOLATED tours config. This file is NEVER imported
 // by playwright.config.ts and is only ever reached via an explicit
 // `--config=playwright.tours.config.ts` (make tours / scripts/run-tours.sh).
 //

--- a/frontend/playwright.tours.config.ts
+++ b/frontend/playwright.tours.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig, devices } from '@playwright/test'
+
+// Dedicated, ISOLATED tours config (arc §0, PR1 D1). This file is NEVER imported
+// by playwright.config.ts and is only ever reached via an explicit
+// `--config=playwright.tours.config.ts` (make tours / scripts/run-tours.sh).
+//
+// Isolation is safety-critical: a tours sweep runs staging-reset.sh, which
+// HARD-WIPES staging. A bare `bunx playwright test` uses the default config
+// (tests/e2e only) and can never reach a tour. Its own testDir/testMatch, no
+// webServer (tours target an already-running remote staging app), a single
+// serial chromium project, and no retries keep an accidental staging wipe
+// impossible.
+export default defineConfig({
+  testDir: './tests/tours',
+  testMatch: '**/*.tour.ts',
+  fullyParallel: false,
+  workers: 1,
+  // A tour error is signal (navigation breakage / missing control), not flake —
+  // never paper over it with a retry.
+  retries: 0,
+  reporter: [['list']],
+  globalSetup: './tests/tours/support/global-setup.ts',
+  projects: [
+    {
+      name: 'tours',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  use: {
+    // Staging frontend — NO default (globalSetup fails loudly if unset).
+    baseURL: process.env.TOURS_BASE_URL,
+    trace: 'on',
+    screenshot: 'only-on-failure',
+  },
+  // NO webServer — tours target a remote, already-running staging app.
+})

--- a/frontend/tests/tours/contacts.tour.ts
+++ b/frontend/tests/tours/contacts.tour.ts
@@ -23,11 +23,14 @@ const LIST_URL = '/contacts?sort=cadence&order=desc'
 const detailUrl = (id: string, action?: 'edit' | 'merge'): string =>
   `/contacts/${id}?sort=cadence&order=desc${action ? `&action=${action}` : ''}`
 
+// Backend API paths (matched by waitForApi against /api/v1 response URLs).
 const CONTACT_ID_PATH = /\/api\/v1\/contacts\/[0-9a-f-]{36}$/
 const CONTACTS_LIST_PATH = /\/api\/v1\/contacts$/
+// Frontend route path (matched by waitForURL against page URLs).
+const DETAIL_PAGE_PATH = /^\/contacts\/[0-9a-f-]{36}$/
 
 test('contacts tour — 7 current ux behaviors', async ({ page, tour }) => {
-  test.setTimeout(300_000)
+  test.setTimeout(480_000)
 
   // --- Reserve distinct contacts up front, by API query, not list position ---
   const listResp = await tour.apiCtx.get('/api/v1/contacts?limit=100&sort=cadence&order=desc')
@@ -77,6 +80,12 @@ test('contacts tour — 7 current ux behaviors', async ({ page, tour }) => {
   const firstId = contacts[0].id
   const midId = contacts[1].id
 
+  // The merge modal overlay — used to root the aria snapshot on the modal for
+  // its captures, so its subtree is not truncated out of the content-rich body.
+  const mergeModal = page
+    .locator('div.fixed.inset-0')
+    .filter({ has: page.getByRole('heading', { name: 'Merge Contacts' }) })
+
   // =====================================================================
   // READ-ONLY BEHAVIORS FIRST
   // =====================================================================
@@ -91,7 +100,7 @@ test('contacts tour — 7 current ux behaviors', async ({ page, tour }) => {
   })
 
   await page.locator('tbody tr').first().getByRole('link').first().click()
-  await page.waitForURL(u => CONTACT_ID_PATH.test(new URL(u).pathname))
+  await page.waitForURL(u => DETAIL_PAGE_PATH.test(new URL(u).pathname))
   await tour.waitForApi(page, 'GET', CONTACT_ID_PATH) // detail contact
   await tour.waitForApi(page, 'GET', CONTACTS_LIST_PATH) // ids_only nav order
   await page.getByRole('button', { name: 'Edit' }).waitFor({ state: 'visible' })
@@ -132,6 +141,7 @@ test('contacts tour — 7 current ux behaviors', async ({ page, tour }) => {
   await tour.capture(page, {
     behaviors: ['CON-041'],
     note: 'action=merge consumed once and stripped from URL',
+    ariaRoot: mergeModal,
   })
   await page.keyboard.press('Escape') // close merge modal without merging
   await page.getByRole('heading', { name: 'Merge Contacts' }).waitFor({ state: 'hidden' })
@@ -249,10 +259,9 @@ test('contacts tour — 7 current ux behaviors', async ({ page, tour }) => {
   })
 
   // --- CON-043: the merge flow keeps the current contact, archives the source ---
-  const modal = page
-    .locator('div.fixed.inset-0')
-    .filter({ has: page.getByRole('heading', { name: 'Merge Contacts' }) })
-
+  // The modal-open captures root aria on `mergeModal` (defined above) so the
+  // modal's queryable evidence (submit disabled, conflict toggles, summary,
+  // name affordances) survives rather than being truncated behind the page.
   await page.goto(detailUrl(target.id))
   await tour.waitForApi(page, 'GET', CONTACT_ID_PATH)
   await page.getByRole('button', { name: 'Merge' }).waitFor({ state: 'visible' })
@@ -263,23 +272,25 @@ test('contacts tour — 7 current ux behaviors', async ({ page, tour }) => {
     behaviors: ['CON-043'],
     note: 'merge modal open, no source: submit disabled',
     pair: { id: 'merge-CON-043', role: 'open' },
+    ariaRoot: mergeModal,
   })
 
   // Binding selector-exclusion: typing the TARGET's own name yields no target
   // candidate (excluded upstream), despite the query matching it.
-  await modal.getByText('Search for a contact to merge...').click()
-  const selectorInput = modal.getByPlaceholder('Search for a contact to merge...')
+  await mergeModal.getByText('Search for a contact to merge...').click()
+  const selectorInput = mergeModal.getByPlaceholder('Search for a contact to merge...')
   await selectorInput.waitFor({ state: 'visible' })
   await selectorInput.fill(target.full_name)
   await tour.capture(page, {
     behaviors: ['CON-043'],
     note: 'selector filtered by TARGET name: target absent from candidates = selector excludes target',
     pair: { id: 'merge-CON-043', role: 'selector-open' },
+    ariaRoot: mergeModal,
   })
 
   // Select the source; hold the preview response to capture the loading state.
   await selectorInput.fill(source.full_name)
-  const sourceOption = modal.getByText(source.full_name, { exact: true })
+  const sourceOption = mergeModal.getByText(source.full_name, { exact: true })
   await sourceOption.waitFor({ state: 'visible' })
   const previewHold = await tour.holdRoute(page, u => u.pathname.endsWith('/merge/preview'))
   await sourceOption.click()
@@ -287,35 +298,39 @@ test('contacts tour — 7 current ux behaviors', async ({ page, tour }) => {
     behaviors: ['CON-043'],
     note: 'preview loading: submit disabled',
     pair: { id: 'merge-CON-043', role: 'preview-loading' },
+    ariaRoot: mergeModal,
   })
   await previewHold.release()
   await tour.waitForApi(page, 'GET', /\/merge\/preview$/)
-  await modal.getByRole('heading', { name: 'Will Be Merged' }).waitFor({ state: 'visible' })
+  await mergeModal.getByRole('heading', { name: 'Will Be Merged' }).waitFor({ state: 'visible' })
   await tour.capture(page, {
     behaviors: ['CON-043'],
     note: 'preview loaded: transfer summary + conflict toggle(s) for the actually-conflicting field(s)',
     pair: { id: 'merge-CON-043', role: 'preview-loaded' },
+    ariaRoot: mergeModal,
   })
 
   // Name quick-fill (renders only when not editing and source_name !== edited).
-  await modal.getByRole('button', { name: 'use this' }).waitFor({ state: 'visible' })
+  await mergeModal.getByRole('button', { name: 'use this' }).waitFor({ state: 'visible' })
   await tour.capture(page, {
     behaviors: ['CON-043'],
     note: 'quick-fill affordance visible (merged name not yet source)',
     pair: { id: 'merge-CON-043', role: 'name-quickfill-available' },
+    ariaRoot: mergeModal,
   })
-  await modal.getByRole('button', { name: 'use this' }).click()
+  await mergeModal.getByRole('button', { name: 'use this' }).click()
   await tour.capture(page, {
     behaviors: ['CON-043'],
     note: 'quick-fill applied: merged name adopts source name',
     pair: { id: 'merge-CON-043', role: 'name-quickfilled' },
+    ariaRoot: mergeModal,
   })
 
   // Manual name edit in edit mode; the live input value is captured via fields
   // (ariaSnapshot does not reliably emit a textbox's value).
   const editedMergedName = `${source.full_name} (merged)`
-  await modal.getByRole('heading', { level: 3 }).click() // handleStartEditingName
-  const nameInput = modal.getByRole('textbox').first()
+  await mergeModal.getByRole('heading', { level: 3 }).click() // handleStartEditingName
+  const nameInput = mergeModal.getByRole('textbox').first()
   await nameInput.waitFor({ state: 'visible' })
   await nameInput.fill(editedMergedName)
   const mergedNameValue = await nameInput.inputValue() // read while visible
@@ -325,15 +340,17 @@ test('contacts tour — 7 current ux behaviors', async ({ page, tour }) => {
     note: 'merged name manually edited in edit mode',
     pair: { id: 'merge-CON-043', role: 'name-edited' },
     fields: { mergedNameInput: mergedNameValue },
+    ariaRoot: mergeModal,
   })
 
   // Merge in flight: hold the POST to capture the disabled submit.
   const mergeHold = await tour.holdRoute(page, u => u.pathname.endsWith('/merge'))
-  await modal.getByRole('button', { name: 'Merge Contacts' }).click()
+  await mergeModal.getByRole('button', { name: 'Merge Contacts' }).click()
   await tour.capture(page, {
     behaviors: ['CON-043'],
     note: 'merge in flight: submit disabled',
     pair: { id: 'merge-CON-043', role: 'in-flight' },
+    ariaRoot: mergeModal,
   })
   await mergeHold.release()
   await tour.waitForApi(page, 'POST', /\/merge$/)

--- a/frontend/tests/tours/contacts.tour.ts
+++ b/frontend/tests/tours/contacts.tour.ts
@@ -1,0 +1,402 @@
+// contacts.tour.ts — an assertion-free walk of the 7 CURRENT contacts `ux`
+// behaviors (CON-038, CON-040, CON-041, CON-042, CON-043, CON-044, CON-045).
+// CON-046 is status:proposed → SKIPPED. Read-only captures run first, then the
+// mutating ones on DISTINCT, API-selected contacts, destructive-last (D7).
+//
+// Imports ONLY `test` from the fixtures — never `expect` — so the tour stays
+// assertion-free (arc §3). Readiness is via waitForApi / locator.waitFor /
+// waitForURL (D9), never expect().
+
+import { test } from './support/tour-fixtures'
+
+interface TourContact {
+  id: string
+  full_name: string
+  cadence: string | null
+  location: string | null
+  birthday: string | null
+}
+
+// The default list context (contact-list-params: cadence, desc). Every list /
+// detail URL carries it so the nav order matches the list order (CON-038).
+const LIST_URL = '/contacts?sort=cadence&order=desc'
+const detailUrl = (id: string, action?: 'edit' | 'merge'): string =>
+  `/contacts/${id}?sort=cadence&order=desc${action ? `&action=${action}` : ''}`
+
+const CONTACT_ID_PATH = /\/api\/v1\/contacts\/[0-9a-f-]{36}$/
+const CONTACTS_LIST_PATH = /\/api\/v1\/contacts$/
+
+test('contacts tour — 7 current ux behaviors', async ({ page, tour }) => {
+  test.setTimeout(300_000)
+
+  // --- Reserve distinct contacts up front, by API query, not list position ---
+  const listResp = await tour.apiCtx.get('/api/v1/contacts?limit=100&sort=cadence&order=desc')
+  const contacts = ((await listResp.json())?.data ?? []) as TourContact[]
+  if (contacts.length < 4) {
+    throw new Error(`tour: prod-shaped seed too small (${contacts.length} contacts) for the tour`)
+  }
+
+  const nameCount = new Map<string, number>()
+  for (const c of contacts) nameCount.set(c.full_name, (nameCount.get(c.full_name) ?? 0) + 1)
+  const uniqueName = (c: TourContact): boolean => nameCount.get(c.full_name) === 1
+
+  // markContact = the first cadence-desc row (guaranteed on list page 1).
+  const markContact = contacts[0]
+  const reserved = new Set<string>([markContact.id])
+
+  // CON-043 REQUIRES a cadence-differing pair with unique names (so the
+  // client-side selector filter is unambiguous). Throw if none — a tour error
+  // is signal (arc §7), not a silent evidence-less capture.
+  let target: TourContact | undefined
+  let source: TourContact | undefined
+  for (let i = 0; i < contacts.length && !target; i++) {
+    const a = contacts[i]
+    if (reserved.has(a.id) || !a.cadence || !uniqueName(a)) continue
+    for (let j = i + 1; j < contacts.length; j++) {
+      const b = contacts[j]
+      if (reserved.has(b.id) || !b.cadence || !uniqueName(b)) continue
+      if (a.cadence !== b.cadence) {
+        target = a
+        source = b
+        break
+      }
+    }
+  }
+  if (!target || !source) {
+    throw new Error('tour: CON-043 requires a cadence-differing, unique-named pair; seed lacks one')
+  }
+  reserved.add(target.id)
+  reserved.add(source.id)
+
+  const deleteContact = contacts.find(c => !reserved.has(c.id))
+  if (!deleteContact) throw new Error('tour: no distinct contact left for the delete step')
+  reserved.add(deleteContact.id)
+  const actionParamContact = contacts.find(c => !reserved.has(c.id)) ?? markContact
+
+  // Mid-list + first contact for keyboard-nav (read-only; order = default nav).
+  const firstId = contacts[0].id
+  const midId = contacts[1].id
+
+  // =====================================================================
+  // READ-ONLY BEHAVIORS FIRST
+  // =====================================================================
+
+  // --- CON-038: list + detail share the default cadence order ---
+  await page.goto(LIST_URL)
+  await tour.waitForApi(page, 'GET', CONTACTS_LIST_PATH)
+  await page.getByRole('heading', { name: 'Contacts', level: 2 }).waitFor({ state: 'visible' })
+  await tour.capture(page, {
+    behaviors: ['CON-038'],
+    note: 'contact list, default cadence order (no explicit sort)',
+  })
+
+  await page.locator('tbody tr').first().getByRole('link').first().click()
+  await page.waitForURL(u => CONTACT_ID_PATH.test(new URL(u).pathname))
+  await tour.waitForApi(page, 'GET', CONTACT_ID_PATH) // detail contact
+  await tour.waitForApi(page, 'GET', CONTACTS_LIST_PATH) // ids_only nav order
+  await page.getByRole('button', { name: 'Edit' }).waitFor({ state: 'visible' })
+  await tour.capture(page, {
+    behaviors: ['CON-038'],
+    note: 'contact detail opened from default list; prev/next nav bar',
+  })
+
+  // --- CON-045: birthdays grouped by proximity under accelerated time ---
+  // Readiness = rendered cards (the cache-warm accelerated frame), NOT a fresh
+  // system/time GET (which would deadlock on the warm 5m-stale cache).
+  await page.goto('/birthdays')
+  await tour.waitForApi(page, 'GET', CONTACTS_LIST_PATH) // the limit=1000 load
+  await page.getByTestId('birthday-card').first().waitFor({ state: 'visible', timeout: 20_000 })
+  await tour.capture(page, {
+    behaviors: ['CON-045'],
+    note: 'birthdays page, rendered accelerated frame (full list + all cards)',
+    arrayCap: Infinity, // preserve the FULL limit=1000 list (grouping/order/placeholder-year)
+    ariaCap: Infinity, // preserve ALL visible birthday cards (a display behavior)
+  })
+
+  // --- CON-041: one-shot ?action= param strip ---
+  await page.goto(detailUrl(actionParamContact.id, 'edit'))
+  await page.waitForURL(u => !new URL(u).search.includes('action='))
+  await tour.waitForApi(page, 'GET', CONTACT_ID_PATH)
+  await page.getByRole('heading', { name: 'Edit Contact' }).waitFor({ state: 'visible' })
+  await tour.capture(page, {
+    behaviors: ['CON-041'],
+    note: 'action=edit consumed once and stripped from URL',
+  })
+  await page.getByRole('heading', { name: 'Edit Contact' }).click() // blur, focus → body
+  await page.keyboard.press('Escape') // discard edit without saving
+  await page.getByRole('button', { name: 'Edit' }).waitFor({ state: 'visible' })
+
+  await page.goto(detailUrl(actionParamContact.id, 'merge'))
+  await page.waitForURL(u => !new URL(u).search.includes('action='))
+  await page.getByRole('heading', { name: 'Merge Contacts' }).waitFor({ state: 'visible' })
+  await tour.capture(page, {
+    behaviors: ['CON-041'],
+    note: 'action=merge consumed once and stripped from URL',
+  })
+  await page.keyboard.press('Escape') // close merge modal without merging
+  await page.getByRole('heading', { name: 'Merge Contacts' }).waitFor({ state: 'hidden' })
+
+  // --- CON-040: keyboard navigation drives the detail page ---
+  await gotoDetailReady(midId)
+  await tour.capture(page, {
+    behaviors: ['CON-040'],
+    note: 'detail before keyboard nav (view mode)',
+  })
+
+  let beforePath = new URL(page.url()).pathname
+  await page.keyboard.press('ArrowRight')
+  await page.waitForURL(u => new URL(u).pathname !== beforePath)
+  await page.getByRole('button', { name: 'Edit' }).waitFor({ state: 'visible' })
+  await tour.capture(page, { behaviors: ['CON-040'], note: 'ArrowRight moved to next contact' })
+
+  beforePath = new URL(page.url()).pathname
+  await page.keyboard.press('ArrowLeft')
+  await page.waitForURL(u => new URL(u).pathname !== beforePath)
+  await page.getByRole('button', { name: 'Edit' }).waitFor({ state: 'visible' })
+  await tour.capture(page, { behaviors: ['CON-040'], note: 'ArrowLeft moved to previous contact' })
+
+  // Boundary: first contact → Previous nav disabled (aria [disabled]).
+  await gotoDetailReady(firstId)
+  await tour.capture(page, {
+    behaviors: ['CON-040'],
+    note: 'boundary: first contact, Previous nav disabled',
+  })
+
+  // Input-focus inertness (view mode, unconfounded from edit): the Add-Task
+  // modal does NOT set isEditing, so nav stays enabled; the input-focus guard
+  // alone suppresses the arrow.
+  await page.getByRole('button', { name: 'Add' }).click()
+  await page.getByRole('heading', { name: /Add Task for/ }).waitFor({ state: 'visible' })
+  await page
+    .getByPlaceholder('Follow up about surgery next tuesday p2')
+    .waitFor({ state: 'visible' }) // auto-focused on mount
+  await page.keyboard.press('ArrowRight')
+  await page.getByRole('heading', { name: /Add Task for/ }).waitFor({ state: 'visible' }) // no nav
+  await tour.capture(page, {
+    behaviors: ['CON-040'],
+    note: 'focus in Add-Task input (view mode): ArrowRight does NOT navigate — input-focus guard',
+  })
+  await page.keyboard.press('Escape')
+  await page.getByRole('heading', { name: /Add Task for/ }).waitFor({ state: 'hidden' })
+
+  // Enter opens edit mode (view swaps to ContactForm).
+  await page.getByRole('heading', { name: 'Contact Information' }).click() // focus → body
+  await page.keyboard.press('Enter')
+  await page.getByRole('heading', { name: 'Edit Contact' }).waitFor({ state: 'visible' })
+  await tour.capture(page, {
+    behaviors: ['CON-040'],
+    note: 'Enter opened edit mode (ContactForm)',
+  })
+
+  // Arrows inert while editing — evidence is the UNCHANGED url (nav is also
+  // present-but-disabled in edit mode; the url is the load-bearing proof).
+  await page.getByRole('heading', { name: 'Edit Contact' }).click() // focus → body
+  await page.keyboard.press('ArrowRight')
+  await page.getByRole('heading', { name: 'Edit Contact' }).waitFor({ state: 'visible' }) // still editing
+  await tour.capture(page, {
+    behaviors: ['CON-040'],
+    note: 'ArrowRight in edit mode: url unchanged — arrows inert while editing',
+  })
+
+  // Escape discards edit, back to view mode.
+  await page.getByRole('heading', { name: 'Edit Contact' }).click() // focus → body
+  await page.keyboard.press('Escape')
+  await page.getByRole('button', { name: 'Edit' }).waitFor({ state: 'visible' })
+  await tour.capture(page, {
+    behaviors: ['CON-040'],
+    note: 'Escape discards edit, back to view mode',
+  })
+
+  // Escape from view returns to the list (context preserved).
+  await gotoDetailReady(midId)
+  await page.keyboard.press('Escape')
+  await page.waitForURL(u => new URL(u).pathname === '/contacts') // strict pathname
+  await tour.waitForApi(page, 'GET', CONTACTS_LIST_PATH)
+  await tour.capture(page, {
+    behaviors: ['CON-040'],
+    note: 'Escape from view returns to the list, context preserved',
+  })
+
+  // =====================================================================
+  // MUTATING BEHAVIORS (distinct contacts, destructive-last)
+  // =====================================================================
+
+  // --- CON-044: mark-as-contacted logs a mutual interaction from the list ---
+  await page.goto(LIST_URL)
+  await tour.waitForApi(page, 'GET', CONTACTS_LIST_PATH)
+  await page.getByRole('heading', { name: 'Contacts', level: 2 }).waitFor({ state: 'visible' })
+  const markRow = page
+    .locator('tbody tr')
+    .filter({ has: page.locator(`a[href*="/contacts/${markContact.id}"]`) })
+  await markRow.first().waitFor({ state: 'visible' })
+  await tour.capture(page, {
+    behaviors: ['CON-044'],
+    note: 'before mark-as-contacted (list row activity state)',
+    pair: { id: 'markcontacted-CON-044', role: 'before' },
+  })
+
+  await markRow.getByRole('button', { name: 'Contact actions' }).click()
+  await page.getByRole('menuitem', { name: 'Mark as Contacted' }).click()
+  await tour.waitForApi(
+    page,
+    'POST',
+    new RegExp(`/api/v1/contacts/${markContact.id}/interactions$`)
+  )
+  await tour.capture(page, {
+    behaviors: ['CON-044'],
+    note: 'after mark-as-contacted: mutual interaction logged (server-timestamped)',
+    pair: { id: 'markcontacted-CON-044', role: 'after' },
+  })
+
+  // --- CON-043: the merge flow keeps the current contact, archives the source ---
+  const modal = page
+    .locator('div.fixed.inset-0')
+    .filter({ has: page.getByRole('heading', { name: 'Merge Contacts' }) })
+
+  await page.goto(detailUrl(target.id))
+  await tour.waitForApi(page, 'GET', CONTACT_ID_PATH)
+  await page.getByRole('button', { name: 'Merge' }).waitFor({ state: 'visible' })
+  await page.getByRole('button', { name: 'Merge' }).click()
+  await page.getByRole('heading', { name: 'Merge Contacts' }).waitFor({ state: 'visible' })
+  await tour.waitForApi(page, 'GET', CONTACTS_LIST_PATH) // selector's limit=500 load
+  await tour.capture(page, {
+    behaviors: ['CON-043'],
+    note: 'merge modal open, no source: submit disabled',
+    pair: { id: 'merge-CON-043', role: 'open' },
+  })
+
+  // Binding selector-exclusion: typing the TARGET's own name yields no target
+  // candidate (excluded upstream), despite the query matching it.
+  await modal.getByText('Search for a contact to merge...').click()
+  const selectorInput = modal.getByPlaceholder('Search for a contact to merge...')
+  await selectorInput.waitFor({ state: 'visible' })
+  await selectorInput.fill(target.full_name)
+  await tour.capture(page, {
+    behaviors: ['CON-043'],
+    note: 'selector filtered by TARGET name: target absent from candidates = selector excludes target',
+    pair: { id: 'merge-CON-043', role: 'selector-open' },
+  })
+
+  // Select the source; hold the preview response to capture the loading state.
+  await selectorInput.fill(source.full_name)
+  const sourceOption = modal.getByText(source.full_name, { exact: true })
+  await sourceOption.waitFor({ state: 'visible' })
+  const previewHold = await tour.holdRoute(page, u => u.pathname.endsWith('/merge/preview'))
+  await sourceOption.click()
+  await tour.capture(page, {
+    behaviors: ['CON-043'],
+    note: 'preview loading: submit disabled',
+    pair: { id: 'merge-CON-043', role: 'preview-loading' },
+  })
+  await previewHold.release()
+  await tour.waitForApi(page, 'GET', /\/merge\/preview$/)
+  await modal.getByRole('heading', { name: 'Will Be Merged' }).waitFor({ state: 'visible' })
+  await tour.capture(page, {
+    behaviors: ['CON-043'],
+    note: 'preview loaded: transfer summary + conflict toggle(s) for the actually-conflicting field(s)',
+    pair: { id: 'merge-CON-043', role: 'preview-loaded' },
+  })
+
+  // Name quick-fill (renders only when not editing and source_name !== edited).
+  await modal.getByRole('button', { name: 'use this' }).waitFor({ state: 'visible' })
+  await tour.capture(page, {
+    behaviors: ['CON-043'],
+    note: 'quick-fill affordance visible (merged name not yet source)',
+    pair: { id: 'merge-CON-043', role: 'name-quickfill-available' },
+  })
+  await modal.getByRole('button', { name: 'use this' }).click()
+  await tour.capture(page, {
+    behaviors: ['CON-043'],
+    note: 'quick-fill applied: merged name adopts source name',
+    pair: { id: 'merge-CON-043', role: 'name-quickfilled' },
+  })
+
+  // Manual name edit in edit mode; the live input value is captured via fields
+  // (ariaSnapshot does not reliably emit a textbox's value).
+  const editedMergedName = `${source.full_name} (merged)`
+  await modal.getByRole('heading', { level: 3 }).click() // handleStartEditingName
+  const nameInput = modal.getByRole('textbox').first()
+  await nameInput.waitFor({ state: 'visible' })
+  await nameInput.fill(editedMergedName)
+  const mergedNameValue = await nameInput.inputValue() // read while visible
+  await page.keyboard.press('Enter') // confirm
+  await tour.capture(page, {
+    behaviors: ['CON-043'],
+    note: 'merged name manually edited in edit mode',
+    pair: { id: 'merge-CON-043', role: 'name-edited' },
+    fields: { mergedNameInput: mergedNameValue },
+  })
+
+  // Merge in flight: hold the POST to capture the disabled submit.
+  const mergeHold = await tour.holdRoute(page, u => u.pathname.endsWith('/merge'))
+  await modal.getByRole('button', { name: 'Merge Contacts' }).click()
+  await tour.capture(page, {
+    behaviors: ['CON-043'],
+    note: 'merge in flight: submit disabled',
+    pair: { id: 'merge-CON-043', role: 'in-flight' },
+  })
+  await mergeHold.release()
+  await tour.waitForApi(page, 'POST', /\/merge$/)
+  await page.getByRole('heading', { name: 'Merge Contacts' }).waitFor({ state: 'hidden' }) // closed on success
+  await tour.capture(page, {
+    behaviors: ['CON-043'],
+    note: 'merge succeeded: POST kept target + field_selections default-to-target; probe GET source → 404 (archived)',
+    pair: { id: 'merge-CON-043', role: 'after' },
+    probes: [{ method: 'GET', path: `/api/v1/contacts/${source.id}` }],
+  })
+
+  // Page-level success banner, then its ~5s auto-dismiss.
+  await page.getByText(/merged successfully/i).waitFor({ state: 'visible' })
+  await tour.capture(page, {
+    behaviors: ['CON-043'],
+    note: 'success banner shown (page-level mergeMessage)',
+    pair: { id: 'merge-CON-043', role: 'outcome-reported' },
+  })
+  await page.getByText(/merged successfully/i).waitFor({ state: 'hidden', timeout: 10_000 })
+  await tour.capture(page, {
+    behaviors: ['CON-043'],
+    note: 'success banner auto-dismissed after ~5s',
+    pair: { id: 'merge-CON-043', role: 'dismissed' },
+  })
+
+  // --- CON-042: deleting a contact requires explicit confirmation ---
+  // Dismiss bracket then accept bracket on the SAME contact.
+  await page.goto(detailUrl(deleteContact.id))
+  await tour.waitForApi(page, 'GET', CONTACT_ID_PATH)
+  await page.getByRole('button', { name: 'Delete' }).waitFor({ state: 'visible' })
+  await tour.capture(page, {
+    behaviors: ['CON-042'],
+    note: 'detail before delete (dismiss path)',
+    pair: { id: 'delete-CON-042', role: 'before' },
+  })
+
+  await tour.withDialog(page, { accept: false }, async () => {
+    await page.getByRole('button', { name: 'Delete' }).click()
+  })
+  await tour.capture(page, {
+    behaviors: ['CON-042'],
+    note: 'after dismiss: still on detail, contact NOT deleted (probe GET 200)',
+    pair: { id: 'delete-CON-042', role: 'after-dismiss' },
+    probes: [{ method: 'GET', path: `/api/v1/contacts/${deleteContact.id}` }],
+  })
+
+  await tour.withDialog(page, { accept: true }, async () => {
+    await page.getByRole('button', { name: 'Delete' }).click()
+  })
+  await page.waitForURL(u => new URL(u).pathname === '/contacts') // strict pathname
+  await tour.waitForApi(page, 'GET', CONTACTS_LIST_PATH)
+  await tour.capture(page, {
+    behaviors: ['CON-042'],
+    note: 'after accept: returned to list; DELETE 204 + probe GET 404 confirm deletion',
+    pair: { id: 'delete-CON-042', role: 'after-accept' },
+    probes: [{ method: 'GET', path: `/api/v1/contacts/${deleteContact.id}` }],
+  })
+
+  // Open a fresh detail page (view mode) and wait for both the contact + nav ids.
+  async function gotoDetailReady(id: string): Promise<void> {
+    await page.goto(detailUrl(id))
+    await tour.waitForApi(page, 'GET', new RegExp(`/api/v1/contacts/${id}$`))
+    await tour.waitForApi(page, 'GET', CONTACTS_LIST_PATH) // ids_only nav order
+    await page.getByRole('button', { name: 'Edit' }).waitFor({ state: 'visible' })
+  }
+})

--- a/frontend/tests/tours/contacts.tour.ts
+++ b/frontend/tests/tours/contacts.tour.ts
@@ -1,11 +1,11 @@
 // contacts.tour.ts — an assertion-free walk of the 7 CURRENT contacts `ux`
 // behaviors (CON-038, CON-040, CON-041, CON-042, CON-043, CON-044, CON-045).
 // CON-046 is status:proposed → SKIPPED. Read-only captures run first, then the
-// mutating ones on DISTINCT, API-selected contacts, destructive-last (D7).
+// mutating ones on DISTINCT, API-selected contacts, destructive-last.
 //
 // Imports ONLY `test` from the fixtures — never `expect` — so the tour stays
-// assertion-free (arc §3). Readiness is via waitForApi / locator.waitFor /
-// waitForURL (D9), never expect().
+// assertion-free. Readiness is via waitForApi / locator.waitFor / waitForURL,
+// never expect().
 
 import { test } from './support/tour-fixtures'
 
@@ -49,7 +49,7 @@ test('contacts tour — 7 current ux behaviors', async ({ page, tour }) => {
 
   // CON-043 REQUIRES a cadence-differing pair with unique names (so the
   // client-side selector filter is unambiguous). Throw if none — a tour error
-  // is signal (arc §7), not a silent evidence-less capture.
+  // is signal, not a silent evidence-less capture.
   let target: TourContact | undefined
   let source: TourContact | undefined
   for (let i = 0; i < contacts.length && !target; i++) {
@@ -97,6 +97,7 @@ test('contacts tour — 7 current ux behaviors', async ({ page, tour }) => {
   await tour.capture(page, {
     behaviors: ['CON-038'],
     note: 'contact list, default cadence order (no explicit sort)',
+    pair: { id: 'default-order-CON-038', role: 'list' },
   })
 
   await page.locator('tbody tr').first().getByRole('link').first().click()
@@ -107,6 +108,7 @@ test('contacts tour — 7 current ux behaviors', async ({ page, tour }) => {
   await tour.capture(page, {
     behaviors: ['CON-038'],
     note: 'contact detail opened from default list; prev/next nav bar',
+    pair: { id: 'default-order-CON-038', role: 'detail' },
   })
 
   // --- CON-045: birthdays grouped by proximity under accelerated time ---
@@ -147,29 +149,42 @@ test('contacts tour — 7 current ux behaviors', async ({ page, tour }) => {
   await page.getByRole('heading', { name: 'Merge Contacts' }).waitFor({ state: 'hidden' })
 
   // --- CON-040: keyboard navigation drives the detail page ---
+  // The whole keyboard sequence is one bracket the grader diffs by seq: the
+  // nav/inert then-items are proven by comparing consecutive captures' urls.
+  const navPair = 'keyboard-nav-CON-040'
   await gotoDetailReady(midId)
   await tour.capture(page, {
     behaviors: ['CON-040'],
     note: 'detail before keyboard nav (view mode)',
+    pair: { id: navPair, role: 'view-before' },
   })
 
   let beforePath = new URL(page.url()).pathname
   await page.keyboard.press('ArrowRight')
   await page.waitForURL(u => new URL(u).pathname !== beforePath)
   await page.getByRole('button', { name: 'Edit' }).waitFor({ state: 'visible' })
-  await tour.capture(page, { behaviors: ['CON-040'], note: 'ArrowRight moved to next contact' })
+  await tour.capture(page, {
+    behaviors: ['CON-040'],
+    note: 'ArrowRight moved to next contact',
+    pair: { id: navPair, role: 'arrow-right-next' },
+  })
 
   beforePath = new URL(page.url()).pathname
   await page.keyboard.press('ArrowLeft')
   await page.waitForURL(u => new URL(u).pathname !== beforePath)
   await page.getByRole('button', { name: 'Edit' }).waitFor({ state: 'visible' })
-  await tour.capture(page, { behaviors: ['CON-040'], note: 'ArrowLeft moved to previous contact' })
+  await tour.capture(page, {
+    behaviors: ['CON-040'],
+    note: 'ArrowLeft moved to previous contact',
+    pair: { id: navPair, role: 'arrow-left-prev' },
+  })
 
   // Boundary: first contact → Previous nav disabled (aria [disabled]).
   await gotoDetailReady(firstId)
   await tour.capture(page, {
     behaviors: ['CON-040'],
     note: 'boundary: first contact, Previous nav disabled',
+    pair: { id: navPair, role: 'boundary-first' },
   })
 
   // Input-focus inertness (view mode, unconfounded from edit): the Add-Task
@@ -185,6 +200,7 @@ test('contacts tour — 7 current ux behaviors', async ({ page, tour }) => {
   await tour.capture(page, {
     behaviors: ['CON-040'],
     note: 'focus in Add-Task input (view mode): ArrowRight does NOT navigate — input-focus guard',
+    pair: { id: navPair, role: 'input-focus-inert' },
   })
   await page.keyboard.press('Escape')
   await page.getByRole('heading', { name: /Add Task for/ }).waitFor({ state: 'hidden' })
@@ -196,6 +212,7 @@ test('contacts tour — 7 current ux behaviors', async ({ page, tour }) => {
   await tour.capture(page, {
     behaviors: ['CON-040'],
     note: 'Enter opened edit mode (ContactForm)',
+    pair: { id: navPair, role: 'enter-edit' },
   })
 
   // Arrows inert while editing — evidence is the UNCHANGED url (nav is also
@@ -206,6 +223,7 @@ test('contacts tour — 7 current ux behaviors', async ({ page, tour }) => {
   await tour.capture(page, {
     behaviors: ['CON-040'],
     note: 'ArrowRight in edit mode: url unchanged — arrows inert while editing',
+    pair: { id: navPair, role: 'arrow-edit-inert' },
   })
 
   // Escape discards edit, back to view mode.
@@ -215,6 +233,7 @@ test('contacts tour — 7 current ux behaviors', async ({ page, tour }) => {
   await tour.capture(page, {
     behaviors: ['CON-040'],
     note: 'Escape discards edit, back to view mode',
+    pair: { id: navPair, role: 'escape-discard' },
   })
 
   // Escape from view returns to the list (context preserved).
@@ -225,6 +244,7 @@ test('contacts tour — 7 current ux behaviors', async ({ page, tour }) => {
   await tour.capture(page, {
     behaviors: ['CON-040'],
     note: 'Escape from view returns to the list, context preserved',
+    pair: { id: navPair, role: 'escape-to-list' },
   })
 
   // =====================================================================

--- a/frontend/tests/tours/support/capture.ts
+++ b/frontend/tests/tours/support/capture.ts
@@ -1,0 +1,273 @@
+// The capture engine (arc §1). Emits one parseable capture record per capture()
+// call: a structured aria node tree, self-describing endpoint-grouped /api/v1
+// responses, the accelerated serverTime frame, native dialogs, and optional
+// probes/fields — with conservative deterministic normalization (normalize.ts).
+
+import * as fs from 'fs'
+import * as path from 'path'
+import type {
+  APIRequestContext,
+  APIResponse,
+  Page,
+  Request,
+  Response,
+  TestInfo,
+} from '@playwright/test'
+import {
+  CAPTURE_FORMAT_VERSION,
+  type ApiProbe,
+  type ApiResponseItem,
+  type ApiResponses,
+  type Capture,
+  type CaptureOptions,
+  type DialogRecord,
+  type ServerTimeFrame,
+} from './types'
+import {
+  createUuidMapper,
+  DEFAULT_ARIA_CAP,
+  DEFAULT_ARRAY_CAP,
+  endpointKey,
+  normalizeAriaTree,
+  normalizeJson,
+  normalizeUrl,
+  parseAriaSnapshot,
+  parseQuery,
+  type UuidMapper,
+} from './normalize'
+import { capturesDir, getCurrentRunId } from './run-dir'
+
+const MUTATING = new Set(['POST', 'PUT', 'PATCH'])
+
+type PathPattern = string | RegExp
+type RouteMatcher = (url: URL) => boolean
+
+export interface WithDialogOptions {
+  accept: boolean
+  timeoutMs?: number
+}
+
+export interface RouteHold {
+  release: () => Promise<void>
+}
+
+function slugify(note: string): string {
+  return (
+    note
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 60) || 'capture'
+  )
+}
+
+// One TourApi per test (a tour is a single serial test). Its UUID mapper is
+// shared across every capture in the tour so before/after pairs correlate
+// (arc §1c-1). The response buffer + listener are set up by the fixture.
+export class TourApi {
+  private seq = 0
+  private readonly uuid: UuidMapper = createUuidMapper()
+  private readonly tour: string
+  private readonly pendingDialogs: DialogRecord[] = []
+
+  constructor(
+    readonly apiCtx: APIRequestContext,
+    private readonly buffer: Response[],
+    testInfo: TestInfo
+  ) {
+    this.tour = path.basename(testInfo.file).replace(/\.tour\.ts$/, '')
+  }
+
+  // Write one capture record (arc §1a). Every call site must first pass an
+  // explicit readiness gate (D9) so the response buffer is complete.
+  async capture(page: Page, opts: CaptureOptions): Promise<void> {
+    const arrayCap = opts.arrayCap ?? DEFAULT_ARRAY_CAP
+    const ariaCap = opts.ariaCap ?? DEFAULT_ARIA_CAP
+    const seq = ++this.seq
+
+    const url = normalizeUrl(page.url(), this.uuid)
+    const ariaYaml = await page.locator('body').ariaSnapshot()
+    const aria = normalizeAriaTree(parseAriaSnapshot(ariaYaml), this.uuid, ariaCap)
+
+    const apiResponses: ApiResponses = {}
+    // Drain everything buffered since the previous capture; record EVERY item.
+    const drained = this.buffer.splice(0)
+    for (const resp of drained) {
+      await this.recordResponse(apiResponses, resp, arrayCap)
+    }
+    for (const probe of opts.probes ?? []) {
+      await this.recordProbe(apiResponses, probe, arrayCap)
+    }
+
+    const serverTime = await this.fetchServerTime()
+    const fields = opts.fields
+      ? (normalizeJson(opts.fields, this.uuid, arrayCap) as Record<string, unknown>)
+      : undefined
+    const dialogs = this.pendingDialogs.splice(0)
+
+    const record: Capture = {
+      captureFormatVersion: CAPTURE_FORMAT_VERSION,
+      tour: this.tour,
+      seq,
+      behaviors: opts.behaviors,
+      note: opts.note,
+      url,
+      pair: opts.pair ?? null,
+      serverTime,
+      aria,
+      apiResponses,
+      ...(fields ? { fields } : {}),
+      dialogs,
+    }
+    this.write(seq, opts.note, record)
+  }
+
+  // Register a native-dialog handler (D5): record the message into the pending
+  // capture's dialogs[], accept/dismiss per the flag, await both the dialog and
+  // the triggering action, and throw loudly if no dialog fires in time (a
+  // delete flow that no longer prompts is a real regression, not to be
+  // swallowed). page.waitForEvent auto-removes its listener.
+  async withDialog(
+    page: Page,
+    opts: WithDialogOptions,
+    action: () => Promise<void>
+  ): Promise<void> {
+    const { accept, timeoutMs = 5000 } = opts
+    const dialogPromise = page.waitForEvent('dialog', { timeout: timeoutMs }).then(async dialog => {
+      this.pendingDialogs.push({ type: dialog.type(), message: dialog.message() })
+      if (accept) await dialog.accept()
+      else await dialog.dismiss()
+    })
+    const results = await Promise.allSettled([dialogPromise, Promise.resolve().then(action)])
+    for (const r of results) {
+      if (r.status === 'rejected') throw r.reason
+    }
+  }
+
+  // Readiness sugar (D9): resolve on the matching buffered response, else wait
+  // for the next one — NOT expect(), so tours stay assertion-free.
+  async waitForApi(
+    page: Page,
+    method: string,
+    pathPattern: PathPattern,
+    opts: { timeout?: number } = {}
+  ): Promise<Response> {
+    const timeout = opts.timeout ?? 15000
+    const matches = (r: Response): boolean =>
+      r.request().method() === method && this.matchPath(r.url(), pathPattern)
+    const existing = this.buffer.find(matches)
+    if (existing) return existing
+    return page.waitForResponse(matches, { timeout })
+  }
+
+  // Deterministically hold a route until release() (D5/CON-043 transient
+  // states): captures a loading/in-flight disabled state without timing luck.
+  async holdRoute(page: Page, matcher: RouteMatcher): Promise<RouteHold> {
+    let releaseGate!: () => void
+    const gate = new Promise<void>(resolve => {
+      releaseGate = resolve
+    })
+    await page.route(matcher, async route => {
+      await gate
+      await route.continue()
+    })
+    return {
+      release: async () => {
+        releaseGate()
+        await page.unroute(matcher)
+      },
+    }
+  }
+
+  private matchPath(url: string, pattern: PathPattern): boolean {
+    let pathname: string
+    try {
+      pathname = new URL(url).pathname
+    } catch {
+      pathname = url
+    }
+    return typeof pattern === 'string' ? pathname.includes(pattern) : pattern.test(pathname)
+  }
+
+  private async recordResponse(map: ApiResponses, resp: Response, arrayCap: number): Promise<void> {
+    const req = resp.request()
+    const method = req.method()
+    const fullUrl = resp.url()
+    const item: ApiResponseItem = {
+      method,
+      requestUrl: normalizeUrl(fullUrl, this.uuid),
+      query: parseQuery(fullUrl, this.uuid),
+      status: resp.status(),
+      body: await this.readBody(resp, arrayCap),
+    }
+    if (MUTATING.has(method)) {
+      const requestBody = this.readRequestBody(req, arrayCap)
+      if (requestBody !== undefined) item.requestBody = requestBody
+    }
+    const key = endpointKey(method, fullUrl)
+    ;(map[key] ??= []).push(item)
+  }
+
+  private async recordProbe(map: ApiResponses, probe: ApiProbe, arrayCap: number): Promise<void> {
+    const resp = await this.apiCtx.fetch(probe.path, { method: probe.method })
+    const item: ApiResponseItem = {
+      method: probe.method,
+      requestUrl: normalizeUrl(probe.path, this.uuid),
+      query: parseQuery(probe.path, this.uuid),
+      status: resp.status(),
+      body: await this.readBody(resp, arrayCap),
+      probe: true,
+    }
+    const key = endpointKey(probe.method, probe.path)
+    ;(map[key] ??= []).push(item)
+  }
+
+  private async readBody(resp: Response | APIResponse, arrayCap: number): Promise<unknown> {
+    try {
+      const json = await resp.json()
+      return normalizeJson(json, this.uuid, arrayCap)
+    } catch {
+      // Empty / non-JSON (e.g. DELETE → 204) — recorded as null, never dropped.
+      return null
+    }
+  }
+
+  private readRequestBody(req: Request, arrayCap: number): unknown {
+    try {
+      const data = req.postDataJSON()
+      if (data === null || data === undefined) return undefined
+      return normalizeJson(data, this.uuid, arrayCap)
+    } catch {
+      return undefined
+    }
+  }
+
+  // The authoritative accelerated frame (D3): fetched via the dedicated apiCtx
+  // (NOT the page context) so it is not caught by the response listener.
+  private async fetchServerTime(): Promise<ServerTimeFrame | null> {
+    try {
+      const resp = await this.apiCtx.get('/api/v1/system/time')
+      const envelope = (await resp.json()) as {
+        data?: Record<string, unknown>
+      } & Record<string, unknown>
+      const data = (envelope.data ?? envelope) as Record<string, unknown>
+      return {
+        currentTime: String(data.current_time ?? ''),
+        isAccelerated: Boolean(data.is_accelerated),
+        accelerationFactor: Number(data.acceleration_factor ?? 1),
+        baseTime: String(data.base_time ?? ''),
+        environment: data.environment ? String(data.environment) : undefined,
+      }
+    } catch {
+      return null
+    }
+  }
+
+  private write(seq: number, note: string, record: Capture): void {
+    const runId = getCurrentRunId()
+    const dir = capturesDir(runId, this.tour)
+    fs.mkdirSync(dir, { recursive: true })
+    const file = path.join(dir, `${String(seq).padStart(3, '0')}-${slugify(note)}.json`)
+    fs.writeFileSync(file, `${JSON.stringify(record, null, 2)}\n`, 'utf8')
+  }
+}

--- a/frontend/tests/tours/support/capture.ts
+++ b/frontend/tests/tours/support/capture.ts
@@ -1,7 +1,7 @@
-// The capture engine (arc §1). Emits one parseable capture record per capture()
-// call: a structured aria node tree, self-describing endpoint-grouped /api/v1
-// responses, the accelerated serverTime frame, native dialogs, and optional
-// probes/fields — with conservative deterministic normalization (normalize.ts).
+// The capture engine. Emits one parseable capture record per capture() call: a
+// structured aria node tree, self-describing endpoint-grouped /api/v1 responses,
+// the accelerated serverTime frame, native dialogs, and optional probes/fields —
+// with conservative deterministic normalization (normalize.ts).
 
 import * as fs from 'fs'
 import * as path from 'path'
@@ -62,8 +62,8 @@ function slugify(note: string): string {
 }
 
 // One TourApi per test (a tour is a single serial test). Its UUID mapper is
-// shared across every capture in the tour so before/after pairs correlate
-// (arc §1c-1). The response buffer + listener are set up by the fixture.
+// shared across every capture in the tour so before/after pairs correlate. The
+// response buffer + listener are set up by the fixture.
 export class TourApi {
   private seq = 0
   private readonly uuid: UuidMapper = createUuidMapper()
@@ -78,8 +78,8 @@ export class TourApi {
     this.tour = path.basename(testInfo.file).replace(/\.tour\.ts$/, '')
   }
 
-  // Write one capture record (arc §1a). Every call site must first pass an
-  // explicit readiness gate (D9) so the response buffer is complete.
+  // Write one capture record. Every call site must first pass an explicit
+  // readiness gate so the response buffer is complete.
   async capture(page: Page, opts: CaptureOptions): Promise<void> {
     const arrayCap = opts.arrayCap ?? DEFAULT_ARRAY_CAP
     const ariaCap = opts.ariaCap ?? DEFAULT_ARIA_CAP
@@ -123,7 +123,7 @@ export class TourApi {
     this.write(seq, opts.note, record)
   }
 
-  // Register a native-dialog handler (D5): record the message into the pending
+  // Register a native-dialog handler: record the message into the pending
   // capture's dialogs[], accept/dismiss per the flag, await both the dialog and
   // the triggering action, and throw loudly if no dialog fires in time (a
   // delete flow that no longer prompts is a real regression, not to be
@@ -145,8 +145,8 @@ export class TourApi {
     }
   }
 
-  // Readiness sugar (D9): resolve on the matching buffered response, else wait
-  // for the next one — NOT expect(), so tours stay assertion-free.
+  // Readiness sugar: resolve on the matching buffered response, else wait for
+  // the next one — NOT expect(), so tours stay assertion-free.
   async waitForApi(
     page: Page,
     method: string,
@@ -161,8 +161,8 @@ export class TourApi {
     return page.waitForResponse(matches, { timeout })
   }
 
-  // Deterministically hold a route until release() (D5/CON-043 transient
-  // states): captures a loading/in-flight disabled state without timing luck.
+  // Deterministically hold a route until release() (for capturing a
+  // loading/in-flight disabled state without timing luck).
   // The handler continues each intercepted route exactly once after the gate
   // opens; we deliberately do NOT page.unroute() on release — that races the
   // held route's continue and throws "Route is already handled". Leaving the
@@ -250,24 +250,33 @@ export class TourApi {
     }
   }
 
-  // The authoritative accelerated frame (D3): fetched via the dedicated apiCtx
-  // (NOT the page context) so it is not caught by the response listener.
-  private async fetchServerTime(): Promise<ServerTimeFrame | null> {
+  // The authoritative accelerated frame: fetched via the dedicated apiCtx (NOT
+  // the page context) so it is not caught by the response listener. Every
+  // capture must be stamped with this frame — a failed or malformed fetch
+  // THROWS to fail the sweep loudly rather than emit a frame-less capture.
+  private async fetchServerTime(): Promise<ServerTimeFrame> {
+    const resp = await this.apiCtx.get('/api/v1/system/time')
+    if (!resp.ok()) {
+      throw new Error(
+        `tours: GET /api/v1/system/time returned ${resp.status()} — cannot stamp the capture with a server-time frame`
+      )
+    }
+    let envelope: ({ data?: Record<string, unknown> } & Record<string, unknown>) | undefined
     try {
-      const resp = await this.apiCtx.get('/api/v1/system/time')
-      const envelope = (await resp.json()) as {
-        data?: Record<string, unknown>
-      } & Record<string, unknown>
-      const data = (envelope.data ?? envelope) as Record<string, unknown>
-      return {
-        currentTime: String(data.current_time ?? ''),
-        isAccelerated: Boolean(data.is_accelerated),
-        accelerationFactor: Number(data.acceleration_factor ?? 1),
-        baseTime: String(data.base_time ?? ''),
-        environment: data.environment ? String(data.environment) : undefined,
-      }
+      envelope = await resp.json()
     } catch {
-      return null
+      throw new Error('tours: GET /api/v1/system/time returned a non-JSON body')
+    }
+    const data = (envelope?.data ?? envelope) as Record<string, unknown> | undefined
+    if (!data || !data.current_time) {
+      throw new Error('tours: GET /api/v1/system/time response is missing current_time')
+    }
+    return {
+      currentTime: String(data.current_time),
+      isAccelerated: Boolean(data.is_accelerated),
+      accelerationFactor: Number(data.acceleration_factor ?? 1),
+      baseTime: String(data.base_time ?? ''),
+      environment: data.environment ? String(data.environment) : undefined,
     }
   }
 

--- a/frontend/tests/tours/support/capture.ts
+++ b/frontend/tests/tours/support/capture.ts
@@ -15,6 +15,7 @@ import type {
 } from '@playwright/test'
 import {
   CAPTURE_FORMAT_VERSION,
+  CAPTURE_GENERATOR_VERSION,
   type ApiProbe,
   type ApiResponseItem,
   type ApiResponses,
@@ -49,6 +50,22 @@ export interface WithDialogOptions {
 
 export interface RouteHold {
   release: () => Promise<void>
+}
+
+// Emit apiResponses with a deterministic order: keys sorted, and each
+// endpoint's items sorted by (method, requestUrl, status) — the buffer drains
+// in response-completion order, which is non-deterministic run-to-run.
+function sortApiResponses(map: ApiResponses): ApiResponses {
+  const sorted: ApiResponses = {}
+  for (const key of Object.keys(map).sort()) {
+    sorted[key] = [...map[key]].sort(
+      (a, b) =>
+        a.method.localeCompare(b.method) ||
+        a.requestUrl.localeCompare(b.requestUrl) ||
+        a.status - b.status
+    )
+  }
+  return sorted
 }
 
 function slugify(note: string): string {
@@ -108,6 +125,7 @@ export class TourApi {
 
     const record: Capture = {
       captureFormatVersion: CAPTURE_FORMAT_VERSION,
+      captureGeneratorVersion: CAPTURE_GENERATOR_VERSION,
       tour: this.tour,
       seq,
       behaviors: opts.behaviors,
@@ -116,7 +134,7 @@ export class TourApi {
       pair: opts.pair ?? null,
       serverTime,
       aria,
-      apiResponses,
+      apiResponses: sortApiResponses(apiResponses),
       ...(fields ? { fields } : {}),
       dialogs,
     }

--- a/frontend/tests/tours/support/capture.ts
+++ b/frontend/tests/tours/support/capture.ts
@@ -86,7 +86,8 @@ export class TourApi {
     const seq = ++this.seq
 
     const url = normalizeUrl(page.url(), this.uuid)
-    const ariaYaml = await page.locator('body').ariaSnapshot()
+    const ariaRoot = opts.ariaRoot ?? page.locator('body')
+    const ariaYaml = await ariaRoot.ariaSnapshot()
     const aria = normalizeAriaTree(parseAriaSnapshot(ariaYaml), this.uuid, ariaCap)
 
     const apiResponses: ApiResponses = {}
@@ -162,19 +163,26 @@ export class TourApi {
 
   // Deterministically hold a route until release() (D5/CON-043 transient
   // states): captures a loading/in-flight disabled state without timing luck.
+  // The handler continues each intercepted route exactly once after the gate
+  // opens; we deliberately do NOT page.unroute() on release — that races the
+  // held route's continue and throws "Route is already handled". Leaving the
+  // registration is harmless once the gate is open (later matching requests
+  // continue immediately) and it is torn down when the page closes.
   async holdRoute(page: Page, matcher: RouteMatcher): Promise<RouteHold> {
     let releaseGate!: () => void
     const gate = new Promise<void>(resolve => {
       releaseGate = resolve
     })
+    let released = false
     await page.route(matcher, async route => {
       await gate
       await route.continue()
     })
     return {
       release: async () => {
+        if (released) return
+        released = true
         releaseGate()
-        await page.unroute(matcher)
       },
     }
   }

--- a/frontend/tests/tours/support/global-setup.ts
+++ b/frontend/tests/tours/support/global-setup.ts
@@ -1,6 +1,6 @@
-// Tours globalSetup (D6): validate required env, establish the run dir, and
-// write the run manifest (arc §1b). Runs once in the main process before any
-// worker; the runId is handed to capture() via run-dir's marker.
+// Tours globalSetup: validate required env, establish the run dir, and write
+// the run manifest. Runs once in the main process before any worker; the runId
+// is handed to capture() via run-dir's marker.
 
 import * as fs from 'fs'
 import type { FullConfig } from '@playwright/test'

--- a/frontend/tests/tours/support/global-setup.ts
+++ b/frontend/tests/tours/support/global-setup.ts
@@ -7,6 +7,43 @@ import type { FullConfig } from '@playwright/test'
 import { buildManifest } from './manifest'
 import { generateRunId, manifestPath, runDir, setCurrentRunId } from './run-dir'
 
+// A target environment is safe to tour only if it is present AND not a
+// production alias. Empty / unknown / missing is treated as production
+// (fail-closed, mirroring the backend's own production gate).
+const PROD_OR_UNKNOWN = new Set(['', 'production', 'prod', 'unknown'])
+
+// Fail-closed production guard: the tours issue real mutations (delete, merge,
+// mark-contacted) against the Playwright target and write captures, so refuse to
+// run unless that target self-reports a non-production environment. Uses the
+// same GET /api/v1/system/time the captures rely on; its `environment` is the
+// backend's CRM_ENV. This guards the actual test target, independent of the
+// (decoupled) staging-reset host.
+async function assertNonProductionTarget(): Promise<void> {
+  const apiBase = (process.env.TOURS_API_URL || process.env.TOURS_BASE_URL || '').replace(/\/$/, '')
+  const apiKey = process.env.TOURS_API_KEY ?? ''
+  const url = `${apiBase}/api/v1/system/time`
+  let environment: string | undefined
+  try {
+    const resp = await fetch(url, { headers: { 'X-API-Key': apiKey } })
+    if (!resp.ok) throw new Error(`GET /api/v1/system/time returned ${resp.status}`)
+    const body = (await resp.json()) as { data?: { environment?: string } }
+    environment = body?.data?.environment
+  } catch (err) {
+    throw new Error(
+      `tours: REFUSING — could not verify the target environment via ${url}: ` +
+        `${err instanceof Error ? err.message : String(err)}. ` +
+        'Tours mutate data and must run only against a verified non-production target.'
+    )
+  }
+  if (PROD_OR_UNKNOWN.has((environment ?? '').trim().toLowerCase())) {
+    throw new Error(
+      `tours: REFUSING — target reports environment='${environment ?? ''}' ` +
+        '(production / empty / unknown). Tours issue real mutations (delete/merge/mark-contacted) ' +
+        'and write captures, so they run ONLY against a non-production target.'
+    )
+  }
+}
+
 export default async function globalSetup(_config: FullConfig): Promise<void> {
   const required = ['TOURS_BASE_URL', 'TOURS_API_KEY']
   const missing = required.filter(k => !process.env[k])
@@ -15,6 +52,9 @@ export default async function globalSetup(_config: FullConfig): Promise<void> {
       `tours: missing required env: ${missing.join(', ')} — run via scripts/run-tours.sh (make tours)`
     )
   }
+
+  // Refuse to touch a production (or unverifiable) target before anything runs.
+  await assertNonProductionTarget()
 
   const runId = process.env.TOURS_RUN_ID || generateRunId()
   process.env.TOURS_RUN_ID = runId

--- a/frontend/tests/tours/support/global-setup.ts
+++ b/frontend/tests/tours/support/global-setup.ts
@@ -1,0 +1,33 @@
+// Tours globalSetup (D6): validate required env, establish the run dir, and
+// write the run manifest (arc §1b). Runs once in the main process before any
+// worker; the runId is handed to capture() via run-dir's marker.
+
+import * as fs from 'fs'
+import type { FullConfig } from '@playwright/test'
+import { buildManifest } from './manifest'
+import { generateRunId, manifestPath, runDir, setCurrentRunId } from './run-dir'
+
+export default async function globalSetup(_config: FullConfig): Promise<void> {
+  const required = ['TOURS_BASE_URL', 'TOURS_API_KEY']
+  const missing = required.filter(k => !process.env[k])
+  if (missing.length > 0) {
+    throw new Error(
+      `tours: missing required env: ${missing.join(', ')} — run via scripts/run-tours.sh (make tours)`
+    )
+  }
+
+  const runId = process.env.TOURS_RUN_ID || generateRunId()
+  process.env.TOURS_RUN_ID = runId
+
+  fs.mkdirSync(runDir(runId), { recursive: true })
+  setCurrentRunId(runId)
+
+  const manifest = buildManifest({
+    runId,
+    gitSha: process.env.TOURS_GIT_SHA,
+    stagingImageDigest: process.env.TOURS_IMAGE_DIGEST,
+    seedProfile: process.env.TOURS_SEED_PROFILE,
+    baseUrl: process.env.TOURS_BASE_URL,
+  })
+  fs.writeFileSync(manifestPath(runId), `${JSON.stringify(manifest, null, 2)}\n`, 'utf8')
+}

--- a/frontend/tests/tours/support/manifest.ts
+++ b/frontend/tests/tours/support/manifest.ts
@@ -1,0 +1,37 @@
+// Run-manifest assembly + host redaction (arc §1b). Pure — no Playwright import.
+
+import { CAPTURE_FORMAT_VERSION, CAPTURE_GENERATOR_VERSION, type Manifest } from './types'
+
+// Redact the staging host: keep the scheme + path shape, replace the host with
+// the literal <staging> so the hostname is never committed (arc §4.6). Falls
+// back to a fully-opaque value if the URL cannot be parsed.
+export function redactHost(baseUrl: string): string {
+  try {
+    const u = new URL(baseUrl)
+    return `${u.protocol}//<staging>${u.pathname === '/' ? '/' : u.pathname}`
+  } catch {
+    return '<staging>'
+  }
+}
+
+export interface ManifestEnv {
+  runId: string
+  gitSha?: string
+  stagingImageDigest?: string
+  seedProfile?: string
+  baseUrl?: string
+  timestamp?: string
+}
+
+export function buildManifest(env: ManifestEnv): Manifest {
+  return {
+    captureFormatVersion: CAPTURE_FORMAT_VERSION,
+    captureGeneratorVersion: CAPTURE_GENERATOR_VERSION,
+    gitSha: env.gitSha || 'unknown',
+    stagingImageDigest: env.stagingImageDigest || 'unknown',
+    seedProfile: env.seedProfile || 'prod-shaped',
+    baseUrl: env.baseUrl ? redactHost(env.baseUrl) : '<staging>',
+    timestamp: env.timestamp || new Date().toISOString(),
+    runId: env.runId,
+  }
+}

--- a/frontend/tests/tours/support/manifest.ts
+++ b/frontend/tests/tours/support/manifest.ts
@@ -1,10 +1,10 @@
-// Run-manifest assembly + host redaction (arc §1b). Pure — no Playwright import.
+// Run-manifest assembly + host redaction. Pure — no Playwright import.
 
 import { CAPTURE_FORMAT_VERSION, CAPTURE_GENERATOR_VERSION, type Manifest } from './types'
 
 // Redact the staging host: keep the scheme + path shape, replace the host with
-// the literal <staging> so the hostname is never committed (arc §4.6). Falls
-// back to a fully-opaque value if the URL cannot be parsed.
+// the literal <staging> so the hostname is never committed. Falls back to a
+// fully-opaque value if the URL cannot be parsed.
 export function redactHost(baseUrl: string): string {
   try {
     const u = new URL(baseUrl)

--- a/frontend/tests/tours/support/normalize.test.ts
+++ b/frontend/tests/tours/support/normalize.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect } from 'vitest'
+import {
+  createUuidMapper,
+  mapUuids,
+  normalizeUrl,
+  parseQuery,
+  endpointKey,
+  normalizeJson,
+  parseAriaSnapshot,
+  normalizeAriaTree,
+  DEFAULT_ARRAY_CAP,
+  DEFAULT_ARIA_CAP,
+} from './normalize'
+import type { AriaNode } from './types'
+
+const UUID_A = '11111111-1111-4111-8111-111111111111'
+const UUID_B = '22222222-2222-4222-8222-222222222222'
+
+describe('UUID mapper', () => {
+  it('maps a UUID to a stable run-scoped ordinal', () => {
+    const m = createUuidMapper()
+    expect(m.map(UUID_A)).toBe('<id:1>')
+    expect(m.map(UUID_A)).toBe('<id:1>') // same uuid → same ordinal
+    expect(m.map(UUID_B)).toBe('<id:2>')
+    expect(m.map(UUID_A)).toBe('<id:1>') // still stable after a second uuid
+  })
+
+  it('is case-insensitive on the UUID', () => {
+    const m = createUuidMapper()
+    expect(m.map(UUID_A.toUpperCase())).toBe('<id:1>')
+    expect(m.map(UUID_A.toLowerCase())).toBe('<id:1>')
+  })
+
+  it('maps the SAME uuid identically across body, requestUrl, query, and aria', () => {
+    const m = createUuidMapper()
+    const inBody = normalizeJson({ id: UUID_A }, m, DEFAULT_ARRAY_CAP) as { id: string }
+    const inUrl = normalizeUrl(`https://host/api/v1/contacts/${UUID_A}`, m)
+    const inQuery = parseQuery(`https://host/api/v1/contacts?source_id=${UUID_A}`, m)
+    const inAria = normalizeAriaTree(
+      { role: 'link', name: `contact ${UUID_A}` },
+      m,
+      DEFAULT_ARIA_CAP
+    )
+    expect(inBody.id).toBe('<id:1>')
+    expect(inUrl).toBe('/api/v1/contacts/<id:1>')
+    expect(inQuery.source_id).toBe('<id:1>')
+    expect(inAria.name).toBe('contact <id:1>')
+  })
+
+  it('maps multiple UUIDs inside one string', () => {
+    const m = createUuidMapper()
+    expect(mapUuids(`${UUID_A} and ${UUID_B}`, m)).toBe('<id:1> and <id:2>')
+  })
+})
+
+describe('normalizeUrl / parseQuery / endpointKey', () => {
+  it('strips the host and preserves path + query with UUIDs mapped', () => {
+    const m = createUuidMapper()
+    const url = `https://staging.example/api/v1/contacts?sort=cadence&order=desc`
+    expect(normalizeUrl(url, m)).toBe('/api/v1/contacts?sort=cadence&order=desc')
+  })
+
+  it('preserves and sorts query params, mapping UUID values', () => {
+    const m = createUuidMapper()
+    const q = parseQuery(`https://h/api/v1/contacts?order=desc&sort=cadence&ids_only=true`, m)
+    expect(Object.keys(q)).toEqual(['ids_only', 'order', 'sort'])
+    expect(q).toEqual({ ids_only: 'true', order: 'desc', sort: 'cadence' })
+  })
+
+  it('templates UUID path segments to :id for the endpoint key', () => {
+    expect(
+      endpointKey('GET', `https://h/api/v1/contacts/${UUID_A}/merge/preview?source_id=x`)
+    ).toBe('GET /api/v1/contacts/:id/merge/preview')
+    expect(endpointKey('DELETE', `https://h/api/v1/contacts/${UUID_A}`)).toBe(
+      'DELETE /api/v1/contacts/:id'
+    )
+  })
+
+  it('distinguishes the list, ids_only, and limit=1000 requests by query', () => {
+    const m = createUuidMapper()
+    expect(parseQuery('https://h/api/v1/contacts?sort=cadence&order=desc', m)).not.toEqual(
+      parseQuery('https://h/api/v1/contacts?ids_only=true', m)
+    )
+    expect(parseQuery('https://h/api/v1/contacts?limit=1000', m).limit).toBe('1000')
+  })
+})
+
+describe('normalizeJson deny-list vs preserve-list', () => {
+  it('sentinels audit-only wall-clock columns but preserves behavior-relevant dates', () => {
+    const m = createUuidMapper()
+    const out = normalizeJson(
+      {
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-02T00:00:00Z',
+        contact_by: '2026-03-01T00:00:00Z',
+        last_contacted: '2026-02-01T00:00:00Z',
+        last_response_at: '2026-02-02T00:00:00Z',
+        last_outreach_at: '2026-02-03T00:00:00Z',
+        last_interaction_at: '2026-02-04T00:00:00Z',
+        birthday: '1990-05-05',
+        occurred_at: '2026-02-05T00:00:00Z',
+        deleted_at: '2026-02-06T00:00:00Z',
+      },
+      m,
+      DEFAULT_ARRAY_CAP
+    ) as Record<string, string>
+    expect(out.created_at).toBe('<ts>')
+    expect(out.updated_at).toBe('<ts>')
+    // Behavior-relevant dates survive verbatim (grader evidence).
+    expect(out.contact_by).toBe('2026-03-01T00:00:00Z')
+    expect(out.last_contacted).toBe('2026-02-01T00:00:00Z')
+    expect(out.last_response_at).toBe('2026-02-02T00:00:00Z')
+    expect(out.last_outreach_at).toBe('2026-02-03T00:00:00Z')
+    expect(out.last_interaction_at).toBe('2026-02-04T00:00:00Z')
+    expect(out.birthday).toBe('1990-05-05')
+    expect(out.occurred_at).toBe('2026-02-05T00:00:00Z')
+    expect(out.deleted_at).toBe('2026-02-06T00:00:00Z')
+  })
+
+  it('redacts transport / token noise but keeps the key structure', () => {
+    const m = createUuidMapper()
+    const out = normalizeJson(
+      { etag: 'W/"abc"', csrf_token: 'zzz', session_id: 'sss', name: 'Contact A' },
+      m,
+      DEFAULT_ARRAY_CAP
+    ) as Record<string, string>
+    expect(out.etag).toBe('<redacted>')
+    expect(out.csrf_token).toBe('<redacted>')
+    expect(out.session_id).toBe('<redacted>')
+    expect(out.name).toBe('Contact A')
+  })
+
+  it('preserves error envelopes and status evidence (404 body kept)', () => {
+    const m = createUuidMapper()
+    const out = normalizeJson(
+      { success: false, error: { code: 'NOT_FOUND', message: 'Contact not found' } },
+      m,
+      DEFAULT_ARRAY_CAP
+    )
+    expect(out).toEqual({
+      error: { code: 'NOT_FOUND', message: 'Contact not found' },
+      success: false,
+    })
+  })
+
+  it('stable-sorts object keys recursively', () => {
+    const m = createUuidMapper()
+    const out = normalizeJson({ b: 1, a: { d: 2, c: 3 } }, m, DEFAULT_ARRAY_CAP)
+    expect(JSON.stringify(out)).toBe('{"a":{"c":3,"d":2},"b":1}')
+  })
+
+  it('maps UUID values inside bodies and requestBody payloads', () => {
+    const m = createUuidMapper()
+    const out = normalizeJson(
+      { source_contact_id: UUID_A, field_selections: { cadence: 'target' } },
+      m,
+      DEFAULT_ARRAY_CAP
+    )
+    expect(out).toEqual({
+      field_selections: { cadence: 'target' },
+      source_contact_id: '<id:1>',
+    })
+  })
+})
+
+describe('normalizeJson array capping', () => {
+  it('caps arrays at the default 50 with a __truncated__ tail', () => {
+    const m = createUuidMapper()
+    const arr = Array.from({ length: 60 }, (_v, i) => ({ n: i }))
+    const out = normalizeJson(arr, m, DEFAULT_ARRAY_CAP) as unknown[]
+    expect(out).toHaveLength(DEFAULT_ARRAY_CAP + 1)
+    expect(out[DEFAULT_ARRAY_CAP]).toEqual({ __truncated__: 10 })
+  })
+
+  it('arrayCap = Infinity preserves the full array (e.g. CON-045 limit=1000)', () => {
+    const m = createUuidMapper()
+    const arr = Array.from({ length: 300 }, (_v, i) => i)
+    const out = normalizeJson(arr, m, Infinity) as unknown[]
+    expect(out).toHaveLength(300)
+    expect(out.some(v => typeof v === 'object')).toBe(false)
+  })
+})
+
+describe('parseAriaSnapshot', () => {
+  it('parses indentation into nesting', () => {
+    const yaml = ['- navigation "Main":', '  - link "Contacts"', '  - link "Birthdays"'].join('\n')
+    const root = parseAriaSnapshot(yaml)
+    expect(root.children).toHaveLength(1)
+    const nav = root.children![0] as AriaNode
+    expect(nav.role).toBe('navigation')
+    expect(nav.name).toBe('Main')
+    expect(nav.children).toHaveLength(2)
+    expect((nav.children![0] as AriaNode).role).toBe('link')
+    expect((nav.children![1] as AriaNode).name).toBe('Birthdays')
+  })
+
+  it('parses state tokens into node fields', () => {
+    const yaml = [
+      '- button "Previous contact" [disabled]',
+      '- button "Next contact"',
+      '- checkbox "Agree" [checked]',
+      '- checkbox "Partial" [checked=mixed]',
+      '- heading "Contacts" [level=2]',
+      '- button "Toggle" [pressed] [expanded]',
+      '- option "Selected" [selected]',
+    ].join('\n')
+    const kids = parseAriaSnapshot(yaml).children as AriaNode[]
+    expect(kids[0]).toEqual({ role: 'button', name: 'Previous contact', disabled: true })
+    expect(kids[1]).toEqual({ role: 'button', name: 'Next contact' })
+    expect(kids[2].checked).toBe(true)
+    expect(kids[3].checked).toBe('mixed')
+    expect(kids[4].level).toBe(2)
+    expect(kids[5].pressed).toBe(true)
+    expect(kids[5].expanded).toBe(true)
+    expect(kids[6].selected).toBe(true)
+  })
+
+  it('preserves leaf text nodes verbatim (banner / card copy)', () => {
+    const yaml = [
+      '- paragraph:',
+      '  - text: Contacts merged successfully!', // bare scalar (no quoting needed)
+      '- generic: "Value: with colon"', // quoted (a ": " forces quoting)
+    ].join('\n')
+    const kids = parseAriaSnapshot(yaml).children as AriaNode[]
+    const textLeaf = kids[0].children![0] as AriaNode
+    expect(textLeaf).toEqual({ role: 'text', text: 'Contacts merged successfully!' })
+    // A single inlined text child is preserved as a text leaf too.
+    const inlineLeaf = kids[1].children![0] as AriaNode
+    expect(inlineLeaf).toEqual({ role: 'text', text: 'Value: with colon' })
+  })
+
+  it('drops non-deterministic ref / cursor tokens', () => {
+    const yaml = '- button "Delete" [ref=e12] [cursor=pointer]'
+    const node = (parseAriaSnapshot(yaml).children as AriaNode[])[0]
+    expect(node).toEqual({ role: 'button', name: 'Delete' })
+  })
+
+  it('handles a single-quote-wrapped key (name with YAML-special chars)', () => {
+    // Playwright wraps the WHOLE createKey (role + name + [tokens]) in single
+    // quotes when it needs escaping; '' escapes a literal quote. The ": " in the
+    // name is what forces the wrap here.
+    const yaml = `- 'button "It''s: here" [disabled]'`
+    const node = (parseAriaSnapshot(yaml).children as AriaNode[])[0]
+    expect(node.role).toBe('button')
+    expect(node.name).toBe("It's: here")
+    expect(node.disabled).toBe(true)
+  })
+})
+
+describe('normalizeAriaTree', () => {
+  it('UUID-maps names and text and caps repeated siblings at the default 20', () => {
+    const parent: AriaNode = {
+      role: 'list',
+      children: Array.from({ length: 25 }, (_v, i) => ({
+        role: 'listitem' as const,
+        name: `item ${i} ${UUID_A}`,
+      })),
+    }
+    const m = createUuidMapper()
+    const out = normalizeAriaTree(parent, m, DEFAULT_ARIA_CAP)
+    expect(out.children).toHaveLength(DEFAULT_ARIA_CAP + 1)
+    expect((out.children![0] as AriaNode).name).toBe('item 0 <id:1>')
+    expect(out.children![DEFAULT_ARIA_CAP]).toEqual({ __ariaTruncated__: 5 })
+  })
+
+  it('ariaCap = Infinity preserves ALL siblings (e.g. CON-045 birthday cards)', () => {
+    const parent: AriaNode = {
+      role: 'list',
+      children: Array.from({ length: 40 }, () => ({ role: 'listitem' as const })),
+    }
+    const out = normalizeAriaTree(parent, createUuidMapper(), Infinity)
+    expect(out.children).toHaveLength(40)
+    expect(out.children!.every(c => 'role' in c)).toBe(true)
+  })
+
+  it('carries state fields through normalization', () => {
+    const out = normalizeAriaTree(
+      { role: 'button', name: 'Previous contact', disabled: true },
+      createUuidMapper(),
+      DEFAULT_ARIA_CAP
+    )
+    expect(out).toEqual({ role: 'button', name: 'Previous contact', disabled: true })
+  })
+})

--- a/frontend/tests/tours/support/normalize.test.ts
+++ b/frontend/tests/tours/support/normalize.test.ts
@@ -83,6 +83,15 @@ describe('normalizeUrl / parseQuery / endpointKey', () => {
     )
     expect(parseQuery('https://h/api/v1/contacts?limit=1000', m).limit).toBe('1000')
   })
+
+  it('parses query on a RELATIVE path too (harness probe paths)', () => {
+    const m = createUuidMapper()
+    expect(parseQuery(`/api/v1/contacts?source_id=${UUID_A}&x=1`, m)).toEqual({
+      source_id: '<id:1>',
+      x: '1',
+    })
+    expect(parseQuery(`/api/v1/contacts/${UUID_A}`, m)).toEqual({})
+  })
 })
 
 describe('normalizeJson deny-list vs preserve-list', () => {

--- a/frontend/tests/tours/support/normalize.test.ts
+++ b/frontend/tests/tours/support/normalize.test.ts
@@ -92,6 +92,13 @@ describe('normalizeUrl / parseQuery / endpointKey', () => {
     })
     expect(parseQuery(`/api/v1/contacts/${UUID_A}`, m)).toEqual({})
   })
+
+  it('templates the endpoint key on a RELATIVE path too (harness probe paths)', () => {
+    expect(endpointKey('GET', `/api/v1/contacts/${UUID_A}`)).toBe('GET /api/v1/contacts/:id')
+    expect(endpointKey('GET', `/api/v1/contacts/${UUID_A}/merge/preview?source_id=x`)).toBe(
+      'GET /api/v1/contacts/:id/merge/preview'
+    )
+  })
 })
 
 describe('normalizeJson deny-list vs preserve-list', () => {
@@ -137,6 +144,59 @@ describe('normalizeJson deny-list vs preserve-list', () => {
     expect(out.csrf_token).toBe('<redacted>')
     expect(out.session_id).toBe('<redacted>')
     expect(out.name).toBe('Contact A')
+  })
+
+  it('sentinels every transport-noise and secret-bearing key name', () => {
+    const m = createUuidMapper()
+    const secretKeys = [
+      // REDACT_DENY
+      'etag',
+      'request_id',
+      'requestid',
+      'trace_id',
+      'traceid',
+      // TOKEN_KEY
+      'token',
+      'access_token',
+      'refresh_token',
+      'csrf',
+      'secret',
+      'client_secret',
+      'session_id',
+      'password',
+      'passphrase',
+      'api_key',
+      'apikey',
+      'api-key',
+      'authorization',
+      'bearer',
+      'private_key',
+      'private-key',
+      'access_key',
+    ]
+    for (const key of secretKeys) {
+      const out = normalizeJson({ [key]: 'sensitive-value' }, m, DEFAULT_ARRAY_CAP) as Record<
+        string,
+        string
+      >
+      expect(out[key], `${key} should be sentineled`).toBe('<redacted>')
+    }
+  })
+
+  it('scrubs the host of absolute URLs inside body string values', () => {
+    const m = createUuidMapper()
+    const out = normalizeJson(
+      {
+        profile_photo: `https://staging-secret.example.com/photos/${UUID_A}.jpg?v=1`,
+        error: 'failed to reach http://staging-secret.example.com:8080/api/v1/x',
+        full_name: 'Contact A',
+      },
+      m,
+      DEFAULT_ARRAY_CAP
+    ) as Record<string, string>
+    expect(out.profile_photo).toBe('https://<host>/photos/<id:1>.jpg?v=1')
+    expect(out.error).toBe('failed to reach http://<host>/api/v1/x')
+    expect(out.full_name).toBe('Contact A') // non-URL strings untouched
   })
 
   it('preserves error envelopes and status evidence (404 body kept)', () => {
@@ -212,6 +272,7 @@ describe('parseAriaSnapshot', () => {
       '- heading "Contacts" [level=2]',
       '- button "Toggle" [pressed] [expanded]',
       '- option "Selected" [selected]',
+      '- option "Focused" [active]',
     ].join('\n')
     const kids = parseAriaSnapshot(yaml).children as AriaNode[]
     expect(kids[0]).toEqual({ role: 'button', name: 'Previous contact', disabled: true })
@@ -222,6 +283,7 @@ describe('parseAriaSnapshot', () => {
     expect(kids[5].pressed).toBe(true)
     expect(kids[5].expanded).toBe(true)
     expect(kids[6].selected).toBe(true)
+    expect(kids[7].active).toBe(true)
   })
 
   it('preserves leaf text nodes verbatim (banner / card copy)', () => {
@@ -289,5 +351,18 @@ describe('normalizeAriaTree', () => {
       DEFAULT_ARIA_CAP
     )
     expect(out).toEqual({ role: 'button', name: 'Previous contact', disabled: true })
+  })
+
+  it('host-scrubs absolute URLs inside aria names/text', () => {
+    const out = normalizeAriaTree(
+      {
+        role: 'link',
+        name: 'photo',
+        children: [{ role: 'text', text: 'https://staging-secret.example.com/p.jpg' }],
+      },
+      createUuidMapper(),
+      DEFAULT_ARIA_CAP
+    )
+    expect((out.children![0] as AriaNode).text).toBe('https://<host>/p.jpg')
   })
 })

--- a/frontend/tests/tours/support/normalize.ts
+++ b/frontend/tests/tours/support/normalize.ts
@@ -22,7 +22,10 @@ const UUID_SEGMENT = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{
 const TIMESTAMP_DENY = new Set(['created_at', 'updated_at'])
 // Transport noise → inert <redacted> sentinel.
 const REDACT_DENY = new Set(['etag', 'request_id', 'requestid', 'trace_id', 'traceid'])
-const TOKEN_KEY = /token|csrf|secret|session_id/i
+// Secret-bearing key names → inert <redacted> sentinel. Kept broad so a future
+// tour over a settings/oauth surface cannot leak a credential value.
+const TOKEN_KEY =
+  /token|csrf|secret|session_id|password|passphrase|api[_-]?key|apikey|authorization|bearer|private[_-]?key|access[_-]?key/i
 
 // ---------------------------------------------------------------------------
 // Run-scoped UUID → ordinal mapper
@@ -52,6 +55,26 @@ export function createUuidMapper(): UuidMapper {
 
 export function mapUuids(value: string, mapper: UuidMapper): string {
   return value.replace(UUID_GLOBAL, m => mapper.map(m))
+}
+
+// Redact the host of any absolute http(s) URL embedded in a string value (e.g. a
+// profile_photo DTO field or an error-body URL), keeping the path + query. This
+// is defense-in-depth alongside the non-production target guard, so captures
+// never carry a real hostname even inside body/aria text.
+export function scrubHosts(value: string): string {
+  return value.replace(/https?:\/\/[^\s"'<>)\]}]+/gi, m => {
+    try {
+      const u = new URL(m)
+      return `${u.protocol}//<host>${u.pathname}${u.search}`
+    } catch {
+      return m
+    }
+  })
+}
+
+// Host-redact then UUID-map a free-text value (body strings, aria names/text).
+function scrubString(value: string, mapper: UuidMapper): string {
+  return mapUuids(scrubHosts(value), mapper)
 }
 
 // ---------------------------------------------------------------------------
@@ -108,7 +131,7 @@ export function endpointKey(method: string, url: string): string {
 
 export function normalizeJson(value: unknown, mapper: UuidMapper, arrayCap: number): unknown {
   if (value === null || value === undefined) return value
-  if (typeof value === 'string') return mapUuids(value, mapper)
+  if (typeof value === 'string') return scrubString(value, mapper)
   if (typeof value === 'number' || typeof value === 'boolean') return value
 
   if (Array.isArray(value)) {
@@ -342,8 +365,8 @@ export function parseAriaSnapshot(yaml: string): AriaNode {
 // Normalize a parsed aria tree: UUID-map names + text, cap repeated siblings.
 export function normalizeAriaTree(node: AriaNode, mapper: UuidMapper, ariaCap: number): AriaNode {
   const out: AriaNode = { role: node.role }
-  if (node.name !== undefined) out.name = mapUuids(node.name, mapper)
-  if (node.text !== undefined) out.text = mapUuids(node.text, mapper)
+  if (node.name !== undefined) out.name = scrubString(node.name, mapper)
+  if (node.text !== undefined) out.text = scrubString(node.text, mapper)
   if (node.disabled !== undefined) out.disabled = node.disabled
   if (node.checked !== undefined) out.checked = node.checked
   if (node.expanded !== undefined) out.expanded = node.expanded

--- a/frontend/tests/tours/support/normalize.ts
+++ b/frontend/tests/tours/support/normalize.ts
@@ -1,0 +1,365 @@
+// Deterministic, conservative normalization for the tours capture format
+// (arc §1c/§1d). Pure functions only — NO Playwright import — so this module is
+// unit-testable without a browser (see normalize.test.ts) and importable by
+// PR2's grader.
+//
+// Design: preserve-by-default, deny-list only. A blunt "strip all
+// timestamps/ids" would destroy the very evidence time- and identity-dependent
+// verifiers must read, so we MAP UUIDs (never drop), sentinel only transport /
+// audit-only noise, and preserve semantic dates + query strings.
+
+import type { AriaChild, AriaNode } from './types'
+
+export const DEFAULT_ARRAY_CAP = 50
+export const DEFAULT_ARIA_CAP = 20
+
+const UUID_GLOBAL = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi
+const UUID_SEGMENT = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+// Audit-only wall-clock columns no toured behavior references → inert <ts>
+// sentinel (key structure preserved). Behavior-relevant dates (contact_by,
+// last_contacted, birthday, occurred_at, deleted_at, …) are NOT here and so
+// survive verbatim.
+const TIMESTAMP_DENY = new Set(['created_at', 'updated_at'])
+// Transport noise → inert <redacted> sentinel.
+const REDACT_DENY = new Set(['etag', 'request_id', 'requestid', 'trace_id', 'traceid'])
+const TOKEN_KEY = /token|csrf|secret|session_id/i
+
+// ---------------------------------------------------------------------------
+// Run-scoped UUID → ordinal mapper (arc §1c-1)
+// ---------------------------------------------------------------------------
+
+export interface UuidMapper {
+  map(uuid: string): string
+}
+
+// A first-seen map so the same UUID → the same <id:N> across every capture in a
+// run (before/after pairs correlate; PII-safe; structure-preserving).
+export function createUuidMapper(): UuidMapper {
+  const seen = new Map<string, string>()
+  let n = 0
+  return {
+    map(uuid: string): string {
+      const key = uuid.toLowerCase()
+      let placeholder = seen.get(key)
+      if (!placeholder) {
+        placeholder = `<id:${++n}>`
+        seen.set(key, placeholder)
+      }
+      return placeholder
+    },
+  }
+}
+
+export function mapUuids(value: string, mapper: UuidMapper): string {
+  return value.replace(UUID_GLOBAL, m => mapper.map(m))
+}
+
+// ---------------------------------------------------------------------------
+// URL normalization (arc §1c-3): host-stripped, query preserved, UUIDs mapped
+// ---------------------------------------------------------------------------
+
+function stripHost(url: string): string {
+  try {
+    const u = new URL(url)
+    return u.pathname + u.search
+  } catch {
+    return url
+  }
+}
+
+export function normalizeUrl(url: string, mapper: UuidMapper): string {
+  return mapUuids(stripHost(url), mapper)
+}
+
+export function parseQuery(url: string, mapper: UuidMapper): Record<string, string> {
+  const out: Record<string, string> = {}
+  try {
+    const u = new URL(url)
+    const keys = [...u.searchParams.keys()].sort()
+    for (const k of keys) {
+      out[k] = mapUuids(u.searchParams.get(k) ?? '', mapper)
+    }
+  } catch {
+    // Non-URL input yields an empty query.
+  }
+  return out
+}
+
+// The grouping key: "<METHOD> <path with UUID segments → :id>" (arc §1a).
+export function endpointKey(method: string, url: string): string {
+  let path: string
+  try {
+    path = new URL(url).pathname
+  } catch {
+    path = url.split('?')[0]
+  }
+  const templated = path
+    .split('/')
+    .map(seg => (UUID_SEGMENT.test(seg) ? ':id' : seg))
+    .join('/')
+  return `${method} ${templated}`
+}
+
+// ---------------------------------------------------------------------------
+// JSON body normalization (arc §1c-2/4/5)
+// ---------------------------------------------------------------------------
+
+export function normalizeJson(value: unknown, mapper: UuidMapper, arrayCap: number): unknown {
+  if (value === null || value === undefined) return value
+  if (typeof value === 'string') return mapUuids(value, mapper)
+  if (typeof value === 'number' || typeof value === 'boolean') return value
+
+  if (Array.isArray(value)) {
+    let arr = value
+    let truncated = 0
+    if (Number.isFinite(arrayCap) && arr.length > arrayCap) {
+      truncated = arr.length - arrayCap
+      arr = arr.slice(0, arrayCap)
+    }
+    const out: unknown[] = arr.map(v => normalizeJson(v, mapper, arrayCap))
+    if (truncated > 0) out.push({ __truncated__: truncated })
+    return out
+  }
+
+  if (typeof value === 'object') {
+    const src = value as Record<string, unknown>
+    const out: Record<string, unknown> = {}
+    for (const key of Object.keys(src).sort()) {
+      if (TIMESTAMP_DENY.has(key)) {
+        out[key] = '<ts>'
+      } else if (REDACT_DENY.has(key) || TOKEN_KEY.test(key)) {
+        out[key] = '<redacted>'
+      } else {
+        out[key] = normalizeJson(src[key], mapper, arrayCap)
+      }
+    }
+    return out
+  }
+
+  return value
+}
+
+// ---------------------------------------------------------------------------
+// Aria snapshot YAML → node tree (arc §1d) — the key testable seam
+// ---------------------------------------------------------------------------
+
+// Unescape a YAML double-quoted scalar (Playwright's yamlEscapeValueIfNeeded /
+// JSON.stringify emit these; the escaper is a JSON superset with \xNN).
+function unescapeDoubleQuoted(raw: string): string {
+  const inner = raw.slice(1, -1)
+  return inner.replace(/\\(x[0-9a-fA-F]{2}|u[0-9a-fA-F]{4}|.)/g, (_m, esc: string) => {
+    if (esc[0] === 'x' || esc[0] === 'u') return String.fromCharCode(parseInt(esc.slice(1), 16))
+    switch (esc) {
+      case 'n':
+        return '\n'
+      case 'r':
+        return '\r'
+      case 't':
+        return '\t'
+      case 'b':
+        return '\b'
+      case 'f':
+        return '\f'
+      case '"':
+        return '"'
+      case '\\':
+        return '\\'
+      case '/':
+        return '/'
+      default:
+        return esc
+    }
+  })
+}
+
+// A YAML scalar is either a double-quoted string or a bare value.
+function parseScalar(raw: string): string {
+  const trimmed = raw.trim()
+  if (trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    return unescapeDoubleQuoted(trimmed)
+  }
+  return trimmed
+}
+
+// Read a JSON-style double-quoted string starting at s[i] (s[i] === '"').
+function readJsonString(s: string, i: number): { value: string; end: number } {
+  let j = i + 1
+  while (j < s.length) {
+    if (s[j] === '\\') {
+      j += 2
+      continue
+    }
+    if (s[j] === '"') break
+    j++
+  }
+  const raw = s.slice(i, j + 1)
+  return { value: unescapeDoubleQuoted(raw), end: j + 1 }
+}
+
+// Read a "[token]" starting at s[i] (s[i] === '[').
+function readBracket(s: string, i: number): { token: string; end: number } {
+  let j = i + 1
+  while (j < s.length && s[j] !== ']') j++
+  return { token: s.slice(i + 1, j), end: j + 1 }
+}
+
+// Read a YAML single-quoted string starting at s[0] === "'" (Playwright wraps a
+// whole createKey in single quotes when it needs escaping; '' → ').
+function readSingleQuoted(s: string): { value: string; rest: string } {
+  let j = 1
+  let out = ''
+  while (j < s.length) {
+    if (s[j] === "'") {
+      if (s[j + 1] === "'") {
+        out += "'"
+        j += 2
+        continue
+      }
+      j++ // consume closing quote
+      break
+    }
+    out += s[j]
+    j++
+  }
+  return { value: out, rest: s.slice(j) }
+}
+
+function applyToken(node: AriaNode, token: string): void {
+  if (token === 'disabled') node.disabled = true
+  else if (token === 'checked') node.checked = true
+  else if (token === 'checked=mixed') node.checked = 'mixed'
+  else if (token === 'expanded') node.expanded = true
+  else if (token === 'active') node.active = true
+  else if (token === 'pressed') node.pressed = true
+  else if (token === 'pressed=mixed') node.pressed = 'mixed'
+  else if (token === 'selected') node.selected = true
+  else if (token.startsWith('level=')) node.level = Number(token.slice('level='.length))
+  // ref= and cursor=pointer are non-deterministic / not part of the contract — dropped.
+}
+
+// Parse a createKey string: role ["name"] [tokens...] (no trailing marker).
+function parseKey(s: string): AriaNode {
+  const str = s.trim()
+  let i = 0
+  while (i < str.length && str[i] !== ' ' && str[i] !== '"' && str[i] !== '[') i++
+  const node: AriaNode = { role: str.slice(0, i) }
+  while (i < str.length) {
+    const c = str[i]
+    if (c === ' ') {
+      i++
+    } else if (c === '"') {
+      const r = readJsonString(str, i)
+      node.name = r.value
+      i = r.end
+    } else if (c === '[') {
+      const r = readBracket(str, i)
+      applyToken(node, r.token)
+      i = r.end
+    } else {
+      i++ // unexpected char — skip defensively
+    }
+  }
+  return node
+}
+
+// Split "key: value" / "key:" respecting quoted names (a ':' inside a name must
+// not be read as the marker).
+function splitKeyAndMarker(s: string): { key: string; marker: string } {
+  let inStr = false
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i]
+    if (inStr) {
+      if (c === '\\') {
+        i++
+        continue
+      }
+      if (c === '"') inStr = false
+      continue
+    }
+    if (c === '"') inStr = true
+    else if (c === ':') return { key: s.slice(0, i), marker: s.slice(i) }
+  }
+  return { key: s, marker: '' }
+}
+
+// The marker is '' | ':' (has children) | ': <value>' (single inline text child).
+function markerToInlineText(marker: string): string | undefined {
+  if (marker === '' || marker === ':') return undefined
+  if (marker.startsWith(': ')) return parseScalar(marker.slice(2))
+  return parseScalar(marker.slice(1).replace(/^\s+/, ''))
+}
+
+function parseNodeLine(content: string): AriaNode {
+  const rest = content.slice(2) // drop the leading "- "
+  if (rest.startsWith('text:')) {
+    return { role: 'text', text: parseScalar(rest.slice('text:'.length).replace(/^\s+/, '')) }
+  }
+  let keyStr: string
+  let marker: string
+  if (rest.startsWith("'")) {
+    const r = readSingleQuoted(rest)
+    keyStr = r.value
+    marker = r.rest
+  } else {
+    const split = splitKeyAndMarker(rest)
+    keyStr = split.key
+    marker = split.marker
+  }
+  const node = parseKey(keyStr)
+  const inline = markerToInlineText(marker)
+  if (inline !== undefined) node.children = [{ role: 'text', text: inline }]
+  return node
+}
+
+function countIndent(line: string): number {
+  let n = 0
+  while (n < line.length && line[n] === ' ') n++
+  return n
+}
+
+// Parse Playwright's ariaSnapshot() YAML into a single root node whose children
+// are the snapshot's top-level nodes. Indentation drives nesting.
+export function parseAriaSnapshot(yaml: string): AriaNode {
+  const root: AriaNode = { role: 'root', children: [] }
+  const stack: Array<{ indent: number; node: AriaNode }> = [{ indent: -1, node: root }]
+  const lines = yaml.split('\n')
+  for (const rawLine of lines) {
+    if (rawLine.trim() === '') continue
+    const indent = countIndent(rawLine)
+    const content = rawLine.slice(indent)
+    if (!content.startsWith('- ')) continue // defensive: skip malformed lines
+    const node = parseNodeLine(content)
+    while (stack.length > 1 && stack[stack.length - 1].indent >= indent) stack.pop()
+    const parent = stack[stack.length - 1].node
+    ;(parent.children ??= []).push(node)
+    stack.push({ indent, node })
+  }
+  return root
+}
+
+// Normalize a parsed aria tree: UUID-map names + text, cap repeated siblings.
+export function normalizeAriaTree(node: AriaNode, mapper: UuidMapper, ariaCap: number): AriaNode {
+  const out: AriaNode = { role: node.role }
+  if (node.name !== undefined) out.name = mapUuids(node.name, mapper)
+  if (node.text !== undefined) out.text = mapUuids(node.text, mapper)
+  if (node.disabled !== undefined) out.disabled = node.disabled
+  if (node.checked !== undefined) out.checked = node.checked
+  if (node.expanded !== undefined) out.expanded = node.expanded
+  if (node.level !== undefined) out.level = node.level
+  if (node.pressed !== undefined) out.pressed = node.pressed
+  if (node.selected !== undefined) out.selected = node.selected
+  if (node.active !== undefined) out.active = node.active
+  if (node.children && node.children.length > 0) {
+    let kids = node.children as AriaNode[]
+    let truncated = 0
+    if (Number.isFinite(ariaCap) && kids.length > ariaCap) {
+      truncated = kids.length - ariaCap
+      kids = kids.slice(0, ariaCap)
+    }
+    const children: AriaChild[] = kids.map(k => normalizeAriaTree(k, mapper, ariaCap))
+    if (truncated > 0) children.push({ __ariaTruncated__: truncated })
+    out.children = children
+  }
+  return out
+}

--- a/frontend/tests/tours/support/normalize.ts
+++ b/frontend/tests/tours/support/normalize.ts
@@ -1,7 +1,6 @@
-// Deterministic, conservative normalization for the tours capture format
-// (arc §1c/§1d). Pure functions only — NO Playwright import — so this module is
-// unit-testable without a browser (see normalize.test.ts) and importable by
-// PR2's grader.
+// Deterministic, conservative normalization for the tours capture format.
+// Pure functions only — NO Playwright import — so this module is unit-testable
+// without a browser (see normalize.test.ts) and importable by the grader.
 //
 // Design: preserve-by-default, deny-list only. A blunt "strip all
 // timestamps/ids" would destroy the very evidence time- and identity-dependent
@@ -26,7 +25,7 @@ const REDACT_DENY = new Set(['etag', 'request_id', 'requestid', 'trace_id', 'tra
 const TOKEN_KEY = /token|csrf|secret|session_id/i
 
 // ---------------------------------------------------------------------------
-// Run-scoped UUID → ordinal mapper (arc §1c-1)
+// Run-scoped UUID → ordinal mapper
 // ---------------------------------------------------------------------------
 
 export interface UuidMapper {
@@ -56,7 +55,7 @@ export function mapUuids(value: string, mapper: UuidMapper): string {
 }
 
 // ---------------------------------------------------------------------------
-// URL normalization (arc §1c-3): host-stripped, query preserved, UUIDs mapped
+// URL normalization: host-stripped, query preserved, UUIDs mapped
 // ---------------------------------------------------------------------------
 
 function stripHost(url: string): string {
@@ -75,7 +74,9 @@ export function normalizeUrl(url: string, mapper: UuidMapper): string {
 export function parseQuery(url: string, mapper: UuidMapper): Record<string, string> {
   const out: Record<string, string> = {}
   try {
-    const u = new URL(url)
+    // A dummy base lets both absolute URLs (base ignored) and relative paths
+    // (e.g. a harness probe path) parse, so probe items preserve query too.
+    const u = new URL(url, 'http://localhost')
     const keys = [...u.searchParams.keys()].sort()
     for (const k of keys) {
       out[k] = mapUuids(u.searchParams.get(k) ?? '', mapper)
@@ -86,7 +87,7 @@ export function parseQuery(url: string, mapper: UuidMapper): Record<string, stri
   return out
 }
 
-// The grouping key: "<METHOD> <path with UUID segments → :id>" (arc §1a).
+// The grouping key: "<METHOD> <path with UUID segments → :id>".
 export function endpointKey(method: string, url: string): string {
   let path: string
   try {
@@ -102,7 +103,7 @@ export function endpointKey(method: string, url: string): string {
 }
 
 // ---------------------------------------------------------------------------
-// JSON body normalization (arc §1c-2/4/5)
+// JSON body normalization: sentinel deny-list keys, sort keys, cap arrays
 // ---------------------------------------------------------------------------
 
 export function normalizeJson(value: unknown, mapper: UuidMapper, arrayCap: number): unknown {
@@ -141,7 +142,7 @@ export function normalizeJson(value: unknown, mapper: UuidMapper, arrayCap: numb
 }
 
 // ---------------------------------------------------------------------------
-// Aria snapshot YAML → node tree (arc §1d) — the key testable seam
+// Aria snapshot YAML → node tree — the key testable seam
 // ---------------------------------------------------------------------------
 
 // Unescape a YAML double-quoted scalar (Playwright's yamlEscapeValueIfNeeded /

--- a/frontend/tests/tours/support/run-dir.ts
+++ b/frontend/tests/tours/support/run-dir.ts
@@ -1,0 +1,47 @@
+// Run-directory resolution + the runId handoff between globalSetup (main
+// process) and capture() (worker process). globalSetup writes a CURRENT_RUN_ID
+// marker; capture() reads it (preferring TOURS_RUN_ID when the wrapper exported
+// one). Both anchor the .runs tree relative to this file, so the resolution is
+// independent of the invocation cwd.
+
+import * as fs from 'fs'
+import * as path from 'path'
+
+// support/ → tests/tours/. `typeof __dirname` is safe even when undeclared.
+const supportDir =
+  typeof __dirname !== 'undefined' ? __dirname : path.resolve(process.cwd(), 'tests/tours/support')
+
+export const RUNS_ROOT = path.resolve(supportDir, '..', '.runs')
+const MARKER = path.join(RUNS_ROOT, 'CURRENT_RUN_ID')
+
+// A filesystem-safe wall-clock run id (arc §1a: <runId> = run wall timestamp).
+export function generateRunId(): string {
+  return new Date().toISOString().replace(/[:.]/g, '-')
+}
+
+export function setCurrentRunId(runId: string): void {
+  fs.mkdirSync(RUNS_ROOT, { recursive: true })
+  fs.writeFileSync(MARKER, runId, 'utf8')
+}
+
+export function getCurrentRunId(): string {
+  const fromEnv = process.env.TOURS_RUN_ID
+  if (fromEnv) return fromEnv
+  try {
+    return fs.readFileSync(MARKER, 'utf8').trim()
+  } catch {
+    throw new Error('tours: no current run id — globalSetup must run before capture()')
+  }
+}
+
+export function runDir(runId: string): string {
+  return path.join(RUNS_ROOT, runId)
+}
+
+export function capturesDir(runId: string, tour: string): string {
+  return path.join(runDir(runId), 'captures', tour)
+}
+
+export function manifestPath(runId: string): string {
+  return path.join(runDir(runId), 'manifest.json')
+}

--- a/frontend/tests/tours/support/run-dir.ts
+++ b/frontend/tests/tours/support/run-dir.ts
@@ -14,7 +14,7 @@ const supportDir =
 export const RUNS_ROOT = path.resolve(supportDir, '..', '.runs')
 const MARKER = path.join(RUNS_ROOT, 'CURRENT_RUN_ID')
 
-// A filesystem-safe wall-clock run id (arc §1a: <runId> = run wall timestamp).
+// A filesystem-safe wall-clock run id (the run's wall timestamp).
 export function generateRunId(): string {
   return new Date().toISOString().replace(/[:.]/g, '-')
 }

--- a/frontend/tests/tours/support/tour-fixtures.ts
+++ b/frontend/tests/tours/support/tour-fixtures.ts
@@ -1,0 +1,44 @@
+// The tours test fixture. Extends @playwright/test with a per-test `tour` that
+// bundles: a dedicated APIRequestContext carrying X-API-Key (D3), a
+// context-level /api/v1 response buffer attached BEFORE the first navigation
+// (D4/D9), and the capture()/withDialog()/waitForApi()/holdRoute() helpers.
+//
+// Tours import ONLY `test` from here — never `expect` — so they stay
+// assertion-free (arc §3).
+
+import { test as base, type Response } from '@playwright/test'
+import { TourApi } from './capture'
+
+export const test = base.extend<{ tour: TourApi }>({
+  tour: async ({ page, playwright }, use, testInfo) => {
+    const apiBase = process.env.TOURS_API_URL || process.env.TOURS_BASE_URL
+    const apiKey = process.env.TOURS_API_KEY
+    if (!apiBase || !apiKey) {
+      throw new Error(
+        'tours: TOURS_API_URL (or TOURS_BASE_URL) and TOURS_API_KEY must be set (see scripts/run-tours.sh)'
+      )
+    }
+
+    const apiCtx = await playwright.request.newContext({
+      baseURL: apiBase,
+      extraHTTPHeaders: { 'X-API-Key': apiKey },
+    })
+
+    // Buffer every /api/v1 response since the last capture. Attached before the
+    // test body runs (hence before its first navigation) so no early response
+    // is missed.
+    const buffer: Response[] = []
+    const onResponse = (resp: Response): void => {
+      if (resp.url().includes('/api/v1/')) buffer.push(resp)
+    }
+    page.context().on('response', onResponse)
+
+    const tour = new TourApi(apiCtx, buffer, testInfo)
+    try {
+      await use(tour)
+    } finally {
+      page.context().off('response', onResponse)
+      await apiCtx.dispose()
+    }
+  },
+})

--- a/frontend/tests/tours/support/tour-fixtures.ts
+++ b/frontend/tests/tours/support/tour-fixtures.ts
@@ -1,10 +1,11 @@
 // The tours test fixture. Extends @playwright/test with a per-test `tour` that
-// bundles: a dedicated APIRequestContext carrying X-API-Key (D3), a
-// context-level /api/v1 response buffer attached BEFORE the first navigation
-// (D4/D9), and the capture()/withDialog()/waitForApi()/holdRoute() helpers.
+// bundles: a dedicated APIRequestContext carrying X-API-Key, a context-level
+// /api/v1 response buffer attached BEFORE the first navigation (so no early
+// response is missed), and the capture()/withDialog()/waitForApi()/holdRoute()
+// helpers.
 //
 // Tours import ONLY `test` from here — never `expect` — so they stay
-// assertion-free (arc §3).
+// assertion-free.
 
 import { test as base, type Response } from '@playwright/test'
 import { TourApi } from './capture'

--- a/frontend/tests/tours/support/types.ts
+++ b/frontend/tests/tours/support/types.ts
@@ -3,9 +3,11 @@
 // This is the single load-bearing interface of the arc: PR1 produces it, and
 // PR2's hybrid grader + PR3's corpus consume it. The schema is authored here
 // per arc §1 and versioned via captureFormatVersion / captureGeneratorVersion —
-// any schema change bumps both (arc §3). Keep this file free of any Playwright
-// import so the pure normalizer + its unit tests can consume it without a
-// browser runtime.
+// any schema change bumps both (arc §3). The only Playwright reference is the
+// type-only `Locator` import below (erased at compile time — the pure normalizer
+// and its vitest unit tests never load a browser runtime).
+
+import type { Locator } from '@playwright/test'
 
 export const CAPTURE_FORMAT_VERSION = 1
 export const CAPTURE_GENERATOR_VERSION = 1
@@ -113,7 +115,8 @@ export interface Manifest {
 }
 
 // Options accepted by capture(). `behaviors` + `note` are required; everything
-// else is optional per-capture tuning (arc §1a/§1c-5).
+// else is optional per-capture tuning (arc §1a/§1c-5). `ariaRoot` is an
+// authoring-time locator, NOT part of the emitted record.
 export interface CaptureOptions {
   behaviors: string[]
   note: string
@@ -126,6 +129,12 @@ export interface CaptureOptions {
   arrayCap?: number
   /** Aria sibling cap (default 20; Infinity preserves all siblings). */
   ariaCap?: number
+  /**
+   * Element to root the aria snapshot at (default: the page body). Scope to an
+   * overlay (e.g. a modal) so its focused subtree is not truncated out of a
+   * content-rich body by ariaCap.
+   */
+  ariaRoot?: Locator
 }
 
 export interface ApiProbe {

--- a/frontend/tests/tours/support/types.ts
+++ b/frontend/tests/tours/support/types.ts
@@ -1,21 +1,21 @@
-// Shared capture-format contract for the tours harness (Piece 4 Track B, #606).
+// Shared capture-format contract for the tours harness.
 //
-// This is the single load-bearing interface of the arc: PR1 produces it, and
-// PR2's hybrid grader + PR3's corpus consume it. The schema is authored here
-// per arc §1 and versioned via captureFormatVersion / captureGeneratorVersion —
-// any schema change bumps both (arc §3). The only Playwright reference is the
-// type-only `Locator` import below (erased at compile time — the pure normalizer
-// and its vitest unit tests never load a browser runtime).
+// This is the single load-bearing interface: the tours produce these records
+// and the downstream grader + corpus consume them. It is versioned via
+// captureFormatVersion / captureGeneratorVersion — bump both on any schema
+// change. The only Playwright reference is the type-only `Locator` import below
+// (erased at compile time — the pure normalizer and its vitest unit tests never
+// load a browser runtime).
 
 import type { Locator } from '@playwright/test'
 
 export const CAPTURE_FORMAT_VERSION = 1
 export const CAPTURE_GENERATOR_VERSION = 1
 
-// A single accessibility node parsed from Playwright's ariaSnapshot() YAML
-// (arc §1d). Element nodes carry a role, an optional accessible name, per-node
-// state (only when its token is present), and children. Visible copy is
-// preserved as leaf text nodes: { role: 'text', text }.
+// A single accessibility node parsed from Playwright's ariaSnapshot() YAML.
+// Element nodes carry a role, an optional accessible name, per-node state (only
+// when its token is present), and children. Visible copy is preserved as leaf
+// text nodes: { role: 'text', text }.
 export interface AriaNode {
   role: string
   /** Accessible name (element nodes) — UUID-mapped, host-redacted. */
@@ -44,11 +44,11 @@ export interface JsonTruncationMarker {
   __truncated__: number
 }
 
-// A single self-describing /api/v1 response item (arc §1a). Items are grouped
-// under a templated endpoint key (e.g. "GET /api/v1/contacts/:id"); the
-// requestUrl + parsed query disambiguate otherwise-identical keys. Mutating
-// requests also carry a normalized requestBody. `probe: true` flags an item
-// obtained by a harness-initiated fetch (D4), not observed on the page.
+// A single self-describing /api/v1 response item. Items are grouped under a
+// templated endpoint key (e.g. "GET /api/v1/contacts/:id"); the requestUrl +
+// parsed query disambiguate otherwise-identical keys. Mutating requests also
+// carry a normalized requestBody. `probe: true` flags an item obtained by a
+// harness-initiated fetch, not observed on the page.
 export interface ApiResponseItem {
   method: string
   requestUrl: string
@@ -63,8 +63,9 @@ export interface ApiResponseItem {
 
 export type ApiResponses = Record<string, ApiResponseItem[]>
 
-// The accelerated server-time frame from GET /api/v1/system/time (arc §1a).
-// Preserved raw — it is the interpretation anchor for time-dependent evidence.
+// The accelerated server-time frame from GET /api/v1/system/time. Preserved raw
+// — it is the interpretation anchor for time-dependent evidence. Every capture
+// is stamped with one (a failed fetch fails the sweep loudly).
 export interface ServerTimeFrame {
   currentTime: string
   isAccelerated: boolean
@@ -74,19 +75,19 @@ export interface ServerTimeFrame {
 }
 
 // Groups an ordered sequence of captures (by seq) that the grader diffs as one
-// bracket. `role` is a free label, NOT an enum (arc §1a).
+// bracket. `role` is a free label, NOT an enum.
 export interface CapturePair {
   id: string
   role: string
 }
 
-// A native browser dialog observed during a capture's bracketed action (D5).
+// A native browser dialog observed during a capture's bracketed action.
 export interface DialogRecord {
   type: string
   message: string
 }
 
-// One capture record — one JSON object per capture() call (arc §1a).
+// One capture record — one JSON object per capture() call.
 export interface Capture {
   captureFormatVersion: number
   tour: string
@@ -95,14 +96,14 @@ export interface Capture {
   note: string
   url: string
   pair: CapturePair | null
-  serverTime: ServerTimeFrame | null
+  serverTime: ServerTimeFrame
   aria: AriaNode
   apiResponses: ApiResponses
   fields?: Record<string, unknown>
   dialogs: DialogRecord[]
 }
 
-// The run manifest (arc §1b). The staging host is redacted.
+// The run manifest. The staging host is redacted.
 export interface Manifest {
   captureFormatVersion: number
   captureGeneratorVersion: number
@@ -115,8 +116,8 @@ export interface Manifest {
 }
 
 // Options accepted by capture(). `behaviors` + `note` are required; everything
-// else is optional per-capture tuning (arc §1a/§1c-5). `ariaRoot` is an
-// authoring-time locator, NOT part of the emitted record.
+// else is optional per-capture tuning. `ariaRoot` is an authoring-time locator,
+// NOT part of the emitted record.
 export interface CaptureOptions {
   behaviors: string[]
   note: string

--- a/frontend/tests/tours/support/types.ts
+++ b/frontend/tests/tours/support/types.ts
@@ -1,0 +1,134 @@
+// Shared capture-format contract for the tours harness (Piece 4 Track B, #606).
+//
+// This is the single load-bearing interface of the arc: PR1 produces it, and
+// PR2's hybrid grader + PR3's corpus consume it. The schema is authored here
+// per arc §1 and versioned via captureFormatVersion / captureGeneratorVersion —
+// any schema change bumps both (arc §3). Keep this file free of any Playwright
+// import so the pure normalizer + its unit tests can consume it without a
+// browser runtime.
+
+export const CAPTURE_FORMAT_VERSION = 1
+export const CAPTURE_GENERATOR_VERSION = 1
+
+// A single accessibility node parsed from Playwright's ariaSnapshot() YAML
+// (arc §1d). Element nodes carry a role, an optional accessible name, per-node
+// state (only when its token is present), and children. Visible copy is
+// preserved as leaf text nodes: { role: 'text', text }.
+export interface AriaNode {
+  role: string
+  /** Accessible name (element nodes) — UUID-mapped, host-redacted. */
+  name?: string
+  /** Verbatim visible copy (role === 'text' leaves) — UUID-mapped. */
+  text?: string
+  disabled?: boolean
+  checked?: boolean | 'mixed'
+  expanded?: boolean
+  level?: number
+  pressed?: boolean | 'mixed'
+  selected?: boolean
+  active?: boolean
+  children?: AriaChild[]
+}
+
+// A sibling-cap marker inserted when a parent has more children than ariaCap.
+export interface AriaTruncationMarker {
+  __ariaTruncated__: number
+}
+
+export type AriaChild = AriaNode | AriaTruncationMarker
+
+// An array-cap marker inserted when a normalized JSON array exceeds arrayCap.
+export interface JsonTruncationMarker {
+  __truncated__: number
+}
+
+// A single self-describing /api/v1 response item (arc §1a). Items are grouped
+// under a templated endpoint key (e.g. "GET /api/v1/contacts/:id"); the
+// requestUrl + parsed query disambiguate otherwise-identical keys. Mutating
+// requests also carry a normalized requestBody. `probe: true` flags an item
+// obtained by a harness-initiated fetch (D4), not observed on the page.
+export interface ApiResponseItem {
+  method: string
+  requestUrl: string
+  query: Record<string, string>
+  status: number
+  // Parsed + normalized JSON body, or null for an empty / non-JSON body
+  // (e.g. a 204). The item + its status is never dropped.
+  body: unknown
+  requestBody?: unknown
+  probe?: boolean
+}
+
+export type ApiResponses = Record<string, ApiResponseItem[]>
+
+// The accelerated server-time frame from GET /api/v1/system/time (arc §1a).
+// Preserved raw — it is the interpretation anchor for time-dependent evidence.
+export interface ServerTimeFrame {
+  currentTime: string
+  isAccelerated: boolean
+  accelerationFactor: number
+  baseTime: string
+  environment?: string
+}
+
+// Groups an ordered sequence of captures (by seq) that the grader diffs as one
+// bracket. `role` is a free label, NOT an enum (arc §1a).
+export interface CapturePair {
+  id: string
+  role: string
+}
+
+// A native browser dialog observed during a capture's bracketed action (D5).
+export interface DialogRecord {
+  type: string
+  message: string
+}
+
+// One capture record — one JSON object per capture() call (arc §1a).
+export interface Capture {
+  captureFormatVersion: number
+  tour: string
+  seq: number
+  behaviors: string[]
+  note: string
+  url: string
+  pair: CapturePair | null
+  serverTime: ServerTimeFrame | null
+  aria: AriaNode
+  apiResponses: ApiResponses
+  fields?: Record<string, unknown>
+  dialogs: DialogRecord[]
+}
+
+// The run manifest (arc §1b). The staging host is redacted.
+export interface Manifest {
+  captureFormatVersion: number
+  captureGeneratorVersion: number
+  gitSha: string
+  stagingImageDigest: string
+  seedProfile: string
+  baseUrl: string
+  timestamp: string
+  runId: string
+}
+
+// Options accepted by capture(). `behaviors` + `note` are required; everything
+// else is optional per-capture tuning (arc §1a/§1c-5).
+export interface CaptureOptions {
+  behaviors: string[]
+  note: string
+  pair?: CapturePair
+  /** Harness-initiated fetches recorded into apiResponses with probe: true. */
+  probes?: ApiProbe[]
+  /** Named structured values read directly (e.g. an input's live value). */
+  fields?: Record<string, unknown>
+  /** Response-array cap (default 50; Infinity preserves the full array). */
+  arrayCap?: number
+  /** Aria sibling cap (default 20; Infinity preserves all siblings). */
+  ariaCap?: number
+}
+
+export interface ApiProbe {
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
+  path: string
+}

--- a/frontend/tests/tours/support/types.ts
+++ b/frontend/tests/tours/support/types.ts
@@ -87,9 +87,12 @@ export interface DialogRecord {
   message: string
 }
 
-// One capture record — one JSON object per capture() call.
+// One capture record — one JSON object per capture() call. Both version fields
+// are stamped so a single capture file is self-describing (the manifest also
+// carries captureGeneratorVersion at the run level).
 export interface Capture {
   captureFormatVersion: number
+  captureGeneratorVersion: number
   tour: string
   seq: number
   behaviors: string[]

--- a/scripts/run-tours.sh
+++ b/scripts/run-tours.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Reset-before-run wrapper for the agentic UX QA tours (Piece 4 Track B, #606).
+#
+# Runs staging-reset.sh (ssh) for a known prod-shaped world BEFORE Playwright
+# launches, resolves the deployed staging image digest (read-only ssh, mirroring
+# staging-reset.sh's read_image_ref WITHOUT modifying that shared script),
+# exports the run env, then launches the dedicated tours config.
+#
+# Config comes from ENV ONLY (never committed):
+#   TOURS_BASE_URL   staging frontend base URL (required)
+#   TOURS_API_KEY    staging X-API-Key         (required)
+#   TOURS_API_URL    staging backend base URL  (optional; defaults to TOURS_BASE_URL)
+#   TOURS_SKIP_RESET=1  skip staging-reset (dev iteration against a seeded staging)
+#
+# Usage: scripts/run-tours.sh [extra playwright args...]   (or: make tours)
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# --- Required env (fail loud) ---
+missing=()
+[ -n "${TOURS_BASE_URL:-}" ] || missing+=("TOURS_BASE_URL")
+[ -n "${TOURS_API_KEY:-}" ] || missing+=("TOURS_API_KEY")
+if [ "${#missing[@]}" -gt 0 ]; then
+    echo "run-tours: missing required env: ${missing[*]}" >&2
+    echo "run-tours: set TOURS_BASE_URL and TOURS_API_KEY (and optionally TOURS_API_URL) from your env; never commit them." >&2
+    exit 1
+fi
+
+# --- Reset staging to the prod-shaped world (unless skipped) ---
+if [ "${TOURS_SKIP_RESET:-0}" = "1" ]; then
+    echo "run-tours: TOURS_SKIP_RESET=1 — skipping staging-reset (using existing seeded staging)" >&2
+else
+    echo "run-tours: resetting + reseeding staging (prod-shaped)..." >&2
+    bash "$REPO_ROOT/scripts/staging-reset.sh"
+fi
+
+# --- Resolve the deployed image digest (read-only; best-effort) ---
+# Mirror staging-reset.sh's read_image_ref defaults without importing it.
+STAGING_HOST="${STAGING_HOST:-stovepipes}"
+CRM_USER="${CRM_USER:-staging}"
+CRM_HOME="${CRM_HOME:-/var/lib/staging}"
+BACKEND_UNIT="${STAGING_BACKEND_UNIT:-$CRM_HOME/.config/containers/systemd/personalcrm-backend.container}"
+IMAGE_DIGEST="$(ssh "$STAGING_HOST" "sudo -n -u $CRM_USER sed -n 's/^Image=//p' '$BACKEND_UNIT' 2>/dev/null | head -1" 2>/dev/null || true)"
+if [ -z "$IMAGE_DIGEST" ]; then
+    echo "run-tours: WARNING — could not read deployed image digest from $BACKEND_UNIT (manifest records 'unknown')" >&2
+    IMAGE_DIGEST="unknown"
+fi
+
+# --- Export run env consumed by globalSetup + the capture helper ---
+export TOURS_RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"
+export TOURS_GIT_SHA="$(git rev-parse HEAD)"
+export TOURS_IMAGE_DIGEST="$IMAGE_DIGEST"
+export TOURS_SEED_PROFILE="prod-shaped"
+
+echo "run-tours: launching tours (runId=$TOURS_RUN_ID)..." >&2
+cd "$REPO_ROOT/frontend"
+exec bunx playwright test --config=playwright.tours.config.ts "$@"

--- a/scripts/run-tours.sh
+++ b/scripts/run-tours.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Reset-before-run wrapper for the agentic UX QA tours (Piece 4 Track B, #606).
+# Reset-before-run wrapper for the agentic UX QA tours.
 #
 # Runs staging-reset.sh (ssh) for a known prod-shaped world BEFORE Playwright
 # launches, resolves the deployed staging image digest (read-only ssh, mirroring


### PR DESCRIPTION
## Summary

PR1 of the Piece 4 · Track B agentic UX QA harness (#606, umbrella #380). Adds a fully-isolated Playwright **tours** suite that drives a running app and emits **parseable capture JSON** for a downstream LLM judge (PR2). This PR is **frontend/script/docs-only — zero backend Go changes** and is a **test harness, not app UI**.

Design SSOT: `.ai/spec/2026-07-08-piece4-track-b-agentic-qa-harness-design.md` (incl. the 2026-07-09 addendum). This is a 3-PR arc: **PR1 (this) → PR2 (judge + hybrid grader + corpus tooling) → PR3 (dashboard + cadence tours + v0 corpus)**, terminating in advisory mode. PR4 (reporter/issue-mode) is deferred to a later arc.

## What's in PR1

- **Dedicated isolated config** `frontend/playwright.tours.config.ts` (no `webServer`, serial single-worker `tours` project) — deliberately NOT a project inside the shared `playwright.config.ts`, so a tours sweep (which mutates its target) can never be triggered by `make test-e2e`, the diff-selector, `test-map-coverage-check.sh`, or a bare `bunx playwright test`. Isolation is safety-critical and independently verified (4/4).
- **Capture engine** `frontend/tests/tours/support/` — the assertion-free `capture()` records, per point: a structured **aria node tree** (parsed from `ariaSnapshot()`, not a blob), endpoint-grouped self-describing `/api/v1` responses (with `requestUrl`/`query` + mutating-request bodies), the accelerated **serverTime frame**, native-dialog messages, and before/after **pairs** for multi-step/mutating behaviors. Deterministic normalization: UUIDs→ordinals, secret/host scrub, stable key/array sort, repeat caps.
- **Fail-closed production guard**: before any run, `globalSetup` fetches `/api/v1/system/time` for the actual Playwright target and throws if `environment` is production/empty/unknown — so the destructive steps (delete/merge/interactions) can never fire at a prod target, independent of the reset host.
- **Run dir + manifest** (git SHA, image digest, seed profile, generator version, redacted host); `.runs/` gitignored.
- **`scripts/run-tours.sh` + `make tours`** reset-before-run wrapper (staging `staging-reset.sh` ssh mode; `TOURS_SKIP_RESET=1` for pre-seeded targets).
- **`contacts.tour.ts`** — walks the 7 current contacts `ux` behaviors: CON-038, CON-040, CON-041, CON-042, CON-043, CON-044, CON-045 (CON-046 is `proposed` → skipped). Every `then`-item has a binding evidence path.

## Verification

- Offline gate green: `tsc --noEmit` clean, `prettier --check` clean, vitest **413/413** (incl. the normalizer parser/scrub/determinism unit tests), isolation proof **4/4**.
- **Live sweep**: a clean prod-shaped sweep produced 30 captures, inspected PII-free with every `then`-item's evidence present (serverTime frame on all, CON-042 dialog + probe 404/200, CON-043 merge `field_selections` + source→404, CON-040 disabled boundary, etc.). The sweep also caught 3 real runtime bugs the offline checks could not (detail-readiness wait, a Playwright unroute race, and an aria cap truncating the merge modal) — all fixed here.
- Codex review clean; pre-push gate (lint + unit + integration + frontend + @smoke E2E) green.

## Deferred / follow-ups (non-blocking)

- **Staging ssh-reset + real pinned image digest**: the required live-sweep gate was satisfied against a **local prod-shaped seed** (deterministic → capture-format-identical to staging); the ssh `staging-reset.sh` path and a real staging image digest are a low-risk follow-up that does not affect capture-format correctness. The manifest records an honest `local:<sha>` digest for local runs (no fabricated staging digest).
- **Six non-blocking review-head P2/P3 items** to fold into PR2 (same normalizer/capture code): add automated tests for the prod-guard and `sortApiResponses`; a split-origin guard note; a UUID-ordinal first-seen determinism comment; a comment tying the guard deny-set to `config.IsProductionCRMEnv`; and broader aria state-field assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
