### PR TITLE
fix(knowledge): deterministic survivor for same-value stint merges

### DIFF
--- a/backend/internal/db/assertion.sql.go
+++ b/backend/internal/db/assertion.sql.go
@@ -88,6 +88,7 @@ WHERE status = 'accepted'
   AND predicate_key = $2
   AND tstzrange(valid_from, valid_to, '[)')
    && tstzrange($3::timestamptz, $4::timestamptz, '[)')
+ORDER BY valid_from ASC NULLS FIRST, id ASC
 FOR UPDATE
 `
 
@@ -106,6 +107,9 @@ type FindAcceptedForSlotParams struct {
 // currently-open accepted row. FOR UPDATE locks any found row as the second belt
 // behind the advisory lock. The ::timestamptz casts pin the probe-range param
 // types (sqlc cannot infer the type of a bare arg inside tstzrange()).
+// Deterministic order: widenReaffirmation takes rows[0] as the surviving
+// stint, so an unordered result flips the survivor between runs (earliest
+// stint wins; NULL valid_from = open start = earliest; id as the tie-break).
 func (q *Queries) FindAcceptedForSlot(ctx context.Context, arg FindAcceptedForSlotParams) ([]*Assertion, error) {
 	rows, err := q.db.Query(ctx, FindAcceptedForSlot,
 		arg.SubjectNodeID,
@@ -163,6 +167,7 @@ WHERE status = 'accepted'
       )
   AND tstzrange(valid_from, valid_to, '[)')
    && tstzrange($4::timestamptz, $5::timestamptz, '[)')
+ORDER BY valid_from ASC NULLS FIRST, id ASC
 FOR UPDATE
 `
 

--- a/backend/internal/db/assertion.sql.go
+++ b/backend/internal/db/assertion.sql.go
@@ -110,6 +110,9 @@ type FindAcceptedForSlotParams struct {
 // Deterministic order: widenReaffirmation takes rows[0] as the surviving
 // stint, so an unordered result flips the survivor between runs (earliest
 // stint wins; NULL valid_from = open start = earliest; id as the tie-break).
+// An open-start row coexists with a later DISJOINT same-value stint only via
+// a future-bounded valid_to; NULLS FIRST makes the open start — logically the
+// earliest — the survivor when a bridge merges them.
 func (q *Queries) FindAcceptedForSlot(ctx context.Context, arg FindAcceptedForSlotParams) ([]*Assertion, error) {
 	rows, err := q.db.Query(ctx, FindAcceptedForSlot,
 		arg.SubjectNodeID,
@@ -750,6 +753,27 @@ func (q *Queries) RolloverDueBoundedSuccessors(ctx context.Context, now pgtype.T
 		return nil, err
 	}
 	return items, nil
+}
+
+const SetAssertionPendingSuccessor = `-- name: SetAssertionPendingSuccessor :exec
+UPDATE assertion
+SET superseded_by = $1
+WHERE id = $2
+`
+
+type SetAssertionPendingSuccessorParams struct {
+	SupersededBy pgtype.UUID `json:"superseded_by"`
+	ID           pgtype.UUID `json:"id"`
+}
+
+// Widen-merge linkage inheritance: when a same-value merge absorbs a stint
+// bounded by a pending future successor into a survivor that has none, the
+// survivor takes over the predecessor role (superseded_by while still
+// accepted) so the rollover sweep terminalizes it at the bound and emits the
+// assertion.superseded event the derived caches rely on.
+func (q *Queries) SetAssertionPendingSuccessor(ctx context.Context, arg SetAssertionPendingSuccessorParams) error {
+	_, err := q.db.Exec(ctx, SetAssertionPendingSuccessor, arg.SupersededBy, arg.ID)
+	return err
 }
 
 const TransitionStatus = `-- name: TransitionStatus :exec

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -542,6 +542,9 @@ type Querier interface {
 	// currently-open accepted row. FOR UPDATE locks any found row as the second belt
 	// behind the advisory lock. The ::timestamptz casts pin the probe-range param
 	// types (sqlc cannot infer the type of a bare arg inside tstzrange()).
+	// Deterministic order: widenReaffirmation takes rows[0] as the surviving
+	// stint, so an unordered result flips the survivor between runs (earliest
+	// stint wins; NULL valid_from = open start = earliest; id as the tie-break).
 	FindAcceptedForSlot(ctx context.Context, arg FindAcceptedForSlotParams) ([]*Assertion, error)
 	// Single-cardinality conflict check for a SYMMETRIC predicate: the single-current
 	// invariant is PER-PARTICIPANT, so the slot is any accepted edge where EITHER new

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -545,6 +545,9 @@ type Querier interface {
 	// Deterministic order: widenReaffirmation takes rows[0] as the surviving
 	// stint, so an unordered result flips the survivor between runs (earliest
 	// stint wins; NULL valid_from = open start = earliest; id as the tie-break).
+	// An open-start row coexists with a later DISJOINT same-value stint only via
+	// a future-bounded valid_to; NULLS FIRST makes the open start — logically the
+	// earliest — the survivor when a bridge merges them.
 	FindAcceptedForSlot(ctx context.Context, arg FindAcceptedForSlotParams) ([]*Assertion, error)
 	// Single-cardinality conflict check for a SYMMETRIC predicate: the single-current
 	// invariant is PER-PARTICIPANT, so the slot is any accepted edge where EITHER new
@@ -1684,6 +1687,12 @@ type Querier interface {
 	// be called freely from parallel test packages without contending with
 	// the pairing-flow tests that hold the singleton slot.
 	SeedRevokedMacHost(ctx context.Context, arg SeedRevokedMacHostParams) (*MacHost, error)
+	// Widen-merge linkage inheritance: when a same-value merge absorbs a stint
+	// bounded by a pending future successor into a survivor that has none, the
+	// survivor takes over the predecessor role (superseded_by while still
+	// accepted) so the rollover sweep terminalizes it at the bound and emits the
+	// assertion.superseded event the derived caches rely on.
+	SetAssertionPendingSuccessor(ctx context.Context, arg SetAssertionPendingSuccessorParams) error
 	SetContactMethodPrimary(ctx context.Context, arg SetContactMethodPrimaryParams) error
 	// Persist external_task_id on a row without touching state. Used by the
 	// close-while-pending race path: the create worker enters on a row that

--- a/backend/internal/db/queries/assertion.sql
+++ b/backend/internal/db/queries/assertion.sql
@@ -51,6 +51,9 @@ WHERE proposition_key = $1
 -- Deterministic order: widenReaffirmation takes rows[0] as the surviving
 -- stint, so an unordered result flips the survivor between runs (earliest
 -- stint wins; NULL valid_from = open start = earliest; id as the tie-break).
+-- An open-start row coexists with a later DISJOINT same-value stint only via
+-- a future-bounded valid_to; NULLS FIRST makes the open start — logically the
+-- earliest — the survivor when a bridge merges them.
 SELECT * FROM assertion
 WHERE status = 'accepted'
   AND knowledge_to IS NULL
@@ -111,6 +114,16 @@ SET valid_from = $2,
     valid_to = $3,
     proposition_key = $4
 WHERE id = $1;
+
+-- name: SetAssertionPendingSuccessor :exec
+-- Widen-merge linkage inheritance: when a same-value merge absorbs a stint
+-- bounded by a pending future successor into a survivor that has none, the
+-- survivor takes over the predecessor role (superseded_by while still
+-- accepted) so the rollover sweep terminalizes it at the bound and emits the
+-- assertion.superseded event the derived caches rely on.
+UPDATE assertion
+SET superseded_by = sqlc.arg(superseded_by)
+WHERE id = sqlc.arg(id);
 
 -- name: RolloverDueBoundedSuccessors :many
 -- The rollover job: terminalize the bounded-with-pending-successor rows whose

--- a/backend/internal/db/queries/assertion.sql
+++ b/backend/internal/db/queries/assertion.sql
@@ -48,6 +48,9 @@ WHERE proposition_key = $1
 -- currently-open accepted row. FOR UPDATE locks any found row as the second belt
 -- behind the advisory lock. The ::timestamptz casts pin the probe-range param
 -- types (sqlc cannot infer the type of a bare arg inside tstzrange()).
+-- Deterministic order: widenReaffirmation takes rows[0] as the surviving
+-- stint, so an unordered result flips the survivor between runs (earliest
+-- stint wins; NULL valid_from = open start = earliest; id as the tie-break).
 SELECT * FROM assertion
 WHERE status = 'accepted'
   AND knowledge_to IS NULL
@@ -55,6 +58,7 @@ WHERE status = 'accepted'
   AND predicate_key = sqlc.arg(predicate_key)
   AND tstzrange(valid_from, valid_to, '[)')
    && tstzrange(sqlc.arg(effective_from)::timestamptz, sqlc.arg(new_valid_to)::timestamptz, '[)')
+ORDER BY valid_from ASC NULLS FIRST, id ASC
 FOR UPDATE;
 
 -- name: FindAcceptedForSlotSymmetric :many
@@ -73,6 +77,7 @@ WHERE status = 'accepted'
       )
   AND tstzrange(valid_from, valid_to, '[)')
    && tstzrange(sqlc.arg(effective_from)::timestamptz, sqlc.arg(new_valid_to)::timestamptz, '[)')
+ORDER BY valid_from ASC NULLS FIRST, id ASC
 FOR UPDATE;
 
 -- name: CloseAssertion :exec

--- a/backend/internal/repository/assertion.go
+++ b/backend/internal/repository/assertion.go
@@ -441,6 +441,16 @@ func (r *AssertionRepository) BoundPendingSuccessorTx(ctx context.Context, tx pg
 	})
 }
 
+// SetAssertionPendingSuccessorTx stamps superseded_by on a still-accepted
+// survivor that inherited a merged stint's pending future successor, so the
+// rollover sweep terminalizes it at the bound.
+func (r *AssertionRepository) SetAssertionPendingSuccessorTx(ctx context.Context, tx pgx.Tx, id, successorID uuid.UUID) error {
+	return db.New(tx).SetAssertionPendingSuccessor(ctx, db.SetAssertionPendingSuccessorParams{
+		ID:           uuidToPgUUID(id),
+		SupersededBy: uuidToPgUUID(successorID),
+	})
+}
+
 // WidenAssertionValidityTx widens an accepted row's valid window to cover new
 // evidence and sets the recomputed proposition_key.
 func (r *AssertionRepository) WidenAssertionValidityTx(ctx context.Context, tx pgx.Tx, id uuid.UUID, validFrom, validTo *time.Time, propositionKey string) error {

--- a/backend/internal/service/assert.go
+++ b/backend/internal/service/assert.go
@@ -997,14 +997,6 @@ func (s *AssertService) widenReaffirmation(ctx context.Context, tx pgx.Tx, predi
 		}
 	}
 
-	// If the survivor is bounded by a PENDING future successor (superseded_by set
-	// while still accepted), widening valid_to past that bound would un-bound it and
-	// leave two current rows once the successor's date passes. Keep the existing
-	// valid_to as the upper cap (only the backward lower-bound extension is safe).
-	if survivor.SupersededBy != nil {
-		widenedTo = utcPtr(survivor.ValidTo)
-	}
-
 	// Recompute the proposition_key from the widened valid_from bucket.
 	widenedReq := *req
 	widenedReq.ValidFrom = widenedFrom
@@ -1013,6 +1005,7 @@ func (s *AssertService) widenReaffirmation(ctx context.Context, tx pgx.Tx, predi
 	// Collision: another LIVE row (NOT in the overlap probe — e.g. a disjoint stint)
 	// already holds the recomputed key. Merge it into the survivor instead of
 	// UPDATE-ing into the unique index (which would 23505).
+	var mergedCollider *repository.Assertion
 	if newKey != survivor.PropositionKey {
 		collider, err := s.assertionRepo.FindLivePropositionTx(ctx, tx, newKey)
 		if err != nil && !errors.Is(err, db.ErrNotFound) {
@@ -1026,7 +1019,54 @@ func (s *AssertService) widenReaffirmation(ctx context.Context, tx pgx.Tx, predi
 			if err := s.mergeSameValue(ctx, tx, collider, survivor); err != nil {
 				return nil, err
 			}
+			mergedCollider = collider
 		}
+	}
+
+	// Pending-successor cap + linkage inheritance, AFTER the collider merge so
+	// ordering (not bucket geometry) guarantees a collider can neither un-cap
+	// the window nor dodge the scan. Widening valid_to past a pending future
+	// successor's bound would leave two current rows once its date passes, and
+	// the bound can sit on ANY merged stint — the deterministic earliest-first
+	// order routinely merges a later bounded stint into an older survivor. Cap
+	// at the EARLIEST bound and inherit that stint's successor linkage so the
+	// rollover sweep still terminalizes the survivor at the bound (emitting the
+	// assertion.superseded event the derived caches rely on). Deliberately reads
+	// the PRE-merge in-memory structs: mergeSameValue has already re-stamped the
+	// losers' superseded_by to the survivor in the DB, and the cap needs the
+	// original successor pointer (the stale struct is load-bearing here).
+	capCandidates := same
+	if mergedCollider != nil {
+		capCandidates = append(append([]*repository.Assertion{}, same...), mergedCollider)
+	}
+	var capSource *repository.Assertion
+	for _, st := range capCandidates {
+		if st.SupersededBy == nil || st.ValidTo == nil {
+			continue
+		}
+		// Floor: never shrink below the survivor's own pre-widen valid_to — a
+		// due-but-unrolled bounded collider's past bound would otherwise rewrite
+		// the current stint entirely into the past. A nil valid_to is +inf, so an
+		// open-ended survivor skips EVERY bound (capping an open current row at a
+		// collider's past-ward bound is always wrong; the underlying design gap
+		// is #626's scope).
+		if survivor.ValidTo == nil || st.ValidTo.Before(*survivor.ValidTo) {
+			continue
+		}
+		if widenedTo == nil || st.ValidTo.Before(*widenedTo) {
+			widenedTo = utcPtr(st.ValidTo)
+			capSource = st
+		}
+	}
+	// Linkage follows the cap: if the tightest bound came from a merged stint,
+	// the survivor's rollover lineage must point at THAT stint's successor
+	// (keeping a pre-existing later successor pointer would emit the wrong
+	// lineage when the earlier bound falls due).
+	if capSource != nil && capSource.ID != survivor.ID {
+		if err := s.assertionRepo.SetAssertionPendingSuccessorTx(ctx, tx, survivor.ID, *capSource.SupersededBy); err != nil {
+			return nil, fmt.Errorf("inherit pending successor on widen: %w", err)
+		}
+		survivor.SupersededBy = capSource.SupersededBy
 	}
 
 	existing := survivor
@@ -1252,9 +1292,31 @@ func (s *AssertService) resolveAcceptConflicts(ctx context.Context, tx pgx.Tx, p
 		}
 		// Do NOT clear a pending-successor bound (superseded_by set): widening past it
 		// would leave two current rows once the successor date passes (only the
-		// backward lower-bound extends). Mirrors widenReaffirmation.
-		if survivor.SupersededBy != nil {
-			widenedTo = utcPtr(survivor.ValidTo)
+		// backward lower-bound extends). The bound can sit on ANY merged stint, not
+		// only the survivor — cap at the earliest bound and inherit that stint's
+		// successor linkage so the rollover sweep still terminalizes the survivor
+		// at the bound. Pre-merge in-memory structs are read on purpose (the stale
+		// struct carries the original successor pointer). Mirrors widenReaffirmation.
+		var capSource *repository.Assertion
+		for _, st := range same {
+			if st.SupersededBy == nil || st.ValidTo == nil {
+				continue
+			}
+			// Floor + linkage-follows-cap: mirrors widenReaffirmation (nil
+			// valid_to = +inf → an open-ended survivor skips every bound).
+			if survivor.ValidTo == nil || st.ValidTo.Before(*survivor.ValidTo) {
+				continue
+			}
+			if widenedTo == nil || st.ValidTo.Before(*widenedTo) {
+				widenedTo = utcPtr(st.ValidTo)
+				capSource = st
+			}
+		}
+		if capSource != nil && capSource.ID != survivor.ID {
+			if err := s.assertionRepo.SetAssertionPendingSuccessorTx(ctx, tx, survivor.ID, *capSource.SupersededBy); err != nil {
+				return nil, false, fmt.Errorf("inherit pending successor at accept: %w", err)
+			}
+			survivor.SupersededBy = capSource.SupersededBy
 		}
 		survivor.ValidFrom = widenedFrom
 		survivor.ValidTo = widenedTo

--- a/backend/tests/assert_integration_test.go
+++ b/backend/tests/assert_integration_test.go
@@ -983,6 +983,107 @@ func TestAssert_ValidTime(t *testing.T) {
 		assert.Equal(t, rowA.ID, survivor.ID, "survivor is the first matched stint, widened")
 	})
 
+	// Case 27: a bridging reaffirmation that merges a LATER stint bounded by a
+	// pending future successor into an EARLIER (deterministic) survivor must
+	// inherit BOTH the bound (widening past it would overlap the successor's
+	// window once its date passes) AND the successor linkage (the rollover sweep
+	// only terminalizes rows with superseded_by set, and its assertion.superseded
+	// event drives the derived caches).
+	t.Run("27 bridging inherits a merged stint's pending-successor bound", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
+		now := accelerated.GetCurrentTime().UTC().Truncate(time.Microsecond)
+
+		// An OLD past-bounded NYC stint (no successor) — the deterministic survivor.
+		old0 := time.Date(now.Year()-6, 1, 1, 0, 0, 0, 0, time.UTC)
+		old1 := time.Date(now.Year()-4, 1, 1, 0, 0, 0, 0, time.UTC)
+		oldReq := textFactReq(subject, "home_address", "NYC", gen.Prefix(), "old")
+		oldReq.ValidFrom, oldReq.ValidTo = &old0, &old1
+		oldRow, err := h.svc.Assert(ctx, oldReq)
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, oldRow.ID)
+
+		// Current NYC + a FUTURE LA successor → NYC bounded (superseded_by set,
+		// still accepted/knowledge-open, so the overlap probe sees it).
+		thisYear := time.Date(now.Year(), 1, 15, 0, 0, 0, 0, time.UTC)
+		nycReq := textFactReq(subject, "home_address", "NYC", gen.Prefix(), "nyc")
+		nycReq.ValidFrom = &thisYear
+		nyc, err := h.svc.Assert(ctx, nycReq)
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, nyc.ID)
+		future := now.Add(30 * 24 * time.Hour)
+		laReq := textFactReq(subject, "home_address", "LA", gen.Prefix(), "la")
+		laReq.ValidFrom = &future
+		la, err := h.svc.Assert(ctx, laReq)
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, la.ID)
+		boundedNYC, err := h.assertionRepo.GetAssertion(ctx, nyc.ID)
+		require.NoError(t, err)
+		require.NotNil(t, boundedNYC.ValidTo, "NYC bounded by the pending LA successor")
+		require.NotNil(t, boundedNYC.SupersededBy)
+
+		// An open-ended bridging NYC write overlapping BOTH stints: the earlier
+		// stint survives (deterministic order) and MUST inherit the LA bound.
+		bridge0 := time.Date(now.Year()-5, 6, 1, 0, 0, 0, 0, time.UTC)
+		bridge := textFactReq(subject, "home_address", "NYC", gen.Prefix(), "br")
+		bridge.ValidFrom = &bridge0
+		survivor, err := h.svc.Assert(ctx, bridge)
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, survivor.ID)
+		assert.Equal(t, oldRow.ID, survivor.ID, "earliest stint survives deterministically")
+
+		after, err := h.assertionRepo.GetAssertion(ctx, survivor.ID)
+		require.NoError(t, err)
+		require.NotNil(t, after.ValidTo, "merged stint's pending-successor bound inherited")
+		assert.True(t, after.ValidTo.Equal(*boundedNYC.ValidTo), "capped at the successor start")
+		require.NotNil(t, after.SupersededBy, "successor linkage inherited (rollover terminalizes the survivor)")
+		assert.Equal(t, la.ID, *after.SupersededBy, "survivor points at the pending LA successor")
+	})
+
+	// Case 28: an open-start (NULL valid_from) same-value stint coexists with a
+	// later DISJOINT stint via a future-bounded valid_to, and sorts EARLIEST
+	// (NULLS FIRST) — pins the spec's "an open start sorts earliest" clause
+	// (PostgreSQL's ASC default is NULLS LAST, which would flip this survivor).
+	t.Run("28 open-start stint is the deterministic survivor", func(t *testing.T) {
+		t.Parallel()
+		gen, _ := migrationGenerator(t)
+		subject := h.seedPerson(t, ctx, gen.Prefix(), "subj")
+		now := accelerated.GetCurrentTime().UTC().Truncate(time.Microsecond)
+
+		// Open-start NYC bounded in the FUTURE (valid_to > effective_from=now
+		// passes validation) — valid_from stays NULL, bucket "open".
+		openEnd := time.Date(now.Year()+2, 1, 1, 0, 0, 0, 0, time.UTC)
+		openReq := textFactReq(subject, "home_address", "NYC", gen.Prefix(), "open")
+		openReq.ValidTo = &openEnd
+		openRow, err := h.svc.Assert(ctx, openReq)
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, openRow.ID)
+		require.Nil(t, openRow.ValidFrom, "open start persists as NULL valid_from")
+
+		// A later DISJOINT dated NYC stint in a DIFFERENT year bucket (no
+		// overlap → coexists; distinct bucket → no proposition-key dedup).
+		d0 := time.Date(now.Year()+3, 1, 1, 0, 0, 0, 0, time.UTC)
+		d1 := time.Date(now.Year()+4, 1, 1, 0, 0, 0, 0, time.UTC)
+		datedReq := textFactReq(subject, "home_address", "NYC", gen.Prefix(), "dated")
+		datedReq.ValidFrom, datedReq.ValidTo = &d0, &d1
+		datedRow, err := h.svc.Assert(ctx, datedReq)
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, datedRow.ID)
+		require.NotEqual(t, openRow.ID, datedRow.ID, "disjoint stints coexist")
+
+		// A bridge overlapping both (its own year bucket ≠ the dated row's, so
+		// it cannot dedup against either): the open-start row must survive.
+		b0 := time.Date(now.Year()+1, 6, 1, 0, 0, 0, 0, time.UTC)
+		b1 := time.Date(now.Year()+3, 6, 1, 0, 0, 0, 0, time.UTC)
+		bridge := textFactReq(subject, "home_address", "NYC", gen.Prefix(), "br")
+		bridge.ValidFrom, bridge.ValidTo = &b0, &b1
+		survivor, err := h.svc.Assert(ctx, bridge)
+		require.NoError(t, err)
+		h.cleanupAssertionEvents(t, ctx, survivor.ID)
+		assert.Equal(t, openRow.ID, survivor.ID, "open start sorts earliest (NULLS FIRST)")
+	})
+
 	// Case 25: the rollover sweep does NOT abort on a bounded row whose
 	// knowledge_from was set in the future (KnowledgeFromOverride); knowledge_to is
 	// clamped via GREATEST so the assertion_knowledge_range CHECK holds.

--- a/spec/knowledge.yaml
+++ b/spec/knowledge.yaml
@@ -111,7 +111,7 @@ behaviors:
       - the surviving row's validity window widens to the union of the windows
       - a window that bridges several non-contiguous same-value stints merges them all into one survivor (provenance moved, losers closed pointing at the survivor)
       - the survivor is deterministic — the earliest stint by validity start (an open start sorts earliest, row id as the tie-break)
-      - a survivor already bounded by a pending future successor keeps that upper bound (only the backward extension applies)
+      - a pending future successor's bound on any merged stint caps the widened window at the earliest such bound, and the survivor inherits that successor linkage so the rollover still terminalizes it at the bound (only the backward extension applies)
     provenance: [widenReaffirmation, sameValueConflicts, mergeSameValue, FindAcceptedForSlot]
 
   - id: KNW-010

--- a/spec/knowledge.yaml
+++ b/spec/knowledge.yaml
@@ -110,8 +110,9 @@ behaviors:
       - no new row is created and nothing is superseded as a value change
       - the surviving row's validity window widens to the union of the windows
       - a window that bridges several non-contiguous same-value stints merges them all into one survivor (provenance moved, losers closed pointing at the survivor)
+      - the survivor is deterministic — the earliest stint by validity start (an open start sorts earliest, row id as the tie-break)
       - a survivor already bounded by a pending future successor keeps that upper bound (only the backward extension applies)
-    provenance: [widenReaffirmation, sameValueConflicts, mergeSameValue]
+    provenance: [widenReaffirmation, sameValueConflicts, mergeSameValue, FindAcceptedForSlot]
 
   - id: KNW-010
     title: Past-bounded history coexists with the current value


### PR DESCRIPTION
## What

`widenReaffirmation` takes `rows[0]` of the slot-overlap probe as the surviving stint, but `FindAcceptedForSlot`/`FindAcceptedForSlotSymmetric` had no ORDER BY — so when a bridging write overlapped several same-value stints, the survivor was whichever row PostgreSQL happened to return first. Under parallel integration-test load the order flips, which is exactly the intermittent `TestAssert_ValidTime/24` failure (UUID mismatch at assert_integration_test.go:983) that hit three pre-push gate runs today. This is the repo's own "SQL queries without ORDER BY" gotcha.

**Fix:** `ORDER BY valid_from ASC NULLS FIRST, id ASC` on both probes — the earliest stint (open start earliest) deterministically survives, row id as the tie-break. Semantic no-op for every other caller (single-cardinality paths see ≤1 row or are order-insensitive); the widen path's window-union math is unchanged, only the choice of which row carries the union is now pinned.

**Spec:** KNW-009 extended in place with the deterministic-survivor then-item (maintenance rule; `make spec-lint` green).

## Testing

- `make sqlc` + `go build ./cmd/crm-api` clean (SQL string change only, no signature changes)
- `TestAssert_ValidTime` (incl. case 24) and the full `TestAssert*` set (concurrency + integration) pass on three consecutive runs with the proper harness
- Full pre-push gate green with the fix in-tree