### PR TITLE
fix(synthetic): cause-driven overdue/recent seeding + post-seed coherence gate

### DIFF
--- a/.ai/spec/2026-07-13-synthetic-seed-fidelity-audit.md
+++ b/.ai/spec/2026-07-13-synthetic-seed-fidelity-audit.md
@@ -1,0 +1,96 @@
+# Synthetic Seed Fidelity Audit — invariants, classification, staging measurements
+
+**Date:** 2026-07-13. **Trigger:** three consecutive false regressions from the agentic UX QA judge, each traced to the seeded world holding state production cannot produce (missing follow-up state → "feature doesn't exist"; follow-up without an outbound → "awaiting reply to nothing"; `last_contacted` without an interaction → issue #640, closed invalid, refiled as #641). **Question:** are those three the whole story, or the tip of something broader? **Method:** five parallel read-only audits (one per invariant family: cadence timestamps, knowledge/assertions, contact_task, interactions/events, identity/structural), each deriving invariants from the production write paths, classifying every seed write as cause-driven vs endpoint-written, and emitting measurement SQL — then all queries run against the live staging world (167 live contacts, prod-shaped profile, image `58dbbccf`).
+
+**Answer:** the seed's replay architecture is fundamentally sound — every interaction/event row is authored by a real provider, identity matching runs the real matcher, contact/node/merge/soft-delete all go through real services, and 14 of the ~25 measured invariants came back clean. But there are two large, judge-visible coherence breaks (F1, F4), one environment-level surprise that is not a seed bug at all (F2), and a tail of small, cheap-to-fix shape gaps. The three incidents were not isolated: they are all instances of one pattern — **writing a derived endpoint (or a partial causal chain) instead of driving the cause** — and that pattern has more live instances.
+
+## The one-line principle
+
+Seed the cause, not the endpoint. If production derives a value, the seed must either drive the production deriver or reproduce its exact output shape — anything in between produces worlds the judge correctly reports as broken.
+
+## Findings, ranked by (occurrence × judge-visibility)
+
+### F1 — The overdue population is built on production-impossible state (confirms + expands #641)
+
+Measured: **111/114** contacts with `last_contacted` have it *earlier than* `created_at` (production forces creation-time; the handler ignores any client value — `handlers/contact.go:142-160`, CON-001). Worse: **95/114** have a non-creation `last_contacted` with **no backing interaction row at all** (and `last_interaction_at` NULL) — production's own delete-rollback path (CAD-010, `contact.sql:519-542`) proves every non-creation `last_contacted` must equal a live inbound/mutual interaction's `occurred_at`. Root cause: `factory.WithOverdue()`/`WithRecent()` (`factory/domain.go:190-198`) write `spec.LastContacted` raw, and `catalogOptionsFor` (`profiles.go:1002-1023`) applies them to ~2/3 of every catalog contact, deliberately skipping interaction replay for them so the cadence engine won't overwrite the fake value (`profiles.go:296-302`). The judge-facing symptom is severe: "Last contacted 3 months ago" in the header next to an **empty activity timeline** — a structural contradiction requiring no domain knowledge to flag. This population is the entire overdue cohort, i.e. the dashboard's central subject.
+
+Fix direction (cause-driven): overdue = a contact **created long ago** (backdated `created_at`, which the repo layer accepts legitimately) whose creation-time `last_contacted` is therefore old — matching the dominant real-world overdue shape — plus a smaller cohort whose `last_contacted` moved because a **replayed inbound/mutual interaction** occurred at the desired time. Both shapes are production-reachable; neither needs the factory to touch `last_contacted` at all.
+
+### F2 — `CRM_ENV=staging` silently runs hour-scale cadences (environment finding, NOT a seed bug)
+
+Measured: **149/149** cadence-bearing contacts have `contact_by` equal to `last_contacted`'s date instead of `last_contacted + cadence`. Diagnosis: `GetCadenceConfig` (`cadence/cadence_config.go:20-43`) keys off `CRM_ENV`, and `staging` selects the "fast staging" branch — **monthly = 1 hour, weekly = 10 minutes**. Every cadence computation on the staging box, at seed time and at runtime, uses hour-scale durations; with `CalculateContactBy` date-truncating (staging is not `IsTestingMode()`), monthly `contact_by` collapses onto `last_contacted`'s own date. Consequence for QA: the staging world's overdue math — the app's central value loop — does not behave like production's. A judge that checks "monthly cadence + last contacted Apr 14 → due mid-May" will (correctly, per prod semantics) fail the UI, which shows due-same-day. This interacts with F1: today's overdue cohort is overdue for two stacked non-prod reasons.
+
+**Decision (2026-07-13): staging runs production cadence semantics.** The `staging`/`accelerated` alias pair is consumed in exactly two places, both in `cadence/cadence_config.go`: `GetCadenceConfig` (durations) and the overdue-days scaler (which on staging computes one "day" as 10min/7, inflating displayed overdue-ness ~1000×). Nothing else in the repo sets or consumes `CRM_ENV=staging`. Fix: move `staging` out of the accelerated case in both switches — `staging` gets production durations and production overdue-day math; `accelerated` keeps the hour-scale behavior for future compressed-time environments. Ships as a separate small PR after PR 1; the staging box needs no `.env` change, just a redeploy + reseed. Rationale: under prod durations, overdue states are provided by the seeded world's time-shape (PR 1's backdated-creation cohort), not by compressed clocks — and a judge cannot be calibrated to a world where rendered dates and computed durations disagree by three orders of magnitude.
+
+### F3 — The one "awaiting reply" row renders as "Untitled task" with a dead Todoist link
+
+`SeedPendingFollowUp` (`replay/todoist.go:231-247`) writes `metadata = {due_date}` only; production's `FollowUpManager.applyCreate` (`followup_manager.go:525-532`) atomically writes `content`, `marker_json`, `project_id`, `label_name`, `integration_instance_id`. The API DTO reads `metadata["content"]` and the frontend falls back to the literal string **"Untitled task"** (`tasks-section.tsx:16-17`) instead of production's "Follow up: [Name](link) (awaiting reply)". It also leaves `external_task_id=''` on a `managed` row — a state production cannot produce (finalize sets state + id together, `todoist_op_worker.go:239-272`), and the "Open in Todoist" affordance links to `todoist://task?id=` with nothing after `id=`. Measured: 1/1 followup_loop rows affected, every run. This is the sole evidence row for the CAD-029/036 "awaiting reply" behaviors — the exact row the judge inspects to confirm the feature exists. Highest fix priority per token of effort.
+
+### F4 — Every message-sourced interaction is inbound; conversations are 100% one-sided
+
+Measured: **48/48** message-source rows (email/telegram/gchat/messages, 12 each) are `inbound`; zero `outbound` or `mutual` for any message source, in any profile. Root: all four factories only build inbound payloads (`Generator.GmailMessage` "builds an inbound email" `sources.go:71-117`; `TelegramMessage` adapter hardcodes `Out: false` `replay/telegram.go:64`; same for GChat/iMessage) — while the real providers carry both directions (`gmail.go:875-878`). Combined with the ≥21-day spacing (`WithMessageAge`), no reply-bridging or promote-to-mutual ever fires. Judge-facing symptom: every conversation surface shows the user never once replying — reads as a broken compose/send pipeline, the same false-regression class as CAD-036. Also leaves the direction-inclusive dedup paths and the email promote-to-mutual branch structurally unexercised.
+
+### F5 — `external_sync_state` is completely empty; Settings shows "never connected" over a world full of synced data
+
+Measured: **0 rows** despite six sources' interaction histories. Root: the replay adapters construct in-memory `SyncState` structs and never persist them (`gmail.go:54-58`, `gcal.go:115`, `todoist.go:143-150`); the gchat adapter persists then deletes its row in the same call (`gchat.go:56-64`). The Settings sync UI, sync badge, and StalenessService all read this table. Fix: persist prod-shaped sync-state rows (source, account, cursor, last-sync timestamps) as a seed step or in the adapters.
+
+### F6 — Notes coverage is 3% (5/167)
+
+The core "capture context about people" surface is empty on 162 of 167 contact pages — likely to read as "feature unused/broken" to a judge touring contact detail. `runCatalogProfile` seeds the notepad bucket minimally by design. Fix is a knob, not a redesign: seed notepad notes on a realistic fraction of catalog contacts (prod's actual fraction is measurable and can calibrate it).
+
+### F7 — cadence_due contact_task incoherences (real, but currently invisible to a UI judge)
+
+Measured: all **150** todoist cadence_due rows carry a raw-UUID temp `external_task_id` forever (the fake client returns no `TempIDMap`, so the same-tick finalize never runs — in prod the temp id is a sub-second transient); **1** `dismissed` cadence_due row exists (a combination no production code path can write — dismissal routes to `handleSkipTrigger` for cadence_due); **2** `completed` cadence_due rows have no outbound/mutual interaction within a day (production completion always implies one, and the next reconcile tick deletes completed rows anyway). Mitigating fact (verified): **no frontend surface fetches `lifecycle=cadence_due` today** — contact detail queries only manual + managed followup_loop. Correctness debt for any future API-level judge pass or cadence-due UI; not urgent for the current UI-only judge.
+
+### F8 — One stranded knowledge assertion (invisible today, visible when SP1 UI ships)
+
+Measured: exactly **1** contact with a current-accepted `birthday` assertion whose `contact.birthday` cache is NULL — the predicted `profiles.go:558-564` write, which drives the real `AssertService.Assert` but through a bare service with no `KnowledgeCacheUpdater` wired (`replay/assertion.go:26-35`), a partial replay of the causal chain. Everything else in the knowledge family measured clean (person-node dual-write 0 violations both directions; cache↔assertion coherent for lives_in/how_met; the 5 open assertions on dead nodes are all on soft-deleted contacts — prod-accurate retention). Fix: have `ReplayAssertion` refresh the cache for cutover predicates, or route the birthday demo through the contact-create authority flip.
+
+### F9 — Coverage absences (world is narrower than prod, not incoherent)
+
+Zero interaction rows for `todoist`, `anarlog_sessions`, `phone_calls` in any profile; gcal multi-attendee fan-out never seeded (factory hardcodes 2 attendees — the multi-entity `source_ref` dedup P0 has zero seed coverage); contact_method mix is 168 email / 3 telegram / 3 phone with no other types; per-contact message spacing is a uniform 21 days (non-organic but harmless). File under "expand when a tour needs it."
+
+## What measured clean (the architecture is right)
+
+External-identity exact-match integrity (0/10 violations), matched external_contact liveness, contact_method value shapes, interaction `source_ref` formats, dedup uniqueness (interaction and contact_task, both directions), event-bus per-entity `source_id` fan-out keys, venue population per source, person-node dual-write, proposition-slot uniqueness, `last_outreach_at`/`last_response_at` interaction-existence (0 violations each — the settled per-source cohort is fully coherent). The replay-through-real-providers design works; the violations cluster exactly where the seed bypasses or partially drives a production path.
+
+## Judge-calibration note (not a seed fix)
+
+Contact soft-delete does NOT cascade in production (`service/contact.go:552-577` touches only contact + node); live contact_method/note rows pointing at soft-deleted contacts are prod-accurate (measured: 4 methods on deleted contacts). If the judge ever flags this, it is a true positive about prod behavior, not a seed artifact.
+
+## Recommended fix packaging
+
+1. **PR: cadence causality** (F1) — replace `WithOverdue`/`WithRecent` endpoint writes with cause-driven shapes (backdated `created_at` cohort + replayed-interaction cohort), and add a post-seed **coherence gate** to the profile coverage test asserting zero violations of the production-impossible invariants (F1's two, plus T1/T4/T5 from F7/F3 and the F8 cache check). The gate is what prevents instance four from being discovered by a confused judge.
+2. **PR: follow-up row shape** (F3) — small; full prod metadata + synthetic alphanumeric external id in `SeedPendingFollowUp`.
+3. **Decision: staging cadence scale** (F2) — environment design question, decide before or alongside PR 1 (the overdue cohort's shape depends on which durations staging runs).
+4. **PR: outbound/mutual message variants** (F4) — factory + adapter work per source.
+5. **PR: sync-state persistence + notes coverage** (F5, F6) — both small seeding additions.
+6. **Backlog:** F7 (pair with any future cadence-due UI or API-level judging), F8 (pair with SP1 UI), F9 (expand per-tour).
+
+## Appendix: measurement summary (staging, 2026-07-13, 167 live contacts)
+
+| Check | Violations / population |
+|---|---|
+| last_contacted < created_at | 111 / 114 |
+| last_contacted > created_at without last_response_at | 0 / 3 |
+| non-creation last_contacted, no last_interaction_at | 95 / 114 |
+| non-creation last_contacted, no matching inbound/mutual interaction | 95 / 114 |
+| last_outreach_at without matching outbound/mutual interaction | 0 / 7 |
+| last_response_at without matching inbound/mutual interaction | 0 / 19 |
+| contact_by set while cadence unset | 0 / 167 |
+| contact_by ≠ last_contacted + prod-scale cadence | 149 / 149 (see F2 — env, not seed) |
+| live contact without live person node (and inverse) | 0 / 167 both |
+| accepted cutover assertion without cache column | 1 (birthday) |
+| open assertions on dead nodes | 5, all on soft-deleted contacts (prod-accurate) |
+| dismissed cadence_due (production-impossible) | 1 / 150 |
+| completed cadence_due without nearby interaction | 2 |
+| todoist rows stuck on raw-UUID temp id | 150 / 150 |
+| managed followup_loop with empty external_task_id | 1 / 1 |
+| followup_loop missing required metadata keys | 1 / 1 |
+| message sources with zero outbound/mutual | 4 / 4 sources (48 rows all inbound) |
+| interaction sources with zero rows | todoist, anarlog_sessions, phone_calls |
+| gcal multi-attendee fan-out events | 0 seeded |
+| external_sync_state rows | 0 (six sources active) |
+| contacts with notepad notes | 5 / 167 (3%) |
+| exact-matched identity without contact_method | 0 / 10 |
+| all uniqueness/dedup/source_ref-shape checks | clean |

--- a/Makefile
+++ b/Makefile
@@ -447,7 +447,7 @@ test: test-unit test-integration test-frontend
 
 test-unit:
 	@echo "Running backend unit tests..."
-	@cd backend && go test ./tests/... ./internal/matching/... ./internal/events/... ./internal/service/... ./internal/contacttask/... ./internal/spec/... ./cmd/spec-lint/... $(GOTEST_VERBOSE) -short
+	@cd backend && go test ./tests/... ./internal/matching/... ./internal/events/... ./internal/service/... ./internal/contacttask/... ./internal/synthetic/factory/... ./internal/spec/... ./cmd/spec-lint/... $(GOTEST_VERBOSE) -short
 
 # Provisions the per-worktree Postgres instance BEFORE the integration recipes
 # expand $(TEST_DATABASE_URL) (gh #433). As a prerequisite it runs to

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -2164,6 +2164,29 @@ type Querier interface {
 	// list by the test before it reaches here; format() with %I quotes the
 	// identifier so it can never be an injection vector.
 	TestCountAllRows(ctx context.Context, tableName string) (int64, error)
+	// Coherence gate: count the namespace's contacts whose non-creation last_contacted
+	// is NOT backed by a live inbound/mutual interaction at the same occurred_at, or
+	// whose last_interaction_at is not in lockstep with last_contacted. Asserted == 0.
+	// last_contacted <> created_at exempts the creation stamp (the backdated cohort
+	// sets both columns from ONE *time.Time, so they are byte-equal; there is no seed
+	// path left that writes last_contacted disconnected from created_at). A moved
+	// last_contacted must (i) equal last_interaction_at (the cadence updater writes
+	// both to occurred_at under one guard) and (ii) be backed by a live inbound/mutual
+	// interaction at the same occurred_at (CAD-010). Caller passes a BARE prefix.
+	TestCountIncoherentLastContactedByNamePrefix(ctx context.Context, namePrefix pgtype.Text) (int64, error)
+	// Coherence gate (F3): count the namespace's managed follow-up loop tasks that do
+	// NOT carry the production Todoist shape. Asserted == 0. COALESCE(...,'') is
+	// load-bearing: a JSON-null or absent key makes metadata->>k return SQL NULL, and
+	// `NULL NOT LIKE x` is NULL (not TRUE) — it would silently pass. COALESCE collapses
+	// NULL/absent to '' so the LIKE fails and the row is flagged. Caller passes a BARE
+	// prefix.
+	TestCountIncoherentManagedFollowUpsByNamePrefix(ctx context.Context, namePrefix pgtype.Text) (int64, error)
+	// Coherence gate (positive): count the namespace's contacts whose last_contacted
+	// IS backed by a live inbound/mutual interaction at the same occurred_at AND whose
+	// last_interaction_at is in lockstep. Asserted >= 1, proving the zero-violation gate
+	// is not vacuous — the interaction-moved cohort exists and sets last_interaction_at
+	// in lockstep where an interaction drove the write. Caller passes a BARE prefix.
+	TestCountInteractionBackedLastContactedByNamePrefix(ctx context.Context, namePrefix pgtype.Text) (int64, error)
 	// Test-only: counts venue-type nodes that no live interaction references via
 	// venue_id. Used by the venue backfill test to assert the no-orphan-node guard.
 	TestCountOrphanVenueNodes(ctx context.Context) (int64, error)
@@ -2192,6 +2215,11 @@ type Querier interface {
 	// test to prove the attended FOR SHARE conflicts with a concurrent FOR UPDATE
 	// without a sleep/timeout. Production code must NOT call this.
 	TestGetCalendarEventByIDForUpdateNoWait(ctx context.Context, id pgtype.UUID) (*CalendarEvent, error)
+	// Coherence gate (F3, Go-side): return the namespace's live managed follow-up loop
+	// task's contact_id, external_task_id, and metadata so the test can decode the
+	// marker and confirm it points at the row's own contact. Caller passes a BARE
+	// prefix; expects exactly one live follow-up in the namespace.
+	TestGetLiveFollowUpByNamePrefix(ctx context.Context, namePrefix pgtype.Text) (*TestGetLiveFollowUpByNamePrefixRow, error)
 	// TEST ONLY. Hard-deletes a calendar_event row by primary key. Used
 	// by integration tests that exercise the "target row vanished between
 	// snapshot and resolve-link" path. Production code must NOT call this.
@@ -2310,6 +2338,13 @@ type Querier interface {
 	// Reset test only: a marker row in telegram_session (the Telegram auth session
 	// the reset wipes). session_data_encrypted + encryption_nonce are NOT NULL bytea.
 	TestInsertTelegramSessionMarker(ctx context.Context) error
+	// Tour capacity gate: for each live contact in the namespace, return the four
+	// CAD-029 activity flags (outreach / response / pending-followup / none) so the Go
+	// test can compute a maximum bipartite matching and prove the world has FOUR
+	// DISTINCT assignable contacts (the precondition for cadence-followup.tour.ts).
+	// has_pending mirrors FindPendingFollowUp's live followup_loop predicate. Caller
+	// passes a BARE prefix.
+	TestListCadenceActivityFlagsByNamePrefix(ctx context.Context, namePrefix pgtype.Text) ([]*TestListCadenceActivityFlagsByNamePrefixRow, error)
 	// Profile coverage test only: list the namespace's contacts (by full_name
 	// prefix) with the bucket-defining columns + a method count, so the test can
 	// assert the catalog produced ≥1 overdue (cadence + last_contacted in the past),

--- a/backend/internal/db/queries/test.sql
+++ b/backend/internal/db/queries/test.sql
@@ -1047,6 +1047,8 @@ SELECT
     c.id,
     c.cadence,
     c.last_contacted,
+    c.created_at,
+    c.contact_by,
     (SELECT COUNT(*) FROM contact_method cm WHERE cm.contact_id = c.id) AS method_count
 FROM contact c
 WHERE c.full_name LIKE @name_prefix || '%'
@@ -1170,3 +1172,120 @@ VALUES (@kind, 'default', @state::river_job_state, '{}'::jsonb, '{}'::jsonb, 1, 
 -- query leaves NULL) since Tier-0's wait/run arithmetic needs it populated.
 INSERT INTO river_job (kind, queue, state, args, metadata, priority, max_attempts, scheduled_at, attempted_at, finalized_at)
 VALUES (@kind, 'default', @state::river_job_state, '{}'::jsonb, '{}'::jsonb, 1, 1, @scheduled_at, @attempted_at, @finalized_at);
+
+-- name: TestCountIncoherentLastContactedByNamePrefix :one
+-- Coherence gate: count the namespace's contacts whose non-creation last_contacted
+-- is NOT backed by a live inbound/mutual interaction at the same occurred_at, or
+-- whose last_interaction_at is not in lockstep with last_contacted. Asserted == 0.
+-- last_contacted <> created_at exempts the creation stamp (the backdated cohort
+-- sets both columns from ONE *time.Time, so they are byte-equal; there is no seed
+-- path left that writes last_contacted disconnected from created_at). A moved
+-- last_contacted must (i) equal last_interaction_at (the cadence updater writes
+-- both to occurred_at under one guard) and (ii) be backed by a live inbound/mutual
+-- interaction at the same occurred_at (CAD-010). Caller passes a BARE prefix.
+SELECT COUNT(*)
+FROM contact c
+WHERE c.full_name LIKE @name_prefix || '%'
+  AND c.deleted_at IS NULL
+  AND c.last_contacted IS NOT NULL
+  AND c.last_contacted <> c.created_at
+  AND (
+        c.last_interaction_at IS DISTINCT FROM c.last_contacted
+     OR NOT EXISTS (
+          SELECT 1 FROM interaction i
+          WHERE i.contact_id = c.id
+            AND i.deleted_at IS NULL
+            AND i.direction IN ('inbound','mutual')
+            AND i.occurred_at = c.last_contacted
+        )
+  );
+
+-- name: TestCountInteractionBackedLastContactedByNamePrefix :one
+-- Coherence gate (positive): count the namespace's contacts whose last_contacted
+-- IS backed by a live inbound/mutual interaction at the same occurred_at AND whose
+-- last_interaction_at is in lockstep. Asserted >= 1, proving the zero-violation gate
+-- is not vacuous — the interaction-moved cohort exists and sets last_interaction_at
+-- in lockstep where an interaction drove the write. Caller passes a BARE prefix.
+SELECT COUNT(*)
+FROM contact c
+WHERE c.full_name LIKE @name_prefix || '%'
+  AND c.deleted_at IS NULL
+  AND c.last_interaction_at IS NOT NULL
+  AND c.last_interaction_at = c.last_contacted
+  AND EXISTS (
+        SELECT 1 FROM interaction i
+        WHERE i.contact_id = c.id
+          AND i.deleted_at IS NULL
+          AND i.direction IN ('inbound','mutual')
+          AND i.occurred_at = c.last_contacted
+      );
+
+-- name: TestCountIncoherentManagedFollowUpsByNamePrefix :one
+-- Coherence gate (F3): count the namespace's managed follow-up loop tasks that do
+-- NOT carry the production Todoist shape. Asserted == 0. COALESCE(...,'') is
+-- load-bearing: a JSON-null or absent key makes metadata->>k return SQL NULL, and
+-- `NULL NOT LIKE x` is NULL (not TRUE) — it would silently pass. COALESCE collapses
+-- NULL/absent to '' so the LIKE fails and the row is flagged. Caller passes a BARE
+-- prefix.
+SELECT COUNT(*)
+FROM contact_task ct
+JOIN contact c ON ct.contact_id = c.id
+WHERE c.full_name LIKE @name_prefix || '%'
+  AND c.deleted_at IS NULL
+  AND ct.lifecycle = 'followup_loop'
+  AND ct.state = 'managed'
+  AND (
+        ct.external_task_id IS NULL OR ct.external_task_id = ''
+     OR ct.external_task_id !~ '^[A-Za-z0-9]+$'
+     OR COALESCE(ct.metadata->>'due_date','') !~ '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'
+     OR COALESCE(ct.metadata->>'project_id','')              = ''
+     OR COALESCE(ct.metadata->>'label_name','')              = ''
+     OR COALESCE(ct.metadata->>'integration_instance_id','') = ''
+     OR COALESCE(ct.metadata->>'content','')     NOT LIKE 'Follow up:%(awaiting reply)'
+     OR COALESCE(ct.metadata->>'marker_json','')  NOT LIKE '%followup_loop%'
+  );
+
+-- name: TestGetLiveFollowUpByNamePrefix :one
+-- Coherence gate (F3, Go-side): return the namespace's live managed follow-up loop
+-- task's contact_id, external_task_id, and metadata so the test can decode the
+-- marker and confirm it points at the row's own contact. Caller passes a BARE
+-- prefix; expects exactly one live follow-up in the namespace.
+SELECT ct.contact_id, ct.external_task_id, ct.metadata
+FROM contact_task ct
+JOIN contact c ON ct.contact_id = c.id
+WHERE c.full_name LIKE @name_prefix || '%'
+  AND c.deleted_at IS NULL
+  AND ct.lifecycle = 'followup_loop'
+  AND ct.state = 'managed'
+LIMIT 1;
+
+-- name: TestListCadenceActivityFlagsByNamePrefix :many
+-- Tour capacity gate: for each live contact in the namespace, return the four
+-- CAD-029 activity flags (outreach / response / pending-followup / none) so the Go
+-- test can compute a maximum bipartite matching and prove the world has FOUR
+-- DISTINCT assignable contacts (the precondition for cadence-followup.tour.ts).
+-- has_pending mirrors FindPendingFollowUp's live followup_loop predicate. Caller
+-- passes a BARE prefix.
+SELECT
+    c.id,
+    (c.last_outreach_at IS NOT NULL)::boolean AS has_outreach,
+    (c.last_response_at IS NOT NULL)::boolean AS has_response,
+    EXISTS (
+        SELECT 1 FROM contact_task ct
+        WHERE ct.contact_id = c.id
+          AND ct.lifecycle = 'followup_loop'
+          AND ct.state = 'managed'
+    )::boolean AS has_pending,
+    (
+        c.last_outreach_at IS NULL
+        AND c.last_response_at IS NULL
+        AND NOT EXISTS (
+            SELECT 1 FROM contact_task ct
+            WHERE ct.contact_id = c.id
+              AND ct.lifecycle = 'followup_loop'
+              AND ct.state = 'managed'
+        )
+    )::boolean AS has_none
+FROM contact c
+WHERE c.full_name LIKE @name_prefix || '%'
+  AND c.deleted_at IS NULL;

--- a/backend/internal/db/test.sql.go
+++ b/backend/internal/db/test.sql.go
@@ -2173,6 +2173,102 @@ func (q *Queries) TestCountAllRows(ctx context.Context, tableName string) (int64
 	return column_1, err
 }
 
+const TestCountIncoherentLastContactedByNamePrefix = `-- name: TestCountIncoherentLastContactedByNamePrefix :one
+SELECT COUNT(*)
+FROM contact c
+WHERE c.full_name LIKE $1 || '%'
+  AND c.deleted_at IS NULL
+  AND c.last_contacted IS NOT NULL
+  AND c.last_contacted <> c.created_at
+  AND (
+        c.last_interaction_at IS DISTINCT FROM c.last_contacted
+     OR NOT EXISTS (
+          SELECT 1 FROM interaction i
+          WHERE i.contact_id = c.id
+            AND i.deleted_at IS NULL
+            AND i.direction IN ('inbound','mutual')
+            AND i.occurred_at = c.last_contacted
+        )
+  )
+`
+
+// Coherence gate: count the namespace's contacts whose non-creation last_contacted
+// is NOT backed by a live inbound/mutual interaction at the same occurred_at, or
+// whose last_interaction_at is not in lockstep with last_contacted. Asserted == 0.
+// last_contacted <> created_at exempts the creation stamp (the backdated cohort
+// sets both columns from ONE *time.Time, so they are byte-equal; there is no seed
+// path left that writes last_contacted disconnected from created_at). A moved
+// last_contacted must (i) equal last_interaction_at (the cadence updater writes
+// both to occurred_at under one guard) and (ii) be backed by a live inbound/mutual
+// interaction at the same occurred_at (CAD-010). Caller passes a BARE prefix.
+func (q *Queries) TestCountIncoherentLastContactedByNamePrefix(ctx context.Context, namePrefix pgtype.Text) (int64, error) {
+	row := q.db.QueryRow(ctx, TestCountIncoherentLastContactedByNamePrefix, namePrefix)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const TestCountIncoherentManagedFollowUpsByNamePrefix = `-- name: TestCountIncoherentManagedFollowUpsByNamePrefix :one
+SELECT COUNT(*)
+FROM contact_task ct
+JOIN contact c ON ct.contact_id = c.id
+WHERE c.full_name LIKE $1 || '%'
+  AND c.deleted_at IS NULL
+  AND ct.lifecycle = 'followup_loop'
+  AND ct.state = 'managed'
+  AND (
+        ct.external_task_id IS NULL OR ct.external_task_id = ''
+     OR ct.external_task_id !~ '^[A-Za-z0-9]+$'
+     OR COALESCE(ct.metadata->>'due_date','') !~ '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'
+     OR COALESCE(ct.metadata->>'project_id','')              = ''
+     OR COALESCE(ct.metadata->>'label_name','')              = ''
+     OR COALESCE(ct.metadata->>'integration_instance_id','') = ''
+     OR COALESCE(ct.metadata->>'content','')     NOT LIKE 'Follow up:%(awaiting reply)'
+     OR COALESCE(ct.metadata->>'marker_json','')  NOT LIKE '%followup_loop%'
+  )
+`
+
+// Coherence gate (F3): count the namespace's managed follow-up loop tasks that do
+// NOT carry the production Todoist shape. Asserted == 0. COALESCE(...,”) is
+// load-bearing: a JSON-null or absent key makes metadata->>k return SQL NULL, and
+// `NULL NOT LIKE x` is NULL (not TRUE) — it would silently pass. COALESCE collapses
+// NULL/absent to ” so the LIKE fails and the row is flagged. Caller passes a BARE
+// prefix.
+func (q *Queries) TestCountIncoherentManagedFollowUpsByNamePrefix(ctx context.Context, namePrefix pgtype.Text) (int64, error) {
+	row := q.db.QueryRow(ctx, TestCountIncoherentManagedFollowUpsByNamePrefix, namePrefix)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const TestCountInteractionBackedLastContactedByNamePrefix = `-- name: TestCountInteractionBackedLastContactedByNamePrefix :one
+SELECT COUNT(*)
+FROM contact c
+WHERE c.full_name LIKE $1 || '%'
+  AND c.deleted_at IS NULL
+  AND c.last_interaction_at IS NOT NULL
+  AND c.last_interaction_at = c.last_contacted
+  AND EXISTS (
+        SELECT 1 FROM interaction i
+        WHERE i.contact_id = c.id
+          AND i.deleted_at IS NULL
+          AND i.direction IN ('inbound','mutual')
+          AND i.occurred_at = c.last_contacted
+      )
+`
+
+// Coherence gate (positive): count the namespace's contacts whose last_contacted
+// IS backed by a live inbound/mutual interaction at the same occurred_at AND whose
+// last_interaction_at is in lockstep. Asserted >= 1, proving the zero-violation gate
+// is not vacuous — the interaction-moved cohort exists and sets last_interaction_at
+// in lockstep where an interaction drove the write. Caller passes a BARE prefix.
+func (q *Queries) TestCountInteractionBackedLastContactedByNamePrefix(ctx context.Context, namePrefix pgtype.Text) (int64, error) {
+	row := q.db.QueryRow(ctx, TestCountInteractionBackedLastContactedByNamePrefix, namePrefix)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const TestCountTaggedAsAssertionsForSubject = `-- name: TestCountTaggedAsAssertionsForSubject :one
 SELECT COUNT(*) FROM assertion
 WHERE subject_node_id = $1
@@ -2217,6 +2313,34 @@ func (q *Queries) TestDeleteTagsByIds(ctx context.Context, tagIds []pgtype.UUID)
 		return 0, err
 	}
 	return result.RowsAffected(), nil
+}
+
+const TestGetLiveFollowUpByNamePrefix = `-- name: TestGetLiveFollowUpByNamePrefix :one
+SELECT ct.contact_id, ct.external_task_id, ct.metadata
+FROM contact_task ct
+JOIN contact c ON ct.contact_id = c.id
+WHERE c.full_name LIKE $1 || '%'
+  AND c.deleted_at IS NULL
+  AND ct.lifecycle = 'followup_loop'
+  AND ct.state = 'managed'
+LIMIT 1
+`
+
+type TestGetLiveFollowUpByNamePrefixRow struct {
+	ContactID      pgtype.UUID `json:"contact_id"`
+	ExternalTaskID string      `json:"external_task_id"`
+	Metadata       []byte      `json:"metadata"`
+}
+
+// Coherence gate (F3, Go-side): return the namespace's live managed follow-up loop
+// task's contact_id, external_task_id, and metadata so the test can decode the
+// marker and confirm it points at the row's own contact. Caller passes a BARE
+// prefix; expects exactly one live follow-up in the namespace.
+func (q *Queries) TestGetLiveFollowUpByNamePrefix(ctx context.Context, namePrefix pgtype.Text) (*TestGetLiveFollowUpByNamePrefixRow, error) {
+	row := q.db.QueryRow(ctx, TestGetLiveFollowUpByNamePrefix, namePrefix)
+	var i TestGetLiveFollowUpByNamePrefixRow
+	err := row.Scan(&i.ContactID, &i.ExternalTaskID, &i.Metadata)
+	return &i, err
 }
 
 const TestInsertContactAtID = `-- name: TestInsertContactAtID :exec
@@ -2464,11 +2588,79 @@ func (q *Queries) TestInsertTelegramSessionMarker(ctx context.Context) error {
 	return err
 }
 
+const TestListCadenceActivityFlagsByNamePrefix = `-- name: TestListCadenceActivityFlagsByNamePrefix :many
+SELECT
+    c.id,
+    (c.last_outreach_at IS NOT NULL)::boolean AS has_outreach,
+    (c.last_response_at IS NOT NULL)::boolean AS has_response,
+    EXISTS (
+        SELECT 1 FROM contact_task ct
+        WHERE ct.contact_id = c.id
+          AND ct.lifecycle = 'followup_loop'
+          AND ct.state = 'managed'
+    )::boolean AS has_pending,
+    (
+        c.last_outreach_at IS NULL
+        AND c.last_response_at IS NULL
+        AND NOT EXISTS (
+            SELECT 1 FROM contact_task ct
+            WHERE ct.contact_id = c.id
+              AND ct.lifecycle = 'followup_loop'
+              AND ct.state = 'managed'
+        )
+    )::boolean AS has_none
+FROM contact c
+WHERE c.full_name LIKE $1 || '%'
+  AND c.deleted_at IS NULL
+`
+
+type TestListCadenceActivityFlagsByNamePrefixRow struct {
+	ID          pgtype.UUID `json:"id"`
+	HasOutreach bool        `json:"has_outreach"`
+	HasResponse bool        `json:"has_response"`
+	HasPending  bool        `json:"has_pending"`
+	HasNone     bool        `json:"has_none"`
+}
+
+// Tour capacity gate: for each live contact in the namespace, return the four
+// CAD-029 activity flags (outreach / response / pending-followup / none) so the Go
+// test can compute a maximum bipartite matching and prove the world has FOUR
+// DISTINCT assignable contacts (the precondition for cadence-followup.tour.ts).
+// has_pending mirrors FindPendingFollowUp's live followup_loop predicate. Caller
+// passes a BARE prefix.
+func (q *Queries) TestListCadenceActivityFlagsByNamePrefix(ctx context.Context, namePrefix pgtype.Text) ([]*TestListCadenceActivityFlagsByNamePrefixRow, error) {
+	rows, err := q.db.Query(ctx, TestListCadenceActivityFlagsByNamePrefix, namePrefix)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []*TestListCadenceActivityFlagsByNamePrefixRow{}
+	for rows.Next() {
+		var i TestListCadenceActivityFlagsByNamePrefixRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.HasOutreach,
+			&i.HasResponse,
+			&i.HasPending,
+			&i.HasNone,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const TestListContactBucketsByNamePrefix = `-- name: TestListContactBucketsByNamePrefix :many
 SELECT
     c.id,
     c.cadence,
     c.last_contacted,
+    c.created_at,
+    c.contact_by,
     (SELECT COUNT(*) FROM contact_method cm WHERE cm.contact_id = c.id) AS method_count
 FROM contact c
 WHERE c.full_name LIKE $1 || '%'
@@ -2479,6 +2671,8 @@ type TestListContactBucketsByNamePrefixRow struct {
 	ID            pgtype.UUID        `json:"id"`
 	Cadence       pgtype.Text        `json:"cadence"`
 	LastContacted pgtype.Timestamptz `json:"last_contacted"`
+	CreatedAt     pgtype.Timestamptz `json:"created_at"`
+	ContactBy     pgtype.Date        `json:"contact_by"`
 	MethodCount   int64              `json:"method_count"`
 }
 
@@ -2501,6 +2695,8 @@ func (q *Queries) TestListContactBucketsByNamePrefix(ctx context.Context, namePr
 			&i.ID,
 			&i.Cadence,
 			&i.LastContacted,
+			&i.CreatedAt,
+			&i.ContactBy,
 			&i.MethodCount,
 		); err != nil {
 			return nil, err

--- a/backend/internal/repository/contact.go
+++ b/backend/internal/repository/contact.go
@@ -158,6 +158,10 @@ type CreateContactRequest struct {
 	Cadence       *string    `json:"cadence,omitempty"`
 	LastContacted *time.Time `json:"last_contacted,omitempty"`
 	ProfilePhoto  *string    `json:"profile_photo,omitempty"`
+	// CreatedAt overrides the creation timestamp. Set only by the synthetic
+	// seed to backdate a contact into the simulated past; production paths
+	// leave it nil so creation stamps the current accelerated time.
+	CreatedAt *time.Time `json:"-"`
 }
 
 // UpdateContactRequest represents the request to update a contact
@@ -309,6 +313,9 @@ func (r *ContactRepository) ListContacts(ctx context.Context, params ListContact
 func (r *ContactRepository) CreateContact(ctx context.Context, req CreateContactRequest) (*Contact, error) {
 	// Use accelerated time for created_at to ensure consistency with time acceleration
 	createdAt := accelerated.GetCurrentTime()
+	if req.CreatedAt != nil {
+		createdAt = *req.CreatedAt
+	}
 
 	// Calculate contact_by if cadence is set
 	var contactBy pgtype.Date

--- a/backend/internal/repository/synthetic_support.go
+++ b/backend/internal/repository/synthetic_support.go
@@ -727,11 +727,14 @@ func (r *SyntheticSupportRepository) InsertResetMarkers(ctx context.Context) err
 }
 
 // ContactBucket is the bucket-defining projection of a seeded contact (profile
-// coverage test only): cadence, last_contacted, and method count.
+// coverage test only): cadence, last_contacted, created_at, contact_by, and
+// method count.
 type ContactBucket struct {
 	ID            uuid.UUID
 	Cadence       *string
 	LastContacted *time.Time
+	CreatedAt     *time.Time
+	ContactBy     *time.Time
 	MethodCount   int64
 }
 
@@ -759,7 +762,95 @@ func (r *SyntheticSupportRepository) ListContactBucketsByNamePrefix(ctx context.
 			t := row.LastContacted.Time
 			b.LastContacted = &t
 		}
+		if row.CreatedAt.Valid {
+			t := row.CreatedAt.Time
+			b.CreatedAt = &t
+		}
+		if row.ContactBy.Valid {
+			t := row.ContactBy.Time
+			b.ContactBy = &t
+		}
 		out = append(out, b)
+	}
+	return out, nil
+}
+
+// IncoherentLastContactedCountByNamePrefix returns the number of the namespace's
+// contacts whose non-creation last_contacted is not backed by a live
+// inbound/mutual interaction at the same occurred_at (or whose last_interaction_at
+// is not in lockstep). Coherence gate (a); asserted == 0. Test only.
+func (r *SyntheticSupportRepository) IncoherentLastContactedCountByNamePrefix(ctx context.Context, namePrefix string) (int64, error) {
+	return r.queries.TestCountIncoherentLastContactedByNamePrefix(ctx, pgtype.Text{String: namePrefix, Valid: true})
+}
+
+// InteractionBackedLastContactedCountByNamePrefix returns the number of the
+// namespace's contacts whose last_contacted IS backed by a live inbound/mutual
+// interaction at the same occurred_at with last_interaction_at in lockstep.
+// Coherence gate (a-positive); asserted >= 1. Test only.
+func (r *SyntheticSupportRepository) InteractionBackedLastContactedCountByNamePrefix(ctx context.Context, namePrefix string) (int64, error) {
+	return r.queries.TestCountInteractionBackedLastContactedByNamePrefix(ctx, pgtype.Text{String: namePrefix, Valid: true})
+}
+
+// IncoherentManagedFollowUpCountByNamePrefix returns the number of the namespace's
+// managed follow-up loop tasks that do not carry the production Todoist shape
+// (alphanumeric external id + prod metadata + content/marker shape). Coherence
+// gate (c); asserted == 0. Test only.
+func (r *SyntheticSupportRepository) IncoherentManagedFollowUpCountByNamePrefix(ctx context.Context, namePrefix string) (int64, error) {
+	return r.queries.TestCountIncoherentManagedFollowUpsByNamePrefix(ctx, pgtype.Text{String: namePrefix, Valid: true})
+}
+
+// LiveFollowUp is the Go-side projection of the namespace's live managed follow-up
+// loop task: its contact_id, external_task_id, and raw metadata JSON, so the
+// coverage test can decode the marker and confirm the link. Coherence gate (c-Go).
+type LiveFollowUp struct {
+	ContactID      uuid.UUID
+	ExternalTaskID string
+	Metadata       []byte
+}
+
+// GetLiveFollowUpByNamePrefix returns the namespace's single live managed follow-up
+// loop task's contact_id, external_task_id, and metadata JSON. Test only.
+func (r *SyntheticSupportRepository) GetLiveFollowUpByNamePrefix(ctx context.Context, namePrefix string) (*LiveFollowUp, error) {
+	row, err := r.queries.TestGetLiveFollowUpByNamePrefix(ctx, pgtype.Text{String: namePrefix, Valid: true})
+	if err != nil {
+		return nil, err
+	}
+	return &LiveFollowUp{
+		ContactID:      uuid.UUID(row.ContactID.Bytes),
+		ExternalTaskID: row.ExternalTaskID,
+		Metadata:       row.Metadata,
+	}, nil
+}
+
+// CadenceActivityFlags is the per-contact CAD-029 activity projection (outreach /
+// response / pending-followup / none) used by the tour-capacity gate to prove four
+// distinct assignable contacts exist.
+type CadenceActivityFlags struct {
+	ContactID   uuid.UUID
+	HasOutreach bool
+	HasResponse bool
+	HasPending  bool
+	HasNone     bool
+}
+
+// ListCadenceActivityFlagsByNamePrefix returns the per-contact activity flags for
+// the namespace's live contacts so the coverage test can compute a maximum
+// bipartite matching and assert the world contains four distinct assignable
+// contacts for cadence-followup.tour.ts. Test only.
+func (r *SyntheticSupportRepository) ListCadenceActivityFlagsByNamePrefix(ctx context.Context, namePrefix string) ([]CadenceActivityFlags, error) {
+	rows, err := r.queries.TestListCadenceActivityFlagsByNamePrefix(ctx, pgtype.Text{String: namePrefix, Valid: true})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]CadenceActivityFlags, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, CadenceActivityFlags{
+			ContactID:   uuid.UUID(row.ID.Bytes),
+			HasOutreach: row.HasOutreach,
+			HasResponse: row.HasResponse,
+			HasPending:  row.HasPending,
+			HasNone:     row.HasNone,
+		})
 	}
 	return out, nil
 }

--- a/backend/internal/synthetic/factory/domain.go
+++ b/backend/internal/synthetic/factory/domain.go
@@ -25,6 +25,7 @@ type ContactSpec struct {
 	FullName      string
 	Methods       []MethodSpec
 	Cadence       *string
+	CreatedAt     *time.Time
 	LastContacted *time.Time
 	Birthday      *time.Time
 	Location      *string
@@ -41,18 +42,18 @@ type ContactSpec struct {
 type ContactOption func(*contactConfig)
 
 type contactConfig struct {
-	withEmail    bool
-	withPhone    bool
-	withTelegram bool
-	noMethods    bool
-	cadence      *string
-	overdue      bool
-	recent       bool
-	birthday     *time.Time
-	howMet       *string
-	location     *string
-	unicodeName  bool
-	descender    bool
+	withEmail            bool
+	withPhone            bool
+	withTelegram         bool
+	noMethods            bool
+	cadence              *string
+	createdAge           *time.Duration
+	recentCreationWindow *time.Duration
+	birthday             *time.Time
+	howMet               *string
+	location             *string
+	unicodeName          bool
+	descender            bool
 }
 
 // WithEmail adds an email contact_method (default ON if no method option is
@@ -76,12 +77,27 @@ func WithCadence(cadence string) ContactOption {
 	return func(c *contactConfig) { c.cadence = &cadence }
 }
 
-// WithOverdue gives the contact a last_contacted far enough in the past that,
-// combined with a cadence, it reads as overdue. Anchor-relative.
-func WithOverdue() ContactOption { return func(c *contactConfig) { c.overdue = true } }
+// WithCreatedAge backdates the contact to `age` before the anchor, mirroring the
+// create handler: created_at and last_contacted are both stamped to that one past
+// instant. Combined with a cadence, a far-enough age reads as overdue — with an
+// empty timeline that is honest (added long ago, no interactions logged). Draws no
+// PRNG (fixed age).
+func WithCreatedAge(age time.Duration) ContactOption {
+	return func(c *contactConfig) {
+		d := age
+		c.createdAge = &d
+	}
+}
 
-// WithRecent gives the contact a recent last_contacted (anchor-relative).
-func WithRecent() ContactOption { return func(c *contactConfig) { c.recent = true } }
+// WithRecentCreation backdates the contact to a deterministic instant within the
+// last `window`, again stamping created_at and last_contacted from that one value.
+// Draws one recentOffset from the PRNG (the recent-window jitter).
+func WithRecentCreation(window time.Duration) ContactOption {
+	return func(c *contactConfig) {
+		w := window
+		c.recentCreationWindow = &w
+	}
+}
 
 // WithBirthday1900Sentinel sets the prod 1900-MM-DD month/day-only sentinel —
 // a representative edge case the catalog can build on.
@@ -187,13 +203,16 @@ func (g *Generator) Contact(opts ...ContactOption) ContactSpec {
 		spec.Methods = append(spec.Methods, MethodSpec{Type: "telegram", Value: handle, IsPrimary: len(spec.Methods) == 0})
 	}
 
+	// Backdated cohorts stamp created_at and last_contacted from ONE past instant,
+	// mirroring the create handler (at creation, last_contacted == created_at).
 	switch {
-	case cfg.overdue:
-		// ~90 days ago — overdue for any sub-quarterly cadence.
-		t := g.at(-90 * 24 * time.Hour)
+	case cfg.createdAge != nil:
+		t := g.at(-*cfg.createdAge)
+		spec.CreatedAt = &t
 		spec.LastContacted = &t
-	case cfg.recent:
-		t := g.at(g.recentOffset(48 * time.Hour))
+	case cfg.recentCreationWindow != nil:
+		t := g.at(g.recentOffset(*cfg.recentCreationWindow))
+		spec.CreatedAt = &t
 		spec.LastContacted = &t
 	}
 

--- a/backend/internal/synthetic/factory/draw_order_test.go
+++ b/backend/internal/synthetic/factory/draw_order_test.go
@@ -1,0 +1,58 @@
+package factory
+
+import (
+	"testing"
+	"time"
+)
+
+// drawOrderAnchor is a fixed anchor for the draw-count tests; its value is
+// irrelevant (these tests only compare PRNG draw positions, not timestamps).
+var drawOrderAnchor = time.Date(2024, time.January, 2, 3, 4, 5, 0, time.UTC)
+
+// baseDrawOrderOpts is the option set a catalog slot carries MINUS the age option,
+// so the reference build differs from the option build only by that one option.
+func baseDrawOrderOpts() []ContactOption {
+	return []ContactOption{WithEmail(), WithCadence("weekly")}
+}
+
+// TestWithCreatedAge_DrawsZero proves WithCreatedAge adds NO generator draw over
+// the identical base build: the overdue catalog slots drew zero before this change
+// (the old WithOverdue used a fixed offset), so the shared-generator stream — and
+// every downstream replay's ids — stays byte-identical.
+func TestWithCreatedAge_DrawsZero(t *testing.T) {
+	t.Parallel()
+
+	gA := NewGeneratorAt(DefaultSeed, "draworder", drawOrderAnchor)
+	_ = gA.Contact(append(baseDrawOrderOpts(), WithCreatedAge(90*24*time.Hour))...)
+	withOption := gA.rng.Uint64()
+
+	gB := NewGeneratorAt(DefaultSeed, "draworder", drawOrderAnchor)
+	_ = gB.Contact(baseDrawOrderOpts()...)
+	withoutOption := gB.rng.Uint64()
+
+	if withOption != withoutOption {
+		t.Fatalf("WithCreatedAge changed the PRNG stream position: got next-raw %d with the option vs %d without it (expected equal — zero extra draws)", withOption, withoutOption)
+	}
+}
+
+// TestWithRecentCreation_DrawsOneRecentOffset proves WithRecentCreation's sole
+// extra draw is exactly one recentOffset — the same draw the deleted WithRecent
+// made at that stream position — so the shared-generator sequence is preserved.
+func TestWithRecentCreation_DrawsOneRecentOffset(t *testing.T) {
+	t.Parallel()
+
+	const window = 48 * time.Hour
+
+	gC := NewGeneratorAt(DefaultSeed, "draworder", drawOrderAnchor)
+	_ = gC.Contact(append(baseDrawOrderOpts(), WithRecentCreation(window))...)
+	withOption := gC.rng.Uint64()
+
+	gD := NewGeneratorAt(DefaultSeed, "draworder", drawOrderAnchor)
+	_ = gD.Contact(baseDrawOrderOpts()...)
+	gD.recentOffset(window) // the option's single extra draw
+	withoutOption := gD.rng.Uint64()
+
+	if withOption != withoutOption {
+		t.Fatalf("WithRecentCreation did not draw exactly one recentOffset: got next-raw %d with the option vs %d after one manual recentOffset (expected equal)", withOption, withoutOption)
+	}
+}

--- a/backend/internal/synthetic/profiles.go
+++ b/backend/internal/synthetic/profiles.go
@@ -849,7 +849,7 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 			return res, fmt.Errorf("profile %s: replay gcal for awaiting-reply contact: %w", params.Profile, err)
 		}
 		res.SettledInteractions++
-		if _, err := h.SeedPendingFollowUp(ctx, fuContact.ID); err != nil {
+		if _, err := h.SeedPendingFollowUp(ctx, fuContact.ID, fuContact.FullName); err != nil {
 			return res, fmt.Errorf("profile %s: seed pending follow-up: %w", params.Profile, err)
 		}
 		res.SeededTasks++
@@ -972,6 +972,15 @@ var catalogSignalKeys = []string{
 // relationship_signal rows so they are identifiable as toolkit-authored.
 const syntheticSignalMethodVersion = "synthetic-seed"
 
+// catalogOverdueAge backdates the overdue catalog cohort ~90 days before the
+// anchor (created_at == last_contacted), far enough that a sub-quarterly cadence
+// reads as overdue. catalogRecentWindow bounds the recently-created cohort within
+// the last ~48h. Both are anchor-relative.
+const (
+	catalogOverdueAge   = 90 * 24 * time.Hour
+	catalogRecentWindow = 48 * time.Hour
+)
+
 // catalogLocationStems is the small fixed pool the lives_in location rotates over
 // so locations repeat across contacts (prod-like) while staying deterministic. The
 // values are flat (no comma/hierarchy) so EnsurePlaceTx mints a flat place node
@@ -1004,19 +1013,20 @@ func catalogOptionsFor(i, n int, anchor time.Time, prefix string) []factory.Cont
 
 	// The no-method bucket: a cadence-bearing contact with NO contact_method.
 	if i == 3 && n > 3 {
-		opts = append(opts, factory.WithNoMethods(), factory.WithCadence("monthly"), factory.WithOverdue())
+		opts = append(opts, factory.WithNoMethods(), factory.WithCadence("monthly"), factory.WithCreatedAge(catalogOverdueAge))
 		return opts
 	}
 
 	opts = append(opts, factory.WithEmail())
 
-	// Cadence + recency spread: every third contact overdue, every third recent,
-	// the rest never-contacted (no LastContacted).
+	// Cadence + recency spread: every third contact created long ago (overdue with
+	// an honest empty timeline), every third created recently, the rest
+	// never-contacted (no last_contacted).
 	switch i % 3 {
 	case 0:
-		opts = append(opts, factory.WithCadence("monthly"), factory.WithOverdue())
+		opts = append(opts, factory.WithCadence("monthly"), factory.WithCreatedAge(catalogOverdueAge))
 	case 1:
-		opts = append(opts, factory.WithCadence("weekly"), factory.WithRecent())
+		opts = append(opts, factory.WithCadence("weekly"), factory.WithRecentCreation(catalogRecentWindow))
 	default:
 		// never-contacted: a cadence but no last_contacted.
 		opts = append(opts, factory.WithCadence("quarterly"))

--- a/backend/internal/synthetic/replay/replay.go
+++ b/backend/internal/synthetic/replay/replay.go
@@ -243,6 +243,7 @@ func (h *Harness) SeedContact(ctx context.Context, spec factory.ContactSpec) (*r
 	contact, _, err := h.contactService.CreateContact(ctx, repository.CreateContactRequest{
 		FullName:      spec.FullName,
 		Cadence:       spec.Cadence,
+		CreatedAt:     spec.CreatedAt,
 		LastContacted: spec.LastContacted,
 		Birthday:      spec.Birthday,
 		Location:      spec.Location,

--- a/backend/internal/synthetic/replay/todoist.go
+++ b/backend/internal/synthetic/replay/todoist.go
@@ -3,6 +3,7 @@ package replay
 import (
 	"context"
 	"fmt"
+	"math/big"
 	"time"
 
 	"personal-crm/backend/internal/accelerated"
@@ -19,6 +20,17 @@ import (
 // cadence-scaled window from the outbound — CAD-011). Read off the accelerated
 // clock, never the wall clock.
 const followUpSeedWindow = 3 * 24 * time.Hour
+
+// Synthetic follow-up shape constants mirror what FollowUpManager.applyCreate
+// writes in production (content link, marker instance, project/label metadata).
+// syntheticIntegrationInstanceID is shared by the marker's Instance and the
+// integration_instance_id metadata key so they agree, exactly as prod does.
+const (
+	syntheticFrontendBase          = "https://synthetic.local"
+	syntheticIntegrationInstanceID = "synthetic-todoist-instance"
+	syntheticFollowUpProjectID     = "synthetic-followup-project"
+	syntheticFollowUpLabelName     = "synthetic-followup-label"
+)
 
 // TodoistResult is the settled outcome of a Todoist replay.
 type TodoistResult struct {
@@ -228,20 +240,49 @@ func (h *Harness) TransitionTodoistCadenceTaskState(ctx context.Context, contact
 // worker (and is its sole writer — CAD-005, CI-guarded), so it is still nil at seed
 // time. The caller establishes the chain by construction (see the awaiting-reply
 // scenario in profiles.go), and the profile coverage check proves it post-Quiesce.
-func (h *Harness) SeedPendingFollowUp(ctx context.Context, contactID uuid.UUID) (uuid.UUID, error) {
+func (h *Harness) SeedPendingFollowUp(ctx context.Context, contactID uuid.UUID, fullName string) (uuid.UUID, error) {
 	taskRepo := repository.NewContactTaskRepository(h.database.Queries)
 	deadline := accelerated.GetCurrentTime().Add(followUpSeedWindow)
-	task, err := taskRepo.CreateContactTask(ctx, repository.CreateContactTaskRequest{
-		ContactID: contactID,
-		Provider:  todoist.SourceName,
+
+	content := fmt.Sprintf("Follow up: [%s](%s/contacts/%s) (awaiting reply)", fullName, syntheticFrontendBase, contactID)
+	markerJSON, err := contacttask.EncodeMarker(contacttask.CRMMarker{
+		ContactID: contactID.String(),
 		Kind:      contacttask.KindReachOut,
 		Lifecycle: contacttask.LifecycleFollowUpLoop,
-		State:     string(repository.ContactTaskStateManaged),
-		Metadata:  map[string]any{"due_date": deadline.Format(todoist.DateFormat)},
+		Instance:  syntheticIntegrationInstanceID,
+	})
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("encode follow-up marker for contact %s: %w", contactID, err)
+	}
+
+	task, err := taskRepo.CreateContactTask(ctx, repository.CreateContactTaskRequest{
+		ContactID:      contactID,
+		Provider:       todoist.SourceName,
+		Kind:           contacttask.KindReachOut,
+		Lifecycle:      contacttask.LifecycleFollowUpLoop,
+		ExternalTaskID: externalTaskIDForContact(contactID),
+		State:          string(repository.ContactTaskStateManaged),
+		Metadata: map[string]any{
+			"due_date":                deadline.Format(todoist.DateFormat),
+			"content":                 content,
+			"marker_json":             string(markerJSON),
+			"project_id":              syntheticFollowUpProjectID,
+			"label_name":              syntheticFollowUpLabelName,
+			"integration_instance_id": syntheticIntegrationInstanceID,
+		},
 	})
 	if err != nil {
 		return uuid.Nil, fmt.Errorf("seed pending follow-up for contact %s: %w", contactID, err)
 	}
 	h.track(func(c *created) { c.addContactTask(task.ID) })
 	return task.ID, nil
+}
+
+// externalTaskIDForContact derives a stable, alphanumeric external id from the
+// contact's UUID via base62 (digits 0-9a-zA-Z). This matches the Todoist-v1 id
+// shape (alphanumeric strings, not UUIDs) and is unique per contact, so it never
+// collides on the global partial-unique follow-up index.
+func externalTaskIDForContact(contactID uuid.UUID) string {
+	id := contactID
+	return new(big.Int).SetBytes(id[:]).Text(62)
 }

--- a/backend/tests/synthetic_factory_test.go
+++ b/backend/tests/synthetic_factory_test.go
@@ -148,10 +148,23 @@ func TestSyntheticFactory_EdgeCaseOptions(t *testing.T) {
 	uni := g.Contact(factory.WithUnicodeName())
 	assert.True(t, strings.ContainsAny(uni.FullName, "Ünïcödé"), "unicode name should carry non-ASCII")
 
-	// Overdue contact has a past last_contacted.
-	od := g.Contact(factory.WithEmail(), factory.WithCadence("weekly"), factory.WithOverdue())
+	// Backdated (created-long-ago) contact: created_at and last_contacted are both
+	// stamped to the same past instant (anchor − age).
+	const age = 90 * 24 * time.Hour
+	od := g.Contact(factory.WithEmail(), factory.WithCadence("weekly"), factory.WithCreatedAge(age))
+	require.NotNil(t, od.CreatedAt)
 	require.NotNil(t, od.LastContacted)
-	assert.True(t, od.LastContacted.Before(fixedAnchor))
+	assert.Equal(t, *od.CreatedAt, *od.LastContacted, "created_at and last_contacted must be identical")
+	assert.Equal(t, fixedAnchor.Add(-age), *od.CreatedAt, "backdated instant must be anchor − age")
+
+	// Recently-created contact: both columns set, equal, and within the window.
+	const window = 48 * time.Hour
+	rc := g.Contact(factory.WithEmail(), factory.WithCadence("weekly"), factory.WithRecentCreation(window))
+	require.NotNil(t, rc.CreatedAt)
+	require.NotNil(t, rc.LastContacted)
+	assert.Equal(t, *rc.CreatedAt, *rc.LastContacted, "created_at and last_contacted must be identical")
+	assert.False(t, rc.CreatedAt.After(fixedAnchor), "recent creation must not be after the anchor")
+	assert.False(t, rc.CreatedAt.Before(fixedAnchor.Add(-window)), "recent creation must be within the window")
 }
 
 func TestSyntheticFactory_MatchIntentAddressesDistinctIdentifiers(t *testing.T) {

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"encoding/json"
 	"regexp"
 	"strconv"
 	"strings"
@@ -9,6 +10,8 @@ import (
 	"time"
 
 	"personal-crm/backend/internal/accelerated"
+	"personal-crm/backend/internal/cadence"
+	"personal-crm/backend/internal/contacttask"
 	"personal-crm/backend/internal/repository"
 	"personal-crm/backend/internal/synthetic"
 	"personal-crm/backend/internal/synthetic/factory"
@@ -81,6 +84,130 @@ func TestSyntheticProfile_MinimalScopedMatchesSeedAll(t *testing.T) {
 // TestSyntheticProfile_DevCoversCatalog asserts the dev profile produces the
 // producible edge-case + pending coverage. Counts are scoped to the harness's
 // namespace.
+// assertSeedCoherence runs the post-seed coherence gate over one namespace: no
+// production-impossible last_contacted (gate a), a non-vacuous interaction-moved
+// cohort (gate a-positive), prod-shaped managed follow-ups (gate c) whose marker
+// decodes and points at the seeded contact (gate c-Go), a cause-driven overdue
+// cohort computed via the production cadence helper (env-robust), and the CAD-029
+// tour capacity (four distinct assignable contacts). Called by both coverage tests.
+func assertSeedCoherence(t *testing.T, ctx context.Context, support *repository.SyntheticSupportRepository, prefix string) {
+	t.Helper()
+	now := accelerated.GetCurrentTime()
+
+	// Gate (a): zero production-impossible last_contacted (a non-creation, non-null
+	// last_contacted must be backed by a live inbound/mutual interaction at the same
+	// occurred_at, with last_interaction_at in lockstep).
+	incoherent, err := support.IncoherentLastContactedCountByNamePrefix(ctx, prefix)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), incoherent, "no contact may carry a moved last_contacted without a backing interaction + lockstep last_interaction_at")
+
+	// Gate (a-positive): the interaction-moved cohort exists (proves gate a is not
+	// vacuous) and sets last_interaction_at in lockstep.
+	backed, err := support.InteractionBackedLastContactedCountByNamePrefix(ctx, prefix)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, backed, int64(1), "≥1 contact whose last_contacted is backed by an inbound/mutual interaction with lockstep last_interaction_at")
+
+	// Gate (c): managed follow-ups carry the production Todoist shape.
+	incoherentFU, err := support.IncoherentManagedFollowUpCountByNamePrefix(ctx, prefix)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), incoherentFU, "every managed follow-up loop must carry an alphanumeric external id + prod metadata + content/marker shape")
+
+	// Gate (c-Go): the follow-up's marker decodes and references its own contact.
+	fu, err := support.GetLiveFollowUpByNamePrefix(ctx, prefix)
+	require.NoError(t, err)
+	var meta map[string]any
+	require.NoError(t, json.Unmarshal(fu.Metadata, &meta))
+	markerJSON, _ := meta["marker_json"].(string)
+	marker, ok := contacttask.DecodeMarker(markerJSON)
+	require.True(t, ok, "follow-up marker_json must decode")
+	require.Equal(t, fu.ContactID.String(), marker.ContactID, "marker must reference the follow-up's own contact")
+	require.Equal(t, contacttask.KindReachOut, marker.Kind)
+	require.Equal(t, contacttask.LifecycleFollowUpLoop, marker.Lifecycle)
+	instanceID, _ := meta["integration_instance_id"].(string)
+	require.NotEmpty(t, marker.Instance, "marker instance must be non-empty")
+	require.Equal(t, instanceID, marker.Instance, "marker instance must agree with integration_instance_id metadata")
+	content, _ := meta["content"].(string)
+	require.Contains(t, content, "/contacts/"+fu.ContactID.String(), "follow-up content must link the contact")
+
+	// Cause-driven overdue cohort + the D1 verification, computed from the bucket
+	// rows via the production cadence helper (env-robust: it does not matter whether
+	// the harness runs with time acceleration on).
+	buckets, err := support.ListContactBucketsByNamePrefix(ctx, prefix)
+	require.NoError(t, err)
+	overdueFloor := now.Add(-14 * 24 * time.Hour)
+	var overdueByHelper, backdatedOverdue int
+	for _, b := range buckets {
+		if b.Cadence == nil || *b.Cadence == "" || b.CreatedAt == nil {
+			continue
+		}
+		cadenceType, perr := cadence.ParseCadence(*b.Cadence)
+		if perr != nil {
+			continue
+		}
+		if cadence.IsOverdueWithConfig(cadenceType, b.LastContacted, *b.CreatedAt, now) {
+			overdueByHelper++
+		}
+		// D1: a backdated (created-long-ago) contact is overdue with an honest empty
+		// timeline — created_at far in the past, last_contacted == created_at (the
+		// creation stamp), and a computed contact_by already elapsed.
+		if b.LastContacted != nil && b.LastContacted.Equal(*b.CreatedAt) &&
+			b.CreatedAt.Before(overdueFloor) &&
+			b.ContactBy != nil && b.ContactBy.Before(now) {
+			backdatedOverdue++
+		}
+	}
+	require.GreaterOrEqual(t, overdueByHelper, 1, "≥1 overdue contact via the production cadence helper")
+	require.GreaterOrEqual(t, backdatedOverdue, 1, "≥1 backdated overdue contact (far-past created_at == last_contacted, contact_by elapsed)")
+
+	// Tour capacity (CAD-029): the world must contain FOUR DISTINCT contacts
+	// assignable to the outreach / response / pending / none states — the precondition
+	// for cadence-followup.tour.ts. Proven via a maximum bipartite matching that must
+	// saturate all four states.
+	flags, err := support.ListCadenceActivityFlagsByNamePrefix(ctx, prefix)
+	require.NoError(t, err)
+	require.Equal(t, 4, maxDistinctStateAssignment(flags), "four CAD-029 states must be assignable to four distinct contacts")
+}
+
+// maxDistinctStateAssignment returns the size of a maximum matching between the
+// four CAD-029 states (outreach, response, pending, none) and the given contacts,
+// where a state may be assigned to any contact carrying that flag and each contact
+// covers at most one state. Standard augmenting-path (Kuhn's) search — trivial at
+// this scale.
+func maxDistinctStateAssignment(flags []repository.CadenceActivityFlags) int {
+	// state index → the flag each state requires on a contact.
+	stateHas := []func(repository.CadenceActivityFlags) bool{
+		func(f repository.CadenceActivityFlags) bool { return f.HasOutreach },
+		func(f repository.CadenceActivityFlags) bool { return f.HasResponse },
+		func(f repository.CadenceActivityFlags) bool { return f.HasPending },
+		func(f repository.CadenceActivityFlags) bool { return f.HasNone },
+	}
+	contactToState := make([]int, len(flags))
+	for i := range contactToState {
+		contactToState[i] = -1
+	}
+	var augment func(state int, seen []bool) bool
+	augment = func(state int, seen []bool) bool {
+		for ci, f := range flags {
+			if !stateHas[state](f) || seen[ci] {
+				continue
+			}
+			seen[ci] = true
+			if contactToState[ci] == -1 || augment(contactToState[ci], seen) {
+				contactToState[ci] = state
+				return true
+			}
+		}
+		return false
+	}
+	matched := 0
+	for s := 0; s < len(stateHas); s++ {
+		if augment(s, make([]bool, len(flags))) {
+			matched++
+		}
+	}
+	return matched
+}
+
 func TestSyntheticProfile_DevCoversCatalog(t *testing.T) {
 	testsupport.RequireLongTests(t)
 	database, ctx := newSyntheticDB(t)
@@ -157,6 +284,10 @@ func TestSyntheticProfile_DevCoversCatalog(t *testing.T) {
 	remaining, err := h.ContactsRemaining(ctx)
 	require.NoError(t, err)
 	require.Greater(t, remaining, int64(0), "dev profile seeds catalog contacts")
+
+	// Post-seed coherence gate (F1/F3 + tour capacity), scoped to the namespace.
+	support := repository.NewSyntheticSupportRepository(database.Queries)
+	assertSeedCoherence(t, ctx, support, h.Generator().Prefix())
 }
 
 // TestSyntheticProfile_ProdShapedCoverageCheck is the load-bearing coverage
@@ -251,11 +382,11 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 	buckets, err := support.ListContactBucketsByNamePrefix(ctx, h.Generator().Prefix())
 	require.NoError(t, err)
 
-	// "Overdue" must mean a last_contacted WELL in the past (WithOverdue seeds
-	// ~90 days ago), NOT merely before now — a recent contact (WithRecent seeds
-	// <48h ago) is also before now. Using a 14-day-ago floor distinguishes the
-	// overdue bucket from the recent bucket, so a clobber-to-recent regression
-	// (the bug this guards) would FAIL here.
+	// "Overdue" must mean a last_contacted WELL in the past (the backdated cohort
+	// is created ~90 days ago, stamping last_contacted == created_at), NOT merely
+	// before now — a recently-created contact (<48h ago) is also before now. Using a
+	// 14-day-ago floor distinguishes the overdue bucket from the recent bucket, so a
+	// clobber-to-recent regression (the bug this guards) would FAIL here.
 	var overdue, neverContacted, noMethod int
 	now := accelerated.GetCurrentTime()
 	overdueFloor := now.Add(-14 * 24 * time.Hour)
@@ -275,6 +406,9 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 	require.GreaterOrEqual(t, overdue, 1, "≥1 cadence-bearing contact with a far-past last_contacted (overdue bucket survived a settling replay)")
 	require.GreaterOrEqual(t, neverContacted, 1, "≥1 cadence-bearing never-contacted contact (NULL last_contacted survived)")
 	require.GreaterOrEqual(t, noMethod, 1, "≥1 no-method contact (the no-method bucket exists)")
+
+	// Post-seed coherence gate (F1/F3 + tour capacity), scoped to the namespace.
+	assertSeedCoherence(t, ctx, support, h.Generator().Prefix())
 
 	// Bio facts (how_met, location, real-year birthdays) ride on the contact-create
 	// authority flip; the catalog carries ≥1 of each. A location additionally mints


### PR DESCRIPTION
Implements findings **F1** and **F3** of the synthetic-seed fidelity audit (`.ai/spec/2026-07-13-synthetic-seed-fidelity-audit.md`, committed here) — the seed wrote derived cadence state production cannot produce, which made the QA judge report confident false regressions.

## What changed

- **`WithOverdue`/`WithRecent` deleted** — they wrote `spec.LastContacted` raw (production forces creation-time; 111/114 staging contacts had `last_contacted < created_at`, 95/114 with no backing interaction). Replaced with cause-driven shapes:
  - `WithCreatedAge` — the overdue cohort is now contacts **created long ago** (backdated `created_at` through the seed path), so creation-time `last_contacted` is old and coherent by construction.
  - `WithRecentCreation` — draw-preserving replacement for the recent cohort (consumes the same single PRNG draw the deleted option did, keeping the shared generator stream byte-identical — verified by the determinism suite and a new white-box draw-order test).
- **F3: `SeedPendingFollowUp` now writes the production row shape** — full metadata (`content`, `marker_json`, `project_id`, `label_name`, `integration_instance_id`) + a synthetic alphanumeric external id, so the "awaiting reply" task renders as production would (was: literal "Untitled task" + dead `todoist://` link).
- **Post-seed coherence gate** in both profile coverage tests, via test-only sqlc queries (namespace-scoped): asserts the *causal* invariants — a moved `last_contacted` must be backed by a live inbound/mutual interaction with `last_interaction_at` in lockstep (merge-exempt), managed follow-ups carry non-empty external id + required metadata. Deliberately NOT `last_contacted >= created_at`: backdated manual interactions and import-created NULL `last_contacted` are production-legal.
- Overdue/tour-state proxies assert via the production `cadence.IsOverdueWithConfig` helper (env-robust across cadence scales) and a maximum-bipartite-matching capacity check guarantees the four CAD-029 activity states the tours select on.
- Makefile `test-unit` now includes `./internal/synthetic/factory/...` (the draw-order guard was in an unenumerated package).

## Verification

Full synthetic profile+replay suite incl. determinism green; both coverage tests green with the gate active; plan and implementation each passed independent Codex review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETUbFQwweNKprCDdv8aTUs