### PR TITLE
fix(qa): make the seeded awaiting-reply state coherent, and stop trusting a wire field that lies

### DIFF
--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -1874,6 +1874,13 @@ type Querier interface {
 	// absent from the seeded world, the tours cannot capture it, and the agentic judge reads
 	// that absence as a missing feature. contact_task has no deleted_at; the contact
 	// soft-delete filter scopes to live catalog contacts. Caller passes a BARE prefix.
+	//
+	// last_outreach_at IS NOT NULL is part of the CONTRACT, not a filter of convenience: a
+	// follow-up is opened BY an outbound (CAD-011), so one hanging on a contact with no
+	// outbound renders as "Awaiting reply" with nothing to await a reply to — a state
+	// production cannot reach. The first version of this seed produced exactly that, and the
+	// agentic judge (correctly) failed the contact page for it. Counting only COHERENT
+	// follow-ups is what makes this assertion mean what it says.
 	SyntheticCountLiveFollowUpsByNamePrefix(ctx context.Context, namePrefix pgtype.Text) (int64, error)
 	// Merge/soft-delete coverage test support: count the live (deleted_at IS NULL) nodes
 	// among the given ids, scoped to THIS run's tracked node ids. Used to assert a merge

--- a/backend/internal/db/queries/test.sql
+++ b/backend/internal/db/queries/test.sql
@@ -330,12 +330,20 @@ WHERE c.full_name LIKE @name_prefix || '%'
 -- absent from the seeded world, the tours cannot capture it, and the agentic judge reads
 -- that absence as a missing feature. contact_task has no deleted_at; the contact
 -- soft-delete filter scopes to live catalog contacts. Caller passes a BARE prefix.
+--
+-- last_outreach_at IS NOT NULL is part of the CONTRACT, not a filter of convenience: a
+-- follow-up is opened BY an outbound (CAD-011), so one hanging on a contact with no
+-- outbound renders as "Awaiting reply" with nothing to await a reply to — a state
+-- production cannot reach. The first version of this seed produced exactly that, and the
+-- agentic judge (correctly) failed the contact page for it. Counting only COHERENT
+-- follow-ups is what makes this assertion mean what it says.
 SELECT COUNT(*)
 FROM contact_task ct
 JOIN contact c ON ct.contact_id = c.id
 WHERE c.full_name LIKE @name_prefix || '%'
   AND ct.lifecycle = 'followup_loop'
   AND ct.state IN ('managed', 'pending_remote_create')
+  AND c.last_outreach_at IS NOT NULL
   AND c.deleted_at IS NULL;
 
 -- name: SyntheticDeleteContactMethodsByContactIds :execrows

--- a/backend/internal/db/test.sql.go
+++ b/backend/internal/db/test.sql.go
@@ -1089,6 +1089,7 @@ JOIN contact c ON ct.contact_id = c.id
 WHERE c.full_name LIKE $1 || '%'
   AND ct.lifecycle = 'followup_loop'
   AND ct.state IN ('managed', 'pending_remote_create')
+  AND c.last_outreach_at IS NOT NULL
   AND c.deleted_at IS NULL
 `
 
@@ -1100,6 +1101,13 @@ WHERE c.full_name LIKE $1 || '%'
 // absent from the seeded world, the tours cannot capture it, and the agentic judge reads
 // that absence as a missing feature. contact_task has no deleted_at; the contact
 // soft-delete filter scopes to live catalog contacts. Caller passes a BARE prefix.
+//
+// last_outreach_at IS NOT NULL is part of the CONTRACT, not a filter of convenience: a
+// follow-up is opened BY an outbound (CAD-011), so one hanging on a contact with no
+// outbound renders as "Awaiting reply" with nothing to await a reply to — a state
+// production cannot reach. The first version of this seed produced exactly that, and the
+// agentic judge (correctly) failed the contact page for it. Counting only COHERENT
+// follow-ups is what makes this assertion mean what it says.
 func (q *Queries) SyntheticCountLiveFollowUpsByNamePrefix(ctx context.Context, namePrefix pgtype.Text) (int64, error) {
 	row := q.db.QueryRow(ctx, SyntheticCountLiveFollowUpsByNamePrefix, namePrefix)
 	var count int64

--- a/backend/internal/synthetic/profiles.go
+++ b/backend/internal/synthetic/profiles.go
@@ -726,18 +726,6 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		// shown only contact pages with no "Awaiting reply" marker, concluded the FEATURE
 		// DID NOT EXIST and reported a false CAD-036 regression — every run.
 		//
-		// Seeded on the LAST cadence-bearing contact so it cannot collide with the
-		// state-transition slots above (which take the first len(nonManagedTaskStates)).
-		// Draws no generator PRNG, so it does not shift the deterministic id sequence the
-		// earlier source replays depend on.
-		if followUpIdx := len(cadenceBearingCatalogIDs) - 1; followUpIdx >= len(nonManagedTaskStates) {
-			if _, err := h.SeedPendingFollowUp(ctx, cadenceBearingCatalogIDs[followUpIdx]); err != nil {
-				return res, fmt.Errorf("profile %s: seed pending follow-up: %w", params.Profile, err)
-			}
-			// A NEW row, unlike the state transitions above (which only flip existing ones).
-			res.SeededTasks++
-			res.SeededPendingFollowUps = 1
-		}
 	}
 
 	// Merge + soft-delete scenarios. Seeded LAST: each draws gen.Contact (name PRNG)
@@ -829,6 +817,44 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		res.TelegramDiscovery++
 	}
 
+	// --- The "awaiting reply" scenario (has_pending_followup) -----------------------
+	//
+	// Seeded LAST, after every other generator-driven block: it draws gen.Contact +
+	// gen.GCalEvent, and appending keeps the deterministic id/handle sequence the earlier
+	// source replays depend on unshifted.
+	//
+	// COHERENT BY CONSTRUCTION, and that is the whole point. A follow-up loop is opened BY
+	// an outbound (CAD-011) — it is the app waiting on a reply to something you actually
+	// sent. The first version of this seed hung a follow-up on an arbitrary cadence-bearing
+	// contact with no outbound, which renders as "⚠ Awaiting reply" with nothing to be
+	// awaiting a reply TO — a state production cannot reach. The agentic judge caught it and
+	// (correctly) failed the contact page for it.
+	//
+	// So the scenario builds the whole causal chain: a contact WITH a cadence (CAD-011
+	// requires one), a GCal event — whose interaction is recorded as MUTUAL, and mutual
+	// bumps last_outreach_at (CAD-006) — and then the live follow-up. We do not write the
+	// cadence timestamps ourselves: they are sole-writer property of the cadence engine
+	// (CAD-005, CI-guarded), applied asynchronously by its River worker. That is also why
+	// the seed cannot ASSERT on last_outreach_at here (the job has not run yet); the
+	// coverage check asserts it post-Quiesce, which is the honest place to prove the chain
+	// actually landed.
+	if params.Counts.SeededTasks > 0 {
+		fuSpec := gen.Contact(factory.WithEmail(), factory.WithCadence(followUpScenarioCadence))
+		fuContact, err := h.SeedContact(ctx, fuSpec)
+		if err != nil {
+			return res, fmt.Errorf("profile %s: seed awaiting-reply contact: %w", params.Profile, err)
+		}
+		res.Contacts++
+		if _, err := h.ReplayGCal(ctx, fuContact.ID, gen.GCalEvent(fuSpec, factory.MatchSeeded, factory.WithMessageAge(interactionSpreadAge(0)))); err != nil {
+			return res, fmt.Errorf("profile %s: replay gcal for awaiting-reply contact: %w", params.Profile, err)
+		}
+		res.SettledInteractions++
+		if _, err := h.SeedPendingFollowUp(ctx, fuContact.ID); err != nil {
+			return res, fmt.Errorf("profile %s: seed pending follow-up: %w", params.Profile, err)
+		}
+		res.SeededTasks++
+		res.SeededPendingFollowUps = 1
+	}
 	return res, nil
 }
 
@@ -859,6 +885,11 @@ const (
 	mergeWinnerFactPredicate = "traveling"
 	mergeLoserFactPredicate  = "on_sabbatical"
 )
+
+// followUpScenarioCadence is the cadence on the "awaiting reply" scenario contact. A
+// follow-up loop only opens for a contact that HAS a cadence (CAD-011/CAD-012), so the
+// scenario cannot express the state without one.
+const followUpScenarioCadence = "monthly"
 
 // nonManagedTaskStates is the deterministic spread of non-`managed` contact_task
 // surface states the profile transitions cadence tasks into (one each), so staging

--- a/backend/internal/synthetic/replay/todoist.go
+++ b/backend/internal/synthetic/replay/todoist.go
@@ -218,6 +218,16 @@ func (h *Harness) TransitionTodoistCadenceTaskState(ctx context.Context, contact
 // tasks in. Draws NO generator PRNG (it only reads a seeded contact id), so it is
 // safe to run alongside the other non-generator replays without shifting the
 // deterministic id sequence earlier source replays depend on.
+//
+// CALLER'S CONTRACT: `contactID` must be a contact with a cadence AND an outbound —
+// a follow-up is opened BY an outbound (CAD-011), so one on a contact with neither
+// renders as "Awaiting reply" with nothing to be awaiting a reply TO, a state
+// production cannot reach. (The judge failed the contact page for exactly that when
+// this seed first hung a follow-up on an arbitrary contact.) This is NOT asserted
+// here: the cadence engine writes last_outreach_at asynchronously from its River
+// worker (and is its sole writer — CAD-005, CI-guarded), so it is still nil at seed
+// time. The caller establishes the chain by construction (see the awaiting-reply
+// scenario in profiles.go), and the profile coverage check proves it post-Quiesce.
 func (h *Harness) SeedPendingFollowUp(ctx context.Context, contactID uuid.UUID) (uuid.UUID, error) {
 	taskRepo := repository.NewContactTaskRepository(h.database.Queries)
 	deadline := accelerated.GetCurrentTime().Add(followUpSeedWindow)

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -134,11 +134,13 @@ func TestSyntheticProfile_DevCoversCatalog(t *testing.T) {
 	// index; the dev catalog is large enough to carry ≥1.
 	require.GreaterOrEqual(t, res.ContactsWithLocation, 1, "dev profile seeds location bio facts")
 	// MessagesPerContact spreads MULTIPLE settled interactions per dedicated source
-	// contact: SettledInteractions == (settled contacts) × MessagesPerContact, and
-	// strictly more than one interaction per contact.
+	// contact: SettledInteractions == (settled contacts) × MessagesPerContact — PLUS the
+	// single GCal event the awaiting-reply scenario replays (one per seeded follow-up).
+	// That event is the OUTBOUND half of the scenario's causal chain: mutual direction
+	// (CAD-006) gives the contact the last_outreach_at a follow-up requires (CAD-011).
 	settledContacts := res.GmailSettled + res.TelegramSettled + res.GCalSettled + res.GChatSettled + res.IMessageSettled
-	require.Equal(t, settledContacts*params.Counts.MessagesPerContact, res.SettledInteractions,
-		"dev profile spreads MessagesPerContact interactions per settled contact")
+	require.Equal(t, settledContacts*params.Counts.MessagesPerContact+res.SeededPendingFollowUps, res.SettledInteractions,
+		"dev profile spreads MessagesPerContact interactions per settled contact, plus the awaiting-reply scenario's GCal event")
 	require.Greater(t, res.SettledInteractions, settledContacts, "dev profile seeds >1 interaction per settled contact")
 	// Merge + soft-delete scenarios are standalone contacts seeded at full count
 	// (independent of catalog size), so the dev result equals the dev knobs.
@@ -417,15 +419,25 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 	require.Equal(t, 1, res.SeededPendingFollowUps, "profile seeds exactly one live follow-up")
 	liveFollowUps, err := support.CountLiveFollowUpsByNamePrefix(ctx, prefix)
 	require.NoError(t, err)
+	// The query requires last_outreach_at IS NOT NULL — a follow-up is opened BY an outbound
+	// (CAD-011), so one on a contact with no outbound is a state production cannot reach.
+	// The first version of this seed produced exactly that incoherent world, and the judge
+	// (correctly) failed the contact page for showing "Awaiting reply" with nothing to be
+	// awaiting a reply to. Asserting COHERENCE, not just presence, is the point.
 	require.GreaterOrEqual(t, liveFollowUps, int64(1),
-		"≥1 LIVE followup_loop task — the has_pending_followup state the contact page renders")
+		"≥1 COHERENT live followup_loop task (on a contact with an outbound) — the has_pending_followup state the contact page renders")
 
 	// Interaction volume: each dedicated source contact carries MessagesPerContact
 	// settled interactions, so SettledInteractions == (settled contacts) ×
-	// MessagesPerContact, strictly more than one per contact.
+	// MessagesPerContact — PLUS the single GCal event the awaiting-reply scenario
+	// replays (one per seeded follow-up), which is a real settled interaction and is
+	// counted as one. It is the OUTBOUND half of that scenario's causal chain: mutual
+	// direction (CAD-006) is what gives the contact the last_outreach_at a follow-up
+	// requires (CAD-011), so it is not bookkeeping — it is the reason the state is
+	// coherent at all.
 	settledContacts := res.GmailSettled + res.TelegramSettled + res.GCalSettled + res.GChatSettled + res.IMessageSettled
-	require.Equal(t, settledContacts*params.Counts.MessagesPerContact, res.SettledInteractions,
-		"MessagesPerContact interactions per settled contact")
+	require.Equal(t, settledContacts*params.Counts.MessagesPerContact+res.SeededPendingFollowUps, res.SettledInteractions,
+		"MessagesPerContact interactions per settled contact, plus the awaiting-reply scenario's GCal event")
 	require.Greater(t, res.SettledInteractions, settledContacts, ">1 interaction per settled contact")
 
 	// Interaction temporal spread (DB-level): ≥1 settled contact must carry ≥2

--- a/frontend/tests/tours/cadence-followup.tour.ts
+++ b/frontend/tests/tours/cadence-followup.tour.ts
@@ -36,10 +36,25 @@ test('cadence-followup tour — contact-detail cadence surfaces', async ({ page,
   }
   const outreachContact = pick(c => !!c.last_outreach_at, 'last_outreach_at (CAD-029[0])')
   const responseContact = pick(c => !!c.last_response_at, 'last_response_at (CAD-029[1])')
-  // Fails loudly rather than skipping: a world with no live follow-up is a SEED bug (the
-  // prod-shaped profile seeds one), and silently touring without this state is what
-  // produced the false CAD-036 regression in the first place.
-  const pendingContact = pick(c => !!c.has_pending_followup, 'has_pending_followup (CAD-029[2])')
+  // has_pending_followup is ONLY computed by the DETAIL handler. The list (and overdue)
+  // payloads carry the field as a non-pointer bool with no omitempty, so they ship
+  // `has_pending_followup: false` for every contact unconditionally — present, always
+  // false, and therefore meaningless. Selecting on it from the list silently matches
+  // nothing (and `noneContact`'s !has_pending_followup clause below is vacuously true for
+  // the same reason). Probe the detail endpoint, which actually answers.
+  const pendingContact = await (async () => {
+    for (const c of contacts) {
+      const r = await tour.apiCtx.get(`/api/v1/contacts/${c.id}`)
+      if (((await r.json())?.data ?? {}).has_pending_followup) return c
+    }
+    // Loud, never skipped: a world with no live follow-up is a SEED bug (the prod-shaped
+    // profile seeds one), and touring without this state is exactly what produced the
+    // false CAD-036 regression — the judge read the missing state as a missing feature.
+    throw new Error(
+      'cadence-followup tour: no seeded contact with has_pending_followup (CAD-029[2])'
+    )
+  })()
+  reserved.add(pendingContact.id)
   const noneContact = pick(
     c => !c.last_outreach_at && !c.last_response_at && !c.has_pending_followup,
     'no recent-activity signals (CAD-029[3])'


### PR DESCRIPTION
Two follow-ups from validating #637 against staging. **Both were found by the agentic judge**, which is the point of the exercise.

## The seeded follow-up was an impossible state — and the judge failed the page for it

#637 hung a live follow-up on an arbitrary cadence-bearing contact: one with **no outbound**. But a follow-up loop is opened **by** an outbound (CAD-011) — it is the app waiting on a reply to something you actually sent. So the contact page rendered **"⚠ Awaiting reply" with nothing to be awaiting a reply TO**, a state production can never reach.

The judge caught it, and its critique was exactly right:

> *"The page does surface that a reply is pending, but in that state it stops there: it does not tell the user when the outbound message was sent or when the last response occurred."*

**The verdict was correct. The world was wrong.** That is a good failure — the judge is not hallucinating, it is faithfully reporting incoherent evidence.

### The fix: build the causal chain, not its endpoint

The seed now constructs the whole chain, coherent by construction:

1. a contact **with a cadence** (CAD-011/CAD-012 require one),
2. a **GCal event**, whose interaction is recorded as **mutual** — and mutual bumps `last_outreach_at` (CAD-006),
3. then the live follow-up.

Seeded **last**, after every other generator-driven block, so its PRNG draws cannot shift the id sequence earlier replays depend on — `ProdShapedDeterministic` still passes.

We do **not** write `last_outreach_at` ourselves: it is sole-writer property of the cadence engine (CAD-005, CI-guarded), applied asynchronously by its River worker. That is also why the seed cannot *assert* on it at seed time — the job hasn't run yet. Instead the coverage check proves the chain landed **post-Quiesce**: its query now requires `last_outreach_at IS NOT NULL`, so it asserts a **coherent** follow-up, not merely a present one. The interaction-volume invariants (prod-shaped *and* dev) account for the scenario's GCal event — which is not bookkeeping, it *is* the outbound half of the chain.

## `has_pending_followup` is a lie on the list endpoint

It is a non-pointer bool with no `omitempty` (`contact_dto.go:27`), and **only the detail handler computes it** (`contact.go:260`). Every other payload goes through `contactToResponse`, which leaves it at the zero value — so `GET /api/v1/contacts` and `/contacts/overdue` ship `has_pending_followup: false` for **every contact, unconditionally**. Present, always false, meaningless.

The cadence tour had been selecting on it **from the list payload** — so its `noneContact` predicate's `!has_pending_followup` clause has been **vacuously true for every contact since it was written**. The tour now probes the detail endpoint, which actually answers.

The wire-contract bug itself is left alone deliberately — fixing it means computing the field in the list/overdue queries, which is a product change, not a test fix. Filed as **#638**.

## Verification

`golangci-lint` 0 issues · `go build` · `tsc` · 687 frontend tests · **all 7 synthetic profile tests** (incl. `DevCoversCatalog`, `ProdShapedCoverageCheck`, `ProdShapedDeterministic`) · full pre-push gate green.

Next: merge → staging redeploys → re-run tours + judge. That run gives the first **honest** CAD-036 verdict, against a world that finally contains a coherent "awaiting reply" state.