### PR TITLE
chore(hooks): merge-gated review verdict + jobsample clock-skew clamp

### DIFF
--- a/backend/internal/jobsample/recorder.go
+++ b/backend/internal/jobsample/recorder.go
@@ -75,11 +75,18 @@ func eventToSample(ev *river.Event) (repository.JobExecSampleRow, bool) {
 	// job.FinalizedAt is stamped by the River client (Go clock). When the
 	// client clock lags the DB clock by more than the job's run time,
 	// FinalizedAt lands before AttemptedAt and the insert would violate
-	// job_exec_sample_interval_chk, silently dropping the sample. Clamp so
-	// best-effort capture survives bounded clock skew.
+	// job_exec_sample_interval_chk, silently dropping the sample. Fall back
+	// to the synthesized end: RunDuration is measured client-side, so it is
+	// skew-immune and non-negative, and the row keeps its true width for the
+	// sweep-line occupancy query. (No-op for the synthesized default above.)
 	if finalizedAt.Before(*job.AttemptedAt) {
-		finalizedAt = *job.AttemptedAt
+		finalizedAt = job.AttemptedAt.Add(ev.JobStats.RunDuration)
 	}
+
+	// QueueWaitDuration mixes the same two clocks (client start minus
+	// DB-stamped scheduled_at), so the same skew can drive it negative and
+	// violate job_exec_sample_wait_chk. Clamp to zero.
+	waitMs := max(ev.JobStats.QueueWaitDuration.Milliseconds(), 0)
 
 	return repository.JobExecSampleRow{
 		RiverJobID:  job.ID,
@@ -89,7 +96,7 @@ func eventToSample(ev *river.Event) (repository.JobExecSampleRow, bool) {
 		FinalizedAt: finalizedAt,
 		Attempt:     job.Attempt,
 		State:       string(job.State),
-		QueueWaitMs: ev.JobStats.QueueWaitDuration.Milliseconds(),
+		QueueWaitMs: waitMs,
 	}, true
 }
 

--- a/backend/internal/jobsample/recorder.go
+++ b/backend/internal/jobsample/recorder.go
@@ -71,6 +71,15 @@ func eventToSample(ev *river.Event) (repository.JobExecSampleRow, bool) {
 	if job.FinalizedAt != nil {
 		finalizedAt = *job.FinalizedAt
 	}
+	// AttemptedAt is stamped by River's fetch query (DB clock) while
+	// job.FinalizedAt is stamped by the River client (Go clock). When the
+	// client clock lags the DB clock by more than the job's run time,
+	// FinalizedAt lands before AttemptedAt and the insert would violate
+	// job_exec_sample_interval_chk, silently dropping the sample. Clamp so
+	// best-effort capture survives bounded clock skew.
+	if finalizedAt.Before(*job.AttemptedAt) {
+		finalizedAt = *job.AttemptedAt
+	}
 
 	return repository.JobExecSampleRow{
 		RiverJobID:  job.ID,

--- a/backend/internal/jobsample/recorder_test.go
+++ b/backend/internal/jobsample/recorder_test.go
@@ -54,6 +54,39 @@ func TestEventToSample_Completed(t *testing.T) {
 	assert.True(t, row.CreatedAt.IsZero())
 }
 
+func TestEventToSample_ClockSkew_ClampsFinalizedAt(t *testing.T) {
+	t.Parallel()
+	// AttemptedAt comes from the DB clock and FinalizedAt from the client
+	// clock; a client clock lagging the DB clock by more than the run time
+	// yields FinalizedAt < AttemptedAt, which the interval check constraint
+	// would reject. eventToSample must clamp instead of emitting a row the
+	// insert will drop.
+	attempted := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	finalized := attempted.Add(-40 * time.Millisecond)
+
+	ev := &river.Event{
+		Kind: river.EventKindJobCompleted,
+		Job: &rivertype.JobRow{
+			ID:          43,
+			Kind:        "test_kind",
+			Queue:       "default",
+			Attempt:     1,
+			AttemptedAt: ptrTime(attempted),
+			FinalizedAt: ptrTime(finalized),
+			State:       rivertype.JobStateCompleted,
+		},
+		JobStats: &river.JobStatistics{
+			RunDuration:       2 * time.Millisecond,
+			QueueWaitDuration: 250 * time.Millisecond,
+		},
+	}
+
+	row, ok := eventToSample(ev)
+	require.True(t, ok)
+	assert.Equal(t, attempted, row.AttemptedAt)
+	assert.Equal(t, attempted, row.FinalizedAt, "FinalizedAt must be clamped to AttemptedAt, never before it")
+}
+
 func TestEventToSample_RetryableFailure_SynthesizesFinalizedAt(t *testing.T) {
 	t.Parallel()
 	attempted := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)

--- a/backend/internal/jobsample/recorder_test.go
+++ b/backend/internal/jobsample/recorder_test.go
@@ -84,7 +84,37 @@ func TestEventToSample_ClockSkew_ClampsFinalizedAt(t *testing.T) {
 	row, ok := eventToSample(ev)
 	require.True(t, ok)
 	assert.Equal(t, attempted, row.AttemptedAt)
-	assert.Equal(t, attempted, row.FinalizedAt, "FinalizedAt must be clamped to AttemptedAt, never before it")
+	assert.Equal(t, attempted.Add(2*time.Millisecond), row.FinalizedAt,
+		"skewed FinalizedAt must fall back to AttemptedAt+RunDuration (skew-immune), preserving interval width")
+}
+
+func TestEventToSample_ClockSkew_ClampsNegativeWait(t *testing.T) {
+	t.Parallel()
+	// QueueWaitDuration = client start - DB-stamped scheduled_at, so the same
+	// client-behind-DB skew can drive it negative; an unclamped negative wait
+	// violates job_exec_sample_wait_chk and silently drops the sample.
+	attempted := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	ev := &river.Event{
+		Kind: river.EventKindJobCompleted,
+		Job: &rivertype.JobRow{
+			ID:          44,
+			Kind:        "test_kind",
+			Queue:       "default",
+			Attempt:     1,
+			AttemptedAt: ptrTime(attempted),
+			FinalizedAt: ptrTime(attempted.Add(3 * time.Millisecond)),
+			State:       rivertype.JobStateCompleted,
+		},
+		JobStats: &river.JobStatistics{
+			RunDuration:       3 * time.Millisecond,
+			QueueWaitDuration: -40 * time.Millisecond,
+		},
+	}
+
+	row, ok := eventToSample(ev)
+	require.True(t, ok)
+	assert.Equal(t, int64(0), row.QueueWaitMs, "negative (skewed) queue wait must clamp to 0")
 }
 
 func TestEventToSample_RetryableFailure_SynthesizesFinalizedAt(t *testing.T) {

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -4,8 +4,9 @@
 # Reads configuration from .ai/pre-push.json. Runs enabled checks; blocks push
 # if any required check fails.
 #
-# Execution model (L3): review-log and the Swift gate run first (cheap / path-
-# gated fast-fail). Then four independent phases run CONCURRENTLY — LINT,
+# Execution model (L3): review-log (advisory warn only — the Claude review
+# verdict is enforced at merge time, not push time) and the Swift gate run first
+# (cheap / path-gated fast-fail). Then four independent phases run CONCURRENTLY — LINT,
 # GO (test-unit && test-integration, the DB-owning long pole), FRONTEND, and
 # FILTER (pre-push filter unit tests) — each buffered to its own log. Once all
 # four pass, E2E runs EXCLUSIVELY and last, because make test-e2e-diff DROPs the
@@ -32,10 +33,13 @@ CONFIG_FILE=".ai/pre-push.json"
 # path-filters.yml is the single source of truth (shared with CI's dorny filter).
 FILTERS_FILE="path-filters.yml"
 
-# Check Claude review log for HEAD. Replaces the prior CI claude-review job —
-# /review-head writes the verdict to .ai/log/review/<HEAD-sha>.md, and the push
-# is allowed only if that file contains "RESULT=PASS".
-# Bypass with `git push --no-verify` if you really need to skip.
+# Check Claude review log for HEAD — ADVISORY ONLY (merge-gated review model).
+# /review-head writes the verdict to .ai/log/review/<HEAD-sha>.md. The verdict is
+# enforced at MERGE time by the workflow's merge gate (monitor-pr with
+# verdict-required=true / plan-and-ship Phase 2.5 barrier: verdict PASS + review
+# bot clean + CI green), NOT at push time. Pushing first lets review-head, CI,
+# and the PR review bot run in parallel instead of in series; the deterministic
+# gates below (lint + tests + E2E) still block the push.
 check_review_log() {
   local enabled
   enabled=$(jq -r '.review.enabled // false' "$CONFIG_FILE")
@@ -48,23 +52,13 @@ check_review_log() {
   local review_file=".ai/log/review/${head_sha}.md"
 
   if [[ ! -f "$review_file" ]]; then
-    echo "" >&2
-    echo "==============================================================" >&2
-    echo "FAILED: No Claude review found for HEAD (${head_sha:0:12})" >&2
-    echo "Expected: $review_file" >&2
-    echo "Run /review-head before pushing (or use --no-verify to skip)." >&2
-    echo "==============================================================" >&2
-    exit 1
+    echo "  [review] WARN no Claude review for HEAD (${head_sha:0:12}) — required at MERGE time; run /review-head in parallel with CI + the PR bot after pushing" >&2
+    return 0
   fi
 
   if ! grep -q '^RESULT=PASS$' "$review_file"; then
-    echo "" >&2
-    echo "==============================================================" >&2
-    echo "FAILED: Claude review for HEAD did not pass" >&2
-    echo "File:  $review_file" >&2
-    echo "Address findings and re-run /review-head (HEAD must change)." >&2
-    echo "==============================================================" >&2
-    exit 1
+    echo "  [review] WARN Claude review for HEAD (${head_sha:0:12}) is not PASS — the merge gate will block until a passing (delta) review exists" >&2
+    return 0
   fi
 
   echo "  [review] OK Claude review of ${head_sha:0:12}" >&2


### PR DESCRIPTION
## Summary

Two commits:

1. **chore(hooks): make pre-push review verdict advisory (merge-gated).** The Claude review verdict (`.ai/log/review/<sha>.md`) no longer blocks the push — the hook warns instead, and the verdict is enforced at merge time by the workflow's merge gate (monitor-pr `verdict-required` / plan-and-ship Phase 2.5 barrier: verdict PASS + review bot clean + CI green). Pushing first lets review-head, CI, and the PR review bot run in parallel instead of in series, consolidating their findings into a single fix round. The deterministic push gates (lint, tests, E2E) are unchanged and still block. Companion to dev-workflow plugin v0.7.0 (spengrah/agent-skills#7).

2. **fix(jobsample): clamp finalized_at to attempted_at under clock skew.** `AttemptedAt` is stamped by River's fetch query (DB clock) while `job.FinalizedAt` is stamped by the River client (Go clock). When the client clock lags the DB clock by more than a job's run time (observed ~25–65ms host-vs-container skew after a colima VM recreation), `FinalizedAt` lands before `AttemptedAt`, the insert violates `job_exec_sample_interval_chk`, and the sample row is silently dropped — surfacing as deterministic `TestJobSampleRecorder_EndToEnd` / `_RepeatedSnooze` failures. Clamp `FinalizedAt` to the `AttemptedAt` floor so best-effort capture survives bounded clock skew. Regression unit test added (`TestEventToSample_ClockSkew_ClampsFinalizedAt`). Prod is unaffected in practice (app + DB share a clock on the Pi), but any split-clock deployment would hit this.

## Test plan

- Full pre-push gates green locally (lint, unit, integration incl. LONG_TESTS, frontend, E2E-diff).
- New unit test covers the skew-clamp branch; the two previously-failing integration tests pass repeatedly (`-count=2`) post-fix.
- Hook change exercised live: the advisory `[review] WARN` path printed on push without blocking; the Claude review for this PR runs at merge time per the new flow.