### PR TITLE
feat(tours): run the judge over live captures + pin a cheap judge model

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Personal CRM Makefile
 
-.PHONY: help setup dev dev-seed staging-reset tours build crm-admin mac-daemon test test-daemon-local clean docker-up docker-down docker-reset test-cadence-ultra test-cadence-fast qa-eval prod staging testing start start-local stop restart reload status dev-stop dev-restart dev-api-stop dev-api-start dev-api-restart ci-build-backend ci-build-frontend ci-build ci-test test-e2e test-e2e-local test-e2e-diff e2e-db deploy-mac promote setup-pi setup-mac-deploy dev-native postgres-native sqlc smoke-test test-deploy-scripts worktree-env worktree-deps test-integration-fast test-integration-slow test-clean-clones worktree-test-pg-ensure test-pg-stop test-pg-teardown test-pg-reap test-pg-smoke check-cadence-sole-writer check-followup-sole-writer check-rematch-sole-dispatcher check-crm-marker-construction check-sqlc-select-lists lint-ingest-registry spec-lint api-types api-types-check
+.PHONY: help setup dev dev-seed staging-reset tours build crm-admin mac-daemon test test-daemon-local clean docker-up docker-down docker-reset test-cadence-ultra test-cadence-fast qa-eval qa-report prod staging testing start start-local stop restart reload status dev-stop dev-restart dev-api-stop dev-api-start dev-api-restart ci-build-backend ci-build-frontend ci-build ci-test test-e2e test-e2e-local test-e2e-diff e2e-db deploy-mac promote setup-pi setup-mac-deploy dev-native postgres-native sqlc smoke-test test-deploy-scripts worktree-env worktree-deps test-integration-fast test-integration-slow test-clean-clones worktree-test-pg-ensure test-pg-stop test-pg-teardown test-pg-reap test-pg-smoke check-cadence-sole-writer check-followup-sole-writer check-rematch-sole-dispatcher check-crm-marker-construction check-sqlc-select-lists lint-ingest-registry spec-lint api-types api-types-check
 
 # Repo root (supports running make from subdirectories).
 REPO_ROOT := $(shell git rev-parse --show-toplevel)
@@ -286,6 +286,9 @@ tours: ## Reset staging + run the agentic UX QA tours. Config from env only: TOU
 
 qa-eval: ## Run the agentic UX QA hybrid grader over the seed corpus (verifiers-only merge gate; OFFLINE, deterministic). QA_JUDGE + `--judge` add the advisory live-judge layer.
 	@cd frontend && bun run tests/tours/judge/eval/run.ts
+
+qa-report: ## Render the advisory report over a tours run dir (RUNDIR relative to frontend/, or absolute). JUDGE=1 adds the live judge over residue items (codex quota); OUT=<file> writes to a file instead of stdout.
+	@cd frontend && bun run tests/tours/judge/report/render.ts "$(RUNDIR)" $(OUT) $(if $(filter 1,$(JUDGE)),--judge,)
 
 # Native PostgreSQL (for containerized development without Docker-in-Docker)
 # Symlink the main checkout's gitignored env files (.env, frontend/.env.local,

--- a/Makefile
+++ b/Makefile
@@ -288,7 +288,7 @@ qa-eval: ## Run the agentic UX QA hybrid grader over the seed corpus (verifiers-
 	@cd frontend && bun run tests/tours/judge/eval/run.ts
 
 qa-report: ## Render the advisory report over a tours run dir (RUNDIR relative to frontend/, or absolute). JUDGE=1 adds the live judge over residue items (codex quota); OUT=<file> writes to a file instead of stdout.
-	@cd frontend && bun run tests/tours/judge/report/render.ts "$(RUNDIR)" $(OUT) $(if $(filter 1,$(JUDGE)),--judge,)
+	@cd frontend && bun run tests/tours/judge/report/render.ts "$(RUNDIR)" $(if $(OUT),"$(OUT)",) $(if $(filter 1,$(JUDGE)),--judge,)
 
 # Native PostgreSQL (for containerized development without Docker-in-Docker)
 # Symlink the main checkout's gitignored env files (.env, frontend/.env.local,

--- a/frontend/tests/tours/judge/DEFERRED.md
+++ b/frontend/tests/tours/judge/DEFERRED.md
@@ -19,7 +19,7 @@ The user is unavailable, so PR2 is engineered to be mergeable with **zero** huma
 
 ## Manual authoring (needs codex quota — not a CI gate)
 
-- **Real stronger-model draft labels.** `corpus/labels/CON-042.draft.json` is a structural placeholder. The genuine model-drafted critiques come from the manual `label.ts` run above and are committed like the corpus captures. The merge gate is only the CLI's **machinery** (unit-tested with a mocked drafter).
+- **Real stronger-model draft labels.** `corpus/labels/CON-042.draft.json` is a structural placeholder. The genuine model-drafted critiques come from the manual `label.ts` run above and are committed like the corpus captures. The merge gate is only the CLI's **machinery** (unit-tested with a mocked drafter). **Chosen drafter: Claude** — a _different model family_ from the cheap codex judge (`gpt-5.4-mini`), which maximally breaks the "no LLM-generated ground truth" circularity (a codex judge is never graded against codex-drafted labels). Needs a `Judge`-interface adapter (Anthropic endpoint, selected via `QA_LABELER=claude`); until it lands, labeling stays deferred (residue is 3 items).
 - **Live judge smoke.** `QA_JUDGE=codex-exec bun run tests/tours/judge/eval/run.ts --judge --limit 2` exercises the live `codex exec` adapter over judge-tagged cases; `--repeat N` measures self-consistency. Advisory, never a merge gate.
 
 ## Tooling follow-ups

--- a/frontend/tests/tours/judge/adapter/codex-exec.test.ts
+++ b/frontend/tests/tours/judge/adapter/codex-exec.test.ts
@@ -236,6 +236,42 @@ describe('makeCodexExecJudge (injected run — no live call)', () => {
     }
   })
 
+  it('threads opts.effort into the codex reasoning-effort arg', async () => {
+    let seenArgs: string[] = []
+    const judge = makeCodexExecJudge({
+      effort: 'high',
+      run: async args => {
+        seenArgs = args
+        return stream({
+          verdicts: [{ item_index: 0, verdict: 'pass', citation: 'c', critique: 'k' }],
+        })
+      },
+    })
+    await judge(input)
+    expect(seenArgs).toContain('model_reasoning_effort=high')
+  })
+
+  it('falls back to QA_JUDGE_EFFORT when no effort is passed', async () => {
+    const prev = process.env.QA_JUDGE_EFFORT
+    process.env.QA_JUDGE_EFFORT = 'medium'
+    try {
+      let seenArgs: string[] = []
+      const judge = makeCodexExecJudge({
+        run: async args => {
+          seenArgs = args
+          return stream({
+            verdicts: [{ item_index: 0, verdict: 'pass', citation: 'c', critique: 'k' }],
+          })
+        },
+      })
+      await judge(input)
+      expect(seenArgs).toContain('model_reasoning_effort=medium')
+    } finally {
+      if (prev === undefined) delete process.env.QA_JUDGE_EFFORT
+      else process.env.QA_JUDGE_EFFORT = prev
+    }
+  })
+
   it('grounding rule: an uncited judge fail downgrades to unsure', async () => {
     const judge = makeCodexExecJudge({
       run: async () =>

--- a/frontend/tests/tours/judge/adapter/codex-exec.test.ts
+++ b/frontend/tests/tours/judge/adapter/codex-exec.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest'
 import {
   codexArgs,
+  DEFAULT_JUDGE_EFFORT,
+  DEFAULT_JUDGE_MODEL,
   makeCodexExecJudge,
   parseCodexEventStream,
   verdictsFromCodexOutput,
@@ -104,6 +106,22 @@ describe('codexArgs', () => {
       '-',
     ])
   })
+
+  it('pins reasoning effort via -c when set', () => {
+    expect(codexArgs('/tmp/s.json', 'm', 'low')).toEqual([
+      'exec',
+      '--json',
+      '--output-schema',
+      '/tmp/s.json',
+      '--sandbox',
+      'read-only',
+      '--model',
+      'm',
+      '-c',
+      'model_reasoning_effort=low',
+      '-',
+    ])
+  })
 })
 
 describe('makeCodexExecJudge (injected run — no live call)', () => {
@@ -187,6 +205,34 @@ describe('makeCodexExecJudge (injected run — no live call)', () => {
     } finally {
       if (prev === undefined) delete process.env.QA_JUDGE_MODEL
       else process.env.QA_JUDGE_MODEL = prev
+    }
+  })
+
+  it('defaults to the pinned cheap model + low effort (never inherits operator config)', async () => {
+    const prevModel = process.env.QA_JUDGE_MODEL
+    const prevEffort = process.env.QA_JUDGE_EFFORT
+    delete process.env.QA_JUDGE_MODEL
+    delete process.env.QA_JUDGE_EFFORT
+    try {
+      let seenArgs: string[] = []
+      const judge = makeCodexExecJudge({
+        run: async args => {
+          seenArgs = args
+          return stream({
+            verdicts: [{ item_index: 0, verdict: 'pass', citation: 'c', critique: 'k' }],
+          })
+        },
+      })
+      await judge(input)
+      // The bug this guards: with nothing pinned the judge must use the cheap
+      // default, NOT silently inherit the operator's codex config (gpt-5.5/xhigh).
+      expect(seenArgs[seenArgs.indexOf('--model') + 1]).toBe(DEFAULT_JUDGE_MODEL)
+      expect(seenArgs).toContain(`model_reasoning_effort=${DEFAULT_JUDGE_EFFORT}`)
+    } finally {
+      if (prevModel === undefined) delete process.env.QA_JUDGE_MODEL
+      else process.env.QA_JUDGE_MODEL = prevModel
+      if (prevEffort === undefined) delete process.env.QA_JUDGE_EFFORT
+      else process.env.QA_JUDGE_EFFORT = prevEffort
     }
   })
 

--- a/frontend/tests/tours/judge/adapter/codex-exec.ts
+++ b/frontend/tests/tours/judge/adapter/codex-exec.ts
@@ -121,6 +121,7 @@ export function verdictsFromCodexOutput(stdout: string): {
 export interface CodexExecOptions {
   bin?: string
   model?: string
+  effort?: string
   tracePath?: string
   // Injected for tests: run codex and return raw stdout (defaults to a spawn).
   run?: (args: string[], prompt: string) => Promise<string>
@@ -156,12 +157,25 @@ function defaultRun(
     })
 }
 
+// The spec mandates a CHEAP judge ("cheap model judges, stronger model authors
+// issues"). Pin a mini-tier model + low reasoning effort as the DEFAULT so the
+// judge never silently inherits the operator's codex config (a global
+// gpt-5.5 / xhigh default is both costly AND miscalibrating here — over-reasoning
+// invents false fails). Overridable via QA_JUDGE_MODEL / QA_JUDGE_EFFORT or opts
+// (e.g. the labeler passes a stronger model). gpt-5.4-mini is the cheapest tier
+// the pinned Codex CLI supports on a ChatGPT account; gpt-5.6-luna is cheaper/
+// newer but needs a Codex CLI upgrade (revalidate exact models at build time).
+export const DEFAULT_JUDGE_MODEL = 'gpt-5.4-mini'
+export const DEFAULT_JUDGE_EFFORT = 'low'
+
 // Build the argv for `codex exec` (schema written to a temp file). Passes
-// --model when set so the stronger-model labeling path (QA_JUDGE_MODEL /
-// QA_LABELER_MODEL) actually selects that model, not just labels the trace.
-export function codexArgs(schemaPath: string, model?: string): string[] {
+// --model when set (so the model is actually selected, not just labeled in the
+// trace) and pins reasoning effort via `-c` when set — the judge must NOT
+// inherit the operator's codex config effort (e.g. a global xhigh).
+export function codexArgs(schemaPath: string, model?: string, effort?: string): string[] {
   const args = ['exec', '--json', '--output-schema', schemaPath, '--sandbox', 'read-only']
   if (model) args.push('--model', model)
+  if (effort) args.push('-c', `model_reasoning_effort=${effort}`)
   args.push('-')
   return args
 }
@@ -179,7 +193,8 @@ function allUnsure(input: JudgeInput, critique: string): PerItemVerdict[] {
 // tool-using run (or a parse miss) yields all-unsure (never a fabricated fail).
 export function makeCodexExecJudge(opts: CodexExecOptions = {}): Judge {
   const bin = opts.bin ?? process.env.QA_JUDGE_CODEX_BIN ?? 'codex'
-  const model = opts.model ?? process.env.QA_JUDGE_MODEL
+  const model = opts.model ?? process.env.QA_JUDGE_MODEL ?? DEFAULT_JUDGE_MODEL
+  const effort = opts.effort ?? process.env.QA_JUDGE_EFFORT ?? DEFAULT_JUDGE_EFFORT
   const timeoutMs = opts.timeoutMs ?? 120_000
   const run = opts.run ?? defaultRun(bin, timeoutMs)
   const tracePath = opts.tracePath ?? process.env.QA_JUDGE_TRACE
@@ -193,7 +208,7 @@ export function makeCodexExecJudge(opts: CodexExecOptions = {}): Judge {
     let error: string | undefined
     try {
       for (let attempt = 0; attempt < 2; attempt++) {
-        const stdout = await run(codexArgs(schemaPath, model), prompt)
+        const stdout = await run(codexArgs(schemaPath, model, effort), prompt)
         result = verdictsFromCodexOutput(stdout)
         if (!result.rejectedForTool) break // pure-criticism run — accept
       }

--- a/frontend/tests/tours/judge/adapter/codex-exec.ts
+++ b/frontend/tests/tours/judge/adapter/codex-exec.ts
@@ -168,6 +168,11 @@ function defaultRun(
 export const DEFAULT_JUDGE_MODEL = 'gpt-5.4-mini'
 export const DEFAULT_JUDGE_EFFORT = 'low'
 
+// Monotonic per-process counter for the schema temp file, so judge calls in one
+// process can never collide on the same pid+millisecond path (callers may invoke
+// the judge for several behaviors close together).
+let schemaSeq = 0
+
 // Build the argv for `codex exec` (schema written to a temp file). Passes
 // --model when set (so the model is actually selected, not just labeled in the
 // trace) and pins reasoning effort via `-c` when set — the judge must NOT
@@ -201,7 +206,10 @@ export function makeCodexExecJudge(opts: CodexExecOptions = {}): Judge {
 
   return async (input: JudgeInput): Promise<PerItemVerdict[]> => {
     const prompt = buildPrompt(input)
-    const schemaPath = path.join(os.tmpdir(), `qa-judge-schema-${process.pid}-${Date.now()}.json`)
+    const schemaPath = path.join(
+      os.tmpdir(),
+      `qa-judge-schema-${process.pid}-${Date.now()}-${schemaSeq++}.json`
+    )
     fs.writeFileSync(schemaPath, JSON.stringify(OUTPUT_SCHEMA), 'utf8')
     const start = Date.now()
     let result: ReturnType<typeof verdictsFromCodexOutput> | undefined

--- a/frontend/tests/tours/judge/eval/run.ts
+++ b/frontend/tests/tours/judge/eval/run.ts
@@ -12,10 +12,11 @@ import * as path from 'path'
 import { loadCorpus } from '../corpus/load'
 import { resolveCaseCaptures } from '../doctor'
 import { buildJudgeInput } from '../judge-input'
+import { behaviorSpec } from '../spec-catalog'
 import { selectJudge } from '../adapter'
-import type { Capture } from '../../support/types'
-import type { ItemVerdicts, Verdict } from '../grader/types'
-import { runEval, type JudgeRunner } from './core'
+import { makeJudgeRunner } from '../judge-runner'
+import type { Verdict } from '../grader/types'
+import { runEval } from './core'
 import {
   abstentionRate,
   fmtPct,
@@ -45,26 +46,13 @@ function parseArgs(argv: string[]): {
   return { corpusRoot, judge, limit, repeat }
 }
 
-function judgeRunnerFromProfile(): JudgeRunner {
-  const judge = selectJudge(process.env.QA_JUDGE ?? 'codex-exec')
-  return async (behaviorId: string, captures: Capture[]): Promise<ItemVerdicts> => {
-    const input = buildJudgeInput(behaviorId, captures)
-    if (!input || input.items.length === 0) return {}
-    const verdicts = await judge(input)
-    const out: ItemVerdicts = {}
-    for (const v of verdicts)
-      out[v.itemIndex] = { verdict: v.verdict, citation: v.citation, reason: v.critique }
-    return out
-  }
-}
-
 async function main(): Promise<void> {
   const { corpusRoot, judge, limit, repeat } = parseArgs(process.argv.slice(2))
   const corpus = loadCorpus(corpusRoot)
   let cases = corpus.cases
   if (limit !== undefined) cases = cases.slice(0, limit)
 
-  const runner = judge ? judgeRunnerFromProfile() : undefined
+  const runner = judge ? makeJudgeRunner() : undefined
   const result = await runEval(cases, c => corpus.capturesFor(c), { judge: runner })
 
   console.log(
@@ -106,6 +94,34 @@ async function main(): Promise<void> {
     }
     const avg = scores.length ? scores.reduce((a, b) => a + b, 0) / scores.length : 1
     console.log(`  judge self-consistency (${repeat} repeats): ${fmtPct(avg)} (advisory)\n`)
+  }
+
+  // The JUDGE's actual verdicts on the residue items — the whole point of the
+  // agentic layer. Advisory + label-gated, so these are EXCLUDED from the matrix
+  // above; printed here so the judgment is visible, not merely counted. These
+  // are the candidate critiques a human later corrects into ground-truth labels.
+  if (judge) {
+    const icon: Record<Verdict, string> = { pass: '✅', fail: '❌', unsure: '⚠️' }
+    console.log('Judge verdicts — residue items (advisory; not part of the merge gate):')
+    let shown = 0
+    for (const c of result.cases) {
+      // source==='judge' = every item the judge actually ruled on: pure
+      // judge-tagged items AND verifier items that abstained and fell back.
+      const judged = c.items.filter(i => i.source === 'judge')
+      if (judged.length === 0) continue
+      const spec = behaviorSpec(c.behaviorId)
+      for (const it of judged) {
+        shown += 1
+        const thenText = spec?.then[it.thenIndex] ?? ''
+        const kind = it.grader === 'verifier' ? ' (verifier-fallback)' : ''
+        console.log(`  ${c.caseId} [${it.thenIndex}] ${icon[it.predicted]} ${it.predicted}${kind}`)
+        if (thenText) console.log(`      then: ${thenText}`)
+        if (it.citation) console.log(`      cite: ${it.citation}`)
+        if (it.reason) console.log(`      critique: ${it.reason}`)
+      }
+    }
+    if (shown === 0) console.log('  (none — no judge-tagged residue items in this corpus)')
+    console.log('')
   }
 
   // Label-gated metrics.

--- a/frontend/tests/tours/judge/judge-runner.test.ts
+++ b/frontend/tests/tours/judge/judge-runner.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest'
+import { runnerFromJudge } from './judge-runner'
+import type { Judge } from './adapter'
+import type { Capture } from '../support/types'
+
+// A minimal capture tagging a behavior; the evidence content is irrelevant to
+// the runner (buildJudgeInput derives residue items from the behavior's spec +
+// classification, not from the capture's payload).
+const cap = (behavior: string): Capture =>
+  ({
+    behaviors: [behavior],
+    aria: { role: 'root', children: [] },
+    apiResponses: {},
+    url: '/x',
+    serverTime: { now: '2026-01-01T00:00:00Z', accelerationFactor: 1, isAccelerated: false },
+    dialogs: [],
+  }) as unknown as Capture
+
+describe('runnerFromJudge', () => {
+  it('maps the judge per-item verdicts into ItemVerdicts keyed by then-index', async () => {
+    // CON-042[0] ("a confirmation prompt warns…") is a judge-tagged residue item.
+    const judge: Judge = vi.fn(async () => [
+      {
+        itemIndex: 0,
+        verdict: 'fail' as const,
+        citation: 'DIALOGS[0].message',
+        critique: 'empty warning',
+      },
+    ])
+    const run = runnerFromJudge(judge)
+    const out = await run('CON-042', [cap('CON-042')])
+    expect(judge).toHaveBeenCalledOnce()
+    expect(out).toEqual({
+      0: { verdict: 'fail', citation: 'DIALOGS[0].message', reason: 'empty warning' },
+    })
+  })
+
+  it('returns {} and never calls the judge when the behavior has no residue items', async () => {
+    const judge: Judge = vi.fn(async () => [])
+    const run = runnerFromJudge(judge)
+    // An unknown behavior has no spec → buildJudgeInput returns undefined.
+    const out = await run('ZZZ-999', [cap('ZZZ-999')])
+    expect(out).toEqual({})
+    expect(judge).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/tests/tours/judge/judge-runner.ts
+++ b/frontend/tests/tours/judge/judge-runner.ts
@@ -1,0 +1,35 @@
+// Bridge: a Judge adapter → a per-behavior runner the grader/eval/report consume.
+// Shared by the eval's --judge advisory layer AND the live-capture report, so
+// both wire the judge identically (build the residue evidence bundle, call the
+// judge, map its per-item verdicts into the grader's ItemVerdicts shape). The
+// judge is only invoked when a behavior actually has residue items.
+
+import { selectJudge } from './adapter'
+import type { Judge } from './adapter'
+import { buildJudgeInput } from './judge-input'
+import type { Capture } from '../support/types'
+import type { ItemVerdicts } from './grader/types'
+
+// (behaviorId, captures) → judge verdicts keyed by then-index. Empty ({}) when
+// the behavior has no residue items — no judge call is made in that case.
+export type JudgeRunner = (behaviorId: string, captures: Capture[]) => Promise<ItemVerdicts>
+
+// Wrap a concrete Judge. Pure w.r.t. selection — testable with a fake judge.
+export function runnerFromJudge(judge: Judge): JudgeRunner {
+  return async (behaviorId: string, captures: Capture[]): Promise<ItemVerdicts> => {
+    const input = buildJudgeInput(behaviorId, captures)
+    if (!input || input.items.length === 0) return {}
+    const verdicts = await judge(input)
+    const out: ItemVerdicts = {}
+    for (const v of verdicts)
+      out[v.itemIndex] = { verdict: v.verdict, citation: v.citation, reason: v.critique }
+    return out
+  }
+}
+
+// Select the judge by the QA_JUDGE env (default codex-exec) and wrap it.
+export function makeJudgeRunner(
+  profile: string = process.env.QA_JUDGE ?? 'codex-exec'
+): JudgeRunner {
+  return runnerFromJudge(selectJudge(profile))
+}

--- a/frontend/tests/tours/judge/report/render.ts
+++ b/frontend/tests/tours/judge/report/render.ts
@@ -161,13 +161,18 @@ async function main(): Promise<void> {
   const fs = await import('fs')
   const path = await import('path')
   const { groupByBehavior, gradeBehavior } = await import('../grader/grade')
-  const [runDir, outFile] = process.argv.slice(2)
-  if (runDir === '-h' || runDir === '--help') {
-    console.log('usage: render.ts <runDir> [outFile]')
+  const argv = process.argv.slice(2)
+  if (argv.includes('-h') || argv.includes('--help')) {
+    console.log('usage: render.ts <runDir> [outFile] [--judge]')
+    console.log(
+      '  --judge  run the LLM judge over residue items (advisory; needs codex quota / QA_JUDGE)'
+    )
     process.exit(0)
   }
+  const useJudge = argv.includes('--judge')
+  const [runDir, outFile] = argv.filter(a => !a.startsWith('--'))
   if (!runDir) {
-    console.error('usage: render.ts <runDir> [outFile]')
+    console.error('usage: render.ts <runDir> [outFile] [--judge]')
     process.exit(2)
   }
   const capturesRoot = path.join(runDir, 'captures')
@@ -181,7 +186,16 @@ async function main(): Promise<void> {
   }
   walk(capturesRoot)
   const captures = files.map(f => JSON.parse(fs.readFileSync(f, 'utf8')))
-  const grades = groupByBehavior(captures).map(set => gradeBehavior(set))
+
+  // The advisory judge layer over residue items (opt-in; the report is advisory
+  // either way). Without --judge, judge-tagged items render as "pending labels";
+  // with it, the judge's grounded verdict + critique lands in the per-item detail.
+  const runner = useJudge ? (await import('../judge-runner')).makeJudgeRunner() : undefined
+  const grades = await Promise.all(
+    groupByBehavior(captures).map(async set =>
+      gradeBehavior(set, runner ? { judge: await runner(set.behaviorId, set.captures) } : {})
+    )
+  )
   let runId: string | undefined
   let gitSha: string | undefined
   const manifestPath = path.join(runDir, 'manifest.json')

--- a/frontend/tests/tours/judge/report/render.ts
+++ b/frontend/tests/tours/judge/report/render.ts
@@ -191,11 +191,15 @@ async function main(): Promise<void> {
   // either way). Without --judge, judge-tagged items render as "pending labels";
   // with it, the judge's grounded verdict + critique lands in the per-item detail.
   const runner = useJudge ? (await import('../judge-runner')).makeJudgeRunner() : undefined
-  const grades = await Promise.all(
-    groupByBehavior(captures).map(async set =>
-      gradeBehavior(set, runner ? { judge: await runner(set.behaviorId, set.captures) } : {})
-    )
-  )
+  // Grade SERIALLY (matching eval/core.ts's `for … await` loop). The judge calls
+  // must NOT fan out: concurrent codex spawns storm a quota-limited account, and
+  // parallel invocation is what the eval path deliberately avoids. Serial keeps
+  // the report identical to the eval and one codex subprocess at a time.
+  const grades = []
+  for (const set of groupByBehavior(captures)) {
+    const judge = runner ? await runner(set.behaviorId, set.captures) : undefined
+    grades.push(gradeBehavior(set, judge ? { judge } : {}))
+  }
   let runId: string | undefined
   let gitSha: string | undefined
   const manifestPath = path.join(runDir, 'manifest.json')


### PR DESCRIPTION
## What

Two related changes to the agentic UX QA judge, both proven end-to-end against the live staging sweep:

1. **Run the judge over live captures.** `render.ts --judge` wires the LLM judge into the live-capture report path (it previously graded verifiers deterministically and marked judge items "pending"). New `make qa-report RUNDIR=… JUDGE=1` renders a run dir with the judge layer. A shared `judge-runner` factory dedupes the judge wiring across the eval and the report. `qa-eval --judge` now **prints the judge's per-item verdicts + critiques** (they were computed but only counted before).

2. **Pin a cheap judge model (bug fix).** The `codex-exec` adapter only passed `--model` when `QA_JUDGE_MODEL` was set and never controlled reasoning effort — so with nothing pinned it silently inherited the operator's codex config (here `gpt-5.5` / `xhigh`), the opposite of the spec's "cheap model judges" (design lines 10/35/62). Now defaults to `gpt-5.4-mini` + `low` effort (both overridable via `QA_JUDGE_MODEL` / `QA_JUDGE_EFFORT`), and actually pins effort via `-c model_reasoning_effort`.

## Why it matters

- The judge is the point of the harness (the non-verifiable, semantic residue), but it had never actually run over live app captures — only the frozen corpus. Now a real staging sweep gets judge verdicts.
- Running the judge on the flagship at max reasoning was both costly and *miscalibrating*: over-reasoning is what produced a false-fail on CON-043 (it reasoned flattened evidence frames into a contradiction). Cheap + low effort gives the same correct verdicts, faster.

## Verification

- Typecheck clean; 234/234 tours tests + full frontend suite green (2 unrelated userEvent-timeout flakes retried per repo norm, pass in isolation).
- Live proof: judge ran over the 49-capture staging sweep (`model=gpt-5.4-mini` confirmed in trace, ~7–9s/call) — pass on the clean delete-confirm, fail on the doctored empty-warning case, grounded abstention on the ambiguous merge-outcome item.
- New tests: `judge-runner` verdict mapping; `codexArgs` effort arg; a regression guard proving the judge uses the cheap default and never inherits operator config.

## Notes / follow-ups (not in this PR)

- **Advisory only** — files no issues (issue-mode is the deferred PR4).
- **Labeler = Claude** (different family, cleanest circularity break) is recorded in `judge/DEFERRED.md`, deferred until the residue grows past 3 items (needs a `Judge`-interface adapter).
- The live run surfaced a real *harness* limitation: `buildEvidence` flattens all capture frames into one aria blob, losing the temporal ordering that sequence behaviors (CON-043[5] "reported and auto-dismissed") need — a separate improvement candidate.