### PR TITLE
fix(cadence): staging env runs production cadence semantics

### DIFF
--- a/.ai/guides/feature-development.md
+++ b/.ai/guides/feature-development.md
@@ -511,7 +511,7 @@ See [`.ai/patterns/frontend.md`](../patterns/frontend.md) for full form, mutatio
 .env                      # Active environment (gitignored)
 .env.example              # Template with all variables
 .env.example.production   # Real-world timing
-.env.example.staging      # Fast cadences (hours)
+.env.example.staging      # Production cadence durations (QA world; CRM_ENV=accelerated for hour-scale)
 .env.example.testing      # Ultra-fast (minutes)
 ```
 

--- a/.ai/guides/feature-development.md
+++ b/.ai/guides/feature-development.md
@@ -511,7 +511,8 @@ See [`.ai/patterns/frontend.md`](../patterns/frontend.md) for full form, mutatio
 .env                      # Active environment (gitignored)
 .env.example              # Template with all variables
 .env.example.production   # Real-world timing
-.env.example.staging      # Production cadence durations (QA world; CRM_ENV=accelerated for hour-scale)
+.env.example.staging      # Production cadence durations (staging QA world)
+.env.example.accelerated  # Fast cadences (hours) — make test-cadence-fast
 .env.example.testing      # Ultra-fast (minutes)
 ```
 

--- a/.env.example.accelerated
+++ b/.env.example.accelerated
@@ -1,0 +1,94 @@
+# Accelerated Environment - compressed cadences (months in hours) for local validation
+# Copy this file to .env via `make accelerated`; used by `make test-cadence-fast`
+
+# ===========================================
+# DATABASE CONFIGURATION
+# ===========================================
+DATABASE_URL=postgres://crm_user:crm_password@localhost:5432/crm_staging?sslmode=disable
+
+# Docker Compose database settings
+POSTGRES_DB=crm_staging
+POSTGRES_USER=crm_user
+POSTGRES_PASSWORD=crm_password
+POSTGRES_PORT=5432
+
+# ===========================================
+# API SERVER CONFIGURATION
+# ===========================================
+# NOTE: For systemd deployment, PORT is defined in service files
+# For local staging (make dev), add PORT=8080 if needed
+NODE_ENV=staging
+GIN_MODE=debug
+
+# ===========================================
+# CRM ENVIRONMENT
+# ===========================================
+CRM_ENV=accelerated
+
+# ===========================================
+# AUTHENTICATION & SESSION
+# ===========================================
+# Can use dev values for staging, or generate test secrets
+SESSION_SECRET=dev-session-secret-change-in-production-12345
+API_KEY=dev-api-key-change-in-production
+
+# ===========================================
+# AI & EMBEDDINGS
+# ===========================================
+# Get your API key from https://console.anthropic.com/
+ANTHROPIC_API_KEY=your-anthropic-api-key-here
+
+# ===========================================
+# TELEGRAM SYNC (OPTIONAL)
+# ===========================================
+# Get API credentials from https://my.telegram.org/apps
+# TELEGRAM_API_ID=your-api-id-here
+# TELEGRAM_API_HASH=your-api-hash-here
+
+# ===========================================
+# BACKUP CONFIGURATION
+# ===========================================
+BACKUP_PATH=/path/to/your/backup/directory
+HOME_SERVER_HOST=your-home-server.local
+HOME_SERVER_USER=backup-user
+
+# ===========================================
+# STAGING SETTINGS
+# ===========================================
+# Log level: info for staging (moderate verbosity)
+LOG_LEVEL=info
+
+# Set to 'false' to enable debug logging (deprecated, use LOG_LEVEL instead)
+DEBUG=false
+
+# CORS: Can allow all for staging testing
+CORS_ALLOW_ALL=true
+
+# Frontend URL for CORS configuration
+FRONTEND_URL=http://localhost:3000
+
+# ===========================================
+# SCHEDULER CONFIGURATION
+# ===========================================
+SCHEDULER_ENABLED=true
+SCHEDULER_CRON="*/5m"  # Reminder scheduler: every 5 minutes for staging (external sync scheduler always runs every hour)
+
+# ===========================================
+# FEATURE FLAGS
+# ===========================================
+# Enable experimental features for testing
+ENABLE_VECTOR_SEARCH=false
+ENABLE_TELEGRAM_SYNC=false
+ENABLE_CALENDAR_SYNC=false
+
+# Frontend feature flags (must match backend settings)
+
+# ===========================================
+# REMINDER CADENCES
+# ===========================================
+# Accelerated timing (handled in code based on CRM_ENV):
+# - Weekly cadence: 10 minutes (test 1 week in 10 minutes)
+# - Monthly cadence: 1 hour (test 1 month in 1 hour)
+# - Quarterly cadence: 3 hours (test 1 quarter in 3 hours)
+# - Biannual cadence: 6 hours
+# - Annual cadence: 12 hours

--- a/.env.example.staging
+++ b/.env.example.staging
@@ -1,5 +1,6 @@
-# Staging Environment - Accelerated cadences for rapid validation
+# Staging Environment - production cadence durations over a seeded QA world
 # Copy this file to .env for staging testing
+# (For compressed cadences — months in hours — use CRM_ENV=accelerated instead.)
 
 # ===========================================
 # DATABASE CONFIGURATION
@@ -86,9 +87,8 @@ ENABLE_CALENDAR_SYNC=false
 # ===========================================
 # REMINDER CADENCES
 # ===========================================
-# Staging uses accelerated timing (handled in code based on CRM_ENV):
-# - Weekly cadence: 10 minutes (test 1 week in 10 minutes)
-# - Monthly cadence: 1 hour (test 1 month in 1 hour)
-# - Quarterly cadence: 3 hours (test 1 quarter in 3 hours)
-# - Biannual cadence: 6 hours
-# - Annual cadence: 12 hours
+# Staging uses PRODUCTION cadence durations (handled in code based on CRM_ENV):
+# overdue/due states come from the seeded world's time-shape, not compressed
+# clocks, so rendered dates agree with duration semantics for QA judging.
+# CRM_ENV=accelerated selects the compressed scale (weekly=10min, monthly=1h,
+# quarterly=3h, biannual=6h, annual=12h) for throwaway preview environments.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Personal CRM Makefile
 
-.PHONY: help setup dev dev-seed staging-reset tours build crm-admin mac-daemon test test-daemon-local clean docker-up docker-down docker-reset test-cadence-ultra test-cadence-fast qa-eval qa-report prod staging testing start start-local stop restart reload status dev-stop dev-restart dev-api-stop dev-api-start dev-api-restart ci-build-backend ci-build-frontend ci-build ci-test test-e2e test-e2e-local test-e2e-diff e2e-db deploy-mac promote setup-pi setup-mac-deploy dev-native postgres-native sqlc smoke-test test-deploy-scripts worktree-env worktree-deps test-integration-fast test-integration-slow test-clean-clones worktree-test-pg-ensure test-pg-stop test-pg-teardown test-pg-reap test-pg-smoke check-cadence-sole-writer check-followup-sole-writer check-rematch-sole-dispatcher check-crm-marker-construction check-sqlc-select-lists lint-ingest-registry spec-lint api-types api-types-check
+.PHONY: help setup dev dev-seed staging-reset tours build crm-admin mac-daemon test test-daemon-local clean docker-up docker-down docker-reset test-cadence-ultra test-cadence-fast qa-eval qa-report prod staging accelerated testing start start-local stop restart reload status dev-stop dev-restart dev-api-stop dev-api-start dev-api-restart ci-build-backend ci-build-frontend ci-build ci-test test-e2e test-e2e-local test-e2e-diff e2e-db deploy-mac promote setup-pi setup-mac-deploy dev-native postgres-native sqlc smoke-test test-deploy-scripts worktree-env worktree-deps test-integration-fast test-integration-slow test-clean-clones worktree-test-pg-ensure test-pg-stop test-pg-teardown test-pg-reap test-pg-smoke check-cadence-sole-writer check-followup-sole-writer check-rematch-sole-dispatcher check-crm-marker-construction check-sqlc-select-lists lint-ingest-registry spec-lint api-types api-types-check
 
 # Repo root (supports running make from subdirectories).
 REPO_ROOT := $(shell git rev-parse --show-toplevel)
@@ -114,7 +114,7 @@ help:
 	@echo ""
 	@echo "Environment Management:"
 	@echo "  testing     - Switch to testing environment (ultra-fast cadences)"
-	@echo "  staging     - Switch to staging environment (fast cadences)" 
+	@echo "  staging     - Switch to staging environment (production cadence durations)" 
 	@echo "  prod        - Switch to production environment (real cadences)"
 	@echo ""
 	@echo "Development:"
@@ -160,7 +160,7 @@ help:
 	@echo ""
 	@echo "Cadence Testing:"
 	@echo "  test-cadence-ultra - Test all cadences in minutes (testing env)"
-	@echo "  test-cadence-fast  - Test all cadences in hours (staging env)"
+	@echo "  test-cadence-fast  - Test all cadences in hours (accelerated env)"
 	@echo ""
 	@echo "Deployment:"
 	@echo "  setup-pi         - One-time Pi setup (create user, directories)"
@@ -681,9 +681,21 @@ testing:
 	@echo "Use 'make test-cadence-ultra' to validate all cadences quickly"
 
 staging:
-	@echo "Switching to STAGING environment (fast cadences)..."
+	@echo "Switching to STAGING environment (production cadence durations)..."
 	@cp .env.example.staging .env
 	@echo "✅ Staging environment active:"
+	@echo "   - Weekly cadence: 7 days"
+	@echo "   - Monthly cadence: 30 days"
+	@echo "   - Quarterly cadence: 90 days"
+	@echo "   - Reminder scheduler: every 5 minutes"
+	@echo "   - External sync scheduler: every hour"
+	@echo ""
+	@echo "Use 'make accelerated' + 'make test-cadence-fast' for hour-scale cadences"
+
+accelerated:
+	@echo "Switching to ACCELERATED environment (fast cadences)..."
+	@cp .env.example.accelerated .env
+	@echo "✅ Accelerated environment active:"
 	@echo "   - Weekly cadence: 10 minutes (1 week = 10 min)"
 	@echo "   - Monthly cadence: 1 hour (1 month = 1 hour)"
 	@echo "   - Quarterly cadence: 3 hours (1 quarter = 3 hours)"
@@ -731,12 +743,12 @@ test-cadence-fast:
 	@echo "🏎️  Starting FAST cadence testing..."
 	@echo "This will test all reminder cadences in hours!"
 	@echo ""
-	@make staging
+	@make accelerated
 	@make docker-up
 	@bash scripts/sync-postgres-auth.sh
 	@make logs
 	@echo "Starting backend with fast cadences..."
-	@set -a && source ./.env && set +a && export DATABASE_URL="postgres://$${POSTGRES_USER}:$${POSTGRES_PASSWORD}@localhost:$${POSTGRES_PORT:-5432}/$${POSTGRES_DB}?sslmode=disable" && cd backend && nohup go run ./cmd/crm-api > ../logs/backend-staging.log 2>&1 & echo $$! > ../logs/backend-staging.pid && cd ../.. && bash -c "disown %1" 2>/dev/null || true
+	@set -a && source ./.env && set +a && export DATABASE_URL="postgres://$${POSTGRES_USER}:$${POSTGRES_PASSWORD}@localhost:$${POSTGRES_PORT:-5432}/$${POSTGRES_DB}?sslmode=disable" && cd backend && nohup go run ./cmd/crm-api > ../logs/backend-accelerated.log 2>&1 & echo $$! > ../logs/backend-accelerated.pid && cd ../.. && bash -c "disown %1" 2>/dev/null || true
 	@echo ""
 	@echo "⏱️  CADENCE TIMING (fast):"
 	@echo "   - Weekly: 10 minutes (1 week = 10 min)"
@@ -745,7 +757,7 @@ test-cadence-fast:
 	@echo "   - Reminder scheduler: every 5 minutes"
 	@echo "   - External sync scheduler: every hour"
 	@echo ""
-	@echo "📋 Logs: logs/backend-staging.log"
+	@echo "📋 Logs: logs/backend-accelerated.log"
 	@echo "💡 Perfect for validating 3+ months of cadence behavior in 3 hours!"
 	@echo "💡 Process will continue running after you close this terminal"
 

--- a/backend/internal/cadence/cadence_config.go
+++ b/backend/internal/cadence/cadence_config.go
@@ -31,8 +31,12 @@ func GetCadenceConfig() CadenceConfig {
 			Biannual:  1 * time.Hour,    // Test biannual every hour
 			Annual:    2 * time.Hour,    // Test annual every 2 hours
 		}
-	case "staging", "accelerated":
-		// Fast staging: validate months in hours
+	case "accelerated":
+		// Compressed-time preview environments: validate months in hours.
+		// CRM_ENV=staging deliberately does NOT take this branch: the
+		// persistent staging environment hosts a prod-shaped QA world whose
+		// rendered dates must agree with production duration semantics, so
+		// staging falls through to the production cadences below.
 		return CadenceConfig{
 			Weekly:    10 * time.Minute, // 10 minutes = 1 week (test week in 10min)
 			Biweekly:  20 * time.Minute, // 20 minutes = 2 weeks
@@ -41,8 +45,9 @@ func GetCadenceConfig() CadenceConfig {
 			Biannual:  6 * time.Hour,    // 6 hours = 6 months
 			Annual:    12 * time.Hour,   // 12 hours = 1 year
 		}
-	case "production", "prod", "":
-		// Production: real-world cadences
+	case "staging", "production", "prod", "":
+		// Production semantics: real-world cadences. Staging shares them —
+		// its QA world is prod-shaped by construction, not by compressed time.
 		return CadenceConfig{
 			Weekly:    7 * 24 * time.Hour,   // 1 week
 			Biweekly:  14 * 24 * time.Hour,  // 2 weeks
@@ -141,20 +146,22 @@ func GetOverdueDaysWithConfig(cadenceType CadenceType, lastContacted *time.Time,
 		return int(overdueTime / (24 * time.Hour))
 	}
 
-	// When acceleration is OFF but in testing/staging env, use scaled days
-	// This allows testing "X days overdue" scenarios in minutes without acceleration
+	// When acceleration is OFF but in a compressed-cadence env, use scaled days
+	// This allows testing "X days overdue" scenarios in minutes without acceleration.
+	// CRM_ENV=staging is NOT scaled: it runs production cadences (see
+	// GetCadenceConfig), so its overdue days are real days.
 	env := os.Getenv("CRM_ENV")
 	switch env {
 	case "test", "testing":
 		// In test mode, 1 "day" = 2 minutes (weekly cadence / 7)
 		scaledDay := 2 * time.Minute / 7
 		return int(overdueTime / scaledDay)
-	case "staging", "accelerated":
-		// In staging mode, 1 "day" = 10 minutes / 7
+	case "accelerated":
+		// In accelerated mode, 1 "day" = 10 minutes / 7
 		scaledDay := 10 * time.Minute / 7
 		return int(overdueTime / scaledDay)
 	default:
-		// Production: normal days
+		// Production and staging: normal days
 		return int(overdueTime / (24 * time.Hour))
 	}
 }

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -73,7 +73,7 @@ type FeatureFlags struct {
 
 // RuntimeConfig holds runtime-only settings (not validated at startup)
 type RuntimeConfig struct {
-	CRMEnvironment   string // production|staging|test|accelerated (affects cadence)
+	CRMEnvironment   string // production|staging|test|accelerated (staging shares production cadence durations; test/accelerated run compressed cadences)
 	TimeAcceleration int    // Default: 1 (no acceleration)
 	TimeBase         string // RFC3339 timestamp for acceleration base
 }

--- a/backend/tests/unit/cadence_test.go
+++ b/backend/tests/unit/cadence_test.go
@@ -332,9 +332,9 @@ func TestGetCadenceConfig(t *testing.T) {
 			checkWeekly: 2 * time.Minute,
 		},
 		{
-			name:        "Staging environment",
+			name:        "Staging environment shares production durations",
 			envValue:    "staging",
-			checkWeekly: 10 * time.Minute,
+			checkWeekly: 7 * 24 * time.Hour,
 		},
 		{
 			name:        "Accelerated environment",
@@ -447,13 +447,31 @@ func TestIsOverdueWithConfig(t *testing.T) {
 			expected:    true,
 		},
 		{
-			name:        "Staging - monthly not overdue (1 hour cadence)",
+			name:        "Accelerated - monthly not overdue (1 hour cadence)",
+			env:         "accelerated",
+			cadence:     cadence.CadenceMonthly,
+			lastContact: timePtr(time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)),
+			created:     time.Date(2023, 12, 1, 12, 0, 0, 0, time.UTC),
+			checkTime:   time.Date(2024, 1, 1, 12, 30, 0, 0, time.UTC), // 30 minutes later
+			expected:    false,
+		},
+		{
+			name:        "Staging - monthly not overdue 30 minutes later (production durations)",
 			env:         "staging",
 			cadence:     cadence.CadenceMonthly,
 			lastContact: timePtr(time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)),
 			created:     time.Date(2023, 12, 1, 12, 0, 0, 0, time.UTC),
 			checkTime:   time.Date(2024, 1, 1, 12, 30, 0, 0, time.UTC), // 30 minutes later
 			expected:    false,
+		},
+		{
+			name:        "Staging - monthly overdue 31 days later (production durations)",
+			env:         "staging",
+			cadence:     cadence.CadenceMonthly,
+			lastContact: timePtr(time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)),
+			created:     time.Date(2023, 12, 1, 12, 0, 0, 0, time.UTC),
+			checkTime:   time.Date(2024, 2, 1, 12, 0, 0, 0, time.UTC), // 31 days later
+			expected:    true,
 		},
 	}
 
@@ -495,6 +513,15 @@ func TestGetOverdueDaysWithConfig(t *testing.T) {
 			created:      time.Date(2023, 12, 1, 12, 0, 0, 0, time.UTC),
 			checkTime:    time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC), // Due Jan 17, now Jan 15
 			expectedDays: 0,
+		},
+		{
+			name:         "Staging - 7 real days overdue (no scaled days)",
+			env:          "staging",
+			cadence:      cadence.CadenceWeekly,
+			lastContact:  timePtr(time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)),
+			created:      time.Date(2023, 12, 1, 12, 0, 0, 0, time.UTC),
+			checkTime:    time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC), // Due Jan 8, now Jan 15
+			expectedDays: 7,
 		},
 	}
 


### PR DESCRIPTION
Implements finding **F2** of the synthetic-seed fidelity audit (`.ai/spec/2026-07-13-synthetic-seed-fidelity-audit.md`, merged in #643).

`CRM_ENV=staging` previously selected the hour-scale cadence branch (monthly = 1 hour) and a scaled overdue-day unit (10min/7) — built for compressed-time preview environments before the persistent staging box existed. The staging QA world is prod-shaped **by construction** (seeded history provides the overdue/due states), so compressed durations made every rendered date disagree with duration semantics: 149/149 seeded contacts had `contact_by` collapsed onto `last_contacted`'s date, and displayed overdue-days were inflated ~1000×. An LLM judge cannot be calibrated to a world where dates and durations disagree by three orders of magnitude.

## What changed

- `GetCadenceConfig`: `staging` moved out of the hour-scale case into the production-durations case; `accelerated` keeps hour-scale for future compressed-time environments.
- `GetOverdueDaysWithConfig`: same split — staging counts real days.
- Test coverage: staging asserts production durations + real overdue days; the hour-scale branch keeps coverage via `accelerated`.
- `.env.example.staging` + guide comments updated to match.

The staging host needs no `.env` change — redeploy + reseed picks this up (the reseed recomputes `contact_by` under production durations; the arc's validation task covers it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETUbFQwweNKprCDdv8aTUs