### PR TITLE
feat(synthetic): notes coverage + audit carry-overs (F6)

### DIFF
--- a/.ai/spec/2026-07-13-synthetic-seed-fidelity-audit.md
+++ b/.ai/spec/2026-07-13-synthetic-seed-fidelity-audit.md
@@ -64,8 +64,9 @@ Contact soft-delete does NOT cascade in production (`service/contact.go:552-577`
 2. **PR: follow-up row shape** (F3) — small; full prod metadata + synthetic alphanumeric external id in `SeedPendingFollowUp`.
 3. **Decision: staging cadence scale** (F2) — environment design question, decide before or alongside PR 1 (the overdue cohort's shape depends on which durations staging runs).
 4. **PR: outbound/mutual message variants** (F4) — factory + adapter work per source.
-5. **PR: sync-state persistence + notes coverage** (F5, F6) — both small seeding additions.
-6. **Backlog:** F7 (pair with any future cadence-due UI or API-level judging), F8 (pair with SP1 UI), F9 (expand per-tour).
+5. **PR: notes coverage** (F6) — small seeding addition (seed notes on a realistic fraction of catalog contacts).
+6. **Deferred to its own issue: sync-state persistence** (F5) — NOT a small seeding addition after review. The fake-fetcher seed has no safe cause to produce `external_sync_state`: its only visible value is the Settings "connected" badge, which is gated behind `oauth_credential` accounts, and seeding fake OAuth is actively harmful (Todoist Settings decrypts the token + calls the Todoist API on page load; the live staging scheduler enqueues enabled sync-state rows once due, fails on the fake credentials, and flips them to `status='error'`; Google badges also require exact per-source scopes). Seeding `external_sync_state` *without* OAuth is scheduler-benign but delivers no visible value (badges need OAuth; the global staleness banner produces no breaches at 0 rows either way) and creates an orphan sync-state with no backing connected account — the exact incoherence class this audit fights. So **empty `external_sync_state` is the expected, benign state**; delivering "connected + synced" needs real OAuth-account state and a design decision, deferred to its own GH issue (same pattern as F9 → #642).
+7. **Backlog:** F7 (pair with any future cadence-due UI or API-level judging), F8 (pair with SP1 UI), F9 (expand per-tour).
 
 ## Appendix: measurement summary (staging, 2026-07-13, 167 live contacts)
 

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -2164,6 +2164,18 @@ type Querier interface {
 	// list by the test before it reaches here; format() with %I quotes the
 	// identifier so it can never be an injection vector.
 	TestCountAllRows(ctx context.Context, tableName string) (int64, error)
+	// Coverage gate (F6): count the namespace's LIVE contacts that carry a NON-EMPTY
+	// NOTEPAD note — the category the contact-detail endpoint renders via GetContactNotepad.
+	// The category='notepad' filter is load-bearing: SeedNote writes via CreateNotepad, and
+	// without the filter the gate could pass on some other note category while the contact
+	// detail page still renders empty. The body <> '' filter matters too: MergeContacts
+	// writes a spurious EMPTY-body notepad note onto every merge winner (an always-true
+	// nil-check on GetContactNoteByCategory's ErrNoRows return), which carries no rendered
+	// content and so is not "a contact with notes" for coverage purposes — counting it would
+	// make this gate disagree with res.ContactsWithNotes by the merge count. `note` has NO
+	// deleted_at column (it is hard-deleted at teardown), so there is no soft-delete
+	// predicate on the join. Caller passes a BARE prefix.
+	TestCountContactsWithNotepadByNamePrefix(ctx context.Context, namePrefix pgtype.Text) (int64, error)
 	// Coherence gate: count the namespace's contacts whose non-creation last_contacted
 	// is NOT backed by a live inbound/mutual interaction at the same occurred_at, or
 	// whose last_interaction_at is not in lockstep with last_contacted. Asserted == 0.
@@ -2205,6 +2217,13 @@ type Querier interface {
 	// Test-only: counts venue-type nodes that no live interaction references via
 	// venue_id. Used by the venue backfill test to assert the no-orphan-node guard.
 	TestCountOrphanVenueNodes(ctx context.Context) (int64, error)
+	// Coverage gate (D3, F4 not-vacuous): count the namespace's LIVE contacts in the
+	// PURE-OUTBOUND shape — last_outreach_at set while last_contacted is NULL. This is the
+	// "I messaged them, no reply yet" cohort (an outbound moves only last_outreach_at,
+	// CAD-006). Asserted >= 1 so the zero-violation TestCountIncoherentOutreachByNamePrefix
+	// gate is not vacuously satisfied by a world with no last_outreach_at at all. Caller
+	// passes a BARE prefix.
+	TestCountPureOutboundContactsByNamePrefix(ctx context.Context, namePrefix pgtype.Text) (int64, error)
 	// Tag-migration test only: count the LIVE accepted `tagged_as` assertions whose
 	// subject is a given node, so a test asserts exactly one per migrated contact_tag
 	// and that an idempotent re-run creates no duplicates.

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -2168,12 +2168,12 @@ type Querier interface {
 	// NOTEPAD note — the category the contact-detail endpoint renders via GetContactNotepad.
 	// The category='notepad' filter is load-bearing: SeedNote writes via CreateNotepad, and
 	// without the filter the gate could pass on some other note category while the contact
-	// detail page still renders empty. The body <> '' filter matters too: MergeContacts
-	// writes a spurious EMPTY-body notepad note onto every merge winner (an always-true
-	// nil-check on GetContactNoteByCategory's ErrNoRows return), which carries no rendered
-	// content and so is not "a contact with notes" for coverage purposes — counting it would
-	// make this gate disagree with res.ContactsWithNotes by the merge count. `note` has NO
-	// deleted_at column (it is hard-deleted at teardown), so there is no soft-delete
+	// detail page still renders empty. The non-empty-body filter matters too (issue #648):
+	// MergeContacts writes a spurious empty-body notepad note onto every merge winner (an
+	// always-true nil-check on GetContactNoteByCategory's ErrNoRows return), which carries no
+	// rendered content and so is not "a contact with notes" for coverage purposes — counting
+	// it would make this gate disagree with res.ContactsWithNotes by the merge count. `note`
+	// has NO deleted_at column (it is hard-deleted at teardown), so there is no soft-delete
 	// predicate on the join. Caller passes a BARE prefix.
 	TestCountContactsWithNotepadByNamePrefix(ctx context.Context, namePrefix pgtype.Text) (int64, error)
 	// Coherence gate: count the namespace's contacts whose non-creation last_contacted

--- a/backend/internal/db/queries/test.sql
+++ b/backend/internal/db/queries/test.sql
@@ -1350,3 +1350,36 @@ GROUP BY i.direction;
 SELECT last_contacted, last_interaction_at, last_outreach_at, last_response_at
 FROM contact
 WHERE id = @contact_id;
+
+-- name: TestCountContactsWithNotepadByNamePrefix :one
+-- Coverage gate (F6): count the namespace's LIVE contacts that carry a NON-EMPTY
+-- NOTEPAD note — the category the contact-detail endpoint renders via GetContactNotepad.
+-- The category='notepad' filter is load-bearing: SeedNote writes via CreateNotepad, and
+-- without the filter the gate could pass on some other note category while the contact
+-- detail page still renders empty. The body <> '' filter matters too: MergeContacts
+-- writes a spurious EMPTY-body notepad note onto every merge winner (an always-true
+-- nil-check on GetContactNoteByCategory's ErrNoRows return), which carries no rendered
+-- content and so is not "a contact with notes" for coverage purposes — counting it would
+-- make this gate disagree with res.ContactsWithNotes by the merge count. `note` has NO
+-- deleted_at column (it is hard-deleted at teardown), so there is no soft-delete
+-- predicate on the join. Caller passes a BARE prefix.
+SELECT COUNT(DISTINCT c.id)
+FROM contact c
+JOIN note n ON n.contact_id = c.id AND n.category = 'notepad'
+WHERE c.full_name LIKE @name_prefix || '%'
+  AND c.deleted_at IS NULL
+  AND n.body <> '';
+
+-- name: TestCountPureOutboundContactsByNamePrefix :one
+-- Coverage gate (D3, F4 not-vacuous): count the namespace's LIVE contacts in the
+-- PURE-OUTBOUND shape — last_outreach_at set while last_contacted is NULL. This is the
+-- "I messaged them, no reply yet" cohort (an outbound moves only last_outreach_at,
+-- CAD-006). Asserted >= 1 so the zero-violation TestCountIncoherentOutreachByNamePrefix
+-- gate is not vacuously satisfied by a world with no last_outreach_at at all. Caller
+-- passes a BARE prefix.
+SELECT COUNT(*)
+FROM contact c
+WHERE c.full_name LIKE @name_prefix || '%'
+  AND c.deleted_at IS NULL
+  AND c.last_outreach_at IS NOT NULL
+  AND c.last_contacted IS NULL;

--- a/backend/internal/db/queries/test.sql
+++ b/backend/internal/db/queries/test.sql
@@ -1356,12 +1356,12 @@ WHERE id = @contact_id;
 -- NOTEPAD note — the category the contact-detail endpoint renders via GetContactNotepad.
 -- The category='notepad' filter is load-bearing: SeedNote writes via CreateNotepad, and
 -- without the filter the gate could pass on some other note category while the contact
--- detail page still renders empty. The body <> '' filter matters too: MergeContacts
--- writes a spurious EMPTY-body notepad note onto every merge winner (an always-true
--- nil-check on GetContactNoteByCategory's ErrNoRows return), which carries no rendered
--- content and so is not "a contact with notes" for coverage purposes — counting it would
--- make this gate disagree with res.ContactsWithNotes by the merge count. `note` has NO
--- deleted_at column (it is hard-deleted at teardown), so there is no soft-delete
+-- detail page still renders empty. The non-empty-body filter matters too (issue #648):
+-- MergeContacts writes a spurious empty-body notepad note onto every merge winner (an
+-- always-true nil-check on GetContactNoteByCategory's ErrNoRows return), which carries no
+-- rendered content and so is not "a contact with notes" for coverage purposes — counting
+-- it would make this gate disagree with res.ContactsWithNotes by the merge count. `note`
+-- has NO deleted_at column (it is hard-deleted at teardown), so there is no soft-delete
 -- predicate on the join. Caller passes a BARE prefix.
 SELECT COUNT(DISTINCT c.id)
 FROM contact c

--- a/backend/internal/db/test.sql.go
+++ b/backend/internal/db/test.sql.go
@@ -2173,6 +2173,33 @@ func (q *Queries) TestCountAllRows(ctx context.Context, tableName string) (int64
 	return column_1, err
 }
 
+const TestCountContactsWithNotepadByNamePrefix = `-- name: TestCountContactsWithNotepadByNamePrefix :one
+SELECT COUNT(DISTINCT c.id)
+FROM contact c
+JOIN note n ON n.contact_id = c.id AND n.category = 'notepad'
+WHERE c.full_name LIKE $1 || '%'
+  AND c.deleted_at IS NULL
+  AND n.body <> ''
+`
+
+// Coverage gate (F6): count the namespace's LIVE contacts that carry a NON-EMPTY
+// NOTEPAD note — the category the contact-detail endpoint renders via GetContactNotepad.
+// The category='notepad' filter is load-bearing: SeedNote writes via CreateNotepad, and
+// without the filter the gate could pass on some other note category while the contact
+// detail page still renders empty. The body <> ” filter matters too: MergeContacts
+// writes a spurious EMPTY-body notepad note onto every merge winner (an always-true
+// nil-check on GetContactNoteByCategory's ErrNoRows return), which carries no rendered
+// content and so is not "a contact with notes" for coverage purposes — counting it would
+// make this gate disagree with res.ContactsWithNotes by the merge count. `note` has NO
+// deleted_at column (it is hard-deleted at teardown), so there is no soft-delete
+// predicate on the join. Caller passes a BARE prefix.
+func (q *Queries) TestCountContactsWithNotepadByNamePrefix(ctx context.Context, namePrefix pgtype.Text) (int64, error) {
+	row := q.db.QueryRow(ctx, TestCountContactsWithNotepadByNamePrefix, namePrefix)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const TestCountIncoherentLastContactedByNamePrefix = `-- name: TestCountIncoherentLastContactedByNamePrefix :one
 SELECT COUNT(*)
 FROM contact c
@@ -2322,6 +2349,28 @@ type TestCountNonInboundMessageInteractionsBySourceByNamePrefixParams struct {
 // direction). Caller passes a BARE prefix + the source.
 func (q *Queries) TestCountNonInboundMessageInteractionsBySourceByNamePrefix(ctx context.Context, arg TestCountNonInboundMessageInteractionsBySourceByNamePrefixParams) (int64, error) {
 	row := q.db.QueryRow(ctx, TestCountNonInboundMessageInteractionsBySourceByNamePrefix, arg.NamePrefix, arg.Source)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const TestCountPureOutboundContactsByNamePrefix = `-- name: TestCountPureOutboundContactsByNamePrefix :one
+SELECT COUNT(*)
+FROM contact c
+WHERE c.full_name LIKE $1 || '%'
+  AND c.deleted_at IS NULL
+  AND c.last_outreach_at IS NOT NULL
+  AND c.last_contacted IS NULL
+`
+
+// Coverage gate (D3, F4 not-vacuous): count the namespace's LIVE contacts in the
+// PURE-OUTBOUND shape — last_outreach_at set while last_contacted is NULL. This is the
+// "I messaged them, no reply yet" cohort (an outbound moves only last_outreach_at,
+// CAD-006). Asserted >= 1 so the zero-violation TestCountIncoherentOutreachByNamePrefix
+// gate is not vacuously satisfied by a world with no last_outreach_at at all. Caller
+// passes a BARE prefix.
+func (q *Queries) TestCountPureOutboundContactsByNamePrefix(ctx context.Context, namePrefix pgtype.Text) (int64, error) {
+	row := q.db.QueryRow(ctx, TestCountPureOutboundContactsByNamePrefix, namePrefix)
 	var count int64
 	err := row.Scan(&count)
 	return count, err

--- a/backend/internal/db/test.sql.go
+++ b/backend/internal/db/test.sql.go
@@ -2186,12 +2186,12 @@ WHERE c.full_name LIKE $1 || '%'
 // NOTEPAD note — the category the contact-detail endpoint renders via GetContactNotepad.
 // The category='notepad' filter is load-bearing: SeedNote writes via CreateNotepad, and
 // without the filter the gate could pass on some other note category while the contact
-// detail page still renders empty. The body <> ” filter matters too: MergeContacts
-// writes a spurious EMPTY-body notepad note onto every merge winner (an always-true
-// nil-check on GetContactNoteByCategory's ErrNoRows return), which carries no rendered
-// content and so is not "a contact with notes" for coverage purposes — counting it would
-// make this gate disagree with res.ContactsWithNotes by the merge count. `note` has NO
-// deleted_at column (it is hard-deleted at teardown), so there is no soft-delete
+// detail page still renders empty. The non-empty-body filter matters too (issue #648):
+// MergeContacts writes a spurious empty-body notepad note onto every merge winner (an
+// always-true nil-check on GetContactNoteByCategory's ErrNoRows return), which carries no
+// rendered content and so is not "a contact with notes" for coverage purposes — counting
+// it would make this gate disagree with res.ContactsWithNotes by the merge count. `note`
+// has NO deleted_at column (it is hard-deleted at teardown), so there is no soft-delete
 // predicate on the join. Caller passes a BARE prefix.
 func (q *Queries) TestCountContactsWithNotepadByNamePrefix(ctx context.Context, namePrefix pgtype.Text) (int64, error) {
 	row := q.db.QueryRow(ctx, TestCountContactsWithNotepadByNamePrefix, namePrefix)

--- a/backend/internal/repository/synthetic_support.go
+++ b/backend/internal/repository/synthetic_support.go
@@ -862,6 +862,25 @@ func (r *SyntheticSupportRepository) IncoherentOutreachCountByNamePrefix(ctx con
 	return r.queries.TestCountIncoherentOutreachByNamePrefix(ctx, pgtype.Text{String: namePrefix, Valid: true})
 }
 
+// PureOutboundContactCountByNamePrefix returns the number of the namespace's live
+// contacts in the pure-outbound shape (last_outreach_at set, last_contacted NULL) —
+// the "messaged them, no reply yet" cohort. Coverage gate (D3): asserted >= 1 so the
+// zero-violation IncoherentOutreachCountByNamePrefix gate is not vacuously satisfied by
+// a world with no last_outreach_at at all. Test only.
+func (r *SyntheticSupportRepository) PureOutboundContactCountByNamePrefix(ctx context.Context, namePrefix string) (int64, error) {
+	return r.queries.TestCountPureOutboundContactsByNamePrefix(ctx, pgtype.Text{String: namePrefix, Valid: true})
+}
+
+// ContactsWithNotepadCountByNamePrefix returns the number of the namespace's live
+// contacts that carry a NON-EMPTY notepad note — the category the contact-detail page
+// renders. Coverage gate (F6): asserted == res.ContactsWithNotes so the seeded notes
+// actually landed on the notepad surface the UI reads (empty-body notepads, e.g. the
+// ones MergeContacts spuriously writes on merge winners, carry no rendered content and
+// are excluded). Test only.
+func (r *SyntheticSupportRepository) ContactsWithNotepadCountByNamePrefix(ctx context.Context, namePrefix string) (int64, error) {
+	return r.queries.TestCountContactsWithNotepadByNamePrefix(ctx, pgtype.Text{String: namePrefix, Valid: true})
+}
+
 // NonInboundMessageInteractionCountBySourceByNamePrefix returns the number of live
 // outbound/mutual interactions of one message source on the namespace's contacts.
 // Coherence gate (F4, d-positive); the test asserts >= 1 for each of the four message

--- a/backend/internal/repository/synthetic_support.go
+++ b/backend/internal/repository/synthetic_support.go
@@ -875,8 +875,8 @@ func (r *SyntheticSupportRepository) PureOutboundContactCountByNamePrefix(ctx co
 // contacts that carry a NON-EMPTY notepad note — the category the contact-detail page
 // renders. Coverage gate (F6): asserted == res.ContactsWithNotes so the seeded notes
 // actually landed on the notepad surface the UI reads (empty-body notepads, e.g. the
-// ones MergeContacts spuriously writes on merge winners, carry no rendered content and
-// are excluded). Test only.
+// ones MergeContacts spuriously writes on merge winners (issue #648), carry no rendered
+// content and are excluded). Test only.
 func (r *SyntheticSupportRepository) ContactsWithNotepadCountByNamePrefix(ctx context.Context, namePrefix string) (int64, error) {
 	return r.queries.TestCountContactsWithNotepadByNamePrefix(ctx, pgtype.Text{String: namePrefix, Valid: true})
 }

--- a/backend/internal/synthetic/profiles.go
+++ b/backend/internal/synthetic/profiles.go
@@ -62,6 +62,12 @@ type ProfileResult struct {
 	ContactsWithBirthday int
 	ContactsWithHowMet   int
 	ContactsWithLocation int
+	// ContactsWithNotes counts the catalog contacts that carry a notepad note (the
+	// category the contact-detail page renders). Seeded on a deterministic fraction
+	// of the catalog (every third contact by index, ⌈n/3⌉ total) so contact-detail
+	// pages are not near-empty — a judge touring an empty page reads it as a broken
+	// feature. Counts-only / no PII.
+	ContactsWithNotes int
 	// SeededTasks counts the contact_task rows the profile seeded — one `managed`
 	// cadence task per cadence-bearing catalog contact (via ReplayTodoist's
 	// reconcile), a deterministic three of which are then transitioned to the
@@ -310,7 +316,6 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 	// never-contacted intent), and every contact would carry a method (no
 	// no-method bucket). The settled per-source interactions live on the
 	// dedicated contacts below instead.
-	var firstCatalogContactID uuid.UUID
 	catalogContactIDs := make([]uuid.UUID, 0, n)
 	// cadenceBearingCatalogIDs is the subset whose spec carries a cadence —
 	// CreateContact auto-computes contact_by from cadence, making them eligible for
@@ -348,17 +353,23 @@ func runCatalogProfile(ctx context.Context, h *Harness, params SeedParams, res P
 		if spec.Cadence != nil && *spec.Cadence != "" {
 			cadenceBearingCatalogIDs = append(cadenceBearingCatalogIDs, contact.ID)
 		}
-		if i == 0 {
-			firstCatalogContactID = contact.ID
-		}
 	}
 
-	// Give the catalog its "≥1 contact with notes" bucket (a notepad note on the
-	// first catalog contact, via the existing note repo).
-	if firstCatalogContactID != uuid.Nil {
-		if err := h.SeedNote(ctx, firstCatalogContactID, "catalog notepad note"); err != nil {
-			return res, fmt.Errorf("profile %s: seed catalog note: %w", params.Profile, err)
+	// Give a realistic fraction of catalog contacts a notepad note — every third
+	// contact by index (⌈n/3⌉ total), a personal-CRM-like density — so contact-detail
+	// pages carry content instead of reading as an unused/broken feature to a judge
+	// touring them. SeedNote draws NO generator PRNG (it prepends gen.Prefix() to the
+	// literal body), so this pass is ordering-safe: it cannot shift the deterministic
+	// id/handle sequence the source replays below depend on. Bodies are unprefixed
+	// literals (SeedNote adds the namespace prefix) so no gen.Note() draw is needed.
+	for i, contactID := range catalogContactIDs {
+		if i%3 != 0 {
+			continue
 		}
+		if err := h.SeedNote(ctx, contactID, fmt.Sprintf("catalog notepad note %d", i)); err != nil {
+			return res, fmt.Errorf("profile %s: seed catalog note %d: %w", params.Profile, i, err)
+		}
+		res.ContactsWithNotes++
 	}
 
 	// A few settled interactions on DEDICATED contacts per source so every source

--- a/backend/tests/synthetic_profile_integration_test.go
+++ b/backend/tests/synthetic_profile_integration_test.go
@@ -239,6 +239,15 @@ func assertMessageDirectionCoverage(t *testing.T, ctx context.Context, support *
 	require.NoError(t, err)
 	require.Equal(t, int64(0), incoherentOut, "no contact may carry a moved last_outreach_at without a backing outbound/mutual interaction")
 
+	// Gate (d, not-vacuous): the zero-violation check above is only meaningful if the
+	// world actually contains last_outreach_at values. Assert the PURE-OUTBOUND cohort
+	// exists (last_outreach_at set, last_contacted NULL) — the three outbound-only
+	// contacts (gmail/gchat/imessage). Without this a world with no last_outreach_at at
+	// all would satisfy the == 0 gate vacuously.
+	pureOutbound, err := support.PureOutboundContactCountByNamePrefix(ctx, prefix)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, pureOutbound, int64(1), "≥1 pure-outbound contact (last_outreach_at set, last_contacted NULL) — the outbound gate is not vacuous")
+
 	// Gate (d-positive): EACH message source has ≥1 outbound/mutual interaction (the
 	// F4 fix is per-source; every one measured 0 before this).
 	for _, source := range f4MessageSources {
@@ -358,6 +367,24 @@ func TestSyntheticProfile_DevCoversCatalog(t *testing.T) {
 	assertSeedCoherence(t, ctx, support, h.Generator().Prefix())
 	// Two-sided message-direction coverage (F4).
 	assertMessageDirectionCoverage(t, ctx, support, h, res)
+	// Notes coverage (F6).
+	assertNotesCoverage(t, ctx, support, h, res, params.Counts.SeededContacts)
+}
+
+// assertNotesCoverage runs the F6 notes gate: the profile seeds a note on a
+// deterministic fraction (every third catalog contact by index, ⌈n/3⌉ total), so the
+// result count must equal ⌈seededContacts/3⌉ AND the notepad notes must actually be
+// present in the DB for that many contacts (namespace-scoped). Tying the expectation to
+// the catalog size — not a floor — catches a constant-count regression (e.g. "always
+// seed 2") that would leave a prod-shaped catalog near-empty. Called by both coverage
+// tests.
+func assertNotesCoverage(t *testing.T, ctx context.Context, support *repository.SyntheticSupportRepository, h *synthetic.Harness, res synthetic.ProfileResult, seededContacts int) {
+	t.Helper()
+	expectedNotes := (seededContacts + 2) / 3 // ⌈seededContacts/3⌉ (the i%3==0 subset)
+	require.Equal(t, expectedNotes, res.ContactsWithNotes, "notes seeded on ⌈catalog/3⌉ contacts")
+	notepadContacts, err := support.ContactsWithNotepadCountByNamePrefix(ctx, h.Generator().Prefix())
+	require.NoError(t, err)
+	require.Equal(t, int64(res.ContactsWithNotes), notepadContacts, "non-empty notepad notes present in the DB for exactly the seeded contacts")
 }
 
 // TestSyntheticProfile_ProdShapedCoverageCheck is the load-bearing coverage
@@ -481,6 +508,8 @@ func TestSyntheticProfile_ProdShapedCoverageCheck(t *testing.T) {
 	assertSeedCoherence(t, ctx, support, h.Generator().Prefix())
 	// Two-sided message-direction coverage (F4).
 	assertMessageDirectionCoverage(t, ctx, support, h, res)
+	// Notes coverage (F6).
+	assertNotesCoverage(t, ctx, support, h, res, params.Counts.SeededContacts)
 
 	// Bio facts (how_met, location, real-year birthdays) ride on the contact-create
 	// authority flip; the catalog carries ≥1 of each. A location additionally mints

--- a/backend/tests/unit/cadence_test.go
+++ b/backend/tests/unit/cadence_test.go
@@ -535,6 +535,32 @@ func TestGetOverdueDaysWithConfig(t *testing.T) {
 	}
 }
 
+// TestGetOverdueDaysWithConfig_Accelerated covers the CRM_ENV=accelerated scaled-day
+// branch (1 "day" = 10 minutes / 7), which the table test above does not reach. That
+// branch is guarded: GetOverdueDaysWithConfig returns real 24h days whenever
+// TIME_ACCELERATION is active, so the test neutralizes TIME_ACCELERATION (empty →
+// isAccelerationActive() false) to fall through to the CRM_ENV switch. checkTime is
+// placed exactly overdueDays scaled-days past the due point, so the branch's truncating
+// division yields exactly overdueDays. Serial (t.Setenv mutates process env) so it does
+// not race sibling cadence tests; deliberately does NOT touch IsTestingMode (#645).
+func TestGetOverdueDaysWithConfig_Accelerated(t *testing.T) {
+	t.Setenv("CRM_ENV", "accelerated")
+	t.Setenv("TIME_ACCELERATION", "")
+
+	const overdueDays = 5
+	scaledDay := 10 * time.Minute / 7 // the accelerated branch's "1 day"
+
+	lastContact := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	created := time.Date(2023, 12, 1, 12, 0, 0, 0, time.UTC)
+	// nextContactDue = lastContact + the accelerated weekly duration (read under the
+	// same env the SUT sees); checkTime sits exactly overdueDays scaled-days past it.
+	nextDue := lastContact.Add(cadence.GetCadenceDuration(cadence.CadenceWeekly))
+	checkTime := nextDue.Add(overdueDays * scaledDay)
+
+	result := cadence.GetOverdueDaysWithConfig(cadence.CadenceWeekly, &lastContact, created, checkTime)
+	assert.Equal(t, overdueDays, result)
+}
+
 // TestBiweeklyCadenceComprehensive tests biweekly cadence across all functions
 func TestBiweeklyCadenceComprehensive(t *testing.T) {
 	t.Parallel()

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -141,7 +141,7 @@ ssh <pi-hostname> 'sudo journalctl -u personalcrm-frontend -f'
 - `.env` - Your local development config (gitignored)
 - `.env.example` - Template for new developers
 - `.env.example.testing` - Deterministic values for tests
-- `.env.example.staging` - Fast cadences for staging
+- `.env.example.staging` - Staging config (production cadence semantics)
 - `.env.example.production` - Template for production
 
 ## Pi Prerequisites


### PR DESCRIPTION
## Summary

Audit finding F6: only 5/167 seeded contacts carried notes, leaving contact-detail pages near-empty across the QA world. This PR seeds a notepad note on every third catalog contact (⌈n/3⌉ total) via the ordering-safe `SeedNote` path, plus three small carry-overs from earlier arc PRs. F5 (external_sync_state) was deferred out of the arc to #647 after plan review showed its real fix requires an OAuth-state design decision; the audit spec records the deferral.

## What changed

- **F6 notes coverage**: notepad note on a deterministic fraction (every third by index, ⌈n/3⌉) of catalog contacts. `SeedNote` draws no generator PRNG, so the pass is ordering-safe and the determinism fingerprint is unchanged. Adds `ProfileResult.ContactsWithNotes` and a catalog-size-tied gate in both profile coverage tests: `res.ContactsWithNotes == ceil(SeededContacts/3)` plus a namespace-scoped DB count of **non-empty** notepad notes. The non-empty filter is deliberate — a pre-existing production bug (#648, found by this gate) makes every contact merge write a spurious empty-body notepad note onto the merge winner, and "page carries content" is the correct F6 semantic regardless.
- **D3**: positive assertion closing PR3's outbound-gate vacuity — a pure-outbound cohort must have `last_outreach_at` set and `last_contacted` NULL at the cadence level, so the gate can no longer pass vacuously.
- **D4**: `docs/DEPLOYMENT.md` staging line updated (stale "fast cadences" description after #644).
- **D5**: unit test for the `CRM_ENV=accelerated` scaled overdue-days branch (serial, `TIME_ACCELERATION` neutralized).
- **D6**: audit spec F5 packaging paragraph records the deferral rationale (empty `external_sync_state` is scheduler-benign; the visible symptom needs real OAuth state the fake-fetcher seed has no safe cause to produce; #647 owns the decision).

## Testing

- `go build ./...`, `go vet`, `make lint`, full `make test-unit` (incl. the factory draw-order guard)
- LONG_TESTS synthetic suite green: DevCoversCatalog + ProdShapedCoverageCheck (both run the F6/D3 gates) + ProdShapedDeterministic
- Full pre-push gate (lint + all suites + diff-selected E2E) passed on push
- 2 local Codex rounds: round-1 FAIL was a sandbox false positive (SSH signature invisible to the read-only sandbox; verified Good ED25519 locally) + one comment typo, fixed; round-2 delta PASS clean

Part of the synthetic-seed fidelity arc (audit: `.ai/spec/2026-07-13-synthetic-seed-fidelity-audit.md`); follows #643 (F1+F3), #644 (F2), #646 (F4). Related issues: #647 (F5 deferral), #648 (merge notepad bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)