### PR TITLE
feat(tours): qa forced-command ssh reseed path (TOURS_RESEED_SSH)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -531,6 +531,7 @@ test-deploy-scripts:
 	@bash scripts/staging-deployed-sha.test.sh
 	@bash scripts/staging-reseed.test.sh
 	@bash scripts/admin/setup-staging-reseed-host.sh.test.sh
+	@bash scripts/run-tours.test.sh
 	@bash scripts/reconcile-mac-daemon.test.sh
 	@bash scripts/setup-mac-deploy.test.sh
 	@bash scripts/trigger-mac-deploy.test.sh

--- a/scripts/run-tours.sh
+++ b/scripts/run-tours.sh
@@ -11,6 +11,13 @@
 #   TOURS_API_KEY    staging X-API-Key         (required)
 #   TOURS_API_URL    staging backend base URL  (optional; defaults to TOURS_BASE_URL)
 #   TOURS_SKIP_RESET=1  skip staging-reset (dev iteration against a seeded staging)
+#   TOURS_RESEED_SSH    forced-command ssh dest for the prod-shaped reseed (e.g.
+#                       qa-staging@10.100.0.1). When set (and not skipped), reseed via
+#                       this instead of staging-reset.sh — the QA-sandbox path, since
+#                       staging-reset.sh's ssh->STAGING_HOST + sudo -u <tenant> does
+#                       NOT route from the sandbox. optional.
+#   TOURS_RESEED_KEY    ssh identity file for TOURS_RESEED_SSH (optional; absolute path
+#                       or $HOME-expanded, e.g. $HOME/.ssh/qa_staging)
 #
 # Usage: scripts/run-tours.sh [extra playwright args...]   (or: make tours)
 
@@ -32,6 +39,16 @@ fi
 # --- Reset staging to the prod-shaped world (unless skipped) ---
 if [ "${TOURS_SKIP_RESET:-0}" = "1" ]; then
     echo "run-tours: TOURS_SKIP_RESET=1 — skipping staging-reset (using existing seeded staging)" >&2
+elif [ -n "${TOURS_RESEED_SSH:-}" ]; then
+    # QA reseed path: a locked-down forced-command ssh key whose remote
+    # authorized_keys pins the prod-shaped reseed on the staging host. Reaches it
+    # over the same network route the tours use — unlike staging-reset.sh, whose
+    # `ssh $STAGING_HOST` + `sudo -u <tenant>` does NOT route from the sandbox.
+    # Fail loud (set -e): never sweep against an unreseeded/unknown world.
+    echo "run-tours: reseeding staging (prod-shaped) via qa-reseed ssh ($TOURS_RESEED_SSH)..." >&2
+    reseed_ssh=(ssh -o BatchMode=yes -o ConnectTimeout=10)
+    [ -n "${TOURS_RESEED_KEY:-}" ] && reseed_ssh+=(-i "$TOURS_RESEED_KEY")
+    "${reseed_ssh[@]}" "$TOURS_RESEED_SSH" reseed
 else
     echo "run-tours: resetting + reseeding staging (prod-shaped)..." >&2
     bash "$REPO_ROOT/scripts/staging-reset.sh"
@@ -43,7 +60,7 @@ STAGING_HOST="${STAGING_HOST:-stovepipes}"
 CRM_USER="${CRM_USER:-staging}"
 CRM_HOME="${CRM_HOME:-/var/lib/staging}"
 BACKEND_UNIT="${STAGING_BACKEND_UNIT:-$CRM_HOME/.config/containers/systemd/personalcrm-backend.container}"
-IMAGE_DIGEST="$(ssh "$STAGING_HOST" "sudo -n -u $CRM_USER sed -n 's/^Image=//p' '$BACKEND_UNIT' 2>/dev/null | head -1" 2>/dev/null || true)"
+IMAGE_DIGEST="$(ssh -o BatchMode=yes -o ConnectTimeout=10 "$STAGING_HOST" "sudo -n -u $CRM_USER sed -n 's/^Image=//p' '$BACKEND_UNIT' 2>/dev/null | head -1" 2>/dev/null || true)"
 if [ -z "$IMAGE_DIGEST" ]; then
     echo "run-tours: WARNING — could not read deployed image digest from $BACKEND_UNIT (manifest records 'unknown')" >&2
     IMAGE_DIGEST="unknown"
@@ -60,7 +77,8 @@ export TOURS_IMAGE_DIGEST="$IMAGE_DIGEST"
 #     established out-of-band (crm-admin --reset-and-seed --profile prod-shaped);
 #   - else, when the staging reset was SKIPPED, the seed is whatever was already
 #     on the target → 'unknown' (do NOT assert 'prod-shaped');
-#   - else (this wrapper ran the prod-shaped reset) → 'prod-shaped'.
+#   - else (this wrapper ran the prod-shaped reset — staging-reset.sh OR the
+#     TOURS_RESEED_SSH forced-command reseed) → 'prod-shaped'.
 # The manifest label is a hint only; the binding PII guarantee is the corpus
 # data audit (synth-prodshaped- name gate + email/phone scrub).
 if [ -n "${TOURS_SEED_PROFILE:-}" ]; then

--- a/scripts/run-tours.test.sh
+++ b/scripts/run-tours.test.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Tests for run-tours.sh's reset-path selection (the reseed seam).
+#
+# run-tours.sh picks ONE of three reset behaviors before launching Playwright:
+#   TOURS_SKIP_RESET=1   -> skip entirely (use the already-seeded target)
+#   TOURS_RESEED_SSH set -> qa forced-command ssh reseed (the QA-sandbox path)
+#   else                 -> bash scripts/staging-reset.sh (the Mac / ssh-to-host path)
+#
+# We run a REWRITTEN COPY of run-tours.sh with the real staging-reset.sh invocation
+# rewritten to a recording stub (sed to stdout; the committed script stays byte-pure),
+# and `ssh` / `bunx` shadowed on PATH by recording stubs so nothing touches the
+# network, a browser, or staging. All checks run anywhere.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/run-tours.sh"
+cd "$REPO_ROOT" # so run-tours.sh's `git rev-parse --show-toplevel` resolves
+
+PASS=0
+FAIL=0
+fail() { echo "  FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+ok()   { PASS=$((PASS + 1)); }
+
+make_sandbox() {
+    SANDBOX="$(mktemp -d)"
+    CALL_LOG="$SANDBOX/calls.log"
+    : > "$CALL_LOG"
+    mkdir -p "$SANDBOX/bin"
+
+    # ssh stub: record argv; emit no stdout (so the image-digest read resolves to
+    # 'unknown'); exit code from SSH_STUB_RC (default 0) to simulate reseed failure.
+    cat > "$SANDBOX/bin/ssh" <<EOF
+#!/usr/bin/env bash
+echo "ssh \$*" >> "$CALL_LOG"
+exit \${SSH_STUB_RC:-0}
+EOF
+    # bunx stub: record the playwright launch; exit 0 (no real browser).
+    cat > "$SANDBOX/bin/bunx" <<EOF
+#!/usr/bin/env bash
+echo "bunx \$*" >> "$CALL_LOG"
+exit 0
+EOF
+    # staging-reset.sh stub (the default Mac path): record the call.
+    cat > "$SANDBOX/bin/staging-reset.sh" <<EOF
+#!/usr/bin/env bash
+echo "staging-reset.sh \$*" >> "$CALL_LOG"
+exit 0
+EOF
+    chmod +x "$SANDBOX/bin/ssh" "$SANDBOX/bin/bunx" "$SANDBOX/bin/staging-reset.sh"
+
+    # Rewrite ONLY the real staging-reset.sh invocation to the stub (sed to stdout;
+    # '#' delimiter so the path slashes need no escaping). Committed script untouched.
+    sed "s#\"\$REPO_ROOT/scripts/staging-reset.sh\"#\"$SANDBOX/bin/staging-reset.sh\"#" \
+        "$SCRIPT" > "$SANDBOX/run-tours.sh"
+    # Guard: fail loudly if the rewrite no-op'd (the staging-reset.sh invocation
+    # string in run-tours.sh drifted) instead of silently exercising the real script.
+    grep -q "$SANDBOX/bin/staging-reset.sh" "$SANDBOX/run-tours.sh" \
+        || { echo "  FAIL: sed rewrite no-op — staging-reset.sh invocation drifted" >&2; exit 1; }
+    chmod +x "$SANDBOX/run-tours.sh"
+}
+
+cleanup_sandbox() { [ -n "${SANDBOX:-}" ] && rm -rf "$SANDBOX"; }
+
+# run <ENV=val...> : run the rewritten copy with stubs on PATH; sets RC + CALL_LOG.
+run() {
+    : > "$CALL_LOG"
+    env PATH="$SANDBOX/bin:$PATH" \
+        TOURS_BASE_URL="http://staging.test" TOURS_API_KEY="k" \
+        "$@" \
+        bash "$SANDBOX/run-tours.sh" >/dev/null 2>&1
+    RC=$?
+}
+
+echo "run-tours.sh reset-path selection tests"
+make_sandbox
+trap cleanup_sandbox EXIT
+
+# 1. TOURS_SKIP_RESET=1 -> no reseed, no staging-reset, still launches playwright.
+run TOURS_SKIP_RESET=1
+grep -q 'staging-reset.sh' "$CALL_LOG" && fail "skip: staging-reset must NOT run" || ok
+grep -qE 'ssh .*reseed' "$CALL_LOG" && fail "skip: reseed ssh must NOT run" || ok
+grep -q 'bunx .*playwright' "$CALL_LOG" && ok || fail "skip: playwright should launch"
+
+# 2. TOURS_RESEED_SSH (+key) -> qa reseed ssh with -i, NOT staging-reset.
+run TOURS_RESEED_SSH="qa-staging@10.100.0.1" TOURS_RESEED_KEY="/tmp/k"
+grep -qE 'ssh .*-i /tmp/k .*qa-staging@10.100.0.1 reseed' "$CALL_LOG" && ok \
+    || fail "reseed: expected qa reseed ssh '-i /tmp/k ... qa-staging@10.100.0.1 reseed'"
+grep -q 'staging-reset.sh' "$CALL_LOG" && fail "reseed: staging-reset must NOT run" || ok
+grep -q 'bunx .*playwright' "$CALL_LOG" && ok || fail "reseed: playwright should launch"
+
+# 2b. TOURS_RESEED_SSH without a key -> ssh reseed, no -i.
+run TOURS_RESEED_SSH="qa-staging@10.100.0.1"
+grep -qE 'ssh .*qa-staging@10.100.0.1 reseed' "$CALL_LOG" && ok || fail "reseed(no key): expected qa reseed ssh"
+grep -qE 'ssh -o [^;]*-i ' "$CALL_LOG" && fail "reseed(no key): must not pass -i" || ok
+
+# 2c. Reseed ssh FAILS -> fail loud: script aborts, playwright NOT launched.
+run TOURS_RESEED_SSH="qa-staging@10.100.0.1" SSH_STUB_RC=1
+[ "$RC" -ne 0 ] && ok || fail "reseed-fail: script should exit non-zero"
+grep -q 'bunx .*playwright' "$CALL_LOG" && fail "reseed-fail: playwright must NOT launch after a failed reseed" || ok
+
+# 3. Default -> staging-reset.sh runs, no reseed ssh.
+run
+grep -q 'staging-reset.sh' "$CALL_LOG" && ok || fail "default: staging-reset.sh should run"
+grep -qE 'ssh .*reseed' "$CALL_LOG" && fail "default: reseed ssh must NOT run" || ok
+
+# 4. Precedence: TOURS_SKIP_RESET=1 wins over TOURS_RESEED_SSH when both are set.
+run TOURS_SKIP_RESET=1 TOURS_RESEED_SSH="qa-staging@10.100.0.1" TOURS_RESEED_KEY="/tmp/k"
+grep -qE 'ssh .*reseed' "$CALL_LOG" && fail "precedence: skip must win over reseed ssh" || ok
+grep -q 'staging-reset.sh' "$CALL_LOG" && fail "precedence: staging-reset must NOT run" || ok
+grep -q 'bunx .*playwright' "$CALL_LOG" && ok || fail "precedence: playwright should launch"
+
+echo "  PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## What

Adds an opt-in `TOURS_RESEED_SSH` (+ optional `TOURS_RESEED_KEY`) reset path to `scripts/run-tours.sh`, so a QA sweep can reseed staging to the prod-shaped world over the same network route the tours use.

## Why

`run-tours.sh`'s default reset (`staging-reset.sh`) shells `ssh $STAGING_HOST` + `sudo -u <tenant>`, which does not route from the QA sandbox. The only way to sweep from the sandbox was `TOURS_SKIP_RESET=1` + a manual reset from the Mac. The new path reseeds via a locked-down forced-command ssh key reachable from the sandbox, so a plain `make tours` self-reseeds.

## Behavior

Reset-path precedence (the Mac and existing skip flows are unchanged):

1. `TOURS_SKIP_RESET=1` → skip (use the already-seeded target)
2. `TOURS_RESEED_SSH` set → forced-command ssh reseed (new; the sandbox path)
3. else → `staging-reset.sh` (the Mac / ssh-to-host path)

Fail-loud under `set -e`: a failed reseed aborts before Playwright launches, so a sweep never runs against an unreseeded world. The reseed lands in the manifest's `prod-shaped` seed-profile branch.

## Testing

- `scripts/run-tours.test.sh` (new, wired into `test-deploy-scripts`): 15 assertions over reset-path selection (skip / reseed ± key / precedence / default) + fail-loud-on-reseed-failure, using the repo's sed-rewrite stub convention (no network, browser, or staging).
- `make test-deploy-scripts` green; full pre-push gate (lint + Go + frontend + E2E) green.
- Live: the exact reseed command exited 0 against staging (reseeded prod-shaped, 165 contacts).

## Review

review-head PASS (delta re-reviewed after amend); no P0/P1. Two P2s folded in pre-merge — hardened the sibling image-digest ssh (BatchMode/ConnectTimeout) and added the precedence test. One cosmetic P3 remains (this test uses a flat structure vs the sibling suites' `test_*()`/`main()` shape) — non-blocking.
