### PR TITLE
feat(tours): judge pass over SSOT intents (judged UX goals)

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -35,6 +35,7 @@
         "tailwindcss": "^4",
         "typescript": "^5",
         "vitest": "^4.0.16",
+        "yaml": "^2.9.0",
       },
     },
   },
@@ -1176,6 +1177,8 @@
     "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
 
     "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
+
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,6 +44,7 @@
     "prettier": "^3.7.4",
     "tailwindcss": "^4",
     "typescript": "^5",
-    "vitest": "^4.0.16"
+    "vitest": "^4.0.16",
+    "yaml": "^2.9.0"
   }
 }

--- a/frontend/tests/tours/judge/DEFERRED.md
+++ b/frontend/tests/tours/judge/DEFERRED.md
@@ -32,3 +32,11 @@ The user is unavailable, so PR2 is engineered to be mergeable with **zero** huma
 PR3 grows the corpus toward the v0 size **mechanically** (new tours' synthetic captures + doctored self-labeled + clean cases) and lands the verifiers-only eval end-to-end, but the **full v0 human-validated freeze stays deferred** — exactly like the label-gated metrics above. It needs the maintainer's corrected ground-truth labels for the real/clean/ambiguous cases, the 70/30 frozen dev/held-out split, and the fail-precision-over-held-out bar. Un-defer via the same recipe: draft with a stronger model (`*.draft.json`), the maintainer corrects in place (`*.labeled.json`), and PR4 wires the bar + issue-mode flip. **No human-labeling ask is surfaced by PR3** — everything it ships is mergeable with zero human labels.
 
 _(The PR2 capture-coverage caveats CON-038[0] / CON-040[0] are now toured — the bare-`/contacts` and last-contact-boundary captures land in `contacts.tour.ts` (PR3 follow-up 3), so those then-items are proven, not abstained.)_
+
+## Intent-pass labels (label-gated, same recipe)
+
+The intent pass (`intent-runner.ts`, one judge call per `type: intent` SSOT behavior) is advisory and label-gated exactly like the item-judge residue:
+
+- **Intent fail-precision joins the north star**: fail-precision is measured over the judge's residual item fails AND intent fails, over a human-labeled held-out set. Deferred with the same dependency.
+- **Intent-case expectations are hypotheses.** `corpus/intent-cases/*.json` carry `expected_hypothesis` — self-labeled guesses printed for eyeballing under `--judge`, never trusted ground truth and never a merge gate. The maintainer's corrected labels supersede them via the label.ts draft → `*.labeled.json` recipe above (the Claude drafter covers intents too).
+- **Live intent smoke**: `QA_JUDGE=codex-exec bun run tests/tours/judge/eval/run.ts --judge` now also prints intent verdicts vs hypotheses; `QA_INTENT_MODEL`/`QA_INTENT_EFFORT` override the pass's stronger-model default (`gpt-5.5`/`medium` — revalidate against the pinned Codex CLI's model list at first live run).

--- a/frontend/tests/tours/judge/README.md
+++ b/frontend/tests/tours/judge/README.md
@@ -11,6 +11,10 @@ Each behavior's `then`-items are classified in `grader/classification.ts`, keyed
 
 Aggregation: any item `fail` → behavior `fail`; all `pass` → `pass`; else `unsure`. The **grounding rule** downgrades an uncited `fail` to `unsure` (`grader/grade.ts`).
 
+## The intent pass (judged experience goals)
+
+Sibling of the item-judge residue: one judge call per `type: intent` behavior in the SSOT (`intent-catalog.ts`, a transcription kept YAML-synced by `intent-catalog.test.ts`). Evidence binds via the inverted `serves:` edges — captures tagged with the intent's ID or any serving behavior, deduped, capped at 8 with the dropped count surfaced (`intent-input.ts`). The prompt renders an INTENT block + per-capture `CAPTURE[n]` sections; a `fail` must cite the capture index + node/path, and the preamble forbids failing goals for aria-invisible visual qualities (abstain instead — screenshots are the PR3 follow-up). Verdicts land in the report's **Intents** section: a `current` intent failing is a regression signal, a `proposed` intent passing is a progress signal. The pass runs only under `--judge` (report CLI `JUDGE=1` / eval `--judge`), defaults to a stronger model than the cheap item judge (`QA_INTENT_MODEL`/`QA_INTENT_EFFORT`, default gpt-5.5/medium), and never touches the offline merge gate. `corpus/intent-cases/*.json` carry self-labeled hypothesis verdicts (see `DEFERRED.md` — labels pending).
+
 ## Running the eval
 
 ```bash

--- a/frontend/tests/tours/judge/adapter/intent-prompt.test.ts
+++ b/frontend/tests/tours/judge/adapter/intent-prompt.test.ts
@@ -1,0 +1,73 @@
+// The intent prompt variant: INTENT block (statement, status framing),
+// per-capture CAPTURE[n] sections in order, the single [0] item, and the
+// no-visual-styling caution — while the behavior path stays byte-identical.
+
+import { describe, expect, it } from 'vitest'
+import { buildPrompt } from './prompt'
+import type { JudgeInput } from './types'
+
+const base: JudgeInput = {
+  behaviorId: 'DSH-010',
+  behaviorTitle: 'at a glance',
+  given: '',
+  when: '',
+  then: ['the statement'],
+  items: [{ itemIndex: 0, thenText: 'the statement' }],
+  evidence: {},
+  intent: { statement: 'the statement', status: 'current' },
+  captureSections: [
+    {
+      note: 'dashboard#1 — cards',
+      evidence: { url: 'http://x/1', aria: { role: 'root', children: [] } },
+    },
+    {
+      note: 'dashboard#2 — empty',
+      evidence: { url: 'http://x/2', aria: { role: 'root', children: [] } },
+    },
+  ],
+}
+
+describe('buildPrompt (intent variant)', () => {
+  const prompt = buildPrompt(base)
+
+  it('renders the INTENT block with statement and status framing', () => {
+    expect(prompt).toContain('=== INTENT ===')
+    expect(prompt).toContain('INTENT DSH-010: at a glance')
+    expect(prompt).toContain('STATEMENT: the statement')
+    expect(prompt).toContain('STATUS: current')
+  })
+
+  it('renders one CAPTURE[n] section per bound capture, in order', () => {
+    const first = prompt.indexOf('=== CAPTURE[0] — dashboard#1 — cards ===')
+    const second = prompt.indexOf('=== CAPTURE[1] — dashboard#2 — empty ===')
+    expect(first).toBeGreaterThan(-1)
+    expect(second).toBeGreaterThan(first)
+    expect(prompt.indexOf('http://x/1')).toBeLessThan(prompt.indexOf('http://x/2'))
+  })
+
+  it('carries the capture-index grounding rule and the visual-styling caution', () => {
+    expect(prompt).toContain('cite the capture index')
+    expect(prompt).toMatch(/do not fail a goal for purely visual qualities/)
+  })
+
+  it('lists the single [0] item', () => {
+    expect(prompt).toContain('=== ITEMS ===')
+    expect(prompt).toContain('[0] the statement')
+  })
+
+  it('does not affect the behavior-path prompt', () => {
+    const behaviorInput: JudgeInput = {
+      behaviorId: 'CON-042',
+      behaviorTitle: 't',
+      given: 'g',
+      when: 'w',
+      then: ['a'],
+      items: [{ itemIndex: 0, thenText: 'a' }],
+      evidence: { url: 'http://y' },
+    }
+    const p = buildPrompt(behaviorInput)
+    expect(p).toContain('=== SPEC ===')
+    expect(p).not.toContain('=== INTENT ===')
+    expect(p).not.toContain('CAPTURE[')
+  })
+})

--- a/frontend/tests/tours/judge/adapter/prompt.ts
+++ b/frontend/tests/tours/judge/adapter/prompt.ts
@@ -45,6 +45,29 @@ const SYSTEM_PREAMBLE = [
   '`citation`. An uncited fail is treated as unsure. Categorical only — no scores.',
 ].join('\n')
 
+// The intent-pass preamble: the judge grades ONE experience goal over several
+// CAPTURE[n] sections instead of then-items over one merged evidence bundle.
+const INTENT_PREAMBLE = [
+  'You are a read-only UX experience JUDGE. You are criticism, not agency: reason',
+  'ONLY over the labeled evidence blocks below. Do NOT use any tool, run any',
+  'command, browse, or fetch — a run that calls a tool is DISCARDED.',
+  '',
+  'Under INTENT is one experience GOAL the surface exists to achieve. Under',
+  'CAPTURE[0..n] are independent captured states of that surface (accessibility',
+  'tree + recorded API responses). Judge whether the captured surface, taken as',
+  'a whole, ACHIEVES the goal — not whether individual elements exist, but',
+  'whether a user in these states would actually get the experience the goal',
+  'names. Return ONE categorical verdict for item [0]:',
+  '  - pass   : the evidence shows the goal is achieved in the captured states',
+  '  - fail   : the evidence shows the goal is violated or undermined',
+  '  - unsure : the evidence is insufficient to judge the goal (abstention)',
+  'GROUNDING RULE: a `fail` MUST cite the capture index AND the exact aria node',
+  'label or JSON path that undermines the goal (e.g. "CAPTURE[2]: <cite>") in',
+  '`citation`. An uncited fail is treated as unsure. The aria tree carries no',
+  'visual styling — do not fail a goal for purely visual qualities (size, color,',
+  'spacing) you cannot observe; abstain instead. Categorical only — no scores.',
+].join('\n')
+
 // Render the normalized aria tree as a stable indented outline.
 export function renderAria(node: AriaNode, indent = 0): string {
   const pad = '  '.repeat(indent)
@@ -99,6 +122,8 @@ export function fewShotBlock(): string {
 }
 
 export function buildPrompt(input: JudgeInput): string {
+  if (input.intent) return buildIntentPrompt(input)
+
   const spec = [
     `BEHAVIOR ${input.behaviorId}: ${input.behaviorTitle}`,
     `GIVEN: ${input.given}`,
@@ -115,6 +140,33 @@ export function buildPrompt(input: JudgeInput): string {
     block('SPEC', spec),
     renderEvidence(input.evidence),
     block('ITEMS', items),
+    'Return ONLY JSON matching the required schema: { "verdicts": [ { "item_index", "verdict", "citation", "critique" } ] }.',
+  ].filter(p => p.trim() !== '')
+
+  return parts.join('\n\n')
+}
+
+// The intent-pass prompt: INTENT block + one CAPTURE[n] section per bound
+// capture (same labeled-block protocol inside each section), fixed order.
+function buildIntentPrompt(input: JudgeInput): string {
+  const intent = input.intent
+  if (!intent) throw new Error('buildIntentPrompt requires input.intent')
+  const head = [
+    `INTENT ${input.behaviorId}: ${input.behaviorTitle}`,
+    `STATUS: ${intent.status} (current = achieved today, judge as regression; proposed = aspirational, judge as progress)`,
+    `STATEMENT: ${intent.statement}`,
+  ].join('\n')
+
+  const sections = (input.captureSections ?? []).map((s, n) =>
+    block(`CAPTURE[${n}] — ${s.note}`, renderEvidence(s.evidence))
+  )
+
+  const parts = [
+    INTENT_PREAMBLE,
+    fewShotBlock(),
+    block('INTENT', head),
+    ...sections,
+    block('ITEMS', `  [0] ${intent.statement}`),
     'Return ONLY JSON matching the required schema: { "verdicts": [ { "item_index", "verdict", "citation", "critique" } ] }.',
   ].filter(p => p.trim() !== '')
 

--- a/frontend/tests/tours/judge/adapter/types.ts
+++ b/frontend/tests/tours/judge/adapter/types.ts
@@ -20,6 +20,13 @@ export interface EvidenceBlocks {
   dialogs?: DialogRecord[]
 }
 
+// One capture rendered as its own labeled CAPTURE[n] section in an intent
+// prompt (multi-capture evidence stays sectioned, never merged).
+export interface CaptureSection {
+  note: string
+  evidence: EvidenceBlocks
+}
+
 export interface JudgeInput {
   behaviorId: string
   behaviorTitle: string
@@ -28,6 +35,14 @@ export interface JudgeInput {
   then: string[] // full then list (context)
   items: JudgeItem[] // the residual items to grade
   evidence: EvidenceBlocks
+  /**
+   * Intent variant: set on an intent-pass call. The prompt renders an INTENT
+   * block (statement instead of GWT) and per-capture CAPTURE[n] sections from
+   * captureSections; `evidence` is ignored. behaviorId/behaviorTitle carry the
+   * intent's id/title; items is the single statement item (index 0).
+   */
+  intent?: { statement: string; status: 'current' | 'proposed' }
+  captureSections?: CaptureSection[]
 }
 
 // Categorical per-item verdict. `citation` is the exact aria node label / JSON

--- a/frontend/tests/tours/judge/corpus/intent-case.test.ts
+++ b/frontend/tests/tours/judge/corpus/intent-case.test.ts
@@ -5,6 +5,7 @@
 import * as path from 'path'
 import { describe, expect, it } from 'vitest'
 import { INTENT_CATALOG } from '../intent-catalog'
+import { bindIntentCaptures } from '../intent-input'
 import { loadCorpus } from './load'
 import { parseIntentCase } from './schema'
 
@@ -49,6 +50,26 @@ describe('committed intent-cases', () => {
       expect(INTENT_CATALOG[ic.intent_id], `${ic.id} intent`).toBeDefined()
       const captures = corpus.capturesFor(ic)
       expect(captures.length).toBe(ic.captures.length)
+    }
+  })
+
+  // File resolution alone is not enough: a case whose captures carry no
+  // serving-behavior tag would silently produce "no evidence bound" on every
+  // live run, defeating the hypothesis it exists to test.
+  it('every case actually binds evidence; doctored mutations hit a bound capture', () => {
+    for (const ic of corpus.intentCases) {
+      const intent = INTENT_CATALOG[ic.intent_id]
+      const captures = corpus.capturesFor(ic)
+      const { captures: bound } = bindIntentCaptures(intent, captures)
+      expect(bound.length, `${ic.id} binds no captures`).toBeGreaterThan(0)
+      if (ic.mutation && 'captureIndex' in ic.mutation && ic.mutation.captureIndex !== undefined) {
+        const target = captures[ic.mutation.captureIndex]
+        expect(target, `${ic.id} mutation captureIndex out of range`).toBeDefined()
+        expect(
+          bound.some(c => c.tour === target.tour && c.seq === target.seq),
+          `${ic.id} mutated capture is not in the bound set — the doctored fail never reaches the judge`
+        ).toBe(true)
+      }
     }
   })
 })

--- a/frontend/tests/tours/judge/corpus/intent-case.test.ts
+++ b/frontend/tests/tours/judge/corpus/intent-case.test.ts
@@ -1,0 +1,54 @@
+// Intent-case schema rules (mirror of the Case rules): doctored requires a
+// mutation, clean must not carry one; committed intent-cases load and their
+// capture refs + intent ids resolve.
+
+import * as path from 'path'
+import { describe, expect, it } from 'vitest'
+import { INTENT_CATALOG } from '../intent-catalog'
+import { loadCorpus } from './load'
+import { parseIntentCase } from './schema'
+
+const CORPUS = path.join(import.meta.dirname ?? __dirname)
+
+const clean = {
+  id: 'x-clean',
+  intent_id: 'DSH-010',
+  source: 'clean',
+  captures: ['dashboard/a.json'],
+  expected_hypothesis: 'pass',
+}
+
+describe('parseIntentCase', () => {
+  it('accepts a clean case and a doctored case with a mutation', () => {
+    expect(parseIntentCase(clean).id).toBe('x-clean')
+    expect(
+      parseIntentCase({
+        ...clean,
+        id: 'x-doc',
+        source: 'doctored',
+        mutation: { op: 'blank_dialog' },
+        expected_hypothesis: 'fail',
+      }).source
+    ).toBe('doctored')
+  })
+
+  it('rejects doctored-without-mutation and clean-with-mutation', () => {
+    expect(() => parseIntentCase({ ...clean, source: 'doctored' })).toThrow(/requires a mutation/)
+    expect(() => parseIntentCase({ ...clean, mutation: { op: 'blank_dialog' } })).toThrow(
+      /must not carry a mutation/
+    )
+  })
+})
+
+describe('committed intent-cases', () => {
+  const corpus = loadCorpus(CORPUS)
+
+  it('load, reference known intents, and resolve their captures', () => {
+    expect(corpus.intentCases.length).toBeGreaterThanOrEqual(2)
+    for (const ic of corpus.intentCases) {
+      expect(INTENT_CATALOG[ic.intent_id], `${ic.id} intent`).toBeDefined()
+      const captures = corpus.capturesFor(ic)
+      expect(captures.length).toBe(ic.captures.length)
+    }
+  })
+})

--- a/frontend/tests/tours/judge/corpus/intent-cases/DSH-010-clean.json
+++ b/frontend/tests/tours/judge/corpus/intent-cases/DSH-010-clean.json
@@ -1,0 +1,15 @@
+{
+  "id": "DSH-010-clean",
+  "intent_id": "DSH-010",
+  "source": "clean",
+  "captures": [
+    "dashboard/004-overdue-list-urgency-default-sort-cards-count-tiers.json",
+    "dashboard/005-overdue-list-name-sort-alphabetical.json",
+    "dashboard/006-overdue-list-last-contacted-sort-oldest-first.json",
+    "dashboard/007-before-mark-as-contacted-dashboard-overdue-list.json",
+    "dashboard/008-after-mark-as-contacted-mutual-interaction-overdue-refetch-n.json",
+    "dashboard/011-caught-up-empty-state-add-view-list-affordances.json"
+  ],
+  "expected_hypothesis": "pass",
+  "notes": "Self-labeled HYPOTHESIS, not ground truth: the untouched prod-shaped sweep shows named cards with cadence, overdue duration, a reachable method, and a suggested action - a user should be able to decide who to contact next and how without opening a contact page."
+}

--- a/frontend/tests/tours/judge/corpus/intent-cases/DSH-011-doctored.json
+++ b/frontend/tests/tours/judge/corpus/intent-cases/DSH-011-doctored.json
@@ -1,0 +1,18 @@
+{
+  "id": "DSH-011-doctored",
+  "intent_id": "DSH-011",
+  "source": "doctored",
+  "captures": [
+    "dashboard/002-dashboard-shell-global-nav-header-add-contact-no-dashboard-s.json",
+    "dashboard/010-overdue-error-state-500-error-carries-the-reason-not-caught-.json",
+    "dashboard/011-caught-up-empty-state-add-view-list-affordances.json"
+  ],
+  "mutation": {
+    "op": "remove_aria_subtree",
+    "captureIndex": 1,
+    "node_role": "heading",
+    "node_name": "Error loading overdue contacts"
+  },
+  "expected_hypothesis": "fail",
+  "notes": "Self-labeled HYPOTHESIS, not ground truth: removing the error announcement leaves the failed-load state blank/ambiguous - the goal explicitly names 'never stranded on a blank or ambiguous screen', so the doctored surface should be judged a violation. If the judge abstains instead (nav + Add Contact remain), that disagreement is exactly what this case is meant to surface for labeling."
+}

--- a/frontend/tests/tours/judge/corpus/load.ts
+++ b/frontend/tests/tours/judge/corpus/load.ts
@@ -5,7 +5,7 @@
 import * as fs from 'fs'
 import * as path from 'path'
 import type { Capture } from '../../support/types'
-import { parseCase, type Case } from './schema'
+import { parseCase, parseIntentCase, type Case, type IntentCase } from './schema'
 
 export function loadCapture(capturesRoot: string, ref: string): Capture {
   return JSON.parse(fs.readFileSync(path.join(capturesRoot, ref), 'utf8')) as Capture
@@ -18,12 +18,16 @@ export function loadCaseFile(file: string): Case {
 export interface LoadedCorpus {
   cases: Case[]
   byId: Map<string, Case>
+  // Intent-pass hypothesis cases (corpus/intent-cases/) — --judge only, never
+  // the merge gate.
+  intentCases: IntentCase[]
   capturesRoot: string
-  capturesFor(c: Case): Capture[]
+  capturesFor(c: Case | IntentCase): Capture[]
 }
 
 export function loadCorpus(corpusRoot: string): LoadedCorpus {
   const casesDir = path.join(corpusRoot, 'cases')
+  const intentCasesDir = path.join(corpusRoot, 'intent-cases')
   const capturesRoot = path.join(corpusRoot, 'captures')
   const cases: Case[] = []
   if (fs.existsSync(casesDir)) {
@@ -32,10 +36,21 @@ export function loadCorpus(corpusRoot: string): LoadedCorpus {
       cases.push(loadCaseFile(path.join(casesDir, f)))
     }
   }
+  const intentCases: IntentCase[] = []
+  if (fs.existsSync(intentCasesDir)) {
+    for (const f of fs.readdirSync(intentCasesDir).sort()) {
+      if (!f.endsWith('.json')) continue
+      intentCases.push(
+        parseIntentCase(JSON.parse(fs.readFileSync(path.join(intentCasesDir, f), 'utf8')))
+      )
+    }
+  }
   return {
     cases,
     byId: new Map(cases.map(c => [c.id, c])),
+    intentCases,
     capturesRoot,
-    capturesFor: (c: Case): Capture[] => c.captures.map(r => loadCapture(capturesRoot, r)),
+    capturesFor: (c: Case | IntentCase): Capture[] =>
+      c.captures.map(r => loadCapture(capturesRoot, r)),
   }
 }

--- a/frontend/tests/tours/judge/corpus/schema.ts
+++ b/frontend/tests/tours/judge/corpus/schema.ts
@@ -112,3 +112,29 @@ export function parseCase(obj: unknown): Case {
   }
   return c
 }
+
+// An intent-pass case. Its expectation is a self-labeled HYPOTHESIS — intent
+// verdicts are judge-only, so these run under --judge only and NEVER gate the
+// merge (ground truth comes from the deferred human-labeling path).
+export const IntentCaseSchema = z.object({
+  id: z.string().min(1),
+  intent_id: z.string().min(1),
+  captures: z.array(z.string()).min(1),
+  source: z.enum(['clean', 'doctored']),
+  mutation: MutationSchema.optional(),
+  expected_hypothesis: VerdictSchema,
+  notes: z.string().optional(),
+})
+
+export type IntentCase = z.infer<typeof IntentCaseSchema>
+
+export function parseIntentCase(obj: unknown): IntentCase {
+  const c = IntentCaseSchema.parse(obj)
+  if (c.source === 'doctored' && !c.mutation) {
+    throw new Error(`intent case ${c.id}: source=doctored requires a mutation`)
+  }
+  if (c.source === 'clean' && c.mutation) {
+    throw new Error(`intent case ${c.id}: source=clean must not carry a mutation`)
+  }
+  return c
+}

--- a/frontend/tests/tours/judge/eval/run.ts
+++ b/frontend/tests/tours/judge/eval/run.ts
@@ -124,6 +124,36 @@ async function main(): Promise<void> {
     console.log('')
   }
 
+  // The intent pass over the corpus's intent-hypothesis cases (--judge only).
+  // Expectations are self-labeled HYPOTHESES, not ground truth — printed for
+  // eyeballing, NEVER part of the merge gate (ground truth is the deferred
+  // human-labeling path).
+  if (judge && corpus.intentCases.length > 0) {
+    const { applyMutation } = await import('../doctor')
+    const { intentSpec } = await import('../intent-catalog')
+    const { makeIntentJudge, runIntentPass } = await import('../intent-runner')
+    const intentJudge = makeIntentJudge()
+    const icon: Record<Verdict, string> = { pass: '✅', fail: '❌', unsure: '⚠️' }
+    console.log('Intent-pass verdicts vs self-labeled hypotheses (advisory; never the merge gate):')
+    for (const ic of corpus.intentCases) {
+      const spec = intentSpec(ic.intent_id)
+      if (!spec) {
+        console.log(`  ${ic.id}: SKIP — unknown intent ${ic.intent_id} (catalog drift?)`)
+        continue
+      }
+      let captures = corpus.capturesFor(ic)
+      if (ic.mutation) captures = applyMutation(captures, ic.mutation)
+      const [grade] = await runIntentPass(captures, intentJudge, [spec])
+      const agree = grade.verdict === ic.expected_hypothesis ? 'agrees with' : 'DIFFERS from'
+      console.log(
+        `  ${ic.id} ${icon[grade.verdict]} ${grade.verdict} — ${agree} hypothesis (${ic.expected_hypothesis})`
+      )
+      if (grade.citation) console.log(`      cite: ${grade.citation}`)
+      if (grade.reason) console.log(`      critique: ${grade.reason}`)
+    }
+    console.log('')
+  }
+
   // Label-gated metrics.
   console.log(
     '  fail-precision over held-out (north star): N/A — pending human labels (see judge/DEFERRED.md)'

--- a/frontend/tests/tours/judge/eval/run.ts
+++ b/frontend/tests/tours/judge/eval/run.ts
@@ -10,7 +10,7 @@
 
 import * as path from 'path'
 import { loadCorpus } from '../corpus/load'
-import { resolveCaseCaptures } from '../doctor'
+import { applyMutation, resolveCaseCaptures } from '../doctor'
 import { buildJudgeInput } from '../judge-input'
 import { behaviorSpec } from '../spec-catalog'
 import { selectJudge } from '../adapter'
@@ -129,27 +129,32 @@ async function main(): Promise<void> {
   // eyeballing, NEVER part of the merge gate (ground truth is the deferred
   // human-labeling path).
   if (judge && corpus.intentCases.length > 0) {
-    const { applyMutation } = await import('../doctor')
     const { intentSpec } = await import('../intent-catalog')
     const { makeIntentJudge, runIntentPass } = await import('../intent-runner')
     const intentJudge = makeIntentJudge()
     const icon: Record<Verdict, string> = { pass: '✅', fail: '❌', unsure: '⚠️' }
     console.log('Intent-pass verdicts vs self-labeled hypotheses (advisory; never the merge gate):')
     for (const ic of corpus.intentCases) {
-      const spec = intentSpec(ic.intent_id)
-      if (!spec) {
-        console.log(`  ${ic.id}: SKIP — unknown intent ${ic.intent_id} (catalog drift?)`)
-        continue
+      // One malformed advisory case must not abort the run (the merge-gate
+      // section below still has to print and exit-code).
+      try {
+        const spec = intentSpec(ic.intent_id)
+        if (!spec) {
+          console.log(`  ${ic.id}: SKIP — unknown intent ${ic.intent_id} (catalog drift?)`)
+          continue
+        }
+        let captures = corpus.capturesFor(ic)
+        if (ic.mutation) captures = applyMutation(captures, ic.mutation)
+        const [grade] = await runIntentPass(captures, intentJudge, [spec])
+        const agree = grade.verdict === ic.expected_hypothesis ? 'agrees with' : 'DIFFERS from'
+        console.log(
+          `  ${ic.id} ${icon[grade.verdict]} ${grade.verdict} — ${agree} hypothesis (${ic.expected_hypothesis})`
+        )
+        if (grade.citation) console.log(`      cite: ${grade.citation}`)
+        if (grade.reason) console.log(`      critique: ${grade.reason}`)
+      } catch (err) {
+        console.log(`  ${ic.id}: ERROR — ${err instanceof Error ? err.message : String(err)}`)
       }
-      let captures = corpus.capturesFor(ic)
-      if (ic.mutation) captures = applyMutation(captures, ic.mutation)
-      const [grade] = await runIntentPass(captures, intentJudge, [spec])
-      const agree = grade.verdict === ic.expected_hypothesis ? 'agrees with' : 'DIFFERS from'
-      console.log(
-        `  ${ic.id} ${icon[grade.verdict]} ${grade.verdict} — ${agree} hypothesis (${ic.expected_hypothesis})`
-      )
-      if (grade.citation) console.log(`      cite: ${grade.citation}`)
-      if (grade.reason) console.log(`      critique: ${grade.reason}`)
     }
     console.log('')
   }

--- a/frontend/tests/tours/judge/eval/run.ts
+++ b/frontend/tests/tours/judge/eval/run.ts
@@ -128,13 +128,17 @@ async function main(): Promise<void> {
   // Expectations are self-labeled HYPOTHESES, not ground truth — printed for
   // eyeballing, NEVER part of the merge gate (ground truth is the deferred
   // human-labeling path).
-  if (judge && corpus.intentCases.length > 0) {
+  // --limit caps live judge cost for intent cases exactly as it does for the
+  // main corpus (each intent case is a potential LLM call).
+  let intentCases = corpus.intentCases
+  if (limit !== undefined) intentCases = intentCases.slice(0, limit)
+  if (judge && intentCases.length > 0) {
     const { intentSpec } = await import('../intent-catalog')
     const { makeIntentJudge, runIntentPass } = await import('../intent-runner')
     const intentJudge = makeIntentJudge()
     const icon: Record<Verdict, string> = { pass: '✅', fail: '❌', unsure: '⚠️' }
     console.log('Intent-pass verdicts vs self-labeled hypotheses (advisory; never the merge gate):')
-    for (const ic of corpus.intentCases) {
+    for (const ic of intentCases) {
       // One malformed advisory case must not abort the run (the merge-gate
       // section below still has to print and exit-code).
       try {

--- a/frontend/tests/tours/judge/intent-catalog.test.ts
+++ b/frontend/tests/tours/judge/intent-catalog.test.ts
@@ -1,0 +1,76 @@
+// The INTENT_CATALOG ↔ SSOT sync guard: parses the three toured domains' spec
+// YAML and asserts the transcription matches — intent ids/titles/statements/
+// status verbatim, and servedBy equal to the corpus-wide inversion of the
+// `serves:` edges. Catalog drift fails HERE (offline), never in a live run.
+
+import * as fs from 'fs'
+import * as path from 'path'
+import { parse } from 'yaml'
+import { describe, expect, it } from 'vitest'
+import { INTENT_CATALOG } from './intent-catalog'
+
+const SPEC_DIR = path.join(import.meta.dirname ?? __dirname, '..', '..', '..', '..', 'spec')
+const TOURED_DOMAINS = ['contacts.yaml', 'dashboard.yaml', 'cadence-followup.yaml']
+
+interface YamlBehavior {
+  id: string
+  title: string
+  type: string
+  status: string
+  statement?: string
+  serves?: string | string[]
+}
+
+function loadBehaviors(): YamlBehavior[] {
+  return TOURED_DOMAINS.flatMap(f => {
+    const doc = parse(fs.readFileSync(path.join(SPEC_DIR, f), 'utf8')) as {
+      behaviors: YamlBehavior[]
+    }
+    return doc.behaviors
+  })
+}
+
+describe('intent-catalog ↔ spec YAML sync', () => {
+  const behaviors = loadBehaviors()
+  const yamlIntents = behaviors.filter(b => b.type === 'intent')
+
+  it('transcribes exactly the intent set of the toured domains', () => {
+    expect(Object.keys(INTENT_CATALOG).sort()).toEqual(yamlIntents.map(b => b.id).sort())
+  })
+
+  it('transcribes title/statement/status verbatim', () => {
+    for (const b of yamlIntents) {
+      const spec = INTENT_CATALOG[b.id]
+      expect(spec, `catalog missing ${b.id}`).toBeDefined()
+      expect(spec.title, `${b.id} title`).toBe(b.title)
+      expect(spec.statement, `${b.id} statement`).toBe(b.statement)
+      expect(spec.status, `${b.id} status`).toBe(b.status)
+    }
+  })
+
+  it('servedBy is the inversion of the YAML serves edges', () => {
+    const inverted: Record<string, string[]> = {}
+    for (const b of behaviors) {
+      const serves = b.serves === undefined ? [] : Array.isArray(b.serves) ? b.serves : [b.serves]
+      for (const target of serves) {
+        ;(inverted[target] ??= []).push(b.id)
+      }
+    }
+    for (const id of Object.keys(INTENT_CATALOG)) {
+      expect(INTENT_CATALOG[id].servedBy.slice().sort(), `${id} servedBy`).toEqual(
+        (inverted[id] ?? []).sort()
+      )
+    }
+    // No serves edge points at a non-catalog target within the toured domains.
+    for (const target of Object.keys(inverted)) {
+      expect(INTENT_CATALOG[target], `serves target ${target} missing from catalog`).toBeDefined()
+    }
+  })
+
+  it('every servedBy entry names a behavior that exists in the YAML', () => {
+    const ids = new Set(behaviors.map(b => b.id))
+    for (const spec of Object.values(INTENT_CATALOG)) {
+      for (const b of spec.servedBy) expect(ids.has(b), `${spec.id} servedBy ${b}`).toBe(true)
+    }
+  })
+})

--- a/frontend/tests/tours/judge/intent-catalog.test.ts
+++ b/frontend/tests/tours/judge/intent-catalog.test.ts
@@ -10,7 +10,6 @@ import { describe, expect, it } from 'vitest'
 import { INTENT_CATALOG } from './intent-catalog'
 
 const SPEC_DIR = path.join(import.meta.dirname ?? __dirname, '..', '..', '..', '..', 'spec')
-const TOURED_DOMAINS = ['contacts.yaml', 'dashboard.yaml', 'cadence-followup.yaml']
 
 interface YamlBehavior {
   id: string
@@ -21,20 +20,27 @@ interface YamlBehavior {
   serves?: string | string[]
 }
 
+// Genuinely corpus-wide: every spec/*.yaml, matching the linter's resolution
+// scope — a cross-domain serves edge or an intent minted in a non-toured
+// domain lands in the inversion (and fails the sync assertions) instead of
+// silently under-binding evidence.
 function loadBehaviors(): YamlBehavior[] {
-  return TOURED_DOMAINS.flatMap(f => {
-    const doc = parse(fs.readFileSync(path.join(SPEC_DIR, f), 'utf8')) as {
-      behaviors: YamlBehavior[]
-    }
-    return doc.behaviors
-  })
+  return fs
+    .readdirSync(SPEC_DIR)
+    .filter(f => f.endsWith('.yaml'))
+    .flatMap(f => {
+      const doc = parse(fs.readFileSync(path.join(SPEC_DIR, f), 'utf8')) as {
+        behaviors: YamlBehavior[]
+      }
+      return doc.behaviors
+    })
 }
 
 describe('intent-catalog ↔ spec YAML sync', () => {
   const behaviors = loadBehaviors()
   const yamlIntents = behaviors.filter(b => b.type === 'intent')
 
-  it('transcribes exactly the intent set of the toured domains', () => {
+  it('transcribes exactly the intent set of the whole corpus', () => {
     expect(Object.keys(INTENT_CATALOG).sort()).toEqual(yamlIntents.map(b => b.id).sort())
   })
 

--- a/frontend/tests/tours/judge/intent-catalog.ts
+++ b/frontend/tests/tours/judge/intent-catalog.ts
@@ -1,0 +1,97 @@
+// The intent-behavior catalog: the `type: intent` rows of the behavior SSOT
+// (spec/{dashboard,contacts,cadence-followup}.yaml), transcribed verbatim like
+// SPEC_CATALOG, plus `servedBy` — the corpus-wide INVERSION of the YAML's
+// `serves:` edges. The judge binds an intent's evidence to captures tagged with
+// the intent's own ID or any behavior in servedBy (see intent-input.ts).
+//
+// Kept in sync with the YAML by a unit test that parses the spec files and
+// asserts ids/titles/statements/status AND the inverted edges match
+// (intent-catalog.test.ts) — catalog drift fails offline tests, not a live run.
+
+export type IntentStatus = 'current' | 'proposed'
+
+export interface IntentSpec {
+  id: string
+  title: string
+  statement: string
+  status: IntentStatus
+  /** Behavior IDs whose `serves:` lists name this intent (inverted edges). */
+  servedBy: string[]
+}
+
+export const INTENT_CATALOG: Record<string, IntentSpec> = {
+  'DSH-010': {
+    id: 'DSH-010',
+    title: 'The dashboard tells the user who to reach out to, at a glance',
+    statement:
+      "a user opening the dashboard can decide who to contact next and how to reach them without opening any contact's page — the overdue surface is scannable rather than a wall of undifferentiated entries, and more urgent relationships stand out from less urgent ones",
+    status: 'current',
+    servedBy: ['CAD-026', 'CAD-027', 'CAD-028'],
+  },
+  'DSH-011': {
+    id: 'DSH-011',
+    title: 'The dashboard never dead-ends',
+    statement:
+      'whatever state the dashboard is in — populated, all caught up, still loading, or failed — the user always has a clear next action available and is never stranded on a blank or ambiguous screen',
+    status: 'current',
+    servedBy: ['CAD-026', 'DSH-003', 'DSH-004'],
+  },
+  'DSH-012': {
+    id: 'DSH-012',
+    title: 'The dashboard reflects reality without manual refreshes',
+    statement:
+      'any action in the app that changes who is overdue is reflected on an open dashboard without the user reloading the page — the overdue list can be trusted as live',
+    status: 'proposed',
+    servedBy: ['CAD-028', 'DSH-005', 'DSH-009'],
+  },
+  'CON-050': {
+    id: 'CON-050',
+    title: 'Destructive contact actions are deliberate',
+    statement:
+      'contact data is never lost through a single accidental interaction — destructive flows demand an explicit, informed confirmation, and what will happen is visible before it happens',
+    status: 'current',
+    servedBy: ['CON-042', 'CON-043'],
+  },
+  'CON-051': {
+    id: 'CON-051',
+    title: "Browsing contacts never loses the user's place",
+    statement:
+      'moving between the contact list and contact detail feels like traversing one consistent, ordered list — sort, search, and filter context carries across navigation in both directions, with keyboard and mouse as equals',
+    status: 'current',
+    servedBy: ['CON-038', 'CON-040', 'CON-041'],
+  },
+  'CON-052': {
+    id: 'CON-052',
+    title: 'The birthdays page is a planning surface, not a data dump',
+    statement:
+      'the birthdays page answers whose birthday needs attention now and soon — imminent birthdays stand apart from distant ones, celebrated ones recede, and the user never has to compute dates themselves',
+    status: 'current',
+    servedBy: ['CON-045'],
+  },
+  'CAD-036': {
+    id: 'CAD-036',
+    title: 'A contact page answers where the relationship stands',
+    statement:
+      "a contact's detail page answers where things stand with this person — when we last talked in each direction, whether a reply is pending, and what work is queued — without the user digging through raw history",
+    status: 'current',
+    servedBy: ['CAD-029', 'CAD-030', 'CAD-031'],
+  },
+  'CAD-037': {
+    id: 'CAD-037',
+    title: 'CRM task actions are safe for remote task state',
+    statement:
+      "managing a linked task from the CRM never silently mutates or destroys the user's task in the remote app — remote state changes only where the user expects them to happen",
+    status: 'current',
+    servedBy: ['CAD-033'],
+  },
+}
+
+export function intentSpec(id: string): IntentSpec | undefined {
+  return INTENT_CATALOG[id]
+}
+
+export function allIntents(): IntentSpec[] {
+  return Object.keys(INTENT_CATALOG)
+    .sort()
+    .map(id => INTENT_CATALOG[id])
+}

--- a/frontend/tests/tours/judge/intent-input.test.ts
+++ b/frontend/tests/tours/judge/intent-input.test.ts
@@ -1,0 +1,87 @@
+// Binding: an intent's evidence = captures tagged with the intent ID or any
+// servedBy behavior, deduped by (tour, seq), ordered, capped with an explicit
+// dropped count. Zero-bind stays empty (the runner abstains without a call).
+
+import { describe, expect, it } from 'vitest'
+import type { Capture } from '../support/types'
+import type { IntentSpec } from './intent-catalog'
+import { bindIntentCaptures, buildIntentJudgeInput } from './intent-input'
+
+function cap(tour: string, seq: number, behaviors: string[]): Capture {
+  return {
+    captureFormatVersion: 1,
+    captureGeneratorVersion: 1,
+    tour,
+    seq,
+    behaviors,
+    note: `note-${tour}-${seq}`,
+    url: `http://x/${tour}/${seq}`,
+    pair: null,
+    serverTime: {
+      currentTime: 't',
+      isAccelerated: true,
+      accelerationFactor: 1,
+      baseTime: 't',
+    },
+    aria: { role: 'root', children: [] },
+    apiResponses: {},
+    dialogs: [],
+  }
+}
+
+const intent: IntentSpec = {
+  id: 'DSH-010',
+  title: 't',
+  statement: 's',
+  status: 'current',
+  servedBy: ['CAD-026', 'CAD-027'],
+}
+
+describe('bindIntentCaptures', () => {
+  it('binds servedBy-tagged and directly-tagged captures, skips others', () => {
+    const all = [
+      cap('dashboard', 1, ['CAD-026']),
+      cap('dashboard', 2, ['DSH-002']), // unrelated
+      cap('dashboard', 3, ['DSH-010']), // direct intent tag
+      cap('contacts', 1, ['CAD-027', 'CON-038']),
+    ]
+    const { captures, dropped } = bindIntentCaptures(intent, all)
+    expect(captures.map(c => `${c.tour}#${c.seq}`)).toEqual([
+      'contacts#1',
+      'dashboard#1',
+      'dashboard#3',
+    ])
+    expect(dropped).toBe(0)
+  })
+
+  it('dedupes a capture tagging several bound behaviors', () => {
+    const all = [cap('dashboard', 1, ['CAD-026', 'CAD-027', 'DSH-010'])]
+    expect(bindIntentCaptures(intent, all).captures).toHaveLength(1)
+  })
+
+  it('caps and reports the dropped count', () => {
+    const all = Array.from({ length: 5 }, (_, i) => cap('dashboard', i, ['CAD-026']))
+    const { captures, dropped } = bindIntentCaptures(intent, all, 3)
+    expect(captures.map(c => c.seq)).toEqual([0, 1, 2])
+    expect(dropped).toBe(2)
+  })
+
+  it('binds nothing when no capture tags the intent or a serving behavior', () => {
+    const { captures, dropped } = bindIntentCaptures(intent, [cap('dashboard', 1, ['DSH-002'])])
+    expect(captures).toHaveLength(0)
+    expect(dropped).toBe(0)
+  })
+})
+
+describe('buildIntentJudgeInput', () => {
+  it('builds the single-item intent variant with per-capture sections', () => {
+    const bound = [cap('dashboard', 1, ['CAD-026']), cap('dashboard', 2, ['CAD-027'])]
+    const input = buildIntentJudgeInput(intent, bound)
+    expect(input.behaviorId).toBe('DSH-010')
+    expect(input.intent).toEqual({ statement: 's', status: 'current' })
+    expect(input.items).toEqual([{ itemIndex: 0, thenText: 's' }])
+    expect(input.captureSections).toHaveLength(2)
+    expect(input.captureSections?.[0].note).toBe('dashboard#1 — note-dashboard-1')
+    expect(input.captureSections?.[0].evidence.url).toBe('http://x/dashboard/1')
+  })
+})

--- a/frontend/tests/tours/judge/intent-input.ts
+++ b/frontend/tests/tours/judge/intent-input.ts
@@ -1,0 +1,68 @@
+// Bind an intent's evidence and build its judge input. An intent's evidence is
+// the union of captures tagged with the intent's own ID or with any behavior in
+// its servedBy set (the inverted `serves:` edges from the SSOT), deduped,
+// ordered by (tour, seq), and capped — the dropped count is surfaced, never
+// silently truncated. Pure — no model, no fs.
+
+import type { Capture } from '../support/types'
+import type { CaptureSection, JudgeInput } from './adapter/types'
+import type { IntentSpec } from './intent-catalog'
+
+// Default per-intent capture cap: multi-capture prompts carry full aria trees,
+// so an unbounded union can blow the prompt budget. 8 keeps the common tours
+// intact; the report logs what was dropped.
+export const INTENT_CAPTURE_CAP = 8
+
+export interface BoundIntentCaptures {
+  captures: Capture[]
+  dropped: number
+}
+
+export function bindIntentCaptures(
+  intent: IntentSpec,
+  all: Capture[],
+  cap: number = INTENT_CAPTURE_CAP
+): BoundIntentCaptures {
+  const wanted = new Set([intent.id, ...intent.servedBy])
+  const seen = new Set<string>()
+  const bound: Capture[] = []
+  for (const c of all) {
+    if (!c.behaviors.some(b => wanted.has(b))) continue
+    const key = `${c.tour}#${c.seq}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    bound.push(c)
+  }
+  bound.sort((a, b) => (a.tour === b.tour ? a.seq - b.seq : a.tour < b.tour ? -1 : 1))
+  const kept = bound.slice(0, cap)
+  return { captures: kept, dropped: bound.length - kept.length }
+}
+
+// One CAPTURE[n] section per bound capture — evidence stays sectioned (the
+// behavior path's merged-aria bundle would blur which state showed what).
+export function captureSection(c: Capture): CaptureSection {
+  return {
+    note: `${c.tour}#${c.seq} — ${c.note}`,
+    evidence: {
+      url: c.url,
+      aria: c.aria,
+      api: c.apiResponses,
+      serverTime: c.serverTime,
+      dialogs: c.dialogs,
+    },
+  }
+}
+
+export function buildIntentJudgeInput(intent: IntentSpec, bound: Capture[]): JudgeInput {
+  return {
+    behaviorId: intent.id,
+    behaviorTitle: intent.title,
+    given: '',
+    when: '',
+    then: [intent.statement],
+    items: [{ itemIndex: 0, thenText: intent.statement }],
+    evidence: {},
+    intent: { statement: intent.statement, status: intent.status },
+    captureSections: bound.map(captureSection),
+  }
+}

--- a/frontend/tests/tours/judge/intent-runner.test.ts
+++ b/frontend/tests/tours/judge/intent-runner.test.ts
@@ -1,0 +1,88 @@
+// The intent pass with a fake judge: zero-evidence abstains WITHOUT a model
+// call, verdicts flow through the grounding rule (uncited fail → unsure), and
+// missing verdicts degrade to unsure.
+
+import { describe, expect, it } from 'vitest'
+import type { Judge, JudgeInput } from './adapter'
+import type { Capture } from '../support/types'
+import type { IntentSpec } from './intent-catalog'
+import { runIntentPass } from './intent-runner'
+
+function cap(behaviors: string[]): Capture {
+  return {
+    captureFormatVersion: 1,
+    captureGeneratorVersion: 1,
+    tour: 'dashboard',
+    seq: 1,
+    behaviors,
+    note: 'n',
+    url: 'http://x',
+    pair: null,
+    serverTime: { currentTime: 't', isAccelerated: true, accelerationFactor: 1, baseTime: 't' },
+    aria: { role: 'root', children: [] },
+    apiResponses: {},
+    dialogs: [],
+  }
+}
+
+const intent: IntentSpec = {
+  id: 'DSH-010',
+  title: 'at a glance',
+  statement: 's',
+  status: 'current',
+  servedBy: ['CAD-026'],
+}
+
+function fakeJudge(verdict: 'pass' | 'fail' | 'unsure', citation: string): Judge {
+  return async (_input: JudgeInput) => [{ itemIndex: 0, verdict, citation, critique: 'c' }]
+}
+
+describe('runIntentPass', () => {
+  it('abstains without a judge call when no evidence binds', async () => {
+    let called = 0
+    const judge: Judge = async input => {
+      called++
+      return input.items.map(i => ({
+        itemIndex: i.itemIndex,
+        verdict: 'pass' as const,
+        citation: '',
+        critique: '',
+      }))
+    }
+    const [g] = await runIntentPass([cap(['DSH-002'])], judge, [intent])
+    expect(called).toBe(0)
+    expect(g.verdict).toBe('unsure')
+    expect(g.boundCount).toBe(0)
+    expect(g.reason).toMatch(/no evidence bound/)
+  })
+
+  it('passes a grounded verdict through', async () => {
+    const [g] = await runIntentPass([cap(['CAD-026'])], fakeJudge('pass', ''), [intent])
+    expect(g.verdict).toBe('pass')
+    expect(g.boundCount).toBe(1)
+    expect(g.status).toBe('current')
+  })
+
+  it('downgrades an uncited fail to unsure (grounding rule)', async () => {
+    const [g] = await runIntentPass([cap(['CAD-026'])], fakeJudge('fail', ''), [intent])
+    expect(g.verdict).toBe('unsure')
+    expect(g.reason).toMatch(/no grounding citation/)
+  })
+
+  it('keeps a cited fail', async () => {
+    const [g] = await runIntentPass(
+      [cap(['CAD-026'])],
+      fakeJudge('fail', 'CAPTURE[0]: heading "x"'),
+      [intent]
+    )
+    expect(g.verdict).toBe('fail')
+    expect(g.citation).toBe('CAPTURE[0]: heading "x"')
+  })
+
+  it('degrades a missing verdict to unsure', async () => {
+    const judge: Judge = async () => []
+    const [g] = await runIntentPass([cap(['CAD-026'])], judge, [intent])
+    expect(g.verdict).toBe('unsure')
+    expect(g.reason).toMatch(/no verdict returned/)
+  })
+})

--- a/frontend/tests/tours/judge/intent-runner.test.ts
+++ b/frontend/tests/tours/judge/intent-runner.test.ts
@@ -94,6 +94,13 @@ describe('runIntentPass', () => {
     expect(g.verdict).toBe('unsure')
   })
 
+  it('downgrades a fail whose residue is punctuation-only', async () => {
+    const [g] = await runIntentPass([cap(['CAD-026'])], fakeJudge('fail', 'CAPTURE[0] ()."'), [
+      intent,
+    ])
+    expect(g.verdict).toBe('unsure')
+  })
+
   it('downgrades a fail whose capture index is out of range', async () => {
     const [g] = await runIntentPass(
       [cap(['CAD-026'])],

--- a/frontend/tests/tours/judge/intent-runner.test.ts
+++ b/frontend/tests/tours/judge/intent-runner.test.ts
@@ -86,7 +86,21 @@ describe('runIntentPass', () => {
       [intent]
     )
     expect(g.verdict).toBe('unsure')
-    expect(g.reason).toMatch(/citation lacks the required CAPTURE\[n\] index/)
+    expect(g.reason).toMatch(/citation needs an in-range CAPTURE\[n\] index/)
+  })
+
+  it('downgrades a fail cited with a bare capture marker (no node/path)', async () => {
+    const [g] = await runIntentPass([cap(['CAD-026'])], fakeJudge('fail', 'CAPTURE[0]:'), [intent])
+    expect(g.verdict).toBe('unsure')
+  })
+
+  it('downgrades a fail whose capture index is out of range', async () => {
+    const [g] = await runIntentPass(
+      [cap(['CAD-026'])],
+      fakeJudge('fail', 'CAPTURE[99]: heading "x"'),
+      [intent]
+    )
+    expect(g.verdict).toBe('unsure')
   })
 
   it('degrades a missing verdict to unsure', async () => {

--- a/frontend/tests/tours/judge/intent-runner.test.ts
+++ b/frontend/tests/tours/judge/intent-runner.test.ts
@@ -69,7 +69,7 @@ describe('runIntentPass', () => {
     expect(g.reason).toMatch(/no grounding citation/)
   })
 
-  it('keeps a cited fail', async () => {
+  it('keeps a fail cited with a CAPTURE[n] index', async () => {
     const [g] = await runIntentPass(
       [cap(['CAD-026'])],
       fakeJudge('fail', 'CAPTURE[0]: heading "x"'),
@@ -77,6 +77,16 @@ describe('runIntentPass', () => {
     )
     expect(g.verdict).toBe('fail')
     expect(g.citation).toBe('CAPTURE[0]: heading "x"')
+  })
+
+  it('downgrades a fail whose citation lacks the CAPTURE[n] index', async () => {
+    const [g] = await runIntentPass(
+      [cap(['CAD-026'])],
+      fakeJudge('fail', 'heading "Error loading overdue contacts"'),
+      [intent]
+    )
+    expect(g.verdict).toBe('unsure')
+    expect(g.reason).toMatch(/citation lacks the required CAPTURE\[n\] index/)
   })
 
   it('degrades a missing verdict to unsure', async () => {

--- a/frontend/tests/tours/judge/intent-runner.ts
+++ b/frontend/tests/tours/judge/intent-runner.ts
@@ -75,11 +75,20 @@ export async function runIntentPass(
       grades.push({ ...base, verdict: 'unsure', reason: 'no verdict returned' })
       continue
     }
-    const grounded = applyGrounding({
+    let grounded = applyGrounding({
       verdict: v.verdict,
       citation: v.citation,
       reason: v.critique,
     })
+    // Intent grounding is stricter than the generic rule: the prompt requires
+    // a fail to name the capture index it bound to, so a citation without a
+    // CAPTURE[n] reference cannot anchor a regression/progress signal.
+    if (grounded.verdict === 'fail' && !/CAPTURE\[\d+\]/.test(grounded.citation ?? '')) {
+      grounded = {
+        verdict: 'unsure',
+        reason: `${grounded.reason ?? 'fail'} — downgraded to unsure: citation lacks the required CAPTURE[n] index`,
+      }
+    }
     grades.push({ ...base, ...grounded })
   }
   return grades

--- a/frontend/tests/tours/judge/intent-runner.ts
+++ b/frontend/tests/tours/judge/intent-runner.ts
@@ -31,6 +31,19 @@ export interface IntentGrade {
 export const DEFAULT_INTENT_MODEL = 'gpt-5.5'
 export const DEFAULT_INTENT_EFFORT = 'medium'
 
+// A fail citation is grounded iff it names at least one IN-RANGE CAPTURE[n]
+// index AND carries a non-empty node label / JSON path beyond the marker(s).
+// Pure; exported for tests.
+export function isGroundedIntentCitation(citation: string, boundCount: number): boolean {
+  const indices = [...citation.matchAll(/CAPTURE\[(\d+)\]/g)].map(m => Number(m[1]))
+  if (indices.length === 0 || !indices.some(i => i < boundCount)) return false
+  const residue = citation
+    .replace(/CAPTURE\[\d+\]/g, ' ')
+    .replace(/[:;,\s—–-]+/g, ' ')
+    .trim()
+  return residue !== ''
+}
+
 export function makeIntentJudge(kind: string = process.env.QA_JUDGE ?? 'codex-exec'): Judge {
   if (kind === 'codex-exec') {
     const model = process.env.QA_INTENT_MODEL ?? DEFAULT_INTENT_MODEL
@@ -85,12 +98,16 @@ export async function runIntentPass(
       reason: v.critique,
     })
     // Intent grounding is stricter than the generic rule: the prompt requires
-    // a fail to name the capture index it bound to, so a citation without a
-    // CAPTURE[n] reference cannot anchor a regression/progress signal.
-    if (grounded.verdict === 'fail' && !/CAPTURE\[\d+\]/.test(grounded.citation ?? '')) {
+    // a fail to name the capture index it bound to PLUS the node/path within
+    // it — a bare marker, an out-of-range index, or a missing marker cannot
+    // anchor a regression/progress signal.
+    if (
+      grounded.verdict === 'fail' &&
+      !isGroundedIntentCitation(grounded.citation ?? '', bound.length)
+    ) {
       grounded = {
         verdict: 'unsure',
-        reason: `${grounded.reason ?? 'fail'} — downgraded to unsure: citation lacks the required CAPTURE[n] index`,
+        reason: `${grounded.reason ?? 'fail'} — downgraded to unsure: citation needs an in-range CAPTURE[n] index plus the node/path it binds to`,
       }
     }
     grades.push({ ...base, ...grounded })

--- a/frontend/tests/tours/judge/intent-runner.ts
+++ b/frontend/tests/tours/judge/intent-runner.ts
@@ -1,0 +1,86 @@
+// The intent pass: one judge call per intent over the union of its bound
+// captures (see intent-input.ts). Sibling of the item-judge residue path —
+// never part of the offline merge gate; verdicts are advisory and label-gated
+// like the rest of the judge layer.
+
+import { selectJudge } from './adapter'
+import { makeCodexExecJudge } from './adapter/codex-exec'
+import type { Judge } from './adapter'
+import { applyGrounding } from './grader/grade'
+import type { Verdict } from './grader/types'
+import { allIntents, type IntentSpec, type IntentStatus } from './intent-catalog'
+import { bindIntentCaptures, buildIntentJudgeInput, INTENT_CAPTURE_CAP } from './intent-input'
+import type { Capture } from '../support/types'
+
+export interface IntentGrade {
+  intentId: string
+  title: string
+  status: IntentStatus
+  verdict: Verdict
+  citation?: string
+  reason?: string
+  boundCount: number
+  droppedCount: number
+  servedBy: string[]
+}
+
+// Intent judgment is the semantically hard task and the call count is small
+// (~one per intent per run), so it defaults to a stronger model + effort than
+// the cheap item-residue judge. Overridable via QA_INTENT_MODEL /
+// QA_INTENT_EFFORT; QA_JUDGE still selects the adapter kind.
+export const DEFAULT_INTENT_MODEL = 'gpt-5.5'
+export const DEFAULT_INTENT_EFFORT = 'medium'
+
+export function makeIntentJudge(kind: string = process.env.QA_JUDGE ?? 'codex-exec'): Judge {
+  const model = process.env.QA_INTENT_MODEL ?? DEFAULT_INTENT_MODEL
+  if (kind === 'codex-exec') {
+    const effort = process.env.QA_INTENT_EFFORT ?? DEFAULT_INTENT_EFFORT
+    return makeCodexExecJudge({ model, effort })
+  }
+  return selectJudge(kind, model)
+}
+
+// Run the pass SERIALLY (matching the residue path: concurrent codex spawns
+// storm a quota-limited account). A zero-evidence intent abstains WITHOUT a
+// model call — a freshly minted design-session intent is visibly unjudgeable,
+// not silently absent.
+export async function runIntentPass(
+  captures: Capture[],
+  judge: Judge,
+  intents: IntentSpec[] = allIntents(),
+  cap: number = INTENT_CAPTURE_CAP
+): Promise<IntentGrade[]> {
+  const grades: IntentGrade[] = []
+  for (const intent of intents) {
+    const { captures: bound, dropped } = bindIntentCaptures(intent, captures, cap)
+    const base = {
+      intentId: intent.id,
+      title: intent.title,
+      status: intent.status,
+      boundCount: bound.length,
+      droppedCount: dropped,
+      servedBy: intent.servedBy,
+    }
+    if (bound.length === 0) {
+      grades.push({
+        ...base,
+        verdict: 'unsure',
+        reason: 'no evidence bound — no capture tags this intent or a serving behavior',
+      })
+      continue
+    }
+    const verdicts = await judge(buildIntentJudgeInput(intent, bound))
+    const v = verdicts.find(x => x.itemIndex === 0)
+    if (!v) {
+      grades.push({ ...base, verdict: 'unsure', reason: 'no verdict returned' })
+      continue
+    }
+    const grounded = applyGrounding({
+      verdict: v.verdict,
+      citation: v.citation,
+      reason: v.critique,
+    })
+    grades.push({ ...base, ...grounded })
+  }
+  return grades
+}

--- a/frontend/tests/tours/judge/intent-runner.ts
+++ b/frontend/tests/tours/judge/intent-runner.ts
@@ -32,16 +32,18 @@ export const DEFAULT_INTENT_MODEL = 'gpt-5.5'
 export const DEFAULT_INTENT_EFFORT = 'medium'
 
 // A fail citation is grounded iff it names at least one IN-RANGE CAPTURE[n]
-// index AND carries a non-empty node label / JSON path beyond the marker(s).
+// index AND carries a node label / JSON path beyond the marker(s) — the
+// residue must contain a word character (allow-list), so punctuation-only
+// tails like "CAPTURE[0]." never ground. Deliberately a flat heuristic: the
+// in-range and residue checks are independent over the whole string (no
+// marker↔residue association — the model's citation syntax isn't guaranteed),
+// and its worst failure mode is a conservative fail→unsure downgrade.
 // Pure; exported for tests.
 export function isGroundedIntentCitation(citation: string, boundCount: number): boolean {
   const indices = [...citation.matchAll(/CAPTURE\[(\d+)\]/g)].map(m => Number(m[1]))
   if (indices.length === 0 || !indices.some(i => i < boundCount)) return false
-  const residue = citation
-    .replace(/CAPTURE\[\d+\]/g, ' ')
-    .replace(/[:;,\s—–-]+/g, ' ')
-    .trim()
-  return residue !== ''
+  const residue = citation.replace(/CAPTURE\[\d+\]/g, ' ')
+  return /[\p{L}\p{N}]/u.test(residue)
 }
 
 export function makeIntentJudge(kind: string = process.env.QA_JUDGE ?? 'codex-exec'): Judge {

--- a/frontend/tests/tours/judge/intent-runner.ts
+++ b/frontend/tests/tours/judge/intent-runner.ts
@@ -32,12 +32,16 @@ export const DEFAULT_INTENT_MODEL = 'gpt-5.5'
 export const DEFAULT_INTENT_EFFORT = 'medium'
 
 export function makeIntentJudge(kind: string = process.env.QA_JUDGE ?? 'codex-exec'): Judge {
-  const model = process.env.QA_INTENT_MODEL ?? DEFAULT_INTENT_MODEL
   if (kind === 'codex-exec') {
+    const model = process.env.QA_INTENT_MODEL ?? DEFAULT_INTENT_MODEL
     const effort = process.env.QA_INTENT_EFFORT ?? DEFAULT_INTENT_EFFORT
     return makeCodexExecJudge({ model, effort })
   }
-  return selectJudge(kind, model)
+  // Non-codex adapters own their model config (e.g. QA_JUDGE_HTTP_MODEL) and
+  // an explicit opts.model would override it — so the codex-oriented
+  // DEFAULT_INTENT_MODEL must not leak onto other endpoints. Only an explicit
+  // QA_INTENT_MODEL overrides.
+  return selectJudge(kind, process.env.QA_INTENT_MODEL)
 }
 
 // Run the pass SERIALLY (matching the residue path: concurrent codex spawns

--- a/frontend/tests/tours/judge/report/render-intents.test.ts
+++ b/frontend/tests/tours/judge/report/render-intents.test.ts
@@ -1,0 +1,49 @@
+// The Intents report section: present only when intent grades are passed,
+// current-fail framed as regression, proposed-pass framed as progress, and
+// over-cap drops surfaced (no silent truncation).
+
+import { describe, expect, it } from 'vitest'
+import type { IntentGrade } from '../intent-runner'
+import { renderReport } from './render'
+
+function grade(over: Partial<IntentGrade>): IntentGrade {
+  return {
+    intentId: 'DSH-010',
+    title: 'at a glance',
+    status: 'current',
+    verdict: 'pass',
+    boundCount: 3,
+    droppedCount: 0,
+    servedBy: ['CAD-026'],
+    ...over,
+  }
+}
+
+describe('renderReport intents section', () => {
+  it('is absent without intent grades', () => {
+    expect(renderReport({ grades: [] })).not.toContain('## Intents')
+  })
+
+  it('frames a current fail as a regression signal', () => {
+    const md = renderReport({
+      grades: [],
+      intents: [grade({ verdict: 'fail', citation: 'CAPTURE[1]: heading "x"' })],
+    })
+    expect(md).toContain('## Intents — judged experience goals (advisory)')
+    expect(md).toContain('REGRESSION SIGNAL')
+    expect(md).toContain('cite: CAPTURE[1]: heading "x"')
+  })
+
+  it('frames a proposed pass as a progress signal', () => {
+    const md = renderReport({
+      grades: [],
+      intents: [grade({ intentId: 'DSH-012', status: 'proposed', verdict: 'pass' })],
+    })
+    expect(md).toContain('progress signal')
+  })
+
+  it('surfaces over-cap drops', () => {
+    const md = renderReport({ grades: [], intents: [grade({ droppedCount: 2 })] })
+    expect(md).toContain('2 over the cap DROPPED')
+  })
+})

--- a/frontend/tests/tours/judge/report/render.ts
+++ b/frontend/tests/tours/judge/report/render.ts
@@ -10,6 +10,7 @@ import { SPEC_CATALOG } from '../spec-catalog'
 import { SKIP_LIST } from './skip-list'
 import type { BehaviorGrade } from '../grader/grade'
 import type { Verdict } from '../grader/types'
+import type { IntentGrade } from '../intent-runner'
 
 export interface ReportMeta {
   runId?: string
@@ -20,6 +21,8 @@ export interface ReportMeta {
 export interface ReportInput {
   meta?: ReportMeta
   grades: BehaviorGrade[]
+  // Intent-pass grades (present only on --judge runs; the pass costs quota).
+  intents?: IntentGrade[]
 }
 
 const ICON: Record<Verdict, string> = { pass: '✅', fail: '❌', unsure: '⚠️' }
@@ -123,6 +126,40 @@ export function renderReport(input: ReportInput): string {
     lines.push('')
   }
 
+  // Intents — the judged experience goals (type: intent in the SSOT). A current
+  // intent failing is a REGRESSION signal; a proposed intent passing is a
+  // PROGRESS signal (candidate to flip current). Advisory, judge-only.
+  if (input.intents && input.intents.length > 0) {
+    lines.push('## Intents — judged experience goals (advisory)')
+    lines.push('')
+    lines.push(
+      '> One judge call per intent over the captures bound via its `serves:` edges. ' +
+        'A `current` intent failing is a regression signal; a `proposed` intent passing is a ' +
+        'progress signal (consider flipping it current in the SSOT).'
+    )
+    lines.push('')
+    for (const g of input.intents) {
+      const signal =
+        g.status === 'current'
+          ? g.verdict === 'fail'
+            ? ' — ⚠️ REGRESSION SIGNAL'
+            : ''
+          : g.verdict === 'pass'
+            ? ' — 📈 progress signal (proposed goal judged achieved)'
+            : ' (proposed)'
+      lines.push(`### ${g.intentId} — ${ICON[g.verdict]} ${g.verdict}${signal}`)
+      lines.push('')
+      lines.push(`- ${g.title}`)
+      lines.push(
+        `- evidence: ${g.boundCount} capture(s) via serves-edges [${g.servedBy.join(', ')}]` +
+          (g.droppedCount > 0 ? ` — ${g.droppedCount} over the cap DROPPED (not judged)` : '')
+      )
+      if (g.citation) lines.push(`- cite: ${g.citation}`)
+      if (g.reason) lines.push(`- critique: ${g.reason}`)
+      lines.push('')
+    }
+  }
+
   // Coverage — first-cut scope (D5): the 3 scoped domains' current-ux behaviors
   // (toured vs untoured) + the explicit skip-list. Advisory; files no issues; NOT
   // a repo-wide scanner (the other SSOT domains are Piece 3's scope).
@@ -200,6 +237,14 @@ async function main(): Promise<void> {
     const judge = runner ? await runner(set.behaviorId, set.captures) : undefined
     grades.push(gradeBehavior(set, judge ? { judge } : {}))
   }
+
+  // The intent pass (judge-only; serial like the residue path). Uses its own
+  // stronger-model default (QA_INTENT_MODEL / QA_INTENT_EFFORT).
+  let intents
+  if (useJudge) {
+    const { makeIntentJudge, runIntentPass } = await import('../intent-runner')
+    intents = await runIntentPass(captures, makeIntentJudge())
+  }
   let runId: string | undefined
   let gitSha: string | undefined
   const manifestPath = path.join(runDir, 'manifest.json')
@@ -211,7 +256,7 @@ async function main(): Promise<void> {
     runId = m.runId
     gitSha = m.gitSha
   }
-  const md = renderReport({ meta: { runId, gitSha }, grades })
+  const md = renderReport({ meta: { runId, gitSha }, grades, intents })
   if (outFile) fs.writeFileSync(outFile, md, 'utf8')
   else process.stdout.write(md)
 }

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -9,6 +9,10 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: './vitest.setup.ts',
     exclude: ['tests/e2e/**', 'node_modules/**'],
+    // The default 5s ceiling flakes userEvent-heavy suites when the pre-push
+    // hook runs vitest concurrently with the Go integration + E2E lanes on one
+    // box (#607) — a ceiling raise never slows a passing test.
+    testTimeout: 15_000,
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## What

PR 2 of the SSOT intent-layer arc (design: `.ai/spec/2026-07-10-ssot-intent-layer-and-judged-ux-goals-design.md`, parent #380; schema landed in #622). Adds the harness intent pass — the judge layer that grades `type: intent` experience goals over captured evidence. Aria-only in this PR; screenshots are the next PR.

**The pass (sibling of the item-judge residue, never the merge gate):**
- `intent-catalog.ts` — transcription of the 8 SSOT intents + `servedBy` (the corpus-wide inversion of `serves:`), kept YAML-synced by a guard test that parses the three spec files (new `yaml` devDep, zero transitive deps)
- `intent-input.ts` — evidence binding: union of captures tagged with the intent ID or any serving behavior, deduped by (tour, seq), capped at 8 with the dropped count surfaced (no silent truncation); zero-bind → visible `unsure`, no model call
- `adapter/prompt.ts` — intent prompt variant: INTENT block + per-capture `CAPTURE[n]` sections; grounding rule extended to require the capture index; explicit caution that aria carries no visual styling (abstain rather than fail on visual qualities)
- `intent-runner.ts` — serial per-intent calls through the existing codex-exec adapter (tool-rejection, tracing, retries reused); stronger-model default for the pass (`QA_INTENT_MODEL`/`QA_INTENT_EFFORT`, default gpt-5.5/medium) while the cheap item-judge default stays
- report: an **Intents** section — a `current` intent failing renders as a regression signal, a `proposed` intent passing as a progress signal (candidate to flip current)
- eval `--judge`: intent-hypothesis cases (`corpus/intent-cases/*.json`, 1 clean + 1 doctored) with self-labeled hypotheses, printed for eyeballing — explicitly not ground truth, never gating
- `DEFERRED.md`/`README.md` — intent labels join the label-gated path; fail-precision north star now spans item + intent fails

## Testing

- 5 new offline test files: YAML-sync guard, binding/dedupe/cap, runner grounding + zero-evidence abstention, intent prompt rendering, report section framing, intent-case schema rules — 647/647 frontend suite green
- `make qa-eval` PASS — the offline verifiers-only merge gate is byte-identical in behavior (intents never enter it)
- `tsc --noEmit` clean, `make lint` clean, full pre-push gate green (two earlier gate runs flaked on out-of-diff userEvent 5s timeouts under concurrent lane load — the tracked #607/#612 class; each failing test passes standalone)

## Notes

- The live intent smoke (`--judge` with codex quota) is deliberately not run here; the model default (`gpt-5.5`) is flagged in DEFERRED.md for revalidation at first live run.

**Riders added during review rounds:** stricter intent-fail grounding (`isGroundedIntentCitation`: in-range CAPTURE[n] + word-character node/path residue), `--limit` applied to intent cases, intent model default scoped to the codex-exec adapter, and a one-line `testTimeout: 15s` in vitest.config fixing the #607 gate flake (which hit this PR's pushes six times).