### PR TITLE
feat(synthetic): outbound + mutual message-direction seeding (F4)

### DIFF
--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -2181,12 +2181,27 @@ type Querier interface {
 	// NULL/absent to '' so the LIKE fails and the row is flagged. Caller passes a BARE
 	// prefix.
 	TestCountIncoherentManagedFollowUpsByNamePrefix(ctx context.Context, namePrefix pgtype.Text) (int64, error)
+	// Coherence gate (F4, d): count the namespace's contacts whose last_outreach_at is
+	// set but NOT backed by a live outbound/mutual interaction at that exact
+	// occurred_at. Asserted == 0. last_outreach_at is sole-written by the cadence
+	// updater from an outbound/mutual interaction (CAD-006), so a moved value with no
+	// backing outbound/mutual row is a production-impossible seed shape. Caller passes
+	// a BARE prefix.
+	TestCountIncoherentOutreachByNamePrefix(ctx context.Context, namePrefix pgtype.Text) (int64, error)
 	// Coherence gate (positive): count the namespace's contacts whose last_contacted
 	// IS backed by a live inbound/mutual interaction at the same occurred_at AND whose
 	// last_interaction_at is in lockstep. Asserted >= 1, proving the zero-violation gate
 	// is not vacuous — the interaction-moved cohort exists and sets last_interaction_at
 	// in lockstep where an interaction drove the write. Caller passes a BARE prefix.
 	TestCountInteractionBackedLastContactedByNamePrefix(ctx context.Context, namePrefix pgtype.Text) (int64, error)
+	// Coherence gate (F4, d-positive): count the LIVE outbound-or-mutual interactions of
+	// ONE message source on the namespace's contacts. F4 measured 0 for EACH of the four
+	// message sources (email/telegram/gchat/messages), so the test calls this once per
+	// source and asserts >= 1 for every one. The allowlist is hardcoded in the test and
+	// deliberately EXCLUDES gcal (the awaiting-reply GCal event is already mutual, so
+	// including it would let the assertion pass without exercising any message-source
+	// direction). Caller passes a BARE prefix + the source.
+	TestCountNonInboundMessageInteractionsBySourceByNamePrefix(ctx context.Context, arg TestCountNonInboundMessageInteractionsBySourceByNamePrefixParams) (int64, error)
 	// Test-only: counts venue-type nodes that no live interaction references via
 	// venue_id. Used by the venue backfill test to assert the no-orphan-node guard.
 	TestCountOrphanVenueNodes(ctx context.Context) (int64, error)
@@ -2215,6 +2230,12 @@ type Querier interface {
 	// test to prove the attended FOR SHARE conflicts with a concurrent FOR UPDATE
 	// without a sleep/timeout. Production code must NOT call this.
 	TestGetCalendarEventByIDForUpdateNoWait(ctx context.Context, id pgtype.UUID) (*CalendarEvent, error)
+	// Coherence gate (F4, d-mutual-verify timestamps): return one contact's four cadence
+	// timestamp columns so the test can assert the promoted mutual set them all together
+	// (mutual writes last_contacted / last_interaction_at / last_outreach_at /
+	// last_response_at to the same replyAt). Covers last_response_at, which the
+	// direction-count query alone does not prove.
+	TestGetContactCadenceTimestampsForContact(ctx context.Context, contactID pgtype.UUID) (*TestGetContactCadenceTimestampsForContactRow, error)
 	// Coherence gate (F3, Go-side): return the namespace's live managed follow-up loop
 	// task's contact_id, external_task_id, and metadata so the test can decode the
 	// marker and confirm it points at the row's own contact. Caller passes a BARE
@@ -2357,6 +2378,13 @@ type Querier interface {
 	// exact key columns + partial predicate of the eligible/stale-claim indexes
 	// (migration 073). Read-only catalog access, mirroring TestListPublicTables.
 	TestListIndexDefsForComms(ctx context.Context) ([]*TestListIndexDefsForCommsRow, error)
+	// Coherence gate (F4, d-mutual-verify): for one contact + source, return (direction,
+	// count) over live interactions, so the test can assert the telegram-mutual contact's
+	// two seeded messages COLLAPSED into a single promoted mutual row — proving
+	// PromoteInteractionToMutualTx ran, not that an outbound and an inbound merely coexist
+	// as two rows. A mis-set bridge window (2 rows, or an un-promoted outbound) fails
+	// loudly.
+	TestListInteractionDirectionCountsForContact(ctx context.Context, arg TestListInteractionDirectionCountsForContactParams) ([]*TestListInteractionDirectionCountsForContactRow, error)
 	// Profile coverage test only: for the namespace's contacts (by full_name prefix)
 	// that have interactions, return the per-contact interaction count and the span
 	// (in seconds) between the earliest and latest interaction, so the test can

--- a/backend/internal/db/queries/test.sql
+++ b/backend/internal/db/queries/test.sql
@@ -1289,3 +1289,64 @@ SELECT
 FROM contact c
 WHERE c.full_name LIKE @name_prefix || '%'
   AND c.deleted_at IS NULL;
+
+-- name: TestCountIncoherentOutreachByNamePrefix :one
+-- Coherence gate (F4, d): count the namespace's contacts whose last_outreach_at is
+-- set but NOT backed by a live outbound/mutual interaction at that exact
+-- occurred_at. Asserted == 0. last_outreach_at is sole-written by the cadence
+-- updater from an outbound/mutual interaction (CAD-006), so a moved value with no
+-- backing outbound/mutual row is a production-impossible seed shape. Caller passes
+-- a BARE prefix.
+SELECT COUNT(*)
+FROM contact c
+WHERE c.full_name LIKE @name_prefix || '%'
+  AND c.deleted_at IS NULL
+  AND c.last_outreach_at IS NOT NULL
+  AND NOT EXISTS (
+        SELECT 1 FROM interaction i
+        WHERE i.contact_id = c.id
+          AND i.deleted_at IS NULL
+          AND i.direction IN ('outbound', 'mutual')
+          AND i.occurred_at = c.last_outreach_at
+      );
+
+-- name: TestCountNonInboundMessageInteractionsBySourceByNamePrefix :one
+-- Coherence gate (F4, d-positive): count the LIVE outbound-or-mutual interactions of
+-- ONE message source on the namespace's contacts. F4 measured 0 for EACH of the four
+-- message sources (email/telegram/gchat/messages), so the test calls this once per
+-- source and asserts >= 1 for every one. The allowlist is hardcoded in the test and
+-- deliberately EXCLUDES gcal (the awaiting-reply GCal event is already mutual, so
+-- including it would let the assertion pass without exercising any message-source
+-- direction). Caller passes a BARE prefix + the source.
+SELECT COUNT(*)
+FROM interaction i
+JOIN contact c ON i.contact_id = c.id
+WHERE c.full_name LIKE @name_prefix || '%'
+  AND c.deleted_at IS NULL
+  AND i.deleted_at IS NULL
+  AND i.source = @source
+  AND i.direction IN ('outbound', 'mutual');
+
+-- name: TestListInteractionDirectionCountsForContact :many
+-- Coherence gate (F4, d-mutual-verify): for one contact + source, return (direction,
+-- count) over live interactions, so the test can assert the telegram-mutual contact's
+-- two seeded messages COLLAPSED into a single promoted mutual row — proving
+-- PromoteInteractionToMutualTx ran, not that an outbound and an inbound merely coexist
+-- as two rows. A mis-set bridge window (2 rows, or an un-promoted outbound) fails
+-- loudly.
+SELECT i.direction, COUNT(*) AS n
+FROM interaction i
+WHERE i.contact_id = @contact_id
+  AND i.source = @source
+  AND i.deleted_at IS NULL
+GROUP BY i.direction;
+
+-- name: TestGetContactCadenceTimestampsForContact :one
+-- Coherence gate (F4, d-mutual-verify timestamps): return one contact's four cadence
+-- timestamp columns so the test can assert the promoted mutual set them all together
+-- (mutual writes last_contacted / last_interaction_at / last_outreach_at /
+-- last_response_at to the same replyAt). Covers last_response_at, which the
+-- direction-count query alone does not prove.
+SELECT last_contacted, last_interaction_at, last_outreach_at, last_response_at
+FROM contact
+WHERE id = @contact_id;

--- a/backend/internal/db/test.sql.go
+++ b/backend/internal/db/test.sql.go
@@ -2241,6 +2241,34 @@ func (q *Queries) TestCountIncoherentManagedFollowUpsByNamePrefix(ctx context.Co
 	return count, err
 }
 
+const TestCountIncoherentOutreachByNamePrefix = `-- name: TestCountIncoherentOutreachByNamePrefix :one
+SELECT COUNT(*)
+FROM contact c
+WHERE c.full_name LIKE $1 || '%'
+  AND c.deleted_at IS NULL
+  AND c.last_outreach_at IS NOT NULL
+  AND NOT EXISTS (
+        SELECT 1 FROM interaction i
+        WHERE i.contact_id = c.id
+          AND i.deleted_at IS NULL
+          AND i.direction IN ('outbound', 'mutual')
+          AND i.occurred_at = c.last_outreach_at
+      )
+`
+
+// Coherence gate (F4, d): count the namespace's contacts whose last_outreach_at is
+// set but NOT backed by a live outbound/mutual interaction at that exact
+// occurred_at. Asserted == 0. last_outreach_at is sole-written by the cadence
+// updater from an outbound/mutual interaction (CAD-006), so a moved value with no
+// backing outbound/mutual row is a production-impossible seed shape. Caller passes
+// a BARE prefix.
+func (q *Queries) TestCountIncoherentOutreachByNamePrefix(ctx context.Context, namePrefix pgtype.Text) (int64, error) {
+	row := q.db.QueryRow(ctx, TestCountIncoherentOutreachByNamePrefix, namePrefix)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const TestCountInteractionBackedLastContactedByNamePrefix = `-- name: TestCountInteractionBackedLastContactedByNamePrefix :one
 SELECT COUNT(*)
 FROM contact c
@@ -2264,6 +2292,36 @@ WHERE c.full_name LIKE $1 || '%'
 // in lockstep where an interaction drove the write. Caller passes a BARE prefix.
 func (q *Queries) TestCountInteractionBackedLastContactedByNamePrefix(ctx context.Context, namePrefix pgtype.Text) (int64, error) {
 	row := q.db.QueryRow(ctx, TestCountInteractionBackedLastContactedByNamePrefix, namePrefix)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const TestCountNonInboundMessageInteractionsBySourceByNamePrefix = `-- name: TestCountNonInboundMessageInteractionsBySourceByNamePrefix :one
+SELECT COUNT(*)
+FROM interaction i
+JOIN contact c ON i.contact_id = c.id
+WHERE c.full_name LIKE $1 || '%'
+  AND c.deleted_at IS NULL
+  AND i.deleted_at IS NULL
+  AND i.source = $2
+  AND i.direction IN ('outbound', 'mutual')
+`
+
+type TestCountNonInboundMessageInteractionsBySourceByNamePrefixParams struct {
+	NamePrefix pgtype.Text `json:"name_prefix"`
+	Source     string      `json:"source"`
+}
+
+// Coherence gate (F4, d-positive): count the LIVE outbound-or-mutual interactions of
+// ONE message source on the namespace's contacts. F4 measured 0 for EACH of the four
+// message sources (email/telegram/gchat/messages), so the test calls this once per
+// source and asserts >= 1 for every one. The allowlist is hardcoded in the test and
+// deliberately EXCLUDES gcal (the awaiting-reply GCal event is already mutual, so
+// including it would let the assertion pass without exercising any message-source
+// direction). Caller passes a BARE prefix + the source.
+func (q *Queries) TestCountNonInboundMessageInteractionsBySourceByNamePrefix(ctx context.Context, arg TestCountNonInboundMessageInteractionsBySourceByNamePrefixParams) (int64, error) {
+	row := q.db.QueryRow(ctx, TestCountNonInboundMessageInteractionsBySourceByNamePrefix, arg.NamePrefix, arg.Source)
 	var count int64
 	err := row.Scan(&count)
 	return count, err
@@ -2313,6 +2371,36 @@ func (q *Queries) TestDeleteTagsByIds(ctx context.Context, tagIds []pgtype.UUID)
 		return 0, err
 	}
 	return result.RowsAffected(), nil
+}
+
+const TestGetContactCadenceTimestampsForContact = `-- name: TestGetContactCadenceTimestampsForContact :one
+SELECT last_contacted, last_interaction_at, last_outreach_at, last_response_at
+FROM contact
+WHERE id = $1
+`
+
+type TestGetContactCadenceTimestampsForContactRow struct {
+	LastContacted     pgtype.Timestamptz `json:"last_contacted"`
+	LastInteractionAt pgtype.Timestamptz `json:"last_interaction_at"`
+	LastOutreachAt    pgtype.Timestamptz `json:"last_outreach_at"`
+	LastResponseAt    pgtype.Timestamptz `json:"last_response_at"`
+}
+
+// Coherence gate (F4, d-mutual-verify timestamps): return one contact's four cadence
+// timestamp columns so the test can assert the promoted mutual set them all together
+// (mutual writes last_contacted / last_interaction_at / last_outreach_at /
+// last_response_at to the same replyAt). Covers last_response_at, which the
+// direction-count query alone does not prove.
+func (q *Queries) TestGetContactCadenceTimestampsForContact(ctx context.Context, contactID pgtype.UUID) (*TestGetContactCadenceTimestampsForContactRow, error) {
+	row := q.db.QueryRow(ctx, TestGetContactCadenceTimestampsForContact, contactID)
+	var i TestGetContactCadenceTimestampsForContactRow
+	err := row.Scan(
+		&i.LastContacted,
+		&i.LastInteractionAt,
+		&i.LastOutreachAt,
+		&i.LastResponseAt,
+	)
+	return &i, err
 }
 
 const TestGetLiveFollowUpByNamePrefix = `-- name: TestGetLiveFollowUpByNamePrefix :one
@@ -2734,6 +2822,51 @@ func (q *Queries) TestListIndexDefsForComms(ctx context.Context) ([]*TestListInd
 	for rows.Next() {
 		var i TestListIndexDefsForCommsRow
 		if err := rows.Scan(&i.Indexname, &i.Indexdef); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const TestListInteractionDirectionCountsForContact = `-- name: TestListInteractionDirectionCountsForContact :many
+SELECT i.direction, COUNT(*) AS n
+FROM interaction i
+WHERE i.contact_id = $1
+  AND i.source = $2
+  AND i.deleted_at IS NULL
+GROUP BY i.direction
+`
+
+type TestListInteractionDirectionCountsForContactParams struct {
+	ContactID pgtype.UUID `json:"contact_id"`
+	Source    string      `json:"source"`
+}
+
+type TestListInteractionDirectionCountsForContactRow struct {
+	Direction string `json:"direction"`
+	N         int64  `json:"n"`
+}
+
+// Coherence gate (F4, d-mutual-verify): for one contact + source, return (direction,
+// count) over live interactions, so the test can assert the telegram-mutual contact's
+// two seeded messages COLLAPSED into a single promoted mutual row — proving
+// PromoteInteractionToMutualTx ran, not that an outbound and an inbound merely coexist
+// as two rows. A mis-set bridge window (2 rows, or an un-promoted outbound) fails
+// loudly.
+func (q *Queries) TestListInteractionDirectionCountsForContact(ctx context.Context, arg TestListInteractionDirectionCountsForContactParams) ([]*TestListInteractionDirectionCountsForContactRow, error) {
+	rows, err := q.db.Query(ctx, TestListInteractionDirectionCountsForContact, arg.ContactID, arg.Source)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []*TestListInteractionDirectionCountsForContactRow{}
+	for rows.Next() {
+		var i TestListInteractionDirectionCountsForContactRow
+		if err := rows.Scan(&i.Direction, &i.N); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)

--- a/backend/internal/repository/synthetic_support.go
+++ b/backend/internal/repository/synthetic_support.go
@@ -855,6 +855,71 @@ func (r *SyntheticSupportRepository) ListCadenceActivityFlagsByNamePrefix(ctx co
 	return out, nil
 }
 
+// IncoherentOutreachCountByNamePrefix returns the number of the namespace's contacts
+// whose last_outreach_at is set but not backed by a live outbound/mutual interaction
+// at the same occurred_at. Coherence gate (F4, d); asserted == 0. Test only.
+func (r *SyntheticSupportRepository) IncoherentOutreachCountByNamePrefix(ctx context.Context, namePrefix string) (int64, error) {
+	return r.queries.TestCountIncoherentOutreachByNamePrefix(ctx, pgtype.Text{String: namePrefix, Valid: true})
+}
+
+// NonInboundMessageInteractionCountBySourceByNamePrefix returns the number of live
+// outbound/mutual interactions of one message source on the namespace's contacts.
+// Coherence gate (F4, d-positive); the test asserts >= 1 for each of the four message
+// sources (email/telegram/gchat/messages). Test only.
+func (r *SyntheticSupportRepository) NonInboundMessageInteractionCountBySourceByNamePrefix(ctx context.Context, namePrefix, source string) (int64, error) {
+	return r.queries.TestCountNonInboundMessageInteractionsBySourceByNamePrefix(ctx, db.TestCountNonInboundMessageInteractionsBySourceByNamePrefixParams{
+		NamePrefix: pgtype.Text{String: namePrefix, Valid: true},
+		Source:     source,
+	})
+}
+
+// InteractionDirectionCountsForContact returns the per-direction live-interaction
+// counts for one contact + source as a direction→count map, so the coverage check
+// can assert the telegram-mutual contact's messages collapsed into exactly one mutual
+// row (proving the promote fired, not mere coexistence). Coherence gate (F4,
+// d-mutual-verify). Test only.
+func (r *SyntheticSupportRepository) InteractionDirectionCountsForContact(ctx context.Context, contactID uuid.UUID, source string) (map[string]int64, error) {
+	rows, err := r.queries.TestListInteractionDirectionCountsForContact(ctx, db.TestListInteractionDirectionCountsForContactParams{
+		ContactID: uuidToPgUUID(contactID),
+		Source:    source,
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]int64, len(rows))
+	for _, row := range rows {
+		out[row.Direction] = row.N
+	}
+	return out, nil
+}
+
+// ContactCadenceTimestamps is the four-column cadence-timestamp projection of a
+// contact used by the F4 mutual-verify gate to assert the promoted mutual set them
+// all together.
+type ContactCadenceTimestamps struct {
+	LastContacted     *time.Time
+	LastInteractionAt *time.Time
+	LastOutreachAt    *time.Time
+	LastResponseAt    *time.Time
+}
+
+// ContactCadenceTimestampsForContact returns one contact's four cadence timestamp
+// columns so the coverage check can assert the reply-bridged mutual set
+// last_contacted / last_interaction_at / last_outreach_at / last_response_at all
+// non-null and equal. Coherence gate (F4, d-mutual-verify). Test only.
+func (r *SyntheticSupportRepository) ContactCadenceTimestampsForContact(ctx context.Context, contactID uuid.UUID) (*ContactCadenceTimestamps, error) {
+	row, err := r.queries.TestGetContactCadenceTimestampsForContact(ctx, uuidToPgUUID(contactID))
+	if err != nil {
+		return nil, err
+	}
+	return &ContactCadenceTimestamps{
+		LastContacted:     pgTimestamptzToTimePtr(row.LastContacted),
+		LastInteractionAt: pgTimestamptzToTimePtr(row.LastInteractionAt),
+		LastOutreachAt:    pgTimestamptzToTimePtr(row.LastOutreachAt),
+		LastResponseAt:    pgTimestamptzToTimePtr(row.LastResponseAt),
+	}, nil
+}
+
 // InteractionSpread is the per-contact interaction-history projection of a seeded
 // contact (profile coverage test only): how many interactions it carries and the
 // span between its earliest and latest one.

--- a/backend/internal/synthetic/factory/sources.go
+++ b/backend/internal/synthetic/factory/sources.go
@@ -30,6 +30,12 @@ type messageConfig struct {
 	// offset (e.g. Gmail's −2h). Zero leaves the default (the most-recent message);
 	// growing it across a replay loop spreads older interactions back over time.
 	age time.Duration
+	// outbound flips the message's direction marker so the real provider derives an
+	// OUTBOUND (I-sent-it) interaction instead of the default inbound. Each factory
+	// applies it to whichever field the provider reads for direction (Gmail From/
+	// LabelIds, GChat Sender, Telegram Out, iMessage kind). Direction is computed
+	// provider-side, so this is purely a payload-shape change — no PRNG draw.
+	outbound bool
 }
 
 // WithMessageAge shifts a source message's timestamp further back by age, added
@@ -44,6 +50,18 @@ func WithMessageAge(age time.Duration) MessageOption {
 			age = 0
 		}
 		c.age = age
+	}
+}
+
+// WithOutbound marks a source message as OUTBOUND (sent by the account) rather
+// than the default inbound. The provider derives direction from the payload, so
+// each factory flips the field the provider reads: Gmail swaps From/To + the
+// INBOX→SENT label, GChat sets the sender to the me-user, Telegram sets the Out
+// flag, iMessage marshals the raw_message.sent kind. Counter-neutral (draws the
+// identical deterministic counters as inbound; no PRNG).
+func WithOutbound() MessageOption {
+	return func(c *messageConfig) {
+		c.outbound = true
 	}
 }
 
@@ -68,21 +86,31 @@ type GmailMessageSpec struct {
 	Intent     MatchIntent
 }
 
-// GmailMessage builds an inbound email from the target contact (MatchSeeded) or
-// from an unknown correspondent (MatchUnknown → match-only: no contact, no
-// interaction). SentAt is anchored before now − safety lag so the Gmail cursor
-// window includes it.
+// GmailMessage builds an email between the account and the target contact
+// (MatchSeeded) or an unknown correspondent (MatchUnknown → match-only: no
+// contact, no interaction). Inbound by default (From=contact); WithOutbound()
+// flips it to a sent message (From=account, SENT label). SentAt is anchored
+// before now − safety lag so the Gmail cursor window includes it.
 func (g *Generator) GmailMessage(target ContactSpec, intent MatchIntent, opts ...MessageOption) GmailMessageSpec {
 	mo := applyMessageOptions(opts)
 	account := g.accountEmail()
-	from := target.Email
+	peer := target.Email
 	if intent == MatchUnknown {
-		from = g.unknownEmail()
+		peer = g.unknownEmail()
 	}
-	if from == "" {
+	if peer == "" {
 		// Target has no email (e.g. phone-only contact) — fall back to an
 		// addressable synthetic email so the message is well-formed.
-		from = g.unknownEmail()
+		peer = g.unknownEmail()
+	}
+	// The provider derives direction from whether From ∈ meSet: inbound is
+	// From=peer/To=account with an INBOX label; outbound swaps them and carries a
+	// SENT label instead.
+	from, to := peer, account
+	label := "INBOX"
+	if mo.outbound {
+		from, to = account, peer
+		label = "SENT"
 	}
 	externalID := fmt.Sprintf("<%sgmail-%d@synthetic.example>", g.Prefix(), g.bumpSourceSeq())
 	// 2h before now − safety lag (anchor-relative) so it is inside the scanned,
@@ -95,12 +123,12 @@ func (g *Generator) GmailMessage(target ContactSpec, intent MatchIntent, opts ..
 		ThreadId:     g.Prefix() + "thr-" + fmt.Sprint(g.sourceIDSeq),
 		InternalDate: sentAt.UnixMilli(),
 		Snippet:      "synthetic snippet",
-		LabelIds:     []string{"INBOX"},
+		LabelIds:     []string{label},
 		Payload: &gmailapi.MessagePart{
 			MimeType: "text/plain",
 			Headers: []*gmailapi.MessagePartHeader{
 				{Name: "From", Value: from},
-				{Name: "To", Value: account},
+				{Name: "To", Value: to},
 				{Name: "Subject", Value: "synthetic subject"},
 				{Name: "Message-ID", Value: externalID},
 			},
@@ -132,9 +160,12 @@ type GChatMessageSpec struct {
 	Intent      MatchIntent
 }
 
-// GChatMessage builds an inbound chat message from the target contact
-// (MatchSeeded) or an unknown sender (MatchUnknown → match-only: no row, no
-// interaction, no contact). Anchor-relative create time.
+// GChatMessage builds a chat message in a space the account and the target
+// contact both belong to (MatchSeeded) or with an unknown sender (MatchUnknown →
+// match-only: no row, no interaction, no contact). Inbound by default (the
+// contact is the sender); WithOutbound() sets the sender to the me-user, so the
+// provider derives OUTBOUND and fans the message out to the contact co-member.
+// Anchor-relative create time.
 func (g *Generator) GChatMessage(target ContactSpec, intent MatchIntent, opts ...MessageOption) GChatMessageSpec {
 	mo := applyMessageOptions(opts)
 	account := g.accountEmail()
@@ -152,6 +183,14 @@ func (g *Generator) GChatMessage(target ContactSpec, intent MatchIntent, opts ..
 		senderEmail = g.unknownEmail()
 	}
 
+	// The message sender is the contact (inbound) by default; outbound makes the
+	// account the sender while the contact stays a JOINED co-member, so the
+	// provider's outbound fan-out matches the contact (see gchat classifyMessage).
+	messageSender := senderUser
+	if mo.outbound {
+		messageSender = meUser
+	}
+
 	return GChatMessageSpec{
 		AccountID: account,
 		SpaceName: spaceName,
@@ -162,7 +201,7 @@ func (g *Generator) GChatMessage(target ContactSpec, intent MatchIntent, opts ..
 		},
 		Message: &chat.Message{
 			Name:       msgName,
-			Sender:     &chat.User{Name: senderUser, Type: "HUMAN"},
+			Sender:     &chat.User{Name: messageSender, Type: "HUMAN"},
 			Text:       "synthetic chat message",
 			CreateTime: createTime.UTC().Format(time.RFC3339Nano),
 		},
@@ -235,15 +274,21 @@ type TelegramMessageSpec struct {
 	Text              string
 	SentAt            time.Time
 	Intent            MatchIntent
+	// Out marks the message as OUTGOING (sent by the account). The replay adapter
+	// maps it to tg.Message.Out, from which the provider derives the outbound
+	// direction; for outbound it also sets FromID to self while PeerID stays the
+	// peer, so peer matching still resolves the contact.
+	Out bool
 	// MatchHandle is the telegram handle to register as the seeded contact's
 	// method (MatchSeeded). Empty for MatchUnknown.
 	MatchHandle string
 }
 
-// TelegramMessage builds a private inbound message from the target contact
-// (MatchSeeded → matched interaction; requires the target has a telegram method)
-// or an unknown peer (MatchUnknown → telegram_message.matched_contact_id IS NULL
-// + discovery candidate). PeerUserID/TelegramMessageID come from this namespace's
+// TelegramMessage builds a private message with the target contact (MatchSeeded →
+// matched interaction; requires the target has a telegram method) or an unknown
+// peer (MatchUnknown → telegram_message.matched_contact_id IS NULL + discovery
+// candidate). Inbound by default; WithOutbound() sets Out so the adapter drives an
+// outgoing message. PeerUserID/TelegramMessageID come from this namespace's
 // reserved numeric sub-blocks.
 func (g *Generator) TelegramMessage(target ContactSpec, intent MatchIntent, opts ...MessageOption) TelegramMessageSpec {
 	mo := applyMessageOptions(opts)
@@ -270,6 +315,7 @@ func (g *Generator) TelegramMessage(target ContactSpec, intent MatchIntent, opts
 		Text:              "synthetic telegram message",
 		SentAt:            sentAt,
 		Intent:            intent,
+		Out:               mo.outbound,
 		MatchHandle:       handle,
 	}
 }
@@ -356,11 +402,13 @@ type IMessageSpec struct {
 	Intent   MatchIntent
 }
 
-// IMessage builds a raw_message.received envelope from the target contact's
-// phone (MatchSeeded → matched interaction) or an unknown handle (MatchUnknown →
-// messages_message.matched_contact_id IS NULL). hostID is the revoked synthetic
-// mac host the harness seeded (the payload's HostID field; the host-only kind
-// allowlist requires a non-nil host).
+// IMessage builds a raw_message envelope for the target contact's phone
+// (MatchSeeded → matched interaction) or an unknown handle (MatchUnknown →
+// messages_message.matched_contact_id IS NULL). Received by default; WithOutbound()
+// marshals the raw_message.sent kind + payload so the inline ingest handler sets
+// IsOutgoing and the derived interaction is outbound. hostID is the revoked
+// synthetic mac host the harness seeded (the payload's HostID field; the host-only
+// kind allowlist requires a non-nil host).
 func (g *Generator) IMessage(target ContactSpec, intent MatchIntent, hostID uuid.UUID, opts ...MessageOption) (IMessageSpec, error) {
 	mo := applyMessageOptions(opts)
 	seq := g.bumpSourceSeq()
@@ -384,7 +432,19 @@ func (g *Generator) IMessage(target ContactSpec, intent MatchIntent, hostID uuid
 		IsGroup:     false,
 		SentAt:      sentAt,
 	}
-	raw, err := events.Marshal(events.KindRawMessageReceived, payload)
+	// events.Marshal enforces the exact payload type per kind, so an outbound
+	// message MUST switch to the RawMessageSentPayload alias, not just flip the
+	// kind. Both kinds share the same field shape (the alias is a defined type over
+	// RawMessageReceivedPayload).
+	kind := events.KindRawMessageReceived
+	var raw []byte
+	var err error
+	if mo.outbound {
+		kind = events.KindRawMessageSent
+		raw, err = events.Marshal(kind, events.RawMessageSentPayload(payload))
+	} else {
+		raw, err = events.Marshal(kind, payload)
+	}
 	if err != nil {
 		return IMessageSpec{}, fmt.Errorf("marshal raw_message payload: %w", err)
 	}
@@ -392,7 +452,7 @@ func (g *Generator) IMessage(target ContactSpec, intent MatchIntent, hostID uuid
 		Envelope: &events.Envelope{
 			Source:     "messages",
 			SourceID:   guid,
-			Kind:       events.KindRawMessageReceived,
+			Kind:       kind,
 			Payload:    raw,
 			ObservedAt: sentAt,
 		},

--- a/backend/internal/synthetic/profiles.go
+++ b/backend/internal/synthetic/profiles.go
@@ -120,6 +120,16 @@ type ProfileResult struct {
 	UnmatchedGmailCorrespondence int
 	UnmatchedAnarlogHumans       int
 	TelegramDiscovery            int
+	// OutboundOnlyContacts / MutualMessageContacts count the two-sided
+	// message-direction cohort (F4): the OUTBOUND-only contacts (one each for gmail /
+	// gchat / imessage — "I messaged them, no reply yet" → last_outreach_at set,
+	// last_contacted NULL) and the single reply-bridged telegram MUTUAL contact (an
+	// outbound + a newer inbound within the bridge window promote in place to one
+	// mutual interaction). Kept OUT of the SettledInteractions equation on purpose:
+	// the mutual pair is two replay calls collapsing to one promoted row, so folding
+	// it into a call-vs-row count would muddy that invariant. Counts-only / no PII.
+	OutboundOnlyContacts  int
+	MutualMessageContacts int
 }
 
 // ProfileParams returns the default SeedParams for a named profile (error on an
@@ -855,6 +865,94 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		res.SeededTasks++
 		res.SeededPendingFollowUps = 1
 	}
+
+	// --- Two-sided message-direction cohort (F4) --------------------------------
+	//
+	// Seeded LAST, after every other generator-driven block: it draws gen.Contact
+	// (name PRNG) + source replays, and appending keeps the deterministic id/handle
+	// sequence the earlier source replays depend on unshifted (the message factories
+	// draw ZERO PRNG — only deterministic counters — but gen.Contact does, so this
+	// must still land at the very end).
+	//
+	// Every message-sourced interaction the loops above produce is INBOUND, so the
+	// judge never sees the user reply and reads every conversation as one-sided (a
+	// false "broken compose/send" signal). This block gives the four message sources
+	// their non-inbound coverage: three OUTBOUND-only contacts (gmail / gchat /
+	// imessage) modelling "I messaged them, no reply yet", and one reply-bridged
+	// telegram MUTUAL contact that exercises the promote-to-mutual primitive.
+
+	// Three OUTBOUND-only contacts — one each for gmail / gchat / imessage. Each
+	// carries a single outbound interaction: last_outreach_at set (CAD-006),
+	// last_contacted / last_interaction_at NULL (an outbound touches neither), so
+	// these pass the PR1 lockstep gate unchanged (NULL last_contacted → exempt).
+	obGmailSpec := gen.Contact(factory.WithEmail())
+	obGmailContact, err := h.SeedContact(ctx, obGmailSpec)
+	if err != nil {
+		return res, fmt.Errorf("profile %s: seed outbound gmail contact: %w", params.Profile, err)
+	}
+	res.Contacts++
+	if _, err := h.ReplayGmail(ctx, obGmailContact.ID, gen.GmailMessage(obGmailSpec, factory.MatchSeeded, factory.WithOutbound(), factory.WithMessageAge(messageOutboundAge))); err != nil {
+		return res, fmt.Errorf("profile %s: replay outbound gmail: %w", params.Profile, err)
+	}
+	res.OutboundOnlyContacts++
+
+	obGChatSpec := gen.Contact(factory.WithEmail())
+	obGChatContact, err := h.SeedContact(ctx, obGChatSpec)
+	if err != nil {
+		return res, fmt.Errorf("profile %s: seed outbound gchat contact: %w", params.Profile, err)
+	}
+	res.Contacts++
+	if _, err := h.ReplayGChat(ctx, obGChatContact.ID, gen.GChatMessage(obGChatSpec, factory.MatchSeeded, factory.WithOutbound(), factory.WithMessageAge(messageOutboundAge))); err != nil {
+		return res, fmt.Errorf("profile %s: replay outbound gchat: %w", params.Profile, err)
+	}
+	res.OutboundOnlyContacts++
+
+	obIMsgSpec := gen.Contact(factory.WithPhone())
+	obIMsgContact, err := h.SeedContact(ctx, obIMsgSpec)
+	if err != nil {
+		return res, fmt.Errorf("profile %s: seed outbound imessage contact: %w", params.Profile, err)
+	}
+	res.Contacts++
+	obIMsg, err := gen.IMessage(obIMsgSpec, factory.MatchSeeded, h.MacHostID(), factory.WithOutbound(), factory.WithMessageAge(messageOutboundAge))
+	if err != nil {
+		return res, fmt.Errorf("profile %s: build outbound imessage: %w", params.Profile, err)
+	}
+	if _, err := h.ReplayIMessage(ctx, obIMsgContact.ID, obIMsg); err != nil {
+		return res, fmt.Errorf("profile %s: replay outbound imessage: %w", params.Profile, err)
+	}
+	res.OutboundOnlyContacts++
+
+	// One MUTUAL (reply-bridged) telegram contact. Telegram runs its aggregation
+	// engine INLINE in ReplayTelegram (worker-free), so the promote is reliable.
+	// Build one OUTBOUND spec, then CLONE it for the inbound reply — keeping the SAME
+	// PeerUserID + TelegramChatID (the bridge requires prev.chatID == b.chatID; a
+	// second gen.TelegramMessage call would allocate a fresh peer/chat and never
+	// bridge), bumping the message id, flipping Out to false, and dating it strictly
+	// NEWER than the outbound but within the 48h bridge window. The inbound reply's
+	// aggregation finds the outbound interaction and PromoteInteractionToMutualTx
+	// flips it in place: one mutual row, last_contacted == last_interaction_at ==
+	// last_outreach_at == last_response_at.
+	mutualSpec := gen.Contact(factory.WithTelegram())
+	mutualContact, err := h.SeedContact(ctx, mutualSpec)
+	if err != nil {
+		return res, fmt.Errorf("profile %s: seed mutual telegram contact: %w", params.Profile, err)
+	}
+	res.Contacts++
+	tgOutbound := gen.TelegramMessage(mutualSpec, factory.MatchSeeded, factory.WithOutbound(), factory.WithMessageAge(messageMutualOutboundAge))
+	if _, err := h.ReplayTelegram(ctx, mutualContact.ID, tgOutbound); err != nil {
+		return res, fmt.Errorf("profile %s: replay mutual telegram outbound: %w", params.Profile, err)
+	}
+	tgReply := tgOutbound // clone: same peer + chat, so the bridge can fire
+	tgReply.TelegramMessageID = tgOutbound.TelegramMessageID + 1
+	tgReply.Out = false
+	// Newer than the outbound by exactly (outboundAge − replyAge) = 6h (< 48h).
+	tgReply.SentAt = tgOutbound.SentAt.Add(messageMutualOutboundAge - messageMutualReplyAge)
+	if _, err := h.ReplayTelegram(ctx, mutualContact.ID, tgReply); err != nil {
+		return res, fmt.Errorf("profile %s: replay mutual telegram reply: %w", params.Profile, err)
+	}
+	h.SetMutualMessageContactID(mutualContact.ID)
+	res.MutualMessageContacts++
+
 	return res, nil
 }
 
@@ -1103,6 +1201,24 @@ const interactionSpreadInterval = 21 * 24 * time.Hour
 func interactionSpreadAge(j int) time.Duration {
 	return time.Duration(j) * interactionSpreadInterval
 }
+
+// Message-age anchors for the two-sided direction block (F4). All are backward
+// offsets from the generator anchor (applied via the factories' WithMessageAge),
+// so they stay anchor-relative/deterministic (no time.Now()). The mutual reply is
+// strictly NEWER than the mutual outbound (smaller age) and their gap is well
+// under the aggregation reply-bridge window (replyBridgeHours=48h), so the inbound
+// reply promotes the outbound interaction in place to mutual.
+const (
+	// messageOutboundAge dates the OUTBOUND-only contacts' single message a few
+	// days back — recent enough to be plainly current, not so recent it collides
+	// with the ~2h/1h source default windows.
+	messageOutboundAge = 3 * 24 * time.Hour
+	// messageMutualOutboundAge dates the mutual pair's OUTBOUND half.
+	messageMutualOutboundAge = 5 * 24 * time.Hour
+	// messageMutualReplyAge dates the mutual pair's INBOUND reply: 6h newer than the
+	// outbound (age 6h smaller), well within the 48h bridge window.
+	messageMutualReplyAge = messageMutualOutboundAge - 6*time.Hour
+)
 
 // SeedAllowed is the single chokepoint guard the seed/reset entrypoints route
 // through. It returns an error iff CRM_ENV is a production alias (production /

--- a/backend/internal/synthetic/replay/replay.go
+++ b/backend/internal/synthetic/replay/replay.go
@@ -170,6 +170,14 @@ type Harness struct {
 	// harness tracks the production default rather than hard-coding a copy.
 	groupMaxMembers int
 
+	// mutualMessageContactID is the contact the two-sided message-direction block
+	// (profiles.go) seeded as a reply-bridged telegram MUTUAL. A profile sets it via
+	// SetMutualMessageContactID after seeding; the coverage check reads it via
+	// MutualMessageContactID to assert the promote-to-mutual collapse. It is NOT a
+	// ProfileResult field: contact ids come from uuid_generate_v4() (non-deterministic),
+	// so it must stay off the counts-only, determinism-compared result struct.
+	mutualMessageContactID uuid.UUID
+
 	created   *created
 	createdMu sync.Mutex
 
@@ -634,6 +642,26 @@ func (h *Harness) MergedWinnerNodeIDs() []uuid.UUID {
 	h.createdMu.Lock()
 	defer h.createdMu.Unlock()
 	return append([]uuid.UUID(nil), h.created.mergedWinnerNodeIDs...)
+}
+
+// SetMutualMessageContactID records the contact the two-sided message block seeded
+// as a reply-bridged telegram mutual, so the coverage check can resolve it via
+// MutualMessageContactID. Called by the seeding block (package synthetic) after it
+// seeds the mutual pair — hence exported. Guarded by the ledger mutex for parity
+// with the other tracked ids.
+func (h *Harness) SetMutualMessageContactID(id uuid.UUID) {
+	h.createdMu.Lock()
+	defer h.createdMu.Unlock()
+	h.mutualMessageContactID = id
+}
+
+// MutualMessageContactID returns the contact the two-sided message block seeded as
+// a reply-bridged telegram mutual (uuid.Nil if the block did not run — e.g. a
+// profile with it disabled). Read by the coverage check to assert the promote.
+func (h *Harness) MutualMessageContactID() uuid.UUID {
+	h.createdMu.Lock()
+	defer h.createdMu.Unlock()
+	return h.mutualMessageContactID
 }
 
 // gateBClear reports whether Gate B has reached zero for this replay's contacts.

--- a/backend/internal/synthetic/replay/telegram.go
+++ b/backend/internal/synthetic/replay/telegram.go
@@ -55,18 +55,7 @@ func (h *Harness) ReplayTelegram(ctx context.Context, contactID uuid.UUID, spec 
 	// Track this peer for cleanup (by-peer telegram_message delete).
 	h.track(func(c *created) { c.addTelegramPeer(spec.PeerUserID) })
 
-	username := spec.PeerUsername
-	user := &tg.User{ID: spec.PeerUserID, Username: username, FirstName: "Synth"}
-	entities := tg.Entities{Users: map[int64]*tg.User{spec.PeerUserID: user}}
-	msg := &tg.Message{
-		ID:      int(spec.TelegramMessageID),
-		Message: spec.Text,
-		Out:     false, // inbound
-		Date:    int(spec.SentAt.Unix()),
-		PeerID:  &tg.PeerUser{UserID: spec.PeerUserID},
-		FromID:  &tg.PeerUser{UserID: spec.PeerUserID},
-	}
-	update := &tg.UpdateNewMessage{Message: msg}
+	entities, update := BuildPrivateUpdate(spec)
 
 	if err := handler.HandleNewMessage(ctx, entities, update); err != nil {
 		return TelegramResult{}, fmt.Errorf("telegram handle message: %w", err)
@@ -91,4 +80,31 @@ func (h *Harness) ReplayTelegram(ctx context.Context, contactID uuid.UUID, spec 
 		return TelegramResult{}, err
 	}
 	return TelegramResult{ContactID: contactID, PeerUserID: spec.PeerUserID, Matched: true}, nil
+}
+
+// BuildPrivateUpdate constructs the *tg.UpdateNewMessage + tg.Entities the private
+// path reads: a *tg.PeerUser message whose PeerID is the peer (from which
+// ParseMessage derives PeerUserID regardless of direction) and whose FromID is the
+// sender — the peer for inbound, self (telegramSelfUserID) for outbound, so
+// IsOutgoing=msg.Out reads the direction while peer matching still resolves the
+// contact via PeerID. Exposed so the factory outbound-marker test can assert the
+// message shape without a DB harness. FromID is set via SetFromID (NOT a bare
+// struct-field assignment): SetFromID sets the flag bit GetFromID checks (see
+// buildGroupUpdate), so a reader using the getter actually sees it.
+func BuildPrivateUpdate(spec factory.TelegramMessageSpec) (tg.Entities, *tg.UpdateNewMessage) {
+	user := &tg.User{ID: spec.PeerUserID, Username: spec.PeerUsername, FirstName: "Synth"}
+	entities := tg.Entities{Users: map[int64]*tg.User{spec.PeerUserID: user}}
+	fromID := &tg.PeerUser{UserID: spec.PeerUserID}
+	if spec.Out {
+		fromID = &tg.PeerUser{UserID: telegramSelfUserID}
+	}
+	msg := &tg.Message{
+		ID:      int(spec.TelegramMessageID),
+		Message: spec.Text,
+		Out:     spec.Out,
+		Date:    int(spec.SentAt.Unix()),
+		PeerID:  &tg.PeerUser{UserID: spec.PeerUserID},
+	}
+	msg.SetFromID(fromID)
+	return entities, &tg.UpdateNewMessage{Message: msg}
 }

--- a/backend/tests/synthetic_factory_test.go
+++ b/backend/tests/synthetic_factory_test.go
@@ -5,10 +5,14 @@ import (
 	"testing"
 	"time"
 
+	"personal-crm/backend/internal/events"
 	"personal-crm/backend/internal/matching"
 	"personal-crm/backend/internal/synthetic"
 	"personal-crm/backend/internal/synthetic/factory"
+	"personal-crm/backend/internal/synthetic/replay"
 
+	"github.com/google/uuid"
+	"github.com/gotd/td/tg"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	gmailapi "google.golang.org/api/gmail/v1"
@@ -179,6 +183,84 @@ func TestSyntheticFactory_MatchIntentAddressesDistinctIdentifiers(t *testing.T) 
 	unknownFrom := gmailHeaderValue(unknown.Message, "From")
 	assert.Equal(t, target.Email, seededFrom, "seeded message should come from the target's email")
 	assert.NotEqual(t, target.Email, unknownFrom, "unknown message must not address the seeded contact")
+}
+
+// TestSyntheticFactory_WithOutboundFlipsDirectionMarker asserts WithOutbound()
+// produces each source's OUTBOUND payload marker (the field the real provider reads
+// for direction), leaving the default inbound marker otherwise. This is a
+// payload-marker assertion only — the factories provably never touch the PRNG (only
+// deterministic counters), so there is no stream to preserve; counter-order is
+// guarded by the determinism fingerprint + the LAST-append placement. The adapter
+// wiring (Out → outbound interaction) is covered behaviorally by the mutual-promote
+// gate in the profile coverage tests.
+func TestSyntheticFactory_WithOutboundFlipsDirectionMarker(t *testing.T) {
+	t.Parallel()
+	g := factory.NewGeneratorAt(factory.DefaultSeed, "outbound", fixedAnchor)
+	emailTarget := g.Contact(factory.WithEmail())
+	phoneTarget := g.Contact(factory.WithPhone())
+	tgTarget := g.Contact(factory.WithTelegram())
+	hostID := uuid.New()
+
+	// Gmail: inbound is From=contact + INBOX; outbound swaps to From=account (≠
+	// contact), To=contact, and a SENT label.
+	gmIn := g.GmailMessage(emailTarget, factory.MatchSeeded)
+	assert.Equal(t, emailTarget.Email, gmailHeaderValue(gmIn.Message, "From"), "inbound gmail is from the contact")
+	assert.Equal(t, []string{"INBOX"}, gmIn.Message.LabelIds, "inbound gmail carries the INBOX label")
+	gmOut := g.GmailMessage(emailTarget, factory.MatchSeeded, factory.WithOutbound())
+	assert.NotEqual(t, emailTarget.Email, gmailHeaderValue(gmOut.Message, "From"), "outbound gmail is from the account, not the contact")
+	assert.Equal(t, emailTarget.Email, gmailHeaderValue(gmOut.Message, "To"), "outbound gmail is addressed to the contact")
+	assert.Equal(t, []string{"SENT"}, gmOut.Message.LabelIds, "outbound gmail carries the SENT label (provider derives outbound)")
+
+	// GChat: inbound sender resolves to the contact's email; outbound sets the sender
+	// to the me-user (resolves to the account, ≠ contact) while the contact stays a
+	// resolvable co-member for the outbound fan-out.
+	gcIn := g.GChatMessage(emailTarget, factory.MatchSeeded)
+	assert.Equal(t, emailTarget.Email, gcIn.EmailByUser[gcIn.Message.Sender.Name], "inbound gchat sender is the contact")
+	gcOut := g.GChatMessage(emailTarget, factory.MatchSeeded, factory.WithOutbound())
+	assert.NotEqual(t, emailTarget.Email, gcOut.EmailByUser[gcOut.Message.Sender.Name], "outbound gchat sender is the account, not the contact")
+	assert.Contains(t, gcOut.EmailByUser, gcOut.Message.Sender.Name, "outbound gchat sender must be resolvable")
+	assert.Contains(t, mapStringValues(gcOut.EmailByUser), emailTarget.Email, "the contact stays a resolvable co-member for the outbound fan-out")
+
+	// Telegram: the Out marker the adapter maps to tg.Message.Out, plus the FromID
+	// the adapter sets via SetFromID (so GetFromID round-trips) — the peer for
+	// inbound, self for outbound.
+	tgIn := g.TelegramMessage(tgTarget, factory.MatchSeeded)
+	assert.False(t, tgIn.Out, "inbound telegram is incoming")
+	_, inUpdate := replay.BuildPrivateUpdate(tgIn)
+	inMsg := inUpdate.Message.(*tg.Message)
+	assert.False(t, inMsg.Out)
+	inFrom, inOK := inMsg.GetFromID()
+	require.True(t, inOK, "inbound telegram FromID must round-trip via GetFromID (SetFromID sets the flag bit)")
+	assert.Equal(t, &tg.PeerUser{UserID: tgIn.PeerUserID}, inFrom, "inbound telegram is from the peer")
+
+	tgOut := g.TelegramMessage(tgTarget, factory.MatchSeeded, factory.WithOutbound())
+	assert.True(t, tgOut.Out, "outbound telegram sets Out")
+	_, outUpdate := replay.BuildPrivateUpdate(tgOut)
+	outMsg := outUpdate.Message.(*tg.Message)
+	assert.True(t, outMsg.Out)
+	outFrom, outOK := outMsg.GetFromID()
+	require.True(t, outOK, "outbound telegram FromID must round-trip via GetFromID (SetFromID sets the flag bit)")
+	outPeer, isUser := outFrom.(*tg.PeerUser)
+	require.True(t, isUser, "outbound telegram FromID must be a user peer")
+	assert.NotEqual(t, tgOut.PeerUserID, outPeer.UserID, "outbound telegram FromID is self, not the peer")
+
+	// iMessage: the envelope kind (received vs sent) the inline handler reads.
+	imIn, err := g.IMessage(phoneTarget, factory.MatchSeeded, hostID)
+	require.NoError(t, err)
+	assert.Equal(t, events.KindRawMessageReceived, imIn.Envelope.Kind, "inbound imessage is raw_message.received")
+	imOut, err := g.IMessage(phoneTarget, factory.MatchSeeded, hostID, factory.WithOutbound())
+	require.NoError(t, err)
+	assert.Equal(t, events.KindRawMessageSent, imOut.Envelope.Kind, "outbound imessage is raw_message.sent")
+}
+
+// mapStringValues returns the values of a string→string map (test helper — the
+// stdlib maps.Values returns an iterator, not a slice, in this Go version).
+func mapStringValues(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for _, v := range m {
+		out = append(out, v)
+	}
+	return out
 }
 
 // gmailHeaderValue returns the value of the named header on a gmail message.

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"personal-crm/backend/internal/synthetic/factory"
 	"personal-crm/backend/tests/testsupport"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -208,6 +209,73 @@ func maxDistinctStateAssignment(flags []repository.CadenceActivityFlags) int {
 	return matched
 }
 
+// f4MessageSources is the exact message-source allowlist the two-sided
+// direction gate (F4, d-positive) asserts non-inbound coverage for. F4 measured 0
+// outbound/mutual interactions for EACH of these four sources. It DELIBERATELY
+// excludes gcal — the awaiting-reply GCal event is already mutual, so including it
+// would let the per-source assertion pass without any message-source direction
+// coverage — plus todoist / manual / anarlog_sessions / phone_calls.
+var f4MessageSources = []string{
+	repository.InteractionSourceEmail,
+	repository.InteractionSourceTelegram,
+	repository.InteractionSourceGChat,
+	repository.InteractionSourceMessages,
+}
+
+// assertMessageDirectionCoverage runs the F4 two-sided message-direction gate over
+// one namespace: no last_outreach_at without a backing outbound/mutual interaction
+// (gate d), each of the four message sources carries ≥1 outbound/mutual interaction
+// (gate d-positive, was 0/0/0/0), the seeded cohort counts match (3 outbound-only + 1
+// mutual), the telegram-mutual contact's two seeded messages collapsed into exactly
+// one promoted mutual row (gate d-mutual-verify), and that promoted mutual set all
+// four cadence timestamps non-null and equal. Called by both coverage tests.
+func assertMessageDirectionCoverage(t *testing.T, ctx context.Context, support *repository.SyntheticSupportRepository, h *synthetic.Harness, res synthetic.ProfileResult) {
+	t.Helper()
+	prefix := h.Generator().Prefix()
+
+	// Gate (d): zero last_outreach_at values not backed by a live outbound/mutual
+	// interaction at the same occurred_at.
+	incoherentOut, err := support.IncoherentOutreachCountByNamePrefix(ctx, prefix)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), incoherentOut, "no contact may carry a moved last_outreach_at without a backing outbound/mutual interaction")
+
+	// Gate (d-positive): EACH message source has ≥1 outbound/mutual interaction (the
+	// F4 fix is per-source; every one measured 0 before this).
+	for _, source := range f4MessageSources {
+		n, err := support.NonInboundMessageInteractionCountBySourceByNamePrefix(ctx, prefix, source)
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, n, int64(1), "message source %q must carry ≥1 outbound/mutual interaction (F4)", source)
+	}
+
+	// The block seeds a fixed cohort: 3 outbound-only (gmail/gchat/imessage) + 1
+	// telegram mutual, in both profiles.
+	require.Equal(t, 3, res.OutboundOnlyContacts, "three outbound-only message contacts seeded")
+	require.Equal(t, 1, res.MutualMessageContacts, "one reply-bridged telegram mutual contact seeded")
+
+	// Gate (d-mutual-verify): the telegram-mutual contact's two seeded messages must
+	// have COLLAPSED into a single promoted mutual row — proving
+	// PromoteInteractionToMutualTx ran, not that an outbound and an inbound coexist.
+	mutualID := h.MutualMessageContactID()
+	require.NotEqual(t, uuid.Nil, mutualID, "the two-sided block must have recorded the mutual contact id")
+	dirCounts, err := support.InteractionDirectionCountsForContact(ctx, mutualID, repository.InteractionSourceTelegram)
+	require.NoError(t, err)
+	require.Equal(t, map[string]int64{repository.InteractionDirectionMutual: 1}, dirCounts,
+		"telegram-mutual contact must have exactly one live mutual interaction and no residual outbound/inbound rows")
+
+	// Gate (d-mutual-verify, timestamps): the promoted mutual set all four cadence
+	// columns together (mutual writes last_contacted / last_interaction_at /
+	// last_outreach_at / last_response_at to the same replyAt).
+	ts, err := support.ContactCadenceTimestampsForContact(ctx, mutualID)
+	require.NoError(t, err)
+	require.NotNil(t, ts.LastContacted, "mutual contact last_contacted must be set")
+	require.NotNil(t, ts.LastInteractionAt, "mutual contact last_interaction_at must be set")
+	require.NotNil(t, ts.LastOutreachAt, "mutual contact last_outreach_at must be set")
+	require.NotNil(t, ts.LastResponseAt, "mutual contact last_response_at must be set")
+	require.True(t, ts.LastContacted.Equal(*ts.LastInteractionAt), "mutual last_contacted == last_interaction_at")
+	require.True(t, ts.LastContacted.Equal(*ts.LastOutreachAt), "mutual last_contacted == last_outreach_at")
+	require.True(t, ts.LastContacted.Equal(*ts.LastResponseAt), "mutual last_contacted == last_response_at")
+}
+
 func TestSyntheticProfile_DevCoversCatalog(t *testing.T) {
 	testsupport.RequireLongTests(t)
 	database, ctx := newSyntheticDB(t)
@@ -288,6 +356,8 @@ func TestSyntheticProfile_DevCoversCatalog(t *testing.T) {
 	// Post-seed coherence gate (F1/F3 + tour capacity), scoped to the namespace.
 	support := repository.NewSyntheticSupportRepository(database.Queries)
 	assertSeedCoherence(t, ctx, support, h.Generator().Prefix())
+	// Two-sided message-direction coverage (F4).
+	assertMessageDirectionCoverage(t, ctx, support, h, res)
 }
 
 // TestSyntheticProfile_ProdShapedCoverageCheck is the load-bearing coverage
@@ -409,6 +479,8 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 
 	// Post-seed coherence gate (F1/F3 + tour capacity), scoped to the namespace.
 	assertSeedCoherence(t, ctx, support, h.Generator().Prefix())
+	// Two-sided message-direction coverage (F4).
+	assertMessageDirectionCoverage(t, ctx, support, h, res)
 
 	// Bio facts (how_met, location, real-year birthdays) ride on the contact-create
 	// authority flip; the catalog carries ≥1 of each. A location additionally mints


### PR DESCRIPTION
## Summary

Audit finding F4: the seeded QA world's message interactions were 48/48 inbound-only — a prod-impossible shape that skews direction-sensitive UX (outreach tracking, mutual-conversation surfaces) and starves the judge of real variety. This PR adds outbound and mutual message-direction coverage, seeded through the REAL provider replay paths (never direct DB writes), plus an additive coherence gate so the shape can't silently regress.

## What changed

- **`WithOutbound()` MessageOption** on all 4 message factories: gmail (From/To header swap + INBOX→SENT), gchat (sender=me), telegram (`Out` flag), imessage (`raw_message.sent` payload kind). Net-new factory construction only — the real providers/consumers already support outbound.
- **Telegram private-path payload fidelity**: message construction extracted into `replay.BuildPrivateUpdate` using `msg.SetFromID` (gotd conditional fields are invisible to `GetFromID` unless set via the setter), mirroring the existing group-path idiom. Factory test asserts the FromID round-trips via `GetFromID` for both directions.
- **Seed block appended LAST in `runCatalogProfile`**: 3 outbound-only contacts (gmail/gchat/imessage) + 1 telegram reply-bridged pair that promotes to mutual (inbound+outbound, same chat, within the 48h reply bridge). Ordering-safe: message factories draw zero PRNG (deterministic counters), guarded by the existing draw-order test.
- **Outbound-causality gate** (test-only sqlc queries + namespace-scoped repository wrappers, wired into both profile coverage tests): per-source non-inbound coverage across `{email, telegram, gchat, messages}` (gcal deliberately excluded — its events are already mutual), plus an assertion that the telegram pair actually collapsed to exactly one mutual interaction, verifying `PromoteInteractionToMutualTx` ran rather than mere coexistence.
- **PR1 lockstep gate intact**: outbound sets `applyLastContacted=false, applyLastOutreachAt=true`, so it moves only `last_outreach_at`; promote-to-mutual moves `last_contacted`/`last_interaction_at` together in one tx. No seeded shape diverges the pair, so the invariant stays load-bearing and unloosened.

## Testing

- `go build ./...`, `go vet`, `make lint` clean
- Factory unit tests incl. the zero-PRNG draw-order guard and the new FromID round-trip + outbound-marker assertions
- LONG_TESTS profile suite: DevCoversCatalog, ProdShapedCoverageCheck (both run the new F4 gates), ProdShapedDeterministic, MinimalScopedMatchesSeedAll, plus replay/golden/seed-all byte-stability pins
- Full pre-push gate (lint + all suites + diff-selected E2E) passed on push

Part of the synthetic-seed fidelity arc (audit: `.ai/spec/2026-07-13-synthetic-seed-fidelity-audit.md`); follows #643 (F1+F3) and #644 (F2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)